### PR TITLE
[Distributed] Invoking distributed func defined via extension crashes on x86

### DIFF
--- a/test/Distributed/Runtime/distributed_actor_hop_to.swift
+++ b/test/Distributed/Runtime/distributed_actor_hop_to.swift
@@ -41,12 +41,31 @@ distributed actor Worker: LifecycleWatch {
 
 @main struct Main {
   static func main() async {
-    let worker: any LifecycleWatch = Worker(actorSystem: DefaultDistributedActorSystem())
+    let actorSystem = DefaultDistributedActorSystem()
+
+    let worker: any LifecycleWatch = Worker(actorSystem: actorSystem)
     try! await worker.test(x: 42, "on protocol")
 
     // CHECK: executed: test(x:_:)
     // CHECK: executed: watch(x:_:) - x = 42, y = on protocol
     // CHECK: done executed: test(x:_:)
+
+    // ==== --------------------------------------------------------------------
+
+    let remote = try! Worker.resolve(id: worker.id, using: actorSystem)
+    try! await remote.test(x: 42, "direct") // Remote call
+    // CHECK: >> remoteCallVoid: on:main.Worker, target:test(x:_:)
+    // CHECK: << onReturnVoid: ()
+
+    let remoteAny: any LifecycleWatch = remote
+    try! await remoteAny.test(x: 42, "direct") // Remote call
+    // CHECK: >> remoteCallVoid: on:main.Worker, target:test(x:_:)
+    // CHECK: << onReturnVoid: ()
+
+    let remoteAnyOptional: (any LifecycleWatch)? = remote
+    try! await remoteAnyOptional?.test(x: 42, "direct") // Remote call
+    // CHECK: >> remoteCallVoid: on:main.Worker, target:test(x:_:)
+    // CHECK: << onReturnVoid: ()
 
     print("OK") // CHECK: OK
   }

--- a/test/Distributed/Runtime/distributed_actor_hop_to.swift
+++ b/test/Distributed/Runtime/distributed_actor_hop_to.swift
@@ -14,7 +14,6 @@
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
 // UNSUPPORTED: OS=windows-msvc
 
-
 import Distributed
 import FakeDistributedActorSystems
 
@@ -44,28 +43,14 @@ distributed actor Worker: LifecycleWatch {
     let actorSystem = DefaultDistributedActorSystem()
 
     let worker: any LifecycleWatch = Worker(actorSystem: actorSystem)
-    try! await worker.test(x: 42, "on protocol")
-
-    // CHECK: executed: test(x:_:)
-    // CHECK: executed: watch(x:_:) - x = 42, y = on protocol
-    // CHECK: done executed: test(x:_:)
-
     // ==== --------------------------------------------------------------------
 
     let remote = try! Worker.resolve(id: worker.id, using: actorSystem)
-    try! await remote.test(x: 42, "direct") // Remote call
-    // CHECK: >> remoteCallVoid: on:main.Worker, target:test(x:_:)
-    // CHECK: << onReturnVoid: ()
-
     let remoteAny: any LifecycleWatch = remote
     try! await remoteAny.test(x: 42, "direct") // Remote call
     // CHECK: >> remoteCallVoid: on:main.Worker, target:test(x:_:)
     // CHECK: << onReturnVoid: ()
 
-    let remoteAnyOptional: (any LifecycleWatch)? = remote
-    try! await remoteAnyOptional?.test(x: 42, "direct") // Remote call
-    // CHECK: >> remoteCallVoid: on:main.Worker, target:test(x:_:)
-    // CHECK: << onReturnVoid: ()
 
     print("OK") // CHECK: OK
   }


### PR DESCRIPTION
Resolves rdar://91888361 


Making sure such calls still call the remote impl and don't get tricked by the existential.
This is super important that this always works, so making sure by including the tests.