### PR TITLE
[5.7] [Parse] Introduce `/.../` regex literals

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -848,6 +848,7 @@ namespace swift {
     friend class DiagnosticTransaction;
     friend class CompoundDiagnosticTransaction;
     friend class DiagnosticStateRAII;
+    friend class DiagnosticQueue;
 
   public:
     explicit DiagnosticEngine(SourceManager &SourceMgr)
@@ -1137,9 +1138,19 @@ namespace swift {
     /// Send \c diag to all diagnostic consumers.
     void emitDiagnostic(const Diagnostic &diag);
 
+    /// Handle a new diagnostic, which will either be emitted, or added to an
+    /// active transaction.
+    void handleDiagnostic(Diagnostic &&diag);
+
+    /// Clear any tentative diagnostics.
+    void clearTentativeDiagnostics();
+
     /// Send all tentative diagnostics to all diagnostic consumers and
     /// delete them.
     void emitTentativeDiagnostics();
+
+    /// Forward all tentative diagnostics to a different diagnostic engine.
+    void forwardTentativeDiagnosticsTo(DiagnosticEngine &targetEngine);
 
   public:
     DiagnosticKind declaredDiagnosticKindFor(const DiagID id);
@@ -1330,6 +1341,78 @@ namespace swift {
                                         Engine.TentativeDiagnostics.end());
 
       DiagnosticTransaction::commit();
+    }
+  };
+
+  /// Represents a queue of diagnostics that have their emission delayed until
+  /// the queue is destroyed. This is similar to DiagnosticTransaction, but
+  /// with a few key differences:
+  /// 
+  /// - The queue maintains its own diagnostic engine (which may be accessed
+  ///   through `getDiags()`), and diagnostics must be specifically emitted
+  ///   using that engine to be enqueued.
+  /// - It allows for non-LIFO transactions, as each queue operates
+  ///   independently.
+  /// - A queue can be drained multiple times without having to be recreated
+  ///   (unlike DiagnosticTransaction, it has no concept of "closing").
+  ///
+  /// Note you may add DiagnosticTransactions to the queue's diagnostic engine,
+  /// but they must be closed before attempting to clear or emit the diagnostics
+  /// in the queue.
+  ///
+  class DiagnosticQueue final {
+    /// The underlying diagnostic engine that the diagnostics will be emitted
+    /// by.
+    DiagnosticEngine &UnderlyingEngine;
+
+    /// A temporary engine used to queue diagnostics.
+    DiagnosticEngine QueueEngine;
+
+    /// Whether the queued diagnostics should be emitted on the destruction of
+    /// the queue, or whether they should be cleared.
+    bool EmitOnDestruction;
+
+  public:
+    DiagnosticQueue(const DiagnosticQueue &) = delete;
+    DiagnosticQueue &operator=(const DiagnosticQueue &) = delete;
+
+    /// Create a new diagnostic queue with a given engine to forward the
+    /// diagnostics to.
+    explicit DiagnosticQueue(DiagnosticEngine &engine, bool emitOnDestruction)
+        : UnderlyingEngine(engine), QueueEngine(engine.SourceMgr),
+          EmitOnDestruction(emitOnDestruction) {
+      // Open a transaction to avoid emitting any diagnostics for the temporary
+      // engine.
+      QueueEngine.TransactionCount++;
+    }
+
+    /// Retrieve the engine which may be used to enqueue diagnostics.
+    DiagnosticEngine &getDiags() { return QueueEngine; }
+
+    /// Retrieve the underlying engine which will receive the diagnostics.
+    DiagnosticEngine &getUnderlyingDiags() { return UnderlyingEngine; }
+
+    /// Clear this queue and erase all diagnostics recorded.
+    void clear() {
+      assert(QueueEngine.TransactionCount == 1 &&
+             "Must close outstanding DiagnosticTransactions before draining");
+      QueueEngine.clearTentativeDiagnostics();
+    }
+
+    /// Emit all the diagnostics recorded by this queue.
+    void emit() {
+      assert(QueueEngine.TransactionCount == 1 &&
+             "Must close outstanding DiagnosticTransactions before draining");
+      QueueEngine.forwardTentativeDiagnosticsTo(UnderlyingEngine);
+    }
+
+    ~DiagnosticQueue() {
+      if (EmitOnDestruction) {
+        emit();
+      } else {
+        clear();
+      }
+      QueueEngine.TransactionCount--;
     }
   };
 

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -94,6 +94,9 @@ ERROR(forbidden_extended_escaping_string,none,
 ERROR(regex_literal_parsing_error,none,
       "%0", (StringRef))
 
+ERROR(prefix_slash_not_allowed,none,
+      "prefix operator may not contain '/'", ())
+
 //------------------------------------------------------------------------------
 // MARK: Lexer diagnostics
 //------------------------------------------------------------------------------

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -143,7 +143,10 @@ ERROR(lex_invalid_escape_delimiter,none,
 ERROR(lex_invalid_closing_delimiter,none,
       "too many '#' characters in closing delimiter", ())
 
-ERROR(lex_unterminated_regex,none,
+ERROR(lex_regex_literal_invalid_starting_char,none,
+      "regex literal may not start with %0; add backslash to escape",
+      (StringRef))
+ERROR(lex_regex_literal_unterminated,none,
       "unterminated regex literal", ())
 
 ERROR(lex_invalid_unicode_scalar,none,

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -564,8 +564,9 @@ namespace swift {
     /// Enables dumping type witness systems from associated type inference.
     bool DumpTypeWitnessSystems = false;
 
-    /// Enables `/.../` syntax regular-expression literals
-    bool EnableForwardSlashRegexLiterals = false;
+    /// Enables `/.../` syntax regular-expression literals. This requires
+    /// experimental string processing. Note this does not affect `#/.../#`.
+    bool EnableBareSlashRegexLiterals = false;
 
     /// Sets the target we are building for and updates platform conditions
     /// to match.

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -562,6 +562,9 @@ def disable_deserialization_recovery :
 def enable_experimental_string_processing :
   Flag<["-"], "enable-experimental-string-processing">,
   HelpText<"Enable experimental string processing">;
+def disable_experimental_string_processing :
+  Flag<["-"], "disable-experimental-string-processing">,
+  HelpText<"Disable experimental string processing">;
 
 def enable_experimental_variadic_generics :
   Flag<["-"], "enable-experimental-variadic-generics">,

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -559,6 +559,11 @@ public:
     return f(backtrackScope);
   }
 
+  /// Discard the current token. This will avoid interface hashing or updating
+  /// the previous loc. Only should be used if you've completely re-lexed
+  /// a different token at that position.
+  SourceLoc discardToken();
+
   /// Consume a token that we created on the fly to correct the original token
   /// stream from lexer.
   void consumeExtraToken(Token K);
@@ -1752,7 +1757,16 @@ public:
   ParserResult<Expr>
   parseExprPoundCodeCompletion(Optional<StmtKind> ParentKind);
 
+  UnresolvedDeclRefExpr *makeExprOperator(const Token &opToken);
   UnresolvedDeclRefExpr *parseExprOperator();
+
+  /// Try re-lex a '/' operator character as a regex literal. This should be
+  /// called when parsing in an expression position to ensure a regex literal is
+  /// correctly parsed.
+  ///
+  /// If \p mustBeRegex is set to true, a regex literal will always be lexed if
+  /// enabled. Otherwise, it will not be lexed if it may be ambiguous.
+  void tryLexRegexLiteral(bool mustBeRegex);
 
   void validateCollectionElement(ParserResult<Expr> element);
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -500,15 +500,23 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
       = A->getOption().matches(OPT_enable_deserialization_recovery);
   }
 
-  // Experimental string processing
-  Opts.EnableExperimentalStringProcessing |=
-      Args.hasArg(OPT_enable_experimental_string_processing);
-
   // Whether '/.../' regex literals are enabled. This implies experimental
   // string processing.
   if (Args.hasArg(OPT_enable_bare_slash_regex)) {
     Opts.EnableBareSlashRegexLiterals = true;
     Opts.EnableExperimentalStringProcessing = true;
+  }
+
+  // Experimental string processing.
+  if (auto A = Args.getLastArg(OPT_enable_experimental_string_processing,
+                               OPT_disable_experimental_string_processing)) {
+    Opts.EnableExperimentalStringProcessing =
+        A->getOption().matches(OPT_enable_experimental_string_processing);
+
+    // When experimental string processing is explicitly disabled, also disable
+    // forward slash regex `/.../`.
+    if (!Opts.EnableExperimentalStringProcessing)
+      Opts.EnableBareSlashRegexLiterals = false;
   }
 
   Opts.EnableExperimentalBoundGenericExtensions |=

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -504,6 +504,13 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableExperimentalStringProcessing |=
       Args.hasArg(OPT_enable_experimental_string_processing);
 
+  // Whether '/.../' regex literals are enabled. This implies experimental
+  // string processing.
+  if (Args.hasArg(OPT_enable_bare_slash_regex)) {
+    Opts.EnableBareSlashRegexLiterals = true;
+    Opts.EnableExperimentalStringProcessing = true;
+  }
+
   Opts.EnableExperimentalBoundGenericExtensions |=
     Args.hasArg(OPT_enable_experimental_bound_generic_extensions);
 
@@ -1008,9 +1015,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   if (Args.hasArg(OPT_disable_requirement_machine_reuse))
     Opts.EnableRequirementMachineReuse = false;
-
-  if (Args.hasArg(OPT_enable_bare_slash_regex))
-    Opts.EnableForwardSlashRegexLiterals = true;
 
   if (Args.hasArg(OPT_enable_requirement_machine_opaque_archetypes))
     Opts.EnableRequirementMachineOpaqueArchetypes = true;

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -2541,20 +2541,13 @@ void Lexer::lexImpl() {
   case '&': case '|':  case '^': case '~': case '.':
     return lexOperatorIdentifier();
 
-  case 'r':
-    // If we have experimental string processing enabled, try lex a regex
-    // literal.
-    if (tryLexRegexLiteral(TokStart))
-      return;
-    LLVM_FALLTHROUGH;
-
   case 'A': case 'B': case 'C': case 'D': case 'E': case 'F': case 'G':
   case 'H': case 'I': case 'J': case 'K': case 'L': case 'M': case 'N':
   case 'O': case 'P': case 'Q': case 'R': case 'S': case 'T': case 'U':
   case 'V': case 'W': case 'X': case 'Y': case 'Z':
   case 'a': case 'b': case 'c': case 'd': case 'e': case 'f': case 'g':
   case 'h': case 'i': case 'j': case 'k': case 'l': case 'm': case 'n':
-  case 'o': case 'p': case 'q': /*r above*/ case 's': case 't': case 'u':
+  case 'o': case 'p': case 'q': case 'r': case 's': case 't': case 'u':
   case 'v': case 'w': case 'x': case 'y': case 'z':
   case '_':
     return lexIdentifier();

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -8528,6 +8528,13 @@ Parser::parseDeclOperator(ParseDeclOptions Flags, DeclAttributes &Attributes) {
                                    Tok.getRawText().front() == '!'))
       diagnose(Tok, diag::postfix_operator_name_cannot_start_with_unwrap);
 
+  // Prefix operators may not contain the `/` character when `/.../` regex
+  // literals are enabled.
+  if (Context.LangOpts.EnableBareSlashRegexLiterals) {
+    if (Attributes.hasAttribute<PrefixAttr>() && Tok.getText().contains("/"))
+      diagnose(Tok, diag::prefix_slash_not_allowed);
+  }
+
   // A common error is to try to define an operator with something in the
   // unicode plane considered to be an operator, or to try to define an
   // operator like "not".  Analyze and diagnose this specifically.

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -511,6 +511,10 @@ ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
 ParserResult<Expr> Parser::parseExprUnary(Diag<> Message, bool isExprBasic) {
   SyntaxParsingContext UnaryContext(SyntaxContext, SyntaxContextKind::Expr);
   UnresolvedDeclRefExpr *Operator;
+
+  // First check to see if we have the start of a regex literal `/.../`.
+  tryLexRegexLiteral(/*mustBeRegex*/ true);
+
   switch (Tok.getKind()) {
   default:
     // If the next token is not an operator, just parse this as expr-postfix.
@@ -532,16 +536,32 @@ ParserResult<Expr> Parser::parseExprUnary(Diag<> Message, bool isExprBasic) {
   case tok::backslash:
     return parseExprKeyPath();
 
-  case tok::oper_postfix:
+  case tok::oper_postfix: {
     // Postfix operators cannot start a subexpression, but can happen
     // syntactically because the operator may just follow whatever precedes this
     // expression (and that may not always be an expression).
     diagnose(Tok, diag::invalid_postfix_operator);
     Tok.setKind(tok::oper_prefix);
-    LLVM_FALLTHROUGH;
-  case tok::oper_prefix:
     Operator = parseExprOperator();
     break;
+  }
+  case tok::oper_prefix: {
+    // Check to see if we can split a prefix operator containing `/`, e.g `!/`,
+    // which might be a prefix operator on a regex literal.
+    if (Context.LangOpts.EnableBareSlashRegexLiterals) {
+      auto slashIdx = Tok.getText().find("/");
+      if (slashIdx != StringRef::npos) {
+        auto prefix = Tok.getText().take_front(slashIdx);
+        if (!prefix.empty()) {
+          Operator = makeExprOperator({Tok.getKind(), prefix});
+          consumeStartingCharacterOfCurrentToken(Tok.getKind(), prefix.size());
+          break;
+        }
+      }
+    }
+    Operator = parseExprOperator();
+    break;
+  }
   case tok::oper_binary_spaced:
   case tok::oper_binary_unspaced: {
     // For recovery purposes, accept an oper_binary here.
@@ -860,17 +880,50 @@ static DeclRefKind getDeclRefKindForOperator(tok kind) {
   }
 }
 
-/// parseExprOperator - Parse an operator reference expression.  These
-/// are not "proper" expressions; they can only appear in binary/unary
-/// operators.
-UnresolvedDeclRefExpr *Parser::parseExprOperator() {
+UnresolvedDeclRefExpr *Parser::makeExprOperator(const Token &Tok) {
   assert(Tok.isAnyOperator());
   DeclRefKind refKind = getDeclRefKindForOperator(Tok.getKind());
   SourceLoc loc = Tok.getLoc();
   DeclNameRef name(Context.getIdentifier(Tok.getText()));
-  consumeToken();
   // Bypass local lookup.
   return new (Context) UnresolvedDeclRefExpr(name, refKind, DeclNameLoc(loc));
+}
+
+/// parseExprOperator - Parse an operator reference expression.  These
+/// are not "proper" expressions; they can only appear in binary/unary
+/// operators.
+UnresolvedDeclRefExpr *Parser::parseExprOperator() {
+  auto *op = makeExprOperator(Tok);
+  consumeToken();
+  return op;
+}
+
+void Parser::tryLexRegexLiteral(bool mustBeRegex) {
+  if (!Context.LangOpts.EnableBareSlashRegexLiterals)
+    return;
+
+  // Check to see if we have the start of a regex literal `/.../`.
+  switch (Tok.getKind()) {
+  case tok::oper_prefix:
+  case tok::oper_binary_spaced:
+  case tok::oper_binary_unspaced: {
+    if (!Tok.getText().startswith("/"))
+      break;
+
+    // Try re-lex as a `/.../` regex literal.
+    auto state = getParserPosition().LS;
+    L->tryLexForwardSlashRegexLiteralFrom(state, mustBeRegex);
+
+    // Discard the current token, which will be replaced by the re-lexed token,
+    // which may or may not be a regex literal token.
+    discardToken();
+
+    assert(Tok.getText().startswith("/"));
+    break;
+  }
+  default:
+    break;
+  }
 }
 
 /// parseExprSuper
@@ -3159,6 +3212,11 @@ ParserStatus Parser::parseExprList(tok leftTok, tok rightTok,
     Identifier FieldName;
     SourceLoc FieldNameLoc;
     parseOptionalArgumentLabel(FieldName, FieldNameLoc);
+
+    // First check to see if we have the start of a regex literal `/.../`. We
+    // need to do this before handling unapplied operator references, as e.g
+    // `(/, /)` might be a regex literal.
+    tryLexRegexLiteral(/*mustBeRegex*/ false);
 
     // See if we have an operator decl ref '(<op>)'. The operator token in
     // this case lexes as a binary operator because it neither leads nor

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -579,13 +579,16 @@ const Token &Parser::peekToken() {
   return L->peekNextToken();
 }
 
-SourceLoc Parser::consumeTokenWithoutFeedingReceiver() {
-  SourceLoc Loc = Tok.getLoc();
+SourceLoc Parser::discardToken() {
   assert(Tok.isNot(tok::eof) && "Lexing past eof!");
-
-  recordTokenHash(Tok);
-
+  SourceLoc Loc = Tok.getLoc();
   L->lex(Tok, LeadingTrivia, TrailingTrivia);
+  return Loc;
+}
+
+SourceLoc Parser::consumeTokenWithoutFeedingReceiver() {
+  recordTokenHash(Tok);
+  auto Loc = discardToken();
   PreviousLoc = Loc;
   return Loc;
 }

--- a/test/IDE/complete_regex.swift
+++ b/test/IDE/complete_regex.swift
@@ -4,7 +4,7 @@
 // RUN: %target-swift-ide-test -enable-bare-slash-regex -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
 
 func testLiteral() {
-  #/foo/#.#^RE_LITERAL_MEMBER^#
+  /foo/.#^RE_LITERAL_MEMBER^#
 // RE_LITERAL_MEMBER: Begin completions
 // RE_LITERAL_MEMBER-DAG: Keyword[self]/CurrNominal:          self[#Regex<Substring>#];
 // RE_LITERAL_MEMBER: End completions

--- a/test/IDE/complete_regex.swift
+++ b/test/IDE/complete_regex.swift
@@ -1,7 +1,7 @@
 // REQUIRES: swift_in_compiler
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -enable-experimental-string-processing -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+// RUN: %target-swift-ide-test -enable-bare-slash-regex -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
 
 func testLiteral() {
   #/foo/#.#^RE_LITERAL_MEMBER^#

--- a/test/SourceKit/Sema/sema_regex.swift
+++ b/test/SourceKit/Sema/sema_regex.swift
@@ -3,7 +3,7 @@ public func retRegex() -> Regex<Substring> {
 }
 
 // REQUIRES: swift_in_compiler
-// RUN: %sourcekitd-test -req=sema %s -- %s -Xfrontend -enable-experimental-string-processing | %FileCheck %s
+// RUN: %sourcekitd-test -req=sema %s -- %s -Xfrontend -enable-bare-slash-regex | %FileCheck %s
 
 // CHECK: [
 // CHECK:   {

--- a/test/SourceKit/Sema/sema_regex.swift
+++ b/test/SourceKit/Sema/sema_regex.swift
@@ -1,5 +1,5 @@
 public func retRegex() -> Regex<Substring> {
-  #/foo/#
+  /foo/
 }
 
 // REQUIRES: swift_in_compiler

--- a/test/StringProcessing/Frontend/disable-flag.swift
+++ b/test/StringProcessing/Frontend/disable-flag.swift
@@ -1,0 +1,14 @@
+// RUN: %target-typecheck-verify-swift -enable-bare-slash-regex -disable-experimental-string-processing
+// RUN: %target-typecheck-verify-swift -disable-experimental-string-processing -enable-bare-slash-regex
+// RUN: %target-typecheck-verify-swift -enable-experimental-string-processing -disable-experimental-string-processing -enable-bare-slash-regex
+
+prefix operator /
+
+_ = /x/
+// expected-error@-1 {{'/' is not a prefix unary operator}}
+// expected-error@-2 {{cannot find 'x' in scope}}
+// expected-error@-3 {{'/' is not a postfix unary operator}}
+
+_ = #/x/# // expected-error {{expected expression in assignment}}
+
+func foo(_ x: Regex<Substring>) {} // expected-error {{cannot find type 'Regex' in scope}}

--- a/test/StringProcessing/Frontend/enable-flag.swift
+++ b/test/StringProcessing/Frontend/enable-flag.swift
@@ -1,0 +1,12 @@
+// RUN: %target-typecheck-verify-swift -enable-bare-slash-regex -enable-experimental-string-processing
+// RUN: %target-typecheck-verify-swift -enable-experimental-string-processing -enable-bare-slash-regex
+// RUN: %target-typecheck-verify-swift -disable-experimental-string-processing -enable-experimental-string-processing -enable-bare-slash-regex
+
+// REQUIRES: swift_in_compiler
+
+prefix operator / // expected-error {{prefix operator may not contain '/'}}
+
+_ = /x/
+_ = #/x/#
+
+func foo(_ x: Regex<Substring>) {}

--- a/test/StringProcessing/Parse/forward-slash-regex.swift
+++ b/test/StringProcessing/Parse/forward-slash-regex.swift
@@ -1,0 +1,5 @@
+// RUN: %target-typecheck-verify-swift -enable-bare-slash-regex
+
+prefix operator /  // expected-error {{prefix operator may not contain '/'}}
+prefix operator ^/ // expected-error {{prefix operator may not contain '/'}}
+prefix operator /^/ // expected-error {{prefix operator may not contain '/'}}

--- a/test/StringProcessing/Parse/forward-slash-regex.swift
+++ b/test/StringProcessing/Parse/forward-slash-regex.swift
@@ -1,5 +1,283 @@
 // RUN: %target-typecheck-verify-swift -enable-bare-slash-regex
+// REQUIRES: swift_in_compiler
+// REQUIRES: concurrency
 
 prefix operator /  // expected-error {{prefix operator may not contain '/'}}
 prefix operator ^/ // expected-error {{prefix operator may not contain '/'}}
 prefix operator /^/ // expected-error {{prefix operator may not contain '/'}}
+
+precedencegroup P {
+  associativity: left
+}
+
+// Fine.
+infix operator /^/ : P
+func /^/ (lhs: Int, rhs: Int) -> Int { 0 }
+
+let i = 0 /^/ 1/^/3
+
+let x = /abc/
+_ = /abc/
+_ = /x/.self
+_ = /\//
+_ = /\\/
+
+// These unfortunately become infix `=/`. We could likely improve the diagnostic
+// though.
+let z=/0/
+// expected-error@-1 {{type annotation missing in pattern}}
+// expected-error@-2 {{consecutive statements on a line must be separated by ';'}}
+// expected-error@-3 {{expected expression after unary operator}}
+// expected-error@-4 {{cannot find operator '=/' in scope}}
+// expected-error@-5 {{'/' is not a postfix unary operator}}
+_=/0/
+// expected-error@-1 {{'_' can only appear in a pattern or on the left side of an assignment}}
+// expected-error@-2 {{cannot find operator '=/' in scope}}
+// expected-error@-3 {{'/' is not a postfix unary operator}}
+
+_ = /x
+// expected-error@-1 {{unterminated regex literal}}
+
+_ = !/x/
+// expected-error@-1 {{cannot convert value of type 'Regex<Substring>' to expected argument type 'Bool'}}
+
+_ = /x/! // expected-error {{cannot force unwrap value of non-optional type 'Regex<Substring>'}}
+_ = /x/ + /y/ // expected-error {{binary operator '+' cannot be applied to two 'Regex<Substring>' operands}}
+
+_ = /x/+/y/
+// expected-error@-1 {{cannot find operator '+/' in scope}}
+// expected-error@-2 {{'/' is not a postfix unary operator}}
+// expected-error@-3 {{cannot find 'y' in scope}}
+
+_ = /x/?.blah
+// expected-error@-1 {{cannot use optional chaining on non-optional value of type 'Regex<Substring>'}}
+// expected-error@-2 {{value of type 'Regex<Substring>' has no member 'blah'}}
+_ = /x/!.blah
+// expected-error@-1 {{cannot force unwrap value of non-optional type 'Regex<Substring>'}}
+// expected-error@-2 {{value of type 'Regex<Substring>' has no member 'blah'}}
+
+_ = /x /? // expected-error {{cannot use optional chaining on non-optional value of type 'Regex<Substring>'}}
+  .blah // expected-error {{value of type 'Regex<Substring>' has no member 'blah'}}
+
+_ = 0; /x / // expected-warning {{regular expression literal is unused}}
+
+_ = /x / ? 0 : 1 // expected-error {{cannot convert value of type 'Regex<Substring>' to expected condition type 'Bool'}}
+_ = .random() ? /x / : .blah // expected-error {{type 'Regex<Substring>' has no member 'blah'}}
+
+_ = /x/ ?? /x/ // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'Regex<Substring>', so the right side is never used}}
+_ = /x / ?? /x / // expected-warning {{left side of nil coalescing operator '??' has non-optional type 'Regex<Substring>', so the right side is never used}}
+
+_ = /x/??/x/ // expected-error {{'/' is not a postfix unary operator}}
+
+_ = /x/ ... /y/ // expected-error {{referencing operator function '...' on 'Comparable' requires that 'Regex<Substring>' conform to 'Comparable'}}
+
+_ = /x/.../y/
+// expected-error@-1 {{missing whitespace between '...' and '/' operators}}
+// expected-error@-2 {{'/' is not a postfix unary operator}}
+// expected-error@-3 {{cannot find 'y' in scope}}
+
+_ = /x /...
+// expected-error@-1 {{unary operator '...' cannot be applied to an operand of type 'Regex<Substring>'}}
+// expected-note@-2 {{overloads for '...' exist with these partially matching parameter lists}}
+
+do {
+  _ = true / false /; // expected-error {{expected expression after operator}}
+}
+
+_ = "\(/x/)"
+
+func defaulted(x: Regex<Substring> = /x/) {}
+
+func foo<T>(_ x: T, y: T) {}
+foo(/abc/, y: /abc /)
+
+func bar<T>(_ x: inout T) {}
+
+// TODO: We split this into a prefix '&', but inout is handled specially when
+// parsing an argument list. This shouldn't matter anyway, but we should at
+// least have a custom diagnostic.
+bar(&/x/)
+// expected-error@-1 {{'&' is not a prefix unary operator}}
+
+struct S {
+  subscript(x: Regex<Substring>) -> Void { () }
+}
+
+func testSubscript(_ x: S) {
+  x[/x/]
+  x[/x /]
+}
+
+func testReturn() -> Regex<Substring> {
+  if .random() {
+    return /x/
+  }
+  return /x /
+}
+
+func testThrow() throws {
+  throw /x / // expected-error {{thrown expression type 'Regex<Substring>' does not conform to 'Error'}}
+}
+
+_ = [/abc/, /abc /]
+_ = [/abc/:/abc/] // expected-error {{generic struct 'Dictionary' requires that 'Regex<Substring>' conform to 'Hashable'}}
+_ = [/abc/ : /abc/] // expected-error {{generic struct 'Dictionary' requires that 'Regex<Substring>' conform to 'Hashable'}}
+_ = [/abc /:/abc /] // expected-error {{generic struct 'Dictionary' requires that 'Regex<Substring>' conform to 'Hashable'}}
+_ = [/abc /: /abc /] // expected-error {{generic struct 'Dictionary' requires that 'Regex<Substring>' conform to 'Hashable'}}
+_ = (/abc/, /abc /)
+_ = ((/abc /))
+
+_ = { /abc/ }
+_ = {
+  /abc/
+}
+
+let _: () -> Int = {
+  0
+  / 1 /
+  2
+}
+
+_ = {
+  0 // expected-warning {{integer literal is unused}}
+  /1 / // expected-warning {{regular expression literal is unused}}
+  2 // expected-warning {{integer literal is unused}}
+}
+
+// Operator chain, as a regex literal may not start with space.
+_ = 2
+/ 1 / .bitWidth
+
+_ = 2
+/1/ .bitWidth // expected-error {{value of type 'Regex<Substring>' has no member 'bitWidth'}}
+
+_ = 2
+/ 1 /
+  .bitWidth
+
+_ = 2
+/1 /
+  .bitWidth // expected-error {{value of type 'Regex<Substring>' has no member 'bitWidth'}}
+
+let z =
+/y/
+
+// While '.' is technically an operator character, it seems more likely that
+// the user hasn't written the member name yet.
+_ = 0. / 1 / 2 // expected-error {{expected member name following '.'}}
+_ = 0 . / 1 / 2 // expected-error {{expected member name following '.'}}
+
+switch "" {
+case /x/:
+  // expected-error@-1 {{expression pattern of type 'Regex<Substring>' cannot match values of type 'String'}}
+  // expected-note@-2 {{overloads for '~=' exist with these partially matching parameter lists: (Substring, String)}}
+  break
+case _ where /x /:
+  // expected-error@-1 {{cannot convert value of type 'Regex<Substring>' to expected condition type 'Bool'}}
+  break
+default:
+  break
+}
+
+do {} catch /x / {}
+// expected-error@-1 {{expression pattern of type 'Regex<Substring>' cannot match values of type 'any Error'}}
+// expected-error@-2 {{binary operator '~=' cannot be applied to two 'any Error' operands}}
+// expected-warning@-3 {{'catch' block is unreachable because no errors are thrown in 'do' block}}
+
+switch /x / {
+default:
+  break
+}
+
+if /x / {} // expected-error {{cannot convert value of type 'Regex<Substring>' to expected condition type 'Bool'}}
+if /x /.smth {} // expected-error {{value of type 'Regex<Substring>' has no member 'smth'}}
+
+func testGuard() {
+  guard /x/ else { return } // expected-error {{cannot convert value of type 'Regex<Substring>' to expected condition type 'Bool'}}
+}
+
+for x in [0] where /x/ {} // expected-error {{cannot convert value of type 'Regex<Substring>' to expected condition type 'Bool'}}
+
+typealias Magic<T> = T
+_ = /x/ as Magic
+_ = /x/ as! String // expected-warning {{cast from 'Regex<Substring>' to unrelated type 'String' always fails}}
+
+_ = type(of: /x /)
+
+do {
+  let /x / // expected-error {{expected pattern}}
+}
+
+_ = try /x/; _ = try /x /
+// expected-warning@-1 2{{no calls to throwing functions occur within 'try' expression}}
+_ = try? /x/; _ = try? /x /
+// expected-warning@-1 2{{no calls to throwing functions occur within 'try' expression}}
+_ = try! /x/; _ = try! /x /
+// expected-warning@-1 2{{no calls to throwing functions occur within 'try' expression}}
+
+_ = await /x / // expected-warning {{no 'async' operations occur within 'await' expression}}
+
+/x/ = 0 // expected-error {{cannot assign to value: literals are not mutable}}
+/x/() // expected-error {{cannot call value of non-function type 'Regex<Substring>'}}
+
+// We treat the following as comments, as it seems more likely the user has
+// written a comment and is still in the middle of writing the characters before
+// it.
+_ = /x// comment
+// expected-error@-1 {{unterminated regex literal}}
+
+_ = /x // comment
+// expected-error@-1 {{unterminated regex literal}}
+
+_ = /x/*comment*/
+// expected-error@-1 {{unterminated regex literal}}
+
+// These become regex literals, unless surrounded in parens.
+func baz(_ x: (Int, Int) -> Int, _ y: (Int, Int) -> Int) {} // expected-note 2{{'baz' declared here}}
+baz(/, /)
+// expected-error@-1 {{cannot convert value of type 'Regex<Substring>' to expected argument type '(Int, Int) -> Int'}}
+// expected-error@-2 {{missing argument for parameter #2 in call}}
+baz(/,/)
+// expected-error@-1 {{cannot convert value of type 'Regex<Substring>' to expected argument type '(Int, Int) -> Int'}}
+// expected-error@-2 {{missing argument for parameter #2 in call}}
+baz((/), /)
+
+func qux<T>(_ x: (Int, Int) -> Int, _ y: T) -> Int { 0 }
+do {
+  _ = qux(/, 1) / 2
+  // expected-error@-1 {{cannot parse regular expression: closing ')' does not balance any groups openings}}
+  // expected-error@-2 {{expected ',' separator}}
+}
+do {
+  _ = qux(/, "(") / 2
+  // expected-error@-1 {{cannot convert value of type 'Regex<(Substring, Substring)>' to expected argument type '(Int, Int) -> Int'}}
+  // expected-error@-2 {{expected ',' separator}}
+}
+_ = qux(/, 1) // this comment tests to make sure we don't try and end the regex on the starting '/' of '//'.
+
+let arr: [Double] = [2, 3, 4]
+_ = arr.reduce(1, /) / 3
+_ = arr.reduce(1, /) + arr.reduce(1, /)
+
+// Fine.
+_ = /./
+
+// You need to escape if you want a regex literal to start with these characters.
+_ = /\ /
+_ = / / // expected-error {{regex literal may not start with space; add backslash to escape}} {{6-6=\}}
+
+_ = /\)/
+_ = /)/ // expected-error {{closing ')' does not balance any groups openings}}
+
+_ = /,/
+_ = /}/
+_ = /]/
+_ = /:/
+_ = /;/
+
+// Don't emit diagnostics here, as we re-lex.
+_ = /0xG/
+_ = /0oG/
+_ = /"/
+_ = /'/
+_ = /<#placeholder#>/

--- a/test/StringProcessing/Parse/regex.swift
+++ b/test/StringProcessing/Parse/regex.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-string-processing
+// RUN: %target-typecheck-verify-swift -enable-bare-slash-regex
 // REQUIRES: swift_in_compiler
 
 _ = #/abc/#

--- a/test/StringProcessing/Parse/regex.swift
+++ b/test/StringProcessing/Parse/regex.swift
@@ -1,17 +1,20 @@
 // RUN: %target-typecheck-verify-swift -enable-bare-slash-regex
 // REQUIRES: swift_in_compiler
 
+_ = /abc/
 _ = #/abc/#
 _ = ##/abc/##
 
 func foo<T>(_ x: T...) {}
-foo(#/abc/#, ##/abc/##)
+foo(/abc/, #/abc/#, ##/abc/##)
 
-let arr = [#/abc/#, ##/abc/##]
+let arr = [/abc/, #/abc/#, ##/abc/##]
 
+_ = /\w+/.self
 _ = #/\w+/#.self
 _ = ##/\w+/##.self
 
+_ = /#\/\#\\/
 _ = #/#/\/\#\\/#
 _ = ##/#|\|\#\\/##
 

--- a/test/StringProcessing/Parse/regex_parse_end_of_buffer.swift
+++ b/test/StringProcessing/Parse/regex_parse_end_of_buffer.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-string-processing
+// RUN: %target-typecheck-verify-swift -enable-bare-slash-regex
 // REQUIRES: swift_in_compiler
 
 // Note there is purposefully no trailing newline here.

--- a/test/StringProcessing/Parse/regex_parse_error.swift
+++ b/test/StringProcessing/Parse/regex_parse_error.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-string-processing
+// RUN: %target-typecheck-verify-swift -enable-bare-slash-regex
 // REQUIRES: swift_in_compiler
 
 _ = #/(/# // expected-error {{expected ')'}}

--- a/test/StringProcessing/Parse/regex_parse_error.swift
+++ b/test/StringProcessing/Parse/regex_parse_error.swift
@@ -1,9 +1,11 @@
 // RUN: %target-typecheck-verify-swift -enable-bare-slash-regex
 // REQUIRES: swift_in_compiler
 
+_ = /(/ // expected-error {{expected ')'}}
 _ = #/(/# // expected-error {{expected ')'}}
 
 // FIXME: Should be 'group openings'
+_ = /)/ // expected-error {{closing ')' does not balance any groups openings}}
 _ = #/)/# // expected-error {{closing ')' does not balance any groups openings}}
 
 _ = #/\\/''/ // expected-error {{unterminated regex literal}}
@@ -25,11 +27,21 @@ do {
 
 _ = #/\(?'abc/#
 
-_ = #/\
-/#
-// expected-error@-2 {{unterminated regex literal}}
-// expected-error@-3 {{expected escape sequence}}
-// expected-error@-3 {{expected expression}}
+do {
+  _ = /\
+  /
+  // expected-error@-2 {{unterminated regex literal}}
+  // expected-error@-3 {{expected escape sequence}}
+} // expected-error {{expected expression after operator}}
+
+do {
+  _ = #/\
+  /#
+  // expected-error@-2 {{unterminated regex literal}}
+  // expected-error@-3 {{expected escape sequence}}
+  // expected-error@-3 {{unterminated regex literal}}
+  // expected-warning@-4 {{regular expression literal is unused}}
+}
 
 func foo<T>(_ x: T, _ y: T) {}
 foo(#/(?/#, #/abc/#) // expected-error {{expected group specifier}}

--- a/test/StringProcessing/Runtime/regex_basic.swift
+++ b/test/StringProcessing/Runtime/regex_basic.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-string-processing)
+// RUN: %target-run-simple-swift(-Xfrontend -enable-bare-slash-regex)
 
 // REQUIRES: swift_in_compiler,string_processing,executable_test
 

--- a/test/StringProcessing/SILGen/regex_literal_silgen.swift
+++ b/test/StringProcessing/SILGen/regex_literal_silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen -enable-experimental-string-processing %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-bare-slash-regex %s | %FileCheck %s
 // REQUIRES: swift_in_compiler
 
 var s = #/abc/#

--- a/test/StringProcessing/Sema/regex_literal_type_inference.swift
+++ b/test/StringProcessing/Sema/regex_literal_type_inference.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-string-processing
+// RUN: %target-typecheck-verify-swift -enable-bare-slash-regex
 // REQUIRES: swift_in_compiler
 
 let r0 = #/./#

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -815,6 +815,11 @@ static llvm::cl::opt<bool> EnableExperimentalStringProcessing(
     llvm::cl::desc("Enable experimental string processing"),
     llvm::cl::init(false));
 
+static llvm::cl::opt<bool> EnableBareSlashRegexLiterals(
+    "enable-bare-slash-regex",
+    llvm::cl::desc("Enable the ability to write '/.../' regex literals"),
+    llvm::cl::init(false));
+
 static llvm::cl::list<std::string>
 AccessNotesPath("access-notes-path", llvm::cl::desc("Path to access notes file"),
                 llvm::cl::cat(Category));
@@ -4288,7 +4293,11 @@ int main(int argc, char *argv[]) {
     InitInvok.getLangOptions().EnableExperimentalNamedOpaqueTypes = true;
   }
   if (options::EnableExperimentalStringProcessing) {
-    InitInvok.getLangOptions().EnableExperimentalStringProcessing= true;
+    InitInvok.getLangOptions().EnableExperimentalStringProcessing = true;
+  }
+  if (options::EnableBareSlashRegexLiterals) {
+    InitInvok.getLangOptions().EnableBareSlashRegexLiterals = true;
+    InitInvok.getLangOptions().EnableExperimentalStringProcessing = true;
   }
 
   if (!options::Triple.empty())

--- a/unittests/Parse/LexerTests.cpp
+++ b/unittests/Parse/LexerTests.cpp
@@ -804,6 +804,9 @@ TEST_F(LexerTest, DiagnoseEmbeddedNul) {
           LexerMode::Swift, HashbangMode::Disallowed,
           CommentRetentionMode::None, TriviaRetentionMode::WithTrivia);
 
+  Token Tok;
+  L.lex(Tok);
+
   ASSERT_TRUE(containsPrefix(DiagConsumer.messages,
                              "1, 2: nul character embedded in middle of file"));
   ASSERT_TRUE(containsPrefix(DiagConsumer.messages,


### PR DESCRIPTION
*5.7 cherry-pick of https://github.com/apple/swift/pull/42119 + https://github.com/apple/swift/pull/42340*

Start parsing regex literals with `/.../` delimiters when `-enable-bare-slash-regex` is passed. Additionally, introduce a `-disable-experimental-string-processing` frontend flag that disables experimental string processing, including `/.../` literals.

rdar://83253726