### PR TITLE
[stdlib][docs] Slightly clarify Hashable docs

### DIFF
--- a/stdlib/public/core/Hashable.swift
+++ b/stdlib/public/core/Hashable.swift
@@ -109,6 +109,7 @@ public protocol Hashable: Equatable {
   ///
   /// - Important: `hashValue` is deprecated as a `Hashable` requirement. To
   ///   conform to `Hashable`, implement the `hash(into:)` requirement instead.
+  ///   (The compiler will provide an implementation for `hashValue` for you.)
   var hashValue: Int { get }
 
   /// Hashes the essential components of this value by feeding them into the
@@ -119,8 +120,9 @@ public protocol Hashable: Equatable {
   /// in your type's `==` operator implementation. Call `hasher.combine(_:)`
   /// with each of these components.
   ///
-  /// - Important: Never call `finalize()` on `hasher`. Doing so may become a
-  ///   compile-time error in the future.
+  /// - Important: `hash(into:)` implementations must never call `finalize()` on
+  ///    the `hasher` instance provided, or replace it with a different
+  ///    instance. Doing so may become compile-time errors in the future.
   ///
   /// - Parameter hasher: The hasher to use when combining the components
   ///   of this instance.


### PR DESCRIPTION
In `hash(into:)` docs, clarify that the prohibition on calling `finalize()` only applies to the hasher instance that is passed to the `hash(into:)` method -- it is not intended to forbid calling `finalize` in general. Also note that replacing the instance is likewise prohibited.

In `hashValue`, explain that the compiler will take care of providing a suitable implementation.