### PR TITLE
[cxx-interop] Fix SIL deserialization error

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2629,6 +2629,10 @@ bool importer::shouldSuppressDeclImport(const clang::Decl *decl) {
     return false;
   }
 
+  if (isa<clang::BuiltinTemplateDecl>(decl)) {
+    return true;
+  }
+
   return false;
 }
 

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -1925,11 +1925,27 @@ void importer::addEntryToLookupTable(SwiftLookupTable &table,
   // Walk the members of any context that can have nested members.
   if (isa<clang::TagDecl>(named) || isa<clang::ObjCInterfaceDecl>(named) ||
       isa<clang::ObjCProtocolDecl>(named) ||
-      isa<clang::ObjCCategoryDecl>(named) || isa<clang::NamespaceDecl>(named)) {
+      isa<clang::ObjCCategoryDecl>(named)) {
     clang::DeclContext *dc = cast<clang::DeclContext>(named);
     for (auto member : dc->decls()) {
       if (auto namedMember = dyn_cast<clang::NamedDecl>(member))
         addEntryToLookupTable(table, namedMember, nameImporter);
+    }
+  }
+  if (isa<clang::NamespaceDecl>(named)) {
+    llvm::SmallPtrSet<clang::Decl *, 8> alreadyAdded;
+    alreadyAdded.insert(named->getCanonicalDecl());
+
+    for (auto redecl : named->redecls()) {
+      auto dc = cast<clang::DeclContext>(redecl);
+      for (auto member : dc->decls()) {
+        auto canonicalMember = member->getCanonicalDecl();
+        if (!alreadyAdded.insert(canonicalMember).second)
+          continue;
+
+        if (auto namedMember = dyn_cast<clang::NamedDecl>(canonicalMember))
+          addEntryToLookupTable(table, namedMember, nameImporter);
+      }
     }
   }
 }

--- a/test/Interop/Cxx/class/nested-records-module-interface.swift
+++ b/test/Interop/Cxx/class/nested-records-module-interface.swift
@@ -82,7 +82,7 @@
 // CHECK:   struct ForwardDeclaredFriend {
 // CHECK:     init()
 // CHECK:   }
-// CHECK:   static func takesFriend(_ b: NestedDeclIsAFirstForwardDeclaration.ForwardDeclaredFriend)
+// CHECK:   static func takesFriend(_ f: NestedDeclIsAFirstForwardDeclaration.ForwardDeclaredFriend)
 // CHECK:   struct HasNestedForwardDeclaration {
 // CHECK:     init()
 // CHECK:     struct IsNestedForwardDeclaration {

--- a/test/Interop/Cxx/namespace/templates-module-interface.swift
+++ b/test/Interop/Cxx/namespace/templates-module-interface.swift
@@ -47,10 +47,10 @@
 // CHECK-NEXT: }
 // CHECK-NEXT: typealias ForwardDeclaredClassTemplateOutOfLineChar = TemplatesNS1.TemplatesNS2.__CxxTemplateInstN12TemplatesNS112TemplatesNS237ForwardDeclaredClassTemplateOutOfLineIcEE
 // CHECK-NEXT: enum TemplatesNS4 {
-// CHECK-NEXT:   struct __CxxTemplateInstN12TemplatesNS417HasSpecializationIiEE {
+// CHECK-NEXT:   struct __CxxTemplateInstN12TemplatesNS417HasSpecializationIcEE {
 // CHECK-NEXT:     init()
 // CHECK-NEXT:   }
-// CHECK-NEXT:   struct __CxxTemplateInstN12TemplatesNS417HasSpecializationIcEE {
+// CHECK-NEXT:   struct __CxxTemplateInstN12TemplatesNS417HasSpecializationIiEE {
 // CHECK-NEXT:     init()
 // CHECK-NEXT:   }
 // CHECK-NEXT:   struct HasSpecialization<> {


### PR DESCRIPTION
Make sure nested namespaces are added to the SwiftLookupTable when they are declared in a non-canonical redecl of the parent namespace.

This was blocking C++ interop adoption in SwiftCompilerSources.