### PR TITLE
[AutoDiff][DebugInfo] Properly transfer location info from debug_value into alloc_stack in pullback cloner

### DIFF
--- a/lib/SILOptimizer/Differentiation/Common.cpp
+++ b/lib/SILOptimizer/Differentiation/Common.cpp
@@ -257,6 +257,11 @@ findDebugLocationAndVariable(SILValue originalValue) {
   for (auto *use : originalValue->getUses()) {
     if (auto *dvi = dyn_cast<DebugValueInst>(use->getUser()))
       return dvi->getVarInfo().map([&](SILDebugVariable var) {
+        // We need to drop `op_deref` here as we're transferring debug info
+        // location from debug_value instruction (which describes how to get value)
+        // into alloc_stack (which describes the location)
+        if (var.DIExpr.startsWithDeref())
+          var.DIExpr.eraseElement(var.DIExpr.element_begin());
         return std::make_pair(dvi->getDebugLocation(), var);
       });
   }

--- a/test/AutoDiff/compiler_crashers_fixed/sr15849-invalid-debug-info.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/sr15849-invalid-debug-info.swift
@@ -1,0 +1,137 @@
+// SR-15849: Mutating functions with control flow can cause assertion failure
+// for conflicting debug variable type.
+
+// RUN: %target-swift-frontend -emit-ir -O -g %s | %FileCheck %s
+// CHECK-LABEL: define internal swiftcc float @"$s4main8TestTypeV24doDifferentiableTimeStep04timeG0ySf_tFTJpSSpSrTA"
+// CHECK: [[SELF:%.*]] = alloca %T4main8TestTypeV06ManualB7TangentV, align 4
+// CHECK: call void @llvm.dbg.declare(metadata %T4main8TestTypeV06ManualB7TangentV* [[SELF]]
+
+import _Differentiation
+
+public protocol TestInterface {
+    mutating func doDifferentiableTimeStep(timeStep: Float)
+
+    var zeroTangentVectorInitializer: () -> TestInterfaceTangentVector { get }
+    mutating func move(by offset: TestInterfaceTangentVector)
+}
+
+public protocol TestInterfaceTangentVector {
+    static var zero: Self { get }
+    static func add(lhs: TestInterfaceTangentVector, rhs: TestInterfaceTangentVector) -> TestInterfaceTangentVector
+    static func subtract(lhs: TestInterfaceTangentVector, rhs: TestInterfaceTangentVector) -> TestInterfaceTangentVector
+    static func equals(lhs: TestInterfaceTangentVector, rhs: TestInterfaceTangentVector) -> Bool
+}
+
+public extension TestInterface {
+    var zeroTangentVector: TestInterfaceTangentVector { zeroTangentVectorInitializer() }
+}
+
+private typealias InitFunction = @convention(c) () -> UnsafeMutableRawPointer
+
+public protocol HasZeroTangentVectorDuplicate: Differentiable {
+    var duplicateZeroTangentVectorInitializer: () -> TangentVector { get }
+}
+
+public extension HasZeroTangentVectorDuplicate {
+    var zeroTangentVector: TangentVector { duplicateZeroTangentVectorInitializer() }
+}
+
+public extension HasZeroTangentVectorDuplicate {
+    var duplicateZeroTangentVectorInitializer: () -> TangentVector {
+        { Self.TangentVector.zero }
+    }
+}
+
+struct TestType: TestInterface {
+	struct TestState: Differentiable {
+		public struct TangentVector: Differentiable, AdditiveArithmetic {
+			public typealias TangentVector = TestState.TangentVector
+			public var property0: Float.TangentVector
+			public var time: Float.TangentVector
+			public var property1: Float.TangentVector
+		}
+
+		public mutating func move(by offset: TangentVector) {
+			self.property0.move(by: offset.property0)
+			self.time.move(by: offset.time)
+			self.property1.move(by: offset.property1)
+		}
+
+		@noDerivative
+		var needUpdate: Bool
+		@noDerivative
+		var initialConditionsAreStale: Bool
+		var property0: Float
+		var time: Float
+		var property1: Float
+
+		init() {
+			self.needUpdate = true
+			self.initialConditionsAreStale = true
+			self.property0 = 0.01
+			self.time = 0.01
+			self.property1 = 0.01
+		}
+	}
+
+	var state = TestState()
+
+	@differentiable(reverse)
+	mutating func doDifferentiableTimeStep(timeStep: Float) {
+        if state.needUpdate {
+            differentiableDoFlow()
+        }
+        if state.initialConditionsAreStale {
+            doInit()
+        }
+	}
+
+	@differentiable(reverse)
+	mutating func differentiableDoFlow() {
+        state.property1 = 1.2
+        state.property0 = 2.3
+        state.needUpdate = false
+	}
+	mutating func doInit() {
+		state.initialConditionsAreStale = false
+	}
+
+}
+
+extension TestType: Differentiable {
+   struct ManualTestTangent: Differentiable & AdditiveArithmetic {
+       var state: TestState.TangentVector
+   }
+   typealias TangentVector = ManualTestTangent
+
+   mutating func move(by offset: ManualTestTangent) {
+       self.state.move(by: offset.state)
+   }
+}
+extension TestType: HasZeroTangentVectorDuplicate {}
+
+
+extension TestType {
+   mutating func move(by offset: TestInterfaceTangentVector) {
+       self.move(by: offset as! Self.TangentVector)
+   }
+
+   var zeroTangentVectorInitializer: () -> TestInterfaceTangentVector {
+       let initializer: () -> TangentVector = self.duplicateZeroTangentVectorInitializer
+       return initializer
+   }
+}
+
+extension TestType.TangentVector: TestInterfaceTangentVector {
+   static func add(lhs: TestInterfaceTangentVector, rhs: TestInterfaceTangentVector) -> TestInterfaceTangentVector {
+       return (lhs as! Self) + (rhs as! Self)
+   }
+
+   static func subtract(lhs: TestInterfaceTangentVector, rhs: TestInterfaceTangentVector) -> TestInterfaceTangentVector {
+       return (lhs as! Self) - (rhs as! Self)
+   }
+
+   static func equals(lhs: TestInterfaceTangentVector, rhs: TestInterfaceTangentVector) -> Bool {
+       return (lhs as! Self) == (rhs as! Self)
+   }
+}


### PR DESCRIPTION
In order to transfer debug info from `debug_value` to `alloc_stack` we need to drop `op_ref` debug expression, as the latter instruction represents the location and not the value itself. Also, fix the debug info verifier as variable type was deduced from `alloc_stack` / `alloc_box` improperly: pointer type of instruction itself was used instead of underlying object type.

The issue is only exposed when both optimizations (SIL mem2reg at least) and debug info are enabled

Resolves SR-15849