### PR TITLE
Spelling include

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -2025,7 +2025,7 @@ using ExtendedExistentialTypeShape
 /// existential shape.
 ///
 /// We'd like to use BLAKE3 for this, but pending acceptance of
-/// that into LLVM, we're using SHA-256.  We simply truncaate the
+/// that into LLVM, we're using SHA-256.  We simply truncate the
 /// hash to the desired length.
 struct UniqueHash {
   static_assert(NumBytes_UniqueHash % sizeof(uint32_t) == 0,

--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -3541,7 +3541,7 @@ public:
     return getTypeContextDescriptorFlags().hasSingletonMetadataInitialization();
   }
 
-  /// Does this type have "foreign" metadata initialiation?
+  /// Does this type have "foreign" metadata initialization?
   bool hasForeignMetadataInitialization() const {
     return getTypeContextDescriptorFlags().hasForeignMetadataInitialization();
   }

--- a/include/swift/ABI/ObjectFile.h
+++ b/include/swift/ABI/ObjectFile.h
@@ -29,7 +29,7 @@ public:
     return {};
   }
   /// Get the name of the segment in the symbol rich binary that may contain
-  /// Swift meteadata.
+  /// Swift metadata.
   virtual llvm::Optional<llvm::StringRef> getSymbolRichSegmentName() {
     return {};
   }

--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -563,7 +563,7 @@ public:
   /// \c Executing, then \c waitingTask has been added to the
   /// wait queue and will be scheduled when the future completes. Otherwise,
   /// the future has completed and can be queried.
-  /// The waiting task's async context will be intialized with the parameters if
+  /// The waiting task's async context will be initialized with the parameters if
   /// the current's task state is executing.
   FutureFragment::Status waitFuture(AsyncTask *waitingTask,
                                     AsyncContext *waitingTaskContext,

--- a/include/swift/ABI/TrailingObjects.h
+++ b/include/swift/ABI/TrailingObjects.h
@@ -46,7 +46,7 @@
 /// determine the size needed for allocation via
 /// 'additionalSizeToAlloc' and 'totalSizeToAlloc'.
 ///
-/// All the methods implemented by this class are are intended for use
+/// All the methods implemented by this class are intended for use
 /// by the implementation of the class, not as part of its interface
 /// (thus, private inheritance is suggested).
 ///

--- a/include/swift/Migrator/FixitFilter.h
+++ b/include/swift/Migrator/FixitFilter.h
@@ -67,7 +67,7 @@ struct FixitFilter {
     // due to the extension rename not having been applied. The below diag(s)
     // can provide undesireable fixits that rename references of these
     // no-longer-visible members to similar still-visible ones.
-    // Note: missing_argument_lables and extra_argument_labels are filtered out
+    // Note: missing_argument_labels and extra_argument_labels are filtered out
     // elsewhere
     if (Info.ID == diag::wrong_argument_labels.ID)
       return false;

--- a/include/swift/Migrator/FixitFilter.h
+++ b/include/swift/Migrator/FixitFilter.h
@@ -65,7 +65,7 @@ struct FixitFilter {
     // primary file, so if a nominal type was renamed, for example, any members
     // users have added in an extension in a separate file may not be visible,
     // due to the extension rename not having been applied. The below diag(s)
-    // can provide undesireable fixits that rename references of these
+    // can provide undesirable fixits that rename references of these
     // no-longer-visible members to similar still-visible ones.
     // Note: missing_argument_labels and extra_argument_labels are filtered out
     // elsewhere

--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -1378,7 +1378,7 @@ public:
 
     // The Fields section has gathered info on types that includes their mangled
     // names. Use that to build a dictionary from a type's demangled name to its
-    // mangeled name
+    // mangled name
     std::unordered_map<std::string, std::string> typeNameToManglingMap;
     for (const auto &section : ReflectionInfos) {
       for (auto descriptor : section.Field) {

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -653,7 +653,7 @@ public:
         isBridged);
   }
 
-  /// Given a known-opaque existential, attemp to discover the pointer to its
+  /// Given a known-opaque existential, attempt to discover the pointer to its
   /// metadata address and its value.
   llvm::Optional<RemoteExistential>
   readMetadataAndValueOpaqueExistential(RemoteAddress ExistentialAddress) {

--- a/include/swift/Runtime/AccessibleFunction.h
+++ b/include/swift/Runtime/AccessibleFunction.h
@@ -1,4 +1,4 @@
-//===---- AcceesibleFunction.h - Runtime accessible functions ---*- C++ -*-===//
+//===---- AccessibleFunction.h - Runtime accessible functions ---*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/Runtime/Atomic.h
+++ b/include/swift/Runtime/Atomic.h
@@ -234,7 +234,7 @@ public:
 } // end namespace swift::impl
 
 /// A simple wrapper for std::atomic that provides the most important
-/// interfaces and fixes the API bug where all of the orderings dafault
+/// interfaces and fixes the API bug where all of the orderings default
 /// to sequentially-consistent.
 ///
 /// It also sometimes uses a different implementation in cases where

--- a/include/swift/Runtime/AtomicWaitQueue.h
+++ b/include/swift/Runtime/AtomicWaitQueue.h
@@ -76,7 +76,7 @@ class AtomicWaitQueue {
   Mutex WaitQueueLock;
 
   /// Add a reference to this queue.  Must be called while holding the
-  /// globaal lock.
+  /// global lock.
   void retain_locked() {
     referenceCount++;
   }

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -216,7 +216,7 @@ void swift_taskGroup_destroy(TaskGroup *group);
 /// more 'pending' child to account for.
 ///
 /// This function SHOULD be called from the AsyncTask running the task group,
-/// however is generally thread-safe as it only only works with the group status.
+/// however is generally thread-safe as it only works with the group status.
 ///
 /// Its Swift signature is
 ///

--- a/include/swift/Runtime/Debug.h
+++ b/include/swift/Runtime/Debug.h
@@ -183,7 +183,7 @@ struct RuntimeErrorDetails {
   const char *currentStackDescription;
 
   // Number of frames in the current stack that should be ignored when reporting
-  // the issue (exluding the reportToDebugger/_swift_runtime_on_report frame).
+  // the issue (excluding the reportToDebugger/_swift_runtime_on_report frame).
   // The remaining top frame should point to user's code where the bug is.
   uintptr_t framesToSkip;
 

--- a/include/swift/Runtime/Enum.h
+++ b/include/swift/Runtime/Enum.h
@@ -59,7 +59,7 @@ void swift_initEnumMetadataSinglePayload(EnumMetadata *enumType,
                                          unsigned emptyCases);
 
 using getExtraInhabitantTag_t =
-  SWIFT_CC(swift) unsigned (const OpaqueValue *vaue,
+  SWIFT_CC(swift) unsigned (const OpaqueValue *value,
                             unsigned numExtraInhabitants,
                             const Metadata *payloadType);
 

--- a/include/swift/Runtime/Enum.h
+++ b/include/swift/Runtime/Enum.h
@@ -130,7 +130,7 @@ void swift_storeEnumTagMultiPayload(OpaqueValue *value,
                                     unsigned whichCase);
 
 /// The unspecialized getEnumTagSinglePayload value witness to be used by the
-/// VWTs for for specialized generic enums that are multi-payload.
+/// VWTs for specialized generic enums that are multi-payload.
 ///
 /// Runtime availability: Swift 5.6
 SWIFT_RUNTIME_EXPORT
@@ -139,7 +139,7 @@ unsigned swift_getMultiPayloadEnumTagSinglePayload(const OpaqueValue *value,
                                                    const Metadata *enumType);
 
 /// The unspecialized storeEnumTagSinglePayload value witness to be used by the
-/// VWTs for for specialized generic enums that are multi-payload.
+/// VWTs for specialized generic enums that are multi-payload.
 ///
 /// Runtime availability: Swift 5.6
 SWIFT_RUNTIME_EXPORT

--- a/include/swift/Runtime/Exclusivity.h
+++ b/include/swift/Runtime/Exclusivity.h
@@ -73,7 +73,7 @@ void swift_dumpTrackedAccesses();
 #endif
 
 // When building the concurrency library for back deployment, we rename these
-// symbols unformly so they don't conflict with the real concurrency library.
+// symbols uniformly so they don't conflict with the real concurrency library.
 #ifdef SWIFT_CONCURRENCY_BACK_DEPLOYMENT
 #  define swift_task_enterThreadLocalContext swift_task_enterThreadLocalContextBackDeploy
 #  define swift_task_exitThreadLocalContext swift_task_exitThreadLocalContextBackDeploy

--- a/include/swift/Runtime/Heap.h
+++ b/include/swift/Runtime/Heap.h
@@ -29,7 +29,7 @@
 namespace swift {
 namespace {
 // This is C++17 and newer, so we simply re-define it.  Since the codebase is
-// C++14, asume that DR1558 is accounted for and that unused parameters in alias
+// C++14, assume that DR1558 is accounted for and that unused parameters in alias
 // templates are guaranteed to ensure SFINAE and are not ignored.
 template <typename ...>
 using void_t = void;

--- a/include/swift/Runtime/Heap.h
+++ b/include/swift/Runtime/Heap.h
@@ -91,7 +91,7 @@ struct aligned_alloc<Alignment_, true> {
 
 #if defined(_WIN32)
   // FIXME: why is this even needed?  This is not permitted as per the C++
-  // standrd new.delete.placement (§17.6.3.4).
+  // standard new.delete.placement (§17.6.3.4).
   [[nodiscard]] void *operator new(std::size_t size, void *where) noexcept {
     return ::operator new(size, where);
   }

--- a/include/swift/Runtime/HeapObject.h
+++ b/include/swift/Runtime/HeapObject.h
@@ -302,7 +302,7 @@ bool swift_isUniquelyReferenced_nonNull_native(const struct HeapObject *);
 /// \p type: 0 - withoutActuallyEscaping verification
 ///              Was the closure passed to a withoutActuallyEscaping block
 ///              escaped in the block?
-///          1 - @objc closure sentinel verfication
+///          1 - @objc closure sentinel verification
 ///              Was the closure passed to Objective-C escaped?
 SWIFT_RUNTIME_EXPORT
 bool swift_isEscapingClosureAtFileLocation(const struct HeapObject *object,

--- a/include/swift/Runtime/SwiftDtoa.h
+++ b/include/swift/Runtime/SwiftDtoa.h
@@ -196,7 +196,7 @@ extern "C" {
 // * `d` is the number to be formatted
 // * `dest` is a buffer of length `length`
 //
-// Ouput:
+// Output:
 // * Return value is the length of the string placed into `dest`
 //   or zero if the buffer is too small.
 // * For infinity, it copies "inf" or "-inf".

--- a/include/swift/Strings.h
+++ b/include/swift/Strings.h
@@ -61,7 +61,7 @@ constexpr static const StringLiteral DEFAULT_ACTOR_STORAGE_FIELD_NAME =
 constexpr static const StringLiteral BUILTIN_TYPE_NAME_PREFIX = "Builtin.";
 
 /// The default SPI group name to associate with Clang SPIs.
-constexpr static const StringLiteral CLANG_MODULE_DEFUALT_SPI_GROUP_NAME =
+constexpr static const StringLiteral CLANG_MODULE_DEFAULT_SPI_GROUP_NAME =
   "OBJC_DEFAULT_SPI_GROUP";
 
 /// The attribute name for @_spi_available

--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
@@ -272,7 +272,7 @@ int swift_reflection_projectExistential(SwiftReflectionContextRef ContextRef,
 /// - When dealing with an error existential, this version will dereference 
 ///   the ExistentialAddress before proceeding.
 /// - After setting OutInstanceTypeRef and OutStartOfInstanceData this version
-///   may derefence and set OutStartOfInstanceData if OutInstanceTypeRef is a 
+///   may dereference and set OutStartOfInstanceData if OutInstanceTypeRef is a 
 ///   class TypeRef.
 SWIFT_REMOTE_MIRROR_LINKAGE
 int swift_reflection_projectExistentialAndUnwrapClass(

--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirrorLegacyInteropTypes.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirrorLegacyInteropTypes.h
@@ -22,7 +22,7 @@
 
 #include "SwiftRemoteMirror.h"
 
-/// The remote representation of a Swift metada pointer as returned by
+/// The remote representation of a Swift metadata pointer as returned by
 /// interop wrappers.
 typedef struct swift_metadata_interop {
   uintptr_t Metadata;

--- a/include/swift/SymbolGraphGen/FragmentInfo.h
+++ b/include/swift/SymbolGraphGen/FragmentInfo.h
@@ -25,7 +25,7 @@ namespace symbolgraphgen {
 struct FragmentInfo {
   /// The swift decl of the referenced symbol.
   const ValueDecl *VD;
-  /// The path components of the refereced symbol.
+  /// The path components of the referenced symbol.
   SmallVector<PathComponent, 4> ParentContexts;
 };
 

--- a/include/swift/Syntax/AbsoluteRawSyntax.h
+++ b/include/swift/Syntax/AbsoluteRawSyntax.h
@@ -129,7 +129,7 @@ public:
   }
 };
 
-/// Represents a node's position in a syntax tree, described by its overal
+/// Represents a node's position in a syntax tree, described by its overall
 /// textual offset and the position within its parent.
 class AbsoluteSyntaxPosition {
 public:

--- a/include/swift/Syntax/AbsoluteRawSyntax.h
+++ b/include/swift/Syntax/AbsoluteRawSyntax.h
@@ -254,7 +254,7 @@ public:
   }
 };
 
-/// A \c RawSyntax node that is enrichted with information of its position
+/// A \c RawSyntax node that is enriched with information of its position
 /// within the syntax tree it lives in.
 class AbsoluteRawSyntax {
   /// OptionalStorage is a friend so it can access the \c nullptr initializer

--- a/include/swift/Syntax/AbsoluteRawSyntax.h
+++ b/include/swift/Syntax/AbsoluteRawSyntax.h
@@ -303,7 +303,7 @@ public:
     return Info;
   }
 
-  /// Get the position at which the leading triva of this node starts.
+  /// Get the position at which the leading trivia of this node starts.
   AbsoluteSyntaxPosition getPosition() const {
     return getInfo().getPosition();
   };

--- a/include/swift/Syntax/AtomicCache.h
+++ b/include/swift/Syntax/AtomicCache.h
@@ -25,7 +25,7 @@ namespace swift {
 template <typename T>
 class AtomicCache {
   // Whatever type is created through this cache must be pointer-sized,
-  // othwerise, we can't pretend it's a uintptr_t and use its
+  // otherwise, we can't pretend it's a uintptr_t and use its
   // compare_exchange_strong.
   static_assert(sizeof(uintptr_t) == sizeof(RC<T>),
                 "RC<T> must be pointer sized!");

--- a/include/swift/Syntax/RawSyntax.h
+++ b/include/swift/Syntax/RawSyntax.h
@@ -26,7 +26,7 @@
 //
 // RawSyntax nodes always live in a SyntaxArena. The user of the RawSyntax nodes
 // is responsible to ensure that the SyntaxArena stays alive while the RawSyntax
-// nodes are being accessed. During tree cration this is done by the
+// nodes are being accessed. During tree creation this is done by the
 // SyntaxTreeCreator holding on to the arena. In lib/Syntax, the root SyntaxData
 // node retains the syntax arena. Should a RawSyntaxNode A reference a node B
 // from a different arena, it automatically adds B's arena as a child arena of

--- a/include/swift/Syntax/RawSyntax.h
+++ b/include/swift/Syntax/RawSyntax.h
@@ -276,7 +276,7 @@ class RawSyntax final
                                         Bits.Token.TrailingTriviaLength);
   }
 
-  /// Compute the node's text length by summing up the length of its childern
+  /// Compute the node's text length by summing up the length of its children
   size_t computeTextLength() {
     size_t TextLength = 0;
     for (size_t I = 0, NumChildren = getNumChildren(); I < NumChildren; ++I) {

--- a/include/swift/Syntax/Serialization/SyntaxDeserialization.h
+++ b/include/swift/Syntax/Serialization/SyntaxDeserialization.h
@@ -112,7 +112,7 @@ struct TokenDescription {
   StringRef Text;
 };
 
-/// Desrialization traits for TokenDescription.
+/// Deserialization traits for TokenDescription.
 /// TokenDescriptions always serialized with a token kind, which is
 /// the stringified version of their name in the tok:: enum.
 /// ```

--- a/include/swift/Syntax/Syntax.h
+++ b/include/swift/Syntax/Syntax.h
@@ -18,7 +18,7 @@
 // There are two versions of the Syntax type.
 // SyntaxRef:
 // SyntaxRef is designed around efficiency. It *does not* retain the
-// SyntaxDataRef that stores its data - the user must gurantee that the
+// SyntaxDataRef that stores its data - the user must guarantee that the
 // SyntaxDataRef outlives the SyntaxRef that references it. Instead,
 // SyntaxDataRef provides a *view* into the SyntaxDataRef and the view provides
 // all convenience APIs. The advantage of this is that the underlying SyntaxData

--- a/include/swift/Syntax/Syntax.h
+++ b/include/swift/Syntax/Syntax.h
@@ -21,7 +21,7 @@
 // SyntaxDataRef that stores its data - the user must gurantee that the
 // SyntaxDataRef outlives the SyntaxRef that references it. Instead,
 // SyntaxDataRef provides a *view* into the SyntaxDataRef and the view provides
-// all convinience APIs. The advantage of this is that the underlying SyntaxData
+// all convenience APIs. The advantage of this is that the underlying SyntaxData
 // can be stack-allocated and does not need to be copied when the the SyntaxRef
 // is being passsed around or when the SyntaxRef is being casted.
 //

--- a/include/swift/Syntax/Syntax.h
+++ b/include/swift/Syntax/Syntax.h
@@ -310,7 +310,7 @@ public:
     return Data->getAbsolutePositionBeforeLeadingTrivia();
   }
 
-  /// Get the offset at which the actual content (i.e. non-triva) of this node
+  /// Get the offset at which the actual content (i.e. non-trivia) of this node
   /// starts.
   AbsoluteOffsetPosition getAbsolutePositionAfterLeadingTrivia() const {
     return Data->getAbsolutePositionAfterLeadingTrivia();
@@ -405,7 +405,7 @@ public:
     return getDataRef()->getAbsolutePositionBeforeLeadingTrivia();
   }
 
-  /// Get the offset at which the actual content (i.e. non-triva) of this node
+  /// Get the offset at which the actual content (i.e. non-trivia) of this node
   /// starts.
   AbsoluteOffsetPosition getAbsolutePositionAfterLeadingTrivia() const {
     return getDataRef()->getAbsolutePositionAfterLeadingTrivia();

--- a/include/swift/Syntax/Syntax.h
+++ b/include/swift/Syntax/Syntax.h
@@ -33,7 +33,7 @@
 //
 // Note that the two access modes can also be mixed. When a syntax tree is
 // accessed by Syntax (memory-safe) nodes, they can be demoted to SyntaxRef
-// nodes to perform perfomance-critical tasks.
+// nodes to perform performance-critical tasks.
 //===----------------------------------------------------------------------===//
 
 #ifndef SWIFT_SYNTAX_SYNTAX_H

--- a/include/swift/Syntax/Syntax.h
+++ b/include/swift/Syntax/Syntax.h
@@ -23,7 +23,7 @@
 // SyntaxDataRef provides a *view* into the SyntaxDataRef and the view provides
 // all convenience APIs. The advantage of this is that the underlying SyntaxData
 // can be stack-allocated and does not need to be copied when the the SyntaxRef
-// is being passsed around or when the SyntaxRef is being casted.
+// is being passed around or when the SyntaxRef is being casted.
 //
 // Syntax:
 // The syntax nodes are designed for memory safety. Syntax nodes always retain

--- a/include/swift/Syntax/Syntax.h
+++ b/include/swift/Syntax/Syntax.h
@@ -98,7 +98,7 @@ class OwnedSyntaxRef {
   SyntaxRefType Ref;
 
 public:
-  /// Create an *uninintialized* \c OwnedSyntaxRef. Its storage needs to be
+  /// Create an *unininitialized* \c OwnedSyntaxRef. Its storage needs to be
   /// initialised by writing a \c SyntaxDataRef to the pointer returned by
   /// \c getDataPtr()
   /// Implementation Note: We need to initialise \c Ref without validation,

--- a/include/swift/Syntax/Syntax.h
+++ b/include/swift/Syntax/Syntax.h
@@ -98,7 +98,7 @@ class OwnedSyntaxRef {
   SyntaxRefType Ref;
 
 public:
-  /// Create an *unininitialized* \c OwnedSyntaxRef. Its storage needs to be
+  /// Create an *uninitialized* \c OwnedSyntaxRef. Its storage needs to be
   /// initialised by writing a \c SyntaxDataRef to the pointer returned by
   /// \c getDataPtr()
   /// Implementation Note: We need to initialise \c Ref without validation,

--- a/include/swift/Syntax/SyntaxData.h
+++ b/include/swift/Syntax/SyntaxData.h
@@ -76,7 +76,7 @@ protected:
   /// RawSyntax's \c SyntaxArena outlives this \c SyntaxDataRef.
   ///
   /// In \c SyntaxData, the backing \c SyntaxArena is retained via the \c Arena
-  /// property, lifiting the responsibility to guarantee the \c RawSyntax node
+  /// property, lifting the responsibility to guarantee the \c RawSyntax node
   /// stays alive from the user.
   AbsoluteRawSyntax AbsoluteRaw;
 

--- a/include/swift/Syntax/SyntaxFactory.h.gyb
+++ b/include/swift/Syntax/SyntaxFactory.h.gyb
@@ -60,7 +60,7 @@ public:
   );
 
   /// Count the number of children for a given syntax node kind,
-  /// returning a pair of mininum and maximum count of children. The gap
+  /// returning a pair of minimum and maximum count of children. The gap
   /// between these two numbers is the number of optional children.
   static std::pair<unsigned, unsigned> countChildren(SyntaxKind Kind);
 

--- a/include/swift/TBDGen/TBDGen.h
+++ b/include/swift/TBDGen/TBDGen.h
@@ -71,7 +71,7 @@ struct TBDGenOptions {
   /// For these modules, TBD gen should embed their symbols in the emitted tbd
   /// file.
   /// Typically, these modules are static linked libraries. Thus their symbols
-  /// are embeded in the current dylib.
+  /// are embedded in the current dylib.
   std::vector<std::string> embedSymbolsFromModules;
 
   friend bool operator==(const TBDGenOptions &lhs, const TBDGenOptions &rhs) {


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fixes some misspellings in Swift include, it is split per https://github.com/apple/swift/pull/42421#issuecomment-1101092698


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
