### PR TITLE
[AutoDiff][RequirementMachine] Regression test for S4TF RNN/Sequential crasher caused by GenericSignatureBuilder

### DIFF
--- a/test/AutoDiff/compiler_crashers_fixed/sr15884-generic-signature-builder-keypath-iterable.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/sr15884-generic-signature-builder-keypath-iterable.swift
@@ -1,0 +1,47 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+
+// SR-15884: Crash while compiling Swift for TensorFlow. This was caused by a
+// bug in GenericSignatureBuilder, similar to one involving `CaseIterable`. In
+// this reproducer, `KeyPathIterabe` is similar enough to `CaseIterable` to 
+// cause the GSB crash. It was fixed by RequirementMachine abstract signatures.
+
+import _Differentiation
+@_spi(Reflection) import Swift
+
+struct RNNCellInput<Input>: Differentiable {}
+struct RNNCellOutput<Output>: Differentiable {}
+
+protocol Layer: Differentiable {
+  associatedtype Input
+  associatedtype Output: Differentiable
+  
+  @differentiable(reverse)
+  func callAsFunction(_ input: Input) -> Output
+}
+
+public protocol KeyPathIterable {
+  associatedtype AllKeyPaths: Sequence
+    where AllKeyPaths.Element == PartialKeyPath<Self>
+}
+
+protocol RecurrentLayerCell: Layer, KeyPathIterable
+where
+  Input == RNNCellInput<TimeStepInput>,
+  Output == RNNCellOutput<TimeStepOutput>
+{
+  associatedtype TimeStepInput
+  associatedtype TimeStepOutput: Differentiable
+}
+
+struct RecurrentLayer<Cell: RecurrentLayerCell>: Layer {
+  typealias Input = Cell.TimeStepInput
+  typealias Output = Cell.TimeStepOutput
+
+  var cell: Cell
+
+  @differentiable(reverse)
+  func callAsFunction(_ inputs: Cell.TimeStepInput) -> Cell.TimeStepOutput {
+    // expected-warning @+1 {{function call causes an infinite recursion}}
+    return self(inputs)
+  }
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
The `KeyPathIterable` protocol from [Swift for TensorFlow](https://github.com/s4tf/s4tf) triggered a bug in GSB similar to what `CaseIterable` sometimes does. Through pull requests #41631 and #42111, the crash log gradually changed as RequirementMachineAbstractSignatures was progressively enabled more. Now that we only use RequirementMachine, the crash no longer happens.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-15884 and makes the [workaround](https://github.com/s4tf/s4tf/pull/6) recently added to S4TF no longer necessary.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
