### PR TITLE
Add missing parameter in `UnsafeMutableRawPointer`

### DIFF
--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -410,7 +410,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///     with `type`.
   @inlinable
   public func storeBytes<T>(
-    of value: T, toByteOffset offset: Int = 0, as: T.Type
+    of value: T, toByteOffset offset: Int = 0, as type: T.Type
   ) {
     _debugPrecondition(offset >= 0, "${Self}.storeBytes with negative offset")
     _debugPrecondition(offset + MemoryLayout<T>.size <= self.count,


### PR DESCRIPTION
Here, as in `UnsafeMutableRawPointer.storeBytes(of:toByteOffset:as:)` "as" is an argument label and "type" is the parameter.  Because the function body doesn't use this — it's just for type information — changing its name from "as" to "type" doesn't have any impact there.

I'm making this PR separate from the [PR](https://github.com/apple/swift/pull/41392) to fix the docs, which is already merged.

This change is also on a separate "do-not-merge" [PR for an upcoming SE pitch](https://github.com/apple/swift/pull/41033) in 067a14962bc482256b0c45ceed2edc136a75d407.  If we merge that, we can discard this focused PR.