### PR TITLE
Spelling decl

### DIFF
--- a/test/decl/func/operator.swift
+++ b/test/decl/func/operator.swift
@@ -201,7 +201,7 @@ func ??= <T>(result : inout T?, rhs : Int) {  // ok
 
 
 
-// <rdar://problem/14296004> [QoI] Poor diagnostic/recovery when two operators (e.g., == and -) are adjacted without spaces.
+// <rdar://problem/14296004> [QoI] Poor diagnostic/recovery when two operators (e.g., == and -) are adjacent without spaces.
 _ = n*-4       // expected-error {{missing whitespace between '*' and '-' operators}} {{6-6= }} {{7-7= }}
 if n==-1 {}    // expected-error {{missing whitespace between '==' and '-' operators}} {{5-5= }} {{7-7= }}
 

--- a/test/decl/operator/lookup.swift
+++ b/test/decl/operator/lookup.swift
@@ -96,7 +96,7 @@ func testOperatorLookup() {
   // through ExportsAC.
   >>>1
 
-  // We've been evil and overriden TernaryPrecedence in both modules A and B.
+  // We've been evil and overridden TernaryPrecedence in both modules A and B.
   // Make sure we emit an ambiguity error without emitting a 'broken stdlib'
   // error.
   true ? () : () // expected-error {{multiple precedence groups found}}

--- a/test/decl/operator/lookup_compatibility.swift
+++ b/test/decl/operator/lookup_compatibility.swift
@@ -105,7 +105,7 @@ func testOperatorLookup() {
   // through ExportsAC.
   >>>1
 
-  // We've been evil and overriden TernaryPrecedence in both modules A and B.
+  // We've been evil and overridden TernaryPrecedence in both modules A and B.
   // Make sure we emit an ambiguity error without emitting a 'broken stdlib'
   // error.
   true ? () : () // expected-error {{multiple precedence groups found}}

--- a/test/decl/protocol/conforms/Inputs/fixit_stub_ambiguity_module.swift
+++ b/test/decl/protocol/conforms/Inputs/fixit_stub_ambiguity_module.swift
@@ -1,7 +1,7 @@
 public struct Notification {}
 
 public protocol AmbiguousFuncProtocol {
-  func application(recieved: Notification)
+  func application(received: Notification)
 }
 
 public protocol AmbiguousVarProtocol {

--- a/test/decl/protocol/conforms/error_self_conformance.swift
+++ b/test/decl/protocol/conforms/error_self_conformance.swift
@@ -9,7 +9,7 @@ func testSimple(error: Error) {
 }
 
 protocol ErrorRefinement : Error {}
-func testErrorRefinment(error: ErrorRefinement) {
+func testErrorRefinement(error: ErrorRefinement) {
   opensError(error) // okay
   wantsError(error, error) // expected-error {{type 'any ErrorRefinement' cannot conform to 'Error'}} expected-note {{only concrete types such as structs, enums and classes can conform to protocols}}
 }

--- a/test/decl/protocol/conforms/fixit_stub_editor_amiguity.swift
+++ b/test/decl/protocol/conforms/fixit_stub_editor_amiguity.swift
@@ -9,7 +9,7 @@ struct Notification {}
 
 struct MyApp: AmbiguousFuncProtocol {
 // expected-error@-1 {{type 'MyApp' does not conform to protocol 'AmbiguousFuncProtocol'}}
-// expected-note@-2 {{do you want to add protocol stubs?}} {{38-38=\n    func application(recieved: Ambiguous.Notification) {\n        <#code#>\n    \}\n}}
+// expected-note@-2 {{do you want to add protocol stubs?}} {{38-38=\n    func application(received: Ambiguous.Notification) {\n        <#code#>\n    \}\n}}
 }
 
 extension MyApp: AmbiguousVarProtocol {

--- a/test/decl/protocol/protocol_with_superclass.swift
+++ b/test/decl/protocol/protocol_with_superclass.swift
@@ -326,7 +326,7 @@ protocol DuplicateSuper : Concrete, Concrete {}
 // expected-warning@-1 {{redundant superclass constraint 'Self' : 'Concrete'}}
 // expected-error@-2 {{duplicate inheritance from 'Concrete'}}
 
-// Ambigous name lookup situation
+// Ambiguous name lookup situation
 protocol Amb : Concrete {}
 // expected-note@-1 {{'Amb' previously declared here}}
 // expected-note@-2 {{found this candidate}}

--- a/test/decl/protocol/recursive_requirement.swift
+++ b/test/decl/protocol/recursive_requirement.swift
@@ -6,8 +6,8 @@ protocol Foo {
   associatedtype Bar : Foo
 }
 
-struct Oroborous : Foo {
-  typealias Bar = Oroborous
+struct Ouroboros : Foo {
+  typealias Bar = Ouroboros
 }
 
 // -----

--- a/test/decl/protocol/special/coding/class_codable_member_type_lookup.swift
+++ b/test/decl/protocol/special/coding/class_codable_member_type_lookup.swift
@@ -18,7 +18,7 @@ struct SynthesizedClass : Codable {
   // Qualified type lookup should always be unambiguous.
   public func qualifiedFoo(_ key: SynthesizedClass.CodingKeys) {} // expected-error {{method cannot be declared public because its parameter uses a private type}}
   internal func qualifiedBar(_ key: SynthesizedClass.CodingKeys) {} // expected-error {{method cannot be declared internal because its parameter uses a private type}}
-  fileprivate func qualfiedBaz(_ key: SynthesizedClass.CodingKeys) {} // expected-error {{method cannot be declared fileprivate because its parameter uses a private type}}
+  fileprivate func qualifiedBaz(_ key: SynthesizedClass.CodingKeys) {} // expected-error {{method cannot be declared fileprivate because its parameter uses a private type}}
   private func qualifiedQux(_ key: SynthesizedClass.CodingKeys) {}
 
   // Unqualified lookups should find the synthesized CodingKeys type instead
@@ -97,7 +97,7 @@ struct SynthesizedClass : Codable {
     // Qualified lookup should remain as-is.
     public func qualifiedFoo(_ key: SynthesizedClass.CodingKeys) {} // expected-error {{method cannot be declared public because its parameter uses a private type}}
     internal func qualifiedBar(_ key: SynthesizedClass.CodingKeys) {} // expected-error {{method cannot be declared internal because its parameter uses a private type}}
-    fileprivate func qualfiedBaz(_ key: SynthesizedClass.CodingKeys) {} // expected-error {{method cannot be declared fileprivate because its parameter uses a private type}}
+    fileprivate func qualifiedBaz(_ key: SynthesizedClass.CodingKeys) {} // expected-error {{method cannot be declared fileprivate because its parameter uses a private type}}
     private func qualifiedQux(_ key: SynthesizedClass.CodingKeys) {}
 
     // Unqualified lookups should find the SynthesizedClass's synthesized
@@ -186,7 +186,7 @@ struct NonSynthesizedClass : Codable { // expected-note 4 {{'NonSynthesizedClass
   // type here.
   public func qualifiedFoo(_ key: NonSynthesizedClass.CodingKeys) {} // expected-error {{'CodingKeys' is not a member type of struct 'class_codable_member_type_lookup.NonSynthesizedClass'}}
   internal func qualifiedBar(_ key: NonSynthesizedClass.CodingKeys) {} // expected-error {{'CodingKeys' is not a member type of struct 'class_codable_member_type_lookup.NonSynthesizedClass'}}
-  fileprivate func qualfiedBaz(_ key: NonSynthesizedClass.CodingKeys) {} // expected-error {{'CodingKeys' is not a member type of struct 'class_codable_member_type_lookup.NonSynthesizedClass'}}
+  fileprivate func qualifiedBaz(_ key: NonSynthesizedClass.CodingKeys) {} // expected-error {{'CodingKeys' is not a member type of struct 'class_codable_member_type_lookup.NonSynthesizedClass'}}
   private func qualifiedQux(_ key: NonSynthesizedClass.CodingKeys) {} // expected-error {{'CodingKeys' is not a member type of struct 'class_codable_member_type_lookup.NonSynthesizedClass'}}
 
   // Unqualified lookups should find the public top-level CodingKeys type.
@@ -268,7 +268,7 @@ struct ExplicitClass : Codable {
   // Qualified type lookup should always be unambiguous.
   public func qualifiedFoo(_ key: ExplicitClass.CodingKeys) {}
   internal func qualifiedBar(_ key: ExplicitClass.CodingKeys) {}
-  fileprivate func qualfiedBaz(_ key: ExplicitClass.CodingKeys) {}
+  fileprivate func qualifiedBaz(_ key: ExplicitClass.CodingKeys) {}
   private func qualifiedQux(_ key: ExplicitClass.CodingKeys) {}
 
   // Unqualified lookups should find the synthesized CodingKeys type instead
@@ -347,7 +347,7 @@ struct ExplicitClass : Codable {
     // Qualified lookup should remain as-is.
     public func qualifiedFoo(_ key: ExplicitClass.CodingKeys) {}
     internal func qualifiedBar(_ key: ExplicitClass.CodingKeys) {}
-    fileprivate func qualfiedBaz(_ key: ExplicitClass.CodingKeys) {}
+    fileprivate func qualifiedBaz(_ key: ExplicitClass.CodingKeys) {}
     private func qualifiedQux(_ key: ExplicitClass.CodingKeys) {}
 
     // Unqualified lookups should find the ExplicitClass's synthesized
@@ -437,7 +437,7 @@ struct ExtendedClass : Codable {
   // Qualified type lookup should always be unambiguous.
   public func qualifiedFoo(_ key: ExtendedClass.CodingKeys) {}
   internal func qualifiedBar(_ key: ExtendedClass.CodingKeys) {}
-  fileprivate func qualfiedBaz(_ key: ExtendedClass.CodingKeys) {}
+  fileprivate func qualifiedBaz(_ key: ExtendedClass.CodingKeys) {}
   private func qualifiedQux(_ key: ExtendedClass.CodingKeys) {}
 
   // Unqualified lookups should find the synthesized CodingKeys type instead
@@ -516,7 +516,7 @@ struct ExtendedClass : Codable {
     // Qualified lookup should remain as-is.
     public func qualifiedFoo(_ key: ExtendedClass.CodingKeys) {}
     internal func qualifiedBar(_ key: ExtendedClass.CodingKeys) {}
-    fileprivate func qualfiedBaz(_ key: ExtendedClass.CodingKeys) {}
+    fileprivate func qualifiedBaz(_ key: ExtendedClass.CodingKeys) {}
     private func qualifiedQux(_ key: ExtendedClass.CodingKeys) {}
 
     // Unqualified lookups should find the ExtendedClass's synthesized

--- a/test/decl/protocol/special/coding/struct_codable_member_type_lookup.swift
+++ b/test/decl/protocol/special/coding/struct_codable_member_type_lookup.swift
@@ -18,7 +18,7 @@ struct SynthesizedStruct : Codable {
   // Qualified type lookup should always be unambiguous.
   public func qualifiedFoo(_ key: SynthesizedStruct.CodingKeys) {} // expected-error {{method cannot be declared public because its parameter uses a private type}}
   internal func qualifiedBar(_ key: SynthesizedStruct.CodingKeys) {} // expected-error {{method cannot be declared internal because its parameter uses a private type}}
-  fileprivate func qualfiedBaz(_ key: SynthesizedStruct.CodingKeys) {} // expected-error {{method cannot be declared fileprivate because its parameter uses a private type}}
+  fileprivate func qualifiedBaz(_ key: SynthesizedStruct.CodingKeys) {} // expected-error {{method cannot be declared fileprivate because its parameter uses a private type}}
   private func qualifiedQux(_ key: SynthesizedStruct.CodingKeys) {}
 
   // Unqualified lookups should find the synthesized CodingKeys type instead
@@ -97,7 +97,7 @@ struct SynthesizedStruct : Codable {
     // Qualified lookup should remain as-is.
     public func qualifiedFoo(_ key: SynthesizedStruct.CodingKeys) {} // expected-error {{method cannot be declared public because its parameter uses a private type}}
     internal func qualifiedBar(_ key: SynthesizedStruct.CodingKeys) {} // expected-error {{method cannot be declared internal because its parameter uses a private type}}
-    fileprivate func qualfiedBaz(_ key: SynthesizedStruct.CodingKeys) {} // expected-error {{method cannot be declared fileprivate because its parameter uses a private type}}
+    fileprivate func qualifiedBaz(_ key: SynthesizedStruct.CodingKeys) {} // expected-error {{method cannot be declared fileprivate because its parameter uses a private type}}
     private func qualifiedQux(_ key: SynthesizedStruct.CodingKeys) {}
 
     // Unqualified lookups should find the SynthesizedStruct's synthesized
@@ -186,7 +186,7 @@ struct NonSynthesizedStruct : Codable { // expected-note 4 {{'NonSynthesizedStru
   // type here.
   public func qualifiedFoo(_ key: NonSynthesizedStruct.CodingKeys) {} // expected-error {{'CodingKeys' is not a member type of struct 'struct_codable_member_type_lookup.NonSynthesizedStruct'}}
   internal func qualifiedBar(_ key: NonSynthesizedStruct.CodingKeys) {} // expected-error {{'CodingKeys' is not a member type of struct 'struct_codable_member_type_lookup.NonSynthesizedStruct'}}
-  fileprivate func qualfiedBaz(_ key: NonSynthesizedStruct.CodingKeys) {} // expected-error {{'CodingKeys' is not a member type of struct 'struct_codable_member_type_lookup.NonSynthesizedStruct'}}
+  fileprivate func qualifiedBaz(_ key: NonSynthesizedStruct.CodingKeys) {} // expected-error {{'CodingKeys' is not a member type of struct 'struct_codable_member_type_lookup.NonSynthesizedStruct'}}
   private func qualifiedQux(_ key: NonSynthesizedStruct.CodingKeys) {} // expected-error {{'CodingKeys' is not a member type of struct 'struct_codable_member_type_lookup.NonSynthesizedStruct'}}
 
   // Unqualified lookups should find the public top-level CodingKeys type.
@@ -268,7 +268,7 @@ struct ExplicitStruct : Codable {
   // Qualified type lookup should always be unambiguous.
   public func qualifiedFoo(_ key: ExplicitStruct.CodingKeys) {}
   internal func qualifiedBar(_ key: ExplicitStruct.CodingKeys) {}
-  fileprivate func qualfiedBaz(_ key: ExplicitStruct.CodingKeys) {}
+  fileprivate func qualifiedBaz(_ key: ExplicitStruct.CodingKeys) {}
   private func qualifiedQux(_ key: ExplicitStruct.CodingKeys) {}
 
   // Unqualified lookups should find the synthesized CodingKeys type instead
@@ -347,7 +347,7 @@ struct ExplicitStruct : Codable {
     // Qualified lookup should remain as-is.
     public func qualifiedFoo(_ key: ExplicitStruct.CodingKeys) {}
     internal func qualifiedBar(_ key: ExplicitStruct.CodingKeys) {}
-    fileprivate func qualfiedBaz(_ key: ExplicitStruct.CodingKeys) {}
+    fileprivate func qualifiedBaz(_ key: ExplicitStruct.CodingKeys) {}
     private func qualifiedQux(_ key: ExplicitStruct.CodingKeys) {}
 
     // Unqualified lookups should find the ExplicitStruct's synthesized
@@ -437,7 +437,7 @@ struct ExtendedStruct : Codable {
   // Qualified type lookup should always be unambiguous.
   public func qualifiedFoo(_ key: ExtendedStruct.CodingKeys) {}
   internal func qualifiedBar(_ key: ExtendedStruct.CodingKeys) {}
-  fileprivate func qualfiedBaz(_ key: ExtendedStruct.CodingKeys) {}
+  fileprivate func qualifiedBaz(_ key: ExtendedStruct.CodingKeys) {}
   private func qualifiedQux(_ key: ExtendedStruct.CodingKeys) {}
 
   // Unqualified lookups should find the synthesized CodingKeys type instead
@@ -516,7 +516,7 @@ struct ExtendedStruct : Codable {
     // Qualified lookup should remain as-is.
     public func qualifiedFoo(_ key: ExtendedStruct.CodingKeys) {}
     internal func qualifiedBar(_ key: ExtendedStruct.CodingKeys) {}
-    fileprivate func qualfiedBaz(_ key: ExtendedStruct.CodingKeys) {}
+    fileprivate func qualifiedBaz(_ key: ExtendedStruct.CodingKeys) {}
     private func qualifiedQux(_ key: ExtendedStruct.CodingKeys) {}
 
     // Unqualified lookups should find the ExtendedStruct's synthesized

--- a/test/decl/protocol/warn_override.swift
+++ b/test/decl/protocol/warn_override.swift
@@ -19,7 +19,7 @@ protocol P1: P0 {
   var prop: A { get } // expected-warning{{implicit override should be marked with 'override' or suppressed with '@_nonoverride'}}
 }
 
-// Silence warnings with @_nonoveride.
+// Silence warnings with @_nonoverride.
 protocol P2: P0 {
   @_nonoverride
   associatedtype A

--- a/test/decl/var/effectful_property_wrapper.swift
+++ b/test/decl/var/effectful_property_wrapper.swift
@@ -13,7 +13,7 @@ struct Abstraction<T> {
         get throws { return value } // expected-error{{property wrappers currently cannot define an 'async' or 'throws' accessor}}
     }
 
-    // its OK to have effectul props that are not `wrappedValue`
+    // its OK to have effectful props that are not `wrappedValue`
 
     var prop1 : T {
       get async { value }

--- a/test/decl/var/lazy_self_capture.swift
+++ b/test/decl/var/lazy_self_capture.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift -parse-as-library
 
 // This test case must be in a file with no other errors, otherwise we won't
-// compute caputures.
+// compute captures.
 
 class C {
   lazy var foo: String = {


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fixes some misspellings in Swift decl, it is split per https://github.com/apple/swift/pull/42421#issuecomment-1101092698


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
