### PR TITLE
Spelling test type

### DIFF
--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -274,7 +274,7 @@ func associatedTypeIdentity() {
   sameType(gary(candace()).r_out(), gary(candace()).r_out())
   sameType(gary(doug()).r_out(), gary(doug()).r_out())
   // TODO(diagnostics): This is not great but the problem comes from the way solver discovers and attempts bindings, if we could detect that
-  // `(some R).S` from first reference to `gary()` in incosistent with the second one based on the parent type of `S` it would be much easier to diagnose.
+  // `(some R).S` from first reference to `gary()` in inconsistent with the second one based on the parent type of `S` it would be much easier to diagnose.
   sameType(gary(doug()).r_out(), gary(candace()).r_out())
   // expected-error@-1:12 {{conflicting arguments to generic parameter 'T' ('some R' (result type of 'doug') vs. 'some R' (result type of 'candace'))}}
   // expected-error@-2:34 {{conflicting arguments to generic parameter 'T' ('some R' (result type of 'doug') vs. 'some R' (result type of 'candace'))}}

--- a/test/type/opaque_return_structural.swift
+++ b/test/type/opaque_return_structural.swift
@@ -66,7 +66,7 @@ func funcToAnyOpaqueCoercion() -> S1<some Any> {
 }
 
 // TODO: We should give better error messages here. The opaque types have
-// underlying types 'Int' and 'String', but the return statments have underlying
+// underlying types 'Int' and 'String', but the return statements have underlying
 // types '(Int, Int)' and '(String, Int)'.
 func structuralMismatchedReturnTypes(_ x: Bool, _ y: Int, _ z: String) -> (some P, Int) { // expected-error{{do not have matching underlying types}}
   if x {


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fixes some misspellings in Swift test/type, it is split per https://github.com/apple/swift/pull/42421#issuecomment-1101092698


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
