### PR TITLE
[TypeChecker] NFC: Adjust SwiftUI to use %target-cpu instead of x86_64

### DIFF
--- a/validation-test/Sema/SwiftUI/rdar57201781.swift
+++ b/validation-test/Sema/SwiftUI/rdar57201781.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -target x86_64-apple-macosx10.15 -swift-version 5
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.15 -swift-version 5
 
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx


### PR DESCRIPTION
Resolves: rdar://91849144

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
