### PR TITLE
[IRGen] Emit mod summary for full LTO to enable hermetic seal with lld

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -82,6 +82,7 @@
 #include "llvm/Transforms/Instrumentation/SanitizerCoverage.h"
 #include "llvm/Transforms/Instrumentation/ThreadSanitizer.h"
 #include "llvm/Transforms/ObjCARC.h"
+#include "llvm/Transforms/Scalar.h"
 
 #include <thread>
 
@@ -601,10 +602,29 @@ bool swift::compileAndWriteLLVM(llvm::Module *module,
     EmitPasses.add(createPrintModulePass(out));
     break;
   case IRGenOutputKind::LLVMBitcode: {
+    // Emit a module summary by default for Regular LTO except ld64-based ones
+    // (which use the legacy LTO API).
+    bool EmitRegularLTOSummary =
+        targetMachine->getTargetTriple().getVendor() != llvm::Triple::Apple;
+
+    if (EmitRegularLTOSummary || opts.LLVMLTOKind == IRGenLLVMLTOKind::Thin) {
+      // Rename anon globals to be able to export them in the summary.
+      EmitPasses.add(createNameAnonGlobalPass());
+    }
+
     if (opts.LLVMLTOKind == IRGenLLVMLTOKind::Thin) {
       EmitPasses.add(createWriteThinLTOBitcodePass(out));
     } else {
-      EmitPasses.add(createBitcodeWriterPass(out));
+      if (EmitRegularLTOSummary) {
+        module->addModuleFlag(llvm::Module::Error, "ThinLTO", uint32_t(0));
+        // Assume other sources are compiled with -fsplit-lto-unit (it's enabled
+        // by default when -flto is specified on platforms that support regular
+        // lto summary.)
+        module->addModuleFlag(llvm::Module::Error, "EnableSplitLTOUnit",
+                              uint32_t(1));
+      }
+      EmitPasses.add(createBitcodeWriterPass(
+          out, /*ShouldPreserveUseListOrder*/ false, EmitRegularLTOSummary));
     }
     break;
   }


### PR DESCRIPTION
LTO pipeline requires consistent `EnableSplitLTOUnit` and module summary
in regular full LTO bitcode, and clang enables `EnableSplitLTOUnit` and
emit regular lto module summary on non-ld64 platforms.
Therefore, swiftc has to emit them for the consistency with clang.

This patch unlocks stdlib to be linked with a simple code with `--hermetic-seal-at-link` and lld on Linux

---

There are still some remaining issues:
1. autolinking somehow does not work
2. It seems conditional-dead-stripping doesn't work now when targeting ELF. `test/IRGen/conditional-dead-strip-exec.swift` doesn't pass yet.
3. `test/IRGen/virtual-function-elimination-exec.swift` and `test/IRGen/witness-method-elimination-exec.swift` are failing with the following preemption error.
```
ld.lld: error: cannot preempt symbol: $sBoWV
>>> defined in /home/katei/.ghq/work.katei.dev/swift-source/build/Ninja-ReleaseAssert/swift-linux-x86_64/lib/swift/linux/libswiftCore.so
>>> referenced by ld-temp.o
>>>               lto.tmp:($s4main7MyClassCMf)
```

It would be appreciated if you have any ideas.

Depends on https://github.com/apple/llvm-project/pull/4228