### PR TITLE
[cxx-interop] Fix libstdc++ test failure with CentOS 7

### DIFF
--- a/test/Interop/Cxx/stdlib/libstdcxx-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/libstdcxx-module-interface.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-ide-test -print-module -module-to-print=std -source-filename=x -enable-experimental-cxx-interop -module-cache-path %t > %t/interface.swift
 // RUN: %FileCheck %s -check-prefix=CHECK-STD < %t/interface.swift
+// RUN: %FileCheck %s -check-prefix=CHECK-SIZE-T < %t/interface.swift
 // RUN: %FileCheck %s -check-prefix=CHECK-TO-STRING < %t/interface.swift
 // RUN: %FileCheck %s -check-prefix=CHECK-STRING < %t/interface.swift
 
@@ -9,23 +10,19 @@
 // This test is specific to libstdc++ and only runs on platforms where libstdc++ is used.
 // REQUIRES: OS=linux-gnu
 
-// REQUIRES: rdar91670704
-
 // CHECK-STD: enum std {
-// CHECK-STD:   enum __cxx11 {
-// CHECK-STD:     struct __CxxTemplateInstNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE {
-// CHECK-STD:       typealias value_type = std.__CxxTemplateInstSt11char_traitsIcE.char_type
-// CHECK-STD:     }
-// CHECK-STD:     struct __CxxTemplateInstNSt7__cxx1112basic_stringIwSt11char_traitsIwESaIwEEE {
-// CHECK-STD:       typealias value_type = std.__CxxTemplateInstSt11char_traitsIwE.char_type
-// CHECK-STD:     }
-// CHECK-STD:   }
+// CHECK-STRING:   struct {{__CxxTemplateInstNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE|__CxxTemplateInstSs}} {
+// CHECK-STRING:     typealias value_type = std.__CxxTemplateInstSt11char_traitsIcE.char_type
+// CHECK-STRING:   }
+// CHECK-STRING:   struct {{__CxxTemplateInstNSt7__cxx1112basic_stringIwSt11char_traitsIwESaIwEEE|__CxxTemplateInstSbIwSt11char_traitsIwESaIwEE}} {
+// CHECK-STRING:     typealias value_type = std.__CxxTemplateInstSt11char_traitsIwE.char_type
+// CHECK-STRING:   }
 
 // CHECK-TO-STRING:   static func to_string(_ __val: Int32) -> std{{(.__cxx11)?}}.string
 // CHECK-TO-STRING:   static func to_wstring(_ __val: Int32) -> std{{(.__cxx11)?}}.wstring
 
-// CHECK-STD:   typealias size_t = Int
+// CHECK-SIZE-T:   typealias size_t = Int
 
-// CHECK-STRING:   typealias string = std.__cxx11.__CxxTemplateInstNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
-// CHECK-STRING:   typealias wstring = std.__cxx11.__CxxTemplateInstNSt7__cxx1112basic_stringIwSt11char_traitsIwESaIwEEE
+// CHECK-STRING:   typealias string = std.{{__cxx11.__CxxTemplateInstNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE|__CxxTemplateInstSs}}
+// CHECK-STRING:   typealias wstring = std.{{__cxx11.__CxxTemplateInstNSt7__cxx1112basic_stringIwSt11char_traitsIwESaIwEEE|__CxxTemplateInstSbIwSt11char_traitsIwESaIwEE}}
 // CHECK-STD: }

--- a/test/Interop/Cxx/stdlib/use-std-string.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string.swift
@@ -5,8 +5,6 @@
 // Enable this everywhere once we have a solution for modularizing other C++ stdlibs: rdar://87654514
 // REQUIRES: OS=macosx || OS=linux-gnu
 
-// REQUIRES: rdar91548568
-
 import StdlibUnittest
 import StdString
 #if os(Linux)
@@ -19,7 +17,7 @@ import std.string
 var StdStringTestSuite = TestSuite("StdString")
 
 StdStringTestSuite.test("init") {
-    let s = CxxString()
+    var s = CxxString() // declared as `var` because of outdated libstdc++ on CentOS 7
     expectEqual(s.size(), 0)
     expectTrue(s.empty())
 }


### PR DESCRIPTION
This fixes `use-std-string.swift` & `libstdcxx-module-interface.swift`.

CentOS 7 comes with an outdated libstdc++ version. In that version, `std::basic_string` has a `mutable` member, which makes all of `basic_string`'s member functions mutating in Swift. This prevents us from calling `size()` or `empty()` on an immutable value of `std.string`. We should force these methods to be imported as non-mutating in Swift, but for now let's use `var` to make the tests pass.

rdar://91548568
rdar://91670704
