### PR TITLE
[CodeCompletion] Support type checking attributes even if they are not part of the AST

### DIFF
--- a/include/swift/AST/ASTNode.h
+++ b/include/swift/AST/ASTNode.h
@@ -78,6 +78,10 @@ namespace swift {
 
     /// Whether the AST node is implicit.
     bool isImplicit() const;
+
+    friend llvm::hash_code hash_value(ASTNode N) {
+      return llvm::hash_value(N.getOpaqueValue());
+    }
   };
 } // namespace swift
 

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -18,6 +18,7 @@
 
 #include "swift/AST/ActorIsolation.h"
 #include "swift/AST/AnyFunctionRef.h"
+#include "swift/AST/ASTNode.h"
 #include "swift/AST/ASTTypeIDs.h"
 #include "swift/AST/Effects.h"
 #include "swift/AST/GenericParamList.h"
@@ -1544,12 +1545,82 @@ public:
   readDependencySource(const evaluator::DependencyRecorder &) const;
 };
 
+/// Describes the context in which the AST node to type check in a
+/// \c TypeCheckASTNodeAtLocRequest should be searched. This can be either of
+/// two cases:
+///  1. A \c DeclContext that contains the node representing the location to
+///     type check
+///  2. If the node that should be type checked that might not be part of the
+///     AST (e.g. because it is a dangling property attribute), an \c ASTNode
+///     that contains the location to type check in together with a DeclContext
+///     in which we should pretend that node occurs.
+class TypeCheckASTNodeAtLocContext {
+  DeclContext *DC;
+  ASTNode Node;
+
+  /// Memberwise initializer
+  TypeCheckASTNodeAtLocContext(DeclContext *DC, ASTNode Node)
+      : DC(DC), Node(Node) {
+    assert(DC != nullptr);
+  }
+
+public:
+  static TypeCheckASTNodeAtLocContext declContext(DeclContext *DC) {
+    return TypeCheckASTNodeAtLocContext(DC, /*Node=*/nullptr);
+  }
+
+  static TypeCheckASTNodeAtLocContext node(DeclContext *DC, ASTNode Node) {
+    assert(!Node.isNull());
+    return TypeCheckASTNodeAtLocContext(DC, Node);
+  }
+
+  DeclContext *getDeclContext() const { return DC; }
+
+  bool isForUnattachedNode() const { return !Node.isNull(); }
+
+  ASTNode getUnattachedNode() const {
+    assert(isForUnattachedNode());
+    return Node;
+  }
+
+  ASTNode &getUnattachedNode() {
+    assert(isForUnattachedNode());
+    return Node;
+  }
+
+  friend llvm::hash_code hash_value(const TypeCheckASTNodeAtLocContext &ctx) {
+    return llvm::hash_combine(ctx.DC, ctx.Node);
+  }
+
+  friend bool operator==(const TypeCheckASTNodeAtLocContext &lhs,
+                         const TypeCheckASTNodeAtLocContext &rhs) {
+    return lhs.DC == rhs.DC && lhs.Node == rhs.Node;
+  }
+
+  friend bool operator!=(const TypeCheckASTNodeAtLocContext &lhs,
+                         const TypeCheckASTNodeAtLocContext &rhs) {
+    return !(lhs == rhs);
+  }
+
+  friend SourceLoc
+  extractNearestSourceLoc(const TypeCheckASTNodeAtLocContext &ctx) {
+    if (!ctx.Node.isNull()) {
+      return ctx.Node.getStartLoc();
+    } else {
+      return extractNearestSourceLoc(ctx.DC);
+    }
+  }
+};
+
+void simple_display(llvm::raw_ostream &out,
+                    const TypeCheckASTNodeAtLocContext &ctx);
+
 /// Request to typecheck a function body element at the given source location.
 ///
 /// Produces true if an error occurred, false otherwise.
 class TypeCheckASTNodeAtLocRequest
     : public SimpleRequest<TypeCheckASTNodeAtLocRequest,
-                           bool(DeclContext *, SourceLoc),
+                           bool(TypeCheckASTNodeAtLocContext, SourceLoc),
                            RequestFlags::Uncached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -1558,7 +1629,8 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  bool evaluate(Evaluator &evaluator, DeclContext *DC, SourceLoc Loc) const;
+  bool evaluate(Evaluator &evaluator, TypeCheckASTNodeAtLocContext,
+                SourceLoc Loc) const;
 };
 
 /// Request to obtain a list of stored properties in a nominal type.
@@ -3605,6 +3677,7 @@ public:
   bool isCached() const { return true; }
 };
 
+void simple_display(llvm::raw_ostream &out, ASTNode node);
 void simple_display(llvm::raw_ostream &out, Type value);
 void simple_display(llvm::raw_ostream &out, const TypeRepr *TyR);
 void simple_display(llvm::raw_ostream &out, ImplicitMemberAction action);

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -345,7 +345,7 @@ SWIFT_REQUEST(TypeChecker, TypeCheckFunctionBodyRequest,
               BraceStmt *(AbstractFunctionDecl *), SeparatelyCached,
               NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, TypeCheckASTNodeAtLocRequest,
-              bool(DeclContext *, SourceLoc),
+              bool(TypeCheckASTNodeAtLocContext, SourceLoc),
               Uncached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, UnderlyingTypeRequest, Type(TypeAliasDecl *),
               SeparatelyCached, NoLocationInfo)

--- a/include/swift/Parse/CodeCompletionCallbacks.h
+++ b/include/swift/Parse/CodeCompletionCallbacks.h
@@ -118,6 +118,11 @@ public:
   /// Set target decl for attribute if the CC token is in attribute of the decl.
   virtual void setAttrTargetDeclKind(Optional<DeclKind> DK) {}
 
+  /// Set that the code completion token occurred in a custom attribute. This
+  /// allows us to type check the custom attribute even if it is not attached to
+  /// the AST, e.g. because there is no var declaration following it.
+  virtual void setCompletingInAttribute(CustomAttr *Attr){};
+
   /// Complete expr-dot after we have consumed the dot.
   virtual void completeDotExpr(CodeCompletionExpr *E, SourceLoc DotLoc) {};
 

--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -19,7 +19,9 @@
 #ifndef SWIFT_SEMA_IDETYPECHECKING_H
 #define SWIFT_SEMA_IDETYPECHECKING_H
 
+#include "swift/AST/ASTNode.h"
 #include "swift/AST/Identifier.h"
+#include "swift/AST/TypeCheckRequests.h"
 #include "swift/Basic/SourceLoc.h"
 #include <memory>
 #include <tuple>
@@ -140,8 +142,9 @@ namespace swift {
   /// Typecheck the given expression.
   bool typeCheckExpression(DeclContext *DC, Expr *&parsedExpr);
 
-  /// Type check a function body element which is at \p TargetLoc .
-  bool typeCheckASTNodeAtLoc(DeclContext *DC, SourceLoc TargetLoc);
+  /// Type check a function body element which is at \p TagetLoc.
+  bool typeCheckASTNodeAtLoc(TypeCheckASTNodeAtLocContext TypeCheckCtx,
+                             SourceLoc TargetLoc);
 
   /// Thunk around \c TypeChecker::typeCheckForCodeCompletion to make it
   /// available to \c swift::ide.

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -62,6 +62,14 @@ void swift::simple_display(llvm::raw_ostream &out,
   }
 }
 
+void swift::simple_display(llvm::raw_ostream &out, ASTNode node) {
+  if (node) {
+    node.dump(out);
+  } else {
+    out << "null";
+  }
+}
+
 void swift::simple_display(llvm::raw_ostream &out, Type type) {
   if (type)
     type.print(out);

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -115,6 +115,12 @@ class CodeCompletionCallbacksImpl : public CodeCompletionCallbacks {
   DeclContext *CurDeclContext = nullptr;
   DeclAttrKind AttrKind;
 
+  /// When the code completion token occurs in a custom attribute, the attribute
+  /// it occurs in. Used so we can complete inside the attribute even if it's
+  /// not attached to the AST, e.g. because there is no var decl it could be
+  /// attached to.
+  CustomAttr *AttrWithCompletion = nullptr;
+
   /// In situations when \c SyntaxKind hints or determines
   /// completions, i.e. a precedence group attribute, this
   /// can be set and used to control the code completion scenario.
@@ -225,6 +231,11 @@ public:
 
     if (!AttTargetIsIndependent)
       AttTargetDK = DK;
+  }
+
+  void setCompletingInAttribute(CustomAttr *Attr) override {
+    AttrWithCompletion = Attr;
+    CurDeclContext = P.CurDeclContext;
   }
 
   void completeDotExpr(CodeCompletionExpr *E, SourceLoc DotLoc) override;
@@ -1330,16 +1341,24 @@ bool CodeCompletionCallbacksImpl::trySolverCompletion(bool MaybeFuncBody) {
     ? ParsedExpr->getLoc()
     : CurDeclContext->getASTContext().SourceMgr.getCodeCompletionLoc();
 
-  switch (Kind) {
-  case CompletionKind::DotExpr: {
-    assert(CodeCompleteTokenExpr);
-    assert(CurDeclContext);
-
-    DotExprTypeCheckCompletionCallback Lookup(CodeCompleteTokenExpr,
-                                              CurDeclContext);
+  auto typeCheckWithLookup = [this, &CompletionLoc](
+                                 TypeCheckCompletionCallback &Lookup) {
     llvm::SaveAndRestore<TypeCheckCompletionCallback*>
       CompletionCollector(Context.CompletionCallback, &Lookup);
-    typeCheckContextAt(CurDeclContext, CompletionLoc);
+    if (AttrWithCompletion) {
+      /// The attribute might not be attached to the AST if there is no var decl
+      /// it could be attached to. Type check it standalone.
+      ASTNode Call = CallExpr::create(
+          CurDeclContext->getASTContext(), AttrWithCompletion->getTypeExpr(),
+          AttrWithCompletion->getArgs(), /*implicit=*/true);
+      typeCheckContextAt(
+          TypeCheckASTNodeAtLocContext::node(CurDeclContext, Call),
+          CompletionLoc);
+    } else {
+      typeCheckContextAt(
+          TypeCheckASTNodeAtLocContext::declContext(CurDeclContext),
+          CompletionLoc);
+    }
 
     // This (hopefully) only happens in cases where the expression isn't
     // typechecked during normal compilation either (e.g. member completion in a
@@ -1348,6 +1367,16 @@ bool CodeCompletionCallbacksImpl::trySolverCompletion(bool MaybeFuncBody) {
     // tooling in general though.
     if (!Lookup.gotCallback())
       Lookup.fallbackTypeCheck(CurDeclContext);
+  };
+
+  switch (Kind) {
+  case CompletionKind::DotExpr: {
+    assert(CodeCompleteTokenExpr);
+    assert(CurDeclContext);
+
+    DotExprTypeCheckCompletionCallback Lookup(CodeCompleteTokenExpr,
+                                              CurDeclContext);
+    typeCheckWithLookup(Lookup);
 
     addKeywords(CompletionContext.getResultSink(), MaybeFuncBody);
 
@@ -1362,12 +1391,7 @@ bool CodeCompletionCallbacksImpl::trySolverCompletion(bool MaybeFuncBody) {
 
     UnresolvedMemberTypeCheckCompletionCallback Lookup(CodeCompleteTokenExpr,
                                                        CurDeclContext);
-    llvm::SaveAndRestore<TypeCheckCompletionCallback*>
-      CompletionCollector(Context.CompletionCallback, &Lookup);
-    typeCheckContextAt(CurDeclContext, CompletionLoc);
-
-    if (!Lookup.gotCallback())
-      Lookup.fallbackTypeCheck(CurDeclContext);
+    typeCheckWithLookup(Lookup);
 
     addKeywords(CompletionContext.getResultSink(), MaybeFuncBody);
     Lookup.deliverResults(CurDeclContext, DotLoc, CompletionContext, Consumer);
@@ -1380,9 +1404,7 @@ bool CodeCompletionCallbacksImpl::trySolverCompletion(bool MaybeFuncBody) {
     // so we can safely cast the \c ParsedExpr back to a \c KeyPathExpr.
     auto KeyPath = cast<KeyPathExpr>(ParsedExpr);
     KeyPathTypeCheckCompletionCallback Lookup(KeyPath);
-    llvm::SaveAndRestore<TypeCheckCompletionCallback *> CompletionCollector(
-        Context.CompletionCallback, &Lookup);
-    typeCheckContextAt(CurDeclContext, CompletionLoc);
+    typeCheckWithLookup(Lookup);
 
     Lookup.deliverResults(CurDeclContext, DotLoc, CompletionContext, Consumer);
     return true;
@@ -1392,13 +1414,7 @@ bool CodeCompletionCallbacksImpl::trySolverCompletion(bool MaybeFuncBody) {
     assert(CurDeclContext);
     ArgumentTypeCheckCompletionCallback Lookup(CodeCompleteTokenExpr,
                                                CurDeclContext);
-    llvm::SaveAndRestore<TypeCheckCompletionCallback *> CompletionCollector(
-        Context.CompletionCallback, &Lookup);
-    typeCheckContextAt(CurDeclContext, CompletionLoc);
-
-    if (!Lookup.gotCallback()) {
-      Lookup.fallbackTypeCheck(CurDeclContext);
-    }
+    typeCheckWithLookup(Lookup);
 
     Lookup.deliverResults(ShouldCompleteCallPatternAfterParen, CompletionLoc,
                           CurDeclContext, CompletionContext, Consumer);
@@ -1425,13 +1441,7 @@ bool CodeCompletionCallbacksImpl::trySolverCompletion(bool MaybeFuncBody) {
       // need to have a TypeCheckCompletionCallback so we can call
       // deliverResults on it to deliver the keyword results from the completion
       // context's result sink to the consumer.
-      llvm::SaveAndRestore<TypeCheckCompletionCallback *> CompletionCollector(
-          Context.CompletionCallback, &Lookup);
-      typeCheckContextAt(CurDeclContext, CompletionLoc);
-
-      if (!Lookup.gotCallback()) {
-        Lookup.fallbackTypeCheck(CurDeclContext);
-      }
+      typeCheckWithLookup(Lookup);
     }
 
     addKeywords(CompletionContext.getResultSink(), MaybeFuncBody);
@@ -1446,13 +1456,7 @@ bool CodeCompletionCallbacksImpl::trySolverCompletion(bool MaybeFuncBody) {
 
     AfterPoundExprCompletion Lookup(CodeCompleteTokenExpr, CurDeclContext,
                                     ParentStmtKind);
-    llvm::SaveAndRestore<TypeCheckCompletionCallback *> CompletionCollector(
-        Context.CompletionCallback, &Lookup);
-    typeCheckContextAt(CurDeclContext, CompletionLoc);
-
-    if (!Lookup.gotCallback()) {
-      Lookup.fallbackTypeCheck(CurDeclContext);
-    }
+    typeCheckWithLookup(Lookup);
 
     addKeywords(CompletionContext.getResultSink(), MaybeFuncBody);
 
@@ -1522,7 +1526,7 @@ void CodeCompletionCallbacksImpl::doneParsing() {
 
   undoSingleExpressionReturn(CurDeclContext);
   typeCheckContextAt(
-      CurDeclContext,
+      TypeCheckASTNodeAtLocContext::declContext(CurDeclContext),
       ParsedExpr
           ? ParsedExpr->getLoc()
           : CurDeclContext->getASTContext().SourceMgr.getCodeCompletionLoc());

--- a/lib/IDE/ConformingMethodList.cpp
+++ b/lib/IDE/ConformingMethodList.cpp
@@ -68,7 +68,8 @@ void ConformingMethodListCallbacks::doneParsing() {
   if (!ParsedExpr)
     return;
 
-  typeCheckContextAt(CurDeclContext, ParsedExpr->getLoc());
+  typeCheckContextAt(TypeCheckASTNodeAtLocContext::declContext(CurDeclContext),
+                     ParsedExpr->getLoc());
 
   Type T = ParsedExpr->getType();
 

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -43,39 +43,39 @@ using namespace ide;
 // typeCheckContextAt(DeclContext, SourceLoc)
 //===----------------------------------------------------------------------===//
 
-void swift::ide::typeCheckContextAt(DeclContext *DC, SourceLoc Loc) {
+void swift::ide::typeCheckContextAt(TypeCheckASTNodeAtLocContext TypeCheckCtx,
+                                    SourceLoc Loc) {
   // Make sure the extension has been bound.
-  {
-    // Even if the extension is invalid (e.g. nested in a function or another
-    // type), we want to know the "intended nominal" of the extension so that
-    // we can know the type of 'Self'.
-    SmallVector<ExtensionDecl *, 1> extensions;
-    for (auto typeCtx = DC->getInnermostTypeContext(); typeCtx != nullptr;
-         typeCtx = typeCtx->getParent()->getInnermostTypeContext()) {
-      if (auto *ext = dyn_cast<ExtensionDecl>(typeCtx))
-        extensions.push_back(ext);
-    }
-    while (!extensions.empty()) {
-      extensions.back()->computeExtendedNominal();
-      extensions.pop_back();
-    }
-
-    // If the completion happens in the inheritance clause of the extension,
-    // 'DC' is the parent of the extension. We need to iterate the top level
-    // decls to find it. In theory, we don't need the extended nominal in the
-    // inheritance clause, but ASTScope lookup requires that. We don't care
-    // unless 'DC' is not 'SourceFile' because non-toplevel extensions are
-    // 'canNeverBeBound()' anyway.
-    if (auto *SF = dyn_cast<SourceFile>(DC)) {
-      auto &SM = DC->getASTContext().SourceMgr;
-      for (auto *decl : SF->getTopLevelDecls())
-        if (auto *ext = dyn_cast<ExtensionDecl>(decl))
-          if (SM.rangeContainsTokenLoc(ext->getSourceRange(), Loc))
-            ext->computeExtendedNominal();
-    }
+  auto DC = TypeCheckCtx.getDeclContext();
+  // Even if the extension is invalid (e.g. nested in a function or another
+  // type), we want to know the "intended nominal" of the extension so that
+  // we can know the type of 'Self'.
+  SmallVector<ExtensionDecl *, 1> extensions;
+  for (auto typeCtx = DC->getInnermostTypeContext(); typeCtx != nullptr;
+       typeCtx = typeCtx->getParent()->getInnermostTypeContext()) {
+    if (auto *ext = dyn_cast<ExtensionDecl>(typeCtx))
+      extensions.push_back(ext);
+  }
+  while (!extensions.empty()) {
+    extensions.back()->computeExtendedNominal();
+    extensions.pop_back();
   }
 
-  swift::typeCheckASTNodeAtLoc(DC, Loc);
+  // If the completion happens in the inheritance clause of the extension,
+  // 'DC' is the parent of the extension. We need to iterate the top level
+  // decls to find it. In theory, we don't need the extended nominal in the
+  // inheritance clause, but ASTScope lookup requires that. We don't care
+  // unless 'DC' is not 'SourceFile' because non-toplevel extensions are
+  // 'canNeverBeBound()' anyway.
+  if (auto *SF = dyn_cast<SourceFile>(DC)) {
+    auto &SM = DC->getASTContext().SourceMgr;
+    for (auto *decl : SF->getTopLevelDecls())
+      if (auto *ext = dyn_cast<ExtensionDecl>(decl))
+        if (SM.rangeContainsTokenLoc(ext->getSourceRange(), Loc))
+          ext->computeExtendedNominal();
+  }
+
+  swift::typeCheckASTNodeAtLoc(TypeCheckCtx, Loc);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/IDE/ExprContextAnalysis.h
+++ b/lib/IDE/ExprContextAnalysis.h
@@ -14,6 +14,7 @@
 #define SWIFT_IDE_EXPRCONTEXTANALYSIS_H
 
 #include "swift/AST/Type.h"
+#include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/SourceLoc.h"
@@ -29,7 +30,8 @@ enum class SemanticContextKind : uint8_t;
 
 /// Type check parent contexts of the given decl context, and the body of the
 /// given context until \c Loc if the context is a function body.
-void typeCheckContextAt(DeclContext *DC, SourceLoc Loc);
+void typeCheckContextAt(TypeCheckASTNodeAtLocContext TypeCheckCtx,
+                        SourceLoc Loc);
 
 /// From \p DC, find and returns the outer most expression which source range is
 /// exact the same as \p TargetRange. Returns \c nullptr if not found.

--- a/lib/IDE/TypeContextInfo.cpp
+++ b/lib/IDE/TypeContextInfo.cpp
@@ -89,7 +89,8 @@ void ContextInfoCallbacks::doneParsing() {
   if (!ParsedExpr)
     return;
 
-  typeCheckContextAt(CurDeclContext, ParsedExpr->getLoc());
+  typeCheckContextAt(TypeCheckASTNodeAtLocContext::declContext(CurDeclContext),
+                     ParsedExpr->getLoc());
 
   ExprContextInfo Info(CurDeclContext, ParsedExpr);
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3147,6 +3147,9 @@ ParserResult<CustomAttr> Parser::parseCustomAttribute(
   auto *TE = new (Context) TypeExpr(type.get());
   auto *customAttr = CustomAttr::create(Context, atLoc, TE, initContext,
                                         argList);
+  if (status.hasCodeCompletion() && CodeCompletion) {
+    CodeCompletion->setCompletingInAttribute(customAttr);
+  }
   return makeParserResult(status, customAttr);
 }
 

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1793,40 +1793,58 @@ static void checkClassConstructorBody(ClassDecl *classDecl,
   }
 }
 
-bool TypeCheckASTNodeAtLocRequest::evaluate(Evaluator &evaluator,
-                                            DeclContext *DC,
-                                            SourceLoc Loc) const {
-  auto &ctx = DC->getASTContext();
+void swift::simple_display(llvm::raw_ostream &out,
+                           const TypeCheckASTNodeAtLocContext &ctx) {
+  if (ctx.isForUnattachedNode()) {
+    llvm::errs() << "(unattached_node: ";
+    simple_display(out, ctx.getUnattachedNode());
+    llvm::errs() << " decl_context: ";
+    simple_display(out, ctx.getDeclContext());
+    llvm::errs() << ")";
+  } else {
+    llvm::errs() << "(decl_context: ";
+    simple_display(out, ctx.getDeclContext());
+    llvm::errs() << ")";
+  }
+}
+
+bool TypeCheckASTNodeAtLocRequest::evaluate(
+    Evaluator &evaluator, TypeCheckASTNodeAtLocContext typeCheckCtx,
+    SourceLoc Loc) const {
+  auto &ctx = typeCheckCtx.getDeclContext()->getASTContext();
   assert(DiagnosticSuppression::isEnabled(ctx.Diags) &&
          "Diagnosing and Single ASTNode type checking don't mix");
 
-  // Initializers aren't walked by ASTWalker and thus we don't find the context
-  // to type check using ASTNodeFinder. Also, initializers aren't representable
-  // by ASTNodes that can be type checked using typeCheckASTNode.
-  // Handle them specifically here.
-  if (auto *patternInit = dyn_cast<PatternBindingInitializer>(DC)) {
-    if (auto *PBD = patternInit->getBinding()) {
-      auto i = patternInit->getBindingIndex();
-      PBD->getPattern(i)->forEachVariable(
-          [](VarDecl *VD) { (void)VD->getInterfaceType(); });
-      if (PBD->getInit(i)) {
-        if (!PBD->isInitializerChecked(i)) {
-          typeCheckPatternBinding(PBD, i,
-                                  /*LeaveClosureBodyUnchecked=*/true);
-          return false;
+  if (!typeCheckCtx.isForUnattachedNode()) {
+    auto DC = typeCheckCtx.getDeclContext();
+    // Initializers aren't walked by ASTWalker and thus we don't find the
+    // context to type check using ASTNodeFinder. Also, initializers aren't
+    // representable by ASTNodes that can be type checked using
+    // typeCheckASTNode. Handle them specifically here.
+    if (auto *patternInit = dyn_cast<PatternBindingInitializer>(DC)) {
+      if (auto *PBD = patternInit->getBinding()) {
+        auto i = patternInit->getBindingIndex();
+        PBD->getPattern(i)->forEachVariable(
+            [](VarDecl *VD) { (void)VD->getInterfaceType(); });
+        if (PBD->getInit(i)) {
+          if (!PBD->isInitializerChecked(i)) {
+            typeCheckPatternBinding(PBD, i,
+                                    /*LeaveClosureBodyUnchecked=*/true);
+            return false;
+          }
         }
       }
-    }
-  } else if (auto *defaultArg = dyn_cast<DefaultArgumentInitializer>(DC)) {
-    if (auto *AFD = dyn_cast<AbstractFunctionDecl>(defaultArg->getParent())) {
-      auto *Param = AFD->getParameters()->get(defaultArg->getIndex());
-      (void)Param->getTypeCheckedDefaultExpr();
-      return false;
-    }
-    if (auto *SD = dyn_cast<SubscriptDecl>(defaultArg->getParent())) {
-      auto *Param = SD->getIndices()->get(defaultArg->getIndex());
-      (void)Param->getTypeCheckedDefaultExpr();
-      return false;
+    } else if (auto *defaultArg = dyn_cast<DefaultArgumentInitializer>(DC)) {
+      if (auto *AFD = dyn_cast<AbstractFunctionDecl>(defaultArg->getParent())) {
+        auto *Param = AFD->getParameters()->get(defaultArg->getIndex());
+        (void)Param->getTypeCheckedDefaultExpr();
+        return false;
+      }
+      if (auto *SD = dyn_cast<SubscriptDecl>(defaultArg->getParent())) {
+        auto *Param = SD->getIndices()->get(defaultArg->getIndex());
+        (void)Param->getTypeCheckedDefaultExpr();
+        return false;
+      }
     }
   }
 
@@ -1836,10 +1854,19 @@ bool TypeCheckASTNodeAtLocRequest::evaluate(Evaluator &evaluator,
     SourceManager &SM;
     SourceLoc Loc;
     ASTNode *FoundNode = nullptr;
+
+    /// The innermost DeclContext that contains \c FoundNode.
     DeclContext *DC = nullptr;
 
   public:
     ASTNodeFinder(SourceManager &SM, SourceLoc Loc) : SM(SM), Loc(Loc) {}
+
+    /// Set an \c ASTNode and \c DeclContext to type check if we don't find a
+    /// more nested node.
+    void setInitialFind(ASTNode &FoundNode, DeclContext *DC) {
+      this->FoundNode = &FoundNode;
+      this->DC = DC;
+    }
 
     bool isNull() const { return !FoundNode; }
     ASTNode &getRef() const {
@@ -1919,13 +1946,19 @@ bool TypeCheckASTNodeAtLocRequest::evaluate(Evaluator &evaluator,
     }
 
   } finder(ctx.SourceMgr, Loc);
-  DC->walkContext(finder);
+  if (typeCheckCtx.isForUnattachedNode()) {
+    finder.setInitialFind(typeCheckCtx.getUnattachedNode(),
+                          typeCheckCtx.getDeclContext());
+    typeCheckCtx.getUnattachedNode().walk(finder);
+  } else {
+    typeCheckCtx.getDeclContext()->walkContext(finder);
+  }
 
   // Nothing found at the location, or the decl context does not own the 'Loc'.
   if (finder.isNull())
     return true;
 
-  DC = finder.getDeclContext();
+  DeclContext *DC = finder.getDeclContext();
 
   if (auto *AFD = dyn_cast<AbstractFunctionDecl>(DC)) {
     if (AFD->isBodyTypeChecked())
@@ -1965,7 +1998,9 @@ bool TypeCheckASTNodeAtLocRequest::evaluate(Evaluator &evaluator,
   // signature first unless it has already been type checked.
   if (auto CE = dyn_cast<ClosureExpr>(DC)) {
     if (CE->getBodyState() == ClosureExpr::BodyState::Parsed) {
-      swift::typeCheckASTNodeAtLoc(CE->getParent(), CE->getLoc());
+      swift::typeCheckASTNodeAtLoc(
+          TypeCheckASTNodeAtLocContext::declContext(CE->getParent()),
+          CE->getLoc());
       // We need the actor isolation of the closure to be set so that we can
       // annotate results that are on the same global actor.
       // Since we are evaluating TypeCheckASTNodeAtLocRequest for every closure

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -490,12 +490,13 @@ void swift::typeCheckPatternBinding(PatternBindingDecl *PBD,
                                        /*patternType=*/Type(), options);
 }
 
-bool swift::typeCheckASTNodeAtLoc(DeclContext *DC, SourceLoc TargetLoc) {
-  auto &Ctx = DC->getASTContext();
+bool swift::typeCheckASTNodeAtLoc(TypeCheckASTNodeAtLocContext TypeCheckCtx,
+                                  SourceLoc TargetLoc) {
+  auto &Ctx = TypeCheckCtx.getDeclContext()->getASTContext();
   DiagnosticSuppression suppression(Ctx.Diags);
-  return !evaluateOrDefault(Ctx.evaluator,
-                            TypeCheckASTNodeAtLocRequest{DC, TargetLoc},
-                            true);
+  return !evaluateOrDefault(
+      Ctx.evaluator, TypeCheckASTNodeAtLocRequest{TypeCheckCtx, TargetLoc},
+      true);
 }
 
 bool swift::typeCheckForCodeCompletion(

--- a/test/IDE/complete_attributes.swift
+++ b/test/IDE/complete_attributes.swift
@@ -24,9 +24,9 @@ struct MyValue {
 // MEMBER_MyValue-DAG: Decl[StaticVar]/CurrNominal:        val[#Int#];
 // MEMBER_MyValue: End completions
 
-class TestUknownDanglingAttr1 {
+class TestUnkownDanglingAttr1 {
   @UknownAttr(arg: MyValue.#^ATTRARG_MEMBER^#)
 }
-class TestUknownDanglingAttr2 {
+class TestUnkownDanglingAttr2 {
   @UknownAttr(arg: { MyValue.#^ATTRARG_MEMBER_IN_CLOSURE^# })
 }

--- a/test/IDE/complete_property_delegate_attribute.swift
+++ b/test/IDE/complete_property_delegate_attribute.swift
@@ -1,7 +1,5 @@
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=AFTER_PAREN | %FileCheck %s -check-prefix=AFTER_PAREN
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ARG_MyEnum_NODOT | %FileCheck %s -check-prefix=ARG_MyEnum_NODOT
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ARG_MyEnum_DOT | %FileCheck %s -check-prefix=ARG_MyEnum_DOT
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ARG_MyEnum_NOBINDING | %FileCheck %s -check-prefix=ARG_MyEnum_NOBINDING
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
 
 enum MyEnum {
   case east, west
@@ -42,7 +40,32 @@ struct TestStruct {
 
   @MyStruct(arg1: MyEnum.#^ARG_MyEnum_NOBINDING^#)
 // ARG_MyEnum_NOBINDING: Begin completions
-// ARG_MyEnum_NOBINDING-DAG: Decl[EnumElement]/CurrNominal: east[#MyEnum#];
-// ARG_MyEnum_NOBINDING-DAG: Decl[EnumElement]/CurrNominal: west[#MyEnum#];
-// ARG_MyEnum_NOBINDING: End completions
+// ARG_MyEnum_NOBINDING-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Convertible]: east[#MyEnum#];
+// ARG_MyEnum_NOBINDING-DAG: Decl[EnumElement]/CurrNominal/TypeRelation[Convertible]: west[#MyEnum#];
+// ARG_MyEnum_NOBINDINaG: End completions
+
+  // FIXME: No call patterns are suggested if we are completing in variable with multiple property wrappers (rdar://91480982)
+  func sync1() {}
+
+  @MyStruct(arg1: MyEnum.east, #^SECOND_ARG_LABEL^#) var test4
+// SECOND_ARG_LABEL: Begin completions, 1 items
+// SECOND_ARG_LABEL-DAG: Pattern/Local/Flair[ArgLabels]:     {#arg2: Int#}[#Int#];
+// SECOND_ARG_LABEL: End completions
+
+  @MyStruct(arg1: MyEnum.east, #^SECOND_ARG_LABEL_NO_VAR?check=SECOND_ARG_LABEL^#)
+
+  // FIXME: No call patterns are suggested if we are completing in variable with multiple property wrappers (rdar://91480982)
+  func sync2() {}
+
+  @MyStruct(arg1: MyEnum.east, arg2: #^SECOND_ARG^#) var test4
+// SECOND_ARG: Begin completions
+// SECOND_ARG-DAG: Decl[GlobalVar]/CurrModule/TypeRelation[Convertible]: globalInt[#Int#]; name=globalInt
+// SECOND_ARG: End completions
+
+  @MyStruct(arg1: MyEnum.east, arg2: #^SECOND_ARG_NO_VAR?check=SECOND_ARG^#)
+
+  // FIXME: No call patterns are suggested if we are completing in variable with multiple property wrappers (rdar://91480982)
+  func sync3() {}
+
+  @MyStruct(#^WITHOUT_VAR?check=AFTER_PAREN^#
 }


### PR DESCRIPTION
The code completion might occur inside an attriubte that isn’t part of the AST because it’s missing a `VarDecl` that it could be attached to. In these cases, record the `CustomAttr` and type check it standalone, pretending it was part of a `DeclContext`.

This also fixes a few issues where code completion previously wouldn’t find the attribute constructor call and thus wasn’t providing code completion inside the property wrapper.

rdar://92842803