### PR TITLE
[Static Mirror] Extract names of external-type conformances

### DIFF
--- a/test/Reflection/Inputs/cmodules/module.modulemap
+++ b/test/Reflection/Inputs/cmodules/module.modulemap
@@ -1,0 +1,4 @@
+module testModA {
+  header "testModA.h"
+  export *
+}

--- a/test/Reflection/Inputs/cmodules/testModA.h
+++ b/test/Reflection/Inputs/cmodules/testModA.h
@@ -1,0 +1,4 @@
+#import <Foundation/Foundation.h>
+@interface testModAClass : NSObject
+@property int x;
+@end

--- a/test/Reflection/Inputs/cmodules/testModA.m
+++ b/test/Reflection/Inputs/cmodules/testModA.m
@@ -1,0 +1,9 @@
+#import "testModA.h"
+
+@implementation testModAClass
+- (instancetype) init {
+    if ((self = [super init]) == nil) return nil;
+    self.x = 42;
+    return self;
+}
+@end

--- a/test/Reflection/Inputs/swiftmodules/testModB.swift
+++ b/test/Reflection/Inputs/swiftmodules/testModB.swift
@@ -1,0 +1,3 @@
+import Foundation
+
+public struct testModBStruct {}

--- a/test/Reflection/conformance_descriptors_of_external_types.swift
+++ b/test/Reflection/conformance_descriptors_of_external_types.swift
@@ -1,0 +1,29 @@
+// REQUIRES: objc_interop, OS=macosx
+// Temporarily disable on arm64e (rdar://88579818)
+// UNSUPPORTED: CPU=arm64e
+
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/includes)
+
+// Build external Swift library/module
+// RUN: %target-build-swift %S/Inputs/swiftmodules/testModB.swift -parse-as-library -emit-module -emit-library -module-name testModB -o %t/includes/testModB.o
+
+// Build external Clang library
+// RUN: %target-clang %S/Inputs/cmodules/testModA.m -c -o %t/testModA.o
+
+// Build the test into a binary
+// RUN: %target-build-swift %s -parse-as-library -emit-module -emit-library -module-name ExternalConformanceCheck -I %t/includes -I %S/Inputs/cmodules -o %t/ExternalConformances %t/testModA.o %t/includes/testModB.o
+
+// RUN: %target-swift-reflection-dump -binary-filename %t/ExternalConformances -binary-filename %platform-module-dir/%target-library-name(swiftCore) | %FileCheck %s
+
+import testModA
+import testModB
+
+protocol myTestProto {}
+extension testModBStruct : myTestProto {}
+extension testModAClass : myTestProto {}
+
+// CHECK: CONFORMANCES:
+// CHECK: =============
+// CHECK-DAG:  (__C.testModAClass) : ExternalConformanceCheck.myTestProto
+// CHECK-DAG: _$s8testModB0aB7BStructVMn (testModB.testModBStruct) : ExternalConformanceCheck.myTestProto


### PR DESCRIPTION
Covering two cases: external ObjC class extensions that add a conformances, and extensions of external Swift types that add a conformance. For both cases, we were not previously reading out the type name correctly, or at all.

Resolves rdar://91832735
