### PR TITLE
[Sema] Diagnose regex literals if `Regex<Output>` is unavailable

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2958,6 +2958,13 @@ public:
         maybeDiagStorageAccess(S->getDecl().getDecl(), S->getSourceRange(), DC);
       }
     }
+    if (auto *RLE = dyn_cast<RegexLiteralExpr>(E)) {
+      // Regex literals require both the Regex<Output> type to be available, as
+      // well as the initializer that is implicitly called.
+      auto Range = RLE->getSourceRange();
+      diagnoseDeclRefAvailability(Context.getRegexDecl(), Range);
+      diagnoseDeclRefAvailability(RLE->getInitializer(), Range);
+    }
     if (auto KP = dyn_cast<KeyPathExpr>(E)) {
       maybeDiagKeyPath(KP);
     }

--- a/test/StringProcessing/Frontend/enable-flag.swift
+++ b/test/StringProcessing/Frontend/enable-flag.swift
@@ -1,6 +1,6 @@
-// RUN: %target-typecheck-verify-swift -enable-bare-slash-regex -enable-experimental-string-processing
-// RUN: %target-typecheck-verify-swift -enable-experimental-string-processing -enable-bare-slash-regex
-// RUN: %target-typecheck-verify-swift -disable-experimental-string-processing -enable-experimental-string-processing -enable-bare-slash-regex
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-bare-slash-regex -enable-experimental-string-processing
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-string-processing -enable-bare-slash-regex
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -disable-experimental-string-processing -enable-experimental-string-processing -enable-bare-slash-regex
 
 // REQUIRES: swift_in_compiler
 

--- a/test/StringProcessing/SILGen/regex_literal_silgen.swift
+++ b/test/StringProcessing/SILGen/regex_literal_silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen -enable-bare-slash-regex %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-bare-slash-regex -disable-availability-checking %s | %FileCheck %s
 // REQUIRES: swift_in_compiler
 
 var s = #/abc/#

--- a/test/StringProcessing/Sema/regex_literal_availability.swift
+++ b/test/StringProcessing/Sema/regex_literal_availability.swift
@@ -1,0 +1,15 @@
+// RUN: %target-typecheck-verify-swift -enable-bare-slash-regex -target %target-cpu-apple-macosx12.0
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: OS=macosx
+
+_ = /x/ // expected-error {{'Regex' is only available in}}
+// expected-note@-1 {{add 'if #available' version check}}
+
+_ = #/x/# // expected-error {{'Regex' is only available in}}
+// expected-note@-1 {{add 'if #available' version check}}
+
+if #available(SwiftStdlib 5.7, *) {
+  _ = /x/
+  _ = #/x/#
+}


### PR DESCRIPTION
Because we don't form a type-checked call to the Regex initializer in the AST, we need to explicitly handle the availability checking for `Regex<Output>` and the initializer we're implicitly calling.

rdar://92156542