### PR TITLE
Improve Over-Availability Diagnostics 

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5575,10 +5575,12 @@ NOTE(note_deprecated_rename, none,
      "use '%0' instead", (StringRef))
 
 ERROR(availability_decl_more_than_enclosing, none,
-      "declaration cannot be more available than enclosing scope", ())
+      "%0 cannot be more available than enclosing scope",
+      (DescriptiveDeclKind))
 
 NOTE(availability_decl_more_than_enclosing_enclosing_here, none,
-     "enclosing scope here", ())
+     "enclosing scope requires availability of %0 %1 or newer",
+     (StringRef, llvm::VersionTuple))
 
 ERROR(availability_decl_only_version_newer, none,
       "%0 is only available in %1 %2 or newer",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5578,6 +5578,10 @@ ERROR(availability_decl_more_than_enclosing, none,
       "%0 cannot be more available than enclosing scope",
       (DescriptiveDeclKind))
 
+NOTE(availability_implicit_decl_here, none,
+     "%0 implicitly declared here with availability of %1 %2 or newer",
+     (DescriptiveDeclKind, StringRef, llvm::VersionTuple))
+
 NOTE(availability_decl_more_than_enclosing_enclosing_here, none,
      "enclosing scope requires availability of %0 %1 or newer",
      (StringRef, llvm::VersionTuple))

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2177,9 +2177,10 @@ bool PlatformAvailability::isPlatformRelevant(StringRef name) const {
     return name == "ios" || name == "ios_app_extension";
 
   case PlatformKind::macCatalyst:
+    return name == "ios" || name == "maccatalyst";
   case PlatformKind::macCatalystApplicationExtension:
-    // ClangImporter does not yet support macCatalyst.
-    return false;
+    return name == "ios" || name == "ios_app_extension" ||
+           name == "maccatalyst" || name == "maccatalyst_app_extension";
 
   case PlatformKind::tvOS:
     return name == "tvos";

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -9083,9 +9083,12 @@ void ClangImporter::Implementation::importAttributes(
         llvm::StringSwitch<Optional<PlatformKind>>(Platform)
           .Case("ios", PlatformKind::iOS)
           .Case("macos", PlatformKind::macOS)
+          .Case("maccatalyst", PlatformKind::macCatalyst)
           .Case("tvos", PlatformKind::tvOS)
           .Case("watchos", PlatformKind::watchOS)
           .Case("ios_app_extension", PlatformKind::iOSApplicationExtension)
+          .Case("maccatalyst_app_extension",
+                PlatformKind::macCatalystApplicationExtension)
           .Case("macos_app_extension",
                 PlatformKind::macOSApplicationExtension)
           .Case("tvos_app_extension",

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1713,6 +1713,12 @@ void AttributeChecker::visitAvailableAttr(AvailableAttr *attr) {
       diagnose(D->isImplicit() ? EnclosingDecl->getLoc() : attr->getLocation(),
                diag::availability_decl_more_than_enclosing,
                D->getDescriptiveKind());
+      if (D->isImplicit())
+        diagnose(EnclosingDecl->getLoc(),
+                 diag::availability_implicit_decl_here,
+                 D->getDescriptiveKind(),
+                 prettyPlatformString(targetPlatform(Ctx.LangOpts)),
+                 AttrRange.getOSVersion().getLowerEndpoint());
       diagnose(EnclosingDecl->getLoc(),
                diag::availability_decl_more_than_enclosing_enclosing_here,
                prettyPlatformString(targetPlatform(Ctx.LangOpts)),

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1710,9 +1710,13 @@ void AttributeChecker::visitAvailableAttr(AvailableAttr *attr) {
 
   if (EnclosingDecl) {
     if (!AttrRange.isContainedIn(EnclosingAnnotatedRange.getValue())) {
-      diagnose(attr->getLocation(), diag::availability_decl_more_than_enclosing);
+      diagnose(D->isImplicit() ? EnclosingDecl->getLoc() : attr->getLocation(),
+               diag::availability_decl_more_than_enclosing,
+               D->getDescriptiveKind());
       diagnose(EnclosingDecl->getLoc(),
-               diag::availability_decl_more_than_enclosing_enclosing_here);
+               diag::availability_decl_more_than_enclosing_enclosing_here,
+               prettyPlatformString(targetPlatform(Ctx.LangOpts)),
+               EnclosingAnnotatedRange->getOSVersion().getLowerEndpoint());
     }
   }
 

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -615,19 +615,19 @@ class ClassAvailableOn10_9 {
 }
 
 @available(OSX, introduced: 10.51)
-class ClassAvailableOn10_51 { // expected-note {{enclosing scope here}}
+class ClassAvailableOn10_51 { // expected-note {{enclosing scope requires availability of macOS 10.51 or newer}}
   func someMethod() {}
   class func someClassMethod() {
     let _ = ClassAvailableOn10_51()
   }
   var someProp : Int = 22
 
-  @available(OSX, introduced: 10.9) // expected-error {{declaration cannot be more available than enclosing scope}}
+  @available(OSX, introduced: 10.9) // expected-error {{instance method cannot be more available than enclosing scope}}
   func someMethodAvailableOn10_9() { }
 
   @available(OSX, introduced: 10.52)
-  var propWithGetter: Int { // expected-note{{enclosing scope here}}
-    @available(OSX, introduced: 10.51) // expected-error {{declaration cannot be more available than enclosing scope}}
+  var propWithGetter: Int { // expected-note{{enclosing scope requires availability of macOS 10.52 or newer}}
+    @available(OSX, introduced: 10.51) // expected-error {{getter cannot be more available than enclosing scope}}
     get { return 0 }
   }
 }
@@ -1022,8 +1022,8 @@ extension ClassToExtend : ProtocolAvailableOn10_51 {
 }
 
 @available(OSX, introduced: 10.51)
-extension ClassToExtend { // expected-note {{enclosing scope here}}
-  @available(OSX, introduced: 10.9) // expected-error {{declaration cannot be more available than enclosing scope}}
+extension ClassToExtend { // expected-note {{enclosing scope requires availability of macOS 10.51 or newer}}
+  @available(OSX, introduced: 10.9) // expected-error {{instance method cannot be more available than enclosing scope}}
   func extensionMethod10_9() { }
 }
 

--- a/test/attr/Inputs/custom-modules/available_nsobject.h
+++ b/test/attr/Inputs/custom-modules/available_nsobject.h
@@ -1,0 +1,16 @@
+@import Foundation;
+
+__attribute__((availability(macosx,introduced=10.0)))
+__attribute__((availability(ios,introduced=2.0)))
+__attribute__((availability(tvos,introduced=1.0)))
+__attribute__((availability(watchos,introduced=2.0)))
+__attribute__((availability(maccatalyst,introduced=13.1)))
+@interface NSBaseClass : NSObject
+- (instancetype) init
+  __attribute__((objc_designated_initializer))
+  __attribute__((availability(macosx,introduced=10.0)))
+  __attribute__((availability(ios,introduced=2.0)))
+  __attribute__((availability(tvos,introduced=1.0)))
+  __attribute__((availability(watchos,introduced=2.0)))
+  __attribute__((availability(maccatalyst,introduced=13.1)));
+@end

--- a/test/attr/Inputs/custom-modules/module.map
+++ b/test/attr/Inputs/custom-modules/module.map
@@ -1,3 +1,4 @@
 module AttrObjc_FooClangModule { header "attr_objc_foo_clang_module.h" }
 module Testable_ClangModule { header "testable_clang.h" }
 module ObjcAsync { header "objc_async.h" }
+module Available_NSObject { header "available_nsobject.h" }

--- a/test/attr/attr_availability_maccatalyst_implicit.swift
+++ b/test/attr/attr_availability_maccatalyst_implicit.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend -I %t -I %S/Inputs/custom-modules -parse-stdlib -parse-as-library -typecheck -verify -target x86_64-apple-ios15.4-macabi %s
+
+// REQUIRES: objc_interop
+// REQUIRES: maccatalyst_support
+
+import Available_NSObject
+
+@available(iOS 15.0, *)
+open class OverAvailableClass: NSBaseClass {}
+// expected-error@-1 {{initializer cannot be more available than enclosing scope}}
+// expected-note@-2 {{initializer implicitly declared here with availability of Mac Catalyst 13.1 or newer}}
+// expected-note@-3 {{enclosing scope requires availability of Mac Catalyst 15.0 or newer}}
+

--- a/test/attr/attr_availability_osx.swift
+++ b/test/attr/attr_availability_osx.swift
@@ -84,11 +84,11 @@ doSomethingDeprecatedOniOS() // okay
 struct TestStruct {}
 
 @available(macOS 10.10, *)
-extension TestStruct { // expected-note {{enclosing scope here}}
+extension TestStruct { // expected-note {{enclosing scope requires availability of macOS 10.10 or newer}}
   @available(swift 400)
   func doTheThing() {} // expected-note {{'doTheThing()' was introduced in Swift 400}}
 
-  @available(macOS 10.9, *) // expected-error {{declaration cannot be more available than enclosing scope}}
+  @available(macOS 10.9, *) // expected-error {{instance method cannot be more available than enclosing scope}}
   @available(swift 400)
   func doAnotherThing() {} // expected-note {{'doAnotherThing()' was introduced in Swift 400}}
 


### PR DESCRIPTION
Teach the clang importer about mac catalyst availability annotations, and use this to improve the diagnostics for over-available declarations. Especially implicit ones since those used to point cryptically at a bogus source location.

The test case in here is particularly tricky because there's two sources of implicit data: swift synthesizes an initializer, and clang synthesizes an implicit macCatalyst availability floor for (the real) NSObject. Put the two together and if you subclass `NSObject` without providing an override of `-init` with matching explicit availability you can wind up trapped.  

rdar://74513654