### PR TITLE
Spelling test moduleinterface

### DIFF
--- a/test/ModuleInterface/ModuleCache/SDKDependencies-disable-validation.swift
+++ b/test/ModuleInterface/ModuleCache/SDKDependencies-disable-validation.swift
@@ -62,7 +62,7 @@
 // RUN: echo '2: PASSED'
 
 
-// 3) Baseline check: Make sure we use the the prebuilt module cache when using the SDK it was built with
+// 3) Baseline check: Make sure we use the prebuilt module cache when using the SDK it was built with
 //
 // RUN: %target-swift-frontend -typecheck -I %t/my-sdk -sdk %t/my-sdk -prebuilt-module-cache-path %t/prebuilt-cache -module-cache-path %t/MCP -emit-dependencies-path %t/dummy.d -track-system-dependencies -disable-modules-validate-system-headers %s
 //

--- a/test/ModuleInterface/ModuleCache/SDKDependencies.swift
+++ b/test/ModuleInterface/ModuleCache/SDKDependencies.swift
@@ -72,7 +72,7 @@
 // RUN: echo '2: PASSED'
 
 
-// 3) Baseline check: Make sure we use the the prebuilt module cache when using the SDK it was built with
+// 3) Baseline check: Make sure we use the prebuilt module cache when using the SDK it was built with
 //
 // RUN: %target-swift-frontend -typecheck -I %t/my-sdk -sdk %t/my-sdk -prebuilt-module-cache-path %t/prebuilt-cache -module-cache-path %t/MCP -emit-dependencies-path %t/dummy.d -track-system-dependencies  -emit-loaded-module-trace-path %t/trace.json %s
 //

--- a/test/ModuleInterface/ossa-modules/sdk-test-stdlib-ossa.swift
+++ b/test/ModuleInterface/ossa-modules/sdk-test-stdlib-ossa.swift
@@ -25,7 +25,7 @@
 
 // RUN: %target-swift-frontend -typecheck -sdk '%t/SDK' -prebuilt-module-cache-path '%t/PreBuiltSDKModules' -module-cache-path %t/TempModuleCacheOther -resource-dir '' -parse-stdlib -Rmodule-interface-rebuild %S/Inputs/sdk-test-stdlib-no-ossa-referent-no-rebuild-remark.swift -verify -enable-ossa-modules
 
-// Flacky hangs: rdar://77288690
+// Flaky hangs: rdar://77288690
 // UNSUPPORTED: CPU=arm64, CPU=arm64e
 
 @_fixed_layout

--- a/test/ModuleInterface/swift_build_sdk_interfaces/compiler-crash-windows.test-sh
+++ b/test/ModuleInterface/swift_build_sdk_interfaces/compiler-crash-windows.test-sh
@@ -1,4 +1,4 @@
-# This test is intentionally specialized on windows becauase not --crash behaves
+# This test is intentionally specialized on windows because not --crash behaves
 # differently there. The exit code from the crashing frontend invocations is
 # mapped to `-21` there, which lit's `not` along does not remap correctly.
 # See rdar://59397376


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fixes some misspellings in Swift test/ModuleInterface, it is split per https://github.com/apple/swift/pull/42421#issuecomment-1101092698


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
