### PR TITLE
[build-presets] Enabled SourceKit-LSP tests on Linux

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -873,8 +873,6 @@ foundation
 libdispatch
 indexstore-db
 sourcekit-lsp
-# SourceKit-LSP tests are flaky on Linux due to rdar://92260631
-skip-test-sourcekit-lsp
 swiftdocc
 lit-args=-v --time-tests
 
@@ -1110,8 +1108,6 @@ swiftsyntax
 swiftsyntax-verify-generated-files
 indexstore-db
 sourcekit-lsp
-# SourceKit-LSP tests are flaky on Linux due to rdar://92260631
-skip-test-sourcekit-lsp
 install-llvm
 install-swift
 install-llbuild
@@ -1679,9 +1675,6 @@ skip-test-libicu
 skip-test-foundation
 skip-test-libdispatch
 skip-test-xctest
-
-# SourceKit-LSP tests are flaky on Linux due to rdar://92260631
-skip-test-sourcekit-lsp
 
 # Builds enough of the the toolchain to build a swift pacakge on macOS.
 [preset: mixin_swiftpm_package_macos_platform]


### PR DESCRIPTION
The SourceKit-LSP test failures seem to be caused by a bug of `swift test --parallel` on Linux. Since SourceKit-LSP now runs its test on Linux serially (https://github.com/apple/sourcekit-lsp/pull/490), we should be able to enable the tests again.
