### PR TITLE
[SymbolGraph] Initialize newly added IncludeClangDocs field

### DIFF
--- a/lib/DriverTool/swift_symbolgraph_extract_main.cpp
+++ b/lib/DriverTool/swift_symbolgraph_extract_main.cpp
@@ -170,6 +170,7 @@ int swift_symbolgraph_extract_main(ArrayRef<const char *> Args,
       ParsedArgs.hasArg(OPT_v),
       ParsedArgs.hasArg(OPT_skip_inherited_docs),
       ParsedArgs.hasArg(OPT_include_spi_symbols),
+      /*IncludeClangDocs=*/false,
   };
 
   if (auto *A = ParsedArgs.getLastArg(OPT_minimum_access_level)) {


### PR DESCRIPTION
This was added recently but not initialized in symbolgraph-extract.
We never output Clang imported symbols from this tool, so always passing
false is fine for now.