### PR TITLE
[docs] Update "Print after LLVM IR" to mention disable-swift-specific-llvm-optzns.

### DIFF
--- a/docs/DebuggingTheCompiler.md
+++ b/docs/DebuggingTheCompiler.md
@@ -110,7 +110,7 @@ swiftc -g -emit-sil -O file.swift
 * **IRGen** To print the LLVM IR after IR generation:
 
 ```sh
-swiftc -emit-ir -Xfrontend -disable-llvm-optzns -O file.swift
+swiftc -emit-ir -Xfrontend -disable-llvm-optzns -Xfrontend -disable-swift-specific-llvm-optzns -O file.swift
 ```
 
 * **LLVM passes** To print the LLVM IR after LLVM passes:


### PR DESCRIPTION
Swift also has swift specific LLVM optzns that we run. To get the IR generation
right after IRGen, one needs both disable-llvm-optzns and
disable-swift-specific-llvm-optzns.

----

Just noticed this while talking with @ahmedbougacha 