### PR TITLE
[CodeCompletion] Don't distinguish convertible and identical type relation

### DIFF
--- a/include/swift/IDE/CodeCompletionResultType.h
+++ b/include/swift/IDE/CodeCompletionResultType.h
@@ -100,13 +100,10 @@ enum class CodeCompletionResultTypeRelation : uint8_t {
   /// The result's type is invalid at the expected position.
   Invalid,
 
-  /// The result's type is convertible to the type of the expected.
+  /// The result's type is convertible or identical to the type of the expected.
   Convertible,
 
-  /// The result's type is identical to the type of the expected.
-  Identical,
-
-  MAX_VALUE = Identical
+  MAX_VALUE = Convertible
 };
 
 class USRBasedType;
@@ -145,23 +142,14 @@ public:
     /// convertible.
     llvm::SmallVector<const USRBasedType *, 1> Types;
 
-    /// Whether a match against this type should be considered convertible
-    /// instead of identical. This is used to model optional conversions.
-    /// If we have
-    ///   let x: Int? = #^COMPLETE^#
-    /// we add both 'Int?' and 'Int' as contextual types to the
-    /// USRBasedTypeContext, but an identical match against 'Int' should only
-    /// be considered convertible.
-    bool IsConvertible;
-
   public:
     /// Compute the type relation of \p ResultType to this conextual type.
     CodeCompletionResultTypeRelation
     typeRelation(const USRBasedType *ResultType,
                  const USRBasedType *VoidType) const;
 
-    ContextualType(ArrayRef<const USRBasedType *> Types, bool IsConvertible)
-        : Types(Types.begin(), Types.end()), IsConvertible(IsConvertible) {
+    ContextualType(ArrayRef<const USRBasedType *> Types)
+        : Types(Types.begin(), Types.end()) {
       assert(!Types.empty() && "USRBasedTypeContext::ContextualType should "
                                "contain at least one type");
     }

--- a/lib/IDE/CodeCompletionResult.cpp
+++ b/lib/IDE/CodeCompletionResult.cpp
@@ -490,9 +490,6 @@ void CodeCompletionResult::printPrefix(raw_ostream &OS) const {
   case CodeCompletionResultTypeRelation::Invalid:
     Prefix.append("/TypeRelation[Invalid]");
     break;
-  case CodeCompletionResultTypeRelation::Identical:
-    Prefix.append("/TypeRelation[Identical]");
-    break;
   case CodeCompletionResultTypeRelation::Convertible:
     Prefix.append("/TypeRelation[Convertible]");
     break;

--- a/lib/IDE/CodeCompletionResultType.cpp
+++ b/lib/IDE/CodeCompletionResultType.cpp
@@ -29,15 +29,13 @@ USRBasedTypeContext::USRBasedTypeContext(const ExpectedTypeContext *TypeContext,
     : Arena(Arena) {
 
   for (auto possibleTy : TypeContext->getPossibleTypes()) {
-    ContextualTypes.emplace_back(USRBasedType::fromType(possibleTy, Arena),
-                                 /*IsConvertible=*/false);
+    ContextualTypes.emplace_back(USRBasedType::fromType(possibleTy, Arena));
 
     // Add the unwrapped optional types as 'convertible' contextual types.
     auto UnwrappedOptionalType = possibleTy->getOptionalObjectType();
     while (UnwrappedOptionalType) {
       ContextualTypes.emplace_back(
-          USRBasedType::fromType(UnwrappedOptionalType, Arena),
-          /*IsConvertible=*/true);
+          USRBasedType::fromType(UnwrappedOptionalType, Arena));
       UnwrappedOptionalType = UnwrappedOptionalType->getOptionalObjectType();
     }
 
@@ -57,7 +55,7 @@ USRBasedTypeContext::USRBasedTypeContext(const ExpectedTypeContext *TypeContext,
       // Archetypes are also be used to model generic return types, in which
       // case they don't have any conformsTo entries. We simply ignore those.
       if (!USRTypes.empty()) {
-        ContextualTypes.emplace_back(USRTypes, /*IsConvertible=*/false);
+        ContextualTypes.emplace_back(USRTypes);
       }
     }
   }
@@ -76,6 +74,9 @@ USRBasedTypeContext::typeRelation(const USRBasedType *ResultType) const {
   TypeRelation Res = TypeRelation::Unknown;
   for (auto &ContextualType : ContextualTypes) {
     Res = std::max(Res, ContextualType.typeRelation(ResultType, VoidType));
+    if (Res == TypeRelation::MAX_VALUE) {
+      return Res; // We can't improve further
+    }
   }
   return Res;
 }
@@ -105,7 +106,7 @@ TypeRelation USRBasedType::typeRelationImpl(
     return TypeRelation::Unknown;
   }
   if (ResultType == this) {
-    return TypeRelation::Identical;
+    return TypeRelation::Convertible;
   }
   for (const USRBasedType *Supertype : ResultType->getSupertypes()) {
     if (!VisitedTypes.insert(Supertype).second) {
@@ -239,13 +240,9 @@ TypeRelation USRBasedTypeContext::ContextualType::typeRelation(
 
   /// Types is a conjunction, not a disjunction (see documentation on Types),
   /// so we need to compute the minimum type relation here.
-  TypeRelation Result = TypeRelation::Identical;
+  TypeRelation Result = TypeRelation::Convertible;
   for (auto ContextType : Types) {
     Result = std::min(Result, ContextType->typeRelation(ResultType, VoidType));
-  }
-
-  if (IsConvertible && Result == TypeRelation::Identical) {
-    Result = TypeRelation::Convertible;
   }
   return Result;
 }
@@ -262,7 +259,7 @@ static TypeRelation calculateTypeRelation(Type Ty, Type ExpectedTy,
   // requirements – ignore them
   if (!Ty->hasTypeParameter() && !ExpectedTy->hasTypeParameter()) {
     if (Ty->isEqual(ExpectedTy))
-      return TypeRelation::Identical;
+      return TypeRelation::Convertible;
     bool isAny = false;
     isAny |= ExpectedTy->isAny();
     isAny |= ExpectedTy->is<ArchetypeType>() &&

--- a/test/IDE/complete_accessor.swift
+++ b/test/IDE/complete_accessor.swift
@@ -11,7 +11,7 @@
 // NO_OBSERVER-NOT: willSet
 // NO_OBSERVER-NOT: didSet
 
-// WITH_GLOBAL: Decl[GlobalVar]/CurrModule{{(/TypeRelation\[Identical\])?}}: globalValue[#String#];
+// WITH_GLOBAL: Decl[GlobalVar]/CurrModule{{(/TypeRelation\[Convertible\])?}}: globalValue[#String#];
 // NO_GLOBAL-NOT: globalValue;
 
 // WITH_SELF: Decl[LocalVar]/Local:               self[#{{.+}}#]; name=self

--- a/test/IDE/complete_after_super.swift
+++ b/test/IDE/complete_after_super.swift
@@ -107,11 +107,11 @@ extension SuperBaseA {
 // COMMON_BASE_A_DOT: End completions
 
 // COMMON_BASE_A_DOT_CONTEXT: Begin completions
-// COMMON_BASE_A_DOT_CONTEXT-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Identical]: baseInstanceVar[#Int#]{{; name=.+$}}
-// COMMON_BASE_A_DOT_CONTEXT-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Identical]: baseProp[#Int#]{{; name=.+$}}
+// COMMON_BASE_A_DOT_CONTEXT-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]: baseInstanceVar[#Int#]{{; name=.+$}}
+// COMMON_BASE_A_DOT_CONTEXT-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]: baseProp[#Int#]{{; name=.+$}}
 // COMMON_BASE_A_DOT_CONTEXT-DAG: Decl[InstanceMethod]/CurrNominal: baseFunc0()[#Void#]{{; name=.+$}}
 // COMMON_BASE_A_DOT_CONTEXT-DAG: Decl[InstanceMethod]/CurrNominal: baseFunc1({#(a): Int#})[#Void#]{{; name=.+$}}
-// COMMON_BASE_A_DOT_CONTEXT-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Identical]: baseExtProp[#Int#]{{; name=.+$}}
+// COMMON_BASE_A_DOT_CONTEXT-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]: baseExtProp[#Int#]{{; name=.+$}}
 // COMMON_BASE_A_DOT_CONTEXT-DAG: Decl[InstanceMethod]/CurrNominal: baseExtFunc0()[#Void#]{{; name=.+$}}
 // COMMON_BASE_A_DOT_CONTEXT: End completions
 

--- a/test/IDE/complete_ambiguous.swift
+++ b/test/IDE/complete_ambiguous.swift
@@ -40,7 +40,7 @@ arrayWrapper(overloadedReturn()).#^SKIP_DUPLICATES^#
 let x: (inout Int, Int) -> () = arrayWrapper(overloadedReturn()).#^SKIP_COMPOUND_DUPLICATES^#
 
 // SKIP_COMPOUND_DUPLICATES: Begin completions
-// SKIP_COMPOUND_DUPLICATES: Decl[InstanceMethod]/Super/IsSystem/TypeRelation[Identical]: formIndex(_:offsetBy:)[#(inout Int, Int) -> ()#]{{; name=.+$}}
+// SKIP_COMPOUND_DUPLICATES: Decl[InstanceMethod]/Super/IsSystem/TypeRelation[Convertible]: formIndex(_:offsetBy:)[#(inout Int, Int) -> ()#]{{; name=.+$}}
 // SKIP_COMPOUND_DUPLICATES-NOT: formIndex(_:offsetBy:)[#(inout Int, Int) -> ()#]
 // SKIP_COMPOUND_DUPLICATES: End completions
 
@@ -72,7 +72,7 @@ let x: A = overloadedReturn(1).#^RELATED_EXTRAARG?check=RELATED^#
 
 // RELATED: Begin completions, 4 items
 // RELATED-DAG: Keyword[self]/CurrNominal:          self[#A#]{{; name=.+$}}
-// RELATED-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: doAThings()[#A#]{{; name=.+$}}
+// RELATED-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: doAThings()[#A#]{{; name=.+$}}
 // RELATED-DAG: Keyword[self]/CurrNominal:          self[#B#]{{; name=.+$}}
 // RELATED-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: doBThings()[#Void#]{{; name=.+$}}
 // RELATED: End completions
@@ -89,9 +89,9 @@ overloadedArg(.#^UNRESOLVED_AMBIGUOUS^#)
 
 // UNRESOLVED_AMBIGUOUS: Begin completions, 4 items
 // UNRESOLVED_AMBIGUOUS-DAG: Decl[InstanceMethod]/CurrNominal: doAThings({#(self): A#})[#() -> A#]{{; name=.+$}}
-// UNRESOLVED_AMBIGUOUS-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Identical]: init()[#A#]{{; name=.+$}}
+// UNRESOLVED_AMBIGUOUS-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: init()[#A#]{{; name=.+$}}
 // UNRESOLVED_AMBIGUOUS-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: doBThings({#(self): B#})[#() -> Void#]{{; name=.+$}}
-// UNRESOLVED_AMBIGUOUS-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Identical]: init()[#B#]{{; name=.+$}}
+// UNRESOLVED_AMBIGUOUS-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: init()[#B#]{{; name=.+$}}
 // UNRESOLVED_AMBIGUOUS: End completions
 
 // Make sure we still offer A and B members as the user may intend to add a member on the end of the overloadedArg call later that has type B.
@@ -105,7 +105,7 @@ takesB(overloadedArg2(.#^UNRESOLVED_UNAMBIGUOUS^#))
 
 // UNRESOLVED_UNAMBIGUOUS: Begin completions, 2 items
 // UNRESOLVED_UNAMBIGUOUS-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: doBThings({#(self): B#})[#() -> Void#]{{; name=.+$}}
-// UNRESOLVED_UNAMBIGUOUS-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Identical]: init()[#B#]{{; name=.+$}}
+// UNRESOLVED_UNAMBIGUOUS-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: init()[#B#]{{; name=.+$}}
 // UNRESOLVED_UNAMBIGUOUS: End completions
 
 
@@ -149,7 +149,7 @@ takesAnonClosure { $1.#^UNAMBIGUOUSCLOSURE_ARG^# }
 takesAnonClosure { $0.#^AMBIGUOUSCLOSURE_ARG^# }
 // AMBIGUOUSCLOSURE_ARG: Begin completions, 4 items
 // AMBIGUOUSCLOSURE_ARG-DAG: Keyword[self]/CurrNominal: self[#A#]{{; name=.+$}}
-// AMBIGUOUSCLOSURE_ARG-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: doAThings()[#A#]{{; name=.+$}}
+// AMBIGUOUSCLOSURE_ARG-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: doAThings()[#A#]{{; name=.+$}}
 // AMBIGUOUSCLOSURE_ARG-DAG: Keyword[self]/CurrNominal: self[#B#]{{; name=.+$}}
 // AMBIGUOUSCLOSURE_ARG-DAG: Decl[InstanceMethod]/CurrNominal: doBThings()[#Void#]{{; name=.+$}}
 // AMBIGUOUSCLOSURE_ARG: End completions
@@ -158,9 +158,9 @@ takesAnonClosure { TestRelations.#^AMBIGUOUSCLOSURE_ARG_RETURN^# }
 // AMBIGUOUSCLOSURE_ARG_RETURN: Begin completions, 6 items
 // AMBIGUOUSCLOSURE_ARG_RETURN-DAG: Keyword[self]/CurrNominal: self[#TestRelations.Type#]{{; name=.+$}}
 // AMBIGUOUSCLOSURE_ARG_RETURN-DAG: Keyword/CurrNominal: Type[#TestRelations.Type#]{{; name=.+$}}
-// AMBIGUOUSCLOSURE_ARG_RETURN-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Identical]: a[#A#]{{; name=.+$}}
-// AMBIGUOUSCLOSURE_ARG_RETURN-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Identical]: b[#B#]{{; name=.+$}}
-// AMBIGUOUSCLOSURE_ARG_RETURN-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Identical]: ab[#(A, B)#]{{; name=.+$}}
+// AMBIGUOUSCLOSURE_ARG_RETURN-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Convertible]: a[#A#]{{; name=.+$}}
+// AMBIGUOUSCLOSURE_ARG_RETURN-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Convertible]: b[#B#]{{; name=.+$}}
+// AMBIGUOUSCLOSURE_ARG_RETURN-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Convertible]: ab[#(A, B)#]{{; name=.+$}}
 // AMBIGUOUSCLOSURE_ARG_RETURN-DAG: Decl[Constructor]/CurrNominal: init()[#TestRelations#]{{; name=.+$}}
 // AMBIGUOUSCLOSURE_ARG_RETURN: End completions
 
@@ -186,7 +186,7 @@ func arrayLiteralDictionaryMismatch<T>(a: inout T) where T: ExpressibleByDiction
 // PARSED_AS_ARRAY_KEY: Begin completions, 6 items
 // PARSED_AS_ARRAY_KEY-DAG: Keyword[self]/CurrNominal: self[#TestRelations.Type#]{{; name=.+$}}
 // PARSED_AS_ARRAY_KEY-DAG: Keyword/CurrNominal: Type[#TestRelations.Type#]{{; name=.+$}}
-// PARSED_AS_ARRAY_KEY-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Identical]: a[#A#]{{; name=.+$}}
+// PARSED_AS_ARRAY_KEY-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Convertible]: a[#A#]{{; name=.+$}}
 // PARSED_AS_ARRAY_KEY-DAG: Decl[StaticVar]/CurrNominal: b[#B#]{{; name=.+$}}
 // PARSED_AS_ARRAY_KEY-DAG: Decl[StaticVar]/CurrNominal: ab[#(A, B)#]{{; name=.+$}}
 // PARSED_AS_ARRAY_KEY-DAG: Decl[Constructor]/CurrNominal: init()[#TestRelations#]{{; name=.+$}}
@@ -199,7 +199,7 @@ let _: [(A, B)] = [TestRelations.#^PARSED_AS_ARRAY_ARRAY?check=PARSED_AS_ARRAY_T
 // PARSED_AS_ARRAY_TUPLE-DAG: Keyword/CurrNominal: Type[#TestRelations.Type#]{{; name=.+$}}
 // PARSED_AS_ARRAY_TUPLE-DAG: Decl[StaticVar]/CurrNominal: a[#A#]{{; name=.+$}}
 // PARSED_AS_ARRAY_TUPLE-DAG: Decl[StaticVar]/CurrNominal: b[#B#]{{; name=.+$}}
-// PARSED_AS_ARRAY_TUPLE-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Identical]: ab[#(A, B)#]{{; name=.+$}}
+// PARSED_AS_ARRAY_TUPLE-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Convertible]: ab[#(A, B)#]{{; name=.+$}}
 // PARSED_AS_ARRAY_TUPLE-DAG: Decl[Constructor]/CurrNominal: init()[#TestRelations#]{{; name=.+$}}
 // PARSED_AS_ARRAY_TUPLE: End completions
 
@@ -230,7 +230,7 @@ func testMissingArgs() {
   // OVERLOADEDFUNC_FOO: Begin completions, 5 items
   // OVERLOADEDFUNC_FOO-DAG: Keyword[self]/CurrNominal: self[#Test.Type#]{{; name=.+$}}
   // OVERLOADEDFUNC_FOO-DAG: Keyword/CurrNominal: Type[#Test.Type#]{{; name=.+$}}
-  // OVERLOADEDFUNC_FOO-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Identical]: foo[#Foo#]{{; name=.+$}}
+  // OVERLOADEDFUNC_FOO-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Convertible]: foo[#Foo#]{{; name=.+$}}
   // OVERLOADEDFUNC_FOO-DAG: Decl[StaticVar]/CurrNominal: bar[#Bar#]{{; name=.+$}}
   // OVERLOADEDFUNC_FOO-DAG: Decl[Constructor]/CurrNominal: init()[#Test#]{{; name=.+$}}
   // OVERLOADEDFUNC_FOO: End completions
@@ -240,7 +240,7 @@ func testMissingArgs() {
   // OVERLOADEDFUNC_BAR-DAG: Keyword[self]/CurrNominal: self[#Test.Type#]{{; name=.+$}}
   // OVERLOADEDFUNC_BAR-DAG: Keyword/CurrNominal: Type[#Test.Type#]{{; name=.+$}}
   // OVERLOADEDFUNC_BAR-DAG: Decl[StaticVar]/CurrNominal: foo[#Foo#]{{; name=.+$}}
-  // OVERLOADEDFUNC_BAR-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Identical]: bar[#Bar#]{{; name=.+$}}
+  // OVERLOADEDFUNC_BAR-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Convertible]: bar[#Bar#]{{; name=.+$}}
   // OVERLOADEDFUNC_BAR-DAG: Decl[Constructor]/CurrNominal: init()[#Test#]{{; name=.+$}}
   // OVERLOADEDFUNC_BAR: End completions
 
@@ -259,8 +259,8 @@ func testMissingArgs() {
   // OVERLOADEDFUNC_BOTH: Begin completions, 5 items
   // OVERLOADEDFUNC_BOTH-DAG: Keyword[self]/CurrNominal: self[#Test.Type#]{{; name=.+$}}
   // OVERLOADEDFUNC_BOTH-DAG: Keyword/CurrNominal: Type[#Test.Type#]{{; name=.+$}}
-  // OVERLOADEDFUNC_BOTH-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Identical]: foo[#Foo#]{{; name=.+$}}
-  // OVERLOADEDFUNC_BOTH-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Identical]: bar[#Bar#]{{; name=.+$}}
+  // OVERLOADEDFUNC_BOTH-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Convertible]: foo[#Foo#]{{; name=.+$}}
+  // OVERLOADEDFUNC_BOTH-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Convertible]: bar[#Bar#]{{; name=.+$}}
   // OVERLOADEDFUNC_BOTH-DAG: Decl[Constructor]/CurrNominal: init()[#Test#]{{; name=.+$}}
   // OVERLOADEDFUNC_BOTH: End completions
 
@@ -286,32 +286,32 @@ func testMissingArgs() {
   trailing(x: 2) { .#^MISSINGARG_TRAILING^# }
 
   // MISSINGARG_INLINE: Begin completions, 14 items
-  // MISSINGARG_INLINE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: foo[#Foo#]; name=foo
+  // MISSINGARG_INLINE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: foo[#Foo#]; name=foo
   // MISSINGARG_INLINE-DAG: Decl[InstanceMethod]/CurrNominal:   hash({#(self): Foo#})[#(into: inout Hasher) -> Void#]; name=hash(:)
-  // MISSINGARG_INLINE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: bar[#Bar#]; name=bar
+  // MISSINGARG_INLINE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: bar[#Bar#]; name=bar
   // MISSINGARG_INLINE-DAG: Decl[InstanceMethod]/CurrNominal:   hash({#(self): Bar#})[#(into: inout Hasher) -> Void#]; name=hash(:)
-  // MISSINGARG_INLINE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: bop[#Bop#]; name=bop
+  // MISSINGARG_INLINE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: bop[#Bop#]; name=bop
   // MISSINGARG_INLINE-DAG: Decl[InstanceMethod]/CurrNominal:   hash({#(self): Bop#})[#(into: inout Hasher) -> Void#]; name=hash(:)
-  // MISSINGARG_INLINE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: bix[#Bix#]; name=bix
+  // MISSINGARG_INLINE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: bix[#Bix#]; name=bix
   // MISSINGARG_INLINE-DAG: Decl[InstanceMethod]/CurrNominal:   hash({#(self): Bix#})[#(into: inout Hasher) -> Void#]; name=hash(:)
-  // MISSINGARG_INLINE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: boy[#Boy#]; name=boy
+  // MISSINGARG_INLINE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: boy[#Boy#]; name=boy
   // MISSINGARG_INLINE-DAG: Decl[InstanceMethod]/CurrNominal:   hash({#(self): Boy#})[#(into: inout Hasher) -> Void#]; name=hash(:)
-  // MISSINGARG_INLINE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: blu[#Blu#]; name=blu
+  // MISSINGARG_INLINE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: blu[#Blu#]; name=blu
   // MISSINGARG_INLINE-DAG: Decl[InstanceMethod]/CurrNominal:   hash({#(self): Blu#})[#(into: inout Hasher) -> Void#]; name=hash(:)
-  // MISSINGARG_INLINE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: baz[#Baz#]; name=baz
+  // MISSINGARG_INLINE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: baz[#Baz#]; name=baz
   // MISSINGARG_INLINE-DAG: Decl[InstanceMethod]/CurrNominal:   hash({#(self): Baz#})[#(into: inout Hasher) -> Void#]; name=hash(:)
   // MISSINGARG_INLINE: End completions
 
   // MISSINGARG_TRAILING: Begin completions, 10 items
-  // MISSINGARG_TRAILING-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: foo[#Foo#]; name=foo
+  // MISSINGARG_TRAILING-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: foo[#Foo#]; name=foo
   // MISSINGARG_TRAILING-DAG: Decl[InstanceMethod]/CurrNominal:   hash({#(self): Foo#})[#(into: inout Hasher) -> Void#]; name=hash(:)
-  // MISSINGARG_TRAILING-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: bar[#Bar#]; name=bar
+  // MISSINGARG_TRAILING-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: bar[#Bar#]; name=bar
   // MISSINGARG_TRAILING-DAG: Decl[InstanceMethod]/CurrNominal:   hash({#(self): Bar#})[#(into: inout Hasher) -> Void#]; name=hash(:)
-  // MISSINGARG_TRAILING-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: bop[#Bop#]; name=bop
+  // MISSINGARG_TRAILING-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: bop[#Bop#]; name=bop
   // MISSINGARG_TRAILING-DAG: Decl[InstanceMethod]/CurrNominal:   hash({#(self): Bop#})[#(into: inout Hasher) -> Void#]; name=hash(:)
-  // MISSINGARG_TRAILING-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: bix[#Bix#]; name=bix
+  // MISSINGARG_TRAILING-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: bix[#Bix#]; name=bix
   // MISSINGARG_TRAILING-DAG: Decl[InstanceMethod]/CurrNominal:   hash({#(self): Bix#})[#(into: inout Hasher) -> Void#]; name=hash(:)
-  // MISSINGARG_TRAILING-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: boy[#Boy#]; name=boy
+  // MISSINGARG_TRAILING-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: boy[#Boy#]; name=boy
   // MISSINGARG_TRAILING-DAG: Decl[InstanceMethod]/CurrNominal:   hash({#(self): Boy#})[#(into: inout Hasher) -> Void#]; name=hash(:)
   // MISSINGARG_TRAILING: End completions
 }
@@ -443,8 +443,8 @@ struct TestFuncBodyBuilder {
   }
 }
 // FUNCBUILDER_FUNCBODY: Begin completions, 3 items
-// FUNCBUILDER_FUNCBODY-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: first[#Thing.ThingEnum#];
-// FUNCBUILDER_FUNCBODY-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: second[#Thing.ThingEnum#];
+// FUNCBUILDER_FUNCBODY-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: first[#Thing.ThingEnum#];
+// FUNCBUILDER_FUNCBODY-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: second[#Thing.ThingEnum#];
 // FUNCBUILDER_FUNCBODY-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): Thing.ThingEnum#})[#(into: inout Hasher) -> Void#];
 // FUNCBUILDER_FUNCBODY: End completions
 
@@ -473,9 +473,9 @@ func testBestSolutionFilter() {
 // BEST_SOLUTION_FILTER: Begin completions
 // BEST_SOLUTION_FILTER-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: enumElem[#Enum123#]{{; name=.+$}}
 // BEST_SOLUTION_FILTER-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): Enum123#})[#(into: inout Hasher) -> Void#]{{; name=.+$}}
-// BEST_SOLUTION_FILTER-DAG: Keyword[nil]/None/Erase[1]/TypeRelation[Identical]: nil[#Enum123?#]{{; name=.+$}}
-// BEST_SOLUTION_FILTER-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Identical]: none[#Optional<Enum123>#]{{; name=.+$}}
-// BEST_SOLUTION_FILTER-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Identical]: some({#Enum123#})[#Optional<Enum123>#]{{; name=.+$}}
+// BEST_SOLUTION_FILTER-DAG: Keyword[nil]/None/Erase[1]/TypeRelation[Convertible]: nil[#Enum123?#]{{; name=.+$}}
+// BEST_SOLUTION_FILTER-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Convertible]: none[#Optional<Enum123>#]{{; name=.+$}}
+// BEST_SOLUTION_FILTER-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Convertible]: some({#Enum123#})[#Optional<Enum123>#]{{; name=.+$}}
 // BEST_SOLUTION_FILTER: End completions
 
 func testBestSolutionGeneric() {
@@ -519,7 +519,7 @@ func testAmbiguousArgs() {
 
   // ARG_LABEL: Begin completions
   // ARG_LABEL-DAG: Decl[LocalVar]/Local:                          localString[#String#]; name=localString
-  // ARG_LABEL-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]:  localInt[#Int#]; name=localInt
+  // ARG_LABEL-DAG: Decl[LocalVar]/Local/TypeRelation[Convertible]:  localInt[#Int#]; name=localInt
   // ARG_LABEL: End completions
 
   overloaded().someFunc(a: 2, c: "Foo", #^ARG_NO_LABEL2^#)
@@ -573,7 +573,7 @@ func testAmbiguousArgs() {
   overloaded().variadic(y: 2, x: 2, #^NONINITIAL_VARARG^#)
   // NONINITIAL_VARARG: Begin completions
   // NONINITIAL_VARARG-NOT: name=x:
-  // NONINITIAL_VARARG: Decl[LocalVar]/Local/TypeRelation[Identical]:  localInt[#Int#]; name=localInt
+  // NONINITIAL_VARARG: Decl[LocalVar]/Local/TypeRelation[Convertible]:  localInt[#Int#]; name=localInt
   // NONINITIAL_VARARG-NOT: name=x:
   // NONINITIAL_VARARG: End completions
 }

--- a/test/IDE/complete_annotation.swift
+++ b/test/IDE/complete_annotation.swift
@@ -89,13 +89,13 @@ func testImplicitMember() -> MyStruct {
   return .#^EXPR_IMPLICITMEMBER^#
 }
 // EXPR_IMPLICITMEMBER: Begin completions, 7 items
-// EXPR_IMPLICITMEMBER-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Identical]: <name>init</name>(<callarg><callarg.label>x</callarg.label>: <callarg.type><typeid.sys>Int</typeid.sys></callarg.type></callarg>); typename=<typeid.user>MyStruct</typeid.user>;
-// EXPR_IMPLICITMEMBER-DAG: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: <name>instance</name>; typename=<typeid.user>MyStruct</typeid.user>;
+// EXPR_IMPLICITMEMBER-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: <name>init</name>(<callarg><callarg.label>x</callarg.label>: <callarg.type><typeid.sys>Int</typeid.sys></callarg.type></callarg>); typename=<typeid.user>MyStruct</typeid.user>;
+// EXPR_IMPLICITMEMBER-DAG: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: <name>instance</name>; typename=<typeid.user>MyStruct</typeid.user>;
 // EXPR_IMPLICITMEMBER-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: <name>labelNameParamName</name>(<callarg><callarg.label>_</callarg.label> <callarg.param>self</callarg.param>: <callarg.type><typeid.user>MyStruct</typeid.user></callarg.type></callarg>); typename=(label: (<keyword>inout</keyword> <typeid.sys>Int</typeid.sys>) <keyword>throws</keyword> -&gt; <typeid.user>MyStruct</typeid.user>) -&gt; <typeid.sys>Void</typeid.sys>;
 // EXPR_IMPLICITMEMBER-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: <name>labelName</name>(<callarg><callarg.label>_</callarg.label> <callarg.param>self</callarg.param>: <callarg.type><typeid.user>MyStruct</typeid.user></callarg.type></callarg>); typename=(label: (<attribute>@autoclosure</attribute> () -&gt; <typeid.sys>Int</typeid.sys>) -&gt; <typeid.sys>Int</typeid.sys>) -&gt; <typeid.sys>Void</typeid.sys>;
 // EXPR_IMPLICITMEMBER-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: <name>sameName</name>(<callarg><callarg.label>_</callarg.label> <callarg.param>self</callarg.param>: <callarg.type><typeid.user>MyStruct</typeid.user></callarg.type></callarg>); typename=(label: <keyword>inout</keyword> <typeid.sys>Int</typeid.sys>) -&gt; <typeid.sys>Void</typeid.sys>;
 // EXPR_IMPLICITMEMBER-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: <name>paramName</name>(<callarg><callarg.label>_</callarg.label> <callarg.param>self</callarg.param>: <callarg.type><typeid.user>MyStruct</typeid.user></callarg.type></callarg>); typename=(<typeid.sys>Int</typeid.sys>) -&gt; <typeid.sys>Void</typeid.sys>;
-// EXPR_IMPLICITMEMBER-DAG: Decl[StaticMethod]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: <name>create</name>(<callarg><callarg.label>x</callarg.label>: <callarg.type><typeid.sys>Int</typeid.sys></callarg.type></callarg>); typename=<typeid.user>MyStruct</typeid.user>;
+// EXPR_IMPLICITMEMBER-DAG: Decl[StaticMethod]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: <name>create</name>(<callarg><callarg.label>x</callarg.label>: <callarg.type><typeid.sys>Int</typeid.sys></callarg.type></callarg>); typename=<typeid.user>MyStruct</typeid.user>;
 // EXPR_IMPLICITMEMBER: End completions
 
 func testArgument() -> MyStruct {

--- a/test/IDE/complete_assignment.swift
+++ b/test/IDE/complete_assignment.swift
@@ -73,10 +73,10 @@ func f1() {
 }
 
 // ASSIGN_1: Begin completions
-// ASSIGN_1-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]:               	I3[#Int#]; name=I3
-// ASSIGN_1-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Identical]:      	I1[#Int#]; name=I1
-// ASSIGN_1-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Identical]:      	I2[#Int#]; name=I2
-// ASSIGN_1-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]:   	IntGenerator()[#Int#]; name=IntGenerator()
+// ASSIGN_1-DAG: Decl[LocalVar]/Local/TypeRelation[Convertible]:               	I3[#Int#]; name=I3
+// ASSIGN_1-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]:      	I1[#Int#]; name=I1
+// ASSIGN_1-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]:      	I2[#Int#]; name=I2
+// ASSIGN_1-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]:   	IntGenerator()[#Int#]; name=IntGenerator()
 // ASSIGN_1-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: 			VoidGen()[#Void#]; name=VoidGen()
 // ASSIGN_1-DAG: Decl[InstanceVar]/CurrNominal:                               S1[#String#]; name=S1
 
@@ -86,12 +86,12 @@ func f2() {
 }
 
 // ASSIGN_2-DAG: Begin completions
-// ASSIGN_2-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]:               		I3[#Int?#]; name=I3
+// ASSIGN_2-DAG: Decl[LocalVar]/Local/TypeRelation[Convertible]:               		I3[#Int?#]; name=I3
 // ASSIGN_2-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]:      	I1[#Int#]; name=I1
 // ASSIGN_2-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]:      	I2[#Int#]; name=I2
-// ASSIGN_2-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Identical]:      		IO1[#Int?#]; name=IO1
+// ASSIGN_2-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]:      		IO1[#Int?#]; name=IO1
 // ASSIGN_2-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]:   	IntGenerator()[#Int#]; name=IntGenerator()
-// ASSIGN_2-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]:      IntOpGenerator()[#Int?#]; name=IntOpGenerator()
+// ASSIGN_2-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]:      IntOpGenerator()[#Int?#]; name=IntOpGenerator()
 // ASSIGN_2-DAG: Decl[InstanceVar]/CurrNominal:                                 S1[#String#]; name=S1
 
 	func f3() {
@@ -100,10 +100,10 @@ func f2() {
 	}
 
 // ASSIGN_3-DAG: Begin completions
-// ASSIGN_3-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]:                S3[#String#]; name=S3
-// ASSIGN_3-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Identical]:       S1[#String#]; name=S1
-// ASSIGN_3-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Identical]:       S2[#String#]; name=S2
-// ASSIGN_3-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]:    StringGenerator()[#String#]; name=StringGenerator()
+// ASSIGN_3-DAG: Decl[LocalVar]/Local/TypeRelation[Convertible]:                S3[#String#]; name=S3
+// ASSIGN_3-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]:       S1[#String#]; name=S1
+// ASSIGN_3-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]:       S2[#String#]; name=S2
+// ASSIGN_3-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]:    StringGenerator()[#String#]; name=StringGenerator()
 // ASSIGN_3-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]:      VoidGen()[#Void#]; name=VoidGen()
 // ASSIGN_3-DAG: Decl[InstanceVar]/CurrNominal:                               I1[#Int#]; name=I1
 
@@ -113,12 +113,12 @@ func f2() {
 	}
 
 // ASSIGN_4-DAG: Begin completions
-// ASSIGN_4-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]:                S4[#String?#]; name=S4
+// ASSIGN_4-DAG: Decl[LocalVar]/Local/TypeRelation[Convertible]:                S4[#String?#]; name=S4
 // ASSIGN_4-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]:     S1[#String#]; name=S1
 // ASSIGN_4-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]:     S2[#String#]; name=S2
-// ASSIGN_4-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Identical]:       SO1[#String?#]; name=SO1
+// ASSIGN_4-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]:       SO1[#String?#]; name=SO1
 // ASSIGN_4-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]:  StringGenerator()[#String#]; name=StringGenerator()
-// ASSIGN_4-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]:    StringOpGenerator()[#String?#]; name=StringOpGenerator()
+// ASSIGN_4-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]:    StringOpGenerator()[#String?#]; name=StringOpGenerator()
 // ASSIGN_4-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]:      VoidGen()[#Void#]; name=VoidGen()
 // ASSIGN_4-DAG: Decl[InstanceVar]/CurrNominal:                               I1[#Int#]; name=I1
 
@@ -128,8 +128,8 @@ func f2() {
 	}
 
 // ASSIGN_5: Begin completions, 3 items
-// ASSIGN_5-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     case2[#D1#]; name=case2
-// ASSIGN_5-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     case1[#D1#]; name=case1
+// ASSIGN_5-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]:     case2[#D1#]; name=case2
+// ASSIGN_5-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]:     case1[#D1#]; name=case1
 // ASSIGN_5-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]:     hash({#(self): D1#})[#(into: inout Hasher) -> Void#]; name=hash(:)
 
 	func f6() {
@@ -137,8 +137,8 @@ func f2() {
 	  d = .#^ASSIGN_6^#
 	}
 // ASSIGN_6: Begin completions, 3 items
-// ASSIGN_6-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     case3[#D2#]; name=case3
-// ASSIGN_6-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     case4[#D2#]; name=case4
+// ASSIGN_6-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]:     case3[#D2#]; name=case3
+// ASSIGN_6-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]:     case4[#D2#]; name=case4
 // ASSIGN_6-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]:     hash({#(self): D2#})[#(into: inout Hasher) -> Void#]; name=hash(:)
 
   func f7 (C : C2) {
@@ -147,7 +147,7 @@ func f2() {
   }
 
 // ASSIGN_7: Begin completions
-// ASSIGN_7-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: IntGen()[#Int#]
+// ASSIGN_7-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: IntGen()[#Int#]
 // ASSIGN_7-DAG: Decl[InstanceMethod]/CurrNominal:   IntOpGen()[#Int?#]
 // ASSIGN_7-DAG: Decl[InstanceMethod]/CurrNominal:   D1Gen()[#D1#]
 // ASSIGN_7-DAG: Decl[InstanceMethod]/CurrNominal:   D2Gen()[#D2#]
@@ -161,7 +161,7 @@ func f2() {
 
 // ASSIGN_8: Begin completions
 // ASSIGN_8-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: IntGen()[#Int#]
-// ASSIGN_8-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: IntOpGen()[#Int?#]
+// ASSIGN_8-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: IntOpGen()[#Int?#]
 // ASSIGN_8-DAG: Decl[InstanceMethod]/CurrNominal:   D1Gen()[#D1#]
 // ASSIGN_8-DAG: Decl[InstanceMethod]/CurrNominal:   D2Gen()[#D2#]
 // ASSIGN_8-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: VoidGen()[#Void#]
@@ -175,7 +175,7 @@ func f2() {
 // ASSIGN_9: Begin completions
 // ASSIGN_9-DAG: Decl[InstanceMethod]/CurrNominal:   IntGen()[#Int#]
 // ASSIGN_9-DAG: Decl[InstanceMethod]/CurrNominal:   IntOpGen()[#Int?#]
-// ASSIGN_9-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: D1Gen()[#D1#]
+// ASSIGN_9-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: D1Gen()[#D1#]
 // ASSIGN_9-DAG: Decl[InstanceMethod]/CurrNominal:   D2Gen()[#D2#]
 // ASSIGN_9-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: VoidGen()[#Void#]
 // ASSIGN_9-DAG: Decl[InstanceVar]/CurrNominal:      InternalC2[#C2#]
@@ -188,7 +188,7 @@ func f2() {
 // ASSIGN_10: Begin completions
 // ASSIGN_10-DAG: Decl[InstanceMethod]/CurrNominal:   IntGen()[#Int#]
 // ASSIGN_10-DAG: Decl[InstanceMethod]/CurrNominal:   IntOpGen()[#Int?#]
-// ASSIGN_10-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: D1Gen()[#D1#]
+// ASSIGN_10-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: D1Gen()[#D1#]
 // ASSIGN_10-DAG: Decl[InstanceMethod]/CurrNominal:   D2Gen()[#D2#]
 // ASSIGN_10-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: VoidGen()[#Void#]
 // ASSIGN_10-DAG: Decl[InstanceVar]/CurrNominal:      InternalC2[#C2#]
@@ -211,7 +211,7 @@ func f2() {
   }
 
 // ASSIGN_12: Begin completions
-// ASSIGN_12-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: IntGen()[#Int#]
+// ASSIGN_12-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: IntGen()[#Int#]
 // ASSIGN_12-DAG: Decl[InstanceMethod]/CurrNominal:   IntOpGen()[#Int?#]
 // ASSIGN_12-DAG: Decl[InstanceMethod]/CurrNominal:   D1Gen()[#D1#]
 // ASSIGN_12-DAG: Decl[InstanceMethod]/CurrNominal:   D2Gen()[#D2#]
@@ -222,9 +222,9 @@ func f2() {
     var i : Int = #^ASSIGN_13^#
   }
 // ASSIGN_13: Begin completions
-// ASSIGN_13-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Identical]:       I1[#Int#]; name=I1
-// ASSIGN_13-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Identical]:       I2[#Int#]; name=I2
-// ASSIGN_13-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]:    IntGenerator()[#Int#]; name=IntGenerator()
+// ASSIGN_13-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]:       I1[#Int#]; name=I1
+// ASSIGN_13-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]:       I2[#Int#]; name=I2
+// ASSIGN_13-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]:    IntGenerator()[#Int#]; name=IntGenerator()
 // ASSIGN_13-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]:      VoidGen()[#Void#]; name=VoidGen()
 // ASSIGN_13-DAG: Decl[InstanceVar]/CurrNominal:                               S1[#String#]; name=S1
 
@@ -235,9 +235,9 @@ func f2() {
 // ASSIGN_14-DAG: Begin completions
 // ASSIGN_14-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]:       I1[#Int#]; name=I1
 // ASSIGN_14-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]:       I2[#Int#]; name=I2
-// ASSIGN_14-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Identical]:         IO1[#Int?#]; name=IO1
+// ASSIGN_14-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]:         IO1[#Int?#]; name=IO1
 // ASSIGN_14-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]:    IntGenerator()[#Int#]; name=IntGenerator()
-// ASSIGN_14-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]:      IntOpGenerator()[#Int?#]; name=IntOpGenerator()
+// ASSIGN_14-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]:      IntOpGenerator()[#Int?#]; name=IntOpGenerator()
 // ASSIGN_14-DAG: Decl[InstanceVar]/CurrNominal:                                 S1[#String#]; name=S1
 
   func f15() {
@@ -252,7 +252,7 @@ func f2() {
 // ASSIGN_16: Begin completions
 // ASSIGN_16-DAG: Decl[InstanceMethod]/CurrNominal:   IntGen()[#Int#]
 // ASSIGN_16-DAG: Decl[InstanceMethod]/CurrNominal:   IntOpGen()[#Int?#]
-// ASSIGN_16-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: D1Gen()[#D1#]
+// ASSIGN_16-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: D1Gen()[#D1#]
 // ASSIGN_16-DAG: Decl[InstanceMethod]/CurrNominal:   D2Gen()[#D2#]
 // ASSIGN_16-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: VoidGen()[#Void#]
 // ASSIGN_16-DAG: Decl[InstanceVar]/CurrNominal:      InternalC2[#C2#]
@@ -262,7 +262,7 @@ func f2() {
   }
 
 // ASSIGN_17: Begin completions
-// ASSIGN_17-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: IntGen()[#Int#]
+// ASSIGN_17-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: IntGen()[#Int#]
 // ASSIGN_17-DAG: Decl[InstanceMethod]/CurrNominal:   IntOpGen()[#Int?#]
 // ASSIGN_17-DAG: Decl[InstanceMethod]/CurrNominal:   D1Gen()[#D1#]
 // ASSIGN_17-DAG: Decl[InstanceMethod]/CurrNominal:   D2Gen()[#D2#]
@@ -276,7 +276,7 @@ func f2() {
 // ASSIGN_18: Begin completions
 // ASSIGN_18-DAG: Decl[InstanceMethod]/CurrNominal:   IntGen()[#Int#]
 // ASSIGN_18-DAG: Decl[InstanceMethod]/CurrNominal:   IntOpGen()[#Int?#]
-// ASSIGN_18-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: D1Gen()[#D1#]
+// ASSIGN_18-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: D1Gen()[#D1#]
 // ASSIGN_18-DAG: Decl[InstanceMethod]/CurrNominal:   D2Gen()[#D2#]
 // ASSIGN_18-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: VoidGen()[#Void#]
 // ASSIGN_18-DAG: Decl[InstanceVar]/CurrNominal:      InternalC2[#C2#]
@@ -291,4 +291,4 @@ class Test19 {
   var prop: Bool
 }
 // rdar://23111219
-// ASSIGN_19: Decl[LocalVar]/Local/TypeRelation[Identical]: t[#Bool#]
+// ASSIGN_19: Decl[LocalVar]/Local/TypeRelation[Convertible]: t[#Bool#]

--- a/test/IDE/complete_associated_types.swift
+++ b/test/IDE/complete_associated_types.swift
@@ -345,6 +345,6 @@ struct A<T>: MyProto {
 // BROKEN_CONFORMANCE_UNASSIGNABLE: End completions
 
 // BROKEN_CONFORMANCE_ASSIGNABLE: Begin completions
-// BROKEN_CONFORMANCE_ASSIGNABLE-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]: exact[#(Int, (Int, Int))#]; name=exact
-// BROKEN_CONFORMANCE_ASSIGNABLE-DAG: Decl[InstanceVar]/Super/TypeRelation[Identical]: matches[#(Int, (Int, Int))#]; name=matches
+// BROKEN_CONFORMANCE_ASSIGNABLE-DAG: Decl[LocalVar]/Local/TypeRelation[Convertible]: exact[#(Int, (Int, Int))#]; name=exact
+// BROKEN_CONFORMANCE_ASSIGNABLE-DAG: Decl[InstanceVar]/Super/TypeRelation[Convertible]: matches[#(Int, (Int, Int))#]; name=matches
 // BROKEN_CONFORMANCE_ASSIGNABLE: End completions

--- a/test/IDE/complete_cache_notrecommended.swift
+++ b/test/IDE/complete_cache_notrecommended.swift
@@ -25,7 +25,7 @@ func testSync() -> Int{
 // 'async'-ness in the cache. (rdar://78317170)
 
 // GLOBAL_IN_SYNC: Begin completions
-// GLOBAL_IN_SYNC-DAG: Decl[FreeFunction]/OtherModule[MyModule]/TypeRelation[Identical]: globalAsyncFunc()[' async'][#Int#];
+// GLOBAL_IN_SYNC-DAG: Decl[FreeFunction]/OtherModule[MyModule]/TypeRelation[Convertible]: globalAsyncFunc()[' async'][#Int#];
 // GLOBAL_IN_SYNC-DAG: Decl[FreeFunction]/OtherModule[MyModule]/NotRecommended: deprecatedFunc()[#Void#];
 // GLOBAL_IN_SYNC-DAG: Decl[Actor]/OtherModule[MyModule]:  MyActor[#MyActor#];
 // GLOBAL_IN_SYNC: End completions
@@ -33,7 +33,7 @@ func testSync() -> Int{
 func testAsync() async -> Int {
     #^GLOBAL_IN_ASYNC^#
 // GLOBAL_IN_ASYNC: Begin completions
-// GLOBAL_IN_ASYNC-DAG: Decl[FreeFunction]/OtherModule[MyModule]/TypeRelation[Identical]: globalAsyncFunc()[' async'][#Int#];
+// GLOBAL_IN_ASYNC-DAG: Decl[FreeFunction]/OtherModule[MyModule]/TypeRelation[Convertible]: globalAsyncFunc()[' async'][#Int#];
 // GLOBAL_IN_ASYNC-DAG: Decl[FreeFunction]/OtherModule[MyModule]/NotRecommended: deprecatedFunc()[#Void#];
 // GLOBAL_IN_ASYNC-DAG: Decl[Actor]/OtherModule[MyModule]:  MyActor[#MyActor#];
 // GLOBAL_IN_ASYNC: End completions
@@ -42,7 +42,7 @@ func testSyncMember(obj: MyActor) -> Int {
     obj.#^MEMBER_IN_SYNC^#
 // MEMBER_IN_SYNC: Begin completions, 4 items
 // MEMBER_IN_SYNC-DAG: Keyword[self]/CurrNominal:          self[#MyActor#];
-// MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended/TypeRelation[Identical]: actorMethod()[' async'][#Int#];
+// MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended/TypeRelation[Convertible]: actorMethod()[' async'][#Int#];
 // MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: deprecatedMethod()[' async'][#Void#];
 // MEMBER_IN_SYNC-DAG: Decl[InstanceVar]/CurrNominal:      unownedExecutor[#UnownedSerialExecutor#];
 // MEMBER_IN_SYNC: End completions
@@ -52,7 +52,7 @@ func testSyncMember(obj: MyActor) async -> Int {
     obj.#^MEMBER_IN_ASYNC^#
 // MEMBER_IN_ASYNC: Begin completions, 4 items
 // MEMBER_IN_ASYNC-DAG: Keyword[self]/CurrNominal:          self[#MyActor#];
-// MEMBER_IN_ASYNC-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: actorMethod()[' async'][#Int#];
+// MEMBER_IN_ASYNC-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: actorMethod()[' async'][#Int#];
 // MEMBER_IN_ASYNC-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: deprecatedMethod()[' async'][#Void#];
 // MEMBER_IN_ASYNC-DAG: Decl[InstanceVar]/CurrNominal:      unownedExecutor[#UnownedSerialExecutor#];
 // MEMBER_IN_ASYNC: End completions

--- a/test/IDE/complete_call_arg.swift
+++ b/test/IDE/complete_call_arg.swift
@@ -95,8 +95,8 @@ class C1 {
 // EXPECT_OINT-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: f2()[#Void#]; name=f2()
 // EXPECT_OINT-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Convertible]: i2[#Int#]; name=i2
 // EXPECT_OINT-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Convertible]: i1[#Int#]; name=i1
-// EXPECT_OINT-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Identical]: oi2[#Int?#]; name=oi2
-// EXPECT_OINT-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Identical]: oi1[#Int?#]; name=oi1
+// EXPECT_OINT-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Convertible]: oi2[#Int?#]; name=oi2
+// EXPECT_OINT-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Convertible]: oi1[#Int?#]; name=oi1
 // EXPECT_OINT-DAG: Decl[GlobalVar]/CurrModule:         os1[#String?#]; name=os1
 // EXPECT_OINT-DAG: Keyword[try]/None: try; name=try
 // EXPECT_OINT-DAG: Keyword[try]/None: try!; name=try!
@@ -109,10 +109,10 @@ class C1 {
 // EXPECT_INT-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: f1()[#Void#]; name=f1()
 // EXPECT_INT-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: f2()[#Void#]; name=f2()
 // EXPECT_INT-DAG: Decl[FreeFunction]/CurrModule/TypeRelation[Invalid]: voidGen()[#Void#]; name=voidGen()
-// EXPECT_INT-DAG: Decl[FreeFunction]/CurrModule/TypeRelation[Identical]: intGen()[#Int#]; name=intGen()
-// EXPECT_INT-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Identical]: i1[#Int#]; name=i1
-// EXPECT_INT-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Identical]: i2[#Int#]; name=i2
-// EXPECT_INT-DAG: Decl[Struct]/OtherModule[Swift]/IsSystem/TypeRelation[Identical]: Int[#Int#]
+// EXPECT_INT-DAG: Decl[FreeFunction]/CurrModule/TypeRelation[Convertible]: intGen()[#Int#]; name=intGen()
+// EXPECT_INT-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Convertible]: i1[#Int#]; name=i1
+// EXPECT_INT-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Convertible]: i2[#Int#]; name=i2
+// EXPECT_INT-DAG: Decl[Struct]/OtherModule[Swift]/IsSystem/TypeRelation[Convertible]: Int[#Int#]
 // EXPECT_INT-DAG: Decl[FreeFunction]/CurrModule:      ointGen()[#Int?#]; name=ointGen()
 // EXPECT_INT-DAG: Decl[GlobalVar]/CurrModule:         oi1[#Int?#]; name=oi1
 // EXPECT_INT-DAG: Decl[GlobalVar]/CurrModule:         os2[#String?#]; name=os2
@@ -145,9 +145,9 @@ class C2 {
 // EXPECT_OSTRING-DAG: Decl[FreeFunction]/CurrModule/TypeRelation[Convertible]: stringGen()[#String#]; name=stringGen()
 // EXPECT_OSTRING-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Convertible]: s2[#String#]; name=s2
 // EXPECT_OSTRING-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Convertible]: s1[#String#]; name=s1
-// EXPECT_OSTRING-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Identical]: os1[#String?#]; name=os1
-// EXPECT_OSTRING-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Identical]: os2[#String?#]; name=os2
-// EXPECT_OSTRING-DAG: Decl[FreeFunction]/CurrModule/TypeRelation[Identical]: ostringGen()[#String?#]; name=ostringGen()
+// EXPECT_OSTRING-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Convertible]: os1[#String?#]; name=os1
+// EXPECT_OSTRING-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Convertible]: os2[#String?#]; name=os2
+// EXPECT_OSTRING-DAG: Decl[FreeFunction]/CurrModule/TypeRelation[Convertible]: ostringGen()[#String?#]; name=ostringGen()
 // EXPECT_OSTRING-DAG: Decl[GlobalVar]/CurrModule:         i1[#Int#]; name=i1
 // EXPECT_OSTRING-DAG: Decl[GlobalVar]/CurrModule:         i2[#Int#]; name=i2
 // EXPECT_OSTRING-DAG: Keyword[try]/None: try; name=try
@@ -160,10 +160,10 @@ class C2 {
 // EXPECT_STRING: Begin completions
 // EXPECT_STRING-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: f1()[#Void#]; name=f1()
 // EXPECT_STRING-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: f2()[#Void#]; name=f2()
-// EXPECT_STRING-DAG: Decl[FreeFunction]/CurrModule/TypeRelation[Identical]: stringGen()[#String#]; name=stringGen()
-// EXPECT_STRING-DAG: Decl[Struct]/OtherModule[Swift]/IsSystem/TypeRelation[Identical]: String[#String#]
-// EXPECT_STRING-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Identical]: s1[#String#]; name=s1
-// EXPECT_STRING-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Identical]: s2[#String#]; name=s2
+// EXPECT_STRING-DAG: Decl[FreeFunction]/CurrModule/TypeRelation[Convertible]: stringGen()[#String#]; name=stringGen()
+// EXPECT_STRING-DAG: Decl[Struct]/OtherModule[Swift]/IsSystem/TypeRelation[Convertible]: String[#String#]
+// EXPECT_STRING-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Convertible]: s1[#String#]; name=s1
+// EXPECT_STRING-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Convertible]: s2[#String#]; name=s2
 // EXPECT_STRING-DAG: Decl[GlobalVar]/CurrModule:         os1[#String?#]; name=os1
 // EXPECT_STRING-DAG: Decl[GlobalVar]/CurrModule:         os2[#String?#]; name=os2
 // EXPECT_STRING-DAG: Keyword[try]/None: try; name=try
@@ -217,28 +217,28 @@ class C3 {
 // OVERLOAD3: Begin completions
 // OVERLOAD3-DAG: Decl[InstanceVar]/CurrNominal:      C1I[#C1#]; name=C1I
 // OVERLOAD3-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: f1()[#Void#]; name=f1()
-// OVERLOAD3-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Identical]: C2I[#C2#]; name=C2I
-// OVERLOAD3-DAG: Decl[Class]/CurrModule/TypeRelation[Identical]: C2[#C2#]
+// OVERLOAD3-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]: C2I[#C2#]; name=C2I
+// OVERLOAD3-DAG: Decl[Class]/CurrModule/TypeRelation[Convertible]: C2[#C2#]
 // OVERLOAD3: End completions
 
 // OVERLOAD4: Begin completions
-// OVERLOAD4-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Identical]: C1I[#C1#]; name=C1I
+// OVERLOAD4-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]: C1I[#C1#]; name=C1I
 // OVERLOAD4-DAG: Decl[InstanceVar]/CurrNominal:      C2I[#C2#]; name=C2I
 // OVERLOAD4-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: f1()[#Void#]; name=f1()
-// OVERLOAD4-DAG: Decl[Class]/CurrModule/TypeRelation[Identical]: C1[#C1#]
+// OVERLOAD4-DAG: Decl[Class]/CurrModule/TypeRelation[Convertible]: C1[#C1#]
 // OVERLOAD4: End completions
 
 // OVERLOAD5: Begin completions
 // OVERLOAD5-DAG: Decl[FreeFunction]/CurrModule/Flair[ArgLabels]:      ['(']{#(a): C1#}, {#b1: C2#}[')'][#Void#]; name=:b1:
 // OVERLOAD5-DAG: Decl[FreeFunction]/CurrModule/Flair[ArgLabels]:      ['(']{#(a): C2#}, {#b2: C1#}[')'][#Void#]; name=:b2:
-// OVERLOAD5-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Identical]: C1I[#C1#]; name=C1I
-// OVERLOAD5-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Identical]: C2I[#C2#]; name=C2I
+// OVERLOAD5-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]: C1I[#C1#]; name=C1I
+// OVERLOAD5-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]: C2I[#C2#]; name=C2I
 // OVERLOAD5: End completions
 
 // OVERLOAD6: Begin completions
 // OVERLOAD6-DAG: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]:   ['(']{#(a1): C1#}, {#b1: C2#}[')'][#Void#]; name=:b1:
 // OVERLOAD6-DAG: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]:   ['(']{#a2: C2#}, {#b2: C1#}[')'][#Void#]; name=a2:b2:
-// OVERLOAD6-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Identical]: C1I[#C1#]; name=C1I
+// OVERLOAD6-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]: C1I[#C1#]; name=C1I
 // OVERLOAD6-DAG: Decl[InstanceVar]/CurrNominal:      C2I[#C2#]; name=C2I
 // OVERLOAD6: End completions
 
@@ -258,7 +258,7 @@ extension C3 {
 // HASERROR1: End completions
 
 // HASERROR2: Begin completions
-// HASERROR2-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Identical]: C1I[#C1#];
+// HASERROR2-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]: C1I[#C1#];
 // HASERROR2-DAG: Decl[InstanceVar]/CurrNominal:      C2I[#C2#];
 // HASERROR2: End completions
 
@@ -327,7 +327,7 @@ class C4 {
 
 // MEMBER1: Begin completions
 // MEMBER1-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: IntGen()[#Int#]; name=IntGen()
-// MEMBER1-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: IntOpGen()[#Int?#]; name=IntOpGen()
+// MEMBER1-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: IntOpGen()[#Int?#]; name=IntOpGen()
 // MEMBER1-DAG: Decl[InstanceMethod]/CurrNominal:   StringGen()[#String#]; name=StringGen()
 // MEMBER1-DAG: Decl[InstanceMethod]/CurrNominal:   StringOpGen()[#String?#]; name=StringOpGen()
 // MEMBER1-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: IntTaker({#(i1): Int#}, {#i2: Int#})[#Void#]; name=IntTaker(:i2:)
@@ -339,7 +339,7 @@ class C4 {
 // MEMBER1-NOT: Keyword[super]
 
 // MEMBER2: Begin completions
-// MEMBER2-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: IntGen()[#Int#]; name=IntGen()
+// MEMBER2-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: IntGen()[#Int#]; name=IntGen()
 // MEMBER2-DAG: Decl[InstanceMethod]/CurrNominal:   IntOpGen()[#Int?#]; name=IntOpGen()
 // MEMBER2-DAG: Decl[InstanceMethod]/CurrNominal:   StringGen()[#String#]; name=StringGen()
 // MEMBER2-DAG: Decl[InstanceMethod]/CurrNominal:   StringOpGen()[#String?#]; name=StringOpGen()
@@ -350,14 +350,14 @@ class C4 {
 // MEMBER3-DAG: Decl[InstanceMethod]/CurrNominal:   IntGen()[#Int#]; name=IntGen()
 // MEMBER3-DAG: Decl[InstanceMethod]/CurrNominal:   IntOpGen()[#Int?#]; name=IntOpGen()
 // MEMBER3-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: StringGen()[#String#]; name=StringGen()
-// MEMBER3-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: StringOpGen()[#String?#]; name=StringOpGen()
+// MEMBER3-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: StringOpGen()[#String?#]; name=StringOpGen()
 // MEMBER3-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: IntTaker({#(i1): Int#}, {#i2: Int#})[#Void#]; name=IntTaker(:i2:)
 // MEMBER3-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: StringTaker({#(s1): String#}, {#s2: String#})[#Void#]; name=StringTaker(:s2:)
 
 // MEMBER4: Begin completions
 // MEMBER4-DAG: Decl[InstanceMethod]/CurrNominal:   IntGen()[#Int#]; name=IntGen()
 // MEMBER4-DAG: Decl[InstanceMethod]/CurrNominal:   IntOpGen()[#Int?#]; name=IntOpGen()
-// MEMBER4-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: StringGen()[#String#]; name=StringGen()
+// MEMBER4-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: StringGen()[#String#]; name=StringGen()
 // MEMBER4-DAG: Decl[InstanceMethod]/CurrNominal:   StringOpGen()[#String?#]; name=StringOpGen()
 // MEMBER4-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: IntTaker({#(i1): Int#}, {#i2: Int#})[#Void#]; name=IntTaker(:i2:)
 // MEMBER4-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: StringTaker({#(s1): String#}, {#s2: String#})[#Void#]; name=StringTaker(:s2:)
@@ -370,14 +370,14 @@ class C4 {
 
 // MEMBER8: Begin completions
 // MEMBER8-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: InternalIntGen()[#Int#]; name=InternalIntGen()
-// MEMBER8-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: InternalIntOpGen()[#Int?#]; name=InternalIntOpGen()
+// MEMBER8-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: InternalIntOpGen()[#Int?#]; name=InternalIntOpGen()
 // MEMBER8-DAG: Decl[InstanceMethod]/CurrNominal:   InternalStringGen()[#String#]; name=InternalStringGen()
 // MEMBER8-DAG: Decl[InstanceMethod]/CurrNominal:   InternalStringOpGen()[#String?#]; name=InternalStringOpGen()
 // MEMBER8-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: InternalIntTaker({#(i1): Int#}, {#i2: Int#})[#Void#]; name=InternalIntTaker(:i2:)
 // MEMBER8-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: InternalStringTaker({#(s1): String#}, {#s2: String#})[#Void#]; name=InternalStringTaker(:s2:)
 
 // FARG6: Begin completions
-// FARG6-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: InternalIntGen()[#Int#]
+// FARG6-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: InternalIntGen()[#Int#]
 // FARG6-DAG: Decl[InstanceMethod]/CurrNominal:   InternalIntOpGen()[#Int?#]
 // FARG6-DAG: Decl[InstanceMethod]/CurrNominal:   InternalStringGen()[#String#]
 // FARG6-DAG: Decl[InstanceMethod]/CurrNominal:   InternalStringOpGen()[#String?#]
@@ -438,8 +438,8 @@ struct EmptyOverload {
 }
 _ = EmptyOverload(foo: #^EMPTY_OVERLOAD_2?check=EMPTY_OVERLOAD^#)
 // EMPTY_OVERLOAD: Begin completions
-// EMPTY_OVERLOAD-DAG: Decl[GlobalVar]/Local/TypeRelation[Identical]: i2[#Int#];
-// EMPTY_OVERLOAD-DAG: Decl[GlobalVar]/Local/TypeRelation[Identical]: i1[#Int#];
+// EMPTY_OVERLOAD-DAG: Decl[GlobalVar]/Local/TypeRelation[Convertible]: i2[#Int#];
+// EMPTY_OVERLOAD-DAG: Decl[GlobalVar]/Local/TypeRelation[Convertible]: i1[#Int#];
 // EMPTY_OVERLOAD: End completions
 
 public func fopen() -> TestBoundGeneric1! { fatalError() }
@@ -489,17 +489,17 @@ func testTupleShuffle() {
   let _ = shuffled(z: .#^SHUFFLE_3^#)
 }
 // SHUFFLE_1: Begin completions
-// SHUFFLE_1-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Identical]: i1[#Int#]; name=i1
-// SHUFFLE_1-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Identical]: i2[#Int#]; name=i2
+// SHUFFLE_1-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Convertible]: i1[#Int#]; name=i1
+// SHUFFLE_1-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Convertible]: i2[#Int#]; name=i2
 
 // SHUFFLE_2: Begin completions
-// SHUFFLE_2-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Identical]: s1[#String#]; name=s1
-// SHUFFLE_2-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Identical]: s2[#String#]; name=s2
+// SHUFFLE_2-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Convertible]: s1[#String#]; name=s1
+// SHUFFLE_2-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Convertible]: s2[#String#]; name=s2
 
 // SHUFFLE_3: Begin completions, 4 items
-// SHUFFLE_3-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     foo[#SimpleEnum#]; name=foo
-// SHUFFLE_3-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     bar[#SimpleEnum#]; name=bar
-// SHUFFLE_3-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     baz[#SimpleEnum#]; name=baz
+// SHUFFLE_3-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]:     foo[#SimpleEnum#]; name=foo
+// SHUFFLE_3-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]:     bar[#SimpleEnum#]; name=bar
+// SHUFFLE_3-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]:     baz[#SimpleEnum#]; name=baz
 // SHUFFLE_3-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]:     hash({#(self): SimpleEnum#})[#(into: inout Hasher) -> Void#]; name=hash(:)
 
 
@@ -510,8 +510,8 @@ class HasSubscript {
 func testSubscript(obj: HasSubscript, intValue: Int, strValue: String) {
   let _ = obj[#^SUBSCRIPT_1^#
 // SUBSCRIPT_1: Begin completions
-// SUBSCRIPT_1-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Identical]: i1[#Int#]; name=i1
-// SUBSCRIPT_1-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Identical]: i2[#Int#]; name=i2
+// SUBSCRIPT_1-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Convertible]: i1[#Int#]; name=i1
+// SUBSCRIPT_1-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Convertible]: i2[#Int#]; name=i2
 // SUBSCRIPT_1-DAG: Decl[GlobalVar]/CurrModule: s1[#String#]; name=s1
 // SUBSCRIPT_1-DAG: Decl[GlobalVar]/CurrModule: s2[#String#]; name=s2
 // SUBSCRIPT_1-DAG: Keyword[try]/None: try; name=try
@@ -524,8 +524,8 @@ func testSubscript(obj: HasSubscript, intValue: Int, strValue: String) {
 // SUBSCRIPT_1_DOT: Begin completions
 // SUBSCRIPT_1_DOT-NOT: i1
 // SUBSCRIPT_1_DOT-NOT: s1
-// SUBSCRIPT_1_DOT-DAG: Decl[StaticVar]/Super/Flair[ExprSpecific]/IsSystem/TypeRelation[Identical]: max[#Int#]; name=max
-// SUBSCRIPT_1_DOT-DAG: Decl[StaticVar]/Super/Flair[ExprSpecific]/IsSystem/TypeRelation[Identical]: min[#Int#]; name=min
+// SUBSCRIPT_1_DOT-DAG: Decl[StaticVar]/Super/Flair[ExprSpecific]/IsSystem/TypeRelation[Convertible]: max[#Int#]; name=max
+// SUBSCRIPT_1_DOT-DAG: Decl[StaticVar]/Super/Flair[ExprSpecific]/IsSystem/TypeRelation[Convertible]: min[#Int#]; name=min
 
   let _ = obj[42, #^SUBSCRIPT_2^#
 // SUBSCRIPT_2: Begin completions, 1 items
@@ -534,15 +534,15 @@ func testSubscript(obj: HasSubscript, intValue: Int, strValue: String) {
   let _ = obj[42, .#^SUBSCRIPT_2_DOT^#
 // Note: we still provide completions despite the missing label - there's a fixit to add it in later.
 // SUBSCRIPT_2_DOT: Begin completions
-// SUBSCRIPT_2_DOT: Decl[Constructor]/CurrNominal/IsSystem/TypeRelation[Identical]: init()[#String#]; name=init()
-// SUBSCRIPT_2_DOT: Decl[Constructor]/CurrNominal/IsSystem/TypeRelation[Identical]: init({#(c): Character#})[#String#]; name=init(:)
+// SUBSCRIPT_2_DOT: Decl[Constructor]/CurrNominal/IsSystem/TypeRelation[Convertible]: init()[#String#]; name=init()
+// SUBSCRIPT_2_DOT: Decl[Constructor]/CurrNominal/IsSystem/TypeRelation[Convertible]: init({#(c): Character#})[#String#]; name=init(:)
 
   let _ = obj[42, default: #^SUBSCRIPT_3^#
 // SUBSCRIPT_3: Begin completions
 // SUBSCRIPT_3-DAG: Decl[GlobalVar]/CurrModule: i1[#Int#]; name=i1
 // SUBSCRIPT_3-DAG: Decl[GlobalVar]/CurrModule: i2[#Int#]; name=i2
-// SUBSCRIPT_3-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Identical]: s1[#String#]; name=s1
-// SUBSCRIPT_3-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Identical]: s2[#String#]; name=s2
+// SUBSCRIPT_3-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Convertible]: s1[#String#]; name=s1
+// SUBSCRIPT_3-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Convertible]: s2[#String#]; name=s2
 // SUBSCRIPT_3-DAG: Keyword[try]/None: try; name=try
 // SUBSCRIPT_3-DAG: Keyword[try]/None: try!; name=try!
 // SUBSCRIPT_3-DAG: Keyword[try]/None: try?; name=try?
@@ -553,8 +553,8 @@ func testSubscript(obj: HasSubscript, intValue: Int, strValue: String) {
 // SUBSCRIPT_3_DOT: Begin completions
 // SUBSCRIPT_3_DOT-NOT: i1
 // SUBSCRIPT_3_DOT-NOT: s1
-// SUBSCRIPT_3_DOT-DAG: Decl[Constructor]/CurrNominal/IsSystem/TypeRelation[Identical]: init()[#String#]; name=init()
-// SUBSCRIPT_3_DOT-DAG: Decl[Constructor]/CurrNominal/IsSystem/TypeRelation[Identical]: init({#(c): Character#})[#String#]; name=init(:)
+// SUBSCRIPT_3_DOT-DAG: Decl[Constructor]/CurrNominal/IsSystem/TypeRelation[Convertible]: init()[#String#]; name=init()
+// SUBSCRIPT_3_DOT-DAG: Decl[Constructor]/CurrNominal/IsSystem/TypeRelation[Convertible]: init({#(c): Character#})[#String#]; name=init(:)
 
 }
 
@@ -566,7 +566,7 @@ func testNestedContext() {
 // ERRORCONTEXT_NESTED_1: Begin completions
 // ERRORCONTEXT_NESTED_1-DAG: Decl[GlobalVar]/CurrModule: i1[#Int#]; name=i1
 // ERRORCONTEXT_NESTED_1-DAG: Decl[GlobalVar]/CurrModule: i2[#Int#]; name=i2
-// ERRORCONTEXT_NESTED_1-NOT: TypeRelation[Identical]
+// ERRORCONTEXT_NESTED_1-NOT: TypeRelation[Convertible]
 
   for _ in [bar(#^ERRORCONTEXT_NESTED_2?check=ERRORCONTEXT_NESTED_1^#)] {}
 // Same as ERRORCONTEXT_NESTED_1.
@@ -608,10 +608,10 @@ func testStaticMemberCall() {
 
   let _ = TestStaticMemberCall.create2(#^STATIC_METHOD_AFTERPAREN_2^#)
 // STATIC_METHOD_AFTERPAREN_2: Begin completions
-// STATIC_METHOD_AFTERPAREN_2-DAG: Decl[StaticMethod]/CurrNominal/Flair[ArgLabels]/TypeRelation[Identical]: ['(']{#(arg1): Int#}[')'][#TestStaticMemberCall#];
-// STATIC_METHOD_AFTERPAREN_2-DAG: Decl[StaticMethod]/CurrNominal/Flair[ArgLabels]/TypeRelation[Identical]: ['(']{#(arg1): Int#}, {#arg2: Int#}, {#arg3: Int#}, {#arg4: Int#}[')'][#TestStaticMemberCall#];
-// STATIC_METHOD_AFTERPAREN_2-DAG: Decl[Struct]/OtherModule[Swift]/IsSystem/TypeRelation[Identical]: Int[#Int#];
-// STATIC_METHOD_AFTERPAREN_2-DAG: Literal[Integer]/None/TypeRelation[Identical]: 0[#Int#];
+// STATIC_METHOD_AFTERPAREN_2-DAG: Decl[StaticMethod]/CurrNominal/Flair[ArgLabels]/TypeRelation[Convertible]: ['(']{#(arg1): Int#}[')'][#TestStaticMemberCall#];
+// STATIC_METHOD_AFTERPAREN_2-DAG: Decl[StaticMethod]/CurrNominal/Flair[ArgLabels]/TypeRelation[Convertible]: ['(']{#(arg1): Int#}, {#arg2: Int#}, {#arg3: Int#}, {#arg4: Int#}[')'][#TestStaticMemberCall#];
+// STATIC_METHOD_AFTERPAREN_2-DAG: Decl[Struct]/OtherModule[Swift]/IsSystem/TypeRelation[Convertible]: Int[#Int#];
+// STATIC_METHOD_AFTERPAREN_2-DAG: Literal[Integer]/None/TypeRelation[Convertible]: 0[#Int#];
 // STATIC_METHOD_AFTERPAREN_2: End completions
 
   let _ = TestStaticMemberCall.create2(1, #^STATIC_METHOD_SECOND^#)
@@ -635,15 +635,15 @@ func testStaticMemberCall() {
 func testImplicitMember() {
   let _: TestStaticMemberCall = .create1(#^IMPLICIT_MEMBER_AFTERPAREN_1^#)
 // IMPLICIT_MEMBER_AFTERPAREN_1: Begin completions, 1 items
-// IMPLICIT_MEMBER_AFTERPAREN_1: Decl[StaticMethod]/CurrNominal/Flair[ArgLabels]/TypeRelation[Identical]: ['(']{#arg1: Int#}[')'][#TestStaticMemberCall#]; name=arg1:
+// IMPLICIT_MEMBER_AFTERPAREN_1: Decl[StaticMethod]/CurrNominal/Flair[ArgLabels]/TypeRelation[Convertible]: ['(']{#arg1: Int#}[')'][#TestStaticMemberCall#]; name=arg1:
 // IMPLICIT_MEMBER_AFTERPAREN_1: End completions
 
   let _: TestStaticMemberCall = .create2(#^IMPLICIT_MEMBER_AFTERPAREN_2^#)
 // IMPLICIT_MEMBER_AFTERPAREN_2: Begin completions
-// IMPLICIT_MEMBER_AFTERPAREN_2-DAG: Decl[StaticMethod]/CurrNominal/Flair[ArgLabels]/TypeRelation[Identical]: ['(']{#(arg1): Int#}[')'][#TestStaticMemberCall#];
-// IMPLICIT_MEMBER_AFTERPAREN_2-DAG: Decl[StaticMethod]/CurrNominal/Flair[ArgLabels]/TypeRelation[Identical]: ['(']{#(arg1): Int#}, {#arg2: Int#}, {#arg3: Int#}, {#arg4: Int#}[')'][#TestStaticMemberCall#];
-// IMPLICIT_MEMBER_AFTERPAREN_2-DAG: Decl[Struct]/OtherModule[Swift]/IsSystem/TypeRelation[Identical]: Int[#Int#];
-// IMPLICIT_MEMBER_AFTERPAREN_2-DAG: Literal[Integer]/None/TypeRelation[Identical]: 0[#Int#];
+// IMPLICIT_MEMBER_AFTERPAREN_2-DAG: Decl[StaticMethod]/CurrNominal/Flair[ArgLabels]/TypeRelation[Convertible]: ['(']{#(arg1): Int#}[')'][#TestStaticMemberCall#];
+// IMPLICIT_MEMBER_AFTERPAREN_2-DAG: Decl[StaticMethod]/CurrNominal/Flair[ArgLabels]/TypeRelation[Convertible]: ['(']{#(arg1): Int#}, {#arg2: Int#}, {#arg3: Int#}, {#arg4: Int#}[')'][#TestStaticMemberCall#];
+// IMPLICIT_MEMBER_AFTERPAREN_2-DAG: Decl[Struct]/OtherModule[Swift]/IsSystem/TypeRelation[Convertible]: Int[#Int#];
+// IMPLICIT_MEMBER_AFTERPAREN_2-DAG: Literal[Integer]/None/TypeRelation[Convertible]: 0[#Int#];
 // IMPLICIT_MEMBER_AFTERPAREN_2: End completions
 
   let _: TestStaticMemberCall? = .create1(#^IMPLICIT_MEMBER_AFTERPAREN_3^#)
@@ -665,7 +665,7 @@ func testImplicitMember() {
 
   let _: TestStaticMemberCall = .createOverloaded(#^IMPLICIT_MEMBER_OVERLOADED^#)
 // IMPLICIT_MEMBER_OVERLOADED: Begin completions, 2 items
-// IMPLICIT_MEMBER_OVERLOADED: Decl[StaticMethod]/CurrNominal/Flair[ArgLabels]/TypeRelation[Identical]: ['(']{#arg1: Int#}[')'][#TestStaticMemberCall#]; name=arg1:
+// IMPLICIT_MEMBER_OVERLOADED: Decl[StaticMethod]/CurrNominal/Flair[ArgLabels]/TypeRelation[Convertible]: ['(']{#arg1: Int#}[')'][#TestStaticMemberCall#]; name=arg1:
 // IMPLICIT_MEMBER_OVERLOADED: Decl[StaticMethod]/CurrNominal/Flair[ArgLabels]:     ['(']{#arg1: String#}[')'][#String#]; name=arg1:
 // IMPLICIT_MEMBER_OVERLOADED: End completions
 }
@@ -787,9 +787,9 @@ func testPamrameterFlags(_: Int, inoutArg: inout Int, autoclosureArg: @autoclosu
 func testTupleElement(arg: (SimpleEnum, SimpleEnum)) {
   testTupleElement(arg: (.foo, .#^TUPLEELEM_1^#))
 // TUPLEELEM_1: Begin completions, 4 items
-// TUPLEELEM_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     foo[#SimpleEnum#]; name=foo
-// TUPLEELEM_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     bar[#SimpleEnum#]; name=bar
-// TUPLEELEM_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     baz[#SimpleEnum#]; name=baz
+// TUPLEELEM_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]:     foo[#SimpleEnum#]; name=foo
+// TUPLEELEM_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]:     bar[#SimpleEnum#]; name=bar
+// TUPLEELEM_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]:     baz[#SimpleEnum#]; name=baz
 // TUPLEELEM_1-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]:     hash({#(self): SimpleEnum#})[#(into: inout Hasher) -> Void#]; name=hash(:)
 // TUPLEELEM_1: End completions
   testTupleElement(arg: (.foo, .bar, .#^TUPLEELEM_2^#))
@@ -807,9 +807,9 @@ func testKeyPathThunkInBase() {
 
     foo(\.value).testFunc(.#^KEYPATH_THUNK_BASE^#)
 // KEYPATH_THUNK_BASE: Begin completions, 4 items
-// KEYPATH_THUNK_BASE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     foo[#SimpleEnum#]; name=foo
-// KEYPATH_THUNK_BASE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     bar[#SimpleEnum#]; name=bar
-// KEYPATH_THUNK_BASE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     baz[#SimpleEnum#]; name=baz
+// KEYPATH_THUNK_BASE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]:     foo[#SimpleEnum#]; name=foo
+// KEYPATH_THUNK_BASE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]:     bar[#SimpleEnum#]; name=bar
+// KEYPATH_THUNK_BASE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]:     baz[#SimpleEnum#]; name=baz
 // KEYPATH_THUNK_BASE-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]:     hash({#(self): SimpleEnum#})[#(into: inout Hasher) -> Void#]; name=hash(:)
 // KEYPATH_THUNK_BASE: End completions
 }
@@ -925,7 +925,7 @@ func testCompleteLabelAfterVararg() {
     // COMPLETE_AFTER_VARARG_WITH_PREV_PARAM: End completions
     value.test("test", xArg: .bar, .#^COMPLETE_MEMBER_IN_VARARG^#)
     // COMPLETE_MEMBER_IN_VARARG: Begin completions, 2 items
-    // COMPLETE_MEMBER_IN_VARARG-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: bar[#Foo#];
+    // COMPLETE_MEMBER_IN_VARARG-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: bar[#Foo#];
     // COMPLETE_MEMBER_IN_VARARG-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): Foo#})[#(into: inout Hasher) -> Void#];
     // COMPLETE_MEMBER_IN_VARARG: End completions
   }
@@ -937,26 +937,26 @@ func testCompleteLabelAfterVararg() {
   private func testSr14515(value: Sr14515, foo: Foo, baz: Baz) {
     value.test(foo, #^COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG^#)
     // COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG: Begin completions
-    // COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]: foo[#Foo#];
+    // COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG-DAG: Decl[LocalVar]/Local/TypeRelation[Convertible]: foo[#Foo#];
     // COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG-DAG: Pattern/Local/Flair[ArgLabels]:               {#yArg: Baz#}[#Baz#];
     // COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG: End completions
 
     // The leading dot completion tests that have picked the right type for the argument
     value.test(foo, .#^COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG_DOT^#)
     // COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG_DOT: Begin completions, 2 items
-    // COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG_DOT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: bar[#Foo#];
+    // COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG_DOT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: bar[#Foo#];
     // COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG_DOT-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): Foo#})[#(into: inout Hasher) -> Void#];
     // COMPLETE_VARARG_FOLLOWED_BY_NORMAL_ARG_DOT: End completions
 
     value.test(foo, yArg: #^COMPLETE_ARG_AFTER_VARARG^#)
     // COMPLETE_ARG_AFTER_VARARG: Begin completions
-    // COMPLETE_ARG_AFTER_VARARG-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]: baz[#Baz#];
+    // COMPLETE_ARG_AFTER_VARARG-DAG: Decl[LocalVar]/Local/TypeRelation[Convertible]: baz[#Baz#];
     // COMPLETE_ARG_AFTER_VARARG-NOT: Pattern/Local/Flair[ArgLabels]:               {#yArg: Baz#}[#Baz#];
     // COMPLETE_ARG_AFTER_VARARG: End completions
 
     value.test(foo, yArg: .#^COMPLETE_ARG_AFTER_VARARG_DOT^#)
     // COMPLETE_ARG_AFTER_VARARG_DOT: Begin completions, 2 items
-    // COMPLETE_ARG_AFTER_VARARG_DOT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: bazCase[#Baz#];
+    // COMPLETE_ARG_AFTER_VARARG_DOT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: bazCase[#Baz#];
     // COMPLETE_ARG_AFTER_VARARG_DOT-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): Baz#})[#(into: inout Hasher) -> Void#];
     // COMPLETE_ARG_AFTER_VARARG_DOT: End completions
   }
@@ -1033,7 +1033,7 @@ func testArgsAfterCompletion() {
   SubOverloaded()[x: 1, .#^VALID_UNRESOLVED_SUB?check=VALID_UNRESOLVED_NOCOMMA^#, localB]
 
   // VALID_UNRESOLVED: Begin completions, 2 items
-  // VALID_UNRESOLVED-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: a[#A#]; name=a
+  // VALID_UNRESOLVED-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: a[#A#]; name=a
   // VALID_UNRESOLVED-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): A#})[#(into: inout Hasher) -> Void#]; name=hash(:)
   // VALID_UNRESOLVED: End completions
 
@@ -1041,8 +1041,8 @@ func testArgsAfterCompletion() {
   SubOverloaded()[x: 1, .#^VALID_UNRESOLVED_NOCOMA_SUB?check=VALID_UNRESOLVED_NOCOMMA^# localB]
 
   // VALID_UNRESOLVED_NOCOMMA: Begin completions, 4 items
-  // VALID_UNRESOLVED_NOCOMMA-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: a[#A#]; name=a
-  // VALID_UNRESOLVED_NOCOMMA-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: b[#B#]; name=b
+  // VALID_UNRESOLVED_NOCOMMA-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: a[#A#]; name=a
+  // VALID_UNRESOLVED_NOCOMMA-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: b[#B#]; name=b
   // VALID_UNRESOLVED_NOCOMMA-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): A#})[#(into: inout Hasher) -> Void#]; name=hash(:)
   // VALID_UNRESOLVED_NOCOMMA-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): B#})[#(into: inout Hasher) -> Void#]; name=hash(:)
   // VALID_UNRESOLVED_NOCOMMA: End completions
@@ -1053,8 +1053,8 @@ func testArgsAfterCompletion() {
   overloaded(x: 1, #^VALID_GLOBAL^#, localB)
   SubOverloaded()[x: 1, #^VALID_GLOBAL_SUB?check=VALID_GLOBAL^#, localB]
   // VALID_GLOBAL: Begin completions
-  // VALID_GLOBAL-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]: localA[#A#]; name=localA
-  // VALID_GLOBAL-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]: localB[#B#]; name=localB
+  // VALID_GLOBAL-DAG: Decl[LocalVar]/Local/TypeRelation[Convertible]: localA[#A#]; name=localA
+  // VALID_GLOBAL-DAG: Decl[LocalVar]/Local/TypeRelation[Convertible]: localB[#B#]; name=localB
   // VALID_GLOBAL: End completions
 
   func takesIntGivesB(_ x: Int) -> B { return B.b }
@@ -1210,13 +1210,13 @@ func testFuncTyVars(param: (Int, String, Double) -> ()) {
   local(2, "hello", #^LOCAL_ARG3?check=FUNCTY_DOUBLE^#)
 
   // FUNCTY_STRING: Begin completions
-  // FUNCTY_STRING-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]: someString[#String#];
+  // FUNCTY_STRING-DAG: Decl[LocalVar]/Local/TypeRelation[Convertible]: someString[#String#];
   // FUNCTY_STRING-DAG: Decl[LocalVar]/Local: someDouble[#Double#];
   // FUNCTY_STRING-DAG: Decl[LocalVar]/Local: someInt[#Int#];
   // FUNCTY_STRING: End completions
 
   // FUNCTY_DOUBLE: Begin completions
-  // FUNCTY_DOUBLE-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]: someDouble[#Double#];
+  // FUNCTY_DOUBLE-DAG: Decl[LocalVar]/Local/TypeRelation[Convertible]: someDouble[#Double#];
   // FUNCTY_DOUBLE-DAG: Decl[LocalVar]/Local: someString[#String#];
   // FUNCTY_DOUBLE-DAG: Decl[LocalVar]/Local: someInt[#Int#];
   // FUNCTY_DOUBLE: End completions
@@ -1340,9 +1340,9 @@ func testConversionBetterThanIgnoreArgs() {
 }
 
 // CONVERSION_NO_BETTER_THAN_IGNORE_ARGS: Begin completions
-// CONVERSION_NO_BETTER_THAN_IGNORE_ARGS-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: one[#Numbers#];
-// CONVERSION_NO_BETTER_THAN_IGNORE_ARGS-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: two[#Numbers#];
-// CONVERSION_NO_BETTER_THAN_IGNORE_ARGS-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: three[#Numbers#];
+// CONVERSION_NO_BETTER_THAN_IGNORE_ARGS-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: one[#Numbers#];
+// CONVERSION_NO_BETTER_THAN_IGNORE_ARGS-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: two[#Numbers#];
+// CONVERSION_NO_BETTER_THAN_IGNORE_ARGS-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: three[#Numbers#];
 // CONVERSION_NO_BETTER_THAN_IGNORE_ARGS: End completions
 
 func testDynamicMemberSubscriptLookup() {
@@ -1368,7 +1368,7 @@ func testDynamicMemberSubscriptLookup() {
 }
 
 // DYNAMIC_MEMBER_SUBSCRIPT_LOOKUP: Begin completions
-// DYNAMIC_MEMBER_SUBSCRIPT_LOOKUP-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]: index[#Int#]; name=index
+// DYNAMIC_MEMBER_SUBSCRIPT_LOOKUP-DAG: Decl[LocalVar]/Local/TypeRelation[Convertible]: index[#Int#]; name=index
 // DYNAMIC_MEMBER_SUBSCRIPT_LOOKUP-DAG: Pattern/CurrNominal/Flair[ArgLabels]: ['[']{#keyPath: KeyPath<Binding<MyStruct>, Value>#}[']'][#Value#]; name=keyPath:
 // DYNAMIC_MEMBER_SUBSCRIPT_LOOKUP: End completions
 
@@ -1395,7 +1395,7 @@ func testTopLevelFuncWithErrorParam() {
 
   foo(x: .#^TOP_LEVEL_FUNC_WITH_ERROR_PARAM^#)
 // TOP_LEVEL_FUNC_WITH_ERROR_PARAM: Begin completions, 2 items
-// TOP_LEVEL_FUNC_WITH_ERROR_PARAM-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: a[#A#]; name=a
+// TOP_LEVEL_FUNC_WITH_ERROR_PARAM-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: a[#A#]; name=a
 // TOP_LEVEL_FUNC_WITH_ERROR_PARAM-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): A#})[#(into: inout Hasher) -> Void#]; name=hash(:)
 // TOP_LEVEL_FUNC_WITH_ERROR_PARAM: End completions
 }

--- a/test/IDE/complete_call_as_function.swift
+++ b/test/IDE/complete_call_as_function.swift
@@ -109,8 +109,8 @@ func testCallAsFunctionOverloaded(fn: Functor) {
 
   fn(h: .left, v: .#^OVERLOADED_ARG2_VALUE^#)
 //OVERLOADED_ARG2_VALUE: Begin completions, 3 items
-//OVERLOADED_ARG2_VALUE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: up[#Functor.Vertical#];
-//OVERLOADED_ARG2_VALUE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: down[#Functor.Vertical#];
+//OVERLOADED_ARG2_VALUE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: up[#Functor.Vertical#];
+//OVERLOADED_ARG2_VALUE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: down[#Functor.Vertical#];
 //OVERLOADED_ARG2_VALUE-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): Functor.Vertical#})[#(into: inout Hasher) -> Void#];
 //OVERLOADED_ARG2_VALUE: End completions
 }

--- a/test/IDE/complete_constrained.swift
+++ b/test/IDE/complete_constrained.swift
@@ -118,9 +118,9 @@ struct Vegetarian: EatsFruit, EatsVegetables { }
 func testVegetarian(chef: Chef<Vegetarian>) {
   chef.cook(.#^CONDITIONAL_OVERLOAD_ARG^#)
 // CONDITIONAL_OVERLOAD_ARG: Begin completions, 4 items
-// CONDITIONAL_OVERLOAD_ARG-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:    apple[#Fruit#]; name=apple
+// CONDITIONAL_OVERLOAD_ARG-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]:    apple[#Fruit#]; name=apple
 // CONDITIONAL_OVERLOAD_ARG-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]:    hash({#(self): Fruit#})[#(into: inout Hasher) -> Void#]; name=hash(:)
-// CONDITIONAL_OVERLOAD_ARG-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:    broccoli[#Vegetable#]; name=broccoli
+// CONDITIONAL_OVERLOAD_ARG-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]:    broccoli[#Vegetable#]; name=broccoli
 // CONDITIONAL_OVERLOAD_ARG-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]:    hash({#(self): Vegetable#})[#(into: inout Hasher) -> Void#]; name=hash(:)
 // CONDITIONAL_OVERLOAD_ARG: End completions
 
@@ -131,7 +131,7 @@ func testVegetarian(chef: Chef<Vegetarian>) {
 // Note: 'eat' is from an inapplicable constrained extension. We complete as if the user intends to addess that later
 //       (e.g. by adding the missing 'Meat' conformance to 'Vegetarian' - clearly not the intention here - but replace 'Meat' with 'Equatable').
 // CONDITIONAL_INAPPLICABLE_ARG: Begin completions, 2 items
-// CONDITIONAL_INAPPLICABLE_ARG-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: chicken[#Meat#]; name=chicken
+// CONDITIONAL_INAPPLICABLE_ARG-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: chicken[#Meat#]; name=chicken
 // CONDITIONAL_INAPPLICABLE_ARG-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): Meat#})[#(into: inout Hasher) -> Void#]; name=hash(:)
 // CONDITIONAL_INAPPLICABLE_ARG: End completions
 }

--- a/test/IDE/complete_constructor.swift
+++ b/test/IDE/complete_constructor.swift
@@ -284,7 +284,7 @@ struct ClosureInInit1 {
   var prop1: S = {
     return S(#^CLOSURE_IN_INIT_1^#
   }
-// CLOSURE_IN_INIT_1: Decl[Constructor]/CurrNominal/Flair[ArgLabels]{{(/TypeRelation\[Identical\])?}}:      ['(']{#Int#}[')'][#S#];
+// CLOSURE_IN_INIT_1: Decl[Constructor]/CurrNominal/Flair[ArgLabels]{{(/TypeRelation\[Convertible\])?}}:      ['(']{#Int#}[')'][#S#];
   var prop2: S = {
     return S(#^CLOSURE_IN_INIT_2?check=CLOSURE_IN_INIT_1^#
   }()
@@ -330,8 +330,8 @@ class DependentTypeInClosure<Data: DataType> {
 func testDependentTypeInClosure() {
   let _: DependentTypeInClosure = .#^DEPENDENT_IN_CLOSURE_3^#
 // DEPENDENT_IN_CLOSURE_3: Begin completions, 2 items
-// DEPENDENT_IN_CLOSURE_3-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Identical]: init({#(arg): DataType#}, {#fn: (Data.Content) -> Void##(Data.Content) -> Void#})[#DependentTypeInClosure<DataType>#];
-// DEPENDENT_IN_CLOSURE_3-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Identical]: init({#arg: DataType#}, {#fn: () -> Data.Content##() -> Data.Content#})[#DependentTypeInClosure<DataType>#];
+// DEPENDENT_IN_CLOSURE_3-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: init({#(arg): DataType#}, {#fn: (Data.Content) -> Void##(Data.Content) -> Void#})[#DependentTypeInClosure<DataType>#];
+// DEPENDENT_IN_CLOSURE_3-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: init({#arg: DataType#}, {#fn: () -> Data.Content##() -> Data.Content#})[#DependentTypeInClosure<DataType>#];
 // DEPENDENT_IN_CLOSURE_3: End completions
 
   let _ = DependentTypeInClosure(#^DEPENDENT_IN_CLOSURE_1^#)

--- a/test/IDE/complete_crashes.swift
+++ b/test/IDE/complete_crashes.swift
@@ -52,7 +52,7 @@ class C {
 ({ x in 2+x })(#^CLOSURE_CALLED_IN_PLACE_1^#
 
 // WITH_GLOBAL_INT: Begin completions
-// WITH_GLOBAL_INT-DAG: Decl[FreeFunction]/CurrModule/TypeRelation[Identical]: globalFuncInt()[#Int#]; name=globalFuncInt()
+// WITH_GLOBAL_INT-DAG: Decl[FreeFunction]/CurrModule/TypeRelation[Convertible]: globalFuncInt()[#Int#]; name=globalFuncInt()
 // WITH_GLOBAL_INT: End completions
 
 // rdar://19634354
@@ -67,7 +67,7 @@ while true {
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_PARAM_AND_ASSOC_TYPE | %FileCheck %s -check-prefix=GENERIC_PARAM_AND_ASSOC_TYPE
 struct CustomGenericCollection<Key> : ExpressibleByDictionaryLiteral {
   // GENERIC_PARAM_AND_ASSOC_TYPE: Begin completions
-  // GENERIC_PARAM_AND_ASSOC_TYPE-DAG: Decl[InstanceVar]/CurrNominal/NotRecommended/TypeRelation[Identical]:      count[#Int#]; name=count
+  // GENERIC_PARAM_AND_ASSOC_TYPE-DAG: Decl[InstanceVar]/CurrNominal/NotRecommended/TypeRelation[Convertible]:      count[#Int#]; name=count
   // GENERIC_PARAM_AND_ASSOC_TYPE-DAG: Decl[GenericTypeParam]/Local:       Key[#Key#]; name=Key
   // GENERIC_PARAM_AND_ASSOC_TYPE-DAG: Decl[TypeAlias]/CurrNominal:        Value[#Value#]; name=Value
   // GENERIC_PARAM_AND_ASSOC_TYPE: End completions

--- a/test/IDE/complete_default_arguments.swift
+++ b/test/IDE/complete_default_arguments.swift
@@ -165,5 +165,5 @@ func testDefaultArgInit3(_ x: Int = #^DEFAULT_ARG_INIT_3^#) { }
 // DEFAULT_ARG_INIT: End completions
 
 // DEFAULT_ARG_INIT_INTCONTEXT: Begin completions
-// DEFAULT_ARG_INIT_INTCONTEXT: Decl[GlobalVar]/CurrModule/TypeRelation[Identical]: globalVar[#Int#]{{; name=.+$}}
+// DEFAULT_ARG_INIT_INTCONTEXT: Decl[GlobalVar]/CurrModule/TypeRelation[Convertible]: globalVar[#Int#]{{; name=.+$}}
 // DEFAULT_ARG_INIT_INTCONTEXT: End completions

--- a/test/IDE/complete_diagnostics.swift
+++ b/test/IDE/complete_diagnostics.swift
@@ -107,6 +107,6 @@ func testOwnGetter() {
       #^GETTER^#
     }
 // GETTER: Begin completions 
-// GETTER-DAG: Decl[LocalVar]/Local/NotRecommended/TypeRelation[Identical]: valueInOwnGetter[#Int#]; name=valueInOwnGetter; diagnostics=warning:attempting to access 'valueInOwnGetter' within its own getter{{$}}
+// GETTER-DAG: Decl[LocalVar]/Local/NotRecommended/TypeRelation[Convertible]: valueInOwnGetter[#Int#]; name=valueInOwnGetter; diagnostics=warning:attempting to access 'valueInOwnGetter' within its own getter{{$}}
 // GETTER: End completions
 }

--- a/test/IDE/complete_enum_elements.swift
+++ b/test/IDE/complete_enum_elements.swift
@@ -14,9 +14,9 @@ enum FooEnum: CaseIterable {
 }
 
 // FOO_ENUM_TYPE_CONTEXT: Begin completions
-// FOO_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: .Foo1[#FooEnum#]{{; name=.+$}}
-// FOO_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: .Foo2[#FooEnum#]{{; name=.+$}}
-// FOO_ENUM_TYPE_CONTEXT-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Identical]: .alias1[#FooEnum#]; name=alias1
+// FOO_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Convertible]: .Foo1[#FooEnum#]{{; name=.+$}}
+// FOO_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Convertible]: .Foo2[#FooEnum#]{{; name=.+$}}
+// FOO_ENUM_TYPE_CONTEXT-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Convertible]: .alias1[#FooEnum#]; name=alias1
 // FOO_ENUM_TYPE_CONTEXT: End completions
 
 // FOO_ENUM_NO_DOT: Begin completions
@@ -44,18 +44,18 @@ enum FooEnum: CaseIterable {
 // FOO_ENUM_DOT_CONTEXT: Begin completions
 // FOO_ENUM_DOT_CONTEXT-NEXT: Keyword[self]/CurrNominal: self[#FooEnum.Type#]; name=self
 // FOO_ENUM_DOT_CONTEXT-NEXT: Keyword/CurrNominal: Type[#FooEnum.Type#]; name=Type
-// FOO_ENUM_DOT_CONTEXT-NEXT: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: Foo1[#FooEnum#]{{; name=.+$}}
-// FOO_ENUM_DOT_CONTEXT-NEXT: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: Foo2[#FooEnum#]{{; name=.+$}}
-// FOO_ENUM_DOT_CONTEXT-NEXT: Decl[StaticVar]/CurrNominal/TypeRelation[Identical]: alias1[#FooEnum#]{{; name=.+$}}
+// FOO_ENUM_DOT_CONTEXT-NEXT: Decl[EnumElement]/CurrNominal/TypeRelation[Convertible]: Foo1[#FooEnum#]{{; name=.+$}}
+// FOO_ENUM_DOT_CONTEXT-NEXT: Decl[EnumElement]/CurrNominal/TypeRelation[Convertible]: Foo2[#FooEnum#]{{; name=.+$}}
+// FOO_ENUM_DOT_CONTEXT-NEXT: Decl[StaticVar]/CurrNominal/TypeRelation[Convertible]: alias1[#FooEnum#]{{; name=.+$}}
 // FOO_ENUM_DOT_CONTEXT-NEXT: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): FooEnum#})[#(into: inout Hasher) -> Void#]{{; name=.+$}}
 // FOO_ENUM_DOT_CONTEXT-NEXT: Decl[TypeAlias]/CurrNominal: AllCases[#[FooEnum]#]{{; name=.+$}}
 // FOO_ENUM_DOT_CONTEXT-NEXT: Decl[StaticVar]/CurrNominal: allCases[#[FooEnum]#]{{; name=.+$}}
 // FOO_ENUM_DOT_CONTEXT-NEXT: End completions
 
 // FOO_ENUM_DOT_ELEMENTS: Begin completions, 6 items
-// FOO_ENUM_DOT_ELEMENTS-NEXT: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: Foo1[#FooEnum#]{{; name=.+$}}
-// FOO_ENUM_DOT_ELEMENTS-NEXT: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: Foo2[#FooEnum#]{{; name=.+$}}
-// FOO_ENUM_DOT_ELEMENTS-NEXT: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: alias1[#FooEnum#]; name=alias1
+// FOO_ENUM_DOT_ELEMENTS-NEXT: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: Foo1[#FooEnum#]{{; name=.+$}}
+// FOO_ENUM_DOT_ELEMENTS-NEXT: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: Foo2[#FooEnum#]{{; name=.+$}}
+// FOO_ENUM_DOT_ELEMENTS-NEXT: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: alias1[#FooEnum#]; name=alias1
 // FOO_ENUM_DOT_ELEMENTS-NEXT: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): FooEnum#})[#(into: inout Hasher) -> Void#]; name=hash(:)
 // FOO_ENUM_DOT_ELEMENTS-NEXT: Decl[TypeAlias]/CurrNominal: AllCases[#[FooEnum]#]; name=AllCases
 // FOO_ENUM_DOT_ELEMENTS-NEXT: Decl[StaticVar]/CurrNominal:        allCases[#[FooEnum]#]; name=allCases
@@ -82,18 +82,18 @@ enum BarEnum {
 }
 
 // BAR_ENUM_TYPE_CONTEXT: Begin completions
-// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: .Bar1[#BarEnum#]{{; name=.+$}}
-// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: .Bar2()[#BarEnum#]{{; name=.+$}}
-// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: .Bar3({#Int#})[#BarEnum#]{{; name=.+$}}
-// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: .Bar4({#a: Int#}, {#b: Float#})[#BarEnum#]{{; name=.+$}}
-// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: .Bar5({#a: Int#}, {#(Float)#})[#BarEnum#]{{; name=.+$}}
-// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: .Bar6({#a: Int#}, {#b: (Float)#})[#BarEnum#]{{; name=.+$}}
-// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: .Bar7({#a: Int#}, {#(b: Float, c: Double)#})[#BarEnum#]{{; name=.+$}}
-// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: .Bar8({#a: Int#}, {#b: (c: Float, d: Double)#})[#BarEnum#]{{; name=.+$}}
-// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: .Bar9({#Int#})[#BarEnum#]{{; name=.+$}}
-// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: .Bar10({#Int#}, {#Float#})[#BarEnum#]{{; name=.+$}}
-// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: .Bar11({#Int#}, {#(Float)#})[#BarEnum#]{{; name=.+$}}
-// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: .Bar12({#Int#}, {#(Float, Double)#})[#BarEnum#]{{; name=.+$}}
+// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Convertible]: .Bar1[#BarEnum#]{{; name=.+$}}
+// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Convertible]: .Bar2()[#BarEnum#]{{; name=.+$}}
+// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Convertible]: .Bar3({#Int#})[#BarEnum#]{{; name=.+$}}
+// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Convertible]: .Bar4({#a: Int#}, {#b: Float#})[#BarEnum#]{{; name=.+$}}
+// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Convertible]: .Bar5({#a: Int#}, {#(Float)#})[#BarEnum#]{{; name=.+$}}
+// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Convertible]: .Bar6({#a: Int#}, {#b: (Float)#})[#BarEnum#]{{; name=.+$}}
+// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Convertible]: .Bar7({#a: Int#}, {#(b: Float, c: Double)#})[#BarEnum#]{{; name=.+$}}
+// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Convertible]: .Bar8({#a: Int#}, {#b: (c: Float, d: Double)#})[#BarEnum#]{{; name=.+$}}
+// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Convertible]: .Bar9({#Int#})[#BarEnum#]{{; name=.+$}}
+// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Convertible]: .Bar10({#Int#}, {#Float#})[#BarEnum#]{{; name=.+$}}
+// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Convertible]: .Bar11({#Int#}, {#(Float)#})[#BarEnum#]{{; name=.+$}}
+// BAR_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Convertible]: .Bar12({#Int#}, {#(Float, Double)#})[#BarEnum#]{{; name=.+$}}
 // BAR_ENUM_TYPE_CONTEXT: End completions
 
 // BAR_ENUM_NO_DOT: Begin completions
@@ -148,8 +148,8 @@ enum BazEnum<T> {
 }
 
 // BAZ_ENUM_TYPE_CONTEXT: Begin completions
-// BAZ_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: .Baz1[#BazEnum<Int>#]{{; name=.+$}}
-// BAZ_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: .Baz2({#Int#})[#BazEnum<Int>#]{{; name=.+$}}
+// BAZ_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Convertible]: .Baz1[#BazEnum<Int>#]{{; name=.+$}}
+// BAZ_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Convertible]: .Baz2({#Int#})[#BazEnum<Int>#]{{; name=.+$}}
 // BAZ_ENUM_TYPE_CONTEXT: End completions
 
 // BAZ_INT_ENUM_NO_DOT: Begin completions, 8 items
@@ -202,8 +202,8 @@ enum QuxEnum : Int {
 }
 
 // QUX_ENUM_TYPE_CONTEXT: Begin completions
-// QUX_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: .Qux1[#QuxEnum#]{{; name=.+$}}
-// QUX_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Identical]: .Qux2[#QuxEnum#]{{; name=.+$}}
+// QUX_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Convertible]: .Qux1[#QuxEnum#]{{; name=.+$}}
+// QUX_ENUM_TYPE_CONTEXT-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Convertible]: .Qux2[#QuxEnum#]{{; name=.+$}}
 // QUX_ENUM_TYPE_CONTEXT: End completions
 
 // QUX_ENUM_NO_DOT: Begin completions, 7 items
@@ -364,16 +364,16 @@ func testWithInvalid1() {
 // UNRESOLVED_1:  Begin completions
 // UNRESOLVED_1-NOT:  Baz
 // UNRESOLVED_1-NOT:  Bar
-// UNRESOLVED_1-DAG:  Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     Qux1[#QuxEnum#]; name=Qux1
-// UNRESOLVED_1-DAG:  Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     Qux2[#QuxEnum#]; name=Qux2
+// UNRESOLVED_1-DAG:  Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]:     Qux1[#QuxEnum#]; name=Qux1
+// UNRESOLVED_1-DAG:  Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]:     Qux2[#QuxEnum#]; name=Qux2
 // UNRESOLVED_1-NOT:  Okay
 }
 
 func testUnqualified1(x: QuxEnum) {
   _ = x == .Qux1 || x == .#^UNRESOLVED_2^#Qux2
   // UNRESOLVED_2: Begin completions
-  // UNRESOLVED_2-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     Qux1[#QuxEnum#]; name=Qux1
-  // UNRESOLVED_2-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     Qux2[#QuxEnum#]; name=Qux2
+  // UNRESOLVED_2-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]:     Qux1[#QuxEnum#]; name=Qux1
+  // UNRESOLVED_2-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]:     Qux2[#QuxEnum#]; name=Qux2
   // UNRESOLVED_2-DAG: Decl[TypeAlias]/CurrNominal:                                RawValue[#Int#]; name=RawValue
   // UNRESOLVED_2-DAG: Decl[Constructor]/CurrNominal:                              init({#rawValue: Int#})[#QuxEnum?#]; name=init(rawValue:)
   // UNRESOLVED_2-DAG: Decl[InstanceMethod]/Super/IsSystem/TypeRelation[Invalid]:  hash({#(self): QuxEnum#})[#(into: inout Hasher) -> Void#]; name=hash(:)
@@ -406,7 +406,7 @@ func completeEquatableEnum(x: PlainEnum) {
   case .#^PATTERN_MATCH_PLAIN_ENUM^#
 // We shouldn't suggest staticMember here because PlainEnum isn't equatable and thus doesn't have a ~= operator defined between instances
 // PATTERN_MATCH_PLAIN_ENUM:     Begin completions, 1 items
-// PATTERN_MATCH_PLAIN_ENUM-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: caseWithAssociatedType({#SomeStruct#})[#PlainEnum#];
+// PATTERN_MATCH_PLAIN_ENUM-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: caseWithAssociatedType({#SomeStruct#})[#PlainEnum#];
 // PATTERN_MATCH_PLAIN_ENUM:     End completions
   }
 }
@@ -428,10 +428,10 @@ func completeEnumWithCustomPatternMatchingOperator(x: EnumWithCustomPatternMatch
 // We should also suggest enum cases from `EnumWithCustomPatternMatchingOperator` whose pattern matching doesn't go through any `~=` operator.
 // We shouldn't suggest `staticMember` because `EnumWithCustomPatternMatchingOperator` doesn`t have `~=` defined between two of its instances.
 // PATTERN_MATCH_ENUM_WITH_CUSTOM_PATTERN_MATCHING:     Begin completions, 4 items
-// PATTERN_MATCH_ENUM_WITH_CUSTOM_PATTERN_MATCHING-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: otherEnumCase[#OtherEnum#];
-// PATTERN_MATCH_ENUM_WITH_CUSTOM_PATTERN_MATCHING-DAG: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: otherStaticMember[#OtherEnum#];
+// PATTERN_MATCH_ENUM_WITH_CUSTOM_PATTERN_MATCHING-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: otherEnumCase[#OtherEnum#];
+// PATTERN_MATCH_ENUM_WITH_CUSTOM_PATTERN_MATCHING-DAG: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: otherStaticMember[#OtherEnum#];
 // PATTERN_MATCH_ENUM_WITH_CUSTOM_PATTERN_MATCHING-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): OtherEnum#})[#(into: inout Hasher) -> Void#];
-// PATTERN_MATCH_ENUM_WITH_CUSTOM_PATTERN_MATCHING-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: caseWithAssociatedType({#SomeStruct#})[#EnumWithCustomPatternMatchingOperator#];
+// PATTERN_MATCH_ENUM_WITH_CUSTOM_PATTERN_MATCHING-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: caseWithAssociatedType({#SomeStruct#})[#EnumWithCustomPatternMatchingOperator#];
 // PATTERN_MATCH_ENUM_WITH_CUSTOM_PATTERN_MATCHING:     End completions
   }
 }
@@ -440,7 +440,7 @@ func completeEnumAssociatedTypeWithCustomPatternMatchingOperator(x: EnumWithCust
   switch x {
   case .caseWithAssociatedType(.#^COMPLETE_ASSOCIATED_TYPE_WITH_CUSTOM_PATTERN_MATCHING^#)
 // COMPLETE_ASSOCIATED_TYPE_WITH_CUSTOM_PATTERN_MATCHING:     Begin completions, 1 items
-// COMPLETE_ASSOCIATED_TYPE_WITH_CUSTOM_PATTERN_MATCHING-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Identical]: init({#structMember: String#})[#SomeStruct#];
+// COMPLETE_ASSOCIATED_TYPE_WITH_CUSTOM_PATTERN_MATCHING-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: init({#structMember: String#})[#SomeStruct#];
 // COMPLETE_ASSOCIATED_TYPE_WITH_CUSTOM_PATTERN_MATCHING:     End completions
   }
 }
@@ -456,7 +456,7 @@ func completeEquatableEnum(x: EquatableEnum) {
   case .#^PATTERN_MATCH_EQUATABLE_ENUM^#
 // Suggest all static members of `EquatableEnum` because we can pattern match through the `~=` operator between two equatable types defined in the stdlib.
 // PATTERN_MATCH_EQUATABLE_ENUM:     Begin completions, 2 items
-// PATTERN_MATCH_EQUATABLE_ENUM-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: caseWithAssociatedType({#SomeStruct#})[#EquatableEnum#];
+// PATTERN_MATCH_EQUATABLE_ENUM-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: caseWithAssociatedType({#SomeStruct#})[#EquatableEnum#];
 // PATTERN_MATCH_EQUATABLE_ENUM-DAG: Decl[StaticVar]/CurrNominal:        staticMember[#EnumWithCustomPatternMatchingOperator#];
 // PATTERN_MATCH_EQUATABLE_ENUM:     End completions
   }
@@ -477,10 +477,10 @@ func completeEnumWithCustomPatternMatchingOperator(x: EquatableEnumWithCustomPat
   case .#^PATTERN_MATCH_EQUATABLE_ENUM_WITH_CUSTOM_PATTERN_MATCHING^#
 // Same as PATTERN_MATCH_ENUM_WITH_CUSTOM_PATTERN_MATCHING but also suggest static members on `EquatableEnumWithCustomPatternMatchingOperator` because its `Equatable`
 // PATTERN_MATCH_EQUATABLE_ENUM_WITH_CUSTOM_PATTERN_MATCHING:     Begin completions, 5 items
-// PATTERN_MATCH_EQUATABLE_ENUM_WITH_CUSTOM_PATTERN_MATCHING-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: otherEnumCase[#OtherEnum#];
-// PATTERN_MATCH_EQUATABLE_ENUM_WITH_CUSTOM_PATTERN_MATCHING-DAG: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: otherStaticMember[#OtherEnum#];
+// PATTERN_MATCH_EQUATABLE_ENUM_WITH_CUSTOM_PATTERN_MATCHING-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: otherEnumCase[#OtherEnum#];
+// PATTERN_MATCH_EQUATABLE_ENUM_WITH_CUSTOM_PATTERN_MATCHING-DAG: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: otherStaticMember[#OtherEnum#];
 // PATTERN_MATCH_EQUATABLE_ENUM_WITH_CUSTOM_PATTERN_MATCHING-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): OtherEnum#})[#(into: inout Hasher) -> Void#];
-// PATTERN_MATCH_EQUATABLE_ENUM_WITH_CUSTOM_PATTERN_MATCHING-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: caseWithAssociatedType({#SomeStruct#})[#EquatableEnumWithCustomPatternMatchingOperator#];
+// PATTERN_MATCH_EQUATABLE_ENUM_WITH_CUSTOM_PATTERN_MATCHING-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: caseWithAssociatedType({#SomeStruct#})[#EquatableEnumWithCustomPatternMatchingOperator#];
 // PATTERN_MATCH_EQUATABLE_ENUM_WITH_CUSTOM_PATTERN_MATCHING-DAG: Decl[StaticVar]/CurrNominal:        staticMember[#EnumWithCustomPatternMatchingOperator#];
 // PATTERN_MATCH_EQUATABLE_ENUM_WITH_CUSTOM_PATTERN_MATCHING:     End completions
   }
@@ -495,5 +495,5 @@ func completeInNestedPatternMatching(x: WithNestedEnum) {
   case .bar(.#^NESTED_ENUM_PATTERN_MATCHING^#)
 }
 // NESTED_ENUM_PATTERN_MATCHING:     Begin completions, 1 items
-// NESTED_ENUM_PATTERN_MATCHING-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: caseWithAssociatedType({#SomeStruct#})[#PlainEnum#];
+// NESTED_ENUM_PATTERN_MATCHING-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: caseWithAssociatedType({#SomeStruct#})[#PlainEnum#];
 // NESTED_ENUM_PATTERN_MATCHING:     End completions

--- a/test/IDE/complete_enum_unresolved_dot_argument_labels.swift
+++ b/test/IDE/complete_enum_unresolved_dot_argument_labels.swift
@@ -11,7 +11,7 @@ func testInit() {
   var state = DragState.inactive
   state = .dragging(#^SIGNATURE^#)
   // SIGNATURE: Begin completions, 1 item
-  // SIGNATURE: Pattern/CurrModule/Flair[ArgLabels]/TypeRelation[Identical]: ['(']{#translationX: Int#}, {#translationY: Int#}[')'][#DragState#];
+  // SIGNATURE: Pattern/CurrModule/Flair[ArgLabels]/TypeRelation[Convertible]: ['(']{#translationX: Int#}, {#translationY: Int#}[')'][#DragState#];
   // SIGNATURE: End completions
 
   state = .dragging(translationX: 2, #^ARGUMENT^#)
@@ -21,7 +21,7 @@ func testInit() {
 
   state = .defaulted(#^DEFAULTED^#)
   // DEFAULTED: Begin completions, 1 items
-  // DEFAULTED: Pattern/CurrModule/Flair[ArgLabels]/TypeRelation[Identical]: ['(']{#x: Int#}, {#y: Int#}, {#z: Int#}, {#extra: Int#}[')'][#DragState#];
+  // DEFAULTED: Pattern/CurrModule/Flair[ArgLabels]/TypeRelation[Convertible]: ['(']{#x: Int#}, {#y: Int#}, {#z: Int#}, {#extra: Int#}[')'][#DragState#];
   // DEFAULTED: End completions
 
   state = .defaulted(x: 1, #^DEFAULTEDARG^#)
@@ -45,7 +45,7 @@ func testMatch() {
   case .dragging(translationX: 2, #^MATCH_ARGY^#):
     // MATCH_ARGY: Begin completions
     // FIXME: This should have an identical type relation
-    // MATCH_ARGY: Decl[LocalVar]/Local/TypeRelation[Identical]: localInt[#Int#]; name=localInt
+    // MATCH_ARGY: Decl[LocalVar]/Local/TypeRelation[Convertible]: localInt[#Int#]; name=localInt
     // FIXME: We should offer 'translationY:' (without any flair since it's optional), `let translationY`, and `_`
     // MATCH_ARGY: End completions
     break

--- a/test/IDE/complete_expr_postfix_begin.swift
+++ b/test/IDE/complete_expr_postfix_begin.swift
@@ -34,7 +34,7 @@ typealias FooTypealias = Int
 // COMMON-DAG: Decl[Enum]/CurrModule:       FooEnum[#FooEnum#]{{; name=.+$}}
 // COMMON-DAG: Decl[Class]/CurrModule:      FooClass[#FooClass#]{{; name=.+$}}
 // COMMON-DAG: Decl[Protocol]/CurrModule/Flair[RareType]: FooProtocol[#FooProtocol#]{{; name=.+$}}
-// COMMON-DAG: Decl[TypeAlias]/CurrModule{{(/TypeRelation\[Identical\])?}}:  FooTypealias[#Int#]{{; name=.+$}}
+// COMMON-DAG: Decl[TypeAlias]/CurrModule{{(/TypeRelation\[Convertible\])?}}:  FooTypealias[#Int#]{{; name=.+$}}
 // COMMON-DAG: Decl[GlobalVar]/CurrModule:  fooObject[#FooStruct#]{{; name=.+$}}
 // COMMON-DAG: Keyword[try]/None: try{{; name=.+$}}
 // COMMON-DAG: Literal[Boolean]/None: true[#Bool#]{{; name=.+$}}
@@ -45,10 +45,10 @@ typealias FooTypealias = Int
 // COMMON-DAG: Decl[Struct]/OtherModule[Swift]/IsSystem:    Int32[#Int32#]{{; name=.+$}}
 // COMMON-DAG: Decl[Struct]/OtherModule[Swift]/IsSystem:    Int64[#Int64#]{{; name=.+$}}
 // COMMON-DAG: Decl[Struct]/OtherModule[Swift]/IsSystem:    Bool[#Bool#]{{; name=.+$}}
-// COMMON-DAG: Keyword[#function]/None{{(/TypeRelation\[Identical\])?}}: #function[#String#]{{; name=.+$}}
-// COMMON-DAG: Keyword[#file]/None{{(/TypeRelation\[Identical\])?}}: #file[#String#]{{; name=.+$}}
-// COMMON-DAG: Keyword[#line]/None{{(/TypeRelation\[Identical\])?}}: #line[#Int#]{{; name=.+$}}
-// COMMON-DAG: Keyword[#column]/None{{(/TypeRelation\[Identical\])?}}: #column[#Int#]{{; name=.+$}}
+// COMMON-DAG: Keyword[#function]/None{{(/TypeRelation\[Convertible\])?}}: #function[#String#]{{; name=.+$}}
+// COMMON-DAG: Keyword[#file]/None{{(/TypeRelation\[Convertible\])?}}: #file[#String#]{{; name=.+$}}
+// COMMON-DAG: Keyword[#line]/None{{(/TypeRelation\[Convertible\])?}}: #line[#Int#]{{; name=.+$}}
+// COMMON-DAG: Keyword[#column]/None{{(/TypeRelation\[Convertible\])?}}: #column[#Int#]{{; name=.+$}}
 // COMMON: End completions
 
 // NO_SELF-NOT: {{[[:<:]][Ss]elf[[:>:]]}}
@@ -334,8 +334,8 @@ func foo() -> Undeclared {
 }
 // MY_ALIAS_1: Begin completions
 // MY_ALIAS_1-DAG: Decl[TypeAlias]/Local:                        MyAlias[#(T, T)#];
-// MY_ALIAS_1-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]: x[#MyAlias<Int>#]; name=x
-// MY_ALIAS_1-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]: y[#(Int, Int)#]; name=y
+// MY_ALIAS_1-DAG: Decl[LocalVar]/Local/TypeRelation[Convertible]: x[#MyAlias<Int>#]; name=x
+// MY_ALIAS_1-DAG: Decl[LocalVar]/Local/TypeRelation[Convertible]: y[#(Int, Int)#]; name=y
 // MY_ALIAS_1: End completions
 
 func testGenericTypealias1() {
@@ -346,8 +346,8 @@ func testGenericTypealias1() {
 }
 // MY_ALIAS_2: Begin completions
 // MY_ALIAS_2-DAG: Decl[TypeAlias]/Local:                        MyAlias[#(T, T)#];
-// MY_ALIAS_2-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]: x[#(Int, Int)#]; name=x
-// MY_ALIAS_2-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]: y[#MyAlias<Int>#]; name=y
+// MY_ALIAS_2-DAG: Decl[LocalVar]/Local/TypeRelation[Convertible]: x[#(Int, Int)#]; name=x
+// MY_ALIAS_2-DAG: Decl[LocalVar]/Local/TypeRelation[Convertible]: y[#MyAlias<Int>#]; name=y
 // MY_ALIAS_2: End completions
 func testGenericTypealias2() {
   typealias MyAlias<T> = (T, T)
@@ -375,9 +375,9 @@ func testInForEach2(arg: Int) {
   }
   let after = 4
 // IN_FOR_EACH_2-NOT: Decl[LocalVar]
-// IN_FOR_EACH_2: Decl[LocalVar]/Local/TypeRelation[Identical]: local[#Int#];
+// IN_FOR_EACH_2: Decl[LocalVar]/Local/TypeRelation[Convertible]: local[#Int#];
 // IN_FOR_EACH_2-NOT: after
-// IN_FOR_EACH_2: Decl[LocalVar]/Local/TypeRelation[Identical]: arg[#Int#];
+// IN_FOR_EACH_2: Decl[LocalVar]/Local/TypeRelation[Convertible]: arg[#Int#];
 // IN_FOR_EACH_2-NOT: Decl[LocalVar]
 }
 func testInForEach3(arg: Int) {
@@ -439,9 +439,9 @@ func testInForEach10(arg: Int) {
   let after = 4
 }
 // IN_FOR_EACH_10-NOT: Decl[LocalVar]
-// IN_FOR_EACH_10: Decl[LocalVar]/Local/TypeRelation[Identical]:               local[#Int#];
+// IN_FOR_EACH_10: Decl[LocalVar]/Local/TypeRelation[Convertible]:               local[#Int#];
 // IN_FOR_EACH_10-NOT: after
-// IN_FOR_EACH_10: Decl[LocalVar]/Local/TypeRelation[Identical]:               arg[#Int#];
+// IN_FOR_EACH_10: Decl[LocalVar]/Local/TypeRelation[Convertible]:               arg[#Int#];
 // IN_FOR_EACH_10-NOT: Decl[LocalVar]
 func testInForEach11(arg: Int) {
   let local = 2
@@ -477,13 +477,13 @@ func testTuple(localInt: Int) {
   let _: (Int, String) = (#^IN_TUPLE_2^#, "foo")
 }
 // IN_TUPLE_1: Begin completions
-// IN_TUPLE_1-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]: localStr[#String#]; name=localStr
+// IN_TUPLE_1-DAG: Decl[LocalVar]/Local/TypeRelation[Convertible]: localStr[#String#]; name=localStr
 // IN_TUPLE_1-DAG: Decl[LocalVar]/Local:               localInt[#Int#]; name=localInt
 // IN_TUPLE_1: End completions
 
 // IN_TUPLE_2: Begin completions
 // IN_TUPLE_2-DAG: Decl[LocalVar]/Local:               localStr[#String#]; name=localStr
-// IN_TUPLE_2-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]: localInt[#Int#]; name=localInt
+// IN_TUPLE_2-DAG: Decl[LocalVar]/Local/TypeRelation[Convertible]: localInt[#Int#]; name=localInt
 // IN_TUPLE_2: End completions
 
 var ownInit1: Int = #^OWN_INIT_1^#
@@ -529,13 +529,13 @@ func ownInitTestingParamInterp(ownInit12: String = "\(#^OWN_INIT_12^#)") {
 func ownInitTestingShadow(ownInit7: Int) {
   var ownInit7: Int = #^OWN_INIT_7^#
   // OWN_INIT_7: Begin completions
-  // OWN_INIT_7: Decl[LocalVar]/Local/TypeRelation[Identical]: ownInit7[#Int#];
+  // OWN_INIT_7: Decl[LocalVar]/Local/TypeRelation[Convertible]: ownInit7[#Int#];
 }
 
 var inAccessor1: Int {
   get { #^OWN_ACCESSOR_1^# }
 // OWN_ACCESSOR_1: Begin completions
-// OWN_ACCESSOR_1: Decl[GlobalVar]/CurrModule/NotRecommended/TypeRelation[Identical]: inAccessor1[#Int#];
+// OWN_ACCESSOR_1: Decl[GlobalVar]/CurrModule/NotRecommended/TypeRelation[Convertible]: inAccessor1[#Int#];
   set { #^OWN_ACCESSOR_2^# }
 // OWN_ACCESSOR_2: Begin completions
 // OWN_ACCESSOR_2: Decl[GlobalVar]/CurrModule: inAccessor1[#Int#];
@@ -550,7 +550,7 @@ class InAccessorTest {
   var inAccessor3: Int {
     get { #^OWN_ACCESSOR_5^# }
 // OWN_ACCESSOR_5: Begin completions
-// OWN_ACCESSOR_5: Decl[InstanceVar]/CurrNominal/NotRecommended/TypeRelation[Identical]: inAccessor3[#Int#];
+// OWN_ACCESSOR_5: Decl[InstanceVar]/CurrNominal/NotRecommended/TypeRelation[Convertible]: inAccessor3[#Int#];
     set { #^OWN_ACCESSOR_6^# }
 // OWN_ACCESSOR_6: Begin completions
 // OWN_ACCESSOR_6: Decl[InstanceVar]/CurrNominal: inAccessor3[#Int#];
@@ -566,7 +566,7 @@ func inAccessorTest() {
   var inAccessor5: Int {
     get { #^OWN_ACCESSOR_9^# }
 // OWN_ACCESSOR_9: Begin completions
-// OWN_ACCESSOR_9: Decl[LocalVar]/Local/NotRecommended/TypeRelation[Identical]: inAccessor5[#Int#];
+// OWN_ACCESSOR_9: Decl[LocalVar]/Local/NotRecommended/TypeRelation[Convertible]: inAccessor5[#Int#];
     set { #^OWN_ACCESSOR_10^# }
 // OWN_ACCESSOR_10: Begin completions
 // OWN_ACCESSOR_10: Decl[LocalVar]/Local: inAccessor5[#Int#];

--- a/test/IDE/complete_func_reference.swift
+++ b/test/IDE/complete_func_reference.swift
@@ -69,7 +69,7 @@ do {
   take(#^VOID_VOID_0^#)
 }
 // VOID_VOID: Begin completions
-// VOID_VOID-DAG: Decl{{.*}}/TypeRelation[Identical]: voidToVoid[#() -> ()#];
+// VOID_VOID-DAG: Decl{{.*}}/TypeRelation[Convertible]: voidToVoid[#() -> ()#];
 // VOID_VOID-DAG: Decl{{.*}}/TypeRelation[Invalid]: anyToVoid({#a: Any#})[#Void#];
 // VOID_VOID-DAG: Decl{{.*}}/TypeRelation[Invalid]: intToVoid({#a: Int#})[#Void#];
 // VOID_VOID-DAG: Decl{{.*}}:      anyToAny({#a: Any#})[#Any#];
@@ -121,7 +121,7 @@ do {
 }
 
 // ANY_INT: Begin completions
-// ANY_INT_DAG: Decl{{.*}}/TypeRelation[Identical]: anyToInt(a:); name=anyToInt(a:)
+// ANY_INT_DAG: Decl{{.*}}/TypeRelation[Convertible]: anyToInt(a:); name=anyToInt(a:)
 // ANY_INT-DAG: Decl{{.*}}/TypeRelation[Invalid]: intToVoid({#a: Int#})[#Void#];
 // ANY_INT-DAG: Decl{{.*}}/TypeRelation[Invalid]: anyToVoid({#a: Any#})[#Void#];
 // ANY_INT-DAG: Decl{{.*}}/TypeRelation[Invalid]: voidToVoid()[#Void#];
@@ -134,7 +134,7 @@ do {
 // ANY_INT: End completions
 
 // ANY_INT_STATIC_CURRY: Begin completions
-// ANY_INT_STATIC_CURRY-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: anyToInt({#(self): S0#})[#(a: Any) -> Int#];
+// ANY_INT_STATIC_CURRY-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: anyToInt({#(self): S0#})[#(a: Any) -> Int#];
 // ANY_INT_STATIC_CURRY-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: voidToVoid({#(self): S0#})[#() -> Void#];
 // ANY_INT_STATIC_CURRY-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: intToVoid({#(self): S0#})[#(a: Int) -> Void#];
 // ANY_INT_STATIC_CURRY-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: anyToVoid({#(self): S0#})[#(a: Any) -> Void#];
@@ -152,7 +152,7 @@ do {
 }
 
 // INT_ANY: Begin completions
-// INT_ANY-DAG: Decl{{.*}}/TypeRelation[Identical]: intToAny(a:)[#(Int) -> Any#];
+// INT_ANY-DAG: Decl{{.*}}/TypeRelation[Convertible]: intToAny(a:)[#(Int) -> Any#];
 // INT_ANY-DAG: Decl{{.*}}/TypeRelation[Convertible]: intToInt(a:)[#(Int) -> Int#];
 // INT_ANY-DAG: Decl{{.*}}/TypeRelation[Convertible]: intToVoid(a:)[#(Int) -> ()#];
 // INT_ANY-DAG: Decl{{.*}}/TypeRelation[Convertible]: anyToAny(a:)[#(Any) -> Any#];
@@ -169,7 +169,7 @@ do {
 // INT_ANY_STATIC_CURRY-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: intToVoid({#(self): S0#})[#(a: Int) -> Void#];
 // INT_ANY_STATIC_CURRY-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: anyToAny({#(self): S0#})[#(a: Any) -> Any#];
 // INT_ANY_STATIC_CURRY-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: anyToVoid({#(self): S0#})[#(a: Any) -> Void#];
-// INT_ANY_STATIC_CURRY-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: intToAny({#(self): S0#})[#(a: Int) -> Any#];
+// INT_ANY_STATIC_CURRY-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: intToAny({#(self): S0#})[#(a: Int) -> Any#];
 // INT_ANY_STATIC_CURRY-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: anyToInt({#(self): S0#})[#(a: Any) -> Int#];
 // INT_ANY_STATIC_CURRY-DAG: Decl[InstanceMethod]/CurrNominal: returnsIntToInt({#(self): S0#})[#() -> (Int) -> Int#];
 // INT_ANY_STATIC_CURRY-DAG: Decl[InstanceMethod]/CurrNominal:   voidToAny({#(self): S0#})[#() -> Any#];
@@ -201,7 +201,7 @@ do {
   func take(_: @escaping ()->(Int)->Int) {}
   take(S0.#^VOID_INT_INT_2^#)
 }
-// VOID_INT_INT-DAG: Decl{{.*}}/TypeRelation[Identical]: returnsIntToInt[#() -> (Int) -> Int#];
+// VOID_INT_INT-DAG: Decl{{.*}}/TypeRelation[Convertible]: returnsIntToInt[#() -> (Int) -> Int#];
 // VOID_INT_INT-DAG: Decl{{.*}}/TypeRelation[Invalid]: intToVoid({#a: Int#})[#Void#];
 // VOID_INT_INT-DAG: Decl{{.*}}/TypeRelation[Invalid]: anyToVoid({#a: Any#})[#Void#];
 // VOID_INT_INT-DAG: Decl{{.*}}/TypeRelation[Invalid]: voidToVoid()[#Void#];

--- a/test/IDE/complete_in_accessors.swift
+++ b/test/IDE/complete_in_accessors.swift
@@ -20,17 +20,17 @@ func returnsInt() -> Int {}
 
 // WITH_GLOBAL_DECLS: Begin completions
 // WITH_GLOBAL_DECLS-DAG: Decl[Struct]/CurrModule:       FooStruct[#FooStruct#]{{; name=.+$}}
-// WITH_GLOBAL_DECLS-DAG: Decl[FreeFunction]/CurrModule{{(/TypeRelation\[Identical\])?}}: returnsInt()[#Int#]{{; name=.+$}}
+// WITH_GLOBAL_DECLS-DAG: Decl[FreeFunction]/CurrModule{{(/TypeRelation\[Convertible\])?}}: returnsInt()[#Int#]{{; name=.+$}}
 // WITH_GLOBAL_DECLS: End completions
 
 // WITH_GLOBAL_DECLS1: Begin completions
 // WITH_GLOBAL_DECLS1-DAG: Decl[Struct]/CurrModule:       FooStruct[#FooStruct#]{{; name=.+$}}
-// WITH_GLOBAL_DECLS1-DAG: Decl[FreeFunction]/CurrModule/TypeRelation[Identical]: returnsInt()[#Int#]{{; name=.+$}}
+// WITH_GLOBAL_DECLS1-DAG: Decl[FreeFunction]/CurrModule/TypeRelation[Convertible]: returnsInt()[#Int#]{{; name=.+$}}
 // WITH_GLOBAL_DECLS1: End completions
 
 // WITH_MEMBER_DECLS: Begin completions
 // WITH_MEMBER_DECLS-DAG: Decl[Struct]/CurrModule:          FooStruct[#FooStruct#]{{; name=.+$}}
-// WITH_MEMBER_DECLS-DAG: Decl[FreeFunction]/CurrModule{{(/TypeRelation\[Identical\])?}}:    returnsInt()[#Int#]{{; name=.+$}}
+// WITH_MEMBER_DECLS-DAG: Decl[FreeFunction]/CurrModule{{(/TypeRelation\[Convertible\])?}}:    returnsInt()[#Int#]{{; name=.+$}}
 // WITH_MEMBER_DECLS-DAG: Decl[LocalVar]/Local:             self[#MemberAccessors#]{{; name=.+$}}
 // WITH_MEMBER_DECLS-DAG: Decl[InstanceVar]/CurrNominal:    instanceVar[#Double#]{{; name=.+$}}
 // WITH_MEMBER_DECLS-DAG: Decl[InstanceMethod]/CurrNominal: instanceFunc({#(a): Int#})[#Float#]{{; name=.+$}}
@@ -38,7 +38,7 @@ func returnsInt() -> Int {}
 
 // WITH_MEMBER_DECLS_INIT: Begin completions
 // WITH_MEMBER_DECLS_INIT-DAG: Decl[Struct]/CurrModule:          FooStruct[#FooStruct#]{{; name=.+$}}
-// WITH_MEMBER_DECLS_INIT-DAG: Decl[FreeFunction]/CurrModule/TypeRelation[Identical]: returnsInt()[#Int#]{{; name=.+$}}
+// WITH_MEMBER_DECLS_INIT-DAG: Decl[FreeFunction]/CurrModule/TypeRelation[Convertible]: returnsInt()[#Int#]{{; name=.+$}}
 // WITH_MEMBER_DECLS_INIT-DAG: Decl[InstanceMethod]/CurrNominal: instanceFunc({#(self): MemberAccessors#})[#(Int) -> Float#]{{; name=.+$}}
 // WITH_MEMBER_DECLS_INIT: End completions
 
@@ -47,15 +47,15 @@ func returnsInt() -> Int {}
 
 // WITH_LOCAL_DECLS: Begin completions
 // WITH_LOCAL_DECLS-DAG: Decl[Struct]/CurrModule:          FooStruct[#FooStruct#]{{; name=.+$}}
-// WITH_LOCAL_DECLS-DAG: Decl[FreeFunction]/CurrModule{{(/TypeRelation\[Identical\])?}}:    returnsInt()[#Int#]{{; name=.+$}}
-// WITH_LOCAL_DECLS-DAG: Decl[LocalVar]/Local{{(/TypeRelation\[Identical\])?}}:             functionParam[#Int#]{{; name=.+$}}
+// WITH_LOCAL_DECLS-DAG: Decl[FreeFunction]/CurrModule{{(/TypeRelation\[Convertible\])?}}:    returnsInt()[#Int#]{{; name=.+$}}
+// WITH_LOCAL_DECLS-DAG: Decl[LocalVar]/Local{{(/TypeRelation\[Convertible\])?}}:             functionParam[#Int#]{{; name=.+$}}
 // WITH_LOCAL_DECLS-DAG: Decl[FreeFunction]/Local:         localFunc({#(a): Int#})[#Float#]{{; name=.+$}}
 // WITH_LOCAL_DECLS: End completions
 
 // WITH_LOCAL_DECLS1: Begin completions
 // WITH_LOCAL_DECLS1-DAG: Decl[Struct]/CurrModule:          FooStruct[#FooStruct#]{{; name=.+$}}
-// WITH_LOCAL_DECLS1-DAG: Decl[FreeFunction]/CurrModule/TypeRelation[Identical]:    returnsInt()[#Int#]{{; name=.+$}}
-// WITH_LOCAL_DECLS1-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]: functionParam[#Int#]{{; name=.+$}}
+// WITH_LOCAL_DECLS1-DAG: Decl[FreeFunction]/CurrModule/TypeRelation[Convertible]:    returnsInt()[#Int#]{{; name=.+$}}
+// WITH_LOCAL_DECLS1-DAG: Decl[LocalVar]/Local/TypeRelation[Convertible]: functionParam[#Int#]{{; name=.+$}}
 // WITH_LOCAL_DECLS1-DAG: Decl[FreeFunction]/Local:         localFunc({#(a): Int#})[#Float#]{{; name=.+$}}
 // WITH_LOCAL_DECLS1: End completions
 
@@ -337,14 +337,14 @@ func accessorsInFunction(_ functionParam: Int) {
 
 // ACCESSORS_IN_MEMBER_FUNC_1: Begin completions
 // ACCESSORS_IN_MEMBER_FUNC_1-DAG: Decl[LocalVar]/Local:             self[#AccessorsInMemberFunction#]
-// ACCESSORS_IN_MEMBER_FUNC_1-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]:             functionParam[#Int#]
+// ACCESSORS_IN_MEMBER_FUNC_1-DAG: Decl[LocalVar]/Local/TypeRelation[Convertible]:             functionParam[#Int#]
 // ACCESSORS_IN_MEMBER_FUNC_1-DAG: Decl[InstanceVar]/CurrNominal:    instanceVar[#Double#]
 // ACCESSORS_IN_MEMBER_FUNC_1-DAG: Decl[InstanceMethod]/CurrNominal: instanceFunc({#(a): Int#})[#Float#]
 // ACCESSORS_IN_MEMBER_FUNC_1: End completions
 
 // ACCESSORS_IN_MEMBER_FUNC_2: Begin completions
 // ACCESSORS_IN_MEMBER_FUNC_2-DAG: Decl[LocalVar]/Local:            self[#AccessorsInMemberFunction#]
-// ACCESSORS_IN_MEMBER_FUNC_2-DAG: Decl[LocalVar]/Local{{(/TypeRelation\[Identical\])?}}:            functionParam[#Int#]
+// ACCESSORS_IN_MEMBER_FUNC_2-DAG: Decl[LocalVar]/Local{{(/TypeRelation\[Convertible\])?}}:            functionParam[#Int#]
 // ACCESSORS_IN_MEMBER_FUNC_2-DAG: Decl[InstanceVar]/OutNominal:    instanceVar[#Double#]
 // ACCESSORS_IN_MEMBER_FUNC_2-DAG: Decl[InstanceMethod]/OutNominal: instanceFunc({#(a): Int#})[#Float#]
 // ACCESSORS_IN_MEMBER_FUNC_2: End completions

--- a/test/IDE/complete_in_closures.swift
+++ b/test/IDE/complete_in_closures.swift
@@ -15,7 +15,7 @@ struct FooStruct {
 // FOO_OBJECT_DOT: Begin completions
 // FOO_OBJECT_DOT-NEXT: Keyword[self]/CurrNominal: self[#FooStruct#]; name=self
 // FOO_OBJECT_DOT-NEXT: Decl[InstanceVar]/CurrNominal:    instanceVar[#Int#]{{; name=.+$}}
-// FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Identical\])?}}: instanceFunc0()[#Void#]{{; name=.+$}}
+// FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Convertible\])?}}: instanceFunc0()[#Void#]{{; name=.+$}}
 // FOO_OBJECT_DOT-NEXT: End completions
 
 // WITH_GLOBAL_DECLS: Begin completions
@@ -312,8 +312,8 @@ func testIIFE() {
   }()
 }
 // IN_IIFE_1: Begin completions
-// IN_IIFE_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: north[#SomeEnum#]
-// IN_IIFE_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: south[#SomeEnum#]
+// IN_IIFE_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: north[#SomeEnum#]
+// IN_IIFE_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: south[#SomeEnum#]
 
 extension Error {
   var myErrorNumber: Int { return 0 }

--- a/test/IDE/complete_in_result_builder.swift
+++ b/test/IDE/complete_in_result_builder.swift
@@ -68,7 +68,7 @@ func testGlobalLookup() {
   @TupleBuilder<String> var x5 {
     if #^GLOBAL_LOOKUP_IN_IF_CONDITION^# {
 // GLOBAL_LOOKUP_IN_IF_CONDITION: Begin completions
-// GLOBAL_LOOKUP_IN_IF_CONDITION: Decl[GlobalVar]/CurrModule/TypeRelation[Identical]: MyConstantBool[#Bool#]; name=MyConstantBool
+// GLOBAL_LOOKUP_IN_IF_CONDITION: Decl[GlobalVar]/CurrModule/TypeRelation[Convertible]: MyConstantBool[#Bool#]; name=MyConstantBool
 // GLOBAL_LOOKUP_IN_IF_CONDITION: End completions
     }
   }
@@ -105,9 +105,9 @@ func testPatternMatching() {
     let x = Letters.b
     if case .#^COMPLETE_PATTERN_MATCHING_IN_IF?check=COMPLETE_CASE^# = x {
 // COMPLETE_CASE: Begin completions
-// COMPLETE_CASE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: a[#Letters#];
-// COMPLETE_CASE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: b[#Letters#];
-// COMPLETE_CASE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: c[#Letters#];
+// COMPLETE_CASE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: a[#Letters#];
+// COMPLETE_CASE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: b[#Letters#];
+// COMPLETE_CASE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: c[#Letters#];
 // COMPLETE_CASE: End completions
     }
   }
@@ -124,8 +124,8 @@ func testPatternMatching() {
     let x: FooStruct? = FooStruct()
     guard case .#^GUARD_CASE_PATTERN_1?check=OPTIONAL_FOOSTRUCT^# = x {}
     // OPTIONAL_FOOSTRUCT: Begin completions, 2 items
-    // OPTIONAL_FOOSTRUCT-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Identical]: none[#Optional<FooStruct>#]; name=none
-    // OPTIONAL_FOOSTRUCT-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Identical]: some({#FooStruct#})[#Optional<FooStruct>#]; name=some()
+    // OPTIONAL_FOOSTRUCT-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Convertible]: none[#Optional<FooStruct>#]; name=none
+    // OPTIONAL_FOOSTRUCT-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Convertible]: some({#FooStruct#})[#Optional<FooStruct>#]; name=some()
     // OPTIONAL_FOOSTRUCT: End completions
   }
 
@@ -148,7 +148,7 @@ func testCompleteFunctionArgument() {
   @TupleBuilder<String> var x1 {
     StringFactory.makeString(x: #^ARGUMENT_LOOKUP^#)
     // ARGUMENT_LOOKUP: Begin completions
-    // ARGUMENT_LOOKUP: Decl[GlobalVar]/CurrModule/TypeRelation[Identical]: MyConstantString[#String#];
+    // ARGUMENT_LOOKUP: Decl[GlobalVar]/CurrModule/TypeRelation[Convertible]: MyConstantString[#String#];
     // ARGUMENT_LOOKUP: End completions
   }
 

--- a/test/IDE/complete_invalid_result_builder.swift
+++ b/test/IDE/complete_invalid_result_builder.swift
@@ -55,6 +55,6 @@ test {
 }
 
 // MYENUM_MEMBERS: Begin completions
-// MYENUM_MEMBERS-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: a[#MyEnum#]; name=a
-// MYENUM_MEMBERS-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: b[#MyEnum#]; name=b
+// MYENUM_MEMBERS-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: a[#MyEnum#]; name=a
+// MYENUM_MEMBERS-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: b[#MyEnum#]; name=b
 // MYENUM_MEMBERS: End completions 

--- a/test/IDE/complete_keywords.swift
+++ b/test/IDE/complete_keywords.swift
@@ -174,10 +174,10 @@
 // KW_DECL_STMT_TOPLEVEL-DAG: Keyword[try]/None: try{{; name=.+$}}
 // KW_DECL_STMT_TOPLEVEL-DAG: Keyword[try]/None: try!{{; name=.+$}}
 // KW_DECL_STMT_TOPLEVEL-DAG: Keyword[try]/None: try?{{; name=.+$}}
-// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[#function]/None{{(/TypeRelation\[Identical\])?}}: #function[#String#]{{; name=.+$}}
-// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[#file]/None{{(/TypeRelation\[Identical\])?}}: #file[#String#]{{; name=.+$}}
-// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[#line]/None{{(/TypeRelation\[Identical\])?}}: #line[#Int#]{{; name=.+$}}
-// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[#column]/None{{(/TypeRelation\[Identical\])?}}: #column[#Int#]{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[#function]/None{{(/TypeRelation\[Convertible\])?}}: #function[#String#]{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[#file]/None{{(/TypeRelation\[Convertible\])?}}: #file[#String#]{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[#line]/None{{(/TypeRelation\[Convertible\])?}}: #line[#Int#]{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[#column]/None{{(/TypeRelation\[Convertible\])?}}: #column[#Int#]{{; name=.+$}}
 //
 // Literals
 //
@@ -247,10 +247,10 @@
 // KW_DECL_STMT-DAG: Keyword[try]/None: try{{; name=.+$}}
 // KW_DECL_STMT-DAG: Keyword[try]/None: try!{{; name=.+$}}
 // KW_DECL_STMT-DAG: Keyword[try]/None: try?{{; name=.+$}}
-// KW_DECL_STMT-DAG: Keyword[#function]/None{{(/TypeRelation\[Identical\])?}}: #function[#String#]{{; name=.+$}}
-// KW_DECL_STMT-DAG: Keyword[#file]/None{{(/TypeRelation\[Identical\])?}}: #file[#String#]{{; name=.+$}}
-// KW_DECL_STMT-DAG: Keyword[#line]/None{{(/TypeRelation\[Identical\])?}}: #line[#Int#]{{; name=.+$}}
-// KW_DECL_STMT-DAG: Keyword[#column]/None{{(/TypeRelation\[Identical\])?}}: #column[#Int#]{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword[#function]/None{{(/TypeRelation\[Convertible\])?}}: #function[#String#]{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword[#file]/None{{(/TypeRelation\[Convertible\])?}}: #file[#String#]{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword[#line]/None{{(/TypeRelation\[Convertible\])?}}: #line[#Int#]{{; name=.+$}}
+// KW_DECL_STMT-DAG: Keyword[#column]/None{{(/TypeRelation\[Convertible\])?}}: #column[#Int#]{{; name=.+$}}
 //
 // Literals
 //
@@ -267,10 +267,10 @@
 // KW_EXPR-DAG: Keyword[try]/None: try{{; name=.+$}}
 // KW_EXPR-DAG: Keyword[try]/None: try!{{; name=.+$}}
 // KW_EXPR-DAG: Keyword[try]/None: try?{{; name=.+$}}
-// KW_EXPR-DAG: Keyword[#function]/None{{(/TypeRelation\[Identical\])?}}: #function[#String#]{{; name=.+$}}
-// KW_EXPR-DAG: Keyword[#file]/None{{(/TypeRelation\[Identical\])?}}: #file[#String#]{{; name=.+$}}
-// KW_EXPR-DAG: Keyword[#line]/None{{(/TypeRelation\[Identical\])?}}: #line[#Int#]{{; name=.+$}}
-// KW_EXPR-DAG: Keyword[#column]/None{{(/TypeRelation\[Identical\])?}}: #column[#Int#]{{; name=.+$}}
+// KW_EXPR-DAG: Keyword[#function]/None{{(/TypeRelation\[Convertible\])?}}: #function[#String#]{{; name=.+$}}
+// KW_EXPR-DAG: Keyword[#file]/None{{(/TypeRelation\[Convertible\])?}}: #file[#String#]{{; name=.+$}}
+// KW_EXPR-DAG: Keyword[#line]/None{{(/TypeRelation\[Convertible\])?}}: #line[#Int#]{{; name=.+$}}
+// KW_EXPR-DAG: Keyword[#column]/None{{(/TypeRelation\[Convertible\])?}}: #column[#Int#]{{; name=.+$}}
 //
 // let and var
 //
@@ -279,8 +279,8 @@
 //
 // Literals
 //
-// KW_EXPR-DAG: Literal[Boolean]/None{{(/TypeRelation\[Identical\])?}}: false[#Bool#]{{; name=.+$}}
-// KW_EXPR-DAG: Literal[Boolean]/None{{(/TypeRelation\[Identical\])?}}: true[#Bool#]{{; name=.+$}}
+// KW_EXPR-DAG: Literal[Boolean]/None{{(/TypeRelation\[Convertible\])?}}: false[#Bool#]{{; name=.+$}}
+// KW_EXPR-DAG: Literal[Boolean]/None{{(/TypeRelation\[Convertible\])?}}: true[#Bool#]{{; name=.+$}}
 // KW_EXPR-DAG: Literal[Nil]/None: nil{{; name=.+$}}
 // KW_EXPR: End completions
 
@@ -481,15 +481,15 @@ func testContextualType() {
 // CONTEXT_UINT32: Begin completions
 // CONTEXT_UINT32-DAG: Keyword[#function]/None:            #function[#String#]; name=#function
 // CONTEXT_UINT32-DAG: Keyword[#file]/None:                #file[#String#]; name=#file
-// CONTEXT_UINT32-DAG: Keyword[#line]/None/TypeRelation[Identical]: #line[#UInt32#]; name=#line
-// CONTEXT_UINT32-DAG: Keyword[#column]/None/TypeRelation[Identical]: #column[#UInt32#]; name=#column
+// CONTEXT_UINT32-DAG: Keyword[#line]/None/TypeRelation[Convertible]: #line[#UInt32#]; name=#line
+// CONTEXT_UINT32-DAG: Keyword[#column]/None/TypeRelation[Convertible]: #column[#UInt32#]; name=#column
 // CONTEXT_UINT32-DAG: Keyword[#dsohandle]/None:           #dsohandle[#UnsafeRawPointer#]; name=#dsohandle
 // CONTEXT_UINT32: End completions
 
   let _: StaticString = #^CONTEXT_STATICSTRING^#
 // CONTEXT_STATICSTRING: Begin completions
-// CONTEXT_STATICSTRING-DAG: Keyword[#function]/None/TypeRelation[Identical]: #function[#StaticString#]; name=#function
-// CONTEXT_STATICSTRING-DAG: Keyword[#file]/None/TypeRelation[Identical]: #file[#StaticString#]; name=#file
+// CONTEXT_STATICSTRING-DAG: Keyword[#function]/None/TypeRelation[Convertible]: #function[#StaticString#]; name=#function
+// CONTEXT_STATICSTRING-DAG: Keyword[#file]/None/TypeRelation[Convertible]: #file[#StaticString#]; name=#file
 // CONTEXT_STATICSTRING-DAG: Keyword[#line]/None:                #line[#Int#]; name=#line
 // CONTEXT_STATICSTRING-DAG: Keyword[#column]/None:              #column[#Int#]; name=#column
 // CONTEXT_STATICSTRING-DAG: Keyword[#dsohandle]/None:           #dsohandle[#UnsafeRawPointer#]; name=#dsohandle

--- a/test/IDE/complete_multibracestmt.swift
+++ b/test/IDE/complete_multibracestmt.swift
@@ -33,7 +33,7 @@ func test(pred: Bool) {
 }
 
 // CHECK: Begin completions, 3 items
-// CHECK-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: bar[#E#]; name=bar
-// CHECK-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: foo[#E#]; name=foo
+// CHECK-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: bar[#E#]; name=bar
+// CHECK-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: foo[#E#]; name=foo
 // CHECK-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): E#})[#(into: inout Hasher) -> Void#]; name=hash(:)
 // CHECK: End completions

--- a/test/IDE/complete_multiple_files.swift
+++ b/test/IDE/complete_multiple_files.swift
@@ -59,6 +59,6 @@ var sr15495: Void = {
 }()
 
 // VAR_INITIALIZED_BY_CALLING_CLOSURE:     Begin completions, 2 items
-// VAR_INITIALIZED_BY_CALLING_CLOSURE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: bar[#Foo#];
+// VAR_INITIALIZED_BY_CALLING_CLOSURE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: bar[#Foo#];
 // VAR_INITIALIZED_BY_CALLING_CLOSURE-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): Foo#})[#(into: inout Hasher) -> Void#];
 // VAR_INITIALIZED_BY_CALLING_CLOSURE:     End completions

--- a/test/IDE/complete_operator_operand.swift
+++ b/test/IDE/complete_operator_operand.swift
@@ -13,15 +13,15 @@ func <--> (lhs: C2, rhs: C1) -> Bool {}
 func test_binary1(c1: C1, c2: C2) {
   _ = c1 <--> #^BINARY_RHS_1^#
 // BINARY_RHS_1: Begin completion
-// BINARY_RHS_1-NOT: Decl[LocalVar]/Local/TypeRelation[Identical]: c1[#C1#]; name=c1
-// BINARY_RHS_1-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]: c2[#C2#]; name=c2
+// BINARY_RHS_1-NOT: Decl[LocalVar]/Local/TypeRelation[Convertible]: c1[#C1#]; name=c1
+// BINARY_RHS_1-DAG: Decl[LocalVar]/Local/TypeRelation[Convertible]: c2[#C2#]; name=c2
 }
 
 func test_binary2(c1: C1, c2: C2) {
   _ = c2 <--> #^BINARY_RHS_2^#
 // BINARY_RHS_2: Begin completion
-// BINARY_RHS_2-NOT: Decl[LocalVar]/Local/TypeRelation[Identical]: c2[#C2#]; name=c2
-// BINARY_RHS_2-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]: c1[#C1#]; name=c1
+// BINARY_RHS_2-NOT: Decl[LocalVar]/Local/TypeRelation[Convertible]: c2[#C2#]; name=c2
+// BINARY_RHS_2-DAG: Decl[LocalVar]/Local/TypeRelation[Convertible]: c1[#C1#]; name=c1
 }
 
 prefix func --> (operand: C1) -> Bool {}
@@ -30,6 +30,6 @@ prefix func --> (operand: C2) -> Bool {}
 func test_prefix1(c1: C1, c2: C2) {
   _ = -->#^PREFIX_1^#
 // PREFIX_1: Begin completion
-// PREFIX_1-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]: c1[#C1#]; name=c1
-// PREFIX_1-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]: c2[#C2#]; name=c2
+// PREFIX_1-DAG: Decl[LocalVar]/Local/TypeRelation[Convertible]: c1[#C1#]; name=c1
+// PREFIX_1-DAG: Decl[LocalVar]/Local/TypeRelation[Convertible]: c2[#C2#]; name=c2
 }

--- a/test/IDE/complete_pattern.swift
+++ b/test/IDE/complete_pattern.swift
@@ -220,5 +220,5 @@ func test_cc_in_pattern(subject: IntHolder, i1: Int) {
 }
 
 // CC_IN_PATTERN_1: Begin completions
-// CC_IN_PATTERN_1-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]: i1[#Int#]; name=i1
+// CC_IN_PATTERN_1-DAG: Decl[LocalVar]/Local/TypeRelation[Convertible]: i1[#Int#]; name=i1
 // CC_IN_PATTERN_1: End completions

--- a/test/IDE/complete_pound_expr.swift
+++ b/test/IDE/complete_pound_expr.swift
@@ -20,29 +20,29 @@ func test1() {
 // POUND_EXPR_INTCONTEXT-DAG: Keyword[#file]/None:                file[#String#]; name=file
 // POUND_EXPR_INTCONTEXT-DAG: Keyword[#fileID]/None: fileID[#String#]; name=fileID
 // POUND_EXPR_INTCONTEXT-DAG: Keyword[#filePath]/None: filePath[#String#]; name=filePath
-// POUND_EXPR_INTCONTEXT-DAG: Keyword[#line]/None/TypeRelation[Identical]: line[#Int#]; name=line
-// POUND_EXPR_INTCONTEXT-DAG: Keyword[#column]/None/TypeRelation[Identical]: column[#Int#]; name=column
+// POUND_EXPR_INTCONTEXT-DAG: Keyword[#line]/None/TypeRelation[Convertible]: line[#Int#]; name=line
+// POUND_EXPR_INTCONTEXT-DAG: Keyword[#column]/None/TypeRelation[Convertible]: column[#Int#]; name=column
 // POUND_EXPR_INTCONTEXT-DAG: Keyword[#dsohandle]/None:           dsohandle[#UnsafeRawPointer#]; name=dsohandle
 // POUND_EXPR_INTCONTEXT: End completions
 
 // POUND_EXPR_STRINGCONTEXT: Begin completions, 8 items
-// POUND_EXPR_STRINGCONTEXT-DAG: Keyword[#function]/None/TypeRelation[Identical]: function[#String#];
-// POUND_EXPR_STRINGCONTEXT-DAG: Keyword[#file]/None/TypeRelation[Identical]: file[#String#];
-// POUND_EXPR_STRINGCONTEXT-DAG: Keyword[#fileID]/None/TypeRelation[Identical]: fileID[#String#];
-// POUND_EXPR_STRINGCONTEXT-DAG: Keyword[#filePath]/None/TypeRelation[Identical]: filePath[#String#];
+// POUND_EXPR_STRINGCONTEXT-DAG: Keyword[#function]/None/TypeRelation[Convertible]: function[#String#];
+// POUND_EXPR_STRINGCONTEXT-DAG: Keyword[#file]/None/TypeRelation[Convertible]: file[#String#];
+// POUND_EXPR_STRINGCONTEXT-DAG: Keyword[#fileID]/None/TypeRelation[Convertible]: fileID[#String#];
+// POUND_EXPR_STRINGCONTEXT-DAG: Keyword[#filePath]/None/TypeRelation[Convertible]: filePath[#String#];
 // POUND_EXPR_STRINGCONTEXT-DAG: Keyword[#line]/None:                line[#Int#];
 // POUND_EXPR_STRINGCONTEXT-DAG: Keyword[#column]/None:              column[#Int#];
 // POUND_EXPR_STRINGCONTEXT-DAG: Keyword[#dsohandle]/None:           dsohandle[#UnsafeRawPointer#];
-// POUND_EXPR_STRINGCONTEXT-DAG: Keyword/None/TypeRelation[Identical]: keyPath({#@objc property sequence#})[#String#];
+// POUND_EXPR_STRINGCONTEXT-DAG: Keyword/None/TypeRelation[Convertible]: keyPath({#@objc property sequence#})[#String#];
 // POUND_EXPR_STRINGCONTEXT: End completions
 
 // POUND_EXPR_SELECTORCONTEXT: Begin completions, 8 items
-// POUND_EXPR_SELECTORCONTEXT-DAG: Keyword[#function]/None/TypeRelation[Identical]: function[#Selector#];
-// POUND_EXPR_SELECTORCONTEXT-DAG: Keyword[#file]/None/TypeRelation[Identical]: file[#Selector#];
-// POUND_EXPR_SELECTORCONTEXT-DAG: Keyword[#fileID]/None/TypeRelation[Identical]: fileID[#Selector#];
-// POUND_EXPR_SELECTORCONTEXT-DAG: Keyword[#filePath]/None/TypeRelation[Identical]: filePath[#Selector#];
+// POUND_EXPR_SELECTORCONTEXT-DAG: Keyword[#function]/None/TypeRelation[Convertible]: function[#Selector#];
+// POUND_EXPR_SELECTORCONTEXT-DAG: Keyword[#file]/None/TypeRelation[Convertible]: file[#Selector#];
+// POUND_EXPR_SELECTORCONTEXT-DAG: Keyword[#fileID]/None/TypeRelation[Convertible]: fileID[#Selector#];
+// POUND_EXPR_SELECTORCONTEXT-DAG: Keyword[#filePath]/None/TypeRelation[Convertible]: filePath[#Selector#];
 // POUND_EXPR_SELECTORCONTEXT-DAG: Keyword[#line]/None:                line[#Int#];
 // POUND_EXPR_SELECTORCONTEXT-DAG: Keyword[#column]/None:              column[#Int#];
 // POUND_EXPR_SELECTORCONTEXT-DAG: Keyword[#dsohandle]/None:           dsohandle[#UnsafeRawPointer#];
-// POUND_EXPR_SELECTORCONTEXT-DAG: Keyword/None/TypeRelation[Identical]: selector({#@objc method#})[#Selector#];
+// POUND_EXPR_SELECTORCONTEXT-DAG: Keyword/None/TypeRelation[Convertible]: selector({#@objc method#})[#Selector#];
 // POUND_EXPR_SELECTORCONTEXT: End completions

--- a/test/IDE/complete_pound_keypath.swift
+++ b/test/IDE/complete_pound_keypath.swift
@@ -67,7 +67,7 @@ func completeInKeyPath6() {
 
 // CHECK-AFTER_POUND-NOT: keyPath
 
-// CHECK-KEYPATH_ARG: Keyword/None/TypeRelation[Identical]: #keyPath({#@objc property sequence#})[#String#]; name=#keyPath()
+// CHECK-KEYPATH_ARG: Keyword/None/TypeRelation[Convertible]: #keyPath({#@objc property sequence#})[#String#]; name=#keyPath()
 
 // CHECK-IN_KEYPATH: Decl[InstanceVar]/CurrNominal:      prop1[#String#]; name=prop1
 // CHECK-IN_KEYPATH: Decl[InstanceVar]/CurrNominal:      prop2[#ObjCClass?#]; name=prop2

--- a/test/IDE/complete_pound_selector.swift
+++ b/test/IDE/complete_pound_selector.swift
@@ -74,7 +74,7 @@ class Subclass : NSObject {
 // CHECK-AFTER_POUND-NOT: selector
 // CHECK-AFTER_POUND: Keyword/Local/Flair[ExprSpecific]:               available({#Platform...#}, *); name=available(*)
 
-// CHECK-CONTEXT_SELECTOR: Keyword/None/TypeRelation[Identical]: #selector({#@objc method#})[#Selector#]; name=#selector()
+// CHECK-CONTEXT_SELECTOR: Keyword/None/TypeRelation[Convertible]: #selector({#@objc method#})[#Selector#]; name=#selector()
 
 // CHECK-SELECTOR_BASIC: Keyword/None:                       getter: {#@objc property#}; name=getter: 
 // CHECK-SELECTOR_BASIC: Keyword/None:                       setter: {#@objc property#}; name=setter: 

--- a/test/IDE/complete_property_delegate_attribute.swift
+++ b/test/IDE/complete_property_delegate_attribute.swift
@@ -29,14 +29,14 @@ struct TestStruct {
   var test2
 // ARG_MyEnum_NODOT: Begin completions
 // ARG_MyEnum_NODOT-DAG: Decl[Struct]/CurrModule:            TestStruct[#TestStruct#]; name=TestStruct
-// ARG_MyEnum_NODOT-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Identical]: globalMyEnum[#MyEnum#]; name=globalMyEnum
+// ARG_MyEnum_NODOT-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Convertible]: globalMyEnum[#MyEnum#]; name=globalMyEnum
 // ARG_MyEnum_NODOT: End completions
 
   @MyStruct(arg1: .#^ARG_MyEnum_DOT^#
   var test3
 // ARG_MyEnum_DOT: Begin completions, 3 items
-// ARG_MyEnum_DOT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     east[#MyEnum#]; name=east
-// ARG_MyEnum_DOT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     west[#MyEnum#]; name=west
+// ARG_MyEnum_DOT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]:     east[#MyEnum#]; name=east
+// ARG_MyEnum_DOT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]:     west[#MyEnum#]; name=west
 // ARG_MyEnum_DOT-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): MyEnum#})[#(into: inout Hasher) -> Void#];
 // ARG_MyEnum_DOT: End completions
 

--- a/test/IDE/complete_protocol_static_member.swift
+++ b/test/IDE/complete_protocol_static_member.swift
@@ -59,7 +59,7 @@ func test() {
   receiver(.#^COMPLETE_GENERIC_TYPE^#)
 }
 // COMPLETE_GENERIC_TYPE: Begin completions, 2 items
-// COMPLETE_GENERIC_TYPE: Decl[Constructor]/CurrNominal/TypeRelation[Identical]: init()[#Indicator<T>#];
+// COMPLETE_GENERIC_TYPE: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: init()[#Indicator<T>#];
 // COMPLETE_GENERIC_TYPE: Decl[StaticVar]/CurrNominal/TypeRelation[Convertible]: activity[#Indicator<Sr12973>#];
 // COMPLETE_GENERIC_TYPE: End completions
 
@@ -67,6 +67,6 @@ func testRecursive<T>(_ inidicator: Indicator<T>) {
   testRecursive(.#^COMPLETE_RECURSIVE_GENERIC^#)
 // FIXME: We should be suggesting `.activity` here because the call to `testRecursive` happens with new generic parameters
 // COMPLETE_RECURSIVE_GENERIC: Begin completions, 1 item
-// COMPLETE_RECURSIVE_GENERIC-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Identical]: init()[#Indicator<T>#];
+// COMPLETE_RECURSIVE_GENERIC-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: init()[#Indicator<T>#];
 // COMPLETE_RECURSIVE_GENERIC: End completions
 }

--- a/test/IDE/complete_rdar63965160.swift
+++ b/test/IDE/complete_rdar63965160.swift
@@ -34,5 +34,5 @@ func test(values: [Value]) {
 }
 // CHECK: Begin completions, 2 items
 // CHECK-DAG: Keyword[self]/CurrNominal:          self[#Value#];
-// CHECK-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[{{Convertible|Identical}}]: name[#String#];
+// CHECK-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]: name[#String#];
 // CHECK: End completions

--- a/test/IDE/complete_rdar75200217.swift
+++ b/test/IDE/complete_rdar75200217.swift
@@ -31,5 +31,5 @@ func deserializeName(_ data: Array<UInt16>, flag: Bool) {
 }
 
 // CHECK: Begin completions
-// CHECK-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: utf8[#Encoding#];
+// CHECK-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: utf8[#Encoding#];
 // CHECK: End completions

--- a/test/IDE/complete_return.swift
+++ b/test/IDE/complete_return.swift
@@ -83,8 +83,8 @@ func testTR1() -> Int? {
 	return #^RETURN_TR1^#
 
 // RETURN_TR1: Begin completions
-// RETURN_TR1-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]: oi[#Int?#]{{; name=.+$}}
-// RETURN_TR1-DAG: Decl[FreeFunction]/CurrModule/TypeRelation[Identical]: testTR1()[#Int?#]{{; name=.+$}}
+// RETURN_TR1-DAG: Decl[LocalVar]/Local/TypeRelation[Convertible]: oi[#Int?#]{{; name=.+$}}
+// RETURN_TR1-DAG: Decl[FreeFunction]/CurrModule/TypeRelation[Convertible]: testTR1()[#Int?#]{{; name=.+$}}
 // RETURN_TR1-DAG: Decl[LocalVar]/Local/TypeRelation[Convertible]: i[#Int#]{{; name=.+$}}
 // RETURN_TR1-DAG: Decl[FreeFunction]/CurrModule/TypeRelation[Invalid]: testReturnInt1()[#Void#]{{; name=.+$}}
 // RETURN_TR1-DAG: Decl[LocalVar]/Local:               fs[#FooStruct#]{{; name=.+$}}
@@ -96,7 +96,7 @@ func testTR2(_ g : Gen) -> Int? {
 
 // RETURN_TR2: Begin completions
 // RETURN_TR2-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: IntGen()[#Int#]{{; name=.+$}}
-// RETURN_TR2-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: IntOpGen()[#Int?#]{{; name=.+$}}
+// RETURN_TR2-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: IntOpGen()[#Int?#]{{; name=.+$}}
 // RETURN_TR2-DAG: Decl[InstanceMethod]/CurrNominal:   StringGen()[#String#]{{; name=.+$}}
 // RETURN_TR2-DAG: Decl[InstanceMethod]/CurrNominal:   StringOpGen()[#String?#]{{; name=.+$}}
 // RETURN_TR2-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: IntTaker({#(i1): Int#}, {#i2: Int#})[#Void#]{{; name=.+$}}
@@ -108,7 +108,7 @@ func testTR3(_ g : Gen) -> Int? {
 
 // RETURN_TR3: Begin completions
 // RETURN_TR3-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: InternalIntGen()[#Int#]{{; name=.+$}}
-// RETURN_TR3-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: InternalIntOpGen()[#Int?#]{{; name=.+$}}
+// RETURN_TR3-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: InternalIntOpGen()[#Int?#]{{; name=.+$}}
 // RETURN_TR3-DAG: Decl[InstanceMethod]/CurrNominal:   InternalStringGen()[#String#]{{; name=.+$}}
 // RETURN_TR3-DAG: Decl[InstanceMethod]/CurrNominal:   InternalStringOpGen()[#String?#]{{; name=.+$}}
 // RETURN_TR3-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: InternalIntTaker({#(i1): Int#}, {#i2: Int#})[#Void#]{{; name=.+$}}

--- a/test/IDE/complete_single_expression_return.swift
+++ b/test/IDE/complete_single_expression_return.swift
@@ -16,7 +16,7 @@ struct TestSingleExprClosureRet {
 
 // TestSingleExprClosureRet: Begin completions
 // TestSingleExprClosureRet-DAG: Decl[InstanceMethod]/CurrNominal:   str()[#String#];
-// TestSingleExprClosureRet-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: int()[#Int#];
+// TestSingleExprClosureRet-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: int()[#Int#];
 // TestSingleExprClosureRet-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: void()[#Void#];
 // TestSingleExprClosureRet: End completions
 }
@@ -35,7 +35,7 @@ struct TestSingleExprClosureRetVoid {
 // TestSingleExprClosureRetVoid: Begin completions
 // TestSingleExprClosureRetVoid-DAG: Decl[InstanceMethod]/CurrNominal: str()[#String#];
 // TestSingleExprClosureRetVoid-DAG: Decl[InstanceMethod]/CurrNominal: int()[#Int#];
-// TestSingleExprClosureRetVoid-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: void()[#Void#];
+// TestSingleExprClosureRetVoid-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: void()[#Void#];
 // TestSingleExprClosureRetVoid: End completions
 }
 
@@ -53,7 +53,7 @@ struct TestSingleExprClosureRetUnresolved {
 
 // TestSingleExprClosureRetUnresolved: Begin completions
 // TestSingleExprClosureRetUnresolved-NOT: notMine
-// TestSingleExprClosureRetUnresolved: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: myEnum[#MyEnum#];
+// TestSingleExprClosureRetUnresolved: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: myEnum[#MyEnum#];
 // TestSingleExprClosureRetUnresolved-NOT: notMine
 // TestSingleExprClosureRetUnresolved: End completions
 }
@@ -70,7 +70,7 @@ struct TestSingleExprClosure {
   }
 // TestSingleExprClosure: Begin completions
 // TestSingleExprClosure-DAG: Decl[InstanceMethod]/CurrNominal:   str()[#String#];
-// TestSingleExprClosure-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: int()[#Int#];
+// TestSingleExprClosure-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: int()[#Int#];
 // NOTE: this differs from the one using a return keyword.
 // TestSingleExprClosure-DAG: Decl[InstanceMethod]/CurrNominal: void()[#Void#];
 // TestSingleExprClosure: End completions
@@ -108,7 +108,7 @@ struct TestSingleExprClosureUnresolved {
 }
 // TestSingleExprClosureUnresolved: Begin completions
 // TestSingleExprClosureUnresolved-NOT: notMine
-// TestSingleExprClosureUnresolved: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: myEnum[#MyEnum#];
+// TestSingleExprClosureUnresolved: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: myEnum[#MyEnum#];
 // TestSingleExprClosureUnresolved-NOT: notMine
 // TestSingleExprClosureUnresolved: End completions
 
@@ -138,7 +138,7 @@ struct TestSingleExprClosureGlobal {
   }
 // TestSingleExprClosureGlobal: Begin completions
 // TestSingleExprClosureGlobal-DAG: Decl[InstanceMethod]/OutNominal:   str()[#String#];
-// TestSingleExprClosureGlobal-DAG: Decl[InstanceMethod]/OutNominal/TypeRelation[Identical]: int()[#Int#];
+// TestSingleExprClosureGlobal-DAG: Decl[InstanceMethod]/OutNominal/TypeRelation[Convertible]: int()[#Int#];
 // TestSingleExprClosureGlobal-DAG: Decl[InstanceMethod]/OutNominal: void()[#Void#];
 // TestSingleExprClosureGlobal: End completions
 }
@@ -190,7 +190,7 @@ struct TestSingleExprFuncRet {
 
 // TestSingleExprFuncRet: Begin completions
 // TestSingleExprFuncRet-DAG: Decl[InstanceMethod]/CurrNominal:   str()[#String#];
-// TestSingleExprFuncRet-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: int()[#Int#];
+// TestSingleExprFuncRet-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: int()[#Int#];
 // TestSingleExprFuncRet-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: void()[#Void#];
 // TestSingleExprFuncRet: End completions
 }
@@ -206,7 +206,7 @@ struct TestSingleExprFunc {
 
 // TestSingleExprFunc: Begin completions
 // TestSingleExprFunc-DAG: Decl[InstanceMethod]/CurrNominal:   str()[#String#];
-// TestSingleExprFunc-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: int()[#Int#];
+// TestSingleExprFunc-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: int()[#Int#];
 // TestSingleExprFunc-DAG: Decl[InstanceMethod]/CurrNominal: void()[#Void#];
 // TestSingleExprFunc: End completions
 }
@@ -223,7 +223,7 @@ struct TestSingleExprFuncUnresolved {
 
 // TestSingleExprFuncUnresolved: Begin completions
 // TestSingleExprFuncUnresolved-NOT: notMine
-// TestSingleExprFuncUnresolved: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: myEnum[#MyEnum#];
+// TestSingleExprFuncUnresolved: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: myEnum[#MyEnum#];
 // TestSingleExprFuncUnresolved-NOT: notMine
 // TestSingleExprFuncUnresolved: End completions
 }
@@ -266,7 +266,7 @@ struct TestSingleExprFuncGlobal {
   }
 // TestSingleExprFuncGlobal: Begin completions
 // TestSingleExprFuncGlobal-DAG: Decl[InstanceMethod]/CurrNominal:   str()[#String#];
-// TestSingleExprFuncGlobal-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: int()[#Int#];
+// TestSingleExprFuncGlobal-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: int()[#Int#];
 // TestSingleExprFuncGlobal-DAG: Decl[InstanceMethod]/CurrNominal: void()[#Void#];
 // TestSingleExprFuncGlobal: End completions
 }
@@ -300,7 +300,7 @@ struct TestSingleExprAccessorRet {
 
 // TestSingleExprAccessorRet: Begin completions
 // TestSingleExprAccessorRet-DAG: Decl[InstanceMethod]/CurrNominal:   str()[#String#];
-// TestSingleExprAccessorRet-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: int()[#Int#];
+// TestSingleExprAccessorRet-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: int()[#Int#];
 // TestSingleExprAccessorRet-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: void()[#Void#];
 // TestSingleExprAccessorRet: End completions
 }
@@ -316,7 +316,7 @@ struct TestSingleExprAccessor {
 
 // TestSingleExprAccessor: Begin completions
 // TestSingleExprAccessor-DAG: Decl[InstanceMethod]/CurrNominal:   str()[#String#];
-// TestSingleExprAccessor-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: int()[#Int#];
+// TestSingleExprAccessor-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: int()[#Int#];
 // TestSingleExprAccessor-DAG: Decl[InstanceMethod]/CurrNominal: void()[#Void#];
 // TestSingleExprAccessor: End completions
 }
@@ -333,7 +333,7 @@ struct TestSingleExprAccessorUnresolved {
 
 // TestSingleExprAccessorUnresolved: Begin completions
 // TestSingleExprAccessorUnresolved-NOT: notMine
-// TestSingleExprAccessorUnresolved: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: myEnum[#MyEnum#];
+// TestSingleExprAccessorUnresolved: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: myEnum[#MyEnum#];
 // TestSingleExprAccessorUnresolved-NOT: notMine
 // TestSingleExprAccessorUnresolved: End completions
 }
@@ -376,7 +376,7 @@ struct TestSingleExprAccessorGlobal {
   }
 // TestSingleExprAccessorGlobal: Begin completions
 // TestSingleExprAccessorGlobal-DAG: Decl[InstanceMethod]/CurrNominal:   str()[#String#];
-// TestSingleExprAccessorGlobal-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: int()[#Int#];
+// TestSingleExprAccessorGlobal-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: int()[#Int#];
 // TestSingleExprAccessorGlobal-DAG: Decl[InstanceMethod]/CurrNominal: void()[#Void#];
 // TestSingleExprAccessorGlobal: End completions
 }
@@ -394,7 +394,7 @@ struct TestNonSingleExprAccessorGlobal {
 // TestNonSingleExprAccessorGlobal: Begin completions
 // TestNonSingleExprAccessorGlobal-DAG: Decl[InstanceMethod]/CurrNominal: str()[#String#];
 // FIXME: should should not have type context.
-// TestNonSingleExprAccessorGlobal-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: int()[#Int#];
+// TestNonSingleExprAccessorGlobal-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: int()[#Int#];
 // TestNonSingleExprAccessorGlobal-DAG: Decl[InstanceMethod]/CurrNominal: void()[#Void#];
 // TestNonSingleExprAccessorGlobal: End completions
 }
@@ -452,7 +452,7 @@ struct TestSingleExprSubscriptRet {
 
 // TestSingleExprSubscriptRet: Begin completions
 // TestSingleExprSubscriptRet-DAG: Decl[InstanceMethod]/CurrNominal:   str()[#String#];
-// TestSingleExprSubscriptRet-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: int()[#Int#];
+// TestSingleExprSubscriptRet-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: int()[#Int#];
 // TestSingleExprSubscriptRet-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: void()[#Void#];
 // TestSingleExprSubscriptRet: End completions
 }
@@ -468,7 +468,7 @@ struct TestSingleExprSubscript {
 
 // TestSingleExprSubscript: Begin completions
 // TestSingleExprSubscript-DAG: Decl[InstanceMethod]/CurrNominal:   str()[#String#];
-// TestSingleExprSubscript-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: int()[#Int#];
+// TestSingleExprSubscript-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: int()[#Int#];
 // TestSingleExprSubscript-DAG: Decl[InstanceMethod]/CurrNominal: void()[#Void#];
 // TestSingleExprSubscript: End completions
 }
@@ -485,7 +485,7 @@ struct TestSingleExprSubscriptUnresolved {
 
 // TestSingleExprSubscriptUnresolved: Begin completions
 // TestSingleExprSubscriptUnresolved-NOT: notMine
-// TestSingleExprSubscriptUnresolved: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: myEnum[#MyEnum#];
+// TestSingleExprSubscriptUnresolved: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: myEnum[#MyEnum#];
 // TestSingleExprSubscriptUnresolved-NOT: notMine
 // TestSingleExprSubscriptUnresolved: End completions
 }
@@ -516,7 +516,7 @@ struct TestSingleExprSubscriptGlobal {
 
 // TestSingleExprSubscriptGlobal: Begin completions
 // TestSingleExprSubscriptGlobal-DAG: Decl[InstanceMethod]/CurrNominal: str()[#String#];
-// TestSingleExprSubscriptGlobal-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: int()[#Int#];
+// TestSingleExprSubscriptGlobal-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: int()[#Int#];
 // TestSingleExprSubscriptGlobal-DAG: Decl[InstanceMethod]/CurrNominal: void()[#Void#];
 // TestSingleExprSubscriptGlobal: End completions
 }
@@ -546,7 +546,7 @@ enum TestSingeExprInitNilRet {
   init?() {
     return #^TestSingeExprInitNilRet^#
   }
-// TestSingeExprInitNilRet: Literal[Nil]/None/TypeRelation[Identical]: nil[#TestSingeExprInitNil{{(Ret)?}}?#];
+// TestSingeExprInitNilRet: Literal[Nil]/None/TypeRelation[Convertible]: nil[#TestSingeExprInitNil{{(Ret)?}}?#];
 }
 
 enum TestSingeExprInitNil {
@@ -590,7 +590,7 @@ enum TopLevelEnum {
   case foo
 }
 
-// TopLevelEnum: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: foo[#TopLevelEnum#];
+// TopLevelEnum: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: foo[#TopLevelEnum#];
 
 var testAccessorUnresolvedTopLevel: TopLevelEnum {
   .#^testAccessorUnresolvedTopLevel?check=TopLevelEnum^#

--- a/test/IDE/complete_skipbody.swift
+++ b/test/IDE/complete_skipbody.swift
@@ -77,6 +77,6 @@ default:
 
 // CHECK: Begin completions, 3 items
 // CHECK-DAG: Keyword[self]/CurrNominal:          self[#MyStruct#]; name=self
-// CHECK-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Identical]:      x[#Int#]; name=x
-// CHECK-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Identical]:      y[#Int#]; name=y
+// CHECK-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]:      x[#Int#]; name=x
+// CHECK-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]:      y[#Int#]; name=y
 // CHECK: End completions

--- a/test/IDE/complete_sr13271.swift
+++ b/test/IDE/complete_sr13271.swift
@@ -48,8 +48,8 @@ func test() {
     .#^B^#
   }
 // B: Begin completions, 2 items
-// B-DAG: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: baz[#B#]; name=baz
-// B-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Identical]: init()[#B#]; name=init()
+// B-DAG: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: baz[#B#]; name=baz
+// B-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: init()[#B#]; name=init()
 // B: End completions
 }
 

--- a/test/IDE/complete_stmt_controlling_expr.swift
+++ b/test/IDE/complete_stmt_controlling_expr.swift
@@ -395,8 +395,8 @@ func testSwitchCaseWhereExprIJ1(_ fooObject: FooStruct) {
 // COND_COMMON: End completions
 
 // COND_WHERE_COMMON: Begin completions
-// COND_WHERE_COMMON-DAG: Literal[Boolean]/None/TypeRelation[Identical]: true[#Bool#]{{; name=.+$}}
-// COND_WHERE_COMMON-DAG: Literal[Boolean]/None/TypeRelation[Identical]: false[#Bool#]{{; name=.+$}}
+// COND_WHERE_COMMON-DAG: Literal[Boolean]/None/TypeRelation[Convertible]: true[#Bool#]{{; name=.+$}}
+// COND_WHERE_COMMON-DAG: Literal[Boolean]/None/TypeRelation[Convertible]: false[#Bool#]{{; name=.+$}}
 // COND_WHERE_COMMON-DAG: Decl[LocalVar]/Local:        fooObject[#FooStruct#]{{; name=.+$}}
 // COND_WHERE_COMMON-DAG: Decl[LocalVar]/Local:        localInt[#Int#]{{; name=.+$}}
 // COND_WHERE_COMMON-DAG: Decl[LocalVar]/Local:        localFooObject[#FooStruct#]{{; name=.+$}}
@@ -405,8 +405,8 @@ func testSwitchCaseWhereExprIJ1(_ fooObject: FooStruct) {
 
 
 // COND-WITH-RELATION: Begin completions
-// COND-WITH-RELATION-DAG: Literal[Boolean]/None/TypeRelation[Identical]: true[#Bool#]{{; name=.+$}}
-// COND-WITH-RELATION-DAG: Literal[Boolean]/None/TypeRelation[Identical]: false[#Bool#]{{; name=.+$}}
+// COND-WITH-RELATION-DAG: Literal[Boolean]/None/TypeRelation[Convertible]: true[#Bool#]{{; name=.+$}}
+// COND-WITH-RELATION-DAG: Literal[Boolean]/None/TypeRelation[Convertible]: false[#Bool#]{{; name=.+$}}
 // COND-WITH-RELATION-DAG: Decl[LocalVar]/Local:        fooObject[#FooStruct#]{{; name=.+$}}
 // COND-WITH-RELATION-DAG: Decl[LocalVar]/Local:        localInt[#Int#]{{; name=.+$}}
 // COND-WITH-RELATION-DAG: Decl[LocalVar]/Local:        localFooObject[#FooStruct#]{{; name=.+$}}
@@ -418,7 +418,7 @@ func testSwitchCaseWhereExprIJ1(_ fooObject: FooStruct) {
 
 // COND-WITH-RELATION1: Begin completions
 // COND-WITH-RELATION1-DAG: Decl[InstanceVar]/CurrNominal:      instanceVar[#Int#]{{; name=.+$}}
-// COND-WITH-RELATION1-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: boolGen()[#Bool#]{{; name=.+$}}
+// COND-WITH-RELATION1-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: boolGen()[#Bool#]{{; name=.+$}}
 // COND-WITH-RELATION1-DAG: Decl[InstanceMethod]/CurrNominal:   intGen()[#Int#]{{; name=.+$}}
 // COND-WITH-RELATION1: End completions
 
@@ -431,7 +431,7 @@ func testSwitchCaseWhereExprIJ1(_ fooObject: FooStruct) {
 enum A { case aaa }
 enum B { case bbb }
 // UNRESOLVED_B-NOT: aaa
-// UNRESOLVED_B: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:     bbb[#B#]; name=bbb
+// UNRESOLVED_B: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]:     bbb[#B#]; name=bbb
 // UNRESOLVED_B-NOT: aaa
 
 struct AA {
@@ -539,7 +539,7 @@ func testGuardCase(x:FooStruct?) {
 
 // FOOSTRUCT_DOT_BOOL: Begin completions
 // FOOSTRUCT_DOT_BOOL-DAG: Decl[InstanceVar]/CurrNominal:      instanceVar[#Int#];
-// FOOSTRUCT_DOT_BOOL-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: boolGen()[#Bool#];
+// FOOSTRUCT_DOT_BOOL-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: boolGen()[#Bool#];
 // FOOSTRUCT_DOT_BOOL-DAG: Decl[InstanceMethod]/CurrNominal:   intGen()[#Int#];
 // FOOSTRUCT_DOT_BOOL: End completions
 
@@ -554,8 +554,8 @@ func testGuardCase(x:FooStruct?) {
 // FOOSTRUCT_LOCALVAL: End completions
 
 // OPTIONAL_FOOSTRUCT: Begin completions, 2 items
-// OPTIONAL_FOOSTRUCT-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Identical]: none[#Optional<FooStruct>#]; name=none
-// OPTIONAL_FOOSTRUCT-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Identical]: some({#FooStruct#})[#Optional<FooStruct>#]; name=some()
+// OPTIONAL_FOOSTRUCT-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Convertible]: none[#Optional<FooStruct>#]; name=none
+// OPTIONAL_FOOSTRUCT-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Convertible]: some({#FooStruct#})[#Optional<FooStruct>#]; name=some()
 // OPTIONAL_FOOSTRUCT: End completions
 
 func returnOpt() -> String? { nil }

--- a/test/IDE/complete_string_interpolation.swift
+++ b/test/IDE/complete_string_interpolation.swift
@@ -34,24 +34,24 @@ var messenger = Messenger()
 func testMessenger(intVal: Int, fltVal: Float) {
   messenger.send("  \(intVal, format: .#^OVERLOAD_INT^#) ")
 // OVERLOAD_INT: Begin completions, 3 items
-// OVERLOAD_INT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: decimal[#MsgInterpolation.IntFormat#];
-// OVERLOAD_INT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: hex[#MsgInterpolation.IntFormat#];
+// OVERLOAD_INT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: decimal[#MsgInterpolation.IntFormat#];
+// OVERLOAD_INT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: hex[#MsgInterpolation.IntFormat#];
 // OVERLOAD_INT-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): MsgInterpolation.IntFormat#})[#(into: inout Hasher) -> Void#];
 // OVERLOAD_INT: End completions
 
   messenger.send("  \(5, format: .#^OVERLOAD_INTLITERAL^#, extraneousArg: 10) ")
 // OVERLOAD_INTLITERAL: Begin completions, 5 items
-// OVERLOAD_INTLITERAL-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: decimal[#MsgInterpolation.IntFormat#];
-// OVERLOAD_INTLITERAL-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: hex[#MsgInterpolation.IntFormat#];
+// OVERLOAD_INTLITERAL-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: decimal[#MsgInterpolation.IntFormat#];
+// OVERLOAD_INTLITERAL-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: hex[#MsgInterpolation.IntFormat#];
 // OVERLOAD_INTLITERAL-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): MsgInterpolation.IntFormat#})[#(into: inout Hasher) -> Void#];
-// OVERLOAD_INTLITERAL-DAG: Decl[StaticMethod]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: precision({#Int#})[#MsgInterpolation.FloatFormat#];
-// OVERLOAD_INTLITERAL-DAG: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: hex[#MsgInterpolation.FloatFormat#];
+// OVERLOAD_INTLITERAL-DAG: Decl[StaticMethod]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: precision({#Int#})[#MsgInterpolation.FloatFormat#];
+// OVERLOAD_INTLITERAL-DAG: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: hex[#MsgInterpolation.FloatFormat#];
 // OVERLOAD_INTLITERAL: End completions
 
   messenger.send("  \(fltVal, format: .#^OVERLOAD_FLT^#) ")
   messenger.send("  \(5.0, format: .#^OVERLOAD_FLTLITERAL^#) ")
 // OVERLOAD_FLT: Begin completions, 2 items
-// OVERLOAD_FLT-DAG: Decl[StaticMethod]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: precision({#Int#})[#MsgInterpolation.FloatFormat#];
-// OVERLOAD_FLT-DAG: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: hex[#MsgInterpolation.FloatFormat#];
+// OVERLOAD_FLT-DAG: Decl[StaticMethod]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: precision({#Int#})[#MsgInterpolation.FloatFormat#];
+// OVERLOAD_FLT-DAG: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: hex[#MsgInterpolation.FloatFormat#];
 // OVERLOAD_FLT: End completions
 }

--- a/test/IDE/complete_subscript.swift
+++ b/test/IDE/complete_subscript.swift
@@ -175,5 +175,5 @@ func testSettableSub(x: inout HasSettableSub) {
 // SETTABLE_SUBSCRIPT: Begin completions
 // SETTABLE_SUBSCRIPT-DAG: Pattern/CurrNominal/Flair[ArgLabels]: ['[']{#keyPath: KeyPath<HasSettableSub, Value>#}[']'][#Value#];
 // SETTABLE_SUBSCRIPT-DAG: Decl[Subscript]/CurrNominal/Flair[ArgLabels]: ['[']{#(a): String#}[']'][#@lvalue Any#];
-// SETTABLE_SUBSCRIPT-DAG: Decl[LocalVar]/Local/TypeRelation[Identical]: local[#String#]; name=local
+// SETTABLE_SUBSCRIPT-DAG: Decl[LocalVar]/Local/TypeRelation[Convertible]: local[#String#]; name=local
 // SETTABLE_SUBSCRIPT: End completions

--- a/test/IDE/complete_type_relation_global_results.swift
+++ b/test/IDE/complete_type_relation_global_results.swift
@@ -64,9 +64,9 @@ func test() -> MyProto {
 // CHECK-DAG: Decl[Struct]/OtherModule[Lib]/TypeRelation[Convertible]: Foo[#Foo#];
 // CHECK-DAG: Decl[GlobalVar]/OtherModule[Lib]/TypeRelation[Convertible]: GLOBAL_FOO[#Foo#];
 // CHECK-DAG: Decl[Struct]/OtherModule[Lib]:      Bar[#Bar#];
-// CHECK-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]/TypeRelation[Identical]: MyProto[#MyProto#];
+// CHECK-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]/TypeRelation[Convertible]: MyProto[#MyProto#];
 // CHECK-DAG: Decl[FreeFunction]/OtherModule[Lib]/TypeRelation[Convertible]: makeFoo()[#Foo#];
-// CHECK-DAG: Decl[FreeFunction]/OtherModule[Lib]/TypeRelation[Identical]: returnSomeMyProto()[#MyProto#];
+// CHECK-DAG: Decl[FreeFunction]/OtherModule[Lib]/TypeRelation[Convertible]: returnSomeMyProto()[#MyProto#];
 // CHECK: End completions
 
 
@@ -97,7 +97,7 @@ func testAlsoConsiderMetatype() -> MyClass.Type {
   return #^ALSO_CONSIDER_METATYPE^#
 }
 // ALSO_CONSIDER_METATYPE: Begin completions
-// ALSO_CONSIDER_METATYPE-DAG: Decl[Class]/OtherModule[Lib]/TypeRelation[Identical]: MyClass[#MyClass#];
+// ALSO_CONSIDER_METATYPE-DAG: Decl[Class]/OtherModule[Lib]/TypeRelation[Convertible]: MyClass[#MyClass#];
 // FIXME: MySubclass should be 'Convertible' but we don't currently store metatype supertypes in USRBasedType.
 // ALSO_CONSIDER_METATYPE-DAG: Decl[Class]/OtherModule[Lib]: MySubclass[#MySubclass#];
 // ALSO_CONSIDER_METATYPE: End completions
@@ -128,7 +128,7 @@ func testGenericReturn<T: MyProto>() -> T {
   return #^GENERIC_RETURN^#
 }
 
-// FIXME: We don't support USR-based type comparison in generic contexts. MyProto and returnMyProto should be 'Identical'. makeFoo and FooBar should be 'Convertible'
+// FIXME: We don't support USR-based type comparison in generic contexts. MyProto, returnMyProto, makeFoo and FooBar should be 'Convertible'
 // GENERIC_RETURN: Begin completions
 // GENERIC_RETURN-DAG: Decl[Struct]/OtherModule[Lib]: Foo[#Foo#];
 // GENERIC_RETURN-DAG: Decl[GlobalVar]/OtherModule[Lib]: GLOBAL_FOO[#Foo#];
@@ -171,7 +171,7 @@ func testGenericReturn() -> MyBaseProto {
 // TRANSITIVE_CONFORMANCE-DAG: Decl[Struct]/OtherModule[Lib]/TypeRelation[Convertible]: Foo[#Foo#];
 // TRANSITIVE_CONFORMANCE-DAG: Decl[FreeFunction]/OtherModule[Lib]/TypeRelation[Convertible]: returnSomeMyProto()[#MyProto#];
 // TRANSITIVE_CONFORMANCE-DAG: Decl[GlobalVar]/OtherModule[Lib]/TypeRelation[Convertible]: GLOBAL_FOO[#Foo#];
-// TRANSITIVE_CONFORMANCE-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]/TypeRelation[Identical]: MyBaseProto[#MyBaseProto#];
+// TRANSITIVE_CONFORMANCE-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]/TypeRelation[Convertible]: MyBaseProto[#MyBaseProto#];
 // TRANSITIVE_CONFORMANCE-DAG: Decl[Struct]/OtherModule[Lib]:      Bar[#Bar#];
 // TRANSITIVE_CONFORMANCE-DAG: Decl[Class]/OtherModule[Lib]/TypeRelation[Convertible]: MySubclassConformingToMyProto[#MySubclassConformingToMyProto#];
 // TRANSITIVE_CONFORMANCE-DAG: Decl[Struct]/OtherModule[Lib]/TypeRelation[Convertible]: FooBar[#FooBar#];
@@ -190,8 +190,8 @@ func protoWithAssocType() -> ProtoWithAssocType {
 
 // PROTO_WITH_ASSOC_TYPE: Begin completions
 // PROTO_WITH_ASSOC_TYPE-DAG: Decl[Struct]/OtherModule[Lib]/TypeRelation[Convertible]: StructWithAssocType[#StructWithAssocType#];
-// PROTO_WITH_ASSOC_TYPE-DAG: Decl[FreeFunction]/OtherModule[Lib]/TypeRelation[Identical]: makeProtoWithAssocType()[#ProtoWithAssocType#];
-// PROTO_WITH_ASSOC_TYPE-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]/TypeRelation[Identical]: ProtoWithAssocType[#ProtoWithAssocType#];
+// PROTO_WITH_ASSOC_TYPE-DAG: Decl[FreeFunction]/OtherModule[Lib]/TypeRelation[Convertible]: makeProtoWithAssocType()[#ProtoWithAssocType#];
+// PROTO_WITH_ASSOC_TYPE-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]/TypeRelation[Convertible]: ProtoWithAssocType[#ProtoWithAssocType#];
 // PROTO_WITH_ASSOC_TYPE: End completions
 
 // RUN: %empty-directory(%t/completion-cache)

--- a/test/IDE/complete_unresolved_chains.swift
+++ b/test/IDE/complete_unresolved_chains.swift
@@ -37,10 +37,10 @@ func testChains() {
 
 // UNRESOLVED_CHAIN_1: Begin completions, 5 items
 // UNRESOLVED_CHAIN_1-DAG: Keyword[self]/CurrNominal:          self[#ChainStruct2#]; name=self
-// UNRESOLVED_CHAIN_1-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Identical]: chainStruct1[#ChainStruct1#];
+// UNRESOLVED_CHAIN_1-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]: chainStruct1[#ChainStruct1#];
 // UNRESOLVED_CHAIN_1-DAG: Decl[InstanceVar]/CurrNominal:      chainEnum[#ChainEnum#];
 // UNRESOLVED_CHAIN_1-DAG: Decl[InstanceVar]/CurrNominal:      chainStruct2[#ChainStruct2#];
-// UNRESOLVED_CHAIN_1-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Identical]: chainStruct1Func()[#ChainStruct1#];
+// UNRESOLVED_CHAIN_1-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: chainStruct1Func()[#ChainStruct1#];
 // UNRESOLVED_CHAIN_1: End completions
 
 // UNRESOLVED_CHAIN_2: Begin completions, 5 items
@@ -53,7 +53,7 @@ func testChains() {
 
 // UNRESOLVED_CHAIN_3: Begin completions, 5 items
 // UNRESOLVED_CHAIN_3-DAG: Decl[InstanceVar]/CurrNominal:      chainStruct1[#ChainStruct1#]; name=chainStruct1
-// UNRESOLVED_CHAIN_3-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Identical]: chainEnum[#ChainEnum#]; name=chainEnum
+// UNRESOLVED_CHAIN_3-DAG: Decl[InstanceVar]/CurrNominal/TypeRelation[Convertible]: chainEnum[#ChainEnum#]; name=chainEnum
 // UNRESOLVED_CHAIN_3-DAG: Decl[InstanceVar]/CurrNominal:      chainStruct2[#ChainStruct2#]; name=chainStruct2
 // UNRESOLVED_CHAIN_3-DAG: Decl[InstanceMethod]/CurrNominal:   chainStruct1Func()[#ChainStruct1#]; name=chainStruct1Func()
 // UNRESOLVED_CHAIN_3: End completions
@@ -75,9 +75,9 @@ func testDoublyNestedType() {
 // DOUBLY_NESTED: Begin completions, 8 items
 // DOUBLY_NESTED-DAG: Keyword[self]/CurrNominal:          self[#Outer.Inner.Type#]; name=self
 // DOUBLY_NESTED-DAG: Decl[Class]/CurrNominal/TypeRelation[Convertible]: InnerInner[#Outer.Inner.InnerInner#];
-// DOUBLY_NESTED-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Identical]: outer[#Outer#];
+// DOUBLY_NESTED-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Convertible]: outer[#Outer#];
 // DOUBLY_NESTED-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Convertible]: inner[#Outer.Inner#];
-// DOUBLY_NESTED-DAG: Decl[StaticMethod]/CurrNominal/TypeRelation[Identical]: makeOuter()[#Outer#];
+// DOUBLY_NESTED-DAG: Decl[StaticMethod]/CurrNominal/TypeRelation[Convertible]: makeOuter()[#Outer#];
 // DOUBLY_NESTED-DAG: Decl[StaticMethod]/CurrNominal/TypeRelation[Convertible]: makeInner()[#Outer.Inner#];
 // DOUBLY_NESTED-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: init()[#Outer.Inner#];
 // DOUBLY_NESTED-DAG: Decl[Class]/Super/TypeRelation[Convertible]: Inner[#Outer.Inner#];

--- a/test/IDE/complete_unresolved_members.swift
+++ b/test/IDE/complete_unresolved_members.swift
@@ -98,9 +98,9 @@ class C2 {
 // UNRESOLVED_1:  Begin completions
 // UNRESOLVED_1-NOT:  SomeEnum1
 // UNRESOLVED_1-NOT:  SomeEnum2
-// UNRESOLVED_1-DAG:  Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: Option1[#SomeOptions1#]; name=Option1
-// UNRESOLVED_1-DAG:  Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: Option2[#SomeOptions1#]; name=Option2
-// UNRESOLVED_1-DAG:  Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: Option3[#SomeOptions1#]; name=Option3
+// UNRESOLVED_1-DAG:  Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: Option1[#SomeOptions1#]; name=Option1
+// UNRESOLVED_1-DAG:  Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: Option2[#SomeOptions1#]; name=Option2
+// UNRESOLVED_1-DAG:  Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: Option3[#SomeOptions1#]; name=Option3
 // UNRESOLVED_1-DAG:  Decl[StaticVar]/CurrNominal:        NotOption[#Int#]; name=NotOption
 // UNRESOLVED_1-NOT:  NotStaticOption
 }
@@ -115,9 +115,9 @@ class C3 {
 // UNRESOLVED_2:  Begin completions
 // UNRESOLVED_2-NOT:  SomeEnum1
 // UNRESOLVED_2-NOT:  SomeEnum2
-// UNRESOLVED_2-DAG:  Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: Option4[#SomeOptions2#]; name=Option4
-// UNRESOLVED_2-DAG:  Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: Option5[#SomeOptions2#]; name=Option5
-// UNRESOLVED_2-DAG:  Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: Option6[#SomeOptions2#]; name=Option6
+// UNRESOLVED_2-DAG:  Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: Option4[#SomeOptions2#]; name=Option4
+// UNRESOLVED_2-DAG:  Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: Option5[#SomeOptions2#]; name=Option5
+// UNRESOLVED_2-DAG:  Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: Option6[#SomeOptions2#]; name=Option6
 // UNRESOLVED_2-NOT:  Not
 }
 
@@ -145,8 +145,8 @@ class C4 {
 
 // Exhaustive to make sure we don't include `SomeOptions1`, `SomeOptions2`, `none` or `some` entries.
 // UNRESOLVED_3: Begin completions, 3 items
-// UNRESOLVED_3-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: North[#SomeEnum1#]; name=North
-// UNRESOLVED_3-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: South[#SomeEnum1#]; name=South
+// UNRESOLVED_3-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: North[#SomeEnum1#]; name=North
+// UNRESOLVED_3-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: South[#SomeEnum1#]; name=South
 // UNRESOLVED_3-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): SomeEnum1#})[#(into: inout Hasher) -> Void#]; name=hash(:)
 // UNRESOLVED_3: End completions
 
@@ -155,9 +155,9 @@ class C4 {
 // UNRESOLVED_3_OPT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: North[#SomeEnum1#];
 // UNRESOLVED_3_OPT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: South[#SomeEnum1#];
 // UNRESOLVED_3_OPT-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): SomeEnum1#})[#(into: inout Hasher) -> Void#];
-// UNRESOLVED_3_OPT-DAG: Keyword[nil]/None/Erase[1]/TypeRelation[Identical]: nil[#SomeEnum1?#]; name=nil
-// UNRESOLVED_3_OPT-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Identical]: none[#Optional<SomeEnum1>#]; name=none
-// UNRESOLVED_3_OPT-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Identical]: some({#SomeEnum1#})[#Optional<SomeEnum1>#];
+// UNRESOLVED_3_OPT-DAG: Keyword[nil]/None/Erase[1]/TypeRelation[Convertible]: nil[#SomeEnum1?#]; name=nil
+// UNRESOLVED_3_OPT-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Convertible]: none[#Optional<SomeEnum1>#]; name=none
+// UNRESOLVED_3_OPT-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Convertible]: some({#SomeEnum1#})[#Optional<SomeEnum1>#];
 // UNRESOLVED_3_OPT-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem: map({#(self): Optional<SomeEnum1>#})[#((SomeEnum1) throws -> U) -> U?#];
 // UNRESOLVED_3_OPT-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem: flatMap({#(self): Optional<SomeEnum1>#})[#((SomeEnum1) throws -> U?) -> U?#];
 // UNRESOLVED_3_OPT-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem/TypeRelation[Invalid]: hash({#(self): Optional<SomeEnum1>#})[#(into: inout Hasher) -> Void#];
@@ -168,9 +168,9 @@ class C4 {
 // UNRESOLVED_3_OPTOPTOPT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: North[#SomeEnum1#];
 // UNRESOLVED_3_OPTOPTOPT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: South[#SomeEnum1#];
 // UNRESOLVED_3_OPTOPTOPT-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): SomeEnum1#})[#(into: inout Hasher) -> Void#];
-// UNRESOLVED_3_OPTOPTOPT-DAG: Keyword[nil]/None/Erase[1]/TypeRelation[Identical]: nil[#SomeEnum1???#]; name=nil
-// UNRESOLVED_3_OPTOPTOPT-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Identical]: none[#Optional<SomeEnum1??>#]; name=none
-// UNRESOLVED_3_OPTOPTOPT-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Identical]: some({#SomeEnum1??#})[#Optional<SomeEnum1??>#];
+// UNRESOLVED_3_OPTOPTOPT-DAG: Keyword[nil]/None/Erase[1]/TypeRelation[Convertible]: nil[#SomeEnum1???#]; name=nil
+// UNRESOLVED_3_OPTOPTOPT-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Convertible]: none[#Optional<SomeEnum1??>#]; name=none
+// UNRESOLVED_3_OPTOPTOPT-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Convertible]: some({#SomeEnum1??#})[#Optional<SomeEnum1??>#];
 // UNRESOLVED_3_OPTOPTOPT-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem: map({#(self): Optional<SomeEnum1??>#})[#((SomeEnum1??) throws -> U) -> U?#];
 // UNRESOLVED_3_OPTOPTOPT-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem: flatMap({#(self): Optional<SomeEnum1??>#})[#((SomeEnum1??) throws -> U?) -> U?#];
 // UNRESOLVED_3_OPTOPTOPT-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem/TypeRelation[Invalid]: hash({#(self): Optional<SomeEnum1??>#})[#(into: inout Hasher) -> Void#];
@@ -189,11 +189,11 @@ func testOptionalWithCustomExtension() {
 // UNRESOLVED_OPT_4-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]:     earth[#Somewhere#];
 // UNRESOLVED_OPT_4-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]:     mars[#Somewhere#];
 // UNRESOLVED_OPT_4-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): Somewhere#})[#(into: inout Hasher) -> Void#];
-// UNRESOLVED_OPT_4-DAG: Keyword[nil]/None/Erase[1]/TypeRelation[Identical]: nil[#Somewhere?#]; name=nil
-// UNRESOLVED_OPT_4-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Identical]: none[#Optional<Somewhere>#]; name=none
-// UNRESOLVED_OPT_4-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Identical]: some({#Somewhere#})[#Optional<Somewhere>#];
-// UNRESOLVED_OPT_4-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Identical]: init({#str: String#})[#Optional<Somewhere>#]; name=init(str:)
-// UNRESOLVED_OPT_4-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Identical]: nowhere[#Optional<Somewhere>#]; name=nowhere
+// UNRESOLVED_OPT_4-DAG: Keyword[nil]/None/Erase[1]/TypeRelation[Convertible]: nil[#Somewhere?#]; name=nil
+// UNRESOLVED_OPT_4-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Convertible]: none[#Optional<Somewhere>#]; name=none
+// UNRESOLVED_OPT_4-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Convertible]: some({#Somewhere#})[#Optional<Somewhere>#];
+// UNRESOLVED_OPT_4-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: init({#str: String#})[#Optional<Somewhere>#]; name=init(str:)
+// UNRESOLVED_OPT_4-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Convertible]: nowhere[#Optional<Somewhere>#]; name=nowhere
 // UNRESOLVED_OPT_4-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem: map({#(self): Optional<Somewhere>#})[#((Somewhere) throws -> U) -> U?#];
 // UNRESOLVED_OPT_4-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem: flatMap({#(self): Optional<Somewhere>#})[#((Somewhere) throws -> U?) -> U?#];
 // UNRESOLVED_OPT_4-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem/TypeRelation[Invalid]: hash({#(self): Optional<Somewhere>#})[#(into: inout Hasher) -> Void#];
@@ -218,12 +218,12 @@ OptionSetTaker5([.#^UNRESOLVED_15?check=UNRESOLVED_1^#], .Option4, .South, .West
 
 OptionSetTaker6(.#^UNRESOLVED_16^#, .Option4)
 // UNRESOLVED_16:  Begin completions
-// UNRESOLVED_16-DAG:  Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: Option1[#SomeOptions1#];
-// UNRESOLVED_16-DAG:  Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: Option2[#SomeOptions1#];
-// UNRESOLVED_16-DAG:  Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: Option3[#SomeOptions1#];
-// UNRESOLVED_16-DAG:  Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: Option4[#SomeOptions2#];
-// UNRESOLVED_16-DAG:  Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: Option5[#SomeOptions2#];
-// UNRESOLVED_16-DAG:  Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: Option6[#SomeOptions2#];
+// UNRESOLVED_16-DAG:  Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: Option1[#SomeOptions1#];
+// UNRESOLVED_16-DAG:  Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: Option2[#SomeOptions1#];
+// UNRESOLVED_16-DAG:  Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: Option3[#SomeOptions1#];
+// UNRESOLVED_16-DAG:  Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: Option4[#SomeOptions2#];
+// UNRESOLVED_16-DAG:  Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: Option5[#SomeOptions2#];
+// UNRESOLVED_16-DAG:  Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: Option6[#SomeOptions2#];
 // UNRESOLVED_16-DAG:  Decl[StaticVar]/CurrNominal:        NotOption[#Int#]; name=NotOption
 // UNRESOLVED_16:  End completion
 
@@ -240,9 +240,9 @@ Container.EnumTaker1(.#^UNRESOLVED_20?check=UNRESOLVED_3^#
 func parserSync() {}
 
 // UNRESOLVED_4: Begin completions
-// UNRESOLVED_4-DAG: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: Option1[#SomeOptions1#]; name=Option1
-// UNRESOLVED_4-DAG: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: Option2[#SomeOptions1#]; name=Option2
-// UNRESOLVED_4-DAG: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: Option3[#SomeOptions1#]; name=Option3
+// UNRESOLVED_4-DAG: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: Option1[#SomeOptions1#]; name=Option1
+// UNRESOLVED_4-DAG: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: Option2[#SomeOptions1#]; name=Option2
+// UNRESOLVED_4-DAG: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: Option3[#SomeOptions1#]; name=Option3
 // UNRESOLVED_4-NOT: Option4
 // UNRESOLVED_4-NOT: Option5
 // UNRESOLVED_4-NOT: Option6
@@ -318,8 +318,8 @@ func testAvail1(_ x: EnumAvail1) {
 }
 // ENUM_AVAIL_1: Begin completions, 3 items
 // ENUM_AVAIL_1-NOT: AAA
-// ENUM_AVAIL_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: aaa[#EnumAvail1#];
-// ENUM_AVAIL_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/NotRecommended/TypeRelation[Identical]: BBB[#EnumAvail1#];
+// ENUM_AVAIL_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: aaa[#EnumAvail1#];
+// ENUM_AVAIL_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/NotRecommended/TypeRelation[Convertible]: BBB[#EnumAvail1#];
 // ENUM_AVAIL_1-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): EnumAvail1#})[#(into: inout Hasher) -> Void#];
 // ENUM_AVAIL_1-NOT: AAA
 // ENUM_AVAIL_1: End completions
@@ -329,9 +329,9 @@ func testAvail2(_ x: OptionsAvail1) {
 }
 // OPTIONS_AVAIL_1: Begin completions
 // OPTIONS_AVAIL_1-NOT: AAA
-// OPTIONS_AVAIL_1-DAG: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: aaa[#OptionsAvail1#];
-// OPTIONS_AVAIL_1-DAG: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/NotRecommended/TypeRelation[Identical]: BBB[#OptionsAvail1#];
-// OPTIONS_AVAIL_1-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Identical]: init({#rawValue: Int#})[#OptionsAvail1#]
+// OPTIONS_AVAIL_1-DAG: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: aaa[#OptionsAvail1#];
+// OPTIONS_AVAIL_1-DAG: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/NotRecommended/TypeRelation[Convertible]: BBB[#OptionsAvail1#];
+// OPTIONS_AVAIL_1-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: init({#rawValue: Int#})[#OptionsAvail1#]
 // OPTIONS_AVAIL_1-NOT: AAA
 // OPTIONS_AVAIL_1: End completions
 
@@ -345,7 +345,7 @@ func testWithLiteral1() {
   let s: S
   _ = s.takeEnum(thing: .#^WITH_LITERAL_1^#, other: 1.0)
 // WITH_LITERAL_1: Begin completions, 2 items
-// WITH_LITERAL_1-NEXT: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: myCase[#S.MyEnum#];
+// WITH_LITERAL_1-NEXT: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: myCase[#S.MyEnum#];
 // WITH_LITERAL_1-NEXT: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): S.MyEnum#})[#(into: inout Hasher) -> Void#];
 // WITH_LITERAL_1-NEXT: End completions
 }
@@ -370,7 +370,7 @@ func testWithLiteral3() {
     func test(s: S) {
       _ = s.takeEnum(thing: .#^WITH_LITERAL_3^#, other: 1.0)
 // WITH_LITERAL_3: Begin completions, 2 items
-// WITH_LITERAL_3-NEXT: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: myCase[#MyEnum#];
+// WITH_LITERAL_3-NEXT: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: myCase[#MyEnum#];
 // WITH_LITERAL_3-NEXT: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): MyEnum#})[#(into: inout Hasher) -> Void#];
 // WITH_LITERAL_3-NEXT: End completions
     }
@@ -387,9 +387,9 @@ func enumFromOtherFile() -> EnumFromOtherFile {
   return .#^OTHER_FILE_1^# // Don't crash.
 }
 // OTHER_FILE_1: Begin completions
-// OTHER_FILE_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: b({#String#})[#EnumFromOtherFile#];
-// OTHER_FILE_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: a({#Int#})[#EnumFromOtherFile#];
-// OTHER_FILE_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: c[#EnumFromOtherFile#];
+// OTHER_FILE_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: b({#String#})[#EnumFromOtherFile#];
+// OTHER_FILE_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: a({#Int#})[#EnumFromOtherFile#];
+// OTHER_FILE_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: c[#EnumFromOtherFile#];
 // OTHER_FILE_1: End completions
 
 struct NonOptSet {
@@ -408,11 +408,11 @@ func testNonOptSet() {
   x = .#^NON_OPT_SET_1^#
 }
 // NON_OPT_SET_1: Begin completions, 6 items
-// NON_OPT_SET_1-DAG: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]:    a[#NonOptSet#]
+// NON_OPT_SET_1-DAG: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]:    a[#NonOptSet#]
 // NON_OPT_SET_1-DAG: Decl[StaticVar]/CurrNominal:        wrongType[#Int#];
-// NON_OPT_SET_1-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Identical]:  init({#x: Int#}, {#y: Int#})[#NonOptSet#]
-// NON_OPT_SET_1-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Identical]:  init()[#NonOptSet#]
-// NON_OPT_SET_1-DAG: Decl[StaticMethod]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: b()[#NonOptSet#]
+// NON_OPT_SET_1-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]:  init({#x: Int#}, {#y: Int#})[#NonOptSet#]
+// NON_OPT_SET_1-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]:  init()[#NonOptSet#]
+// NON_OPT_SET_1-DAG: Decl[StaticMethod]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: b()[#NonOptSet#]
 // NON_OPT_SET_1-DAG: Decl[InstanceMethod]/CurrNominal: notStatic({#(self): NonOptSet#})[#() -> NonOptSet#];
 // NON_OPT_SET_1: End completions
 
@@ -431,8 +431,8 @@ func testInStringInterpolation() {
   let y = "enum: \(.#^STRING_INTERPOLATION_INVALID?check=NOCRASH^#)" // Dont'crash.
 }
 // STRING_INTERPOLATION_1: Begin completions
-// STRING_INTERPOLATION_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: foo[#MyEnum#];
-// STRING_INTERPOLATION_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: bar[#MyEnum#];
+// STRING_INTERPOLATION_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: foo[#MyEnum#];
+// STRING_INTERPOLATION_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: bar[#MyEnum#];
 // STRING_INTERPOLATION_1: End completions
 
 class BaseClass {
@@ -451,11 +451,11 @@ func testSubType() {
   var _: BaseClass = .#^SUBTYPE_1^#
 }
 // SUBTYPE_1: Begin completions, 6 items
-// SUBTYPE_1-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Identical]: init()[#BaseClass#];
+// SUBTYPE_1-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: init()[#BaseClass#];
 // SUBTYPE_1-DAG: Decl[Class]/CurrNominal/TypeRelation[Convertible]: SubClass[#BaseClass.SubClass#];
 // SUBTYPE_1-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Convertible]: subInstance[#BaseClass.SubClass#];
 // SUBTYPE_1-DAG: Decl[Constructor]/CurrNominal:      init({#failable: Void#})[#BaseClass?#];
-// SUBTYPE_1-DAG: Decl[TypeAlias]/Super/TypeRelation[Identical]: Concrete1[#BaseClass#];
+// SUBTYPE_1-DAG: Decl[TypeAlias]/Super/TypeRelation[Convertible]: Concrete1[#BaseClass#];
 // SUBTYPE_1-DAG: Decl[TypeAlias]/Super:              Concrete2[#AnotherTy#];
 // SUBTYPE_1: End completions
 
@@ -486,14 +486,14 @@ switch Generic<Int>.empty {
 case let .#^GENERIC_4?check=GENERIC_1_INT^#
 }
 // GENERIC_1_INT: Begin completions
-// GENERIC_1_INT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: contains({#content: Int#})[#Generic<Int>#];
-// GENERIC_1_INT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: empty[#Generic<Int>#];
+// GENERIC_1_INT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: contains({#content: Int#})[#Generic<Int>#];
+// GENERIC_1_INT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: empty[#Generic<Int>#];
 // GENERIC_1_INT: End completions
 
 // GENERIC_1_U: Begin completions
-// GENERIC_1_U-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: contains({#content: U#})[#Generic<U>#];
-// GENERIC_1_U-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: empty[#Generic<U>#];
-// GENERIC_1_U-DAG: Decl[StaticMethod]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: create({#U#})[#Generic<U>#];
+// GENERIC_1_U-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: contains({#content: U#})[#Generic<U>#];
+// GENERIC_1_U-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: empty[#Generic<U>#];
+// GENERIC_1_U-DAG: Decl[StaticMethod]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: create({#U#})[#Generic<U>#];
 // GENERIC_1_U: End completions
 
 struct HasCreator {
@@ -504,7 +504,7 @@ func testHasStaticClosure() {
   let _: HasCreator = .#^STATIC_CLOSURE_1^#
 }
 // STATIC_CLOSURE_1: Begin completions, 3 items
-// STATIC_CLOSURE_1-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Identical]: init()[#HasCreator#];
+// STATIC_CLOSURE_1-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: init()[#HasCreator#];
 // FIXME: Suggest 'create()[#HasCreateor#]', not 'create'.
 // STATIC_CLOSURE_1-DAG: Decl[StaticVar]/CurrNominal:        create[#() -> HasCreator#];
 // STATIC_CLOSURE_1-DAG: Decl[StaticVar]/CurrNominal:        create_curried[#() -> () -> HasCreator#];
@@ -519,11 +519,11 @@ struct HasOverloaded {
 func testOverload(val: HasOverloaded) {
   let _ = val.takeEnum(.#^OVERLOADED_METHOD_1^#)
 // OVERLOADED_METHOD_1: Begin completions, 6 items
-// OVERLOADED_METHOD_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: South[#SomeEnum1#]; name=South
-// OVERLOADED_METHOD_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: North[#SomeEnum1#]; name=North
+// OVERLOADED_METHOD_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: South[#SomeEnum1#]; name=South
+// OVERLOADED_METHOD_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: North[#SomeEnum1#]; name=North
 // OVERLOADED_METHOD_1-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): SomeEnum1#})[#(into: inout Hasher) -> Void#];
-// OVERLOADED_METHOD_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: East[#SomeEnum2#]; name=East
-// OVERLOADED_METHOD_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: West[#SomeEnum2#]; name=West
+// OVERLOADED_METHOD_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: East[#SomeEnum2#]; name=East
+// OVERLOADED_METHOD_1-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: West[#SomeEnum2#]; name=West
 // OVERLOADED_METHOD_1-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): SomeEnum2#})[#(into: inout Hasher) -> Void#];
 // OVERLOADED_METHOD_1: End completions
 
@@ -541,7 +541,7 @@ func receiveHasStatic<T: HasStatic>(x: T)  {}
 func testingGenericParam1<T: HasStatic>(x: inout T, fn: (T) -> Void) -> T {
   x = .#^GENERICPARAM_1^#
 // GENERICPARAM_1: Begin completions, 1 items
-// GENERICPARAM_1: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: instance[#HasStatic#]; name=instance
+// GENERICPARAM_1: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: instance[#HasStatic#]; name=instance
 // GENERICPARAM_1: End completions
 
   /* Parser sync. */;
@@ -649,7 +649,7 @@ func receiveMyStructOfMyProtocol<T: MyProtocol>(value: MyStruct<T>) {}
 func testTypeParamInContextType() {
   receiveMyStructOfMyProtocol(value: .#^TYPEPARAM_IN_CONTEXTTYPE_1^#)
 // TYPEPARAM_IN_CONTEXTTYPE_1: Begin completions, 3 items
-// TYPEPARAM_IN_CONTEXTTYPE_1-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Identical]:      init()[#MyStruct<MyProtocol>#];
+// TYPEPARAM_IN_CONTEXTTYPE_1-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]:      init()[#MyStruct<MyProtocol>#];
 // TYPEPARAM_IN_CONTEXTTYPE_1-DAG: Decl[StaticVar]/CurrNominal/TypeRelation[Convertible]: myProtocolOption[#MyStruct<ConcreteMyProtocol>#];
 // TYPEPARAM_IN_CONTEXTTYPE_1-DAG: Decl[StaticVar]/CurrNominal:        otherProtocolOption[#MyStruct<ConcreteOtherProtocol>#];
 // TYPEPARAM_IN_CONTEXTTYPE_1: End completions
@@ -672,7 +672,7 @@ func testTernaryOperator2(cond: Bool) {
   func sync(){}
   let _: SomeEnum1 = .#^TERNARY_CONDITION^# ? .bogus : .bogus
 // TERNARY_CONDITION: Begin completions
-// TERNARY_CONDITION-DAG: Decl[Constructor]/CurrNominal/IsSystem/TypeRelation[Identical]: init()[#Bool#]; name=init()
+// TERNARY_CONDITION-DAG: Decl[Constructor]/CurrNominal/IsSystem/TypeRelation[Convertible]: init()[#Bool#]; name=init()
 // TERNARY_CONDITION: End completions
 }
 
@@ -683,11 +683,11 @@ func testClosureReturnTypeForOverloaded() {
     .#^OVERLOADED_CLOSURE_RETURN^#
   }
 // OVERLOADED_CLOSURE_RETURN: Begin completions, 6 items
-// OVERLOADED_CLOSURE_RETURN-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: South[#SomeEnum1#];
-// OVERLOADED_CLOSURE_RETURN-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: North[#SomeEnum1#];
+// OVERLOADED_CLOSURE_RETURN-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: South[#SomeEnum1#];
+// OVERLOADED_CLOSURE_RETURN-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: North[#SomeEnum1#];
 // OVERLOADED_CLOSURE_RETURN-DAG: Decl[InstanceMethod]/CurrNominal:   hash({#(self): SomeEnum1#})[#(into: inout Hasher) -> Void#];
-// OVERLOADED_CLOSURE_RETURN-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: East[#SomeEnum2#];
-// OVERLOADED_CLOSURE_RETURN-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: West[#SomeEnum2#];
+// OVERLOADED_CLOSURE_RETURN-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: East[#SomeEnum2#];
+// OVERLOADED_CLOSURE_RETURN-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: West[#SomeEnum2#];
 // OVERLOADED_CLOSURE_RETURN-DAG: Decl[InstanceMethod]/CurrNominal:   hash({#(self): SomeEnum2#})[#(into: inout Hasher) -> Void#];
 // OVERLOADED_CLOSURE_RETURN: End completions
 }
@@ -720,12 +720,12 @@ func testSameType() {
   testSugarType(.#^SUGAR_TYPE^#
 // Ensure results aren't duplicated.
 // SUGAR_TYPE: Begin completions, 9 items
-// SUGAR_TYPE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: South[#SomeEnum1#];
-// SUGAR_TYPE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: North[#SomeEnum1#];
+// SUGAR_TYPE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: South[#SomeEnum1#];
+// SUGAR_TYPE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: North[#SomeEnum1#];
 // SUGAR_TYPE-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): SomeEnum1#})[#(into: inout Hasher) -> Void#];
-// SUGAR_TYPE-DAG: Keyword[nil]/None/Erase[1]/TypeRelation[Identical]: nil[#SomeEnum1?#];
-// SUGAR_TYPE-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Identical]: none[#Optional<SomeEnum1>#];
-// SUGAR_TYPE-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Identical]: some({#SomeEnum1#})[#Optional<SomeEnum1>#];
+// SUGAR_TYPE-DAG: Keyword[nil]/None/Erase[1]/TypeRelation[Convertible]: nil[#SomeEnum1?#];
+// SUGAR_TYPE-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Convertible]: none[#Optional<SomeEnum1>#];
+// SUGAR_TYPE-DAG: Decl[EnumElement]/CurrNominal/IsSystem/TypeRelation[Convertible]: some({#SomeEnum1#})[#Optional<SomeEnum1>#];
 // SUGAR_TYPE-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem: map({#(self): Optional<SomeEnum1>#})[#((SomeEnum1) throws -> U) -> U?#];
 // SUGAR_TYPE-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem: flatMap({#(self): Optional<SomeEnum1>#})[#((SomeEnum1) throws -> U?) -> U?#];
 // SUGAR_TYPE-DAG: Decl[InstanceMethod]/CurrNominal/IsSystem/TypeRelation[Invalid]: hash({#(self): Optional<SomeEnum1>#})[#(into: inout Hasher) -> Void#];

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -142,36 +142,36 @@ var fooObject: FooStruct
 // FOO_OBJECT_DOT-NEXT: Keyword[self]/CurrNominal: self[#FooStruct#]; name=self
 // FOO_OBJECT_DOT-NEXT: Decl[InstanceVar]/CurrNominal:    lazyInstanceVar[#Int#]{{; name=.+$}}
 // FOO_OBJECT_DOT-NEXT: Decl[InstanceVar]/CurrNominal:    instanceVar[#Int#]{{; name=.+$}}
-// FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Identical\])?}}: instanceFunc0()[#Void#]{{; name=.+$}}
-// FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Identical\])?}}: instanceFunc1({#(a): Int#})[#Void#]{{; name=.+$}}
-// FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Identical\])?}}: instanceFunc2({#(a): Int#}, {#b: &Double#})[#Void#]{{; name=.+$}}
-// FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Identical\])?}}: instanceFunc3({#(a): Int#}, {#(Float, Double)#})[#Void#]{{; name=.+$}}
-// FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Identical\])?}}: instanceFunc4({#(a): Int?#}, {#b: Int!#}, {#c: &Int?#}, {#d: &Int!#})[#Void#]{{; name=.+$}}
+// FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Convertible\])?}}: instanceFunc0()[#Void#]{{; name=.+$}}
+// FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Convertible\])?}}: instanceFunc1({#(a): Int#})[#Void#]{{; name=.+$}}
+// FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Convertible\])?}}: instanceFunc2({#(a): Int#}, {#b: &Double#})[#Void#]{{; name=.+$}}
+// FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Convertible\])?}}: instanceFunc3({#(a): Int#}, {#(Float, Double)#})[#Void#]{{; name=.+$}}
+// FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Convertible\])?}}: instanceFunc4({#(a): Int?#}, {#b: Int!#}, {#c: &Int?#}, {#d: &Int!#})[#Void#]{{; name=.+$}}
 // FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: instanceFunc5()[#Int?#]{{; name=.+$}}
 // FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: instanceFunc6()[#Int!#]{{; name=.+$}}
-// FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Identical\])?}}: instanceFunc7({#a: Int#})[#Void#]{{; name=.+$}}
-// FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Identical\])?}}: instanceFunc8({#(a): (Int, Int)#})[#Void#]{{; name=.+$}}
-// FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Identical\])?}}: instanceFunc9({#a: Int#})[#Void#]{{; name=.+$}}
-// FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Identical\])?}}: instanceFunc10({#arg: Int#})[#Void#]{{; name=.+$}}
-// FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Identical\])?}}: instanceFunc10({#arg: Int#}, {#optArg: Int#})[#Void#]{{; name=.+$}}
+// FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Convertible\])?}}: instanceFunc7({#a: Int#})[#Void#]{{; name=.+$}}
+// FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Convertible\])?}}: instanceFunc8({#(a): (Int, Int)#})[#Void#]{{; name=.+$}}
+// FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Convertible\])?}}: instanceFunc9({#a: Int#})[#Void#]{{; name=.+$}}
+// FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Convertible\])?}}: instanceFunc10({#arg: Int#})[#Void#]{{; name=.+$}}
+// FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Convertible\])?}}: instanceFunc10({#arg: Int#}, {#optArg: Int#})[#Void#]{{; name=.+$}}
 //
-// FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Identical\])?}}: varargInstanceFunc0({#(v): Int...#})[#Void#]{{; name=.+$}}
-// FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Identical\])?}}: varargInstanceFunc1({#(a): Float#}, {#v: Int...#})[#Void#]{{; name=.+$}}
-// FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Identical\])?}}: varargInstanceFunc2({#(a): Float#}, {#b: Double#}, {#v: Int...#})[#Void#]{{; name=.+$}}
+// FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Convertible\])?}}: varargInstanceFunc0({#(v): Int...#})[#Void#]{{; name=.+$}}
+// FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Convertible\])?}}: varargInstanceFunc1({#(a): Float#}, {#v: Int...#})[#Void#]{{; name=.+$}}
+// FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Convertible\])?}}: varargInstanceFunc2({#(a): Float#}, {#b: Double#}, {#v: Int...#})[#Void#]{{; name=.+$}}
 //
 // FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: overloadedInstanceFunc1()[#Int#]{{; name=.+$}}
 // FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: overloadedInstanceFunc1()[#Double#]{{; name=.+$}}
 // FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: overloadedInstanceFunc2({#(x): Int#})[#Int#]{{; name=.+$}}
 // FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: overloadedInstanceFunc2({#(x): Double#})[#Int#]{{; name=.+$}}
 // FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: builderFunc1({#(a): Int#})[#FooStruct#]{{; name=.+$}}
-// FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Identical\])?}}: selectorVoidFunc1({#(a): Int#}, {#b: Float#})[#Void#]{{; name=.+$}}
-// FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Identical\])?}}: selectorVoidFunc2({#(a): Int#}, {#b: Float#}, {#c: Double#})[#Void#]{{; name=.+$}}
-// FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Identical\])?}}: selectorVoidFunc3({#(a): Int#}, {#b: (Float, Double)#})[#Void#]{{; name=.+$}}
+// FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Convertible\])?}}: selectorVoidFunc1({#(a): Int#}, {#b: Float#})[#Void#]{{; name=.+$}}
+// FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Convertible\])?}}: selectorVoidFunc2({#(a): Int#}, {#b: Float#}, {#c: Double#})[#Void#]{{; name=.+$}}
+// FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Convertible\])?}}: selectorVoidFunc3({#(a): Int#}, {#b: (Float, Double)#})[#Void#]{{; name=.+$}}
 // FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: selectorStringFunc1({#(a): Int#}, {#b: Float#})[#String#]{{; name=.+$}}
 // FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: selectorStringFunc2({#(a): Int#}, {#b: Float#}, {#c: Double#})[#String#]{{; name=.+$}}
 // FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal: selectorStringFunc3({#(a): Int#}, {#b: (Float, Double)#})[#String#]{{; name=.+$}}
 // FOO_OBJECT_DOT-NEXT: Decl[InstanceVar]/CurrNominal:    extProp[#Int#]{{; name=.+$}}
-// FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Identical\])?}}: extFunc0()[#Void#]{{; name=.+$}}
+// FOO_OBJECT_DOT-NEXT: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Convertible\])?}}: extFunc0()[#Void#]{{; name=.+$}}
 // FOO_OBJECT_DOT-NEXT: End completions
 
 // FOO_OBJECT_NO_DOT: Begin completions
@@ -439,8 +439,8 @@ func testSwitch1() {
 }
 
 // IN_SWITCH_CASE: Begin completions
-// IN_SWITCH_CASE-DAG: Decl[GlobalVar]/CurrModule{{(/TypeRelation\[Identical\])?}}: fooObject[#FooStruct#]{{; name=.+$}}
-// IN_SWITCH_CASE-DAG: Decl[Struct]/CurrModule{{(/TypeRelation\[Identical\])?}}:    FooStruct[#FooStruct#]{{; name=.+$}}
+// IN_SWITCH_CASE-DAG: Decl[GlobalVar]/CurrModule{{(/TypeRelation\[Convertible\])?}}: fooObject[#FooStruct#]{{; name=.+$}}
+// IN_SWITCH_CASE-DAG: Decl[Struct]/CurrModule{{(/TypeRelation\[Convertible\])?}}:    FooStruct[#FooStruct#]{{; name=.+$}}
 // IN_SWITCH_CASE: End completions
 
 //===--- Helper types that are used in this test
@@ -1959,7 +1959,7 @@ struct SimpleStruct {
 }
 // SIMPLE_OBJECT_DOT: Begin completions
 // SIMPLE_OBJECT_DOT-DAG: Keyword[self]/CurrNominal:          self[#SimpleStruct#]; name=self
-// SIMPLE_OBJECT_DOT-DAG: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Identical\])?}}: foo()[#SimpleStruct#]; name=foo()
+// SIMPLE_OBJECT_DOT-DAG: Decl[InstanceMethod]/CurrNominal{{(/TypeRelation\[Convertible\])?}}: foo()[#SimpleStruct#]; name=foo()
 // SIMPLE_OBJECT_DOT: End completions
 func testInCollectionLiteral(value: SimpleStruct) {
   let _ = [
@@ -2045,7 +2045,7 @@ func testRdar90136020() {
     let a: Int64 = #^RDAR90136020^#
 // RDAR90136020: Begin completions
 // RDAR90136020-NOT: name=Int64{{$}}
-// RDAR90136020: Decl[Struct]/OtherModule[Swift]/IsSystem/TypeRelation[Identical]: Int64[#Int64#]; name=Int64
+// RDAR90136020: Decl[Struct]/OtherModule[Swift]/IsSystem/TypeRelation[Convertible]: Int64[#Int64#]; name=Int64
 // RDAR90136020-NOT: name=Int64{{$}}
 // RDAR90136020: End completions
 }

--- a/test/IDE/complete_value_literals.swift
+++ b/test/IDE/complete_value_literals.swift
@@ -61,12 +61,12 @@ func testNil0() {
 func testNil1() {
   let x: MyNil1 = #^NIL_1^#
 }
-// NIL_1: Literal[Nil]/None/TypeRelation[Identical]: nil[#MyNil1#];
+// NIL_1: Literal[Nil]/None/TypeRelation[Convertible]: nil[#MyNil1#];
 
 func testNil2() {
   let x: Int? = #^NIL_2^#
 }
-// NIL_2: Literal[Nil]/None/TypeRelation[Identical]: nil[#Int?#];
+// NIL_2: Literal[Nil]/None/TypeRelation[Convertible]: nil[#Int?#];
 
 func testBool0() {
   let x: Int = #^BOOL_0^#
@@ -77,14 +77,14 @@ func testBool0() {
 func testBool1() {
   let x: MyBool1 = #^BOOL_1^#
 }
-// BOOL_1: Literal[Boolean]/None/TypeRelation[Identical]: true[#MyBool1#];
-// BOOL_1: Literal[Boolean]/None/TypeRelation[Identical]: false[#MyBool1#];
+// BOOL_1: Literal[Boolean]/None/TypeRelation[Convertible]: true[#MyBool1#];
+// BOOL_1: Literal[Boolean]/None/TypeRelation[Convertible]: false[#MyBool1#];
 
 func testBool2() {
   let x: Bool = #^BOOL_2^#
 }
-// BOOL_2: Literal[Boolean]/None/TypeRelation[Identical]: true[#Bool#];
-// BOOL_2: Literal[Boolean]/None/TypeRelation[Identical]: false[#Bool#];
+// BOOL_2: Literal[Boolean]/None/TypeRelation[Convertible]: true[#Bool#];
+// BOOL_2: Literal[Boolean]/None/TypeRelation[Convertible]: false[#Bool#];
 
 func testBool3() {
   let x: Bool? = #^BOOL_3^#
@@ -106,17 +106,17 @@ func testInt0() {
 func testInt1() {
   let x: MyInt1 = #^INT_1^#
 }
-// INT_1: Literal[Integer]/None/TypeRelation[Identical]: 0[#MyInt1#];
+// INT_1: Literal[Integer]/None/TypeRelation[Convertible]: 0[#MyInt1#];
 
 func testInt2() {
   let x: Int = #^INT_2^#
 }
-// INT_2: Literal[Integer]/None/TypeRelation[Identical]: 0[#Int#];
+// INT_2: Literal[Integer]/None/TypeRelation[Convertible]: 0[#Int#];
 
 func testDouble0() {
   let x: Double = #^DOUBLE_0^#
 }
-// DOUBLE_0: Literal[Integer]/None/TypeRelation[Identical]: 0[#Double#];
+// DOUBLE_0: Literal[Integer]/None/TypeRelation[Convertible]: 0[#Double#];
 
 func testString0() {
   let x: Int = #^STRING_0^#
@@ -126,25 +126,25 @@ func testString0() {
 func testString1() {
   let x: MyString1 = #^STRING_1^#
 }
-// STRING_1: Literal[String]/None/TypeRelation[Identical]: "{#(abc)#}"[#MyString1#];
+// STRING_1: Literal[String]/None/TypeRelation[Convertible]: "{#(abc)#}"[#MyString1#];
 
 func testString2() {
   let x: String = #^STRING_2^#
 }
-// STRING_2: Literal[String]/None/TypeRelation[Identical]: "{#(abc)#}"[#String#];
+// STRING_2: Literal[String]/None/TypeRelation[Convertible]: "{#(abc)#}"[#String#];
 
 func testString3() {
   let x: MyUnicodeScalar1 = #^STRING_3^#
 }
-// STRING_3: Literal[String]/None/TypeRelation[Identical]: "{#(abc)#}"[#MyUnicodeScalar1#];
+// STRING_3: Literal[String]/None/TypeRelation[Convertible]: "{#(abc)#}"[#MyUnicodeScalar1#];
 func testString4() {
   let x: MyCharacter1 = #^STRING_4^#
 }
-// STRING_4: Literal[String]/None/TypeRelation[Identical]: "{#(abc)#}"[#MyCharacter1#];
+// STRING_4: Literal[String]/None/TypeRelation[Convertible]: "{#(abc)#}"[#MyCharacter1#];
 func testString5() {
   let x: Character = #^STRING_5^#
 }
-// STRING_5: Literal[String]/None/TypeRelation[Identical]: "{#(abc)#}"[#Character#];
+// STRING_5: Literal[String]/None/TypeRelation[Convertible]: "{#(abc)#}"[#Character#];
 
 func testArray0() {
   let x: Int = #^ARRAY_0^#
@@ -154,12 +154,12 @@ func testArray0() {
 func testArray1() {
   let x: MyArray1<MyInt1> = #^ARRAY_1^#
 }
-// ARRAY_1: Literal[Array]/None/TypeRelation[Identical]: [{#(values)#}][#MyArray1<MyInt1>#];
+// ARRAY_1: Literal[Array]/None/TypeRelation[Convertible]: [{#(values)#}][#MyArray1<MyInt1>#];
 
 func testArray2() {
   let x: [MyInt1] = #^ARRAY_2^#
 }
-// ARRAY_2: Literal[Array]/None/TypeRelation[Identical]: [{#(values)#}][#[MyInt1]#];
+// ARRAY_2: Literal[Array]/None/TypeRelation[Convertible]: [{#(values)#}][#[MyInt1]#];
 
 func testDict0() {
   let x: Int = #^DICT_0^#
@@ -169,12 +169,12 @@ func testDict0() {
 func testDict1() {
   let x: MyDict1<MyInt1, MyString1> = #^DICT_1^#
 }
-// DICT_1: Literal[Dictionary]/None/TypeRelation[Identical]: [{#(key)#}: {#(value)#}][#MyDict1<MyInt1, MyString1>#];
+// DICT_1: Literal[Dictionary]/None/TypeRelation[Convertible]: [{#(key)#}: {#(value)#}][#MyDict1<MyInt1, MyString1>#];
 
 func testDict2() {
   let x: [MyInt1: MyString1] = #^DICT_2^#
 }
-// DICT_2: Literal[Dictionary]/None/TypeRelation[Identical]: [{#(key)#}: {#(value)#}][#[MyInt1 : MyString1]#];
+// DICT_2: Literal[Dictionary]/None/TypeRelation[Convertible]: [{#(key)#}: {#(value)#}][#[MyInt1 : MyString1]#];
 
 func testTuple0() {
   let x: Int = #^TUPLE_0^#
@@ -184,13 +184,13 @@ func testTuple0() {
 func testTuple1() {
   let x: (MyInt1, MyString1) = #^TUPLE_1^#
 }
-// TUPLE_1: Literal[Tuple]/None/TypeRelation[Identical]: ({#(values)#})[#(MyInt1, MyString1)#];
+// TUPLE_1: Literal[Tuple]/None/TypeRelation[Convertible]: ({#(values)#})[#(MyInt1, MyString1)#];
 
 func testTuple2() {
   let x: (MyInt1, MyString1, MyDouble1) = #^TUPLE_2^#
 }
 // FIXME: should we extend the tuple to have the right number of elements?
-// TUPLE_2: Literal[Tuple]/None/TypeRelation[Identical]: ({#(values)#})[#(MyInt1, MyString1, MyDouble1)#];
+// TUPLE_2: Literal[Tuple]/None/TypeRelation[Convertible]: ({#(values)#})[#(MyInt1, MyString1, MyDouble1)#];
 
 struct MyColor1: _ExpressibleByColorLiteral {
   init(_colorLiteralRed: Float, green: Float, blue: Float, alpha: Float) {}
@@ -203,7 +203,7 @@ func testColor0() {
 func testColor1() {
   let x: MyColor1 = #^COLOR_1^#
 }
-// COLOR_1: Literal[_Color]/None/TypeRelation[Identical]: #colorLiteral({#red: Float#}, {#green: Float#}, {#blue: Float#}, {#alpha: Float#})[#MyColor1#];
+// COLOR_1: Literal[_Color]/None/TypeRelation[Convertible]: #colorLiteral({#red: Float#}, {#green: Float#}, {#blue: Float#}, {#alpha: Float#})[#MyColor1#];
 
 func testColor2() {
   let x: MyColor1? = #^COLOR_2^#
@@ -221,4 +221,4 @@ func testImage0() {
 func testImage1() {
   let x: MyImage1 = #^IMAGE_1^#
 }
-// IMAGE_1: Literal[_Image]/None/TypeRelation[Identical]: #imageLiteral({#resourceName: String#})[#MyImage1#];
+// IMAGE_1: Literal[_Image]/None/TypeRelation[Convertible]: #imageLiteral({#resourceName: String#})[#MyImage1#];

--- a/test/SourceKit/CodeComplete/complete_typerelation.swift
+++ b/test/SourceKit/CodeComplete/complete_typerelation.swift
@@ -47,7 +47,7 @@ func testUnknown() {
 
 // BOOLCONTEXT-LABEL: key.name: "false",
 // BOOLCONTEXT:       key.typename: "Bool",
-// BOOLCONTEXT:       key.typerelation: source.codecompletion.typerelation.identical,
+// BOOLCONTEXT:       key.typerelation: source.codecompletion.typerelation.convertible,
 // BOOLCONTEXT-LABEL: }
 // BOOLCONTEXT-LABEL: key.name: "Int",
 // BOOLCONTEXT:       key.typename: "Int",
@@ -59,7 +59,7 @@ func testUnknown() {
 // BOOLCONTEXT-LABEL: }
 // BOOLCONTEXT-LABEL: key.name: "true",
 // BOOLCONTEXT:       key.typename: "Bool",
-// BOOLCONTEXT:       key.typerelation: source.codecompletion.typerelation.identical,
+// BOOLCONTEXT:       key.typerelation: source.codecompletion.typerelation.convertible,
 // BOOLCONTEXT-LABEL: }
 
 // OPTIONALCONTEXT-LABEL: key.name: "false",
@@ -72,7 +72,7 @@ func testUnknown() {
 // OPTIONALCONTEXT-LABEL: }
 // OPTIONALCONTEXT-LABEL: key.name: "nil",
 // OPTIONALCONTEXT:       key.typename: "Int?",
-// OPTIONALCONTEXT:       key.typerelation: source.codecompletion.typerelation.identical,
+// OPTIONALCONTEXT:       key.typerelation: source.codecompletion.typerelation.convertible,
 // OPTIONALCONTEXT-LABEL: }
 // OPTIONALCONTEXT-LABEL: key.name: "true",
 // OPTIONALCONTEXT:       key.typename: "Bool",

--- a/test/SourceKit/CodeComplete/complete_typerelation.swift.identical.response
+++ b/test/SourceKit/CodeComplete/complete_typerelation.swift.identical.response
@@ -7,7 +7,7 @@
       key.description: "bar(Int)",
       key.typename: "MyEnum",
       key.context: source.codecompletion.context.thisclass,
-      key.typerelation: source.codecompletion.typerelation.identical,
+      key.typerelation: source.codecompletion.typerelation.convertible,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:21complete_typerelation6MyEnumO3baryACSicACmF",
       key.modulename: "complete_typerelation"
@@ -19,7 +19,7 @@
       key.description: "foo",
       key.typename: "MyEnum",
       key.context: source.codecompletion.context.thisclass,
-      key.typerelation: source.codecompletion.typerelation.identical,
+      key.typerelation: source.codecompletion.typerelation.convertible,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:21complete_typerelation6MyEnumO3fooyA2CmF",
       key.modulename: "complete_typerelation"
@@ -78,7 +78,7 @@
       key.description: "staticReturnMyEnum()",
       key.typename: "MyEnum",
       key.context: source.codecompletion.context.thisclass,
-      key.typerelation: source.codecompletion.typerelation.identical,
+      key.typerelation: source.codecompletion.typerelation.convertible,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:21complete_typerelation6MyEnumO012staticReturncD0ACyFZ",
       key.modulename: "complete_typerelation"

--- a/test/SourceKit/CodeComplete/complete_unresolvedmember.swift.response
+++ b/test/SourceKit/CodeComplete/complete_unresolvedmember.swift.response
@@ -7,7 +7,7 @@
       key.description: "create()",
       key.typename: "Foo",
       key.context: source.codecompletion.context.exprspecific,
-      key.typerelation: source.codecompletion.typerelation.identical,
+      key.typerelation: source.codecompletion.typerelation.convertible,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:25complete_unresolvedmember3FooO6createACyFZ",
       key.modulename: "complete_unresolvedmember"
@@ -19,7 +19,7 @@
       key.description: "east",
       key.typename: "Foo",
       key.context: source.codecompletion.context.exprspecific,
-      key.typerelation: source.codecompletion.typerelation.identical,
+      key.typerelation: source.codecompletion.typerelation.convertible,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:25complete_unresolvedmember3FooO4eastyA2CmF",
       key.modulename: "complete_unresolvedmember"
@@ -31,7 +31,7 @@
       key.description: "init(i: Int)",
       key.typename: "Foo",
       key.context: source.codecompletion.context.thisclass,
-      key.typerelation: source.codecompletion.typerelation.identical,
+      key.typerelation: source.codecompletion.typerelation.convertible,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:25complete_unresolvedmember3FooO1iACSi_tcfc",
       key.modulename: "complete_unresolvedmember"
@@ -43,7 +43,7 @@
       key.description: "init(s: String)",
       key.typename: "Foo",
       key.context: source.codecompletion.context.thisclass,
-      key.typerelation: source.codecompletion.typerelation.identical,
+      key.typerelation: source.codecompletion.typerelation.convertible,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:25complete_unresolvedmember3FooO1sACSS_tcfc",
       key.modulename: "complete_unresolvedmember"
@@ -55,7 +55,7 @@
       key.description: "instance",
       key.typename: "Foo",
       key.context: source.codecompletion.context.exprspecific,
-      key.typerelation: source.codecompletion.typerelation.identical,
+      key.typerelation: source.codecompletion.typerelation.convertible,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:25complete_unresolvedmember3FooO8instanceACvpZ",
       key.modulename: "complete_unresolvedmember"
@@ -67,7 +67,7 @@
       key.description: "other(String)",
       key.typename: "Foo",
       key.context: source.codecompletion.context.exprspecific,
-      key.typerelation: source.codecompletion.typerelation.identical,
+      key.typerelation: source.codecompletion.typerelation.convertible,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:25complete_unresolvedmember3FooO5otheryACSScACmF",
       key.modulename: "complete_unresolvedmember"
@@ -79,7 +79,7 @@
       key.description: "west",
       key.typename: "Foo",
       key.context: source.codecompletion.context.exprspecific,
-      key.typerelation: source.codecompletion.typerelation.identical,
+      key.typerelation: source.codecompletion.typerelation.convertible,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:25complete_unresolvedmember3FooO4westyA2CmF",
       key.modulename: "complete_unresolvedmember"

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -682,7 +682,6 @@ static ResultBucket getResultBucket(Item &item, bool hasRequiredTypes,
   case CodeCompletionResultKind::Declaration:
     switch (completion->getExpectedTypeRelation()) {
     case swift::ide::CodeCompletionResultTypeRelation::Convertible:
-    case swift::ide::CodeCompletionResultTypeRelation::Identical:
       return ResultBucket::NormalTypeMatch;
     case swift::ide::CodeCompletionResultTypeRelation::NotApplicable:
     case swift::ide::CodeCompletionResultTypeRelation::Unknown:

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -518,7 +518,6 @@ bool SwiftToSourceKitCompletionAdapter::handleResult(
   static UIdent CCTypeRelUnrelated("source.codecompletion.typerelation.unrelated");
   static UIdent CCTypeRelInvalid("source.codecompletion.typerelation.invalid");
   static UIdent CCTypeRelConvertible("source.codecompletion.typerelation.convertible");
-  static UIdent CCTypeRelIdentical("source.codecompletion.typerelation.identical");
 
   switch (Result->getExpectedTypeRelation()) {
   case CodeCompletionResultTypeRelation::NotApplicable:
@@ -531,8 +530,6 @@ bool SwiftToSourceKitCompletionAdapter::handleResult(
     Info.TypeRelation = CCTypeRelInvalid; break;
   case CodeCompletionResultTypeRelation::Convertible:
     Info.TypeRelation = CCTypeRelConvertible; break;
-  case CodeCompletionResultTypeRelation::Identical:
-    Info.TypeRelation = CCTypeRelIdentical; break;
   }
 
   Info.ModuleName = Result->getModuleName();

--- a/validation-test/IDE/crashers_2_fixed/sr14494.swift
+++ b/validation-test/IDE/crashers_2_fixed/sr14494.swift
@@ -32,6 +32,6 @@ struct BottomMenu: MyView {
 }
 
 // CHECK: Begin completions, 2 items
-// CHECK: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Identical]: center[#MyAlignment#]; name=center
-// CHECK: Decl[Constructor]/CurrNominal/TypeRelation[Identical]: init()[#MyAlignment#]; name=init()
+// CHECK: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: center[#MyAlignment#]; name=center
+// CHECK: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: init()[#MyAlignment#]; name=init()
 // CHECK: End completions

--- a/validation-test/IDE/crashers_fixed/assign-anyobject.swift
+++ b/validation-test/IDE/crashers_fixed/assign-anyobject.swift
@@ -2,4 +2,4 @@
 var bar: AnyObject
 var foo: AnyObject
 foo = #^A^#
-// CHECK: Decl[GlobalVar]/Local/TypeRelation[Identical]: foo[#AnyObject#];
+// CHECK: Decl[GlobalVar]/Local/TypeRelation[Convertible]: foo[#AnyObject#];


### PR DESCRIPTION
I think that preferring identical over convertible makes sense in e.g. C++ where we have implicit user-defined type conversions but since we don’t have them in Swift, I think the distinction doesn’t make too much sense, because if we have a `func foo(x: Int?)`, want don’t really want to  prioritize variables of type `Int?` over `Int` Similarly if we have `func foo(x: View)`, we don’t want to prioritize a variable of type `View` over e.g. `Text`.

rdar://91349364