### PR TITLE
caches: tweak the Windows toolchain build

### DIFF
--- a/cmake/caches/Windows-arm64.cmake
+++ b/cmake/caches/Windows-arm64.cmake
@@ -66,6 +66,8 @@ set(LLVM_TOOL_LLVM_SHLIB_BUILD NO CACHE BOOL "")
 # Avoid swig dependency for lldb
 set(LLDB_ALLOW_STATIC_BINDINGS YES CACHE BOOL "")
 set(LLDB_USE_STATIC_BINDINGS YES CACHE BOOL "")
+set(LLDB_ENABLE_PYTHON YES CACHE BOOL "")
+set(LLDB_EMBED_PYTHON_HOME NO CACHE BOOL "")
 
 # This requires perl which may not be available on Windows
 set(SWIFT_INCLUDE_DOCS NO CACHE BOOL "")

--- a/cmake/caches/Windows-x86_64.cmake
+++ b/cmake/caches/Windows-x86_64.cmake
@@ -66,6 +66,8 @@ set(LLVM_TOOL_LLVM_SHLIB_BUILD NO CACHE BOOL "")
 # Avoid swig dependency for lldb
 set(LLDB_ALLOW_STATIC_BINDINGS YES CACHE BOOL "")
 set(LLDB_USE_STATIC_BINDINGS YES CACHE BOOL "")
+set(LLDB_ENABLE_PYTHON YES CACHE BOOL "")
+set(LLDB_EMBED_PYTHON_HOME NO CACHE BOOL "")
 
 # This requires perl which may not be available on Windows
 set(SWIFT_INCLUDE_DOCS NO CACHE BOOL "")


### PR DESCRIPTION
Update the toolchain configuration to disable the python home embedding.
This should allow us to be more freestanding of the python location and
give us better control of the python library being used.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
