### PR TITLE
Add custom native toolchains to build-script

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2386,11 +2386,9 @@ skip-test-cmark
 build-swift-tools=0
 skip-early-swift-driver
 
-# Then set the paths to our native tools. If compiling against a toolchain,
-# these should all be the ./usr/bin directory.
-native-swift-tools-path=%(toolchain_path)s
-native-llvm-tools-path=%(toolchain_path)s
-native-clang-tools-path=%(toolchain_path)s
+# Then set the paths to our native tools. If compiling against a toolchain, this
+# should point to the root of the toolchain.
+custom-native-toolchain=%(toolchain_path)s
 
 build-ninja
 lit-args=--filter=':: stdlib/' -v

--- a/utils/build-script
+++ b/utils/build-script
@@ -598,7 +598,8 @@ def main_normal():
         print_note('Using toolchain {}'.format(xcrun_toolchain))
         args.darwin_xcrun_toolchain = xcrun_toolchain
 
-    toolchain = host_toolchain(xcrun_toolchain=args.darwin_xcrun_toolchain)
+    toolchain = host_toolchain(xcrun_toolchain=args.darwin_xcrun_toolchain,
+                               custom_native_toolchain=args.custom_native_toolchain)
     os.environ['TOOLCHAINS'] = args.darwin_xcrun_toolchain
 
     if args.host_cc is not None:

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -594,6 +594,10 @@ def create_argument_parser():
                 "for each cross-compiled toolchain's destdir, useful when building "
                 "multiple toolchains and can be disabled if only cross-compiling one.")
 
+    option('--custom-native-toolchain', store,
+           default=None,
+           help="Specify a custom location to find compilers and tools")
+
     option('--stdlib-deployment-targets', store,
            type=argparse.ShellSplitType(),
            default=None,

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -134,6 +134,7 @@ EXPECTED_DEFAULTS = {
     'cross_compile_append_host_target_to_destdir': True,
     'cross_compile_deps_path': None,
     'cross_compile_hosts': [],
+    'custom_native_toolchain': None,
     'darwin_deployment_version_ios':
         defaults.DARWIN_DEPLOYMENT_VERSION_IOS,
     'darwin_deployment_version_osx':
@@ -718,6 +719,7 @@ EXPECTED_OPTIONS = [
     PathOption('--install-symroot'),
     PathOption('--install-destdir'),
     EnableOption('--install-all'),
+    PathOption('--custom-native-toolchain'),
     PathOption('--native-clang-tools-path'),
     PathOption('--native-llvm-tools-path'),
     PathOption('--native-swift-tools-path'),

--- a/utils/swift_build_support/swift_build_support/build_script_invocation.py
+++ b/utils/swift_build_support/swift_build_support/build_script_invocation.py
@@ -358,6 +358,18 @@ class BuildScriptInvocation(object):
                 "--native-swift-tools-path=%s" % args.native_swift_tools_path
             ]
 
+        if args.custom_native_toolchain is not None:
+            if self.toolchain.swiftc is not None:
+                swift_path = os.path.dirname(self.toolchain.swiftc)
+                impl_args += [
+                    "--native-swift-tools-path=%s" % swift_path
+                ]
+            if self.toolchain.cc is not None:
+                clang_path = os.path.dirname(self.toolchain.cc)
+                impl_args += [
+                    "--native-clang-tools-path=%s" % clang_path
+                ]
+
         # If we have extra_swift_args, combine all of them together and then
         # add them as one command.
         if args.extra_swift_args:

--- a/utils/swift_build_support/swift_build_support/toolchain.py
+++ b/utils/swift_build_support/swift_build_support/toolchain.py
@@ -208,7 +208,22 @@ class Haiku(GenericUnix):
         super(Haiku, self)
 
 
+class Custom(Toolchain):
+    def __init__(self, path):
+        self.base_path = path
+
+    def find_tool(self, *names):
+        names = set(names)
+        for dirpath, _, filenames in os.walk(self.base_path):
+            candidates = set(filenames) & names
+            if candidates:
+                return os.path.join(dirpath, next(iter(candidates)))
+
+
 def host_toolchain(**kwargs):
+    native_toolchain_path = kwargs.pop('custom_native_toolchain', None)
+    if native_toolchain_path is not None:
+        return Custom(native_toolchain_path)
     sys = platform.system()
     if sys == 'Darwin':
         return MacOSX(kwargs.pop('xcrun_toolchain', 'default'))

--- a/validation-test/BuildSystem/test_custom_toolchain.test
+++ b/validation-test/BuildSystem/test_custom_toolchain.test
@@ -1,0 +1,13 @@
+# RUN: %empty-directory(%t)
+# RUN: mkdir -p %t
+# RUN: touch %t/cmake %t/clang %t/clang++ %t/ninja %t/swiftc
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --skip-build --skip-early-swift-driver --custom-native-toolchain %t --cmark --static-curl --swiftpm 2>&1 | %FileCheck %s
+
+# Check cmark (cmake build-script product)
+
+# CHECK-LABEL: --- Building cmark ---
+# CHECK: [[$CUSTOM_TOOLCHAIN_PATH:BUILD_DIR/validation-test-[^/]*/BuildSystem/Output/test_custom_toolchain.test.tmp/]]cmake
+# CHECK-SAME: -DCMAKE_C_COMPILER:PATH=[[$CUSTOM_TOOLCHAIN_PATH]]clang
+# CHECK-SAME: -DCMAKE_CXX_COMPILER:PATH=[[$CUSTOM_TOOLCHAIN_PATH]]clang++
+# CHECK-SAME: -DCMAKE_Swift_COMPILER:PATH=[[$CUSTOM_TOOLCHAIN_PATH]]swiftc
+# CHECK-SAME: -DCMAKE_MAKE_PROGRAM=[[$CUSTOM_TOOLCHAIN_PATH]]ninja


### PR DESCRIPTION
This patch adds the ability to specify custom locations to look for build tools.
The main idea is to be able to re-use an already built swift toolchain for building with freestanding configurations.
I'm not sure exactly how the python toolchain pieces integrate with `build-script-impl`.

rdar://92540252