### PR TITLE
[cxx-interop] Use typedef's swift_name attr to rename anonymous enums.

### DIFF
--- a/test/Interop/Cxx/enum/Inputs/anonymous-with-swift-name.h
+++ b/test/Interop/Cxx/enum/Inputs/anonymous-with-swift-name.h
@@ -22,6 +22,22 @@ typedef CF_OPTIONS(unsigned, CFColorMask) {
 inline SOColorMask useSOColorMask(SOColorMask mask) { return mask; }
 inline CFColorMask useCFColorMask(CFColorMask mask) { return mask; }
 
+struct ParentStruct { };
+
+typedef __attribute__((availability(swift, unavailable))) __attribute__((swift_name("ParentStruct.NewName"))) unsigned OldName;
+
+enum __attribute__((flag_enum,enum_extensibility(open))) : OldName {
+  kOldNameOne = (1 << 1),
+  kOldNameTwo = (1 << 2)
+};
+
+typedef __attribute__((availability(swift, unavailable))) __attribute__((swift_name("GlobalNewName"))) unsigned GlobalOldName;
+
+enum __attribute__((flag_enum,enum_extensibility(open))) : GlobalOldName {
+  kGlobalOldNameOne = (1 << 1),
+  kGlobalOldNameTwo = (1 << 2)
+};
+
 #if __OBJC__
 @interface ColorMaker
 - (void)makeColorWithOptions:(SOColorMask)opts;

--- a/test/Interop/Cxx/enum/anonymous-with-swift-name-module-interface.swift
+++ b/test/Interop/Cxx/enum/anonymous-with-swift-name-module-interface.swift
@@ -56,3 +56,50 @@
 
 // CHECK: func useSOColorMask(_ mask: SOColorMask) -> SOColorMask
 // CHECK: func useCFColorMask(_ mask: CFColorMask) -> CFColorMask
+
+// Test rename with "swift_name" attr:
+// CHECK: struct ParentStruct
+
+// CHECK: @available(swift, obsoleted: 3, renamed: "ParentStruct.NewName")
+// CHECK: @available(*, unavailable, message: "Not available in Swift")
+// CHECK: typealias OldName = ParentStruct.NewName
+// CHECK: extension ParentStruct {
+// CHECK:     @available(*, unavailable, message: "Not available in Swift")
+// CHECK:     typealias NewName = UInt32
+// CHECK:     struct NewName : OptionSet, @unchecked Sendable {
+// CHECK:         init(rawValue: UInt32)
+// CHECK:         let rawValue: UInt32
+// CHECK:         typealias RawValue = UInt32
+// CHECK:         typealias Element = ParentStruct.NewName
+// CHECK:         typealias ArrayLiteralElement = ParentStruct.NewName
+// CHECK:         static var one: ParentStruct.NewName { get }
+// CHECK:         @available(swift, obsoleted: 3, renamed: "one")
+// CHECK:         static var One: ParentStruct.NewName { get }
+// CHECK:         static var two: ParentStruct.NewName { get }
+// CHECK:         @available(swift, obsoleted: 3, renamed: "two")
+// CHECK:         static var Two: ParentStruct.NewName { get }
+// CHECK:     }
+// CHECK: }
+
+// CHECK: @available(swift, obsoleted: 3, renamed: "ParentStruct.NewName")
+// CHECK: typealias OldName = ParentStruct.NewName
+// CHECK: @available(*, unavailable, message: "Not available in Swift")
+// CHECK: typealias GlobalNewName = UInt32
+// CHECK: @available(swift, obsoleted: 3, renamed: "GlobalNewName")
+// CHECK: @available(*, unavailable, message: "Not available in Swift")
+// CHECK: typealias GlobalOldName = GlobalNewName
+// CHECK: struct GlobalNewName : OptionSet, @unchecked Sendable {
+// CHECK:     init(rawValue: UInt32)
+// CHECK:     let rawValue: UInt32
+// CHECK:     typealias RawValue = UInt32
+// CHECK:     typealias Element = GlobalNewName
+// CHECK:     typealias ArrayLiteralElement = GlobalNewName
+// CHECK:     static var one: GlobalNewName { get }
+// CHECK:     @available(swift, obsoleted: 3, renamed: "one")
+// CHECK:     static var One: GlobalNewName { get }
+// CHECK:     static var two: GlobalNewName { get }
+// CHECK:     @available(swift, obsoleted: 3, renamed: "two")
+// CHECK:     static var Two: GlobalNewName { get }
+// CHECK: }
+// CHECK: @available(swift, obsoleted: 3, renamed: "GlobalNewName")
+// CHECK: typealias GlobalOldName = GlobalNewName


### PR DESCRIPTION
Thanks Puyan for helping find the cause of this issue. 