### PR TITLE
NFC: Test emitted interface for module containing subclass of an Obj-C class with an `NS_SWIFT_UNAVAILABLE` initializer

### DIFF
--- a/test/ModuleInterface/Inputs/inherited-objc-initializers/InheritedObjCInits.h
+++ b/test/ModuleInterface/Inputs/inherited-objc-initializers/InheritedObjCInits.h
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+
+@interface FrameworkObject : NSObject
+- (nonnull instancetype)initWithInvocation:(nullable NSInvocation *)invocation NS_SWIFT_UNAVAILABLE("unavailable");
+- (nonnull instancetype)initWithSelector:(nonnull SEL)selector;
+- (nonnull instancetype)initWithInteger:(NSInteger)integer;
+@end

--- a/test/ModuleInterface/Inputs/inherited-objc-initializers/module.modulemap
+++ b/test/ModuleInterface/Inputs/inherited-objc-initializers/module.modulemap
@@ -1,0 +1,4 @@
+module InheritedObjCInits {
+  header "InheritedObjCInits.h"
+  export *
+}

--- a/test/ModuleInterface/inherited-objc-superclass-initializers.swift
+++ b/test/ModuleInterface/inherited-objc-superclass-initializers.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -I %S/Inputs/inherited-objc-initializers/
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -I %S/Inputs/inherited-objc-initializers/
+// RUN: %FileCheck %s < %t.swiftinterface
+
+// REQUIRES: objc_interop
+
+import InheritedObjCInits
+
+// CHECK: @objc @_inheritsConvenienceInitializers public class Subclass : InheritedObjCInits.FrameworkObject {
+public class Subclass: FrameworkObject {
+  // CHECK-NEXT: @objc override dynamic public init(selector: ObjectiveC.Selector)
+  // CHECK-NEXT: @objc override dynamic public init(integer: Swift.Int)
+  // CHECK-NEXT: @objc override dynamic public init()
+  // CHECK-NEXT: @objc deinit
+} // CHECK-NEXT:{{^}$}}


### PR DESCRIPTION
Add a test that exercises subclassing an Obj-C subclass of `NSObject` and verifies the printed members of the Swift subclass when emitting a module interface for a module containing the Swift subclass. Also verifies that `NS_SWIFT_UNAVAILABLE` initializers are omitted from the emitted interface.

Relates to rdar://91981394