### PR TITLE
[IRGen] Return null reference from IRGenFunction::emitUnmanagedAlloc …

### DIFF
--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -534,6 +534,9 @@ llvm::Value *IRGenFunction::emitUnmanagedAlloc(const HeapLayout &layout,
                                                const llvm::Twine &name,
                                            llvm::Constant *captureDescriptor,
                                            const HeapNonFixedOffsets *offsets) {
+  if (layout.isKnownEmpty())
+    return IGM.RefCountedNull;
+
   llvm::Value *metadata = layout.getPrivateMetadata(IGM, captureDescriptor);
   llvm::Value *size, *alignMask;
   if (offsets) {

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -1508,7 +1508,10 @@ class FixedBoxTypeInfoBase : public BoxTypeInfo {
 public:
   FixedBoxTypeInfoBase(IRGenModule &IGM, HeapLayout &&layout)
     : BoxTypeInfo(IGM), layout(std::move(layout))
-  {}
+  {
+    // Empty layouts should always use EmptyBoxTypeInfo instead
+    assert(!layout.isKnownEmpty());
+  }
 
   OwnedAddress
   allocate(IRGenFunction &IGF, SILType boxedType, GenericEnvironment *env,

--- a/test/IRGen/partial_apply.sil
+++ b/test/IRGen/partial_apply.sil
@@ -848,3 +848,20 @@ entry(%0 : $EmptyType, %1: $*SomeType, %3: $FixedType):
   %40 = tuple()
   return %40 : $()
 }
+
+// Test that we don't have an alloc object with 0, because that is not allowed
+// CHECK-LABEL: define{{.*}} swiftcc void @my_test_case
+// CHECK-NOT: swift_allocObject
+// CHECK: ret
+sil @take_empty : $@convention(thin) (@in_guaranteed EmptyType) -> ()
+sil @my_test_case : $@convention(thin)  () -> () {
+entry:
+  %5 = alloc_stack $EmptyType
+  // store % to %5
+  %f = function_ref @take_empty : $@convention(thin) (@in_guaranteed EmptyType) -> ()
+  %36 = partial_apply [callee_guaranteed] %f(%5) : $@convention(thin) (@in_guaranteed EmptyType) -> ()
+  release_value %36: $@callee_guaranteed () ->()
+  dealloc_stack %5 : $*EmptyType
+  %t = tuple()
+  return %t : $()
+}

--- a/test/Interpreter/closure_zero_size_allocation.swift
+++ b/test/Interpreter/closure_zero_size_allocation.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift -O
+// RUN: %target-run-simple-swift(-O)
 
 // rdar://92418090
 

--- a/test/Interpreter/closure_zero_size_allocation.swift
+++ b/test/Interpreter/closure_zero_size_allocation.swift
@@ -1,0 +1,16 @@
+// RUN: %target-run-simple-swift -O
+
+// rdar://92418090
+
+protocol P {
+  var covariantSelfPropClosure: ((Self) -> Void) -> Void { get }
+}
+extension P {
+  var covariantSelfPropClosure: ((Self) -> Void) -> Void { { $0(self) } }
+}
+
+struct S: P {}
+
+let p: P = S()
+
+p.covariantSelfPropClosure { _ in }


### PR DESCRIPTION
…when layout isKnownEmpty

rdar://92418090

This fixes a runtime crash on x86 caused by allocations of size 0, which are later deallocated with swift_deallocObjectImpl, but are missing the object header.
