### PR TITLE
IRGen: clang-format a header (NFC)

### DIFF
--- a/include/swift/Runtime/RuntimeFnWrappersGen.h
+++ b/include/swift/Runtime/RuntimeFnWrappersGen.h
@@ -17,11 +17,11 @@
 #define SWIFT_RUNTIME_RUNTIMEFNWRAPPERSGEN_H
 
 #include "swift/SIL/RuntimeEffect.h"
-#include "llvm/IR/Module.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/IR/Module.h"
 
 namespace swift {
-  
+
 class AvailabilityContext;
 class ASTContext;
 
@@ -34,14 +34,12 @@ enum class RuntimeAvailability {
 /// Generate an llvm declaration for a runtime entry with a
 /// given name, return types, argument types, attributes and
 /// a calling convention.
-llvm::Constant *getRuntimeFn(llvm::Module &Module,
-                      llvm::Constant *&cache,
-                      char const *name,
-                      llvm::CallingConv::ID cc,
-                      RuntimeAvailability availability,
-                      llvm::ArrayRef<llvm::Type*> retTypes,
-                      llvm::ArrayRef<llvm::Type*> argTypes,
-                      llvm::ArrayRef<llvm::Attribute::AttrKind> attrs);
+llvm::Constant *getRuntimeFn(llvm::Module &Module, llvm::Constant *&cache,
+                             char const *name, llvm::CallingConv::ID cc,
+                             RuntimeAvailability availability,
+                             llvm::ArrayRef<llvm::Type *> retTypes,
+                             llvm::ArrayRef<llvm::Type *> argTypes,
+                             llvm::ArrayRef<llvm::Attribute::AttrKind> attrs);
 
-} /* Namespace swift */
+} // namespace swift
 #endif


### PR DESCRIPTION
This simply clang-formats a header to reflow the parameters, remove
bleeding whitespace, sort headers, and normalize the end of namespace
marker.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
