### PR TITLE
[5.7] fix a crash/hang in SimplifyCFG.

### DIFF
--- a/test/SILOptimizer/simplify_cfg_crash.swift
+++ b/test/SILOptimizer/simplify_cfg_crash.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -O %s -emit-sil -o /dev/null
+
+public class X {}
+
+public func testit(_ s: [X]) -> X? {
+  var r: X?
+  for e in s {
+    if r == nil {
+      r = e
+    } else if e !== r {
+      return nil
+    }
+  }
+  return r
+}
+


### PR DESCRIPTION
Jump threading in an unreachable CFG region can lead to a crash (in an assert compiler) or hang (in an no-assert compiler) in `ValueBase::replaceAllUsesWith`.

Unfortunately I couldn't come up with an isolated SIL test case.

rdar://92267349
