### PR TITLE
Use LLVM runtimes build

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -810,21 +810,6 @@ function set_build_options_for_host() {
             ;;
     esac
 
-
-    # We don't currently support building compiler-rt for cross-compile targets.
-    # It's not clear that's useful anyway.
-    if [[ $(is_cross_tools_host "${host}") ]] ; then
-      llvm_cmake_options+=(
-          -DLLVM_TOOL_COMPILER_RT_BUILD:BOOL=FALSE
-          -DLLVM_BUILD_EXTERNAL_COMPILER_RT:BOOL=FALSE
-      )
-    else
-      llvm_cmake_options+=(
-          -DLLVM_TOOL_COMPILER_RT_BUILD:BOOL="$(false_true ${SKIP_BUILD_COMPILER_RT})"
-          -DLLVM_BUILD_EXTERNAL_COMPILER_RT:BOOL="$(false_true ${SKIP_BUILD_COMPILER_RT})"
-      )
-    fi
-
     # If we are asked to not generate test targets for LLVM and or Swift,
     # disable as many LLVM tools as we can. This improves compile time when
     # compiling with LTO.
@@ -1828,9 +1813,12 @@ for host in "${ALL_HOSTS[@]}"; do
                 )
 
                 llvm_enable_projects=("clang")
+                llvm_enable_runtimes=("")
 
-                if [[ ! "${SKIP_BUILD_COMPILER_RT}" && ! $(is_cross_tools_host ${host}) ]]; then
-                    llvm_enable_projects+=("compiler-rt")
+                if [[ ! "${SKIP_BUILD_COMPILER_RT}" ]]; then
+                    llvm_enable_runtimes+=("compiler-rt")
+                    build_targets=("${build_targets[@]}"
+                                    runtimes)
                 fi
 
                 if [[ ! "${SKIP_BUILD_CLANG_TOOLS_EXTRA}" ]]; then
@@ -1851,6 +1839,7 @@ for host in "${ALL_HOSTS[@]}"; do
 
                 cmake_options+=(
                     -DLLVM_ENABLE_PROJECTS="$(join ";" ${llvm_enable_projects[@]})"
+                    -DLLVM_ENABLE_RUNTIMES="$(join ";" ${llvm_enable_runtimes[@]})"
                 )
 
                 # NOTE: This is not a dead option! It is relied upon for certain


### PR DESCRIPTION
LLVM plans to remove the legacy methods for building compiler-rt. This
change updates build-script to use LLVM_ENABLE_RUNTIMES to build
compiler-rt with the just-built clang instead of the legacy methods.

See: https://discourse.llvm.org/t/rfc-deprecate-and-remove-llvm-build-external-compiler-rt/62058/8