### PR TITLE
[Codable][Sema] Change local bindings to match auto-generated coding keys

### DIFF
--- a/test/refactoring/AddCodableImplementation/Outputs/enum/codable.swift.expected
+++ b/test/refactoring/AddCodableImplementation/Outputs/enum/codable.swift.expected
@@ -41,11 +41,11 @@ enum Payload: Codable {
     var container = encoder.container(keyedBy: Payload.CodingKeys.self)
 
     switch self {
-    case .plain(let a0):
+    case .plain(let _0):
 
       var nestedContainer = container.nestedContainer(keyedBy: Payload.PlainCodingKeys.self, forKey: Payload.CodingKeys.plain)
 
-      try nestedContainer.encode(a0, forKey: Payload.PlainCodingKeys._0)
+      try nestedContainer.encode(_0, forKey: Payload.PlainCodingKeys._0)
       case .pair(let key, let value):
 
       var nestedContainer = container.nestedContainer(keyedBy: Payload.PairCodingKeys.self, forKey: Payload.CodingKeys.pair)

--- a/test/refactoring/AddCodableImplementation/Outputs/enum/encodable.swift.expected
+++ b/test/refactoring/AddCodableImplementation/Outputs/enum/encodable.swift.expected
@@ -29,11 +29,11 @@ enum Payload_E: Encodable {
     var container = encoder.container(keyedBy: Payload_E.CodingKeys.self)
 
     switch self {
-    case .plain(let a0):
+    case .plain(let _0):
 
       var nestedContainer = container.nestedContainer(keyedBy: Payload_E.PlainCodingKeys.self, forKey: Payload_E.CodingKeys.plain)
 
-      try nestedContainer.encode(a0, forKey: Payload_E.PlainCodingKeys._0)
+      try nestedContainer.encode(_0, forKey: Payload_E.PlainCodingKeys._0)
       case .pair(let key, let value):
 
       var nestedContainer = container.nestedContainer(keyedBy: Payload_E.PairCodingKeys.self, forKey: Payload_E.CodingKeys.pair)

--- a/test/stdlib/CodableInvalidKeys.swift
+++ b/test/stdlib/CodableInvalidKeys.swift
@@ -1,0 +1,93 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+
+import Swift
+
+// expected-error @+2 {{type 'Foo' does not conform to protocol 'Decodable'}}
+// expected-error @+1 {{type 'Foo' does not conform to protocol 'Encodable'}}
+enum Foo: Codable {
+  // expected-note @+2 {{cannot automatically synthesize 'Decodable' for 'Foo' because user defined parameter name '_0' in 'foo' conflicts with automatically generated parameter name}}
+  // expected-note @+1 {{cannot automatically synthesize 'Encodable' for 'Foo' because user defined parameter name '_0' in 'foo' conflicts with automatically generated parameter name}}
+  case foo(Int, _0: String)
+}
+
+// Original set of crashers detected from PR-39825:
+
+// expected-error @+2 {{type 'Foo2' does not conform to protocol 'Decodable'}}
+// expected-error @+1 {{type 'Foo2' does not conform to protocol 'Encodable'}}
+enum Foo2: Codable {
+  // expected-note @+2 {{cannot automatically synthesize 'Decodable' for 'Foo2' because user defined parameter name 'a0' in 'foo' conflicts with automatically generated parameter name}}
+  // expected-note @+1 {{cannot automatically synthesize 'Encodable' for 'Foo2' because user defined parameter name 'a0' in 'foo' conflicts with automatically generated parameter name}}
+  case foo(Int, a0: String)
+}
+
+// expected-error @+2 {{type 'Foo3' does not conform to protocol 'Decodable'}}
+// expected-error @+1 {{type 'Foo3' does not conform to protocol 'Encodable'}}
+enum Foo3: Codable {
+  // expected-note @+2 {{cannot automatically synthesize 'Decodable' for 'Foo3' because user defined parameter name 'a2' in 'foo' conflicts with automatically generated parameter name}}
+  // expected-note @+1 {{cannot automatically synthesize 'Encodable' for 'Foo3' because user defined parameter name 'a2' in 'foo' conflicts with automatically generated parameter name}}
+  case foo(Int, String, String, a2: String)
+}
+
+// expected-error @+2 {{type 'Foo4' does not conform to protocol 'Decodable'}}
+// expected-error @+1 {{type 'Foo4' does not conform to protocol 'Encodable'}}
+enum Foo4: Codable {
+  // expected-note @+2 {{cannot automatically synthesize 'Decodable' for 'Foo4' because user defined parameter name 'a2' in 'foo' conflicts with automatically generated parameter name}}
+  // expected-note @+1 {{cannot automatically synthesize 'Encodable' for 'Foo4' because user defined parameter name 'a2' in 'foo' conflicts with automatically generated parameter name}}
+  case foo(String, String, String, a2: String)
+}
+
+// Valid code that successfully compiled in PR-39825
+
+enum Foo5: Codable {
+  case foo(_0: Int, String)
+}
+
+enum Foo6: Codable {
+  case foo(_0: Int, _1: String)
+}
+
+enum Foo7: Codable {
+  case foo(Int, _1: String)
+}
+
+enum Foo8: Codable {
+  case foo(_1: Int, _0: String)
+}
+
+// Cases relating to `a0`:
+
+enum Foo9 {
+  case foo(Int, a0: String)
+}
+
+enum Foo10: Codable {
+  case foo(Int, _a0: String)
+}
+
+// expected-error @+2 {{type 'Foo11' does not conform to protocol 'Decodable'}}
+// expected-error @+1 {{type 'Foo11' does not conform to protocol 'Encodable'}}
+enum Foo11: Codable {
+  // expected-note @+2 {{cannot automatically synthesize 'Decodable' for 'Foo11' because user defined parameter name 'a1' in 'foo' conflicts with automatically generated parameter name}}
+  // expected-note @+1 {{cannot automatically synthesize 'Encodable' for 'Foo11' because user defined parameter name 'a1' in 'foo' conflicts with automatically generated parameter name}}
+  case foo(a1: Int, String)
+}
+
+enum Foo12: Codable {
+  case foo(a0: Int, qt: String)
+}
+
+enum Foo13: Codable {
+  case foo(qt: Int, a0: String)
+}
+
+enum Foo14: Codable {
+  case foo(_1: Int, a0: String)
+}
+
+enum Foo15: Codable {
+  case foo(_0: Int, a0: String)
+}
+
+enum Foo16: Codable {
+  case foo(Int, b0: String)
+}

--- a/test/stdlib/CodableInvalidKeys.swift
+++ b/test/stdlib/CodableInvalidKeys.swift
@@ -12,27 +12,15 @@ enum Foo: Codable {
 
 // Original set of crashers detected from PR-39825:
 
-// expected-error @+2 {{type 'Foo2' does not conform to protocol 'Decodable'}}
-// expected-error @+1 {{type 'Foo2' does not conform to protocol 'Encodable'}}
 enum Foo2: Codable {
-  // expected-note @+2 {{cannot automatically synthesize 'Decodable' for 'Foo2' because user defined parameter name 'a0' in 'foo' conflicts with automatically generated parameter name}}
-  // expected-note @+1 {{cannot automatically synthesize 'Encodable' for 'Foo2' because user defined parameter name 'a0' in 'foo' conflicts with automatically generated parameter name}}
   case foo(Int, a0: String)
 }
 
-// expected-error @+2 {{type 'Foo3' does not conform to protocol 'Decodable'}}
-// expected-error @+1 {{type 'Foo3' does not conform to protocol 'Encodable'}}
 enum Foo3: Codable {
-  // expected-note @+2 {{cannot automatically synthesize 'Decodable' for 'Foo3' because user defined parameter name 'a2' in 'foo' conflicts with automatically generated parameter name}}
-  // expected-note @+1 {{cannot automatically synthesize 'Encodable' for 'Foo3' because user defined parameter name 'a2' in 'foo' conflicts with automatically generated parameter name}}
   case foo(Int, String, String, a2: String)
 }
 
-// expected-error @+2 {{type 'Foo4' does not conform to protocol 'Decodable'}}
-// expected-error @+1 {{type 'Foo4' does not conform to protocol 'Encodable'}}
 enum Foo4: Codable {
-  // expected-note @+2 {{cannot automatically synthesize 'Decodable' for 'Foo4' because user defined parameter name 'a2' in 'foo' conflicts with automatically generated parameter name}}
-  // expected-note @+1 {{cannot automatically synthesize 'Encodable' for 'Foo4' because user defined parameter name 'a2' in 'foo' conflicts with automatically generated parameter name}}
   case foo(String, String, String, a2: String)
 }
 
@@ -64,11 +52,7 @@ enum Foo10: Codable {
   case foo(Int, _a0: String)
 }
 
-// expected-error @+2 {{type 'Foo11' does not conform to protocol 'Decodable'}}
-// expected-error @+1 {{type 'Foo11' does not conform to protocol 'Encodable'}}
 enum Foo11: Codable {
-  // expected-note @+2 {{cannot automatically synthesize 'Decodable' for 'Foo11' because user defined parameter name 'a1' in 'foo' conflicts with automatically generated parameter name}}
-  // expected-note @+1 {{cannot automatically synthesize 'Encodable' for 'Foo11' because user defined parameter name 'a1' in 'foo' conflicts with automatically generated parameter name}}
   case foo(a1: Int, String)
 }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
When an enum conforms to `Codable` and a case has associated values with specific labels, they can conflict with auto-generated coding keys. The cases of `_0, _1, _2...` are already accounted for by the compiler. Names such as `a0, a1, a2...` are not, resulting in a corrupted compiler state that can crash in either Sema or SILGen. When conflicting keys match values with the same Swift type, the crash happens later on because it slips past an assertion. At SILGen, it results in duplicated debug variables.

```swift
enum Foo: Codable {
  case foo(Int, a0: String)
}
```

The compiler is bound to stop compiling in the cases of `a0, a1, a2...`. This PR makes the compiler emit a correct warning before stopping, by checking for `a0` at the same time as it checks for `_0`. In addition, it adds a validation test that covers all possible permutations of associated values like `_0` or `a0`. Many do not conflict with auto-generated names, and are allowed to compile.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves a crash found in https://github.com/apple/swift/pull/39825#issuecomment-950506828, which was related to a solution for SR-15271.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
