### PR TITLE
Add `-disable-experimental-string-processing`

### DIFF
--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -562,6 +562,9 @@ def disable_deserialization_recovery :
 def enable_experimental_string_processing :
   Flag<["-"], "enable-experimental-string-processing">,
   HelpText<"Enable experimental string processing">;
+def disable_experimental_string_processing :
+  Flag<["-"], "disable-experimental-string-processing">,
+  HelpText<"Disable experimental string processing">;
 
 def enable_experimental_variadic_generics :
   Flag<["-"], "enable-experimental-variadic-generics">,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -500,15 +500,23 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
       = A->getOption().matches(OPT_enable_deserialization_recovery);
   }
 
-  // Experimental string processing
-  Opts.EnableExperimentalStringProcessing |=
-      Args.hasArg(OPT_enable_experimental_string_processing);
-
   // Whether '/.../' regex literals are enabled. This implies experimental
   // string processing.
   if (Args.hasArg(OPT_enable_bare_slash_regex)) {
     Opts.EnableBareSlashRegexLiterals = true;
     Opts.EnableExperimentalStringProcessing = true;
+  }
+
+  // Experimental string processing.
+  if (auto A = Args.getLastArg(OPT_enable_experimental_string_processing,
+                               OPT_disable_experimental_string_processing)) {
+    Opts.EnableExperimentalStringProcessing =
+        A->getOption().matches(OPT_enable_experimental_string_processing);
+
+    // When experimental string processing is explicitly disabled, also disable
+    // forward slash regex `/.../`.
+    if (!Opts.EnableExperimentalStringProcessing)
+      Opts.EnableBareSlashRegexLiterals = false;
   }
 
   Opts.EnableExperimentalBoundGenericExtensions |=

--- a/test/StringProcessing/Frontend/disable-flag.swift
+++ b/test/StringProcessing/Frontend/disable-flag.swift
@@ -1,0 +1,14 @@
+// RUN: %target-typecheck-verify-swift -enable-bare-slash-regex -disable-experimental-string-processing
+// RUN: %target-typecheck-verify-swift -disable-experimental-string-processing -enable-bare-slash-regex
+// RUN: %target-typecheck-verify-swift -enable-experimental-string-processing -disable-experimental-string-processing -enable-bare-slash-regex
+
+prefix operator /
+
+_ = /x/
+// expected-error@-1 {{'/' is not a prefix unary operator}}
+// expected-error@-2 {{cannot find 'x' in scope}}
+// expected-error@-3 {{'/' is not a postfix unary operator}}
+
+_ = #/x/# // expected-error {{expected expression in assignment}}
+
+func foo(_ x: Regex<Substring>) {} // expected-error {{cannot find type 'Regex' in scope}}

--- a/test/StringProcessing/Frontend/enable-flag.swift
+++ b/test/StringProcessing/Frontend/enable-flag.swift
@@ -1,0 +1,12 @@
+// RUN: %target-typecheck-verify-swift -enable-bare-slash-regex -enable-experimental-string-processing
+// RUN: %target-typecheck-verify-swift -enable-experimental-string-processing -enable-bare-slash-regex
+// RUN: %target-typecheck-verify-swift -disable-experimental-string-processing -enable-experimental-string-processing -enable-bare-slash-regex
+
+// REQUIRES: swift_in_compiler
+
+prefix operator / // expected-error {{prefix operator may not contain '/'}}
+
+_ = /x/
+_ = #/x/#
+
+func foo(_ x: Regex<Substring>) {}


### PR DESCRIPTION
Introduce a frontend flag that disables experimental string processing, including `/.../` literals.

