### PR TITLE
[SSADestroyHoisting] Handle loops.

### DIFF
--- a/include/swift/SIL/BasicBlockUtils.h
+++ b/include/swift/SIL/BasicBlockUtils.h
@@ -13,8 +13,9 @@
 #ifndef SWIFT_SIL_BASICBLOCKUTILS_H
 #define SWIFT_SIL_BASICBLOCKUTILS_H
 
-#include "swift/SIL/SILValue.h"
 #include "swift/SIL/BasicBlockBits.h"
+#include "swift/SIL/BasicBlockDatastructures.h"
+#include "swift/SIL/SILValue.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
@@ -155,6 +156,81 @@ void findJointPostDominatingSet(
 bool checkDominates(SILBasicBlock *sourceBlock, SILBasicBlock *destBlock);
 #endif
 
+/// Walk depth-first the region backwards reachable from the provided roots
+/// constrained by \p region's \p isInRegion member function.
+///
+/// interface Region {
+///   /// Whether the indicated basic block is within the region of the graph
+///   /// that should be traversed.
+///   bool isInRegion(SILBasicBlock *)
+/// }
+template <typename Region>
+struct SILCFGBackwardDFS {
+  Region &region;
+  ArrayRef<SILBasicBlock *> roots;
+  Optional<SmallVector<SILBasicBlock *, 16>> cachedPostOrder;
+  Optional<BasicBlockSet> cachedVisited;
+
+  SILCFGBackwardDFS(Region &region, ArrayRef<SILBasicBlock *> roots)
+      : region(region), roots(roots) {}
+
+  /// Visit the blocks of the region in post-order.
+  ///
+  /// interface Visitor {
+  ///     /// Visit each block in topological order.
+  ///     void visit(SILBasicBlock *)
+  /// }
+  template <typename Visitor>
+  void visitPostOrder(Visitor &visitor) {
+    if (roots.empty())
+      return;
+    auto *function = roots.front()->getParent();
+    cachedVisited.emplace(function);
+    for (auto *root : roots) {
+      SmallVector<std::pair<SILBasicBlock *, SILBasicBlock::pred_iterator>, 32>
+          stack;
+      if (!region.isInRegion(root))
+        continue;
+      stack.push_back({root, root->pred_begin()});
+      while (!stack.empty()) {
+        while (stack.back().second != stack.back().first->pred_end()) {
+          auto predecessor = *stack.back().second;
+          stack.back().second++;
+          if (!region.isInRegion(predecessor))
+            continue;
+          if (cachedVisited->insert(predecessor))
+            stack.push_back({predecessor, predecessor->pred_begin()});
+        }
+        visitor.visit(stack.back().first);
+        stack.pop_back();
+      }
+    }
+  }
+
+  /// Visit the region in post-order and cache the visited blocks.
+  void cachePostOrder() {
+    if (cachedPostOrder)
+      return;
+    struct Visitor {
+      SILCFGBackwardDFS<Region> &dfs;
+      void visit(SILBasicBlock *block) {
+        dfs.cachedPostOrder->push_back(block);
+      }
+    };
+    cachedPostOrder.emplace();
+    Visitor visitor{*this};
+    visitPostOrder(visitor);
+  }
+
+  /// The region in post-order.
+  ArrayRef<SILBasicBlock *> postOrder() {
+    cachePostOrder();
+    return *cachedPostOrder;
+  };
+
+  /// The region in reverse post-order.
+  auto reversePostOrder() { return llvm::reverse(postOrder()); }
+};
 } // namespace swift
 
 #endif

--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -48,7 +48,7 @@ private:
   /// A backreference to the containing SILFunction.
   SILFunction *Parent;
 
-  /// PrevList - This is a list of all of the terminator operands that are
+  /// PredList - This is a list of all of the terminator operands that are
   /// branching to this block, forming the predecessor list.  This is
   /// automatically managed by the SILSuccessor class.
   SILSuccessor *PredList = nullptr;

--- a/include/swift/SILOptimizer/Analysis/Reachability.h
+++ b/include/swift/SILOptimizer/Analysis/Reachability.h
@@ -65,6 +65,7 @@ class BackwardReachability {
   SILFunction *function;
   BlockReachability &reachableBlocks;
   BasicBlockWorklist cfgWorklist;
+  bool solved = false;
 
 public:
   BackwardReachability(SILFunction *function,
@@ -74,6 +75,7 @@ public:
 
   // Initialize data flow starting points before running solveBackward.
   void initLastUse(SILInstruction *lastUsePoint) {
+    assert(!solved && "adding last use after solving!?");
     auto *lastUseBlock = lastUsePoint->getParent();
     auto *previous = lastUsePoint->getPreviousInstruction();
     if (!previous || canReachBlockBegin(previous)) {
@@ -93,6 +95,7 @@ public:
         pushPreds(block);
       }
     }
+    solved = true;
   }
 
 protected:

--- a/include/swift/SILOptimizer/Analysis/Reachability.h
+++ b/include/swift/SILOptimizer/Analysis/Reachability.h
@@ -13,21 +13,19 @@
 /// Reachability data flow analysis using a path-discovery worklist. For
 /// efficient data flow propagation based on a single SSA value and its uses.
 ///
-/// TODO: Add an optimistic data flow for more aggresive optimization:
-/// - Add another set for blocks reachable by barriers
-/// - Change the meet operation to a union
-/// - Propagate past barriers up to the SSA def
-/// - Iterate to a fix-point.
-///
 //===----------------------------------------------------------------------===//
 
 #ifndef SWIFT_SILOPTIMIZER_ANALYSIS_REACHABILITY_H
 #define SWIFT_SILOPTIMIZER_ANALYSIS_REACHABILITY_H
 
+#include "swift/SIL/BasicBlockBits.h"
 #include "swift/SIL/BasicBlockDatastructures.h"
 #include "swift/SIL/SILBasicBlock.h"
+#include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILSuccessor.h"
+#include "llvm/ADT/PointerUnion.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/Debug.h"
 
 namespace swift {
 
@@ -136,6 +134,759 @@ protected:
     }
   }
 };
+
+/// Iterative, optimistic data flow for analyzing backward reachability from a
+/// set of gens to their dominating def or nearest barrier.
+///
+/// Uses a worklist approach to avoid extraneous iteration.  Additionally,
+/// avoids analyzing reachability in blocks which are known to be unreachable.
+///
+/// interface Effects {
+///     /// The effect, if any, of the specified instruction.
+///     Effect effectForInstruction(SILInstruction *);
+///
+///     /// The effect, if any, of the phis of the specified block.
+///     Effect effectForPhi(SILBasicBlock *);
+///
+///     /// The uses from which reachability will begin.
+///     ArrayRef<SILInstruction *> gens();
+/// }
+template <typename Effects>
+class IterativeBackwardReachability final {
+public:
+  /// How an instruction or phi can modify the state of a block.
+  ///
+  /// NoEffect - the state is unmodified
+  /// Kill - the state becomes unreachable
+  /// Gen - the state becomes reachable
+  struct Effect final {
+    enum class Value {
+      NoEffect,
+      Kill,
+      Gen,
+    };
+    Value value;
+
+    Effect(Value value) : value(value) {}
+    Effect() : value(Value::NoEffect) {}
+
+    static Effect NoEffect() { return {Value::NoEffect}; }
+    static Effect Kill() { return {Value::Kill}; }
+    static Effect Gen() { return {Value::Gen}; }
+
+    bool isNoEffect() const { return value == Value::NoEffect; }
+
+    /// Form the effect equivalent to first applying this effect and then
+    /// applying the specified effect.
+    Effect composing(Effect other) const {
+      return other.isNoEffect() ? *this : other;
+    }
+
+    explicit operator bool() const { return !isNoEffect(); }
+    bool operator==(const Effect &other) { return value == other.value; }
+    bool operator!=(const Effect &other) { return value != other.value; }
+  };
+
+  /// How reachable a point in the function is:
+  /// - Unreachable: Some path from a gen to here passes through a kill.
+  /// - Reachable: No path from a gen point to here passes through a kill.
+  /// - Unknown: This point is the unexplored end of a block which contains a
+  ///            gen.
+  ///
+  /// These states form a simple lattice:
+  ///
+  ///       Unknown (top)
+  ///          |
+  ///      Reachable
+  ///          |
+  ///     Unreachable (bottom)
+  ///
+  /// During initialization, certain points may be set to have the Unknown
+  /// state.  After that point, all blocks which have been discovered are
+  /// optimistically assumed to have Reachable begin and end states until it is
+  /// recorded otherwise.
+  struct State final {
+    enum class Value {
+      Unreachable,
+      Reachable,
+      Unknown,
+    };
+    Value value;
+
+    static State Unreachable() { return {Value::Unreachable}; }
+    static State Reachable() { return {Value::Reachable}; }
+    static State Unknown() { return {Value::Unknown}; }
+    State meet(State other) { return value < other.value ? *this : other; }
+    State apply(Effect effect) {
+      switch (effect.value) {
+      case Effect::Value::NoEffect:
+        return *this;
+      case Effect::Value::Kill:
+        return Unreachable();
+      case Effect::Value::Gen:
+        return Reachable();
+      };
+    };
+    bool operator==(const State &other) { return value == other.value; }
+    bool operator!=(const State &other) { return value != other.value; }
+  };
+
+  /// The output of the dataflow.
+  class Result final {
+    /// Blocks whose instructions+phis are summarized as gen.
+    BasicBlockSet genBlocks;
+    /// Blocks whose instructions+phis are summarized as kill.
+    BasicBlockSet killBlocks;
+    /// Blocks whose ends are in the ::Unreachable state.
+    BasicBlockSet unreachableEndBlocks;
+    /// Blocks whose ends are in the ::Unknown state.
+    BasicBlockSet unknownEndBlocks;
+
+  public:
+    /// The blocks found between the gens and the defBlock into which
+    /// reachability may extend.
+    BasicBlockSetVector discoveredBlocks;
+    /// The sublist of gens which are killed within the blocks where they occur.
+    SmallSetVector<SILInstruction *, 32> localGens;
+
+    /// Construct a result for running IterativeBackwardReachability in a given
+    /// function.
+    Result(SILFunction *function)
+        : genBlocks(function), killBlocks(function),
+          unreachableEndBlocks(function), unknownEndBlocks(function),
+          discoveredBlocks(function){};
+
+    /// The previously recorded end state of the specified block.
+    State getEndStateForBlock(SILBasicBlock *block);
+
+    /// The begin state of the specified block.
+    State getBeginStateForBlock(SILBasicBlock *block) {
+      auto endState = getEndStateForBlock(block);
+      return transferEndToBegin(block, endState);
+    }
+
+    /// The summary effect of the specified block on reachability, as previously
+    /// recorded.
+    Effect getEffectForBlock(SILBasicBlock *block);
+
+    /// Record the summary effect of the specified block.
+    template <bool SkipOverwrite>
+    void setEffectForBlock(SILBasicBlock *block, Effect effect);
+
+    /// Transfer the specified block's provided end state to its begin state by
+    /// applying its effect.
+    State transferEndToBegin(SILBasicBlock *block, State state) {
+      auto effect = getEffectForBlock(block);
+      return state.apply(effect);
+    }
+
+    /// During initialization, set the specified block's initial state to be
+    /// ::Unknown.
+    void initializeEndStateToUnknown(SILBasicBlock *block) {
+      unknownEndBlocks.insert(block);
+    }
+
+    /// Record a transition (down-lattice) of the indicated block to the
+    /// specified state.
+    bool setEndStateforBlock(SILBasicBlock *block, State state);
+
+  private:
+    Result(Result const &) = delete;
+    Result &operator=(Result const &) = delete;
+  };
+
+  /// Construct a dataflow for the specified function to run from the gens
+  /// provided by \p effects to the specified def block.  So that the result
+  /// structure can be owned by the caller, it is taken by reference here.
+  ///
+  /// If a nullptr defBlock is specified, the dataflow may run up to the begin
+  /// of the function.
+  IterativeBackwardReachability(SILFunction *function, SILBasicBlock *defBlock,
+                                Effects &effects, Result &result)
+      : function(function), defBlock(defBlock), effects(effects),
+        result(result), dataflowWorklist(function) {}
+
+  /// Step 1: Prepare to run the global dataflow: discover and summarize the
+  /// blocks in the relevant region.
+  ///
+  /// Effects are queried in order to summarize.
+  void initialize();
+
+  /// Step 2 (Optional): Add kills beyond those that were already added during
+  /// initialization, requerying effects as needed.
+  void addKill(SILInstruction *instruction);
+
+  /// Step 3: Propagate reachability through the blocks in the identified
+  /// region.
+  void solve();
+
+  /// Step 4 (Optional): Visit each barrier instruction, phi, and block.
+  ///
+  /// Effects are requeried.
+  ///
+  /// A barrier block here means the target block of a barrier edge.
+  ///
+  /// interface Visitor {
+  ///     void visitBarrierInstruction(SILInstruction *)
+  ///     void visitBarrierPhi(SILBasicBlock *)
+  ///     void visitBarrierBlock(SILBasicBlock *)
+  /// }
+  template <typename Visitor>
+  void findBarriers(Visitor &visitor);
+
+private:
+  /// How far along the dataflow is.
+  enum class Stage {
+    /// The dataflow has not done any work.
+    Unstarted,
+    /// Performing local, sub-block dataflow from gens, determining which gens
+    /// are local to and should be stored in \p localGens.
+    Initializing,
+    /// Discovering blocks into which reachability may extend and lazily doing
+    /// local dataflows of those blocks as they are seen.
+    SolvingLocal,
+    /// Discovery has completed and local dataflow has been performed for all
+    /// discovered blocks.  At this point, clients are free to examine the
+    /// Result's \p discoveredBlocks add more kills.
+    SolvedLocal,
+    /// Running the iterative dataflow, draining the worklist of blocks which
+    /// are unreachable-at-begin.
+    SolvingGlobal,
+    /// The dataflow has finished.
+    SolvedGlobal,
+  };
+
+  /// The function in which the dataflow will run.
+  SILFunction *function;
+  /// The block containing the def for the value--the dataflow will not
+  /// propagate beyond this block.
+  SILBasicBlock *defBlock;
+
+  /// Input to the dataflow.
+  Effects &effects;
+  /// Output from the dataflow.
+  Result &result;
+
+  /// The worklist for the global data flow.  It consists of blocks whose begin
+  /// states have been found to be unreachable; the unreachable-at-begin-ness of
+  /// each such block is to be propagated into unreachable-at-end-ness of its
+  /// predecessors.
+  BasicBlockWorklist dataflowWorklist;
+  /// Current activity of the dataflow.
+  Stage stage = Stage::Unstarted;
+
+  /// Whether the def effectively occurs within the specified block.
+  bool isEffectiveDefBlock(SILBasicBlock *block) {
+    return defBlock ? block == defBlock : block == &*function->begin();
+  }
+
+  /// Form the meet of the end state of the provided predecessor with the begin
+  /// states of all its successors.
+  State meetOverSuccessors(SILBasicBlock *predecessor);
+
+  /// Whether the first (non-NoEffect) effect before the specified instruction
+  /// is of the indicated kind.
+  bool findLocalEffectBefore(SILInstruction *from, Effect target);
+
+  /// Summarize the effect of the block.
+  Effect summarizeLocalEffect(SILBasicBlock *block);
+
+  /// Carry out the portion of initialization corresponding to a single gen.
+  void initializeFromGen(SILInstruction *gen);
+
+  /// Propagates the unreachable-at-begin-ness of the specified block into
+  /// unreachable-at-end-ness of its predecessors.
+  void propagateIntoPredecessors(SILBasicBlock *successor);
+
+  /// Find and visit a single barrier instruction, phi, or block.  Returns true
+  /// if one is found.
+  ///
+  /// A barrier block here means the target block of a barrier edge.
+  ///
+  /// interface Visitor {
+  ///     void visitBarrierInstruction(SILInstruction *)
+  ///     void visitBarrierPhi(SILBasicBlock *)
+  ///     void visitBarrierBlock(SILBasicBlock *)
+  /// }
+  template <typename Visitor>
+  bool findBarrier(SILInstruction *from, SILBasicBlock *block,
+                   Visitor &visitor);
+};
+
+//===----------------------------------------------------------------------===//
+// MARK: IterativeBackwardReachability - Initialization
+//===----------------------------------------------------------------------===//
+
+/// Prepare the dataflow to run.
+///
+/// Simultaneously (1) discover the blocks which could be reached and within
+/// which consequently the data flow must run and (2) summarize the local
+/// effect of each block for use by the dataflow.
+///
+/// Starting from the gens, find all blocks which might be reached up to and
+/// including the defBlock.  Summarize the effects of these blocks along the
+/// way.
+template <typename Effects>
+void IterativeBackwardReachability<Effects>::initialize() {
+  assert(stage == Stage::Unstarted);
+  stage = Stage::Initializing;
+  for (auto *gen : effects.gens()) {
+    initializeFromGen(gen);
+  }
+  stage = Stage::SolvingLocal;
+  /// Thanks to StackList's iterator guarantees (BasicBlockSetVector uses
+  /// StackList's iterator), the iterator won't be invalidated by the
+  /// modification that is done within the loop.
+  for (auto iterator = result.discoveredBlocks.begin();
+       iterator != result.discoveredBlocks.end(); ++iterator) {
+    auto *block = *iterator;
+    auto effect = summarizeLocalEffect(block);
+    result.template setEffectForBlock</*SkipOverwrite=*/true>(block, effect);
+    if (effect == Effect::Kill()) {
+      // This block is a kill, so it is unreachable at its begin.  Propagate
+      // that unreachable-at-begin-ness to unreachable-at-end-ness of its
+      // predecessors, if any of them are ever discovered.
+      dataflowWorklist.push(block);
+      // This block is a kill, so dataflow can't propagate a reachable state
+      // through this block to its predecessors.  Don't add its predecessors
+      // to the list of discoverable blocks--they can't be reachable by way of
+      // this block.  Note though that they may become reachable through other
+      // adjacent successors.
+      continue;
+    }
+    if (isEffectiveDefBlock(block)) {
+      // If this block is the effective def block, dataflow mustn't propagate
+      // a reachable state through this block to its predecessors.
+      continue;
+    }
+    for (auto *predecessor : block->getPredecessorBlocks())
+      result.discoveredBlocks.insert(predecessor);
+  }
+  stage = Stage::SolvedLocal;
+}
+
+/// Initialize the dataflow for a single gen from effect.gens.
+///
+/// Summarize and record the local effect of the partial instruction range
+/// starting at gen and running to the begin of the block.
+template <typename Effects>
+void IterativeBackwardReachability<Effects>::initializeFromGen(
+    SILInstruction *gen) {
+  auto *block = gen->getParent();
+
+  if (findLocalEffectBefore(gen, Effect::Kill())) {
+    // If there is a local kill before this gen, then it is a local gen.
+    result.localGens.insert(gen);
+  } else {
+    result.template setEffectForBlock</*SkipOverwrite=*/true>(block,
+                                                              Effect::Gen());
+    // Only add blocks whose begins are reached to the list of blocks which
+    // must participate in the global dataflow.
+    result.discoveredBlocks.insert(block);
+    // When considering gen in isolation, we don't have enough information to
+    // decide whether it is reachable.  It may be reachable, from some other
+    // gen, but it may not be.  Set its state to ::Unknown, the top state of the
+    // lattice.  During the dataflow, its state may be updated downwards in the
+    // lattice.
+    result.initializeEndStateToUnknown(block);
+  }
+}
+
+/// Summarize the effect of the block.
+///
+/// Compose all the effects in the block, starting from the last instruction and
+/// working backwards through the first instruction and the phi if any.
+template <typename Effects>
+typename IterativeBackwardReachability<Effects>::Effect
+IterativeBackwardReachability<Effects>::summarizeLocalEffect(
+    SILBasicBlock *block) {
+  Effect runningEffect;
+  for (auto &instruction : llvm::reverse(*block)) {
+    auto effect = effects.effectForInstruction(&instruction);
+    runningEffect = runningEffect.composing(effect);
+  }
+  if (block->hasPhi()) {
+    auto effect = effects.effectForPhi(block);
+    runningEffect = runningEffect.composing(effect);
+  }
+  return runningEffect;
+}
+
+/// Whether an effect of the indicated kind occurs before the specified
+/// instruction.
+///
+/// Scan the effects in the block backwards from the specified instruction.  If
+/// any effect along the way is of the indicated kind, return true.
+template <typename Effects>
+bool IterativeBackwardReachability<Effects>::findLocalEffectBefore(
+    SILInstruction *from, Effect target) {
+  assert(target != Effect::NoEffect());
+  for (auto *instruction = from->getPreviousInstruction(); instruction;
+       instruction = instruction->getPreviousInstruction()) {
+    auto effect = effects.effectForInstruction(instruction);
+    if (effect == target)
+      return true;
+  }
+  auto *block = from->getParent();
+  if (block->hasPhi()) {
+    auto effect = effects.effectForPhi(block);
+    if (effect == target)
+      return true;
+  }
+  return false;
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: IterativeBackwardReachability - Modification
+//===----------------------------------------------------------------------===//
+
+/// Record a new kill.
+///
+/// To be called only after initialization.
+template <typename Effects>
+void IterativeBackwardReachability<Effects>::addKill(
+    SILInstruction *instruction) {
+  // TODO: Trim discovered set if possible.
+  assert(stage == Stage::SolvedLocal);
+  auto *block = instruction->getParent();
+
+  // If the kill isn't even in a discovered block, it has no effect.
+  if (!result.discoveredBlocks.contains(block))
+    return;
+
+  if (result.getEffectForBlock(block) != Effect::Gen()) {
+    // If the block wasn't previously a gen block, without further work, we
+    // already know that adding a kill to the block makes it a kill block.
+    result.template setEffectForBlock</*SkipOverwrite=*/true>(block,
+                                                              Effect::Kill());
+    return;
+  }
+
+  // The block was previously a gen block, so the new kill may or may not make
+  // it a kill block; it depends on whether the new kill is above the gen which
+  // made the block a gen.  We could resummarize the block, starting from the
+  // new kill.  As an optimization, instead, we just walk until we find a gen.
+
+  // Search for a previous gen.
+  if (findLocalEffectBefore(instruction, Effect::Gen()))
+    // If one is found, the new kill doesn't alter the block's effect.
+    return;
+
+  // Since no previous gen was found, the block is now a kill.
+  result.template setEffectForBlock</*SkipOverwrite=*/false>(block,
+                                                             Effect::Kill());
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: IterativeBackwardReachability - Solving
+//===----------------------------------------------------------------------===//
+
+/// Iteratively solve the global dataflow.
+///
+/// Drain the worklist which consists of blocks each of whose begins are
+/// unreachable, propagating that unreachable-at-begin-ness into
+/// unreachable-at-end-ness of its predecessors.
+template <typename Effects>
+void IterativeBackwardReachability<Effects>::solve() {
+  assert(stage == Stage::SolvedLocal);
+  stage = Stage::SolvingGlobal;
+  // Now that all discovered blocks have been summarized, seed the worklist
+  // with those discovered blocks which we can already tell are unreachable
+  // at begin.
+  for (auto *block : result.discoveredBlocks) {
+    auto endState = meetOverSuccessors(block);
+    if (result.setEndStateforBlock(block, endState)) {
+      // The end state was updated.  See whether that resulted in the begin
+      // state becoming unreachable.
+      auto beginState = result.getBeginStateForBlock(block);
+      if (beginState == State::Unreachable()) {
+        // The begin state is now unreachable.  Add the block to the worklist
+        // so that its unreachable-at-begin-ness gets propagated to
+        // unreachable-at-end-ness of its predecessors.
+        dataflowWorklist.pushIfNotVisited(block);
+      }
+    }
+  }
+  // Drain the worklist.
+  while (auto *block = dataflowWorklist.popAndForget()) {
+    // Propagate block's unreachable-at-begin-ness into
+    // unreachable-at-end-ness of its predecessors.
+    propagateIntoPredecessors(block);
+  }
+  stage = Stage::SolvedGlobal;
+}
+
+/// Propagates the unreachable-at-begin-ness of the specified block into
+/// unreachable-at-end-ness of its predecessors.
+///
+/// If that new unreachable-at-end-ness of any predecessor results in that
+/// predecessor being newly unreachable at begin, add the predecessor to the
+/// worklist.
+///
+/// Called with each block from the worklist as it is drained.  A block is added
+/// to the worklist only when it is known to be unreachable at begin;
+/// consequently, when forming the meet of that block's begin state with its
+/// predecessor's end state, we can skip requerying the block's end state--it
+/// must be ::Unreachable.
+template <typename Effects>
+void IterativeBackwardReachability<Effects>::propagateIntoPredecessors(
+    SILBasicBlock *successor) {
+  // State isn't tracked above the def block.  Don't propagate state changes
+  // into its predecessors.
+  if (isEffectiveDefBlock(successor))
+    return;
+  assert(result.getBeginStateForBlock(successor) == State::Unreachable() &&
+         "propagating unreachability into predecessors of block whose begin is "
+         "reachable?!");
+  for (auto *predecessor : successor->getPredecessorBlocks()) {
+    // Blocks are added to the worklist whenever they are found to be
+    // unreachable at begin.  Specifically, no checks are done at that time that
+    // the block's predecessors are discovered.  Check now.
+    if (!result.discoveredBlocks.contains(predecessor))
+      continue;
+    auto oldEndState = result.getEndStateForBlock(predecessor);
+    auto newEndState = State::Unreachable().meet(oldEndState);
+    if (result.setEndStateforBlock(predecessor, newEndState)) {
+      // The end state of predecessor was changed.  Its begin state may be newly
+      // ::Unreachable.
+      if (result.getBeginStateForBlock(predecessor) == State::Unreachable()) {
+        // Propagate predecessor's new unreachable-at-begin-ness to
+        // unreachable-at-end-ness of _its_ predecessors.
+        dataflowWorklist.pushIfNotVisited(predecessor);
+      }
+    }
+  }
+}
+
+template <typename Effects>
+typename IterativeBackwardReachability<Effects>::State
+IterativeBackwardReachability<Effects>::meetOverSuccessors(
+    SILBasicBlock *predecessor) {
+  auto state = result.getEndStateForBlock(predecessor);
+  for (auto *successor : predecessor->getSuccessorBlocks()) {
+    state = state.meet(result.getBeginStateForBlock(successor));
+  }
+  return state;
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: IterativeBackwardReachability - Barrier Discovery
+//===----------------------------------------------------------------------===//
+
+/// Backwards walk discovered blocks and partial blocks starting at gens,
+/// visiting barrier instructions, phis, and blocks.
+///
+/// interface Visitor {
+///     /// Invoked with an instruction which is a barrier.
+///     void visitBarrierInstruction(SILInstruction *)
+///
+///     /// Invoked with a block one of whose phi arguments is a barrier.
+///     void visitBarrierPhi(SILBasicBlock *)
+///
+///     /// Invoked with target of an edge which is a barrier.
+///     ///
+///     /// Given a block P only some of whose successors S are
+///     /// reachable-at-begin, an edge E from P to S is a barrier.  This
+///     /// function is invoked for each such edge E with the block S.  Thanks
+///     /// to the lack of critical edges in SIL, that uniquely identifies the
+///     /// edge as the only edge to S.
+///     ///
+///     /// Additionally, this may be invoked with the effective def block if
+///     /// no barriers are found between the gens and it.
+///     void visitBarrierBlock(SILBasicBlock *)
+/// }
+template <typename Effects>
+template <typename Visitor>
+void IterativeBackwardReachability<Effects>::findBarriers(Visitor &visitor) {
+  assert(stage == Stage::SolvedGlobal);
+  for (auto *block : result.discoveredBlocks) {
+    switch (result.getEndStateForBlock(block).value) {
+    case State::Value::Reachable:
+      findBarrier(&block->back(), block, visitor);
+      break;
+    case State::Value::Unreachable:
+      for (auto *successor : block->getSuccessorBlocks()) {
+        if (result.getBeginStateForBlock(successor) == State::Reachable()) {
+          visitor.visitBarrierBlock(successor);
+        }
+      }
+      break;
+    case State::Value::Unknown:
+      // A block which contained a gen which was never overwritten by global
+      // data flow.
+      break;
+    }
+  }
+  for (auto *gen : effects.gens()) {
+    bool foundBarrier =
+        findBarrier(gen->getPreviousInstruction(), gen->getParent(), visitor);
+    assert((foundBarrier || !result.localGens.contains(gen)) &&
+           "local gen without in-block kill?!");
+    (void)foundBarrier;
+  }
+}
+
+/// Find a single barrier, starting from the specified instruction (nullable)
+/// within the indicated block (non-nullable) and visit it.
+///
+/// Return whether a barrier was found.
+///
+/// interface Visitor {
+///     /// Invoked with an instruction which is a barrier.
+///     void visitBarrierInstruction(SILInstruction *)
+///
+///     /// Invoked with a block one of whose phi arguments is a barrier.
+///     void visitBarrierPhi(SILBasicBlock *)
+///
+///     /// Invoked with target of an edge which is a barrier.
+///     ///
+///     /// Given a block P only some of whose successors S are
+///     /// reachable-at-begin, an edge E from P to S is a barrier.  This
+///     /// function is invoked for each such edge E with the block S.  Thanks
+///     /// to the lack of critical edges in SIL, that uniquely identifies the
+///     /// edge as the only edge to S.
+///     ///
+///     /// Additionally, this may be invoked with the effective def block if
+///     /// no barriers are found between the gens and it.
+///     void visitBarrierBlock(SILBasicBlock *)
+/// }
+template <typename Effects>
+template <typename Visitor>
+bool IterativeBackwardReachability<Effects>::findBarrier(SILInstruction *from,
+                                                         SILBasicBlock *block,
+                                                         Visitor &visitor) {
+  for (auto *instruction = from; instruction;
+       instruction = instruction->getPreviousInstruction()) {
+    auto effect = effects.effectForInstruction(instruction);
+    if (!effect)
+      continue;
+    if (effect == Effect::Gen()) {
+      assert(false && "found gen (before kill) in reachable block");
+      continue;
+    }
+    // effect == Effect::Kill
+    visitor.visitBarrierInstruction(instruction);
+    return true;
+  }
+  if (block->hasPhi()) {
+    if (auto effect = effects.effectForPhi(block)) {
+      if (effect == Effect::Kill()) {
+        visitor.visitBarrierPhi(block);
+        return true;
+      }
+    }
+  }
+  assert(result.getEffectForBlock(block) != Effect::Kill());
+  if (isEffectiveDefBlock(block)) {
+    visitor.visitBarrierBlock(block);
+    return true;
+  }
+  return false;
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: IterativeBackwardReachability::Result - State
+//===----------------------------------------------------------------------===//
+
+/// The previously recorded end state of the specified block.
+template <typename Effects>
+typename IterativeBackwardReachability<Effects>::State
+IterativeBackwardReachability<Effects>::Result::getEndStateForBlock(
+    SILBasicBlock *block) {
+  if (!discoveredBlocks.contains(block))
+    return State::Unreachable();
+  if (unreachableEndBlocks.contains(block))
+    return State::Unreachable();
+  if (unknownEndBlocks.contains(block))
+    return State::Unknown();
+  return State::Reachable();
+}
+
+/// Record a transition of the indicated block to the specified state.
+///
+/// States must transition down the State lattice.
+///
+/// The state is recorded in:
+/// - unreachableEndBlocks; blocks contained here are ::Unreachable
+/// - unknownEndBlocks; blocks contained here are ::Unknown
+/// Blocks that are in neither are ::Reachable.
+template <typename Effects>
+bool IterativeBackwardReachability<Effects>::Result::setEndStateforBlock(
+    SILBasicBlock *block, State state) {
+  switch (state.value) {
+  case State::Value::Unreachable: {
+    auto previouslyUnknown = unknownEndBlocks.contains(block);
+    unknownEndBlocks.erase(block);
+    auto notPreviouslyUnreachable = unreachableEndBlocks.insert(block);
+    assert(!previouslyUnknown ||
+           notPreviouslyUnreachable &&
+               "block was previously in both unknown and unreachable?!");
+    return previouslyUnknown || notPreviouslyUnreachable;
+  }
+  case State::Value::Reachable: {
+    auto previouslyUnknown = unknownEndBlocks.contains(block);
+    unknownEndBlocks.erase(block);
+    assert(!unreachableEndBlocks.contains(block) &&
+           "transitioning up lattice?! unreachable->reachable");
+    return previouslyUnknown;
+  }
+  case State::Value::Unknown: {
+    auto notPreviouslyUnknown = unknownEndBlocks.insert(block);
+    assert(!unreachableEndBlocks.contains(block) &&
+           "transitioning up lattice?! unreachable->unknown");
+    assert(!notPreviouslyUnknown &&
+           "transitioning up lattice?! reachable->unknown");
+    return notPreviouslyUnknown;
+  }
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: IterativeBackwardReachability::Result - Effects
+//===----------------------------------------------------------------------===//
+
+/// The summary effect of the specified block on reachability, as previously
+/// recorded.
+template <typename Effects>
+typename IterativeBackwardReachability<Effects>::Effect
+IterativeBackwardReachability<Effects>::Result::getEffectForBlock(
+    SILBasicBlock *block) {
+  if (genBlocks.contains(block))
+    return Effect::Gen();
+  if (killBlocks.contains(block))
+    return Effect::Kill();
+  return Effect::NoEffect();
+}
+
+/// Record the summary effect of the specified block.
+///
+/// If it is statically known that the block has not already had its effect set
+/// to an incompatible value, we can avoid clearing the old effect.  For
+/// example, if this is the first time a block's state has been set, or if we
+/// are setting a block's state to ::Gen and we already know it isn't ::Kill.
+template <typename Effects>
+template <bool SkipOverwrite>
+void IterativeBackwardReachability<Effects>::Result::setEffectForBlock(
+    SILBasicBlock *block, Effect effect) {
+  switch (effect.value) {
+  case Effect::Value::NoEffect:
+    if (!SkipOverwrite) {
+      genBlocks.erase(block);
+      killBlocks.erase(block);
+    }
+    return;
+  case Effect::Value::Gen:
+    genBlocks.insert(block);
+    if (!SkipOverwrite)
+      killBlocks.erase(block);
+    return;
+  case Effect::Value::Kill:
+    killBlocks.insert(block);
+    if (!SkipOverwrite)
+      genBlocks.erase(block);
+    return;
+  }
+}
 
 } // end namespace swift
 

--- a/include/swift/SILOptimizer/Analysis/VisitBarrierAccessScopes.h
+++ b/include/swift/SILOptimizer/Analysis/VisitBarrierAccessScopes.h
@@ -1,0 +1,303 @@
+//===--- VisitBarrierAccessScopes.h - Find access scopes with barriers ----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Given a region of a function, backwards-reachable from some set of roots, on
+// which gen/kill effects can be determined, determines which access scopes must
+// also be treated as kills in view of the rule that a kill within an access
+// scope makes the access scope itself a kill.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/SIL/BasicBlockDatastructures.h"
+#include "swift/SIL/BasicBlockUtils.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/Optional.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallPtrSet.h"
+
+namespace swift {
+
+class BeginAccessInst;
+class EndAccessInst;
+class SILInstruction;
+class SILBasicBlock;
+class SILInstruction;
+
+/// Visits the begin_access instructions corresponding to access scopes that
+/// must be regarded as barriers (in particular, their end_access instructions
+/// must be) because they contain other barriers.
+///
+/// interface Effects {
+///   typename Effect
+///
+///   /// The root instructions from which to walk.
+///   iterable gens()
+///
+///   /// The gens which are killed within the block where they occur.
+///   iterable localGens()
+///
+///   /// Whether the indicated instruction is killed within the specified
+///   /// block.
+///   bool isLocalGen(SILInstruction *)
+///
+///   /// The effect, if any, of the specified instruction.
+///   Effects::Effect effectForPhi(SILBasicBlock *)
+///
+///   /// The effect, if any, of the phis of the specified block.
+///   Effects::Effect effectForInstruction(SILInstruction *)
+/// }
+/// interface Visitor {
+///   /// Whether the indicated basic block is within the region of the graph
+///   /// that should be traversed.
+///   bool isInRegion(SILBasicBlock *)
+///
+///   /// Visit each discovered begin_access instruction which defines a barrier
+///   /// scope.
+///   void visitBarrierAccessScope(BeginAccessInst *)
+/// }
+///
+/// Implements SILCFGBackwardDFS::Visitor
+template <typename Effects, typename Visitor>
+class VisitBarrierAccessScopes {
+  using This = VisitBarrierAccessScopes<Effects, Visitor>;
+  /// Describes the effect, if any, of each instruction and phi.
+  Effects &effects;
+  /// Describes the search region and visits the found barriers.
+  Visitor &visitor;
+  /// The function in which to find barrier access scopes.
+  SILFunction *function;
+  /// The blocks which have already been visited.  Used to determine whether a
+  /// block being visited is a barrier block.
+  BasicBlockSet visited;
+
+  /// The access scopes that are live at the begin of each block after visiting
+  /// all the block's predecessors and its instructions.
+  llvm::DenseMap<SILBasicBlock *, llvm::SmallPtrSet<BeginAccessInst *, 2>>
+      liveInAccessScopes;
+  /// While visiting a block's instructions, the access scopes that are
+  /// currently live.
+  llvm::SmallPtrSet<BeginAccessInst *, 2> runningLiveAccessScopes;
+
+public:
+  VisitBarrierAccessScopes(SILFunction *function, Effects &effects,
+                           Visitor &visitor)
+      : effects(effects), visitor(visitor), function(function),
+        visited(function){};
+
+  /// Visit the begin_access instructions.
+  ///
+  /// Sort the backwards-reachable, in-region blocks topologically.  Then visit
+  /// them in the reverse of that order, so that when any block is visited, all
+  /// of its non-backedge* successors will already have been visited.
+  ///
+  /// While visiting, which access scopes are live within blocks is tracked,
+  /// storing the access scopes that are live at the begin of a block, and
+  /// noting that every access scope live at the begin of any successor is also
+  /// live at the end of a block.
+  ///
+  /// * These are backedges in the reversed graph, that are ignored in a reverse
+  /// depth-first search.
+  ///
+  /// Finally, look through the instructions between local gens and their kills
+  /// for further barrier access scopes.
+  void visit() {
+    // First, collect the gens whose blocks should be used as the roots of the
+    // region--those that are non-local.
+    //
+    // Keep track of which gens are at the beginning of the region (i.e. none of
+    // whose successors are in the region) so that we can avoid iterating over
+    // the instructions below those gens.
+    SmallVector<SILBasicBlock *, 32> rootBlocks;
+    llvm::DenseMap<SILBasicBlock *, SILInstruction *> genForRoot;
+    for (auto *instruction : effects.gens()) {
+      if (effects.isLocalGen(instruction))
+        continue;
+      auto *block = instruction->getParent();
+      rootBlocks.push_back(block);
+      // If none of this block's successors are in the region, then we don't
+      // need to visit the whole block--just the portion starting from this gen.
+      if (!llvm::any_of(block->getSuccessorBlocks(),
+                        [&](SILBasicBlock *successor) {
+                          return visitor.isInRegion(successor);
+                        })) {
+        genForRoot[block] = instruction;
+      }
+    }
+    // Then do a backward DFS from those roots, and visit the blocks in reverse
+    // post-order.
+    SILCFGBackwardDFS<This> dfs(*this, rootBlocks);
+    for (auto *block : dfs.reversePostOrder()) {
+      // Check whether this block contains a non-local gen.
+      auto iterator = genForRoot.find(block);
+      if (iterator != genForRoot.end()) {
+        visitBlockFromGen(iterator->getSecond());
+      } else {
+        visitBlock(block);
+      }
+    }
+    // Finally, visit local gens which weren't visited already.
+    for (auto *instruction : effects.localGens()) {
+      auto *block = instruction->getParent();
+      auto isInRegion = dfs.cachedVisited && dfs.cachedVisited->contains(block);
+      auto visitedFullBlock = genForRoot.find(block) == genForRoot.end();
+      if (isInRegion && visitedFullBlock)
+        continue;
+      // This local gen is either entirely outside the blocks that define the
+      // region (!isInRegion) or it is in one of the bottom (i.e. one none of
+      // whose successors are in the region) blocks in the region only the top
+      // of which was already visited.  Either way, the instructions between the
+      // local gen and its kill have not yet been visited.  Visit them now.
+      auto foundLocalKill = visitBlockFromGenUntilBegin(instruction);
+      assert(foundLocalKill && "local gen without local kill?!");
+      (void)foundLocalKill;
+    }
+  }
+
+private:
+  /// Entry points for visiting: they visit increasingly large portions of a
+  /// block.
+  /// - visitBlockFromGenUntilBegin: Instructions and phi until a kill.
+  /// - visitBlockFromGen: Instructions, phi, and begin.
+  /// - visitBlock: End, instructions, phi, and begin.
+
+  /// Visit instructions and phis starting from the specified gen until a kill
+  /// is found.
+  bool visitBlockFromGenUntilBegin(SILInstruction *from) {
+    assert(effects.effectForInstruction(from) == Effects::Effect::Gen());
+    for (auto *instruction = from; instruction;
+         instruction = instruction->getPreviousInstruction()) {
+      if (visitInstruction(instruction))
+        return true;
+    }
+    auto *block = from->getParent();
+    if (block->hasPhi()) {
+      if (visitPhi(block))
+        return true;
+    }
+    return false;
+  }
+
+  /// Visit a block from a non-local gen which begins the region.
+  ///
+  /// Avoids visiting the portion of the block occurring after an initial gen.
+  void visitBlockFromGen(SILInstruction *from) {
+    auto *block = from->getParent();
+
+    assert(effects.effectForInstruction(from) == Effects::Effect::Gen());
+    assert(!llvm::any_of(
+        block->getSuccessorBlocks(),
+        [&](SILBasicBlock *successor) { return visited.contains(successor); }));
+
+    visited.insert(block);
+    bool foundLocalKill = visitBlockFromGenUntilBegin(from);
+    assert(!foundLocalKill && "found local kill for non-local gen?!");
+    (void)foundLocalKill;
+    visitBlockBegin(block);
+  }
+
+  /// Visit a block fully; its end, its body, its phi, and its begin.
+  void visitBlock(SILBasicBlock *block) {
+    visitBlockEnd(block);
+    for (auto &instruction : llvm::reverse(*block)) {
+      visitInstruction(&instruction);
+    }
+    if (block->hasPhi())
+      visitPhi(block);
+    visitBlockBegin(block);
+  }
+
+  /// Visit block components:
+  /// - block end
+  /// - instruction
+  /// - phi
+  /// - block begin
+
+  /// Visit an instruction.  Returns whether it is a barrier.
+  bool visitInstruction(SILInstruction *instruction) {
+    if (auto *eai = dyn_cast<EndAccessInst>(instruction)) {
+      runningLiveAccessScopes.insert(eai->getBeginAccess());
+    } else if (auto *bai = dyn_cast<BeginAccessInst>(instruction)) {
+      runningLiveAccessScopes.erase(bai);
+    }
+    return handleEffect(effects.effectForInstruction(instruction));
+  }
+
+  /// Visit a phi.  Returns whether it is a barrier.
+  bool visitPhi(SILBasicBlock *block) {
+    return handleEffect(effects.effectForPhi(block));
+  }
+
+  /// Visit a block begin.  If any access scopes are live, record them for use
+  /// (unioning) when the end of a predecessor is visited.
+  void visitBlockBegin(SILBasicBlock *block) {
+    if (!runningLiveAccessScopes.empty()) {
+      liveInAccessScopes[block] = runningLiveAccessScopes;
+    }
+  }
+
+  /// Visit a block end.  Set the running access scopes for the block to be the
+  /// union of all access scopes live at the begin of successor blocks.  Returns
+  /// whether the block is a barrier.
+  bool visitBlockEnd(SILBasicBlock *block) {
+    visited.insert(block);
+    runningLiveAccessScopes.clear();
+    for (auto *successor : block->getSuccessorBlocks()) {
+      auto iterator = liveInAccessScopes.find(successor);
+      if (iterator != liveInAccessScopes.end()) {
+        for (auto *bai : iterator->getSecond()) {
+          runningLiveAccessScopes.insert(bai);
+        }
+      }
+    }
+    // If any of this block's predecessors haven't already been visited, it
+    // means that they aren't in the region and consequently this block is a
+    // barrier block.
+    if (llvm::any_of(block->getSuccessorBlocks(), [&](SILBasicBlock *block) {
+          return !visited.contains(block);
+        })) {
+      handleBarrier();
+      return true;
+    }
+
+    return false;
+  }
+
+  /// Effect procecessing
+
+  bool handleEffect(typename Effects::Effect effect) {
+    switch (effect.value) {
+    case Effects::Effect::Value::NoEffect:
+      return false;
+    case Effects::Effect::Value::Gen:
+      runningLiveAccessScopes.clear();
+      return false;
+    case Effects::Effect::Value::Kill:
+      handleBarrier();
+      return true;
+    }
+  }
+
+  void handleBarrier() {
+    for (auto *scope : runningLiveAccessScopes) {
+      visitor.visitBarrierAccessScope(scope);
+    }
+  }
+
+  /// SILCFGBackwardDFS::Visitor
+  friend struct SILCFGBackwardDFS<This>;
+
+  /// Whether the block is in the region of interest.  Just a passhthrough to
+  /// our visitor.
+  bool isInRegion(SILBasicBlock *block) { return visitor.isInRegion(block); }
+};
+
+} // end namespace swift

--- a/lib/SILOptimizer/Transforms/SSADestroyHoisting.cpp
+++ b/lib/SILOptimizer/Transforms/SSADestroyHoisting.cpp
@@ -98,6 +98,7 @@
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SILOptimizer/Analysis/Reachability.h"
+#include "swift/SILOptimizer/Analysis/VisitBarrierAccessScopes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/InstructionDeleter.h"
 
@@ -186,23 +187,25 @@ protected:
   }
 };
 
+class DestroyReachability;
+
 /// Step #2: Perform backward dataflow from KnownStorageUses.originalDestroys to
 /// KnownStorageUses.storageUsers to find deinitialization barriers.
-class DeinitBarriers {
+class DeinitBarriers final {
 public:
-  // Data flow state: blocks whose beginning is backward reachable from a
-  // destroy without first reaching a barrier or storage use.
-  SmallPtrSetVector<SILBasicBlock *, 4> destroyReachesBeginBlocks;
+  // Instructions beyond which a destroy_addr cannot be hoisted, reachable from
+  // a destroy_addr.  Deinit barriers or storage uses.
+  SmallSetVector<SILInstruction *, 4> barrierInstructions;
 
-  // Data flow state: blocks whose end is backward reachable from a destroy
-  // without first reaching a barrier or storage use.
-  SmallPtrSet<SILBasicBlock *, 4> destroyReachesEndBlocks;
+  // Phis beyond which a destroy_addr cannot be hoisted, reachable from a
+  // destroy_addr.
+  SmallSetVector<SILBasicBlock *, 4> barrierPhis;
 
-  // Deinit barriers or storage uses within a block, reachable from a destroy.
-  SmallVector<SILInstruction *, 4> barriers;
+  // Blocks beyond the end of which a destroy_addr cannot be hoisted.
+  SmallSetVector<SILBasicBlock *, 4> barrierBlocks;
 
   // Debug instructions that are no longer within this lifetime after shrinking.
-  SmallVector<SILInstruction *, 4> deadUsers;
+  SmallSetVector<SILInstruction *, 4> deadUsers;
 
   // The access scopes which are hoisting barriers.
   //
@@ -222,22 +225,13 @@ public:
     storageDefInst = rootValue->getDefiningInstruction();
   }
 
-  void compute() {
-    FindBarrierAccessScopes(*this).solveBackward();
-    if (barrierAccessScopes.size() == 0)
-      return;
-    destroyReachesBeginBlocks.clear();
-    destroyReachesEndBlocks.clear();
-    barriers.clear();
-    deadUsers.clear();
-    DestroyReachability(*this).solveBackward();
-  }
+  void compute() { DestroyReachability(*this).solve(); }
 
   bool isBarrier(SILInstruction *instruction) const {
-    return classificationIsBarrier(
-        classifyInstruction(instruction, ignoreDeinitBarriers, storageDefInst,
-                            barrierAccessScopes, knownUses));
+    return classificationIsBarrier(classifyInstruction(instruction));
   };
+
+  friend class DestroyReachability;
 
 private:
   DeinitBarriers(DeinitBarriers const &) = delete;
@@ -249,177 +243,95 @@ private:
 
   enum class Classification { DeadUser, Barrier, Other };
 
-  Classification classifyInstruction(SILInstruction *inst) {
-    return classifyInstruction(inst, ignoreDeinitBarriers, storageDefInst,
-                               barrierAccessScopes, knownUses);
-  }
-
-  static Classification classifyInstruction(
-      SILInstruction *inst, bool ignoreDeinitBarriers,
-      SILInstruction *storageDefInst,
-      const llvm::SmallPtrSetImpl<BeginAccessInst *> &barrierAccessScopes,
-      const KnownStorageUses &knownUses);
-
-  void visitedInstruction(SILInstruction *instruction,
-                          Classification classification);
+  Classification classifyInstruction(SILInstruction *inst) const;
 
   static bool classificationIsBarrier(Classification classification);
 
-  // Implements BackwardReachability::BlockReachability
-  //
-  // Determine which end_access instructions must be treated as barriers.
-  //
-  // An end_access is a barrier if the access scope it ends contains any deinit
-  // barriers.  Suppose that it weren't treated as a barrier.  Then the
-  // destroy_addr would be hoisted up to the in-scope deinit barrier.  That
-  // could result in a deinit being executed within the scope which was
-  // previously executed outside it.  Executing a deinit in the scope could
-  // violate exclusivity.
-  //
-  // So before determining what ALL the barriers are, we need to determine which
-  // end_access instructions are barriers.  Do that by observing which access
-  // scopes are open when encountering a barrier.  The access scopes which are
-  // open are those for which we've seen an end_access instruction when walking
-  // backwards from the destroy_addrs.  Add these access scopes to
-  // DeinitBarriers::barrierAccessScopes.
-  //
-  // Tracking which access scopes are open consists of two parts:
-  // (1) in-block analysis
-  // (2) cross-block analysis
-  // For (1), maintain a set of access scopes which are currently open.  Insert
-  // and erase scopes when seeing begin_access and end_access instructions when
-  // they're visited in checkReachableBarrier.  A stack can't be used here
-  // because access scopes are not necessarily nested.
-  // For (2), when entering a block, the access scope is the union of all the
-  // open access scopes in the block's predecessors.
-  class FindBarrierAccessScopes {
+  /// Operates backward reachability and access scope visitor.  Implements the
+  /// interfaces involved.
+  ///
+  /// Implements IterativeBackwardReachability::findBarriers::Visitor
+  /// Implements VisitBarrierAccessScopes::Visitor
+  /// Implements IterativeBackwardReachability::Effects
+  /// Implements VisitBarrierAccessScopes::Effects
+  class DestroyReachability final {
+    using Dataflow = IterativeBackwardReachability<DestroyReachability>;
+    using Effect = Dataflow::Effect;
+    using ScopeVisitor =
+        VisitBarrierAccessScopes<DestroyReachability, DestroyReachability>;
+
     DeinitBarriers &result;
-    llvm::DenseMap<SILBasicBlock *, llvm::SmallPtrSet<BeginAccessInst *, 2>>
-        liveInAccessScopes;
-    llvm::SmallPtrSet<BeginAccessInst *, 2> runningLiveAccessScopes;
-
-    BackwardReachability<FindBarrierAccessScopes> reachability;
-
-  public:
-    FindBarrierAccessScopes(DeinitBarriers &result)
-        : result(result), reachability(result.knownUses.getFunction(), *this) {
-      // Seed backward reachability with destroy points.
-      for (SILInstruction *destroy : result.knownUses.originalDestroys) {
-        reachability.initLastUse(destroy);
-      }
-    }
-
-    void markLiveAccessScopesAsBarriers() {
-      for (auto *scope : runningLiveAccessScopes) {
-        result.barrierAccessScopes.insert(scope);
-      }
-    }
-
-    bool hasReachableBegin(SILBasicBlock *block) {
-      return result.destroyReachesBeginBlocks.contains(block);
-    }
-
-    void markReachableBegin(SILBasicBlock *block) {
-      result.destroyReachesBeginBlocks.insert(block);
-      if (!runningLiveAccessScopes.empty()) {
-        liveInAccessScopes[block] = runningLiveAccessScopes;
-      }
-    }
-
-    void markReachableEnd(SILBasicBlock *block) {
-      result.destroyReachesEndBlocks.insert(block);
-      runningLiveAccessScopes.clear();
-      for (auto *predecessor : block->getPredecessorBlocks()) {
-        auto iterator = liveInAccessScopes.find(predecessor);
-        if (iterator != liveInAccessScopes.end()) {
-          for (auto *bai : iterator->getSecond()) {
-            runningLiveAccessScopes.insert(bai);
-          }
-        }
-      }
-    }
-
-    bool checkReachableBarrier(SILInstruction *inst) {
-      // For correctness, it is required that
-      // FindBarrierAccessScopes::checkReachableBarrier return true whenever
-      // DestroyReachability::checkReachableBarrier does, with one exception:
-      // DestryReachability::checkReachableBarrier will also return true for any
-      // end_access barrier that FindBarrierAccessScopes finds.
-      if (auto *eai = dyn_cast<EndAccessInst>(inst)) {
-        runningLiveAccessScopes.insert(eai->getBeginAccess());
-      } else if (auto *bai = dyn_cast<BeginAccessInst>(inst)) {
-        runningLiveAccessScopes.erase(bai);
-      }
-      auto classification = result.classifyInstruction(inst);
-      result.visitedInstruction(inst, classification);
-      auto isBarrier = result.classificationIsBarrier(classification);
-      if (isBarrier) {
-        markLiveAccessScopesAsBarriers();
-      }
-      // If we've seen a barrier, then we can stop looking for access scopes.
-      // Any that were open already have now been marked as barriers.  And if
-      // none are open, the second data flow won't get beyond this barrier to
-      // face subsequent end_access instructions.
-      return isBarrier;
-    }
-
-    bool checkReachablePhiBarrier(SILBasicBlock *block) {
-      bool isBarrier =
-          llvm::any_of(block->getPredecessorBlocks(), [&](auto *predecessor) {
-            return result.isBarrier(predecessor->getTerminator());
-          });
-      if (isBarrier) {
-        // If there's a barrier preventing us from hoisting out of this block,
-        // then every open access scope contains a barrier, so all the
-        // corresponding end_access instructions are barriers too.
-        markLiveAccessScopesAsBarriers();
-      }
-      return isBarrier;
-    }
-
-    void solveBackward() { reachability.solveBackward(); }
-  };
-
-  // Conforms to BackwardReachability::BlockReachability
-  class DestroyReachability {
-    DeinitBarriers &result;
-
-    BackwardReachability<DestroyReachability> reachability;
+    Dataflow::Result reachability;
+    Dataflow dataflow;
+    Optional<SmallVector<SILBasicBlock *, 16>> cachedRoots;
+    bool recordDeadUsers = false;
 
   public:
     DestroyReachability(DeinitBarriers &result)
-        : result(result), reachability(result.knownUses.getFunction(), *this) {
-      // Seed backward reachability with destroy points.
-      for (SILInstruction *destroy : result.knownUses.originalDestroys) {
-        reachability.initLastUse(destroy);
+        : result(result), reachability(result.knownUses.getFunction()),
+          dataflow(result.knownUses.getFunction(),
+                   result.storageDefInst ? result.storageDefInst->getParent()
+                                         : nullptr,
+                   *this, reachability) {}
+
+    void solve();
+
+  private:
+    friend Dataflow;
+    friend ScopeVisitor;
+
+    /// IterativeBackwardReachability::Effects
+    /// VisitBarrierAccessScopes::Effects
+
+    ArrayRef<SILInstruction *> gens() {
+      return result.knownUses.originalDestroys;
+    }
+
+    Effect effectForInstruction(SILInstruction *instruction);
+
+    Effect effectForPhi(SILBasicBlock *block);
+
+    /// VisitBarrierAccessScopes::Effects
+
+    bool isLocalGen(SILInstruction *instruction) {
+      return reachability.localGens.contains(instruction);
+    }
+
+    auto localGens() { return reachability.localGens; }
+
+    /// IterativeBackwardReachability::findBarriers::Visitor:
+
+    void visitBarrierInstruction(SILInstruction *instruction) {
+      result.barrierInstructions.insert(instruction);
+    }
+
+    void visitBarrierPhi(SILBasicBlock *block) {
+      result.barrierPhis.insert(block);
+    }
+
+    void visitBarrierBlock(SILBasicBlock *block) {
+      result.barrierBlocks.insert(block);
+    }
+
+    /// VisitBarrierAccessScopes::Visitor
+
+    ArrayRef<SILBasicBlock *> roots();
+
+    bool isInRegion(SILBasicBlock *block) {
+      return reachability.discoveredBlocks.contains(block);
+    }
+
+    void visitBarrierAccessScope(BeginAccessInst *bai) {
+      result.barrierAccessScopes.insert(bai);
+      for (auto *eai : bai->getEndAccesses()) {
+        dataflow.addKill(eai);
       }
     }
-
-    bool hasReachableBegin(SILBasicBlock *block) {
-      return result.destroyReachesBeginBlocks.contains(block);
-    }
-
-    void markReachableBegin(SILBasicBlock *block) {
-      result.destroyReachesBeginBlocks.insert(block);
-    }
-
-    void markReachableEnd(SILBasicBlock *block) {
-      result.destroyReachesEndBlocks.insert(block);
-    }
-
-    bool checkReachableBarrier(SILInstruction *);
-
-    bool checkReachablePhiBarrier(SILBasicBlock *);
-
-    void solveBackward() { reachability.solveBackward(); }
   };
 };
 
-DeinitBarriers::Classification DeinitBarriers::classifyInstruction(
-    SILInstruction *inst, bool ignoreDeinitBarriers,
-    SILInstruction *storageDefInst,
-    const llvm::SmallPtrSetImpl<BeginAccessInst *> &barrierAccessScopes,
-    const KnownStorageUses &knownUses) {
+DeinitBarriers::Classification
+DeinitBarriers::classifyInstruction(SILInstruction *inst) const {
   if (knownUses.debugInsts.contains(inst)) {
     return Classification::DeadUser;
   }
@@ -433,9 +345,9 @@ DeinitBarriers::Classification DeinitBarriers::classifyInstruction(
     return Classification::Barrier;
   }
   if (auto *eai = dyn_cast<EndAccessInst>(inst)) {
-    return barrierAccessScopes.contains(eai->getBeginAccess())
-               ? Classification::Barrier
-               : Classification::Other;
+    if (barrierAccessScopes.contains(eai->getBeginAccess())) {
+      return Classification::Barrier;
+    }
   }
   return Classification::Other;
 }
@@ -451,46 +363,35 @@ bool DeinitBarriers::classificationIsBarrier(Classification classification) {
   llvm_unreachable("exhaustive switch is not exhaustive?!");
 }
 
-void DeinitBarriers::visitedInstruction(SILInstruction *instruction,
-                                        Classification classification) {
-  assert(classifyInstruction(instruction) == classification);
-  switch (classification) {
-  case Classification::DeadUser:
-    deadUsers.push_back(instruction);
-    break;
-  case Classification::Barrier:
-    barriers.push_back(instruction);
-    break;
-  case Classification::Other:
-    break;
-  }
-}
-
-/// Return true if \p inst is a barrier.
-///
-/// Called exactly once for each reachable instruction. This is guaranteed to
-/// hold as a barrier occurs between any original destroys that are reachable
-/// from each. Any path reaching multiple destroys requires initialization,
-/// which is a storageUser and therefore a barrier.
-bool DeinitBarriers::DestroyReachability::checkReachableBarrier(
+DeinitBarriers::DestroyReachability::Effect
+DeinitBarriers::DestroyReachability::effectForInstruction(
     SILInstruction *instruction) {
-  // For correctness, it is required that
-  // DestroyReachability::checkReachableBarrier return true whenever
-  // FindBarrierAccessScopes::checkReachableBarrier does.  It must additionally
-  // return true when encountering an end_access barrier that
-  // FindBarrierAccessScope determined is a barrier.
+  if (llvm::find(result.knownUses.originalDestroys, instruction) !=
+      result.knownUses.originalDestroys.end())
+    return Effect::Gen();
   auto classification = result.classifyInstruction(instruction);
-  result.visitedInstruction(instruction, classification);
-  return result.classificationIsBarrier(classification);
+  if (recordDeadUsers && classification == Classification::DeadUser)
+    result.deadUsers.insert(instruction);
+  return result.classificationIsBarrier(classification) ? Effect::Kill()
+                                                        : Effect::NoEffect();
 }
 
-bool DeinitBarriers::DestroyReachability::checkReachablePhiBarrier(
-    SILBasicBlock *block) {
-  assert(llvm::all_of(block->getArguments(),
-                      [&](auto argument) { return PhiValue(argument); }));
-  return llvm::any_of(block->getPredecessorBlocks(), [&](auto *predecessor) {
-    return result.isBarrier(predecessor->getTerminator());
-  });
+DeinitBarriers::DestroyReachability::Effect
+DeinitBarriers::DestroyReachability::effectForPhi(SILBasicBlock *block) {
+  bool isBarrier =
+      llvm::any_of(block->getPredecessorBlocks(), [&](auto *predecessor) {
+        return result.isBarrier(predecessor->getTerminator());
+      });
+  return isBarrier ? Effect::Kill() : Effect::NoEffect();
+}
+
+void DeinitBarriers::DestroyReachability::solve() {
+  dataflow.initialize();
+  ScopeVisitor visitor(result.knownUses.getFunction(), *this, *this);
+  visitor.visit();
+  dataflow.solve();
+  recordDeadUsers = true;
+  dataflow.findBarriers(*this);
 }
 
 /// Algorithm for hoisting the destroys of a single uniquely identified storage
@@ -576,7 +477,7 @@ bool HoistDestroys::rewriteDestroys(const AccessStorage &storage,
                                     const KnownStorageUses &knownUses,
                                     const DeinitBarriers &deinitBarriers) {
   // Place a new destroy after each barrier instruction.
-  for (SILInstruction *barrier : deinitBarriers.barriers) {
+  for (SILInstruction *barrier : deinitBarriers.barrierInstructions) {
     auto *barrierBlock = barrier->getParent();
     if (barrier != barrierBlock->getTerminator()) {
       if (!foldBarrier(barrier, storage, knownUses, deinitBarriers))
@@ -589,24 +490,13 @@ bool HoistDestroys::rewriteDestroys(const AccessStorage &storage,
   }
   // Place a new destroy at each CFG edge in which the successor's beginning is
   // reached but the predecessors end is not reached.
-  for (auto *beginReachedBlock : deinitBarriers.destroyReachesBeginBlocks) {
-    SILInstruction *barrier = nullptr;
-    if (auto *predecessor = beginReachedBlock->getSinglePredecessorBlock()) {
-      if (deinitBarriers.destroyReachesEndBlocks.contains(predecessor))
-        continue;
-
-      barrier = predecessor->getTerminator();
-
-    } else if (!beginReachedBlock->pred_empty()) {
-      // This is the only successor, so the destroy must reach the predecessors.
-      assert(llvm::all_of(
-          beginReachedBlock->getPredecessorBlocks(), [&](auto *predecessor) {
-            return deinitBarriers.destroyReachesEndBlocks.contains(predecessor);
-          }));
-      continue;
-    }
+  for (auto *block : deinitBarriers.barrierPhis) {
+    // The destroy does not reach above the block's phi.
+    insertDestroy(nullptr, &block->front(), knownUses);
+  }
+  for (auto *block : deinitBarriers.barrierBlocks) {
     // The destroy does not reach the end of any predecessors.
-    insertDestroy(barrier, &beginReachedBlock->front(), knownUses);
+    insertDestroy(nullptr, &block->front(), knownUses);
   }
   // Delete dead users before merging destroys.
   for (auto *deadInst : deinitBarriers.deadUsers) {

--- a/test/SILOptimizer/hoist_destroy_addr.sil
+++ b/test/SILOptimizer/hoist_destroy_addr.sil
@@ -239,7 +239,7 @@ bb3:
 // CHECK-NEXT: br bb1
 // CHECK: bb3:
 // CHECKDEB:   debug_value [[ALLOC]] : $*T, let, name "t"
-// CHECKOPT-NONE: debug_value
+// CHECKOPT-NOT: debug_value
 // CHECK:   destroy_addr [[ALLOC]] : $*T
 // CHECK:   dealloc_stack [[ALLOC]] : $*T
 // CHECK-LABEL: } // end sil function 'destroyLoop'
@@ -346,6 +346,106 @@ backedge:
 exit:
   %321 = tuple ()
   return %321 : $()
+}
+
+// Exercise portion of IterativeBackwardReachability where an
+// unreachable-at-begin block is added to the worklist but its predecessor
+// isn't discovered.
+//
+// CHECK-LABEL: sil [ossa] @undiscovered_predecessor_of_unreachable_at_begin : {{.*}} {
+// CHECK:         apply undef
+// CHECK-NEXT:    destroy_addr
+// CHECK-LABEL: } // end sil function 'undiscovered_predecessor_of_unreachable_at_begin'
+sil [ossa] @undiscovered_predecessor_of_unreachable_at_begin : $@convention(thin) (@owned S) -> () {
+entry(%instance : @owned $S):
+  %addr = alloc_stack $S
+  store %instance to [init] %addr : $*S
+  br applier
+
+applier:
+  apply undef() : $@convention(thin) () -> ()
+  br good
+
+good:
+  destroy_addr %addr : $*S
+  dealloc_stack %addr : $*S
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Access scopes that are open at barrier blocks are barriers.  Otherwise, we
+// would hoist destroy_addrs into the scopes when the destroy_addrs are hoisted
+// up to the begin of blocks whose predecessor is the barrier block.
+//
+// CHECK-LABEL: sil [ossa] @nohoist_into_access_scope_barred_by_barrier_block : {{.*}} {
+// CHECK:       {{bb[0-9]+}}({{%[^,]+}} : @owned $X, [[INOUT:%[^,]+]] : $*X):
+// CHECK:         [[ADDR:%[^,]+]] = alloc_stack $X                             
+// CHECK:         [[SCOPE:%[^,]+]] = begin_access [modify] [static] [[INOUT]] : $*X    
+// CHECK:         cond_br undef, [[LEFT:bb[0-9]+]],
+// CHECK:       [[LEFT]]:                                              
+// CHECK:         end_access [[SCOPE]] : $*X                             
+// CHECK-NEXT:    destroy_addr [[ADDR]] : $*X                           
+// CHECK-LABEL: } // end sil function 'nohoist_into_access_scope_barred_by_barrier_block'
+sil [ossa] @nohoist_into_access_scope_barred_by_barrier_block : $@convention(thin) (@owned X, @inout X) -> () {
+entry(%instance : @owned $X, %second : $*X):
+    %addr = alloc_stack $X
+    store %instance to [init] %addr : $*X
+    %scope = begin_access [modify] [static] %second : $*X
+    cond_br undef, left, right
+
+left:
+    end_access %scope : $*X
+    %ignore = tuple ()
+    destroy_addr %addr : $*X
+    br exit
+
+right:
+    end_access %scope : $*X
+    apply undef(%addr) : $@convention(thin) (@in X) -> ()
+    br exit
+
+exit:
+    dealloc_stack %addr : $*X
+    %retval = tuple ()
+    return %retval : $()
+}
+
+// Access scopes that are open at barrier blocks are barriers.  That includes 
+// barrier blocks both of whose successors contain gens (if one contains a prior
+// kill).
+//
+// CHECK-LABEL: sil [ossa] @nohoist_into_access_scope_barred_by_barrier_block_2 : {{.*}} {
+// CHECK:       {{bb[0-9]+}}({{%[^,]+}} : @owned $X, [[INOUT:%[^,]+]] : $*X):
+// CHECK:         [[ADDR:%[^,]+]] = alloc_stack $X                             
+// CHECK:         [[SCOPE:%[^,]+]] = begin_access [modify] [static] [[INOUT]] : $*X    
+// CHECK:         cond_br undef, [[LEFT:bb[0-9]+]],
+// CHECK:       [[LEFT]]:                                              
+// CHECK:         end_access [[SCOPE]] : $*X                             
+// CHECK-NEXT:    destroy_addr [[ADDR]] : $*X                           
+// CHECK-LABEL: } // end sil function 'nohoist_into_access_scope_barred_by_barrier_block_2'
+sil [ossa] @nohoist_into_access_scope_barred_by_barrier_block_2 : $@convention(thin) (@owned X, @inout X) -> () {
+entry(%instance : @owned $X, %second : $*X):
+    %addr = alloc_stack $X
+    store %instance to [init] %addr : $*X
+    %scope = begin_access [modify] [static] %second : $*X
+    cond_br undef, left, right
+
+left:
+    end_access %scope : $*X
+    %ignore = tuple ()
+    destroy_addr %addr : $*X
+    br exit
+
+right:
+    end_access %scope : $*X
+    apply undef(%addr) : $@convention(thin) (@in_guaranteed X) -> ()
+    destroy_addr %addr : $*X
+    br exit
+
+exit:
+    dealloc_stack %addr : $*X
+    %retval = tuple ()
+    return %retval : $()
 }
 
 // Hoist a destroy_addr of an @in argument over a load from an alloc_stack.

--- a/test/SILOptimizer/hoist_destroy_addr_loop.sil
+++ b/test/SILOptimizer/hoist_destroy_addr_loop.sil
@@ -1,0 +1,74 @@
+// RUN: %target-sil-opt -opt-mode=none  -enable-sil-verify-all %s -ssa-destroy-hoisting | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECKDEB
+// RUN: %target-sil-opt -opt-mode=speed -enable-sil-verify-all %s -ssa-destroy-hoisting | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECKOPT
+
+sil_stage canonical
+
+import Builtin
+
+typealias AnyObject = Builtin.AnyObject
+
+class X {
+}
+
+sil [ossa] @get_owned_X : $@convention(thin) () -> @owned X 
+
+// Hoist the destroy_addr of an inout over a loop and over a deinit barrier to
+// the top of the enclosing function.
+//
+// CHECK-LABEL: sil [ossa] @hoist_over_loop_inout : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[ADDR:%[^,]+]] :
+// CHECK-NEXT:    destroy_addr [[ADDR]]
+// CHECK-LABEL: } // end sil function 'hoist_over_loop_inout'
+sil [ossa] @hoist_over_loop_inout : $@convention(thin) (@inout X) -> () {
+bb0(%0 : $*X):
+ %1 = function_ref @get_owned_X : $@convention(thin) () -> @owned X 
+ %14 = apply %1() : $@convention(thin) () -> @owned X 
+ br bb1                        
+
+bb1:   
+ br bb2   
+
+bb2:   
+ cond_br undef, bb3, bb4   
+
+bb3:   
+ br bb1   
+
+bb4:   
+ destroy_addr %0 : $*X   
+ store %14 to [init] %0 : $*X            
+ %23 = tuple ()   
+ return %23 : $()   
+}
+
+// CHECK-LABEL: sil [ossa] @nohoist_into_unrelated_access_scope_above_loop : {{.*}} {
+// CHECK:       {{bb[0-9]+}}({{%[^,]+}} : @owned $X, [[REGISTER_1:%[^,]+]] : $*X):
+// CHECK:         end_access
+// CHECK-NEXT:    destroy_addr
+// CHECK-LABEL: } // end sil function 'nohoist_into_unrelated_access_scope_above_loop'
+sil [ossa] @nohoist_into_unrelated_access_scope_above_loop : $@convention(thin) (@owned X, @inout X) -> () {
+bb0(%instance : @owned $X, %second: $*X):
+ %addr = alloc_stack $X
+ store %instance to [init] %addr : $*X
+ %scope = begin_access [modify] [static] %second : $*X
+ %1 = function_ref @get_owned_X : $@convention(thin) () -> @owned X 
+ %14 = apply %1() : $@convention(thin) () -> @owned X 
+ destroy_value %14 : $X
+ end_access %scope : $*X
+ br bb1                        
+
+bb1:   
+ br bb2   
+
+bb2:   
+ cond_br undef, bb3, bb4   
+
+bb3:   
+ br bb1   
+
+bb4:   
+ destroy_addr %addr : $*X
+ dealloc_stack %addr : $*X
+ %23 = tuple ()   
+ return %23 : $()   
+}

--- a/validation-test/SILOptimizer/hoist_destroy_addr.sil
+++ b/validation-test/SILOptimizer/hoist_destroy_addr.sil
@@ -1,0 +1,2297 @@
+// RUN: %target-sil-opt -opt-mode=none  -enable-sil-verify-all %s -ssa-destroy-hoisting | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECKDEB
+// RUN: %target-sil-opt -opt-mode=speed -enable-sil-verify-all %s -ssa-destroy-hoisting | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECKOPT
+
+// REQUIRES: long_test
+// REQUIRES: objc_interop
+
+import Builtin
+import Swift
+import SwiftShims
+
+sil [ossa] @$s10Foundation4DataV06InlineB0Vys5UInt8VSicis : $@convention(method) (UInt8, Int, @inout Data.InlineData) -> ()
+sil [ossa] @$s10Foundation4DataV10LargeSliceVys5UInt8VSicis : $@convention(method) (UInt8, Int, @inout Data.LargeSlice) -> ()
+sil [ossa] @$s10Foundation4DataV11InlineSliceVys5UInt8VSicis : $@convention(method) (UInt8, Int, @inout Data.InlineSlice) -> ()
+sil [ossa] @$sSMsSKRzrlE7reverseyyF : $@convention(method) <τ_0_0 where τ_0_0 : BidirectionalCollection, τ_0_0 : MutableCollection> (@inout τ_0_0) -> ()
+sil [ossa] @$sSMsSKRzrlE7reverseyyFSays5UInt8VG_Tg5 : $@convention(method) (@inout Array<UInt8>) -> ()
+sil [ossa] @$sSN16_uncheckedBoundsSNyxGx5lower_x5uppert_tcfC : $@convention(method) <τ_0_0 where τ_0_0 : Comparable> (@in τ_0_0, @in τ_0_0, @thin ClosedRange<τ_0_0>.Type) -> @out ClosedRange<τ_0_0>
+sil [ossa] @$sSR5start5countSRyxGSPyxGSg_SitcfCs5UInt8V_Tg5 : $@convention(method) (Optional<UnsafePointer<UInt8>>, Int, @thin UnsafeBufferPointer<UInt8>.Type) -> UnsafeBufferPointer<UInt8>
+sil [ossa] @$sSRys5UInt8VGSSs5Error_pIgyozo_ACSSsAD_pIegyrzo_TR : $@convention(thin) (UnsafeBufferPointer<UInt8>, @noescape @callee_guaranteed (UnsafeBufferPointer<UInt8>) -> (@owned String, @error Error)) -> (@out String, @error Error)
+sil [ossa] @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+sil [ossa] @$sSUss17FixedWidthIntegerRzrlEyxqd__cSzRd__lufC : $@convention(method) <τ_0_0 where τ_0_0 : FixedWidthInteger, τ_0_0 : UnsignedInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
+sil [ossa] @$sSXsE2teoiySbx_5BoundQztFZ : $@convention(method) <τ_0_0 where τ_0_0 : RangeExpression> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0.Bound, @thick τ_0_0.Type) -> Bool
+sil [ossa] @$sSZsE8isSignedSbvgZ : $@convention(method) <τ_0_0 where τ_0_0 : SignedInteger> (@thick τ_0_0.Type) -> Bool
+sil [ossa] @$sSZss17FixedWidthIntegerRzrlEyxqd__cSzRd__lufC : $@convention(method) <τ_0_0 where τ_0_0 : FixedWidthInteger, τ_0_0 : SignedInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
+sil [ossa] @$sSa034_makeUniqueAndReserveCapacityIfNotB0yyFs5UInt8V_Tg5 : $@convention(method) (@inout Array<UInt8>) -> ()
+sil [ossa] @$sSa12_endMutationyyFs5UInt8V_Tg5 : $@convention(method) (@inout Array<UInt8>) -> ()
+sil [ossa] @$sSa22_allocateUninitializedySayxG_SpyxGtSiFZs5UInt8V_Tg5 : $@convention(method) (Int, @thin Array<UInt8>.Type) -> (@owned Array<UInt8>, UnsafeMutablePointer<UInt8>)
+sil [ossa] @$sSa23withUnsafeBufferPointeryqd__qd__SRyxGKXEKlF : $@convention(method) <τ_0_0><τ_1_0> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2 where τ_0_0 == τ_0_1> (UnsafeBufferPointer<τ_0_0>) -> (@out τ_0_2, @error Error) for <τ_0_0, τ_0_0, τ_1_0>, @guaranteed Array<τ_0_0>) -> (@out τ_1_0, @error Error)
+sil [ossa] @$sSa36_reserveCapacityAssumingUniqueBuffer8oldCountySi_tFs5UInt8V_Tg5 : $@convention(method) (Int, @inout Array<UInt8>) -> ()
+sil [ossa] @$sSa37_appendElementAssumeUniqueAndCapacity_03newB0ySi_xntFs5UInt8V_Tg5 : $@convention(method) (Int, UInt8, @inout Array<UInt8>) -> ()
+sil [ossa] @$sSa6appendyyxnF : $@convention(method) <τ_0_0> (@in τ_0_0, @inout Array<τ_0_0>) -> ()
+sil [ossa] @$sSa6appendyyxnFs5UInt8V_Tg5 : $@convention(method) (UInt8, @inout Array<UInt8>) -> ()
+sil [ossa] @$sSlsE7isEmptySbvg : $@convention(method) <τ_0_0 where τ_0_0 : Collection> (@in_guaranteed τ_0_0) -> Bool
+sil [ossa] @$sSp14moveInitialize4from5countySpyxG_SitF : $@convention(method) <τ_0_0> (UnsafeMutablePointer<τ_0_0>, Int, UnsafeMutablePointer<τ_0_0>) -> ()
+sil [ossa] @$sSzsE12_description5radix9uppercaseSSSi_SbtF21_quotientAndRemainderL_y9MagnitudeQz_AFtAFSzRzlF : $@convention(thin) <τ_0_0 where τ_0_0 : BinaryInteger> (@in_guaranteed τ_0_0.Magnitude, Bool, Int, @in_guaranteed τ_0_0.Magnitude) -> (@out τ_0_0.Magnitude, @out τ_0_0.Magnitude)
+sil [ossa] @$sSzsE12_description5radix9uppercaseSSSi_SbtF6_asciiL_ys5UInt8VAFSzRzlF : $@convention(thin) (UInt8, Bool, Bool) -> UInt8
+sil [ossa] @$sSzsE12_description5radix9uppercaseSSSi_SbtFSSSRys5UInt8VGXEfU_ : $@convention(thin) (UnsafeBufferPointer<UInt8>) -> @owned String
+sil [ossa] @$ss12_ArrayBufferV19firstElementAddressSpyxGvgs5UInt8V_Tg5 : $@convention(method) (@guaranteed _ArrayBuffer<UInt8>) -> UnsafeMutablePointer<UInt8>
+sil [ossa] @$ss14_int64ToString_5radix9uppercaseSSs5Int64V_AESbtF : $@convention(thin) (Int64, Int64, Bool) -> @owned String
+sil [ossa] @$ss15_uint64ToString_5radix9uppercaseSSs6UInt64V_s5Int64VSbtF : $@convention(thin) (UInt64, Int64, Bool) -> @owned String
+sil [ossa] @$ss17FixedWidthIntegerPsE03bitB0Sivg : $@convention(method) <τ_0_0 where τ_0_0 : FixedWidthInteger> (@in_guaranteed τ_0_0) -> Int
+sil [ossa] @$ss17FixedWidthIntegerPsE18truncatingIfNeededxqd___tcSzRd__lufC : $@convention(method) <τ_0_0 where τ_0_0 : FixedWidthInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
+sil [ossa] @$ss17_assertionFailure__4file4line5flagss5NeverOs12StaticStringV_A2HSus6UInt32VtF : $@convention(thin) (StaticString, StaticString, StaticString, UInt, UInt32) -> Never
+sil [ossa] @$ss18_fatalErrorMessage__4file4line5flagss5NeverOs12StaticStringV_A2HSus6UInt32VtF : $@convention(thin) (StaticString, StaticString, StaticString, UInt, UInt32) -> Never
+sil [ossa] @$ss18_growArrayCapacityyS2iF : $@convention(thin) (Int) -> Int
+sil [ossa] @$ss22_ContiguousArrayBufferV12mutableCountSivs : $@convention(method) <τ_0_0> (Int, @guaranteed _ContiguousArrayBuffer<τ_0_0>) -> ()
+sil [ossa] @$ss22_ContiguousArrayBufferV19_uninitializedCount15minimumCapacityAByxGSi_SitcfC : $@convention(method) <τ_0_0> (Int, Int, @thin _ContiguousArrayBuffer<τ_0_0>.Type) -> @owned _ContiguousArrayBuffer<τ_0_0>
+sil [ossa] @$ss22_ContiguousArrayBufferV19firstElementAddressSpyxGvg : $@convention(method) <τ_0_0> (@guaranteed _ContiguousArrayBuffer<τ_0_0>) -> UnsafeMutablePointer<τ_0_0>
+sil [ossa] @$ss22_ContiguousArrayBufferV8capacitySivg : $@convention(method) <τ_0_0> (@guaranteed _ContiguousArrayBuffer<τ_0_0>) -> Int
+sil [ossa] @$ss27_allocateUninitializedArrayySayxG_BptBwlF : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
+sil [ossa] @$ss3maxyxx_xtSLRzlF : $@convention(thin) <τ_0_0 where τ_0_0 : Comparable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0) -> @out τ_0_0
+sil [ossa] @$ss48_UnsafePartiallyInitializedContiguousArrayBufferV23addWithExistingCapacityyyxF : $@convention(method) <τ_0_0> (@in_guaranteed τ_0_0, @inout _UnsafePartiallyInitializedContiguousArrayBuffer<τ_0_0>) -> ()
+sil [ossa] @$ss7UnicodeO6ScalarV5values6UInt32Vvg : $@convention(method) (Unicode.Scalar) -> UInt32
+
+struct Data {
+    internal enum _Representation {
+        case empty
+        case inline(InlineData)
+        case slice(InlineSlice)
+        case large(LargeSlice)
+    }
+    internal struct InlineData {
+        @usableFromInline typealias Buffer = (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+                                              UInt8, UInt8, UInt8, UInt8, UInt8, UInt8) //len  //enum
+        var bytes: Buffer
+        var length: UInt8
+    }
+    internal struct InlineSlice {
+        var slice: Range<HalfInt>
+        var storage: __DataStorage
+    }
+    internal final class __DataStorage {
+        var _bytes: UnsafeMutableRawPointer?
+        var _length: Int
+        var _capacity: Int
+        var _offset: Int
+        var _deallocator: ((UnsafeMutableRawPointer, Int) -> Void)?
+        var _needToZero: Bool
+    }
+    internal struct LargeSlice {
+        var slice: RangeReference
+        var storage: __DataStorage
+    }
+    internal final class RangeReference {
+        var range: Range<Int>
+    }
+    internal typealias HalfInt = Int32
+}
+
+sil [ossa] @getX : $@convention(thin) () -> @owned X 
+sil [ossa] @useX : $@convention(thin) (@owned X) -> ()  
+
+class X {}
+
+// CHECK-LABEL: sil [ossa] @hoist_over_loop_and_fold_into_load_copy : {{.*}} {
+// CHECK: load [take]
+// CHECK-LABEL: } // end sil function 'hoist_over_loop_and_fold_into_load_copy'
+sil [ossa] @hoist_over_loop_and_fold_into_load_copy : $@convention(thin) (@inout X) -> () {
+bb0(%0 : $*X):
+ %1 = function_ref @getX : $@convention(thin) () -> @owned X 
+ %2 = begin_access [read] [static] %0 : $*X      
+ %3 = load [copy] %2 : $*X              
+ end_access %2 : $*X              
+ %5 = function_ref @useX : $@convention(thin) (@owned X) -> ()  
+ %6 = apply %5(%3) : $@convention(thin) (@owned X) -> ()
+ br bb1                        
+
+bb1:   
+ br bb2   
+
+bb2:   
+ cond_br undef, bb3, bb4   
+
+bb3:   
+ br bb1   
+
+bb4:   
+ destroy_addr %0 : $*X   
+ cond_br undef, bb5, bb6   
+
+bb5:   
+ %13 = begin_access [modify] [static] %0 : $*X  
+ %14 = apply %1() : $@convention(thin) () -> @owned X 
+ store %14 to [init] %13 : $*X            
+ end_access %13 : $*X                 
+ br bb7                        
+
+bb6:   
+ %18 = begin_access [modify] [static] %0 : $*X  
+ %19 = apply %1() : $@convention(thin) () -> @owned X 
+ store %19 to [init] %18 : $*X            
+ end_access %18 : $*X                 
+ br bb7                        
+
+bb7:   
+ %23 = tuple ()   
+ return %23 : $()   
+}
+
+// CHECK-LABEL: sil [ossa] @$sSlsE20_failEarlyRangeCheck_6boundsy5IndexQz_SnyADGtFSnySiG_Tg5 : {{.*}} {
+// CHECK-LABEL: } // end sil function '$sSlsE20_failEarlyRangeCheck_6boundsy5IndexQz_SnyADGtFSnySiG_Tg5'
+sil [ossa] @$sSlsE20_failEarlyRangeCheck_6boundsy5IndexQz_SnyADGtFSnySiG_Tg5 : $@convention(method) (Int, Range<Int>, Range<Int>) -> () {
+bb0(%0 : $Int, %1 : $Range<Int>, %2 : $Range<Int>):
+  debug_value %0 : $Int, let, name "index", argno 1
+  %4 = alloc_stack $Int
+  store %0 to [trivial] %4 : $*Int
+  debug_value %1 : $Range<Int>, let, name "bounds", argno 2
+  %7 = alloc_stack $Range<Int>
+  store %1 to [trivial] %7 : $*Range<Int>
+  debug_value %2 : $Range<Int>, let, name "self", argno 3, implicit
+  %10 = alloc_stack $Range<Int>
+  store %2 to [trivial] %10 : $*Range<Int>
+  debug_value %4 : $*Int, let, name "index", argno 1, expr op_deref
+  debug_value %7 : $*Range<Int>, let, name "bounds", argno 2, expr op_deref
+  debug_value %10 : $*Range<Int>, let, name "self", argno 3, implicit, expr op_deref
+  %15 = alloc_stack $Range<Int>
+  copy_addr %7 to [initialization] %15 : $*Range<Int>
+  %17 = alloc_stack $Int
+  copy_addr %4 to [initialization] %17 : $*Int
+  %19 = string_literal utf8 "Index out of bounds"
+  %20 = integer_literal $Builtin.Word, 19
+  %21 = builtin "ptrtoint_Word"(%19 : $Builtin.RawPointer) : $Builtin.Word
+  br bb1
+
+bb1:
+  %23 = integer_literal $Builtin.Int8, 2
+  br bb2
+
+bb2:
+  %25 = struct $StaticString (%21 : $Builtin.Word, %20 : $Builtin.Word, %23 : $Builtin.Int8)
+  %26 = string_literal utf8 "Swift/Collection.swift"
+  %27 = integer_literal $Builtin.Word, 22
+  %28 = builtin "ptrtoint_Word"(%26 : $Builtin.RawPointer) : $Builtin.Word
+  br bb3
+
+bb3:
+  %30 = integer_literal $Builtin.Int8, 2
+  br bb4
+
+bb4:
+  %32 = struct $StaticString (%28 : $Builtin.Word, %27 : $Builtin.Word, %30 : $Builtin.Int8)
+  %33 = integer_literal $Builtin.Int64, 714
+  %34 = struct $UInt (%33 : $Builtin.Int64)
+  %35 = builtin "assert_configuration"() : $Builtin.Int32
+  %36 = integer_literal $Builtin.Int32, 0
+  %37 = builtin "cmp_eq_Int32"(%35 : $Builtin.Int32, %36 : $Builtin.Int32) : $Builtin.Int1
+  cond_br %37, bb5, bb6
+
+bb5:
+  %39 = metatype $@thick Int.Type
+  %40 = struct_element_addr %15 : $*Range<Int>, #Range.lowerBound
+  %41 = alloc_stack $Int
+  copy_addr %40 to [initialization] %41 : $*Int
+  %43 = witness_method $Int, #Comparable."<=" : <Self where Self : Comparable> (Self.Type) -> (Self, Self) -> Bool : $@convention(witness_method: Comparable) <τ_0_0 where τ_0_0 : Comparable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
+  %44 = apply %43<Int>(%41, %17, %39) : $@convention(witness_method: Comparable) <τ_0_0 where τ_0_0 : Comparable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
+  destroy_addr %41 : $*Int
+  dealloc_stack %41 : $*Int
+  %47 = alloc_stack $Int
+  copy_addr %17 to [initialization] %47 : $*Int
+  %49 = alloc_stack $Range<Int>
+  copy_addr %15 to [initialization] %49 : $*Range<Int>
+  %51 = struct_extract %44 : $Bool, #Bool._value
+  cond_br %51, bb7, bb8
+
+bb6:
+  %53 = builtin "assert_configuration"() : $Builtin.Int32
+  %54 = integer_literal $Builtin.Int32, 1
+  %55 = builtin "cmp_eq_Int32"(%53 : $Builtin.Int32, %54 : $Builtin.Int32) : $Builtin.Int1
+  cond_br %55, bb18, bb19
+
+bb7:
+  %57 = metatype $@thick Int.Type
+  %58 = struct_element_addr %49 : $*Range<Int>, #Range.upperBound
+  %59 = alloc_stack $Int
+  copy_addr %58 to [initialization] %59 : $*Int
+  %61 = witness_method $Int, #Comparable."<" : <Self where Self : Comparable> (Self.Type) -> (Self, Self) -> Bool : $@convention(witness_method: Comparable) <τ_0_0 where τ_0_0 : Comparable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
+  %62 = apply %61<Int>(%47, %59, %57) : $@convention(witness_method: Comparable) <τ_0_0 where τ_0_0 : Comparable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
+  destroy_addr %59 : $*Int
+  dealloc_stack %59 : $*Int
+  br bb9(%62 : $Bool)
+
+bb8:
+  %66 = integer_literal $Builtin.Int1, 0
+  %67 = struct $Bool (%66 : $Builtin.Int1)
+  br bb9(%67 : $Bool)
+
+bb9(%69 : $Bool):
+  destroy_addr %47 : $*Int
+  destroy_addr %49 : $*Range<Int>
+  dealloc_stack %49 : $*Range<Int>
+  dealloc_stack %47 : $*Int
+  %74 = struct_extract %69 : $Bool, #Bool._value
+  %75 = integer_literal $Builtin.Int1, -1
+  %76 = builtin "int_expect_Int1"(%74 : $Builtin.Int1, %75 : $Builtin.Int1) : $Builtin.Int1
+  %77 = integer_literal $Builtin.Int1, -1
+  %78 = builtin "xor_Int1"(%76 : $Builtin.Int1, %77 : $Builtin.Int1) : $Builtin.Int1
+  cond_br %78, bb10, bb11
+
+bb10:
+  %80 = string_literal utf8 "Fatal error"
+  %81 = integer_literal $Builtin.Word, 11
+  %82 = builtin "ptrtoint_Word"(%80 : $Builtin.RawPointer) : $Builtin.Word
+  br bb12
+
+bb11:
+  destroy_addr %17 : $*Int
+  destroy_addr %15 : $*Range<Int>
+  br bb17
+
+bb12:
+  %87 = integer_literal $Builtin.Int8, 2
+  br bb13
+
+bb13:
+  %89 = struct $StaticString (%82 : $Builtin.Word, %81 : $Builtin.Word, %87 : $Builtin.Int8)
+  %90 = builtin "assert_configuration"() : $Builtin.Int32
+  %91 = integer_literal $Builtin.Int32, 0
+  %92 = builtin "cmp_eq_Int32"(%90 : $Builtin.Int32, %91 : $Builtin.Int32) : $Builtin.Int1
+  cond_br %92, bb14, bb15
+
+bb14:
+  %94 = integer_literal $Builtin.Int32, 1
+  %95 = struct $UInt32 (%94 : $Builtin.Int32)
+  br bb16(%95 : $UInt32)
+
+bb15:
+  %97 = integer_literal $Builtin.Int32, 0
+  %98 = struct $UInt32 (%97 : $Builtin.Int32)
+  br bb16(%98 : $UInt32)
+
+bb16(%100 : $UInt32):
+  %101 = function_ref @$ss17_assertionFailure__4file4line5flagss5NeverOs12StaticStringV_A2HSus6UInt32VtF : $@convention(thin) (StaticString, StaticString, StaticString, UInt, UInt32) -> Never
+  %102 = apply %101(%89, %25, %32, %34, %100) : $@convention(thin) (StaticString, StaticString, StaticString, UInt, UInt32) -> Never
+  unreachable
+
+bb17:
+  %104 = tuple ()
+  dealloc_stack %17 : $*Int
+  dealloc_stack %15 : $*Range<Int>
+  %107 = tuple ()
+  dealloc_stack %10 : $*Range<Int>
+  dealloc_stack %7 : $*Range<Int>
+  dealloc_stack %4 : $*Int
+  return %107 : $()
+
+bb18:
+  %112 = metatype $@thick Int.Type
+  %113 = struct_element_addr %15 : $*Range<Int>, #Range.lowerBound
+  %114 = alloc_stack $Int
+  copy_addr %113 to [initialization] %114 : $*Int
+  %116 = witness_method $Int, #Comparable."<=" : <Self where Self : Comparable> (Self.Type) -> (Self, Self) -> Bool : $@convention(witness_method: Comparable) <τ_0_0 where τ_0_0 : Comparable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
+  %117 = apply %116<Int>(%114, %17, %112) : $@convention(witness_method: Comparable) <τ_0_0 where τ_0_0 : Comparable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
+  destroy_addr %114 : $*Int
+  dealloc_stack %114 : $*Int
+  %120 = alloc_stack $Int
+  copy_addr [take] %17 to [initialization] %120 : $*Int
+  %122 = alloc_stack $Range<Int>
+  copy_addr [take] %15 to [initialization] %122 : $*Range<Int>
+  %124 = struct_extract %117 : $Bool, #Bool._value
+  cond_br %124, bb20, bb21
+
+bb19:
+  destroy_addr %17 : $*Int
+  destroy_addr %15 : $*Range<Int>
+  br bb23
+
+bb20:
+  %129 = metatype $@thick Int.Type
+  %130 = struct_element_addr %122 : $*Range<Int>, #Range.upperBound
+  %131 = alloc_stack $Int
+  copy_addr %130 to [initialization] %131 : $*Int
+  %133 = witness_method $Int, #Comparable."<" : <Self where Self : Comparable> (Self.Type) -> (Self, Self) -> Bool : $@convention(witness_method: Comparable) <τ_0_0 where τ_0_0 : Comparable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
+  %134 = apply %133<Int>(%120, %131, %129) : $@convention(witness_method: Comparable) <τ_0_0 where τ_0_0 : Comparable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
+  destroy_addr %131 : $*Int
+  dealloc_stack %131 : $*Int
+  br bb22(%134 : $Bool)
+
+bb21:
+  %138 = integer_literal $Builtin.Int1, 0
+  %139 = struct $Bool (%138 : $Builtin.Int1)
+  br bb22(%139 : $Bool)
+
+bb22(%141 : $Bool):
+  destroy_addr %120 : $*Int
+  destroy_addr %122 : $*Range<Int>
+  dealloc_stack %122 : $*Range<Int>
+  dealloc_stack %120 : $*Int
+  %146 = struct_extract %141 : $Bool, #Bool._value
+  %147 = integer_literal $Builtin.Int1, -1
+  %148 = builtin "xor_Int1"(%146 : $Builtin.Int1, %147 : $Builtin.Int1) : $Builtin.Int1
+  cond_fail %148 : $Builtin.Int1, "Index out of bounds"
+  br bb23
+
+bb23:
+  br bb17
+}
+
+// CHECK-LABEL: sil [ossa] @$sSzsE12_description5radix9uppercaseSSSi_SbtFs4Int8V_Tg5 : {{.*}} {
+// CHECK-LABEL: } // end sil function '$sSzsE12_description5radix9uppercaseSSSi_SbtFs4Int8V_Tg5'
+sil [ossa] @$sSzsE12_description5radix9uppercaseSSSi_SbtFs4Int8V_Tg5 : $@convention(method) (Int, Bool, Int8) -> @owned String {
+bb0(%0 : $Int, %1 : $Bool, %2 : $Int8):
+  debug_value %2 : $Int8, let, name "self", argno 3, implicit
+  %4 = alloc_stack $Int8
+  store %2 to [trivial] %4 : $*Int8
+  debug_value %0 : $Int, let, name "radix", argno 1
+  debug_value %1 : $Bool, let, name "uppercase", argno 2
+  debug_value %4 : $*Int8, let, name "self", argno 3, implicit, expr op_deref
+  %9 = string_literal utf8 "Radix must be between 2 and 36"
+  %10 = integer_literal $Builtin.Word, 30
+  %11 = builtin "ptrtoint_Word"(%9 : $Builtin.RawPointer) : $Builtin.Word
+  br bb1
+
+bb1:
+  %13 = integer_literal $Builtin.Int8, 2
+  br bb2
+
+bb2:
+  %15 = struct $StaticString (%11 : $Builtin.Word, %10 : $Builtin.Word, %13 : $Builtin.Int8)
+  %16 = string_literal utf8 "Swift/Integers.swift"
+  %17 = integer_literal $Builtin.Word, 20
+  %18 = builtin "ptrtoint_Word"(%16 : $Builtin.RawPointer) : $Builtin.Word
+  br bb3
+
+bb3:
+  %20 = integer_literal $Builtin.Int8, 2
+  br bb4
+
+bb4:
+  %22 = struct $StaticString (%18 : $Builtin.Word, %17 : $Builtin.Word, %20 : $Builtin.Int8)
+  %23 = integer_literal $Builtin.Int64, 1498
+  %24 = struct $UInt (%23 : $Builtin.Int64)
+  %25 = builtin "assert_configuration"() : $Builtin.Int32
+  %26 = integer_literal $Builtin.Int32, 0
+  %27 = builtin "cmp_eq_Int32"(%25 : $Builtin.Int32, %26 : $Builtin.Int32) : $Builtin.Int1
+  cond_br %27, bb5, bb6
+
+bb5:
+  %29 = metatype $@thin ClosedRange<Int>.Type
+  %30 = metatype $@thick ClosedRange<Int>.Type
+  %31 = alloc_stack $ClosedRange<Int>
+  %32 = metatype $@thin Int.Type
+  %33 = integer_literal $Builtin.Int64, 2
+  %34 = struct $Int (%33 : $Builtin.Int64)
+  %35 = integer_literal $Builtin.Int64, 36
+  %36 = struct $Int (%35 : $Builtin.Int64)
+  br bb7
+
+bb6:
+  %38 = builtin "assert_configuration"() : $Builtin.Int32
+  %39 = integer_literal $Builtin.Int32, 1
+  %40 = builtin "cmp_eq_Int32"(%38 : $Builtin.Int32, %39 : $Builtin.Int32) : $Builtin.Int1
+  cond_br %40, bb60, bb61
+
+bb7:
+  br bb8
+
+bb8:
+  br bb9
+
+bb9:
+  br bb10
+
+bb10:
+  %45 = builtin "assert_configuration"() : $Builtin.Int32
+  %46 = integer_literal $Builtin.Int32, 0
+  %47 = builtin "cmp_eq_Int32"(%45 : $Builtin.Int32, %46 : $Builtin.Int32) : $Builtin.Int1
+  cond_br %47, bb11, bb12
+
+bb11:
+  br bb13
+
+bb12:
+  %50 = builtin "assert_configuration"() : $Builtin.Int32
+  %51 = integer_literal $Builtin.Int32, 1
+  %52 = builtin "cmp_eq_Int32"(%50 : $Builtin.Int32, %51 : $Builtin.Int32) : $Builtin.Int1
+  cond_br %52, bb57, bb58
+
+bb13:
+  br bb14
+
+bb14:
+  %55 = tuple ()
+  %56 = metatype $@thin ClosedRange<Int>.Type
+  %57 = alloc_stack $Int
+  store %34 to [trivial] %57 : $*Int
+  %59 = alloc_stack $Int
+  store %36 to [trivial] %59 : $*Int
+  %61 = function_ref @$sSN16_uncheckedBoundsSNyxGx5lower_x5uppert_tcfC : $@convention(method) <τ_0_0 where τ_0_0 : Comparable> (@in τ_0_0, @in τ_0_0, @thin ClosedRange<τ_0_0>.Type) -> @out ClosedRange<τ_0_0>
+  %62 = apply %61<Int>(%31, %57, %59, %56) : $@convention(method) <τ_0_0 where τ_0_0 : Comparable> (@in τ_0_0, @in τ_0_0, @thin ClosedRange<τ_0_0>.Type) -> @out ClosedRange<τ_0_0>
+  dealloc_stack %59 : $*Int
+  dealloc_stack %57 : $*Int
+  %65 = tuple ()
+  %66 = load [trivial] %31 : $*ClosedRange<Int>
+  %67 = alloc_stack $ClosedRange<Int>
+  store %66 to [trivial] %67 : $*ClosedRange<Int>
+  %69 = alloc_stack $Int
+  store %0 to [trivial] %69 : $*Int
+  %71 = function_ref @$sSXsE2teoiySbx_5BoundQztFZ : $@convention(method) <τ_0_0 where τ_0_0 : RangeExpression> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0.Bound, @thick τ_0_0.Type) -> Bool
+  %72 = apply %71<ClosedRange<Int>>(%67, %69, %30) : $@convention(method) <τ_0_0 where τ_0_0 : RangeExpression> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0.Bound, @thick τ_0_0.Type) -> Bool
+  dealloc_stack %69 : $*Int
+  dealloc_stack %67 : $*ClosedRange<Int>
+  dealloc_stack %31 : $*ClosedRange<Int>
+  %76 = struct_extract %72 : $Bool, #Bool._value
+  %77 = integer_literal $Builtin.Int1, -1
+  %78 = builtin "int_expect_Int1"(%76 : $Builtin.Int1, %77 : $Builtin.Int1) : $Builtin.Int1
+  %79 = integer_literal $Builtin.Int1, -1
+  %80 = builtin "xor_Int1"(%78 : $Builtin.Int1, %79 : $Builtin.Int1) : $Builtin.Int1
+  cond_br %80, bb15, bb16
+
+bb15:
+  %82 = string_literal utf8 "Fatal error"
+  %83 = integer_literal $Builtin.Word, 11
+  %84 = builtin "ptrtoint_Word"(%82 : $Builtin.RawPointer) : $Builtin.Word
+  br bb17
+
+bb16:
+  br bb22
+
+bb17:
+  %87 = integer_literal $Builtin.Int8, 2
+  br bb18
+
+bb18:
+  %89 = struct $StaticString (%84 : $Builtin.Word, %83 : $Builtin.Word, %87 : $Builtin.Int8)
+  %90 = builtin "assert_configuration"() : $Builtin.Int32
+  %91 = integer_literal $Builtin.Int32, 0
+  %92 = builtin "cmp_eq_Int32"(%90 : $Builtin.Int32, %91 : $Builtin.Int32) : $Builtin.Int1
+  cond_br %92, bb19, bb20
+
+bb19:
+  %94 = integer_literal $Builtin.Int32, 1
+  %95 = struct $UInt32 (%94 : $Builtin.Int32)
+  br bb21(%95 : $UInt32)
+
+bb20:
+  %97 = integer_literal $Builtin.Int32, 0
+  %98 = struct $UInt32 (%97 : $Builtin.Int32)
+  br bb21(%98 : $UInt32)
+
+bb21(%100 : $UInt32):
+  %101 = function_ref @$ss17_assertionFailure__4file4line5flagss5NeverOs12StaticStringV_A2HSus6UInt32VtF : $@convention(thin) (StaticString, StaticString, StaticString, UInt, UInt32) -> Never
+  %102 = apply %101(%89, %15, %22, %24, %100) : $@convention(thin) (StaticString, StaticString, StaticString, UInt, UInt32) -> Never
+  unreachable
+
+bb22:
+  %104 = tuple ()
+  %105 = witness_method $Int8, #BinaryInteger.bitWidth!getter : <Self where Self : BinaryInteger> (Self) -> () -> Int : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@in_guaranteed τ_0_0) -> Int
+  %106 = apply %105<Int8>(%4) : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@in_guaranteed τ_0_0) -> Int
+  %107 = integer_literal $Builtin.Int64, 64
+  %108 = struct_extract %106 : $Int, #Int._value
+  %109 = builtin "cmp_slt_Int64"(%107 : $Builtin.Int64, %108 : $Builtin.Int64) : $Builtin.Int1
+  %110 = integer_literal $Builtin.Int1, -1
+  %111 = builtin "xor_Int1"(%109 : $Builtin.Int1, %110 : $Builtin.Int1) : $Builtin.Int1
+  cond_br %111, bb23, bb24
+
+bb23:
+  %113 = alloc_stack $Int64
+  %114 = metatype $@thin Int64.Type
+  %115 = metatype $@thick Int64.Type
+  %116 = alloc_stack $Int
+  store %0 to [trivial] %116 : $*Int
+  %118 = function_ref @$sSZss17FixedWidthIntegerRzrlEyxqd__cSzRd__lufC : $@convention(method) <τ_0_0 where τ_0_0 : FixedWidthInteger, τ_0_0 : SignedInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
+  %119 = apply %118<Int64, Int>(%113, %116, %115) : $@convention(method) <τ_0_0 where τ_0_0 : FixedWidthInteger, τ_0_0 : SignedInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
+  dealloc_stack %116 : $*Int
+  %121 = load [trivial] %113 : $*Int64
+  debug_value %121 : $Int64, let, name "radix_"
+  dealloc_stack %113 : $*Int64
+  %124 = metatype $@thick Int8.Type
+  %125 = witness_method $Int8, #BinaryInteger.isSigned!getter : <Self where Self : BinaryInteger> (Self.Type) -> () -> Bool : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@thick τ_0_0.Type) -> Bool
+  %126 = apply %125<Int8>(%124) : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@thick τ_0_0.Type) -> Bool
+  %127 = struct_extract %126 : $Bool, #Bool._value
+  cond_br %127, bb25, bb26
+
+bb24:
+  %129 = metatype $@thick Int8.Type
+  %130 = integer_literal $Builtin.IntLiteral, 0
+  %131 = metatype $@thick Int8.Type
+  %132 = alloc_stack $Int8
+  %133 = witness_method $Int8, #_ExpressibleByBuiltinIntegerLiteral.init!allocator : <Self where Self : _ExpressibleByBuiltinIntegerLiteral> (Self.Type) -> (Builtin.IntLiteral) -> Self : $@convention(witness_method: _ExpressibleByBuiltinIntegerLiteral) <τ_0_0 where τ_0_0 : _ExpressibleByBuiltinIntegerLiteral> (Builtin.IntLiteral, @thick τ_0_0.Type) -> @out τ_0_0
+  %134 = apply %133<Int8>(%132, %130, %131) : $@convention(witness_method: _ExpressibleByBuiltinIntegerLiteral) <τ_0_0 where τ_0_0 : _ExpressibleByBuiltinIntegerLiteral> (Builtin.IntLiteral, @thick τ_0_0.Type) -> @out τ_0_0
+  %135 = metatype $@thick Int8.Type
+  %136 = alloc_stack $Int8
+  %137 = witness_method $Int8, #ExpressibleByIntegerLiteral.init!allocator : <Self where Self : ExpressibleByIntegerLiteral> (Self.Type) -> (Self.IntegerLiteralType) -> Self : $@convention(witness_method: ExpressibleByIntegerLiteral) <τ_0_0 where τ_0_0 : ExpressibleByIntegerLiteral> (@in τ_0_0.IntegerLiteralType, @thick τ_0_0.Type) -> @out τ_0_0
+  %138 = apply %137<Int8>(%136, %132, %135) : $@convention(witness_method: ExpressibleByIntegerLiteral) <τ_0_0 where τ_0_0 : ExpressibleByIntegerLiteral> (@in τ_0_0.IntegerLiteralType, @thick τ_0_0.Type) -> @out τ_0_0
+  %139 = witness_method $Int8, #Equatable."==" : <Self where Self : Equatable> (Self.Type) -> (Self, Self) -> Bool : $@convention(witness_method: Equatable) <τ_0_0 where τ_0_0 : Equatable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
+  %140 = apply %139<Int8>(%4, %136, %129) : $@convention(witness_method: Equatable) <τ_0_0 where τ_0_0 : Equatable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
+  destroy_addr %136 : $*Int8
+  dealloc_stack %136 : $*Int8
+  dealloc_stack %132 : $*Int8
+  %144 = struct_extract %140 : $Bool, #Bool._value
+  cond_br %144, bb29, bb30
+
+bb25:
+  %146 = alloc_stack $Int64
+  %147 = metatype $@thin Int64.Type
+  %148 = metatype $@thick Int64.Type
+  %149 = alloc_stack $Int8
+  copy_addr %4 to [initialization] %149 : $*Int8
+  %151 = function_ref @$ss17FixedWidthIntegerPsE18truncatingIfNeededxqd___tcSzRd__lufC : $@convention(method) <τ_0_0 where τ_0_0 : FixedWidthInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
+  %152 = apply %151<Int64, Int8>(%146, %149, %148) : $@convention(method) <τ_0_0 where τ_0_0 : FixedWidthInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
+  dealloc_stack %149 : $*Int8
+  %154 = load [trivial] %146 : $*Int64
+  %155 = function_ref @$ss14_int64ToString_5radix9uppercaseSSs5Int64V_AESbtF : $@convention(thin) (Int64, Int64, Bool) -> @owned String
+  %156 = apply %155(%154, %121, %1) : $@convention(thin) (Int64, Int64, Bool) -> @owned String
+  dealloc_stack %146 : $*Int64
+  br bb27(%156 : $String)
+
+bb26:
+  %159 = alloc_stack $UInt64
+  %160 = metatype $@thin UInt64.Type
+  %161 = metatype $@thick UInt64.Type
+  %162 = alloc_stack $Int8
+  copy_addr %4 to [initialization] %162 : $*Int8
+  %164 = function_ref @$ss17FixedWidthIntegerPsE18truncatingIfNeededxqd___tcSzRd__lufC : $@convention(method) <τ_0_0 where τ_0_0 : FixedWidthInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
+  %165 = apply %164<UInt64, Int8>(%159, %162, %161) : $@convention(method) <τ_0_0 where τ_0_0 : FixedWidthInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
+  dealloc_stack %162 : $*Int8
+  %167 = load [trivial] %159 : $*UInt64
+  %168 = function_ref @$ss15_uint64ToString_5radix9uppercaseSSs6UInt64V_s5Int64VSbtF : $@convention(thin) (UInt64, Int64, Bool) -> @owned String
+  %169 = apply %168(%167, %121, %1) : $@convention(thin) (UInt64, Int64, Bool) -> @owned String
+  dealloc_stack %159 : $*UInt64
+  br bb27(%169 : $String)
+
+bb27(%172 : @owned $String):
+  br bb28(%172 : $String)
+
+bb28(%174 : @owned $String):
+  dealloc_stack %4 : $*Int8
+  return %174 : $String
+
+bb29:
+  %177 = string_literal utf8 "0"
+  %178 = integer_literal $Builtin.Word, 1
+  %179 = integer_literal $Builtin.Int1, -1
+  %180 = metatype $@thin String.Type
+  %181 = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  %182 = apply %181(%177, %178, %179, %180) : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  br bb28(%182 : $String)
+
+bb30:
+  %184 = struct_extract %0 : $Int, #Int._value
+  %185 = builtin "int_ctpop_Int64"(%184 : $Builtin.Int64) : $Builtin.Int64
+  %186 = integer_literal $Builtin.Int64, 1
+  %187 = builtin "cmp_eq_Int64"(%185 : $Builtin.Int64, %186 : $Builtin.Int64) : $Builtin.Int1
+  %188 = struct $Bool (%187 : $Builtin.Int1)
+  debug_value %188 : $Bool, let, name "isRadixPowerOfTwo"
+  %190 = alloc_stack $UInt8, let, name "radix_"
+  %191 = metatype $@thick UInt8.Type
+  %192 = alloc_stack $Int
+  store %0 to [trivial] %192 : $*Int
+  %194 = witness_method $UInt8, #BinaryInteger.init!allocator : <Self where Self : BinaryInteger><T where T : BinaryInteger> (Self.Type) -> (T) -> Self : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
+  %195 = apply %194<UInt8, Int>(%190, %192, %191) : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
+  dealloc_stack %192 : $*Int
+  %197 = integer_literal $Builtin.Int64, 10
+  %198 = struct_extract %0 : $Int, #Int._value
+  %199 = builtin "cmp_slt_Int64"(%197 : $Builtin.Int64, %198 : $Builtin.Int64) : $Builtin.Int1
+  %200 = struct $Bool (%199 : $Builtin.Int1)
+  debug_value %200 : $Bool, let, name "hasLetters"
+  %202 = metatype $@thick Int8.Type
+  %203 = witness_method $Int8, #BinaryInteger.isSigned!getter : <Self where Self : BinaryInteger> (Self.Type) -> () -> Bool : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@thick τ_0_0.Type) -> Bool
+  %204 = apply %203<Int8>(%202) : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@thick τ_0_0.Type) -> Bool
+  %205 = alloc_stack $Int8
+  copy_addr %4 to [initialization] %205 : $*Int8
+  %207 = struct_extract %204 : $Bool, #Bool._value
+  cond_br %207, bb31, bb32
+
+bb31:
+  %209 = metatype $@thick Int8.Type
+  %210 = integer_literal $Builtin.IntLiteral, 0
+  %211 = metatype $@thick Int8.Type
+  %212 = alloc_stack $Int8
+  %213 = witness_method $Int8, #_ExpressibleByBuiltinIntegerLiteral.init!allocator : <Self where Self : _ExpressibleByBuiltinIntegerLiteral> (Self.Type) -> (Builtin.IntLiteral) -> Self : $@convention(witness_method: _ExpressibleByBuiltinIntegerLiteral) <τ_0_0 where τ_0_0 : _ExpressibleByBuiltinIntegerLiteral> (Builtin.IntLiteral, @thick τ_0_0.Type) -> @out τ_0_0
+  %214 = apply %213<Int8>(%212, %210, %211) : $@convention(witness_method: _ExpressibleByBuiltinIntegerLiteral) <τ_0_0 where τ_0_0 : _ExpressibleByBuiltinIntegerLiteral> (Builtin.IntLiteral, @thick τ_0_0.Type) -> @out τ_0_0
+  %215 = metatype $@thick Int8.Type
+  %216 = alloc_stack $Int8
+  %217 = witness_method $Int8, #ExpressibleByIntegerLiteral.init!allocator : <Self where Self : ExpressibleByIntegerLiteral> (Self.Type) -> (Self.IntegerLiteralType) -> Self : $@convention(witness_method: ExpressibleByIntegerLiteral) <τ_0_0 where τ_0_0 : ExpressibleByIntegerLiteral> (@in τ_0_0.IntegerLiteralType, @thick τ_0_0.Type) -> @out τ_0_0
+  %218 = apply %217<Int8>(%216, %212, %215) : $@convention(witness_method: ExpressibleByIntegerLiteral) <τ_0_0 where τ_0_0 : ExpressibleByIntegerLiteral> (@in τ_0_0.IntegerLiteralType, @thick τ_0_0.Type) -> @out τ_0_0
+  %219 = witness_method $Int8, #Comparable."<" : <Self where Self : Comparable> (Self.Type) -> (Self, Self) -> Bool : $@convention(witness_method: Comparable) <τ_0_0 where τ_0_0 : Comparable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
+  %220 = apply %219<Int8>(%205, %216, %209) : $@convention(witness_method: Comparable) <τ_0_0 where τ_0_0 : Comparable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
+  destroy_addr %216 : $*Int8
+  destroy_addr %205 : $*Int8
+  dealloc_stack %216 : $*Int8
+  dealloc_stack %212 : $*Int8
+  br bb33(%220 : $Bool)
+
+bb32:
+  destroy_addr %205 : $*Int8
+  %227 = integer_literal $Builtin.Int1, 0
+  %228 = struct $Bool (%227 : $Builtin.Int1)
+  br bb33(%228 : $Bool)
+
+bb33(%230 : $Bool):
+  dealloc_stack %205 : $*Int8
+  debug_value %230 : $Bool, let, name "isNegative"
+  %233 = alloc_stack $UInt8, var, name "value"
+  %234 = witness_method $Int8, #Numeric.magnitude!getter : <Self where Self : Numeric> (Self) -> () -> Self.Magnitude : $@convention(witness_method: Numeric) <τ_0_0 where τ_0_0 : Numeric> (@in_guaranteed τ_0_0) -> @out τ_0_0.Magnitude
+  %235 = apply %234<Int8>(%233, %4) : $@convention(witness_method: Numeric) <τ_0_0 where τ_0_0 : Numeric> (@in_guaranteed τ_0_0) -> @out τ_0_0.Magnitude
+  %236 = alloc_stack $Array<UInt8>, var, name "result"
+  %237 = integer_literal $Builtin.Word, 0
+  %238 = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
+  %239 = apply %238<UInt8>(%237) : $@convention(thin) <τ_0_0> (Builtin.Word) -> (@owned Array<τ_0_0>, Builtin.RawPointer)
+  (%240, %241) = destructure_tuple %239 : $(Array<UInt8>, Builtin.RawPointer)
+  %242 = pointer_to_address %241 : $Builtin.RawPointer to [strict] $*UInt8
+  store %240 to [init] %236 : $*Array<UInt8>
+  br bb34
+
+bb34:
+  %245 = alloc_stack $UInt8
+  copy_addr %233 to [initialization] %245 : $*UInt8
+  %247 = integer_literal $Builtin.Int64, 0
+  %248 = struct $Int (%247 : $Builtin.Int64)
+  %249 = metatype $@thick UInt8.Type
+  %250 = witness_method $UInt8, #BinaryInteger.isSigned!getter : <Self where Self : BinaryInteger> (Self.Type) -> () -> Bool : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@thick τ_0_0.Type) -> Bool
+  %251 = apply %250<UInt8>(%249) : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@thick τ_0_0.Type) -> Bool
+  %252 = alloc_stack $UInt8
+  copy_addr %245 to [initialization] %252 : $*UInt8
+  %254 = struct_extract %251 : $Bool, #Bool._value
+  cond_br %254, bb35, bb36
+
+bb35:
+  %256 = metatype $@thick UInt8.Type
+  %257 = integer_literal $Builtin.IntLiteral, 0
+  %258 = metatype $@thick UInt8.Type
+  %259 = alloc_stack $UInt8
+  %260 = witness_method $UInt8, #_ExpressibleByBuiltinIntegerLiteral.init!allocator : <Self where Self : _ExpressibleByBuiltinIntegerLiteral> (Self.Type) -> (Builtin.IntLiteral) -> Self : $@convention(witness_method: _ExpressibleByBuiltinIntegerLiteral) <τ_0_0 where τ_0_0 : _ExpressibleByBuiltinIntegerLiteral> (Builtin.IntLiteral, @thick τ_0_0.Type) -> @out τ_0_0
+  %261 = apply %260<UInt8>(%259, %257, %258) : $@convention(witness_method: _ExpressibleByBuiltinIntegerLiteral) <τ_0_0 where τ_0_0 : _ExpressibleByBuiltinIntegerLiteral> (Builtin.IntLiteral, @thick τ_0_0.Type) -> @out τ_0_0
+  %262 = metatype $@thick UInt8.Type
+  %263 = alloc_stack $UInt8
+  %264 = witness_method $UInt8, #ExpressibleByIntegerLiteral.init!allocator : <Self where Self : ExpressibleByIntegerLiteral> (Self.Type) -> (Self.IntegerLiteralType) -> Self : $@convention(witness_method: ExpressibleByIntegerLiteral) <τ_0_0 where τ_0_0 : ExpressibleByIntegerLiteral> (@in τ_0_0.IntegerLiteralType, @thick τ_0_0.Type) -> @out τ_0_0
+  %265 = apply %264<UInt8>(%263, %259, %262) : $@convention(witness_method: ExpressibleByIntegerLiteral) <τ_0_0 where τ_0_0 : ExpressibleByIntegerLiteral> (@in τ_0_0.IntegerLiteralType, @thick τ_0_0.Type) -> @out τ_0_0
+  %266 = witness_method $UInt8, #Comparable."<" : <Self where Self : Comparable> (Self.Type) -> (Self, Self) -> Bool : $@convention(witness_method: Comparable) <τ_0_0 where τ_0_0 : Comparable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
+  %267 = apply %266<UInt8>(%252, %263, %256) : $@convention(witness_method: Comparable) <τ_0_0 where τ_0_0 : Comparable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
+  destroy_addr %263 : $*UInt8
+  dealloc_stack %263 : $*UInt8
+  dealloc_stack %259 : $*UInt8
+  br bb37(%267 : $Bool)
+
+bb36:
+  %272 = integer_literal $Builtin.Int1, 0
+  %273 = struct $Bool (%272 : $Builtin.Int1)
+  br bb37(%273 : $Bool)
+
+bb37(%275 : $Bool):
+  destroy_addr %252 : $*UInt8
+  dealloc_stack %252 : $*UInt8
+  %278 = metatype $@thick Int.Type
+  %279 = function_ref @$sSZsE8isSignedSbvgZ : $@convention(method) <τ_0_0 where τ_0_0 : SignedInteger> (@thick τ_0_0.Type) -> Bool
+  %280 = apply %279<Int>(%278) : $@convention(method) <τ_0_0 where τ_0_0 : SignedInteger> (@thick τ_0_0.Type) -> Bool
+  %281 = struct_extract %280 : $Bool, #Bool._value
+  cond_br %281, bb38, bb39
+
+bb38:
+  %283 = tuple ()
+  %284 = tuple ()
+  %285 = tuple ()
+  %286 = integer_literal $Builtin.Int1, 0
+  %287 = struct $Bool (%286 : $Builtin.Int1)
+  br bb40(%287 : $Bool)
+
+bb39:
+  %289 = integer_literal $Builtin.Int1, 0
+  %290 = struct $Bool (%289 : $Builtin.Int1)
+  br bb40(%290 : $Bool)
+
+bb40(%292 : $Bool):
+  %293 = metatype $@thin Bool.Type
+  %294 = struct_extract %275 : $Bool, #Bool._value
+  %295 = struct_extract %292 : $Bool, #Bool._value
+  %296 = builtin "cmp_eq_Int1"(%294 : $Builtin.Int1, %295 : $Builtin.Int1) : $Builtin.Int1
+  %297 = integer_literal $Builtin.Int1, -1
+  %298 = builtin "xor_Int1"(%296 : $Builtin.Int1, %297 : $Builtin.Int1) : $Builtin.Int1
+  cond_br %298, bb41, bb42
+
+bb41:
+  %300 = integer_literal $Builtin.Int1, 0
+  %301 = struct $Bool (%300 : $Builtin.Int1)
+  br bb43(%301 : $Bool)
+
+bb42:
+  %303 = witness_method $UInt8, #BinaryInteger.bitWidth!getter : <Self where Self : BinaryInteger> (Self) -> () -> Int : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@in_guaranteed τ_0_0) -> Int
+  %304 = apply %303<UInt8>(%245) : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@in_guaranteed τ_0_0) -> Int
+  %305 = alloc_stack $Int
+  store %248 to [trivial] %305 : $*Int
+  %307 = function_ref @$ss17FixedWidthIntegerPsE03bitB0Sivg : $@convention(method) <τ_0_0 where τ_0_0 : FixedWidthInteger> (@in_guaranteed τ_0_0) -> Int
+  %308 = apply %307<Int>(%305) : $@convention(method) <τ_0_0 where τ_0_0 : FixedWidthInteger> (@in_guaranteed τ_0_0) -> Int
+  destroy_addr %305 : $*Int
+  %310 = struct_extract %304 : $Int, #Int._value
+  %311 = struct_extract %308 : $Int, #Int._value
+  %312 = builtin "cmp_slt_Int64"(%310 : $Builtin.Int64, %311 : $Builtin.Int64) : $Builtin.Int1
+  dealloc_stack %305 : $*Int
+  cond_br %312, bb51, bb52
+
+bb43(%315 : $Bool):
+  %316 = struct_extract %315 : $Bool, #Bool._value
+  %317 = integer_literal $Builtin.Int1, -1
+  %318 = builtin "xor_Int1"(%316 : $Builtin.Int1, %317 : $Builtin.Int1) : $Builtin.Int1
+  destroy_addr %245 : $*UInt8
+  dealloc_stack %245 : $*UInt8
+  cond_br %318, bb44, bb45
+
+bb44:
+  %322 = alloc_stack $UInt8, let, name "quotient"
+  %323 = alloc_stack $UInt8, let, name "remainder"
+  %324 = alloc_stack $UInt8
+  copy_addr %233 to [initialization] %324 : $*UInt8
+  %326 = function_ref @$sSzsE12_description5radix9uppercaseSSSi_SbtF21_quotientAndRemainderL_y9MagnitudeQz_AFtAFSzRzlF : $@convention(thin) <τ_0_0 where τ_0_0 : BinaryInteger> (@in_guaranteed τ_0_0.Magnitude, Bool, Int, @in_guaranteed τ_0_0.Magnitude) -> (@out τ_0_0.Magnitude, @out τ_0_0.Magnitude)
+  %327 = apply %326<Int8>(%322, %323, %324, %188, %0, %190) : $@convention(thin) <τ_0_0 where τ_0_0 : BinaryInteger> (@in_guaranteed τ_0_0.Magnitude, Bool, Int, @in_guaranteed τ_0_0.Magnitude) -> (@out τ_0_0.Magnitude, @out τ_0_0.Magnitude)
+  destroy_addr %324 : $*UInt8
+  dealloc_stack %324 : $*UInt8
+  %330 = alloc_stack $UInt8
+  %331 = metatype $@thin UInt8.Type
+  %332 = metatype $@thick UInt8.Type
+  %333 = alloc_stack $UInt8
+  copy_addr %323 to [initialization] %333 : $*UInt8
+  %335 = function_ref @$ss17FixedWidthIntegerPsE18truncatingIfNeededxqd___tcSzRd__lufC : $@convention(method) <τ_0_0 where τ_0_0 : FixedWidthInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
+  %336 = apply %335<UInt8, UInt8>(%330, %333, %332) : $@convention(method) <τ_0_0 where τ_0_0 : FixedWidthInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
+  dealloc_stack %333 : $*UInt8
+  %338 = load [trivial] %330 : $*UInt8
+  %339 = function_ref @$sSzsE12_description5radix9uppercaseSSSi_SbtF6_asciiL_ys5UInt8VAFSzRzlF : $@convention(thin) (UInt8, Bool, Bool) -> UInt8
+  %340 = apply %339(%338, %200, %1) : $@convention(thin) (UInt8, Bool, Bool) -> UInt8
+  dealloc_stack %330 : $*UInt8
+  %342 = alloc_stack $UInt8
+  store %340 to [trivial] %342 : $*UInt8
+  %344 = function_ref @$sSa6appendyyxnF : $@convention(method) <τ_0_0> (@in τ_0_0, @inout Array<τ_0_0>) -> ()
+  %345 = apply %344<UInt8>(%342, %236) : $@convention(method) <τ_0_0> (@in τ_0_0, @inout Array<τ_0_0>) -> ()
+  dealloc_stack %342 : $*UInt8
+  destroy_addr %233 : $*UInt8
+  copy_addr %322 to [initialization] %233 : $*UInt8
+  destroy_addr %323 : $*UInt8
+  dealloc_stack %323 : $*UInt8
+  destroy_addr %322 : $*UInt8
+  dealloc_stack %322 : $*UInt8
+  br bb34
+
+bb45:
+  %354 = struct_extract %230 : $Bool, #Bool._value
+  cond_br %354, bb46, bb47
+
+bb46:
+  %356 = alloc_stack $UInt8
+  %357 = metatype $@thin UInt8.Type
+  %358 = metatype $@thick UInt8.Type
+  %359 = integer_literal $Builtin.Int32, 45
+  %360 = struct $UInt32 (%359 : $Builtin.Int32)
+  %361 = struct $Unicode.Scalar (%360 : $UInt32)
+  %362 = function_ref @$ss7UnicodeO6ScalarV5values6UInt32Vvg : $@convention(method) (Unicode.Scalar) -> UInt32
+  %363 = apply %362(%361) : $@convention(method) (Unicode.Scalar) -> UInt32
+  %364 = alloc_stack $UInt32
+  store %363 to [trivial] %364 : $*UInt32
+  %366 = function_ref @$sSUss17FixedWidthIntegerRzrlEyxqd__cSzRd__lufC : $@convention(method) <τ_0_0 where τ_0_0 : FixedWidthInteger, τ_0_0 : UnsignedInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
+  %367 = apply %366<UInt8, UInt32>(%356, %364, %358) : $@convention(method) <τ_0_0 where τ_0_0 : FixedWidthInteger, τ_0_0 : UnsignedInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
+  dealloc_stack %364 : $*UInt32
+  %369 = load [trivial] %356 : $*UInt8
+  %370 = alloc_stack $UInt8
+  store %369 to [trivial] %370 : $*UInt8
+  %372 = function_ref @$sSa6appendyyxnF : $@convention(method) <τ_0_0> (@in τ_0_0, @inout Array<τ_0_0>) -> ()
+  %373 = apply %372<UInt8>(%370, %236) : $@convention(method) <τ_0_0> (@in τ_0_0, @inout Array<τ_0_0>) -> ()
+  dealloc_stack %370 : $*UInt8
+  dealloc_stack %356 : $*UInt8
+  br bb48
+
+bb47:
+  br bb48
+
+bb48:
+  %378 = function_ref @$sSMsSKRzrlE7reverseyyF : $@convention(method) <τ_0_0 where τ_0_0 : BidirectionalCollection, τ_0_0 : MutableCollection> (@inout τ_0_0) -> ()
+  %379 = apply %378<Array<UInt8>>(%236) : $@convention(method) <τ_0_0 where τ_0_0 : BidirectionalCollection, τ_0_0 : MutableCollection> (@inout τ_0_0) -> ()
+  %380 = alloc_stack $String
+  %381 = load [copy] %236 : $*Array<UInt8>
+  %382 = function_ref @$sSzsE12_description5radix9uppercaseSSSi_SbtFSSSRys5UInt8VGXEfU_ : $@convention(thin) (UnsafeBufferPointer<UInt8>) -> @owned String
+  %383 = thin_to_thick_function %382 : $@convention(thin) (UnsafeBufferPointer<UInt8>) -> @owned String to $@noescape @callee_guaranteed (UnsafeBufferPointer<UInt8>) -> @owned String
+  %384 = convert_function %383 : $@noescape @callee_guaranteed (UnsafeBufferPointer<UInt8>) -> @owned String to $@noescape @callee_guaranteed (UnsafeBufferPointer<UInt8>) -> (@owned String, @error Error)
+  %385 = function_ref @$sSRys5UInt8VGSSs5Error_pIgyozo_ACSSsAD_pIegyrzo_TR : $@convention(thin) (UnsafeBufferPointer<UInt8>, @noescape @callee_guaranteed (UnsafeBufferPointer<UInt8>) -> (@owned String, @error Error)) -> (@out String, @error Error)
+  %386 = partial_apply [callee_guaranteed] [on_stack] %385(%384) : $@convention(thin) (UnsafeBufferPointer<UInt8>, @noescape @callee_guaranteed (UnsafeBufferPointer<UInt8>) -> (@owned String, @error Error)) -> (@out String, @error Error)
+  %387 = convert_function %386 : $@noescape @callee_guaranteed (UnsafeBufferPointer<UInt8>) -> (@out String, @error Error) to $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2 where τ_0_0 == τ_0_1> (UnsafeBufferPointer<τ_0_0>) -> (@out τ_0_2, @error Error) for <UInt8, UInt8, String>
+  %388 = function_ref @$sSa23withUnsafeBufferPointeryqd__qd__SRyxGKXEKlF : $@convention(method) <τ_0_0><τ_1_0> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2 where τ_0_0 == τ_0_1> (UnsafeBufferPointer<τ_0_0>) -> (@out τ_0_2, @error Error) for <τ_0_0, τ_0_0, τ_1_0>, @guaranteed Array<τ_0_0>) -> (@out τ_1_0, @error Error)
+  try_apply %388<UInt8, String>(%380, %387, %381) : $@convention(method) <τ_0_0><τ_1_0> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2 where τ_0_0 == τ_0_1> (UnsafeBufferPointer<τ_0_0>) -> (@out τ_0_2, @error Error) for <τ_0_0, τ_0_0, τ_1_0>, @guaranteed Array<τ_0_0>) -> (@out τ_1_0, @error Error), normal bb49, error bb50
+
+bb49(%390 : $()):
+  destroy_addr %190 : $*UInt8
+  dealloc_stack %386 : $@noescape @callee_guaranteed (UnsafeBufferPointer<UInt8>) -> (@out String, @error Error)
+  destroy_value %381 : $Array<UInt8>
+  %394 = load [take] %380 : $*String
+  dealloc_stack %380 : $*String
+  destroy_addr %236 : $*Array<UInt8>
+  dealloc_stack %236 : $*Array<UInt8>
+  destroy_addr %233 : $*UInt8
+  dealloc_stack %233 : $*UInt8
+  dealloc_stack %190 : $*UInt8
+  br bb28(%394 : $String)
+
+bb50(%402 : @owned $Error):
+  unreachable
+
+bb51:
+  %404 = alloc_stack $Int
+  %405 = metatype $@thick Int.Type
+  %406 = alloc_stack $UInt8
+  copy_addr %245 to [initialization] %406 : $*UInt8
+  %408 = function_ref @$ss17FixedWidthIntegerPsE18truncatingIfNeededxqd___tcSzRd__lufC : $@convention(method) <τ_0_0 where τ_0_0 : FixedWidthInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
+  %409 = apply %408<Int, UInt8>(%404, %406, %405) : $@convention(method) <τ_0_0 where τ_0_0 : FixedWidthInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
+  %410 = tuple ()
+  dealloc_stack %406 : $*UInt8
+  %412 = load [trivial] %404 : $*Int
+  %413 = struct_extract %412 : $Int, #Int._value
+  %414 = builtin "cmp_eq_Int64"(%413 : $Builtin.Int64, %247 : $Builtin.Int64) : $Builtin.Int1
+  %415 = struct $Bool (%414 : $Builtin.Int1)
+  destroy_addr %404 : $*Int
+  dealloc_stack %404 : $*Int
+  br bb43(%415 : $Bool)
+
+bb52:
+  %419 = witness_method $UInt8, #BinaryInteger.bitWidth!getter : <Self where Self : BinaryInteger> (Self) -> () -> Int : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@in_guaranteed τ_0_0) -> Int
+  %420 = apply %419<UInt8>(%245) : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@in_guaranteed τ_0_0) -> Int
+  %421 = alloc_stack $Int
+  store %248 to [trivial] %421 : $*Int
+  %423 = function_ref @$ss17FixedWidthIntegerPsE03bitB0Sivg : $@convention(method) <τ_0_0 where τ_0_0 : FixedWidthInteger> (@in_guaranteed τ_0_0) -> Int
+  %424 = apply %423<Int>(%421) : $@convention(method) <τ_0_0 where τ_0_0 : FixedWidthInteger> (@in_guaranteed τ_0_0) -> Int
+  destroy_addr %421 : $*Int
+  %426 = struct_extract %424 : $Int, #Int._value
+  %427 = struct_extract %420 : $Int, #Int._value
+  %428 = builtin "cmp_slt_Int64"(%426 : $Builtin.Int64, %427 : $Builtin.Int64) : $Builtin.Int1
+  dealloc_stack %421 : $*Int
+  cond_br %428, bb53, bb54
+
+bb53:
+  %431 = metatype $@thick UInt8.Type
+  %432 = alloc_stack $UInt8
+  %433 = metatype $@thick UInt8.Type
+  %434 = alloc_stack $Int
+  store %248 to [trivial] %434 : $*Int
+  %436 = witness_method $UInt8, #BinaryInteger.init!allocator : <Self where Self : BinaryInteger><T where T : BinaryInteger> (Self.Type) -> (T) -> Self : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
+  %437 = apply %436<UInt8, Int>(%432, %434, %433) : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
+  dealloc_stack %434 : $*Int
+  %439 = witness_method $UInt8, #Equatable."==" : <Self where Self : Equatable> (Self.Type) -> (Self, Self) -> Bool : $@convention(witness_method: Equatable) <τ_0_0 where τ_0_0 : Equatable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
+  %440 = apply %439<UInt8>(%245, %432, %431) : $@convention(witness_method: Equatable) <τ_0_0 where τ_0_0 : Equatable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
+  destroy_addr %432 : $*UInt8
+  dealloc_stack %432 : $*UInt8
+  br bb43(%440 : $Bool)
+
+bb54:
+  %444 = metatype $@thick UInt8.Type
+  %445 = witness_method $UInt8, #BinaryInteger.isSigned!getter : <Self where Self : BinaryInteger> (Self.Type) -> () -> Bool : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@thick τ_0_0.Type) -> Bool
+  %446 = apply %445<UInt8>(%444) : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@thick τ_0_0.Type) -> Bool
+  %447 = struct_extract %446 : $Bool, #Bool._value
+  cond_br %447, bb55, bb56
+
+bb55:
+  %449 = alloc_stack $Int
+  %450 = metatype $@thick Int.Type
+  %451 = alloc_stack $UInt8
+  copy_addr %245 to [initialization] %451 : $*UInt8
+  %453 = function_ref @$ss17FixedWidthIntegerPsE18truncatingIfNeededxqd___tcSzRd__lufC : $@convention(method) <τ_0_0 where τ_0_0 : FixedWidthInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
+  %454 = apply %453<Int, UInt8>(%449, %451, %450) : $@convention(method) <τ_0_0 where τ_0_0 : FixedWidthInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
+  %455 = tuple ()
+  dealloc_stack %451 : $*UInt8
+  %457 = load [trivial] %449 : $*Int
+  %458 = struct_extract %457 : $Int, #Int._value
+  %459 = builtin "cmp_eq_Int64"(%458 : $Builtin.Int64, %247 : $Builtin.Int64) : $Builtin.Int1
+  %460 = struct $Bool (%459 : $Builtin.Int1)
+  destroy_addr %449 : $*Int
+  dealloc_stack %449 : $*Int
+  br bb43(%460 : $Bool)
+
+bb56:
+  %464 = metatype $@thick UInt8.Type
+  %465 = alloc_stack $UInt8
+  %466 = metatype $@thick UInt8.Type
+  %467 = alloc_stack $Int
+  store %248 to [trivial] %467 : $*Int
+  %469 = witness_method $UInt8, #BinaryInteger.init!allocator : <Self where Self : BinaryInteger><T where T : BinaryInteger> (Self.Type) -> (T) -> Self : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
+  %470 = apply %469<UInt8, Int>(%465, %467, %466) : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
+  dealloc_stack %467 : $*Int
+  %472 = witness_method $UInt8, #Equatable."==" : <Self where Self : Equatable> (Self.Type) -> (Self, Self) -> Bool : $@convention(witness_method: Equatable) <τ_0_0 where τ_0_0 : Equatable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
+  %473 = apply %472<UInt8>(%245, %465, %464) : $@convention(witness_method: Equatable) <τ_0_0 where τ_0_0 : Equatable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
+  destroy_addr %465 : $*UInt8
+  dealloc_stack %465 : $*UInt8
+  br bb43(%473 : $Bool)
+
+bb57:
+  br bb59
+
+bb58:
+  br bb59
+
+bb59:
+  br bb14
+
+bb60:
+  %480 = metatype $@thin ClosedRange<Int>.Type
+  %481 = metatype $@thick ClosedRange<Int>.Type
+  %482 = alloc_stack $ClosedRange<Int>
+  %483 = metatype $@thin Int.Type
+  %484 = integer_literal $Builtin.Int64, 2
+  %485 = struct $Int (%484 : $Builtin.Int64)
+  %486 = integer_literal $Builtin.Int64, 36
+  %487 = struct $Int (%486 : $Builtin.Int64)
+  br bb62
+
+bb61:
+  br bb70
+
+bb62:
+  br bb63
+
+bb63:
+  br bb64
+
+bb64:
+  br bb65
+
+bb65:
+  %493 = builtin "assert_configuration"() : $Builtin.Int32
+  %494 = integer_literal $Builtin.Int32, 0
+  %495 = builtin "cmp_eq_Int32"(%493 : $Builtin.Int32, %494 : $Builtin.Int32) : $Builtin.Int1
+  cond_br %495, bb66, bb67
+
+bb66:
+  br bb68
+
+bb67:
+  %498 = builtin "assert_configuration"() : $Builtin.Int32
+  %499 = integer_literal $Builtin.Int32, 1
+  %500 = builtin "cmp_eq_Int32"(%498 : $Builtin.Int32, %499 : $Builtin.Int32) : $Builtin.Int1
+  cond_br %500, bb71, bb72
+
+bb68:
+  br bb69
+
+bb69:
+  %503 = tuple ()
+  %504 = metatype $@thin ClosedRange<Int>.Type
+  %505 = alloc_stack $Int
+  store %485 to [trivial] %505 : $*Int
+  %507 = alloc_stack $Int
+  store %487 to [trivial] %507 : $*Int
+  %509 = function_ref @$sSN16_uncheckedBoundsSNyxGx5lower_x5uppert_tcfC : $@convention(method) <τ_0_0 where τ_0_0 : Comparable> (@in τ_0_0, @in τ_0_0, @thin ClosedRange<τ_0_0>.Type) -> @out ClosedRange<τ_0_0>
+  %510 = apply %509<Int>(%482, %505, %507, %504) : $@convention(method) <τ_0_0 where τ_0_0 : Comparable> (@in τ_0_0, @in τ_0_0, @thin ClosedRange<τ_0_0>.Type) -> @out ClosedRange<τ_0_0>
+  dealloc_stack %507 : $*Int
+  dealloc_stack %505 : $*Int
+  %513 = tuple ()
+  %514 = load [trivial] %482 : $*ClosedRange<Int>
+  %515 = alloc_stack $ClosedRange<Int>
+  store %514 to [trivial] %515 : $*ClosedRange<Int>
+  %517 = alloc_stack $Int
+  store %0 to [trivial] %517 : $*Int
+  %519 = function_ref @$sSXsE2teoiySbx_5BoundQztFZ : $@convention(method) <τ_0_0 where τ_0_0 : RangeExpression> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0.Bound, @thick τ_0_0.Type) -> Bool
+  %520 = apply %519<ClosedRange<Int>>(%515, %517, %481) : $@convention(method) <τ_0_0 where τ_0_0 : RangeExpression> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0.Bound, @thick τ_0_0.Type) -> Bool
+  dealloc_stack %517 : $*Int
+  dealloc_stack %515 : $*ClosedRange<Int>
+  dealloc_stack %482 : $*ClosedRange<Int>
+  %524 = struct_extract %520 : $Bool, #Bool._value
+  %525 = integer_literal $Builtin.Int1, -1
+  %526 = builtin "xor_Int1"(%524 : $Builtin.Int1, %525 : $Builtin.Int1) : $Builtin.Int1
+  cond_fail %526 : $Builtin.Int1, "Radix must be between 2 and 36"
+  br bb70
+
+bb70:
+  br bb22
+
+bb71:
+  br bb73
+
+bb72:
+  br bb73
+
+bb73:
+  br bb69
+}
+
+// CHECK-LABEL: sil [ossa] @$sSS_5radix9uppercaseSSx_SiSbtcSzRzlufC : {{.*}} {
+// CHECK-LABEL: } // end sil function '$sSS_5radix9uppercaseSSx_SiSbtcSzRzlufC'
+sil [ossa] @$sSS_5radix9uppercaseSSx_SiSbtcSzRzlufC : $@convention(method) <T where T : BinaryInteger> (@in T, Int, Bool, @thin String.Type) -> @owned String {
+bb0(%0 : $*T, %1 : $Int, %2 : $Bool, %3 : $@thin String.Type):
+  %10 = string_literal utf8 "Radix must be between 2 and 36"
+  %11 = integer_literal $Builtin.Word, 30
+  %12 = builtin "ptrtoint_Word"(%10 : $Builtin.RawPointer) : $Builtin.Word
+  %13 = integer_literal $Builtin.Int8, 2
+  %14 = struct $StaticString (%12 : $Builtin.Word, %11 : $Builtin.Word, %13 : $Builtin.Int8)
+  %15 = string_literal utf8 "Swift/Integers.swift"
+  %16 = integer_literal $Builtin.Word, 20
+  %17 = builtin "ptrtoint_Word"(%15 : $Builtin.RawPointer) : $Builtin.Word
+  %18 = integer_literal $Builtin.Int8, 2
+  %19 = struct $StaticString (%17 : $Builtin.Word, %16 : $Builtin.Word, %18 : $Builtin.Int8)
+  %20 = integer_literal $Builtin.Int64, 1498
+  %21 = struct $UInt (%20 : $Builtin.Int64)
+  %22 = builtin "assert_configuration"() : $Builtin.Int32
+  %23 = integer_literal $Builtin.Int32, 0
+  %24 = builtin "cmp_eq_Int32"(%22 : $Builtin.Int32, %23 : $Builtin.Int32) : $Builtin.Int1
+  cond_br %24, bb2, bb1
+
+bb1:
+  %26 = builtin "assert_configuration"() : $Builtin.Int32
+  %27 = integer_literal $Builtin.Int32, 1
+  %28 = builtin "cmp_eq_Int32"(%26 : $Builtin.Int32, %27 : $Builtin.Int32) : $Builtin.Int1
+  cond_br %28, bb83, bb84
+
+bb2:
+  %30 = integer_literal $Builtin.Int64, 2
+  %31 = integer_literal $Builtin.Int64, 36
+  %34 = destructure_struct %1 : $Int
+  %35 = builtin "cmp_slt_Int64"(%34 : $Builtin.Int64, %30 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %35, bb3, bb4
+
+bb3:
+  %37 = integer_literal $Builtin.Int1, 0
+  br bb5(%37 : $Builtin.Int1)
+
+bb4:
+  %39 = builtin "cmp_slt_Int64"(%31 : $Builtin.Int64, %34 : $Builtin.Int64) : $Builtin.Int1
+  %40 = integer_literal $Builtin.Int1, -1
+  %41 = builtin "xor_Int1"(%39 : $Builtin.Int1, %40 : $Builtin.Int1) : $Builtin.Int1
+  br bb5(%41 : $Builtin.Int1)
+
+bb5(%43 : $Builtin.Int1):
+  %44 = integer_literal $Builtin.Int1, -1
+  %45 = builtin "int_expect_Int1"(%43 : $Builtin.Int1, %44 : $Builtin.Int1) : $Builtin.Int1
+  cond_br %45, bb7, bb6
+
+bb6:
+  %47 = string_literal utf8 "Fatal error"
+  %48 = integer_literal $Builtin.Word, 11
+  %49 = builtin "ptrtoint_Word"(%47 : $Builtin.RawPointer) : $Builtin.Word
+  %50 = integer_literal $Builtin.Int8, 2
+  %51 = struct $StaticString (%49 : $Builtin.Word, %48 : $Builtin.Word, %50 : $Builtin.Int8)
+  %52 = builtin "assert_configuration"() : $Builtin.Int32
+  %53 = integer_literal $Builtin.Int32, 0
+  %54 = builtin "cmp_eq_Int32"(%52 : $Builtin.Int32, %53 : $Builtin.Int32) : $Builtin.Int1
+  cond_br %54, bb8, bb9
+
+bb7:
+  br bb11
+
+bb8:
+  %57 = integer_literal $Builtin.Int32, 1
+  %58 = struct $UInt32 (%57 : $Builtin.Int32)
+  br bb10(%58 : $UInt32)
+
+bb9:
+  %60 = integer_literal $Builtin.Int32, 0
+  %61 = struct $UInt32 (%60 : $Builtin.Int32)
+  br bb10(%61 : $UInt32)
+
+bb10(%63 : $UInt32):
+  %64 = function_ref @$ss17_assertionFailure__4file4line5flagss5NeverOs12StaticStringV_A2HSus6UInt32VtF : $@convention(thin) (StaticString, StaticString, StaticString, UInt, UInt32) -> Never
+  %65 = apply %64(%51, %14, %19, %21, %63) : $@convention(thin) (StaticString, StaticString, StaticString, UInt, UInt32) -> Never
+  unreachable
+
+bb11:
+  %67 = witness_method $T, #BinaryInteger.bitWidth!getter : <Self where Self : BinaryInteger> (Self) -> () -> Int : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@in_guaranteed τ_0_0) -> Int
+  %68 = apply %67<T>(%0) : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@in_guaranteed τ_0_0) -> Int
+  %69 = integer_literal $Builtin.Int64, 64
+  %70 = struct_extract %68 : $Int, #Int._value
+  %71 = builtin "cmp_slt_Int64"(%69 : $Builtin.Int64, %70 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %71, bb13, bb12
+
+bb12:
+  %75 = destructure_struct %1 : $Int
+  %77 = struct $Int64 (%75 : $Builtin.Int64)
+  %79 = metatype $@thick T.Type
+  %80 = witness_method $T, #BinaryInteger.isSigned!getter : <Self where Self : BinaryInteger> (Self.Type) -> () -> Bool : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@thick τ_0_0.Type) -> Bool
+  %81 = apply %80<T>(%79) : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@thick τ_0_0.Type) -> Bool
+  %82 = struct_extract %81 : $Bool, #Bool._value
+  cond_br %82, bb14, bb15
+
+bb13:
+  %84 = metatype $@thick T.Type
+  %85 = integer_literal $Builtin.IntLiteral, 0
+  %86 = metatype $@thick T.IntegerLiteralType.Type
+  %87 = alloc_stack $T.IntegerLiteralType
+  %88 = witness_method $T.IntegerLiteralType, #_ExpressibleByBuiltinIntegerLiteral.init!allocator : <Self where Self : _ExpressibleByBuiltinIntegerLiteral> (Self.Type) -> (Builtin.IntLiteral) -> Self : $@convention(witness_method: _ExpressibleByBuiltinIntegerLiteral) <τ_0_0 where τ_0_0 : _ExpressibleByBuiltinIntegerLiteral> (Builtin.IntLiteral, @thick τ_0_0.Type) -> @out τ_0_0
+  %89 = apply %88<T.IntegerLiteralType>(%87, %85, %86) : $@convention(witness_method: _ExpressibleByBuiltinIntegerLiteral) <τ_0_0 where τ_0_0 : _ExpressibleByBuiltinIntegerLiteral> (Builtin.IntLiteral, @thick τ_0_0.Type) -> @out τ_0_0
+  %90 = metatype $@thick T.Type
+  %91 = alloc_stack $T
+  %92 = witness_method $T, #ExpressibleByIntegerLiteral.init!allocator : <Self where Self : ExpressibleByIntegerLiteral> (Self.Type) -> (Self.IntegerLiteralType) -> Self : $@convention(witness_method: ExpressibleByIntegerLiteral) <τ_0_0 where τ_0_0 : ExpressibleByIntegerLiteral> (@in τ_0_0.IntegerLiteralType, @thick τ_0_0.Type) -> @out τ_0_0
+  %93 = apply %92<T>(%91, %87, %90) : $@convention(witness_method: ExpressibleByIntegerLiteral) <τ_0_0 where τ_0_0 : ExpressibleByIntegerLiteral> (@in τ_0_0.IntegerLiteralType, @thick τ_0_0.Type) -> @out τ_0_0
+  %94 = witness_method $T, #Equatable."==" : <Self where Self : Equatable> (Self.Type) -> (Self, Self) -> Bool : $@convention(witness_method: Equatable) <τ_0_0 where τ_0_0 : Equatable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
+  %95 = apply %94<T>(%0, %91, %84) : $@convention(witness_method: Equatable) <τ_0_0 where τ_0_0 : Equatable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
+  destroy_addr %91 : $*T
+  dealloc_stack %91 : $*T
+  dealloc_stack %87 : $*T.IntegerLiteralType
+  %99 = struct_extract %95 : $Bool, #Bool._value
+  cond_br %99, bb17, bb18
+
+bb14:
+  %102 = witness_method $T, #BinaryInteger._lowWord!getter : <Self where Self : BinaryInteger> (Self) -> () -> UInt : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@in_guaranteed τ_0_0) -> UInt
+  %103 = apply %102<T>(%0) : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@in_guaranteed τ_0_0) -> UInt
+  destroy_addr %0 : $*T
+  %105 = struct_extract %103 : $UInt, #UInt._value
+  %107 = struct $Int64 (%105 : $Builtin.Int64)
+  %108 = function_ref @$ss14_int64ToString_5radix9uppercaseSSs5Int64V_AESbtF : $@convention(thin) (Int64, Int64, Bool) -> @owned String
+  %109 = apply %108(%107, %77, %2) : $@convention(thin) (Int64, Int64, Bool) -> @owned String
+  br bb16(%109 : $String)
+
+bb15:
+  %112 = witness_method $T, #BinaryInteger._lowWord!getter : <Self where Self : BinaryInteger> (Self) -> () -> UInt : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@in_guaranteed τ_0_0) -> UInt
+  %113 = apply %112<T>(%0) : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@in_guaranteed τ_0_0) -> UInt
+  destroy_addr %0 : $*T
+  %116 = struct_extract %113 : $UInt, #UInt._value
+  %119 = struct $UInt64 (%116 : $Builtin.Int64)
+  %120 = function_ref @$ss15_uint64ToString_5radix9uppercaseSSs6UInt64V_s5Int64VSbtF : $@convention(thin) (UInt64, Int64, Bool) -> @owned String
+  %121 = apply %120(%119, %77, %2) : $@convention(thin) (UInt64, Int64, Bool) -> @owned String
+  br bb16(%121 : $String)
+
+bb16(%123 : @owned $String):
+  return %123 : $String
+
+bb17:
+  destroy_addr %0 : $*T
+  %126 = string_literal utf8 "0"
+  %127 = integer_literal $Builtin.Word, 1
+  %128 = integer_literal $Builtin.Int1, -1
+  %129 = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  %130 = apply %129(%126, %127, %128, %3) : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  br bb16(%130 : $String)
+
+bb18:
+  %132 = struct_extract %1 : $Int, #Int._value
+  %133 = builtin "int_ctpop_Int64"(%132 : $Builtin.Int64) : $Builtin.Int64
+  %134 = integer_literal $Builtin.Int64, 1
+  %135 = builtin "cmp_eq_Int64"(%133 : $Builtin.Int64, %134 : $Builtin.Int64) : $Builtin.Int1
+  %137 = alloc_stack $T.Magnitude, let, name "radix_"
+  %138 = metatype $@thick T.Magnitude.Type
+  %139 = alloc_stack $Int
+  store %1 to [trivial] %139 : $*Int
+  %141 = witness_method $T.Magnitude, #BinaryInteger.init!allocator : <Self where Self : BinaryInteger><T where T : BinaryInteger> (Self.Type) -> (T) -> Self : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
+  %142 = apply %141<T.Magnitude, Int>(%137, %139, %138) : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
+  dealloc_stack %139 : $*Int
+  %144 = integer_literal $Builtin.Int64, 10
+  %145 = struct_extract %1 : $Int, #Int._value
+  %146 = builtin "cmp_slt_Int64"(%144 : $Builtin.Int64, %145 : $Builtin.Int64) : $Builtin.Int1
+  %148 = metatype $@thick T.Type
+  %149 = witness_method $T, #BinaryInteger.isSigned!getter : <Self where Self : BinaryInteger> (Self.Type) -> () -> Bool : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@thick τ_0_0.Type) -> Bool
+  %150 = apply %149<T>(%148) : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@thick τ_0_0.Type) -> Bool
+  %151 = alloc_stack $T
+  copy_addr %0 to [initialization] %151 : $*T
+  %153 = struct_extract %150 : $Bool, #Bool._value
+  cond_br %153, bb19, bb20
+
+bb19:
+  %155 = metatype $@thick T.Type
+  %156 = integer_literal $Builtin.IntLiteral, 0
+  %157 = metatype $@thick T.IntegerLiteralType.Type
+  %158 = alloc_stack $T.IntegerLiteralType
+  %159 = witness_method $T.IntegerLiteralType, #_ExpressibleByBuiltinIntegerLiteral.init!allocator : <Self where Self : _ExpressibleByBuiltinIntegerLiteral> (Self.Type) -> (Builtin.IntLiteral) -> Self : $@convention(witness_method: _ExpressibleByBuiltinIntegerLiteral) <τ_0_0 where τ_0_0 : _ExpressibleByBuiltinIntegerLiteral> (Builtin.IntLiteral, @thick τ_0_0.Type) -> @out τ_0_0
+  %160 = apply %159<T.IntegerLiteralType>(%158, %156, %157) : $@convention(witness_method: _ExpressibleByBuiltinIntegerLiteral) <τ_0_0 where τ_0_0 : _ExpressibleByBuiltinIntegerLiteral> (Builtin.IntLiteral, @thick τ_0_0.Type) -> @out τ_0_0
+  %161 = metatype $@thick T.Type
+  %162 = alloc_stack $T
+  %163 = witness_method $T, #ExpressibleByIntegerLiteral.init!allocator : <Self where Self : ExpressibleByIntegerLiteral> (Self.Type) -> (Self.IntegerLiteralType) -> Self : $@convention(witness_method: ExpressibleByIntegerLiteral) <τ_0_0 where τ_0_0 : ExpressibleByIntegerLiteral> (@in τ_0_0.IntegerLiteralType, @thick τ_0_0.Type) -> @out τ_0_0
+  %164 = apply %163<T>(%162, %158, %161) : $@convention(witness_method: ExpressibleByIntegerLiteral) <τ_0_0 where τ_0_0 : ExpressibleByIntegerLiteral> (@in τ_0_0.IntegerLiteralType, @thick τ_0_0.Type) -> @out τ_0_0
+  %165 = witness_method $T, #Comparable."<" : <Self where Self : Comparable> (Self.Type) -> (Self, Self) -> Bool : $@convention(witness_method: Comparable) <τ_0_0 where τ_0_0 : Comparable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
+  %166 = apply %165<T>(%151, %162, %155) : $@convention(witness_method: Comparable) <τ_0_0 where τ_0_0 : Comparable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
+  destroy_addr %162 : $*T
+  destroy_addr %151 : $*T
+  dealloc_stack %162 : $*T
+  dealloc_stack %158 : $*T.IntegerLiteralType
+  br bb21(%166 : $Bool)
+
+bb20:
+  destroy_addr %151 : $*T
+  %173 = integer_literal $Builtin.Int1, 0
+  %174 = struct $Bool (%173 : $Builtin.Int1)
+  br bb21(%174 : $Bool)
+
+bb21(%176 : $Bool):
+  dealloc_stack %151 : $*T
+  %179 = alloc_stack $T.Magnitude, var, name "value"
+  %180 = witness_method $T, #Numeric.magnitude!getter : <Self where Self : Numeric> (Self) -> () -> Self.Magnitude : $@convention(witness_method: Numeric) <τ_0_0 where τ_0_0 : Numeric> (@in_guaranteed τ_0_0) -> @out τ_0_0.Magnitude
+  %181 = apply %180<T>(%179, %0) : $@convention(witness_method: Numeric) <τ_0_0 where τ_0_0 : Numeric> (@in_guaranteed τ_0_0) -> @out τ_0_0.Magnitude
+  %182 = alloc_stack $Array<UInt8>, var, name "result"
+  %183 = integer_literal $Builtin.Int64, 0
+  %184 = struct $Int (%183 : $Builtin.Int64)
+  %186 = metatype $@thin Array<UInt8>.Type
+  %187 = function_ref @$sSa22_allocateUninitializedySayxG_SpyxGtSiFZs5UInt8V_Tg5 : $@convention(method) (Int, @thin Array<UInt8>.Type) -> (@owned Array<UInt8>, UnsafeMutablePointer<UInt8>)
+  %188 = apply %187(%184, %186) : $@convention(method) (Int, @thin Array<UInt8>.Type) -> (@owned Array<UInt8>, UnsafeMutablePointer<UInt8>)
+  (%189, %190) = destructure_tuple %188 : $(Array<UInt8>, UnsafeMutablePointer<UInt8>)
+  %192 = struct_extract %190 : $UnsafeMutablePointer<UInt8>, #UnsafeMutablePointer._rawValue
+  %193 = tuple (%189 : $Array<UInt8>, %192 : $Builtin.RawPointer)
+  (%194, %195) = destructure_tuple %193 : $(Array<UInt8>, Builtin.RawPointer)
+  store %194 to [init] %182 : $*Array<UInt8>
+  br bb22
+
+bb22:
+  %198 = alloc_stack $T.Magnitude
+  copy_addr %179 to [initialization] %198 : $*T.Magnitude
+  %200 = integer_literal $Builtin.Int64, 0
+  %201 = struct $Int (%200 : $Builtin.Int64)
+  %202 = metatype $@thick T.Magnitude.Type
+  %203 = witness_method $T.Magnitude, #BinaryInteger.isSigned!getter : <Self where Self : BinaryInteger> (Self.Type) -> () -> Bool : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@thick τ_0_0.Type) -> Bool
+  %204 = apply %203<T.Magnitude>(%202) : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@thick τ_0_0.Type) -> Bool
+  %205 = alloc_stack $T.Magnitude
+  copy_addr %198 to [initialization] %205 : $*T.Magnitude
+  %207 = struct_extract %204 : $Bool, #Bool._value
+  cond_br %207, bb23, bb24
+
+bb23:
+  %209 = metatype $@thick T.Magnitude.Type
+  %210 = integer_literal $Builtin.IntLiteral, 0
+  %211 = metatype $@thick T.Magnitude.IntegerLiteralType.Type
+  %212 = alloc_stack $T.Magnitude.IntegerLiteralType
+  %213 = witness_method $T.Magnitude.IntegerLiteralType, #_ExpressibleByBuiltinIntegerLiteral.init!allocator : <Self where Self : _ExpressibleByBuiltinIntegerLiteral> (Self.Type) -> (Builtin.IntLiteral) -> Self : $@convention(witness_method: _ExpressibleByBuiltinIntegerLiteral) <τ_0_0 where τ_0_0 : _ExpressibleByBuiltinIntegerLiteral> (Builtin.IntLiteral, @thick τ_0_0.Type) -> @out τ_0_0
+  %214 = apply %213<T.Magnitude.IntegerLiteralType>(%212, %210, %211) : $@convention(witness_method: _ExpressibleByBuiltinIntegerLiteral) <τ_0_0 where τ_0_0 : _ExpressibleByBuiltinIntegerLiteral> (Builtin.IntLiteral, @thick τ_0_0.Type) -> @out τ_0_0
+  %215 = metatype $@thick T.Magnitude.Type
+  %216 = alloc_stack $T.Magnitude
+  %217 = witness_method $T.Magnitude, #ExpressibleByIntegerLiteral.init!allocator : <Self where Self : ExpressibleByIntegerLiteral> (Self.Type) -> (Self.IntegerLiteralType) -> Self : $@convention(witness_method: ExpressibleByIntegerLiteral) <τ_0_0 where τ_0_0 : ExpressibleByIntegerLiteral> (@in τ_0_0.IntegerLiteralType, @thick τ_0_0.Type) -> @out τ_0_0
+  %218 = apply %217<T.Magnitude>(%216, %212, %215) : $@convention(witness_method: ExpressibleByIntegerLiteral) <τ_0_0 where τ_0_0 : ExpressibleByIntegerLiteral> (@in τ_0_0.IntegerLiteralType, @thick τ_0_0.Type) -> @out τ_0_0
+  %219 = witness_method $T.Magnitude, #Comparable."<" : <Self where Self : Comparable> (Self.Type) -> (Self, Self) -> Bool : $@convention(witness_method: Comparable) <τ_0_0 where τ_0_0 : Comparable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
+  %220 = apply %219<T.Magnitude>(%205, %216, %209) : $@convention(witness_method: Comparable) <τ_0_0 where τ_0_0 : Comparable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
+  destroy_addr %216 : $*T.Magnitude
+  destroy_addr %205 : $*T.Magnitude
+  dealloc_stack %216 : $*T.Magnitude
+  dealloc_stack %212 : $*T.Magnitude.IntegerLiteralType
+  br bb25(%220 : $Bool)
+
+bb24:
+  destroy_addr %205 : $*T.Magnitude
+  %227 = integer_literal $Builtin.Int1, 0
+  %228 = struct $Bool (%227 : $Builtin.Int1)
+  br bb25(%228 : $Bool)
+
+bb25(%230 : $Bool):
+  dealloc_stack %205 : $*T.Magnitude
+  %232 = struct_extract %230 : $Bool, #Bool._value
+  cond_br %232, bb26, bb27
+
+bb26:
+  destroy_addr %198 : $*T.Magnitude
+  %235 = integer_literal $Builtin.Int1, 0
+  %236 = struct $Bool (%235 : $Builtin.Int1)
+  br bb28(%236 : $Bool)
+
+bb27:
+  %238 = witness_method $T.Magnitude, #BinaryInteger.bitWidth!getter : <Self where Self : BinaryInteger> (Self) -> () -> Int : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@in_guaranteed τ_0_0) -> Int
+  %239 = apply %238<T.Magnitude>(%198) : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@in_guaranteed τ_0_0) -> Int
+  %240 = integer_literal $Builtin.Int64, 64
+  %241 = struct_extract %239 : $Int, #Int._value
+  %242 = builtin "cmp_slt_Int64"(%241 : $Builtin.Int64, %240 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %242, bb77, bb78
+
+bb28(%244 : $Bool):
+  %245 = struct_extract %244 : $Bool, #Bool._value
+  dealloc_stack %198 : $*T.Magnitude
+  cond_br %245, bb56, bb29
+
+bb29:
+  %248 = alloc_stack $T.Magnitude, let, name "quotient"
+  %249 = alloc_stack $T.Magnitude, let, name "remainder"
+  %254 = alloc_stack $(T.Magnitude, T.Magnitude)
+  cond_br %135, bb30, bb31
+
+bb30:
+  %256 = tuple_element_addr %254 : $*(T.Magnitude, T.Magnitude), 0
+  %257 = tuple_element_addr %254 : $*(T.Magnitude, T.Magnitude), 1
+  %258 = metatype $@thick T.Magnitude.Type
+  %259 = struct_extract %1 : $Int, #Int._value
+  %260 = integer_literal $Builtin.Int1, 0
+  %261 = builtin "int_cttz_Int64"(%259 : $Builtin.Int64, %260 : $Builtin.Int1) : $Builtin.Int64
+  %262 = struct $Int (%261 : $Builtin.Int64)
+  %263 = alloc_stack $Int
+  store %262 to [trivial] %263 : $*Int
+  %265 = witness_method $T.Magnitude, #BinaryInteger.">>" : <Self where Self : BinaryInteger><RHS where RHS : BinaryInteger> (Self.Type) -> (Self, RHS) -> Self : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in_guaranteed τ_0_0, @in_guaranteed τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
+  %266 = apply %265<T.Magnitude, Int>(%256, %179, %263, %258) : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in_guaranteed τ_0_0, @in_guaranteed τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
+  dealloc_stack %263 : $*Int
+  %268 = metatype $@thick T.Magnitude.Type
+  %269 = alloc_stack $T.Magnitude
+  %270 = metatype $@thick T.Magnitude.Type
+  %271 = integer_literal $Builtin.IntLiteral, 1
+  %272 = metatype $@thick T.Magnitude.IntegerLiteralType.Type
+  %273 = alloc_stack $T.Magnitude.IntegerLiteralType
+  %274 = witness_method $T.Magnitude.IntegerLiteralType, #_ExpressibleByBuiltinIntegerLiteral.init!allocator : <Self where Self : _ExpressibleByBuiltinIntegerLiteral> (Self.Type) -> (Builtin.IntLiteral) -> Self : $@convention(witness_method: _ExpressibleByBuiltinIntegerLiteral) <τ_0_0 where τ_0_0 : _ExpressibleByBuiltinIntegerLiteral> (Builtin.IntLiteral, @thick τ_0_0.Type) -> @out τ_0_0
+  %275 = apply %274<T.Magnitude.IntegerLiteralType>(%273, %271, %272) : $@convention(witness_method: _ExpressibleByBuiltinIntegerLiteral) <τ_0_0 where τ_0_0 : _ExpressibleByBuiltinIntegerLiteral> (Builtin.IntLiteral, @thick τ_0_0.Type) -> @out τ_0_0
+  %276 = metatype $@thick T.Magnitude.Type
+  %277 = alloc_stack $T.Magnitude
+  %278 = witness_method $T.Magnitude, #ExpressibleByIntegerLiteral.init!allocator : <Self where Self : ExpressibleByIntegerLiteral> (Self.Type) -> (Self.IntegerLiteralType) -> Self : $@convention(witness_method: ExpressibleByIntegerLiteral) <τ_0_0 where τ_0_0 : ExpressibleByIntegerLiteral> (@in τ_0_0.IntegerLiteralType, @thick τ_0_0.Type) -> @out τ_0_0
+  %279 = apply %278<T.Magnitude>(%277, %273, %276) : $@convention(witness_method: ExpressibleByIntegerLiteral) <τ_0_0 where τ_0_0 : ExpressibleByIntegerLiteral> (@in τ_0_0.IntegerLiteralType, @thick τ_0_0.Type) -> @out τ_0_0
+  %280 = witness_method $T.Magnitude, #AdditiveArithmetic."-" : <Self where Self : AdditiveArithmetic> (Self.Type) -> (Self, Self) -> Self : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> @out τ_0_0
+  %281 = apply %280<T.Magnitude>(%269, %137, %277, %270) : $@convention(witness_method: AdditiveArithmetic) <τ_0_0 where τ_0_0 : AdditiveArithmetic> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> @out τ_0_0
+  destroy_addr %277 : $*T.Magnitude
+  dealloc_stack %277 : $*T.Magnitude
+  dealloc_stack %273 : $*T.Magnitude.IntegerLiteralType
+  %285 = witness_method $T.Magnitude, #BinaryInteger."&" : <Self where Self : BinaryInteger> (Self.Type) -> (Self, Self) -> Self : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> @out τ_0_0
+  %286 = apply %285<T.Magnitude>(%257, %179, %269, %268) : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> @out τ_0_0
+  destroy_addr %269 : $*T.Magnitude
+  destroy_addr %179 : $*T.Magnitude
+  dealloc_stack %269 : $*T.Magnitude
+  br bb32
+
+bb31:
+  %291 = alloc_stack $T.Magnitude
+  %292 = alloc_stack $T.Magnitude
+  %293 = witness_method $T.Magnitude, #BinaryInteger.quotientAndRemainder : <Self where Self : BinaryInteger> (Self) -> (Self) -> (quotient: Self, remainder: Self) : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0) -> (@out τ_0_0, @out τ_0_0)
+  %294 = apply %293<T.Magnitude>(%291, %292, %137, %179) : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0) -> (@out τ_0_0, @out τ_0_0)
+  destroy_addr %179 : $*T.Magnitude
+  %296 = tuple_element_addr %254 : $*(T.Magnitude, T.Magnitude), 0
+  %297 = tuple_element_addr %254 : $*(T.Magnitude, T.Magnitude), 1
+  copy_addr [take] %291 to [initialization] %296 : $*T.Magnitude
+  copy_addr [take] %292 to [initialization] %297 : $*T.Magnitude
+  dealloc_stack %292 : $*T.Magnitude
+  dealloc_stack %291 : $*T.Magnitude
+  br bb32
+
+bb32:
+  %303 = tuple_element_addr %254 : $*(T.Magnitude, T.Magnitude), 0
+  %304 = tuple_element_addr %254 : $*(T.Magnitude, T.Magnitude), 1
+  copy_addr [take] %303 to [initialization] %248 : $*T.Magnitude
+  copy_addr [take] %304 to [initialization] %249 : $*T.Magnitude
+  dealloc_stack %254 : $*(T.Magnitude, T.Magnitude)
+  %309 = witness_method $T.Magnitude, #BinaryInteger._lowWord!getter : <Self where Self : BinaryInteger> (Self) -> () -> UInt : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@in_guaranteed τ_0_0) -> UInt
+  %310 = apply %309<T.Magnitude>(%249) : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@in_guaranteed τ_0_0) -> UInt
+  destroy_addr %249 : $*T.Magnitude
+  %313 = struct_extract %310 : $UInt, #UInt._value
+  %314 = builtin "truncOrBitCast_Int64_Int8"(%313 : $Builtin.Int64) : $Builtin.Int8
+  cond_br %146, bb34, bb33
+
+bb33:
+  %321 = integer_literal $Builtin.Int1, -1
+  br bb35(%321 : $Builtin.Int1)
+
+bb34:
+  %323 = integer_literal $Builtin.Int8, 10
+  %324 = builtin "cmp_ult_Int8"(%314 : $Builtin.Int8, %323 : $Builtin.Int8) : $Builtin.Int1
+  br bb35(%324 : $Builtin.Int1)
+
+bb35(%326 : $Builtin.Int1):
+  cond_br %326, bb36, bb37
+
+bb36:
+  %328 = builtin "assert_configuration"() : $Builtin.Int32
+  %329 = integer_literal $Builtin.Int32, 0
+  %330 = builtin "cmp_eq_Int32"(%328 : $Builtin.Int32, %329 : $Builtin.Int32) : $Builtin.Int1
+  %331 = integer_literal $Builtin.Int8, 48
+  br bb38(%331 : $Builtin.Int8)
+
+bb37:
+  %336 = struct_extract %2 : $Bool, #Bool._value
+  cond_br %336, bb54, bb55
+
+bb38(%338 : $Builtin.Int8):
+  %339 = integer_literal $Builtin.Int1, 0
+  %340 = builtin "uadd_with_overflow_Int8"(%338 : $Builtin.Int8, %314 : $Builtin.Int8, %339 : $Builtin.Int1) : $(Builtin.Int8, Builtin.Int1)
+  (%341, %342) = destructure_tuple %340 : $(Builtin.Int8, Builtin.Int1)
+  %343 = struct $UInt8 (%341 : $Builtin.Int8)
+  %346 = function_ref @$sSa034_makeUniqueAndReserveCapacityIfNotB0yyFs5UInt8V_Tg5 : $@convention(method) (@inout Array<UInt8>) -> ()
+  %347 = apply %346(%182) : $@convention(method) (@inout Array<UInt8>) -> ()
+  %348 = struct_element_addr %182 : $*Array<UInt8>, #Array._buffer
+  %349 = struct_element_addr %348 : $*_ArrayBuffer<UInt8>, #_ArrayBuffer._storage
+  %350 = struct_element_addr %349 : $*_BridgeStorage<__ContiguousArrayStorageBase>, #_BridgeStorage.rawValue
+  %351 = load_borrow %350 : $*Builtin.BridgeObject
+  %352 = string_literal utf8 "Swift/BridgeStorage.swift"
+  %353 = integer_literal $Builtin.Word, 25
+  %354 = builtin "ptrtoint_Word"(%352 : $Builtin.RawPointer) : $Builtin.Word
+  %355 = integer_literal $Builtin.Int8, 2
+  %356 = struct $StaticString (%354 : $Builtin.Word, %353 : $Builtin.Word, %355 : $Builtin.Int8)
+  %357 = integer_literal $Builtin.Int64, 127
+  %358 = struct $UInt (%357 : $Builtin.Int64)
+  %359 = string_literal utf8 ""
+  %360 = integer_literal $Builtin.Word, 0
+  %361 = builtin "ptrtoint_Word"(%359 : $Builtin.RawPointer) : $Builtin.Word
+  %362 = struct $StaticString (%361 : $Builtin.Word, %360 : $Builtin.Word, %355 : $Builtin.Int8)
+  %363 = classify_bridge_object %351 : $Builtin.BridgeObject
+  (%364, %365) = destructure_tuple %363 : $(Builtin.Int1, Builtin.Int1)
+  %366 = builtin "or_Int1"(%364 : $Builtin.Int1, %365 : $Builtin.Int1) : $Builtin.Int1
+  %367 = integer_literal $Builtin.Int1, 0
+  %368 = builtin "int_expect_Int1"(%366 : $Builtin.Int1, %367 : $Builtin.Int1) : $Builtin.Int1
+  cond_br %368, bb39, bb40
+
+bb39:
+  %370 = string_literal utf8 "Fatal error"
+  %371 = integer_literal $Builtin.Word, 11
+  %372 = builtin "ptrtoint_Word"(%370 : $Builtin.RawPointer) : $Builtin.Word
+  %373 = struct $StaticString (%372 : $Builtin.Word, %371 : $Builtin.Word, %355 : $Builtin.Int8)
+  %374 = builtin "assert_configuration"() : $Builtin.Int32
+  %375 = integer_literal $Builtin.Int32, 0
+  %376 = builtin "cmp_eq_Int32"(%374 : $Builtin.Int32, %375 : $Builtin.Int32) : $Builtin.Int1
+  cond_br %376, bb41, bb42
+
+bb40:
+  %378 = integer_literal $Builtin.Int64, 128
+  %379 = struct $UInt (%378 : $Builtin.Int64)
+  %382 = bridge_object_to_word %351 : $Builtin.BridgeObject to $Builtin.Word
+  %383 = builtin "zextOrBitCast_Word_Int64"(%382 : $Builtin.Word) : $Builtin.Int64
+  %384 = integer_literal $Builtin.Int64, 8070450532247928839
+  %385 = builtin "and_Int64"(%383 : $Builtin.Int64, %384 : $Builtin.Int64) : $Builtin.Int64
+  %386 = integer_literal $Builtin.Int64, 0
+  %387 = builtin "cmp_eq_Int64"(%385 : $Builtin.Int64, %386 : $Builtin.Int64) : $Builtin.Int1
+  %388 = integer_literal $Builtin.Int1, -1
+  %389 = builtin "int_expect_Int1"(%387 : $Builtin.Int1, %388 : $Builtin.Int1) : $Builtin.Int1
+  cond_br %389, bb44, bb45
+
+bb41:
+  %391 = integer_literal $Builtin.Int32, 1
+  %392 = struct $UInt32 (%391 : $Builtin.Int32)
+  br bb43(%392 : $UInt32)
+
+bb42:
+  %394 = struct $UInt32 (%375 : $Builtin.Int32)
+  br bb43(%394 : $UInt32)
+
+bb43(%396 : $UInt32):
+  %397 = function_ref @$ss18_fatalErrorMessage__4file4line5flagss5NeverOs12StaticStringV_A2HSus6UInt32VtF : $@convention(thin) (StaticString, StaticString, StaticString, UInt, UInt32) -> Never
+  %398 = apply %397(%373, %362, %356, %358, %396) : $@convention(thin) (StaticString, StaticString, StaticString, UInt, UInt32) -> Never
+  unreachable
+
+bb44:
+  %400 = unchecked_ref_cast %351 : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
+  %404 = ref_element_addr %400 : $__ContiguousArrayStorageBase, #__ContiguousArrayStorageBase.countAndCapacity
+  %405 = struct_element_addr %404 : $*_ArrayBody, #_ArrayBody._storage
+  %406 = struct_element_addr %405 : $*_SwiftArrayBodyStorage, #_SwiftArrayBodyStorage.count
+  %407 = struct_element_addr %406 : $*Int, #Int._value
+  %408 = load [trivial] %407 : $*Builtin.Int64
+  %409 = string_literal utf8 "Swift/IntegerTypes.swift"
+  %410 = integer_literal $Builtin.Word, 24
+  %411 = builtin "ptrtoint_Word"(%409 : $Builtin.RawPointer) : $Builtin.Word
+  %412 = struct $StaticString (%411 : $Builtin.Word, %410 : $Builtin.Word, %355 : $Builtin.Int8)
+  %413 = integer_literal $Builtin.Int64, 15235
+  %414 = struct $UInt (%413 : $Builtin.Int64)
+  %415 = builtin "cmp_slt_Int64"(%408 : $Builtin.Int64, %386 : $Builtin.Int64) : $Builtin.Int1
+  %416 = builtin "int_expect_Int1"(%415 : $Builtin.Int1, %367 : $Builtin.Int1) : $Builtin.Int1
+  cond_br %416, bb46, bb47
+
+bb45:
+  %418 = string_literal utf8 "Fatal error"
+  %419 = integer_literal $Builtin.Word, 11
+  %420 = builtin "ptrtoint_Word"(%418 : $Builtin.RawPointer) : $Builtin.Word
+  %421 = struct $StaticString (%420 : $Builtin.Word, %419 : $Builtin.Word, %355 : $Builtin.Int8)
+  %422 = builtin "assert_configuration"() : $Builtin.Int32
+  %423 = integer_literal $Builtin.Int32, 0
+  %424 = builtin "cmp_eq_Int32"(%422 : $Builtin.Int32, %423 : $Builtin.Int32) : $Builtin.Int1
+  cond_br %424, bb51, bb52
+
+bb46:
+  %426 = string_literal utf8 "Fatal error"
+  %427 = integer_literal $Builtin.Word, 11
+  %428 = builtin "ptrtoint_Word"(%426 : $Builtin.RawPointer) : $Builtin.Word
+  %429 = struct $StaticString (%428 : $Builtin.Word, %427 : $Builtin.Word, %355 : $Builtin.Int8)
+  %430 = builtin "assert_configuration"() : $Builtin.Int32
+  %431 = integer_literal $Builtin.Int32, 0
+  %432 = builtin "cmp_eq_Int32"(%430 : $Builtin.Int32, %431 : $Builtin.Int32) : $Builtin.Int1
+  cond_br %432, bb48, bb49
+
+bb47:
+  %434 = builtin "assumeNonNegative_Int64"(%408 : $Builtin.Int64) : $Builtin.Int64
+  %435 = struct $Int (%434 : $Builtin.Int64)
+  end_borrow %351 : $Builtin.BridgeObject
+  %438 = function_ref @$sSa36_reserveCapacityAssumingUniqueBuffer8oldCountySi_tFs5UInt8V_Tg5 : $@convention(method) (Int, @inout Array<UInt8>) -> ()
+  %439 = apply %438(%435, %182) : $@convention(method) (Int, @inout Array<UInt8>) -> ()
+  %440 = function_ref @$sSa37_appendElementAssumeUniqueAndCapacity_03newB0ySi_xntFs5UInt8V_Tg5 : $@convention(method) (Int, UInt8, @inout Array<UInt8>) -> ()
+  %441 = apply %440(%435, %343, %182) : $@convention(method) (Int, UInt8, @inout Array<UInt8>) -> ()
+  %442 = function_ref @$sSa12_endMutationyyFs5UInt8V_Tg5 : $@convention(method) (@inout Array<UInt8>) -> ()
+  %443 = apply %442(%182) : $@convention(method) (@inout Array<UInt8>) -> ()
+  copy_addr [take] %248 to [initialization] %179 : $*T.Magnitude
+  dealloc_stack %249 : $*T.Magnitude
+  dealloc_stack %248 : $*T.Magnitude
+  br bb22
+
+bb48:
+  %448 = integer_literal $Builtin.Int32, 1
+  %449 = struct $UInt32 (%448 : $Builtin.Int32)
+  br bb50(%449 : $UInt32)
+
+bb49:
+  %451 = struct $UInt32 (%431 : $Builtin.Int32)
+  br bb50(%451 : $UInt32)
+
+bb50(%453 : $UInt32):
+  %454 = function_ref @$ss18_fatalErrorMessage__4file4line5flagss5NeverOs12StaticStringV_A2HSus6UInt32VtF : $@convention(thin) (StaticString, StaticString, StaticString, UInt, UInt32) -> Never
+  %455 = apply %454(%429, %362, %412, %414, %453) : $@convention(thin) (StaticString, StaticString, StaticString, UInt, UInt32) -> Never
+  unreachable
+
+bb51:
+  %457 = integer_literal $Builtin.Int32, 1
+  %458 = struct $UInt32 (%457 : $Builtin.Int32)
+  br bb53(%458 : $UInt32)
+
+bb52:
+  %460 = struct $UInt32 (%423 : $Builtin.Int32)
+  br bb53(%460 : $UInt32)
+
+bb53(%462 : $UInt32):
+  %463 = function_ref @$ss18_fatalErrorMessage__4file4line5flagss5NeverOs12StaticStringV_A2HSus6UInt32VtF : $@convention(thin) (StaticString, StaticString, StaticString, UInt, UInt32) -> Never
+  %464 = apply %463(%421, %362, %356, %379, %462) : $@convention(thin) (StaticString, StaticString, StaticString, UInt, UInt32) -> Never
+  unreachable
+
+bb54:
+  %466 = builtin "assert_configuration"() : $Builtin.Int32
+  %467 = integer_literal $Builtin.Int32, 0
+  %468 = builtin "cmp_eq_Int32"(%466 : $Builtin.Int32, %467 : $Builtin.Int32) : $Builtin.Int1
+  %469 = integer_literal $Builtin.Int8, 55
+  br bb38(%469 : $Builtin.Int8)
+
+bb55:
+  %472 = builtin "assert_configuration"() : $Builtin.Int32
+  %473 = integer_literal $Builtin.Int32, 0
+  %474 = builtin "cmp_eq_Int32"(%472 : $Builtin.Int32, %473 : $Builtin.Int32) : $Builtin.Int1
+  %475 = integer_literal $Builtin.Int8, 87
+  br bb38(%475 : $Builtin.Int8)
+
+bb56:
+  %478 = struct_extract %176 : $Bool, #Bool._value
+  cond_br %478, bb57, bb58
+
+bb57:
+  %480 = integer_literal $Builtin.Int8, 45
+  %483 = struct $UInt8 (%480 : $Builtin.Int8)
+  %484 = function_ref @$sSa6appendyyxnFs5UInt8V_Tg5 : $@convention(method) (UInt8, @inout Array<UInt8>) -> ()
+  %485 = apply %484(%483, %182) : $@convention(method) (UInt8, @inout Array<UInt8>) -> ()
+  br bb59
+
+bb58:
+  br bb59
+
+bb59:
+  %488 = function_ref @$sSMsSKRzrlE7reverseyyFSays5UInt8VG_Tg5 : $@convention(method) (@inout Array<UInt8>) -> ()
+  %489 = apply %488(%182) : $@convention(method) (@inout Array<UInt8>) -> ()
+  %490 = load [copy] %182 : $*Array<UInt8>
+  %491 = function_ref @$sSzsE12_description5radix9uppercaseSSSi_SbtFSSSRys5UInt8VGXEfU_ : $@convention(thin) (UnsafeBufferPointer<UInt8>) -> @owned String
+  %492 = thin_to_thick_function %491 : $@convention(thin) (UnsafeBufferPointer<UInt8>) -> @owned String to $@noescape @callee_guaranteed (UnsafeBufferPointer<UInt8>) -> @owned String
+  %493 = convert_function %492 : $@noescape @callee_guaranteed (UnsafeBufferPointer<UInt8>) -> @owned String to $@noescape @callee_guaranteed (UnsafeBufferPointer<UInt8>) -> (@owned String, @error Error)
+  %494 = begin_borrow %490 : $Array<UInt8>
+  %496 = struct_extract %494 : $Array<UInt8>, #Array._buffer
+  %497 = alloc_stack $String
+  %500 = metatype $@thin UnsafeBufferPointer<UInt8>.Type
+  %501 = function_ref @$ss12_ArrayBufferV19firstElementAddressSpyxGvgs5UInt8V_Tg5 : $@convention(method) (@guaranteed _ArrayBuffer<UInt8>) -> UnsafeMutablePointer<UInt8>
+  %502 = apply %501(%496) : $@convention(method) (@guaranteed _ArrayBuffer<UInt8>) -> UnsafeMutablePointer<UInt8>
+  %503 = struct_extract %502 : $UnsafeMutablePointer<UInt8>, #UnsafeMutablePointer._rawValue
+  %504 = struct $UnsafePointer<UInt8> (%503 : $Builtin.RawPointer)
+  %505 = enum $Optional<UnsafePointer<UInt8>>, #Optional.some!enumelt, %504 : $UnsafePointer<UInt8>
+  %509 = struct_extract %496 : $_ArrayBuffer<UInt8>, #_ArrayBuffer._storage
+  %511 = string_literal utf8 "Swift/BridgeStorage.swift"
+  %512 = integer_literal $Builtin.Word, 25
+  %513 = builtin "ptrtoint_Word"(%511 : $Builtin.RawPointer) : $Builtin.Word
+  %514 = integer_literal $Builtin.Int8, 2
+  %515 = struct $StaticString (%513 : $Builtin.Word, %512 : $Builtin.Word, %514 : $Builtin.Int8)
+  %516 = integer_literal $Builtin.Int64, 127
+  %517 = struct $UInt (%516 : $Builtin.Int64)
+  %518 = string_literal utf8 ""
+  %519 = integer_literal $Builtin.Word, 0
+  %520 = builtin "ptrtoint_Word"(%518 : $Builtin.RawPointer) : $Builtin.Word
+  %521 = struct $StaticString (%520 : $Builtin.Word, %519 : $Builtin.Word, %514 : $Builtin.Int8)
+  %523 = struct_extract %509 : $_BridgeStorage<__ContiguousArrayStorageBase>, #_BridgeStorage.rawValue
+  %524 = classify_bridge_object %523 : $Builtin.BridgeObject
+  (%525, %526) = destructure_tuple %524 : $(Builtin.Int1, Builtin.Int1)
+  %527 = builtin "or_Int1"(%525 : $Builtin.Int1, %526 : $Builtin.Int1) : $Builtin.Int1
+  %528 = integer_literal $Builtin.Int1, 0
+  %529 = builtin "int_expect_Int1"(%527 : $Builtin.Int1, %528 : $Builtin.Int1) : $Builtin.Int1
+  cond_br %529, bb60, bb61
+
+bb60:
+  %531 = string_literal utf8 "Fatal error"
+  %532 = integer_literal $Builtin.Word, 11
+  %533 = builtin "ptrtoint_Word"(%531 : $Builtin.RawPointer) : $Builtin.Word
+  %534 = struct $StaticString (%533 : $Builtin.Word, %532 : $Builtin.Word, %514 : $Builtin.Int8)
+  %535 = builtin "assert_configuration"() : $Builtin.Int32
+  %536 = integer_literal $Builtin.Int32, 0
+  %537 = builtin "cmp_eq_Int32"(%535 : $Builtin.Int32, %536 : $Builtin.Int32) : $Builtin.Int1
+  cond_br %537, bb62, bb63
+
+bb61:
+  %539 = integer_literal $Builtin.Int64, 128
+  %540 = struct $UInt (%539 : $Builtin.Int64)
+  %543 = bridge_object_to_word %523 : $Builtin.BridgeObject to $Builtin.Word
+  %544 = builtin "zextOrBitCast_Word_Int64"(%543 : $Builtin.Word) : $Builtin.Int64
+  %545 = integer_literal $Builtin.Int64, 8070450532247928839
+  %546 = builtin "and_Int64"(%544 : $Builtin.Int64, %545 : $Builtin.Int64) : $Builtin.Int64
+  %547 = integer_literal $Builtin.Int64, 0
+  %548 = builtin "cmp_eq_Int64"(%546 : $Builtin.Int64, %547 : $Builtin.Int64) : $Builtin.Int1
+  %549 = integer_literal $Builtin.Int1, -1
+  %550 = builtin "int_expect_Int1"(%548 : $Builtin.Int1, %549 : $Builtin.Int1) : $Builtin.Int1
+  cond_br %550, bb65, bb66
+
+bb62:
+  %552 = integer_literal $Builtin.Int32, 1
+  %553 = struct $UInt32 (%552 : $Builtin.Int32)
+  br bb64(%553 : $UInt32)
+
+bb63:
+  %555 = struct $UInt32 (%536 : $Builtin.Int32)
+  br bb64(%555 : $UInt32)
+
+bb64(%557 : $UInt32):
+  %558 = function_ref @$ss18_fatalErrorMessage__4file4line5flagss5NeverOs12StaticStringV_A2HSus6UInt32VtF : $@convention(thin) (StaticString, StaticString, StaticString, UInt, UInt32) -> Never
+  %559 = apply %558(%534, %521, %515, %517, %557) : $@convention(thin) (StaticString, StaticString, StaticString, UInt, UInt32) -> Never
+  unreachable
+
+bb65:
+  %561 = unchecked_ref_cast %523 : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
+  %564 = ref_element_addr %561 : $__ContiguousArrayStorageBase, #__ContiguousArrayStorageBase.countAndCapacity
+  %565 = struct_element_addr %564 : $*_ArrayBody, #_ArrayBody._storage
+  %566 = struct_element_addr %565 : $*_SwiftArrayBodyStorage, #_SwiftArrayBodyStorage.count
+  %567 = struct_element_addr %566 : $*Int, #Int._value
+  %568 = load [trivial] %567 : $*Builtin.Int64
+  %569 = string_literal utf8 "Swift/IntegerTypes.swift"
+  %570 = integer_literal $Builtin.Word, 24
+  %571 = builtin "ptrtoint_Word"(%569 : $Builtin.RawPointer) : $Builtin.Word
+  %572 = struct $StaticString (%571 : $Builtin.Word, %570 : $Builtin.Word, %514 : $Builtin.Int8)
+  %573 = integer_literal $Builtin.Int64, 15235
+  %574 = struct $UInt (%573 : $Builtin.Int64)
+  %575 = builtin "cmp_slt_Int64"(%568 : $Builtin.Int64, %547 : $Builtin.Int64) : $Builtin.Int1
+  %576 = builtin "int_expect_Int1"(%575 : $Builtin.Int1, %528 : $Builtin.Int1) : $Builtin.Int1
+  cond_br %576, bb67, bb68
+
+bb66:
+  %578 = string_literal utf8 "Fatal error"
+  %579 = integer_literal $Builtin.Word, 11
+  %580 = builtin "ptrtoint_Word"(%578 : $Builtin.RawPointer) : $Builtin.Word
+  %581 = struct $StaticString (%580 : $Builtin.Word, %579 : $Builtin.Word, %514 : $Builtin.Int8)
+  %582 = builtin "assert_configuration"() : $Builtin.Int32
+  %583 = integer_literal $Builtin.Int32, 0
+  %584 = builtin "cmp_eq_Int32"(%582 : $Builtin.Int32, %583 : $Builtin.Int32) : $Builtin.Int1
+  cond_br %584, bb74, bb75
+
+bb67:
+  %586 = string_literal utf8 "Fatal error"
+  %587 = integer_literal $Builtin.Word, 11
+  %588 = builtin "ptrtoint_Word"(%586 : $Builtin.RawPointer) : $Builtin.Word
+  %589 = struct $StaticString (%588 : $Builtin.Word, %587 : $Builtin.Word, %514 : $Builtin.Int8)
+  %590 = builtin "assert_configuration"() : $Builtin.Int32
+  %591 = integer_literal $Builtin.Int32, 0
+  %592 = builtin "cmp_eq_Int32"(%590 : $Builtin.Int32, %591 : $Builtin.Int32) : $Builtin.Int1
+  cond_br %592, bb71, bb72
+
+bb68:
+  %594 = builtin "assumeNonNegative_Int64"(%568 : $Builtin.Int64) : $Builtin.Int64
+  %595 = struct $Int (%594 : $Builtin.Int64)
+  %596 = function_ref @$sSR5start5countSRyxGSPyxGSg_SitcfCs5UInt8V_Tg5 : $@convention(method) (Optional<UnsafePointer<UInt8>>, Int, @thin UnsafeBufferPointer<UInt8>.Type) -> UnsafeBufferPointer<UInt8>
+  %597 = apply %596(%505, %595, %500) : $@convention(method) (Optional<UnsafePointer<UInt8>>, Int, @thin UnsafeBufferPointer<UInt8>.Type) -> UnsafeBufferPointer<UInt8>
+  try_apply %493(%597) : $@noescape @callee_guaranteed (UnsafeBufferPointer<UInt8>) -> (@owned String, @error Error), normal bb69, error bb70
+
+bb69(%599 : @owned $String):
+  destroy_addr %137 : $*T.Magnitude
+  store %599 to [init] %497 : $*String
+  %602 = tuple ()
+  destroy_addr %0 : $*T
+  destroy_addr %179 : $*T.Magnitude
+  %606 = alloc_stack $_ArrayBuffer<UInt8>
+  %607 = store_borrow %496 to %606 : $*_ArrayBuffer<UInt8>
+  %608 = load_borrow %606 : $*_ArrayBuffer<UInt8>
+  fix_lifetime %608 : $_ArrayBuffer<UInt8>
+  end_borrow %608 : $_ArrayBuffer<UInt8>
+  dealloc_stack %606 : $*_ArrayBuffer<UInt8>
+  %612 = load [take] %497 : $*String
+  dealloc_stack %497 : $*String
+  end_borrow %494 : $Array<UInt8>
+  destroy_value %490 : $Array<UInt8>
+  %616 = load [take] %182 : $*Array<UInt8>
+  destroy_value %616 : $Array<UInt8>
+  dealloc_stack %182 : $*Array<UInt8>
+  dealloc_stack %179 : $*T.Magnitude
+  dealloc_stack %137 : $*T.Magnitude
+  br bb16(%612 : $String)
+
+bb70(%622 : @owned $Error):
+  %624 = alloc_stack $_ArrayBuffer<UInt8>
+  %625 = store_borrow %496 to %624 : $*_ArrayBuffer<UInt8>
+  %626 = load_borrow %624 : $*_ArrayBuffer<UInt8>
+  fix_lifetime %626 : $_ArrayBuffer<UInt8>
+  end_borrow %626 : $_ArrayBuffer<UInt8>
+  dealloc_stack %624 : $*_ArrayBuffer<UInt8>
+  dealloc_stack %497 : $*String
+  unreachable
+
+bb71:
+  %632 = integer_literal $Builtin.Int32, 1
+  %633 = struct $UInt32 (%632 : $Builtin.Int32)
+  br bb73(%633 : $UInt32)
+
+bb72:
+  %635 = struct $UInt32 (%591 : $Builtin.Int32)
+  br bb73(%635 : $UInt32)
+
+bb73(%637 : $UInt32):
+  %638 = function_ref @$ss18_fatalErrorMessage__4file4line5flagss5NeverOs12StaticStringV_A2HSus6UInt32VtF : $@convention(thin) (StaticString, StaticString, StaticString, UInt, UInt32) -> Never
+  %639 = apply %638(%589, %521, %572, %574, %637) : $@convention(thin) (StaticString, StaticString, StaticString, UInt, UInt32) -> Never
+  unreachable
+
+bb74:
+  %641 = integer_literal $Builtin.Int32, 1
+  %642 = struct $UInt32 (%641 : $Builtin.Int32)
+  br bb76(%642 : $UInt32)
+
+bb75:
+  %644 = struct $UInt32 (%583 : $Builtin.Int32)
+  br bb76(%644 : $UInt32)
+
+bb76(%646 : $UInt32):
+  %647 = function_ref @$ss18_fatalErrorMessage__4file4line5flagss5NeverOs12StaticStringV_A2HSus6UInt32VtF : $@convention(thin) (StaticString, StaticString, StaticString, UInt, UInt32) -> Never
+  %648 = apply %647(%581, %521, %515, %540, %646) : $@convention(thin) (StaticString, StaticString, StaticString, UInt, UInt32) -> Never
+  unreachable
+
+bb77:
+  %651 = witness_method $T.Magnitude, #BinaryInteger._lowWord!getter : <Self where Self : BinaryInteger> (Self) -> () -> UInt : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@in_guaranteed τ_0_0) -> UInt
+  %652 = apply %651<T.Magnitude>(%198) : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@in_guaranteed τ_0_0) -> UInt
+  destroy_addr %198 : $*T.Magnitude
+  %654 = struct_extract %652 : $UInt, #UInt._value
+  %656 = builtin "cmp_eq_Int64"(%654 : $Builtin.Int64, %200 : $Builtin.Int64) : $Builtin.Int1
+  %657 = struct $Bool (%656 : $Builtin.Int1)
+  br bb28(%657 : $Bool)
+
+bb78:
+  %659 = witness_method $T.Magnitude, #BinaryInteger.bitWidth!getter : <Self where Self : BinaryInteger> (Self) -> () -> Int : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@in_guaranteed τ_0_0) -> Int
+  %660 = apply %659<T.Magnitude>(%198) : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@in_guaranteed τ_0_0) -> Int
+  %661 = integer_literal $Builtin.Int64, 64
+  %662 = struct_extract %660 : $Int, #Int._value
+  %663 = builtin "cmp_slt_Int64"(%661 : $Builtin.Int64, %662 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %663, bb79, bb80
+
+bb79:
+  %665 = metatype $@thick T.Magnitude.Type
+  %666 = alloc_stack $T.Magnitude
+  %667 = metatype $@thick T.Magnitude.Type
+  %668 = alloc_stack $Int
+  store %201 to [trivial] %668 : $*Int
+  %670 = witness_method $T.Magnitude, #BinaryInteger.init!allocator : <Self where Self : BinaryInteger><T where T : BinaryInteger> (Self.Type) -> (T) -> Self : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
+  %671 = apply %670<T.Magnitude, Int>(%666, %668, %667) : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
+  dealloc_stack %668 : $*Int
+  %673 = witness_method $T.Magnitude, #Equatable."==" : <Self where Self : Equatable> (Self.Type) -> (Self, Self) -> Bool : $@convention(witness_method: Equatable) <τ_0_0 where τ_0_0 : Equatable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
+  %674 = apply %673<T.Magnitude>(%198, %666, %665) : $@convention(witness_method: Equatable) <τ_0_0 where τ_0_0 : Equatable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
+  destroy_addr %666 : $*T.Magnitude
+  destroy_addr %198 : $*T.Magnitude
+  dealloc_stack %666 : $*T.Magnitude
+  br bb28(%674 : $Bool)
+
+bb80:
+  %679 = metatype $@thick T.Magnitude.Type
+  %680 = witness_method $T.Magnitude, #BinaryInteger.isSigned!getter : <Self where Self : BinaryInteger> (Self.Type) -> () -> Bool : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@thick τ_0_0.Type) -> Bool
+  %681 = apply %680<T.Magnitude>(%679) : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@thick τ_0_0.Type) -> Bool
+  %682 = struct_extract %681 : $Bool, #Bool._value
+  cond_br %682, bb81, bb82
+
+bb81:
+  %685 = witness_method $T.Magnitude, #BinaryInteger._lowWord!getter : <Self where Self : BinaryInteger> (Self) -> () -> UInt : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@in_guaranteed τ_0_0) -> UInt
+  %686 = apply %685<T.Magnitude>(%198) : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@in_guaranteed τ_0_0) -> UInt
+  destroy_addr %198 : $*T.Magnitude
+  %688 = struct_extract %686 : $UInt, #UInt._value
+  %690 = builtin "cmp_eq_Int64"(%688 : $Builtin.Int64, %200 : $Builtin.Int64) : $Builtin.Int1
+  %691 = struct $Bool (%690 : $Builtin.Int1)
+  br bb28(%691 : $Bool)
+
+bb82:
+  %693 = metatype $@thick T.Magnitude.Type
+  %694 = alloc_stack $T.Magnitude
+  %695 = metatype $@thick T.Magnitude.Type
+  %696 = alloc_stack $Int
+  store %201 to [trivial] %696 : $*Int
+  %698 = witness_method $T.Magnitude, #BinaryInteger.init!allocator : <Self where Self : BinaryInteger><T where T : BinaryInteger> (Self.Type) -> (T) -> Self : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
+  %699 = apply %698<T.Magnitude, Int>(%694, %696, %695) : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
+  dealloc_stack %696 : $*Int
+  %701 = witness_method $T.Magnitude, #Equatable."==" : <Self where Self : Equatable> (Self.Type) -> (Self, Self) -> Bool : $@convention(witness_method: Equatable) <τ_0_0 where τ_0_0 : Equatable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
+  %702 = apply %701<T.Magnitude>(%198, %694, %693) : $@convention(witness_method: Equatable) <τ_0_0 where τ_0_0 : Equatable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
+  destroy_addr %694 : $*T.Magnitude
+  destroy_addr %198 : $*T.Magnitude
+  dealloc_stack %694 : $*T.Magnitude
+  br bb28(%702 : $Bool)
+
+bb83:
+  %707 = integer_literal $Builtin.Int64, 2
+  %708 = integer_literal $Builtin.Int64, 36
+  %711 = destructure_struct %1 : $Int
+  %712 = builtin "cmp_slt_Int64"(%711 : $Builtin.Int64, %707 : $Builtin.Int64) : $Builtin.Int1
+  cond_fail %712 : $Builtin.Int1, "Radix must be between 2 and 36"
+  %714 = builtin "cmp_slt_Int64"(%708 : $Builtin.Int64, %711 : $Builtin.Int64) : $Builtin.Int1
+  cond_fail %714 : $Builtin.Int1, "Radix must be between 2 and 36"
+  br bb11
+
+bb84:
+  br bb11
+}
+
+// CHECK-LABEL: sil [ossa] @$ss23LazyPrefixWhileSequenceVsSlRzrlE5IndexV5endOfADyx_Gx_tcfC : {{.*}} {
+// CHECKDEB:   debug_value
+// CHECKOPT-NOT: debug_value
+// CHECK-LABEL: } // end sil function '$ss23LazyPrefixWhileSequenceVsSlRzrlE5IndexV5endOfADyx_Gx_tcfC'
+sil [ossa] @$ss23LazyPrefixWhileSequenceVsSlRzrlE5IndexV5endOfADyx_Gx_tcfC : $@convention(method) <Base where Base : Collection> (@in Base, @thin LazyPrefixWhileSequence<Base>.Index.Type) -> @out LazyPrefixWhileSequence<Base>.Index {
+bb0(%0 : $*LazyPrefixWhileSequence<Base>.Index, %1 : $*Base, %2 : $@thin LazyPrefixWhileSequence<Base>.Index.Type):
+  %4 = alloc_stack $LazyPrefixWhileSequence<Base>.Index, var, name "self", implicit 
+  debug_value %1 : $*Base, let, name "endOf", argno 1, expr op_deref 
+  %6 = metatype $@thin LazyPrefixWhileSequence<Base>._IndexRepresentation.Type
+  %7 = alloc_stack $LazyPrefixWhileSequence<Base>._IndexRepresentation 
+  inject_enum_addr %7 : $*LazyPrefixWhileSequence<Base>._IndexRepresentation, #LazyPrefixWhileSequence._IndexRepresentation.pastEnd!enumelt 
+  %9 = struct_element_addr %4 : $*LazyPrefixWhileSequence<Base>.Index, #LazyPrefixWhileSequence.Index._value 
+  destroy_addr %1 : $*Base                        
+  copy_addr [take] %7 to [initialization] %9 : $*LazyPrefixWhileSequence<Base>._IndexRepresentation 
+  dealloc_stack %7 : $*LazyPrefixWhileSequence<Base>._IndexRepresentation 
+  copy_addr [take] %4 to [initialization] %0 : $*LazyPrefixWhileSequence<Base>.Index 
+  dealloc_stack %4 : $*LazyPrefixWhileSequence<Base>.Index 
+  %14 = tuple ()                                  
+  return %14 : $()                                
+}
+
+// CHECK-LABEL: sil [ossa] @$sSMsSKRzrlE14_insertionSort6within9sortedEnd2byySny5IndexSlQzG_AFSb7ElementSTQz_AItKXEtKFSays7UnicodeO6ScalarV6scalar_AK9_NormDataV04normM0tG_Tg5 : {{.*}} {
+// CHECK-LABEL: } // end sil function '$sSMsSKRzrlE14_insertionSort6within9sortedEnd2byySny5IndexSlQzG_AFSb7ElementSTQz_AItKXEtKFSays7UnicodeO6ScalarV6scalar_AK9_NormDataV04normM0tG_Tg5'
+sil [ossa] @$sSMsSKRzrlE14_insertionSort6within9sortedEnd2byySny5IndexSlQzG_AFSb7ElementSTQz_AItKXEtKFSays7UnicodeO6ScalarV6scalar_AK9_NormDataV04normM0tG_Tg5 : $@convention(method) (Range<Int>, Int, @noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1) -> (Bool, @error Error) for <(scalar: Unicode.Scalar, normData: Unicode._NormData), (scalar: Unicode.Scalar, normData: Unicode._NormData)>, @inout Array<(scalar: Unicode.Scalar, normData: Unicode._NormData)>) -> @error Error {
+bb0(%0 : $Range<Int>, %1 : $Int, %2 : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1) -> (Bool, @error Error) for <(scalar: Unicode.Scalar, normData: Unicode._NormData), (scalar: Unicode.Scalar, normData: Unicode._NormData)>, %3 : $*Array<(scalar: Unicode.Scalar, normData: Unicode._NormData)>):
+  debug_value %0 : $Range<Int>, let, name "range", argno 1
+  %5 = alloc_stack $Range<Int>
+  store %0 to [trivial] %5 : $*Range<Int>
+  debug_value %1 : $Int, let, name "sortedEnd", argno 2
+  %8 = alloc_stack $Int
+  store %1 to [trivial] %8 : $*Int
+  debug_value %5 : $*Range<Int>, let, name "range", argno 1, expr op_deref
+  debug_value %8 : $*Int, let, name "sortedEnd", argno 2, expr op_deref
+  debug_value %2 : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1) -> (Bool, @error Error) for <(scalar: Unicode.Scalar, normData: Unicode._NormData), (scalar: Unicode.Scalar, normData: Unicode._NormData)>, let, name "areInIncreasingOrder", argno 3
+  debug_value %3 : $*Array<(scalar: Unicode.Scalar, normData: Unicode._NormData)>, var, name "self", argno 4, implicit, expr op_deref
+  debug_value undef : $Error, var, name "$error", argno 5
+  %15 = alloc_stack $Int, var, name "sortedEnd"
+  copy_addr %8 to [initialization] %15 : $*Int
+  br bb1
+
+bb1:
+  %18 = alloc_stack $Int
+  copy_addr %15 to [initialization] %18 : $*Int
+  %20 = struct_element_addr %5 : $*Range<Int>, #Range.upperBound
+  %21 = alloc_stack $Int
+  copy_addr %20 to [initialization] %21 : $*Int
+  %23 = metatype $@thick Int.Type
+  %24 = witness_method $Int, #Equatable."==" : <Self where Self : Equatable> (Self.Type) -> (Self, Self) -> Bool : $@convention(witness_method: Equatable) <τ_0_0 where τ_0_0 : Equatable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
+  %25 = apply %24<Int>(%18, %21, %23) : $@convention(witness_method: Equatable) <τ_0_0 where τ_0_0 : Equatable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
+  %26 = struct_extract %25 : $Bool, #Bool._value
+  %27 = integer_literal $Builtin.Int1, -1
+  %28 = builtin "xor_Int1"(%26 : $Builtin.Int1, %27 : $Builtin.Int1) : $Builtin.Int1
+  destroy_addr %21 : $*Int
+  dealloc_stack %21 : $*Int
+  destroy_addr %18 : $*Int
+  dealloc_stack %18 : $*Int
+  cond_br %28, bb2, bb3
+
+bb2:
+  %34 = alloc_stack $Int, var, name "i"
+  copy_addr %15 to [initialization] %34 : $*Int
+  br bb4
+
+bb3:
+  destroy_addr %15 : $*Int
+  dealloc_stack %15 : $*Int
+  %39 = tuple ()
+  dealloc_stack %8 : $*Int
+  dealloc_stack %5 : $*Range<Int>
+  return %39 : $()
+
+bb4:
+  %43 = alloc_stack $Int, let, name "j"
+  %44 = witness_method $Array<(scalar: Unicode.Scalar, normData: Unicode._NormData)>, #BidirectionalCollection.index : <Self where Self : BidirectionalCollection> (Self) -> (Self.Index) -> Self.Index : $@convention(witness_method: BidirectionalCollection) <τ_0_0 where τ_0_0 : BidirectionalCollection> (@in_guaranteed τ_0_0.Index, @in_guaranteed τ_0_0) -> @out τ_0_0.Index
+  %45 = apply %44<Array<(scalar: Unicode.Scalar, normData: Unicode._NormData)>>(%43, %34, %3) : $@convention(witness_method: BidirectionalCollection) <τ_0_0 where τ_0_0 : BidirectionalCollection> (@in_guaranteed τ_0_0.Index, @in_guaranteed τ_0_0) -> @out τ_0_0.Index
+  %46 = witness_method $Array<(scalar: Unicode.Scalar, normData: Unicode._NormData)>, #Collection.subscript!read : <Self where Self : Collection> (Self) -> (Self.Index) -> () : $@yield_once @convention(witness_method: Collection) <τ_0_0 where τ_0_0 : Collection> (@in_guaranteed τ_0_0.Index, @in_guaranteed τ_0_0) -> @yields @in_guaranteed τ_0_0.Element
+  (%47, %48) = begin_apply %46<Array<(scalar: Unicode.Scalar, normData: Unicode._NormData)>>(%34, %3) : $@yield_once @convention(witness_method: Collection) <τ_0_0 where τ_0_0 : Collection> (@in_guaranteed τ_0_0.Index, @in_guaranteed τ_0_0) -> @yields @in_guaranteed τ_0_0.Element
+  %49 = alloc_stack $(scalar: Unicode.Scalar, normData: Unicode._NormData)
+  copy_addr %47 to [initialization] %49 : $*(scalar: Unicode.Scalar, normData: Unicode._NormData)
+  end_apply %48
+  %52 = witness_method $Array<(scalar: Unicode.Scalar, normData: Unicode._NormData)>, #Collection.subscript!read : <Self where Self : Collection> (Self) -> (Self.Index) -> () : $@yield_once @convention(witness_method: Collection) <τ_0_0 where τ_0_0 : Collection> (@in_guaranteed τ_0_0.Index, @in_guaranteed τ_0_0) -> @yields @in_guaranteed τ_0_0.Element
+  (%53, %54) = begin_apply %52<Array<(scalar: Unicode.Scalar, normData: Unicode._NormData)>>(%43, %3) : $@yield_once @convention(witness_method: Collection) <τ_0_0 where τ_0_0 : Collection> (@in_guaranteed τ_0_0.Index, @in_guaranteed τ_0_0) -> @yields @in_guaranteed τ_0_0.Element
+  %55 = alloc_stack $(scalar: Unicode.Scalar, normData: Unicode._NormData)
+  copy_addr %53 to [initialization] %55 : $*(scalar: Unicode.Scalar, normData: Unicode._NormData)
+  end_apply %54
+  try_apply %2(%49, %55) : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1) -> (Bool, @error Error) for <(scalar: Unicode.Scalar, normData: Unicode._NormData), (scalar: Unicode.Scalar, normData: Unicode._NormData)>, normal bb5, error bb6
+
+bb5(%59 : $Bool):
+  destroy_addr %55 : $*(scalar: Unicode.Scalar, normData: Unicode._NormData)
+  dealloc_stack %55 : $*(scalar: Unicode.Scalar, normData: Unicode._NormData)
+  destroy_addr %49 : $*(scalar: Unicode.Scalar, normData: Unicode._NormData)
+  dealloc_stack %49 : $*(scalar: Unicode.Scalar, normData: Unicode._NormData)
+  %64 = struct_extract %59 : $Bool, #Bool._value
+  %65 = integer_literal $Builtin.Int1, -1
+  %66 = builtin "xor_Int1"(%64 : $Builtin.Int1, %65 : $Builtin.Int1) : $Builtin.Int1
+  cond_br %66, bb7, bb8
+
+bb6(%68 : @owned $Error):
+  destroy_addr %55 : $*(scalar: Unicode.Scalar, normData: Unicode._NormData)
+  dealloc_stack %55 : $*(scalar: Unicode.Scalar, normData: Unicode._NormData)
+  destroy_addr %49 : $*(scalar: Unicode.Scalar, normData: Unicode._NormData)
+  dealloc_stack %49 : $*(scalar: Unicode.Scalar, normData: Unicode._NormData)
+  destroy_addr %43 : $*Int
+  dealloc_stack %43 : $*Int
+  destroy_addr %34 : $*Int
+  dealloc_stack %34 : $*Int
+  destroy_addr %15 : $*Int
+  dealloc_stack %15 : $*Int
+  dealloc_stack %8 : $*Int
+  dealloc_stack %5 : $*Range<Int>
+  throw %68 : $Error
+
+bb7:
+  destroy_addr %43 : $*Int
+  dealloc_stack %43 : $*Int
+  br bb9
+
+bb8:
+  %85 = witness_method $Array<(scalar: Unicode.Scalar, normData: Unicode._NormData)>, #MutableCollection.swapAt : <Self where Self : MutableCollection> (inout Self) -> (Self.Index, Self.Index) -> () : $@convention(witness_method: MutableCollection) <τ_0_0 where τ_0_0 : MutableCollection> (@in_guaranteed τ_0_0.Index, @in_guaranteed τ_0_0.Index, @inout τ_0_0) -> ()
+  %86 = apply %85<Array<(scalar: Unicode.Scalar, normData: Unicode._NormData)>>(%34, %43, %3) : $@convention(witness_method: MutableCollection) <τ_0_0 where τ_0_0 : MutableCollection> (@in_guaranteed τ_0_0.Index, @in_guaranteed τ_0_0.Index, @inout τ_0_0) -> ()
+  copy_addr %43 to %34 : $*Int
+  destroy_addr %43 : $*Int
+  dealloc_stack %43 : $*Int
+  %90 = alloc_stack $Int
+  copy_addr %34 to [initialization] %90 : $*Int
+  %92 = struct_element_addr %5 : $*Range<Int>, #Range.lowerBound
+  %93 = alloc_stack $Int
+  copy_addr %92 to [initialization] %93 : $*Int
+  %95 = metatype $@thick Int.Type
+  %96 = witness_method $Int, #Equatable."==" : <Self where Self : Equatable> (Self.Type) -> (Self, Self) -> Bool : $@convention(witness_method: Equatable) <τ_0_0 where τ_0_0 : Equatable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
+  %97 = apply %96<Int>(%90, %93, %95) : $@convention(witness_method: Equatable) <τ_0_0 where τ_0_0 : Equatable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
+  %98 = struct_extract %97 : $Bool, #Bool._value
+  %99 = integer_literal $Builtin.Int1, -1
+  %100 = builtin "xor_Int1"(%98 : $Builtin.Int1, %99 : $Builtin.Int1) : $Builtin.Int1
+  destroy_addr %93 : $*Int
+  dealloc_stack %93 : $*Int
+  destroy_addr %90 : $*Int
+  dealloc_stack %90 : $*Int
+  cond_br %100, bb10, bb11
+
+bb9:
+  %106 = witness_method $Array<(scalar: Unicode.Scalar, normData: Unicode._NormData)>, #Collection.formIndex : <Self where Self : Collection> (Self) -> (inout Self.Index) -> () : $@convention(witness_method: Collection) <τ_0_0 where τ_0_0 : Collection> (@inout τ_0_0.Index, @in_guaranteed τ_0_0) -> ()
+  %107 = apply %106<Array<(scalar: Unicode.Scalar, normData: Unicode._NormData)>>(%15, %3) : $@convention(witness_method: Collection) <τ_0_0 where τ_0_0 : Collection> (@inout τ_0_0.Index, @in_guaranteed τ_0_0) -> ()
+  destroy_addr %34 : $*Int
+  dealloc_stack %34 : $*Int
+  br bb1
+
+bb10:
+  br bb4
+
+bb11:
+  br bb9
+}
+
+// CHECK-LABEL: sil [ossa] @$sSD5IndexV8_asCocoas02__C10DictionaryVAAVvM : {{.*}} {
+// CHECK-LABEL: } // end sil function '$sSD5IndexV8_asCocoas02__C10DictionaryVAAVvM'
+sil [ossa] @$sSD5IndexV8_asCocoas02__C10DictionaryVAAVvM : $@yield_once @convention(method) <Key, Value where Key : Hashable> (@inout Dictionary<Key, Value>.Index) -> @yields @inout __CocoaDictionary.Index {
+bb0(%0 : $*Dictionary<Key, Value>.Index):
+  debug_value %0 : $*Dictionary<Key, Value>.Index, var, name "self", argno 1, implicit, expr op_deref
+  %2 = alloc_stack $__CocoaDictionary.Index, var, name "cocoa"
+  %3 = struct_element_addr %0 : $*Dictionary<Key, Value>.Index, #Dictionary.Index._variant
+  %4 = load [copy] %3 : $*Dictionary<Key, Value>.Index._Variant
+  switch_enum %4 : $Dictionary<Key, Value>.Index._Variant, case #Dictionary.Index._Variant.cocoa!enumelt: bb1, case #Dictionary.Index._Variant.native!enumelt: bb3
+
+bb1(%6 : @owned $__CocoaDictionary.Index):
+  store %6 to [init] %2 : $*__CocoaDictionary.Index
+  %8 = integer_literal $Builtin.Int64, 0
+  %9 = struct $Int (%8 : $Builtin.Int64)
+  %10 = struct $_HashTable.Bucket (%9 : $Int)
+  %11 = integer_literal $Builtin.Int32, 0
+  %12 = struct $Int32 (%11 : $Builtin.Int32)
+  debug_value %12 : $Int32, let, name "age", argno 2
+  %14 = struct $_HashTable.Index (%10 : $_HashTable.Bucket, %12 : $Int32)
+  debug_value %14 : $_HashTable.Index, let, name "dummy"
+  %16 = enum $Dictionary<Key, Value>.Index._Variant, #Dictionary.Index._Variant.native!enumelt, %14 : $_HashTable.Index
+  %17 = struct $Dictionary<Key, Value>.Index (%16 : $Dictionary<Key, Value>.Index._Variant)
+  store %17 to [assign] %0 : $*Dictionary<Key, Value>.Index
+  yield %2 : $*__CocoaDictionary.Index, resume bb2, unwind bb9
+
+bb2:
+  debug_value %0 : $*Dictionary<Key, Value>.Index, var, name "self", argno 1, implicit, expr op_deref
+  %21 = load [copy] %2 : $*__CocoaDictionary.Index
+  %22 = enum $Dictionary<Key, Value>.Index._Variant, #Dictionary.Index._Variant.cocoa!enumelt, %21 : $__CocoaDictionary.Index
+  %23 = struct $Dictionary<Key, Value>.Index (%22 : $Dictionary<Key, Value>.Index._Variant)
+  store %23 to [assign] %0 : $*Dictionary<Key, Value>.Index
+  %25 = tuple ()
+  %26 = load [take] %2 : $*__CocoaDictionary.Index
+  destroy_value %26 : $__CocoaDictionary.Index
+  dealloc_stack %2 : $*__CocoaDictionary.Index
+  %29 = tuple ()
+  return %29 : $()
+
+bb3(%31 : $_HashTable.Index):
+  dealloc_stack %2 : $*__CocoaDictionary.Index
+  %33 = string_literal utf8 "Attempting to access Dictionary elements using an invalid index"
+  %34 = integer_literal $Builtin.Word, 63
+  %35 = builtin "ptrtoint_Word"(%33 : $Builtin.RawPointer) : $Builtin.Word
+  %36 = integer_literal $Builtin.Int8, 2
+  %37 = struct $StaticString (%35 : $Builtin.Word, %34 : $Builtin.Word, %36 : $Builtin.Int8)
+  %38 = string_literal utf8 "Swift/Dictionary.swift"
+  %39 = integer_literal $Builtin.Word, 22
+  %40 = builtin "ptrtoint_Word"(%38 : $Builtin.RawPointer) : $Builtin.Word
+  %41 = integer_literal $Builtin.Int8, 2
+  %42 = struct $StaticString (%40 : $Builtin.Word, %39 : $Builtin.Word, %41 : $Builtin.Int8)
+  %43 = integer_literal $Builtin.Int64, 1843
+  %44 = struct $UInt (%43 : $Builtin.Int64)
+  %45 = builtin "assert_configuration"() : $Builtin.Int32
+  %46 = integer_literal $Builtin.Int32, 0
+  %47 = builtin "cmp_eq_Int32"(%45 : $Builtin.Int32, %46 : $Builtin.Int32) : $Builtin.Int1
+  cond_br %47, bb5, bb4
+
+bb4:
+  %49 = builtin "assert_configuration"() : $Builtin.Int32
+  %50 = integer_literal $Builtin.Int32, 1
+  %51 = builtin "cmp_eq_Int32"(%49 : $Builtin.Int32, %50 : $Builtin.Int32) : $Builtin.Int1
+  cond_fail %51 : $Builtin.Int1, "Attempting to access Dictionary elements using an invalid index"
+  %53 = builtin "conditionallyUnreachable"() : $Never
+  unreachable
+
+bb5:
+  %55 = string_literal utf8 "Fatal error"
+  %56 = integer_literal $Builtin.Word, 11
+  %57 = builtin "ptrtoint_Word"(%55 : $Builtin.RawPointer) : $Builtin.Word
+  %58 = integer_literal $Builtin.Int8, 2
+  %59 = struct $StaticString (%57 : $Builtin.Word, %56 : $Builtin.Word, %58 : $Builtin.Int8)
+  %60 = builtin "assert_configuration"() : $Builtin.Int32
+  %61 = integer_literal $Builtin.Int32, 0
+  %62 = builtin "cmp_eq_Int32"(%60 : $Builtin.Int32, %61 : $Builtin.Int32) : $Builtin.Int1
+  cond_br %62, bb6, bb7
+
+bb6:
+  %64 = integer_literal $Builtin.Int32, 1
+  %65 = struct $UInt32 (%64 : $Builtin.Int32)
+  br bb8(%65 : $UInt32)
+
+bb7:
+  %67 = integer_literal $Builtin.Int32, 0
+  %68 = struct $UInt32 (%67 : $Builtin.Int32)
+  br bb8(%68 : $UInt32)
+
+bb8(%70 : $UInt32):
+  %71 = function_ref @$ss17_assertionFailure__4file4line5flagss5NeverOs12StaticStringV_A2HSus6UInt32VtF : $@convention(thin) (StaticString, StaticString, StaticString, UInt, UInt32) -> Never
+  %72 = apply %71(%59, %37, %42, %44, %70) : $@convention(thin) (StaticString, StaticString, StaticString, UInt, UInt32) -> Never
+  unreachable
+
+bb9:
+  debug_value %0 : $*Dictionary<Key, Value>.Index, var, name "self", argno 1, implicit, expr op_deref
+  %75 = load [copy] %2 : $*__CocoaDictionary.Index
+  %76 = enum $Dictionary<Key, Value>.Index._Variant, #Dictionary.Index._Variant.cocoa!enumelt, %75 : $__CocoaDictionary.Index
+  %77 = struct $Dictionary<Key, Value>.Index (%76 : $Dictionary<Key, Value>.Index._Variant)
+  store %77 to [assign] %0 : $*Dictionary<Key, Value>.Index
+  %79 = tuple ()
+  %80 = load [take] %2 : $*__CocoaDictionary.Index
+  destroy_value %80 : $__CocoaDictionary.Index
+  dealloc_stack %2 : $*__CocoaDictionary.Index
+  unwind
+}
+
+// CHECK-LABEL: sil [ossa] @$ss48_UnsafePartiallyInitializedContiguousArrayBufferV3addyyxFs7UnicodeO6ScalarV_Tg5 : {{.*}} {
+// CHECK-LABEL: } // end sil function '$ss48_UnsafePartiallyInitializedContiguousArrayBufferV3addyyxFs7UnicodeO6ScalarV_Tg5'
+sil [ossa] @$ss48_UnsafePartiallyInitializedContiguousArrayBufferV3addyyxFs7UnicodeO6ScalarV_Tg5 : $@convention(method) (Unicode.Scalar, @inout _UnsafePartiallyInitializedContiguousArrayBuffer<Unicode.Scalar>) -> () {
+bb0(%0 : $Unicode.Scalar, %1 : $*_UnsafePartiallyInitializedContiguousArrayBuffer<Unicode.Scalar>):
+  debug_value %0 : $Unicode.Scalar, let, name "element", argno 1
+  %3 = alloc_stack $Unicode.Scalar
+  store %0 to [trivial] %3 : $*Unicode.Scalar
+  debug_value %3 : $*Unicode.Scalar, let, name "element", argno 1, expr op_deref
+  debug_value %1 : $*_UnsafePartiallyInitializedContiguousArrayBuffer<Unicode.Scalar>, var, name "self", argno 2, implicit, expr op_deref
+  %7 = struct_element_addr %1 : $*_UnsafePartiallyInitializedContiguousArrayBuffer<Unicode.Scalar>, #_UnsafePartiallyInitializedContiguousArrayBuffer.remainingCapacity
+  %8 = load [trivial] %7 : $*Int
+  %9 = integer_literal $Builtin.Int64, 0
+  %10 = struct_extract %8 : $Int, #Int._value
+  %11 = builtin "cmp_eq_Int64"(%10 : $Builtin.Int64, %9 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %11, bb1, bb2
+
+bb1:
+  %13 = alloc_stack $Int
+  %14 = struct_element_addr %1 : $*_UnsafePartiallyInitializedContiguousArrayBuffer<Unicode.Scalar>, #_UnsafePartiallyInitializedContiguousArrayBuffer.result
+  %15 = load_borrow %14 : $*_ContiguousArrayBuffer<Unicode.Scalar>
+  %16 = function_ref @$ss22_ContiguousArrayBufferV8capacitySivg : $@convention(method) <τ_0_0> (@guaranteed _ContiguousArrayBuffer<τ_0_0>) -> Int
+  %17 = apply %16<Unicode.Scalar>(%15) : $@convention(method) <τ_0_0> (@guaranteed _ContiguousArrayBuffer<τ_0_0>) -> Int
+  end_borrow %15 : $_ContiguousArrayBuffer<Unicode.Scalar>
+  %19 = function_ref @$ss18_growArrayCapacityyS2iF : $@convention(thin) (Int) -> Int
+  %20 = apply %19(%17) : $@convention(thin) (Int) -> Int
+  %21 = alloc_stack $Int
+  store %20 to [trivial] %21 : $*Int
+  %23 = integer_literal $Builtin.Int64, 1
+  %24 = struct $Int (%23 : $Builtin.Int64)
+  %25 = alloc_stack $Int
+  store %24 to [trivial] %25 : $*Int
+  %27 = function_ref @$ss3maxyxx_xtSLRzlF : $@convention(thin) <τ_0_0 where τ_0_0 : Comparable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0) -> @out τ_0_0
+  %28 = apply %27<Int>(%13, %21, %25) : $@convention(thin) <τ_0_0 where τ_0_0 : Comparable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0) -> @out τ_0_0
+  dealloc_stack %25 : $*Int
+  dealloc_stack %21 : $*Int
+  %31 = load [trivial] %13 : $*Int
+  debug_value %31 : $Int, let, name "newCapacity"
+  dealloc_stack %13 : $*Int
+  %34 = alloc_stack $_ContiguousArrayBuffer<Unicode.Scalar>, var, name "newResult"
+  %35 = metatype $@thin _ContiguousArrayBuffer<Unicode.Scalar>.Type
+  %36 = integer_literal $Builtin.Int64, 0
+  %37 = struct $Int (%36 : $Builtin.Int64)
+  %38 = function_ref @$ss22_ContiguousArrayBufferV19_uninitializedCount15minimumCapacityAByxGSi_SitcfC : $@convention(method) <τ_0_0> (Int, Int, @thin _ContiguousArrayBuffer<τ_0_0>.Type) -> @owned _ContiguousArrayBuffer<τ_0_0>
+  %39 = apply %38<Unicode.Scalar>(%31, %37, %35) : $@convention(method) <τ_0_0> (Int, Int, @thin _ContiguousArrayBuffer<τ_0_0>.Type) -> @owned _ContiguousArrayBuffer<τ_0_0>
+  %40 = copy_value %39 : $_ContiguousArrayBuffer<Unicode.Scalar>
+  store %40 to [init] %34 : $*_ContiguousArrayBuffer<Unicode.Scalar>
+  %42 = metatype $@thin UnsafeMutablePointer<Unicode.Scalar>.Type
+  %43 = function_ref @$ss22_ContiguousArrayBufferV19firstElementAddressSpyxGvg : $@convention(method) <τ_0_0> (@guaranteed _ContiguousArrayBuffer<τ_0_0>) -> UnsafeMutablePointer<τ_0_0>
+  %44 = apply %43<Unicode.Scalar>(%39) : $@convention(method) <τ_0_0> (@guaranteed _ContiguousArrayBuffer<τ_0_0>) -> UnsafeMutablePointer<τ_0_0>
+  %45 = struct_element_addr %1 : $*_UnsafePartiallyInitializedContiguousArrayBuffer<Unicode.Scalar>, #_UnsafePartiallyInitializedContiguousArrayBuffer.result
+  %46 = load_borrow %45 : $*_ContiguousArrayBuffer<Unicode.Scalar>
+  %47 = function_ref @$ss22_ContiguousArrayBufferV8capacitySivg : $@convention(method) <τ_0_0> (@guaranteed _ContiguousArrayBuffer<τ_0_0>) -> Int
+  %48 = apply %47<Unicode.Scalar>(%46) : $@convention(method) <τ_0_0> (@guaranteed _ContiguousArrayBuffer<τ_0_0>) -> Int
+  end_borrow %46 : $_ContiguousArrayBuffer<Unicode.Scalar>
+  %50 = struct_extract %44 : $UnsafeMutablePointer<Unicode.Scalar>, #UnsafeMutablePointer._rawValue
+  %51 = struct_extract %48 : $Int, #Int._value
+  %52 = builtin "truncOrBitCast_Int64_Word"(%51 : $Builtin.Int64) : $Builtin.Word
+  %53 = metatype $@thick Unicode.Scalar.Type
+  %54 = pointer_to_address %50 : $Builtin.RawPointer to [strict] $*Unicode.Scalar
+  %55 = index_addr %54 : $*Unicode.Scalar, %52 : $Builtin.Word
+  %56 = address_to_pointer %55 : $*Unicode.Scalar to $Builtin.RawPointer
+  %57 = struct $UnsafeMutablePointer<Unicode.Scalar> (%56 : $Builtin.RawPointer)
+  %58 = tuple ()
+  %59 = tuple ()
+  %60 = tuple ()
+  %61 = tuple ()
+  %62 = struct_element_addr %1 : $*_UnsafePartiallyInitializedContiguousArrayBuffer<Unicode.Scalar>, #_UnsafePartiallyInitializedContiguousArrayBuffer.p
+  store %57 to [trivial] %62 : $*UnsafeMutablePointer<Unicode.Scalar>
+  %64 = function_ref @$ss22_ContiguousArrayBufferV8capacitySivg : $@convention(method) <τ_0_0> (@guaranteed _ContiguousArrayBuffer<τ_0_0>) -> Int
+  %65 = apply %64<Unicode.Scalar>(%39) : $@convention(method) <τ_0_0> (@guaranteed _ContiguousArrayBuffer<τ_0_0>) -> Int
+  %66 = struct_element_addr %1 : $*_UnsafePartiallyInitializedContiguousArrayBuffer<Unicode.Scalar>, #_UnsafePartiallyInitializedContiguousArrayBuffer.result
+  %67 = load_borrow %66 : $*_ContiguousArrayBuffer<Unicode.Scalar>
+  %68 = function_ref @$ss22_ContiguousArrayBufferV8capacitySivg : $@convention(method) <τ_0_0> (@guaranteed _ContiguousArrayBuffer<τ_0_0>) -> Int
+  %69 = apply %68<Unicode.Scalar>(%67) : $@convention(method) <τ_0_0> (@guaranteed _ContiguousArrayBuffer<τ_0_0>) -> Int
+  end_borrow %67 : $_ContiguousArrayBuffer<Unicode.Scalar>
+  %71 = struct_extract %65 : $Int, #Int._value
+  %72 = struct_extract %69 : $Int, #Int._value
+  %73 = integer_literal $Builtin.Int1, -1
+  %74 = builtin "ssub_with_overflow_Int64"(%71 : $Builtin.Int64, %72 : $Builtin.Int64, %73 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  (%75, %76) = destructure_tuple %74 : $(Builtin.Int64, Builtin.Int1)
+  br bb3
+
+bb2:
+  br bb8
+
+bb3:
+  br bb4
+
+bb4:
+  cond_fail %76 : $Builtin.Int1, "arithmetic overflow"
+  %81 = struct $Int (%75 : $Builtin.Int64)
+  %82 = tuple ()
+  %83 = struct_element_addr %1 : $*_UnsafePartiallyInitializedContiguousArrayBuffer<Unicode.Scalar>, #_UnsafePartiallyInitializedContiguousArrayBuffer.remainingCapacity
+  store %81 to [trivial] %83 : $*Int
+  %85 = struct_element_addr %1 : $*_UnsafePartiallyInitializedContiguousArrayBuffer<Unicode.Scalar>, #_UnsafePartiallyInitializedContiguousArrayBuffer.result
+  %86 = load_borrow %85 : $*_ContiguousArrayBuffer<Unicode.Scalar>
+  %87 = alloc_stack $_ContiguousArrayBuffer<Unicode.Scalar>
+  %88 = store_borrow %86 to %87 : $*_ContiguousArrayBuffer<Unicode.Scalar>
+  %89 = load_borrow %87 : $*_ContiguousArrayBuffer<Unicode.Scalar>
+  %90 = alloc_stack $_ContiguousArrayBuffer<Unicode.Scalar>
+  %91 = store_borrow %89 to %90 : $*_ContiguousArrayBuffer<Unicode.Scalar>
+  %92 = function_ref @$sSlsE7isEmptySbvg : $@convention(method) <τ_0_0 where τ_0_0 : Collection> (@in_guaranteed τ_0_0) -> Bool
+  %93 = apply %92<_ContiguousArrayBuffer<Unicode.Scalar>>(%90) : $@convention(method) <τ_0_0 where τ_0_0 : Collection> (@in_guaranteed τ_0_0) -> Bool
+  dealloc_stack %90 : $*_ContiguousArrayBuffer<Unicode.Scalar>
+  end_borrow %86 : $_ContiguousArrayBuffer<Unicode.Scalar>
+  %96 = struct_extract %93 : $Bool, #Bool._value
+  %97 = integer_literal $Builtin.Int1, -1
+  %98 = builtin "xor_Int1"(%96 : $Builtin.Int1, %97 : $Builtin.Int1) : $Builtin.Int1
+  end_borrow %89 : $_ContiguousArrayBuffer<Unicode.Scalar>
+  dealloc_stack %87 : $*_ContiguousArrayBuffer<Unicode.Scalar>
+  cond_br %98, bb5, bb6
+
+bb5:
+  %102 = function_ref @$ss22_ContiguousArrayBufferV19firstElementAddressSpyxGvg : $@convention(method) <τ_0_0> (@guaranteed _ContiguousArrayBuffer<τ_0_0>) -> UnsafeMutablePointer<τ_0_0>
+  %103 = apply %102<Unicode.Scalar>(%39) : $@convention(method) <τ_0_0> (@guaranteed _ContiguousArrayBuffer<τ_0_0>) -> UnsafeMutablePointer<τ_0_0>
+  %104 = struct_element_addr %1 : $*_UnsafePartiallyInitializedContiguousArrayBuffer<Unicode.Scalar>, #_UnsafePartiallyInitializedContiguousArrayBuffer.result
+  %105 = load_borrow %104 : $*_ContiguousArrayBuffer<Unicode.Scalar>
+  %106 = function_ref @$ss22_ContiguousArrayBufferV19firstElementAddressSpyxGvg : $@convention(method) <τ_0_0> (@guaranteed _ContiguousArrayBuffer<τ_0_0>) -> UnsafeMutablePointer<τ_0_0>
+  %107 = apply %106<Unicode.Scalar>(%105) : $@convention(method) <τ_0_0> (@guaranteed _ContiguousArrayBuffer<τ_0_0>) -> UnsafeMutablePointer<τ_0_0>
+  end_borrow %105 : $_ContiguousArrayBuffer<Unicode.Scalar>
+  %109 = struct_element_addr %1 : $*_UnsafePartiallyInitializedContiguousArrayBuffer<Unicode.Scalar>, #_UnsafePartiallyInitializedContiguousArrayBuffer.result
+  %110 = load_borrow %109 : $*_ContiguousArrayBuffer<Unicode.Scalar>
+  %111 = function_ref @$ss22_ContiguousArrayBufferV8capacitySivg : $@convention(method) <τ_0_0> (@guaranteed _ContiguousArrayBuffer<τ_0_0>) -> Int
+  %112 = apply %111<Unicode.Scalar>(%110) : $@convention(method) <τ_0_0> (@guaranteed _ContiguousArrayBuffer<τ_0_0>) -> Int
+  end_borrow %110 : $_ContiguousArrayBuffer<Unicode.Scalar>
+  %114 = function_ref @$sSp14moveInitialize4from5countySpyxG_SitF : $@convention(method) <τ_0_0> (UnsafeMutablePointer<τ_0_0>, Int, UnsafeMutablePointer<τ_0_0>) -> ()
+  %115 = apply %114<Unicode.Scalar>(%107, %112, %103) : $@convention(method) <τ_0_0> (UnsafeMutablePointer<τ_0_0>, Int, UnsafeMutablePointer<τ_0_0>) -> ()
+  %116 = struct_element_addr %1 : $*_UnsafePartiallyInitializedContiguousArrayBuffer<Unicode.Scalar>, #_UnsafePartiallyInitializedContiguousArrayBuffer.result
+  %117 = load_borrow %116 : $*_ContiguousArrayBuffer<Unicode.Scalar>
+  %118 = integer_literal $Builtin.Int64, 0
+  %119 = struct $Int (%118 : $Builtin.Int64)
+  %120 = function_ref @$ss22_ContiguousArrayBufferV12mutableCountSivs : $@convention(method) <τ_0_0> (Int, @guaranteed _ContiguousArrayBuffer<τ_0_0>) -> ()
+  %121 = apply %120<Unicode.Scalar>(%119, %117) : $@convention(method) <τ_0_0> (Int, @guaranteed _ContiguousArrayBuffer<τ_0_0>) -> ()
+  end_borrow %117 : $_ContiguousArrayBuffer<Unicode.Scalar>
+  br bb7
+
+bb6:
+  br bb7
+
+bb7:
+  %125 = struct_element_addr %1 : $*_UnsafePartiallyInitializedContiguousArrayBuffer<Unicode.Scalar>, #_UnsafePartiallyInitializedContiguousArrayBuffer.result
+  %126 = load [copy] %125 : $*_ContiguousArrayBuffer<Unicode.Scalar>
+  %127 = struct_element_addr %1 : $*_UnsafePartiallyInitializedContiguousArrayBuffer<Unicode.Scalar>, #_UnsafePartiallyInitializedContiguousArrayBuffer.result
+  store %39 to [assign] %127 : $*_ContiguousArrayBuffer<Unicode.Scalar>
+  destroy_addr %34 : $*_ContiguousArrayBuffer<Unicode.Scalar>
+  store %126 to [init] %34 : $*_ContiguousArrayBuffer<Unicode.Scalar>
+  destroy_addr %34 : $*_ContiguousArrayBuffer<Unicode.Scalar>
+  dealloc_stack %34 : $*_ContiguousArrayBuffer<Unicode.Scalar>
+  br bb8
+
+bb8:
+  %133 = function_ref @$ss48_UnsafePartiallyInitializedContiguousArrayBufferV23addWithExistingCapacityyyxF : $@convention(method) <τ_0_0> (@in_guaranteed τ_0_0, @inout _UnsafePartiallyInitializedContiguousArrayBuffer<τ_0_0>) -> ()
+  %134 = apply %133<Unicode.Scalar>(%3, %1) : $@convention(method) <τ_0_0> (@in_guaranteed τ_0_0, @inout _UnsafePartiallyInitializedContiguousArrayBuffer<τ_0_0>) -> ()
+  %135 = tuple ()
+  dealloc_stack %3 : $*Unicode.Scalar
+  return %135 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @$s10Foundation4DataV15_RepresentationOys5UInt8VSicis : {{.*}} {
+// CHECK-LABEL: } // end sil function '$s10Foundation4DataV15_RepresentationOys5UInt8VSicis'
+sil [ossa] @$s10Foundation4DataV15_RepresentationOys5UInt8VSicis : $@convention(method) (UInt8, Int, @inout Data._Representation) -> () {
+bb0(%0 : $UInt8, %1 : $Int, %2 : $*Data._Representation):
+  debug_value %0 : $UInt8, let, name "newValue", argno 1
+  debug_value %1 : $Int, let, name "index", argno 2, implicit
+  debug_value %2 : $*Data._Representation, var, name "self", argno 3, implicit, expr op_deref
+  %6 = load [copy] %2 : $*Data._Representation
+  switch_enum %6 : $Data._Representation, case #Data._Representation.empty!enumelt: bb1, case #Data._Representation.inline!enumelt: bb5, case #Data._Representation.slice!enumelt: bb6, case #Data._Representation.large!enumelt: bb7
+
+bb1:
+  br bb2
+
+bb2:
+  br bb3
+
+bb3:
+  br bb4
+
+bb4:
+  %11 = integer_literal $Builtin.Int1, -1
+  cond_fail %11 : $Builtin.Int1, "precondition failure"
+  unreachable
+
+bb5(%14 : $Data.InlineData):
+  %15 = alloc_stack [lexical] $Data.InlineData, var, name "inline"
+  store %14 to [trivial] %15 : $*Data.InlineData
+  debug_value %15 : $*Data.InlineData, var, name "inline", expr op_deref
+  %18 = function_ref @$s10Foundation4DataV06InlineB0Vys5UInt8VSicis : $@convention(method) (UInt8, Int, @inout Data.InlineData) -> ()
+  %19 = apply %18(%0, %1, %15) : $@convention(method) (UInt8, Int, @inout Data.InlineData) -> ()
+  %20 = metatype $@thin Data._Representation.Type
+  %21 = load [trivial] %15 : $*Data.InlineData
+  %22 = enum $Data._Representation, #Data._Representation.inline!enumelt, %21 : $Data.InlineData
+  store %22 to [assign] %2 : $*Data._Representation
+  dealloc_stack %15 : $*Data.InlineData
+  br bb8
+
+bb6(%26 : @owned $Data.InlineSlice):
+  %27 = alloc_stack [lexical] $Data.InlineSlice, var, name "slice"
+  store %26 to [init] %27 : $*Data.InlineSlice
+  debug_value %27 : $*Data.InlineSlice, var, name "slice", expr op_deref
+  %30 = metatype $@thin Data._Representation.Type
+  %31 = enum $Data._Representation, #Data._Representation.empty!enumelt
+  store %31 to [assign] %2 : $*Data._Representation
+  %33 = function_ref @$s10Foundation4DataV11InlineSliceVys5UInt8VSicis : $@convention(method) (UInt8, Int, @inout Data.InlineSlice) -> ()
+  %34 = apply %33(%0, %1, %27) : $@convention(method) (UInt8, Int, @inout Data.InlineSlice) -> ()
+  %35 = metatype $@thin Data._Representation.Type
+  %36 = load [copy] %27 : $*Data.InlineSlice
+  %37 = enum $Data._Representation, #Data._Representation.slice!enumelt, %36 : $Data.InlineSlice
+  store %37 to [assign] %2 : $*Data._Representation
+  destroy_addr %27 : $*Data.InlineSlice
+  dealloc_stack %27 : $*Data.InlineSlice
+  br bb8
+
+bb7(%42 : @owned $Data.LargeSlice):
+  %43 = alloc_stack [lexical] $Data.LargeSlice, var, name "slice"
+  store %42 to [init] %43 : $*Data.LargeSlice
+  debug_value %43 : $*Data.LargeSlice, var, name "slice", expr op_deref
+  %46 = metatype $@thin Data._Representation.Type
+  %47 = enum $Data._Representation, #Data._Representation.empty!enumelt
+  store %47 to [assign] %2 : $*Data._Representation
+  %49 = function_ref @$s10Foundation4DataV10LargeSliceVys5UInt8VSicis : $@convention(method) (UInt8, Int, @inout Data.LargeSlice) -> ()
+  %50 = apply %49(%0, %1, %43) : $@convention(method) (UInt8, Int, @inout Data.LargeSlice) -> ()
+  %51 = metatype $@thin Data._Representation.Type
+  %52 = load [copy] %43 : $*Data.LargeSlice
+  %53 = enum $Data._Representation, #Data._Representation.large!enumelt, %52 : $Data.LargeSlice
+  store %53 to [assign] %2 : $*Data._Representation
+  destroy_addr %43 : $*Data.LargeSlice
+  dealloc_stack %43 : $*Data.LargeSlice
+  br bb8
+
+bb8:
+  %58 = tuple ()
+  return %58 : $()
+}


### PR DESCRIPTION
Previously, SSADestroyHoisting used two pessimistic BackwardReachability dataflows.  Here, it is made to use IterativeBackwardReachability including a call to the optionally-used method solvePessimistic to do a pessimistic dataflow (to find barrier access scopes) and an optimistic dataflow (to find all barriers).
