### PR TITLE
Rename flag for enabling forward slash literals to be less ambiguous.

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -680,9 +680,9 @@ def disable_actor_data_race_checks :
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Disable runtime checks for actor data races">;
 
-def enable_regex_literals : Flag<["-"], "enable-regex-literals">,
+def enable_bare_slash_regex : Flag<["-"], "enable-bare-slash-regex">,
   Flags<[FrontendOption, ModuleInterfaceOptionIgnorable]>,
-  HelpText<"Enable the use of regular-expression literals">;
+  HelpText<"Enable the use of forward slash regular-expression literal syntax">;
 
 def warn_implicit_overrides :
   Flag<["-"], "warn-implicit-overrides">,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -298,7 +298,7 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
                        options::OPT_verify_incremental_dependencies);
   inputArgs.AddLastArg(arguments, options::OPT_access_notes_path);
   inputArgs.AddLastArg(arguments, options::OPT_library_level);
-  inputArgs.AddLastArg(arguments, options::OPT_enable_regex_literals);
+  inputArgs.AddLastArg(arguments, options::OPT_enable_bare_slash_regex);
   inputArgs.AddLastArg(arguments, options::OPT_async_main);
 
   // Pass on any build config options

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1006,7 +1006,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   if (Args.hasArg(OPT_disable_requirement_machine_reuse))
     Opts.EnableRequirementMachineReuse = false;
 
-  if (Args.hasArg(OPT_enable_regex_literals))
+  if (Args.hasArg(OPT_enable_bare_slash_regex))
     Opts.EnableForwardSlashRegexLiterals = true;
 
   if (Args.hasArg(OPT_enable_requirement_machine_opaque_archetypes))

--- a/lib/Option/features.json
+++ b/lib/Option/features.json
@@ -22,7 +22,7 @@
       "name": "empty-abi-descriptor"
     },
     {
-      "name": "enable-regex-literals"
+      "name": "enable-bare-slash-regex"
     }    
   ]
 }

--- a/test/Driver/enable_regex_literals_flag.swift
+++ b/test/Driver/enable_regex_literals_flag.swift
@@ -1,9 +1,9 @@
-// RUN: %target-swiftc_driver  -enable-regex-literals -disallow-use-new-driver -driver-print-jobs  %s 2>^1 | %FileCheck %s
+// RUN: %target-swiftc_driver  -enable-bare-slash-regex -disallow-use-new-driver -driver-print-jobs  %s 2>^1 | %FileCheck %s
 // The new driver has its own test for this
 
 // REQUIRES: cplusplus_driver
 
-// CHECK: {{.*}}swift{{c|-frontend}}{{(.exe)?"?}} -frontend{{.*}}-enable-regex-literals
+// CHECK: {{.*}}swift{{c|-frontend}}{{(.exe)?"?}} -frontend{{.*}}-enable-bare-slash-regex
 
 public func foo() -> Int {
     return 42

--- a/test/ModuleInterface/option-preservation.swift
+++ b/test/ModuleInterface/option-preservation.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -enable-library-evolution -emit-module-interface-path %t.swiftinterface -module-name t %s -target-min-inlining-version 42 -emit-module -o /dev/null -Onone -enforce-exclusivity=unchecked -autolink-force-load -enable-regex-literals
+// RUN: %target-swift-frontend -enable-library-evolution -emit-module-interface-path %t.swiftinterface -module-name t %s -target-min-inlining-version 42 -emit-module -o /dev/null -Onone -enforce-exclusivity=unchecked -autolink-force-load -enable-bare-slash-regex
 // RUN: %FileCheck %s < %t.swiftinterface -check-prefix=CHECK-SWIFTINTERFACE
 //
 // CHECK-SWIFTINTERFACE: swift-module-flags:
@@ -10,7 +10,7 @@
 // CHECK-SWIFTINTERFACE-SAME: -autolink-force-load
 // CHECK-SWIFTINTERFACE: swift-module-flags-ignorable:
 // CHECK-SWIFTINTERFACE-SAME: -target-min-inlining-version 42
-// CHECK-SWIFTINTERFACE-SAME: -enable-regex-literals
+// CHECK-SWIFTINTERFACE-SAME: -enable-bare-slash-regex
 
 // Make sure flags show up when filelists are enabled
 


### PR DESCRIPTION
Previous spelling could easily be mistaken for gating the entire feature.

Part of rdar://91119995