### PR TITLE
[5.7][Refactoring] Fix an issue where refactoring misses to refactor references after prefix operators

### DIFF
--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -310,10 +310,12 @@ static Expr *extractNameExpr(Expr *Fn) {
 
 std::pair<bool, ArgumentList *>
 NameMatcher::walkToArgumentListPre(ArgumentList *ArgList) {
-  auto Labels = getCallArgLabelRanges(getSourceMgr(), ArgList,
-                                      LabelRangeEndAt::BeforeElemStart);
-  tryResolve(Parent, ArgList->getStartLoc(), LabelRangeType::CallArg,
+  if (!ArgList->isImplicit()) {
+    auto Labels = getCallArgLabelRanges(getSourceMgr(), ArgList,
+                                        LabelRangeEndAt::BeforeElemStart);
+    tryResolve(Parent, ArgList->getStartLoc(), LabelRangeType::CallArg,
              Labels.first, Labels.second);
+  }
   if (isDone())
     return {false, ArgList};
 

--- a/test/refactoring/rename/Outputs/prefix_operator/refactor.swift.expected
+++ b/test/refactoring/rename/Outputs/prefix_operator/refactor.swift.expected
@@ -1,0 +1,6 @@
+let bar: Int = 12
+let negfoo = -bar
+print("opposite of \(bar) is \(negfoo)")
+
+
+

--- a/test/refactoring/rename/prefix_operator.swift
+++ b/test/refactoring/rename/prefix_operator.swift
@@ -1,0 +1,13 @@
+let foo: Int = 12
+let negfoo = -foo
+print("opposite of \(foo) is \(negfoo)")
+
+// RUN: %empty-directory(%t.result)
+
+// RUN: %refactor -rename -source-filename %s -pos=1:5 -new-name bar >> %t.result/def.swift
+// RUN: %target-swift-frontend-typecheck %t.result/def.swift
+// RUN: diff -u %S/Outputs/prefix_operator/refactor.swift.expected %t.result/def.swift
+
+// RUN: %refactor -rename -source-filename %s -pos=2:15 -new-name bar >> %t.result/operator_ref.swift
+// RUN: %target-swift-frontend-typecheck %t.result/operator_ref.swift
+// RUN: diff -u %S/Outputs/prefix_operator/refactor.swift.expected %t.result/operator_ref.swift


### PR DESCRIPTION
* **Explanation**: Local refactoring misses references to a variable after a prefix operator because it can’t differentiate the call arguments, which start with a `(` in normal function calls, from the actual argument based on the location if the argument list is implicit (like for prefix operators).
* **Scope**: Local refactoring
* **Risk**: Low (only affects local refactoring of variables that occur in implicit argument lists)
* **Testing**: Added regression test
* **Issue**: rdar://91588948
* **Reviewer**: @bnbarham @benlangmuir and @hamishknight on https://github.com/apple/swift/pull/58613
