### PR TITLE
Prepare to (but does not) enable string processing by default.

### DIFF
--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -422,10 +422,6 @@ def disable_implicit_concurrency_module_import : Flag<["-"],
   "disable-implicit-concurrency-module-import">,
   HelpText<"Disable the implicit import of the _Concurrency module.">;
 
-def disable_implicit_distributed_module_import : Flag<["-"],
-  "disable-implicit-distributed-module-import">,
-  HelpText<"Disable the implicit import of the Distributed module.">;
-
 def disable_implicit_string_processing_module_import : Flag<["-"],
   "disable-implicit-string-processing-module-import">,
   HelpText<"Disable the implicit import of the _StringProcessing module.">;

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -794,7 +794,9 @@ bool CompilerInvocation::shouldImportSwiftConcurrency() const {
 
 bool CompilerInvocation::shouldImportSwiftStringProcessing() const {
   return getLangOptions().EnableExperimentalStringProcessing &&
-      !getLangOptions().DisableImplicitStringProcessingModuleImport;
+      !getLangOptions().DisableImplicitStringProcessingModuleImport &&
+      getFrontendOptions().InputMode !=
+        FrontendOptions::ParseInputMode::SwiftModuleInterface;
 }
 
 /// Implicitly import the SwiftOnoneSupport module in non-optimized

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -1760,6 +1760,12 @@ function(add_swift_target_library name)
                       "-Xfrontend;-disable-implicit-distributed-module-import")
   endif()
 
+  # Turn off implicit import of _StringProcessing when building libraries
+  if(SWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING)
+    list(APPEND SWIFTLIB_SWIFT_COMPILE_FLAGS
+                      "-Xfrontend;-disable-implicit-string-processing-module-import")
+  endif()
+
   if(SWIFTLIB_IS_STDLIB AND SWIFT_STDLIB_ENABLE_PRESPECIALIZATION)
     list(APPEND SWIFTLIB_SWIFT_COMPILE_FLAGS "-Xfrontend;-prespecialize-generic-metadata")
   endif()

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -1754,12 +1754,6 @@ function(add_swift_target_library name)
   # Turn off implicit import of _Concurrency when building libraries
   list(APPEND SWIFTLIB_SWIFT_COMPILE_FLAGS "-Xfrontend;-disable-implicit-concurrency-module-import")
 
-  # Turn off implicit import of Distributed when building libraries
-  if(SWIFT_ENABLE_EXPERIMENTAL_DISTRIBUTED)
-    list(APPEND SWIFTLIB_SWIFT_COMPILE_FLAGS
-                      "-Xfrontend;-disable-implicit-distributed-module-import")
-  endif()
-
   # Turn off implicit import of _StringProcessing when building libraries
   if(SWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING)
     list(APPEND SWIFTLIB_SWIFT_COMPILE_FLAGS


### PR DESCRIPTION
This is some groundwork to make it possible to flip the `-enable-experimental-string-processing` flag on by default if and when it passes Swift Evolution. This PR itself do **not** change the defaults.

- Do not implicitly import _StringProcessing when building a module interface.
- Do not implicitly import _StringProcessing when core libraries, same as _Concurrency.

This PR also removes `-disable-implicit-distributed-module-import` (7244f78). because Distributed is never implicitly imported.