### PR TITLE
[5.7] Fix a compile-time issue in EscapeAnalysis

### DIFF
--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -1035,23 +1035,10 @@ EscapeAnalysis::ConnectionGraph::getOrCreateReferenceContent(SILValue refVal,
 
   // Determine whether the object that refVal refers to only contains
   // references.
-  bool contentHasReferenceOnly = false;
-  if (refVal) {
-    SILType refType = refVal->getType();
-    if (auto *C = refType.getClassOrBoundGenericClass()) {
-      PointerKind aggregateKind = NoPointer;
-      for (auto *field : C->getStoredProperties()) {
-        SILType fieldType = refType
-                                .getFieldType(field, F->getModule(),
-                                              F->getTypeExpansionContext())
-                                .getObjectType();
-        PointerKind fieldKind = EA->findCachedPointerKind(fieldType, *F);
-        if (fieldKind > aggregateKind)
-          aggregateKind = fieldKind;
-      }
-      contentHasReferenceOnly = canOnlyContainReferences(aggregateKind);
-    }
-  }
+  bool contentHasReferenceOnly =
+      refVal ? canOnlyContainReferences(
+          EA->findCachedClassPropertiesKind(refVal->getType(), *F))
+             : false;
   getOrCreateContentNode(objNode, false, contentHasReferenceOnly);
   return objNode;
 }


### PR DESCRIPTION
Replace a loop with a call to findCachedClassPropertiesKind. This was
the original intention, but it looks like the refactoring was
incorrectly merged.

Noticed by Slava Pestov based on Erik Eckstein's compile time trace.

(cherry picked from commit 99f363a712c58e22a27ce7eb6ccc770933bc7323)
