### PR TITLE
[TypeChecker] Fix a crash in inherited default argument type-checking

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7099,12 +7099,19 @@ void ParamDecl::setDefaultExpr(Expr *E, bool isTypeChecked) {
            "Can't overwrite type-checked default with un-type-checked default");
   }
   defaultInfo->DefaultArg = E;
-  defaultInfo->ExprType = E->getType();
+  // `Inherited` default arguments do not have an expression,
+  // so if the storage has been pre-allocated already we need
+  // to be careful requesting type here.
+  defaultInfo->ExprType = E ? E->getType() : Type();
   defaultInfo->InitContextAndIsTypeChecked.setInt(isTypeChecked);
 }
 
 void ParamDecl::setDefaultExprType(Type type) {
   if (!DefaultValueAndFlags.getPointer()) {
+    // If there is no type, let's not allocate storage.
+    if (!type)
+      return;
+
     DefaultValueAndFlags.setPointer(
         getASTContext().Allocate<StoredDefaultArgument>());
   }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1065,8 +1065,10 @@ Expr *DefaultArgumentExprRequest::evaluate(Evaluator &evaluator,
 
 Type DefaultArgumentTypeRequest::evaluate(Evaluator &evaluator,
                                           ParamDecl *param) const {
-  if (auto expr = param->getTypeCheckedDefaultExpr())
-    return expr->getType();
+  if (auto *expr = param->getTypeCheckedDefaultExpr()) {
+    // If the request failed, let's not propagate ErrorType up.
+    return isa<ErrorExpr>(expr) ? Type() : expr->getType();
+  }
   return Type();
 }
 

--- a/test/Constraints/type_inference_from_default_exprs.swift
+++ b/test/Constraints/type_inference_from_default_exprs.swift
@@ -199,3 +199,35 @@ func test_allow_same_type_between_dependent_types() {
     s.test() // expected-error {{instance method 'test' requires the types 'String' and 'Default.X' (aka 'Int') be equivalent}}
   }
 }
+
+// Crash when default type is requested before inherited constructor is type-checked
+
+protocol StorageType {
+  var identifier: String { get }
+}
+
+class Storage {
+}
+
+extension Storage {
+  struct Test {
+    static let test = CustomStorage<String>("") // triggers default type request
+  }
+}
+
+class BaseStorage<T> : Storage, StorageType {
+  enum StorageType {
+  case standard
+  }
+
+  let identifier: String
+  let type: StorageType
+
+  init(_ id: String, type: StorageType = .standard) {
+    self.identifier = id
+    self.type = type
+  }
+}
+
+final class CustomStorage<T>: BaseStorage<T> { // Ok - no crash typechecking inherited init
+}


### PR DESCRIPTION
In some circumstances request for default type is made before
inherited constructor has been validated and storage has been
allocated for invalid type which then triggered a crash during
declaration checking.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
