### PR TITLE
[SwiftCompilerSources] Make Package.swift static

### DIFF
--- a/SwiftCompilerSources/.gitignore
+++ b/SwiftCompilerSources/.gitignore
@@ -1,0 +1,1 @@
+.swiftpm

--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -267,25 +267,3 @@ else()
   endif()
 
 endif()
-
-# Configure 'SwiftCompilerModules' SwiftPM package. The 'Package.swift' will
-# be created at '${build_dir}/SwiftCompilerModulesPackage/Package.swift' and can
-# be built with 'swift-build'.
-# Note that this SwiftPM package itself is just for development purposes, and
-# is not actually used for the compiler building. 
-set(swiftcompiler_modules_package_directory
-    "${SWIFT_BINARY_DIR}/SwiftCompilerModulesPackage")
-configure_file(Package.swift.in
-  "${swiftcompiler_modules_package_directory}/Package.swift" @ONLY)
-# SwiftPM requires all sources are inside the directory of 'Package.swift'.
-# Create symlinks to the actual source directories.
-execute_process(COMMAND
-  "${CMAKE_COMMAND}" -E create_symlink
-  "${CMAKE_CURRENT_SOURCE_DIR}/Sources"
-  "${swiftcompiler_modules_package_directory}/Sources")
-if(SWIFT_BUILD_REGEX_PARSER_IN_COMPILER)
-  execute_process(COMMAND
-    "${CMAKE_COMMAND}" -E create_symlink
-    "${EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR}/Sources/_RegexParser"
-    "${swiftcompiler_modules_package_directory}/_RegexParser_Sources")
-endif()

--- a/SwiftCompilerSources/Package.swift
+++ b/SwiftCompilerSources/Package.swift
@@ -11,10 +11,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// NOTE: This 'Package.swift.in' file is for CMake configure_file().
-// Generated 'Package.swift' can be found in
-// '${swift_build_dir}/SwiftCompilerSources/Package.swift'.
-
 import PackageDescription
 
 private extension Target {
@@ -23,9 +19,7 @@ private extension Target {
       "-Xfrontend", "-validate-tbd-against-ir=none",
       "-Xfrontend", "-enable-cxx-interop",
       // Bridging modules and headers
-      "-Xcc", "-I", "-Xcc", "@SWIFT_SOURCE_DIR@/include",
-      // Generated C headers
-      "-Xcc", "-I", "-Xcc", "@CMAKE_BINARY_DIR@/include",
+      "-Xcc", "-I", "-Xcc", "../include",
       "-cross-module-optimization"
     ]),
   ]

--- a/SwiftCompilerSources/_RegexParser_Sources
+++ b/SwiftCompilerSources/_RegexParser_Sources
@@ -1,0 +1,1 @@
+../../swift-experimental-string-processing/Sources/_RegexParser


### PR DESCRIPTION
`Package.swift` in the build directory and symlinking Sources directory wasn't great for source control and break points. Since C modules doesn't need the generated headers at this point, make `Package.swift` static again with a symlink to the string processing source directory.
