### PR TITLE
Gate Clock Runtime Test on Current Runtimes

### DIFF
--- a/test/Concurrency/Runtime/clock.swift
+++ b/test/Concurrency/Runtime/clock.swift
@@ -4,6 +4,10 @@
 // REQUIRES: executable_test
 // REQUIRES: concurrency_runtime
 
+// Test requires _swift_task_enterThreadLocalContext which is not available 
+// in the back deployment runtime.
+// UNSUPPORTED: back_deployment_runtime
+
 import _Concurrency
 import StdlibUnittest
 


### PR DESCRIPTION
The back deployment runtime does not contain the symbols necessary
to execute this test. Mark it unsupported.