### PR TITLE
[AutoDiff] Disable tests on `use_os_stdlib` or `back_deployment_runtime`

### DIFF
--- a/test/AutoDiff/stdlib/lit.local.cfg
+++ b/test/AutoDiff/stdlib/lit.local.cfg
@@ -1,0 +1,4 @@
+# AutoDiff is not shipped in any OS and does not support backdeployment
+if 'use_os_stdlib' in config.available_features or \
+   'back_deployment_runtime' in config.available_features:
+    config.unsupported = True

--- a/test/AutoDiff/stdlib/simd.swift
+++ b/test/AutoDiff/stdlib/simd.swift
@@ -2,8 +2,6 @@
 // REQUIRES: executable_test
 
 // Would fail due to unavailability of swift_autoDiffCreateLinearMapContext.
-// UNSUPPORTED: use_os_stdlib
-// UNSUPPORTED: back_deployment_runtime
 
 import _Differentiation
 import StdlibUnittest

--- a/test/AutoDiff/validation-test/address_only_tangentvector.swift
+++ b/test/AutoDiff/validation-test/address_only_tangentvector.swift
@@ -2,8 +2,6 @@
 // REQUIRES: executable_test
 
 // Would fail due to unavailability of swift_autoDiffCreateLinearMapContext.
-// UNSUPPORTED: use_os_stdlib
-// UNSUPPORTED: back_deployment_runtime
 
 import StdlibUnittest
 import DifferentiationUnittest

--- a/test/AutoDiff/validation-test/array.swift
+++ b/test/AutoDiff/validation-test/array.swift
@@ -3,8 +3,6 @@
 // REQUIRES: executable_test
 
 // Would fail due to unavailability of swift_autoDiffCreateLinearMapContext.
-// UNSUPPORTED: use_os_stdlib
-// UNSUPPORTED: back_deployment_runtime
 
 import StdlibUnittest
 import _Differentiation

--- a/test/AutoDiff/validation-test/inout_parameters.swift
+++ b/test/AutoDiff/validation-test/inout_parameters.swift
@@ -2,8 +2,6 @@
 // REQUIRES: executable_test
 
 // Would fail due to unavailability of swift_autoDiffCreateLinearMapContext.
-// UNSUPPORTED: use_os_stdlib
-// UNSUPPORTED: back_deployment_runtime
 
 // `inout` parameter differentiation tests.
 

--- a/test/AutoDiff/validation-test/lit.local.cfg
+++ b/test/AutoDiff/validation-test/lit.local.cfg
@@ -1,0 +1,4 @@
+# AutoDiff is not shipped in any OS and does not support backdeployment
+if 'use_os_stdlib' in config.available_features or \
+   'back_deployment_runtime' in config.available_features:
+    config.unsupported = True


### PR DESCRIPTION
AutoDiff is not ABI-stable and not shipped in any OS. We disable all AutoDiff runtime tests with `use_os_stdlib` or `back_deployment_runtime`.