### PR TITLE
swift-inspect: update instructions for Windows

### DIFF
--- a/tools/swift-inspect/README.md
+++ b/tools/swift-inspect/README.md
@@ -13,7 +13,7 @@ swift-inspect can be built using [swift-package-manager](https://github.com/appl
 In order to build on Windows, some additional parameters must be passed to the build tool to locate the necessary libraries.
 
 ~~~
-swift build -Xcc -I%DEVELOPER_DIR%\Toolchains\unknown-Asserts-development.xctoolchain\usr\include\swift\SwiftRemoteMirror -Xlinker %DEVELOPER_DIR%\Toolchains\unknown-Asserts-development.xctoolchain\usr\lib\swift\windows\x86_64\swiftRemoteMirror.lib
+swift build -Xcc -I%SDKROOT%\usr\include\swift\SwiftRemoteMirror -Xlinker %SDKROOT%\usr\lib\swift\windows\x86_64\swiftRemoteMirror.lib
 ~~~
 
 ### Using


### PR DESCRIPTION
Remove the reference to `DEVELOPER_DIR` and update the instructions to
actually be usable with a released snapshot (and official releases).
The development setup should mimic the actual layout further and is a
separate issue.  This requires a new snapshot with
apple/swift-installer-scripts#128 included.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
