### PR TITLE
[ConstraintSystem] Fail `~=` synthesis if constraint generation fails

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4587,6 +4587,7 @@ public:
   /// Generate constraints for the given solution target.
   ///
   /// \returns true if an error occurred, false otherwise.
+  LLVM_NODISCARD
   bool generateConstraints(SolutionApplicationTarget &target,
                            FreeTypeVariableBinding allowFreeTypeVariables);
 
@@ -4595,11 +4596,13 @@ public:
   /// \param closure the closure expression
   ///
   /// \returns \c true if constraint generation failed, \c false otherwise
+  LLVM_NODISCARD
   bool generateConstraints(ClosureExpr *closure);
 
   /// Generate constraints for the given (unchecked) expression.
   ///
   /// \returns a possibly-sanitized expression, or null if an error occurred.
+  LLVM_NODISCARD
   Expr *generateConstraints(Expr *E, DeclContext *dc,
                             bool isInputExpression = true);
 
@@ -4607,6 +4610,7 @@ public:
   /// value of the given expression.
   ///
   /// \returns a possibly-sanitized initializer, or null if an error occurred.
+  LLVM_NODISCARD
   Type generateConstraints(Pattern *P, ConstraintLocatorBuilder locator,
                            bool bindPatternVarsOneWay,
                            PatternBindingDecl *patternBinding,
@@ -4616,6 +4620,7 @@ public:
   ///
   /// \returns true if there was an error in constraint generation, false
   /// if generation succeeded.
+  LLVM_NODISCARD
   bool generateConstraints(StmtCondition condition, DeclContext *dc);
 
   /// Generate constraints for a case statement.
@@ -4625,6 +4630,7 @@ public:
   ///
   /// \returns true if there was an error in constraint generation, false
   /// if generation succeeded.
+  LLVM_NODISCARD
   bool generateConstraints(CaseStmt *caseStmt, DeclContext *dc,
                            Type subjectType, ConstraintLocator *locator);
 
@@ -4668,6 +4674,7 @@ public:
   /// \param propertyType The type of the wrapped property.
   ///
   /// \returns true if there is an error.
+  LLVM_NODISCARD
   bool generateWrappedPropertyTypeConstraints(VarDecl *wrappedVar,
                                               Type initializerType,
                                               Type propertyType);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9914,8 +9914,9 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
       }
 
       if (!paramDecl->getName().hasDollarPrefix()) {
-        generateWrappedPropertyTypeConstraints(paramDecl, backingType,
-                                               param.getParameterType());
+        if (generateWrappedPropertyTypeConstraints(paramDecl, backingType,
+                                                   param.getParameterType()))
+          return false;
       }
 
       auto result = applyPropertyWrapperToParameter(backingType, param.getParameterType(),

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -8978,7 +8978,8 @@ static bool inferEnumMemberThroughTildeEqualsOperator(
     }
   }
 
-  cs.generateConstraints(target, FreeTypeVariableBinding::Disallow);
+  if (cs.generateConstraints(target, FreeTypeVariableBinding::Disallow))
+    return true;
 
   // Sub-expression associated with expression pattern is the enum element
   // access which needs to be connected to the provided element type.

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -316,3 +316,16 @@ func test_wrapped_var_without_initializer() {
     var v;
   }
 }
+
+// rdar://92366212 - crash in ConstraintSystem::getType
+func test_unknown_refs_in_tilde_operator() {
+  enum E {
+  }
+
+  let _: (E) -> Void = {
+    if case .test(unknown) = $0 {
+      // expected-error@-1 {{type 'E' has no member 'test'}}
+      // expected-error@-2 2 {{cannot find 'unknown' in scope}}
+    }
+  }
+}

--- a/unittests/Sema/PlaceholderTypeInferenceTests.cpp
+++ b/unittests/Sema/PlaceholderTypeInferenceTests.cpp
@@ -36,7 +36,9 @@ TEST_F(SemaTest, TestPlaceholderInferenceForArrayLiteral) {
 
   ConstraintSystem cs(DC, ConstraintSystemOptions());
   cs.setContextualType(arrayExpr, {arrayRepr, arrayTy}, CTP_Initialization);
-  cs.generateConstraints(target, FreeTypeVariableBinding::Disallow);
+  auto failed = cs.generateConstraints(target, FreeTypeVariableBinding::Disallow);
+  ASSERT_FALSE(failed);
+
   SmallVector<Solution, 2> solutions;
   cs.solve(solutions);
 
@@ -75,7 +77,9 @@ TEST_F(SemaTest, TestPlaceholderInferenceForDictionaryLiteral) {
 
   ConstraintSystem cs(DC, ConstraintSystemOptions());
   cs.setContextualType(dictExpr, {dictRepr, dictTy}, CTP_Initialization);
-  cs.generateConstraints(target, FreeTypeVariableBinding::Disallow);
+  auto failed = cs.generateConstraints(target, FreeTypeVariableBinding::Disallow);
+  ASSERT_FALSE(failed);
+
   SmallVector<Solution, 2> solutions;
   cs.solve(solutions);
 

--- a/unittests/Sema/UnresolvedMemberLookupTests.cpp
+++ b/unittests/Sema/UnresolvedMemberLookupTests.cpp
@@ -33,9 +33,11 @@ TEST_F(SemaTest, TestLookupAlwaysLooksThroughOptionalBase) {
   auto *UMCRE = new (Context) UnresolvedMemberChainResultExpr(UME, UME);
 
   ConstraintSystem cs(DC, ConstraintSystemOptions());
-  cs.generateConstraints(UMCRE, DC);
+  auto *expr = cs.generateConstraints(UMCRE, DC);
+  ASSERT_TRUE(expr);
+
   cs.addConstraint(
-      ConstraintKind::Conversion, cs.getType(UMCRE), intOptType,
+      ConstraintKind::Conversion, cs.getType(expr), intOptType,
       cs.getConstraintLocator(UMCRE, ConstraintLocator::ContextualType));
   SmallVector<Solution, 2> solutions;
   cs.solve(solutions);
@@ -67,10 +69,12 @@ TEST_F(SemaTest, TestLookupPrefersResultsOnOptionalRatherThanBase) {
   auto *UMCRE = new (Context) UnresolvedMemberChainResultExpr(UME, UME);
 
   ConstraintSystem cs(DC, ConstraintSystemOptions());
-  cs.generateConstraints(UMCRE, DC);
+  auto *expr = cs.generateConstraints(UMCRE, DC);
+  ASSERT_TRUE(expr);
+
   cs.addConstraint(
-      ConstraintKind::Conversion, cs.getType(UMCRE), intOptType,
-      cs.getConstraintLocator(UMCRE, ConstraintLocator::ContextualType));
+      ConstraintKind::Conversion, cs.getType(expr), intOptType,
+      cs.getConstraintLocator(expr, ConstraintLocator::ContextualType));
   SmallVector<Solution, 2> solutions;
   cs.solve(solutions);
 


### PR DESCRIPTION
If constraint generation for application of `~=` failed, that should
result in an immediate synthesis failure.

Also add `LLVM_NODISCARD` to `generate*` methods
to make it harder to make such a mistake in the future.

Resolves: rdar://92366212

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
