### PR TITLE
[C++-Interop] Teach omitNeedlessWords to handle raw integer C-enums in C++

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2431,6 +2431,19 @@ DefaultArgumentKind ClangImporter::Implementation::inferDefaultArgument(
           return DefaultArgumentKind::EmptyArray;
       }
     }
+  } else if (const clang::TypedefType *typedefType =
+                 type->getAs<clang::TypedefType>()) {
+    // Get the AvailabilityAttr that would be set from CF/NS_OPTIONS
+    if (importer::isUnavailableInSwift(typedefType->getDecl(), nullptr, true)) {
+      // If we've taken this branch it means we have an enum type, and it is
+      // likely an integer or NSInteger that is being used by NS/CF_OPTIONS to
+      // behave like a C enum in the presence of C++.
+      auto enumName = typedefType->getDecl()->getDeclName().getAsString();
+      for (auto word : llvm::reverse(camel_case::getWords(enumName))) {
+        if (camel_case::sameWordIgnoreFirstCase(word, "options"))
+          return DefaultArgumentKind::EmptyArray;
+      }
+    }
   }
 
   // NSDictionary arguments default to [:] (or nil, if nullable) if "options",

--- a/test/Interop/Cxx/enum/Inputs/c-enums-withOptions-omit.h
+++ b/test/Interop/Cxx/enum/Inputs/c-enums-withOptions-omit.h
@@ -1,0 +1,8 @@
+// Enum usage that is bitwise-able and assignable in C++, aka how CF_OPTIONS
+// does things.
+typedef int __attribute__((availability(swift, unavailable))) NSEnumerationOptions;
+enum : NSEnumerationOptions { NSEnumerationConcurrent, NSEnumerationReverse };
+
+@interface NSSet
+- (void)enumerateObjectsWithOptions:(NSEnumerationOptions)opts ;
+@end

--- a/test/Interop/Cxx/enum/Inputs/module.modulemap
+++ b/test/Interop/Cxx/enum/Inputs/module.modulemap
@@ -12,3 +12,8 @@ module AnonymousWithSwiftName {
   header "anonymous-with-swift-name.h"
   requires cplusplus
 }
+
+module CenumsWithOptionsOmit {
+  header "c-enums-withOptions-omit.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/enum/c-enums-withOptions-omit.swift
+++ b/test/Interop/Cxx/enum/c-enums-withOptions-omit.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=CenumsWithOptionsOmit -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
+// REQUIRES: objc_interop
+
+import CenumsWithOptionsOmit
+
+// CHECK: class NSSet {
+// CHECK-NEXT: class func enumerateObjects(options
+// CHECK-NEXT: func enumerateObjects(options
+// CHECK-NEXT: @available(swift, obsoleted: 3, renamed: "enumerateObjects(options:)")


### PR DESCRIPTION
As I understand it, enums in C++ do not allow for bitwise operations
that can also be assigned or returned as the same enum type. As a result
there are macros in (Core)Foundation like NS/CF_OPTIONS that produce
enums differently depending on #if __cplusplus or not.

Because of this, code in omitNeedlessWordsInFunctionName and
subsequently inferDefaultArgument in the ClangImporter that is in charge
of replacing "needless words" from method and enum names does not
trigger in the case of C++ because it is looking for EnumDecls that dont
exists because they are actually typedefs on wrap integers or
NSIntegers.

This change attempts to do the renaming off of the typedef alone when
such code exists. However at the moment it is somewhat of a work in
progress.

Special thanks to @bulbazord (Alex Langford) for taking the time to investigate this issue. 