### PR TITLE
[cmake] Remove Python 2 from build requirement

### DIFF
--- a/cmake/modules/StandaloneOverlay.cmake
+++ b/cmake/modules/StandaloneOverlay.cmake
@@ -132,7 +132,6 @@ include(SwiftConfigureSDK)
 include(SwiftComponents)
 include(DarwinSDKs)
 
-find_package(Python2 COMPONENTS Interpreter REQUIRED)
 find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
 # Without this line, installing components is broken. This needs refactoring.


### PR DESCRIPTION
In theory, this requirement is no longer necenssary. Let's see if CI
agrees.