### PR TITLE
[stdlib] Stop printing collection elements in their debug form

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1453,14 +1453,14 @@ extension Array: CustomReflectable {
 extension Array: CustomStringConvertible, CustomDebugStringConvertible {
   /// A textual representation of the array and its elements.
   public var description: String {
-    return _makeCollectionDescription()
+    _makeCollectionDescription()
   }
 
   /// A textual representation of the array and its elements, suitable for
   /// debugging.
   public var debugDescription: String {
     // Always show sugared representation for Arrays.
-    return _makeCollectionDescription()
+    _makeCollectionDescription(usingDebugDescriptions: true)
   }
 }
 

--- a/stdlib/public/core/ArrayShared.swift
+++ b/stdlib/public/core/ArrayShared.swift
@@ -94,12 +94,18 @@ func _finalizeUninitializedArray<Element>(
 }
 #endif
 
-extension Collection {  
-  // Utility method for collections that wish to implement
-  // CustomStringConvertible and CustomDebugStringConvertible using a bracketed
-  // list of elements, like an array.
+extension Collection {
+  /// Utility method for collections that wish to implement
+  /// `CustomStringConvertible` and `CustomDebugStringConvertible` using a
+  /// bracketed list of elements, like an array.
+  ///
+  /// - Parameter type: If non-nil, wrap the generated description in an
+  ///     emulated initializer invocation for the specified type name.
+  /// - Parameter debug: If true, print elements using their debug-style
+  ///     descriptions. Otherwise use a regular string conversion.
   internal func _makeCollectionDescription(
-    withTypeName type: String? = nil
+    withTypeName type: String? = nil,
+    usingDebugDescriptions debug: Bool = false
   ) -> String {
 #if !SWIFT_STDLIB_STATIC_PRINT
     var result = ""
@@ -116,7 +122,11 @@ extension Collection {
       } else {
         result += ", "
       }
-      debugPrint(item, terminator: "", to: &result)
+      if debug {
+        debugPrint(item, terminator: "", to: &result)
+      } else {
+        print(item, terminator: "", to: &result)
+      }
     }
     result += type != nil ? "])" : "]"
     return result

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -1133,13 +1133,14 @@ extension ArraySlice: CustomReflectable {
 extension ArraySlice: CustomStringConvertible, CustomDebugStringConvertible {
   /// A textual representation of the array and its elements.
   public var description: String {
-    return _makeCollectionDescription()
+    _makeCollectionDescription()
   }
 
   /// A textual representation of the array and its elements, suitable for
   /// debugging.
   public var debugDescription: String {
-    return _makeCollectionDescription(withTypeName: "ArraySlice")
+    _makeCollectionDescription(
+      withTypeName: "ArraySlice", usingDebugDescriptions: true)
   }
 }
 

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -1034,13 +1034,14 @@ extension ContiguousArray: CustomReflectable {
 extension ContiguousArray: CustomStringConvertible, CustomDebugStringConvertible {
   /// A textual representation of the array and its elements.
   public var description: String {
-    return _makeCollectionDescription()
+    _makeCollectionDescription()
   }
 
   /// A textual representation of the array and its elements, suitable for
   /// debugging.
   public var debugDescription: String {
-    return _makeCollectionDescription(withTypeName: "ContiguousArray")
+    _makeCollectionDescription(
+      withTypeName: "ContiguousArray", usingDebugDescriptions: true)
   }
 }
 

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1397,11 +1397,12 @@ extension Dictionary {
     }
 
     public var description: String {
-      return _makeCollectionDescription()
+      _makeCollectionDescription()
     }
 
     public var debugDescription: String {
-      return _makeCollectionDescription(withTypeName: "Dictionary.Keys")
+      _makeCollectionDescription(
+        withTypeName: "Dictionary.Keys", usingDebugDescriptions: true)
     }
   }
 
@@ -1479,11 +1480,12 @@ extension Dictionary {
     }
 
     public var description: String {
-      return _makeCollectionDescription()
+      _makeCollectionDescription()
     }
 
     public var debugDescription: String {
-      return _makeCollectionDescription(withTypeName: "Dictionary.Values")
+      _makeCollectionDescription(
+        withTypeName: "Dictionary.Values", usingDebugDescriptions: true)
     }
 
     @inlinable
@@ -1675,13 +1677,13 @@ extension Collection {
   // list of elements.
   // FIXME: Doesn't use the withTypeName argument yet
   internal func _makeKeyValuePairDescription<K, V>(
-    withTypeName type: String? = nil
+    withTypeName type: String? = nil,
+    usingDebugDescriptions debug: Bool = false
   ) -> String where Element == (key: K, value: V) {
 #if !SWIFT_STDLIB_STATIC_PRINT
     if self.isEmpty {
       return "[:]"
     }
-    
     var result = "["
     var first = true
     for (k, v) in self {
@@ -1690,9 +1692,17 @@ extension Collection {
       } else {
         result += ", "
       }
-      debugPrint(k, terminator: "", to: &result)
+      if debug {
+        debugPrint(k, terminator: "", to: &result)
+      } else {
+        print(k, terminator: "", to: &result)
+      }
       result += ": "
-      debugPrint(v, terminator: "", to: &result)
+      if debug {
+        debugPrint(v, terminator: "", to: &result)
+      } else {
+        print(v, terminator: "", to: &result)
+      }
     }
     result += "]"
     return result
@@ -1705,13 +1715,13 @@ extension Collection {
 extension Dictionary: CustomStringConvertible, CustomDebugStringConvertible {
   /// A string that represents the contents of the dictionary.
   public var description: String {
-    return _makeKeyValuePairDescription()
+    _makeKeyValuePairDescription()
   }
 
   /// A string that represents the contents of the dictionary, suitable for
   /// debugging.
   public var debugDescription: String {
-    return _makeKeyValuePairDescription()
+    _makeKeyValuePairDescription(usingDebugDescriptions: true)
   }
 }
 

--- a/stdlib/public/core/KeyValuePairs.swift
+++ b/stdlib/public/core/KeyValuePairs.swift
@@ -128,7 +128,7 @@ extension KeyValuePairs: RandomAccessCollection {
 extension KeyValuePairs: CustomStringConvertible {
   /// A string that represents the contents of the dictionary.
   public var description: String {
-    return _makeKeyValuePairDescription()
+    _makeKeyValuePairDescription()
   }
 }
 
@@ -136,7 +136,7 @@ extension KeyValuePairs: CustomDebugStringConvertible {
   /// A string that represents the contents of the dictionary, suitable for
   /// debugging.
   public var debugDescription: String {
-    return _makeKeyValuePairDescription()
+    _makeKeyValuePairDescription(usingDebugDescriptions: true)
   }
 }
 

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -1031,12 +1031,13 @@ extension Set: SetAlgebra {
 extension Set: CustomStringConvertible, CustomDebugStringConvertible {
   /// A string that represents the contents of the set.
   public var description: String {
-    return _makeCollectionDescription()
+    _makeCollectionDescription()
   }
 
   /// A string that represents the contents of the set, suitable for debugging.
   public var debugDescription: String {
-    return _makeCollectionDescription(withTypeName: "Set")
+    _makeCollectionDescription(
+      withTypeName: "Set", usingDebugDescriptions: true)
   }
 }
 


### PR DESCRIPTION
In the `CustomStringConvertible` conformances of standard collection types, we currently print elements using `debugPrint` rather than `print`. This is useful for a handful of string types (`String`,
`Substring`, possibly `Unicode.Scalar`, `Character`, etc), because it takes care of properly quoting the results, but it’s not the right choice in general.

Switch to using `print` in `description` implementations. (We’ll need to do something about string types — e.g., special casing them — but first, let’s see if there are any other undesired consequences.)
