### PR TITLE
Spelling lib migrator

### DIFF
--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -1300,7 +1300,7 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
     if (Params.size() <= Idx)
       return;
 
-    // Get the internal name of the changed paramter.
+    // Get the internal name of the changed parameter.
     auto VariableName = Params[Idx]->getParameterName().str();
 
     // Insert the helper function to convert the type back to raw types.

--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -1432,7 +1432,7 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
     if (auto *VD = dyn_cast<VarDecl>(D)) {
       for (auto *Item: getRelatedDiffItems(VD)) {
         if (auto *CD = dyn_cast<CommonDiffItem>(Item)) {
-          // If the overriden property has been renamed, we should rename
+          // If the overridden property has been renamed, we should rename
           // this property decl as well.
           if (CD->isRename() && VD->getNameLoc().isValid()) {
             Editor.replaceToken(VD->getNameLoc(), CD->getNewName());

--- a/lib/Migrator/Diff.h
+++ b/lib/Migrator/Diff.h
@@ -662,7 +662,7 @@ class diff_match_patch {
   static string_t diff_linesToCharsMunge(const string_t &text, std::map<LinePtr, size_t> &lineHash) {
     string_t chars;
     // Walk the text, pulling out a substring for each line.
-    // text.split('\n') would would temporarily double our memory footprint.
+    // text.split('\n') would temporarily double our memory footprint.
     // Modifying text would create many large strings to garbage collect.
     typename string_t::size_type lineLen;
     for (typename string_t::const_pointer lineStart = text.c_str(), textEnd = lineStart + text.size(); lineStart < textEnd; lineStart += lineLen + 1) {


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fixes some misspellings in Swift lib/migrator, it is split per https://github.com/apple/swift/pull/42421#issuecomment-1101092698


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
