### PR TITLE
[ConstraintSystem] Extend availability check to cover unavailable ext…

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -6263,7 +6263,7 @@ void ConstraintSystem::diagnoseFailureFor(SolutionApplicationTarget target) {
 bool ConstraintSystem::isDeclUnavailable(const Decl *D,
                                          ConstraintLocator *locator) const {
   // First check whether this declaration is universally unavailable.
-  if (D->getAttrs().isUnavailable(getASTContext()))
+  if (AvailableAttr::isUnavailable(D))
     return true;
 
   return TypeChecker::isDeclarationUnavailable(D, DC, [&] {

--- a/test/Constraints/availability.swift
+++ b/test/Constraints/availability.swift
@@ -43,3 +43,25 @@ func unavailableFunction(_ x: Int) -> Bool { true } // expected-note {{'unavaila
 func sr13260(_ arr: [Int]) {
   for x in arr where unavailableFunction(x) {} // expected-error {{'unavailableFunction' is unavailable}}
 }
+
+// rdar://92364955 - ambiguity with member declared in unavailable extension
+struct WithUnavailableExt {
+}
+
+@available(*, unavailable)
+extension WithUnavailableExt {
+  static var foo: WithUnavailableExt = WithUnavailableExt()
+}
+
+func test_no_ambiguity_with_unavailable_ext() {
+  struct A {
+    static var foo: A = A()
+  }
+
+  struct Test {
+    init(_: A) {}
+    init(_: WithUnavailableExt) {}
+  }
+
+  _ = Test(.foo) // Ok `A.foo` since `foo` from `WithUnavailableExt` is unavailable
+}


### PR DESCRIPTION
…ensions

The solver used to check availability attribute on the declaration
itself, a better approach is to go through `AvailableAttr::isUnavailable`
because that also covers unavailable extensions.

Resolves: rdar://92364955

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
