### PR TITLE
[SwiftSyntax] Decode error message in incr_transefer_round_trip.py

### DIFF
--- a/utils/incrparse/incr_transfer_round_trip.py
+++ b/utils/incrparse/incr_transfer_round_trip.py
@@ -93,7 +93,7 @@ def main():
         print('Test case "%s" of %s FAILed' % (test_case, test_file),
               file=sys.stderr)
         print('Parsing the swift file failed:\n', file=sys.stderr)
-        print(e.output, file=sys.stderr)
+        print(e.output.decode('UTF-8'), file=sys.stderr)
         sys.exit(1)
 
     # Check if the two syntax trees are the same


### PR DESCRIPTION
Otherwise, we output the error as a binary string. I think this started happening with the switch to Python 3.