### PR TITLE
[Sema] Improving implicit closure capture diagnostic wording

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1965,6 +1965,9 @@ NOTE(non_sendable_nominal,none,
 NOTE(add_nominal_sendable_conformance,none,
      "consider making %0 %1 conform to the 'Sendable' protocol",
      (DescriptiveDeclKind, DeclName))
+NOTE(add_generic_parameter_sendable_conformance,none,
+     "consider making generic parameter %0 conform to the 'Sendable' protocol",
+     (Type))
 REMARK(add_predates_concurrency_import,none,
      "add '@preconcurrency' to %select{suppress|treat}0 "
      "'Sendable'-related %select{warnings|errors}0 from module %1"
@@ -4569,6 +4572,12 @@ ERROR(concurrent_access_of_inout_param,none,
       (DeclName))
 ERROR(non_sendable_capture,none,
       "capture of %1 with non-sendable type %0 in a `@Sendable` closure",
+      (Type, DeclName))
+ERROR(implicit_async_let_non_sendable_capture,none,
+      "capture of %1 with non-sendable type %0 in 'async let' binding",
+      (Type, DeclName))
+ERROR(implicit_non_sendable_capture,none,
+      "implicit capture of %1 requires that %0 conforms to `Sendable`",
       (Type, DeclName))
 
 NOTE(actor_isolated_sync_func,none,

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -255,7 +255,7 @@ var concurrentFuncVar: (@Sendable (NotConcurrent) -> Void)? = nil
 // ----------------------------------------------------------------------
 func acceptConcurrentUnary<T>(_: @Sendable (T) -> T) { }
 
-func concurrentClosures<T>(_: T) {
+func concurrentClosures<T>(_: T) { // expected-note{{consider making generic parameter 'T' conform to the 'Sendable' protocol}} {{26-26=: Sendable}}
   acceptConcurrentUnary { (x: T) in
     _ = x // ok
     acceptConcurrentUnary { _ in x } // expected-warning{{capture of 'x' with non-sendable type 'T' in a `@Sendable` closure}}
@@ -269,7 +269,7 @@ struct S1: Sendable {
   var nc: NotConcurrent // expected-warning{{stored property 'nc' of 'Sendable'-conforming struct 'S1' has non-sendable type 'NotConcurrent'}}
 }
 
-struct S2<T>: Sendable {
+struct S2<T>: Sendable { // expected-note{{consider making generic parameter 'T' conform to the 'Sendable' protocol}} {{12-12=: Sendable}}
   var nc: T // expected-warning{{stored property 'nc' of 'Sendable'-conforming generic struct 'S2' has non-sendable type 'T'}}
 }
 

--- a/test/Concurrency/sr15049.swift
+++ b/test/Concurrency/sr15049.swift
@@ -19,26 +19,33 @@ func testAsyncSequence1Sendable<Seq: AsyncSequence>(_ seq: Seq) async throws whe
    async let _ = seq.reduce(0) { $0 + $1 } // OK
 }
 
-// TODO(diagnostics) [SR-16092]: Add a tailored wording for implicit autoclosure captures in sendable warnings, because 
-// from user perspective there is no closure capture, so diagnostic can be confusing.
-func testAsyncSequenceTypedPattern<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int {
+func testAsyncSequenceTypedPattern<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int { // expected-note{{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{54-54=, Sendable}}
    async let result: Int = seq.reduce(0) { $0 + $1 } // OK
    // expected-warning@-1{{immutable value 'result' was never used; consider replacing with '_' or removing it}}
-   // expected-warning@-2{{capture of 'seq' with non-sendable type 'Seq' in a `@Sendable` closure}}
+   // expected-warning@-2{{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
 }
 
-func testAsyncSequenceTypedPattern1<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int {
+func testAsyncSequenceTypedPattern1<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int { // expected-note{{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{55-55=, Sendable}}
    async let _: Int = seq.reduce(0) { $0 + $1 } // OK
-   // expected-warning@-1{{capture of 'seq' with non-sendable type 'Seq' in a `@Sendable` closure}}
+   // expected-warning@-1{{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
 }
 
-func testAsyncSequence<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int {
+func testAsyncSequence<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int { // expected-note{{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{42-42=, Sendable}}
    async let result = seq.reduce(0) { $0 + $1 } // OK
    // expected-warning@-1{{initialization of immutable value 'result' was never used; consider replacing with assignment to '_' or removing it}}
-   // expected-warning@-2{{capture of 'seq' with non-sendable type 'Seq' in a `@Sendable` closure}}
+   // expected-warning@-2{{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
 }
 
-func testAsyncSequence1<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int {
+func testAsyncSequence1<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int { // expected-note{{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{43-43=, Sendable}}
    async let _ = seq.reduce(0) { $0 + $1 } // OK
-   // expected-warning@-1{{capture of 'seq' with non-sendable type 'Seq' in a `@Sendable` closure}}
+   // expected-warning@-1{{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
+}
+
+func testAsyncSequence3<Seq>(_ seq: Seq) async throws where Seq: AsyncSequence, Seq.Element == Int { // expected-note{{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{28-28=: Sendable}}
+   async let result = seq // expected-warning{{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
+   //expected-warning@-1{{initialization of immutable value 'result' was never used; consider replacing with assignment to '_' or removing it}}
+}
+
+func testAsyncSequence4<Seq>(_ seq: Seq) async throws where Seq: AsyncSequence, Seq.Element == Int { // expected-note{{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{28-28=: Sendable}}
+   async let _ = seq // expected-warning{{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
 }

--- a/test/Distributed/distributed_protocol_isolation.swift
+++ b/test/Distributed/distributed_protocol_isolation.swift
@@ -127,6 +127,7 @@ protocol Server {
   func send<Message: Codable>(message: Message) async throws -> String
 }
 actor MyServer : Server {
+  // expected-note@+1{{consider making generic parameter 'Message' conform to the 'Sendable' protocol}} {{29-29=, Sendable}}
   func send<Message: Codable>(message: Message) throws -> String { "" }  // expected-warning{{non-sendable type 'Message' in parameter of actor-isolated instance method 'send(message:)' satisfying non-isolated protocol requirement cannot cross actor boundary}}
 }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Improve diagnostic wording for implicit closure captures such as `async let` capture.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-16092.
Fixes #58351 
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
