### PR TITLE
[Distributed][Workaround] Initializers crash when DA has state and uses the local testing system

### DIFF
--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -472,7 +472,6 @@ bool AbstractFunctionDecl::isDistributedActorSystemRemoteCall(bool isVoidReturn)
   if (!invocationParam->isInOut()) {
     return false;
   }
-
   // --- Check parameter: throwing: Err.Type
   auto thrownTypeParam = params->get(3);
   if (thrownTypeParam->getArgumentName() != C.Id_throwing) {

--- a/stdlib/public/Distributed/DistributedActorSystem.swift
+++ b/stdlib/public/Distributed/DistributedActorSystem.swift
@@ -12,7 +12,12 @@
 import Swift
 import _Concurrency
 
-/// A distributed actor system
+/// A distributed actor system is what enables all functionality of distributed actors.
+///
+/// Distributed actors must always be associated with a concrete distributed actor system,
+/// and do so by declaring a `typealias ActorSystem = ...`, or by having a module wide
+/// `typealias DefaultDistributedActorSystem` declared which then applies to all distributed
+/// actors that do not declare a specific type alias in their bodies.
 @available(SwiftStdlib 5.7, *)
 public protocol DistributedActorSystem: Sendable {
   /// The identity used by actors that communicate via this transport

--- a/test/Distributed/Runtime/distributed_actor_init_local.swift
+++ b/test/Distributed/Runtime/distributed_actor_init_local.swift
@@ -90,6 +90,26 @@ distributed actor MaybeAfterAssign {
   }
 }
 
+distributed actor LocalTestingSystemDA {
+  typealias ActorSystem = LocalTestingDistributedActorSystem
+  var x: Int
+  init() {
+    actorSystem = .init()
+    x = 100
+  }
+}
+
+distributed actor LocalTestingDA_Int {
+  typealias ActorSystem = LocalTestingDistributedActorSystem
+  var int: Int
+  init() {
+    actorSystem = .init()
+    int = 12
+    // CRASH
+  }
+}
+
+
 // ==== Fake Transport ---------------------------------------------------------
 
 struct ActorAddress: Sendable, Hashable, Codable {
@@ -262,6 +282,10 @@ func test() async {
   // CHECK:      assign type:MaybeAfterAssign, id:ActorAddress(address: "[[ID10:.*]]")
   // CHECK-NEXT: ready actor:main.MaybeAfterAssign, id:ActorAddress(address: "[[ID10]]")
 
+  let localDA = LocalTestingDA_Int()
+  print("localDA = \(localDA.id)")
+  // CHECK: localDA = LocalTestingActorAddress(uuid: "1")
+
   // the following tests fail to initialize the actor's identity.
   print("-- start of no-assign tests --")
   test.append(MaybeSystem(nil))
@@ -270,7 +294,6 @@ func test() async {
   // CHECK: -- start of no-assign tests --
   // CHECK-NOT: assign
   // CHECK: -- end of no-assign tests --
-
 
   // resigns that come out of the deinits:
 

--- a/test/Distributed/distributed_actor_layout.swift
+++ b/test/Distributed/distributed_actor_layout.swift
@@ -12,8 +12,6 @@ import FakeDistributedActorSystems
 @available(SwiftStdlib 5.7, *)
 typealias DefaultDistributedActorSystem = FakeActorSystem
 
-class MyClass { }
-
 // Ensure that the actor layout is (metadata pointer, default actor, id, system,
 // <user fields>)
 
@@ -23,12 +21,27 @@ protocol HasActorSystem {
 
 extension MyActor: HasActorSystem { }
 
-// CHECK: %T27distributed_actor_accessors7MyActorC = type <{ %swift.refcounted, %swift.defaultactor, %T27FakeDistributedActorSystems0C7AddressV, %T27FakeDistributedActorSystems0aC6SystemV, %T27distributed_actor_accessors7MyClassC* }>
+// CHECK: %T27distributed_actor_accessors7MyActorC = type <{ %swift.refcounted, %swift.defaultactor, %T27FakeDistributedActorSystems0C7AddressV, %T27FakeDistributedActorSystems0aC6SystemV, %TSS }>
 @available(SwiftStdlib 5.7, *)
 public distributed actor MyActor {
-  var field: MyClass = MyClass()
+  var field: String = ""
 
   init(actorSystem: FakeActorSystem) {
+    self.actorSystem = actorSystem
+  }
+}
+
+// CHECK: %T27distributed_actor_accessors10MyActorIntC = type <{ %swift.refcounted, %swift.defaultactor }>
+//
+// This does not have the concrete fields in the IR type because the LocalTestingDistributedActorSystem
+// is declared in Distributed, which means that it is compiled with library evolution turned on,
+// which causes the type to be laid out at runtime.
+@available(SwiftStdlib 5.7, *)
+public distributed actor MyActorInt {
+  public typealias ActorSystem = LocalTestingDistributedActorSystem
+  var field: String = ""
+
+  init(actorSystem: LocalTestingDistributedActorSystem) {
     self.actorSystem = actorSystem
   }
 }

--- a/test/Distributed/distributed_actor_system_missing_adhoc_requirement_impls.swift
+++ b/test/Distributed/distributed_actor_system_missing_adhoc_requirement_impls.swift
@@ -7,836 +7,836 @@
 import Distributed
 
 struct MissingRemoteCall: DistributedActorSystem {
-  // expected-error@-1{{struct 'MissingRemoteCall' is missing witness for protocol requirement 'remoteCall'}}
-  // expected-note@-2{{protocol 'MissingRemoteCall' requires function 'remoteCall' with signature:}}
+    // expected-error@-1{{struct 'MissingRemoteCall' is missing witness for protocol requirement 'remoteCall'}}
+    // expected-note@-2{{protocol 'MissingRemoteCall' requires function 'remoteCall' with signature:}}
 
-  // expected-error@-4{{struct 'MissingRemoteCall' is missing witness for protocol requirement 'remoteCallVoid'}}
-  // expected-note@-5{{protocol 'MissingRemoteCall' requires function 'remoteCallVoid' with signature:}}
+    // expected-error@-4{{struct 'MissingRemoteCall' is missing witness for protocol requirement 'remoteCallVoid'}}
+    // expected-note@-5{{protocol 'MissingRemoteCall' requires function 'remoteCallVoid' with signature:}}
 
-  typealias ActorID = ActorAddress
-  typealias InvocationDecoder = FakeInvocationDecoder
-  typealias InvocationEncoder = FakeInvocationEncoder
-  typealias SerializationRequirement = Codable
-  typealias ResultHandler = FakeResultHandler
+    typealias ActorID = ActorAddress
+    typealias InvocationDecoder = FakeInvocationDecoder
+    typealias InvocationEncoder = FakeInvocationEncoder
+    typealias SerializationRequirement = Codable
+    typealias ResultHandler = FakeResultHandler
 
-  func resolve<Act>(id: ActorID, as actorType: Act.Type)
-    throws -> Act? where Act: DistributedActor {
-    return nil
-  }
+    func resolve<Act>(id: ActorID, as actorType: Act.Type)
+        throws -> Act? where Act: DistributedActor {
+        return nil
+    }
 
-  func assignID<Act>(_ actorType: Act.Type) -> ActorID
-    where Act: DistributedActor {
-    ActorAddress(parse: "fake://123")
-  }
+    func assignID<Act>(_ actorType: Act.Type) -> ActorID
+        where Act: DistributedActor {
+        ActorAddress(parse: "fake://123")
+    }
 
-  func actorReady<Act>(_ actor: Act)
-    where Act: DistributedActor,
-    Act.ID == ActorID {
-  }
+    func actorReady<Act>(_ actor: Act)
+        where Act: DistributedActor,
+        Act.ID == ActorID {
+    }
 
-  func resignID(_ id: ActorID) {
-  }
+    func resignID(_ id: ActorID) {
+    }
 
-  func makeInvocationEncoder() -> InvocationEncoder {
-  }
+    func makeInvocationEncoder() -> InvocationEncoder {
+    }
 }
 
 struct MissingRemoteCall_missingInout_on_encoder: DistributedActorSystem {
-  // expected-error@-1{{struct 'MissingRemoteCall_missingInout_on_encoder' is missing witness for protocol requirement 'remoteCall'}}
-  // expected-note@-2{{protocol 'MissingRemoteCall_missingInout_on_encoder' requires function 'remoteCall' with signature:}}
+    // expected-error@-1{{struct 'MissingRemoteCall_missingInout_on_encoder' is missing witness for protocol requirement 'remoteCall'}}
+    // expected-note@-2{{protocol 'MissingRemoteCall_missingInout_on_encoder' requires function 'remoteCall' with signature:}}
 
-  // expected-error@-4{{struct 'MissingRemoteCall_missingInout_on_encoder' is missing witness for protocol requirement 'remoteCallVoid'}}
-  // expected-note@-5{{protocol 'MissingRemoteCall_missingInout_on_encoder' requires function 'remoteCallVoid' with signature:}}
+    // expected-error@-4{{struct 'MissingRemoteCall_missingInout_on_encoder' is missing witness for protocol requirement 'remoteCallVoid'}}
+    // expected-note@-5{{protocol 'MissingRemoteCall_missingInout_on_encoder' requires function 'remoteCallVoid' with signature:}}
 
-  typealias ActorID = ActorAddress
-  typealias InvocationDecoder = FakeInvocationDecoder
-  typealias InvocationEncoder = FakeInvocationEncoder
-  typealias SerializationRequirement = Codable
-  typealias ResultHandler = FakeResultHandler
+    typealias ActorID = ActorAddress
+    typealias InvocationDecoder = FakeInvocationDecoder
+    typealias InvocationEncoder = FakeInvocationEncoder
+    typealias SerializationRequirement = Codable
+    typealias ResultHandler = FakeResultHandler
 
-  func resolve<Act>(id: ActorID, as actorType: Act.Type)
-    throws -> Act? where Act: DistributedActor {
-    return nil
-  }
+    func resolve<Act>(id: ActorID, as actorType: Act.Type)
+        throws -> Act? where Act: DistributedActor {
+        return nil
+    }
 
-  func assignID<Act>(_ actorType: Act.Type) -> ActorID
-    where Act: DistributedActor {
-    ActorAddress(parse: "fake://123")
-  }
+    func assignID<Act>(_ actorType: Act.Type) -> ActorID
+        where Act: DistributedActor {
+        ActorAddress(parse: "fake://123")
+    }
 
-  func actorReady<Act>(_ actor: Act)
-    where Act: DistributedActor,
-    Act.ID == ActorID {
-  }
+    func actorReady<Act>(_ actor: Act)
+        where Act: DistributedActor,
+        Act.ID == ActorID {
+    }
 
-  func resignID(_ id: ActorID) {
-  }
+    func resignID(_ id: ActorID) {
+    }
 
-  func remoteCall<Act, Err, Res>(
-      on actor: Act,
-      target: RemoteCallTarget,
-      invocation: InvocationEncoder, // MISSING 'inout'
-      throwing: Err.Type,
-      returning: Res.Type
-  ) async throws -> Res
-      where Act: DistributedActor,
-      Act.ID == ActorID,
-      Err: Error,
-      Res: SerializationRequirement {
-    fatalError("NOT IMPLEMENTED \(#function)")
-  }
+    func remoteCall<Act, Err, Res>(
+        on actor: Act,
+        target: RemoteCallTarget,
+        invocation: InvocationEncoder, // MISSING 'inout'
+        throwing: Err.Type,
+        returning: Res.Type
+    ) async throws -> Res
+        where Act: DistributedActor,
+        Act.ID == ActorID,
+        Err: Error,
+        Res: SerializationRequirement {
+        fatalError("NOT IMPLEMENTED \(#function)")
+    }
 
-  func remoteCallVoid<Act, Err>(
-      on actor: Act,
-      target: RemoteCallTarget,
-      invocation: InvocationEncoder, // MISSING 'inout'
-      throwing: Err.Type
-  ) async throws
-      where Act: DistributedActor,
-      Act.ID == ActorID,
-      Err: Error {
-    fatalError("NOT IMPLEMENTED \(#function)")
-  }
+    func remoteCallVoid<Act, Err>(
+        on actor: Act,
+        target: RemoteCallTarget,
+        invocation: InvocationEncoder, // MISSING 'inout'
+        throwing: Err.Type
+    ) async throws
+        where Act: DistributedActor,
+        Act.ID == ActorID,
+        Err: Error {
+        fatalError("NOT IMPLEMENTED \(#function)")
+    }
 
-  func makeInvocationEncoder() -> InvocationEncoder {
-  }
+    func makeInvocationEncoder() -> InvocationEncoder {
+    }
 }
 
 struct MissingRemoteCall_missing_makeInvocationEncoder: DistributedActorSystem {
-  // expected-error@-1{{type 'MissingRemoteCall_missing_makeInvocationEncoder' does not conform to protocol 'DistributedActorSystem'}}
+    // expected-error@-1{{type 'MissingRemoteCall_missing_makeInvocationEncoder' does not conform to protocol 'DistributedActorSystem'}}
 
-  typealias ActorID = ActorAddress
-  typealias InvocationDecoder = FakeInvocationDecoder
-  typealias InvocationEncoder = FakeInvocationEncoder
-  typealias SerializationRequirement = Codable
-  typealias ResultHandler = FakeResultHandler
+    typealias ActorID = ActorAddress
+    typealias InvocationDecoder = FakeInvocationDecoder
+    typealias InvocationEncoder = FakeInvocationEncoder
+    typealias SerializationRequirement = Codable
+    typealias ResultHandler = FakeResultHandler
 
-  func resolve<Act>(id: ActorID, as actorType: Act.Type)
-    throws -> Act? where Act: DistributedActor {
-    return nil
-  }
+    func resolve<Act>(id: ActorID, as actorType: Act.Type)
+        throws -> Act? where Act: DistributedActor {
+        return nil
+    }
 
-  func assignID<Act>(_ actorType: Act.Type) -> ActorID
-    where Act: DistributedActor {
-    ActorAddress(parse: "fake://123")
-  }
+    func assignID<Act>(_ actorType: Act.Type) -> ActorID
+        where Act: DistributedActor {
+        ActorAddress(parse: "fake://123")
+    }
 
-  func actorReady<Act>(_ actor: Act)
-    where Act: DistributedActor,
-    Act.ID == ActorID {
-  }
+    func actorReady<Act>(_ actor: Act)
+        where Act: DistributedActor,
+        Act.ID == ActorID {
+    }
 
-  func remoteCall<Act, Err, Res>(
-    on actor: Act,
-    target: RemoteCallTarget,
-    invocation: inout InvocationEncoder,
-    throwing: Err.Type,
-    returning: Res.Type
-  ) async throws -> Res
-    where Act: DistributedActor,
-          Act.ID == ActorID,
-          Err: Error,
-          Res: SerializationRequirement {
-    fatalError("NOT IMPLEMENTED \(#function)")
-  }
+    func remoteCall<Act, Err, Res>(
+        on actor: Act,
+        target: RemoteCallTarget,
+        invocation: inout InvocationEncoder,
+        throwing: Err.Type,
+        returning: Res.Type
+    ) async throws -> Res
+        where Act: DistributedActor,
+        Act.ID == ActorID,
+        Err: Error,
+        Res: SerializationRequirement {
+        fatalError("NOT IMPLEMENTED \(#function)")
+    }
 
-  func remoteCallVoid<Act, Err>(
-    on actor: Act,
-    target: RemoteCallTarget,
-    invocation: inout InvocationEncoder,
-    throwing: Err.Type
-  ) async throws
-    where Act: DistributedActor,
-          Act.ID == ActorID,
-          Err: Error {
-    fatalError("NOT IMPLEMENTED \(#function)")
-  }
+    func remoteCallVoid<Act, Err>(
+        on actor: Act,
+        target: RemoteCallTarget,
+        invocation: inout InvocationEncoder,
+        throwing: Err.Type
+    ) async throws
+        where Act: DistributedActor,
+        Act.ID == ActorID,
+        Err: Error {
+        fatalError("NOT IMPLEMENTED \(#function)")
+    }
 
-  func resignID(_ id: ActorID) {
-  }
+    func resignID(_ id: ActorID) {
+    }
 
-  // func makeInvocationEncoder() -> InvocationEncoder {} // MISSING
+    // func makeInvocationEncoder() -> InvocationEncoder {} // MISSING
 }
 
 struct Error_wrongReturn: DistributedActorSystem {
-  // expected-error@-1{{struct 'Error_wrongReturn' is missing witness for protocol requirement 'remoteCall'}}
-  // expected-note@-2{{protocol 'Error_wrongReturn' requires function 'remoteCall' with signature:}}
+    // expected-error@-1{{struct 'Error_wrongReturn' is missing witness for protocol requirement 'remoteCall'}}
+    // expected-note@-2{{protocol 'Error_wrongReturn' requires function 'remoteCall' with signature:}}
 
-  // expected-error@-4{{struct 'Error_wrongReturn' is missing witness for protocol requirement 'remoteCallVoid'}}
-  // expected-note@-5{{protocol 'Error_wrongReturn' requires function 'remoteCallVoid' with signature:}}
+    // expected-error@-4{{struct 'Error_wrongReturn' is missing witness for protocol requirement 'remoteCallVoid'}}
+    // expected-note@-5{{protocol 'Error_wrongReturn' requires function 'remoteCallVoid' with signature:}}
 
-  typealias ActorID = ActorAddress
-  typealias InvocationDecoder = FakeInvocationDecoder
-  typealias InvocationEncoder = FakeInvocationEncoder
-  typealias SerializationRequirement = Codable
-  typealias ResultHandler = FakeResultHandler
+    typealias ActorID = ActorAddress
+    typealias InvocationDecoder = FakeInvocationDecoder
+    typealias InvocationEncoder = FakeInvocationEncoder
+    typealias SerializationRequirement = Codable
+    typealias ResultHandler = FakeResultHandler
 
-  func resolve<Act>(id: ActorID, as actorType: Act.Type)
-    throws -> Act? where Act: DistributedActor {
-    return nil
-  }
+    func resolve<Act>(id: ActorID, as actorType: Act.Type)
+        throws -> Act? where Act: DistributedActor {
+        return nil
+    }
 
-  func assignID<Act>(_ actorType: Act.Type) -> ActorID
-    where Act: DistributedActor {
-    ActorAddress(parse: "fake://123")
-  }
+    func assignID<Act>(_ actorType: Act.Type) -> ActorID
+        where Act: DistributedActor {
+        ActorAddress(parse: "fake://123")
+    }
 
-  func actorReady<Act>(_ actor: Act)
-    where Act: DistributedActor,
-    Act.ID == ActorID {
-  }
+    func actorReady<Act>(_ actor: Act)
+        where Act: DistributedActor,
+        Act.ID == ActorID {
+    }
 
-  func resignID(_ id: ActorID) {
-  }
+    func resignID(_ id: ActorID) {
+    }
 
-  func makeInvocationEncoder() -> InvocationEncoder {
-  }
+    func makeInvocationEncoder() -> InvocationEncoder {
+    }
 
-  public func remoteCall<Act, Err, Res>(
-    on actor: Act,
-    target: RemoteCallTarget,
-    invocation invocationEncoder: inout InvocationEncoder,
-    throwing: Err.Type,
-    returning: Res.Type
-  ) async throws -> String // ERROR: wrong return type
-    where Act: DistributedActor,
-    Act.ID == ActorID,
-    Err: Error,
-    Res: SerializationRequirement {
-    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
-  }
+    public func remoteCall<Act, Err, Res>(
+        on actor: Act,
+        target: RemoteCallTarget,
+        invocation invocationEncoder: inout InvocationEncoder,
+        throwing: Err.Type,
+        returning: Res.Type
+    ) async throws -> String // ERROR: wrong return type
+        where Act: DistributedActor,
+        Act.ID == ActorID,
+        Err: Error,
+        Res: SerializationRequirement {
+        throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+    }
 
-  public func remoteCall<Act, Err, Res>(
-    on actor: Act,
-    target: RemoteCallTarget,
-    invocation invocationEncoder: inout InvocationEncoder,
-    throwing: Err.Type,
-    returning: Res.Type
-  ) async throws // ERROR: wrong return type (void)
-    where Act: DistributedActor,
-    Act.ID == ActorID,
-    Err: Error,
-    Res: SerializationRequirement {
-    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
-  }
+    public func remoteCall<Act, Err, Res>(
+        on actor: Act,
+        target: RemoteCallTarget,
+        invocation invocationEncoder: inout InvocationEncoder,
+        throwing: Err.Type,
+        returning: Res.Type
+    ) async throws // ERROR: wrong return type (void)
+        where Act: DistributedActor,
+        Act.ID == ActorID,
+        Err: Error,
+        Res: SerializationRequirement {
+        throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+    }
 
-  public func remoteCallVoid<Act, Err>(
-    on actor: Act,
-    target: RemoteCallTarget,
-    invocation invocationEncoder: inout InvocationEncoder,
-    throwing: Err.Type
-  ) throws -> String // ERROR: should not return anything
-    where Act: DistributedActor,
-    Act.ID == ActorID,
-    Err: Error {
-    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
-  }
+    public func remoteCallVoid<Act, Err>(
+        on actor: Act,
+        target: RemoteCallTarget,
+        invocation invocationEncoder: inout InvocationEncoder,
+        throwing: Err.Type
+    ) throws -> String // ERROR: should not return anything
+        where Act: DistributedActor,
+        Act.ID == ActorID,
+        Err: Error {
+        throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+    }
 }
 
 struct BadRemoteCall_param: DistributedActorSystem {
-  // expected-error@-1{{struct 'BadRemoteCall_param' is missing witness for protocol requirement 'remoteCall'}}
-  // expected-note@-2{{protocol 'BadRemoteCall_param' requires function 'remoteCall' with signature:}}
+    // expected-error@-1{{struct 'BadRemoteCall_param' is missing witness for protocol requirement 'remoteCall'}}
+    // expected-note@-2{{protocol 'BadRemoteCall_param' requires function 'remoteCall' with signature:}}
 
-  // expected-error@-4{{struct 'BadRemoteCall_param' is missing witness for protocol requirement 'remoteCallVoid'}}
-  // expected-note@-5{{protocol 'BadRemoteCall_param' requires function 'remoteCallVoid' with signature:}}
+    // expected-error@-4{{struct 'BadRemoteCall_param' is missing witness for protocol requirement 'remoteCallVoid'}}
+    // expected-note@-5{{protocol 'BadRemoteCall_param' requires function 'remoteCallVoid' with signature:}}
 
-  typealias ActorID = ActorAddress
-  typealias InvocationDecoder = FakeInvocationDecoder
-  typealias InvocationEncoder = FakeInvocationEncoder
-  typealias SerializationRequirement = Codable
-  typealias ResultHandler = FakeResultHandler
+    typealias ActorID = ActorAddress
+    typealias InvocationDecoder = FakeInvocationDecoder
+    typealias InvocationEncoder = FakeInvocationEncoder
+    typealias SerializationRequirement = Codable
+    typealias ResultHandler = FakeResultHandler
 
-  func resolve<Act>(id: ActorID, as actorType: Act.Type)
-    throws -> Act? where Act: DistributedActor {
-    return nil
-  }
+    func resolve<Act>(id: ActorID, as actorType: Act.Type)
+        throws -> Act? where Act: DistributedActor {
+        return nil
+    }
 
-  func assignID<Act>(_ actorType: Act.Type) -> ActorID
-    where Act: DistributedActor {
-    ActorAddress(parse: "fake://123")
-  }
+    func assignID<Act>(_ actorType: Act.Type) -> ActorID
+        where Act: DistributedActor {
+        ActorAddress(parse: "fake://123")
+    }
 
-  func actorReady<Act>(_ actor: Act)
-    where Act: DistributedActor,
-    Act.ID == ActorID {}
-  func resignID(_ id: ActorID) {}
-  func makeInvocationEncoder() -> InvocationEncoder {
-  }
+    func actorReady<Act>(_ actor: Act)
+        where Act: DistributedActor,
+        Act.ID == ActorID {}
+    func resignID(_ id: ActorID) {}
+    func makeInvocationEncoder() -> InvocationEncoder {
+    }
 
-  public func remoteCall<Act, Err, Res>(
-    on actor: Act,
-    target: RemoteCallTarget,
-    // invocation invocationEncoder: inout InvocationEncoder, // ERROR: missing parameter
-    throwing: Err.Type,
-    returning: Res.Type
-  ) async throws -> Res
-    where Act: DistributedActor,
-    Act.ID == ActorID,
-    Err: Error,
-    Res: SerializationRequirement {
-    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
-  }
+    public func remoteCall<Act, Err, Res>(
+        on actor: Act,
+        target: RemoteCallTarget,
+        // invocation invocationEncoder: inout InvocationEncoder, // ERROR: missing parameter
+        throwing: Err.Type,
+        returning: Res.Type
+    ) async throws -> Res
+        where Act: DistributedActor,
+        Act.ID == ActorID,
+        Err: Error,
+        Res: SerializationRequirement {
+        throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+    }
 
-  public func remoteCallVoid<Act, Err>(
-    on actor: Act,
-    target: RemoteCallTarget,
-    // invocation invocationEncoder: inout InvocationEncoder, // ERROR: missing parameter
-    throwing: Err.Type
-  ) async throws
-    where Act: DistributedActor,
-    Act.ID == ActorID,
-    Err: Error {
-    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
-  }
+    public func remoteCallVoid<Act, Err>(
+        on actor: Act,
+        target: RemoteCallTarget,
+        // invocation invocationEncoder: inout InvocationEncoder, // ERROR: missing parameter
+        throwing: Err.Type
+    ) async throws
+        where Act: DistributedActor,
+        Act.ID == ActorID,
+        Err: Error {
+        throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+    }
 }
 
 public struct BadRemoteCall_notPublic: DistributedActorSystem {
-  public typealias ActorID = ActorAddress
-  public typealias InvocationDecoder = PublicFakeInvocationDecoder
-  public typealias InvocationEncoder = PublicFakeInvocationEncoder
-  public typealias SerializationRequirement = Codable
-  public typealias ResultHandler = FakeResultHandler
+    public typealias ActorID = ActorAddress
+    public typealias InvocationDecoder = PublicFakeInvocationDecoder
+    public typealias InvocationEncoder = PublicFakeInvocationEncoder
+    public typealias SerializationRequirement = Codable
+    public typealias ResultHandler = FakeResultHandler
 
-  public func resolve<Act>(id: ActorID, as actorType: Act.Type)
-    throws -> Act? where Act: DistributedActor {
-    return nil
-  }
+    public func resolve<Act>(id: ActorID, as actorType: Act.Type)
+        throws -> Act? where Act: DistributedActor {
+        return nil
+    }
 
-  public func assignID<Act>(_ actorType: Act.Type) -> ActorID
-    where Act: DistributedActor {
-    ActorAddress(parse: "fake://123")
-  }
+    public func assignID<Act>(_ actorType: Act.Type) -> ActorID
+        where Act: DistributedActor {
+        ActorAddress(parse: "fake://123")
+    }
 
-  public func actorReady<Act>(_ actor: Act)
-    where Act: DistributedActor,
-    Act.ID == ActorID {}
-  public func resignID(_ id: ActorID) {}
-  public func makeInvocationEncoder() -> InvocationEncoder {
-  }
+    public func actorReady<Act>(_ actor: Act)
+        where Act: DistributedActor,
+        Act.ID == ActorID {}
+    public func resignID(_ id: ActorID) {}
+    public func makeInvocationEncoder() -> InvocationEncoder {
+    }
 
-  // expected-error@+1{{method 'remoteCall(on:target:invocation:throwing:returning:)' must be as accessible as its enclosing type because it matches a requirement in protocol 'DistributedActorSystem'}}
-  func remoteCall<Act, Err, Res>(
-    on actor: Act,
-    target: RemoteCallTarget,
-    invocation invocationEncoder: inout InvocationEncoder,
-    throwing: Err.Type,
-    returning: Res.Type
-  ) async throws -> Res
-    where Act: DistributedActor,
-          Act.ID == ActorID,
-          Err: Error,
-          Res: SerializationRequirement {
-    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
-  }
+    // expected-error@+1{{method 'remoteCall(on:target:invocation:throwing:returning:)' must be as accessible as its enclosing type because it matches a requirement in protocol 'DistributedActorSystem'}}
+    func remoteCall<Act, Err, Res>(
+        on actor: Act,
+        target: RemoteCallTarget,
+        invocation invocationEncoder: inout InvocationEncoder,
+        throwing: Err.Type,
+        returning: Res.Type
+    ) async throws -> Res
+        where Act: DistributedActor,
+        Act.ID == ActorID,
+        Err: Error,
+        Res: SerializationRequirement {
+        throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+    }
 
-  // expected-error@+1{{method 'remoteCallVoid(on:target:invocation:throwing:)' must be as accessible as its enclosing type because it matches a requirement in protocol 'DistributedActorSystem'}}
-  func remoteCallVoid<Act, Err>(
-    on actor: Act,
-    target: RemoteCallTarget,
-    invocation invocationEncoder: inout InvocationEncoder,
-    throwing: Err.Type
-  ) async throws
-    where Act: DistributedActor,
-    Act.ID == ActorID,
-    Err: Error {
-    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
-  }
+    // expected-error@+1{{method 'remoteCallVoid(on:target:invocation:throwing:)' must be as accessible as its enclosing type because it matches a requirement in protocol 'DistributedActorSystem'}}
+    func remoteCallVoid<Act, Err>(
+        on actor: Act,
+        target: RemoteCallTarget,
+        invocation invocationEncoder: inout InvocationEncoder,
+        throwing: Err.Type
+    ) async throws
+        where Act: DistributedActor,
+        Act.ID == ActorID,
+        Err: Error {
+        throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+    }
 }
 
 public struct BadRemoteCall_badResultConformance: DistributedActorSystem {
-  // expected-error@-1{{struct 'BadRemoteCall_badResultConformance' is missing witness for protocol requirement 'remoteCall'}}
-  // expected-note@-2{{protocol 'BadRemoteCall_badResultConformance' requires function 'remoteCall' with signature:}}
+    // expected-error@-1{{struct 'BadRemoteCall_badResultConformance' is missing witness for protocol requirement 'remoteCall'}}
+    // expected-note@-2{{protocol 'BadRemoteCall_badResultConformance' requires function 'remoteCall' with signature:}}
 
-  public typealias ActorID = ActorAddress
-  public typealias InvocationDecoder = PublicFakeInvocationDecoder
-  public typealias InvocationEncoder = PublicFakeInvocationEncoder
-  public typealias SerializationRequirement = Codable
-  public typealias ResultHandler = FakeResultHandler
+    public typealias ActorID = ActorAddress
+    public typealias InvocationDecoder = PublicFakeInvocationDecoder
+    public typealias InvocationEncoder = PublicFakeInvocationEncoder
+    public typealias SerializationRequirement = Codable
+    public typealias ResultHandler = FakeResultHandler
 
-  public func resolve<Act>(id: ActorID, as actorType: Act.Type)
-    throws -> Act? where Act: DistributedActor {
-    return nil
-  }
+    public func resolve<Act>(id: ActorID, as actorType: Act.Type)
+        throws -> Act? where Act: DistributedActor {
+        return nil
+    }
 
-  public func assignID<Act>(_ actorType: Act.Type) -> ActorID
-    where Act: DistributedActor {
-    ActorAddress(parse: "fake://123")
-  }
+    public func assignID<Act>(_ actorType: Act.Type) -> ActorID
+        where Act: DistributedActor {
+        ActorAddress(parse: "fake://123")
+    }
 
-  public func actorReady<Act>(_ actor: Act)
-    where Act: DistributedActor,
-    Act.ID == ActorID {}
-  public func resignID(_ id: ActorID) {}
-  public func makeInvocationEncoder() -> InvocationEncoder {
-  }
+    public func actorReady<Act>(_ actor: Act)
+        where Act: DistributedActor,
+        Act.ID == ActorID {}
+    public func resignID(_ id: ActorID) {}
+    public func makeInvocationEncoder() -> InvocationEncoder {
+    }
 
-  public func remoteCall<Act, Err, Res>(
-    on actor: Act,
-    target: RemoteCallTarget,
-    invocation invocationEncoder: inout InvocationEncoder,
-    throwing: Err.Type,
-    returning: Res.Type
-  ) async throws -> Res
-    where Act: DistributedActor,
-          Act.ID == ActorID,
-          Err: Error,
-          Res: SomeProtocol { // ERROR: bad, this must be SerializationRequirement
-    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
-  }
+    public func remoteCall<Act, Err, Res>(
+        on actor: Act,
+        target: RemoteCallTarget,
+        invocation invocationEncoder: inout InvocationEncoder,
+        throwing: Err.Type,
+        returning: Res.Type
+    ) async throws -> Res
+        where Act: DistributedActor,
+        Act.ID == ActorID,
+        Err: Error,
+        Res: SomeProtocol { // ERROR: bad, this must be SerializationRequirement
+        throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+    }
 
-  public func remoteCallVoid<Act, Err>(
-    on actor: Act,
-    target: RemoteCallTarget,
-    invocation invocationEncoder: inout InvocationEncoder,
-    throwing: Err.Type
-  ) async throws
-    where Act: DistributedActor,
-    Act.ID == ActorID,
-    Err: Error {
-    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
-  }
+    public func remoteCallVoid<Act, Err>(
+        on actor: Act,
+        target: RemoteCallTarget,
+        invocation invocationEncoder: inout InvocationEncoder,
+        throwing: Err.Type
+    ) async throws
+        where Act: DistributedActor,
+        Act.ID == ActorID,
+        Err: Error {
+        throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+    }
 }
 
 // This tests the ability to handle composite types with multiple layers
 // Codable & SomeProtocol -> Encodable & Decodable & SomeProtocol
 struct BadRemoteCall_largeSerializationRequirement: DistributedActorSystem {
-  typealias ActorID = ActorAddress
-  typealias InvocationDecoder = LargeSerializationReqFakeInvocationDecoder
-  typealias InvocationEncoder = LargeSerializationReqFakeInvocationEncoder
-  typealias SerializationRequirement = Codable & SomeProtocol
-  typealias ResultHandler = LargeSerializationReqFakeInvocationResultHandler
+    typealias ActorID = ActorAddress
+    typealias InvocationDecoder = LargeSerializationReqFakeInvocationDecoder
+    typealias InvocationEncoder = LargeSerializationReqFakeInvocationEncoder
+    typealias SerializationRequirement = Codable & SomeProtocol
+    typealias ResultHandler = LargeSerializationReqFakeInvocationResultHandler
 
-  func resolve<Act>(id: ActorID, as actorType: Act.Type)
-    throws -> Act? where Act: DistributedActor {
-    return nil
-  }
+    func resolve<Act>(id: ActorID, as actorType: Act.Type)
+        throws -> Act? where Act: DistributedActor {
+        return nil
+    }
 
-  func assignID<Act>(_ actorType: Act.Type) -> ActorID
-    where Act: DistributedActor {
-    ActorAddress(parse: "fake://123")
-  }
+    func assignID<Act>(_ actorType: Act.Type) -> ActorID
+        where Act: DistributedActor {
+        ActorAddress(parse: "fake://123")
+    }
 
-  func actorReady<Act>(_ actor: Act)
-    where Act: DistributedActor,
-    Act.ID == ActorID {}
-  func resignID(_ id: ActorID) {}
-  func makeInvocationEncoder() -> InvocationEncoder {
-  }
+    func actorReady<Act>(_ actor: Act)
+        where Act: DistributedActor,
+        Act.ID == ActorID {}
+    func resignID(_ id: ActorID) {}
+    func makeInvocationEncoder() -> InvocationEncoder {
+    }
 
-  func remoteCall<Act, Err, Res>(
-    on actor: Act,
-    target: RemoteCallTarget,
-    invocation invocationEncoder: inout InvocationEncoder,
-    throwing: Err.Type,
-    returning: Res.Type
-  ) async throws -> Res
-    where Act: DistributedActor,
-          Act.ID == ActorID,
-          Err: Error,
-          Res: SerializationRequirement {
-    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
-  }
+    func remoteCall<Act, Err, Res>(
+        on actor: Act,
+        target: RemoteCallTarget,
+        invocation invocationEncoder: inout InvocationEncoder,
+        throwing: Err.Type,
+        returning: Res.Type
+    ) async throws -> Res
+        where Act: DistributedActor,
+        Act.ID == ActorID,
+        Err: Error,
+        Res: SerializationRequirement {
+        throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+    }
 
-  func remoteCallVoid<Act, Err>(
-    on actor: Act,
-    target: RemoteCallTarget,
-    invocation invocationEncoder: inout InvocationEncoder,
-    throwing: Err.Type
-  ) async throws
-    where Act: DistributedActor,
-    Act.ID == ActorID,
-    Err: Error {
-    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
-  }
+    func remoteCallVoid<Act, Err>(
+        on actor: Act,
+        target: RemoteCallTarget,
+        invocation invocationEncoder: inout InvocationEncoder,
+        throwing: Err.Type
+    ) async throws
+        where Act: DistributedActor,
+        Act.ID == ActorID,
+        Err: Error {
+        throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+    }
 }
 
 struct BadRemoteCall_largeSerializationRequirementSlightlyOffInDefinition: DistributedActorSystem {
-  // expected-error@-1{{struct 'BadRemoteCall_largeSerializationRequirementSlightlyOffInDefinition' is missing witness for protocol requirement 'remoteCall'}}
-  // expected-note@-2{{protocol 'BadRemoteCall_largeSerializationRequirementSlightlyOffInDefinition' requires function 'remoteCall' with signature:}}
+    // expected-error@-1{{struct 'BadRemoteCall_largeSerializationRequirementSlightlyOffInDefinition' is missing witness for protocol requirement 'remoteCall'}}
+    // expected-note@-2{{protocol 'BadRemoteCall_largeSerializationRequirementSlightlyOffInDefinition' requires function 'remoteCall' with signature:}}
 
-  typealias ActorID = ActorAddress
-  typealias InvocationDecoder = LargeSerializationReqFakeInvocationDecoder
-  typealias InvocationEncoder = LargeSerializationReqFakeInvocationEncoder
-  typealias SerializationRequirement = Codable & SomeProtocol
-  typealias ResultHandler = LargeSerializationReqFakeInvocationResultHandler
+    typealias ActorID = ActorAddress
+    typealias InvocationDecoder = LargeSerializationReqFakeInvocationDecoder
+    typealias InvocationEncoder = LargeSerializationReqFakeInvocationEncoder
+    typealias SerializationRequirement = Codable & SomeProtocol
+    typealias ResultHandler = LargeSerializationReqFakeInvocationResultHandler
 
-  func resolve<Act>(id: ActorID, as actorType: Act.Type)
-    throws -> Act? where Act: DistributedActor {
-    return nil
-  }
+    func resolve<Act>(id: ActorID, as actorType: Act.Type)
+        throws -> Act? where Act: DistributedActor {
+        return nil
+    }
 
-  func assignID<Act>(_ actorType: Act.Type) -> ActorID
-    where Act: DistributedActor {
-    ActorAddress(parse: "fake://123")
-  }
+    func assignID<Act>(_ actorType: Act.Type) -> ActorID
+        where Act: DistributedActor {
+        ActorAddress(parse: "fake://123")
+    }
 
-  func actorReady<Act>(_ actor: Act)
-    where Act: DistributedActor,
-    Act.ID == ActorID {}
-  func resignID(_ id: ActorID) {}
-  func makeInvocationEncoder() -> InvocationEncoder {
-  }
+    func actorReady<Act>(_ actor: Act)
+        where Act: DistributedActor,
+        Act.ID == ActorID {}
+    func resignID(_ id: ActorID) {}
+    func makeInvocationEncoder() -> InvocationEncoder {
+    }
 
-  func remoteCall<Act, Err, Res>(
-    on actor: Act,
-    target: RemoteCallTarget,
-    invocation invocationEncoder: inout InvocationEncoder,
-    throwing: Err.Type,
-    returning: Res.Type
-  ) async throws -> Res
-    where Act: DistributedActor,
-          Act.ID == ActorID,
-          Err: Error,
-          Res: SomeProtocol { // ERROR: missing Codable!!!
-    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
-  }
+    func remoteCall<Act, Err, Res>(
+        on actor: Act,
+        target: RemoteCallTarget,
+        invocation invocationEncoder: inout InvocationEncoder,
+        throwing: Err.Type,
+        returning: Res.Type
+    ) async throws -> Res
+        where Act: DistributedActor,
+        Act.ID == ActorID,
+        Err: Error,
+        Res: SomeProtocol { // ERROR: missing Codable!!!
+        throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+    }
 
-  func remoteCallVoid<Act, Err>(
-    on actor: Act,
-    target: RemoteCallTarget,
-    invocation invocationEncoder: inout InvocationEncoder,
-    throwing: Err.Type
-  ) async throws
-    where Act: DistributedActor,
-    Act.ID == ActorID,
-    Err: Error {
-    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
-  }
+    func remoteCallVoid<Act, Err>(
+        on actor: Act,
+        target: RemoteCallTarget,
+        invocation invocationEncoder: inout InvocationEncoder,
+        throwing: Err.Type
+    ) async throws
+        where Act: DistributedActor,
+        Act.ID == ActorID,
+        Err: Error {
+        throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+    }
 }
 
 struct BadRemoteCall_anySerializationRequirement: DistributedActorSystem {
-  typealias ActorID = ActorAddress
-  typealias InvocationDecoder = AnyInvocationDecoder
-  typealias InvocationEncoder = AnyInvocationEncoder
-  typealias SerializationRequirement = Any // !!
-  typealias ResultHandler = AnyResultHandler
+    typealias ActorID = ActorAddress
+    typealias InvocationDecoder = AnyInvocationDecoder
+    typealias InvocationEncoder = AnyInvocationEncoder
+    typealias SerializationRequirement = Any // !!
+    typealias ResultHandler = AnyResultHandler
 
-  func resolve<Act>(id: ActorID, as actorType: Act.Type)
-    throws -> Act? where Act: DistributedActor {
-    return nil
-  }
+    func resolve<Act>(id: ActorID, as actorType: Act.Type)
+        throws -> Act? where Act: DistributedActor {
+        return nil
+    }
 
-  func assignID<Act>(_ actorType: Act.Type) -> ActorID
-    where Act: DistributedActor {
-    ActorAddress(parse: "fake://123")
-  }
+    func assignID<Act>(_ actorType: Act.Type) -> ActorID
+        where Act: DistributedActor {
+        ActorAddress(parse: "fake://123")
+    }
 
-  func actorReady<Act>(_ actor: Act)
-    where Act: DistributedActor,
-    Act.ID == ActorID {}
-  func resignID(_ id: ActorID) {}
-  func makeInvocationEncoder() -> InvocationEncoder {
-  }
+    func actorReady<Act>(_ actor: Act)
+        where Act: DistributedActor,
+        Act.ID == ActorID {}
+    func resignID(_ id: ActorID) {}
+    func makeInvocationEncoder() -> InvocationEncoder {
+    }
 
-  func remoteCall<Act, Err, Res>(
-    on actor: Act,
-    target: RemoteCallTarget,
-    invocation invocationEncoder: inout InvocationEncoder,
-    throwing: Err.Type,
-    returning: Res.Type
-  ) async throws -> Res
-    where Act: DistributedActor,
-          Act.ID == ActorID,
-          Err: Error,
-          Res: SerializationRequirement {
-    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
-  }
+    func remoteCall<Act, Err, Res>(
+        on actor: Act,
+        target: RemoteCallTarget,
+        invocation invocationEncoder: inout InvocationEncoder,
+        throwing: Err.Type,
+        returning: Res.Type
+    ) async throws -> Res
+        where Act: DistributedActor,
+        Act.ID == ActorID,
+        Err: Error,
+        Res: SerializationRequirement {
+        throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+    }
 
-  func remoteCallVoid<Act, Err>(
-    on actor: Act,
-    target: RemoteCallTarget,
-    invocation invocationEncoder: inout InvocationEncoder,
-    throwing: Err.Type
-  ) async throws
-    where Act: DistributedActor,
-    Act.ID == ActorID,
-    Err: Error {
-    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
-  }
+    func remoteCallVoid<Act, Err>(
+        on actor: Act,
+        target: RemoteCallTarget,
+        invocation invocationEncoder: inout InvocationEncoder,
+        throwing: Err.Type
+    ) async throws
+        where Act: DistributedActor,
+        Act.ID == ActorID,
+        Err: Error {
+        throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+    }
 }
 
 // ==== ------------------------------------------------------------------------
 
 public struct ActorAddress: Sendable, Hashable, Codable {
-  let address: String
-  init(parse address: String) {
-    self.address = address
-  }
+    let address: String
+    init(parse address: String) {
+        self.address = address
+    }
 }
 
 public protocol SomeProtocol: Sendable {}
 
 struct FakeInvocationEncoder: DistributedTargetInvocationEncoder {
-  typealias SerializationRequirement = Codable
+    typealias SerializationRequirement = Codable
 
-  mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
-  mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
-  mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
-  mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
-  mutating func doneRecording() throws {}
+    mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+    mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
+    mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
+    mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
+    mutating func doneRecording() throws {}
 }
 
 struct AnyInvocationEncoder: DistributedTargetInvocationEncoder {
-  typealias SerializationRequirement = Any
+    typealias SerializationRequirement = Any
 
-  mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
-  mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
-  mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
-  mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
-  mutating func doneRecording() throws {}
+    mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+    mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
+    mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
+    mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
+    mutating func doneRecording() throws {}
 }
 
 struct LargeSerializationReqFakeInvocationEncoder: DistributedTargetInvocationEncoder {
-  typealias SerializationRequirement = Codable & SomeProtocol
+    typealias SerializationRequirement = Codable & SomeProtocol
 
-  mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
-  mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
-  mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
-  mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
-  mutating func doneRecording() throws {}
+    mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+    mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
+    mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
+    mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
+    mutating func doneRecording() throws {}
 }
 
 public struct PublicFakeInvocationEncoder: DistributedTargetInvocationEncoder {
-  public typealias SerializationRequirement = Codable
+    public typealias SerializationRequirement = Codable
 
-  public mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
-  public mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
-  public mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
-  public mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
-  public mutating func doneRecording() throws {}
+    public mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+    public mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
+    public mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
+    public mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
+    public mutating func doneRecording() throws {}
 }
 
 struct FakeInvocationEncoder_missing_recordArgument: DistributedTargetInvocationEncoder {
-  //expected-error@-1{{struct 'FakeInvocationEncoder_missing_recordArgument' is missing witness for protocol requirement 'recordArgument'}}
-  //expected-note@-2{{protocol 'FakeInvocationEncoder_missing_recordArgument' requires function 'recordArgument' with signature:}}
-  typealias SerializationRequirement = Codable
+    //expected-error@-1{{struct 'FakeInvocationEncoder_missing_recordArgument' is missing witness for protocol requirement 'recordArgument'}}
+    //expected-note@-2{{protocol 'FakeInvocationEncoder_missing_recordArgument' requires function 'recordArgument' with signature:}}
+    typealias SerializationRequirement = Codable
 
-  mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
-  // MISSING: mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
-  mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
-  mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
-  mutating func doneRecording() throws {}
+    mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+    // MISSING: mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
+    mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
+    mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
+    mutating func doneRecording() throws {}
 }
 
 struct FakeInvocationEncoder_missing_recordArgument2: DistributedTargetInvocationEncoder {
-  //expected-error@-1{{struct 'FakeInvocationEncoder_missing_recordArgument2' is missing witness for protocol requirement 'recordArgument'}}
-  //expected-note@-2{{protocol 'FakeInvocationEncoder_missing_recordArgument2' requires function 'recordArgument' with signature:}}
-  typealias SerializationRequirement = Codable
+    //expected-error@-1{{struct 'FakeInvocationEncoder_missing_recordArgument2' is missing witness for protocol requirement 'recordArgument'}}
+    //expected-note@-2{{protocol 'FakeInvocationEncoder_missing_recordArgument2' requires function 'recordArgument' with signature:}}
+    typealias SerializationRequirement = Codable
 
-  mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
-  mutating func recordArgument<Argument: SomeProtocol>(_ argument: Argument) throws {} // BAD
-  mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
-  mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
-  mutating func doneRecording() throws {}
+    mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+    mutating func recordArgument<Argument: SomeProtocol>(_ argument: Argument) throws {} // BAD
+    mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
+    mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
+    mutating func doneRecording() throws {}
 }
 
 struct FakeInvocationEncoder_missing_recordReturnType: DistributedTargetInvocationEncoder {
-  //expected-error@-1{{struct 'FakeInvocationEncoder_missing_recordReturnType' is missing witness for protocol requirement 'recordReturnType'}}
-  //expected-note@-2{{protocol 'FakeInvocationEncoder_missing_recordReturnType' requires function 'recordReturnType' with signature:}}
-  typealias SerializationRequirement = Codable
+    //expected-error@-1{{struct 'FakeInvocationEncoder_missing_recordReturnType' is missing witness for protocol requirement 'recordReturnType'}}
+    //expected-note@-2{{protocol 'FakeInvocationEncoder_missing_recordReturnType' requires function 'recordReturnType' with signature:}}
+    typealias SerializationRequirement = Codable
 
-  mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
-  mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
-  // MISSING: mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
-  mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
-  mutating func doneRecording() throws {}
+    mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+    mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
+    // MISSING: mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
+    mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
+    mutating func doneRecording() throws {}
 }
 
 struct FakeInvocationEncoder_missing_recordErrorType: DistributedTargetInvocationEncoder {
-  //expected-error@-1{{type 'FakeInvocationEncoder_missing_recordErrorType' does not conform to protocol 'DistributedTargetInvocationEncoder'}}
-  typealias SerializationRequirement = Codable
+    //expected-error@-1{{type 'FakeInvocationEncoder_missing_recordErrorType' does not conform to protocol 'DistributedTargetInvocationEncoder'}}
+    typealias SerializationRequirement = Codable
 
-  mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
-  mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
-  mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
-  // MISSING: mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
-  mutating func doneRecording() throws {}
+    mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+    mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
+    mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
+    // MISSING: mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
+    mutating func doneRecording() throws {}
 }
 
 struct FakeInvocationEncoder_recordArgument_wrongType: DistributedTargetInvocationEncoder {
-  //expected-error@-1{{struct 'FakeInvocationEncoder_recordArgument_wrongType' is missing witness for protocol requirement 'recordArgument'}}
-  //expected-note@-2{{protocol 'FakeInvocationEncoder_recordArgument_wrongType' requires function 'recordArgument' with signature:}}
-  typealias SerializationRequirement = Codable
+    //expected-error@-1{{struct 'FakeInvocationEncoder_recordArgument_wrongType' is missing witness for protocol requirement 'recordArgument'}}
+    //expected-note@-2{{protocol 'FakeInvocationEncoder_recordArgument_wrongType' requires function 'recordArgument' with signature:}}
+    typealias SerializationRequirement = Codable
 
-  mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
-  mutating func recordArgument<Argument: SerializationRequirement>(_ argument: String, other: Argument) throws {} // BAD
-  mutating func recordArgument<Argument: SerializationRequirement>(_ argument: Argument.Type) throws {} // BAD
-  mutating func recordArgument<Argument: SerializationRequirement>(badName: Argument) throws {} // BAD
-  mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
-  mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
-  mutating func doneRecording() throws {}
+    mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+    mutating func recordArgument<Argument: SerializationRequirement>(_ argument: String, other: Argument) throws {} // BAD
+    mutating func recordArgument<Argument: SerializationRequirement>(_ argument: Argument.Type) throws {} // BAD
+    mutating func recordArgument<Argument: SerializationRequirement>(badName: Argument) throws {} // BAD
+    mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
+    mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
+    mutating func doneRecording() throws {}
 }
 struct FakeInvocationEncoder_recordArgument_missingMutating: DistributedTargetInvocationEncoder {
-  //expected-error@-1{{struct 'FakeInvocationEncoder_recordArgument_missingMutating' is missing witness for protocol requirement 'recordArgument'}}
-  //expected-note@-2{{protocol 'FakeInvocationEncoder_recordArgument_missingMutating' requires function 'recordArgument' with signature:}}
-  typealias SerializationRequirement = Codable
+    //expected-error@-1{{struct 'FakeInvocationEncoder_recordArgument_missingMutating' is missing witness for protocol requirement 'recordArgument'}}
+    //expected-note@-2{{protocol 'FakeInvocationEncoder_recordArgument_missingMutating' requires function 'recordArgument' with signature:}}
+    typealias SerializationRequirement = Codable
 
-  mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
-  func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
-  mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
-  mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
-  mutating func doneRecording() throws {}
+    mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+    func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
+    mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
+    mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
+    mutating func doneRecording() throws {}
 }
 
 struct FakeInvocationEncoder_recordResultType_wrongType: DistributedTargetInvocationEncoder {
-  //expected-error@-1{{struct 'FakeInvocationEncoder_recordResultType_wrongType' is missing witness for protocol requirement 'recordReturnType'}}
-  //expected-note@-2{{protocol 'FakeInvocationEncoder_recordResultType_wrongType' requires function 'recordReturnType' with signature:}}
-  typealias SerializationRequirement = Codable
+    //expected-error@-1{{struct 'FakeInvocationEncoder_recordResultType_wrongType' is missing witness for protocol requirement 'recordReturnType'}}
+    //expected-note@-2{{protocol 'FakeInvocationEncoder_recordResultType_wrongType' requires function 'recordReturnType' with signature:}}
+    typealias SerializationRequirement = Codable
 
-  mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
-  mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
-  mutating func recordReturnType<R: SerializationRequirement>(s: String, _ resultType: R.Type) throws {} // BAD
-  mutating func recordReturnType<R: SomeProtocol>(_ resultType: R.Type) throws {} // BAD
-  mutating func recordReturnType<R: SerializationRequirement>(badName: R.Type) throws {} // BAD
-  mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
-  mutating func doneRecording() throws {}
+    mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+    mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
+    mutating func recordReturnType<R: SerializationRequirement>(s: String, _ resultType: R.Type) throws {} // BAD
+    mutating func recordReturnType<R: SomeProtocol>(_ resultType: R.Type) throws {} // BAD
+    mutating func recordReturnType<R: SerializationRequirement>(badName: R.Type) throws {} // BAD
+    mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
+    mutating func doneRecording() throws {}
 }
 
 struct FakeInvocationEncoder_recordErrorType_wrongType: DistributedTargetInvocationEncoder {
-  //expected-error@-1{{type 'FakeInvocationEncoder_recordErrorType_wrongType' does not conform to protocol 'DistributedTargetInvocationEncoder'}}
-  typealias SerializationRequirement = Codable
+    //expected-error@-1{{type 'FakeInvocationEncoder_recordErrorType_wrongType' does not conform to protocol 'DistributedTargetInvocationEncoder'}}
+    typealias SerializationRequirement = Codable
 
-  mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
-  mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
-  mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
-  mutating func recordErrorType<E: Error>(BadName type: E.Type) throws {} // BAD
-  mutating func recordErrorType<E: SerializationRequirement>(_ type: E.Type) throws {} // BAD
-  //expected-note@-1{{candidate has non-matching type '<E> (E.Type) throws -> ()'}}
-  mutating func doneRecording() throws {}
+    mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+    mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
+    mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
+    mutating func recordErrorType<E: Error>(BadName type: E.Type) throws {} // BAD
+    mutating func recordErrorType<E: SerializationRequirement>(_ type: E.Type) throws {} // BAD
+    //expected-note@-1{{candidate has non-matching type '<E> (E.Type) throws -> ()'}}
+    mutating func doneRecording() throws {}
 }
 
 class FakeInvocationDecoder: DistributedTargetInvocationDecoder {
-  typealias SerializationRequirement = Codable
+    typealias SerializationRequirement = Codable
 
-  func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
-  func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
-  func decodeReturnType() throws -> Any.Type? { nil }
-  func decodeErrorType() throws -> Any.Type? { nil }
+    func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
+    func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
+    func decodeReturnType() throws -> Any.Type? { nil }
+    func decodeErrorType() throws -> Any.Type? { nil }
 }
 
 class AnyInvocationDecoder: DistributedTargetInvocationDecoder {
-  typealias SerializationRequirement = Any
+    typealias SerializationRequirement = Any
 
-  func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
-  func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
-  func decodeReturnType() throws -> Any.Type? { nil }
-  func decodeErrorType() throws -> Any.Type? { nil }
+    func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
+    func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
+    func decodeReturnType() throws -> Any.Type? { nil }
+    func decodeErrorType() throws -> Any.Type? { nil }
 }
 
 class LargeSerializationReqFakeInvocationDecoder : DistributedTargetInvocationDecoder {
-  typealias SerializationRequirement = Codable & SomeProtocol
+    typealias SerializationRequirement = Codable & SomeProtocol
 
-  func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
-  func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
-  func decodeReturnType() throws -> Any.Type? { nil }
-  func decodeErrorType() throws -> Any.Type? { nil }
+    func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
+    func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
+    func decodeReturnType() throws -> Any.Type? { nil }
+    func decodeErrorType() throws -> Any.Type? { nil }
 }
 
 public final class PublicFakeInvocationDecoder : DistributedTargetInvocationDecoder {
-  public typealias SerializationRequirement = Codable
+    public typealias SerializationRequirement = Codable
 
-  public func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
-  public func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
-  public func decodeReturnType() throws -> Any.Type? { nil }
-  public func decodeErrorType() throws -> Any.Type? { nil }
+    public func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
+    public func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
+    public func decodeReturnType() throws -> Any.Type? { nil }
+    public func decodeErrorType() throws -> Any.Type? { nil }
 }
 
 public final class PublicFakeInvocationDecoder_badNotPublic: DistributedTargetInvocationDecoder {
-  public typealias SerializationRequirement = Codable
+    public typealias SerializationRequirement = Codable
 
-  public func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
-  func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
-  // expected-error@-1{{method 'decodeNextArgument()' must be as accessible as its enclosing type because it matches a requirement in protocol 'DistributedTargetInvocationDecoder'}}
-  func decodeReturnType() throws -> Any.Type? { nil }
-  // expected-error@-1{{method 'decodeReturnType()' must be declared public because it matches a requirement in public protocol 'DistributedTargetInvocationDecoder'}}
-  // expected-note@-2{{mark the instance method as 'public' to satisfy the requirement}}
-  func decodeErrorType() throws -> Any.Type? { nil }
-  // expected-error@-1{{method 'decodeErrorType()' must be declared public because it matches a requirement in public protocol 'DistributedTargetInvocationDecoder'}}
-  // expected-note@-2{{mark the instance method as 'public' to satisfy the requirement}}
+    public func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
+    func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
+    // expected-error@-1{{method 'decodeNextArgument()' must be as accessible as its enclosing type because it matches a requirement in protocol 'DistributedTargetInvocationDecoder'}}
+    func decodeReturnType() throws -> Any.Type? { nil }
+    // expected-error@-1{{method 'decodeReturnType()' must be declared public because it matches a requirement in public protocol 'DistributedTargetInvocationDecoder'}}
+    // expected-note@-2{{mark the instance method as 'public' to satisfy the requirement}}
+    func decodeErrorType() throws -> Any.Type? { nil }
+    // expected-error@-1{{method 'decodeErrorType()' must be declared public because it matches a requirement in public protocol 'DistributedTargetInvocationDecoder'}}
+    // expected-note@-2{{mark the instance method as 'public' to satisfy the requirement}}
 }
 
 final class PublicFakeInvocationDecoder_badBadProtoRequirement: DistributedTargetInvocationDecoder {
-  // expected-error@-1{{class 'PublicFakeInvocationDecoder_badBadProtoRequirement' is missing witness for protocol requirement 'decodeNextArgument'}}
-  // expected-note@-2{{protocol 'PublicFakeInvocationDecoder_badBadProtoRequirement' requires function 'decodeNextArgument' with signature:}}
-  typealias SerializationRequirement = Codable
+    // expected-error@-1{{class 'PublicFakeInvocationDecoder_badBadProtoRequirement' is missing witness for protocol requirement 'decodeNextArgument'}}
+    // expected-note@-2{{protocol 'PublicFakeInvocationDecoder_badBadProtoRequirement' requires function 'decodeNextArgument' with signature:}}
+    typealias SerializationRequirement = Codable
 
-  func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
-  func decodeNextArgument<Argument: SomeProtocol>() throws -> Argument { fatalError() }
-  func decodeReturnType() throws -> Any.Type? { nil }
-  func decodeErrorType() throws -> Any.Type? { nil }
+    func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
+    func decodeNextArgument<Argument: SomeProtocol>() throws -> Argument { fatalError() }
+    func decodeReturnType() throws -> Any.Type? { nil }
+    func decodeErrorType() throws -> Any.Type? { nil }
 }
 
 public struct FakeResultHandler: DistributedTargetInvocationResultHandler {
-  public typealias SerializationRequirement = Codable
+    public typealias SerializationRequirement = Codable
 
-  public func onReturn<Success: SerializationRequirement>(value: Success) async throws {
-    print("RETURN: \(value)")
-  }
-  public func onReturnVoid() async throws {
-    print("RETURN VOID")
-  }
-  public func onThrow<Err: Error>(error: Err) async throws {
-    print("ERROR: \(error)")
-  }
+    public func onReturn<Success: SerializationRequirement>(value: Success) async throws {
+        print("RETURN: \(value)")
+    }
+    public func onReturnVoid() async throws {
+        print("RETURN VOID")
+    }
+    public func onThrow<Err: Error>(error: Err) async throws {
+        print("ERROR: \(error)")
+    }
 }
 
 struct AnyResultHandler: DistributedTargetInvocationResultHandler {
-  typealias SerializationRequirement = Any
+    typealias SerializationRequirement = Any
 
-  func onReturn<Success: SerializationRequirement>(value: Success) async throws {
-    print("RETURN: \(value)")
-  }
-  func onReturnVoid() async throws {
-    print("RETURN VOID")
-  }
-  func onThrow<Err: Error>(error: Err) async throws {
-    print("ERROR: \(error)")
-  }
+    func onReturn<Success: SerializationRequirement>(value: Success) async throws {
+        print("RETURN: \(value)")
+    }
+    func onReturnVoid() async throws {
+        print("RETURN VOID")
+    }
+    func onThrow<Err: Error>(error: Err) async throws {
+        print("ERROR: \(error)")
+    }
 }
 struct LargeSerializationReqFakeInvocationResultHandler: DistributedTargetInvocationResultHandler {
-  typealias SerializationRequirement = Codable & SomeProtocol
+    typealias SerializationRequirement = Codable & SomeProtocol
 
-  func onReturn<Success: SerializationRequirement>(value: Success) async throws {
-    print("RETURN: \(value)")
-  }
-  func onReturnVoid() async throws {
-    print("RETURN VOID")
-  }
-  func onThrow<Err: Error>(error: Err) async throws {
-    print("ERROR: \(error)")
-  }
+    func onReturn<Success: SerializationRequirement>(value: Success) async throws {
+        print("RETURN: \(value)")
+    }
+    func onReturnVoid() async throws {
+        print("RETURN VOID")
+    }
+    func onThrow<Err: Error>(error: Err) async throws {
+        print("ERROR: \(error)")
+    }
 }
 
 struct BadResultHandler_missingOnReturn: DistributedTargetInvocationResultHandler {
-  // expected-error@-1{{struct 'BadResultHandler_missingOnReturn' is missing witness for protocol requirement 'onReturn'}}
-  // expected-note@-2{{protocol 'BadResultHandler_missingOnReturn' requires function 'onReturn' with signature:}}
-  typealias SerializationRequirement = Codable
+    // expected-error@-1{{struct 'BadResultHandler_missingOnReturn' is missing witness for protocol requirement 'onReturn'}}
+    // expected-note@-2{{protocol 'BadResultHandler_missingOnReturn' requires function 'onReturn' with signature:}}
+    typealias SerializationRequirement = Codable
 
-  // func onReturn<Res: SerializationRequirement>(value: Res) async throws {} // MISSING
-  func onReturnVoid() async throws {}
-  func onThrow<Err: Error>(error: Err) async throws {}
+    // func onReturn<Res: SerializationRequirement>(value: Res) async throws {} // MISSING
+    func onReturnVoid() async throws {}
+    func onThrow<Err: Error>(error: Err) async throws {}
 }
 struct BadResultHandler_missingRequirement: DistributedTargetInvocationResultHandler {
-  // expected-error@-1{{struct 'BadResultHandler_missingRequirement' is missing witness for protocol requirement 'onReturn'}}
-  // expected-note@-2{{protocol 'BadResultHandler_missingRequirement' requires function 'onReturn' with signature:}}
-  typealias SerializationRequirement = Codable
+    // expected-error@-1{{struct 'BadResultHandler_missingRequirement' is missing witness for protocol requirement 'onReturn'}}
+    // expected-note@-2{{protocol 'BadResultHandler_missingRequirement' requires function 'onReturn' with signature:}}
+    typealias SerializationRequirement = Codable
 
-  func onReturn<Success>(value: Success) async throws {} // MISSING : Codable
-  func onReturnVoid() async throws {}
-  func onThrow<Err: Error>(error: Err) async throws {}
+    func onReturn<Success>(value: Success) async throws {} // MISSING : Codable
+    func onReturnVoid() async throws {}
+    func onThrow<Err: Error>(error: Err) async throws {}
 }
 
 public struct PublicFakeResultHandler: DistributedTargetInvocationResultHandler {
-  public typealias SerializationRequirement = Codable
+    public typealias SerializationRequirement = Codable
 
-  public func onReturn<Success: SerializationRequirement>(value: Success) async throws {
-    print("RETURN: \(value)")
-  }
-  public func onReturnVoid() async throws {
-    print("RETURN VOID")
-  }
-  public func onThrow<Err: Error>(error: Err) async throws {
-    print("ERROR: \(error)")
-  }
+    public func onReturn<Success: SerializationRequirement>(value: Success) async throws {
+        print("RETURN: \(value)")
+    }
+    public func onReturnVoid() async throws {
+        print("RETURN VOID")
+    }
+    public func onThrow<Err: Error>(error: Err) async throws {
+        print("ERROR: \(error)")
+    }
 }
 


### PR DESCRIPTION
Reproducer for rdar://92712849

This for now is only a workaround, while we try to solve the real issue

When the LocalTestingDistributedActorSystem is used and the actor has state, initializers crash.