### PR TITLE
[SymbolGraphGen] skip underscored implicit Clang decls

### DIFF
--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -583,6 +583,12 @@ bool SymbolGraph::isImplicitlyPrivate(const Decl *D,
 
   // Don't record effectively internal declarations if specified
   if (D->hasUnderscoredNaming()) {
+    // Some implicit decls from Clang with underscored names sneak in, so throw those out
+    if (const auto *clangD = D->getClangDecl()) {
+      if (clangD->isImplicit())
+        return true;
+    }
+
     AccessLevel symLevel = AccessLevel::Public;
     if (const ValueDecl *VD = dyn_cast<ValueDecl>(D)) {
       symLevel = VD->getFormalAccess();

--- a/test/SymbolGraph/ClangImporter/BridgingHeader.swift
+++ b/test/SymbolGraph/ClangImporter/BridgingHeader.swift
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-pch -pch-output-dir %t %S/Inputs/ObjcProperty/ObjcProperty.framework/Headers/ObjcProperty.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-module-path %t/BridgingHeader.swiftmodule -import-objc-header %S/Inputs/ObjcProperty/ObjcProperty.framework/Headers/ObjcProperty.h -pch-output-dir %t -module-name BridgingHeader -disable-objc-attr-requires-foundation-module %s -emit-symbol-graph -emit-symbol-graph-dir %t -symbol-graph-minimum-access-level internal
+
+// RUN: %FileCheck %s --input-file %t/BridgingHeader.symbols.json
+
+// REQUIRES: objc_interop
+
+// There are a few implicit symbols from Clang that snuck in when building with minimum-access
+// level of "internal". Make sure they don't sneak back in. rdar://92018648
+
+// CHECK-NOT: __NSConstantString
+// CHECK-NOT: __builtin_ms_va_list
+// CHECK-NOT: __builtin_va_list
+


### PR DESCRIPTION
Resolves rdar://92018648

When building symbol graphs with a minimum access level of `internal`, with a precompiled header for Objective-C code, some implicit decls from Clang appear in the symbol graph. This PR filters these out by specifically targeting symbols with underscored names and Clang decls, where the Clang decl is marked as implicit.