### PR TITLE
[5.7] SIL: fix serialization of the `unchecked_ref_cast` instruction

### DIFF
--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1345,7 +1345,6 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   ONEOPERAND_ONETYPE_INST(RefTo##Name) \
   ONEOPERAND_ONETYPE_INST(Name##ToRef)
 #include "swift/AST/ReferenceStorage.def"
-  ONEOPERAND_ONETYPE_INST(UncheckedRefCast)
   ONEOPERAND_ONETYPE_INST(UncheckedAddrCast)
   ONEOPERAND_ONETYPE_INST(UncheckedTrivialBitCast)
   ONEOPERAND_ONETYPE_INST(UncheckedBitwiseCast)
@@ -2667,6 +2666,17 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     ResultInst = Builder.createCheckedCastAddrBranch(
         Loc, consumption, src, srcFormalType, dest, targetFormalType, successBB,
         failureBB);
+    break;
+  }
+  case SILInstructionKind::UncheckedRefCastInst: {
+    assert(RecordKind == SIL_ONE_TYPE_ONE_OPERAND &&
+           "Layout should be OneTypeOneOperand.");
+    auto *urc = Builder.createUncheckedRefCast(Loc,
+        getLocalValue(ValID, getSILType(MF->getType(TyID2),
+                                        (SILValueCategory)TyCategory2, Fn)),
+        getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
+    urc->setForwardingOwnershipKind(decodeValueOwnership(Attr));
+    ResultInst = urc;
     break;
   }
   case SILInstructionKind::UncheckedRefCastAddrInst: {

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 687; // RefAdHocRequirementFunction info in SILFunctionLayout
+const uint16_t SWIFTMODULE_VERSION_MINOR = 690; // cast ownership serialization
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -331,7 +331,7 @@ namespace sil_block {
   using SILOneTypeOneOperandLayout = BCRecordLayout<
     SIL_ONE_TYPE_ONE_OPERAND,
     SILInstOpCodeField,
-    BCFixed<1>,          // Optional attribute
+    BCFixed<2>,          // Optional attribute
     TypeIDField,
     SILTypeCategoryField,
     TypeIDField,

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1752,6 +1752,8 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     if (SI.getKind() == SILInstructionKind::ConvertFunctionInst) {
       if (cast<ConvertFunctionInst>(SI).withoutActuallyEscaping())
         attrs |= 0x01;
+    } else if (auto *refCast = dyn_cast<UncheckedRefCastInst>(&SI)) {
+      attrs = encodeValueOwnership(refCast->getOwnershipKind());
     }
     writeConversionLikeInstruction(cast<SingleValueInstruction>(&SI), attrs);
     break;

--- a/test/Serialization/ossa_sil.sil
+++ b/test/Serialization/ossa_sil.sil
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -emit-module -module-name ossa -o %t/ossa.swiftmodule %s
+// RUN: %target-sil-opt %t/ossa.swiftmodule | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+class X {}
+
+// CHECK-LABEL: sil [serialized] [canonical] [ossa] @test_unchecked_ref_cast
+sil [serialized] [ossa] @test_unchecked_ref_cast : $@convention(thin) (@guaranteed AnyObject) -> @owned X {
+bb0(%0 : @guaranteed $AnyObject):
+  // CHECK: %1 = unchecked_ref_cast %0 : $AnyObject to $X, forwarding: @unowned
+  %1 = unchecked_ref_cast %0 : $AnyObject to $X, forwarding: @unowned
+  %2 = copy_value %1 : $X
+  return %2 : $X
+}
+


### PR DESCRIPTION
We didn't serialize the ownership kind, which resulted in a miscompile causing an over-release.

The unchecked_ref_cast is the only instruction for which we change the ownership in the optimizer, so that it doesn't match the operand's ownership. Therefore this fix is sufficient for now - we don't need to serialize the ownership of other instructions.
But this is really a design flaw of the `OwnershipForwardingMixin`. It should not allow to set the ownership to arbitrary values.

This is a cherry-pick of https://github.com/apple/swift/pull/58709

rdar://92696202
