### PR TITLE
[build-presets] Disable SourceKit-LSP tests on Linux

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -873,6 +873,8 @@ foundation
 libdispatch
 indexstore-db
 sourcekit-lsp
+# SourceKit-LSP tests are flaky on Linux due to rdar://92260631
+skip-test-sourcekit-lsp
 swiftdocc
 lit-args=-v --time-tests
 
@@ -1108,6 +1110,8 @@ swiftsyntax
 swiftsyntax-verify-generated-files
 indexstore-db
 sourcekit-lsp
+# SourceKit-LSP tests are flaky on Linux due to rdar://92260631
+skip-test-sourcekit-lsp
 install-llvm
 install-swift
 install-llbuild
@@ -1675,6 +1679,9 @@ skip-test-libicu
 skip-test-foundation
 skip-test-libdispatch
 skip-test-xctest
+
+# SourceKit-LSP tests are flaky on Linux due to rdar://92260631
+skip-test-sourcekit-lsp
 
 # Builds enough of the the toolchain to build a swift pacakge on macOS.
 [preset: mixin_swiftpm_package_macos_platform]


### PR DESCRIPTION
SourceKit-LSP tests have failed on Linux again after https://github.com/apple/swift/pull/42479. Disable them again until the root cause is fixed.