### PR TITLE
AST: Rename the `ResilienceBoundary` to `APIBoundary` in `TypeRefinementContext::Reason`

### DIFF
--- a/include/swift/AST/TypeRefinementContext.h
+++ b/include/swift/AST/TypeRefinementContext.h
@@ -58,11 +58,11 @@ public:
     /// function declaration or the contents of a class declaration).
     Decl,
 
-    /// The context was introduced by a resilience boundary; that is, we are in
+    /// The context was introduced by an API boundary; that is, we are in
     /// a module with library evolution enabled and the parent context's
     /// contents can be visible to the module's clients, but this context's
     /// contents are not.
-    ResilienceBoundary,
+    APIBoundary,
 
     /// The context was introduced for the Then branch of an IfStmt.
     IfStmtThenBranch,
@@ -131,8 +131,7 @@ private:
     }
 
     Decl *getAsDecl() const {
-      assert(IntroReason == Reason::Decl ||
-             IntroReason == Reason::ResilienceBoundary);
+      assert(IntroReason == Reason::Decl || IntroReason == Reason::APIBoundary);
       return D;
     }
 
@@ -195,10 +194,8 @@ public:
 
   /// Create a refinement context for the given declaration.
   static TypeRefinementContext *
-  createForResilienceBoundary(ASTContext &Ctx, Decl *D,
-                              TypeRefinementContext *Parent,
-                              const AvailabilityContext &Info,
-                              SourceRange SrcRange);
+  createForAPIBoundary(ASTContext &Ctx, Decl *D, TypeRefinementContext *Parent,
+                       const AvailabilityContext &Info, SourceRange SrcRange);
 
   /// Create a refinement context for the Then branch of the given IfStmt.
   static TypeRefinementContext *

--- a/lib/AST/TypeRefinementContext.cpp
+++ b/lib/AST/TypeRefinementContext.cpp
@@ -64,18 +64,14 @@ TypeRefinementContext::createForDecl(ASTContext &Ctx, Decl *D,
       TypeRefinementContext(Ctx, D, Parent, SrcRange, Info, ExplicitInfo);
 }
 
-TypeRefinementContext *
-TypeRefinementContext::createForResilienceBoundary(ASTContext &Ctx, Decl *D,
-                                TypeRefinementContext *Parent,
-                                const AvailabilityContext &Info,
-                                SourceRange SrcRange) {
+TypeRefinementContext *TypeRefinementContext::createForAPIBoundary(
+    ASTContext &Ctx, Decl *D, TypeRefinementContext *Parent,
+    const AvailabilityContext &Info, SourceRange SrcRange) {
   assert(D);
   assert(Parent);
-  return new (Ctx)
-      TypeRefinementContext(Ctx, IntroNode(D, Reason::ResilienceBoundary),
-                            Parent, SrcRange, Info,
-                            AvailabilityContext::alwaysAvailable());
-
+  return new (Ctx) TypeRefinementContext(
+      Ctx, IntroNode(D, Reason::APIBoundary), Parent, SrcRange, Info,
+      AvailabilityContext::alwaysAvailable());
 }
 
 TypeRefinementContext *
@@ -184,7 +180,7 @@ void TypeRefinementContext::dump(raw_ostream &OS, SourceManager &SrcMgr) const {
 SourceLoc TypeRefinementContext::getIntroductionLoc() const {
   switch (getReason()) {
   case Reason::Decl:
-  case Reason::ResilienceBoundary:
+  case Reason::APIBoundary:
     return Node.getAsDecl()->getLoc();
 
   case Reason::IfStmtThenBranch:
@@ -298,7 +294,7 @@ TypeRefinementContext::getAvailabilityConditionVersionSourceRange(
       Node.getAsWhileStmt()->getCond(), Platform, Version);
 
   case Reason::Root:
-  case Reason::ResilienceBoundary:
+  case Reason::APIBoundary:
     return SourceRange();
   }
 
@@ -312,8 +308,7 @@ void TypeRefinementContext::print(raw_ostream &OS, SourceManager &SrcMgr,
 
   OS << " versions=" << AvailabilityInfo.getOSVersion().getAsString();
 
-  if (getReason() == Reason::Decl
-      || getReason() == Reason::ResilienceBoundary) {
+  if (getReason() == Reason::Decl || getReason() == Reason::APIBoundary) {
     Decl *D = Node.getAsDecl();
     OS << " decl=";
     if (auto VD = dyn_cast<ValueDecl>(D)) {
@@ -355,8 +350,8 @@ StringRef TypeRefinementContext::getReasonName(Reason R) {
   case Reason::Decl:
     return "decl";
 
-  case Reason::ResilienceBoundary:
-    return "resilience_boundary";
+  case Reason::APIBoundary:
+    return "api_boundary";
 
   case Reason::IfStmtThenBranch:
     return "if_then";

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -543,10 +543,8 @@ private:
                                                     DeclInfo, ExplicitDeclInfo,
                                                     Range);
     else
-      NewTRC =
-          TypeRefinementContext::createForResilienceBoundary(Context, D,
-                                                             getCurrentTRC(),
-                                                             DeclInfo, Range);
+      NewTRC = TypeRefinementContext::createForAPIBoundary(
+          Context, D, getCurrentTRC(), DeclInfo, Range);
 
     // Possibly use this as an effective parent context later.
     recordEffectiveParentContext(D, NewTRC);
@@ -677,9 +675,8 @@ private:
         AvailabilityContext::forDeploymentTarget(Context);
     DeploymentTargetInfo.intersectWith(getCurrentTRC()->getAvailabilityInfo());
 
-    return TypeRefinementContext::createForResilienceBoundary(
-                                           Context, D, getCurrentTRC(),
-                                           DeploymentTargetInfo, range);
+    return TypeRefinementContext::createForAPIBoundary(
+        Context, D, getCurrentTRC(), DeploymentTargetInfo, range);
   }
 
   std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {

--- a/test/Sema/availability_refinement_contexts_target_min_inlining.swift
+++ b/test/Sema/availability_refinement_contexts_target_min_inlining.swift
@@ -11,8 +11,8 @@
 // CHECK-tvos: {{^}}(root versions=[9.0,+Inf)
 // CHECK-watchos: {{^}}(root versions=[2.0,+Inf)
 
-// CHECK-macosx-NEXT: {{^}}  (resilience_boundary versions=[10.15.0,+Inf) decl=foo()
-// CHECK-ios-NEXT: {{^}}  (resilience_boundary versions=[13.0.0,+Inf) decl=foo()
-// CHECK-tvos-NEXT: {{^}}  (resilience_boundary versions=[13.0.0,+Inf) decl=foo()
-// CHECK-watchos-NEXT: {{^}}  (resilience_boundary versions=[6.0.0,+Inf) decl=foo()
+// CHECK-macosx-NEXT: {{^}}  (api_boundary versions=[10.15.0,+Inf) decl=foo()
+// CHECK-ios-NEXT: {{^}}  (api_boundary versions=[13.0.0,+Inf) decl=foo()
+// CHECK-tvos-NEXT: {{^}}  (api_boundary versions=[13.0.0,+Inf) decl=foo()
+// CHECK-watchos-NEXT: {{^}}  (api_boundary versions=[6.0.0,+Inf) decl=foo()
 func foo() {}

--- a/test/Sema/availability_refinement_contexts_target_min_inlining_maccatalyst.swift
+++ b/test/Sema/availability_refinement_contexts_target_min_inlining_maccatalyst.swift
@@ -11,5 +11,5 @@
 // Verify that -target-min-inlining-version min implies 13.1 on macCatalyst.
 
 // CHECK: {{^}}(root versions=[13.1,+Inf)
-// CHECK-NEXT: {{^}}  (resilience_boundary versions=[14.4.0,+Inf) decl=foo()
+// CHECK-NEXT: {{^}}  (api_boundary versions=[14.4.0,+Inf) decl=foo()
 func foo() {}


### PR DESCRIPTION
Rename the `ResilienceBoundary` member of the `TypeRefinementContext::Reason` enum to `APIBoundary`.

I missed needing to rename this in https://github.com/apple/swift/pull/58707.