### PR TITLE
[5.7][Refactoring] Fix a crash that occurred when converting if/else of enum with raw value to switch statement

### DIFF
--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -2514,14 +2514,24 @@ bool RefactoringActionConvertToSwitchStmt::performChange() {
     SourceManager &SM;
 
     bool isFunctionNameAllowed(BinaryExpr *E) {
-      auto FunctionBody = dyn_cast<DotSyntaxCallExpr>(E->getFn())->getFn();
-      auto FunctionDeclaration = dyn_cast<DeclRefExpr>(FunctionBody)->getDecl();
-      const auto FunctionName = dyn_cast<FuncDecl>(FunctionDeclaration)
-          ->getBaseIdentifier().str();
-      return FunctionName == "~="
-      || FunctionName == "=="
-      || FunctionName == "__derived_enum_equals"
-      || FunctionName == "__derived_struct_equals";
+      Expr *Fn = E->getFn();
+      if (auto DotSyntaxCall = dyn_cast_or_null<DotSyntaxCallExpr>(Fn)) {
+        Fn = DotSyntaxCall->getFn();
+      }
+      DeclRefExpr *DeclRef = dyn_cast_or_null<DeclRefExpr>(Fn);
+      if (!DeclRef) {
+        return false;
+      }
+      auto FunctionDeclaration = dyn_cast_or_null<FuncDecl>(DeclRef->getDecl());
+      if (!FunctionDeclaration) {
+        return false;
+      }
+      auto &ASTCtx = FunctionDeclaration->getASTContext();
+      const auto FunctionName = FunctionDeclaration->getBaseIdentifier();
+      return FunctionName == ASTCtx.Id_MatchOperator ||
+             FunctionName == ASTCtx.Id_EqualsOperator ||
+             FunctionName == ASTCtx.Id_derived_enum_equals ||
+             FunctionName == ASTCtx.Id_derived_struct_equals;
     }
 
     void appendPattern(Expr *LHS, Expr *RHS) {

--- a/test/refactoring/ConvertToSwitchStmt/Outputs/enum_with_raw_value/L8-3.swift.expected
+++ b/test/refactoring/ConvertToSwitchStmt/Outputs/enum_with_raw_value/L8-3.swift.expected
@@ -1,0 +1,21 @@
+enum EnumWithUnderlyingValue: String {
+    case north, south, east, west
+}
+
+
+
+func foo(test: EnumWithUnderlyingValue) {
+  switch test {
+case .north:
+print("north")
+case .south:
+print("south")
+case .east:
+print("east")
+default:
+break
+}
+}
+
+
+

--- a/test/refactoring/ConvertToSwitchStmt/basic.swift
+++ b/test/refactoring/ConvertToSwitchStmt/basic.swift
@@ -131,7 +131,7 @@ func checkEmptyBody(e: E) {
   }
 }
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
 
 // RUN: %refactor -convert-to-switch-stmt -source-filename %s -pos=9:3 -end-pos=16:4 > %t.result/L9-3.swift
 // RUN: %target-swift-frontend-typecheck %t.result/L9-3.swift

--- a/test/refactoring/ConvertToSwitchStmt/enum_with_raw_value.swift
+++ b/test/refactoring/ConvertToSwitchStmt/enum_with_raw_value.swift
@@ -1,0 +1,22 @@
+enum EnumWithUnderlyingValue: String {
+    case north, south, east, west
+}
+
+
+
+func foo(test: EnumWithUnderlyingValue) {
+  if test == .north {
+    print("north")
+  } else if test == .south {
+    print("south")
+  } else if test == .east {
+    print("east")
+  }
+}
+
+
+// RUN: %empty-directory(%t.result)
+
+// RUN: %refactor -convert-to-switch-stmt -source-filename %s -pos=8:3 -end-pos=14:4 > %t.result/L8-3.swift
+// RUN: %target-swift-frontend-typecheck %t.result/L8-3.swift
+// RUN: diff -u %S/Outputs/enum_with_raw_value/L8-3.swift.expected %t.result/L8-3.swift


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/58611 to release/5.7

---

* **Explanation**: If you try to refactor an `if … else if` statement to a switch statement and the enum that is being conformed to has an underlying raw value, refactoring would crash. This PR fixes the crash.
* **Scope**: “Refactor to Switch Statement” refactoring
* **Risk**: Low, this only changes behavior in situations that would previously crash with a `nullptr` issue
* **Testing**: Added regression test case
* **Issue**: rdar://84707973
* **Reviewer**: @bnbarham on https://github.com/apple/swift/pull/58611 