### PR TITLE
[5.7] [Sema] Don't warn on trailing closures in closure conditions

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3709,6 +3709,7 @@ static void checkStmtConditionTrailingClosure(ASTContext &ctx, const Expr *E) {
       case ExprKind::Array:
       case ExprKind::Dictionary:
       case ExprKind::InterpolatedStringLiteral:
+      case ExprKind::Closure:
         // If a trailing closure appears as a child of one of these types of
         // expression, don't diagnose it as there is no ambiguity.
         return {E->isImplicit(), E};

--- a/test/expr/closure/trailing.swift
+++ b/test/expr/closure/trailing.swift
@@ -475,3 +475,13 @@ func rdar85343171() {
   // Okay, as trailing closure is nested in argument list.
   if foo(bar {}) {}
 }
+
+// rdar://92521618 - Spurious warning on trailing closure nested within a
+// closure initializer.
+
+func rdar92521618() {
+  func foo(_ fn: () -> Void) -> Int? { 0 }
+
+  if let _ = { foo {} }() {}
+  guard let _ = { foo {} }() else { return }
+}


### PR DESCRIPTION
5.7 cherry-pick of https://github.com/apple/swift/pull/58524

- Explanation: Silences a spurious trailing closure warning in the body of a closure condition
- Scope: Silences a warning
- Radar: rdar://92521618
- Risk: Low
- Testing: Added test case
- Reviewer: @xedin & @owenv 