### PR TITLE
Sema: Avoid diagnosing potential unavailability of type components of unavailable decls

### DIFF
--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -1583,6 +1583,11 @@ class DeclAvailabilityChecker : public DeclVisitor<DeclAvailabilityChecker> {
     // Don't bother checking errors.
     if (type && type->hasError())
       return;
+    
+    // If the decl which references this type is unavailable on the current
+    // platform, don't diagnose the availability of the type.
+    if (AvailableAttr::isUnavailable(context))
+      return;
 
     DeclAvailabilityFlags flags = None;
 

--- a/test/attr/attr_availability_transitive_osx.swift
+++ b/test/attr/attr_availability_transitive_osx.swift
@@ -110,11 +110,42 @@ extension Outer {
 }
 
 @available(OSX, unavailable)
-struct NotOnOSX {
+struct NotOnOSX { // expected-note {{'NotOnOSX' has been explicitly marked unavailable here}}
   var osx_init_osx = osx() // OK
   lazy var osx_lazy_osx = osx() // OK
   var osx_init_multi1_osx = osx(), osx_init_multi2_osx = osx() // OK
   var (osx_init_deconstruct1_osx, osx_init_deconstruct2_osx) = osx_pair() // OK
   var (_, osx_init_deconstruct2_only_osx) = osx_pair() // OK
   var (osx_init_deconstruct1_only_osx, _) = osx_pair() // OK
+}
+
+@available(OSX, unavailable)
+extension NotOnOSX {
+  func osx_call_osx() {
+    osx() // OK
+  }
+
+  func osx_call_osx_extension() {
+    osx_extension() // OK; osx_extension is only unavailable if -application-extension is passed.
+  }
+}
+
+@available(OSXApplicationExtension, unavailable)
+extension NotOnOSX { } // expected-error {{'NotOnOSX' is unavailable in macOS}}
+
+@available(OSXApplicationExtension, unavailable)
+struct NotOnOSXApplicationExtension { }
+
+@available(OSX, unavailable)
+extension NotOnOSXApplicationExtension { } // OK; NotOnOSXApplicationExtension is only unavailable if -application-extension is passed.
+
+@available(OSXApplicationExtension, unavailable)
+extension NotOnOSXApplicationExtension {
+  func osx_call_osx() {
+    osx() // expected-error {{'osx()' is unavailable in macOS}}
+  }
+
+  func osx_call_osx_extension() {
+    osx_extension() // OK
+  }
 }

--- a/test/attr/attr_availability_transitive_osx_extension.swift
+++ b/test/attr/attr_availability_transitive_osx_extension.swift
@@ -4,10 +4,10 @@
 // Allow referencing unavailable API in situations where the caller is marked unavailable in the same circumstances.
 
 @available(OSX, unavailable)
-func osx() {} // expected-note 2{{'osx()' has been explicitly marked unavailable here}}
+func osx() {} // expected-note 3{{'osx()' has been explicitly marked unavailable here}}
 
 @available(OSXApplicationExtension, unavailable)
-func osx_extension() {} // expected-note 2{{'osx_extension()' has been explicitly marked unavailable here}}
+func osx_extension() {} // expected-note 3{{'osx_extension()' has been explicitly marked unavailable here}}
 
 func call_osx_extension() {
     osx_extension() // expected-error {{'osx_extension()' is unavailable}}
@@ -34,4 +34,38 @@ func osx_extension_call_osx_extension() {
 @available(OSXApplicationExtension, unavailable)
 func osx_extension_call_osx() {
     osx() // expected-error {{'osx()' is unavailable}}
+}
+
+@available(OSX, unavailable)
+struct NotOnOSX { }
+
+@available(OSX, unavailable)
+extension NotOnOSX {
+  func osx_call_osx() {
+    osx() // OK
+  }
+
+  func osx_call_osx_extension() {
+    osx_extension() // expected-error {{'osx_extension()' is unavailable in application extensions for macOS}}
+  }
+}
+
+@available(OSXApplicationExtension, unavailable)
+extension NotOnOSX { }
+
+@available(OSXApplicationExtension, unavailable)
+struct NotOnOSXApplicationExtension { }
+
+@available(OSX, unavailable)
+extension NotOnOSXApplicationExtension { }
+
+@available(OSXApplicationExtension, unavailable)
+extension NotOnOSXApplicationExtension {
+  func osx_call_osx() {
+    osx() // expected-error {{'osx()' is unavailable in macOS}}
+  }
+
+  func osx_call_osx_extension() {
+    osx_extension() // OK
+  }
 }


### PR DESCRIPTION
Avoid diagnosing potential unavailability of type components (extension nominal type, superclass, etc.) on declarations that are explicitly unavailable.

Resolves rdar://92179327