### PR TITLE
Disable failing convenience_init_peer_delegation.swift test.

### DIFF
--- a/test/Interpreter/convenience_init_peer_delegation.swift
+++ b/test/Interpreter/convenience_init_peer_delegation.swift
@@ -27,6 +27,7 @@
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 // XFAIL: CPU=arm64e
+// REQUIRES: rdar92102119
 
 import Darwin
 


### PR DESCRIPTION
Example failure:
https://ci.swift.org/job/oss-swift_tools-RA_stdlib-RDA_test-simulator//281/console