### PR TITLE
Revert "runtime: allow over-aligned types in the runtime"

### DIFF
--- a/include/swift/Runtime/Atomic.h
+++ b/include/swift/Runtime/Atomic.h
@@ -18,8 +18,6 @@
 #define SWIFT_RUNTIME_ATOMIC_H
 
 #include "swift/Runtime/Config.h"
-#include "swift/Runtime/Heap.h"
-
 #include <assert.h>
 #include <atomic>
 #if defined(_WIN64)
@@ -45,65 +43,13 @@
 
 namespace swift {
 namespace impl {
-
-// FIXME: why can we not use the definitions from Heap.h?  It seems that we
-// would fail to collapse the structure down in that case and end up with size
-// differences.
-template <std::size_t Alignment_>
-struct requires_aligned_alloc {
-#if defined(__cpp_aligned_new)
-  // If we have C++17 or newer we can use the alignment aware allocation
-  // implicitly.
-  static constexpr const bool value = false;
-#else
-#if defined(__STDCPP_DEFAULT_NEW_ALIGNMENT__)
-  static constexpr const bool value =
-      Alignment_ > std::alignment_of<std::max_align_t>::value &&
-      Alignment_ > __STDCPP_DEFAULT_NEW_ALIGNMENT__;
-#else
-  static constexpr const bool value =
-      Alignment_ > std::alignment_of<std::max_align_t>::value;
-#endif
-#endif
-};
-
-template <std::size_t Alignment_,
-          bool = requires_aligned_alloc<Alignment_>::value>
-struct aligned_alloc;
-
-template <std::size_t Alignment_>
-struct aligned_alloc<Alignment_, false> {};
-
-template <std::size_t Alignment_>
-struct aligned_alloc<Alignment_, true> {
-  [[nodiscard]] void *operator new(std::size_t size) noexcept {
-#if defined(_WIN32)
-    return _aligned_malloc(size, Alignment_);
-#else
-    static_assert(Alignment_ >= sizeof(void *),
-                  "posix_memalign requires minimal alignment of pointer");
-    void *ptr = nullptr;
-    (void)posix_memalign(&ptr, Alignment_, size);
-    return ptr;
-#endif
-  }
-
-  void operator delete(void *ptr) noexcept {
-#if defined(_WIN32)
-    _aligned_free(ptr);
-#else
-    free(ptr);
-#endif
-  }
-};
-
 /// The default implementation for swift::atomic<T>, which just wraps
 /// std::atomic with minor differences.
 ///
 /// TODO: should we make this use non-atomic operations when the runtime
 /// is single-threaded?
 template <class Value, size_t Size = sizeof(Value)>
-class alignas(Size) atomic_impl : public aligned_alloc<Size> {
+class alignas(Size) atomic_impl {
   std::atomic<Value> value;
 public:
   constexpr atomic_impl(Value value) : value(value) {}

--- a/include/swift/Runtime/Heap.h
+++ b/include/swift/Runtime/Heap.h
@@ -18,17 +18,10 @@
 #define SWIFT_RUNTIME_HEAP_H
 
 #include <cstddef>
-#include <cstdint>
-#include <cstdlib>
 #include <new>
-#include <type_traits>
 #include <utility>
 
 #include "swift/Runtime/Config.h"
-
-#if defined(_WIN32)
-#include <malloc.h>
-#endif
 
 namespace swift {
 // Allocate plain old memory. This is the generalized entry point
@@ -85,77 +78,6 @@ static inline void swift_cxx_deleteObject(T *ptr) {
     swift_slowDealloc(ptr, sizeof(T), alignof(T) - 1);
   }
 }
-
-namespace {
-// This is C++17 and newer, so we simply re-define it.  Since the codebase is
-// C++14, assume that DR1558 is accounted for and that unused parameters in alias
-// templates are guaranteed to ensure SFINAE and are not ignored.
-template <typename ...>
-using void_t = void;
-
-template <typename T, typename = void>
-struct is_aligned_alloc_aware : std::false_type {};
-
-template <typename T>
-struct is_aligned_alloc_aware<T, void_t<decltype(T::operator new(0))>>
-    : std::true_type {};
-}
-
-template <std::size_t Alignment_>
-struct requires_aligned_alloc {
-#if defined(__cpp_aligned_new)
-  // If we have C++17 or newer we can use the alignment aware allocation
-  // implicitly.
-  static constexpr const bool value = false;
-#else
-#if defined(__STDCPP_DEFAULT_NEW_ALIGNMENT__)
-  static constexpr const bool value =
-      Alignment_ > std::alignment_of<std::max_align_t>::value &&
-      Alignment_ > __STDCPP_DEFAULT_NEW_ALIGNMENT__;
-#else
-  static constexpr const bool value =
-      Alignment_ > std::alignment_of<std::max_align_t>::value;
-#endif
-#endif
-};
-
-template <std::size_t Alignment_,
-          bool = requires_aligned_alloc<Alignment_>::value>
-struct aligned_alloc;
-
-template <std::size_t Alignment_>
-struct aligned_alloc<Alignment_, false> {};
-
-template <std::size_t Alignment_>
-struct aligned_alloc<Alignment_, true> {
-  [[nodiscard]] void *operator new(std::size_t size) noexcept {
-#if defined(_WIN32)
-    return _aligned_malloc(size, Alignment_);
-#else
-    static_assert(Alignment_ >= sizeof(void *),
-                  "posix_memalign requires minimal alignment of pointer");
-    void *ptr = nullptr;
-    (void)posix_memalign(&ptr, Alignment_, size);
-    return ptr;
-#endif
-  }
-
-  void operator delete(void *ptr) noexcept {
-#if defined(_WIN32)
-    _aligned_free(ptr);
-#else
-    free(ptr);
-#endif
-  }
-
-#if defined(_WIN32)
-  // FIXME: why is this even needed?  This is not permitted as per the C++
-  // standard new.delete.placement (§17.6.3.4).
-  [[nodiscard]] void *operator new(std::size_t size, void *where) noexcept {
-    return ::operator new(size, where);
-  }
-#endif
-};
 }
 
 #endif // SWIFT_RUNTIME_HEAP_H

--- a/include/swift/Runtime/HeapObject.h
+++ b/include/swift/Runtime/HeapObject.h
@@ -20,6 +20,7 @@
 #include <cstddef>
 #include <cstdint>
 #include "swift/Runtime/Config.h"
+#include "swift/Runtime/Heap.h"
 
 #if SWIFT_OBJC_INTEROP
 #include <objc/objc.h>

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -580,8 +580,7 @@ public:
 ///     achieved through careful arrangement of the storage for this in the
 ///     DefaultActorImpl. The additional alignment requirements are
 ///     enforced by static asserts below.
-class alignas(2 * sizeof(void *)) ActiveActorStatus
-    : public swift::aligned_alloc<2 * sizeof(void *)> {
+class alignas(sizeof(void *) * 2) ActiveActorStatus {
 #if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION && SWIFT_POINTER_IS_4_BYTES
   uint32_t Flags;
   dispatch_lock_t DrainLock;

--- a/stdlib/public/Concurrency/AsyncLet.cpp
+++ b/stdlib/public/Concurrency/AsyncLet.cpp
@@ -21,7 +21,6 @@
 #include "swift/ABI/Task.h"
 #include "swift/ABI/TaskOptions.h"
 #include "swift/Runtime/Mutex.h"
-#include "swift/Runtime/Heap.h"
 #include "swift/Runtime/HeapObject.h"
 #include "llvm/ADT/PointerIntPair.h"
 #include "TaskPrivate.h"
@@ -36,9 +35,7 @@
 using namespace swift;
 
 namespace {
-class alignas(Alignment_AsyncLet) AsyncLetImpl
-    : public swift::aligned_alloc<Alignment_AsyncLet>,
-      public ChildTaskStatusRecord {
+class alignas(Alignment_AsyncLet) AsyncLetImpl: public ChildTaskStatusRecord {
 public:
   // This is where we could define a Status or other types important for async-let
 

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -26,7 +26,6 @@
 #include "swift/Runtime/DispatchShims.h"
 #include "swift/Runtime/Error.h"
 #include "swift/Runtime/Exclusivity.h"
-#include "swift/Runtime/Heap.h"
 #include "swift/Runtime/HeapObject.h"
 #include <atomic>
 #include <new>
@@ -526,12 +525,6 @@ public:
 #endif
 static_assert(sizeof(ActiveTaskStatus) == ACTIVE_TASK_STATUS_SIZE,
   "ActiveTaskStatus is of incorrect size");
-#if !defined(_WIN64)
-static_assert(sizeof(swift::atomic<ActiveTaskStatus>) == sizeof(std::atomic<ActiveTaskStatus>),
-              "swift::atomic pads std::atomic, memory aliasing invariants violated");
-#endif
-static_assert(sizeof(swift::atomic<ActiveTaskStatus>) == sizeof(ActiveTaskStatus),
-              "swift::atomic pads ActiveTaskStatus, memory aliasing invariants violated");
 
 /// The size of an allocator slab. We want the full allocation to fit into a
 /// 1024-byte malloc quantum. We subtract off the slab header size, plus a
@@ -553,7 +546,7 @@ struct AsyncTask::PrivateStorage {
 
   /// Storage for the ActiveTaskStatus. See doc for ActiveTaskStatus for size
   /// and alignment requirements.
-  alignas(alignof(ActiveTaskStatus)) char StatusStorage[sizeof(ActiveTaskStatus)];
+  alignas(ActiveTaskStatus) char StatusStorage[sizeof(ActiveTaskStatus)];
 
   /// The allocator for the task stack.
   /// Currently 2 words + 8 bytes.

--- a/stdlib/public/SwiftShims/RefCount.h
+++ b/stdlib/public/SwiftShims/RefCount.h
@@ -626,9 +626,8 @@ class RefCountBitsT {
 
 typedef RefCountBitsT<RefCountIsInline> InlineRefCountBits;
 
-class alignas(2 * sizeof(void*)) SideTableRefCountBits
-    : public swift::aligned_alloc<2 * sizeof(void *)>,
-      public RefCountBitsT<RefCountNotInline> {
+class alignas(sizeof(void*) * 2) SideTableRefCountBits : public RefCountBitsT<RefCountNotInline>
+{
   uint32_t weakBits;
 
   public:

--- a/stdlib/public/runtime/KnownMetadata.cpp
+++ b/stdlib/public/runtime/KnownMetadata.cpp
@@ -15,7 +15,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/Runtime/Metadata.h"
-#include "swift/Runtime/Heap.h"
 #include "swift/Runtime/HeapObject.h"
 #include "swift/Runtime/Numeric.h"
 #include "MetadataImpl.h"
@@ -41,19 +40,19 @@ OpaqueValue *swift::swift_copyPOD(OpaqueValue *dest, OpaqueValue *src,
 namespace {
   // A type sized and aligned the way Swift wants Int128 (and Float80/Float128)
   // to be sized and aligned.
-  struct alignas(16) int128_like : swift::aligned_alloc<16> {
+  struct alignas(16) int128_like {
     char data[16];
   };
 
   static_assert(MaximumAlignment == 16, "max alignment was hardcoded");
-  struct alignas(16) int256_like : swift::aligned_alloc<16> {
+  struct alignas(16) int256_like {
     char data[32];
   };
-  struct alignas(16) int512_like : swift::aligned_alloc<16> {
+  struct alignas(16) int512_like {
     char data[64];
   };
 
-  struct alignas(16) float80_like : swift::aligned_alloc<16> {
+  struct alignas(16) float80_like {
     char data[10];
   };
 } // end anonymous namespace
@@ -90,8 +89,7 @@ namespace ctypes {
     // Types that are defined in the _Concurrency library
 
     // Default actor storage type.
-    struct alignas(2 * alignof(void*)) BD
-        : swift::aligned_alloc<2 * alignof(void*)> {
+    struct alignas(2 * alignof(void*)) BD {
       void *storage[NumWords_DefaultActor];
     };
 

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -24,7 +24,6 @@
 #include "swift/Runtime/Casting.h"
 #include "swift/Runtime/EnvironmentVariables.h"
 #include "swift/Runtime/ExistentialContainer.h"
-#include "swift/Runtime/Heap.h"
 #include "swift/Runtime/HeapObject.h"
 #include "swift/Runtime/Mutex.h"
 #include "swift/Runtime/Once.h"
@@ -6158,15 +6157,9 @@ void swift::blockOnMetadataDependency(MetadataDependency root,
 #if !SWIFT_STDLIB_PASSTHROUGH_METADATA_ALLOCATOR
 
 namespace {
-  struct alignas(2 * sizeof(uintptr_t)) PoolRange
-      : swift::aligned_alloc<2 * sizeof(uintptr_t)> {
+  struct alignas(sizeof(uintptr_t) * 2) PoolRange {
     static constexpr uintptr_t PageSize = 16 * 1024;
     static constexpr uintptr_t MaxPoolAllocationSize = PageSize / 2;
-
-    constexpr PoolRange(char *Begin, size_t Remaining)
-        : Begin(Begin), Remaining(Remaining) {}
-
-    PoolRange() : Begin(nullptr), Remaining(0) {}
 
     /// The start of the allocation.
     char *Begin;

--- a/stdlib/public/runtime/MetadataCache.h
+++ b/stdlib/public/runtime/MetadataCache.h
@@ -15,7 +15,6 @@
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/STLExtras.h"
 #include "swift/Runtime/Concurrent.h"
-#include "swift/Runtime/Heap.h"
 #include "swift/Runtime/Metadata.h"
 #include "swift/Runtime/Mutex.h"
 #include "swift/Runtime/AtomicWaitQueue.h"
@@ -621,9 +620,8 @@ const size_t PrivateMetadataTrackingAlignment = 16;
 
 /// The wait queue object that we create for metadata that are
 /// being actively initialized right now.
-struct alignas(PrivateMetadataTrackingAlignment) MetadataWaitQueue
-    : swift::aligned_alloc<PrivateMetadataTrackingAlignment>,
-      public AtomicWaitQueue<MetadataWaitQueue, ConcurrencyControl::LockType> {
+struct alignas(PrivateMetadataTrackingAlignment) MetadataWaitQueue :
+  public AtomicWaitQueue<MetadataWaitQueue, ConcurrencyControl::LockType> {
 
   /// A pointer to the completion context being used to complete this
   /// metadata.  This is only actually filled in if:
@@ -682,8 +680,7 @@ struct alignas(PrivateMetadataTrackingAlignment) MetadataWaitQueue
 
 /// A record used to store information about an attempt to
 /// complete a metadata when there's no active worker thread.
-struct alignas(PrivateMetadataTrackingAlignment) SuspendedMetadataCompletion
-    : swift::aligned_alloc<PrivateMetadataTrackingAlignment> {
+struct alignas(PrivateMetadataTrackingAlignment) SuspendedMetadataCompletion {
   MetadataDependency BlockingDependency;
   std::unique_ptr<PrivateMetadataCompletionContext> PersistentContext;
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
`swift::aligned_alloc` (and friends) was added as a workaround for 32-bit platforms' `operator new` under-aligning allocations, but this was later corrected more cleanly by including `<new>` for placement new and by using `swift_cxx_newObject()` to rely on `swift_slowAlloc()` for allocations instead of `operator new`. The commit that added `swift::aligned_alloc` can be removed now.

This change reverts commit b694ce4634569dc382721e404fddc451fec112a4.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves #58498.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
