### PR TITLE
Use less exotic unicode chars

### DIFF
--- a/validation-test/Python/line-directive.swift
+++ b/validation-test/Python/line-directive.swift
@@ -1,2 +1,2 @@
 // RUN: %{python} %utils/line-directive
-// RUN: %{python} %utils/line-directive -- %{python} -c "print('Hello 😄🂐')"
+// RUN: %{python} %utils/line-directive -- %{python} -c "print('你好')"


### PR DESCRIPTION
The characters used before were in the private-use section had surrogate
chars. This led to issues with some python utf8 decoder implementations
resulting in the error

```
UnicodeEncodeError: 'utf-8' codec can't encode characters in position
13-20: surrogates not allowed
```

This uses more normal utf8 characters that should hopefully work
everywhere while still exhibiting issues decoding to ascii.

rdar://92613094