### PR TITLE
[NewPM] Start porting Swift specific LLVM passes to New Pass Manager

### DIFF
--- a/include/swift/LLVMPasses/Passes.h
+++ b/include/swift/LLVMPasses/Passes.h
@@ -102,6 +102,23 @@ namespace swift {
     static char ID;
     InlineTreePrinter() : llvm::ModulePass(ID) {}
   };
+
+  struct SwiftMergeFunctionsPass
+      : public llvm::PassInfoMixin<SwiftMergeFunctionsPass> {
+
+    bool ptrAuthOptionsSet = false;
+    bool ptrAuthEnabled = false;
+    unsigned ptrAuthKey = 0;
+
+    SwiftMergeFunctionsPass() {}
+    SwiftMergeFunctionsPass(bool ptrAuthEnabled, unsigned ptrAuthKey)
+        : ptrAuthOptionsSet(true), ptrAuthEnabled(ptrAuthEnabled),
+          ptrAuthKey(ptrAuthKey) {}
+
+    llvm::PreservedAnalyses run(llvm::Module &M,
+                                llvm::ModuleAnalysisManager &AM);
+  };
+
 } // end namespace swift
 
 #endif

--- a/include/swift/LLVMPasses/PassesFwd.h
+++ b/include/swift/LLVMPasses/PassesFwd.h
@@ -24,7 +24,7 @@ namespace llvm {
   void initializeSwiftARCOptPass(PassRegistry &);
   void initializeSwiftARCContractPass(PassRegistry &);
   void initializeInlineTreePrinterPass(PassRegistry &);
-  void initializeSwiftMergeFunctionsPass(PassRegistry &);
+  void initializeSwiftMergeFunctionsLegacyPassPass(PassRegistry &);
   void initializeSwiftDbgAddrBlockSplitterPass(PassRegistry &);
 }
 
@@ -32,8 +32,8 @@ namespace swift {
   llvm::FunctionPass *createSwiftARCOptPass();
   llvm::FunctionPass *createSwiftARCContractPass();
   llvm::ModulePass *createInlineTreePrinterPass();
-  llvm::ModulePass *createSwiftMergeFunctionsPass(bool ptrAuthEnabled,
-                                                  unsigned ptrAuthKey);
+  llvm::ModulePass *createSwiftMergeFunctionsLegacyPass(bool ptrAuthEnabled,
+                                                        unsigned ptrAuthKey);
   llvm::FunctionPass *createSwiftDbgAddrBlockSplitter();
   llvm::ImmutablePass *createSwiftAAWrapperPass();
   llvm::ImmutablePass *createSwiftRCIdentityPass();

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -35,6 +35,7 @@ namespace llvm {
   class Module;
   class TargetOptions;
   class TargetMachine;
+  class PassBuilder;
 }
 
 namespace swift {
@@ -232,6 +233,10 @@ namespace swift {
                       StringRef ModuleName, const PrimarySpecificPaths &PSPs,
                       StringRef PrivateDiscriminator,
                       llvm::GlobalVariable **outModuleHash = nullptr);
+
+  /// Register pipeline parsing callbacks, which add Swift specific LLVM passes
+  /// for the given pass builder instance.
+  void registerLLVMPipelineParsingCallback(llvm::PassBuilder &PB);
 
   /// Given an already created LLVM module, construct a pass pipeline and run
   /// the Swift LLVM Pipeline upon it. This does not cause the module to be

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -14,7 +14,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#define DEBUG_TYPE "irgen"
 #include "IRGenModule.h"
 #include "swift/ABI/MetadataValues.h"
 #include "swift/AST/DiagnosticsIRGen.h"
@@ -65,6 +64,7 @@
 #include "llvm/MC/SubtargetFeature.h"
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Object/ObjectFile.h"
+#include "llvm/Passes/PassBuilder.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -88,6 +88,8 @@
 #if HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+
+#define DEBUG_TYPE "irgen"
 
 using namespace swift;
 using namespace irgen;
@@ -216,6 +218,8 @@ void setModuleFlags(IRGenModule &IGM) {
   }
 }
 
+void swift::registerLLVMPipelineParsingCallback(llvm::PassBuilder &PB) {
+}
 void swift::performLLVMOptimizations(const IRGenOptions &Opts,
                                      llvm::Module *Module,
                                      llvm::TargetMachine *TargetMachine) {

--- a/test/LLVMPasses/merge_func.ll
+++ b/test/LLVMPasses/merge_func.ll
@@ -1,4 +1,5 @@
 ; RUN: %swift-llvm-opt -swift-merge-functions -swiftmergefunc-threshold=4 %s | %FileCheck %s
+; RUN: %swift-llvm-opt -enable-new-pm -swift-merge-functions -swiftmergefunc-threshold=4 %s | %FileCheck %s
 
 @g1 = external global i32
 @g2 = external global i32

--- a/test/LLVMPasses/merge_func_coff.ll
+++ b/test/LLVMPasses/merge_func_coff.ll
@@ -1,4 +1,5 @@
 ; RUN: %swift-llvm-opt -mtriple i686-windows -swift-merge-functions -swiftmergefunc-threshold=4 %s | %FileCheck %s
+; RUN: %swift-llvm-opt -enable-new-pm -mtriple i686-windows -swift-merge-functions -swiftmergefunc-threshold=4 %s | %FileCheck %s
 
 @g = external global i32
 

--- a/test/LLVMPasses/merge_func_ptrauth.ll
+++ b/test/LLVMPasses/merge_func_ptrauth.ll
@@ -1,4 +1,5 @@
 ; RUN: %swift-llvm-opt -swift-merge-functions -swiftmergefunc-threshold=4 %s | %FileCheck %s
+; RUN: %swift-llvm-opt -enable-new-pm -swift-merge-functions -swiftmergefunc-threshold=4 %s | %FileCheck %s
 ; REQUIRES: CODEGENERATOR=AArch64
 
 target triple = "arm64e-apple-macosx11.0.0"

--- a/tools/swift-llvm-opt/LLVMOpt.cpp
+++ b/tools/swift-llvm-opt/LLVMOpt.cpp
@@ -288,7 +288,7 @@ int main(int argc, char **argv) {
   initializeSwiftARCOptPass(Registry);
   initializeSwiftARCContractPass(Registry);
   initializeInlineTreePrinterPass(Registry);
-  initializeSwiftMergeFunctionsPass(Registry);
+  initializeSwiftMergeFunctionsLegacyPassPass(Registry);
 
   llvm::cl::ParseCommandLineOptions(argc, argv, "Swift LLVM optimizer\n");
 


### PR DESCRIPTION
LLVM's legacy PM has been deprecated since [13.0.0](https://releases.llvm.org/13.0.0/docs/ReleaseNotes.html#changes-to-the-llvm-ir), and it will be removed in the near future.
Let's move to [New Pass Manager](https://llvm.org/docs/NewPassManager.html)

This is the very first step to enabling our incremental porting of Swift specific LLVM passes and post-IRGen optimization pipeline.

This PR ports `swift-llvm-opt` to enable testing, and also `swift-merge-functions` as a PoC.

This is a part of SR-16122.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
