### PR TITLE
[Concurrency] Minor tweaks to continuation, task, and job tracing.

### DIFF
--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -836,7 +836,11 @@ static AsyncTaskAndContext swift_task_create_commonImpl(
   // be is the final hop.  Store a signed null instead.
   initialContext->Parent = nullptr;
 
-  concurrency::trace::task_create(task, parent, group, asyncLet);
+  concurrency::trace::task_create(
+      task, parent, group, asyncLet,
+      static_cast<uint8_t>(task->Flags.getPriority()),
+      task->Flags.task_isChildTask(), task->Flags.task_isFuture(),
+      task->Flags.task_isGroupChildTask(), task->Flags.task_isAsyncLetTask());
 
   // Attach to the group, if needed.
   if (group) {

--- a/stdlib/public/Concurrency/Tracing.h
+++ b/stdlib/public/Concurrency/Tracing.h
@@ -58,7 +58,8 @@ void actor_note_job_queue(HeapObject *actor, Job *first,
 // Task trace calls.
 
 void task_create(AsyncTask *task, AsyncTask *parent, TaskGroup *group,
-                 AsyncLet *asyncLet);
+                 AsyncLet *asyncLet, uint8_t jobPriority, bool isChildTask,
+                 bool isFuture, bool isGroupChildTask, bool isAsyncLetTask);
 
 void task_destroy(AsyncTask *task);
 
@@ -103,9 +104,9 @@ struct job_run_info {
 // call to task_run_end.  Any information we want to log must be
 // extracted from the job when we start to run it because execution
 // will invalidate the job.
-job_run_info job_run_begin(Job *job, ExecutorRef *executor);
+job_run_info job_run_begin(Job *job);
 
-void job_run_end(ExecutorRef *executor, job_run_info info);
+void job_run_end(job_run_info info);
 
 } // namespace trace
 } // namespace concurrency

--- a/stdlib/public/Concurrency/TracingStubs.h
+++ b/stdlib/public/Concurrency/TracingStubs.h
@@ -43,7 +43,9 @@ inline void actor_note_job_queue(HeapObject *actor, Job *first,
                                  Job *(*getNext)(Job *)) {}
 
 inline void task_create(AsyncTask *task, AsyncTask *parent, TaskGroup *group,
-                        AsyncLet *asyncLet) {}
+                        AsyncLet *asyncLet, uint8_t jobPriority,
+                        bool isChildTask, bool isFuture, bool isGroupChildTask,
+                        bool isAsyncLetTask) {}
 
 inline void task_destroy(AsyncTask *task) {}
 
@@ -74,10 +76,9 @@ inline void job_enqueue_global_with_delay(unsigned long long delay, Job *job) {}
 
 inline void job_enqueue_main_executor(Job *job) {}
 
-inline job_run_info job_run_begin(Job *job, ExecutorRef *executor) { return {}; }
+inline job_run_info job_run_begin(Job *job) { return {}; }
 
-inline void job_run_end(ExecutorRef *executor, job_run_info info) {
-}
+inline void job_run_end(job_run_info info) {}
 
 } // namespace trace
 } // namespace concurrency


### PR DESCRIPTION
Change continuation signposts to emit an interval for init/resume.

Fix task_create to take the decoded flags as separate parameters, matching other calls.

Move job_run trace calls into runJobInEstablishedExecutorContext. swift_job_runImpl didn't catch everything.

rdar://92149411