### PR TITLE
Sidetables should not use `operator new` or `operator delete`.

### DIFF
--- a/include/swift/Runtime/Heap.h
+++ b/include/swift/Runtime/Heap.h
@@ -20,13 +20,72 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
+#include <new>
 #include <type_traits>
+#include <utility>
+
+#include "swift/Runtime/Config.h"
 
 #if defined(_WIN32)
 #include <malloc.h>
 #endif
 
 namespace swift {
+// Allocate plain old memory. This is the generalized entry point
+// Never returns nil. The returned memory is uninitialized. 
+//
+// An "alignment mask" is just the alignment (a power of 2) minus 1.
+SWIFT_RUNTIME_EXPORT
+void *swift_slowAlloc(size_t bytes, size_t alignMask);
+
+// If the caller cannot promise to zero the object during destruction,
+// then call these corresponding APIs:
+SWIFT_RUNTIME_EXPORT
+void swift_slowDealloc(void *ptr, size_t bytes, size_t alignMask);
+
+/// Allocate and construct an instance of type \c T.
+///
+/// \param args The arguments to pass to the constructor for \c T.
+///
+/// \returns A pointer to a new, fully constructed instance of \c T. This
+///   function never returns \c nullptr. The caller is responsible for
+///   eventually destroying the resulting object by passing it to
+///   \c swift_cxx_deleteObject().
+///
+/// This function avoids the use of the global \c operator \c new (which may be
+/// overridden by other code in a process) in favor of calling
+/// \c swift_slowAlloc() and constructing the new object with placement new.
+///
+/// This function is capable of returning well-aligned memory even on platforms
+/// that do not implement the C++17 "over-aligned new" feature.
+template <typename T, typename... Args>
+static inline T *swift_cxx_newObject(Args &&... args) {
+  auto result = reinterpret_cast<T *>(swift_slowAlloc(sizeof(T),
+                                                      alignof(T) - 1));
+  ::new (result) T(std::forward<Args>(args)...);
+  return result;
+}
+
+/// Destruct and deallocate an instance of type \c T.
+///
+/// \param ptr A pointer to an instance of type \c T previously created with a
+///   call to \c swift_cxx_newObject().
+///
+/// This function avoids the use of the global \c operator \c delete (which may
+/// be overridden by other code in a process) in favor of directly calling the
+/// destructor for \a *ptr and then freeing its memory by calling
+/// \c swift_slowDealloc().
+///
+/// The effect of passing a pointer to this function that was \em not returned
+/// from \c swift_cxx_newObject() is undefined.
+template <typename T>
+static inline void swift_cxx_deleteObject(T *ptr) {
+  if (ptr) {
+    ptr->~T();
+    swift_slowDealloc(ptr, sizeof(T), alignof(T) - 1);
+  }
+}
+
 namespace {
 // This is C++17 and newer, so we simply re-define it.  Since the codebase is
 // C++14, assume that DR1558 is accounted for and that unused parameters in alias

--- a/include/swift/Runtime/HeapObject.h
+++ b/include/swift/Runtime/HeapObject.h
@@ -19,8 +19,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <new>
-#include <utility>
 #include "swift/Runtime/Config.h"
 
 #if SWIFT_OBJC_INTEROP
@@ -119,62 +117,6 @@ BoxPair swift_makeBoxUnique(OpaqueValue *buffer, Metadata const *type,
 /// Returns the address of a heap object representing all empty box types.
 SWIFT_RUNTIME_EXPORT
 HeapObject* swift_allocEmptyBox();
-
-// Allocate plain old memory. This is the generalized entry point
-// Never returns nil. The returned memory is uninitialized. 
-//
-// An "alignment mask" is just the alignment (a power of 2) minus 1.
-
-SWIFT_RUNTIME_EXPORT
-void *swift_slowAlloc(size_t bytes, size_t alignMask);
-
-// If the caller cannot promise to zero the object during destruction,
-// then call these corresponding APIs:
-SWIFT_RUNTIME_EXPORT
-void swift_slowDealloc(void *ptr, size_t bytes, size_t alignMask);
-
-/// Allocate and construct an instance of type \c T.
-///
-/// \param args The arguments to pass to the constructor for \c T.
-///
-/// \returns A pointer to a new, fully constructed instance of \c T. This
-///   function never returns \c nullptr. The caller is responsible for
-///   eventually destroying the resulting object by passing it to
-///   \c swift_cxx_deleteObject().
-///
-/// This function avoids the use of the global \c operator \c new (which may be
-/// overridden by other code in a process) in favor of calling
-/// \c swift_slowAlloc() and constructing the new object with placement new.
-///
-/// This function is capable of returning well-aligned memory even on platforms
-/// that do not implement the C++17 "over-aligned new" feature.
-template <typename T, typename... Args>
-static inline T *swift_cxx_newObject(Args &&... args) {
-  auto result = reinterpret_cast<T *>(swift_slowAlloc(sizeof(T),
-                                                      alignof(T) - 1));
-  ::new (result) T(std::forward<Args>(args)...);
-  return result;
-}
-
-/// Destruct and deallocate an instance of type \c T.
-///
-/// \param ptr A pointer to an instance of type \c T previously created with a
-///   call to \c swift_cxx_newObject().
-///
-/// This function avoids the use of the global \c operator \c delete (which may
-/// be overridden by other code in a process) in favor of directly calling the
-/// destructor for \a *ptr and then freeing its memory by calling
-/// \c swift_slowDealloc().
-///
-/// The effect of passing a pointer to this function that was \em not returned
-/// from \c swift_cxx_newObject() is undefined.
-template <typename T>
-static inline void swift_cxx_deleteObject(T *ptr) {
-  if (ptr) {
-    ptr->~T();
-    swift_slowDealloc(ptr, sizeof(T), alignof(T) - 1);
-  }
-}
 
 /// Atomically increments the retain count of an object.
 ///

--- a/stdlib/public/SwiftShims/RefCount.h
+++ b/stdlib/public/SwiftShims/RefCount.h
@@ -1329,6 +1329,9 @@ class HeapObjectSideTableEntry {
 #endif
   { }
 
+  void *operator new(size_t) = delete;
+  void operator delete(void *) = delete;
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Winvalid-offsetof"
   static ptrdiff_t refCountsOffset() {
@@ -1455,7 +1458,7 @@ class HeapObjectSideTableEntry {
     // Weak ref count is now zero. Delete the side table entry.
     // FREED -> DEAD
     assert(refCounts.getUnownedCount() == 0);
-    delete this;
+    swift_cxx_deleteObject(this);
   }
 
   void decrementWeakNonAtomic() {
@@ -1468,7 +1471,7 @@ class HeapObjectSideTableEntry {
     // Weak ref count is now zero. Delete the side table entry.
     // FREED -> DEAD
     assert(refCounts.getUnownedCount() == 0);
-    delete this;
+    swift_cxx_deleteObject(this);
   }
 
   uint32_t getWeakCount() const {

--- a/stdlib/public/runtime/RefCount.cpp
+++ b/stdlib/public/runtime/RefCount.cpp
@@ -97,7 +97,7 @@ HeapObjectSideTableEntry* RefCounts<InlineRefCountBits>::allocateSideTable(bool 
   // Preflight passed. Allocate a side table.
   
   // FIXME: custom side table allocator
-  HeapObjectSideTableEntry *side = new HeapObjectSideTableEntry(getHeapObject());
+  auto side = swift_cxx_newObject<HeapObjectSideTableEntry>(getHeapObject());
   
   auto newbits = InlineRefCountBits(side);
   
@@ -106,7 +106,7 @@ HeapObjectSideTableEntry* RefCounts<InlineRefCountBits>::allocateSideTable(bool 
       // Already have a side table. Return it and delete ours.
       // Read before delete to streamline barriers.
       auto result = oldbits.getSideTable();
-      delete side;
+      swift_cxx_deleteObject(side);
       return result;
     }
     else if (failIfDeiniting && oldbits.getIsDeiniting()) {


### PR DESCRIPTION
Sidetables should not use `operator new` or `operator delete`. This change switches them over to `swift_cxx_newObject()` and `swift_cxx_deleteObject()` which wrap `swift_slowAlloc()` and `swift_slowDealloc()` respectively.

**Why is this important?** Because these operators can be overridden globally by code in other modules. Imagine a game that has a custom memory allocator (a common scenario!) The developers of this game may want to have all C++ allocations go through their custom allocator. Now, what happens if they implement the guts of this allocator in Swift (in whole or in part)? Well… better hope you never need to allocate a sidetable while you're in there.