### PR TITLE
[5.7] Disable failing distributed actor tests.  

### DIFF
--- a/test/Distributed/Runtime/distributed_actor_in_other_module.swift
+++ b/test/Distributed/Runtime/distributed_actor_in_other_module.swift
@@ -15,6 +15,8 @@
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
 // UNSUPPORTED: windows
 
+// REQUIRES: rdar92277324
+
 import Distributed
 import EchoActorModule
 import FakeDistributedActorSystems


### PR DESCRIPTION
Example failure: https://ci.swift.org/job/oss-swift-5.7_tools-RA_stdlib-DA_test-simulators//65/console
Resolves rdar://92277271
