### PR TITLE
Change the definition of MALLOC_ALIGN_MASK so it should always be correct on all platforms.

### DIFF
--- a/stdlib/public/runtime/Heap.cpp
+++ b/stdlib/public/runtime/Heap.cpp
@@ -29,28 +29,27 @@
 using namespace swift;
 
 #if defined(__APPLE__)
-// Apple malloc is always 16-byte aligned.
-#  define MALLOC_ALIGN_MASK 15
+/// On Apple platforms, \c malloc() is always 16-byte aligned.
+static constexpr size_t MALLOC_ALIGN_MASK = 15;
 
-#elif defined(__linux__)
-// Linux malloc is 16-byte aligned on 64-bit, and 8-byte aligned on 32-bit.
-#  if defined(__LP64)
-#    define MALLOC_ALIGN_MASK 15
-#  else
-#    define MALLOC_ALIGN_MASK 7
-#  endif
-
-#elif defined(_WIN64)
-// Windows malloc is 16-byte aligned on 64-bit and 8-byte aligned on 32-bit.
-#  define MALLOC_ALIGN_MASK 15
-#elif defined(_WIN32)
-#  define MALLOC_ALIGN_MASK 7
+#elif defined(__linux__) || defined(_WIN32)
+/// On Linux and Windows, \c malloc() returns 16-byte aligned pointers on 64-bit
+/// and 8-byte aligned pointers on 32-bit.
+#if defined(__LP64) || defined(_WIN64)
+static constexpr size_t MALLOC_ALIGN_MASK = 15;
+#else
+static constexpr size_t MALLOC_ALIGN_MASK = 7;
+#endif
 
 #else
-// Unknown alignment, but the standard requires alignment suitable for the largest
-// standard types.
-#  define MALLOC_ALIGN_MASK std::max(alignof(void *), alignof(double))
-
+/// This platform's \c malloc() constraints are unknown, so fall back to a value
+/// derived from \c std::max_align_t that will be sufficient, but is not
+/// necessarily optimal.
+///
+/// The C and C++ standards defined \c max_align_t as a type whose alignment is
+/// at least that of every scalar type. It is the lower bound for the alignment
+/// of any pointer returned from \c malloc().
+static constexpr size_t MALLOC_ALIGN_MASK = alignof(std::max_align_t) - 1;
 #endif
 
 // This assert ensures that manually allocated memory always uses the


### PR DESCRIPTION
Change the definition of `MALLOC_ALIGN_MASK` so it should always be correct on all platforms.

<!-- What's in this pull request? -->

The default path that defines `MALLOC_ALIGN_MASK` does so incorrectly, producing a power-of-two value instead of a mask. This change resolves the issue by redefining `MALLOC_ALIGN_MASK` for all platforms in terms of the C/C++ standard `max_align_t` type (which exists for this purpose.)

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves #58486.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
