### PR TITLE
Mark a test as needing asserts enabled.

### DIFF
--- a/test/SILOptimizer/semantic-arc-opt-unchecked-ownership-conversion.sil
+++ b/test/SILOptimizer/semantic-arc-opt-unchecked-ownership-conversion.sil
@@ -1,5 +1,6 @@
-// REQUIRES: rdar72627921
 // RUN: %target-sil-opt -module-name Swift -enable-sil-verify-all -semantic-arc-opts -sil-semantic-arc-peepholes-ownership-conversion-elim -sil-semantic-arc-peepholes-lifetime-joining %s | %FileCheck %s
+
+// REQUIRES: asserts
 
 sil_stage canonical
 


### PR DESCRIPTION
The problem is that this pass is setup such that when asserts are enabled we are
able to turn off/on internal parts of the transformation. When asserts are
disabled, we don’t support this and just run with everything. This causes the
output to differ.

rdar://72627921