### PR TITLE
Support hermetic indexing information + introduce `-file-prefix-map`

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -338,12 +338,9 @@ WARNING(framework_search_path_includes_framework_extension,none,
 ERROR(error_optimization_remark_pattern, none, "%0 in '%1'",
       (StringRef, StringRef))
 
-ERROR(error_invalid_debug_prefix_map, none,
-      "values for '-debug-prefix-map' must be in the format 'original=remapped'"
-      ", but '%0' was provided", (StringRef))
-ERROR(error_invalid_coverage_prefix_map, none,
-      "values for '-coverage-prefix-map' must be in the format "
-      "'original=remapped', but '%0' was provided", (StringRef))
+ERROR(error_opt_invalid_mapping, none,
+      "values for '%0' must be in the format 'original=remapped', but '%1' was "
+      "provided", (StringRef, StringRef))
 
 ERROR(invalid_vfs_overlay_file,none,
       "invalid virtual overlay file '%0'", (StringRef))

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -254,6 +254,11 @@ public:
   /// Path prefixes that should be rewritten in coverage info.
   PathRemapper CoveragePrefixMap;
 
+  /// Path prefixes that should be rewritten in info besides debug and coverage
+  /// (use DebugPrefixMap and CoveragePrefixMap for those) - currently just
+  /// indexing info.
+  PathRemapper FilePrefixMap;
+
   /// What level of debug info to generate.
   IRGenDebugInfoLevel DebugInfoLevel : 2;
 

--- a/include/swift/Basic/PathRemapper.h
+++ b/include/swift/Basic/PathRemapper.h
@@ -25,6 +25,7 @@
 #define SWIFT_BASIC_PATHREMAPPER_H
 
 #include "swift/Basic/LLVM.h"
+#include "clang/Basic/PathRemapper.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/Twine.h"
 
@@ -56,6 +57,15 @@ public:
         return (Twine(Mapping.second) +
                 Path.substr(Mapping.first.size())).str();
     return Path.str();
+  }
+
+  /// Returns the Clang PathRemapper equivalent, suitable for use with Clang
+  /// APIs.
+  clang::PathRemapper asClangPathRemapper() const {
+    clang::PathRemapper Remapper;
+    for (const auto &Mapping : PathMappings)
+      Remapper.addMapping(Mapping.first, Mapping.second);
+    return Remapper;
   }
 };
 

--- a/include/swift/Index/IndexRecord.h
+++ b/include/swift/Index/IndexRecord.h
@@ -14,6 +14,7 @@
 #define SWIFT_INDEX_INDEXRECORD_H
 
 #include "swift/Basic/LLVM.h"
+#include "swift/Basic/PathRemapper.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 
@@ -44,11 +45,14 @@ namespace index {
 /// \param targetTriple The target for this compilation.
 ///
 /// \param dependencyTracker The set of dependencies seen while building.
+///
+/// \param pathRemapper Remapper to use for paths in index data.
 bool indexAndRecord(SourceFile *primarySourceFile, StringRef indexUnitToken,
                     StringRef indexStorePath, bool indexSystemModules,
                     bool skipStdlib, bool isDebugCompilation,
                     StringRef targetTriple,
-                    const DependencyTracker &dependencyTracker);
+                    const DependencyTracker &dependencyTracker,
+                    const PathRemapper &pathRemapper);
 
 /// Index the given module and store the results to \p indexStorePath.
 ///
@@ -76,11 +80,14 @@ bool indexAndRecord(SourceFile *primarySourceFile, StringRef indexUnitToken,
 /// \param targetTriple The target for this compilation.
 ///
 /// \param dependencyTracker The set of dependencies seen while building.
+///
+/// \param pathRemapper Remapper to use for paths in index data.
 bool indexAndRecord(ModuleDecl *module, ArrayRef<std::string> indexUnitTokens,
                     StringRef moduleUnitToken, StringRef indexStorePath,
                     bool indexSystemModules, bool skipStdlib,
                     bool isDebugCompilation, StringRef targetTriple,
-                    const DependencyTracker &dependencyTracker);
+                    const DependencyTracker &dependencyTracker,
+                    const PathRemapper &pathRemapper);
 // FIXME: indexUnitTokens could be StringRef, but that creates an impedance
 // mismatch in the caller.
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -857,6 +857,9 @@ def debug_prefix_map : Separate<["-"], "debug-prefix-map">,
 def coverage_prefix_map : Separate<["-"], "coverage-prefix-map">,
   Flags<[FrontendOption]>,
   HelpText<"Remap source paths in coverage info">, MetaVarName<"<prefix=replacement>">;
+def file_prefix_map : Separate<["-"], "file-prefix-map">,
+  Flags<[FrontendOption]>,
+  HelpText<"Remap source paths in debug, coverage, and index info">, MetaVarName<"<prefix=replacement>">;
 
 def file_compilation_dir : Separate<["-"], "file-compilation-dir">,
   Flags<[FrontendOption]>, MetaVarName<"<path>">,

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -223,17 +223,16 @@ static void validateDebugInfoArgs(DiagnosticEngine &diags,
     }
   }
 
-  // Check for any -debug-prefix-map options that aren't of the form
+  // Check for any -*-prefix-map options that aren't of the form
   // 'original=remapped' (either side can be empty, however).
-  for (auto A : args.getAllArgValues(options::OPT_debug_prefix_map))
-    if (A.find('=') == StringRef::npos)
-      diags.diagnose(SourceLoc(), diag::error_invalid_debug_prefix_map, A);
-
-  // Check for any -coverage-prefix-map options that aren't of the form
-  // 'original=remapped' (either side can be empty, however).
-  for (auto A : args.getAllArgValues(options::OPT_coverage_prefix_map))
-    if (A.find('=') == StringRef::npos)
-      diags.diagnose(SourceLoc(), diag::error_invalid_coverage_prefix_map, A);
+  for (const Arg *A : args.filtered(options::OPT_debug_prefix_map,
+                                    options::OPT_coverage_prefix_map,
+                                    options::OPT_file_prefix_map)) {
+    StringRef val = A->getValue();
+    if (val.find('=') == StringRef::npos)
+      diags.diagnose(SourceLoc(), diag::error_opt_invalid_mapping,
+                     A->getOption().getPrefixedName(), val);
+  }
 }
 
 static void validateVerifyIncrementalDependencyArgs(DiagnosticEngine &diags,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -305,8 +305,9 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddAllArgs(arguments, options::OPT_D);
 
   // Pass on file paths that should be remapped in debug info.
-  inputArgs.AddAllArgs(arguments, options::OPT_debug_prefix_map);
-  inputArgs.AddAllArgs(arguments, options::OPT_coverage_prefix_map);
+  inputArgs.AddAllArgs(arguments, options::OPT_debug_prefix_map,
+                                  options::OPT_coverage_prefix_map,
+                                  options::OPT_file_prefix_map);
 
   std::string globalRemapping = getGlobalDebugPathRemapping();
   if (!globalRemapping.empty()) {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1210,14 +1210,23 @@ static bool ParseClangImporterArgs(ClangImporterOptions &Opts,
     Opts.ExtraArgs.push_back(A->getValue());
   }
 
-  for (auto A : Args.getAllArgValues(OPT_debug_prefix_map)) {
+  for (const Arg *A : Args.filtered(OPT_file_prefix_map,
+                                    OPT_debug_prefix_map)) {
+    std::string Val(A->getValue());
     // Forward -debug-prefix-map arguments from Swift to Clang as
-    // -fdebug-prefix-map. This is required to ensure DIFiles created there,
-    // like "<swift-imported-modules>", have their paths remapped properly.
+    // -fdebug-prefix-map= and -file-prefix-map as -ffile-prefix-map=.
+    //
+    // This is required to ensure DIFiles created there, like
+    /// "<swift-imported-modules>", as well as index data, have their paths
+    // remapped properly.
+    //
     // (Note, however, that Clang's usage of std::map means that the remapping
     // may not be applied in the same order, which can matter if one mapping is
     // a prefix of another.)
-    Opts.ExtraArgs.push_back("-fdebug-prefix-map=" + A);
+    if (A->getOption().matches(OPT_file_prefix_map))
+      Opts.ExtraArgs.push_back("-ffile-prefix-map=" + Val);
+    else
+      Opts.ExtraArgs.push_back("-fdebug-prefix-map=" + Val);
   }
 
   if (!workingDirectory.empty()) {
@@ -2000,6 +2009,13 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
                    Opts.DebugInfoLevel == IRGenDebugInfoLevel::LineTables
                      ? "-gline-tables-only"
                      : "-gdwarf_types");
+  }
+
+  for (auto A : Args.getAllArgValues(options::OPT_file_prefix_map)) {
+    auto SplitMap = StringRef(A).split('=');
+    Opts.FilePrefixMap.addMapping(SplitMap.first, SplitMap.second);
+    Opts.DebugPrefixMap.addMapping(SplitMap.first, SplitMap.second);
+    Opts.CoveragePrefixMap.addMapping(SplitMap.first, SplitMap.second);
   }
 
   for (auto A : Args.getAllArgValues(options::OPT_debug_prefix_map)) {

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1745,7 +1745,8 @@ static void emitIndexDataForSourceFile(SourceFile *PrimarySourceFile,
                                  opts.IndexStorePath, opts.IndexSystemModules,
                                  opts.IndexIgnoreStdlib, isDebugCompilation,
                                  Invocation.getTargetTriple(),
-                                 *Instance.getDependencyTracker());
+                                 *Instance.getDependencyTracker(),
+                                 Invocation.getIRGenOptions().FilePrefixMap);
   } else {
     std::string moduleToken =
         Invocation.getModuleOutputPathForAtMostOnePrimary();
@@ -1760,7 +1761,8 @@ static void emitIndexDataForSourceFile(SourceFile *PrimarySourceFile,
                                  opts.IndexIgnoreStdlib,
                                  isDebugCompilation,
                                  Invocation.getTargetTriple(),
-                                 *Instance.getDependencyTracker());
+                                 *Instance.getDependencyTracker(),
+                                 Invocation.getIRGenOptions().FilePrefixMap);
   }
 }
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1088,8 +1088,11 @@ void Serializer::writeHeader(const SerializationOptions &options) {
               ++Arg;
               continue;
             }
-          } else if (arg.startswith("-fdebug-prefix-map=")) {
-            // We don't serialize the debug prefix map flags as these
+          } else if (arg.startswith("-fdebug-prefix-map=") ||
+              arg.startswith("-ffile-prefix-map=") ||
+              arg.startswith("-fcoverage-prefix-map=") ||
+              arg.startswith("-fmacro-prefix-map=")) {
+            // We don't serialize any of the prefix map flags as these flags
             // contain absolute paths that are not usable on different
             // machines. These flags are not necessary to compile the
             // clang modules again so are safe to remove.

--- a/test/Index/Store/unit-multiple-sourcefiles-remapped.swift
+++ b/test/Index/Store/unit-multiple-sourcefiles-remapped.swift
@@ -1,0 +1,40 @@
+//===--- Building source files separately with a module merge at the end
+
+// RUN: %empty-directory(%t)
+// RUN: touch %t/s1.swift %t/s2.swift
+// RUN: %target-swift-frontend -index-store-path %t/idx -file-prefix-map %t=REMAPPED_OUT_DIR -primary-file %t/s1.swift %t/s2.swift -o %t/s1.o -c -module-name main -emit-module -emit-module-path %t/s1.swiftmodule
+// RUN: %target-swift-frontend -index-store-path %t/idx -file-prefix-map %t=REMAPPED_OUT_DIR %t/s1.swift -primary-file %t/s2.swift -o %t/s2.o -c -module-name main -emit-module -emit-module-path %t/s2.swiftmodule
+// RUN: %target-swift-frontend -index-store-path %t/idx -file-prefix-map %t=REMAPPED_OUT_DIR %t/s1.swiftmodule %t/s2.swiftmodule -emit-module -o %t/main.swiftmodule -module-name main
+// RUN: c-index-test core -print-unit %t/idx | %FileCheck %s
+
+//===--- Building source files together (e.g. WMO)
+
+// RUN: %empty-directory(%t)
+// RUN: touch %t/s1.swift %t/s2.swift
+// RUN: %target-swift-frontend -index-store-path %t/idx -file-prefix-map %t=REMAPPED_OUT_DIR %t/s1.swift %t/s2.swift -o %t/s1.o -o %t/s2.o -c -module-name main -emit-module -emit-module-path %t/main.swiftmodule
+// RUN: c-index-test core -print-unit %t/idx | %FileCheck %s
+
+//===--- Building separately but with relative paths for the source file inputs
+
+// RUN: %empty-directory(%t)
+// RUN: cd %t
+// RUN: touch %t/s1.swift %t/s2.swift
+// RUN: %target-swift-frontend -index-store-path idx -file-prefix-map %t=REMAPPED_OUT_DIR -primary-file s1.swift s2.swift -o s1.o -c -module-name main -emit-module -emit-module-path s1.swiftmodule
+// RUN: %target-swift-frontend -index-store-path idx -file-prefix-map %t=REMAPPED_OUT_DIR s1.swift -primary-file s2.swift -o s2.o -c -module-name main -emit-module -emit-module-path s2.swiftmodule
+// RUN: %target-swift-frontend -index-store-path idx -file-prefix-map %t=REMAPPED_OUT_DIR s1.swiftmodule s2.swiftmodule -emit-module -o main.swiftmodule -module-name main
+// RUN: c-index-test core -print-unit idx | %FileCheck %s
+// CHECK-NOT: main.swiftmodule-{{[A-Z0-9]*}}
+
+// CHECK: s1.o-{{2LQAU7D8TZHZ8|2RHC8ZJFDYDW4}}
+// CHECK: --------
+// CHECK: out-file: REMAPPED_OUT_DIR{{/|\\}}s1.o
+// CHECK: DEPEND START
+// CHECK: Unit | system | {{.*}}Swift.swiftmodule
+// CHECK: DEPEND END
+
+// CHECK: s2.o-{{2OIL2LG8UULK6|15MCL6ZLKZKNL}}
+// CHECK: --------
+// CHECK: out-file: REMAPPED_OUT_DIR{{/|\\}}s2.o
+// CHECK: DEPEND START
+// CHECK: Unit | system | {{.*}}Swift.swiftmodule
+// CHECK: DEPEND END

--- a/test/Index/Store/unit-one-sourcefile-remapped.swift
+++ b/test/Index/Store/unit-one-sourcefile-remapped.swift
@@ -1,0 +1,23 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t/BuildRoot && cd %t/BuildRoot
+// RUN: %target-swift-frontend -index-store-path %t/idx -file-prefix-map %S=REMAPPED_SRC_ROOT -file-prefix-map %t=REMAPPED_OUT_DIR %s -o %t/file1.o -typecheck
+// RUN: c-index-test core -print-unit %t/idx | %FileCheck %s --dump-input-filter all
+
+// CHECK: file1.o-1AYKXZF3HH50A
+// CHECK: --------
+// CHECK: main-path: REMAPPED_SRC_ROOT{{/|\\}}unit-one-sourcefile-remapped.swift
+// CHECK: work-dir: REMAPPED_OUT_DIR{{/|\\}}BuildRoot
+// CHECK: out-file: REMAPPED_OUT_DIR{{/|\\}}file1.o
+// CHECK: DEPEND START
+// CHECK: Unit | system | Swift | {{BUILD_DIR|.*lib\\swift\\windows}}{{.*}}Swift.swiftmodule
+// CHECK: DEPEND END
+
+
+// Check round-trip remapping to make sure they're converted back to the local paths.
+// RUN: c-index-test core -print-unit %t/idx -index-store-prefix-map REMAPPED_SRC_ROOT=%S -index-store-prefix-map  REMAPPED_OUT_DIR=%t | %FileCheck %s -check-prefix=ROUNDTRIP --dump-input-filter all
+
+// ROUNDTRIP: file1.o-1AYKXZF3HH50A
+// ROUNDTRIP: --------
+// ROUNDTRIP: main-path: SOURCE_DIR{{/|\\}}test{{/|\\}}Index{{/|\\}}Store{{/|\\}}unit-one-sourcefile-remapped.swift
+// ROUNDTRIP-NOT: work-dir: REMAPPED_OUT_DIR
+// ROUNDTRIP-NOT: out-file: REMAPPED_OUT_DIR

--- a/test/Index/Store/unit-pcm-dependency-remapped.swift
+++ b/test/Index/Store/unit-pcm-dependency-remapped.swift
@@ -1,0 +1,100 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t/BUILDROOT && cd %t/BUILDROOT
+// RUN: %target-swift-frontend -disable-implicit-concurrency-module-import -index-store-path %t/idx -file-prefix-map %t=REMAPPED_OUT_DIR -primary-file %s -o %t/s1.o -I %S/Inputs -typecheck -module-cache-path %t/mcp -enable-objc-interop
+// RUN: c-index-test core -print-unit %t/idx | %FileCheck %s -check-prefix=FILE1 --dump-input-filter all
+
+// If the module cache already exists, the pcm gets indexed.
+// RUN: rm -rf %t/idx
+// RUN: %target-swift-frontend -disable-implicit-concurrency-module-import -index-store-path %t/idx -file-prefix-map %t=REMAPPED_OUT_DIR -primary-file %s -o %t/s1.o -I %S/Inputs -typecheck -module-cache-path %t/mcp -enable-objc-interop
+// RUN: c-index-test core -print-unit %t/idx | %FileCheck %s -check-prefix=FILE1 --dump-input-filter all
+
+// FIXME: index the bridging header!
+
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/BUILDROOT && cd %t/BUILDROOT
+// RUN: echo 'import ClangModuleA' > %t/s2.swift
+// RUN: %target-swift-frontend -disable-implicit-concurrency-module-import -index-store-path %t/idx -file-prefix-map %S=REMAPPED_SRC_DIR -file-prefix-map %t=REMAPPED_OUT_DIR %s %t/s2.swift -o %t/s1.o -o %t/s2.o -I %S/Inputs -c -emit-module -module-name main -emit-module-path %t/main.swiftmodule -module-cache-path %t/mcp -enable-objc-interop
+// RUN: c-index-test core -print-unit %t/idx > %t/both.txt
+// RUN: %FileCheck %s -check-prefixes=FILE1,FILE1-ABSOLUTE < %t/both.txt --dump-input-filter all
+// RUN: %FileCheck %s -check-prefixes=FILE2,FILE2-ABSOLUTE < %t/both.txt --dump-input-filter all
+
+//===--- Same as above, but with relative paths for the source file inputs,
+//===--- which we give from the %t test dir.
+
+// RUN: %empty-directory(%t)
+// RUN: cd %t
+// RUN: cp %s %t/
+// RUN: echo 'import ClangModuleA' > %t/s2.swift
+// RUN: %target-swift-frontend -disable-implicit-concurrency-module-import -index-store-path idx -file-prefix-map %t=REMAPPED_OUT_DIR unit-pcm-dependency-remapped.swift s2.swift -o s1.o -o s2.o -I %S/Inputs -c -emit-module -module-name main -emit-module-path main.swiftmodule -module-cache-path mcp -enable-objc-interop
+// RUN: c-index-test core -print-unit %t/idx > %t/both.txt
+// RUN: %FileCheck %s -check-prefixes=FILE1,FILE1-RELATIVE < %t/both.txt --dump-input-filter all
+// RUN: %FileCheck %s -check-prefixes=FILE2,FILE2-RELATIVE < %t/both.txt --dump-input-filter all
+
+
+import ClangModuleB
+import ClangModuleC.Sub1
+import ClangModuleC.Sub2
+
+func test() {
+  funcA()
+  funcB()
+}
+
+// FILE1: ClangModuleA-
+// FILE1: --------
+// FILE1: is-system: 0
+// FILE1: has-main: 0
+// FILE1: out-file: REMAPPED_OUT_DIR{{.*}}ClangModuleA-{{.*}}.pcm
+// FILE1: DEPEND START
+// FILE1: Record | user | {{.*}}ClangModuleA.h | ClangModuleA.h-
+// FILE1: DEPEND END
+
+// FILE1: ClangModuleB-
+// FILE1: --------
+// FILE1: is-system: 0
+// FILE1: has-main: 0
+// FILE1: out-file: REMAPPED_OUT_DIR{{.*}}ClangModuleB-{{.*}}.pcm
+// FILE1: DEPEND START
+// FILE1: Unit | user | ClangModuleA | REMAPPED_OUT_DIR{{/|\\}}mcp{{.*}}ClangModuleA-{{.*}}.pcm | ClangModuleA-{{.*}}.pcm-
+// FILE1: Record | user | {{.*}}ClangModuleB.h | ClangModuleB.h-
+// FILE1: DEPEND END
+
+// FILE1: s1.o-{{2LQAU7D8TZHZ8|2RHC8ZJFDYDW4}}
+// FILE1: --------
+// FILE1: has-main: 1
+// FILE1-ABSOLUTE: main-path: REMAPPED_SRC_DIR{{.*}}unit-pcm-dependency-remapped.swift
+// FILE1-ABSOLUTE: work-dir: REMAPPED_OUT_DIR{{/|\\}}BUILDROOT
+// FILE1-RELATIVE: main-path: REMAPPED_OUT_DIR{{.*}}unit-pcm-dependency-remapped.swift
+// FILE1-RELATIVE: work-dir: REMAPPED_OUT_DIR
+// FILE1: out-file: REMAPPED_OUT_DIR{{/|\\}}s1.o
+// FILE1: DEPEND START
+// FILE1-NOT: ClangModuleA.h
+// FILE1-NOT: Unit |{{.*}}ClangModuleA
+// FILE1: Unit | system | Swift | {{BUILD_DIR|.*lib\\swift\\windows}}{{.*}}Swift.swiftmodule
+// FILE1-NOT: Unit |{{.*}}ClangModuleA
+// FILE1: Unit | user | ClangModuleB | REMAPPED_OUT_DIR{{/|\\}}mcp{{.*}}ClangModuleB-{{[A-Z0-9]*}}.pcm | ClangModuleB-{{[A-Z0-9]*}}.pcm-
+// FILE1: Unit | user | ClangModuleC | REMAPPED_OUT_DIR{{/|\\}}mcp{{.*}}ClangModuleC-{{[A-Z0-9]*}}.pcm | ClangModuleC-{{[A-Z0-9]*}}.pcm-
+// FILE1-NOT: Unit |{{.*}}ClangModuleA
+// FILE1: Record | user | {{.*}}unit-pcm-dependency-remapped.swift | unit-pcm-dependency-remapped.swift-
+// FILE1-NOT: Unit |{{.*}}ClangModuleA
+// FILE1: DEPEND END (4)
+
+// FILE2-NOT: main.swiftmodule-
+
+// FILE2: s2.o-{{2OIL2LG8UULK6|15MCL6ZLKZKNL}}
+// FILE2: --------
+// FILE2: has-main: 1
+// FILE2: main-path: REMAPPED_OUT_DIR{{.*}}s2.swift
+// FILE2: out-file: {{.*}}s2.o
+// FILE2: DEPEND START
+// FILE2-NOT: ClangModuleB.h
+// FILE2-NOT: Unit |{{.*}}ClangModuleB
+// FILE2-NOT: Record
+// FILE2: Unit | system | Swift | {{BUILD_DIR|.*lib\\swift\\windows}}{{.*}}Swift.swiftmodule
+// FILE2-NOT: Unit |{{.*}}ClangModuleB
+// FILE2-NOT: Record
+// FILE2: Unit | user | ClangModuleA | REMAPPED_OUT_DIR{{/|\\}}mcp{{.*}}ClangModuleA-{{[A-Z0-9]*}}.pcm | ClangModuleA-{{[A-Z0-9]*}}.pcm-
+// FILE2: Record | user | {{.*}}s2.swift | s2.swift-
+// FILE2-NOT: Unit |{{.*}}ClangModuleB
+// FILE2-NOT: Record
+// FILE2: DEPEND END


### PR DESCRIPTION
Swiftc port of https://github.com/apple/llvm-project/pull/4207, via introducing a new flag, `-file-prefix-map` as discussed on the Swift forums [here](https://forums.swift.org/t/standardizing-support-for-path-remappings-hermetic-builds-and-indexing/56713). The `-file-prefix-map` can be used in place of the existing `-debug-prefix-map` and `-coverage-prefix-map` flags.

With this, `-file-prefix-map` can be used to make the index output files hermetic/reproducible, and then the reverse mappings (remote=local or hermetic=local) can be given to the IndexStore libraries to remap the hermetic paths to the proper locations on the local machines.