### PR TITLE
[Glibc] Add missing C stdlib header

### DIFF
--- a/stdlib/public/Platform/glibc.modulemap.gyb
+++ b/stdlib/public/Platform/glibc.modulemap.gyb
@@ -42,6 +42,10 @@ module SwiftGlibc [system] {
 % end
 
   header "SwiftGlibc.h"
+
+  // <assert.h>'s use of NDEBUG requires textual inclusion. 
+  textual header "assert.h"
+
   export *
 }
 


### PR DESCRIPTION
`assert.h` is missing from the modulemap, which causes clang to consider `assert.h` to be a part of the first module to include it. This causes issues in SwiftCompilerSources when we try to use classes coming from LLVM headers on Linux:

```
<module-includes>:2:10: note: in file included from <module-includes>:2:
#include "Basic/BasicBridging.h"
         ^
/home/build-user/swift/include/swift/Basic/BasicBridging.h:17:10: note: in file included from /home/build-user/swift/include/swift/Basic/BasicBridging.h:17:
#include "swift/Basic/SourceLoc.h"
         ^
/home/build-user/swift/include/swift/Basic/SourceLoc.h:60:5: error: declaration of '__assert_fail' must be imported from module 'LLVM_Utils.Support.MathExtras' before it is required
    assert(isValid() && "Can't advance an invalid location");
    ^
/usr/include/assert.h:95:9: note: expanded from macro 'assert'
      : __assert_fail (#expr, __FILE__, __LINE__, __ASSERT_FUNCTION))
        ^
/usr/include/assert.h:69:13: note: declaration here is not visible
extern void __assert_fail (const char *__assertion, const char *__file,
            ^
/home/build-user/swift/SwiftCompilerSources/Sources/Basic/Utils.swift:13:19: error: could not build C module 'BasicBridging'
@_exported import BasicBridging
                  ^
```