### PR TITLE
[CodeCompletion] Avoid creating circles in the USRBasedType supertype hierarchy

### DIFF
--- a/validation-test/IDE/crashers_2_fixed/rdar91765262.swift
+++ b/validation-test/IDE/crashers_2_fixed/rdar91765262.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/ImportPath)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swift-frontend -disable-availability-checking -emit-module %t/Lib.swift -o %t/ImportPath/Lib.swiftmodule -emit-module-interface-path %t/ImportPath/Lib.swiftinterface
+
+// BEGIN Lib.swift
+
+// Proto and Class have a circular supertype relationship.
+
+public protocol Proto : Class {}
+public class Class : Proto {}
+
+// BEGIN test.swift
+
+import Lib
+
+// RUN: %empty-directory(%t/completion-cache)
+// RUN: %target-swift-ide-test -code-completion -source-filename %t/test.swift -code-completion-token COMPLETE -I %t/ImportPath
+
+func test() -> Proto {
+  return #^COMPLETE^#
+}


### PR DESCRIPTION
You would think that superclass + conformances form a DAG. You are wrong!
We can achieve a circular supertype hierarcy with

```swift
protocol Proto : Class {}
class Class : Proto {}
```

USRBasedType is not set up for this. Serialization of code completion results from global modules can't handle cycles in the supertype hierarchy
because it writes the DAG leaf to root(s) and needs to know the type offsets. To get consistent results independent of where we start
constructing USRBasedTypes, ignore superclasses of protocols. If we kept track of already visited types, we would get different results depending on
whether we start constructing the USRBasedType hierarchy from Proto or Class.
Ignoring superclasses of protocols is safe to do because USRBasedType is an under-approximation anyway.

rdar://91765262