### PR TITLE
Change the signature of `_swift_withWin32DbgHelpLibrary()` to not use `std::function` (which is not ABI-safe in C functions.)

### DIFF
--- a/stdlib/public/runtime/ImageInspectionCOFF.cpp
+++ b/stdlib/public/runtime/ImageInspectionCOFF.cpp
@@ -77,13 +77,13 @@ static StaticMutex mutex;
 static bool isDbgHelpInitialized = false;
 
 void swift::_swift_withWin32DbgHelpLibrary(
-  const std::function<void(bool /* isInitialized */)>& body) {
-  mutex.withLock([&body] () {
+  void (* body)(bool isInitialized, void *context), void *context) {
+  mutex.withLock([=] () {
     if (!isDbgHelpInitialized) {
       SymSetOptions(SYMOPT_UNDNAME | SYMOPT_DEFERRED_LOADS);
       isDbgHelpInitialized = SymInitialize(GetCurrentProcess(), nullptr, true);
     }
-    body(isDbgHelpInitialized);
+    body(isDbgHelpInitialized, context);
   });
 }
 #endif


### PR DESCRIPTION
Change the signature of `_swift_withWin32DbgHelpLibrary()` to not use `std::function` (which is not ABI-safe in C functions.) **This change only affects Windows.**

Nothing outside the Swift repo is using this function, so it should not present an ABI-breaking change. The existing signature is still usable by way of a `static inline` function, so no call sites in the repo need changes.
