### PR TITLE
[5.7] FeatureFlags: rename feature flag enable-bare-slash-regex. NFC

### DIFF
--- a/lib/Option/features.json
+++ b/lib/Option/features.json
@@ -22,7 +22,7 @@
       "name": "empty-abi-descriptor"
     },
     {
-      "name": "enable-bare-slash-regex"
+      "name": "enable-bare-slash-regex-updated"
     }    
   ]
 }


### PR DESCRIPTION
 rdar://92703659