### PR TITLE
Spelling interop

### DIFF
--- a/test/Interop/Cxx/class/memberwise-initializer-typechecker.swift
+++ b/test/Interop/Cxx/class/memberwise-initializer-typechecker.swift
@@ -4,14 +4,14 @@ import MemberwiseInitializer
 
 let structPrivateOnly = StructPrivateOnly(varPrivate: 42)  // expected-error {{argument passed to call that takes no arguments}}
 let structPublicOnly = StructPublicOnly(varPublic: 42)
-let structEmptyPrivateSetion = StructEmptyPrivateSection(varPublic: 42)
+let structEmptyPrivateSection = StructEmptyPrivateSection(varPublic: 42)
 let structPublicAndPrivate1 = StructPublicAndPrivate(varPublic: 42)  // expected-error {{argument passed to call that takes no arguments}}
 let structPublicAndPrivate2 = StructPublicAndPrivate(varPublic: 42, varPrivate: 23)  // expected-error {{argument passed to call that takes no arguments}}
 let structWithUnimportedMemberFunction = StructWithUnimportedMemberFunction(varPublic: 42)
 
 let classPrivateOnly = ClassPrivateOnly(varPrivate: 42) // expected-error {{argument passed to call that takes no arguments}}
 let classPublicOnly = ClassPublicOnly(varPublic: 42)
-let classEmptyPublicSetion = ClassEmptyPublicSection(varPrivate: 42) // expected-error {{argument passed to call that takes no arguments}}
+let classEmptyPublicSection = ClassEmptyPublicSection(varPrivate: 42) // expected-error {{argument passed to call that takes no arguments}}
 let classPublicAndPrivate1 = ClassPrivateAndPublic(varPublic: 23)  // expected-error {{argument passed to call that takes no arguments}}
 let classPublicAndPrivate2 = ClassPrivateAndPublic(varPrivate: 42, varPublic: 23)  // expected-error {{argument passed to call that takes no arguments}}
 let classWithUnimportedMemberFunction = ClassWithUnimportedMemberFunction(varPublic: 42)

--- a/test/Interop/Cxx/class/type-classification-non-trivial-irgen.swift
+++ b/test/Interop/Cxx/class/type-classification-non-trivial-irgen.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swiftxx-frontend -I %S/Inputs %s -emit-ir | %FileCheck %s
 
-// Verify that non-trival/address-only C++ classes are constructed and accessed
+// Verify that non-trivial/address-only C++ classes are constructed and accessed
 // correctly. Make sure that we correctly IRGen functions that construct
 // non-trivial C++ classes, take those classes as a parameter, and access those
 // classes members.

--- a/test/Interop/Cxx/templates/Inputs/defaulted-template-type-parameter.h
+++ b/test/Interop/Cxx/templates/Inputs/defaulted-template-type-parameter.h
@@ -36,10 +36,10 @@ template <class T>
 void functionTemplateWithDefaultedParam(T = 0) {}
 
 template <class T = void>
-void defaultedTemplateTypeParamUsedInSignatureAndUnrealtedParam(int, T) {}
+void defaultedTemplateTypeParamUsedInSignatureAndUnrelatedParam(int, T) {}
 
 template <class = void>
-void defaultedTemplateTypeParamAndUnrealtedParam(int) {}
+void defaultedTemplateTypeParamAndUnrelatedParam(int) {}
 
 template <class T = int>
 void overloadedDefaultedTemplate(T) {}

--- a/test/Interop/Cxx/templates/Inputs/function-templates.h
+++ b/test/Interop/Cxx/templates/Inputs/function-templates.h
@@ -24,7 +24,7 @@ template <class R, class T, class U> R templateParameterReturnType(T a, U b) {
 // Same here:
 template <class T> void cannotInferTemplate() {}
 
-struct HasVariadicMemeber {
+struct HasVariadicMember {
   void test1(...) {}
   void test2(int, ...) {}
 };

--- a/test/Interop/Cxx/templates/Inputs/module.modulemap
+++ b/test/Interop/Cxx/templates/Inputs/module.modulemap
@@ -33,7 +33,7 @@ module ExplicitClassSpecialization {
   requires cplusplus
 }
 
-module ClassTemplateInstantionExistingSpecialization {
+module ClassTemplateInstantiationExistingSpecialization {
   header "class-template-instantiation-existing-specialization.h"
   requires cplusplus
 }

--- a/test/Interop/Cxx/templates/class-template-instantiation-existing-specialization.swift
+++ b/test/Interop/Cxx/templates/class-template-instantiation-existing-specialization.swift
@@ -3,7 +3,7 @@
 // REQUIRES: executable_test
 
 // Please don't add tests into this test case - its setup is quite delicate.
-import ClassTemplateInstantionExistingSpecialization
+import ClassTemplateInstantiationExistingSpecialization
 import StdlibUnittest
 
 var TemplatesTestSuite = TestSuite("TemplatesTestSuite")

--- a/test/Interop/Cxx/templates/defaulted-template-type-parameter-module-interface.swift
+++ b/test/Interop/Cxx/templates/defaulted-template-type-parameter-module-interface.swift
@@ -16,7 +16,7 @@
 // CHECK: func overloadedDefaultedTemplate(_: Int32)
 // CHECK: func defaultedTemplateReferenceTypeParam<T>(_ t: inout T)
 // The following types aren't imported correctly, but that does not have to do
-// with the fact that the template type paramaters are defaulted.
+// with the fact that the template type parameters are defaulted.
 // TODO: reenable the following checks: (rdar://90587703)
 // TODO-CHECK: func defaultedTemplatePointerTypeParam<T>(_ t: UnsafeMutablePointer<T>)
 // TODO-CHECK: func defaultedTemplatePointerPointerTypeParam<T>(_ t: UnsafeMutablePointer<OpaquePointer?>!)

--- a/test/Interop/Cxx/templates/defaulted-template-type-parameter-module-interface.swift
+++ b/test/Interop/Cxx/templates/defaulted-template-type-parameter-module-interface.swift
@@ -10,8 +10,8 @@
 // CHECK: func defaultedTemplateTypeParamUsedInReturn<T>() -> T
 // CHECK: func defaultedTemplateTypeParamAndDefaultedParam<T>(_: T)
 // CHECK: func functionTemplateWithDefaultedParam<T>(_: T)
-// CHECK: func defaultedTemplateTypeParamUsedInSignatureAndUnrealtedParam<T>(_: Int32, _: T)
-// CHECK: func defaultedTemplateTypeParamAndUnrealtedParam(_: Int32)
+// CHECK: func defaultedTemplateTypeParamUsedInSignatureAndUnrelatedParam<T>(_: Int32, _: T)
+// CHECK: func defaultedTemplateTypeParamAndUnrelatedParam(_: Int32)
 // CHECK: func overloadedDefaultedTemplate<T>(_: T)
 // CHECK: func overloadedDefaultedTemplate(_: Int32)
 // CHECK: func defaultedTemplateReferenceTypeParam<T>(_ t: inout T)

--- a/test/Interop/Cxx/templates/defaulted-template-type-parameter.swift
+++ b/test/Interop/Cxx/templates/defaulted-template-type-parameter.swift
@@ -24,8 +24,8 @@ DefaultedTemplateTestSuite.test("Function with defaulted template type parameter
   let _: Int = defaultedTemplateTypeParamUsedInReturn()
   defaultedTemplateTypeParamAndDefaultedParam(0)
   functionTemplateWithDefaultedParam(0)
-  defaultedTemplateTypeParamUsedInSignatureAndUnrealtedParam(0, 0)
-  defaultedTemplateTypeParamAndUnrealtedParam(0)
+  defaultedTemplateTypeParamUsedInSignatureAndUnrelatedParam(0, 0)
+  defaultedTemplateTypeParamAndUnrelatedParam(0)
 }
 
 DefaultedTemplateTestSuite.test("Overloaded function template is not ambiguous") {

--- a/test/Interop/Cxx/templates/dependent-types.swift
+++ b/test/Interop/Cxx/templates/dependent-types.swift
@@ -23,7 +23,7 @@ DependentTypesTestSuite.test("Different dependent inferred by arg.") {
   expectEqual(m.getValue(), 42)
 }
 
-DependentTypesTestSuite.test("Instanciate the same function twice") {
+DependentTypesTestSuite.test("Instantiate the same function twice") {
   // Intentionally test the same thing twice.
   let m = dependantReturnTypeInffered(42) as! M<Int>
   expectEqual(m.getValue(), 42)

--- a/test/Interop/Cxx/templates/function-template-module-interface.swift
+++ b/test/Interop/Cxx/templates/function-template-module-interface.swift
@@ -7,7 +7,7 @@
 // CHECK: func templateParameterReturnType<R, T, U>(_ a: T, _ b: U) -> R
 // CHECK: func cannotInferTemplate<T>(T: T.Type)
 
-// CHECK: struct HasVariadicMemeber {
+// CHECK: struct HasVariadicMember {
 // CHECK:   @available(*, unavailable, message: "Variadic function is unavailable")
 // CHECK:   mutating func test1(_ varargs: Any...)
 // CHECK:   @available(*, unavailable, message: "Variadic function is unavailable")

--- a/test/Interop/Cxx/templates/swift-class-instantiation-in-namespace-module-interface.swift
+++ b/test/Interop/Cxx/templates/swift-class-instantiation-in-namespace-module-interface.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swiftxx-frontend -emit-module -o %t/SwiftClassTemplateInNamespaceModule.swiftmodule %S/Inputs/SwiftClassTemplateInNamespaceModule.swift -I %S/Inputs -enable-library-evolution -swift-version 5
 // RUN: %target-swift-ide-test -print-module -module-to-print=SwiftClassTemplateInNamespaceModule -I %t/ -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
-// The following bug needs to be resolved so decls in __ObjC don't dissapear.
+// The following bug needs to be resolved so decls in __ObjC don't disappear.
 // REQUIRES: SR-14211
 
 // CHECK: import ClassTemplateInNamespaceForSwiftModule

--- a/test/Interop/Cxx/templates/template-type-parameter-not-in-signature.swift
+++ b/test/Interop/Cxx/templates/template-type-parameter-not-in-signature.swift
@@ -17,7 +17,7 @@ TemplateNotInSignatureTestSuite.test("Function with defaulted template type para
   expectEqual(y, 10)
 }
 
-TemplateNotInSignatureTestSuite.test("Instanciate the same function template twice.") {
+TemplateNotInSignatureTestSuite.test("Instantiate the same function template twice.") {
   // Intentionally test the same thing twice.
   templateTypeParamNotUsedInSignature(T: Int.self)
   templateTypeParamNotUsedInSignature(T: Int.self)

--- a/test/Interop/Cxx/value-witness-table/Inputs/custom-destructors.h
+++ b/test/Interop/Cxx/value-witness-table/Inputs/custom-destructors.h
@@ -26,7 +26,7 @@ struct HasDefaultedDestructor {
 };
 
 // For the following objects with virtual bases / destructors, make sure that
-// any exectuable user of these objects disable rtti and exceptions. Otherwise,
+// any executable user of these objects disable rtti and exceptions. Otherwise,
 // the linker will error because of undefined vtables.
 // FIXME: Once we can link with libc++ we can enable RTTI.
 

--- a/test/Interop/Cxx/value-witness-table/witness-layout-opts-irgen.swift
+++ b/test/Interop/Cxx/value-witness-table/witness-layout-opts-irgen.swift
@@ -3,7 +3,7 @@
 // This test checks that the compiler uses well-known witness tables for types
 // that have the appropriate size/shape (for example, { i8 x 4 } -> i32).
 
-// These witness tables look very differnt on Windows so it doesn't make sense
+// These witness tables look very different on Windows so it doesn't make sense
 // to test them in the same file.
 // XFAIL: OS=windows-msvc
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fixes some misspellings in Swift interop, it is split per https://github.com/apple/swift/pull/42421#issuecomment-1101092698


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
