### PR TITLE
Fix `async_task_priority.swift` test failure

### DIFF
--- a/test/Concurrency/async_task_priority.swift
+++ b/test/Concurrency/async_task_priority.swift
@@ -3,6 +3,7 @@
 // RUN: %target-codesign %t/async_task_priority
 // RUN: %target-run %t/async_task_priority
 
+// REQUIRES: VENDOR=apple
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 // REQUIRES: libdispatch

--- a/test/Concurrency/async_task_priority.swift
+++ b/test/Concurrency/async_task_priority.swift
@@ -13,7 +13,7 @@
 // UNSUPPORTED: back_deployment_runtime
 
 import Darwin
-@_predatesConcurrency import Dispatch
+@preconcurrency import Dispatch
 import StdlibUnittest
 
 func loopUntil(priority: TaskPriority) async {


### PR DESCRIPTION
This patch updates `async_task_priority.swift` to only run on Apple platforms since it directly imports `Darwin`.
Additionally, replaces `@_predatesConcurrency` with the final `@preconcurrency` spelling.