### PR TITLE
[5.7][stdlib] Fix nullability logic of `memcmp`

### DIFF
--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -60,10 +60,11 @@ static inline __swift_size_t _swift_stdlib_strlen_unsigned(const unsigned char *
 SWIFT_READONLY
 static inline int _swift_stdlib_memcmp(const void *s1, const void *s2,
                                        __swift_size_t n) {
-#if defined(__APPLE__) || defined(__ANDROID__) || defined(__OpenBSD__) || defined(_WIN32)
-  extern int memcmp(const void * _Nullable, const void * _Nullable, __swift_size_t);
+// FIXME: Is there a way to identify Glibc specifically?
+#if defined(__gnu_linux__)
+  extern int memcmp(const void * _Nonnull, const void * _Nonnull, __swift_size_t);
 #else
-  extern int memcmp(const void *, const void *, __swift_size_t);
+  extern int memcmp(const void * _Null_unspecified, const void * _Null_unspecified, __swift_size_t);
 #endif
   return memcmp(s1, s2, n);
 }

--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -60,7 +60,7 @@ static inline __swift_size_t _swift_stdlib_strlen_unsigned(const unsigned char *
 SWIFT_READONLY
 static inline int _swift_stdlib_memcmp(const void *s1, const void *s2,
                                        __swift_size_t n) {
-#if defined(__APPLE__) || defined(__ANDROID__) || defined(__OpenBSD__)
+#if defined(__APPLE__) || defined(__ANDROID__) || defined(__OpenBSD__) || defined(_WIN32)
   extern int memcmp(const void * _Nullable, const void * _Nullable, __swift_size_t);
 #else
   extern int memcmp(const void *, const void *, __swift_size_t);


### PR DESCRIPTION
Cherry-pick of #41797 into Swift 5.7 release branch.

Fix the nullability judging logic for `extern int memcmp` in `LibcShims.h`.