### PR TITLE
 Integrate newer string processing (a0ed7e1)

### DIFF
--- a/stdlib/public/RegexBuilder/CMakeLists.txt
+++ b/stdlib/public/RegexBuilder/CMakeLists.txt
@@ -40,7 +40,6 @@ add_swift_target_library(swiftRegexBuilder ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
     -DswiftRegexBuilder_EXPORTS
   SWIFT_COMPILE_FLAGS
     ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
-    -Xfrontend -enable-experimental-pairwise-build-block
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
 
   SWIFT_MODULE_DEPENDS _StringProcessing

--- a/stdlib/public/StringProcessing/CMakeLists.txt
+++ b/stdlib/public/StringProcessing/CMakeLists.txt
@@ -41,7 +41,6 @@ add_swift_target_library(swift_StringProcessing ${SWIFT_STDLIB_LIBRARY_BUILD_TYP
     -Dswift_StringProcessing_EXPORTS
   SWIFT_COMPILE_FLAGS
     ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
-    -Xfrontend -enable-experimental-pairwise-build-block
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
 
   SWIFT_MODULE_DEPENDS _RegexParser

--- a/test/SourceKit/Sema/sema_regex.swift
+++ b/test/SourceKit/Sema/sema_regex.swift
@@ -3,7 +3,7 @@ public func retRegex() -> Regex<Substring> {
 }
 
 // REQUIRES: swift_in_compiler
-// RUN: %sourcekitd-test -req=sema %s -- %s -Xfrontend -enable-bare-slash-regex | %FileCheck %s
+// RUN: %sourcekitd-test -req=sema %s -- %s -Xfrontend -enable-bare-slash-regex -Xfrontend -disable-availability-checking | %FileCheck %s
 
 // CHECK: [
 // CHECK:   {

--- a/test/StringProcessing/Frontend/enable-flag.swift
+++ b/test/StringProcessing/Frontend/enable-flag.swift
@@ -9,4 +9,5 @@ prefix operator / // expected-error {{prefix operator may not contain '/'}}
 _ = /x/
 _ = #/x/#
 
+@available(SwiftStdlib 5.7, *)
 func foo(_ x: Regex<Substring>) {}

--- a/test/StringProcessing/Parse/forward-slash-regex.swift
+++ b/test/StringProcessing/Parse/forward-slash-regex.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-bare-slash-regex
+// RUN: %target-typecheck-verify-swift -enable-bare-slash-regex -disable-availability-checking
 // REQUIRES: swift_in_compiler
 // REQUIRES: concurrency
 

--- a/test/StringProcessing/Parse/regex.swift
+++ b/test/StringProcessing/Parse/regex.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-bare-slash-regex
+// RUN: %target-typecheck-verify-swift -enable-bare-slash-regex -disable-availability-checking
 // REQUIRES: swift_in_compiler
 
 _ = /abc/

--- a/test/StringProcessing/Parse/regex_parse_end_of_buffer.swift
+++ b/test/StringProcessing/Parse/regex_parse_end_of_buffer.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-bare-slash-regex
+// RUN: %target-typecheck-verify-swift -enable-bare-slash-regex -disable-availability-checking
 // REQUIRES: swift_in_compiler
 
 // Note there is purposefully no trailing newline here.

--- a/test/StringProcessing/Parse/regex_parse_error.swift
+++ b/test/StringProcessing/Parse/regex_parse_error.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-bare-slash-regex
+// RUN: %target-typecheck-verify-swift -enable-bare-slash-regex -disable-availability-checking
 // REQUIRES: swift_in_compiler
 
 _ = /(/ // expected-error {{expected ')'}}

--- a/test/StringProcessing/Runtime/regex_basic.swift
+++ b/test/StringProcessing/Runtime/regex_basic.swift
@@ -7,12 +7,13 @@ import StdlibUnittest
 var RegexBasicTests = TestSuite("RegexBasic")
 
 extension String {
+  @available(SwiftStdlib 5.7, *)
   func expectMatch<T>(
     _ regex: Regex<T>,
     file: String = #file,
     line: UInt = #line
   ) -> Regex<T>.Match {
-    guard let result = matchWhole(regex) else {
+    guard let result = wholeMatch(of: regex) else {
       expectUnreachable("Failed match", file: file, line: line)
       fatalError()
     }
@@ -21,6 +22,7 @@ extension String {
 }
 
 RegexBasicTests.test("Basic") {
+  guard #available(SwiftStdlib 5.7, *) else { return }
   let input = "aabccd"
 
   let match1 = input.expectMatch(#/aabcc./#)
@@ -33,6 +35,7 @@ RegexBasicTests.test("Basic") {
 }
 
 RegexBasicTests.test("Modern") {
+  guard #available(SwiftStdlib 5.7, *) else { return }
   let input = "aabccd"
 
   let match1 = input.expectMatch(#/
@@ -43,6 +46,7 @@ RegexBasicTests.test("Modern") {
 }
 
 RegexBasicTests.test("Captures") {
+  guard #available(SwiftStdlib 5.7, *) else { return }
   let input = """
     A6F0..A6F1    ; Extend # Mn   [2] BAMUM COMBINING MARK KOQNDON..BAMUM \
     COMBINING MARK TUKWENTIS

--- a/test/StringProcessing/Sema/regex_literal_type_inference.swift
+++ b/test/StringProcessing/Sema/regex_literal_type_inference.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-bare-slash-regex
+// RUN: %target-typecheck-verify-swift -enable-bare-slash-regex -disable-availability-checking
 // REQUIRES: swift_in_compiler
 
 let r0 = #/./#

--- a/test/StringProcessing/Sema/string_processing_import.swift
+++ b/test/StringProcessing/Sema/string_processing_import.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-string-processing -disable-implicit-string-processing-module-import
+// RUN: %target-typecheck-verify-swift -enable-experimental-string-processing -disable-implicit-string-processing-module-import -disable-availability-checking
 // REQUIRES: swift_in_compiler
 
 // expected-error @+1 {{missing 'Regex' declaration, probably because the '_StringProcessing' module was not imported properly}}


### PR DESCRIPTION
Friend PR: apple/swift-experimental-string-processing#282.

Also remove the `-enable-experimental-pairwise-build-block` flag when building regex modules as the feature is already on by default.