### PR TITLE
[cxx-interop] Fix `test/Interop/Cxx/stdlib/use-std-string.swift`

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5655,10 +5655,20 @@ ClangImporter::getCXXFunctionTemplateSpecialization(SubstitutionMap subst,
 }
 
 bool ClangImporter::isCXXMethodMutating(const clang::CXXMethodDecl *method) {
-  return isa<clang::CXXConstructorDecl>(method) || !method->isConst() ||
-         (method->getParent()->hasMutableFields() &&
-          !isAnnotatedWith(method, "nonmutating")) ||
-         isAnnotatedWith(method, "mutating");
+  if (isa<clang::CXXConstructorDecl>(method) || !method->isConst())
+    return true;
+  if (isAnnotatedWith(method, "mutating"))
+    return true;
+  if (method->getParent()->hasMutableFields()) {
+    if (isAnnotatedWith(method, "nonmutating"))
+      return false;
+    // FIXME(rdar://91961524): figure out a way to handle mutable fields
+    // without breaking classes from the C++ standard library (e.g.
+    // `std::string` which has a mutable member in old libstdc++ version used on
+    // CentOS 7)
+    return false;
+  }
+  return false;
 }
 
 bool ClangImporter::isAnnotatedWith(const clang::CXXMethodDecl *method,

--- a/test/Interop/Cxx/class/mutability-annotations-module-interface.swift
+++ b/test/Interop/Cxx/class/mutability-annotations-module-interface.swift
@@ -8,7 +8,7 @@
 
 // CHECK: struct HasMutableProperty {
 // CHECK:   func annotatedNonMutating() -> Int32
-// CHECK:   mutating func noAnnotation() -> Int32
+// TODO-CHECK:   mutating func noAnnotation() -> Int32
 // CHECK:   mutating func contradictingAnnotations() -> Int32
 // CHECK:   func duplicateAnnotations() -> Int32
 // CHECK:   var a: Int32

--- a/test/Interop/Cxx/class/mutability-annotations-typechecker.swift
+++ b/test/Interop/Cxx/class/mutability-annotations-typechecker.swift
@@ -6,10 +6,10 @@ let obj = HasConstMethodAnnotatedAsMutating(a: 42) // expected-note {{change 'le
 let i = obj.annotatedMutating() // expected-error {{cannot use mutating member on immutable value: 'obj' is a 'let' constant}}
 
 let objWMutableProperty = HasMutableProperty(a: 42, b: 21) // expected-note {{change 'let' to 'var' to make it mutable}}
-// expected-note@-1 {{change 'let' to 'var' to make it mutable}}
+// TODO-note@-1 {{change 'let' to 'var' to make it mutable}}
 
 let _ = objWMutableProperty.annotatedNonMutating()
-let _ = objWMutableProperty.noAnnotation() // expected-error {{cannot use mutating member on immutable value: 'objWMutableProperty' is a 'let' constant}}
+let _ = objWMutableProperty.noAnnotation() // TODO-error {{cannot use mutating member on immutable value: 'objWMutableProperty' is a 'let' constant}}
 let _ = objWMutableProperty.contradictingAnnotations() // expected-error {{cannot use mutating member on immutable value: 'objWMutableProperty' is a 'let' constant}}
 let _ = objWMutableProperty.duplicateAnnotations()
 

--- a/test/Interop/Cxx/stdlib/use-std-string.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string.swift
@@ -5,8 +5,6 @@
 // Enable this everywhere once we have a solution for modularizing other C++ stdlibs: rdar://87654514
 // REQUIRES: OS=macosx || OS=linux-gnu
 
-// REQUIRES: rdar92621793
-
 import StdlibUnittest
 import StdString
 #if os(Linux)


### PR DESCRIPTION
Temporarily disable the checks for mutable fields in a C++ struct. A better solution would be to use some heuristic to detect if a method mutates a mutable field, and allow the user to adjust mutability with the existing `nonmutating` annotation.

This test was disabled in https://github.com/apple/swift/pull/58622.

rdar://92621793