### PR TITLE
[Type Resolution] Resolve `(any P.Type).Type` as the metatype of an existential metatype.

### DIFF
--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -314,3 +314,9 @@ func testAnyFixIt() {
   // expected-error@+1 {{optional 'any' type must be written '(any HasAssoc.Type)?'}}{{10-28=(any HasAssoc.Type)?}}
   let _: any HasAssoc.Type? = nil
 }
+
+func testNestedMetatype() {
+  let _: (any P.Type).Type = (any P.Type).self
+  let _: (any (P.Type)).Type = (any P.Type).self
+  let _: ((any (P.Type))).Type = (any P.Type).self
+}


### PR DESCRIPTION
Until we model `ExistentialMetatypeType` as `ExistentialType(MetatypeType)`, type resolution needs to look through the instance type repr when resolving a metatype. Otherwise, there's no way to distinguish between `P.Type.Type`, which is an existential metatype, and `(any P.Type).Type`, which is the static metatype of an existential metatype.

Resolves: rdar://91784600
