### PR TITLE
[Diagnostics] Improve diagnostic message for extraneous `&`

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1206,7 +1206,7 @@ ERROR(missing_address_of_yield,none,
       "yielding mutable value of type %0 requires explicit '&'",
       (Type))
 ERROR(extraneous_address_of,none,
-      "use of extraneous '&'",
+      "'&' may only be used to pass an argument to inout parameter",
       ())
 ERROR(extra_address_of,none,
       "'&' used with non-inout argument of type %0",

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -453,7 +453,7 @@ func testTypeSugar(_ a : Int) {
 
 // <rdar://problem/21974772> SegFault in FailureDiagnosis::visitInOutExpr
 func r21974772(_ y : Int) {
-  let x = &(1.0 + y) // expected-error {{use of extraneous '&'}}
+  let x = &(1.0 + y) // expected-error {{'&' may only be used to pass an argument to inout parameter}}
 }
 
 // <rdar://problem/22020088> QoI: missing member diagnostic on optional gives worse error message than existential/bound generic/etc

--- a/test/Constraints/lvalues.swift
+++ b/test/Constraints/lvalues.swift
@@ -159,8 +159,8 @@ func testInOut(_ arg: inout Int) {
 }
 
 // Don't infer inout types.
-var ir = &i // expected-error {{use of extraneous '&'}}
-var ir2 = ((&i)) // expected-error {{use of extraneous '&'}}
+var ir = &i // expected-error {{'&' may only be used to pass an argument to inout parameter}}
+var ir2 = ((&i)) // expected-error {{'&' may only be used to pass an argument to inout parameter}}
 
 // <rdar://problem/17133089>
 func takeArrayRef(_ x: inout Array<String>) { }
@@ -279,10 +279,10 @@ func look_through_parens_when_checking_inout() {
   func modifyPoint(source: inout Point) {}
 
   var point = Point(x: 0, y: 0)
-  modifyPoint((&point)) // expected-error {{use of extraneous '&}} {{16-17=(}} {{15-16=&}}
-  modifyPoint(((&point))) // expected-error {{use of extraneous '&}} {{17-18=(}} {{15-16=&}}
-  modifyPoint(source: (&point)) // expected-error {{use of extraneous '&}} {{24-25=(}} {{23-24=&}}
-  modifyPoint(source: ((&point))) // expected-error {{use of extraneous '&}} {{25-26=(}} {{23-24=&}}
-  modifyPoint((&point), 0) // expected-error {{use of extraneous '&}} {{16-17=(}} {{15-16=&}}
-  modifyPoint((&point), msg: "") // expected-error {{use of extraneous '&}} {{16-17=(}} {{15-16=&}}
+  modifyPoint((&point)) // expected-error {{'&' may only be used to pass an argument to inout parameter}} {{16-17=(}} {{15-16=&}}
+  modifyPoint(((&point))) // expected-error {{'&' may only be used to pass an argument to inout parameter}} {{17-18=(}} {{15-16=&}}
+  modifyPoint(source: (&point)) // expected-error {{'&' may only be used to pass an argument to inout parameter}} {{24-25=(}} {{23-24=&}}
+  modifyPoint(source: ((&point))) // expected-error {{'&' may only be used to pass an argument to inout parameter}} {{25-26=(}} {{23-24=&}}
+  modifyPoint((&point), 0) // expected-error {{'&' may only be used to pass an argument to inout parameter}} {{16-17=(}} {{15-16=&}}
+  modifyPoint((&point), msg: "") // expected-error {{'&' may only be used to pass an argument to inout parameter}} {{16-17=(}} {{15-16=&}}
 }

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -470,17 +470,17 @@ func rdar75146811() {
   var arr: [Double]! = []
 
   test(&arr) // expected-error {{cannot convert value of type '[Double]?' to expected argument type 'Double'}}
-  test((&arr)) // expected-error {{use of extraneous '&'}}
+  test((&arr)) // expected-error {{'&' may only be used to pass an argument to inout parameter}}
   // expected-error@-1 {{cannot convert value of type '[Double]?' to expected argument type 'Double'}}
   test(&(arr)) // expected-error {{cannot convert value of type '[Double]?' to expected argument type 'Double'}}
 
   test_tuple(&arr, x: 0) // expected-error {{cannot convert value of type '[Double]?' to expected argument type 'Double'}}
-  test_tuple((&arr), x: 0) // expected-error {{use of extraneous '&'}}
+  test_tuple((&arr), x: 0) // expected-error {{'&' may only be used to pass an argument to inout parameter}}
   // expected-error@-1 {{cannot convert value of type '[Double]?' to expected argument type 'Double'}}
   test_tuple(&(arr), x: 0) // expected-error {{cannot convert value of type '[Double]?' to expected argument type 'Double'}}
 
   test_named(x: &arr) // expected-error {{cannot convert value of type '[Double]?' to expected argument type 'Double'}}
-  test_named(x: (&arr)) // expected-error {{use of extraneous '&'}}
+  test_named(x: (&arr)) // expected-error {{'&' may only be used to pass an argument to inout parameter}}
   // expected-error@-1 {{cannot convert value of type '[Double]?' to expected argument type 'Double'}}
   test_named(x: &(arr)) // expected-error {{cannot convert value of type '[Double]?' to expected argument type 'Double'}}
 }

--- a/test/Parse/pointer_conversion.swift.gyb
+++ b/test/Parse/pointer_conversion.swift.gyb
@@ -65,8 +65,8 @@ func mutablePointerArguments(_ p: UnsafeMutablePointer<Int>,
   takesMutableArrayPointer(&ii)
 
   // We don't allow these conversions outside of function arguments.
-  var x: UnsafeMutablePointer<Int> = &i // expected-error {{use of extraneous '&'}}
-  x = &ii // expected-error {{use of extraneous '&'}}
+  var x: UnsafeMutablePointer<Int> = &i // expected-error {{'&' may only be used to pass an argument to inout parameter}}
+  x = &ii // expected-error {{'&' may only be used to pass an argument to inout parameter}}
   _ = x
 }
 
@@ -97,9 +97,9 @@ func mutableVoidPointerArguments(_ p: UnsafeMutablePointer<Int>,
   takesMutableVoidPointer(ff) // expected-error{{cannot convert value of type '[Int]' to expected argument type 'UnsafeMutableRawPointer${diag_suffix}'}}
 
   // We don't allow these conversions outside of function arguments.
-  var x: UnsafeMutableRawPointer = &i // expected-error {{use of extraneous '&'}}
+  var x: UnsafeMutableRawPointer = &i // expected-error {{'&' may only be used to pass an argument to inout parameter}}
   x = p // expected-error{{cannot assign value of type 'UnsafeMutablePointer<Int>' to type 'UnsafeMutableRawPointer'}}
-  x = &ii // expected-error {{use of extraneous '&'}}
+  x = &ii // expected-error {{'&' may only be used to pass an argument to inout parameter}}
   _ = x
 }
 
@@ -132,9 +132,9 @@ func mutableRawPointerArguments(_ p: UnsafeMutablePointer<Int>,
   takesMutableRawPointer(ff) // expected-error{{cannot convert value of type '[Int]' to expected argument type 'UnsafeMutableRawPointer${diag_suffix}'}}
 
   // We don't allow these conversions outside of function arguments.
-  var x: UnsafeMutableRawPointer = &i // expected-error {{use of extraneous '&'}}
+  var x: UnsafeMutableRawPointer = &i // expected-error {{'&' may only be used to pass an argument to inout parameter}}
   x = p // expected-error{{cannot assign value of type 'UnsafeMutablePointer<Int>' to type 'UnsafeMutableRawPointer'}}
-  x = &ii //expected-error {{use of extraneous '&'}}
+  x = &ii //expected-error {{'&' may only be used to pass an argument to inout parameter}}
   _ = x
 }
 
@@ -167,7 +167,7 @@ func constPointerArguments(_ p: UnsafeMutablePointer<Int>,
   // expected-error@-1 3 {{cannot convert value of type 'Double' to expected element type 'Int'}}
 
   // We don't allow these conversions outside of function arguments.
-  var x: UnsafePointer<Int> = &i // expected-error {{use of extraneous '&'}}
+  var x: UnsafePointer<Int> = &i // expected-error {{'&' may only be used to pass an argument to inout parameter}}
   x = ii // expected-error{{cannot assign value of type '[Int]' to type 'UnsafePointer<Int>'}}
   x = p // expected-error{{cannot assign value of type 'UnsafeMutablePointer<Int>' to type 'UnsafePointer<Int>'}}
 }
@@ -201,7 +201,7 @@ func constVoidPointerArguments(_ p: UnsafeMutablePointer<Int>,
   takesConstVoidPointer([0.0, 1.0, 2.0])
 
   // We don't allow these conversions outside of function arguments.
-  var x: UnsafeRawPointer = &i // expected-error {{use of extraneous '&'}}
+  var x: UnsafeRawPointer = &i // expected-error {{'&' may only be used to pass an argument to inout parameter}}
   x = ii // expected-error{{cannot assign value of type '[Int]' to type 'UnsafeRawPointer'}}
   x = p // expected-error{{cannot assign value of type 'UnsafeMutablePointer<Int>' to type 'UnsafeRawPointer'}}
   x = fp // expected-error{{cannot assign value of type 'UnsafeMutablePointer<Float>' to type 'UnsafeRawPointer'}}
@@ -241,7 +241,7 @@ func constRawPointerArguments(_ p: UnsafeMutablePointer<Int>,
   takesConstRawPointer([0.0, 1.0, 2.0])
 
   // We don't allow these conversions outside of function arguments.
-  var x: UnsafeRawPointer = &i // expected-error {{use of extraneous '&'}}
+  var x: UnsafeRawPointer = &i // expected-error {{'&' may only be used to pass an argument to inout parameter}}
   x = ii // expected-error{{cannot assign value of type '[Int]' to type 'UnsafeRawPointer'}}
   x = p // expected-error{{cannot assign value of type 'UnsafeMutablePointer<Int>' to type 'UnsafeRawPointer'}}
   x = fp // expected-error{{cannot assign value of type 'UnsafeMutablePointer<Float>' to type 'UnsafeRawPointer'}}

--- a/test/Parse/pointer_conversion_objc.swift.gyb
+++ b/test/Parse/pointer_conversion_objc.swift.gyb
@@ -72,5 +72,5 @@ func autoreleasingPointerArguments(p: UnsafeMutablePointer<Int>,
   // expected-note@-1 {{arguments to generic parameter 'Pointee' ('[C]' and 'C') are expected to be equal}}
   takesAutoreleasingPointer(&dd) // expected-error{{cannot convert value of type 'AutoreleasingUnsafeMutablePointer<[D]>' to expected argument type 'AutoreleasingUnsafeMutablePointer<C>'}}
   // expected-note@-1 {{arguments to generic parameter 'Pointee' ('[D]' and 'C') are expected to be equal}}
-  let _: AutoreleasingUnsafeMutablePointer<C> = &c // expected-error {{use of extraneous '&'}}
+  let _: AutoreleasingUnsafeMutablePointer<C> = &c // expected-error {{'&' may only be used to pass an argument to inout parameter}}
 }

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -816,7 +816,7 @@ func test23550816(ss: [String], s: String) {
 // <rdar://problem/23719432> [practicalswift] Compiler crashes on &(Int:_)
 func test23719432() {
   var x = 42
-  &(Int:x) // expected-error {{use of extraneous '&'}}
+    &(Int:x) // expected-error {{'&' may only be used to pass an argument to inout parameter}}
 }
 
 // <rdar://problem/19911096> QoI: terrible recovery when using '·' for an operator

--- a/test/Sema/diag_invalid_interpolation_4_2.swift
+++ b/test/Sema/diag_invalid_interpolation_4_2.swift
@@ -10,6 +10,6 @@ _ = "\(y: &x)"
 // expected-note@-3 {{remove 'y' label to keep current behavior}}
 
 _ = "\(x, y: &x)"
-// expected-error@-1 {{use of extraneous '&'}}
+// expected-error@-1 {{'&' may only be used to pass an argument to inout parameter}}
 // expected-warning@-2 {{interpolating multiple values will not form a tuple in Swift 5}}
 // expected-note@-3 {{insert parentheses to keep current behavior}}

--- a/test/TypeCoercion/overload_noncall.swift
+++ b/test/TypeCoercion/overload_noncall.swift
@@ -52,7 +52,7 @@ func test_inout() {
   x = accept_XY(&xy);
 
   x = xy
-  x = &xy; // expected-error {{use of extraneous '&'}}
+  x = &xy; // expected-error {{'&' may only be used to pass an argument to inout parameter}}
   accept_Z(&xy); // expected-error{{cannot convert value of type 'X' to expected argument type 'Z'}}
 }
 

--- a/test/decl/func/default-values.swift
+++ b/test/decl/func/default-values.swift
@@ -132,10 +132,10 @@ func inoutFuncWithDefaultArg1(x: inout Int = 1) {} // expected-error {{cannot pr
 func inoutFuncWithDefaultArg2(x: inout Int = bLiteral) {} // expected-error {{cannot provide default value to inout parameter 'x'}}
 func inoutFuncWithDefaultArg3(x: inout Int = aLiteral) {} // expected-error {{cannot provide default value to inout parameter 'x'}}
 func inoutFuncWithDefaultArg4(x: inout Int = &aLiteral) {} // expected-error {{cannot provide default value to inout parameter 'x'}}
-// expected-error@-1 {{use of extraneous '&'}}
+// expected-error@-1 {{'&' may only be used to pass an argument to inout parameter}}
 
 func inoutFuncWithDefaultArg5(x: inout Int = &bLiteral) {} // expected-error {{cannot provide default value to inout parameter 'x'}}
-// expected-error@-1 {{use of extraneous '&'}}
+// expected-error@-1 {{'&' may only be used to pass an argument to inout parameter}}
 
 func inoutFuncWithDefaultArg6(x: inout Int = #file) {} // expected-error {{cannot provide default value to inout parameter 'x'}}
 // expected-error@-1 {{default argument value of type 'String' cannot be converted to type 'Int'}}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -542,8 +542,8 @@ func testInOut(_ arg: inout Int) {
   takesExplicitInt(x) // expected-error{{passing value of type 'Int' to an inout parameter requires explicit '&'}} {{20-20=&}}
   takesExplicitInt(&x)
   takesInt(&x) // expected-error{{'&' used with non-inout argument of type 'Int'}}
-  var y = &x //expected-error {{use of extraneous '&'}}
-  var z = &arg //expected-error {{use of extraneous '&'}}
+  var y = &x //expected-error {{'&' may only be used to pass an argument to inout parameter}}
+  var z = &arg //expected-error {{'&' may only be used to pass an argument to inout parameter}}
 
   takesExplicitInt(5) // expected-error {{cannot pass immutable value as inout argument: literals are not mutable}}
 }
@@ -701,8 +701,8 @@ func test() {
   let y = Foo()
 
   // rdar://15708430
-  (&x).method()  // expected-error {{use of extraneous '&'}}
-  (&x).mutatingMethod() // expected-error {{use of extraneous '&'}}
+  (&x).method()  // expected-error {{'&' may only be used to pass an argument to inout parameter}}
+  (&x).mutatingMethod() // expected-error {{'&' may only be used to pass an argument to inout parameter}}
 }
 
 
@@ -832,20 +832,20 @@ public struct TestPropMethodOverloadGroup {
 // <rdar://problem/18496742> Passing ternary operator expression as inout crashes Swift compiler
 func inoutTests(_ arr: inout Int) {
   var x = 1, y = 2
-  (true ? &x : &y) // expected-error {{use of extraneous '&'}}
-  let a = (true ? &x : &y) // expected-error {{use of extraneous '&'}}
+  (true ? &x : &y) // expected-error {{'&' may only be used to pass an argument to inout parameter}}
+  let a = (true ? &x : &y) // expected-error {{'&' may only be used to pass an argument to inout parameter}}
 
-  inoutTests(true ? &x : &y) // expected-error {{use of extraneous '&'}}
+  inoutTests(true ? &x : &y) // expected-error {{'&' may only be used to pass an argument to inout parameter}}
 
-  &_ // expected-error {{use of extraneous '&'}}
+  &_ // expected-error {{'&' may only be used to pass an argument to inout parameter}}
 
-  inoutTests((&x, 24).0) // expected-error {{use of extraneous '&'}}
+  inoutTests((&x, 24).0) // expected-error {{'&' may only be used to pass an argument to inout parameter}}
 
-  inoutTests((&x)) // expected-error {{use of extraneous '&'}} {{15-16=(}} {{14-15=&}}
+  inoutTests((&x)) // expected-error {{'&' may only be used to pass an argument to inout parameter}} {{15-16=(}} {{14-15=&}}
   inoutTests(&x)
   
   // <rdar://problem/17489894> inout not rejected as operand to assignment operator
-  &x += y  // expected-error {{use of extraneous '&'}}
+  &x += y  // expected-error {{'&' may only be used to pass an argument to inout parameter}}
 
   // <rdar://problem/23249098>
   func takeAny(_ x: Any) {}
@@ -861,7 +861,7 @@ func inoutTests(_ arr: inout Int) {
 // <rdar://problem/20802757> Compiler crash in default argument & inout expr
 var g20802757 = 2
 func r20802757(_ z: inout Int = &g20802757) { // expected-error {{cannot provide default value to inout parameter 'z'}}
-  // expected-error@-1 {{use of extraneous '&'}}
+  // expected-error@-1 {{'&' may only be used to pass an argument to inout parameter}}
   print(z)
 }
 


### PR DESCRIPTION
Resolves: https://github.com/apple/swift/issues/58389

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
