### PR TITLE
Disable implicit Sendable diagnostics via -strict-concurrency=off.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -323,6 +323,9 @@ struct SendableCheckContext {
   /// Sendable conformance in this context.
   DiagnosticBehavior defaultDiagnosticBehavior() const;
 
+  /// Determine the diagnostic behavior for an implicitly non-Sendable type.
+  DiagnosticBehavior implicitSendableDiagnosticBehavior() const;
+
   /// Determine the diagnostic behavior when referencing the given nominal
   /// type in this context.
   DiagnosticBehavior diagnosticBehavior(NominalTypeDecl *nominal) const;

--- a/test/Concurrency/strict_concurrency_off.swift
+++ b/test/Concurrency/strict_concurrency_off.swift
@@ -1,0 +1,55 @@
+// RUN: %target-typecheck-verify-swift -strict-concurrency=off
+// REQUIRES: concurrency
+
+class C1 { }
+// expected-note@-1{{class 'C1' does not conform to the 'Sendable' protocol}}
+
+@_nonSendable class C2 { }
+// expected-note@-1 2{{class 'C2' does not conform to the 'Sendable' protocol}}
+
+class C3 { }
+// expected-note@-1 2{{class 'C3' does not conform to the 'Sendable' protocol}}
+
+@available(*, unavailable)
+extension C3: Sendable { }
+
+struct S1: Sendable {
+  let c1: C1 // expected-warning{{stored property 'c1' of 'Sendable'-conforming struct 'S1' has non-sendable type 'C1'}}
+  let c2: C2 // expected-warning{{stored property 'c2' of 'Sendable'-conforming struct 'S1' has non-sendable type 'C2'}}
+  let c3: C3 // expected-warning{{stored property 'c3'}}
+}
+
+struct S2 {
+  let c1: C1
+}
+
+struct S3 {
+  let c2: C2
+}
+
+
+func takeSendable(_ body: @Sendable () -> Void) {
+}
+
+func passSendable(
+    c1: C1, c2: C2, c3: C3, fn: @escaping () -> Void, s1: S1, s2: S2, s3: S3
+) async {
+  // Don't warn about implicitly non-Sendable types
+  takeSendable { print(c1) }
+  takeSendable { print(fn) }
+
+  // Warn about explicitly non-Sendable types
+  takeSendable { print(c2) } // expected-warning{{capture of 'c2' with non-sendable type 'C2' in a `@Sendable` closure}}
+  takeSendable { print(c3) } // expected-warning{{capture of 'c3' with non-sendable type 'C3' in a `@Sendable` closure}}
+
+  // Don't warn about explicitly Sendable type, even when it's wrong.
+  takeSendable { print(s1) }
+
+  // Don't warn when we wrapped an implicitly non-Sendable type in a struct.
+  takeSendable { print(s2) }
+
+  // FIXME: Ideally, we would warn about cases where a type in this module is
+  // inferred to be non-Sendable based on something explicitly non-Sendable,
+  // like in the case below.
+  takeSendable { print(s3) }
+}

--- a/test/Concurrency/strict_concurrency_off.swift
+++ b/test/Concurrency/strict_concurrency_off.swift
@@ -31,6 +31,7 @@ struct S3 {
 func takeSendable(_ body: @Sendable () -> Void) {
 }
 
+@available(SwiftStdlib 5.1, *)
 func passSendable(
     c1: C1, c2: C2, c3: C3, fn: @escaping () -> Void, s1: S1, s2: S2, s3: S3
 ) async {


### PR DESCRIPTION
When `-strict-concurrency=off` is provided, disable the diagnostics about missing `Sendable` conformances for implicitly-non-Sendable and non-nominal types. This emulates the behavior of Swift 5.5 and Swift 5.6, albeit under control of a compiler flag.