### PR TITLE
SR-15138: Unused Parameter in SILFunction.init()

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -390,11 +390,11 @@ private:
 
   SILFunction(SILModule &module, SILLinkage linkage, StringRef mangledName,
               CanSILFunctionType loweredType, GenericEnvironment *genericEnv,
-              Optional<SILLocation> loc, IsBare_t isBareSILFunction,
-              IsTransparent_t isTrans, IsSerialized_t isSerialized,
-              ProfileCounter entryCount, IsThunk_t isThunk,
-              SubclassScope classSubclassScope, Inline_t inlineStrategy,
-              EffectsKind E, const SILDebugScope *debugScope,
+              IsBare_t isBareSILFunction, IsTransparent_t isTrans,
+              IsSerialized_t isSerialized, ProfileCounter entryCount,
+              IsThunk_t isThunk, SubclassScope classSubclassScope,
+              Inline_t inlineStrategy, EffectsKind E,
+              const SILDebugScope *debugScope,
               IsDynamicallyReplaceable_t isDynamic,
               IsExactSelfClass_t isExactSelfClass,
               IsDistributed_t isDistributed);
@@ -402,11 +402,9 @@ private:
   static SILFunction *
   create(SILModule &M, SILLinkage linkage, StringRef name,
          CanSILFunctionType loweredType, GenericEnvironment *genericEnv,
-         Optional<SILLocation> loc, IsBare_t isBareSILFunction,
-         IsTransparent_t isTrans, IsSerialized_t isSerialized,
+         IsBare_t isBareSILFunction, IsTransparent_t isTrans, IsSerialized_t isSerialized,
          ProfileCounter entryCount, IsDynamicallyReplaceable_t isDynamic,
-         IsDistributed_t isDistributed,
-         IsExactSelfClass_t isExactSelfClass,
+         IsDistributed_t isDistributed, IsExactSelfClass_t isExactSelfClass,
          IsThunk_t isThunk = IsNotThunk,
          SubclassScope classSubclassScope = SubclassScope::NotApplicable,
          Inline_t inlineStrategy = InlineDefault,
@@ -414,18 +412,14 @@ private:
          SILFunction *InsertBefore = nullptr,
          const SILDebugScope *DebugScope = nullptr);
 
-  void init(SILLinkage Linkage, StringRef Name,
-                         CanSILFunctionType LoweredType,
-                         GenericEnvironment *genericEnv,
-                         Optional<SILLocation> Loc, IsBare_t isBareSILFunction,
-                         IsTransparent_t isTrans, IsSerialized_t isSerialized,
-                         ProfileCounter entryCount, IsThunk_t isThunk,
-                         SubclassScope classSubclassScope,
-                         Inline_t inlineStrategy, EffectsKind E,
-                         const SILDebugScope *DebugScope,
-                         IsDynamicallyReplaceable_t isDynamic,
-                         IsExactSelfClass_t isExactSelfClass,
-                         IsDistributed_t isDistributed);
+  void init(SILLinkage Linkage, StringRef Name, CanSILFunctionType LoweredType,
+            GenericEnvironment *genericEnv, IsBare_t isBareSILFunction,
+            IsTransparent_t isTrans, IsSerialized_t isSerialized,
+            ProfileCounter entryCount, IsThunk_t isThunk,
+            SubclassScope classSubclassScope, Inline_t inlineStrategy,
+            EffectsKind E, const SILDebugScope *DebugScope,
+            IsDynamicallyReplaceable_t isDynamic,
+            IsExactSelfClass_t isExactSelfClass, IsDistributed_t isDistributed);
 
   /// Set has ownership to the given value. True means that the function has
   /// ownership, false means it does not.
@@ -1333,7 +1327,6 @@ public:
   void viewCFG() const;
   /// Like ViewCFG, but the graph does not show the contents of basic blocks.
   void viewCFGOnly() const;
-
 };
 
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -82,8 +82,7 @@ void SILFunction::removeSpecializeAttr(SILSpecializeAttr *attr) {
 
 SILFunction *
 SILFunction::create(SILModule &M, SILLinkage linkage, StringRef name,
-                    CanSILFunctionType loweredType,
-                    GenericEnvironment *genericEnv, Optional<SILLocation> loc,
+                    CanSILFunctionType loweredType, GenericEnvironment *genericEnv,
                     IsBare_t isBareSILFunction, IsTransparent_t isTrans,
                     IsSerialized_t isSerialized, ProfileCounter entryCount,
                     IsDynamicallyReplaceable_t isDynamic,
@@ -108,17 +107,16 @@ SILFunction::create(SILModule &M, SILLinkage linkage, StringRef name,
     // Resurrect a zombie function.
     // This happens for example if a specialized function gets dead and gets
     // deleted. And afterwards the same specialization is created again.
-    fn->init(linkage, name, loweredType, genericEnv, loc, isBareSILFunction,
-             isTrans, isSerialized, entryCount, isThunk, classSubclassScope,
+    fn->init(linkage, name, loweredType, genericEnv, isBareSILFunction, isTrans,
+             isSerialized, entryCount, isThunk, classSubclassScope,
              inlineStrategy, E, debugScope, isDynamic, isExactSelfClass,
              isDistributed);
     assert(fn->empty());
   } else {
-    fn = new (M) SILFunction(M, linkage, name, loweredType, genericEnv, loc,
-                                isBareSILFunction, isTrans, isSerialized,
-                                entryCount, isThunk, classSubclassScope,
-                                inlineStrategy, E, debugScope,
-                                isDynamic, isExactSelfClass, isDistributed);
+    fn = new (M) SILFunction(
+        M, linkage, name, loweredType, genericEnv, isBareSILFunction, isTrans,
+        isSerialized, entryCount, isThunk, classSubclassScope, inlineStrategy,
+        E, debugScope, isDynamic, isExactSelfClass, isDistributed);
   }
   if (entry) entry->setValue(fn);
 
@@ -138,25 +136,21 @@ static FunctionParseFn parseFunction = nullptr;
 static FunctionCopyEffectsFn copyEffectsFunction = nullptr;
 static FunctionGetEffectFlagsFn getEffectFlagsFunction = nullptr;
 
-SILFunction::SILFunction(SILModule &Module, SILLinkage Linkage, StringRef Name,
-                         CanSILFunctionType LoweredType,
-                         GenericEnvironment *genericEnv,
-                         Optional<SILLocation> Loc, IsBare_t isBareSILFunction,
-                         IsTransparent_t isTrans, IsSerialized_t isSerialized,
-                         ProfileCounter entryCount, IsThunk_t isThunk,
-                         SubclassScope classSubclassScope,
-                         Inline_t inlineStrategy, EffectsKind E,
-                         const SILDebugScope *DebugScope,
-                         IsDynamicallyReplaceable_t isDynamic,
-                         IsExactSelfClass_t isExactSelfClass,
-                         IsDistributed_t isDistributed)
+SILFunction::SILFunction(
+    SILModule &Module, SILLinkage Linkage, StringRef Name,
+    CanSILFunctionType LoweredType, GenericEnvironment *genericEnv,
+    IsBare_t isBareSILFunction, IsTransparent_t isTrans,
+    IsSerialized_t isSerialized, ProfileCounter entryCount, IsThunk_t isThunk,
+    SubclassScope classSubclassScope, Inline_t inlineStrategy, EffectsKind E,
+    const SILDebugScope *DebugScope, IsDynamicallyReplaceable_t isDynamic,
+    IsExactSelfClass_t isExactSelfClass, IsDistributed_t isDistributed)
     : SwiftObjectHeader(functionMetatype), Module(Module),
       index(Module.getNewFunctionIndex()),
       Availability(AvailabilityContext::alwaysAvailable()) {
-  init(Linkage, Name, LoweredType, genericEnv, Loc, isBareSILFunction, isTrans,
-       isSerialized, entryCount, isThunk, classSubclassScope, inlineStrategy,
-       E, DebugScope, isDynamic, isExactSelfClass, isDistributed);
-  
+  init(Linkage, Name, LoweredType, genericEnv, isBareSILFunction, isTrans,
+       isSerialized, entryCount, isThunk, classSubclassScope, inlineStrategy, E,
+       DebugScope, isDynamic, isExactSelfClass, isDistributed);
+
   // Set our BB list to have this function as its parent. This enables us to
   // splice efficiently basic blocks in between functions.
   BlockList.Parent = this;
@@ -164,18 +158,14 @@ SILFunction::SILFunction(SILModule &Module, SILLinkage Linkage, StringRef Name,
     initFunction({this}, &libswiftSpecificData, sizeof(libswiftSpecificData));
 }
 
-void SILFunction::init(SILLinkage Linkage, StringRef Name,
-                         CanSILFunctionType LoweredType,
-                         GenericEnvironment *genericEnv,
-                         Optional<SILLocation> Loc, IsBare_t isBareSILFunction,
-                         IsTransparent_t isTrans, IsSerialized_t isSerialized,
-                         ProfileCounter entryCount, IsThunk_t isThunk,
-                         SubclassScope classSubclassScope,
-                         Inline_t inlineStrategy, EffectsKind E,
-                         const SILDebugScope *DebugScope,
-                         IsDynamicallyReplaceable_t isDynamic,
-                         IsExactSelfClass_t isExactSelfClass,
-                         IsDistributed_t isDistributed) {
+void SILFunction::init(
+    SILLinkage Linkage, StringRef Name, CanSILFunctionType LoweredType,
+    GenericEnvironment *genericEnv, IsBare_t isBareSILFunction,
+    IsTransparent_t isTrans, IsSerialized_t isSerialized,
+    ProfileCounter entryCount, IsThunk_t isThunk,
+    SubclassScope classSubclassScope, Inline_t inlineStrategy, EffectsKind E,
+    const SILDebugScope *DebugScope, IsDynamicallyReplaceable_t isDynamic,
+    IsExactSelfClass_t isExactSelfClass, IsDistributed_t isDistributed) {
   this->Name = Name;
   this->LoweredType = LoweredType;
   this->GenericEnv = genericEnv;
@@ -197,7 +187,7 @@ void SILFunction::init(SILLinkage Linkage, StringRef Name,
   this->IsDistributed = isDistributed;
   this->Inlined = false;
   this->Zombie = false;
-  this->HasOwnership = true,
+  this->HasOwnership = true;
   this->WasDeserializedCanonical = false;
   this->IsStaticallyLinked = false;
   this->IsWithoutActuallyEscapingThunk = false;
@@ -285,7 +275,6 @@ void SILFunction::numberValues(llvm::DenseMap<const SILNode*, unsigned> &
     }
   }
 }
-
 
 ASTContext &SILFunction::getASTContext() const {
   return getModule().getASTContext();
@@ -636,7 +625,6 @@ void SILFunction::viewCFG() const {
 void SILFunction::viewCFGOnly() const {
   viewCFGHelper(this, /*skipBBContents=*/true);
 }
-
 
 bool SILFunction::hasDynamicSelfMetadata() const {
   auto paramTypes =

--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -35,7 +35,7 @@ SILFunction *SILFunctionBuilder::getOrCreateFunction(
     return fn;
   }
 
-  auto fn = SILFunction::create(mod, linkage, name, type, nullptr, loc,
+  auto fn = SILFunction::create(mod, linkage, name, type, nullptr,
                                 isBareSILFunction, isTransparent, isSerialized,
                                 entryCount, isDynamic, isDistributed,
                                 IsNotExactSelfClass, isThunk, subclassScope);
@@ -295,7 +295,7 @@ SILFunction *SILFunctionBuilder::getOrCreateFunction(
     IsDistributed = IsDistributed_t::IsDistributed;
   }
 
-  auto *F = SILFunction::create(mod, linkage, name, constantType, nullptr, None,
+  auto *F = SILFunction::create(mod, linkage, name, constantType, nullptr,
                                 IsNotBare, IsTrans, IsSer, entryCount, IsDyn,
                                 IsDistributed, IsNotExactSelfClass,
                                 IsNotThunk, constant.getSubclassScope(),
@@ -362,7 +362,7 @@ SILFunction *SILFunctionBuilder::createFunction(
     IsThunk_t isThunk, SubclassScope subclassScope,
     Inline_t inlineStrategy, EffectsKind EK, SILFunction *InsertBefore,
     const SILDebugScope *DebugScope) {
-  return SILFunction::create(mod, linkage, name, loweredType, genericEnv, loc,
+  return SILFunction::create(mod, linkage, name, loweredType, genericEnv,
                              isBareSILFunction, isTrans, isSerialized,
                              entryCount, isDynamic, isDistributed,
                              IsNotExactSelfClass, isThunk, subclassScope,


### PR DESCRIPTION
**Reason**
 - Fixes SR-15138

**Content**

 - Deleted unused parameter from init()
 - Applied formatting to changed files
 - There also extra loc parameter in fabric function SILFunctionBuilder::createFunction(), but it will affect plenty of files.
 - So firstly I want to merge changes related to the initializer
