### PR TITLE
Spelling sil

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Effects.swift
+++ b/SwiftCompilerSources/Sources/SIL/Effects.swift
@@ -262,7 +262,7 @@ extension StringParser {
       }
       if function.numIndirectResultArguments > 0 {
         if function.numIndirectResultArguments != 1 {
-          try throwError("mutli-value returns not supported yet")
+          try throwError("multi-value returns not supported yet")
         }
         value = .argument(0)
       } else {

--- a/SwiftCompilerSources/Sources/SIL/Effects.swift
+++ b/SwiftCompilerSources/Sources/SIL/Effects.swift
@@ -274,7 +274,7 @@ extension StringParser {
       }
       value = .argument(argIdx + function.numIndirectResultArguments)
     } else {
-      try throwError("paramter name or return expected")
+      try throwError("parameter name or return expected")
     }
 
     let valueType: Type

--- a/SwiftCompilerSources/Sources/SIL/Effects.swift
+++ b/SwiftCompilerSources/Sources/SIL/Effects.swift
@@ -93,7 +93,7 @@ public struct ArgumentEffect : CustomStringConvertible, CustomReflectable {
   public enum Kind {
     /// The selected argument value does not escape.
     ///
-    /// Synatx examples:
+    /// Syntax examples:
     ///    !%0       // argument 0 does not escape
     ///    !%0.**    // argument 0 and all transitively contained values do not escape
     ///
@@ -101,7 +101,7 @@ public struct ArgumentEffect : CustomStringConvertible, CustomReflectable {
     
     /// The selected argument value escapes to the specified selection (= first payload).
     ///
-    /// Synatx examples:
+    /// Syntax examples:
     ///    %0.s1 => %r   // field 2 of argument 0 exclusively escapes via return.
     ///    %0.s1 -> %1   // field 2 of argument 0 - and other values - escape to argument 1.
     ///

--- a/SwiftCompilerSources/Sources/SIL/SubstitutionMap.swift
+++ b/SwiftCompilerSources/Sources/SIL/SubstitutionMap.swift
@@ -1,4 +1,4 @@
-//===--- PassUtils.swift - Utilities for optimzation passes ---------------===//
+//===--- PassUtils.swift - Utilities for optimization passes ---------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/SIL/AbstractionPattern.h
+++ b/include/swift/SIL/AbstractionPattern.h
@@ -679,7 +679,7 @@ public:
   /// imported as a method.
   ///
   /// For example, if the original function is:
-  ///   void CCRefrigatorSetTemperature(CCRefrigeratorRef fridge,
+  ///   void CCRefrigeratorSetTemperature(CCRefrigeratorRef fridge,
   ///                                   CCRefrigeratorCompartment compartment,
   ///                                   CCTemperature temperature);
   /// then the uncurried type is:
@@ -699,7 +699,7 @@ public:
   /// C function imported as a method.
   ///
   /// For example, if the original function is:
-  ///   void CCRefrigatorSetTemperature(CCRefrigeratorRef fridge,
+  ///   void CCRefrigeratorSetTemperature(CCRefrigeratorRef fridge,
   ///                                   CCRefrigeratorCompartment compartment,
   ///                                   CCTemperature temperature);
   /// then the curried type is:
@@ -840,7 +840,7 @@ private:
   /// type of a C function imported as a method.
   ///
   /// For example, if the original function is:
-  ///   CCRefrigatorSetTemperature(CCRefrigeratorRef, CCTemperature)
+  ///   CCRefrigeratorSetTemperature(CCRefrigeratorRef, CCTemperature)
   /// then the curried type is:
   ///   (CCRefrigerator) -> (CCTemperature) -> ()
   /// and the partially-applied curried type is:

--- a/include/swift/SIL/ApplySite.h
+++ b/include/swift/SIL/ApplySite.h
@@ -329,7 +329,7 @@ public:
     case ApplySiteKind::PartialApplyInst:
       // The arguments to partial_apply are a suffix of the partial_apply's
       // callee. Note that getSubstCalleeConv is function type of the callee
-      // argument passed to this apply, not necessarilly the function type of
+      // argument passed to this apply, not necessarily the function type of
       // the underlying callee function (i.e. it is based on the `getCallee`
       // type, not the `getCalleeOrigin` type).
       //

--- a/include/swift/SIL/BasicBlockDatastructures.h
+++ b/include/swift/SIL/BasicBlockDatastructures.h
@@ -29,7 +29,7 @@ namespace swift {
 /// Unfortunately it's not possible to use `llvm::SetVector` directly because
 /// the BasicBlockSet and StackList constructors needs a `SILFunction` argument.
 ///
-/// Note: This class does not provide a `remove` method intentinally, because
+/// Note: This class does not provide a `remove` method intentionally, because
 /// it would have a O(n) complexity.
 class BasicBlockSetVector {
   StackList<SILBasicBlock *> vector;

--- a/include/swift/SIL/BasicBlockUtils.h
+++ b/include/swift/SIL/BasicBlockUtils.h
@@ -127,7 +127,7 @@ protected:
 ///      loop-nest relative to \p dominatingBlock causing us to go around a
 ///      backedge and hit the block during our traversal. In this case, we
 ///      have already during the traversal passed the exiting blocks of the
-///      sub-loop as joint postdominace completion set blocks. This is useful
+///      sub-loop as joint postdominance completion set blocks. This is useful
 ///      if one is using this API for lifetime extension purposes of lifetime
 ///      ending uses and one needs to insert compensating copy_value at these
 ///      locations due to the lack of strong control-equivalence in between

--- a/include/swift/SIL/DynamicCasts.h
+++ b/include/swift/SIL/DynamicCasts.h
@@ -67,7 +67,7 @@ DynamicCastFeasibility classifyDynamicCast(
     ModuleDecl *context,
     CanType sourceType, CanType targetType,
     bool isSourceTypeExact = false,
-    bool isWholdModuleOpts = false);
+    bool isWholeModuleOpts = false);
 
 SILValue emitSuccessfulScalarUnconditionalCast(SILBuilder &B, SILLocation loc,
                                                SILDynamicCastInst inst);

--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -367,7 +367,7 @@ protected:
     // Define bits for use in the AccessEnforcementOpts pass. Each begin_access
     // in the function is mapped to one instance of this subclass.  Reserve a
     // bit for a seenNestedConflict flag, which is the per-begin-access result
-    // of pass-specific analysis. The remaning bits are sufficient to index all
+    // of pass-specific analysis. The remaining bits are sufficient to index all
     // begin_[unpaired_]access instructions.
     //
     // `AccessRepresentation` refers to the AccessRepresentationBitfield defined

--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -991,7 +991,7 @@ namespace swift {
 /// this, we instead consider it an invalid AccessPath. This is the only case in
 /// which AccessPath::storage can differ from AccessStorage::compute().
 ///
-/// Storing an AccessPath ammortizes to constant space. To cache identification
+/// Storing an AccessPath amortizes to constant space. To cache identification
 /// of address locations, AccessPath should be used rather than the
 /// ProjectionPath which requires quadratic space in the number of address
 /// values and quadratic time when comparing addresses.

--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -567,7 +567,7 @@ private:
 /// The base of a formal access.
 ///
 /// Note that the SILValue that represents a storage object is not
-/// necessarilly an address type. It may instead be a SILBoxType. So, even
+/// necessarily an address type. It may instead be a SILBoxType. So, even
 /// though address phis are not allowed, finding the base of an access may
 /// require traversing phis.
 class AccessBase : public AccessRepresentation {

--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -559,7 +559,7 @@ public:
 private:
   // Disable direct comparison because we allow subclassing with bitfields.
   // Currently, we use DenseMapInfo to unique storage, which defines key
-  // equalilty only in terms of the base AccessStorage class bits.
+  // equality only in terms of the base AccessStorage class bits.
   bool operator==(const AccessRepresentation &) const = delete;
   bool operator!=(const AccessRepresentation &) const = delete;
 };

--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -267,7 +267,7 @@ enum class AccessUseType { Exact, Inner, Overlapping };
 /// The enum values are ordered.  Each successive cast kind is more
 /// transformative than the last.
 ///
-/// TODO: Distinguish between LayoutEquivalent and LayoutCompatibile.
+/// TODO: Distinguish between LayoutEquivalent and LayoutCompatible.
 enum class AccessStorageCast { Identity, Type };
 
 /// The physical representation used to identify access information and common

--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -1199,7 +1199,7 @@ public:
 
 // Encapsulate the result of computing an AccessPath. AccessPath does not store
 // the base address of the formal access because it does not always uniquely
-// indentify the access, but AccessPath users may use the base address to to
+// identify the access, but AccessPath users may use the base address to to
 // recover the def-use chain for a specific global_addr or ref_element_addr.
 struct AccessPathWithBase {
   AccessPath accessPath;

--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -1819,7 +1819,7 @@ public:
 
   // Secondary entry point to check that cloning will succeed.
   bool canCloneUseDefChain(SILValue addr) {
-    // Use any valid address as a placeholder. It is innaccessible.
+    // Use any valid address as a placeholder. It is inaccessible.
     placeHolder = addr;
     return cloneRecursive(addr);
   }

--- a/include/swift/SIL/MemoryLocations.h
+++ b/include/swift/SIL/MemoryLocations.h
@@ -113,7 +113,7 @@ public:
     ///    location 4 (Inner.b):     [           4]
     /// \endcode
     ///
-    /// Bit 2 is never set because Inner is completly represented by its
+    /// Bit 2 is never set because Inner is completely represented by its
     /// sub-locations 3 and 4. But bit 0 is set in location 0 (the "self" bit),
     /// because it represents the untracked field ``Outer.z``.
     ///

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -543,7 +543,7 @@ struct BorrowedValue {
   /// called with a scope that is not local.
   ///
   /// NOTE: To determine if a scope is a local scope, call
-  /// BorrowScopeIntoducingValue::isLocalScope().
+  /// BorrowScopeIntroducingValue::isLocalScope().
   void getLocalScopeEndingInstructions(
       SmallVectorImpl<SILInstruction *> &scopeEndingInsts) const;
 
@@ -559,7 +559,7 @@ struct BorrowedValue {
   /// instructions before storing them.
   ///
   /// NOTE: To determine if a scope is a local scope, call
-  /// BorrowScopeIntoducingValue::isLocalScope().
+  /// BorrowScopeIntroducingValue::isLocalScope().
   bool visitLocalScopeEndingUses(function_ref<bool(Operand *)> visitor) const;
 
   bool isLocalScope() const { return kind.isLocalScope(); }

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -799,7 +799,7 @@ struct InteriorPointerOperand {
   }
 
   /// If \p val is a result of an instruction that is an interior pointer,
-  /// return an interor pointer operand based off of the base value operand of
+  /// return an interior pointer operand based off of the base value operand of
   /// the instruction.
   static InteriorPointerOperand inferFromResult(SILValue resultValue) {
     auto kind = InteriorPointerOperandKind::inferFromResult(resultValue);

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -93,7 +93,7 @@ inline bool isForwardingConsume(SILValue value) {
 /// scope (doing so would be extremely inefficient). The lifetime of a borrow
 /// introducing instruction is always determined by its direct EndBorrow uses
 /// (see BorrowedValue::visitLocalScopeEndingUses). None of the non-scope-ending
-/// uses are relevant, and there's no need to transively follow forwarding
+/// uses are relevant, and there's no need to transitively follow forwarding
 /// uses. However, this utility may be used on borrow-introducing values when
 /// updating OSSA form to place EndBorrow uses after introducing new phis.
 ///

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -865,7 +865,7 @@ struct InteriorPointerOperand {
   }
 
   /// Transitively compute the list of leaf uses that this interior pointer
-  /// operand puts on its parent guaranted value.
+  /// operand puts on its parent guaranteed value.
   ///
   /// If \p foundUses is nullptr, this simply returns true if no PointerEscapes
   /// were found.

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -136,7 +136,7 @@ bool findExtendedUsesOfSimpleBorrowedValue(
 /// valid BorrowedValue), then its uses are discovered transitively by looking
 /// through forwarding operations. If any use is a PointerEscape, then this
 /// returns false without adding more uses--the guaranteed value's lifetime is
-/// indeterminite. If a use introduces a nested borrow scope, it creates use
+/// indeterminate. If a use introduces a nested borrow scope, it creates use
 /// points where the "extended" borrow scope ends. An extended borrow
 /// scope is found by looking through any reborrows that end the nested
 /// scope. Other uses within nested borrow scopes are ignored.

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -1011,7 +1011,7 @@ public:
     /// An owned value from the formation of a new alloc_box.
     AllocBoxInit,
 
-    /// An owned value from the formataion of a new alloc_ref.
+    /// An owned value from the formation of a new alloc_ref.
     AllocRefInit,
   };
 

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -90,7 +90,7 @@ inline bool isForwardingConsume(SILValue value) {
 /// borrow scope and may be reborrowed.
 ///
 /// In valid OSSA, this should never be called on values that introduce a new
-/// scope (doing so would be extremely innefficient). The lifetime of a borrow
+/// scope (doing so would be extremely inefficient). The lifetime of a borrow
 /// introducing instruction is always determined by its direct EndBorrow uses
 /// (see BorrowedValue::visitLocalScopeEndingUses). None of the non-scope-ending
 /// uses are relevant, and there's no need to transively follow forwarding

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -901,7 +901,7 @@ private:
 /// scope and interiorPointerOp is irrelevant.
 ///
 /// If hasOwnership() is true, then interiorPointerOp refers to the operand that
-/// converts a non-address value into the address from which the contructor's
+/// converts a non-address value into the address from which the constructor's
 /// address is derived. If the best-effort to find an InteriorPointerOperand
 /// fails, then interiorPointerOp remains invalid, and clients must be
 /// conservative.

--- a/include/swift/SIL/PrunedLiveness.h
+++ b/include/swift/SIL/PrunedLiveness.h
@@ -384,7 +384,7 @@ struct PrunedLivenessBoundary {
   /// If the jointly post-dominating destroys do not include dead end paths,
   /// then any uses on those paths will not be included in the boundary. The
   /// resulting partial boundary will have holes along those paths. The dead end
-  /// successors of blocks in this live set on are not necessarilly identified
+  /// successors of blocks in this live set on are not necessarily identified
   /// by DeadEndBlocks.
   void compute(const PrunedLiveness &liveness,
                ArrayRef<SILBasicBlock *> postDomBlocks);

--- a/include/swift/SIL/PrunedLiveness.h
+++ b/include/swift/SIL/PrunedLiveness.h
@@ -26,7 +26,7 @@
 /// Dead, LiveWithin, LiveOut.
 ///
 /// A LiveWithin block has a liveness boundary within the block. The client can
-/// determine the boundary's intruction position by searching for the last use.
+/// determine the boundary's instruction position by searching for the last use.
 ///
 /// LiveOut indicates that liveness extends into a successor edges, therefore,
 /// no uses within that block can be on the liveness boundary, unless that use

--- a/include/swift/SIL/PrunedLiveness.h
+++ b/include/swift/SIL/PrunedLiveness.h
@@ -199,7 +199,7 @@ protected:
 /// if they don't occur on the liveness boundary. Lifetime-ending uses that end
 /// up on the final liveness boundary may be used to end the lifetime. It is up
 /// to the client to determine which uses are potentially lifetime-ending. In
-/// OSSA, the lifetime-ending property might be detemined by
+/// OSSA, the lifetime-ending property might be determined by
 /// OwnershipConstraint::isLifetimeEnding(). In non-OSSA, it might be determined
 /// by deallocation. If a lifetime-ending use ends up within the liveness
 /// boundary, then it is up to the client to figure out how to "extend" the

--- a/include/swift/SIL/RuntimeEffect.h
+++ b/include/swift/SIL/RuntimeEffect.h
@@ -46,7 +46,7 @@ enum class RuntimeEffect : unsigned {
 
   /// The runtime function performs exclusivity checking.
   /// This does not have any observable runtime effect like locking or
-  /// allocation, but it's modelled separatly.
+  /// allocation, but it's modelled separately.
   ExclusivityChecking = 0x100,
 
   /// The runtime function calls ObjectiveC methods.

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -46,7 +46,7 @@ class SILBuilderContext {
 
   SILModule &Module;
 
-  /// Allow the SIL module conventions to be overriden within the builder.
+  /// Allow the SIL module conventions to be overridden within the builder.
   /// This supports passes that lower SIL to a new stage.
   SILModuleConventions silConv = SILModuleConventions(Module);
 

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -189,7 +189,7 @@ public:
 
   SubstitutionMap getOpSubstitutionMap(SubstitutionMap Subs) {
     // If we have open existentials to substitute, check whether that's
-    // relevant to this this particular substitution.
+    // relevant to this particular substitution.
     if (!OpenedExistentialSubs.empty()) {
       for (auto ty : Subs.getReplacementTypes()) {
         // If we found a type containing an opened existential, substitute

--- a/include/swift/SIL/SILConstants.h
+++ b/include/swift/SIL/SILConstants.h
@@ -695,7 +695,7 @@ private:
   // known.
   bool hasNonConstantCaptures = true;
 
-  // A substitution map that partially maps the generic paramters of the
+  // A substitution map that partially maps the generic parameters of the
   // applied function to the generic arguments of passed to the call.
   SubstitutionMap substitutionMap;
 

--- a/include/swift/SIL/SILConstants.h
+++ b/include/swift/SIL/SILConstants.h
@@ -53,7 +53,7 @@ public:
 
   /// Allocate storage for a given number of elements of a specific type
   /// provided as a template parameter. Precondition: \c T must have an
-  /// accesible zero argument constructor.
+  /// accessible zero argument constructor.
   /// \param numElts number of elements of the type to allocate.
   template <typename T> T *allocate(unsigned numElts) {
     T *res = (T *)allocate(sizeof(T) * numElts, alignof(T));

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -9309,7 +9309,7 @@ public:
   }
 };
 
-/// LinearFunctionInst - given a function, its derivative and traspose functions,
+/// LinearFunctionInst - given a function, its derivative and transpose functions,
 /// create an `@differentiable(_linear)` function that represents a bundle of these.
 class LinearFunctionInst final
     : public InstructionBaseWithTrailingOperands<

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -121,11 +121,11 @@ StringRef getSILInstructionName(SILInstructionKind Kind);
 /// that just from the number of elements we can infer the size of each element
 /// due to the restricted problem space. Specificially:
 ///
-/// 1. Size == 0 implies nothing is stored and thus element size is irrelevent.
+/// 1. Size == 0 implies nothing is stored and thus element size is irrelevant.
 /// 2. Size == 1 implies we either had a single value instruction or a multiple
 /// value instruction, but no matter what instruction we had, we are going to
 /// store the results at the same starting location so element size is
-/// irrelevent.
+/// irrelevant.
 /// 3. Size > 1 implies we must be storing multiple value instruction results
 /// implying that the size of each stored element must be
 /// sizeof(MultipleValueInstructionResult).

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -5875,7 +5875,7 @@ class SetDeallocatingInst
 
 /// ObjectInst - Represents a object value type.
 ///
-/// This instruction can only appear at the end of a gobal variable's
+/// This instruction can only appear at the end of a global variable's
 /// static initializer list.
 class ObjectInst final : public InstructionBaseWithTrailingOperands<
                              SILInstructionKind::ObjectInst, ObjectInst,

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -854,7 +854,7 @@ public:
 };
 
 inline SILNode *SILInstruction::asSILNode() {
-  // Even if this insttruction is not a NonSingleValueInstruction, but a
+  // Even if this instruction is not a NonSingleValueInstruction, but a
   // SingleValueInstruction, the SILNode is at the same offset as in a
   // NonSingleValueInstruction. See the top-level comment of SILInstruction.
   SILNode *node = (NonSingleValueInstruction *)this;

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -119,7 +119,7 @@ StringRef getSILInstructionName(SILInstructionKind Kind);
 ///
 /// *NOTE* The reason why this does not store the size of the stored element is
 /// that just from the number of elements we can infer the size of each element
-/// due to the restricted problem space. Specificially:
+/// due to the restricted problem space. Specifically:
 ///
 /// 1. Size == 0 implies nothing is stored and thus element size is irrelevant.
 /// 2. Size == 1 implies we either had a single value instruction or a multiple

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -2277,7 +2277,7 @@ public:
     return getAllOperands().slice(getNumTailTypes() + 1);
   }
   // Is the deinit and the size of the dynamic type known to be equivalent to
-  // the the base type (i.e `this->getType()`).
+  // the base type (i.e `this->getType()`).
   bool isDynamicTypeDeinitAndSizeKnownEquivalentToBaseType() const;
 };
 

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -9512,7 +9512,7 @@ SILFunction *ApplyInstBase<Impl, Base, false>::getCalleeFunction() const {
   SILValue Callee = getCalleeOrigin();
 
   while (true) {
-    // Intentionally don't lookup throught dynamic_function_ref and
+    // Intentionally don't lookup through dynamic_function_ref and
     // previous_dynamic_function_ref as the target of those functions is not
     // statically known.
     if (auto *FRI = dyn_cast<FunctionRefInst>(Callee))

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1374,7 +1374,7 @@ public:
   /// end of the specific subclass object.
   ///
   /// *NOTE* subclassDeltaOffset must be use only 5 bits. This gives us to
-  /// support subclasses up to 32 bytes in size. We can scavange up to 6 more
+  /// support subclasses up to 32 bytes in size. We can scavenge up to 6 more
   /// bits from ValueBase if this is not large enough.
   MultipleValueInstructionResult(unsigned index, SILType type,
                                  ValueOwnershipKind ownershipKind);

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -170,7 +170,7 @@ public:
     /// Link functions with shared linkage. Used by the mandatory pipeline.
     LinkNormal,
 
-    /// Link all functions. Used by the performance pipeine.
+    /// Link all functions. Used by the performance pipeline.
     LinkAll
   };
 

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -334,7 +334,7 @@ private:
   /// A mapping from root opened archetypes to the instructions which define
   /// them.
   ///
-  /// The value is either a SingleValueInstrution or a PlaceholderValue, in case
+  /// The value is either a SingleValueInstruction or a PlaceholderValue, in case
   /// an opened archetype definition is looked up during parsing or
   /// deserializing SIL, where opened archetypes can be forward referenced.
   ///

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -274,7 +274,7 @@ private:
   /// Declarations which are externally visible.
   ///
   /// These are method declarations which are referenced from inlinable
-  /// functions due to cross-module-optimzation. Those declarations don't have
+  /// functions due to cross-module-optimization. Those declarations don't have
   /// any attributes or linkage which mark them as externally visible by
   /// default.
   /// Currently this table is not serialized.

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -935,7 +935,7 @@ public:
   /// See scheduledForDeletion for details.
   void scheduleForDeletion(SILInstruction *I);
 
-  /// Deletes all scheuled instructions for real.
+  /// Deletes all scheduled instructions for real.
   /// See scheduledForDeletion for details.
   void flushDeletedInsts();
 

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -684,7 +684,7 @@ public:
 
   // This is currently limited to VarDecl because the visibility of global
   // variables and class properties is straightforward, while the visibility of
-  // class methods (ValueDecls) depends on the subclass scope. "Visiblity" has
+  // class methods (ValueDecls) depends on the subclass scope. "Visibility" has
   // a different meaning when vtable layout is at stake.
   bool isVisibleExternally(const VarDecl *decl) {
     return isPossiblyUsedExternally(getDeclSILLinkage(decl), isWholeModule());

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -431,7 +431,7 @@ public:
   /// e.g. an open_existential_addr.
   ///
   /// In case the opened archetype is not defined yet (e.g. during parsing or
-  /// deserilization), a PlaceholderValue is returned. This should not be the
+  /// deserialization), a PlaceholderValue is returned. This should not be the
   /// case outside of parsing or deserialization.
   SILValue getRootOpenedArchetypeDef(CanOpenedArchetypeType archetype,
                                      SILFunction *inFunction);

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -304,7 +304,7 @@ public:
   bool isAddressOnly(const SILFunction &F) const;
 
   /// True if the underlying AST type is trivial, meaning it is loadable and can
-  /// be trivially copied, moved or detroyed. Returns false for address types
+  /// be trivially copied, moved or destroyed. Returns false for address types
   /// even though they are technically trivial.
   bool isTrivial(const SILFunction &F) const;
 

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -501,7 +501,7 @@ public:
   }
 
   /// Return the reference ownership of this type if it is a reference storage
-  /// type. Otherwse, return None.
+  /// type. Otherwise, return None.
   Optional<ReferenceOwnership> getReferenceStorageOwnership() const {
     auto type = getASTType()->getAs<ReferenceStorageType>();
     if (!type)

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -309,7 +309,7 @@ struct ValueOwnershipKind {
   OperandOwnership getForwardingOperandOwnership(bool allowUnowned) const;
 
   /// Returns true if \p Other can be merged successfully with this, implying
-  /// that the two ownership kinds are "compatibile".
+  /// that the two ownership kinds are "compatible".
   ///
   /// The reason why we do not compare directy is to allow for
   /// OwnershipKind::None to merge into other forms of ValueOwnershipKind.

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -421,7 +421,7 @@ public:
     DirectChildren, ///> Expand the value into its direct children and place
                     ///> operations on the children.
     MostDerivedDescendents, ///> Expand the value into its most derived
-                            ///> substypes and perform operations on these
+                            ///> subtypes and perform operations on these
                             ///> types.
   };
 

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -430,7 +430,7 @@ OperandOwnershipClassifier::visitStoreBorrowInst(StoreBorrowInst *i) {
   return OperandOwnership::TrivialUse;
 }
 
-// Get the OperandOwnership for instaneous apply, yield, and return uses.
+// Get the OperandOwnership for instantaneous apply, yield, and return uses.
 // This does not apply to uses that begin an explicit borrow scope in the
 // caller, such as begin_apply.
 static OperandOwnership getFunctionArgOwnership(SILArgumentConvention argConv,

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -39,7 +39,7 @@ namespace {
 class OperandOwnershipClassifier
   : public SILInstructionVisitor<OperandOwnershipClassifier, OperandOwnership> {
   LLVM_ATTRIBUTE_UNUSED SILModule &mod;
-  // Allow module conventions to be overriden while lowering between canonical
+  // Allow module conventions to be overridden while lowering between canonical
   // and lowered SIL stages.
   SILModuleConventions silConv;
 

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -271,7 +271,7 @@ OPERAND_OWNERSHIP(InteriorPointer, OpenExistentialBox)
 OPERAND_OWNERSHIP(InteriorPointer, HopToExecutor)
 OPERAND_OWNERSHIP(InteriorPointer, ExtractExecutor)
 
-// Instructions that propagate a value value within a borrow scope.
+// Instructions that propagate a value within a borrow scope.
 OPERAND_OWNERSHIP(ForwardingBorrow, TupleExtract)
 OPERAND_OWNERSHIP(ForwardingBorrow, StructExtract)
 OPERAND_OWNERSHIP(ForwardingBorrow, DifferentiableFunctionExtract)

--- a/lib/SIL/IR/SILBuilder.cpp
+++ b/lib/SIL/IR/SILBuilder.cpp
@@ -638,7 +638,7 @@ void SILBuilder::emitScopedBorrowOperation(SILLocation loc, SILValue original,
 /// copy. This does require the client code to handle ending the lifetime of an
 /// owned result even if the input was passed as guaranteed.
 ///
-/// Note: For simplicitly, ownership None is not propagated for any statically
+/// Note: For simplicity, ownership None is not propagated for any statically
 /// nontrivial result, even if \p targetType may also be dynamically
 /// trivial. For example, the operand of a switch_enum could be a nested enum
 /// such that all switch cases may be dynamically trivial. Or a checked_cast_br

--- a/lib/SIL/IR/SILConstants.cpp
+++ b/lib/SIL/IR/SILConstants.cpp
@@ -378,7 +378,7 @@ unsigned SymbolicValue::getIntegerValueBitWidth() const {
 // Returns a SymbolicValue representing a UTF-8 encoded string.
 SymbolicValue SymbolicValue::getString(StringRef string,
                                        SymbolicValueAllocator &allocator) {
-  // TODO: Could have an inline representation for strings if thre was demand,
+  // TODO: Could have an inline representation for strings if there was demand,
   // just store a char[8] as the storage.
 
   auto *resultPtr = allocator.allocate<char>(string.size());

--- a/lib/SIL/IR/SILDebugInfoExpression.cpp
+++ b/lib/SIL/IR/SILDebugInfoExpression.cpp
@@ -12,7 +12,7 @@
 ///
 /// \file
 /// This file contains the table used by SILDIExprInfo to map from
-/// SILDIExprOperator to suppliment information like the operator string.
+/// SILDIExprOperator to supplement information like the operator string.
 ///
 //===----------------------------------------------------------------------===//
 

--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -322,7 +322,7 @@ SILFunction *SILFunctionBuilder::getOrCreateFunction(
         F->setSpecialPurpose(SILFunction::Purpose::LazyPropertyGetter);
         
         // Lazy property getters should not get inlined because they are usually
-        // non-tivial functions (otherwise the user would not implement it as
+        // non-trivial functions (otherwise the user would not implement it as
         // lazy property). Inlining such getters would most likely not benefit
         // other optimizations because the top-level switch_enum cannot be
         // constant folded in most cases.

--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -125,7 +125,7 @@ void SILFunctionBuilder::addFunctionAttributes(
     if (ParameterList *paramList = fnDecl->getParameters()) {
       for (ParamDecl *pd : *paramList) {
         // Give up on tuples. Their elements are added as individual
-        // argumenst. It destroys the 1-1 relation ship between parameters
+        // arguments. It destroys the 1-1 relation ship between parameters
         // and arguments.
         if (isa<TupleType>(CanType(pd->getType())))
           break;

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -2279,7 +2279,7 @@ struct DefaultAllocatorConventions : DefaultConventions {
   }
 };
 
-/// The default conventions for Swift setter acccessors.
+/// The default conventions for Swift setter accessories.
 ///
 /// These take self at +0, but all other parameters at +1. This is because we
 /// assume that setter parameters are likely to be values to be forwarded into

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -4630,7 +4630,7 @@ static bool areABICompatibleParamsOrReturns(SILType a, SILType b,
 
     // Opaque types are compatible with their substitution.
     if (inFunction) {
-      auto opaqueTypesSubsituted = aa;
+      auto opaqueTypesSubstituted = aa;
       auto *dc = inFunction->getDeclContext();
       auto *currentModule = inFunction->getModule().getSwiftModule();
       if (!dc || !dc->isChildContextOf(currentModule))
@@ -4639,15 +4639,15 @@ static bool areABICompatibleParamsOrReturns(SILType a, SILType b,
           dc, inFunction->getResilienceExpansion(),
           inFunction->getModule().isWholeModule());
       if (aa.getASTType()->hasOpaqueArchetype())
-        opaqueTypesSubsituted = aa.subst(inFunction->getModule(), replacer,
+        opaqueTypesSubstituted = aa.subst(inFunction->getModule(), replacer,
                                          replacer, CanGenericSignature(), true);
 
-      auto opaqueTypesSubsituted2 = bb;
+      auto opaqueTypesSubstituted2 = bb;
       if (bb.getASTType()->hasOpaqueArchetype())
-        opaqueTypesSubsituted2 =
+        opaqueTypesSubstituted2 =
             bb.subst(inFunction->getModule(), replacer, replacer,
                      CanGenericSignature(), true);
-      if (opaqueTypesSubsituted == opaqueTypesSubsituted2)
+      if (opaqueTypesSubstituted == opaqueTypesSubstituted2)
         continue;
     }
 

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -3969,7 +3969,7 @@ public:
 
     auto patternSubs = origType->getPatternSubstitutions();
 
-    // If we have an invocation signatture, we generally shouldn't
+    // If we have an invocation signature, we generally shouldn't
     // substitute into the pattern substitutions and component types.
     if (auto sig = origType->getInvocationGenericSignature()) {
       // Substitute the invocation substitutions if present.

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -716,7 +716,7 @@ static CanSILFunctionType getAutoDiffPullbackType(
         std::distance(originalFnTy->getParameters().begin(), &*inoutParamIt);
     auto inoutParam = originalFnTy->getParameters()[paramIndex];
     // The pullback parameter convention depends on whether the original `inout`
-    // paramater is a differentiability parameter.
+    // parameter is a differentiability parameter.
     // - If yes, the pullback parameter convention is `@inout`.
     // - If no, the pullback parameter convention is `@in_guaranteed`.
     auto inoutParamTanType = getAutoDiffTangentTypeForLinearMap(

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -3943,7 +3943,7 @@ public:
     //   add the appropriate invocation substitutions.
     //
     // - Otherwise, if there are pattern substitutions, just substitute
-    //   those; the other components are inside the patttern generic
+    //   those; the other components are inside the pattern generic
     //   signature.
     //
     // - Otherwise, substitute the basic components.

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -399,7 +399,7 @@ static CanGenericSignature buildDifferentiableGenericSignature(CanGenericSignatu
 
         // The GSB used to drop requirements which reference non-existent
         // generic parameters, whereas the RequirementMachine asserts now.
-        // Filter thes requirements out explicitly to preserve the old
+        // Filter these requirements out explicitly to preserve the old
         // behavior.
         if (std::find_if(genericParams.begin(), genericParams.end(),
                          [interfaceTy](CanGenericTypeParamType t) -> bool {

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1444,7 +1444,7 @@ SILInstructionResultArray::SILInstructionResultArray(
   auto *Value = static_cast<const ValueBase *>(SVI);
   assert(uintptr_t(Value) != uintptr_t(SVI) &&
          "Expected value to be offset from SVI since it is not the first "
-         "multi-inheritence parent");
+         "multi-inheritance parent");
   Pointer = reinterpret_cast<const uint8_t *>(Value);
 
 #ifndef NDEBUG

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -240,7 +240,7 @@ SILInstructionKind swift::getSILInstructionKind(StringRef name) {
   llvm::errs() << "Unknown SIL instruction name\n";
   abort();
 #endif
-  llvm_unreachable("Unknown SIL insruction name");
+  llvm_unreachable("Unknown SIL instruction name");
 }
 
 /// Map SILInstructionKind to a corresponding SILInstruction name.

--- a/lib/SIL/IR/SILModule.cpp
+++ b/lib/SIL/IR/SILModule.cpp
@@ -178,7 +178,7 @@ void SILModule::checkForLeaks() const {
                        
   if (numAllocated != instsInModule) {
     llvm::errs() << "Leaking instructions!\n";
-    llvm::errs() << "Alloated instructions: " << numAllocated << '\n';
+    llvm::errs() << "Allocated instructions: " << numAllocated << '\n';
     llvm::errs() << "Instructions in module: " << instsInModule << '\n';
     llvm_unreachable("leaking instructions");
   }

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2115,7 +2115,7 @@ TypeConverter::getTypeLowering(AbstractionPattern origType,
   auto loweredSubstType =
       computeLoweredRValueType(forExpansion, origType, substType);
 
-  // If that didn't change the type and the key is cachable, there's no
+  // If that didn't change the type and the key is cacheable, there's no
   // point in re-checking the table, so just construct a type lowering
   // and cache it.
   if (loweredSubstType == substType && key.isCacheable()) {

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -3317,7 +3317,7 @@ public:
     return (isa<SubstitutableType>(type) || isa<DependentMemberType>(type));
   };
 
-  // We can fast-path some of these checks by proviing these two overrides:
+  // We can fast-path some of these checks by providing these two overrides:
   bool visitSubstitutableType(CanSubstitutableType type1,
                               CanSubstitutableType type2) {
     return false;

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -1784,7 +1784,7 @@ namespace {
         //
         // Note: if the type is in a different module, the lowering does
         // not depend on the resilience expansion, so we do not need to set
-        // the isResilent() flag above.
+        // the isResilient() flag above.
         if (!sameModule || Expansion.getResilienceExpansion() ==
                                ResilienceExpansion::Minimal) {
           properties.addSubobject(RecursiveProperties::forOpaque());

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -3277,14 +3277,14 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
     break;
   }
   case SILInstructionKind::IsEscapingClosureInst: {
-    bool IsObjcVerifcationType = false;
-    if (parseSILOptional(IsObjcVerifcationType, *this, "objc"))
+    bool IsObjcVerificationType = false;
+    if (parseSILOptional(IsObjcVerificationType, *this, "objc"))
       return true;
     if (parseTypedValueRef(Val, B) || parseSILDebugLocation(InstLoc, B))
       return true;
     ResultVal = B.createIsEscapingClosure(
         InstLoc, Val,
-        IsObjcVerifcationType ? IsEscapingClosureInst::ObjCEscaping
+        IsObjcVerificationType ? IsEscapingClosureInst::ObjCEscaping
                               : IsEscapingClosureInst::WithoutActuallyEscaping);
     break;
   }

--- a/lib/SIL/Utils/DynamicCasts.cpp
+++ b/lib/SIL/Utils/DynamicCasts.cpp
@@ -295,7 +295,7 @@ static CanType getHashableExistentialType(ModuleDecl *M) {
 // Potentially bridged values:
 // - includes struct, enum, non-class archetype, non-class existential,
 //   and non-objc-metatype
-// - these types are potentially trivial after subsitution. If so, then they
+// - these types are potentially trivial after substitution. If so, then they
 //   convert to a reference when casting to AnyObject or certain classes
 //
 // Any and AnyObject existentials:

--- a/lib/SIL/Utils/DynamicCasts.cpp
+++ b/lib/SIL/Utils/DynamicCasts.cpp
@@ -279,7 +279,7 @@ static CanType getHashableExistentialType(ModuleDecl *M) {
 //
 //          let c = b as! C // releases __SwiftValue
 //
-// After unwrapping Optional, the type may fall into one one of
+// After unwrapping Optional, the type may fall into one of
 // the following categories that are relevant for cast ownership:
 //
 // Class-bound types (hasReferenceSemantics() && !isPotentiallyAnyObject())

--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -626,7 +626,7 @@ RuntimeEffect swift::getRuntimeEffect(SILInstruction *inst, SILType &impactType)
       return RuntimeEffect::MetaData | RuntimeEffect::RefCounting;
     return RuntimeEffect::MetaData;
   }
-  // Equialent to a copy_addr [init]
+  // Equivalent to a copy_addr [init]
   case SILInstructionKind::MarkUnresolvedMoveAddrInst: {
     return RuntimeEffect::MetaData | RuntimeEffect::RefCounting;
   }

--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -240,7 +240,7 @@ SILValue swift::stripBorrow(SILValue V) {
 // All instructions handled here must propagate their first operand into their
 // single result.
 //
-// This is guaranteed to handle all function-type converstions: ThinToThick,
+// This is guaranteed to handle all function-type conversions: ThinToThick,
 // ConvertFunction, and ConvertEscapeToNoEscapeInst.
 SingleValueInstruction *swift::getSingleValueCopyOrCast(SILInstruction *I) {
   if (auto *convert = dyn_cast<ConversionInst>(I))

--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -484,7 +484,7 @@ RuntimeEffect swift::getRuntimeEffect(SILInstruction *inst, SILType &impactType)
     return RuntimeEffect::NoEffect;
 
   case SILInstructionKind::DebugValueInst:
-    // Ignore runtime calls of debug_vlaue
+    // Ignore runtime calls of debug_value
     return RuntimeEffect::NoEffect;
 
   case SILInstructionKind::GetAsyncContinuationInst:

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -1525,7 +1525,7 @@ class AccessPathDefUseTraversal {
 
   // Indices of the path to match from inner to outer component.
   // A cursor is used to represent the most recently visited def.
-  // During def-use traversal, the cursor starts at the end of pathIndicies and
+  // During def-use traversal, the cursor starts at the end of pathIndices and
   // decrements with each projection.
   // The first index represents an exact match.
   // Index < 0 represents some subobject of the requested path.

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -1535,7 +1535,7 @@ class AccessPathDefUseTraversal {
   // prior to reaching the base address.
   struct DFSEntry {
     // Next potential use to visit and flag indicating whether traversal has
-    // reachaed the access base yet.
+    // reached the access base yet.
     llvm::PointerIntPair<Operand *, 1, bool> useAndIsRef;
     int pathCursor; // position within pathIndices
     int offset;     // index_addr offsets seen prior to this use

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -534,7 +534,7 @@ isDistinctFrom(const AccessRepresentation &other) const {
     // Any type of nested/argument address may be within the same object.
     //
     // We also currently assume Unidentified access may be within an object
-    // purely to handle KeyPath accesses. The deriviation of the KeyPath
+    // purely to handle KeyPath accesses. The derivation of the KeyPath
     // address must separately appear to be a Class access so that all Class
     // accesses are accounted for.
     return false;

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -2508,7 +2508,7 @@ static void visitBuiltinAddress(BuiltinInst *builtin,
   }
   if (auto ID = builtin->getIntrinsicID()) {
     switch (ID.getValue()) {
-      // Exhaustively verifying all LLVM instrinsics that access memory is
+      // Exhaustively verifying all LLVM intrinsics that access memory is
       // impractical. Instead, we call out the few common cases and return in
       // the default case.
     default:

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -1249,7 +1249,7 @@ class AccessPathVisitor : public FindAccessVisitorImpl<AccessPathVisitor> {
           pathLength(pathLength) {}
   };
 
-  // Only access projections affect this path. Since they are are not allowed
+  // Only access projections affect this path. Since they are not allowed
   // beyond phis, this path is not part of AccessPathVisitor::Result.
   llvm::SmallVector<AccessPath::Index, 8> reversePath;
   // Holds a non-zero value if an index_addr has been processed without yet

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -80,7 +80,7 @@ public:
       }
     }
     // If the result is now invalid, reset it and process the current phi as an
-    // unrecgonized access instead.
+    // unrecognized access instead.
     if (!useDefVisitor.isResultValid()) {
       useDefVisitor.restoreResult(savedResult);
       visitNonAccess(phiArg);

--- a/lib/SIL/Utils/MemoryLocations.cpp
+++ b/lib/SIL/Utils/MemoryLocations.cpp
@@ -422,7 +422,7 @@ bool MemoryLocations::analyzeAddrProjection(
              isa<InitExistentialAddrInst>(projection));
              
       // We can only handle a single enum payload type for a location or or a
-      // single concrete existential type. Mismatching types can have a differnt
+      // single concrete existential type. Mismatching types can have a different
       // number of (non-trivial) sub-locations and we cannot handle this.
       // But we ignore opened existential types, because those cannot have
       // sub-locations (there cannot be an address projection on an

--- a/lib/SIL/Utils/PrunedLiveness.cpp
+++ b/lib/SIL/Utils/PrunedLiveness.cpp
@@ -279,7 +279,7 @@ void PrunedLivenessBoundary::compute(const PrunedLiveness &liveness,
     switch (liveness.getBlockLiveness(bb)) {
     case PrunedLiveBlocks::LiveOut:
       // A lifetimeEndBlock may be determined to be LiveOut after analyzing the
-      // extended liveness. It is irrelevent for finding the boundary.
+      // extended liveness. It is irrelevant for finding the boundary.
       break;
     case PrunedLiveBlocks::LiveWithin: {
       // The liveness boundary is inside this block. Insert a final destroy

--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -694,10 +694,10 @@ BridgedInstruction SILBuilder_createBuiltinBinaryFunction(
 }
 
 BridgedInstruction SILBuilder_createCondFail(BridgedInstruction insertionPoint,
-          BridgedLocation loc, BridgedValue condition, BridgedStringRef messge) {
+          BridgedLocation loc, BridgedValue condition, BridgedStringRef message) {
   SILBuilder builder(castToInst(insertionPoint), getSILDebugScope(loc));
   return {builder.createCondFail(getRegularLocation(loc),
-    castToSILValue(condition), getStringRef(messge))};
+    castToSILValue(condition), getStringRef(message))};
 }
 
 BridgedInstruction SILBuilder_createIntegerLiteral(BridgedInstruction insertionPoint,

--- a/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
+++ b/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
@@ -23,7 +23,7 @@ using namespace swift;
 
 llvm::cl::opt<bool> DontAbortOnMemoryLifetimeErrors(
     "dont-abort-on-memory-lifetime-errors",
-    llvm::cl::desc("Don't abort compliation if the memory lifetime checker "
+    llvm::cl::desc("Don't abort compilation if the memory lifetime checker "
                    "detects an error."));
 
 namespace {

--- a/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
+++ b/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
@@ -304,7 +304,7 @@ void MemoryLifetimeVerifier::initDataflow(BitDataflow &dataFlow) {
     }
     bs.data.exitSet.set();
 
-    // Anything weired can happen in unreachable blocks. So just ignore them.
+    // Anything weird can happen in unreachable blocks. So just ignore them.
     // Note: while solving the dataflow, unreachable blocks are implicitly
     // ignored, because their entry/exit sets are all-ones and their gen/kill
     // sets are all-zeroes.

--- a/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
+++ b/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
@@ -629,7 +629,7 @@ void MemoryLifetimeVerifier::checkBlock(SILBasicBlock *block, Bits &bits) {
         // We don't want to check `debug_value` instructions that
         // are used to mark variable declarations (e.g. its SSA value is
         // an alloc_stack), which don't have any `op_deref` in its
-        // di-expression, because that memory does't need to be initialized
+        // di-expression, because that memory doesn't need to be initialized
         // when `debug_value` is referencing it.
         if (cast<DebugValueInst>(&I)->hasAddrVal() &&
             cast<DebugValueInst>(&I)->exprStartsWithDeref())

--- a/lib/SIL/Verifier/SILOwnershipVerifier.cpp
+++ b/lib/SIL/Verifier/SILOwnershipVerifier.cpp
@@ -797,7 +797,7 @@ void SILValue::verifyOwnership(DeadEndBlocks *deadEndBlocks) const {
   //
   // NOTE: We purposely return if we do can not look up a module here to ensure
   // that if we run into something that we do not understand, we do not assert
-  // in user code even tohugh we aren't going to actually verify (the default
+  // in user code even though we aren't going to actually verify (the default
   // behavior when -sil-verify-all is disabled).
   auto *mod = Value->getModule();
   if (!mod || !mod->getOptions().VerifyAll)
@@ -841,7 +841,7 @@ void SILFunction::verifyOwnership(DeadEndBlocks *deadEndBlocks) const {
   //
   // NOTE: We purposely return if we do can not look up a module here to ensure
   // that if we run into something that we do not understand, we do not assert
-  // in user code even tohugh we aren't going to actually verify (the default
+  // in user code even though we aren't going to actually verify (the default
   // behavior when -sil-verify-all is disabled).
   auto *mod = &getModule();
   if (!mod || !mod->getOptions().VerifyAll)

--- a/lib/SIL/Verifier/SILOwnershipVerifier.cpp
+++ b/lib/SIL/Verifier/SILOwnershipVerifier.cpp
@@ -669,7 +669,7 @@ bool SILValueOwnershipChecker::checkUses() {
     }
   }
 
-  // Check if we are an instruction that forwards forwards guaranteed
+  // Check if we are an instruction that forwards guaranteed
   // ownership. In such a case, we are a subobject projection. We should not
   // have any lifetime ending uses.
   if (value.getOwnershipKind() == OwnershipKind::Guaranteed

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1301,7 +1301,7 @@ public:
     if (!varInfo)
       return;
 
-    // Retrive debug variable type
+    // Retrieve debug variable type
     SILType DebugVarTy;
     if (varInfo->Type)
       DebugVarTy = *varInfo->Type;

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -5108,7 +5108,7 @@ public:
     require(IEC->getVerificationType() == IsEscapingClosureInst::ObjCEscaping ||
                 IEC->getVerificationType() ==
                     IsEscapingClosureInst::WithoutActuallyEscaping,
-            "unknown verfication type");
+            "unknown verification type");
   }
 
   void checkDifferentiableFunctionInst(DifferentiableFunctionInst *dfi) {

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -2304,7 +2304,7 @@ public:
     // those accesses.
     identifyFormalAccess(BAI);
     // FIXME: rdar://57291811 - the following check for valid storage will be
-    // reenabled shortly. A fix is planned. In the meantime, the possiblity that
+    // reenabled shortly. A fix is planned. In the meantime, the possibility that
     // a real miscompilation could be caused by this failure is insignificant.
     // I will probably enable a much broader SILVerification of address-type
     // block arguments first to ensure we never hit this check again.

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1949,9 +1949,9 @@ public:
           return true;
         if (t.getASTType() == t.getASTContext().TheNativeObjectType)
           return true;
-        if (auto clas = t.getClassOrBoundGenericClass())
+        if (auto clazz = t.getClassOrBoundGenericClass())
           // Must be a class defined in Swift.
-          return clas->hasKnownSwiftImplementation();
+          return clazz->hasKnownSwiftImplementation();
         return false;
       };
       

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -346,7 +346,7 @@ void verifyKeyPathComponent(SILModule &M,
       // TODO: This should probably be unconditionally +1 when we
       // can represent that.
       require(newValueParam.getConvention() == normalArgConvention,
-              "setter value parameter should havee normal arg convention");
+              "setter value parameter should have normal arg convention");
 
       auto baseParam = substSetterType->getParameters()[1];
       require(baseParam.getConvention() == normalArgConvention

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1011,7 +1011,7 @@ public:
 
         // Address-only values are potentially unmovable when borrowed. See also
         // checkOwnershipForwardingInst. A phi implies a move of its arguments
-        // because they can't necessarilly all reuse the same storage.
+        // because they can't necessarily all reuse the same storage.
         require((!arg->getType().isAddressOnly(F)
                  || arg->getOwnershipKind() != OwnershipKind::Guaranteed),
                 "Guaranteed address-only phi not allowed--implies a copy");

--- a/test/SIL/Parser/basic.sil
+++ b/test/SIL/Parser/basic.sil
@@ -1232,7 +1232,7 @@ bb0:
 
 // CHECK-LABEL: sil @test_alloc_stack_flags
 sil @test_alloc_stack_flags : $() -> () {
-  // CHECK: alloc_stack $Builtin.NativeObjec
+  // CHECK: alloc_stack $Builtin.NativeObject
   %instance = alloc_stack $Builtin.NativeObject
   dealloc_stack %instance : $*Builtin.NativeObject
   // CHECK: alloc_stack [dynamic_lifetime]

--- a/test/SIL/Parser/witness_tables.sil
+++ b/test/SIL/Parser/witness_tables.sil
@@ -108,7 +108,7 @@ extension ConditionalStruct : P where T : P {
 
 // CHECK-LABEL: sil_witness_table hidden <T where T : P> ConditionalStruct<T>: P module witness_tables {
 // CHECK-NEXT:    conditional_conformance (T: P): dependent
-// CHECL-NEXT:   }
+// CHECK-NEXT:   }
 sil_witness_table hidden <T where T : P> ConditionalStruct<T>: P module t4 {
   conditional_conformance (T: P): dependent
 }

--- a/test/SIL/Serialization/function-global-function.sil
+++ b/test/SIL/Serialization/function-global-function.sil
@@ -4,7 +4,7 @@ sil_stage canonical
 
 import Builtin
 
-// Check that we don't crash if a serialiable function is referenced from the
+// Check that we don't crash if a serializable function is referenced from the
 // initializer of a global variable.
 
 sil_global [serialized] @globalFuncPtr : $@callee_guaranteed () -> () = {

--- a/test/SIL/Serialization/public_external.sil
+++ b/test/SIL/Serialization/public_external.sil
@@ -53,7 +53,7 @@ sil shared @se : $@convention(thin) () -> () {
 // Check that external non-shared functions are serialized only
 // if they are referenced from something reachable from non-external functions.
 // Since all these fN functions are referenced only from an external function,
-// do not serialize even their declrations.
+// do not serialize even their declarations.
 
 // CHECK-NOT: sil{{.*}}@fn1 : $@convention(thin) () -> ()
 sil public_external [serialized] [noinline] @fn1 : $@convention(thin) () -> () {


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fixes some misspellings in Swift sil, it is split per https://github.com/apple/swift/pull/42421#issuecomment-1101092698


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
A naive split of just /SIL/ fails because of a couple of dependencies in SILOptimizer.