### PR TITLE
[SILGen] Use opaque AP for ObjC-async returns.

### DIFF
--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -2839,7 +2839,7 @@ SILType GetAsyncContinuationInstBase::getLoweredResumeType() const {
   auto formalType = getFormalResumeType();
   auto &M = getFunction()->getModule();
   auto c = getFunction()->getTypeExpansionContext();
-  return M.Types.getLoweredType(AbstractionPattern(formalType), formalType, c);
+  return M.Types.getLoweredType(AbstractionPattern::getOpaque(), formalType, c);
 }
 
 ReturnInst::ReturnInst(SILFunction &func, SILDebugLocation debugLoc,

--- a/lib/SILGen/ResultPlan.cpp
+++ b/lib/SILGen/ResultPlan.cpp
@@ -506,9 +506,8 @@ public:
   {
     // Allocate space to receive the resume value when the continuation is
     // resumed.
-    opaqueResumeType =
-        SGF.getLoweredType(AbstractionPattern(calleeTypeInfo.substResultType),
-                           calleeTypeInfo.substResultType);
+    opaqueResumeType = SGF.getLoweredType(AbstractionPattern::getOpaque(),
+                                          calleeTypeInfo.substResultType);
     resumeBuf = SGF.emitTemporaryAllocation(loc, opaqueResumeType);
   }
   
@@ -707,14 +706,12 @@ public:
     // The incoming value is the maximally-abstracted result type of the
     // continuation. Move it out of the resume buffer and reabstract it if
     // necessary.
-    auto resumeResult = SGF.emitLoad(loc, resumeBuf,
-      calleeTypeInfo.origResultType
-         ? *calleeTypeInfo.origResultType
-         : AbstractionPattern(calleeTypeInfo.substResultType),
-                 calleeTypeInfo.substResultType,
-                 SGF.getTypeLowering(calleeTypeInfo.substResultType),
-                 SGFContext(), IsTake);
-    
+    auto resumeResult =
+        SGF.emitLoad(loc, resumeBuf, AbstractionPattern::getOpaque(),
+                     calleeTypeInfo.substResultType,
+                     SGF.getTypeLowering(calleeTypeInfo.substResultType),
+                     SGFContext(), IsTake);
+
     return RValue(SGF, loc, calleeTypeInfo.substResultType, resumeResult);
   }
 };

--- a/validation-test/SILGen/Inputs/rdar85526916.h
+++ b/validation-test/SILGen/Inputs/rdar85526916.h
@@ -1,0 +1,21 @@
+#include <Foundation/Foundation.h>
+
+#pragma clang assume_nonnull begin
+
+@interface PFXObject : NSObject
+- (void)performGetStringIdentityWithCompletionHandler:
+    (void (^)(NSString * _Nonnull(^ _Nonnull)(NSString * _Nonnull)))completionHandler;
+- (void)performGetStringAppendWithCompletionHandler:
+    (void (^)(NSString * _Nonnull(^ _Nonnull)(NSString * _Nonnull, NSString * _Nonnull)))completionHandler;
+- (void)performGetIntegerIdentityWithCompletionHandler:
+    (void (^)(NSInteger(^ _Nonnull)(NSInteger)))completionHandler;
+- (void)performGetIntegerSubtractWithCompletionHandler:
+    (void (^)(NSInteger(^ _Nonnull)(NSInteger, NSInteger)))completionHandler;
+- (void)performGetUIntegerIdentityWithCompletionHandler:
+    (void (^)(NSUInteger(^ _Nonnull)(NSUInteger)))completionHandler;
+- (void)performGetUIntegerAddWithCompletionHandler:
+    (void (^)(NSUInteger(^ _Nonnull)(NSUInteger, NSUInteger)))completionHandler;
+@end
+
+#pragma clang assume_nonnull end
+

--- a/validation-test/SILGen/Inputs/rdar85526916.m
+++ b/validation-test/SILGen/Inputs/rdar85526916.m
@@ -1,0 +1,45 @@
+#include "rdar85526916.h"
+
+#pragma clang assume_nonnull begin
+
+@implementation PFXObject
+- (void)performGetStringIdentityWithCompletionHandler:
+    (void (^)(NSString * _Nonnull(^ _Nonnull)(NSString * _Nonnull)))completionHandler {
+  completionHandler(^(NSString * _Nonnull input) {
+    return input;
+  });
+}
+- (void)performGetStringAppendWithCompletionHandler:
+    (void (^)(NSString * _Nonnull(^ _Nonnull)(NSString * _Nonnull, NSString * _Nonnull)))completionHandler {
+  completionHandler(^(NSString * _Nonnull one, NSString * _Nonnull two) {
+    return [one stringByAppendingString: two];
+  });
+}
+- (void)performGetIntegerIdentityWithCompletionHandler:
+    (void (^)(NSInteger(^ _Nonnull)(NSInteger)))completionHandler {
+  completionHandler(^(NSInteger input) {
+    return input;
+  });
+}
+- (void)performGetIntegerSubtractWithCompletionHandler:
+    (void (^)(NSInteger(^ _Nonnull)(NSInteger, NSInteger)))completionHandler {
+  completionHandler(^(NSInteger lhs, NSInteger rhs) {
+    return lhs - rhs;
+  });
+}
+- (void)performGetUIntegerIdentityWithCompletionHandler:
+    (void (^)(NSUInteger(^ _Nonnull)(NSUInteger)))completionHandler {
+  completionHandler(^(NSUInteger input) {
+    return input;
+  });
+}
+- (void)performGetUIntegerAddWithCompletionHandler:
+    (void (^)(NSUInteger(^ _Nonnull)(NSUInteger, NSUInteger)))completionHandler {
+  completionHandler(^(NSUInteger lhs, NSUInteger rhs) {
+    return lhs + rhs;
+  });
+}
+@end
+
+#pragma clang assume_nonnull end
+

--- a/validation-test/SILGen/rdar85526916.swift
+++ b/validation-test/SILGen/rdar85526916.swift
@@ -1,0 +1,34 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang %S/Inputs/rdar85526916.m -I %S/Inputs -c -o %t/rdar85526916.o
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -import-objc-header %S/Inputs/rdar85526916.h -Xlinker %t/rdar85526916.o -parse-as-library %s -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+func run(on object: PFXObject) async throws {
+  // CHECK: howdy
+  print(await object.performGetStringIdentity()("howdy"))
+  // CHECK: mundo
+  print(await object.performGetStringAppend()("mun", "do"))
+  // CHECK: -9035768
+  print(await object.performGetIntegerIdentity()(-9035768))
+  // CHECK: 57
+  print(await object.performGetIntegerSubtract()(60, 3))
+  // CHECK: 9035768
+  print(await object.performGetUIntegerIdentity()(9035768))
+  // CHECK: 3
+  print(await object.performGetUIntegerAdd()(1+1, 1))
+}
+
+@main struct Main {
+  static func main() async throws {
+    let object = PFXObject()
+    try await run(on: object)
+  }
+}
+

--- a/validation-test/compiler_crashers_2_fixed/rdar79383990.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar79383990.swift
@@ -1,6 +1,5 @@
 // RUN: %target-swift-frontend %s -emit-silgen -disable-availability-checking -import-objc-header %S/Inputs/rdar79383990.h
 // REQUIRES: objc_interop
-// REQUIRES: OS=macosx
 
 import Foundation
 

--- a/validation-test/compiler_crashers_2_fixed/rdar81590807.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar81590807.swift
@@ -12,8 +12,6 @@
 
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx || OS=ios
-// Enable with rdar://85526879
-// UNSUPPORTED: CPU=arm64e
 
 // rdar://82123254
 // UNSUPPORTED: use_os_stdlib

--- a/validation-test/compiler_crashers_2_fixed/rdar81617749.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar81617749.swift
@@ -9,8 +9,6 @@
 
 // Enable with rdar://81617749
 // UNSUPPORTED: CPU=i386 && OS=watchos
-// Enable with rdar://85526916
-// UNSUPPORTED: CPU=arm64e
 
 // rdar://82123254
 // UNSUPPORTED: use_os_stdlib


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/42508 .

Previously, the `AbstractionPattern` that was used for the value "returned" (i.e. via a completion handler) from ObjC mostly (but not quite always) was "type".

The generated completion handler correctly (because this is required in order to call `_resumeUnsafeContinuation`) reabstracted the block (e.g.  from `@convention(block) () -> ()` to `@substituted <T> () -> @out T for <()>`).  The callee of the ObjC function, however, loaded the function from the block as if it were not reabstracted (e.g. `() -> ()`).

On most platforms, that happened to work.  On arm64e, that difference in types caused in a difference in pointer signing, resulting in a failure at runtime.

rdar://85526879
rdar://85526916
