### PR TITLE
Remove Bogus Macro Assert in LUT Building

### DIFF
--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -1969,12 +1969,6 @@ void importer::addMacrosToLookupTable(SwiftLookupTable &table,
 
       // If we're in a module, we really need moduleMacro to be valid.
       if (isModule && !moduleMacro) {
-#ifndef NDEBUG
-        // Refetch this just for the assertion.
-        clang::MacroDirective *MD = pp.getLocalMacroDirective(macro.first);
-        assert(isa<clang::VisibilityMacroDirective>(MD));
-#endif
-
         // FIXME: "public" visibility macros should actually be added to the 
         // table.
         return;

--- a/test/ClangImporter/Inputs/custom-modules/TextualHeaders.framework/Modules/module.modulemap
+++ b/test/ClangImporter/Inputs/custom-modules/TextualHeaders.framework/Modules/module.modulemap
@@ -1,0 +1,12 @@
+framework module TextualHeaders [system] {
+  umbrella "PrivateHeaders"
+  
+  explicit module TextualHeader {
+    textual header "TextualHeader.h"
+    export *
+  }
+
+  explicit module * { export * }
+
+  export_as TextualHeaders_Private
+}

--- a/test/ClangImporter/Inputs/custom-modules/TextualHeaders.framework/PrivateHeaders/TextualHeader.h
+++ b/test/ClangImporter/Inputs/custom-modules/TextualHeaders.framework/PrivateHeaders/TextualHeader.h
@@ -1,0 +1,1 @@
+#define BOOM 42

--- a/test/ClangImporter/textual_headers.swift
+++ b/test/ClangImporter/textual_headers.swift
@@ -1,0 +1,2 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -typecheck -F %S/Inputs/custom-modules %s -verify
+import TextualHeaders


### PR DESCRIPTION
This assertion assumes that only visibility directives for builtin
macros find their way here. However, the presence of textual headers
in modules means any macro directive can wind up here since clang will
report that it is currently not building a module.

It's been half a decade since this code did anything useful with
macro directives in textual headers, so just leave things be.

rdar://91768988