### PR TITLE
Spelling test symbolgraph

### DIFF
--- a/test/SymbolGraph/Relationships/DefaultImplementationOf/Indirect.swift
+++ b/test/SymbolGraph/Relationships/DefaultImplementationOf/Indirect.swift
@@ -15,5 +15,5 @@ extension Q {
 
 // CHECK-DAG: "kind": "defaultImplementationOf",{{[[:space:]]*}}"source": "s:8Indirect1QPAAE3fooyyF",{{[[:space:]]*}}"target": "s:8Indirect1PP3fooyyF"
 
-// Since foo is a default implementation of a requirment, we don't consider this to be a "member"
+// Since foo is a default implementation of a requirement, we don't consider this to be a "member"
 // CHECK-NOT: memberOf

--- a/test/SymbolGraph/Symbols/SkipsSPI.swift
+++ b/test/SymbolGraph/Symbols/SkipsSPI.swift
@@ -29,11 +29,11 @@ public class ClassShouldntAppear {}
 // This struct should appear
 public struct StructShouldAppear {
 
-  // This shouldn't appear beacause it is @_spi(OtherModule), despite `StructShouldAppear`.
+  // This shouldn't appear because it is @_spi(OtherModule), despite `StructShouldAppear`.
   @_spi(OtherModule)
   public func functionShouldntAppear() {}
 
-  // This shouldn't appear beacause it is @_spi(OtherModule), despite `StructShouldAppear`.
+  // This shouldn't appear because it is @_spi(OtherModule), despite `StructShouldAppear`.
   @_spi(OtherModule)
   public struct InnerStructShouldntAppear {}
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fixes some misspellings in Swift test/SymbolGraph, it is split per https://github.com/apple/swift/pull/42421#issuecomment-1101092698


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
