### PR TITLE
CrossModuleOptimization: Don't serialize pre-specialized public entry points

### DIFF
--- a/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
+++ b/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
@@ -207,7 +207,9 @@ bool CrossModuleOptimization::canSerializeFunction(
   // Do the same check for the specializations of such functions.
   if (function->isSpecialization()) {
     const SILFunction *parent = function->getSpecializationInfo()->getParent();
-    if (!parent->getSpecializeAttrs().empty())
+    // Don't serialize exported (public) specializations.
+    if (!parent->getSpecializeAttrs().empty() &&
+        function->getLinkage() == SILLinkage::Public)
       return false;
   }
 

--- a/test/SILOptimizer/Inputs/cross-module/cross-module.swift
+++ b/test/SILOptimizer/Inputs/cross-module/cross-module.swift
@@ -17,6 +17,7 @@ public struct Container {
     var arr = Array<Base>()
     arr.append(Base())
     print(arr)
+    dontBlockSerialization(arr)
     return t
   }
 

--- a/test/SILOptimizer/Inputs/cross-module/cross-submodule.swift
+++ b/test/SILOptimizer/Inputs/cross-module/cross-submodule.swift
@@ -10,3 +10,9 @@ public func genericSubmoduleFunc<T>(_ t: T) {
   printit(t)
 }
 
+@_specialize(exported: true, where T == Int)
+@inlinable
+@inline(never)
+public func dontBlockSerialization<T>(_ t: T) {
+    print(t)
+}


### PR DESCRIPTION
We should continue to use the public pre-specialized entry point from another module. But not block other uses of generic specializations.
