### PR TITLE
[5.7-04182022] properly handle isolated and _const type reprs when printing

### DIFF
--- a/include/swift/AST/TypeReprNodes.def
+++ b/include/swift/AST/TypeReprNodes.def
@@ -31,6 +31,13 @@
 #define ABSTRACT_TYPEREPR(Id, Parent)
 #endif
 
+/// SPECIFIER_TYPEREPR(Id, Parent)
+///
+/// A specific TypeRepr that's a child of SpecifierTypeRepr.
+#ifndef SPECIFIER_TYPEREPR
+#define SPECIFIER_TYPEREPR TYPEREPR
+#endif
+
 #ifndef LAST_TYPEREPR
 #define LAST_TYPEREPR(Id)
 #endif
@@ -58,15 +65,16 @@ TYPEREPR(NamedOpaqueReturn, TypeRepr)
 TYPEREPR(Existential, TypeRepr)
 TYPEREPR(Placeholder, TypeRepr)
 ABSTRACT_TYPEREPR(Specifier, TypeRepr)
-  TYPEREPR(InOut, SpecifierTypeRepr)
-  TYPEREPR(Shared, SpecifierTypeRepr)
-  TYPEREPR(Owned, SpecifierTypeRepr)
-  TYPEREPR(Isolated, SpecifierTypeRepr)
-  TYPEREPR(CompileTimeConst, SpecifierTypeRepr)
+  SPECIFIER_TYPEREPR(InOut, SpecifierTypeRepr)
+  SPECIFIER_TYPEREPR(Shared, SpecifierTypeRepr)
+  SPECIFIER_TYPEREPR(Owned, SpecifierTypeRepr)
+  SPECIFIER_TYPEREPR(Isolated, SpecifierTypeRepr)
+  SPECIFIER_TYPEREPR(CompileTimeConst, SpecifierTypeRepr)
 TYPEREPR(Fixed, TypeRepr)
 TYPEREPR(SILBox, TypeRepr)
 LAST_TYPEREPR(SILBox)
 
+#undef SPECIFIER_TYPEREPR
 #undef ABSTRACT_TYPEREPR
 #undef TYPEREPR
 #undef LAST_TYPEREPR

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -546,6 +546,12 @@ void SpecifierTypeRepr::printImpl(ASTPrinter &Printer,
   case TypeReprKind::Owned:
     Printer.printKeyword("__owned", Opts, " ");
     break;
+  case TypeReprKind::Isolated:
+    Printer.printKeyword("isolated", Opts, " ");
+    break;
+  case TypeReprKind::CompileTimeConst:
+    Printer.printKeyword("_const", Opts, " ");
+    break;
   default:
     llvm_unreachable("unknown specifier type repr");
     break;

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -537,6 +537,11 @@ void NamedOpaqueReturnTypeRepr::printImpl(ASTPrinter &Printer,
 void SpecifierTypeRepr::printImpl(ASTPrinter &Printer,
                                   const PrintOptions &Opts) const {
   switch (getKind()) {
+#define TYPEREPR(CLASS, PARENT) case TypeReprKind::CLASS:
+#define SPECIFIER_TYPEREPR(CLASS, PARENT)
+#include "swift/AST/TypeReprNodes.def"
+    llvm_unreachable("invalid repr kind");
+    break;
   case TypeReprKind::InOut:
     Printer.printKeyword("inout", Opts, " ");
     break;
@@ -551,9 +556,6 @@ void SpecifierTypeRepr::printImpl(ASTPrinter &Printer,
     break;
   case TypeReprKind::CompileTimeConst:
     Printer.printKeyword("_const", Opts, " ");
-    break;
-  default:
-    llvm_unreachable("unknown specifier type repr");
     break;
   }
   printTypeRepr(Base, Printer, Opts);

--- a/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/Isolated.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/Isolated.swift
@@ -1,0 +1,63 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name Isolated -emit-module -emit-module-path %t/Isolated.swiftmodule -disable-availability-checking
+// RUN: %target-swift-symbolgraph-extract -module-name Isolated -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/Isolated.symbols.json
+
+// REQUIRES: concurrency
+
+// prior to being added to the printer impl, `isolated` appeared as `inout` in non-assertion builds.
+// ensure it renders correctly.
+
+public actor SomeActor {}
+
+public func asdf(param: isolated SomeActor) {}
+
+// CHECK-LABEL:  "precise": "s:8Isolated4asdf5paramyAA9SomeActorCYi_tF",
+
+// the `declarationFragments` token is part of the `functionSignature` first, so skip that
+// CHECK: "functionSignature"
+// CHECK: "declarationFragments"
+
+// CHECK:           "declarationFragments": [
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "kind": "keyword",
+// CHECK-NEXT:          "spelling": "func"
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "kind": "text",
+// CHECK-NEXT:          "spelling": " "
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "kind": "identifier",
+// CHECK-NEXT:          "spelling": "asdf"
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "kind": "text",
+// CHECK-NEXT:          "spelling": "("
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "kind": "externalParam",
+// CHECK-NEXT:          "spelling": "param"
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "kind": "text",
+// CHECK-NEXT:          "spelling": ": "
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "kind": "keyword",
+// CHECK-NEXT:          "spelling": "isolated"
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "kind": "text",
+// CHECK-NEXT:          "spelling": " "
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "kind": "typeIdentifier",
+// CHECK-NEXT:          "spelling": "SomeActor",
+// CHECK-NEXT:          "preciseIdentifier": "s:8Isolated9SomeActorC"
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "kind": "text",
+// CHECK-NEXT:          "spelling": ")"
+// CHECK-NEXT:        }
+// CHECK-NEXT:      ],

--- a/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/TypeRepr.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/TypeRepr.swift
@@ -1,0 +1,51 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name TypeRepr -emit-module -emit-module-path %t/
+// RUN: %target-swift-symbolgraph-extract -module-name TypeRepr -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/TypeRepr.symbols.json
+
+// prior to being added to the printer impl, `_const` parameters were rendered as `inout` in
+// non-assertion builds. ensure it renders correctly.
+
+public func asdf(param: _const String? = nil) {}
+
+// CHECK-LABEL: "precise": "s:8TypeRepr4asdf5paramySSSgYt_tF"
+
+// the `declarationFragments` token is part of the `functionSignature` first, so skip that
+// CHECK: "functionSignature"
+// CHECK: "declarationFragments"
+
+// CHECK:      "declarationFragments": [
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "kind": "keyword",
+// CHECK-NEXT:     "spelling": "func"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "kind": "text",
+// CHECK-NEXT:     "spelling": " "
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "kind": "identifier",
+// CHECK-NEXT:     "spelling": "asdf"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "kind": "text",
+// CHECK-NEXT:     "spelling": "("
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "kind": "externalParam",
+// CHECK-NEXT:     "spelling": "param"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "kind": "text",
+// CHECK-NEXT:     "spelling": ": "
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "kind": "typeIdentifier",
+// CHECK-NEXT:     "spelling": "String",
+// CHECK-NEXT:     "preciseIdentifier": "s:SS"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "kind": "text",
+// CHECK-NEXT:     "spelling": "? = nil)"
+// CHECK-NEXT:   }
+// CHECK-NEXT: ],


### PR DESCRIPTION
This is a cherry-pick of https://github.com/apple/swift/pull/58729 onto `release/5.7-04182022`.

Explanation: The AST Printer cannot currently handle function parameters labeled `isolated` or `_const`. On a build with assertions, this causes the process to crash; without assertions, `inout` is printed as a default (due to the UB generated with the `llvm_unreachable` macro). This PR adds these type representations to the AST Printer.

Scope: The change is limited to the AST printing mechanism for `SpecifierTypeRepr`s. The AST printer is currently primarily used by SymbolGraphGen for rendering "declaration fragments".

Radar: rdar://93028516

Risk: Low. This should not affect normal compilation.

Testing: Two new lit tests were added: `SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/{Isolated,TypeRepr}.swift`. These ensure that these annotations are correctly rendered in a symbol graph. (The test for `_const` currently filters out the attribute, since the in-progress implementation uses an attribute with an underscored name. SymbolGraphGen filters out such underscored attributes, so the behavior in the test is correct.)