### PR TITLE
Spelling index

### DIFF
--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -740,7 +740,7 @@ private:
   /// Extensions redeclare all generic parameters of their extended type to add
   /// their additional restrictions. There are two issues with this model for
   /// indexing:
-  ///  - The generic paramter declarations of the extension are implicit so we
+  ///  - The generic parameter declarations of the extension are implicit so we
   ///    wouldn't report them in the index. Any usage of the generic param in
   ///    the extension references this implicit declaration so we don't include
   ///    it in the index either.
@@ -749,7 +749,7 @@ private:
   ///    declaration of the param in the extended type.
   ///
   /// To fix these issues, we replace the reference to the implicit generic
-  /// parameter defined in the extension by a reference to the generic paramter
+  /// parameter defined in the extension by a reference to the generic parameter
   /// defined in the extended type.
   ///
   /// \returns the canonicalized replaced generic param decl if it can be found
@@ -759,7 +759,7 @@ private:
     auto Extension = dyn_cast_or_null<ExtensionDecl>(
         GenParam->getDeclContext()->getAsDecl());
     if (!Extension) {
-      // We are not referencing a generic paramter defined in an extension.
+      // We are not referencing a generic parameter defined in an extension.
       // Nothing to do.
       return GenParam;
     }

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -767,7 +767,7 @@ private:
            "Generic param decls in extension should always be implicit and "
            "shadow a generic param in the extended type.");
     assert(Extension->getExtendedNominal() &&
-           "The implict generic types on the extension should only be created "
+           "The implicit generic types on the extension should only be created "
            "if the extended type was found");
 
     auto ExtendedTypeGenSig =

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -1241,8 +1241,8 @@ bool IndexSwiftASTWalker::startEntityDecl(ValueDecl *D) {
       return false;
   }
 
-  for (auto Overriden: collectAllOverriddenDecls(D, /*IncludeProtocolReqs=*/false)) {
-    addRelation(Info, (SymbolRoleSet) SymbolRole::RelationOverrideOf, Overriden);
+  for (auto Overridden: collectAllOverriddenDecls(D, /*IncludeProtocolReqs=*/false)) {
+    addRelation(Info, (SymbolRoleSet) SymbolRole::RelationOverrideOf, Overridden);
   }
 
   if (auto Parent = getParentDecl()) {

--- a/lib/Index/IndexSymbol.cpp
+++ b/lib/Index/IndexSymbol.cpp
@@ -30,7 +30,7 @@ static bool isUnitTestCase(const ClassDecl *D) {
     return false;
 
   return D->walkSuperclasses([D](ClassDecl *SuperD) {
-    if (SuperD != D && // Do not treate XCTestCase itself as a test.
+    if (SuperD != D && // Do not treat XCTestCase itself as a test.
         SuperD->getNameStr() == "XCTestCase")
       return TypeWalker::Action::Stop; // Found test; stop and return true.
     return TypeWalker::Action::Continue;

--- a/test/Index/Store/unit-custom-output-path-driver.swift
+++ b/test/Index/Store/unit-custom-output-path-driver.swift
@@ -77,7 +77,7 @@
 //    INDEX_WITH_NEGATIVE-NOT: second_out.o
 //    INDEX_WITH_NEGATIVE-NOT: second_different.o
 //
-//    Run with a diferent -index-unit-output-path
+//    Run with a different -index-unit-output-path
 //    RUN: echo '{                                                     ' > %/t/outputmap-different2.json
 //    RUN: echo '   "%/t/main.swift":{                                 ' >> %/t/outputmap-different2.json
 //    RUN: echo '      "object": "%/t/main_different.o",               ' >> %/t/outputmap-different2.json

--- a/test/Index/Store/unit-custom-output-path.swift
+++ b/test/Index/Store/unit-custom-output-path.swift
@@ -43,7 +43,7 @@
 //    INDEX_WITH_NEGATIVE-NOT: main_out.o
 //    INDEX_WITH_NEGATIVE-NOT: different.o
 //
-//    Run with a diferent -index-unit-output-path
+//    Run with a different -index-unit-output-path
 //    RUN: %target-swift-frontend -typecheck -parse-stdlib \
 //    RUN:     -module-name mod_name -index-store-path %t/idx_with \
 //    RUN:     -primary-file %t/main.swift %t/second.swift \

--- a/test/Index/index_generic_params.swift
+++ b/test/Index/index_generic_params.swift
@@ -80,7 +80,7 @@ extension Wrapper2.NonGenericWrapped where Wrapper2Param: P1 {
   func bar(x: Wrapper2Param.Assoc) {}
 }
 
-// MARK: - Test extending an unkown type
+// MARK: - Test extending an unknown type
 
 // Check that we don't crash. We don't expect the generic params to show up in the index.
 extension MyUnknownType where Wrapper2Param: P1 {


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fixes some misspellings in Swift index, it is split per https://github.com/apple/swift/pull/42421#issuecomment-1101092698


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
