### PR TITLE
Downgrade missing @Sendable to a warning in Swift 5.x mode.

### DIFF
--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -59,7 +59,7 @@ func testCV(
   acceptCV(ns4) // expected-warning{{type 'NS4' does not conform to the 'Sendable' protocol}}
   acceptCV(fn) // expected-warning{{type '() -> Void' does not conform to the 'Sendable' protocol}}
   // expected-note@-1{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-  acceptSendableFn(fn) // expected-error{{passing non-sendable parameter 'fn' to function expecting a @Sendable closure}}
+  acceptSendableFn(fn) // expected-warning{{passing non-sendable parameter 'fn' to function expecting a @Sendable closure}}
 }
 
 // rdar://83942484 - spurious Sendable diagnostics


### PR DESCRIPTION
We're treating Sendable issues as warnings, not errors, so downgrade
function conversion errors to warnings as well. Fixes rdar://92291276.
