### PR TITLE
IRGen: address feedback on dynamic cast optimization changes

### DIFF
--- a/lib/IRGen/GenCast.cpp
+++ b/lib/IRGen/GenCast.cpp
@@ -1089,7 +1089,14 @@ llvm::Value *irgen::emitFastClassCastIfPossible(IRGenFunction &IGF,
     return nullptr;
 
   // Get the metadata pointer of the destination class type.
-  llvm::Value *destMetadata = IGF.IGM.getAddrOfTypeMetadata(targetFormalType);
+  llvm::Value *destMetadata;
+  // Windows will force the lazy initialization of class metadata.  In such a
+  // scenario, we need to access the metadata through the metadata accessor to
+  // ensure that the singleton metadata is properly initialized by the runtime.
+  // Failure to do so would result in the subsequent accesses going to the
+  // metadata cache to find that the entry, which it expects to be initialized,
+  // is not actually initialized (it was observed that the `PrivateTrackingInfo`
+  // field for the metadata cache entry was uninitialized).
   if (IGF.IGM.IRGen.Opts.LazyInitializeClassMetadata) {
     llvm::Function *accessor =
         IGF.IGM.getAddrOfTypeMetadataAccessFunction(targetFormalType,
@@ -1100,6 +1107,8 @@ llvm::Value *irgen::emitFastClassCastIfPossible(IRGenFunction &IGF,
     auto response =
         IGF.emitGenericTypeMetadataAccessFunctionCall(accessor, {}, request);
     destMetadata = response.getMetadata();
+  } else {
+    destMetadata = IGF.IGM.getAddrOfTypeMetadata(targetFormalType);
   }
   llvm::Value *lhs = IGF.Builder.CreateBitCast(destMetadata, IGF.IGM.Int8PtrTy);
     


### PR DESCRIPTION
This adds an explanatory comment around the check and divergent path for
the metadata access.  Additionally, clean up the unnecessary IR traffic
on the path by sinking the default GEP into the `else` case.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
