### PR TITLE
COWOpts: handle `struct_extract` and `struct` instructions.

### DIFF
--- a/test/SILOptimizer/cow_opts.sil
+++ b/test/SILOptimizer/cow_opts.sil
@@ -11,6 +11,10 @@ final class Buffer {
   init()
 }
 
+struct Str {
+  @_hasStorage var b: Buffer { get set }
+}
+
 sil @unknown : $@convention(thin) (@guaranteed Buffer) -> ()
 
 // CHECK-LABEL: sil @test_simple
@@ -92,11 +96,35 @@ bb0(%0 : $*Buffer):
 sil @test_loop : $@convention(thin) (@owned Buffer) -> (Builtin.Int1, @owned Buffer) {
 bb0(%0 : $Buffer):
   %e = end_cow_mutation %0 : $Buffer
-  br bb1(%e : $Buffer)
-bb1(%a : $Buffer):
-  (%u, %b) = begin_cow_mutation %a : $Buffer
+  %s1 = struct $Str (%e: $Buffer)
+  br bb1(%s1 : $Str)
+bb1(%a : $Str):
+  %as = struct_extract %a : $Str, #Str.b
+  (%u, %b) = begin_cow_mutation %as : $Buffer
   %e2 = end_cow_mutation %b : $Buffer
-  cond_br undef, bb1(%e2 : $Buffer), bb2
+  %s2 = struct $Str (%e2: $Buffer)
+  cond_br undef, bb1(%s2 : $Str), bb2
+bb2:
+  %t = tuple (%u : $Builtin.Int1, %e2 : $Buffer)
+  return %t : $(Builtin.Int1, Buffer)
+}
+
+// CHECK-LABEL: sil @not_all_incoming_values_are_end_cow_mutation
+// CHECK:   ([[U:%[0-9]+]], {{.*}}) = begin_cow_mutation
+// CHECK:   [[B:%[0-9]+]] = end_cow_mutation
+// CHECK:   [[T:%[0-9]+]] = tuple ([[U]] : $Builtin.Int1, [[B]] : $Buffer)
+// CHECK:   return [[T]]
+// CHECK: } // end sil function 'not_all_incoming_values_are_end_cow_mutation'
+sil @not_all_incoming_values_are_end_cow_mutation : $@convention(thin) (@owned Buffer) -> (Builtin.Int1, @owned Buffer) {
+bb0(%0 : $Buffer):
+  %s1 = struct $Str (%0: $Buffer)
+  br bb1(%s1 : $Str)
+bb1(%a : $Str):
+  %as = struct_extract %a : $Str, #Str.b
+  (%u, %b) = begin_cow_mutation %as : $Buffer
+  %e2 = end_cow_mutation %b : $Buffer
+  %s2 = struct $Str (%e2: $Buffer)
+  cond_br undef, bb1(%s2 : $Str), bb2
 bb2:
   %t = tuple (%u : $Builtin.Int1, %e2 : $Buffer)
   return %t : $(Builtin.Int1, Buffer)


### PR DESCRIPTION
Sometimes the def-use chain between `end_cow_mutation` and `begin_cow_mutation` has a phi-term which is wrapped in a struct (e.g. `Array`).
The PhiExpansionPass is supposed to clean that up, but this only works if there are no "unknown" uses of the phi term.
With this change, COWOpts can handle such patterns without relying on the PhiExpansionPass.

rdar://91964659
