### PR TITLE
spelling: interpret

### DIFF
--- a/test/Misc/serialized-diagnostics-interpret-mode.swift
+++ b/test/Misc/serialized-diagnostics-interpret-mode.swift
@@ -4,11 +4,11 @@
 
 // RUN: %target-swift-frontend -typecheck -serialize-diagnostics-path %t.dia %s -verify
 // RUN: %target-swift-frontend -typecheck -serialize-diagnostics-path=%t_EQ.dia %s -verify
-// RUN: not %swift_driver -serialize-diagnostics-path %t_intepret_mode.dia %s
-// RUN: not %swift_driver -serialize-diagnostics-path=%t_EQ_intepret_mode.dia %s
+// RUN: not %swift_driver -serialize-diagnostics-path %t_interpret_mode.dia %s
+// RUN: not %swift_driver -serialize-diagnostics-path=%t_EQ_interpret_mode.dia %s
 
 // RUN: diff %t.dia %t_EQ.dia
-// RUN: diff %t.dia %t_intepret_mode.dia
-// RUN: diff %t.dia %t_EQ_intepret_mode.dia
+// RUN: diff %t.dia %t_interpret_mode.dia
+// RUN: diff %t.dia %t_EQ_interpret_mode.dia
 
 var x = 1 x = 2   // expected-error {{consecutive statements on a line must be separated by ';'}} {{10-10=;}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fixes some misspellings in Swift test/Misc/serialized-diagnostics-interpret-mode.swift, it is split per https://github.com/apple/swift/pull/42421#issuecomment-1101092698


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

fwiw, this is scary