### PR TITLE
Use Disjunction Constraint to find main function

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -223,9 +223,6 @@ namespace swift {
     /// Emit a remark after loading a module.
     bool EnableModuleLoadingRemarks = false;
 
-    /// Resolve main function as though it were called from an async context
-    bool EnableAsyncMainResolution = false;
-
     ///
     /// Support for alternate usage modes
     ///

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -270,10 +270,6 @@ def pch_output_dir: Separate<["-"], "pch-output-dir">,
   Flags<[FrontendOption, HelpHidden, ArgumentIsPath]>,
   HelpText<"Directory to persist automatically created precompiled bridging headers">;
 
-def async_main: Flag<["-"], "async-main">,
-    Flags<[FrontendOption]>,
-    HelpText<"Resolve main function as if it were called from an asynchronous context">;
-
 // FIXME: Unhide this once it doesn't depend on an output file map.
 def incremental : Flag<["-"], "incremental">,
   Flags<[NoInteractiveOption, HelpHidden, DoesNotAffectIncrementalBuild]>,

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1535,7 +1535,7 @@ enum class ConstraintSystemFlags {
   /// Note that this flag is automatically applied to all constraint systems,
   /// when \c DebugConstraintSolver is set in \c TypeCheckerOptions. It can be
   /// automatically enabled for select constraint solving attempts by setting
-  /// \c DebugConstraintSolverAttempt. Finally, it can also be automatically 
+  /// \c DebugConstraintSolverAttempt. Finally, it can also be automatically
   /// enabled for a pre-configured set of expressions on line numbers by setting
   /// \c DebugConstraintSolverOnLines.
   DebugConstraints = 0x10,
@@ -1559,10 +1559,6 @@ enum class ConstraintSystemFlags {
   /// calling conventions, say due to Clang attributes such as
   /// `__attribute__((ns_consumed))`.
   UseClangFunctionTypes = 0x80,
-
-  /// When set, nominal typedecl contexts are asynchronous contexts.
-  /// This is set while searching for the main function
-  ConsiderNominalTypeContextsAsync = 0x100,
 };
 
 /// Options that affect the constraint system as a whole.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1559,6 +1559,9 @@ enum class ConstraintSystemFlags {
   /// calling conventions, say due to Clang attributes such as
   /// `__attribute__((ns_consumed))`.
   UseClangFunctionTypes = 0x80,
+
+  /// When set, ignore async/sync mismatches
+  IgnoreAsyncSyncMismatch = 0x100,
 };
 
 /// Options that affect the constraint system as a whole.

--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -21,7 +21,6 @@
 
 #include "swift/AST/Identifier.h"
 #include "swift/Basic/SourceLoc.h"
-#include "swift/Basic/OptionSet.h"
 #include <memory>
 #include <tuple>
 
@@ -51,8 +50,6 @@ namespace swift {
   class ConstraintSystem;
   class Solution;
   class SolutionApplicationTarget;
-  enum class ConstraintSystemFlags;
-  using ConstraintSystemOptions = OptionSet<ConstraintSystemFlags>;
   }
 
   /// Typecheck binding initializer at \p bindingIndex.
@@ -96,9 +93,8 @@ namespace swift {
   /// Unlike other member lookup functions, \c swift::resolveValueMember()
   /// should be used when you want to look up declarations with the same name as
   /// one you already have.
-  ResolvedMemberResult
-  resolveValueMember(DeclContext &DC, Type BaseTy, DeclName Name,
-                     constraints::ConstraintSystemOptions Options = {});
+  ResolvedMemberResult resolveValueMember(DeclContext &DC, Type BaseTy,
+                                          DeclName Name);
 
   /// Given a type and an extension to the original type decl of that type,
   /// decide if the extension has been applied, i.e. if the requirements of the

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -300,7 +300,6 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_access_notes_path);
   inputArgs.AddLastArg(arguments, options::OPT_library_level);
   inputArgs.AddLastArg(arguments, options::OPT_enable_bare_slash_regex);
-  inputArgs.AddLastArg(arguments, options::OPT_async_main);
 
   // Pass on any build config options
   inputArgs.AddAllArgs(arguments, options::OPT_D);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -497,8 +497,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     Diags.diagnose(SourceLoc(), diag::warn_flag_deprecated,
                    "-enable-experimental-async-top-level");
 
-  Opts.EnableAsyncMainResolution = Args.hasArg(OPT_async_main);
-
   Opts.DiagnoseInvalidEphemeralnessAsError |=
       Args.hasArg(OPT_enable_invalid_ephemeralness_as_error);
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4417,11 +4417,10 @@ getMemberDecls(InterestedMemberKind Kind) {
   llvm_unreachable("unhandled kind");
 }
 
-ResolvedMemberResult
-swift::resolveValueMember(DeclContext &DC, Type BaseTy, DeclName Name,
-                          ConstraintSystemOptions Options) {
+ResolvedMemberResult swift::resolveValueMember(DeclContext &DC, Type BaseTy,
+                                               DeclName Name) {
   ResolvedMemberResult Result;
-  ConstraintSystem CS(&DC, Options);
+  ConstraintSystem CS(&DC, None);
 
   // Look up all members of BaseTy with the given Name.
   MemberLookupResult LookupResult = CS.performMemberLookup(

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3304,7 +3304,8 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
     // If we're choosing an asynchronous declaration within a synchronous
     // context, or vice-versa, increase the async/async mismatch score.
     if (auto func = dyn_cast<AbstractFunctionDecl>(decl)) {
-      if (!func->hasPolymorphicEffect(EffectKind::Async) &&
+      if (!Options.contains(ConstraintSystemFlags::IgnoreAsyncSyncMismatch) &&
+          !func->hasPolymorphicEffect(EffectKind::Async) &&
           func->isAsyncContext() != isAsynchronousContext(useDC)) {
         increaseScore(
             func->isAsyncContext() ? SK_AsyncInSyncMismatch : SK_SyncInAsync);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2900,11 +2900,6 @@ bool ConstraintSystem::isAsynchronousContext(DeclContext *dc) {
         FunctionType::ExtInfo()).isAsync();
   }
 
-  if (Options.contains(
-          ConstraintSystemFlags::ConsiderNominalTypeContextsAsync) &&
-      isa<NominalTypeDecl>(dc))
-    return true;
-
   return false;
 }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2171,14 +2171,8 @@ SynthesizeMainFunctionRequest::evaluate(Evaluator &evaluator,
   // mainType.main() from the entry point, and that would require fully
   // type-checking the call to mainType.main().
 
-  constraints::ConstraintSystemOptions lookupOptions;
-  if (context.LangOpts.EnableAsyncMainResolution)
-    lookupOptions |=
-        constraints::ConstraintSystemFlags::ConsiderNominalTypeContextsAsync;
-
   auto resolution = resolveValueMember(
-      *declContext, nominal->getInterfaceType(), context.Id_main,
-      lookupOptions);
+      *declContext, nominal->getInterfaceType(), context.Id_main);
   FuncDecl *mainFunction =
       resolveMainFunctionDecl(declContext, resolution, context);
   if (!mainFunction) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2172,7 +2172,8 @@ SynthesizeMainFunctionRequest::evaluate(Evaluator &evaluator,
   // type-checking the call to mainType.main().
 
   auto resolution = resolveValueMember(
-      *declContext, nominal->getInterfaceType(), context.Id_main);
+      *declContext, nominal->getInterfaceType(), context.Id_main,
+      constraints::ConstraintSystemFlags::IgnoreAsyncSyncMismatch);
   FuncDecl *mainFunction =
       resolveMainFunctionDecl(declContext, resolution, context);
   if (!mainFunction) {

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3380,7 +3380,8 @@ getActorIsolationForMainFuncDecl(FuncDecl *fnDecl) {
   if (!declContext)
     return {};
   const bool isMainDeclContext =
-      declContext->getAttrs().hasAttribute<MainTypeAttr>();
+      declContext->getAttrs().hasAttribute<MainTypeAttr>(
+          /*allow invalid*/ true);
 
   ASTContext &ctx = fnDecl->getASTContext();
 

--- a/test/Concurrency/async_main_resolution.swift
+++ b/test/Concurrency/async_main_resolution.swift
@@ -1,6 +1,11 @@
+// This test aims to show that no preference is given to either the async or
+// sync main function. The most specific, valid, main function will be
+// selected if one exists. If two main functions could exist, the usage is
+// ambiguous.
+
 // async main is nested deeper in protocols than sync, use sync
 // sync main is nested deeper in protocols than async, use async
-// async and sync are same level, use async
+// async and sync are same level, error
 
 // REQUIRES: concurrency
 
@@ -10,23 +15,17 @@
 // BOTH:         MainProtocol has both sync and async main
 // INHERIT_SYNC: main type directly conforms to synchronous main protocol
 
-// | async flag | has async main | has sync main | both | inherits sync | nested async | Result     | Run                                                                                                                                                       |
-// |            |                |               |      |               |              | Error      | RUN: not %target-swift-frontend -disable-availability-checking -DNO_ASYNC -DNO_SYNC  -parse-as-library -typecheck -dump-ast %s 2>&1                       | %FileCheck %s --check-prefix=CHECK-IS-ERROR
-// |            | x              |               |      |               |              | Async Main | RUN: %target-swift-frontend -disable-availability-checking -DNO_SYNC -parse-as-library -typecheck -dump-ast %s                                            | %FileCheck %s --check-prefix=CHECK-IS-ASYNC
-// | x          |                | x             |      |               |              | Sync Main  | RUN: %target-swift-frontend -disable-availability-checking -DNO_ASYNC -async-main -parse-as-library -typecheck -dump-ast %s                               | %FileCheck %s --check-prefix=CHECK-IS-SYNC
-// | x          | x              | x             |      |               |              | Async Main | RUN: %target-swift-frontend -disable-availability-checking -async-main -parse-as-library -typecheck -dump-ast %s                                          | %FileCheck %s --check-prefix=CHECK-IS-ASYNC
-// |            | x              | x             |      |               |              | Sync Main  | RUN: %target-swift-frontend -disable-availability-checking -parse-as-library -typecheck -dump-ast %s                                                      | %FileCheck %s --check-prefix=CHECK-IS-SYNC
-// |            | x              | x             |      |               | x            | Async Main | RUN: %target-swift-frontend -disable-availability-checking -DASYNC_NESTED -parse-as-library -typecheck -dump-ast %s                                       | %FileCheck %s --check-prefix=CHECK-IS-ASYNC
-// |            | x              | x             |      | x             | x            | Sync Main  | RUN: %target-swift-frontend -disable-availability-checking -DINHERIT_SYNC -DASYNC_NESTED -parse-as-library -typecheck -dump-ast %s                        | %FileCheck %s --check-prefix=CHECK-IS-SYNC
-// | x          | x              | x             |      | x             | x            | Async Main | RUN: %target-swift-frontend -disable-availability-checking -DINHERIT_SYNC -DASYNC_NESTED -async-main -parse-as-library -typecheck -dump-ast %s            | %FileCheck %s --check-prefix=CHECK-IS-ASYNC
-// | x          |                | x             |      | x             | x            | Sync Main  | RUN: %target-swift-frontend -disable-availability-checking -DNO_ASYNC -DINHERIT_SYNC -DASYNC_NESTED -async-main -parse-as-library -typecheck -dump-ast %s | %FileCheck %s --check-prefix=CHECK-IS-SYNC
-// |            |                | x             | x    |               |              | Sync Main  | RUN: %target-swift-frontend -disable-availability-checking -DBOTH -DNO_ASYNC -parse-as-library -typecheck -dump-ast %s                                    | %FileCheck %s --check-prefix=CHECK-IS-SYNC
-// | x          |                | x             | x    |               |              | Async Main | RUN: %target-swift-frontend -disable-availability-checking -DBOTH -DNO_ASYNC -async-main -parse-as-library -typecheck -dump-ast %s                        | %FileCheck %s --check-prefix=CHECK-IS-ASYNC
-
-// tldr;
-// If async flag is set, will pick an asynchronous main function if one is available and related. If none exist, will fall back on synchronous main.
-// If async flag is not set, will pick a asynchronous main function if one is available and related. If none exist, will fall back on an asynchronous main
-// If neither are available; error
+// | has async main | has sync main | both | inherits sync | nested async | Result |                         | Run                                                                                                                                          |
+// |                |               |      |               |              | Error  | No main                 | RUN: not %target-swift-frontend -disable-availability-checking -DNO_SYNC -DNO_ASYNC -parse-as-library -typecheck -dump-ast %s 2>&1           | %FileCheck %s --check-prefix=CHECK-IS-ERROR1
+// | x              | x             | x    | x             |              | Error  | Ambiguous main in MainP | RUN: not %target-swift-frontend -disable-availability-checking -DBOTH -DINHERIT_SYNC -parse-as-library -typecheck -dump-ast %s 2>&1          | %FileCheck %s --check-prefix=CHECK-IS-ERROR2
+// |                | x             | x    | x             |              | Error  | Ambiguous main in MainP | RUN: not %target-swift-frontend -disable-availability-checking -DBOTH -DINHERIT_SYNC -parse-as-library -typecheck -dump-ast %s 2>&1          | %FileCheck %s --check-prefix=CHECK-IS-ERROR2
+// | x              | x             | x    |               |              | Async  | Directly selected       | RUN: %target-swift-frontend -disable-availability-checking -DBOTH -parse-as-library -typecheck -dump-ast %s                                  | %FileCheck %s --check-prefix=CHECK-IS-ASYNC
+// | x              | x             |      |               |              | Async  | Directly selected       | RUN: %target-swift-frontend -disable-availability-checking -parse-as-library -typecheck -dump-ast %s                                         | %FileCheck %s --check-prefix=CHECK-IS-ASYNC
+// |                | x             |      |               |              | Sync   | Indirectly selected     | RUN: %target-swift-frontend -disable-availability-checking -DNO_ASYNC -parse-as-library -typecheck -dump-ast %s                              | %FileCheck %s --check-prefix=CHECK-IS-SYNC
+// | x              | x             |      | x             | x            | Sync   | Directly selected       | RUN: %target-swift-frontend -disable-availability-checking -DINHERIT_SYNC -DASYNC_NESTED -parse-as-library -typecheck -dump-ast %s           | %FileCheck %s --check-prefix=CHECK-IS-SYNC
+// | x              |               |      | x             | x            | Async  | Indirectly selected     | RUN: %target-swift-frontend -disable-availability-checking -DNO_SYNC -DINHERIT_SYNC -DASYNC_NESTED -parse-as-library -typecheck -dump-ast %s | %FileCheck %s --check-prefix=CHECK-IS-ASYNC
+// | x              |               |      | x             |              | Error  | Unrelated async main    | RUN: not %target-swift-frontend -disable-availability-checking -DNO_SYNC -DINHERIT_SYNC -parse-as-library -typecheck -dump-ast %s 2>&1       | %FileCheck %s --check-prefix=CHECK-IS-ERROR1
+// |                | x             |      |               | x            | Error  | Unrelated sync main     | RUN: not %target-swift-frontend -disable-availability-checking -DNO_ASYNC -DASYNC_NESTED -parse-as-library -typecheck -dump-ast %s  2>&1     | %FileCheck %s --check-prefix=CHECK-IS-ERROR1
 
 #if ASYNC_NESTED
 protocol AsyncMainProtocol { }
@@ -71,4 +70,5 @@ extension MainProtocol {
 // CHECK-IS-ASYNC: (func_decl implicit "$main()" interface type='(MyMain.Type) -> () async -> ()'
 // CHECK-IS-ASYNC:       (declref_expr implicit type='(MyMain.Type) -> () async -> ()'
 
-// CHECK-IS-ERROR: error: 'MyMain' is annotated with @main and must provide a main static function of type {{\(\) -> Void or \(\) throws -> Void|\(\) -> Void, \(\) throws -> Void, \(\) async -> Void, or \(\) async throws -> Void}}
+// CHECK-IS-ERROR1: error: 'MyMain' is annotated with @main and must provide a main static function of type {{\(\) -> Void or \(\) throws -> Void|\(\) -> Void, \(\) throws -> Void, \(\) async -> Void, or \(\) async throws -> Void}}
+// CHECK-IS-ERROR2: error: ambiguous use of 'main'

--- a/test/Concurrency/where_clause_main_resolution.swift
+++ b/test/Concurrency/where_clause_main_resolution.swift
@@ -1,9 +1,6 @@
 // RUN: %target-swift-frontend -disable-availability-checking -D CONFIG1 -dump-ast -parse-as-library %s | %FileCheck %s --check-prefixes=CHECK,CHECK-CONFIG1
-// RUN: %target-swift-frontend -disable-availability-checking -D CONFIG1 -dump-ast -parse-as-library -async-main %s | %FileCheck %s --check-prefixes=CHECK,CHECK-CONFIG1-ASYNC
 // RUN: %target-swift-frontend -disable-availability-checking -D CONFIG2 -dump-ast -parse-as-library %s | %FileCheck %s --check-prefixes=CHECK,CHECK-CONFIG2
-// RUN: %target-swift-frontend -disable-availability-checking -D CONFIG2 -dump-ast -parse-as-library -async-main %s | %FileCheck %s --check-prefixes=CHECK,CHECK-CONFIG2-ASYNC
 // RUN: %target-swift-frontend -disable-availability-checking -D CONFIG3 -dump-ast -parse-as-library %s | %FileCheck %s --check-prefixes=CHECK,CHECK-CONFIG3
-// RUN: %target-swift-frontend -disable-availability-checking -D CONFIG3 -dump-ast -parse-as-library -async-main %s | %FileCheck %s --check-prefixes=CHECK,CHECK-CONFIG3-ASYNC
 
 // REQUIRES: concurrency
 
@@ -21,40 +18,31 @@ protocol App {
 // CHECK: (source_file "[[SOURCE_FILE:[^"]+]]"
 // CHECK: (extension_decl range={{\[}}[[SOURCE_FILE]]:{{[0-9]+}}:{{[0-9]+}} - line:{{[0-9]+}}:{{[0-9]+}}{{\]}} App where
 // CHECK: (extension_decl range={{\[}}[[SOURCE_FILE]]:{{[0-9]+}}:{{[0-9]+}} - line:{{[0-9]+}}:{{[0-9]+}}{{\]}} App where
+// CHECK: (extension_decl range={{\[}}[[SOURCE_FILE]]:{{[0-9]+}}:{{[0-9]+}} - line:{{[0-9]+}}:{{[0-9]+}}{{\]}} App where
 // CHECK: (extension_decl range={{\[}}[[SOURCE_FILE]]:{{[0-9]+}}:{{[0-9]+}} - line:{{[0-9]+}}:{{[0-9]+}}{{\]}}
 // CHECK-NOT: where
 // CHECK-NEXT: (func_decl range={{\[}}[[SOURCE_FILE]]:[[DEFAULT_ASYNCHRONOUS_MAIN_LINE:[0-9]+]]:{{[0-9]+}} - line:{{[0-9]+}}:{{[0-9]+}}{{\]}} "main()"
 // CHECK-SAME: interface type='<Self where Self : App> (Self.Type) -> () async -> ()'
-// CHECK: (func_decl range={{\[}}[[SOURCE_FILE]]:[[DEFAULT_SYNCHRONOUS_MAIN_LINE:[0-9]+]]:{{[0-9]+}} - line:{{[0-9]+}}:{{[0-9]+}}{{\]}} "main()"
-// CHECK-SAME: interface type='<Self where Self : App> (Self.Type) -> () -> ()'
-
 
 extension App where Configuration == Config1 {
 // CHECK-CONFIG1: (func_decl implicit "$main()" interface type='(MainType.Type) -> () -> ()'
 // CHECK-CONFIG1: [[SOURCE_FILE]]:[[# @LINE+1 ]]
     static func main() { }
-
-// CHECK-CONFIG1-ASYNC: (func_decl implicit "$main()" interface type='(MainType.Type) -> () async -> ()'
-// CHECK-CONFIG1-ASYNC: [[SOURCE_FILE]]:[[DEFAULT_ASYNCHRONOUS_MAIN_LINE]]
 }
 
 extension App where Configuration == Config2 {
-// CHECK-CONFIG2: (func_decl implicit "$main()" interface type='(MainType.Type) -> () -> ()'
-// CHECK-CONFIG2: [[SOURCE_FILE]]:[[DEFAULT_SYNCHRONOUS_MAIN_LINE]]
-
-// CHECK-CONFIG2-ASYNC: (func_decl implicit "$main()" interface type='(MainType.Type) -> () async -> ()'
-// CHECK-CONFIG2-ASYNC: [[SOURCE_FILE]]:[[# @LINE+1 ]]
+// CHECK-CONFIG2: (func_decl implicit "$main()" interface type='(MainType.Type) -> () async -> ()'
+// CHECK-CONFIG2: [[SOURCE_FILE]]:[[# @LINE+1 ]]
     static func main() async { }
 }
 
-extension App {
+extension App where Configuration == Config3 {
 // CHECK-CONFIG3-ASYNC: (func_decl implicit "$main()" interface type='(MainType.Type) -> () async -> ()'
-// CHECK-CONFIG3-ASYNC: [[SOURCE_FILE]]:[[# @LINE+1 ]]
-    static func main() async { }
+// CHECK-CONFIG3-ASYNC: [[SOURCE_FILE]]:[[DEFAULT_ASYNCHRONOUS_MAIN_LINE]]
+}
 
-// CHECK-CONFIG3: (func_decl implicit "$main()" interface type='(MainType.Type) -> () -> ()'
-// CHECK-CONFIG3: [[SOURCE_FILE]]:[[# @LINE+1 ]]
-    static func main() { }
+extension App {
+    static func main() async { }
 }
 
 @main

--- a/test/attr/ApplicationMain/attr_main_struct_from_two_protocols_one_missing.swift
+++ b/test/attr/ApplicationMain/attr_main_struct_from_two_protocols_one_missing.swift
@@ -8,14 +8,14 @@ protocol Runnable {
 protocol OtherThing {
 }
 
-extension Runnable where Self : OtherThing { // expected-note{{where 'Self' = 'EntryPoint'}}
+extension Runnable where Self : OtherThing {
     static func main() {
         let it = Self.init()
         it.run()
     }
 }
 
-@main // expected-error{{referencing static method 'main()' on 'Runnable' requires that 'EntryPoint' conform to 'OtherThing'}}
+@main //expected-error{{'EntryPoint' is annotated with @main and must provide a main static function}}
 struct EntryPoint : Runnable {
   func run() {
   }


### PR DESCRIPTION
Third time trying to get the main function resolution behaving correctly.
The challenge here is that, unlike other functions, we don't have a way to determine whether the "calling context" of the main function is synchronous or asynchronous because there isn't a calling context. It is up to the main function to determine whether the rest of the program is run from a sync or async context.

The last two designs didn't work correctly for various reasons.
Simply making the constraint solver ignore async/sync mismatches results in incorrect behavior with conditional conformances. The following snippet exposed the issue. The original resolver would fall back on grabbing the first candidate from the list of candidates if no best solution was found. A best solution wouldn't be set if there were ambiguities or missing functions. The candidates were in the order of declaration in the source file. So in this case, if you selected configuration 3, it would see the ambiguity between the synchronous and asynchronous main function, and select the main function in config 1. (This is bad!) It should instead report the ambiguity.

```swift
@main
struct MainType : App {
#if CONFIG1
    typealias Configuration = Config1
#elseif CONFIG2
    typealias Configuration = Config2
#elseif CONFIG3
    typealias Configuration = Config3
#endif
}

protocol AppConfiguration { }

struct Config1: AppConfiguration {}
struct Config2: AppConfiguration {}
struct Config3: AppConfiguration {}

protocol App {
    associatedtype Configuration: AppConfiguration
}

extension App where Configuration == Config1 {
    static func main() { print("Config1") }
}

extension App where Configuration == Config2 {
    static func main() async { print("Config2") }
}

extension App {
    static func main() async { print("Default Async") }

    static func main() { print("Default Sync") }
} 
```

To mitigate this, I tried using an `async-main` flag, which would bias the constraint solver in favor of one over the other.
This was not ideal for a few reasons. While it resolved the above case with the explicit flag, it first, required an explicit flag that would completely change the behavior of the program, but second, would prefer either the sync or async function of the specific type. e.g, in the above case, if you specified `Config1`, with the async flag selected, it would choose the default async main function instead of the function from `Config1`.

In order to actually fix this to be properly sane, I've done a bit of digging with the constraint solver. Rather than dragging out everything called `main`, then trawling the list of everything we found, I've set up a disjunction constraint of only the types and names of valid main functions. This way we only get a list of valid function declarations, with a valid type, called `main`. The valid types are `() -> Void`, `() async -> Void`, `() throws -> Void`, `() async throws -> Void`, `@MainActor () -> Void`, `@MainActor () async -> Void`, `@MainActor () throws -> Void`, and `@MainActor () async throws -> Void`.