### PR TITLE
Spelling lib symbolgraphgen

### DIFF
--- a/lib/SymbolGraphGen/AvailabilityMixin.h
+++ b/lib/SymbolGraphGen/AvailabilityMixin.h
@@ -67,7 +67,7 @@ struct Availability {
 
   /// Returns true if this availability item doesn't have
   /// any introduced version, deprecated version, obsoleted version,
-  /// or uncondtional deprecation status.
+  /// or unconditional deprecation status.
   ///
   /// \note \c message and \c renamed are not considered.
   bool empty() const;

--- a/lib/SymbolGraphGen/Symbol.cpp
+++ b/lib/SymbolGraphGen/Symbol.cpp
@@ -324,7 +324,7 @@ static SubstitutionMap getSubMapForDecl(const ValueDecl *D, Type BaseType) {
     return {};
 
   // Map from the base type into the this declaration's innermost type context,
-  // or if we're dealing with an extention rather than a member, into its
+  // or if we're dealing with an extension rather than a member, into its
   // extended nominal (the extension's own requirements shouldn't be considered
   // in the substitution).
   swift::DeclContext *DC;

--- a/lib/SymbolGraphGen/Symbol.h
+++ b/lib/SymbolGraphGen/Symbol.h
@@ -53,7 +53,7 @@ class Symbol {
                          SourceManager &SourceMgr,
                          llvm::json::OStream &OS) const;
 
-  void serializeRange(size_t InitialIdentation,
+  void serializeRange(size_t InitialIndentation,
                       SourceRange Range, SourceManager &SourceMgr,
                       llvm::json::OStream &OS) const;
 

--- a/lib/SymbolGraphGen/Symbol.h
+++ b/lib/SymbolGraphGen/Symbol.h
@@ -101,7 +101,7 @@ public:
     return SynthesizedBaseTypeDecl;
   }
 
-  /// Reteive the path components associated with this symbol, from outermost
+  /// Retrieve the path components associated with this symbol, from outermost
   /// to innermost (this symbol).
   void getPathComponents(SmallVectorImpl<PathComponent> &Components) const;
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fixes some misspellings in Swift lib/SymbolGraphGen, it is split per https://github.com/apple/swift/pull/42421#issuecomment-1101092698


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
