### PR TITLE
Fix benchmark build+run

### DIFF
--- a/benchmark/scripts/run_smoke_bench
+++ b/benchmark/scripts/run_smoke_bench
@@ -307,11 +307,12 @@ def report_code_size(opt_level, old_dir, new_dir, architecture, platform, output
 
 
 def get_codesize(filename):
-    output = subprocess.check_output(["size", filename]).splitlines()
-    header_line = output[0]
-    data_line = output[1]
+    output = subprocess.check_output(["size", filename])
+    lines = output.decode('utf-8').splitlines()
+    header_line = lines[0]
+    data_line = lines[1]
     if header_line.find("__TEXT") != 0:
-        sys.exit("unexpected output from size command:\n" + output)
+        sys.exit("unexpected output from size command:\n" + lines)
     return int(data_line.split("\t")[0])
 
 
@@ -361,7 +362,8 @@ performance team (@eeckstein).
   <summary><strong>Hardware Overview</strong></summary>
 
 """
-    po = subprocess.check_output(["system_profiler", "SPHardwareDataType"])
+    output = subprocess.check_output(["system_profiler", "SPHardwareDataType"])
+    po = output.decode('utf-8')
     for line in po.splitlines():
         selection = [
             "Model Name",

--- a/benchmark/utils/TestsUtils.swift
+++ b/benchmark/utils/TestsUtils.swift
@@ -324,11 +324,13 @@ public func someProtocolFactory() -> SomeProtocol { return MyStruct() }
 // It's important that this function is in another module than the tests
 // which are using it.
 @inline(never)
+@_semantics("optimize.no.crossmodule")
 public func blackHole<T>(_ x: T) {
 }
 
 // Return the passed argument without letting the optimizer know that.
 @inline(never)
+@_semantics("optimize.no.crossmodule")
 public func identity<T>(_ x: T) -> T {
   return x
 }
@@ -337,12 +339,15 @@ public func identity<T>(_ x: T) -> T {
 // It's important that this function is in another module than the tests
 // which are using it.
 @inline(never)
+@_semantics("optimize.no.crossmodule")
 public func getInt(_ x: Int) -> Int { return x }
 
 // The same for String.
 @inline(never)
+@_semantics("optimize.no.crossmodule")
 public func getString(_ s: String) -> String { return s }
 
 // The same for Substring.
 @inline(never)
+@_semantics("optimize.no.crossmodule")
 public func getSubstring(_ s: Substring) -> Substring { return s }


### PR DESCRIPTION
* fix `run_smoke_bench` after upgrading to python3

Need to decode result of `subprocess.check_output`

* prevent some utility functions from being cross-module optimized.

Function bodies of `blackHole`, `identity`, etc. must not be visible in the benchmark modules.
Enabling CMO by default broke this. Since then we need to explicitly exclude those functions from cross-module-optimization.