### PR TITLE
[build-presets] Re-enable SourceKit-LSP tests on Linux

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -876,8 +876,6 @@ foundation
 libdispatch
 indexstore-db
 sourcekit-lsp
-# SourceKit-LSP tests are flaky on Linux, disable them until we have fixed the root cause - rdar://90437872
-skip-test-sourcekit-lsp
 swiftdocc
 lit-args=-v --time-tests
 
@@ -1113,8 +1111,6 @@ swiftsyntax
 swiftsyntax-verify-generated-files
 indexstore-db
 sourcekit-lsp
-# SourceKit-LSP tests are flaky on Linux, disable them until we have fixed the root cause - rdar://89359439
-skip-test-sourcekit-lsp
 install-llvm
 install-swift
 install-llbuild
@@ -1687,9 +1683,6 @@ skip-test-libicu
 skip-test-foundation
 skip-test-libdispatch
 skip-test-xctest
-
-# SourceKit-LSP tests are flaky on Linux, disable them until we have fixed the root cause - rdar://90437872
-skip-test-sourcekit-lsp
 
 # Builds enough of the the toolchain to build a swift pacakge on macOS.
 [preset: mixin_swiftpm_package_macos_platform]


### PR DESCRIPTION
I haven’t been able to reproduce the test failure after running it 200 times locally. I think it’s been fixed in the meantime.

rdar://90437872