### PR TITLE
[Sema] Limit optional type variable hole propagation only to OptionalEvaluationExpr binding

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1993,7 +1993,8 @@ bool TypeVariableBinding::attempt(ConstraintSystem &cs) const {
   // without any contextual information, so even though `x` would get
   // bound to result type of the chain, underlying type variable wouldn't
   // be resolved, so we need to propagate holes up the conversion chain.
-  if (TypeVar->getImpl().canBindToHole()) {
+  if (TypeVar->getImpl().canBindToHole() &&
+      srcLocator->directlyAt<OptionalEvaluationExpr>()) {
     if (auto objectTy = type->getOptionalObjectType()) {
       if (auto *typeVar = objectTy->getAs<TypeVariableType>())
         cs.recordPotentialHole(typeVar);

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -509,3 +509,6 @@ func rdar85166519() {
     v?.addingReportingOverflow(0) // expected-error {{cannot convert value of type '(partialValue: Int, overflow: Bool)?' to expected dictionary key type 'Int'}}
   ]
 }
+
+// https://github.com/apple/swift/issues/58539
+if let x = nil {} // expected-error{{'nil' requires a contextual type}}

--- a/test/Constraints/try_swift5.swift
+++ b/test/Constraints/try_swift5.swift
@@ -1,0 +1,12 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5
+
+// https://github.com/apple/swift/issues/58661
+class I58661 {
+  func throwing<T>() throws -> T { // expected-note{{in call to function 'throwing()'}}
+    throw Swift.fatalError()
+  }
+
+  func reproduce() {
+    let check = try? throwing() // expected-error{{generic parameter 'T' could not be inferred}}
+  }
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
The logic introduced in https://github.com/apple/swift/pull/39238 causes this issue for `OptionalTryExpr` in swift 5 mode (where constraint is added with an optional layer to the type variable representing the result of this expression) will propagate the hole from source type variable that in this case a generic parameter making the solver to attempt bind a hole directly to the `opt try` variable which since not handled in diagnostics let the solver in this missing diagnostic state. But the thing is that in this case the hole doesn't need to be propagated because it would be bound to `opt try` variable through the source variable relation. 

I was actually unsure if it was better to special case `OptionalTry` and not propagate for that, but since the comment it seems the edge case for this need of propagation is only for `OptionalEvaluationExpr` it sounded reasonable to do this way. But let me know what you think is the best solution =] 

Edit: Also solves the `if let x = nil {}` in #58539 is the same case for `NilLiteralExpr`. Added regression test.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Fixes #58661 
Fixes #58539

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
