### PR TITLE
🍒[5.7][Distributed] Diagnose missing inout on remoteCall decls

### DIFF
--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -491,10 +491,12 @@ bool AbstractFunctionDecl::isDistributedActorSystemRemoteCall(bool isVoidReturn)
     return false;
   }
 
-  // --- Check parameter: invocation InvocationEncoder
-  // FIXME: NOT INOUT, but we crash today if not
+  // --- Check parameter: invocation: inout InvocationEncoder
   auto invocationParam = params->get(2);
   if (invocationParam->getArgumentName() != C.Id_invocation) {
+    return false;
+  }
+  if (!invocationParam->isInOut()) {
     return false;
   }
 

--- a/test/Distributed/distributed_actor_system_missing_adhoc_requirement_impls.swift
+++ b/test/Distributed/distributed_actor_system_missing_adhoc_requirement_impls.swift
@@ -41,6 +41,67 @@ struct MissingRemoteCall: DistributedActorSystem {
   }
 }
 
+struct MissingRemoteCall_missingInout_on_encoder: DistributedActorSystem {
+  // expected-error@-1{{struct 'MissingRemoteCall_missingInout_on_encoder' is missing witness for protocol requirement 'remoteCall'}}
+  // expected-note@-2{{protocol 'MissingRemoteCall_missingInout_on_encoder' requires function 'remoteCall' with signature:}}
+
+  // expected-error@-4{{struct 'MissingRemoteCall_missingInout_on_encoder' is missing witness for protocol requirement 'remoteCallVoid'}}
+  // expected-note@-5{{protocol 'MissingRemoteCall_missingInout_on_encoder' requires function 'remoteCallVoid' with signature:}}
+
+  typealias ActorID = ActorAddress
+  typealias InvocationDecoder = FakeInvocationDecoder
+  typealias InvocationEncoder = FakeInvocationEncoder
+  typealias SerializationRequirement = Codable
+  typealias ResultHandler = FakeResultHandler
+
+  func resolve<Act>(id: ActorID, as actorType: Act.Type)
+    throws -> Act? where Act: DistributedActor {
+    return nil
+  }
+
+  func assignID<Act>(_ actorType: Act.Type) -> ActorID
+    where Act: DistributedActor {
+    ActorAddress(parse: "fake://123")
+  }
+
+  func actorReady<Act>(_ actor: Act)
+    where Act: DistributedActor,
+    Act.ID == ActorID {
+  }
+
+  func resignID(_ id: ActorID) {
+  }
+
+  func remoteCall<Act, Err, Res>(
+      on actor: Act,
+      target: RemoteCallTarget,
+      invocation: InvocationEncoder, // MISSING 'inout'
+      throwing: Err.Type,
+      returning: Res.Type
+  ) async throws -> Res
+      where Act: DistributedActor,
+      Act.ID == ActorID,
+      Err: Error,
+      Res: SerializationRequirement {
+    fatalError("NOT IMPLEMENTED \(#function)")
+  }
+
+  func remoteCallVoid<Act, Err>(
+      on actor: Act,
+      target: RemoteCallTarget,
+      invocation: InvocationEncoder, // MISSING 'inout'
+      throwing: Err.Type
+  ) async throws
+      where Act: DistributedActor,
+      Act.ID == ActorID,
+      Err: Error {
+    fatalError("NOT IMPLEMENTED \(#function)")
+  }
+
+  func makeInvocationEncoder() -> InvocationEncoder {
+  }
+}
+
 struct MissingRemoteCall_missing_makeInvocationEncoder: DistributedActorSystem {
   // expected-error@-1{{type 'MissingRemoteCall_missing_makeInvocationEncoder' does not conform to protocol 'DistributedActorSystem'}}
 


### PR DESCRIPTION
Description: Diagnosis of a missing `inout` in an ad hoc protocol requirement witness. We just missed to fix this FIXME before.
Original PR: https://github.com/apple/swift/pull/58672
Risk: Low, this adde a diagnosis on something that would have failed in other ways
Resolves https://github.com/apple/swift/issues/58671
Resolves rdar://92754877