### PR TITLE
[runtime] Break loop in tuple dynamicCast checking

### DIFF
--- a/stdlib/public/runtime/DynamicCast.cpp
+++ b/stdlib/public/runtime/DynamicCast.cpp
@@ -1234,6 +1234,7 @@ tryCastToTuple(
   for (unsigned i = 0; typesMatch && i != numElements; ++i) {
     if (srcTupleType->getElement(i).Type != destTupleType->getElement(i).Type) {
       typesMatch = false;
+      break;
     }
   }
 


### PR DESCRIPTION
After finding that the tuple types aren't equal, break to avoid going through the whole tuple.