### PR TITLE
🍒 [5.7] AST: Fix bug in subclass composition minimization

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4146,6 +4146,12 @@ CanType ProtocolCompositionType::getMinimalCanonicalType(
   if (superclass)
     MinimalMembers.insert(MinimalMembers.begin(), superclass->getCanonicalType());
 
+  // If we are left with a single member and no layout constraint, the member
+  // is the minimal type. Also, note that a protocol composition cannot be
+  // constructed with a single member unless there is a layout constraint.
+  if (MinimalMembers.size() == 1 && !MinimalHasExplicitAnyObject)
+    return CanType(MinimalMembers.front());
+
   // The resulting composition is necessarily canonical.
   return CanType(build(Ctx, MinimalMembers, MinimalHasExplicitAnyObject));
 }

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4115,7 +4115,6 @@ CanType ProtocolCompositionType::getMinimalCanonicalType(
     return Reqs.front().getSecondType()->getCanonicalType();
   }
 
-  Type superclass;
   llvm::SmallVector<Type, 2> MinimalMembers;
   bool MinimalHasExplicitAnyObject = false;
   auto ifaceTy = Sig.getGenericParams().back();
@@ -4126,10 +4125,6 @@ CanType ProtocolCompositionType::getMinimalCanonicalType(
 
     switch (Req.getKind()) {
     case RequirementKind::Superclass:
-      assert((!superclass || superclass->isEqual(Req.getSecondType()))
-             && "Multiple distinct superclass constraints!");
-      superclass = Req.getSecondType();
-      break;
     case RequirementKind::Conformance:
       MinimalMembers.push_back(Req.getSecondType());
       break;
@@ -4141,10 +4136,10 @@ CanType ProtocolCompositionType::getMinimalCanonicalType(
     }
   }
 
-  // Ensure superclass bounds appear first regardless of their order among
-  // the signature's requirements.
-  if (superclass)
-    MinimalMembers.insert(MinimalMembers.begin(), superclass->getCanonicalType());
+  // A superclass constraint is always retained and must appear first in the
+  // members list.
+  assert(Composition->getMembers().front()->getClassOrBoundGenericClass() ==
+         MinimalMembers.front()->getClassOrBoundGenericClass());
 
   // If we are left with a single member and no layout constraint, the member
   // is the minimal type. Also, note that a protocol composition cannot be

--- a/test/type/subclass_composition.swift
+++ b/test/type/subclass_composition.swift
@@ -42,6 +42,8 @@ typealias OtherAndP2 = Other & P2
 
 protocol P3 : class {}
 
+protocol P4 {}
+
 struct Unrelated {}
 
 //
@@ -69,6 +71,18 @@ func alreadyConforms(_: P3 & AnyObject) {} // expected-error {{invalid redeclara
 
 func alreadyConformsMeta(_: P3.Type) {} // expected-note {{'alreadyConformsMeta' previously declared here}}
 func alreadyConformsMeta(_: (P3 & AnyObject).Type) {} // expected-error {{invalid redeclaration of 'alreadyConformsMeta'}}
+
+func notARedeclaration(_: P4) {}
+func notARedeclaration(_: P4 & AnyObject) {}
+
+do {
+  class C: P4 {}
+  struct S<T: P4> {
+    // Don't crash when computing minimal compositions inside a generic context.
+    func redeclaration(_: C & P4) {} // expected-note {{'redeclaration' previously declared here}}
+    func redeclaration(_: C & P4) {} // expected-error {{invalid redeclaration of 'redeclaration'}}
+  }
+}
 
 // SE-0156 stipulates that a composition can contain multiple classes, as long
 // as they are all the same.


### PR DESCRIPTION
* Description: Protocol composition minimization has a fast path for the case of a single requirement in the existential signature. This fast path was also supposed to prevent us from falling through to constructing a protocol composition with a single component and hitting an assertion in `ProtocolComposition::build`. When opened archetype signatures were upgraded to encompass surrounding generic contexts, the fast path ceased to serve this purpose in the presence of requirements on other generic parameters.
* Scope: Redeclaration checking involving subclass existentials.
* Risk: Low.
* Reviewers: @slavapestov
* Testing: Regression tests.
* Original PR: #58554