### PR TITLE
[CSStep] Abort any binding step when constraint system is 'too complex'

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5450,6 +5450,9 @@ public:
   }
 
   bool getExpressionTooComplex(SmallVectorImpl<Solution> const &solutions) {
+    if (isExpressionAlreadyTooComplex)
+      return true;
+
     size_t solutionMemory = 0;
     for (auto const& s : solutions) {
       solutionMemory += s.getTotalMemory();

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -504,6 +504,11 @@ protected:
 
 public:
   StepResult take(bool prevFailed) override {
+    // Before attempting the next choice, let's check whether the constraint
+    // system is too complex already.
+    if (CS.getExpressionTooComplex(Solutions))
+      return done(/*isSuccess=*/false);
+
     while (auto choice = Producer()) {
       if (shouldSkip(*choice))
         continue;


### PR DESCRIPTION
Previously the "too complex" would be detected by `ComponentStep::take`
but binding steps would still proceed until the producer is exhausted
because it considers failure of the previous resume to be just a failed
choice.


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
