### PR TITLE
[Gardening] Fix alignment of `ActiveActorStatus` diagram

### DIFF
--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -574,27 +574,27 @@ public:
 ///
 /// 32 bit systems with SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION=1
 ///
-///          Flags               Drain Lock               Unused                JobRef
-/// |----------------------|----------------------|----------------------|-------------------|
-///          32 bits                32 bits                32 bits              32 bits
+///       Flags        Drain Lock        Unused          JobRef
+/// |---------------|---------------|---------------|---------------|
+///      32 bits         32 bits         32 bits         32 bits
 ///
 /// 64 bit systems with SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION=1
 ///
-///         Flags                Drain Lock             JobRef
-/// |----------------------|-------------------|----------------------|
-///          32 bits                32 bits             64 bits
+///       Flags        Drain Lock                JobRef
+/// |---------------|---------------|-------------------------------|
+///      32 bits         32 bits                 64 bits
 ///
 /// 32 bit systems with SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION=0
 ///
-///          Flags                  JobRef
-/// |----------------------|----------------------|
-///          32 bits                32 bits
+///       Flags          JobRef
+/// |---------------|---------------|
+///      32 bits         32 bits
 //
 /// 64 bit systems with SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION=0
 ///
-///         Flags                  Unused                 JobRef
-/// |----------------------|----------------------|---------------------|
-///         32 bits                 32 bits               64 bits
+///       Flags          Unused                  JobRef
+/// |---------------|---------------|-------------------------------|
+///      32 bits         32 bits                 64 bits
 ///
 /// Size requirements:
 ///     On 64 bit systems or if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION=1,


### PR DESCRIPTION
Each "-" is 2 bits, and each "|" has 1 bit on either side.