### PR TITLE
[5.7-04182022][SymbolGraphGen] skip underscored implicit Clang decls

### DIFF
--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -583,6 +583,12 @@ bool SymbolGraph::isImplicitlyPrivate(const Decl *D,
 
   // Don't record effectively internal declarations if specified
   if (D->hasUnderscoredNaming()) {
+    // Some implicit decls from Clang with underscored names sneak in, so throw those out
+    if (const auto *clangD = D->getClangDecl()) {
+      if (clangD->isImplicit())
+        return true;
+    }
+
     AccessLevel symLevel = AccessLevel::Public;
     if (const ValueDecl *VD = dyn_cast<ValueDecl>(D)) {
       symLevel = VD->getFormalAccess();

--- a/test/SymbolGraph/ClangImporter/BridgingHeader.swift
+++ b/test/SymbolGraph/ClangImporter/BridgingHeader.swift
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-pch -pch-output-dir %t %S/Inputs/ObjcProperty/ObjcProperty.framework/Headers/ObjcProperty.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-module-path %t/BridgingHeader.swiftmodule -import-objc-header %S/Inputs/ObjcProperty/ObjcProperty.framework/Headers/ObjcProperty.h -pch-output-dir %t -module-name BridgingHeader -disable-objc-attr-requires-foundation-module %s -emit-symbol-graph -emit-symbol-graph-dir %t -symbol-graph-minimum-access-level internal
+
+// RUN: %FileCheck %s --input-file %t/BridgingHeader.symbols.json
+
+// REQUIRES: objc_interop
+
+// There are a few implicit symbols from Clang that snuck in when building with minimum-access
+// level of "internal". Make sure they don't sneak back in. rdar://92018648
+
+// CHECK-NOT: __NSConstantString
+// CHECK-NOT: __builtin_ms_va_list
+// CHECK-NOT: __builtin_va_list
+


### PR DESCRIPTION
This is a cherry-pick of https://github.com/apple/swift/pull/42493 onto `release/5.7-04182022`.

**Explanation**: When generating symbol graphs for projects with a precompiled header and a minimum-access-level of `internal`, several implicit Clang decls started appearing after https://github.com/apple/swift/pull/41156 stopped unanimously filtering out underscore-prefixed symbols. This PR filters out implicit Clang decls with underscore-prefixed names, as they're unlikely to be useful to consumers of symbol graphs.

**Scope**: The change is isolated to SymbolGraphGen, and due to the behavior of underscored symbol filtering, should only affect symbol graphs where the minimum access level is set to `internal` or below.

**Radar**: rdar://92018648

**Risk**: Low. This won't affect normal compilation. The impact on symbol graphs is minimal; only implicit Clang decls in specific circumstances are filtered out.

**Testing**: A new lit test, `SymbolGraph/ClangImporter/BridgingHeader.swift`, has been added to verify that using a precompiled header does not add three specific decls otherwise added by Clang.