### PR TITLE
[ModuleInterface] Ignore adjacent swiftmodules under the Frameworks folder

### DIFF
--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -651,9 +651,19 @@ class ModuleInterfaceLoaderImpl {
 
   std::pair<std::string, std::string> getCompiledModuleCandidates() {
     std::pair<std::string, std::string> result;
-    // Keep track of whether we should attempt to load a .swiftmodule adjacent
-    // to the .swiftinterface.
+    // Should we attempt to load a swiftmodule adjacent to the swiftinterface?
     bool shouldLoadAdjacentModule = true;
+
+    // Don't use the adjacent swiftmodule for frameworks from the public
+    // Frameworks folder of the SDK.
+    SmallString<128> publicFrameworksPath;
+    llvm::sys::path::append(publicFrameworksPath,
+                            ctx.SearchPathOpts.getSDKPath(),
+                            "System", "Library", "Frameworks");
+    if (!ctx.SearchPathOpts.getSDKPath().empty() &&
+        modulePath.startswith(publicFrameworksPath)) {
+      shouldLoadAdjacentModule = false;
+    }
 
     switch (loadMode) {
     case ModuleLoadingMode::OnlyInterface:

--- a/test/ModuleInterface/ignore-adjacent-swiftmodules.swift
+++ b/test/ModuleInterface/ignore-adjacent-swiftmodules.swift
@@ -1,0 +1,37 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/cache)
+// REQUIRES: VENDOR=apple
+
+/// Prepare the SDK.
+// RUN: cp -r %S/../Sema/Inputs/public-private-sdk %t/sdk
+// RUN: %target-swift-frontend -emit-module -module-name PublicSwift -enable-library-evolution -swift-version 5 \
+// RUN:   %t/sdk/System/Library/Frameworks/PublicSwift.framework/Modules/PublicSwift.swiftmodule/source.swift \
+// RUN:   -o %t/sdk/System/Library/Frameworks/PublicSwift.framework/Modules/PublicSwift.swiftmodule/%target-swiftmodule-name \
+// RUN:   -emit-module-interface-path %t/sdk/System/Library/Frameworks/PublicSwift.framework/Modules/PublicSwift.swiftmodule/%target-swiftinterface-name
+// RUN: %target-swift-typecheck-module-from-interface(%t/sdk/System/Library/Frameworks/PublicSwift.framework/Modules/PublicSwift.swiftmodule/%target-swiftinterface-name) -module-name PublicSwift
+// RUN: %target-swift-frontend -emit-module -module-name PrivateSwift -enable-library-evolution -swift-version 5 \
+// RUN:   %t/sdk/System/Library/PrivateFrameworks/PrivateSwift.framework/Modules/PrivateSwift.swiftmodule/source.swift \
+// RUN:   -o %t/sdk/System/Library/PrivateFrameworks/PrivateSwift.framework/Modules/PrivateSwift.swiftmodule/%target-swiftmodule-name \
+// RUN:   -emit-module-interface-path %t/sdk/System/Library/PrivateFrameworks/PrivateSwift.framework/Modules/PrivateSwift.swiftmodule/%target-swiftinterface-name
+// RUN: %target-swift-typecheck-module-from-interface(%t/sdk/System/Library/PrivateFrameworks/PrivateSwift.framework/Modules/PrivateSwift.swiftmodule/%target-swiftinterface-name) -module-name PrivateSwift
+
+/// Break the swiftmodules.
+// RUN: echo "This is a malformed swiftmodule" > %t/sdk/System/Library/Frameworks/PublicSwift.framework/Modules/PublicSwift.swiftmodule/%target-swiftmodule-name
+// RUN: echo "This is a malformed swiftmodule" > %t/sdk/System/Library/PrivateFrameworks/PrivateSwift.framework/Modules/PrivateSwift.swiftmodule/%target-swiftmodule-name
+
+/// There should be no attempt at loading the malformed PublicSwift swiftmodule.
+/// This means no notes about:
+/// * compiled module is out of date
+/// * unable to load compiled module '*': malformed
+// RUN: %target-swift-frontend -typecheck %s -sdk %t/sdk \
+// RUN:   -module-name Main -module-cache-path %t/cache \
+// RUN:   -F %t/sdk/System/Library/PrivateFrameworks/ \
+// RUN:   -verify -Rmodule-interface-rebuild
+
+import PublicSwift // expected-remark {{rebuilding module 'PublicSwift' from interface}}
+
+// The private adjacent module under PrivateFrameworks should still be tried first, and then rebuilt.
+import PrivateSwift
+// expected-remark @-1 {{rebuilding module 'PrivateSwift' from interface}}
+// expected-note @-2 {{compiled module is out of date}}
+// expected-note @-3 {{: malformed}}


### PR DESCRIPTION
Always use the swiftinterfaces of modules under the public Frameworks
folder in the SDK. Distributed swiftmodules are unreliable, they should
only be used as a local cache. Let's avoid them when possible.

rdar://92037292