### PR TITLE
[Refactoring] Always walk parent decl context of value decl for local rename

### DIFF
--- a/test/refactoring/rename/Outputs/localEnum/Other_first.swift.expected
+++ b/test/refactoring/rename/Outputs/localEnum/Other_first.swift.expected
@@ -1,0 +1,36 @@
+
+func myFunc() {
+  print(LocalEnum.north)
+
+  enum LocalEnum {
+    case north
+    case south
+  }
+
+  print(LocalEnum.north)
+}
+
+
+struct Other {
+  enum EnumInStruct {
+    case primary
+    case second
+  }
+
+  func foo() {
+    print(EnumInStruct.primary)
+  }
+}
+
+
+func nested() {
+  struct MyStruct {
+    enum NestedEnum {
+      case a
+      case b
+    }
+  }
+
+  print(MyStruct.NestedEnum.a)
+}
+

--- a/test/refactoring/rename/Outputs/localEnum/myFunc_north.swift.expected
+++ b/test/refactoring/rename/Outputs/localEnum/myFunc_north.swift.expected
@@ -1,0 +1,36 @@
+
+func myFunc() {
+  print(LocalEnum.east)
+
+  enum LocalEnum {
+    case east
+    case south
+  }
+
+  print(LocalEnum.east)
+}
+
+
+struct Other {
+  enum EnumInStruct {
+    case first
+    case second
+  }
+
+  func foo() {
+    print(EnumInStruct.first)
+  }
+}
+
+
+func nested() {
+  struct MyStruct {
+    enum NestedEnum {
+      case a
+      case b
+    }
+  }
+
+  print(MyStruct.NestedEnum.a)
+}
+

--- a/test/refactoring/rename/Outputs/localEnum/nested_a.swift.expected
+++ b/test/refactoring/rename/Outputs/localEnum/nested_a.swift.expected
@@ -1,0 +1,36 @@
+
+func myFunc() {
+  print(LocalEnum.north)
+
+  enum LocalEnum {
+    case north
+    case south
+  }
+
+  print(LocalEnum.north)
+}
+
+
+struct Other {
+  enum EnumInStruct {
+    case first
+    case second
+  }
+
+  func foo() {
+    print(EnumInStruct.first)
+  }
+}
+
+
+func nested() {
+  struct MyStruct {
+    enum NestedEnum {
+      case one
+      case b
+    }
+  }
+
+  print(MyStruct.NestedEnum.one)
+}
+

--- a/test/refactoring/rename/localEnum.swift
+++ b/test/refactoring/rename/localEnum.swift
@@ -1,0 +1,51 @@
+// RUN: %empty-directory(%t.result)
+
+func myFunc() {
+  print(LocalEnum.north)
+
+  enum LocalEnum {
+    case north
+    case south
+  }
+
+  print(LocalEnum.north)
+}
+
+// RUN: %refactor -rename -source-filename %s -pos=4:19 -new-name east > %t.result/north_ref_before.swift
+// RUN: diff -u %S/Outputs/localEnum/myFunc_north.swift.expected %t.result/north_ref_before.swift
+// RUN: %refactor -rename -source-filename %s -pos=7:10 -new-name east > %t.result/north_def.swift
+// RUN: diff -u %S/Outputs/localEnum/myFunc_north.swift.expected %t.result/north_def.swift
+// RUN: %refactor -rename -source-filename %s -pos=11:19 -new-name east > %t.result/north_ref_after.swift
+// RUN: diff -u %S/Outputs/localEnum/myFunc_north.swift.expected %t.result/north_ref_after.swift
+
+struct Other {
+  enum EnumInStruct {
+    case first
+    case second
+  }
+
+  func foo() {
+    print(EnumInStruct.first)
+  }
+}
+
+// RUN: %refactor -rename -source-filename %s -pos=23:10 -new-name primary > %t.result/first_def.swift
+// RUN: diff -u %S/Outputs/localEnum/Other_first.swift.expected %t.result/first_def.swift
+// RUN: %refactor -rename -source-filename %s -pos=28:24 -new-name primary > %t.result/first_ref.swift
+// RUN: diff -u %S/Outputs/localEnum/Other_first.swift.expected %t.result/first_ref.swift
+
+func nested() {
+  struct MyStruct {
+    enum NestedEnum {
+      case a
+      case b
+    }
+  }
+
+  print(MyStruct.NestedEnum.a)
+}
+
+// RUN: %refactor -rename -source-filename %s -pos=40:12 -new-name one > %t.result/a_def.swift
+// RUN: diff -u %S/Outputs/localEnum/nested_a.swift.expected %t.result/a_def.swift
+// RUN: %refactor -rename -source-filename %s -pos=45:29 -new-name one > %t.result/a_ref.swift
+// RUN: diff -u %S/Outputs/localEnum/nested_a.swift.expected %t.result/a_ref.swift


### PR DESCRIPTION
Previously, we only walked the parent scope of the decl context that declared the value to rename if it was a TopLevelCodeDecl. But also functions can have locally declared types that can be used in sibling scopes. Thus, we always need to walk the parent DeclContext of the one declaring the value we are renaming.

rdar://89836229