### PR TITLE
[Distributed] Enforce strict order of synthesized id and actorSystem properties; avoid wrong offset crashes

### DIFF
--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -472,6 +472,7 @@ bool AbstractFunctionDecl::isDistributedActorSystemRemoteCall(bool isVoidReturn)
   if (!invocationParam->isInOut()) {
     return false;
   }
+
   // --- Check parameter: throwing: Err.Type
   auto thrownTypeParam = params->get(3);
   if (thrownTypeParam->getArgumentName() != C.Id_throwing) {

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -51,6 +51,18 @@ void DerivedConformance::addMembersToConformanceContext(
     IDC->addMember(child);
 }
 
+void DerivedConformance::addMemberToConformanceContext(
+    Decl *member, Decl *hint) {
+  auto IDC = cast<IterableDeclContext>(ConformanceDecl);
+  IDC->addMember(member, hint, /*insertAtHead=*/false);
+}
+
+void DerivedConformance::addMemberToConformanceContext(
+    Decl *member, bool insertAtHead) {
+  auto IDC = cast<IterableDeclContext>(ConformanceDecl);
+  IDC->addMember(member, /*hint=*/nullptr, insertAtHead);
+}
+
 Type DerivedConformance::getProtocolType() const {
   return Protocol->getDeclaredInterfaceType();
 }
@@ -324,10 +336,6 @@ ValueDecl *DerivedConformance::getDerivableRequirement(NominalTypeDecl *nominal,
     // Actor.unownedExecutor
     if (name.isSimpleName(ctx.Id_unownedExecutor))
       return getRequirement(KnownProtocolKind::Actor);
-
-    // DistributedActor.id
-    if(name.isSimpleName(ctx.Id_id))
-      return getRequirement(KnownProtocolKind::DistributedActor);
 
     // DistributedActor.actorSystem
     if(name.isSimpleName(ctx.Id_actorSystem))

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -70,6 +70,10 @@ public:
 
   /// Add \c children as members of the context that declares the conformance.
   void addMembersToConformanceContext(ArrayRef<Decl *> children);
+  /// Add \c member right after the \c hint member which may be the tail
+  void addMemberToConformanceContext(Decl *member, Decl* hint);
+  /// Add \c member in front of any other existing members
+  void addMemberToConformanceContext(Decl *member, bool insertAtHead);
 
   /// Get the declared type of the protocol that this is conformance is for.
   Type getProtocolType() const;

--- a/stdlib/public/Distributed/LocalTestingDistributedActorSystem.swift
+++ b/stdlib/public/Distributed/LocalTestingDistributedActorSystem.swift
@@ -43,7 +43,7 @@ public final class LocalTestingDistributedActorSystem: DistributedActorSystem, @
   public init() {}
 
   public func resolve<Act>(id: ActorID, as actorType: Act.Type)
-    throws -> Act? where Act: DistributedActor {
+    throws -> Act? where Act: DistributedActor, Act.ID == ActorID {
     guard let anyActor = self.activeActorsLock.withLock({ self.activeActors[id] }) else {
       throw LocalTestingDistributedActorSystemError(message: "Unable to locate id '\(id)' locally")
     }
@@ -54,7 +54,7 @@ public final class LocalTestingDistributedActorSystem: DistributedActorSystem, @
   }
 
   public func assignID<Act>(_ actorType: Act.Type) -> ActorID
-    where Act: DistributedActor {
+    where Act: DistributedActor, Act.ID == ActorID {
     let id = self.idProvider.next()
     self.assignedIDsLock.withLock {
       self.assignedIDs.insert(id)
@@ -63,8 +63,7 @@ public final class LocalTestingDistributedActorSystem: DistributedActorSystem, @
   }
 
   public func actorReady<Act>(_ actor: Act)
-    where Act: DistributedActor,
-    Act.ID == ActorID {
+    where Act: DistributedActor, Act.ID == ActorID {
     guard self.assignedIDsLock.withLock({ self.assignedIDs.contains(actor.id) }) else {
       fatalError("Attempted to mark an unknown actor '\(actor.id)' ready")
     }
@@ -246,10 +245,27 @@ fileprivate class _Lock {
   private let underlying: UnsafeMutablePointer<pthread_mutex_t>
   #endif
 
+  init() {
+    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    self.underlying = UnsafeMutablePointer.allocate(capacity: 1)
+    self.underlying.initialize(to: os_unfair_lock())
+    #elseif os(Windows)
+    self.underlying = UnsafeMutablePointer.allocate(capacity: 1)
+    InitializeSRWLock(self.underlying)
+    #elseif os(WASI)
+    // WASI environment has only a single thread
+    #else
+    self.underlying = UnsafeMutablePointer.allocate(capacity: 1)
+    guard pthread_mutex_init(self.underlying, nil) == 0 else {
+      fatalError("pthread_mutex_init failed")
+    }
+    #endif
+  }
+
   deinit {
     #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
     // `os_unfair_lock`s do not need to be explicitly destroyed
-    #elseif os(Windows)    
+    #elseif os(Windows)
     // `SRWLOCK`s do not need to be explicitly destroyed
     #elseif os(WASI)
     // WASI environment has only a single thread
@@ -265,21 +281,6 @@ fileprivate class _Lock {
     #endif
   }
 
-  init() {
-    #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
-    self.underlying = UnsafeMutablePointer.allocate(capacity: 1)
-    #elseif os(Windows)
-    self.underlying = UnsafeMutablePointer.allocate(capacity: 1)
-    InitializeSRWLock(self.underlying)
-    #elseif os(WASI)
-    // WASI environment has only a single thread
-    #else
-    self.underlying = UnsafeMutablePointer.allocate(capacity: 1)
-    guard pthread_mutex_init(self.underlying, nil) == 0 else {
-      fatalError("pthread_mutex_init failed")
-    }
-    #endif
-  }
 
   @discardableResult
   func withLock<T>(_ body: () -> T) -> T {

--- a/test/Distributed/Runtime/distributed_actor_init_local.swift
+++ b/test/Distributed/Runtime/distributed_actor_init_local.swift
@@ -8,8 +8,6 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-// REQUIRES: rdar92910719
-
 import Distributed
 
 enum MyError: Error {
@@ -92,15 +90,6 @@ distributed actor MaybeAfterAssign {
   }
 }
 
-distributed actor LocalTestingSystemDA {
-  typealias ActorSystem = LocalTestingDistributedActorSystem
-  var x: Int
-  init() {
-    actorSystem = .init()
-    x = 100
-  }
-}
-
 distributed actor LocalTestingDA_Int {
   typealias ActorSystem = LocalTestingDistributedActorSystem
   var int: Int
@@ -110,7 +99,6 @@ distributed actor LocalTestingDA_Int {
     // CRASH
   }
 }
-
 
 // ==== Fake Transport ---------------------------------------------------------
 
@@ -296,6 +284,7 @@ func test() async {
   // CHECK: -- start of no-assign tests --
   // CHECK-NOT: assign
   // CHECK: -- end of no-assign tests --
+
 
   // resigns that come out of the deinits:
 

--- a/test/Distributed/Runtime/distributed_actor_init_local.swift
+++ b/test/Distributed/Runtime/distributed_actor_init_local.swift
@@ -286,7 +286,7 @@ func test() async {
 
   let localDA = LocalTestingDA_Int()
   print("localDA = \(localDA.id)")
-  // CHECK: localDA = LocalTestingActorAddress(uuid: "1")
+  // CHECK: localDA = LocalTestingActorID(id: "1")
 
   // the following tests fail to initialize the actor's identity.
   print("-- start of no-assign tests --")

--- a/test/Distributed/distributed_actor_layout.swift
+++ b/test/Distributed/distributed_actor_layout.swift
@@ -12,6 +12,8 @@ import FakeDistributedActorSystems
 @available(SwiftStdlib 5.7, *)
 typealias DefaultDistributedActorSystem = FakeActorSystem
 
+class MyClass { }
+
 // Ensure that the actor layout is (metadata pointer, default actor, id, system,
 // <user fields>)
 
@@ -21,10 +23,10 @@ protocol HasActorSystem {
 
 extension MyActor: HasActorSystem { }
 
-// CHECK: %T27distributed_actor_accessors7MyActorC = type <{ %swift.refcounted, %swift.defaultactor, %T27FakeDistributedActorSystems0C7AddressV, %T27FakeDistributedActorSystems0aC6SystemV, %TSS }>
+// CHECK: %T27distributed_actor_accessors7MyActorC = type <{ %swift.refcounted, %swift.defaultactor, %T27FakeDistributedActorSystems0C7AddressV, %T27FakeDistributedActorSystems0aC6SystemV, %T27distributed_actor_accessors7MyClassC* }>
 @available(SwiftStdlib 5.7, *)
 public distributed actor MyActor {
-  var field: String = ""
+  var field: MyClass = MyClass()
 
   init(actorSystem: FakeActorSystem) {
     self.actorSystem = actorSystem

--- a/test/Distributed/distributed_actor_system_missing_adhoc_requirement_impls.swift
+++ b/test/Distributed/distributed_actor_system_missing_adhoc_requirement_impls.swift
@@ -7,836 +7,836 @@
 import Distributed
 
 struct MissingRemoteCall: DistributedActorSystem {
-    // expected-error@-1{{struct 'MissingRemoteCall' is missing witness for protocol requirement 'remoteCall'}}
-    // expected-note@-2{{protocol 'MissingRemoteCall' requires function 'remoteCall' with signature:}}
+  // expected-error@-1{{struct 'MissingRemoteCall' is missing witness for protocol requirement 'remoteCall'}}
+  // expected-note@-2{{protocol 'MissingRemoteCall' requires function 'remoteCall' with signature:}}
 
-    // expected-error@-4{{struct 'MissingRemoteCall' is missing witness for protocol requirement 'remoteCallVoid'}}
-    // expected-note@-5{{protocol 'MissingRemoteCall' requires function 'remoteCallVoid' with signature:}}
+  // expected-error@-4{{struct 'MissingRemoteCall' is missing witness for protocol requirement 'remoteCallVoid'}}
+  // expected-note@-5{{protocol 'MissingRemoteCall' requires function 'remoteCallVoid' with signature:}}
 
-    typealias ActorID = ActorAddress
-    typealias InvocationDecoder = FakeInvocationDecoder
-    typealias InvocationEncoder = FakeInvocationEncoder
-    typealias SerializationRequirement = Codable
-    typealias ResultHandler = FakeResultHandler
+  typealias ActorID = ActorAddress
+  typealias InvocationDecoder = FakeInvocationDecoder
+  typealias InvocationEncoder = FakeInvocationEncoder
+  typealias SerializationRequirement = Codable
+  typealias ResultHandler = FakeResultHandler
 
-    func resolve<Act>(id: ActorID, as actorType: Act.Type)
-        throws -> Act? where Act: DistributedActor {
-        return nil
-    }
+  func resolve<Act>(id: ActorID, as actorType: Act.Type)
+    throws -> Act? where Act: DistributedActor {
+    return nil
+  }
 
-    func assignID<Act>(_ actorType: Act.Type) -> ActorID
-        where Act: DistributedActor {
-        ActorAddress(parse: "fake://123")
-    }
+  func assignID<Act>(_ actorType: Act.Type) -> ActorID
+    where Act: DistributedActor {
+    ActorAddress(parse: "fake://123")
+  }
 
-    func actorReady<Act>(_ actor: Act)
-        where Act: DistributedActor,
-        Act.ID == ActorID {
-    }
+  func actorReady<Act>(_ actor: Act)
+    where Act: DistributedActor,
+    Act.ID == ActorID {
+  }
 
-    func resignID(_ id: ActorID) {
-    }
+  func resignID(_ id: ActorID) {
+  }
 
-    func makeInvocationEncoder() -> InvocationEncoder {
-    }
+  func makeInvocationEncoder() -> InvocationEncoder {
+  }
 }
 
 struct MissingRemoteCall_missingInout_on_encoder: DistributedActorSystem {
-    // expected-error@-1{{struct 'MissingRemoteCall_missingInout_on_encoder' is missing witness for protocol requirement 'remoteCall'}}
-    // expected-note@-2{{protocol 'MissingRemoteCall_missingInout_on_encoder' requires function 'remoteCall' with signature:}}
+  // expected-error@-1{{struct 'MissingRemoteCall_missingInout_on_encoder' is missing witness for protocol requirement 'remoteCall'}}
+  // expected-note@-2{{protocol 'MissingRemoteCall_missingInout_on_encoder' requires function 'remoteCall' with signature:}}
 
-    // expected-error@-4{{struct 'MissingRemoteCall_missingInout_on_encoder' is missing witness for protocol requirement 'remoteCallVoid'}}
-    // expected-note@-5{{protocol 'MissingRemoteCall_missingInout_on_encoder' requires function 'remoteCallVoid' with signature:}}
+  // expected-error@-4{{struct 'MissingRemoteCall_missingInout_on_encoder' is missing witness for protocol requirement 'remoteCallVoid'}}
+  // expected-note@-5{{protocol 'MissingRemoteCall_missingInout_on_encoder' requires function 'remoteCallVoid' with signature:}}
 
-    typealias ActorID = ActorAddress
-    typealias InvocationDecoder = FakeInvocationDecoder
-    typealias InvocationEncoder = FakeInvocationEncoder
-    typealias SerializationRequirement = Codable
-    typealias ResultHandler = FakeResultHandler
+  typealias ActorID = ActorAddress
+  typealias InvocationDecoder = FakeInvocationDecoder
+  typealias InvocationEncoder = FakeInvocationEncoder
+  typealias SerializationRequirement = Codable
+  typealias ResultHandler = FakeResultHandler
 
-    func resolve<Act>(id: ActorID, as actorType: Act.Type)
-        throws -> Act? where Act: DistributedActor {
-        return nil
-    }
+  func resolve<Act>(id: ActorID, as actorType: Act.Type)
+    throws -> Act? where Act: DistributedActor {
+    return nil
+  }
 
-    func assignID<Act>(_ actorType: Act.Type) -> ActorID
-        where Act: DistributedActor {
-        ActorAddress(parse: "fake://123")
-    }
+  func assignID<Act>(_ actorType: Act.Type) -> ActorID
+    where Act: DistributedActor {
+    ActorAddress(parse: "fake://123")
+  }
 
-    func actorReady<Act>(_ actor: Act)
-        where Act: DistributedActor,
-        Act.ID == ActorID {
-    }
+  func actorReady<Act>(_ actor: Act)
+    where Act: DistributedActor,
+    Act.ID == ActorID {
+  }
 
-    func resignID(_ id: ActorID) {
-    }
+  func resignID(_ id: ActorID) {
+  }
 
-    func remoteCall<Act, Err, Res>(
-        on actor: Act,
-        target: RemoteCallTarget,
-        invocation: InvocationEncoder, // MISSING 'inout'
-        throwing: Err.Type,
-        returning: Res.Type
-    ) async throws -> Res
-        where Act: DistributedActor,
-        Act.ID == ActorID,
-        Err: Error,
-        Res: SerializationRequirement {
-        fatalError("NOT IMPLEMENTED \(#function)")
-    }
+  func remoteCall<Act, Err, Res>(
+      on actor: Act,
+      target: RemoteCallTarget,
+      invocation: InvocationEncoder, // MISSING 'inout'
+      throwing: Err.Type,
+      returning: Res.Type
+  ) async throws -> Res
+      where Act: DistributedActor,
+      Act.ID == ActorID,
+      Err: Error,
+      Res: SerializationRequirement {
+    fatalError("NOT IMPLEMENTED \(#function)")
+  }
 
-    func remoteCallVoid<Act, Err>(
-        on actor: Act,
-        target: RemoteCallTarget,
-        invocation: InvocationEncoder, // MISSING 'inout'
-        throwing: Err.Type
-    ) async throws
-        where Act: DistributedActor,
-        Act.ID == ActorID,
-        Err: Error {
-        fatalError("NOT IMPLEMENTED \(#function)")
-    }
+  func remoteCallVoid<Act, Err>(
+      on actor: Act,
+      target: RemoteCallTarget,
+      invocation: InvocationEncoder, // MISSING 'inout'
+      throwing: Err.Type
+  ) async throws
+      where Act: DistributedActor,
+      Act.ID == ActorID,
+      Err: Error {
+    fatalError("NOT IMPLEMENTED \(#function)")
+  }
 
-    func makeInvocationEncoder() -> InvocationEncoder {
-    }
+  func makeInvocationEncoder() -> InvocationEncoder {
+  }
 }
 
 struct MissingRemoteCall_missing_makeInvocationEncoder: DistributedActorSystem {
-    // expected-error@-1{{type 'MissingRemoteCall_missing_makeInvocationEncoder' does not conform to protocol 'DistributedActorSystem'}}
+  // expected-error@-1{{type 'MissingRemoteCall_missing_makeInvocationEncoder' does not conform to protocol 'DistributedActorSystem'}}
 
-    typealias ActorID = ActorAddress
-    typealias InvocationDecoder = FakeInvocationDecoder
-    typealias InvocationEncoder = FakeInvocationEncoder
-    typealias SerializationRequirement = Codable
-    typealias ResultHandler = FakeResultHandler
+  typealias ActorID = ActorAddress
+  typealias InvocationDecoder = FakeInvocationDecoder
+  typealias InvocationEncoder = FakeInvocationEncoder
+  typealias SerializationRequirement = Codable
+  typealias ResultHandler = FakeResultHandler
 
-    func resolve<Act>(id: ActorID, as actorType: Act.Type)
-        throws -> Act? where Act: DistributedActor {
-        return nil
-    }
+  func resolve<Act>(id: ActorID, as actorType: Act.Type)
+    throws -> Act? where Act: DistributedActor {
+    return nil
+  }
 
-    func assignID<Act>(_ actorType: Act.Type) -> ActorID
-        where Act: DistributedActor {
-        ActorAddress(parse: "fake://123")
-    }
+  func assignID<Act>(_ actorType: Act.Type) -> ActorID
+    where Act: DistributedActor {
+    ActorAddress(parse: "fake://123")
+  }
 
-    func actorReady<Act>(_ actor: Act)
-        where Act: DistributedActor,
-        Act.ID == ActorID {
-    }
+  func actorReady<Act>(_ actor: Act)
+    where Act: DistributedActor,
+    Act.ID == ActorID {
+  }
 
-    func remoteCall<Act, Err, Res>(
-        on actor: Act,
-        target: RemoteCallTarget,
-        invocation: inout InvocationEncoder,
-        throwing: Err.Type,
-        returning: Res.Type
-    ) async throws -> Res
-        where Act: DistributedActor,
-        Act.ID == ActorID,
-        Err: Error,
-        Res: SerializationRequirement {
-        fatalError("NOT IMPLEMENTED \(#function)")
-    }
+  func remoteCall<Act, Err, Res>(
+    on actor: Act,
+    target: RemoteCallTarget,
+    invocation: inout InvocationEncoder,
+    throwing: Err.Type,
+    returning: Res.Type
+  ) async throws -> Res
+    where Act: DistributedActor,
+          Act.ID == ActorID,
+          Err: Error,
+          Res: SerializationRequirement {
+    fatalError("NOT IMPLEMENTED \(#function)")
+  }
 
-    func remoteCallVoid<Act, Err>(
-        on actor: Act,
-        target: RemoteCallTarget,
-        invocation: inout InvocationEncoder,
-        throwing: Err.Type
-    ) async throws
-        where Act: DistributedActor,
-        Act.ID == ActorID,
-        Err: Error {
-        fatalError("NOT IMPLEMENTED \(#function)")
-    }
+  func remoteCallVoid<Act, Err>(
+    on actor: Act,
+    target: RemoteCallTarget,
+    invocation: inout InvocationEncoder,
+    throwing: Err.Type
+  ) async throws
+    where Act: DistributedActor,
+          Act.ID == ActorID,
+          Err: Error {
+    fatalError("NOT IMPLEMENTED \(#function)")
+  }
 
-    func resignID(_ id: ActorID) {
-    }
+  func resignID(_ id: ActorID) {
+  }
 
-    // func makeInvocationEncoder() -> InvocationEncoder {} // MISSING
+  // func makeInvocationEncoder() -> InvocationEncoder {} // MISSING
 }
 
 struct Error_wrongReturn: DistributedActorSystem {
-    // expected-error@-1{{struct 'Error_wrongReturn' is missing witness for protocol requirement 'remoteCall'}}
-    // expected-note@-2{{protocol 'Error_wrongReturn' requires function 'remoteCall' with signature:}}
+  // expected-error@-1{{struct 'Error_wrongReturn' is missing witness for protocol requirement 'remoteCall'}}
+  // expected-note@-2{{protocol 'Error_wrongReturn' requires function 'remoteCall' with signature:}}
 
-    // expected-error@-4{{struct 'Error_wrongReturn' is missing witness for protocol requirement 'remoteCallVoid'}}
-    // expected-note@-5{{protocol 'Error_wrongReturn' requires function 'remoteCallVoid' with signature:}}
+  // expected-error@-4{{struct 'Error_wrongReturn' is missing witness for protocol requirement 'remoteCallVoid'}}
+  // expected-note@-5{{protocol 'Error_wrongReturn' requires function 'remoteCallVoid' with signature:}}
 
-    typealias ActorID = ActorAddress
-    typealias InvocationDecoder = FakeInvocationDecoder
-    typealias InvocationEncoder = FakeInvocationEncoder
-    typealias SerializationRequirement = Codable
-    typealias ResultHandler = FakeResultHandler
+  typealias ActorID = ActorAddress
+  typealias InvocationDecoder = FakeInvocationDecoder
+  typealias InvocationEncoder = FakeInvocationEncoder
+  typealias SerializationRequirement = Codable
+  typealias ResultHandler = FakeResultHandler
 
-    func resolve<Act>(id: ActorID, as actorType: Act.Type)
-        throws -> Act? where Act: DistributedActor {
-        return nil
-    }
+  func resolve<Act>(id: ActorID, as actorType: Act.Type)
+    throws -> Act? where Act: DistributedActor {
+    return nil
+  }
 
-    func assignID<Act>(_ actorType: Act.Type) -> ActorID
-        where Act: DistributedActor {
-        ActorAddress(parse: "fake://123")
-    }
+  func assignID<Act>(_ actorType: Act.Type) -> ActorID
+    where Act: DistributedActor {
+    ActorAddress(parse: "fake://123")
+  }
 
-    func actorReady<Act>(_ actor: Act)
-        where Act: DistributedActor,
-        Act.ID == ActorID {
-    }
+  func actorReady<Act>(_ actor: Act)
+    where Act: DistributedActor,
+    Act.ID == ActorID {
+  }
 
-    func resignID(_ id: ActorID) {
-    }
+  func resignID(_ id: ActorID) {
+  }
 
-    func makeInvocationEncoder() -> InvocationEncoder {
-    }
+  func makeInvocationEncoder() -> InvocationEncoder {
+  }
 
-    public func remoteCall<Act, Err, Res>(
-        on actor: Act,
-        target: RemoteCallTarget,
-        invocation invocationEncoder: inout InvocationEncoder,
-        throwing: Err.Type,
-        returning: Res.Type
-    ) async throws -> String // ERROR: wrong return type
-        where Act: DistributedActor,
-        Act.ID == ActorID,
-        Err: Error,
-        Res: SerializationRequirement {
-        throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
-    }
+  public func remoteCall<Act, Err, Res>(
+    on actor: Act,
+    target: RemoteCallTarget,
+    invocation invocationEncoder: inout InvocationEncoder,
+    throwing: Err.Type,
+    returning: Res.Type
+  ) async throws -> String // ERROR: wrong return type
+    where Act: DistributedActor,
+    Act.ID == ActorID,
+    Err: Error,
+    Res: SerializationRequirement {
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+  }
 
-    public func remoteCall<Act, Err, Res>(
-        on actor: Act,
-        target: RemoteCallTarget,
-        invocation invocationEncoder: inout InvocationEncoder,
-        throwing: Err.Type,
-        returning: Res.Type
-    ) async throws // ERROR: wrong return type (void)
-        where Act: DistributedActor,
-        Act.ID == ActorID,
-        Err: Error,
-        Res: SerializationRequirement {
-        throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
-    }
+  public func remoteCall<Act, Err, Res>(
+    on actor: Act,
+    target: RemoteCallTarget,
+    invocation invocationEncoder: inout InvocationEncoder,
+    throwing: Err.Type,
+    returning: Res.Type
+  ) async throws // ERROR: wrong return type (void)
+    where Act: DistributedActor,
+    Act.ID == ActorID,
+    Err: Error,
+    Res: SerializationRequirement {
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+  }
 
-    public func remoteCallVoid<Act, Err>(
-        on actor: Act,
-        target: RemoteCallTarget,
-        invocation invocationEncoder: inout InvocationEncoder,
-        throwing: Err.Type
-    ) throws -> String // ERROR: should not return anything
-        where Act: DistributedActor,
-        Act.ID == ActorID,
-        Err: Error {
-        throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
-    }
+  public func remoteCallVoid<Act, Err>(
+    on actor: Act,
+    target: RemoteCallTarget,
+    invocation invocationEncoder: inout InvocationEncoder,
+    throwing: Err.Type
+  ) throws -> String // ERROR: should not return anything
+    where Act: DistributedActor,
+    Act.ID == ActorID,
+    Err: Error {
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+  }
 }
 
 struct BadRemoteCall_param: DistributedActorSystem {
-    // expected-error@-1{{struct 'BadRemoteCall_param' is missing witness for protocol requirement 'remoteCall'}}
-    // expected-note@-2{{protocol 'BadRemoteCall_param' requires function 'remoteCall' with signature:}}
+  // expected-error@-1{{struct 'BadRemoteCall_param' is missing witness for protocol requirement 'remoteCall'}}
+  // expected-note@-2{{protocol 'BadRemoteCall_param' requires function 'remoteCall' with signature:}}
 
-    // expected-error@-4{{struct 'BadRemoteCall_param' is missing witness for protocol requirement 'remoteCallVoid'}}
-    // expected-note@-5{{protocol 'BadRemoteCall_param' requires function 'remoteCallVoid' with signature:}}
+  // expected-error@-4{{struct 'BadRemoteCall_param' is missing witness for protocol requirement 'remoteCallVoid'}}
+  // expected-note@-5{{protocol 'BadRemoteCall_param' requires function 'remoteCallVoid' with signature:}}
 
-    typealias ActorID = ActorAddress
-    typealias InvocationDecoder = FakeInvocationDecoder
-    typealias InvocationEncoder = FakeInvocationEncoder
-    typealias SerializationRequirement = Codable
-    typealias ResultHandler = FakeResultHandler
+  typealias ActorID = ActorAddress
+  typealias InvocationDecoder = FakeInvocationDecoder
+  typealias InvocationEncoder = FakeInvocationEncoder
+  typealias SerializationRequirement = Codable
+  typealias ResultHandler = FakeResultHandler
 
-    func resolve<Act>(id: ActorID, as actorType: Act.Type)
-        throws -> Act? where Act: DistributedActor {
-        return nil
-    }
+  func resolve<Act>(id: ActorID, as actorType: Act.Type)
+    throws -> Act? where Act: DistributedActor {
+    return nil
+  }
 
-    func assignID<Act>(_ actorType: Act.Type) -> ActorID
-        where Act: DistributedActor {
-        ActorAddress(parse: "fake://123")
-    }
+  func assignID<Act>(_ actorType: Act.Type) -> ActorID
+    where Act: DistributedActor {
+    ActorAddress(parse: "fake://123")
+  }
 
-    func actorReady<Act>(_ actor: Act)
-        where Act: DistributedActor,
-        Act.ID == ActorID {}
-    func resignID(_ id: ActorID) {}
-    func makeInvocationEncoder() -> InvocationEncoder {
-    }
+  func actorReady<Act>(_ actor: Act)
+    where Act: DistributedActor,
+    Act.ID == ActorID {}
+  func resignID(_ id: ActorID) {}
+  func makeInvocationEncoder() -> InvocationEncoder {
+  }
 
-    public func remoteCall<Act, Err, Res>(
-        on actor: Act,
-        target: RemoteCallTarget,
-        // invocation invocationEncoder: inout InvocationEncoder, // ERROR: missing parameter
-        throwing: Err.Type,
-        returning: Res.Type
-    ) async throws -> Res
-        where Act: DistributedActor,
-        Act.ID == ActorID,
-        Err: Error,
-        Res: SerializationRequirement {
-        throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
-    }
+  public func remoteCall<Act, Err, Res>(
+    on actor: Act,
+    target: RemoteCallTarget,
+    // invocation invocationEncoder: inout InvocationEncoder, // ERROR: missing parameter
+    throwing: Err.Type,
+    returning: Res.Type
+  ) async throws -> Res
+    where Act: DistributedActor,
+    Act.ID == ActorID,
+    Err: Error,
+    Res: SerializationRequirement {
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+  }
 
-    public func remoteCallVoid<Act, Err>(
-        on actor: Act,
-        target: RemoteCallTarget,
-        // invocation invocationEncoder: inout InvocationEncoder, // ERROR: missing parameter
-        throwing: Err.Type
-    ) async throws
-        where Act: DistributedActor,
-        Act.ID == ActorID,
-        Err: Error {
-        throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
-    }
+  public func remoteCallVoid<Act, Err>(
+    on actor: Act,
+    target: RemoteCallTarget,
+    // invocation invocationEncoder: inout InvocationEncoder, // ERROR: missing parameter
+    throwing: Err.Type
+  ) async throws
+    where Act: DistributedActor,
+    Act.ID == ActorID,
+    Err: Error {
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+  }
 }
 
 public struct BadRemoteCall_notPublic: DistributedActorSystem {
-    public typealias ActorID = ActorAddress
-    public typealias InvocationDecoder = PublicFakeInvocationDecoder
-    public typealias InvocationEncoder = PublicFakeInvocationEncoder
-    public typealias SerializationRequirement = Codable
-    public typealias ResultHandler = FakeResultHandler
+  public typealias ActorID = ActorAddress
+  public typealias InvocationDecoder = PublicFakeInvocationDecoder
+  public typealias InvocationEncoder = PublicFakeInvocationEncoder
+  public typealias SerializationRequirement = Codable
+  public typealias ResultHandler = FakeResultHandler
 
-    public func resolve<Act>(id: ActorID, as actorType: Act.Type)
-        throws -> Act? where Act: DistributedActor {
-        return nil
-    }
+  public func resolve<Act>(id: ActorID, as actorType: Act.Type)
+    throws -> Act? where Act: DistributedActor {
+    return nil
+  }
 
-    public func assignID<Act>(_ actorType: Act.Type) -> ActorID
-        where Act: DistributedActor {
-        ActorAddress(parse: "fake://123")
-    }
+  public func assignID<Act>(_ actorType: Act.Type) -> ActorID
+    where Act: DistributedActor {
+    ActorAddress(parse: "fake://123")
+  }
 
-    public func actorReady<Act>(_ actor: Act)
-        where Act: DistributedActor,
-        Act.ID == ActorID {}
-    public func resignID(_ id: ActorID) {}
-    public func makeInvocationEncoder() -> InvocationEncoder {
-    }
+  public func actorReady<Act>(_ actor: Act)
+    where Act: DistributedActor,
+    Act.ID == ActorID {}
+  public func resignID(_ id: ActorID) {}
+  public func makeInvocationEncoder() -> InvocationEncoder {
+  }
 
-    // expected-error@+1{{method 'remoteCall(on:target:invocation:throwing:returning:)' must be as accessible as its enclosing type because it matches a requirement in protocol 'DistributedActorSystem'}}
-    func remoteCall<Act, Err, Res>(
-        on actor: Act,
-        target: RemoteCallTarget,
-        invocation invocationEncoder: inout InvocationEncoder,
-        throwing: Err.Type,
-        returning: Res.Type
-    ) async throws -> Res
-        where Act: DistributedActor,
-        Act.ID == ActorID,
-        Err: Error,
-        Res: SerializationRequirement {
-        throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
-    }
+  // expected-error@+1{{method 'remoteCall(on:target:invocation:throwing:returning:)' must be as accessible as its enclosing type because it matches a requirement in protocol 'DistributedActorSystem'}}
+  func remoteCall<Act, Err, Res>(
+    on actor: Act,
+    target: RemoteCallTarget,
+    invocation invocationEncoder: inout InvocationEncoder,
+    throwing: Err.Type,
+    returning: Res.Type
+  ) async throws -> Res
+    where Act: DistributedActor,
+          Act.ID == ActorID,
+          Err: Error,
+          Res: SerializationRequirement {
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+  }
 
-    // expected-error@+1{{method 'remoteCallVoid(on:target:invocation:throwing:)' must be as accessible as its enclosing type because it matches a requirement in protocol 'DistributedActorSystem'}}
-    func remoteCallVoid<Act, Err>(
-        on actor: Act,
-        target: RemoteCallTarget,
-        invocation invocationEncoder: inout InvocationEncoder,
-        throwing: Err.Type
-    ) async throws
-        where Act: DistributedActor,
-        Act.ID == ActorID,
-        Err: Error {
-        throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
-    }
+  // expected-error@+1{{method 'remoteCallVoid(on:target:invocation:throwing:)' must be as accessible as its enclosing type because it matches a requirement in protocol 'DistributedActorSystem'}}
+  func remoteCallVoid<Act, Err>(
+    on actor: Act,
+    target: RemoteCallTarget,
+    invocation invocationEncoder: inout InvocationEncoder,
+    throwing: Err.Type
+  ) async throws
+    where Act: DistributedActor,
+    Act.ID == ActorID,
+    Err: Error {
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+  }
 }
 
 public struct BadRemoteCall_badResultConformance: DistributedActorSystem {
-    // expected-error@-1{{struct 'BadRemoteCall_badResultConformance' is missing witness for protocol requirement 'remoteCall'}}
-    // expected-note@-2{{protocol 'BadRemoteCall_badResultConformance' requires function 'remoteCall' with signature:}}
+  // expected-error@-1{{struct 'BadRemoteCall_badResultConformance' is missing witness for protocol requirement 'remoteCall'}}
+  // expected-note@-2{{protocol 'BadRemoteCall_badResultConformance' requires function 'remoteCall' with signature:}}
 
-    public typealias ActorID = ActorAddress
-    public typealias InvocationDecoder = PublicFakeInvocationDecoder
-    public typealias InvocationEncoder = PublicFakeInvocationEncoder
-    public typealias SerializationRequirement = Codable
-    public typealias ResultHandler = FakeResultHandler
+  public typealias ActorID = ActorAddress
+  public typealias InvocationDecoder = PublicFakeInvocationDecoder
+  public typealias InvocationEncoder = PublicFakeInvocationEncoder
+  public typealias SerializationRequirement = Codable
+  public typealias ResultHandler = FakeResultHandler
 
-    public func resolve<Act>(id: ActorID, as actorType: Act.Type)
-        throws -> Act? where Act: DistributedActor {
-        return nil
-    }
+  public func resolve<Act>(id: ActorID, as actorType: Act.Type)
+    throws -> Act? where Act: DistributedActor {
+    return nil
+  }
 
-    public func assignID<Act>(_ actorType: Act.Type) -> ActorID
-        where Act: DistributedActor {
-        ActorAddress(parse: "fake://123")
-    }
+  public func assignID<Act>(_ actorType: Act.Type) -> ActorID
+    where Act: DistributedActor {
+    ActorAddress(parse: "fake://123")
+  }
 
-    public func actorReady<Act>(_ actor: Act)
-        where Act: DistributedActor,
-        Act.ID == ActorID {}
-    public func resignID(_ id: ActorID) {}
-    public func makeInvocationEncoder() -> InvocationEncoder {
-    }
+  public func actorReady<Act>(_ actor: Act)
+    where Act: DistributedActor,
+    Act.ID == ActorID {}
+  public func resignID(_ id: ActorID) {}
+  public func makeInvocationEncoder() -> InvocationEncoder {
+  }
 
-    public func remoteCall<Act, Err, Res>(
-        on actor: Act,
-        target: RemoteCallTarget,
-        invocation invocationEncoder: inout InvocationEncoder,
-        throwing: Err.Type,
-        returning: Res.Type
-    ) async throws -> Res
-        where Act: DistributedActor,
-        Act.ID == ActorID,
-        Err: Error,
-        Res: SomeProtocol { // ERROR: bad, this must be SerializationRequirement
-        throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
-    }
+  public func remoteCall<Act, Err, Res>(
+    on actor: Act,
+    target: RemoteCallTarget,
+    invocation invocationEncoder: inout InvocationEncoder,
+    throwing: Err.Type,
+    returning: Res.Type
+  ) async throws -> Res
+    where Act: DistributedActor,
+          Act.ID == ActorID,
+          Err: Error,
+          Res: SomeProtocol { // ERROR: bad, this must be SerializationRequirement
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+  }
 
-    public func remoteCallVoid<Act, Err>(
-        on actor: Act,
-        target: RemoteCallTarget,
-        invocation invocationEncoder: inout InvocationEncoder,
-        throwing: Err.Type
-    ) async throws
-        where Act: DistributedActor,
-        Act.ID == ActorID,
-        Err: Error {
-        throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
-    }
+  public func remoteCallVoid<Act, Err>(
+    on actor: Act,
+    target: RemoteCallTarget,
+    invocation invocationEncoder: inout InvocationEncoder,
+    throwing: Err.Type
+  ) async throws
+    where Act: DistributedActor,
+    Act.ID == ActorID,
+    Err: Error {
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+  }
 }
 
 // This tests the ability to handle composite types with multiple layers
 // Codable & SomeProtocol -> Encodable & Decodable & SomeProtocol
 struct BadRemoteCall_largeSerializationRequirement: DistributedActorSystem {
-    typealias ActorID = ActorAddress
-    typealias InvocationDecoder = LargeSerializationReqFakeInvocationDecoder
-    typealias InvocationEncoder = LargeSerializationReqFakeInvocationEncoder
-    typealias SerializationRequirement = Codable & SomeProtocol
-    typealias ResultHandler = LargeSerializationReqFakeInvocationResultHandler
+  typealias ActorID = ActorAddress
+  typealias InvocationDecoder = LargeSerializationReqFakeInvocationDecoder
+  typealias InvocationEncoder = LargeSerializationReqFakeInvocationEncoder
+  typealias SerializationRequirement = Codable & SomeProtocol
+  typealias ResultHandler = LargeSerializationReqFakeInvocationResultHandler
 
-    func resolve<Act>(id: ActorID, as actorType: Act.Type)
-        throws -> Act? where Act: DistributedActor {
-        return nil
-    }
+  func resolve<Act>(id: ActorID, as actorType: Act.Type)
+    throws -> Act? where Act: DistributedActor {
+    return nil
+  }
 
-    func assignID<Act>(_ actorType: Act.Type) -> ActorID
-        where Act: DistributedActor {
-        ActorAddress(parse: "fake://123")
-    }
+  func assignID<Act>(_ actorType: Act.Type) -> ActorID
+    where Act: DistributedActor {
+    ActorAddress(parse: "fake://123")
+  }
 
-    func actorReady<Act>(_ actor: Act)
-        where Act: DistributedActor,
-        Act.ID == ActorID {}
-    func resignID(_ id: ActorID) {}
-    func makeInvocationEncoder() -> InvocationEncoder {
-    }
+  func actorReady<Act>(_ actor: Act)
+    where Act: DistributedActor,
+    Act.ID == ActorID {}
+  func resignID(_ id: ActorID) {}
+  func makeInvocationEncoder() -> InvocationEncoder {
+  }
 
-    func remoteCall<Act, Err, Res>(
-        on actor: Act,
-        target: RemoteCallTarget,
-        invocation invocationEncoder: inout InvocationEncoder,
-        throwing: Err.Type,
-        returning: Res.Type
-    ) async throws -> Res
-        where Act: DistributedActor,
-        Act.ID == ActorID,
-        Err: Error,
-        Res: SerializationRequirement {
-        throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
-    }
+  func remoteCall<Act, Err, Res>(
+    on actor: Act,
+    target: RemoteCallTarget,
+    invocation invocationEncoder: inout InvocationEncoder,
+    throwing: Err.Type,
+    returning: Res.Type
+  ) async throws -> Res
+    where Act: DistributedActor,
+          Act.ID == ActorID,
+          Err: Error,
+          Res: SerializationRequirement {
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+  }
 
-    func remoteCallVoid<Act, Err>(
-        on actor: Act,
-        target: RemoteCallTarget,
-        invocation invocationEncoder: inout InvocationEncoder,
-        throwing: Err.Type
-    ) async throws
-        where Act: DistributedActor,
-        Act.ID == ActorID,
-        Err: Error {
-        throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
-    }
+  func remoteCallVoid<Act, Err>(
+    on actor: Act,
+    target: RemoteCallTarget,
+    invocation invocationEncoder: inout InvocationEncoder,
+    throwing: Err.Type
+  ) async throws
+    where Act: DistributedActor,
+    Act.ID == ActorID,
+    Err: Error {
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+  }
 }
 
 struct BadRemoteCall_largeSerializationRequirementSlightlyOffInDefinition: DistributedActorSystem {
-    // expected-error@-1{{struct 'BadRemoteCall_largeSerializationRequirementSlightlyOffInDefinition' is missing witness for protocol requirement 'remoteCall'}}
-    // expected-note@-2{{protocol 'BadRemoteCall_largeSerializationRequirementSlightlyOffInDefinition' requires function 'remoteCall' with signature:}}
+  // expected-error@-1{{struct 'BadRemoteCall_largeSerializationRequirementSlightlyOffInDefinition' is missing witness for protocol requirement 'remoteCall'}}
+  // expected-note@-2{{protocol 'BadRemoteCall_largeSerializationRequirementSlightlyOffInDefinition' requires function 'remoteCall' with signature:}}
 
-    typealias ActorID = ActorAddress
-    typealias InvocationDecoder = LargeSerializationReqFakeInvocationDecoder
-    typealias InvocationEncoder = LargeSerializationReqFakeInvocationEncoder
-    typealias SerializationRequirement = Codable & SomeProtocol
-    typealias ResultHandler = LargeSerializationReqFakeInvocationResultHandler
+  typealias ActorID = ActorAddress
+  typealias InvocationDecoder = LargeSerializationReqFakeInvocationDecoder
+  typealias InvocationEncoder = LargeSerializationReqFakeInvocationEncoder
+  typealias SerializationRequirement = Codable & SomeProtocol
+  typealias ResultHandler = LargeSerializationReqFakeInvocationResultHandler
 
-    func resolve<Act>(id: ActorID, as actorType: Act.Type)
-        throws -> Act? where Act: DistributedActor {
-        return nil
-    }
+  func resolve<Act>(id: ActorID, as actorType: Act.Type)
+    throws -> Act? where Act: DistributedActor {
+    return nil
+  }
 
-    func assignID<Act>(_ actorType: Act.Type) -> ActorID
-        where Act: DistributedActor {
-        ActorAddress(parse: "fake://123")
-    }
+  func assignID<Act>(_ actorType: Act.Type) -> ActorID
+    where Act: DistributedActor {
+    ActorAddress(parse: "fake://123")
+  }
 
-    func actorReady<Act>(_ actor: Act)
-        where Act: DistributedActor,
-        Act.ID == ActorID {}
-    func resignID(_ id: ActorID) {}
-    func makeInvocationEncoder() -> InvocationEncoder {
-    }
+  func actorReady<Act>(_ actor: Act)
+    where Act: DistributedActor,
+    Act.ID == ActorID {}
+  func resignID(_ id: ActorID) {}
+  func makeInvocationEncoder() -> InvocationEncoder {
+  }
 
-    func remoteCall<Act, Err, Res>(
-        on actor: Act,
-        target: RemoteCallTarget,
-        invocation invocationEncoder: inout InvocationEncoder,
-        throwing: Err.Type,
-        returning: Res.Type
-    ) async throws -> Res
-        where Act: DistributedActor,
-        Act.ID == ActorID,
-        Err: Error,
-        Res: SomeProtocol { // ERROR: missing Codable!!!
-        throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
-    }
+  func remoteCall<Act, Err, Res>(
+    on actor: Act,
+    target: RemoteCallTarget,
+    invocation invocationEncoder: inout InvocationEncoder,
+    throwing: Err.Type,
+    returning: Res.Type
+  ) async throws -> Res
+    where Act: DistributedActor,
+          Act.ID == ActorID,
+          Err: Error,
+          Res: SomeProtocol { // ERROR: missing Codable!!!
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+  }
 
-    func remoteCallVoid<Act, Err>(
-        on actor: Act,
-        target: RemoteCallTarget,
-        invocation invocationEncoder: inout InvocationEncoder,
-        throwing: Err.Type
-    ) async throws
-        where Act: DistributedActor,
-        Act.ID == ActorID,
-        Err: Error {
-        throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
-    }
+  func remoteCallVoid<Act, Err>(
+    on actor: Act,
+    target: RemoteCallTarget,
+    invocation invocationEncoder: inout InvocationEncoder,
+    throwing: Err.Type
+  ) async throws
+    where Act: DistributedActor,
+    Act.ID == ActorID,
+    Err: Error {
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+  }
 }
 
 struct BadRemoteCall_anySerializationRequirement: DistributedActorSystem {
-    typealias ActorID = ActorAddress
-    typealias InvocationDecoder = AnyInvocationDecoder
-    typealias InvocationEncoder = AnyInvocationEncoder
-    typealias SerializationRequirement = Any // !!
-    typealias ResultHandler = AnyResultHandler
+  typealias ActorID = ActorAddress
+  typealias InvocationDecoder = AnyInvocationDecoder
+  typealias InvocationEncoder = AnyInvocationEncoder
+  typealias SerializationRequirement = Any // !!
+  typealias ResultHandler = AnyResultHandler
 
-    func resolve<Act>(id: ActorID, as actorType: Act.Type)
-        throws -> Act? where Act: DistributedActor {
-        return nil
-    }
+  func resolve<Act>(id: ActorID, as actorType: Act.Type)
+    throws -> Act? where Act: DistributedActor {
+    return nil
+  }
 
-    func assignID<Act>(_ actorType: Act.Type) -> ActorID
-        where Act: DistributedActor {
-        ActorAddress(parse: "fake://123")
-    }
+  func assignID<Act>(_ actorType: Act.Type) -> ActorID
+    where Act: DistributedActor {
+    ActorAddress(parse: "fake://123")
+  }
 
-    func actorReady<Act>(_ actor: Act)
-        where Act: DistributedActor,
-        Act.ID == ActorID {}
-    func resignID(_ id: ActorID) {}
-    func makeInvocationEncoder() -> InvocationEncoder {
-    }
+  func actorReady<Act>(_ actor: Act)
+    where Act: DistributedActor,
+    Act.ID == ActorID {}
+  func resignID(_ id: ActorID) {}
+  func makeInvocationEncoder() -> InvocationEncoder {
+  }
 
-    func remoteCall<Act, Err, Res>(
-        on actor: Act,
-        target: RemoteCallTarget,
-        invocation invocationEncoder: inout InvocationEncoder,
-        throwing: Err.Type,
-        returning: Res.Type
-    ) async throws -> Res
-        where Act: DistributedActor,
-        Act.ID == ActorID,
-        Err: Error,
-        Res: SerializationRequirement {
-        throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
-    }
+  func remoteCall<Act, Err, Res>(
+    on actor: Act,
+    target: RemoteCallTarget,
+    invocation invocationEncoder: inout InvocationEncoder,
+    throwing: Err.Type,
+    returning: Res.Type
+  ) async throws -> Res
+    where Act: DistributedActor,
+          Act.ID == ActorID,
+          Err: Error,
+          Res: SerializationRequirement {
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+  }
 
-    func remoteCallVoid<Act, Err>(
-        on actor: Act,
-        target: RemoteCallTarget,
-        invocation invocationEncoder: inout InvocationEncoder,
-        throwing: Err.Type
-    ) async throws
-        where Act: DistributedActor,
-        Act.ID == ActorID,
-        Err: Error {
-        throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
-    }
+  func remoteCallVoid<Act, Err>(
+    on actor: Act,
+    target: RemoteCallTarget,
+    invocation invocationEncoder: inout InvocationEncoder,
+    throwing: Err.Type
+  ) async throws
+    where Act: DistributedActor,
+    Act.ID == ActorID,
+    Err: Error {
+    throw ExecuteDistributedTargetError(message: "\(#function) not implemented.")
+  }
 }
 
 // ==== ------------------------------------------------------------------------
 
 public struct ActorAddress: Sendable, Hashable, Codable {
-    let address: String
-    init(parse address: String) {
-        self.address = address
-    }
+  let address: String
+  init(parse address: String) {
+    self.address = address
+  }
 }
 
 public protocol SomeProtocol: Sendable {}
 
 struct FakeInvocationEncoder: DistributedTargetInvocationEncoder {
-    typealias SerializationRequirement = Codable
+  typealias SerializationRequirement = Codable
 
-    mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
-    mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
-    mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
-    mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
-    mutating func doneRecording() throws {}
+  mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+  mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
+  mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
+  mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
+  mutating func doneRecording() throws {}
 }
 
 struct AnyInvocationEncoder: DistributedTargetInvocationEncoder {
-    typealias SerializationRequirement = Any
+  typealias SerializationRequirement = Any
 
-    mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
-    mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
-    mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
-    mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
-    mutating func doneRecording() throws {}
+  mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+  mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
+  mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
+  mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
+  mutating func doneRecording() throws {}
 }
 
 struct LargeSerializationReqFakeInvocationEncoder: DistributedTargetInvocationEncoder {
-    typealias SerializationRequirement = Codable & SomeProtocol
+  typealias SerializationRequirement = Codable & SomeProtocol
 
-    mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
-    mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
-    mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
-    mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
-    mutating func doneRecording() throws {}
+  mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+  mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
+  mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
+  mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
+  mutating func doneRecording() throws {}
 }
 
 public struct PublicFakeInvocationEncoder: DistributedTargetInvocationEncoder {
-    public typealias SerializationRequirement = Codable
+  public typealias SerializationRequirement = Codable
 
-    public mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
-    public mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
-    public mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
-    public mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
-    public mutating func doneRecording() throws {}
+  public mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+  public mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
+  public mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
+  public mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
+  public mutating func doneRecording() throws {}
 }
 
 struct FakeInvocationEncoder_missing_recordArgument: DistributedTargetInvocationEncoder {
-    //expected-error@-1{{struct 'FakeInvocationEncoder_missing_recordArgument' is missing witness for protocol requirement 'recordArgument'}}
-    //expected-note@-2{{protocol 'FakeInvocationEncoder_missing_recordArgument' requires function 'recordArgument' with signature:}}
-    typealias SerializationRequirement = Codable
+  //expected-error@-1{{struct 'FakeInvocationEncoder_missing_recordArgument' is missing witness for protocol requirement 'recordArgument'}}
+  //expected-note@-2{{protocol 'FakeInvocationEncoder_missing_recordArgument' requires function 'recordArgument' with signature:}}
+  typealias SerializationRequirement = Codable
 
-    mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
-    // MISSING: mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
-    mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
-    mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
-    mutating func doneRecording() throws {}
+  mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+  // MISSING: mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
+  mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
+  mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
+  mutating func doneRecording() throws {}
 }
 
 struct FakeInvocationEncoder_missing_recordArgument2: DistributedTargetInvocationEncoder {
-    //expected-error@-1{{struct 'FakeInvocationEncoder_missing_recordArgument2' is missing witness for protocol requirement 'recordArgument'}}
-    //expected-note@-2{{protocol 'FakeInvocationEncoder_missing_recordArgument2' requires function 'recordArgument' with signature:}}
-    typealias SerializationRequirement = Codable
+  //expected-error@-1{{struct 'FakeInvocationEncoder_missing_recordArgument2' is missing witness for protocol requirement 'recordArgument'}}
+  //expected-note@-2{{protocol 'FakeInvocationEncoder_missing_recordArgument2' requires function 'recordArgument' with signature:}}
+  typealias SerializationRequirement = Codable
 
-    mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
-    mutating func recordArgument<Argument: SomeProtocol>(_ argument: Argument) throws {} // BAD
-    mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
-    mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
-    mutating func doneRecording() throws {}
+  mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+  mutating func recordArgument<Argument: SomeProtocol>(_ argument: Argument) throws {} // BAD
+  mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
+  mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
+  mutating func doneRecording() throws {}
 }
 
 struct FakeInvocationEncoder_missing_recordReturnType: DistributedTargetInvocationEncoder {
-    //expected-error@-1{{struct 'FakeInvocationEncoder_missing_recordReturnType' is missing witness for protocol requirement 'recordReturnType'}}
-    //expected-note@-2{{protocol 'FakeInvocationEncoder_missing_recordReturnType' requires function 'recordReturnType' with signature:}}
-    typealias SerializationRequirement = Codable
+  //expected-error@-1{{struct 'FakeInvocationEncoder_missing_recordReturnType' is missing witness for protocol requirement 'recordReturnType'}}
+  //expected-note@-2{{protocol 'FakeInvocationEncoder_missing_recordReturnType' requires function 'recordReturnType' with signature:}}
+  typealias SerializationRequirement = Codable
 
-    mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
-    mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
-    // MISSING: mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
-    mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
-    mutating func doneRecording() throws {}
+  mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+  mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
+  // MISSING: mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
+  mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
+  mutating func doneRecording() throws {}
 }
 
 struct FakeInvocationEncoder_missing_recordErrorType: DistributedTargetInvocationEncoder {
-    //expected-error@-1{{type 'FakeInvocationEncoder_missing_recordErrorType' does not conform to protocol 'DistributedTargetInvocationEncoder'}}
-    typealias SerializationRequirement = Codable
+  //expected-error@-1{{type 'FakeInvocationEncoder_missing_recordErrorType' does not conform to protocol 'DistributedTargetInvocationEncoder'}}
+  typealias SerializationRequirement = Codable
 
-    mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
-    mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
-    mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
-    // MISSING: mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
-    mutating func doneRecording() throws {}
+  mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+  mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
+  mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
+  // MISSING: mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
+  mutating func doneRecording() throws {}
 }
 
 struct FakeInvocationEncoder_recordArgument_wrongType: DistributedTargetInvocationEncoder {
-    //expected-error@-1{{struct 'FakeInvocationEncoder_recordArgument_wrongType' is missing witness for protocol requirement 'recordArgument'}}
-    //expected-note@-2{{protocol 'FakeInvocationEncoder_recordArgument_wrongType' requires function 'recordArgument' with signature:}}
-    typealias SerializationRequirement = Codable
+  //expected-error@-1{{struct 'FakeInvocationEncoder_recordArgument_wrongType' is missing witness for protocol requirement 'recordArgument'}}
+  //expected-note@-2{{protocol 'FakeInvocationEncoder_recordArgument_wrongType' requires function 'recordArgument' with signature:}}
+  typealias SerializationRequirement = Codable
 
-    mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
-    mutating func recordArgument<Argument: SerializationRequirement>(_ argument: String, other: Argument) throws {} // BAD
-    mutating func recordArgument<Argument: SerializationRequirement>(_ argument: Argument.Type) throws {} // BAD
-    mutating func recordArgument<Argument: SerializationRequirement>(badName: Argument) throws {} // BAD
-    mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
-    mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
-    mutating func doneRecording() throws {}
+  mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+  mutating func recordArgument<Argument: SerializationRequirement>(_ argument: String, other: Argument) throws {} // BAD
+  mutating func recordArgument<Argument: SerializationRequirement>(_ argument: Argument.Type) throws {} // BAD
+  mutating func recordArgument<Argument: SerializationRequirement>(badName: Argument) throws {} // BAD
+  mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
+  mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
+  mutating func doneRecording() throws {}
 }
 struct FakeInvocationEncoder_recordArgument_missingMutating: DistributedTargetInvocationEncoder {
-    //expected-error@-1{{struct 'FakeInvocationEncoder_recordArgument_missingMutating' is missing witness for protocol requirement 'recordArgument'}}
-    //expected-note@-2{{protocol 'FakeInvocationEncoder_recordArgument_missingMutating' requires function 'recordArgument' with signature:}}
-    typealias SerializationRequirement = Codable
+  //expected-error@-1{{struct 'FakeInvocationEncoder_recordArgument_missingMutating' is missing witness for protocol requirement 'recordArgument'}}
+  //expected-note@-2{{protocol 'FakeInvocationEncoder_recordArgument_missingMutating' requires function 'recordArgument' with signature:}}
+  typealias SerializationRequirement = Codable
 
-    mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
-    func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
-    mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
-    mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
-    mutating func doneRecording() throws {}
+  mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+  func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
+  mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
+  mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
+  mutating func doneRecording() throws {}
 }
 
 struct FakeInvocationEncoder_recordResultType_wrongType: DistributedTargetInvocationEncoder {
-    //expected-error@-1{{struct 'FakeInvocationEncoder_recordResultType_wrongType' is missing witness for protocol requirement 'recordReturnType'}}
-    //expected-note@-2{{protocol 'FakeInvocationEncoder_recordResultType_wrongType' requires function 'recordReturnType' with signature:}}
-    typealias SerializationRequirement = Codable
+  //expected-error@-1{{struct 'FakeInvocationEncoder_recordResultType_wrongType' is missing witness for protocol requirement 'recordReturnType'}}
+  //expected-note@-2{{protocol 'FakeInvocationEncoder_recordResultType_wrongType' requires function 'recordReturnType' with signature:}}
+  typealias SerializationRequirement = Codable
 
-    mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
-    mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
-    mutating func recordReturnType<R: SerializationRequirement>(s: String, _ resultType: R.Type) throws {} // BAD
-    mutating func recordReturnType<R: SomeProtocol>(_ resultType: R.Type) throws {} // BAD
-    mutating func recordReturnType<R: SerializationRequirement>(badName: R.Type) throws {} // BAD
-    mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
-    mutating func doneRecording() throws {}
+  mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+  mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
+  mutating func recordReturnType<R: SerializationRequirement>(s: String, _ resultType: R.Type) throws {} // BAD
+  mutating func recordReturnType<R: SomeProtocol>(_ resultType: R.Type) throws {} // BAD
+  mutating func recordReturnType<R: SerializationRequirement>(badName: R.Type) throws {} // BAD
+  mutating func recordErrorType<E: Error>(_ type: E.Type) throws {}
+  mutating func doneRecording() throws {}
 }
 
 struct FakeInvocationEncoder_recordErrorType_wrongType: DistributedTargetInvocationEncoder {
-    //expected-error@-1{{type 'FakeInvocationEncoder_recordErrorType_wrongType' does not conform to protocol 'DistributedTargetInvocationEncoder'}}
-    typealias SerializationRequirement = Codable
+  //expected-error@-1{{type 'FakeInvocationEncoder_recordErrorType_wrongType' does not conform to protocol 'DistributedTargetInvocationEncoder'}}
+  typealias SerializationRequirement = Codable
 
-    mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
-    mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
-    mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
-    mutating func recordErrorType<E: Error>(BadName type: E.Type) throws {} // BAD
-    mutating func recordErrorType<E: SerializationRequirement>(_ type: E.Type) throws {} // BAD
-    //expected-note@-1{{candidate has non-matching type '<E> (E.Type) throws -> ()'}}
-    mutating func doneRecording() throws {}
+  mutating func recordGenericSubstitution<T>(_ type: T.Type) throws {}
+  mutating func recordArgument<Value: SerializationRequirement>(_ argument: RemoteCallArgument<Value>) throws {}
+  mutating func recordReturnType<R: SerializationRequirement>(_ type: R.Type) throws {}
+  mutating func recordErrorType<E: Error>(BadName type: E.Type) throws {} // BAD
+  mutating func recordErrorType<E: SerializationRequirement>(_ type: E.Type) throws {} // BAD
+  //expected-note@-1{{candidate has non-matching type '<E> (E.Type) throws -> ()'}}
+  mutating func doneRecording() throws {}
 }
 
 class FakeInvocationDecoder: DistributedTargetInvocationDecoder {
-    typealias SerializationRequirement = Codable
+  typealias SerializationRequirement = Codable
 
-    func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
-    func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
-    func decodeReturnType() throws -> Any.Type? { nil }
-    func decodeErrorType() throws -> Any.Type? { nil }
+  func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
+  func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
+  func decodeReturnType() throws -> Any.Type? { nil }
+  func decodeErrorType() throws -> Any.Type? { nil }
 }
 
 class AnyInvocationDecoder: DistributedTargetInvocationDecoder {
-    typealias SerializationRequirement = Any
+  typealias SerializationRequirement = Any
 
-    func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
-    func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
-    func decodeReturnType() throws -> Any.Type? { nil }
-    func decodeErrorType() throws -> Any.Type? { nil }
+  func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
+  func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
+  func decodeReturnType() throws -> Any.Type? { nil }
+  func decodeErrorType() throws -> Any.Type? { nil }
 }
 
 class LargeSerializationReqFakeInvocationDecoder : DistributedTargetInvocationDecoder {
-    typealias SerializationRequirement = Codable & SomeProtocol
+  typealias SerializationRequirement = Codable & SomeProtocol
 
-    func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
-    func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
-    func decodeReturnType() throws -> Any.Type? { nil }
-    func decodeErrorType() throws -> Any.Type? { nil }
+  func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
+  func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
+  func decodeReturnType() throws -> Any.Type? { nil }
+  func decodeErrorType() throws -> Any.Type? { nil }
 }
 
 public final class PublicFakeInvocationDecoder : DistributedTargetInvocationDecoder {
-    public typealias SerializationRequirement = Codable
+  public typealias SerializationRequirement = Codable
 
-    public func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
-    public func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
-    public func decodeReturnType() throws -> Any.Type? { nil }
-    public func decodeErrorType() throws -> Any.Type? { nil }
+  public func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
+  public func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
+  public func decodeReturnType() throws -> Any.Type? { nil }
+  public func decodeErrorType() throws -> Any.Type? { nil }
 }
 
 public final class PublicFakeInvocationDecoder_badNotPublic: DistributedTargetInvocationDecoder {
-    public typealias SerializationRequirement = Codable
+  public typealias SerializationRequirement = Codable
 
-    public func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
-    func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
-    // expected-error@-1{{method 'decodeNextArgument()' must be as accessible as its enclosing type because it matches a requirement in protocol 'DistributedTargetInvocationDecoder'}}
-    func decodeReturnType() throws -> Any.Type? { nil }
-    // expected-error@-1{{method 'decodeReturnType()' must be declared public because it matches a requirement in public protocol 'DistributedTargetInvocationDecoder'}}
-    // expected-note@-2{{mark the instance method as 'public' to satisfy the requirement}}
-    func decodeErrorType() throws -> Any.Type? { nil }
-    // expected-error@-1{{method 'decodeErrorType()' must be declared public because it matches a requirement in public protocol 'DistributedTargetInvocationDecoder'}}
-    // expected-note@-2{{mark the instance method as 'public' to satisfy the requirement}}
+  public func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
+  func decodeNextArgument<Argument: SerializationRequirement>() throws -> Argument { fatalError() }
+  // expected-error@-1{{method 'decodeNextArgument()' must be as accessible as its enclosing type because it matches a requirement in protocol 'DistributedTargetInvocationDecoder'}}
+  func decodeReturnType() throws -> Any.Type? { nil }
+  // expected-error@-1{{method 'decodeReturnType()' must be declared public because it matches a requirement in public protocol 'DistributedTargetInvocationDecoder'}}
+  // expected-note@-2{{mark the instance method as 'public' to satisfy the requirement}}
+  func decodeErrorType() throws -> Any.Type? { nil }
+  // expected-error@-1{{method 'decodeErrorType()' must be declared public because it matches a requirement in public protocol 'DistributedTargetInvocationDecoder'}}
+  // expected-note@-2{{mark the instance method as 'public' to satisfy the requirement}}
 }
 
 final class PublicFakeInvocationDecoder_badBadProtoRequirement: DistributedTargetInvocationDecoder {
-    // expected-error@-1{{class 'PublicFakeInvocationDecoder_badBadProtoRequirement' is missing witness for protocol requirement 'decodeNextArgument'}}
-    // expected-note@-2{{protocol 'PublicFakeInvocationDecoder_badBadProtoRequirement' requires function 'decodeNextArgument' with signature:}}
-    typealias SerializationRequirement = Codable
+  // expected-error@-1{{class 'PublicFakeInvocationDecoder_badBadProtoRequirement' is missing witness for protocol requirement 'decodeNextArgument'}}
+  // expected-note@-2{{protocol 'PublicFakeInvocationDecoder_badBadProtoRequirement' requires function 'decodeNextArgument' with signature:}}
+  typealias SerializationRequirement = Codable
 
-    func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
-    func decodeNextArgument<Argument: SomeProtocol>() throws -> Argument { fatalError() }
-    func decodeReturnType() throws -> Any.Type? { nil }
-    func decodeErrorType() throws -> Any.Type? { nil }
+  func decodeGenericSubstitutions() throws -> [Any.Type] { [] }
+  func decodeNextArgument<Argument: SomeProtocol>() throws -> Argument { fatalError() }
+  func decodeReturnType() throws -> Any.Type? { nil }
+  func decodeErrorType() throws -> Any.Type? { nil }
 }
 
 public struct FakeResultHandler: DistributedTargetInvocationResultHandler {
-    public typealias SerializationRequirement = Codable
+  public typealias SerializationRequirement = Codable
 
-    public func onReturn<Success: SerializationRequirement>(value: Success) async throws {
-        print("RETURN: \(value)")
-    }
-    public func onReturnVoid() async throws {
-        print("RETURN VOID")
-    }
-    public func onThrow<Err: Error>(error: Err) async throws {
-        print("ERROR: \(error)")
-    }
+  public func onReturn<Success: SerializationRequirement>(value: Success) async throws {
+    print("RETURN: \(value)")
+  }
+  public func onReturnVoid() async throws {
+    print("RETURN VOID")
+  }
+  public func onThrow<Err: Error>(error: Err) async throws {
+    print("ERROR: \(error)")
+  }
 }
 
 struct AnyResultHandler: DistributedTargetInvocationResultHandler {
-    typealias SerializationRequirement = Any
+  typealias SerializationRequirement = Any
 
-    func onReturn<Success: SerializationRequirement>(value: Success) async throws {
-        print("RETURN: \(value)")
-    }
-    func onReturnVoid() async throws {
-        print("RETURN VOID")
-    }
-    func onThrow<Err: Error>(error: Err) async throws {
-        print("ERROR: \(error)")
-    }
+  func onReturn<Success: SerializationRequirement>(value: Success) async throws {
+    print("RETURN: \(value)")
+  }
+  func onReturnVoid() async throws {
+    print("RETURN VOID")
+  }
+  func onThrow<Err: Error>(error: Err) async throws {
+    print("ERROR: \(error)")
+  }
 }
 struct LargeSerializationReqFakeInvocationResultHandler: DistributedTargetInvocationResultHandler {
-    typealias SerializationRequirement = Codable & SomeProtocol
+  typealias SerializationRequirement = Codable & SomeProtocol
 
-    func onReturn<Success: SerializationRequirement>(value: Success) async throws {
-        print("RETURN: \(value)")
-    }
-    func onReturnVoid() async throws {
-        print("RETURN VOID")
-    }
-    func onThrow<Err: Error>(error: Err) async throws {
-        print("ERROR: \(error)")
-    }
+  func onReturn<Success: SerializationRequirement>(value: Success) async throws {
+    print("RETURN: \(value)")
+  }
+  func onReturnVoid() async throws {
+    print("RETURN VOID")
+  }
+  func onThrow<Err: Error>(error: Err) async throws {
+    print("ERROR: \(error)")
+  }
 }
 
 struct BadResultHandler_missingOnReturn: DistributedTargetInvocationResultHandler {
-    // expected-error@-1{{struct 'BadResultHandler_missingOnReturn' is missing witness for protocol requirement 'onReturn'}}
-    // expected-note@-2{{protocol 'BadResultHandler_missingOnReturn' requires function 'onReturn' with signature:}}
-    typealias SerializationRequirement = Codable
+  // expected-error@-1{{struct 'BadResultHandler_missingOnReturn' is missing witness for protocol requirement 'onReturn'}}
+  // expected-note@-2{{protocol 'BadResultHandler_missingOnReturn' requires function 'onReturn' with signature:}}
+  typealias SerializationRequirement = Codable
 
-    // func onReturn<Res: SerializationRequirement>(value: Res) async throws {} // MISSING
-    func onReturnVoid() async throws {}
-    func onThrow<Err: Error>(error: Err) async throws {}
+  // func onReturn<Res: SerializationRequirement>(value: Res) async throws {} // MISSING
+  func onReturnVoid() async throws {}
+  func onThrow<Err: Error>(error: Err) async throws {}
 }
 struct BadResultHandler_missingRequirement: DistributedTargetInvocationResultHandler {
-    // expected-error@-1{{struct 'BadResultHandler_missingRequirement' is missing witness for protocol requirement 'onReturn'}}
-    // expected-note@-2{{protocol 'BadResultHandler_missingRequirement' requires function 'onReturn' with signature:}}
-    typealias SerializationRequirement = Codable
+  // expected-error@-1{{struct 'BadResultHandler_missingRequirement' is missing witness for protocol requirement 'onReturn'}}
+  // expected-note@-2{{protocol 'BadResultHandler_missingRequirement' requires function 'onReturn' with signature:}}
+  typealias SerializationRequirement = Codable
 
-    func onReturn<Success>(value: Success) async throws {} // MISSING : Codable
-    func onReturnVoid() async throws {}
-    func onThrow<Err: Error>(error: Err) async throws {}
+  func onReturn<Success>(value: Success) async throws {} // MISSING : Codable
+  func onReturnVoid() async throws {}
+  func onThrow<Err: Error>(error: Err) async throws {}
 }
 
 public struct PublicFakeResultHandler: DistributedTargetInvocationResultHandler {
-    public typealias SerializationRequirement = Codable
+  public typealias SerializationRequirement = Codable
 
-    public func onReturn<Success: SerializationRequirement>(value: Success) async throws {
-        print("RETURN: \(value)")
-    }
-    public func onReturnVoid() async throws {
-        print("RETURN VOID")
-    }
-    public func onThrow<Err: Error>(error: Err) async throws {
-        print("ERROR: \(error)")
-    }
+  public func onReturn<Success: SerializationRequirement>(value: Success) async throws {
+    print("RETURN: \(value)")
+  }
+  public func onReturnVoid() async throws {
+    print("RETURN VOID")
+  }
+  public func onThrow<Err: Error>(error: Err) async throws {
+    print("ERROR: \(error)")
+  }
 }
 

--- a/test/IRGen/distributed_actor.swift
+++ b/test/IRGen/distributed_actor.swift
@@ -6,7 +6,7 @@
 import Distributed
 
 // Type descriptor.
-// CHECK-LABEL: @"$s17distributed_actor7MyActorC2id11Distributed012LocalTestingD7AddressVvpWvd"
+// CHECK-LABEL: @"$s17distributed_actor7MyActorC2id11Distributed012LocalTestingD2IDVvpWvd"
 @available(SwiftStdlib 5.6, *)
 public distributed actor MyActor {
   public typealias ActorSystem = LocalTestingDistributedActorSystem


### PR DESCRIPTION
Resolves rdar://92712849 - the root cause of all those issues
Resolves rdar://92910719 - which disabled the still failing test since the workaround was not good enough

This is the actual solution for all our mystical offset issues -- the order of the synthesized AST fields MUST match the order IRGen enforces (and the DA needs in any case); where the id and system are the FIRST fields, and must be specifically: id, system because that's what IRGen emits and many places seem to expect the order matches between the original AST and whatever gets derived form it and IR.

This probably also resolves a few other crashers we had with similar crash reasons of weird mismatching offsets, I'll be verifying those.