### PR TITLE
[5.7] remainder of alignment changes

### DIFF
--- a/include/swift/Runtime/Atomic.h
+++ b/include/swift/Runtime/Atomic.h
@@ -95,14 +95,6 @@ struct aligned_alloc<Alignment_, true> {
     free(ptr);
 #endif
   }
-
-#if defined(_WIN32)
-  // FIXME: why is this even needed?  This is not permitted as per the C++
-  // standrd new.delete.placement (§17.6.3.4).
-  [[nodiscard]] void *operator new(std::size_t size, void *where) noexcept {
-    return ::operator new(size, where);
-  }
-#endif
 };
 
 /// The default implementation for swift::atomic<T>, which just wraps

--- a/include/swift/Runtime/HeapObject.h
+++ b/include/swift/Runtime/HeapObject.h
@@ -19,6 +19,8 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <new>
+#include <utility>
 #include "swift/Runtime/Config.h"
 
 #if SWIFT_OBJC_INTEROP
@@ -130,6 +132,49 @@ void *swift_slowAlloc(size_t bytes, size_t alignMask);
 // then call these corresponding APIs:
 SWIFT_RUNTIME_EXPORT
 void swift_slowDealloc(void *ptr, size_t bytes, size_t alignMask);
+
+/// Allocate and construct an instance of type \c T.
+///
+/// \param args The arguments to pass to the constructor for \c T.
+///
+/// \returns A pointer to a new, fully constructed instance of \c T. This
+/// 	function never returns \c nullptr. The caller is responsible for
+///   eventually destroying the resulting object by passing it to
+///   \c swift_cxx_deleteObject().
+///
+/// This function avoids the use of the global \c operator \c new (which may be
+/// overridden by other code in a process) in favor of calling
+/// \c swift_slowAlloc() and constructing the new object with placement new.
+/// 
+/// This function is capable of returning well-aligned memory even on platforms
+/// that do not implement the C++17 "over-aligned new" feature.
+template <typename T, typename... Args>
+static inline T *swift_cxx_newObject(Args &&... args) {
+  auto result = reinterpret_cast<T *>(swift_slowAlloc(sizeof(T),
+                                                      alignof(T) - 1));
+  ::new (result) T(std::forward<Args>(args)...);
+  return result;
+}
+
+/// Destruct and deallocate an instance of type \c T.
+///
+/// \param ptr A pointer to an instance of type \c T previously created with a
+/// 	call to \c swift_cxx_newObject().
+///
+/// This function avoids the use of the global \c operator \c delete (which may
+/// be overridden by other code in a process) in favor of directly calling the
+/// destructor for \a *ptr and then freeing its memory by calling
+/// \c swift_slowDealloc().
+///
+/// The effect of passing a pointer to this function that was \em not returned
+/// from \c swift_cxx_newObject() is undefined.
+template <typename T>
+static inline void swift_cxx_deleteObject(T *ptr) {
+  if (ptr) {
+  	ptr->~T();
+  	swift_slowDealloc(ptr, sizeof(T), alignof(T) - 1);
+  }
+}
 
 /// Atomically increments the retain count of an object.
 ///

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -17,6 +17,7 @@
 
 #include "swift/Runtime/Concurrency.h"
 #include <atomic>
+#include <new>
 
 #ifdef _WIN32
 // On Windows, an include below triggers an indirect include of minwindef.h

--- a/stdlib/public/Concurrency/AsyncLet.cpp
+++ b/stdlib/public/Concurrency/AsyncLet.cpp
@@ -31,6 +31,8 @@
 #include <dlfcn.h>
 #endif
 
+#include <new>
+
 using namespace swift;
 
 namespace {

--- a/stdlib/public/Concurrency/AsyncLet.cpp
+++ b/stdlib/public/Concurrency/AsyncLet.cpp
@@ -141,7 +141,7 @@ static AsyncLetImpl *asImpl(const AsyncLet *alet) {
 
 void swift::asyncLet_addImpl(AsyncTask *task, AsyncLet *asyncLet,
                              bool didAllocateInParentTask) {
-  AsyncLetImpl *impl = new (asyncLet) AsyncLetImpl(task);
+  AsyncLetImpl *impl = ::new (asyncLet) AsyncLetImpl(task);
   impl->setDidAllocateFromParentTask(didAllocateInParentTask);
 
   auto record = impl->getTaskRecord();

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -28,6 +28,7 @@
 #include "Debug.h"
 #include "Error.h"
 #include <atomic>
+#include <new>
 
 #if SWIFT_CONCURRENCY_ENABLE_DISPATCH
 #include <dispatch/dispatch.h>
@@ -770,20 +771,20 @@ static AsyncTaskAndContext swift_task_create_commonImpl(
   // Initialize the child fragment if applicable.
   if (parent) {
     auto childFragment = task->childFragment();
-    new (childFragment) AsyncTask::ChildFragment(parent);
+    ::new (childFragment) AsyncTask::ChildFragment(parent);
   }
 
   // Initialize the group child fragment if applicable.
   if (group) {
     auto groupChildFragment = task->groupChildFragment();
-    new (groupChildFragment) AsyncTask::GroupChildFragment(group);
+    ::new (groupChildFragment) AsyncTask::GroupChildFragment(group);
   }
 
   // Initialize the future fragment if applicable.
   if (futureResultType) {
     assert(task->isFuture());
     auto futureFragment = task->futureFragment();
-    new (futureFragment) FutureFragment(futureResultType);
+    ::new (futureFragment) FutureFragment(futureResultType);
 
     // Set up the context for the future so there is no error, and a successful
     // result will be written into the future fragment's storage.
@@ -1202,7 +1203,7 @@ swift_task_addCancellationHandlerImpl(
   void *allocation =
       swift_task_alloc(sizeof(CancellationNotificationStatusRecord));
   auto unsigned_handler = swift_auth_code(handler, 3848);
-  auto *record = new (allocation)
+  auto *record = ::new (allocation)
       CancellationNotificationStatusRecord(unsigned_handler, context);
 
   bool fireHandlerNow = false;
@@ -1237,7 +1238,7 @@ swift_task_createNullaryContinuationJobImpl(
   void *allocation =
       swift_task_alloc(sizeof(NullaryContinuationJob));
   auto *job =
-      new (allocation) NullaryContinuationJob(
+      ::new (allocation) NullaryContinuationJob(
         swift_task_getCurrent(), static_cast<JobPriority>(priority),
         continuation);
 

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -33,6 +33,7 @@
 #include "string"
 #include "queue" // TODO: remove and replace with usage of our mpsc queue
 #include <atomic>
+#include <new>
 #include <assert.h>
 #if SWIFT_CONCURRENCY_ENABLE_DISPATCH
 #include <dispatch/dispatch.h>
@@ -469,7 +470,7 @@ SWIFT_CC(swift)
 static void swift_taskGroup_initializeImpl(TaskGroup *group, const Metadata *T) {
   SWIFT_TASK_DEBUG_LOG("creating task group = %p", group);
 
-  TaskGroupImpl *impl = new (group) TaskGroupImpl(T);
+  TaskGroupImpl *impl = ::new (group) TaskGroupImpl(T);
   auto record = impl->getTaskRecord();
   assert(impl == record && "the group IS the task record");
 

--- a/stdlib/public/Concurrency/TaskLocal.cpp
+++ b/stdlib/public/Concurrency/TaskLocal.cpp
@@ -24,6 +24,7 @@
 #include "swift/ABI/Metadata.h"
 #include "llvm/ADT/PointerIntPair.h"
 #include "TaskPrivate.h"
+#include <new>
 #include <set>
 
 #if SWIFT_STDLIB_HAS_ASL
@@ -207,7 +208,7 @@ TaskLocal::Item::createLink(AsyncTask *task,
   size_t amountToAllocate = Item::itemSize(valueType);
   void *allocation = task ? _swift_task_alloc_specific(task, amountToAllocate)
                           : malloc(amountToAllocate);
-  Item *item = new (allocation) Item(key, valueType);
+  Item *item = ::new (allocation) Item(key, valueType);
 
   auto next = task ? task->_private().Local.head
                    : FallbackTaskLocalStorage::get()->head;

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -29,6 +29,7 @@
 #include "swift/Runtime/Heap.h"
 #include "swift/Runtime/HeapObject.h"
 #include <atomic>
+#include <new>
 
 #define SWIFT_FATAL_ERROR swift_Concurrency_fatalError
 #include "../runtime/StackAllocator.h"
@@ -655,11 +656,11 @@ AsyncTask::OpaquePrivateStorage::get() const {
   return reinterpret_cast<const PrivateStorage &>(*this);
 }
 inline void AsyncTask::OpaquePrivateStorage::initialize(JobPriority basePri) {
-  new (this) PrivateStorage(basePri);
+  ::new (this) PrivateStorage(basePri);
 }
 inline void AsyncTask::OpaquePrivateStorage::initializeWithSlab(
     JobPriority basePri, void *slab, size_t slabCapacity) {
-  new (this) PrivateStorage(basePri, slab, slabCapacity);
+  ::new (this) PrivateStorage(basePri, slab, slabCapacity);
 }
 inline void AsyncTask::OpaquePrivateStorage::complete(AsyncTask *task) {
   get().complete(task);

--- a/stdlib/public/runtime/AccessibleFunction.cpp
+++ b/stdlib/public/runtime/AccessibleFunction.cpp
@@ -23,6 +23,7 @@
 #include "swift/Runtime/Metadata.h"
 
 #include <cstdint>
+#include <new>
 
 using namespace swift;
 
@@ -153,7 +154,7 @@ swift::runtime::swift_findAccessibleFunction(const char *targetNameStart,
     S.Cache.getOrInsert(
         name, [&](AccessibleFunctionCacheEntry *entry, bool created) {
           if (created)
-            new (entry) AccessibleFunctionCacheEntry{name, record};
+            ::new (entry) AccessibleFunctionCacheEntry{name, record};
           return true;
         });
   }

--- a/stdlib/public/runtime/AnyHashableSupport.cpp
+++ b/stdlib/public/runtime/AnyHashableSupport.cpp
@@ -21,6 +21,8 @@
 #include "swift/Runtime/Debug.h"
 #include "swift/Runtime/HeapObject.h"
 
+#include <new>
+
 using namespace swift;
 using namespace swift::hashable_support;
 
@@ -103,7 +105,7 @@ findHashableBaseTypeImpl(const Metadata *type) {
   HashableConformances.getOrInsert(key, [&](HashableConformanceEntry *entry,
                                             bool created) {
     if (created)
-      new (entry) HashableConformanceEntry(key, baseTypeThatConformsToHashable);
+      ::new (entry) HashableConformanceEntry(key, baseTypeThatConformsToHashable);
     return true; // Keep the new entry.
   });
   return baseTypeThatConformsToHashable;

--- a/stdlib/public/runtime/AutoDiffSupport.cpp
+++ b/stdlib/public/runtime/AutoDiffSupport.cpp
@@ -14,6 +14,8 @@
 #include "swift/ABI/Metadata.h"
 #include "swift/Runtime/HeapObject.h"
 
+#include <new>
+
 using namespace swift;
 using namespace llvm;
 
@@ -59,7 +61,7 @@ AutoDiffLinearMapContext *swift::swift_autoDiffCreateLinearMapContext(
       sizeof(AutoDiffLinearMapContext), alignof(AutoDiffLinearMapContext))
       + topLevelLinearMapStructSize;
   auto *buffer = (AutoDiffLinearMapContext *)malloc(allocationSize);
-  return new (buffer) AutoDiffLinearMapContext;
+  return ::new (buffer) AutoDiffLinearMapContext;
 }
 
 void *swift::swift_autoDiffProjectTopLevelSubcontext(

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -31,6 +31,7 @@
 #include <cstring>
 #include <cstdio>
 #include <cstdlib>
+#include <new>
 #include <thread>
 #include "../SwiftShims/GlobalObjects.h"
 #include "../SwiftShims/RuntimeShims.h"
@@ -124,7 +125,7 @@ static HeapObject *_swift_allocObject_(HeapMetadata const *metadata,
   // NOTE: this relies on the C++17 guaranteed semantics of no null-pointer
   // check on the placement new allocator which we have observed on Windows,
   // Linux, and macOS.
-  new (object) HeapObject(metadata);
+  ::new (object) HeapObject(metadata);
 
   // If leak tracking is enabled, start tracking this object.
   SWIFT_LEAKS_START_TRACKING_OBJECT(object);

--- a/stdlib/public/runtime/KeyPaths.cpp
+++ b/stdlib/public/runtime/KeyPaths.cpp
@@ -14,6 +14,7 @@
 #include "swift/Runtime/Metadata.h"
 #include <cstdint>
 #include <cstring>
+#include <new>
 
 using namespace swift;
 
@@ -98,7 +99,7 @@ namespace {
     static OpaqueValue *allocateIn(const Metadata *type,
                                    YieldOnceBuffer *buffer) {
       auto *temp =
-        new (reinterpret_cast<void*>(buffer)) YieldOnceTemporary(type);
+        ::new (reinterpret_cast<void*>(buffer)) YieldOnceTemporary(type);
       return type->allocateBufferIn(&temp->Buffer);
     }
 

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2385,7 +2385,7 @@ static ValueWitnessTable *getMutableVWTableForInit(StructMetadata *self,
   // Otherwise, allocate permanent memory for it and copy the existing table.
   void *memory = allocateMetadata(sizeof(ValueWitnessTable),
                                   alignof(ValueWitnessTable));
-  auto newTable = new (memory) ValueWitnessTable(*oldTable);
+  auto newTable = ::new (memory) ValueWitnessTable(*oldTable);
 
   // If we ever need to check layout-completeness asynchronously from
   // initialization, we'll need this to be a store-release (and rely on
@@ -4650,7 +4650,7 @@ static const WitnessTable *_getForeignWitnessTable(
   ForeignWitnessTables.getOrInsert(
       key, [&](ForeignWitnessTableCacheEntry *entryPtr, bool created) {
         if (created)
-          new (entryPtr)
+          ::new (entryPtr)
               ForeignWitnessTableCacheEntry(key, witnessTableCandidate);
         result = entryPtr->data;
         return true;

--- a/stdlib/public/runtime/MetadataImpl.h
+++ b/stdlib/public/runtime/MetadataImpl.h
@@ -100,11 +100,11 @@ struct NativeBox {
   }
   
   static T *initializeWithCopy(T *dest, T *src) {
-    return new (dest) T(*src);
+    return ::new (dest) T(*src);
   }
 
   static T *initializeWithTake(T *dest, T *src) {
-    T *result = new (dest) T(std::move(*src));
+    T *result = ::new (dest) T(std::move(*src));
     src->T::~T();
     return result;
   }

--- a/stdlib/public/runtime/MetadataImpl.h
+++ b/stdlib/public/runtime/MetadataImpl.h
@@ -51,6 +51,7 @@
 #include "EnumImpl.h"
 
 #include <cstring>
+#include <new>
 #include <type_traits>
 
 namespace swift {

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -38,6 +38,7 @@
 #include <functional>
 #include <vector>
 #include <list>
+#include <new>
 
 using namespace swift;
 using namespace Demangle;
@@ -774,7 +775,7 @@ _findContextDescriptor(Demangle::NodePointer node,
                                                     *entry,
                                                 bool created) {
       if (created)
-        new (entry) NominalTypeDescriptorCacheEntry{mangledName, foundContext};
+        ::new (entry) NominalTypeDescriptorCacheEntry{mangledName, foundContext};
       return true;
     });
 
@@ -931,7 +932,7 @@ _findProtocolDescriptor(NodePointer node,
                                                      *entry,
                                                  bool created) {
       if (created)
-        new (entry) ProtocolDescriptorCacheEntry{mangledName, foundProtocol};
+        ::new (entry) ProtocolDescriptorCacheEntry{mangledName, foundProtocol};
       return true;
     });
   }

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -31,6 +31,7 @@
 #include "ImageInspection.h"
 #include "Private.h"
 
+#include <new>
 #include <vector>
 
 #if __has_include(<mach-o/dyld_priv.h>)
@@ -510,7 +511,7 @@ struct ConformanceState {
                             SectionsToScan.snapshot().count() != sectionsCount)
                           return false; // abandon the new entry
 
-                        new (entry) ConformanceCacheEntry(
+                        ::new (entry) ConformanceCacheEntry(
                             ConformanceCacheKey(type, proto), witness);
                         return true; // keep the new entry
                       });

--- a/stdlib/public/runtime/StackAllocator.h
+++ b/stdlib/public/runtime/StackAllocator.h
@@ -25,6 +25,7 @@
 #include "swift/Runtime/Debug.h"
 #include "llvm/Support/Alignment.h"
 #include <cstddef>
+#include <new>
 
 // Notes: swift::fatalError is not shared between libswiftCore and libswift_Concurrency
 // and libswift_Concurrency uses swift_Concurrency_fatalError instead.
@@ -170,7 +171,7 @@ private:
       assert(llvm::isAligned(llvm::Align(alignment), alignedSize));
       assert(canAllocate(alignedSize));
       void *buffer = getAddr(currentOffset);
-      auto *allocation = new (buffer) Allocation(lastAllocation, this);
+      auto *allocation = ::new (buffer) Allocation(lastAllocation, this);
       currentOffset += Allocation::includingHeader(alignedSize);
       if (guardAllocations) {
         uintptr_t *endOfCurrentAllocation = (uintptr_t *)getAddr(currentOffset);
@@ -251,7 +252,7 @@ private:
     size_t capacity = std::max(SlabCapacity,
                                Allocation::includingHeader(size));
     void *slabBuffer = malloc(Slab::includingHeader(capacity));
-    Slab *newSlab = new (slabBuffer) Slab(capacity);
+    Slab *newSlab = ::new (slabBuffer) Slab(capacity);
     if (slab)
       slab->next = newSlab;
     else
@@ -292,7 +293,7 @@ public:
     char *end = (char *)firstSlabBuffer + bufferCapacity;
     assert(start + Slab::headerSize() <= end &&
            "buffer for first slab too small");
-    firstSlab = new (start) Slab(end - start - Slab::headerSize());
+    firstSlab = ::new (start) Slab(end - start - Slab::headerSize());
     firstSlabIsPreallocated = true;
     numAllocatedSlabs = 0;
   }

--- a/stdlib/public/runtime/SwiftRT-COFF.cpp
+++ b/stdlib/public/runtime/SwiftRT-COFF.cpp
@@ -65,7 +65,7 @@ static void swift_image_constructor() {
   { reinterpret_cast<uintptr_t>(&__start_##name) + sizeof(__start_##name),     \
     reinterpret_cast<uintptr_t>(&__stop_##name) - reinterpret_cast<uintptr_t>(&__start_##name) - sizeof(__start_##name) }
 
-  new (&sections) swift::MetadataSections {
+  ::new (&sections) swift::MetadataSections {
       swift::CurrentSectionMetadataVersion,
       { __ImageBase },
 

--- a/stdlib/public/runtime/SwiftRT-ELF.cpp
+++ b/stdlib/public/runtime/SwiftRT-ELF.cpp
@@ -56,7 +56,7 @@ static void swift_image_constructor() {
   { reinterpret_cast<uintptr_t>(&__start_##name),                              \
     static_cast<uintptr_t>(&__stop_##name - &__start_##name) }
 
-  new (&sections) swift::MetadataSections {
+  ::new (&sections) swift::MetadataSections {
       swift::CurrentSectionMetadataVersion,
       { __dso_handle },
 

--- a/stdlib/public/runtime/SwiftValue.mm
+++ b/stdlib/public/runtime/SwiftValue.mm
@@ -34,6 +34,8 @@
 #include <objc/runtime.h>
 #include <Foundation/Foundation.h>
 
+#include <new>
+
 using namespace swift;
 using namespace swift::hashable_support;
 
@@ -196,7 +198,7 @@ __SwiftValue *swift::bridgeAnythingToSwiftValueObject(OpaqueValue *src,
    */
 
   auto header = getSwiftValueHeader(instance);
-  new (header) SwiftValueHeader();
+  ::new (header) SwiftValueHeader();
   header->type = srcType;
 
   auto payload = getSwiftValuePayload(instance, alignMask);


### PR DESCRIPTION
This pulls in the remainder of the alignment related changes from main to 5.7.

The changes here are syntactic for the most part.  The single change that is more than syntax only is the change to add in the new internal wrapper for the placement allocator.  This ensures that we always use the proper allocator for Swift and will not be intercepted by the user.

The changes for the alignment should be low risk on all platforms and this has been in main for a week.

Discussed with @mikeash separately and he agrees that this change should be low risk and good to have.

CC: @grynspan @mikeash @airspeedswift 