### PR TITLE
[SwiftCompilerModules] Configured Package.swift use its own directory

### DIFF
--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -252,22 +252,23 @@ else()
 endif()
 
 # Configure 'SwiftCompilerModules' SwiftPM package. The 'Package.swift' will
-# be created at '${build_dir}/SwiftCompilerSources/Package.swift' and can be
-# built with 'swift-build'.
+# be created at '${build_dir}/SwiftCompilerModulesPackage/Package.swift' and can
+# be built with 'swift-build'.
 # Note that this SwiftPM package itself is just for development purposes, and
 # is not actually used for the compiler building. 
-set(swiftcompiler_source_dir_name "_Sources")
+set(swiftcompiler_modules_package_directory
+    "${SWIFT_BINARY_DIR}/SwiftCompilerModulesPackage")
 configure_file(Package.swift.in
-  "${CMAKE_CURRENT_BINARY_DIR}/Package.swift" @ONLY)
+  "${swiftcompiler_modules_package_directory}/Package.swift" @ONLY)
 # SwiftPM requires all sources are inside the directory of 'Package.swift'.
 # Create symlinks to the actual source directories.
 execute_process(COMMAND
   "${CMAKE_COMMAND}" -E create_symlink
   "${CMAKE_CURRENT_SOURCE_DIR}/Sources"
-  "${CMAKE_CURRENT_BINARY_DIR}/${swiftcompiler_source_dir_name}")
+  "${swiftcompiler_modules_package_directory}/Sources")
 if(SWIFT_BUILD_REGEX_PARSER_IN_COMPILER)
   execute_process(COMMAND
     "${CMAKE_COMMAND}" -E create_symlink
     "${EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR}/Sources/_RegexParser"
-    "${CMAKE_CURRENT_BINARY_DIR}/_RegexParser_Sources")
+    "${swiftcompiler_modules_package_directory}/_RegexParser_Sources")
 endif()

--- a/SwiftCompilerSources/Package.swift.in
+++ b/SwiftCompilerSources/Package.swift.in
@@ -39,7 +39,7 @@ private extension Target {
       .target(
         name: name,
         dependencies: dependencies,
-        path: path ?? "@swiftcompiler_source_dir_name@/\(name)",
+        path: path ?? "Sources/\(name)",
         exclude: ["CMakeLists.txt"],
         sources: sources,
         swiftSettings: defaultSwiftSettings + swiftSettings)


### PR DESCRIPTION
Previously, it used `${CMAKE_CURRENT_BINARY_DIR}` as the package directory. However, since that directory contains all build artifacts so opening it in Xcode shows those unnecessary files.

Instead of using `${CMAKE_CURRENT_BINARY_DIR}`, create its own directory (`SwiftCompilerCompilerModulesPackage/`) in the root build directory.
