### PR TITLE
SILFunctionBuilder: Don't create [serialized] function post serialization

### DIFF
--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -270,7 +270,11 @@ SILFunction *SILFunctionBuilder::getOrCreateFunction(
 
   IsTransparent_t IsTrans =
       constant.isTransparent() ? IsTransparent : IsNotTransparent;
+
   IsSerialized_t IsSer = constant.isSerialized();
+  // Don't create a [serialized] function after serialization has happened.
+  if (IsSer == IsSerialized && mod.isSerialized())
+    IsSer = IsNotSerialized;
 
   Inline_t inlineStrategy = InlineDefault;
   if (constant.isNoinline())


### PR DESCRIPTION
This might fix the randomly occuring errors of:

```
SIL verification failed: cannot have a serialized function after the module has been serialized: !F->isSerialized() || !mod.isSerialized() || mod.isParsedAsSerializedSIL()
```