### PR TITLE
[DRAFT][stdlib] String.Index: Add custom printing

### DIFF
--- a/stdlib/public/core/StringIndex.swift
+++ b/stdlib/public/core/StringIndex.swift
@@ -528,7 +528,7 @@ extension String.Index: CustomStringConvertible {
   @inline(never)
   public var description: String {
     // For the regular `description`, we just print the offset value along with
-    // its encoding and the transcoded offset, in a compact form: `23[utf8]+1`.
+    // its encoding and the transcoded offset, in a compact form: `23.utf8+1`.
     //
     // This is intended to expose crucial positioning information in a form that
     // remains relatively readable even when part of a larger printout, e.g., as
@@ -547,7 +547,11 @@ extension String.Index: CustomDebugStringConvertible {
   @inline(never)
   public var debugDescription: String {
     var d = "String.Index("
-    d += "offset: \(self.description)"
+    d += "offset: \(_encodedOffset)"
+    d += ", encoding: \(_encodingDescription)"
+    if transcodedOffset != 0 {
+      d += ", transcodedOffset: \(transcodedOffset)"
+    }
     if _isCharacterAligned {
       d += ", aligned: character"
     } else if _isScalarAligned {

--- a/stdlib/public/core/StringIndex.swift
+++ b/stdlib/public/core/StringIndex.swift
@@ -564,3 +564,27 @@ extension String.Index: CustomDebugStringConvertible {
     return d
   }
 }
+
+@available(SwiftStdlib 5.7, *)
+extension String.Index: CustomReflectable {
+  @available(SwiftStdlib 5.7, *)
+  @inline(never)
+  public var customMirror: Mirror {
+    var children: [(label: String?, value: Any)] = []
+    children.reserveCapacity(5)
+    children.append(("_encodedOffset", _encodedOffset))
+    children.append(("_encoding", _encodingDescription))
+    if transcodedOffset > 0 {
+      children.append(("_transcodedOffset", transcodedOffset))
+    }
+    if _isCharacterAligned {
+      children.append(("_aligned", "character"))
+    } else if _isScalarAligned {
+      children.append(("_aligned", "scalar"))
+    }
+    if let stride = characterStride {
+      children.append(("_characterStride", stride))
+    }
+    return Mirror(self, children: children, displayStyle: .struct)
+  }
+}

--- a/stdlib/public/core/StringIndex.swift
+++ b/stdlib/public/core/StringIndex.swift
@@ -565,6 +565,7 @@ extension String.Index: CustomDebugStringConvertible {
   }
 }
 
+#if SWIFT_ENABLE_REFLECTION
 @available(SwiftStdlib 5.7, *)
 extension String.Index: CustomReflectable {
   @available(SwiftStdlib 5.7, *)
@@ -572,7 +573,7 @@ extension String.Index: CustomReflectable {
   public var customMirror: Mirror {
     var children: [(label: String?, value: Any)] = []
     children.reserveCapacity(5)
-    children.append(("_encodedOffset", _encodedOffset))
+    children.append(("_offset", _encodedOffset))
     children.append(("_encoding", _encodingDescription))
     if transcodedOffset > 0 {
       children.append(("_transcodedOffset", transcodedOffset))
@@ -583,8 +584,9 @@ extension String.Index: CustomReflectable {
       children.append(("_aligned", "scalar"))
     }
     if let stride = characterStride {
-      children.append(("_characterStride", stride))
+      children.append(("_stride", stride))
     }
     return Mirror(self, children: children, displayStyle: .struct)
   }
 }
+#endif

--- a/stdlib/public/core/StringIndex.swift
+++ b/stdlib/public/core/StringIndex.swift
@@ -512,3 +512,51 @@ extension String.Index: Hashable {
     hasher.combine(orderingValue)
   }
 }
+
+@available(SwiftStdlib 5.7, *)
+extension String.Index: CustomStringConvertible {
+  internal var _encodingDescription: String {
+    switch (_rawBits & Self.__utf8Bit != 0, _rawBits & Self.__utf16Bit != 0) {
+    case (false, false): return "unknown"
+    case (true, false): return "utf8"
+    case (false, true): return "utf16"
+    case (true, true): return "any"
+    }
+  }
+
+  @available(SwiftStdlib 5.7, *)
+  @inline(never)
+  public var description: String {
+    // For the regular `description`, we just print the offset value along with
+    // its encoding and the transcoded offset, in a compact form: `23[utf8]+1`.
+    //
+    // This is intended to expose crucial positioning information in a form that
+    // remains relatively readable even when part of a larger printout, e.g., as
+    // with range expressions like `12[utf8]..<56[utf8]+1`.
+    var d = "\(_encodedOffset)[\(_encodingDescription)]"
+    if transcodedOffset != 0 {
+      d += "+\(transcodedOffset)"
+    }
+    return d
+  }
+}
+
+@available(SwiftStdlib 5.7, *)
+extension String.Index: CustomDebugStringConvertible {
+  @available(SwiftStdlib 5.7, *)
+  @inline(never)
+  public var debugDescription: String {
+    var d = "String.Index("
+    d += "offset: \(self.description)"
+    if _isCharacterAligned {
+      d += ", aligned: character"
+    } else if _isScalarAligned {
+      d += ", aligned: scalar"
+    }
+    if let stride = characterStride {
+      d += ", stride: \(stride)"
+    }
+    d += ")"
+    return d
+  }
+}

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -56,7 +56,6 @@ Func Collection.subranges(where:) has been removed
 Func MutableCollection.moveSubranges(_:to:) has been removed
 Func MutableCollection.removeSubranges(_:) has been removed
 Func RangeReplaceableCollection.removeSubranges(_:) has been removed
-Struct AnyHashable has added a conformance to an existing protocol _HasCustomAnyHashableRepresentation
 Struct DiscontiguousSlice has been removed
 Struct RangeSet has been removed
 Subscript Collection.subscript(_:) has been removed
@@ -66,6 +65,12 @@ Protocol CodingKey has generic signature change from <Self : Swift.CustomDebugSt
 Protocol Error has added inherited protocol Sendable
 Protocol Error has generic signature change from to <Self : Swift.Sendable>
 Enum Never has added a conformance to an existing protocol Identifiable
+
+// The ABI checker doesn't understand protocol conformances with availability
+// yet.
+Struct AnyHashable has added a conformance to an existing protocol _HasCustomAnyHashableRepresentation
+Struct String.Index has added a conformance to an existing protocol CustomStringConvertible
+Struct String.Index has added a conformance to an existing protocol CustomDebugStringConvertible
 
 // These haven't actually been removed; they are simply marked unavailable.
 // This seems to be a false positive in the ABI checker. This is not an ABI

--- a/test/stdlib/StringIndex.swift
+++ b/test/stdlib/StringIndex.swift
@@ -28,6 +28,258 @@ let simpleStrings: [String] = [
   "",
 ]
 
+suite.test("CustomStringConvertible/native") {
+  guard #available(SwiftStdlib 5.7, *) else { return }
+
+  let string = "a👉🏼b"
+
+  func check<S: Collection>(
+    _ s: S,
+    _ expected: [String],
+    file: String = #file, line: UInt = #line
+  ) where S.Index == String.Index {
+    let indices = Array(s.indices) + [s.endIndex]
+    expectEqual(
+      indices.count,
+      expected.count,
+      "count",
+      file: file, line: line)
+    for i in 0 ..< indices.count {
+      expectEqual(
+        "\(indices[i])",
+        expected[i],
+        "i: \(i)",
+        file: file, line: line)
+    }
+  }
+
+  check(string, [
+      "0[any]",
+      "1[utf8]",
+      "9[utf8]",
+      "10[utf8]",
+    ])
+  check(string.unicodeScalars, [
+      "0[any]",
+      "1[utf8]",
+      "5[utf8]",
+      "9[utf8]",
+      "10[utf8]",
+    ])
+  check(string.utf8, [
+      "0[any]",
+      "1[utf8]",
+      "2[utf8]",
+      "3[utf8]",
+      "4[utf8]",
+      "5[utf8]",
+      "6[utf8]",
+      "7[utf8]",
+      "8[utf8]",
+      "9[utf8]",
+      "10[utf8]",
+    ])
+  check(string.utf16, [
+      "0[any]",
+      "1[utf8]",
+      "1[utf8]+1",
+      "5[utf8]",
+      "5[utf8]+1",
+      "9[utf8]",
+      "10[utf8]",
+    ])
+}
+
+#if _runtime(_ObjC)
+suite.test("CustomStringConvertible/bridged") {
+  guard #available(SwiftStdlib 5.7, *) else { return }
+
+  let string = "a👉🏼b" as NSString as String
+
+  func check<S: Collection>(
+    _ s: S,
+    _ expected: [String],
+    file: String = #file, line: UInt = #line
+  ) where S.Index == String.Index {
+    let indices = Array(s.indices) + [s.endIndex]
+    expectEqual(
+      indices.count,
+      expected.count,
+      "count",
+      file: file, line: line)
+    for i in 0 ..< indices.count {
+      expectEqual(
+        "\(indices[i])",
+        expected[i],
+        "i: \(i)",
+        file: file, line: line)
+    }
+  }
+
+  check(string, [
+      "0[any]",
+      "1[utf16]",
+      "5[utf16]",
+      "6[utf16]",
+    ])
+  check(string.unicodeScalars, [
+      "0[any]",
+      "1[utf16]",
+      "3[utf16]",
+      "5[utf16]",
+      "6[utf16]",
+    ])
+  check(string.utf8, [
+      "0[any]",
+      "1[utf16]",
+      "1[utf16]+1",
+      "1[utf16]+2",
+      "1[utf16]+3",
+      "3[utf16]",
+      "3[utf16]+1",
+      "3[utf16]+2",
+      "3[utf16]+3",
+      "5[utf16]",
+      "6[utf16]",
+    ])
+  check(string.utf16, [
+      "0[any]",
+      "1[utf16]",
+      "2[utf16]",
+      "3[utf16]",
+      "4[utf16]",
+      "5[utf16]",
+      "6[utf16]",
+    ])
+}
+#endif
+
+suite.test("CustomDebugStringConvertible/native") {
+  guard #available(SwiftStdlib 5.7, *) else { return }
+
+  let string = "a👉🏼b"
+
+  func check<S: Collection>(
+    _ s: S,
+    _ expected: [String],
+    file: String = #file, line: UInt = #line
+  ) where S.Index == String.Index {
+    let indices = Array(s.indices) + [s.endIndex]
+    expectEqual(
+      indices.count,
+      expected.count,
+      "count",
+      file: file, line: line)
+    for i in 0 ..< indices.count {
+      expectEqual(
+        String(reflecting: indices[i]),
+        expected[i],
+        "i: \(i)",
+        file: file, line: line)
+    }
+  }
+
+  check(string, [
+      "String.Index(offset: 0[any], aligned: character)",
+      "String.Index(offset: 1[utf8], aligned: character, stride: 8)",
+      "String.Index(offset: 9[utf8], aligned: character, stride: 1)",
+      "String.Index(offset: 10[utf8], aligned: character)",
+    ])
+  check(string.unicodeScalars, [
+      "String.Index(offset: 0[any], aligned: character)",
+      "String.Index(offset: 1[utf8], aligned: scalar)",
+      "String.Index(offset: 5[utf8], aligned: scalar)",
+      "String.Index(offset: 9[utf8], aligned: scalar)",
+      "String.Index(offset: 10[utf8], aligned: character)",
+    ])
+  check(string.utf8, [
+      "String.Index(offset: 0[any], aligned: character)",
+      "String.Index(offset: 1[utf8])",
+      "String.Index(offset: 2[utf8])",
+      "String.Index(offset: 3[utf8])",
+      "String.Index(offset: 4[utf8])",
+      "String.Index(offset: 5[utf8])",
+      "String.Index(offset: 6[utf8])",
+      "String.Index(offset: 7[utf8])",
+      "String.Index(offset: 8[utf8])",
+      "String.Index(offset: 9[utf8])",
+      "String.Index(offset: 10[utf8], aligned: character)",
+    ])
+  check(string.utf16, [
+      "String.Index(offset: 0[any], aligned: character)",
+      "String.Index(offset: 1[utf8], aligned: scalar)",
+      "String.Index(offset: 1[utf8]+1)",
+      "String.Index(offset: 5[utf8], aligned: scalar)",
+      "String.Index(offset: 5[utf8]+1)",
+      "String.Index(offset: 9[utf8], aligned: scalar)",
+      "String.Index(offset: 10[utf8], aligned: character)",
+    ])
+}
+
+#if _runtime(_ObjC)
+suite.test("CustomDebugStringConvertible/bridged") {
+  guard #available(SwiftStdlib 5.7, *) else { return }
+
+  let string = "a👉🏼b" as NSString as String
+
+  func check<S: Collection>(
+    _ s: S,
+    _ expected: [String],
+    file: String = #file, line: UInt = #line
+  ) where S.Index == String.Index {
+    let indices = Array(s.indices) + [s.endIndex]
+    expectEqual(
+      indices.count,
+      expected.count,
+      "count",
+      file: file, line: line)
+    for i in 0 ..< indices.count {
+      expectEqual(
+        String(reflecting: indices[i]),
+        expected[i],
+        "i: \(i)",
+        file: file, line: line)
+    }
+  }
+
+  check(string, [
+      "String.Index(offset: 0[any], aligned: character)",
+      "String.Index(offset: 1[utf16], aligned: character, stride: 4)",
+      "String.Index(offset: 5[utf16], aligned: character, stride: 1)",
+      "String.Index(offset: 6[utf16], aligned: character)",
+    ])
+  check(string.unicodeScalars, [
+      "String.Index(offset: 0[any], aligned: character)",
+      "String.Index(offset: 1[utf16], aligned: scalar)",
+      "String.Index(offset: 3[utf16], aligned: scalar)",
+      "String.Index(offset: 5[utf16], aligned: scalar)",
+      "String.Index(offset: 6[utf16], aligned: character)",
+    ])
+  check(string.utf8, [
+      "String.Index(offset: 0[any], aligned: character)",
+      "String.Index(offset: 1[utf16], aligned: scalar)",
+      "String.Index(offset: 1[utf16]+1)",
+      "String.Index(offset: 1[utf16]+2)",
+      "String.Index(offset: 1[utf16]+3)",
+      "String.Index(offset: 3[utf16], aligned: scalar)",
+      "String.Index(offset: 3[utf16]+1)",
+      "String.Index(offset: 3[utf16]+2)",
+      "String.Index(offset: 3[utf16]+3)",
+      "String.Index(offset: 5[utf16], aligned: scalar)",
+      "String.Index(offset: 6[utf16], aligned: character)",
+    ])
+  check(string.utf16, [
+      "String.Index(offset: 0[any], aligned: character)",
+      "String.Index(offset: 1[utf16])",
+      "String.Index(offset: 2[utf16])",
+      "String.Index(offset: 3[utf16])",
+      "String.Index(offset: 4[utf16])",
+      "String.Index(offset: 5[utf16])",
+      "String.Index(offset: 6[utf16], aligned: character)",
+    ])
+}
+#endif
+
 suite.test("basic sanity checks")
 .forEach(in: simpleStrings) { s in
   let utf8 = Array(s.utf8)

--- a/test/stdlib/StringIndex.swift
+++ b/test/stdlib/StringIndex.swift
@@ -180,39 +180,39 @@ suite.test("CustomDebugStringConvertible/native") {
   }
 
   check(string, [
-      "String.Index(offset: 0[any], aligned: character)",
-      "String.Index(offset: 1[utf8], aligned: character, stride: 8)",
-      "String.Index(offset: 9[utf8], aligned: character, stride: 1)",
-      "String.Index(offset: 10[utf8], aligned: character)",
+      "String.Index(offset: 0, encoding: any, aligned: character)",
+      "String.Index(offset: 1, encoding: utf8, aligned: character, stride: 8)",
+      "String.Index(offset: 9, encoding: utf8, aligned: character, stride: 1)",
+      "String.Index(offset: 10, encoding: utf8, aligned: character)",
     ])
   check(string.unicodeScalars, [
-      "String.Index(offset: 0[any], aligned: character)",
-      "String.Index(offset: 1[utf8], aligned: scalar)",
-      "String.Index(offset: 5[utf8], aligned: scalar)",
-      "String.Index(offset: 9[utf8], aligned: scalar)",
-      "String.Index(offset: 10[utf8], aligned: character)",
+      "String.Index(offset: 0, encoding: any, aligned: character)",
+      "String.Index(offset: 1, encoding: utf8, aligned: scalar)",
+      "String.Index(offset: 5, encoding: utf8, aligned: scalar)",
+      "String.Index(offset: 9, encoding: utf8, aligned: scalar)",
+      "String.Index(offset: 10, encoding: utf8, aligned: character)",
     ])
   check(string.utf8, [
-      "String.Index(offset: 0[any], aligned: character)",
-      "String.Index(offset: 1[utf8])",
-      "String.Index(offset: 2[utf8])",
-      "String.Index(offset: 3[utf8])",
-      "String.Index(offset: 4[utf8])",
-      "String.Index(offset: 5[utf8])",
-      "String.Index(offset: 6[utf8])",
-      "String.Index(offset: 7[utf8])",
-      "String.Index(offset: 8[utf8])",
-      "String.Index(offset: 9[utf8])",
-      "String.Index(offset: 10[utf8], aligned: character)",
+      "String.Index(offset: 0, encoding: any, aligned: character)",
+      "String.Index(offset: 1, encoding: utf8)",
+      "String.Index(offset: 2, encoding: utf8)",
+      "String.Index(offset: 3, encoding: utf8)",
+      "String.Index(offset: 4, encoding: utf8)",
+      "String.Index(offset: 5, encoding: utf8)",
+      "String.Index(offset: 6, encoding: utf8)",
+      "String.Index(offset: 7, encoding: utf8)",
+      "String.Index(offset: 8, encoding: utf8)",
+      "String.Index(offset: 9, encoding: utf8)",
+      "String.Index(offset: 10, encoding: utf8, aligned: character)",
     ])
   check(string.utf16, [
-      "String.Index(offset: 0[any], aligned: character)",
-      "String.Index(offset: 1[utf8], aligned: scalar)",
-      "String.Index(offset: 1[utf8]+1)",
-      "String.Index(offset: 5[utf8], aligned: scalar)",
-      "String.Index(offset: 5[utf8]+1)",
-      "String.Index(offset: 9[utf8], aligned: scalar)",
-      "String.Index(offset: 10[utf8], aligned: character)",
+      "String.Index(offset: 0, encoding: any, aligned: character)",
+      "String.Index(offset: 1, encoding: utf8, aligned: scalar)",
+      "String.Index(offset: 1, encoding: utf8, transcodedOffset: 1)",
+      "String.Index(offset: 5, encoding: utf8, aligned: scalar)",
+      "String.Index(offset: 5, encoding: utf8, transcodedOffset: 1)",
+      "String.Index(offset: 9, encoding: utf8, aligned: scalar)",
+      "String.Index(offset: 10, encoding: utf8, aligned: character)",
     ])
 }
 
@@ -243,39 +243,39 @@ suite.test("CustomDebugStringConvertible/bridged") {
   }
 
   check(string, [
-      "String.Index(offset: 0[any], aligned: character)",
-      "String.Index(offset: 1[utf16], aligned: character, stride: 4)",
-      "String.Index(offset: 5[utf16], aligned: character, stride: 1)",
-      "String.Index(offset: 6[utf16], aligned: character)",
+      "String.Index(offset: 0, encoding: any, aligned: character)",
+      "String.Index(offset: 1, encoding: utf16, aligned: character, stride: 4)",
+      "String.Index(offset: 5, encoding: utf16, aligned: character, stride: 1)",
+      "String.Index(offset: 6, encoding: utf16, aligned: character)",
     ])
   check(string.unicodeScalars, [
-      "String.Index(offset: 0[any], aligned: character)",
-      "String.Index(offset: 1[utf16], aligned: scalar)",
-      "String.Index(offset: 3[utf16], aligned: scalar)",
-      "String.Index(offset: 5[utf16], aligned: scalar)",
-      "String.Index(offset: 6[utf16], aligned: character)",
+      "String.Index(offset: 0, encoding: any, aligned: character)",
+      "String.Index(offset: 1, encoding: utf16, aligned: scalar)",
+      "String.Index(offset: 3, encoding: utf16, aligned: scalar)",
+      "String.Index(offset: 5, encoding: utf16, aligned: scalar)",
+      "String.Index(offset: 6, encoding: utf16, aligned: character)",
     ])
   check(string.utf8, [
-      "String.Index(offset: 0[any], aligned: character)",
-      "String.Index(offset: 1[utf16], aligned: scalar)",
-      "String.Index(offset: 1[utf16]+1)",
-      "String.Index(offset: 1[utf16]+2)",
-      "String.Index(offset: 1[utf16]+3)",
-      "String.Index(offset: 3[utf16], aligned: scalar)",
-      "String.Index(offset: 3[utf16]+1)",
-      "String.Index(offset: 3[utf16]+2)",
-      "String.Index(offset: 3[utf16]+3)",
-      "String.Index(offset: 5[utf16], aligned: scalar)",
-      "String.Index(offset: 6[utf16], aligned: character)",
+      "String.Index(offset: 0, encoding: any, aligned: character)",
+      "String.Index(offset: 1, encoding: utf16, aligned: scalar)",
+      "String.Index(offset: 1, encoding: utf16, transcodedOffset: 1)",
+      "String.Index(offset: 1, encoding: utf16, transcodedOffset: 2)",
+      "String.Index(offset: 1, encoding: utf16, transcodedOffset: 3)",
+      "String.Index(offset: 3, encoding: utf16, aligned: scalar)",
+      "String.Index(offset: 3, encoding: utf16, transcodedOffset: 1)",
+      "String.Index(offset: 3, encoding: utf16, transcodedOffset: 2)",
+      "String.Index(offset: 3, encoding: utf16, transcodedOffset: 3)",
+      "String.Index(offset: 5, encoding: utf16, aligned: scalar)",
+      "String.Index(offset: 6, encoding: utf16, aligned: character)",
     ])
   check(string.utf16, [
-      "String.Index(offset: 0[any], aligned: character)",
-      "String.Index(offset: 1[utf16])",
-      "String.Index(offset: 2[utf16])",
-      "String.Index(offset: 3[utf16])",
-      "String.Index(offset: 4[utf16])",
-      "String.Index(offset: 5[utf16])",
-      "String.Index(offset: 6[utf16], aligned: character)",
+      "String.Index(offset: 0, encoding: any, aligned: character)",
+      "String.Index(offset: 1, encoding: utf16)",
+      "String.Index(offset: 2, encoding: utf16)",
+      "String.Index(offset: 3, encoding: utf16)",
+      "String.Index(offset: 4, encoding: utf16)",
+      "String.Index(offset: 5, encoding: utf16)",
+      "String.Index(offset: 6, encoding: utf16, aligned: character)",
     ])
 }
 #endif


### PR DESCRIPTION
[This changes the public API of the stdlib, so it will likely need to go through the Swift Evolution process before landing.]

**Forum pitch:** https://forums.swift.org/t/improving-string-index-s-printed-descriptions/57027

This PR conforms `String.Index` to `CustomStringConvertible` and `CustomDebugStringConvertible`, making it easier to understand what these indices actually are, and considerably simplifying the debugging experience when working with string indices.

Having String indices print nicer will be particularly helpful while working with the new string processing algorithms.

For reference, in Swift 5.6, `String.Index` uses an unhelpful, mirror-based description that is not at all human-readable, not even for the humans working on the implementation of `String` in the stdlib: 

```swift
  let string = "👋🏼 Привіт"

  print(string.startIndex) // ⟹ Index(_rawBits: 1)
  print(string.endIndex) // ⟹ Index(_rawBits: 1376257)
```

String indices are simply offsets from the start of the string's underlying storage representation, referencing a particular UTF-8 or UTF-16 code unit, depending on the string's encoding. Most Swift strings are UTF-8 encoded, but strings bridged over from Objective-C may remain in their original UTF-16 encoded form.

For `CustomStringConvertible`, the index description displays the storage offset value and its encoding:

```swift
  let string = "👋🏼 Привіт"

  print(string.startIndex) // ⟹ "0(any)"
  print(string.endIndex) // ⟹ "21(utf8)"
```

Note how the start index does not care about its storage encoding -- offset zero is the same location in either case.

String index ranges print in a compact, easily understandable form:

```swift
  let i = string.firstIndex(of: "р")!
  let j = string.firstIndex(of: "і")!
  print(i ..< j) // ⟹ 11(utf8)..<17(utf8)
```

Exposing the actual storage offsets in the description effectively demonstrates how indices work, helping people gain a better understanding of both the underlying Unicode concepts, and the details of their implementation in Swift.

For example, successive `String` indices tend to skip code units in irregular ways, reflecting the size of the underlying grapheme clusters.

```swift
  print(string.indices.map { "\($0)" })
  // ⟹ ["0(any)", "8(utf8)", "9(utf8)", "11(utf8)", "13(utf8)", "15(utf8)", "17(utf8)", "19(utf8)"]
```

Note how the initial emoji takes up 8 code units, followed by a 1-unit ASCII space, and ending with a series of Cyrillic characters that take two UTF-8 code units each.

Looking at indices in the Unicode scalars view shows how the emoji breaks into two separate code points (U+1F44B and U+1F3FC, at offsets 13 and 17, respectively):

```swift
  print(string.unicodeScalars.indices.map { "\($0)" })
  // ⟹ ["0(any)", "4(utf8)", "8(utf8)", "9(utf8)", "11(utf8)", "13(utf8)", "15(utf8)", "17(utf8)", "19(utf8)"]
```

This is a native UTF-8 string, so indices in the UTF-8 view are rather boring -- they simply count offsets from 0 up to 21:

```swift
  print(string.utf8.indices.map { "\($0)" })
  // ⟹ ["0(any)", "1(utf8)", "2(utf8)", "3(utf8)", ..., "19(utf8)", "20(utf8)"]
```

UTF-16 indices are rather more interesting, as the string starts with two Unicode scalars outside the BMP. In UTF-16, these are encoded as surrogate pairs, which aren't directly present in this string's storage. To manage this, the index values for the trailing surrogates include a transcoded offset value (the `+1` in the printout below),  to help identify which code unit is addressed by the index:

```swift
  print(string.utf16.indices.map { "\($0)" })
  // ⟹ ["0(any)", "0(utf8)+1", "4(utf8)", "4(utf8)+1", "8(utf8)", "9(utf8)", "11(utf8)", "13(utf8)", "15(utf8)", "17(utf8)", "19(utf8)"]
```

The `CustomDebugStringConvertible` output is a bit more verbose. In addition to the offset + encoding, it also includes the information that is maintained in the bits of the index that are reserved for performance flags and other auxiliary data.

For example, index `i` below is addressing the UTF-8 code unit at offset 10 in some string, which happens to be the first code unit in a `Character` (i.e., an extended grapheme cluster) of length 8:

```
print(String(reflecting: i)) // ⟹ String.Index(offset: 10(utf8), aligned: character, stride: 8)
```

rdar://