### PR TITLE
Spelling lib printasclang

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -289,7 +289,7 @@ private:
     printDocumentationComment(CD);
 
     // This is just for testing, so we check explicitly for the attribute instead
-    // of asking if the class is weak imported. If the class has availablility,
+    // of asking if the class is weak imported. If the class has availability,
     // we'll print a SWIFT_AVAIALBLE() which implies __attribute__((weak_imported))
     // already.
     if (CD->getAttrs().hasAttribute<WeakLinkedAttr>())

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -290,7 +290,7 @@ private:
 
     // This is just for testing, so we check explicitly for the attribute instead
     // of asking if the class is weak imported. If the class has availability,
-    // we'll print a SWIFT_AVAIALBLE() which implies __attribute__((weak_imported))
+    // we'll print a SWIFT_AVAILABLE() which implies __attribute__((weak_imported))
     // already.
     if (CD->getAttrs().hasAttribute<WeakLinkedAttr>())
       os << "SWIFT_WEAK_IMPORT\n";


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fixes some misspellings in Swift lib/PrintAsClang, it is split per https://github.com/apple/swift/pull/42421#issuecomment-1101092698


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
