### PR TITLE
[cxx-interop] Add basic C++ stdlib overlay

### DIFF
--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -278,6 +278,10 @@ def enable_experimental_concurrency :
   Flag<["-"], "enable-experimental-concurrency">,
   HelpText<"Enable experimental concurrency model">;
 
+def enable_experimental_cxx_interop :
+  Flag<["-"], "enable-experimental-cxx-interop">,
+  HelpText<"Enable C++ interop code generation and config directives">;
+
 def enable_lexical_borrow_scopes :
   Joined<["-"], "enable-lexical-borrow-scopes=">,
   HelpText<"Whether to emit lexical borrow scopes (default: true)">,
@@ -824,11 +828,6 @@ def emit_sorted_sil : Flag<["-"], "emit-sorted-sil">,
 
 def emit_syntax : Flag<["-"], "emit-syntax">,
   HelpText<"Parse input file(s) and emit the Syntax tree(s) as JSON">, ModeOpt;
-
-def enable_experimental_cxx_interop :
-  Flag<["-"], "enable-experimental-cxx-interop">,
-  HelpText<"Enable C++ interop code generation and config directives">,
-  Flags<[FrontendOption, HelpHidden]>;
 
 def enable_cxx_interop :
   Flag<["-"], "enable-cxx-interop">,

--- a/stdlib/public/Cxx/CMakeLists.txt
+++ b/stdlib/public/Cxx/CMakeLists.txt
@@ -122,3 +122,24 @@ endforeach()
 add_custom_target(libstdcxx-modulemap DEPENDS ${libstdcxx_modulemap_target_list})
 set_property(TARGET libstdcxx-modulemap PROPERTY FOLDER "Miscellaneous")
 add_dependencies(sdk-overlay libstdcxx-modulemap)
+
+
+#
+# C++ Standard Library Overlay.
+#
+add_swift_target_library(swiftstd ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+    std.swift
+    String.swift
+
+    SWIFT_MODULE_DEPENDS_OSX Darwin
+    SWIFT_MODULE_DEPENDS_IOS Darwin
+    SWIFT_MODULE_DEPENDS_TVOS Darwin
+    SWIFT_MODULE_DEPENDS_WATCHOS Darwin
+
+    SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
+    -Xfrontend -enable-experimental-cxx-interop
+    -Xfrontend -module-interface-preserve-types-as-written
+
+    LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}" -lc++
+    TARGET_SDKS ALL_APPLE_PLATFORMS # TODO: support other platforms as well
+    INSTALL_IN_COMPONENT sdk-overlay)

--- a/stdlib/public/Cxx/String.swift
+++ b/stdlib/public/Cxx/String.swift
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+extension std.string {
+  public init(_ string: String) {
+    self.init()
+    for char in string.utf8 {
+      self.push_back(value_type(char))
+    }
+  }
+}
+
+extension String {
+  public init(cxxString: std.string) {
+    self.init(cString: cxxString.c_str())
+  }
+}

--- a/stdlib/public/Cxx/std.swift
+++ b/stdlib/public/Cxx/std.swift
@@ -1,0 +1,13 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_exported import std // Clang module

--- a/test/Interop/Cxx/stdlib/overlay/string.swift
+++ b/test/Interop/Cxx/stdlib/overlay/string.swift
@@ -1,0 +1,21 @@
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-cxx-interop)
+//
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx
+
+import StdlibUnittest
+import std
+
+var StdStringOverlayTestSuite = TestSuite("std::string overlay")
+
+StdStringOverlayTestSuite.test("std::string <=> Swift.String") {
+  let cxx1 = std.string()
+  let swift1 = String(cxxString: cxx1)
+  expectEqual(swift1, "")
+
+  let cxx2 = std.string("something123")
+  let swift2 = String(cxxString: cxx2)
+  expectEqual(swift2, "something123")
+}
+
+runAllTests()

--- a/validation-test/ParseableInterface/verify_all_overlays.py
+++ b/validation-test/ParseableInterface/verify_all_overlays.py
@@ -51,8 +51,12 @@ for filename in os.listdir(sdk_overlay_dir):
 
     # swift -build-module-from-parseable-interface
     output_path = os.path.join(output_dir, module_name + ".swiftmodule")
+    compiler_args = ["-o", output_path, "-module-name", module_name,
+                     interface_file]
+    if module_name == "std":
+        compiler_args += ["-enable-experimental-cxx-interop"]
+
     status = subprocess.call(compiler_invocation +
-                             ["-o", output_path, "-module-name", module_name,
-                              interface_file])
+                             compiler_args)
     if status != 0:
         print("# " + target_os + ": " + module_name)


### PR DESCRIPTION
This will allow us to add Swift conformances to C++ standard library types, and improve usability of the C++ standard library from Swift.