### PR TITLE
[CodeCompletion] Mark types that can’t be used as attributes as having an invalid type relation when used after '@'

### DIFF
--- a/include/swift/IDE/CompletionLookup.h
+++ b/include/swift/IDE/CompletionLookup.h
@@ -240,13 +240,16 @@ public:
 
   void setIsStaticMetatype(bool value) { IsStaticMetatype = value; }
 
-  void setExpectedTypes(ArrayRef<Type> Types,
-                        bool isImplicitSingleExpressionReturn,
-                        bool preferNonVoid = false) {
+  void setExpectedTypes(
+      ArrayRef<Type> Types, bool isImplicitSingleExpressionReturn,
+      bool preferNonVoid = false,
+      OptionSet<CustomAttributeKind> expectedCustomAttributeKinds = {}) {
     expectedTypeContext.setIsImplicitSingleExpressionReturn(
         isImplicitSingleExpressionReturn);
     expectedTypeContext.setPreferNonVoid(preferNonVoid);
     expectedTypeContext.setPossibleTypes(Types);
+    expectedTypeContext.setExpectedCustomAttributeKinds(
+        expectedCustomAttributeKinds);
   }
 
   void setIdealExpectedType(Type Ty) { expectedTypeContext.setIdealType(Ty); }

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1695,6 +1695,35 @@ void CodeCompletionCallbacksImpl::doneParsing() {
 
   case CompletionKind::AttributeBegin: {
     Lookup.getAttributeDeclCompletions(IsInSil, AttTargetDK);
+    OptionSet<CustomAttributeKind> ExpectedCustomAttributeKinds;
+    if (AttTargetDK) {
+      switch (*AttTargetDK) {
+      case DeclKind::Var:
+        ExpectedCustomAttributeKinds |= CustomAttributeKind::GlobalActor;
+        LLVM_FALLTHROUGH;
+      case DeclKind::Param:
+        ExpectedCustomAttributeKinds |= CustomAttributeKind::ResultBuilder;
+        ExpectedCustomAttributeKinds |= CustomAttributeKind::PropertyWrapper;
+        break;
+      case DeclKind::Func:
+        ExpectedCustomAttributeKinds |= CustomAttributeKind::ResultBuilder;
+        ExpectedCustomAttributeKinds |= CustomAttributeKind::GlobalActor;
+        break;
+      default:
+        break;
+      }
+    }
+    if (!ExpectedCustomAttributeKinds) {
+      // If we don't know on which decl kind we are completing, suggest all
+      // attribute kinds.
+      ExpectedCustomAttributeKinds |= CustomAttributeKind::PropertyWrapper;
+      ExpectedCustomAttributeKinds |= CustomAttributeKind::ResultBuilder;
+      ExpectedCustomAttributeKinds |= CustomAttributeKind::GlobalActor;
+    }
+    Lookup.setExpectedTypes(/*Types=*/{},
+                            /*isImplicitSingleExpressionReturn=*/false,
+                            /*preferNonVoid=*/false,
+                            ExpectedCustomAttributeKinds);
 
     // TypeName at attribute position after '@'.
     // - VarDecl: Property Wrappers.

--- a/lib/IDE/CodeCompletionResultType.cpp
+++ b/lib/IDE/CodeCompletionResultType.cpp
@@ -22,11 +22,32 @@ using namespace swift;
 using namespace ide;
 using TypeRelation = CodeCompletionResultTypeRelation;
 
+// MARK: - Utilities
+
+/// Returns the kind of attributes \c Ty can be used as.
+static OptionSet<CustomAttributeKind> getCustomAttributeKinds(Type Ty) {
+  OptionSet<CustomAttributeKind> Result;
+  if (auto NominalTy = Ty->getAs<NominalType>()) {
+    auto NominalDecl = NominalTy->getDecl();
+    if (NominalDecl->getAttrs().hasAttribute<PropertyWrapperAttr>()) {
+      Result |= CustomAttributeKind::PropertyWrapper;
+    }
+    if (NominalDecl->getAttrs().hasAttribute<ResultBuilderAttr>()) {
+      Result |= CustomAttributeKind::ResultBuilder;
+    }
+    if (NominalDecl->isGlobalActor()) {
+      Result |= CustomAttributeKind::GlobalActor;
+    }
+  }
+  return Result;
+}
+
 // MARK: - USRBasedTypeContext
 
 USRBasedTypeContext::USRBasedTypeContext(const ExpectedTypeContext *TypeContext,
                                          USRBasedTypeArena &Arena)
-    : Arena(Arena) {
+    : Arena(Arena), ExpectedCustomAttributeKinds(
+                        TypeContext->getExpectedCustomAttributeKinds()) {
 
   for (auto possibleTy : TypeContext->getPossibleTypes()) {
     ContextualTypes.emplace_back(USRBasedType::fromType(possibleTy, Arena));
@@ -63,6 +84,11 @@ USRBasedTypeContext::USRBasedTypeContext(const ExpectedTypeContext *TypeContext,
 
 TypeRelation
 USRBasedTypeContext::typeRelation(const USRBasedType *ResultType) const {
+  if (ExpectedCustomAttributeKinds) {
+    return ResultType->getCustomAttributeKinds() & ExpectedCustomAttributeKinds
+               ? TypeRelation::Convertible
+               : TypeRelation::Unrelated;
+  }
   const USRBasedType *VoidType = Arena.getVoidType();
   if (ResultType == VoidType) {
     // Void is not convertible to anything and we don't report Void <-> Void
@@ -85,7 +111,7 @@ USRBasedTypeContext::typeRelation(const USRBasedType *ResultType) const {
 
 USRBasedTypeArena::USRBasedTypeArena() {
   // '$sytD' is the USR of the Void type.
-  VoidType = USRBasedType::fromUSR("$sytD", {}, *this);
+  VoidType = USRBasedType::fromUSR("$sytD", {}, {}, *this);
 }
 
 const USRBasedType *USRBasedTypeArena::getVoidType() const { return VoidType; }
@@ -125,11 +151,12 @@ TypeRelation USRBasedType::typeRelationImpl(
 }
 
 const USRBasedType *USRBasedType::null(USRBasedTypeArena &Arena) {
-  return USRBasedType::fromUSR(/*USR=*/"", /*Supertypes=*/{}, Arena);
+  return USRBasedType::fromUSR(/*USR=*/"", /*Supertypes=*/{}, {}, Arena);
 }
 
 const USRBasedType *
 USRBasedType::fromUSR(StringRef USR, ArrayRef<const USRBasedType *> Supertypes,
+                      OptionSet<CustomAttributeKind> CustomAttributeKinds,
                       USRBasedTypeArena &Arena) {
   auto ExistingTypeIt = Arena.CanonicalTypes.find(USR);
   if (ExistingTypeIt != Arena.CanonicalTypes.end()) {
@@ -142,7 +169,7 @@ USRBasedType::fromUSR(StringRef USR, ArrayRef<const USRBasedType *> Supertypes,
   Supertypes = Supertypes.copy(Arena.Allocator);
 
   const USRBasedType *Result =
-      new (Arena.Allocator) USRBasedType(USR, Supertypes);
+      new (Arena.Allocator) USRBasedType(USR, Supertypes, CustomAttributeKinds);
   Arena.CanonicalTypes[USR] = Result;
   return Result;
 }
@@ -223,7 +250,8 @@ const USRBasedType *USRBasedType::fromType(Type Ty, USRBasedTypeArena &Arena) {
     return ImpliedSupertypes.contains(Ty);
   });
 
-  return USRBasedType::fromUSR(USR, Supertypes, Arena);
+  return USRBasedType::fromUSR(USR, Supertypes, ::getCustomAttributeKinds(Ty),
+                               Arena);
 }
 
 TypeRelation USRBasedType::typeRelation(const USRBasedType *ResultType,
@@ -281,6 +309,12 @@ calculateMaxTypeRelation(Type Ty, const ExpectedTypeContext &typeContext,
                          const DeclContext &DC) {
   if (Ty->isVoid() && typeContext.requiresNonVoid())
     return TypeRelation::Invalid;
+  if (typeContext.getExpectedCustomAttributeKinds()) {
+    return (getCustomAttributeKinds(Ty) &
+            typeContext.getExpectedCustomAttributeKinds())
+               ? TypeRelation::Convertible
+               : TypeRelation::Unrelated;
+  }
   if (typeContext.empty())
     return TypeRelation::Unknown;
 

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -14,11 +14,30 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ON_MEMBER_INDEPENDENT_1 | %FileCheck %s -check-prefix=ON_MEMBER_LAST
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ON_MEMBER_INDEPENDENT_2 | %FileCheck %s -check-prefix=ON_MEMBER_LAST
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ON_MEMBER_LAST | %FileCheck %s -check-prefix=ON_MEMBER_LAST
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=IN_CLOSURE | %FileCheck %s -check-prefix=IN_CLOSURE
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=KEYWORD_INDEPENDENT_1 | %FileCheck %s -check-prefix=KEYWORD_LAST
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=KEYWORD_INDEPENDENT_2 | %FileCheck %s -check-prefix=KEYWORD_LAST
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=KEYWORD_LAST | %FileCheck %s -check-prefix=KEYWORD_LAST
 
 struct MyStruct {}
+
+@propertyWrapper
+struct MyPropertyWrapper {
+  var wrappedValue: String
+}
+
+@resultBuilder
+struct MyResultBuilder {
+  static func buildBlock(_ components: Int) -> Int {
+    return components.first!
+  }
+}
+
+@globalActor
+actor MyGlobalActor {
+  static let shared = MyGlobalActor()
+}
+
 
 @available(#^AVAILABILITY1^#)
 
@@ -74,7 +93,10 @@ struct MyStruct {}
 // KEYWORD2-NEXT:             Keyword/None:                       Sendable[#Func Attribute#]; name=Sendable
 // KEYWORD2-NEXT:             Keyword/None:                       preconcurrency[#Func Attribute#]; name=preconcurrency
 // KEYWORD2-NOT:              Keyword
-// KEYWORD2:                  Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
+// KEYWORD2-DAG:              Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
+// KEYWORD2-DAG:              Decl[Struct]/CurrModule:            MyPropertyWrapper[#MyPropertyWrapper#]; name=MyPropertyWrapper
+// KEYWORD2-DAG:              Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyResultBuilder[#MyResultBuilder#]; name=MyResultBuilder
+// KEYWORD2-DAG:              Decl[Actor]/CurrModule/TypeRelation[Convertible]: MyGlobalActor[#MyGlobalActor#]; name=MyGlobalActor
 // KEYWORD2:                  End completions
 
 @#^KEYWORD3^# class C {}
@@ -148,7 +170,10 @@ struct MyStruct {}
 // ON_GLOBALVAR-DAG: Keyword/None:                       exclusivity[#Var Attribute#]; name=exclusivity
 // ON_GLOBALVAR-DAG: Keyword/None:                       preconcurrency[#Var Attribute#]; name=preconcurrency
 // ON_GLOBALVAR-NOT: Keyword
-// ON_GLOBALVAR: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
+// ON_GLOBALVAR-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
+// ON_GLOBALVAR-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyPropertyWrapper[#MyPropertyWrapper#]; name=MyPropertyWrapper
+// ON_GLOBALVAR-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyResultBuilder[#MyResultBuilder#]; name=MyResultBuilder
+// ON_GLOBALVAR-DAG: Decl[Actor]/CurrModule/TypeRelation[Convertible]: MyGlobalActor[#MyGlobalActor#]; name=MyGlobalActor
 // ON_GLOBALVAR: End completions
 
 struct _S {
@@ -182,7 +207,10 @@ struct _S {
 // ON_PROPERTY-DAG: Keyword/None:                       exclusivity[#Var Attribute#]; name=exclusivity
 // ON_PROPERTY-DAG: Keyword/None:                       preconcurrency[#Var Attribute#]; name=preconcurrency
 // ON_PROPERTY-NOT: Keyword
-// ON_PROPERTY: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
+// ON_PROPERTY-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
+// ON_PROPERTY-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyPropertyWrapper[#MyPropertyWrapper#]; name=MyPropertyWrapper
+// ON_PROPERTY-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyResultBuilder[#MyResultBuilder#]; name=MyResultBuilder
+// ON_PROPERTY-DAG: Decl[Actor]/CurrModule/TypeRelation[Convertible]: MyGlobalActor[#MyGlobalActor#]; name=MyGlobalActor
 // ON_PROPERTY-NOT: Decl[PrecedenceGroup]
 // ON_PROPERTY: End completions
 
@@ -207,13 +235,21 @@ struct _S {
 // ON_METHOD-DAG: Keyword/None:                       noDerivative[#Func Attribute#]; name=noDerivative
 // ON_METHOD-DAG: Keyword/None:                       preconcurrency[#Func Attribute#]; name=preconcurrency
 // ON_METHOD-NOT: Keyword
-// ON_METHOD: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
+// ON_METHOD-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
+// ON_METHOD-DAG: Decl[Struct]/CurrModule:            MyPropertyWrapper[#MyPropertyWrapper#]; name=MyPropertyWrapper
+// ON_METHOD-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyResultBuilder[#MyResultBuilder#]; name=MyResultBuilder
+// ON_METHOD-DAG: Decl[Actor]/CurrModule/TypeRelation[Convertible]: MyGlobalActor[#MyGlobalActor#]; name=MyGlobalActor
+
+
 // ON_METHOD: End completions
 
   func bar(@#^ON_PARAM_1^#)
 // ON_PARAM: Begin completions
 // ON_PARAM-NOT: Keyword
-// ON_PARAM: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
+// ON_PARAM-DAG: Decl[Struct]/CurrModule:             MyStruct[#MyStruct#]; name=MyStruct
+// ON_PARAM-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyPropertyWrapper[#MyPropertyWrapper#]; name=MyPropertyWrapper
+// ON_PARAM-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyResultBuilder[#MyResultBuilder#]; name=MyResultBuilder
+// ON_PARAM-DAG: Decl[Actor]/CurrModule:              MyGlobalActor[#MyGlobalActor#]; name=MyGlobalActor
 // ON_PARAM-NOT: Keyword
 // ON_PARAM: End completions
 
@@ -270,10 +306,27 @@ struct _S {
 // ON_MEMBER_LAST-DAG: Keyword/None:                       exclusivity[#Declaration Attribute#]; name=exclusivity
 // ON_MEMBER_LAST-DAG: Keyword/None:                       preconcurrency[#Declaration Attribute#]; name=preconcurrency
 // ON_MEMBER_LAST-NOT: Keyword
-// ON_MEMBER_LAST: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
+// ON_MEMBER_LAST-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
+// ON_MEMBER_LAST-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyPropertyWrapper[#MyPropertyWrapper#]; name=MyPropertyWrapper
+// ON_MEMBER_LAST-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyResultBuilder[#MyResultBuilder#]; name=MyResultBuilder
+// ON_MEMBER_LAST-DAG: Decl[Actor]/CurrModule/TypeRelation[Convertible]: MyGlobalActor[#MyGlobalActor#]; name=MyGlobalActor
 // ON_MEMBER_LAST-NOT: Decl[PrecedenceGroup]
 // ON_MEMBER_LAST: End completions
 }
+
+func takeClosure(_: () -> Void) {
+  takeClosure { @#^IN_CLOSURE^# in
+    print("x")
+  }
+}
+// FIXME: We should mark MyPropertyWrapper and MyResultBuilder as Unrelated
+// IN_CLOSURE: Begin completions
+// IN_CLOSURE-DAG: Decl[Struct]/CurrModule: MyStruct[#MyStruct#]; name=MyStruct
+// IN_CLOSURE-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyPropertyWrapper[#MyPropertyWrapper#]; name=MyPropertyWrapper
+// IN_CLOSURE-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyResultBuilder[#MyResultBuilder#]; name=MyResultBuilder
+// IN_CLOSURE-DAG: Decl[Actor]/CurrModule/TypeRelation[Convertible]: MyGlobalActor[#MyGlobalActor#]; name=MyGlobalActor
+// IN_CLOSURE: End completions
+
 
 @#^KEYWORD_INDEPENDENT_1^#
 
@@ -322,5 +375,8 @@ func dummy2() {}
 // KEYWORD_LAST-DAG: Keyword/None:                       exclusivity[#Declaration Attribute#]; name=exclusivity
 // KEYWORD_LAST-DAG: Keyword/None:                       preconcurrency[#Declaration Attribute#]; name=preconcurrency
 // KEYWORD_LAST-NOT: Keyword
-// KEYWORD_LAST: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
+// KEYWORD_LAST-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
+// KEYWORD_LAST-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyPropertyWrapper[#MyPropertyWrapper#]; name=MyPropertyWrapper
+// KEYWORD_LAST-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyResultBuilder[#MyResultBuilder#]; name=MyResultBuilder
+// KEYWORD_LAST-DAG: Decl[Actor]/CurrModule/TypeRelation[Convertible]: MyGlobalActor[#MyGlobalActor#]; name=MyGlobalActor
 // KEYWORD_LAST:                  End completions

--- a/test/IDE/complete_type_relation_global_results.swift
+++ b/test/IDE/complete_type_relation_global_results.swift
@@ -47,6 +47,15 @@ public struct StructWithAssocType: ProtoWithAssocType {
 
 public func makeProtoWithAssocType() -> some ProtoWithAssocType { return StructWithAssocType() }
 
+@propertyWrapper
+public struct MyPropertyWrapper {
+  public var wrappedValue: String
+
+  public init(wrappedValue: String) {
+    self.wrappedValue = wrappedValue
+  }
+}
+
 // BEGIN test.swift
 
 import Lib
@@ -203,7 +212,7 @@ func protoWithAssocTypeInOpaqueContext() -> some ProtoWithAssocType {
 }
 
 // RUN: %empty-directory(%t/completion-cache)
-// RUN: %target-swift-ide-test -code-completion -source-filename %t/test.swift -code-completion-token PROTO_WITH_ASSOC_TYPE_GENERIC_RETURN_CONTEXT -completion-cache-path %t/completion-cache -I %t/ImportPath
+// RUN: %target-swift-ide-test -code-completion -source-filename %t/test.swift -code-completion-token PROTO_WITH_ASSOC_TYPE_GENERIC_RETURN_CONTEXT -completion-cache-path %t/completion-cache -I %t/ImportPath | %FileCheck %s --check-prefix=PROTO_WITH_ASSOC_TYPE_GENERIC_RETURN_CONTEXT
 // Perform the same completion again, this time using the code completion cache
 // RUN: %target-swift-ide-test -code-completion -source-filename %t/test.swift -code-completion-token PROTO_WITH_ASSOC_TYPE_GENERIC_RETURN_CONTEXT -completion-cache-path %t/completion-cache -I %t/ImportPath | %FileCheck %s --check-prefix=PROTO_WITH_ASSOC_TYPE_GENERIC_RETURN_CONTEXT
 func protoWithAssocTypeInGenericContext<T: ProtoWithAssocType>() -> T {
@@ -216,3 +225,17 @@ func protoWithAssocTypeInGenericContext<T: ProtoWithAssocType>() -> T {
 // PROTO_WITH_ASSOC_TYPE_GENERIC_RETURN_CONTEXT-DAG: Decl[Protocol]/OtherModule[Lib]/Flair[RareType]: ProtoWithAssocType[#ProtoWithAssocType#];
 // PROTO_WITH_ASSOC_TYPE_GENERIC_RETURN_CONTEXT: End completions
 
+
+// RUN: %empty-directory(%t/completion-cache)
+// RUN: %target-swift-ide-test -code-completion -source-filename %t/test.swift -code-completion-token PROPERTY_WRAPPER -completion-cache-path %t/completion-cache -I %t/ImportPath | %FileCheck %s --check-prefix=PROPERTY_WRAPPER
+// Perform the same completion again, this time using the code completion cache
+// RUN: %target-swift-ide-test -code-completion -source-filename %t/test.swift -code-completion-token PROPERTY_WRAPPER -completion-cache-path %t/completion-cache -I %t/ImportPath | %FileCheck %s --check-prefix=PROPERTY_WRAPPER
+
+struct TestPropertyWrapper {
+  @#^PROPERTY_WRAPPER^# var foo: String
+}
+
+// PROPERTY_WRAPPER: Begin completions
+// PROPERTY_WRAPPER-DAG: Decl[Struct]/OtherModule[Lib]/TypeRelation[Convertible]: MyPropertyWrapper[#MyPropertyWrapper#];
+// PROPERTY_WRAPPER-DAG: Decl[Struct]/OtherModule[Lib]: StructWithAssocType[#StructWithAssocType#];
+// PROPERTY_WRAPPER: End completions


### PR DESCRIPTION
When completing after `@`, record what kind of attributes are applicable here (property wrapper, result builder, global actor), mark types that are marked as property wrapper etc. as having a 'Convertible' type relation and mark all other types as having an 'Invalid' type relation.

rdar://78239501