### PR TITLE
Revert https://github.com/apple/swift/pull/58731

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/BasicBlock.swift
+++ b/SwiftCompilerSources/Sources/SIL/BasicBlock.swift
@@ -25,7 +25,7 @@ final public class BasicBlock : ListNode, CustomStringConvertible, HasName {
   public var function: Function { SILBasicBlock_getFunction(bridged).function }
 
   public var description: String {
-    let s = SILBasicBlock_debugDescription(bridged)
+    var s = SILBasicBlock_debugDescription(bridged)
     return String(cString: s.c_str())
   }
 

--- a/SwiftCompilerSources/Sources/SIL/Function.swift
+++ b/SwiftCompilerSources/Sources/SIL/Function.swift
@@ -21,7 +21,7 @@ final public class Function : CustomStringConvertible, HasName {
   }
 
   final public var description: String {
-    let s = SILFunction_debugDescription(bridged)
+    var s = SILFunction_debugDescription(bridged)
     return String(cString: s.c_str())
   }
 

--- a/SwiftCompilerSources/Sources/SIL/GlobalVariable.swift
+++ b/SwiftCompilerSources/Sources/SIL/GlobalVariable.swift
@@ -19,7 +19,7 @@ final public class GlobalVariable : CustomStringConvertible, HasName {
   }
 
   public var description: String {
-    let s = SILGlobalVariable_debugDescription(bridged)
+    var s = SILGlobalVariable_debugDescription(bridged)
     return String(cString: s.c_str())
   }
 

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -38,7 +38,7 @@ public class Instruction : ListNode, CustomStringConvertible, Hashable {
   final public var function: Function { block.function }
 
   final public var description: String {
-    let s = SILNode_debugDescription(bridgedNode)
+    var s = SILNode_debugDescription(bridgedNode)
     return String(cString: s.c_str())
   }
 
@@ -136,7 +136,7 @@ public class SingleValueInstruction : Instruction, Value {
 
 public final class MultipleValueInstructionResult : Value {
   final public var description: String {
-    let s = SILNode_debugDescription(bridgedNode)
+    var s = SILNode_debugDescription(bridgedNode)
     return String(cString: s.c_str())
   }
 

--- a/SwiftCompilerSources/Sources/SIL/Value.swift
+++ b/SwiftCompilerSources/Sources/SIL/Value.swift
@@ -21,7 +21,7 @@ public protocol Value : AnyObject, CustomStringConvertible {
 
 extension Value {
   public var description: String {
-    let s = SILNode_debugDescription(bridgedNode)
+    var s = SILNode_debugDescription(bridgedNode)
     return String(cString: s.c_str())
   }
 


### PR DESCRIPTION
The changes from https://github.com/apple/swift/pull/58731 break compilation for compiler developers who choose to bootstrap with hosttools. Apparently older Swift compilers import `std::string::c_str()` as mutating.

This reverts commit d83c17e8324b3fbf69e2504d8d48c8ec160b621f.
