### PR TITLE
[Sema] Don't warn on trailing closures in closure conditions

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3740,6 +3740,7 @@ static void checkStmtConditionTrailingClosure(ASTContext &ctx, const Expr *E) {
       case ExprKind::Array:
       case ExprKind::Dictionary:
       case ExprKind::InterpolatedStringLiteral:
+      case ExprKind::Closure:
         // If a trailing closure appears as a child of one of these types of
         // expression, don't diagnose it as there is no ambiguity.
         return {E->isImplicit(), E};

--- a/test/expr/closure/trailing.swift
+++ b/test/expr/closure/trailing.swift
@@ -475,3 +475,13 @@ func rdar85343171() {
   // Okay, as trailing closure is nested in argument list.
   if foo(bar {}) {}
 }
+
+// rdar://92521618 - Spurious warning on trailing closure nested within a
+// closure initializer.
+
+func rdar92521618() {
+  func foo(_ fn: () -> Void) -> Int? { 0 }
+
+  if let _ = { foo {} }() {}
+  guard let _ = { foo {} }() else { return }
+}


### PR DESCRIPTION
Add ClosureExpr to the list of expressions we don't walk into for the purposes of diagnosing trailing closures in conditional initializers.

rdar://92521618