### PR TITLE
Spelling parse

### DIFF
--- a/include/swift/Parse/CodeCompletionCallbacks.h
+++ b/include/swift/Parse/CodeCompletionCallbacks.h
@@ -128,7 +128,7 @@ public:
   /// by user.
   virtual void completePostfixExprBeginning(CodeCompletionExpr *E) {};
 
-  /// Complete the beginning of expr-postfix in a for-each loop sequqence
+  /// Complete the beginning of expr-postfix in a for-each loop sequence
   /// -- no tokens provided by user.
   virtual void completeForEachSequenceBeginning(CodeCompletionExpr *E) {};
 

--- a/include/swift/Parse/CodeCompletionCallbacks.h
+++ b/include/swift/Parse/CodeCompletionCallbacks.h
@@ -212,7 +212,7 @@ public:
 
   /// Complete a yield statement.  A missing yield index means that the
   /// completion immediately follows the 'yield' keyword; it may be either
-  /// an expresion or a parenthesized expression list.  A present yield
+  /// an expression or a parenthesized expression list.  A present yield
   /// index means that the completion is within the parentheses and is
   /// for a specific yield value.
   virtual void completeYieldStmt(CodeCompletionExpr *E,

--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -423,7 +423,7 @@ public:
   /// source location.
   ///
   /// If \c ExtraIndentation is not null, it will be set to an appropriate
-  /// additional intendation for adding code in a smaller scope "within" \c Loc.
+  /// additional indentation for adding code in a smaller scope "within" \c Loc.
   static StringRef getIndentationForLine(SourceManager &SM, SourceLoc Loc,
                                          StringRef *ExtraIndentation = nullptr);
 

--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -231,7 +231,7 @@ public:
   }
 
   /// Lex a token. If \c TriviaRetentionMode is \c WithTrivia, passed pointers
-  /// to trivias are populated.
+  /// to trivia are populated.
   void lex(Token &Result, StringRef &LeadingTriviaResult,
            StringRef &TrailingTriviaResult) {
     Result = NextToken;
@@ -661,7 +661,7 @@ private:
 /// A lexer that can lex trivia into its pieces
 class TriviaLexer {
 public:
-  /// Decompose the triva in \p TriviaStr into their pieces.
+  /// Decompose the trivia in \p TriviaStr into their pieces.
   static ParsedTrivia lexTrivia(StringRef TriviaStr);
 };
 

--- a/include/swift/Parse/ParsedRawSyntaxNode.h
+++ b/include/swift/Parse/ParsedRawSyntaxNode.h
@@ -152,7 +152,7 @@ public:
   /// must be interpreted by the \c SyntaxParseAction, which likely also needs
   /// the node type (layout or token) to interpret the data.
   /// The data opaque data returned by this function *must not* be used to
-  /// record the node, only to insepect it.
+  /// record the node, only to inspect it.
   OpaqueSyntaxNode getUnsafeDeferredOpaqueData() const {
     assert(isDeferredLayout() || isDeferredToken());
     return Data.getOpaque();

--- a/include/swift/Parse/ParsedRawSyntaxRecorder.h
+++ b/include/swift/Parse/ParsedRawSyntaxRecorder.h
@@ -159,7 +159,7 @@ public:
                                    /*IsMissing=*/false, range);
   }
 
-  /// Record a raw syntax collecton without eny elements. \p loc can be invalid
+  /// Record a raw syntax collection without eny elements. \p loc can be invalid
   /// or an approximate location of where an element of the collection would be
   /// if not missing.
   ParsedRawSyntaxNode recordEmptyRawSyntaxCollection(syntax::SyntaxKind kind,

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1704,7 +1704,7 @@ public:
   /// \param inLoc The location of the 'in' keyword, if present.
   ///
   /// \returns ParserStatus error if an error occurred. Success if no signature
-  /// is present or succssfully parsed.
+  /// is present or successfully parsed.
   ParserStatus parseClosureSignatureIfPresent(
           DeclAttributes &attributes,
           SourceRange &bracketRange,

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -477,7 +477,7 @@ public:
         savedConsumer(receiver, this) {}
       void receive(const Token &tok) override { delayedTokens.push_back(tok); }
       Optional<std::vector<Token>> finalize() override {
-        llvm_unreachable("Cannot finalize a DelayedTokenReciever");
+        llvm_unreachable("Cannot finalize a DelayedTokenReceiver");
       }
       ~DelayedTokenReceiver() {
         if (!shouldTransfer)

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -901,7 +901,7 @@ public:
   /// When encountering an error or a missing matching token (e.g. '}'), return
   /// the location to use for it. This value should be at the last token in
   /// the ASTNode being parsed so that it nests within any enclosing nodes, and,
-  /// for ASTScope lookups, it does not preceed any identifiers to be looked up.
+  /// for ASTScope lookups, it does not precede any identifiers to be looked up.
   /// However, the latter case does not hold when  parsing an interpolated
   /// string literal because there may be identifiers to be looked up in the
   /// literal and their locations will not precede the location of a missing

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1982,7 +1982,7 @@ DeclName formDeclName(ASTContext &ctx,
                       bool isInitializer,
                       bool isSubscript = false);
 
-/// Form a Swift declaration name referemce from its constituent parts.
+/// Form a Swift declaration name reference from its constituent parts.
 DeclNameRef formDeclNameRef(ASTContext &ctx,
                             StringRef baseName,
                             ArrayRef<StringRef> argumentLabels,

--- a/include/swift/Parse/ParserResult.h
+++ b/include/swift/Parse/ParserResult.h
@@ -168,7 +168,7 @@ public:
   }
 
   /// Return true if either 1) no errors were encountered while parsing this,
-  /// or 2) there were errors but the the parser already recovered from them.
+  /// or 2) there were errors but the parser already recovered from them.
   bool isSuccess() const { return !isError(); }
   bool isErrorOrHasCompletion() const { return IsError || IsCodeCompletion; }
 

--- a/include/swift/Parse/SyntaxParseActions.h
+++ b/include/swift/Parse/SyntaxParseActions.h
@@ -143,7 +143,7 @@ public:
                                             size_t childIndex) const = 0;
 
   /// To verify \c ParsedRawSyntaxNode element ranges, the range of child nodes
-  /// returend by \c getDeferredChild needs to be determined. That's what this
+  /// returned by \c getDeferredChild needs to be determined. That's what this
   /// method does.
   /// It assumes that \p node is a deferred layout node starting at \p startLoc
   /// and returns the range of the child node at \p childIndex.

--- a/include/swift/Parse/SyntaxParseActions.h
+++ b/include/swift/Parse/SyntaxParseActions.h
@@ -138,7 +138,7 @@ public:
   /// retrieved using \c getDeferredChildRange if element ranges should be
   /// verified
   /// \p node is the parent node for which the child at position \p ChildIndex
-  /// should be retrieved. Furthmore, \p node starts at \p StartLoc.
+  /// should be retrieved. Furthermore, \p node starts at \p StartLoc.
   virtual DeferredNodeInfo getDeferredChild(OpaqueSyntaxNode node,
                                             size_t childIndex) const = 0;
 

--- a/include/swift/Parse/SyntaxParsingContext.h
+++ b/include/swift/Parse/SyntaxParsingContext.h
@@ -116,7 +116,7 @@ private:
   /// Indicates what action should be performed on the destruction of
   ///  SyntaxParsingContext
   enum class AccumulationMode {
-    // Coerece the result to one of ContextKind.
+    // Coerce the result to one of ContextKind.
     // E.g. for ContextKind::Expr, passthroug if the result is CallExpr, whereas
     // <UnknownExpr><SomeDecl /></UnknownDecl> for non Exprs.
     CoerceKind,

--- a/include/swift/Parse/SyntaxParsingContext.h
+++ b/include/swift/Parse/SyntaxParsingContext.h
@@ -117,7 +117,7 @@ private:
   ///  SyntaxParsingContext
   enum class AccumulationMode {
     // Coerce the result to one of ContextKind.
-    // E.g. for ContextKind::Expr, passthroug if the result is CallExpr, whereas
+    // E.g. for ContextKind::Expr, passthrough if the result is CallExpr, whereas
     // <UnknownExpr><SomeDecl /></UnknownDecl> for non Exprs.
     CoerceKind,
 

--- a/include/swift/Parse/SyntaxParsingContext.h
+++ b/include/swift/Parse/SyntaxParsingContext.h
@@ -304,7 +304,7 @@ public:
   /// collection kind. If there're no nodes that can fit into the collection kind,
   /// this function does nothing. Otherwise, it creates a collection node in place
   /// to contain all sequential suitable nodes from back.
-  void collectNodesInPlace(SyntaxKind ColletionKind,
+  void collectNodesInPlace(SyntaxKind CollectionKind,
        SyntaxNodeCreationKind nodeCreateK = SyntaxNodeCreationKind::Recorded);
 
   /// On destruction, construct a specified kind of syntax node consuming the

--- a/include/swift/Parse/SyntaxParsingContext.h
+++ b/include/swift/Parse/SyntaxParsingContext.h
@@ -154,7 +154,7 @@ private:
 
   RootContextData *RootData;
 
-  // Offet for 'Storage' this context owns from.
+  // Offset for 'Storage' this context owns from.
   const size_t Offset;
 
   // Operation on destruction.

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -205,7 +205,7 @@ void Lexer::initialize(unsigned Offset, unsigned EndOffset) {
   // Check for Unicode BOM at start of file (Only UTF-8 BOM supported now).
   size_t BOMLength = contents.startswith("\xEF\xBB\xBF") ? 3 : 0;
 
-  // Keep information about existance of UTF-8 BOM for transparency source code
+  // Keep information about existence of UTF-8 BOM for transparency source code
   // editing with libSyntax.
   ContentStart = BufferStart + BOMLength;
 

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -2722,7 +2722,7 @@ Restart:
     goto Restart;
   case '/':
     if (IsForTrailingTrivia || isKeepingComments()) {
-      // Don't lex comments as trailing trivias (for now).
+      // Don't lex comments as trailing trivia (for now).
       // Don't try to lex comments here if we are lexing comments as Tokens.
       break;
     } else if (*CurPtr == '/') {

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1359,7 +1359,7 @@ unsigned Lexer::lexCharacter(const char *&CurPtr, char StopQuote,
   case '"':
   case '\'':
     if (CurPtr[-1] == StopQuote) {
-      // Mutliline and custom escaping are only enabled for " quote.
+      // Multiline and custom escaping are only enabled for " quote.
       if (LLVM_UNLIKELY(StopQuote != '"'))
         return ~0U;
       if (!IsMultilineString && !CustomDelimiterLen)

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1908,7 +1908,7 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
 
   if (QuoteChar == '\'') {
     assert(!IsMultilineString && CustomDelimiterLen == 0 &&
-           "Single quoted string cannot have custom delimitor, nor multiline");
+           "Single quoted string cannot have custom delimiter, nor multiline");
     diagnoseSingleQuoteStringLiteral(TokStart, CurPtr);
   }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -6343,7 +6343,7 @@ static bool parseAccessorIntroducer(Parser &P,
 /// \endverbatim
 ///
 /// While only 'get' accessors currently support such specifiers,
-/// this routine will also diagnose unspported effects specifiers on
+/// this routine will also diagnose unsupported effects specifiers on
 /// other accessors.
 ///
 /// \param accessors the accessors we've parsed already.

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1716,7 +1716,7 @@ void Parser::parseAllAvailabilityMacroArguments() {
   // The sub-parser is not actually parsing the source file but the LangOpts
   // AvailabilityMacros. No point creating a libSyntax tree for it. In fact, the
   // creation of a libSyntax tree would always fail because the
-  // AvailibilityMacro is not valid Swift source code.
+  // AvailabilityMacro is not valid Swift source code.
   LangOpts.BuildSyntaxTree = false;
 
   for (StringRef macro: LangOpts.AvailabilityMacros) {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2921,7 +2921,7 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
     StringRef message;
     if (consumeIf(tok::l_paren)) {
       if (!Tok.is(tok::identifier)) {
-        llvm_unreachable("Flag must start with an indentifier");
+        llvm_unreachable("Flag must start with an identifier");
       }
 
       StringRef flag = Tok.getText();

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -583,7 +583,7 @@ ParserResult<Expr> Parser::parseExprUnary(Diag<> Message, bool isExprBasic) {
   if (SubExpr.isNull())
     return Status;
 
-  // We are sure we can create a prefix prefix operator expr now.
+  // We are sure we can create a prefix operator expr now.
   UnaryContext.setCreateSyntax(SyntaxKind::PrefixOperatorExpr);
 
   // Check if we have a unary '-' with number literal sub-expression, for

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -177,7 +177,7 @@ ParserResult<Expr> Parser::parseExprArrow() {
 ParserResult<Expr> Parser::parseExprSequence(Diag<> Message,
                                              bool isExprBasic,
                                              bool isForConditionalDirective) {
-  SyntaxParsingContext ExprSequnceContext(SyntaxContext, SyntaxContextKind::Expr);
+  SyntaxParsingContext ExprSequenceContext(SyntaxContext, SyntaxContextKind::Expr);
 
   SmallVector<Expr*, 8> SequencedExprs;
   SourceLoc startLoc = Tok.getLoc();
@@ -380,8 +380,8 @@ done:
   if (SequencedExprs.size() == 1)
     return makeParserResult(SequenceStatus, SequencedExprs[0]);
 
-  ExprSequnceContext.createNodeInPlace(SyntaxKind::ExprList);
-  ExprSequnceContext.setCreateSyntax(SyntaxKind::SequenceExpr);
+  ExprSequenceContext.createNodeInPlace(SyntaxKind::ExprList);
+  ExprSequenceContext.setCreateSyntax(SyntaxKind::SequenceExpr);
   return makeParserResult(SequenceStatus,
                           SequenceExpr::create(Context, SequencedExprs));
 }

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3503,7 +3503,7 @@ ParserResult<Expr> Parser::parseExprPoundUnknown(SourceLoc LSquareLoc) {
 /// Handle code completion after pound in expression position.
 ///
 /// In case it's in a stmt condition position, specify \p ParentKind to
-/// decide the position accepts #available(...) condtion.
+/// decide the position accepts #available(...) condition.
 ///
 /// expr-pound-codecompletion:
 ///   '#' code-completion-token

--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -807,8 +807,8 @@ ParserResult<IfConfigDecl> Parser::parseIfConfig(
       // We shouldn't skip code if we are building syntax tree.
       // The parser will keep running and we just discard the AST part.
       DiagnosticSuppression suppression(Context.Diags);
-      SmallVector<ASTNode, 16> dropedElements;
-      parseElements(dropedElements, false);
+      SmallVector<ASTNode, 16> droppedElements;
+      parseElements(droppedElements, false);
     } else {
       DiagnosticTransaction DT(Diags);
       skipUntilConditionalBlockClose();

--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -153,7 +153,7 @@ class ValidateIfConfigCondition :
     return UDRE->getName().getBaseIdentifier().str();
   }
 
-  /// True for expressions represeting either top level modules
+  /// True for expressions representing either top level modules
   /// or nested submodules.
   bool isModulePath(Expr *E) {
     auto UDE = dyn_cast<UnresolvedDotExpr>(E);

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -846,7 +846,7 @@ Parser::parseFunctionArguments(SmallVectorImpl<Identifier> &NamePieces,
     status |= CurriedParameterClause;
   }
 
-  // If the decl uses currying syntax, complain that that syntax has gone away.
+  // If the decl uses currying syntax, complain that syntax has gone away.
   if (MultipleParameterLists) {
     diagnose(BodyParams->getStartLoc(),
              diag::parameter_curry_syntax_removed);

--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -74,7 +74,7 @@ ParseMembersRequest::evaluate(Evaluator &evaluator,
 
   unsigned bufferID = *sf->getBufferID();
 
-  // Lexer diaganostics have been emitted during skipping, so we disable lexer's
+  // Lexer diagnostics have been emitted during skipping, so we disable lexer's
   // diagnostic engine here.
   Parser parser(bufferID, *sf, /*No Lexer Diags*/nullptr, nullptr, nullptr);
   // Disable libSyntax creation in the delayed parsing.

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -94,7 +94,7 @@ bool Parser::isStartOfStmt() {
     consumeToken(tok::identifier);
     consumeToken(tok::colon);
 
-    // We treating IDENTIIFIER: { as start of statement to provide missed 'do'
+    // We treating IDENTIFIER: { as start of statement to provide missed 'do'
     // diagnostics. This case will be handled in parseStmt().
     if (Tok.is(tok::l_brace)) {
       return true;

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1273,7 +1273,7 @@ ParserResult<PoundAvailableInfo> Parser::parseStmtConditionPoundAvailable() {
     isUnavailability = true;
   }
 
-  SyntaxParsingContext ConditonCtxt(SyntaxContext, Kind);
+  SyntaxParsingContext ConditionCtxt(SyntaxContext, Kind);
   SourceLoc PoundLoc;
 
   PoundLoc = consumeToken(MainToken);

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -790,7 +790,7 @@ void Parser::skipListUntilDeclRBrace(SourceLoc startLoc, tok T1, tok T2) {
         consumeToken();
         
         // If the following token is either <identifier> or :, it means that
-        // this `var` or `let` shoud be interpreted as a label
+        // this `var` or `let` should be interpreted as a label
         if ((Tok.canBeArgumentLabel() && peekToken().is(tok::colon)) ||
              peekToken().is(tok::colon)) {
           backtrack.cancelBacktrack();

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -413,7 +413,7 @@ class TokenRecorder: public ConsumeTokenReceiver {
   // Token list ordered by their appearance in the source file.
   std::vector<Token> Tokens;
 
-  // Registered token kind change. These changes are regiestered before the
+  // Registered token kind change. These changes are registered before the
   // token is consumed, so we need to keep track of them here.
   llvm::DenseMap<const void*, tok> TokenKindChangeMap;
 
@@ -504,7 +504,7 @@ public:
       return;
     }
 
-    // Update Token kind if a kind update was regiestered before.
+    // Update Token kind if a kind update was registered before.
     auto Found = TokenKindChangeMap.find(Tok.getLoc().
                                          getOpaquePointerValue());
     if (Found != TokenKindChangeMap.end()) {

--- a/lib/Parse/SyntaxParsingContext.cpp
+++ b/lib/Parse/SyntaxParsingContext.cpp
@@ -302,21 +302,21 @@ void SyntaxParsingContext::createNodeInPlace(SyntaxKind Kind,
   }
 }
 
-void SyntaxParsingContext::collectNodesInPlace(SyntaxKind ColletionKind,
+void SyntaxParsingContext::collectNodesInPlace(SyntaxKind CollectionKind,
                                          SyntaxNodeCreationKind nodeCreateK) {
-  assert(isCollectionKind(ColletionKind));
+  assert(isCollectionKind(CollectionKind));
   assert(isTopOfContextStack());
   if (!Enabled)
     return;
   auto Parts = getParts();
   auto Count = 0;
   for (auto I = Parts.rbegin(), End = Parts.rend(); I != End; ++I) {
-    if (!SyntaxFactory::canServeAsCollectionMemberRaw(ColletionKind, I->getKind()))
+    if (!SyntaxFactory::canServeAsCollectionMemberRaw(CollectionKind, I->getKind()))
       break;
     ++Count;
   }
   if (Count)
-    createNodeInPlace(ColletionKind, Count, nodeCreateK);
+    createNodeInPlace(CollectionKind, Count, nodeCreateK);
 }
 
 static ParsedRawSyntaxNode finalizeSourceFile(RootContextData &RootData,

--- a/test/AutoDiff/Parse/transpose_attr_parse.swift
+++ b/test/AutoDiff/Parse/transpose_attr_parse.swift
@@ -79,7 +79,7 @@ func transpose(v: Float) -> Float
 func transpose(v: Float) -> Float
 
 // NOTE: The "expected ',' separator" diagnostic is not ideal.
-// Ideally, the diagnostic should point out that that `Swift.Float.+(_:_)` is
+// Ideally, the diagnostic should point out that `Swift.Float.+(_:_)` is
 // not a valid declaration name (missing colon after second argument label).
 // expected-error @+2 {{expected ',' separator}}
 // expected-error @+1 {{expected declaration}}
@@ -87,7 +87,7 @@ func transpose(v: Float) -> Float
 func transpose(v: Float) -> Float
 
 // NOTE: The "expected ',' separator" diagnostic is not ideal.
-// Ideally, the diagnostic should point out that that `Swift.Float.+.a` is
+// Ideally, the diagnostic should point out that `Swift.Float.+.a` is
 // not a valid declaration name.
 // expected-error @+2 {{expected ',' separator}}
 // expected-error @+1 {{expected declaration}}

--- a/test/Parse/ConditionalCompilation/toplevel_parseaslibrary.swift
+++ b/test/Parse/ConditionalCompilation/toplevel_parseaslibrary.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift -parse-as-library -D FOO
 
-// '-parse-as-library' doesn't allow exprssions nor statements in #if blocks.
+// '-parse-as-library' doesn't allow expressions nor statements in #if blocks.
 
 func foo() {}
 

--- a/test/Parse/availability_query_unavailability.swift
+++ b/test/Parse/availability_query_unavailability.swift
@@ -112,7 +112,7 @@ if case 42 = 42, #available(macOS 10.51, *), #unavailable(macOS 10.52) { // expe
 if #available(macOS 10.51, *), case 42 = 42, #unavailable(macOS 10.52) { // expected-error {{#available and #unavailable cannot be in the same statement}}
 }
 
-// Allow availabiility and unavailability to mix if they are not in the same statement.
+// Allow availability and unavailability to mix if they are not in the same statement.
 if #unavailable(macOS 11) {
   if #available(macOS 10, *) { }
 }

--- a/test/Parse/diagnose_availability.swift
+++ b/test/Parse/diagnose_availability.swift
@@ -87,5 +87,5 @@ emptyMessage()
 func extendedEscapedMultilineMessage() {}
 
 // expected-error@+1{{'renamed' cannot be an extended escaping string literal}}
-@available(*, unavailable, renamed: #"avialable()"#)
+@available(*, unavailable, renamed: #"available()"#)
 func extenedEscpaedRenamed() {}

--- a/test/Parse/diagnose_availability.swift
+++ b/test/Parse/diagnose_availability.swift
@@ -88,4 +88,4 @@ func extendedEscapedMultilineMessage() {}
 
 // expected-error@+1{{'renamed' cannot be an extended escaping string literal}}
 @available(*, unavailable, renamed: #"available()"#)
-func extenedEscpaedRenamed() {}
+func extenedEscapedRenamed() {}

--- a/test/Parse/diagnose_availability.swift
+++ b/test/Parse/diagnose_availability.swift
@@ -88,4 +88,4 @@ func extendedEscapedMultilineMessage() {}
 
 // expected-error@+1{{'renamed' cannot be an extended escaping string literal}}
 @available(*, unavailable, renamed: #"available()"#)
-func extenedEscapedRenamed() {}
+func extendedEscapedRenamed() {}

--- a/test/Parse/diagnose_availability_windows.swift
+++ b/test/Parse/diagnose_availability_windows.swift
@@ -22,7 +22,7 @@ func windows10() {}
 windows10()
 // expected-note@-1 {{add 'if #available' version check}}
 
-func coniditonal_compilation() {
+func conditional_compilation() {
   if #available(Windows 10, *) {
   }
 }

--- a/test/Parse/multiline_errors.swift
+++ b/test/Parse/multiline_errors.swift
@@ -137,7 +137,7 @@ _ = "hello\(
             // expected-error@-2 {{unterminated string literal}}
 
 _ = """
-  line one \ non-whitepace
+  line one \ non-whitespace
   line two
   """
   // expected-error@-3 {{invalid escape sequence in literal}}

--- a/test/Parse/multiline_string.swift
+++ b/test/Parse/multiline_string.swift
@@ -119,7 +119,7 @@ _ = """
   """
 // CHECK: "newline elided"
 
-// contains trailing whitepsace
+// contains trailing whitespace
 _ = """
   trailing \
   \("""
@@ -129,14 +129,14 @@ _ = """
       substring3
       """)
     """) \
-  whitepsace
+  whitespace
   """
 // CHECK: "trailing "
 // CHECK: "substring1 "
 // CHECK: "substring2 substring3"
-// CHECK: " whitepsace"
+// CHECK: " whitespace"
 
-// contains trailing whitepsace
+// contains trailing whitespace
 _ = """
     foo\ 
 
@@ -144,7 +144,7 @@ _ = """
     """
 // CHECK: "foo\nbar"
 
-// contains trailing whitepsace
+// contains trailing whitespace
 _ = """
     foo\ 
     

--- a/test/Parse/omit_return.swift
+++ b/test/Parse/omit_return.swift
@@ -1700,7 +1700,7 @@ class D_optionalTryUnusedImplicit {
 
 
 
-// Miscellanceous
+// Miscellaneous
 
 class CSuperExpr_Base { init() {} }
 class CSuperExpr_Derived : CSuperExpr_Base { override init() { super.init() } }

--- a/test/Parse/omit_return.swift
+++ b/test/Parse/omit_return.swift
@@ -477,8 +477,8 @@ func ff_implicitTupleShuffle(_ input: (one: Int, two: Int)) -> (two: Int, one: I
     input // expected-warning {{expression shuffles the elements of this tuple; this behavior is deprecated}}
 }
 
-func ff_implicitCollectionUpcast(_ deriveds: [Derived]) -> [Base] {
-    deriveds
+func ff_implicitCollectionUpcast(_ derived: [Derived]) -> [Base] {
+    derived
 }
 
 func ff_implicitErasureExpr(_ conformer: SomeProtoConformer) -> SomeProto {

--- a/test/Parse/omit_return_ifdecl.swift
+++ b/test/Parse/omit_return_ifdecl.swift
@@ -680,9 +680,9 @@ func ff_implicitTupleShuffle(_ input: (one: Int, two: Int)) -> (two: Int, one: I
     #endif
 }
 
-func ff_implicitCollectionUpcast(_ deriveds: [Derived]) -> [Base] {
+func ff_implicitCollectionUpcast(_ derived: [Derived]) -> [Base] {
     #if true
-    deriveds
+    derived
     #endif
 }
 

--- a/test/Parse/omit_return_ifdecl.swift
+++ b/test/Parse/omit_return_ifdecl.swift
@@ -2421,7 +2421,7 @@ class D_optionalTryUnusedImplicit {
 
 
 
-// Miscellanceous
+// Miscellaneous
 
 class CSuperExpr_Base { init() {} }
 class CSuperExpr_Derived : CSuperExpr_Base { override init() { super.init() } }

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -807,7 +807,7 @@ func test23086402(a: A23086402) {
 
 // <rdar://problem/23550816> QoI: Poor diagnostic in argument list of "print" (varargs related)
 // The situation has changed. String now conforms to the RangeReplaceableCollection protocol
-// and `ss + s` becomes ambiguous. Diambiguation is provided with the unavailable overload
+// and `ss + s` becomes ambiguous. Disambiguation is provided with the unavailable overload
 // in order to produce a meaningful diagnostics. (Related: <rdar://problem/31763930>)
 func test23550816(ss: [String], s: String) {
   print(ss + s)  // expected-error {{'+' is unavailable: Operator '+' cannot be used to append a String to a sequence of strings}}

--- a/test/Parse/self_rebinding.swift
+++ b/test/Parse/self_rebinding.swift
@@ -102,7 +102,7 @@ struct TypeWithSelfComputedVar {
     }
 }
 
-/// Test fix_unqualified_access_member_named_self doesn't appear appear for property called `self`
+/// Test fix_unqualified_access_member_named_self doesn't appear for property called `self`
 /// it can't currently be referenced as a static member -- unlike a method with the same name
 struct TypeWithSelfProperty {
     


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fixes some misspellings in Swift parse, it is split per https://github.com/apple/swift/pull/42421#issuecomment-1101092698


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
