### PR TITLE
[cxx-interop] Add "pass through" tests for simd vector types

### DIFF
--- a/test/Interop/SwiftToCxx/functions/swift-simd-vector-functions-cxx-bridging.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-simd-vector-functions-cxx-bridging.swift
@@ -1,0 +1,33 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -typecheck -module-name Functions -clang-header-expose-public-decls -emit-clang-header-path %t/functions.h
+// RUN: %FileCheck %s < %t/functions.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/functions.h)
+
+// CHECK:      inline swift_double2 passThroughdouble2(swift_double2 x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT:   return _impl::$s9Functions18passThroughdouble2y4simd7double2VAEF(x);
+// CHECK-NEXT: }
+
+// CHECK:      inline swift_float3 passThroughfloat3(swift_float3 x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT:   return _impl::$s9Functions17passThroughfloat3y4simd6float3VAEF(x);
+// CHECK-NEXT: }
+
+// CHECK:      inline swift_float4 passThroughfloat4(swift_float4 x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT:   return _impl::$s9Functions17passThroughfloat4y4simd6float4VAEF(x);
+// CHECK-NEXT: }
+
+// CHECK:      inline swift_int3 passThroughint3(swift_int3 x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT:   return _impl::$s9Functions15passThroughint3y4simd4int3VAEF(x);
+// CHECK-NEXT: }
+
+// CHECK:      inline swift_uint4 passThroughuint4(swift_uint4 x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT:   return _impl::$s9Functions16passThroughuint4y4simd5uint4VAEF(x);
+// CHECK-NEXT: }
+
+import simd
+
+public func passThroughfloat3(_ x: float3) -> float3 { return x }
+public func passThroughfloat4(_ x: float4) -> float4 { return x }
+public func passThroughdouble2(_ x: double2) -> double2 { return x }
+public func passThroughint3(_ x: int3) -> int3 { return x }
+public func passThroughuint4(_ x: uint4) -> uint4 { return x }


### PR DESCRIPTION
<!-- What's in this pull request? -->
Add some "pass through" tests for simd vector types like `float3` and `double2`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
