### PR TITLE
ASTPrinter: Rename PrimaryAssociatedTypes feature to PrimaryAssociatedTypes2 [5.7]

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -74,7 +74,7 @@ LANGUAGE_FEATURE(BuiltinStackAlloc, 0, "Builtin.stackAlloc", true)
 SUPPRESSIBLE_LANGUAGE_FEATURE(SpecializeAttributeWithAvailability, 0, "@_specialize attribute with availability", true)
 LANGUAGE_FEATURE(BuiltinAssumeAlignment, 0, "Builtin.assumeAlignment", true)
 SUPPRESSIBLE_LANGUAGE_FEATURE(UnsafeInheritExecutor, 0, "@_unsafeInheritExecutor", true)
-SUPPRESSIBLE_LANGUAGE_FEATURE(PrimaryAssociatedTypes, 346, "Primary associated types", true)
+SUPPRESSIBLE_LANGUAGE_FEATURE(PrimaryAssociatedTypes2, 346, "Primary associated types", true)
 SUPPRESSIBLE_LANGUAGE_FEATURE(UnavailableFromAsync, 0, "@_unavailableFromAsync", true)
 SUPPRESSIBLE_LANGUAGE_FEATURE(NoAsyncAvailability, 340, "@available(*, noasync)", true)
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2972,7 +2972,7 @@ static void suppressingFeatureUnsafeInheritExecutor(PrintOptions &options,
   options.ExcludeAttrList.resize(originalExcludeAttrCount);
 }
 
-static bool usesFeaturePrimaryAssociatedTypes(Decl *decl) {
+static bool usesFeaturePrimaryAssociatedTypes2(Decl *decl) {
   if (auto *protoDecl = dyn_cast<ProtocolDecl>(decl)) {
     if (protoDecl->getPrimaryAssociatedTypes().size() > 0)
       return true;
@@ -2981,7 +2981,7 @@ static bool usesFeaturePrimaryAssociatedTypes(Decl *decl) {
   return false;
 }
 
-static void suppressingFeaturePrimaryAssociatedTypes(PrintOptions &options,
+static void suppressingFeaturePrimaryAssociatedTypes2(PrintOptions &options,
                                          llvm::function_ref<void()> action) {
   bool originalPrintPrimaryAssociatedTypes = options.PrintPrimaryAssociatedTypes;
   options.PrintPrimaryAssociatedTypes = false;

--- a/test/ModuleInterface/parameterized-protocols.swift
+++ b/test/ModuleInterface/parameterized-protocols.swift
@@ -7,7 +7,7 @@ public protocol HasPrimaryAssociatedTypes<T, U> {
   associatedtype U : Equatable
 }
 
-// CHECK: #if compiler(>=5.3) && $PrimaryAssociatedTypes
+// CHECK: #if compiler(>=5.3) && $PrimaryAssociatedTypes2
 // CHECK-NEXT: public protocol HasPrimaryAssociatedTypes<T, U> {
 // CHECK-NEXT:   associatedtype T : Swift.Collection
 // CHECK-NEXT:   associatedtype U : Swift.Equatable where Self.U == Self.T.Element


### PR DESCRIPTION
There was a window where the PrimaryAssociatedTypes feature guarded the old
syntax; let's make sure we don't see breakage if a new standard library is
used with an old compiler.

Cherry-pick of https://github.com/apple/swift/pull/42308.