### PR TITLE
[cxx-interop] Import enum, not typedef for parameter types.

### DIFF
--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -33,6 +33,9 @@
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/Decl.h"
+#include "clang/Lex/MacroInfo.h"
+#include "clang/Lex/Preprocessor.h"
 #include "clang/AST/DeclVisitor.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/Basic/IdentifierTable.h"
@@ -60,12 +63,8 @@ class SmallBitVector;
 
 namespace clang {
 class APValue;
-class Decl;
 class DeclarationName;
-class EnumDecl;
-class MacroInfo;
 class MangleContext;
-class NamedDecl;
 class ObjCInterfaceDecl;
 class ObjCMethodDecl;
 class ObjCPropertyDecl;
@@ -1860,6 +1859,26 @@ static inline Type applyToFunctionType(
   }
 
   return type;
+}
+
+inline Optional<const clang::EnumDecl *> findAnonymousEnumForTypedef(
+    const ASTContext &ctx,
+    const clang::TypedefType *typedefType) {
+  auto *typedefDecl = typedefType->getDecl();
+  auto *lookupTable = ctx.getClangModuleLoader()->findLookupTable(typedefDecl->getOwningModule());
+
+  auto foundDecls = lookupTable->lookup(
+      SerializedSwiftName(typedefDecl->getName()), EffectiveClangContext());
+
+  auto found = llvm::find_if(foundDecls, [](SwiftLookupTable::SingleEntry decl) {
+    return decl.is<clang::NamedDecl *>() &&
+        isa<clang::EnumDecl>(decl.get<clang::NamedDecl *>());
+  });
+
+  if (found != foundDecls.end())
+    return cast<clang::EnumDecl>(found->get<clang::NamedDecl *>());
+
+  return None;
 }
 
 }

--- a/test/Interop/Cxx/enum/Inputs/anonymous-with-swift-name.h
+++ b/test/Interop/Cxx/enum/Inputs/anonymous-with-swift-name.h
@@ -19,4 +19,7 @@ typedef CF_OPTIONS(unsigned, CFColorMask) {
   kCFColorMaskAll = ~0U
 };
 
+inline SOColorMask useSOColorMask(SOColorMask mask) { return mask; }
+inline CFColorMask useCFColorMask(CFColorMask mask) { return mask; }
+
 #endif // TEST_INTEROP_CXX_ENUM_INPUTS_ANONYMOUS_WITH_SWIFT_NAME_H

--- a/test/Interop/Cxx/enum/anonymous-with-swift-name-module-interface.swift
+++ b/test/Interop/Cxx/enum/anonymous-with-swift-name-module-interface.swift
@@ -53,3 +53,6 @@
 // CHECK:   @available(swift, obsoleted: 3, renamed: "all")
 // CHECK:   static var All: CFColorMask { get }
 // CHECK: }
+
+// CHECK: func useSOColorMask(_ mask: SOColorMask) -> SOColorMask
+// CHECK: func useCFColorMask(_ mask: CFColorMask) -> CFColorMask

--- a/test/Interop/Cxx/enum/anonymous-with-swift-name.swift
+++ b/test/Interop/Cxx/enum/anonymous-with-swift-name.swift
@@ -20,15 +20,28 @@ AnonymousEnumsTestSuite.test("SOME_OPTIONS") {
 }
 
 AnonymousEnumsTestSuite.test("CF_OPTIONS") {
-  let red: SOColorMask = .red
-  let green = SOColorMask.green
-  let blue = .blue as SOColorMask
-  let all: SOColorMask = .all
+  let red: CFColorMask = .red
+  let green = CFColorMask.green
+  let blue = .blue as CFColorMask
+  let all: CFColorMask = .all
 
   expectEqual(red.rawValue, 2)
   expectEqual(green.rawValue, 4)
   expectEqual(blue.rawValue, 8)
   expectEqual(all.rawValue, ~CUnsignedInt(0))
+}
+
+AnonymousEnumsTestSuite.test("Parameter types") {
+  let red: CFColorMask = .red
+  let green = CFColorMask.green
+
+  let blue = useSOColorMask(.blue)
+  let all = useSOColorMask(.all)
+
+  expectEqual(red, useCFColorMask(.red))
+  expectEqual(green, useCFColorMask(.green))
+  expectEqual(blue, .blue)
+  expectEqual(all, .all)
 }
 
 runAllTests()


### PR DESCRIPTION
Lookup the "anonymous" enum when importing parameter types rather than using the typedef's underlying type.

Based on https://github.com/apple/swift/pull/42223