### PR TITLE
🍒[5.7-04182022][Distributed] Guard ID synthesis from happening multiple times

### DIFF
--- a/include/swift/AST/DistributedDecl.h
+++ b/include/swift/AST/DistributedDecl.h
@@ -31,6 +31,9 @@ class DeclContext;
 class FuncDecl;
 class NominalTypeDecl;
 
+/// Obtain a distributed actor's well-known property by name.
+VarDecl* lookupDistributedActorProperty(NominalTypeDecl *decl, DeclName name);
+
 /// Determine the concrete type of 'ActorSystem' as seen from the member.
 /// E.g. when in a protocol, and trying to determine what the actor system was
 /// constrained to.

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -62,6 +62,45 @@
 using namespace swift;
 
 /******************************************************************************/
+/********************** Distributed Actor Properties **************************/
+/******************************************************************************/
+
+VarDecl* swift::lookupDistributedActorProperty(NominalTypeDecl *decl, DeclName name) {
+  assert(decl && "decl was null");
+  auto &C = decl->getASTContext();
+
+  auto clazz = dyn_cast<ClassDecl>(decl);
+  if (!clazz)
+    return nullptr;
+
+  auto refs = decl->lookupDirect(name);
+  if (refs.size() != 1)
+    return nullptr;
+
+  auto var = dyn_cast<VarDecl>(refs.front());
+  if (!var)
+    return nullptr;
+
+  Type expectedType = Type();
+  if (name == C.Id_id) {
+    expectedType = getDistributedActorIDType(decl);
+  } else if (name == C.Id_actorSystem) {
+    expectedType = getDistributedActorSystemType(decl);
+  } else {
+    llvm_unreachable("Unexpected distributed actor property lookup!");
+  }
+  if (!expectedType)
+    return nullptr;
+
+  if (!var->getInterfaceType()->isEqual(expectedType))
+    return nullptr;
+
+  assert(var->isSynthesized() && "Expected compiler synthesized property");
+  return var;
+}
+
+
+/******************************************************************************/
 /************** Distributed Actor System Associated Types *********************/
 /******************************************************************************/
 

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -737,6 +737,13 @@ VarDecl *GetDistributedActorIDPropertyRequest::evaluate(
   if (!classDecl)
     return nullptr;
 
+  // We may enter this request multiple times, e.g. in multi-file projects,
+  // so in order to avoid synthesizing a property many times, first perform
+  // a lookup and return if it already exists.
+  if (auto existingProp = lookupDistributedActorProperty(classDecl, C.Id_id)) {
+    return existingProp;
+  }
+
   return addImplicitDistributedActorIDProperty(classDecl);
 }
 

--- a/test/Distributed/Inputs/EchoActor.swift
+++ b/test/Distributed/Inputs/EchoActor.swift
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Distributed
+
+distributed actor Echo /* in the mirror */{
+  typealias ActorSystem = LocalTestingDistributedActorSystem
+
+  distributed func echo(_ input: String) -> String {
+    return "echo: \(input)"
+  }
+}

--- a/test/Distributed/Runtime/distributed_actor_in_other_module.swift
+++ b/test/Distributed/Runtime/distributed_actor_in_other_module.swift
@@ -1,0 +1,35 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/EchoActorModule.swiftmodule -module-name EchoActorModule -disable-availability-checking %S/../Inputs/EchoActor.swift
+// RUN: %target-build-swift -module-name main -Xfrontend -enable-experimental-distributed -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift %S/../Inputs/EchoActor.swift -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s --color
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+// FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
+// UNSUPPORTED: windows
+
+import Distributed
+import EchoActorModule
+import FakeDistributedActorSystems
+
+func test() async {
+  let system = LocalTestingDistributedActorSystem()
+
+  let echo = Echo(actorSystem: system)
+  let reply = try! await echo.echo("in the mirror")
+  // CHECK: reply: echo: in the mirror
+  print("reply: \(reply)")
+}
+
+@main struct Main {
+  static func main() async {
+    await test()
+  }
+}


### PR DESCRIPTION
**Description:** Avoid synthesising the ID property many times in case of multi module builds. Without this declaring a distributed actor in separate files, in a multi module project, will cause a compiler crash. More detailed description on why that is in original ticket.
**Risk:** Low
**Review by:** @DougGregor @kavon 
**Testing:** Verified using sample app; unit tests
**Original PR:** https://github.com/apple/swift/pull/42577
**Radar:** rdar://92162535