### PR TITLE
[Distributed] unlock test which used to fail on 32bit watch

### DIFF
--- a/test/Distributed/Runtime/distributed_actor_localSystem.swift
+++ b/test/Distributed/Runtime/distributed_actor_localSystem.swift
@@ -13,9 +13,6 @@
 // rdar://90373022
 // UNSUPPORTED: OS=watchos
 
-// FIXME(distributed): seems to fail also on simulator on x86_64?
-// REQUIRES: rdar90373022
-
 import Distributed
 
 distributed actor Worker {


### PR DESCRIPTION
Resolves rdar://90373022 

This was about a test failure on 32bit simulator but was ages ago and I suspect we fixed many related things since;
Was: Test failure: Swift(watchsimulator-i386) :: Distributed/Runtime/distributed_actor_localSystem.swift