### PR TITLE
stdlib: correct `CLong` for Windows ARM64

### DIFF
--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -47,7 +47,7 @@ public typealias CShort = Int16
 public typealias CInt = Int32
 
 /// The C 'long' type.
-#if os(Windows) && arch(x86_64)
+#if os(Windows) && (arch(x86_64) || arch(arm64))
 public typealias CLong = Int32
 #else
 public typealias CLong = Int


### PR DESCRIPTION
The Windows ARM64 build with the toolchain fixes exposed the missed type
aliasing for `CLong` when building Foundation.  With this it is finally
possible to build a complete SDK for Windows AArch64.