### PR TITLE
[LookupVisibleDecls] Implement shadowing for unqualified lookups

### DIFF
--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -420,13 +420,17 @@ public:
 class UsableFilteringDeclConsumer final : public VisibleDeclConsumer {
   const SourceManager &SM;
   const DeclContext *DC;
+  const DeclContext *typeContext;
   SourceLoc Loc;
+  llvm::DenseMap<DeclBaseName, std::pair<ValueDecl *, DeclVisibilityKind>>
+      SeenNames;
   VisibleDeclConsumer &ChainedConsumer;
 
 public:
   UsableFilteringDeclConsumer(const SourceManager &SM, const DeclContext *DC,
                               SourceLoc loc, VisibleDeclConsumer &consumer)
-      : SM(SM), DC(DC), Loc(loc), ChainedConsumer(consumer) {}
+      : SM(SM), DC(DC), typeContext(DC->getInnermostTypeContext()), Loc(loc),
+        ChainedConsumer(consumer) {}
 
   void foundDecl(ValueDecl *D, DeclVisibilityKind reason,
                  DynamicLookupInfo dynamicLookupInfo) override;

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -1178,7 +1178,7 @@ static void lookupVisibleDeclsImpl(VisibleDeclConsumer &Consumer,
                                    const DeclContext *DC,
                                    bool IncludeTopLevel, SourceLoc Loc) {
   const SourceManager &SM = DC->getASTContext().SourceMgr;
-  auto Reason = DeclVisibilityKind::MemberOfCurrentNominal;
+  auto MemberReason = DeclVisibilityKind::MemberOfCurrentNominal;
 
   // If we are inside of a method, check to see if there are any ivars in scope,
   // and if so, whether this is a reference to one of them.
@@ -1280,12 +1280,15 @@ static void lookupVisibleDeclsImpl(VisibleDeclConsumer &Consumer,
       dcGenericParams = dcGenericParams->getOuterParameters();
     }
 
-    if (ExtendedType)
-      ::lookupVisibleMemberDecls(ExtendedType, Consumer, DC, LS, Reason,
+    if (ExtendedType) {
+      ::lookupVisibleMemberDecls(ExtendedType, Consumer, DC, LS, MemberReason,
                                  nullptr);
 
+      // Going outside the current type context.
+      MemberReason = DeclVisibilityKind::MemberOfOutsideNominal;
+    }
+
     DC = DC->getParent();
-    Reason = DeclVisibilityKind::MemberOfOutsideNominal;
   }
 
   if (auto SF = dyn_cast<SourceFile>(DC)) {

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1712,7 +1712,6 @@ class Mappable<T> {
 }
 
 let x = Mappable(())
-// expected-note@-1 4{{'x' declared here}}
 x.map { (_: Void) in return () }
 x.map { (_: ()) in () }
 

--- a/test/IDE/complete_escaped_keyword.swift
+++ b/test/IDE/complete_escaped_keyword.swift
@@ -65,11 +65,11 @@ enum MyEnum {
   func testInstance(val: MyEnum) {
     let _ = #^INSTANCE_PRIMARY^#
 // INSTANCE_PRIMARY: Begin completion
+// INSTANCE_PRIMARY-NOT: self[#Int#];
 // INSTANCE_PRIMARY-DAG: Decl[LocalVar]/Local:               self[#MyEnum#]; name=self
-// INSTANCE_PRIMARY-DAG: Decl[InstanceVar]/CurrNominal:      self[#Int#]; name=self
-// FIXME: ^ This is shadowed. We should hide this.
 // INSTANCE_PRIMARY-DAG: Decl[InstanceMethod]/CurrNominal:   `init`({#deinit: String#})[#Int#]; name=`init`(deinit:)
 // INSTANCE_PRIMARY-DAG: Decl[InstanceMethod]/CurrNominal:   `if`({#else: String#})[#Int#]; name=`if`(else:)
+// INSTANCE_PRIMARY-NOT: self[#Int#];
 // INSTANCE_PRIMARY: End completion
 
     let _ = self#^INSTANCE_SELF_NODOT^#

--- a/test/IDE/complete_in_accessors.swift
+++ b/test/IDE/complete_in_accessors.swift
@@ -345,8 +345,8 @@ func accessorsInFunction(_ functionParam: Int) {
 // ACCESSORS_IN_MEMBER_FUNC_2: Begin completions
 // ACCESSORS_IN_MEMBER_FUNC_2-DAG: Decl[LocalVar]/Local:            self[#AccessorsInMemberFunction#]
 // ACCESSORS_IN_MEMBER_FUNC_2-DAG: Decl[LocalVar]/Local{{(/TypeRelation\[Convertible\])?}}:            functionParam[#Int#]
-// ACCESSORS_IN_MEMBER_FUNC_2-DAG: Decl[InstanceVar]/OutNominal:    instanceVar[#Double#]
-// ACCESSORS_IN_MEMBER_FUNC_2-DAG: Decl[InstanceMethod]/OutNominal: instanceFunc({#(a): Int#})[#Float#]
+// ACCESSORS_IN_MEMBER_FUNC_2-DAG: Decl[InstanceVar]/CurrNominal:    instanceVar[#Double#]
+// ACCESSORS_IN_MEMBER_FUNC_2-DAG: Decl[InstanceMethod]/CurrNominal: instanceFunc({#(a): Int#})[#Float#]
 // ACCESSORS_IN_MEMBER_FUNC_2: End completions
 
 struct AccessorsInMemberFunction {

--- a/test/IDE/complete_member_decls_from_parent_decl_context.swift
+++ b/test/IDE/complete_member_decls_from_parent_decl_context.swift
@@ -237,6 +237,7 @@ struct NestedOuter1 {
       func aTestInstanceFunc() {
         #^NESTED_NOMINAL_DECL_A_1^#
 // NESTED_NOMINAL_DECL_A_1: Begin completions
+// NESTED_NOMINAL_DECL_A_1-NOT: self[#NestedOuter1#]
 // NESTED_NOMINAL_DECL_A_1-DAG: Decl[LocalVar]/Local:             self[#NestedInnerA#]{{; name=.+$}}
 // NESTED_NOMINAL_DECL_A_1-DAG: Decl[InstanceMethod]/CurrNominal: aTestInstanceFunc()[#Void#]{{; name=.+$}}
 // NESTED_NOMINAL_DECL_A_1-DAG: Decl[InstanceVar]/CurrNominal:    aInstanceVar[#Int#]{{; name=.+$}}
@@ -248,11 +249,11 @@ struct NestedOuter1 {
 // FIXME: should this really come as Local?
 // NESTED_NOMINAL_DECL_A_1-DAG: Decl[Struct]/Local:               NestedInnerA[#NestedInnerA#]{{; name=.+$}}
 // NESTED_NOMINAL_DECL_A_1-DAG: Decl[Struct]/CurrModule:          NestedOuter1[#NestedOuter1#]{{; name=.+$}}
-// FIXME: the following decls are wrong.
-// NESTED_NOMINAL_DECL_A_1-DAG: Decl[LocalVar]/Local:             self[#NestedOuter1#]{{; name=.+$}}
-// NESTED_NOMINAL_DECL_A_1-DAG: Decl[InstanceMethod]/OutNominal:  testInstanceFunc()[#Void#]{{; name=.+$}}
-// NESTED_NOMINAL_DECL_A_1-DAG: Decl[InstanceVar]/OutNominal:     outerInstanceVar[#Int#]{{; name=.+$}}
-// NESTED_NOMINAL_DECL_A_1-DAG: Decl[InstanceMethod]/OutNominal:  outerInstanceFunc()[#Void#]{{; name=.+$}}
+
+// NESTED_NOMINAL_DECL_A_1-NOT: self[#NestedOuter1#]
+// NESTED_NOMINAL_DECL_A_1-NOT: testInstanceFunc()
+// NESTED_NOMINAL_DECL_A_1-NOT: outerInstanceVar
+// NESTED_NOMINAL_DECL_A_1-NOT: outerInstanceFunc()
 // NESTED_NOMINAL_DECL_A_1: End completions
       }
       static func aTestStaticFunc() {
@@ -271,20 +272,20 @@ struct NestedOuter1 {
 // FIXME: should this really come as Local?
 // NESTED_NOMINAL_DECL_A_2-DAG: Decl[Struct]/Local:               NestedInnerA[#NestedInnerA#]{{; name=.+$}}
 // NESTED_NOMINAL_DECL_A_2-DAG: Decl[Struct]/CurrModule:          NestedOuter1[#NestedOuter1#]{{; name=.+$}}
-// FIXME: the following decls are wrong.
-// NESTED_NOMINAL_DECL_A_2-DAG: Decl[LocalVar]/Local:             self[#NestedOuter1#]{{; name=.+$}}
-// NESTED_NOMINAL_DECL_A_2-DAG: Decl[InstanceMethod]/OutNominal:  testInstanceFunc()[#Void#]{{; name=.+$}}
-// NESTED_NOMINAL_DECL_A_2-DAG: Decl[InstanceVar]/OutNominal:     outerInstanceVar[#Int#]{{; name=.+$}}
-// NESTED_NOMINAL_DECL_A_2-DAG: Decl[InstanceMethod]/OutNominal:  outerInstanceFunc()[#Void#]{{; name=.+$}}
+
+// NESTED_NOMINAL_DECL_A_2-NOT: self[#NestedOuter1#]
+// NESTED_NOMINAL_DECL_A_2-NOT: testInstanceFunc()
+// NESTED_NOMINAL_DECL_A_2-NOT: outerInstanceVar[#Int#]
+// NESTED_NOMINAL_DECL_A_2-NOT: outerInstanceFunc()
 // NESTED_NOMINAL_DECL_A_2: End completions
       }
 
       typealias ATestTypealias = #^NESTED_NOMINAL_DECL_A_3^#
 // NESTED_NOMINAL_DECL_A_3: Begin completions
-// NESTED_NOMINAL_DECL_A_3-DAG: Decl[Struct]/OutNominal:    NestedInnerAStruct[#NestedInnerAStruct#]{{; name=.+$}}
-// NESTED_NOMINAL_DECL_A_3-DAG: Decl[Class]/OutNominal:     NestedInnerAClass[#NestedInnerAClass#]{{; name=.+$}}
-// NESTED_NOMINAL_DECL_A_3-DAG: Decl[Enum]/OutNominal:      NestedInnerAEnum[#NestedInnerAEnum#]{{; name=.+$}}
-// NESTED_NOMINAL_DECL_A_3-DAG: Decl[TypeAlias]/OutNominal: NestedInnerATypealias[#Int#]{{; name=.+$}}
+// NESTED_NOMINAL_DECL_A_3-DAG: Decl[Struct]/CurrNominal:    NestedInnerAStruct[#NestedInnerAStruct#]{{; name=.+$}}
+// NESTED_NOMINAL_DECL_A_3-DAG: Decl[Class]/CurrNominal:     NestedInnerAClass[#NestedInnerAClass#]{{; name=.+$}}
+// NESTED_NOMINAL_DECL_A_3-DAG: Decl[Enum]/CurrNominal:      NestedInnerAEnum[#NestedInnerAEnum#]{{; name=.+$}}
+// NESTED_NOMINAL_DECL_A_3-DAG: Decl[TypeAlias]/CurrNominal: NestedInnerATypealias[#Int#]{{; name=.+$}}
 // FIXME: should this really come as Local?
 // NESTED_NOMINAL_DECL_A_3-DAG: Decl[Struct]/Local:          NestedInnerA[#NestedInnerA#]{{; name=.+$}}
 // NESTED_NOMINAL_DECL_A_3-DAG: Decl[TypeAlias]/OutNominal:  OuterTypealias[#Int#]{{; name=.+$}}
@@ -339,6 +340,7 @@ struct NestedOuter1 {
       func bTestInstanceFunc() {
         #^NESTED_NOMINAL_DECL_B_1^#
 // NESTED_NOMINAL_DECL_B_1: Begin completions
+// NESTED_NOMINAL_DECL_B_1-NOT: self[#NestedOuter1.Type#]
 // NESTED_NOMINAL_DECL_B_1-DAG: Decl[LocalVar]/Local:             self[#NestedInnerB#]{{; name=.+$}}
 // NESTED_NOMINAL_DECL_B_1-DAG: Decl[InstanceMethod]/CurrNominal: bTestInstanceFunc()[#Void#]{{; name=.+$}}
 // NESTED_NOMINAL_DECL_B_1-DAG: Decl[InstanceVar]/CurrNominal:    bInstanceVar[#Int#]{{; name=.+$}}
@@ -350,19 +352,21 @@ struct NestedOuter1 {
 // FIXME: should this really come as Local?
 // NESTED_NOMINAL_DECL_B_1-DAG: Decl[Struct]/Local:               NestedInnerB[#NestedInnerB#]{{; name=.+$}}
 // NESTED_NOMINAL_DECL_B_1-DAG: Decl[Struct]/CurrModule:          NestedOuter1[#NestedOuter1#]{{; name=.+$}}
-// FIXME: the following decls are wrong.
-// NESTED_NOMINAL_DECL_B_1-DAG: Decl[LocalVar]/Local:             self[#NestedOuter1.Type#]{{; name=.+$}}
-// NESTED_NOMINAL_DECL_B_1-DAG: Decl[InstanceMethod]/OutNominal:  testInstanceFunc()[#Void#]{{; name=.+$}}
-// NESTED_NOMINAL_DECL_B_1-DAG: Decl[StaticMethod]/OutNominal:    testStaticFunc()[#Void#]{{; name=.+$}}
-// NESTED_NOMINAL_DECL_B_1-DAG: Decl[InstanceMethod]/OutNominal:  outerInstanceFunc()[#Void#]{{; name=.+$}}
-// NESTED_NOMINAL_DECL_B_1-DAG: Decl[StaticVar]/OutNominal:       outerStaticVar[#Int#]{{; name=.+$}}
-// NESTED_NOMINAL_DECL_B_1-DAG: Decl[StaticMethod]/OutNominal:    outerStaticFunc()[#Void#]{{; name=.+$}}
 // NESTED_NOMINAL_DECL_B_1-DAG: Decl[TypeAlias]/OutNominal:       OuterTypealias[#Int#]{{; name=.+$}}
+
+// NESTED_NOMINAL_DECL_B_1-NOT: self[#NestedOuter1.Type#]
+// NESTED_NOMINAL_DECL_B_1-NOT: testInstanceFunc()
+// NESTED_NOMINAL_DECL_B_1-NOT: testStaticFunc()
+// NESTED_NOMINAL_DECL_B_1-NOT: outerInstanceFunc()
+// NESTED_NOMINAL_DECL_B_1-NOT: outerStaticVar
+// NESTED_NOMINAL_DECL_B_1-NOT: outerStaticFunc()
+
 // NESTED_NOMINAL_DECL_B_1: End completions
       }
       static func bTestStaticFunc() {
         #^NESTED_NOMINAL_DECL_B_2^#
 // NESTED_NOMINAL_DECL_B_2: Begin completions
+// NESTED_NOMINAL_DECL_B_2-NOT: self[#NestedOuter1.Type#]
 // NESTED_NOMINAL_DECL_B_2-DAG: Decl[LocalVar]/Local:             self[#NestedInnerB.Type#]{{; name=.+$}}
 // NESTED_NOMINAL_DECL_B_2-DAG: Decl[InstanceMethod]/CurrNominal: bTestInstanceFunc({#(self): &NestedInnerB#})[#() -> Void#]{{; name=.+$}}
 // NESTED_NOMINAL_DECL_B_2-DAG: Decl[StaticMethod]/CurrNominal:   bTestStaticFunc()[#Void#]{{; name=.+$}}
@@ -376,23 +380,24 @@ struct NestedOuter1 {
 // FIXME: should this really come as Local?
 // NESTED_NOMINAL_DECL_B_2-DAG: Decl[Struct]/Local:               NestedInnerB[#NestedInnerB#]{{; name=.+$}}
 // NESTED_NOMINAL_DECL_B_2-DAG: Decl[Struct]/CurrModule:          NestedOuter1[#NestedOuter1#]{{; name=.+$}}
-// FIXME: the following decls are wrong.
-// NESTED_NOMINAL_DECL_B_2-DAG: Decl[LocalVar]/Local:             self[#NestedOuter1.Type#]{{; name=.+$}}
-// NESTED_NOMINAL_DECL_B_2-DAG: Decl[InstanceMethod]/OutNominal:  testInstanceFunc()[#Void#]{{; name=.+$}}
+// NESTED_NOMINAL_DECL_B_2-DAG: Decl[TypeAlias]/OutNominal:       OuterTypealias[#Int#]{{; name=.+$}}
 // NESTED_NOMINAL_DECL_B_2-DAG: Decl[StaticMethod]/OutNominal:    testStaticFunc()[#Void#]{{; name=.+$}}
-// NESTED_NOMINAL_DECL_B_2-DAG: Decl[InstanceMethod]/OutNominal:  outerInstanceFunc()[#Void#]{{; name=.+$}}
 // NESTED_NOMINAL_DECL_B_2-DAG: Decl[StaticVar]/OutNominal:       outerStaticVar[#Int#]{{; name=.+$}}
 // NESTED_NOMINAL_DECL_B_2-DAG: Decl[StaticMethod]/OutNominal:    outerStaticFunc()[#Void#]{{; name=.+$}}
-// NESTED_NOMINAL_DECL_B_2-DAG: Decl[TypeAlias]/OutNominal:       OuterTypealias[#Int#]{{; name=.+$}}
+
+// NESTED_NOMINAL_DECL_B_2-NOT: self[#NestedOuter1.Type#]
+// NESTED_NOMINAL_DECL_B_2-NOT: testInstanceFunc()
+// NESTED_NOMINAL_DECL_B_2-NOT: outerInstanceFunc()
+
 // NESTED_NOMINAL_DECL_B_2: End completions
       }
 
       typealias BTestTypealias = #^NESTED_NOMINAL_DECL_B_3^#
 // NESTED_NOMINAL_DECL_B_3: Begin completions
-// NESTED_NOMINAL_DECL_B_3-DAG: Decl[Struct]/OutNominal:    NestedInnerBStruct[#NestedInnerBStruct#]{{; name=.+$}}
-// NESTED_NOMINAL_DECL_B_3-DAG: Decl[Class]/OutNominal:     NestedInnerBClass[#NestedInnerBClass#]{{; name=.+$}}
-// NESTED_NOMINAL_DECL_B_3-DAG: Decl[Enum]/OutNominal:      NestedInnerBEnum[#NestedInnerBEnum#]{{; name=.+$}}
-// NESTED_NOMINAL_DECL_B_3-DAG: Decl[TypeAlias]/OutNominal: NestedInnerBTypealias[#Int#]{{; name=.+$}}
+// NESTED_NOMINAL_DECL_B_3-DAG: Decl[Struct]/CurrNominal:    NestedInnerBStruct[#NestedInnerBStruct#]{{; name=.+$}}
+// NESTED_NOMINAL_DECL_B_3-DAG: Decl[Class]/CurrNominal:     NestedInnerBClass[#NestedInnerBClass#]{{; name=.+$}}
+// NESTED_NOMINAL_DECL_B_3-DAG: Decl[Enum]/CurrNominal:      NestedInnerBEnum[#NestedInnerBEnum#]{{; name=.+$}}
+// NESTED_NOMINAL_DECL_B_3-DAG: Decl[TypeAlias]/CurrNominal: NestedInnerBTypealias[#Int#]{{; name=.+$}}
 // FIXME: should this really come as Local?
 // NESTED_NOMINAL_DECL_B_3-DAG: Decl[Struct]/Local:          NestedInnerB[#NestedInnerB#]{{; name=.+$}}
 // NESTED_NOMINAL_DECL_B_3-DAG: Decl[TypeAlias]/OutNominal:  OuterTypealias[#Int#]{{; name=.+$}}
@@ -491,10 +496,10 @@ func testOuterC() {
 
     typealias CTestTypealias = #^NESTED_NOMINAL_DECL_C_3^#
 // NESTED_NOMINAL_DECL_C_3: Begin completions
-// NESTED_NOMINAL_DECL_C_3-DAG: Decl[Struct]/OutNominal:    NestedInnerCStruct[#NestedInnerCStruct#]{{; name=.+$}}
-// NESTED_NOMINAL_DECL_C_3-DAG: Decl[Class]/OutNominal:     NestedInnerCClass[#NestedInnerCClass#]{{; name=.+$}}
-// NESTED_NOMINAL_DECL_C_3-DAG: Decl[Enum]/OutNominal:      NestedInnerCEnum[#NestedInnerCEnum#]{{; name=.+$}}
-// NESTED_NOMINAL_DECL_C_3-DAG: Decl[TypeAlias]/OutNominal: NestedInnerCTypealias[#Int#]{{; name=.+$}}
+// NESTED_NOMINAL_DECL_C_3-DAG: Decl[Struct]/CurrNominal:   NestedInnerCStruct[#NestedInnerCStruct#]{{; name=.+$}}
+// NESTED_NOMINAL_DECL_C_3-DAG: Decl[Class]/CurrNominal:    NestedInnerCClass[#NestedInnerCClass#]{{; name=.+$}}
+// NESTED_NOMINAL_DECL_C_3-DAG: Decl[Enum]/CurrNominal:     NestedInnerCEnum[#NestedInnerCEnum#]{{; name=.+$}}
+// NESTED_NOMINAL_DECL_C_3-DAG: Decl[TypeAlias]/CurrNominal: NestedInnerCTypealias[#Int#]{{; name=.+$}}
 // FIXME: should this really come as Local?
 // NESTED_NOMINAL_DECL_C_3-DAG: Decl[Struct]/Local:          NestedInnerC[#NestedInnerC#]{{; name=.+$}}
 // NESTED_NOMINAL_DECL_C_3: End completions
@@ -547,17 +552,18 @@ func testOuterD() {
         }
         func dFunc3() {}
       }
-      func dFunc2() {}
+      func dFunc5() {}
     }
   }
 }
 // NESTED_NOMINAL_DECL_D_1: Begin completions
+// NESTED_NOMINAL_DECL_D_1-NOT: dFunc5()
 // NESTED_NOMINAL_DECL_D_1-DAG: Decl[LocalVar]/Local:             self[#Nested1.Nested2#]{{; name=.+$}}
 // NESTED_NOMINAL_DECL_D_1-DAG: Decl[FreeFunction]/Local:         dFunc4()[#Void#]{{; name=.+$}}
 // NESTED_NOMINAL_DECL_D_1-DAG: Decl[InstanceMethod]/CurrNominal: dFunc3()[#Void#]{{; name=.+$}}
 // NESTED_NOMINAL_DECL_D_1-DAG: Decl[FreeFunction]/Local:         dFunc2()[#Void#]{{; name=.+$}}
-// NESTED_NOMINAL_DECL_D_1-DAG: Decl[FreeFunction]/Local:         dFunc2()[#Void#]{{; name=.+$}}
 // NESTED_NOMINAL_DECL_D_1-DAG: Decl[FreeFunction]/Local:         dFunc1()[#Void#]{{; name=.+$}}
+// NESTED_NOMINAL_DECL_D_1-NOT: dFunc5()
 // NESTED_NOMINAL_DECL_D_1: End completions
 
 func testOuterE() {
@@ -576,19 +582,20 @@ func testOuterE() {
           }
           func dFunc3() {}
         }
-        func dFunc2() {}
+        func dFunc6() {}
       }
     } // end c2
   } // end c1
 }
 // NESTED_NOMINAL_DECL_E_1: Begin completions
+// NESTED_NOMINAL_DECL_E_1-NOT: dFunc6()
 // NESTED_NOMINAL_DECL_E_1-DAG: Decl[LocalVar]/Local:            self[#Nested1.Nested2#]{{; name=.+$}}
 // NESTED_NOMINAL_DECL_E_1-DAG: Decl[FreeFunction]/Local:        dFunc5()[#Void#]; name=dFunc5()
 // NESTED_NOMINAL_DECL_E_1-DAG: Decl[FreeFunction]/Local:        dFunc4()[#Void#]; name=dFunc4()
-// NESTED_NOMINAL_DECL_E_1-DAG: Decl[InstanceMethod]/OutNominal: dFunc3()[#Void#]; name=dFunc3()
-// NESTED_NOMINAL_DECL_E_1-DAG: Decl[InstanceMethod]/OutNominal: dFunc2()[#Void#]; name=dFunc2()
+// NESTED_NOMINAL_DECL_E_1-DAG: Decl[InstanceMethod]/CurrNominal: dFunc3()[#Void#]; name=dFunc3()
 // NESTED_NOMINAL_DECL_E_1-DAG: Decl[FreeFunction]/Local:        dFunc2()[#Void#]; name=dFunc2()
 // NESTED_NOMINAL_DECL_E_1-DAG: Decl[FreeFunction]/Local:        dFunc1()[#Void#]; name=dFunc1()
+// NESTED_NOMINAL_DECL_E_1-NOT: dFunc6()
 // NESTED_NOMINAL_DECL_E_1: End completions
 
 class SR627_BaseClass<T> {

--- a/test/IDE/complete_override.swift
+++ b/test/IDE/complete_override.swift
@@ -277,13 +277,13 @@ class OuterNominal : ProtocolA {
 class OuterNominal2: ProtocolA {
   var f = { #^NESTED_CLOSURE_1?keywords=false^# }()
 }
-// NESTED_CLOSURE_1-NOT: Decl{{.*}}/Super
+// NESTED_CLOSURE_1-NOT: Decl{{.*}}/Super: func
 // NESTED_CLOSURE_1-NOT: {|}
 
 class OuterNominal3: ProtocolA {
   var f = { static #^NESTED_CLOSURE_2?keywords=false^# }()
 }
-// NESTED_CLOSURE_2-NOT: Decl{{.*}}/Super
+// NESTED_CLOSURE_2-NOT: Decl{{.*}}/Super: func
 // NESTED_CLOSURE_2-NOT: {|}
 
 class OmitKW1 : ProtocolA {

--- a/test/IDE/complete_shadowing.swift
+++ b/test/IDE/complete_shadowing.swift
@@ -1,0 +1,292 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+
+// LOCAL_STRING_TESTVALUE-NOT: name=testValue
+// LOCAL_STRING_TESTVALUE:     Decl[LocalVar]/Local: testValue[#String#]; name=testValue
+// LOCAL_STRING_TESTVALUE-NOT: name=testValue
+
+// CURRNOMINAL_STRING_TESTVALUE-NOT: name=testValue
+// CURRNOMINAL_STRING_TESTVALUE:     Decl[InstanceVar]/CurrNominal: testValue[#String#]; name=testValue
+// CURRNOMINAL_STRING_TESTVALUE-NOT: name=testValue
+
+// CURRNOMINAL_STRING_TESTVALUE_STATIC-NOT: name=testValue
+// CURRNOMINAL_STRING_TESTVALUE_STATIC:     Decl[StaticVar]/CurrNominal: testValue[#String#]; name=testValue
+// CURRNOMINAL_STRING_TESTVALUE_STATIC-NOT: name=testValue
+
+// SUPER_STRING_TESTVALUE-NOT: name=testValue
+// SUPER_STRING_TESTVALUE:     Decl[InstanceVar]/Super: testValue[#String#]; name=testValue
+// SUPER_STRING_TESTVALUE-NOT: name=testValue
+
+// OUTNOMINAL_STRING_TESTVALUE_STATIC-NOT: name=testValue
+// OUTNOMINAL_STRING_TESTVALUE_STATIC:     Decl[StaticVar]/OutNominal: testValue[#String#]; name=testValue
+// OUTNOMINAL_STRING_TESTVALUE_STATIC-NOT: name=testValue
+  
+// GENERICPARAM_TESTVALUE-NOT: name=testValue
+// GENERICPARAM_TESTVALUE:  Decl[GenericTypeParam]/Local: testValue[#testValue#]; name=testValue
+// GENERICPARAM_TESTVALUE-NOT: name=testValue
+
+func test_Param_Local(testValue: Int) {
+  var testValue: String = ""
+  #^Param_Local?check=LOCAL_STRING_TESTVALUE^#
+}
+
+func test_Local_BindingIf(optStr: String?) {
+  var testValue: Int = 12
+  if let testValue = optStr {
+    #^Local_BindingIf?check=LOCAL_STRING_TESTVALUE^#
+  }
+}
+
+func test_Local_BindingGuard(optStr: String?) {
+  var testValue: Int = 12
+  guard var testValue = optStr else {
+    return
+  }
+  #^Local_BindingGuard?check=LOCAL_STRING_TESTVALUE^#
+}
+
+func test_Local_LocalDo() {
+  var testValue: Int = 12
+  do {
+    var testValue: String = ""
+    #^Local_LocalDo?check=LOCAL_STRING_TESTVALUE^#
+  }
+}
+
+func test_Local_LocalFunc() {
+  var testValue: Int = 12
+  func inner() {
+    var testValue: String = ""
+    #^Local_LocalFunc?check=LOCAL_STRING_TESTVALUE^#
+  }
+}
+
+func test_Local_Member() {
+  var testValue: Int = 12
+  struct Inner {
+    var testValue: String = ""
+    func test() {
+      #^Local_Member?check=CURRNOMINAL_STRING_TESTVALUE^#
+    }
+  }
+}
+
+protocol ProtoWithStringTestValueReq {
+  var testValue: String { get }
+}
+func test_Local_InheritedMemberProtoReq() {
+  var testValue: Int = 12
+  struct Inner: ProtoWithStringTestValueReq {
+    func test() {
+      #^Local_InheritedMemberProtoReq?check=SUPER_STRING_TESTVALUE^#
+    }
+  }
+}
+
+protocol ProtoWithStringTestValueExt {}
+extension ProtoWithStringTestValueExt {
+  var testValue: String { "" }
+}
+func test_Local_InheritedMemberProtoExt() {
+  var testValue: Int = 12
+  struct Inner: ProtoWithStringTestValueExt {
+    func test() {
+      #^Local_InheritedMemberProtoExt?check=SUPER_STRING_TESTVALUE^#
+    }
+  }
+}
+
+class ClassWithStringTestValue {
+  var testValue: String { "" }
+}
+func test_Local_InheritedMemberSuper() {
+  var testValue: Int = 12
+  class Inner: ClassWithStringTestValue {
+    func test() {
+      #^Local_InheritedMemberSuper?check=SUPER_STRING_TESTVALUE^#
+    }
+  }
+}
+
+struct test_Member_Local {
+  var testValue: Int = 12
+  func test() {
+    var testValue: String = ""
+    #^Member_Local?check=LOCAL_STRING_TESTVALUE^#
+  }
+}
+
+struct test_OutNominal_Member {
+  static var testValue: Int = 12
+  struct Inner {
+    static var testValue: String = ""
+    static func test() {
+      #^OutNominal_Member?check=CURRNOMINAL_STRING_TESTVALUE_STATIC^#
+    }
+  }
+}
+
+struct test_OutNominal_Local {
+  static var testValue: Int = 12
+  struct Inner {
+    static func test() {
+      var testValue: String = ""
+      #^OutNominal_Local?check=LOCAL_STRING_TESTVALUE^#
+    }
+  }
+}
+
+func test_Local_OutNominal() {
+  var testValue: Int = 12
+  struct Outer {
+    static var testValue: String = ""
+    struct Inner {
+      static func test() {
+        // FIXME: Currently any 'testValue' is not suggested. But since this is
+        // in 'static', 'Outer.testValue' is visible and usable.
+        // Note that the local 'testValue: Int' is not usable because struct
+        // decl cannot close over local values in outer scope.
+        #^Local_OutNominal?check=OUTNOMINAL_STRING_TESTVALUE_STATIC;xfail=rdar92479209^#
+      }
+    }
+  }
+}
+
+var globalTest: Int = 1
+func test_Global_Local() {
+  var globalTest: String = ""
+  #^Global_Local^#
+// FIXME: currently global varialbles are suggested despite they are shadowed.
+// Ideally they should be suggested with the qualification (i.e. 'ModuleName.globalTest')
+// Global_Local-DAG: Decl[LocalVar]/Local:               globalTest[#String#]; name=globalTest
+// Global_Local-DAG: Decl[GlobalVar]/CurrModule:         globalTest[#Int#]; name=globalTest
+}
+
+func test_GenericParam_Local<testValue>(_: testValue) {
+  var testValue: String = ""
+  // FIXME: The generic parameter is suggested because lookupVisibleDeclsImpl() reports it first.
+  #^GenericParam_Local?check=LOCAL_STRING_TESTVALUE;xfail=FIXME^#
+}
+
+func test_GenericParam_Param<testValue>(testValue: String, _: testValue) {
+  // FIXME: The generic parameter is suggested because lookupVisibleDeclsImpl() reports it first.
+  #^GenericParam_Param?check=LOCAL_STRING_TESTVALUE;xfail=FIXME^#
+}
+
+func test_GenericParam_LocalClosure<testValue>(_: testValue) {
+  _ =  {
+    var testValue: String = ""
+    #^GenericParam_LocalClosure?check=LOCAL_STRING_TESTVALUE^#
+  }
+}
+
+func test_Local_GenericParamType() {
+  var testValue: String = ""
+  struct S<testValue> {
+    var test = #^Local_GenericParamType?check=GENERICPARAM_TESTVALUE^#
+  }
+}
+
+func test_Local_GenericParamType() {
+  var testValue: String = ""
+  func test<testValue>(_: testValue) {
+    #^Local_GenericParam?check=GENERICPARAM_TESTVALUE^#
+  }
+}
+
+func test_LocalFunc_LocalVar() {
+  func testValue(arg: Int) {}
+  var testValue: String = ""
+  #^LocalFunc_LocalVar^#
+// LocalFunc_LocalVar-NOT: name=testValue
+// LocalFunc_LocalVar-DAG: Decl[FreeFunction]/Local:           testValue({#arg: Int#})[#Void#]; name=testValue(arg:)
+// LocalFunc_LocalVar-DAG: Decl[LocalVar]/Local:               testValue[#String#]; name=testValue
+// LocalFunc_LocalVar-NOT: name=testValue
+}
+
+func test_LocalFunc_LocalVarDo() {
+  func testValue(arg: Int) {}
+  do {
+    var testValue: String = ""
+    #^LocalFunc_LocalVarDo?check=LOCAL_STRING_TESTVALUE^#
+  }
+}
+
+func test_LocalVar_LocalFuncDo() {
+  var testValue: String = ""
+  do {
+    func testValue(arg: Int) {}
+    #^LocalVar_LocalFuncDo^#
+// FIXME: 'var testValue' is actually shadowed and not usable. 'Decl[LocalVar]/Local: testValue[#String#]' should not be suggested.
+// LocalVar_LocalFuncDo-NOT: name=testValue
+// LocalVar_LocalFuncDo-DAG: Decl[FreeFunction]/Local:           testValue({#arg: Int#})[#Void#]; name=testValue(arg:)
+// LocalVar_LocalFuncDo-DAG: Decl[LocalVar]/Local:               testValue[#String#]; name=testValue
+// LocalVar_LocalFuncDo-NOT: name=testValue
+  }
+}
+
+struct test_Member_Member {
+  var testValue: String = ""
+  func testValue(arg: String) {}
+
+  func test() {
+    #^Member_Member^#
+// Member_Member-NOT: name=testValue
+// Member_Member-DAG: Decl[InstanceVar]/CurrNominal:      testValue[#String#]; name=testValue
+// Member_Member-DAG: Decl[InstanceMethod]/CurrNominal:   testValue({#arg: String#})[#Void#]; name=testValue(arg:)
+// Member_Member-NOT: name=testValue
+  }
+}
+
+protocol ProtoWithIntTestValueReq {
+  var testValue: Int { get }
+}
+struct test_InheritedMemberProtoReq_Member: ProtoWithIntTestValueReq {
+  var testValue: String = ""
+
+  func test() {
+    #^InheritedMemberProtoReq_Member?check=CURRNOMINAL_STRING_TESTVALUE^#
+  }
+}
+
+protocol ProtoWithIntTestValueExt {}
+extension ProtoWithIntTestValueExt {
+  var testValue: Int { 1 }
+}
+struct test_InheritedMemberProtoExt_Member: ProtoWithIntTestValueExt {
+  var testValue: String = ""
+
+  func test() {
+    #^InheritedMemberProtoExt_Member^#
+// InheritedMemberProtoExt_Member-NOT: name=testValue
+// InheritedMemberProtoExt_Member-DAG: Decl[InstanceVar]/CurrNominal:      testValue[#String#]; name=testValue
+// InheritedMemberProtoExt_Member-DAG: Decl[InstanceVar]/Super:            testValue[#Int#]; name=testValue
+// InheritedMemberProtoExt_Member-NOT: name=testValue
+  }
+}
+
+protocol ClassWitnIntTestValue {
+  var testValue: Int { 1 }
+}
+struct test_InheritedMemberSuper_Member: ClassWithIntTestValue {
+  var testValue: String = ""
+
+  func test() {
+    #^InheritedMemberSuper?check=CURRNOMINAL_STRING_TESTVALUE^#
+  }
+}
+
+func test_LocalTy_OutNominalTy() {
+  struct testValue {} // Local
+  struct Outer {
+    class testValue {} // OutNominal
+    struct Inner {
+      func test() {
+        #^LocalTy_OutNominalTy^#
+// LocalTy_OutNominalTy-NOT: name=testValue
+// LocalTy_OutNominalTy-DAG: Decl[Class]/OutNominal: testValue[#Outer.testValue#]; name=testValue
+// LocalTy_OutNominalTy-NOT: name=testValue
+      }
+    }
+  }
+}

--- a/test/IDE/complete_single_expression_return.swift
+++ b/test/IDE/complete_single_expression_return.swift
@@ -137,9 +137,9 @@ struct TestSingleExprClosureGlobal {
     }()
   }
 // TestSingleExprClosureGlobal: Begin completions
-// TestSingleExprClosureGlobal-DAG: Decl[InstanceMethod]/OutNominal:   str()[#String#];
-// TestSingleExprClosureGlobal-DAG: Decl[InstanceMethod]/OutNominal/TypeRelation[Convertible]: int()[#Int#];
-// TestSingleExprClosureGlobal-DAG: Decl[InstanceMethod]/OutNominal: void()[#Void#];
+// TestSingleExprClosureGlobal-DAG: Decl[InstanceMethod]/CurrNominal:   str()[#String#];
+// TestSingleExprClosureGlobal-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: int()[#Int#];
+// TestSingleExprClosureGlobal-DAG: Decl[InstanceMethod]/CurrNominal: void()[#Void#];
 // TestSingleExprClosureGlobal: End completions
 }
 
@@ -155,9 +155,9 @@ struct TestNonSingleExprClosureGlobal {
     }()
   }
 // TestNonSingleExprClosureGlobal: Begin completions
-// TestNonSingleExprClosureGlobal-DAG: Decl[InstanceMethod]/OutNominal: str()[#String#];
-// TestNonSingleExprClosureGlobal-DAG: Decl[InstanceMethod]/OutNominal: int()[#Int#];
-// TestNonSingleExprClosureGlobal-DAG: Decl[InstanceMethod]/OutNominal: void()[#Void#];
+// TestNonSingleExprClosureGlobal-DAG: Decl[InstanceMethod]/CurrNominal: str()[#String#];
+// TestNonSingleExprClosureGlobal-DAG: Decl[InstanceMethod]/CurrNominal: int()[#Int#];
+// TestNonSingleExprClosureGlobal-DAG: Decl[InstanceMethod]/CurrNominal: void()[#Void#];
 // TestNonSingleExprClosureGlobal: End completions
 }
 

--- a/test/Parse/switch.swift
+++ b/test/Parse/switch.swift
@@ -246,7 +246,7 @@ case (1, _):
 func patternVarUsedInAnotherPattern(x: Int) {
   switch x {
   case let a, // expected-error {{'a' must be bound in every pattern}}
-       a: // expected-error {{cannot find 'a' in scope}}
+       value: // expected-error {{cannot find 'value' in scope}}
     break
   }
 }

--- a/test/Sema/typo_correction.swift
+++ b/test/Sema/typo_correction.swift
@@ -100,10 +100,9 @@ func takesSomeClassArchetype<T : SomeClass>(_ t: T) {
 }
 
 // Typo correction of unqualified lookup from generic context.
+func match1() {}
+// expected-note@-1 {{'match1' declared here}}
 struct Generic<T> { // expected-note {{'T' declared as parameter to type 'Generic'}}
-  func match1() {}
-  // expected-note@-1 {{'match1' declared here}}
-
   class Inner {
     func doStuff() {
       match0()
@@ -119,8 +118,6 @@ protocol P { // expected-note {{'P' previously declared here}}
 }
 
 protocol P {} // expected-error {{invalid redeclaration of 'P'}}
-// expected-note@-1 2{{did you mean 'P'?}}
-// expected-note@-2 {{'P' declared here}}
 
 func hasTypo() {
   _ = P.a.a // expected-error {{type 'Generic<T>' has no member 'a'}}
@@ -143,7 +140,7 @@ enum Foo {
   case flashing // expected-note {{'flashing' declared here}}
 }
 
-func foo(_ a: Foo) { // expected-note {{'foo' declared here}}
+func foo(_ a: Foo) {
 }
 
 func bar() {

--- a/test/SourceKit/CodeComplete/complete_popular_api.swift
+++ b/test/SourceKit/CodeComplete/complete_popular_api.swift
@@ -83,7 +83,6 @@ struct OuterNominal {
 // POPULAR_STMT_0:   DDModuleColor
 // POPULAR_STMT_0:   EEModuleColor
 // POPULAR_STMT_0:   CCModuleColor
-// POPULAR_STMT_0:   fromOuterNominalColor
 // POPULAR_STMT_0:   globalColor
 // POPULAR_STMT_0:   okay()
 // POPULAR_STMT_0:   ModuleCollaborate
@@ -97,7 +96,6 @@ struct OuterNominal {
 // POPULAR_STMT_0:   DDModuleColor
 // POPULAR_STMT_0:   EEModuleColor
 // POPULAR_STMT_0:   CCModuleColor
-// POPULAR_STMT_0:   fromOuterNominalColor
 // POPULAR_STMT_0:   globalColor
 // POPULAR_STMT_0:   ModuleCollaborate
 // POPULAR_STMT_0:   BBModuleColor

--- a/test/decl/func/local-function-overload.swift
+++ b/test/decl/func/local-function-overload.swift
@@ -40,11 +40,9 @@ func invalid2() {
   func inner(_: String) {}
   // expected-note@-1 {{candidate expects value of type 'String' for parameter #1}}
   // expected-note@-2 {{found this candidate}}
-  // expected-note@-3 {{did you mean 'inner'?}}
 
   func inner(label: Int) {}
   // expected-note@-1 {{found this candidate}}
-  // expected-note@-2 {{did you mean 'inner'?}}
 
   inner([])
   // expected-error@-1 {{no exact matches in call to local function 'inner'}}

--- a/test/decl/var/static_var.swift
+++ b/test/decl/var/static_var.swift
@@ -287,10 +287,10 @@ extension ProtoAdopter : ProtosEvilTwin {}
 
 // rdar://18990358
 public struct Foo { // expected-note {{to match this opening '{'}}}
-  public static let S { _ = 0; a // expected-error{{computed property must have an explicit type}} {{22-22=: <# Type #>}}
+  public static let S { _ = 0; aaaaaa // expected-error{{computed property must have an explicit type}} {{22-22=: <# Type #>}}
     // expected-error@-1{{type annotation missing in pattern}}
     // expected-error@-2{{'let' declarations cannot be computed properties}} {{17-20=var}}
-    // expected-error@-3{{cannot find 'a' in scope}}
+    // expected-error@-3{{cannot find 'aaaaaa' in scope}}
 }
 
 // expected-error@+1 {{expected '}' in struct}}


### PR DESCRIPTION
```swift
func test(value: String?) {
  var value = value

  if let value = value {
    <HERE>
  }
}
```
Code completion used to suggest 3 'value's (parameter, `var value: String?`, and `let value: String`). But since only the inner most `let value: String` is usable, code completion only should suggest it.

Tweaked the "usable" check:
  * Local type/func decls are usable even before declaration
  * Outer nominal Instance member are not usable
  * Type context cannot close over values in outer type contexts

Added shadowing rule by the base name:
  * Type members don't shadow each other as long as they are in the
    same type context.
  * Local values shadow everything in outer scope
    * Except that 'func' decl doesn't shadow 'var' decl if they are in the
      same scope.

Even after this PR, global values are always suggested because they are collected by different mechanism.

rdar://86285396