### PR TITLE
Spelling constraints

### DIFF
--- a/test/Constraints/array_literal_local_array.swift
+++ b/test/Constraints/array_literal_local_array.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift
 
-// SR-9611: Array type locally interfers with array literals.
+// SR-9611: Array type locally interferes with array literals.
 struct Array { }
 
 func foo() {

--- a/test/Constraints/availability.swift
+++ b/test/Constraints/availability.swift
@@ -16,7 +16,7 @@ func f(c: C) {
   let _: C? = C(c)
 }
 
-// rdar://problem/60047439 - unable to disambiguite expression based on availability
+// rdar://problem/60047439 - unable to disambiguate expression based on availability
 func test_contextual_member_with_availability() {
   struct A {
     static var foo: A = A()

--- a/test/Constraints/availability.swift
+++ b/test/Constraints/availability.swift
@@ -16,7 +16,7 @@ func f(c: C) {
   let _: C? = C(c)
 }
 
-// rdar://problem/60047439 - unable to disambiguite expression based on availablity
+// rdar://problem/60047439 - unable to disambiguite expression based on availability
 func test_contextual_member_with_availability() {
   struct A {
     static var foo: A = A()

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -1071,11 +1071,11 @@ func rdar_74435602(error: Error?) {
 // SR-14280
 let _: (@convention(block) () -> Void)? = Bool.random() ? nil : {} // OK
 let _: (@convention(thin) () -> Void)? = Bool.random() ? nil : {} // OK
-let _: (@convention(c) () -> Void)? = Bool.random() ? nil : {} // OK on type checking, diagnostics are deffered to SIL
+let _: (@convention(c) () -> Void)? = Bool.random() ? nil : {} // OK on type checking, diagnostics are deferred to SIL
 
 let _: (@convention(block) () -> Void)? = Bool.random() ? {} : {} // OK
 let _: (@convention(thin) () -> Void)? = Bool.random() ? {} : {} // OK
-let _: (@convention(c) () -> Void)? = Bool.random() ? {} : {} // OK on type checking, diagnostics are deffered to SIL
+let _: (@convention(c) () -> Void)? = Bool.random() ? {} : {} // OK on type checking, diagnostics are deferred to SIL
 
 // Make sure that diagnostic is attached to the closure even when body is empty (implicitly returns `Void`)
 var emptyBodyMismatch: () -> Int {

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -906,7 +906,7 @@ func rdar78781552() {
   }
 }
 
-// rdar://79757320 - failured to produce a diagnostic when unresolved dependent member is used in function result position
+// rdar://79757320 - failed to produce a diagnostic when unresolved dependent member is used in function result position
 
 protocol R_79757320 {
   associatedtype In

--- a/test/Constraints/implicit_double_cgfloat_conversion.swift
+++ b/test/Constraints/implicit_double_cgfloat_conversion.swift
@@ -149,7 +149,7 @@ func test_narrowing_is_delayed(x: Double, y: CGFloat) {
   // CHECK: function_ref @$s34implicit_double_cgfloat_conversion25test_narrowing_is_delayed1x1yySd_12CoreGraphics7CGFloatVtF10overloadedL_yS2d_SdtF
   // CHECK: @$s34implicit_double_cgfloat_conversion25test_narrowing_is_delayed1x1yySd_12CoreGraphics7CGFloatVtF10overloadedL_yS2d_SdtF
   // CHECK: function_ref @$s12CoreGraphics7CGFloatVyACSdcf
-  let _: CGFloat = overloaded(x, overloaded(x, y)) // Prefers `overloaded(Double, Double) -> Double` in both occurances.
+  let _: CGFloat = overloaded(x, overloaded(x, y)) // Prefers `overloaded(Double, Double) -> Double` in both occurrences.
 
   // Calls should behave exactly the same as contextual conversions.
 

--- a/test/Constraints/keypath_dynamic_member_lookup.swift
+++ b/test/Constraints/keypath_dynamic_member_lookup.swift
@@ -287,7 +287,7 @@ func prefer_readonly_keypath_over_reference_writable() {
 }
 
 
-// rdar://problem/52779809 - condiitional conformance shadows names of members reachable through dynamic lookup
+// rdar://problem/52779809 - conditional conformance shadows names of members reachable through dynamic lookup
 
 protocol P {
   var foo: Int { get }

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -688,7 +688,7 @@ func testSR13359(_ pair: (Int, Int), _ alias: Pair, _ void: Void, labeled: (a: I
   _ = pair[1] // expected-error {{cannot access element using subscript for tuple type '(Int, Int)'; did you mean to use '.1'?}} {{11-14=.1}}
   _ = pair[2] // expected-error {{cannot access element using subscript for tuple type '(Int, Int)'; use '.' notation instead}} {{none}}
   _ = pair[100] // expected-error {{cannot access element using subscript for tuple type '(Int, Int)'; use '.' notation instead}} {{none}}
-  _ = pair["strting"] // expected-error {{cannot access element using subscript for tuple type '(Int, Int)'; use '.' notation instead}} {{none}}
+  _ = pair["string"] // expected-error {{cannot access element using subscript for tuple type '(Int, Int)'; use '.' notation instead}} {{none}}
   _ = pair[-1] // expected-error {{cannot access element using subscript for tuple type '(Int, Int)'; use '.' notation instead}} {{none}}
   _ = pair[1, 1] // expected-error {{cannot access element using subscript for tuple type '(Int, Int)'; use '.' notation instead}} {{none}}
   _ = void[0] // expected-error {{value of type 'Void' has no subscripts}}
@@ -700,7 +700,7 @@ func testSR13359(_ pair: (Int, Int), _ alias: Pair, _ void: Void, labeled: (a: I
   _ = alias[1] // expected-error {{cannot access element using subscript for tuple type 'Pair' (aka '(Int, Int)'); did you mean to use '.1'?}} {{12-15=.1}}
   _ = alias[2] // expected-error {{cannot access element using subscript for tuple type 'Pair' (aka '(Int, Int)'); use '.' notation instead}} {{none}}
   _ = alias[100] // expected-error {{cannot access element using subscript for tuple type 'Pair' (aka '(Int, Int)'); use '.' notation instead}} {{none}}
-  _ = alias["strting"] // expected-error {{cannot access element using subscript for tuple type 'Pair' (aka '(Int, Int)'); use '.' notation instead}} {{none}}
+  _ = alias["string"] // expected-error {{cannot access element using subscript for tuple type 'Pair' (aka '(Int, Int)'); use '.' notation instead}} {{none}}
   _ = alias[-1] // expected-error {{cannot access element using subscript for tuple type 'Pair' (aka '(Int, Int)'); use '.' notation instead}} {{none}}
   _ = alias[1, 1] // expected-error {{cannot access element using subscript for tuple type 'Pair' (aka '(Int, Int)'); use '.' notation instead}} {{none}}
   _ = alias[0x00] // expected-error {{cannot access element using subscript for tuple type 'Pair' (aka '(Int, Int)'); use '.' notation instead}} {{none}}
@@ -711,7 +711,7 @@ func testSR13359(_ pair: (Int, Int), _ alias: Pair, _ void: Void, labeled: (a: I
   _ = labeled[1] // expected-error {{cannot access element using subscript for tuple type '(a: Int, b: Int)'; did you mean to use '.1'?}} {{14-17=.1}}
   _ = labeled[2] // expected-error {{cannot access element using subscript for tuple type '(a: Int, b: Int)'; use '.' notation instead}} {{none}}
   _ = labeled[100] // expected-error {{cannot access element using subscript for tuple type '(a: Int, b: Int)'; use '.' notation instead}} {{none}}
-  _ = labeled["strting"] // expected-error {{cannot access element using subscript for tuple type '(a: Int, b: Int)'; use '.' notation instead}} {{none}}
+  _ = labeled["string"] // expected-error {{cannot access element using subscript for tuple type '(a: Int, b: Int)'; use '.' notation instead}} {{none}}
   _ = labeled[-1] // expected-error {{cannot access element using subscript for tuple type '(a: Int, b: Int)'; use '.' notation instead}} {{none}}
   _ = labeled[1, 1] // expected-error {{cannot access element using subscript for tuple type '(a: Int, b: Int)'; use '.' notation instead}} {{none}}
   _ = labeled[0x00] // expected-error {{cannot access element using subscript for tuple type '(a: Int, b: Int)'; use '.' notation instead}} {{none}}

--- a/test/Constraints/opened_existentials.swift
+++ b/test/Constraints/opened_existentials.swift
@@ -202,7 +202,7 @@ func testTakeValueAndClosure(p: any P) {
   takeValueAndClosure(p, body: overloadedGenericFunctionTakingP)
   takeValueAndClosure(p, body: genericFunctionTakingPQ) // expected-error{{global function 'genericFunctionTakingPQ' requires that 'T' conform to 'Q'}}
 
-  // Do not allow opening if there are any uses of the the type parameter before
+  // Do not allow opening if there are any uses of the type parameter before
   // the opened parameter. This maintains left-to-right evaluation order.
   takeValueAndClosureBackwards( // expected-error{{type 'any P' cannot conform to 'P'}}
     // expected-note@-1{{only concrete types such as structs, enums and classes can conform to protocols}}

--- a/test/Constraints/overload_filtering.swift
+++ b/test/Constraints/overload_filtering.swift
@@ -42,7 +42,7 @@ func testUnresolvedMember(i: Int) -> X {
 func test_member_filtering() {
   struct S {
     // Result types here are different intentionally,
-    // if there were the same simplication logic would
+    // if there were the same simplification logic would
     // trigger and disable overloads during constraint
     // generation.
     func foo(_: Int) -> S { S() }

--- a/test/Constraints/result_builder_diags.swift
+++ b/test/Constraints/result_builder_diags.swift
@@ -801,7 +801,7 @@ func test_missing_member_in_optional_context() {
   }
 }
 
-func test_redeclations() {
+func test_redeclarations() {
   tuplify(true) { c in
     let foo = 0 // expected-note {{'foo' previously declared here}}
     let foo = foo // expected-error {{invalid redeclaration of 'foo'}}

--- a/test/Constraints/tuple.swift
+++ b/test/Constraints/tuple.swift
@@ -195,9 +195,9 @@ struct Victory<General> {
 struct MagicKingdom<K> : Kingdom {
   typealias King = K
 }
-func magify<T>(_ t: T) -> MagicKingdom<T> { return MagicKingdom() }
+func magnify<T>(_ t: T) -> MagicKingdom<T> { return MagicKingdom() }
 func foo(_ pair: (Int, Int)) -> Victory<(x: Int, y: Int)> {
-  return Victory(magify(pair)) // expected-error {{initializer 'init(_:)' requires the types '(x: Int, y: Int)' and 'MagicKingdom<(Int, Int)>.King' (aka '(Int, Int)') be equivalent}}
+  return Victory(magnify(pair)) // expected-error {{initializer 'init(_:)' requires the types '(x: Int, y: Int)' and 'MagicKingdom<(Int, Int)>.King' (aka '(Int, Int)') be equivalent}}
 }
 
 

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1673,7 +1673,7 @@ public extension Optional {
 
 // https://bugs.swift.org/browse/SR-6837
 
-// FIXME: Can't overlaod local functions so these must be top-level
+// FIXME: Can't overload local functions so these must be top-level
 func takePairOverload(_ pair: (Int, Int?)) {}
 func takePairOverload(_: () -> ()) {}
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fixes some misspellings in Swift constraints, it is split per https://github.com/apple/swift/pull/42421#issuecomment-1101092698


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
