### PR TITLE
Dynamic type lookup string compare optimization

### DIFF
--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -474,10 +474,13 @@ static bool sameObjCTypeManglings(Demangle::NodePointer node1,
 #endif
 
 /// Optimization for the case where we need to compare a StringRef and a null terminated C string
-/// Not converting s2 to a StringRef avoids the need to call both strlen and memcmp
+/// Not converting s2 to a StringRef avoids the need to call both strlen and memcmp when non-matching
+/// but equal length
 static bool stringRefEqualsCString(StringRef s1, const char *s2) {
   size_t length = s1.size();
-  return strncmp(s1.data(), s2, length) == 0 && s2[length] == '\0';
+  // It may be possible for s1 to contain embedded NULL characters
+  // so additionally validate that the lengths match
+  return strncmp(s1.data(), s2, length) == 0 && strlen(s2) == length;
 }
 
 bool

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -39,6 +39,7 @@
 #include <vector>
 #include <list>
 #include <new>
+#include <cstring>
 
 using namespace swift;
 using namespace Demangle;
@@ -472,6 +473,13 @@ static bool sameObjCTypeManglings(Demangle::NodePointer node1,
 }
 #endif
 
+/// Optimization for the case where we need to compare a StringRef and a null terminated C string
+/// Not converting s2 to a StringRef avoids the need to call both strlen and memcmp
+static bool stringRefEqualsCString(StringRef s1, const char *s2) {
+  size_t length = s1.size();
+  return strncmp(s1.data(), s2, length) == 0 && s2[length] == '\0';
+}
+
 bool
 swift::_contextDescriptorMatchesMangling(const ContextDescriptor *context,
                                          Demangle::NodePointer node) {
@@ -496,7 +504,7 @@ swift::_contextDescriptorMatchesMangling(const ContextDescriptor *context,
       // Match to a mangled module name.
       if (node->getKind() != Demangle::Node::Kind::Module)
         return false;
-      if (!node->getText().equals(module->Name.get()))
+      if (!stringRefEqualsCString(node->getText(), module->Name.get()))
         return false;
       
       node = nullptr;
@@ -568,7 +576,7 @@ swift::_contextDescriptorMatchesMangling(const ContextDescriptor *context,
         auto nameNode = node->getChild(1);
         if (nameNode->getKind() != Demangle::Node::Kind::Identifier)
           return false;
-        if (nameNode->getText() == proto->Name.get()) {
+        if (stringRefEqualsCString(nameNode->getText(), proto->Name.get())) {
           node = node->getChild(0);
           break;
         }


### PR DESCRIPTION
<!-- What's in this pull request? -->

This is a small optimization for a specific path of dynamic type lookup, as profiled below in our iOS application. In a small synthetic benchmark, using `strncmp` is roughly twice as fast as using `strlen` + `memcmp` via `StringRef` in the case where the two mangled type strings match.

<img width="1307" alt="Screen Shot 2022-03-30 at 11 53 25 AM" src="https://user-images.githubusercontent.com/643618/163600164-c136dd77-a6b3-4b54-8a31-eb27fe81fea3.png">


(missing frames due to inlining?)

Other ideas for optimizing this path welcome!

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
