### PR TITLE
IRGen: Set `readonly` and `willreturn` on meta data instantiation functions

### DIFF
--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -2272,7 +2272,8 @@ MetadataResponse irgen::emitGenericTypeMetadataAccessFunction(
     // materialize the nominal type descriptor and call this thunk.
     auto generateThunkFn = [&IGM,
                             checkPrespecialized](IRGenFunction &subIGF) {
-      subIGF.CurFn->setDoesNotAccessMemory();
+      subIGF.CurFn->setOnlyReadsMemory();
+      subIGF.CurFn->setWillReturn();
       subIGF.CurFn->setCallingConv(IGM.SwiftCC);
       IGM.setHasNoFramePointer(subIGF.CurFn);
 
@@ -2853,7 +2854,8 @@ emitMetadataAccessByMangledName(IRGenFunction &IGF, CanType type,
           ? "__swift_instantiateConcreteTypeFromMangledNameAbstract"
           : "__swift_instantiateConcreteTypeFromMangledName";
   auto generateInstantiationFn = [&IGM, request](IRGenFunction &subIGF) {
-    subIGF.CurFn->setDoesNotAccessMemory();
+    subIGF.CurFn->setOnlyReadsMemory();
+    subIGF.CurFn->setWillReturn();
     IGM.setHasNoFramePointer(subIGF.CurFn);
 
     auto params = subIGF.collectParameters();
@@ -2956,7 +2958,7 @@ emitMetadataAccessByMangledName(IRGenFunction &IGF, CanType type,
            llvm::ConstantPointerNull::get(IGM.Int8PtrPtrTy)});
     }
     call->setDoesNotThrow();
-    call->setDoesNotAccessMemory();
+    call->setOnlyReadsMemory();
     call->setCallingConv(IGM.SwiftCC);
 
     // Store the result back to the cache. Metadata instantatiation should
@@ -2991,7 +2993,7 @@ emitMetadataAccessByMangledName(IRGenFunction &IGF, CanType type,
   
   auto call = IGF.Builder.CreateCall(instantiationFn, cache);
   call->setDoesNotThrow();
-  call->setDoesNotAccessMemory();
+  call->setOnlyReadsMemory();
   
   auto response = MetadataResponse::forComplete(call);
   

--- a/test/IRGen/default_function_ir_attributes.swift
+++ b/test/IRGen/default_function_ir_attributes.swift
@@ -56,7 +56,7 @@ func foo() {}
 
 //   helper function: __swift_instantiateConcreteTypeFromMangledName
 // CHECK-LABEL: define {{.*}} @__swift_instantiateConcreteTypeFromMangledName(
-// CHECK-SAME: [[ATTRS_NOINLINE_READNONE_NOUNWIND_NOFRAME:#[0-9]+]]
+// CHECK-SAME: [[ATTRS_NOINLINE_READONLY_NOUNWIND_NOFRAME:#[0-9]+]]
 
 func use_metadata() -> Any.Type {
   return ((C) -> Int).self
@@ -96,7 +96,7 @@ func test_class_existential_cast_3(value: AnyObject) -> C & CP0 {
 
 //   metadata accessor
 // CHECK-LABEL: define {{.*}} @"$s30default_function_ir_attributes1CCMa"(
-// CHECK-SAME: [[ATTRS_NOINLINE_READNONE_NOUNWIND_NOFRAME]]
+// CHECK-SAME: [[ATTRS_NOINLINE_READNONE_NOUNWIND_NOFRAME:#[0-9]+]]
 
 //   helper function: dynamic_cast_existential_1_superclass_conditional
 // CHECK-LABEL: define {{.*}} @dynamic_cast_existential_1_superclass_conditional(
@@ -164,7 +164,7 @@ func test_computed_key_path_generic_thunks<T: P0 & Hashable>(value: T) -> KeyPat
 
 //   helper function: __swift_instantiateGenericMetadata
 // CHECK-LABEL: define {{.*}} @__swift_instantiateGenericMetadata(
-// CHECK-SAME: [[ATTRS_NOINLINE_READNONE_NOUNWIND_NOFRAME]]
+// CHECK-SAME: [[ATTRS_NOINLINE_READONLY_NOUNWIND_NOFRAME]]
 
 //   Use the presence of a target-cpu attribute as a litmus for
 //   whether constructInitialAttributes was called, since it's very
@@ -172,4 +172,5 @@ func test_computed_key_path_generic_thunks<T: P0 & Hashable>(value: T) -> KeyPat
 // CHECK: attributes [[ATTRS_SIMPLE]] = { [[CUSTOM_ATTRS:.*target-cpu.*]] }{{$}}
 // CHECK-DAG: attributes [[ATTRS_NOINLINE_NOUNWIND]] = { noinline nounwind {{.*target-cpu.*}} }
 // CHECK-DAG: attributes [[ATTRS_NOINLINE_READNONE_NOUNWIND_NOFRAME]] = { noinline nounwind readnone {{.*}}"frame-pointer"="none"{{.*target-cpu.*}} }
+// CHECK-DAG: attributes [[ATTRS_NOINLINE_READONLY_NOUNWIND_NOFRAME]] = { noinline nounwind readonly willreturn {{.*}}"frame-pointer"="none"{{.*target-cpu.*}} }
 // CHECK-DAG: attributes [[ATTRS_NOUNWIND]] = { nounwind [[CUSTOM_ATTRS]] }{{$}}

--- a/test/IRGen/generic_metatypes.swift
+++ b/test/IRGen/generic_metatypes.swift
@@ -145,5 +145,5 @@ func makeGenericMetatypes() {
 // CHECK-NOT: call void @llvm.lifetime.end
 // CHECK:   ret %swift.metadata_response
 
-// CHECK-DAG: attributes [[NOUNWIND_READNONE]] = { nounwind readnone }
+// CHECK-DAG: attributes [[NOUNWIND_READNONE]] = { nounwind readonly }
 // CHECK-DAG: attributes [[NOUNWIND_OPT]] = { noinline nounwind "

--- a/test/IRGen/generic_metatypes_future.swift
+++ b/test/IRGen/generic_metatypes_future.swift
@@ -175,5 +175,5 @@ func makeGenericMetatypes() {
 // CHECK-NOT: call void @llvm.lifetime.end
 // CHECK:   ret %swift.metadata_response
 
-// CHECK-DAG: attributes [[NOUNWIND_READNONE]] = { nounwind readnone }
+// CHECK-DAG: attributes [[NOUNWIND_READNONE]] = { nounwind readonly }
 // CHECK-DAG: attributes [[NOUNWIND_OPT]] = { noinline nounwind "


### PR DESCRIPTION
`readonly` (instead of `readnone`) because we want there to be a memory control
dependence on potential preceeding availability checks.

`willreturn` such that LLVM can remove calls without a use.
