### PR TITLE
[CodeCompletion] Suggest 'actor' decl introducer keyword

### DIFF
--- a/test/IDE/complete_keywords.swift
+++ b/test/IDE/complete_keywords.swift
@@ -6,6 +6,7 @@
 
 // KW_DECL: Begin completions
 // KW_DECL-DAG: Keyword[class]/None: class{{; name=.+$}}
+// KW_DECL-DAG: Keyword/None: actor{{; name=.+$}}
 // KW_DECL-DAG: Keyword/None: convenience{{; name=.+$}}
 // KW_DECL-DAG: Keyword[deinit]/None: deinit{{; name=.+$}}
 // KW_DECL-DAG: Keyword/None: dynamic{{; name=.+$}}
@@ -42,6 +43,7 @@
 
 // KW_DECL_PROTOCOL: Begin completions
 // KW_DECL_PROTOCOL-DAG: Keyword[class]/None/Flair[RareKeyword]: class{{; name=.+$}}
+// KW_DECL_PROTOCOL-DAG: Keyword/None/Flair[RareKeyword]: actor{{; name=.+$}}
 // KW_DECL_PROTOCOL-DAG: Keyword/None: convenience{{; name=.+$}}
 // KW_DECL_PROTOCOL-DAG: Keyword[deinit]/None: deinit{{; name=.+$}}
 // KW_DECL_PROTOCOL-DAG: Keyword/None: dynamic{{; name=.+$}}
@@ -78,6 +80,7 @@
 
 // KW_DECL_TYPECONTEXT: Begin completions
 // KW_DECL_TYPECONTEXT-DAG: Keyword[class]/None: class{{; name=.+$}}
+// KW_DECL_TYPECONTEXT-DAG: Keyword/None: actor{{; name=.+$}}
 // KW_DECL_TYPECONTEXT-DAG: Keyword/None: convenience{{; name=.+$}}
 // KW_DECL_TYPECONTEXT-DAG: Keyword[deinit]/None: deinit{{; name=.+$}}
 // KW_DECL_TYPECONTEXT-DAG: Keyword/None: dynamic{{; name=.+$}}
@@ -118,6 +121,7 @@
 // Declaration keywords.
 //
 // KW_DECL_STMT_TOPLEVEL-DAG: Keyword[class]/None: class{{; name=.+$}}
+// KW_DECL_STMT_TOPLEVEL-DAG: Keyword/None: actor{{; name=.+$}}
 // KW_DECL_STMT_TOPLEVEL-DAG: Keyword/None: convenience{{; name=.+$}}
 // KW_DECL_STMT_TOPLEVEL-DAG: Keyword[deinit]/None: deinit{{; name=.+$}}
 // KW_DECL_STMT_TOPLEVEL-DAG: Keyword/None: dynamic{{; name=.+$}}

--- a/test/SourceKit/CodeComplete/complete_override.swift.response
+++ b/test/SourceKit/CodeComplete/complete_override.swift.response
@@ -32,6 +32,16 @@
     },
     {
       key.kind: source.lang.swift.keyword,
+      key.name: "actor",
+      key.sourcetext: "actor",
+      key.description: "actor",
+      key.typename: "",
+      key.context: source.codecompletion.context.none,
+      key.typerelation: source.codecompletion.typerelation.notapplicable,
+      key.num_bytes_to_erase: 0
+    },
+    {
+      key.kind: source.lang.swift.keyword,
       key.name: "associatedtype",
       key.sourcetext: "associatedtype",
       key.description: "associatedtype",


### PR DESCRIPTION
Previously `actor` keyword was suggested as (deprecated) `actor` decl modifier, and it was gated by `-enable-experimental-concurrency` compiler argument.
Add `actor` as a type decl introducer. This causes duplicated `actor` in code completion if `-enable-experimental-concurrency`, but that option is basically useless at this point, so I assume not many people is using it. Also `actor` as a modifier will be removed soon.

[#58520] rdar://92511769
