### PR TITLE
[cxx-interop] Import complex inferred dependent return types

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -228,7 +228,7 @@ namespace {
 
     // TODO: Add support for dependent types (SR-13809).
 #define DEPENDENT_TYPE(Class, Base)                                            \
-  ImportResult Visit##Class##Type(const clang::Class##Type *) { return Type(); }
+  ImportResult Visit##Class##Type(const clang::Class##Type *) { return Impl.SwiftContext.TheAnyType; }
 #define TYPE(Class, Base)
 #include "clang/AST/TypeNodes.inc"
 

--- a/test/Interop/Cxx/templates/Inputs/dependent-types.h
+++ b/test/Interop/Cxx/templates/Inputs/dependent-types.h
@@ -26,20 +26,20 @@ template<class T, class U>
 M<U> differentDependentArgAndRet(M<T> a) { return {a.value}; }
 
 template<class T>
-M<T> dependantReturnTypeInffered(T a) { return {a}; }
+M<T> dependantReturnTypeInferred(T a) { return {a}; }
 
 template<class T>
 M<T> dependantReturnTypeSameAsArg(M<T> a) { return {a.value}; }
 
 // TODO: still not supported yet (rdar://89034704)
 template<class T, class U>
-typename M<U>::U complexDifferentDependentArgAndRet(typename M<T>::U  a) { return a.value; }
+typename M<U>::U complexDifferentDependentArgAndRet(typename M<T>::U  a) { return a; }
 
 template<class T>
-typename M<T>::U complexDependantReturnTypeInffered(T a) { return a; }
+typename M<T>::U complexDependantReturnTypeInferred(T a) { return a; }
 
 template<class T>
-typename M<T>::U complexDependantReturnTypeSameAsArg(typename M<T>::U  a) { return a.value; }
+typename M<T>::U complexDependantReturnTypeSameAsArg(typename M<T>::U  a) { return a; }
 
 template<class T>
 M<T> multipleArgs(M<T> a, T b, int c) { return {a.value + b}; }

--- a/test/Interop/Cxx/templates/dependent-types-module-interface.swift
+++ b/test/Interop/Cxx/templates/dependent-types-module-interface.swift
@@ -1,12 +1,13 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=DependentTypes -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK: func differentDependentArgAndRet<T, U>(_ a: Any, T: T.Type, U: U.Type) -> Any
-// CHECK: func dependantReturnTypeInffered<T>(_ a: T) -> Any
+// CHECK: func dependantReturnTypeInferred<T>(_ a: T) -> Any
 // CHECK: func dependantReturnTypeSameAsArg<T>(_ a: Any, T: T.Type) -> Any
+// CHECK: func complexDependantReturnTypeInferred<T>(_ a: T) -> Any
 // CHECK: func multipleArgs<T>(_ a: Any, _ b: T, _ c: Int32) -> Any
 // CHECK: func multipleDependentArgsInferred<T, U>(_ a: Any, _ b: Any, _ c: T, _ d: U) -> Any
 // CHECK: func multipleDependentArgs<T, U>(_ a: Any, _ b: Any, T: T.Type, U: U.Type) -> Any
 // CHECK: func refToDependent<T>(_ a: inout T) -> Any
-// We don't support references to dependent types (rdar://89034440).
+// TODO: Currently not imported (rdar://89034440).
 // CHECK-NOT: dependentRef
 // CHECK-NOT: dependentRefAndRefInferred

--- a/test/Interop/Cxx/templates/dependent-types-silgen.swift
+++ b/test/Interop/Cxx/templates/dependent-types-silgen.swift
@@ -6,7 +6,7 @@ import DependentTypes
 // CHECK-LABEL: sil [ossa] @$s4main4tests5Int64VyF : $@convention(thin) () -> Int64
 // CHECK:   [[ANY_OUT:%.*]] = alloc_stack $Any
 
-// CHECK:   [[THUNK_REF:%.*]] = function_ref @$sSC27dependantReturnTypeInfferedyyps5Int64VF : $@convention(thin) (Int64) -> @out Any
+// CHECK:   [[THUNK_REF:%.*]] = function_ref @$sSC27dependantReturnTypeInferredyyps5Int64VF : $@convention(thin) (Int64) -> @out Any
 // CHECK:   apply [[THUNK_REF]]([[ANY_OUT]], %{{[0-9]+}}) : $@convention(thin) (Int64) -> @out Any
 
 // CHECK:   [[SPEC_OUT:%.*]] = alloc_stack $__CxxTemplateInst1MIxE
@@ -24,21 +24,21 @@ import DependentTypes
 
 
 // Check the synthesized thunk:
-// CHECK-LABEL: sil [transparent] [serialized] [ossa] @$sSC27dependantReturnTypeInfferedyyps5Int64VF : $@convention(thin) (Int64) -> @out Any
+// CHECK-LABEL: sil [transparent] [serialized] [ossa] @$sSC27dependantReturnTypeInferredyyps5Int64VF : $@convention(thin) (Int64) -> @out Any
 // CHECK: bb0(%0 : $*Any, %1 : $Int64):
 // CHECK:   [[SPEC_OUT:%.*]] = alloc_stack $__CxxTemplateInst1MIxE
 
-// CHECK:   [[FN:%.*]] = function_ref @{{_Z27dependantReturnTypeInfferedIxE1MIT_ES1_|\?\?\$dependantReturnTypeInffered@_J@@YA\?AU\?\$M@_J@@_J@Z}} : $@convention(c) (Int64) -> __CxxTemplateInst1MIxE
+// CHECK:   [[FN:%.*]] = function_ref @{{_Z27dependantReturnTypeInferredIxE1MIT_ES1_|\?\?\$dependantReturnTypeInferred@_J@@YA\?AU\?\$M@_J@@_J@Z}} : $@convention(c) (Int64) -> __CxxTemplateInst1MIxE
 // CHECK:   [[OUT:%.*]] = apply [[FN]](%1) : $@convention(c) (Int64) -> __CxxTemplateInst1MIxE
 
 // CHECK:   store [[OUT]] to [trivial] [[SPEC_OUT]] : $*__CxxTemplateInst1MIxE
 // CHECK:   unconditional_checked_cast_addr __CxxTemplateInst1MIxE in [[SPEC_OUT]] : $*__CxxTemplateInst1MIxE to Any in %0 : $*Any
-// CHECK-LABEL: end sil function '$sSC27dependantReturnTypeInfferedyyps5Int64VF'
+// CHECK-LABEL: end sil function '$sSC27dependantReturnTypeInferredyyps5Int64VF'
 
 public func test() -> Int64 {
-  let m = dependantReturnTypeInffered(Int64(42)) as! M<Int64>
+  let m = dependantReturnTypeInferred(Int64(42)) as! M<Int64>
   return m.getValue()
 }
 
 // CHECK-LABEL: sil [clang __CxxTemplateInst1MIxE.getValue] @{{_ZNK1MIxE8getValueEv|\?getValue@\?\$M@_J@@QEBA_JXZ}} : $@convention(cxx_method) (@in_guaranteed __CxxTemplateInst1MIxE) -> Int64
-// CHECK-LABEL: sil [serialized] [clang dependantReturnTypeInffered]  @{{_Z27dependantReturnTypeInfferedIxE1MIT_ES1_|\?\?\$dependantReturnTypeInffered@_J@@YA\?AU\?\$M@_J@@_J@Z}} : $@convention(c) (Int64) -> __CxxTemplateInst1MIxE
+// CHECK-LABEL: sil [serialized] [clang dependantReturnTypeInferred]  @{{_Z27dependantReturnTypeInferredIxE1MIT_ES1_|\?\?\$dependantReturnTypeInferred@_J@@YA\?AU\?\$M@_J@@_J@Z}} : $@convention(c) (Int64) -> __CxxTemplateInst1MIxE

--- a/test/Interop/Cxx/templates/dependent-types.swift
+++ b/test/Interop/Cxx/templates/dependent-types.swift
@@ -19,16 +19,16 @@ DependentTypesTestSuite.test("Different dependent arg and return type.") {
 }
 
 DependentTypesTestSuite.test("Different dependent inferred by arg.") {
-  let m = dependantReturnTypeInffered(42) as! M<Int>
+  let m = dependantReturnTypeInferred(42) as! M<Int>
   expectEqual(m.getValue(), 42)
 }
 
 DependentTypesTestSuite.test("Instantiate the same function twice") {
   // Intentionally test the same thing twice.
-  let m = dependantReturnTypeInffered(42) as! M<Int>
+  let m = dependantReturnTypeInferred(42) as! M<Int>
   expectEqual(m.getValue(), 42)
 
-  let m2 = dependantReturnTypeInffered(42) as! M<Int>
+  let m2 = dependantReturnTypeInferred(42) as! M<Int>
   expectEqual(m2.getValue(), 42)
 }
 
@@ -58,7 +58,6 @@ DependentTypesTestSuite.test("Takes const ref and returns dependent type.") {
   expectEqual(m.getValue(), 42)
 }
 
-
 // We still have some problems calling methods on Windows: SR-13129 and rdar://88391102
 #if !os(Windows)
 DependentTypesTestSuite.test("Function template methods") {
@@ -83,6 +82,40 @@ DependentTypesTestSuite.test("Function template methods (static)") {
   let m2 = M<Int>.memberDependentReturnTypeStatic(CInt(32)) as! M<CInt>
   expectEqual(m2.getValue(), 32)
 }
+
+DependentTypesTestSuite.test("Complex different dependent return type inferrd.") {
+  let m = complexDependantReturnTypeInferred(M<Int>(value: 42)) as! M<Int>
+  expectEqual(m.getValue(), 42)
+}
+
+// TODO: Currently still failing: Could not cast value of type '__C.__CxxTemplateInst1MIlE' to 'Swift.Int'
+DependentTypesTestSuite.test("Complex different dependent argument and return type") {
+  let m = complexDifferentDependentArgAndRet(42, T: Int.self, U: Int.self) as! Int
+  expectEqual(m, 42)
+
+  let m2 = complexDependantReturnTypeSameAsArg(42, T: Int.self) as! Int
+  expectEqual(m2, 42)
+}
+
 #endif // Windows
+
+//TODO: Import issue: rdar://89028943
+// DependentTypesTestSuite.test("Dependent to Reference") {
+//   var x = 42
+//   let m = dependentToRef(x) as! M<Int>
+//   expectEqual(m.getValue(), 42)
+// }
+
+//TODO: Not imported: rdar://89034440
+// DependentTypesTestSuite.test("Dependent Reference.") {
+//   let m = dependentRef()
+//   expectEqual(m.getValue(), 42)
+// }
+
+//TODO: Not imported: rdar://89034440
+// DependentTypesTestSuite.test("Dependent reference and reference inferred") {
+  // let m = dependentRefAndRefInferred(M<Int>(value: 40), 2) as! M<Int>
+  // expectEqual(m.getValue(), 42)
+// }
 
 runAllTests()


### PR DESCRIPTION
Add support for importing Cxx methods that have inferred dependent return types to be the swift `Any` type

Related to: [SR-13809](https://bugs.swift.org/browse/SR-13809)

@zoecarver @hyp 