### PR TITLE
Fix misspelled `CHECK` lines

### DIFF
--- a/test/AutoDiff/IRGen/runtime.swift
+++ b/test/AutoDiff/IRGen/runtime.swift
@@ -20,5 +20,5 @@ func test_context_builtins() {
 // CHECK-LABEL: define{{.*}}@test_context_builtins()
 // CHECK: entry:
 // CHECK:   [[CTX:%.*]] = call swiftcc %swift.refcounted* @swift_autoDiffCreateLinearMapContext({{i[0-9]+}} {{.*}})
-// CEHCK:   call swiftcc i8* @swift_autoDiffProjectTopLevelSubcontext(%swift.refcounted* [[CTX]])
+// CHECK:   call swiftcc i8* @swift_autoDiffProjectTopLevelSubcontext(%swift.refcounted* [[CTX]])
 // CHECK:   [[BUF:%.*]] = call swiftcc i8* @swift_autoDiffAllocateSubcontext(%swift.refcounted* [[CTX]], {{i[0-9]+}} {{.*}})

--- a/test/Interop/Cxx/class/type-classification-non-trivial-silgen.swift
+++ b/test/Interop/Cxx/class/type-classification-non-trivial-silgen.swift
@@ -31,7 +31,7 @@ public func testStructWithSubobjectDestructor() {
   let d = StructWithSubobjectDestructor()
 }
 
-// CHECK-LABLE: sil [ossa] @$s4main37testStructWithCopyConstructorAndValueSbyF
+// CHECK-LABEL: sil [ossa] @$s4main37testStructWithCopyConstructorAndValueSbyF
 // CHECK: [[AS:%.*]] = alloc_stack [lexical] $StructWithCopyConstructorAndValue
 // CHECK: [[FN:%.*]] = function_ref @{{_ZN33StructWithCopyConstructorAndValueC1Ei|\?\?0StructWithCopyConstructorAndValue@@QEAA@H@Z}} : $@convention(c) (Int32) -> @out StructWithCopyConstructorAndValue
 // CHECK: apply [[FN]]([[AS]], %{{.*}}) : $@convention(c) (Int32) -> @out StructWithCopyConstructorAndValue
@@ -44,7 +44,7 @@ public func testStructWithSubobjectDestructor() {
 // CHECK: [[OUT:%.*]] = apply [[CMP_FN]]([[OBJ_VAL]], [[INT_42]], %{{.*}}) : $@convention(method) (Int32, Int32, @thin Int32.Type) -> Bool
 // CHECK: destroy_addr [[AS]] : $*StructWithCopyConstructorAndValue
 // CHECK: return [[OUT]] : $Bool
-// CHECK-LABLE: end sil function '$s4main37testStructWithCopyConstructorAndValueSbyF'
+// CHECK-LABEL: end sil function '$s4main37testStructWithCopyConstructorAndValueSbyF'
 
 // CHECK-LABEL: sil [clang StructWithCopyConstructorAndValue.init] @{{_ZN33StructWithCopyConstructorAndValueC1Ei|\?\?0StructWithCopyConstructorAndValue@@QEAA@H@Z}} : $@convention(c) (Int32) -> @out StructWithCopyConstructorAndValue
 public func testStructWithCopyConstructorAndValue() -> Bool {

--- a/test/SILGen/casts.swift
+++ b/test/SILGen/casts.swift
@@ -60,7 +60,7 @@ func is_archetype<T : B>(b: B, _: T) -> Bool {
   // CHECK:   integer_literal {{.*}} -1
   // CHECK:   destroy_value [[CASTED_ARG]]
   // CHECK: [[NO]]([[ORIGINAL_VALUE:%.*]] : @owned $B):
-  // CHCEK:   destroy_value [[CASTED_ARG]]
+  // CHECK:   destroy_value [[ORIGINAL_VALUE]]
   // CHECK:   integer_literal {{.*}} 0
   return b is T
 }

--- a/test/SILGen/closures.swift
+++ b/test/SILGen/closures.swift
@@ -206,7 +206,7 @@ func small_closure_capture(_ x: Int) -> Int {
 func small_closure_capture_with_argument(_ x: Int) -> (_ y: Int) -> Int {
   var x = x
   // CHECK: [[XBOX:%[0-9]+]] = alloc_box ${ var Int }
-  // CHEKC: [[XLIFETIME:%[0-9]+]] = begin_borrow [lexical] [[XBOX]]
+  // CHECK: [[XLIFETIME:%[0-9]+]] = begin_borrow [lexical] [[XBOX]]
 
   return { x + $0 }
   // -- func expression

--- a/test/SILGen/objc_imported_generic.swift
+++ b/test/SILGen/objc_imported_generic.swift
@@ -38,10 +38,10 @@ public func genericSubscriptOnAnyObject(o: AnyObject, b: Bool) -> AnyObject? {
 }
 
 // CHECK-LABEL: sil [ossa] @$s21objc_imported_generic0C20SubscriptOnAnyObject1o1byXlSgyXl_SbtF
-// CHECK: bb0([[ANY:%.*]]
-// CHCEK:   [[OPENED_ANY:%.*]] = open_existential_ref [[ANY]]
+// CHECK: bb0([[ANY:%.*]] : @guaranteed $AnyObject, [[BOOL:%.*]] : $Bool):
+// CHECK:   [[OPENED_ANY:%.*]] = open_existential_ref [[ANY]] : $AnyObject to $@opened([[TAG:.*]]) AnyObject
 // CHECK:   [[OPENED_ANY_COPY:%.*]] = copy_value [[OPENED_ANY]]
-// CHECK:   dynamic_method_br [[OPENED_ANY_COPY]] : $@opened([[TAG:.*]]) AnyObject, #GenericClass.subscript!getter.foreign, bb1
+// CHECK:   dynamic_method_br [[OPENED_ANY_COPY]] : $@opened([[TAG]]) AnyObject, #GenericClass.subscript!getter.foreign, bb1
 // CHECK:   bb1({{%.*}} : $@convention(objc_method) (UInt16, @opened([[TAG]]) AnyObject) -> @autoreleased AnyObject):
 // CHECK: } // end sil function '$s21objc_imported_generic0C20SubscriptOnAnyObject1o1byXlSgyXl_SbtF'
 

--- a/test/SILGen/versioned_attribute.swift
+++ b/test/SILGen/versioned_attribute.swift
@@ -22,5 +22,5 @@
 // CHECK-LABEL: sil [ossa] @$s19versioned_attribute5HorseCfd : $@convention(method) (@guaranteed Horse) -> @owned Builtin.NativeObject
 // CHECK-LABEL: sil [ossa] @$s19versioned_attribute5HorseCfD : $@convention(method) (@owned Horse) -> ()
 
-// CHEKC-LABEL: sil [ossa] @$s19versioned_attribute9GiftHorseCfd : $@convention(method) (@guaranteed GiftHorse) -> @owned Builtin.NativeObject
+// CHECK-LABEL: sil [ossa] @$s19versioned_attribute9GiftHorseCfd : $@convention(method) (@guaranteed GiftHorse) -> @owned Builtin.NativeObject
 // CHECK-LABEL: sil [ossa] @$s19versioned_attribute9GiftHorseCfD : $@convention(method) (@owned GiftHorse) -> ()


### PR DESCRIPTION
Fixes several misspelled `CHECK` lines in the tests (motivated by https://github.com/apple/swift/pull/42421). Most of the tests still passed after fixing just the `CHECK` spelling, but a few tests needed further updates.