### PR TITLE
[TypeChecker] SE-0352: Require coercion if result type contains existential(s) that would loose generic requirements

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6325,5 +6325,19 @@ ERROR(attr_incompatible_with_back_deploy,none,
       "'%0' cannot be applied to a back deployed %1",
       (DeclAttribute, DescriptiveDeclKind))
 
+//------------------------------------------------------------------------------
+// MARK: Implicit opening of existential types
+//------------------------------------------------------------------------------
+
+ERROR(result_requires_explicit_coercion,none,
+      "inferred result type %0 requires explicit coercion due to "
+      "loss of generic requirements",
+      (Type))
+
+NOTE(candidate_result_requires_explicit_coercion,none,
+     "inferred result type %0 requires explicit coercion due to "
+     "loss of generic requirements",
+     (Type))
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -394,6 +394,10 @@ enum class FixKind : uint8_t {
   /// Ignore a type mismatch while trying to infer generic parameter type
   /// from default expression.
   IgnoreDefaultExprTypeMismatch,
+
+  /// Coerce a result type of a call to a particular existential type
+  /// by adding `as any <#Type#>`.
+  AddExplicitExistentialCoercion,
 };
 
 class ConstraintFix {
@@ -2979,6 +2983,26 @@ public:
   static bool classof(const ConstraintFix *fix) {
     return fix->getKind() == FixKind::IgnoreDefaultExprTypeMismatch;
   }
+};
+
+class AddExplicitExistentialCoercion final : public ConstraintFix {
+  Type ErasedResultType;
+
+  AddExplicitExistentialCoercion(ConstraintSystem &cs, Type erasedResultTy,
+                                 ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::AddExplicitExistentialCoercion, locator),
+        ErasedResultType(erasedResultTy) {}
+
+public:
+  std::string getName() const override {
+    return "add explicit existential type coercion";
+  }
+
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  static AddExplicitExistentialCoercion *create(ConstraintSystem &cs,
+                                                Type resultTy,
+                                                ConstraintLocator *locator);
 };
 
 } // end namespace constraints

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -3000,6 +3000,12 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
+  static bool isRequired(
+      ConstraintSystem &cs, Type resultTy,
+      SmallVectorImpl<std::pair<TypeVariableType *, OpenedArchetypeType *>>
+          &openedExistentials,
+      ConstraintLocatorBuilder locator);
+
   static AddExplicitExistentialCoercion *create(ConstraintSystem &cs,
                                                 Type resultTy,
                                                 ConstraintLocator *locator);

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -3000,11 +3000,16 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  static bool isRequired(
-      ConstraintSystem &cs, Type resultTy,
-      SmallVectorImpl<std::pair<TypeVariableType *, OpenedArchetypeType *>>
-          &openedExistentials,
-      ConstraintLocatorBuilder locator);
+  static bool
+  isRequired(ConstraintSystem &cs, Type resultTy,
+             ArrayRef<std::pair<TypeVariableType *, OpenedArchetypeType *>>
+                 openedExistentials,
+             ConstraintLocatorBuilder locator);
+
+  static bool isRequired(ConstraintSystem &cs, Type resultTy,
+                         llvm::function_ref<Optional<Type>(TypeVariableType *)>
+                             findExistentialType,
+                         ConstraintLocatorBuilder locator);
 
   static AddExplicitExistentialCoercion *create(ConstraintSystem &cs,
                                                 Type resultTy,

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -8152,21 +8152,10 @@ bool MissingExplicitExistentialCoercion::diagnoseAsError() {
 }
 
 bool MissingExplicitExistentialCoercion::diagnoseAsNote() {
-  auto selectedOverload = getCalleeOverloadChoiceIfAvailable(getLocator());
-  if (!selectedOverload)
-    return false;
-
-  const auto &choice = selectedOverload->choice;
-
-  if (auto *decl = choice.getDeclOrNull()) {
-    auto diagnostic = emitDiagnosticAt(
-        decl, diag::candidate_result_requires_explicit_coercion,
-        ErasedResultType);
-    fixIt(diagnostic);
-    return true;
-  }
-
-  return false;
+  auto diagnostic = emitDiagnostic(
+      diag::candidate_result_requires_explicit_coercion, ErasedResultType);
+  fixIt(diagnostic);
+  return true;
 }
 
 void MissingExplicitExistentialCoercion::fixIt(

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -8158,9 +8158,39 @@ bool MissingExplicitExistentialCoercion::diagnoseAsNote() {
   return true;
 }
 
+bool MissingExplicitExistentialCoercion::fixItRequiresParens() const {
+  auto anchor = getAsExpr(getRawAnchor());
+
+  // If it's a member reference an an existential metatype, let's
+  // use the parent "call" expression.
+  if (auto *UDE = dyn_cast_or_null<UnresolvedDotExpr>(anchor))
+    anchor = findParentExpr(UDE);
+
+  if (!anchor)
+    return false;
+
+  const auto &solution = getSolution();
+  return llvm::any_of(
+      solution.OpenedExistentialTypes,
+      [&anchor](const auto &openedExistential) {
+        if (auto openedLoc = simplifyLocatorToAnchor(openedExistential.first)) {
+          return anchor == getAsExpr(openedLoc);
+        }
+        return false;
+      });
+}
+
 void MissingExplicitExistentialCoercion::fixIt(
     InFlightDiagnostic &diagnostic) const {
+  bool requiresParens = fixItRequiresParens();
+
+  auto callRange = getSourceRange();
+
+  if (requiresParens)
+    diagnostic.fixItInsert(callRange.Start, "(");
+
   auto printOpts = PrintOptions::forDiagnosticArguments();
-  diagnostic.fixItInsertAfter(getSourceRange().End,
-                              "as " + ErasedResultType->getString(printOpts));
+  diagnostic.fixItInsertAfter(callRange.End,
+                              "as " + ErasedResultType->getString(printOpts) +
+                                  (requiresParens ? ")" : ""));
 }

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2717,6 +2717,46 @@ public:
   bool diagnoseAsError() override;
 };
 
+/// Diagnose situations where inferring existential type for result of
+/// a call would result in loss of generic requirements.
+///
+/// \code
+/// protocol P {
+///  associatedtype A
+/// }
+///
+/// protocol Q {
+///  associatedtype B: P where B.A == Int
+/// }
+///
+/// func getB<T: Q>(_: T) -> T.B { ... }
+///
+/// func test(v: any Q) {
+///   let _ = getB(v) // <- produces `any P` which looses A == Int
+/// }
+/// \endcode
+class MissingExplicitExistentialCoercion final : public FailureDiagnostic {
+  Type ErasedResultType;
+
+public:
+  MissingExplicitExistentialCoercion(const Solution &solution,
+                                     Type erasedResultTy,
+                                     ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator),
+        ErasedResultType(resolveType(erasedResultTy)) {}
+
+  SourceRange getSourceRange() const override {
+    auto rawAnchor = getRawAnchor();
+    return {rawAnchor.getStartLoc(), rawAnchor.getEndLoc()};
+  }
+
+  bool diagnoseAsError() override;
+  bool diagnoseAsNote() override;
+
+private:
+  void fixIt(InFlightDiagnostic &diagnostic) const;
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2755,6 +2755,13 @@ public:
 
 private:
   void fixIt(InFlightDiagnostic &diagnostic) const;
+
+  /// Determine whether the fix-it to add `as any ...` requires parens.
+  ///
+  /// Parens are required to avoid suppressing existential opening
+  /// if result of the call is passed as an argument to another call
+  /// that requires such opening.
+  bool fixItRequiresParens() const;
 };
 
 } // end namespace constraints

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2183,3 +2183,15 @@ IgnoreDefaultExprTypeMismatch::create(ConstraintSystem &cs, Type argType,
   return new (cs.getAllocator())
       IgnoreDefaultExprTypeMismatch(cs, argType, paramType, locator);
 }
+
+bool AddExplicitExistentialCoercion::diagnose(const Solution &solution,
+                                              bool asNote) const {
+  return false;
+}
+
+AddExplicitExistentialCoercion *
+AddExplicitExistentialCoercion::create(ConstraintSystem &cs, Type resultTy,
+                                       ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      AddExplicitExistentialCoercion(cs, resultTy, locator);
+}

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2247,7 +2247,7 @@ bool AddExplicitExistentialCoercion::isRequired(
         // If result is an existential type and the base has `where` clauses
         // associated with its associated types, the call needs a coercion.
         if (erasedMemberTy->isExistentialType() &&
-            hasConstrainedAssociatedTypes(opened->second)) {
+            hasConstrainedAssociatedTypes(member)) {
           RequiresCoercion = true;
           return Action::Stop;
         }
@@ -2273,6 +2273,19 @@ bool AddExplicitExistentialCoercion::isRequired(
     }
 
   private:
+    bool hasConstrainedAssociatedTypes(DependentMemberType *member) {
+      auto *assocType = member->getAssocType();
+
+      // If this member has associated type requirements, we are done.
+      if (assocType->getTrailingWhereClause())
+        return true;
+
+      if (auto *DMT = member->getBase()->getAs<DependentMemberType>())
+        return hasConstrainedAssociatedTypes(DMT);
+
+      return false;
+    }
+
     bool hasConstrainedAssociatedTypes(ArchetypeType *archetypeTy) {
       assert(archetypeTy);
       for (auto *protocol : archetypeTy->getConformsTo()) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11449,6 +11449,18 @@ ConstraintSystem::simplifyApplicableFnConstraint(
             result2, opened.second->getExistentialType(), opened.first,
             TypePosition::Covariant);
       }
+
+      // If result type has any erased existential types it requires explicit
+      // `as` coercion.
+      if (AddExplicitExistentialCoercion::isRequired(
+              *this, func2->getResult(), openedExistentials, locator)) {
+        if (!shouldAttemptFixes())
+          return SolutionKind::Error;
+
+        if (recordFix(AddExplicitExistentialCoercion::create(
+                *this, result2, getConstraintLocator(locator))))
+          return SolutionKind::Error;
+      }
     }
 
     // The result types are equivalent.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1479,13 +1479,14 @@ shouldOpenExistentialCallArgument(
     return None;
 
   // An argument expression that explicitly coerces to an existential
-  // disables the implicit opening of the existential.
+  // disables the implicit opening of the existential unless it's
+  // wrapped in parens.
   if (argExpr) {
     if (auto argCast = dyn_cast<ExplicitCastExpr>(
             argExpr->getSemanticsProvidingExpr())) {
       if (auto typeRepr = argCast->getCastTypeRepr()) {
         if (auto toType = cs.getType(typeRepr)) {
-          if (toType->isAnyExistentialType())
+          if (!isa<ParenExpr>(argExpr) && toType->isAnyExistentialType())
             return None;
         }
       }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -13078,6 +13078,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::DropAsyncAttribute:
   case FixKind::AllowSwiftToCPointerConversion:
   case FixKind::AllowTupleLabelMismatch:
+  case FixKind::AddExplicitExistentialCoercion:
     llvm_unreachable("handled elsewhere");
   }
 

--- a/test/Constraints/opened_existentials.swift
+++ b/test/Constraints/opened_existentials.swift
@@ -233,7 +233,6 @@ func testExplicitCoercionRequirement(v: any B, otherV: any B & D) {
   func getComplex<T: B>(_: T) -> ([(x: (a: T.C, b: Int), y: Int)], [Int: T.C]) { fatalError() }
 
   func overloaded<T: B>(_: T) -> (x: Int, y: T.C) { fatalError() }
-  // expected-note@-1 {{inferred result type '(x: Int, y: any P)' requires explicit coercion due to loss of generic requirements}} {{251:20-20=as (x: Int, y: any P)}}
   func overloaded<T: P>(_: T) -> Int { 42 }
   // expected-note@-1 {{candidate requires that 'any B' conform to 'P' (requirement specified as 'T' : 'P')}}
 
@@ -249,6 +248,7 @@ func testExplicitCoercionRequirement(v: any B, otherV: any B & D) {
   _ = getComplex(v) as ([(x: (a: any P, b: Int), y: Int)], [Int : any P]) // Ok
 
   _ = overloaded(v) // expected-error {{no exact matches in call to local function 'overloaded'}}
+  // expected-note@-1 {{inferred result type '(x: Int, y: any P)' requires explicit coercion due to loss of generic requirements}} {{20-20=as (x: Int, y: any P)}}
 
   func acceptsAny<T>(_: T) {}
 

--- a/test/Constraints/opened_existentials.swift
+++ b/test/Constraints/opened_existentials.swift
@@ -283,4 +283,8 @@ func testExplicitCoercionRequirement(v: any B, otherV: any B & D) {
   func getBDSelf<T: D>(_: T) -> T { fatalError() }
   _ = getBDSelf(otherV) // expected-error {{inferred result type 'any B & D' requires explicit coercion due to loss of generic requirements}} {{24-24=as any B & D}}
   _ = getBDSelf(otherV) as any B & D // Ok
+
+  func getP<T: P>(_: T) {}
+  getP(getC(v)) // expected-error {{inferred result type 'any P' requires explicit coercion due to loss of generic requirements}} {{8-8=(}} {{15-15=as any P)}}
+  getP(v.getC()) // expected-error {{inferred result type 'any P' requires explicit coercion due to loss of generic requirements}}  {{8-8=(}} {{14-14=as any P)}}
 }

--- a/test/Constraints/opened_existentials.swift
+++ b/test/Constraints/opened_existentials.swift
@@ -213,6 +213,7 @@ func testTakeValueAndClosure(p: any P) {
 
 protocol B {
   associatedtype C: P where C.A == Double
+  associatedtype D: P
 }
 
 func testExplicitCoercionRequirement(v: any B) {
@@ -222,7 +223,7 @@ func testExplicitCoercionRequirement(v: any B) {
   func getComplex<T: B>(_: T) -> ([(x: (a: T.C, b: Int), y: Int)], [Int: T.C]) { fatalError() }
 
   func overloaded<T: B>(_: T) -> (x: Int, y: T.C) { fatalError() }
-  // expected-note@-1 {{inferred result type '(x: Int, y: any P)' requires explicit coercion due to loss of generic requirements}} {{240:20-20=as (x: Int, y: any P)}}
+  // expected-note@-1 {{inferred result type '(x: Int, y: any P)' requires explicit coercion due to loss of generic requirements}} {{241:20-20=as (x: Int, y: any P)}}
   func overloaded<T: P>(_: T) -> Int { 42 }
   // expected-note@-1 {{candidate requires that 'any B' conform to 'P' (requirement specified as 'T' : 'P')}}
 
@@ -238,4 +239,8 @@ func testExplicitCoercionRequirement(v: any B) {
   _ = getComplex(v) as ([(x: (a: any P, b: Int), y: Int)], [Int : any P]) // Ok
 
   _ = overloaded(v) // expected-error {{no exact matches in call to local function 'overloaded'}}
+
+  func getAssocNoRequirements<T: B>(_: T) -> (Int, [T.D]) { fatalError() }
+
+  _ = getAssocNoRequirements(v) // Ok, `D` doesn't have any requirements
 }

--- a/test/Constraints/opened_existentials.swift
+++ b/test/Constraints/opened_existentials.swift
@@ -287,4 +287,7 @@ func testExplicitCoercionRequirement(v: any B, otherV: any B & D) {
   func getP<T: P>(_: T) {}
   getP(getC(v)) // expected-error {{inferred result type 'any P' requires explicit coercion due to loss of generic requirements}} {{8-8=(}} {{15-15=as any P)}}
   getP(v.getC()) // expected-error {{inferred result type 'any P' requires explicit coercion due to loss of generic requirements}}  {{8-8=(}} {{14-14=as any P)}}
+
+  getP((getC(v) as any P))   // Ok - parens avoid opening suppression
+  getP((v.getC() as any P))  // Ok - parens avoid opening suppression
 }

--- a/test/decl/protocol/existential_member_accesses_self_assoctype.swift
+++ b/test/decl/protocol/existential_member_accesses_self_assoctype.swift
@@ -694,7 +694,7 @@ protocol MiscTestsProto {
 do {
   func miscTests(_ arg: any MiscTestsProto) {
     var r: any Sequence & IteratorProtocol = arg.getR()
-    r.makeIterator() // expected-warning {{result of call to 'makeIterator()' is unused}}
+    r.makeIterator() // expected-error {{inferred result type 'any IteratorProtocol' requires explicit coercion due to loss of generic requirements}} {{19-19=as any IteratorProtocol}}
     r.next() // expected-warning {{result of call to 'next()' is unused}}
     r.nonexistent() // expected-error {{value of type 'any IteratorProtocol & Sequence' has no member 'nonexistent'}}
 
@@ -786,8 +786,7 @@ do {
     _ = arg.method3 // expected-error {{member 'method3' cannot be used on value of type 'any ConcreteAssocTypes'; consider using a generic constraint instead}}
     _ = arg.property1 // expected-error {{member 'property1' cannot be used on value of type 'any ConcreteAssocTypes'; consider using a generic constraint instead}}
     // Covariant 'Self' erasure works in conjunction with concrete associated types.
-    let _: (Bool, any ConcreteAssocTypes) = arg.property2 // expected-error {{inferred result type '(Bool, any ConcreteAssocTypes)' requires explicit coercion due to loss of generic requirements}} {{58-58=as (Bool, any ConcreteAssocTypes)}}
-    let _: (Bool, any ConcreteAssocTypes) = arg.property2 as (Bool, any ConcreteAssocTypes) // Ok
+    let _: (Bool, any ConcreteAssocTypes) = arg.property2 // ok
     _ = arg.property3 // expected-error {{member 'property3' cannot be used on value of type 'any ConcreteAssocTypes'; consider using a generic constraint instead}}
     _ = arg[subscript1: false] // expected-error {{member 'subscript' cannot be used on value of type 'any ConcreteAssocTypes'; consider using a generic constraint instead}}
     _ = arg[subscript2: false] // expected-error {{member 'subscript' cannot be used on value of type 'any ConcreteAssocTypes'; consider using a generic constraint instead}}

--- a/test/decl/protocol/existential_member_accesses_self_assoctype.swift
+++ b/test/decl/protocol/existential_member_accesses_self_assoctype.swift
@@ -786,7 +786,8 @@ do {
     _ = arg.method3 // expected-error {{member 'method3' cannot be used on value of type 'any ConcreteAssocTypes'; consider using a generic constraint instead}}
     _ = arg.property1 // expected-error {{member 'property1' cannot be used on value of type 'any ConcreteAssocTypes'; consider using a generic constraint instead}}
     // Covariant 'Self' erasure works in conjunction with concrete associated types.
-    let _: (Bool, any ConcreteAssocTypes) = arg.property2 // ok
+    let _: (Bool, any ConcreteAssocTypes) = arg.property2 // expected-error {{inferred result type '(Bool, any ConcreteAssocTypes)' requires explicit coercion due to loss of generic requirements}} {{58-58=as (Bool, any ConcreteAssocTypes)}}
+    let _: (Bool, any ConcreteAssocTypes) = arg.property2 as (Bool, any ConcreteAssocTypes) // Ok
     _ = arg.property3 // expected-error {{member 'property3' cannot be used on value of type 'any ConcreteAssocTypes'; consider using a generic constraint instead}}
     _ = arg[subscript1: false] // expected-error {{member 'subscript' cannot be used on value of type 'any ConcreteAssocTypes'; consider using a generic constraint instead}}
     _ = arg[subscript2: false] // expected-error {{member 'subscript' cannot be used on value of type 'any ConcreteAssocTypes'; consider using a generic constraint instead}}


### PR DESCRIPTION
Implements SE-0352 revision - require explicit `as` coercion when existential
erasure loses information. 

For example:

```swift
protocol P {
  associatedtype A
}

protocol Q {
  associatedtype B: P where B.A == Int
}

func getB<T: Q>(_: T) -> T.B { ... }

func test(v: any Q) {
  let _ = getB(v) // <- produces `any P` which loses A == Int
}
```

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
