### PR TITLE
spelling: differentiate

### DIFF
--- a/lib/SyntaxParse/SyntaxTreeCreator.cpp
+++ b/lib/SyntaxParse/SyntaxTreeCreator.cpp
@@ -199,14 +199,14 @@ OpaqueSyntaxNode SyntaxTreeCreator::makeDeferredLayout(
 
 OpaqueSyntaxNode
 SyntaxTreeCreator::recordDeferredToken(OpaqueSyntaxNode deferred) {
-  // We don't diffirentiate between deferred and recorded nodes. See comment in
+  // We don't differentiate between deferred and recorded nodes. See comment in
   // makeDeferredToken.
   return deferred;
 }
 
 OpaqueSyntaxNode
 SyntaxTreeCreator::recordDeferredLayout(OpaqueSyntaxNode deferred) {
-  // We don't diffirentiate between deferred and recorded nodes. See comment in
+  // We don't differentiate between deferred and recorded nodes. See comment in
   // makeDeferredToken.
   return deferred;
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fixes some misspellings in Swift lib/SyntaxParse, it is split per https://github.com/apple/swift/pull/42421#issuecomment-1101092698


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
