### PR TITLE
allow swift-symbolgraph-extract to be called on non-swift modules

### DIFF
--- a/lib/DriverTool/swift_symbolgraph_extract_main.cpp
+++ b/lib/DriverTool/swift_symbolgraph_extract_main.cpp
@@ -223,7 +223,10 @@ int swift_symbolgraph_extract_main(ArrayRef<const char *> Args,
     return EXIT_FAILURE;
   }
 
-  const auto &MainFile = M->getMainFile(FileUnitKind::SerializedAST);
+  FileUnitKind expectedKind = FileUnitKind::SerializedAST;
+  if (M->isNonSwiftModule())
+    expectedKind = FileUnitKind::ClangModule;
+  const auto &MainFile = M->getMainFile(expectedKind);
   
   if (Options.PrintMessages)
     llvm::errs() << "Emitting symbol graph for module file: " << MainFile.getModuleDefiningPath() << '\n';


### PR DESCRIPTION
Resolves rdar://90842354.

When `swift-symbolgraph-extract` is called on a non-Swift module (i.e. a framework with only C or Objective-C code), it trips an assertion in `ModuleDecl::getMainFile`. This is because `getMainFile` is being told to expect a `SerializedAST` file, but it's instead finding a `ClangModule` file. This PR looks at the module and instead asks for a `ClangModule` file if it's a non-Swift module.

Note that this only affects builds with assertions enabled - when assertions are turned off, the offending line is skipped, and the module is actually loaded and parsed correctly anyway. This change is mainly to allow debug/assertion builds to be used in this situation.