### PR TITLE
[BuilderTransform] Extract all builder related operations into `ResultBuilder` type

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -108,22 +108,15 @@ namespace constraints {
 struct ResultBuilder {
 private:
   DeclContext *DC;
+  /// An implicit variable that represents `Self` type of the result builder.
+  VarDecl *BuilderSelf;
   Type BuilderType;
   llvm::SmallDenseMap<DeclName, bool> SupportedOps;
 
   Identifier BuildOptionalId;
 
 public:
-  ResultBuilder(DeclContext *DC, Type builderType)
-      : DC(DC), BuilderType(builderType) {
-    auto &ctx = DC->getASTContext();
-    // Use buildOptional(_:) if available, otherwise fall back to buildIf
-    // when available.
-    BuildOptionalId =
-        (supports(ctx.Id_buildOptional) || !supports(ctx.Id_buildIf))
-            ? ctx.Id_buildOptional
-            : ctx.Id_buildIf;
-  }
+  ResultBuilder(ConstraintSystem *CS, DeclContext *DC, Type builderType);
 
   DeclContext *getDeclContext() const { return DC; }
 
@@ -139,6 +132,10 @@ public:
                 bool checkAvailability = false);
 
   bool supportsOptional() { return supports(getBuildOptionalId()); }
+
+  Expr *buildCall(SourceLoc loc, Identifier fnName,
+                  ArrayRef<Expr *> argExprs,
+                  ArrayRef<Identifier> argLabels) const;
 };
 
 /// Describes the algorithm to use for trailing closure matching.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -143,6 +143,10 @@ public:
 
   /// Build an implicit variable in this context.
   VarDecl *buildVar(SourceLoc loc);
+
+  /// Build a reference to a given variable and mark it
+  /// as located at a given source location.
+  DeclRefExpr *buildVarRef(VarDecl *var, SourceLoc loc);
 };
 
 /// Describes the algorithm to use for trailing closure matching.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -115,6 +115,10 @@ private:
 
   Identifier BuildOptionalId;
 
+  /// Counter used to give unique names to the variables that are
+  /// created implicitly.
+  unsigned VarCounter = 0;
+
 public:
   ResultBuilder(ConstraintSystem *CS, DeclContext *DC, Type builderType);
 
@@ -136,6 +140,9 @@ public:
   Expr *buildCall(SourceLoc loc, Identifier fnName,
                   ArrayRef<Expr *> argExprs,
                   ArrayRef<Identifier> argLabels) const;
+
+  /// Build an implicit variable in this context.
+  VarDecl *buildVar(SourceLoc loc);
 };
 
 /// Describes the algorithm to use for trailing closure matching.

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -337,12 +337,6 @@ protected:
     return captureExpr(call, /*oneWay=*/true, braceStmt);
   }
 
-  VarDecl *visitReturnStmt(ReturnStmt *stmt) {
-    if (!unhandledNode)
-      unhandledNode = stmt;
-    return nullptr;
-  }
-
   VarDecl *visitDoStmt(DoStmt *doStmt) {
     auto childVar = visitBraceStmt(doStmt->getBody());
     if (!childVar)
@@ -904,6 +898,7 @@ protected:
   CONTROL_FLOW_STMT(Fallthrough)
   CONTROL_FLOW_STMT(Fail)
   CONTROL_FLOW_STMT(PoundAssert)
+  CONTROL_FLOW_STMT(Return)
 
 #undef CONTROL_FLOW_STMT
 };


### PR DESCRIPTION
This is a very first step towards transforming result builder handling into an AST transformation.
Makes it possible to share common functionality between existing and new transforms and cache
the information about the builder if needed.

The list of operations:

- `supports(...)`
- `buildCall(...)`
- `buildVar(...)`
- `buildVarRef(...)`

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
