### PR TITLE
[CodeCompletion] _compilerInitialized and _local are UserInaccessible

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -268,6 +268,7 @@ SIMPLE_DECL_ATTR(objcMembers, ObjCMembers,
   34)
 CONTEXTUAL_SIMPLE_DECL_ATTR(_compilerInitialized, CompilerInitialized,
   OnVar |
+  UserInaccessible |
   ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   35)
 CONTEXTUAL_SIMPLE_DECL_ATTR(__consuming, Consuming,
@@ -727,6 +728,7 @@ DECL_ATTR(_backDeploy, BackDeploy,
 
 CONTEXTUAL_SIMPLE_DECL_ATTR(_local, KnownToBeLocal,
   DeclModifier | OnFunc | OnParam | OnVar |
+  UserInaccessible |
   ABIBreakingToAdd | ABIBreakingToRemove |
   APIBreakingToAdd | APIBreakingToRemove,
   130)

--- a/test/SourceKit/CodeComplete/complete_override.swift.response
+++ b/test/SourceKit/CodeComplete/complete_override.swift.response
@@ -2,29 +2,9 @@
   key.results: [
     {
       key.kind: source.lang.swift.keyword,
-      key.name: "_compilerInitialized",
-      key.sourcetext: "_compilerInitialized",
-      key.description: "_compilerInitialized",
-      key.typename: "",
-      key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.notapplicable,
-      key.num_bytes_to_erase: 0
-    },
-    {
-      key.kind: source.lang.swift.keyword,
       key.name: "_const",
       key.sourcetext: "_const",
       key.description: "_const",
-      key.typename: "",
-      key.context: source.codecompletion.context.none,
-      key.typerelation: source.codecompletion.typerelation.notapplicable,
-      key.num_bytes_to_erase: 0
-    },
-    {
-      key.kind: source.lang.swift.keyword,
-      key.name: "_local",
-      key.sourcetext: "_local",
-      key.description: "_local",
       key.typename: "",
       key.context: source.codecompletion.context.none,
       key.typerelation: source.codecompletion.typerelation.notapplicable,


### PR DESCRIPTION
These declaration modifiers are not meant to be used from user source code. Mark them `UserInaccessible` so code completion don't show them.

rdar://92970201
