### PR TITLE
[CSApply] Rewrite types of a constructed tuple

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7744,7 +7744,15 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
     auto *packed = apply->getArgs()->packIntoImplicitTupleOrParen(
         ctx, [&](Expr *E) { return cs.getType(E); });
     cs.cacheType(packed);
-    return coerceToType(packed, tupleTy, cs.getConstraintLocator(packed));
+    auto *result = coerceToType(packed, tupleTy, cs.getConstraintLocator(packed));
+    // Resetting the types of tuple is necessary because
+    // `packIntoImplicitTupleOrParen` sets types in AST
+    // where `coerceToType` only updates constraint system
+    // cache. This creates a mismatch that would not be
+    // corrected by `setExprTypes` if this tuple is used
+    // as an argument that is wrapped in an autoclosure.
+    solution.setExprTypes(result);
+    return result;
   }
 
   // We're constructing a value of nominal type. Look for the constructor or

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar90366182.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar90366182.swift
@@ -1,0 +1,24 @@
+// RUN: %target-typecheck-verify-swift
+
+class Data {
+}
+
+class Test {
+  var lastIndex: Int = 0
+
+  func test(_ arr: [[Data]]) {
+    typealias I = (index: Int, data: [Int])
+
+    struct Pair: Hashable {
+      var lhs: Int
+      var rhs: Int
+    }
+
+    let data = [Pair: I]()
+    for index in 0..<arr.count {
+      for (idx, _) in arr[index].enumerated() {
+        _ = data[Pair(lhs: index, rhs: idx)] ?? I(index: lastIndex, data: [Int]()) // Ok
+      }
+    }
+  }
+}


### PR DESCRIPTION
When construction call is rewritten into a tuple conversion,
rewriter has to make sure that AST types are reset otherwise
it would end up with types set by `packIntoImplicitTupleOrParen`
which could contain l-values.

Resolves: rdar://90366182


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
