### PR TITLE
Fix cast ownership to use the new doesCastPreserveOwnership API

### DIFF
--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -189,9 +189,9 @@ public:
     return use->getOwnershipConstraint();
   }
 
-  bool isDirectlyForwarding() const {
+  bool preservesOwnership() const {
     auto &mixin = *OwnershipForwardingMixin::get(use->getUser());
-    return mixin.isDirectlyForwarding();
+    return mixin.preservesOwnership();
   }
 
   ValueOwnershipKind getForwardingOwnershipKind() const;

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1112,16 +1112,18 @@ public:
 /// initializes the kind field on our object is run before our constructor runs.
 class OwnershipForwardingMixin {
   ValueOwnershipKind ownershipKind;
-  bool directlyForwards;
+  bool preservesOwnershipFlag;
 
 protected:
   OwnershipForwardingMixin(SILInstructionKind kind,
                            ValueOwnershipKind ownershipKind,
-                           bool isDirectlyForwarding = true)
-      : ownershipKind(ownershipKind), directlyForwards(isDirectlyForwarding) {
+                           bool preservesOwnership = true)
+      : ownershipKind(ownershipKind),
+        preservesOwnershipFlag(preservesOwnership) {
     assert(isa(kind) && "Invalid subclass?!");
     assert(ownershipKind && "invalid forwarding ownership");
-    assert((directlyForwards || ownershipKind != OwnershipKind::Guaranteed) &&
+    assert((preservesOwnershipFlag
+            || ownershipKind != OwnershipKind::Guaranteed) &&
            "Non directly forwarding instructions can not forward guaranteed "
            "ownership");
   }
@@ -1160,7 +1162,7 @@ public:
     return ownershipKind;
   }
   void setForwardingOwnershipKind(ValueOwnershipKind newKind) {
-    assert((isDirectlyForwarding() || newKind != OwnershipKind::Guaranteed) &&
+    assert((preservesOwnership() || newKind != OwnershipKind::Guaranteed) &&
            "Non directly forwarding instructions can not forward guaranteed "
            "ownership");
     ownershipKind = newKind;
@@ -8083,9 +8085,9 @@ protected:
   OwnershipForwardingTermInst(SILInstructionKind kind,
                               SILDebugLocation debugLoc,
                               ValueOwnershipKind ownershipKind,
-                              bool isDirectlyForwarding = true)
+                              bool preservesOwnership = true)
       : TermInst(kind, debugLoc),
-        OwnershipForwardingMixin(kind, ownershipKind, isDirectlyForwarding) {
+        OwnershipForwardingMixin(kind, ownershipKind, preservesOwnership) {
     assert(classof(kind));
   }
 

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -925,7 +925,7 @@ SILValue swift::findOwnershipReferenceAggregate(SILValue ref) {
       if (auto *term = arg->getSingleTerminator()) {
         if (term->isTransformationTerminator()) {
           auto *ti = cast<OwnershipForwardingTermInst>(term);
-          if (ti->isDirectlyForwarding()) {
+          if (ti->preservesOwnership()) {
             root = term->getOperand(0);
             continue;
           }

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -35,11 +35,11 @@ bool swift::canOpcodeForwardGuaranteedValues(SILValue value) {
   if (auto *arg = dyn_cast<SILArgument>(value))
     if (auto *ti = arg->getSingleTerminator())
       if (ti->isTransformationTerminator())
-        return OwnershipForwardingMixin::get(ti)->isDirectlyForwarding();
+        return OwnershipForwardingMixin::get(ti)->preservesOwnership();
 
   if (auto *inst = value->getDefiningInstruction())
     if (auto *mixin = OwnershipForwardingMixin::get(inst))
-      return mixin->isDirectlyForwarding() &&
+      return mixin->preservesOwnership() &&
              !isa<OwnedFirstArgForwardingSingleValueInst>(inst);
 
   return false;
@@ -47,7 +47,7 @@ bool swift::canOpcodeForwardGuaranteedValues(SILValue value) {
 
 bool swift::canOpcodeForwardGuaranteedValues(Operand *use) {
   if (auto *mixin = OwnershipForwardingMixin::get(use->getUser()))
-    return mixin->isDirectlyForwarding() &&
+    return mixin->preservesOwnership() &&
            !isa<OwnedFirstArgForwardingSingleValueInst>(use->getUser());
   return false;
 }
@@ -58,11 +58,11 @@ bool swift::canOpcodeForwardOwnedValues(SILValue value) {
   if (auto *arg = dyn_cast<SILPhiArgument>(value))
     if (auto *predTerm = arg->getSingleTerminator())
       if (predTerm->isTransformationTerminator())
-        return OwnershipForwardingMixin::get(predTerm)->isDirectlyForwarding();
+        return OwnershipForwardingMixin::get(predTerm)->preservesOwnership();
 
   if (auto *inst = value->getDefiningInstruction())
     if (auto *mixin = OwnershipForwardingMixin::get(inst))
-      return mixin->isDirectlyForwarding() &&
+      return mixin->preservesOwnership() &&
              !isa<GuaranteedFirstArgForwardingSingleValueInst>(inst);
 
   return false;
@@ -71,7 +71,7 @@ bool swift::canOpcodeForwardOwnedValues(SILValue value) {
 bool swift::canOpcodeForwardOwnedValues(Operand *use) {
   auto *user = use->getUser();
   if (auto *mixin = OwnershipForwardingMixin::get(user))
-    return mixin->isDirectlyForwarding() &&
+    return mixin->preservesOwnership() &&
            !isa<GuaranteedFirstArgForwardingSingleValueInst>(user);
   return false;
 }
@@ -1078,7 +1078,7 @@ bool swift::getAllBorrowIntroducingValues(SILValue inputValue,
       auto *arg = cast<SILPhiArgument>(value);
       auto *termInst = arg->getSingleTerminator();
       assert(termInst && termInst->isTransformationTerminator() &&
-             OwnershipForwardingMixin::get(termInst)->isDirectlyForwarding());
+             OwnershipForwardingMixin::get(termInst)->preservesOwnership());
       assert(termInst->getNumOperands() == 1 &&
              "Transforming terminators should always have a single operand");
       worklist.push_back(termInst->getAllOperands()[0].get());
@@ -1130,7 +1130,7 @@ BorrowedValue swift::getSingleBorrowIntroducingValue(SILValue inputValue) {
       auto *arg = cast<SILPhiArgument>(currentValue);
       auto *termInst = arg->getSingleTerminator();
       assert(termInst && termInst->isTransformationTerminator() &&
-             OwnershipForwardingMixin::get(termInst)->isDirectlyForwarding());
+             OwnershipForwardingMixin::get(termInst)->preservesOwnership());
       assert(termInst->getNumOperands() == 1 &&
              "Transformation terminators should only have single operands");
       currentValue = termInst->getAllOperands()[0].get();
@@ -1183,7 +1183,7 @@ bool swift::getAllOwnedValueIntroducers(
       auto *arg = cast<SILPhiArgument>(value);
       auto *termInst = arg->getSingleTerminator();
       assert(termInst && termInst->isTransformationTerminator() &&
-             OwnershipForwardingMixin::get(termInst)->isDirectlyForwarding());
+             OwnershipForwardingMixin::get(termInst)->preservesOwnership());
       assert(termInst->getNumOperands() == 1 &&
              "Transforming terminators should always have a single operand");
       worklist.push_back(termInst->getAllOperands()[0].get());
@@ -1231,7 +1231,7 @@ OwnedValueIntroducer swift::getSingleOwnedValueIntroducer(SILValue inputValue) {
       auto *arg = cast<SILPhiArgument>(currentValue);
       auto *termInst = arg->getSingleTerminator();
       assert(termInst && termInst->isTransformationTerminator() &&
-             OwnershipForwardingMixin::get(termInst)->isDirectlyForwarding());
+             OwnershipForwardingMixin::get(termInst)->preservesOwnership());
       assert(termInst->getNumOperands()
              - termInst->getNumTypeDependentOperands() == 1 &&
              "Transformation terminators should only have single operands");

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -4139,7 +4139,7 @@ public:
                       OwnershipKind::Guaranteed,
               "checked_cast_br with an AnyObject typed source cannot forward "
               "guaranteed ownership");
-      require(CBI->isDirectlyForwarding() ||
+      require(CBI->preservesOwnership() ||
                   CBI->getOperand().getOwnershipKind() !=
                       OwnershipKind::Guaranteed,
               "If checked_cast_br is not directly forwarding, it can not have "

--- a/lib/SILOptimizer/Mandatory/MoveOnlyChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyChecker.cpp
@@ -257,7 +257,7 @@ bool CopyOfBorrowedProjectionChecker::check(SILValue markedValue) {
         if (auto op = ForwardingOperand(use)) {
           // If our user is not directly forwarding, we cannot convert its
           // ownership to be guaranteed, so we treat it as a true consuming use.
-          if (!op.isDirectlyForwarding()) {
+          if (!op.preservesOwnership()) {
             foundConsumesOfBorrowedSubValues.push_back(user);
             liveness.updateForUse(user, /*lifetimeEnding*/ true);
             break;

--- a/lib/SILOptimizer/SemanticARC/OwnershipLiveRange.cpp
+++ b/lib/SILOptimizer/SemanticARC/OwnershipLiveRange.cpp
@@ -91,7 +91,7 @@ OwnershipLiveRange::OwnershipLiveRange(SILValue value)
     // here), we could get back a different value. Thus we can not transform
     // such a thing from owned to guaranteed.
     if (auto *i = OwnershipForwardingMixin::get(op->getUser())) {
-      if (!i->isDirectlyForwarding()) {
+      if (!i->preservesOwnership()) {
         tmpUnknownConsumingUses.push_back(op);
         continue;
       }

--- a/test/SILOptimizer/rcidentity_opaque.sil
+++ b/test/SILOptimizer/rcidentity_opaque.sil
@@ -10,11 +10,23 @@ class Base {}
 
 class Sub : Base {}
 
+struct Bool {
+  var value : Builtin.Int1
+}
+
 protocol P {}
 
 protocol PClass : AnyObject {}
 
 protocol PBase : Base {}
+
+public protocol Hashable {}
+
+public struct AnyHashable: Hashable {
+  internal var base: Any
+
+  public init<H: Hashable>(_ base: H)
+}
 
 // Test dynamic casts that preserve ownership. See DynamicCasts.cpp
 // swift::doesCastPreserveOwnershipForTypes.
@@ -24,6 +36,7 @@ protocol PBase : Base {}
 //   (A) one type is a bridged value and the other is an object:
 //      (A1) Boxing: <trivial> as! Object
 //      (A2) Unboxing: Object as! <trivial>
+//      (A3) Class-bridging: Error as! NSError
 //
 //   (B) one type is transparently wrapped in __SwiftValue, while the other is
 //       unwrapped. Given:
@@ -270,33 +283,46 @@ bb0(%0 : @owned $T):
 }
 
 // =============================================================================
-// (B1) Wrapped casts - may forward through a wrapper object
-//
-// Note: the AnyHashable-to-AnyObject cases are currently covered
-// by the potentially bridged casts.
+// (A3) Class bridging
 
-// TODO: The compiler could recognize this case as forwarded. Casting
-// *from* a class to AnyObject will not wrap the class.
+// Casting to NSError is indirect since it may conform to Error and
+// require Error-to-NSError bridging, unless we can statically see
+// that the source type inherits NSError.
 //
-// CHECK-LABEL: @testClassToClassArchetypeIsWrapped
+// A class-constrained archetype may be bound to NSError, unless it has a
+// non-NSError superclass constraint. Casts to archetypes thus must always be
+// indirect.
+//
+// CHECK-LABEL: @testClassToClassArchetypeIsBridged
 // CHECK: RESULT #0: 0 = 0
 // CHECK: RESULT #1: 1 = 1
-sil [ossa] @testClassToClassArchetypeIsWrapped : $@convention(thin) <U : AnyObject>(@owned Base) -> @owned U {
+sil [ossa] @testClassToClassArchetypeIsBridged : $@convention(thin) <U : AnyObject>(@owned Base) -> @owned U {
 bb0(%0 : @owned $Base):
   %1 = unconditional_checked_cast %0 : $Base to U
   return %1 : $U
 }
 
 // =============================================================================
-// (B2) Wrapped casts - may forward through a wrapper object
+// (B1) __SwiftValue Wrapping
 //
-// Note: (B1) the AnyHashable-to-AnyObject cases are currently covered
-// by the potentially bridged casts.
+// Note: the AnyHashable-to-AnyObject cases are currently covered by
+// the same logic that checks for potentially bridged casts. We
+// include it here for completeness.
+
+// CHECK-LABEL: @testNonClassToClassArchetypeIsWrapped
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 1
+sil [ossa] @testNonClassToClassArchetypeIsWrapped : $@convention(thin) <U : AnyObject>(@owned AnyHashable) -> @owned U {
+bb0(%0 : @owned $AnyHashable):
+  %1 = unconditional_checked_cast %0 : $AnyHashable to U
+  return %1 : $U
+}
+
+// =============================================================================
+// (B2) __SwiftValue Unwrapping
 //
 // TODO: In the future, when the runtime stops wrapping nontrivial types inside
-// __SwiftValue, cases (B1) and (B2) above will no longer apply. At that time,
-// expand ownership preserving cast types to AnyObject. Then remove the
-// isPotentiallyAnyObject() check.
+// __SwiftValue, cases (B1) and (B2) will no longer apply.
 
 // CHECK-LABEL: @testAnyObjectToClassIsWrapped
 // CHECK: RESULT #0: 0 = 0
@@ -310,9 +336,9 @@ bb0(%0 : @owned $AnyObject):
 // CHECK-LABEL: @testClassArchetypeToClassIsWrapped
 // CHECK: RESULT #0: 0 = 0
 // CHECK: RESULT #1: 1 = 1
-sil [ossa] @testClassArchetypeToClassIsWrapped : $@convention(thin) <U : AnyObject>(@owned U) -> @owned Sub {
-bb0(%0 : @owned $U):
-  %1 = unconditional_checked_cast %0 : $U to Sub
+sil [ossa] @testClassArchetypeToClassIsWrapped : $@convention(thin) <T : AnyObject>(@owned T) -> @owned Sub {
+bb0(%0 : @owned $T):
+  %1 = unconditional_checked_cast %0 : $T to Sub
   return %1 : $Sub
 }
 
@@ -401,4 +427,13 @@ sil [ossa] @testClassToClassIsForwarded : $@convention(thin) (@owned Base) -> @o
 bb0(%0 : @owned $Base):
   %1 = unconditional_checked_cast %0 : $Base to Sub
   return %1 : $Sub
+}
+
+// CHECK-LABEL: @testClassToAnyObjectIsForwarded
+// CHECK: RESULT #0: 0 = 0
+// CHECK: RESULT #1: 1 = 0
+sil [ossa] @testClassToAnyObjectIsForwarded : $@convention(thin) (@owned Base) -> @owned AnyObject {
+bb0(%0 : @owned $Base):
+  %1 = unconditional_checked_cast %0 : $Base to AnyObject
+  return %1 : $AnyObject
 }


### PR DESCRIPTION
CheckedBranchInst now uses doesCastPreserveOwnership.

Use the new API that determines whether a cast preserves ownership. Remove an old hack.

Refine doesCastPreserveOwnershipForTypes to allow borrowed class-to-AnyObject scalar casts.