### PR TITLE
[TypeChecker] SE-0347: Enable type inference from default expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ _**Note:** This is in reverse chronological order, so newer entries are added to
 
 ## Swift 5.7
 
+* [SE-0347][]:
+
+  It's now possible to use a default value expression with a generic parameter type
+  to default the argument and its type:
+
+  ```
+  func compute<C: Collection>(_ values: C = [0, 1, 2]) {
+    ...
+  }
+  ```
+
+  `compute` is now accepted by compiler and `[Int]` is going to be inferred
+  for `C` at call sites that do not provide the argument explicitly.
+
 * [SE-0326][]:
 
   It's now possible to infer parameter and result types from the body of a multi-statement
@@ -9150,6 +9164,7 @@ Swift 1.0
 [SE-0340]: <https://github.com/apple/swift-evolution/blob/main/proposals/0340-swift-noasync.md>
 [SE-0345]: <https://github.com/apple/swift-evolution/blob/main/proposals/0345-if-let-shorthand.md>
 [SE-0326]: <https://github.com/apple/swift-evolution/blob/main/proposals/0326-extending-multi-statement-closure-inference.md>
+[SE-0347]: <https://github.com/apple/swift-evolution/blob/main/proposals/0347-type-inference-from-default-exprs.md>
 
 [SR-75]: <https://bugs.swift.org/browse/SR-75>
 [SR-106]: <https://bugs.swift.org/browse/SR-106>

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -752,10 +752,6 @@ namespace swift {
     /// closures.
     bool EnableMultiStatementClosureInference = true;
 
-    /// Enable experimental support for generic parameter inference in
-    /// parameter positions from associated default expressions.
-    bool EnableTypeInferenceFromDefaultArguments = false;
-
     /// See \ref FrontendOptions.PrintFullConvention
     bool PrintFullConvention = false;
   };

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1104,9 +1104,6 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
   Opts.EnableMultiStatementClosureInference |=
       Args.hasArg(OPT_experimental_multi_statement_closures);
 
-  Opts.EnableTypeInferenceFromDefaultArguments |=
-      Args.hasArg(OPT_experimental_type_inference_from_defaults);
-
   Opts.PrintFullConvention |=
       Args.hasArg(OPT_experimental_print_full_convention);
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1780,7 +1780,8 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
     if (parameterBindings[paramIdx].empty() && callee) {
       auto &ctx = cs.getASTContext();
 
-      if (ctx.TypeCheckerOpts.EnableTypeInferenceFromDefaultArguments) {
+      // Type inference from default value expressions.
+      {
         auto *paramList = getParameterList(callee);
         if (!paramList)
           continue;

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -464,10 +464,6 @@ Type TypeChecker::typeCheckParameterDefault(Expr *&defaultValue,
       return defaultValue->getType();
     }
 
-    // If inference is disabled, fail.
-    if (!ctx.TypeCheckerOpts.EnableTypeInferenceFromDefaultArguments)
-      return Type();
-
     // Caller-side defaults are always type-checked based on the concrete
     // type of the argument deduced at a particular call site.
     if (isa<MagicIdentifierLiteralExpr>(defaultValue))

--- a/test/Constraints/type_inference_from_default_exprs.swift
+++ b/test/Constraints/type_inference_from_default_exprs.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend-emit-module -emit-module-path %t/InferViaDefaults.swiftmodule -enable-experimental-type-inference-from-defaults -module-name InferViaDefaults %S/Inputs/type_inference_via_defaults_other_module.swift
-// RUN: %target-swift-frontend -enable-experimental-type-inference-from-defaults -module-name main -typecheck -verify -I %t %s %S/Inputs/type_inference_via_defaults_other_module.swift
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/InferViaDefaults.swiftmodule -module-name InferViaDefaults %S/Inputs/type_inference_via_defaults_other_module.swift
+// RUN: %target-swift-frontend -module-name main -typecheck -verify -I %t %s %S/Inputs/type_inference_via_defaults_other_module.swift
 
 func testInferFromResult<T>(_: T = 42) -> T { fatalError() } // Ok
 

--- a/test/Constraints/type_inference_from_default_exprs_executable_test.swift
+++ b/test/Constraints/type_inference_from_default_exprs_executable_test.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend-emit-module -emit-module-path %t/InferViaDefaults.swiftmodule -enable-experimental-type-inference-from-defaults -module-name InferViaDefaults %S/Inputs/type_inference_via_defaults_other_module.swift
-// RUN: %target-build-swift -module-name main -Xfrontend -enable-experimental-type-inference-from-defaults -parse-as-library -I %t %s %S/Inputs/type_inference_via_defaults_other_module.swift -o %t/a.out
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/InferViaDefaults.swiftmodule -module-name InferViaDefaults %S/Inputs/type_inference_via_defaults_other_module.swift
+// RUN: %target-build-swift -module-name main -Xfrontend -parse-as-library -I %t %s %S/Inputs/type_inference_via_defaults_other_module.swift -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s --color
 
 // REQUIRES: OS=macosx && CPU=x86_64

--- a/test/decl/func/vararg.swift
+++ b/test/decl/func/vararg.swift
@@ -1,5 +1,4 @@
 // RUN: %target-typecheck-verify-swift
-// RUN: %target-typecheck-verify-swift -enable-experimental-type-inference-from-defaults
 
 var t1a: (Int...) = (1)
 // expected-error@-1 {{cannot create a variadic tuple}}

--- a/test/expr/closure/basic.swift
+++ b/test/expr/closure/basic.swift
@@ -1,5 +1,4 @@
 // RUN: %target-typecheck-verify-swift
-// RUN: %target-typecheck-verify-swift -enable-experimental-type-inference-from-defaults
 
 func takeIntToInt(_ f: (Int) -> Int) { }
 func takeIntIntToInt(_ f: (Int, Int) -> Int) { }


### PR DESCRIPTION
- Removes the flag
- Adds a ChangeLog entry for SE-0347

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
