### PR TITLE
Frontend: add an additional search path for swift modules

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -188,7 +188,15 @@ static void updateRuntimeLibraryPaths(SearchPathOptions &SearchPathOpts,
     LibPath = SearchPathOpts.getSDKPath();
     llvm::sys::path::append(LibPath, "usr", "lib", "swift");
     if (!Triple.isOSDarwin()) {
+      // Use the non-architecture suffixed form with directory-layout
+      // swiftmodules.
       llvm::sys::path::append(LibPath, getPlatformNameForTriple(Triple));
+      RuntimeLibraryImportPaths.push_back(std::string(LibPath.str()));
+
+      // Compatibility with older releases - use the architecture suffixed form
+      // for pre-directory-layout multi-architecture layout.  Note that some
+      // platforms (e.g. Windows) will use this even with directory layout in
+      // older releases.
       llvm::sys::path::append(LibPath, swift::getMajorArchitectureName(Triple));
     }
     RuntimeLibraryImportPaths.push_back(std::string(LibPath.str()));


### PR DESCRIPTION
This setups the frontend to search both an architecture suffixed and
unsuffixed path.  This improves the multi-architecture setup for
Windows, enabling it use the directory form of the swift modules with
the architectures overlaying in the swift module and leaving the arch
suffixed directory for the import libraries.

This can be fully generalized as this also enables Linux to use the
multi-architecture search path for the swift modules enabling it to
eventually adopt a SDK model as well.