### PR TITLE
Rename -strict-concurrency=explicit to minimal

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -62,7 +62,7 @@ namespace swift {
   enum class StrictConcurrency {
     /// Enforce Sendable constraints where it has been explicitly adopted and
     /// perform actor-isolation checking wherever code has adopted concurrency.
-    Explicit,
+    Minimal,
     /// Enforce Sendable constraints and perform actor-isolation checking
     /// wherever code has adopted concurrency, including code that has
     /// explicitly adopted Sendable.

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -697,7 +697,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     Opts.StrictConcurrencyLevel = StrictConcurrency::Complete;
   } else if (const Arg *A = Args.getLastArg(OPT_strict_concurrency)) {
     auto value = llvm::StringSwitch<Optional<StrictConcurrency>>(A->getValue())
-      .Case("explicit", StrictConcurrency::Explicit)
+      .Case("minimal", StrictConcurrency::Minimal)
       .Case("targeted", StrictConcurrency::Targeted)
       .Case("complete", StrictConcurrency::Complete)
       .Default(None);

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -659,7 +659,7 @@ SendableCheckContext::implicitSendableDiagnosticBehavior() const {
 
     LLVM_FALLTHROUGH;
 
-  case StrictConcurrency::Explicit:
+  case StrictConcurrency::Minimal:
     // Explicit Sendable conformances always diagnose, even when strict
     // strict checking is disabled.
     if (isExplicitSendableConformance())
@@ -2140,7 +2140,7 @@ namespace {
     /// \returns true if we diagnosed the entity, \c false otherwise.
     bool diagnoseReferenceToUnsafeGlobal(ValueDecl *value, SourceLoc loc) {
       switch (value->getASTContext().LangOpts.StrictConcurrencyLevel) {
-      case StrictConcurrency::Explicit:
+      case StrictConcurrency::Minimal:
       case StrictConcurrency::Targeted:
         // Never diagnose.
         return false;
@@ -3926,7 +3926,7 @@ bool swift::contextRequiresStrictConcurrencyChecking(
     return true;
 
   case StrictConcurrency::Targeted:
-  case StrictConcurrency::Explicit:
+  case StrictConcurrency::Minimal:
     // Check below to see if the context has adopted concurrency features.
     break;
   }

--- a/test/Concurrency/strict_concurrency_minimal.swift
+++ b/test/Concurrency/strict_concurrency_minimal.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -strict-concurrency=explicit
+// RUN: %target-typecheck-verify-swift -strict-concurrency=minimal
 // REQUIRES: concurrency
 
 class C1 { }


### PR DESCRIPTION
This makes it far more clear what the relative ordering of the options is.

Thanks, Jake!
