### PR TITLE
[5.7][Sema] Allow code to shadow definitions in implicit _StringProcessing module

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -528,6 +528,22 @@ static void recordShadowedDeclsAfterTypeMatch(
         }
       }
 
+      // Next, prefer any other module over the _StringProcessing module.
+      if (auto spModule = ctx.getLoadedModule(ctx.Id_StringProcessing)) {
+        if ((firstModule == spModule) != (secondModule == spModule)) {
+          // If second module is _StringProcessing, then it is shadowed by
+          // first.
+          if (secondModule == spModule) {
+            shadowed.insert(secondDecl);
+            continue;
+          }
+
+          // Otherwise, the first declaration is shadowed by the second.
+          shadowed.insert(firstDecl);
+          break;
+        }
+      }
+
       // The Foundation overlay introduced Data.withUnsafeBytes, which is
       // treated as being ambiguous with SwiftNIO's Data.withUnsafeBytes
       // extension. Apply a special-case name shadowing rule to use the

--- a/test/StringProcessing/Sema/Inputs/ShadowsStringProcessing.swift
+++ b/test/StringProcessing/Sema/Inputs/ShadowsStringProcessing.swift
@@ -1,0 +1,4 @@
+ public struct Regex<T> {
+   public var someProperty: T?
+   public init() { }
+ }

--- a/test/StringProcessing/Sema/string_processing_module_shadowing.swift
+++ b/test/StringProcessing/Sema/string_processing_module_shadowing.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/ShadowsStringProcessing.swiftmodule -module-name ShadowsStringProcessing %S/Inputs/ShadowsStringProcessing.swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -I %t -enable-experimental-string-processing -disable-availability-checking
+
+import ShadowsStringProcessing
+
+func f(_ t : Regex<Substring>) -> Bool {
+  return t.someProperty == "123"
+}
+
+func g(_: _StringProcessing.Regex<Substring>) {}


### PR DESCRIPTION
Cherry-pick of: #58625

---

Treat _StringProcessing decls as if it were declared in the Swift module, just like how _Concurrency is treated (#34642).