### PR TITLE
[.github] Update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.
 
 <!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
-Resolves SR-NNNN.
+Resolves PR-NNNNN.
 
 <!--
 Before merging this pull request, you must run the Swift continuous integration tests.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.
 
 <!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
-Resolves PR-NNNNN.
+Resolves #NNNNN.
 
 <!--
 Before merging this pull request, you must run the Swift continuous integration tests.


### PR DESCRIPTION
<!-- What's in this pull request? -->
Two things:

1) Since we moved from JIRA to GitHub issues, there is no standardized way to reference bug numbers in the compiler. We previously used the convention `SR15818_Struct` or `SR_15818_Struct` in regression tests, sometimes substituting `PR` for `SR` to indicate crashers reported in a pull request. Now, we would be putting `#15818_Struct` or `15818_Struct` in source code, which is not valid code. Alternatively, we would do `Issue15818_Struct` but that's like using `PullRequest15818_Struct` instead of `PR15818_Struct`. Is there any form of standardization in the post-JIRA era?

- I originally put "Resolves PR-NNNNN" instead of "Resolves #NNNNN" for this reason.

2) Expand to 5 digits. It's far past the point where most pull requests resolve something with 4 digits. JIRA was 50% past 9,999 before jumping to GitHub issues, and now we're 60% of the way to 100,000.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
