### PR TITLE
[5.7] [Regex] Downgrade implicit import warning to remark

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -149,8 +149,8 @@ WARNING(emit_reference_dependencies_without_primary_file,none,
 
 WARNING(warn_implicit_concurrency_import_failed,none,
         "unable to perform implicit import of \"_Concurrency\" module: no such module found", ())
-WARNING(warn_implicit_string_processing_import_failed,none,
-        "unable to perform implicit import of \"_StringProcessing\" module: no such module found", ())
+REMARK(warn_implicit_string_processing_import_failed,none,
+       "unable to perform implicit import of \"_StringProcessing\" module: no such module found", ())
 
 ERROR(error_module_name_required,none, "-module-name is required", ())
 ERROR(error_bad_module_name,none,


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/58689

-----

Temporarily downgrade the warning "unable to perform implicit import of '_StringProcessing' module: no such module found" to a remark to suppress some unuseful build noise.

rdar://92588458