### PR TITLE
swift SIL: Fix `variable never mutated` warnings a different way

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/BasicBlock.swift
+++ b/SwiftCompilerSources/Sources/SIL/BasicBlock.swift
@@ -25,8 +25,7 @@ final public class BasicBlock : ListNode, CustomStringConvertible, HasName {
   public var function: Function { SILBasicBlock_getFunction(bridged).function }
 
   public var description: String {
-    let s = SILBasicBlock_debugDescription(bridged)
-    return String(cString: s.c_str())
+    return String(cString: SILBasicBlock_debugDescription(bridged).c_str())
   }
 
   public var arguments: ArgumentArray { ArgumentArray(block: self) }

--- a/SwiftCompilerSources/Sources/SIL/Function.swift
+++ b/SwiftCompilerSources/Sources/SIL/Function.swift
@@ -21,8 +21,7 @@ final public class Function : CustomStringConvertible, HasName {
   }
 
   final public var description: String {
-    let s = SILFunction_debugDescription(bridged)
-    return String(cString: s.c_str())
+    return String(cString: SILFunction_debugDescription(bridged).c_str())
   }
 
   public var entryBlock: BasicBlock {

--- a/SwiftCompilerSources/Sources/SIL/GlobalVariable.swift
+++ b/SwiftCompilerSources/Sources/SIL/GlobalVariable.swift
@@ -19,8 +19,7 @@ final public class GlobalVariable : CustomStringConvertible, HasName {
   }
 
   public var description: String {
-    let s = SILGlobalVariable_debugDescription(bridged)
-    return String(cString: s.c_str())
+    return String(cString: SILGlobalVariable_debugDescription(bridged).c_str())
   }
 
   // TODO: initializer instructions

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -38,8 +38,7 @@ public class Instruction : ListNode, CustomStringConvertible, Hashable {
   final public var function: Function { block.function }
 
   final public var description: String {
-    let s = SILNode_debugDescription(bridgedNode)
-    return String(cString: s.c_str())
+    return String(cString: SILNode_debugDescription(bridgedNode).c_str())
   }
 
   final public var operands: OperandArray {
@@ -136,8 +135,7 @@ public class SingleValueInstruction : Instruction, Value {
 
 public final class MultipleValueInstructionResult : Value {
   final public var description: String {
-    let s = SILNode_debugDescription(bridgedNode)
-    return String(cString: s.c_str())
+    return String(cString: SILNode_debugDescription(bridgedNode).c_str())
   }
 
   public var instruction: Instruction {

--- a/SwiftCompilerSources/Sources/SIL/Value.swift
+++ b/SwiftCompilerSources/Sources/SIL/Value.swift
@@ -21,8 +21,7 @@ public protocol Value : AnyObject, CustomStringConvertible {
 
 extension Value {
   public var description: String {
-    let s = SILNode_debugDescription(bridgedNode)
-    return String(cString: s.c_str())
+    return String(cString: SILNode_debugDescription(bridgedNode).c_str())
   }
 
   public var uses: UseList {


### PR DESCRIPTION
The changes from https://github.com/apple/swift/pull/58731 break compilation for compiler developers who choose to bootstrap with hosttools. Apparently older Swift compilers import `std::string::c_str()` as mutating. To avoid the warning and keep things compatible with hosttools, skip storing the value in a temporary.
