### PR TITLE
Add emission of Frontend parseable-output in WMO jobs.

### DIFF
--- a/test/Frontend/parseable_output.swift
+++ b/test/Frontend/parseable_output.swift
@@ -1,25 +1,30 @@
-// RUN: %target-swift-frontend -primary-file %s -o %t.out -emit-module -emit-module-path %t.swiftmodule -frontend-parseable-output 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s %S/Inputs/filelist-other.swift -o %t.out -module-name parseable_output -emit-module -emit-module-path %t.swiftmodule -serialize-diagnostics -serialize-diagnostics-path %t.dia -frontend-parseable-output 2>&1 | %FileCheck %s
+// Check without primary files (WMO):
+// RUN: %target-swift-frontend %s %S/Inputs/filelist-other.swift -o %t.out -module-name parseable_output -emit-module -emit-module-path %t.swiftmodule -serialize-diagnostics -serialize-diagnostics-path %t.dia -frontend-parseable-output 2>&1 | %FileCheck %s
 
 // CHECK: {{[1-9][0-9]*}}
 // CHECK-NEXT: {
 // CHECK-NEXT:   "kind": "began",
 // CHECK-NEXT:   "name": "compile",
-// CHECK-NEXT:   "command": "{{.*[\\/]}}swift-frontend{{(\.exe)?}}{{.*}}-primary-file {{.*[\\/]}}parseable_output.swift -o {{.*[\\/]}}parseable_output.swift.tmp.out  -emit-module -emit-module-path {{.*[\\/]}}parseable_output.swift.tmp.swiftmodule -frontend-parseable-output",
+// CHECK-NEXT:   "command": "{{.*[\\/]}}swift-frontend{{(\.exe)?}}{{.*}} {{.*[\\/]}}parseable_output.swift {{.*[\\/]}}filelist-other.swift -o {{.*[\\/]}}parseable_output.swift.tmp.out -module-name parseable_output -emit-module -emit-module-path {{.*[\\/]}}parseable_output.swift.tmp.swiftmodule -serialize-diagnostics -serialize-diagnostics-path {{.*[\\/]}}parseable_output.swift.tmp.dia -frontend-parseable-output",
 // CHECK-NEXT:   "command_executable": "{{.*[\\/]}}swift{{(-frontend|c)?(\.exe)?}}",
 // CHECK-NEXT:   "command_arguments": [
-// CHECK:          "-primary-file",
-// CHECK-NEXT:     "{{.*[\\/]}}parseable_output.swift",
+// CHECK:          "{{.*[\\/]}}parseable_output.swift",
 // CHECK:          "-o",
 // CHECK-NEXT:     "{{.*[\\/]}}parseable_output.swift.tmp.out",
+// CHECK-NEXT:     "-module-name",
+// CHECK-NEXT:     "parseable_output",
 // CHECK-NEXT:     "-emit-module",
 // CHECK-NEXT:     "-emit-module-path",
 // CHECK-NEXT:     "{{.*[\\/]}}parseable_output.swift.tmp.swiftmodule",
+// CHECK-NEXT:     "-serialize-diagnostics",
+// CHECK-NEXT:     "-serialize-diagnostics-path"
+// CHECK-NEXT:     "{{.*[\\/]}}parseable_output.swift.tmp.dia",
 // CHECK-NEXT:     "-frontend-parseable-output"
 // CHECK-NEXT:   ],
 // CHECK-NEXT:   "inputs": [
 // CHECK-NEXT:       "{{.*[\\/]}}parseable_output.swift"
-// CHECK-NEXT:     ],
-// CHECK-NEXT:     "outputs": [
+// CHECK:        "outputs": [
 // CHECK-NEXT:       {
 // CHECK-NEXT:         "type": "image",
 // CHECK-NEXT:         "path": "{{.*[\\/]}}parseable_output.swift.tmp.out"
@@ -27,6 +32,10 @@
 // CHECK-NEXT:       {
 // CHECK-NEXT:         "type": "swiftmodule",
 // CHECK-NEXT:         "path": "{{.*[\\/]}}parseable_output.swift.tmp.swiftmodule"
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "type": "diagnostics",
+// CHECK-NEXT:         "path": "{{.*[\\/]}}parseable_output.swift.tmp.dia"
 // CHECK-NEXT:       }
 // CHECK-NEXT:     ],
 // CHECK-NEXT:     "pid": [[PID:[0-9]*]]

--- a/test/Frontend/parseable_output_error.swift
+++ b/test/Frontend/parseable_output_error.swift
@@ -1,4 +1,6 @@
 // RUN: not %target-swift-frontend -primary-file %s -o %t.out -emit-module -emit-module-path %t.swiftmodule -frontend-parseable-output 2>&1 | %FileCheck %s
+// Check without primary files (WMO):
+// RUN: not %target-swift-frontend %s -o %t.out -emit-module -emit-module-path %t.swiftmodule -frontend-parseable-output 2>&1 | %FileCheck %s
 
 func foo() {
     return 11;
@@ -7,11 +9,10 @@ func foo() {
 // CHECK-NEXT: {
 // CHECK-NEXT:   "kind": "began",
 // CHECK-NEXT:   "name": "compile",
-// CHECK-NEXT:   "command": "{{.*[\\/]}}swift-frontend{{(\.exe)?}}{{.*}}-primary-file {{.*[\\/]}}parseable_output_error.swift -o {{.*[\\/]}}parseable_output_error.swift.tmp.out  -emit-module -emit-module-path {{.*[\\/]}}parseable_output_error.swift.tmp.swiftmodule -frontend-parseable-output",
+// CHECK-NEXT:   "command": "{{.*[\\/]}}swift-frontend{{(\.exe)?}}{{.*}} {{.*[\\/]}}parseable_output_error.swift -o {{.*[\\/]}}parseable_output_error.swift.tmp.out  -emit-module -emit-module-path {{.*[\\/]}}parseable_output_error.swift.tmp.swiftmodule -frontend-parseable-output",
 // CHECK-NEXT:   "command_executable": "{{.*[\\/]}}swift{{(-frontend|c)?(\.exe)?}}",
 // CHECK-NEXT:   "command_arguments": [
-// CHECK:          "-primary-file",
-// CHECK-NEXT:     "{{.*[\\/]}}parseable_output_error.swift",
+// CHECK:     "{{.*[\\/]}}parseable_output_error.swift",
 // CHECK-NEXT:     "-o",
 // CHECK-NEXT:     "{{.*[\\/]}}parseable_output_error.swift.tmp.out",
 // CHECK-NEXT:     "-emit-module",
@@ -43,7 +44,7 @@ func foo() {
 // CHECK-NEXT:   "kind": "finished",
 // CHECK-NEXT:   "name": "compile",
 // CHECK-NEXT:   "pid": [[PID]],
-// CHECK-NEXT:   "output": "{{.*[\\/]}}parseable_output_error.swift:4:12: error: unexpected non-void return value in void function{{.*}}return 11;{{.*[\\/]}}parseable_output_error.swift:4:12: note: did you mean to add a return type?{{.*}}return 11;
+// CHECK-NEXT:   "output": "{{.*[\\/]}}parseable_output_error.swift:6:12: error: unexpected non-void return value in void function{{.*}}return 11;{{.*[\\/]}}parseable_output_error.swift:6:12: note: did you mean to add a return type?{{.*}}return 11;
 // CHECK-NEXT:   "process": {
 // CHECK-NEXT:     "real_pid": [[PID]]
 // CHECK-NEXT:   },


### PR DESCRIPTION
Frontend emitting parsable output, as implemented, emitted began/finished messages on a per-primary basis. Which means that `-frontend-parseable-output` had no effect in contexts where no primary inputs are specified, such as WMO. This change fixes that by also emitting began/finished messages when no primary outputs are specified.

Resolves rdar://91999048
