### PR TITLE
Spelling tools swift syntax test

### DIFF
--- a/tools/swift-syntax-test/swift-syntax-test.cpp
+++ b/tools/swift-syntax-test/swift-syntax-test.cpp
@@ -406,7 +406,7 @@ bool parseIncrementalEditArguments(SyntaxParsingCache *Cache,
         SourceMgr.getLocOffsetInBuffer(EditStartLoc, BufferID);
     auto EditEndOffset = SourceMgr.getLocOffsetInBuffer(EditEndLoc, BufferID);
     Cache->addEdit(EditStartOffset, EditEndOffset,
-                   /*ReplacmentLength=*/Matches[5].size());
+                   /*ReplacementLength=*/Matches[5].size());
   }
   return true;
 }

--- a/tools/swift-syntax-test/swift-syntax-test.cpp
+++ b/tools/swift-syntax-test/swift-syntax-test.cpp
@@ -360,13 +360,13 @@ bool parseIncrementalEditArguments(SyntaxParsingCache *Cache,
                                    StringRef OldFileName) {
   // Get a source manager for the old file
   InputFile OldFile = InputFile(OldFileName, true);
-  auto OldFileBufferOrErrror = llvm::MemoryBuffer::getFileOrSTDIN(OldFileName);
-  if (!OldFileBufferOrErrror) {
+  auto OldFileBufferOrError = llvm::MemoryBuffer::getFileOrSTDIN(OldFileName);
+  if (!OldFileBufferOrError) {
     llvm::errs() << "Unable to open old source file";
     return false;
   }
   SourceManager SourceMgr;
-  unsigned BufferID = SourceMgr.addNewSourceBuffer(std::move(OldFileBufferOrErrror.get()));
+  unsigned BufferID = SourceMgr.addNewSourceBuffer(std::move(OldFileBufferOrError.get()));
 
   llvm::Regex MatchRegex("([0-9]+):([0-9]+)-([0-9]+):([0-9]+)=(.*)");
   // Parse the source edits


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fixes some misspellings in Swift tools/swift-syntax-test, it is split per https://github.com/apple/swift/pull/42421#issuecomment-1101092698


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
