### PR TITLE
Implement -strict-concurrency control and default to "minimal"

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -60,15 +60,16 @@ namespace swift {
 
   /// Describes how strict concurrency checking should be.
   enum class StrictConcurrency {
-    /// Turns off strict checking, which disables (e.g.) Sendable checking in
-    /// most cases.
-    Off,
-    /// Enables concurrency checking in a limited manner that is intended to
-    /// only affect code that has already adopted the concurrency model.
-    Limited,
-    /// Enables strict concurrency checking throughout the entire model,
-    /// providing an approximation of the fully-checked model.
-    On
+    /// Enforce Sendable constraints where it has been explicitly adopted and
+    /// perform actor-isolation checking wherever code has adopted concurrency.
+    Explicit,
+    /// Enforce Sendable constraints and perform actor-isolation checking
+    /// wherever code has adopted concurrency, including code that has
+    /// explicitly adopted Sendable.
+    Targeted,
+    /// Enforce Sendable constraints and actor-isolation checking throughout
+    /// the entire module.
+    Complete,
   };
 
   /// Access or distribution level of a library.
@@ -324,7 +325,7 @@ namespace swift {
     bool UseMalloc = false;
 
     /// Specifies how strict concurrency checking will be.
-    StrictConcurrency StrictConcurrencyLevel = StrictConcurrency::Limited;
+    StrictConcurrency StrictConcurrencyLevel = StrictConcurrency::Targeted;
 
     /// Enable experimental #assert feature.
     bool EnableExperimentalStaticAssert = false;

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -62,7 +62,7 @@ namespace swift {
   enum class StrictConcurrency {
     /// Enforce Sendable constraints where it has been explicitly adopted and
     /// perform actor-isolation checking wherever code has adopted concurrency.
-    Explicit,
+    Minimal,
     /// Enforce Sendable constraints and perform actor-isolation checking
     /// wherever code has adopted concurrency, including code that has
     /// explicitly adopted Sendable.

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -58,6 +58,19 @@ namespace swift {
     Complete,
   };
 
+  /// Describes how strict concurrency checking should be.
+  enum class StrictConcurrency {
+    /// Turns off strict checking, which disables (e.g.) Sendable checking in
+    /// most cases.
+    Off,
+    /// Enables concurrency checking in a limited manner that is intended to
+    /// only affect code that has already adopted the concurrency model.
+    Limited,
+    /// Enables strict concurrency checking throughout the entire model,
+    /// providing an approximation of the fully-checked model.
+    On
+  };
+
   /// Access or distribution level of a library.
   enum class LibraryLevel : uint8_t {
     /// Application Programming Interface that is publicly distributed so
@@ -310,11 +323,8 @@ namespace swift {
     /// optimized custom allocator, so that memory debugging tools can be used.
     bool UseMalloc = false;
 
-    /// Provide additional warnings about code that is unsafe in the
-    /// eventual Swift concurrency model, and will eventually become errors
-    /// in a future Swift language version, but are too noisy for existing
-    /// language modes.
-    bool WarnConcurrency = false;
+    /// Specifies how strict concurrency checking will be.
+    StrictConcurrency StrictConcurrencyLevel = StrictConcurrency::Limited;
 
     /// Enable experimental #assert feature.
     bool EnableExperimentalStaticAssert = false;

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -325,7 +325,7 @@ namespace swift {
     bool UseMalloc = false;
 
     /// Specifies how strict concurrency checking will be.
-    StrictConcurrency StrictConcurrencyLevel = StrictConcurrency::Targeted;
+    StrictConcurrency StrictConcurrencyLevel = StrictConcurrency::Minimal;
 
     /// Enable experimental #assert feature.
     bool EnableExperimentalStaticAssert = false;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -706,9 +706,9 @@ def warn_concurrency : Flag<["-"], "warn-concurrency">,
 def strict_concurrency : Joined<["-"], "strict-concurrency=">,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Specify the how strict concurrency checking will be. The value may "
-           "be 'off' (most 'Sendable' checking is disabled), "
-           "'limited' ('Sendable' checking is enabled in code that uses the "
-           "concurrency model, or 'on' ('Sendable' and other checking is "
+           "be 'explicit' (most 'Sendable' checking is disabled), "
+           "'targeted' ('Sendable' checking is enabled in code that uses the "
+           "concurrency model, or 'complete' ('Sendable' and other checking is "
            "enabled for all code in the module)">;
 
 def Rpass_EQ : Joined<["-"], "Rpass=">,

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -699,12 +699,12 @@ def warn_swift3_objc_inference : Flag<["-"], "warn-swift3-objc-inference">,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild, HelpHidden]>;
 
 def warn_concurrency : Flag<["-"], "warn-concurrency">,
-  Flags<[FrontendOption, DoesNotAffectIncrementalBuild, ModuleInterfaceOptionIgnorable]>,
+  Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Warn about code that is unsafe according to the Swift Concurrency "
            "model and will become ill-formed in a future language version">;
 
 def strict_concurrency : Joined<["-"], "strict-concurrency=">,
-  Flags<[FrontendOption, ModuleInterfaceOptionIgnorable]>,
+  Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Specify the how strict concurrency checking will be. The value may "
            "be 'off' (most 'Sendable' checking is disabled), "
            "'limited' ('Sendable' checking is enabled in code that uses the "

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -703,6 +703,14 @@ def warn_concurrency : Flag<["-"], "warn-concurrency">,
   HelpText<"Warn about code that is unsafe according to the Swift Concurrency "
            "model and will become ill-formed in a future language version">;
 
+def strict_concurrency : Joined<["-"], "strict-concurrency=">,
+  Flags<[FrontendOption, ModuleInterfaceOptionIgnorable]>,
+  HelpText<"Specify the how strict concurrency checking will be. The value may "
+           "be 'off' (most 'Sendable' checking is disabled), "
+           "'limited' ('Sendable' checking is enabled in code that uses the "
+           "concurrency model, or 'on' ('Sendable' and other checking is "
+           "enabled for all code in the module)">;
+
 def Rpass_EQ : Joined<["-"], "Rpass=">,
   Flags<[FrontendOption]>,
   HelpText<"Report performed transformations by optimization passes whose "

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9164,7 +9164,7 @@ ActorIsolation swift::getActorIsolationOfContext(DeclContext *dc) {
   if (auto *tld = dyn_cast<TopLevelCodeDecl>(dc)) {
     if (dc->isAsyncContext() ||
         dc->getASTContext().LangOpts.StrictConcurrencyLevel
-            >= StrictConcurrency::On) {
+            >= StrictConcurrency::Complete) {
       if (Type mainActor = dc->getASTContext().getMainActorType())
         return ActorIsolation::forGlobalActor(
             mainActor,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9162,7 +9162,9 @@ ActorIsolation swift::getActorIsolationOfContext(DeclContext *dc) {
   }
 
   if (auto *tld = dyn_cast<TopLevelCodeDecl>(dc)) {
-    if (dc->isAsyncContext() || dc->getASTContext().LangOpts.WarnConcurrency) {
+    if (dc->isAsyncContext() ||
+        dc->getASTContext().LangOpts.StrictConcurrencyLevel
+            >= StrictConcurrency::On) {
       if (Type mainActor = dc->getASTContext().getMainActorType())
         return ActorIsolation::forGlobalActor(
             mainActor,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -235,6 +235,7 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
                        options::OPT_enable_actor_data_race_checks,
                        options::OPT_disable_actor_data_race_checks);
   inputArgs.AddLastArg(arguments, options::OPT_warn_concurrency);
+  inputArgs.AddLastArg(arguments, options::OPT_strict_concurrency);
   inputArgs.AddLastArg(arguments, options::OPT_warn_implicit_overrides);
   inputArgs.AddLastArg(arguments, options::OPT_typo_correction_limit);
   inputArgs.AddLastArg(arguments, options::OPT_enable_app_extension);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -684,7 +684,28 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     }
   }
 
-  Opts.WarnConcurrency |= Args.hasArg(OPT_warn_concurrency);
+  // Swift 6+ uses the strictest concurrency level.
+  if (Opts.isSwiftVersionAtLeast(6)) {
+    Opts.StrictConcurrencyLevel = StrictConcurrency::On;
+  } else if (const Arg *A = Args.getLastArg(OPT_strict_concurrency)) {
+    auto value = llvm::StringSwitch<Optional<StrictConcurrency>>(A->getValue())
+      .Case("off", StrictConcurrency::Off)
+      .Case("limited", StrictConcurrency::Limited)
+      .Case("on", StrictConcurrency::On)
+      .Default(None);
+
+    if (value)
+      Opts.StrictConcurrencyLevel = *value;
+    else
+      Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
+                     A->getAsString(Args), A->getValue());
+
+  } else if (Args.hasArg(OPT_warn_concurrency)) {
+    Opts.StrictConcurrencyLevel = StrictConcurrency::On;
+  } else {
+    // Default to "limited" checking in Swift 5.x.
+    Opts.StrictConcurrencyLevel = StrictConcurrency::Limited;
+  }
 
   Opts.WarnImplicitOverrides =
     Args.hasArg(OPT_warn_implicit_overrides);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -689,7 +689,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     Opts.StrictConcurrencyLevel = StrictConcurrency::Complete;
   } else if (const Arg *A = Args.getLastArg(OPT_strict_concurrency)) {
     auto value = llvm::StringSwitch<Optional<StrictConcurrency>>(A->getValue())
-      .Case("explicit", StrictConcurrency::Explicit)
+      .Case("minimal", StrictConcurrency::Minimal)
       .Case("targeted", StrictConcurrency::Targeted)
       .Case("complete", StrictConcurrency::Complete)
       .Default(None);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -686,12 +686,12 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   // Swift 6+ uses the strictest concurrency level.
   if (Opts.isSwiftVersionAtLeast(6)) {
-    Opts.StrictConcurrencyLevel = StrictConcurrency::On;
+    Opts.StrictConcurrencyLevel = StrictConcurrency::Complete;
   } else if (const Arg *A = Args.getLastArg(OPT_strict_concurrency)) {
     auto value = llvm::StringSwitch<Optional<StrictConcurrency>>(A->getValue())
-      .Case("off", StrictConcurrency::Off)
-      .Case("limited", StrictConcurrency::Limited)
-      .Case("on", StrictConcurrency::On)
+      .Case("explicit", StrictConcurrency::Explicit)
+      .Case("targeted", StrictConcurrency::Targeted)
+      .Case("complete", StrictConcurrency::Complete)
       .Default(None);
 
     if (value)
@@ -701,10 +701,10 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
                      A->getAsString(Args), A->getValue());
 
   } else if (Args.hasArg(OPT_warn_concurrency)) {
-    Opts.StrictConcurrencyLevel = StrictConcurrency::On;
+    Opts.StrictConcurrencyLevel = StrictConcurrency::Complete;
   } else {
     // Default to "limited" checking in Swift 5.x.
-    Opts.StrictConcurrencyLevel = StrictConcurrency::Limited;
+    Opts.StrictConcurrencyLevel = StrictConcurrency::Targeted;
   }
 
   Opts.WarnImplicitOverrides =

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -703,8 +703,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   } else if (Args.hasArg(OPT_warn_concurrency)) {
     Opts.StrictConcurrencyLevel = StrictConcurrency::Complete;
   } else {
-    // Default to "limited" checking in Swift 5.x.
-    Opts.StrictConcurrencyLevel = StrictConcurrency::Targeted;
+    // Default to minimal checking in Swift 5.x.
+    Opts.StrictConcurrencyLevel = StrictConcurrency::Minimal;
   }
 
   Opts.WarnImplicitOverrides =

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1018,8 +1018,7 @@ ModuleDecl *CompilerInstance::getMainModule() const {
     }
     if (Invocation.getFrontendOptions().EnableLibraryEvolution)
       MainModule->setResilienceStrategy(ResilienceStrategy::Resilient);
-    if (Invocation.getLangOptions().StrictConcurrencyLevel
-            >= StrictConcurrency::On)
+    if (Invocation.getLangOptions().isSwiftVersionAtLeast(6))
       MainModule->setIsConcurrencyChecked(true);
 
     // Register the main module with the AST context.

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1018,8 +1018,8 @@ ModuleDecl *CompilerInstance::getMainModule() const {
     }
     if (Invocation.getFrontendOptions().EnableLibraryEvolution)
       MainModule->setResilienceStrategy(ResilienceStrategy::Resilient);
-    if (Invocation.getLangOptions().WarnConcurrency ||
-        Invocation.getLangOptions().isSwiftVersionAtLeast(6))
+    if (Invocation.getLangOptions().StrictConcurrencyLevel
+            >= StrictConcurrency::On)
       MainModule->setIsConcurrencyChecked(true);
 
     // Register the main module with the AST context.

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -768,7 +768,7 @@ void CompletionLookup::analyzeActorIsolation(
   }
 
   // If the reference is 'async', all types must be 'Sendable'.
-  if (Ctx.LangOpts.StrictConcurrencyLevel >= StrictConcurrency::On &&
+  if (Ctx.LangOpts.StrictConcurrencyLevel >= StrictConcurrency::Complete &&
       implicitlyAsync && T) {
     auto *M = CurrDeclContext->getParentModule();
     if (isa<VarDecl>(VD)) {

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -750,8 +750,7 @@ void CompletionLookup::analyzeActorIsolation(
     // For "unsafe" global actor isolation, automatic 'async' only happens
     // if the context has adopted concurrency.
     if (!CanCurrDeclContextHandleAsync &&
-        !completionContextUsesConcurrencyFeatures(CurrDeclContext) &&
-        !CurrDeclContext->getParentModule()->isConcurrencyChecked()) {
+        !completionContextUsesConcurrencyFeatures(CurrDeclContext)) {
       return;
     }
     LLVM_FALLTHROUGH;
@@ -769,7 +768,7 @@ void CompletionLookup::analyzeActorIsolation(
   }
 
   // If the reference is 'async', all types must be 'Sendable'.
-  if (CurrDeclContext->getParentModule()->isConcurrencyChecked() &&
+  if (Ctx.LangOpts.StrictConcurrencyLevel >= StrictConcurrency::On &&
       implicitlyAsync && T) {
     auto *M = CurrDeclContext->getParentModule();
     if (isa<VarDecl>(VD)) {

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -347,7 +347,7 @@ GlobalActorAttributeRequest::evaluate(
       if (var->isTopLevelGlobal() &&
           (var->getDeclContext()->isAsyncContext() ||
            var->getASTContext().LangOpts.StrictConcurrencyLevel >=
-             StrictConcurrency::On)) {
+             StrictConcurrency::Complete)) {
         var->diagnose(diag::global_actor_top_level_var)
             .highlight(globalActorAttr->getRangeWithAt());
         return None;
@@ -771,7 +771,7 @@ DiagnosticBehavior SendableCheckContext::defaultDiagnosticBehavior() const {
 DiagnosticBehavior
 SendableCheckContext::implicitSendableDiagnosticBehavior() const {
   switch (fromDC->getASTContext().LangOpts.StrictConcurrencyLevel) {
-  case StrictConcurrency::Limited:
+  case StrictConcurrency::Targeted:
     // Limited checking only diagnoses implicit Sendable within contexts that
     // have adopted concurrency.
     if (shouldDiagnoseExistingDataRaces(fromDC))
@@ -779,7 +779,7 @@ SendableCheckContext::implicitSendableDiagnosticBehavior() const {
 
     LLVM_FALLTHROUGH;
 
-  case StrictConcurrency::Off:
+  case StrictConcurrency::Explicit:
     // Explicit Sendable conformances always diagnose, even when strict
     // strict checking is disabled.
     if (isExplicitSendableConformance())
@@ -787,7 +787,7 @@ SendableCheckContext::implicitSendableDiagnosticBehavior() const {
 
     return DiagnosticBehavior::Ignore;
 
-  case StrictConcurrency::On:
+  case StrictConcurrency::Complete:
     return defaultDiagnosticBehavior();
   }
 }
@@ -2071,12 +2071,12 @@ namespace {
     /// \returns true if we diagnosed the entity, \c false otherwise.
     bool diagnoseReferenceToUnsafeGlobal(ValueDecl *value, SourceLoc loc) {
       switch (value->getASTContext().LangOpts.StrictConcurrencyLevel) {
-      case StrictConcurrency::Off:
-      case StrictConcurrency::Limited:
+      case StrictConcurrency::Explicit:
+      case StrictConcurrency::Targeted:
         // Never diagnose.
         return false;
 
-      case StrictConcurrency::On:
+      case StrictConcurrency::Complete:
         break;
       }
 
@@ -3984,7 +3984,7 @@ ActorIsolation ActorIsolationRequest::evaluate(
   if (auto var = dyn_cast<VarDecl>(value)) {
     if (var->isTopLevelGlobal() &&
         (var->getASTContext().LangOpts.StrictConcurrencyLevel >=
-             StrictConcurrency::On ||
+             StrictConcurrency::Complete ||
          var->getDeclContext()->isAsyncContext())) {
       if (Type mainActor = var->getASTContext().getMainActorType())
         return inferredIsolation(
@@ -4186,11 +4186,11 @@ bool swift::contextRequiresStrictConcurrencyChecking(
     const DeclContext *dc,
     llvm::function_ref<Type(const AbstractClosureExpr *)> getType) {
   switch (dc->getASTContext().LangOpts.StrictConcurrencyLevel) {
-  case StrictConcurrency::On:
+  case StrictConcurrency::Complete:
     return true;
 
-  case StrictConcurrency::Limited:
-  case StrictConcurrency::Off:
+  case StrictConcurrency::Targeted:
+  case StrictConcurrency::Explicit:
     // Check below to see if the context has adopted concurrency features.
     break;
   }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -346,7 +346,8 @@ GlobalActorAttributeRequest::evaluate(
       // ... but not if it's an async-context top-level global
       if (var->isTopLevelGlobal() &&
           (var->getDeclContext()->isAsyncContext() ||
-           var->getASTContext().LangOpts.WarnConcurrency)) {
+           var->getASTContext().LangOpts.StrictConcurrencyLevel >=
+             StrictConcurrency::On)) {
         var->diagnose(diag::global_actor_top_level_var)
             .highlight(globalActorAttr->getRangeWithAt());
         return None;
@@ -3954,7 +3955,8 @@ ActorIsolation ActorIsolationRequest::evaluate(
 
   if (auto var = dyn_cast<VarDecl>(value)) {
     if (var->isTopLevelGlobal() &&
-        (var->getASTContext().LangOpts.WarnConcurrency ||
+        (var->getASTContext().LangOpts.StrictConcurrencyLevel >=
+             StrictConcurrency::On ||
          var->getDeclContext()->isAsyncContext())) {
       if (Type mainActor = var->getASTContext().getMainActorType())
         return inferredIsolation(

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -728,9 +728,6 @@ static bool hasUnavailableConformance(ProtocolConformanceRef conformance) {
 }
 
 static bool shouldDiagnoseExistingDataRaces(const DeclContext *dc) {
-  if (dc->getParentModule()->isConcurrencyChecked())
-    return true;
-
   return contextRequiresStrictConcurrencyChecking(dc, [](const AbstractClosureExpr *) {
     return Type();
   });
@@ -2049,8 +2046,15 @@ namespace {
     ///
     /// \returns true if we diagnosed the entity, \c false otherwise.
     bool diagnoseReferenceToUnsafeGlobal(ValueDecl *value, SourceLoc loc) {
-      if (!getDeclContext()->getParentModule()->isConcurrencyChecked())
+      switch (value->getASTContext().LangOpts.StrictConcurrencyLevel) {
+      case StrictConcurrency::Off:
+      case StrictConcurrency::Limited:
+        // Never diagnose.
         return false;
+
+      case StrictConcurrency::On:
+        break;
+      }
 
       // Only diagnose direct references to mutable global state.
       auto var = dyn_cast<VarDecl>(value);
@@ -4157,9 +4161,15 @@ void swift::checkOverrideActorIsolation(ValueDecl *value) {
 bool swift::contextRequiresStrictConcurrencyChecking(
     const DeclContext *dc,
     llvm::function_ref<Type(const AbstractClosureExpr *)> getType) {
-  // If Swift >= 6, everything uses strict concurrency checking.
-  if (dc->getASTContext().LangOpts.isSwiftVersionAtLeast(6))
+  switch (dc->getASTContext().LangOpts.StrictConcurrencyLevel) {
+  case StrictConcurrency::On:
     return true;
+
+  case StrictConcurrency::Limited:
+  case StrictConcurrency::Off:
+    // Check below to see if the context has adopted concurrency features.
+    break;
+  }
 
   while (!dc->isModuleScopeContext()) {
     if (auto closure = dyn_cast<AbstractClosureExpr>(dc)) {

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -736,7 +736,7 @@ static bool shouldDiagnoseExistingDataRaces(const DeclContext *dc) {
 /// Determine the default diagnostic behavior for this language mode.
 static DiagnosticBehavior defaultSendableDiagnosticBehavior(
     const LangOptions &langOpts) {
-  // Prior to Swift 6, all Sendable-related diagnostics are warnings.
+  // Prior to Swift 6, all Sendable-related diagnostics are warnings at most.
   if (!langOpts.isSwiftVersionAtLeast(6))
     return DiagnosticBehavior::Warning;
 
@@ -766,6 +766,30 @@ DiagnosticBehavior SendableCheckContext::defaultDiagnosticBehavior() const {
     return DiagnosticBehavior::Ignore;
 
   return defaultSendableDiagnosticBehavior(fromDC->getASTContext().LangOpts);
+}
+
+DiagnosticBehavior
+SendableCheckContext::implicitSendableDiagnosticBehavior() const {
+  switch (fromDC->getASTContext().LangOpts.StrictConcurrencyLevel) {
+  case StrictConcurrency::Limited:
+    // Limited checking only diagnoses implicit Sendable within contexts that
+    // have adopted concurrency.
+    if (shouldDiagnoseExistingDataRaces(fromDC))
+      return DiagnosticBehavior::Warning;
+
+    LLVM_FALLTHROUGH;
+
+  case StrictConcurrency::Off:
+    // Explicit Sendable conformances always diagnose, even when strict
+    // strict checking is disabled.
+    if (isExplicitSendableConformance())
+      return DiagnosticBehavior::Warning;
+
+    return DiagnosticBehavior::Ignore;
+
+  case StrictConcurrency::On:
+    return defaultDiagnosticBehavior();
+  }
 }
 
 /// Determine whether the given nominal type has an explicit Sendable
@@ -862,10 +886,10 @@ DiagnosticBehavior SendableCheckContext::diagnosticBehavior(
         : DiagnosticBehavior::Ignore;
   }
 
-  auto defaultBehavior = defaultDiagnosticBehavior();
+  DiagnosticBehavior defaultBehavior = implicitSendableDiagnosticBehavior();
 
   // If we are checking an implicit Sendable conformance, don't suppress
-  // diagnostics for declarations in the same module. We want them so make
+  // diagnostics for declarations in the same module. We want them to make
   // enclosing inferred types non-Sendable.
   if (defaultBehavior == DiagnosticBehavior::Ignore &&
       nominal->getParentSourceFile() &&
@@ -883,7 +907,7 @@ bool swift::diagnoseSendabilityErrorBasedOn(
   if (nominal) {
     behavior = fromContext.diagnosticBehavior(nominal);
   } else {
-    behavior = fromContext.defaultDiagnosticBehavior();
+    behavior = fromContext.implicitSendableDiagnosticBehavior();
   }
 
   bool wasSuppressed = diagnose(behavior);

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -779,7 +779,7 @@ SendableCheckContext::implicitSendableDiagnosticBehavior() const {
 
     LLVM_FALLTHROUGH;
 
-  case StrictConcurrency::Explicit:
+  case StrictConcurrency::Minimal:
     // Explicit Sendable conformances always diagnose, even when strict
     // strict checking is disabled.
     if (isExplicitSendableConformance())
@@ -2071,7 +2071,7 @@ namespace {
     /// \returns true if we diagnosed the entity, \c false otherwise.
     bool diagnoseReferenceToUnsafeGlobal(ValueDecl *value, SourceLoc loc) {
       switch (value->getASTContext().LangOpts.StrictConcurrencyLevel) {
-      case StrictConcurrency::Explicit:
+      case StrictConcurrency::Minimal:
       case StrictConcurrency::Targeted:
         // Never diagnose.
         return false;
@@ -4190,7 +4190,7 @@ bool swift::contextRequiresStrictConcurrencyChecking(
     return true;
 
   case StrictConcurrency::Targeted:
-  case StrictConcurrency::Explicit:
+  case StrictConcurrency::Minimal:
     // Check below to see if the context has adopted concurrency features.
     break;
   }

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -300,6 +300,9 @@ struct SendableCheckContext {
   /// Sendable conformance in this context.
   DiagnosticBehavior defaultDiagnosticBehavior() const;
 
+  /// Determine the diagnostic behavior for an implicitly non-Sendable type.
+  DiagnosticBehavior implicitSendableDiagnosticBehavior() const;
+
   /// Determine the diagnostic behavior when referencing the given nominal
   /// type in this context.
   DiagnosticBehavior diagnosticBehavior(NominalTypeDecl *nominal) const;

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules %s -verify -verify-additional-file %swift_src_root/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h -strict-concurrency=limited -parse-as-library
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules %s -verify -verify-additional-file %swift_src_root/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h -strict-concurrency=targeted -parse-as-library
 
 // REQUIRES: objc_interop
 // REQUIRES: concurrency

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -1,10 +1,9 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules %s -verify -verify-additional-file %swift_src_root/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h -warn-concurrency -parse-as-library
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules %s -verify -verify-additional-file %swift_src_root/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h -strict-concurrency=limited -parse-as-library
 
 // REQUIRES: objc_interop
 // REQUIRES: concurrency
 import Foundation
 import ObjCConcurrency
-// expected-remark@-1{{add '@preconcurrency' to suppress 'Sendable'-related warnings from module 'ObjCConcurrency'}}
 
 @available(SwiftStdlib 5.5, *)
 @MainActor func onlyOnMainActor() { }
@@ -358,8 +357,6 @@ func testSender(
   // expected-warning@-1 {{conformance of 'NonSendableClass' to 'Sendable' is unavailable}}
 
   sender.sendGeneric(sendableGeneric)
-  // expected-warning@-1 {{type 'GenericObject<SendableClass>' does not conform to the 'Sendable' protocol}}
-  // FIXME(rdar://89992569): Should allow for the possibility that GenericObject will have a Sendable subclass
   sender.sendGeneric(nonSendableGeneric)
   // expected-error@-1 {{argument type 'GenericObject<SendableClass>' does not conform to expected type 'Sendable'}}
   // FIXME(rdar://89992095): Should be a warning because we're in -warn-concurrency

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -463,7 +463,7 @@ func testGlobalActorClosures() {
     return 17
   }
 
-  acceptConcurrentClosure { @SomeGlobalActor in 5 } // expected-warning{{converting function value of type '@SomeGlobalActor @Sendable () -> Int' to '@Sendable () -> Int' loses global actor 'SomeGlobalActor'}}
+  acceptConcurrentClosure { @SomeGlobalActor in 5 } // expected-error{{converting function value of type '@SomeGlobalActor @Sendable () -> Int' to '@Sendable () -> Int' loses global actor 'SomeGlobalActor'}}
 }
 
 @available(SwiftStdlib 5.1, *)

--- a/test/Concurrency/async_tasks.swift
+++ b/test/Concurrency/async_tasks.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift  -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -strict-concurrency=limited -disable-availability-checking
 // REQUIRES: concurrency
 
 @available(SwiftStdlib 5.1, *)

--- a/test/Concurrency/async_tasks.swift
+++ b/test/Concurrency/async_tasks.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -strict-concurrency=limited -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -strict-concurrency=targeted -disable-availability-checking
 // REQUIRES: concurrency
 
 @available(SwiftStdlib 5.1, *)

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -174,7 +174,7 @@ func testConcurrency() {
 func testUnsafeSendableNothing() {
   var x = 5
   acceptUnsafeSendable {
-    x = 17
+    x = 17 // expected-error{{mutation of captured var 'x' in concurrently-executing code}}
   }
   print(x)
 }

--- a/test/Concurrency/predates_concurrency_import.swift
+++ b/test/Concurrency/predates_concurrency_import.swift
@@ -1,9 +1,11 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -warn-concurrency %S/Inputs/StrictModule.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -swift-version 6 %S/Inputs/StrictModule.swift
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -disable-availability-checking
 
 // RUN: %target-typecheck-verify-swift -typecheck  -I %t
+// REQUIRES: concurrency
+// REQUIRES: asserts
 
 @preconcurrency import NonStrictModule
 @_predatesConcurrency import StrictModule // expected-warning{{'@_predatesConcurrency' has been renamed to '@preconcurrency'}}

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -strict-concurrency=limited
 // REQUIRES: concurrency
 // REQUIRES: OS=macosx
 

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -strict-concurrency=limited
+// RUN: %target-typecheck-verify-swift -strict-concurrency=targeted
 // REQUIRES: concurrency
 // REQUIRES: OS=macosx
 

--- a/test/Concurrency/sendable_module_checking.swift
+++ b/test/Concurrency/sendable_module_checking.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -warn-concurrency %S/Inputs/StrictModule.swift
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
-// RUN: %target-swift-frontend -typecheck -disable-availability-checking -I %t 2>&1 %s | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -strict-concurrency=limited -disable-availability-checking -I %t 2>&1 %s | %FileCheck %s
 
 // REQUIRES: concurrency
 

--- a/test/Concurrency/sendable_module_checking.swift
+++ b/test/Concurrency/sendable_module_checking.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -warn-concurrency %S/Inputs/StrictModule.swift
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
-// RUN: %target-swift-frontend -typecheck -strict-concurrency=limited -disable-availability-checking -I %t 2>&1 %s | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -strict-concurrency=targeted -disable-availability-checking -I %t 2>&1 %s | %FileCheck %s
 
 // REQUIRES: concurrency
 

--- a/test/Concurrency/sendable_preconcurrency.swift
+++ b/test/Concurrency/sendable_preconcurrency.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -swift-version 6 %S/Inputs/StrictModule.swift
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
-// RUN: %target-typecheck-verify-swift -disable-availability-checking -I %t
+// RUN: %target-typecheck-verify-swift -strict-concurrency=limited -disable-availability-checking -I %t
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/sendable_preconcurrency.swift
+++ b/test/Concurrency/sendable_preconcurrency.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -swift-version 6 %S/Inputs/StrictModule.swift
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
-// RUN: %target-typecheck-verify-swift -strict-concurrency=limited -disable-availability-checking -I %t
+// RUN: %target-typecheck-verify-swift -strict-concurrency=targeted -disable-availability-checking -I %t
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/sendable_preconcurrency.swift
+++ b/test/Concurrency/sendable_preconcurrency.swift
@@ -1,9 +1,10 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -warn-concurrency %S/Inputs/StrictModule.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -swift-version 6 %S/Inputs/StrictModule.swift
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
 // RUN: %target-typecheck-verify-swift -disable-availability-checking -I %t
 
 // REQUIRES: concurrency
+// REQUIRES: asserts
 
 import StrictModule // no remark: we never recommend @preconcurrency due to an explicitly non-Sendable (via -warn-concurrency) type
 @preconcurrency import NonStrictModule

--- a/test/Concurrency/sendable_without_preconcurrency.swift
+++ b/test/Concurrency/sendable_without_preconcurrency.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -swift-version 6 %S/Inputs/StrictModule.swift
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
-// RUN: %target-typecheck-verify-swift -disable-availability-checking -I %t
+// RUN: %target-typecheck-verify-swift -strict-concurrency=limited -disable-availability-checking -I %t
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/sendable_without_preconcurrency.swift
+++ b/test/Concurrency/sendable_without_preconcurrency.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -swift-version 6 %S/Inputs/StrictModule.swift
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
-// RUN: %target-typecheck-verify-swift -strict-concurrency=limited -disable-availability-checking -I %t
+// RUN: %target-typecheck-verify-swift -strict-concurrency=targeted -disable-availability-checking -I %t
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/sendable_without_preconcurrency.swift
+++ b/test/Concurrency/sendable_without_preconcurrency.swift
@@ -1,9 +1,10 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -warn-concurrency %S/Inputs/StrictModule.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -swift-version 6 %S/Inputs/StrictModule.swift
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
 // RUN: %target-typecheck-verify-swift -disable-availability-checking -I %t
 
 // REQUIRES: concurrency
+// REQUIRES: asserts
 
 import StrictModule // no remark: we never recommend @preconcurrency due to an explicitly non-Sendable (via -warn-concurrency) type
 import NonStrictModule

--- a/test/Concurrency/sendable_without_preconcurrency_2.swift
+++ b/test/Concurrency/sendable_without_preconcurrency_2.swift
@@ -1,9 +1,10 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -warn-concurrency %S/Inputs/StrictModule.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -swift-version 6 %S/Inputs/StrictModule.swift
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
 // RUN: %target-typecheck-verify-swift -disable-availability-checking -I %t
 
 // REQUIRES: concurrency
+// REQUIRES: asserts
 
 import StrictModule // no remark: we never recommend @preconcurrency due to an explicitly non-Sendable (via -warn-concurrency) type
 import NonStrictModule // expected-remark{{add '@preconcurrency' to suppress 'Sendable'-related warnings from module 'NonStrictModule'}}

--- a/test/Concurrency/sendable_without_preconcurrency_2.swift
+++ b/test/Concurrency/sendable_without_preconcurrency_2.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -swift-version 6 %S/Inputs/StrictModule.swift
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
-// RUN: %target-typecheck-verify-swift -disable-availability-checking -I %t
+// RUN: %target-typecheck-verify-swift -strict-concurrency=limited -disable-availability-checking -I %t
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/sendable_without_preconcurrency_2.swift
+++ b/test/Concurrency/sendable_without_preconcurrency_2.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -swift-version 6 %S/Inputs/StrictModule.swift
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
-// RUN: %target-typecheck-verify-swift -strict-concurrency=limited -disable-availability-checking -I %t
+// RUN: %target-typecheck-verify-swift -strict-concurrency=targeted -disable-availability-checking -I %t
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/strict_concurrency_explicit.swift
+++ b/test/Concurrency/strict_concurrency_explicit.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -strict-concurrency=off
+// RUN: %target-typecheck-verify-swift -strict-concurrency=explicit
 // REQUIRES: concurrency
 
 class C1 { }

--- a/test/Concurrency/strict_concurrency_minimal.swift
+++ b/test/Concurrency/strict_concurrency_minimal.swift
@@ -1,4 +1,5 @@
 // RUN: %target-typecheck-verify-swift -strict-concurrency=minimal
+// RUN: %target-typecheck-verify-swift
 // REQUIRES: concurrency
 
 class C1 { }

--- a/test/Concurrency/strict_concurrency_minimal.swift
+++ b/test/Concurrency/strict_concurrency_minimal.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -strict-concurrency=explicit
+// RUN: %target-typecheck-verify-swift -strict-concurrency=minimal
 // REQUIRES: concurrency
 
 class C1 { }

--- a/test/Concurrency/strict_concurrency_off.swift
+++ b/test/Concurrency/strict_concurrency_off.swift
@@ -1,0 +1,55 @@
+// RUN: %target-typecheck-verify-swift -strict-concurrency=off
+// REQUIRES: concurrency
+
+class C1 { }
+// expected-note@-1{{class 'C1' does not conform to the 'Sendable' protocol}}
+
+@_nonSendable class C2 { }
+// expected-note@-1 2{{class 'C2' does not conform to the 'Sendable' protocol}}
+
+class C3 { }
+// expected-note@-1 2{{class 'C3' does not conform to the 'Sendable' protocol}}
+
+@available(*, unavailable)
+extension C3: Sendable { }
+
+struct S1: Sendable {
+  let c1: C1 // expected-warning{{stored property 'c1' of 'Sendable'-conforming struct 'S1' has non-sendable type 'C1'}}
+  let c2: C2 // expected-warning{{stored property 'c2' of 'Sendable'-conforming struct 'S1' has non-sendable type 'C2'}}
+  let c3: C3 // expected-warning{{stored property 'c3'}}
+}
+
+struct S2 {
+  let c1: C1
+}
+
+struct S3 {
+  let c2: C2
+}
+
+
+func takeSendable(_ body: @Sendable () -> Void) {
+}
+
+func passSendable(
+    c1: C1, c2: C2, c3: C3, fn: @escaping () -> Void, s1: S1, s2: S2, s3: S3
+) async {
+  // Don't warn about implicitly non-Sendable types
+  takeSendable { print(c1) }
+  takeSendable { print(fn) }
+
+  // Warn about explicitly non-Sendable types
+  takeSendable { print(c2) } // expected-warning{{capture of 'c2' with non-sendable type 'C2' in a `@Sendable` closure}}
+  takeSendable { print(c3) } // expected-warning{{capture of 'c3' with non-sendable type 'C3' in a `@Sendable` closure}}
+
+  // Don't warn about explicitly Sendable type, even when it's wrong.
+  takeSendable { print(s1) }
+
+  // Don't warn when we wrapped an implicitly non-Sendable type in a struct.
+  takeSendable { print(s2) }
+
+  // FIXME: Ideally, we would warn about cases where a type in this module is
+  // inferred to be non-Sendable based on something explicitly non-Sendable,
+  // like in the case below.
+  takeSendable { print(s3) }
+}

--- a/test/Concurrency/strict_concurrency_off.swift
+++ b/test/Concurrency/strict_concurrency_off.swift
@@ -31,6 +31,7 @@ struct S3 {
 func takeSendable(_ body: @Sendable () -> Void) {
 }
 
+@available(SwiftStdlib 5.1, *)
 func passSendable(
     c1: C1, c2: C2, c3: C3, fn: @escaping () -> Void, s1: S1, s2: S2, s3: S3
 ) async {

--- a/test/Concurrency/toplevel/no-async-6-top-level.swift
+++ b/test/Concurrency/toplevel/no-async-6-top-level.swift
@@ -12,9 +12,9 @@ var a = 10 // expected-note 2 {{var declared here}}
 
 // expected-note@+1 3{{add '@MainActor' to make global function 'nonIsolatedSync()' part of global actor 'MainActor'}}
 func nonIsolatedSync() {
-    print(a) // expected-error {{main actor-isolated var 'a' can not be referenced from a non-isolated context}}
-    a = a + 10 // expected-error{{main actor-isolated var 'a' can not be referenced from a non-isolated context}}
-  // expected-error@-1{{main actor-isolated var 'a' can not be mutated from a non-isolated context}}
+    print(a) // expected-error {{var 'a' isolated to global actor 'MainActor' can not be referenced from this synchronous context}}
+    a = a + 10 // expected-error{{var 'a' isolated to global actor 'MainActor' can not be referenced from this synchronous context}}
+  // expected-error@-1{{var 'a' isolated to global actor 'MainActor' can not be mutated from this context}}
 }
 
 @MainActor
@@ -25,7 +25,7 @@ func isolatedSync() {
 
 func nonIsolatedAsync() async {
   await print(a)
-  a = a + 10 // expected-error{{main actor-isolated var 'a' can not be mutated from a non-isolated context}}
+  a = a + 10 // expected-error{{var 'a' isolated to global actor 'MainActor' can not be mutated from this context}}
   // expected-note@-1{{property access is 'async'}}
   // expected-error@-2{{expression is 'async' but is not marked with 'await'}}
 }

--- a/test/Distributed/distributed_protocol_isolation.swift
+++ b/test/Distributed/distributed_protocol_isolation.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/Inputs/FakeDistributedActorSystems.swift
-// RUN: %target-swift-frontend -typecheck -verify -strict-concurrency=limited -disable-availability-checking -I %t 2>&1 %s
+// RUN: %target-swift-frontend -typecheck -verify -strict-concurrency=targeted -disable-availability-checking -I %t 2>&1 %s
 // REQUIRES: concurrency
 // REQUIRES: distributed
 

--- a/test/Distributed/distributed_protocol_isolation.swift
+++ b/test/Distributed/distributed_protocol_isolation.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/Inputs/FakeDistributedActorSystems.swift
-// RUN: %target-swift-frontend -typecheck -verify -disable-availability-checking -I %t 2>&1 %s
+// RUN: %target-swift-frontend -typecheck -verify -strict-concurrency=limited -disable-availability-checking -I %t 2>&1 %s
 // REQUIRES: concurrency
 // REQUIRES: distributed
 

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -4281,7 +4281,8 @@ int main(int argc, char *argv[]) {
     InitInvok.getLangOptions().EnableExperimentalConcurrency = true;
   }
   if (options::WarnConcurrency) {
-    InitInvok.getLangOptions().StrictConcurrencyLevel = StrictConcurrency::On;
+    InitInvok.getLangOptions().StrictConcurrencyLevel =
+        StrictConcurrency::Complete;
   }
   if (options::DisableImplicitConcurrencyImport) {
     InitInvok.getLangOptions().DisableImplicitConcurrencyModuleImport = true;

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -4281,7 +4281,7 @@ int main(int argc, char *argv[]) {
     InitInvok.getLangOptions().EnableExperimentalConcurrency = true;
   }
   if (options::WarnConcurrency) {
-    InitInvok.getLangOptions().WarnConcurrency = true;
+    InitInvok.getLangOptions().StrictConcurrencyLevel = StrictConcurrency::On;
   }
   if (options::DisableImplicitConcurrencyImport) {
     InitInvok.getLangOptions().DisableImplicitConcurrencyModuleImport = true;

--- a/validation-test/Sema/SwiftUI/rdar76252310.swift
+++ b/validation-test/Sema/SwiftUI/rdar76252310.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.15 -swift-version 5 -strict-concurrency=limited
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.15 -swift-version 5 -strict-concurrency=targeted
 
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx

--- a/validation-test/Sema/SwiftUI/rdar76252310.swift
+++ b/validation-test/Sema/SwiftUI/rdar76252310.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.15 -swift-version 5
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.15 -swift-version 5 -strict-concurrency=limited
 
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx


### PR DESCRIPTION
Replace `-warn-concurrency` with a more granular option
`-swift-concurrency=`, where the developer can select one of three
different "modes":

* `minimal` disables `Sendable` checking for most cases. (This is the Swift
5.5 and Swift 5.6 behavior, and the default for now)
* `targeted` enables `Sendable` checking within code that has adopted
Swift concurrency.
* `complete` enables `Sendable` and other concurrency checking throughout
the module. (This is equivalent to `-warn-concurrency` now).

Implements rdar://91930849.