### PR TITLE
[ConstraintSystem] Improve precision of "too complex" diagnostic

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5415,9 +5415,9 @@ public:
   
   /// Determine if we've already explored too many paths in an
   /// attempt to solve this expression.
-  bool isExpressionAlreadyTooComplex = false;
-  bool getExpressionTooComplex(size_t solutionMemory) {
-    if (isExpressionAlreadyTooComplex)
+  bool isAlreadyTooComplex = false;
+  bool isTooComplex(size_t solutionMemory) {
+    if (isAlreadyTooComplex)
       return true;
 
     auto CancellationFlag = getASTContext().CancellationFlag;
@@ -5428,7 +5428,7 @@ public:
     MaxMemory = std::max(used, MaxMemory);
     auto threshold = getASTContext().TypeCheckerOpts.SolverMemoryThreshold;
     if (MaxMemory > threshold) {
-      return isExpressionAlreadyTooComplex= true;
+      return isAlreadyTooComplex= true;
     }
 
     if (Timer && Timer->isExpired()) {
@@ -5437,27 +5437,27 @@ public:
       // emitting an error.
       Timer->disableWarning();
 
-      return isExpressionAlreadyTooComplex = true;
+      return isAlreadyTooComplex = true;
     }
 
     // Bail out once we've looked at a really large number of
     // choices.
     if (CountScopes > getASTContext().TypeCheckerOpts.SolverBindingThreshold) {
-      return isExpressionAlreadyTooComplex = true;
+      return isAlreadyTooComplex = true;
     }
 
     return false;
   }
 
-  bool getExpressionTooComplex(SmallVectorImpl<Solution> const &solutions) {
-    if (isExpressionAlreadyTooComplex)
+  bool isTooComplex(SmallVectorImpl<Solution> const &solutions) {
+    if (isAlreadyTooComplex)
       return true;
 
     size_t solutionMemory = 0;
     for (auto const& s : solutions) {
       solutionMemory += s.getTotalMemory();
     }
-    return getExpressionTooComplex(solutionMemory);
+    return isTooComplex(solutionMemory);
   }
 
   // If the given constraint is an applied disjunction, get the argument function

--- a/include/swift/Sema/SolutionResult.h
+++ b/include/swift/Sema/SolutionResult.h
@@ -64,6 +64,9 @@ private:
   /// \c numSolutions entries.
   Solution *solutions = nullptr;
 
+  /// A source range that was too complex to solve.
+  Optional<SourceRange> TooComplexAt = None;
+
   /// General constructor for the named constructors.
   SolutionResult(Kind kind) : kind(kind) {
     emittedDiagnostic = false;
@@ -95,9 +98,7 @@ public:
 
   /// Produce a "too complex" failure, which was not yet been
   /// diagnosed.
-  static SolutionResult forTooComplex() {
-    return SolutionResult(TooComplex);
-  }
+  static SolutionResult forTooComplex(Optional<SourceRange> affected);
 
   /// Produce a failure that has already been diagnosed.
   static SolutionResult forError() {
@@ -122,6 +123,10 @@ public:
 
   /// Take the set of solutions when there is an ambiguity.
   MutableArrayRef<Solution> takeAmbiguousSolutions() &&;
+
+  /// Retrieve a range of source that has been determined to be too
+  /// complex to solve in a reasonable time.
+  Optional<SourceRange> getTooComplexAt() const { return TooComplexAt; }
 
   /// Whether this solution requires the client to produce a diagnostic.
   bool requiresDiagnostic() const {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -9106,6 +9106,12 @@ SolutionResult SolutionResult::forAmbiguous(
   return result;
 }
 
+SolutionResult SolutionResult::forTooComplex(Optional<SourceRange> affected) {
+  SolutionResult result(Kind::TooComplex);
+  result.TooComplexAt = affected;
+  return result;
+}
+
 SolutionResult::~SolutionResult() {
   assert((!requiresDiagnostic() || emittedDiagnostic) &&
          "SolutionResult was destroyed without emitting a diagnostic");

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1374,7 +1374,7 @@ ConstraintSystem::solveImpl(SolutionApplicationTarget &target,
   SmallVector<Solution, 4> solutions;
   solve(solutions, allowFreeTypeVariables);
 
-  if (getExpressionTooComplex(solutions))
+  if (isTooComplex(solutions))
     return SolutionResult::forTooComplex();
 
   switch (solutions.size()) {
@@ -1415,7 +1415,7 @@ bool ConstraintSystem::solve(SmallVectorImpl<Solution> &solutions,
   filterSolutions(solutions);
 
   // We fail if there is no solution or the expression was too complex.
-  return solutions.empty() || getExpressionTooComplex(solutions);
+  return solutions.empty() || isTooComplex(solutions);
 }
 
 void ConstraintSystem::solveImpl(SmallVectorImpl<Solution> &solutions) {

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -251,7 +251,7 @@ bool SplitterStep::mergePartialSolutions() const {
 
     // Since merging partial solutions can go exponential, make sure we didn't
     // pass the "too complex" thresholds including allocated memory and time.
-    if (CS.getExpressionTooComplex(solutionMemory))
+    if (CS.isTooComplex(solutionMemory))
       return false;
 
   } while (nextCombination(counts, indices));
@@ -313,7 +313,7 @@ StepResult ComponentStep::take(bool prevFailed) {
   // One of the previous components created by "split"
   // failed, it means that we can't solve this component.
   if ((prevFailed && DependsOnPartialSolutions.empty()) ||
-      CS.getExpressionTooComplex(Solutions))
+      CS.isTooComplex(Solutions))
     return done(/*isSuccess=*/false);
 
   // Setup active scope, only if previous component didn't fail.

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -506,7 +506,7 @@ public:
   StepResult take(bool prevFailed) override {
     // Before attempting the next choice, let's check whether the constraint
     // system is too complex already.
-    if (CS.getExpressionTooComplex(Solutions))
+    if (CS.isTooComplex(Solutions))
       return done(/*isSuccess=*/false);
 
     while (auto choice = Producer()) {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3784,7 +3784,7 @@ SolutionResult ConstraintSystem::salvage() {
   }
 
   if (isTooComplex(viable))
-    return SolutionResult::forTooComplex();
+    return SolutionResult::forTooComplex(getTooComplexRange());
 
   // Could not produce a specific diagnostic; punt to the client.
   return SolutionResult::forUndiagnosedError();

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3776,7 +3776,7 @@ SolutionResult ConstraintSystem::salvage() {
     // Fall through to produce diagnostics.
   }
 
-  if (getExpressionTooComplex(viable))
+  if (isTooComplex(viable))
     return SolutionResult::forTooComplex();
 
   // Could not produce a specific diagnostic; punt to the client.

--- a/validation-test/Sema/type_checker_perf/slow/rdar19612086.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar19612086.swift
@@ -11,12 +11,11 @@ struct rdar19612086 {
   let x = 1.0
 
   var description : String {
-    return "\(i)" + Stringly(format: "%.2f", x) +
+    return "\(i)" + Stringly(format: "%.2f", x) +   // expected-error {{reasonable time}}
            "\(i+1)" + Stringly(format: "%.2f", x) +
            "\(i+2)" + Stringly(format: "%.2f", x) +
            "\(i+3)" + Stringly(format: "%.2f", x) +
            "\(i+4)" + Stringly(format: "%.2f", x) +
            "\(i+5)" + Stringly(format: "%.2f", x)
-    // expected-error@-1 {{reasonable time}}
   }
 }

--- a/validation-test/Sema/type_checker_perf/slow/rdar22079400.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar22079400.swift
@@ -1,9 +1,8 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
 // REQUIRES: tools-release,no_asan
 
-let _ = (0...1).lazy.flatMap {
+let _ = (0...1).lazy.flatMap { // expected-error {{reasonable time}}
   a in (1...2).lazy.map { b in (a, b) }
 }.filter {
-  // expected-error@-1 {{reasonable time}}
   1 < $0 && $0 < $1 && $0 + $1 < 3
 }

--- a/validation-test/Sema/type_checker_perf/slow/rdar91310777.swift
+++ b/validation-test/Sema/type_checker_perf/slow/rdar91310777.swift
@@ -1,0 +1,16 @@
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// REQUIRES: tools-release,no_asan
+
+func compute(_ cont: () -> Void) {}
+
+func test() {
+  compute {
+    let x = 42
+    compute {
+      print(x)
+      let v: UInt64 = UInt64((24 / UInt32(1)) + UInt32(0) - UInt32(0) - 24 / 42 - 42)
+      // expected-error@-1 {{the compiler is unable to type-check this expression in reasonable time; try breaking up the expression into distinct sub-expressions}}
+      print(v)
+    }
+  }
+}


### PR DESCRIPTION
This is a follow-up to https://github.com/apple/swift/pull/41282 which introduced a
timer per sub-target. This patch takes advantage of the fact that `ExpressionTime`
holds locator and uses that to compute affected range, which helps to point to a
particular sub-target were "too complex" has been detected.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
