### PR TITLE
[Refactoring] Fix an issue where refactoring misses to refactor references after prefix operators

### DIFF
--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -440,11 +440,6 @@ public:
         HandleLabels = Resolved.LabelType != LabelRangeType::None;
         break;
       }
-    } else if (Resolved.LabelType != LabelRangeType::None &&
-               !Config.IsNonProtocolType &&
-               // FIXME: Workaround for enum case labels until we support them
-               Config.Usage != NameUsage::Definition) {
-      return RegionType::Mismatch;
     }
 
     if (HandleLabels) {

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -310,10 +310,12 @@ static Expr *extractNameExpr(Expr *Fn) {
 
 std::pair<bool, ArgumentList *>
 NameMatcher::walkToArgumentListPre(ArgumentList *ArgList) {
-  auto Labels = getCallArgLabelRanges(getSourceMgr(), ArgList,
-                                      LabelRangeEndAt::BeforeElemStart);
-  tryResolve(Parent, ArgList->getStartLoc(), LabelRangeType::CallArg,
+  if (!ArgList->isImplicit()) {
+    auto Labels = getCallArgLabelRanges(getSourceMgr(), ArgList,
+                                        LabelRangeEndAt::BeforeElemStart);
+    tryResolve(Parent, ArgList->getStartLoc(), LabelRangeType::CallArg,
              Labels.first, Labels.second);
+  }
   if (isDone())
     return {false, ArgList};
 

--- a/test/refactoring/rename/Outputs/prefix_operator/refactor.swift.expected
+++ b/test/refactoring/rename/Outputs/prefix_operator/refactor.swift.expected
@@ -1,0 +1,6 @@
+let bar: Int = 12
+let negfoo = -bar
+print("opposite of \(bar) is \(negfoo)")
+
+
+

--- a/test/refactoring/rename/prefix_operator.swift
+++ b/test/refactoring/rename/prefix_operator.swift
@@ -1,0 +1,13 @@
+let foo: Int = 12
+let negfoo = -foo
+print("opposite of \(foo) is \(negfoo)")
+
+// RUN: %empty-directory(%t.result)
+
+// RUN: %refactor -rename -source-filename %s -pos=1:5 -new-name bar >> %t.result/def.swift
+// RUN: %target-swift-frontend-typecheck %t.result/def.swift
+// RUN: diff -u %S/Outputs/prefix_operator/refactor.swift.expected %t.result/def.swift
+
+// RUN: %refactor -rename -source-filename %s -pos=2:15 -new-name bar >> %t.result/operator_ref.swift
+// RUN: %target-swift-frontend-typecheck %t.result/operator_ref.swift
+// RUN: diff -u %S/Outputs/prefix_operator/refactor.swift.expected %t.result/operator_ref.swift


### PR DESCRIPTION
The removed `else if` branch caused the argument to the `-` operator to be be reported as `Mismatch`. I couldn’t figure out what that branch was for, so I removed it.

@akyrtzi If you have any memory what the removed `else if` branch was for, I would be interested to hear it. But I assume that you don’t remember since it’s been nearly 5 years since you upstreamed local renaming.

rdar://91588948