### PR TITLE
[5.7][Type Resolution] Emit a tailored diagnostic for the incorrect `any P?` syntax.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4755,6 +4755,9 @@ ERROR(unchecked_not_existential,none,
 ERROR(any_not_existential,none,
        "'any' has no effect on %select{concrete type|type parameter}0 %1",
        (bool, Type))
+ERROR(incorrect_optional_any,none,
+      "optional 'any' type must be written %0",
+      (Type))
 ERROR(existential_requires_any,none,
       "use of %select{protocol |}2%0 as a type must be written %1",
       (Type, Type, bool))

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -308,4 +308,9 @@ func testAnyFixIt() {
   let _: HasAssoc.Type? = ConformingType.self
   // expected-warning@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=(any HasAssoc)}}
   let _: HasAssoc.Protocol? = (any HasAssoc).self
+
+  // expected-error@+1 {{optional 'any' type must be written '(any HasAssoc)?'}}{{10-23=(any HasAssoc)?}}
+  let _: any HasAssoc? = nil
+  // expected-error@+1 {{optional 'any' type must be written '(any HasAssoc.Type)?'}}{{10-28=(any HasAssoc.Type)?}}
+  let _: any HasAssoc.Type? = nil
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/42277

---

The compiler now emits the following error for the incorrect `any P?` syntax, with a fix-it to insert parenthesis:

```swift
protocol P {}

var p: any P? = nil // error: optional 'any' type must be written '(any P)?'
```

Resolves: rdar://90558740