### PR TITLE
[5.7] IRGen: Use the current function name for the swift_suspend_point thunk

### DIFF
--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -2434,7 +2434,9 @@ llvm::Function *IRGenFunction::getOrCreateResumeFromSuspensionFn() {
 }
 
 llvm::Function *IRGenFunction::createAsyncSuspendFn() {
-  StringRef name = "__swift_suspend_point";
+  llvm::SmallString<40> nameBuffer;
+  llvm::raw_svector_ostream(nameBuffer) << CurFn->getName() << ".1";
+  StringRef name(nameBuffer);
   if (llvm::GlobalValue *F = IGM.Module.getNamedValue(name))
     return cast<llvm::Function>(F);
 
@@ -2455,7 +2457,8 @@ llvm::Function *IRGenFunction::createAsyncSuspendFn() {
   suspendFn->setDoesNotThrow();
   IRGenFunction suspendIGF(IGM, suspendFn);
   if (IGM.DebugInfo)
-    IGM.DebugInfo->emitArtificialFunction(suspendIGF, suspendFn);
+    IGM.DebugInfo->emitOutlinedFunction(suspendIGF, suspendFn,
+                                        CurFn->getName());
   auto &Builder = suspendIGF.Builder;
 
   llvm::Value *resumeFunction = suspendFn->getArg(0);

--- a/test/DebugInfo/move_function_dbginfo_async.swift
+++ b/test/DebugInfo/move_function_dbginfo_async.swift
@@ -89,7 +89,7 @@ public func letSimpleTest<T>(_ msg: __owned T) async {
 // CHECK-LABEL: define internal swifttailcc void @"$s27move_function_dbginfo_async13varSimpleTestyyxz_xtYalFTQ0_"(i8* swiftasync %0)
 // CHECK: entryresume.0:
 // CHECK:   call void @llvm.dbg.addr(metadata i8* %0, metadata !{{[0-9]+}}, metadata !DIExpression(DW_OP_deref, DW_OP_plus_uconst, 16, DW_OP_plus_uconst, 8, DW_OP_deref))
-// CHECK: musttail call swifttailcc void @swift_task_switch(%swift.context* swiftasync %9, i8* bitcast (void (i8*)* @"$s27move_function_dbginfo_async13varSimpleTestyyxz_xtYalFTY1_" to i8*), i64 0, i64 0)
+// CHECK: musttail call swifttailcc void @swift_task_switch(%swift.context* swiftasync %{{[0-9]+}}, i8* bitcast (void (i8*)* @"$s27move_function_dbginfo_async13varSimpleTestyyxz_xtYalFTY1_" to i8*), i64 0, i64 0)
 // CHECK-NEXT: ret void
 // CHECK-NEXT: }
 //

--- a/test/IRGen/async/hop_to_executor.sil
+++ b/test/IRGen/async/hop_to_executor.sil
@@ -16,8 +16,8 @@ import _Concurrency
 // CHECK-SAME: %swift.context* swiftasync %0, [[INT]] %1, [[INT]] %2)
 // CHECK-DAG: [[CTX:%[0-9]+]] = bitcast %swift.context* %0
 // CHECK-DAG: [[RESUME:%[0-9]+]] = call i8* @llvm.coro.async.resume()
-// CHECK-x86_64: call {{.*}} @llvm.coro.suspend.async{{.*}}(i32 0, i8* [[RESUME]], i8* bitcast (i8* (i8*)* @__swift_async_resume_get_context to i8*), i8* bitcast (void (i8*, [[INT]], [[INT]], %swift.context*)* @__swift_suspend_point to i8*), i8* [[RESUME]], [[INT]] %1, [[INT]] %2, %swift.context* {{%[0-9]+}})
-// CHECK-arm64e: call {{.*}} @llvm.coro.suspend.async{{.*}}(i32 0, i8* [[RESUME]], i8* bitcast (i8* (i8*)* @__swift_async_resume_get_context to i8*), i8* bitcast (void (i8*, [[INT]], [[INT]], %swift.context*)* @__swift_suspend_point to i8*), i8* [[RESUME]], [[INT]] %1, [[INT]] %2, %swift.context* {{%[0-9]+}})
+// CHECK-x86_64: call {{.*}} @llvm.coro.suspend.async{{.*}}(i32 0, i8* [[RESUME]], i8* bitcast (i8* (i8*)* @__swift_async_resume_get_context to i8*), i8* bitcast (void (i8*, [[INT]], [[INT]], %swift.context*)* @test_simple.1 to i8*), i8* [[RESUME]], [[INT]] %1, [[INT]] %2, %swift.context* {{%[0-9]+}})
+// CHECK-arm64e: call {{.*}} @llvm.coro.suspend.async{{.*}}(i32 0, i8* [[RESUME]], i8* bitcast (i8* (i8*)* @__swift_async_resume_get_context to i8*), i8* bitcast (void (i8*, [[INT]], [[INT]], %swift.context*)* @test_simple.1 to i8*), i8* [[RESUME]], [[INT]] %1, [[INT]] %2, %swift.context* {{%[0-9]+}})
 // CHECK: [[RET_CONTINUATION:%.*]] = bitcast void (%swift.context*)* {{.*}} to i8*
 // CHECK:  call i1 (i8*, i1, ...) @llvm.coro.end.async(i8* {{.*}}, i1 false, void (i8*, %swift.context*)* @[[TAIL_CALL_FUNC:.*]], i8* [[RET_CONTINUATION]]
 // CHECK-WIN: ret void
@@ -30,7 +30,7 @@ bb0(%0 : $Optional<Builtin.Executor>):
   return %3 : $()
 }
 
-// CHECK-LABEL: define internal swift{{(tail)?}}cc void @__swift_suspend_point
+// CHECK-LABEL: define internal swift{{(tail)?}}cc void @test_simple.1
 // CHECK-SAME:  (i8* [[RESUME_FN:%0]], [[INT]] %1, [[INT]] %2, %swift.context* [[CTXT:%[^,]+]])
 // CHECK-arm64e: [[RESUME_FN_INT:%[^,]+]] = ptrtoint i8* [[RESUME_FN]] to i64
 // CHECK-arm64e: [[PTRAUTH_SIGN:%[^,]+]] = call i64 @llvm.ptrauth.sign.i64(i64 [[RESUME_FN_INT]], i32 0, i64 0)


### PR DESCRIPTION
This is an incremental improvement of the debug info at a
(hop_to_executor) suspend site.

Before this patch the debug info at the call site would use the
`__swift_suspend_point` function name as the current function after
coro lowering has inlined the thunk.

The proper fix is to rewire the debug info such that the thunk name is
never mentioned rather the current function that suspend site sits in is
used.

Until I have figured out how to do that using the current function name
instead of `__swift_suspend_point` for the thunk is an incremental
improvement in the debug information consumers can observe.

rdar://90859530

This is the same approach as we took for the await suspend points (vs.
hop to executor in this patch) in the PR #41645.

Risk is very low, only a function name of a function that is guaranteed
to be inlined during coroutine splitting is changed.


Matching `main` PR: #42454