### PR TITLE
[move-function-dbginfo] Modify a test slightly to fix the arm64 bots and re-enable that test.

### DIFF
--- a/test/DebugInfo/move_function_dbginfo_async.swift
+++ b/test/DebugInfo/move_function_dbginfo_async.swift
@@ -3,8 +3,6 @@
 // RUN: %target-swift-frontend -parse-as-library -disable-availability-checking -g -c %s -o %t/out.o
 // RUN: %llvm-dwarfdump --show-children %t/out.o | %FileCheck -check-prefix=DWARF %s
 
-// REQUIRES: rdar91467528
-
 // This test checks that:
 //
 // 1. At the IR level, we insert the appropriate llvm.dbg.addr, llvm.dbg.value.
@@ -235,7 +233,9 @@ public func varSimpleTest<T>(_ msg: inout T, _ msg2: T) async {
 // DWARF-NEXT: DW_AT_name       ("k")
 //
 // DWARF:    DW_TAG_variable
-// DWARF-NEXT: DW_AT_location	(DW_OP_entry_value([[ASYNC_REG]]), DW_OP_deref, DW_OP_plus_uconst 0x10, DW_OP_plus_uconst 0x10)
+// We don't pattern match the actual entry value of "m" since we don't guarantee
+// it is an entry value since it isn't moved.
+// DWARF-NEXT: DW_AT_location
 // DWARF-NEXT: DW_AT_name ("m")
 //
 // DWARF: DW_AT_linkage_name	("$s3out16varSimpleTestVaryyYaFTY2_")
@@ -249,7 +249,9 @@ public func varSimpleTest<T>(_ msg: inout T, _ msg2: T) async {
 //
 // DWARF: DW_AT_linkage_name  ("$s3out16varSimpleTestVaryyYaFTQ3_")
 // DWARF: DW_TAG_variable
-// DWARF-NEXT: DW_AT_location  (DW_OP_entry_value([[ASYNC_REG]]), DW_OP_deref, DW_OP_plus_uconst 0x10, DW_OP_plus_uconst 0x10)
+// We don't pattern match the actual entry value of "m" since we don't guarantee
+// it is an entry value since it isn't moved.
+// DWARF-NEXT: DW_AT_location
 // DWARF-NEXT: DW_AT_name  ("m")
 // K is dead here.
 // DWARF: DW_TAG_variable
@@ -258,7 +260,9 @@ public func varSimpleTest<T>(_ msg: inout T, _ msg2: T) async {
 // We reinitialize k in 4.
 // DWARF: DW_AT_linkage_name  ("$s3out16varSimpleTestVaryyYaFTY4_")
 // DWARF: DW_TAG_variable
-// DWARF-NEXT: DW_AT_location  (DW_OP_entry_value([[ASYNC_REG]]), DW_OP_plus_uconst 0x10, DW_OP_plus_uconst 0x10)
+// We don't pattern match the actual entry value of "m" since we don't guarantee
+// it is an entry value since it isn't moved.
+// DWARF-NEXT: DW_AT_location
 // DWARF-NEXT: DW_AT_name  ("m")
 // DWARF: DW_TAG_variable
 // DWARF-NEXT: DW_AT_location  (0x{{[0-9a-f]+}}:


### PR DESCRIPTION
The pattern started to fail here since the variable "m" is not a variable that
we moved so as a result we use heuristics to determine if it should become an
entry value.

Noting that we only pattern match "m" to ensure that we can easily check the
variable "k" afterwards (the thing that was actually moved), I just loosened the
pattern so that we validate that we found "m" but do not check "m"'s
location. This guarantees that on all platforms this will pattern match
appropriately.

rdar://91467528
