### PR TITLE
[5.7][Sema] Limit optional type variable hole propagation only to OptionalEvaluationExpr binding 

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1993,7 +1993,8 @@ bool TypeVariableBinding::attempt(ConstraintSystem &cs) const {
   // without any contextual information, so even though `x` would get
   // bound to result type of the chain, underlying type variable wouldn't
   // be resolved, so we need to propagate holes up the conversion chain.
-  if (TypeVar->getImpl().canBindToHole()) {
+  if (TypeVar->getImpl().canBindToHole() &&
+      srcLocator->directlyAt<OptionalEvaluationExpr>()) {
     if (auto objectTy = type->getOptionalObjectType()) {
       if (auto *typeVar = objectTy->getAs<TypeVariableType>())
         cs.recordPotentialHole(typeVar);

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1993,11 +1993,16 @@ bool TypeVariableBinding::attempt(ConstraintSystem &cs) const {
   // without any contextual information, so even though `x` would get
   // bound to result type of the chain, underlying type variable wouldn't
   // be resolved, so we need to propagate holes up the conversion chain.
-  if (TypeVar->getImpl().canBindToHole() &&
-      srcLocator->directlyAt<OptionalEvaluationExpr>()) {
-    if (auto objectTy = type->getOptionalObjectType()) {
-      if (auto *typeVar = objectTy->getAs<TypeVariableType>())
-        cs.recordPotentialHole(typeVar);
+  // Also propagate in code completion mode because in some cases code
+  // completion relies on type variable being a potential hole.
+  if (TypeVar->getImpl().canBindToHole()) {
+    if (srcLocator->directlyAt<OptionalEvaluationExpr>() ||
+        cs.isForCodeCompletion()) {
+      if (auto objectTy = type->getOptionalObjectType()) {
+        if (auto *typeVar = objectTy->getAs<TypeVariableType>()) {
+          cs.recordPotentialHole(typeVar);
+        }
+      }
     }
   }
 

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -509,3 +509,6 @@ func rdar85166519() {
     v?.addingReportingOverflow(0) // expected-error {{cannot convert value of type '(partialValue: Int, overflow: Bool)?' to expected dictionary key type 'Int'}}
   ]
 }
+
+// https://github.com/apple/swift/issues/58539
+if let x = nil {} // expected-error{{'nil' requires a contextual type}}

--- a/test/Constraints/try_swift5.swift
+++ b/test/Constraints/try_swift5.swift
@@ -1,0 +1,12 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5
+
+// https://github.com/apple/swift/issues/58661
+class I58661 {
+  func throwing<T>() throws -> T { // expected-note{{in call to function 'throwing()'}}
+    throw Swift.fatalError()
+  }
+
+  func reproduce() {
+    let check = try? throwing() // expected-error{{generic parameter 'T' could not be inferred}}
+  }
+}

--- a/validation-test/IDE/stress_tester_issues_fixed/rdar93127707.swift
+++ b/validation-test/IDE/stress_tester_issues_fixed/rdar93127707.swift
@@ -1,0 +1,9 @@
+// RUN: %swift-ide-test -code-completion -source-filename %s -code-completion-token COMPLETE | %FileCheck %s
+
+struct Foo {
+  var x: Int = {
+    guard let foo = #^COMPLETE^#
+  }()
+}
+
+// CHECK: Decl[Struct]/CurrModule:            Foo[#Foo#];


### PR DESCRIPTION
Cherry-pick of #58740 and #58849

---------------
**Explanation:** The logic introduced in https://github.com/apple/swift/pull/39238 causes this issue for OptionalTryExpr in swift 5 mode (where constraint is added with an optional layer to the type variable representing the result of this expression) will propagate the hole from source type variable that in this case a generic parameter making the solver to attempt bind a hole directly to the `opt try` variable which since not handled in diagnostics let the solver in this missing diagnostic state. But the thing is that in this case the hole doesn't need to be propagated because it would be bound to `opt try` variable through the source variable relation. So we limit to `OptionalEvaluationExpr` specific case where propagation is needed.
**Scope:** Sema diagnostics.
**Risk:** Low
**Testing:** Added regression tests
**Issues:** https://github.com/apple/swift/issues/58661  https://github.com/apple/swift/issues/58539
**Reviewer:** @xedin  


