### PR TITLE
[ChangeLog] Add missing language mode for code block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,7 @@ _**Note:** This is in reverse chronological order, so newer entries are added to
   in places that would previously fail because `any` types do not conform
   to their protocols. For example:
 
-  ```
+  ```swift
   protocol P {
     associatedtype A
     func getA() -> A


### PR DESCRIPTION
<!-- What's in this pull request? -->
Previously, the section in question did not show syntax coloring.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
This PR is similar to a recent commit, https://github.com/apple/swift/commit/be8a4eccc5cbf413e5b827c7613293f94bee558a.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
