### PR TITLE
[ConstraintSystem] Adjust `getCalleeLocator` to handle implicit `call…

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -564,6 +564,13 @@ ConstraintLocator *ConstraintSystem::getCalleeLocator(
   }
 
   if (auto *UDE = getAsExpr<UnresolvedDotExpr>(anchor)) {
+    if (UDE->isImplicit() &&
+        UDE->getName().getBaseName() == Context.Id_callAsFunction) {
+      return getConstraintLocator(anchor,
+                                  {LocatorPathElt::ApplyFunction(),
+                                   LocatorPathElt::ImplicitCallAsFunction()});
+    }
+
     return getConstraintLocator(
         anchor, TypeChecker::getSelfForInitDelegationInConstructor(DC, UDE)
                     ? ConstraintLocator::ConstructorMember

--- a/test/Constraints/result_builder.swift
+++ b/test/Constraints/result_builder.swift
@@ -1174,3 +1174,27 @@ let list3 = list {
 }
 print(list3)
 // CHECK: (cons "4" (cons (cons "3" (cons 2.0 nil)) (cons 1 nil)))
+
+func test_callAsFunction_with_resultBuilder() {
+  struct CallableTest {
+    func callAsFunction<T>(@TupleBuilder _ body: (Bool) -> T) {
+      print(body(true))
+    }
+  }
+
+  CallableTest() {
+    0
+    "with parens"
+    $0
+  }
+
+  CallableTest {
+    1
+    "without parens"
+    $0
+  }
+}
+
+test_callAsFunction_with_resultBuilder()
+// CHECK: (0, "with parens", true)
+// CHECK: (1, "without parens", true)


### PR DESCRIPTION
…AsFunction`

A call to `.callAsFunction` could be injected after initializer if the type is
callable, `getCalleeLocator` should recognize that situation and return
appropriate locator otherwise if `callAsFunction` has e.g. a result builder
attached to one of its parameters the solver wouldn't be able to find it.

Resolves: rdar://92914226

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
