### PR TITLE
[docs] Add spot check for python architecture

### DIFF
--- a/docs/HowToGuides/GettingStarted.md
+++ b/docs/HowToGuides/GettingStarted.md
@@ -170,6 +170,7 @@ Double-check that running `pwd` prints a path ending with `swift`.
 
 * Run `cmake --version`: This should be 3.19.6 or higher.
 * Run `python3 --version`: Check that this succeeds.
+  * If you are on macOS and are building for both `arm64` and `x86_64` (e.g. when using `build-toolchain`), verify that both architectures are included in your python distribution using `file $(which python3)`. If you installed python via homebrew, it will likely only include the architecture of your build machine, resulting in `ld: symbol(s) not found` linker errors during the build.
 * Run `ninja --version`: Check that this succeeds.
 * Run `sccache --version`: Check that this succeeds.
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
If users installed a version of python that doesn't have all architectures and are building on macOS, they can get build errors mentioning missing symbols during the linking stage of LLVM. This can easily happen when installing some packages through homebrew, since homebrew only ever installs binaries of the build machine architecture. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves #58708