### PR TITLE
[Frontend] NFC: fix compiler warning

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -801,7 +801,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     Opts.ClangTarget = llvm::Triple(A->getValue());
   }
 
-  Opts.EnableCXXInterop |= Args.hasArg(OPT_enable_experimental_cxx_interop) |
+  Opts.EnableCXXInterop |= Args.hasArg(OPT_enable_experimental_cxx_interop) ||
                            Args.hasArg(OPT_enable_cxx_interop);
   Opts.EnableObjCInterop =
       Args.hasFlag(OPT_enable_objc_interop, OPT_disable_objc_interop,


### PR DESCRIPTION
```
[218/807] Building CXX object lib/Frontend/CMakeFiles/swiftFrontend.dir/CompilerInvocation.cpp.o
/home/egorzh/swift/swift/lib/Frontend/CompilerInvocation.cpp:804:28: warning: use of bitwise '|' with boolean operands [-Wbitwise-instead-of-logical]
  Opts.EnableCXXInterop |= Args.hasArg(OPT_enable_experimental_cxx_interop) |
                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                            ||
/home/egorzh/swift/swift/lib/Frontend/CompilerInvocation.cpp:804:28: note: cast one or both operands to int to silence this warning
```