### PR TITLE
[TypeChecker] NFC: Un-XFAIL SwiftUI test-case which has been fixed

### DIFF
--- a/validation-test/Sema/SwiftUI/rdar57201781.swift
+++ b/validation-test/Sema/SwiftUI/rdar57201781.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -target x86_64-apple-macosx10.15 -swift-version 5
-// REQUIRES: rdar66110075
+
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx
 
@@ -9,7 +9,7 @@ struct ContentView : View {
   @State var foo: [String] = Array(repeating: "", count: 5)
 
   var body: some View {
-    VStack { // expected-error{{type of expression is ambiguous without more context}}
+    VStack {
       HStack {
         Text("")
         TextFi // expected-error {{cannot find 'TextFi' in scope}}


### PR DESCRIPTION
Test-case should no longer produce "type of expression is ambiguous"
fallback diagnostic.

Resolves: rdar://66110075

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
