### PR TITLE
[Parse] Split prefix operators from regex in the lexer

### DIFF
--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -565,10 +565,17 @@ public:
     void operator=(const SILBodyRAII&) = delete;
   };
 
-  /// Attempt to re-lex a regex literal with forward slashes `/.../` from a
-  /// given lexing state. If \p mustBeRegex is set to true, a regex literal will
-  /// always be lexed. Otherwise, it will not be lexed if it may be ambiguous.
-  void tryLexForwardSlashRegexLiteralFrom(State S, bool mustBeRegex);
+  /// A RAII object for switching the lexer into forward slash regex `/.../`
+  /// lexing mode.
+  class ForwardSlashRegexRAII final {
+    llvm::SaveAndRestore<LexerForwardSlashRegexMode> Scope;
+
+  public:
+    ForwardSlashRegexRAII(Lexer &L, bool MustBeRegex)
+        : Scope(L.ForwardSlashRegexMode,
+                MustBeRegex ? LexerForwardSlashRegexMode::Always
+                            : LexerForwardSlashRegexMode::Tentative) {}
+  };
 
 private:
   /// Nul character meaning kind.

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1758,7 +1758,6 @@ public:
   ParserResult<Expr>
   parseExprPoundCodeCompletion(Optional<StmtKind> ParentKind);
 
-  UnresolvedDeclRefExpr *makeExprOperator(const Token &opToken);
   UnresolvedDeclRefExpr *parseExprOperator();
 
   /// Try re-lex a '/' operator character as a regex literal. This should be

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -2081,9 +2081,6 @@ bool Lexer::tryLexRegexLiteral(const char *TokStart) {
 }
 
 void Lexer::tryLexForwardSlashRegexLiteralFrom(State S, bool mustBeRegex) {
-  if (!LangOpts.EnableBareSlashRegexLiterals)
-    return;
-
   // Try re-lex with forward slash enabled.
   llvm::SaveAndRestore<LexerForwardSlashRegexMode> RegexLexingScope(
       ForwardSlashRegexMode, mustBeRegex

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -815,6 +815,13 @@ void Lexer::lexOperatorIdentifier() {
         rangeContainsPlaceholderEnd(CurPtr + 2, BufferEnd)) {
       break;
     }
+
+    // If we are lexing a `/.../` regex literal, we don't consider `/` to be an
+    // operator character.
+    if (ForwardSlashRegexMode != LexerForwardSlashRegexMode::None &&
+        *CurPtr == '/') {
+      break;
+    }
   } while (advanceIfValidContinuationOfOperator(CurPtr, BufferEnd));
 
   if (CurPtr-TokStart > 2) {
@@ -2078,15 +2085,6 @@ bool Lexer::tryLexRegexLiteral(const char *TokStart) {
   // We either had a successful lex, or something that was recoverable.
   formToken(tok::regex_literal, TokStart);
   return true;
-}
-
-void Lexer::tryLexForwardSlashRegexLiteralFrom(State S, bool mustBeRegex) {
-  // Try re-lex with forward slash enabled.
-  llvm::SaveAndRestore<LexerForwardSlashRegexMode> RegexLexingScope(
-      ForwardSlashRegexMode, mustBeRegex
-                                 ? LexerForwardSlashRegexMode::Always
-                                 : LexerForwardSlashRegexMode::Tentative);
-  restoreState(S, /*enableDiagnostics*/ true);
 }
 
 /// lexEscapedIdentifier:

--- a/test/StringProcessing/Parse/forward-slash-regex-disabled.swift
+++ b/test/StringProcessing/Parse/forward-slash-regex-disabled.swift
@@ -1,0 +1,34 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-string-processing -disable-availability-checking
+
+// REQUIRES: swift_in_compiler
+
+prefix operator /
+prefix operator ^/
+prefix operator /^/
+
+precedencegroup P {
+  associativity: left
+}
+
+// The divisions in the body of the below operators make sure we don't try and
+// consider them to be ending delimiters of a regex.
+infix operator /^/ : P
+func /^/ (lhs: Int, rhs: Int) -> Int { 1 / 2 }
+
+infix operator /^ : P
+func /^ (lhs: Int, rhs: Int) -> Int { 1 / 2 }
+
+infix operator ^^/ : P
+func ^^/ (lhs: Int, rhs: Int) -> Int { 1 / 2 }
+
+_ = #/x/#
+
+_ = /x/
+// expected-error@-1 {{'/' is not a prefix unary operator}}
+// expected-error@-2 {{cannot find 'x' in scope}}
+// expected-error@-3 {{'/' is not a postfix unary operator}}
+
+func baz(_ x: (Int, Int) -> Int, _ y: (Int, Int) -> Int) {}
+baz(/, /)
+baz(/^, /)
+baz(^^/, /)

--- a/test/StringProcessing/Parse/forward-slash-regex.swift
+++ b/test/StringProcessing/Parse/forward-slash-regex.swift
@@ -35,18 +35,23 @@ _ = /x/.self
 _ = /\//
 _ = /\\/
 
-// These unfortunately become infix `=/`. We could likely improve the diagnostic
-// though.
-let z=/0/
-// expected-error@-1 {{type annotation missing in pattern}}
-// expected-error@-2 {{consecutive statements on a line must be separated by ';'}}
-// expected-error@-3 {{expected expression after unary operator}}
-// expected-error@-4 {{cannot find operator '=/' in scope}}
-// expected-error@-5 {{'/' is not a postfix unary operator}}
-_=/0/
-// expected-error@-1 {{'_' can only appear in a pattern or on the left side of an assignment}}
-// expected-error@-2 {{cannot find operator '=/' in scope}}
-// expected-error@-3 {{'/' is not a postfix unary operator}}
+// This is just here to appease typo correction.
+let y = 0
+
+// These unfortunately become prefix `=` and infix `=/` respectively. We could
+// likely improve the diagnostic though.
+do {
+  let z=/0/
+  // expected-error@-1 {{type annotation missing in pattern}}
+  // expected-error@-2 {{consecutive statements on a line must be separated by ';'}}
+  // expected-error@-3 {{expected expression}}
+}
+do {
+  _=/0/
+  // expected-error@-1 {{'_' can only appear in a pattern or on the left side of an assignment}}
+  // expected-error@-2 {{cannot find operator '=/' in scope}}
+  // expected-error@-3 {{'/' is not a postfix unary operator}}
+}
 
 _ = /x
 // expected-error@-1 {{unterminated regex literal}}
@@ -58,9 +63,11 @@ _ = (!/x/)
 // expected-error@-1 {{cannot convert value of type 'Regex<Substring>' to expected argument type 'Bool'}}
 
 _ = !/ /
-// expected-error@-1 {{unary operator cannot be separated from its operand}}
-// expected-error@-2 {{cannot find operator '!/' in scope}}
-// expected-error@-3 {{unterminated regex literal}}
+// expected-error@-1 {{regex literal may not start with space; add backslash to escape}}
+// expected-error@-2 {{cannot convert value of type 'Regex<Substring>' to expected argument type 'Bool'}}
+
+_ = !!/ /
+// expected-error@-1 {{regex literal may not start with space; add backslash to escape}}
 
 _ = !!/x/
 _ = (!!/x/)
@@ -75,7 +82,6 @@ _ = /x/ + /y/ // expected-error {{binary operator '+' cannot be applied to two '
 _ = /x/+/y/
 // expected-error@-1 {{cannot find operator '+/' in scope}}
 // expected-error@-2 {{'/' is not a postfix unary operator}}
-// expected-error@-3 {{cannot find 'y' in scope}}
 
 _ = /x/?.blah
 // expected-error@-1 {{cannot use optional chaining on non-optional value of type 'Regex<Substring>'}}
@@ -102,7 +108,6 @@ _ = /x/ ... /y/ // expected-error {{referencing operator function '...' on 'Comp
 _ = /x/.../y/
 // expected-error@-1 {{missing whitespace between '...' and '/' operators}}
 // expected-error@-2 {{'/' is not a postfix unary operator}}
-// expected-error@-3 {{cannot find 'y' in scope}}
 
 _ = /x /...
 // expected-error@-1 {{unary operator '...' cannot be applied to an operand of type 'Regex<Substring>'}}
@@ -120,12 +125,7 @@ func foo<T>(_ x: T, y: T) {}
 foo(/abc/, y: /abc /)
 
 func bar<T>(_ x: inout T) {}
-
-// TODO: We split this into a prefix '&', but inout is handled specially when
-// parsing an argument list. This shouldn't matter anyway, but we should at
-// least have a custom diagnostic.
-bar(&/x/)
-// expected-error@-1 {{'&' is not a prefix unary operator}}
+bar(&/x/) // expected-error {{cannot pass immutable value as inout argument: literals are not mutable}}
 
 struct S {
   subscript(x: Regex<Substring>) -> Void { () }
@@ -259,7 +259,7 @@ _ = /x/*comment*/
 // expected-error@-1 {{unterminated regex literal}}
 
 // These become regex literals, unless surrounded in parens.
-func baz(_ x: (Int, Int) -> Int, _ y: (Int, Int) -> Int) {} // expected-note 3{{'baz' declared here}}
+func baz(_ x: (Int, Int) -> Int, _ y: (Int, Int) -> Int) {} // expected-note 4{{'baz' declared here}}
 baz(/, /)
 // expected-error@-1 {{cannot convert value of type 'Regex<Substring>' to expected argument type '(Int, Int) -> Int'}}
 // expected-error@-2 {{missing argument for parameter #2 in call}}
@@ -278,8 +278,7 @@ do {
   // expected-note@-2 {{to match this opening '('}}
 } // expected-error {{expected ')' in expression list}}
 
-// TODO: Should we do prefix operator splitting here?
-baz(^^/, /)
+baz(^^/, /) // expected-error {{missing argument for parameter #2 in call}}
 baz((^^/), /)
 
 func bazbaz(_ x: (Int, Int) -> Int, _ y: Int) {}
@@ -305,8 +304,9 @@ quxqux(/^/) // expected-error {{cannot convert value of type 'Regex<Substring>' 
 quxqux((/^/)) // expected-error {{cannot convert value of type 'Regex<Substring>' to expected argument type '(Int, Int) -> Int'}}
 quxqux({ $0 /^/ $1 })
 
-// FIXME: We should be able to do operator splitting here and form `!(/^/)`.
-quxqux(!/^/) // expected-error {{unary operators must not be juxtaposed; parenthesize inner expression}}
+quxqux(!/^/)
+// expected-error@-1 {{cannot convert value of type 'Bool' to expected argument type '(Int, Int) -> Int'}}
+// expected-error@-2 {{cannot convert value of type 'Regex<Substring>' to expected argument type 'Bool'}}
 
 quxqux(/^)
 

--- a/test/StringProcessing/Parse/forward-slash-regex.swift
+++ b/test/StringProcessing/Parse/forward-slash-regex.swift
@@ -6,13 +6,26 @@ prefix operator /  // expected-error {{prefix operator may not contain '/'}}
 prefix operator ^/ // expected-error {{prefix operator may not contain '/'}}
 prefix operator /^/ // expected-error {{prefix operator may not contain '/'}}
 
+prefix operator !!
+prefix func !! <T>(_ x: T) -> T { x }
+
+prefix operator ^^
+prefix func ^^ <T>(_ x: T) -> T { x }
+
 precedencegroup P {
   associativity: left
 }
 
-// Fine.
+// The divisions in the body of the below operators make sure we don't try and
+// consider them to be ending delimiters of a regex.
 infix operator /^/ : P
-func /^/ (lhs: Int, rhs: Int) -> Int { 0 }
+func /^/ (lhs: Int, rhs: Int) -> Int { 1 / 2 }
+
+infix operator /^ : P
+func /^ (lhs: Int, rhs: Int) -> Int { 1 / 2 }
+
+infix operator ^^/ : P
+func ^^/ (lhs: Int, rhs: Int) -> Int { 1 / 2 }
 
 let i = 0 /^/ 1/^/3
 
@@ -40,6 +53,21 @@ _ = /x
 
 _ = !/x/
 // expected-error@-1 {{cannot convert value of type 'Regex<Substring>' to expected argument type 'Bool'}}
+
+_ = (!/x/)
+// expected-error@-1 {{cannot convert value of type 'Regex<Substring>' to expected argument type 'Bool'}}
+
+_ = !/ /
+// expected-error@-1 {{unary operator cannot be separated from its operand}}
+// expected-error@-2 {{cannot find operator '!/' in scope}}
+// expected-error@-3 {{unterminated regex literal}}
+
+_ = !!/x/
+_ = (!!/x/)
+
+_ = /^)
+// expected-error@-1 {{unterminated regex literal}}
+// expected-error@-2 {{closing ')' does not balance any groups openings}}
 
 _ = /x/! // expected-error {{cannot force unwrap value of non-optional type 'Regex<Substring>'}}
 _ = /x/ + /y/ // expected-error {{binary operator '+' cannot be applied to two 'Regex<Substring>' operands}}
@@ -231,7 +259,7 @@ _ = /x/*comment*/
 // expected-error@-1 {{unterminated regex literal}}
 
 // These become regex literals, unless surrounded in parens.
-func baz(_ x: (Int, Int) -> Int, _ y: (Int, Int) -> Int) {} // expected-note 2{{'baz' declared here}}
+func baz(_ x: (Int, Int) -> Int, _ y: (Int, Int) -> Int) {} // expected-note 3{{'baz' declared here}}
 baz(/, /)
 // expected-error@-1 {{cannot convert value of type 'Regex<Substring>' to expected argument type '(Int, Int) -> Int'}}
 // expected-error@-2 {{missing argument for parameter #2 in call}}
@@ -240,8 +268,23 @@ baz(/,/)
 // expected-error@-2 {{missing argument for parameter #2 in call}}
 baz((/), /)
 
+baz(/^, /)
+// expected-error@-1 {{cannot convert value of type 'Regex<Substring>' to expected argument type '(Int, Int) -> Int'}}
+// expected-error@-2 {{missing argument for parameter #2 in call}}
+
+do {
+  baz((/^), /)
+  // expected-error@-1 {{closing ')' does not balance any groups openings}}
+  // expected-note@-2 {{to match this opening '('}}
+} // expected-error {{expected ')' in expression list}}
+
+// TODO: Should we do prefix operator splitting here?
+baz(^^/, /)
+baz((^^/), /)
+
 func bazbaz(_ x: (Int, Int) -> Int, _ y: Int) {}
 bazbaz(/, 0)
+bazbaz(^^/, 0)
 
 func qux<T>(_ x: (Int, Int) -> Int, _ y: T) -> Int { 0 }
 do {
@@ -255,6 +298,23 @@ do {
   // expected-error@-2:21 {{expected ',' separator}}
 }
 _ = qux(/, 1) // this comment tests to make sure we don't try and end the regex on the starting '/' of '//'.
+_ = qux(/, 1) /* same thing with a block comment */
+
+func quxqux(_ x: (Int, Int) -> Int) {}
+quxqux(/^/) // expected-error {{cannot convert value of type 'Regex<Substring>' to expected argument type '(Int, Int) -> Int'}}
+quxqux((/^/)) // expected-error {{cannot convert value of type 'Regex<Substring>' to expected argument type '(Int, Int) -> Int'}}
+quxqux({ $0 /^/ $1 })
+
+// FIXME: We should be able to do operator splitting here and form `!(/^/)`.
+quxqux(!/^/) // expected-error {{unary operators must not be juxtaposed; parenthesize inner expression}}
+
+quxqux(/^)
+
+do {
+  quxqux(/^) / 1
+  // expected-error@-1 {{closing ')' does not balance any groups openings}}
+  // expected-error@-2 {{expected ',' separator}}
+}
 
 let arr: [Double] = [2, 3, 4]
 _ = arr.reduce(1, /) / 3
@@ -282,3 +342,15 @@ _ = /0oG/
 _ = /"/
 _ = /'/
 _ = /<#placeholder#>/
+
+_ = ^^/0xG/
+_ = ^^/0oG/
+_ = ^^/"/
+_ = ^^/'/
+_ = ^^/<#placeholder#>/
+
+_ = (^^/0xG/)
+_ = (^^/0oG/)
+_ = (^^/"/)
+_ = (^^/'/)
+_ = (^^/<#placeholder#>/)


### PR DESCRIPTION
Teach the lexer not to consider `/` an operator character when attempting to re-lex a regex literal. This allows us to split off a prefix operator for cases such as `foo(!/^/)` and `foo(!/, /)` rather than treating them as unapplied infix operators. This matches the behavior outside of an argument list.

This also improves diagnostics for cases such as `foo(&/.../)`, as we now correctly produce a `tok::amp_prefix`.

rdar://92469917