### PR TITLE
[5.7][stdlib] Fix warning on Clock.Duration

### DIFF
--- a/stdlib/public/Concurrency/Clock.swift
+++ b/stdlib/public/Concurrency/Clock.swift
@@ -32,7 +32,7 @@ import Swift
 /// `SuspendingClock`.
 @available(SwiftStdlib 5.7, *)
 public protocol Clock: Sendable {
-  associatedtype Duration: DurationProtocol
+  associatedtype Duration
   associatedtype Instant: InstantProtocol where Instant.Duration == Duration
 
   var now: Instant { get }


### PR DESCRIPTION
(Cherry picked from #58411, reviewed by @phausler, @slavapestov & @stephentyrone)

https://github.com/apple/swift/pull/42314 introduced `Clock.Duration` as an associated type:

```swift
@available(SwiftStdlib 5.7, *)
public protocol Clock: Sendable {
  associatedtype Duration: DurationProtocol
  associatedtype Instant: InstantProtocol where Instant.Duration == Duration
  …
}
```

Unfortunately this produces a warning:

```
…/swift/stdlib/public/Concurrency/Clock.swift:35:28: warning: redundant conformance constraint 'Self.Duration' : 'DurationProtocol'
  associatedtype Duration: DurationProtocol
                           ^
```

To keep the stdlib build log free of noise, it seems we’ll need to update this declaration to remove the direct requirement.

rdar://92306564
