### PR TITLE
[5.7][CodeCompletion] Avoid creating circles in the USRBasedType supertype hierarchy

### DIFF
--- a/lib/IDE/CodeCompletionResultType.cpp
+++ b/lib/IDE/CodeCompletionResultType.cpp
@@ -203,10 +203,38 @@ const USRBasedType *USRBasedType::fromType(Type Ty, USRBasedTypeArena &Arena) {
           Conformance->getProtocol()->getDeclaredInterfaceType(), Arena));
     }
   }
-  Type Superclass = Ty->getSuperclass();
+
+  // You would think that superclass + conformances form a DAG. You are wrong!
+  // We can achieve a circular supertype hierarcy with
+  //
+  // protocol Proto : Class {}
+  // class Class : Proto {}
+  //
+  // USRBasedType is not set up for this. Serialization of code completion
+  // results from global modules can't handle cycles in the supertype hierarchy
+  // because it writes the DAG leaf to root(s) and needs to know the type
+  // offsets. To get consistent results independent of where we start
+  // constructing USRBasedTypes, ignore superclasses of protocols. If we kept
+  // track of already visited types, we would get different results depending on
+  // whether we start constructing the USRBasedType hierarchy from Proto or
+  // Class.
+  // Ignoring superclasses of protocols is safe to do because USRBasedType is an
+  // under-approximation anyway.
+
+  /// If `Ty` is a class type and has a superclass, return that. In all other
+  /// cases, return null.
+  auto getSuperclass = [](Type Ty) -> Type {
+    if (isa_and_nonnull<ClassDecl>(Ty->getAnyNominal())) {
+      return Ty->getSuperclass();
+    } else {
+      return Type();
+    }
+  };
+
+  Type Superclass = getSuperclass(Ty);
   while (Superclass) {
     Supertypes.push_back(USRBasedType::fromType(Superclass, Arena));
-    Superclass = Superclass->getSuperclass();
+    Superclass = getSuperclass(Superclass);
   }
 
   assert(llvm::all_of(Supertypes, [&USR](const USRBasedType *Ty) {

--- a/validation-test/IDE/crashers_2_fixed/rdar91765262.swift
+++ b/validation-test/IDE/crashers_2_fixed/rdar91765262.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/ImportPath)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swift-frontend -disable-availability-checking -emit-module %t/Lib.swift -o %t/ImportPath/Lib.swiftmodule -emit-module-interface-path %t/ImportPath/Lib.swiftinterface
+
+// BEGIN Lib.swift
+
+// Proto and Class have a circular supertype relationship.
+
+public protocol Proto : Class {}
+public class Class : Proto {}
+
+// BEGIN test.swift
+
+import Lib
+
+// RUN: %empty-directory(%t/completion-cache)
+// RUN: %target-swift-ide-test -code-completion -source-filename %t/test.swift -code-completion-token COMPLETE -I %t/ImportPath
+
+func test() -> Proto {
+  return #^COMPLETE^#
+}


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/58522 to release/5.7

---

* **Explanation**: You are able to create circles in the superclass + conformance supertype hierarchy using
```swift
protocol Proto : Class {}
class Class : Proto {}
```
`USRBasedType`, which we use to model types for cached code completion results from other modules isn’t set up for this, it assumes that the supertype hierarchy forms a DAG (see main PR for more detail) and crashes with a stack overflow if an imported module contains such a circular type structure. To fix, ignore any superclass requirements on protocols, which eliminates the possibility of this super type circle.
* **Scope**: Type relation computation (i.e. scoring) for code completion items that conform to a protocol with a superclass requirement.
* **Risk**: Low
* **Testing**: Added regression test
* **Issue**: rdar://91765262
* **Reviewer**: @bnbarham on https://github.com/apple/swift/pull/58522