### PR TITLE
IRGen: disable class fast casting on Windows

### DIFF
--- a/lib/IRGen/GenCast.cpp
+++ b/lib/IRGen/GenCast.cpp
@@ -1061,6 +1061,11 @@ llvm::Value *irgen::emitFastClassCastIfPossible(IRGenFunction &IGF,
                                                 llvm::Value *instance,
                                                 CanType sourceFormalType,
                                                 CanType targetFormalType) {
+  // Currently fast casting causes a miscompile on Windows.
+  // TODO: fix https://bugs.swift.org/browse/SR-16112 and enable fast casting on Windows.
+  if (IGF.IGM.Triple.isOSWindows())
+    return nullptr;
+
   if (!doesCastPreserveOwnershipForTypes(IGF.IGM.getSILModule(), sourceFormalType,
                                          targetFormalType)) {
     return nullptr;

--- a/test/Casting/fast_class_casts.swift
+++ b/test/Casting/fast_class_casts.swift
@@ -15,6 +15,8 @@
 
 // REQUIRES: executable_test
 
+// Currently fast casting causes a miscompile on Windows.
+// UNSUPPORTED: windows
 
 import Classes
 import ResilientClasses


### PR DESCRIPTION
It causes some problems on CI.
