### PR TITLE
Spelling tools swift serialize diagnostics

### DIFF
--- a/tools/swift-serialize-diagnostics/swift-serialize-diagnostics.cpp
+++ b/tools/swift-serialize-diagnostics/swift-serialize-diagnostics.cpp
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// Convert localization YAML files to a srialized format.
+// Convert localization YAML files to a serialized format.
 //
 //===----------------------------------------------------------------------===//
 

--- a/tools/swift-serialize-diagnostics/swift-serialize-diagnostics.cpp
+++ b/tools/swift-serialize-diagnostics/swift-serialize-diagnostics.cpp
@@ -86,7 +86,7 @@ int main(int argc, char *argv[]) {
   // Print out the diagnostics IDs that are available in YAML but not available
   // in `.def`
   if (!yaml.unknownIDs.empty()) {
-    llvm::errs() << "These diagnostic IDs are no longer availiable: '";
+    llvm::errs() << "These diagnostic IDs are no longer available: '";
     llvm::interleave(
         yaml.unknownIDs, [&](std::string id) { llvm::errs() << id; },
         [&] { llvm::errs() << ", "; });


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fixes some misspellings in Swift tools/swift-serialize-diagnostics, it is split per https://github.com/apple/swift/pull/42421#issuecomment-1101092698


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
