### PR TITLE
Downgrade missing `@Sendable` error on local functions to a warning.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2652,7 +2652,8 @@ namespace {
         func->diagnose(
             diag::local_function_executed_concurrently,
             func->getDescriptiveKind(), func->getName())
-          .fixItInsert(func->getAttributeInsertionLoc(false), "@Sendable ");
+          .fixItInsert(func->getAttributeInsertionLoc(false), "@Sendable ")
+          .warnUntilSwiftVersion(6);
 
         // Add the @Sendable attribute implicitly, so we don't diagnose
         // again.

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -690,7 +690,7 @@ func checkLocalFunctions() async {
     i = 17
   }
 
-  func local2() { // expected-error{{concurrently-executed local function 'local2()' must be marked as '@Sendable'}}{{3-3=@Sendable }}
+  func local2() { // expected-warning{{concurrently-executed local function 'local2()' must be marked as '@Sendable'}}{{3-3=@Sendable }}
     j = 42
   }
 
@@ -721,7 +721,7 @@ func checkLocalFunctions() async {
     }
   }
 
-  func local3() { // expected-error{{concurrently-executed local function 'local3()' must be marked as '@Sendable'}}
+  func local3() { // expected-warning{{concurrently-executed local function 'local3()' must be marked as '@Sendable'}}
     k = 25 // expected-error{{mutation of captured var 'k' in concurrently-executing code}}
   }
 


### PR DESCRIPTION
We're staging in most of these checks via warnings in Swift 5.x.
Fixes rdar://92986898.
