### PR TITLE
[stdlib][docs] Clarify BidirectionalCollection requirements

### DIFF
--- a/stdlib/public/core/BidirectionalCollection.swift
+++ b/stdlib/public/core/BidirectionalCollection.swift
@@ -28,13 +28,17 @@
 /// `Collection` protocol.
 ///
 /// Indices that are moved forward and backward in a bidirectional collection
-/// move by the same amount in each direction. That is, for any index `i` into
-/// a bidirectional collection `c`:
+/// move by the same amount in each direction. That is, for any valid index `i`
+/// into a bidirectional collection `c`:
 ///
 /// - If `i >= c.startIndex && i < c.endIndex`, then
 ///   `c.index(before: c.index(after: i)) == i`.
 /// - If `i > c.startIndex && i <= c.endIndex`, then
 ///   `c.index(after: c.index(before: i)) == i`.
+///
+/// Valid indices are exactly those indices that are reachable from the
+/// collection's `startIndex` by repeated applications of `index(after:)`, up
+/// to, and including, the `endIndex`.
 public protocol BidirectionalCollection: Collection
 where SubSequence: BidirectionalCollection, Indices: BidirectionalCollection {
   // FIXME: Only needed for associated type inference.


### PR DESCRIPTION
As [discussed on the forum](https://forums.swift.org/t/string-index-unification-vs-bidirectionalcollection-requirements/55946),  `BidirectionalCollection` requirements as currently stated can be interpreted to forbid conforming types from accepting indices that lie between valid (i.e., reachable) indices in the collection. Among other undesirable effects, this interpretation would render SE-0180 (String.Index overhaul) incompatible with these requirements.

Update the wording to clarify that the requirements only apply to valid indices. (Collection protocols do not constrain the behavior of invalid indices — it’s up to individual collection types to implement them as they wish.)

rdar://92297280