### PR TITLE
`line-directive` decode utf8 charset

### DIFF
--- a/utils/line-directive
+++ b/utils/line-directive
@@ -690,7 +690,8 @@ def run():
             command_args,
             stderr=subprocess.STDOUT,
             stdout=subprocess.PIPE,
-            universal_newlines=True
+            universal_newlines=True,
+            encoding='UTF-8'
         )
 
         sources = '(?P<file>' + '|'.join(re.escape(s) for s in sources) + ')'

--- a/validation-test/Python/line-directive.swift
+++ b/validation-test/Python/line-directive.swift
@@ -1,1 +1,2 @@
 // RUN: %{python} %utils/line-directive
+// RUN: %{python} %utils/line-directive -- %{python} -c "print('Hello 😄🂐')"


### PR DESCRIPTION
The line-directive was failing due to receiving non-ascii chars.
This patch sets the command to expect utf-8 encoded strings.

I'm not sure how to cross-test within the same repo, but this patch should fix the encoding issue in https://github.com/apple/swift/pull/34343.

rdar://70403601