### PR TITLE
🍒[5.7-04182022][Distributed] Force the order of properties in AST

### DIFF
--- a/lib/Sema/DerivedConformanceDistributedActor.cpp
+++ b/lib/Sema/DerivedConformanceDistributedActor.cpp
@@ -426,7 +426,6 @@ static FuncDecl *deriveDistributedActorSystem_invokeHandlerOnReturn(
 /******************************* PROPERTIES ***********************************/
 /******************************************************************************/
 
-// TODO(distributed): make use of this after all, but FORCE it?
 static ValueDecl *deriveDistributedActor_id(DerivedConformance &derived) {
   assert(derived.Nominal->isDistributedActor());
   auto &C = derived.Context;
@@ -480,17 +479,12 @@ static ValueDecl *deriveDistributedActor_actorSystem(
   // `actorSystem` MUST be the second field, because for a remote instance
   // we don't allocate memory after those two fields, so their order is very
   // important. The `hint` below makes sure the system is inserted right after.
-  if (auto id = derived.Nominal->getDistributedActorIDProperty()) {
-    derived.addMemberToConformanceContext(pbDecl, /*hint=*/id);
-    derived.addMemberToConformanceContext(propDecl, /*hint=*/id);
-  } else {
-    // it will be synthesized next, and will insert at head,
-    // so in order for system to be SECOND (as it must be),
-    // we'll insert at head right now and as id gets synthesized we'll get
-    // the correct order: id, actorSystem.
-    derived.addMemberToConformanceContext(pbDecl, /*insertAtHead==*/true);
-    derived.addMemberToConformanceContext(propDecl, /*insertAtHead=*/true);
-  }
+  auto id = derived.Nominal->getDistributedActorIDProperty();
+  assert(id && "id must be synthesized first, so it is the first field of any "
+               "distributed actor (followed by actorSystem)");
+
+  derived.addMemberToConformanceContext(pbDecl, /*hint=*/id);
+  derived.addMemberToConformanceContext(propDecl, /*hint=*/id);
 
   return propDecl;
 }

--- a/lib/Sema/DerivedConformanceDistributedActor.cpp
+++ b/lib/Sema/DerivedConformanceDistributedActor.cpp
@@ -426,6 +426,32 @@ static FuncDecl *deriveDistributedActorSystem_invokeHandlerOnReturn(
 /******************************* PROPERTIES ***********************************/
 /******************************************************************************/
 
+// TODO(distributed): make use of this after all, but FORCE it?
+static ValueDecl *deriveDistributedActor_id(DerivedConformance &derived) {
+  assert(derived.Nominal->isDistributedActor());
+  auto &C = derived.Context;
+
+  // ```
+  // nonisolated let id: Self.ID // Self.ActorSystem.ActorID
+  // ```
+  auto propertyType = getDistributedActorIDType(derived.Nominal);
+
+  VarDecl *propDecl;
+  PatternBindingDecl *pbDecl;
+  std::tie(propDecl, pbDecl) = derived.declareDerivedProperty(
+      DerivedConformance::SynthesizedIntroducer::Let, C.Id_id, propertyType,
+      propertyType,
+      /*isStatic=*/false, /*isFinal=*/true);
+
+  // mark as nonisolated, allowing access to it from everywhere
+  propDecl->getAttrs().add(
+      new (C) NonisolatedAttr(/*IsImplicit=*/true));
+
+  derived.addMemberToConformanceContext(pbDecl, /*insertAtHead=*/true);
+  derived.addMemberToConformanceContext(propDecl, /*insertAtHead=*/true);
+  return propDecl;
+}
+
 static ValueDecl *deriveDistributedActor_actorSystem(
     DerivedConformance &derived) {
   auto &C = derived.Context;
@@ -454,9 +480,17 @@ static ValueDecl *deriveDistributedActor_actorSystem(
   // `actorSystem` MUST be the second field, because for a remote instance
   // we don't allocate memory after those two fields, so their order is very
   // important. The `hint` below makes sure the system is inserted right after.
-  auto id = derived.Nominal->getDistributedActorIDProperty();
-  derived.addMemberToConformanceContext(pbDecl, /*hint=*/id);
-  derived.addMemberToConformanceContext(propDecl, /*hint=*/id);
+  if (auto id = derived.Nominal->getDistributedActorIDProperty()) {
+    derived.addMemberToConformanceContext(pbDecl, /*hint=*/id);
+    derived.addMemberToConformanceContext(propDecl, /*hint=*/id);
+  } else {
+    // it will be synthesized next, and will insert at head,
+    // so in order for system to be SECOND (as it must be),
+    // we'll insert at head right now and as id gets synthesized we'll get
+    // the correct order: id, actorSystem.
+    derived.addMemberToConformanceContext(pbDecl, /*insertAtHead==*/true);
+    derived.addMemberToConformanceContext(propDecl, /*insertAtHead=*/true);
+  }
 
   return propDecl;
 }
@@ -551,14 +585,11 @@ deriveDistributedActorType_SerializationRequirement(
 
 ValueDecl *DerivedConformance::deriveDistributedActor(ValueDecl *requirement) {
   if (auto var = dyn_cast<VarDecl>(requirement)) {
+    if (var->getName() == Context.Id_id)
+      return deriveDistributedActor_id(*this);
+
     if (var->getName() == Context.Id_actorSystem)
       return deriveDistributedActor_actorSystem(*this);
-
-    if (var->getName() == Context.Id_id)
-      llvm_unreachable("DistributedActor.id MUST be synthesized earlier, "
-                       "because it is forced by the Identifiable conformance. "
-                       "If we attempted to do synthesis here, the earlier phase "
-                       "failed and something is wrong: please report a bug.");
   }
 
   if (auto func = dyn_cast<FuncDecl>(requirement)) {

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -51,6 +51,18 @@ void DerivedConformance::addMembersToConformanceContext(
     IDC->addMember(child);
 }
 
+void DerivedConformance::addMemberToConformanceContext(
+    Decl *member, Decl *hint) {
+  auto IDC = cast<IterableDeclContext>(ConformanceDecl);
+  IDC->addMember(member, hint, /*insertAtHead=*/false);
+}
+
+void DerivedConformance::addMemberToConformanceContext(
+    Decl *member, bool insertAtHead) {
+  auto IDC = cast<IterableDeclContext>(ConformanceDecl);
+  IDC->addMember(member, /*hint=*/nullptr, insertAtHead);
+}
+
 Type DerivedConformance::getProtocolType() const {
   return Protocol->getDeclaredInterfaceType();
 }
@@ -324,10 +336,6 @@ ValueDecl *DerivedConformance::getDerivableRequirement(NominalTypeDecl *nominal,
     // Actor.unownedExecutor
     if (name.isSimpleName(ctx.Id_unownedExecutor))
       return getRequirement(KnownProtocolKind::Actor);
-
-    // DistributedActor.id
-    if(name.isSimpleName(ctx.Id_id))
-      return getRequirement(KnownProtocolKind::DistributedActor);
 
     // DistributedActor.actorSystem
     if(name.isSimpleName(ctx.Id_actorSystem))

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -337,6 +337,10 @@ ValueDecl *DerivedConformance::getDerivableRequirement(NominalTypeDecl *nominal,
     if (name.isSimpleName(ctx.Id_unownedExecutor))
       return getRequirement(KnownProtocolKind::Actor);
 
+    // DistributedActor.id
+    if(name.isSimpleName(ctx.Id_id))
+      return getRequirement(KnownProtocolKind::DistributedActor);
+
     // DistributedActor.actorSystem
     if(name.isSimpleName(ctx.Id_actorSystem))
       return getRequirement(KnownProtocolKind::DistributedActor);

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -70,6 +70,10 @@ public:
 
   /// Add \c children as members of the context that declares the conformance.
   void addMembersToConformanceContext(ArrayRef<Decl *> children);
+  /// Add \c member right after the \c hint member which may be the tail
+  void addMemberToConformanceContext(Decl *member, Decl* hint);
+  /// Add \c member in front of any other existing members
+  void addMemberToConformanceContext(Decl *member, bool insertAtHead);
 
   /// Get the declared type of the protocol that this is conformance is for.
   Type getProtocolType() const;

--- a/stdlib/public/Distributed/LocalTestingDistributedActorSystem.swift
+++ b/stdlib/public/Distributed/LocalTestingDistributedActorSystem.swift
@@ -27,7 +27,7 @@ import WinSDK
 /// prototyping stages of development where a real system is not necessary yet.
 @available(SwiftStdlib 5.7, *)
 public final class LocalTestingDistributedActorSystem: DistributedActorSystem, @unchecked Sendable {
-  public typealias ActorID = LocalTestingActorAddress
+  public typealias ActorID = LocalTestingActorID
   public typealias ResultHandler = LocalTestingInvocationResultHandler
   public typealias InvocationEncoder = LocalTestingInvocationEncoder
   public typealias InvocationDecoder = LocalTestingInvocationDecoder
@@ -115,32 +115,45 @@ public final class LocalTestingDistributedActorSystem: DistributedActorSystem, @
 
     init() {}
 
-    mutating func next() -> LocalTestingActorAddress {
+    mutating func next() -> LocalTestingActorID {
       let id: Int = self.counterLock.withLock {
         self.counter += 1
         return self.counter
       }
-      return LocalTestingActorAddress(parse: "\(id)")
+      return LocalTestingActorID(id: "\(id)")
     }
   }
 }
 
 @available(SwiftStdlib 5.7, *)
-public struct LocalTestingActorAddress: Hashable, Sendable, Codable {
-  public let address: String
+@available(*, deprecated, renamed: "LocalTestingActorID")
+public typealias LocalTestingActorAddress = LocalTestingActorID
 
-  public init(parse address: String) {
-    self.address = address
+@available(SwiftStdlib 5.7, *)
+public struct LocalTestingActorID: Hashable, Sendable, Codable {
+  @available(*, deprecated, renamed: "id")
+  public var address: String {
+    self.id
+  }
+  public let id: String
+
+  @available(*, deprecated, renamed: "init(id:)")
+  public init(parse id: String) {
+    self.id = id
+  }
+
+  public init(id: String) {
+    self.id = id
   }
 
   public init(from decoder: Decoder) throws {
     let container = try decoder.singleValueContainer()
-    self.address = try container.decode(String.self)
+    self.id = try container.decode(String.self)
   }
 
   public func encode(to encoder: Encoder) throws {
     var container = encoder.singleValueContainer()
-    try container.encode(self.address)
+    try container.encode(self.id)
   }
 }
 

--- a/test/Distributed/Inputs/EchoActor.swift
+++ b/test/Distributed/Inputs/EchoActor.swift
@@ -14,7 +14,7 @@
 
 import Distributed
 
-distributed actor Echo /* in the mirror */{
+distributed actor Echo /* in the mirror */ {
   typealias ActorSystem = LocalTestingDistributedActorSystem
 
   distributed func echo(_ input: String) -> String {

--- a/test/Distributed/Runtime/distributed_actor_in_other_module.swift
+++ b/test/Distributed/Runtime/distributed_actor_in_other_module.swift
@@ -8,7 +8,6 @@
 // REQUIRES: concurrency
 // REQUIRES: distributed
 
-
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 

--- a/test/Distributed/Runtime/distributed_actor_init_local.swift
+++ b/test/Distributed/Runtime/distributed_actor_init_local.swift
@@ -255,7 +255,7 @@ func test() async {
   // CHECK-NOT: ready
   // CHECK: resign id:ActorAddress(address: "[[ID5]]")
 
-  test.append(await PickATransport2(other: 1, thesystem: system))
+  test.append(await PickATransport2(other: 1, theSystem: system))
   // CHECK: assign type:PickATransport2, id:ActorAddress(address: "[[ID6:.*]]")
   // CHECK: ready actor:main.PickATransport2, id:ActorAddress(address: "[[ID6]]")
 

--- a/test/Distributed/Runtime/distributed_actor_init_local.swift
+++ b/test/Distributed/Runtime/distributed_actor_init_local.swift
@@ -8,6 +8,10 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
+// FIXME(distributed): 5.7 branches seem to be missing something; as `main + 32bit watch` does not crash on DA usage with the local testing actor system, but 5.7 does.
+// rdar://92952551
+// UNSUPPORTED: OS=watchos
+
 import Distributed
 
 enum MyError: Error {

--- a/test/Distributed/Runtime/distributed_actor_init_local.swift
+++ b/test/Distributed/Runtime/distributed_actor_init_local.swift
@@ -21,8 +21,8 @@ distributed actor PickATransport1 {
 }
 
 distributed actor PickATransport2 {
-  init(other: Int, thesystem: FakeActorSystem) async {
-    self.actorSystem = thesystem
+  init(other: Int, theSystem: FakeActorSystem) async {
+    self.actorSystem = theSystem
   }
 }
 
@@ -89,6 +89,17 @@ distributed actor MaybeAfterAssign {
     x = 100
   }
 }
+
+distributed actor LocalTestingDA_Int {
+  typealias ActorSystem = LocalTestingDistributedActorSystem
+  var int: Int
+  init() {
+    actorSystem = .init()
+    int = 12
+    // CRASH
+  }
+}
+
 
 // ==== Fake Transport ---------------------------------------------------------
 
@@ -261,6 +272,10 @@ func test() async {
   test.append(MaybeAfterAssign(fail: false))
   // CHECK:      assign type:MaybeAfterAssign, id:ActorAddress(address: "[[ID10:.*]]")
   // CHECK-NEXT: ready actor:main.MaybeAfterAssign, id:ActorAddress(address: "[[ID10]]")
+
+  let localDA = LocalTestingDA_Int()
+  print("localDA = \(localDA.id)")
+  // CHECK: localDA = LocalTestingActorID(id: "1")
 
   // the following tests fail to initialize the actor's identity.
   print("-- start of no-assign tests --")

--- a/test/IRGen/distributed_actor.swift
+++ b/test/IRGen/distributed_actor.swift
@@ -6,7 +6,7 @@
 import Distributed
 
 // Type descriptor.
-// CHECK-LABEL: @"$s17distributed_actor7MyActorC2id11Distributed012LocalTestingD7AddressVvpWvd"
+// CHECK-LABEL: @"$s17distributed_actor7MyActorC2id11Distributed012LocalTestingD2IDVvpWvd"
 @available(SwiftStdlib 5.6, *)
 public distributed actor MyActor {
   public typealias ActorSystem = LocalTestingDistributedActorSystem


### PR DESCRIPTION
Issue Summary:
- Using the LocalTestingDistributedActorSystem crashes without this fix.
- In general, using distributed actor systems declared in library evolution mode compiled modules would fail

Original PR: https://github.com/apple/swift/pull/58745
Radar: 
- rdar://92712849 - the root cause of all those issues
- rdar://92910719 - which disabled the still failing test since the workaround was not good enough

Risk: Low, no impact on adopters


Details: 

This is the actual solution for all our mystical offset issues -- the order of the synthesized AST fields MUST match the order IRGen enforces (and the DA needs in any case); where the id and system are the FIRST fields, and must be specifically: id, system because that's what IRGen emits and many places seem to expect the order matches between the original AST and whatever gets derived form it and IR.

This probably also resolves a few other crashers we had with similar crash reasons of weird mismatching offsets, I'll be verifying those.