### PR TITLE
[NFC][CursorInfo] Temporarily disable some doc comment check lines

### DIFF
--- a/test/SourceKit/CursorInfo/cursor_symbol_graph_objc.swift
+++ b/test/SourceKit/CursorInfo/cursor_symbol_graph_objc.swift
@@ -217,11 +217,11 @@ struct ObjCStruct {
   // CHECK-ART-NEXT:      {
   // CHECK-ART-NEXT:        "text": " last"
   // CHECK-ART-NEXT:      },
-  // CHECK-ART-NEXT:      {
-  // CHECK-ART-NEXT:        "text": "   "
-  // CHECK-ART-NEXT:      }
-  // CHECK-ART-NEXT:    ]
-  // CHECK-ART-NEXT:  }
+  // DISABLED-CHECK-ART-NEXT:      {
+  // DISABLED-CHECK-ART-NEXT:        "text": "   "
+  // DISABLED-CHECK-ART-NEXT:      }
+  // DISABLED-CHECK-ART-NEXT:    ]
+  // DISABLED-CHECK-ART-NEXT:  }
 
   /// doc1
   // reg1
@@ -268,14 +268,14 @@ struct ObjCStruct {
   // CHECK-MIXED-DOC-NEXT:      {
   // CHECK-MIXED-DOC-NEXT:        "text": ""
   // CHECK-MIXED-DOC-NEXT:      },
-  // CHECK-MIXED-DOC-NEXT:      {
-  // CHECK-MIXED-DOC-NEXT:        "text": ""
-  // CHECK-MIXED-DOC-NEXT:      },
-  // CHECK-MIXED-DOC-NEXT:      {
-  // CHECK-MIXED-DOC-NEXT:        "text": "doc3"
-  // CHECK-MIXED-DOC-NEXT:      }
-  // CHECK-MIXED-DOC-NEXT:    ]
-  // CHECK-MIXED-DOC-NEXT:  }
+  // DISABLED-CHECK-MIXED-DOC-NEXT:      {
+  // DISABLED-CHECK-MIXED-DOC-NEXT:        "text": ""
+  // DISABLED-CHECK-MIXED-DOC-NEXT:      },
+  // DISABLED-CHECK-MIXED-DOC-NEXT:      {
+  // DISABLED-CHECK-MIXED-DOC-NEXT:        "text": "doc3"
+  // DISABLED-CHECK-MIXED-DOC-NEXT:      }
+  // DISABLED-CHECK-MIXED-DOC-NEXT:    ]
+  // DISABLED-CHECK-MIXED-DOC-NEXT:  }
 };
 
 #line 10 "other.h"


### PR DESCRIPTION
Pull request apple/llvm-project#4442 brings in a change to
`RawComment::getFormattedText` that removes spurious new lines
and whitespaces at the end of block comments. It breaks the
`cursor_symbol_graph_objc` test which is assuming the old behavior.
Temporarily disable the relevant check lines in the test to merge the
llvm change, and then fix the test properly and switch to the new
`getFormattedLines` in SymbolGraphGen.