### PR TITLE
[5.7] [Parse] Update for new regex compiler interface

### DIFF
--- a/lib/Parse/ParseRegex.cpp
+++ b/lib/Parse/ParseRegex.cpp
@@ -43,7 +43,7 @@ ParserResult<Expr> Parser::parseExprRegexLiteral() {
 
   // Let the Swift library parse the contents, returning an error, or null if
   // successful.
-  unsigned version;
+  unsigned version = 0;
   auto capturesBuf = Context.AllocateUninitialized<uint8_t>(
       RegexLiteralExpr::getCaptureStructureSerializationAllocationSize(
           regexText.size()));
@@ -57,6 +57,7 @@ ParserResult<Expr> Parser::parseExprRegexLiteral() {
   if (hadError) {
     return makeParserResult(new (Context) ErrorExpr(loc));
   }
+  assert(version >= 1);
   return makeParserResult(RegexLiteralExpr::createParsed(
       Context, loc, regexText, version, capturesBuf));
 }

--- a/test/StringProcessing/Parse/forward-slash-regex.swift
+++ b/test/StringProcessing/Parse/forward-slash-regex.swift
@@ -169,8 +169,6 @@ _ = 0 . / 1 / 2 // expected-error {{expected member name following '.'}}
 
 switch "" {
 case /x/:
-  // expected-error@-1 {{expression pattern of type 'Regex<Substring>' cannot match values of type 'String'}}
-  // expected-note@-2 {{overloads for '~=' exist with these partially matching parameter lists: (Substring, String)}}
   break
 case _ where /x /:
   // expected-error@-1 {{cannot convert value of type 'Regex<Substring>' to expected condition type 'Bool'}}


### PR DESCRIPTION
*5.7 cherry-pick of https://github.com/apple/swift/pull/58463*

---

Update to match the new compiler interface in https://github.com/apple/swift-experimental-string-processing/pull/364.