### PR TITLE
[cxx-interop] Fix SIL deserialization error for C++ methods

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5141,6 +5141,7 @@ getActualSILFunctionTypeRepresentation(uint8_t rep) {
   CASE(Method)
   CASE(ObjCMethod)
   CASE(WitnessMethod)
+  CASE(CXXMethod)
 #undef CASE
   default:
     return None;


### PR DESCRIPTION
This fixes `Memory corruption or serialization format inconsistency` error when compiling with cross module optimization enabled.