### PR TITLE
[AutoDiff] Disable LBA tests on `use_os_stdlib` or `back_deployment_runtime`

### DIFF
--- a/test/AutoDiff/IRGen/loadable_by_address.swift
+++ b/test/AutoDiff/IRGen/loadable_by_address.swift
@@ -4,6 +4,9 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
 // `isLargeLoadableType` depends on the ABI and differs between architectures.
 // REQUIRES: CPU=x86_64
 

--- a/test/AutoDiff/IRGen/loadable_by_address_cross_module.swift
+++ b/test/AutoDiff/IRGen/loadable_by_address_cross_module.swift
@@ -1,3 +1,6 @@
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
 // First, check that LBA actually modifies the function, so that this test is useful.
 
 // RUN: %target-swift-frontend -emit-sil %S/Inputs/loadable_by_address_cross_module.swift | %FileCheck %s -check-prefix=CHECK-MODULE-PRE-LBA


### PR DESCRIPTION
rdar://92757783