### PR TITLE
[5.7] [SILOpt] Added flag to disable destroy hoisting.

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -58,6 +58,14 @@ enum class CopyPropagationOption : uint8_t {
   On
 };
 
+enum class DestroyHoistingOption : uint8_t {
+  // Do not run SSADestroyHoisting.
+  Off = 0,
+
+  // Run SSADestroyHoisting pass after AllocBoxToStack in the function passes.
+  On = 1
+};
+
 class SILModule;
 
 class SILOptions {
@@ -83,6 +91,11 @@ public:
   ///
   /// When this is 'On' the pipeline has default behavior.
   CopyPropagationOption CopyPropagation = CopyPropagationOption::On;
+
+  /// Whether to run the SSADestroyHoisting pass.
+  ///
+  /// When this 'On' the pipeline has the default behavior.
+  DestroyHoistingOption DestroyHoisting = DestroyHoistingOption::On;
 
   /// Controls whether the SIL ARC optimizations are run.
   bool EnableARCOptimizations = true;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -248,6 +248,10 @@ let Flags = [FrontendOption, NoDriverOption, HelpHidden, ModuleInterfaceOptionIg
   def enable_lexical_lifetimes_noArg :
     Flag<["-"], "enable-lexical-lifetimes">,
     HelpText<"Enable lexical lifetimes">;
+  def enable_destroy_hoisting :
+    Joined<["-"], "enable-destroy-hoisting=">,
+    HelpText<"Whether to enable destroy hoisting">,
+    MetaVarName<"true|false">;
 }
 
 // Flags that are saved into module interfaces

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1553,6 +1553,15 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
   // -Ounchecked might also set removal of runtime asserts (cond_fail).
   Opts.RemoveRuntimeAsserts |= Args.hasArg(OPT_RemoveRuntimeAsserts);
 
+  Optional<DestroyHoistingOption> specifiedDestroyHoistingOption;
+  if (Arg *A = Args.getLastArg(OPT_enable_destroy_hoisting)) {
+    specifiedDestroyHoistingOption = 
+        llvm::StringSwitch<Optional<DestroyHoistingOption>>(A->getValue())
+          .Case("true", DestroyHoistingOption::On)
+          .Case("false", DestroyHoistingOption::Off)
+          .Default(None);
+  }
+
   Optional<CopyPropagationOption> specifiedCopyPropagationOption;
   if (Arg *A = Args.getLastArg(OPT_copy_propagation_state_EQ)) {
     specifiedCopyPropagationOption =
@@ -1654,13 +1663,17 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
 
   // Unless overridden below, enabling copy propagation means enabling lexical
   // lifetimes.
-  if (Opts.CopyPropagation == CopyPropagationOption::On)
+  if (Opts.CopyPropagation == CopyPropagationOption::On) {
     Opts.LexicalLifetimes = LexicalLifetimesOption::On;
+    Opts.DestroyHoisting = DestroyHoistingOption::On;
+  }
 
   // Unless overridden below, disable copy propagation means disabling lexical
   // lifetimes.
-  if (Opts.CopyPropagation == CopyPropagationOption::Off)
+  if (Opts.CopyPropagation == CopyPropagationOption::Off) {
     Opts.LexicalLifetimes = LexicalLifetimesOption::DiagnosticMarkersOnly;
+    Opts.DestroyHoisting = DestroyHoistingOption::Off;
+  }
 
   // If move-only is enabled, always enable lexical lifetime as well.  Move-only
   // depends on lexical lifetimes.
@@ -1681,6 +1694,8 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
       Opts.LexicalLifetimes = LexicalLifetimesOption::Off;
     }
   }
+  if (specifiedDestroyHoistingOption)
+    Opts.DestroyHoisting = *specifiedDestroyHoistingOption;
 
   Opts.EnableARCOptimizations &= !Args.hasArg(OPT_disable_arc_opts);
   Opts.EnableOSSAModules |= Args.hasArg(OPT_enable_ossa_modules);

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -354,7 +354,9 @@ void addFunctionPasses(SILPassPipelinePlan &P,
   // Promote box allocations to stack allocations.
   P.addAllocBoxToStack();
 
-  P.addSSADestroyHoisting();
+  if (P.getOptions().DestroyHoisting == DestroyHoistingOption::On) {
+    P.addSSADestroyHoisting();
+  }
 
   // Propagate copies through stack locations.  Should run after
   // box-to-stack promotion since it is limited to propagating through

--- a/test/SILOptimizer/disable-copy-propagation-frontend-flag.swift
+++ b/test/SILOptimizer/disable-copy-propagation-frontend-flag.swift
@@ -1,0 +1,103 @@
+// RUN: %target-swift-frontend %s \
+// RUN:     -O \
+// RUN:     -Xllvm -sil-print-pass-name \
+// RUN:     -emit-ir \
+// RUN:     -o /dev/null \
+// RUN: 2>&1 | %FileCheck -check-prefix CHECK-CPUNSPEC-DHUNSPEC %s
+
+// RUN: %target-swift-frontend %s \
+// RUN:     -O \
+// RUN:     -enable-destroy-hoisting=false \
+// RUN:     -Xllvm -sil-print-pass-name \
+// RUN:     -emit-ir \
+// RUN:     -o /dev/null \
+// RUN: 2>&1 | %FileCheck -check-prefix CHECK-CPUNSPEC-DHOFF %s
+
+// RUN: %target-swift-frontend %s \
+// RUN:     -O \
+// RUN:     -enable-destroy-hoisting=true \
+// RUN:     -Xllvm -sil-print-pass-name \
+// RUN:     -emit-ir \
+// RUN:     -o /dev/null \
+// RUN: 2>&1 | %FileCheck -check-prefix CHECK-CPUNSPEC-DHON %s
+
+// RUN: %target-swift-frontend %s \
+// RUN:     -O \
+// RUN:     -enable-copy-propagation=false \
+// RUN:     -Xllvm -sil-print-pass-name \
+// RUN:     -emit-ir \
+// RUN:     -o /dev/null \
+// RUN: 2>&1 | %FileCheck -check-prefix CHECK-CPOFF-DHUNSPEC %s
+
+// RUN: %target-swift-frontend %s \
+// RUN:     -O \
+// RUN:     -enable-copy-propagation=false \
+// RUN:     -enable-destroy-hoisting=false \
+// RUN:     -Xllvm -sil-print-pass-name \
+// RUN:     -emit-ir \
+// RUN:     -o /dev/null \
+// RUN: 2>&1 | %FileCheck -check-prefix CHECK-CPOFF-DHOFF %s
+
+// RUN: %target-swift-frontend %s \
+// RUN:     -O \
+// RUN:     -enable-copy-propagation=false \
+// RUN:     -enable-destroy-hoisting=true \
+// RUN:     -Xllvm -sil-print-pass-name \
+// RUN:     -emit-ir \
+// RUN:     -o /dev/null \
+// RUN: 2>&1 | %FileCheck -check-prefix CHECK-CPOFF-DHON %s
+
+// RUN: %target-swift-frontend %s \
+// RUN:     -O \
+// RUN:     -enable-copy-propagation=true \
+// RUN:     -Xllvm -sil-print-pass-name \
+// RUN:     -emit-ir \
+// RUN:     -o /dev/null \
+// RUN: 2>&1 | %FileCheck -check-prefix CHECK-CPON-DHUNSPEC %s
+
+// RUN: %target-swift-frontend %s \
+// RUN:     -O \
+// RUN:     -enable-copy-propagation=true \
+// RUN:     -enable-destroy-hoisting=false \
+// RUN:     -Xllvm -sil-print-pass-name \
+// RUN:     -emit-ir \
+// RUN:     -o /dev/null \
+// RUN: 2>&1 | %FileCheck -check-prefix CHECK-CPON-DHOFF %s
+
+// RUN: %target-swift-frontend %s \
+// RUN:     -O \
+// RUN:     -enable-copy-propagation=true \
+// RUN:     -enable-destroy-hoisting=true \
+// RUN:     -Xllvm -sil-print-pass-name \
+// RUN:     -emit-ir \
+// RUN:     -o /dev/null \
+// RUN: 2>&1 | %FileCheck -check-prefix CHECK-CPON-DHON %s
+
+// CHECK-CPUNSPEC-DHUNSPEC: copy-propagation
+// CHECK-CPUNSPEC-DHUNSPEC: ssa-destroy-hoisting
+
+// CHECK-CPUNSPEC-DHOFF: copy-propagation
+// CHECK-CPUNSPEC-DHOFF-NOT: ssa-destroy-hoisting
+
+// CHECK-CPUNSPEC-DHON: copy-propagation
+// CHECK-CPUNSPEC-DHON: ssa-destroy-hoisting
+
+// CHECK-CPOFF-DHUNSPEC-NOT: copy-propagation
+// CHECK-CPOFF-DHUNSPEC-NOT: ssa-destroy-hoisting
+
+// CHECK-CPOFF-DHOFF-NOT: copy-propagation
+// CHECK-CPOFF-DHOFF-NOT: ssa-destroy-hoisting
+
+// CHECK-CPOFF-DHON-NOT: copy-propagation
+// CHECK-CPOFF-DHON: ssa-destroy-hoisting
+
+// CHECK-CPON-DHUNSPEC: copy-propagation
+// CHECK-CPON-DHUNSPEC: ssa-destroy-hoisting
+
+// CHECK-CPON-DHOFF: copy-propagation
+// CHECK-CPON-DHOFF-NOT: ssa-destroy-hoisting
+
+// CHECK-CPON-DHON: copy-propagation
+// CHECK-CPON-DHON: ssa-destroy-hoisting
+
+func foo() {}


### PR DESCRIPTION
It is on by default.  The default changes with the value of the CopyPropagation setting.  But it can still be overridden.
