### PR TITLE
[CSClosure] (Mostly NFC) Renames and introduction of `AnyFunctionRef`

### DIFF
--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -209,10 +209,9 @@ enum class ConstraintKind : char {
   /// inferred from a conversion, so the check is more relax comparing to
   /// `ConformsTo`.
   TransitivelyConformsTo,
-  /// Represents an AST node contained in a body of a closure. It has only
-  /// one type - type variable representing type of a node, other side is
-  /// the AST node to infer the type for.
-  ClosureBodyElement,
+  /// Represents an AST node contained in a body of a function/closure.
+  /// It only has an AST node to generate constraints and infer the type for.
+  SyntacticElement,
   /// Do not add new uses of this, it only exists to retain compatibility for
   /// rdar://85263844.
   ///
@@ -240,8 +239,8 @@ enum class ConstraintClassification : char {
   /// A conjunction constraint.
   Conjunction,
 
-  /// An element of a closure body.
-  ClosureElement,
+  /// An element of a closure/function body.
+  SyntacticElement,
 };
 
 /// Specifies a restriction on the kind of conversion that should be
@@ -448,7 +447,7 @@ class Constraint final : public llvm::ilist_node<Constraint>,
       ContextualTypeInfo Context;
       /// Identifies whether result of this node is unused.
       bool IsDiscarded;
-    } ClosureElement;
+    } SyntacticElement;
   };
 
   /// The locator that describes where in the expression this
@@ -589,12 +588,12 @@ public:
       Optional<TrailingClosureMatching> trailingClosureMatching,
       ConstraintLocator *locator);
 
-  static Constraint *createClosureBodyElement(ConstraintSystem &cs,
+  static Constraint *createSyntacticElement(ConstraintSystem &cs,
                                               ASTNode node,
                                               ConstraintLocator *locator,
                                               bool isDiscarded = false);
 
-  static Constraint *createClosureBodyElement(ConstraintSystem &cs,
+  static Constraint *createSyntacticElement(ConstraintSystem &cs,
                                               ASTNode node,
                                               ContextualTypeInfo context,
                                               ConstraintLocator *locator,
@@ -708,8 +707,8 @@ public:
     case ConstraintKind::Conjunction:
       return ConstraintClassification::Conjunction;
 
-    case ConstraintKind::ClosureBodyElement:
-      return ConstraintClassification::ClosureElement;
+    case ConstraintKind::SyntacticElement:
+      return ConstraintClassification::SyntacticElement;
     }
 
     llvm_unreachable("Unhandled ConstraintKind in switch.");
@@ -732,7 +731,7 @@ public:
     case ConstraintKind::ValueWitness:
       return Member.First;
 
-    case ConstraintKind::ClosureBodyElement:
+    case ConstraintKind::SyntacticElement:
       llvm_unreachable("closure body element constraint has no type operands");
 
     default:
@@ -746,7 +745,7 @@ public:
     case ConstraintKind::Disjunction:
     case ConstraintKind::Conjunction:
     case ConstraintKind::BindOverload:
-    case ConstraintKind::ClosureBodyElement:
+    case ConstraintKind::SyntacticElement:
       llvm_unreachable("constraint has no second type");
 
     case ConstraintKind::ValueMember:
@@ -855,19 +854,19 @@ public:
     return Member.UseDC;
   }
 
-  ASTNode getClosureElement() const {
-    assert(Kind == ConstraintKind::ClosureBodyElement);
-    return ClosureElement.Element;
+  ASTNode getSyntacticElement() const {
+    assert(Kind == ConstraintKind::SyntacticElement);
+    return SyntacticElement.Element;
   }
 
   ContextualTypeInfo getElementContext() const {
-    assert(Kind == ConstraintKind::ClosureBodyElement);
-    return ClosureElement.Context;
+    assert(Kind == ConstraintKind::SyntacticElement);
+    return SyntacticElement.Context;
   }
 
   bool isDiscardedElement() const {
-    assert(Kind == ConstraintKind::ClosureBodyElement);
-    return ClosureElement.IsDiscarded;
+    assert(Kind == ConstraintKind::SyntacticElement);
+    return SyntacticElement.IsDiscarded;
   }
 
   /// For an applicable function constraint, retrieve the trailing closure

--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -1012,11 +1012,11 @@ public:
   }
 };
 
-class LocatorPathElt::ClosureBodyElement final
+class LocatorPathElt::SyntacticElement final
     : public StoredPointerElement<void> {
 public:
-  ClosureBodyElement(ASTNode element)
-      : StoredPointerElement(PathElementKind::ClosureBodyElement,
+  SyntacticElement(ASTNode element)
+      : StoredPointerElement(PathElementKind::SyntacticElement,
                              element.getOpaqueValue()) {
     assert(element);
   }
@@ -1054,7 +1054,7 @@ public:
   }
 
   static bool classof(const LocatorPathElt *elt) {
-    return elt->getKind() == PathElementKind::ClosureBodyElement;
+    return elt->getKind() == PathElementKind::SyntacticElement;
   }
 };
 

--- a/include/swift/Sema/ConstraintLocatorPathElts.def
+++ b/include/swift/Sema/ConstraintLocatorPathElts.def
@@ -229,8 +229,9 @@ CUSTOM_LOCATOR_PATH_ELT(ImplicitConversion)
 /// An implicit call to a 'dynamicMember' subscript for a dynamic member lookup.
 SIMPLE_LOCATOR_PATH_ELT(ImplicitDynamicMemberSubscript)
 
-/// The element of the closure body e.g. statement, declaration, or expression.
-CUSTOM_LOCATOR_PATH_ELT(ClosureBodyElement)
+/// The element of the closure/function body e.g. statement, pattern,
+/// declaration, or expression.
+CUSTOM_LOCATOR_PATH_ELT(SyntacticElement)
 
 /// The element of the pattern binding declaration.
 CUSTOM_LOCATOR_PATH_ELT(PatternBindingElement)

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5120,9 +5120,9 @@ private:
                  TypeMatchOptions flags,
                  ConstraintLocatorBuilder locator);
 
-  /// Simplify a closure body element constraint by generating required
+  /// Simplify a syntactic element constraint by generating required
   /// constraints to represent the given element in constraint system.
-  SolutionKind simplifyClosureBodyElementConstraint(
+  SolutionKind simplifySyntacticElementConstraint(
       ASTNode element, ContextualTypeInfo context, bool isDiscarded,
       TypeMatchOptions flags, ConstraintLocatorBuilder locator);
 

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1385,7 +1385,7 @@ void PotentialBindings::infer(Constraint *constraint) {
   case ConstraintKind::EscapableFunctionOf:
   case ConstraintKind::OpenedExistentialOf:
   case ConstraintKind::KeyPath:
-  case ConstraintKind::ClosureBodyElement:
+  case ConstraintKind::SyntacticElement:
   case ConstraintKind::Conjunction:
   case ConstraintKind::BindTupleOfFunctionParams:
     // Constraints from which we can't do anything.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2189,7 +2189,7 @@ ConstraintSystem::matchTupleTypes(TupleType *tuple1, TupleType *tuple2,
   case ConstraintKind::DefaultClosureType:
   case ConstraintKind::UnresolvedMemberChainBase:
   case ConstraintKind::PropertyWrapper:
-  case ConstraintKind::ClosureBodyElement:
+  case ConstraintKind::SyntacticElement:
   case ConstraintKind::BindTupleOfFunctionParams:
     llvm_unreachable("Not a conversion");
   }
@@ -2352,7 +2352,7 @@ static bool matchFunctionRepresentations(FunctionType::ExtInfo einfo1,
   case ConstraintKind::DefaultClosureType:
   case ConstraintKind::UnresolvedMemberChainBase:
   case ConstraintKind::PropertyWrapper:
-  case ConstraintKind::ClosureBodyElement:
+  case ConstraintKind::SyntacticElement:
   case ConstraintKind::BindTupleOfFunctionParams:
     return true;
   }
@@ -2796,7 +2796,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
   case ConstraintKind::DefaultClosureType:
   case ConstraintKind::UnresolvedMemberChainBase:
   case ConstraintKind::PropertyWrapper:
-  case ConstraintKind::ClosureBodyElement:
+  case ConstraintKind::SyntacticElement:
   case ConstraintKind::BindTupleOfFunctionParams:
     llvm_unreachable("Not a relational constraint");
   }
@@ -6012,7 +6012,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
     case ConstraintKind::DefaultClosureType:
     case ConstraintKind::UnresolvedMemberChainBase:
     case ConstraintKind::PropertyWrapper:
-    case ConstraintKind::ClosureBodyElement:
+    case ConstraintKind::SyntacticElement:
     case ConstraintKind::BindTupleOfFunctionParams:
       llvm_unreachable("Not a relational constraint");
     }
@@ -13145,7 +13145,7 @@ ConstraintSystem::addConstraintImpl(ConstraintKind kind, Type first,
   case ConstraintKind::KeyPath:
   case ConstraintKind::KeyPathApplication:
   case ConstraintKind::DefaultClosureType:
-  case ConstraintKind::ClosureBodyElement:
+  case ConstraintKind::SyntacticElement:
     llvm_unreachable("Use the correct addConstraint()");
   }
 
@@ -13675,9 +13675,9 @@ ConstraintSystem::simplifyConstraint(const Constraint &constraint) {
         constraint.getFirstType(), constraint.getSecondType(),
         /*flags=*/None, constraint.getLocator());
 
-  case ConstraintKind::ClosureBodyElement:
-    return simplifyClosureBodyElementConstraint(
-        constraint.getClosureElement(), constraint.getElementContext(),
+  case ConstraintKind::SyntacticElement:
+    return simplifySyntacticElementConstraint(
+        constraint.getSyntacticElement(), constraint.getElementContext(),
         constraint.isDiscardedElement(),
         /*flags=*/None, constraint.getLocator());
 

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -112,8 +112,8 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second,
   case ConstraintKind::KeyPathApplication:
     llvm_unreachable("Key path constraint takes three types");
 
-  case ConstraintKind::ClosureBodyElement:
-    llvm_unreachable("Closure body element constraint should use create()");
+  case ConstraintKind::SyntacticElement:
+    llvm_unreachable("Syntactic element constraint should use create()");
   }
 
   std::uninitialized_copy(typeVars.begin(), typeVars.end(),
@@ -161,7 +161,7 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second, Type Third,
   case ConstraintKind::DefaultClosureType:
   case ConstraintKind::UnresolvedMemberChainBase:
   case ConstraintKind::PropertyWrapper:
-  case ConstraintKind::ClosureBodyElement:
+  case ConstraintKind::SyntacticElement:
   case ConstraintKind::BindTupleOfFunctionParams:
     llvm_unreachable("Wrong constructor");
 
@@ -260,12 +260,12 @@ Constraint::Constraint(ConstraintKind kind, ConstraintFix *fix, Type first,
 Constraint::Constraint(ASTNode node, ContextualTypeInfo context,
                        bool isDiscarded, ConstraintLocator *locator,
                        SmallPtrSetImpl<TypeVariableType *> &typeVars)
-    : Kind(ConstraintKind::ClosureBodyElement), TheFix(nullptr),
+    : Kind(ConstraintKind::SyntacticElement), TheFix(nullptr),
       HasRestriction(false), IsActive(false), IsDisabled(false),
       IsDisabledForPerformance(false), RememberChoice(false), IsFavored(false),
       IsIsolated(false),
-      NumTypeVariables(typeVars.size()), ClosureElement{node, context,
-                                                        isDiscarded},
+      NumTypeVariables(typeVars.size()), SyntacticElement{node, context,
+                                                          isDiscarded},
       Locator(locator) {
   std::copy(typeVars.begin(), typeVars.end(), getTypeVariablesBuffer().begin());
 }
@@ -343,9 +343,9 @@ Constraint *Constraint::clone(ConstraintSystem &cs) const {
     return create(cs, getKind(), getFirstType(), getSecondType(), getThirdType(),
                   getLocator());
 
-  case ConstraintKind::ClosureBodyElement:
-    return createClosureBodyElement(cs, getClosureElement(), getLocator(),
-                                    isDiscardedElement());
+  case ConstraintKind::SyntacticElement:
+    return createSyntacticElement(cs, getSyntacticElement(), getLocator(),
+                                  isDiscardedElement());
   }
 
   llvm_unreachable("Unhandled ConstraintKind in switch.");
@@ -387,9 +387,9 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm) const {
     return;
   }
 
-  if (Kind == ConstraintKind::ClosureBodyElement) {
+  if (Kind == ConstraintKind::SyntacticElement) {
     auto *locator = getLocator();
-    auto element = getClosureElement();
+    auto element = getSyntacticElement();
 
     if (auto patternBindingElt =
             locator
@@ -399,8 +399,8 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm) const {
       Out << patternBindingElt->getIndex() << " : ";
       patternBinding->getPattern(patternBindingElt->getIndex())->dump(Out);
     } else {
-      Out << "closure body element ";
-      getClosureElement().dump(Out);
+      Out << "syntactic element ";
+      element.dump(Out);
     }
 
     return;
@@ -529,8 +529,8 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm) const {
     llvm_unreachable("disjunction handled above");
   case ConstraintKind::Conjunction:
     llvm_unreachable("conjunction handled above");
-  case ConstraintKind::ClosureBodyElement:
-    llvm_unreachable("closure body element handled above");
+  case ConstraintKind::SyntacticElement:
+    llvm_unreachable("syntactic element handled above");
   }
 
   if (!skipSecond)
@@ -702,7 +702,7 @@ gatherReferencedTypeVars(Constraint *constraint,
 
     break;
 
-  case ConstraintKind::ClosureBodyElement:
+  case ConstraintKind::SyntacticElement:
     typeVars.insert(constraint->getTypeVariables().begin(),
                     constraint->getTypeVariables().end());
     break;
@@ -1027,19 +1027,19 @@ Constraint *Constraint::createApplicableFunction(
   return constraint;
 }
 
-Constraint *Constraint::createClosureBodyElement(ConstraintSystem &cs,
-                                                 ASTNode node,
-                                                 ConstraintLocator *locator,
-                                                 bool isDiscarded) {
-  return createClosureBodyElement(cs, node, ContextualTypeInfo(), locator,
-                                  isDiscarded);
+Constraint *Constraint::createSyntacticElement(ConstraintSystem &cs,
+                                               ASTNode node,
+                                               ConstraintLocator *locator,
+                                               bool isDiscarded) {
+  return createSyntacticElement(cs, node, ContextualTypeInfo(), locator,
+                                isDiscarded);
 }
 
-Constraint *Constraint::createClosureBodyElement(ConstraintSystem &cs,
-                                                 ASTNode node,
-                                                 ContextualTypeInfo context,
-                                                 ConstraintLocator *locator,
-                                                 bool isDiscarded) {
+Constraint *Constraint::createSyntacticElement(ConstraintSystem &cs,
+                                               ASTNode node,
+                                               ContextualTypeInfo context,
+                                               ConstraintLocator *locator,
+                                               bool isDiscarded) {
   SmallPtrSet<TypeVariableType *, 4> typeVars;
   unsigned size = totalSizeToAlloc<TypeVariableType *>(typeVars.size());
   void *mem = cs.getAllocator().Allocate(size, alignof(Constraint));

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -93,7 +93,7 @@ unsigned LocatorPathElt::getNewSummaryFlags() const {
   case ConstraintLocator::PlaceholderType:
   case ConstraintLocator::ImplicitConversion:
   case ConstraintLocator::ImplicitDynamicMemberSubscript:
-  case ConstraintLocator::ClosureBodyElement:
+  case ConstraintLocator::SyntacticElement:
   case ConstraintLocator::PackType:
   case ConstraintLocator::PackElement:
   case ConstraintLocator::PatternBindingElement:
@@ -554,10 +554,10 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) const {
       out << "placeholder type";
       break;
 
-    case ConstraintLocator::ClosureBodyElement:
+    case ConstraintLocator::SyntacticElement:
       // TODO: Would be great to print a kind of element this is e.g.
       //       "if", "for each", "switch" etc.
-      out << "closure body element";
+      out << "syntactic element";
       break;
 
     case ConstraintLocator::ImplicitDynamicMemberSubscript:

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5079,8 +5079,8 @@ void constraints::simplifyLocator(ASTNode &anchor,
       continue;
     }
 
-    case ConstraintLocator::ClosureBodyElement: {
-      auto bodyElt = path[0].castTo<LocatorPathElt::ClosureBodyElement>();
+    case ConstraintLocator::SyntacticElement: {
+      auto bodyElt = path[0].castTo<LocatorPathElt::SyntacticElement>();
       anchor = bodyElt.getElement();
       path = path.slice(1);
       continue;


### PR DESCRIPTION
This is one more step toward type-checking result builder bodies using conjunctions.

The changes rename `ClosureBodyElement` to `SyntacticElement` to indicate that
contained element could come from not just closure but a function body as well.

Both constraint generator and solution application walkers have been renamed as well,
and switched to use `AnyFunctionRef` instead of `ClosureExpr`.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
