### PR TITLE
Spelling tools swift inspect

### DIFF
--- a/tools/swift-inspect/Sources/swift-inspect/Backtrace.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Backtrace.swift
@@ -21,7 +21,7 @@ internal func backtrace(_ stack: [swift_reflection_ptr_t], style: BacktraceStyle
                         _ symbolicate: (swift_addr_t) -> (module: String?, symbol: String?)) -> String {
   func entry(_ address: swift_reflection_ptr_t) -> String {
     let (module, symbol) = symbolicate(swift_addr_t(address))
-    return "\(hex: address) (\(module ?? "<uknown>")) \(symbol ??  "<unknown>")"
+    return "\(hex: address) (\(module ?? "<unknown>")) \(symbol ??  "<unknown>")"
   }
 
   // The pointers to the locations in the backtrace are stored from deepest to

--- a/tools/swift-inspect/Sources/swift-inspect/Operations/DumpRawMetadata.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Operations/DumpRawMetadata.swift
@@ -37,7 +37,7 @@ internal struct DumpRawMetadata: ParsableCommand {
           if let stack = stacks?[allocation.ptr] {
             print(backtrace(stack, style: style, process.symbolicate))
           } else {
-            print("  No stcktrace available")
+            print("  No stack trace available")
           }
         }
       }


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fixes some misspellings in Swift tools/swift/inspect, it is split per https://github.com/apple/swift/pull/42421#issuecomment-1101092698


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
