### PR TITLE
[sil] Ban reborrows/guaranteed phis in Raw SIL.

### DIFF
--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "sil-verifier"
+
 #include "VerifierPrivate.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/AnyFunctionRef.h"
@@ -36,6 +37,7 @@
 #include "swift/SIL/PrettyStackTrace.h"
 #include "swift/SIL/SILDebugScope.h"
 #include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILFunctionConventions.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SIL/SILVTable.h"
 #include "swift/SIL/SILVTableVisitor.h"
@@ -2694,6 +2696,30 @@ public:
             "Source value should be an address value");
     require(!F.hasOwnership(),
             "retain_value is only in functions with unqualified ownership");
+  }
+
+  void checkBeginBorrowInst(BeginBorrowInst *I) {
+    // If we are in Raw SIL, we require that begin_borrow is always ended by an
+    // end_borrow instead of a different instruction (e.x.: br). This makes it
+    // easier for diagnostic passes to avoid needing to support guaranteed phis
+    // while allowing later performance passes like SILMem2Reg to insert
+    // guaranteed phis as needed.
+    //
+    // NOTE: SILGen maintains this invariant already.
+    //
+    // NOTE: If we need to eventually support guaranteed phis earlier in the Raw
+    // Pipeline, we will need to design a more complex solution where we
+    // maintain this invariant early in the pipeline.
+    auto &mod = I->getModule();
+    if (mod.getStage() == SILStage::Raw &&
+        !I->getFunction()->wasDeserializedCanonical()) {
+      SILModuleConventions modConventions(mod);
+      for (auto *use : I->getUses()) {
+        require(use->getOperandOwnership(&modConventions) !=
+                    OperandOwnership::Reborrow,
+                "In Raw SIL, begin_borrow can not be reborrowed?!");
+      }
+    }
   }
 
   void checkCopyValueInst(CopyValueInst *I) {

--- a/test/SILOptimizer/mem2reg_lifetime.sil
+++ b/test/SILOptimizer/mem2reg_lifetime.sil
@@ -4,6 +4,7 @@
 // Copied from mem2reg_ossa.sil                                               {{
 // =============================================================================
 
+sil_stage canonical
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/mem2reg_lifetime_nontrivial.sil
+++ b/test/SILOptimizer/mem2reg_lifetime_nontrivial.sil
@@ -1,5 +1,7 @@
 // RUN: %target-sil-opt -enable-sil-verify-all -enable-lexical-lifetimes %s -mem2reg | %FileCheck %s
 
+sil_stage canonical
+
 import Builtin
 import Swift
 

--- a/test/SILOptimizer/mem2reg_lifetime_nontrivial_casts.sil
+++ b/test/SILOptimizer/mem2reg_lifetime_nontrivial_casts.sil
@@ -1,5 +1,7 @@
 // RUN: %target-sil-opt -enable-sil-verify-all -enable-lexical-lifetimes %s -mem2reg | %FileCheck %s
 
+sil_stage canonical
+
 import Builtin
 import Swift
 

--- a/test/SILOptimizer/mem2reg_liveness_lifetime.sil
+++ b/test/SILOptimizer/mem2reg_liveness_lifetime.sil
@@ -1,5 +1,7 @@
 // RUN: %target-sil-opt -enable-sil-verify-all -enable-lexical-lifetimes %s -mem2reg | %FileCheck %s
 
+sil_stage canonical
+
 import Builtin
 import Swift
 

--- a/test/SILOptimizer/shrink_borrow_scope.sil
+++ b/test/SILOptimizer/shrink_borrow_scope.sil
@@ -1,5 +1,7 @@
 // RUN: %target-sil-opt -copy-propagation -enable-sil-verify-all %s | %FileCheck %s
 
+sil_stage canonical
+
 import Builtin
 import Swift
 


### PR DESCRIPTION
We need reborrows to exist in SIL so we can mem2reg borrowed things in the
performance pipeline. Today, earlier in the pipeline, we never emit reborrows,
so in this commit I future proof this condition by banning reborrows in Raw SIL
via the SILVerifier. This simplifies the world that diagnostic passes need to
consider. If we need to re-enable support for reborrows in the diagnostic
pipeline, we can ban it later in the diagnostic pipeline.
