### PR TITLE
Resolve a structural calculation error with clocks that prevented sleep to properly transmit to dispatch_after

### DIFF
--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -12,7 +12,6 @@
 
 if(NOT swift_concurrency_extra_sources)
   set(swift_concurrency_extra_sources
-    Clock.cpp
     Clock.swift
     ContinuousClock.swift
     SuspendingClock.swift
@@ -76,6 +75,7 @@ add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
   AsyncLet.cpp
   AsyncLet.swift
   CheckedContinuation.swift
+  Clock.cpp
   GlobalExecutor.cpp
   Errors.swift
   Error.cpp

--- a/stdlib/public/Concurrency/DispatchGlobalExecutor.inc
+++ b/stdlib/public/Concurrency/DispatchGlobalExecutor.inc
@@ -225,44 +225,7 @@ static void swift_task_enqueueGlobalWithDelayImpl(JobDelay delay,
   dispatch_after_f(when, queue, dispatchContext, dispatchFunction);
 }
 
-// TODO: The following is cribbed from libdispatch, we should replace it with an official API
-typedef enum {
-  DISPATCH_CLOCK_UPTIME,
-  DISPATCH_CLOCK_MONOTONIC,
-  DISPATCH_CLOCK_WALL,
-#define DISPATCH_CLOCK_COUNT  (DISPATCH_CLOCK_WALL + 1)
-} dispatch_clock_t;
-
 #define DISPATCH_UP_OR_MONOTONIC_TIME_MASK  (1ULL << 63)
-#define DISPATCH_WALLTIME_MASK  (1ULL << 62)
-#define DISPATCH_TIME_MAX_VALUE (DISPATCH_WALLTIME_MASK - 1)
-static inline uint64_t
-_dispatch_time_nano2mach(uint64_t value) {
-#if HAS_MACH_TIME
-  struct mach_timebase_info info = calculateTimebase();
-  return (value * info.denom) / info.numer;
-#else
-  return value;
-#endif
-}
-
-static inline dispatch_time_t
-_dispatch_clock_and_value_to_time(dispatch_clock_t clock, uint64_t value)
-{
-  if (value >= DISPATCH_TIME_MAX_VALUE) {
-    return DISPATCH_TIME_FOREVER;
-  }
-  switch (clock) {
-  case DISPATCH_CLOCK_WALL:
-    return -_dispatch_time_nano2mach(value);
-  case DISPATCH_CLOCK_UPTIME:
-    return _dispatch_time_nano2mach(value);
-  case DISPATCH_CLOCK_MONOTONIC:
-    return _dispatch_time_nano2mach(value) | DISPATCH_UP_OR_MONOTONIC_TIME_MASK;
-  }
-  __builtin_unreachable();
-}
-// END: REPLACEMENT
 
 SWIFT_CC(swift)
 static void swift_task_enqueueGlobalWithDeadlineImpl(long long sec,
@@ -282,18 +245,16 @@ static void swift_task_enqueueGlobalWithDeadlineImpl(long long sec,
   job->SchedulerPrivate[Job::DispatchQueueIndex] =
       DISPATCH_QUEUE_GLOBAL_EXECUTOR;
 
-  dispatch_time_t when;
-  switch (clock) {
-    case swift_clock_id_continuous: {
-      uint64_t q = sec * NSEC_PER_SEC + nsec;
-      when = _dispatch_clock_and_value_to_time(DISPATCH_CLOCK_MONOTONIC, q);
-      break;
-    }
-    case swift_clock_id_suspending: {
-      uint64_t q = sec * NSEC_PER_SEC + nsec;
-      when = _dispatch_clock_and_value_to_time(DISPATCH_CLOCK_UPTIME, q);
-      break;
-    }
+  long long nowSec;
+  long long nowNsec;
+  swift_get_time(&nowSec, &nowNsec, (swift_clock_id)clock);
+
+  uint64_t delta = (sec - nowSec) * NSEC_PER_SEC + nsec - nowNsec;
+
+  dispatch_time_t when = dispatch_time(DISPATCH_TIME_NOW, delta);
+
+  if (clock == swift_clock_id_continuous) {
+    when |= DISPATCH_UP_OR_MONOTONIC_TIME_MASK;
   }
   // TODO: this should pass the leeway/tolerance along when it is not -1 nanoseconds
   // either a dispatch_source can be created or a better dispatch_after_f can be made for this

--- a/test/Concurrency/Runtime/clock.swift
+++ b/test/Concurrency/Runtime/clock.swift
@@ -1,0 +1,71 @@
+// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library)
+
+// REQUIRES: concurrency
+// REQUIRES: executable_test
+// REQUIRES: concurrency_runtime
+
+import _Concurrency
+import StdlibUnittest
+
+var tests = TestSuite("Time")
+
+@main struct Main {
+  static func main() async {
+    tests.test("ContinuousClock sleep") {
+      let clock = ContinuousClock()
+      let elapsed = await clock.measure {
+        try! await clock.sleep(until: .now + .milliseconds(100))
+      }
+      // give a reasonable range of expected elapsed time
+      expectTrue(elapsed > .milliseconds(90))
+      expectTrue(elapsed < .milliseconds(200))
+    }
+
+    tests.test("SuspendingClock sleep") {
+      let clock = SuspendingClock()
+      let elapsed = await clock.measure {
+        try! await clock.sleep(until: .now + .milliseconds(100))
+      }
+      // give a reasonable range of expected elapsed time
+      expectTrue(elapsed > .milliseconds(90))
+      expectTrue(elapsed < .milliseconds(200))
+    }
+
+    tests.test("duration addition") {
+      let d1 = Duration.milliseconds(500)
+      let d2 = Duration.milliseconds(500)
+      let d3 = Duration.milliseconds(-500)
+      let sum = d1 + d2
+      expectEqual(sum, .seconds(1))
+      let comps = sum.components
+      expectEqual(comps.seconds, 1)
+      expectEqual(comps.attoseconds, 0)
+      let adjusted = sum + d3
+      expectEqual(adjusted, .milliseconds(500))
+    }
+
+    tests.test("duration subtraction") {
+      let d1 = Duration.nanoseconds(500)
+      let d2 = d1 - .nanoseconds(100)
+      expectEqual(d2, .nanoseconds(400))
+      let d3 = d1 - .nanoseconds(500)
+      expectEqual(d3, .nanoseconds(0))
+      let d4 = d1 - .nanoseconds(600)
+      expectEqual(d4, .nanoseconds(-100))
+    }
+
+    tests.test("duration division") {
+      let d1 = Duration.seconds(1)
+      let halfSecond = d1 / 2
+      expectEqual(halfSecond, .milliseconds(500))
+    }
+
+    tests.test("duration multiplication") {
+      let d1 = Duration.seconds(1)
+      let twoSeconds = d1 * 2
+      expectEqual(twoSeconds, .seconds(2))
+    }
+
+    await runAllTestsAsync()
+  }
+}


### PR DESCRIPTION
This is a cherry-pick of the same fix applied to main per request of @DougGregor 

The calculation for building back up dispatch_time_t values incorrectly calculated those structures. This change adjusts that to a more stable approach until dispatch can offer an API to do so.

The previous code would hang indefinitely with some quite reasonable deadlines for Clock.sleep this corrects that and adds unit tests to validate the correct behavior.

This resolves: rdar://92056379