### PR TITLE
[Refactoring] Several improvements to memberwise initializer generation

### DIFF
--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -3160,8 +3160,6 @@ static void generateMemberwiseInit(SourceEditConsumer &EditConsumer,
                                    ArrayRef<MemberwiseParameter> memberVector,
                                    SourceLoc targetLocation) {
   
-  assert(!memberVector.empty());
-
   EditConsumer.accept(SM, targetLocation, "\ninternal init(");
   auto insertMember = [&SM](const MemberwiseParameter &memberData,
                             raw_ostream &OS, bool wantsSeparator) {
@@ -3197,12 +3195,10 @@ static void generateMemberwiseInit(SourceEditConsumer &EditConsumer,
   // Process the initial list of members, inserting commas as appropriate.
   std::string Buffer;
   llvm::raw_string_ostream OS(Buffer);
-  for (const auto &memberData : memberVector.drop_back()) {
-    insertMember(memberData, OS, /*wantsSeparator*/ true);
+  for (const auto &memberData : llvm::enumerate(memberVector)) {
+    bool wantsSeparator = (memberData.index() != memberVector.size() - 1);
+    insertMember(memberData.value(), OS, wantsSeparator);
   }
-
-  // Process the last (or perhaps, only) member.
-  insertMember(memberVector.back(), OS, /*wantsSeparator*/ false);
 
   // Synthesize the body.
   OS << ") {\n";
@@ -3269,10 +3265,6 @@ collectMembersForInit(const ResolvedCursorInfo &CursorInfo,
                               varDecl->getType(), defaultInit);
   }
 
-  if (memberVector.empty()) {
-    return SourceLoc();
-  }
-  
   return targetLocation;
 }
 

--- a/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/class_members.swift.expected
+++ b/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/class_members.swift.expected
@@ -1,5 +1,5 @@
 class Person {
-internal init(firstName: String? = nil, lastName: String? = nil, age: Int? = nil, planet: String = "Earth", solarSystem: String = "Milky Way", avgHeight: Int = 175, location: @escaping () -> Place = { fatalError() }, secondLocation: (() -> Place)? = nil, wrapped: String = "") {
+internal init(firstName: String? = nil, lastName: String? = nil, age: Int? = nil, planet: String = "Earth", solarSystem: String = "Milky Way", avgHeight: Int = 175, location: @escaping () -> Place = { fatalError() }, secondLocation: (() -> Place)? = nil, wrapped: String = "", didSet: String = "ds") {
 self.firstName = firstName
 self.lastName = lastName
 self.age = age
@@ -9,6 +9,7 @@ self.avgHeight = avgHeight
 self.location = location
 self.secondLocation = secondLocation
 self.wrapped = wrapped
+self.didSet = didSet
 }
 
   var firstName: String!
@@ -22,6 +23,13 @@ self.wrapped = wrapped
   var secondLocation: (() -> Place)!
   @MyWrapper var wrapped: String = ""
   var computed: String { "hi" }
+  var getSet: String {
+    get { "hi" }
+    set {}
+  }
+  var didSet: String = "ds" {
+    didSet { print("didSet") }
+  }
 }
 
 struct Place {

--- a/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/class_members.swift.expected
+++ b/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/class_members.swift.expected
@@ -1,5 +1,5 @@
 class Person {
-internal init(firstName: String? = nil, lastName: String? = nil, age: Int? = nil, planet: String = "Earth", solarSystem: String = "Milky Way", avgHeight: Int = 175, location: @escaping () -> Place = { fatalError() }, secondLocation: (() -> Place)? = nil) {
+internal init(firstName: String? = nil, lastName: String? = nil, age: Int? = nil, planet: String = "Earth", solarSystem: String = "Milky Way", avgHeight: Int = 175, location: @escaping () -> Place = { fatalError() }, secondLocation: (() -> Place)? = nil, wrapped: String = "") {
 self.firstName = firstName
 self.lastName = lastName
 self.age = age
@@ -8,6 +8,7 @@ self.solarSystem = solarSystem
 self.avgHeight = avgHeight
 self.location = location
 self.secondLocation = secondLocation
+self.wrapped = wrapped
 }
 
   var firstName: String!
@@ -19,6 +20,8 @@ self.secondLocation = secondLocation
   lazy var idea: Idea = { fatalError() }()
   var location: () -> Place = { fatalError() }
   var secondLocation: (() -> Place)!
+  @MyWrapper var wrapped: String = ""
+  var computed: String { "hi" }
 }
 
 struct Place {
@@ -31,6 +34,7 @@ struct Place {
   let postalCode: Int
   let plusFour: Int?
   let callback: Callback
+  @MyWrapper var wrapped: String
 }
 
 protocol Thing {
@@ -39,6 +43,11 @@ protocol Thing {
 
 enum Idea {
   var subject: String { fatalError() }
+}
+
+@propertyWrapper
+struct MyWrapper {
+  let wrappedValue: String
 }
 
 

--- a/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/class_members.swift.expected
+++ b/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/class_members.swift.expected
@@ -35,6 +35,7 @@ struct Place {
   let plusFour: Int?
   let callback: Callback
   @MyWrapper var wrapped: String
+  var `protocol`: String
 }
 
 protocol Thing {

--- a/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/class_members.swift.expected
+++ b/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/class_members.swift.expected
@@ -45,10 +45,16 @@ enum Idea {
   var subject: String { fatalError() }
 }
 
+struct OnlyComputed {
+  lazy var idea: Idea = { fatalError() }()
+  var computed: String { "hi" }
+}
+
 @propertyWrapper
 struct MyWrapper {
   let wrappedValue: String
 }
+
 
 
 

--- a/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/only_computed_members.swift.expected
+++ b/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/only_computed_members.swift.expected
@@ -10,6 +10,13 @@ class Person {
   var secondLocation: (() -> Place)!
   @MyWrapper var wrapped: String = ""
   var computed: String { "hi" }
+  var getSet: String {
+    get { "hi" }
+    set {}
+  }
+  var didSet: String = "ds" {
+    didSet { print("didSet") }
+  }
 }
 
 struct Place {

--- a/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/only_computed_members.swift.expected
+++ b/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/only_computed_members.swift.expected
@@ -34,6 +34,9 @@ enum Idea {
 }
 
 struct OnlyComputed {
+internal init() {
+}
+
   lazy var idea: Idea = { fatalError() }()
   var computed: String { "hi" }
 }
@@ -43,16 +46,7 @@ struct MyWrapper {
   let wrappedValue: String
 }
 
-// RUN: %empty-directory(%t.result)
-// RUN: %refactor -memberwise-init -source-filename %s -pos=1:8 > %t.result/generate_memberwise.swift
-// RUN: diff -u %S/Outputs/generate_memberwise/class_members.swift.expected %t.result/generate_memberwise.swift
 
-// RUN: %refactor -memberwise-init -source-filename %s -pos=15:8 > %t.result/struct_members.swift
-// RUN: diff -u %S/Outputs/generate_memberwise/struct_members.swift.expected %t.result/struct_members.swift
 
-// RUN: %refactor -memberwise-init -source-filename %s -pos=36:8 > %t.result/only_computed_members.swift
-// RUN: diff -u %S/Outputs/generate_memberwise/only_computed_members.swift.expected %t.result/only_computed_members.swift
 
-// RUN: not %refactor -memberwise-init -source-filename %s -pos=24:10 > %t.result/protocol_members.swift
-// RUN: not %refactor -memberwise-init -source-filename %s -pos=28:6 > %t.result/enum_members.swift
 

--- a/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/only_computed_members.swift.expected
+++ b/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/only_computed_members.swift.expected
@@ -23,6 +23,7 @@ struct Place {
   let plusFour: Int?
   let callback: Callback
   @MyWrapper var wrapped: String
+  var `protocol`: String
 }
 
 protocol Thing {

--- a/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/struct_members.swift.expected
+++ b/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/struct_members.swift.expected
@@ -10,6 +10,13 @@ class Person {
   var secondLocation: (() -> Place)!
   @MyWrapper var wrapped: String = ""
   var computed: String { "hi" }
+  var getSet: String {
+    get { "hi" }
+    set {}
+  }
+  var didSet: String = "ds" {
+    didSet { print("didSet") }
+  }
 }
 
 struct Place {

--- a/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/struct_members.swift.expected
+++ b/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/struct_members.swift.expected
@@ -13,7 +13,7 @@ class Person {
 }
 
 struct Place {
-internal init(person: Person, street: String, apartment: Optional<String> = nil, city: String, state: String, postalCode: Int, plusFour: Int? = nil, callback: @escaping Place.Callback, wrapped: String) {
+internal init(person: Person, street: String, apartment: Optional<String> = nil, city: String, state: String, postalCode: Int, plusFour: Int? = nil, callback: @escaping Place.Callback, wrapped: String, `protocol`: String) {
 self.person = person
 self.street = street
 self.apartment = apartment
@@ -23,6 +23,7 @@ self.postalCode = postalCode
 self.plusFour = plusFour
 self.callback = callback
 self.wrapped = wrapped
+self.`protocol` = `protocol`
 }
 
   typealias Callback = () -> ()
@@ -35,6 +36,7 @@ self.wrapped = wrapped
   let plusFour: Int?
   let callback: Callback
   @MyWrapper var wrapped: String
+  var `protocol`: String
 }
 
 protocol Thing {

--- a/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/struct_members.swift.expected
+++ b/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/struct_members.swift.expected
@@ -45,10 +45,16 @@ enum Idea {
   var subject: String { fatalError() }
 }
 
+struct OnlyComputed {
+  lazy var idea: Idea = { fatalError() }()
+  var computed: String { "hi" }
+}
+
 @propertyWrapper
 struct MyWrapper {
   let wrappedValue: String
 }
+
 
 
 

--- a/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/struct_members.swift.expected
+++ b/test/refactoring/MemberwiseInit/Outputs/generate_memberwise/struct_members.swift.expected
@@ -8,10 +8,12 @@ class Person {
   lazy var idea: Idea = { fatalError() }()
   var location: () -> Place = { fatalError() }
   var secondLocation: (() -> Place)!
+  @MyWrapper var wrapped: String = ""
+  var computed: String { "hi" }
 }
 
 struct Place {
-internal init(person: Person, street: String, apartment: Optional<String>, city: String, state: String, postalCode: Int, plusFour: Int?, callback: @escaping Place.Callback) {
+internal init(person: Person, street: String, apartment: Optional<String> = nil, city: String, state: String, postalCode: Int, plusFour: Int? = nil, callback: @escaping Place.Callback, wrapped: String) {
 self.person = person
 self.street = street
 self.apartment = apartment
@@ -20,6 +22,7 @@ self.state = state
 self.postalCode = postalCode
 self.plusFour = plusFour
 self.callback = callback
+self.wrapped = wrapped
 }
 
   typealias Callback = () -> ()
@@ -31,6 +34,7 @@ self.callback = callback
   let postalCode: Int
   let plusFour: Int?
   let callback: Callback
+  @MyWrapper var wrapped: String
 }
 
 protocol Thing {
@@ -39,6 +43,11 @@ protocol Thing {
 
 enum Idea {
   var subject: String { fatalError() }
+}
+
+@propertyWrapper
+struct MyWrapper {
+  let wrappedValue: String
 }
 
 

--- a/test/refactoring/MemberwiseInit/generate_memberwise.swift
+++ b/test/refactoring/MemberwiseInit/generate_memberwise.swift
@@ -10,6 +10,13 @@ class Person {
   var secondLocation: (() -> Place)!
   @MyWrapper var wrapped: String = ""
   var computed: String { "hi" }
+  var getSet: String {
+    get { "hi" }
+    set {}
+  }
+  var didSet: String = "ds" {
+    didSet { print("didSet") }
+  }
 }
 
 struct Place {
@@ -48,12 +55,12 @@ struct MyWrapper {
 // RUN: %refactor -memberwise-init -source-filename %s -pos=1:8 > %t.result/generate_memberwise.swift
 // RUN: diff -u %S/Outputs/generate_memberwise/class_members.swift.expected %t.result/generate_memberwise.swift
 
-// RUN: %refactor -memberwise-init -source-filename %s -pos=15:8 > %t.result/struct_members.swift
+// RUN: %refactor -memberwise-init -source-filename %s -pos=22:8 > %t.result/struct_members.swift
 // RUN: diff -u %S/Outputs/generate_memberwise/struct_members.swift.expected %t.result/struct_members.swift
 
-// RUN: %refactor -memberwise-init -source-filename %s -pos=37:8 > %t.result/only_computed_members.swift
+// RUN: %refactor -memberwise-init -source-filename %s -pos=44:8 > %t.result/only_computed_members.swift
 // RUN: diff -u %S/Outputs/generate_memberwise/only_computed_members.swift.expected %t.result/only_computed_members.swift
 
-// RUN: not %refactor -memberwise-init -source-filename %s -pos=29:10 > %t.result/protocol_members.swift
-// RUN: not %refactor -memberwise-init -source-filename %s -pos=33:6 > %t.result/enum_members.swift
+// RUN: not %refactor -memberwise-init -source-filename %s -pos=36:10 > %t.result/protocol_members.swift
+// RUN: not %refactor -memberwise-init -source-filename %s -pos=40:6 > %t.result/enum_members.swift
 

--- a/test/refactoring/MemberwiseInit/generate_memberwise.swift
+++ b/test/refactoring/MemberwiseInit/generate_memberwise.swift
@@ -8,6 +8,8 @@ class Person {
   lazy var idea: Idea = { fatalError() }()
   var location: () -> Place = { fatalError() }
   var secondLocation: (() -> Place)!
+  @MyWrapper var wrapped: String = ""
+  var computed: String { "hi" }
 }
 
 struct Place {
@@ -20,6 +22,7 @@ struct Place {
   let postalCode: Int
   let plusFour: Int?
   let callback: Callback
+  @MyWrapper var wrapped: String
 }
 
 protocol Thing {
@@ -30,13 +33,18 @@ enum Idea {
   var subject: String { fatalError() }
 }
 
+@propertyWrapper
+struct MyWrapper {
+  let wrappedValue: String
+}
+
 // RUN: %empty-directory(%t.result)
 // RUN: %refactor -memberwise-init -source-filename %s -pos=1:8 > %t.result/generate_memberwise.swift
 // RUN: diff -u %S/Outputs/generate_memberwise/class_members.swift.expected %t.result/generate_memberwise.swift
 
-// RUN: %refactor -memberwise-init -source-filename %s -pos=13:8 > %t.result/struct_members.swift
+// RUN: %refactor -memberwise-init -source-filename %s -pos=15:8 > %t.result/struct_members.swift
 // RUN: diff -u %S/Outputs/generate_memberwise/struct_members.swift.expected %t.result/struct_members.swift
 
-// RUN: not %refactor -memberwise-init -source-filename %s -pos=21:10 > %t.result/protocol_members.swift
-// RUN: not %refactor -memberwise-init -source-filename %s -pos=25:6 > %t.result/enum_members.swift
+// RUN: not %refactor -memberwise-init -source-filename %s -pos=24:10 > %t.result/protocol_members.swift
+// RUN: not %refactor -memberwise-init -source-filename %s -pos=28:6 > %t.result/enum_members.swift
 

--- a/test/refactoring/MemberwiseInit/generate_memberwise.swift
+++ b/test/refactoring/MemberwiseInit/generate_memberwise.swift
@@ -23,6 +23,7 @@ struct Place {
   let plusFour: Int?
   let callback: Callback
   @MyWrapper var wrapped: String
+  var `protocol`: String
 }
 
 protocol Thing {
@@ -50,9 +51,9 @@ struct MyWrapper {
 // RUN: %refactor -memberwise-init -source-filename %s -pos=15:8 > %t.result/struct_members.swift
 // RUN: diff -u %S/Outputs/generate_memberwise/struct_members.swift.expected %t.result/struct_members.swift
 
-// RUN: %refactor -memberwise-init -source-filename %s -pos=36:8 > %t.result/only_computed_members.swift
+// RUN: %refactor -memberwise-init -source-filename %s -pos=37:8 > %t.result/only_computed_members.swift
 // RUN: diff -u %S/Outputs/generate_memberwise/only_computed_members.swift.expected %t.result/only_computed_members.swift
 
-// RUN: not %refactor -memberwise-init -source-filename %s -pos=24:10 > %t.result/protocol_members.swift
-// RUN: not %refactor -memberwise-init -source-filename %s -pos=28:6 > %t.result/enum_members.swift
+// RUN: not %refactor -memberwise-init -source-filename %s -pos=29:10 > %t.result/protocol_members.swift
+// RUN: not %refactor -memberwise-init -source-filename %s -pos=33:6 > %t.result/enum_members.swift
 


### PR DESCRIPTION
Generating a memberwise init would skip over properties with property wrappers. Switch the implementation of memberwise init generation closer to the one that generates the implicit memberwise init by also using `getMembers()` instead of `getStoredProperties()`.

---

If type has no memberwise initializable members, generate an empty initializer instead of failing.

---

Previously, we were dropping backticks, which might lead to invalid code if the type member was a keyword. Maintain any backticks from type members in the generated memberwise initializer.

rdar://89057767
rdar://81888671