### PR TITLE
[NFC][Gardening] Remove outdated section about integrated swift-repl 

### DIFF
--- a/docs/DebuggingTheCompiler.md
+++ b/docs/DebuggingTheCompiler.md
@@ -206,17 +206,12 @@ Conformances:
     (integer_literal_expr type='Int2048' location=test.swift:3:10 range=[test.swift:3:10 - line:3:10] value=0)))
 ```
 
-When using the integrated swift-repl, one can dump the same output for each
+When using swift LLDB REPL, one can dump the same output for each
 expression as one evaluates the expression by enabling constraints debugging by
-typing `:constraints debug on`:
+passing the flag `-Xfrontend -debug-constraints`:
 
-    $ swift -frontend -repl -enable-objc-interop -module-name REPL
-    ***  You are running Swift's integrated REPL,  ***
-    ***  intended for compiler and stdlib          ***
-    ***  development and testing purposes only.    ***
-    ***  The full REPL is built as part of LLDB.   ***
-    ***  Type ':help' for assistance.              ***
-    (swift) :constraints debug on
+    $ swift repl -Xfrontend -debug-constraints
+    1> let foo = 1
 
 ## Debugging on SIL Level
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Swift's integrated repl was removed so this section on DebuggingTheCompiler docs is outdated. See [[RFC: Removing the integrated REPL](https://forums.swift.org/t/rfc-removing-the-integrated-repl/35441)](https://forums.swift.org/t/rfc-removing-the-integrated-repl/35441) for reference.
So this adjusts the `DebuggingTheCompiler.md` `Debugging the Type Checker` section with instructions on how to see this output using LLDB REPL.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
