### PR TITLE
Add a flag `-enable-default-cmo` to enable default cross-module-optimization.

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -66,6 +66,12 @@ enum class DestroyHoistingOption : uint8_t {
   On = 1
 };
 
+enum class CrossModuleOptimizationMode : uint8_t {
+  Off = 0,
+  Default = 1,
+  Aggressive = 2
+};
+
 class SILModule;
 
 class SILOptions {
@@ -117,7 +123,7 @@ public:
   bool DisableSILPerfOptimizations = false;
 
   /// Controls whether cross module optimization is enabled.
-  bool CrossModuleOptimization = false;
+  CrossModuleOptimizationMode CMOMode = CrossModuleOptimizationMode::Off;
 
   /// Enables experimental performance annotations.
   bool EnablePerformanceAnnotations = false;

--- a/include/swift/AST/TBDGenRequests.h
+++ b/include/swift/AST/TBDGenRequests.h
@@ -50,13 +50,8 @@ class TBDGenDescriptor final {
   FileOrModule Input;
   TBDGenOptions Opts;
 
-  /// Symbols (e.g. function names) which are made public by the
-  /// CrossModuleOptimization pass and therefore must be included in the TBD file.
-  TBDSymbolSetPtr publicCMOSymbols;
-
-  TBDGenDescriptor(FileOrModule input, const TBDGenOptions &opts,
-                   TBDSymbolSetPtr publicCMOSymbols)
-      : Input(input), Opts(opts), publicCMOSymbols(publicCMOSymbols) {
+  TBDGenDescriptor(FileOrModule input, const TBDGenOptions &opts)
+      : Input(input), Opts(opts) {
     assert(input);
   }
 
@@ -78,21 +73,17 @@ public:
   const StringRef getDataLayoutString() const;
   const llvm::Triple &getTarget() const;
 
-  TBDSymbolSetPtr getPublicCMOSymbols() const { return publicCMOSymbols; }
-
   bool operator==(const TBDGenDescriptor &other) const;
   bool operator!=(const TBDGenDescriptor &other) const {
     return !(*this == other);
   }
 
-  static TBDGenDescriptor forFile(FileUnit *file, const TBDGenOptions &opts,
-                                  TBDSymbolSetPtr publicCMOSymbols) {
-    return TBDGenDescriptor(file, opts, publicCMOSymbols);
+  static TBDGenDescriptor forFile(FileUnit *file, const TBDGenOptions &opts) {
+    return TBDGenDescriptor(file, opts);
   }
 
-  static TBDGenDescriptor forModule(ModuleDecl *M, const TBDGenOptions &opts,
-                                    TBDSymbolSetPtr publicCMOSymbols) {
-    return TBDGenDescriptor(M, opts, publicCMOSymbols);
+  static TBDGenDescriptor forModule(ModuleDecl *M, const TBDGenOptions &opts) {
+    return TBDGenDescriptor(M, opts);
   }
 };
 
@@ -163,9 +154,6 @@ public:
     /// A symbol used to customize linker behavior, introduced by TBDGen.
     LinkerDirective,
 
-    /// A symbol which was made public by the CrossModuleOptimization pass.
-    CrossModuleOptimization,
-
     /// A symbol with an unknown origin.
     // FIXME: This should be eliminated.
     Unknown
@@ -185,8 +173,7 @@ private:
     irEntity = entity;
   }
   explicit SymbolSource(Kind kind) : kind(kind) {
-    assert(kind == Kind::LinkerDirective || kind == Kind::Unknown ||
-           kind == Kind::CrossModuleOptimization);
+    assert(kind == Kind::LinkerDirective || kind == Kind::Unknown);
   }
 
 public:
@@ -199,19 +186,12 @@ public:
   static SymbolSource forLinkerDirective() {
     return SymbolSource{Kind::LinkerDirective};
   }
-  static SymbolSource forCrossModuleOptimization() {
-    return SymbolSource{Kind::CrossModuleOptimization};
-  }
   static SymbolSource forUnknown() {
     return SymbolSource{Kind::Unknown};
   }
 
   bool isLinkerDirective() const {
     return kind == Kind::LinkerDirective;
-  }
-
-  bool isFromCrossModuleOptimization() const {
-    return kind == Kind::CrossModuleOptimization;
   }
 
   SILDeclRef getSILDeclRef() const {

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -436,7 +436,6 @@ class CompilerInstance {
   std::unique_ptr<ASTContext> Context;
   std::unique_ptr<Lowering::TypeConverter> TheSILTypes;
   std::unique_ptr<DiagnosticVerifier> DiagVerifier;
-  TBDSymbolSetPtr publicCMOSymbols;
 
   /// A cache describing the set of inter-module dependencies that have been queried.
   /// Null if not present.
@@ -587,10 +586,6 @@ public:
   /// If a code completion buffer has been set, returns the corresponding source
   /// file.
   SourceFile *getCodeCompletionFile() const;
-
-  /// Return the symbols (e.g. function names) which are made public by the
-  /// CrossModuleOptimization pass and therefore must be included in the TBD file.
-  TBDSymbolSetPtr getPublicCMOSymbols() const { return publicCMOSymbols; }
 
 private:
   /// Set up the file system by loading and validating all VFS overlay YAML

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -812,6 +812,10 @@ def Oplayground : Flag<["-"], "Oplayground">, Group<O_Group>,
   Flags<[HelpHidden, FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Compile with optimizations appropriate for a playground">;
 
+def EnbaleDefaultCMO : Flag<["-"], "enable-default-cmo">,
+  Flags<[HelpHidden, FrontendOption]>,
+  HelpText<"Perform conservative cross-module optimization">;
+
 def CrossModuleOptimization : Flag<["-"], "cross-module-optimization">,
   Flags<[HelpHidden, FrontendOption]>,
   HelpText<"Perform cross-module optimization">;

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -38,7 +38,6 @@
 #include "swift/SIL/SILVTable.h"
 #include "swift/SIL/SILWitnessTable.h"
 #include "swift/SIL/TypeLowering.h"
-#include "swift/TBDGen/TBDGen.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/FoldingSet.h"
 #include "llvm/ADT/MapVector.h"
@@ -387,10 +386,6 @@ private:
 
   /// Folding set for key path patterns.
   llvm::FoldingSet<KeyPathPattern> KeyPathPatterns;
-  
-  /// Symbols (e.g. function names) which are made public by the
-  /// CrossModuleOptimization pass and therefore must be included in the TBD file.
-  TBDSymbolSetPtr publicCMOSymbols;
 
 public:
   ~SILModule();
@@ -559,12 +554,6 @@ public:
   bool isOptimizedOnoneSupportModule() const;
 
   const SILOptions &getOptions() const { return Options; }
-
-  /// Return the symbols (e.g. function names) which are made public by the
-  /// CrossModuleOptimization pass and therefore must be included in the TBD file.
-  TBDSymbolSetPtr getPublicCMOSymbols() { return publicCMOSymbols; }
-
-  void addPublicCMOSymbol(StringRef symbol);
 
   using iterator = FunctionListType::iterator;
   using const_iterator = FunctionListType::const_iterator;

--- a/include/swift/TBDGen/TBDGen.h
+++ b/include/swift/TBDGen/TBDGen.h
@@ -16,9 +16,6 @@
 #include "llvm/ADT/StringSet.h"
 #include "swift/Basic/Version.h"
 #include <vector>
-#include <set>
-#include <string>
-#include <memory>
 
 namespace llvm {
 class raw_ostream;
@@ -107,26 +104,12 @@ struct TBDGenOptions {
   }
 };
 
-/// Used for symbols which are made public by the CrossModuleOptimization pass
-/// and therefore must be included in the TBD file.
-///
-/// We cannot use llvm::StringSet, because we need deterministic iteration order.
-using TBDSymbolSet = std::set<std::string>;
-
-/// A pointer to TBDSymbolSet.
-///
-/// Do reference counting for memory management.
-/// This set is created in the optimizer and primarily stored in the SILModule.
-/// But then they need to be kept alive beyond the lifetime of the SILModule.
-using TBDSymbolSetPtr = std::shared_ptr<TBDSymbolSet>;
-
 std::vector<std::string> getPublicSymbols(TBDGenDescriptor desc);
 
 void writeTBDFile(ModuleDecl *M, llvm::raw_ostream &os,
-                  const TBDGenOptions &opts, TBDSymbolSetPtr publicCMOSymbols);
+                  const TBDGenOptions &opts);
 
-void writeAPIJSONFile(ModuleDecl *M, llvm::raw_ostream &os, bool PrettyPrint,
-                      TBDSymbolSetPtr publicCMOSymbols);
+void writeAPIJSONFile(ModuleDecl *M, llvm::raw_ostream &os, bool PrettyPrint);
 
 } // end namespace swift
 

--- a/lib/DriverTool/swift_api_extract_main.cpp
+++ b/lib/DriverTool/swift_api_extract_main.cpp
@@ -215,7 +215,7 @@ public:
       return 1;
 
     if (OutputFilename == "-") {
-      writeAPIJSONFile(M, llvm::outs(), PrettyPrint, nullptr);
+      writeAPIJSONFile(M, llvm::outs(), PrettyPrint);
       return 0;
     }
 
@@ -227,7 +227,7 @@ public:
       return 1;
     }
 
-    writeAPIJSONFile(M, OS, PrettyPrint, nullptr);
+    writeAPIJSONFile(M, OS, PrettyPrint);
     return 0;
   }
 };

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1745,7 +1745,11 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
       OPT_enable_actor_data_race_checks,
       OPT_disable_actor_data_race_checks, /*default=*/false);
   Opts.DisableSILPerfOptimizations |= Args.hasArg(OPT_disable_sil_perf_optzns);
-  Opts.CrossModuleOptimization |= Args.hasArg(OPT_CrossModuleOptimization);
+  if (Args.hasArg(OPT_CrossModuleOptimization)) {
+    Opts.CMOMode = CrossModuleOptimizationMode::Aggressive;
+  } else if (Args.hasArg(OPT_EnbaleDefaultCMO)) {
+    Opts.CMOMode = CrossModuleOptimizationMode::Default;  
+  }
   Opts.EnablePerformanceAnnotations |=
       Args.hasArg(OPT_ExperimentalPerformanceAnnotations);
   Opts.VerifyAll |= Args.hasArg(OPT_sil_verify_all);

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1330,8 +1330,6 @@ bool CompilerInstance::performSILProcessing(SILModule *silModule) {
 
   performSILOptimizations(Invocation, silModule);
 
-  publicCMOSymbols = silModule->getPublicCMOSymbols();
-
   if (auto *stats = getStatsReporter())
     countStatsPostSILOpt(*stats, *silModule);
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -702,7 +702,8 @@ static bool writeTBDIfNeeded(CompilerInstance &Instance) {
     return false;
   }
 
-  if (Invocation.getSILOptions().CrossModuleOptimization) {
+  if (Invocation.getSILOptions().CMOMode ==
+      CrossModuleOptimizationMode::Aggressive) {
     Instance.getDiags().diagnose(SourceLoc(),
                                  diag::tbd_not_supported_with_cmo);
     return false;
@@ -1406,7 +1407,7 @@ static bool validateTBDIfNeeded(const CompilerInvocation &Invocation,
     }
 
     // Cross-module optimization does not support TBD.
-    if (Invocation.getSILOptions().CrossModuleOptimization) {
+    if (Invocation.getSILOptions().CMOMode == CrossModuleOptimizationMode::Aggressive) {
       return false;
     }
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -702,10 +702,15 @@ static bool writeTBDIfNeeded(CompilerInstance &Instance) {
     return false;
   }
 
+  if (Invocation.getSILOptions().CrossModuleOptimization) {
+    Instance.getDiags().diagnose(SourceLoc(),
+                                 diag::tbd_not_supported_with_cmo);
+    return false;
+  }
+
   const std::string &TBDPath = Invocation.getTBDPathForWholeModule();
 
-  return writeTBD(Instance.getMainModule(), TBDPath, tbdOpts,
-                  Instance.getPublicCMOSymbols());
+  return writeTBD(Instance.getMainModule(), TBDPath, tbdOpts);
 }
 
 static bool performCompileStepsPostSILGen(CompilerInstance &Instance,
@@ -1392,16 +1397,16 @@ static bool processCommandLineAndRunImmediately(CompilerInstance &Instance,
 
 static bool validateTBDIfNeeded(const CompilerInvocation &Invocation,
                                 ModuleOrSourceFile MSF,
-                                const llvm::Module &IRModule,
-                                TBDSymbolSetPtr publicCMOSymbols) {
-  auto mode = Invocation.getFrontendOptions().ValidateTBDAgainstIR;
-  if (mode == FrontendOptions::TBDValidationMode::All &&
-      Invocation.getSILOptions().CrossModuleOptimization)
-    mode = FrontendOptions::TBDValidationMode::MissingFromTBD;
-
+                                const llvm::Module &IRModule) {
+  const auto mode = Invocation.getFrontendOptions().ValidateTBDAgainstIR;
   const bool canPerformTBDValidation = [&]() {
     // If the user has requested we skip validation, honor it.
     if (mode == FrontendOptions::TBDValidationMode::None) {
+      return false;
+    }
+
+    // Cross-module optimization does not support TBD.
+    if (Invocation.getSILOptions().CrossModuleOptimization) {
       return false;
     }
 
@@ -1465,10 +1470,9 @@ static bool validateTBDIfNeeded(const CompilerInvocation &Invocation,
   // noise from e.g. statically-linked libraries.
   Opts.embedSymbolsFromModules.clear();
   if (auto *SF = MSF.dyn_cast<SourceFile *>()) {
-    return validateTBD(SF, IRModule, Opts, publicCMOSymbols,
-                       diagnoseExtraSymbolsInTBD);
+    return validateTBD(SF, IRModule, Opts, diagnoseExtraSymbolsInTBD);
   } else {
-    return validateTBD(MSF.get<ModuleDecl *>(), IRModule, Opts, publicCMOSymbols,
+    return validateTBD(MSF.get<ModuleDecl *>(), IRModule, Opts,
                        diagnoseExtraSymbolsInTBD);
   }
 }
@@ -1681,8 +1685,6 @@ static bool performCompileStepsPostSILGen(CompilerInstance &Instance,
     return processCommandLineAndRunImmediately(
         Instance, std::move(SM), MSF, observer, ReturnValue);
 
-  TBDSymbolSetPtr publicCMOSymbols = SM->getPublicCMOSymbols();
-
   StringRef OutputFilename = PSPs.OutputFilename;
   std::vector<std::string> ParallelOutputFilenames =
       opts.InputsAndOutputs.copyOutputFilenames();
@@ -1701,8 +1703,7 @@ static bool performCompileStepsPostSILGen(CompilerInstance &Instance,
   if (!IRModule)
     return Instance.getDiags().hadAnyError();
 
-  if (validateTBDIfNeeded(Invocation, MSF, *IRModule.getModule(),
-                          publicCMOSymbols))
+  if (validateTBDIfNeeded(Invocation, MSF, *IRModule.getModule()))
     return true;
 
   return generateCode(Instance, OutputFilename, IRModule.getModule(),

--- a/lib/FrontendTool/TBD.cpp
+++ b/lib/FrontendTool/TBD.cpp
@@ -42,7 +42,7 @@ static std::vector<StringRef> sortSymbols(llvm::StringSet<> &symbols) {
 }
 
 bool swift::writeTBD(ModuleDecl *M, StringRef OutputFilename,
-                     const TBDGenOptions &Opts, TBDSymbolSetPtr publicCMOSymbols) {
+                     const TBDGenOptions &Opts) {
   std::error_code EC;
   llvm::raw_fd_ostream OS(OutputFilename, EC, llvm::sys::fs::OF_None);
   if (EC) {
@@ -51,7 +51,7 @@ bool swift::writeTBD(ModuleDecl *M, StringRef OutputFilename,
     return true;
   }
 
-  writeTBDFile(M, OS, Opts, publicCMOSymbols);
+  writeTBDFile(M, OS, Opts);
 
   return false;
 }
@@ -152,10 +152,8 @@ static bool validateSymbols(DiagnosticEngine &diags,
 bool swift::validateTBD(ModuleDecl *M,
                         const llvm::Module &IRModule,
                         const TBDGenOptions &opts,
-                        TBDSymbolSetPtr publicCMOSymbols,
                         bool diagnoseExtraSymbolsInTBD) {
-  auto symbols = getPublicSymbols(TBDGenDescriptor::forModule(M, opts,
-                                  publicCMOSymbols));
+  auto symbols = getPublicSymbols(TBDGenDescriptor::forModule(M, opts));
   return validateSymbols(M->getASTContext().Diags, symbols, IRModule,
                          diagnoseExtraSymbolsInTBD);
 }
@@ -163,10 +161,8 @@ bool swift::validateTBD(ModuleDecl *M,
 bool swift::validateTBD(FileUnit *file,
                         const llvm::Module &IRModule,
                         const TBDGenOptions &opts,
-                        TBDSymbolSetPtr publicCMOSymbols,
                         bool diagnoseExtraSymbolsInTBD) {
-  auto symbols = getPublicSymbols(TBDGenDescriptor::forFile(file, opts,
-                                  publicCMOSymbols));
+  auto symbols = getPublicSymbols(TBDGenDescriptor::forFile(file, opts));
   return validateSymbols(file->getParentModule()->getASTContext().Diags,
                          symbols, IRModule, diagnoseExtraSymbolsInTBD);
 }

--- a/lib/FrontendTool/TBD.h
+++ b/lib/FrontendTool/TBD.h
@@ -14,7 +14,6 @@
 #define SWIFT_FRONTENDTOOL_TBD_H
 
 #include "swift/Frontend/FrontendOptions.h"
-#include "swift/TBDGen/TBDGen.h"
 
 namespace llvm {
 class StringRef;
@@ -27,16 +26,14 @@ class FrontendOptions;
 struct TBDGenOptions;
 
 bool writeTBD(ModuleDecl *M, StringRef OutputFilename,
-              const TBDGenOptions &Opts, TBDSymbolSetPtr publicCMOSymbols);
+              const TBDGenOptions &Opts);
 bool validateTBD(ModuleDecl *M,
                  const llvm::Module &IRModule,
                  const TBDGenOptions &opts,
-                 TBDSymbolSetPtr publicCMOSymbols,
                  bool diagnoseExtraSymbolsInTBD);
 bool validateTBD(FileUnit *M,
                  const llvm::Module &IRModule,
                  const TBDGenOptions &opts,
-                 TBDSymbolSetPtr publicCMOSymbols,
                  bool diagnoseExtraSymbolsInTBD);
 }
 

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -1032,7 +1032,6 @@ getSymbolSourcesToEmit(const IRGenDescriptor &desc) {
       irEntitiesToEmit.push_back(source->getIRLinkEntity());
       break;
     case SymbolSource::Kind::LinkerDirective:
-    case SymbolSource::Kind::CrossModuleOptimization:
     case SymbolSource::Kind::Unknown:
       llvm_unreachable("Not supported");
     }

--- a/lib/IRGen/IRGenRequests.cpp
+++ b/lib/IRGen/IRGenRequests.cpp
@@ -81,13 +81,11 @@ ModuleDecl *IRGenDescriptor::getParentModule() const {
 }
 
 TBDGenDescriptor IRGenDescriptor::getTBDGenDescriptor() const {
-  TBDSymbolSetPtr cmoSymbolSet = (SILMod ? SILMod->getPublicCMOSymbols()
-                                         : nullptr);
   if (auto *file = Ctx.dyn_cast<FileUnit *>()) {
-    return TBDGenDescriptor::forFile(file, TBDOpts, cmoSymbolSet);
+    return TBDGenDescriptor::forFile(file, TBDOpts);
   } else {
     auto *M = Ctx.get<ModuleDecl *>();
-    return TBDGenDescriptor::forModule(M, TBDOpts, cmoSymbolSet);
+    return TBDGenDescriptor::forModule(M, TBDOpts);
   }
 }
 

--- a/lib/SIL/IR/SILModule.cpp
+++ b/lib/SIL/IR/SILModule.cpp
@@ -752,12 +752,6 @@ bool SILModule::isOptimizedOnoneSupportModule() const {
          getSwiftModule()->isOnoneSupportModule();
 }
 
-void SILModule::addPublicCMOSymbol(StringRef symbol) {
-  if (!publicCMOSymbols)
-    publicCMOSymbols = std::make_shared<TBDSymbolSet>();
-  publicCMOSymbols->insert(symbol.str());
-}
-
 void SILModule::setSerializeSILAction(SILModule::ActionCallback Action) {
   assert(!SerializeSILAction && "Serialization action can be set only once");
   SerializeSILAction = Action;

--- a/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
+++ b/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
@@ -613,9 +613,20 @@ class CrossModuleOptimizationPass: public SILModuleTransform {
       return;
     if (!M.isWholeModule())
       return;
+      
+    bool conservative = false;
+    switch (M.getOptions().CMOMode) {
+      case swift::CrossModuleOptimizationMode::Off:
+        return;
+      case swift::CrossModuleOptimizationMode::Default:
+        conservative = true;
+        break;
+      case swift::CrossModuleOptimizationMode::Aggressive:
+        conservative = false;
+        break;
+    }
 
-    CrossModuleOptimization CMO(M,
-      /*conservative*/ !M.getOptions().CrossModuleOptimization);
+    CrossModuleOptimization CMO(M, conservative);
     CMO.serializeFunctionsInModule();
   }
 };

--- a/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
+++ b/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
@@ -251,8 +251,11 @@ bool CrossModuleOptimization::canSerializeInstruction(SILInstruction *inst,
     // In conservative mode we don't want to turn non-public functions into
     // public functions, because that can increase code size. E.g. if the
     // function is completely inlined afterwards.
-    if (conservative && !hasPublicVisibility(callee->getLinkage()))
+    // Also, when emitting TBD files, we cannot introduce a new public symbol.
+    if ((conservative || M.getOptions().emitTBD) &&
+        !hasPublicVisibility(callee->getLinkage())) {
       return false;
+    }
 
     // Recursivly walk down the call graph.
     if (canSerializeFunction(callee, canSerializeFlags, maxDepth - 1))
@@ -270,8 +273,10 @@ bool CrossModuleOptimization::canSerializeInstruction(SILInstruction *inst,
   }
   if (auto *GAI = dyn_cast<GlobalAddrInst>(inst)) {
     SILGlobalVariable *global = GAI->getReferencedGlobal();
-    if (conservative && !hasPublicVisibility(global->getLinkage()))
+    if ((conservative || M.getOptions().emitTBD) &&
+        !hasPublicVisibility(global->getLinkage())) {
       return false;
+    }
     return true;
   }
   if (auto *KPI = dyn_cast<KeyPathInst>(inst)) {
@@ -491,7 +496,6 @@ void CrossModuleOptimization::serializeInstruction(SILInstruction *inst,
     }
     if (!hasPublicVisibility(global->getLinkage())) {
       global->setLinkage(SILLinkage::Public);
-      M.addPublicCMOSymbol(global->getName());
     }
     return;
   }
@@ -534,7 +538,6 @@ void CrossModuleOptimization::makeFunctionUsableFromInline(SILFunction *function
   if (!isAvailableExternally(function->getLinkage()) &&
       function->getLinkage() != SILLinkage::Public) {
     function->setLinkage(SILLinkage::Public);
-    M.addPublicCMOSymbol(function->getName());
   }
 }
 

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -77,7 +77,7 @@ void TBDGenVisitor::addSymbolInternal(StringRef name, SymbolKind kind,
     return;
 
 #ifndef NDEBUG
-  if (kind == SymbolKind::GlobalSymbol && !source.isFromCrossModuleOptimization()) {
+  if (kind == SymbolKind::GlobalSymbol) {
     if (!DuplicateSymbolChecker.insert(name).second) {
       llvm::dbgs() << "TBDGen duplicate symbol: " << name << '\n';
       assert(false && "TBDGen symbol appears twice");
@@ -1202,13 +1202,7 @@ void TBDGenVisitor::visitFile(FileUnit *file) {
 void TBDGenVisitor::visit(const TBDGenDescriptor &desc) {
   // Add any autolinking force_load symbols.
   addFirstFileSymbols();
-
-  if (desc.getPublicCMOSymbols()) {
-    for (const std::string &sym : *desc.getPublicCMOSymbols()) {
-      addSymbol(sym, SymbolSource::forCrossModuleOptimization());
-    }
-  }
-
+  
   if (auto *singleFile = desc.getSingleFile()) {
     assert(SwiftModule == singleFile->getParentModule() &&
            "mismatched file and module");
@@ -1352,9 +1346,9 @@ std::vector<std::string> swift::getPublicSymbols(TBDGenDescriptor desc) {
   return llvm::cantFail(evaluator(PublicSymbolsRequest{desc}));
 }
 void swift::writeTBDFile(ModuleDecl *M, llvm::raw_ostream &os,
-                const TBDGenOptions &opts, TBDSymbolSetPtr publicCMOSymbols) {
+                         const TBDGenOptions &opts) {
   auto &evaluator = M->getASTContext().evaluator;
-  auto desc = TBDGenDescriptor::forModule(M, opts, publicCMOSymbols);
+  auto desc = TBDGenDescriptor::forModule(M, opts);
   auto file = llvm::cantFail(evaluator(GenerateTBDRequest{desc}));
   llvm::cantFail(llvm::MachO::TextAPIWriter::writeToStream(os, file),
                  "YAML writing should be error-free");
@@ -1497,10 +1491,10 @@ apigen::API APIGenRequest::evaluate(Evaluator &evaluator,
 }
 
 void swift::writeAPIJSONFile(ModuleDecl *M, llvm::raw_ostream &os,
-                             bool PrettyPrint, TBDSymbolSetPtr publicCMOSymbols) {
+                             bool PrettyPrint) {
   TBDGenOptions opts;
   auto &evaluator = M->getASTContext().evaluator;
-  auto desc = TBDGenDescriptor::forModule(M, opts, publicCMOSymbols);
+  auto desc = TBDGenDescriptor::forModule(M, opts);
   auto api = llvm::cantFail(evaluator(APIGenRequest{desc}));
   api.writeAPIJSONFile(os, PrettyPrint);
 }

--- a/test/SILOptimizer/default-cmo.swift
+++ b/test/SILOptimizer/default-cmo.swift
@@ -1,9 +1,9 @@
 
 // RUN: %empty-directory(%t) 
 
-// RUN: %target-build-swift -O -wmo -parse-as-library -emit-module -emit-module-path=%t/Submodule.swiftmodule -module-name=Submodule %S/Inputs/cross-module/default-submodule.swift -c -o %t/submodule.o
-// RUN: %target-build-swift -O -wmo -parse-as-library -emit-module -emit-module-path=%t/Module.swiftmodule -module-name=Module -I%t -I%S/Inputs/cross-module %S/Inputs/cross-module/default-module.swift -c -o %t/module.o
-// RUN: %target-build-swift -O -wmo -parse-as-library -emit-tbd -emit-tbd-path %t/ModuleTBD.tbd -emit-module -emit-module-path=%t/ModuleTBD.swiftmodule -module-name=ModuleTBD -I%t -I%S/Inputs/cross-module %S/Inputs/cross-module/default-module.swift -c -o %t/moduletbd.o
+// RUN: %target-build-swift -O -wmo -Xfrontend -enable-default-cmo -parse-as-library -emit-module -emit-module-path=%t/Submodule.swiftmodule -module-name=Submodule %S/Inputs/cross-module/default-submodule.swift -c -o %t/submodule.o
+// RUN: %target-build-swift -O -wmo -Xfrontend -enable-default-cmo -parse-as-library -emit-module -emit-module-path=%t/Module.swiftmodule -module-name=Module -I%t -I%S/Inputs/cross-module %S/Inputs/cross-module/default-module.swift -c -o %t/module.o
+// RUN: %target-build-swift -O -wmo -Xfrontend -enable-default-cmo -parse-as-library -emit-tbd -emit-tbd-path %t/ModuleTBD.tbd -emit-module -emit-module-path=%t/ModuleTBD.swiftmodule -module-name=ModuleTBD -I%t -I%S/Inputs/cross-module %S/Inputs/cross-module/default-module.swift -c -o %t/moduletbd.o
 
 // RUN: %target-build-swift -O -wmo -module-name=Main -I%t %s -emit-sil | %FileCheck %s
 


### PR DESCRIPTION
So far, the swift-frontend decided by itself if CMO can be enabled. This caused problems when used with an old driver, which doesn't consider CMO.
Now, the driver decides when to use default CMO by passing this flag to swift-frontend.

Corresponding swift-driver change: https://github.com/apple/swift-driver/pull/1086

Also, revert "Add a mechanism to let cross-module-optimization add additional TBD symbols."
It's not needed anymore because CMO does not introduce public symbols when a TBD file is emitted.
