### PR TITLE
[CodeCompletion] Only include results from other modules once

### DIFF
--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -2146,7 +2146,7 @@ bool CompletionLookup::tryModuleCompletions(Type ExprType, bool TypesOnly) {
                                        .withModuleQualifier(false);
       if (TypesOnly)
         Request = Request.onlyTypes();
-      RequestedCachedResults.push_back(Request);
+      RequestedCachedResults.insert(Request);
     }
     return true;
   }
@@ -2709,7 +2709,7 @@ void CompletionLookup::getValueCompletionsInDeclContext(SourceLoc Loc,
 
   lookupVisibleDecls(FilteringConsumer, CurrDeclContext,
                      /*IncludeTopLevel=*/false, Loc);
-  RequestedCachedResults.push_back(
+  RequestedCachedResults.insert(
       RequestedResultsTy::toplevelResults().withModuleQualifier(
           ModuleQualifier));
 
@@ -3013,9 +3013,9 @@ void CompletionLookup::collectPrecedenceGroups() {
     if (Module == CurrModule)
       continue;
 
-    RequestedCachedResults.push_back(RequestedResultsTy::fromModule(Module)
-                                         .onlyPrecedenceGroups()
-                                         .withModuleQualifier(false));
+    RequestedCachedResults.insert(RequestedResultsTy::fromModule(Module)
+                                      .onlyPrecedenceGroups()
+                                      .withModuleQualifier(false));
   }
 }
 
@@ -3105,7 +3105,7 @@ void CompletionLookup::getTypeCompletionsInDeclContext(SourceLoc Loc,
   lookupVisibleDecls(AccessFilteringConsumer, CurrDeclContext,
                      /*IncludeTopLevel=*/false, Loc);
 
-  RequestedCachedResults.push_back(
+  RequestedCachedResults.insert(
       RequestedResultsTy::toplevelResults().onlyTypes().withModuleQualifier(
           ModuleQualifier));
 }


### PR DESCRIPTION
In case of ambigous expression/global completions, we call `getValueCompletionsInDeclContext` multiple times for the amigous solutions to the constraint system. This can cause modules to be included multiple times in `RequestedCachedResults` and thus global results from these modules are reported multiple times. Make `RequestedCachedResults` a set so we don’t get duplicate results.

rdar://92048610