### PR TITLE
[5.7][Runtime] Add pointer auth to accessible function section/cache

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -1424,6 +1424,9 @@ namespace SpecialPointerAuthDiscriminators {
 
   /// Dispatch integration.
   const uint16_t DispatchInvokeFunction = 0xf493; // = 62611
+
+  /// Functions accessible at runtime (i.e. distributed method accessors).
+  const uint16_t AccessibleFunctionRecord = 0x438c; // = 17292
 }
 
 /// The number of arguments that will be passed directly to a generic

--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -302,6 +302,9 @@ extern uintptr_t __COMPATIBILITY_LIBRARIES_CANNOT_CHECK_THE_IS_SWIFT_BIT_DIRECTL
 #define __ptrauth_swift_dispatch_invoke_function                               \
   __ptrauth(ptrauth_key_process_independent_code, 1,                           \
             SpecialPointerAuthDiscriminators::DispatchInvokeFunction)
+#define __ptrauth_swift_accessible_function_record                             \
+  __ptrauth(ptrauth_key_process_independent_data, 1,                           \
+            SpecialPointerAuthDiscriminators::AccessibleFunctionRecord)
 #define __ptrauth_swift_objc_superclass                                        \
   __ptrauth(ptrauth_key_process_independent_data, 1,                           \
             swift::SpecialPointerAuthDiscriminators::ObjCSuperclass)
@@ -334,6 +337,7 @@ extern uintptr_t __COMPATIBILITY_LIBRARIES_CANNOT_CHECK_THE_IS_SWIFT_BIT_DIRECTL
 #define __ptrauth_swift_cancellation_notification_function
 #define __ptrauth_swift_escalation_notification_function
 #define __ptrauth_swift_dispatch_invoke_function
+#define __ptrauth_swift_accessible_function_record
 #define __ptrauth_swift_objc_superclass
 #define __ptrauth_swift_runtime_function_entry
 #define __ptrauth_swift_runtime_function_entry_with_key(__key)

--- a/stdlib/public/runtime/AccessibleFunction.cpp
+++ b/stdlib/public/runtime/AccessibleFunction.cpp
@@ -30,7 +30,10 @@ using namespace swift;
 namespace {
 
 struct AccessibleFunctionsSection {
-  const AccessibleFunctionRecord *Begin, *End;
+  const AccessibleFunctionRecord *__ptrauth_swift_accessible_function_record
+      Begin;
+  const AccessibleFunctionRecord *__ptrauth_swift_accessible_function_record
+      End;
 
   AccessibleFunctionsSection(const AccessibleFunctionRecord *begin,
                              const AccessibleFunctionRecord *end)
@@ -51,12 +54,12 @@ private:
   const char *Name;
   size_t NameLength;
 
-  const AccessibleFunctionRecord *Func;
+  const AccessibleFunctionRecord *__ptrauth_swift_accessible_function_record R;
 
 public:
   AccessibleFunctionCacheEntry(llvm::StringRef name,
-                               const AccessibleFunctionRecord *func)
-      : Func(func) {
+                               const AccessibleFunctionRecord *record)
+      : R(record) {
     char *Name = reinterpret_cast<char *>(malloc(name.size()));
     memcpy(Name, name.data(), name.size());
 
@@ -64,7 +67,7 @@ public:
     this->NameLength = name.size();
   }
 
-  const AccessibleFunctionRecord *getFunction() const { return Func; }
+  const AccessibleFunctionRecord *getRecord() const { return R; }
 
   bool matchesKey(llvm::StringRef name) {
     return name == llvm::StringRef{Name, NameLength};
@@ -139,21 +142,21 @@ swift::runtime::swift_findAccessibleFunction(const char *targetNameStart,
   {
     auto snapshot = S.Cache.snapshot();
     if (auto E = snapshot.find(name))
-      return E->getFunction();
+      return E->getRecord();
   }
 
   // If entry doesn't exist (either record doesn't exist, hasn't been loaded, or
   // requested yet), let's try to find it and add to the cache.
 
-  auto *function = _searchForFunctionRecord(S, name);
-  if (function) {
+  auto *record = _searchForFunctionRecord(S, name);
+  if (record) {
     S.Cache.getOrInsert(
         name, [&](AccessibleFunctionCacheEntry *entry, bool created) {
           if (created)
-            new (entry) AccessibleFunctionCacheEntry{name, function};
+            new (entry) AccessibleFunctionCacheEntry{name, record};
           return true;
         });
   }
 
-  return function;
+  return record;
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/42311

---

- Add pointer auth primitives (discriminator and `__ptrauth` alias) for accessible functions
- Add new `__ptrauth_swift_accessible_function_record` to both section and runtime cache.

(cherry picked from commit 9157cb044e84680e4273be6cb42b0e98de20d4f0)
(cherry picked from commit 8cfb4ea0879bb52c0cca70d2f1b59839798ff5f4)
(cherry picked from commit 9165af24dd86de1165f772695fe6ad38e6792e7c)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
