### PR TITLE
[incrParse] Encode Unicode characters in command output if stdout doesn't support Unicode

### DIFF
--- a/utils/incrparse/test_util.py
+++ b/utils/incrparse/test_util.py
@@ -25,7 +25,12 @@ def escapeCmdArg(arg):
 def run_command(cmd):
     if sys.version_info[0] < 3:
         cmd = list(map(lambda s: s.encode('utf-8'), cmd))
-    print(' '.join([escapeCmdArg(arg) for arg in cmd]))
+    cmdStr = ' '.join([escapeCmdArg(arg) for arg in cmd])
+    if not sys.stdout.encoding.lower().startswith('utf'):
+        # stdout doesn't support Unicode characters, encode them into an escape
+        # sequence
+        cmdStr = cmdStr.encode('utf-8')
+    print(cmdStr)
     if sys.version_info[0] < 3 or platform.system() == 'Windows':
         return subprocess.check_output(cmd, stderr=subprocess.STDOUT)
     else:


### PR DESCRIPTION
In verbose mode incrparse/test_util.py outputs the commands it executes to stdout. Since these commands contain Unicode emojis, it fails if stdout doesn't support Unicode. In these cases, encode the Unicode characters to their escape sequence.

rdar://92047111