### PR TITLE
Disabling failing test distributed_actor_init_local

### DIFF
--- a/test/Distributed/Runtime/distributed_actor_init_local.swift
+++ b/test/Distributed/Runtime/distributed_actor_init_local.swift
@@ -8,6 +8,8 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
+// REQUIRES: rdar92910719
+
 import Distributed
 
 enum MyError: Error {


### PR DESCRIPTION
Blocking `distributed_actor_init_local.swift` on rdar://92910719.
It's failing on watcsimulator-i386.

https://ci.swift.org/job/oss-swift-pr-test-macoss/453
https://ci.swift.org/job/oss-swift_tools-RA_stdlib-RDA_test-simulator/349