### PR TITLE
[5.7-04182022] Unique extended existential shapes using the generalized AST type

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -637,7 +637,7 @@ Types
   type ::= protocol-list 'p'                 // existential type
   type ::= protocol-list superclass 'Xc'     // existential type with superclass
   type ::= protocol-list 'Xl'                // existential type with AnyObject
-  type ::= protocol-list 'y' (type* '_')* type* retroactive-conformance* 'Xp'   // parameterized protocol type
+  type ::= protocol-list 'y' (type* '_')* type* retroactive-conformance* 'XP'   // parameterized protocol type
   type ::= type-list 't'                     // tuple
   type ::= type generic-signature 'u'        // generic type
   type ::= 'x'                               // generic param, depth=0, idx=0
@@ -918,21 +918,9 @@ root protocol conformance, and the suffix 'g'.
 
 ::
 
-  // No generalization signature, no type expression.
-  extended-existential-shape ::= generic-signature 'Xg' extended-existential-value-storage
-
-  // Generalization signature (the second one), no type expression.
-  extended-existential-shape ::= generic-signature generic-signature 'XG' extended-existential-value-storage
-
-  // No generalization signature, type expression.
-  extended-existential-shape ::= generic-signature type 'Xh' extended-existential-value-storage
-
-  // Generalization signature (the second one), type expression.
-  extended-existential-shape ::= generic-signature generic-signature type 'Xh' extended-existential-value-storage
-
-  extended-existential-value-storage ::= 'o' // opaque
-  extended-existential-value-storage ::= 'c' // class
-  extended-existential-value-storage ::= 'm' // metatype
+  // No generalization signature.
+  extended-existential-shape ::= type 'Xg' // no generalization signature
+  extended-existential-shape ::= generic-signature type 'XG'
 
 Identifiers
 ~~~~~~~~~~~

--- a/include/swift/Demangling/DemangleNodes.def
+++ b/include/swift/Demangling/DemangleNodes.def
@@ -336,7 +336,6 @@ NODE(OpaqueReturnTypeIndexed)
 NODE(BackDeploymentThunk)
 NODE(BackDeploymentFallback)
 NODE(ExtendedExistentialTypeShape)
-NODE(ExtendedExistentialValueStorage)
 NODE(Uniquable)
 
 #undef CONTEXT_NODE

--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -125,10 +125,6 @@ class LinkEntity {
     ExtendedExistentialIsUniqueMask = 0x100,
     ExtendedExistentialIsSharedShift = 9,
     ExtendedExistentialIsSharedMask = 0x200,
-    ExtendedExistentialMetatypeDepthShift = 10,
-    ExtendedExistentialMetatypeDepthMask =
-      ~(KindMask | ExtendedExistentialIsUniqueMask |
-        ExtendedExistentialIsSharedMask),
   };
 #define LINKENTITY_SET_FIELD(field, value) (value << field##Shift)
 #define LINKENTITY_GET_FIELD(value, field) ((value & field##Mask) >> field##Shift)
@@ -1368,9 +1364,7 @@ public:
   }
 
   static LinkEntity forExtendedExistentialTypeShape(CanGenericSignature genSig,
-                                                    CanExistentialType
-                                                      existentialType,
-                                                    unsigned metatypeDepth,
+                                                    CanType existentialType,
                                                     bool isUnique,
                                                     bool isShared) {
     LinkEntity entity;
@@ -1380,8 +1374,7 @@ public:
     entity.Data =
         LINKENTITY_SET_FIELD(Kind, unsigned(Kind::ExtendedExistentialTypeShape))
       | LINKENTITY_SET_FIELD(ExtendedExistentialIsUnique, unsigned(isUnique))
-      | LINKENTITY_SET_FIELD(ExtendedExistentialIsShared, unsigned(isShared))
-      | LINKENTITY_SET_FIELD(ExtendedExistentialMetatypeDepth, metatypeDepth);
+      | LINKENTITY_SET_FIELD(ExtendedExistentialIsShared, unsigned(isShared));
     return entity;
   }
 
@@ -1484,9 +1477,9 @@ public:
              reinterpret_cast<const GenericSignatureImpl*>(SecondaryPointer));
   }
 
-  CanExistentialType getExtendedExistentialTypeShapeType() const {
+  CanType getExtendedExistentialTypeShapeType() const {
     assert(getKind() == Kind::ExtendedExistentialTypeShape);
-    return cast<ExistentialType>(CanType(reinterpret_cast<TypeBase*>(Pointer)));
+    return CanType(reinterpret_cast<TypeBase*>(Pointer));
   }
 
   bool isExtendedExistentialTypeShapeUnique() const {
@@ -1497,11 +1490,6 @@ public:
   bool isExtendedExistentialTypeShapeShared() const {
     assert(getKind() == Kind::ExtendedExistentialTypeShape);
     return LINKENTITY_GET_FIELD(Data, ExtendedExistentialIsShared);
-  }
-
-  unsigned getExtendedExistentialTypeShapeMetatypeDepth() const {
-    assert(getKind() == Kind::ExtendedExistentialTypeShape);
-    return LINKENTITY_GET_FIELD(Data, ExtendedExistentialMetatypeDepth);
   }
 
   bool isDynamicallyReplaceable() const {

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -3231,8 +3231,6 @@ NodePointer Demangler::demangleSpecialType() {
       return popFunctionType(Node::Kind::CFunctionPointer);
     case 'g':
     case 'G':
-    case 'h':
-    case 'H':
       return demangleExtendedExistentialShape(specialChar);
     case 'z':
       switch (auto cchar = nextChar()) {
@@ -3382,47 +3380,19 @@ NodePointer Demangler::demangleSpecialType() {
 }
 
 NodePointer Demangler::demangleExtendedExistentialShape(char nodeKind) {
-  assert(nodeKind == 'g' || nodeKind == 'G' ||
-         nodeKind == 'h' || nodeKind == 'H');
+  assert(nodeKind == 'g' || nodeKind == 'G');
 
-  NodePointer type = nullptr;
-  if (nodeKind == 'h' || nodeKind == 'H')
-    type = popNode(Node::Kind::Type);
+  NodePointer type = popNode(Node::Kind::Type);
 
   NodePointer genSig = nullptr;
-  if (nodeKind == 'G' || nodeKind == 'H')
+  if (nodeKind == 'G')
     genSig = popNode(Node::Kind::DependentGenericSignature);
-
-  NodePointer reqSig = popNode(Node::Kind::DependentGenericSignature);
-
-  NodePointer valueStorage = [&]() -> NodePointer {
-    switch (nextChar()) {
-    case 'o':
-      return createNode(Node::Kind::ExtendedExistentialValueStorage,
-                        "opaque");
-    case 'c':
-      return createNode(Node::Kind::ExtendedExistentialValueStorage,
-                        "class");
-    case 'm':
-      return createNode(Node::Kind::ExtendedExistentialValueStorage,
-                        "metatype");
-    default:
-      return nullptr;
-    }
-  }();
-  if (!valueStorage) return nullptr;
-
-  // Make a default type expression if one wasn't given.
-  if (!type) {
-    type = createType(getDependentGenericParamType(genSig ? 1 : 0, 0));
-  }
 
   if (genSig) {
     return createWithChildren(Node::Kind::ExtendedExistentialTypeShape,
-                              reqSig, genSig, type, valueStorage);
+                              genSig, type);
   } else {
-    return createWithChildren(Node::Kind::ExtendedExistentialTypeShape,
-                              reqSig, type, valueStorage);
+    return createWithChild(Node::Kind::ExtendedExistentialTypeShape, type);
   }
 }
 

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -595,7 +595,6 @@ private:
     case Node::Kind::BackDeploymentThunk:
     case Node::Kind::BackDeploymentFallback:
     case Node::Kind::ExtendedExistentialTypeShape:
-    case Node::Kind::ExtendedExistentialValueStorage:
     case Node::Kind::Uniquable:
       return false;
     }
@@ -2975,9 +2974,8 @@ NodePointer NodePrinter::print(NodePointer Node, unsigned depth,
     auto savedDisplayWhereClauses = Options.DisplayWhereClauses;
     Options.DisplayWhereClauses = true;
 
-    NodePointer reqSig = Node->getChild(0);
     NodePointer genSig = nullptr, type = nullptr;
-    if (Node->getNumChildren() == 4) {
+    if (Node->getNumChildren() == 2) {
       genSig = Node->getChild(1);
       type = Node->getChild(2);
     } else {
@@ -2989,17 +2987,12 @@ NodePointer NodePrinter::print(NodePointer Node, unsigned depth,
       print(genSig, depth + 1);
       Printer << " ";
     }
-    Printer << "any";
-    print(reqSig, depth + 1);
-    Printer << " ";
+    Printer << "any ";
     print(type, depth + 1);
 
     Options.DisplayWhereClauses = savedDisplayWhereClauses;
     return nullptr;
   }
-  case Node::Kind::ExtendedExistentialValueStorage:
-    Printer << Node->getText();
-    return nullptr;
   }
 
   printer_unreachable("bad node kind!");

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -2725,10 +2725,6 @@ ManglingError Remangler::mangleExtendedExistentialTypeShape(Node *node,
                                                      unsigned int depth) {
   return MANGLING_ERROR(ManglingError::UnsupportedNodeKind, node);
 }
-ManglingError Remangler::mangleExtendedExistentialValueStorage(Node *node,
-                                                     unsigned int depth) {
-  return MANGLING_ERROR(ManglingError::UnsupportedNodeKind, node);
-}
 ManglingError
 Remangler::mangleCanonicalSpecializedGenericMetaclass(Node *node,
                                                       unsigned depth) {

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -317,7 +317,12 @@ getTypeRefImpl(IRGenModule &IGM,
                CanType type,
                CanGenericSignature sig,
                MangledTypeRefRole role) {
+  bool useFlatUnique = false;
   switch (role) {
+  case MangledTypeRefRole::FlatUnique:
+    useFlatUnique = true;
+    break;
+
   case MangledTypeRefRole::DefaultAssociatedTypeWitness:
   case MangledTypeRefRole::Metadata:
     // Note that we're using all of the nominal types referenced by this type,
@@ -342,7 +347,9 @@ getTypeRefImpl(IRGenModule &IGM,
   }
 
   IRGenMangler Mangler;
-  auto SymbolicName = Mangler.mangleTypeForReflection(IGM, sig, type);
+  auto SymbolicName =
+    useFlatUnique ? Mangler.mangleTypeForFlatUniqueTypeRef(sig, type)
+                  : Mangler.mangleTypeForReflection(IGM, sig, type);
   return {IGM.getAddrOfStringForTypeRef(SymbolicName, role),
           SymbolicName.runtimeSizeInBytes()};
 }

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -469,20 +469,12 @@ public:
   }
 
   void appendExtendedExistentialTypeShape(CanGenericSignature genSig,
-                                          CanExistentialType type,
-                                          unsigned metatypeDepth);
+                                          CanType shapeType);
 
   /// Mangle the symbol name for an extended existential type shape.
   std::string mangleExtendedExistentialTypeShape(bool isUnique,
                                                  CanGenericSignature genSig,
-                                                 CanExistentialType type,
-                                                 unsigned metatypeDepth);
-
-  /// Mangle an extended existential type shape for the uniquing hash.
-  std::string mangleExtendedExistentialTypeShapeForUniquing(
-                                                 CanGenericSignature genSig,
-                                                 CanExistentialType type,
-                                                 unsigned metatypeDepth);
+                                                 CanType shapeType);
 
   std::string mangleCoroutineContinuationPrototype(CanSILFunctionType type) {
     return mangleTypeSymbol(type, "TC");
@@ -600,6 +592,14 @@ public:
   std::string mangleTypeForForeignMetadataUniquing(Type type) {
     return mangleTypeWithoutPrefix(type);
   }
+
+  void configureForSymbolicMangling() {
+    OptimizeProtocolNames = false;
+    UseObjCRuntimeNames = true;
+  }
+
+  SymbolicMangling mangleTypeForFlatUniqueTypeRef(CanGenericSignature sig,
+                                                  CanType ty);
 
   SymbolicMangling mangleTypeForReflection(IRGenModule &IGM,
                                            CanGenericSignature genericSig,

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -575,6 +575,9 @@ enum class MangledTypeRefRole {
   /// The mangled type reference is used for a default associated type
   /// witness.
   DefaultAssociatedTypeWitness,
+  /// The mangled type reference must be a flat string (i.e. no
+  /// symbolic references) and unique for the target type.
+  FlatUnique,
 };
 
 /// IRGenModule - Primary class for emitting IR for global declarations.

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -516,11 +516,10 @@ std::string LinkEntity::mangleAsString() const {
   case Kind::ExtendedExistentialTypeShape: {
     auto genSig = getExtendedExistentialTypeShapeGenSig();
     auto existentialType = getExtendedExistentialTypeShapeType();
-    auto metatypeDepth = getExtendedExistentialTypeShapeMetatypeDepth();
     auto isUnique = isExtendedExistentialTypeShapeUnique();
 
     return mangler.mangleExtendedExistentialTypeShape(
-                     isUnique, genSig, existentialType, metatypeDepth);
+                     isUnique, genSig, existentialType);
   }
   }
   llvm_unreachable("bad entity kind!");

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -362,6 +362,10 @@ llvm::Constant *IRGenModule::getAddrOfStringForTypeRef(
              ProtocolRequirementFlags::AssociatedTypeInProtocolContextByte);
     break;
 
+  case MangledTypeRefRole::FlatUnique:
+    assert(mangling.SymbolicReferences.empty());
+    break;
+
   case MangledTypeRefRole::Metadata:
   case MangledTypeRefRole::Reflection:
     break;

--- a/test/IRGen/existential_shape_metadata.swift
+++ b/test/IRGen/existential_shape_metadata.swift
@@ -1,14 +1,16 @@
 // RUN: %target-swift-frontend -emit-ir %s -swift-version 5  -disable-availability-checking -enable-parameterized-existential-types | %IRGenFileCheck %s
 
-// CHECK-LABEL: @"$s1TQyd__Rsz26existential_shape_metadata2Q0Rd__llXGoMq" = linkonce_odr hidden constant
+// CHECK-LABEL: @"$sl26existential_shape_metadata2Q0_pyxXPXGMq" = linkonce_odr hidden constant
 // CHECK-SAME:  { i32 {{.*}}sub ([[INT]] ptrtoint (i8** @{{[0-9]+}} to [[INT]])
-// CHECK-SAME:    [16 x i8] c"2\C6\0A\EA>\EE/`\DBphz\CB\FA7\8E",
 // CHECK-SAME:    i32 6400,
+// CHECK-SAME:    i32 {{.*}} @"flat unique 26existential_shape_metadata2Q0_pyxXP"
 // CHECK-SAME:    i16 2, i16 2, i16 3, i16 0,
 // CHECK-SAME:    i16 1, i16 0, i16 1, i16 0, i32 1,
 
-// CHECK-LABEL: @"$s1TQyd__Rsz26existential_shape_metadata2R033_881A0B6978EB4286E7CFF1E27030ACACLLRd__llXGo" = internal constant
+// CHECK-LABEL: @"$sl26existential_shape_metadata2R033_881A0B6978EB4286E7CFF1E27030ACACLL_pyxXPXG" = internal constant
 // CHECK-SAME:  { i32 6400,
+//   This could use a symbolic reference because this doesn't have to be uniqued.
+// CHECK-SAME:    i32 {{.*}} @"flat unique 26existential_shape_metadata2R033_881A0B6978EB4286E7CFF1E27030ACACLL_pyxXP"
 // CHECK-SAME:    i16 2, i16 2, i16 3, i16 0,
 // CHECK-SAME:    i16 1, i16 0, i16 1, i16 0, i32 1,
 
@@ -51,7 +53,7 @@ public func testConcrete() -> Any.Type {
   // CHECK:   [[T0:%.*]] = getelementptr inbounds [1 x i8*], [1 x i8*]* [[ARGS]], i32 0, i32 0
   // CHECK:   store i8*  bitcast (%swift.type* @"$sSiN" to i8*), i8** [[T0]], align
   // CHECK:   [[T0:%.*]] = bitcast [1 x i8*]* [[ARGS]] to i8**
-  // CHECK:   [[CALL:%.*]] = call %swift.type* @swift_getExtendedExistentialTypeMetadata({{.*}}@"$s1TQyd__Rsz26existential_shape_metadata2Q0Rd__llXGoMq{{(\.ptrauth)?}}" to i8*), i8** [[T0]])
+  // CHECK:   [[CALL:%.*]] = call %swift.type* @swift_getExtendedExistentialTypeMetadata({{.*}}@"$sl26existential_shape_metadata2Q0_pyxXPXGMq{{(\.ptrauth)?}}" to i8*), i8** [[T0]])
   // CHECK:   store atomic %swift.type* [[CALL]], %swift.type** @"$s26existential_shape_metadata2Q0_pySiXPML" release, align
   // CHECK:   br label %[[CONT]]
   // CHECK: [[CONT]]:
@@ -68,7 +70,7 @@ public func testDependent<T>(t: T.Type) -> Any.Type {
   // CHECK: [[T1:%.*]] = bitcast %swift.type* %T to i8*
   // CHECK: store i8* [[T1]], i8** [[T0]], align
   // CHECK: [[T0:%.*]] = bitcast [1 x i8*]* [[ARGS]] to i8**
-  // CHECK: [[METADATA:%.*]] = call %swift.type* @swift_getExtendedExistentialTypeMetadata({{.*}}@"$s1TQyd__Rsz26existential_shape_metadata2Q0Rd__llXGoMq{{(\.ptrauth)?}}" to i8*), i8** [[T0]])
+  // CHECK: [[METADATA:%.*]] = call %swift.type* @swift_getExtendedExistentialTypeMetadata({{.*}}@"$sl26existential_shape_metadata2Q0_pyxXPXGMq{{(\.ptrauth)?}}" to i8*), i8** [[T0]])
   // CHECK: ret %swift.type* [[METADATA]]
   return (any Q0<T>).self
 }
@@ -83,7 +85,7 @@ public func testComplexApplication<T>(t: T.Type) -> Any.Type {
   // CHECK: [[T1:%.*]] = bitcast %swift.type* [[B_T]] to i8*
   // CHECK: store i8* [[T1]], i8** [[T0]], align
   // CHECK: [[T0:%.*]] = bitcast [1 x i8*]* [[ARGS]] to i8**
-  // CHECK: [[METADATA:%.*]] = call %swift.type* @swift_getExtendedExistentialTypeMetadata({{.*}}@"$s1TQyd__Rsz26existential_shape_metadata2Q0Rd__llXGoMq{{(\.ptrauth)?}}" to i8*), i8** [[T0]])
+  // CHECK: [[METADATA:%.*]] = call %swift.type* @swift_getExtendedExistentialTypeMetadata({{.*}}@"$sl26existential_shape_metadata2Q0_pyxXPXGMq{{(\.ptrauth)?}}" to i8*), i8** [[T0]])
   // CHECK: ret %swift.type* [[METADATA]]
   return (any Q0<B<T>>).self
 }
@@ -97,7 +99,7 @@ public func test_private<T>(t: T.Type) -> Any.Type {
   // CHECK: store i8* [[T1]], i8** [[T0]], align
   // CHECK: [[T0:%.*]] = bitcast [1 x i8*]* [[ARGS]] to i8**
   //   FIXME: this should be unique?
-  // CHECK: [[METADATA:%.*]] = call %swift.type* @swift_getExtendedExistentialTypeMetadata_unique({{.*}}@"$s1TQyd__Rsz26existential_shape_metadata2R033_881A0B6978EB4286E7CFF1E27030ACACLLRd__llXGo{{(\.ptrauth)?}}" to i8*), i8** [[T0]])
+  // CHECK: [[METADATA:%.*]] = call %swift.type* @swift_getExtendedExistentialTypeMetadata_unique({{.*}}@"$sl26existential_shape_metadata2R033_881A0B6978EB4286E7CFF1E27030ACACLL_pyxXPXG{{(\.ptrauth)?}}" to i8*), i8** [[T0]])
   // CHECK: ret %swift.type* [[METADATA]]
   return (any R0<T>).self
 }
@@ -119,4 +121,4 @@ public func test_privateApplication<T>(t: T.Type) -> Any.Type {
   // CHECK: [[T0:%.*]] = getelementptr inbounds [1 x i8*], [1 x i8*]* [[ARGS]], i32 0, i32 0
   // CHECK: store i8* {{.*}}"$s26existential_shape_metadata1C33_881A0B6978EB4286E7CFF1E27030ACACLLVMf"{{.*}}, i8** [[T0]], align
   // CHECK: [[T0:%.*]] = bitcast [1 x i8*]* [[ARGS]] to i8**
-  // CHECK: [[METADATA:%.*]] = call %swift.type* @swift_getExtendedExistentialTypeMetadata({{.*}}@"$s1TQyd__Rsz26existential_shape_metadata2Q0Rd__llXGoMq{{(\.ptrauth)?}}" to i8*), i8** [[T0]])
+  // CHECK: [[METADATA:%.*]] = call %swift.type* @swift_getExtendedExistentialTypeMetadata({{.*}}@"$sl26existential_shape_metadata2Q0_pyxXPXGMq{{(\.ptrauth)?}}" to i8*), i8** [[T0]])

--- a/test/Interpreter/parameterized_existentials.swift
+++ b/test/Interpreter/parameterized_existentials.swift
@@ -1,8 +1,6 @@
 // RUN: %target-run-simple-swift(-Xfrontend -enable-parameterized-existential-types)
 // REQUIRES: executable_test
 
-// REQUIRES: disabled
-
 import StdlibUnittest
 
 var ParameterizedProtocolsTestSuite = TestSuite("ParameterizedProtocols")

--- a/unittests/runtime/ExtendedExistential.cpp
+++ b/unittests/runtime/ExtendedExistential.cpp
@@ -23,12 +23,15 @@ static const ModuleContextDescriptor *module() {
   });
 }
 
-template <unsigned N>
-static ProtocolSpecifier globalProtocol() {
+static ProtocolSpecifier P() {
   return protocol(buildGlobalProtocolDescriptor(module(), [] {
-    std::ostringstream str;
-    str << "Anonymous" << N;
-    return str.str();
+    return "P";
+  }));
+}
+
+static ProtocolSpecifier Q() {
+  return protocol(buildGlobalProtocolDescriptor(module(), [] {
+    return "Q";
   }));
 }
 
@@ -209,32 +212,32 @@ TEST(TestExtendedExistential, shapeUniquing) {
     return shape(
       genSig(param()),
       reqSig(param(),
-             conforms(reqParam(0), globalProtocol<0>()),
-             sameType(member(reqParam(0), "Element"), genParam(0)))
+             conforms(reqParam(0), P()),
+             sameType(member(reqParam(0), P(), "Element"), genParam(0)))
     );
   });
   auto shape1 = buildGlobalNonUniqueShape(567, []{
     return shape(
       genSig(param()),
       reqSig(param(),
-             conforms(reqParam(0), globalProtocol<0>()),
-             sameType(member(reqParam(0), "Element"), genParam(0)))
+             conforms(reqParam(0), P()),
+             sameType(member(reqParam(0), P(), "Element"), genParam(0)))
     );
   });
   auto shape2 = buildGlobalNonUniqueShape(1123, []{
     return shape(
       genSig(param()),
       reqSig(param(),
-             conforms(reqParam(0), globalProtocol<1>()),
-             sameType(member(reqParam(0), "Element"), genParam(0)))
+             conforms(reqParam(0), Q()),
+             sameType(member(reqParam(0), Q(), "Element"), genParam(0)))
     );
   });
   auto shape3 = buildGlobalNonUniqueShape(1123, []{
     return shape(
       genSig(param()),
       reqSig(param(),
-             conforms(reqParam(0), globalProtocol<1>()),
-             sameType(member(reqParam(0), "Element"), genParam(0)))
+             conforms(reqParam(0), Q()),
+             sameType(member(reqParam(0), Q(), "Element"), genParam(0)))
     );
   });
 
@@ -265,7 +268,7 @@ TEST(TestExtendedExistential, nullaryMetadata) {
   auto shape1 = buildGlobalShape([]{
     return shape(
       reqSig(param(),
-             conforms(reqParam(0), globalProtocol<0>()))
+             conforms(reqParam(0), P()))
     );
   });
   auto metadata1 = swift_getExtendedExistentialTypeMetadata_unique(shape1, nullptr);
@@ -281,14 +284,14 @@ TEST(TestExtendedExistential, unaryMetadata) {
     return shape(
       genSig(param()),
       reqSig(param(),
-             conforms(reqParam(0), globalProtocol<0>()))
+             conforms(reqParam(0), P()))
     );
   });
   auto shape2 = buildGlobalShape([]{
     return shape(
       genSig(param()),
       reqSig(param(),
-             conforms(reqParam(0), globalProtocol<1>()))
+             conforms(reqParam(0), Q()))
     );
   });
 
@@ -328,7 +331,7 @@ TEST(TestExtendedExistential, binaryMetadata) {
     return shape(
       genSig(param(), param()),
       reqSig(param(),
-             conforms(reqParam(0), globalProtocol<0>()))
+             conforms(reqParam(0), P()))
     );
   });
 
@@ -396,7 +399,7 @@ TEST(TestExtendedExistential, defaultOpaqueValueWitnessses) {
   auto shape1 = buildGlobalShape([]{
     return shape(
       reqSig(param(),
-             conforms(reqParam(0), globalProtocol<0>()))
+             conforms(reqParam(0), P()))
     );
   });
   auto metadata1 = swift_getExtendedExistentialTypeMetadata_unique(shape1, nullptr);
@@ -408,8 +411,8 @@ TEST(TestExtendedExistential, defaultOpaqueValueWitnessses) {
   auto shape2 = buildGlobalShape([]{
     return shape(
       reqSig(param(),
-             conforms(reqParam(0), globalProtocol<0>()),
-             conforms(reqParam(0), globalProtocol<1>()))
+             conforms(reqParam(0), P()),
+             conforms(reqParam(0), Q()))
     );
   });
   auto metadata2 = swift_getExtendedExistentialTypeMetadata_unique(shape2, nullptr);
@@ -438,7 +441,7 @@ TEST(TestExtendedExistential, defaultClassValueWitnessses) {
     return shape(
       special(SpecialKind::Class),
       reqSig(param(),
-             conforms(reqParam(0), globalProtocol<0>()))
+             conforms(reqParam(0), P()))
     );
   });
   auto metadata1 = swift_getExtendedExistentialTypeMetadata_unique(shape1, nullptr);
@@ -451,8 +454,8 @@ TEST(TestExtendedExistential, defaultClassValueWitnessses) {
     return shape(
       special(SpecialKind::Class),
       reqSig(param(),
-             conforms(reqParam(0), globalProtocol<0>()),
-             conforms(reqParam(0), globalProtocol<1>()))
+             conforms(reqParam(0), P()),
+             conforms(reqParam(0), Q()))
     );
   });
   auto metadata2 = swift_getExtendedExistentialTypeMetadata_unique(shape2, nullptr);
@@ -481,7 +484,7 @@ TEST(TestExtendedExistential, defaultMetatypeValueWitnessses) {
     return shape(
       special(SpecialKind::Metatype),
       reqSig(param(),
-             conforms(reqParam(0), globalProtocol<0>()))
+             conforms(reqParam(0), P()))
     );
   });
   auto metadata1 = swift_getExtendedExistentialTypeMetadata_unique(shape1, nullptr);
@@ -494,8 +497,8 @@ TEST(TestExtendedExistential, defaultMetatypeValueWitnessses) {
     return shape(
       special(SpecialKind::Metatype),
       reqSig(param(),
-             conforms(reqParam(0), globalProtocol<0>()),
-             conforms(reqParam(0), globalProtocol<1>()))
+             conforms(reqParam(0), P()),
+             conforms(reqParam(0), Q()))
     );
   });
   auto metadata2 = swift_getExtendedExistentialTypeMetadata_unique(shape2, nullptr);

--- a/unittests/runtime/MetadataObjectBuilder.h
+++ b/unittests/runtime/MetadataObjectBuilder.h
@@ -76,9 +76,7 @@ inline void addProtocolDescriptor(AnyObjectBuilder &builder,
 
   ObjectRef<const char> selfType;
   if (!baseProtocols.empty()) {
-    auto subbuilder = builder.createSubobject<const char>(/*align*/ 2);
-    mangleGenericParamType(subbuilder, 0, 0);
-    selfType = subbuilder.ref();
+    selfType = createMangledTypeString(builder, typeParam(0, 0));
   }
 
   // Requirement signature requirement descriptors


### PR DESCRIPTION
I wrote out this whole analysis of why different existential types might have the same logical content, and then I turned around and immediately uniqued existential shapes purely by logical content rather than the (generalized) formal type. Oh well. At least it's not too late to make ABI changes like this.

We now store a reference to a mangling of the generalized formal type directly in the shape. This type alone is sufficient to unique the shape:

By the nature of the generalization algorithm, every type parameter in the generalization signature should be mentioned in the generalized formal type in a deterministic order.

By the nature of the generalization algorithm, every other requirement in the generalization signature should be implied by the positions in which generalization type parameters appear (e.g. because the formal type is C & P, where C constrains its type parameter for well-formedness).

The requirement signature and type expression are extracted from the existential type.

As a result, we no longer rely on computing a unique hash at compile time.

Storing this separately from the requirement signature potentially allows runtimes with general shape support to work with future extensions to existential types even if they cannot demangle the generalized formal type.

Storing the generalized formal type also allows us to easily and reliably extract the formal type of the existential. Otherwise, it's quite a heroic endeavor to match requirements back up with primary associated types. Doing so would also only allows us to extract some matching formal type, not necessarily the right formal type. So there's some good synergy here.

5.7-04182022 version of #42563.

**Scope**: ABI change affecting constrained existential types, which shouldn't yet be used anywhere
**Issues**: rdar://92274408
**Risk**: Low because of the presumed lack of adoption
**Testing**: Regression tests
**Reviewer**: Holly Borla