### PR TITLE
Soften new unavailable conformance diagnostics

### DIFF
--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -30,6 +30,7 @@
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/SaveAndRestore.h"
+#include "clang/AST/ASTContext.h"
 using namespace swift;
 
 #define DEBUG_TYPE "Name lookup"
@@ -733,6 +734,14 @@ unsigned DeclContext::printContext(raw_ostream &OS, const unsigned indent,
     }
   }
   }
+
+  if (auto decl = getAsDecl())
+    if (decl->getClangNode().getLocation().isValid()) {
+      auto &clangSM = getASTContext().getClangModuleLoader()
+                          ->getClangASTContext().getSourceManager();
+      OS << " clang_loc=";
+      decl->getClangNode().getLocation().print(OS, clangSM);
+    }
 
   if (!onlyAPartialLine)
     OS << "\n";

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -158,7 +158,8 @@ bool
 TypeChecker::diagnoseConformanceExportability(SourceLoc loc,
                                               const RootProtocolConformance *rootConf,
                                               const ExtensionDecl *ext,
-                                              const ExportContext &where) {
+                                              const ExportContext &where,
+                                              bool useConformanceAvailabilityErrorsOption) {
   if (!where.mustOnlyReferenceExportedDecls())
     return false;
 
@@ -178,6 +179,9 @@ TypeChecker::diagnoseConformanceExportability(SourceLoc loc,
                      rootConf->getProtocol()->getName(),
                      static_cast<unsigned>(*reason),
                      M->getName(),
-                     static_cast<unsigned>(originKind));
+                     static_cast<unsigned>(originKind))
+      .warnUntilSwiftVersionIf(useConformanceAvailabilityErrorsOption &&
+                               !ctx.LangOpts.EnableConformanceAvailabilityErrors,
+                               6);
   return true;
 }

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -220,14 +220,16 @@ diagnoseConformanceAvailability(SourceLoc loc,
                                 ProtocolConformanceRef conformance,
                                 const ExportContext &context,
                                 Type depTy=Type(),
-                                Type replacementTy=Type());
+                                Type replacementTy=Type(),
+                                bool useConformanceAvailabilityErrorsOption = false);
 
 bool
 diagnoseSubstitutionMapAvailability(SourceLoc loc,
                                     SubstitutionMap subs,
                                     const ExportContext &context,
                                     Type depTy=Type(),
-                                    Type replacementTy=Type());
+                                    Type replacementTy=Type(),
+                                    bool useConformanceAvailabilityErrorsOption = false);
 
 /// Diagnose uses of unavailable declarations. Returns true if a diagnostic
 /// was emitted.
@@ -261,7 +263,8 @@ bool diagnoseExplicitUnavailability(
     SourceLoc loc,
     const RootProtocolConformance *rootConf,
     const ExtensionDecl *ext,
-    const ExportContext &where);
+    const ExportContext &where,
+    bool useConformanceAvailabilityErrorsOption = false);
 
 /// Check if \p decl has a introduction version required by -require-explicit-availability
 void checkExplicitAvailability(Decl *decl);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -999,7 +999,8 @@ bool diagnoseDeclRefExportability(SourceLoc loc,
 bool diagnoseConformanceExportability(SourceLoc loc,
                                       const RootProtocolConformance *rootConf,
                                       const ExtensionDecl *ext,
-                                      const ExportContext &where);
+                                      const ExportContext &where,
+                                      bool useConformanceAvailabilityErrorsOpt = false);
 
 /// \name Availability checking
 ///

--- a/test/Sema/conformance_availability_warn.swift
+++ b/test/Sema/conformance_availability_warn.swift
@@ -52,3 +52,33 @@ func passAvailableConformance1a(x: HasAvailableConformance1) {
   _ = x.isGalloping
   _ = UsesHorse<HasAvailableConformance1>.self
 }
+
+// Explicit unavailability
+public struct HasAvailableConformance2 {}
+
+@available(*, unavailable)
+extension HasAvailableConformance2 : Horse {} // expected-note 6 {{conformance of 'HasAvailableConformance2' to 'Horse' has been explicitly marked unavailable here}}
+
+// Some availability diagnostics become warnings in Swift 5 mode without
+// -enable-conformance-availability-errors because they were incorrectly
+// accepted before and rejecting them would break source compatibility. Others
+// are unaffected because they have always been rejected.
+
+func passAvailableConformance2(x: HasAvailableConformance2) {
+  takesHorse(x) // expected-error {{conformance of 'HasAvailableConformance2' to 'Horse' is unavailable}}
+  takesHorseExistential(x) // expected-warning {{conformance of 'HasAvailableConformance2' to 'Horse' is unavailable; this is an error in Swift 6}}
+  x.giddyUp() // expected-error {{conformance of 'HasAvailableConformance2' to 'Horse' is unavailable}}
+  _ = x.isGalloping // expected-error {{conformance of 'HasAvailableConformance2' to 'Horse' is unavailable}}
+  _ = x[keyPath: \.isGalloping] // expected-error {{conformance of 'HasAvailableConformance2' to 'Horse' is unavailable}}
+  _ = UsesHorse<HasAvailableConformance2>.self // expected-error {{conformance of 'HasAvailableConformance2' to 'Horse' is unavailable}}
+}
+
+@available(*, unavailable)
+func passAvailableConformance2a(x: HasAvailableConformance2) {
+  takesHorse(x)
+  takesHorseExistential(x)
+  x.giddyUp()
+  _ = x.isGalloping
+  _ = UsesHorse<HasAvailableConformance2>.self
+}
+


### PR DESCRIPTION
In apple/swift#41054, we fixed an oversight which caused us to not notice when a user erased a concrete type to an existential using an unavailable conformance. Unfortunately, this is source-breaking and needs to be reduced to a warning in Swift 5 mode unless the user opts in.

This PR also includes an enhancement to `DeclContext` dumping that helps when locating imported declarations; I'm not sure this code is actually valid in its present form, and might remove it if it's a problem.

Fixes rdar://91940820.