### PR TITLE
[Sema] Improvements on typeCheckCheckedCast and checked cast diagnostics

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3712,12 +3712,8 @@ namespace {
       expr->setCastType(toType);
       cs.setType(castTypeRepr, toType);
 
-      auto castContextKind =
-          SuppressDiagnostics ? CheckedCastContextKind::None
-                              : CheckedCastContextKind::IsExpr;
       auto castKind = TypeChecker::typeCheckCheckedCast(
-          fromType, toType, castContextKind, dc, expr->getLoc(), sub,
-          castTypeRepr->getSourceRange());
+          fromType, toType, CheckedCastContextKind::IsExpr, dc);
 
       switch (castKind) {
       case CheckedCastKind::Unresolved:
@@ -3726,19 +3722,7 @@ namespace {
           
       case CheckedCastKind::Coercion:
       case CheckedCastKind::BridgingCoercion:
-        expr->setCastKind(castKind);
-        break;
       case CheckedCastKind::ValueCast:
-        // Check the cast target is a non-foreign type
-        if (auto cls = toType->getAs<ClassType>()) {
-          if (cls->getDecl()->getForeignClassKind() ==
-                ClassDecl::ForeignKind::CFType) {
-            ctx.Diags.diagnose(expr->getLoc(), diag::isa_is_foreign_check,
-                               toType);
-          }
-        }
-        expr->setCastKind(castKind);
-        break;
       case CheckedCastKind::ArrayDowncast:
       case CheckedCastKind::DictionaryDowncast:
       case CheckedCastKind::SetDowncast:
@@ -4169,17 +4153,16 @@ namespace {
       if (hasForcedOptionalResult(expr))
         toType = toType->getOptionalObjectType();
 
-      auto castContextKind = SuppressDiagnostics || expr->isImplicit()
-                                 ? CheckedCastContextKind::None
-                                 : CheckedCastContextKind::ForcedCast;
-
       const auto castKind = TypeChecker::typeCheckCheckedCast(
-          fromType, toType, castContextKind, dc, expr->getLoc(), sub,
-          castTypeRange);
+          fromType, toType, CheckedCastContextKind::ForcedCast, dc);
       switch (castKind) {
         /// Invalid cast.
       case CheckedCastKind::Unresolved:
-        return nullptr;
+        if (expr->isImplicit())
+          return nullptr;
+
+        expr->setCastKind(CheckedCastKind::ValueCast);
+        break;
       case CheckedCastKind::Coercion:
       case CheckedCastKind::BridgingCoercion: {
         expr->setCastKind(castKind);
@@ -4240,7 +4223,6 @@ namespace {
              "cast requires TypeRepr; implicit casts are superfluous");
 
       // The subexpression is always an rvalue.
-      auto &ctx = cs.getASTContext();
       auto sub = cs.coerceToRValue(expr->getSubExpr());
       expr->setSubExpr(sub);
 
@@ -4248,39 +4230,11 @@ namespace {
       const auto fromType = cs.getType(sub);
       const auto toType = expr->getCastType();
 
-      bool isSubExprLiteral = isa<LiteralExpr>(sub);
-      auto castContextKind =
-          (SuppressDiagnostics || expr->isImplicit() || isSubExprLiteral)
-              ? CheckedCastContextKind::None
-              : CheckedCastContextKind::ConditionalCast;
-
       auto castKind = TypeChecker::typeCheckCheckedCast(
-          fromType, toType, castContextKind, dc, expr->getLoc(), sub,
-          castTypeRepr->getSourceRange());
+          fromType, toType, CheckedCastContextKind::ConditionalCast, dc);
       switch (castKind) {
       // Invalid cast.
       case CheckedCastKind::Unresolved:
-        // FIXME: This literal diagnostics needs to be revisited by a proposal
-        // to unify casting semantics for literals.
-        // https://bugs.swift.org/browse/SR-12093
-        if (isSubExprLiteral) {
-          auto protocol = TypeChecker::getLiteralProtocol(ctx, sub);
-          // Special handle for literals conditional checked cast when they can
-          // be statically coerced to the cast type.
-          if (protocol && TypeChecker::conformsToProtocol(
-                              toType, protocol, dc->getParentModule())) {
-            ctx.Diags
-                .diagnose(expr->getLoc(),
-                          diag::literal_conditional_downcast_to_coercion,
-                          toType);
-          } else {
-            ctx.Diags
-                .diagnose(expr->getLoc(), diag::downcast_to_unrelated, fromType,
-                          toType)
-                .highlight(sub->getSourceRange())
-                .highlight(castTypeRepr->getSourceRange());
-          }
-        }
         expr->setCastKind(CheckedCastKind::ValueCast);
         break;
 
@@ -6148,12 +6102,9 @@ static Expr *buildElementConversion(ExprRewriter &rewriter,
                                     Type destType, bool bridged,
                                     ConstraintLocatorBuilder locator,
                                     Expr *element) {
-  if (bridged &&
-      TypeChecker::typeCheckCheckedCast(srcType, destType,
-                                        CheckedCastContextKind::None,
-                                        rewriter.dc,
-                                        SourceLoc(), nullptr, SourceRange())
-        != CheckedCastKind::Coercion) {
+  if (bridged && TypeChecker::typeCheckCheckedCast(
+                     srcType, destType, CheckedCastContextKind::None,
+                     rewriter.dc) != CheckedCastKind::Coercion) {
     if (auto conversion =
           rewriter.buildObjCBridgeExpr(element, destType, locator))
         return conversion;

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2574,11 +2574,23 @@ public:
   bool diagnoseAsError() override;
 
 private:
-  bool diagnoseIfExpr() const;
+  bool diagnoseIsExpr() const;
 
   bool diagnoseForcedCastExpr() const;
 
   bool diagnoseConditionalCastExpr() const;
+};
+
+/// Warn situations where the compiler can statically know a runtime
+/// checked cast always succeed.
+class NoopExistentialToCFTypeCheckedCast final : public CheckedCastBaseFailure {
+public:
+  NoopExistentialToCFTypeCheckedCast(const Solution &solution, Type fromType,
+                                     Type toType, CheckedCastKind kind,
+                                     ConstraintLocator *locator)
+      : CheckedCastBaseFailure(solution, fromType, toType, kind, locator) {}
+
+  bool diagnoseAsError() override;
 };
 
 /// Warn situations where the compiler can statically know a runtime
@@ -2589,6 +2601,18 @@ public:
   UnsupportedRuntimeCheckedCastFailure(const Solution &solution, Type fromType,
                                        Type toType, CheckedCastKind kind,
                                        ConstraintLocator *locator)
+      : CheckedCastBaseFailure(solution, fromType, toType, kind, locator) {}
+
+  bool diagnoseAsError() override;
+};
+
+/// Emit a warning when compiler can detect that checked cast would fail at
+/// runtime based on statically known types.
+class CheckedCastToUnrelatedFailure final : public CheckedCastBaseFailure {
+public:
+  CheckedCastToUnrelatedFailure(const Solution &solution, Type fromType,
+                                Type toType, CheckedCastKind kind,
+                                ConstraintLocator *locator)
       : CheckedCastBaseFailure(solution, fromType, toType, kind, locator) {}
 
   bool diagnoseAsError() override;

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -152,8 +152,7 @@ CoerceToCheckedCast *CoerceToCheckedCast::attempt(ConstraintSystem &cs,
     return nullptr;
 
   const auto castKind = TypeChecker::typeCheckCheckedCast(
-      fromType, toType, CheckedCastContextKind::Coercion, cs.DC,
-      SourceLoc(), coerceExpr->getSubExpr(), SourceRange());
+      fromType, toType, CheckedCastContextKind::Coercion, cs.DC);
 
   // Invalid cast.
   if (castKind == CheckedCastKind::Unresolved)
@@ -1999,6 +1998,33 @@ bool AllowNoopCheckedCast::diagnose(const Solution &solution,
   return warning.diagnose(asNote);
 }
 
+AllowNoopExistentialToCFTypeCheckedCast *
+AllowNoopExistentialToCFTypeCheckedCast::attempt(ConstraintSystem &cs,
+                                                 Type fromType, Type toType,
+                                                 CheckedCastKind kind,
+                                                 ConstraintLocator *locator) {
+  if (!isExpr<IsExpr>(locator->getAnchor()))
+    return nullptr;
+
+  if (!fromType->isExistentialType())
+    return nullptr;
+
+  const auto *cls = toType->getAs<ClassType>();
+  if (!(cls && cls->getDecl()->getForeignClassKind() ==
+                   ClassDecl::ForeignKind::CFType))
+    return nullptr;
+
+  return new (cs.getAllocator()) AllowNoopExistentialToCFTypeCheckedCast(
+      cs, fromType, toType, kind, locator);
+}
+
+bool AllowNoopExistentialToCFTypeCheckedCast::diagnose(const Solution &solution,
+                                                       bool asNote) const {
+  NoopExistentialToCFTypeCheckedCast warning(
+      solution, getFromType(), getToType(), CastKind, getLocator());
+  return warning.diagnose(asNote);
+}
+
 // Although function types maybe compile-time convertible because
 // compiler can emit thunks at SIL to handle the conversion when
 // required, only convertions that are supported by the runtime are
@@ -2039,6 +2065,26 @@ bool AllowUnsupportedRuntimeCheckedCast::diagnose(const Solution &solution,
   UnsupportedRuntimeCheckedCastFailure failure(
       solution, getFromType(), getToType(), CastKind, getLocator());
   return failure.diagnose(asNote);
+}
+
+AllowCheckedCastToUnrelated *
+AllowCheckedCastToUnrelated::attempt(ConstraintSystem &cs, Type fromType,
+                                     Type toType, CheckedCastKind kind,
+                                     ConstraintLocator *locator) {
+  // Explicit optional-to-optional casts always succeed because a nil
+  // value of any optional type can be cast to any other optional type.
+  if (fromType->getOptionalObjectType() && toType->getOptionalObjectType()) {
+    return nullptr;
+  }
+  return new (cs.getAllocator())
+      AllowCheckedCastToUnrelated(cs, fromType, toType, kind, locator);
+}
+
+bool AllowCheckedCastToUnrelated::diagnose(const Solution &solution,
+                                           bool asNote) const {
+  CheckedCastToUnrelatedFailure warning(solution, getFromType(), getToType(),
+                                        CastKind, getLocator());
+  return warning.diagnose(asNote);
 }
 
 bool AllowInvalidStaticMemberRefOnProtocolMetatype::diagnose(

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1058,9 +1058,8 @@ bool TypeChecker::isObjCBridgedTo(Type type1, Type type2, DeclContext *dc,
 }
 
 bool TypeChecker::checkedCastMaySucceed(Type t1, Type t2, DeclContext *dc) {
-  auto kind = TypeChecker::typeCheckCheckedCast(t1, t2,
-                                                CheckedCastContextKind::None, dc,
-                                   SourceLoc(), nullptr, SourceRange());
+  auto kind = TypeChecker::typeCheckCheckedCast(
+      t1, t2, CheckedCastContextKind::None, dc);
   return (kind != CheckedCastKind::Unresolved);
 }
 
@@ -1559,24 +1558,10 @@ void ConstraintSystem::print(raw_ostream &out) const {
 }
 
 /// Determine the semantics of a checked cast operation.
-CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
-                                                  Type toType,
-                                                  CheckedCastContextKind contextKind,
-                                                  DeclContext *dc,
-                                                  SourceLoc diagLoc,
-                                                  Expr *fromExpr,
-                                                  SourceRange diagToRange) {
-  // Determine whether we should suppress diagnostics.
-  const bool suppressDiagnostics =
-      contextKind == CheckedCastContextKind::None ||
-      contextKind == CheckedCastContextKind::Coercion;
-  assert((suppressDiagnostics || diagLoc.isValid()) &&
-         "diagnostics require a valid source location");
-
-  SourceRange diagFromRange;
-  if (fromExpr)
-    diagFromRange = fromExpr->getSourceRange();
-  
+CheckedCastKind
+TypeChecker::typeCheckCheckedCast(Type fromType, Type toType,
+                                  CheckedCastContextKind contextKind,
+                                  DeclContext *dc) {
   // If the from/to types are equivalent or convertible, this is a coercion.
   bool unwrappedIUO = false;
   if (fromType->isEqual(toType) ||
@@ -1594,31 +1579,20 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
     return CheckedCastKind::BridgingCoercion;
   }
 
-  Type origFromType = fromType;
-  Type origToType = toType;
-
   auto *module = dc->getParentModule();
-
-  auto &diags = dc->getASTContext().Diags;
   bool optionalToOptionalCast = false;
 
   // Local function to indicate failure.
   auto failed = [&] {
-    if (suppressDiagnostics) {
+    if (contextKind == CheckedCastContextKind::Coercion)
       return CheckedCastKind::Unresolved;
-    }
 
     // Explicit optional-to-optional casts always succeed because a nil
     // value of any optional type can be cast to any other optional type.
     if (optionalToOptionalCast)
       return CheckedCastKind::ValueCast;
 
-    diags.diagnose(diagLoc, diag::downcast_to_unrelated, origFromType,
-                   origToType)
-      .highlight(diagFromRange)
-      .highlight(diagToRange);
-
-    return CheckedCastKind::ValueCast;
+    return CheckedCastKind::Unresolved;
   };
 
   // TODO: Explore optionals using the same strategy used by the
@@ -1647,9 +1621,8 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
   // downcast. Complain.
   auto &Context = dc->getASTContext();
   if (extraFromOptionals > 0) {
-    switch (typeCheckCheckedCast(fromType, toType,
-                                 CheckedCastContextKind::None, dc,
-                                 SourceLoc(), nullptr, SourceRange())) {
+    switch (typeCheckCheckedCast(fromType, toType, CheckedCastContextKind::None,
+                                 dc)) {
     case CheckedCastKind::Coercion:
     case CheckedCastKind::BridgingCoercion: {
       // Treat this as a value cast so we preserve the semantics.
@@ -1670,7 +1643,7 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
   auto checkElementCast = [&](Type fromElt, Type toElt,
                               CheckedCastKind castKind) -> CheckedCastKind {
     switch (typeCheckCheckedCast(fromElt, toElt, CheckedCastContextKind::None,
-                                 dc, SourceLoc(), nullptr, SourceRange())) {
+                                 dc)) {
     case CheckedCastKind::Coercion:
       return CheckedCastKind::Coercion;
 
@@ -1685,13 +1658,13 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
 
     case CheckedCastKind::Unresolved:
       // Even though we know the elements cannot be downcast, we cannot return
-      // failed() here as it's possible for an empty Array, Set or Dictionary to
-      // be cast to any element type at runtime (SR-6192). The one exception to
-      // this is when we're checking whether we can treat a coercion as a checked
-      // cast because we don't want to tell the user to use as!, as it's probably
-      // the wrong suggestion.
+      // Unresolved here as it's possible for an empty Array, Set or Dictionary
+      // to be cast to any element type at runtime (SR-6192). The one exception
+      // to this is when we're checking whether we can treat a coercion as a
+      // checked cast because we don't want to tell the user to use as!, as it's
+      // probably the wrong suggestion.
       if (contextKind == CheckedCastContextKind::Coercion)
-        return failed();
+        return CheckedCastKind::Unresolved;
       return castKind;
     }
     llvm_unreachable("invalid cast type");
@@ -1712,8 +1685,7 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
         hasBridgingConversion = NoBridging;
       bool hasCast = false;
       switch (typeCheckCheckedCast(fromKeyValue->first, toKeyValue->first,
-                                   CheckedCastContextKind::None, dc,
-                                   SourceLoc(), nullptr, SourceRange())) {
+                                   CheckedCastContextKind::None, dc)) {
       case CheckedCastKind::Coercion:
         hasCoercion = true;
         break;
@@ -1727,7 +1699,7 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
         // Handled the same as in checkElementCast; see comment there for
         // rationale.
         if (contextKind == CheckedCastContextKind::Coercion)
-          return failed();
+          return CheckedCastKind::Unresolved;
         LLVM_FALLTHROUGH;
 
       case CheckedCastKind::ArrayDowncast:
@@ -1739,8 +1711,7 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
       }
 
       switch (typeCheckCheckedCast(fromKeyValue->second, toKeyValue->second,
-                                   CheckedCastContextKind::None, dc,
-                                   SourceLoc(), nullptr, SourceRange())) {
+                                   CheckedCastContextKind::None, dc)) {
       case CheckedCastKind::Coercion:
         hasCoercion = true;
         break;
@@ -1754,7 +1725,7 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
         // Handled the same as in checkElementCast; see comment there for
         // rationale.
         if (contextKind == CheckedCastContextKind::Coercion)
-          return failed();
+          return CheckedCastKind::Unresolved;
         LLVM_FALLTHROUGH;
 
       case CheckedCastKind::ArrayDowncast:
@@ -1836,31 +1807,14 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
   if (fromFunctionType &&
       (toExistentialType || (toArchetypeType && toConstrainedArchetype))) {
     switch (contextKind) {
+    case CheckedCastContextKind::None:
     case CheckedCastContextKind::ConditionalCast:
     case CheckedCastContextKind::ForcedCast:
-      diags.diagnose(diagLoc, diag::downcast_to_unrelated, origFromType,
-                     origToType)
-          .highlight(diagFromRange)
-          .highlight(diagToRange);
-
-      // If we're referring to a function with a return value (not Void) then
-      // emit a fix-it suggesting to add `()` to call the function
-      if (auto DRE = dyn_cast<DeclRefExpr>(fromExpr)) {
-        if (auto FD = dyn_cast<FuncDecl>(DRE->getDecl())) {
-          if (!FD->getResultInterfaceType()->isVoid()) {
-            diags.diagnose(diagLoc, diag::downcast_to_unrelated_fixit,
-                           FD->getBaseIdentifier())
-                .fixItInsertAfter(fromExpr->getEndLoc(), "()");
-          }
-        }
-      }
-
-      return CheckedCastKind::ValueCast;
+      return CheckedCastKind::Unresolved;
 
     case CheckedCastContextKind::IsPattern:
     case CheckedCastContextKind::EnumElementPattern:
     case CheckedCastContextKind::IsExpr:
-    case CheckedCastContextKind::None:
     case CheckedCastContextKind::Coercion:
       break;
     }
@@ -1870,8 +1824,7 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
   if (Type bridgedToClass = getDynamicBridgedThroughObjCClass(dc, fromType,
                                                               toType)) {
     switch (typeCheckCheckedCast(bridgedToClass, fromType,
-                                 CheckedCastContextKind::None, dc, SourceLoc(),
-                                 nullptr, SourceRange())) {
+                                 CheckedCastContextKind::None, dc)) {
     case CheckedCastKind::ArrayDowncast:
     case CheckedCastKind::BridgingCoercion:
     case CheckedCastKind::Coercion:
@@ -1889,8 +1842,7 @@ CheckedCastKind TypeChecker::typeCheckCheckedCast(Type fromType,
   if (Type bridgedFromClass = getDynamicBridgedThroughObjCClass(dc, toType,
                                                                 fromType)) {
     switch (typeCheckCheckedCast(toType, bridgedFromClass,
-                                 CheckedCastContextKind::None, dc, SourceLoc(),
-                                 nullptr, SourceRange())) {
+                                 CheckedCastContextKind::None, dc)) {
     case CheckedCastKind::ArrayDowncast:
     case CheckedCastKind::BridgingCoercion:
     case CheckedCastKind::Coercion:

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -666,18 +666,15 @@ bool typeCheckCondition(Expr *&expr, DeclContext *dc);
 ///
 /// \param fromType       The source type of the cast.
 /// \param toType         The destination type of the cast.
+/// \param contextKind    The cast context in which this is being typechecked.
 /// \param dc             The context of the cast.
-/// \param diagLoc        The location at which to report diagnostics.
-/// \param fromExpr       The expression describing the input operand.
-/// \param diagToRange    The source range of the destination type.
 ///
 /// \returns a CheckedCastKind indicating the semantics of the cast. If the
 /// cast is invalid, Unresolved is returned. If the cast represents an implicit
 /// conversion, Coercion is returned.
 CheckedCastKind typeCheckCheckedCast(Type fromType, Type toType,
-                                     CheckedCastContextKind ctxKind,
-                                     DeclContext *dc, SourceLoc diagLoc,
-                                     Expr *fromExpr, SourceRange diagToRange);
+                                     CheckedCastContextKind contextKind,
+                                     DeclContext *dc);
 
 /// Find the Objective-C class that bridges between a value of the given
 /// dynamic type and the given value type.

--- a/test/Misc/misc_diagnostics.swift
+++ b/test/Misc/misc_diagnostics.swift
@@ -170,8 +170,28 @@ func tuple_splat2(_ q : (a : Int, b : Int)) {
 }
 
 // SR-1612: Type comparison of foreign types is always true.
-func is_foreign(a: AnyObject) -> Bool {
+protocol SR1612_P {}
+class SR1612: NSObject, SR1612_P {}
+// Existentials
+func is_foreign_anyobject(a: AnyObject) -> Bool {
   return a is CGColor // expected-warning {{'is' test is always true because 'CGColor' is a Core Foundation type}}
+}
+
+func is_foreign_any(a: Any) -> Bool {
+  return a is CGColor // expected-warning {{'is' test is always true because 'CGColor' is a Core Foundation type}}
+}
+
+func is_foreign_p(a: SR1612_P) -> Bool {
+  return a is CGColor // expected-warning {{'is' test is always true because 'CGColor' is a Core Foundation type}}
+}
+
+// Concrete type.
+func is_foreign_concrete(a: SR1612) -> Bool {
+  return a is CGColor // False at runtime
+}
+// Concrete foundation.
+func is_foreign_s(a: NSString) -> Bool {
+  return a is CGColor // False at runtime
 }
 
 func test_implicit_cgfloat_conversion() {
@@ -187,14 +207,14 @@ func test_implicit_cgfloat_conversion() {
   test_to(d + d) // Ok (Double -> CGFloat for both arguments)
   test_to(d + cgf) // Ok
   test_to(d + cgf - d) // Ok (prefer CGFloat -> Double for `cgf`), it's a better solution than trying to convert `d`s to `CGFloat`
-  test_to(d + cgf - cgf) // Ok (only one choice here to conver `d` to CGFloat)
+  test_to(d + cgf - cgf) // Ok (only one choice here to convert `d` to CGFloat)
 
   test_from(cgf) // Ok (CGFloat -> Double)
   test_from(f) // expected-error {{cannot convert value of type 'Float' to expected argument type 'Double'}}
   test_from(cgf + cgf) // Ok (CGFloat -> Double for both arguments)
   test_from(d + cgf) // Ok
   test_from(cgf + d - cgf) // (prefer Double -> CGFloat for `d`), it's a better solution than trying to convert `cgf`s to `Double`
-  test_from(cgf + d - d) // Ok (only one choice here to conver `cgf` to Double)
+  test_from(cgf + d - d) // Ok (only one choice here to convert `cgf` to Double)
 
   func test_returns_double(_: CGFloat) -> Double {
     42.0

--- a/test/expr/cast/as_coerce.swift
+++ b/test/expr/cast/as_coerce.swift
@@ -118,14 +118,18 @@ func sr6022() -> Any { return 0 }
 func sr6022_1() { return; }
 protocol SR6022_P {}
 
+_ = sr6022 is SR6022_P // expected-warning {{cast from '() -> Any' to unrelated type 'any SR6022_P' always fails}} // expected-note {{did you mean to call 'sr6022' with '()'?}}{{11-11=()}}
 _ = sr6022 as! SR6022_P // expected-warning {{cast from '() -> Any' to unrelated type 'any SR6022_P' always fails}} // expected-note {{did you mean to call 'sr6022' with '()'?}}{{11-11=()}}
 _ = sr6022 as? SR6022_P // expected-warning {{cast from '() -> Any' to unrelated type 'any SR6022_P' always fails}} // expected-note {{did you mean to call 'sr6022' with '()'}}{{11-11=()}}
+_ = sr6022_1 is SR6022_P // expected-warning {{cast from '() -> ()' to unrelated type 'any SR6022_P' always fails}}
 _ = sr6022_1 as! SR6022_P // expected-warning {{cast from '() -> ()' to unrelated type 'any SR6022_P' always fails}}
 _ = sr6022_1 as? SR6022_P // expected-warning {{cast from '() -> ()' to unrelated type 'any SR6022_P' always fails}}
 
 func testSR6022_P<T: SR6022_P>(_: T.Type) {
+  _ = sr6022 is T // expected-warning {{cast from '() -> Any' to unrelated type 'T' always fails}} // expected-note {{did you mean to call 'sr6022' with '()'?}}{{13-13=()}}
   _ = sr6022 as! T // expected-warning {{cast from '() -> Any' to unrelated type 'T' always fails}} // expected-note {{did you mean to call 'sr6022' with '()'?}}{{13-13=()}}
   _ = sr6022 as? T // expected-warning {{cast from '() -> Any' to unrelated type 'T' always fails}} // expected-note {{did you mean to call 'sr6022' with '()'?}}{{13-13=()}}
+  _ = sr6022_1 is T // expected-warning {{cast from '() -> ()' to unrelated type 'T' always fails}}
   _ = sr6022_1 as! T // expected-warning {{cast from '() -> ()' to unrelated type 'T' always fails}}
   _ = sr6022_1 as? T // expected-warning {{cast from '() -> ()' to unrelated type 'T' always fails}}
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
The idea here is to improve a little bit the `TypeChecker::typeCheckCheckedCast` by decoupling diagnostic emitting logic from it. The improvements are both in the removing all extra diagnostic code and moving them to solver based fix format but also in the method signature as well by removing diagnostic specific parameters which in many cases were passed as `SourceLoc(), nullptr, SourceRange()`. This is not much but I think it could be a small win, so let me know what you think.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
No related to any SR.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
