### PR TITLE
Add regression test for #56024 crasher

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/sr13589.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr13589.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-emit-silgen %s
+
+// https://github.com/apple/swift/issues/56024
+
+public var UNIMPLEMENTED: Never { fatalError("UNIMPLEMENTED") }
+
+public func UNIMPLEMENTED(
+    function: String = #function,
+    file: StaticString = #file,
+    line: UInt = #line
+) -> Never {
+    fatalError("UNIMPLEMENTED ← \(function)", file: file, line: line)
+}
+
+public struct Test {
+    public func foo() throws -> UnkeyedDecodingContainer {
+        UNIMPLEMENTED()
+    }
+}


### PR DESCRIPTION
The crasher is no longer reproducible, and the generated SIL is looking good. Add a regression test so that we can close the issue.


