### PR TITLE
[5.7][CodeCompletion] Update for SE-0345 shorthand optional binding

### DIFF
--- a/include/swift/IDE/CodeCompletionResult.h
+++ b/include/swift/IDE/CodeCompletionResult.h
@@ -223,6 +223,7 @@ enum class CompletionKind : uint8_t {
   StmtLabel,
   ForEachPatternBeginning,
   TypeAttrBeginning,
+  OptionalBinding,
 };
 
 enum class CodeCompletionDiagnosticSeverity : uint8_t {

--- a/include/swift/IDE/CompletionLookup.h
+++ b/include/swift/IDE/CompletionLookup.h
@@ -33,12 +33,15 @@
 namespace swift {
 namespace ide {
 
-using DeclFilter = std::function<bool(ValueDecl *, DeclVisibilityKind)>;
+using DeclFilter =
+    std::function<bool(ValueDecl *, DeclVisibilityKind, DynamicLookupInfo)>;
 
 /// A filter that always returns \c true.
-bool DefaultFilter(ValueDecl *VD, DeclVisibilityKind Kind);
+bool DefaultFilter(ValueDecl *VD, DeclVisibilityKind Kind,
+                   DynamicLookupInfo dynamicLookupInfo);
 
-bool KeyPathFilter(ValueDecl *decl, DeclVisibilityKind);
+bool KeyPathFilter(ValueDecl *decl, DeclVisibilityKind,
+                   DynamicLookupInfo dynamicLookupInfo);
 
 /// Returns \c true only if the completion is happening for top-level
 /// declrarations. i.e.:
@@ -528,7 +531,7 @@ public:
         : Consumer(Consumer), Filter(Filter) {}
     void foundDecl(ValueDecl *VD, DeclVisibilityKind Kind,
                    DynamicLookupInfo dynamicLookupInfo) override {
-      if (Filter(VD, Kind))
+      if (Filter(VD, Kind, dynamicLookupInfo))
         Consumer.foundDecl(VD, Kind, dynamicLookupInfo);
     }
   };
@@ -588,6 +591,8 @@ public:
                                  bool ResultsHaveLeadingDot);
 
   void getStmtLabelCompletions(SourceLoc Loc, bool isContinue);
+
+  void getOptionalBindingCompletions(SourceLoc Loc);
 };
 
 } // end namespace ide

--- a/include/swift/Parse/CodeCompletionCallbacks.h
+++ b/include/swift/Parse/CodeCompletionCallbacks.h
@@ -236,6 +236,8 @@ public:
 
   virtual void completeTypeAttrBeginning() {};
 
+  virtual void completeOptionalBinding(){};
+
   /// Signals that the AST for the all the delayed-parsed code was
   /// constructed.  No \c complete*() callbacks will be done after this.
   virtual void doneParsing() = 0;

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -274,6 +274,7 @@ public:
   void completeStmtLabel(StmtKind ParentKind) override;
   void completeForEachPatternBeginning(bool hasTry, bool hasAwait) override;
   void completeTypeAttrBeginning() override;
+  void completeOptionalBinding() override;
 
   void doneParsing() override;
 
@@ -625,6 +626,11 @@ void CodeCompletionCallbacksImpl::completeForEachPatternBeginning(
     ParsedKeywords.emplace_back("await");
 }
 
+void CodeCompletionCallbacksImpl::completeOptionalBinding() {
+  CurDeclContext = P.CurDeclContext;
+  Kind = CompletionKind::OptionalBinding;
+}
+
 void CodeCompletionCallbacksImpl::completeTypeAttrBeginning() {
   CurDeclContext = P.CurDeclContext;
   Kind = CompletionKind::TypeAttrBeginning;
@@ -907,6 +913,7 @@ void CodeCompletionCallbacksImpl::addKeywords(CodeCompletionResultSink &Sink,
   case CompletionKind::PrecedenceGroup:
   case CompletionKind::StmtLabel:
   case CompletionKind::TypeAttrBeginning:
+  case CompletionKind::OptionalBinding:
     break;
 
   case CompletionKind::EffectsSpecifier: {
@@ -1886,6 +1893,12 @@ void CodeCompletionCallbacksImpl::doneParsing() {
     break;
 
   }
+  case CompletionKind::OptionalBinding: {
+    SourceLoc Loc = P.Context.SourceMgr.getCodeCompletionLoc();
+    Lookup.getOptionalBindingCompletions(Loc);
+    break;
+  }
+
   case CompletionKind::AfterIfStmtElse:
   case CompletionKind::CaseStmtKeyword:
   case CompletionKind::EffectsSpecifier:

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1590,6 +1590,13 @@ Parser::parseStmtConditionElement(SmallVectorImpl<StmtConditionElement> &result,
       ThePattern = makeParserResult(Status, P);
     }
 
+  } else if (Tok.is(tok::code_complete)) {
+    if (CodeCompletion) {
+      CodeCompletion->completeOptionalBinding();
+    }
+    ThePattern = makeParserResult(new (Context) AnyPattern(Tok.getLoc()));
+    ThePattern.setHasCodeCompletionAndIsError();
+    consumeToken(tok::code_complete);
   } else {
     ConditionCtxt.setCreateSyntax(SyntaxKind::OptionalBindingCondition);
     // Otherwise, this is an implicit optional binding "if let".

--- a/test/IDE/complete_optional_binding.swift
+++ b/test/IDE/complete_optional_binding.swift
@@ -1,0 +1,75 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+
+let topLevelOpt: Int?
+
+do {
+  let topLevelLocalOpt: Int?
+  let topLevelLocalNonOpt: Int
+
+  if let #^TOPLEVEL_IF_LET?check=TOPLEVEL^#
+// TOPLEVEL: Begin completions, 1 items
+// TOPLEVEL-DAG: Decl[LocalVar]/Local:               topLevelLocalOpt[#Int?#];
+// TOPLEVEL: End completions
+// FIXME: show 'topLevelOpt'
+}
+
+struct MyStruct<T> {
+    var propOpt: Int?
+    var propNonOpt: Int 
+    var propGenOpt: T?
+    var propGenNonOpt: T
+
+    func testMethod<U>(paramGenOpt: U?, paramGenNonOpt: U, paramOpt: Int?, paramNonOpt: Int) {
+        var localOpt: Int?
+        var localNonOpt: Int
+        var localGenOpt: U?
+        var localGenNonOpt: U
+
+        do {
+          if let #^IF_LET?check=IN_FUNC^#
+        }
+        do {
+          if var #^IF_VAR?check=IN_FUNC^#
+        }
+        do {
+          if true {} else if let #^ELSEIF_LET?check=IN_FUNC^#
+        }
+        do {
+          if true {} else if var #^ELSEIF_VAR?check=IN_FUNC^#
+        }
+        do {
+          guard let #^GUARD_LET?check=IN_FUNC^#
+        }
+        do {
+          guard var #^GUARD_VAR?check=IN_FUNC^#
+        }
+        do {
+          while let #^WHILE_LET?check=IN_FUNC^#
+        }
+        do {
+          while var #^WHILE_VAR?check=IN_FUNC^#
+        }
+
+// IN_FUNC: Begin completions, 6 items
+// IN_FUNC-DAG: Decl[LocalVar]/Local:               localOpt[#Int?#];
+// IN_FUNC-DAG: Decl[LocalVar]/Local:               localGenOpt[#U?#];
+// IN_FUNC-DAG: Decl[LocalVar]/Local:               paramGenOpt[#U?#];
+// IN_FUNC-DAG: Decl[LocalVar]/Local:               paramOpt[#Int?#];
+// IN_FUNC-DAG: Decl[InstanceVar]/CurrNominal:      propOpt[#Int?#];
+// IN_FUNC-DAG: Decl[InstanceVar]/CurrNominal:      propGenOpt[#T?#];
+// IN_FUNC-NOT: NonOpt
+// IN_FUNC: End completions
+    }
+}
+
+func testPreviousElements() {
+  let localOptOpt: Int??
+
+  if let localOpt = localOptOpt, let localNonOpt = localOpt, let #^PREV_ELEMENT^#
+// PREV_ELEMENT: Begin completions, 2 items
+// PREV_ELEMENT-DAG: Decl[LocalVar]/Local:               localOptOpt[#Int??#];
+// PREV_ELEMENT-DAG: Decl[LocalVar]/Local:               localOpt[#Int?#];
+// PREV_ELEMENT-NOT: NonOpt
+// PREV_ELEMENT: End completions
+}


### PR DESCRIPTION
Cherry-pick #42145 into `release/5.7`

* Explanation: Update for SE-0345 (https://github.com/apple/swift-evolution/blob/main/proposals/0345-if-let-shorthand.md) which introduces a shorthand syntax for optional binding in control statement conditions. Previously code completion didn't suggest anything after `if let` because that is a position of name declaration. But with this change, it suggest visible `Optional` values after `if let/var` to help typing the shorthand syntax.
* Scope: Code completion in statement conditions
* Issues: rdar://90399603
* Risk: Low. This is a new feature, but uses well-established method of completion mechanism
* Testing: Added regression test cases
* Reviewer: Alex Hoppen (@ahoppen)