### PR TITLE
Spelling test swift indent

### DIFF
--- a/test/swift-indent/basic.swift
+++ b/test/swift-indent/basic.swift
@@ -225,7 +225,7 @@ func foo(
 }
 
 
-// Sequence expressions should indent realtive to their first element. Leading
+// Sequence expressions should indent relative to their first element. Leading
 // "=" should be considered part of the sequence when present.
 //
 let arrayA = [0]

--- a/test/swift-indent/basic.swift
+++ b/test/swift-indent/basic.swift
@@ -407,7 +407,7 @@ func a() {
 }
 
 
-// Array/Dictionay/Tuple/Closure within arg list shouldn't cause their solo
+// Array/Dictionary/Tuple/Closure within arg list shouldn't cause their solo
 // closing tokens to indent.
 //
 foo(a: [


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fixes some misspellings in Swift test/swift-indent, it is split per https://github.com/apple/swift/pull/42421#issuecomment-1101092698


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
