### PR TITLE
[cxx-interop] Rename `enable-cxx-interop` -> `enable-experimental-cxx-interop`.

### DIFF
--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -74,7 +74,7 @@ function(add_swift_compiler_modules_library name)
 
   set(swift_compile_options
       "-Xfrontend" "-validate-tbd-against-ir=none"
-      "-Xfrontend" "-enable-cxx-interop"
+      "-Xfrontend" "-enable-experimental-cxx-interop"
       "-Xcc" "-UIBOutlet" "-Xcc" "-UIBAction" "-Xcc" "-UIBInspectable")
 
   if(CMAKE_BUILD_TYPE STREQUAL Debug)

--- a/benchmark/Package.swift
+++ b/benchmark/Package.swift
@@ -118,7 +118,7 @@ targets.append(
     path: "utils",
     sources: ["main.swift"],
     swiftSettings: [.unsafeFlags(["-Xfrontend",
-                                  "-enable-cxx-interop",
+                                  "-enable-experimental-cxx-interop",
                                   "-I",
                                   "utils/CxxTests"])]))
 
@@ -157,7 +157,7 @@ targets += cxxSingleSourceLibraries.map { name in
     path: "cxx-source",
     sources: ["\(name).swift"],
     swiftSettings: [.unsafeFlags(["-Xfrontend",
-                                  "-enable-cxx-interop",
+                                  "-enable-experimental-cxx-interop",
                                   "-I",
                                   "utils/CxxTests"])])
 }

--- a/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
+++ b/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
@@ -478,10 +478,10 @@ function (swift_benchmark_compile_archopts)
       list(APPEND SWIFT_BENCH_OBJFILES "${objfile}")
       list(APPEND bench_library_swiftmodules "${swiftmodule}")
 
-      # Only set "enable-cxx-interop" for tests in the "cxx-source" directory.
+      # Only set "enable-experimental-cxx-interop" for tests in the "cxx-source" directory.
       set(cxx_options "")
       if ("${module_name_path}" MATCHES ".*cxx-source/.*")
-        list(APPEND cxx_options "-Xfrontend" "-enable-cxx-interop" "-I" "${srcdir}/utils/CxxTests/")
+        list(APPEND cxx_options "-Xfrontend" "-enable-experimental-cxx-interop" "-I" "${srcdir}/utils/CxxTests/")
       endif()
 
       if ("${bench_flags}" MATCHES "-whole-module.*")
@@ -590,7 +590,7 @@ function (swift_benchmark_compile_archopts)
       "-whole-module-optimization"
       "-emit-module" "-module-name" "${module_name}"
       "-I" "${objdir}"
-      "-Xfrontend" "-enable-cxx-interop"
+      "-Xfrontend" "-enable-experimental-cxx-interop"
       "-I" "${srcdir}/utils/CxxTests/"
       "-o" "${objdir}/${module_name}.o"
       "${source}")

--- a/docs/CppInteroperability/GettingStartedWithC++Interop.md
+++ b/docs/CppInteroperability/GettingStartedWithC++Interop.md
@@ -34,12 +34,12 @@ module Cxx {
 Add the C++ module to the include path and enable C++ interop:
 - Navigate to your project directory 
 - In `Project` navigate to `Build Settings` -> `Swift Compiler`
-- Under `Custom Flags` -> `Other Swift Flags` add`-Xfrontend -enable-cxx-interop`
+- Under `Custom Flags` -> `Other Swift Flags` add`-Xfrontend -enable-experimental-cxx-interop`
 - Under `Search Paths` -> `Import Paths` add your search path to the C++ module (i.e, `./ProjectName/Cxx`). Repeat this step in `Other Swift Flags` 
 
 ```
 //Add to Other Swift Flags and Import Paths respectively
--Xfrontend -enable-cxx-interop 
+-Xfrontend -enable-experimental-cxx-interop 
 -I./ProjectName/Cxx
 ```
 
@@ -88,7 +88,7 @@ After creating your Swift package project, follow the steps [Creating a Module t
 - Swift code will be in `Sources/CxxInterop` called `main.swift`
 - C++ source code follows the example shown in [Creating a Module to contain your C++ source code](#creating-a-module-to-contain-your-c-source-code)
 - Under targets, add the name of your C++ module and the directory containing the Swift code as a target.
-- In the target defining your Swift target, add a`dependencies` to the C++ Module, the `path`, `source`, and `swiftSettings` with `unsafeFlags` with the source to the C++ Module, and enable `-enable-cxx-interop`
+- In the target defining your Swift target, add a`dependencies` to the C++ Module, the `path`, `source`, and `swiftSettings` with `unsafeFlags` with the source to the C++ Module, and enable `-enable-experimental-cxx-interop`
 
 ```
 //In Package Manifest
@@ -118,7 +118,7 @@ let package = Package(
             sources: [ "main.swift" ],
             swiftSettings: [.unsafeFlags([
                 "-I", "Sources/Cxx",
-                "-Xfrontend", "-enable-cxx-interop",
+                "-Xfrontend", "-enable-experimental-cxx-interop",
             ])]
         ),
     ]
@@ -151,7 +151,7 @@ After creating your project follow the steps [Creating a Module to contain your 
 - Create a `CMakeLists.txt` file and configure for your project
 - In`add_library` invoke `cxx-support` with the path to the C++ implementation file
 - Add the `target_include_directories` with `cxx-support` and path to the C++ Module `${CMAKE_SOURCE_DIR}/Sources/Cxx`
-- Add the `add_executable` to the specific files/directory you would like to generate source, with`SHELL:-Xfrontend -enable-cxx-interop`.
+- Add the `add_executable` to the specific files/directory you would like to generate source, with`SHELL:-Xfrontend -enable-experimental-cxx-interop`.
 - In the example below we will be following the file structure used in [Creating a Swift Package](#Creating-a-Swift-Package) 
 
 ```
@@ -176,7 +176,7 @@ target_include_directories(cxx-support PUBLIC
 
 add_executable(CxxInterop ./Sources/CxxInterop/main.swift)
 target_compile_options(CxxInterop PRIVATE
-  "SHELL:-Xfrontend -enable-cxx-interop"
+  "SHELL:-Xfrontend -enable-experimental-cxx-interop"
 target_link_libraries(CxxInterop PRIVATE cxx-support)
 
 ```

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -823,8 +823,8 @@ def emit_sorted_sil : Flag<["-"], "emit-sorted-sil">,
 def emit_syntax : Flag<["-"], "emit-syntax">,
   HelpText<"Parse input file(s) and emit the Syntax tree(s) as JSON">, ModeOpt;
 
-def enable_cxx_interop :
-  Flag<["-"], "enable-cxx-interop">,
+def enable_experimental_cxx_interop :
+  Flag<["-"], "enable-experimental-cxx-interop">,
   HelpText<"Enable C++ interop code generation and config directives">,
   Flags<[FrontendOption, HelpHidden]>;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -608,10 +608,6 @@ def enable_experimental_concise_pound_file : Flag<["-"],
   Flags<[FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Enable experimental concise '#file' identifier">;
 
-def enable_experimental_cxx_interop :
-  Flag<["-"], "enable-experimental-cxx-interop">,
-  HelpText<"Allow importing C++ modules into Swift (experimental feature)">;
-
 def experimental_cxx_stdlib :
   Separate<["-"], "experimental-cxx-stdlib">,
   HelpText<"C++ standard library to use; forwarded to Clang's -stdlib flag">;

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -190,7 +190,7 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
 
   // Add flags for C++ interop.
   if (inputArgs.hasArg(options::OPT_enable_experimental_cxx_interop)) {
-    arguments.push_back("-enable-cxx-interop");
+    arguments.push_back("-enable-experimental-cxx-interop");
   }
   if (const Arg *arg =
           inputArgs.getLastArg(options::OPT_experimental_cxx_stdlib)) {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -757,7 +757,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     Opts.ClangTarget = llvm::Triple(A->getValue());
   }
 
-  Opts.EnableCXXInterop |= Args.hasArg(OPT_enable_cxx_interop);
+  Opts.EnableCXXInterop |= Args.hasArg(OPT_enable_experimental_cxx_interop);
   Opts.EnableObjCInterop =
       Args.hasFlag(OPT_enable_objc_interop, OPT_disable_objc_interop,
                    Target.isOSDarwin());

--- a/test/Driver/cxx_interop.swift
+++ b/test/Driver/cxx_interop.swift
@@ -1,10 +1,10 @@
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s -enable-experimental-cxx-interop 2>^1 | %FileCheck -check-prefix ENABLE %s
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s -Xfrontend -enable-experimental-cxx-interop 2>^1 | %FileCheck -check-prefix ENABLE %s
 
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s -enable-experimental-cxx-interop -experimental-cxx-stdlib libc++ 2>^1 | %FileCheck -check-prefix STDLIB %s
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s -Xfrontend -enable-experimental-cxx-interop -experimental-cxx-stdlib libc++ 2>^1 | %FileCheck -check-prefix STDLIB %s
 
 // ENABLE: swift
-// ENABLE: -enable-cxx-interop
+// ENABLE: -enable-experimental-cxx-interop
 
 // STDLIB: swift
-// STDLIB-DAG: -enable-cxx-interop
+// STDLIB-DAG: -enable-experimental-cxx-interop
 // STDLIB-DAG: -Xcc -stdlib=libc++

--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -452,7 +452,7 @@
 // IOS-no-cxx-interop-NOT: -lc++
 
 // IOS-cxx-interop-libcxx: swift
-// IOS-cxx-interop-libcxx-DAG: -enable-cxx-interop
+// IOS-cxx-interop-libcxx-DAG: -enable-experimental-cxx-interop
 // IOS-cxx-interop-libcxx-DAG: -o [[OBJECTFILE:.*]]
 
 // IOS-cxx-interop-libcxx: {{(bin/)?}}ld{{"? }}
@@ -465,7 +465,7 @@
 // LINUX-cxx-interop-NOT: -stdlib
 
 // LINUX-cxx-interop-libcxx: swift
-// LINUX-cxx-interop-libcxx-DAG: -enable-cxx-interop
+// LINUX-cxx-interop-libcxx-DAG: -enable-experimental-cxx-interop
 // LINUX-cxx-interop-libcxx-DAG: -o [[OBJECTFILE:.*]]
 
 // LINUX-cxx-interop-libcxx: clang++{{(\.exe)?"? }}
@@ -476,7 +476,7 @@
 // WINDOWS-cxx-interop-NOT: -stdlib
 
 // WINDOWS-cxx-interop-libcxx: swift
-// WINDOWS-cxx-interop-libcxx-DAG: -enable-cxx-interop
+// WINDOWS-cxx-interop-libcxx-DAG: -enable-experimental-cxx-interop
 // WINDOWS-cxx-interop-libcxx-DAG: -o [[OBJECTFILE:.*]]
 
 // WINDOWS-cxx-interop-libcxx: clang++{{(\.exe)?"? }}

--- a/test/Interop/Cxx/apinotes/apinotes-objcxx-smoke.swift
+++ b/test/Interop/Cxx/apinotes/apinotes-objcxx-smoke.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=SomeModule -I %S/Inputs -source-filename=x -enable-cxx-interop -enable-objc-interop | %FileCheck -check-prefix=CHECK-IDE-TEST %s
-// RUN: %swift-frontend -c -enable-cxx-interop -enable-objc-interop -I %S/Inputs %s -o - -emit-sil | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=SomeModule -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop -enable-objc-interop | %FileCheck -check-prefix=CHECK-IDE-TEST %s
+// RUN: %swift-frontend -c -enable-experimental-cxx-interop -enable-objc-interop -I %S/Inputs %s -o - -emit-sil | %FileCheck %s
 
 import SomeModule
 

--- a/test/Interop/Cxx/class/access-specifiers-module-interface.swift
+++ b/test/Interop/Cxx/class/access-specifiers-module-interface.swift
@@ -1,7 +1,7 @@
 // Test module interface produced for C++ access specifiers test.
 // In particular, we don't want any of the private members showing up here.
 
-// RUN: %target-swift-ide-test -print-module -module-to-print=AccessSpecifiers -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=AccessSpecifiers -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK:      struct PublicPrivate {
 // CHECK-NEXT:   init()

--- a/test/Interop/Cxx/class/access-specifiers-typechecker.swift
+++ b/test/Interop/Cxx/class/access-specifiers-typechecker.swift
@@ -1,7 +1,7 @@
 // Test that C++ access specifiers are honored, i.e. private members aren't
 // imported.
 
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs -enable-cxx-interop
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs -enable-experimental-cxx-interop
 
 import AccessSpecifiers
 

--- a/test/Interop/Cxx/class/class-protocol-name-clash.swift
+++ b/test/Interop/Cxx/class/class-protocol-name-clash.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -c -enable-cxx-interop -I %S/Inputs
+// RUN: %target-swift-frontend %s -c -enable-experimental-cxx-interop -I %S/Inputs
 //
 // REQUIRES: objc_interop
 

--- a/test/Interop/Cxx/class/constructors-copy-irgen.swift
+++ b/test/Interop/Cxx/class/constructors-copy-irgen.swift
@@ -1,8 +1,8 @@
 // Target-specific tests for C++ copy constructor code generation.
 
-// RUN: %swift -module-name Swift -target x86_64-apple-macosx10.9 -dump-clang-diagnostics -I %S/Inputs -enable-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=ITANIUM_X64
-// RUN: %swift -module-name Swift -target armv7-none-linux-androideabi -dump-clang-diagnostics -I %S/Inputs -enable-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=ITANIUM_ARM
-// RUN: %swift -module-name Swift -target x86_64-unknown-windows-msvc -dump-clang-diagnostics -I %S/Inputs -enable-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=MICROSOFT_X64
+// RUN: %swift -module-name Swift -target x86_64-apple-macosx10.9 -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=ITANIUM_X64
+// RUN: %swift -module-name Swift -target armv7-none-linux-androideabi -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=ITANIUM_ARM
+// RUN: %swift -module-name Swift -target x86_64-unknown-windows-msvc -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=MICROSOFT_X64
 
 import Constructors
 import TypeClassification

--- a/test/Interop/Cxx/class/constructors-copy-module-interface.swift
+++ b/test/Interop/Cxx/class/constructors-copy-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=Constructors -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=Constructors -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // Make sure we don't import non-copyable types because we will have no way to
 // represent and copy/move these in swift with correct semantics.

--- a/test/Interop/Cxx/class/constructors-executable.swift
+++ b/test/Interop/Cxx/class/constructors-executable.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/class/constructors-irgen.swift
+++ b/test/Interop/Cxx/class/constructors-irgen.swift
@@ -1,8 +1,8 @@
 // Target-specific tests for C++ constructor call code generation.
 
-// RUN: %swift -module-name Swift -target x86_64-apple-macosx10.9 -dump-clang-diagnostics -I %S/Inputs -enable-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=ITANIUM_X64
-// RUN: %swift -module-name Swift -target armv7-unknown-linux-androideabi -dump-clang-diagnostics -I %S/Inputs -enable-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=ITANIUM_ARM
-// RUN: %swift -module-name Swift -target x86_64-unknown-windows-msvc -dump-clang-diagnostics -I %S/Inputs -enable-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=MICROSOFT_X64
+// RUN: %swift -module-name Swift -target x86_64-apple-macosx10.9 -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=ITANIUM_X64
+// RUN: %swift -module-name Swift -target armv7-unknown-linux-androideabi -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=ITANIUM_ARM
+// RUN: %swift -module-name Swift -target x86_64-unknown-windows-msvc -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=MICROSOFT_X64
 
 import Constructors
 import TypeClassification

--- a/test/Interop/Cxx/class/constructors-module-interface.swift
+++ b/test/Interop/Cxx/class/constructors-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=Constructors -I %S/Inputs/ -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=Constructors -I %S/Inputs/ -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK:      struct ExplicitDefaultConstructor {
 // CHECK-NEXT:   init()

--- a/test/Interop/Cxx/class/constructors-objc-irgen.swift
+++ b/test/Interop/Cxx/class/constructors-objc-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs -enable-cxx-interop -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/Interop/Cxx/class/constructors-objc-module-interface.swift
+++ b/test/Interop/Cxx/class/constructors-objc-module-interface.swift
@@ -1,7 +1,7 @@
 // Test that Objective-C types passed to a C++ constructor are bridged
 // correctly.
 
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -module-to-print=ConstructorsObjC -I %S/Inputs/ -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -module-to-print=ConstructorsObjC -I %S/Inputs/ -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/Interop/Cxx/class/constructors-objc-silgen.swift
+++ b/test/Interop/Cxx/class/constructors-objc-silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs -enable-cxx-interop -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs -enable-experimental-cxx-interop -emit-sil %s | %FileCheck %s
 
 // REQUIRES: objc_interop
 import Foundation

--- a/test/Interop/Cxx/class/constructors-typechecker.swift
+++ b/test/Interop/Cxx/class/constructors-typechecker.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs -enable-cxx-interop
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs -enable-experimental-cxx-interop
 
 import Constructors
 

--- a/test/Interop/Cxx/class/destructors-correct-abi-irgen.swift
+++ b/test/Interop/Cxx/class/destructors-correct-abi-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -I %S/Inputs -enable-cxx-interop -emit-ir %s | %FileCheck %s
+// RUN: %swift -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s | %FileCheck %s
 
 import Destructors
 

--- a/test/Interop/Cxx/class/destructors-non-trivial-implicit-irgen.swift
+++ b/test/Interop/Cxx/class/destructors-non-trivial-implicit-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-cxx-interop -I %S/Inputs %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -enable-experimental-cxx-interop -I %S/Inputs %s -emit-ir | %FileCheck %s
 
 import Destructors
 

--- a/test/Interop/Cxx/class/dictionary-of-nsstrings-module-interface.swift
+++ b/test/Interop/Cxx/class/dictionary-of-nsstrings-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=DictionaryOfNSStrings -I %S/Inputs/ -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=DictionaryOfNSStrings -I %S/Inputs/ -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/Interop/Cxx/class/extensions-executable.swift
+++ b/test/Interop/Cxx/class/extensions-executable.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop)
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/Interop/Cxx/class/extensions-irgen.swift
+++ b/test/Interop/Cxx/class/extensions-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 
 import Extensions
 

--- a/test/Interop/Cxx/class/extensions-typechecker.swift
+++ b/test/Interop/Cxx/class/extensions-typechecker.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-cxx-interop
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop
 
 import Extensions
 

--- a/test/Interop/Cxx/class/inheritance/fields-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/fields-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=Fields -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=Fields -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK:      struct HasThreeFields {
 // CHECK-NEXT:   init()

--- a/test/Interop/Cxx/class/inheritance/fields.swift
+++ b/test/Interop/Cxx/class/inheritance/fields.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 //

--- a/test/Interop/Cxx/class/inheritance/functions-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/functions-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=Functions -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=Functions -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK:      struct NonTrivial {
 // CHECK-NEXT:   init()

--- a/test/Interop/Cxx/class/inheritance/functions.swift
+++ b/test/Interop/Cxx/class/inheritance/functions.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/class/inheritance/sub-types-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/sub-types-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=SubTypes -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=SubTypes -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK:      struct Base {
 // CHECK-NEXT:   init()

--- a/test/Interop/Cxx/class/inheritance/type-aliases-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/type-aliases-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=TypeAliases -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=TypeAliases -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK:      struct Base {
 // CHECK-NEXT:   init()

--- a/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-function-execution.swift
+++ b/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-function-execution.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-function-from-nested-calls-execution.swift
+++ b/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-function-from-nested-calls-execution.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-function-from-nested-calls-irgen.swift
+++ b/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-function-from-nested-calls-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 
 import ConstructorCallsFunctionFromNestedCalls
 

--- a/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-function-from-nested-struct-execution.swift
+++ b/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-function-from-nested-struct-execution.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-function-from-nested-struct-irgen.swift
+++ b/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-function-from-nested-struct-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 
 import ConstructorCallsFunctionFromNestedStruct
 

--- a/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-function-irgen.swift
+++ b/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-function-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 
 import ConstructorCallsFunction
 

--- a/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-method-execution.swift
+++ b/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-method-execution.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-method-irgen.swift
+++ b/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-method-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 
 import ConstructorCallsMethod
 

--- a/test/Interop/Cxx/class/inline-function-codegen/field-init-calls-function-execution.swift
+++ b/test/Interop/Cxx/class/inline-function-codegen/field-init-calls-function-execution.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/class/inline-function-codegen/field-init-calls-function-irgen.swift
+++ b/test/Interop/Cxx/class/inline-function-codegen/field-init-calls-function-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 
 import FieldInitCallsFunction
 

--- a/test/Interop/Cxx/class/inline-function-codegen/method-calls-function-execution.swift
+++ b/test/Interop/Cxx/class/inline-function-codegen/method-calls-function-execution.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/class/inline-function-codegen/method-calls-function-irgen.swift
+++ b/test/Interop/Cxx/class/inline-function-codegen/method-calls-function-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 
 import MethodCallsFunction
 

--- a/test/Interop/Cxx/class/inline-function-codegen/method-calls-method-execution.swift
+++ b/test/Interop/Cxx/class/inline-function-codegen/method-calls-method-execution.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/class/inline-function-codegen/method-calls-method-from-nested-struct-execution.swift
+++ b/test/Interop/Cxx/class/inline-function-codegen/method-calls-method-from-nested-struct-execution.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/class/inline-function-codegen/method-calls-method-from-nested-struct-irgen.swift
+++ b/test/Interop/Cxx/class/inline-function-codegen/method-calls-method-from-nested-struct-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 
 import MethodCallsMethodFromNestedStruct
 

--- a/test/Interop/Cxx/class/inline-function-codegen/method-calls-method-irgen.swift
+++ b/test/Interop/Cxx/class/inline-function-codegen/method-calls-method-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 
 import MethodCallsMethod
 

--- a/test/Interop/Cxx/class/inline-function-codegen/static-var-init-calls-function-execution.swift
+++ b/test/Interop/Cxx/class/inline-function-codegen/static-var-init-calls-function-execution.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop -Xfrontend -validate-tbd-against-ir=none)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/class/inline-function-codegen/static-var-init-calls-function-irgen.swift
+++ b/test/Interop/Cxx/class/inline-function-codegen/static-var-init-calls-function-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop -validate-tbd-against-ir=none | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -validate-tbd-against-ir=none | %FileCheck %s
 
 // TODO: See why -validate-tbd-against-ir=none is needed here (SR-14069)
 

--- a/test/Interop/Cxx/class/invalid-nested-struct-module-interface.swift
+++ b/test/Interop/Cxx/class/invalid-nested-struct-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=InvalidNestedStruct -I %S/Inputs/ -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=InvalidNestedStruct -I %S/Inputs/ -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK-NOT: CannotImport
 // CHECK-NOT: ForwardDeclaredSibling

--- a/test/Interop/Cxx/class/linked-records-module-interface.swift
+++ b/test/Interop/Cxx/class/linked-records-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=LinkedRecords -I %S/Inputs/ -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=LinkedRecords -I %S/Inputs/ -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK: enum Space {
 // CHECK:   struct C {

--- a/test/Interop/Cxx/class/member-variables-module-interface.swift
+++ b/test/Interop/Cxx/class/member-variables-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=MemberVariables -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=MemberVariables -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK:      struct MyClass {
 // CHECK-NEXT:   init()

--- a/test/Interop/Cxx/class/member-variables-typechecker.swift
+++ b/test/Interop/Cxx/class/member-variables-typechecker.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-cxx-interop
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop
 
 import MemberVariables
 

--- a/test/Interop/Cxx/class/memberwise-initializer-module-interface.swift
+++ b/test/Interop/Cxx/class/memberwise-initializer-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=MemberwiseInitializer -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=MemberwiseInitializer -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK:      struct StructPrivateOnly {
 // CHECK-NEXT:   init()

--- a/test/Interop/Cxx/class/memberwise-initializer-typechecker.swift
+++ b/test/Interop/Cxx/class/memberwise-initializer-typechecker.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-cxx-interop
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop
 
 import MemberwiseInitializer
 

--- a/test/Interop/Cxx/class/memory-layout-execution.swift
+++ b/test/Interop/Cxx/class/memory-layout-execution.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -I %S/Inputs -o %t/class_layout -Xfrontend -enable-cxx-interop
+// RUN: %target-build-swift %s -I %S/Inputs -o %t/class_layout -Xfrontend -enable-experimental-cxx-interop
 // RUN: %target-codesign %t/class_layout
 // RUN: %target-run %t/class_layout 2&>1
 //

--- a/test/Interop/Cxx/class/method/ambiguous-methods-module-interface.swift
+++ b/test/Interop/Cxx/class/method/ambiguous-methods-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=AmbiguousMethods -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=AmbiguousMethods -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK: func increment(_ a: Int32) -> Int32
 // CHECK: mutating func incrementMutating(_ a: Int32) -> Int32

--- a/test/Interop/Cxx/class/method/ambiguous-methods.swift
+++ b/test/Interop/Cxx/class/method/ambiguous-methods.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 //

--- a/test/Interop/Cxx/class/method/methods-module-interface.swift
+++ b/test/Interop/Cxx/class/method/methods-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=Methods -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=Methods -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK: mutating func nonConstMethod()
 // CHECK: func constMethod()

--- a/test/Interop/Cxx/class/method/methods.swift
+++ b/test/Interop/Cxx/class/method/methods.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 //

--- a/test/Interop/Cxx/class/mutability-annotations-module-interface.swift
+++ b/test/Interop/Cxx/class/mutability-annotations-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=MutabilityAnnotations -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=MutabilityAnnotations -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK: struct HasConstMethodAnnotatedAsMutating {
 // CHECK:   mutating func annotatedMutating() -> Int32

--- a/test/Interop/Cxx/class/mutability-annotations-typechecker.swift
+++ b/test/Interop/Cxx/class/mutability-annotations-typechecker.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-cxx-interop
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop
 
 import MutabilityAnnotations
 

--- a/test/Interop/Cxx/class/mutable-members-module-interface.swift
+++ b/test/Interop/Cxx/class/mutable-members-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=MutableMembers -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=MutableMembers -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK: struct HasPublicMutableMember {
 // CHECK:   mutating func foo() -> Int32

--- a/test/Interop/Cxx/class/mutable-members-typechecker.swift
+++ b/test/Interop/Cxx/class/mutable-members-typechecker.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-cxx-interop
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop
 
 import MutableMembers
 

--- a/test/Interop/Cxx/class/mutable-members.swift
+++ b/test/Interop/Cxx/class/mutable-members.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/class/nested-records-module-interface.swift
+++ b/test/Interop/Cxx/class/nested-records-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=NestedRecords -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=NestedRecords -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK: struct S1 {
 // CHECK:   struct S2 {

--- a/test/Interop/Cxx/class/protocol-conformance-irgen.swift
+++ b/test/Interop/Cxx/class/protocol-conformance-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir -I %S/Inputs -enable-cxx-interop %s | %FileCheck %s
+// RUN: %target-swift-emit-ir -I %S/Inputs -enable-experimental-cxx-interop %s | %FileCheck %s
 
 import ProtocolConformance
 

--- a/test/Interop/Cxx/class/protocol-conformance-silgen.swift
+++ b/test/Interop/Cxx/class/protocol-conformance-silgen.swift
@@ -1,6 +1,6 @@
 // Tests that a C++ class can conform to a Swift protocol.
 
-// RUN: %target-swift-emit-silgen -I %S/Inputs -enable-cxx-interop %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -I %S/Inputs -enable-experimental-cxx-interop %s | %FileCheck %s
 
 import ProtocolConformance
 

--- a/test/Interop/Cxx/class/protocol-conformance-typechecker.swift
+++ b/test/Interop/Cxx/class/protocol-conformance-typechecker.swift
@@ -1,6 +1,6 @@
 // Tests that a C++ class can conform to a Swift protocol.
 
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-cxx-interop
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop
 
 import ProtocolConformance
 

--- a/test/Interop/Cxx/class/protocol-conformance.swift
+++ b/test/Interop/Cxx/class/protocol-conformance.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop)
 
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/class/type-classification-loadable-silgen.swift
+++ b/test/Interop/Cxx/class/type-classification-loadable-silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -I %S/Inputs -enable-cxx-interop %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -I %S/Inputs -enable-experimental-cxx-interop %s | %FileCheck %s
 
 // This test checks that we classify C++ types as loadable and address-only
 // correctly.

--- a/test/Interop/Cxx/class/type-classification-module-interface.swift
+++ b/test/Interop/Cxx/class/type-classification-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=TypeClassification -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=TypeClassification -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // Make sure we don't import objects that we can't copy or destroy.
 // CHECK-NOT: StructWithPrivateDefaultedCopyConstructor

--- a/test/Interop/Cxx/class/type-classification-non-trivial.swift
+++ b/test/Interop/Cxx/class/type-classification-non-trivial.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -I %S/Inputs -o %t/address_only -Xfrontend -enable-cxx-interop
+// RUN: %target-build-swift %s -I %S/Inputs -o %t/address_only -Xfrontend -enable-experimental-cxx-interop
 // RUN: %target-codesign %t/address_only
 // RUN: %target-run %t/address_only 2&>1
 

--- a/test/Interop/Cxx/enum/bool-enums-module-interface.swift
+++ b/test/Interop/Cxx/enum/bool-enums-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=BoolEnums -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=BoolEnums -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // TODO: these should be enums eventually (especially the enum class).
 

--- a/test/Interop/Cxx/enum/scoped-enums-module-interface.swift
+++ b/test/Interop/Cxx/enum/scoped-enums-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=ScopedEnums -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=ScopedEnums -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK: enum ScopedEnumDefined : Int32 {
 // CHECK:   init?(rawValue: Int32)

--- a/test/Interop/Cxx/enum/scoped-enums-silgen.swift
+++ b/test/Interop/Cxx/enum/scoped-enums-silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-sil %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 
 import ScopedEnums
 

--- a/test/Interop/Cxx/enum/scoped-enums.swift
+++ b/test/Interop/Cxx/enum/scoped-enums.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/ergonomics/implicit-computed-properties-module-interface.swift
+++ b/test/Interop/Cxx/ergonomics/implicit-computed-properties-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=ImplicitComputedProperties -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=ImplicitComputedProperties -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK:      struct VoidGetter {
 // CHECK-NOT:     var

--- a/test/Interop/Cxx/ergonomics/implicit-computed-properties.swift
+++ b/test/Interop/Cxx/ergonomics/implicit-computed-properties.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 //

--- a/test/Interop/Cxx/extern-c/extern-c-objcxx-category.swift
+++ b/test/Interop/Cxx/extern-c/extern-c-objcxx-category.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=ExternC -I %S/Inputs -source-filename=x -enable-cxx-interop -enable-objc-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=ExternC -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop -enable-objc-interop | %FileCheck %s
 
 // CHECK: class A {
 // CHECK-NEXT: }

--- a/test/Interop/Cxx/extern-var/extern-var-irgen.swift
+++ b/test/Interop/Cxx/extern-var/extern-var-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 
 import ExternVar
 

--- a/test/Interop/Cxx/extern-var/extern-var-silgen.swift
+++ b/test/Interop/Cxx/extern-var/extern-var-silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-sil %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 
 import ExternVar
 

--- a/test/Interop/Cxx/extern-var/extern-var.swift
+++ b/test/Interop/Cxx/extern-var/extern-var.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-clangxx -c %S/Inputs/extern-var.cpp -I %S/Inputs -o %t/extern-var.o
-// RUN: %target-build-swift %s -I %S/Inputs -o %t/extern-var %t/extern-var.o -Xfrontend -enable-cxx-interop
+// RUN: %target-build-swift %s -I %S/Inputs -o %t/extern-var %t/extern-var.o -Xfrontend -enable-experimental-cxx-interop
 // RUN: %target-codesign %t/extern-var
 // RUN: %target-run %t/extern-var
 //

--- a/test/Interop/Cxx/foreign-reference/error-as-class-member.swift
+++ b/test/Interop/Cxx/foreign-reference/error-as-class-member.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t
 // RUN: split-file %s %t
-// RUN: not %target-swift-frontend -emit-ir -I %t/Inputs  %t/test.swift  -enable-cxx-interop 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend -emit-ir -I %t/Inputs  %t/test.swift  -enable-experimental-cxx-interop 2>&1 | %FileCheck %s
 
 // XFAIL: OS=windows-msvc
 

--- a/test/Interop/Cxx/foreign-reference/error-as-struct-member.swift
+++ b/test/Interop/Cxx/foreign-reference/error-as-struct-member.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t
 // RUN: split-file %s %t
-// RUN: not %target-swift-frontend -emit-ir -I %t/Inputs  %t/test.swift  -enable-cxx-interop 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend -emit-ir -I %t/Inputs  %t/test.swift  -enable-experimental-cxx-interop 2>&1 | %FileCheck %s
 
 //--- Inputs/module.modulemap
 module Test {

--- a/test/Interop/Cxx/foreign-reference/error-in-generic-context.swift
+++ b/test/Interop/Cxx/foreign-reference/error-in-generic-context.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t
 // RUN: split-file %s %t
-// RUN: not %target-swift-frontend -emit-ir -I %t/Inputs  %t/test.swift  -enable-cxx-interop 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend -emit-ir -I %t/Inputs  %t/test.swift  -enable-experimental-cxx-interop 2>&1 | %FileCheck %s
 
 //--- Inputs/module.modulemap
 module Test {

--- a/test/Interop/Cxx/foreign-reference/move-only-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/move-only-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop -validate-tbd-against-ir=none -disable-llvm-verify | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -validate-tbd-against-ir=none -disable-llvm-verify | %FileCheck %s
 
 import MoveOnly
 

--- a/test/Interop/Cxx/foreign-reference/move-only-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/move-only-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=MoveOnly -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=MoveOnly -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK: class MoveOnly {
 // CHECK-NOT: init

--- a/test/Interop/Cxx/foreign-reference/move-only-silgen.swift
+++ b/test/Interop/Cxx/foreign-reference/move-only-silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 
 import MoveOnly
 

--- a/test/Interop/Cxx/foreign-reference/move-only.swift
+++ b/test/Interop/Cxx/foreign-reference/move-only.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-cxx-interop -Xfrontend -validate-tbd-against-ir=none -Xfrontend -disable-llvm-verify)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none -Xfrontend -disable-llvm-verify)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/foreign-reference/not-any-object.swift
+++ b/test/Interop/Cxx/foreign-reference/not-any-object.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unknown -I %t/Inputs  %t/test.swift  -enable-cxx-interop
+// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unknown -I %t/Inputs  %t/test.swift  -enable-experimental-cxx-interop
 
 // REQUIRES: objc_interop
 

--- a/test/Interop/Cxx/foreign-reference/nullable-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/nullable-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=Nullable -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=Nullable -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK: class Empty {
 // CHECK:   func test() -> Int32

--- a/test/Interop/Cxx/foreign-reference/nullable.swift
+++ b/test/Interop/Cxx/foreign-reference/nullable.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-cxx-interop -Xfrontend -validate-tbd-against-ir=none -Xfrontend -disable-llvm-verify -g)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none -Xfrontend -disable-llvm-verify -g)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/foreign-reference/pod-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/pod-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop -validate-tbd-against-ir=none -disable-llvm-verify | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -validate-tbd-against-ir=none -disable-llvm-verify | %FileCheck %s
 
 import POD
 

--- a/test/Interop/Cxx/foreign-reference/pod-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/pod-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=POD -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=POD -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK: class Empty {
 // CHECK-NOT: init

--- a/test/Interop/Cxx/foreign-reference/pod-silgen.swift
+++ b/test/Interop/Cxx/foreign-reference/pod-silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 
 import POD
 

--- a/test/Interop/Cxx/foreign-reference/pod.swift
+++ b/test/Interop/Cxx/foreign-reference/pod.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-cxx-interop -Xfrontend -validate-tbd-against-ir=none -Xfrontend -disable-llvm-verify -g)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none -Xfrontend -disable-llvm-verify -g)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/foreign-reference/singleton-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/singleton-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop -validate-tbd-against-ir=none -disable-llvm-verify | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -validate-tbd-against-ir=none -disable-llvm-verify | %FileCheck %s
 
 import Singleton
 

--- a/test/Interop/Cxx/foreign-reference/singleton-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/singleton-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=Singleton -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=Singleton -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK: class DeletedDtor {
 // CHECK-NOT: init

--- a/test/Interop/Cxx/foreign-reference/singleton-silgen.swift
+++ b/test/Interop/Cxx/foreign-reference/singleton-silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 
 import Singleton
 

--- a/test/Interop/Cxx/foreign-reference/singleton.swift
+++ b/test/Interop/Cxx/foreign-reference/singleton.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-cxx-interop -Xfrontend -validate-tbd-against-ir=none -Xfrontend -disable-llvm-verify)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none -Xfrontend -disable-llvm-verify)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/foreign-reference/witness-table.swift
+++ b/test/Interop/Cxx/foreign-reference/witness-table.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-cxx-interop -Xfrontend -validate-tbd-against-ir=none -Xfrontend -disable-llvm-verify -g)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none -Xfrontend -disable-llvm-verify -g)
 //
 // REQUIRES: executable_test
 // REQUIRES: foreign-reference-type-metadata-support

--- a/test/Interop/Cxx/libc/include-glibc.swift
+++ b/test/Interop/Cxx/libc/include-glibc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-cxx-interop)
 
 // REQUIRES: executable_test
 // REQUIRES: OS=linux-gnu || OS=linux-android

--- a/test/Interop/Cxx/modules/use-namespace-extension-lib.swift
+++ b/test/Interop/Cxx/modules/use-namespace-extension-lib.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: cd %t
-// RUN: %target-build-swift    -I %S/Inputs -Xfrontend -enable-cxx-interop %S/Inputs/namespace-extension-lib.swift -emit-module -emit-library -static -module-name NamespaceExtensionLib
-// RUN: %target-build-swift %s -I %S/Inputs -Xfrontend -enable-cxx-interop -o %t/run -I %t/ -L %t/ -lNamespaceExtensionLib
+// RUN: %target-build-swift    -I %S/Inputs -Xfrontend -enable-experimental-cxx-interop %S/Inputs/namespace-extension-lib.swift -emit-module -emit-library -static -module-name NamespaceExtensionLib
+// RUN: %target-build-swift %s -I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -o %t/run -I %t/ -L %t/ -lNamespaceExtensionLib
 // RUN: %target-codesign %t/run
 // RUN: %target-run %t/run
 //

--- a/test/Interop/Cxx/namespace/class-inline-namespace-irgen.swift
+++ b/test/Interop/Cxx/namespace/class-inline-namespace-irgen.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t
 // RUN: split-file %s %t
-// RUN: %target-swift-emit-ir -I %t/Inputs -enable-cxx-interop %t/test.swift | %FileCheck %t/test.swift
+// RUN: %target-swift-emit-ir -I %t/Inputs -enable-experimental-cxx-interop %t/test.swift | %FileCheck %t/test.swift
 
 
 //--- Inputs/module.modulemap

--- a/test/Interop/Cxx/namespace/classes-irgen.swift
+++ b/test/Interop/Cxx/namespace/classes-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir -I %S/Inputs -enable-cxx-interop %s | %FileCheck %s
+// RUN: %target-swift-emit-ir -I %S/Inputs -enable-experimental-cxx-interop %s | %FileCheck %s
 
 import Classes
 

--- a/test/Interop/Cxx/namespace/classes-module-interface.swift
+++ b/test/Interop/Cxx/namespace/classes-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=Classes -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=Classes -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK:      enum ClassesNS1 {
 // CHECK-NEXT:   struct ForwardDeclaredStruct {

--- a/test/Interop/Cxx/namespace/classes-second-header-module-interface.swift
+++ b/test/Interop/Cxx/namespace/classes-second-header-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=ClassesSecondHeader -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=ClassesSecondHeader -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 
 // Check-next is not used here because a lot of stuff is pulled in from classes.h

--- a/test/Interop/Cxx/namespace/classes-second-header.swift
+++ b/test/Interop/Cxx/namespace/classes-second-header.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/namespace/classes.swift
+++ b/test/Interop/Cxx/namespace/classes.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/namespace/extensions.swift
+++ b/test/Interop/Cxx/namespace/extensions.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/namespace/free-functions-irgen.swift
+++ b/test/Interop/Cxx/namespace/free-functions-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir -I %S/Inputs -enable-cxx-interop %s | %FileCheck %s
+// RUN: %target-swift-emit-ir -I %S/Inputs -enable-experimental-cxx-interop %s | %FileCheck %s
 
 import FreeFunctions
 

--- a/test/Interop/Cxx/namespace/free-functions-module-interface.swift
+++ b/test/Interop/Cxx/namespace/free-functions-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=FreeFunctions -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=FreeFunctions -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK:      enum FunctionsNS1 {
 // CHECK-NEXT:   static func basicFunctionTopLevel() -> UnsafePointer<CChar>!

--- a/test/Interop/Cxx/namespace/free-functions-second-header-module-interface.swift
+++ b/test/Interop/Cxx/namespace/free-functions-second-header-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=FreeFunctionsSecondHeader -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=FreeFunctionsSecondHeader -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // TODO: This file doesn't really test anything because functions need not be defined.
 // CHECK: enum FunctionsNS1 {

--- a/test/Interop/Cxx/namespace/free-functions-second-header.swift
+++ b/test/Interop/Cxx/namespace/free-functions-second-header.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/namespace/free-functions.swift
+++ b/test/Interop/Cxx/namespace/free-functions.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/namespace/function-overload-in-namespace-extension-irgen.swift
+++ b/test/Interop/Cxx/namespace/function-overload-in-namespace-extension-irgen.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t
 // RUN: split-file %s %t
-// RUN: %target-swift-emit-ir -I %t/Inputs -enable-cxx-interop %t/test.swift | %FileCheck %t/test.swift
+// RUN: %target-swift-emit-ir -I %t/Inputs -enable-experimental-cxx-interop %t/test.swift | %FileCheck %t/test.swift
 
 
 //--- Inputs/module.modulemap

--- a/test/Interop/Cxx/namespace/inline-namespace-ambiguity-error.swift
+++ b/test/Interop/Cxx/namespace/inline-namespace-ambiguity-error.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unknown -I %t/Inputs  %t/test.swift  -enable-cxx-interop
+// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unknown -I %t/Inputs  %t/test.swift  -enable-experimental-cxx-interop
 
 //--- Inputs/module.modulemap
 module namespaces {

--- a/test/Interop/Cxx/namespace/inline-namespace-function-call-broken.swift
+++ b/test/Interop/Cxx/namespace/inline-namespace-function-call-broken.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unknown -I %t/Inputs  %t/test.swift  -enable-cxx-interop
+// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unknown -I %t/Inputs  %t/test.swift  -enable-experimental-cxx-interop
 
 //--- Inputs/module.modulemap
 module namespaces {

--- a/test/Interop/Cxx/namespace/submodules-module-interface.swift
+++ b/test/Interop/Cxx/namespace/submodules-module-interface.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=Submodules.SubmoduleA -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
-// RUN: %target-swift-ide-test -print-module -module-to-print=Submodules.SubmoduleB -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=Submodules.SubmoduleA -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=Submodules.SubmoduleB -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK:      enum NS1 {
 // CHECK-NEXT:   enum NS2 {

--- a/test/Interop/Cxx/namespace/templates-irgen.swift
+++ b/test/Interop/Cxx/namespace/templates-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir -I %S/Inputs -enable-cxx-interop %s | %FileCheck %s
+// RUN: %target-swift-emit-ir -I %S/Inputs -enable-experimental-cxx-interop %s | %FileCheck %s
 
 import Templates
 

--- a/test/Interop/Cxx/namespace/templates-module-interface.swift
+++ b/test/Interop/Cxx/namespace/templates-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=Templates -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=Templates -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK:     enum TemplatesNS1 {
 // CHECK-NEXT:   enum TemplatesNS2 {

--- a/test/Interop/Cxx/namespace/templates-second-header-module-interface.swift
+++ b/test/Interop/Cxx/namespace/templates-second-header-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=TemplatesSecondHeader -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=TemplatesSecondHeader -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK: enum TemplatesNS1 {
 // CHECK:   static func basicFunctionTemplateDefinedInDefs<T>(_: T) -> UnsafePointer<CChar>!

--- a/test/Interop/Cxx/namespace/templates-second-header.swift
+++ b/test/Interop/Cxx/namespace/templates-second-header.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/namespace/templates-with-forward-decl-module-interface.swift
+++ b/test/Interop/Cxx/namespace/templates-with-forward-decl-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=TemplatesWithForwardDecl -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=TemplatesWithForwardDecl -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK:      enum NS1 {
 // CHECK-NEXT:   struct __CxxTemplateInstN3NS115ForwardDeclaredIiEE {

--- a/test/Interop/Cxx/namespace/templates.swift
+++ b/test/Interop/Cxx/namespace/templates.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/namespace/top-level-inline-namespace-lookup.swift
+++ b/test/Interop/Cxx/namespace/top-level-inline-namespace-lookup.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unknown -I %t/Inputs  %t/test.swift  -enable-cxx-interop
+// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unknown -I %t/Inputs  %t/test.swift  -enable-experimental-cxx-interop
 
 //--- Inputs/module.modulemap
 module namespaces {

--- a/test/Interop/Cxx/operators/member-inline-irgen.swift
+++ b/test/Interop/Cxx/operators/member-inline-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 //
 // We can't yet call member functions correctly on Windows (SR-13129).
 // XFAIL: *

--- a/test/Interop/Cxx/operators/member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/member-inline-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=MemberInline -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=MemberInline -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 // XFAIL: *
 
 // CHECK: struct LoadableIntWrapper {

--- a/test/Interop/Cxx/operators/member-inline-silgen.swift
+++ b/test/Interop/Cxx/operators/member-inline-silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-sil %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 // XFAIL: *
 
 import MemberInline

--- a/test/Interop/Cxx/operators/member-inline-typechecker.swift
+++ b/test/Interop/Cxx/operators/member-inline-typechecker.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-cxx-interop
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop
 // XFAIL: *
 
 import MemberInline

--- a/test/Interop/Cxx/operators/member-inline.swift
+++ b/test/Interop/Cxx/operators/member-inline.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 
 // REQUIRES: executable_test
 // XFAIL: *

--- a/test/Interop/Cxx/operators/member-out-of-line-irgen.swift
+++ b/test/Interop/Cxx/operators/member-out-of-line-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 //
 // We can't yet call member functions correctly on Windows (SR-13129).
 // XFAIL: *

--- a/test/Interop/Cxx/operators/member-out-of-line-silgen.swift
+++ b/test/Interop/Cxx/operators/member-out-of-line-silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s -check-prefix CHECK-%target-abi
+// RUN: %target-swift-emit-sil %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s -check-prefix CHECK-%target-abi
 
 // XFAIL: *
 

--- a/test/Interop/Cxx/operators/member-out-of-line.swift
+++ b/test/Interop/Cxx/operators/member-out-of-line.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-clangxx -c %S/Inputs/member-out-of-line.cpp -I %S/Inputs -o %t/member-out-of-line.o
-// RUN: %target-build-swift %s -I %S/Inputs -o %t/member-out-of-line %t/member-out-of-line.o -Xfrontend -enable-cxx-interop
+// RUN: %target-build-swift %s -I %S/Inputs -o %t/member-out-of-line %t/member-out-of-line.o -Xfrontend -enable-experimental-cxx-interop
 // RUN: %target-codesign %t/member-out-of-line
 // RUN: %target-run %t/member-out-of-line
 

--- a/test/Interop/Cxx/operators/non-member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/non-member-inline-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=NonMemberInline -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=NonMemberInline -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // XFAIL: *
 

--- a/test/Interop/Cxx/operators/non-member-inline-typechecker.swift
+++ b/test/Interop/Cxx/operators/non-member-inline-typechecker.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-cxx-interop
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop
 
 // XFAIL: *
 

--- a/test/Interop/Cxx/operators/non-member-inline.swift
+++ b/test/Interop/Cxx/operators/non-member-inline.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/operators/non-member-out-of-line-irgen.swift
+++ b/test/Interop/Cxx/operators/non-member-out-of-line-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 
 // XFAIL: *
 

--- a/test/Interop/Cxx/operators/non-member-out-of-line-silgen.swift
+++ b/test/Interop/Cxx/operators/non-member-out-of-line-silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-sil %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 
 // XFAIL: *
 

--- a/test/Interop/Cxx/operators/non-member-out-of-line.swift
+++ b/test/Interop/Cxx/operators/non-member-out-of-line.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-clangxx -c %S/Inputs/non-member-out-of-line.cpp -I %S/Inputs -o %t/non-member-out-of-line.o
-// RUN: %target-build-swift %s -I %S/Inputs -o %t/non-member-out-of-line %t/non-member-out-of-line.o -Xfrontend -enable-cxx-interop
+// RUN: %target-build-swift %s -I %S/Inputs -o %t/non-member-out-of-line %t/non-member-out-of-line.o -Xfrontend -enable-experimental-cxx-interop
 // RUN: %target-codesign %t/non-member-out-of-line
 // RUN: %target-run %t/non-member-out-of-line
 //

--- a/test/Interop/Cxx/reference/closures-module-interface.swift
+++ b/test/Interop/Cxx/reference/closures-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=Closures -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=Closures -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK: func invokeWith42ConstRef(_ fn: ((Int32) -> Void)!)
 // CHECK: func invokeWith42Ref(_ fn: ((UnsafeMutablePointer<Int32>) -> Void)!)

--- a/test/Interop/Cxx/reference/closures.swift
+++ b/test/Interop/Cxx/reference/closures.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-clangxx -c %S/Inputs/reference.cpp -I %S/Inputs -o %t/reference.o
-// RUN: %target-build-swift %s -I %S/Inputs -o %t/reference %t/reference.o -Xfrontend -enable-cxx-interop
+// RUN: %target-build-swift %s -I %S/Inputs -o %t/reference %t/reference.o -Xfrontend -enable-experimental-cxx-interop
 // RUN: %target-codesign %t/reference
 // RUN: %target-run %t/reference
 //

--- a/test/Interop/Cxx/reference/reference-irgen.swift
+++ b/test/Interop/Cxx/reference/reference-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir -I %S/Inputs -enable-cxx-interop %s | %FileCheck %s
+// RUN: %target-swift-emit-ir -I %S/Inputs -enable-experimental-cxx-interop %s | %FileCheck %s
 
 import Reference
 

--- a/test/Interop/Cxx/reference/reference-module-interface.swift
+++ b/test/Interop/Cxx/reference/reference-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=Reference -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=Reference -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK: func getStaticInt() -> Int32
 // CHECK: func getStaticIntRef() -> UnsafeMutablePointer<Int32>

--- a/test/Interop/Cxx/reference/reference-silgen.swift
+++ b/test/Interop/Cxx/reference/reference-silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -I %S/Inputs -enable-cxx-interop %s | %FileCheck %s
+// RUN: %target-swift-emit-sil -I %S/Inputs -enable-experimental-cxx-interop %s | %FileCheck %s
 
 import Reference
 

--- a/test/Interop/Cxx/reference/reference.swift
+++ b/test/Interop/Cxx/reference/reference.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-clangxx -c %S/Inputs/reference.cpp -I %S/Inputs -o %t/reference.o
-// RUN: %target-build-swift %s -I %S/Inputs -o %t/reference %t/reference.o -Xfrontend -enable-cxx-interop
+// RUN: %target-build-swift %s -I %S/Inputs -o %t/reference %t/reference.o -Xfrontend -enable-experimental-cxx-interop
 // RUN: %target-codesign %t/reference
 // RUN: %target-run %t/reference
 //

--- a/test/Interop/Cxx/static/constexpr-static-member-var-errors.swift
+++ b/test/Interop/Cxx/static/constexpr-static-member-var-errors.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=ConstexprStaticMemberVarErrors -I %S/Inputs -source-filename=x -enable-cxx-interop 2>&1 | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=ConstexprStaticMemberVarErrors -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop 2>&1 | %FileCheck %s
 
 // Check that we properly report the error and don't crash when importing an
 // invalid decl.

--- a/test/Interop/Cxx/static/constexpr-static-member-var.swift
+++ b/test/Interop/Cxx/static/constexpr-static-member-var.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-clangxx -c %S/Inputs/static-member-var.cpp -I %S/Inputs -o %t/static-member-var.o
-// RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/static-member-var.o -Xfrontend -enable-cxx-interop
+// RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/static-member-var.o -Xfrontend -enable-experimental-cxx-interop
 // RUN: %target-codesign %t/statics
 // RUN: %target-run %t/statics
 //

--- a/test/Interop/Cxx/static/inline-static-member-var-irgen.swift
+++ b/test/Interop/Cxx/static/inline-static-member-var-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir -I %S/Inputs -enable-cxx-interop %s | %FileCheck %s
+// RUN: %target-swift-emit-ir -I %S/Inputs -enable-experimental-cxx-interop %s | %FileCheck %s
 
 import InlineStaticMemberVar
 

--- a/test/Interop/Cxx/static/inline-static-member-var-silgen.swift
+++ b/test/Interop/Cxx/static/inline-static-member-var-silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -I %S/Inputs -enable-cxx-interop %s | %FileCheck %s
+// RUN: %target-swift-emit-sil -I %S/Inputs -enable-experimental-cxx-interop %s | %FileCheck %s
 
 import InlineStaticMemberVar
 

--- a/test/Interop/Cxx/static/inline-static-member-var.swift
+++ b/test/Interop/Cxx/static/inline-static-member-var.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-clangxx -c %S/Inputs/inline-static-member-var.cpp -I %S/Inputs -o %t/inline-static-member-var.o
-// RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/inline-static-member-var.o -Xfrontend -enable-cxx-interop
+// RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/inline-static-member-var.o -Xfrontend -enable-experimental-cxx-interop
 // RUN: %target-codesign %t/statics
 // RUN: %target-run %t/statics 2&>1
 //

--- a/test/Interop/Cxx/static/static-local-var.swift
+++ b/test/Interop/Cxx/static/static-local-var.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-clangxx -c %S/Inputs/static-local-var.cpp -I %S/Inputs -o %t/static-local-var.o
-// RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/static-local-var.o -Xfrontend -enable-cxx-interop
+// RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/static-local-var.o -Xfrontend -enable-experimental-cxx-interop
 // RUN: %target-codesign %t/statics
 // RUN: %target-run %t/statics
 //

--- a/test/Interop/Cxx/static/static-member-func-irgen.swift
+++ b/test/Interop/Cxx/static/static-member-func-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 
 import StaticMemberFunc
 

--- a/test/Interop/Cxx/static/static-member-func-silgen.swift
+++ b/test/Interop/Cxx/static/static-member-func-silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-sil %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 
 import StaticMemberFunc
 

--- a/test/Interop/Cxx/static/static-member-func.swift
+++ b/test/Interop/Cxx/static/static-member-func.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-clangxx -c %S/Inputs/static-member-func.cpp -I %S/Inputs -o %t/static-member-func.o
-// RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/static-member-func.o -Xfrontend -enable-cxx-interop
+// RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/static-member-func.o -Xfrontend -enable-experimental-cxx-interop
 // RUN: %target-codesign %t/statics
 // RUN: %target-run %t/statics
 //

--- a/test/Interop/Cxx/static/static-member-var-irgen.swift
+++ b/test/Interop/Cxx/static/static-member-var-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir -I %S/Inputs -enable-cxx-interop %s | %FileCheck %s
+// RUN: %target-swift-emit-ir -I %S/Inputs -enable-experimental-cxx-interop %s | %FileCheck %s
 
 // CHECK: @{{_ZN16WithStaticMember12staticMemberE|"\?staticMember@WithStaticMember@@2HA"}} = external {{(dso_local )?}}global i32, align 4
 // CHECK: @{{_ZN26WithIncompleteStaticMember10selfMemberE|"\?selfMember@WithIncompleteStaticMember@@2V1@A"}} = {{external|linkonce_odr}} {{(dso_local )?}}global %class.WithIncompleteStaticMember, align 4

--- a/test/Interop/Cxx/static/static-member-var-module-interface.swift
+++ b/test/Interop/Cxx/static/static-member-var-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=StaticMemberVar -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=StaticMemberVar -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK: struct WithStaticAndInstanceMember {
 // CHECK-NEXT:   init()

--- a/test/Interop/Cxx/static/static-member-var-silgen.swift
+++ b/test/Interop/Cxx/static/static-member-var-silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -I %S/Inputs -enable-cxx-interop %s | %FileCheck %s
+// RUN: %target-swift-emit-sil -I %S/Inputs -enable-experimental-cxx-interop %s | %FileCheck %s
 
 // CHECK: // clang name: WithStaticMember::staticMember
 // CHECK: sil_global public_external @{{_ZN16WithStaticMember12staticMemberE|\?staticMember@WithStaticMember@@2HA}} : $Int32

--- a/test/Interop/Cxx/static/static-member-var.swift
+++ b/test/Interop/Cxx/static/static-member-var.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-clangxx -c %S/Inputs/static-member-var.cpp -I %S/Inputs -o %t/static-member-var.o
-// RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/static-member-var.o -Xfrontend -enable-cxx-interop
+// RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/static-member-var.o -Xfrontend -enable-experimental-cxx-interop
 // RUN: %target-codesign %t/statics
 // RUN: %target-run %t/statics
 //

--- a/test/Interop/Cxx/static/static-var-irgen.swift
+++ b/test/Interop/Cxx/static/static-var-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir -I %S/Inputs -enable-cxx-interop %s | %FileCheck %s
+// RUN: %target-swift-emit-ir -I %S/Inputs -enable-experimental-cxx-interop %s | %FileCheck %s
 
 import StaticVar
 

--- a/test/Interop/Cxx/static/static-var-silgen.swift
+++ b/test/Interop/Cxx/static/static-var-silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -I %S/Inputs -enable-cxx-interop %s | %FileCheck %s
+// RUN: %target-swift-emit-sil -I %S/Inputs -enable-experimental-cxx-interop %s | %FileCheck %s
 
 import StaticVar
 

--- a/test/Interop/Cxx/static/static-var.swift
+++ b/test/Interop/Cxx/static/static-var.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-clangxx -c %S/Inputs/static-var.cpp -I %S/Inputs -o %t/static-var.o
-// RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/static-var.o -Xfrontend -enable-cxx-interop
+// RUN: %target-build-swift %s -I %S/Inputs -o %t/statics %t/static-var.o -Xfrontend -enable-experimental-cxx-interop
 // RUN: %target-codesign %t/statics
 // RUN: %target-run %t/statics
 //

--- a/test/Interop/Cxx/stdlib/fake-toolchain-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/fake-toolchain-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=FakeToolchain -tools-directory %S/Inputs/fake-toolchain/bin -source-filename=x -enable-cxx-interop -Xcc -stdlib=libc++ | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=FakeToolchain -tools-directory %S/Inputs/fake-toolchain/bin -source-filename=x -enable-experimental-cxx-interop -Xcc -stdlib=libc++ | %FileCheck %s
 
 // Clang driver on Windows doesn't support -stdlib=libc++
 // XFAIL: OS=windows-msvc

--- a/test/Interop/Cxx/stdlib/import-foundation-with-indexing.swift
+++ b/test/Interop/Cxx/stdlib/import-foundation-with-indexing.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -c -index-system-modules -index-store-path %t -enable-cxx-interop
+// RUN: %target-swift-frontend %s -c -index-system-modules -index-store-path %t -enable-experimental-cxx-interop
 //
 // REQUIRES: OS=macosx
 

--- a/test/Interop/Cxx/stdlib/std-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/std-module-interface.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=std -source-filename=x -enable-cxx-interop -tools-directory=%llvm_obj_root/bin -module-cache-path %t | %FileCheck %s  -check-prefix=CHECK-STD
-// RUN: %target-swift-ide-test -print-module -module-to-print=std.iosfwd -source-filename=x -enable-cxx-interop -tools-directory=%llvm_obj_root/bin -module-cache-path %t | %FileCheck %s  -check-prefix=CHECK-IOSFWD
-// RUN: %target-swift-ide-test -print-module -module-to-print=std.string -source-filename=x -enable-cxx-interop -tools-directory=%llvm_obj_root/bin -module-cache-path %t | %FileCheck %s  -check-prefix=CHECK-STRING
+// RUN: %target-swift-ide-test -print-module -module-to-print=std -source-filename=x -enable-experimental-cxx-interop -tools-directory=%llvm_obj_root/bin -module-cache-path %t | %FileCheck %s  -check-prefix=CHECK-STD
+// RUN: %target-swift-ide-test -print-module -module-to-print=std.iosfwd -source-filename=x -enable-experimental-cxx-interop -tools-directory=%llvm_obj_root/bin -module-cache-path %t | %FileCheck %s  -check-prefix=CHECK-IOSFWD
+// RUN: %target-swift-ide-test -print-module -module-to-print=std.string -source-filename=x -enable-experimental-cxx-interop -tools-directory=%llvm_obj_root/bin -module-cache-path %t | %FileCheck %s  -check-prefix=CHECK-STRING
 
 // Clang driver on Windows doesn't support -stdlib=libc++
 // UNSUPPORTED: OS=windows-msvc

--- a/test/Interop/Cxx/stdlib/use-std-string.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 //

--- a/test/Interop/Cxx/stdlib/use-std-vector.swift
+++ b/test/Interop/Cxx/stdlib/use-std-vector.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 //

--- a/test/Interop/Cxx/templates/canonical-types-module-interface.swift
+++ b/test/Interop/Cxx/templates/canonical-types-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=CanonicalTypes -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=CanonicalTypes -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK:      struct __CxxTemplateInst12MagicWrapperI10IntWrapperE {
 // CHECK-NEXT:   init()

--- a/test/Interop/Cxx/templates/canonical-types.swift
+++ b/test/Interop/Cxx/templates/canonical-types.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/templates/class-template-eager-instatiation-problems.swift
+++ b/test/Interop/Cxx/templates/class-template-eager-instatiation-problems.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/templates/class-template-in-namespace-module-interface.swift
+++ b/test/Interop/Cxx/templates/class-template-in-namespace-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=ClassTemplateInNamespace -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=ClassTemplateInNamespace -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK: enum Space {
 // CHECK:   struct __CxxTemplateInstN5Space4ShipIJFvbEEEE {

--- a/test/Interop/Cxx/templates/class-template-instantiation-demangling.swift
+++ b/test/Interop/Cxx/templates/class-template-instantiation-demangling.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop | grep 'define.*swiftcc.*$' | grep -o '[[:alnum:]]*__CxxTemplateInst[[:alnum:]]*' | xargs %swift-demangle | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop | grep 'define.*swiftcc.*$' | grep -o '[[:alnum:]]*__CxxTemplateInst[[:alnum:]]*' | xargs %swift-demangle | %FileCheck %s
 
 import Mangling
 

--- a/test/Interop/Cxx/templates/class-template-instantiation-existing-specialization.swift
+++ b/test/Interop/Cxx/templates/class-template-instantiation-existing-specialization.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/templates/class-template-instantiation-typechecker-calls-method-with-error.swift
+++ b/test/Interop/Cxx/templates/class-template-instantiation-typechecker-calls-method-with-error.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop 2>&1 | %FileCheck %s
+// RUN: not %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop 2>&1 | %FileCheck %s
 
 import ClassTemplateInstantiationErrors
 

--- a/test/Interop/Cxx/templates/class-template-instantiation-typechecker-constructor-calls-method-with-error.swift
+++ b/test/Interop/Cxx/templates/class-template-instantiation-typechecker-constructor-calls-method-with-error.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop 2>&1 | %FileCheck %s
+// RUN: not %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop 2>&1 | %FileCheck %s
 
 import ClassTemplateInstantiationErrors
 

--- a/test/Interop/Cxx/templates/class-template-instantiation-typechecker.swift
+++ b/test/Interop/Cxx/templates/class-template-instantiation-typechecker.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop 2>&1 | %FileCheck %s
+// RUN: not %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop 2>&1 | %FileCheck %s
 
 import ClassTemplateInstantiationErrors
 

--- a/test/Interop/Cxx/templates/class-template-instantiation.swift
+++ b/test/Interop/Cxx/templates/class-template-instantiation.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/templates/class-template-non-type-parameter.swift
+++ b/test/Interop/Cxx/templates/class-template-non-type-parameter.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/templates/class-template-template-parameter.swift
+++ b/test/Interop/Cxx/templates/class-template-template-parameter.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/templates/class-template-uninstantiatable-members-irgen.swift
+++ b/test/Interop/Cxx/templates/class-template-uninstantiatable-members-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 
 import ClassTemplateInstantiationErrors
 

--- a/test/Interop/Cxx/templates/class-template-uninstantiatable-members.swift
+++ b/test/Interop/Cxx/templates/class-template-uninstantiatable-members.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/templates/class-template-variadic.swift
+++ b/test/Interop/Cxx/templates/class-template-variadic.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 //

--- a/test/Interop/Cxx/templates/class-template-with-primitive-argument.swift
+++ b/test/Interop/Cxx/templates/class-template-with-primitive-argument.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/templates/class-template-with-typedef-module-interface.swift
+++ b/test/Interop/Cxx/templates/class-template-with-typedef-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=ClassTemplateWithTypedef -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=ClassTemplateWithTypedef -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK: struct __CxxTemplateInst6LanderIcE {
 // CHECK:   init()

--- a/test/Interop/Cxx/templates/defaulted-template-type-parameter-module-interface.swift
+++ b/test/Interop/Cxx/templates/defaulted-template-type-parameter-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=DefaultedTemplateTypeParameter -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=DefaultedTemplateTypeParameter -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK: struct X {
 // CHECK:   init<T>(_: T)

--- a/test/Interop/Cxx/templates/defaulted-template-type-parameter.swift
+++ b/test/Interop/Cxx/templates/defaulted-template-type-parameter.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/templates/define-referenced-inline.swift
+++ b/test/Interop/Cxx/templates/define-referenced-inline.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop -Xcc -fno-exceptions)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -fno-exceptions)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/templates/dependent-types-module-interface.swift
+++ b/test/Interop/Cxx/templates/dependent-types-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=DependentTypes -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=DependentTypes -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK: func differentDependentArgAndRet<T, U>(_ a: Any, T: T.Type, U: U.Type) -> Any
 // CHECK: func dependantReturnTypeInffered<T>(_ a: T) -> Any

--- a/test/Interop/Cxx/templates/dependent-types-silgen.swift
+++ b/test/Interop/Cxx/templates/dependent-types-silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 
 import DependentTypes
 

--- a/test/Interop/Cxx/templates/dependent-types.swift
+++ b/test/Interop/Cxx/templates/dependent-types.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop -Xfrontend -validate-tbd-against-ir=none)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none)
 //
 // REQUIRES: executable_test
 //

--- a/test/Interop/Cxx/templates/explicit-class-specialization-module-interface.swift
+++ b/test/Interop/Cxx/templates/explicit-class-specialization-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=ExplicitClassSpecialization -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=ExplicitClassSpecialization -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK: struct __CxxTemplateInst41HasEmptySpecializationAndStaticDateMemberIiE {
 // CHECK:   static let value: Bool

--- a/test/Interop/Cxx/templates/explicit-class-specialization.swift
+++ b/test/Interop/Cxx/templates/explicit-class-specialization.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/templates/fully-pre-defined-class-template.swift
+++ b/test/Interop/Cxx/templates/fully-pre-defined-class-template.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/templates/function-template-irgen.swift
+++ b/test/Interop/Cxx/templates/function-template-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 
 import FunctionTemplates
 

--- a/test/Interop/Cxx/templates/function-template-module-interface.swift
+++ b/test/Interop/Cxx/templates/function-template-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=FunctionTemplates -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=FunctionTemplates -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK: func addSameTypeParams<T>(_ a: T, _ b: T) -> T
 // CHECK: func addMixedTypeParams<A, B>(_ a: A, _ b: B) -> A

--- a/test/Interop/Cxx/templates/function-template-silgen.swift
+++ b/test/Interop/Cxx/templates/function-template-silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-sil %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 
 import FunctionTemplates
 

--- a/test/Interop/Cxx/templates/function-template-typechecker-errors.swift
+++ b/test/Interop/Cxx/templates/function-template-typechecker-errors.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-typecheck-verify-swift -I %S/Inputs -enable-cxx-interop 2>&1 | %FileCheck %s
+// RUN: not %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop 2>&1 | %FileCheck %s
 
 // README: If you just added support for protocol composition to the
 // ClangTypeConverter, please update this test to use a different type that we

--- a/test/Interop/Cxx/templates/function-template.swift
+++ b/test/Interop/Cxx/templates/function-template.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop -Xfrontend -enable-experimental-opened-existential-types)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xfrontend -enable-experimental-opened-existential-types)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/templates/instantiation-in-multiple-modules/instantiation-in-multiple-modules-irgen.swift
+++ b/test/Interop/Cxx/templates/instantiation-in-multiple-modules/instantiation-in-multiple-modules-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 
 import A
 import B

--- a/test/Interop/Cxx/templates/instantiation-in-multiple-modules/instantiation-in-multiple-modules.swift
+++ b/test/Interop/Cxx/templates/instantiation-in-multiple-modules/instantiation-in-multiple-modules.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/templates/large-class-templates-module-interface.swift
+++ b/test/Interop/Cxx/templates/large-class-templates-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=LargeClassTemplates -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=LargeClassTemplates -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK: struct HasTypeWithSelfAsParam<T> {
 // CHECK: }

--- a/test/Interop/Cxx/templates/linkage-of-swift-symbols-for-imported-types-irgen.swift
+++ b/test/Interop/Cxx/templates/linkage-of-swift-symbols-for-imported-types-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 
 import LinkageOfSwiftSymbolsForImportedTypes
 

--- a/test/Interop/Cxx/templates/mangling-irgen.swift
+++ b/test/Interop/Cxx/templates/mangling-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 
 import Mangling
 

--- a/test/Interop/Cxx/templates/mangling-silgen.swift
+++ b/test/Interop/Cxx/templates/mangling-silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-sil %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 
 import Mangling
 

--- a/test/Interop/Cxx/templates/member-templates-module-interface.swift
+++ b/test/Interop/Cxx/templates/member-templates-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=MemberTemplates -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=MemberTemplates -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK: struct HasMemberTemplates {
 // CHECK:   mutating func addSameTypeParams<T>(_ a: T, _ b: T) -> T

--- a/test/Interop/Cxx/templates/member-templates-silgen.swift
+++ b/test/Interop/Cxx/templates/member-templates-silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-sil %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 
 // We can't yet call member functions correctly on Windows (SR-13129).
 // XFAIL: OS=windows-msvc

--- a/test/Interop/Cxx/templates/member-templates.swift
+++ b/test/Interop/Cxx/templates/member-templates.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/templates/not-pre-defined-class-template-module-interface.swift
+++ b/test/Interop/Cxx/templates/not-pre-defined-class-template-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=NotPreDefinedClassTemplate -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=NotPreDefinedClassTemplate -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK:      struct __CxxTemplateInst12MagicWrapperI10IntWrapperE {
 // CHECK-NEXT:   init()

--- a/test/Interop/Cxx/templates/not-pre-defined-class-template.swift
+++ b/test/Interop/Cxx/templates/not-pre-defined-class-template.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/templates/partially-pre-defined-class-template-irgen.swift
+++ b/test/Interop/Cxx/templates/partially-pre-defined-class-template-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 // REQUIRES: rdar67257133
 import PartiallyPreDefinedClassTemplate
 

--- a/test/Interop/Cxx/templates/partially-pre-defined-class-template-silgen.swift
+++ b/test/Interop/Cxx/templates/partially-pre-defined-class-template-silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-sil %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 
 import PartiallyPreDefinedClassTemplate
 

--- a/test/Interop/Cxx/templates/partially-pre-defined-class-template.swift
+++ b/test/Interop/Cxx/templates/partially-pre-defined-class-template.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/templates/swift-class-instantiation-in-namespace-module-interface.swift
+++ b/test/Interop/Cxx/templates/swift-class-instantiation-in-namespace-module-interface.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swiftxx-frontend -emit-module -o %t/SwiftClassTemplateInNamespaceModule.swiftmodule %S/Inputs/SwiftClassTemplateInNamespaceModule.swift -I %S/Inputs -enable-library-evolution -swift-version 5
-// RUN: %target-swift-ide-test -print-module -module-to-print=SwiftClassTemplateInNamespaceModule -I %t/ -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=SwiftClassTemplateInNamespaceModule -I %t/ -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // The following bug needs to be resolved so decls in __ObjC don't dissapear.
 // REQUIRES: SR-14211

--- a/test/Interop/Cxx/templates/swift-class-instantiation-module-interface.swift
+++ b/test/Interop/Cxx/templates/swift-class-instantiation-module-interface.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swiftxx-frontend -emit-module -o %t/SwiftClassTemplateModule.swiftmodule %S/Inputs/SwiftClassInstantiationModule.swift -I %S/Inputs -enable-library-evolution -swift-version 5
-// RUN: %target-swift-ide-test -print-module -module-to-print=SwiftClassTemplateModule -I %t/ -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=SwiftClassTemplateModule -I %t/ -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 
 // CHECK: import ClassTemplateForSwiftModule

--- a/test/Interop/Cxx/templates/swift-class-instantiation-nested-type-module-interface.swift
+++ b/test/Interop/Cxx/templates/swift-class-instantiation-nested-type-module-interface.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swiftxx-frontend -emit-module -o %t/SwiftClassTemplateNestedTypeModule.swiftmodule %S/Inputs/SwiftClassTemplateNestedTypeModule.swift -I %S/Inputs -enable-library-evolution -swift-version 5
-// RUN: %target-swift-ide-test -print-module -module-to-print=SwiftClassTemplateNestedTypeModule -I %t/ -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=SwiftClassTemplateNestedTypeModule -I %t/ -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // REQUIRES: SR-13261
 

--- a/test/Interop/Cxx/templates/template-type-parameter-not-in-signature-module-interface.swift
+++ b/test/Interop/Cxx/templates/template-type-parameter-not-in-signature-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=TemplateTypeParameterNotInSignature -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=TemplateTypeParameterNotInSignature -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK: func templateTypeParamNotUsedInSignature<T>(T: T.Type)
 // CHECK: func multiTemplateTypeParamNotUsedInSignature<T, U>(T: T.Type, U: U.Type)

--- a/test/Interop/Cxx/templates/template-type-parameter-not-in-signature.swift
+++ b/test/Interop/Cxx/templates/template-type-parameter-not-in-signature.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop -Xfrontend -validate-tbd-against-ir=none)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/templates/using-directive-module-interface.swift
+++ b/test/Interop/Cxx/templates/using-directive-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=UsingDirective -I %S/Inputs -source-filename=x -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=UsingDirective -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK:      struct __CxxTemplateInst12MagicWrapperI10IntWrapperE {
 // CHECK-NEXT:   init()

--- a/test/Interop/Cxx/templates/using-directive.swift
+++ b/test/Interop/Cxx/templates/using-directive.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/union/anonymous-union-partly-invalid-module-interface.swift
+++ b/test/Interop/Cxx/union/anonymous-union-partly-invalid-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=AnonymousUnionPartlyInvalid -I %S/Inputs -source-filename=x -enable-cxx-interop -enable-objc-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=AnonymousUnionPartlyInvalid -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop -enable-objc-interop | %FileCheck %s
 
 // CHECK: class C {
 // CHECK-NEXT: }

--- a/test/Interop/Cxx/union/anonymous-union-partly-invalid.swift
+++ b/test/Interop/Cxx/union/anonymous-union-partly-invalid.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -I %S/Inputs -enable-cxx-interop -enable-objc-interop -emit-ir %s | %FileCheck %s
+// RUN: %swift -I %S/Inputs -enable-experimental-cxx-interop -enable-objc-interop -emit-ir %s | %FileCheck %s
 
 import AnonymousUnionPartlyInvalid
 

--- a/test/Interop/Cxx/value-witness-table/class-template-metadata.swift
+++ b/test/Interop/Cxx/value-witness-table/class-template-metadata.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/value-witness-table/copy-constructors-execution.swift
+++ b/test/Interop/Cxx/value-witness-table/copy-constructors-execution.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/value-witness-table/copy-constructors-irgen.swift
+++ b/test/Interop/Cxx/value-witness-table/copy-constructors-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-cxx-interop -I %S/Inputs %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -enable-experimental-cxx-interop -I %S/Inputs %s -emit-ir | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/Interop/Cxx/value-witness-table/custom-destructors-non-virtual-irgen.swift
+++ b/test/Interop/Cxx/value-witness-table/custom-destructors-non-virtual-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-cxx-interop -I %S/Inputs %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -enable-experimental-cxx-interop -I %S/Inputs %s -emit-ir | %FileCheck %s
 
 // This tests output needs to be updated for arm64.
 // XFAIL: CPU=arm64e

--- a/test/Interop/Cxx/value-witness-table/custom-destructors-non-virtual.swift
+++ b/test/Interop/Cxx/value-witness-table/custom-destructors-non-virtual.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop -O)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -O)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/value-witness-table/custom-destructors-typechecker.swift
+++ b/test/Interop/Cxx/value-witness-table/custom-destructors-typechecker.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-cxx-interop
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop
 
 import CustomDestructor
 

--- a/test/Interop/Cxx/value-witness-table/custom-destructors-virtual-irgen.swift
+++ b/test/Interop/Cxx/value-witness-table/custom-destructors-virtual-irgen.swift
@@ -2,7 +2,7 @@
 // will cause linker errors because of undefined vtables.
 // FIXME: Once we can link with libc++ we can start using RTTI.
 //
-// RUN: %target-swift-frontend -enable-cxx-interop -I %S/Inputs %s -emit-ir -Xcc -fno-rtti | %FileCheck %s
+// RUN: %target-swift-frontend -enable-experimental-cxx-interop -I %S/Inputs %s -emit-ir -Xcc -fno-rtti | %FileCheck %s
 //
 // Windows doesn't support -fno-rtti.
 // UNSUPPORTED: OS=windows-msvc

--- a/test/Interop/Cxx/value-witness-table/custom-destructors-virtual.swift
+++ b/test/Interop/Cxx/value-witness-table/custom-destructors-virtual.swift
@@ -2,8 +2,8 @@
 // will cause linker errors because of undefined vtables.
 // FIXME: Once we can link with libc++ we can start using RTTI.
 // 
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop -Xcc -fno-rtti)
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop -Xcc -fno-rtti -O)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -fno-rtti)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -fno-rtti -O)
 //
 // REQUIRES: executable_test
 // Windows doesn't support -fno-rtti.

--- a/test/Interop/Cxx/value-witness-table/witness-layout-opts-irgen.swift
+++ b/test/Interop/Cxx/value-witness-table/witness-layout-opts-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 
 // This test checks that the compiler uses well-known witness tables for types
 // that have the appropriate size/shape (for example, { i8 x 4 } -> i32).

--- a/test/Interop/Cxx/value-witness-table/witness-lifetime-operations-irgen.swift
+++ b/test/Interop/Cxx/value-witness-table/witness-lifetime-operations-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-cxx-interop -I %S/Inputs %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -enable-experimental-cxx-interop -I %S/Inputs %s -emit-ir | %FileCheck %s
 
 // Temporarily restrict to x86 (rdar://89908618)
 // REQUIRES: CPU=x86_64

--- a/test/Interop/lit.local.cfg
+++ b/test/Interop/lit.local.cfg
@@ -19,7 +19,7 @@ else:
 
 # Enable C++ interop when compiling Swift sources.
 config.substitutions.insert(0, ('%target-interop-build-swift',
-                                '%target-build-swift -Xfrontend -enable-cxx-interop '))
+                                '%target-build-swift -Xfrontend -enable-experimental-cxx-interop '))
 
 # Build C files disallowing implicit functions and with matching link settings, if required by the target.
 config.substitutions.insert(0, ('%target-interop-build-clang',  '%target-clang -x c -Werror=implicit-function-declaration ' + clang_opt))

--- a/test/SILOptimizer/dont_broaden_cxx_address_only.sil
+++ b/test/SILOptimizer/dont_broaden_cxx_address_only.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -silgen-cleanup %s -I %S/Inputs -enable-sil-verify-all -enable-cxx-interop | %FileCheck %s
+// RUN: %target-sil-opt -silgen-cleanup %s -I %S/Inputs -enable-sil-verify-all -enable-experimental-cxx-interop | %FileCheck %s
 
 sil_stage canonical
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2250,7 +2250,7 @@ if platform.system() != 'Darwin' or swift_test_mode == 'optimize_none_with_impli
 #
 
 config.substitutions.append(('%target-clangxx', '%s -std=c++11' % config.target_clang))
-config.substitutions.append(('%target-swiftxx-frontend', '%s -enable-cxx-interop' % config.target_swift_frontend))
+config.substitutions.append(('%target-swiftxx-frontend', '%s -enable-experimental-cxx-interop' % config.target_swift_frontend))
 
 config.substitutions.append(('%target-runtime', config.target_runtime))
 

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -461,7 +461,7 @@ static cl::opt<std::string> RemarksFormat(
     cl::value_desc("format"), cl::init("yaml"));
 
 static llvm::cl::opt<bool>
-    EnableCxxInterop("enable-cxx-interop",
+    EnableCxxInterop("enable-experimental-cxx-interop",
                      llvm::cl::desc("Enable C++ interop."),
                      llvm::cl::init(false));
 

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -762,7 +762,7 @@ static llvm::cl::opt<bool>
                        llvm::cl::cat(Category), llvm::cl::init(false));
 
 static llvm::cl::opt<bool>
-    EnableCxxInterop("enable-cxx-interop",
+    EnableCxxInterop("enable-experimental-cxx-interop",
                      llvm::cl::desc("Enable C++ interop."),
                      llvm::cl::cat(Category), llvm::cl::init(false));
 


### PR DESCRIPTION
Also removes the driver flag, this will now also always be guarded on `-Xfrontend`.