### PR TITLE
[CSClosure] Mark partially inferred external declarations as invalid

### DIFF
--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -329,3 +329,24 @@ func test_unknown_refs_in_tilde_operator() {
     }
   }
 }
+
+// rdar://92347054 - crash during conjunction processing
+func test_no_crash_with_circular_ref_due_to_error() {
+  struct S { // expected-note {{did you mean 'S'?}}
+    var x: Int?
+  }
+
+  func test(v: Int?, arr: [S]) -> Int { // expected-note {{did you mean 'v'?}}
+    // There is missing `f` here which made body of the
+    // `if` a multiple statement closure instead that uses
+    // `next` inside.
+    i let x = v, let next = arr.first?.x { // expected-error {{cannot find 'i' in scope}}
+      // expected-error@-1 {{consecutive statements on a line must be separated by ';'}}
+      // expected-error@-2 {{'let' cannot appear nested inside another 'var' or 'let' pattern}}
+      // expected-error@-3 {{cannot call value of non-function type 'Int?'}}
+      print(next)
+      return x
+    }
+    return 0
+  }
+}


### PR DESCRIPTION
If a syntactic element references an external declaration (relative
to its own context), let's check whether it has any type variables,
and if so, replace them with errors to remove any possibility of
bringing external constraints into element's scope.

Resolves: rdar://92347054

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
