### PR TITLE
[5.7] Ban Nested `some` Types in Existentials

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5049,6 +5049,9 @@ ERROR(unable_to_parse_c_function_type,none,
 ERROR(unsupported_opaque_type,none,
       "'some' types are only permitted in properties, subscripts, and functions", ())
 
+ERROR(unsupported_opaque_type_in_existential,none,
+      "'some' types cannot be used in constraints on existential types", ())
+
 ERROR(opaque_type_unsupported_pattern,none,
       "'some' type can only be declared on a single property declaration", ())
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -573,7 +573,7 @@ static void diagnoseUnboundGenericType(Type ty, SourceLoc loc);
 static Type applyGenericArguments(Type type, TypeResolution resolution,
                                   GenericParamList *silParams,
                                   ComponentIdentTypeRepr *comp) {
-  const auto options = resolution.getOptions();
+  auto options = resolution.getOptions();
   auto dc = resolution.getDeclContext();
   auto loc = comp->getNameLoc().getBaseNameLoc();
 
@@ -657,6 +657,10 @@ static Type applyGenericArguments(Type type, TypeResolution resolution,
       return ErrorType::get(ctx);
     }
 
+    // Disallow opaque types anywhere in the structure of the generic arguments
+    // to a parameterized existential type.
+    if (options.is(TypeResolverContext::ExistentialConstraint))
+      options |= TypeResolutionFlags::DisallowOpaqueTypes;
     auto genericResolution =
       resolution.withOptions(adjustOptionsForGenericArgs(options));
 
@@ -2123,10 +2127,26 @@ NeverNullType TypeResolver::resolveType(TypeRepr *repr,
     // This decl is implicit in the source and is created in such contexts by
     // evaluation of an `OpaqueResultTypeRequest`.
     auto opaqueRepr = cast<OpaqueReturnTypeRepr>(repr);
+    auto diagnoseDisallowedExistential = [&](Type ty) {
+      if (!(options & TypeResolutionFlags::SilenceErrors) &&
+          options.contains(TypeResolutionFlags::DisallowOpaqueTypes)) {
+        // We're specifically looking at an existential type `any P<some Q>`,
+        // so emit a tailored diagnostic. We don't emit an ErrorType here
+        // for better recovery.
+        diagnose(opaqueRepr->getOpaqueLoc(),
+                 diag::unsupported_opaque_type_in_existential);
+        // FIXME: We shouldn't have to invalid the type repr here, but not
+        // doing so causes a double-diagnostic.
+        opaqueRepr->setInvalid();
+      }
+      return ty;
+    };
+
     auto *DC = getDeclContext();
     if (auto opaqueDecl = dyn_cast<OpaqueTypeDecl>(DC)) {
       if (auto ordinal = opaqueDecl->getAnonymousOpaqueParamOrdinal(opaqueRepr))
-        return getIdentityOpaqueTypeArchetypeType(opaqueDecl, *ordinal);
+        return diagnoseDisallowedExistential(
+            getIdentityOpaqueTypeArchetypeType(opaqueDecl, *ordinal));
     }
 
     // Check whether any of the generic parameters in the context represents
@@ -2136,7 +2156,8 @@ NeverNullType TypeResolver::resolveType(TypeRepr *repr,
         if (auto genericParams = genericContext->getGenericParams()) {
           for (auto genericParam : *genericParams) {
             if (genericParam->getOpaqueTypeRepr() == opaqueRepr)
-              return genericParam->getDeclaredInterfaceType();
+              return diagnoseDisallowedExistential(
+                  genericParam->getDeclaredInterfaceType());
           }
         }
       }
@@ -3986,8 +4007,10 @@ TypeResolver::resolveExistentialType(ExistentialTypeRepr *repr,
 NeverNullType TypeResolver::resolveMetatypeType(MetatypeTypeRepr *repr,
                                                 TypeResolutionOptions options) {
   // The instance type of a metatype is always abstract, not SIL-lowered.
-  auto ty = resolveType(repr->getBase(),
-      options.withContext(TypeResolverContext::MetatypeBase));
+  if (options.is(TypeResolverContext::ExistentialConstraint))
+    options |= TypeResolutionFlags::DisallowOpaqueTypes;
+  options = options.withContext(TypeResolverContext::MetatypeBase);
+  auto ty = resolveType(repr->getBase(), options);
   if (ty->hasError()) {
     return ErrorType::get(getASTContext());
   }

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -61,6 +61,12 @@ enum class TypeResolutionFlags : uint16_t {
 
   /// Make internal @usableFromInline and @inlinable decls visible.
   AllowUsableFromInline = 1 << 8,
+
+  /// Forbid \c some types from resolving as opaque types.
+  ///
+  /// Needed to enforce that \c any P<some Q> does not resolve to a
+  /// parameterized existential with an opaque type constraint.
+  DisallowOpaqueTypes = 1 << 9,
 };
 
 /// Type resolution contexts that require special handling.

--- a/test/type/opaque_parameterized_existential.swift
+++ b/test/type/opaque_parameterized_existential.swift
@@ -1,0 +1,30 @@
+// RUN: %target-swift-frontend -enable-parameterized-existential-types -disable-availability-checking -typecheck -verify %s
+
+// I do not like nested some type params,
+// I do not like them Σam-i-am
+protocol P<T> {
+  associatedtype T
+}
+
+extension Never: P { typealias T = Never }
+
+// I do not like them written clear
+func test() -> any P<some P> { fatalError() } // expected-error {{'some' types cannot be used in constraints on existential types}} expected-error {{generic parameter}}
+// I do not like them nested here
+func test() -> any P<[some P]> { fatalError() } // expected-error {{'some' types cannot be used in constraints on existential types}} expected-error {{generic parameter}}
+// I do not like them under questions
+func test() -> any P<(some P)??> { fatalError() } // expected-error {{'some' types cannot be used in constraints on existential types}} expected-error {{generic parameter}}
+// I do not like meta-type intentions
+func test() -> (any P<some P>).Type { fatalError() } // expected-error {{'some' types cannot be used in constraints on existential types}} expected-error {{generic parameter}}
+// I do not like them (meta)static-ly
+func test() -> any P<some P>.Type { fatalError() } // expected-error {{'some' types cannot be used in constraints on existential types}} expected-error {{generic parameter}}
+// I do not like them tupled-three
+func test() -> (Int, any P<some P>, Int) { fatalError() } // expected-error {{'some' types cannot be used in constraints on existential types}} expected-error {{generic parameter}}
+// I do not like them in generics
+struct Wrapper<T> {}
+func test() -> any P<Wrapper<some P>> { fatalError() } // expected-error {{'some' types cannot be used in constraints on existential types}} expected-error {{generic parameter}}
+// Your attempts to nest them put me in hysterics.
+func test(_ x: any P<some P>) {} // expected-error {{'some' types cannot be used in constraints on existential types}}
+
+// No, I do not like nested some type params,
+// I do not like them Σam-i-am

--- a/test/type/parameterized_existential.swift
+++ b/test/type/parameterized_existential.swift
@@ -37,6 +37,8 @@ struct Collapse<T: DoubleWide>: DoubleWide {
 }
 
 func test() -> any DoubleWide<some DoubleWide<Int, Int>, some DoubleWide<Int, Int>> { return Collapse<Int>(x: 42) }
+// expected-error@-1 {{'some' types cannot be used in constraints on existential types}}
+// expected-error@-2 {{'some' types cannot be used in constraints on existential types}}
 
 func diagonalizeAny(_ x: any Sequence<Int>) -> any Sequence<(Int, Int)> {
   return x.map { ($0, $0) }

--- a/validation-test/compiler_crashers_2_fixed/unsupported_recursive_opaque_conformance.swift
+++ b/validation-test/compiler_crashers_2_fixed/unsupported_recursive_opaque_conformance.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -disable-availability-checking -emit-ir -enable-parameterized-existential-types %s
+// RUN: not %target-swift-frontend -disable-availability-checking -emit-ir -enable-parameterized-existential-types %s
 
 protocol P<X, Y> {
   associatedtype X : P


### PR DESCRIPTION
Cherry picked from #58675

---------

We would like to leave room in the language for `some` types in existential
constraints a la `any P<some Q>` to resolve as a part of the requirement
signature of a future generalized existential type. To that end, usages of
`some` types nested anywhere in the arguments of an existential will fail to
resolve.

rdar://92758884