### PR TITLE
[5.7-04182022][ConstraintSystem] A couple of `callAsFunction` fixes

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10926,6 +10926,24 @@ bool ConstraintSystem::simplifyAppliedOverloadsImpl(
 
   auto *argList = getArgumentList(getConstraintLocator(locator));
 
+  // If argument list has trailing closures and this is `init` call to
+  // a callable type, let's not filter anything since there is a possibility
+  // that it needs an implicit `.callAsFunction` to work.
+  if (argList && argList->hasAnyTrailingClosures()) {
+    if (disjunction->getLocator()
+            ->isLastElement<LocatorPathElt::ConstructorMember>()) {
+      auto choice = disjunction->getNestedConstraints()[0]->getOverloadChoice();
+      if (auto *decl = choice.getDeclOrNull()) {
+        auto *dc = decl->getDeclContext();
+        if (auto *parent = dc->getSelfNominalTypeDecl()) {
+          auto type = parent->getDeclaredInterfaceType();
+          if (type->isCallableNominalType(DC))
+            return false;
+        }
+      }
+    }
+  }
+
   // Consider each of the constraints in the disjunction.
 retry_after_fail:
   bool hasUnhandledConstraints = false;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -557,6 +557,13 @@ ConstraintLocator *ConstraintSystem::getCalleeLocator(
   }
 
   if (auto *UDE = getAsExpr<UnresolvedDotExpr>(anchor)) {
+    if (UDE->isImplicit() &&
+        UDE->getName().getBaseName() == Context.Id_callAsFunction) {
+      return getConstraintLocator(anchor,
+                                  {LocatorPathElt::ApplyFunction(),
+                                   LocatorPathElt::ImplicitCallAsFunction()});
+    }
+
     return getConstraintLocator(
         anchor, TypeChecker::getSelfForInitDelegationInConstructor(DC, UDE)
                     ? ConstraintLocator::ConstructorMember

--- a/test/Constraints/callAsFunction.swift
+++ b/test/Constraints/callAsFunction.swift
@@ -29,3 +29,25 @@ struct Test {
     }
   }
 }
+
+// rdar://92912878 - filtering prevents disambiguation of `.callAsFunction`
+func test_no_filtering_of_overloads() {
+  struct S {
+    init() {}
+    init(_: String) {}
+
+    func callAsFunction<T>(_ fn: () -> T) -> T {
+      fn()
+    }
+  }
+
+  func test(_: () -> Void) {
+  }
+
+  test {
+    _ = S() { // Ok
+      _ = 42
+      print("Hello")
+    }
+  }
+}

--- a/test/Constraints/result_builder.swift
+++ b/test/Constraints/result_builder.swift
@@ -1174,3 +1174,27 @@ let list3 = list {
 }
 print(list3)
 // CHECK: (cons "4" (cons (cons "3" (cons 2.0 nil)) (cons 1 nil)))
+
+func test_callAsFunction_with_resultBuilder() {
+  struct CallableTest {
+    func callAsFunction<T>(@TupleBuilder _ body: (Bool) -> T) {
+      print(body(true))
+    }
+  }
+
+  CallableTest() {
+    0
+    "with parens"
+    $0
+  }
+
+  CallableTest {
+    1
+    "without parens"
+    $0
+  }
+}
+
+test_callAsFunction_with_resultBuilder()
+// CHECK: (0, "with parens", true)
+// CHECK: (1, "without parens", true)


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/58778
Cherry-pick of https://github.com/apple/swift/pull/58793

---

- Explanation:

   Both fixes represent usability improvements for `callAsFunction`.

   - Avoid filtering `init` overloads of a callable type if a call has a trailing closure. Filtering 
     prevents from picking an overload that is going to work with implicit `callAsFunction` call.

   - Fix a situation where result builder attached to a `callAsFunction` parameter could
     not be discovered due to incorrect locator.

- Scope: Calls to `init` of a callable type that have trailing closures

- Main Branch PR:  https://github.com/apple/swift/pull/58778, https://github.com/apple/swift/pull/58793
- 5.7 Branch PR: https://github.com/apple/swift/pull/58794

- Resolves: rdar://92912878, rdar://92914226

- Risk: Very low

- Reviewed By: @hborla 

- Testing:  Added regression test-cases to the suite.

Resolves: rdar://92912878
Resolves: rdar://92914226

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
