### PR TITLE
Add 'open' keyword in SwiftSyntax

### DIFF
--- a/utils/gyb_syntax_support/Token.py
+++ b/utils/gyb_syntax_support/Token.py
@@ -166,6 +166,7 @@ SYNTAX_TOKENS = [
     DeclKeyword('Private', 'private', serialization_code=20),
     DeclKeyword('Public', 'public', serialization_code=21),
     DeclKeyword('Static', 'static', serialization_code=22),
+    DeclKeyword('Open', 'open', serialization_code=125),
 
     # Statement keywords
     StmtKeyword('Defer', 'defer', serialization_code=23),


### PR DESCRIPTION
Signed-off-by: Mostfa <almme111@gmail.com>

<!-- What's in this pull request? -->
This pull request add support for 'open' keyword as TokenAccess 
and accessed in swift like this: `TokenSyntax.public`


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
