### PR TITLE
[stdlib] Fix mismatched constant name in `static func ==` doc

### DIFF
--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -375,9 +375,9 @@ extension Optional: Equatable where Wrapped: Equatable {
   /// `numberToMatch` constant is wrapped as an optional before comparing to the
   /// optional `numberFromString`:
   ///
-  ///     let numberToFind: Int = 23
+  ///     let numberToMatch: Int = 23
   ///     let numberFromString: Int? = Int("23")      // Optional(23)
-  ///     if numberToFind == numberFromString {
+  ///     if numberToMatch == numberFromString {
   ///         print("It's a match!")
   ///     }
   ///     // Prints "It's a match!"


### PR DESCRIPTION
- I've found a mismatched constant name in `static func ==` example. 😄
- Given the context, it should be `numberToMatch`, not `numberToFind`.

```swift
  /// You can also use this operator to compare a non-optional value to an
  /// optional that wraps the same type. The non-optional value is wrapped as an
  /// optional before the comparison is made. In the following example, the
  /// `numberToMatch` constant is wrapped as an optional before comparing to the
  /// optional `numberFromString`:

     let **numberToFind**: Int = 23  // → this should be *numberToMatch*
     let numberFromString: Int? = Int("23")      // Optional(23)
     if **numberToFind** == numberFromString {  // → this should be *numberToMatch*
         print("It's a match!")
     }
     // Prints "It's a match!"
```