### PR TITLE
[stdlib] Port SE-0329 Clock APIs to WASI

### DIFF
--- a/stdlib/public/Concurrency/Clock.cpp
+++ b/stdlib/public/Concurrency/Clock.cpp
@@ -42,7 +42,7 @@ void swift_get_time(
       clock_gettime(CLOCK_MONOTONIC_RAW, &continuous);
       *seconds = continuous.tv_sec;
       *nanoseconds = continuous.tv_nsec;
-#elif defined(__OpenBSD__) && HAS_TIME
+#elif (defined(__OpenBSD__) || defined(__wasi__)) && HAS_TIME
       struct timespec continuous;
       clock_gettime(CLOCK_MONOTONIC, &continuous);
       *seconds = continuous.tv_sec;
@@ -74,6 +74,11 @@ void swift_get_time(
 #elif defined(__APPLE__) && HAS_TIME
       struct timespec suspending;
       clock_gettime(CLOCK_UPTIME_RAW, &suspending);
+      *seconds = suspending.tv_sec;
+      *nanoseconds = suspending.tv_nsec;
+#elif defined(__wasi__) && HAS_TIME
+      struct timespec suspending;
+      clock_gettime(CLOCK_MONOTONIC, &suspending);
       *seconds = suspending.tv_sec;
       *nanoseconds = suspending.tv_nsec;
 #elif defined(__OpenBSD__) && HAS_TIME
@@ -121,7 +126,7 @@ switch (clock_id) {
       clock_getres(CLOCK_MONOTONIC_RAW, &continuous);
       *seconds = continuous.tv_sec;
       *nanoseconds = continuous.tv_nsec;
-#elif defined(__OpenBSD__) && HAS_TIME
+#elif (defined(__OpenBSD__) || defined(__wasi__)) && HAS_TIME
       struct timespec continuous;
       clock_getres(CLOCK_MONOTONIC, &continuous);
       *seconds = continuous.tv_sec;
@@ -142,6 +147,10 @@ switch (clock_id) {
       *nanoseconds = suspending.tv_nsec;
 #elif defined(__APPLE__) && HAS_TIME
       clock_getres(CLOCK_UPTIME_RAW, &suspending);
+      *seconds = suspending.tv_sec;
+      *nanoseconds = suspending.tv_nsec;
+#elif defined(__wasi__) && HAS_TIME
+      clock_getres(CLOCK_MONOTONIC, &suspending);
       *seconds = suspending.tv_sec;
       *nanoseconds = suspending.tv_nsec;
 #elif defined(__OpenBSD__) && HAS_TIME


### PR DESCRIPTION
WASI doesn't have "suspending-time" concept yet, so use `CLOCK_MONOTONIC`
for both "continuous" and "suspending" clocks. WASI's "monotonic"
doesn't guarantee any underlying system call implementation, but most
of major implementations use `CLOCK_MONOTONIC` for all underlying
platforms.

This partially buildfixes this platform.

See also: https://github.com/WebAssembly/WASI/blob/main/phases/snapshot/docs.md#variant-cases

