### PR TITLE
[stdlib] Improve Substring.UnicodeScalarView.replaceSubrange performance

### DIFF
--- a/stdlib/public/core/StringGutsRangeReplaceable.swift
+++ b/stdlib/public/core/StringGutsRangeReplaceable.swift
@@ -310,19 +310,17 @@ extension _StringGuts {
       if let repl = newElements as? String {
         if repl._guts.isFastUTF8 {
           return repl._guts.withFastUTF8 {
-            uniqueNativeReplaceSubrange(
-              bounds, with: $0, isASCII: repl._guts.isASCII)
+            uniqueNativeReplaceSubrange(bounds, with: $0)
           }
         }
       } else if let repl = newElements as? Substring {
         if repl._wholeGuts.isFastUTF8 {
           return repl._wholeGuts.withFastUTF8(range: repl._offsetRange) {
-            uniqueNativeReplaceSubrange(
-              bounds, with: $0, isASCII: repl._wholeGuts.isASCII)
+            uniqueNativeReplaceSubrange(bounds, with: $0)
           }
         }
       }
-      return uniqueNativeReplaceSubrange(
+      return genericUniqueNativeReplaceSubrange(
         bounds, with: newElements.lazy.flatMap { $0.utf8 })
     }
 
@@ -353,30 +351,24 @@ extension _StringGuts {
       if let repl = newElements as? String.UnicodeScalarView {
         if repl._guts.isFastUTF8 {
           return repl._guts.withFastUTF8 {
-            uniqueNativeReplaceSubrange(
-              bounds, with: $0, isASCII: repl._guts.isASCII)
+            uniqueNativeReplaceSubrange(bounds, with: $0)
           }
         }
       } else if let repl = newElements as? Substring.UnicodeScalarView {
         if repl._wholeGuts.isFastUTF8 {
           return repl._wholeGuts.withFastUTF8(range: repl._offsetRange) {
-            uniqueNativeReplaceSubrange(
-              bounds, with: $0, isASCII: repl._wholeGuts.isASCII)
+            uniqueNativeReplaceSubrange(bounds, with: $0)
           }
         }
       }
-      if #available(SwiftStdlib 5.1, *) {
-        return uniqueNativeReplaceSubrange(
-          bounds, with: newElements.lazy.flatMap { $0.utf8 })
-      } else {
-        // FIXME: The stdlib should not have a deployment target this ancient.
-        let c = newElements.reduce(0) { $0 + UTF8.width($1) }
-        var utf8: [UInt8] = []
-        utf8.reserveCapacity(c)
-        utf8 = newElements.reduce(into: utf8) { utf8, next in
-          next.withUTF8CodeUnits { utf8.append(contentsOf: $0) }
-        }
-        return uniqueNativeReplaceSubrange(bounds, with: utf8)
+      let c = newElements.reduce(0) { $0 + UTF8.width($1) }
+      var utf8: [UInt8] = []
+      utf8.reserveCapacity(c)
+      utf8 = newElements.reduce(into: utf8) { utf8, next in
+        next.withUTF8CodeUnits { utf8.append(contentsOf: $0) }
+      }
+      return utf8.withUnsafeBufferPointer {
+        uniqueNativeReplaceSubrange(bounds, with: $0)
       }
     }
 
@@ -399,8 +391,7 @@ extension _StringGuts {
   // - Returns: The encoded offset range of the replaced contents in the result.
   internal mutating func uniqueNativeReplaceSubrange(
     _ bounds: Range<Index>,
-    with codeUnits: UnsafeBufferPointer<UInt8>,
-    isASCII: Bool
+    with codeUnits: UnsafeBufferPointer<UInt8>
   ) -> Range<Int> {
     let neededCapacity =
       bounds.lowerBound._encodedOffset
@@ -418,7 +409,7 @@ extension _StringGuts {
   }
 
   // - Returns: The encoded offset range of the replaced contents in the result.
-  internal mutating func uniqueNativeReplaceSubrange<C: Collection>(
+  internal mutating func genericUniqueNativeReplaceSubrange<C: Collection>(
     _ bounds: Range<Index>,
     with codeUnits: C
   ) -> Range<Int>

--- a/stdlib/public/core/StringStorage.swift
+++ b/stdlib/public/core/StringStorage.swift
@@ -634,14 +634,12 @@ extension __StringStorage {
       src: mutableStart + upper, dst: lowerPtr + replCount)
 
     // Copy in the contents.
-    var isASCII = self.isASCII
-    var srcCount = 0
-    for cu in replacement {
-      if cu >= 0x80 { isASCII = false }
-      lowerPtr[srcCount] = cu
-      srcCount += 1
-    }
-    _internalInvariant(srcCount == replCount)
+    let target = UnsafeMutableBufferPointer(start: lowerPtr, count: replCount)
+    var (it, c) = replacement._copyContents(initializing: target)
+    _internalInvariant(c == replCount)
+    _internalInvariant(it.next() == nil)
+
+    let isASCII = self.isASCII && _allASCII(UnsafeBufferPointer(target))
 
     _updateCountAndFlags(
       newCount: lower + replCount + tailCount, newIsASCII: isASCII)


### PR DESCRIPTION
Wrapping an opaque collection type in a lazy flatMap and then applying a for-in loop to it seems to induce too many generic metadata lookups.

1. For `replaceSubrange` on the UnicodeScalarView slice type, copy the data into a temporary array instead. (Using the existing fallback path that covers running the current stdlib on pre-5.1 stdlib. Which was only there to work around an availability issue due to the stdlib's deployment target being set absurdly low.)
2. Use `_copyContents` instead of a for-in loop in the generic `__StringStorage.replace` overload. This ought to help remaining invocations of it.
