### PR TITLE
🍒[5.7][Distributed] SerializationReq must be associated type on DA

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4541,6 +4541,10 @@ NOTE(note_distributed_actor_system_can_be_defined_using_defaultdistributedactors
 ERROR(distributed_actor_protocol_illegal_inheritance,none,
       "non-distributed actor type %0 cannot conform to the 'DistributedActor' protocol",
       (DeclName))
+ERROR(actor_cannot_inherit_distributed_actor_protocol,none,
+      "actor type %0 cannot conform to the 'DistributedActor' protocol. "
+      "Isolation rules of these actor types are not interchangeable.",
+      (DeclName))
 ERROR(broken_distributed_actor_requirement,none,
       "DistributedActor protocol is broken: unexpected requirement", ())
 ERROR(distributed_actor_system_conformance_missing_adhoc_requirement,none,

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -820,6 +820,11 @@ namespace {
 
     void visitClassDecl(ClassDecl *CD) {
       printCommon(CD, "class_decl");
+      if (CD->isExplicitActor()) {
+        OS << " actor";
+      } else if (CD->isExplicitDistributedActor()) {
+        OS << " distributed actor";
+      }
       if (CD->getAttrs().hasAttribute<StaticInitializeObjCMetadataAttr>())
         OS << " @_staticInitializeObjCMetadata";
       printCommonPost(CD);

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -1171,10 +1171,10 @@ llvm::SmallPtrSet<ProtocolDecl *, 2>
 swift::extractDistributedSerializationRequirements(
     ASTContext &C, ArrayRef<Requirement> allRequirements) {
   llvm::SmallPtrSet<ProtocolDecl *, 2> serializationReqs;
-  auto systemProto = C.getDistributedActorSystemDecl();
-  auto serializationReqAssocType =
-      systemProto->getAssociatedType(C.Id_SerializationRequirement);
-  auto systemSerializationReqTy = serializationReqAssocType->getInterfaceType();
+  auto DA = C.getDistributedActorDecl();
+  auto daSerializationReqAssocType =
+      DA->getAssociatedType(C.Id_SerializationRequirement);
+  auto daSystemSerializationReqTy = daSerializationReqAssocType->getInterfaceType();
 
   for (auto req : allRequirements) {
     if (req.getSecondType()->isAny()) {
@@ -1188,7 +1188,7 @@ swift::extractDistributedSerializationRequirements(
       auto dependentTy =
           dependentMemberType->getAssocType()->getInterfaceType();
 
-      if (dependentTy->isEqual(systemSerializationReqTy)) {
+      if (dependentTy->isEqual(daSystemSerializationReqTy)) {
         auto requirementProto = req.getSecondType();
         if (auto proto = dyn_cast_or_null<ProtocolDecl>(
                 requirementProto->getAnyNominal())) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5542,6 +5542,16 @@ void swift::diagnoseConformanceFailure(Type T,
     if (!nominal)
       return;
 
+    if (isa<ClassDecl>(nominal) &&
+        !nominal->isDistributedActor()) {
+      if (nominal->isActor()) {
+        diags.diagnose(ComplainLoc,
+                       diag::actor_cannot_inherit_distributed_actor_protocol,
+                       nominal->getName());
+      } // else, already diagnosed elsewhere
+      return;
+    }
+
     // If it is missing the ActorSystem type, suggest adding it:
     auto systemTy = getDistributedActorSystemType(/*actor=*/nominal);
     if (!systemTy || systemTy->hasError()) {
@@ -6456,12 +6466,12 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
         if (!classDecl->isDistributedActor()) {
           if (classDecl->isActor()) {
             dc->getSelfNominalTypeDecl()
-            ->diagnose(diag::distributed_actor_protocol_illegal_inheritance,
+            ->diagnose(diag::actor_cannot_inherit_distributed_actor_protocol,
                        dc->getSelfNominalTypeDecl()->getName())
                        .fixItInsert(classDecl->getStartLoc(), "distributed ");
           } else {
             dc->getSelfNominalTypeDecl()
-            ->diagnose(diag::actor_protocol_illegal_inheritance,
+            ->diagnose(diag::distributed_actor_protocol_illegal_inheritance,
                        dc->getSelfNominalTypeDecl()->getName())
                        .fixItReplace(nominal->getStartLoc(), "distributed actor");
           }
@@ -6975,6 +6985,7 @@ ValueDecl *TypeChecker::deriveProtocolRequirement(DeclContext *DC,
 
   case KnownDerivableProtocolKind::DistributedActor:
     return derived.deriveDistributedActor(Requirement);
+
   case KnownDerivableProtocolKind::DistributedActorSystem:
     return derived.deriveDistributedActorSystem(Requirement);
 

--- a/stdlib/public/Distributed/DistributedActor.swift
+++ b/stdlib/public/Distributed/DistributedActor.swift
@@ -42,13 +42,14 @@ import _Concurrency
 /// actor system for the decoding initializer when decoding a distributed actor.
 @available(SwiftStdlib 5.7, *)
 public protocol DistributedActor: AnyActor, Identifiable, Hashable
-  where ID == ActorSystem.ActorID {
+  where ID == ActorSystem.ActorID,
+        SerializationRequirement == ActorSystem.SerializationRequirement {
   
   /// The type of transport used to communicate with actors of this type.
   associatedtype ActorSystem: DistributedActorSystem
 
   /// The serialization requirement to apply to all distributed declarations inside the actor.
-  typealias SerializationRequirement = ActorSystem.SerializationRequirement
+  associatedtype SerializationRequirement
 
   /// Logical identity of this distributed actor.
   ///

--- a/test/Distributed/actor_protocols.swift
+++ b/test/Distributed/actor_protocols.swift
@@ -43,12 +43,10 @@ distributed actor DA: DistributedActor {
   typealias ActorSystem = FakeActorSystem
 }
 
-// FIXME: Ideally, we should only emit the tailored conformance error.
-// expected-error@+1 {{type 'A2' does not conform to protocol 'DistributedActor'}}
+// FIXME(distributed): error reporting is a bit whacky here; needs cleanup
+// expected-error@+2{{actor type 'A2' cannot conform to the 'DistributedActor' protocol. Isolation rules of these actor types are not interchangeable.}}
+// expected-error@+1{{actor type 'A2' cannot conform to the 'DistributedActor' protocol. Isolation rules of these actor types are not interchangeable.}}
 actor A2: DistributedActor {
-  // expected-error@-1{{non-distributed actor type 'A2' cannot conform to the 'DistributedActor' protocol}} {{1-1=distributed }}
-  // expected-error@-2{{'DistributedActor' requires the types 'ObjectIdentifier' and 'FakeActorSystem.ActorID' (aka 'ActorAddress') be equivalent}}
-  // expected-note@-3{{requirement specified as 'Self.ID' == 'Self.ActorSystem.ActorID' [with Self = A2]}}
   nonisolated var id: ID {
     fatalError()
   }
@@ -65,12 +63,8 @@ actor A2: DistributedActor {
   }
 }
 
-// FIXME: Ideally, we should only emit the tailored conformance error.
-// expected-error@+1 {{type 'C2' does not conform to protocol 'DistributedActor'}}
+// expected-error@+1{{non-distributed actor type 'C2' cannot conform to the 'DistributedActor' protocol}}
 final class C2: DistributedActor {
-  // expected-error@-1{{non-actor type 'C2' cannot conform to the 'Actor' protocol}}
-  // expected-error@-2{{'DistributedActor' requires the types 'ObjectIdentifier' and 'FakeActorSystem.ActorID' (aka 'ActorAddress') be equivalent}}
-  // expected-note@-3{{requirement specified as 'Self.ID' == 'Self.ActorSystem.ActorID' [with Self = C2]}}
   nonisolated var id: ID {
     fatalError()
   }


### PR DESCRIPTION
**Description:** In order to support public protocol DistributedActor<ID, SerializationRequirement> in the future, we must make SerializationReq an associated type. Thankfully, synthesis of it is pretty simple. The typealias must be synthesized for every concrete DA. Current users won't even notice it changed.

**Risk:** Low; verified no impact on adopters.
**Review by:** @xedin @hborla 
**Testing:** PR testing
**Original PR:** https://github.com/apple/swift/pull/42341
**Radar:** rdar://91664256