### PR TITLE
Spelling concurrency

### DIFF
--- a/test/Concurrency/LLDBDebuggerFunctionActorExtension.swift
+++ b/test/Concurrency/LLDBDebuggerFunctionActorExtension.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift  -disable-availability-checking -debugger-support
 // REQUIRES: concurrency
 
-// This test simulates LLDB's expression evaluator makeing an otherwise illegal
+// This test simulates LLDB's expression evaluator making an otherwise illegal
 // synchronous call into an extension of an actor, as it would to run `p n` in
 // this example.
 

--- a/test/Concurrency/Runtime/async_let_throw_completion_order.swift
+++ b/test/Concurrency/Runtime/async_let_throw_completion_order.swift
@@ -25,8 +25,8 @@ func zim(y: Bar, x: Foo, z: Baz) { print("hooray") }
 
       return try await zim(y: y, x: x, z: z)
     } catch {
-      // CHECK: oopsie woopsie
-      print("oopsie woopsie")
+      // CHECK: oopsie whoopsie
+      print("oopsie whoopsie")
     }
   }
 }

--- a/test/Concurrency/Runtime/exclusivity.swift
+++ b/test/Concurrency/Runtime/exclusivity.swift
@@ -104,7 +104,7 @@ struct Runner {
         }
 
         // Then do a simple test with a single access to make sure that we do
-        // not hit any sccesses b/c we introduced the Task.
+        // not hit any successes b/c we introduced the Task.
         exclusivityTests.test("testDifferentTasksHaveDifferentExclusivityAccessSets") { @MainActor in
             let callee2 = { @MainActor (_ x: inout Int) -> Void in
                 debugLog("==> Enter callee2")

--- a/test/Concurrency/Runtime/exclusivity.swift
+++ b/test/Concurrency/Runtime/exclusivity.swift
@@ -415,7 +415,7 @@ struct Runner {
                     await innerTaskHandle.value
                     debugLog("==> After")
                 }
-                // Accessis over. We shouldn't crash here.
+                // Access is over. We shouldn't crash here.
                 withExclusiveAccess(to: &global1) { _ in
                     debugLog("==> No crash!")
                 }

--- a/test/Concurrency/Runtime/exclusivity_custom_executors.swift
+++ b/test/Concurrency/Runtime/exclusivity_custom_executors.swift
@@ -97,13 +97,13 @@ public final class MySerialExecutor : SerialExecutor {
 
   @inlinable
   public nonisolated var unownedExecutor: UnownedSerialExecutor {
-      debugLog("==> MyMainActor: Getting unowned exector!")
+      debugLog("==> MyMainActor: Getting unowned executor!")
       return executor.asUnownedSerialExecutor()
   }
 
   @inlinable
   public static var sharedUnownedExecutor: UnownedSerialExecutor {
-      debugLog("==> MyMainActor: Getting shared unowned exector!")
+      debugLog("==> MyMainActor: Getting shared unowned executor!")
       return MySerialExecutor.sharedUnownedExecutor
   }
 
@@ -124,14 +124,14 @@ public final class MySerialExecutor : SerialExecutor {
 
   @inlinable
   public nonisolated var unownedExecutor: UnownedSerialExecutor {
-      debugLog("==> MyMainActorWithAccessInUnownedExecAccessor: Getting unowned exector!")
+      debugLog("==> MyMainActorWithAccessInUnownedExecAccessor: Getting unowned executor!")
       withExclusiveAccess(to: &global) { _ in debugLog("Crash!") }
       return executor.asUnownedSerialExecutor()
   }
 
   @inlinable
   public static var sharedUnownedExecutor: UnownedSerialExecutor {
-      debugLog("==> MyMainActorWithAccessInUnownedExecAccessor: Getting shared unowned exector!")
+      debugLog("==> MyMainActorWithAccessInUnownedExecAccessor: Getting shared unowned executor!")
       return MySerialExecutor.sharedUnownedExecutor
   }
 

--- a/test/Concurrency/builtin_silgen.swift
+++ b/test/Concurrency/builtin_silgen.swift
@@ -8,7 +8,7 @@ import _Concurrency
 func suspend() async {}
 
 // Builtin.hopToActor should generate a mandatory hop_to_executor
-// before releaseing the actor and reaching a suspend.
+// before releasing the actor and reaching a suspend.
 //
 // CHECK-LABEL: sil private @$s14builtin_silgen11runDetachedyyFyyYaYbcfU_ : $@convention(thin) @Sendable @async @substituted <τ_0_0> () -> @out τ_0_0 for <()>
 // CHECK:   [[ACTOR:%.*]] = apply {{%.*}}({{%.*}}) : $@convention(method) (@thick MainActor.Type) -> @owned MainActor

--- a/test/Concurrency/throwing.swift
+++ b/test/Concurrency/throwing.swift
@@ -46,7 +46,7 @@ extension MP {
     var tests = TestSuite("Async Throw")
 
     if #available(SwiftStdlib 5.1, *) {
-      tests.test("throwing of naturally direct but indirect reabstration") {
+      tests.test("throwing of naturally direct but indirect reabstraction") {
         let task2 = detach {
           let m = M()
           await verifyCancelled {


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fixes some misspellings in Swift concurrency, it is split per https://github.com/apple/swift/pull/42421#issuecomment-1101092698


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
