### PR TITLE
[CursorInfo] Add Clang documentation to SymbolGraph output

### DIFF
--- a/include/swift/AST/ASTPrinter.h
+++ b/include/swift/AST/ASTPrinter.h
@@ -327,9 +327,6 @@ public:
     printStructurePre(Kind, D);
   }
 
-  /// To sanitize a malformed utf8 string to a well-formed one.
-  static std::string sanitizeUtf8(StringRef Text);
-
 private:
   virtual void anchor();
 };

--- a/include/swift/Basic/Unicode.h
+++ b/include/swift/Basic/Unicode.h
@@ -74,6 +74,9 @@ unsigned extractFirstUnicodeScalar(StringRef S);
 /// unit (Unicode scalar).
 bool isWellFormedUTF8(StringRef S);
 
+/// Replaces any ill-formed subsequences with `u8"\ufffd"`.
+std::string sanitizeUTF8(StringRef Text);
+
 } // end namespace unicode
 } // end namespace swift
 

--- a/include/swift/SymbolGraphGen/SymbolGraphOptions.h
+++ b/include/swift/SymbolGraphGen/SymbolGraphOptions.h
@@ -45,6 +45,9 @@ struct SymbolGraphOptions {
 
   /// Whether to emit symbols with SPI information.
   bool IncludeSPISymbols;
+
+  /// Whether to include documentation for clang nodes or not.
+  bool IncludeClangDocs;
 };
 
 } // end namespace symbolgraphgen

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -46,6 +46,7 @@
 #include "swift/Basic/QuotedString.h"
 #include "swift/Basic/STLExtras.h"
 #include "swift/Basic/StringExtras.h"
+#include "swift/Basic/Unicode.h"
 #include "swift/ClangImporter/ClangImporterRequests.h"
 #include "swift/Config.h"
 #include "swift/Parse/Lexer.h"
@@ -300,31 +301,6 @@ Type TypeTransformContext::getBaseType() const {
 
 bool TypeTransformContext::isPrintingSynthesizedExtension() const {
   return !Decl.isNull();
-}
-
-std::string ASTPrinter::sanitizeUtf8(StringRef Text) {
-  llvm::SmallString<256> Builder;
-  Builder.reserve(Text.size());
-  const llvm::UTF8* Data = reinterpret_cast<const llvm::UTF8*>(Text.begin());
-  const llvm::UTF8* End = reinterpret_cast<const llvm::UTF8*>(Text.end());
-  StringRef Replacement = u8"\ufffd";
-  while (Data < End) {
-    auto Step = llvm::getNumBytesForUTF8(*Data);
-    if (Data + Step > End) {
-      Builder.append(Replacement);
-      break;
-    }
-
-    if (llvm::isLegalUTF8Sequence(Data, Data + Step)) {
-      Builder.append(Data, Data + Step);
-    } else {
-
-      // If malformed, add replacement characters.
-      Builder.append(Replacement);
-    }
-    Data += Step;
-  }
-  return std::string(Builder.str());
 }
 
 void ASTPrinter::anchor() {}
@@ -633,9 +609,9 @@ class PrintAST : public ASTVisitor<PrintAST> {
     bool FirstLine = true;
     for (auto Line : Lines) {
       if (FirstLine)
-        Printer << sanitizeClangDocCommentStyle(ASTPrinter::sanitizeUtf8(Line));
+        Printer << sanitizeClangDocCommentStyle(unicode::sanitizeUTF8(Line));
       else
-        Printer << ASTPrinter::sanitizeUtf8(Line);
+        Printer << unicode::sanitizeUTF8(Line);
       Printer.printNewline();
       FirstLine = false;
     }

--- a/lib/IDE/ModuleInterfacePrinting.cpp
+++ b/lib/IDE/ModuleInterfacePrinting.cpp
@@ -22,6 +22,7 @@
 #include "swift/AST/PrintOptions.h"
 #include "swift/AST/SourceFile.h"
 #include "swift/Basic/PrimitiveParsing.h"
+#include "swift/Basic/Unicode.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/Parse/Token.h"
@@ -977,7 +978,7 @@ void ClangCommentPrinter::printDeclPost(const Decl *D,
     return;
 
   for (auto CommentText : PendingComments) {
-    *this << " " << ASTPrinter::sanitizeUtf8(CommentText);
+    *this << " " << unicode::sanitizeUTF8(CommentText);
   }
   PendingComments.clear();
   if (auto ClangN = swift::ide::getEffectiveClangNode(D))
@@ -1068,7 +1069,7 @@ void ClangCommentPrinter::printComment(StringRef RawText, unsigned StartCol) {
   trimLeadingWhitespaceFromLines(RawText, WhitespaceToTrim, Lines);
 
   for (auto Line : Lines) {
-    *this << ASTPrinter::sanitizeUtf8(Line) << "\n";
+    *this << unicode::sanitizeUTF8(Line) << "\n";
     printIndent();
   }
 }

--- a/test/SourceKit/CursorInfo/cursor_symbol_graph_objc.swift
+++ b/test/SourceKit/CursorInfo/cursor_symbol_graph_objc.swift
@@ -1,92 +1,268 @@
-import Foo
+// REQUIRES: objc_interop
 
-func callObjC() {
-  fooFuncWithComment5()
+// RUN: %empty-directory(%t)
+// RUN: split-file --leading-lines %s %t
+
+//--- use.swift
+import MyMod
+
+func test(s: ObjCStruct) {
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):3 -req-opts=retrieve_symbol_graph=1 %t/use.swift -- -I %t/mod -target %target-triple %t/use.swift | %FileCheck -check-prefix=CHECK-FUNC %s
+  someFunc()
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):9 -req-opts=retrieve_symbol_graph=1 %t/use.swift -- -I %t/mod -target %target-triple %t/use.swift | %FileCheck -check-prefix=CHECK-NO %s
+  _ = s.noDoc
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):9 -req-opts=retrieve_symbol_graph=1 %t/use.swift -- -I %t/mod -target %target-triple %t/use.swift | %FileCheck -check-prefix=CHECK-REG %s
+  _ = s.regComments
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):9 -req-opts=retrieve_symbol_graph=1 %t/use.swift -- -I %t/mod -target %target-triple %t/use.swift | %FileCheck -check-prefix=CHECK-SINGLE1 %s
+  _ = s.simpleSingle1
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):9 -req-opts=retrieve_symbol_graph=1 %t/use.swift -- -I %t/mod -target %target-triple %t/use.swift | %FileCheck -check-prefix=CHECK-SINGLE2 %s
+  _ = s.simpleSingle2
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):9 -req-opts=retrieve_symbol_graph=1 %t/use.swift -- -I %t/mod -target %target-triple %t/use.swift | %FileCheck -check-prefix=CHECK-BLOCK1 %s
+  _ = s.simpleBlock1
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):9 -req-opts=retrieve_symbol_graph=1 %t/use.swift -- -I %t/mod -target %target-triple %t/use.swift | %FileCheck -check-prefix=CHECK-BLOCK2 %s
+  _ = s.simpleBlock2
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):9 -req-opts=retrieve_symbol_graph=1 %t/use.swift -- -I %t/mod -target %target-triple %t/use.swift | %FileCheck -check-prefix=CHECK-ART %s
+  _ = s.artBlock
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):9 -req-opts=retrieve_symbol_graph=1 %t/use.swift -- -I %t/mod -target %target-triple %t/use.swift | %FileCheck -check-prefix=CHECK-MIXED-TYPE %s
+  _ = s.mixedType
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):9 -req-opts=retrieve_symbol_graph=1 %t/use.swift -- -I %t/mod -target %target-triple %t/use.swift | %FileCheck -check-prefix=CHECK-MIXED-DOC %s
+  _ = s.mixedDoc
 }
 
-// REQUIRES: objc_interop
-// RUN: %sourcekitd-test -req=cursor -pos=4:3 -req-opts=retrieve_symbol_graph=1 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp -target %target-triple %s | %FileCheck %s
-//
-// CHECK: SYMBOL GRAPH BEGIN
-// CHECK: {
-// CHECK:   "metadata": {
-// CHECK:     "formatVersion": {
-// CHECK:       "major":
-// CHECK:       "minor":
-// CHECK:       "patch":
-// CHECK:     },
-// CHECK:     "generator":
-// CHECK:   },
-// CHECK:   "module": {
-// CHECK:     "name": "Foo",
-// CHECK:     "platform": {
-// CHECK-NOT:   "architecture": "",
-// CHECK:     }
-// CHECK:   },
-// CHECK:   "relationships": [],
-// CHECK:   "symbols": [
-// CHECK:     {
-// CHECK:       "accessLevel": "public",
-// CHECK:       "declarationFragments": [
-// CHECK:         {
-// CHECK:           "kind": "keyword",
-// CHECK:           "spelling": "func"
-// CHECK:         },
-// CHECK:         {
-// CHECK:           "kind": "text",
-// CHECK:           "spelling": " "
-// CHECK:         },
-// CHECK:         {
-// CHECK:           "kind": "identifier",
-// CHECK:           "spelling": "fooFuncWithComment5"
-// CHECK:         },
-// CHECK:         {
-// CHECK:           "kind": "text",
-// CHECK:           "spelling": "()"
-// CHECK:         }
-// CHECK:       ],
-// CHECK:       "functionSignature": {
-// CHECK:         "returns": [
-// CHECK:           {
-// CHECK:             "kind": "typeIdentifier",
-// CHECK:             "preciseIdentifier": "s:s4Voida",
-// CHECK:             "spelling": "Void"
-// CHECK:           }
-// CHECK:         ]
-// CHECK:       },
-// CHECK:       "identifier": {
-// CHECK:         "interfaceLanguage": "swift",
-// CHECK:         "precise": "c:@F@fooFuncWithComment5"
-// CHECK:       },
-// CHECK:       "kind": {
-// CHECK:         "displayName": "Function",
-// CHECK:         "identifier": "swift.func"
-// CHECK:       },
-// CHECK:       "names": {
-// CHECK:         "subHeading": [
-// CHECK:           {
-// CHECK:             "kind": "keyword",
-// CHECK:             "spelling": "func"
-// CHECK:           },
-// CHECK:           {
-// CHECK:             "kind": "text",
-// CHECK:             "spelling": " "
-// CHECK:           },
-// CHECK:           {
-// CHECK:             "kind": "identifier",
-// CHECK:             "spelling": "fooFuncWithComment5"
-// CHECK:           },
-// CHECK:           {
-// CHECK:             "kind": "text",
-// CHECK:             "spelling": "()"
-// CHECK:           }
-// CHECK:         ],
-// CHECK:         "title": "fooFuncWithComment5()"
-// CHECK:       },
-// CHECK:       "pathComponents": [
-// CHECK:         "fooFuncWithComment5()"
-// CHECK:       ]
-// CHECK:     }
-// CHECK:   ]
-// CHECK: }
-// CHECK: SYMBOL GRAPH END
+// CHECK-FUNC: SYMBOL GRAPH BEGIN
+// CHECK-FUNC: {
+// CHECK-FUNC:   "metadata": {
+// CHECK-FUNC:     "formatVersion": {
+// CHECK-FUNC:       "major":
+// CHECK-FUNC:       "minor":
+// CHECK-FUNC:       "patch":
+// CHECK-FUNC:     },
+// CHECK-FUNC:     "generator":
+// CHECK-FUNC:   },
+// CHECK-FUNC:   "module": {
+// CHECK-FUNC:     "name": "MyMod",
+// CHECK-FUNC:     "platform": {
+// CHECK-FUNC-NOT:   "architecture": "",
+// CHECK-FUNC:     }
+// CHECK-FUNC:   },
+// CHECK-FUNC:   "relationships": [],
+// CHECK-FUNC:   "symbols": [
+// CHECK-FUNC:     {
+// CHECK-FUNC:       "accessLevel": "public",
+// CHECK-FUNC:       "declarationFragments": [
+// CHECK-FUNC:         {
+// CHECK-FUNC:           "kind": "keyword",
+// CHECK-FUNC:           "spelling": "func"
+// CHECK-FUNC:         },
+// CHECK-FUNC:         {
+// CHECK-FUNC:           "kind": "text",
+// CHECK-FUNC:           "spelling": " "
+// CHECK-FUNC:         },
+// CHECK-FUNC:         {
+// CHECK-FUNC:           "kind": "identifier",
+// CHECK-FUNC:           "spelling": "someFunc"
+// CHECK-FUNC:         },
+// CHECK-FUNC:         {
+// CHECK-FUNC:           "kind": "text",
+// CHECK-FUNC:           "spelling": "()"
+// CHECK-FUNC:         }
+// CHECK-FUNC:       ],
+// CHECK-FUNC:       "docComment": {
+// CHECK-FUNC:         "lines": [
+// CHECK-FUNC:           {
+// CHECK-FUNC:             "text": "someFunc doc"
+// CHECK-FUNC:           }
+// CHECK-FUNC:         ]
+// CHECK-FUNC:       },
+// CHECK-FUNC:       "functionSignature": {
+// CHECK-FUNC:         "returns": [
+// CHECK-FUNC:           {
+// CHECK-FUNC:             "kind": "typeIdentifier",
+// CHECK-FUNC:             "preciseIdentifier": "s:s4Voida",
+// CHECK-FUNC:             "spelling": "Void"
+// CHECK-FUNC:           }
+// CHECK-FUNC:         ]
+// CHECK-FUNC:       },
+// CHECK-FUNC:       "identifier": {
+// CHECK-FUNC:         "interfaceLanguage": "swift",
+// CHECK-FUNC:         "precise": "c:@F@someFunc"
+// CHECK-FUNC:       },
+// CHECK-FUNC:       "kind": {
+// CHECK-FUNC:         "displayName": "Function",
+// CHECK-FUNC:         "identifier": "swift.func"
+// CHECK-FUNC:       },
+// CHECK-FUNC:       "names": {
+// CHECK-FUNC:         "subHeading": [
+// CHECK-FUNC:           {
+// CHECK-FUNC:             "kind": "keyword",
+// CHECK-FUNC:             "spelling": "func"
+// CHECK-FUNC:           },
+// CHECK-FUNC:           {
+// CHECK-FUNC:             "kind": "text",
+// CHECK-FUNC:             "spelling": " "
+// CHECK-FUNC:           },
+// CHECK-FUNC:           {
+// CHECK-FUNC:             "kind": "identifier",
+// CHECK-FUNC:             "spelling": "someFunc"
+// CHECK-FUNC:           },
+// CHECK-FUNC:           {
+// CHECK-FUNC:             "kind": "text",
+// CHECK-FUNC:             "spelling": "()"
+// CHECK-FUNC:           }
+// CHECK-FUNC:         ],
+// CHECK-FUNC:         "title": "someFunc()"
+// CHECK-FUNC:       },
+// CHECK-FUNC:       "pathComponents": [
+// CHECK-FUNC:         "someFunc()"
+// CHECK-FUNC:       ]
+// CHECK-FUNC:     }
+// CHECK-FUNC:   ]
+// CHECK-FUNC: }
+// CHECK-FUNC: SYMBOL GRAPH END
+
+//--- mod/module.modulemap
+module MyMod {
+  header "M.h"
+}
+
+//--- mod/M.h
+/// someFunc doc
+void someFunc(void);
+
+struct ObjCStruct {
+  int noDoc;
+  // CHECK-NO-NOT: "docComment"
+
+  // regular comment
+  int regComments;
+  // CHECK-REG-NOT: "docComment"
+
+  /// single line doc
+  int simpleSingle1;
+  // CHECK-SINGLE1: "docComment": {
+  // CHECK-SINGLE1-NEXT:    "lines": [
+  // CHECK-SINGLE1-NEXT:      {
+  // CHECK-SINGLE1-NEXT:        "text": "single line doc"
+  // CHECK-SINGLE1-NEXT:      }
+  // CHECK-SINGLE1-NEXT:    ]
+  // CHECK-SINGLE1-NEXT:  }
+
+  //! single line doc
+  int simpleSingle2;
+  // CHECK-SINGLE2: "docComment": {
+  // CHECK-SINGLE2-NEXT:    "lines": [
+  // CHECK-SINGLE2-NEXT:      {
+  // CHECK-SINGLE2-NEXT:        "text": "single line doc"
+  // CHECK-SINGLE2-NEXT:      }
+  // CHECK-SINGLE2-NEXT:    ]
+  // CHECK-SINGLE2-NEXT:  }
+
+  /** single line block doc */
+  int simpleBlock1;
+  // CHECK-BLOCK1: "docComment": {
+  // CHECK-BLOCK1-NEXT:    "lines": [
+  // CHECK-BLOCK1-NEXT:      {
+  // CHECK-BLOCK1-NEXT:        "text": "single line block doc "
+  // CHECK-BLOCK1-NEXT:      }
+  // CHECK-BLOCK1-NEXT:    ]
+  // CHECK-BLOCK1-NEXT:  }
+
+  /*! single line block doc */
+  int simpleBlock2;
+  // CHECK-BLOCK2: "docComment": {
+  // CHECK-BLOCK2-NEXT:    "lines": [
+  // CHECK-BLOCK2-NEXT:      {
+  // CHECK-BLOCK2-NEXT:        "text": "single line block doc "
+  // CHECK-BLOCK2-NEXT:      }
+  // CHECK-BLOCK2-NEXT:    ]
+  // CHECK-BLOCK2-NEXT:  }
+
+  /**
+   * docs with art prefix
+   *   indent
+   * last
+   */
+  int artBlock;
+  // CHECK-ART: "docComment": {
+  // CHECK-ART-NEXT:    "lines": [
+  // CHECK-ART-NEXT:      {
+  // CHECK-ART-NEXT:        "text": ""
+  // CHECK-ART-NEXT:      },
+  // CHECK-ART-NEXT:      {
+  // CHECK-ART-NEXT:        "text": " docs with art prefix"
+  // CHECK-ART-NEXT:      },
+  // CHECK-ART-NEXT:      {
+  // CHECK-ART-NEXT:        "text": "   indent"
+  // CHECK-ART-NEXT:      },
+  // CHECK-ART-NEXT:      {
+  // CHECK-ART-NEXT:        "text": " last"
+  // CHECK-ART-NEXT:      },
+  // CHECK-ART-NEXT:      {
+  // CHECK-ART-NEXT:        "text": "   "
+  // CHECK-ART-NEXT:      }
+  // CHECK-ART-NEXT:    ]
+  // CHECK-ART-NEXT:  }
+
+  /// doc1
+  // reg1
+  /// doc2 first
+  /// doc2 last
+  // reg2
+  int mixedType;
+  // CHECK-MIXED-TYPE: "docComment": {
+  // CHECK-MIXED-TYPE-NEXT:    "lines": [
+  // CHECK-MIXED-TYPE-NEXT:      {
+  // CHECK-MIXED-TYPE-NEXT:        "text": "doc2 first"
+  // CHECK-MIXED-TYPE-NEXT:      },
+  // CHECK-MIXED-TYPE-NEXT:      {
+  // CHECK-MIXED-TYPE-NEXT:        "text": "doc2 last"
+  // CHECK-MIXED-TYPE-NEXT:      }
+  // CHECK-MIXED-TYPE-NEXT:    ]
+  // CHECK-MIXED-TYPE-NEXT:  }
+
+  /// doc1
+  /**
+      doc2 first
+        doc2 indented
+      doc2 last
+   */
+  /// doc3
+  int mixedDoc;
+  // CHECK-MIXED-DOC: "docComment": {
+  // CHECK-MIXED-DOC-NEXT:    "lines": [
+  // CHECK-MIXED-DOC-NEXT:      {
+  // CHECK-MIXED-DOC-NEXT:        "text": "doc1"
+  // CHECK-MIXED-DOC-NEXT:      },
+  // CHECK-MIXED-DOC-NEXT:      {
+  // CHECK-MIXED-DOC-NEXT:        "text": ""
+  // CHECK-MIXED-DOC-NEXT:      },
+  // CHECK-MIXED-DOC-NEXT:      {
+  // CHECK-MIXED-DOC-NEXT:        "text": "doc2 first"
+  // CHECK-MIXED-DOC-NEXT:      },
+  // CHECK-MIXED-DOC-NEXT:      {
+  // CHECK-MIXED-DOC-NEXT:        "text": "  doc2 indented"
+  // CHECK-MIXED-DOC-NEXT:      },
+  // CHECK-MIXED-DOC-NEXT:      {
+  // CHECK-MIXED-DOC-NEXT:        "text": "doc2 last"
+  // CHECK-MIXED-DOC-NEXT:      },
+  // CHECK-MIXED-DOC-NEXT:      {
+  // CHECK-MIXED-DOC-NEXT:        "text": ""
+  // CHECK-MIXED-DOC-NEXT:      },
+  // CHECK-MIXED-DOC-NEXT:      {
+  // CHECK-MIXED-DOC-NEXT:        "text": ""
+  // CHECK-MIXED-DOC-NEXT:      },
+  // CHECK-MIXED-DOC-NEXT:      {
+  // CHECK-MIXED-DOC-NEXT:        "text": "doc3"
+  // CHECK-MIXED-DOC-NEXT:      }
+  // CHECK-MIXED-DOC-NEXT:    ]
+  // CHECK-MIXED-DOC-NEXT:  }
+};

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -984,10 +984,11 @@ fillSymbolInfo(CursorSymbolInfo &Symbol, const DeclInfo &DInfo,
         Invoc.getLangOptions().Target,
         /*PrettyPrint=*/false,
         AccessLevel::Private,
-        /*EmitSynthesizedMembers*/ false,
-        /*PrintMessages*/ false,
-        /*SkipInheritedDocs*/ false,
-        /*IncludeSPISymbols*/ true,
+        /*EmitSynthesizedMembers=*/false,
+        /*PrintMessages=*/false,
+        /*SkipInheritedDocs=*/false,
+        /*IncludeSPISymbols=*/true,
+        /*IncludeClangDocs=*/true
     };
 
     symbolgraphgen::printSymbolGraphForDecl(DInfo.VD, DInfo.BaseType,


### PR DESCRIPTION
This currently doesn't check for inherited docs, ie. either the
imported declaration has docs or it doesn't. There's also a few odd
cases with mixed doc types and when each line is prefixed with '*', but
it's good enough for an initial implementation.

Moves UTF8 sanitisation out of ASTPrinter.h and into Unicode.h so that
it can be used here as well.

Resolves rdar://91388603.