### PR TITLE
[5.7-04182022][🍒] Enhance SILVerifier to catch more nested suspensions.

### DIFF
--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1646,6 +1646,10 @@ bool SILInstruction::maySuspend() const {
   // await_async_continuation always suspends the current task.
   if (isa<AwaitAsyncContinuationInst>(this))
     return true;
+
+  // hop_to_executor also may cause a suspension
+  if (isa<HopToExecutorInst>(this))
+    return true;
   
   // Fully applying an async function may suspend the caller.
   if (auto applySite = FullApplySite::isa(const_cast<SILInstruction*>(this))) {

--- a/test/SIL/verifier-no-nested-suspend.sil
+++ b/test/SIL/verifier-no-nested-suspend.sil
@@ -1,0 +1,26 @@
+// RUN: not --crash %target-sil-opt %s 2>&1 | %FileCheck %s
+// REQUIRES: asserts
+
+// CHECK: cannot suspend async task while unawaited continuation is active
+
+sil_stage raw
+
+import Builtin
+import Swift
+import SwiftShims
+import _Concurrency
+
+// hello(_:)
+sil hidden [ossa] @$s4main5helloyS2bYaF : $@convention(thin) @async (Bool) -> Bool {
+bb0(%0 : $Bool):
+  debug_value %0 : $Bool, let, name "b", argno 1
+  %2 = enum $Optional<Builtin.Executor>, #Optional.none!enumelt
+  %22 = alloc_stack $Bool
+  %27 = get_async_continuation_addr Bool, %22 : $*Bool
+  hop_to_executor %2 : $Optional<Builtin.Executor> // <- the bad nested suspension
+  await_async_continuation %27 : $Builtin.RawUnsafeContinuation, resume bb1
+
+bb1:
+  dealloc_stack %22 : $*Bool
+  return %0 : $Bool
+}


### PR DESCRIPTION
It is illegal to perform a suspension while an existing continuation capture is in-flight. A continuation capture is in-flight between the `get_continuation*` and its matching `await_continuation`.

Previously, Swift was not treating `hop_to_executor` as an instruction that "may suspend", which was causing the SILVerifier to miss flagging a hop during a suspension as illegal. This PR fixes that.

Currently, the only caller of `SILInstruction::maySuspend` is the SILVerifier, so this should be a non-breaking change.

Supports the resolution of rdar://91502776