### PR TITLE
 Make @preconcurrency import hide sendable variance

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -650,10 +650,17 @@ DiagnosticBehavior SendableCheckContext::defaultDiagnosticBehavior() const {
   return defaultSendableDiagnosticBehavior(fromDC->getASTContext().LangOpts);
 }
 
-/// Determine whether the given nominal type that is within the current module
-/// has an explicit Sendable.
-static bool hasExplicitSendableConformance(NominalTypeDecl *nominal) {
+/// Determine whether the given nominal type has an explicit Sendable
+/// conformance (regardless of its availability).
+static bool hasExplicitSendableConformance(NominalTypeDecl *nominal,
+                                           bool applyModuleDefault = true) {
   ASTContext &ctx = nominal->getASTContext();
+  auto nominalModule = nominal->getParentModule();
+
+  // In a concurrency-checked module, a missing conformance is equivalent to
+  // an explicitly unavailable one. If we want to apply this rule, do so now.
+  if (applyModuleDefault && nominalModule->isConcurrencyChecked())
+    return true;
 
   // Look for any conformance to `Sendable`.
   auto proto = ctx.getProtocol(KnownProtocolKind::Sendable);
@@ -662,7 +669,7 @@ static bool hasExplicitSendableConformance(NominalTypeDecl *nominal) {
 
   // Look for a conformance. If it's present and not (directly) missing,
   // we're done.
-  auto conformance = nominal->getParentModule()->lookupConformance(
+  auto conformance = nominalModule->lookupConformance(
       nominal->getDeclaredInterfaceType(), proto, /*allowMissing=*/true);
   return conformance &&
       !(isa<BuiltinProtocolConformance>(conformance.getConcrete()) &&
@@ -706,18 +713,13 @@ static Optional<AttributedImport<ImportedModule>> findImportFor(
 /// nominal type.
 DiagnosticBehavior SendableCheckContext::diagnosticBehavior(
     NominalTypeDecl *nominal) const {
-  // Determine whether the type was explicitly non-Sendable.
-  auto nominalModule = nominal->getParentModule();
-  bool isExplicitlyNonSendable = nominalModule->isConcurrencyChecked() ||
-      hasExplicitSendableConformance(nominal);
-
   // Determine whether this nominal type is visible via a @preconcurrency
   // import.
   auto import = findImportFor(nominal, fromDC);
+  auto sourceFile = fromDC->getParentSourceFile();
 
   // When the type is explicitly non-Sendable...
-  auto sourceFile = fromDC->getParentSourceFile();
-  if (isExplicitlyNonSendable) {
+  if (hasExplicitSendableConformance(nominal)) {
     // @preconcurrency imports downgrade the diagnostic to a warning in Swift 6,
     if (import && import->options.contains(ImportFlags::Preconcurrency)) {
       if (sourceFile)
@@ -737,7 +739,7 @@ DiagnosticBehavior SendableCheckContext::diagnosticBehavior(
     if (sourceFile)
       sourceFile->setImportUsedPreconcurrency(*import);
 
-    return nominalModule->getASTContext().LangOpts.isSwiftVersionAtLeast(6)
+    return nominal->getASTContext().LangOpts.isSwiftVersionAtLeast(6)
         ? DiagnosticBehavior::Warning
         : DiagnosticBehavior::Ignore;
   }
@@ -797,29 +799,34 @@ static bool diagnoseSingleNonSendableType(
         diag::non_sendable_nominal, nominal->getDescriptiveKind(),
         nominal->getName());
 
-    // This type was imported from another module; try to find the
-    // corresponding import.
-    Optional<AttributedImport<swift::ImportedModule>> import;
-    SourceFile *sourceFile = fromContext.fromDC->getParentSourceFile();
-    if (sourceFile) {
-      import = findImportFor(nominal, fromContext.fromDC);
-    }
+    // When the type is explicitly Sendable *or* explicitly non-Sendable, we
+    // assume it has been audited and `@preconcurrency` is not recommended even
+    // though it would actually affect the diagnostic.
+    if (!hasExplicitSendableConformance(nominal)) {
+      // This type was imported from another module; try to find the
+      // corresponding import.
+      Optional<AttributedImport<swift::ImportedModule>> import;
+      SourceFile *sourceFile = fromContext.fromDC->getParentSourceFile();
+      if (sourceFile) {
+        import = findImportFor(nominal, fromContext.fromDC);
+      }
 
-    // If we found the import that makes this nominal type visible, remark
-    // that it can be @preconcurrency import.
-    // Only emit this remark once per source file, because it can happen a
-    // lot.
-    if (import && !import->options.contains(ImportFlags::Preconcurrency) &&
-        import->importLoc.isValid() && sourceFile &&
-        !sourceFile->hasImportUsedPreconcurrency(*import)) {
-      SourceLoc importLoc = import->importLoc;
-      ctx.Diags.diagnose(
-          importLoc, diag::add_predates_concurrency_import,
-          ctx.LangOpts.isSwiftVersionAtLeast(6),
-          nominal->getParentModule()->getName())
-        .fixItInsert(importLoc, "@preconcurrency ");
+      // If we found the import that makes this nominal type visible, remark
+      // that it can be @preconcurrency import.
+      // Only emit this remark once per source file, because it can happen a
+      // lot.
+      if (import && !import->options.contains(ImportFlags::Preconcurrency) &&
+          import->importLoc.isValid() && sourceFile &&
+          !sourceFile->hasImportUsedPreconcurrency(*import)) {
+        SourceLoc importLoc = import->importLoc;
+        ctx.Diags.diagnose(
+            importLoc, diag::add_predates_concurrency_import,
+            ctx.LangOpts.isSwiftVersionAtLeast(6),
+            nominal->getParentModule()->getName())
+          .fixItInsert(importLoc, "@preconcurrency ");
 
-      sourceFile->setImportUsedPreconcurrency(*import);
+        sourceFile->setImportUsedPreconcurrency(*import);
+      }
     }
   }
 
@@ -1036,7 +1043,7 @@ void swift::diagnoseMissingExplicitSendable(NominalTypeDecl *nominal) {
     return;
 
   // If the conformance is explicitly stated, do nothing.
-  if (hasExplicitSendableConformance(nominal))
+  if (hasExplicitSendableConformance(nominal, /*applyModuleDefault=*/false))
     return;
 
   // Diagnose it.

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -757,80 +757,105 @@ DiagnosticBehavior SendableCheckContext::diagnosticBehavior(
   return defaultBehavior;
 }
 
-/// Produce a diagnostic for a single instance of a non-Sendable type where
-/// a Sendable type is required.
-static bool diagnoseSingleNonSendableType(
-    Type type, SendableCheckContext fromContext, SourceLoc loc,
-    llvm::function_ref<bool(Type, DiagnosticBehavior)> diagnose) {
-
+bool swift::diagnoseSendabilityErrorBasedOn(
+    NominalTypeDecl *nominal, SendableCheckContext fromContext,
+    llvm::function_ref<bool(DiagnosticBehavior)> diagnose) {
   auto behavior = DiagnosticBehavior::Unspecified;
 
-  auto module = fromContext.fromDC->getParentModule();
-  ASTContext &ctx = module->getASTContext();
-  auto nominal = type->getAnyNominal();
   if (nominal) {
     behavior = fromContext.diagnosticBehavior(nominal);
   } else {
     behavior = fromContext.defaultDiagnosticBehavior();
   }
 
-  bool wasSuppressed = diagnose(type, behavior);
+  bool wasSuppressed = diagnose(behavior);
 
-  if (behavior == DiagnosticBehavior::Ignore || wasSuppressed) {
-    // Don't emit any other diagnostics.
-  } else if (type->is<FunctionType>()) {
-    ctx.Diags.diagnose(loc, diag::nonsendable_function_type);
-  } else if (nominal && nominal->getParentModule() == module) {
-    // If the nominal type is in the current module, suggest adding
-    // `Sendable` if it might make sense. Otherwise, just complain.
-    if (isa<StructDecl>(nominal) || isa<EnumDecl>(nominal)) {
-      auto note = nominal->diagnose(
-          diag::add_nominal_sendable_conformance,
-          nominal->getDescriptiveKind(), nominal->getName());
-      addSendableFixIt(nominal, note, /*unchecked=*/false);
-    } else {
-      nominal->diagnose(
-          diag::non_sendable_nominal, nominal->getDescriptiveKind(),
-          nominal->getName());
+  bool emittedDiagnostics =
+      behavior != DiagnosticBehavior::Ignore && !wasSuppressed;
+
+  // When the type is explicitly Sendable *or* explicitly non-Sendable, we
+  // assume it has been audited and `@preconcurrency` is not recommended even
+  // though it would actually affect the diagnostic.
+  bool nominalIsImportedAndHasImplicitSendability =
+      nominal &&
+      nominal->getParentModule() != fromContext.fromDC->getParentModule() &&
+      !hasExplicitSendableConformance(nominal);
+
+  if (emittedDiagnostics && nominalIsImportedAndHasImplicitSendability) {
+    // This type was imported from another module; try to find the
+    // corresponding import.
+    Optional<AttributedImport<swift::ImportedModule>> import;
+    SourceFile *sourceFile = fromContext.fromDC->getParentSourceFile();
+    if (sourceFile) {
+      import = findImportFor(nominal, fromContext.fromDC);
     }
-  } else if (nominal) {
-    // Note which nominal type does not conform to `Sendable`.
-    nominal->diagnose(
-        diag::non_sendable_nominal, nominal->getDescriptiveKind(),
-        nominal->getName());
 
-    // When the type is explicitly Sendable *or* explicitly non-Sendable, we
-    // assume it has been audited and `@preconcurrency` is not recommended even
-    // though it would actually affect the diagnostic.
-    if (!hasExplicitSendableConformance(nominal)) {
-      // This type was imported from another module; try to find the
-      // corresponding import.
-      Optional<AttributedImport<swift::ImportedModule>> import;
-      SourceFile *sourceFile = fromContext.fromDC->getParentSourceFile();
-      if (sourceFile) {
-        import = findImportFor(nominal, fromContext.fromDC);
-      }
+    // If we found the import that makes this nominal type visible, remark
+    // that it can be @preconcurrency import.
+    // Only emit this remark once per source file, because it can happen a
+    // lot.
+    if (import && !import->options.contains(ImportFlags::Preconcurrency) &&
+        import->importLoc.isValid() && sourceFile &&
+        !sourceFile->hasImportUsedPreconcurrency(*import)) {
+      SourceLoc importLoc = import->importLoc;
+      ASTContext &ctx = nominal->getASTContext();
 
-      // If we found the import that makes this nominal type visible, remark
-      // that it can be @preconcurrency import.
-      // Only emit this remark once per source file, because it can happen a
-      // lot.
-      if (import && !import->options.contains(ImportFlags::Preconcurrency) &&
-          import->importLoc.isValid() && sourceFile &&
-          !sourceFile->hasImportUsedPreconcurrency(*import)) {
-        SourceLoc importLoc = import->importLoc;
-        ctx.Diags.diagnose(
-            importLoc, diag::add_predates_concurrency_import,
-            ctx.LangOpts.isSwiftVersionAtLeast(6),
-            nominal->getParentModule()->getName())
-          .fixItInsert(importLoc, "@preconcurrency ");
+      ctx.Diags.diagnose(
+          importLoc, diag::add_predates_concurrency_import,
+          ctx.LangOpts.isSwiftVersionAtLeast(6),
+          nominal->getParentModule()->getName())
+        .fixItInsert(importLoc, "@preconcurrency ");
 
-        sourceFile->setImportUsedPreconcurrency(*import);
-      }
+      sourceFile->setImportUsedPreconcurrency(*import);
     }
   }
 
   return behavior == DiagnosticBehavior::Unspecified && !wasSuppressed;
+}
+
+/// Produce a diagnostic for a single instance of a non-Sendable type where
+/// a Sendable type is required.
+static bool diagnoseSingleNonSendableType(
+    Type type, SendableCheckContext fromContext, SourceLoc loc,
+    llvm::function_ref<bool(Type, DiagnosticBehavior)> diagnose) {
+
+  auto module = fromContext.fromDC->getParentModule();
+  auto nominal = type->getAnyNominal();
+
+  return diagnoseSendabilityErrorBasedOn(nominal, fromContext,
+                                         [&](DiagnosticBehavior behavior) {
+    bool wasSuppressed = diagnose(type, behavior);
+
+    // Don't emit the following notes if we didn't have any diagnostics to
+    // attach them to.
+    if (wasSuppressed || behavior == DiagnosticBehavior::Ignore)
+      return true;
+
+    if (type->is<FunctionType>()) {
+      module->getASTContext().Diags
+          .diagnose(loc, diag::nonsendable_function_type);
+    } else if (nominal && nominal->getParentModule() == module) {
+      // If the nominal type is in the current module, suggest adding
+      // `Sendable` if it might make sense. Otherwise, just complain.
+      if (isa<StructDecl>(nominal) || isa<EnumDecl>(nominal)) {
+        auto note = nominal->diagnose(
+            diag::add_nominal_sendable_conformance,
+            nominal->getDescriptiveKind(), nominal->getName());
+        addSendableFixIt(nominal, note, /*unchecked=*/false);
+      } else {
+        nominal->diagnose(
+            diag::non_sendable_nominal, nominal->getDescriptiveKind(),
+            nominal->getName());
+      }
+    } else if (nominal) {
+      // Note which nominal type does not conform to `Sendable`.
+      nominal->diagnose(
+          diag::non_sendable_nominal, nominal->getDescriptiveKind(),
+          nominal->getName());
+    }
+
+    return false;
+  });
 }
 
 bool swift::diagnoseNonSendableTypes(

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -353,9 +353,10 @@ struct SendableCheckContext {
 ///
 /// \param diagnose Emit a diagnostic indicating that the current type
 /// is non-Sendable, with the suggested behavior limitation. Returns \c true
-/// if an error was produced.
+/// if it did not emit any diagnostics.
 ///
-/// \returns \c true if any diagnostics were produced, \c false otherwise.
+/// \returns \c true if any errors were produced, \c false if no diagnostics or
+/// only warnings and notes were produced.
 bool diagnoseNonSendableTypes(
     Type type, SendableCheckContext fromContext, SourceLoc loc,
     llvm::function_ref<bool(Type, DiagnosticBehavior)> diagnose);
@@ -370,7 +371,8 @@ namespace detail {
 /// Diagnose any non-Sendable types that occur within the given type, using
 /// the given diagnostic.
 ///
-/// \returns \c true if any errors were produced, \c false otherwise.
+/// \returns \c true if any errors were produced, \c false if no diagnostics or
+/// only warnings and notes were produced.
 template<typename ...DiagArgs>
 bool diagnoseNonSendableTypes(
     Type type, SendableCheckContext fromContext, SourceLoc loc,
@@ -388,6 +390,26 @@ bool diagnoseNonSendableTypes(
     return false;
   });
 }
+
+/// Diagnose this sendability error with behavior based on the import of
+/// \p nominal . For instance, depending on how \p nominal is imported into
+/// \p fromContext , the diagnostic behavior limitation may be lower or the
+/// compiler might emit a fix-it adding \c \@preconcurrency to the \c import .
+///
+/// \param nominal The declaration whose import we should check, or \c nullptr
+/// to get behavior for a non-nominal type.
+///
+/// \param fromContext The context where the error will be emitted.
+///
+/// \param diagnose Emit a diagnostic indicating a sendability problem,
+/// with the suggested behavior limitation. Returns \c true
+/// if it did \em not emit any diagnostics.
+///
+/// \returns \c true if any errors were produced, \c false if no diagnostics or
+/// only warnings and notes were produced.
+bool diagnoseSendabilityErrorBasedOn(
+    NominalTypeDecl *nominal, SendableCheckContext fromContext,
+    llvm::function_ref<bool(DiagnosticBehavior)> diagnose);
 
 /// Given a set of custom attributes, pick out the global actor attributes
 /// and perform any necessary resolution and diagnostics, returning the

--- a/test/Concurrency/Inputs/NonStrictModule.swift
+++ b/test/Concurrency/Inputs/NonStrictModule.swift
@@ -1,3 +1,11 @@
-public class NonStrictClass { }
-
 public struct NonStrictStruct { }
+
+open class NonStrictClass {
+  open func send(_ body: @Sendable () -> Void) {}
+  open func dontSend(_ body: () -> Void) {}
+}
+
+public protocol NonStrictProtocol {
+  func send(_ body: @Sendable () -> Void)
+  func dontSend(_ body: () -> Void)
+}

--- a/test/Concurrency/Inputs/StrictModule.swift
+++ b/test/Concurrency/Inputs/StrictModule.swift
@@ -1,3 +1,11 @@
 public struct StrictStruct: Hashable { }
 
-open class StrictClass { }
+open class StrictClass {
+  open func send(_ body: @Sendable () -> Void) {}
+  open func dontSend(_ body: () -> Void) {}
+}
+
+public protocol StrictProtocol {
+  func send(_ body: @Sendable () -> Void)
+  func dontSend(_ body: () -> Void)
+}

--- a/test/Concurrency/Inputs/StrictModule.swift
+++ b/test/Concurrency/Inputs/StrictModule.swift
@@ -1,1 +1,3 @@
 public struct StrictStruct: Hashable { }
+
+open class StrictClass { }

--- a/test/Concurrency/sendable_preconcurrency.swift
+++ b/test/Concurrency/sendable_preconcurrency.swift
@@ -39,3 +39,23 @@ func testA(ns: NS, mt: MyType, mt2: MyType2, mt3: MyType3, sc: StrictClass, nsc:
 }
 
 extension NonStrictStruct: @unchecked Sendable { }
+
+class StrictSubclass: StrictClass {
+  override func send(_ body: () -> ()) {}
+  override func dontSend(_ body: @Sendable () -> ()) {} // expected-warning {{declaration 'dontSend' has a type with different sendability from any potential overrides}}
+}
+
+struct StrictConformer: StrictProtocol {
+  func send(_ body: () -> Void) {}
+  func dontSend(_ body: @Sendable () -> Void) {} // expected-warning {{sendability of function types in instance method 'dontSend' does not match requirement in protocol 'StrictProtocol'}}
+}
+
+class NonStrictSubclass: NonStrictClass {
+  override func send(_ body: () -> ()) {}
+  override func dontSend(_ body: @Sendable () -> ()) {} // no-warning
+}
+
+struct NonStrictConformer: NonStrictProtocol {
+  func send(_ body: () -> Void) {}
+  func dontSend(_ body: @Sendable () -> Void) {} // no-warning
+}

--- a/test/Concurrency/sendable_preconcurrency.swift
+++ b/test/Concurrency/sendable_preconcurrency.swift
@@ -5,7 +5,7 @@
 
 // REQUIRES: concurrency
 
-import StrictModule
+import StrictModule // no remark: we never recommend @preconcurrency due to an explicitly non-Sendable (via -warn-concurrency) type
 @preconcurrency import NonStrictModule
 
 actor A {
@@ -27,12 +27,14 @@ struct MyType3 {
   var nsc: NonStrictClass
 }
 
-func testA(ns: NS, mt: MyType, mt2: MyType2, mt3: MyType3) async {
+func testA(ns: NS, mt: MyType, mt2: MyType2, mt3: MyType3, sc: StrictClass, nsc: NonStrictClass) async {
   Task {
     print(ns) // expected-warning{{capture of 'ns' with non-sendable type 'NS' in a `@Sendable` closure}}
     print(mt) // no warning: MyType is Sendable because we suppressed NonStrictClass's warning
     print(mt2)
     print(mt3)
+    print(sc) // expected-warning {{capture of 'sc' with non-sendable type 'StrictClass' in a `@Sendable` closure}}
+    print(nsc)
   }
 }
 

--- a/test/Concurrency/sendable_without_preconcurrency.swift
+++ b/test/Concurrency/sendable_without_preconcurrency.swift
@@ -5,7 +5,7 @@
 
 // REQUIRES: concurrency
 
-import StrictModule
+import StrictModule // no remark: we never recommend @preconcurrency due to an explicitly non-Sendable (via -warn-concurrency) type
 import NonStrictModule
 
 actor A {
@@ -23,11 +23,12 @@ struct MyType2 { // expected-note{{consider making struct 'MyType2' conform to t
   var ns: NS
 }
 
-func testA(ns: NS, mt: MyType, mt2: MyType2) async {
+func testA(ns: NS, mt: MyType, mt2: MyType2, sc: StrictClass, nsc: NonStrictClass) async {
   Task {
     print(ns) // expected-warning{{capture of 'ns' with non-sendable type 'NS' in a `@Sendable` closure}}
     print(mt) // no warning: MyType is Sendable because we suppressed NonStrictClass's warning
     print(mt2) // expected-warning{{capture of 'mt2' with non-sendable type 'MyType2' in a `@Sendable` closure}}
+    print(sc) // expected-warning{{capture of 'sc' with non-sendable type 'StrictClass' in a `@Sendable` closure}}
   }
 }
 

--- a/test/Concurrency/sendable_without_preconcurrency.swift
+++ b/test/Concurrency/sendable_without_preconcurrency.swift
@@ -33,3 +33,23 @@ func testA(ns: NS, mt: MyType, mt2: MyType2, sc: StrictClass, nsc: NonStrictClas
 }
 
 extension NonStrictStruct: @unchecked Sendable { }
+
+class StrictSubclass: StrictClass {
+  override func send(_ body: () -> ()) {}
+  override func dontSend(_ body: () -> ()) {}
+}
+
+struct StrictConformer: StrictProtocol {
+  func send(_ body: () -> Void) {}
+  func dontSend(_ body: () -> Void) {}
+}
+
+class NonStrictSubclass: NonStrictClass {
+  override func send(_ body: () -> ()) {}
+  override func dontSend(_ body: () -> ()) {}
+}
+
+struct NonStrictConformer: NonStrictProtocol {
+  func send(_ body: () -> Void) {}
+  func dontSend(_ body: () -> Void) {}
+}

--- a/test/Concurrency/sendable_without_preconcurrency_2.swift
+++ b/test/Concurrency/sendable_without_preconcurrency_2.swift
@@ -5,7 +5,7 @@
 
 // REQUIRES: concurrency
 
-import StrictModule
+import StrictModule // no remark: we never recommend @preconcurrency due to an explicitly non-Sendable (via -warn-concurrency) type
 import NonStrictModule // expected-remark{{add '@preconcurrency' to suppress 'Sendable'-related warnings from module 'NonStrictModule'}}
 
 actor A {
@@ -23,11 +23,13 @@ struct MyType2: Sendable {
   var ns: NS // expected-warning{{stored property 'ns' of 'Sendable'-conforming struct 'MyType2' has non-sendable type 'NS'}}
 }
 
-func testA(ns: NS, mt: MyType, mt2: MyType2) async {
+func testA(ns: NS, mt: MyType, mt2: MyType2, sc: StrictClass, nsc: NonStrictClass) async {
   Task {
     print(ns) // expected-warning{{capture of 'ns' with non-sendable type 'NS' in a `@Sendable` closure}}
     print(mt) // no warning: MyType is Sendable because we suppressed NonStrictClass's warning
     print(mt2)
+    print(sc) // expected-warning {{capture of 'sc' with non-sendable type 'StrictClass' in a `@Sendable` closure}}
+    print(nsc) // expected-warning {{capture of 'nsc' with non-sendable type 'NonStrictClass' in a `@Sendable` closure}}
   }
 }
 

--- a/test/Concurrency/sendable_without_preconcurrency_2.swift
+++ b/test/Concurrency/sendable_without_preconcurrency_2.swift
@@ -34,3 +34,23 @@ func testA(ns: NS, mt: MyType, mt2: MyType2, sc: StrictClass, nsc: NonStrictClas
 }
 
 extension NonStrictStruct: @unchecked Sendable { }
+
+class StrictSubclass: StrictClass {
+  override func send(_ body: () -> ()) {}
+  override func dontSend(_ body: @Sendable () -> ()) {} // expected-warning {{declaration 'dontSend' has a type with different sendability from any potential overrides}}
+}
+
+struct StrictConformer: StrictProtocol {
+  func send(_ body: () -> Void) {}
+  func dontSend(_ body: @Sendable () -> Void) {} // expected-warning {{sendability of function types in instance method 'dontSend' does not match requirement in protocol 'StrictProtocol'}}
+}
+
+class NonStrictSubclass: NonStrictClass {
+  override func send(_ body: () -> ()) {}
+  override func dontSend(_ body: @Sendable () -> ()) {} // expected-warning {{declaration 'dontSend' has a type with different sendability from any potential overrides}}
+}
+
+struct NonStrictConformer: NonStrictProtocol {
+  func send(_ body: () -> Void) {}
+  func dontSend(_ body: @Sendable () -> Void) {} // expected-warning {{sendability of function types in instance method 'dontSend' does not match requirement in protocol 'NonStrictProtocol'}}
+}

--- a/test/attr/attr_concurrent.swift
+++ b/test/attr/attr_concurrent.swift
@@ -135,8 +135,8 @@ class SuperSendable {
 
 class SubSendable: SuperSendable {
   override func runsInBackground(_: () -> Void) {}
-  override func runsInForeground(_: @Sendable () -> Void) {} // expected-warning {{declaration 'runsInForeground' has a type with different sendability from any potential overrides; this is an error in Swift 6}}
-  override func runnableInBackground() -> () -> Void { fatalError() }  // expected-warning {{declaration 'runnableInBackground()' has a type with different sendability from any potential overrides; this is an error in Swift 6}}
+  override func runsInForeground(_: @Sendable () -> Void) {} // expected-warning {{declaration 'runsInForeground' has a type with different sendability from any potential overrides}}
+  override func runnableInBackground() -> () -> Void { fatalError() }  // expected-warning {{declaration 'runnableInBackground()' has a type with different sendability from any potential overrides}}
   override func runnableInForeground() -> @Sendable () -> Void { fatalError() }
 }
 
@@ -149,7 +149,7 @@ protocol AbstractSendable {
 
 struct ConcreteSendable: AbstractSendable {
   func runsInBackground(_: () -> Void) {}
-  func runsInForeground(_: @Sendable () -> Void) {} // expected-warning {{sendability of function types in instance method 'runsInForeground' does not match requirement in protocol 'AbstractSendable'; this is an error in Swift 6}}
-  func runnableInBackground() -> () -> Void { fatalError() } // expected-warning {{sendability of function types in instance method 'runnableInBackground()' does not match requirement in protocol 'AbstractSendable'; this is an error in Swift 6}}
+  func runsInForeground(_: @Sendable () -> Void) {} // expected-warning {{sendability of function types in instance method 'runsInForeground' does not match requirement in protocol 'AbstractSendable'}}
+  func runnableInBackground() -> () -> Void { fatalError() } // expected-warning {{sendability of function types in instance method 'runnableInBackground()' does not match requirement in protocol 'AbstractSendable'}}
   func runnableInForeground() -> @Sendable () -> Void { fatalError() }
 }

--- a/test/decl/protocol/conforms/associated_type.swift
+++ b/test/decl/protocol/conforms/associated_type.swift
@@ -64,7 +64,7 @@ struct X1b : P1 {
 struct SendableX1b : P1 {
   typealias A = @Sendable (Int) -> Int
 
-  func f(_: (Int) -> Int) { } // expected-warning {{sendability of function types in instance method 'f' does not match requirement in protocol 'P1'; this is an error in Swift 6}}
+  func f(_: (Int) -> Int) { } // expected-warning {{sendability of function types in instance method 'f' does not match requirement in protocol 'P1'}}
 }
 
 struct X1c : P1 {
@@ -99,15 +99,15 @@ struct X2b : P2 { // expected-error{{type 'X2b' does not conform to protocol 'P2
 }
 
 struct X2c : P2 {
-  func f(_: @Sendable (Int) -> Int) { } // expected-warning{{sendability of function types in instance method 'f' does not match requirement in protocol 'P2'; this is an error in Swift 6}}
-  func g(_: @Sendable (Int) -> Int) { } // expected-warning{{sendability of function types in instance method 'g' does not match requirement in protocol 'P2'; this is an error in Swift 6}}
+  func f(_: @Sendable (Int) -> Int) { } // expected-warning{{sendability of function types in instance method 'f' does not match requirement in protocol 'P2'}}
+  func g(_: @Sendable (Int) -> Int) { } // expected-warning{{sendability of function types in instance method 'g' does not match requirement in protocol 'P2'}}
   func h(_: @Sendable (Int) -> Int) { }
   func i(_: @Sendable (Int) -> Int) { }
 }
 
 struct X2d : P2 { // expected-error{{type 'X2d' does not conform to protocol 'P2'}}
   func f(_: @escaping @Sendable (Int) -> Int) { } // expected-note{{candidate has non-matching type '(@escaping @Sendable (Int) -> Int) -> ()'}}
-  func g(_: @escaping @Sendable (Int) -> Int) { } // expected-warning{{sendability of function types in instance method 'g' does not match requirement in protocol 'P2'; this is an error in Swift 6}}
+  func g(_: @escaping @Sendable (Int) -> Int) { } // expected-warning{{sendability of function types in instance method 'g' does not match requirement in protocol 'P2'}}
   func h(_: @escaping @Sendable (Int) -> Int) { } // expected-note{{candidate has non-matching type '(@escaping @Sendable (Int) -> Int) -> ()'}}
   func i(_: @escaping @Sendable (Int) -> Int) { }
 }


### PR DESCRIPTION
When the conformance checker and override checker detect a difference in a function type’s `@Sendable` attribute that varies in an illegal way, they now check if the protocol/base class was imported with an `@preconcurrency import`, and either limit the diagnostic or suggest adding `@preconcurrency` to the import as appropriate.

Additionally, this PR makes it so we don't emit the remark recommending that `@preconcurrency` be added to an import if the type we're using has explicit sendability; after all, the author of the type has audited it and determined that any sendability problems in your code are not an error. Types in `isConcurrencyChecked()` modules are treated as always having explicit sendability for these purposes, since eventually we want to eliminate `isConcurrencyChecked()` and just serialize their public types as though they are explicitly non-sendable.

Completes rdar://91109455. Followup for #42194.