### PR TITLE
[CSClosure] Diagnose invalid re-declarations in multi-statement closures

### DIFF
--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -1188,10 +1188,6 @@ private:
     if (isa<IfConfigDecl>(decl))
       return;
 
-    // Variable declaration would be handled by a pattern binding.
-    if (isa<VarDecl>(decl))
-      return;
-
     // Generate constraints for pattern binding declarations.
     if (auto patternBinding = dyn_cast<PatternBindingDecl>(decl)) {
       SolutionApplicationTarget target(patternBinding);

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -234,6 +234,20 @@ func test_local_function_capturing_vars() {
   }
 }
 
+func test_test_invalid_redeclaration() {
+  func test(_: () -> Void) {
+  }
+
+  test {
+    let foo = 0 // expected-note {{'foo' previously declared here}}
+    let foo = foo // expected-error {{invalid redeclaration of 'foo'}}
+  }
+
+  test {
+    let (foo, foo) = (5, 6) // expected-error {{invalid redeclaration of 'foo'}} expected-note {{'foo' previously declared here}}
+  }
+}
+
 func test_pattern_ambiguity_doesnot_crash_compiler() {
   enum E {
   case hello(result: Int) // expected-note 2 {{found this candidate}}


### PR DESCRIPTION
Calling `typeCheckDecl` on `VarDecl` is what triggers re-declaration
checking and that was skipped by the solution application logic.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
