### PR TITLE
ModuleInterface: Print existential `any` in swiftinterfaces

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -144,6 +144,7 @@ PrintOptions PrintOptions::printSwiftInterfaceFile(ModuleDecl *ModuleToPrint,
       PrintOptions::FunctionRepresentationMode::Full;
   result.AlwaysTryPrintParameterLabels = true;
   result.PrintSPIs = printSPIs;
+  result.PrintExplicitAny = true;
 
   // We should print __consuming, __owned, etc for the module interface file.
   result.SkipUnderscoredKeywords = false;

--- a/test/ModuleInterface/existential-any.swift
+++ b/test/ModuleInterface/existential-any.swift
@@ -1,0 +1,37 @@
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name main
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name main
+// RUN: %FileCheck %s < %t.swiftinterface
+
+// CHECK: public protocol P
+public protocol P { }
+
+// CHECK: public protocol Q
+public protocol Q {
+  // CHECK: associatedtype A : main.P
+  associatedtype A: P
+}
+
+// CHECK: public func takesAndReturnsP(_ x: any main.P) -> any main.P
+public func takesAndReturnsP(_ x: P) -> P {
+  return x
+}
+
+// CHECK: public func takesAndReturnsOptionalP(_ x: (any main.P)?) -> (any main.P)?
+public func takesAndReturnsOptionalP(_ x: P?) -> P? {
+  return x
+}
+
+// CHECK: public func takesAndReturnsQ(_ x: any main.Q) -> any main.Q
+public func takesAndReturnsQ(_ x: any Q) -> any Q {
+  return x
+}
+
+// CHECK: public struct S
+public struct S {
+  // CHECK: public var p: any main.P
+  public var p: P
+  // CHECK: public var maybeP: (any main.P)?
+  public var maybeP: P?
+  // CHECK: public var q: any main.Q
+  public var q: any Q
+}

--- a/test/ModuleInterface/features.swift
+++ b/test/ModuleInterface/features.swift
@@ -89,7 +89,7 @@ public class OldSchool2: MP {
 // CHECK: public struct UsesRP {
 public struct UsesRP {
   // CHECK: #if compiler(>=5.3) && $RethrowsProtocol
-  // CHECK-NEXT:  public var value: FeatureTest.RP? {
+  // CHECK-NEXT:  public var value: (any FeatureTest.RP)? {
   // CHECK-NOT: #if compiler(>=5.3) && $RethrowsProtocol
   // CHECK: get
   public var value: RP? {

--- a/test/ModuleInterface/top-level-Type-and-Protocol.swift
+++ b/test/ModuleInterface/top-level-Type-and-Protocol.swift
@@ -18,7 +18,7 @@ public func usesType(_ x: Type) {}
 // CHECK: public func genericProtocol<T>(_ x: T) where T : MyModule.`Protocol`
 public func genericProtocol<T: Protocol>(_ x: T) {}
 
-// CHECK: public func existentialProtocol(_ x: MyModule.`Protocol`)
+// CHECK: public func existentialProtocol(_ x: any MyModule.`Protocol`)
 public func existentialProtocol(_ x: Protocol) {}
 
 // CHECK: public struct Parent {


### PR DESCRIPTION
Print existential `any` in swiftinterfaces since `any` is required for protocols with associated types in 5.7.

Resolves rdar://92976269
