### PR TITLE
[Serialization] Allow loading modules built on some SDK variants

### DIFF
--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -156,11 +156,18 @@ Status ModuleFile::associateWithFileContext(FileUnit *file, SourceLoc diagLoc,
       return error(status);
   }
 
+  // The loaded module was built with a compatible SDK if either:
+  // * it was the same SDK
+  // * or one who's name is a prefix of the clients' SDK name. This expects
+  // that a module built with macOS11 can be used with the macOS11.secret SDK.
+  // This is generally the case as SDKs with suffixes are a superset of the
+  // short SDK name equivalent. While this is accepted, this is still not a
+  // recommended configuration and may lead to unreadable swiftmodules.
   StringRef moduleSDK = Core->SDKName;
   StringRef clientSDK = ctx.LangOpts.SDKName;
   if (ctx.SearchPathOpts.EnableSameSDKCheck &&
       !moduleSDK.empty() && !clientSDK.empty() &&
-      moduleSDK != clientSDK) {
+      !clientSDK.startswith(moduleSDK)) {
     status = Status::SDKMismatch;
     return error(status);
   }

--- a/test/Serialization/restrict-swiftmodule-to-sdk.swift
+++ b/test/Serialization/restrict-swiftmodule-to-sdk.swift
@@ -9,8 +9,16 @@
 // RUN: %target-swift-frontend -typecheck %t/Client.swift -swift-version 5 -target-sdk-name A -I %t/build -parse-stdlib -module-cache-path %t/cache
 
 /// Build Client against SDK B, this should fail at loading Lib against a different SDK than A.
-// RUN: not %target-swift-frontend -typecheck %t/Client.swift -swift-version 5 -target-sdk-name B -I %t/build -parse-stdlib -module-cache-path %t/cache 2>&1 | %FileCheck %s
-// CHECK: cannot load module 'Lib' built with SDK 'A' when using SDK 'B': {{.*}}Lib.swiftmodule
+// RUN: not %target-swift-frontend -typecheck %t/Client.swift -swift-version 5 -target-sdk-name B -I %t/build -parse-stdlib -module-cache-path %t/cache 2>&1 | %FileCheck %s -check-prefix=CHECK-AvsB
+// CHECK-AvsB: cannot load module 'Lib' built with SDK 'A' when using SDK 'B': {{.*}}Lib.swiftmodule
+
+/// Build Client against SDK A.Secret, this should accept the SDK as being a super set of A.
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -swift-version 5 -target-sdk-name A.Secret -I %t/build -parse-stdlib -module-cache-path %t/cache
+
+/// Build Lib against SDK C.Secret and Client against SDK C, this should be rejected.
+// RUN: %target-swift-frontend -emit-module %t/Lib.swift -swift-version 5 -target-sdk-name C.Secret -o %t/build -parse-stdlib -module-cache-path %t/cache
+// RUN: not %target-swift-frontend -typecheck %t/Client.swift -swift-version 5 -target-sdk-name C -I %t/build -parse-stdlib -module-cache-path %t/cache 2>&1 | %FileCheck %s -check-prefix=CHECK-C
+// CHECK-C: cannot load module 'Lib' built with SDK 'C.Secret' when using SDK 'C': {{.*}}Lib.swiftmodule
 
 // BEGIN Lib.swift
 public func foo() {}


### PR DESCRIPTION
When restricting loading swiftmodules to the SDK used to build them, an exception should be made for modules built against an SDK that is a subset of the SDK used when loading the module. For example, a module built with the `macOS11` SDK should be loadable by a client targeting the `macOS11.secret` SDK. In such a case, the swiftmodule file is more likely to be reliable.

This check is still gated behind the `ENABLE_RESTRICT_SWIFTMODULE_SDK` env var on the driver side. Loosening this check should make it easier to land it. However, this is still not a recommended configuration so we might want to remove this accepted use case in the future and bring back the requirement for an exact SDK name match.

rdar://92827584