### PR TITLE
[cxx-interop][SwiftCompilerSources] Use `swift::SourceLoc` instead of `BridgedSourceLoc`

### DIFF
--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -165,6 +165,10 @@ function(add_swift_compiler_modules_library name)
               "-emit-module-path" "${build_dir}/${module}.swiftmodule"
               "-parse-as-library" ${sources}
               "-wmo" ${swift_compile_options}
+              # LLVM modules and headers.
+              "-Xcc" "-I" "-Xcc" "${LLVM_MAIN_INCLUDE_DIR}"
+              # Generated LLVM headers.
+              "-Xcc" "-I" "-Xcc" "${LLVM_INCLUDE_DIR}"
               # Bridging modules and headers.
               "-Xcc" "-I" "-Xcc" "${SWIFT_SOURCE_DIR}/include"
               # Generated C headers.

--- a/SwiftCompilerSources/Package.swift
+++ b/SwiftCompilerSources/Package.swift
@@ -20,6 +20,8 @@ private extension Target {
       "-Xfrontend", "-enable-cxx-interop",
       // Bridging modules and headers
       "-Xcc", "-I", "-Xcc", "../include",
+      // LLVM modules and headers
+      "-Xcc", "-I", "-Xcc", "../../llvm-project/llvm/include",
       "-cross-module-optimization"
     ]),
   ]

--- a/SwiftCompilerSources/Sources/AST/DiagnosticEngine.swift
+++ b/SwiftCompilerSources/Sources/AST/DiagnosticEngine.swift
@@ -80,7 +80,7 @@ public struct DiagnosticEngine {
                        highlight: CharSourceRange? = nil,
                        fixIts: [DiagnosticFixIt] = []) {
 
-    let bridgedSourceLoc: BridgedSourceLoc = position.bridged
+    let bridgedSourceLoc: swift.SourceLoc = position.bridged
     let bridgedHighlightRange: BridgedCharSourceRange = highlight.bridged
     var bridgedArgs: [BridgedDiagnosticArgument] = []
     var bridgedFixIts: [BridgedDiagnosticFixIt] = []

--- a/SwiftCompilerSources/Sources/Basic/SourceLoc.swift
+++ b/SwiftCompilerSources/Sources/Basic/SourceLoc.swift
@@ -21,15 +21,15 @@ public struct SourceLoc {
     self.locationInFile = locationInFile
   }
 
-  public init?(bridged: BridgedSourceLoc) {
-    guard let locationInFile = bridged.pointer else {
+  public init?(bridged: swift.SourceLoc) {
+    guard bridged.isValid() else {
       return nil
     }
-    self.init(locationInFile: locationInFile)
+    self.locationInFile = bridged.getOpaquePointerValue().assumingMemoryBound(to: UInt8.self)
   }
 
-  public var bridged: BridgedSourceLoc {
-    .init(pointer: locationInFile)
+  public var bridged: swift.SourceLoc {
+    .init(llvm.SMLoc.getFromPointer(locationInFile))
   }
 }
 
@@ -40,8 +40,8 @@ extension SourceLoc {
 }
 
 extension Optional where Wrapped == SourceLoc {
-  public var bridged: BridgedSourceLoc {
-    self?.bridged ?? .init(pointer: nil)
+  public var bridged: swift.SourceLoc {
+    self?.bridged ?? .init()
   }
 }
 
@@ -68,6 +68,6 @@ public struct CharSourceRange {
 
 extension Optional where Wrapped == CharSourceRange {
   public var bridged: BridgedCharSourceRange {
-    self?.bridged ?? .init(start: .init(pointer: nil), byteLength: 0)
+    self?.bridged ?? .init(start: .init(), byteLength: 0)
   }
 }

--- a/SwiftCompilerSources/Sources/Parse/Regex.swift
+++ b/SwiftCompilerSources/Sources/Parse/Regex.swift
@@ -92,7 +92,7 @@ public func _RegexLiteralParsingFn(
   _ versionOut: UnsafeMutablePointer<CUnsignedInt>,
   _ captureStructureOut: UnsafeMutableRawPointer,
   _ captureStructureSize: CUnsignedInt,
-  _ bridgedDiagnosticBaseLoc: BridgedSourceLoc,
+  _ bridgedDiagnosticBaseLoc: swift.SourceLoc,
   _ bridgedDiagnosticEngine: BridgedDiagnosticEngine
 ) -> Bool {
   let str = String(cString: inputPtr)

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -18,10 +18,6 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 
 //===----------------------------------------------------------------------===//
@@ -56,7 +52,7 @@ typedef struct {
 } BridgedDiagnosticArgument;
 
 typedef struct {
-  BridgedSourceLoc start;
+  swift::SourceLoc start;
   SwiftInt byteLength;
   BridgedStringRef text;
 } BridgedDiagnosticFixIt;
@@ -70,7 +66,7 @@ typedef struct {
 } BridgedOptionalDiagnosticEngine;
 
 // FIXME: Can we bridge InFlightDiagnostic?
-void DiagnosticEngine_diagnose(BridgedDiagnosticEngine, BridgedSourceLoc loc,
+void DiagnosticEngine_diagnose(BridgedDiagnosticEngine, swift::SourceLoc loc,
                                BridgedDiagID diagID, BridgedArrayRef arguments,
                                BridgedCharSourceRange highlight,
                                BridgedArrayRef fixIts);
@@ -78,9 +74,5 @@ void DiagnosticEngine_diagnose(BridgedDiagnosticEngine, BridgedSourceLoc loc,
 bool DiagnosticEngine_hadAnyError(BridgedDiagnosticEngine);
 
 SWIFT_END_NULLABILITY_ANNOTATIONS
-
-#ifdef __cplusplus
-} // extern "C"
-#endif
 
 #endif // SWIFT_AST_ASTBRIDGING_H

--- a/include/swift/Basic/BasicBridging.h
+++ b/include/swift/Basic/BasicBridging.h
@@ -14,11 +14,8 @@
 #define SWIFT_BASIC_BASICBRIDGING_H
 
 #include "swift/Basic/BridgedSwiftObject.h"
+#include "swift/Basic/SourceLoc.h"
 #include <stddef.h>
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 
@@ -48,18 +45,10 @@ void freeBridgedStringRef(BridgedStringRef str);
 //===----------------------------------------------------------------------===//
 
 typedef struct {
-  const unsigned char * _Nullable pointer;
-} BridgedSourceLoc;
-
-typedef struct {
-  BridgedSourceLoc start;
+  swift::SourceLoc start;
   SwiftInt byteLength;
 } BridgedCharSourceRange;
 
 SWIFT_END_NULLABILITY_ANNOTATIONS
-
-#ifdef __cplusplus
-} // extern "C"
-#endif
 
 #endif

--- a/include/swift/Basic/BridgingUtils.h
+++ b/include/swift/Basic/BridgingUtils.h
@@ -36,25 +36,14 @@ inline llvm::ArrayRef<T> getArrayRef(BridgedArrayRef bridged) {
   return {static_cast<const T *>(bridged.data), bridged.numElements};
 }
 
-inline SourceLoc getSourceLoc(const BridgedSourceLoc &bridged) {
-  return SourceLoc(
-      llvm::SMLoc::getFromPointer((const char *)bridged.pointer));
-}
-
-inline BridgedSourceLoc getBridgedSourceLoc(const SourceLoc &loc) {
-  return {static_cast<const unsigned char *>(loc.getOpaquePointerValue())};
-}
-
 inline CharSourceRange
 getCharSourceRange(const BridgedCharSourceRange &bridged) {
-  auto start = getSourceLoc(bridged.start);
-  return CharSourceRange(start, bridged.byteLength);
+  return CharSourceRange(bridged.start, bridged.byteLength);
 }
 
 inline BridgedCharSourceRange
 getBridgedCharSourceRange(const CharSourceRange &range) {
-  auto start = getBridgedSourceLoc(range.getStart());
-  return {start, range.getByteLength()};
+  return {range.getStart(), range.getByteLength()};
 }
 
 /// Copies the string in an malloc'ed memory and the caller is responsible for

--- a/include/swift/Parse/RegexParserBridging.h
+++ b/include/swift/Parse/RegexParserBridging.h
@@ -17,10 +17,6 @@
 #include "swift/AST/ASTBridging.h"
 #include <stdbool.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /// Attempt to lex a regex literal string. Takes the following arguments:
 ///
 /// - CurPtrPtr: A pointer to the current pointer of lexer, which should be the
@@ -60,12 +56,8 @@ typedef bool (*RegexLiteralParsingFn)(/*InputPtr*/ const char *_Nonnull,
                                       /*VersionOut*/ unsigned *_Nonnull,
                                       /*CaptureStructureOut*/ void *_Nonnull,
                                       /*CaptureStructureSize*/ unsigned,
-                                      /*DiagnosticBaseLoc*/ BridgedSourceLoc,
+                                      /*DiagnosticBaseLoc*/ swift::SourceLoc,
                                       BridgedDiagnosticEngine);
 void Parser_registerRegexLiteralParsingFn(RegexLiteralParsingFn _Nullable fn);
-
-#ifdef __cplusplus
-} // extern "C"
-#endif
 
 #endif // REGEX_PARSER_BRIDGING

--- a/lib/AST/ASTBridging.cpp
+++ b/lib/AST/ASTBridging.cpp
@@ -38,14 +38,13 @@ getDiagnosticArgument(const BridgedDiagnosticArgument &bridged) {
 } // namespace
 
 void DiagnosticEngine_diagnose(
-    BridgedDiagnosticEngine bridgedEngine, BridgedSourceLoc bridgedLoc,
+    BridgedDiagnosticEngine bridgedEngine, SourceLoc loc,
     BridgedDiagID bridgedDiagID,
     BridgedArrayRef /*BridgedDiagnosticArgument*/ bridgedArguments,
     BridgedCharSourceRange bridgedHighlight,
     BridgedArrayRef /*BridgedDiagnosticFixIt*/ bridgedFixIts) {
   auto *D = getDiagnosticEngine(bridgedEngine);
 
-  auto loc = getSourceLoc(bridgedLoc);
   auto diagID = static_cast<DiagID>(bridgedDiagID);
   SmallVector<DiagnosticArgument, 2> arguments;
   for (auto bridgedArg :
@@ -62,7 +61,7 @@ void DiagnosticEngine_diagnose(
 
   // Add fix-its.
   for (auto bridgedFixIt : getArrayRef<BridgedDiagnosticFixIt>(bridgedFixIts)) {
-    auto range = CharSourceRange(getSourceLoc(bridgedFixIt.start),
+    auto range = CharSourceRange(bridgedFixIt.start,
                                  bridgedFixIt.byteLength);
     auto text = getStringRef(bridgedFixIt.text);
     inflight.fixItReplaceChars(range.getStart(), range.getEnd(), text);

--- a/lib/Parse/ParseRegex.cpp
+++ b/lib/Parse/ParseRegex.cpp
@@ -51,7 +51,7 @@ ParserResult<Expr> Parser::parseExprRegexLiteral() {
       regexLiteralParsingFn(regexText.str().c_str(), &version,
                             /*captureStructureOut*/ capturesBuf.data(),
                             /*captureStructureSize*/ capturesBuf.size(),
-                            /*diagBaseLoc*/ getBridgedSourceLoc(Tok.getLoc()),
+                            /*diagBaseLoc*/ Tok.getLoc(),
                             getBridgedDiagnosticEngine(&Diags));
   auto loc = consumeToken();
   SourceMgr.recordRegexLiteralStartLoc(loc);


### PR DESCRIPTION
C++ interop is now enabled in SwiftCompilerSources, so we can remove some of the C bridging layer and use C++ classes directly from Swift.

rdar://83361087