### PR TITLE
utils: add ability to disable test runs

### DIFF
--- a/utils/build-windows.bat
+++ b/utils/build-windows.bat
@@ -85,8 +85,9 @@ call :build_lldb %exitOnError%
 path %PATH%;C:\Program Files\Git\usr\bin
 call :build_libdispatch %exitOnError%
 
+path %source_root%\icu-%icu_version%\bin64;%install_directory%\bin;%build_root%\swift\bin;%build_root%\swift\libdispatch-prefix\bin;%PATH%
+
 if %RunTest%==1 (
-  path %source_root%\icu-%icu_version%\bin64;%install_directory%\bin;%build_root%\swift\bin;%build_root%\swift\libdispatch-prefix\bin;%PATH%
   call :test_swift %exitOnError%
   call :test_libdispatch %exitOnError%
 )

--- a/utils/build-windows.bat
+++ b/utils/build-windows.bat
@@ -64,6 +64,9 @@ set CUSTOM_CLANG_MODULE_CACHE=%build_root%\tmp\org.llvm.clang.9999
 md %build_root%\tmp\org.swift.package-manager
 set SWIFTPM_MODULECACHE_OVERRIDE=%build_root%\tmp\org.swift.package-manager
 
+set RunTest=1
+if "%1"=="-notest" set RunTest=0
+
 call :clone_repositories %exitOnError%
 call :download_icu %exitOnError%
 :: TODO: Disabled until we need LLBuild/SwiftPM in this build script.
@@ -82,9 +85,11 @@ call :build_lldb %exitOnError%
 path %PATH%;C:\Program Files\Git\usr\bin
 call :build_libdispatch %exitOnError%
 
-path %source_root%\icu-%icu_version%\bin64;%install_directory%\bin;%build_root%\swift\bin;%build_root%\swift\libdispatch-prefix\bin;%PATH%
-call :test_swift %exitOnError%
-call :test_libdispatch %exitOnError%
+if %RunTest%==1 (
+  path %source_root%\icu-%icu_version%\bin64;%install_directory%\bin;%build_root%\swift\bin;%build_root%\swift\libdispatch-prefix\bin;%PATH%
+  call :test_swift %exitOnError%
+  call :test_libdispatch %exitOnError%
+)
 
 goto :end
 endlocal


### PR DESCRIPTION
This adjusts the build-windows.bat file to support an optional `-notest`
argument that disables testing.  This is more to show how to setup the
script to enable that, to allow further enhancement in the future.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
