### PR TITLE
disable cross-module-optimization

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -862,7 +862,8 @@ SILPassPipelinePlan::getPerformancePassPipeline(const SILOptions &Options) {
     P.addSemanticARCOpts();
   }
 
-  P.addCrossModuleOptimization();
+  // disabled in Swift 5.7
+  // P.addCrossModuleOptimization();
 
   // It is important to serialize before any of the @_semantics
   // functions are inlined, because otherwise the information about

--- a/test/SILOptimizer/cross-module-optimization.swift
+++ b/test/SILOptimizer/cross-module-optimization.swift
@@ -25,6 +25,8 @@
 // RUN: %FileCheck %s -check-prefix=CHECK-SIL < %t/out.sil
 // RUN: %FileCheck %s -check-prefix=CHECK-SIL2 < %t/out.sil
 
+// REQUIRES: cmo_enabled
+
 import Test
 
 // CHECK-SIL: sil_global public_external [serialized] @_swiftEmptySetSingleton : $_SwiftEmptySetSingleton

--- a/test/SILOptimizer/default-cmo.swift
+++ b/test/SILOptimizer/default-cmo.swift
@@ -7,6 +7,7 @@
 
 // RUN: %target-build-swift -O -wmo -module-name=Main -I%t %s -emit-sil | %FileCheck %s
 
+// REQUIRES: cmo_enabled
 
 import Module
 import ModuleTBD


### PR DESCRIPTION
There are still some problems, e.g. in the swift driver, which need to be resolved before we can enable CMO
