### PR TITLE
[TypeChecker] NFC: Remove a literal to make test-case less flaky

### DIFF
--- a/validation-test/Sema/type_checker_perf/fast/multi_statement_closure_with_simd_variable.swift
+++ b/validation-test/Sema/type_checker_perf/fast/multi_statement_closure_with_simd_variable.swift
@@ -16,6 +16,6 @@ test {
 
   let width: Float = 2
 
-  let p = Int(max(20, min(1000, (simd_distance(a, b) + simd_distance(b, c) + simd_distance(c, d)) / width / 4)))
+  let p = Int(max(20, min(1000, (simd_distance(a, b) + simd_distance(b, c) + simd_distance(c, d)) / width)))
   print(p)
 }


### PR DESCRIPTION
Multi-statement closure + simd perf test-case still (albeit very
rarely) fails, so let's remove `/ 4` in attempt to prevent that
happening.

Resolves: rdar://92025732

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
