### PR TITLE
[CSSimplify] NFC: Remove unused ASTContext reference left after SE-0347 flag

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1778,8 +1778,6 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
     // add a constraint from the parameter if necessary, otherwise
     // there is nothing to do but move to the next parameter.
     if (parameterBindings[paramIdx].empty() && callee) {
-      auto &ctx = cs.getASTContext();
-
       // Type inference from default value expressions.
       {
         auto *paramList = getParameterList(callee);


### PR DESCRIPTION
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
