### PR TITLE
[Clang importer] Consider attributes on the typedef name for an anonymous tag.

### DIFF
--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -177,8 +177,16 @@ actor MySubclassCheckingSwiftAttributes : ProtocolWithSwiftAttributes {
 
 // Sendable conformance inference for imported types.
 func acceptCV<T: Sendable>(_: T) { }
-func testCV(r: NSRange) {
+
+struct MyStruct: Sendable {
+  var range: NSRange
+  var inner: SendableStructWithNonSendable
+}
+
+@available(SwiftStdlib 5.5, *)
+func testCV(r: NSRange, someStruct: SendableStructWithNonSendable) async {
   acceptCV(r)
+  acceptCV(someStruct)
 }
 
 // Global actor (unsafe) isolation.

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -265,6 +265,11 @@ typedef NSString *NonSendableStringEnum NS_STRING_ENUM NONSENDABLE;
 typedef NSString *SendableStringStruct NS_EXTENSIBLE_STRING_ENUM;
 typedef NSString *NonSendableStringStruct NS_EXTENSIBLE_STRING_ENUM NONSENDABLE;
 
+SENDABLE
+typedef struct {
+  void *ptr;
+} SendableStructWithNonSendable;
+
 ASSUME_NONSENDABLE_END
 
 typedef id ObjectTypedef;


### PR DESCRIPTION
In C, one can provide a typedef name for an anonymous tag declaration in
one shot, e.g.,

    typedef struct {
      double x, y
    } Point;

In this case, there are effectively two declarations at the C level:
the typedef and the struct. The Clang importer was only taking
attributes from the anonymous struct (i.e., the tag) and not from the
typedef. However, any attributes put before the `typedef` should apply
as well... so consider those, too.

For now, only do this for `swift_attr` attributes, because we're
seeing this primarily with `Sendable` annotations. In the future, we
can look to generalizing it, but that could have source-breaking
consequences.

Fixes rdar://91632960.
