### PR TITLE
Use Location of Inference Sources as a Fallback

### DIFF
--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -787,9 +787,11 @@ InferredGenericSignatureRequestRQM::evaluate(
   // types and such.
   for (auto sourcePair : inferenceSources) {
     auto *typeRepr = sourcePair.getTypeRepr();
-    auto loc = typeRepr ? typeRepr->getStartLoc() : SourceLoc();
+    auto typeLoc = typeRepr ? typeRepr->getStartLoc() : SourceLoc();
+    if (loc.isInvalid())
+      loc = typeLoc;
 
-    inferRequirements(sourcePair.getType(), loc, moduleForInference,
+    inferRequirements(sourcePair.getType(), typeLoc, moduleForInference,
                       requirements);
   }
 

--- a/test/type/parameterized_existential.swift
+++ b/test/type/parameterized_existential.swift
@@ -62,3 +62,11 @@ func saturation(_ dry: any Sponge, _ wet: any Sponge<Int, Int>) {
   _ = wet as any Sponge<String, String> // expected-error {{'any Sponge<Int, Int>' is not convertible to 'any Sponge<String, String>'}}
   // expected-note@-1 {{did you mean to use 'as!' to force downcast?}}
 }
+
+protocol Pair<X, Y> where Self.X == Self.Y {
+  associatedtype X
+  associatedtype Y
+}
+
+func splay(_ x: some Pair<Int, String>) -> (Int, String) { fatalError() }
+// expected-error@-1 {{no type for 'some Pair<Int, String>.X' can satisfy both 'some Pair<Int, String>.X == String' and 'some Pair<Int, String>.X == Int'}}


### PR DESCRIPTION
It's possible for the requirement machine to fail to pick up a source location for its computed errors to attach to when
1) The declaration has no where clause
2) Nor does it have a generic parameter list

This is possible because of the magic of desugaring opaque types in input position to generic parameters a la

func foo(_ : some P<T, U>)

Try to use the first valid user-written inference source to derive a location.

rdar://92105516