### PR TITLE
runtime: use explicit name for placement new

### DIFF
--- a/stdlib/public/runtime/MetadataImpl.h
+++ b/stdlib/public/runtime/MetadataImpl.h
@@ -100,11 +100,11 @@ struct NativeBox {
   }
   
   static T *initializeWithCopy(T *dest, T *src) {
-    return new (dest) T(*src);
+    return ::new (dest) T(*src);
   }
 
   static T *initializeWithTake(T *dest, T *src) {
-    T *result = new (dest) T(std::move(*src));
+    T *result = ::new (dest) T(std::move(*src));
     src->T::~T();
     return result;
   }


### PR DESCRIPTION
The android build seems to find a conflict in the overload set for the
placement new operator due to the custom new overload.  Provide the
indicator that we want the placement new allocator by using the
explicitly namespaced spelling.

Thanks to @buttaface for reporting the build failure.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
