### PR TITLE
[stdlib] Give CJK a fast path for normalization data

### DIFF
--- a/stdlib/public/core/UnicodeData.swift
+++ b/stdlib/public/core/UnicodeData.swift
@@ -67,11 +67,12 @@ extension Unicode {
         return
       }
 
-      // CJK Ideographs
-      if (0x4E00 ... 0x9FFF).contains(scalar.value) {
-        // CCC = 0, NFC_QC = Yes, NFD_QC = Yes
-        rawValue = 0
-        return
+      if (0x2ADD...0xF8FF).contains(scalar.value) {
+        if scalar.value != 0x3099, scalar.value != 0x309A {
+          // CCC = 0, NFC_QC = Yes, NFD_QC = Yes
+          rawValue = 0
+          return
+        }
       }
 
       // CJK COMPATIBILITY IDEOGRAPH

--- a/stdlib/public/core/UnicodeData.swift
+++ b/stdlib/public/core/UnicodeData.swift
@@ -67,6 +67,13 @@ extension Unicode {
         return
       }
 
+      // CJK Ideographs
+      if (0x4E00 ... 0x9FFF).contains(scalar.value) {
+        // CCC = 0, NFC_QC = Yes, NFD_QC = Yes
+        rawValue = 0
+        return
+      }
+
       // CJK COMPATIBILITY IDEOGRAPH
       if (0xF900 ... 0xFA0D).contains(scalar.value) {
         // CCC = 0, NFC_QC = No, NFD_QC = No

--- a/stdlib/public/core/UnicodeData.swift
+++ b/stdlib/public/core/UnicodeData.swift
@@ -64,15 +64,23 @@ extension Unicode {
       if _fastPath(scalar.value < fastUpperbound) {
         // CCC = 0, NFC_QC = Yes, NFD_QC = Yes
         rawValue = 0
-      } else {
-        rawValue = _swift_stdlib_getNormData(scalar.value)
+        return
+      }
 
-        // Because we don't store precomposed hangul in our NFD_QC data, these
-        // will return true for NFD_QC when in fact they are not.
-        if (0xAC00 ... 0xD7A3).contains(scalar.value) {
-          // NFD_QC = false
-          rawValue |= 0x1
-        }
+      // CJK COMPATIBILITY IDEOGRAPH
+      if (0xF900 ... 0xFA0D).contains(scalar.value) {
+        // CCC = 0, NFC_QC = No, NFD_QC = No
+        rawValue = 0x3
+        return
+      }
+
+      rawValue = _swift_stdlib_getNormData(scalar.value)
+
+      // Because we don't store precomposed hangul in our NFD_QC data, these
+      // will return true for NFD_QC when in fact they are not.
+      if (0xAC00 ... 0xD7A3).contains(scalar.value) {
+        // NFD_QC = No
+        rawValue |= 0x1
       }
     }
 


### PR DESCRIPTION
This is for purely for benchmarking at the moment, but try to give CJK compatibility ideographs a fast path into normalization data lookup. These scalars still need to go through decomposition lookup however.