### PR TITLE
Make sure we don't provide duplicate synthesized conformance table entries

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1051,13 +1051,6 @@ static bool shouldCreateMissingConformances(Type type, ProtocolDecl *proto) {
     return true;
   }
 
-  // A 'distributed actor' may have to create missing Codable conformances.
-  if (auto nominal = dyn_cast_or_null<ClassDecl>(type->getAnyNominal())) {
-    return nominal->isDistributedActor() &&
-           (proto->isSpecificProtocol(swift::KnownProtocolKind::Decodable) ||
-            proto->isSpecificProtocol(swift::KnownProtocolKind::Encodable));
-  }
-
   return false;
 }
 

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -1532,8 +1532,16 @@ IterableDeclContext::getLocalConformances(ConformanceLookupKind lookupKind)
       // Look for a Sendable conformance globally. If it is synthesized
       // and matches this declaration context, use it.
       auto dc = getAsGenericContext();
+
+      SmallPtrSet<ProtocolConformance *, 4> known;
       for (auto conformance : findSynthesizedConformances(dc)) {
-        result.push_back(conformance);
+        // Compute the known set of conformances for the first time.
+        if (known.empty()) {
+          known.insert(result.begin(), result.end());
+        }
+
+        if (known.insert(conformance).second)
+          result.push_back(conformance);
       }
       break;
     }

--- a/test/Distributed/distributed_actor_layout.swift
+++ b/test/Distributed/distributed_actor_layout.swift
@@ -17,8 +17,18 @@ class MyClass { }
 // Ensure that the actor layout is (metadata pointer, default actor, id, system,
 // <user fields>)
 
+protocol HasActorSystem {
+  var actorSystem: FakeActorSystem { get }
+}
+
+extension MyActor: HasActorSystem { }
+
 // CHECK: %T27distributed_actor_accessors7MyActorC = type <{ %swift.refcounted, %swift.defaultactor, %T27FakeDistributedActorSystems0C7AddressV, %T27FakeDistributedActorSystems0aC6SystemV, %T27distributed_actor_accessors7MyClassC* }>
 @available(SwiftStdlib 5.7, *)
 public distributed actor MyActor {
   var field: MyClass = MyClass()
+
+  init(actorSystem: FakeActorSystem) {
+    self.actorSystem = actorSystem
+  }
 }


### PR DESCRIPTION
This was benign with `Sendable`, but is not benign for the `Encodable`
and `Decodable` synthesis for distributed actors, which results in a
crash in TBD generation.

Fixes rdar://92008955.
