### PR TITLE
[CSSimplify] Avoid filtering `init` overloads of a callable type

### DIFF
--- a/test/Constraints/callAsFunction.swift
+++ b/test/Constraints/callAsFunction.swift
@@ -29,3 +29,25 @@ struct Test {
     }
   }
 }
+
+// rdar://92912878 - filtering prevents disambiguation of `.callAsFunction`
+func test_no_filtering_of_overloads() {
+  struct S {
+    init() {}
+    init(_: String) {}
+
+    func callAsFunction<T>(_ fn: () -> T) -> T {
+      fn()
+    }
+  }
+
+  func test(_: () -> Void) {
+  }
+
+  test {
+    _ = S() { // Ok
+      _ = 42
+      print("Hello")
+    }
+  }
+}


### PR DESCRIPTION
If there is a call to `init` on a callable type that has a trailing
closure, let's avoid filtering because it's impossible to tell whether
a trailing closure belongs to an `init` call or implicit `.callAsFunction`
that would be attempted after it.

Resolves: rdar://92912878

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
