### PR TITLE
[5.7][IDE] Skip walking serialized internal top level decls in SemaAnnotator

### DIFF
--- a/include/swift/AST/ASTWalker.h
+++ b/include/swift/AST/ASTWalker.h
@@ -235,6 +235,11 @@ public:
   /// until eventually we can remove this altogether.
   virtual bool shouldWalkAccessorsTheOldWay() { return false; }
 
+  /// Whether to walk internal top level decls in serialized modules.
+  ///
+  /// TODO: Consider changing this to false by default.
+  virtual bool shouldWalkSerializedTopLevelInternalDecls() { return true; }
+
   /// walkToParameterListPre - This method is called when first visiting a
   /// ParameterList, before walking into its parameters.  If it returns false,
   /// the subtree is skipped.

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2916,7 +2916,17 @@ bool FileUnit::walk(ASTWalker &walker) {
   getTopLevelDecls(Decls);
   llvm::SaveAndRestore<ASTWalker::ParentTy> SAR(walker.Parent,
                                                 getParentModule());
+
+  bool SkipInternal = getKind() == FileUnitKind::SerializedAST &&
+      !walker.shouldWalkSerializedTopLevelInternalDecls();
   for (Decl *D : Decls) {
+    if (SkipInternal) {
+      if (auto *VD = dyn_cast<ValueDecl>(D)) {
+        if (!VD->isAccessibleFrom(nullptr))
+          continue;
+      }
+    }
+
 #ifndef NDEBUG
     PrettyStackTraceDecl debugStack("walking into decl", D);
 #endif

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -54,6 +54,11 @@ private:
   bool shouldWalkIntoGenericParams() override {
     return SEWalker.shouldWalkIntoGenericParams();
   }
+
+  bool shouldWalkSerializedTopLevelInternalDecls() override {
+    return false;
+  }
+
   bool walkToDeclPre(Decl *D) override;
   bool walkToDeclPreProper(Decl *D);
   std::pair<bool, Expr *> walkToExprPre(Expr *E) override;


### PR DESCRIPTION
Cherry-picks fec7a0b79b2a2318118dc4696ddb5a3410b10114

-----

`SemaAnnotator` always attempts to retrieve the location of the decl. This
requires generating the USR, which needs to resolve the type. But that's
invalid in the presence of `@_implementationOnly`.

This most commonly comes up during index while building as even though
it skip internal decls, by that point it's too late (`SemaAnnotator` has
already tried retrieving the location). Other uses of
`SourceEntityWalker` should be unaffected as they only run over the
current decls in the current module.

For now skip walking internal top level decls from serialized modules in
`SemaAnnotator`. Consider expanding this to most, if not all,
`ASTWalker` clients in the future - it's unlikely `SemaAnnotator` is the
only one with this problem.

Resolves rdar://91279771.