### PR TITLE
[5.7][Type Resolution] Resolve `(any P.Type).Type` as the metatype of an existential metatype.

### DIFF
--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -314,3 +314,9 @@ func testAnyFixIt() {
   // expected-error@+1 {{optional 'any' type must be written '(any HasAssoc.Type)?'}}{{10-28=(any HasAssoc.Type)?}}
   let _: any HasAssoc.Type? = nil
 }
+
+func testNestedMetatype() {
+  let _: (any P.Type).Type = (any P.Type).self
+  let _: (any (P.Type)).Type = (any P.Type).self
+  let _: ((any (P.Type))).Type = (any P.Type).self
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/42380

* **Explanation**: Until we model `ExistentialMetatypeType` as `ExistentialType(MetatypeType)`, type resolution needs to look through the instance type repr when resolving a metatype. Otherwise, there's no way to distinguish between `P.Type.Type`, which is an existential metatype, and `(any P.Type).Type`, which is the static metatype of an existential metatype.
* **Scope**: The change is scoped to resolving metatypes of existential metatypes during type resolution.
* **Risk**: Low.
* **Testing**: Added a couple cases to `test/type/explicit_existential.swift`
* **Reviewer**: @CodaFi 

Resolves: rdar://91784600