### PR TITLE
58711 - `swift_slowAlloc()` and friends should be marked `SWIFT_NODISCARD`

### DIFF
--- a/include/swift/Runtime/Heap.h
+++ b/include/swift/Runtime/Heap.h
@@ -29,7 +29,7 @@ namespace swift {
 // Never returns nil. The returned memory is uninitialized. 
 //
 // An "alignment mask" is just the alignment (a power of 2) minus 1.
-SWIFT_RETURNS_NONNULL SWIFT_RUNTIME_EXPORT
+SWIFT_RETURNS_NONNULL SWIFT_NODISCARD SWIFT_RUNTIME_EXPORT
 void *swift_slowAlloc(size_t bytes, size_t alignMask);
 
 // If the caller cannot promise to zero the object during destruction,
@@ -53,7 +53,7 @@ void swift_slowDealloc(void *ptr, size_t bytes, size_t alignMask);
 /// This function is capable of returning well-aligned memory even on platforms
 /// that do not implement the C++17 "over-aligned new" feature.
 template <typename T, typename... Args>
-SWIFT_RETURNS_NONNULL
+SWIFT_RETURNS_NONNULL SWIFT_NODISCARD
 static inline T *swift_cxx_newObject(Args &&... args) {
   auto result = reinterpret_cast<T *>(swift_slowAlloc(sizeof(T),
                                                       alignof(T) - 1));

--- a/include/swift/Runtime/HeapObject.h
+++ b/include/swift/Runtime/HeapObject.h
@@ -61,7 +61,7 @@ struct OpaqueValue;
 ///
 /// POSSIBILITIES: The argument order is fair game.  It may be useful
 /// to have a variant which guarantees zero-initialized memory.
-SWIFT_RETURNS_NONNULL SWIFT_RUNTIME_EXPORT
+SWIFT_RETURNS_NONNULL SWIFT_NODISCARD SWIFT_RUNTIME_EXPORT
 HeapObject *swift_allocObject(HeapMetadata const *metadata,
                               size_t requiredSize,
                               size_t requiredAlignmentMask);
@@ -117,7 +117,7 @@ BoxPair swift_makeBoxUnique(OpaqueValue *buffer, Metadata const *type,
                                     size_t alignMask);
 
 /// Returns the address of a heap object representing all empty box types.
-SWIFT_RETURNS_NONNULL SWIFT_RUNTIME_EXPORT
+SWIFT_RETURNS_NONNULL SWIFT_NODISCARD SWIFT_RUNTIME_EXPORT
 HeapObject* swift_allocEmptyBox();
 
 /// Atomically increments the retain count of an object.

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -307,7 +307,7 @@ swift_getGenericMetadata(MetadataRequest request,
 ///   - installing new v-table entries and overrides; and
 ///   - registering the class with the runtime under ObjC interop.
 /// Most of this work can be achieved by calling swift_initClassMetadata.
-SWIFT_RETURNS_NONNULL SWIFT_RUNTIME_EXPORT
+SWIFT_RETURNS_NONNULL SWIFT_NODISCARD SWIFT_RUNTIME_EXPORT
 ClassMetadata *
 swift_allocateGenericClassMetadata(const ClassDescriptor *description,
                                    const void *arguments,
@@ -316,7 +316,7 @@ swift_allocateGenericClassMetadata(const ClassDescriptor *description,
 /// Allocate a generic value metadata object.  This is intended to be
 /// called by the metadata instantiation function of a generic struct or
 /// enum.
-SWIFT_RETURNS_NONNULL SWIFT_RUNTIME_EXPORT
+SWIFT_RETURNS_NONNULL SWIFT_NODISCARD SWIFT_RUNTIME_EXPORT
 ValueMetadata *
 swift_allocateGenericValueMetadata(const ValueTypeDescriptor *description,
                                    const void *arguments,

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -93,7 +93,7 @@ static inline bool isValidPointerForNativeRetain(const void *p) {
 // not to emit a bunch of ptrauth instructions just to perform the comparison.
 // We only want to authenticate the function pointer if we actually call it. We
 // can revert to a straight comparison once rdar://problem/55267009 is fixed.
-SWIFT_RETURNS_NONNULL
+SWIFT_RETURNS_NONNULL SWIFT_NODISCARD
 static HeapObject *_swift_allocObject_(HeapMetadata const *metadata,
                                        size_t requiredSize,
                                        size_t requiredAlignmentMask)

--- a/stdlib/public/runtime/MetadataCache.h
+++ b/stdlib/public/runtime/MetadataCache.h
@@ -40,7 +40,8 @@ public:
 
   void Reset() {}
 
-  SWIFT_RETURNS_NONNULL void *Allocate(size_t size, size_t alignment);
+  SWIFT_RETURNS_NONNULL SWIFT_NODISCARD
+  void *Allocate(size_t size, size_t alignment);
   using AllocatorBase<MetadataAllocator>::Allocate;
 
   void Deallocate(const void *Ptr, size_t size, size_t Alignment);
@@ -60,7 +61,8 @@ public:
 class MetadataAllocator {
 public:
   MetadataAllocator(uint16_t tag) {}
-  SWIFT_RETURNS_NONNULL void *Allocate(size_t size, size_t alignment) {
+  SWIFT_RETURNS_NONNULL SWIFT_NODISCARD
+  void *Allocate(size_t size, size_t alignment) {
     if (alignment < sizeof(void*)) alignment = sizeof(void*);
     void *ptr = nullptr;
     if (SWIFT_UNLIKELY(posix_memalign(&ptr, alignment, size) != 0 || !ptr)) {

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -516,7 +516,7 @@ public:
     }
   }
 
-  SWIFT_RETURNS_NONNULL
+  SWIFT_RETURNS_NONNULL SWIFT_NODISCARD
   void *allocateMetadata(size_t size, size_t align);
 
   /// Gather the set of generic arguments that would be written in the


### PR DESCRIPTION
This change marks `swift_slowAlloc()` and friends `SWIFT_NODISCARD` to help prevent memory leaks. Adding this attribute won't, in itself, fix any memory leaks, but it will cause the compiler to emit a diagnostic when an allocation is not used, e.g. in the following code:

```c++
void *memory = nullptr;
...
swift_slowAlloc(...);
...
memcpy(memory, ...);
```

In the above snippet, the author presumably intended to assign the result of `swift_slowAlloc()` to `memory`, but accidentally failed to do so. They then wrote to `memory`—so not only is this a memory leak, it's UB (because dereferencing `nullptr` is UB.)

I'm not aware of any specific issues that `SWIFT_NODISCARD` would catch today—this is a defensive change only.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves #58711.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
