### PR TITLE
Spelling clangimporter

### DIFF
--- a/include/swift/ClangImporter/CXXMethodBridging.h
+++ b/include/swift/ClangImporter/CXXMethodBridging.h
@@ -8,15 +8,15 @@
 #include <string>
 namespace swift {
 struct CXXMethodBridging {
-  enum class Kind { unkown, getter, setter, subscript };
+  enum class Kind { unknown, getter, setter, subscript };
 
-  enum class NameKind { unkown, snake, lower, camel, title };
+  enum class NameKind { unknown, snake, lower, camel, title };
 
   CXXMethodBridging(const clang::CXXMethodDecl *method) : method(method) {}
 
   Kind classify() {
     if (nameIsBlacklist())
-      return Kind::unkown;
+      return Kind::unknown;
 
     // this should be handled as snake case. See: rdar://89453010
     // case. In the future we could
@@ -24,51 +24,51 @@ struct CXXMethodBridging {
     auto nameKind = classifyNameKind();
     if (nameKind != NameKind::title && nameKind != NameKind::camel &&
         nameKind != NameKind::lower)
-      return Kind::unkown;
+      return Kind::unknown;
 
     if (getClangName().startswith_insensitive("set")) {
       // Setters only have one parameter.
       if (method->getNumParams() != 1)
-        return Kind::unkown;
+        return Kind::unknown;
 
       // rdar://89453106 (We need to handle imported properties that return a
       // reference)
       if (method->getParamDecl(0)->getType()->isReferenceType())
-        return Kind::unkown;
+        return Kind::unknown;
 
       return Kind::setter;
     }
 
     // Getters and subscripts cannot return void.
     if (method->getReturnType()->isVoidType())
-      return Kind::unkown;
+      return Kind::unknown;
 
     if (getClangName().startswith_insensitive("get")) {
       // Getters cannot take arguments.
       if (method->getNumParams() != 0)
-        return Kind::unkown;
+        return Kind::unknown;
 
       // rdar://89453106 (We need to handle imported properties that return a
       // reference)
       if (method->getReturnType()->isReferenceType())
-        return Kind::unkown;
+        return Kind::unknown;
 
       return Kind::getter;
     }
 
     // rdar://89453187 (Add subscripts clarification to CXXMethod Bridging to
     // clean up importDecl)
-    return Kind::unkown;
+    return Kind::unknown;
   }
 
   NameKind classifyNameKind() {
     bool allLower = llvm::all_of(getClangName(), islower);
 
     if (getClangName().empty())
-      return NameKind::unkown;
+      return NameKind::unknown;
 
     if (getClangName().contains('_'))
-      return allLower ? NameKind::snake : NameKind::unkown;
+      return allLower ? NameKind::snake : NameKind::unknown;
 
     if (allLower)
       return NameKind::lower;

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4393,7 +4393,7 @@ DeclRefExpr *getInteropStaticCastDeclRefExpr(ASTContext &ctx,
       "Did you forget to define a __swift_interopStaticCast helper function?");
   FuncDecl *staticCastFn = cast<FuncDecl>(results.back());
 
-  // Now we have to force instanciate this. We can't let the type checker do
+  // Now we have to force instantiate this. We can't let the type checker do
   // this yet because it can't infer the "To" type.
   auto subst =
       SubstitutionMap::get(staticCastFn->getGenericSignature(), {derived, base},
@@ -5207,7 +5207,7 @@ clang::FunctionDecl *ClangImporter::instantiateCXXFunctionTemplate(
     return nullptr;
   }
 
-  // Instanciate a specialization of this template using the substitution map.
+  // Instantiate a specialization of this template using the substitution map.
   auto *templateArgList = clang::TemplateArgumentList::CreateCopy(
       func->getASTContext(), templateSubst);
   auto &sema = getClangInstance().getSema();

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7377,7 +7377,7 @@ ConstructorDecl *SwiftDeclConverter::importConstructor(
 }
 
 void SwiftDeclConverter::recordObjCOverride(AbstractFunctionDecl *decl) {
-  // Make sure that we always set the overriden declarations.
+  // Make sure that we always set the overridden declarations.
   SWIFT_DEFER {
     if (!decl->overriddenDeclsComputed())
       decl->setOverriddenDecls({ });

--- a/lib/ClangImporter/ImportEnumInfo.cpp
+++ b/lib/ClangImporter/ImportEnumInfo.cpp
@@ -258,7 +258,7 @@ void EnumInfo::determineConstantNamePrefix(const clang::EnumDecl *decl) {
     return;
   }
 
-  // If there are no enumers, there is no prefix to compute.
+  // If there are no enumerators, there is no prefix to compute.
   auto ec = decl->enumerator_begin(), ecEnd = decl->enumerator_end();
   if (ec == ecEnd)
     return;

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1678,7 +1678,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
     }
   }
 
-  // Spcial case: unnamed/anonymous fields.
+  // Special case: unnamed/anonymous fields.
   if (auto field = dyn_cast<clang::FieldDecl>(D)) {
     static_assert((clang::Decl::lastField - clang::Decl::firstField) == 2,
                   "update logic for new FieldDecl subclasses");

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1263,7 +1263,7 @@ NameImporter::considerAsyncImport(
       }
 
       // Check whether the parameter itself has a name that indicates that
-      // it is a completion handelr.
+      // it is a completion handler.
       if (isCompletionHandlerParamName(
               params[completionHandlerParamIndex]->getName()))
         break;

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -412,7 +412,7 @@ public:
   /// If \p action returns false, the current name will \e not be added to the
   /// set of seen names.
   ///
-  /// The active name for \p activeVerion is always first, followed by the
+  /// The active name for \p activeVersion is always first, followed by the
   /// other names in the order of
   /// ImportNameVersion::forEachOtherImportNameVersion.
   ///

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2121,7 +2121,7 @@ ImportedType ClangImporter::Implementation::importFunctionParamsAndReturnType(
       shouldAllowNSUIntegerAsInt(isFromSystemModule, clangDecl);
 
   // Only eagerly import the return type if it's not too expensive (the current
-  // huristic for that is if it's not a record type).
+  // heuristic for that is if it's not a record type).
   ImportedType importedType;
   ImportDiagnosticAdder addDiag(*this, clangDecl,
                                 clangDecl->getSourceRange().getBegin());

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -316,7 +316,7 @@ public:
   bool isPlatformRelevant(StringRef platform) const;
 
   /// Returns true when the given declaration with the given deprecation
-  /// should be inlucded in the cutoff of imported deprecated APIs marked
+  /// should be included in the cutoff of imported deprecated APIs marked
   /// unavailable.
   bool treatDeprecatedAsUnavailable(const clang::Decl *clangDecl,
                                     const llvm::VersionTuple &version,

--- a/test/ClangImporter/SceneKit_test.swift
+++ b/test/ClangImporter/SceneKit_test.swift
@@ -7,7 +7,7 @@ import SceneKit
 import Foundation
 
 // Test out some explicit renames of typedefs and globals, which are now new
-// wrapper types with nestest values.
+// wrapper types with nested values.
 @available(macOS 10.11, *)
 func testNestingRenames() {
   let _ = SCNGeometrySourceSemantic.self

--- a/test/ClangImporter/experimental_diagnostics_cmacros.swift
+++ b/test/ClangImporter/experimental_diagnostics_cmacros.swift
@@ -34,7 +34,7 @@ _ = INVALID_ARITHMETIC_1
 // CHECK-NEXT: _ = INVALID_ARITHMETIC_1
 // CHECK-NEXT:     ^~~~~~~~~~~~~~~~~~~~
 // CHECK-NEXT:      macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_1' not imported: structure not supported
-// CHECK-NEXT:      #define INVALID_ARITHMETIC_1 5 + INVALID_INTERGER_LITERAL_1
+// CHECK-NEXT:      #define INVALID_ARITHMETIC_1 5 + INVALID_INTEGER_LITERAL_1
 // CHECK-NEXT: {{^}}        ^
 
 _ = INVALID_ARITHMETIC_2

--- a/test/ClangImporter/experimental_eager_diagnostics.swift
+++ b/test/ClangImporter/experimental_eager_diagnostics.swift
@@ -185,7 +185,7 @@ import macros
 // CHECK-NEXT: {{^}}        ^
 
 // CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_1' not imported: structure not supported
-// CHECK-NEXT:      #define INVALID_ARITHMETIC_1 5 + INVALID_INTERGER_LITERAL_1
+// CHECK-NEXT:      #define INVALID_ARITHMETIC_1 5 + INVALID_INTEGER_LITERAL_1
 // CHECK-NEXT: {{^}}        ^
 
 // CHECK:      macros.h:{{[0-9]+}}:9: note: macro 'INVALID_ARITHMETIC_2' not imported: structure not supported

--- a/test/ClangImporter/objc_async_conformance.swift
+++ b/test/ClangImporter/objc_async_conformance.swift
@@ -43,7 +43,7 @@ class ConformsToSync : NSObject, Club {
 ///////
 // selector conflicts
 
-// attempting to satisfy the ObjC async requirement in two ways simultaenously
+// attempting to satisfy the ObjC async requirement in two ways simultaneously
 // is problematic due to a clash in selector names on this ObjC-compatible type
 class SelectorConflict : NSObject, RequiredObserverOnlyCompletion {
   func hello() async -> Bool { true } // expected-note {{method 'hello()' declared here}}

--- a/test/ClangImporter/objc_direct.swift
+++ b/test/ClangImporter/objc_direct.swift
@@ -23,7 +23,7 @@ class Foo {
     }
 }
 
-var otherthing = Foo() as AnyObject
+var otherThing = Foo() as AnyObject
 
 // We expect no error.
-let _ = otherthing.directProtocolMethod()
+let _ = otherThing.directProtocolMethod()

--- a/test/ClangImporter/pch-bridging-header-vs-modular-interface-defn.swift
+++ b/test/ClangImporter/pch-bridging-header-vs-modular-interface-defn.swift
@@ -63,7 +63,7 @@
 // ~~~~~~~~~~~~~~
 //
 // One might hope that this can be fixed by having the merge-modules step take a
-// PCH as well as other steps in the compilation. That unfortuantely only
+// PCH as well as other steps in the compilation. That unfortunately only
 // inverts the problem, which resurfaces in the definition-order of Bar itself:
 // an XRef to __ObjC.Bar gets serialized, and then _it_ can't be found during
 // merge-modules, because the *last-read* defn of Bar -- the modular one, M.Bar

--- a/test/ClangImporter/pch-bridging-header.swift
+++ b/test/ClangImporter/pch-bridging-header.swift
@@ -42,7 +42,7 @@
 // RUN: llvm-objdump --raw-clang-ast %t/pch3/*.pch | llvm-bcanalyzer -dump | %FileCheck %s -check-prefix=PERSISTENT
 // PERSISTENT: ORIGINAL_FILE{{.*}}Inputs/sdk-bridging-header.h
 
-// Test that -pch-disable-validation works in that it won't implicitely create a PCH
+// Test that -pch-disable-validation works in that it won't implicitly create a PCH
 // RUN: not %target-swift-frontend -typecheck %s -import-objc-header %S/Inputs/sdk-bridging-header.h -pch-output-dir %t/no-pch -pch-disable-validation 2>&1 | %FileCheck %s -check-prefix=NO-VALIDATION
 // NO-VALIDATION: PCH file {{.*}} not found
 

--- a/test/Inputs/clang-importer-sdk/usr/include/macros.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/macros.h
@@ -169,7 +169,7 @@ typedef unsigned okay_t;
 #define FUNC_LIKE_MACRO_2(PARAM) PARAM
 
 // Unsupported binary arithmetic
-#define INVALID_ARITHMETIC_1 5 + INVALID_INTERGER_LITERAL_1
+#define INVALID_ARITHMETIC_1 5 + INVALID_INTEGER_LITERAL_1
 #define INVALID_ARITHMETIC_2 INVALID_INTEGER_LITERAL_1 + ADD_TWO
 #define INVALID_ARITHMETIC_3 ADD_TWO + INVALID_INTEGER_LITERAL_1
 #define INVALID_ARITHMETIC_4                                                   \

--- a/unittests/ClangImporter/ClangImporterTests.cpp
+++ b/unittests/ClangImporter/ClangImporterTests.cpp
@@ -71,14 +71,14 @@ TEST(ClangImporterTest, emitPCHInMemory) {
   swift::LangOptions langOpts;
   langOpts.Target = llvm::Triple("x86_64", "apple", "darwin");
   swift::SILOptions silOpts;
-  swift::TypeCheckerOptions typeckOpts;
+  swift::TypeCheckerOptions typecheckOpts;
   INITIALIZE_LLVM();
   swift::SearchPathOptions searchPathOpts;
   swift::symbolgraphgen::SymbolGraphOptions symbolGraphOpts;
   swift::SourceManager sourceMgr;
   swift::DiagnosticEngine diags(sourceMgr);
   std::unique_ptr<ASTContext> context(
-      ASTContext::get(langOpts, typeckOpts, silOpts, searchPathOpts, options,
+      ASTContext::get(langOpts, typecheckOpts, silOpts, searchPathOpts, options,
                       symbolGraphOpts, sourceMgr, diags));
   auto importer = ClangImporter::create(*context);
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fixes some misspellings in Swift clangimporter, it is split per https://github.com/apple/swift/pull/42421#issuecomment-1101092698


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
