### PR TITLE
🍒[5.7][Concurrency] Explicitly ban a class extending AnyActor as well

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4527,8 +4527,8 @@ ERROR(actor_inheritance,none,
       (bool))
 
 ERROR(actor_protocol_illegal_inheritance,none,
-      "non-actor type %0 cannot conform to the 'Actor' protocol",
-      (DeclName))
+      "non-actor type %0 cannot conform to the %1 protocol",
+      (DeclName, DeclName))
 ERROR(distributed_actor_conformance_missing_system_type,none,
       "distributed actor %0 does not declare ActorSystem it can be used with.",
       (DeclName))

--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -59,6 +59,7 @@
     BUILTIN_EXPRESSIBLE_BY_LITERAL_PROTOCOL_WITH_NAME(name, "_" #name)
 
 PROTOCOL(Actor)
+PROTOCOL(AnyActor)
 PROTOCOL(Sequence)
 PROTOCOL(Identifiable)
 PROTOCOL(IteratorProtocol)

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5708,6 +5708,7 @@ SpecialProtocol irgen::getSpecialProtocolID(ProtocolDecl *P) {
   case KnownProtocolKind::Differentiable:
   case KnownProtocolKind::FloatingPoint:
   case KnownProtocolKind::Identifiable:
+  case KnownProtocolKind::AnyActor:
   case KnownProtocolKind::Actor:
   case KnownProtocolKind::DistributedActor:
   case KnownProtocolKind::DistributedActorSystem:

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -6416,7 +6416,19 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
         if (!classDecl->isExplicitActor()) {
           dc->getSelfNominalTypeDecl()
               ->diagnose(diag::actor_protocol_illegal_inheritance,
-                         dc->getSelfNominalTypeDecl()->getName())
+                         dc->getSelfNominalTypeDecl()->getName(),
+                         proto->getName())
+              .fixItReplace(nominal->getStartLoc(), "actor");
+        }
+      }
+    } else if (proto->isSpecificProtocol(KnownProtocolKind::AnyActor)) {
+      if (auto classDecl = dyn_cast<ClassDecl>(nominal)) {
+        if (!classDecl->isExplicitActor() &&
+            !classDecl->isExplicitDistributedActor()) {
+          dc->getSelfNominalTypeDecl()
+              ->diagnose(diag::actor_protocol_illegal_inheritance,
+                         dc->getSelfNominalTypeDecl()->getName(),
+                         proto->getName())
               .fixItReplace(nominal->getStartLoc(), "actor");
         }
       }

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -1105,7 +1105,7 @@ static void traceJobQueue(DefaultActorImpl *actor, Job *first) {
 static SWIFT_ATTRIBUTE_ALWAYS_INLINE void traceActorStateTransition(DefaultActorImpl *actor,
     ActiveActorStatus oldState, ActiveActorStatus newState) {
 
-  SWIFT_TASK_DEBUG_LOG("Actor %p transitioned from %#x to %#x (%s)\n", actor,
+  SWIFT_TASK_DEBUG_LOG("Actor %p transitioned from %#x to %#x (%s)", actor,
                        oldState.getOpaqueFlags(), newState.getOpaqueFlags(),
                        __FUNCTION__);
   newState.traceStateChanged(actor);

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -1053,7 +1053,8 @@ actor A: Actor { // ok
 @available(SwiftStdlib 5.1, *)
 class C: Actor, UnsafeSendable {
   // expected-error@-1{{non-actor type 'C' cannot conform to the 'Actor' protocol}}
-  // expected-warning@-2{{'UnsafeSendable' is deprecated: Use @unchecked Sendable instead}}
+  // expected-error@-2{{non-actor type 'C' cannot conform to the 'AnyActor' protocol}}
+  // expected-warning@-3{{'UnsafeSendable' is deprecated: Use @unchecked Sendable instead}}
   nonisolated var unownedExecutor: UnownedSerialExecutor {
     fatalError()
   }

--- a/test/Distributed/actor_protocols.swift
+++ b/test/Distributed/actor_protocols.swift
@@ -14,8 +14,9 @@ typealias DefaultDistributedActorSystem = FakeActorSystem
 actor A: Actor {} // ok
 
 class C: Actor, UnsafeSendable {
-  // expected-error@-1{{non-actor type 'C' cannot conform to the 'Actor' protocol}} {{1-6=actor}}
-  // expected-warning@-2{{'UnsafeSendable' is deprecated: Use @unchecked Sendable instead}}
+  // expected-error@-1{{non-actor type 'C' cannot conform to the 'AnyActor' protocol}} {{1-6=actor}}
+  // expected-error@-2{{non-actor type 'C' cannot conform to the 'Actor' protocol}} {{1-6=actor}}
+  // expected-warning@-3{{'UnsafeSendable' is deprecated: Use @unchecked Sendable instead}}
   nonisolated var unownedExecutor: UnownedSerialExecutor {
     fatalError()
   }
@@ -43,10 +44,10 @@ distributed actor DA: DistributedActor {
   typealias ActorSystem = FakeActorSystem
 }
 
-// FIXME(distributed): error reporting is a bit whacky here; needs cleanup
-// expected-error@+2{{actor type 'A2' cannot conform to the 'DistributedActor' protocol. Isolation rules of these actor types are not interchangeable.}}
-// expected-error@+1{{actor type 'A2' cannot conform to the 'DistributedActor' protocol. Isolation rules of these actor types are not interchangeable.}}
 actor A2: DistributedActor {
+// FIXME(distributed): error reporting is a bit whacky here; needs cleanup
+// expected-error@-2{{actor type 'A2' cannot conform to the 'DistributedActor' protocol. Isolation rules of these actor types are not interchangeable.}}
+// expected-error@-3{{actor type 'A2' cannot conform to the 'DistributedActor' protocol. Isolation rules of these actor types are not interchangeable.}}
   nonisolated var id: ID {
     fatalError()
   }
@@ -63,8 +64,9 @@ actor A2: DistributedActor {
   }
 }
 
-// expected-error@+1{{non-distributed actor type 'C2' cannot conform to the 'DistributedActor' protocol}}
-final class C2: DistributedActor {
+final class DA2: DistributedActor {
+// expected-error@-1{{non-actor type 'DA2' cannot conform to the 'AnyActor' protocol}}
+// expected-error@-2{{non-distributed actor type 'DA2' cannot conform to the 'DistributedActor' protocol}}
   nonisolated var id: ID {
     fatalError()
   }
@@ -86,3 +88,19 @@ struct S2: DistributedActor {
   // expected-error@-3{{type 'S2' does not conform to protocol 'Identifiable'}}
 }
 
+// ==== -----------------------------------------------------------------------
+
+actor A3: AnyActor {} // ok
+distributed actor DA3: AnyActor {} // ok
+
+class C3: AnyActor, @unchecked Sendable {
+  // expected-error@-1{{non-actor type 'C3' cannot conform to the 'AnyActor' protocol}} {{1-6=actor}}
+}
+
+struct S3: AnyActor {
+  // expected-error@-1{{non-class type 'S3' cannot conform to class protocol 'AnyActor'}}
+}
+
+enum E3: AnyActor {
+  // expected-error@-1{{non-class type 'E3' cannot conform to class protocol 'AnyActor'}}
+}

--- a/test/decl/class/actor/basic.swift
+++ b/test/decl/class/actor/basic.swift
@@ -7,6 +7,7 @@ actor MyActor { }
 class MyActorSubclass1: MyActor { }
 // expected-error@-1{{actor types do not support inheritance}}
 // expected-error@-2{{type 'MyActorSubclass1' cannot conform to the 'Actor' protocol}}
+// expected-error@-3{{non-actor type 'MyActorSubclass1' cannot conform to the 'AnyActor' protocol}}
 
 actor MyActorSubclass2: MyActor { } // expected-error{{actor types do not support inheritance}}
 

--- a/test/decl/protocol/special/Actor.swift
+++ b/test/decl/protocol/special/Actor.swift
@@ -44,7 +44,8 @@ actor A7 {
 @available(SwiftStdlib 5.1, *)
 class C1: Actor {
   // expected-error@-1{{non-actor type 'C1' cannot conform to the 'Actor' protocol}}
-  // expected-warning@-2{{non-final class 'C1' cannot conform to 'Sendable'; use '@unchecked Sendable'}}
+  // expected-error@-2{{non-actor type 'C1' cannot conform to the 'AnyActor' protocol}}
+  // expected-warning@-3{{non-final class 'C1' cannot conform to 'Sendable'; use '@unchecked Sendable'}}
   nonisolated var unownedExecutor: UnownedSerialExecutor {
     fatalError("")
   }
@@ -53,7 +54,8 @@ class C1: Actor {
 @available(SwiftStdlib 5.1, *)
 class C2: Actor {
   // expected-error@-1{{non-actor type 'C2' cannot conform to the 'Actor' protocol}}
-  // expected-warning@-2{{non-final class 'C2' cannot conform to 'Sendable'; use '@unchecked Sendable'}}
+  // expected-error@-2{{non-actor type 'C2' cannot conform to the 'AnyActor' protocol}}
+// expected-warning@-3{{non-final class 'C2' cannot conform to 'Sendable'; use '@unchecked Sendable'}}
   // FIXME: this should be an isolation violation
   var unownedExecutor: UnownedSerialExecutor {
     fatalError("")
@@ -64,7 +66,8 @@ class C2: Actor {
 class C3: Actor {
   // expected-error@-1{{type 'C3' does not conform to protocol 'Actor'}}
   // expected-error@-2{{non-actor type 'C3' cannot conform to the 'Actor' protocol}}
-  // expected-warning@-3{{non-final class 'C3' cannot conform to 'Sendable'; use '@unchecked Sendable'}}
+  // expected-error@-3{{non-actor type 'C3' cannot conform to the 'AnyActor' protocol}}
+  // expected-warning@-4{{non-final class 'C3' cannot conform to 'Sendable'; use '@unchecked Sendable'}}
   nonisolated func enqueue(_ job: UnownedJob) { }
 }
 


### PR DESCRIPTION
Cherry pick of https://github.com/apple/swift/pull/58473

Description: Minor addition to ban class X: AnyActor which slipped through before.
Risk: Low, this should never have been be done in user code.
Radar: Resolves rdar://92426548
