### PR TITLE
spelling: that

### DIFF
--- a/test/NameLookup/Inputs/lazy_function_body_expansion_helper.swift
+++ b/test/NameLookup/Inputs/lazy_function_body_expansion_helper.swift
@@ -1,5 +1,5 @@
 // Body of closure in parameter to call of closureTaker is created lazily
-// and this test ensures that that body scope does get expanded
+// and this test ensures that body scope does get expanded
 var v = closureTaker {
   func amIFound() {}
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fixes some misspellings in Swift test/NameLookup, it is split per https://github.com/apple/swift/pull/42421#issuecomment-1101092698


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
