### PR TITLE
[5.7][CSClosure] Per element variable finder shouldn't walk into closures

### DIFF
--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -49,6 +49,10 @@ public:
       : CS(cs), Parent(parent), ReferencedVars(referencedVars) {}
 
   std::pair<bool, Expr *> walkToExprPre(Expr *expr) override {
+    // Don't walk into into inner closures.
+    if (isa<ClosureExpr>(expr))
+      return {false, expr};
+
     if (auto *DRE = dyn_cast<DeclRefExpr>(expr)) {
       if (auto type = CS.getTypeIfAvailable(DRE->getDecl()))
         inferVariables(type);

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -329,3 +329,22 @@ func test_unknown_refs_in_tilde_operator() {
     }
   }
 }
+
+// Type finder should not walk into inner closures, otherwise
+// it would be able to find `return 42` and bring result type
+// into scope while solving for pattern binding `x`.
+func test_type_finder_doesnt_walk_into_inner_closures() {
+  func test<T>(fn: () -> T) -> T { fn() }
+
+  _ = test { // Ok
+    let x = test {
+      42
+    }
+
+    let _ = test {
+      test { "" }
+    }
+
+    return x
+  }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/58626

---

Walking into a closure that has an explicit or implicit return
statement would bring into scope the type variable that represents
the result of the current closure.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
