### PR TITLE
[TypeChecker] NFC: Remove `-experimental-multi-statement-closures` flag

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -759,10 +759,6 @@ namespace swift {
     /// parameters of closures.
     bool EnableOneWayClosureParameters = false;
 
-    /// Enable experimental support for type inference through multi-statement
-    /// closures.
-    bool EnableMultiStatementClosureInference = true;
-
     /// See \ref FrontendOptions.PrintFullConvention
     bool PrintFullConvention = false;
   };

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -900,10 +900,6 @@ def experimental_one_way_closure_params :
   Flag<["-"], "experimental-one-way-closure-params">,
   HelpText<"Enable experimental support for one-way closure parameters">;
 
-def experimental_multi_statement_closures :
-  Flag<["-"], "experimental-multi-statement-closures">,
-  HelpText<"Enable experimental support for type inference in multi-statement closures">;
-
 def prebuilt_module_cache_path :
   Separate<["-"], "prebuilt-module-cache-path">,
   HelpText<"Directory of prebuilt modules for loading module interfaces">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1146,9 +1146,6 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
   Opts.EnableOneWayClosureParameters |=
       Args.hasArg(OPT_experimental_one_way_closure_params);
 
-  Opts.EnableMultiStatementClosureInference |=
-      Args.hasArg(OPT_experimental_multi_statement_closures);
-
   Opts.PrintFullConvention |=
       Args.hasArg(OPT_experimental_print_full_convention);
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -6639,9 +6639,7 @@ bool ConstraintSystem::participatesInInference(ClosureExpr *closure) const {
   if (Options.contains(ConstraintSystemFlags::LeaveClosureBodyUnchecked))
     return false;
 
-  auto &ctx = closure->getASTContext();
-  if (closure->hasEmptyBody() ||
-      !ctx.TypeCheckerOpts.EnableMultiStatementClosureInference)
+  if (closure->hasEmptyBody())
     return false;
 
   // If body is nested in a parent that has a function builder applied,

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -64,14 +64,10 @@ bool BaseDiagnosticWalker::shouldWalkIntoDeclInClosureContext(Decl *D) {
   if (closure->isSeparatelyTypeChecked())
     return false;
 
-  auto &opts = D->getASTContext().TypeCheckerOpts;
-
-  // If multi-statement inference is enabled, let's not walk
-  // into declarations contained in a multi-statement closure
-  // because they'd be handled via `typeCheckDecl` that runs
+  // Let's not walk into declarations contained in a multi-statement
+  // closure because they'd be handled via `typeCheckDecl` that runs
   // syntactic diagnostics.
-  if (opts.EnableMultiStatementClosureInference &&
-      !closure->hasSingleExpressionBody()) {
+  if (!closure->hasSingleExpressionBody()) {
     // Since pattern bindings get their types through solution application,
     // `typeCheckDecl` doesn't touch initializers (because they are already
     // fully type-checked), so pattern bindings have to be allowed to be

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -1443,12 +1443,10 @@ namespace {
     bool walkToDeclPre(Decl *D) override { return isa<PatternBindingDecl>(D); }
 
     std::pair<bool, Pattern *> walkToPatternPre(Pattern *pattern) override {
-      // With multi-statement closure inference enabled, constraint generation
-      // is responsible for pattern verification and type-checking in the body
-      // of the closure, so there is no need to walk into patterns.
-      bool walkIntoPatterns =
-          !(isa<ClosureExpr>(DC) &&
-            Ctx.TypeCheckerOpts.EnableMultiStatementClosureInference);
+      // Constraint generation is responsible for pattern verification and
+      // type-checking in the body of the closure, so there is no need to
+      // walk into patterns.
+      bool walkIntoPatterns = !isa<ClosureExpr>(DC);
       return {walkIntoPatterns, pattern};
     }
   };
@@ -1460,9 +1458,6 @@ bool PreCheckExpression::walkToClosureExprPre(ClosureExpr *closure) {
   // If we won't be checking the body of the closure, don't walk into it here.
   if (!closure->hasSingleExpressionBody()) {
     if (LeaveClosureBodiesUnchecked)
-      return false;
-
-    if (!Ctx.TypeCheckerOpts.EnableMultiStatementClosureInference)
       return false;
   }
 

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3136,21 +3136,7 @@ private:
   }
 
   bool shouldWalkIntoClosure(AbstractClosureExpr *closure) const {
-    // Multi-statement closures are collected by ExprWalker::rewriteFunction
-    // and checked by ExprWalker::processDelayed in CSApply.cpp.
-    // Single-statement closures only have the attributes checked
-    // by TypeChecker::checkClosureAttributes in that rewriteFunction.
-    // Multi-statement closures will be checked explicitly later (as the decl
-    // context in the Where). Single-expression closures will not be
-    // revisited, and are not automatically set as the context of the 'where'.
-    // Don't double-check multi-statement closures, but do check
-    // single-statement closures, setting the closure as the decl context.
-    //
-    // Note about SE-0326: When a flag is enabled multi-statement closures
-    // are type-checked together with enclosing context, so walker behavior
-    // should match that of single-expression closures.
-    return closure->hasSingleExpressionBody() ||
-           Context.TypeCheckerOpts.EnableMultiStatementClosureInference;
+    return true;
   }
 
   /// Walk an abstract closure expression, checking for availability

--- a/lib/Sema/TypeCheckCodeCompletion.cpp
+++ b/lib/Sema/TypeCheckCodeCompletion.cpp
@@ -212,10 +212,6 @@ public:
       // If this is a closure, only walk into its children if they
       // are type-checked in the context of the enclosing expression.
       if (auto closure = dyn_cast<ClosureExpr>(expr)) {
-        // TODO: This has to be deleted once `EnableMultiStatementClosureInference`
-        //       is enabled by default.
-        if (!closure->hasSingleExpressionBody())
-          return { false, expr };
         for (auto &Param : *closure->getParameters()) {
           Param->setSpecifier(swift::ParamSpecifier::Default);
         }

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5 -experimental-multi-statement-closures -enable-experimental-static-assert
+// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-experimental-static-assert
 
 func isInt<T>(_ value: T) -> Bool {
   return value is Int

--- a/validation-test/Sema/SwiftUI/mixed_swiftui_and_multistatement_closures.swift
+++ b/validation-test/Sema/SwiftUI/mixed_swiftui_and_multistatement_closures.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.15 -swift-version 5 -experimental-multi-statement-closures
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.15 -swift-version 5
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx
 

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar85843677.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar85843677.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5 -experimental-multi-statement-closures
+// RUN: %target-typecheck-verify-swift -swift-version 5
 
 func callClosure(closure: () -> ()) {  
   closure()


### PR DESCRIPTION
SE-0326 has been enabled by default, so this flag is no longer necessary.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
