### PR TITLE
Use Python 3

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -340,7 +340,7 @@ function with_pushd() {
 }
 
 function quoted_print() {
-    python -c 'import pipes; import sys; print(" ".join(pipes.quote(arg) for arg in sys.argv[1:]))' "$@"
+    python3 -c 'import pipes; import sys; print(" ".join(pipes.quote(arg) for arg in sys.argv[1:]))' "$@"
 }
 
 function toupper() {


### PR DESCRIPTION
<!-- What's in this pull request? -->
As part of PR  #42086, we already started using python3, But this change is missing.

Currently, it will give the below message while building swift, With this change, it will fix this issue
`swift-project/swift/utils/build-script-impl: line 343: python: command not found`
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
