### PR TITLE
[stdlib] remove most uses of _asCChar and _asUInt8

### DIFF
--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -167,8 +167,7 @@ extension _StringGuts {
     _ f: (UnsafeBufferPointer<CChar>) throws -> R
   ) rethrows -> R {
     return try self.withFastUTF8 { utf8 in
-      let ptr = utf8.baseAddress._unsafelyUnwrappedUnchecked._asCChar
-      return try f(UnsafeBufferPointer(start: ptr, count: utf8.count))
+      return try utf8.withMemoryRebound(to: CChar.self, f)
     }
   }
 }

--- a/test/stdlib/StringAPICString.swift
+++ b/test/stdlib/StringAPICString.swift
@@ -254,9 +254,10 @@ CStringTests.test("String.cString.with.Array.CChar.input") {
   do {
     let (u8p, dealloc) = getASCIIUTF8()
     defer { dealloc() }
-    let cstr = UnsafeRawPointer(u8p).assumingMemoryBound(to: CChar.self)
-    let buffer = UnsafeBufferPointer(start: cstr, count: getUTF8Length(u8p)+1)
-    let str = String(cString: Array(buffer))
+    let buffer = UnsafeBufferPointer(start: u8p, count: getUTF8Length(u8p)+1)
+    let str = buffer.withMemoryRebound(to: CChar.self) {
+      String(cString: Array($0))
+    }
     str.withCString {
       $0.withMemoryRebound(to: UInt8.self, capacity: buffer.count) {
         expectEqualCString(u8p, $0)
@@ -324,9 +325,10 @@ CStringTests.test("String.validatingUTF8.with.Array.input") {
   do {
     let (u8p, dealloc) = getASCIIUTF8()
     defer { dealloc() }
-    let cstr = UnsafeRawPointer(u8p).assumingMemoryBound(to: CChar.self)
-    let buffer = UnsafeBufferPointer(start: cstr, count: getUTF8Length(u8p)+1)
-    let str = String(validatingUTF8: Array(buffer))
+    let buffer = UnsafeBufferPointer(start: u8p, count: getUTF8Length(u8p)+1)
+    let str = buffer.withMemoryRebound(to: CChar.self) {
+      String(validatingUTF8: Array($0))
+    }
     expectNotNil(str)
     str?.withCString {
       $0.withMemoryRebound(to: UInt8.self, capacity: buffer.count) {
@@ -382,9 +384,10 @@ CStringTests.test("String.decodeCString.with.Array.input") {
   do {
     let (u8p, dealloc) = getASCIIUTF8()
     defer { dealloc() }
-    let cstr = UnsafeRawPointer(u8p).assumingMemoryBound(to: Unicode.UTF8.CodeUnit.self)
-    let buffer = UnsafeBufferPointer(start: cstr, count: getUTF8Length(u8p)+1)
-    let result = String.decodeCString(Array(buffer), as: Unicode.UTF8.self)
+    let buffer = UnsafeBufferPointer(start: u8p, count: getUTF8Length(u8p)+1)
+    let result = buffer.withMemoryRebound(to: Unicode.UTF8.CodeUnit.self) {
+      String.decodeCString(Array($0), as: Unicode.UTF8.self)
+    }
     expectNotNil(result)
     expectEqual(result?.repairsMade, false)
     result?.result.withCString {
@@ -448,9 +451,10 @@ CStringTests.test("String.init.decodingCString.with.Array.input") {
   do {
     let (u8p, dealloc) = getASCIIUTF8()
     defer { dealloc() }
-    let cstr = UnsafeRawPointer(u8p).assumingMemoryBound(to: Unicode.UTF8.CodeUnit.self)
-    let buffer = UnsafeBufferPointer(start: cstr, count: getUTF8Length(u8p)+1)
-    let str = String(decodingCString: Array(buffer), as: Unicode.UTF8.self)
+    let buffer = UnsafeBufferPointer(start: u8p, count: getUTF8Length(u8p)+1)
+    let str = buffer.withMemoryRebound(to: Unicode.UTF8.CodeUnit.self) {
+      String(decodingCString: Array($0), as: Unicode.UTF8.self)
+    }
     str.withCString {
       $0.withMemoryRebound(to: UInt8.self, capacity: buffer.count) {
         expectEqualCString(u8p, $0)


### PR DESCRIPTION
These two accessors defined on `UnsafePointer` are likely to lead to undefined behaviour, as they use `assumingMemoryBound` on memory that is known _not_ to be bound to the destination type; that's bad.

This PR changes code sections that initialized `UnsafeBufferPointer` instances using pointers whose `Pointer` type had been changed with `assumingMemoryBound`, and updates them to use `withMemoryRebound` instead.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Partially addresses rdar://91343475.
