### PR TITLE
Build regex parser by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,10 @@ option(SWIFT_BUILD_PERF_TESTSUITE
     "Create in-tree targets for building swift performance benchmarks."
     FALSE)
 
+option(SWIFT_BUILD_REGEX_PARSER_IN_COMPILER
+    "Build the Swift regex parser as part of the compiler."
+    TRUE)
+
 option(SWIFT_INCLUDE_TESTS "Create targets for building/running tests." TRUE)
 
 option(SWIFT_INCLUDE_TEST_BINARIES

--- a/SwiftCompilerSources/Sources/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/CMakeLists.txt
@@ -10,7 +10,7 @@
 
 add_subdirectory(Basic)
 add_subdirectory(AST)
-if(SWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING)
+if(SWIFT_BUILD_REGEX_PARSER_IN_COMPILER)
   add_subdirectory(_RegexParser)
 endif()
 add_subdirectory(SIL)

--- a/SwiftCompilerSources/Sources/Optimizer/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 set(dependencies)
 list(APPEND dependencies Basic SIL)
-if(SWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING)
+if(SWIFT_BUILD_REGEX_PARSER_IN_COMPILER)
   list(APPEND dependencies _CompilerRegexParser)
 endif()
 

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2200,13 +2200,22 @@ for host in "${ALL_HOSTS[@]}"; do
                     )
                 fi
 
-                if [[ $(true_false "${SWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING}") == "TRUE" && \
-                      -d "${EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR}" && \
+                if [[ -d "${EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR}" && \
                       -n "$(ls -A "${EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR}")" ]] ; then
                     cmake_options=(
                         "${cmake_options[@]}"
-                        -DSWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING:BOOL=TRUE
                         -DEXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR="${EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR}"
+                    )
+                    if [[ $(true_false "${SWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING}") == "TRUE" ]] ; then
+                        cmake_options=(
+                            "${cmake_options[@]}"
+                            -DSWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING:BOOL=TRUE
+                        )
+                    fi
+                else
+                    cmake_options=(
+                        "${cmake_options[@]}"
+                        -DSWIFT_BUILD_REGEX_PARSER_IN_COMPILER:BOOL=FALSE
                     )
                 fi
 


### PR DESCRIPTION
Currently, SwiftCompilerSources' inclusion of the regex parser depends on CMake flag `SWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING`. However, in some scenarios we want to build the regex parser as part of the compiler _without_ building the runtime modules. This patch makes building the regex parser the default regardless of `SWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING`. Only when the build environment is missing the string processing repo, we skip building the regex parser by setting `SWIFT_BUILD_REGEX_PARSER_IN_COMPILER` to false.