### PR TITLE
Runtime: correct invalid C++ workaround

### DIFF
--- a/include/swift/Runtime/Atomic.h
+++ b/include/swift/Runtime/Atomic.h
@@ -95,14 +95,6 @@ struct aligned_alloc<Alignment_, true> {
     free(ptr);
 #endif
   }
-
-#if defined(_WIN32)
-  // FIXME: why is this even needed?  This is not permitted as per the C++
-  // standrd new.delete.placement (§17.6.3.4).
-  [[nodiscard]] void *operator new(std::size_t size, void *where) noexcept {
-    return ::operator new(size, where);
-  }
-#endif
 };
 
 /// The default implementation for swift::atomic<T>, which just wraps

--- a/stdlib/public/runtime/MetadataImpl.h
+++ b/stdlib/public/runtime/MetadataImpl.h
@@ -51,6 +51,7 @@
 #include "EnumImpl.h"
 
 #include <cstring>
+#include <new>
 #include <type_traits>
 
 namespace swift {


### PR DESCRIPTION
The placement new operator is only available when `<new>` has been
included.  Add the missing include to the header to allow us to get the
definition of the placement new allocator.  This allows us to remove the
workaround that was there for Windows, and should hopefully repair the
Android build as well.

Thanks to @grynspan for helping identify the underlying issue!

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
