### PR TITLE
Spelling frontend

### DIFF
--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -606,7 +606,7 @@ private:
   void setupStatsReporter();
   void setupDependencyTrackerIfNeeded();
 
-  /// \return false if successsful, true on error.
+  /// \return false if successful, true on error.
   bool setupDiagnosticVerifierIfNeeded();
 
   Optional<unsigned> setUpCodeCompletionBuffer();

--- a/include/swift/Frontend/FrontendInputsAndOutputs.h
+++ b/include/swift/Frontend/FrontendInputsAndOutputs.h
@@ -142,7 +142,7 @@ public:
   assertMustNotBeMoreThanOnePrimaryInputUnlessBatchModeChecksHaveBeenBypassed()
       const;
 
-  // Count-dependend readers:
+  // Count-dependent readers:
 
   /// \return the unique primary input, if one exists.
   const InputFile *getUniquePrimaryInput() const;

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -444,7 +444,7 @@ public:
   bool IncludeSPISymbolsInSymbolGraph = false;
 
   /// Whether to reuse a frontend (i.e. compiler instance) for multiple
-  /// compiletions. This prevents ASTContext being freed.
+  /// compilations. This prevents ASTContext being freed.
   bool ReuseFrontendForMutipleCompilations = false;
 
   /// This is used to obfuscate the serialized search paths so we don't have

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -445,7 +445,7 @@ public:
 
   /// Whether to reuse a frontend (i.e. compiler instance) for multiple
   /// compilations. This prevents ASTContext being freed.
-  bool ReuseFrontendForMutipleCompilations = false;
+  bool ReuseFrontendForMultipleCompilations = false;
 
   /// This is used to obfuscate the serialized search paths so we don't have
   /// to encode the actual paths into the .swiftmodule file.

--- a/lib/Driver/FrontendUtil.cpp
+++ b/lib/Driver/FrontendUtil.cpp
@@ -52,7 +52,7 @@ bool swift::driver::getSingleFrontendInvocationFromDriverArguments(
   // frontend command.
   Args.push_back("-whole-module-optimization");
 
-  // Explictly disable batch mode to avoid a spurious warning when combining
+  // Explicitly disable batch mode to avoid a spurious warning when combining
   // -enable-batch-mode with -whole-module-optimization.  This is an
   // implementation detail.
   Args.push_back("-disable-batch-mode");

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -169,7 +169,7 @@ bool ArgsToFrontendOptionsConverter::convert(
   Optional<FrontendInputsAndOutputs> inputsAndOutputs =
       ArgsToFrontendInputsConverter(Diags, Args).convert(buffers);
 
-  // None here means error, not just "no inputs". Propagage unconditionally.
+  // None here means error, not just "no inputs". Propagate unconditionally.
   if (!inputsAndOutputs)
     return true;
 

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.h
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.h
@@ -81,7 +81,7 @@ public:
   ///             -module-alias Baz=Qux`, the args are ['Foo=Bar', 'Baz=Qux'].  The name
   ///             Foo is the name that appears in source files, while it maps to Bar, the name
   ///             of the binary on disk, /path/to/Bar.swiftmodule(interface), under the hood.
-  /// \param options FrontendOptions containings the module alias map to set args to.
+  /// \param options FrontendOptions containing the module alias map to set args to.
   /// \param diags Used to print diagnostics in case validation of the args fails.
   /// \return Whether the validation passed and successfully set the module alias map
   static bool computeModuleAliases(std::vector<std::string> args,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2362,7 +2362,7 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
   } else if (Triple.isWatchOS() && !Triple.isSimulatorEnvironment()) {
     // watchOS does not support auto async frame pointers due to bitcode, so
     // silently override "auto" to "never" when back-deploying. This approach
-    // sacrifies async backtraces when back-deploying but prevents crashes in
+    // sacrifices async backtraces when back-deploying but prevents crashes in
     // older tools that cannot handle the async frame bit in the frame pointer.
     unsigned major, minor, micro;
     Triple.getWatchOSVersion(major, minor, micro);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -789,7 +789,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   // Collect -clang-target value if specified in the front-end invocation.
   // Usually, the driver will pass down a clang target with the
-  // exactly same value as the main target, so we could dignose the usage of
+  // exactly same value as the main target, so we could diagnose the usage of
   // unavailable APIs.
   // The reason we cannot infer clang target from -target is that not all
   // front-end invocation will include a -target to start with. For instance,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2112,7 +2112,7 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
     Opts.UseTypeLayoutValueHandling
       = A->getOption().matches(OPT_enable_type_layouts);
   } else if (Opts.OptMode == OptimizationMode::NoOptimization) {
-    // Disable type layouts at Onone except if explictly requested.
+    // Disable type layouts at Onone except if explicitly requested.
     Opts.UseTypeLayoutValueHandling = false;
   }
 

--- a/lib/Frontend/DependencyVerifier.cpp
+++ b/lib/Frontend/DependencyVerifier.cpp
@@ -225,7 +225,7 @@ public:
 
 public:
   bool isOwed() const { return state == State::Owed; }
-  FullfillmentToken fullfill() {
+  FullfillmentToken fulfill() {
     assert(state == State::Owed &&
            "Cannot fulfill an obligation more than once!");
     state = State::Fulfilled;
@@ -440,13 +440,13 @@ bool DependencyVerifier::verifyObligations(
           case Expectation::Kind::Negative:
             llvm_unreachable("Should have been handled above!");
           case Expectation::Kind::Member:
-            return O.fullfill();
+            return O.fulfill();
           case Expectation::Kind::PotentialMember:
             assert(O.getName().empty());
-            return O.fullfill();
+            return O.fulfill();
           case Expectation::Kind::Provides:
           case Expectation::Kind::DynamicMember:
-            return O.fullfill();
+            return O.fulfill();
           }
 
           llvm_unreachable("Unhandled expectation kind!");

--- a/lib/Frontend/DependencyVerifier.cpp
+++ b/lib/Frontend/DependencyVerifier.cpp
@@ -127,13 +127,13 @@ struct Obligation {
   /// A token returned when an \c Obligation is fulfilled or failed. An \c
   /// Obligation is the only type that may construct fulfillment tokens.
   ///
-  /// \c FullfillmentToken prevents misuse of the \c Obligation
+  /// \c FulfillmentToken prevents misuse of the \c Obligation
   /// structure by requiring its state to be changed along all program paths.
-  struct FullfillmentToken {
+  struct FulfillmentToken {
     friend Obligation;
 
   private:
-    FullfillmentToken() = default;
+    FulfillmentToken() = default;
   };
 
   /// An \c Obligation::Key is a reduced set of the common data contained in an
@@ -225,16 +225,16 @@ public:
 
 public:
   bool isOwed() const { return state == State::Owed; }
-  FullfillmentToken fulfill() {
+  FulfillmentToken fulfill() {
     assert(state == State::Owed &&
            "Cannot fulfill an obligation more than once!");
     state = State::Fulfilled;
-    return FullfillmentToken{};
+    return FulfillmentToken{};
   }
-  FullfillmentToken fail() {
+  FulfillmentToken fail() {
     assert(state == State::Owed && "Cannot fail an obligation more than once!");
     state = State::Failed;
-    return FullfillmentToken{};
+    return FulfillmentToken{};
   }
 };
 
@@ -278,7 +278,7 @@ private:
   /// fail is called with the unmatched expectation value.
   void matchExpectationOrFail(
       ObligationMap &OM, const Expectation &expectation,
-      llvm::function_ref<Obligation::FullfillmentToken(Obligation &)> fulfill,
+      llvm::function_ref<Obligation::FulfillmentToken(Obligation &)> fulfill,
       llvm::function_ref<void(const Expectation &)> fail) {
     auto entry = OM.find(Obligation::Key::forExpectation(expectation));
     if (entry == OM.end()) {

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1230,7 +1230,7 @@ CompilerInstance::getSourceFileParsingOptions(bool forPrimary) const {
   if (forPrimary ||
       typeOpts.SkipFunctionBodies ==
           FunctionBodySkipping::NonInlinableWithoutTypes ||
-      frontendOpts.ReuseFrontendForMutipleCompilations) {
+      frontendOpts.ReuseFrontendForMultipleCompilations) {
     opts |= SourceFile::ParsingFlags::EnableInterfaceHash;
   }
   return opts;

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -256,9 +256,9 @@ bool CompilerInstance::setUpASTContextIfNeeded() {
 }
 
 void CompilerInstance::setupStatsReporter() {
-  const auto &Invok = getInvocation();
+  const auto &Invoke = getInvocation();
   const std::string &StatsOutputDir =
-      Invok.getFrontendOptions().StatsOutputDir;
+      Invoke.getFrontendOptions().StatsOutputDir;
   if (StatsOutputDir.empty())
     return;
 
@@ -281,9 +281,9 @@ void CompilerInstance::setupStatsReporter() {
     return nullptr;
   };
 
-  const auto &FEOpts = Invok.getFrontendOptions();
-  const auto &LangOpts = Invok.getLangOptions();
-  const auto &SILOpts = Invok.getSILOptions();
+  const auto &FEOpts = Invoke.getFrontendOptions();
+  const auto &LangOpts = Invoke.getLangOptions();
+  const auto &SILOpts = Invoke.getSILOptions();
   const std::string &OutFile =
       FEOpts.InputsAndOutputs.lastInputProducingOutput().outputFilename();
   auto Reporter = std::make_unique<UnifiedStatsReporter>(
@@ -296,9 +296,9 @@ void CompilerInstance::setupStatsReporter() {
       StatsOutputDir,
       &getSourceMgr(),
       getClangSourceManager(getASTContext()),
-      Invok.getFrontendOptions().TraceStats,
-      Invok.getFrontendOptions().ProfileEvents,
-      Invok.getFrontendOptions().ProfileEntities);
+      Invoke.getFrontendOptions().TraceStats,
+      Invoke.getFrontendOptions().ProfileEvents,
+      Invoke.getFrontendOptions().ProfileEntities);
   // Hand the stats reporter down to the ASTContext so the rest of the compiler
   // can use it.
   getASTContext().setStatsReporter(Reporter.get());
@@ -358,9 +358,9 @@ void CompilerInstance::setupDependencyTrackerIfNeeded() {
   DepTracker = std::make_unique<DependencyTracker>(*collectionMode);
 }
 
-bool CompilerInstance::setup(const CompilerInvocation &Invok,
+bool CompilerInstance::setup(const CompilerInvocation &Invoke,
                              std::string &Error) {
-  Invocation = Invok;
+  Invocation = Invoke;
 
   setupDependencyTrackerIfNeeded();
 

--- a/lib/Frontend/FrontendInputsAndOutputs.cpp
+++ b/lib/Frontend/FrontendInputsAndOutputs.cpp
@@ -570,6 +570,6 @@ FrontendInputsAndOutputs::primaryInputNamed(StringRef name) const {
   if (iterator == PrimaryInputsByName.end())
     return nullptr;
   const InputFile *f = &AllInputs[iterator->second];
-  assert(f->isPrimary() && "PrimaryInputsByName should only include primries");
+  assert(f->isPrimary() && "PrimaryInputsByName should only include primaries");
   return f;
 }

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1464,9 +1464,9 @@ InterfaceSubContextDelegateImpl::InterfaceSubContextDelegateImpl(
   }
   // Pass down -explicit-swift-module-map-file
   // FIXME: we shouldn't need this. Remove it?
-  StringRef explictSwiftModuleMap = searchPathOpts.ExplicitSwiftModuleMap;
+  StringRef explicitSwiftModuleMap = searchPathOpts.ExplicitSwiftModuleMap;
   genericSubInvocation.getSearchPathOptions().ExplicitSwiftModuleMap =
-    explictSwiftModuleMap.str();
+    explicitSwiftModuleMap.str();
   auto &subClangImporterOpts = genericSubInvocation.getClangImporterOptions();
   // Respect the detailed-record preprocessor setting of the parent context.
   // This, and the "raw" clang module format it implicitly enables, are
@@ -1474,7 +1474,7 @@ InterfaceSubContextDelegateImpl::InterfaceSubContextDelegateImpl(
   subClangImporterOpts.DetailedPreprocessingRecord =
     clangImporterOpts.DetailedPreprocessingRecord;
 
-  // We need to add these extra clang flags because explict module building
+  // We need to add these extra clang flags because explicit module building
   // related flags are all there: -fno-implicit-modules, -fmodule-map-file=,
   // and -fmodule-file=.
   // If we don't add these flags, the interface will be built with implicit

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1047,7 +1047,7 @@ class ModuleInterfaceLoaderImpl {
       // file and removed the fallback interface file, we can rebuild the cache.
       fallbackBuilder.addExtraDependency(interfacePath);
       // Use cachedOutputPath as the output file path. This output path was
-      // calcualted using the canonical interface file path to make sure we
+      // calculated using the canonical interface file path to make sure we
       // can find it from the canonical interface file.
       auto failedAgain = fallbackBuilder.buildSwiftModule(cachedOutputPath,
           /*shouldSerializeDeps*/true, &moduleBuffer, remarkRebuild);

--- a/lib/Frontend/PrintingDiagnosticConsumer.cpp
+++ b/lib/Frontend/PrintingDiagnosticConsumer.cpp
@@ -781,7 +781,7 @@ namespace {
             printLineEllipsis(Out);
           }
         } else if (lineNumber - lastLineNumber > maxIntermediateLines) {
-          // Use an ellipsis to denote an ommitted part of the file.
+          // Use an ellipsis to denote an omitted part of the file.
           printNumberedLine(SM, BufferID, lastLineNumber + 1, lineNumberIndent,
                             Out);
           printLineEllipsis(Out);

--- a/lib/FrontendTool/Dependencies.h
+++ b/lib/FrontendTool/Dependencies.h
@@ -1,4 +1,4 @@
-//===--- Dependencies.h -- Unified header for dependnecy tracing utilies --===//
+//===--- Dependencies.h -- Unified header for dependency tracing utilies --===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/FrontendTool/Dependencies.h
+++ b/lib/FrontendTool/Dependencies.h
@@ -1,4 +1,4 @@
-//===--- Dependencies.h -- Unified header for dependency tracing utilies --===//
+//===--- Dependencies.h -- Unified header for dependency tracing utilities --===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1510,7 +1510,7 @@ static bool generateCode(CompilerInstance &Instance, StringRef OutputFilename,
   // Free up some compiler resources now that we have an IRModule.
   freeASTContextIfPossible(Instance);
 
-  // If we emitted any errors while perfoming the end-of-pipeline actions, bail.
+  // If we emitted any errors while performing the end-of-pipeline actions, bail.
   if (Instance.getDiags().hadAnyError())
     return true;
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1616,7 +1616,7 @@ static bool performCompileStepsPostSILGen(CompilerInstance &Instance,
   if (observer)
     observer->performedSILProcessing(*SM);
 
-  // Cancellation check after SILOptimzation.
+  // Cancellation check after SILOptimization.
   if (Instance.isCancellationRequested())
     return true;
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1093,7 +1093,7 @@ static bool printSwiftFeature(CompilerInstance &instance) {
   out << "    \"LastOption\"\n";
   out << "  ],\n";
   out << "  \"SupportedFeatures\": [\n";
-  // Print supported featur names here.
+  // Print supported feature names here.
   out << "    \"LastFeature\"\n";
   out << "  ]\n";
   return false;

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1478,7 +1478,7 @@ static void freeASTContextIfPossible(CompilerInstance &Instance) {
   // to live.
   if (Instance.getInvocation()
           .getFrontendOptions()
-          .ReuseFrontendForMutipleCompilations) {
+          .ReuseFrontendForMultipleCompilations) {
     return;
   }
 

--- a/lib/FrontendTool/MakeStyleDependencies.cpp
+++ b/lib/FrontendTool/MakeStyleDependencies.cpp
@@ -29,7 +29,7 @@ swift::frontend::utils::escapeForMake(StringRef raw,
   buffer.clear();
 
   // The escaping rules for GNU make are complicated due to the various
-  // subsitutions and use of the tab in the leading position for recipes.
+  // substitutions and use of the tab in the leading position for recipes.
   // Various symbols have significance in different contexts.  It is not
   // possible to correctly quote all characters in Make (as of 3.7).  Match
   // gcc and clang's behaviour for the escaping which covers only a subset of

--- a/lib/IDE/CompileInstance.cpp
+++ b/lib/IDE/CompileInstance.cpp
@@ -277,7 +277,7 @@ bool CompileInstance::setupCI(
   invocation.getFrontendOptions().LLVMArgs.clear();
 
   /// Declare the frontend to be used for multiple compilations.
-  invocation.getFrontendOptions().ReuseFrontendForMutipleCompilations = true;
+  invocation.getFrontendOptions().ReuseFrontendForMultipleCompilations = true;
 
   // Enable dependency trakcing (excluding system modules) to invalidate the
   // compiler instance if any dependent files are modified.

--- a/test/Frontend/dump-parse.swift
+++ b/test/Frontend/dump-parse.swift
@@ -54,7 +54,7 @@ enum TrailingSemi {
   };
 };
 
-// The substitution map for a declref should be relatively unobtrustive.
+// The substitution map for a declref should be relatively unobtrusive.
 // CHECK-AST-LABEL:   (func_decl{{.*}}"generic(_:)" <T : Hashable> interface type='<T where T : Hashable> (T) -> ()' access=internal captures=(<generic> )
 func generic<T: Hashable>(_: T) {}
 // CHECK-AST:       (pattern_binding_decl

--- a/test/Frontend/module-alias-load.swift
+++ b/test/Frontend/module-alias-load.swift
@@ -9,7 +9,7 @@
 /// Check Bar.swiftmodule is created
 // RUN: test -f %t/Bar.swiftmodule
 
-/// Create a module Foo that imports Cat with -module-alias Cat=Bar with a serialized modue loader
+/// Create a module Foo that imports Cat with -module-alias Cat=Bar with a serialized module loader
 // RUN: %target-swift-frontend -module-name Foo %t/FileFoo.swift -module-alias Cat=Bar -I %t -emit-module -emit-module-path %t/Foo.swiftmodule -Rmodule-loading 2> %t/load-result-foo.output
 
 /// Check Foo.swiftmodule is created and Bar.swiftmodule is loaded

--- a/test/Frontend/module-alias-scan-deps.swift
+++ b/test/Frontend/module-alias-scan-deps.swift
@@ -10,7 +10,7 @@
 // RUN: %target-swift-frontend -module-name AppleLogging -module-alias XLogging=AppleLogging %t/FileLogging.swift -emit-module -emit-module-path %t/AppleLogging.swiftmodule
 // RUN: test -f %t/AppleLogging.swiftmodule
 
-/// Scaned dependencies should contain real name AppleLogging
+/// Scanned dependencies should contain real name AppleLogging
 // RUN: %target-swift-frontend -scan-dependencies  %t/FileLib.swift -module-alias XLogging=AppleLogging -I %t > %t/scandump.output
 // RUN: %FileCheck %s -check-prefix=CHECK-REAL-NAME -input-file  %t/scandump.output
 // CHECK-REAL-NAME-NOT: "swiftPrebuiltExternal": "XLogging"
@@ -23,7 +23,7 @@
 // RUN: %target-swift-frontend -module-name AppleLoggingIF %t/FileLogging.swift -module-alias XLogging=AppleLoggingIF -I %t -emit-module -emit-module-interface-path %t/AppleLoggingIF.swiftinterface -swift-version 5 -enable-library-evolution -I %t
 // RUN: test -f %t/AppleLoggingIF.swiftinterface
 
-/// Scaned dependencies should contain real name AppleLoggingIF
+/// Scanned dependencies should contain real name AppleLoggingIF
 // RUN: %target-swift-frontend -scan-dependencies  %t/FileLib.swift -module-alias XLogging=AppleLoggingIF -I %t > %t/scandumpIF.output
 // RUN: %FileCheck %s -check-prefix=CHECK-REAL-NAME-IF -input-file  %t/scandumpIF.output
 // CHECK-REAL-NAME-IF-NOT: "swift": "XLogging"

--- a/test/Frontend/primary-filelist.swift
+++ b/test/Frontend/primary-filelist.swift
@@ -1,6 +1,6 @@
 // RUN: not %target-swift-frontend -primary-filelist 2>&1 | %FileCheck -check-prefix=CHECK-EXPECTEDARGUMENT %s
 // CHECK-EXPECTEDARGUMENT: error: missing argument value for '-primary-filelist', expected 1 argument(s)
-// RUN: not %target-swift-frontend -primary-filelist nonexistant 2>&1 | %FileCheck -check-prefix=CHECK-BADFILE %s
+// RUN: not %target-swift-frontend -primary-filelist nonexistent 2>&1 | %FileCheck -check-prefix=CHECK-BADFILE %s
 // CHECK-BADFILE: error: cannot open file
 
 // RUN: %empty-directory(%t)

--- a/unittests/FrontendTool/ModuleLoadingTests.cpp
+++ b/unittests/FrontendTool/ModuleLoadingTests.cpp
@@ -96,14 +96,14 @@ protected:
     PrintingDiagnosticConsumer printingConsumer;
     DiagnosticEngine diags(sourceMgr);
     diags.addConsumer(printingConsumer);
-    TypeCheckerOptions typeckOpts;
+    TypeCheckerOptions typecheckOpts;
     LangOptions langOpts;
     langOpts.Target = llvm::Triple(llvm::sys::getDefaultTargetTriple());
     SearchPathOptions searchPathOpts;
     ClangImporterOptions clangImpOpts;
     symbolgraphgen::SymbolGraphOptions symbolGraphOpts;
     SILOptions silOpts;
-    auto ctx = ASTContext::get(langOpts, typeckOpts, silOpts, searchPathOpts,
+    auto ctx = ASTContext::get(langOpts, typecheckOpts, silOpts, searchPathOpts,
                                clangImpOpts, symbolGraphOpts, sourceMgr, diags);
 
     ctx->addModuleInterfaceChecker(


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fixes some misspellings in Swift documentation, it is split per https://github.com/apple/swift/pull/42421#issuecomment-1101092698


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
I've tried to limit this to frontend, I've included frontend* because I didn't want to figure out if there were crossovers.

This required one change to outside a Frontend file because there's a consumer.