### PR TITLE
Sema: Members with availability in unavailable containers should be unavailable

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -333,6 +333,30 @@ static bool computeContainedByDeploymentTarget(TypeRefinementContext *TRC,
                   .isContainedIn(AvailabilityContext::forDeploymentTarget(ctx));
 }
 
+/// Returns true if the reference or any of its parents is an
+/// unconditional unavailable declaration for the same platform.
+static bool isInsideCompatibleUnavailableDeclaration(
+    const Decl *D, const ExportContext &where, const AvailableAttr *attr) {
+  auto referencedPlatform = where.getUnavailablePlatformKind();
+  if (!referencedPlatform)
+    return false;
+
+  if (!attr->isUnconditionallyUnavailable()) {
+    return false;
+  }
+
+  // Refuse calling unavailable functions from unavailable code,
+  // but allow the use of types.
+  PlatformKind platform = attr->Platform;
+  if (platform == PlatformKind::none && !isa<TypeDecl>(D) &&
+      !isa<ExtensionDecl>(D)) {
+    return false;
+  }
+
+  return (*referencedPlatform == platform ||
+          inheritsAvailabilityFromPlatform(platform, *referencedPlatform));
+}
+
 namespace {
 
 /// A class to walk the AST to build the type refinement context hierarchy.
@@ -1191,6 +1215,12 @@ bool TypeChecker::isDeclarationUnavailable(
 Optional<UnavailabilityReason>
 TypeChecker::checkDeclarationAvailability(const Decl *D,
                                           const ExportContext &Where) {
+  // Skip computing potential unavailability if the declaration is explicitly
+  // unavailable and the context is also unavailable.
+  if (const AvailableAttr *Attr = AvailableAttr::isUnavailable(D))
+    if (isInsideCompatibleUnavailableDeclaration(D, Where, Attr))
+      return None;
+
   if (isDeclarationUnavailable(D, Where.getDeclContext(), [&Where] {
         return Where.getAvailabilityContext();
       })) {
@@ -2011,33 +2041,6 @@ const AvailableAttr *TypeChecker::getDeprecated(const Decl *D) {
   }
 
   return nullptr;
-}
-
-/// Returns true if the reference or any of its parents is an
-/// unconditional unavailable declaration for the same platform.
-static bool isInsideCompatibleUnavailableDeclaration(
-    const Decl *D, const ExportContext &where,
-    const AvailableAttr *attr) {
-  auto referencedPlatform = where.getUnavailablePlatformKind();
-  if (!referencedPlatform)
-    return false;
-
-  if (!attr->isUnconditionallyUnavailable()) {
-    return false;
-  }
-
-  // Refuse calling unavailable functions from unavailable code,
-  // but allow the use of types.
-  PlatformKind platform = attr->Platform;
-  if (platform == PlatformKind::none &&
-      !isa<TypeDecl>(D) &&
-      !isa<ExtensionDecl>(D)) {
-    return false;
-  }
-
-  return (*referencedPlatform == platform ||
-          inheritsAvailabilityFromPlatform(platform,
-                                           *referencedPlatform));
 }
 
 static void fixItAvailableAttrRename(InFlightDiagnostic &diag,

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -1632,10 +1632,6 @@ func funcWithMultipleShortFormAnnotationsForTheSamePlatform() {
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
-@available(OSX 10.9, *)
-@available(OSX, unavailable)
-func unavailableWins() { } // expected-note {{'unavailableWins()' has been explicitly marked unavailable here}}
-
 func useShortFormAvailable() {
   // expected-note@-1 4{{add @available attribute to enclosing global function}}
 
@@ -1654,6 +1650,34 @@ func useShortFormAvailable() {
 
   funcWithMultipleShortFormAnnotationsForTheSamePlatform() // expected-error {{'funcWithMultipleShortFormAnnotationsForTheSamePlatform()' is only available in macOS 10.53 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
+}
 
+// Unavailability takes precedence over availability and is inherited
+
+@available(OSX 10.9, *)
+@available(OSX, unavailable)
+func unavailableWins() { }
+    // expected-note@-1 {{'unavailableWins()' has been explicitly marked unavailable here}}
+
+struct HasUnavailableExtension {
+  @available(OSX, unavailable)
+  public func directlyUnavailable() { }
+      // expected-note@-1 {{'directlyUnavailable()' has been explicitly marked unavailable here}}
+}
+
+@available(OSX, unavailable)
+extension HasUnavailableExtension {
+  public func inheritsUnavailable() { }
+      // expected-note@-1 {{'inheritsUnavailable()' has been explicitly marked unavailable here}}
+
+  @available(OSX 10.9, *)
+  public func moreAvailableButStillUnavailable() { }
+      // expected-note@-1 {{'moreAvailableButStillUnavailable()' has been explicitly marked unavailable here}}
+}
+
+func useHasUnavailableExtension(_ s: HasUnavailableExtension) {
   unavailableWins() // expected-error {{'unavailableWins()' is unavailable}}
+  s.directlyUnavailable() // expected-error {{'directlyUnavailable()' is unavailable}}
+  s.inheritsUnavailable() // expected-error {{'inheritsUnavailable()' is unavailable in macOS}}
+  s.moreAvailableButStillUnavailable() // expected-error {{'moreAvailableButStillUnavailable()' is unavailable in macOS}}
 }

--- a/test/attr/attr_availability_transitive_osx.swift
+++ b/test/attr/attr_availability_transitive_osx.swift
@@ -106,7 +106,39 @@ extension Outer {
 
 @available(OSX, unavailable)
 extension Outer {
+  // expected-note@+1 {{'outer_osx_init_osx' has been explicitly marked unavailable here}}
   static var outer_osx_init_osx = osx() // OK
+  
+  // expected-note@+1 {{'osx_call_osx()' has been explicitly marked unavailable here}}
+  func osx_call_osx() {
+    osx() // OK
+  }
+
+  func osx_call_osx_extension() {
+    osx_extension() // OK; osx_extension is only unavailable if -application-extension is passed.
+  }
+  
+  func takes_and_returns_osx(_ x: NotOnOSX) -> NotOnOSX {
+    return x // OK
+  }
+  
+  // This @available should be ignored; inherited unavailability takes precedence
+  @available(OSX 999, *)
+  // expected-note@+1 {{'osx_more_available_but_still_unavailable_call_osx()' has been explicitly marked unavailable here}}
+  func osx_more_available_but_still_unavailable_call_osx() {
+    osx() // OK
+  }
+  
+  // rdar://92551870
+  func osx_call_osx_more_available_but_still_unavailable() {
+    osx_more_available_but_still_unavailable_call_osx() // OK
+  }
+}
+
+func takesOuter(_ o: Outer) {
+  _ = Outer.outer_osx_init_osx // expected-error {{'outer_osx_init_osx' is unavailable in macOS}}
+  o.osx_call_osx() // expected-error {{'osx_call_osx()' is unavailable in macOS}}
+  o.osx_more_available_but_still_unavailable_call_osx() // expected-error {{'osx_more_available_but_still_unavailable_call_osx()' is unavailable in macOS}}
 }
 
 @available(OSX, unavailable)


### PR DESCRIPTION
When computing potential unavailability of a decl, first check whether the decl is explicitly unavailable and the context is also unavailable. If those conditions are met, treat the decl as if it were always available since unavailable code is allowed to reference unavailable decls.

Previously, `TypeChecker::checkDeclarationAvailability()` would behave this way for most explicitly unavailable decls by _accident_. An explicitly unavailable decl has no introduction version, and the existing logic therefore would fail to find a lower bound on the availability of the decl. The edge case that exposed the fragility of this logic was an unavailable extension containing a member with its own explicit availability. The unavailability of the extension ought to trump the availability of the member, but the existing logic couldn't detect that.

The compiler also ought to diagnose the conflicting availability annotations but I'd like to address that separately.

Resolves rdar://92551870