### PR TITLE
[Diagnostics] Ignore implicitly generated `~=` calls

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5566,6 +5566,9 @@ static bool isOperator(Expr *expr, StringRef expectedName) {
 }
 
 Optional<Identifier> constraints::getOperatorName(Expr *expr) {
+  if (auto *apply = dyn_cast<ApplyExpr>(expr))
+    return getOperatorName(apply->getFn());
+
   ValueDecl *choice = nullptr;
   if (auto *ODRE = dyn_cast_or_null<OverloadedDeclRefExpr>(expr)) {
     choice = ODRE->getDecls().front();

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar92327807.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar92327807.swift
@@ -1,0 +1,11 @@
+// RUN: %target-typecheck-verify-swift
+
+enum MyEnum {
+case test
+}
+
+func test(result: MyEnum?) {
+  if let .co = result { // expected-error {{pattern matching in a condition requires the 'case' keyword}}
+    // expected-error@-1 {{type 'MyEnum?' has no member 'co'}}
+  }
+}


### PR DESCRIPTION
These calls are synthesized for convenience of solution application
and should not affect diagnostics. Arguments to `~=` are already
handled specially when repairing failures.

Resolves: rdar://92327807

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
