### PR TITLE
[android] Don't generate a libstdcxx.modulemap

### DIFF
--- a/stdlib/public/Cxx/CMakeLists.txt
+++ b/stdlib/public/Cxx/CMakeLists.txt
@@ -3,7 +3,6 @@ foreach(sdk ${SWIFT_SDKS})
   if(NOT "${sdk}" STREQUAL "LINUX" AND
       NOT "${sdk}" STREQUAL "FREEBSD" AND
       NOT "${sdk}" STREQUAL "OPENBSD" AND
-      NOT "${sdk}" STREQUAL "ANDROID" AND
       NOT "${sdk}" STREQUAL "CYGWIN" AND
       NOT "${sdk}" STREQUAL "HAIKU")
     continue()


### PR DESCRIPTION
Android uses libc++, which already has its own module map.

@egorzhdan, [as we discussed](https://github.com/apple/swift/pull/41953#issuecomment-1110086044), removing this, as [I noticed it breaks some tests on the Android CI too](https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android-arm64/522/consoleText).

@compnerd, letting you know in case you have any input.