### PR TITLE
swiftinterface: print _specialize functions with targetFunction parameter in .swiftinterface

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -107,6 +107,17 @@ static bool isPublicOrUsableFromInline(Type ty) {
   });
 }
 
+static bool isPrespecilizationDeclWithTarget(const ValueDecl *vd) {
+  // Add exported prespecialized symbols.
+  for (auto *attr : vd->getAttrs().getAttributes<SpecializeAttr>()) {
+    if (!attr->isExported())
+      continue;
+    if (auto *targetFun = attr->getTargetFunctionDecl(vd))
+      return true;
+  }
+  return false;
+}
+
 static bool contributesToParentTypeStorage(const AbstractStorageDecl *ASD) {
   auto *DC = ASD->getDeclContext()->getAsDecl();
   if (!DC) return false;
@@ -177,9 +188,11 @@ PrintOptions PrintOptions::printSwiftInterfaceFile(ModuleDecl *ModuleToPrint,
       if (!options.PrintSPIs && D->isSPI())
         return false;
 
-      // Skip anything that isn't 'public' or '@usableFromInline'.
+      // Skip anything that isn't 'public' or '@usableFromInline' or has a
+      // _specialize attribute with a targetFunction parameter.
       if (auto *VD = dyn_cast<ValueDecl>(D)) {
-        if (!isPublicOrUsableFromInline(VD)) {
+        if (!isPublicOrUsableFromInline(VD) &&
+            !isPrespecilizationDeclWithTarget(VD)) {
           // We do want to print private stored properties, without their
           // original names present.
           if (auto *ASD = dyn_cast<AbstractStorageDecl>(VD))

--- a/test/ModuleInterface/attrs.swift
+++ b/test/ModuleInterface/attrs.swift
@@ -18,3 +18,12 @@
   // CHECK-NEXT: public var y: Swift.Int
   public var y: Int
 } // CHECK-NEXT: {{^}$}}
+
+public func someGenericFunction<T>(_ t: T) -> Int { return 0 }
+
+// CHECK: @_specialize(exported: true, kind: full, target: someGenericFunction(_:), where T == Swift.Int)
+// CHECK: internal func __specialize_someGenericFunction<T>(_ t: T)
+@_specialize(exported: true, target: someGenericFunction(_:), where T == Int)
+internal func __specialize_someGenericFunction<T>(_ t: T) -> Int {
+    fatalError("don't call")
+}


### PR DESCRIPTION
If we have an internal function with a `_specialize` attribute that has
a `targetFunction:` parameter we want the function to appear in the
.swiftinterface file such that the exported specialization can be picked up by
the compiler.