### PR TITLE
Add a test for a corner case missed by #41978.

### DIFF
--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1906,6 +1906,12 @@ Expr *AutoClosureExpr::getUnwrappedCurryThunkExpr() const {
     return expr;
   };
 
+  auto maybeUnwrapConversions = [](Expr *expr) {
+    if (auto *covariantReturn = dyn_cast<CovariantReturnConversionExpr>(expr))
+      expr = covariantReturn->getSubExpr();
+    return expr;
+  };
+
   switch (getThunkKind()) {
   case AutoClosureExpr::Kind::None:
   case AutoClosureExpr::Kind::AsyncLet:
@@ -1916,6 +1922,7 @@ Expr *AutoClosureExpr::getUnwrappedCurryThunkExpr() const {
     body = body->getSemanticsProvidingExpr();
     body = maybeUnwrapOpenExistential(body);
     body = maybeUnwrapOptionalEval(body);
+    body = maybeUnwrapConversions(body);
 
     if (auto *outerCall = dyn_cast<ApplyExpr>(body)) {
       return outerCall->getFn();
@@ -1934,6 +1941,7 @@ Expr *AutoClosureExpr::getUnwrappedCurryThunkExpr() const {
       innerBody = innerBody->getSemanticsProvidingExpr();
       innerBody = maybeUnwrapOpenExistential(innerBody);
       innerBody = maybeUnwrapOptionalEval(innerBody);
+      innerBody = maybeUnwrapConversions(innerBody);
 
       if (auto *outerCall = dyn_cast<ApplyExpr>(innerBody)) {
         if (auto *innerCall = dyn_cast<ApplyExpr>(outerCall->getFn())) {

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -315,7 +315,7 @@ func ivars(_ hive: Hive) {
   hive.queen.description() // expected-error{{value of type 'Hive' has no member 'queen'}}
 }
 
-class NSObjectable : NSObjectProtocol {
+class NSObjectable : NSObjectProtocol { // expected-error {{cannot declare conformance to 'NSObjectProtocol' in Swift; 'NSObjectable' should inherit 'NSObject' instead}}
   @objc var description : String { return "" }
   @objc(conformsToProtocol:) func conforms(to _: Protocol) -> Bool { return false }
   @objc(isKindOfClass:) func isKind(of aClass: AnyClass) -> Bool { return false }

--- a/test/Index/index_curry_thunk_objc.swift
+++ b/test/Index/index_curry_thunk_objc.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -enable-objc-interop -print-indexed-symbols -source-filename %s | %FileCheck %s
+// REQUIRES: objc_interop
+
+import Foundation
+
+@objc
+class Foo: NSObject {
+  // CHECK-DAG: constructor/Swift | init(object:)
+  init(object: Any?) {}
+}
+
+extension Foo {
+  // CHECK-DAG: static-property/Swift | boom
+  static let boom = Foo(object: self)
+}

--- a/test/Inputs/clang-importer-sdk/usr/include/objc/NSObject.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/objc/NSObject.h
@@ -6,6 +6,7 @@
 @class NSString;
 
 @protocol NSObject
+- (instancetype)self;
 @property (readonly, copy) NSString *description;
 - (instancetype)retain OBJC_ARC_UNAVAILABLE;
 - (Class)class;

--- a/test/PrintAsObjC/classes.swift
+++ b/test/PrintAsObjC/classes.swift
@@ -113,22 +113,6 @@ class ClassWithCustomName2 {}
 @objc(CustomNameSub)
 class ClassWithCustomNameSub : ClassWithCustomName {}
 
-
-// CHECK-LABEL: @interface ClassWithNSObjectProtocol <NSObject>
-// CHECK-NEXT: @property (nonatomic, readonly, copy) NSString * _Nonnull description;
-// CHECK-NEXT: - (BOOL)conformsToProtocol:(Protocol * _Nonnull)_ SWIFT_WARN_UNUSED_RESULT;
-// CHECK-NEXT: - (BOOL)isKindOfClass:(Class _Nonnull)aClass SWIFT_WARN_UNUSED_RESULT;
-// CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
-// CHECK-NEXT: @end
-@objc @objcMembers class ClassWithNSObjectProtocol : NSObjectProtocol {
-  @objc var description: String { return "me" }
-  @objc(conformsToProtocol:)
-  func conforms(to _: Protocol) -> Bool { return false }
-
-  @objc(isKindOfClass:)
-  func isKind(of aClass: AnyClass) -> Bool { return false }
-}
-
 // CHECK-LABEL: @interface DiscardableResult : NSObject
 // CHECK-NEXT: - (NSInteger)nonDiscardable:(NSInteger)x SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: - (NSInteger)discardable:(NSInteger)x;


### PR DESCRIPTION
A member reference to a function with a dynamic 'Self' result type
can introduce a covariant return expression into the AST. This is
exposed by the (already deeply cursed) -self method on NSObject(Protocol).
Add a regression test and said cursed member to the mock SDK.