### PR TITLE
[5.7] Rename compiler _RegexParser module to _CompilerRegexParser.

### DIFF
--- a/SwiftCompilerSources/Package.swift
+++ b/SwiftCompilerSources/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     .library(
       name: "Swift",
       type: .static,
-      targets: ["SIL", "Optimizer", "_RegexParser"]),
+      targets: ["SIL", "Optimizer", "_CompilerRegexParser"]),
   ],
   dependencies: [
   ],
@@ -26,8 +26,9 @@ let package = Package(
           "-cross-module-optimization"
         ])]),
     .target(
-      name: "_RegexParser",
+      name: "_CompilerRegexParser",
       dependencies: [],
+      path: "_RegexParser",
       swiftSettings: [
         .unsafeFlags([
           "-I", "../include/swift",
@@ -41,7 +42,7 @@ let package = Package(
         ])]),
     .target(
       name: "Optimizer",
-      dependencies: ["SIL", "_RegexParser"],
+      dependencies: ["SIL", "_CompilerRegexParser"],
       swiftSettings: [SwiftSetting.unsafeFlags([
           "-I", "../include/swift",
           "-cross-module-optimization"

--- a/SwiftCompilerSources/Sources/Optimizer/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/CMakeLists.txt
@@ -9,7 +9,7 @@
 set(dependencies)
 list(APPEND dependencies Basic SIL)
 if(SWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING)
-  list(APPEND dependencies _RegexParser)
+  list(APPEND dependencies _CompilerRegexParser)
 endif()
 
 add_swift_compiler_module(Optimizer DEPENDS ${dependencies})

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
@@ -13,8 +13,8 @@
 import SIL
 import OptimizerBridging
 
-#if canImport(_RegexParser)
-import _RegexParser
+#if canImport(_CompilerRegexParser)
+import _CompilerRegexParser
 #endif
 
 @_cdecl("initializeSwiftModules")
@@ -22,7 +22,7 @@ public func initializeSwiftModules() {
   registerSILClasses()
   registerSwiftPasses()
 
-  #if canImport(_RegexParser)
+  #if canImport(_CompilerRegexParser)
   registerRegexParser()
   #endif
 }

--- a/SwiftCompilerSources/Sources/_RegexParser/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/_RegexParser/CMakeLists.txt
@@ -15,6 +15,6 @@ foreach(source ${_LIBSWIFT_REGEX_PARSER_SOURCES})
 endforeach()
 message(STATUS "Using Experimental String Processing library for libswift _RegexParser (${EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR}).")
 
-add_swift_compiler_module(_RegexParser
+add_swift_compiler_module(_CompilerRegexParser
   "${LIBSWIFT_REGEX_PARSER_SOURCES}"
   Regex.swift)


### PR DESCRIPTION
Cherry-pick #42283.

Work around a build failure due to this module having the same name as the runtime _RegexParser module.

rdar://91521407