### PR TITLE
spelling: method

### DIFF
--- a/test/SPI/private_swiftinterface.swift
+++ b/test/SPI/private_swiftinterface.swift
@@ -90,7 +90,7 @@ public func foo() {}
 }
 
 public extension SPIClassLocal {
-  internal func internalExtensionMethode1() {}
+  internal func internalExtensionMethod1() {}
   // CHECK-PRIVATE-NOT: internalExtensionMethod1
   // CHECK-PUBLIC-NOT: internalExtensionMethod1
 }

--- a/test/SPI/protocol_requirement.swift
+++ b/test/SPI/protocol_requirement.swift
@@ -37,7 +37,7 @@ extension PublicProtoRejected {
 extension PublicProtoRejected where Self : Equatable {
   @_spi(Private)
   public func reqWithoutDefault() {
-    // constrainted implementation
+    // constrained implementation
   }
 }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fixes some misspellings in Swift test/SPI, it is split per https://github.com/apple/swift/pull/42421#issuecomment-1101092698


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
