### PR TITLE
[test] expectCrashLater(withMessage:) reliability workaround

### DIFF
--- a/test/stdlib/StringAPICString.swift
+++ b/test/stdlib/StringAPICString.swift
@@ -239,13 +239,10 @@ CStringTests.test("String.cString.with.Array.UInt8.input") {
     }
   }
   // no need to test every case; that is covered in other tests
-  #if os(Linux)
-  expectCrashLater()
-  #else
   expectCrashLater(
-    withMessage: "input of String.init(cString:) must be null-terminated"
+    // Workaround for https://bugs.swift.org/browse/SR-16103 (rdar://91365967)
+    // withMessage: "input of String.init(cString:) must be null-terminated"
   )
-  #endif
   _ = String(cString: [] as [UInt8])
   expectUnreachable()
 }
@@ -264,13 +261,10 @@ CStringTests.test("String.cString.with.Array.CChar.input") {
     }
   }
   // no need to test every case; that is covered in other tests
-  #if os(Linux)
-  expectCrashLater()
-  #else
   expectCrashLater(
-    withMessage: "input of String.init(cString:) must be null-terminated"
+    // Workaround for https://bugs.swift.org/browse/SR-16103 (rdar://91365967)
+    // withMessage: "input of String.init(cString:) must be null-terminated"
   )
-  #endif
   _ = String(cString: [] as [CChar])
   expectUnreachable()
 }
@@ -293,13 +287,10 @@ CStringTests.test("String.cString.with.inout.UInt8.conversion") {
   var str = String(cString: &c)
   expectTrue(str.isEmpty)
   c = 100
-  #if os(Linux)
-  expectCrashLater()
-  #else
   expectCrashLater(
-    withMessage: "input of String.init(cString:) must be null-terminated"
+    // Workaround for https://bugs.swift.org/browse/SR-16103 (rdar://91365967)
+    // withMessage: "input of String.init(cString:) must be null-terminated"
   )
-  #endif
   str = String(cString: &c)
   expectUnreachable()
 }
@@ -309,13 +300,10 @@ CStringTests.test("String.cString.with.inout.CChar.conversion") {
   var str = String(cString: &c)
   expectTrue(str.isEmpty)
   c = 100
-  #if os(Linux)
-  expectCrashLater()
-  #else
   expectCrashLater(
-    withMessage: "input of String.init(cString:) must be null-terminated"
+    // Workaround for https://bugs.swift.org/browse/SR-16103 (rdar://91365967)
+    // withMessage: "input of String.init(cString:) must be null-terminated"
   )
-  #endif
   str = String(cString: &c)
   expectUnreachable()
 }
@@ -335,13 +323,10 @@ CStringTests.test("String.validatingUTF8.with.Array.input") {
     }
   }
   // no need to test every case; that is covered in other tests
-  #if os(Linux)
-  expectCrashLater()
-  #else
   expectCrashLater(
-    withMessage: "input of String.init(validatingUTF8:) must be null-terminated"
+    // Workaround for https://bugs.swift.org/browse/SR-16103 (rdar://91365967)
+    // withMessage: "input of String.init(validatingUTF8:) must be null-terminated"
   )
-  #endif
   _ = String(validatingUTF8: [])
   expectUnreachable()
 }
@@ -367,13 +352,10 @@ CStringTests.test("String.validatingUTF8.with.inout.conversion") {
   expectNotNil(str)
   expectEqual(str?.isEmpty, true)
   c = 100
-  #if os(Linux)
-  expectCrashLater()
-  #else
   expectCrashLater(
-    withMessage: "input of String.init(validatingUTF8:) must be null-terminated"
+    // Workaround for https://bugs.swift.org/browse/SR-16103 (rdar://91365967)
+    // withMessage: "input of String.init(validatingUTF8:) must be null-terminated"
   )
-  #endif
   str = String(validatingUTF8: &c)
   expectUnreachable()
 }
@@ -394,13 +376,10 @@ CStringTests.test("String.decodeCString.with.Array.input") {
     }
   }
   // no need to test every case; that is covered in other tests
-  #if os(Linux)
-  expectCrashLater()
-  #else
   expectCrashLater(
-    withMessage: "input of decodeCString(_:as:repairingInvalidCodeUnits:) must be null-terminated"
+    // Workaround for https://bugs.swift.org/browse/SR-16103 (rdar://91365967)
+    // withMessage: "input of decodeCString(_:as:repairingInvalidCodeUnits:) must be null-terminated"
   )
-  #endif
   _ = String.decodeCString([], as: Unicode.UTF8.self)
   expectUnreachable()
 }
@@ -433,13 +412,10 @@ CStringTests.test("String.decodeCString.with.inout.conversion") {
   expectEqual(result?.result.isEmpty, true)
   expectEqual(result?.repairsMade, false)
   c = 100
-  #if os(Linux)
-  expectCrashLater()
-  #else
   expectCrashLater(
-    withMessage: "input of decodeCString(_:as:repairingInvalidCodeUnits:) must be null-terminated"
+    // Workaround for https://bugs.swift.org/browse/SR-16103 (rdar://91365967)
+    // withMessage: "input of decodeCString(_:as:repairingInvalidCodeUnits:) must be null-terminated"
   )
-  #endif
   result = String.decodeCString(&c, as: Unicode.UTF8.self)
   expectUnreachable()
 }
@@ -458,13 +434,10 @@ CStringTests.test("String.init.decodingCString.with.Array.input") {
     }
   }
   // no need to test every case; that is covered in other tests
-  #if os(Linux)
-  expectCrashLater()
-  #else
   expectCrashLater(
-    withMessage: "input of decodeCString(_:as:repairingInvalidCodeUnits:) must be null-terminated"
+    // Workaround for https://bugs.swift.org/browse/SR-16103 (rdar://91365967)
+    // withMessage: "input of decodeCString(_:as:repairingInvalidCodeUnits:) must be null-terminated"
   )
-  #endif
   _ = String(decodingCString: [], as: Unicode.UTF8.self)
   expectUnreachable()
 }
@@ -487,13 +460,10 @@ CStringTests.test("String.init.decodingCString.with.inout.conversion") {
   var str = String(decodingCString: &c, as: Unicode.UTF8.self)
   expectEqual(str.isEmpty, true)
   c = 100
-  #if os(Linux)
-  expectCrashLater()
-  #else
   expectCrashLater(
-    withMessage: "input of String.init(decodingCString:as:) must be null-terminated"
+    // Workaround for https://bugs.swift.org/browse/SR-16103 (rdar://91365967)
+    // withMessage: "input of String.init(decodingCString:as:) must be null-terminated"
   )
-  #endif
   str = String(decodingCString: &c, as: Unicode.UTF8.self)
   expectUnreachable()
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
Don't check for the message using `expectCrashLater(withMessage:)`. It is not reliable. Just check for a crash.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Works around SR-16103, and a similar issue when testing on simulators.
