### PR TITLE
🍒[5.7][Distributed] Require that SerReq can only be used with protocols

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4643,6 +4643,9 @@ ERROR(distributed_actor_func_param_not_codable,none,
 ERROR(distributed_actor_target_result_not_codable,none,
       "result type %0 of %1 %2 does not conform to serialization requirement '%3'",
       (Type, DescriptiveDeclKind, Identifier, StringRef))
+ERROR(distributed_actor_system_serialization_req_must_be_protocol,none,
+      "'SerializationRequirement' type witness %0 must be a protocol type",
+      (Type))
 ERROR(distributed_actor_remote_func_implemented_manually,none,
       "distributed instance method's %0 remote counterpart %1 cannot not be implemented manually.",
       (Identifier, Identifier))

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -271,12 +271,9 @@ swift::getDistributedSerializationRequirements(
   if (existentialRequirementTy->isAny())
     return true; // we're done here, any means there are no requirements
 
-  if (auto alias = dyn_cast<TypeAliasType>(existentialRequirementTy.getPointer())) {
-    auto ty = alias->getDesugaredType();
-    if (isa<ClassType>(ty) || isa<StructType>(ty) || isa<EnumType>(ty)) {
-      // SerializationRequirement cannot be class or struct nowadays
-      return false;
-    }
+  if (!existentialRequirementTy->isExistentialType()) {
+    // SerializationRequirement must be an existential type
+    return false;
   }
 
   ExistentialType *serialReqType = existentialRequirementTy

--- a/lib/Sema/TypeCheckDistributed.h
+++ b/lib/Sema/TypeCheckDistributed.h
@@ -50,6 +50,9 @@ bool checkDistributedActorSystemAdHocProtocolRequirements(
     Type Adoptee,
     bool diagnose);
 
+/// Check 'DistributedActorSystem' implementations for additional restrictions.
+bool checkDistributedActorSystem(const NominalTypeDecl *system);
+
 /// Typecheck a distributed method declaration
 bool checkDistributedFunction(AbstractFunctionDecl *decl);
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -6467,6 +6467,9 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
           }
         }
       }
+    } else if (proto->isSpecificProtocol(
+                   KnownProtocolKind::DistributedActorSystem)) {
+      checkDistributedActorSystem(nominal);
     } else if (proto->isSpecificProtocol(KnownProtocolKind::Actor)) {
       if (auto classDecl = dyn_cast<ClassDecl>(nominal)) {
         if (!classDecl->isExplicitActor()) {

--- a/test/Distributed/distributed_serializationRequirement_must_be_protocol.swift
+++ b/test/Distributed/distributed_serializationRequirement_must_be_protocol.swift
@@ -1,0 +1,125 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unknown -disable-availability-checking -I %t 2>&1 %s
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+import Distributed
+import FakeDistributedActorSystems
+
+final class SomeClazz: Sendable {}
+final class SomeStruct: Sendable {}
+final class SomeEnum: Sendable {}
+
+// TODO(distributed): improve to diagnose ON the typealias rather than on the system
+// expected-error@+1{{'SerializationRequirement' type witness 'System.SerializationRequirement' (aka 'SomeClazz') must be a protocol type}}
+final class System: DistributedActorSystem {
+  // ignore those since they all fail with the SerializationRequirement being invalid:
+  // expected-error@-2{{type 'System' does not conform to protocol 'DistributedActorSystem'}}
+  // expected-note@-3{{protocol 'System' requires function 'remoteCallVoid'}}
+  // expected-error@-4{{class 'System' is missing witness for protocol requirement 'remoteCall'}}
+  // expected-note@-5{{protocol 'System' requires function 'remoteCall' with signature:}}
+  // expected-error@-6{{class 'System' is missing witness for protocol requirement 'remoteCallVoid'}}
+  typealias ActorID = String
+  typealias InvocationEncoder = ClassInvocationEncoder
+  typealias InvocationDecoder = ClassInvocationDecoder
+
+  typealias ResultHandler = DistributedTargetInvocationResultHandler
+  // expected-note@-1{{possibly intended match 'System.ResultHandler' (aka 'DistributedTargetInvocationResultHandler') does not conform to 'DistributedTargetInvocationResultHandler'}}
+
+  typealias SerializationRequirement = SomeClazz
+
+  func resolve<Act>(id: ActorID, as actorType: Act.Type)
+    throws -> Act? where Act: DistributedActor {
+    fatalError()
+  }
+
+  func assignID<Act>(_ actorType: Act.Type) -> ActorID
+    where Act: DistributedActor {
+    fatalError()
+  }
+
+  func actorReady<Act>(_ actor: Act)
+    where Act: DistributedActor,
+    Act.ID == ActorID {
+    fatalError()
+  }
+
+  func resignID(_ id: ActorID) {
+    fatalError()
+  }
+
+  func makeInvocationEncoder() -> InvocationEncoder {
+    fatalError()
+  }
+
+  func remoteCall<Act, Err, Res>(
+    on actor: Act,
+    target: RemoteCallTarget,
+    invocation: inout InvocationEncoder,
+    throwing errorType: Err.Type,
+    returning returnType: Res.Type
+  ) async throws -> Res
+    where Act: DistributedActor,
+    Act.ID == ActorID,
+    Err: Error,
+    Res: SerializationRequirement {
+    fatalError()
+  }
+
+  func remoteCallVoid<Act, Err>(
+    on actor: Act,
+    target: RemoteCallTarget,
+    invocation: inout InvocationEncoder,
+    throwing errorType: Err.Type
+  ) async throws
+    where Act: DistributedActor,
+    Act.ID == ActorID,
+    Err: Error {
+    fatalError()
+  }
+}
+
+struct ClassInvocationEncoder: DistributedTargetInvocationEncoder {
+  // expected-note@-1{{protocol 'ClassInvocationEncoder' requires function 'recordArgument' with signature:}}
+  // expected-error@-2{{struct 'ClassInvocationEncoder' is missing witness for protocol requirement 'recordArgument'}}
+  // expected-note@-3{{protocol 'ClassInvocationEncoder' requires function 'recordReturnType' with signature:}}
+  // expected-error@-4{{struct 'ClassInvocationEncoder' is missing witness for protocol requirement 'recordReturnType'}}
+  typealias SerializationRequirement = SomeClazz
+
+  public mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+  public mutating func recordArgument<Value: SerializationRequirement>(
+    _ argument: RemoteCallArgument<Value>) throws {}
+  public mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
+  public mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
+  public mutating func doneRecording() throws {}
+}
+
+final class ClassInvocationDecoder: DistributedTargetInvocationDecoder {
+  // expected-error@-1{{class 'ClassInvocationDecoder' is missing witness for protocol requirement 'decodeNextArgument'}}
+  // expected-note@-2{{protocol 'ClassInvocationDecoder' requires function 'decodeNextArgument'}}
+  typealias SerializationRequirement = SomeClazz
+
+  public func decodeGenericSubstitutions() throws -> [Any.Type] {
+    fatalError()
+  }
+
+  public func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument {
+    fatalError()
+  }
+
+  public func decodeErrorType() throws -> Any.Type? {
+    fatalError()
+  }
+
+  public func decodeReturnType() throws -> Any.Type? {
+    fatalError()
+  }
+}
+
+struct DistributedTargetInvocationResultHandler {
+  typealias SerializationRequirement = SomeClazz
+  func onReturn<Success: SomeClazz>(value: Success) async throws {}
+  func onReturnVoid() async throws {}
+  func onThrow<Err: Error>(error: Err) async throws {}
+}


### PR DESCRIPTION
**Description:** In order to in the future support  non "ad-hoc" protocol requirements we must make it possible to express `T: SerializationRequirement` in the future.

Since the `:` implies being a class or protocol, and currently we only have use cases for protocols, let us ban other things so we can figure it out in the near future.

**Risk:** Low.
**Review by:** @xedin @hborla 
**Testing:** PR validation
**Original PR:** https://github.com/apple/swift/pull/42348
**Radar:** rdar://91663499