### PR TITLE
[Distributed] revert too aggressive synthesis removal, and fix it instead

### DIFF
--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -337,6 +337,10 @@ ValueDecl *DerivedConformance::getDerivableRequirement(NominalTypeDecl *nominal,
     if (name.isSimpleName(ctx.Id_unownedExecutor))
       return getRequirement(KnownProtocolKind::Actor);
 
+    // DistributedActor.id
+    if(name.isSimpleName(ctx.Id_id))
+      return getRequirement(KnownProtocolKind::DistributedActor);
+
     // DistributedActor.actorSystem
     if(name.isSimpleName(ctx.Id_actorSystem))
       return getRequirement(KnownProtocolKind::DistributedActor);

--- a/stdlib/public/Distributed/LocalTestingDistributedActorSystem.swift
+++ b/stdlib/public/Distributed/LocalTestingDistributedActorSystem.swift
@@ -124,6 +124,7 @@ public final class LocalTestingDistributedActorSystem: DistributedActorSystem, @
   }
 }
 
+@available(SwiftStdlib 5.7, *)
 @available(*, deprecated, renamed: "LocalTestingActorID")
 public typealias LocalTestingActorAddress = LocalTestingActorID
 

--- a/stdlib/public/Distributed/LocalTestingDistributedActorSystem.swift
+++ b/stdlib/public/Distributed/LocalTestingDistributedActorSystem.swift
@@ -124,7 +124,6 @@ public final class LocalTestingDistributedActorSystem: DistributedActorSystem, @
   }
 }
 
-@available(SwiftStdlib 5.7, *)
 @available(*, deprecated, renamed: "LocalTestingActorID")
 public typealias LocalTestingActorAddress = LocalTestingActorID
 

--- a/test/Distributed/Runtime/distributed_actor_in_other_module.swift
+++ b/test/Distributed/Runtime/distributed_actor_in_other_module.swift
@@ -8,7 +8,6 @@
 // REQUIRES: concurrency
 // REQUIRES: distributed
 
-
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 


### PR DESCRIPTION
A disabled test (due to non-deterministic asan issues) missed to catch that this just removed in https://github.com/apple/swift/pull/58745 code path IS still necessary because other codepaths taken during multi module cases.

This brings back the previously removed synthesis, and instead, makes sure that when it happens we also synthesize in the expected order of the fields: id, actorSystem.

This will be picked right away into: https://github.com/apple/swift/pull/58747 and https://github.com/apple/swift/pull/58748 as they contained the too aggressive code removal.