### PR TITLE
[Syntax] Classify contextual keywords used as decl attribute as contextual keyword

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3871,6 +3871,8 @@ bool Parser::parseDeclModifierList(DeclAttributes &Attributes,
       if (Kind == DAK_Count)
         break;
 
+      Tok.setKind(tok::contextual_keyword);
+
       if (Kind == DAK_Actor) {
         // If the next token is a startOfSwiftDecl, we are part of the modifier
         // list and should consume the actor token (e.g, actor public class Foo)

--- a/test/Syntax/Inputs/serialize_class_decl.json
+++ b/test/Syntax/Inputs/serialize_class_decl.json
@@ -1,0 +1,107 @@
+{
+  "kind": "SourceFile",
+  "layout": [
+    {
+      "kind": "CodeBlockItemList",
+      "layout": [
+        {
+          "kind": "CodeBlockItem",
+          "layout": [
+            {
+              "kind": "ClassDecl",
+              "layout": [
+                null,
+                {
+                  "kind": "ModifierList",
+                  "layout": [
+                    {
+                      "kind": "DeclModifier",
+                      "layout": [
+                        {
+                          "tokenKind": {
+                            "kind": "contextual_keyword",
+                            "text": "final"
+                          },
+                          "leadingTrivia": "\/\/ RUN: %swift-syntax-test -input-source-filename %s -serialize-raw-tree > %t\n\/\/ RUN: diff %t %S\/Inputs\/serialize_class_decl.json -u\n\n",
+                          "trailingTrivia": " ",
+                          "presence": "Present"
+                        },
+                        null,
+                        null,
+                        null
+                      ],
+                      "presence": "Present"
+                    }
+                  ],
+                  "presence": "Present"
+                },
+                {
+                  "tokenKind": {
+                    "kind": "kw_class"
+                  },
+                  "leadingTrivia": "",
+                  "trailingTrivia": " ",
+                  "presence": "Present"
+                },
+                {
+                  "tokenKind": {
+                    "kind": "identifier",
+                    "text": "Foo"
+                  },
+                  "leadingTrivia": "",
+                  "trailingTrivia": " ",
+                  "presence": "Present"
+                },
+                null,
+                null,
+                null,
+                {
+                  "kind": "MemberDeclBlock",
+                  "layout": [
+                    {
+                      "tokenKind": {
+                        "kind": "l_brace"
+                      },
+                      "leadingTrivia": "",
+                      "trailingTrivia": "",
+                      "presence": "Present"
+                    },
+                    {
+                      "kind": "MemberDeclList",
+                      "layout": [],
+                      "presence": "Present"
+                    },
+                    {
+                      "tokenKind": {
+                        "kind": "r_brace"
+                      },
+                      "leadingTrivia": "",
+                      "trailingTrivia": "",
+                      "presence": "Present"
+                    }
+                  ],
+                  "presence": "Present"
+                }
+              ],
+              "presence": "Present"
+            },
+            null,
+            null
+          ],
+          "presence": "Present"
+        }
+      ],
+      "presence": "Present"
+    },
+    {
+      "tokenKind": {
+        "kind": "eof",
+        "text": ""
+      },
+      "leadingTrivia": "\n",
+      "trailingTrivia": "",
+      "presence": "Present"
+    }
+  ],
+  "presence": "Present"
+}

--- a/test/Syntax/Inputs/serialize_distributed_actor.json
+++ b/test/Syntax/Inputs/serialize_distributed_actor.json
@@ -19,7 +19,7 @@
                       "layout": [
                         {
                           "tokenKind": {
-                            "kind": "identifier",
+                            "kind": "contextual_keyword",
                             "text": "distributed"
                           },
                           "leadingTrivia": "\/\/ RUN: %swift-syntax-test -input-source-filename %s -serialize-raw-tree > %t\n\/\/ RUN: diff %t %S\/Inputs\/serialize_distributed_actor.json -u\n\n",
@@ -85,7 +85,7 @@
                                       "layout": [
                                         {
                                           "tokenKind": {
-                                            "kind": "identifier",
+                                            "kind": "contextual_keyword",
                                             "text": "distributed"
                                           },
                                           "leadingTrivia": "\n    ",

--- a/test/Syntax/serialize_class_decl.swift
+++ b/test/Syntax/serialize_class_decl.swift
@@ -1,0 +1,4 @@
+// RUN: %swift-syntax-test -input-source-filename %s -serialize-raw-tree > %t
+// RUN: diff %t %S/Inputs/serialize_class_decl.json -u
+
+final class Foo {}


### PR DESCRIPTION
Previously, we classified e.g. final as an identifier, but it should be qualified as a contextual keyword.

rdar://92463926 [apple/swift-syntax#387]