### PR TITLE
[IRGen] Restore the old code path for emitting existential type metadata for plain protocol and protocol composition types.

### DIFF
--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -1883,7 +1883,16 @@ namespace {
 
     MetadataResponse visitProtocolType(CanProtocolType type,
                                        DynamicMetadataRequest request) {
-      llvm_unreachable("constraint type should be wrapped in existential type");
+      assert(false && "constraint type should be wrapped in existential type");
+
+      CanExistentialType existential(
+          ExistentialType::get(type)->castTo<ExistentialType>());
+
+      if (auto metatype = tryGetLocal(existential, request))
+        return metatype;
+
+      auto metadata = emitExistentialTypeMetadata(existential);
+      return setLocal(type, MetadataResponse::forComplete(metadata));
     }
 
     MetadataResponse
@@ -1892,7 +1901,16 @@ namespace {
       if (type->isAny() || type->isAnyObject())
         return emitSingletonExistentialTypeMetadata(type);
 
-      llvm_unreachable("constraint type should be wrapped in existential type");
+      assert(false && "constraint type should be wrapped in existential type");
+
+      CanExistentialType existential(
+          ExistentialType::get(type)->castTo<ExistentialType>());
+
+      if (auto metatype = tryGetLocal(existential, request))
+        return metatype;
+
+      auto metadata = emitExistentialTypeMetadata(existential);
+      return setLocal(type, MetadataResponse::forComplete(metadata));
     }
 
     MetadataResponse


### PR DESCRIPTION
These types should always be wrapped in `ExistentialType`, but there isn't sufficient validation of this throughout the compiler yet. Change the fatal error when the metadata request sees these plain types to an `assert`, and restore the old type metadata emission path for protocol and protocol composition types to avoid crashing in those cases.

Resolves: rdar://92413116