### PR TITLE
[SymbolGraphGen] consider modules not equal if they're not from the same compiler

### DIFF
--- a/test/SymbolGraph/ClangImporter/ForeignExtensions.swift
+++ b/test/SymbolGraph/ClangImporter/ForeignExtensions.swift
@@ -4,6 +4,10 @@
 // RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.symbols.json --check-prefix BASE
 // RUN: %FileCheck %s --input-file %t/EmitWhileBuilding@Swift.symbols.json --check-prefix EXTENSION
 
+// RUN: %target-swift-symbolgraph-extract -sdk %clang-importer-sdk -module-name EmitWhileBuilding -F %t -output-dir %t -pretty-print -v
+// RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.symbols.json --check-prefix BASE
+// RUN: %FileCheck %s --input-file %t/EmitWhileBuilding@Swift.symbols.json --check-prefix EXTENSION
+
 // REQUIRES: objc_interop
 
 // ensure that the symbol `String.Foo.bar` does not appear in the base module's symbol graph

--- a/test/SymbolGraph/ClangImporter/ForeignExtensions.swift
+++ b/test/SymbolGraph/ClangImporter/ForeignExtensions.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/EmitWhileBuilding/EmitWhileBuilding.framework %t
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-module-path %t/EmitWhileBuilding.framework/Modules/EmitWhileBuilding.swiftmodule/%target-swiftmodule-name -import-underlying-module -F %t -module-name EmitWhileBuilding -disable-objc-attr-requires-foundation-module %s %S/Inputs/EmitWhileBuilding/Extra.swift -emit-symbol-graph -emit-symbol-graph-dir %t
+// RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.symbols.json --check-prefix BASE
+// RUN: %FileCheck %s --input-file %t/EmitWhileBuilding@Swift.symbols.json --check-prefix EXTENSION
+
+// REQUIRES: objc_interop
+
+// ensure that the symbol `String.Foo.bar` does not appear in the base module's symbol graph
+
+// BASE-NOT:     "s:SS17EmitWhileBuildingE3FooO3baryA2CmF",
+// EXTENSION:    "s:SS17EmitWhileBuildingE3FooO3baryA2CmF",
+
+public extension String {
+    enum Foo {
+        case bar
+    }
+}
+


### PR DESCRIPTION
Resolves rdar://92263972

In #41577, symbols were lifted into the main module's symbol graph if they originated from an `@_exported import` module. However, the comparison was based on the modules' names, which caused the comparison to spuriously consider symbols to be "re-exported" if an underlying Clang module was present.[^underlying] This PR tightens that check to also consider whether the modules being compared for re-exporting are both Swift or non-Swift modules.

[^underlying]: When `-import-underlying-module` is given to the frontend, any headers considered to be part of the same module are aggregated into a separate module with the same name as the Swift module, which is then implicitly `@_exported import`ed into the Swift module. As the comparison added in #41577 was based on the name of the module, this means that *everything* that was declared in the Swift module was considered to be re-exported, even if it is technically an extension on a foreign type! Check the test that was added in this PR for an example.