### PR TITLE
[SIL] Initial work on PartialApplySimplification pass

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -84,6 +84,7 @@ TYPE_ATTR(pseudogeneric)
 TYPE_ATTR(yields)
 TYPE_ATTR(yield_once)
 TYPE_ATTR(yield_many)
+TYPE_ATTR(captures_generics)
 
 // SIL metatype attributes.
 TYPE_ATTR(thin)

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -420,14 +420,15 @@ public:
 
   AllocBoxInst *createAllocBox(SILLocation Loc, CanSILBoxType BoxType,
                                Optional<SILDebugVariable> Var = None,
-                               bool hasDynamicLifetime = false) {
+                               bool hasDynamicLifetime = false,
+                               bool reflection = false) {
     llvm::SmallString<4> Name;
     Loc.markAsPrologue();
     assert((!dyn_cast_or_null<VarDecl>(Loc.getAsASTNode<Decl>()) || Var) &&
            "location is a VarDecl, but SILDebugVariable is empty");
     return insert(AllocBoxInst::create(getSILDebugLocation(Loc), BoxType, *F,
                                        substituteAnonymousArgs(Name, Var, Loc),
-                                       hasDynamicLifetime));
+                                       hasDynamicLifetime, reflection));
   }
 
   AllocExistentialBoxInst *

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -461,11 +461,11 @@ public:
     locationStorage = loc.storage;
   }
 
-  /// Return the next instruction or nullptr if this is the last instruction in
-  /// its block.
+  /// Return the previous instruction, or nullptr if this is the first
+  /// instruction in its block.
   SILInstruction *getPreviousInstruction();
 
-  /// Return the previous instruction or nullptr if this is the first
+  /// Return the next instruction, or nullptr if this is the final
   /// instruction in its block.
   SILInstruction *getNextInstruction();
 

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -2289,30 +2289,38 @@ public:
 class AllocBoxInst final
     : public InstructionBaseWithTrailingOperands<
                                            SILInstructionKind::AllocBoxInst,
-                                           AllocBoxInst, AllocationInst, char> {
+                                           AllocBoxInst, AllocationInst, char>
+{
   friend SILBuilder;
 
   TailAllocatedDebugVariable VarInfo;
 
-  bool dynamicLifetime = false;
+  unsigned HasDynamicLifetime : 1;
+  unsigned Reflection : 1;
 
   AllocBoxInst(SILDebugLocation DebugLoc, CanSILBoxType BoxType,
                ArrayRef<SILValue> TypeDependentOperands, SILFunction &F,
-               Optional<SILDebugVariable> Var, bool hasDynamicLifetime);
+               Optional<SILDebugVariable> Var, bool hasDynamicLifetime,
+               bool reflection = false);
 
   static AllocBoxInst *create(SILDebugLocation Loc, CanSILBoxType boxType,
                               SILFunction &F,
                               Optional<SILDebugVariable> Var,
-                              bool hasDynamicLifetime);
+                              bool hasDynamicLifetime,
+                              bool reflection = false);
 
 public:
   CanSILBoxType getBoxType() const {
     return getType().castTo<SILBoxType>();
   }
 
-  void setDynamicLifetime() { dynamicLifetime = true; }
-  bool hasDynamicLifetime() const { return dynamicLifetime; }
+  void setDynamicLifetime() { HasDynamicLifetime = true; }
+  bool hasDynamicLifetime() const { return HasDynamicLifetime; }
 
+  /// True if the box should be emitted with reflection metadata for its
+  /// contents.
+  bool emitReflectionMetadata() const { return Reflection; }
+  
   // Return the type of the memory stored in the alloc_box.
   SILType getAddressType() const;
 

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -427,7 +427,8 @@ public:
 
   /// True if the given type has at least the size and alignment of a native
   /// pointer.
-  bool isPointerSizeAndAligned();
+  bool isPointerSizeAndAligned(SILModule &M,
+                               ResilienceExpansion expansion) const;
 
   /// True if `operTy` can be cast by single-reference value into `resultTy`.
   static bool canRefCast(SILType operTy, SILType resultTy, SILModule &M);
@@ -613,6 +614,12 @@ public:
   llvm::hash_code getHashCode() const {
     return llvm::hash_combine(*this);
   }
+  
+  /// If a type is visibly a singleton aggregate (a tuple with one element, a
+  /// struct with one field, or an enum with a single payload case), return the
+  /// type of its field, which it is guaranteed to have identical layout to.
+  SILType getSingletonAggregateFieldType(SILModule &M,
+                                         ResilienceExpansion expansion) const;
 
   //
   // Accessors for types used in SIL instructions:

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -430,6 +430,11 @@ public:
   bool isPointerSizeAndAligned(SILModule &M,
                                ResilienceExpansion expansion) const;
 
+  /// True if the layout of the given type consists of a single native Swift-
+  /// refcounted object reference, possibly nullable.
+  bool isSingleSwiftRefcounted(SILModule &M,
+                               ResilienceExpansion expansion) const;
+
   /// True if `operTy` can be cast by single-reference value into `resultTy`.
   static bool canRefCast(SILType operTy, SILType resultTy, SILModule &M);
 

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -446,6 +446,8 @@ PASS(MoveFunctionCanonicalization, "sil-move-function-canon",
      "function checking.")
 PASS(DebugInfoCanonicalizer, "sil-onone-debuginfo-canonicalizer",
      "Canonicalize debug info at -Onone by propagating debug info into coroutine funclets")
+PASS(PartialApplySimplification, "partial-apply-simplification",
+     "Transform partial_apply instructions into explicit closure box constructions")
 PASS(PruneVTables, "prune-vtables",
      "Mark class methods that do not require vtable dispatch")
 PASS_RANGE(AllPasses, AADumper, PruneVTables)

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -706,7 +706,8 @@ Type ASTBuilder::createSILBoxTypeWithLayout(
     silFields.emplace_back(field.getPointer()->getCanonicalType(),
                            field.getInt());
   SILLayout *layout =
-      SILLayout::get(Ctx, signature.getCanonicalSignature(), silFields);
+      SILLayout::get(Ctx, signature.getCanonicalSignature(), silFields,
+                     /*captures generics*/ false);
 
   SubstitutionMap substs;
   if (signature)

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -6085,6 +6085,11 @@ public:
   }
 
   void visitSILBoxType(SILBoxType *T) {
+    // Print attributes.
+    if (T->getLayout()->capturesGenericEnvironment()) {
+      Printer << "@captures_generics ";
+    }
+    
     {
       // A box layout has its own independent generic environment. Don't try
       // to print it with the environment's generic params.

--- a/lib/AST/SILLayout.cpp
+++ b/lib/AST/SILLayout.cpp
@@ -72,8 +72,10 @@ static void verifyFields(CanGenericSignature Sig, ArrayRef<SILField> Fields) {
 #endif
 
 SILLayout::SILLayout(CanGenericSignature Sig,
-                     ArrayRef<SILField> Fields)
-  : GenericSigAndFlags(Sig, getFlagsValue(anyMutable(Fields))),
+                     ArrayRef<SILField> Fields,
+                     bool CapturesGenericEnvironment)
+  : GenericSigAndFlags(Sig,
+                 getFlagsValue(anyMutable(Fields), CapturesGenericEnvironment)),
     NumFields(Fields.size())
 {
 #ifndef NDEBUG
@@ -87,8 +89,10 @@ SILLayout::SILLayout(CanGenericSignature Sig,
 
 void SILLayout::Profile(llvm::FoldingSetNodeID &id,
                         CanGenericSignature Generics,
-                        ArrayRef<SILField> Fields) {
+                        ArrayRef<SILField> Fields,
+                        bool CapturesGenericEnvironment) {
   id.AddPointer(Generics.getPointer());
+  id.AddBoolean(CapturesGenericEnvironment);
   for (auto &field : Fields) {
     id.AddPointer(field.getLoweredType().getPointer());
     id.AddBoolean(field.isMutable());

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -5104,7 +5104,9 @@ case TypeKind::Id:
       return *this;
     boxTy = SILBoxType::get(Ptr->getASTContext(),
                             SILLayout::get(Ptr->getASTContext(),
-                                           l->getGenericSignature(), newFields),
+                                           l->getGenericSignature(),
+                                           newFields,
+                                           l->capturesGenericEnvironment()),
                             boxTy->getSubstitutions());
     return boxTy;
   }

--- a/lib/IRGen/GenType.h
+++ b/lib/IRGen/GenType.h
@@ -305,6 +305,10 @@ public:
 /// If a type is visibly a singleton aggregate (a tuple with one element, a
 /// struct with one field, or an enum with a single payload case), return the
 /// type of its field, which it is guaranteed to have identical layout to.
+///
+/// This can use more concrete type layout information than
+/// SILType::getSingletonAggregateFieldType, because we have full access to the
+/// LLVM-level layout of types in IRGen.
 SILType getSingletonAggregateFieldType(IRGenModule &IGM,
                                        SILType t,
                                        ResilienceExpansion expansion);

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -323,24 +323,27 @@ bool AllocRefDynamicInst::isDynamicTypeDeinitAndSizeKnownEquivalentToBaseType() 
 AllocBoxInst::AllocBoxInst(SILDebugLocation Loc, CanSILBoxType BoxType,
                            ArrayRef<SILValue> TypeDependentOperands,
                            SILFunction &F, Optional<SILDebugVariable> Var,
-                           bool hasDynamicLifetime)
+                           bool hasDynamicLifetime,
+                           bool reflection)
     : InstructionBaseWithTrailingOperands(
           TypeDependentOperands, Loc, SILType::getPrimitiveObjectType(BoxType)),
       VarInfo(Var, getTrailingObjects<char>()),
-      dynamicLifetime(hasDynamicLifetime) {}
+      HasDynamicLifetime(hasDynamicLifetime),
+      Reflection(reflection) {}
 
 AllocBoxInst *AllocBoxInst::create(SILDebugLocation Loc,
                                    CanSILBoxType BoxType,
                                    SILFunction &F,
                                    Optional<SILDebugVariable> Var,
-                                   bool hasDynamicLifetime) {
+                                   bool hasDynamicLifetime,
+                                   bool reflection) {
   SmallVector<SILValue, 8> TypeDependentOperands;
   collectTypeDependentOperands(TypeDependentOperands, F, BoxType);
   auto Sz = totalSizeToAlloc<swift::Operand, char>(TypeDependentOperands.size(),
                                                    Var ? Var->Name.size() : 0);
   auto Buf = F.getModule().allocateInst(Sz, alignof(AllocBoxInst));
   return ::new (Buf) AllocBoxInst(Loc, BoxType, TypeDependentOperands, F, Var,
-                                  hasDynamicLifetime);
+                                  hasDynamicLifetime, reflection);
 }
 
 SILType AllocBoxInst::getAddressType() const {

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1355,6 +1355,10 @@ public:
   void visitAllocBoxInst(AllocBoxInst *ABI) {
     if (ABI->hasDynamicLifetime())
       *this << "[dynamic_lifetime] ";
+    
+    if (ABI->emitReflectionMetadata()) {
+      *this << "[reflection] ";
+    }
     *this << ABI->getType();
     printDebugVar(ABI->getVarInfo(),
                   &ABI->getModule().getASTContext().SourceMgr);

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -3516,7 +3516,8 @@ TypeConverter::getInterfaceBoxTypeForCapture(ValueDecl *captured,
   // We don't need to capture the generic environment.
   if (!loweredInterfaceType->hasTypeParameter()) {
     auto layout = SILLayout::get(C, nullptr,
-                                 SILField(loweredInterfaceType, isMutable));
+                                 SILField(loweredInterfaceType, isMutable),
+                                 /*captures generics*/ false);
     return SILBoxType::get(C, layout, {});
   }
   
@@ -3526,7 +3527,8 @@ TypeConverter::getInterfaceBoxTypeForCapture(ValueDecl *captured,
   // only the parts used by the captured variable.
   
   auto layout = SILLayout::get(C, signature,
-                               SILField(loweredInterfaceType, isMutable));
+                               SILField(loweredInterfaceType, isMutable),
+                               /*captures generics*/ false);
   
   // Instantiate the layout with identity substitutions.
   auto subMap = SubstitutionMap::get(
@@ -3597,7 +3599,8 @@ CanSILBoxType TypeConverter::getBoxTypeForEnumElement(
   if (boxSignature == CanGenericSignature()) {
     auto eltIntfTy = elt->getArgumentInterfaceType();
     auto boxVarTy = getLoweredRValueType(context, eltIntfTy);
-    auto layout = SILLayout::get(C, nullptr, SILField(boxVarTy, true));
+    auto layout = SILLayout::get(C, nullptr, SILField(boxVarTy, true),
+                                 /*captures generics*/ false);
     return SILBoxType::get(C, layout, {});
   }
 
@@ -3609,7 +3612,8 @@ CanSILBoxType TypeConverter::getBoxTypeForEnumElement(
 
   auto boxVarTy = getLoweredRValueType(context,
                                        getAbstractionPattern(elt), eltIntfTy);
-  auto layout = SILLayout::get(C, boxSignature, SILField(boxVarTy, true));
+  auto layout = SILLayout::get(C, boxSignature, SILField(boxVarTy, true),
+                               /*captures generics*/ false);
 
   // Instantiate the layout with enum's substitution list.
   auto subMap = boundEnum->getContextSubstitutionMap(

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -2773,10 +2773,18 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
   case SILInstructionKind::AllocBoxInst: {
     bool hasDynamicLifetime = false;
     bool hasReflection = false;
-    if (parseSILOptional(hasDynamicLifetime, *this, "dynamic_lifetime"))
-      return true;
-    if (parseSILOptional(hasReflection, *this, "reflection"))
-      return true;
+    StringRef attrName;
+    SourceLoc attrLoc;
+    while (parseSILOptional(attrName, attrLoc, *this)) {
+      if (attrName.equals("dynamic_lifetime")) {
+        hasDynamicLifetime = true;
+      } else if (attrName.equals("reflection")) {
+        hasReflection = true;
+      } else {
+        P.diagnose(attrLoc, diag::sil_invalid_attribute_for_expected, attrName,
+                   "dynamic_lifetime or reflection");
+      }
+    }
 
     SILType Ty;
     if (parseSILType(Ty))

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -2772,7 +2772,10 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
   switch (Opcode) {
   case SILInstructionKind::AllocBoxInst: {
     bool hasDynamicLifetime = false;
+    bool hasReflection = false;
     if (parseSILOptional(hasDynamicLifetime, *this, "dynamic_lifetime"))
+      return true;
+    if (parseSILOptional(hasReflection, *this, "reflection"))
       return true;
 
     SILType Ty;

--- a/lib/SILGen/ResultPlan.cpp
+++ b/lib/SILGen/ResultPlan.cpp
@@ -179,7 +179,8 @@ public:
         layoutSubs.getGenericSignature().getCanonicalSignature();
     auto boxLayout =
         SILLayout::get(SGF.getASTContext(), layoutSig,
-                       SILField(layoutTy->getCanonicalType(layoutSig), true));
+                       SILField(layoutTy->getCanonicalType(layoutSig), true),
+                       /*captures generics*/ false);
 
     resultBox = SGF.B.createAllocBox(loc,
       SILBoxType::get(SGF.getASTContext(),

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -825,9 +825,16 @@ SILPassPipelinePlan::getIRGenPreparePassPipeline(const SILOptions &Options) {
   SILPassPipelinePlan P(Options);
   P.startPipeline("IRGen Preparation");
   // Insert SIL passes to run during IRGen.
+  /*
+  // Simplify partial_apply instructions by expanding box construction into
+  // component operations.
+  P.addPartialApplySimplification();
+   */
   // Hoist generic alloc_stack instructions to the entry block to enable better
   // llvm-ir generation for dynamic alloca instructions.
   P.addAllocStackHoisting();
+  // Change large loadable types to be passed indirectly across function
+  // boundaries as required by the ABI.
   P.addLoadableByAddress();
 
   return P;

--- a/lib/SILOptimizer/Transforms/CMakeLists.txt
+++ b/lib/SILOptimizer/Transforms/CMakeLists.txt
@@ -25,6 +25,7 @@ target_sources(swiftSILOptimizer PRIVATE
   Outliner.cpp
   ObjectOutliner.cpp
   AssemblyVisionRemarkGenerator.cpp
+  PartialApplySimplification.cpp
   PerformanceInliner.cpp
   PhiArgumentOptimizations.cpp
   PruneVTables.cpp

--- a/lib/SILOptimizer/Transforms/PartialApplySimplification.cpp
+++ b/lib/SILOptimizer/Transforms/PartialApplySimplification.cpp
@@ -488,7 +488,10 @@ void PartialApplySimplificationPass::processKnownCallee(SILFunction *callee,
       
       auto newFunctionRef = B.createFunctionRef(loc, callee);
       auto boxTy = SILBoxType::get(C, newBoxLayout, pa->getSubstitutionMap());
-      auto newBox = B.createAllocBox(loc, boxTy);
+      auto newBox = B.createAllocBox(loc, boxTy,
+                                     /*debug variable*/ None,
+                                     /*dynamic lifetime*/ false,
+                                     /*reflection*/ true);
       
       // Transfer the formerly partially-applied arguments into the box.
       auto appliedArgs = pa->getArguments();

--- a/lib/SILOptimizer/Transforms/PartialApplySimplification.cpp
+++ b/lib/SILOptimizer/Transforms/PartialApplySimplification.cpp
@@ -1,0 +1,567 @@
+//===--- PartialApplySimplification.cpp - Lower partial applications ------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+///
+/// Reduces all partial application functions into explicit closure
+/// constructions.
+///
+/// \c partial_apply is a useful high-level representation for optimization
+/// passes like inlining, but it abstracts over many details of how closures
+/// are constructed. In order to make IRGen lowering simpler, and provide some
+/// opportunity for other passes to optimize closure construction.
+///
+/// When a closure implementation function is private, and is only referenced by
+/// partial applications all of the same shape, then we can replace the function
+/// with one that takes a closure box instead of the partially applied
+/// arguments. Otherwise, a partial application forwarder function is generated
+/// as a shim between the closure entry point, which takes the box, and the
+/// original function, which takes the loaded arguments.
+///
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "sil-partial-apply-simplification"
+
+#include "llvm/Support/Debug.h"
+#include "llvm/ADT/Statistic.h"
+#include "swift/SIL/SILCloner.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/TypeSubstCloner.h"
+#include "swift/SILOptimizer/PassManager/Passes.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/SILOptFunctionBuilder.h"
+#include "swift/SILOptimizer/Utils/SpecializationMangler.h"
+
+STATISTIC(NumInvocationFunctionsChanged,
+          "Number of invocation functions rewritten");
+STATISTIC(NumStaticPartialApplicationForwarders,
+          "Number of static partial application forwarder thunks generated");
+STATISTIC(NumDynamicPartialApplicationForwarders,
+          "Number of dynamic partial application forwarder thunks generated");
+
+using namespace swift;
+
+//===----------------------------------------------------------------------===//
+//                            Top Level Entrypoint
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+struct KnownCallee {
+  /// The set of function_refs to the callee.
+  llvm::SetVector<FunctionRefInst *> FunctionRefs;
+  /// The set of partial application sites.
+  llvm::SetVector<PartialApplyInst *> PartialApplications;
+  /// Whether the callee has non-partial-apply uses.
+  bool HasNonPartialApplyUses = false;
+};
+
+class PartialApplySimplificationPass : public SILModuleTransform {
+  /// The entry point to the transformation.
+  void run() override {
+    // Scan all partial applications in the module so we know what to work with.
+    llvm::DenseMap<SILFunction *, KnownCallee> knownCallees;
+    llvm::SetVector<swift::PartialApplyInst *> dynamicCallees;
+    for (auto &f : *getModule()) {
+      scanFunction(&f, knownCallees, dynamicCallees);
+    }
+
+    for (auto &knownCallee : knownCallees) {
+      processKnownCallee(knownCallee.first, knownCallee.second);
+    }
+    
+    for (auto *dynamicPA : dynamicCallees) {
+      processDynamicCallee(dynamicPA);
+    }
+  }
+
+  void scanFunction(SILFunction *f,
+                    llvm::DenseMap<SILFunction *,
+                                   KnownCallee> &knownCallees,
+                    llvm::SetVector<PartialApplyInst *> &dynamicCallees);
+  
+  void processKnownCallee(SILFunction *callee,
+                          const KnownCallee &pa);
+  
+  void processDynamicCallee(PartialApplyInst *pa);
+};
+
+}
+
+/// True if the partial application is in a form that can be trivially
+/// lowered.
+///
+/// This is true if:
+/// - the callee has convention(method)
+/// - one argument is applied
+/// - the callee is either not generic, or can read its generic environment
+///   out of the single applied argument
+/// - if the partial application is noescape:
+///   - the argument is word-sized or smaller
+///   - the argument is either trivial, or passed with a +0 convention
+///     (guaranteed, unowned, in_guaranteed)
+/// - if the partial application is escapable:
+///   - the argument is either a single Swift-refcounted word, or trivial and
+///     sized strictly less than one word
+///   - the argument ownership convention matches the callee convention of the
+///     resulting function
+static bool isSimplePartialApply(PartialApplyInst *i) {
+  auto calleeTy = i->getCallee()->getType().castTo<SILFunctionType>();
+  if (calleeTy->getRepresentation() != SILFunctionTypeRepresentation::Method) {
+    return false;
+  }
+
+  // TODO: could discount empty captured values here
+  if (i->getNumArguments() != 1) {
+    return false;
+  }
+
+  auto argTy = i->getArguments()[0]->getType();
+
+  if (i->getFunctionType()->isNoEscape()) {
+    // TODO
+    return false;
+  } else {
+    if (!argTy.isObject()) {
+      return false;
+    }
+    
+    // TODO: Handle native-refcounted classes, single-refcounted aggregates,
+    // and bit-packable trivial types using knowledge from IRGen if this becomes
+    // an IRGenPrepare pass
+    if (!argTy.is<SILBoxType>()) {
+      return false;
+    }
+  }
+  
+  return true;
+}
+
+void PartialApplySimplificationPass::scanFunction(SILFunction *f,
+                         llvm::DenseMap<SILFunction *,
+                                        KnownCallee> &knownCallees,
+                         llvm::SetVector<PartialApplyInst *> &dynamicCallees) {
+  // Consider all partial_apply instructions.
+  for (auto &block : *f) {
+    for (auto &inst : block) {
+      // Examine the uses of static function refs.
+      if (auto *fr = dyn_cast<FunctionRefInst>(&inst)) {
+        auto &knownCallee = knownCallees[fr->getReferencedFunction()];
+        knownCallee.FunctionRefs.insert(fr);
+        
+        for (auto *frUse : fr->getUses()) {
+          // Collect partial applications for further transformation.
+          if (auto pa = dyn_cast<PartialApplyInst>(frUse->getUser())) {
+            knownCallee.PartialApplications.insert(pa);
+            continue;
+          }
+          
+          // Record if the function has uses that aren't partial applies.
+          knownCallee.HasNonPartialApplyUses = true;
+        }
+      }
+      
+      if (auto *pa = dyn_cast<PartialApplyInst>(&inst)) {
+        // Static callees get handled when we see the function_ref.
+        if (isa<FunctionRefInst>(pa->getCallee())) {
+          continue;
+        }
+
+        // If the callee isn't static, then we'll need to create a dynamic
+        // forwarder thunk to simplify this partial application.
+        dynamicCallees.insert(pa);
+      }
+    }
+  }
+}
+
+void PartialApplySimplificationPass::processKnownCallee(SILFunction *callee,
+                                                        const KnownCallee &pa) {
+  auto &C = callee->getASTContext();
+  
+  // Skip functions with no partial application uses.
+  if (pa.PartialApplications.empty())
+    return;
+
+  LLVM_DEBUG(llvm::dbgs() << "***** Processing known partial_apply callee "
+                          << callee->getName() << " *****\n");
+  
+  // If the subject of the partial application has other uses that aren't
+  // partial applications, then thunk it.
+  if (pa.HasNonPartialApplyUses) {
+    LLVM_DEBUG(llvm::dbgs() << "Callee has non-partial_apply uses; thunking\n");
+    goto create_forwarding_thunks;
+  }
+
+  // If the subject of the partial application might have external references,
+  // or is itself an external reference, we can't change the existing function
+  // signature. We'll always use forwarding thunks in this case.
+  if (callee->isPossiblyUsedExternally()) {
+    LLVM_DEBUG(llvm::dbgs() << "Callee is possibly used externally; thunking\n");
+    goto create_forwarding_thunks;
+  }
+  if (callee->empty()) {
+    LLVM_DEBUG(llvm::dbgs() << "Callee is a declaration only; thunking\n");
+    goto create_forwarding_thunks;
+  }
+  
+  // Look at the set of all partial applications on this callee to figure
+  // out what to do.
+  // If all of the partial applications are identical (same number of arguments,
+  // same convention, same escapiness, etc.), then we'll alter the invocation
+  // function directly (or leave it alone, if the partial apply is simple
+  // enough already.)
+  
+  // Take an arbitrary partial application as an example to compare the others.
+  {
+    auto examplePA = pa.PartialApplications.front();
+    for (auto i = pa.PartialApplications.begin() + 1,
+              e = pa.PartialApplications.end();
+         i != e;
+         ++i) {
+      auto thisPA = *i;
+      if (examplePA->getType() != thisPA->getType()) {
+        LLVM_DEBUG(llvm::dbgs() << "Mismatched partial application arguments; thunking:\n";
+                   thisPA->print(llvm::dbgs());
+                   examplePA->print(llvm::dbgs()));
+                   
+        goto create_forwarding_thunks;
+      }
+    }
+    
+    // OK, all the partial applications look the same.
+    LLVM_DEBUG(llvm::dbgs() << "All partial applications look like this:\n";
+               examplePA->print(llvm::dbgs()));
+    
+    // If they're simple already, then we don't need to do anything.
+    if (isSimplePartialApply(examplePA)) {
+      LLVM_DEBUG(llvm::dbgs() << "And they're already simple, don't need to do anything!\n");
+      return;
+    }
+    
+    // Rewrite the function type to take the captures in box form.
+    auto origTy = callee->getLoweredFunctionType();
+    auto paResultTy = cast<SILFunctionType>(examplePA->getType().getASTType());
+    // The box captures the generic context and the values of the arguments that
+    // were partially applied. The invocation function is modified to take
+    // a single partially-applied argument for the box, and unload the
+    // elements of the box inside the function.
+    SmallVector<SILField, 4> boxFields;
+    
+    unsigned numUnapplied
+      = origTy->getParameters().size() - examplePA->getArguments().size();
+    auto partiallyAppliedParams = origTy->getParameters().slice(numUnapplied);
+    for (auto param : partiallyAppliedParams) {
+      switch (param.getConvention()) {
+      // Conventions where a copy of the argument is captured.
+      case ParameterConvention::Direct_Guaranteed:
+      case ParameterConvention::Direct_Owned:
+      case ParameterConvention::Direct_Unowned:
+      case ParameterConvention::Indirect_In:
+      case ParameterConvention::Indirect_In_Constant:
+      case ParameterConvention::Indirect_In_Guaranteed:
+        boxFields.push_back(SILField(param.getInterfaceType(), /*mutable*/false));
+        break;
+      
+      // Conventions where an address to the argument is captured.
+      case ParameterConvention::Indirect_Inout:
+      case ParameterConvention::Indirect_InoutAliasable:
+        // Put a RawPointer in the box, which we can turn back into an address
+        // in the function
+        boxFields.push_back(SILField(C.TheRawPointerType, /*mutable*/false));
+        break;
+      }
+    }
+    
+    // The new signature carries over the unapplied arguments.
+    SmallVector<SILParameterInfo, 4> newParams;
+    for (unsigned i = 0; i < numUnapplied; ++i) {
+      newParams.push_back(origTy->getParameters()[i]);
+    }
+    
+    // Instead of the applied arguments, we receive a box containing the
+    // values for those arguments. Work out what that box type is.
+    // TODO: We need a representation of boxes that are nonescaping and/or
+    // capture the generic environment to represent partial applications in
+    // their full generality.
+    if (examplePA->getFunctionType()->isNoEscape()) {
+      LLVM_DEBUG(llvm::dbgs() << "TODO: Nonescaping partial_apply not yet implemented\n");
+      return;
+    }
+    
+    if (origTy->getInvocationGenericSignature()) {
+      LLVM_DEBUG(llvm::dbgs() << "TODO: Generic partial_apply not yet implemented\n");
+      return;
+    }
+    
+    auto newBoxLayout = SILLayout::get(C,
+                                       origTy->getInvocationGenericSignature(),
+                                       boxFields);
+    SubstitutionMap identitySubstitutionMap;
+    if (auto origSig = origTy->getInvocationGenericSignature()) {
+      identitySubstitutionMap = origSig->getIdentitySubstitutionMap();
+    }
+    auto newBoxTy = SILBoxType::get(C, newBoxLayout, identitySubstitutionMap);
+    newParams.push_back(SILParameterInfo(newBoxTy, paResultTy->getCalleeConvention()));
+    
+    auto newExtInfo = origTy->getExtInfo()
+      .withRepresentation(SILFunctionTypeRepresentation::Method);
+    
+    auto newTy = SILFunctionType::get(origTy->getInvocationGenericSignature(),
+                                      newExtInfo, origTy->getCoroutineKind(),
+                                      origTy->getCalleeConvention(),
+                                      newParams,
+                                      origTy->getYields(),
+                                      origTy->getResults(),
+                                      origTy->getOptionalErrorResult(),
+                                      origTy->getPatternSubstitutions(),
+                                      origTy->getInvocationSubstitutions(),
+                                      C);
+    
+    LLVM_DEBUG(llvm::dbgs() << "Changing invocation function signature to\n";
+               newTy->print(llvm::dbgs());
+               llvm::dbgs() << '\n');
+    
+    // Change the invocation function to use the new type, and unbox the
+    // captures in its entry block.
+    callee->rewriteLoweredTypeUnsafe(newTy);
+    
+    // Update the entry block.
+    auto boxConvention = examplePA->getFunctionType()->getCalleeConvention();
+    {
+      SILBuilder B(*callee);
+      auto &entry = *callee->begin();
+      
+      // Insert an argument for the box before the originally applied args.
+      auto boxArgTy = callee->mapTypeIntoContext(
+                                     SILType::getPrimitiveObjectType(newBoxTy));
+      ValueOwnershipKind boxOwnership(*callee, boxArgTy,
+                                      SILArgumentConvention(boxConvention));
+      
+      auto numUnappliedArgs = numUnapplied + origTy->getNumIndirectFormalResults();
+      
+      auto boxArg = entry.insertFunctionArgument(numUnappliedArgs,
+                                                 boxArgTy,
+                                                 boxOwnership);
+      auto appliedBBArgs = entry.getArguments().slice(numUnappliedArgs + 1);
+
+      // Replace the original arguments applied by the partial_apply, by
+      // projections out of the box.
+      SmallVector<AllocStackInst *, 4> AddedStackAllocs;
+      B.setInsertionPoint(&entry, entry.begin());
+      auto loc = examplePA->getLoc();
+      for (unsigned i = 0; i < appliedBBArgs.size(); ++i) {
+        auto appliedArg = appliedBBArgs[i];
+        auto param = partiallyAppliedParams[i];
+        
+        auto proj = B.createProjectBox(loc, boxArg, i);
+        
+        // Load the value out of the box according to the current ownership
+        // mode of the function and the calling convention for the parameter.
+        SILValue projectedArg;
+        if (callee->hasOwnership()) {
+          switch (auto conv = param.getConvention()) {
+          case ParameterConvention::Direct_Unowned:
+            // Load an unowned image of the value from the box.
+            projectedArg = B.createLoadUnowned(loc, proj, IsNotTake);
+            break;
+          case ParameterConvention::Direct_Guaranteed:
+            // Load a borrow of the value from the box.
+            projectedArg = B.createLoadBorrow(loc, proj);
+            break;
+          case ParameterConvention::Direct_Owned:
+            // Load a copy of the value from the box.
+            projectedArg = B.createLoad(loc, proj, LoadOwnershipQualifier::Copy);
+            break;
+          case ParameterConvention::Indirect_In:
+          case ParameterConvention::Indirect_In_Constant: {
+            // Allocate space for a copy of the value that can be consumed by the
+            // function body. We'll need to deallocate the stack slot after the
+            // cloned body.
+            auto copySlot = B.createAllocStack(loc,
+                                              proj->getType().getAddressType());
+            AddedStackAllocs.push_back(copySlot);
+            B.createCopyAddr(loc, proj, copySlot, IsNotTake, IsInitialization);
+            projectedArg = copySlot;
+            break;
+          }
+          case ParameterConvention::Indirect_In_Guaranteed:
+            // We can borrow the value in-place in the box.
+            projectedArg = proj;
+            break;
+          case ParameterConvention::Indirect_Inout:
+          case ParameterConvention::Indirect_InoutAliasable: {
+            // The box capture is a RawPointer with the value of the capture
+            // address.
+            auto ptrVal = B.createLoad(loc, proj, LoadOwnershipQualifier::Trivial);
+            projectedArg = B.createPointerToAddress(loc, ptrVal,
+                        appliedArg->getType(),
+                        /*strict*/ conv == ParameterConvention::Indirect_Inout);
+            break;
+          }
+          }
+        } else {
+          switch (auto conv = param.getConvention()) {
+          case ParameterConvention::Direct_Unowned:
+            // Load an unowned image of the value from the box.
+            projectedArg = B.createLoad(loc, proj, LoadOwnershipQualifier::Unqualified);
+            break;
+          case ParameterConvention::Direct_Guaranteed:
+            // Load a borrow of the value from the box.
+            projectedArg = B.createLoad(loc, proj, LoadOwnershipQualifier::Unqualified);
+            break;
+          case ParameterConvention::Direct_Owned:
+            // Load a copy of the value from the box.
+            projectedArg = B.createLoad(loc, proj, LoadOwnershipQualifier::Unqualified);
+            B.createRetainValue(loc, projectedArg, Atomicity::Atomic);
+            break;
+          case ParameterConvention::Indirect_In:
+          case ParameterConvention::Indirect_In_Constant: {
+            // Allocate space for a copy of the value that can be consumed by the
+            // function body. We'll need to deallocate the stack slot after the
+            // cloned body.
+            auto copySlot = B.createAllocStack(loc,
+                                               proj->getType().getAddressType());
+            AddedStackAllocs.push_back(copySlot);
+            B.createCopyAddr(loc, proj, copySlot, IsNotTake, IsInitialization);
+            projectedArg = copySlot;
+            break;
+          }
+          case ParameterConvention::Indirect_In_Guaranteed:
+            // We can borrow the value in-place in the box.
+            projectedArg = proj;
+            break;
+          case ParameterConvention::Indirect_Inout:
+          case ParameterConvention::Indirect_InoutAliasable: {
+            // The box capture is a RawPointer with the value of the capture
+            // address.
+            auto ptrVal = B.createLoad(loc, proj, LoadOwnershipQualifier::Trivial);
+            projectedArg = B.createPointerToAddress(loc, ptrVal,
+                        appliedArg->getType(),
+                        /*strict*/ conv == ParameterConvention::Indirect_Inout);
+            break;
+          }
+          }
+        }
+        
+        // Replace the original bb arg with the applied arg.
+        appliedArg->replaceAllUsesWith(projectedArg);
+      }
+      
+      // If the box is callee-consumed, we can release it now.
+      if (boxConvention == ParameterConvention::Direct_Owned) {
+        if (callee->hasOwnership()) {
+          B.createDestroyValue(loc, boxArg);
+        } else {
+          B.createStrongRelease(loc, boxArg, Atomicity::Atomic);
+        }
+      }
+      
+      // Erase the original applied arguments.
+      for (unsigned i = 0; i < appliedBBArgs.size(); ++i) {
+        entry.eraseArgument(numUnappliedArgs + 1);
+      }
+      
+      // If we needed to introduce any stack slots to consume copies of
+      // Indirect_In arguments, then balance them with deallocations on all
+      // function exits.
+      if (!AddedStackAllocs.empty()) {
+        llvm_unreachable("todo");
+      }
+    }
+    
+    // Rewrite partial applications to partially apply the new clone.
+    for (auto pa : pa.PartialApplications) {
+      auto caller = pa->getFunction();
+      SILBuilder B(*caller);
+      auto loc = pa->getLoc();
+      B.setInsertionPoint(pa);
+      
+      auto newFunctionRef = B.createFunctionRef(loc, callee);
+      auto boxTy = SILBoxType::get(C, newBoxLayout, pa->getSubstitutionMap());
+      auto newBox = B.createAllocBox(loc, boxTy);
+      
+      // Transfer the formerly partially-applied arguments into the box.
+      auto appliedArgs = pa->getArguments();
+      for (unsigned i = 0; i < appliedArgs.size(); ++i) {
+        auto arg = appliedArgs[i];
+        auto proj = B.createProjectBox(loc, newBox, i);
+        auto param = partiallyAppliedParams[i];
+
+        switch (auto conv = param.getConvention()) {
+        case ParameterConvention::Direct_Owned:
+        case ParameterConvention::Direct_Unowned:
+        case ParameterConvention::Direct_Guaranteed:
+          // Move the value into the box.
+          if (caller->hasOwnership()) {
+            B.createStore(loc, arg, proj, StoreOwnershipQualifier::Init);
+          } else {
+            B.createStore(loc, arg, proj, StoreOwnershipQualifier::Unqualified);
+          }
+          break;
+            
+        case ParameterConvention::Indirect_In_Guaranteed:
+        case ParameterConvention::Indirect_In_Constant:
+        case ParameterConvention::Indirect_In:
+          // Move the value from its current memory location to the box.
+          B.createCopyAddr(loc, arg, proj, IsTake, IsInitialization);
+          break;
+          
+        case ParameterConvention::Indirect_InoutAliasable:
+        case ParameterConvention::Indirect_Inout: {
+          // Pass a pointer to the argument into the box.
+          auto p = B.createAddressToPointer(loc, arg,
+                                            SILType::getRawPointerType(C));
+          if (caller->hasOwnership()) {
+            B.createStore(loc, p, proj, StoreOwnershipQualifier::Trivial);
+          } else {
+            B.createStore(loc, p, proj, StoreOwnershipQualifier::Unqualified);
+          }
+        }
+        }
+      }
+      
+      // Partially apply the new box to create the closure.
+      auto newPA = B.createPartialApply(loc, newFunctionRef,
+                                        pa->getSubstitutionMap(),
+                                        SILValue(newBox),
+                                        boxConvention);
+      assert(isSimplePartialApply(newPA)
+             && "partial apply wasn't simple after transformation?");
+      pa->replaceAllUsesWith(newPA);
+      pa->eraseFromParent();
+    }
+    
+    // Once all the partial applications have been rewritten, then the original
+    // function refs with the old function type should all be unused. Delete
+    // them, since they are no longer valid.
+    for (auto fr : pa.FunctionRefs) {
+      fr->eraseFromParent();
+    }
+
+    ++NumInvocationFunctionsChanged;
+    return;
+  }
+  // Otherwise, we'll produce forwarding thunks for the different partial
+  // application shapes.
+create_forwarding_thunks:
+  LLVM_DEBUG(llvm::dbgs() << "TODO: create forwarding thunk here\n");
+  return;
+}
+
+void PartialApplySimplificationPass::processDynamicCallee(PartialApplyInst *pa){
+  // TODO
+}
+
+SILTransform *swift::createPartialApplySimplification() {
+  return new PartialApplySimplificationPass();
+}

--- a/lib/SILOptimizer/Transforms/PartialApplySimplification.cpp
+++ b/lib/SILOptimizer/Transforms/PartialApplySimplification.cpp
@@ -298,14 +298,10 @@ void PartialApplySimplificationPass::processKnownCallee(SILFunction *callee,
       return;
     }
     
-    if (origTy->getInvocationGenericSignature()) {
-      LLVM_DEBUG(llvm::dbgs() << "TODO: Generic partial_apply not yet implemented\n");
-      return;
-    }
-    
     auto newBoxLayout = SILLayout::get(C,
-                                       origTy->getInvocationGenericSignature(),
-                                       boxFields);
+       origTy->getInvocationGenericSignature(),
+       boxFields,
+       /*capturesGenerics*/ !origTy->getInvocationGenericSignature().isNull());
     SubstitutionMap identitySubstitutionMap;
     if (auto origSig = origTy->getInvocationGenericSignature()) {
       identitySubstitutionMap = origSig->getIdentitySubstitutionMap();

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1951,6 +1951,7 @@ namespace {
     NeverNullType resolveProtocolType(ProtocolTypeRepr *repr,
                                       TypeResolutionOptions options);
     NeverNullType resolveSILBoxType(SILBoxTypeRepr *repr,
+                                    bool capturesGenerics,
                                     TypeResolutionOptions options);
 
     NeverNullType
@@ -2089,7 +2090,9 @@ NeverNullType TypeResolver::resolveType(TypeRepr *repr,
   }
   case TypeReprKind::SILBox:
     assert((options & TypeResolutionFlags::SILType) && "SILBox repr in non-SIL type context?!");
-    return resolveSILBoxType(cast<SILBoxTypeRepr>(repr), options);
+    return resolveSILBoxType(cast<SILBoxTypeRepr>(repr),
+                             /*captures generics*/ false,
+                             options);
 
   case TypeReprKind::Array:
     return resolveArrayType(cast<ArrayTypeRepr>(repr), options);
@@ -2267,6 +2270,12 @@ TypeResolver::resolveAttributedType(TypeAttributes &attrs, TypeRepr *repr,
       options.is(TypeResolverContext::VariadicFunctionInput) &&
       !options.hasBase(TypeResolverContext::EnumElementDecl);
 
+  // SIL box types have an attribute to indicate when the box contains
+  // the captured generic environment.
+  if (auto box = dyn_cast<SILBoxTypeRepr>(repr)) {
+    return resolveSILBoxType(box, attrs.has(TAK_captures_generics), options);
+  }
+  
   // Resolve global actor.
   CustomAttr *globalActorAttr = nullptr;
   Type globalActor;
@@ -3056,6 +3065,7 @@ NeverNullType TypeResolver::resolveASTFunctionType(
 }
 
 NeverNullType TypeResolver::resolveSILBoxType(SILBoxTypeRepr *repr,
+                                              bool capturesGenerics,
                                               TypeResolutionOptions options) {
   // Resolve the field types.
   SmallVector<SILField, 4> fields;
@@ -3112,7 +3122,8 @@ NeverNullType TypeResolver::resolveSILBoxType(SILBoxTypeRepr *repr,
         LookUpConformanceInModule(getDeclContext()->getParentModule()));
   }
 
-  auto layout = SILLayout::get(getASTContext(), genericSig, fields);
+  auto layout = SILLayout::get(getASTContext(), genericSig, fields,
+                               capturesGenerics);
   return SILBoxType::get(getASTContext(), layout, subMap);
 }
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -409,9 +409,11 @@ SILLayout *ModuleFile::readSILLayout(llvm::BitstreamCursor &Cursor) {
   switch (kind) {
   case decls_block::SIL_LAYOUT: {
     GenericSignatureID rawGenericSig;
+    bool capturesGenerics;
     unsigned numFields;
     ArrayRef<uint64_t> types;
     decls_block::SILLayoutLayout::readRecord(scratch, rawGenericSig,
+                                             capturesGenerics,
                                              numFields, types);
     
     SmallVector<SILField, 4> fields;
@@ -426,7 +428,7 @@ SILLayout *ModuleFile::readSILLayout(llvm::BitstreamCursor &Cursor) {
     CanGenericSignature canSig;
     if (auto sig = getGenericSignature(rawGenericSig))
       canSig = sig.getCanonicalSignature();
-    return SILLayout::get(getContext(), canSig, fields);
+    return SILLayout::get(getContext(), canSig, fields, capturesGenerics);
   }
   default:
     fatal();

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1257,7 +1257,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     assert(RecordKind == SIL_ONE_TYPE && "Layout should be OneType.");
     ResultInst = Builder.createAllocBox(
         Loc, cast<SILBoxType>(MF->getType(TyID)->getCanonicalType()), None,
-        /*bool hasDynamicLifetime*/ Attr != 0);
+        /*bool hasDynamicLifetime*/ Attr & 1,
+        /*bool reflection*/ Attr & 2);
     break;
   case SILInstructionKind::AllocStackInst: {
     assert(RecordKind == SIL_ONE_TYPE && "Layout should be OneType.");

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 687; // RefAdHocRequirementFunction info in SILFunctionLayout
+const uint16_t SWIFTMODULE_VERSION_MINOR = 688; // SILBoxType extensions
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1166,6 +1166,7 @@ namespace decls_block {
   using SILLayoutLayout = BCRecordLayout<
     SIL_LAYOUT,
     GenericSignatureIDField,    // generic signature
+    BCFixed<1>,                 // captures generic env
     BCVBR<8>,                   // number of fields
     BCArray<TypeIDWithBitField> // field types with mutability
   >;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1528,6 +1528,7 @@ void Serializer::writeASTBlockEntity(const SILLayout *layout) {
   SILLayoutLayout::emitRecord(
                         Out, ScratchRecord, abbrCode,
                         addGenericSignatureRef(layout->getGenericSignature()),
+                        layout->capturesGenericEnvironment(),
                         layout->getFields().size(),
                         data);
 }

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1002,7 +1002,11 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
   }
   case SILInstructionKind::AllocBoxInst: {
     const AllocBoxInst *ABI = cast<AllocBoxInst>(&SI);
-    writeOneTypeLayout(ABI->getKind(), ABI->hasDynamicLifetime() ? 1 : 0,
+    unsigned flags
+      = (ABI->hasDynamicLifetime() ? 1 : 0)
+      | (ABI->emitReflectionMetadata() ? 2 : 0);
+    writeOneTypeLayout(ABI->getKind(),
+                       flags,
                        ABI->getType());
     break;
   }

--- a/test/SILOptimizer/partial_apply_simplification.sil
+++ b/test/SILOptimizer/partial_apply_simplification.sil
@@ -16,7 +16,7 @@ entry(%x : $Int, %y : $Int):
 // CHECK-LABEL: sil @closure_common_uses_user_a
 // CHECK:       bb0([[Y:%.*]] : $Int):
 // CHECK:         [[F:%.*]] = function_ref @closure_common_uses
-// CHECK-NEXT:    [[BOX:%.*]] = alloc_box ${ let Int }
+// CHECK-NEXT:    [[BOX:%.*]] = alloc_box [reflection] ${ let Int }
 // CHECK-NEXT:    [[BOX_0:%.*]] = project_box [[BOX]] : ${ let Int }, 0
 // CHECK-NEXT:    store [[Y]] to [[BOX_0]]
 // CHECK-NEXT:    [[C:%.*]] = partial_apply [callee_guaranteed] [[F]]([[BOX]])
@@ -30,7 +30,7 @@ entry(%y : $Int):
 // CHECK-LABEL: sil @closure_common_uses_user_b
 // CHECK:       bb0([[Y:%.*]] : $Int):
 // CHECK:         [[F:%.*]] = function_ref @closure_common_uses
-// CHECK-NEXT:    [[BOX:%.*]] = alloc_box ${ let Int }
+// CHECK-NEXT:    [[BOX:%.*]] = alloc_box [reflection] ${ let Int }
 // CHECK-NEXT:    [[BOX_0:%.*]] = project_box [[BOX]] : ${ let Int }, 0
 // CHECK-NEXT:    store [[Y]] to [[BOX_0]]
 // CHECK-NEXT:    [[C:%.*]] = partial_apply [callee_guaranteed] [[F]]([[BOX]])
@@ -83,7 +83,7 @@ entry(%r : $*Int, %x : $Int, %y : $Int):
 // CHECK-LABEL: sil @closure_out_param_user
 // CHECK:       bb0([[Y:%.*]] : $Int):
 // CHECK:         [[F:%.*]] = function_ref @closure_out_param
-// CHECK-NEXT:    [[BOX:%.*]] = alloc_box ${ let Int }
+// CHECK-NEXT:    [[BOX:%.*]] = alloc_box [reflection] ${ let Int }
 // CHECK-NEXT:    [[BOX_0:%.*]] = project_box [[BOX]] : ${ let Int }, 0
 // CHECK-NEXT:    store [[Y]] to [[BOX_0]]
 // CHECK-NEXT:    [[C:%.*]] = partial_apply [callee_guaranteed] [[F]]([[BOX]])
@@ -93,3 +93,42 @@ entry(%y : $Int):
   %c = partial_apply [callee_guaranteed] %f(%y) : $@convention(thin) (Int, Int) -> @out Int
   return %c : $@callee_guaranteed (Int) -> @out Int
 }
+
+sil @add : $@convention(thin) (Int, Int) -> Int
+
+// CHECK-LABEL: sil private @closure_multi_capture
+// CHECK-SAME:    : $@convention(method) (Int, @guaranteed { let (Int, Int) }) -> Int
+// CHECK:       bb0([[X:%.*]] : $Int, [[YZ:%.*]] : ${ let (Int, Int) }):
+// CHECK-NEXT:   [[BOX_PROJ:%.*]] = project_box [[YZ]] :
+// CHECK-NEXT:   [[BOX_0:%.*]] = tuple_element_addr [[BOX_PROJ]] : {{.*}}, 0
+// CHECK-NEXT:   [[Y:%.*]] = load [[BOX_0]] : $*Int
+// CHECK-NEXT:   [[BOX_PROJ:%.*]] = project_box [[YZ]] :
+// CHECK-NEXT:   [[BOX_1:%.*]] = tuple_element_addr [[BOX_PROJ]] : {{.*}}, 1
+// CHECK-NEXT:   [[Z:%.*]] = load [[BOX_1]] : $*Int
+// CHECK:   [[ADD:%.*]] = function_ref @add
+// CHECK-NEXT:   apply [[ADD]]([[Y]], [[Z]])
+sil private @closure_multi_capture : $@convention(thin) (Int, Int, Int) -> Int {
+entry(%x : $Int, %y : $Int, %z : $Int):
+  %f = function_ref @add : $@convention(thin) (Int, Int) -> Int
+  %r = apply %f(%y, %z) : $@convention(thin) (Int, Int) -> Int
+  return %r : $Int
+}
+
+// CHECK-LABEL: sil @closure_multi_capture_user
+// CHECK:       bb0([[Y:%.*]] : $Int, [[Z:%.*]] : $Int):
+// CHECK:         [[BOX:%.*]] = alloc_box [reflection] ${ let (Int, Int) }
+// CHECK:         [[BOX_PROJ:%.*]] = project_box [[BOX]]
+// CHECK:         [[BOX_0:%.*]] = tuple_element_addr [[BOX_PROJ]] : {{.*}}, 0
+// CHECK:         store [[Y]] to [[BOX_0]]
+// CHECK:         [[BOX_PROJ:%.*]] = project_box [[BOX]]
+// CHECK:         [[BOX_1:%.*]] = tuple_element_addr [[BOX_PROJ]] : {{.*}}, 1
+// CHECK:         store [[Z]] to [[BOX_1]]
+// CHECK:         [[RESULT:%.*]] = partial_apply [callee_guaranteed] {{%.*}}([[BOX]])
+// CHECK:         return [[RESULT]]
+sil @closure_multi_capture_user : $@convention(thin) (Int, Int) -> @owned @callee_guaranteed (Int) -> Int {
+entry(%y : $Int, %z : $Int):
+  %f = function_ref @closure_multi_capture : $@convention(thin) (Int, Int, Int) -> Int
+  %c = partial_apply [callee_guaranteed] %f(%y, %z) : $@convention(thin) (Int, Int, Int) -> Int
+  return %c : $@callee_guaranteed (Int) -> Int
+}
+

--- a/test/SILOptimizer/partial_apply_simplification.sil
+++ b/test/SILOptimizer/partial_apply_simplification.sil
@@ -105,7 +105,7 @@ sil @add : $@convention(thin) (Int, Int) -> Int
 // CHECK-NEXT:   [[BOX_PROJ:%.*]] = project_box [[YZ]] :
 // CHECK-NEXT:   [[BOX_1:%.*]] = tuple_element_addr [[BOX_PROJ]] : {{.*}}, 1
 // CHECK-NEXT:   [[Z:%.*]] = load [[BOX_1]] : $*Int
-// CHECK:   [[ADD:%.*]] = function_ref @add
+// CHECK:        [[ADD:%.*]] = function_ref @add
 // CHECK-NEXT:   apply [[ADD]]([[Y]], [[Z]])
 sil private @closure_multi_capture : $@convention(thin) (Int, Int, Int) -> Int {
 entry(%x : $Int, %y : $Int, %z : $Int):
@@ -120,7 +120,6 @@ entry(%x : $Int, %y : $Int, %z : $Int):
 // CHECK:         [[BOX_PROJ:%.*]] = project_box [[BOX]]
 // CHECK:         [[BOX_0:%.*]] = tuple_element_addr [[BOX_PROJ]] : {{.*}}, 0
 // CHECK:         store [[Y]] to [[BOX_0]]
-// CHECK:         [[BOX_PROJ:%.*]] = project_box [[BOX]]
 // CHECK:         [[BOX_1:%.*]] = tuple_element_addr [[BOX_PROJ]] : {{.*}}, 1
 // CHECK:         store [[Z]] to [[BOX_1]]
 // CHECK:         [[RESULT:%.*]] = partial_apply [callee_guaranteed] {{%.*}}([[BOX]])
@@ -132,3 +131,45 @@ entry(%y : $Int, %z : $Int):
   return %c : $@callee_guaranteed (Int) -> Int
 }
 
+// CHECK-LABEL: sil private @closure_nonescaping
+// CHECK-SAME:    : $@convention(method) (Int, @in_guaranteed (Int, Int)) -> Int
+// CHECK:       bb0([[X:%.*]] : $Int, [[YZ:%.*]] : $*(Int, Int)):
+// CHECK:         [[BOX_0:%.*]] = tuple_element_addr [[YZ]] : {{.*}}, 0
+// CHECK-NEXT:    [[Y:%.*]] = load [[BOX_0]] : $*Int
+// CHECK-NEXT:    [[BOX_1:%.*]] = tuple_element_addr [[YZ]] : {{.*}}, 1
+// CHECK-NEXT:    [[Z:%.*]] = load [[BOX_1]] : $*Int
+// CHECK:         [[ADD:%.*]] = function_ref @add
+// CHECK-NEXT:    apply [[ADD]]([[Y]], [[Z]])
+sil private @closure_nonescaping : $@convention(thin) (Int, Int, Int) -> Int {
+entry(%x : $Int, %y : $Int, %z : $Int):
+  %f = function_ref @add : $@convention(thin) (Int, Int) -> Int
+  %r = apply %f(%y, %z) : $@convention(thin) (Int, Int) -> Int
+  return %r : $Int
+}
+
+sil @closure_nonescaping_consumer : $@convention(thin) (@noescape @callee_guaranteed (Int) -> Int, Int) -> Int {
+entry(%f : $@noescape @callee_guaranteed (Int) -> Int, %x : $Int):
+  %y = apply %f(%x) : $@noescape @callee_guaranteed (Int) -> Int
+  return %y : $Int
+}
+
+// CHECK-LABEL: sil @closure_nonescaping_user
+// CHECK:       bb0([[X:%.*]] : $Int, [[Y:%.*]] : $Int, [[Z:%.*]] : $Int):
+// CHECK:         [[F:%.*]] = function_ref @closure_nonescaping
+// CHECK:         [[CONTEXT:%.*]] = alloc_stack $(Int, Int)
+// CHECK:         [[CONTEXT_Y:%.*]] = tuple_element_addr [[CONTEXT]] {{.*}}, 0
+// CHECK:         store [[Y]] to [[CONTEXT_Y]]
+// CHECK:         [[CONTEXT_Z:%.*]] = tuple_element_addr [[CONTEXT]] {{.*}}, 1
+// CHECK:         store [[Z]] to [[CONTEXT_Z]]
+// CHECK:         [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [on_stack] [[F]]([[CONTEXT]])
+// CHECK:         [[CONSUMER:%.*]] = function_ref @closure_nonescaping_consumer
+// CHECK:         apply [[CONSUMER]]([[CLOSURE]], [[X]])
+sil @closure_nonescaping_user : $@convention(thin) (Int, Int, Int) -> Int {
+entry(%x : $Int, %y : $Int, %z : $Int):
+  %f = function_ref @closure_nonescaping : $@convention(thin) (Int, Int, Int) -> Int
+  %c = partial_apply [callee_guaranteed] [on_stack] %f(%y, %z) : $@convention(thin) (Int, Int, Int) -> Int
+  %g = function_ref @closure_nonescaping_consumer : $@convention(thin) (@noescape @callee_guaranteed (Int) -> Int, Int) -> Int
+  %r = apply %g(%c, %x) : $@convention(thin) (@noescape @callee_guaranteed (Int) -> Int, Int) -> Int
+  dealloc_stack %c : $@noescape @callee_guaranteed (Int) -> Int
+  return %r : $Int
+}

--- a/test/SILOptimizer/partial_apply_simplification.sil
+++ b/test/SILOptimizer/partial_apply_simplification.sil
@@ -173,3 +173,19 @@ entry(%x : $Int, %y : $Int, %z : $Int):
   dealloc_stack %c : $@noescape @callee_guaranteed (Int) -> Int
   return %r : $Int
 }
+
+// CHECK-LABEL: sil @closure_nonescaping_full_apply
+// CHECK:       bb0([[X:%.*]] : $Int, [[Y:%.*]] : $Int, [[Z:%.*]] : $Int):
+// CHECK:         [[F:%.*]] = function_ref @closure_nonescaping
+// CHECK:         [[CONTEXT:%.*]] = alloc_stack $(Int, Int)
+// CHECK:         [[CONTEXT_Y:%.*]] = tuple_element_addr [[CONTEXT]] {{.*}}, 0
+// CHECK:         store [[Y]] to [[CONTEXT_Y]]
+// CHECK:         [[CONTEXT_Z:%.*]] = tuple_element_addr [[CONTEXT]] {{.*}}, 1
+// CHECK:         store [[Z]] to [[CONTEXT_Z]]
+// CHECK:         [[CLOSURE:%.*]] = apply [[F]]([[X]], [[CONTEXT]])
+sil @closure_nonescaping_full_apply : $@convention(thin) (Int, Int, Int) -> Int {
+entry(%x : $Int, %y : $Int, %z : $Int):
+  %f = function_ref @closure_nonescaping : $@convention(thin) (Int, Int, Int) -> Int
+  %r = apply %f(%x, %y, %z) : $@convention(thin) (Int, Int, Int) -> Int
+  return %r : $Int
+}

--- a/test/SILOptimizer/partial_apply_simplification.sil
+++ b/test/SILOptimizer/partial_apply_simplification.sil
@@ -189,3 +189,24 @@ entry(%x : $Int, %y : $Int, %z : $Int):
   %r = apply %f(%x, %y, %z) : $@convention(thin) (Int, Int, Int) -> Int
   return %r : $Int
 }
+
+// CHECK-LABEL: sil private @closure_nonescaping_convention_change
+// CHECK-SAME:    : $@convention(method) (Int, @in_guaranteed Int) -> Int {
+sil private @closure_nonescaping_convention_change : $@convention(thin) (Int, @in_guaranteed Int) -> Int {
+entry(%x : $Int, %y : $*Int):
+  %f = function_ref @add : $@convention(thin) (Int, Int) -> Int
+  %z = load %y : $*Int
+  %r = apply %f(%x, %z) : $@convention(thin) (Int, Int) -> Int
+  return %r : $Int
+}
+
+sil @closure_nonescaping_convention_change_user : $@convention(thin) (Int, @in_guaranteed Int) -> Int {
+entry(%x : $Int, %y : $*Int):
+  %f = function_ref @closure_nonescaping_convention_change : $@convention(thin) (Int, @in_guaranteed Int) -> Int
+  %c = partial_apply [callee_guaranteed] [on_stack] %f(%y) : $@convention(thin) (Int, @in_guaranteed Int) -> Int
+  %g = function_ref @closure_nonescaping_consumer : $@convention(thin) (@noescape @callee_guaranteed (Int) -> Int, Int) -> Int
+  %r = apply %g(%c, %x) : $@convention(thin) (@noescape @callee_guaranteed (Int) -> Int, Int) -> Int
+  dealloc_stack %c : $@noescape @callee_guaranteed (Int) -> Int
+  return %r : $Int
+}
+

--- a/test/SILOptimizer/partial_apply_simplification.sil
+++ b/test/SILOptimizer/partial_apply_simplification.sil
@@ -1,0 +1,95 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -partial-apply-simplification | %FileCheck %s
+
+import Swift
+
+// CHECK-LABEL: sil private @closure_common_uses
+// CHECK-SAME:    : $@convention(method) (Int, @guaranteed { let Int }) -> Int {
+// CHECK:      bb0([[X:%.*]] : $Int, [[BOX:%.*]] : ${ let Int }):
+// CHECK-NEXT:   [[BOX_0:%.*]] = project_box [[BOX]] : ${ let Int }, 0
+// CHECK-NEXT:   [[Y:%.*]] = load [[BOX_0]] : $*Int
+// CHECK-NEXT:   return [[Y]]
+sil private @closure_common_uses : $@convention(thin) (Int, Int) -> Int {
+entry(%x : $Int, %y : $Int):
+  return %y : $Int
+}
+
+// CHECK-LABEL: sil @closure_common_uses_user_a
+// CHECK:       bb0([[Y:%.*]] : $Int):
+// CHECK:         [[F:%.*]] = function_ref @closure_common_uses
+// CHECK-NEXT:    [[BOX:%.*]] = alloc_box ${ let Int }
+// CHECK-NEXT:    [[BOX_0:%.*]] = project_box [[BOX]] : ${ let Int }, 0
+// CHECK-NEXT:    store [[Y]] to [[BOX_0]]
+// CHECK-NEXT:    [[C:%.*]] = partial_apply [callee_guaranteed] [[F]]([[BOX]])
+sil @closure_common_uses_user_a : $@convention(thin) (Int) -> @owned @callee_guaranteed (Int) -> Int {
+entry(%y : $Int):
+  %f = function_ref @closure_common_uses : $@convention(thin) (Int, Int) -> Int
+  %c = partial_apply [callee_guaranteed] %f(%y) : $@convention(thin) (Int, Int) -> Int
+  return %c : $@callee_guaranteed (Int) -> Int
+}
+
+// CHECK-LABEL: sil @closure_common_uses_user_b
+// CHECK:       bb0([[Y:%.*]] : $Int):
+// CHECK:         [[F:%.*]] = function_ref @closure_common_uses
+// CHECK-NEXT:    [[BOX:%.*]] = alloc_box ${ let Int }
+// CHECK-NEXT:    [[BOX_0:%.*]] = project_box [[BOX]] : ${ let Int }, 0
+// CHECK-NEXT:    store [[Y]] to [[BOX_0]]
+// CHECK-NEXT:    [[C:%.*]] = partial_apply [callee_guaranteed] [[F]]([[BOX]])
+sil @closure_common_uses_user_b : $@convention(thin) (Int) -> @owned @callee_guaranteed (Int) -> Int {
+entry(%y : $Int):
+  %f = function_ref @closure_common_uses : $@convention(thin) (Int, Int) -> Int
+  %c = partial_apply [callee_guaranteed] %f(%y) : $@convention(thin) (Int, Int) -> Int
+  return %c : $@callee_guaranteed (Int) -> Int
+}
+
+// CHECK-LABEL: sil private @closure_common_uses_owned
+// CHECK-SAME:    : $@convention(method) (Int, @owned { let Int }) -> Int {
+// CHECK:      bb0([[X:%.*]] : $Int, [[BOX:%.*]] : ${ let Int }):
+// CHECK-NEXT:   [[BOX_0:%.*]] = project_box [[BOX]] : ${ let Int }, 0
+// CHECK-NEXT:   [[Y:%.*]] = load [[BOX_0]] : $*Int
+// CHECK-NEXT:   strong_release [[BOX]]
+// CHECK-NEXT:   return [[Y]]
+sil private @closure_common_uses_owned : $@convention(thin) (Int, Int) -> Int {
+entry(%x : $Int, %y : $Int):
+  return %y : $Int
+}
+
+sil @closure_common_uses_owned_user_a : $@convention(thin) (Int) -> @owned @callee_owned (Int) -> Int {
+entry(%y : $Int):
+  %f = function_ref @closure_common_uses_owned : $@convention(thin) (Int, Int) -> Int
+  %c = partial_apply %f(%y) : $@convention(thin) (Int, Int) -> Int
+  return %c : $@callee_owned (Int) -> Int
+}
+
+sil @closure_common_uses_owned_user_b : $@convention(thin) (Int) -> @owned @callee_owned (Int) -> Int {
+entry(%y : $Int):
+  %f = function_ref @closure_common_uses_owned : $@convention(thin) (Int, Int) -> Int
+  %c = partial_apply %f(%y) : $@convention(thin) (Int, Int) -> Int
+  return %c : $@callee_owned (Int) -> Int
+}
+
+// CHECK-LABEL: sil private @closure_out_param
+// CHECK-SAME:    : $@convention(method) (Int, @guaranteed { let Int }) -> @out Int {
+// CHECK:      bb0([[R:%.*]] : $*Int, [[X:%.*]] : $Int, [[BOX:%.*]] : ${ let Int }):
+// CHECK-NEXT:   [[BOX_0:%.*]] = project_box [[BOX]] : ${ let Int }, 0
+// CHECK-NEXT:   [[Y:%.*]] = load [[BOX_0]] : $*Int
+// CHECK-NEXT:   store [[Y]] to [[R]]
+// CHECK-NEXT:   return
+sil private @closure_out_param : $@convention(thin) (Int, Int) -> @out Int {
+entry(%r : $*Int, %x : $Int, %y : $Int):
+  store %y to %r : $*Int
+  return undef : $()
+}
+
+// CHECK-LABEL: sil @closure_out_param_user
+// CHECK:       bb0([[Y:%.*]] : $Int):
+// CHECK:         [[F:%.*]] = function_ref @closure_out_param
+// CHECK-NEXT:    [[BOX:%.*]] = alloc_box ${ let Int }
+// CHECK-NEXT:    [[BOX_0:%.*]] = project_box [[BOX]] : ${ let Int }, 0
+// CHECK-NEXT:    store [[Y]] to [[BOX_0]]
+// CHECK-NEXT:    [[C:%.*]] = partial_apply [callee_guaranteed] [[F]]([[BOX]])
+sil @closure_out_param_user : $@convention(thin) (Int) -> @owned @callee_guaranteed (Int) -> @out Int {
+entry(%y : $Int):
+  %f = function_ref @closure_out_param : $@convention(thin) (Int, Int) -> @out Int
+  %c = partial_apply [callee_guaranteed] %f(%y) : $@convention(thin) (Int, Int) -> @out Int
+  return %c : $@callee_guaranteed (Int) -> @out Int
+}


### PR DESCRIPTION
Introduce a SIL pass, `PartialApplySimplification`, which transforms `partial_apply` instructions into "simple" partial applications that only combine an invocation function and context into a thick function value. It does this by turning arbitrary partial applications into explicit sequences of constructing a box with the captured arguments and then `partial_apply`-ing the box to a modified invocation function that explicitly unpacks the captured arguments from the box. If we get to the point where we can eliminate "complex" partial applications prior to IRGen, that will let us remove a lot of complex code for constructing and unpacking boxes directly in LLVM IR. Doing this transform in SIL also makes it easier to directly modify the invocation function to take a box directly, saving the need for a "partial application forwarder" thunk, when the invocation function is only ever used for the same shape of partial_apply and has no other uses. There is also the potential for other SIL level optimizations to forward copies in and out of the box that would be difficult for LLVM to do.

This PR does not yet integrate the new pass into the default pipeline, but establishes a baseline for testing and further development. There needs to be some additional IRGen implementation work to be able to represent all closure formations in SIL:

- The implementation of multi-field boxes needs to be completed.
- Boxes need to be able to capture and reopen their generic environment, in order to represent captured context from a generic caller.
- Boxes need to be able to have reflection info attached for out-of-process memory tools, for parity with the IRGen partial_apply implementation.
- We need something like `SILBoxType` for representing nonescaping closure contexts. (Tuples can't quite do this because they can't capture generic context.)

This patch also includes extensions to SILBoxType but doesn't yet implement their concretization in IRGen.