### PR TITLE
[5.7][stdlib] Add `Clock.Duration` as an associated type requirement

### DIFF
--- a/stdlib/public/Concurrency/Clock.swift
+++ b/stdlib/public/Concurrency/Clock.swift
@@ -32,7 +32,8 @@ import Swift
 /// `SuspendingClock`.
 @available(SwiftStdlib 5.7, *)
 public protocol Clock: Sendable {
-  associatedtype Instant: InstantProtocol
+  associatedtype Duration: DurationProtocol
+  associatedtype Instant: InstantProtocol where Instant.Duration == Duration
 
   var now: Instant { get }
   var minimumResolution: Instant.Duration { get }


### PR DESCRIPTION
(cherry picked from #42314, commit 0aadfb04443892b06c8b537ebf4a12e343cfc8be)

As [discussed on the forum][forum], we'll likely want to use `Duration` as the primary associated type on `protocol Clock`; however, that protocol currently only has `Instant`.

[forum]: https://forums.swift.org/t/pitch-primary-associated-types-in-the-standard-library/56426/39

To support declaring it as the primary associated type, `protocol Clock` needs to have `Duration` as an associated type requirement:

```
@available(SwiftStdlib 5.7, *)
public protocol Clock: Sendable {
  associatedtype Duration: DurationProtocol
  associatedtype Instant: InstantProtocol where Instant.Duration == Duration

  var now: Instant { get }
  var minimumResolution: Instant.Duration { get }

  func sleep(until deadline: Instant, tolerance: Instant.Duration?) async throws
}
```

This setup is reminiscent of `Sequence.Element` vs. `Sequence.Iterator.Element`.

SE-0329 has not yet shipped in an ABI stable release, so we still have the opportunity to address this.

rdar://91591545
