### PR TITLE
Clean up `Hashable` doc changes

### DIFF
--- a/stdlib/public/core/Hashable.swift
+++ b/stdlib/public/core/Hashable.swift
@@ -109,7 +109,7 @@ public protocol Hashable: Equatable {
   ///
   /// - Important: `hashValue` is deprecated as a `Hashable` requirement. To
   ///   conform to `Hashable`, implement the `hash(into:)` requirement instead.
-  ///   (The compiler will provide an implementation for `hashValue` for you.)
+  ///   The compiler provides an implementation for `hashValue` for you.
   var hashValue: Int { get }
 
   /// Hashes the essential components of this value by feeding them into the
@@ -120,9 +120,10 @@ public protocol Hashable: Equatable {
   /// in your type's `==` operator implementation. Call `hasher.combine(_:)`
   /// with each of these components.
   ///
-  /// - Important: `hash(into:)` implementations must never call `finalize()` on
-  ///    the `hasher` instance provided, or replace it with a different
-  ///    instance. Doing so may become compile-time errors in the future.
+  /// - Important: In your implemention of `hash(into:)`,
+  ///   don't call `finalize()` on the `hasher` instance provided,
+  ///   or replace it with a different instance.
+  ///   Doing so may become a compile-time error in the future.
   ///
   /// - Parameter hasher: The hasher to use when combining the components
   ///   of this instance.


### PR DESCRIPTION
Follow-on to the fixes in #58652, to clean docs up per reference writing guidelines.