### PR TITLE
 Demangling: Fix off-by-one assert in mangleOpaqueType

### DIFF
--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -3327,7 +3327,7 @@ ManglingError Remangler::mangleOpaqueType(Node *node, unsigned depth) {
   if (trySubstitution(node, entry))
     return ManglingError::Success;
 
-  DEMANGLER_ASSERT(node->getNumChildren() >= 2, node);
+  DEMANGLER_ASSERT(node->getNumChildren() >= 3, node);
   RETURN_IF_ERROR(mangle(node->getChild(0), depth + 1));
   auto boundGenerics = node->getChild(2);
   for (unsigned i = 0; i < boundGenerics->getNumChildren(); ++i) {


### PR DESCRIPTION
Fixes off-by-one mistake in #58643.

rdar://88080388