### PR TITLE
[SILGen] Use opaque AP for ObjC-async returns.

### DIFF
--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -2839,7 +2839,7 @@ SILType GetAsyncContinuationInstBase::getLoweredResumeType() const {
   auto formalType = getFormalResumeType();
   auto &M = getFunction()->getModule();
   auto c = getFunction()->getTypeExpansionContext();
-  return M.Types.getLoweredType(AbstractionPattern(formalType), formalType, c);
+  return M.Types.getLoweredType(AbstractionPattern::getOpaque(), formalType, c);
 }
 
 ReturnInst::ReturnInst(SILFunction &func, SILDebugLocation debugLoc,

--- a/lib/SILGen/ResultPlan.cpp
+++ b/lib/SILGen/ResultPlan.cpp
@@ -506,9 +506,8 @@ public:
   {
     // Allocate space to receive the resume value when the continuation is
     // resumed.
-    opaqueResumeType =
-        SGF.getLoweredType(AbstractionPattern(calleeTypeInfo.substResultType),
-                           calleeTypeInfo.substResultType);
+    opaqueResumeType = SGF.getLoweredType(AbstractionPattern::getOpaque(),
+                                          calleeTypeInfo.substResultType);
     resumeBuf = SGF.emitTemporaryAllocation(loc, opaqueResumeType);
   }
   
@@ -707,14 +706,12 @@ public:
     // The incoming value is the maximally-abstracted result type of the
     // continuation. Move it out of the resume buffer and reabstract it if
     // necessary.
-    auto resumeResult = SGF.emitLoad(loc, resumeBuf,
-      calleeTypeInfo.origResultType
-         ? *calleeTypeInfo.origResultType
-         : AbstractionPattern(calleeTypeInfo.substResultType),
-                 calleeTypeInfo.substResultType,
-                 SGF.getTypeLowering(calleeTypeInfo.substResultType),
-                 SGFContext(), IsTake);
-    
+    auto resumeResult =
+        SGF.emitLoad(loc, resumeBuf, AbstractionPattern::getOpaque(),
+                     calleeTypeInfo.substResultType,
+                     SGF.getTypeLowering(calleeTypeInfo.substResultType),
+                     SGFContext(), IsTake);
+
     return RValue(SGF, loc, calleeTypeInfo.substResultType, resumeResult);
   }
 };

--- a/validation-test/compiler_crashers_2_fixed/rdar79383990.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar79383990.swift
@@ -1,6 +1,5 @@
 // RUN: %target-swift-frontend %s -emit-silgen -disable-availability-checking -import-objc-header %S/Inputs/rdar79383990.h
 // REQUIRES: objc_interop
-// REQUIRES: OS=macosx
 
 import Foundation
 

--- a/validation-test/compiler_crashers_2_fixed/rdar81590807.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar81590807.swift
@@ -12,8 +12,6 @@
 
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx || OS=ios
-// Enable with rdar://85526879
-// UNSUPPORTED: CPU=arm64e
 
 // rdar://82123254
 // UNSUPPORTED: use_os_stdlib

--- a/validation-test/compiler_crashers_2_fixed/rdar81617749.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar81617749.swift
@@ -9,8 +9,6 @@
 
 // Enable with rdar://81617749
 // UNSUPPORTED: CPU=i386 && OS=watchos
-// Enable with rdar://85526916
-// UNSUPPORTED: CPU=arm64e
 
 // rdar://82123254
 // UNSUPPORTED: use_os_stdlib


### PR DESCRIPTION
Previously, the AbstractionPattern that was used for the value "returned" (i.e. via a completion handler) from ObjC mostly (but not quite always) was "type".

The generated completion handler correctly (because this is required in order to call `_resumeUnsafeContinuation)` reabstracted the block (e.g.  from `@convention(block) () -> ())` to `@substituted <T> () -> @out T for <()>`).  The callee of the ObjC function, however, loaded the function from the block as if it were not reabstracted (e.g. `() -> ()`).

On arm64e, that difference in types caused in a difference in pointer signing, resulting in a failure at runtime.

rdar://85526879
rdar://85526916
