### PR TITLE
🍒[5.7][Distributed] SILGen must consistently use prop get requests

### DIFF
--- a/lib/SILGen/SILGenDistributed.cpp
+++ b/lib/SILGen/SILGenDistributed.cpp
@@ -38,21 +38,6 @@ using namespace Lowering;
 
 // MARK: utility functions
 
-/// Obtain a nominal type's member by name, as a VarDecl.
-/// \returns nullptr if the name lookup doesn't resolve to exactly one member,
-///          or the subsequent cast to VarDecl failed.
-static VarDecl* lookupProperty(NominalTypeDecl *decl, DeclName name) {
-  assert(decl && "decl was null");
-  if (auto clazz = dyn_cast<ClassDecl>(decl)) {
-    auto refs = decl->lookupDirect(name);
-    if (refs.size() != 1)
-      return nullptr;
-    return dyn_cast<VarDecl>(refs.front());
-  }
-  
-  return nullptr;
-}
-
 /// Emit a reference to a specific stored property of the actor.
 static SILValue emitActorPropertyReference(
     SILGenFunction &SGF, SILLocation loc, SILValue actorSelf,
@@ -186,7 +171,7 @@ static void emitActorSystemInit(SILGenFunction &SGF,
   // By construction, automatically generated distributed actor ctors have
   // exactly one ActorSystem-conforming argument to the constructor,
   // so we grab the first one from the params.
-  VarDecl *var = lookupProperty(classDecl, C.Id_actorSystem);
+  VarDecl *var = classDecl->getDistributedActorSystemProperty();
   assert(var);
       
   initializeProperty(SGF, loc, actorSelf.getValue(), var, systemValue);
@@ -219,7 +204,7 @@ void SILGenFunction::emitDistActorIdentityInit(ConstructorDecl *ctor,
 
   // --- create a temporary storage for the result of the call
   // it will be deallocated automatically as we exit this scope
-  VarDecl *var = lookupProperty(classDecl, C.Id_id);
+  VarDecl *var = classDecl->getDistributedActorIDProperty();
   auto resultTy = getLoweredType(F.mapTypeIntoContext(var->getInterfaceType()));
   auto temp = emitTemporaryAllocation(loc, resultTy);
 
@@ -332,7 +317,7 @@ void SILGenFunction::emitDistributedActorReady(
   ManagedValue actorSystem;
   SGFContext sgfCxt;
   {
-    VarDecl *property = lookupProperty(classDecl, C.Id_actorSystem);
+    VarDecl *property = classDecl->getDistributedActorSystemProperty();
     Type formalType = F.mapTypeIntoContext(property->getInterfaceType());
     SILType loweredType = getLoweredType(formalType).getAddressType();
     SILValue actorSystemRef = emitActorPropertyReference(
@@ -466,11 +451,11 @@ void SILGenFunction::emitDistributedActorFactory(FuncDecl *fd) { // TODO(distrib
     auto classDecl = dc->getSelfClassDecl();
     
     initializeProperty(*this, loc, remote,
-                       lookupProperty(classDecl, C.Id_id),
+                       classDecl->getDistributedActorIDProperty(),
                        idArg);
 
     initializeProperty(*this, loc, remote,
-                       lookupProperty(classDecl, C.Id_actorSystem),
+                       classDecl->getDistributedActorSystemProperty(),
                        actorSystemArg);
 
     // ==== Branch to return the fully initialized remote instance
@@ -513,12 +498,12 @@ void SILGenFunction::emitDistributedActorSystemResignIDCall(
 
   // ==== locate: self.id
   auto idRef = emitActorPropertyReference(
-      *this, loc, actorSelf.getValue(), lookupProperty(actorDecl, ctx.Id_id));
+      *this, loc, actorSelf.getValue(), actorDecl->getDistributedActorIDProperty());
 
   // ==== locate: self.actorSystem
   auto systemRef = emitActorPropertyReference(
       *this, loc, actorSelf.getValue(),
-      lookupProperty(actorDecl, ctx.Id_actorSystem));
+      actorDecl->getDistributedActorSystemProperty());
 
   // Perform the call.
   emitDistributedActorSystemWitnessCall(

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -38,6 +38,42 @@ using namespace swift;
 /************************ PROPERTY SYNTHESIS **********************************/
 /******************************************************************************/
 
+static VarDecl*
+lookupDistributedActorProperty(NominalTypeDecl *decl, DeclName name) {
+  assert(decl && "decl was null");
+  auto &C = decl->getASTContext();
+
+  auto clazz = dyn_cast<ClassDecl>(decl);
+  if (!clazz)
+    return nullptr;
+
+  auto refs = decl->lookupDirect(name);
+  if (refs.size() != 1)
+    return nullptr;
+
+  auto var = dyn_cast<VarDecl>(refs.front());
+  if (!var)
+    return nullptr;
+
+  Type expectedType = Type();
+  if (name == C.Id_id) {
+    expectedType = getDistributedActorIDType(decl);
+  } else if (name == C.Id_actorSystem) {
+    expectedType = getDistributedActorSystemType(decl);
+  } else {
+    llvm_unreachable("Unexpected distributed actor property lookup!");
+  }
+  if (!expectedType)
+    return nullptr;
+
+  if (!var->getInterfaceType()->isEqual(expectedType))
+    return nullptr;
+
+  assert(var->isSynthesized() && "Expected compiler synthesized property");
+  return var;
+}
+
+
 // Note: This would be nice to implement in DerivedConformanceDistributedActor,
 // but we can't since those are lazily triggered and an implementation exists
 // for the 'id' property because 'Identifiable.id' has an extension that impls


### PR DESCRIPTION
**Description:** We must consistently use requests to get properties to avoid any potential chance of not looking up a property. This is mostly a cleanup though, did not cause issues in tests BUT it well could cause issues in larger real projects.
**Risk:** Low
**Review by:** @DougGregor @xedin 
**Testing:** CI testing
**Original PR:** https://github.com/apple/swift/pull/42595
**Radar:**  rdar://92162535