### PR TITLE
Fix alignment issues when allocating in `AtomicWaitQueue`

### DIFF
--- a/include/swift/Runtime/HeapObject.h
+++ b/include/swift/Runtime/HeapObject.h
@@ -19,6 +19,8 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <new>
+#include <utility>
 #include "swift/Runtime/Config.h"
 
 #if SWIFT_OBJC_INTEROP
@@ -130,6 +132,49 @@ void *swift_slowAlloc(size_t bytes, size_t alignMask);
 // then call these corresponding APIs:
 SWIFT_RUNTIME_EXPORT
 void swift_slowDealloc(void *ptr, size_t bytes, size_t alignMask);
+
+/// Allocate and construct an instance of type \c T.
+///
+/// \param args The arguments to pass to the constructor for \c T.
+///
+/// \returns A pointer to a new, fully constructed instance of \c T. This
+/// 	function never returns \c nullptr. The caller is responsible for
+///   eventually destroying the resulting object by passing it to
+///   \c swift_cxx_deleteObject().
+///
+/// This function avoids the use of the global \c operator \c new (which may be
+/// overridden by other code in a process) in favor of calling
+/// \c swift_slowAlloc() and constructing the new object with placement new.
+/// 
+/// This function is capable of returning well-aligned memory even on platforms
+/// that do not implement the C++17 "over-aligned new" feature.
+template <typename T, typename... Args>
+static inline T *swift_cxx_newObject(Args &&... args) {
+  auto result = reinterpret_cast<T *>(swift_slowAlloc(sizeof(T),
+                                                      alignof(T) - 1));
+  ::new (result) T(std::forward<Args>(args)...);
+  return result;
+}
+
+/// Destruct and deallocate an instance of type \c T.
+///
+/// \param ptr A pointer to an instance of type \c T previously created with a
+/// 	call to \c swift_cxx_newObject().
+///
+/// This function avoids the use of the global \c operator \c delete (which may
+/// be overridden by other code in a process) in favor of directly calling the
+/// destructor for \a *ptr and then freeing its memory by calling
+/// \c swift_slowDealloc().
+///
+/// The effect of passing a pointer to this function that was \em not returned
+/// from \c swift_cxx_newObject() is undefined.
+template <typename T>
+static inline void swift_cxx_deleteObject(T *ptr) {
+  if (ptr) {
+  	ptr->~T();
+  	swift_slowDealloc(ptr, sizeof(T), alignof(T) - 1);
+  }
+}
 
 /// Atomically increments the retain count of an object.
 ///


### PR DESCRIPTION
This change ensures that `AtomicWaitQueue` allocates its inner queues in an aligned fashion even when the compiler does not support the C++17 "[over-aligned new](https://en.cppreference.com/w/cpp/memory/new/align_val_t)" feature, and avoids using `new` anyway since it might be overridden by something else in the process.

<!-- What's in this pull request? -->
On some platforms, the compiler does not support the C++17 "over-aligned new" feature. Allocating an instance of type `T` with `new T()` will produce a naturally-aligned pointer, which appears to be insufficient for use with `AtomicWaitQueue` on said platforms. Windows and Android in particular have been identified as affected.

~~The solution is to explicitly call [`std::aligned_alloc()`](https://en.cppreference.com/w/cpp/memory/c/aligned_alloc) (or, if the type's size is somehow not a multiple of its alignment, `std::malloc()`) and to use placement new to initialize the new value. Destruction is accomplished by directly calling the type's destructor and then passing the pointer to `std::free()`.~~

Since `swift_slowAlloc()` and `swift_slowDealloc()` handle alignment already and are the preferred allocation mechanisms in Swift, sub them in for `std::aligned_alloc()` and `std::free()` above.

This fix has the added benefit of avoiding the [global `operator new`](https://en.cppreference.com/w/cpp/memory/new/operator_new), which can be overridden by other code in the process. If the global `operator new` is overridden in such a way that it re-enters the Swift runtime, sadness will result.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!-- Resolves SR-NNNN. -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
