### PR TITLE
Re-enable sanitizer tests broken due to buggy atos

### DIFF
--- a/test/Sanitizers/symbolication.swift
+++ b/test/Sanitizers/symbolication.swift
@@ -5,9 +5,6 @@
 // REQUIRES: asan_runtime
 // REQUIRES: VENDOR=apple
 
-// rdar://75365575 (Failing to start atos external symbolizer)
-// UNSUPPORTED: OS=watchos
-
 // We copy the binary but not the corresponding .dSYM for remote runs (e.g.,
 // on-device testing), and hence online symbolication fails.
 // UNSUPPORTED: remote_run

--- a/test/Sanitizers/tsan/racy_actor_counters.swift
+++ b/test/Sanitizers/tsan/racy_actor_counters.swift
@@ -10,9 +10,6 @@
 // rdar://76038845
 // UNSUPPORTED: use_os_stdlib
 
-// rdar://75365575 (Failing to start atos external symbolizer)
-// UNSUPPORTED: OS=watchos
-
 // REQUIRES: rdar76542113
 
 var globalCounterValue = 0

--- a/test/Sanitizers/tsan/racy_async_let_fibonacci.swift
+++ b/test/Sanitizers/tsan/racy_async_let_fibonacci.swift
@@ -11,9 +11,6 @@
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
 
-// rdar://75365575 (Failing to start atos external symbolizer)
-// UNSUPPORTED: OS=watchos
-
 // rdar://86825277
 // SR-15805
 // UNSUPPORTED: CPU=arm64 || CPU=arm64e


### PR DESCRIPTION
There was a regression in atos, but now a new-enough Xcode version that
includes the fixed atos is now available on Swift CI bots.  We can
re-enable the tests.

Radar-Id: rdar://problem/85471075
