### PR TITLE
Add reference page for Sendable protocol (Swift 5.7-04182022)

### DIFF
--- a/stdlib/public/core/Sendable.swift
+++ b/stdlib/public/core/Sendable.swift
@@ -60,6 +60,13 @@
 ///
 /// Otherwise, you need to declare conformance to `Sendable` explicitly.
 ///
+/// Structures that have nonsendable stored properties
+/// and enumerations that nonsendable associated values
+/// can be marked as `@unchecked Sendable`,
+/// disabling compile-time correctness checks,
+/// after you manually verify that
+/// they satisfy the `Sendable` protocol's semantic requirements.
+///
 /// ### Sendable Actors
 ///
 /// All actor types implicitly conform to `Sendable`

--- a/stdlib/public/core/Sendable.swift
+++ b/stdlib/public/core/Sendable.swift
@@ -19,9 +19,9 @@
 /// All of the following can be marked as sendable:
 ///
 /// - Value types
-/// - References to immutable reference types
+/// - Reference types with no mutable storage
 /// - Reference types that internally manage access to their state
-/// - Functions and closures
+/// - Functions and closures (via `@Sendable`)
 ///
 /// Although this protocol doesn't have any required methods or properties,
 /// it does have semantic requirements that are enforced at compile time.
@@ -31,7 +31,7 @@
 ///
 /// To declare conformance to `Sendable` without any compiler enforcement,
 /// write `@unchecked Sendable`.
-/// You are responsible for the correctness of unchecked sendable types.
+/// You are responsible for the correctness of unchecked sendable types, for example, by protecting all access to its state with a lock or a queue.
 /// Unchecked conformance to `Sendable` also disables enforcement
 /// of the rule that conformance must be in the same file.
 ///

--- a/stdlib/public/core/Sendable.swift
+++ b/stdlib/public/core/Sendable.swift
@@ -19,8 +19,11 @@
 /// All of the following can be marked as sendable:
 ///
 /// - Value types
+///
 /// - Reference types with no mutable storage
+///
 /// - Reference types that internally manage access to their state
+///
 /// - Functions and closures (via `@Sendable`)
 ///
 /// Although this protocol doesn't have any required methods or properties,
@@ -50,10 +53,10 @@
 /// In some cases, structures and enumerations
 /// that satisfy the requirements implicitly conform to `Sendable`:
 ///
-/// -   Frozen structures and enumerations
+/// - Frozen structures and enumerations
 ///
-/// -   Structures and enumerations
-///     that aren't public and aren't marked `@usableFromInline`.
+/// - Structures and enumerations
+///   that aren't public and aren't marked `@usableFromInline`.
 ///
 /// Otherwise, you need to declare conformance to `Sendable` explicitly.
 ///

--- a/stdlib/public/core/Sendable.swift
+++ b/stdlib/public/core/Sendable.swift
@@ -10,13 +10,107 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// The Sendable protocol indicates that value of the given type can
-/// be safely used in concurrent code.
+/// A type whose values can safely be passed across concurrency domains by copying.
+///
+/// You can safely pass values of a sendable type
+/// from one concurrency domains to another ---
+/// for example, you can pass a sendable value as the argument
+/// when calling an actor's methods.
+/// All of the following can be marked as sendable:
+///
+/// - Value types
+/// - References to immutable reference types
+/// - Reference types that internally manage access to their state
+/// - Functions and closures
+///
+/// Although this protocol doesn't have any required methods or properties,
+/// it does have semantic requirements that are enforced at compile time.
+/// These requirements are listed in the sections below.
+/// Conformance to `Sendable` must be declared
+/// in the same file as the type's declaration.
+///
+/// To declare conformance to `Sendable` without any compiler enforcement,
+/// write `@unchecked Sendable`.
+/// You are responsible for the correctness of unchecked sendable types.
+/// Unchecked conformance to `Sendable` also disables enforcement
+/// of the rule that conformance must be in the same file.
+///
+/// For information about the language-level concurrency model that `Task` is part of,
+/// see [Concurrency][concurrency] in [The Swift Programming Language][tspl].
+///
+/// [concurrency]: https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html
+/// [tspl]: https://docs.swift.org/swift-book/
+///
+/// ### Sendable Structures and Enumerations
+///
+/// To satisfy the requirements of the `Sendable` protocol,
+/// an enumeration or structure must have only sendable
+/// members and associated values.
+/// In some cases, structures and enumerations
+/// that satisfy the requirements implicitly conform to `Sendable`:
+///
+/// -   Frozen structures and enumerations
+///
+/// -   Structures and enumerations
+///     that aren't public and aren't marked `@usableFromInline`.
+///
+/// Otherwise, you need to declare conformance to `Sendable` explicitly.
+///
+/// ### Sendable Actors and Classes
+///
+/// All actor types implicitly conform to `Sendable`.
+///
+/// To satisfy the requirements of the `Sendable` protocol,
+/// final classes must contain only immutable stored properties,
+/// and must either be a subclass of `NSObject` or have no superclass.
+///
+/// Other classes can be marked as `@unchecked Sendable`,
+/// disabling compile-time correctness checks,
+/// after you manually verify that they satisfy the semantic requirements.
+///
+/// ### Sendable Functions and Closures
+///
+/// Instead of conforming to the `Sendable` protocol,
+/// you mark sendable functions and closures with the `@Sendable` attribute.
+/// Any values that the function or closure captures must be sendable.
+/// In addition, sendable closures must use only by-value captures,
+/// and the captured values must be of a sendable type.
+///
+/// In a context that expects a sendable closure,
+/// a closure closure that satisfies the requirements
+/// implicitly conforms to `Sendable` ---
+/// for example, in a call to `Task.detached(priority:operation:)`.
+///
+/// You can explicitly mark a closure as sendable
+/// by writing `@Sendable` as part of a type annotation,
+/// or by writing `@Sendable` before the closure's parameters ---
+/// for example:
+///
+/// ```
+/// let sendableClosure = { @Sendable (number: Int) -> String in
+///     if number > 12 {
+///         return "More than a dozen."
+///     } else {
+///         return "Less than a dozen"
+///     }
+/// }
+/// ```
+///
+/// ### Sendable Tuples
+///
+/// To satisfy the requirements of the `Sendable` protocol,
+/// all of the elements of the tuple must be sendable.
+/// Tuples that satisfy the requirements implicitly conform to `Sendable`.
 @_marker public protocol Sendable { }
-
-/// The UnsafeSendable protocol indicates that value of the given type
-/// can be safely used in concurrent code, but disables some safety checking
-/// at the conformance site.
+///
+/// A type whose values can safely be passed across concurrency domains by copying,
+/// but which disables some safety checking at the conformance site.
+///
+/// Use an unchecked conformance to `Sendable` instead.
+///
+/// ```
+/// struct MyStructure: @unchecked Sendable { ... }
+/// ```
 @available(*, deprecated, message: "Use @unchecked Sendable instead")
 @_marker public protocol UnsafeSendable: Sendable { }
 

--- a/stdlib/public/core/Sendable.swift
+++ b/stdlib/public/core/Sendable.swift
@@ -118,6 +118,10 @@
 /// To satisfy the requirements of the `Sendable` protocol,
 /// all of the elements of the tuple must be sendable.
 /// Tuples that satisfy the requirements implicitly conform to `Sendable`.
+///
+/// ### Sendable Metatypes
+///
+/// Metatypes such as `Int.Type` implicitly conform to the `Sendable` protocol.
 @_marker public protocol Sendable { }
 ///
 /// A type whose values can safely be passed across concurrency domains by copying,

--- a/stdlib/public/core/Sendable.swift
+++ b/stdlib/public/core/Sendable.swift
@@ -13,7 +13,7 @@
 /// A type whose values can safely be passed across concurrency domains by copying.
 ///
 /// You can safely pass values of a sendable type
-/// from one concurrency domains to another ---
+/// from one concurrency domain to another ---
 /// for example, you can pass a sendable value as the argument
 /// when calling an actor's methods.
 /// All of the following can be marked as sendable:
@@ -24,7 +24,7 @@
 ///
 /// - Reference types that internally manage access to their state
 ///
-/// - Functions and closures (via `@Sendable`)
+/// - Functions and closures (by marking them with `@Sendable`)
 ///
 /// Although this protocol doesn't have any required methods or properties,
 /// it does have semantic requirements that are enforced at compile time.
@@ -61,7 +61,7 @@
 /// Otherwise, you need to declare conformance to `Sendable` explicitly.
 ///
 /// Structures that have nonsendable stored properties
-/// and enumerations that nonsendable associated values
+/// and enumerations that have nonsendable associated values
 /// can be marked as `@unchecked Sendable`,
 /// disabling compile-time correctness checks,
 /// after you manually verify that
@@ -103,7 +103,7 @@
 /// and the captured values must be of a sendable type.
 ///
 /// In a context that expects a sendable closure,
-/// a closure closure that satisfies the requirements
+/// a closure that satisfies the requirements
 /// implicitly conforms to `Sendable` ---
 /// for example, in a call to `Task.detached(priority:operation:)`.
 ///

--- a/stdlib/public/core/Sendable.swift
+++ b/stdlib/public/core/Sendable.swift
@@ -106,7 +106,7 @@
 /// A type whose values can safely be passed across concurrency domains by copying,
 /// but which disables some safety checking at the conformance site.
 ///
-/// Use an unchecked conformance to `Sendable` instead.
+/// Use an unchecked conformance to `Sendable` instead --- for example:
 ///
 /// ```
 /// struct MyStructure: @unchecked Sendable { ... }

--- a/stdlib/public/core/Sendable.swift
+++ b/stdlib/public/core/Sendable.swift
@@ -86,15 +86,13 @@
 /// or by writing `@Sendable` before the closure's parameters ---
 /// for example:
 ///
-/// ```
-/// let sendableClosure = { @Sendable (number: Int) -> String in
-///     if number > 12 {
-///         return "More than a dozen."
-///     } else {
-///         return "Less than a dozen"
+///     let sendableClosure = { @Sendable (number: Int) -> String in
+///         if number > 12 {
+///             return "More than a dozen."
+///         } else {
+///             return "Less than a dozen"
+///         }
 ///     }
-/// }
-/// ```
 ///
 /// ### Sendable Tuples
 ///
@@ -108,9 +106,7 @@
 ///
 /// Use an unchecked conformance to `Sendable` instead --- for example:
 ///
-/// ```
-/// struct MyStructure: @unchecked Sendable { ... }
-/// ```
+///     struct MyStructure: @unchecked Sendable { ... }
 @available(*, deprecated, message: "Use @unchecked Sendable instead")
 @_marker public protocol UnsafeSendable: Sendable { }
 

--- a/stdlib/public/core/Sendable.swift
+++ b/stdlib/public/core/Sendable.swift
@@ -31,7 +31,8 @@
 ///
 /// To declare conformance to `Sendable` without any compiler enforcement,
 /// write `@unchecked Sendable`.
-/// You are responsible for the correctness of unchecked sendable types, for example, by protecting all access to its state with a lock or a queue.
+/// You are responsible for the correctness of unchecked sendable types,
+/// for example, by protecting all access to its state with a lock or a queue.
 /// Unchecked conformance to `Sendable` also disables enforcement
 /// of the rule that conformance must be in the same file.
 ///
@@ -56,17 +57,32 @@
 ///
 /// Otherwise, you need to declare conformance to `Sendable` explicitly.
 ///
-/// ### Sendable Actors and Classes
+/// ### Sendable Actors
 ///
-/// All actor types implicitly conform to `Sendable`.
+/// All actor types implicitly conform to `Sendable`
+/// because actors ensure that all access to their mutable state
+/// is performed sequentially.
+///
+/// ### Sendable Classes
 ///
 /// To satisfy the requirements of the `Sendable` protocol,
-/// final classes must contain only immutable stored properties,
-/// and must either be a subclass of `NSObject` or have no superclass.
+/// a class must:
 ///
-/// Other classes can be marked as `@unchecked Sendable`,
+/// - Be marked `final`
+///
+/// - Contain only stored properties that are immutable and sendable
+///
+/// - Have no superclass or have `NSObject` as the superclass
+///
+/// Classes marked with `@MainActor` are implicitly sendable,
+/// because the main actor coordinates all access to its state.
+/// These classes can have stored properties that are mutable and nonsendable.
+///
+/// Classes that don't meet the requirements above
+/// can be marked as `@unchecked Sendable`,
 /// disabling compile-time correctness checks,
-/// after you manually verify that they satisfy the semantic requirements.
+/// after you manually verify that
+/// they satisfy the `Sendable` protocol's semantic requirements.
 ///
 /// ### Sendable Functions and Closures
 ///


### PR DESCRIPTION
Cherry-pick of <https://github.com/apple/swift/pull/42128> into Swift 5.7-04182022

Resolves rdar://87221356