### PR TITLE
Ensure clocks properly respect leeways and use raw time for calculations for continuous clocks

### DIFF
--- a/stdlib/public/Concurrency/Clock.cpp
+++ b/stdlib/public/Concurrency/Clock.cpp
@@ -42,7 +42,7 @@ void swift_get_time(
       clock_gettime(CLOCK_MONOTONIC_RAW, &continuous);
       *seconds = continuous.tv_sec;
       *nanoseconds = continuous.tv_nsec;
-#elif defined(__OpenBSD__)) && HAS_TIME
+#elif defined(__OpenBSD__) && HAS_TIME
       struct timespec continuous;
       clock_gettime(CLOCK_MONOTONIC, &continuous);
       *seconds = continuous.tv_sec;
@@ -121,7 +121,7 @@ switch (clock_id) {
       clock_getres(CLOCK_MONOTONIC_RAW, &continuous);
       *seconds = continuous.tv_sec;
       *nanoseconds = continuous.tv_nsec;
-#elif defined(__OpenBSD__)) && HAS_TIME;
+#elif defined(__OpenBSD__) && HAS_TIME;
       struct timespec continuous;
       clock_getres(CLOCK_MONOTONIC, &continuous);
       *seconds = continuous.tv_sec;

--- a/stdlib/public/Concurrency/Clock.cpp
+++ b/stdlib/public/Concurrency/Clock.cpp
@@ -121,7 +121,7 @@ switch (clock_id) {
       clock_getres(CLOCK_MONOTONIC_RAW, &continuous);
       *seconds = continuous.tv_sec;
       *nanoseconds = continuous.tv_nsec;
-#elif defined(__OpenBSD__) && HAS_TIME;
+#elif defined(__OpenBSD__) && HAS_TIME
       struct timespec continuous;
       clock_getres(CLOCK_MONOTONIC, &continuous);
       *seconds = continuous.tv_sec;

--- a/stdlib/public/Concurrency/Clock.cpp
+++ b/stdlib/public/Concurrency/Clock.cpp
@@ -68,7 +68,7 @@ void swift_get_time(
     case swift_clock_id_suspending: {
 #if defined(__linux__) && HAS_TIME
       struct timespec suspending;
-      clock_gettime(CLOCK_MONOTONIC_RAW, &suspending);
+      clock_gettime(CLOCK_MONOTONIC, &suspending);
       *seconds = suspending.tv_sec;
       *nanoseconds = suspending.tv_nsec;
 #elif defined(__APPLE__) && HAS_TIME

--- a/stdlib/public/Concurrency/Clock.cpp
+++ b/stdlib/public/Concurrency/Clock.cpp
@@ -37,7 +37,12 @@ void swift_get_time(
       clock_gettime(CLOCK_BOOTTIME, &continuous);
       *seconds = continuous.tv_sec;
       *nanoseconds = continuous.tv_nsec;
-#elif (defined(__APPLE__) || defined(__OpenBSD__)) && HAS_TIME
+#elif defined(__APPLE__) && HAS_TIME
+      struct timespec continuous;
+      clock_gettime(CLOCK_MONOTONIC_RAW, &continuous);
+      *seconds = continuous.tv_sec;
+      *nanoseconds = continuous.tv_nsec;
+#elif defined(__OpenBSD__)) && HAS_TIME
       struct timespec continuous;
       clock_gettime(CLOCK_MONOTONIC, &continuous);
       *seconds = continuous.tv_sec;
@@ -111,7 +116,12 @@ switch (clock_id) {
       clock_getres(CLOCK_BOOTTIME, &continuous);
       *seconds = continuous.tv_sec;
       *nanoseconds = continuous.tv_nsec;
-#elif (defined(__APPLE__) || defined(__OpenBSD__)) && HAS_TIME
+#elif defined(__APPLE__) && HAS_TIME
+      struct timespec continuous;
+      clock_getres(CLOCK_MONOTONIC_RAW, &continuous);
+      *seconds = continuous.tv_sec;
+      *nanoseconds = continuous.tv_nsec;
+#elif defined(__OpenBSD__)) && HAS_TIME;
       struct timespec continuous;
       clock_getres(CLOCK_MONOTONIC, &continuous);
       *seconds = continuous.tv_sec;

--- a/stdlib/public/Concurrency/DispatchGlobalExecutor.inc
+++ b/stdlib/public/Concurrency/DispatchGlobalExecutor.inc
@@ -234,12 +234,12 @@ struct __swift_job_source {
 
 static void _swift_run_job_leeway(struct __swift_job_source *jobSource) {
   dispatch_source_t source = jobSource->source;
+  dispatch_release(source);
   Job *job = jobSource->job;
   auto task = dyn_cast<AsyncTask>(job);
   assert(task && "provided job must be a task");
   _swift_task_dealloc_specific(task, jobSource);
   __swift_run_job(job);
-  dispatch_release(source);
 }
 
 #if defined(__i386__) || defined(__x86_64__) || !defined(__APPLE__)
@@ -252,7 +252,7 @@ static void _swift_run_job_leeway(struct __swift_job_source *jobSource) {
 // x86 currently implements mach time in nanoseconds
 // this is NOT likely to change
 static inline uint64_t
-time_nano2mach(uint64_t nsec) {
+platform_time(uint64_t nsec) {
   return nsec;
 }
 #else
@@ -261,7 +261,7 @@ time_nano2mach(uint64_t nsec) {
 #if defined(__arm__) || defined(__arm64__)
 // Apple arm platforms currently use a fixed mach timebase of 125/3 (24 MHz)
 static inline uint64_t
-time_nano2mach(uint64_t nsec) {
+platform_time(uint64_t nsec) {
   if (!nsec) {
     return nsec;
   }
@@ -280,7 +280,7 @@ time_nano2mach(uint64_t nsec) {
 
 static inline dispatch_time_t
 clock_and_value_to_time(int clock, long long deadline) {
-  uint64_t value = time_nano2mach((uint64_t)deadline);
+  uint64_t value = platform_time((uint64_t)deadline);
   if (value >= DISPATCH_TIME_MAX_VALUE) {
     return DISPATCH_TIME_FOREVER;
   }
@@ -300,8 +300,7 @@ static void swift_task_enqueueGlobalWithDeadlineImpl(long long sec,
                                                      long long tnsec,
                                                      int clock, Job *job) {
   assert(job && "no job provided");
-  auto task = dyn_cast<AsyncTask>(job);
-  assert(task && "provided job must be a task");
+  auto task = cast<AsyncTask>(job);
 
   JobPriority priority = job->getPriority();
 
@@ -312,9 +311,7 @@ static void swift_task_enqueueGlobalWithDeadlineImpl(long long sec,
 
   uint64_t deadline = sec * NSEC_PER_SEC + nsec;
   dispatch_time_t when = clock_and_value_to_time(clock, deadline);
-  dispatch_function_t dispatchFunction = 
-    (dispatch_function_t)&_swift_run_job_leeway;
-
+  
   if (tnsec != -1) {
     uint64_t leeway = tsec * NSEC_PER_SEC + tnsec;
 
@@ -331,12 +328,13 @@ static void swift_task_enqueueGlobalWithDeadlineImpl(long long sec,
     jobSource->source = source;
 
     dispatch_set_context(source, jobSource);
-    dispatch_source_set_event_handler_f(source, dispatchFunction);
+    dispatch_source_set_event_handler_f(source, 
+      (dispatch_function_t)&_swift_run_job_leeway);
 
     dispatch_activate(source);
   } else {
-    dispatchFunction = &__swift_run_job;
-    dispatch_after_f(when, queue, (void *)job, dispatchFunction);
+    dispatch_after_f(when, queue, (void *)job, 
+      (dispatch_function_t)&__swift_run_job);
   }
 }
 

--- a/stdlib/public/Concurrency/DispatchGlobalExecutor.inc
+++ b/stdlib/public/Concurrency/DispatchGlobalExecutor.inc
@@ -323,7 +323,7 @@ static void swift_task_enqueueGlobalWithDeadlineImpl(long long sec,
     dispatch_source_set_timer(source, when, DISPATCH_TIME_FOREVER, leeway);
 
     size_t sz = sizeof(struct __swift_job_source);
-    
+
     struct __swift_job_source *jobSource = 
         (struct __swift_job_source *)_swift_task_alloc_specific(task, sz);
     

--- a/stdlib/public/Concurrency/DispatchGlobalExecutor.inc
+++ b/stdlib/public/Concurrency/DispatchGlobalExecutor.inc
@@ -24,21 +24,9 @@
 
 #if SWIFT_CONCURRENCY_ENABLE_DISPATCH
 #include <dispatch/dispatch.h>
-#if __has_include(<dispatch/private.h>)
-#include <dispatch/private.h>
-#else
-DISPATCH_ENUM(dispatch_clockid, uintptr_t,
-  DISPATCH_CLOCKID_UPTIME = 1,
-  DISPATCH_CLOCKID_MONOTONIC = 2,
-  DISPATCH_CLOCKID_WALLTIME = 3,
-  DISPATCH_CLOCKID_REALTIME = 3,
-);
-#endif
-
 #if !defined(_WIN32)
 #include <dlfcn.h>
 #endif
-
 #endif
 
 // Ensure that Job's layout is compatible with what Dispatch expects.
@@ -244,10 +232,12 @@ struct __swift_job_source {
   Job *job;
 };
 
-static void __swift_run_job_leeway(struct __swift_job_source *jobSource) {
+static void _swift_run_job_leeway(struct __swift_job_source *jobSource) {
   dispatch_source_t source = jobSource->source;
   Job *job = jobSource->job;
-  free(jobSource);
+  auto task = dyn_cast<AsyncTask>(job);
+  assert(task && "provided job must be a task");
+  _swift_task_dealloc_specific(task, jobSource);
   __swift_run_job(job);
   dispatch_release(source);
 }
@@ -310,6 +300,9 @@ static void swift_task_enqueueGlobalWithDeadlineImpl(long long sec,
                                                      long long tnsec,
                                                      int clock, Job *job) {
   assert(job && "no job provided");
+  auto task = dyn_cast<AsyncTask>(job);
+  assert(task && "provided job must be a task");
+
   JobPriority priority = job->getPriority();
 
   auto queue = getGlobalQueue(priority);
@@ -317,37 +310,33 @@ static void swift_task_enqueueGlobalWithDeadlineImpl(long long sec,
   job->SchedulerPrivate[Job::DispatchQueueIndex] =
       DISPATCH_QUEUE_GLOBAL_EXECUTOR;
 
-  dispatch_clockid_t dispatchClock;
-  if (clock == swift_clock_id_continuous) {
-    dispatchClock = DISPATCH_CLOCKID_MONOTONIC;
-  } else {
-    dispatchClock = DISPATCH_CLOCKID_UPTIME;
-  }
   uint64_t deadline = sec * NSEC_PER_SEC + nsec;
   dispatch_time_t when = clock_and_value_to_time(clock, deadline);
-  
+  dispatch_function_t dispatchFunction = 
+    (dispatch_function_t)&_swift_run_job_leeway;
+
   if (tnsec != -1) {
     uint64_t leeway = tsec * NSEC_PER_SEC + tnsec;
 
     dispatch_source_t source = 
       dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, queue);
+    dispatch_source_set_timer(source, when, DISPATCH_TIME_FOREVER, leeway);
+
+    size_t sz = sizeof(struct __swift_job_source);
     
     struct __swift_job_source *jobSource = 
-      (struct __swift_job_source *)malloc(sizeof(struct __swift_job_source));
+        (struct __swift_job_source *)_swift_task_alloc_specific(task, sz);
+    
     jobSource->job = job;
     jobSource->source = source;
 
     dispatch_set_context(source, jobSource);
-    dispatch_source_set_timer(source, when, 
-                              DISPATCH_TIME_FOREVER, leeway);
-    dispatch_source_set_event_handler_f(source, 
-                                  (dispatch_function_t)&__swift_run_job_leeway);
-    
+    dispatch_source_set_event_handler_f(source, dispatchFunction);
+
     dispatch_activate(source);
   } else {
-    dispatch_function_t dispatchFunction = &__swift_run_job;
-    void *dispatchContext = job;
-    dispatch_after_f(when, queue, dispatchContext, dispatchFunction);
+    dispatchFunction = &__swift_run_job;
+    dispatch_after_f(when, queue, (void *)job, dispatchFunction);
   }
 }
 

--- a/stdlib/public/Concurrency/DispatchGlobalExecutor.inc
+++ b/stdlib/public/Concurrency/DispatchGlobalExecutor.inc
@@ -24,6 +24,22 @@
 
 #if SWIFT_CONCURRENCY_ENABLE_DISPATCH
 #include <dispatch/dispatch.h>
+#if __has_include(<dispatch/private.h>)
+#include <dispatch/private.h>
+#else
+extern "C" {
+DISPATCH_ENUM(dispatch_clockid, uintptr_t,
+  DISPATCH_CLOCKID_UPTIME = 1,
+  DISPATCH_CLOCKID_MONOTONIC = 2,
+  DISPATCH_CLOCKID_WALLTIME = 3,
+  DISPATCH_CLOCKID_REALTIME = 3,
+);
+
+DISPATCH_EXPORT DISPATCH_WARN_RESULT DISPATCH_NOTHROW
+dispatch_time_t
+dispatch_time_from_nsec(dispatch_clockid_t clock, uint64_t deadline);
+}
+#endif
 
 #if !defined(_WIN32)
 #include <dlfcn.h>
@@ -227,6 +243,18 @@ static void swift_task_enqueueGlobalWithDelayImpl(JobDelay delay,
 
 #define DISPATCH_UP_OR_MONOTONIC_TIME_MASK  (1ULL << 63)
 
+struct __swift_job_source {
+  dispatch_source_t source;
+  Job *job;
+};
+
+static void __swift_run_job_leeway(Job *job) {
+  dispatch_source_t source = (dispatch_source_t)job->Reserved;
+  job->Reserved = nullptr;
+  __swift_run_job(job);
+  dispatch_release(source);
+}
+
 SWIFT_CC(swift)
 static void swift_task_enqueueGlobalWithDeadlineImpl(long long sec,
                                                      long long nsec,
@@ -234,10 +262,6 @@ static void swift_task_enqueueGlobalWithDeadlineImpl(long long sec,
                                                      long long tnsec,
                                                      int clock, Job *job) {
   assert(job && "no job provided");
-
-  dispatch_function_t dispatchFunction = &__swift_run_job;
-  void *dispatchContext = job;
-
   JobPriority priority = job->getPriority();
 
   auto queue = getGlobalQueue(priority);
@@ -245,20 +269,27 @@ static void swift_task_enqueueGlobalWithDeadlineImpl(long long sec,
   job->SchedulerPrivate[Job::DispatchQueueIndex] =
       DISPATCH_QUEUE_GLOBAL_EXECUTOR;
 
-  long long nowSec;
-  long long nowNsec;
-  swift_get_time(&nowSec, &nowNsec, (swift_clock_id)clock);
-
-  uint64_t delta = (sec - nowSec) * NSEC_PER_SEC + nsec - nowNsec;
-
-  dispatch_time_t when = dispatch_time(DISPATCH_TIME_NOW, delta);
-
+  dispatch_clockid_t dispatchClock;
   if (clock == swift_clock_id_continuous) {
-    when |= DISPATCH_UP_OR_MONOTONIC_TIME_MASK;
+    dispatchClock = DISPATCH_CLOCKID_MONOTONIC;
+  } else {
+    dispatchClock = DISPATCH_CLOCKID_UPTIME;
   }
-  // TODO: this should pass the leeway/tolerance along when it is not -1 nanoseconds
-  // either a dispatch_source can be created or a better dispatch_after_f can be made for this
-  dispatch_after_f(when, queue, dispatchContext, dispatchFunction);
+  uint64_t deadline = sec * NSEC_PER_SEC + nsec;
+  dispatch_time_t when = dispatch_time_from_nsec(dispatchClock, deadline);
+  dispatch_source_t source = 
+    dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, queue);
+  job->Reserved = source;
+  dispatch_set_context(source, job);
+  uint64_t leeway = 0;
+  if (tnsec != -1) {
+    leeway = tsec * NSEC_PER_SEC + tnsec;
+  }
+  dispatch_source_set_timer(source, when, 
+                            DISPATCH_TIME_FOREVER, leeway);
+  dispatch_source_set_event_handler_f(source, 
+                                  (dispatch_function_t)&__swift_run_job_leeway);
+  dispatch_activate(source);
 }
 
 SWIFT_CC(swift)

--- a/stdlib/public/Concurrency/DispatchGlobalExecutor.inc
+++ b/stdlib/public/Concurrency/DispatchGlobalExecutor.inc
@@ -27,18 +27,12 @@
 #if __has_include(<dispatch/private.h>)
 #include <dispatch/private.h>
 #else
-extern "C" {
 DISPATCH_ENUM(dispatch_clockid, uintptr_t,
   DISPATCH_CLOCKID_UPTIME = 1,
   DISPATCH_CLOCKID_MONOTONIC = 2,
   DISPATCH_CLOCKID_WALLTIME = 3,
   DISPATCH_CLOCKID_REALTIME = 3,
 );
-
-DISPATCH_EXPORT DISPATCH_WARN_RESULT DISPATCH_NOTHROW
-dispatch_time_t
-dispatch_time_from_nsec(dispatch_clockid_t clock, uint64_t deadline);
-}
 #endif
 
 #if !defined(_WIN32)
@@ -242,17 +236,71 @@ static void swift_task_enqueueGlobalWithDelayImpl(JobDelay delay,
 }
 
 #define DISPATCH_UP_OR_MONOTONIC_TIME_MASK  (1ULL << 63)
+#define DISPATCH_WALLTIME_MASK  (1ULL << 62)
+#define DISPATCH_TIME_MAX_VALUE (DISPATCH_WALLTIME_MASK - 1)
 
 struct __swift_job_source {
   dispatch_source_t source;
   Job *job;
 };
 
-static void __swift_run_job_leeway(Job *job) {
-  dispatch_source_t source = (dispatch_source_t)job->Reserved;
-  job->Reserved = nullptr;
+static void __swift_run_job_leeway(struct __swift_job_source *jobSource) {
+  dispatch_source_t source = jobSource->source;
+  Job *job = jobSource->job;
+  free(jobSource);
   __swift_run_job(job);
   dispatch_release(source);
+}
+
+#if defined(__i386__) || defined(__x86_64__) || !defined(__APPLE__)
+#define TIME_UNIT_USES_NANOSECONDS 1
+#else
+#define TIME_UNIT_USES_NANOSECONDS 0
+#endif
+
+#if TIME_UNIT_USES_NANOSECONDS
+// x86 currently implements mach time in nanoseconds
+// this is NOT likely to change
+static inline uint64_t
+time_nano2mach(uint64_t nsec) {
+  return nsec;
+}
+#else
+#define DISPATCH_USE_HOST_TIME 1
+#if defined(__APPLE__)
+#if defined(__arm__) || defined(__arm64__)
+// Apple arm platforms currently use a fixed mach timebase of 125/3 (24 MHz)
+static inline uint64_t
+time_nano2mach(uint64_t nsec) {
+  if (!nsec) {
+    return nsec;
+  }
+  if (nsec >= (uint64_t)INT64_MAX) {
+    return INT64_MAX;
+  }
+  if (nsec >= UINT64_MAX / 3ull) {
+    return (nsec / 125ull) * 3ull;
+  } else {
+    return (nsec * 3ull) / 125ull;
+  }
+}
+#endif
+#endif
+#endif
+
+static inline dispatch_time_t
+clock_and_value_to_time(int clock, long long deadline) {
+  uint64_t value = time_nano2mach((uint64_t)deadline);
+  if (value >= DISPATCH_TIME_MAX_VALUE) {
+    return DISPATCH_TIME_FOREVER;
+  }
+  switch (clock) {
+  case swift_clock_id_suspending:
+    return value;
+  case swift_clock_id_continuous:
+    return value | DISPATCH_UP_OR_MONOTONIC_TIME_MASK;
+  }
+  __builtin_unreachable();
 }
 
 SWIFT_CC(swift)
@@ -276,20 +324,31 @@ static void swift_task_enqueueGlobalWithDeadlineImpl(long long sec,
     dispatchClock = DISPATCH_CLOCKID_UPTIME;
   }
   uint64_t deadline = sec * NSEC_PER_SEC + nsec;
-  dispatch_time_t when = dispatch_time_from_nsec(dispatchClock, deadline);
-  dispatch_source_t source = 
-    dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, queue);
-  job->Reserved = source;
-  dispatch_set_context(source, job);
-  uint64_t leeway = 0;
+  dispatch_time_t when = clock_and_value_to_time(clock, deadline);
+  
   if (tnsec != -1) {
-    leeway = tsec * NSEC_PER_SEC + tnsec;
-  }
-  dispatch_source_set_timer(source, when, 
-                            DISPATCH_TIME_FOREVER, leeway);
-  dispatch_source_set_event_handler_f(source, 
+    uint64_t leeway = tsec * NSEC_PER_SEC + tnsec;
+
+    dispatch_source_t source = 
+      dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, queue);
+    
+    struct __swift_job_source *jobSource = 
+      (struct __swift_job_source *)malloc(sizeof(struct __swift_job_source));
+    jobSource->job = job;
+    jobSource->source = source;
+
+    dispatch_set_context(source, jobSource);
+    dispatch_source_set_timer(source, when, 
+                              DISPATCH_TIME_FOREVER, leeway);
+    dispatch_source_set_event_handler_f(source, 
                                   (dispatch_function_t)&__swift_run_job_leeway);
-  dispatch_activate(source);
+    
+    dispatch_activate(source);
+  } else {
+    dispatch_function_t dispatchFunction = &__swift_run_job;
+    void *dispatchContext = job;
+    dispatch_after_f(when, queue, dispatchContext, dispatchFunction);
+  }
 }
 
 SWIFT_CC(swift)

--- a/test/Concurrency/Runtime/clock.swift
+++ b/test/Concurrency/Runtime/clock.swift
@@ -21,6 +21,16 @@ var tests = TestSuite("Time")
       expectTrue(elapsed < .milliseconds(200))
     }
 
+    tests.test("ContinuousClock sleep with tolerance") {
+      let clock = ContinuousClock()
+      let elapsed = await clock.measure {
+        try! await clock.sleep(until: .now + .milliseconds(100), tolerance: .milliseconds(100))
+      }
+      // give a reasonable range of expected elapsed time
+      expectTrue(elapsed > .milliseconds(90))
+      expectTrue(elapsed < .milliseconds(300))
+    }
+
     tests.test("ContinuousClock sleep longer") {
       let elapsed = await ContinuousClock().measure {
         try! await Task.sleep(until: .now + .seconds(1), clock: .continuous)
@@ -37,6 +47,16 @@ var tests = TestSuite("Time")
       // give a reasonable range of expected elapsed time
       expectTrue(elapsed > .milliseconds(90))
       expectTrue(elapsed < .milliseconds(200))
+    }
+
+    tests.test("SuspendingClock sleep with tolerance") {
+      let clock = SuspendingClock()
+      let elapsed = await clock.measure {
+        try! await clock.sleep(until: .now + .milliseconds(100), tolerance: .milliseconds(100))
+      }
+      // give a reasonable range of expected elapsed time
+      expectTrue(elapsed > .milliseconds(90))
+      expectTrue(elapsed < .milliseconds(300))
     }
 
     tests.test("SuspendingClock sleep longer") {

--- a/test/Concurrency/Runtime/clock.swift
+++ b/test/Concurrency/Runtime/clock.swift
@@ -17,8 +17,8 @@ var tests = TestSuite("Time")
         try! await clock.sleep(until: .now + .milliseconds(100))
       }
       // give a reasonable range of expected elapsed time
-      expectTrue(elapsed > .milliseconds(90))
-      expectTrue(elapsed < .milliseconds(200))
+      expectGT(elapsed, .milliseconds(90))
+      expectLT(elapsed, .milliseconds(200))
     }
 
     tests.test("ContinuousClock sleep with tolerance") {
@@ -27,16 +27,16 @@ var tests = TestSuite("Time")
         try! await clock.sleep(until: .now + .milliseconds(100), tolerance: .milliseconds(100))
       }
       // give a reasonable range of expected elapsed time
-      expectTrue(elapsed > .milliseconds(90))
-      expectTrue(elapsed < .milliseconds(300))
+      expectGT(elapsed, .milliseconds(90))
+      expectLT(elapsed, .milliseconds(300))
     }
 
     tests.test("ContinuousClock sleep longer") {
       let elapsed = await ContinuousClock().measure {
         try! await Task.sleep(until: .now + .seconds(1), clock: .continuous)
       }
-      expectTrue(elapsed > .seconds(1) - .milliseconds(90))
-      expectTrue(elapsed < .seconds(1) + .milliseconds(200))
+      expectGT(elapsed, .seconds(1) - .milliseconds(90))
+      expectLT(elapsed, .seconds(1) + .milliseconds(200))
     }
 
     tests.test("SuspendingClock sleep") {
@@ -45,8 +45,8 @@ var tests = TestSuite("Time")
         try! await clock.sleep(until: .now + .milliseconds(100))
       }
       // give a reasonable range of expected elapsed time
-      expectTrue(elapsed > .milliseconds(90))
-      expectTrue(elapsed < .milliseconds(200))
+      expectGT(elapsed, .milliseconds(90))
+      expectLT(elapsed, .milliseconds(200))
     }
 
     tests.test("SuspendingClock sleep with tolerance") {
@@ -55,16 +55,16 @@ var tests = TestSuite("Time")
         try! await clock.sleep(until: .now + .milliseconds(100), tolerance: .milliseconds(100))
       }
       // give a reasonable range of expected elapsed time
-      expectTrue(elapsed > .milliseconds(90))
-      expectTrue(elapsed < .milliseconds(300))
+      expectGT(elapsed, .milliseconds(90))
+      expectLT(elapsed, .milliseconds(300))
     }
 
     tests.test("SuspendingClock sleep longer") {
       let elapsed = await SuspendingClock().measure {
         try! await Task.sleep(until: .now + .seconds(1), clock: .suspending)
       }
-      expectTrue(elapsed > .seconds(1) - .milliseconds(90))
-      expectTrue(elapsed < .seconds(1) + .milliseconds(200))
+      expectGT(elapsed, .seconds(1) - .milliseconds(90))
+      expectLT(elapsed, .seconds(1) + .milliseconds(200))
     }
 
     tests.test("duration addition") {

--- a/test/Concurrency/Runtime/clock.swift
+++ b/test/Concurrency/Runtime/clock.swift
@@ -21,6 +21,14 @@ var tests = TestSuite("Time")
       expectTrue(elapsed < .milliseconds(200))
     }
 
+    tests.test("ContinuousClock sleep longer") {
+      let elapsed = await ContinuousClock().measure {
+        try! await Task.sleep(until: .now + .seconds(1), clock: .continuous)
+      }
+      expectTrue(elapsed > .seconds(1) - .milliseconds(90))
+      expectTrue(elapsed < .seconds(1) + .milliseconds(200))
+    }
+
     tests.test("SuspendingClock sleep") {
       let clock = SuspendingClock()
       let elapsed = await clock.measure {
@@ -29,6 +37,14 @@ var tests = TestSuite("Time")
       // give a reasonable range of expected elapsed time
       expectTrue(elapsed > .milliseconds(90))
       expectTrue(elapsed < .milliseconds(200))
+    }
+
+    tests.test("SuspendingClock sleep longer") {
+      let elapsed = await SuspendingClock().measure {
+        try! await Task.sleep(until: .now + .seconds(1), clock: .suspending)
+      }
+      expectTrue(elapsed > .seconds(1) - .milliseconds(90))
+      expectTrue(elapsed < .seconds(1) + .milliseconds(200))
     }
 
     tests.test("duration addition") {


### PR DESCRIPTION
Continuous clocks incorrectly used non raw clock values (which could result in missing time frames in cases where the raw clock did not align with dispatch's expectations).

This aligns those expectations further as well as handling the leeway functions for the clock sources.