### PR TITLE
RequirementMachine: Fix handling of Sendable conformances for superclass requirements

### DIFF
--- a/test/Concurrency/sendable_conformance_checking.swift
+++ b/test/Concurrency/sendable_conformance_checking.swift
@@ -165,29 +165,3 @@ extension SendableExtSub: @unchecked Sendable {}
 // Still want to know about same-class redundancy
 class MultiConformance: @unchecked Sendable {} // expected-note {{'MultiConformance' declares conformance to protocol 'Sendable' here}}
 extension MultiConformance: @unchecked Sendable {} // expected-error {{redundant conformance of 'MultiConformance' to protocol 'Sendable'}}
-
-// rdar://91174106 - allow missing Sendable conformances when extending a
-// type generically.
-// FIXME: Should warn because of missing Sendable, but currently is silent
-// because we aren't checking conformance availability here yet.
-struct X<T: Sendable> { }
-enum Y {}
-extension X where T == Y {}
-
-protocol P2 {
-  associatedtype A: Sendable
-}
-
-enum Y2: P2, P3 {
-  typealias A = Y
-}
-
-struct X2<T: P2> { }
-extension X2 where T == Y2 { }
-
-protocol P3 {
-  associatedtype A
-}
-
-struct X3<T: P3> where T.A: Sendable { }
-extension X3 where T == Y2 { }

--- a/test/Generics/missing_sendable_conformance.swift
+++ b/test/Generics/missing_sendable_conformance.swift
@@ -1,0 +1,34 @@
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
+
+// REQUIRES: concurrency
+
+// rdar://91174106 - allow missing Sendable conformances when extending a
+// type generically.
+// FIXME: Should warn because of missing Sendable, but currently is silent
+// because we aren't checking conformance availability here yet.
+class C {}
+
+struct G1<T: Sendable> {}
+
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=G1
+// CHECK-NEXT: Generic signature: <T where T == C>
+extension G1 where T == C {}
+
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=G1
+// CHECK-NEXT: Generic signature: <T where T : C, T : Sendable>
+extension G1 where T : C {}
+
+protocol P {
+  associatedtype A
+}
+
+struct G2<T : P> where T.A : Sendable {}
+
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=G2
+// CHECK-NEXT: Generic signature: <T where T : P, T.[P]A == C>
+extension G2 where T.A == C {}
+
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=G2
+// CHECK-NEXT: Generic signature: <T where T : P, T.[P]A : C, T.[P]A : Sendable>
+extension G2 where T.A : C {}


### PR DESCRIPTION
Don't set allowMissing to true when checking conformance of a superclass requirement
to a protocol, since this prevents us from being able to express something like
'T : C, T : Sendable' to mean 'T can be any subclass of C which is also Sendable'.

Fixes rdar://problem/91530343.