### PR TITLE
IRGen: disable-llvm-optzns should disable the objc-arc-contract pass

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -364,7 +364,8 @@ void swift::performLLVMOptimizations(const IRGenOptions &Opts,
   // rely on any other LLVM ARC transformations, but we do need ARC
   // contraction to add the objc_retainAutoreleasedReturnValue
   // assembly markers and remove clang.arc.used.
-  if (Opts.shouldOptimize() && !DisableObjCARCContract)
+  if (Opts.shouldOptimize() && !DisableObjCARCContract &&
+      !Opts.DisableLLVMOptzns)
     ModulePasses.add(createObjCARCContractPass());
 
   // Do it.

--- a/test/Frontend/embed-bitcode.ll
+++ b/test/Frontend/embed-bitcode.ll
@@ -50,7 +50,6 @@ target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 ; CHECK-COMPILER-OPT-NOT: argument unused
 ; CHECK-COMPILER-OPT-DAG: Control Flow Optimizer
 ; CHECK-COMPILER-OPT-DAG: Machine Common Subexpression Elimination
-; CHECK-COMPILER-OPT-DAG: ObjC ARC contraction
 
 define i32 @f0() nounwind ssp {
        ret i32 0

--- a/test/IRGen/objc_arc_contract.swift
+++ b/test/IRGen/objc_arc_contract.swift
@@ -4,6 +4,8 @@
 
 // RUN: %target-swift-frontend -import-objc-header %S/Inputs/StaticInline.h %s -emit-ir -Xllvm -disable-objc-arc-contract -parse-as-library -O | %FileCheck --check-prefix=CHECK-WITHOUT-PASS %s
 // RUN: %target-swift-frontend -import-objc-header %S/Inputs/StaticInline.h %s -emit-bc -Xllvm -disable-objc-arc-contract -parse-as-library -O -o %t/test1.bc && %llvm-dis -o - %t/test1.bc | %FileCheck --check-prefix=CHECK-WITHOUT-PASS %s
+// RUN: %target-swift-frontend -import-objc-header %S/Inputs/StaticInline.h %s -emit-ir -disable-llvm-optzns -parse-as-library -O | %FileCheck --check-prefix=CHECK-WITHOUT-PASS %s
+// RUN: %target-swift-frontend -import-objc-header %S/Inputs/StaticInline.h %s -emit-bc -disable-llvm-optzns -parse-as-library -O -o %t/test1.bc && %llvm-dis -o - %t/test1.bc | %FileCheck --check-prefix=CHECK-WITHOUT-PASS %s
 
 // RUN: %target-swift-frontend -import-objc-header %S/Inputs/StaticInline.h %s -emit-ir -parse-as-library -O | %FileCheck --check-prefix=CHECK-WITH-PASS %s
 // RUN: %target-swift-frontend -import-objc-header %S/Inputs/StaticInline.h %s -emit-bc -parse-as-library -O -o %t/test2.bc && %llvm-dis -o - %t/test2.bc | %FileCheck --check-prefix=CHECK-WITH-PASS %s


### PR DESCRIPTION
Don't run the objc-arc-contract pass when disable-llvm-optzns is passed.

In pipeline setups where the swift-frontend is called twice;
- the first time to create bitcode
- the second time to generate object code from the bitcode (using
  disable-llvm-optzns)
we don't want to run the objc-arc-contract pass twice.

rdar://91908312