### PR TITLE
[5.7][Sema] Require `any` for SE-0309 existential types.

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4306,7 +4306,6 @@ public:
                            proto->getDeclaredInterfaceType(),
                            proto->getExistentialType(),
                            /*isAlias=*/false)
-            .limitBehavior(DiagnosticBehavior::Warning)
             .fixItReplace(replaceRepr->getSourceRange(), fix);
       }
     } else if (auto *alias = dyn_cast_or_null<TypeAliasDecl>(comp->getBoundDecl())) {
@@ -4325,7 +4324,6 @@ public:
                              alias->getDeclaredInterfaceType(),
                              ExistentialType::get(alias->getDeclaredInterfaceType()),
                              /*isAlias=*/true)
-              .limitBehavior(DiagnosticBehavior::Warning)
               .fixItReplace(replaceRepr->getSourceRange(), fix);
         }
       }

--- a/test/Generics/function_defs.swift
+++ b/test/Generics/function_defs.swift
@@ -34,7 +34,7 @@ func min<T : MethodLessComparable>(_ x: T, y: T) -> T {
 //===----------------------------------------------------------------------===//
 
 func existential<T : EqualComparable, U : EqualComparable>(_ t1: T, t2: T, u: U) {
-  var eqComp : EqualComparable = t1 // expected-warning {{use of protocol 'EqualComparable' as a type must be written 'any EqualComparable'}}
+  var eqComp : any EqualComparable = t1
   eqComp = u
   if t1.isEqual(eqComp) {} // expected-error{{cannot convert value of type 'any EqualComparable' to expected argument type 'T'}}
   if eqComp.isEqual(t2) {}

--- a/test/SILGen/dependent_member_lowering.swift
+++ b/test/SILGen/dependent_member_lowering.swift
@@ -31,7 +31,7 @@ protocol P1: P0 where Foo == String {
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s25dependent_member_lowering26existentialDependentMemberySSAA2P1_pF : $@convention(thin) (@in_guaranteed P1) -> @owned String
-func existentialDependentMember(_ p1: P1) -> String {
+func existentialDependentMember(_ p1: any P1) -> String {
   // CHECK: $@convention(witness_method: P0) <τ_0_0 where τ_0_0 : P0> (@in_guaranteed τ_0_0) -> @out τ_0_0.Foo
   return p1.foo()
 }

--- a/test/decl/nested/protocol.swift
+++ b/test/decl/nested/protocol.swift
@@ -31,7 +31,7 @@ protocol OuterProtocol {
 struct ConformsToOuterProtocol : OuterProtocol {
   typealias Hen = Int
 
-  func f() { let _ = InnerProtocol.self } // expected-warning {{use of protocol 'InnerProtocol' as a type must be written 'any InnerProtocol'}}
+  func f() { let _ = InnerProtocol.self } // expected-error {{use of protocol 'InnerProtocol' as a type must be written 'any InnerProtocol'}}
 }
 
 protocol Racoon {

--- a/test/decl/protocol/conforms/inherited.swift
+++ b/test/decl/protocol/conforms/inherited.swift
@@ -167,13 +167,13 @@ class B : A {
 }
 
 func testB(_ b: B) {
-  var _: P1 = b // expected-warning {{use of protocol 'P1' as a type must be written 'any P1'}}
-  var _: P4 = b // expected-warning {{use of protocol 'P4' as a type must be written 'any P4'}}
-  var _: P5 = b
-  var _: P6 = b
-  var _: P7 = b // expected-warning {{use of protocol 'P7' as a type must be written 'any P7'}}
-  var _: P8 = b
-  var _: P9 = b // expected-warning {{use of protocol 'P9' as a type must be written 'any P9'}}
+  var _: any P1 = b
+  var _: any P4 = b
+  var _: any P5 = b
+  var _: any P6 = b
+  var _: any P7 = b
+  var _: any P8 = b
+  var _: any P9 = b
 }
 
 // Class A5 conforms to P5 in an inheritable manner.

--- a/test/decl/protocol/existential_member_accesses_self_assoctype.swift
+++ b/test/decl/protocol/existential_member_accesses_self_assoctype.swift
@@ -802,9 +802,7 @@ do {
 
     let _: any Class<Struct<Bool>.Inner> & ConcreteAssocTypes =
       arg[
-        // FIXME: Sema thinks (any ConcreteAssocTypes).self is a function ref.
-        // expected-warning@+1 {{use of protocol 'ConcreteAssocTypes' as a type must be written 'any ConcreteAssocTypes'}}
-        subscript4: Struct<Bool>(), ConcreteAssocTypes.self, { true }
+        subscript4: Struct<Bool>(), (any ConcreteAssocTypes).self, { true }
       ]
   }
 }

--- a/test/decl/protocol/existential_member_accesses_self_assoctype_fixit.swift
+++ b/test/decl/protocol/existential_member_accesses_self_assoctype_fixit.swift
@@ -12,12 +12,12 @@ protocol P {
 protocol Q {}
 
 do {
-  func test(p: P) { // expected-warning {{use of protocol 'P' as a type must be written 'any P'}}
+  func test(p: P) { // expected-error {{use of protocol 'P' as a type must be written 'any P'}}
     p.method(false) // expected-error {{member 'method' cannot be used on value of type 'any P'; consider using a generic constraint instead}} {{-1:16--1:17=some P}} {{none}}
   }
 }
 do {
-  func test(p: ((P))) { // expected-warning {{use of protocol 'P' as a type must be written 'any P'}}
+  func test(p: ((P))) { // expected-error {{use of protocol 'P' as a type must be written 'any P'}}
     p.method(false) // expected-error {{member 'method' cannot be used on value of type 'any P'; consider using a generic constraint instead}} {{-1:18--1:19=some P}} {{none}}
   }
 }
@@ -57,12 +57,12 @@ do {
   }
 }
 do {
-  func test(p: P.Type) { // expected-warning {{use of protocol 'P' as a type must be written 'any P'}}
+  func test(p: P.Type) { // expected-error {{use of protocol 'P' as a type must be written 'any P'}}
     p.staticMethod(false) // expected-error {{member 'staticMethod' cannot be used on value of type 'any P.Type'; consider using a generic constraint instead}} {{-1:16--1:17=(some P)}} {{none}}
   }
 }
 do {
-  func test(p: (P).Type) { // expected-warning {{use of protocol 'P' as a type must be written 'any P'}}
+  func test(p: (P).Type) { // expected-error {{use of protocol 'P' as a type must be written 'any P'}}
     p.staticMethod(false) // expected-error {{member 'staticMethod' cannot be used on value of type 'any (P).Type'; consider using a generic constraint instead}} {{-1:17--1:18=some P}} {{none}}
   }
 }
@@ -78,12 +78,12 @@ do {
 }
 
 do {
-  func test(p: P & Q) { // expected-warning {{use of protocol 'P' as a type must be written 'any P'}}
+  func test(p: P & Q) { // expected-error {{use of protocol 'P' as a type must be written 'any P'}}
     p.method(false) // expected-error {{member 'method' cannot be used on value of type 'any P & Q'; consider using a generic constraint instead}} {{-1:16--1:21=some P & Q}} {{none}}
   }
 }
 do {
-  func test(p: ((P & Q))) { // expected-warning {{use of protocol 'P' as a type must be written 'any P'}}
+  func test(p: ((P & Q))) { // expected-error {{use of protocol 'P' as a type must be written 'any P'}}
     p.method(false) // expected-error {{member 'method' cannot be used on value of type 'any P & Q'; consider using a generic constraint instead}} {{-1:18--1:23=some P & Q}} {{none}}
   }
 }
@@ -123,12 +123,12 @@ do {
   }
 }
 do {
-  func test(p: (P & Q).Type) { // expected-warning {{use of protocol 'P' as a type must be written 'any P'}}
+  func test(p: (P & Q).Type) { // expected-error {{use of protocol 'P' as a type must be written 'any P'}}
     p.staticMethod(false) // expected-error {{member 'staticMethod' cannot be used on value of type 'any (P & Q).Type'; consider using a generic constraint instead}} {{-1:17--1:22=some P & Q}} {{none}}
   }
 }
 do {
-  func test(p: ((P & Q)).Type) { // expected-warning {{use of protocol 'P' as a type must be written 'any P'}}
+  func test(p: ((P & Q)).Type) { // expected-error {{use of protocol 'P' as a type must be written 'any P'}}
     p.staticMethod(false) // expected-error {{member 'staticMethod' cannot be used on value of type 'any ((P & Q)).Type'; consider using a generic constraint instead}} {{-1:18--1:23=some P & Q}} {{none}}
   }
 }

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -446,7 +446,7 @@ func i<T : C3>(_ x : T?) -> Bool {
   // expected-warning@-1 {{checking a value with optional type 'T?' against type 'any P1' succeeds whenever the value is non-nil; did you mean to use '!= nil'?}}
 }
 func j(_ x : C1) -> Bool {
-  return x is P1 // expected-warning {{use of protocol 'P1' as a type must be written 'any P1'}}
+  return x is P1 // expected-error {{use of protocol 'P1' as a type must be written 'any P1'}}
 }
 func k(_ x : C1?) -> Bool {
   return x is any P1

--- a/test/decl/protocol/recursive_requirement.swift
+++ b/test/decl/protocol/recursive_requirement.swift
@@ -91,7 +91,7 @@ protocol AsExistentialB {
 }
 
 protocol AsExistentialAssocTypeA {
-  var delegate : AsExistentialAssocTypeB? { get } // expected-warning {{use of protocol 'AsExistentialAssocTypeB' as a type must be written 'any AsExistentialAssocTypeB'}}
+  var delegate : AsExistentialAssocTypeB? { get } // expected-error {{use of protocol 'AsExistentialAssocTypeB' as a type must be written 'any AsExistentialAssocTypeB'}}
 }
 protocol AsExistentialAssocTypeB {
   func aMethod(_ object : AsExistentialAssocTypeA)
@@ -103,7 +103,7 @@ protocol AsExistentialAssocTypeAgainA {
   associatedtype Bar
 }
 protocol AsExistentialAssocTypeAgainB {
-  func aMethod(_ object : AsExistentialAssocTypeAgainA) // expected-warning {{use of protocol 'AsExistentialAssocTypeAgainA' as a type must be written 'any AsExistentialAssocTypeAgainA'}}
+  func aMethod(_ object : AsExistentialAssocTypeAgainA) // expected-error {{use of protocol 'AsExistentialAssocTypeAgainA' as a type must be written 'any AsExistentialAssocTypeAgainA'}}
 }
 
 // SR-547

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -244,8 +244,8 @@ protocol Output {
   associatedtype A
 }
 
-// expected-warning@+2{{use of protocol 'Input' as a type must be written 'any Input'}}{{30-35=any Input}}
-// expected-warning@+1{{use of protocol 'Output' as a type must be written 'any Output'}}{{40-46=any Output}}
+// expected-error@+2{{use of protocol 'Input' as a type must be written 'any Input'}}{{30-35=any Input}}
+// expected-error@+1{{use of protocol 'Output' as a type must be written 'any Output'}}{{40-46=any Output}}
 typealias InvalidFunction = (Input) -> Output
 func testInvalidFunctionAlias(fn: InvalidFunction) {}
 
@@ -253,7 +253,7 @@ typealias ExistentialFunction = (any Input) -> any Output
 func testFunctionAlias(fn: ExistentialFunction) {}
 
 typealias Constraint = Input
-func testConstraintAlias(x: Constraint) {} // expected-warning{{use of 'Constraint' (aka 'Input') as a type must be written 'any Constraint'}}{{29-39=any Constraint}}
+func testConstraintAlias(x: Constraint) {} // expected-error{{use of 'Constraint' (aka 'Input') as a type must be written 'any Constraint'}}{{29-39=any Constraint}}
 
 typealias Existential = any Input
 func testExistentialAlias(x: Existential, y: any Constraint) {}
@@ -287,26 +287,26 @@ func testAnyFixIt() {
     func method() -> any HasAssoc {}
   }
 
-  // expected-warning@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=any HasAssoc}}
+  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=any HasAssoc}}
   let _: HasAssoc = ConformingType()
-  // expected-warning@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{19-27=any HasAssoc}}
+  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{19-27=any HasAssoc}}
   let _: Optional<HasAssoc> = nil
-  // expected-warning@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-23=any HasAssoc.Type}}
+  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-23=any HasAssoc.Type}}
   let _: HasAssoc.Type = ConformingType.self
-  // expected-warning@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-25=any (HasAssoc).Type}}
+  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-25=any (HasAssoc).Type}}
   let _: (HasAssoc).Type = ConformingType.self
-  // expected-warning@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-27=any ((HasAssoc)).Type}}
+  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-27=any ((HasAssoc)).Type}}
   let _: ((HasAssoc)).Type = ConformingType.self
-  // expected-warning@+2 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=(any HasAssoc)}}
-  // expected-warning@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{30-38=(any HasAssoc)}}
+  // expected-error@+2 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=(any HasAssoc)}}
+  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{30-38=(any HasAssoc)}}
   let _: HasAssoc.Protocol = HasAssoc.self
-  // expected-warning@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{11-19=any HasAssoc}}
+  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{11-19=any HasAssoc}}
   let _: (HasAssoc).Protocol = (any HasAssoc).self
-  // expected-warning@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=(any HasAssoc)}}
+  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=(any HasAssoc)}}
   let _: HasAssoc? = ConformingType()
-  // expected-warning@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-23=(any HasAssoc.Type)}}
+  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-23=(any HasAssoc.Type)}}
   let _: HasAssoc.Type? = ConformingType.self
-  // expected-warning@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=(any HasAssoc)}}
+  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=(any HasAssoc)}}
   let _: HasAssoc.Protocol? = (any HasAssoc).self
 
   // expected-error@+1 {{optional 'any' type must be written '(any HasAssoc)?'}}{{10-23=(any HasAssoc)?}}

--- a/test/type/protocol_types.swift
+++ b/test/type/protocol_types.swift
@@ -3,7 +3,7 @@
 protocol HasSelfRequirements {
   func foo(_ x: Self)
 
-  func returnsOwnProtocol() -> HasSelfRequirements // expected-warning {{use of protocol 'HasSelfRequirements' as a type must be written 'any HasSelfRequirements'}}
+  func returnsOwnProtocol() -> HasSelfRequirements // expected-error {{use of protocol 'HasSelfRequirements' as a type must be written 'any HasSelfRequirements'}}
 }
 protocol Bar {
   // init() methods should not prevent use as an existential.
@@ -74,7 +74,7 @@ do {
 
   func checkIt(_ js: Any) throws {
     switch js {
-    case let dbl as HasAssoc: // expected-warning {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}
+    case let dbl as HasAssoc: // expected-error {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}
       throw MyError.bad(dbl)
 
     default:
@@ -83,7 +83,7 @@ do {
   }
 }
 
-func testHasAssoc(_ x: Any, _: HasAssoc) { // expected-warning {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}
+func testHasAssoc(_ x: Any, _: HasAssoc) { // expected-error {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}
   if let p = x as? any HasAssoc {
     p.foo() // don't crash here.
   }
@@ -92,12 +92,12 @@ func testHasAssoc(_ x: Any, _: HasAssoc) { // expected-warning {{use of protocol
     typealias Assoc = Int
     func foo() {}
 
-    func method() -> HasAssoc {} // expected-warning {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}
+    func method() -> HasAssoc {} // expected-error {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}
   }
 }
 
 // SR-38
-var b: HasAssoc // expected-warning {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}
+var b: HasAssoc // expected-error {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}
 
 // Further generic constraint error testing - typealias used inside statements
 protocol P {}
@@ -118,20 +118,20 @@ typealias X = Struct1<Pub & Bar>
 _ = Struct1<Pub & Bar>.self
 
 typealias AliasWhere<T> = T
-where T : HasAssoc, T.Assoc == HasAssoc // expected-warning {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}
+where T : HasAssoc, T.Assoc == HasAssoc // expected-error {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}
 
 struct StructWhere<T>
 where T : HasAssoc,
       T.Assoc == any HasAssoc {}
 
-protocol ProtocolWhere where T == HasAssoc { // expected-warning {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}
+protocol ProtocolWhere where T == HasAssoc { // expected-error {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}
   associatedtype T
 
   associatedtype U : HasAssoc
     where U.Assoc == any HasAssoc
 }
 
-extension HasAssoc where Assoc == HasAssoc {} // expected-warning {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}
+extension HasAssoc where Assoc == HasAssoc {} // expected-error {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}
 
 func FunctionWhere<T>(_: T)
 where T : HasAssoc,


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/42558

* **Explanation**: This diagnostic for requiring `any` on existential types with `Self` or associated type requirements has already been staged in as a warning. Upgrade the warning to an error, per the [SE-0335 proposal](https://github.com/apple/swift-evolution/blob/main/proposals/0335-existential-any.md#source-compatibility).
* **Scope**: This change only affects code using SE-0309 without the `any` keyword.
* **Risk**: Low; SE-0309 is a new feature in Swift 5.7.
* **Testing**: Updated warnings to errors throughout the test suite.
* **Reviewer**: @xedin

Resolves: rdar://92122082