### PR TITLE
Move clock runtime functions to the same compilation build group as the task sleep build group

### DIFF
--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -12,7 +12,6 @@
 
 if(NOT swift_concurrency_extra_sources)
   set(swift_concurrency_extra_sources
-    Clock.cpp
     Clock.swift
     ContinuousClock.swift
     SuspendingClock.swift
@@ -76,6 +75,7 @@ add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
   AsyncLet.cpp
   AsyncLet.swift
   CheckedContinuation.swift
+  Clock.cpp
   GlobalExecutor.cpp
   Errors.swift
   Error.cpp


### PR DESCRIPTION
Isolating the task sleep runtime functions is not exactly plausible since they require internal access to static functions in the runtime, since the bug fix for sleep requires to adjust time scales it needs to use the same clock source. This means that the compilation group that the clock stuff is in must the same as the sleep stuff (with regards to back port deployment). This does not bring in the swift interface side of things (so availability remains the same; this only focuses on the runtime functions).

Resolves: rdar://92102592