### PR TITLE
Sema: Don't require properties to have initializers in classes in module interfaces

### DIFF
--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2441,6 +2441,12 @@ public:
 
   /// Check that all stored properties have in-class initializers.
   void checkRequiredInClassInits(ClassDecl *cd) {
+    // Initializers may be omitted from property declarations in module
+    // interface files so don't diagnose in them.
+    SourceFile *sourceFile = cd->getDeclContext()->getParentSourceFile();
+    if (sourceFile && sourceFile->Kind == SourceFileKind::Interface)
+      return;
+
     ClassDecl *source = nullptr;
     for (auto member : cd->getMembers()) {
       auto pbd = dyn_cast<PatternBindingDecl>(member);

--- a/test/ModuleInterface/requires-stored-property-inits-attr.swift
+++ b/test/ModuleInterface/requires-stored-property-inits-attr.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface)
+// RUN: %FileCheck %s < %t.swiftinterface
+
+// CHECK: @requires_stored_property_inits public class RequiresStoredPropertyInits
+@requires_stored_property_inits
+public class RequiresStoredPropertyInits {
+  // CHECK: final public let a: Swift.Int{{$}}
+  public let a: Int = 0
+
+  public init() {}
+}


### PR DESCRIPTION
Avoid requiring properties to have initializers in `@requires_stored_property_inits` classes when type checking module interfaces. Most initializers are not printed in interfaces so enforcing this requirement in that context doesn't make sense.

Resolves rdar://91505142