### PR TITLE
[Test] Temporarily disable test/Interop/Cxx/stdlib/use-std-string.swift

### DIFF
--- a/test/Interop/Cxx/stdlib/use-std-string.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string.swift
@@ -5,6 +5,8 @@
 // Enable this everywhere once we have a solution for modularizing other C++ stdlibs: rdar://87654514
 // REQUIRES: OS=macosx || OS=linux-gnu
 
+// REQUIRES: rdar92621793
+
 import StdlibUnittest
 import StdString
 #if os(Linux)


### PR DESCRIPTION
Disable failing test while it's being looked into.