### PR TITLE
ModuleInterface: Enable interface verification in more tests

### DIFF
--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -338,6 +338,17 @@ code for the target that is not the build machine:
 * ``%target-swift-autolink-extract``: run ``swift-autolink-extract`` for the
   target to extract its autolink flags on platforms that support them (when the
   autolink-extract feature flag is set)
+  
+* ``%target-swift-emit-module-interface(`` *swift interface path* ``)``
+  *other arguments*: run ``swift-frontend`` for the target, emitting a
+  swiftinterface to the given path and passing additional default flags
+  appropriate for resilient frameworks.
+
+* ``%target-swift-typecheck-module-from-interface(`` *swift interface path*
+  ``)`` *other arguments*: run ``swift-frontend`` for the target, verifying
+  the swiftinterface at the given path and passing additional default flags
+  appropriate for resilient frameworks. Designed to be used in combination with
+  ``%target-swift-emit-module-interface()``.
 
 * ``%target-clang``: run the system's ``clang++`` for the target.
 

--- a/test/AutoDiff/ModuleInterface/differentiation.swift
+++ b/test/AutoDiff/ModuleInterface/differentiation.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t.swiftinterface -enable-library-evolution %s
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface)
 // RUN: %FileCheck %s < %t.swiftinterface
 
 import _Differentiation

--- a/test/ClangImporter/clang-function-types.swift
+++ b/test/ClangImporter/clang-function-types.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swift-frontend -typecheck -swift-version 5 -emit-module-interface-path - -sdk %clang-importer-sdk -enable-library-evolution %s -experimental-print-full-convention -use-clang-function-types | %FileCheck %s
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -sdk %clang-importer-sdk -experimental-print-full-convention -use-clang-function-types
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -sdk %clang-importer-sdk
+// RUN: %FileCheck %s < %t.swiftinterface
 
 import ctypes
 

--- a/test/CrossImport/module-interface.swift
+++ b/test/CrossImport/module-interface.swift
@@ -7,7 +7,8 @@
 // Should pass with -enable-cross-import-overlays
 //
 
-// RUN: %target-swift-frontend -enable-cross-import-overlays -I %t/lib/swift -typecheck -emit-module-interface-path %t.swiftinterface %s -module-name ClientLibrary -swift-version 5 -enable-library-evolution
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -enable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary
 // RUN: %FileCheck %s < %t.swiftinterface
 // RUN: %FileCheck -check-prefix NEGATIVE %s < %t.swiftinterface
 
@@ -15,13 +16,13 @@
 // Should fail with -disable-cross-import-overlays
 //
 
-// RUN: not %target-swift-frontend -disable-cross-import-overlays -I %t/lib/swift -typecheck -emit-module-interface-path %t.swiftinterface %s -module-name ClientLibrary -swift-version 5 -enable-library-evolution 2>/dev/null
+// RUN: not %target-swift-emit-module-interface(%t.swiftinterface) %s -disable-cross-import-overlays -I %t/lib/swift -module-name ClientLibrary 2>/dev/null
 
 //
 // Should fail by default
 //
 
-// RUN: not %target-swift-frontend -I %t/lib/swift -typecheck -emit-module-interface-path %t.swiftinterface %s -module-name ClientLibrary -swift-version 5 -enable-library-evolution 2>/dev/null
+// RUN: not %target-swift-emit-module-interface(%t.swiftinterface) %s -I %t/lib/swift -module-name ClientLibrary -swift-version 5 2>/dev/null
 
 
 import DeclaringLibrary

--- a/test/ModuleInterface/ConstKeyword.swift
+++ b/test/ModuleInterface/ConstKeyword.swift
@@ -1,7 +1,8 @@
 // RUN: %empty-directory(%t)
 
 // Ensure the attribute is printed in swiftinterface files
-// RUN: %target-swift-frontend-typecheck -emit-module-interface-path %t/Foo.swiftinterface %s -module-name Foo
+// RUN: %target-swift-emit-module-interface(%t/Foo.swiftinterface) %s -module-name Foo
+// RUN: %target-swift-typecheck-module-from-interface(%t/Foo.swiftinterface) -module-name Foo
 // RUN: %FileCheck %s < %t/Foo.swiftinterface
 
 // Ensure the attribute is in .swiftmodule files

--- a/test/ModuleInterface/access-filter.swift
+++ b/test/ModuleInterface/access-filter.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t.swiftinterface %s -module-name AccessFilter -requirement-machine-inferred-signatures=on
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name AccessFilter -requirement-machine-inferred-signatures=on
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name AccessFilter
 // RUN: %FileCheck %s < %t.swiftinterface
 // RUN: %FileCheck -check-prefix NEGATIVE %s < %t.swiftinterface
 
@@ -109,7 +110,7 @@ extension UFIProto {
 
 // CHECK: extension AccessFilter.PublicStruct {{[{]$}}
 extension PublicStruct {
-  // CHECK: @_hasInitialValue public static var secretlySettable: Swift.Int {
+  // CHECK: public static var secretlySettable: Swift.Int {
   // CHECK-NEXT: get
   // CHECK-NEXT: }
   public private(set) static var secretlySettable: Int = 0
@@ -123,12 +124,11 @@ extension InternalStruct_BAD: PublicProto {
 // CHECK: extension AccessFilter.UFIStruct : AccessFilter.PublicProto {{[{]$}}
 extension UFIStruct: PublicProto {
   // CHECK-NEXT: @usableFromInline
-  // CHECK-NEXT: internal typealias Assoc = Swift.Int
-
-  // FIXME: Is it okay for this non-@usableFromInline implementation to satisfy
-  // the protocol?
-  func requirement() {}
+  // CHECK-NEXT: internal func requirement()
+  @usableFromInline func requirement() {}
   internal static var dummy: Int { return 0 }
+  // CHECK-NEXT: @usableFromInline
+  // CHECK-NEXT: internal typealias Assoc = Swift.Int
 } // CHECK-NEXT: {{^[}]$}}
 
 // CHECK: public enum PublicEnum {{[{]$}}

--- a/test/ModuleInterface/actor_isolation.swift
+++ b/test/ModuleInterface/actor_isolation.swift
@@ -4,11 +4,11 @@
 // RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule -emit-module-interface-path %t/Test.swiftinterface -module-name Test -enable-experimental-concurrency -I %t %s
 // RUN: %FileCheck %s < %t/Test.swiftinterface
 // RUN: %FileCheck %s -check-prefix SYNTHESIZED < %t/Test.swiftinterface
-// RUN: %target-swift-frontend -typecheck-module-from-interface -module-name Test %t/Test.swiftinterface -I %t 
+// RUN: %target-swift-typecheck-module-from-interface(%t/Test.swiftinterface) -module-name Test -I %t
 
 // RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -disable-objc-attr-requires-foundation-module -emit-module-interface-path %t/TestFromModule.swiftinterface -module-name Test -enable-experimental-concurrency -I %t 
 // RUN: %FileCheck %s < %t/TestFromModule.swiftinterface
-// RUN: %target-swift-frontend -typecheck-module-from-interface -module-name Test %t/TestFromModule.swiftinterface -I %t 
+// RUN: %target-swift-typecheck-module-from-interface(%t/TestFromModule.swiftinterface) -module-name Test -I %t
 
 // REQUIRES: concurrency
 import Preconcurrency

--- a/test/ModuleInterface/actor_objc.swift
+++ b/test/ModuleInterface/actor_objc.swift
@@ -1,11 +1,11 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule -emit-module-interface-path %t/Test.swiftinterface -module-name Test  %s
 // RUN: %FileCheck %s < %t/Test.swiftinterface
-// RUN: %target-swift-frontend -typecheck-module-from-interface -module-name Test %t/Test.swiftinterface 
+// RUN: %target-swift-typecheck-module-from-interface(%t/Test.swiftinterface) -module-name Test
 
 // RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -disable-objc-attr-requires-foundation-module -emit-module-interface-path %t/TestFromModule.swiftinterface -module-name Test 
 // RUN: %FileCheck %s < %t/TestFromModule.swiftinterface
-// RUN: %target-swift-frontend -typecheck-module-from-interface -module-name Test %t/TestFromModule.swiftinterface
+// RUN: %target-swift-typecheck-module-from-interface(%t/TestFromModule.swiftinterface) -module-name Test
 
 // REQUIRES: concurrency
 // REQUIRES: objc_interop

--- a/test/ModuleInterface/actor_protocol.swift
+++ b/test/ModuleInterface/actor_protocol.swift
@@ -1,5 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -typecheck -enable-library-evolution  -disable-availability-checking -emit-module-interface-path %t/Library.swiftinterface -module-name Library %s
+// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -disable-availability-checking -module-name Library
+// RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -disable-availability-checking -module-name Library
 // RUN: %FileCheck --check-prefix CHECK-EXTENSION %s <%t/Library.swiftinterface
 // RUN: %FileCheck --check-prefix CHECK %s <%t/Library.swiftinterface
 // REQUIRES: concurrency

--- a/test/ModuleInterface/attrs.swift
+++ b/test/ModuleInterface/attrs.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t.swiftinterface -enable-library-evolution %s
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name attrs
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name attrs
 // RUN: %FileCheck %s < %t.swiftinterface
 
 // CHECK: @_transparent public func glass() -> Swift.Int { return 0 }{{$}}

--- a/test/ModuleInterface/availability-expansion.swift
+++ b/test/ModuleInterface/availability-expansion.swift
@@ -1,6 +1,13 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -typecheck -module-name Test -emit-module-interface-path %t/Test.swiftinterface %s -define-availability "_iOS8Aligned:macOS 10.10, iOS 8.0" -define-availability "_iOS9Aligned:macOS 10.11, iOS 9.0" -define-availability "_iOS9:iOS 9.0" -define-availability "_macOS10_11:macOS 10.11" -define-availability "_myProject 1.0:macOS 10.11" -define-availability "_myProject 2.5:macOS 10.12"
+// RUN: %target-swift-emit-module-interface(%t/Test.swiftinterface) %s \
+// RUN:   -define-availability "_iOS8Aligned:macOS 10.10, iOS 8.0" \
+// RUN:   -define-availability "_iOS9Aligned:macOS 10.11, iOS 9.0" \
+// RUN:   -define-availability "_iOS9:iOS 9.0" \
+// RUN:   -define-availability "_macOS10_11:macOS 10.11" \
+// RUN:   -define-availability "_myProject 1.0:macOS 10.11" \
+// RUN:   -define-availability "_myProject 2.5:macOS 10.12"
+// RUN: %target-swift-typecheck-module-from-interface(%t/Test.swiftinterface)
 // RUN: %FileCheck %s < %t/Test.swiftinterface
 
 @available(_iOS8Aligned, *)

--- a/test/ModuleInterface/availability-macos-canonical-version.swift
+++ b/test/ModuleInterface/availability-macos-canonical-version.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -typecheck %s -enable-library-evolution -emit-module-interface-path %t/Module.swiftinterface -experimental-skip-non-inlinable-function-bodies
-// RUN: %FileCheck %s --check-prefixes CHECK < %t/Module.swiftinterface
+// RUN: %target-swift-emit-module-interface(%t/Module.swiftinterface) %s
+// RUN: %target-swift-typecheck-module-from-interface(%t/Module.swiftinterface)
+// RUN: %FileCheck %s < %t/Module.swiftinterface
 
 // REQUIRES: OS=macosx
 

--- a/test/ModuleInterface/available-attr-no-collapse.swift
+++ b/test/ModuleInterface/available-attr-no-collapse.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: echo '@available(macOS 12.0, iOS 15.0, macCatalyst 15.0, *)' > %t/Foo.swift
-// RUN: echo 'public struct Foo {}' >> %t/Foo.swift
-
-// RUN: %target-swift-frontend -emit-module -emit-module-interface-path %t/Foo.swiftinterface -enable-library-evolution %t/Foo.swift
+// RUN: %target-swift-emit-module-interface(%t/Foo.swiftinterface) %s
+// RUN: %target-swift-typecheck-module-from-interface(%t/Foo.swiftinterface)
 // RUN: %FileCheck %s < %t/Foo.swiftinterface
 
 // CHECK: macCatalyst
+@available(macOS 12.0, iOS 15.0, macCatalyst 15.0, *)
+public struct Foo {}

--- a/test/ModuleInterface/back-deploy-attr.swift
+++ b/test/ModuleInterface/back-deploy-attr.swift
@@ -1,52 +1,36 @@
 // RUN: %empty-directory(%t)
-
-// Ensure @_backDeploy attributes and function bodies are printed in
-// swiftinterface files.
-// RUN: %target-swiftc_driver -emit-module -o %t/Test.swiftmodule -emit-module-interface-path %t/Test.swiftinterface %s -enable-library-evolution -verify-emitted-module-interface -module-name Test \
-// RUN:   -Xfrontend -define-availability -Xfrontend "_macOS12_1:macOS 12.1" \
-// RUN:   -Xfrontend -define-availability -Xfrontend "_myProject 1.0:macOS 12.1, iOS 15.1"
-// RUN: %FileCheck %s --check-prefix FROMSOURCE --check-prefix CHECK < %t/Test.swiftinterface
-
-// FIXME(backDeploy): Remove this step in favor of a test that exercises using
-// a back deployed API from a test library so that we can avoid -merge-modules
-
-// Ensure @_backDeploy attributes and function bodies are present after
-// deserializing .swiftmodule files.
-// RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -disable-objc-attr-requires-foundation-module -emit-module-interface-path %t/TestFromModule.swiftinterface -module-name Test \
+// RUN: %target-swift-emit-module-interface(%t/Test.swiftinterface) %s \
 // RUN:   -define-availability "_macOS12_1:macOS 12.1" \
 // RUN:   -define-availability "_myProject 1.0:macOS 12.1, iOS 15.1"
-// RUN: %FileCheck %s --check-prefix FROMMODULE --check-prefix CHECK < %t/TestFromModule.swiftinterface
+// RUN: %target-swift-typecheck-module-from-interface(%t/Test.swiftinterface)
+// RUN: %FileCheck %s < %t/Test.swiftinterface
 
 public struct TopLevelStruct {
   // CHECK: @_backDeploy(before: macOS 12.0)
-  // FROMSOURCE: public func backDeployedFunc_SinglePlatform() -> Swift.Int { return 42 }
-  // FROMMODULE: public func backDeployedFunc_SinglePlatform() -> Swift.Int
+  // CHECK: public func backDeployedFunc_SinglePlatform() -> Swift.Int { return 42 }
   @available(macOS 11.0, *)
   @_backDeploy(before: macOS 12.0)
   public func backDeployedFunc_SinglePlatform() -> Int { return 42 }
   
   // CHECK: @_backDeploy(before: macOS 12.0)
   // CHECK: @_backDeploy(before: iOS 15.0)
-  // FROMSOURCE: public func backDeployedFunc_MultiPlatform() -> Swift.Int { return 43 }
-  // FROMMODULE: public func backDeployedFunc_MultiPlatform() -> Swift.Int
+  // CHECK: public func backDeployedFunc_MultiPlatform() -> Swift.Int { return 43 }
   @available(macOS 11.0, iOS 14.0, *)
   @_backDeploy(before: macOS 12.0, iOS 15.0)
   public func backDeployedFunc_MultiPlatform() -> Int { return 43 }
 
   // CHECK: @_backDeploy(before: macOS 12.0)
-  // FROMSOURCE: public var backDeployedComputedProperty: Swift.Int {
-  // FROMSOURCE:   get { 44 }
-  // FROMSOURCE: }
-  // FROMMODULE: public var backDeployedComputedProperty: Swift.Int
+  // CHECK: public var backDeployedComputedProperty: Swift.Int {
+  // CHECK:   get { 44 }
+  // CHECK: }
   @available(macOS 11.0, *)
   @_backDeploy(before: macOS 12.0)
   public var backDeployedComputedProperty: Int { 44 }
 
   // CHECK: @_backDeploy(before: macOS 12.0)
-  // FROMSOURCE: public var backDeployedPropertyWithAccessors: Swift.Int {
-  // FROMSOURCE:   get { 45 }
-  // FROMSOURCE: }
-  // FROMMODULE: public var backDeployedPropertyWithAccessors: Swift.Int
+  // CHECK: public var backDeployedPropertyWithAccessors: Swift.Int {
+  // CHECK:   get { 45 }
+  // CHECK: }
   @available(macOS 11.0, *)
   @_backDeploy(before: macOS 12.0)
   public var backDeployedPropertyWithAccessors: Int {
@@ -54,10 +38,9 @@ public struct TopLevelStruct {
   }
 
   // CHECK: @_backDeploy(before: macOS 12.0)
-  // FROMSOURCE: public subscript(index: Swift.Int) -> Swift.Int {
-  // FROMSOURCE:   get { 46 }
-  // FROMSOURCE: }
-  // FROMMODULE: public subscript(index: Swift.Int) -> Swift.Int
+  // CHECK: public subscript(index: Swift.Int) -> Swift.Int {
+  // CHECK:   get { 46 }
+  // CHECK: }
   @available(macOS 11.0, *)
   @_backDeploy(before: macOS 12.0)
   public subscript(index: Int) -> Int {
@@ -66,8 +49,7 @@ public struct TopLevelStruct {
 }
 
 // CHECK: @_backDeploy(before: macOS 12.0)
-// FROMSOURCE: public func backDeployTopLevelFunc1() -> Swift.Int { return 47 }
-// FROMMODULE: public func backDeployTopLevelFunc1() -> Swift.Int
+// CHECK: public func backDeployTopLevelFunc1() -> Swift.Int { return 47 }
 @available(macOS 11.0, *)
 @_backDeploy(before: macOS 12.0)
 public func backDeployTopLevelFunc1() -> Int { return 47 }
@@ -75,16 +57,14 @@ public func backDeployTopLevelFunc1() -> Int { return 47 }
 // MARK: - Availability macros
 
 // CHECK: @_backDeploy(before: macOS 12.1)
-// FROMSOURCE: public func backDeployTopLevelFunc2() -> Swift.Int { return 48 }
-// FROMMODULE: public func backDeployTopLevelFunc2() -> Swift.Int
+// CHECK: public func backDeployTopLevelFunc2() -> Swift.Int { return 48 }
 @available(macOS 11.0, *)
 @_backDeploy(before: _macOS12_1)
 public func backDeployTopLevelFunc2() -> Int { return 48 }
 
 // CHECK: @_backDeploy(before: macOS 12.1)
 // CHECK: @_backDeploy(before: iOS 15.1)
-// FROMSOURCE: public func backDeployTopLevelFunc3() -> Swift.Int { return 49 }
-// FROMMODULE: public func backDeployTopLevelFunc3() -> Swift.Int
+// CHECK: public func backDeployTopLevelFunc3() -> Swift.Int { return 49 }
 @available(macOS 11.0, iOS 14.0, *)
 @_backDeploy(before: _myProject 1.0)
 public func backDeployTopLevelFunc3() -> Int { return 49 }

--- a/test/ModuleInterface/closure.swift
+++ b/test/ModuleInterface/closure.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -typecheck %s -emit-module-interface-path %t/main.swiftinterface -enable-library-evolution
+// RUN: %target-swift-emit-module-interface(%t/main.swiftinterface) %s
+// RUN: %target-swift-typecheck-module-from-interface(%t/main.swiftinterface)
 // RUN: %FileCheck %s < %t/main.swiftinterface
 
 // CHECK: import Swift

--- a/test/ModuleInterface/concurrency.swift
+++ b/test/ModuleInterface/concurrency.swift
@@ -1,5 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -typecheck -enable-library-evolution -enable-experimental-concurrency -emit-module-interface-path %t/Library.swiftinterface -DLIBRARY -module-name Library %s
+// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -enable-experimental-concurrency -DLIBRARY -module-name Library
+// RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -enable-experimental-concurrency
 
 // REQUIRES: concurrency
 
@@ -36,5 +37,6 @@ func callFn() async {
 // CHECK: public func reasyncFn(_: () async -> ()) reasync
 // CHECK: public func takesSendable(_ block: @escaping @Sendable () async throws ->
 
-// RUN: %target-swift-frontend -typecheck -enable-library-evolution -enable-experimental-concurrency -emit-module-interface-path %t/Library.swiftinterface -DLIBRARY -module-name Library %s -module-interface-preserve-types-as-written
+// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -enable-experimental-concurrency -DLIBRARY -module-name Library -module-interface-preserve-types-as-written
+// RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -enable-experimental-concurrency
 // RUN: %FileCheck %s <%t/Library.swiftinterface

--- a/test/ModuleInterface/conformances.swift
+++ b/test/ModuleInterface/conformances.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend-typecheck -emit-module-interface-path %t.swiftinterface %s
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name conformances
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name conformances
 // RUN: %FileCheck %s < %t.swiftinterface
 // RUN: %FileCheck -check-prefix CHECK-END %s < %t.swiftinterface
 // RUN: %FileCheck -check-prefix NEGATIVE %s < %t.swiftinterface

--- a/test/ModuleInterface/consuming.swift
+++ b/test/ModuleInterface/consuming.swift
@@ -1,8 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/missing)
 // RUN: %empty-directory(%t/inputs)
-// RUN: %target-swift-frontend -emit-module-path %t/missing/Foo.swiftmodule -enable-library-evolution -emit-module-interface-path %t/inputs/Foo.swiftinterface -enable-objc-interop -disable-objc-attr-requires-foundation-module -module-name Foo %s
-// RUN: %FileCheck --input-file %t/inputs/Foo.swiftinterface %s
+// RUN: %target-swift-frontend -emit-module-path %t/missing/Foo.swiftmodule -swift-version 5 -enable-library-evolution -emit-module-interface-path %t/inputs/Foo.swiftinterface -enable-objc-interop -disable-objc-attr-requires-foundation-module -module-name Foo %s
+// RUN: %target-swift-typecheck-module-from-interface(%t/inputs/Foo.swiftinterface)
+// RUN: %FileCheck %s < %t/inputs/Foo.swiftinterface
 
 // RUN: touch %t/Bar.swift
 // RUN: echo "import Foo" > %t/Bar.swift

--- a/test/ModuleInterface/effectful_properties.swift
+++ b/test/ModuleInterface/effectful_properties.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend -typecheck -swift-version 5 -enable-library-evolution -emit-module-interface-path %t.swiftinterface %s -module-name EffProps -disable-availability-checking
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name EffProps -disable-availability-checking
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name EffProps -disable-availability-checking
 // RUN: %FileCheck %s < %t.swiftinterface
 
 public struct MyStruct {}

--- a/test/ModuleInterface/empty-extension.swift
+++ b/test/ModuleInterface/empty-extension.swift
@@ -6,7 +6,8 @@
 // RUN: %target-swift-frontend -emit-module %s -DEXPORTED_LIB -module-name IndirectLib -emit-module-path %t/IndirectLib.swiftmodule -I %t
 // RUN: %target-swift-frontend -emit-module %s -DLIB -module-name Lib -emit-module-path %t/Lib.swiftmodule -I %t
 
-// RUN: %target-swift-frontend-typecheck -emit-module-interface-path %t/out.swiftinterface %s -I %t -swift-version 5 -enable-library-evolution
+// RUN: %target-swift-emit-module-interface(%t/out.swiftinterface) %s -I %t -module-name Test
+// RUN: %target-swift-typecheck-module-from-interface(%t/out.swiftinterface) -I %t -module-name Test
 // RUN: %FileCheck %s < %t/out.swiftinterface
 
 // REQUIRES: OS=macosx

--- a/test/ModuleInterface/escape-Type-and-Protocol.swift
+++ b/test/ModuleInterface/escape-Type-and-Protocol.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swift-frontend -typecheck -emit-module-interface-path - %s | %FileCheck %s
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name main
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name main
+// RUN: %FileCheck %s < %t.swiftinterface
 
 // CHECK: public let Type: Swift.Int
 public let Type = 0
@@ -17,7 +19,7 @@ public class B {
   // CHECK: }
   public class `Type` {}
 
-  // CHECK-NEXT: @_hasInitialValue public var `Type`: Swift.Int
+  // CHECK-NEXT: public var `Type`: Swift.Int
   public var `Type` = 0
 // CHECK: }
 }

--- a/test/ModuleInterface/exported-module-name.swift
+++ b/test/ModuleInterface/exported-module-name.swift
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t/CoreKitClient.swiftinterface -module-name CoreKitClient -I %S/Inputs/exported-module-name-before %s
+// RUN: %target-swift-emit-module-interface(%t/CoreKitClient.swiftinterface) %s -module-name CoreKitClient -I %S/Inputs/exported-module-name-before
 // RUN: %FileCheck -implicit-check-not BAD %s < %t/CoreKitClient.swiftinterface
 
 // Test that we can rebuild it even when the "export as" module goes away.
-// RUN: %target-swift-frontend -compile-module-from-interface -o %t/CoreKitClient.swiftmodule -I %S/Inputs/exported-module-name-after %t/CoreKitClient.swiftinterface
+// RUN: %target-swift-typecheck-module-from-interface(%t/CoreKitClient.swiftinterface) -module-name CoreKitClient -I %S/Inputs/exported-module-name-after
 
 // CHECK: import CoreKit
 import CoreKit

--- a/test/ModuleInterface/features.swift
+++ b/test/ModuleInterface/features.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -typecheck -swift-version 5 -module-name FeatureTest -emit-module-interface-path %t/FeatureTest.swiftinterface -enable-library-evolution  -disable-availability-checking %s
+// RUN: %target-swift-emit-module-interface(%t/FeatureTest.swiftinterface) %s -module-name FeatureTest -disable-availability-checking
+// RUN: %target-swift-typecheck-module-from-interface(%t/FeatureTest.swiftinterface) -module-name FeatureTest -disable-availability-checking
 // RUN: %FileCheck %s < %t/FeatureTest.swiftinterface
-// RUN: %target-swift-frontend -typecheck-module-from-interface -disable-availability-checking -swift-version 5 -module-name FeatureTest %t/FeatureTest.swiftinterface
 
 // REQUIRES: concurrency
 

--- a/test/ModuleInterface/full-convention.swift
+++ b/test/ModuleInterface/full-convention.swift
@@ -1,4 +1,7 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -swift-version 5 -emit-module-interface-path - -enable-library-evolution %s -experimental-print-full-convention -use-clang-function-types | %FileCheck %s
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -swift-version 5 -emit-module-interface-path %t/full-convention.swiftinterface -enable-library-evolution %s -experimental-print-full-convention -use-clang-function-types
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck-module-from-interface %t/full-convention.swiftinterface
+// RUN: %FileCheck %s < %t/full-convention.swiftinterface
 
 import ctypes
 

--- a/test/ModuleInterface/iboutlet-private-set.swift
+++ b/test/ModuleInterface/iboutlet-private-set.swift
@@ -1,9 +1,9 @@
 // REQUIRES: objc_interop
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -typecheck -enable-library-evolution -disable-objc-attr-requires-foundation-module -module-name Foo -emit-module-interface-path %t/Foo.swiftinterface %s
-// RUN: %FileCheck %s -input-file %t/Foo.swiftinterface
-// RUN: %target-swift-frontend -compile-module-from-interface %t/Foo.swiftinterface -o %t/Foo.swiftmodule -module-name Foo
+// RUN: %target-swift-emit-module-interface(%t/Foo.swiftinterface) %s -disable-objc-attr-requires-foundation-module -module-name Foo
+// RUN: %FileCheck %s < %t/Foo.swiftinterface
+// RUN: %target-swift-typecheck-module-from-interface(%t/Foo.swiftinterface) -module-name Foo
 
 // Test the interface we generate for @IBOutlet private(set) properties is
 // consumable.

--- a/test/ModuleInterface/if-configs.swift
+++ b/test/ModuleInterface/if-configs.swift
@@ -3,7 +3,8 @@
 // RUN: %target-swift-frontend -merge-modules -emit-module -o %t/Test.swiftmodule %t/Test~partial.swiftmodule
 // RUN: %target-swift-ide-test -print-module -module-to-print=Test -source-filename=x -I %t -prefer-type-repr=false -fully-qualified-types=true | %FileCheck %s
 
-// RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t.swiftinterface -enable-library-evolution %s
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface)
 // RUN: %FileCheck %s < %t.swiftinterface
 
 // CHECK: func hasClosureDefaultArgWithComplexNestedPoundIfs(_ x: () -> Swift.Void = {

--- a/test/ModuleInterface/imports.swift
+++ b/test/ModuleInterface/imports.swift
@@ -1,7 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -disable-implicit-concurrency-module-import -emit-module -o %t/empty.swiftmodule %S/../Inputs/empty.swift
 // RUN: %target-swift-frontend -disable-implicit-concurrency-module-import -emit-module -o %t/emptyButWithLibraryEvolution.swiftmodule %S/../Inputs/empty.swift -enable-library-evolution
-// RUN: %target-swift-frontend -disable-implicit-concurrency-module-import -typecheck -emit-module-interface-path - %s %S/Inputs/imports-other.swift -I %S/Inputs/imports-clang-modules/ -I %t -verify -swift-version 5 -enable-library-evolution | %FileCheck -implicit-check-not BAD %s
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s %S/Inputs/imports-other.swift -disable-implicit-concurrency-module-import -I %S/Inputs/imports-clang-modules/ -I %t -verify
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -I %S/Inputs/imports-clang-modules/ -I %t
+// RUN: %FileCheck -implicit-check-not BAD %s < %t.swiftinterface
 
 
 @_exported import empty // expected-warning {{module 'empty' was not compiled with library evolution support; using it means binary compatibility for 'imports' can't be guaranteed}}

--- a/test/ModuleInterface/indirect-conformance-implementation-only.swift
+++ b/test/ModuleInterface/indirect-conformance-implementation-only.swift
@@ -3,6 +3,7 @@
 
 // RUN: %target-swift-frontend -emit-module %t/SecretLib.swift -o %t/SecretLib.swiftmodule
 // RUN: %target-swift-frontend -emit-module %t/Client.swift -I %t -emit-module-interface-path %t/Client.swiftinterface -enable-library-evolution -swift-version 5
+// RUN: %target-swift-typecheck-module-from-interface(%t/Client.swiftinterface)
 
 /// The indirect conformance of `s` to `_p` should not be printed. (rdar://78718838)
 // RUN: cat %t/Client.swiftinterface | %FileCheck %s

--- a/test/ModuleInterface/inherited-defaults-execution.swift
+++ b/test/ModuleInterface/inherited-defaults-execution.swift
@@ -8,12 +8,13 @@
 //
 // RUN: %target-build-swift-dylib(%t/%target-library-name(Inherited)) -emit-module-path %t/Inherited.swiftmodule -emit-module-interface-path %t/Inherited.swiftinterface -module-name Inherited %s
 // RUN: rm %t/Inherited.swiftmodule
+// RUN: %target-swift-typecheck-module-from-interface(%t/Inherited.swiftinterface)
 
 // 2) Check the interface includes the synthesized initializers of the base
 //    class in the derived class explicitly and uses the '= super' syntax to
 //    inherit its default arguments.
 //
-// RUN: cat %t/Inherited.swiftinterface | %FileCheck --check-prefix=INTERFACE %s
+// RUN: %FileCheck --check-prefix=INTERFACE %s < %t/Inherited.swiftinterface
 //
 // INTERFACE: public class Base {
 // INTERFACE:   public init(x: Swift.Int = 45, y: Swift.Int = 98)

--- a/test/ModuleInterface/inherited-generic-parameters.swift
+++ b/test/ModuleInterface/inherited-generic-parameters.swift
@@ -1,11 +1,13 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -typecheck %s -emit-module-interface-path %t/main.swiftinterface -enable-library-evolution
+// RUN: %target-swift-emit-module-interface(%t/main.swiftinterface) %s
+// RUN: %target-swift-typecheck-module-from-interface(%t/main.swiftinterface)
 // RUN: %FileCheck %s < %t/main.swiftinterface
 
 // RUN: %target-swift-frontend -emit-module -module-name main -primary-file %s -emit-module-path %t/main~partial.swiftmodule -enable-library-evolution
 
 // RUN: %target-swift-frontend -merge-modules %t/main~partial.swiftmodule -emit-module-path %t/main.swiftmodule -emit-module-interface-path %t/main.swiftinterface -enable-library-evolution
+// RUN: %target-swift-typecheck-module-from-interface(%t/main.swiftinterface)
 // RUN: %FileCheck %s < %t/main.swiftinterface
 
 // This test makes sure that we substitute uses of the superclass's generic
@@ -16,8 +18,8 @@ public class Base<In, Out> {
 // CHECK-NEXT: public init(x: @escaping (In) -> Out)
   public init(x: @escaping (In) -> Out) {}
 
-// CHECK-NEXT: public init<A>(_: A, _: A)
-  public init<A>(_: A, _: A) {}
+// CHECK-NEXT: public init<A>(_ a1: A, _ a2: A)
+  public init<A>(_ a1: A, _ a2: A) {}
 
 // CHECK-NEXT: public init<C>(_: C) where C : main.Base<In, Out>
   public init<C>(_: C) where C : Base<In, Out> {}
@@ -27,7 +29,7 @@ public class Base<In, Out> {
 // CHECK: public class Derived<T> : {{(main.)?}}Base<T, T> {
 public class Derived<T> : Base<T, T> {
 // CHECK-NEXT: override public init(x: @escaping (T) -> T)
-// CHECK-NEXT: override public init<A>(_ argument: A, _ argument: A)
+// CHECK-NEXT: override public init<A>(_ a1: A, _ a2: A)
 // CHECK-NEXT: override public init<C>(_ argument: C) where C : main.Base<T, T>
 // CHECK-NEXT: {{(@objc )?}}deinit
 // CHECK-NEXT: }

--- a/test/ModuleInterface/inherits-superclass-initializers.swift
+++ b/test/ModuleInterface/inherits-superclass-initializers.swift
@@ -2,7 +2,8 @@
 
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -typecheck %s -emit-module-interface-path %t/Module.swiftinterface -module-name Module -enable-library-evolution
+// RUN: %target-swift-emit-module-interface(%t/Module.swiftinterface) %s -module-name Module
+// RUN: %target-swift-typecheck-module-from-interface(%t/Module.swiftinterface) -module-name Module
 // RUN: %FileCheck %s < %t/Module.swiftinterface
 
 // CHECK: @_hasMissingDesignatedInitializers open class Base {

--- a/test/ModuleInterface/inlinable-function.swift
+++ b/test/ModuleInterface/inlinable-function.swift
@@ -1,7 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule -emit-module-interface-path %t/Test.swiftinterface -module-name Test %s
 // RUN: %FileCheck %s --check-prefix FROMSOURCE --check-prefix CHECK < %t/Test.swiftinterface
+// RUN: %target-swift-typecheck-module-from-interface(%t/Test.swiftinterface) -module-name Test
 // RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -disable-objc-attr-requires-foundation-module -emit-module-interface-path %t/TestFromModule.swiftinterface -module-name Test
+// RUN: %target-swift-typecheck-module-from-interface(%t/TestFromModule.swiftinterface) -module-name Test
 // RUN: %FileCheck %s --check-prefix FROMMODULE --check-prefix CHECK < %t/TestFromModule.swiftinterface
 
 // CHECK-LABEL: public struct Foo : Swift.Hashable {

--- a/test/ModuleInterface/loading-remarks.swift
+++ b/test/ModuleInterface/loading-remarks.swift
@@ -3,7 +3,7 @@
 
 /// Create a simple module and interface.
 // RUN: echo 'public func publicFunction() {}' > %t/TestModule.swift
-// RUN: %target-swift-frontend -typecheck %t/TestModule.swift -emit-module-interface-path %t/TestModule.swiftinterface -swift-version 5
+// RUN: %target-swift-emit-module-interface(%t/TestModule.swiftinterface) %t/TestModule.swift
 
 /// Use -Rmodule-loading in a client and look for the diagnostics output.
 // RUN: %target-swift-frontend -typecheck %s -I %t -Rmodule-loading 2>&1 | %FileCheck %s

--- a/test/ModuleInterface/member-typealias.swift
+++ b/test/ModuleInterface/member-typealias.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swift-frontend -typecheck -emit-module-interface-path - %s -enable-library-evolution -module-name MyModule | %FileCheck %s --check-prefix CHECK
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name MyModule
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name MyModule
+// RUN: %FileCheck %s < %t.swiftinterface
 
 public struct MyStruct<T> {
 // CHECK-LABEL: public struct MyStruct<T> {

--- a/test/ModuleInterface/modifiers.swift
+++ b/test/ModuleInterface/modifiers.swift
@@ -1,5 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule -emit-module-interface-path %t/Test.swiftinterface -module-name Test -disable-objc-attr-requires-foundation-module -enable-objc-interop %s
+// RUN: %target-swift-typecheck-module-from-interface(%t/Test.swiftinterface) -module-name Test
 // RUN: %FileCheck %s --check-prefix FROMSOURCE --check-prefix CHECK < %t/Test.swiftinterface
 // RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules %t/Test.swiftmodule -disable-objc-attr-requires-foundation-module -emit-module-interface-path - -module-name Test -enable-objc-interop | %FileCheck %s --check-prefix FROMMODULE --check-prefix CHECK
 

--- a/test/ModuleInterface/module_shadowing.swift
+++ b/test/ModuleInterface/module_shadowing.swift
@@ -2,8 +2,10 @@
 
 // Build modules imported by this file.
 // RUN: %empty-directory(%t/lib)
-// RUN: %target-swift-frontend -typecheck -parse-stdlib -module-cache-path %t/mcp -emit-module-interface-path %t/lib/ShadowyHorror.swiftinterface %S/Inputs/ShadowyHorror.swift -enable-library-evolution -module-name ShadowyHorror -swift-version 5
-// RUN: %target-swift-frontend -typecheck -parse-stdlib -emit-module-interface-path %t/lib/TestModule.swiftinterface %S/Inputs/TestModule.swift -enable-library-evolution -module-name TestModule -swift-version 5
+// RUN: %target-swift-emit-module-interface(%t/lib/ShadowyHorror.swiftinterface) %S/Inputs/ShadowyHorror.swift -parse-stdlib -module-cache-path %t/mcp -module-name ShadowyHorror
+// RUN: %target-swift-typecheck-module-from-interface(%t/lib/ShadowyHorror.swiftinterface) -module-name ShadowyHorror
+// RUN: %target-swift-emit-module-interface(%t/lib/TestModule.swiftinterface) %S/Inputs/TestModule.swift -parse-stdlib -module-name TestModule
+// RUN: %target-swift-typecheck-module-from-interface(%t/lib/TestModule.swiftinterface) -module-name TestModule
 
 // Build this file as a module and check that it emits the expected warnings.
 // RUN: %empty-directory(%t/subtest-1)

--- a/test/ModuleInterface/multiline-availability-message.swift
+++ b/test/ModuleInterface/multiline-availability-message.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -typecheck -module-name Test -emit-module-interface-path %t/Test.swiftinterface %s
+// RUN: %target-swift-emit-module-interface(%t/Test.swiftinterface) %s -module-name Test
+// RUN: %target-swift-typecheck-module-from-interface(%t/Test.swiftinterface) -module-name Test
 // RUN: %FileCheck %s < %t/Test.swiftinterface
 // RUN: %target-swift-frontend -compile-module-from-interface %t/Test.swiftinterface -o %t/Test.swiftmodule
 // RUN: %target-swift-frontend -emit-module -o /dev/null -merge-modules -emit-module-interface-path - %t/Test.swiftmodule -module-name Test | %FileCheck %s

--- a/test/ModuleInterface/non-public-designated-inits-client.swift
+++ b/test/ModuleInterface/non-public-designated-inits-client.swift
@@ -2,7 +2,8 @@
 // init cannot be called.
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -typecheck %S/non-public-designated-inits.swift -emit-module-interface-path %t/Module.swiftinterface -module-name Module -enable-library-evolution
+// RUN: %target-swift-emit-module-interface(%t/Module.swiftinterface) %S/non-public-designated-inits.swift -module-name Module
+// RUN: %target-swift-typecheck-module-from-interface(%t/Module.swiftinterface) -module-name Module
 // RUN: %target-swift-frontend -typecheck -verify %s -I %t
 
 // Make sure the same error is emitted when importing a .swiftmodule

--- a/test/ModuleInterface/non-public-designated-inits.swift
+++ b/test/ModuleInterface/non-public-designated-inits.swift
@@ -2,7 +2,8 @@
 
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -typecheck %s -emit-module-interface-path %t/Module.swiftinterface -module-name Module -enable-library-evolution
+// RUN: %target-swift-emit-module-interface(%t/Module.swiftinterface) %S/non-public-designated-inits.swift -module-name Module
+// RUN: %target-swift-typecheck-module-from-interface(%t/Module.swiftinterface) -module-name Module
 // RUN: %FileCheck %s < %t/Module.swiftinterface
 
 // CHECK: @_hasMissingDesignatedInitializers open class A {

--- a/test/ModuleInterface/nsmanaged-attr.swift
+++ b/test/ModuleInterface/nsmanaged-attr.swift
@@ -3,13 +3,13 @@
 // This test ensures we can properly load modules that have @NSManaged properties.
 
 // 1. Emit this file to a module interface
-// RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t/Module.swiftinterface %s -enable-library-evolution -module-name Module
+// RUN: %target-swift-emit-module-interface(%t/Module.swiftinterface) %s -module-name Module
 
 // 2. Check the interface against what we expect
 // RUN: %FileCheck %s < %t/Module.swiftinterface
 
 // 3. Ensure we can load this module from its interface
-// RUN: echo 'import Module' | %target-swift-frontend -typecheck - -I %t
+// RUN: %target-swift-typecheck-module-from-interface(%t/Module.swiftinterface) -module-name Module
 
 // REQUIRES: objc_interop
 

--- a/test/ModuleInterface/opaque-result-types.swift
+++ b/test/ModuleInterface/opaque-result-types.swift
@@ -1,5 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -typecheck -module-name OpaqueResultTypes -emit-module-interface-path %t/OpaqueResultTypes.swiftinterface %s
+// RUN: %target-swift-emit-module-interface(%t/OpaqueResultTypes.swiftinterface) %s -module-name OpaqueResultTypes
+// RUN: %target-swift-typecheck-module-from-interface(%t/OpaqueResultTypes.swiftinterface) -module-name OpaqueResultTypes
 // RUN: %FileCheck %s < %t/OpaqueResultTypes.swiftinterface
 // RUN: %target-swift-frontend -I %t -typecheck -verify %S/Inputs/opaque-result-types-client.swift
 

--- a/test/ModuleInterface/originally-defined-attr-opaque-result.swift
+++ b/test/ModuleInterface/originally-defined-attr-opaque-result.swift
@@ -1,7 +1,9 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t/CoreVegetable.swiftinterface %S/Inputs/CoreVegetable.swift -disable-availability-checking -enable-library-evolution -swift-version 5
-// RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t/CoreChef.swiftinterface -module-name CoreChef %s -I %t -disable-availability-checking -enable-library-evolution -swift-version 5 -DLIB
+// RUN: %target-swift-emit-module-interface(%t/CoreVegetable.swiftinterface) %S/Inputs/CoreVegetable.swift -disable-availability-checking
+// RUN: %target-swift-typecheck-module-from-interface(%t/CoreVegetable.swiftinterface)
+// RUN: %target-swift-emit-module-interface(%t/CoreChef.swiftinterface) %s -module-name CoreChef -I %t -disable-availability-checking -DLIB
+// RUN: %target-swift-typecheck-module-from-interface(%t/CoreChef.swiftinterface) -module-name CoreChef -I %t -disable-availability-checking
 
 // RUN: %FileCheck %s < %t/CoreChef.swiftinterface
 

--- a/test/ModuleInterface/originally-defined-attr-synthesized-extension.swift
+++ b/test/ModuleInterface/originally-defined-attr-synthesized-extension.swift
@@ -1,7 +1,8 @@
 // RUN: %empty-directory(%t)
 
 // Ensure the originallyDefinedIn attribute is printed in swiftinterface files for synthesized extensions
-// RUN: %target-swift-frontend-typecheck -emit-module-interface-path %t/Foo.swiftinterface %s -module-name Foo
+// RUN: %target-swift-emit-module-interface(%t/Foo.swiftinterface) %s -module-name Foo
+// RUN: %target-swift-typecheck-module-from-interface(%t/Foo.swiftinterface) -module-name Foo
 // RUN: %FileCheck %s < %t/Foo.swiftinterface
 
 @available(OSX 10.7, iOS 7.0, *)

--- a/test/ModuleInterface/originally-defined-attr.swift
+++ b/test/ModuleInterface/originally-defined-attr.swift
@@ -1,11 +1,12 @@
 // RUN: %empty-directory(%t)
 
 // Ensure the attribute is printed in swiftinterface files
-// RUN: %target-swift-frontend-typecheck -emit-module-interface-path %t/Foo.swiftinterface %s -module-name Foo \
+// RUN: %target-swift-emit-module-interface(%t/Foo.swiftinterface) %s -module-name Foo \
 // RUN:   -define-availability "_iOS8Aligned:macOS 10.10, iOS 8.0" \
 // RUN:   -define-availability "_iOS9:iOS 9.0" \
 // RUN:   -define-availability "_macOS10_11:macOS 10.11" \
 // RUN:   -define-availability "_myProject 1.0:macOS 10.11"
+// RUN: %target-swift-typecheck-module-from-interface(%t/Foo.swiftinterface) -module-name Foo
 // RUN: %FileCheck %s < %t/Foo.swiftinterface
 
 // Ensure the attribute is in .swiftmodule files

--- a/test/ModuleInterface/parameterized-protocol-synthesized-extension.swift
+++ b/test/ModuleInterface/parameterized-protocol-synthesized-extension.swift
@@ -1,5 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -typecheck -module-name ParameterizedProtocols -emit-module-interface-path %t/ParameterizedProtocols.swiftinterface %s
+// RUN: %target-swift-emit-module-interface(%t/ParameterizedProtocols.swiftinterface) %s -module-name ParameterizedProtocols
+// RUN: %target-swift-typecheck-module-from-interface(%t/ParameterizedProtocols.swiftinterface) -module-name ParameterizedProtocols
 // RUN: %FileCheck %s < %t/ParameterizedProtocols.swiftinterface
 
 public struct S1 : P1 {

--- a/test/ModuleInterface/parameterized-protocols.swift
+++ b/test/ModuleInterface/parameterized-protocols.swift
@@ -1,5 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -typecheck -module-name ParameterizedProtocols -emit-module-interface-path %t/ParameterizedProtocols.swiftinterface %s
+// RUN: %target-swift-emit-module-interface(%t/ParameterizedProtocols.swiftinterface) %s -module-name ParameterizedProtocols
+// RUN: %target-swift-typecheck-module-from-interface(%t/ParameterizedProtocols.swiftinterface) -module-name ParameterizedProtocols
 // RUN: %FileCheck %s < %t/ParameterizedProtocols.swiftinterface
 
 public protocol HasPrimaryAssociatedTypes<T, U> {

--- a/test/ModuleInterface/property_wrappers.swift
+++ b/test/ModuleInterface/property_wrappers.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -typecheck -swift-version 5 -module-name TestResilient -emit-module-interface-path %t/TestResilient.swiftinterface -enable-library-evolution %s
+// RUN: %target-swift-emit-module-interface(%t/TestResilient.swiftinterface) %s -module-name TestResilient
+// RUN: %target-swift-typecheck-module-from-interface(%t/TestResilient.swiftinterface) -module-name TestResilient
 // RUN: %FileCheck %s < %t/TestResilient.swiftinterface
 
 // RUN: %target-swift-frontend -compile-module-from-interface -swift-version 5 %t/TestResilient.swiftinterface -o %t/TestResilient.swiftmodule

--- a/test/ModuleInterface/protocol-with-self-constraint.swift
+++ b/test/ModuleInterface/protocol-with-self-constraint.swift
@@ -1,5 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -emit-module -o %t/Test.swiftmodule -emit-module-interface-path %t/Test.swiftinterface -module-name Test -enable-library-evolution -swift-version 5 %s
+// RUN: %target-swift-emit-module-interface(%t/Test.swiftinterface) %s -module-name Test
+// RUN: %target-swift-typecheck-module-from-interface(%t/Test.swiftinterface) -module-name Test
 // RUN: %FileCheck %s < %t/Test.swiftinterface
 
 public protocol P {

--- a/test/ModuleInterface/result_builders.swift
+++ b/test/ModuleInterface/result_builders.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -typecheck -module-name ResultBuilders -emit-module-interface-path %t/ResultBuilders.swiftinterface %s
+// RUN: %target-swift-emit-module-interface(%t/ResultBuilders.swiftinterface) %s -module-name ResultBuilders
 // RUN: %FileCheck %s < %t/ResultBuilders.swiftinterface
 // RUN: %target-swift-frontend -I %t -typecheck -verify %S/Inputs/result_builders_client.swift
 // RUN: %target-swift-frontend -compile-module-from-interface %t/ResultBuilders.swiftinterface -o %t/ResultBuilders.swiftmodule

--- a/test/ModuleInterface/sendable_availability.swift
+++ b/test/ModuleInterface/sendable_availability.swift
@@ -1,5 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -typecheck -enable-library-evolution -target %target-cpu-apple-macosx12.0 -emit-module-interface-path %t/Library.swiftinterface -module-name Library %s
+// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -target %target-cpu-apple-macosx12.0 -module-name Library
+// RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -module-name Library
 
 // REQUIRES: concurrency
 // REQUIRES: OS=macosx
@@ -22,5 +23,6 @@ public struct Y { }
 // CHECK: @available(*, unavailable)
 // CHECK-NEXT: extension Library.Y{{( )?}}: @unchecked Swift.Sendable {
 
-// RUN: %target-swift-frontend -typecheck -enable-library-evolution -target %target-cpu-apple-macosx12.0 -emit-module-interface-path %t/Library.swiftinterface -DLIBRARY -module-name Library %s -module-interface-preserve-types-as-written
+// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -target %target-cpu-apple-macosx12.0 -DLIBRARY -module-name Library -module-interface-preserve-types-as-written
+// RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -module-name Library
 // RUN: %FileCheck %s <%t/Library.swiftinterface

--- a/test/ModuleInterface/show-in-interface.swift
+++ b/test/ModuleInterface/show-in-interface.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swift-frontend -typecheck %s -parse-stdlib -emit-module-interface-path - | %FileCheck %s
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface)
+// RUN: %FileCheck %s < %t.swiftinterface
 
 // CHECK: @_show_in_interface public protocol _UnderscoredProtocol {
 // CHECK-NEXT: }

--- a/test/ModuleInterface/skip-import-in-public-interface.swift
+++ b/test/ModuleInterface/skip-import-in-public-interface.swift
@@ -2,7 +2,9 @@
 // RUN: %empty-directory(%t/I)
 
 // RUN: %target-swift-frontend -emit-module -module-name Foo %s -DFoo -emit-module-path %t/I/Foo.swiftmodule
-// RUN: %target-swift-frontend -typecheck -module-name Bar %s -I %t/I -emit-module-interface-path %t/Bar.swiftinterface -emit-private-module-interface-path %t/Bar.private.swiftinterface -skip-import-in-public-interface Foo
+// RUN: %target-swift-emit-module-interface(%t/Bar.swiftinterface) %s -module-name Bar -I %t/I -emit-private-module-interface-path %t/Bar.private.swiftinterface -skip-import-in-public-interface Foo
+// RUN: %target-swift-typecheck-module-from-interface(%t/Bar.swiftinterface) -module-name Bar
+// RUN: %target-swift-typecheck-module-from-interface(%t/Bar.private.swiftinterface) -module-name Bar -I %t/I
 
 // RUN: %FileCheck %s --check-prefix=PUBLIC-INTERFACE < %t/Bar.swiftinterface
 // RUN: %FileCheck %s --check-prefix=PRIVATE-INTERFACE < %t/Bar.private.swiftinterface

--- a/test/ModuleInterface/skip-override-keyword.swift
+++ b/test/ModuleInterface/skip-override-keyword.swift
@@ -1,24 +1,39 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -typecheck -module-name Foo -emit-module-interface-path %t/Foo.swiftinterface %s
-// RUN: %target-swift-frontend -compile-module-from-interface %t/Foo.swiftinterface -o %t/Foo.swiftmodule
+// RUN: %target-swift-emit-module-interface(%t/Foo.swiftinterface) %s -module-name Foo
+// RUN: %target-swift-typecheck-module-from-interface(%t/Foo.swiftinterface) -module-name Foo
+// RUN: %FileCheck %s < %t/Foo.swiftinterface
 
-// RUN: %target-swift-frontend -typecheck -enable-testing -module-name FooWithTesting -emit-module-interface-path %t/FooWithTesting.swiftinterface %s
-// RUN: %target-swift-frontend -compile-module-from-interface %t/FooWithTesting.swiftinterface -o %t/FooWithTesting.swiftmodule
+// RUN: %target-swift-emit-module-interface(%t/FooWithTesting.swiftinterface) %s -module-name FooWithTesting -enable-testing
+// RUN: %target-swift-typecheck-module-from-interface(%t/FooWithTesting.swiftinterface) -module-name FooWithTesting
+// RUN: %FileCheck %s < %t/FooWithTesting.swiftinterface
 
+// CHECK: @_hasMissingDesignatedInitializers public class BaseClass
 public class BaseClass {
   init() { }
   var property: Int { return 1 }
   func doSomething() { }
   subscript(index: Int) -> Int { get { return 0 } set(newValue) {} }
+  // CHECK: @usableFromInline
+  // CHECK-NEXT: internal func doSomethingInline()
   @usableFromInline func doSomethingInline() {}
+  // CHECK: @usableFromInline
+  // CHECK-NEXT: internal func doSomethingUsableFromInline()
   @usableFromInline func doSomethingUsableFromInline() {}
 }
 
+// CHECK: @_inheritsConvenienceInitializers public class DerivedClass : {{Foo|FooWithTesting}}.BaseClass
 public class DerivedClass: BaseClass {
+  // CHECK: public init()
   public override init() { super.init() }
+  // CHECK: public var property: Swift.Int
   public override var property : Int { return 0 }
+  // CHECK: public func doSomething()
   public override func doSomething() { }
+  // CHECK: public subscript(index: Swift.Int) -> Swift.Int
   public override subscript(index: Int) -> Int { get {return 0} set(newValue) {} }
+  // CHECK: @inlinable override public func doSomethingInline() { super.doSomethingInline() }
   @inlinable public override func doSomethingInline() { super.doSomethingInline() }
+  // CHECK: @usableFromInline
+  // CHECK-NEXT: override internal func doSomethingUsableFromInline()
   @usableFromInline override func doSomethingUsableFromInline() { super.doSomethingUsableFromInline() }
 }

--- a/test/ModuleInterface/skip-redundant-conformances.swift
+++ b/test/ModuleInterface/skip-redundant-conformances.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -typecheck -module-name Foo -emit-module-interface-path %t/Foo.swiftinterface %s
-// RUN: %target-swift-frontend -compile-module-from-interface %t/Foo.swiftinterface -o %t/Foo.swiftmodule
+// RUN: %target-swift-emit-module-interface(%t/Foo.swiftinterface) %s -module-name Foo
+// RUN: %target-swift-typecheck-module-from-interface(%t/Foo.swiftinterface) -module-name Foo
 
 public protocol ProtocolA : class {}
 public protocol ProtocolB: ProtocolA {}

--- a/test/ModuleInterface/smoke-test.swift
+++ b/test/ModuleInterface/smoke-test.swift
@@ -1,5 +1,10 @@
-// RUN: %target-swift-frontend -typecheck -emit-module-interface-path - %s | %FileCheck %s
-// RUN: %target-swift-frontend -typecheck -emit-module-interface-path - %s %S/Inputs/other.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-MULTI-FILE %s
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface)
+// RUN: %FileCheck %s < %t.swiftinterface
+
+// RUN: %target-swift-emit-module-interface(%t.multifile.swiftinterface) %s %S/Inputs/other.swift
+// RUN: %target-swift-typecheck-module-from-interface(%t.multifile.swiftinterface)
+// RUN: %FileCheck -check-prefix CHECK -check-prefix CHECK-MULTI-FILE %s < %t.multifile.swiftinterface
 
 // CHECK: public func verySimpleFunction(){{$}}
 public func verySimpleFunction() {}

--- a/test/ModuleInterface/specialized-extension.swift
+++ b/test/ModuleInterface/specialized-extension.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swift-frontend -module-name Test -typecheck -emit-module-interface-path - -enable-experimental-bound-generic-extensions %s -requirement-machine-inferred-signatures=on | %FileCheck %s
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name Test -enable-experimental-bound-generic-extensions -requirement-machine-inferred-signatures=on
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name Test
+// RUN: %FileCheck %s < %t.swiftinterface
 
 public struct Tree<T> {
   public struct Branch<B> {

--- a/test/ModuleInterface/spi-available-interface.swift
+++ b/test/ModuleInterface/spi-available-interface.swift
@@ -1,10 +1,10 @@
 // REQUIRES: OS=macosx
 // RUN: %empty-directory(%t/inputs)
-// RUN: %target-swift-frontend -typecheck %s -F %S/../ClangImporter/Inputs/frameworks -DFoo -emit-module-interface-path %t/inputs/Foo.swiftinterface -module-name Foo -enable-library-evolution -disable-clang-spi -library-level api
+// RUN: %target-swift-emit-module-interface(%t/inputs/Foo.swiftinterface) %s -module-name Foo -F %S/../ClangImporter/Inputs/frameworks -DFoo -disable-clang-spi -library-level api
 
 // RUN: %target-swift-frontend -typecheck %s -F %S/../ClangImporter/Inputs/frameworks -enable-library-evolution -I %t/inputs -disable-clang-spi -library-level api
 
-// RUN: %target-swift-frontend -typecheck-module-from-interface %t/inputs/Foo.swiftinterface -F %S/../ClangImporter/Inputs/frameworks -disable-clang-spi -library-level api
+// RUN: %target-swift-typecheck-module-from-interface(%t/inputs/Foo.swiftinterface) -module-name Foo -F %S/../ClangImporter/Inputs/frameworks -disable-clang-spi -library-level api
 
 
 #if Foo

--- a/test/ModuleInterface/static-initialize-objc-metadata-attr.swift
+++ b/test/ModuleInterface/static-initialize-objc-metadata-attr.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swift-frontend -typecheck -emit-module-interface-path - %s -enable-library-evolution -target %target-pre-stable-abi-triple -module-name Module | %FileCheck %s
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name Module -target %target-pre-stable-abi-triple
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name Module
+// RUN: %FileCheck %s < %t.swiftinterface
 // REQUIRES: objc_interop
 
 import Foundation

--- a/test/ModuleInterface/stdlib.swift
+++ b/test/ModuleInterface/stdlib.swift
@@ -1,5 +1,6 @@
-// RUN: %target-swift-frontend -typecheck -emit-module-interface-path - -parse-stdlib %s | %FileCheck %s
-// RUN: %target-swift-frontend -emit-module-interface-path - -emit-module -o /dev/null -parse-stdlib %s | %FileCheck %s
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -parse-stdlib
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface)
+// RUN: %FileCheck %s < %t.swiftinterface
 
 // CHECK-NOT: import Builtin
 

--- a/test/ModuleInterface/stored-properties-client.swift
+++ b/test/ModuleInterface/stored-properties-client.swift
@@ -5,6 +5,7 @@
 // 1. Build ../stored-properties.swift to a dylib and emit its interface in %t
 
 // RUN: %target-build-swift-dylib(%t/%target-library-name(StoredProperties)) -emit-module-interface-path %t/StoredProperties.swiftinterface %S/stored-properties.swift -module-name StoredProperties -swift-version 5
+// RUN: %target-swift-typecheck-module-from-interface(%t/StoredProperties.swiftinterface) -module-name StoredProperties
 
 // 2. Build this file and link with StoredProperties
 

--- a/test/ModuleInterface/stored-properties.swift
+++ b/test/ModuleInterface/stored-properties.swift
@@ -1,9 +1,11 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t.swiftinterface -module-name StoredProperties %s
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name StoredProperties
 // RUN: %FileCheck %s < %t.swiftinterface --check-prefix CHECK --check-prefix COMMON
 
 // RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t-resilient.swiftinterface -module-name StoredProperties -enable-library-evolution %s
+// RUN: %target-swift-typecheck-module-from-interface(%t-resilient.swiftinterface) -module-name StoredProperties
 // RUN: %FileCheck %s < %t-resilient.swiftinterface --check-prefix RESILIENT --check-prefix COMMON
 
 // RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule -module-name StoredProperties %t.swiftinterface -disable-objc-attr-requires-foundation-module

--- a/test/ModuleInterface/stub-init.swift
+++ b/test/ModuleInterface/stub-init.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swift-frontend -typecheck -swift-version 5 -emit-module-interface-path - -module-name test %s | %FileCheck %s
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name test
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name test
+// RUN: %FileCheck %s < %t.swiftinterface
 
 public class Base {
   public init(x: Int) {}

--- a/test/ModuleInterface/synthesized.swift
+++ b/test/ModuleInterface/synthesized.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend -typecheck -emit-module-interface-path - %s -disable-objc-attr-requires-foundation-module -enable-objc-interop > %t.swiftinterface
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name synthesized -disable-objc-attr-requires-foundation-module -enable-objc-interop
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name synthesized
 // RUN: %FileCheck %s < %t.swiftinterface
 // RUN: %FileCheck -check-prefix=NEGATIVE %s < %t.swiftinterface
 
@@ -7,9 +8,9 @@ public enum HasRawValue: Int {
   // CHECK-NEXT: case a, b, c
   case a, b = 5, c
   // CHECK-DAG: public typealias RawValue = Swift.Int
-  // CHECK-DAG: @inlinable public init?(rawValue: Swift.Int)
+  // CHECK-DAG: public init?(rawValue: Swift.Int)
   // CHECK-DAG: public var rawValue: Swift.Int {
-  // CHECK-DAG:   @inlinable get{{$}}
+  // CHECK-DAG:   get{{$}}
   // CHECK-DAG: }
 } // CHECK: {{^}$}}
 
@@ -20,9 +21,9 @@ public enum HasRawValue: Int {
 // CHECK-LABEL: @objc public enum ObjCEnum : Swift.Int32 {
 // CHECK-NEXT: case a, b = 5, c
 // CHECK-DAG: public typealias RawValue = Swift.Int32
-// CHECK-DAG: @inlinable public init?(rawValue: Swift.Int32)
+// CHECK-DAG: public init?(rawValue: Swift.Int32)
 // CHECK-DAG: public var rawValue: Swift.Int32 {
-// CHECK-DAG:   @inlinable get{{$}}
+// CHECK-DAG:   get{{$}}
 // CHECK-DAG: }
 // CHECK: {{^}$}}
 

--- a/test/ModuleInterface/top-level-Type-and-Protocol.swift
+++ b/test/ModuleInterface/top-level-Type-and-Protocol.swift
@@ -1,9 +1,8 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t/MyModule.swiftinterface -enable-library-evolution %s -module-name MyModule
+// RUN: %target-swift-emit-module-interface(%t/MyModule.swiftinterface) %s -module-name MyModule
+// RUN: %target-swift-typecheck-module-from-interface(%t/MyModule.swiftinterface) -module-name MyModule
 // RUN: %FileCheck %s < %t/MyModule.swiftinterface
-
-// RUN: %target-swift-frontend -compile-module-from-interface %t/MyModule.swiftinterface -o %t/MyModule.swiftmodule
 
 // CHECK: public struct Type {
 // CHECK-NEXT: }

--- a/test/ModuleInterface/type-shadowing.swift
+++ b/test/ModuleInterface/type-shadowing.swift
@@ -1,6 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -typecheck %s -swift-version 5 -enable-library-evolution -emit-module-interface-path %t/Bakery.swiftinterface -DBAKERY -module-name Bakery
-// RUN: %target-swift-frontend -typecheck %s -swift-version 5 -enable-library-evolution -emit-module-interface-path %t/Home.swiftinterface -DHOME -module-name Home -I %t
+// RUN: %target-swift-emit-module-interface(%t/Bakery.swiftinterface) %s -DBAKERY -module-name Bakery
+// RUN: %target-swift-typecheck-module-from-interface(%t/Bakery.swiftinterface) -module-name Bakery
+// RUN: %target-swift-emit-module-interface(%t/Home.swiftinterface) %s -DHOME -module-name Home -I %t
+// RUN: %target-swift-typecheck-module-from-interface(%t/Home.swiftinterface) -module-name Home -I %t
 // RUN: %FileCheck %s < %t/Home.swiftinterface
 
 #if BAKERY

--- a/test/SPI/experimental_spi_imports_swiftinterface.swift
+++ b/test/SPI/experimental_spi_imports_swiftinterface.swift
@@ -11,6 +11,8 @@
 
 /// Test the generated swiftinterface.
 // RUN: %target-swift-frontend -typecheck %s %S/Inputs/experimental_spi_imports_inconsistent.swift -emit-module-interface-path %t/main.swiftinterface -emit-private-module-interface-path %t/main.private.swiftinterface -enable-library-evolution -swift-version 5 -I %t -experimental-spi-imports
+// RUN: %target-swift-typecheck-module-from-interface(%t/main.swiftinterface) -I %t
+// RUN: %target-swift-typecheck-module-from-interface(%t/main.private.swiftinterface) -I %t
 // RUN: %FileCheck -check-prefix=CHECK-PUBLIC %s < %t/main.swiftinterface
 // RUN: %FileCheck -check-prefix=CHECK-PRIVATE %s < %t/main.private.swiftinterface
 

--- a/test/Sema/implementation-only-override.swift
+++ b/test/Sema/implementation-only-override.swift
@@ -1,7 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-typecheck-verify-swift -I %S/Inputs/implementation-only-override -DERRORS -enable-library-evolution -enable-objc-interop
 
-// RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t/Library.swiftinterface -I %S/Inputs/implementation-only-override -enable-library-evolution -enable-objc-interop %s
+// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -I %S/Inputs/implementation-only-override -enable-objc-interop
+// RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -I %S/Inputs/implementation-only-override
 // RUN: %FileCheck %s < %t/Library.swiftinterface
 // RUN: %FileCheck -check-prefix=NEGATIVE %s < %t/Library.swiftinterface
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2259,6 +2259,12 @@ config.substitutions.append(('%target-pic-opt', config.target_pic_opt))
 config.substitutions.append(('%target-msvc-runtime-opt',
                              config.target_msvc_runtime_opt))
 
+config.substitutions.append(('%target-swift-emit-module-interface\(([^)]+)\)',
+                             SubstituteCaptures(r'%target-swift-frontend -swift-version 5 -enable-library-evolution -typecheck -emit-module-interface-path \1')))
+
+config.substitutions.append(('%target-swift-typecheck-module-from-interface\(([^)]+)\)',
+                             SubstituteCaptures(r'%target-swift-frontend -swift-version 5 -enable-library-evolution -typecheck-module-from-interface \1')))
+
 config.substitutions.append(('%target-typecheck-verify-swift', config.target_parse_verify_swift))
 
 config.substitutions.append(('%target-swift-emit-silgen\(mock-sdk:([^)]+)\)',


### PR DESCRIPTION
Introduce a `%target-swiftc-emit-module-interface` lit substitution and adopt it in some tests that involve emitting a swiftinterface. The substitution specifies the additional flags `-swift-version 5 -enable-library-evolution -verify-emitted-module-interface`. There are a few motivations:

- Tests that depend on emitted interfaces should generally use flags that are typical for modules that have textual interfaces (e.g. `-enable-library-evolution`).
- If a test is intended to produce a valid `swiftinterface` then it should verify that interface. This will help prevent interface printing regressions caused by compiler changes.
- Having a commonly used substitution for tests that emit interfaces makes it easy to experiment with compiler flags that might effect interface printing.

Resolves rdar://91634358