### PR TITLE
[Test] Fix broken IDE test

### DIFF
--- a/test/IDE/complete_in_result_builder.swift
+++ b/test/IDE/complete_in_result_builder.swift
@@ -36,7 +36,7 @@ func testGlobalLookup() {
   @TupleBuilder<String> var x1 {
     #^GLOBAL_LOOKUP^#
     // GLOBAL_LOOKUP: Begin completions
-    // GLOBAL_LOOKUP: Decl[GlobalVar]/CurrModule/TypeRelation[Identical]:         MyConstantString[#String#];
+    // GLOBAL_LOOKUP: Decl[GlobalVar]/CurrModule/TypeRelation[Convertible]:         MyConstantString[#String#];
     // GLOBAL_LOOKUP: End completions
   }
 
@@ -81,7 +81,7 @@ func testStaticMemberLookup() {
   @TupleBuilder<String> var x1 {
     StringFactory.#^COMPLETE_STATIC_MEMBER^#
     // COMPLETE_STATIC_MEMBER: Begin completions
-    // COMPLETE_STATIC_MEMBER: Decl[StaticMethod]/CurrNominal/TypeRelation[Identical]:     makeString({#x: String#})[#String#];
+    // COMPLETE_STATIC_MEMBER: Decl[StaticMethod]/CurrNominal/TypeRelation[Convertible]:     makeString({#x: String#})[#String#];
     // COMPLETE_STATIC_MEMBER: End completions
   }
 


### PR DESCRIPTION
`complete_in_result_builder.swift` was modified in
0b9644a0d4884268fd2a4f4558cea4fb737f9529 but ended up being merged
*after* 5d01a097e1e70963929c995ace134d15cb11a548 which removed the
`Identical` type relation entirely.

Replace the two added test cases with `Convertible` instead.
