### PR TITLE
Reimplement actor isolation checking for referencing a declaration.

### DIFF
--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -131,6 +131,8 @@ public:
     return getKind() == GlobalActor || getKind() == GlobalActorUnsafe;
   }
 
+  bool isDistributedActor() const;
+
   Type getGlobalActor() const {
     assert(isGlobalActor());
     return globalActor;

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4457,14 +4457,11 @@ NOTE(note_add_nonisolated_to_decl,none,
      (DeclName, DescriptiveDeclKind))
 NOTE(note_add_async_and_throws_to_decl,none,
      "mark the protocol requirement %0 '%select{|async|throws|async throws}1' "
-     "in order witness it with 'distributed' function declared in distributed actor %2",
-     (DeclName, unsigned, DeclName))
+     "to allow actor-isolated conformances",
+     (DeclName, unsigned))
 NOTE(note_add_distributed_to_decl,none,
-     "add 'distributed' to %0 to make this %1 witness the protocol requirement",
+     "add 'distributed' to %0 to make this %1 satisfy the protocol requirement",
      (DeclName, DescriptiveDeclKind))
-NOTE(note_distributed_requirement_defined_here,none,
-     "distributed instance method requirement %0 declared here",
-     (DeclName))
 NOTE(note_add_globalactor_to_function,none,
      "add '@%0' to make %1 %2 part of global actor %3", 
      (StringRef, DescriptiveDeclKind, DeclName, Type))
@@ -4658,19 +4655,9 @@ WARNING(shared_mutable_state_access,none,
         "reference to %0 %1 is not concurrency-safe because it involves "
         "shared mutable state", (DescriptiveDeclKind, DeclName))
 ERROR(actor_isolated_witness,none,
-     "actor-isolated %0 %1 cannot be used to satisfy a protocol requirement",
-     (DescriptiveDeclKind, DeclName))
-ERROR(distributed_actor_isolated_witness,none,
-     "distributed actor-isolated %0 %1 cannot be used to satisfy a protocol requirement",
-     (DescriptiveDeclKind, DeclName))
-ERROR(global_actor_isolated_witness,none,
-      "%0 %1 isolated to global actor %2 can not satisfy corresponding "
-      "requirement from protocol %3",
-      (DescriptiveDeclKind, DeclName, Type, Identifier))
-ERROR(global_actor_isolated_requirement_witness_conflict,none,
-      "%0 %1 isolated to global actor %2 can not satisfy corresponding "
-      "requirement from protocol %3 isolated to global actor %4",
-      (DescriptiveDeclKind, DeclName, Type, Identifier, Type))
+     "%select{|distributed }0%1 %2 %3 cannot be used to satisfy %4 protocol "
+     "requirement",
+     (bool, ActorIsolation, DescriptiveDeclKind, DeclName, ActorIsolation))
 ERROR(actor_cannot_conform_to_global_actor_protocol,none,
       "actor %0 cannot conform to global actor isolated protocol %1",
       (Type, Type))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4543,7 +4543,7 @@ ERROR(override_implicit_unowned_executor,none,
 ERROR(actor_isolated_non_self_reference,none,
         "%5 %0 %1 can not be "
         "%select{referenced|mutated|used 'inout'}2 "
-        "%select{on a different actor instance|"
+        "%select{from outside the actor|on a different actor instance|"
         "on a non-isolated actor instance|"
         "from a Sendable function|from a Sendable closure|"
         "from an 'async let' initializer|from global actor %4|"
@@ -4565,18 +4565,6 @@ ERROR(actor_isolated_inout_state,none,
 ERROR(actor_isolated_mutating_func,none,
       "cannot call mutating async function %0 on actor-isolated %1 %2",
       (DeclName, DescriptiveDeclKind, DeclName))
-ERROR(global_actor_from_instance_actor_context,none,
-      "%0 %1 isolated to global actor %2 can not be %select{referenced|mutated|used 'inout'}4"
-      " from actor %3 %select{|in a synchronous context}5",
-      (DescriptiveDeclKind, DeclName, Type, DeclName, unsigned, bool))
-ERROR(global_actor_from_other_global_actor_context,none,
-      "%0 %1 isolated to global actor %2 can not be %select{referenced|mutated|used 'inout'}4"
-      " from different global actor %3 %select{|in a synchronous context}5",
-      (DescriptiveDeclKind, DeclName, Type, Type, unsigned, bool))
-ERROR(global_actor_from_nonactor_context,none,
-      "%0 %1 isolated to global actor %2 can not be %select{referenced|mutated|used 'inout'}4"
-      " from %select{this|a non-isolated}3%select{| synchronous}5 context",
-      (DescriptiveDeclKind, DeclName, Type, bool, unsigned, bool))
 ERROR(actor_isolated_call,none,
       "call to %0 function in a synchronous %1 context",
       (ActorIsolation, ActorIsolation))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4541,13 +4541,16 @@ ERROR(override_implicit_unowned_executor,none,
       "cannot override an actor's 'unownedExecutor' property that wasn't "
       "explicitly defined", ())
 ERROR(actor_isolated_non_self_reference,none,
-        "actor-isolated %0 %1 can not be "
+        "%5 %0 %1 can not be "
         "%select{referenced|mutated|used 'inout'}2 "
-        "%select{on a non-isolated actor instance|"
+        "%select{on a different actor instance|"
+        "on a non-isolated actor instance|"
         "from a Sendable function|from a Sendable closure|"
         "from an 'async let' initializer|from global actor %4|"
-        "from the main actor|from a non-isolated context|from a non-isolated autoclosure}3",
-        (DescriptiveDeclKind, DeclName, unsigned, unsigned, Type))
+        "from the main actor|from a non-isolated context|"
+        "from a non-isolated autoclosure}3",
+        (DescriptiveDeclKind, DeclName, unsigned, unsigned, Type,
+         ActorIsolation))
 ERROR(distributed_actor_isolated_non_self_reference,none,
       "distributed actor-isolated %0 %1 can not be accessed from a "
       "non-isolated context",

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9380,3 +9380,7 @@ void swift::simple_display(llvm::raw_ostream &out, AnyFunctionRef fn) {
   else
     out << "closure";
 }
+
+bool ActorIsolation::isDistributedActor() const {
+  return getKind() == ActorInstance && getActor()->isDistributedActor();
+}

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7786,18 +7786,6 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
   return ctorCall;
 }
 
-/// Determine whether this closure should be treated as Sendable.
-static bool isSendableClosure(ConstraintSystem &cs,
-                              const AbstractClosureExpr *closure) {
-  if (auto fnType = cs.getType(const_cast<AbstractClosureExpr *>(closure))
-                        ->getAs<FunctionType>()) {
-    if (fnType->isSendable())
-      return true;
-  }
-
-  return false;
-}
-
 bool ExprRewriter::isDistributedThunk(ConcreteDeclRef ref, Expr *context) {
   auto *FD = dyn_cast_or_null<AbstractFunctionDecl>(ref.getDecl());
   if (!(FD && FD->isInstanceMember() && FD->isDistributed()))
@@ -7821,55 +7809,60 @@ bool ExprRewriter::isDistributedThunk(ConcreteDeclRef ref, Expr *context) {
 
   // If this is a method reference on an potentially isolated
   // actor then it cannot be a remote thunk.
-  if (isPotentiallyIsolatedActor(actor, [&](ParamDecl *P) {
-        return P->isIsolated() ||
-               llvm::is_contained(solution.isolatedParams, P);
-      }))
-    return false;
+  bool isPotentiallyIsolated = isPotentiallyIsolatedActor(
+      actor,
+    [&](ParamDecl *P) {
+    return P->isIsolated() ||
+           llvm::is_contained(solution.isolatedParams, P);
+  });
 
-  if (actor->isKnownToBeLocal())
-    return false;
-  
-  bool isInAsyncLetInitializer = target && target->isAsyncLetInitializer();
+  // Adjust the declaration context to the innermost context that is neither
+  // a local function nor a closure, so that the actor reference is checked
+  auto referenceDC = dc;
+  while (true) {
+    switch (referenceDC->getContextKind()) {
+    case DeclContextKind::AbstractClosureExpr:
+    case DeclContextKind::Initializer:
+    case DeclContextKind::SerializedLocal:
+      referenceDC = referenceDC->getParent();
+      continue;
 
-  auto isActorInitOrDeInitContext = [&](const DeclContext *dc) {
-    return ::isActorInitOrDeInitContext(
-        dc, [&](const AbstractClosureExpr *closure) {
-          return isSendableClosure(cs, closure);
-        });
-  };
+      case DeclContextKind::AbstractFunctionDecl:
+      case DeclContextKind::GenericTypeDecl:
+      case DeclContextKind::SubscriptDecl:
+        if (auto value = dyn_cast<ValueDecl>(referenceDC->getAsDecl())) {
+          if (value->isLocalCapture()) {
+            referenceDC = referenceDC->getParent();
+            continue;
+          }
+        }
+        break;
 
-  switch (ActorIsolationRestriction::forDeclaration(ref, dc)) {
-  case ActorIsolationRestriction::CrossActorSelf: {
-    // Not a thunk if it's used in actor init or de-init.
-    if (!isInAsyncLetInitializer && isActorInitOrDeInitContext(dc))
-      return false;
-
-    // Here we know that the method could be used across actors
-    // and the actor it's used on is non-isolated, which means
-    // that it could be a thunk, so we have to be conservative
-    // about it.
-    return true;
-  }
-
-  case ActorIsolationRestriction::ActorSelf: {
-    // An instance member of an actor can be referenced from an actor's
-    // designated initializer or deinitializer.
-    if (actor->isActorSelf() && !isInAsyncLetInitializer) {
-      if (auto *fn = isActorInitOrDeInitContext(dc)) {
-        if (!(isa<ConstructorDecl>(fn) &&
-              cast<ConstructorDecl>(fn)->isConvenienceInit()))
-          return false;
-      }
+      case DeclContextKind::EnumElementDecl:
+      case DeclContextKind::ExtensionDecl:
+      case DeclContextKind::FileUnit:
+      case DeclContextKind::Module:
+      case DeclContextKind::TopLevelCodeDecl:
+        break;
     }
 
-    // Call on a non-isolated actor in async context requires
-    // implicit thunk.
-    return isInAsyncLetInitializer || cs.isAsynchronousContext(dc);
+    break;
   }
 
-  default:
+  // Create a simple actor reference, assuming that we might be in a
+  // non-isolated context but knowing whether it's potentially isolated.
+  // We only care about the "distributed" flag.
+  ReferencedActor actorRef = ReferencedActor(
+      actor, isPotentiallyIsolated, ReferencedActor::NonIsolatedContext);
+  auto refResult = ActorReferenceResult::forReference(
+      ref, context->getLoc(), referenceDC, None, actorRef);
+  switch (refResult) {
+  case ActorReferenceResult::ExitsActorToNonisolated:
+  case ActorReferenceResult::SameConcurrencyDomain:
     return false;
+
+  case ActorReferenceResult::EntersActor:
+    return refResult.options.contains(ActorReferenceResult::Flags::Distributed);
   }
 }
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7827,6 +7827,9 @@ bool ExprRewriter::isDistributedThunk(ConcreteDeclRef ref, Expr *context) {
       }))
     return false;
 
+  if (actor->isKnownToBeLocal())
+    return false;
+  
   bool isInAsyncLetInitializer = target && target->isAsyncLetInitializer();
 
   auto isActorInitOrDeInitContext = [&](const DeclContext *dc) {

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -446,138 +446,6 @@ bool swift::isLetAccessibleAnywhere(const ModuleDecl *fromModule,
   return varIsSafeAcrossActors(fromModule, let, isolation);
 }
 
-/// Determine the isolation rules for a given declaration.
-ActorIsolationRestriction ActorIsolationRestriction::forDeclaration(
-    ConcreteDeclRef declRef, const DeclContext *fromDC, bool fromExpression) {
-  auto decl = declRef.getDecl();
-
-  switch (decl->getKind()) {
-  case DeclKind::AssociatedType:
-  case DeclKind::Class:
-  case DeclKind::Enum:
-  case DeclKind::Extension:
-  case DeclKind::GenericTypeParam:
-  case DeclKind::OpaqueType:
-  case DeclKind::Protocol:
-  case DeclKind::Struct:
-  case DeclKind::TypeAlias:
-    // Types are always available.
-    return forUnrestricted();
-
-  case DeclKind::EnumCase:
-  case DeclKind::EnumElement:
-    // Type-level entities don't require isolation.
-    return forUnrestricted();
-
-  case DeclKind::IfConfig:
-  case DeclKind::Import:
-  case DeclKind::InfixOperator:
-  case DeclKind::MissingMember:
-  case DeclKind::Module:
-  case DeclKind::PatternBinding:
-  case DeclKind::PostfixOperator:
-  case DeclKind::PoundDiagnostic:
-  case DeclKind::PrecedenceGroup:
-  case DeclKind::PrefixOperator:
-  case DeclKind::TopLevelCode:
-    // Non-value entities don't require isolation.
-    return forUnrestricted();
-
-  case DeclKind::Destructor:
-    // Destructors don't require isolation.
-    return forUnrestricted();
-
-  case DeclKind::Param:
-  case DeclKind::Var:
-  case DeclKind::Accessor:
-  case DeclKind::Constructor:
-  case DeclKind::Func:
-  case DeclKind::Subscript: {
-    // Local captures are checked separately.
-    if (cast<ValueDecl>(decl)->isLocalCapture())
-      return forUnrestricted();
-
-    auto isolation = getActorIsolation(cast<ValueDecl>(decl));
-
-    // 'let' declarations are immutable, so some of them can be accessed across
-    // actors.
-    bool isAccessibleAcrossActors = false;
-    if (auto var = dyn_cast<VarDecl>(decl)) {
-      if (varIsSafeAcrossActors(fromDC->getParentModule(), var, isolation))
-        isAccessibleAcrossActors = true;
-    }
-
-    // A function that provides an asynchronous context has no restrictions
-    // on its access.
-    //
-    // FIXME: technically, synchronous functions are allowed to be cross-actor.
-    // The call-sites are just conditionally async based on where they appear
-    // (outside or inside the actor). This suggests that the implicitly-async
-    // concept could be merged into the CrossActorSelf concept.
-    if (auto func = dyn_cast<AbstractFunctionDecl>(decl)) {
-      if (func->isAsyncContext())
-        isAccessibleAcrossActors = true;
-    }
-
-    // Similarly, a computed property or subscript that has an 'async' getter
-    // provides an asynchronous context, and has no restrictions.
-    if (auto storageDecl = dyn_cast<AbstractStorageDecl>(decl)) {
-      if (auto effectfulGetter = storageDecl->getEffectfulGetAccessor())
-        if (effectfulGetter->hasAsync())
-          isAccessibleAcrossActors = true;
-    }
-
-    // Determine the actor isolation of the given declaration.
-    switch (isolation) {
-    case ActorIsolation::ActorInstance:
-      // Protected actor instance members can only be accessed on 'self'.
-      return forActorSelf(isolation.getActor(),
-          isAccessibleAcrossActors || isa<ConstructorDecl>(decl));
-
-    case ActorIsolation::GlobalActorUnsafe:
-    case ActorIsolation::GlobalActor: {
-      // A global-actor-isolated function referenced within an expression
-      // carries the global actor into its function type. The actual
-      // reference to the function is therefore not restricted, because the
-      // call to the function is.
-      if (fromExpression && isa<AbstractFunctionDecl>(decl))
-        return forUnrestricted();
-
-      Type actorType = isolation.getGlobalActor();
-      if (auto subs = declRef.getSubstitutions())
-        actorType = actorType.subst(subs);
-
-      return forGlobalActor(actorType, isAccessibleAcrossActors,
-                            isolation == ActorIsolation::GlobalActorUnsafe);
-    }
-
-    case ActorIsolation::Independent:
-      // While some synchronous actor inits are not isolated they still need
-      // cross-actor restrictions (e.g., for Sendable) for safety.
-      if (auto *ctor = dyn_cast<ConstructorDecl>(decl))
-        if (auto *parent = ctor->getParent()->getSelfClassDecl())
-          if (parent->isAnyActor())
-            return forActorSelf(parent, /*isCrossActor=*/true);
-
-      // `nonisolated let` members are cross-actor as well.
-      if (auto var = dyn_cast<VarDecl>(decl)) {
-        if (var->isInstanceMember() && var->isLet()) {
-          if (auto parent = var->getDeclContext()->getSelfClassDecl()) {
-            if (parent->isActor() && !parent->isDistributedActor())
-              return forActorSelf(parent, /*isCrossActor=*/true);
-          }
-        }
-      }
-
-      return forUnrestricted();
-
-    case ActorIsolation::Unspecified:
-      return isAccessibleAcrossActors ? forUnrestricted() : forUnsafe();
-    }
-  }
-  }
-}
-
 namespace {
   /// Describes the important parts of a partial apply thunk.
   struct PartialApplyThunkInfo {
@@ -1539,7 +1407,7 @@ static ActorIsolation getInnermostIsolatedContext(const DeclContext *dc) {
 }
 
 /// Determine whether this declaration is always accessed asynchronously.
-static bool isAsyncDecl(ConcreteDeclRef declRef) {
+bool swift::isAsyncDecl(ConcreteDeclRef declRef) {
   auto decl = declRef.getDecl();
 
   // An async function is asynchronously accessed.
@@ -4792,6 +4660,10 @@ static ActorIsolation getActorIsolationForReference(
 
   // A constructor that is not explicitly 'nonisolated' is treated as
   // isolated from the perspective of the referencer.
+  //
+  // FIXME: The current state is that even `nonisolated` initializers are
+  // externally treated as being on the actor, even though this model isn't
+  // consistent. We'll fix it later.
   if (auto ctor = dyn_cast<ConstructorDecl>(decl)) {
     // If the constructor is part of an actor, references to it are treated
     // as needing to enter the actor.
@@ -4826,7 +4698,7 @@ static ActorIsolation getActorIsolationForReference(
 }
 
 /// Determine whether this declaration always throws.
-static bool isThrowsDecl(ConcreteDeclRef declRef) {
+bool swift::isThrowsDecl(ConcreteDeclRef declRef) {
   auto decl = declRef.getDecl();
 
   // An async function is asynchronously accessed.
@@ -4928,13 +4800,33 @@ ActorReferenceResult ActorReferenceResult::forReference(
     ConcreteDeclRef declRef, SourceLoc declRefLoc, const DeclContext *fromDC,
     Optional<VarRefUseEnv> useKind,
     Optional<ReferencedActor> actorInstance) {
+  return forReference(declRef, declRefLoc, fromDC, useKind, actorInstance,
+                      getInnermostIsolatedContext(fromDC));
+}
+
+// Determine if two actor isolation contexts are considered to be equivalent.
+static bool equivalentIsolationContexts(
+    const ActorIsolation &lhs, const ActorIsolation &rhs) {
+  if (lhs == rhs)
+    return true;
+
+  if (lhs == ActorIsolation::ActorInstance &&
+      rhs == ActorIsolation::ActorInstance &&
+      lhs.isDistributedActor() == rhs.isDistributedActor())
+    return true;
+
+  return false;
+}
+
+ActorReferenceResult ActorReferenceResult::forReference(
+    ConcreteDeclRef declRef, SourceLoc declRefLoc, const DeclContext *fromDC,
+    Optional<VarRefUseEnv> useKind,
+    Optional<ReferencedActor> actorInstance,
+    ActorIsolation contextIsolation) {
   // Compute the isolation of the declaration, adjusted for references.
   auto declIsolation = getActorIsolationForReference(declRef.getDecl(), fromDC);
   if (auto subs = declRef.getSubstitutions())
     declIsolation = declIsolation.subst(subs);
-
-  // Compute the isolation of the context.
-  auto contextIsolation = getInnermostIsolatedContext(fromDC);
 
   // When the declaration is not actor-isolated, it can always be accessed
   // directly.
@@ -4955,7 +4847,7 @@ ActorReferenceResult ActorReferenceResult::forReference(
     // If this instance is isolated, we're in the same concurrency domain.
     if (actorInstance->isIsolated())
       return forSameConcurrencyDomain(declIsolation);
-  } else if (contextIsolation == declIsolation) {
+  } else if (equivalentIsolationContexts(declIsolation, contextIsolation)) {
     // The context isolation matches, so we are in the same concurrency
     // domain.
     return forSameConcurrencyDomain(declIsolation);
@@ -5008,13 +4900,21 @@ ActorReferenceResult ActorReferenceResult::forReference(
     options |= Flags::AsyncPromotion;
 
   // If the declaration is isolated to a distributed actor and we are not
-  // guaranteed to be on the same node, adjustments for a distributed call.
-  if (declIsolation.isDistributedActor() &&
-      !(actorInstance && actorInstance->isKnownToBeLocal())) {
-    options |= Flags::Distributed;
+  // guaranteed to be on the same node, make adjustments distributed
+  // access.
+  if (declIsolation.isDistributedActor()) {
+    bool needsDistributed;
+    if (actorInstance)
+      needsDistributed = !actorInstance->isKnownToBeLocal();
+    else
+      needsDistributed = !contextIsolation.isDistributedActor();
 
-    if (!isThrowsDecl(declRef))
-      options |= Flags::ThrowsPromotion;
+    if (needsDistributed) {
+      options |= Flags::Distributed;
+
+      if (!isThrowsDecl(declRef))
+        options |= Flags::ThrowsPromotion;
+    }
   }
 
   return forEntersActor(declIsolation, options);

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1597,10 +1597,6 @@ static void noteGlobalActorOnContext(DeclContext *dc, Type globalActor) {
   }
 }
 
-static bool isAccessibleAcrossActors(
-    ValueDecl *value, const ActorIsolation &isolation,
-    const DeclContext *fromDC, Optional<ReferencedActor> actorInstance);
-
 namespace {
   /// Check for adherence to the actor isolation rules, emitting errors
   /// when actor-isolated declarations are used in an unsafe manner.
@@ -4847,13 +4843,7 @@ static bool isThrowsDecl(ConcreteDeclRef declRef) {
   return false;
 }
 
-/// Determine whether the given value can be accessed across actors
-/// without from normal synchronous code.
-///
-/// \param value The value we are checking.
-/// \param isolation The actor isolation of the value.
-/// \param fromDC The context where we are performing the access.
-static bool isAccessibleAcrossActors(
+bool swift::isAccessibleAcrossActors(
     ValueDecl *value, const ActorIsolation &isolation,
     const DeclContext *fromDC, Optional<ReferencedActor> actorInstance) {
   switch (value->getKind()) {

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1261,6 +1261,9 @@ ReferencedActor ReferencedActor::forGlobalActor(VarDecl *actor,
   return ReferencedActor(actor, isPotentiallyIsolated, kind, globalActor);
 }
 
+static ActorIsolation getActorIsolationForReference(
+    ValueDecl *decl, const DeclContext *fromDC);
+
 bool ReferencedActor::isKnownToBeLocal() const {
   switch (kind) {
   case GlobalActor:
@@ -2250,54 +2253,36 @@ namespace {
         return false;
 
       bool result = false;
-      auto checkDiagnostic = [this, call, isPartialApply,
-                              &result](ValueDecl *decl, SourceLoc argLoc) {
-        auto isolation = ActorIsolationRestriction::forDeclaration(
-            decl, getDeclContext());
-        switch (isolation) {
-        case ActorIsolationRestriction::Unrestricted:
-        case ActorIsolationRestriction::Unsafe:
-          break;
-        case ActorIsolationRestriction::GlobalActorUnsafe:
-          // If we're not supposed to diagnose existing data races here,
-          // we're done.
-          if (!shouldDiagnoseExistingDataRaces(getDeclContext()))
-            break;
+      auto checkDiagnostic = [this, call, isPartialApply, &result](
+          ConcreteDeclRef declRef, SourceLoc argLoc) {
+        auto decl = declRef.getDecl();
+        auto isolation = getActorIsolationForReference(decl, getDeclContext());
+        if (!isolation.isActorIsolated())
+          return;
 
-          LLVM_FALLTHROUGH;
-
-        case ActorIsolationRestriction::GlobalActor: {
-          ctx.Diags.diagnose(argLoc, diag::actor_isolated_inout_state,
-                             decl->getDescriptiveKind(), decl->getName(),
-                             call->isImplicitlyAsync().hasValue());
-          decl->diagnose(diag::kind_declared_here, decl->getDescriptiveKind());
-          result = true;
-          break;
-        }
-        case ActorIsolationRestriction::CrossActorSelf:
-        case ActorIsolationRestriction::ActorSelf: {
-          if (isPartialApply) {
-            // The partially applied InoutArg is a property of actor. This
-            // can really only happen when the property is a struct with a
-            // mutating async method.
-            if (auto partialApply = dyn_cast<ApplyExpr>(call->getFn())) {
-              ValueDecl *fnDecl =
-                  cast<DeclRefExpr>(partialApply->getFn())->getDecl();
+        if (isPartialApply) {
+          // The partially applied InoutArg is a property of actor. This
+          // can really only happen when the property is a struct with a
+          // mutating async method.
+          if (auto partialApply = dyn_cast<ApplyExpr>(call->getFn())) {
+            if (auto declRef = dyn_cast<DeclRefExpr>(partialApply->getFn())) {
+              ValueDecl *fnDecl = declRef->getDecl();
               ctx.Diags.diagnose(call->getLoc(),
                                  diag::actor_isolated_mutating_func,
                                  fnDecl->getName(), decl->getDescriptiveKind(),
                                  decl->getName());
               result = true;
+              return;
             }
-          } else {
-            ctx.Diags.diagnose(argLoc, diag::actor_isolated_inout_state,
-                               decl->getDescriptiveKind(), decl->getName(),
-                               call->isImplicitlyAsync().hasValue());
-            result = true;
           }
-          break;
         }
-        }
+
+        ctx.Diags.diagnose(argLoc, diag::actor_isolated_inout_state,
+                           decl->getDescriptiveKind(), decl->getName(),
+                           call->isImplicitlyAsync().hasValue());
+        decl->diagnose(diag::kind_declared_here, decl->getDescriptiveKind());
+        result = true;
+        return;
       };
       auto expressionWalker = [baseArg = arg->getSubExpr(),
                                checkDiagnostic](Expr *expr) -> Expr * {

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1597,6 +1597,10 @@ static void noteGlobalActorOnContext(DeclContext *dc, Type globalActor) {
   }
 }
 
+static bool isAccessibleAcrossActors(
+    ValueDecl *value, const ActorIsolation &isolation,
+    const DeclContext *fromDC, Optional<ReferencedActor> actorInstance);
+
 namespace {
   /// Check for adherence to the actor isolation rules, emitting errors
   /// when actor-isolated declarations are used in an unsafe manner.
@@ -2696,72 +2700,49 @@ namespace {
     bool checkKeyPathExpr(KeyPathExpr *keyPath) {
       bool diagnosed = false;
 
-      // returns None if it is not a 'let'-bound var decl. Otherwise,
-      // the bool indicates whether a diagnostic was emitted.
-      auto checkLetBoundVarDecl = [&](KeyPathExpr::Component const& component)
-                                                            -> Optional<bool> {
-        auto decl = component.getDeclRef().getDecl();
-        if (auto varDecl = dyn_cast<VarDecl>(decl)) {
-          if (varDecl->isLet()) {
-            auto type = component.getComponentType();
-            if (shouldDiagnoseExistingDataRaces(getDeclContext()) &&
-                diagnoseNonSendableTypes(
-                    type, getDeclContext(), component.getLoc(),
-                    diag::non_sendable_keypath_access))
-              return true;
-
-            return false;
-          }
-        }
-        return None;
-      };
-
       // check the components of the keypath.
       for (const auto &component : keyPath->getComponents()) {
         // The decl referred to by the path component cannot be within an actor.
         if (component.hasDeclRef()) {
           auto concDecl = component.getDeclRef();
-          auto isolation = ActorIsolationRestriction::forDeclaration(
-              concDecl, getDeclContext());
+          auto decl = concDecl.getDecl();
+          auto isolation = getActorIsolationForReference(
+              decl, getDeclContext());
+          switch (isolation) {
+          case ActorIsolation::Independent:
+          case ActorIsolation::Unspecified:
+            break;
 
-          switch (isolation.getKind()) {
-          case ActorIsolationRestriction::Unsafe:
-          case ActorIsolationRestriction::Unrestricted:
-            break; // OK. Does not refer to an actor-isolated member.
-
-          case ActorIsolationRestriction::GlobalActorUnsafe:
-            // Only check if we're in code that's adopted concurrency features.
-            if (!shouldDiagnoseExistingDataRaces(getDeclContext()))
-              break; // do not check
-
-            LLVM_FALLTHROUGH; // otherwise, perform checking
-
-          case ActorIsolationRestriction::GlobalActor:
+          case ActorIsolation::GlobalActor:
+          case ActorIsolation::GlobalActorUnsafe:
             // Disable global actor checking for now.
-            if (!ctx.LangOpts.isSwiftVersionAtLeast(6))
+            if (isolation.isGlobalActor() &&
+                !ctx.LangOpts.isSwiftVersionAtLeast(6))
               break;
 
-            LLVM_FALLTHROUGH; // otherwise, it's invalid so diagnose it.
+            LLVM_FALLTHROUGH;
 
-          case ActorIsolationRestriction::CrossActorSelf:
-            // 'let'-bound decls with this isolation are OK, just check them.
-            if (auto wasLetBound = checkLetBoundVarDecl(component)) {
-              diagnosed = wasLetBound.getValue();
+          case ActorIsolation::ActorInstance:
+            // If this entity is always accessible across actors, just check
+            // Sendable.
+            if (isAccessibleAcrossActors(
+                    decl, isolation, getDeclContext(), None)) {
+              if (diagnoseNonSendableTypes(
+                             component.getComponentType(), getDeclContext(),
+                             component.getLoc(),
+                             diag::non_sendable_keypath_access)) {
+                diagnosed = true;
+              }
               break;
             }
-            LLVM_FALLTHROUGH; // otherwise, it's invalid so diagnose it.
 
-          case ActorIsolationRestriction::ActorSelf: {
-            auto decl = concDecl.getDecl();
             ctx.Diags.diagnose(component.getLoc(),
                                diag::actor_isolated_keypath_component,
-                               isolation.getKind() ==
-                                  ActorIsolationRestriction::CrossActorSelf,
+                               isolation.isDistributedActor(),
                                decl->getDescriptiveKind(), decl->getName());
             diagnosed = true;
             break;
           }
-          }; // end switch
         }
 
         // Captured values in a path component must conform to Sendable.
@@ -4867,12 +4848,12 @@ static bool isThrowsDecl(ConcreteDeclRef declRef) {
 }
 
 /// Determine whether the given value can be accessed across actors
-/// without requiring async promotion.
+/// without from normal synchronous code.
 ///
 /// \param value The value we are checking.
 /// \param isolation The actor isolation of the value.
 /// \param fromDC The context where we are performing the access.
-static bool isAccessibleAcrossActorsWithoutAsyncPromotion(
+static bool isAccessibleAcrossActors(
     ValueDecl *value, const ActorIsolation &isolation,
     const DeclContext *fromDC, Optional<ReferencedActor> actorInstance) {
   switch (value->getKind()) {
@@ -5024,7 +5005,7 @@ ActorReferenceResult ActorReferenceResult::forReference(
   // At this point, we are accessing the target from outside the actor.
   // First, check whether it is something that can be accessed directly,
   // without any kind of promotion.
-  if (isAccessibleAcrossActorsWithoutAsyncPromotion(
+  if (isAccessibleAcrossActors(
           declRef.getDecl(), declIsolation, fromDC, actorInstance))
     return forEntersActor(declIsolation, None);
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1447,7 +1447,7 @@ static bool memberAccessHasSpecialPermissionInSwift5(DeclContext const *refCxt,
         member->getDescriptiveKind(),
         member->getName(),
         useKindInt,
-        baseActor.kind,
+        baseActor.kind + 1,
         baseActor.globalActor,
         getActorIsolation(const_cast<ValueDecl *>(member)))
     .warnUntilSwiftVersion(6);
@@ -1881,7 +1881,7 @@ namespace {
         recordMutableVarParent(load, load->getSubExpr());
 
       if (auto lookup = dyn_cast<LookupExpr>(expr)) {
-        checkMemberReference(lookup->getBase(), lookup->getMember(),
+        checkReference(lookup->getBase(), lookup->getMember(),
                              lookup->getLoc(),
                              /*partialApply*/None,
                              lookup);
@@ -1889,8 +1889,15 @@ namespace {
       }
 
       if (auto declRef = dyn_cast<DeclRefExpr>(expr)) {
-        checkNonMemberReference(
-            declRef->getDeclRef(), declRef->getLoc(), declRef);
+        auto valueRef = declRef->getDeclRef();
+        auto value = valueRef.getDecl();
+        auto loc = declRef->getLoc();
+
+        //FIXME: Should this be subsumed in reference checking?
+        if (value->isLocalCapture())
+          checkLocalCapture(valueRef, loc, declRef);
+        else
+          checkReference(nullptr, valueRef, loc, None, declRef);
         return { true, expr };
       }
 
@@ -1907,7 +1914,7 @@ namespace {
           if (auto memberRef = findMemberReference(partialApply->fn)) {
             // NOTE: partially-applied thunks are never annotated as
             // implicitly async, regardless of whether they are escaping.
-            checkMemberReference(
+            checkReference(
                 partialApply->base, memberRef->first, memberRef->second,
                 partialApply);
 
@@ -1926,7 +1933,7 @@ namespace {
       if (auto call = dyn_cast<SelfApplyExpr>(expr)) {
         Expr *fn = call->getFn()->getValueProvidingExpr();
         if (auto memberRef = findMemberReference(fn)) {
-          checkMemberReference(
+          checkReference(
               call->getBase(), memberRef->first, memberRef->second,
               /*partialApply=*/None, call);
 
@@ -2215,7 +2222,15 @@ namespace {
       if (!var || var->isLet())
         return false;
 
-      if (!var->getDeclContext()->isModuleScopeContext() && !var->isStatic())
+      if (!var->getDeclContext()->isModuleScopeContext() &&
+          !(var->getDeclContext()->isTypeContext() && !var->isInstanceMember()))
+        return false;
+
+      if (!var->hasStorage())
+        return false;
+
+      // If it's actor-isolated, it's already been dealt with.
+      if (getActorIsolation(value).isActorIsolated())
         return false;
 
       ctx.Diags.diagnose(
@@ -2604,97 +2619,6 @@ namespace {
       return false;
     }
 
-    /// Check a reference to an entity within a global actor.
-    bool checkGlobalActorReference(
-        ConcreteDeclRef valueRef, SourceLoc loc, Type globalActor,
-        bool isCrossActor,
-        Expr *context) {
-      ValueDecl *value = valueRef.getDecl();
-      auto declContext = const_cast<DeclContext *>(getDeclContext());
-
-      // Check whether we are within the same isolation context, in which
-      // case there is nothing further to check,
-      auto contextIsolation = getInnermostIsolatedContext(declContext);
-      if (contextIsolation.isGlobalActor() &&
-          contextIsolation.getGlobalActor()->isEqual(globalActor)) {
-        return false;
-      }
-
-      // A cross-actor access requires types to be concurrent-safe.
-      if (isCrossActor) {
-        return diagnoseNonSendableTypesInReference(
-            valueRef, getDeclContext(), loc,
-            SendableCheckReason::CrossActor);
-      }
-
-      // Call is implicitly asynchronous.
-      auto result = tryMarkImplicitlyAsync(
-        loc, valueRef, context,
-        ImplicitActorHopTarget::forGlobalActor(globalActor),
-        /*FIXME if we get global distributed actors*/false);
-      if (result == AsyncMarkingResult::FoundAsync)
-        return false;
-
-      // Diagnose failures.
-      switch (contextIsolation) {
-      case ActorIsolation::ActorInstance: {
-        auto useKind = static_cast<unsigned>(
-            kindOfUsage(value, context).getValueOr(VarRefUseEnv::Read));
-
-        ctx.Diags.diagnose(loc, diag::global_actor_from_instance_actor_context,
-                           value->getDescriptiveKind(), value->getName(),
-                           globalActor, contextIsolation.getActor()->getName(),
-                           useKind, result == AsyncMarkingResult::SyncContext);
-        noteIsolatedActorMember(value, context);
-        return true;
-      }
-
-      case ActorIsolation::GlobalActor:
-      case ActorIsolation::GlobalActorUnsafe: {
-        auto useKind = static_cast<unsigned>(
-            kindOfUsage(value, context).getValueOr(VarRefUseEnv::Read));
-
-        // Otherwise, this is a problematic global actor decl reference.
-        ctx.Diags.diagnose(
-            loc, diag::global_actor_from_other_global_actor_context,
-            value->getDescriptiveKind(), value->getName(), globalActor,
-            contextIsolation.getGlobalActor(), useKind,
-            result == AsyncMarkingResult::SyncContext);
-        noteIsolatedActorMember(value, context);
-        return true;
-      }
-
-      case ActorIsolation::Independent: {
-        auto useKind = static_cast<unsigned>(
-            kindOfUsage(value, context).getValueOr(VarRefUseEnv::Read));
-
-        ctx.Diags.diagnose(loc, diag::global_actor_from_nonactor_context,
-                           value->getDescriptiveKind(), value->getName(),
-                           globalActor,
-                           /*actorIndependent=*/true, useKind,
-                           result == AsyncMarkingResult::SyncContext);
-        noteIsolatedActorMember(value, context);
-        return true;
-      }
-
-      case ActorIsolation::Unspecified: {
-        // Diagnose the reference.
-        auto useKind = static_cast<unsigned>(
-            kindOfUsage(value, context).getValueOr(VarRefUseEnv::Read));
-        ctx.Diags.diagnose(
-          loc, diag::global_actor_from_nonactor_context,
-          value->getDescriptiveKind(), value->getName(), globalActor,
-          /*actorIndependent=*/false, useKind,
-          result == AsyncMarkingResult::SyncContext);
-        noteGlobalActorOnContext(declContext, globalActor);
-        noteIsolatedActorMember(value, context);
-
-        return true;
-      } // end Unspecified case
-      } // end switch
-      llvm_unreachable("unhandled actor isolation kind!");
-    }
-
     /// Find the innermost context in which this declaration was explicitly
     /// captured.
     const DeclContext *findCapturedDeclContext(ValueDecl *value) {
@@ -2874,65 +2798,38 @@ namespace {
       return diagnosed;
     }
 
-    /// Check a reference to a local or global.
-    bool checkNonMemberReference(
-        ConcreteDeclRef valueRef, SourceLoc loc, DeclRefExpr *declRefExpr) {
-      if (!valueRef)
-        return false;
-
-      auto value = valueRef.getDecl();
-
-      if (value->isLocalCapture())
-        return checkLocalCapture(valueRef, loc, declRefExpr);
-
-      switch (auto isolation =
-                  ActorIsolationRestriction::forDeclaration(
-                    valueRef, getDeclContext())) {
-      case ActorIsolationRestriction::Unrestricted:
-        return false;
-
-      case ActorIsolationRestriction::CrossActorSelf:
-      case ActorIsolationRestriction::ActorSelf:
-        llvm_unreachable("non-member reference into an actor");
-
-      case ActorIsolationRestriction::GlobalActorUnsafe:
-        // Only complain if we're in code that's adopted concurrency features.
-        if (!shouldDiagnoseExistingDataRaces(getDeclContext()))
-          return false;
-
-        LLVM_FALLTHROUGH;
-
-      case ActorIsolationRestriction::GlobalActor:
-        return checkGlobalActorReference(
-            valueRef, loc, isolation.getGlobalActor(), isolation.isCrossActor,
-            declRefExpr);
-
-      case ActorIsolationRestriction::Unsafe:
-        return diagnoseReferenceToUnsafeGlobal(value, loc);
-      }
-      llvm_unreachable("unhandled actor isolation kind!");
-    }
-
-    /// Check a reference with the given base expression to the given member.
-    /// Returns true iff the member reference refers to actor-isolated state
-    /// in an invalid or unsafe way such that a diagnostic was emitted.
-    bool checkMemberReference(
-        Expr *base, ConcreteDeclRef memberRef, SourceLoc memberLoc,
+    /// Check a reference to the given declaration.
+    ///
+    /// \param base For a reference to a member, the base expression. May be
+    /// nullptr for non-member referenced.
+    ///
+    /// \returns true if the reference is invalid, in which case a diagnostic
+    /// has already been emitted.
+    bool checkReference(
+        Expr *base, ConcreteDeclRef declRef, SourceLoc loc,
         Optional<PartialApplyThunkInfo> partialApply = None,
         Expr *context = nullptr) {
-      if (!base || !memberRef)
+      if (!declRef)
         return false;
 
-      auto member = memberRef.getDecl();
-      auto isolatedActor = getIsolatedActor(base);
+      auto decl = declRef.getDecl();
+      Optional<ReferencedActor> isolatedActor;
+      if (base)
+        isolatedActor.emplace(getIsolatedActor(base));
       auto result = ActorReferenceResult::forReference(
-          memberRef, memberLoc, getDeclContext(),
-          kindOfUsage(member, context), isolatedActor);
+          declRef, loc, getDeclContext(),
+          kindOfUsage(decl, context), isolatedActor);
       switch (result) {
       case ActorReferenceResult::SameConcurrencyDomain:
+        if (diagnoseReferenceToUnsafeGlobal(decl, loc))
+          return true;
+
         return false;
 
       case ActorReferenceResult::ExitsActorToNonisolated:
+        if (diagnoseReferenceToUnsafeGlobal(decl, loc))
+          return true;
+
         // FIXME: SE-0338 would trigger Sendable checks here.
         return false;
 
@@ -2949,16 +2846,16 @@ namespace {
 
       // A call to a global-actor-isolated function is diagnosed elsewhere.
       if (!partialApply && result.isolation.isGlobalActor() &&
-          isa<AbstractFunctionDecl>(member))
+          isa<AbstractFunctionDecl>(decl))
         return false;
 
       // An escaping partial application of something that is part of
       // the actor's isolated state is never permitted.
-      if (partialApply && partialApply->isEscaping && !isAsyncDecl(memberRef)) {
+      if (partialApply && partialApply->isEscaping && !isAsyncDecl(declRef)) {
         ctx.Diags.diagnose(
-            memberLoc, diag::actor_isolated_partial_apply,
-            member->getDescriptiveKind(),
-            member->getName());
+            loc, diag::actor_isolated_partial_apply,
+            decl->getDescriptiveKind(),
+            decl->getName());
         return true;
       }
 
@@ -2966,7 +2863,7 @@ namespace {
       // Sendable checking and we're done.
       if (!result.options) {
         return diagnoseNonSendableTypesInReference(
-                   memberRef, getDeclContext(), memberLoc,
+                   declRef, getDeclContext(), loc,
                    SendableCheckReason::CrossActor);
       }
 
@@ -2980,7 +2877,7 @@ namespace {
               result.isolation.getGlobalActor())
           : ImplicitActorHopTarget::forInstanceSelf();
       auto implicitAsyncResult = tryMarkImplicitlyAsync(
-          memberLoc, memberRef, context, target, isDistributed);
+          loc, declRef, context, target, isDistributed);
       switch (implicitAsyncResult) {
       case AsyncMarkingResult::FoundAsync:
         // Success! We're done.
@@ -2995,18 +2892,44 @@ namespace {
       case AsyncMarkingResult::NotFound:
         // Complain about access outside of the isolation domain.
         auto useKind = static_cast<unsigned>(
-            kindOfUsage(member, context).getValueOr(VarRefUseEnv::Read));
+            kindOfUsage(decl, context).getValueOr(VarRefUseEnv::Read));
+
+        ReferencedActor::Kind refKind;
+        Type refGlobalActor;
+        if (isolatedActor) {
+          refKind = isolatedActor->kind;
+          refGlobalActor = isolatedActor->globalActor;
+        } else {
+          auto contextIsolation = getInnermostIsolatedContext(getDeclContext());
+          switch (contextIsolation) {
+          case ActorIsolation::ActorInstance:
+            refKind = ReferencedActor::Isolated;
+            break;
+
+          case ActorIsolation::GlobalActor:
+          case ActorIsolation::GlobalActorUnsafe:
+            refGlobalActor = contextIsolation.getGlobalActor();
+            refKind = isMainActor(refGlobalActor)
+                ? ReferencedActor::MainActor
+                : ReferencedActor::GlobalActor;
+            break;
+
+          case ActorIsolation::Unspecified:
+          case ActorIsolation::Independent:
+            refKind = ReferencedActor::NonIsolatedContext;
+            break;
+          }
+        }
 
         ctx.Diags.diagnose(
-            memberLoc, diag::actor_isolated_non_self_reference,
-            member->getDescriptiveKind(),
-            member->getName(),
+            loc, diag::actor_isolated_non_self_reference,
+            decl->getDescriptiveKind(),
+            decl->getName(),
             useKind,
-            isolatedActor.kind,
-            isolatedActor.globalActor,
+            refKind + 1, refGlobalActor,
             result.isolation);
 
-        noteIsolatedActorMember(member, context);
+        noteIsolatedActorMember(decl, context);
 
         if (result.isolation.isGlobalActor()) {
           noteGlobalActorOnContext(

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -412,20 +412,32 @@ Type swift::getExplicitGlobalActor(ClosureExpr *closure) {
 /// nonisolated or it is accessed from within the same module.
 static bool varIsSafeAcrossActors(const ModuleDecl *fromModule,
                                   VarDecl *var,
-                                  ActorIsolation &varIsolation) {
+                                  const ActorIsolation &varIsolation) {
   // must be immutable
   if (!var->isLet())
     return false;
 
-  // if nonisolated, it's OK
-  if (varIsolation == ActorIsolation::Independent)
+  switch (varIsolation) {
+  case ActorIsolation::Independent:
+  case ActorIsolation::Unspecified:
+    // if nonisolated, it's OK
     return true;
 
-  // Otherwise, if it's in the same module then it's OK too.
-  if (fromModule == var->getDeclContext()->getParentModule())
-    return true;
+  case ActorIsolation::ActorInstance:
+  case ActorIsolation::GlobalActor:
+  case ActorIsolation::GlobalActorUnsafe:
+    // If it's explicitly 'nonisolated', it's okay.
+    if (var->getAttrs().hasAttribute<NonisolatedAttr>())
+      return true;
 
-  return false;
+    // If it's distributed, it's not okay.
+    if (auto nominalParent = var->getDeclContext()->getSelfNominalTypeDecl())
+      if (nominalParent->isDistributedActor())
+        return false;
+
+    // If it's actor-isolated but in the same module, then it's OK too.
+    return (fromModule == var->getDeclContext()->getParentModule());
+  }
 }
 
 bool swift::isLetAccessibleAnywhere(const ModuleDecl *fromModule,
@@ -1242,74 +1254,347 @@ static NominalTypeDecl *getSelfActorDecl(const DeclContext *dc) {
   return nominal && nominal->isActor() ? nominal : nullptr;
 }
 
-namespace {
-  /// Describes a referenced actor variable and whether it is isolated.
-  struct ReferencedActor {
-    /// Describes whether the actor variable is isolated or, if it is not
-    /// isolated, why it is not isolated.
-    enum Kind {
-      /// It is isolated.
-      Isolated = 0,
+ReferencedActor ReferencedActor::forGlobalActor(VarDecl *actor,
+                                                bool isPotentiallyIsolated,
+                                                Type globalActor) {
+  Kind kind = isMainActor(globalActor) ? MainActor : GlobalActor;
+  return ReferencedActor(actor, isPotentiallyIsolated, kind, globalActor);
+}
 
-      /// It is not an isolated parameter at all.
-      NonIsolatedParameter,
+bool ReferencedActor::isKnownToBeLocal() const {
+  switch (kind) {
+  case GlobalActor:
+  case AsyncLet:
+  case MainActor:
+  case NonIsolatedAutoclosure:
+  case NonIsolatedContext:
+  case NonIsolatedParameter:
+  case SendableFunction:
+  case SendableClosure:
+    if (isPotentiallyIsolated)
+      return true;
 
-      // It is within a Sendable function.
-      SendableFunction,
+    return actor && actor->isKnownToBeLocal();
 
-      // It is within a Sendable closure.
-      SendableClosure,
+  case Isolated:
+    return true;
+  }
+}
 
-      // It is within an 'async let' initializer.
-      AsyncLet,
+static AbstractFunctionDecl const *
+isActorInitOrDeInitContext(const DeclContext *dc) {
+  return swift::isActorInitOrDeInitContext(
+      dc, [](const AbstractClosureExpr *closure) {
+        return isSendableClosure(closure, /*forActorIsolation=*/false);
+      });
+}
 
-      // It is within a global actor.
-      GlobalActor,
+static bool isStoredProperty(ValueDecl const *member) {
+  if (auto *var = dyn_cast<VarDecl>(member))
+    if (var->hasStorage() && var->isInstanceMember())
+      return true;
+  return false;
+}
 
-      // It is within the main actor.
-      MainActor,
+/// Based on the former escaping-use restriction, which was replaced by
+/// flow-isolation. We need this to support backwards compatability in the
+/// type-checker for programs prior to Swift 6.
+/// \param fn either a constructor or destructor of an actor.
+static bool wasLegacyEscapingUseRestriction(AbstractFunctionDecl *fn) {
+  assert(fn->getDeclContext()->getSelfClassDecl()->isAnyActor());
+  assert(isa<ConstructorDecl>(fn) || isa<DestructorDecl>(fn));
 
-      // It is within a nonisolated context.
-      NonIsolatedContext,
+  // according to today's isolation, determine whether it use to have the
+  // escaping-use restriction
+  switch (getActorIsolation(fn).getKind()) {
+    case ActorIsolation::Independent:
+    case ActorIsolation::GlobalActor:
+    case ActorIsolation::GlobalActorUnsafe:
+      // convenience inits did not have the restriction.
+      if (auto *ctor = dyn_cast<ConstructorDecl>(fn))
+        if (ctor->isConvenienceInit())
+          return false;
 
-      // It is within a nonisolated autoclosure argument. This is primarily here
-      // to aid in giving specific diagnostics, because autoclosures are not
-      // always easy for programmers to notice.
-      NonIsolatedAutoclosure
-    };
+      break; // goto basic case
 
-    VarDecl * const actor;
-    /// The outer scope is known to be running on an actor.
-    /// We may be isolated to the actor or not, depending on the exact expression
-    const bool isPotentiallyIsolated;
-    const Kind kind;
-    const Type globalActor;
+    case ActorIsolation::ActorInstance:
+      // none of these had the restriction affect them.
+      assert(fn->hasAsync());
+      return false;
 
-    ReferencedActor(VarDecl *actor, bool isPotentiallyIsolated, Kind kind, Type globalActor = Type())
-      : actor(actor),
-        isPotentiallyIsolated(isPotentiallyIsolated),
-        kind(kind),
-        globalActor(globalActor) {}
-
-    static ReferencedActor forGlobalActor(VarDecl *actor,
-                                          bool isPotentiallyIsolated,
-                                          Type globalActor) {
-      Kind kind = isMainActor(globalActor) ? MainActor : GlobalActor;
-      return ReferencedActor(actor, isPotentiallyIsolated, kind, globalActor);
-    }
-
-    bool isIsolated() const { return kind == Isolated; }
-
-    /// Whether the variable is the "self" of an actor method.
-    bool isActorSelf() const {
-      if (!actor)
-        return false;
-      return actor->isActorSelf();
-    }
-
-    explicit operator bool() const { return isIsolated(); }
+    case ActorIsolation::Unspecified:
+      // this is basically just objc-marked inits.
+      break;
   };
 
+  return !(fn->hasAsync()); // basic case: not async = had restriction.
+}
+
+/// Note that the given actor member is isolated.
+static void noteIsolatedActorMember(
+    ValueDecl const* decl, Optional<VarRefUseEnv> useKind) {
+  // detect if it is a distributed actor, to provide better isolation notes
+
+  auto nominal = decl->getDeclContext()->getSelfNominalTypeDecl();
+  bool isDistributedActor = false;
+  if (nominal) isDistributedActor = nominal->isDistributedActor();
+
+  // FIXME: Make this diagnostic more sensitive to the isolation context of
+  // the declaration.
+  if (isDistributedActor) {
+    if (isa<VarDecl>(decl)) {
+      // Distributed actor properties are never accessible externally.
+      decl->diagnose(diag::distributed_actor_isolated_property,
+                     decl->getDescriptiveKind(), decl->getName(),
+                     nominal->getName());
+    } else {
+      // it's a function or subscript
+      decl->diagnose(diag::note_distributed_actor_isolated_method,
+                     decl->getDescriptiveKind(),
+                     decl->getName());
+    }
+  } else if (auto func = dyn_cast<AbstractFunctionDecl>(decl)) {
+    func->diagnose(diag::actor_isolated_sync_func,
+      decl->getDescriptiveKind(),
+      decl->getName());
+
+    // was it an attempt to mutate an actor instance's isolated state?
+  } else if (useKind) {
+    if (*useKind == VarRefUseEnv::Read)
+      decl->diagnose(diag::kind_declared_here, decl->getDescriptiveKind());
+    else
+      decl->diagnose(diag::actor_mutable_state, decl->getDescriptiveKind());
+
+  } else {
+    decl->diagnose(diag::kind_declared_here, decl->getDescriptiveKind());
+  }
+}
+
+/// An ad-hoc check specific to member isolation checking. assumed to be
+/// queried when a self-member is being accessed in a context which is not
+/// isolated to self. The "special permission" is part of a backwards
+/// compatability with actor inits and deinits that maintains the
+/// permissive nature of the escaping-use restriction, which was only
+/// staged in as a warning. See implementation for more details.
+///
+/// \returns true if this access in the given context should be allowed
+/// in Sema, with the side-effect of emitting a warning as needed.
+/// If false is returned, then the "special permission" was not granted.
+static bool memberAccessHasSpecialPermissionInSwift5(DeclContext const *refCxt,
+                                    ReferencedActor &baseActor,
+                                    ValueDecl const *member,
+                                    SourceLoc memberLoc,
+                                    Optional<VarRefUseEnv> useKind) {
+  // no need for this in Swift 6+
+  if (refCxt->getASTContext().isSwiftVersionAtLeast(6))
+    return false;
+
+  // must be an access to an instance member.
+  if (!member->isInstanceMember())
+    return false;
+
+  // In the history of actor initializers prior to Swift 6, self-isolated
+  // members could be referenced from any init or deinit, even a synchronous
+  // one, with no diagnostics at all.
+  //
+  // When the escaping-use restriction came into place for the release of
+  // 5.5, it was implemented as a warning and only applied to initializers,
+  // which stated that it would become an error in Swift 6.
+  //
+  // Once 5.6 was released, we also added restrictions in the deinits of
+  // actors, at least for accessing members other than stored properties.
+  //
+  // Later on, for 5.7 we introduced flow-isolation as part of SE-327 for
+  // both inits and deinits. This meant that stored property accesses now
+  // are only sometimes going to be problematic. This change also brought
+  // official changes in isolation for the inits and deinits to handle the
+  // the non-stored-property members. Since those isolation changes are
+  // currently in place, the purpose of the code below is to override the
+  // isolation checking, so that the now-mismatched isolation on member
+  // access is still permitted, but with a warning stating that it will
+  // be rejected in Swift 6.
+  //
+  // In the checking below, we let stored-property accesses go ignored,
+  // so that flow-isolation can warn about them only if needed. This helps
+  // prevent needless warnings on property accesses that will actually be OK
+  // with flow-isolation in the future.
+  if (auto oldFn = isActorInitOrDeInitContext(refCxt)) {
+    auto oldFnMut = const_cast<AbstractFunctionDecl*>(oldFn);
+
+    // If function did not have the escaping-use restriction, then it gets
+    // no special permissions here.
+    if (!wasLegacyEscapingUseRestriction(oldFnMut))
+      return false;
+
+    // At this point, the special permission will be granted. But, we
+    // need to warn now about this permission being taken away in Swift 6
+    // for specific kinds of non-stored-property member accesses:
+
+    // If the context in which we consider the access matches between the
+    // old (escaping-use restriction) and new (flow-isolation) contexts,
+    // and it is a stored property, then permit it here without any warning.
+    // Later, flow-isolation pass will check and emit a warning if needed.
+    if (refCxt == oldFn && isStoredProperty(member))
+      return true;
+
+    // Otherwise, it's definitely going to be illegal, so warn and permit.
+    auto &diags = refCxt->getASTContext().Diags;
+    auto useKindInt = static_cast<unsigned>(
+        useKind.getValueOr(VarRefUseEnv::Read));
+
+    diags.diagnose(
+        memberLoc, diag::actor_isolated_non_self_reference,
+        member->getDescriptiveKind(),
+        member->getName(),
+        useKindInt,
+        baseActor.kind,
+        baseActor.globalActor,
+        getActorIsolation(const_cast<ValueDecl *>(member)))
+    .warnUntilSwiftVersion(6);
+
+    noteIsolatedActorMember(member, useKind);
+    return true;
+  }
+
+  return false;
+}
+
+/// To support flow-isolation, some member accesses in inits / deinits
+/// must be permitted, despite the isolation of 'self' not being
+/// correct in Sema.
+///
+/// \param refCxt the context in which the member reference happens.
+/// \param baseActor the actor referenced in the base of the member access.
+/// \param member the declaration corresponding to the accessed member.
+/// \param memberLoc the source location of the reference to the member.
+///
+/// \returns true iff the member access is permitted in Sema because it will
+/// be verified later by flow-isolation.
+static bool checkedByFlowIsolation(DeclContext const *refCxt,
+                                   ReferencedActor &baseActor,
+                                   ValueDecl const *member,
+                                   SourceLoc memberLoc,
+                                   Optional<VarRefUseEnv> useKind) {
+
+  // base of member reference must be `self`
+  if (!baseActor.isSelf())
+    return false;
+
+  // Must be directly in an init/deinit that uses flow-isolation,
+  // or a defer within such a functions.
+  //
+  // NOTE: once flow-isolation can analyze calls to arbitrary local
+  // functions, we should be using isActorInitOrDeInitContext instead
+  // of this ugly loop.
+  AbstractFunctionDecl const* fnDecl = nullptr;
+  while (true) {
+    fnDecl = dyn_cast_or_null<AbstractFunctionDecl>(refCxt->getAsDecl());
+    if (!fnDecl)
+      break;
+
+    // go up one level if this context is a defer.
+    if (auto *d = dyn_cast<FuncDecl>(fnDecl)) {
+      if (d->isDeferBody()) {
+        refCxt = refCxt->getParent();
+        continue;
+      }
+    }
+    break;
+  }
+
+  if (memberAccessHasSpecialPermissionInSwift5(refCxt, baseActor, member,
+                                               memberLoc, useKind))
+    return true; // then permit it now.
+
+  if (!usesFlowSensitiveIsolation(fnDecl))
+    return false;
+
+  // Stored properties are definitely OK.
+  if (isStoredProperty(member))
+    return true;
+
+  return false;
+}
+
+/// Get the actor isolation of the innermost relevant context.
+static ActorIsolation getInnermostIsolatedContext(const DeclContext *dc) {
+  // Retrieve the actor isolation of the context.
+  auto mutableDC = const_cast<DeclContext *>(dc);
+  switch (auto isolation = getActorIsolationOfContext(mutableDC)) {
+  case ActorIsolation::ActorInstance:
+  case ActorIsolation::Independent:
+  case ActorIsolation::Unspecified:
+    return isolation;
+
+  case ActorIsolation::GlobalActor:
+  case ActorIsolation::GlobalActorUnsafe:
+    return ActorIsolation::forGlobalActor(
+        dc->mapTypeIntoContext(isolation.getGlobalActor()),
+        isolation == ActorIsolation::GlobalActorUnsafe)
+          .withPreconcurrency(isolation.preconcurrency());
+  }
+}
+
+/// Determine whether this declaration is always accessed asynchronously.
+static bool isAsyncDecl(ConcreteDeclRef declRef) {
+  auto decl = declRef.getDecl();
+
+  // An async function is asynchronously accessed.
+  if (auto func = dyn_cast<AbstractFunctionDecl>(decl))
+    return func->hasAsync();
+
+  // A computed property or subscript that has an 'async' getter
+  // is asynchronously accessed.
+  if (auto storageDecl = dyn_cast<AbstractStorageDecl>(decl)) {
+    if (auto effectfulGetter = storageDecl->getEffectfulGetAccessor())
+      return effectfulGetter->hasAsync();
+  }
+
+  return false;
+}
+
+static FuncDecl *findAnnotatableFunction(DeclContext *dc) {
+  auto fn = dyn_cast<FuncDecl>(dc);
+  if (!fn) return nullptr;
+  if (fn->isDeferBody())
+    return findAnnotatableFunction(fn->getDeclContext());
+  return fn;
+}
+
+/// Note when the enclosing context could be put on a global actor.
+static void noteGlobalActorOnContext(DeclContext *dc, Type globalActor) {
+  // If we are in a synchronous function on the global actor,
+  // suggest annotating with the global actor itself.
+  if (auto fn = findAnnotatableFunction(dc)) {
+    // Suppress this for accesssors because you can't change the
+    // actor isolation of an individual accessor.  Arguably we could
+    // add this to the entire storage declaration, though.
+    // Suppress this for async functions out of caution; but don't
+    // suppress it if we looked through a defer.
+    if (!isa<AccessorDecl>(fn) &&
+        (!fn->isAsyncContext() || fn != dc)) {
+      switch (getActorIsolation(fn)) {
+      case ActorIsolation::ActorInstance:
+      case ActorIsolation::GlobalActor:
+      case ActorIsolation::GlobalActorUnsafe:
+      case ActorIsolation::Independent:
+        return;
+
+      case ActorIsolation::Unspecified:
+        fn->diagnose(diag::note_add_globalactor_to_function,
+            globalActor->getWithoutParens().getString(),
+            fn->getDescriptiveKind(),
+            fn->getName(),
+            globalActor)
+          .fixItInsert(fn->getAttributeInsertionLoc(false),
+            diag::insert_globalactor_attr, globalActor);
+          return;
+      }
+    }
+  }
+}
+
+namespace {
   /// Check for adherence to the actor isolation rules, emitting errors
   /// when actor-isolated declarations are used in an unsafe manner.
   class ActorIsolationChecker : public ASTWalker {
@@ -1334,14 +1619,6 @@ namespace {
     /// an inout expr.
     llvm::SmallDenseMap<MutableVarSource, MutableVarParent, 4>
       mutableLocalVarParent;
-
-    /// The values for each case in this enum correspond to %select numbers
-    /// in a diagnostic, so be sure to update it if you add new cases.
-    enum class VarRefUseEnv {
-      Read = 0,
-      Mutating = 1,
-      Inout = 2 // means Mutating; having a separate kind helps diagnostics
-    };
 
     static bool isPropOrSubscript(ValueDecl const* decl) {
       return isa<VarDecl>(decl) || isa<SubscriptDecl>(decl);
@@ -1869,16 +2146,6 @@ namespace {
       return ReferencedActor(var, isPotentiallyIsolated, ReferencedActor::NonIsolatedParameter);
     }
 
-    /// If the expression is a reference to `self`, the `self` declaration.
-    VarDecl *getReferencedSelf(Expr *expr) {
-      if (auto selfVar = getReferencedParamOrCapture(expr))
-        if (selfVar->isSelfParameter() || selfVar->isSelfParamCapture())
-          return selfVar;
-
-      // Not a self reference.
-      return nullptr;
-    }
-
     VarDecl *findReferencedBaseSelf(Expr *expr) {
       if (auto selfVar = getReferencedParamOrCapture(expr))
         if (selfVar->isSelfParameter() || selfVar->isSelfParamCapture())
@@ -1912,86 +2179,10 @@ namespace {
       return nullptr;
     }
 
-    static FuncDecl *findAnnotatableFunction(DeclContext *dc) {
-      auto fn = dyn_cast<FuncDecl>(dc);
-      if (!fn) return nullptr;
-      if (fn->isDeferBody())
-        return findAnnotatableFunction(fn->getDeclContext());
-      return fn;
-    }
-
-    /// Note when the enclosing context could be put on a global actor.
-    void noteGlobalActorOnContext(DeclContext *dc, Type globalActor) {
-      // If we are in a synchronous function on the global actor,
-      // suggest annotating with the global actor itself.
-      if (auto fn = findAnnotatableFunction(dc)) {
-        // Suppress this for accesssors because you can't change the
-        // actor isolation of an individual accessor.  Arguably we could
-        // add this to the entire storage declaration, though.
-        // Suppress this for async functions out of caution; but don't
-        // suppress it if we looked through a defer.
-        if (!isa<AccessorDecl>(fn) &&
-            (!fn->isAsyncContext() || fn != dc)) {
-          switch (getActorIsolation(fn)) {
-          case ActorIsolation::ActorInstance:
-          case ActorIsolation::GlobalActor:
-          case ActorIsolation::GlobalActorUnsafe:
-          case ActorIsolation::Independent:
-            return;
-
-          case ActorIsolation::Unspecified:
-            fn->diagnose(diag::note_add_globalactor_to_function,
-                globalActor->getWithoutParens().getString(),
-                fn->getDescriptiveKind(),
-                fn->getName(),
-                globalActor)
-              .fixItInsert(fn->getAttributeInsertionLoc(false),
-                diag::insert_globalactor_attr, globalActor);
-              return;
-          }
-        }
-      }
-    }
-
     /// Note that the given actor member is isolated.
     /// @param context is allowed to be null if no context is appropriate.
     void noteIsolatedActorMember(ValueDecl const* decl, Expr *context) {
-      // detect if it is a distributed actor, to provide better isolation notes
-
-      auto nominal = decl->getDeclContext()->getSelfNominalTypeDecl();
-      bool isDistributedActor = false;
-      if (nominal) isDistributedActor = nominal->isDistributedActor();
-
-      // FIXME: Make this diagnostic more sensitive to the isolation context of
-      // the declaration.
-      if (isDistributedActor) {
-        if (isa<VarDecl>(decl)) {
-          // Distributed actor properties are never accessible externally.
-          decl->diagnose(diag::distributed_actor_isolated_property,
-                         decl->getDescriptiveKind(), decl->getName(),
-                         nominal->getName());
-        } else {
-          // it's a function or subscript
-          decl->diagnose(diag::note_distributed_actor_isolated_method,
-                         decl->getDescriptiveKind(),
-                         decl->getName());
-        }
-      } else if (auto func = dyn_cast<AbstractFunctionDecl>(decl)) {
-        func->diagnose(diag::actor_isolated_sync_func,
-          decl->getDescriptiveKind(),
-          decl->getName());
-
-        // was it an attempt to mutate an actor instance's isolated state?
-      } else if (auto environment = kindOfUsage(decl, context)) {
-
-        if (environment.getValue() == VarRefUseEnv::Read)
-          decl->diagnose(diag::kind_declared_here, decl->getDescriptiveKind());
-        else
-          decl->diagnose(diag::actor_mutable_state, decl->getDescriptiveKind());
-
-      } else {
-        decl->diagnose(diag::kind_declared_here, decl->getDescriptiveKind());
-      }
+      ::noteIsolatedActorMember(decl, kindOfUsage(decl, context));
     }
 
     // Retrieve the nearest enclosing actor context.
@@ -2111,24 +2302,6 @@ namespace {
       };
       arg->getSubExpr()->forEachChildExpr(expressionWalker);
       return result;
-    }
-
-    /// Get the actor isolation of the innermost relevant context.
-    ActorIsolation getInnermostIsolatedContext(DeclContext *dc) {
-      // Retrieve the actor isolation of the context.
-      switch (auto isolation = getActorIsolationOfContext(dc)) {
-      case ActorIsolation::ActorInstance:
-      case ActorIsolation::Independent:
-      case ActorIsolation::Unspecified:
-        return isolation;
-
-      case ActorIsolation::GlobalActor:
-      case ActorIsolation::GlobalActorUnsafe:
-        return ActorIsolation::forGlobalActor(
-            dc->mapTypeIntoContext(isolation.getGlobalActor()),
-            isolation == ActorIsolation::GlobalActorUnsafe)
-              .withPreconcurrency(isolation.preconcurrency());
-      }
     }
 
     enum class AsyncMarkingResult {
@@ -2701,201 +2874,6 @@ namespace {
       return diagnosed;
     }
 
-    static AbstractFunctionDecl const *
-    isActorInitOrDeInitContext(const DeclContext *dc) {
-      return ::isActorInitOrDeInitContext(
-          dc, [](const AbstractClosureExpr *closure) {
-            return isSendableClosure(closure, /*forActorIsolation=*/false);
-          });
-    }
-
-    static bool isStoredProperty(ValueDecl const *member) {
-      if (auto *var = dyn_cast<VarDecl>(member))
-        if (var->hasStorage() && var->isInstanceMember())
-          return true;
-      return false;
-    }
-
-    /// Based on the former escaping-use restriction, which was replaced by
-    /// flow-isolation. We need this to support backwards compatability in the
-    /// type-checker for programs prior to Swift 6.
-    /// \param fn either a constructor or destructor of an actor.
-    static bool wasLegacyEscapingUseRestriction(AbstractFunctionDecl *fn) {
-      assert(fn->getDeclContext()->getSelfClassDecl()->isAnyActor());
-      assert(isa<ConstructorDecl>(fn) || isa<DestructorDecl>(fn));
-
-      // according to today's isolation, determine whether it use to have the
-      // escaping-use restriction
-      switch (getActorIsolation(fn).getKind()) {
-        case ActorIsolation::Independent:
-        case ActorIsolation::GlobalActor:
-        case ActorIsolation::GlobalActorUnsafe:
-          // convenience inits did not have the restriction.
-          if (auto *ctor = dyn_cast<ConstructorDecl>(fn))
-            if (ctor->isConvenienceInit())
-              return false;
-
-          break; // goto basic case
-
-        case ActorIsolation::ActorInstance:
-          // none of these had the restriction affect them.
-          assert(fn->hasAsync());
-          return false;
-
-        case ActorIsolation::Unspecified:
-          // this is basically just objc-marked inits.
-          break;
-      };
-
-      return !(fn->hasAsync()); // basic case: not async = had restriction.
-    }
-
-    /// An ad-hoc check specific to member isolation checking. assumed to be
-    /// queried when a self-member is being accessed in a context which is not
-    /// isolated to self. The "special permission" is part of a backwards
-    /// compatability with actor inits and deinits that maintains the
-    /// permissive nature of the escaping-use restriction, which was only
-    /// staged in as a warning. See implementation for more details.
-    ///
-    /// \returns true if this access in the given context should be allowed
-    /// in Sema, with the side-effect of emitting a warning as needed.
-    /// If false is returned, then the "special permission" was not granted.
-    bool memberAccessHasSpecialPermissionInSwift5(DeclContext const *refCxt,
-                                        ReferencedActor &baseActor,
-                                        ValueDecl const *member,
-                                        SourceLoc memberLoc,
-                                        Expr *exprCxt) {
-      // no need for this in Swift 6+
-      if (refCxt->getASTContext().isSwiftVersionAtLeast(6))
-        return false;
-
-      // must be an access to an instance member.
-      if (!member->isInstanceMember())
-        return false;
-
-      // In the history of actor initializers prior to Swift 6, self-isolated
-      // members could be referenced from any init or deinit, even a synchronous
-      // one, with no diagnostics at all.
-      //
-      // When the escaping-use restriction came into place for the release of
-      // 5.5, it was implemented as a warning and only applied to initializers,
-      // which stated that it would become an error in Swift 6.
-      //
-      // Once 5.6 was released, we also added restrictions in the deinits of
-      // actors, at least for accessing members other than stored properties.
-      //
-      // Later on, for 5.7 we introduced flow-isolation as part of SE-327 for
-      // both inits and deinits. This meant that stored property accesses now
-      // are only sometimes going to be problematic. This change also brought
-      // official changes in isolation for the inits and deinits to handle the
-      // the non-stored-property members. Since those isolation changes are
-      // currently in place, the purpose of the code below is to override the
-      // isolation checking, so that the now-mismatched isolation on member
-      // access is still permitted, but with a warning stating that it will
-      // be rejected in Swift 6.
-      //
-      // In the checking below, we let stored-property accesses go ignored,
-      // so that flow-isolation can warn about them only if needed. This helps
-      // prevent needless warnings on property accesses that will actually be OK
-      // with flow-isolation in the future.
-      if (auto oldFn = isActorInitOrDeInitContext(refCxt)) {
-        auto oldFnMut = const_cast<AbstractFunctionDecl*>(oldFn);
-
-        // If function did not have the escaping-use restriction, then it gets
-        // no special permissions here.
-        if (!wasLegacyEscapingUseRestriction(oldFnMut))
-          return false;
-
-        // At this point, the special permission will be granted. But, we
-        // need to warn now about this permission being taken away in Swift 6
-        // for specific kinds of non-stored-property member accesses:
-
-        // If the context in which we consider the access matches between the
-        // old (escaping-use restriction) and new (flow-isolation) contexts,
-        // and it is a stored property, then permit it here without any warning.
-        // Later, flow-isolation pass will check and emit a warning if needed.
-        if (refCxt == oldFn && isStoredProperty(member))
-          return true;
-
-
-        // Otherwise, it's definitely going to be illegal, so warn and permit.
-        auto &diags = refCxt->getASTContext().Diags;
-        auto useKind = static_cast<unsigned>(
-            kindOfUsage(member, exprCxt).getValueOr(VarRefUseEnv::Read));
-
-        diags.diagnose(
-            memberLoc, diag::actor_isolated_non_self_reference,
-            member->getDescriptiveKind(),
-            member->getName(),
-            useKind,
-            baseActor.kind - 1,
-            baseActor.globalActor)
-        .warnUntilSwiftVersion(6);
-
-        noteIsolatedActorMember(member, exprCxt);
-        return true;
-      }
-
-      return false;
-    }
-
-    /// To support flow-isolation, some member accesses in inits / deinits
-    /// must be permitted, despite the isolation of 'self' not being
-    /// correct in Sema.
-    ///
-    /// \param refCxt the context in which the member reference happens.
-    /// \param baseActor the actor referenced in the base of the member access.
-    /// \param member the declaration corresponding to the accessed member.
-    /// \param memberLoc the source location of the reference to the member.
-    ///
-    /// \returns true iff the member access is permitted in Sema because it will
-    /// be verified later by flow-isolation.
-    bool checkedByFlowIsolation(DeclContext const *refCxt,
-                                ReferencedActor &baseActor,
-                                ValueDecl const *member,
-                                SourceLoc memberLoc,
-                                Expr *exprCxt) {
-
-      // base of member reference must be `self`
-      if (!baseActor.isActorSelf())
-        return false;
-
-      // Must be directly in an init/deinit that uses flow-isolation,
-      // or a defer within such a functions.
-      //
-      // NOTE: once flow-isolation can analyze calls to arbitrary local
-      // functions, we should be using isActorInitOrDeInitContext instead
-      // of this ugly loop.
-      AbstractFunctionDecl const* fnDecl = nullptr;
-      while (true) {
-        fnDecl = dyn_cast_or_null<AbstractFunctionDecl>(refCxt->getAsDecl());
-        if (!fnDecl)
-          break;
-
-        // go up one level if this context is a defer.
-        if (auto *d = dyn_cast<FuncDecl>(fnDecl)) {
-          if (d->isDeferBody()) {
-            refCxt = refCxt->getParent();
-            continue;
-          }
-        }
-        break;
-      }
-
-      if (memberAccessHasSpecialPermissionInSwift5(refCxt, baseActor, member,
-                                                   memberLoc, exprCxt))
-        return true; // then permit it now.
-
-      if (!usesFlowSensitiveIsolation(fnDecl))
-        return false;
-
-      // Stored properties are definitely OK.
-      if (isStoredProperty(member))
-          return true;
-
-      return false;
-    }
-
     /// Check a reference to a local or global.
     bool checkNonMemberReference(
         ConcreteDeclRef valueRef, SourceLoc loc, DeclRefExpr *declRefExpr) {
@@ -2946,92 +2924,75 @@ namespace {
         return false;
 
       auto member = memberRef.getDecl();
-      switch (auto isolation =
-                  ActorIsolationRestriction::forDeclaration(
-                    memberRef, getDeclContext())) {
-      case ActorIsolationRestriction::Unrestricted:
+      auto isolatedActor = getIsolatedActor(base);
+      auto result = ActorReferenceResult::forReference(
+          memberRef, memberLoc, getDeclContext(),
+          kindOfUsage(member, context), isolatedActor);
+      switch (result) {
+      case ActorReferenceResult::SameConcurrencyDomain:
         return false;
 
-      case ActorIsolationRestriction::CrossActorSelf: {
-        // If a cross-actor reference is to an isolated actor, it's not
-        // crossing actors.
-        auto isolatedActor = getIsolatedActor(base);
-        if (isolatedActor)
-          return false;
+      case ActorReferenceResult::ExitsActorToNonisolated:
+        // FIXME: SE-0338 would trigger Sendable checks here.
+        return false;
 
-        // For now, cross-actor self reference to a member is OK from an actor's
-        // init or deinit. Later, flow-isolation will check unsafe references.
-        if (isActorInitOrDeInitContext(getDeclContext()))
-          return false;
-
-        // If we have a distributed actor that might be remote, check that
-        // we are referencing a properly-distributed member.
-        bool performDistributedChecks =
-            isolation.getActorType()->isDistributedActor() &&
-            !isolatedActor.isPotentiallyIsolated &&
-            !isa<ConstructorDecl>(member) &&
-            !member->getAttrs().hasAttribute<KnownToBeLocalAttr>();
-        if (performDistributedChecks) {
-          if (auto access = checkDistributedAccess(memberLoc, member, context)){
-            // This is a distributed access, so mark it as throwing or
-            // using a distributed thunk as appropriate.
-            markNearestCallAsImplicitly(None, access->first, access->second);
-          } else {
-            return true;
-          }
-        }
-
-        return diagnoseNonSendableTypesInReference(
-            memberRef, getDeclContext(), memberLoc,
-            SendableCheckReason::CrossActor);
+      case ActorReferenceResult::EntersActor:
+        // Handle all of the checking below.
+        break;
       }
 
-      case ActorIsolationRestriction::ActorSelf: {
-        // Check whether the base is a reference to an isolated actor instance.
-        // If so, there's nothing more to check.
-        auto isolatedActor = getIsolatedActor(base);
-        if (isolatedActor)
-          return false;
+      // A partial application of a global-actor-isolated member is always
+      // okay, because the global actor is part of the resulting function
+      // type.
+      if (partialApply && result.isolation.isGlobalActor())
+        return false;
 
-        // Some initializers and deinitializers have special permission to
-        // access an isolated member on `self`. If that case applies, then we
-        // can skip checking.
-        if (checkedByFlowIsolation(getDeclContext(), isolatedActor,
-                                          member, memberLoc, context))
-          return false;
+      // A call to a global-actor-isolated function is diagnosed elsewhere.
+      if (!partialApply && result.isolation.isGlobalActor() &&
+          isa<AbstractFunctionDecl>(member))
+        return false;
 
-        // An escaping partial application of something that is part of
-        // the actor's isolated state is never permitted.
-        if (partialApply && partialApply->isEscaping) {
-          ctx.Diags.diagnose(
-              memberLoc, diag::actor_isolated_partial_apply,
-              member->getDescriptiveKind(),
-              member->getName());
-          return true;
-        }
+      // An escaping partial application of something that is part of
+      // the actor's isolated state is never permitted.
+      if (partialApply && partialApply->isEscaping && !isAsyncDecl(memberRef)) {
+        ctx.Diags.diagnose(
+            memberLoc, diag::actor_isolated_partial_apply,
+            member->getDescriptiveKind(),
+            member->getName());
+        return true;
+      }
 
-        // Try implicit asynchronous access.
-        bool isDistributed = isolation.getActorType()->isDistributedActor() &&
-            !isolatedActor.isPotentiallyIsolated;
-        auto implicitAsyncResult = tryMarkImplicitlyAsync(
-            memberLoc, memberRef, context,
-            ImplicitActorHopTarget::forInstanceSelf(),
-            isDistributed);
+      // If we do not need any async/throws/distributed checks, just perform
+      // Sendable checking and we're done.
+      if (!result.options) {
+        return diagnoseNonSendableTypesInReference(
+                   memberRef, getDeclContext(), memberLoc,
+                   SendableCheckReason::CrossActor);
+      }
 
-        switch (implicitAsyncResult) {
-        case AsyncMarkingResult::FoundAsync:
-          return false;
+      // Some combination of implicit async/throws/distributed is required.
+      bool isDistributed = result.options.contains(
+          ActorReferenceResult::Flags::Distributed);
 
-        case AsyncMarkingResult::NotSendable:
-        case AsyncMarkingResult::NotDistributed:
-          return true;
+      // Determine the actor hop.
+      ImplicitActorHopTarget target = result.isolation.isGlobalActor()
+          ? ImplicitActorHopTarget::forGlobalActor(
+              result.isolation.getGlobalActor())
+          : ImplicitActorHopTarget::forInstanceSelf();
+      auto implicitAsyncResult = tryMarkImplicitlyAsync(
+          memberLoc, memberRef, context, target, isDistributed);
+      switch (implicitAsyncResult) {
+      case AsyncMarkingResult::FoundAsync:
+        // Success! We're done.
+        return false;
 
-        case AsyncMarkingResult::NotFound:
-        case AsyncMarkingResult::SyncContext:
-          // Diagnose below.
-          break;
-        }
+      case AsyncMarkingResult::NotDistributed:
+      case AsyncMarkingResult::NotSendable:
+        // Failed, but diagnostics have already been emitted.
+        return true;
 
+      case AsyncMarkingResult::SyncContext:
+      case AsyncMarkingResult::NotFound:
         // Complain about access outside of the isolation domain.
         auto useKind = static_cast<unsigned>(
             kindOfUsage(member, context).getValueOr(VarRefUseEnv::Read));
@@ -3041,49 +3002,20 @@ namespace {
             member->getDescriptiveKind(),
             member->getName(),
             useKind,
-            isolatedActor.kind - 1,
-            isolatedActor.globalActor);
+            isolatedActor.kind,
+            isolatedActor.globalActor,
+            result.isolation);
 
         noteIsolatedActorMember(member, context);
-        // FIXME: If isolatedActor has a variable in it, refer to that with
-        // more detail?
-        return true;
-      }
 
-      case ActorIsolationRestriction::GlobalActorUnsafe:
-        // Only complain if we're in code that's adopted concurrency features.
-        if (!shouldDiagnoseExistingDataRaces(getDeclContext()))
-          return false;
-
-        LLVM_FALLTHROUGH;
-
-      case ActorIsolationRestriction::GlobalActor: {
-        const bool isInitDeInit = isa<ConstructorDecl>(getDeclContext()) ||
-                                  isa<DestructorDecl>(getDeclContext());
-        // If we are within an initializer or deinitilizer and are referencing a
-        // stored property on "self", we are not crossing actors.
-        if (isInitDeInit && isa<VarDecl>(member) &&
-            cast<VarDecl>(member)->hasStorage() && getReferencedSelf(base))
-          return false;
-        return checkGlobalActorReference(
-            memberRef, memberLoc, isolation.getGlobalActor(),
-            isolation.isCrossActor, context);
-      }
-      case ActorIsolationRestriction::Unsafe:
-        // This case is hit when passing actor state inout to functions in some
-        // cases. The error is emitted by diagnoseInOutArg.
-        auto nominal = member->getDeclContext()->getSelfNominalTypeDecl();
-        if (nominal && nominal->isDistributedActor()) {
-          auto funcDecl = dyn_cast<AbstractFunctionDecl>(member);
-          if (funcDecl && !funcDecl->isStatic()) {
-            member->diagnose(diag::distributed_actor_isolated_method);
-            return true;
-          }
+        if (result.isolation.isGlobalActor()) {
+          noteGlobalActorOnContext(
+              const_cast<DeclContext *>(getDeclContext()),
+              result.isolation.getGlobalActor());
         }
 
-        return false;
+        return true;
       }
-      llvm_unreachable("unhandled actor isolation kind!");
     }
 
     // Attempt to resolve the global actor type of a closure.
@@ -4881,13 +4813,11 @@ AbstractFunctionDecl const *swift::isActorInitOrDeInitContext(
       // Non-Sendable local functions are considered part of the enclosing
       // context.
       if (func->getDeclContext()->isLocalContext()) {
-        if (auto fnType = func->getInterfaceType()->getAs<AnyFunctionType>()) {
-          if (fnType->isSendable())
-            return nullptr;
+        if (func->isSendable())
+          return nullptr;
 
-          dc = dc->getParent();
-          continue;
-        }
+        dc = dc->getParent();
+        continue;
       }
     }
 
@@ -4951,4 +4881,262 @@ bool swift::isPotentiallyIsolatedActor(
     return var->isSelfParamCaptureIsolated();
 
   return false;
+}
+
+/// Determine the actor isolation used when we are referencing the given
+/// declaration.
+static ActorIsolation getActorIsolationForReference(
+    ValueDecl *decl, const DeclContext *fromDC) {
+  auto declIsolation = getActorIsolation(decl);
+
+  // If the isolation is "unsafe" global actor isolation, adjust it based on
+  // context itself. For contexts that require strict checking, treat it as
+  // global actor isolation. Otherwise, treat it as unspecified isolation.
+  if (declIsolation == ActorIsolation::GlobalActorUnsafe) {
+    if (contextRequiresStrictConcurrencyChecking(
+            fromDC,
+            [](const AbstractClosureExpr *closure) {
+              return closure->getType();
+            })) {
+      declIsolation = ActorIsolation::forGlobalActor(
+          declIsolation.getGlobalActor(), /*unsafe=*/false);
+    } else {
+      declIsolation = ActorIsolation::forUnspecified();
+    }
+  }
+
+  // A constructor that is not explicitly 'nonisolated' is treated as
+  // isolated from the perspective of the referencer.
+  if (auto ctor = dyn_cast<ConstructorDecl>(decl)) {
+    // If the constructor is part of an actor, references to it are treated
+    // as needing to enter the actor.
+    if (auto nominal = ctor->getDeclContext()->getSelfNominalTypeDecl()) {
+      if (nominal->isAnyActor())
+        return ActorIsolation::forActorInstance(nominal);
+    }
+
+    // Fall through to treat initializers like any other declaration.
+  }
+
+  // A 'nonisolated let' within an actor is treated as isolated from the
+  // perspective of the referencer.
+  //
+  // FIXME: getActorIsolation(decl) should treat these as isolated.
+  // FIXME: Expand this out to local variables?
+  if (auto var = dyn_cast<VarDecl>(decl)) {
+    if (var->isLet() && isStoredProperty(var) &&
+        declIsolation.isIndependent()) {
+      if (auto nominal = var->getDeclContext()->getSelfNominalTypeDecl()) {
+        if (nominal->isAnyActor())
+          return ActorIsolation::forActorInstance(nominal);
+
+        auto nominalIsolation = getActorIsolation(nominal);
+        if (nominalIsolation.isGlobalActor())
+          return getActorIsolationForReference(nominal, fromDC);
+      }
+    }
+  }
+
+  return declIsolation;
+}
+
+/// Determine whether this declaration always throws.
+static bool isThrowsDecl(ConcreteDeclRef declRef) {
+  auto decl = declRef.getDecl();
+
+  // An async function is asynchronously accessed.
+  if (auto func = dyn_cast<AbstractFunctionDecl>(decl))
+    return func->hasThrows();
+
+  // A computed property or subscript that has an 'async' getter
+  // is asynchronously accessed.
+  if (auto storageDecl = dyn_cast<AbstractStorageDecl>(decl)) {
+    if (auto effectfulGetter = storageDecl->getEffectfulGetAccessor())
+      return effectfulGetter->hasThrows();
+  }
+
+  return false;
+}
+
+/// Determine whether the given value can be accessed across actors
+/// without requiring async promotion.
+///
+/// \param value The value we are checking.
+/// \param isolation The actor isolation of the value.
+/// \param fromDC The context where we are performing the access.
+static bool isAccessibleAcrossActorsWithoutAsyncPromotion(
+    ValueDecl *value, const ActorIsolation &isolation,
+    const DeclContext *fromDC, Optional<ReferencedActor> actorInstance) {
+  switch (value->getKind()) {
+  case DeclKind::AssociatedType:
+  case DeclKind::Class:
+  case DeclKind::Enum:
+  case DeclKind::Extension:
+  case DeclKind::GenericTypeParam:
+  case DeclKind::OpaqueType:
+  case DeclKind::Protocol:
+  case DeclKind::Struct:
+  case DeclKind::TypeAlias:
+    return true;
+
+  case DeclKind::EnumCase:
+  case DeclKind::EnumElement:
+    // Type-level entities are always accessible across actors.
+    return true;
+
+  case DeclKind::IfConfig:
+  case DeclKind::Import:
+  case DeclKind::InfixOperator:
+  case DeclKind::MissingMember:
+  case DeclKind::Module:
+  case DeclKind::PatternBinding:
+  case DeclKind::PostfixOperator:
+  case DeclKind::PoundDiagnostic:
+  case DeclKind::PrecedenceGroup:
+  case DeclKind::PrefixOperator:
+  case DeclKind::TopLevelCode:
+    // Non-value entities are always accessible across actors.
+    return true;
+
+  case DeclKind::Destructor:
+    // Destructors are always accessible across actors.
+    return true;
+
+  case DeclKind::Constructor:
+    // Initializers are accessible across actors unless they are global-actor
+    // qualified.
+    switch (isolation) {
+    case ActorIsolation::ActorInstance:
+    case ActorIsolation::Independent:
+    case ActorIsolation::Unspecified:
+      return true;
+
+    case ActorIsolation::GlobalActorUnsafe:
+    case ActorIsolation::GlobalActor:
+      return false;
+    }
+
+  case DeclKind::Param:
+  case DeclKind::Var:
+    // 'let' declarations are immutable, so some of them can be accessed across
+    // actors.
+    return varIsSafeAcrossActors(
+        fromDC->getParentModule(), cast<VarDecl>(value), isolation);
+
+  case DeclKind::Accessor:
+  case DeclKind::Func:
+  case DeclKind::Subscript:
+    return false;
+  }
+}
+
+ActorReferenceResult ActorReferenceResult::forSameConcurrencyDomain(
+    ActorIsolation isolation) {
+  return ActorReferenceResult{SameConcurrencyDomain, None, isolation};
+}
+
+ActorReferenceResult ActorReferenceResult::forEntersActor(
+    ActorIsolation isolation, Options options) {
+  return ActorReferenceResult{EntersActor, options, isolation};
+}
+
+ActorReferenceResult ActorReferenceResult::forExitsActorToNonisolated(
+    ActorIsolation isolation) {
+  return ActorReferenceResult{ExitsActorToNonisolated, None, isolation};
+}
+
+ActorReferenceResult ActorReferenceResult::forReference(
+    ConcreteDeclRef declRef, SourceLoc declRefLoc, const DeclContext *fromDC,
+    Optional<VarRefUseEnv> useKind,
+    Optional<ReferencedActor> actorInstance) {
+  // Compute the isolation of the declaration, adjusted for references.
+  auto declIsolation = getActorIsolationForReference(declRef.getDecl(), fromDC);
+  if (auto subs = declRef.getSubstitutions())
+    declIsolation = declIsolation.subst(subs);
+
+  // Compute the isolation of the context.
+  auto contextIsolation = getInnermostIsolatedContext(fromDC);
+
+  // When the declaration is not actor-isolated, it can always be accessed
+  // directly.
+  if (!declIsolation.isActorIsolated()) {
+    // If the declaration is asynchronous and we are in an actor-isolated
+    // context (of any kind), then we exit the actor to the nonisolated context.
+    if (isAsyncDecl(declRef) && contextIsolation.isActorIsolated())
+      return forExitsActorToNonisolated(contextIsolation);
+
+    // Otherwise, we stay in the same concurrency domain, whether on an actor
+    // or in a task.
+    return forSameConcurrencyDomain(declIsolation);
+  }
+
+  // The declaration we are accessing is actor-isolated. First, check whether
+  // we are on the same actor already.
+  if (actorInstance && declIsolation == ActorIsolation::ActorInstance) {
+    // If this instance is isolated, we're in the same concurrency domain.
+    if (actorInstance->isIsolated())
+      return forSameConcurrencyDomain(declIsolation);
+  } else if (contextIsolation == declIsolation) {
+    // The context isolation matches, so we are in the same concurrency
+    // domain.
+    return forSameConcurrencyDomain(declIsolation);
+  }
+
+  // If there is an instance and it is checked by flow isolation, treat it
+  // as being in the same concurrency domain.
+  if (actorInstance &&
+      checkedByFlowIsolation(
+          fromDC, *actorInstance, declRef.getDecl(), declRefLoc, useKind))
+    return forSameConcurrencyDomain(declIsolation);
+
+  // If we are delegating to another initializer, treat them as being in the
+  // same concurrency domain.
+  // FIXME: This has a lot of overlap with both the stored-property checks
+  // below and the flow-isolation checks above.
+  if (actorInstance && actorInstance->isSelf() &&
+      isa<ConstructorDecl>(declRef.getDecl()) &&
+      isa<ConstructorDecl>(fromDC))
+    return forSameConcurrencyDomain(declIsolation);
+
+  // If there is an instance that corresponds to 'self',
+  // we are in a constructor or destructor, and we have a stored property of
+  // global-actor-qualified type, pretend we are in the same concurrency
+  // domain.
+  // FIXME: This is an odd carve-out that probably shouldn't have been allowed.
+  // It should at the very least be diagnosed, and either subsumed by flow
+  // isolation or banned outright.
+  // FIXME: At the very least, we should consistently use
+  // isActorInitOrDeInitContext here, but it only wants to think about actors.
+  if (actorInstance && actorInstance->isSelf() &&
+      isStoredProperty(declRef.getDecl()) &&
+      declIsolation.isGlobalActor() &&
+      (isa<ConstructorDecl>(fromDC) || isa<DestructorDecl>(fromDC)))
+    return forSameConcurrencyDomain(declIsolation);
+
+  // At this point, we are accessing the target from outside the actor.
+  // First, check whether it is something that can be accessed directly,
+  // without any kind of promotion.
+  if (isAccessibleAcrossActorsWithoutAsyncPromotion(
+          declRef.getDecl(), declIsolation, fromDC, actorInstance))
+    return forEntersActor(declIsolation, None);
+
+  // This is a cross-actor reference, so determine what adjustments we need
+  // to perform.
+  Options options = None;
+
+  // If the declaration isn't asynchronous, promote to async.
+  if (!isAsyncDecl(declRef))
+    options |= Flags::AsyncPromotion;
+
+  // If the declaration is isolated to a distributed actor and we are not
+  // guaranteed to be on the same node, adjustments for a distributed call.
+  if (declIsolation.isDistributedActor() &&
+      !(actorInstance && actorInstance->isKnownToBeLocal())) {
+    options |= Flags::Distributed;
+
+    if (!isThrowsDecl(declRef))
+      options |= Flags::ThrowsPromotion;
+  }
+
+  return forEntersActor(declIsolation, options);
 }

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -542,6 +542,16 @@ VarDecl *getReferencedParamOrCapture(
     Expr *expr,
     llvm::function_ref<Expr *(OpaqueValueExpr *)> getExistentialValue);
 
+/// Determine whether the given value can be accessed across actors
+/// without from normal synchronous code.
+///
+/// \param value The value we are checking.
+/// \param isolation The actor isolation of the value.
+/// \param fromDC The context where we are performing the access.
+bool isAccessibleAcrossActors(
+    ValueDecl *value, const ActorIsolation &isolation,
+    const DeclContext *fromDC, Optional<ReferencedActor> actorInstance = None);
+
 /// Check whether given variable references to a potentially
 /// isolated actor.
 bool isPotentiallyIsolatedActor(

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -87,130 +87,6 @@ enum class SendableCheckReason {
   ObjC,
 };
 
-/// The isolation restriction in effect for a given declaration that is
-/// referenced from source.
-class ActorIsolationRestriction {
-public:
-  enum Kind {
-    /// There is no restriction on references to the given declaration.
-    Unrestricted,
-
-    /// Access to the declaration is unsafe in any concurrent context.
-    Unsafe,
-
-    /// References to this entity are allowed from anywhere, but doing so
-    /// may cross an actor boundary if it is not from within the same actor's
-    /// isolation domain.
-    CrossActorSelf,
-
-    /// References to this member of an actor are only permitted from within
-    /// the actor's isolation domain.
-    ActorSelf,
-
-    /// References to a declaration that is part of a global actor are
-    /// permitted from other declarations with that same global actor or
-    /// are permitted from elsewhere as a cross-actor reference.
-    GlobalActor,
-
-    /// References to a declaration that is part of a global actor are
-    /// permitted from other declarations with that same global actor or
-    /// are permitted from elsewhere as a cross-actor reference, but
-    /// contexts with unspecified isolation won't diagnose anything.
-    GlobalActorUnsafe,
-  };
-
-private:
-  union {
-    /// The local context that an entity is tied to.
-    DeclContext *localContext;
-
-    /// The actor that the entity is declared in.
-    NominalTypeDecl *actorType;
-
-    /// The global actor type.
-    TypeBase *globalActor;
-  } data;
-
-  explicit ActorIsolationRestriction(Kind kind, bool isCrossActor)
-      : kind(kind), isCrossActor(isCrossActor) { }
-
-public:
-  /// The kind of restriction.
-  const Kind kind;
-
-  /// Whether referencing this from another actor constitutes a cross-acter
-  /// reference.
-  const bool isCrossActor;
-
-  Kind getKind() const { return kind; }
-
-  /// Retrieve the actor type that the declaration is within.
-  NominalTypeDecl *getActorType() const {
-    assert(kind == ActorSelf || 
-           kind == CrossActorSelf);
-    return data.actorType;
-  }
-
-  /// Retrieve the actor that the declaration is within.
-  Type getGlobalActor() const {
-    assert(kind == GlobalActor || kind == GlobalActorUnsafe);
-    return Type(data.globalActor);
-  }
-
-  /// There are no restrictions on the use of the entity.
-  static ActorIsolationRestriction forUnrestricted() {
-    return ActorIsolationRestriction(Unrestricted, /*isCrossActor=*/false);
-  }
-
-  /// Accesses to the given declaration are unsafe.
-  static ActorIsolationRestriction forUnsafe() {
-    return ActorIsolationRestriction(Unsafe, /*isCrossActor=*/false);
-  }
-
-  /// Accesses to the given declaration can only be made via the 'self' of
-  /// the current actor or is a cross-actor access.
-  static ActorIsolationRestriction forActorSelf(
-      NominalTypeDecl *actor, bool isCrossActor) {
-
-    ActorIsolationRestriction result(isCrossActor? CrossActorSelf : ActorSelf,
-                                     isCrossActor);
-    result.data.actorType = actor;
-    return result;
-  }
-
-  /// Accesses to the given declaration can only be made via the 'self' of
-  /// the current actor.
-  static ActorIsolationRestriction forDistributedActorSelf(
-      NominalTypeDecl *actor, bool isCrossActor) {
-    ActorIsolationRestriction result(isCrossActor ? CrossActorSelf : ActorSelf,
-                                     isCrossActor);
-    result.data.actorType = actor;
-    return result;
-  }
-
-  /// Accesses to the given declaration can only be made via this particular
-  /// global actor or is a cross-actor access.
-  static ActorIsolationRestriction forGlobalActor(
-      Type globalActor, bool isCrossActor, bool isUnsafe) {
-    ActorIsolationRestriction result(
-        isUnsafe ? GlobalActorUnsafe : GlobalActor, isCrossActor);
-    result.data.globalActor = globalActor.getPointer();
-    return result;
-  }
-
-  /// Determine the isolation rules for a given declaration.
-  /// The isolation restriction represents the isolation requirement of the
-  /// using context.
-  ///
-  /// \param fromExpression Indicates that the reference is coming from an
-  /// expression.
-  static ActorIsolationRestriction forDeclaration(
-      ConcreteDeclRef declRef, const DeclContext *fromDC,
-      bool fromExpression = true);
-
-  operator Kind() const { return kind; };
-};
-
 /// Check that the actor isolation of an override matches that of its
 /// overridden declaration.
 void checkOverrideActorIsolation(ValueDecl *value);
@@ -361,8 +237,27 @@ public:
       ConcreteDeclRef declRef,
       SourceLoc declRefLoc,
       const DeclContext *fromDC,
-      Optional<VarRefUseEnv> useKind,
+      Optional<VarRefUseEnv> useKind = None,
       Optional<ReferencedActor> actorInstance = None);
+
+  /// Determine what happens when referencing the given declaration from the
+  /// given declaration context.
+  ///
+  ///
+  /// \param declRef The declaration that is being referenced.
+  ///
+  /// \param fromDC The declaration context from which the reference occurs.
+  ///
+  /// \param actorInstance When not \c None, the actor instance value that is
+  /// provided when referencing the declaration. This can be either the base
+  /// of a member access or a parameter passed to a function.
+  static ActorReferenceResult forReference(
+      ConcreteDeclRef declRef,
+      SourceLoc declRefLoc,
+      const DeclContext *fromDC,
+      Optional<VarRefUseEnv> useKind,
+      Optional<ReferencedActor> actorInstance,
+      ActorIsolation contextIsolation);
 
   operator Kind() const { return kind; }
 };
@@ -535,6 +430,12 @@ bool checkSendableConformance(
 AbstractFunctionDecl const *isActorInitOrDeInitContext(
     const DeclContext *dc,
     llvm::function_ref<bool(const AbstractClosureExpr *)> isSendable);
+
+/// Determine whether this declaration is always accessed asynchronously.
+bool isAsyncDecl(ConcreteDeclRef declRef);
+
+/// Determine whether this declaration can throw errors.
+bool isThrowsDecl(ConcreteDeclRef declRef);
 
 /// Find the directly-referenced parameter or capture of a parameter for
 /// for the given expression.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2884,29 +2884,23 @@ static void emitDeclaredHereIfNeeded(DiagnosticEngine &diags,
   diags.diagnose(value, diag::decl_declared_here, value->getName());
 }
 
-/// Determine if the witness can be made implicitly async.
-static bool isValidImplicitAsync(ValueDecl *witness, ValueDecl *requirement) {
-  if (auto witnessFunc = dyn_cast<AbstractFunctionDecl>(witness)) {
-    if (auto requirementFunc = dyn_cast<AbstractFunctionDecl>(requirement)) {
-      return requirementFunc->hasAsync() &&
-          !(witnessFunc->hasThrows() && !requirementFunc->hasThrows());
-    }
-
-    return false;
-  }
-
-  if (auto witnessStorage = dyn_cast<AbstractStorageDecl>(witness)) {
-    if (auto requirementStorage = dyn_cast<AbstractStorageDecl>(requirement)) {
-      auto requirementAccessor = requirementStorage->getEffectfulGetAccessor();
-      if (!requirementAccessor || !requirementAccessor->hasAsync())
-        return false;
-
-      return witnessStorage->isLessEffectfulThan(
-          requirementStorage, EffectKind::Throws);
-    }
-  }
-
+/// Whether this declaration has the 'distributed' modifier on it.
+static bool isDistributedDecl(ValueDecl *decl) {
+  if (auto func = dyn_cast<AbstractFunctionDecl>(decl))
+    return func->isDistributed();
+  if (auto var = dyn_cast<VarDecl>(decl))
+    return var->isDistributed();
   return false;
+}
+
+/// Determine whether there was an explicit global actor attribute on the
+/// given declaration.
+static bool hasExplicitGlobalActorAttr(ValueDecl *decl) {
+  auto globalActorAttr = decl->getGlobalActorAttr();
+  if (!globalActorAttr)
+    return false;
+
+  return !globalActorAttr->first->isImplicit();
 }
 
 bool ConformanceChecker::checkActorIsolation(
@@ -2922,325 +2916,197 @@ bool ConformanceChecker::checkActorIsolation(
     return ConcreteDeclRef(witness);
   };
 
-  // Ensure that the witness is not actor-isolated in a manner that makes it
-  // unsuitable as a witness.
-  bool isCrossActor = false;
-  DiagnosticBehavior behavior = SendableCheckContext(
-      Conformance->getDeclContext()).defaultDiagnosticBehavior();
-  Type witnessGlobalActor;
-  switch (auto witnessRestriction =
-              ActorIsolationRestriction::forDeclaration(
-                  witness, witness->getDeclContext(),
-                  /*fromExpression=*/false)) {
-  case ActorIsolationRestriction::ActorSelf: {
-    auto requirementIsolation = getActorIsolation(requirement);
-
-    // An actor-isolated witness can only conform to an actor-isolated
-    // requirement.
-    auto requirementFunc = dyn_cast<AbstractFunctionDecl>(requirement);
-    if (requirementIsolation == ActorIsolation::ActorInstance &&
-        !(requirementFunc && requirementFunc->isDistributed())) {
-      return false;
-    }
-
-    auto witnessFunc = dyn_cast<AbstractFunctionDecl>(witness);
-    auto nominal = dyn_cast<NominalTypeDecl>(witness->getDeclContext());
-    auto witnessClass = dyn_cast<ClassDecl>(witness->getDeclContext());
-    if (auto extension = dyn_cast<ExtensionDecl>(witness->getDeclContext())) {
-      // We can witness a distributed instance method in an extension, as long as
-      // that extension itself is on a DistributedActor type (including
-      // protocols that inherit from DistributedActor, even if the protocol
-      // requirement was not expressed in terms of distributed actors).
-      nominal = extension->getExtendedNominal();
-    }
-
-    /// Distributed actors can witness protocol requirements either with
-    /// nonisolated or distributed members.
-    if (nominal && nominal->isDistributedActor()) {
-      // A distributed actor may conform to an 'async throws' function
-      // requirement with a distributed function, because those are always
-      // cross-actor.
-      //
-      // If the distributed instance method is well-formed (passed checks) then it can
-      // witness this requirement. I.e. since checks to the distributed function
-      // passed, it can be called through this protocol.
-      if (requirementFunc && witnessFunc && witnessFunc->isDistributed()) {
-        // If the requirement was also a 'distributed func' we most definitely
-        // can witness it with our 'distributed func' witness.
-        if (requirementFunc->isDistributed()) {
-          return false;
-        }
-        if (requirementFunc->hasAsync() && requirementFunc->hasThrows()) {
-          return false;
-        }
-
-        // The witness was distributed, but the requirement func was not
-        // 'async throws', so we can suggest adding those to the protocol
-        int suggestAddingModifiers = 0;
-        if (!requirementFunc->hasAsync()) suggestAddingModifiers += 1;
-        if (!requirementFunc->hasThrows()) suggestAddingModifiers += 2;
-        requirementFunc->diagnose(diag::note_add_async_and_throws_to_decl,
-                                  witness->getName(),
-                                  suggestAddingModifiers,
-                                  witnessClass ? witnessClass->getName() :
-                                                 nominal->getName());
-        // TODO(distributed): fixit inserts for the async/throws
-      }
-
-      // The witness definitely is distributed actor isolated,
-      // so diagnose this as an error; next we'll provide helpful notes
-      witness->diagnose(diag::distributed_actor_isolated_witness,
-                        witness->getDescriptiveKind(), witness->getName())
-          .fixItInsert(witness->getAttributeInsertionLoc(true),
-                       "distributed ");
-
-      // witness is not 'distributed', if the requirement was though,
-      // then we definitely must mark the witness distributed as well.
-      if (!requirementFunc) {
-        return true;
-      }
-
-      if (requirementFunc->isDistributed()) {
-        witness->diagnose(diag::note_add_distributed_to_decl,
-                          witness->getName(),
-                          witness->getDescriptiveKind())
-            .fixItInsert(witness->getAttributeInsertionLoc(true),
-                         "distributed ");
-        requirement->diagnose(diag::note_distributed_requirement_defined_here,
-                              requirement->getName());
-      } else if (requirementFunc->hasAsync() && requirementFunc->hasThrows()) {
-        assert(!requirementFunc->isDistributed());
-        // If the requirement is 'async throws' we can add 'distributed' to the
-        // distributed actor function to witness the requirement.
-        witness->diagnose(diag::note_add_distributed_to_decl,
-                          witness->getName(), witness->getDescriptiveKind())
-            .fixItInsert(witness->getAttributeInsertionLoc(true),
-                         "distributed ");
-      }
-
-      if (!requirementFunc->hasAsync() && !requirementFunc->isDistributed()) {
-        /// The requirement is synchronous, so we can only conform to it using
-        /// 'nonisolated'...
-        witness->diagnose(diag::note_add_nonisolated_to_decl,
-                          witness->getName(), witness->getDescriptiveKind())
-            .fixItInsert(witness->getAttributeInsertionLoc(true),
-                         "nonisolated ");
-
-        /// ... or by suggesting to make it 'async'
-      }
-
-      return true;
-    }
-
-    // A synchronous actor function can witness an asynchronous protocol
-    // requirement, since calls "through" the protocol are always cross-actor,
-    // in which case the function becomes implicitly async.
-    //
-    // In this case, we're crossing actor boundaries so we need to
-    // perform Sendable checking.
-    if (witnessClass && witnessClass->isActor()) {
-      if (isValidImplicitAsync(witness, requirement)) {
-        diagnoseNonSendableTypesInReference(
-            getConcreteWitness(), DC, witness->getLoc(),
-            SendableCheckReason::Conformance);
-
-        return false;
-      }
-    }
-
-    witness->diagnose(diag::actor_isolated_witness,
-                      witness->getDescriptiveKind(),
-                      witness->getName());
-    {
-      auto witnessVar = dyn_cast<VarDecl>(witness);
-      if ((witnessVar && !witnessVar->hasStorage()) || !witnessVar) {
-        if (requirementFunc && requirementFunc->isDistributed()) {
-          // a distributed protocol requirement can be witnessed with a
-          // distributed function:
-          witness->diagnose(diag::note_add_distributed_to_decl,
-                            witness->getName(), witness->getDescriptiveKind())
-              .fixItInsert(witness->getAttributeInsertionLoc(true),
-                           "distributed ");
-          requirement
-              ->diagnose(diag::note_distributed_requirement_defined_here,
-                         requirement->getName());
-        } else {
-          // the only other way to witness is to use a nonisolated member:
-          witness
-              ->diagnose(diag::note_add_nonisolated_to_decl, witness->getName(),
-                         witness->getDescriptiveKind())
-              .fixItInsert(witness->getAttributeInsertionLoc(true),
-                           "nonisolated ");
-        }
-      }
-    }
-
-    return true;
+  // Determine the isolation of the requirement itself.
+  auto requirementIsolation = getActorIsolation(requirement);
+  if (requirementIsolation.requiresSubstitution()) {
+    auto substitutingType = DC->mapTypeIntoContext(Conformance->getType());
+    auto subs = SubstitutionMap::getProtocolSubstitutions(
+        Proto, substitutingType, ProtocolConformanceRef(Conformance));
+    requirementIsolation = requirementIsolation.subst(subs);
   }
 
-  case ActorIsolationRestriction::CrossActorSelf: {
-    if (diagnoseNonSendableTypesInReference(
-            getConcreteWitness(), DC, witness->getLoc(),
-            SendableCheckReason::Conformance)) {
-      return true;
+  auto refResult = ActorReferenceResult::forReference(
+      getConcreteWitness(), witness->getLoc(), DC, None, None,
+      requirementIsolation);
+  bool sameConcurrencyDomain = false;
+  switch (refResult) {
+  case ActorReferenceResult::SameConcurrencyDomain:
+    // If the witness has distributed-actor isolation, we have extra
+    // checking to do.
+    if (refResult.isolation.isDistributedActor()) {
+      sameConcurrencyDomain = true;
+      break;
     }
 
-    auto witnessFunc = dyn_cast<AbstractFunctionDecl>(witness);
-    auto requirementFunc = dyn_cast<AbstractFunctionDecl>(requirement);
-    auto nominal = dyn_cast<NominalTypeDecl>(witness->getDeclContext());
-    auto witnessClass = dyn_cast<ClassDecl>(witness->getDeclContext());
-    if (auto extension = dyn_cast<ExtensionDecl>(witness->getDeclContext())) {
-      // We can witness a distributed instance method in an extension, as long as
-      // that extension itself is on a DistributedActor type (including
-      // protocols that inherit from DistributedActor, even if the protocol
-      // requirement was not expressed in terms of distributed actors).
-      nominal = extension->getExtendedNominal();
-      witnessClass = extension->getSelfClassDecl();
-    }
-
-    if (nominal && nominal->isDistributedActor()) {
-      // A distributed actor may conform to an 'async throws' function
-      // requirement with a distributed function, because those are always
-      // cross-actor.
-      //
-      // If the distributed instance method is well-formed (passed checks) then it can
-      // witness this requirement. I.e. since checks to the distributed function
-      // passed, it can be called through this protocol.
-      if (witnessFunc && witnessFunc->isDistributed()) {
-        // If the requirement was also a 'distributed func' we most definitely
-        // can witness it with our 'distributed func' witness.
-        if (requirementFunc && requirementFunc->isDistributed()) {
-          return false;
-        }
-        if (requirementFunc->hasAsync() && requirementFunc->hasThrows()) {
-          return false;
-        }
-
-        if (requirementFunc) {
-          // The witness was distributed, but the requirement func was not
-          // 'async throws', so we can suggest adding those to the protocol
-          int suggestAddingModifiers = 0;
-          if (!requirementFunc->hasAsync()) suggestAddingModifiers += 1;
-          if (!requirementFunc->hasThrows()) suggestAddingModifiers += 2;
-          requirementFunc->diagnose(diag::note_add_async_and_throws_to_decl,
-                                    witness->getName(),
-                                    suggestAddingModifiers,
-                                    witnessClass ? witnessClass->getName() :
-                                                   nominal->getName());
-          // TODO(distributed): fixit inserts for the async/throws
-        } // TODO(distributed): handle computed properties as well?
-      }
-
-      if (witnessFunc) {
-        witness
-            ->diagnose(diag::distributed_actor_isolated_witness,
-                       witness->getDescriptiveKind(), witness->getName())
-            .fixItInsert(witness->getAttributeInsertionLoc(true),
-                         "distributed ");
-      }
-
-      return true;
-    }
-
+    // Otherwise, we're done.
     return false;
-  }
 
-  case ActorIsolationRestriction::GlobalActorUnsafe:
-    LLVM_FALLTHROUGH;
+  case ActorReferenceResult::ExitsActorToNonisolated:
+    // FIXME: SE-0338 would diagnose this.
+    return false;
 
-  case ActorIsolationRestriction::GlobalActor: {
-    // Hang on to the global actor that's used for the witness. It will need
-    // to match that of the requirement.
-    isCrossActor = witnessRestriction.isCrossActor;
-    witnessGlobalActor = witness->getDeclContext()->mapTypeIntoContext(
-        witnessRestriction.getGlobalActor());
+  case ActorReferenceResult::EntersActor:
+    // Handled below.
     break;
   }
 
-  case ActorIsolationRestriction::Unsafe:
-  case ActorIsolationRestriction::Unrestricted:
-    // The witness is completely unrestricted, so ignore any annotations on
-    // the requirement.
-    return false;
+  // Keep track of what modifiers are missing from the requirement and witness,
+  // so we can decide what to diagnose.
+  enum class MissingFlags {
+    RequirementAsync = 1 << 0,
+    RequirementThrows = 1 << 1,
+    WitnessDistributed = 1 << 2,
+  };
+  OptionSet<MissingFlags> missingOptions;
+
+  // If the witness is accessible across actors and the requirement is not
+  // async, we need an async requirement.
+  // FIXME: feels like ActorReferenceResult should be reporting this back to
+  // us somehow.
+  // To enter the actor, we always need the requirement to be `async`.
+  if (!sameConcurrencyDomain &&
+      !isAsyncDecl(requirement) &&
+      !isAccessibleAcrossActors(witness, refResult.isolation, DC))
+    missingOptions |= MissingFlags::RequirementAsync;
+
+  // If we are entering a distributed actor, the witness must be 'distributed'
+  // and we need the requirement to be 'throws'.
+  bool isDistributed = refResult.isolation.isDistributedActor() &&
+      !witness->getAttrs().hasAttribute<NonisolatedAttr>();
+  if (isDistributed) {
+    // If we're coming from a non-distributed requirement, then the requirement
+    // must be 'throws' to accommodate failure.
+    if (!isDistributedDecl(requirement) && !isThrowsDecl(requirement))
+      missingOptions |= MissingFlags::RequirementThrows;
+
+    if (!isDistributedDecl(witness) &&
+        (isDistributedDecl(requirement) || !missingOptions))
+      missingOptions |= MissingFlags::WitnessDistributed;
   }
 
-  // Check whether the requirement requires some particular actor isolation.
-  Type requirementGlobalActor;
-  switch (auto requirementIsolation = getActorIsolation(requirement)) {
-  case ActorIsolation::ActorInstance:
-    llvm_unreachable("There are not actor protocols");
+  // If we aren't missing anything, do a Sendable check and move on.
+  if (!missingOptions) {
+    SourceLoc loc = witness->getLoc();
+    if (loc.isInvalid())
+      loc = Conformance->getLoc();
 
-  case ActorIsolation::GlobalActorUnsafe:
-    LLVM_FALLTHROUGH;
-
-  case ActorIsolation::GlobalActor: {
-    auto requirementSubs = SubstitutionMap::getProtocolSubstitutions(
-        Proto, Adoptee, ProtocolConformanceRef(Conformance));
-    requirementGlobalActor = requirementIsolation.getGlobalActor()
-        .subst(requirementSubs);
-    break;
-  }
-
-  case ActorIsolation::Independent:
-  case ActorIsolation::Unspecified:
-    break;
-  }
-
-  // If neither has a global actor, we're done.
-  if (!witnessGlobalActor && !requirementGlobalActor)
-    return false;
-
-  // If both have global actors and they are the same, we are done.
-  if (witnessGlobalActor && requirementGlobalActor &&
-      witnessGlobalActor->isEqual(requirementGlobalActor))
-    return false;
-
-  // For cross-actor references, check for non-sendable types.
-  if (isCrossActor) {
-    // If the requirement was imported from Objective-C, it may not have been
-    // annotated appropriately. Allow the mismatch.
-    if (requirement->hasClangNode())
+    // FIXME: Disable Sendable checking when the witness is an initializer
+    // that is explicitly marked nonisolated.
+    if (isa<ConstructorDecl>(witness) &&
+        witness->getAttrs().hasAttribute<NonisolatedAttr>())
       return false;
 
-    return diagnoseNonSendableTypesInReference(
-        getConcreteWitness(), DC, witness->getLoc(),
-        SendableCheckReason::Conformance);
-  }
+    diagnoseNonSendableTypesInReference(
+        getConcreteWitness(), DC, loc, SendableCheckReason::Conformance);
 
-  // If the witness has a global actor but the requirement does not, we have
-  // an isolation error.
-  //
-  // However, we allow this case when the requirement was imported, because
-  // it might not have been annotated.
-  if (witnessGlobalActor && !requirementGlobalActor) {
-    // If the requirement was imported from Objective-C, downgrade to a warning
-    // because it may not have been annotated appropriately.
-    if (requirement->hasClangNode())
-      behavior = std::max(behavior, DiagnosticBehavior::Warning);
-
-    witness->diagnose(
-        diag::global_actor_isolated_witness, witness->getDescriptiveKind(),
-        witness->getName(), witnessGlobalActor, Proto->getName())
-      .limitBehavior(behavior);
-    requirement->diagnose(diag::decl_declared_here, requirement->getName());
-    return behavior == DiagnosticBehavior::Unspecified;
-  }
-
-  // If the requirement has a global actor but the witness does not, it's
-  // fine.
-  if (requirementGlobalActor && !witnessGlobalActor) {
     return false;
   }
 
-  // Both have global actors but they differ, so this is an isolation error.
-  assert(!witnessGlobalActor->isEqual(requirementGlobalActor));
-  witness->diagnose(
-      diag::global_actor_isolated_requirement_witness_conflict,
-      witness->getDescriptiveKind(), witness->getName(), witnessGlobalActor,
-      Proto->getName(), requirementGlobalActor)
+  // Limit the behavior of the diagnostic based on context.
+  // If we're working with requirements imported from Clang, or with global
+  // actor isolation in general, use the default diagnostic behavior based
+  // on the conformance context.
+  DiagnosticBehavior behavior = DiagnosticBehavior::Unspecified;
+  if (requirement->hasClangNode() ||
+      refResult.isolation.isGlobalActor() ||
+      requirementIsolation.isGlobalActor()) {
+    // If the witness or requirement has global actor isolation, downgrade
+    // based on context.
+    behavior = SendableCheckContext(
+        Conformance->getDeclContext()).defaultDiagnosticBehavior();
+  }
+
+  // Complain that this witness cannot conform to the requirement due to
+  // actor isolation.
+  bool isError = (behavior == DiagnosticBehavior::Unspecified);
+  witness->diagnose(diag::actor_isolated_witness,
+                    isDistributed && !isDistributedDecl(witness),
+                    refResult.isolation, witness->getDescriptiveKind(),
+                    witness->getName(), requirementIsolation)
     .limitBehavior(behavior);
-  requirement->diagnose(diag::decl_declared_here, requirement->getName());
-  return behavior == DiagnosticBehavior::Unspecified;
+
+  // If we need 'distributed' on the witness, add it.
+  if (missingOptions.contains(MissingFlags::WitnessDistributed)) {
+    witness->diagnose(
+        diag::note_add_distributed_to_decl, witness->getName(),
+        witness->getDescriptiveKind())
+      .fixItInsert(witness->getAttributeInsertionLoc(true),
+                              "distributed ");
+    missingOptions -= MissingFlags::WitnessDistributed;
+  }
+
+  // One way to address the issue is to make the witness function nonisolated.
+  if ((isa<AbstractFunctionDecl>(witness) || isa<SubscriptDecl>(witness)) &&
+      !hasExplicitGlobalActorAttr(witness) &&
+      !isDistributedDecl(requirement) &&
+      !isDistributedDecl(witness)) {
+    witness->diagnose(
+        diag::note_add_nonisolated_to_decl, witness->getName(),
+        witness->getDescriptiveKind())
+          .fixItInsert(witness->getAttributeInsertionLoc(true), "nonisolated ");
+  }
+
+  // If there are remaining options, they are missing async/throws on the
+  // requirement itself. If we have a source location for the requirement,
+  // provide those in a note.
+  if (missingOptions && requirement->getLoc().isValid() &&
+      isa<AbstractFunctionDecl>(requirement)) {
+    int suggestAddingModifiers = 0;
+    std::string modifiers;
+    if (missingOptions.contains(MissingFlags::RequirementAsync)) {
+      suggestAddingModifiers += 1;
+      modifiers += "async ";
+    }
+
+    if (missingOptions.contains(MissingFlags::RequirementThrows)) {
+      suggestAddingModifiers += 2;
+      modifiers += "throws ";
+    }
+
+    auto diag = requirement->diagnose(diag::note_add_async_and_throws_to_decl,
+                                      witness->getName(),
+                                      suggestAddingModifiers);
+
+    // Figure out where to insert the modifiers so we can emit a Fix-It.
+    SourceLoc insertLoc;
+    bool insertAfter = false;
+    if (auto requirementAbstractFunc =
+            dyn_cast<AbstractFunctionDecl>(requirement)) {
+      if (requirementAbstractFunc->getAsyncLoc().isValid()) {
+        // Insert before the "async" (we only have throws).
+        insertLoc = requirementAbstractFunc->getAsyncLoc();
+        insertAfter = true;
+        modifiers = " throws";
+      } else if (requirementAbstractFunc->getThrowsLoc().isValid()) {
+        // Insert before the "throws" (we only have async)".
+        insertLoc = requirementAbstractFunc->getThrowsLoc();
+      } else if (auto requirementFunc =
+                     dyn_cast<FuncDecl>(requirementAbstractFunc)) {
+        // Insert before the result type, if there is one.
+        if (auto resultTypeRepr = requirementFunc->getResultTypeRepr()) {
+          insertLoc = resultTypeRepr->getStartLoc();
+        }
+      }
+
+      // Insert after the parentheses.
+      if (insertLoc.isInvalid()) {
+        insertLoc = requirementAbstractFunc->getParameters()->getRParenLoc();
+        insertAfter = true;
+        modifiers = " " + modifiers.substr(0, modifiers.size() - 1);
+      }
+    }
+
+    if (insertLoc.isValid()) {
+      if (insertAfter)
+        diag.fixItInsertAfter(insertLoc, modifiers);
+      else
+        diag.fixItInsert(insertLoc, modifiers);
+    }
+  } else {
+    requirement->diagnose(diag::decl_declared_here, requirement->getName());
+  }
+
+  return isError;
 }
 
 bool ConformanceChecker::checkObjCTypeErasedGenerics(

--- a/test/Concurrency/actor_call_implicitly_async.swift
+++ b/test/Concurrency/actor_call_implicitly_async.swift
@@ -278,11 +278,11 @@ func blender(_ peeler : () -> Void) {
   var money = await dollarsInBananaStand
   money -= 1200
 
-  dollarsInBananaStand = money // expected-error{{var 'dollarsInBananaStand' isolated to global actor 'BananaActor' can not be mutated from different global actor 'OrangeActor'}}
+  dollarsInBananaStand = money // expected-error{{global actor 'BananaActor'-isolated var 'dollarsInBananaStand' can not be mutated from global actor 'OrangeActor'}}
 
   // FIXME: these two errors seem a bit redundant.
   // expected-error@+2 {{actor-isolated var 'dollarsInBananaStand' cannot be passed 'inout' to implicitly 'async' function call}}
-  // expected-error@+1 {{var 'dollarsInBananaStand' isolated to global actor 'BananaActor' can not be used 'inout' from different global actor 'OrangeActor'}}
+  // expected-error@+1 {{global actor 'BananaActor'-isolated var 'dollarsInBananaStand' can not be used 'inout' from global actor 'OrangeActor'}}
   await takeInout(&dollarsInBananaStand)
 
   _ = wisk
@@ -459,7 +459,7 @@ func tryEffPropsFromSync() {
   _ = effPropA // expected-error{{'async' property access in a function that does not support concurrency}}
 
   // expected-error@+1 {{property access can throw, but it is not marked with 'try' and the error is not handled}}
-  _ = effPropT // expected-error{{var 'effPropT' isolated to global actor 'BananaActor' can not be referenced from this synchronous context}}
+  _ = effPropT // expected-error{{global actor 'BananaActor'-isolated var 'effPropT' can not be referenced from a non-isolated context}}
   // NOTE: that we don't complain about async access on `effPropT` because it's not declared async, and we're not in an async context!
 
   // expected-error@+1 {{property access can throw, but it is not marked with 'try' and the error is not handled}}

--- a/test/Concurrency/actor_inout_isolation.swift
+++ b/test/Concurrency/actor_inout_isolation.swift
@@ -206,7 +206,7 @@ struct MyGlobalActor {
 // expected-note@-3{{mutation of this var is only permitted within the actor}}
 
 // expected-error@+3{{actor-isolated var 'number' cannot be passed 'inout' to 'async' function call}}
-// expected-error@+2{{var 'number' isolated to global actor 'MyGlobalActor' can not be used 'inout' from a non-isolated context}}
+// expected-error@+2{{global actor 'MyGlobalActor'-isolated var 'number' can not be used 'inout' from a non-isolated context}}
 if #available(SwiftStdlib 5.1, *) {
 let _ = Task.detached { await { (_ foo: inout Int) async in foo += 1 }(&number) }
 }

--- a/test/Concurrency/actor_inout_isolation.swift
+++ b/test/Concurrency/actor_inout_isolation.swift
@@ -25,11 +25,11 @@ struct Point {
 @available(SwiftStdlib 5.1, *)
 actor TestActor {
   // expected-note@+1{{mutation of this property is only permitted within the actor}}
-  var position = Point(x: 0, y: 0)
-  var nextPosition = Point(x: 0, y: 1)
-  var value1: Int = 0
-  var value2: Int = 1
-  var points: [Point] = []
+  var position = Point(x: 0, y: 0) // expected-note 2{{property declared here}}
+  var nextPosition = Point(x: 0, y: 1) // expected-note 2{{property declared here}}
+  var value1: Int = 0 // expected-note 6{{property declared here}}
+  var value2: Int = 1 // expected-note 4{{property declared here}}
+  var points: [Point] = [] // expected-note {{property declared here}}
 
   subscript(x : inout Int) -> Int { // expected-error {{'inout' must not be used on subscript parameters}}
     x += 1
@@ -162,11 +162,11 @@ extension TestActor {
 
 @available(SwiftStdlib 5.1, *)
 actor MyActor {
-  var points: [Point] = []
-  var int: Int = 0
-  var maybeInt: Int?
-  var maybePoint: Point?
-  var myActor: TestActor = TestActor()
+  var points: [Point] = [] // expected-note 2{{property declared here}}
+  var int: Int = 0 // expected-note 2{{property declared here}}
+  var maybeInt: Int? // expected-note 1{{property declared here}}
+  var maybePoint: Point? // expected-note 1{{property declared here}}
+  var myActor: TestActor = TestActor() // expected-note 1{{property declared here}}
 
   // Checking that various ways of unwrapping emit the right error messages at
   // the right times and that illegal operations are caught

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -1411,14 +1411,15 @@ class MA {
 @SomeGlobalActor class SGA: MA {} // expected-error {{global actor 'SomeGlobalActor'-isolated class 'SGA' has different actor isolation from main actor-isolated superclass 'MA'}}
 
 protocol SGA_Proto {
-  @SomeGlobalActor func method() // expected-note {{'method()' declared here}}
+  @SomeGlobalActor func method() // expected-note {{mark the protocol requirement 'method()' 'async' to allow actor-isolated conformances}}
 }
 
 // try to override a MA method with inferred isolation from a protocol requirement
 class SGA_MA: MA, SGA_Proto {
   // expected-error@+2 {{call to global actor 'SomeGlobalActor'-isolated global function 'onions_sga()' in a synchronous main actor-isolated context}}
-  // expected-warning@+1 {{instance method 'method()' isolated to global actor 'MainActor' can not satisfy corresponding requirement from protocol 'SGA_Proto' isolated to global actor 'SomeGlobalActor'}}
+  // expected-warning@+1 {{main actor-isolated instance method 'method()' cannot be used to satisfy global actor 'SomeGlobalActor'-isolated protocol requirement}}
   override func method() { onions_sga() }
+  // expected-note@-1{{add 'nonisolated' to 'method()' to make this instance method not isolated to the actor}}{{3-3=nonisolated }}
 }
 
 class None_MA: MA {

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -68,7 +68,7 @@ actor MyActor: MySuperActor { // expected-error{{actor types do not support inhe
   var name : String = "koala" // expected-note{{property declared here}}
 
   func accessProp() -> String {
-    return self.name // expected-error{{property 'name' isolated to global actor 'MainActor' can not be referenced from actor 'MyActor' in a synchronous context}}
+    return self.name // expected-error{{main actor-isolated property 'name' can not be referenced on a different actor instance}}
   }
 
   static func synchronousClass() { }
@@ -426,11 +426,11 @@ actor Crystal {
   func referToGlobProps() async {
     _ = await globActorVar + globActorProp
 
-    globActorProp = 20 // expected-error {{property 'globActorProp' isolated to global actor 'SomeGlobalActor' can not be mutated from actor 'Crystal'}}
+    globActorProp = 20 // expected-error {{global actor 'SomeGlobalActor'-isolated property 'globActorProp' can not be mutated on a different actor instance}}
 
-    globActorVar = 30 // expected-error {{property 'globActorVar' isolated to global actor 'SomeGlobalActor' can not be mutated from actor 'Crystal'}}
+    globActorVar = 30 // expected-error {{global actor 'SomeGlobalActor'-isolated property 'globActorVar' can not be mutated on a different actor instance}}
 
-    // expected-error@+2 {{property 'globActorVar' isolated to global actor 'SomeGlobalActor' can not be used 'inout' from actor 'Crystal'}}
+    // expected-error@+2 {{global actor 'SomeGlobalActor'-isolated property 'globActorVar' can not be used 'inout' on a different actor instance}}
     // expected-error@+1 {{actor-isolated property 'globActorVar' cannot be passed 'inout' to implicitly 'async' function call}}
     await self.foo(&globActorVar)
 
@@ -959,7 +959,7 @@ class SomeClassWithInits {
 
   deinit {
     print(mutableState) // Okay, we're actor-isolated
-    print(SomeClassWithInits.shared) // expected-error{{static property 'shared' isolated to global actor 'MainActor' can not be referenced from this synchronous context}}
+    print(SomeClassWithInits.shared) // expected-error{{main actor-isolated static property 'shared' can not be referenced from a non-isolated context}}
     beets_ma() //expected-error{{call to main actor-isolated global function 'beets_ma()' in a synchronous nonisolated context}}
   }
 
@@ -985,7 +985,7 @@ class SomeClassWithInits {
 @available(SwiftStdlib 5.1, *)
 func outsideSomeClassWithInits() { // expected-note 3 {{add '@MainActor' to make global function 'outsideSomeClassWithInits()' part of global actor 'MainActor'}}
   _ = SomeClassWithInits() // expected-error{{call to main actor-isolated initializer 'init()' in a synchronous nonisolated context}}
-  _ = SomeClassWithInits.shared // expected-error{{static property 'shared' isolated to global actor 'MainActor' can not be referenced from this synchronous context}}
+  _ = SomeClassWithInits.shared // expected-error{{main actor-isolated static property 'shared' can not be referenced from a non-isolated context}}
   SomeClassWithInits.staticIsolated() // expected-error{{call to main actor-isolated static method 'staticIsolated()' in a synchronous nonisolated context}}
 }
 

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -566,7 +566,7 @@ var number: Int = 42 // expected-note {{var declared here}}
 
 // expected-note@+1 {{add '@SomeGlobalActor' to make global function 'badNumberUser()' part of global actor 'SomeGlobalActor'}}
 func badNumberUser() {
-  //expected-error@+1{{var 'number' isolated to global actor 'SomeGlobalActor' can not be referenced from this synchronous context}}
+  //expected-error@+1{{global actor 'SomeGlobalActor'-isolated var 'number' can not be referenced from a non-isolated context}}
   print("The protected number is: \(number)")
 }
 

--- a/test/Concurrency/actor_isolation_unsafe.swift
+++ b/test/Concurrency/actor_isolation_unsafe.swift
@@ -14,7 +14,7 @@ actor SomeGlobalActor {
 // Witnessing and unsafe global actor
 // ----------------------------------------------------------------------
 protocol P1 {
-  @MainActor(unsafe) func onMainActor() // expected-note{{'onMainActor()' declared here}}
+  @MainActor(unsafe) func onMainActor() // expected-note{{mark the protocol requirement 'onMainActor()' 'async' to allow actor-isolated conformances}}
 }
 
 struct S1_P1: P1 {
@@ -35,7 +35,7 @@ struct S4_P1_quietly: P1 {
 
 @SomeGlobalActor
 struct S4_P1: P1 {
-  @SomeGlobalActor func onMainActor() { } // expected-warning{{instance method 'onMainActor()' isolated to global actor 'SomeGlobalActor' can not satisfy corresponding requirement from protocol 'P1' isolated to global actor 'MainActor'}}
+  @SomeGlobalActor func onMainActor() { } // expected-warning{{global actor 'SomeGlobalActor'-isolated instance method 'onMainActor()' cannot be used to satisfy main actor-isolated protocol requirement}}
 }
 
 

--- a/test/Concurrency/async_main_invalid_global_actor.swift
+++ b/test/Concurrency/async_main_invalid_global_actor.swift
@@ -12,7 +12,7 @@ var poof: Int = 1337 // expected-note{{var declared here}}
 @main struct Doggo {
   @Kat
   static func main() { // expected-error{{main() must be '@MainActor'}}
-    // expected-error@+1{{var 'poof' isolated to global actor 'Kat' can not be referenced from different global actor 'MainActor' in a synchronous context}}
+    // expected-error@+1{{global actor 'Kat'-isolated var 'poof' can not be referenced from the main actor}}
     print("Kat value: \(poof)")
   }
 }

--- a/test/Concurrency/global_actor_from_ordinary_context.swift
+++ b/test/Concurrency/global_actor_from_ordinary_context.swift
@@ -37,7 +37,7 @@ func referenceGlobalActor() async {
 
   // expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
   _ = a[1]  // expected-note{{subscript access is 'async'}}
-  a[0] = 1  // expected-error{{subscript 'subscript(_:)' isolated to global actor 'SomeGlobalActor' can not be mutated from this context}}
+  a[0] = 1  // expected-error{{global actor 'SomeGlobalActor'-isolated subscript 'subscript(_:)' can not be mutated from a non-isolated context}}
 
   // expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
   _ = 32 + a[1] // expected-note@:12{{subscript access is 'async'}}
@@ -126,7 +126,7 @@ func fromAsync() async {
   // expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
   _ = a[1]  // expected-note{{subscript access is 'async'}}
   _ = await a[1]
-  a[0] = 1  // expected-error{{subscript 'subscript(_:)' isolated to global actor 'SomeGlobalActor' can not be mutated from this context}}
+  a[0] = 1  // expected-error{{global actor 'SomeGlobalActor'-isolated subscript 'subscript(_:)' can not be mutated from a non-isolated context}}
 }
 
 // expected-note@+1{{mutation of this var is only permitted within the actor}}

--- a/test/Concurrency/global_actor_from_ordinary_context.swift
+++ b/test/Concurrency/global_actor_from_ordinary_context.swift
@@ -133,7 +133,7 @@ func fromAsync() async {
 @SomeGlobalActor var value: Int = 42
 
 func topLevelSyncFunction(_ number: inout Int) { }
-// expected-error@+1{{var 'value' isolated to global actor 'SomeGlobalActor' can not be used 'inout' from this context}}
+// expected-error@+1{{global actor 'SomeGlobalActor'-isolated var 'value' can not be used 'inout' from a non-isolated context}}
 topLevelSyncFunction(&value)
 
 // Strict checking based on inferred Sendable/async/etc.

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -110,7 +110,7 @@ protocol Interface {
 
 @MainActor
 class Object: Interface {
-  var baz: Int = 42 // expected-warning{{property 'baz' isolated to global actor 'MainActor' can not satisfy corresponding requirement from protocol 'Interface'}}
+  var baz: Int = 42 // expected-warning{{main actor-isolated property 'baz' cannot be used to satisfy nonisolated protocol requirement}}
 }
 
 

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -634,7 +634,7 @@ class Cutter {
 class Butter {
   var a = useFooInADefer() // expected-error {{call to main actor-isolated global function 'useFooInADefer()' in a synchronous global actor 'SomeGlobalActor'-isolated context}}
 
-  nonisolated let b = statefulThingy // expected-error {{var 'statefulThingy' isolated to global actor 'MainActor' can not be referenced from a non-isolated synchronous context}}
+  nonisolated let b = statefulThingy // expected-error {{main actor-isolated var 'statefulThingy' can not be referenced from a non-isolated context}}
 
   var c: Int = {
     return getGlobal7()

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -283,7 +283,7 @@ struct Observed {
 }
 
 func checkObserved(_ o: Observed) { // expected-note {{add '@OtherGlobalActor' to make global function 'checkObserved' part of global actor 'OtherGlobalActor'}}
-  _ = o.thing // expected-error {{property 'thing' isolated to global actor 'OtherGlobalActor' can not be referenced from this synchronous context}}
+  _ = o.thing // expected-error {{global actor 'OtherGlobalActor'-isolated property 'thing' can not be referenced from a non-isolated context}}
 }
 
 // ----------------------------------------------------------------------
@@ -358,9 +358,9 @@ struct HasWrapperOnActor {
 
   // expected-note@+1 3{{to make instance method 'testErrors()'}}
   func testErrors() {
-    _ = synced // expected-error{{property 'synced' isolated to global actor 'MainActor' can not be referenced from this synchronous context}}
-    _ = $synced // expected-error{{property '$synced' isolated to global actor 'SomeGlobalActor' can not be referenced from this synchronous context}}
-    _ = _synced // expected-error{{property '_synced' isolated to global actor 'OtherGlobalActor' can not be referenced from this synchronous context}}
+    _ = synced // expected-error{{main actor-isolated property 'synced' can not be referenced from a non-isolated context}}
+    _ = $synced // expected-error{{global actor 'SomeGlobalActor'-isolated property '$synced' can not be referenced from a non-isolated context}}
+    _ = _synced // expected-error{{global actor 'OtherGlobalActor'-isolated property '_synced' can not be referenced from a non-isolated context}}
   }
 
   @MainActor mutating func testOnMain() {
@@ -422,9 +422,9 @@ actor ActorWithWrapper {
   @WrapperOnActor var synced: Int = 0
   // expected-note@-1 3{{property declared here}}
   func f() {
-    _ = synced // expected-error{{'synced' isolated to global actor}}
-    _ = $synced // expected-error{{'$synced' isolated to global actor}}
-    _ = _synced // expected-error{{'_synced' isolated to global actor}}
+    _ = synced // expected-error{{main actor-isolated property 'synced' can not be referenced on a different actor instance}}
+    _ = $synced // expected-error{{global actor 'SomeGlobalActor'-isolated property '$synced' can not be referenced on a different actor instance}}
+    _ = _synced // expected-error{{global actor 'OtherGlobalActor'-isolated property '_synced' can not be referenced on a different actor instance}}
 
     @WrapperWithMainActorDefaultInit var value: Int // expected-error {{call to main actor-isolated initializer 'init()' in a synchronous actor-isolated context}}
   }
@@ -528,9 +528,9 @@ struct HasWrapperOnUnsafeActor {
   }
 
   nonisolated func testErrors() {
-    _ = synced // expected-error{{property 'synced' isolated to global actor 'MainActor' can not be referenced from}}
-    _ = $synced // expected-error{{property '$synced' isolated to global actor 'SomeGlobalActor' can not be referenced from}}
-    _ = _synced // expected-error{{property '_synced' isolated to global actor 'OtherGlobalActor' can not be referenced from a non-isolated synchronous context}}
+    _ = synced // expected-error{{main actor-isolated property 'synced' can not be referenced from a non-isolated context}}
+    _ = $synced // expected-error{{global actor 'SomeGlobalActor'-isolated property '$synced' can not be referenced from a non-isolated context}}
+    _ = _synced // expected-error{{global actor 'OtherGlobalActor'-isolated property '_synced' can not be referenced from a non-isolated context}}
   }
 
   @MainActor mutating func testOnMain() {

--- a/test/Concurrency/global_actor_inference_swift6.swift
+++ b/test/Concurrency/global_actor_inference_swift6.swift
@@ -81,15 +81,15 @@ struct HasMainActorWrappedProp {
   var computedProp: Int { 0 } // expected-note {{property declared here}}
 
   nonisolated func testErrors() {
-    _ = thing // expected-error {{property 'thing' isolated to global actor 'MainActor' can not be referenced from a non-isolated synchronous context}}
-    _ = _thing.wrappedValue // expected-error {{property 'wrappedValue' isolated to global actor 'MainActor' can not be referenced from a non-isolated synchronous context}}
+    _ = thing // expected-error {{main actor-isolated property 'thing' can not be referenced from a non-isolated context}}
+    _ = _thing.wrappedValue // expected-error {{main actor-isolated property 'wrappedValue' can not be referenced from a non-isolated context}}
 
     _ = _thing
     _ = _thing.accessCount
 
     _ = plainStorage
 
-    _ = computedProp // expected-error {{property 'computedProp' isolated to global actor 'MainActor' can not be referenced from a non-isolated synchronous context}}
+    _ = computedProp // expected-error {{main actor-isolated property 'computedProp' can not be referenced from a non-isolated context}}
   }
 }
 
@@ -99,10 +99,10 @@ struct HasWrapperOnActor {
 
   // expected-note@+1 3{{to make instance method 'testErrors()'}}
   func testErrors() {
-    _ = synced // expected-error{{property 'synced' isolated to global actor 'MainActor' can not be referenced from this synchronous context}}
-    _ = $synced // expected-error{{property '$synced' isolated to global actor 'SomeGlobalActor' can not be referenced from this synchronous context}}
+    _ = synced // expected-error{{main actor-isolated property 'synced' can not be referenced from a non-isolated context}}
+    _ = $synced // expected-error{{global actor 'SomeGlobalActor'-isolated property '$synced' can not be referenced from a non-isolated context}}
     _ = _synced
-    _ = _synced.wrappedValue // expected-error{{property 'wrappedValue' isolated to global actor 'MainActor' can not be referenced from this synchronous context}}
+    _ = _synced.wrappedValue // expected-error{{main actor-isolated property 'wrappedValue' can not be referenced from a non-isolated context}}
   }
 
   @MainActor mutating func testOnMain() {
@@ -123,6 +123,6 @@ struct Carbon {
   @IntWrapper var atomicWeight: Int // expected-note {{property declared here}}
 
   nonisolated func getWeight() -> Int {
-    return atomicWeight // expected-error {{property 'atomicWeight' isolated to global actor 'MainActor' can not be referenced from a non-isolated synchronous context}}
+    return atomicWeight // expected-error {{main actor-isolated property 'atomicWeight' can not be referenced from a non-isolated context}}
   }
 }

--- a/test/Concurrency/toplevel/async-5-top-level.swift
+++ b/test/Concurrency/toplevel/async-5-top-level.swift
@@ -22,7 +22,7 @@ func isolatedSync() {
 func nonIsolatedAsync() async {
     await print(a)
     a = a + 10
-    // expected-error@-1:5 {{var 'a' isolated to global actor 'MainActor' can not be mutated from this context}}
+    // expected-error@-1:5 {{main actor-isolated var 'a' can not be mutated from a non-isolated context}}
     // expected-error@-2:9 {{expression is 'async' but is not marked with 'await'}}{{9-9=await }}
     // expected-note@-3:9 {{property access is 'async'}}
 }

--- a/test/Concurrency/toplevel/async-6-top-level.swift
+++ b/test/Concurrency/toplevel/async-6-top-level.swift
@@ -7,10 +7,10 @@ var a = 10
 // expected-note@-2 2 {{mutation of this var is only permitted within the actor}}
 
 func nonIsolatedSync() { //expected-note 3 {{add '@MainActor' to make global function 'nonIsolatedSync()' part of global actor 'MainActor'}}
-    print(a)    // expected-error {{var 'a' isolated to global actor 'MainActor' can not be referenced from this synchronous context}}
+    print(a)    // expected-error {{main actor-isolated var 'a' can not be referenced from a non-isolated context}}
     a = a + 10
-    // expected-error@-1:5 {{var 'a' isolated to global actor 'MainActor' can not be mutated from this context}}
-    // expected-error@-2:9 {{var 'a' isolated to global actor 'MainActor' can not be referenced from this synchronous context}}
+    // expected-error@-1:9 {{main actor-isolated var 'a' can not be referenced from a non-isolated context}}
+    // expected-error@-2:5 {{main actor-isolated var 'a' can not be mutated from a non-isolated context}}
 
 }
 
@@ -23,7 +23,7 @@ func isolatedSync() {
 func nonIsolatedAsync() async {
     await print(a)
     a = a + 10
-    // expected-error@-1:5 {{var 'a' isolated to global actor 'MainActor' can not be mutated from this context}}
+    // expected-error@-1:5 {{main actor-isolated var 'a' can not be mutated from a non-isolated context}}
     // expected-error@-2:9 {{expression is 'async' but is not marked with 'await'}}
     // expected-note@-3:9 {{property access is 'async'}}
 }

--- a/test/Concurrency/toplevel/main.swift
+++ b/test/Concurrency/toplevel/main.swift
@@ -11,10 +11,10 @@ var b = 14
 
 func nonIsolatedSynchronous() {
     print(a)
-// Swift6-CHECK: var 'a' isolated to global actor 'MainActor'
+// Swift6-CHECK: main actor-isolated var 'a' can not be referenced from a non-isolated context
 // Swift6-CHECK: add '@MainActor' to make global function 'nonIsolatedSynchronous()' part of global actor 'MainActor'
 
-// Swift5-CHECK-NOT: var 'a' isolated to global actor 'MainActor'
+// Swift5-CHECK-NOT: main actor-isolated var 'a' can not be referenced from a non-isolated context
 // Swift5-CHECK-NOT: add '@MainActor' to make global function 'nonIsolatedSynchronous()' part of global actor 'MainActor'
 }
 
@@ -26,13 +26,13 @@ func nonIsolatedAsync() async {
 
 await nonIsolatedAsync()
 
-// Swift6-CHECK: foo.swift{{.*}}var 'a' isolated to global actor 'MainActor' can not be referenced from this synchronous context
-// Swift6-CHECK: foo.swift{{.*}}add '@MainActor' to make global function 'foo()' part of global actor 'MainActor'
+// Swift6-CHECK: foo.swift{{.*}}main actor-isolated var 'a' can not be referenced from a non-isolated context
 // Swift6-CHECK: var declared here
+// Swift6-CHECK: foo.swift{{.*}}add '@MainActor' to make global function 'foo()' part of global actor 'MainActor'
 
-// Swift5-CHECK-NOT: foo.swift{{.*}}var 'a' isolated to global actor 'MainActor' can not be referenced from this synchronous context
-// Swift5-CHECK-NOT: foo.swift{{.*}}add '@MainActor' to make global function 'foo()' part of global actor 'MainActor'
+// Swift5-CHECK-NOT: foo.swift{{.*}}main actor-isolated var 'a' can not be referenced from a non-isolated context
 // Swift5-CHECK-NOT: var declared here
+// Swift5-CHECK-NOT: foo.swift{{.*}}add '@MainActor' to make global function 'foo()' part of global actor 'MainActor'
 
 @MainActor
 func isolated() {

--- a/test/Concurrency/toplevel/synchronous_mainactor.swift
+++ b/test/Concurrency/toplevel/synchronous_mainactor.swift
@@ -6,7 +6,7 @@ var a = 10 // expected-note{{var declared here}}
 var b = 15 // expected-error{{top-level code variables cannot have a global actor}}
 
 func unsafeAccess() { // expected-note{{add '@MainActor' to make global function 'unsafeAccess()' part of global actor 'MainActor'}}
-    print(a) // expected-error@:11{{var 'a' isolated to global actor 'MainActor' can not be referenced from this synchronous context}}
+    print(a) // expected-error@:11{{main actor-isolated var 'a' can not be referenced from a non-isolated context}}
 }
 
 func unsafeAsyncAccess() async {

--- a/test/Distributed/distributed_actor_func_implicitly_async_throws.swift
+++ b/test/Distributed/distributed_actor_func_implicitly_async_throws.swift
@@ -51,12 +51,12 @@ func test_outside(distributed: D) async throws {
 
   distributed.distHelloAsync()// expected-error{{expression is 'async' but is not marked with 'await'}}
   // expected-error@-1{{call can throw but is not marked with 'try'}}
-  // expected-note@-2{{call is 'async'}}
+  // expected-note@-2{{calls to distributed instance method 'distHelloAsync()' from outside of its actor context are implicitly asynchronous}}
   // expected-note@-3{{did you mean to use 'try'?}}
   // expected-note@-4{{did you mean to disable error propagation?}}
   // expected-note@-5{{did you mean to handle error as optional value?}}
   try distributed.distHelloAsync() // expected-error{{expression is 'async' but is not marked with 'await'}}
-  // expected-note@-1{{call is 'async'}}
+  // expected-note@-1{{calls to distributed instance method 'distHelloAsync()' from outside of its actor context are implicitly asynchronous}}
   await distributed.distHelloAsync() // expected-error{{call can throw but is not marked with 'try'}}
   // expected-note@-1{{did you mean to use 'try'?}}
   // expected-note@-2{{did you mean to disable error propagation?}}
@@ -79,12 +79,12 @@ func test_outside(distributed: D) async throws {
 
   distributed.distHelloAsyncThrows() // expected-error{{expression is 'async' but is not marked with 'await'}}
   // expected-error@-1{{call can throw but is not marked with 'try'}}
-  // expected-note@-2{{call is 'async'}}
+  // expected-note@-2{{calls to distributed instance method 'distHelloAsyncThrows()' from outside of its actor context are implicitly asynchronous}}
   // expected-note@-3{{did you mean to use 'try'?}}
   // expected-note@-4{{did you mean to disable error propagation?}}
   // expected-note@-5{{did you mean to handle error as optional value?}}
   try distributed.distHelloAsyncThrows() // expected-error{{expression is 'async' but is not marked with 'await'}}
-  // expected-note@-1{{call is 'async'}}
+  // expected-note@-1{{calls to distributed instance method 'distHelloAsyncThrows()' from outside of its actor context are implicitly asynchronous}}
   await distributed.distHelloAsyncThrows() // expected-error{{call can throw but is not marked with 'try'}}
   // expected-note@-1{{did you mean to use 'try'?}}
   // expected-note@-2{{did you mean to disable error propagation?}}

--- a/test/Distributed/distributed_actor_protocol_isolation.swift
+++ b/test/Distributed/distributed_actor_protocol_isolation.swift
@@ -14,12 +14,16 @@ typealias DefaultDistributedActorSystem = FakeActorSystem
 
 protocol LocalProto {
   func local()
-  // expected-note@-1{{mark the protocol requirement 'local()' 'async throws' in order witness it with 'distributed' function declared in distributed actor 'DAD'}}
+  // expected-note@-1 2{{mark the protocol requirement 'local()' 'async throws' to allow actor-isolated conformances}}
+
   func localAsync() async
-  // expected-note@-1{{mark the protocol requirement 'localAsync()' 'throws' in order witness it with 'distributed' function declared in distributed actor 'DAD'}}
+  // expected-note@-1 2{{mark the protocol requirement 'localAsync()' 'throws' to allow actor-isolated conformances}}{{26-26= throws}}
+
   func localThrows() throws
-  // expected-note@-1{{mark the protocol requirement 'localThrows()' 'async' in order witness it with 'distributed' function declared in distributed actor 'DAD'}}
+  // expected-note@-1 2{{mark the protocol requirement 'localThrows()' 'async' to allow actor-isolated conformances}}{{22-22=async }}
+
   func localAsyncThrows() async throws
+  // expected-note@-1{{'localAsyncThrows()' declared here}}
 }
 
 // TODO(distributed): It should be possible for a distributed actor to conform to this protocol (!),
@@ -50,28 +54,29 @@ protocol DistProtoDistributedActor: DistributedActor {
 
 distributed actor DAL: LocalProto {
   func local() {}
-  // expected-error@-1{{actor-isolated instance method 'local()' cannot be used to satisfy a protocol requirement}}
+  // expected-error@-1{{distributed actor-isolated instance method 'local()' cannot be used to satisfy nonisolated protocol requirement}}
   // expected-note@-2{{add 'nonisolated' to 'local()' to make this instance method not isolated to the actor}}
   func localAsync() async {}
-  // expected-error@-1{{actor-isolated instance method 'localAsync()' cannot be used to satisfy a protocol requirement}}
+  // expected-error@-1{{distributed actor-isolated instance method 'localAsync()' cannot be used to satisfy nonisolated protocol requirement}}
+  // expected-note@-2{{add 'nonisolated' to 'localAsync()' to make this instance method not isolated to the actor}}
   func localThrows() throws {}
-  // expected-error@-1{{actor-isolated instance method 'localThrows()' cannot be used to satisfy a protocol requirement}}
+  // expected-error@-1{{distributed actor-isolated instance method 'localThrows()' cannot be used to satisfy nonisolated protocol requirement}}
   // expected-note@-2{{add 'nonisolated' to 'localThrows()' to make this instance method not isolated to the actor}}
   func localAsyncThrows() async throws {}
-  // expected-error@-1{{actor-isolated instance method 'localAsyncThrows()' cannot be used to satisfy a protocol requirement}}
+  // expected-error@-1{{distributed actor-isolated instance method 'localAsyncThrows()' cannot be used to satisfy nonisolated protocol requirement}}
+  // expected-note@-2{{add 'nonisolated' to 'localAsyncThrows()' to make this instance method not isolated to the actor}}
+  // expected-note@-3{{add 'distributed' to 'localAsyncThrows()' to make this instance method satisfy the protocol requirement}}
 }
 
 distributed actor DAD: LocalProto {
   distributed func local() {}
-  // expected-error@-1{{distributed actor-isolated distributed instance method 'local()' cannot be used to satisfy a protocol requirement}}
-  // expected-note@-2{{add 'nonisolated' to 'local()' to make this distributed instance method not isolated to the actor}}
+  // expected-error@-1{{actor-isolated distributed instance method 'local()' cannot be used to satisfy nonisolated protocol requirement}}
 
   distributed func localAsync() async {}
-  // expected-error@-1{{distributed actor-isolated distributed instance method 'localAsync()' cannot be used to satisfy a protocol requirement}}
+  // expected-error@-1{{actor-isolated distributed instance method 'localAsync()' cannot be used to satisfy nonisolated protocol requirement}}
 
   distributed func localThrows() throws {}
-  // expected-error@-1{{distributed actor-isolated distributed instance method 'localThrows()' cannot be used to satisfy a protocol requirement}}
-  // expected-note@-2{{add 'nonisolated' to 'localThrows()' to make this distributed instance method not isolated to the actor}}
+  // expected-error@-1{{actor-isolated distributed instance method 'localThrows()' cannot be used to satisfy nonisolated protocol requirement}}
 
   distributed func localAsyncThrows() async throws {} // ok!
 }

--- a/test/Distributed/distributed_protocol_isolation.swift
+++ b/test/Distributed/distributed_protocol_isolation.swift
@@ -96,29 +96,27 @@ func outside_good_ext<DP: DistProtocol>(dp: DP) async throws {
 /// A distributed actor could only conform to this by making everything 'nonisolated':
 protocol StrictlyLocal {
   func local()
-  // expected-note@-1{{mark the protocol requirement 'local()' 'async throws' in order witness it with 'distributed' function declared in distributed actor 'Nope2_StrictlyLocal'}}
+  // expected-note@-1 2{{mark the protocol requirement 'local()' 'async throws' to allow actor-isolated conformances}}{{15-15= async throws}}
 
   func localThrows() throws
-  // expected-note@-1{{mark the protocol requirement 'localThrows()' 'async' in order witness it with 'distributed' function declared in distributed actor 'Nope2_StrictlyLocal'}}
-
+  // expected-note@-1 2{{mark the protocol requirement 'localThrows()' 'async' to allow actor-isolated conformances}}{{22-22=async }}
+  
   // TODO: localAsync
 }
 
 distributed actor Nope1_StrictlyLocal: StrictlyLocal {
   func local() {}
-  // expected-error@-1{{actor-isolated instance method 'local()' cannot be used to satisfy a protocol requirement}}
+  // expected-error@-1{{distributed actor-isolated instance method 'local()' cannot be used to satisfy nonisolated protocol requirement}}
   // expected-note@-2{{add 'nonisolated' to 'local()' to make this instance method not isolated to the actor}}
   func localThrows() throws {}
-  // expected-error@-1{{actor-isolated instance method 'localThrows()' cannot be used to satisfy a protocol requirement}}
+  // expected-error@-1{{distributed actor-isolated instance method 'localThrows()' cannot be used to satisfy nonisolated protocol requirement}}
   // expected-note@-2{{add 'nonisolated' to 'localThrows()' to make this instance method not isolated to the actor}}
 }
 distributed actor Nope2_StrictlyLocal: StrictlyLocal {
   distributed func local() {}
-  // expected-error@-1{{actor-isolated distributed instance method 'local()' cannot be used to satisfy a protocol requirement}}
-  // expected-note@-2{{add 'nonisolated' to 'local()' to make this distributed instance method not isolated to the actor}}
+  // expected-error@-1{{actor-isolated distributed instance method 'local()' cannot be used to satisfy nonisolated protocol requirement}}
   distributed func localThrows() throws {}
-  // expected-error@-1{{actor-isolated distributed instance method 'localThrows()' cannot be used to satisfy a protocol requirement}}
-  // expected-note@-2{{add 'nonisolated' to 'localThrows()' to make this distributed instance method not isolated to the actor}}
+  // expected-error@-1{{actor-isolated distributed instance method 'localThrows()' cannot be used to satisfy nonisolated protocol requirement}}
 }
 distributed actor OK_StrictlyLocal: StrictlyLocal {
   nonisolated func local() {}
@@ -134,6 +132,7 @@ actor MyServer : Server {
 
 protocol AsyncThrowsAll {
   func maybe(param: String, int: Int) async throws -> Int
+  // expected-note@-1{{'maybe(param:int:)' declared here}}
 }
 
 actor LocalOK_AsyncThrowsAll: AsyncThrowsAll {
@@ -146,7 +145,9 @@ actor LocalOK_Implicitly_AsyncThrowsAll: AsyncThrowsAll {
 
 distributed actor Nope1_AsyncThrowsAll: AsyncThrowsAll {
   func maybe(param: String, int: Int) async throws -> Int { 111 }
-  // expected-error@-1{{distributed actor-isolated instance method 'maybe(param:int:)' cannot be used to satisfy a protocol requirement}}
+  // expected-error@-1{{distributed actor-isolated instance method 'maybe(param:int:)' cannot be used to satisfy nonisolated protocol requirement}}
+  // expected-note@-2{{add 'nonisolated' to 'maybe(param:int:)' to make this instance method not isolated to the actor}}
+  // expected-note@-3{{add 'distributed' to 'maybe(param:int:)' to make this instance method satisfy the protocol requirement}}
 }
 
 distributed actor OK_AsyncThrowsAll: AsyncThrowsAll {

--- a/test/decl/class/actor/conformance.swift
+++ b/test/decl/class/actor/conformance.swift
@@ -15,14 +15,14 @@ extension MyActor: AsyncProtocol {
 }
 
 protocol SyncProtocol {
-  var propertyA: Int { get }
-  var propertyB: Int { get set }
+  var propertyA: Int { get } // expected-note{{'propertyA' declared here}}
+  var propertyB: Int { get set } // expected-note{{'propertyB' declared here}}
 
-  func syncMethodA()
+  func syncMethodA() // expected-note{{mark the protocol requirement 'syncMethodA()' 'async' to allow actor-isolated conformances}}{{21-21= async}}
 
   func syncMethodC() -> Int
 
-  subscript (index: Int) -> String { get }
+  subscript (index: Int) -> String { get } // expected-note{{'subscript(_:)' declared here}}
 
   static func staticMethod()
   static var staticProperty: Int { get }
@@ -31,14 +31,13 @@ protocol SyncProtocol {
 
 actor OtherActor: SyncProtocol {
   var propertyB: Int = 17
-  // expected-error@-1{{actor-isolated property 'propertyB' cannot be used to satisfy a protocol requirement}}
+  // expected-error@-1{{actor-isolated property 'propertyB' cannot be used to satisfy nonisolated protocol requirement}}
 
   var propertyA: Int { 17 }
-  // expected-error@-1{{actor-isolated property 'propertyA' cannot be used to satisfy a protocol requirement}}
-  // expected-note@-2{{add 'nonisolated' to 'propertyA' to make this property not isolated to the actor}}{{3-3=nonisolated }}
+  // expected-error@-1{{actor-isolated property 'propertyA' cannot be used to satisfy nonisolated protocol requirement}}
 
   func syncMethodA() { }
-  // expected-error@-1{{actor-isolated instance method 'syncMethodA()' cannot be used to satisfy a protocol requirement}}
+  // expected-error@-1{{actor-isolated instance method 'syncMethodA()' cannot be used to satisfy nonisolated protocol requirement}}
   // expected-note@-2{{add 'nonisolated' to 'syncMethodA()' to make this instance method not isolated to the actor}}{{3-3=nonisolated }}
 
   // nonisolated methods are okay.
@@ -46,7 +45,7 @@ actor OtherActor: SyncProtocol {
   nonisolated func syncMethodC() -> Int { 5 }
 
   subscript (index: Int) -> String { "\(index)" }
-  // expected-error@-1{{actor-isolated subscript 'subscript(_:)' cannot be used to satisfy a protocol requirement}}
+  // expected-error@-1{{actor-isolated subscript 'subscript(_:)' cannot be used to satisfy nonisolated protocol requirement}}
   // expected-note@-2{{add 'nonisolated' to 'subscript(_:)' to make this subscript not isolated to the actor}}{{3-3=nonisolated }}
 
   // Static methods and properties are okay.

--- a/test/decl/class/actor/global_actor_conformance.swift
+++ b/test/decl/class/actor/global_actor_conformance.swift
@@ -17,9 +17,9 @@ protocol P1 {
   associatedtype Assoc
 
   @GlobalActor func method1()
-  @GenericGlobalActor<Int> func method2()  // expected-note{{declared here}}
+  @GenericGlobalActor<Int> func method2()  // expected-note{{}}
   @GenericGlobalActor<Assoc> func method3()
-  func method4() // expected-note{{declared here}}
+  func method4() // expected-note{{mark the protocol requirement 'method4()' 'async' to allow actor-isolated conformances}}
 }
 
 protocol P2 {
@@ -33,9 +33,9 @@ class C1 : P1, P2 {
 
   func method1() { }
 
-  @GenericGlobalActor<String> func method2() { } // expected-warning{{instance method 'method2()' isolated to global actor 'GenericGlobalActor<String>' can not satisfy corresponding requirement from protocol 'P1' isolated to global actor 'GenericGlobalActor<Int>'}}
+  @GenericGlobalActor<String> func method2() { } // expected-warning{{global actor 'GenericGlobalActor<String>'-isolated instance method 'method2()' cannot be used to satisfy global actor 'GenericGlobalActor<Int>'-isolated protocol requirement}}
   @GenericGlobalActor<String >func method3() { }
-  @GlobalActor func method4() { } // expected-warning{{instance method 'method4()' isolated to global actor 'GlobalActor' can not satisfy corresponding requirement from protocol 'P1'}}
+  @GlobalActor func method4() { } // expected-warning{{global actor 'GlobalActor'-isolated instance method 'method4()' cannot be used to satisfy nonisolated protocol requirement}}
 
   // Okay: we can ignore the mismatch in global actor types for 'async' methods.
   func asyncMethod1() async { }

--- a/test/decl/protocol/special/DistributedActor.swift
+++ b/test/decl/protocol/special/DistributedActor.swift
@@ -65,13 +65,13 @@ distributed actor D4 {
 
 protocol P1: DistributedActor {
   distributed func dist() -> String
-  // expected-note@-1{{distributed instance method requirement 'dist()' declared here}}
+  // expected-note@-1{{'dist()' declared here}}
 }
 
 distributed actor D5: P1 {
   func dist() -> String { "" }
-  // expected-error@-1{{distributed actor-isolated instance method 'dist()' cannot be used to satisfy a protocol requirement}}
-  // expected-note@-2{{add 'distributed' to 'dist()' to make this instance method witness the protocol requirement}}{{3-3=distributed }}
+  // expected-error@-1{{distributed actor-isolated instance method 'dist()' cannot be used to satisfy actor-isolated protocol requirement}}
+  // expected-note@-2{{add 'distributed' to 'dist()' to make this instance method satisfy the protocol requirement}}{{3-3=distributed }}
 }
 
 // ==== Tests ------------------------------------------------------------------


### PR DESCRIPTION
Start collapsing the several implementations of actor isolation checking
into a single place that determines what it means to reference a declaration
from a given context, potentially supplying an instance for an actor. This
is partly cleanup, and partly staging for the implementation of the
Sendable restrictions introduced in SE-0338. The result of this check
falls into one of three categories:

* Reference occurs within the same concurrency domain (actor/task)
* Reference leaves an actor context to a nonisolated context (SE-0338)
* Reference enters the context of the actor, which might require a
combination of implicit async, implicit throws, and a "distributed" check.

Throughout this change I've sought to maintain the existing semantics,
even where I believe they are incorrect. The changes to the test cases
are not semantic changes, but reflect the unification of some
diagnostic paths that changed the diagnostic text but not when or how
those diagnostics are produced. Additionally, SE-0338 has not yet been
implemented, although this refactoring makes it easier to implement
SE-0338.

Use this new actor isolation checking scheme to implement the most
common actor-isolation checks for accessing both member and
non-member declarations from expressions.
