### PR TITLE
Spelling test lit.cfg

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2528,7 +2528,7 @@ if copy_env is not None:
     config.environment[key] = os.environ[key]
 
 # On macOS reflection information is read through the dyld APIs
-# On other platorms, this information is exported through extra
+# On other platforms, this information is exported through extra
 # entry points in the Swift runtime that are only available in debug builds.
 # Windows currently does not support basic reflection support.
 if 'objc_interop' in config.available_features or ('swift_stdlib_asserts' in config.available_features and not kIsWindows):

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2454,7 +2454,7 @@ config.substitutions.append(('%raw-FileCheck', shell_quote(config.filecheck)))
 config.substitutions.append(('%import-libdispatch', getattr(config, 'import_libdispatch', '')))
 config.substitutions.append(('%import-static-libdispatch', getattr(config, 'import_libdispatch_static', '')))
 
-# Disabe COW sanity checks in the swift runtime by default.
+# Disable COW sanity checks in the swift runtime by default.
 # (But it's required to set this environment variable to something)
 config.environment['SWIFT_DEBUG_ENABLE_COW_CHECKS'] = 'false'
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fixes some misspellings in Swift test/lit.cfg, it is split per https://github.com/apple/swift/pull/42421#issuecomment-1101092698


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
