### PR TITLE
[CSSimplify] Don't attempt to synthesize ~= for optional base types

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9212,17 +9212,21 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
               dyn_cast<EnumElementPattern>(patternLoc->getPattern())) {
         auto enumType = baseObjTy->getMetatypeInstanceType();
 
-        // If the synthesis of ~= resulted in errors (i.e. broken stdlib)
-        // that would be diagnosed inline, so let's just fall through and
-        // let this situation be diagnosed as a missing member.
-        auto hadErrors = inferEnumMemberThroughTildeEqualsOperator(
+        // Optional base type does not trigger `~=` synthesis, but it tries
+        // to find member on both `Optional` and its wrapped type.
+        if (!enumType->getOptionalObjectType()) {
+          // If the synthesis of ~= resulted in errors (i.e. broken stdlib)
+          // that would be diagnosed inline, so let's just fall through and
+          // let this situation be diagnosed as a missing member.
+          auto hadErrors = inferEnumMemberThroughTildeEqualsOperator(
             *this, enumElement, enumType, memberTy, locator);
 
-        // Let's consider current member constraint solved because it's
-        // replaced by a new set of constraints that would resolve member
-        // type.
-        if (!hadErrors)
-          return SolutionKind::Solved;
+          // Let's consider current member constraint solved because it's
+          // replaced by a new set of constraints that would resolve member
+          // type.
+          if (!hadErrors)
+            return SolutionKind::Solved;
+        }
       }
     }
   }

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar92327807.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar92327807.swift
@@ -1,0 +1,31 @@
+// RUN: %target-typecheck-verify-swift
+
+enum MyEnum {
+case test(Int)
+}
+
+func test(result: MyEnum, optResult: MyEnum?) {
+  if let .co = result { // expected-error {{pattern matching in a condition requires the 'case' keyword}}
+    // expected-error@-1 {{type 'MyEnum' has no member 'co'}}
+  }
+
+  if let .co(42) = result { // expected-error {{pattern matching in a condition requires the 'case' keyword}}
+    // expected-error@-1 {{type of expression is ambiguous without more context}}
+  }
+
+  if let .co = optResult { // expected-error {{pattern matching in a condition requires the 'case' keyword}}
+    // expected-error@-1 {{type 'MyEnum?' has no member 'co'}}
+  }
+
+  let _ = {
+    if let .co = result { // expected-error 2 {{pattern matching in a condition requires the 'case' keyword}}
+      // expected-error@-1 {{type 'MyEnum' has no member 'co'}}
+    }
+  }
+
+  let _ = {
+    if let .co = optResult { // expected-error 2 {{pattern matching in a condition requires the 'case' keyword}}
+      // expected-error@-1 {{type 'MyEnum?' has no member 'co'}}
+    }
+  }
+}


### PR DESCRIPTION
`EnumElement` patterns with optional base type do member lookup
on both optional type and its wrapped type but do not synthesize
`~=` operator call.

Resolves: rdar://92327807

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
