### PR TITLE
Introduce missing Sendable conformances for existential conversions

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5433,7 +5433,7 @@ collectExistentialConformances(Type fromType, Type toType,
   SmallVector<ProtocolConformanceRef, 4> conformances;
   for (auto proto : layout.getProtocols()) {
     conformances.push_back(TypeChecker::containsProtocol(
-        fromType, proto, module));
+        fromType, proto, module, false, /*allowMissing=*/true));
   }
 
   return toType->getASTContext().AllocateCopy(conformances);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -7108,7 +7108,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
   case ConstraintKind::SelfObjectOfProtocol: {
     auto conformance = TypeChecker::containsProtocol(
         type, protocol, DC->getParentModule(),
-        /*skipConditionalRequirements=*/true);
+        /*skipConditionalRequirements=*/true,
+        /*allowMissing=*/true);
     if (conformance) {
       return recordConformance(conformance);
     }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5672,7 +5672,8 @@ void ConformanceChecker::emitDelayedDiags() {
 
 ProtocolConformanceRef
 TypeChecker::containsProtocol(Type T, ProtocolDecl *Proto, ModuleDecl *M,
-                              bool skipConditionalRequirements) {
+                              bool skipConditionalRequirements,
+                              bool allowMissing) {
   // Existential types don't need to conform, i.e., they only need to
   // contain the protocol.
   if (T->isExistentialType()) {
@@ -5694,8 +5695,9 @@ TypeChecker::containsProtocol(Type T, ProtocolDecl *Proto, ModuleDecl *M,
     if (auto superclass = layout.getSuperclass()) {
       auto result =
           (skipConditionalRequirements
-           ? M->lookupConformance(superclass, Proto)
-           : TypeChecker::conformsToProtocol(superclass, Proto, M));
+           ? M->lookupConformance(superclass, Proto, allowMissing)
+           : TypeChecker::conformsToProtocol(
+               superclass, Proto, M, allowMissing));
       if (result) {
         return result;
       }
@@ -5713,13 +5715,22 @@ TypeChecker::containsProtocol(Type T, ProtocolDecl *Proto, ModuleDecl *M,
         return ProtocolConformanceRef(Proto);
     }
 
+    // FIXME: Unify with shouldCreateMissingConformances
+    if (allowMissing &&
+        Proto->isSpecificProtocol(KnownProtocolKind::Sendable)) {
+      return ProtocolConformanceRef(
+          M->getASTContext().getBuiltinConformance(
+            T, Proto, GenericSignature(), { },
+            BuiltinConformanceKind::Missing));
+    }
+
     return ProtocolConformanceRef::forInvalid();
   }
 
   // For non-existential types, this is equivalent to checking conformance.
   return (skipConditionalRequirements
-          ? M->lookupConformance(T, Proto)
-          : TypeChecker::conformsToProtocol(T, Proto, M));
+          ? M->lookupConformance(T, Proto, allowMissing)
+          : TypeChecker::conformsToProtocol(T, Proto, M, allowMissing));
 }
 
 ProtocolConformanceRef

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -791,7 +791,8 @@ Expr *addImplicitLoadExpr(
 /// an empty optional.
 ProtocolConformanceRef containsProtocol(Type T, ProtocolDecl *Proto,
                                         ModuleDecl *M,
-                                        bool skipConditionalRequirements=false);
+                                        bool skipConditionalRequirements=false,
+                                        bool allowMissing=false);
 
 /// Determine whether the given type conforms to the given protocol.
 ///

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -354,7 +354,7 @@ func testSender(
 
   sender.sendAnyArray([sendableObject])
   sender.sendAnyArray([nonSendableObject])
-  // expected-warning@-1 {{conformance of 'NonSendableClass' to 'Sendable' is unavailable; this is an error in Swift 6}}
+  // expected-warning@-1 {{conformance of 'NonSendableClass' to 'Sendable' is unavailable}}
 
   sender.sendGeneric(sendableGeneric)
   // expected-warning@-1{{type 'GenericObject<SendableClass>' does not conform to the 'Sendable' protocol}}

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -4,6 +4,7 @@
 // REQUIRES: concurrency
 import Foundation
 import ObjCConcurrency
+// expected-remark@-1{{add '@preconcurrency' to suppress 'Sendable'-related warnings from module 'ObjCConcurrency'}}
 
 @available(SwiftStdlib 5.5, *)
 @MainActor func onlyOnMainActor() { }
@@ -314,6 +315,7 @@ func check() async {
   _ = await BazFrame(size: 0)
 }
 
+@available(SwiftStdlib 5.5, *)
 func testSender(
   sender: NXSender,
   sendableObject: SendableClass,
@@ -325,7 +327,7 @@ func testSender(
   nonSendableGeneric: GenericObject<SendableClass>,
   ptr: UnsafeMutableRawPointer,
   stringArray: [String]
-) {
+) async {
   sender.sendAny(sendableObject)
   sender.sendAny(nonSendableObject)
   // expected-warning@-1 {{conformance of 'NonSendableClass' to 'Sendable' is unavailable}}
@@ -344,22 +346,22 @@ func testSender(
 
   sender.sendProto(sendableProtos)
   sender.sendProto(nonSendableProtos)
-  // expected-error@-1 {{argument type 'any LabellyProtocol & ObjCClub' does not conform to expected type 'Sendable'}}
-  // FIXME(rdar://89992095): Should be a warning because we're in -warn-concurrency
+  // expected-warning@-1 {{type 'any LabellyProtocol & ObjCClub' does not conform to the 'Sendable' protocol}}
 
   sender.sendProtos(sendableProtos)
   sender.sendProtos(nonSendableProtos)
-  // expected-error@-1 {{argument type 'any LabellyProtocol & ObjCClub' does not conform to expected type 'Sendable'}}
-  // FIXME(rdar://89992095): Should be a warning because we're in -warn-concurrency
+  // expected-warning@-1 {{type 'any LabellyProtocol & ObjCClub' does not conform to the 'Sendable' protocol}}
 
   sender.sendAnyArray([sendableObject])
   sender.sendAnyArray([nonSendableObject])
-  // expected-warning@-1 {{conformance of 'NonSendableClass' to 'Sendable' is unavailable}}
+  // expected-warning@-1 {{conformance of 'NonSendableClass' to 'Sendable' is unavailable; this is an error in Swift 6}}
 
   sender.sendGeneric(sendableGeneric)
+  // expected-warning@-1{{type 'GenericObject<SendableClass>' does not conform to the 'Sendable' protocol}}
+  // FIXME: Shouldn't warn
+
   sender.sendGeneric(nonSendableGeneric)
-  // expected-error@-1 {{argument type 'GenericObject<SendableClass>' does not conform to expected type 'Sendable'}}
-  // FIXME(rdar://89992095): Should be a warning because we're in -warn-concurrency
+  // expected-warning@-1 {{type 'GenericObject<SendableClass>' does not conform to the 'Sendable' protocol}}
 
   sender.sendPtr(ptr)
   sender.sendStringArray(stringArray)

--- a/test/Concurrency/sendable_existentials.swift
+++ b/test/Concurrency/sendable_existentials.swift
@@ -1,0 +1,54 @@
+// RUN: %target-typecheck-verify-swift -strict-concurrency=targeted
+// REQUIRES: concurrency
+// REQUIRES: OS=macosx
+
+@preconcurrency func send(_: Sendable) { }
+func sendOpt(_: Sendable?) { }
+
+enum E {
+  case something(Sendable)
+}
+
+@available(SwiftStdlib 5.1, *)
+func testE(a: Any, aOpt: Any?) async {
+  send(a) // expected-warning{{type 'Any' does not conform to the 'Sendable' protocol}}
+  sendOpt(a) // expected-warning{{type 'Any' does not conform to the 'Sendable' protocol}}
+  sendOpt(aOpt) // expected-warning{{type 'Any' does not conform to the 'Sendable' protocol}}
+
+  let _: E = .something(a) // expected-warning{{type 'Any' does not conform to the 'Sendable' protocol}}
+  _ = E.something(a) // expected-warning{{type 'Any' does not conform to the 'Sendable' protocol}}
+
+  var sendable: Sendable
+  sendable = a // expected-warning{{type 'Any' does not conform to the 'Sendable' protocol}}
+
+  var arrayOfSendable: [Sendable]
+  arrayOfSendable = [a, a] // expected-warning 2{{type 'Any' does not conform to the 'Sendable' protocol}}
+
+  func localFunc() { }
+  sendable = localFunc // expected-warning{{type '() -> ()' does not conform to the 'Sendable' protocol}}
+  // expected-note@-1{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+
+  _ = sendable
+  _ = arrayOfSendable
+}
+
+func testESilently(a: Any, aOpt: Any?) {
+  send(a)
+  sendOpt(a)
+  sendOpt(aOpt)
+
+  let _: E = .something(a)
+  _ = E.something(a)
+
+  var sendable: Sendable
+  sendable = a
+
+  var arrayOfSendable: [Sendable]
+  arrayOfSendable = [a, a]
+
+  func localFunc() { }
+  sendable = localFunc
+
+  _ = sendable
+  _ = arrayOfSendable
+}


### PR DESCRIPTION
When performing conversions to an existential that involves Sendable,
introducing missing conformances as needed to allow the type-check to
succeed and then (later) they'll be diagnosed appropriately.

Fixes rdar://89992095.