### PR TITLE
RequirementMachine: Allow missing Sendable conformances [5.7]

### DIFF
--- a/lib/AST/RequirementMachine/ConcreteContraction.cpp
+++ b/lib/AST/RequirementMachine/ConcreteContraction.cpp
@@ -223,7 +223,8 @@ Optional<Type> ConcreteContraction::substTypeParameter(
 
     auto conformance = ((*substBaseType)->isTypeParameter()
                         ? ProtocolConformanceRef(proto)
-                        : module->lookupConformance(*substBaseType, proto));
+                        : module->lookupConformance(*substBaseType, proto,
+                                                    /*allowMissing=*/true));
 
     // The base type doesn't conform, in which case the requirement remains
     // unsubstituted.
@@ -363,7 +364,8 @@ ConcreteContraction::substRequirement(const Requirement &req) const {
     auto *proto = req.getProtocolDecl();
     auto *module = proto->getParentModule();
     if (!substFirstType->isTypeParameter() &&
-        !module->lookupConformance(substFirstType, proto)) {
+        !module->lookupConformance(substFirstType, proto,
+                                   /*allowMissing=*/true)) {
       // Handle the case of <T where T : P, T : C> where C is a class and
       // C does not conform to P by leaving the conformance requirement
       // unsubstituted.

--- a/lib/AST/RequirementMachine/ConcreteTypeWitness.cpp
+++ b/lib/AST/RequirementMachine/ConcreteTypeWitness.cpp
@@ -144,7 +144,8 @@ void PropertyMap::concretizeNestedTypesFromConcreteParent(
     auto *module = proto->getParentModule();
 
     auto conformance = module->lookupConformance(concreteType,
-                                                 const_cast<ProtocolDecl *>(proto));
+                                                 const_cast<ProtocolDecl *>(proto),
+                                                 /*allowMissing=*/true);
     if (conformance.isInvalid()) {
       // For superclass rules, it is totally fine to have a signature like:
       //

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -292,7 +292,8 @@ static void desugarConformanceRequirement(Type subjectType, Type constraintType,
       // Check if the subject type actually conforms.
       auto *protoDecl = constraintType->castTo<ProtocolType>()->getDecl();
       auto *module = protoDecl->getParentModule();
-      auto conformance = module->lookupConformance(subjectType, protoDecl);
+      auto conformance = module->lookupConformance(
+          subjectType, protoDecl, /*allowMissing=*/true);
       if (conformance.isInvalid()) {
         errors.push_back(RequirementError::forInvalidRequirementSubject(
             {RequirementKind::Conformance, subjectType, constraintType}, loc));

--- a/test/Concurrency/sendable_conformance_checking.swift
+++ b/test/Concurrency/sendable_conformance_checking.swift
@@ -165,29 +165,3 @@ extension SendableExtSub: @unchecked Sendable {}
 // Still want to know about same-class redundancy
 class MultiConformance: @unchecked Sendable {} // expected-note {{'MultiConformance' declares conformance to protocol 'Sendable' here}}
 extension MultiConformance: @unchecked Sendable {} // expected-error {{redundant conformance of 'MultiConformance' to protocol 'Sendable'}}
-
-// rdar://91174106 - allow missing Sendable conformances when extending a
-// type generically.
-// FIXME: Should warn because of missing Sendable, but currently is silent
-// because we aren't checking conformance availability here yet.
-struct X<T: Sendable> { }
-enum Y {}
-extension X where T == Y {}
-
-protocol P2 {
-  associatedtype A: Sendable
-}
-
-enum Y2: P2, P3 {
-  typealias A = Y
-}
-
-struct X2<T: P2> { }
-extension X2 where T == Y2 { }
-
-protocol P3 {
-  associatedtype A
-}
-
-struct X3<T: P3> where T.A: Sendable { }
-extension X3 where T == Y2 { }

--- a/test/Concurrency/sendable_conformance_checking.swift
+++ b/test/Concurrency/sendable_conformance_checking.swift
@@ -168,8 +168,26 @@ extension MultiConformance: @unchecked Sendable {} // expected-error {{redundant
 
 // rdar://91174106 - allow missing Sendable conformances when extending a
 // type generically.
-// FIXME: Should warn because of missing Sendable, but currently is silent.
-// We don't want a hard error except in Swift 6.
+// FIXME: Should warn because of missing Sendable, but currently is silent
+// because we aren't checking conformance availability here yet.
 struct X<T: Sendable> { }
 enum Y {}
 extension X where T == Y {}
+
+protocol P2 {
+  associatedtype A: Sendable
+}
+
+enum Y2: P2, P3 {
+  typealias A = Y
+}
+
+struct X2<T: P2> { }
+extension X2 where T == Y2 { }
+
+protocol P3 {
+  associatedtype A
+}
+
+struct X3<T: P3> where T.A: Sendable { }
+extension X3 where T == Y2 { }

--- a/test/Concurrency/sendable_conformance_checking.swift
+++ b/test/Concurrency/sendable_conformance_checking.swift
@@ -165,3 +165,11 @@ extension SendableExtSub: @unchecked Sendable {}
 // Still want to know about same-class redundancy
 class MultiConformance: @unchecked Sendable {} // expected-note {{'MultiConformance' declares conformance to protocol 'Sendable' here}}
 extension MultiConformance: @unchecked Sendable {} // expected-error {{redundant conformance of 'MultiConformance' to protocol 'Sendable'}}
+
+// rdar://91174106 - allow missing Sendable conformances when extending a
+// type generically.
+// FIXME: Should warn because of missing Sendable, but currently is silent.
+// We don't want a hard error except in Swift 6.
+struct X<T: Sendable> { }
+enum Y {}
+extension X where T == Y {}

--- a/test/Generics/missing_sendable_conformance.swift
+++ b/test/Generics/missing_sendable_conformance.swift
@@ -1,0 +1,34 @@
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
+
+// REQUIRES: concurrency
+
+// rdar://91174106 - allow missing Sendable conformances when extending a
+// type generically.
+// FIXME: Should warn because of missing Sendable, but currently is silent
+// because we aren't checking conformance availability here yet.
+class C {}
+
+struct G1<T: Sendable> {}
+
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=G1
+// CHECK-NEXT: Generic signature: <T where T == C>
+extension G1 where T == C {}
+
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=G1
+// CHECK-NEXT: Generic signature: <T where T : C, T : Sendable>
+extension G1 where T : C {}
+
+protocol P {
+  associatedtype A
+}
+
+struct G2<T : P> where T.A : Sendable {}
+
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=G2
+// CHECK-NEXT: Generic signature: <T where T : P, T.[P]A == C>
+extension G2 where T.A == C {}
+
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=G2
+// CHECK-NEXT: Generic signature: <T where T : P, T.[P]A : C, T.[P]A : Sendable>
+extension G2 where T.A : C {}


### PR DESCRIPTION
Supersedes https://github.com/apple/swift/pull/42271. Cherry-pick of https://github.com/apple/swift/pull/42307. Fixes rdar://problem/91174106 and rdar://problem/91530343.