### PR TITLE
spelling: satisfied

### DIFF
--- a/test/Runtime/demangleToMetadata.swift
+++ b/test/Runtime/demangleToMetadata.swift
@@ -430,7 +430,7 @@ DemangleToMetadataTests.test("Nested types in extensions") {
                       .InnermostUConformsToP3<ConformsToP4a>.self,
     _typeByName("4main4SG11VA2A2P1RzlE016InnerTConformsToC0VA2A2P3Rd__rlE018InnermostUConformsfG0VyAA08ConformsfC0V_AA0jf5P2AndG0V_AA0jF3P4aVG")!)
 
-  // Failure case: Dictionary's outer `Key: Hashable` constraint not sastified
+  // Failure case: Dictionary's outer `Key: Hashable` constraint not satisfied
   expectNil(_typeByName("s10DictionaryV4mainE5InnerVyAC12ConformsToP1VSi_AC12ConformsToP1VG"))
   // Failure case: Dictionary's inner `V: P1` constraint not satisfied
   expectNil(_typeByName("s10DictionaryV4mainE5InnerVySSSi_AC12ConformsToP2VG"))


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fixes some misspellings in Swift test/Runtime, it is split per https://github.com/apple/swift/pull/42421#issuecomment-1101092698


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
