### PR TITLE
[Driver] More robust tool searching logic

### DIFF
--- a/lib/DriverTool/driver.cpp
+++ b/lib/DriverTool/driver.cpp
@@ -32,6 +32,7 @@
 #include "swift/FrontendTool/FrontendTool.h"
 #include "swift/DriverTool/DriverTool.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/Triple.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/ConvertUTF.h"
 #include "llvm/Support/Errno.h"
@@ -168,12 +169,13 @@ static bool appendSwiftDriverName(SmallString<256> &buffer) {
     return true;
   }
 
-  llvm::sys::path::append(buffer, "swift-driver");
+  StringRef execSuffix(llvm::Triple(llvm::sys::getProcessTriple()).isOSWindows() ? ".exe" : "");
+  llvm::sys::path::append(buffer, "swift-driver" + execSuffix);
   if (llvm::sys::fs::exists(buffer)) {
     return true;
   }
   llvm::sys::path::remove_filename(buffer);
-  llvm::sys::path::append(buffer, "swift-driver-new");
+  llvm::sys::path::append(buffer, "swift-driver-new" + execSuffix);
   if (llvm::sys::fs::exists(buffer)) {
     return true;
   }


### PR DESCRIPTION
<!-- What's in this pull request? -->
- Fix searching for Swift Driver on Windows;
- Search subcommand with `llvm::sys::findProgramByName`;
- Change fallback subcommand path to its name.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
