### PR TITLE
Perf: use StringSet instead for better lookup performance

### DIFF
--- a/lib/DriverTool/swift_api_digester_main.cpp
+++ b/lib/DriverTool/swift_api_digester_main.cpp
@@ -273,11 +273,10 @@ class RemovedAddedNodeMatcher : public NodeMatcher, public MatchedNodeListener {
   }
 
   static bool isNameTooSimple(StringRef N) {
-    static std::vector<std::string> SimpleNames = {"unit", "data", "log", "coding",
+    static std::unordered_set<std::string> SimpleNames = {"unit", "data", "log", "coding",
       "url", "name", "date", "datecomponents", "notification", "urlrequest",
       "personnamecomponents", "measurement", "dateinterval", "indexset"};
-    return std::find(SimpleNames.begin(), SimpleNames.end(), N) !=
-      SimpleNames.end();
+    return SimpleNames.find(N.str()) != SimpleNames.end();
   }
 
   static bool isSimilarName(StringRef L, StringRef R) {

--- a/lib/DriverTool/swift_api_digester_main.cpp
+++ b/lib/DriverTool/swift_api_digester_main.cpp
@@ -273,10 +273,10 @@ class RemovedAddedNodeMatcher : public NodeMatcher, public MatchedNodeListener {
   }
 
   static bool isNameTooSimple(StringRef N) {
-    static std::unordered_set<std::string> SimpleNames = {"unit", "data", "log", "coding",
+    static llvm::StringSet<> SimpleNames = {"unit", "data", "log", "coding",
       "url", "name", "date", "datecomponents", "notification", "urlrequest",
       "personnamecomponents", "measurement", "dateinterval", "indexset"};
-    return SimpleNames.find(N.str()) != SimpleNames.end();
+    return SimpleNames.contains(N);
   }
 
   static bool isSimilarName(StringRef L, StringRef R) {


### PR DESCRIPTION
<!-- What's in this pull request? -->
`isNameTooSimple` function in `lib/DriverTool/swift_api_digester_main.cpp` had a room to slightly improve the performance.

This PR updates `SimpleNames` to be `StringSet` in place of `vector` to make its time complexity to `O(1)` from `O(n)`.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
