### PR TITLE
Swift SIL: support for sub-pass bisecting: add `PassContext.continueWithNextSubpassRun`

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ReleaseDevirtualizer.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ReleaseDevirtualizer.swift
@@ -43,6 +43,9 @@ let releaseDevirtualizerPass = FunctionPass(
           // these we know that they don't have associated objects, which are
           // _not_ released by the deinit method.
           if let deallocStackRef = instruction as? DeallocStackRefInst {
+            if !context.continueWithNextSubpassRun(for: release) {
+              return
+            }
             tryDevirtualizeReleaseOfObject(context, release, deallocStackRef)
             lastRelease = nil
             continue

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/PassUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/PassUtils.swift
@@ -22,6 +22,11 @@ struct PassContext {
 
   let _bridged: BridgedPassContext
 
+  func continueWithNextSubpassRun(for inst: Instruction? = nil) -> Bool {
+    let bridgedInst = OptionalBridgedInstruction(obj: inst?.bridged.obj)
+    return PassContext_continueWithNextSubpassRun(_bridged, bridgedInst) != 0
+  }
+
   var aliasAnalysis: AliasAnalysis {
     let bridgedAA = PassContext_getAliasAnalysis(_bridged)
     return AliasAnalysis(bridged: bridgedAA)

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -173,6 +173,8 @@ void Function_register(SwiftMetatype metatype,
             FunctionCopyEffectsFn copyEffectsFn,
             FunctionGetEffectFlagsFn hasEffectsFn);
 
+SwiftInt PassContext_continueWithNextSubpassRun(BridgedPassContext passContext,
+                                                OptionalBridgedInstruction inst);
 void PassContext_notifyChanges(BridgedPassContext passContext,
                                enum ChangeNotificationKind changeKind);
 void PassContext_eraseInstruction(BridgedPassContext passContext,

--- a/include/swift/SIL/SILBridgingUtils.h
+++ b/include/swift/SIL/SILBridgingUtils.h
@@ -58,6 +58,12 @@ template <class I = SILInstruction> I *castToInst(BridgedInstruction inst) {
   return cast<I>(static_cast<SILNode *>(inst.obj)->castToInstruction());
 }
 
+template <class I = SILInstruction> I *castToInst(OptionalBridgedInstruction inst) {
+  if (!inst.obj)
+    return nullptr;
+  return cast<I>(static_cast<SILNode *>(inst.obj)->castToInstruction());
+}
+
 inline SILBasicBlock *castToBasicBlock(BridgedBasicBlock block) {
   return static_cast<SILBasicBlock *>(block.obj);
 }

--- a/include/swift/SILOptimizer/PassManager/PassManager.h
+++ b/include/swift/SILOptimizer/PassManager/PassManager.h
@@ -50,6 +50,9 @@ class SwiftPassInvocation {
   /// Backlink to the pass manager.
   SILPassManager *passManager;
 
+  /// The current transform.
+  SILTransform *transform = nullptr;
+
   /// The currently optimized function.
   SILFunction *function = nullptr;
 
@@ -76,6 +79,8 @@ public:
     passManager(passManager) {}
 
   SILPassManager *getPassManager() const { return passManager; }
+  
+  SILTransform *getTransform() const { return transform; }
 
   SILFunction *getFunction() const { return function; }
 
@@ -94,7 +99,7 @@ public:
   void notifyChanges(SILAnalysis::InvalidationKind invalidationKind);
 
   /// Called by the pass manager before the pass starts running.
-  void startFunctionPassRun(SILFunction *function);
+  void startFunctionPassRun(SILFunctionTransform *transform);
 
   /// Called by the SILCombiner before the instruction pass starts running.
   void startInstructionPassRun(SILInstruction *inst);

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -530,7 +530,7 @@ void SILPassManager::runPassOnFunction(unsigned TransIdx, SILFunction *F) {
   assert(changeNotifications == SILAnalysis::InvalidationKind::Nothing
          && "change notifications not cleared");
 
-  swiftPassInvocation.startFunctionPassRun(F);
+  swiftPassInvocation.startFunctionPassRun(SFT);
 
   // Run it!
   SFT->run();
@@ -1209,9 +1209,10 @@ void SwiftPassInvocation::freeBlockSet(BasicBlockSet *set) {
   }
 }
 
-void SwiftPassInvocation::startFunctionPassRun(SILFunction *function) {
-  assert(!this->function && "a pass is already running");
-  this->function = function;
+void SwiftPassInvocation::startFunctionPassRun(SILFunctionTransform *transform) {
+  assert(!this->function && !this->transform && "a pass is already running");
+  this->function = transform->getFunction();
+  this->transform = transform;
 }
 
 void SwiftPassInvocation::startInstructionPassRun(SILInstruction *inst) {
@@ -1221,8 +1222,9 @@ void SwiftPassInvocation::startInstructionPassRun(SILInstruction *inst) {
 
 void SwiftPassInvocation::finishedFunctionPassRun() {
   endPassRunChecks();
-  assert(function && "not running a pass");
+  assert(function && transform && "not running a pass");
   function = nullptr;
+  transform = nullptr;
 }
 
 void SwiftPassInvocation::finishedInstructionPassRun() {
@@ -1280,6 +1282,14 @@ BridgedSlab PassContext_freeSlab(BridgedPassContext passContext,
                                  BridgedSlab slab) {
   auto *inv = castToPassInvocation(passContext);
   return toBridgedSlab(inv->freeSlab(castToSlab(slab)));
+}
+
+SwiftInt PassContext_continueWithNextSubpassRun(BridgedPassContext passContext,
+                                                OptionalBridgedInstruction inst) {
+  SwiftPassInvocation *inv = castToPassInvocation(passContext);
+  SILInstruction *i = castToInst(inst);
+  return inv->getPassManager()->continueWithNextSubpassRun(i,
+                inv->getFunction(), inv->getTransform()) ? 1: 0;
 }
 
 void PassContext_notifyChanges(BridgedPassContext passContext,


### PR DESCRIPTION
and use this in the ReleaseDevirtualizer