### PR TITLE
[5.7] Reenable swift docc tests

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -668,9 +668,6 @@ skip-build-benchmarks
 # Skip playground tests
 skip-test-playgroundsupport
 
-# SKIP SWIFT-DOCC TESTS (87784021)
-skip-test-swiftdocc
-
 [preset: buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx,flto]
 mixin-preset=buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx
 build-subdir=buildbot_incremental
@@ -1612,9 +1609,6 @@ sil-verify-all-macos-only
 # faster.
 skip-test-ios-host
 skip-test-watchos-host
-
-# SKIP SWIFT-DOCC TESTS (87784021)
-skip-test-swiftdocc
 
 
 #===------------------------------------------------------------------------===#

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1344,8 +1344,6 @@ mixin-preset=
 
 # SKIP LLDB TESTS (67923799)
 skip-test-lldb
-# SKIP SWIFT-DOCC TESTS (87784021)
-skip-test-swiftdocc
 skip-test-playgroundsupport
 
 [preset: buildbot_osx_package,use_os_runtime]


### PR DESCRIPTION
This re-enables Swift-DocC tests in toolchain builds.

Commits cherry-picked from #41839 

**Rationale**: Re-enables swift-docc tests in full test, smoke test, and toolchain builds  in CI
**Risk**: Low
**Risk Detail**: There could still be tests whose flakiness is uncovered only after even more test runs are performed.
**Reward**: High
**Reward Details**: Enabling CI testing of DocC is critical to ensure no regressions in functionality are inadvertently introduced.
**Original PR**: #41839 
**Issue**: rdar://90181251