### PR TITLE
Tests: Fix `attr_inlinable_available_maccatalyst` on release 5.7

### DIFF
--- a/test/attr/attr_inlinable_available_maccatalyst.swift
+++ b/test/attr/attr_inlinable_available_maccatalyst.swift
@@ -12,8 +12,9 @@
 // RUN: %target-typecheck-verify-swift -swift-version 5 -enable-library-evolution -target %target-cpu-apple-ios14.4-macabi -target-min-inlining-version min
 
 
+// FIXME: Re-enable with rdar://91387029
 // Check that `-library-level api` implies `-target-min-inlining-version min`
-// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-library-evolution -target %target-cpu-apple-ios14.4-macabi -library-level api
+// RUN/: %target-typecheck-verify-swift -swift-version 5 -enable-library-evolution -target %target-cpu-apple-ios14.4-macabi -library-level api
 
 
 // Check that these rules are only applied when requested and that at least some


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/42301.

Forgot to disable the MacCatalyst variant of the `attr_inlinable_available` test case with https://github.com/apple/swift/pull/42235.
    
Resolves rdar://91549324