### PR TITLE
Runtime: enable Windows workaround on Android

### DIFF
--- a/include/swift/Runtime/Atomic.h
+++ b/include/swift/Runtime/Atomic.h
@@ -96,7 +96,7 @@ struct aligned_alloc<Alignment_, true> {
 #endif
   }
 
-#if defined(_WIN32)
+#if defined(_WIN32) || defined(__ANDROID__)
   // FIXME: why is this even needed?  This is not permitted as per the C++
   // standrd new.delete.placement (§17.6.3.4).
   [[nodiscard]] void *operator new(std::size_t size, void *where) noexcept {


### PR DESCRIPTION
It appears that Android fails similarly as Windows when using the
overloaded `operator new` in the resolution for the placement new
operation.  Attempt to repair the Android builds.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
