### PR TITLE
[5.7][SymbolGraphGen] consider modules not equal if they're not from the same compiler

### DIFF
--- a/test/SymbolGraph/ClangImporter/ForeignExtensions.swift
+++ b/test/SymbolGraph/ClangImporter/ForeignExtensions.swift
@@ -4,6 +4,10 @@
 // RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.symbols.json --check-prefix BASE
 // RUN: %FileCheck %s --input-file %t/EmitWhileBuilding@Swift.symbols.json --check-prefix EXTENSION
 
+// RUN: %target-swift-symbolgraph-extract -sdk %clang-importer-sdk -module-name EmitWhileBuilding -F %t -output-dir %t -pretty-print -v
+// RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.symbols.json --check-prefix BASE
+// RUN: %FileCheck %s --input-file %t/EmitWhileBuilding@Swift.symbols.json --check-prefix EXTENSION
+
 // REQUIRES: objc_interop
 
 // ensure that the symbol `String.Foo.bar` does not appear in the base module's symbol graph

--- a/test/SymbolGraph/ClangImporter/ForeignExtensions.swift
+++ b/test/SymbolGraph/ClangImporter/ForeignExtensions.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/EmitWhileBuilding/EmitWhileBuilding.framework %t
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-module-path %t/EmitWhileBuilding.framework/Modules/EmitWhileBuilding.swiftmodule/%target-swiftmodule-name -import-underlying-module -F %t -module-name EmitWhileBuilding -disable-objc-attr-requires-foundation-module %s %S/Inputs/EmitWhileBuilding/Extra.swift -emit-symbol-graph -emit-symbol-graph-dir %t
+// RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.symbols.json --check-prefix BASE
+// RUN: %FileCheck %s --input-file %t/EmitWhileBuilding@Swift.symbols.json --check-prefix EXTENSION
+
+// REQUIRES: objc_interop
+
+// ensure that the symbol `String.Foo.bar` does not appear in the base module's symbol graph
+
+// BASE-NOT:     "s:SS17EmitWhileBuildingE3FooO3baryA2CmF",
+// EXTENSION:    "s:SS17EmitWhileBuildingE3FooO3baryA2CmF",
+
+public extension String {
+    enum Foo {
+        case bar
+    }
+}
+


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/58421

**Explanation**: https://github.com/apple/swift/pull/41577 made it so that symbols were lifted into a module's symbol graph when their source module was re-exported via an `@_exported import` declaration. However, the comparison that checked this was based purely on the module's name, creating some false positives. This PR tightens that comparison to treat symbols in a foreign-type extension from being treated as part of the underlying Clang module (which is implicitly re-exported) and erroneously placed in the main module's symbol graph.

**Scope**: The change is isolated to SymbolGraphGen, and should only move symbols from the main symbol graph to module-extension symbol graphs.

**Radar**: rdar://92460585

**Risk**: Low. This won't affect normal compilation. There is no impact to the symbol graph data, only where it gets saved.

**Testing**: A new lit test, `SymbolGraph/ClangImporter/ForeignExtensions.swift`, has been added to verify that extensions on foreign types don't get added to the main module's symbol graph.