### PR TITLE
[5.7] SILGen: Emit a closure literal in a function conversion as the converted type.

### DIFF
--- a/lib/SIL/IR/SILBuilder.cpp
+++ b/lib/SIL/IR/SILBuilder.cpp
@@ -154,6 +154,18 @@ SILBuilder::createUncheckedReinterpretCast(SILLocation Loc, SILValue Op,
   if (SILType::canRefCast(Op->getType(), Ty, getModule()))
     return createUncheckedRefCast(Loc, Op, Ty);
 
+  // If the source and destination types are functions with the same
+  // kind of representation, then do a function conversion.
+  if (Op->getType().isObject() && Ty.isObject()) {
+    if (auto OpFnTy = Op->getType().getAs<SILFunctionType>()) {
+      if (auto DestFnTy = Ty.getAs<SILFunctionType>()) {
+        if (OpFnTy->getRepresentation() == DestFnTy->getRepresentation()) {
+          return createConvertFunction(Loc, Op, Ty, /*withoutActuallyEscaping*/ false);
+        }
+      }
+    }
+  }
+  
   // The destination type is nontrivial, and may be smaller than the source
   // type, so RC identity cannot be assumed.
   return insert(UncheckedBitwiseCastInst::create(
@@ -175,6 +187,18 @@ SILBuilder::createUncheckedBitCast(SILLocation Loc, SILValue Op, SILType Ty) {
   if (SILType::canRefCast(Op->getType(), Ty, getModule()))
     return createUncheckedRefCast(Loc, Op, Ty);
 
+  // If the source and destination types are functions with the same
+  // kind of representation, then do a function conversion.
+  if (Op->getType().isObject() && Ty.isObject()) {
+    if (auto OpFnTy = Op->getType().getAs<SILFunctionType>()) {
+      if (auto DestFnTy = Ty.getAs<SILFunctionType>()) {
+        if (OpFnTy->getRepresentation() == DestFnTy->getRepresentation()) {
+          return createConvertFunction(Loc, Op, Ty, /*withoutActuallyEscaping*/ false);
+        }
+      }
+    }
+  }
+  
   // The destination type is nontrivial, and may be smaller than the source
   // type, so RC identity cannot be assumed.
   return createUncheckedValueCast(Loc, Op, Ty);

--- a/test/AutoDiff/SILOptimizer/activity_analysis.swift
+++ b/test/AutoDiff/SILOptimizer/activity_analysis.swift
@@ -552,14 +552,13 @@ func testTryApply(_ x: Float) -> Float {
 // CHECK: bb0:
 // CHECK: [ACTIVE] %0 = argument of bb0 : $Float
 // CHECK: [NONE]   // function_ref closure #1 in testTryApply(_:)
-// CHECK: [NONE]   %3 = convert_function %2 : $@convention(thin) () -> () to $@convention(thin) @noescape () -> ()
-// CHECK: [NONE]   %4 = thin_to_thick_function %3 : $@convention(thin) @noescape () -> () to $@noescape @callee_guaranteed () -> ()
-// CHECK: [NONE]   %5 = convert_function %4 : $@noescape @callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> @error Error
+// CHECK: [NONE]   %3 = convert_function %2 :
+// CHECK: [NONE]   %4 = thin_to_thick_function %3 :
 // CHECK: [NONE]   // function_ref rethrowing(_:)
 // CHECK: bb1:
-// CHECK: [NONE] %8 = argument of bb1 : $()
+// CHECK: [NONE] %7 = argument of bb1 : $()
 // CHECK: bb2:
-// CHECK: [NONE] %10 = argument of bb2 : $Error
+// CHECK: [NONE] %9 = argument of bb2 : $Error
 
 //===----------------------------------------------------------------------===//
 // Coroutine differentiation (`begin_apply`)

--- a/test/DebugInfo/patternvars.swift
+++ b/test/DebugInfo/patternvars.swift
@@ -35,7 +35,7 @@ public func mangle(s: [UnicodeScalar]) -> [UnicodeScalar] {
 // Do we care to expose these via lldb?
 
 // CHECK: define {{.*}}@"$s11patternvars6mangle1sSayAA13UnicodeScalarVGAF_tFA2EXEfU_"
-// CHECK: %[[VAL:[0-9]+]] = call swiftcc i32 @"$s11patternvars13UnicodeScalarV5values6UInt32Vvg"(i32 %0)
+// CHECK: %[[VAL:[0-9]+]] = call swiftcc i32 @"$s11patternvars13UnicodeScalarV5values6UInt32Vvg"(
 // CHECK:       {{[0-9]+}}:
 // CHECK-NOT:   call void @llvm.dbg.value
 // CHECK-NOT:   call void asm sideeffect "", "r"

--- a/test/IRGen/big_types_corner_cases.swift
+++ b/test/IRGen/big_types_corner_cases.swift
@@ -203,7 +203,7 @@ public func testGetFunc() {
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} hidden swiftcc void @"$s22big_types_corner_cases7TestBigC4testyyF"(%T22big_types_corner_cases7TestBigC* swiftself %0)
 // CHECK: [[CALL1:%.*]] = call {{.*}} @__swift_instantiateConcreteTypeFromMangledName({{.*}} @"$sSayy22big_types_corner_cases9BigStructVcSgGMD"
 // CHECK: [[CALL2:%.*]] = call i8** @"$sSayy22big_types_corner_cases9BigStructVcSgGSayxGSlsWl
-// CHECK:  call swiftcc void @"$sSlsE10firstIndex5where0B0QzSgSb7ElementQzKXE_tKF"(%swift.opaque* noalias nocapture sret({{.*}}) %{{[0-9]+}}, i8* bitcast ({{.*}}* @"$s22big_types_corner_cases9BigStruct{{.*}}_TRTA{{(\.ptrauth)?}}" to i8*), %swift.opaque* %{{[0-9]+}}, %swift.type* %{{[0-9]+}}, i8** [[CALL2]]
+// CHECK:  call swiftcc void @"$sSlsE10firstIndex5where0B0QzSgSb7ElementQzKXE_tKF"(%swift.opaque* noalias nocapture sret({{.*}}) %{{[0-9]+}}, i8* bitcast ({{.*}}* @"$s22big_types_corner_cases7TestBig{{.*}}" to i8*), %swift.opaque* null, %swift.type* %{{[0-9]+}}, i8** [[CALL2]]
 class TestBig {
     typealias Handler = (BigStruct) -> Void
 

--- a/test/Profiler/coverage_closure_returns_never.swift
+++ b/test/Profiler/coverage_closure_returns_never.swift
@@ -2,7 +2,8 @@
 
 // CHECK-LABEL: closure #1 (Swift.Never) -> Swift.Never in coverage_closure_returns_never.closure_with_fatal_error(Swift.Array<Swift.Never>) -> ()
 // CHECK: builtin "int_instrprof_increment"
-// CHECK-NEXT: debug_value {{.*}} : $Never
+// CHECK-NEXT: [[LOAD:%.*]] = load {{.*}} : $*Never
+// CHECK-NEXT: debug_value [[LOAD]] : $Never
 // CHECK-NEXT: unreachable
 
 func closure_with_fatal_error(_ arr: [Never]) {

--- a/test/SILGen/closure_literal_reabstraction_async.swift
+++ b/test/SILGen/closure_literal_reabstraction_async.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend -emit-silgen %s -disable-availability-checking | %FileCheck %s
+// REQUIRES: concurrency
+
+@_silgen_name("takeThrowingAsyncClosure")
+func takeThrowingAsyncClosure<T>(_: () async throws -> T) 
+
+// CHECK-LABEL: sil {{.*}} @{{.*}}34passNonthrowingAsyncClosureLiteral
+func passNonthrowingAsyncClosureLiteral() {
+    // Check that the literal closure was emitted directly with an error return,
+    // without a reabstraction thunk to convert from nonthrowing.
+    // CHECK: [[INVOKE_FN:%.*]] = function_ref
+    // CHECK: [[CONVERT_NOESCAPE:%.*]] = convert_function [[INVOKE_FN]]
+    // CHECK: [[CLOSURE:%.*]] = thin_to_thick_function [[CONVERT_NOESCAPE]]
+    // CHECK: [[CALLEE:%.*]] = function_ref @takeThrowingAsyncClosure
+    // CHECK: apply [[CALLEE]]<Int>([[CLOSURE]])
+    takeThrowingAsyncClosure { return 42 }
+}

--- a/test/SILGen/rethrows.swift
+++ b/test/SILGen/rethrows.swift
@@ -71,12 +71,11 @@ func test2() {
 }
 
 // CHECK-LABEL: sil hidden @$s8rethrows5test3yyF : $@convention(thin) () -> () {
-// CHECK:       [[CLOSURE:%.*]] = function_ref @$s8rethrows5test3yyFSiyXEfU_ : $@convention(thin) () -> Int
-// CHECK:       [[CVT:%.*]] = convert_function [[CLOSURE]] : $@convention(thin) () -> Int to $@convention(thin) @noescape () -> Int
+// CHECK:       [[CLOSURE:%.*]] = function_ref @$s8rethrows5test3yyFSiyXEfU_ :
+// CHECK:       [[CVT:%.*]] = convert_function [[CLOSURE]] :
 // CHECK:       [[T0:%.*]] = thin_to_thick_function [[CVT]]
-// CHECK:       [[T1:%.*]] = convert_function [[T0]] : $@noescape @callee_guaranteed () -> Int to $@noescape @callee_guaranteed () -> (Int, @error Error)
-// CHECK:       [[RETHROWER:%.*]] = function_ref @$s8rethrows9rethroweryS2iyKXEKF : $@convention(thin) (@noescape @callee_guaranteed () -> (Int, @error Error)) -> (Int, @error Error)
-// CHECK:       try_apply [[RETHROWER]]([[T1]]) : $@convention(thin) (@noescape @callee_guaranteed () -> (Int, @error Error)) -> (Int, @error Error), normal [[NORMAL:bb1]], error [[ERROR:bb2]]
+// CHECK:       [[RETHROWER:%.*]] = function_ref @$s8rethrows9rethroweryS2iyKXEKF :
+// CHECK:       try_apply [[RETHROWER]]([[T0]]) :
 // CHECK:     [[NORMAL]]({{%.*}} : $Int):
 // CHECK-NEXT:  [[RESULT:%.*]] = tuple ()
 // CHECK-NEXT:  return [[RESULT]]

--- a/test/SILGen/type_lowering_subst_function_type_conditional_conformance.swift
+++ b/test/SILGen/type_lowering_subst_function_type_conditional_conformance.swift
@@ -64,7 +64,8 @@ struct S4<Base> where Base : P1, Base.Element: P1 {
 // CHECK-LABEL: {{^}}sil {{.*}} @${{.*}}2S4{{.*}}3foo{{.*}}F :
 // CHECK: @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : P1, τ_0_0 == τ_0_1, τ_0_0.Element : P1> (@in_guaranteed S3<τ_0_0>) -> () for <Base, Base>
   func foo(index: S3<Base>?) {
-    _ = index.map({ _ = $0 })
+    let f: (S3<Base>) -> () = { _ = $0 }
+    _ = index.map(f)
   }
 }
 

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -1420,14 +1420,15 @@ bb0(%0 : $MyNSObj):
   return %2 : $@callee_owned () -> @owned MyNSObj
 }
 
-// Check that convert_function is not eliminated if the result type of the converted function is different from the apply result type.
-// CHECK-LABEL: sil {{.*}} @do_not_peephole_convert_function : $@convention(thin) (@in AnotherClass) -> @out @callee_owned (@in ()) -> @out AnotherClass {
-// CHECK: [[CF:%[0-9]+]] = convert_function
-// CHECK: [[APPLY:%[0-9]+]] = apply
-// CHECK: [[FUN:%[0-9]+]] = function_ref
-// CHECK: [[CF:%[0-9]+]] = partial_apply [[FUN]]([[APPLY]])
-// CHECK: // end sil function 'do_not_peephole_convert_function'
-sil shared [transparent] [reabstraction_thunk] @do_not_peephole_convert_function : $@convention(thin) (@in AnotherClass) -> @out @callee_owned (@in ()) -> @out AnotherClass {
+// Check that convert_function is eliminated if the result type of the converted function is different from the apply result type.
+// CHECK-LABEL: sil {{.*}} @peephole_convert_function_result_change : $@convention(thin) (@in AnotherClass) -> @out @callee_owned (@in ()) -> @out AnotherClass {
+// CHECK: [[F1:%[0-9]+]] = function_ref @curry_thunk_for_MyNSObj_self
+// CHECK: [[APPLY:%[0-9]+]] = apply [[F1]]
+// CHECK: [[CONV_RESULT:%[0-9]+]] = convert_function [[APPLY]]
+// CHECK: [[FUN:%[0-9]+]] = function_ref @reabstraction_thunk1
+// CHECK: [[CF:%[0-9]+]] = partial_apply [[FUN]]([[CONV_RESULT]])
+// CHECK: // end sil function 'peephole_convert_function_result_change'
+sil shared [transparent] [reabstraction_thunk] @peephole_convert_function_result_change : $@convention(thin) (@in AnotherClass) -> @out @callee_owned (@in ()) -> @out AnotherClass {
 bb0(%0 : $*@callee_owned (@in ()) -> @out AnotherClass, %1 : $*AnotherClass):
   // function_ref @nonobjc curry thunk of MyNSObj.self()
   %2 = function_ref @curry_thunk_for_MyNSObj_self : $@convention(thin) (@owned MyNSObj) -> @owned @callee_owned () -> @owned MyNSObj
@@ -1440,7 +1441,48 @@ bb0(%0 : $*@callee_owned (@in ()) -> @out AnotherClass, %1 : $*AnotherClass):
   store %8 to %0 : $*@callee_owned (@in ()) -> @out AnotherClass
   %10 = tuple ()
   return %10 : $()
-} // end sil function 'do_not_peephole_convert_function'
+} // end sil function 'peephole_convert_function_result_change'
+
+sil @convertible_result_with_error : $@convention(thin) () -> (@owned AnotherClass, @error Error)
+
+// TODO
+sil @peephole_convert_function_result_change_with_error : $@convention(thin) () -> () {
+entry:
+  %f = function_ref @convertible_result_with_error : $@convention(thin) () -> (@owned AnotherClass, @error Error)
+  %c = convert_function %f : $@convention(thin) () -> (@owned AnotherClass, @error Error) to $@convention(thin) () -> (@owned MyNSObj, @error Error)
+  try_apply %c() : $@convention(thin) () -> (@owned MyNSObj, @error Error), normal success, error failure
+
+success(%r : $MyNSObj):
+  strong_release %r : $MyNSObj
+  br exit
+
+failure(%e : $Error):
+  strong_release %e : $Error
+  br exit
+
+exit:
+  return undef : $()
+}
+
+sil @convertible_indirect_result : $@convention(thin) (@guaranteed MyNSObj) -> @out AnotherClass
+
+// CHECK-LABEL: sil @peephole_convert_function_indirect_result :
+// CHECK:       bb0([[A:%.*]] : $AnotherClass):
+// CHECK:         [[F:%.*]] = function_ref @convertible_indirect_result :
+// CHECK:         [[B:%.*]] = alloc_stack $MyNSObj
+// CHECK:         [[B_CONV:%.*]] = unchecked_addr_cast [[B]]
+// CHECK:         [[A_CONV:%.*]] = upcast [[A]]
+// CHECK:         apply [[F]]([[B_CONV]], [[A_CONV]])
+sil @peephole_convert_function_indirect_result : $@convention(thin) (@guaranteed AnotherClass) -> @owned MyNSObj {
+entry(%a : $AnotherClass):
+  %f = function_ref @convertible_indirect_result : $@convention(thin) (@guaranteed MyNSObj) -> @out AnotherClass
+  %c = convert_function %f : $@convention(thin) (@guaranteed MyNSObj) -> @out AnotherClass to $@convention(thin) (@guaranteed AnotherClass) -> @out MyNSObj
+  %b = alloc_stack $*MyNSObj
+  apply %c(%b, %a) : $@convention(thin) (@guaranteed AnotherClass) -> @out MyNSObj
+  %r = load %b : $*MyNSObj
+  dealloc_stack %b : $*MyNSObj
+  return %r : $MyNSObj
+}
 
 // CHECK-LABEL: sil @upcast_formation : $@convention(thin) (@inout E, E, @inout B) -> B {
 // CHECK: bb0

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -1705,14 +1705,15 @@ bb0(%0 : @owned $MyNSObj):
   return %2 : $@callee_owned () -> @owned MyNSObj
 }
 
-// Check that convert_function is not eliminated if the result type of the converted function is different from the apply result type.
-// CHECK-LABEL: sil {{.*}} @do_not_peephole_convert_function : $@convention(thin) (@in AnotherClass) -> @out @callee_owned (@in ()) -> @out AnotherClass {
-// CHECK: [[CF:%[0-9]+]] = convert_function
-// CHECK: [[APPLY:%[0-9]+]] = apply
-// CHECK: [[FUN:%[0-9]+]] = function_ref
-// CHECK: [[CF:%[0-9]+]] = partial_apply [[FUN]]([[APPLY]])
-// CHECK: // end sil function 'do_not_peephole_convert_function'
-sil shared [ossa] [transparent] [reabstraction_thunk] @do_not_peephole_convert_function : $@convention(thin) (@in AnotherClass) -> @out @callee_owned (@in ()) -> @out AnotherClass {
+// Check that convert_function is eliminated if the result type of the converted function is different from the apply result type.
+// CHECK-LABEL: sil {{.*}} @peephole_convert_function_result_change : $@convention(thin) (@in AnotherClass) -> @out @callee_owned (@in ()) -> @out AnotherClass {
+// CHECK: [[F1:%[0-9]+]] = function_ref @curry_thunk_for_MyNSObj_self
+// CHECK: [[APPLY:%[0-9]+]] = apply [[F1]]
+// CHECK: [[CONV_RESULT:%[0-9]+]] = convert_function [[APPLY]]
+// CHECK: [[FUN:%[0-9]+]] = function_ref @reabstraction_thunk1
+// CHECK: [[CF:%[0-9]+]] = partial_apply [[FUN]]([[CONV_RESULT]])
+// CHECK: // end sil function 'peephole_convert_function_result_change'
+sil shared [ossa] [transparent] [reabstraction_thunk] @peephole_convert_function_result_change : $@convention(thin) (@in AnotherClass) -> @out @callee_owned (@in ()) -> @out AnotherClass {
 bb0(%0 : $*@callee_owned (@in ()) -> @out AnotherClass, %1 : $*AnotherClass):
   // function_ref @nonobjc curry thunk of MyNSObj.self()
   %2 = function_ref @curry_thunk_for_MyNSObj_self : $@convention(thin) (@owned MyNSObj) -> @owned @callee_owned () -> @owned MyNSObj
@@ -1725,7 +1726,65 @@ bb0(%0 : $*@callee_owned (@in ()) -> @out AnotherClass, %1 : $*AnotherClass):
   store %8 to [init] %0 : $*@callee_owned (@in ()) -> @out AnotherClass
   %10 = tuple ()
   return %10 : $()
-} // end sil function 'do_not_peephole_convert_function'
+} // end sil function 'peephole_convert_function_result_change'
+
+sil @convertible_result_with_error : $@convention(thin) () -> (@owned AnotherClass, @error Error)
+
+// TODO
+sil [ossa] @peephole_convert_function_result_change_with_error : $@convention(thin) () -> () {
+entry:
+  %f = function_ref @convertible_result_with_error : $@convention(thin) () -> (@owned AnotherClass, @error Error)
+  %c = convert_function %f : $@convention(thin) () -> (@owned AnotherClass, @error Error) to $@convention(thin) () -> (@owned MyNSObj, @error Error)
+  try_apply %c() : $@convention(thin) () -> (@owned MyNSObj, @error Error), normal success, error failure
+
+success(%r : $MyNSObj):
+  destroy_value %r : $MyNSObj
+  br exit
+
+failure(%e : $Error):
+  destroy_value %e : $Error
+  br exit
+
+exit:
+  return undef : $()
+}
+
+sil @convertible_indirect_result : $@convention(thin) (@guaranteed MyNSObj) -> @out AnotherClass
+
+// CHECK-LABEL: sil [ossa] @peephole_convert_function_indirect_result :
+// CHECK:       bb0([[A:%.*]] : @guaranteed $AnotherClass):
+// CHECK:         [[F:%.*]] = function_ref @convertible_indirect_result :
+// CHECK:         [[B:%.*]] = alloc_stack $MyNSObj
+// CHECK:         [[B_CONV:%.*]] = unchecked_addr_cast [[B]]
+// CHECK:         [[A_CONV:%.*]] = upcast [[A]]
+// CHECK:         apply [[F]]([[B_CONV]], [[A_CONV]])
+sil [ossa] @peephole_convert_function_indirect_result : $@convention(thin) (@guaranteed AnotherClass) -> @owned MyNSObj {
+entry(%a : @guaranteed $AnotherClass):
+  %f = function_ref @convertible_indirect_result : $@convention(thin) (@guaranteed MyNSObj) -> @out AnotherClass
+  %c = convert_function %f : $@convention(thin) (@guaranteed MyNSObj) -> @out AnotherClass to $@convention(thin) (@guaranteed AnotherClass) -> @out MyNSObj
+  %b = alloc_stack $*MyNSObj
+  apply %c(%b, %a) : $@convention(thin) (@guaranteed AnotherClass) -> @out MyNSObj
+  %r = load [take] %b : $*MyNSObj
+  dealloc_stack %b : $*MyNSObj
+  return %r : $MyNSObj
+}
+
+sil @convertible_owned_aggregate_input : $@convention(thin) (@owned (MyNSObj, MyNSObj)) -> @owned (AnotherClass, AnotherClass)
+
+// CHECK-LABEL: sil [ossa] @peephole_convert_owned_aggregate_input_result :
+// CHECK:       bb0([[A:%.*]] : @owned $(AnotherClass, AnotherClass)):
+// CHECK:         [[F:%.*]] = function_ref @convertible_owned_aggregate_input :
+// CHECK:         [[A_CONV:%.*]] = unchecked_value_cast [[A]]
+// CHECK:         [[R:%.*]] = apply [[F]]([[A_CONV]])
+// CHECK:         [[R_CONV:%.*]] = unchecked_value_cast [[R]]
+// CHECK:         return [[R_CONV]]
+sil [ossa] @peephole_convert_owned_aggregate_input_result : $@convention(thin) (@owned (AnotherClass, AnotherClass)) -> @owned (MyNSObj, MyNSObj) {
+entry(%a : @owned $(AnotherClass, AnotherClass)):
+  %f = function_ref @convertible_owned_aggregate_input : $@convention(thin) (@owned (MyNSObj, MyNSObj)) -> @owned (AnotherClass, AnotherClass)
+  %c = convert_function %f : $@convention(thin) (@owned (MyNSObj, MyNSObj)) -> @owned (AnotherClass, AnotherClass) to $@convention(thin) (@owned (AnotherClass, AnotherClass)) -> @owned (MyNSObj, MyNSObj)
+  %r = apply %c(%a) : $@convention(thin) (@owned (AnotherClass, AnotherClass)) -> @owned (MyNSObj, MyNSObj)
+  return %r : $(MyNSObj, MyNSObj)
+}
 
 // CHECK-LABEL: sil [ossa] @upcast_formation : $@convention(thin) (@inout E, @owned E, @inout B) -> @owned B {
 // CHECK: bb0


### PR DESCRIPTION
Explanation: Eliminates the reabstraction thunk emitted when calling a function that takes an `(A...) async throws -> R` function parameter with a literal closure argument that doesn't throw, by folding the type conversion into the closure literal's code generation. This is particularly interesting for the `Task.init` constructors, since the symbol name of the closure entry point that the runtime ultimately sees is useful for instrumentation purposes.

Scope: An optimization that removes unnecessary thunks from code generation.

Risk: Low. This unblocks an optimization, which has already been working in the 5.7 branch for pretty much all code we've thrown at it, to apply in more situations.

Testing: Swift CI

Issue: rdar://92756873

Reviewed by: @rjmccall 