### PR TITLE
Spelling unittests

### DIFF
--- a/unittests/runtime/CMakeLists.txt
+++ b/unittests/runtime/CMakeLists.txt
@@ -127,7 +127,7 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
     )
 
   # The local stdlib implementation provides definitions of the swiftCore
-  # interfaes to avoid pulling in swiftCore itself.  Build the SwiftRuntimeTests
+  # interfaces to avoid pulling in swiftCore itself.  Build the SwiftRuntimeTests
   # with swiftCore_EXPORTS to permit exporting the stdlib interfaces.
   target_compile_definitions(SwiftRuntimeTests
                              PRIVATE

--- a/unittests/runtime/ExtendedExistential.cpp
+++ b/unittests/runtime/ExtendedExistential.cpp
@@ -1,4 +1,4 @@
-//===--- ExtendedExiential.cpp - Extended existential metadata unit tests -===//
+//===--- ExtendedExistential.cpp - Extended existential metadata unit tests -===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/unittests/runtime/ExtendedExistential.cpp
+++ b/unittests/runtime/ExtendedExistential.cpp
@@ -398,7 +398,7 @@ TEST(TestExtendedExistential, overrideValueWitnesses) {
   EXPECT_EQ(vwtable0, &table);
 }
 
-TEST(TestExtendedExistential, defaultOpaqueValueWitnessses) {
+TEST(TestExtendedExistential, defaultOpaqueValueWitnesses) {
   auto shape0 = buildGlobalShape([]{
     return shape(
       shapeType(protocolType(P())),
@@ -441,7 +441,7 @@ TEST(TestExtendedExistential, defaultOpaqueValueWitnessses) {
   EXPECT_FALSE(vwtable2->isPOD());
 }
 
-TEST(TestExtendedExistential, defaultClassValueWitnessses) {
+TEST(TestExtendedExistential, defaultClassValueWitnesses) {
   auto shape0 = buildGlobalShape([]{
     return shape(
       special(SpecialKind::Class),
@@ -487,7 +487,7 @@ TEST(TestExtendedExistential, defaultClassValueWitnessses) {
   EXPECT_FALSE(vwtable2->isPOD());
 }
 
-TEST(TestExtendedExistential, defaultMetatypeValueWitnessses) {
+TEST(TestExtendedExistential, defaultMetatypeValueWitnesses) {
   auto shape0 = buildGlobalShape([]{
     return shape(
       special(SpecialKind::Metatype),

--- a/unittests/runtime/LongTests/CMakeLists.txt
+++ b/unittests/runtime/LongTests/CMakeLists.txt
@@ -48,7 +48,7 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
     )
 
   # The local stdlib implementation provides definitions of the swiftCore
-  # interfaes to avoid pulling in swiftCore itself.  Build the
+  # interfaces to avoid pulling in swiftCore itself.  Build the
   # SwiftRuntimeLongTests with swiftCore_EXPORTS to permit exporting the stdlib
   # interfaces.
   target_compile_definitions(SwiftRuntimeLongTests

--- a/unittests/runtime/Stdlib.cpp
+++ b/unittests/runtime/Stdlib.cpp
@@ -229,7 +229,7 @@ const long long $sSGMp[1] = {0};
 SWIFT_RUNTIME_STDLIB_INTERNAL
 const long long $sSiMn[1] = {0};
 
-// DefaultIndicis
+// DefaultIndices
 
 SWIFT_RUNTIME_STDLIB_INTERNAL
 const long long $sSIMn[1] = {0};


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fixes some misspellings in Swift unittests, it is split per https://github.com/apple/swift/pull/42421#issuecomment-1101092698


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
