### PR TITLE
[5.7][CodeCompletion] Offer suggestions if a nested type is followed by a same type requirement

### DIFF
--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -350,9 +350,23 @@ ParserStatus Parser::parseGenericWhereClause(
         SecondType = makeParserResult(new (Context) ErrorTypeRepr(PreviousLoc));
 
       // Add the requirement
-      Requirements.push_back(RequirementRepr::getSameType(FirstType.get(),
-                                                      EqualLoc,
-                                                      SecondType.get()));
+      if (FirstType.hasCodeCompletion()) {
+        // If the first type has a code completion token, don't record a same
+        // type constraint because otherwise if we have
+        //   K.#^COMPLETE^# == Foo
+        // we parse this as
+        //   K == Foo
+        // and thus simplify K to Foo. But we didn't want to state that K is Foo
+        // but that K has a member of type Foo.
+        // FIXME: The proper way to fix this would be to represent the code
+        // completion token in the TypeRepr.
+        Requirements.push_back(RequirementRepr::getTypeConstraint(
+            FirstType.get(), EqualLoc,
+            new (Context) ErrorTypeRepr(SecondType.get()->getLoc())));
+      } else {
+        Requirements.push_back(RequirementRepr::getSameType(
+            FirstType.get(), EqualLoc, SecondType.get()));
+      }
     } else if (FirstType.hasCodeCompletion()) {
       // Recover by adding dummy constraint.
       Requirements.push_back(RequirementRepr::getTypeConstraint(

--- a/test/IDE/complete_where_clause.swift
+++ b/test/IDE/complete_where_clause.swift
@@ -41,6 +41,7 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=EXT_ASSOC_MEMBER_1 | %FileCheck %s -check-prefix=EXT_ASSOC_MEMBER
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=EXT_ASSOC_MEMBER_2 | %FileCheck %s -check-prefix=EXT_ASSOC_MEMBER
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=EXT_SECONDTYPE | %FileCheck %s -check-prefix=EXT_SECONDTYPE
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=WHERE_CLAUSE_WITH_EQUAL | %FileCheck %s -check-prefix=WHERE_CLAUSE_WITH_EQUAL
 
 class A1<T1, T2, T3> {}
 
@@ -264,3 +265,10 @@ extension WithAssoc where Int == #^EXT_SECONDTYPE^#
 // EXT_SECONDTYPE: Begin completions
 // EXT_SECONDTYPE-DAG: Decl[AssociatedType]/CurrNominal:   T;
 // EXT_SECONDTYPE: End completions
+
+func foo<K: WithAssoc>(_ key: K.Type) where K.#^WHERE_CLAUSE_WITH_EQUAL^# == S1 {}
+
+// WHERE_CLAUSE_WITH_EQUAL: Begin completions, 2 items
+// WHERE_CLAUSE_WITH_EQUAL-DAG: Decl[AssociatedType]/CurrNominal:   T;
+// WHERE_CLAUSE_WITH_EQUAL-DAG: Keyword/None:                       Type[#K.Type#];
+// WHERE_CLAUSE_WITH_EQUAL: End completions


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/58614 to release/5.7.

---

* **Explanation**: When completing a type inside a where clause that already had a type on the right-hand side of a `==` requirement, e.g. `K.#^COMPLETE^# == Foo`, we weren’t providing any results because we parsed it as `K == Foo` and thus were providing completion on `Foo` instead of the more generic type `K`. Drop the `== Foo` requirement in these code completion cases to avoid the issue.
* **Scope**: Code completion in where clauses that have a `== <some-type>` requirement after the code completion token.
* **Risk**: Low (only affects code completion)
* **Testing**: Added regression test case
* **Issue**: rdar://77458518
* **Reviewer**: @rintaro on https://github.com/apple/swift/pull/58614