### PR TITLE
[docs][RequirementMachine] Change document class of research paper

### DIFF
--- a/docs/RequirementMachine/RequirementMachine.tex
+++ b/docs/RequirementMachine/RequirementMachine.tex
@@ -10,7 +10,7 @@
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\documentclass[headsepline,bibliography=totoc]{scrreport}
+\documentclass[headsepline,bibliography=totoc]{scrreprt}
 
 \usepackage{imakeidx}
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
I was compiling the RequirementMachine research paper on Papeeria.com because I have a slow internet connection and can't download the 4 GB TeX toolchain. It showed an error that `scrreport.cls` was not found. When I looked up the error on Google, I only saw instances of `scrreprt`, which is extremely close in spelling. After changing the class name, it subsequently compiled.

I request that @slavapestov be the person to review this PR.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
