### PR TITLE
Spelling include swift

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -877,7 +877,7 @@ public:
   //
   // Using Objective-C runtime, KVO can modify object behavior without needing
   // to modify the object's code. This is done by dynamically creating an
-  // artificial subclass of the the object's type.
+  // artificial subclass of the object's type.
   //
   // The isa pointer of the observed object is swapped out to point to
   // the artificial subclass, which has the following properties:

--- a/include/swift/ABI/TaskOptions.h
+++ b/include/swift/ABI/TaskOptions.h
@@ -78,7 +78,7 @@ class TaskGroupTaskOptionRecord : public TaskOptionRecord {
 
 /// Task option to specify on what executor the task should be executed.
 ///
-/// Not passing this option implies that that a "best guess" or good default
+/// Not passing this option implies that a "best guess" or good default
 /// executor should be used instead, most often this may mean the global
 /// concurrent executor, or the enclosing actor's executor.
 class ExecutorTaskOptionRecord : public TaskOptionRecord {

--- a/include/swift/Concurrency/Actor.h
+++ b/include/swift/Concurrency/Actor.h
@@ -39,7 +39,7 @@ enum : uint32_t {
   // It is possible for an actor to be in Running and yet completely released
   // by clients. However, the actor needs to be kept alive until it is done
   // executing the task that is running on it and gives it up. It is only
-  // after that that we can safely deallocate it.
+  // after that we can safely deallocate it.
   ActorStateMask = 0x7,
 
   /// The actor is not currently scheduled.  Completely redundant

--- a/include/swift/Demangling/Demangler.h
+++ b/include/swift/Demangling/Demangler.h
@@ -623,7 +623,7 @@ public:
 
 /// A demangler which uses stack space for its initial memory.
 ///
-/// The \p Size paramter specifies the size of the stack space.
+/// The \p Size parameter specifies the size of the stack space.
 template <size_t Size> class StackAllocatedDemangler : public Demangler {
   char StackSpace[Size];
 

--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -1033,13 +1033,13 @@ private:
       auto parentOffsetAddress = detail::applyRelativeOffset(
           (const char *)contextDescriptorAddress,
           (int32_t)contextDescriptor->getParentOffset());
-      auto parentOfsetBytes = OpaqueByteReader(
+      auto parentOffsetBytes = OpaqueByteReader(
           remote::RemoteAddress(parentOffsetAddress), sizeof(uint32_t));
-      if (!parentOfsetBytes.get()) {
+      if (!parentOffsetBytes.get()) {
         Error = "Failed to parent offset in a type descriptor.";
         return llvm::None;
       }
-      auto parentFieldOffset = (const int32_t *)parentOfsetBytes.get();
+      auto parentFieldOffset = (const int32_t *)parentOffsetBytes.get();
       auto parentTargetAddress = detail::applyRelativeOffset(
           (const char *)parentOffsetAddress, *parentFieldOffset);
 
@@ -1128,13 +1128,13 @@ private:
       auto typeNameOffsetAddress =
           detail::applyRelativeOffset((const char *)typeDescriptorAddress,
                                       (int32_t)typeDescriptor->getNameOffset());
-      auto typeNameOfsetBytes = OpaqueByteReader(
+      auto typeNameOffsetBytes = OpaqueByteReader(
           remote::RemoteAddress(typeNameOffsetAddress), sizeof(uint32_t));
-      if (!typeNameOfsetBytes.get()) {
+      if (!typeNameOffsetBytes.get()) {
         Error = "Failed to read type name offset in a type descriptor.";
         return llvm::None;
       }
-      auto typeNameOffset = (const uint32_t *)typeNameOfsetBytes.get();
+      auto typeNameOffset = (const uint32_t *)typeNameOffsetBytes.get();
       auto typeNameAddress = detail::applyRelativeOffset(
           (const char *)typeNameOffsetAddress, (int32_t)*typeNameOffset);
       std::string typeName;
@@ -1149,15 +1149,15 @@ private:
       auto parentNameOffsetAddress = detail::applyRelativeOffset(
           (const char *)moduleDescriptorAddress,
           (int32_t)moduleDescriptor->getNameOffset());
-      auto parentNameOfsetBytes = OpaqueByteReader(
+      auto parentNameOffsetBytes = OpaqueByteReader(
           remote::RemoteAddress(parentNameOffsetAddress), sizeof(uint32_t));
-      if (!parentNameOfsetBytes.get()) {
+      if (!parentNameOffsetBytes.get()) {
         Error = "Failed to read parent name offset in a module descriptor.";
         return llvm::None;
       }
-      auto parentNameOfset = (const uint32_t *)parentNameOfsetBytes.get();
+      auto parentNameOffset = (const uint32_t *)parentNameOffsetBytes.get();
       auto parentNameAddress = detail::applyRelativeOffset(
-          (const char *)parentNameOffsetAddress, (int32_t)*parentNameOfset);
+          (const char *)parentNameOffsetAddress, (int32_t)*parentNameOffset);
       std::string parentName;
       OpaqueStringReader(remote::RemoteAddress(parentNameAddress), parentName);
       return parentName;
@@ -1183,13 +1183,13 @@ private:
       auto protocolNameOffsetAddress = detail::applyRelativeOffset(
           (const char *)protocolDescriptorAddress,
           (int32_t)protocolDescriptor->getNameOffset());
-      auto protocolNameOfsetBytes = OpaqueByteReader(
+      auto protocolNameOffsetBytes = OpaqueByteReader(
           remote::RemoteAddress(protocolNameOffsetAddress), sizeof(uint32_t));
-      if (!protocolNameOfsetBytes.get()) {
+      if (!protocolNameOffsetBytes.get()) {
         Error = "Failed to read type name offset in a protocol descriptor.";
         return llvm::None;
       }
-      auto protocolNameOffset = (const uint32_t *)protocolNameOfsetBytes.get();
+      auto protocolNameOffset = (const uint32_t *)protocolNameOffsetBytes.get();
 
       // Using the offset above, compute the address of the name field itsel
       // and read it.

--- a/include/swift/Syntax/Syntax.h
+++ b/include/swift/Syntax/Syntax.h
@@ -141,7 +141,7 @@ public:
 
 /// Same as \c OwnedSyntaxRef but can be null. We don't use \c
 /// Optional<OwnedSyntaxRef<SyntaxRefType>>>, because then we couldn't access
-/// the underlying \c SytnaxRefType via the \c -> operator (the use of \c ->
+/// the underlying \c SyntaxRefType via the \c -> operator (the use of \c ->
 /// would access the \c OwnedSyntaxRef<SyntaxRefType> wrapped by \c Optional and
 /// not the \c SyntaxRefType wrapped by \c OwnedSyntaxRef.
 template <typename SyntaxRefType>


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fixes some misspellings in Swift include/swift, it is split per https://github.com/apple/swift/pull/42421#issuecomment-1101092698


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
