### PR TITLE
Don't emit `@preconcurrency import` warnings for Swift interfaces

### DIFF
--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -268,6 +268,16 @@ void swift::performTypeChecking(SourceFile &SF) {
 /// there were no diagnostics downgraded or suppressed due to that
 /// @preconcurrency, suggest that the attribute be removed.
 static void diagnoseUnnecessaryPreconcurrencyImports(SourceFile &sf) {
+  switch (sf.Kind) {
+  case SourceFileKind::Interface:
+  case SourceFileKind::SIL:
+    return;
+
+  case SourceFileKind::Library:
+  case SourceFileKind::Main:
+    break;
+  }
+
   ASTContext &ctx = sf.getASTContext();
   for (const auto &import : sf.getImports()) {
     if (import.options.contains(ImportFlags::Preconcurrency) &&

--- a/test/ModuleInterface/SilencePreconcurrency.swiftinterface
+++ b/test/ModuleInterface/SilencePreconcurrency.swiftinterface
@@ -4,4 +4,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -compile-module-from-interface -o %/t/SilencePreconcurrency.swiftmodule %s -verify
 
+// REQUIRES: OS=macosx
+
 @preconcurrency import Swift

--- a/test/ModuleInterface/SilencePreconcurrency.swiftinterface
+++ b/test/ModuleInterface/SilencePreconcurrency.swiftinterface
@@ -1,0 +1,7 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -target x86_64-apple-macos10.9 -module-name SilencePreconcurrency
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -compile-module-from-interface -o %/t/SilencePreconcurrency.swiftmodule %s -verify
+
+@preconcurrency import Swift


### PR DESCRIPTION
Fixes rdar://88758592.
