### PR TITLE
[Test] Make allocator_sanity.swift more robust on 32-bit.

### DIFF
--- a/test/Runtime/allocator_sanity.swift
+++ b/test/Runtime/allocator_sanity.swift
@@ -18,10 +18,18 @@ AllocationsTestSuite.test("absurd.allocation.misaligned") {
 
 AllocationsTestSuite.test("absurd.allocation.gargantuan") {
   expectCrashLater()
+  // There is a chance that we'll actually be able to allocate Int.max bytes on
+  // 32-bit platforms, since they often have 4GB address spaces and Int.max is
+  // 2GB minus one byte. Allocate twice to ensure failure. That will (attempt
+  // to) allocate 4GB minus two bytes, and we'll definitely have more than two
+  // bytes of other stuff in the process.
   let mustFail = UnsafeMutableRawPointer.allocate(byteCount: Int.max,
                                                   alignment: 0)
+  let mustFail2 = UnsafeMutableRawPointer.allocate(byteCount: Int.max,
+                                                   alignment: 0)
   expectUnreachable()
   _ = mustFail
+  _ = mustFail2
 }
 
 runAllTests()


### PR DESCRIPTION
This test attempts to allocate Int.max bytes and asserts that it crashes. However, this can actually succeed in (some) 32-bit environments, since Int.max is only 2^32-1 bytes there. This causes spurious test failures. Ensure the test crashes by making two gargantuan allocations.

rdar://91687691