### PR TITLE
[WIP] #58686 `swift_slowAlloc()` _et al._ should be marked returns-nonnull to improve codegen

### DIFF
--- a/include/swift/Runtime/Heap.h
+++ b/include/swift/Runtime/Heap.h
@@ -22,13 +22,14 @@
 #include <utility>
 
 #include "swift/Runtime/Config.h"
+#include "../../../stdlib/public/SwiftShims/Visibility.h"
 
 namespace swift {
 // Allocate plain old memory. This is the generalized entry point
 // Never returns nil. The returned memory is uninitialized. 
 //
 // An "alignment mask" is just the alignment (a power of 2) minus 1.
-SWIFT_RUNTIME_EXPORT
+SWIFT_RETURNS_NONNULL SWIFT_RUNTIME_EXPORT
 void *swift_slowAlloc(size_t bytes, size_t alignMask);
 
 // If the caller cannot promise to zero the object during destruction,
@@ -52,6 +53,7 @@ void swift_slowDealloc(void *ptr, size_t bytes, size_t alignMask);
 /// This function is capable of returning well-aligned memory even on platforms
 /// that do not implement the C++17 "over-aligned new" feature.
 template <typename T, typename... Args>
+SWIFT_RETURNS_NONNULL
 static inline T *swift_cxx_newObject(Args &&... args) {
   auto result = reinterpret_cast<T *>(swift_slowAlloc(sizeof(T),
                                                       alignof(T) - 1));

--- a/include/swift/Runtime/HeapObject.h
+++ b/include/swift/Runtime/HeapObject.h
@@ -28,6 +28,7 @@
 
 // Bring in the definition of HeapObject 
 #include "../../../stdlib/public/SwiftShims/HeapObject.h"
+#include "../../../stdlib/public/SwiftShims/Visibility.h"
 
 namespace swift {
   
@@ -60,7 +61,7 @@ struct OpaqueValue;
 ///
 /// POSSIBILITIES: The argument order is fair game.  It may be useful
 /// to have a variant which guarantees zero-initialized memory.
-SWIFT_RUNTIME_EXPORT
+SWIFT_RETURNS_NONNULL SWIFT_RUNTIME_EXPORT
 HeapObject *swift_allocObject(HeapMetadata const *metadata,
                               size_t requiredSize,
                               size_t requiredAlignmentMask);
@@ -116,7 +117,7 @@ BoxPair swift_makeBoxUnique(OpaqueValue *buffer, Metadata const *type,
                                     size_t alignMask);
 
 /// Returns the address of a heap object representing all empty box types.
-SWIFT_RUNTIME_EXPORT
+SWIFT_RETURNS_NONNULL SWIFT_RUNTIME_EXPORT
 HeapObject* swift_allocEmptyBox();
 
 /// Atomically increments the retain count of an object.

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -20,6 +20,7 @@
 #include "swift/ABI/Metadata.h"
 #include "swift/Reflection/Records.h"
 #include "swift/Runtime/Once.h"
+#include "../../../stdlib/public/SwiftShims/Visibility.h"
 
 namespace swift {
 
@@ -306,7 +307,7 @@ swift_getGenericMetadata(MetadataRequest request,
 ///   - installing new v-table entries and overrides; and
 ///   - registering the class with the runtime under ObjC interop.
 /// Most of this work can be achieved by calling swift_initClassMetadata.
-SWIFT_RUNTIME_EXPORT
+SWIFT_RETURNS_NONNULL SWIFT_RUNTIME_EXPORT
 ClassMetadata *
 swift_allocateGenericClassMetadata(const ClassDescriptor *description,
                                    const void *arguments,
@@ -315,7 +316,7 @@ swift_allocateGenericClassMetadata(const ClassDescriptor *description,
 /// Allocate a generic value metadata object.  This is intended to be
 /// called by the metadata instantiation function of a generic struct or
 /// enum.
-SWIFT_RUNTIME_EXPORT
+SWIFT_RETURNS_NONNULL SWIFT_RUNTIME_EXPORT
 ValueMetadata *
 swift_allocateGenericValueMetadata(const ValueTypeDescriptor *description,
                                    const void *arguments,

--- a/stdlib/public/SwiftShims/Visibility.h
+++ b/stdlib/public/SwiftShims/Visibility.h
@@ -236,6 +236,13 @@
 #define SWIFT_NODISCARD
 #endif
 
+#if __has_cpp_attribute(gnu::returns_nonnull)
+#define SWIFT_RETURNS_NONNULL [[gnu::returns_nonnull]]
+#elif defined(_MSC_VER) && defined(_Ret_notnull_)
+#define SWIFT_RETURNS_NONNULL _Ret_notnull_
+#else
+#define SWIFT_RETURNS_NONNULL
+#endif
 
 /// Attributes for runtime-stdlib interfaces.
 /// Use these for C implementations that are imported into Swift via SwiftShims

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -93,6 +93,7 @@ static inline bool isValidPointerForNativeRetain(const void *p) {
 // not to emit a bunch of ptrauth instructions just to perform the comparison.
 // We only want to authenticate the function pointer if we actually call it. We
 // can revert to a straight comparison once rdar://problem/55267009 is fixed.
+SWIFT_RETURNS_NONNULL
 static HeapObject *_swift_allocObject_(HeapMetadata const *metadata,
                                        size_t requiredSize,
                                        size_t requiredAlignmentMask)

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -6313,7 +6313,8 @@ void *MetadataAllocator::Allocate(size_t size, size_t alignment) {
       if (SWIFT_UNLIKELY(_swift_debug_metadataAllocationIterationEnabled))
         poolSize -= sizeof(PoolTrailer);
       allocatedNewPage = true;
-      allocation = new char[PoolRange::PageSize];
+      allocation = reinterpret_cast<char *>(swift_slowAlloc(PoolRange::PageSize,
+                                                            alignof(char) - 1));
       memsetScribble(allocation, PoolRange::PageSize);
 
       if (SWIFT_UNLIKELY(_swift_debug_metadataAllocationIterationEnabled)) {
@@ -6371,7 +6372,7 @@ void *MetadataAllocator::Allocate(size_t size, size_t alignment) {
 
     // If it failed, go back to a neutral state and try again.
     if (allocatedNewPage) {
-      delete[] allocation;
+      swift_slowDealloc(allocation, PoolRange::PageSize, alignof(char) - 1);
     }
   }
 }

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -23,6 +23,7 @@
 #include "swift/Demangling/TypeLookupError.h"
 #include "swift/Runtime/Config.h"
 #include "swift/Runtime/Metadata.h"
+#include "../SwiftShims/Visibility.h"
 
 #if defined(__APPLE__) && __has_include(<TargetConditionals.h>)
 #include <TargetConditionals.h>
@@ -515,6 +516,7 @@ public:
     }
   }
 
+  SWIFT_RETURNS_NONNULL
   void *allocateMetadata(size_t size, size_t align);
 
   /// Gather the set of generic arguments that would be written in the


### PR DESCRIPTION
<!-- What's in this pull request? -->
This change adds the `gnu::returns_nonnull`* attribute to `swift_slowAlloc()` and functions directly derived from it. Any code that calls these functions can be further optimized by the compiler because it knows that any paths assuming a null return value are unreachable.

This attribute is distinct from Apple's `_Nonnull` extension, which (in C/C++) is advisory only and does not affect codegen.

\* For MSVC++, `_Ret_notnull_` is substituted. This macro has no impact on codegen but may produce better diagnostics when annotated functions are misused.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves #58686.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
