### PR TITLE
[WIP] distributed computed properties

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -186,7 +186,7 @@ public:
                                              Type GlobalActorBound,
                                              ModuleDecl *Module);
 
-  std::string mangleDistributedThunk(const FuncDecl *thunk);
+  std::string mangleDistributedThunk(const AbstractFunctionDecl *thunk);
 
   /// Mangle a completion handler block implementation function, used for importing ObjC
   /// APIs as async.

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -660,7 +660,7 @@ SIMPLE_DECL_ATTR(_inheritActorContext, InheritActorContext,
 // 117 was 'spawn' and is now unused
 
 CONTEXTUAL_SIMPLE_DECL_ATTR(distributed, DistributedActor,
-  DeclModifier | OnClass | OnFunc | OnVar |
+  DeclModifier | OnClass | OnFunc | OnAccessor | OnVar |
   ABIBreakingToAdd | ABIBreakingToRemove |
   APIBreakingToAdd | APIBreakingToRemove,
   118)

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4811,6 +4811,9 @@ ERROR(distributed_property_cannot_be_static,none,
 ERROR(distributed_property_can_only_be_computed,none,
       "%0 %1 cannot be 'distributed', only computed properties can",
       (DescriptiveDeclKind, DeclName))
+ERROR(distributed_property_accessor_only_get_can_be_distributed,none,
+      "only 'get' accessors may be 'distributed'",
+      ())
 NOTE(distributed_actor_isolated_property,none,
       "access to %0 %1 is only permitted within distributed actor %2",
       (DescriptiveDeclKind, DeclName, DeclName))

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -155,10 +155,11 @@ protected:
 
   SWIFT_INLINE_BITFIELD_EMPTY(LiteralExpr, Expr);
   SWIFT_INLINE_BITFIELD_EMPTY(IdentityExpr, Expr);
-  SWIFT_INLINE_BITFIELD(LookupExpr, Expr, 1+1+1,
+  SWIFT_INLINE_BITFIELD(LookupExpr, Expr, 1+1+1+1,
     IsSuper : 1,
     IsImplicitlyAsync : 1,
-    IsImplicitlyThrows : 1
+    IsImplicitlyThrows : 1,
+    ShouldApplyDistributedThunk: 1
   );
   SWIFT_INLINE_BITFIELD_EMPTY(DynamicLookupExpr, LookupExpr);
 
@@ -1653,6 +1654,18 @@ public:
   /// networking error.
   void setImplicitlyThrows(bool isImplicitlyThrows) {
     Bits.LookupExpr.IsImplicitlyThrows = isImplicitlyThrows;
+  }
+
+  /// Informs IRGen to that this expression should be applied as its distributed
+  /// thunk, rather than invoking the function directly.
+  ///
+  /// Only intended to be set on distributed get-only computed properties.
+  bool shouldApplyLookupDistributedThunk() const {
+    return Bits.LookupExpr.ShouldApplyDistributedThunk;
+  }
+
+  void setShouldApplyLookupDistributedThunk(bool flag) {
+    Bits.LookupExpr.ShouldApplyDistributedThunk = flag;
   }
 
   static bool classof(const Expr *E) {

--- a/include/swift/AST/StorageImpl.h
+++ b/include/swift/AST/StorageImpl.h
@@ -110,6 +110,10 @@ public:
     /// separately performing a Read into a temporary variable followed by
     /// a Write access back into the storage.
     MaterializeToTemporary,
+
+    /// The access is to a computed distributed property, and thus the
+    /// get-accessor is a distributed thunk which may perform a remote call.
+    DirectToDistributedThunkAccessor,
   };
 
 private:
@@ -149,6 +153,10 @@ public:
     return { dispatched ? DispatchToAccessor : DirectToAccessor, accessor };
   }
 
+  static AccessStrategy getDistributedGetAccessor(AccessorKind accessor) {
+    assert(accessor == AccessorKind::Get);
+    return { DirectToDistributedThunkAccessor, accessor };
+  }
   static AccessStrategy getMaterializeToTemporary(AccessStrategy read,
                                                   AccessStrategy write) {
     return { read, write };

--- a/include/swift/AST/StorageImpl.h
+++ b/include/swift/AST/StorageImpl.h
@@ -111,9 +111,9 @@ public:
     /// a Write access back into the storage.
     MaterializeToTemporary,
 
-    /// The access is to a computed distributed property, and thus the
-    /// get-accessor is a distributed thunk which may perform a remote call.
-    DirectToDistributedThunkAccessor,
+//    /// The access is to a computed distributed property, and thus the
+//    /// get-accessor is a distributed thunk which may perform a remote call.
+//    DirectToDistributedThunkAccessor,
   };
 
 private:
@@ -153,10 +153,10 @@ public:
     return { dispatched ? DispatchToAccessor : DirectToAccessor, accessor };
   }
 
-  static AccessStrategy getDistributedGetAccessor(AccessorKind accessor) {
-    assert(accessor == AccessorKind::Get);
-    return { DirectToDistributedThunkAccessor, accessor };
-  }
+//  static AccessStrategy getDistributedGetAccessor(AccessorKind accessor) {
+//    assert(accessor == AccessorKind::Get);
+//    return { DirectToDistributedThunkAccessor, accessor };
+//  }
   static AccessStrategy getMaterializeToTemporary(AccessStrategy read,
                                                   AccessStrategy write) {
     return { read, write };

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -742,6 +742,8 @@ namespace {
 
     void visitVarDecl(VarDecl *VD) {
       printCommon(VD, "var_decl");
+      if (VD->isDistributed())
+        PrintWithColorRAII(OS, DeclModifierColor) << " distributed";
       if (VD->isLet())
         PrintWithColorRAII(OS, DeclModifierColor) << " let";
       if (VD->getAttrs().hasAttribute<LazyAttr>())
@@ -2015,6 +2017,9 @@ public:
 
   void visitMemberRefExpr(MemberRefExpr *E) {
     printCommon(E, "member_ref_expr");
+    if (E->shouldApplyLookupDistributedThunk()) {
+      OS << " distributed";
+    }
     PrintWithColorRAII(OS, DeclColor) << " decl=";
     printDeclRef(E->getMember());
     if (E->getAccessSemantics() != AccessSemantics::Ordinary)

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3458,7 +3458,7 @@ ASTMangler::mangleOpaqueTypeDescriptorRecord(const OpaqueTypeDecl *decl) {
   return finalize();
 }
 
-std::string ASTMangler::mangleDistributedThunk(const FuncDecl *thunk) {
+std::string ASTMangler::mangleDistributedThunk(const AbstractFunctionDecl *thunk) {
   // Marker protocols cannot be checked at runtime, so there is no point
   // in recording them for distributed thunks.
   llvm::SaveAndRestore<bool> savedAllowMarkerProtocols(AllowMarkerProtocols,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2137,16 +2137,16 @@ getDirectReadAccessStrategy(const AbstractStorageDecl *storage) {
   llvm_unreachable("bad impl kind");
 }
 
-static AccessStrategy
-getDirectToDistributedThunkAccessorStrategy(const AbstractStorageDecl *storage) {
-  switch (storage->getReadImpl()) {
-  case ReadImplKind::Get:
-    return AccessStrategy::getDistributedGetAccessor(AccessorKind::Get);
-  default:
-    llvm_unreachable("bad impl kind for distributed property accessor");
-  }
-  llvm_unreachable("bad impl kind for distributed property accessor");
-}
+//static AccessStrategy
+//getDirectToDistributedThunkAccessorStrategy(const AbstractStorageDecl *storage) {
+//  switch (storage->getReadImpl()) {
+//  case ReadImplKind::Get:
+//    return AccessStrategy::getDistributedGetAccessor(AccessorKind::Get);
+//  default:
+//    llvm_unreachable("bad impl kind for distributed property accessor");
+//  }
+//  llvm_unreachable("bad impl kind for distributed property accessor");
+//}
 
 static AccessStrategy
 getDirectWriteAccessStrategy(const AbstractStorageDecl *storage) {
@@ -2281,13 +2281,13 @@ AbstractStorageDecl::getAccessStrategy(AccessSemantics semantics,
       if (shouldUseNativeDynamicDispatch())
         return getOpaqueAccessStrategy(this, accessKind, /*dispatch*/ false);
 
-      if (auto var = dyn_cast<VarDecl>(this)) {
-        if (var->isDistributed()) {
-          fprintf(stderr, "[%s:%d] (%s) DIST STRATEGY!!\n", __FILE__, __LINE__, __FUNCTION__);
-          var->dump();
-          return getDirectToDistributedThunkAccessorStrategy(this);
-        }
-      }
+//      if (auto var = dyn_cast<VarDecl>(this)) {
+//        if (var->isDistributed()) {
+//          fprintf(stderr, "[%s:%d] (%s) DIST STRATEGY!!\n", __FILE__, __LINE__, __FUNCTION__);
+//          var->dump();
+//          return getDirectToDistributedThunkAccessorStrategy(this);
+//        }
+//      }
 
       // If the storage is resilient from the given module and resilience
       // expansion, we cannot use direct access.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2138,6 +2138,17 @@ getDirectReadAccessStrategy(const AbstractStorageDecl *storage) {
 }
 
 static AccessStrategy
+getDirectToDistributedThunkAccessorStrategy(const AbstractStorageDecl *storage) {
+  switch (storage->getReadImpl()) {
+  case ReadImplKind::Get:
+    return AccessStrategy::getDistributedGetAccessor(AccessorKind::Get);
+  default:
+    llvm_unreachable("bad impl kind for distributed property accessor");
+  }
+  llvm_unreachable("bad impl kind for distributed property accessor");
+}
+
+static AccessStrategy
 getDirectWriteAccessStrategy(const AbstractStorageDecl *storage) {
   switch (storage->getWriteImpl()) {
   case WriteImplKind::Immutable:
@@ -2269,6 +2280,14 @@ AbstractStorageDecl::getAccessStrategy(AccessSemantics semantics,
 
       if (shouldUseNativeDynamicDispatch())
         return getOpaqueAccessStrategy(this, accessKind, /*dispatch*/ false);
+
+      if (auto var = dyn_cast<VarDecl>(this)) {
+        if (var->isDistributed()) {
+          fprintf(stderr, "[%s:%d] (%s) DIST STRATEGY!!\n", __FILE__, __LINE__, __FUNCTION__);
+          var->dump();
+          return getDirectToDistributedThunkAccessorStrategy(this);
+        }
+      }
 
       // If the storage is resilient from the given module and resilience
       // expansion, we cannot use direct access.

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1762,6 +1762,9 @@ void SILGenModule::visitVarDecl(VarDecl *vd) {
   if (vd->hasStorage())
     addGlobalVariable(vd);
 
+  fprintf(stderr, "[%s:%d] (%s) VISIT VAR DECL\n", __FILE__, __LINE__, __FUNCTION__);
+  vd->dump();
+
   vd->visitEmittedAccessors([&](AccessorDecl *accessor) {
     emitFunction(accessor);
   });
@@ -1828,6 +1831,7 @@ SILGenModule::canStorageUseStoredKeyPathComponent(AbstractStorageDecl *decl,
   case AccessStrategy::DirectToAccessor:
   case AccessStrategy::DispatchToAccessor:
   case AccessStrategy::MaterializeToTemporary:
+  case AccessStrategy::DirectToDistributedThunkAccessor:
     return false;
   }
   llvm_unreachable("unhandled strategy");

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1831,7 +1831,7 @@ SILGenModule::canStorageUseStoredKeyPathComponent(AbstractStorageDecl *decl,
   case AccessStrategy::DirectToAccessor:
   case AccessStrategy::DispatchToAccessor:
   case AccessStrategy::MaterializeToTemporary:
-  case AccessStrategy::DirectToDistributedThunkAccessor:
+//  case AccessStrategy::DirectToDistributedThunkAccessor:
     return false;
   }
   llvm_unreachable("unhandled strategy");

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1087,7 +1087,7 @@ public:
 
     // If this is a direct reference to a vardecl, just emit its value directly.
     // Recursive references to callable declarations are allowed.
-    if (isa<VarDecl>(e->getDecl())) {
+    if (auto var = dyn_cast<VarDecl>(e->getDecl())) {
       visitExpr(e);
       return;
     }
@@ -1123,6 +1123,8 @@ public:
 
     /// Some special handling may be necessary for thunks:
     if (callSite && callSite->shouldApplyDistributedThunk()) {
+      fprintf(stderr, "[%s:%d] (%s) SHOULD APPLY DIST THUNK\n", __FILE__, __LINE__, __FUNCTION__);
+
       if (auto distributedThunk = cast<AbstractFunctionDecl>(e->getDecl())->getDistributedThunk()) {
         constant = SILDeclRef(distributedThunk).asDistributed();
       }
@@ -5781,12 +5783,20 @@ RValue SILGenFunction::emitGetAccessor(SILLocation loc, SILDeclRef get,
                                        ArgumentSource &&selfValue, bool isSuper,
                                        bool isDirectUse,
                                        PreparedArguments &&subscriptIndices,
-                                       SGFContext c, bool isOnSelfParameter) {
+                                       SGFContext c,
+                                       bool isOnSelfParameter,
+                                       bool shouldUseDistributedThunk) {
   // Scope any further writeback just within this operation.
   FormalEvaluationScope writebackScope(*this);
 
+  auto constant = get;
+  if (shouldUseDistributedThunk) {
+    get.dump();
+    assert(false && "should use dist thunk");
+  }
+
   Callee getter = emitSpecializedAccessorFunctionRef(
-      *this, loc, get, substitutions, selfValue, isSuper, isDirectUse,
+      *this, loc, constant, substitutions, selfValue, isSuper, isDirectUse,
       isOnSelfParameter);
   bool hasSelf = (bool)selfValue;
   CanAnyFunctionType accessType = getter.getSubstFormalType();

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -5385,6 +5385,7 @@ static Callee getBaseAccessorFunctionRef(SILGenFunction &SGF,
                                          ArgumentSource &selfValue,
                                          bool isSuper,
                                          bool isDirectUse,
+                                         bool isDistributed,
                                          SubstitutionMap subs,
                                          bool isOnSelfParameter) {
   auto *decl = cast<AbstractFunctionDecl>(constant.getDecl());
@@ -5464,12 +5465,13 @@ emitSpecializedAccessorFunctionRef(SILGenFunction &SGF,
                                    ArgumentSource &selfValue,
                                    bool isSuper,
                                    bool isDirectUse,
+                                   bool isDistributed,
                                    bool isOnSelfParameter)
 {
   // Get the accessor function. The type will be a polymorphic function if
   // the Self type is generic.
   Callee callee = getBaseAccessorFunctionRef(SGF, loc, constant, selfValue,
-                                             isSuper, isDirectUse,
+                                             isSuper, isDirectUse, isDistributed,
                                              substitutions, isOnSelfParameter);
   
   // Collect captures if the accessor has them.
@@ -5781,23 +5783,23 @@ SILDeclRef SILGenModule::getAccessorDeclRef(AccessorDecl *accessor) {
 RValue SILGenFunction::emitGetAccessor(SILLocation loc, SILDeclRef get,
                                        SubstitutionMap substitutions,
                                        ArgumentSource &&selfValue, bool isSuper,
-                                       bool isDirectUse,
+                                       bool isDirectUse, bool isDistributed,
                                        PreparedArguments &&subscriptIndices,
                                        SGFContext c,
-                                       bool isOnSelfParameter,
-                                       bool shouldUseDistributedThunk) {
+                                       bool isOnSelfParameter) {
   // Scope any further writeback just within this operation.
   FormalEvaluationScope writebackScope(*this);
 
   auto constant = get;
-  if (shouldUseDistributedThunk) {
-    get.dump();
-    assert(false && "should use dist thunk");
-  }
+
+//  if (isDistributed) {
+//    get.dump();
+//    assert(false && "should use dist thunk");
+//  }
 
   Callee getter = emitSpecializedAccessorFunctionRef(
       *this, loc, constant, substitutions, selfValue, isSuper, isDirectUse,
-      isOnSelfParameter);
+      isDistributed, isOnSelfParameter);
   bool hasSelf = (bool)selfValue;
   CanAnyFunctionType accessType = getter.getSubstFormalType();
 
@@ -5830,7 +5832,7 @@ void SILGenFunction::emitSetAccessor(SILLocation loc, SILDeclRef set,
 
   Callee setter = emitSpecializedAccessorFunctionRef(
       *this, loc, set, substitutions, selfValue, isSuper, isDirectUse,
-      isOnSelfParameter);
+      /*isDistributed=*/false, isOnSelfParameter);
   bool hasSelf = (bool)selfValue;
   CanAnyFunctionType accessType = setter.getSubstFormalType();
 
@@ -5865,14 +5867,14 @@ void SILGenFunction::emitSetAccessor(SILLocation loc, SILDeclRef set,
 ManagedValue SILGenFunction::emitAddressorAccessor(
     SILLocation loc, SILDeclRef addressor, SubstitutionMap substitutions,
     ArgumentSource &&selfValue, bool isSuper, bool isDirectUse,
-    PreparedArguments &&subscriptIndices, SILType addressType,
-    bool isOnSelfParameter) {
+    bool isDistributed, PreparedArguments &&subscriptIndices,
+    SILType addressType, bool isOnSelfParameter) {
   // Scope any further writeback just within this operation.
   FormalEvaluationScope writebackScope(*this);
 
   Callee callee = emitSpecializedAccessorFunctionRef(
       *this, loc, addressor, substitutions, selfValue, isSuper, isDirectUse,
-      isOnSelfParameter);
+      isDistributed,  isOnSelfParameter);
   bool hasSelf = (bool)selfValue;
   CanAnyFunctionType accessType = callee.getSubstFormalType();
 
@@ -5927,7 +5929,9 @@ SILGenFunction::emitCoroutineAccessor(SILLocation loc, SILDeclRef accessor,
   Callee callee =
     emitSpecializedAccessorFunctionRef(*this, loc, accessor,
                                        substitutions, selfValue,
-                                       isSuper, isDirectUse, isOnSelfParameter);
+                                       isSuper, isDirectUse,
+                                       /*isDistributed=*/false,
+                                       isOnSelfParameter);
 
   // We're already in a full formal-evaluation scope.
   // Make a dead writeback scope; applyCoroutine won't try to pop this.

--- a/lib/SILGen/SILGenDistributed.cpp
+++ b/lib/SILGen/SILGenDistributed.cpp
@@ -233,6 +233,7 @@ void SILGenFunction::emitDistActorIdentityInit(ConstructorDecl *ctor,
   initializeProperty(*this, loc, borrowedSelfArg, var, temp);
 }
 
+// TODO(distributed): rename to DistributedActorID
 InitializeDistActorIdentity::InitializeDistActorIdentity(ConstructorDecl *ctor,
                                        ManagedValue actorSelf)
                                        : ctor(ctor),

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3444,23 +3444,23 @@ getIdForKeyPathComponentComputedProperty(SILGenModule &SGM,
     // stable identifier.
     return SGM.getFunction(getterRef, NotForDefinition);
   }
-  case AccessStrategy::DirectToDistributedThunkAccessor: {
-    assert(false && "dont need this");
-    // Locate the distributed thunk for the getter of this property
-    fprintf(stderr, "[%s:%d] (%s) CHECKING.... DirectToDistributedThunkAccessor\n", __FILE__, __LINE__, __FUNCTION__);
-    auto representativeDecl = getRepresentativeAccessorForKeyPath(storage);
-    assert(representativeDecl->isDistributed());
-    fprintf(stderr, "[%s:%d] (%s) OK, representative is DIST\n", __FILE__, __LINE__, __FUNCTION__);
-
-    auto getterThunkRef = SILDeclRef(representativeDecl->getDistributedThunk(),
-                                     SILDeclRef::Kind::Func,
-                                     /*isForeign=*/false,
-                                     /*isDistributed=*/true);
-    fprintf(stderr, "[%s:%d] (%s) THUNK\n", __FILE__, __LINE__, __FUNCTION__);
-    getterThunkRef.dump();
-
-    return SGM.getFunction(getterThunkRef, NotForDefinition);
-  }
+//  case AccessStrategy::DirectToDistributedThunkAccessor: {
+//    assert(false && "dont need this");
+//    // Locate the distributed thunk for the getter of this property
+//    fprintf(stderr, "[%s:%d] (%s) CHECKING.... DirectToDistributedThunkAccessor\n", __FILE__, __LINE__, __FUNCTION__);
+//    auto representativeDecl = getRepresentativeAccessorForKeyPath(storage);
+//    assert(representativeDecl->isDistributed());
+//    fprintf(stderr, "[%s:%d] (%s) OK, representative is DIST\n", __FILE__, __LINE__, __FUNCTION__);
+//
+//    auto getterThunkRef = SILDeclRef(representativeDecl->getDistributedThunk(),
+//                                     SILDeclRef::Kind::Func,
+//                                     /*isForeign=*/false,
+//                                     /*isDistributed=*/true);
+//    fprintf(stderr, "[%s:%d] (%s) THUNK\n", __FILE__, __LINE__, __FUNCTION__);
+//    getterThunkRef.dump();
+//
+//    return SGM.getFunction(getterThunkRef, NotForDefinition);
+//  }
   case AccessStrategy::DispatchToAccessor: {
     // Identify the property by its vtable or wtable slot.
     return SGM.getAccessorDeclRef(getRepresentativeAccessorForKeyPath(storage));

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3444,6 +3444,23 @@ getIdForKeyPathComponentComputedProperty(SILGenModule &SGM,
     // stable identifier.
     return SGM.getFunction(getterRef, NotForDefinition);
   }
+  case AccessStrategy::DirectToDistributedThunkAccessor: {
+    assert(false && "dont need this");
+    // Locate the distributed thunk for the getter of this property
+    fprintf(stderr, "[%s:%d] (%s) CHECKING.... DirectToDistributedThunkAccessor\n", __FILE__, __LINE__, __FUNCTION__);
+    auto representativeDecl = getRepresentativeAccessorForKeyPath(storage);
+    assert(representativeDecl->isDistributed());
+    fprintf(stderr, "[%s:%d] (%s) OK, representative is DIST\n", __FILE__, __LINE__, __FUNCTION__);
+
+    auto getterThunkRef = SILDeclRef(representativeDecl->getDistributedThunk(),
+                                     SILDeclRef::Kind::Func,
+                                     /*isForeign=*/false,
+                                     /*isDistributed=*/true);
+    fprintf(stderr, "[%s:%d] (%s) THUNK\n", __FILE__, __LINE__, __FUNCTION__);
+    getterThunkRef.dump();
+
+    return SGM.getFunction(getterThunkRef, NotForDefinition);
+  }
   case AccessStrategy::DispatchToAccessor: {
     // Identify the property by its vtable or wtable slot.
     return SGM.getAccessorDeclRef(getRepresentativeAccessorForKeyPath(storage));

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1444,7 +1444,8 @@ public:
                          ArgumentSource &&optionalSelfValue, bool isSuper,
                          bool isDirectAccessorUse,
                          PreparedArguments &&optionalSubscripts, SGFContext C,
-                         bool isOnSelfParameter);
+                         bool isOnSelfParameter,
+                         bool shouldUseDistributedThunk);
 
   void emitSetAccessor(SILLocation loc, SILDeclRef setter,
                        SubstitutionMap substitutions,

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1443,9 +1443,9 @@ public:
                          SubstitutionMap substitutions,
                          ArgumentSource &&optionalSelfValue, bool isSuper,
                          bool isDirectAccessorUse,
+                         bool isDistributed,
                          PreparedArguments &&optionalSubscripts, SGFContext C,
-                         bool isOnSelfParameter,
-                         bool shouldUseDistributedThunk);
+                         bool isOnSelfParameter);
 
   void emitSetAccessor(SILLocation loc, SILDeclRef setter,
                        SubstitutionMap substitutions,
@@ -1477,7 +1477,8 @@ public:
   ManagedValue emitAddressorAccessor(
       SILLocation loc, SILDeclRef addressor, SubstitutionMap substitutions,
       ArgumentSource &&optionalSelfValue, bool isSuper,
-      bool isDirectAccessorUse, PreparedArguments &&optionalSubscripts,
+      bool isDirectAccessorUse, bool isDistributed,
+      PreparedArguments &&optionalSubscripts,
       SILType addressType, bool isOnSelfParameter);
 
   CleanupHandle emitCoroutineAccessor(SILLocation loc, SILDeclRef accessor,

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1292,6 +1292,7 @@ namespace {
     bool IsSuper;
     bool IsDirectAccessorUse;
     bool IsOnSelfParameter;
+    bool IsDistributedAccessor;
     SubstitutionMap Substitutions;
     Optional<ActorIsolation> ActorIso;
 
@@ -1304,12 +1305,15 @@ namespace {
                            ArgumentList *argListForDiagnostics,
                            PreparedArguments &&indices,
                            bool isOnSelfParameter = false,
+                           bool isDistributedAccessor = false,
                            Optional<ActorIsolation> actorIso = None)
         : super(kind, decl, baseFormalType, typeData, argListForDiagnostics,
                 std::move(indices)),
           Accessor(accessor), IsSuper(isSuper),
           IsDirectAccessorUse(isDirectAccessorUse),
-          IsOnSelfParameter(isOnSelfParameter), Substitutions(substitutions),
+          IsOnSelfParameter(isOnSelfParameter),
+          IsDistributedAccessor(isDistributedAccessor),
+          Substitutions(substitutions),
           ActorIso(actorIso) {}
 
     AccessorBasedComponent(const AccessorBasedComponent &copied,
@@ -1320,6 +1324,7 @@ namespace {
         IsSuper(copied.IsSuper),
         IsDirectAccessorUse(copied.IsDirectAccessorUse),
         IsOnSelfParameter(copied.IsOnSelfParameter),
+        IsDistributedAccessor(copied.IsDistributedAccessor),
         Substitutions(copied.Substitutions),
         ActorIso(copied.ActorIso) {}
 
@@ -1341,11 +1346,13 @@ namespace {
                            ArgumentList *subscriptArgList,
                            PreparedArguments &&indices,
                            bool isOnSelfParameter,
+                           bool isDistributedAccessor,
                            Optional<ActorIsolation> actorIso)
       : AccessorBasedComponent(GetterSetterKind, decl, accessor, isSuper,
                                isDirectAccessorUse, substitutions,
                                baseFormalType, typeData, subscriptArgList,
-                               std::move(indices), isOnSelfParameter, actorIso)
+                               std::move(indices), isOnSelfParameter,
+                               isDistributedAccessor, actorIso)
     {
       assert(getAccessorDecl()->isGetterOrSetter());
     }
@@ -1650,7 +1657,8 @@ namespace {
 
         rvalue = SGF.emitGetAccessor(
             loc, getter, Substitutions, std::move(args.base), IsSuper,
-            IsDirectAccessorUse, std::move(args.Indices), c, IsOnSelfParameter);
+            IsDirectAccessorUse, std::move(args.Indices), c,
+            IsOnSelfParameter, IsDistributedAccessor);
 
       } // End the evaluation scope before any hop back to the current executor.
 

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -120,7 +120,6 @@ deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
 
   auto selfDecl = thunk->getImplicitSelfDecl();
   selfDecl->getAttrs().add(new (C) KnownToBeLocalAttr(implicit));
-  auto selfRefExpr = new (C) DeclRefExpr(selfDecl, dloc, implicit);
 
   // === return type
   Type returnTy = func->getResultInterfaceType();
@@ -146,8 +145,8 @@ deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
   Type remoteCallTargetTy = RCT->getDeclaredInterfaceType();
 
   // === __isRemoteActor(self)
-  ArgumentList *isRemoteArgs =
-      ArgumentList::forImplicitSingle(C, /*label=*/Identifier(), selfRefExpr);
+  ArgumentList *isRemoteArgs = ArgumentList::forImplicitSingle(
+      C, /*label=*/Identifier(), new (C) DeclRefExpr(selfDecl, dloc, implicit));
 
   FuncDecl *isRemoteFn = C.getIsRemoteDistributedActor();
   assert(isRemoteFn && "Could not find 'is remote' function, is the "
@@ -158,23 +157,53 @@ deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
       CallExpr::createImplicit(C, isRemoteDeclRef, isRemoteArgs);
 
   // === local branch ----------------------------------------------------------
-  // -- forward arguments
-  SmallVector<Expr*, 4> forwardingParams;
-  forwardParameters(thunk, forwardingParams);
-  auto funcRef = UnresolvedDeclRefExpr::createImplicit(C, func->getName());
-  auto forwardingArgList = ArgumentList::forImplicitCallTo(funcRef->getName(), forwardingParams, C);
+  BraceStmt *localBranchStmt;
+  if (auto accessor = dyn_cast<AccessorDecl>(func)) {
+    auto selfRefExpr = new (C) DeclRefExpr(selfDecl, dloc, implicit);
 
-  auto funcDeclRef =
-      UnresolvedDotExpr::createImplicit(C, selfRefExpr, func->getBaseName());
-  Expr *localFuncCall = CallExpr::createImplicit(C, funcDeclRef, forwardingArgList);
-  localFuncCall = AwaitExpr::createImplicit(C, sloc, localFuncCall);
-  if (func->hasThrows()) {
-    localFuncCall = TryExpr::createImplicit(C, sloc, localFuncCall);
+    auto var = accessor->getStorage();
+
+    auto varRef = UnresolvedDeclRefExpr::createImplicit(C, var->getName());
+    auto funcDeclRef =
+        UnresolvedDotExpr::createImplicit(C, selfRefExpr, var->getBaseName());
+
+    Expr *localPropertyAccess = new (C) MemberRefExpr(
+        selfRefExpr, sloc, ConcreteDeclRef(var), dloc, implicit);
+    localPropertyAccess =
+        AwaitExpr::createImplicit(C, sloc, localPropertyAccess);
+    if (accessor->hasThrows()) {
+      localPropertyAccess =
+          TryExpr::createImplicit(C, sloc, localPropertyAccess);
+    }
+
+    auto returnLocalPropertyAccess = new (C) ReturnStmt(sloc, localPropertyAccess, implicit);
+
+    fprintf(stderr, "[%s:%d] (%s) LOCAL BRANCH\n", __FILE__, __LINE__, __FUNCTION__);
+    returnLocalPropertyAccess->dump();
+    localBranchStmt =
+        BraceStmt::create(C, sloc, {returnLocalPropertyAccess}, sloc, implicit);
+  } else {
+    // normal function
+    auto selfRefExpr = new (C) DeclRefExpr(selfDecl, dloc, implicit);
+
+    // -- forward arguments
+    SmallVector<Expr*, 4> forwardingParams;
+    forwardParameters(thunk, forwardingParams);
+    auto funcRef = UnresolvedDeclRefExpr::createImplicit(C, func->getName());
+    auto forwardingArgList = ArgumentList::forImplicitCallTo(funcRef->getName(), forwardingParams, C);
+    auto funcDeclRef =
+        UnresolvedDotExpr::createImplicit(C, selfRefExpr, func->getBaseName());
+
+    Expr *localFuncCall = CallExpr::createImplicit(C, funcDeclRef, forwardingArgList);
+    localFuncCall = AwaitExpr::createImplicit(C, sloc, localFuncCall);
+    if (func->hasThrows()) {
+      localFuncCall = TryExpr::createImplicit(C, sloc, localFuncCall);
+    }
+    auto returnLocalFuncCall = new (C) ReturnStmt(sloc, localFuncCall, implicit);
+
+    localBranchStmt =
+        BraceStmt::create(C, sloc, {returnLocalFuncCall}, sloc, implicit);
   }
-  auto returnLocalFuncCall = new (C) ReturnStmt(sloc, localFuncCall, implicit);
-  auto localBranchStmt = 
-      BraceStmt::create(C, sloc, {returnLocalFuncCall}, sloc, implicit);
-
   // === remote branch  --------------------------------------------------------
   SmallVector<ASTNode, 8> remoteBranchStmts;
   // --- self.actorSystem

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -430,10 +430,19 @@ static bool varIsSafeAcrossActors(const ModuleDecl *fromModule,
     if (var->getAttrs().hasAttribute<NonisolatedAttr>())
       return true;
 
-    // If it's distributed, it's not okay.
-    if (auto nominalParent = var->getDeclContext()->getSelfNominalTypeDecl())
-      if (nominalParent->isDistributedActor())
+    // If it's distributed, generally variable access is not okay...
+    if (auto nominalParent = var->getDeclContext()->getSelfNominalTypeDecl()) {
+      if (nominalParent->isDistributedActor()) {
+        // Unless the variable itself is a distributed computed property,
+        // which are allowed, but subject to the same implicit throws/async
+        // as all other distributed function declarations.
+        if (var->isDistributed()) {
+          return true;
+        }
+
         return false;
+      }
+    }
 
     // If it's actor-isolated but in the same module, then it's OK too.
     return (fromModule == var->getDeclContext()->getParentModule());
@@ -2222,15 +2231,7 @@ namespace {
     Optional<std::pair<bool, bool>>
     checkDistributedAccess(SourceLoc declLoc, ValueDecl *decl,
                            Expr *context) {
-      // Cannot reference properties or subscripts of distributed actors.
-      if (isPropOrSubscript(decl)) {
-        ctx.Diags.diagnose(
-            declLoc, diag::distributed_actor_isolated_non_self_reference,
-            decl->getDescriptiveKind(), decl->getName());
-        noteIsolatedActorMember(decl, context);
-        return None;
-      }
-
+      // If base of the call is 'local' we permit skip distributed checks.
       if (auto baseSelf = findReferencedBaseSelf(context)) {
         if (baseSelf->getAttrs().hasAttribute<KnownToBeLocalAttr>()) {
         return std::make_pair(
@@ -2239,20 +2240,48 @@ namespace {
         }
       }
 
-      // Check that we have a distributed function.
-      auto func = dyn_cast<AbstractFunctionDecl>(decl);
-      if (!func || !func->isDistributed()) {
-        ctx.Diags.diagnose(declLoc,
-                           diag::distributed_actor_isolated_method)
-          .fixItInsert(decl->getAttributeInsertionLoc(true), "distributed ");
+      // Cannot reference subscripts, or stored properties.
+      auto var = dyn_cast<VarDecl>(decl);
+      if (isa<SubscriptDecl>(decl) || var) {
+        // But computed distributed properties are okay,
+        // and treated the same as a distributed func.
+        if (var && var->isDistributed()) {
+          fprintf(stderr, "[%s:%d] (%s) HERE\n", __FILE__, __LINE__, __FUNCTION__);
+          var->dump();
+          bool explicitlyThrowing = false;
+          if (auto getter = var->getAccessor(swift::AccessorKind::Get)) {
+            explicitlyThrowing = getter->hasThrows();
+          }
+          return std::make_pair(
+              /*setThrows*/!explicitlyThrowing,
+              /*isDistributedThunk=*/true);
+        }
 
+        // otherwise, it was a normal property or subscript and therefore illegal
+        ctx.Diags.diagnose(
+            declLoc, diag::distributed_actor_isolated_non_self_reference,
+            decl->getDescriptiveKind(), decl->getName());
         noteIsolatedActorMember(decl, context);
         return None;
       }
 
-      return std::make_pair(
-          /*setThrows=*/!func->hasThrows(),
-          /*isDistributedThunk=*/true);
+      // Check that we have a distributed function or computed property.
+      if (auto afd = dyn_cast<AbstractFunctionDecl>(decl)) {
+        if (!afd->isDistributed()) {
+          ctx.Diags.diagnose(declLoc,
+                             diag::distributed_actor_isolated_method)
+              .fixItInsert(decl->getAttributeInsertionLoc(true), "distributed ");
+
+          noteIsolatedActorMember(decl, context);
+          return None;
+        }
+
+        return std::make_pair(
+            /*setThrows=*/!afd->hasThrows(),
+            /*isDistributedThunk=*/true);
+      }
+
+      return std::make_pair(/*setThrows=*/false, /*distributedThunk=*/false);
     }
 
     /// Attempts to identify and mark a valid cross-actor use of a synchronous
@@ -2269,8 +2298,34 @@ namespace {
       // is it an access to a property?
       if (isPropOrSubscript(decl)) {
         // Cannot reference properties or subscripts of distributed actors.
-        if (isDistributed && !checkDistributedAccess(declLoc, decl, context))
-          return AsyncMarkingResult::NotDistributed;
+        fprintf(stderr, "[%s:%d] (%s) prop\n", __FILE__, __LINE__, __FUNCTION__);
+        if (isDistributed) {
+          fprintf(stderr, "[%s:%d] (%s) prop is dist\n", __FILE__, __LINE__, __FUNCTION__);
+
+          bool setThrows = false;
+          bool usesDistributedThunk = false;
+          if (auto access = checkDistributedAccess(declLoc, decl, context)) {
+            std::tie(setThrows, usesDistributedThunk) = *access;
+          } else {
+            fprintf(stderr, "[%s:%d] (%s) prop is dist -> NOPE \n", __FILE__, __LINE__, __FUNCTION__);
+            return AsyncMarkingResult::NotDistributed;
+          }
+
+          // distributed computed property access, mark it throws + async
+          if (auto lookupExpr = dyn_cast_or_null<LookupExpr>(context)) {
+            if (auto memberRef = dyn_cast<MemberRefExpr>(lookupExpr)) {
+              fprintf(stderr, "[%s:%d] (%s) SET DISTRIBUTED MEMBER REF\n", __FILE__, __LINE__, __FUNCTION__);
+              memberRef->dump();
+
+              memberRef->setImplicitlyThrows(true);
+              memberRef->setShouldApplyLookupDistributedThunk(true);
+            } else {
+              llvm_unreachable("expected distributed prop to be a MemberRef");
+            }
+          } else {
+            llvm_unreachable("expected distributed prop to have LookupExpr");
+          }
+        }
 
         if (auto declRef = dyn_cast_or_null<DeclRefExpr>(context)) {
           if (usageEnv(declRef) == VarRefUseEnv::Read) {
@@ -2328,10 +2383,12 @@ namespace {
         bool setThrows = false;
         bool usesDistributedThunk = false;
         if (isDistributed) {
-          if (auto access = checkDistributedAccess(declLoc, decl, context))
+          if (auto access = checkDistributedAccess(declLoc, decl, context)) {
             std::tie(setThrows, usesDistributedThunk) = *access;
-          else
+            fprintf(stderr, "[%s:%d] (%s) USE THUNK\n", __FILE__, __LINE__, __FUNCTION__);
+          } else {
             return AsyncMarkingResult::NotDistributed;
+          }
         }
 
         // Mark call as implicitly 'async', and also potentially as

--- a/stdlib/public/Distributed/DistributedActorSystem.swift
+++ b/stdlib/public/Distributed/DistributedActorSystem.swift
@@ -73,7 +73,7 @@ public protocol DistributedActorSystem: Sendable {
   /// to the same actor.
   func assignID<Act>(_ actorType: Act.Type) -> ActorID
     where Act: DistributedActor,
-    Act.ID == ActorID
+          Act.ID == ActorID
 
   /// Invoked during a distributed actor's initialization, as soon as it becomes fully initialized.
   ///
@@ -92,7 +92,7 @@ public protocol DistributedActorSystem: Sendable {
   /// - Parameter actor: reference to the (local) actor that was just fully initialized.
   func actorReady<Act>(_ actor: Act)
     where Act: DistributedActor,
-    Act.ID == ActorID
+          Act.ID == ActorID
 
   /// Called during when a distributed actor is deinitialized, or fails to initialize completely (e.g. by throwing
   /// out of an `init` that did not completely initialize all of the the actors stored properties yet).

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_computedProperty.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_computedProperty.swift
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-build-swift -module-name main -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s --color
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// rdar://76038845
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+// FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
+// UNSUPPORTED: windows
+
+import Distributed
+import FakeDistributedActorSystems
+
+typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
+
+distributed actor Greeter {
+  distributed var theDistributedProperty: String {
+    "Patrik the Seastar"
+  }
+}
+
+func test() async throws {
+  let system = DefaultDistributedActorSystem()
+
+  let local = Greeter(actorSystem: system)
+  let ref = try Greeter.resolve(id: local.id, using: system)
+
+  let reply = try await ref.theDistributedProperty
+  // CHECK: >> remoteCall: on:main.Greeter, target:main.Greeter.name, invocation:FakeInvocationEncoder(genericSubs: [], arguments: [], returnType: Optional(Swift.String), errorType: nil), throwing:Swift.Never, returning:Swift.String
+  // CHECK: << remoteCall return: Patrick the Seastar
+  print("reply: \(reply)")
+  // CHECK: reply: Echo: Caplin
+}
+
+@main struct Main {
+  static func main() async {
+    try! await test()
+  }
+}

--- a/test/Distributed/distributed_actor_isolation.swift
+++ b/test/Distributed/distributed_actor_isolation.swift
@@ -42,6 +42,23 @@ distributed actor DistributedActor_1 {
   distributed let letProperty: String = "" // expected-error{{property 'letProperty' cannot be 'distributed', only computed properties can}}
   distributed var varProperty: String = "" // expected-error{{property 'varProperty' cannot be 'distributed', only computed properties can}}
 
+  distributed var computed: String {
+    "computed"
+  }
+
+  distributed var computedNotCodable: NotCodableValue { // expected-error{{result type 'NotCodableValue' of distributed property 'computedNotCodable' does not conform to serialization requirement 'Codable'}}
+    .init()
+  }
+
+  distributed var getSet: String { // expected-error{{'distributed' computed property 'getSet' cannot have setter}}
+    get {
+      "computed"
+    }
+    set {
+      _ = newValue
+    }
+  }
+
   distributed static func distributedStatic() {} // expected-error{{'distributed' method cannot be 'static'}}
   distributed class func distributedClass() {}
   // expected-error@-1{{class methods are only allowed within classes; use 'static' to declare a static method}}

--- a/test/Distributed/distributed_actor_var_implicitly_async_throws.swift
+++ b/test/Distributed/distributed_actor_var_implicitly_async_throws.swift
@@ -35,16 +35,16 @@ distributed actor D {
 
   // OK:
   distributed var distGet: String {
-    distributed get {
+    get distributed {
       "okey"
     }
   }
 
   distributed var distSetGet: String {
-    distributed set {
+    set distributed {
       _ = newValue
     }
-    distributed get {
+    get distributed {
       "okey"
     }
   }

--- a/test/Distributed/distributed_actor_var_implicitly_async_throws.swift
+++ b/test/Distributed/distributed_actor_var_implicitly_async_throws.swift
@@ -33,6 +33,22 @@ distributed actor D {
     "dist"
   }
 
+  // OK:
+  distributed var distGet: String {
+    distributed get {
+      "okey"
+    }
+  }
+
+  distributed var distSetGet: String {
+    distributed set {
+      _ = newValue
+    }
+    distributed get {
+      "okey"
+    }
+  }
+
   // expected-error@+1{{'distributed' property 'hello' cannot be 'static'}}
   static distributed var hello: String {
     "nope!"


### PR DESCRIPTION
Replaces https://github.com/apple/swift/pull/42181 because of the rewrite of isolation checking in https://github.com/apple/swift/pull/42229/


First commit fixes type checking here, but emitting and using the accessor is WIP.

Resolves rdar://91283164