### PR TITLE
NFC: Plumb main decl context down to SILGen

### DIFF
--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -105,6 +105,10 @@ private:
   /// The source location of the main type.
   SourceLoc MainDeclDiagLoc;
 
+  /// DeclContext of the `MainDecl` when coming from @main
+  /// This is the type that `@main`
+  DeclContext *MainDeclContext = nullptr;
+
   /// A hash of all interface-contributing tokens that have been lexed for
   /// this source file.
   ///
@@ -505,11 +509,18 @@ public:
     return getMainDeclDiagLoc();
   }
 
+  /// Get the context with the `@main` attribute.
+  ///
+  /// This is not necessarily the context where the main function decl is
+  /// declared.
+  DeclContext *getMainDeclContext() const { return MainDeclContext; }
+
   /// Register a "main" class for the module, complaining if there is more than
   /// one.
   ///
   /// Should only be called during type-checking.
-  bool registerMainDecl(ValueDecl *mainDecl, SourceLoc diagLoc);
+  bool registerMainDecl(ValueDecl *mainDecl, DeclContext *mainDeclContext,
+                        SourceLoc diagLoc);
 
   /// True if this source file has an application entry point.
   ///

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1746,7 +1746,9 @@ bool ModuleDecl::isBuiltinModule() const {
   return this == getASTContext().TheBuiltinModule;
 }
 
-bool SourceFile::registerMainDecl(ValueDecl *mainDecl, SourceLoc diagLoc) {
+bool SourceFile::registerMainDecl(ValueDecl *mainDecl,
+                                  DeclContext *mainDeclContext,
+                                  SourceLoc diagLoc) {
   assert(mainDecl);
   if (mainDecl == MainDecl)
     return false;
@@ -1756,6 +1758,7 @@ bool SourceFile::registerMainDecl(ValueDecl *mainDecl, SourceLoc diagLoc) {
     return true;
 
   MainDecl = mainDecl;
+  MainDeclContext = mainDeclContext;
   MainDeclDiagLoc = diagLoc;
 
   return false;

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -472,7 +472,7 @@ SILDeclRef SILDeclRef::getAsyncMainDeclEntryPoint(ValueDecl *decl) {
 }
 
 SILDeclRef SILDeclRef::getAsyncMainFileEntryPoint(FileUnit *file) {
-  assert(file->hasEntryPoint() && !file->getMainDecl());
+  assert(file->hasEntryPoint());
   SILDeclRef result;
   result.loc = file;
   result.kind = Kind::AsyncEntryPoint;
@@ -480,7 +480,7 @@ SILDeclRef SILDeclRef::getAsyncMainFileEntryPoint(FileUnit *file) {
 }
 
 SILDeclRef SILDeclRef::getMainFileEntryPoint(FileUnit *file) {
-  assert(file->hasEntryPoint() && !file->getMainDecl());
+  assert(file->hasEntryPoint());
   SILDeclRef result;
   result.loc = file;
   result.kind = Kind::EntryPoint;

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1124,8 +1124,19 @@ void SILGenModule::emitFunctionDefinition(SILDeclRef constant, SILFunction *f) {
     // SourceFileScope).
     auto loc = RegularLocation::getModuleLocation();
     preEmitFunction(constant, f, loc);
-    auto *decl = constant.getDecl();
-    auto *dc = decl->getDeclContext();
+
+    ValueDecl *decl = nullptr;
+    DeclContext *dc = nullptr;
+
+    if (constant.hasDecl())
+      decl = constant.getDecl();
+    else if (constant.hasFileUnit())
+      decl = constant.getFileUnit()->getMainDecl();
+    dc = decl->getDeclContext();
+
+    assert(decl && "decl not set");
+    assert(dc && "decl context not set");
+
     PrettyStackTraceSILFunction X("silgen emitArtificialTopLevel", f);
     // In all cases, a constant.kind == EntryPoint indicates the main entrypoint
     // to the program, @main.
@@ -1146,7 +1157,7 @@ void SILGenModule::emitFunctionDefinition(SILDeclRef constant, SILFunction *f) {
       SILDeclRef mainEntryPoint = SILDeclRef::getAsyncMainDeclEntryPoint(decl);
       SILGenFunction(*this, *f, dc).emitAsyncMainThreadStart(mainEntryPoint);
     } else {
-      SILGenFunction(*this, *f, dc).emitArtificialTopLevel(decl);
+      SILGenFunction(*this, *f, dc).emitArtificialTopLevel(constant);
     }
     postEmitFunction(constant, f);
     return;
@@ -2184,11 +2195,11 @@ public:
 
     // If the source file contains an artificial main, emit the implicit
     // top-level code.
-    if (auto *mainDecl = sf->getMainDecl()) {
-      if (isa<FuncDecl>(mainDecl) &&
-          static_cast<FuncDecl *>(mainDecl)->hasAsync())
-        emitSILFunctionDefinition(
-            SILDeclRef::getAsyncMainDeclEntryPoint(mainDecl));
+    if (FuncDecl *mainDecl = dyn_cast_or_null<FuncDecl>(sf->getMainDecl())) {
+      if (mainDecl->hasAsync())
+        emitSILFunctionDefinition(SILDeclRef::getAsyncMainFileEntryPoint(sf));
+      emitSILFunctionDefinition(SILDeclRef::getMainFileEntryPoint(sf));
+    } else if (auto *mainDecl = sf->getMainDecl()) {
       emitSILFunctionDefinition(SILDeclRef::getMainDeclEntryPoint(mainDecl));
     }
   }

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -576,28 +576,56 @@ ManagedValue emitBuiltinCreateAsyncTask(SILGenFunction &SGF, SILLocation loc,
                                         ArrayRef<ManagedValue> args,
                                         SGFContext C);
 
-void SILGenFunction::emitArtificialTopLevel(Decl *mainDecl) {
+void SILGenFunction::emitArtificialTopLevel(SILDeclRef mainDecl) {
   // Create the argc and argv arguments.
   auto entry = B.getInsertionBB();
   auto paramTypeIter = F.getConventions()
                            .getParameterSILTypes(getTypeExpansionContext())
                            .begin();
 
+  auto getMainDecl = [mainDecl]() -> Decl * {
+    if (mainDecl.hasFileUnit()) {
+      assert(mainDecl.getFileUnit()->hasEntryPoint() &&
+             "File has no entrypoint");
+      SourceFile *file = dyn_cast<SourceFile>(mainDecl.getFileUnit());
+      return file->getMainDecl();
+    } else if (mainDecl.hasDecl()) {
+      return mainDecl.getDecl();
+    }
+    llvm_unreachable("Unimplemented SILDeclRef Entrypoint");
+  };
+
+  auto getMainDeclContext = [mainDecl]() -> DeclContext * {
+    if (mainDecl.hasFileUnit()) {
+      assert(mainDecl.getFileUnit()->hasEntryPoint() &&
+             "File has no entrypoint");
+      SourceFile *file = dyn_cast<SourceFile>(mainDecl.getFileUnit());
+      return file->getMainDeclContext();
+    } else if (mainDecl.hasDecl()) {
+      return mainDecl.getDecl()->getDeclContext();
+    }
+
+    llvm_unreachable("Unimplemented SILDeclRef Entrypoint");
+  };
+
   SILValue argc;
   SILValue argv;
-  const bool isAsyncFunc =
-      isa<FuncDecl>(mainDecl) && static_cast<FuncDecl *>(mainDecl)->hasAsync();
-  if (!isAsyncFunc) {
-    argc = entry->createFunctionArgument(*paramTypeIter);
-    argv = entry->createFunctionArgument(*std::next(paramTypeIter));
+  if (Decl *decl = getMainDecl()) {
+    // If it's not a function, or it's a synchronous function, emit `argc` and
+    // `argv`.
+    FuncDecl *fnDecl = dyn_cast<FuncDecl>(decl);
+    if (!fnDecl || (fnDecl && !fnDecl->hasAsync())) {
+      argc = entry->createFunctionArgument(*paramTypeIter);
+      argv = entry->createFunctionArgument(*std::next(paramTypeIter));
+    }
   }
 
-  switch (mainDecl->getArtificialMainKind()) {
+  switch (getMainDecl()->getArtificialMainKind()) {
   case ArtificialMainKind::UIApplicationMain: {
     // Emit a UIKit main.
     // return UIApplicationMain(C_ARGC, C_ARGV, nil, ClassName);
 
-    auto *mainClass = cast<NominalTypeDecl>(mainDecl);
+    auto *mainClass = cast<NominalTypeDecl>(getMainDecl());
 
     CanType NSStringTy = SGM.Types.getNSStringType();
     CanType OptNSStringTy
@@ -731,7 +759,7 @@ void SILGenFunction::emitArtificialTopLevel(Decl *mainDecl) {
     // Emit an AppKit main.
     // return NSApplicationMain(C_ARGC, C_ARGV);
 
-    auto *mainClass = cast<NominalTypeDecl>(mainDecl);
+    auto *mainClass = cast<NominalTypeDecl>(getMainDecl());
 
     SILParameterInfo argTypes[] = {
       SILParameterInfo(argc->getType().getASTType(),
@@ -773,7 +801,7 @@ void SILGenFunction::emitArtificialTopLevel(Decl *mainDecl) {
   case ArtificialMainKind::TypeMain: {
     // Emit a call to the main static function.
     // return Module.$main();
-    auto *mainFunc = cast<FuncDecl>(mainDecl);
+    auto *mainFunc = cast<FuncDecl>(getMainDecl());
     auto moduleLoc = RegularLocation::getModuleLocation();
     auto *entryBlock = B.getInsertionBB();
 
@@ -781,16 +809,22 @@ void SILGenFunction::emitArtificialTopLevel(Decl *mainDecl) {
     SILFunction *mainFunction =
         SGM.getFunction(mainFunctionDeclRef, NotForDefinition);
 
-    ExtensionDecl *mainExtension =
-        dyn_cast<ExtensionDecl>(mainFunc->getDeclContext());
-
-    NominalTypeDecl *mainType;
-    if (mainExtension) {
-      mainType = mainExtension->getExtendedNominal();
+    NominalTypeDecl *mainTypeDecl = nullptr;
+    if (ExtensionDecl *mainExtension =
+            dyn_cast<ExtensionDecl>(getMainDeclContext())) {
+      mainTypeDecl = mainExtension->getExtendedNominal();
+    } else if (NominalTypeDecl *mainNominal =
+                   dyn_cast<NominalTypeDecl>(getMainDeclContext())) {
+      mainTypeDecl = mainNominal;
     } else {
-      mainType = cast<NominalTypeDecl>(mainFunc->getDeclContext());
+      llvm_unreachable("Unknown main decl context");
     }
-    auto metatype = B.createMetatype(mainType, getLoweredType(mainType->getInterfaceType()));
+    assert(!mainTypeDecl->isGeneric() && "main type must not be generic!");
+    SubstitutionMap substitutions =
+        mainTypeDecl->getDeclaredInterfaceType()->getContextSubstitutionMap(
+            mainFunc->getParentModule(), mainFunc->getDeclContext());
+    auto metatype = B.createMetatype(
+        mainTypeDecl, getLoweredType(mainTypeDecl->getInterfaceType()));
 
     auto mainFunctionRef = B.createFunctionRef(moduleLoc, mainFunction);
 
@@ -846,11 +880,11 @@ void SILGenFunction::emitArtificialTopLevel(Decl *mainDecl) {
       B.createBranch(moduleLoc, exitBlock, {oneReturnValue});
 
       B.setInsertionPoint(entryBlock);
-      B.createTryApply(moduleLoc, mainFunctionRef, SubstitutionMap(),
-                       {metatype}, successBlock, failureBlock);
+      B.createTryApply(moduleLoc, mainFunctionRef, substitutions, {metatype},
+                       successBlock, failureBlock);
     } else {
       B.setInsertionPoint(entryBlock);
-      B.createApply(moduleLoc, mainFunctionRef, SubstitutionMap(), {metatype});
+      B.createApply(moduleLoc, mainFunctionRef, substitutions, {metatype});
       SILValue returnValue =
           B.createIntegerLiteral(moduleLoc, builtinInt32Type, 0);
       B.createBranch(moduleLoc, exitBlock, {returnValue});

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -641,7 +641,7 @@ public:
 
   /// Generates code for an artificial top-level function that starts an
   /// application based on a main type and optionally a main type.
-  void emitArtificialTopLevel(Decl *mainDecl);
+  void emitArtificialTopLevel(SILDeclRef entrypoint);
 
   /// Generate code into @main for starting the async main on the main thread.
   void emitAsyncMainThreadStart(SILDeclRef entryPoint);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1993,7 +1993,7 @@ void AttributeChecker::checkApplicationMainAttribute(DeclAttribute *attr,
 
   // Register the class as the main class in the module. If there are multiples
   // they will be diagnosed.
-  if (SF->registerMainDecl(CD, attr->getLocation()))
+  if (SF->registerMainDecl(CD, CD, attr->getLocation()))
     attr->setInvalid();
 }
 
@@ -2225,6 +2225,13 @@ void AttributeChecker::visitMainTypeAttr(MainTypeAttr *attr) {
   SourceFile *file = D->getDeclContext()->getParentSourceFile();
   assert(file);
 
+  // The main function must be declared in a decl-context
+  // `@main` cannot go on a non-decl-context decl.
+  DeclContext *dCtx = dyn_cast<DeclContext>(D);
+  assert(dCtx && "main must be declared in a decl context");
+  if (!dCtx)
+    return;
+
   auto *func = evaluateOrDefault(context.evaluator,
                                  SynthesizeMainFunctionRequest{D},
                                  nullptr);
@@ -2234,7 +2241,7 @@ void AttributeChecker::visitMainTypeAttr(MainTypeAttr *attr) {
 
   // Register the func as the main decl in the module. If there are multiples
   // they will be diagnosed.
-  if (file->registerMainDecl(func, attr->getLocation()))
+  if (file->registerMainDecl(func, dCtx, attr->getLocation()))
     attr->setInvalid();
 }
 


### PR DESCRIPTION
This patch plumbs the decl context that the `@main` attribute is attached to down, through the SourceFile, to SILGen. This will allow us to build the correct substitution map for calls. This works currently because `$main` is synthesized into the nominal/extension decl that the `@main` is attached to, so the decl context of the `$main` function is the correct decl context. Once `$main` is removed, we will only have a handle to the actual main function, which could be declared somewhere else. e.g., if the `@main` is on a struct that conforms to a protocol that has an extension where the main function is declared.

```swift
protocol App {
}

extension App {
  static func main() { }
}

@main struct MainType : App { }
```

In this case, we want the decl context to be `MainType`, but the decl context of the main decl is the `App` extension.
This also sets up the substitution map instead of using a blank one when making the call.