### PR TITLE
[Autolink Extract] Keep a set of linker flags instead of vector

### DIFF
--- a/test/AutolinkExtract/import.swift
+++ b/test/AutolinkExtract/import.swift
@@ -1,9 +1,15 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swiftc_driver -emit-module -emit-module-path %t/empty.swiftmodule -module-name empty -module-link-name empty %S/empty.swift
 // RUN: %target-swiftc_driver -c %s -I %t -o %t/import_experimental.o
-// RUN: %target-swift-autolink-extract %t/import_experimental.o -o - | %FileCheck --check-prefix CHECK-%target-object-format %s
+// RUN: %target-swiftc_driver -c %s -I %t -o %t/import_experimental_again.o
+// RUN: %target-swift-autolink-extract %t/import_experimental.o %t/import_experimental_again.o -o - | %FileCheck --check-prefix CHECK-%target-object-format %s
+
+// RUN: %target-swift-autolink-extract %t/import_experimental.o %t/import_experimental_again.o -o - | %FileCheck --check-prefix UNIQUE %s
 
 // REQUIRES: autolink-extract
+
+// UNIQUE-COUNT-1: -lempty
+// UNIQUE-COUNT-1: -lswiftCore
 
 // CHECK-elf-DAG: -lswiftCore
 // CHECK-elf-DAG: -lempty


### PR DESCRIPTION
Otherwise we can duplicate linker flags across input binaries, which can result in very large linkerr invocation commands.

Resolves https://github.com/apple/swift/issues/58380
