### PR TITLE
[cxx-interop] Fix libstdc++ test failure with Ubuntu 18.04

### DIFF
--- a/test/Interop/Cxx/stdlib/libstdcxx-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/libstdcxx-module-interface.swift
@@ -1,9 +1,13 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=std -source-filename=x -enable-experimental-cxx-interop -module-cache-path %t | %FileCheck %s  -check-prefix=CHECK-STD
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-ide-test -print-module -module-to-print=std -source-filename=x -enable-experimental-cxx-interop -module-cache-path %t > %t/interface.swift
+// RUN: %FileCheck %s -check-prefix=CHECK-STD < %t/interface.swift
+// RUN: %FileCheck %s -check-prefix=CHECK-TO-STRING < %t/interface.swift
+// RUN: %FileCheck %s -check-prefix=CHECK-STRING < %t/interface.swift
+
+// Running this test with different versions of libstdc++ will result in the decls being printed in different order.
 
 // This test is specific to libstdc++ and only runs on platforms where libstdc++ is used.
 // REQUIRES: OS=linux-gnu
-
-// REQUIRES: rdar91518316
 
 // CHECK-STD: enum std {
 // CHECK-STD:   enum __cxx11 {
@@ -15,11 +19,11 @@
 // CHECK-STD:     }
 // CHECK-STD:   }
 
-// CHECK-STD:   static func to_string(_ __val: Int32) -> std.string
-// CHECK-STD:   static func to_wstring(_ __val: Int32) -> std.wstring
+// CHECK-TO-STRING:   static func to_string(_ __val: Int32) -> std{{(.__cxx11)?}}.string
+// CHECK-TO-STRING:   static func to_wstring(_ __val: Int32) -> std{{(.__cxx11)?}}.wstring
 
 // CHECK-STD:   typealias size_t = Int
 
-// CHECK-STD:   typealias string = std.__cxx11.__CxxTemplateInstNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
-// CHECK-STD:   typealias wstring = std.__cxx11.__CxxTemplateInstNSt7__cxx1112basic_stringIwSt11char_traitsIwESaIwEEE
+// CHECK-STRING:   typealias string = std.__cxx11.__CxxTemplateInstNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
+// CHECK-STRING:   typealias wstring = std.__cxx11.__CxxTemplateInstNSt7__cxx1112basic_stringIwSt11char_traitsIwESaIwEEE
 // CHECK-STD: }


### PR DESCRIPTION
When importing an older version of libstdc++, the decls might get printed in a different order. This change makes the test work properly for libstdc++-7 as well as libstdc++-9.

rdar://91518316