### PR TITLE
[5.7-04182022] Sema: Accept existentials without `any` in swiftinterfaces

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3539,11 +3539,12 @@ void swift::performAbstractFuncDeclDiagnostics(AbstractFunctionDecl *AFD) {
 }
 
 // Perform MiscDiagnostics on Switch Statements.
-static void checkSwitch(ASTContext &ctx, const SwitchStmt *stmt) {
+static void checkSwitch(ASTContext &ctx, const SwitchStmt *stmt,
+                        DeclContext *DC) {
   // We want to warn about "case .Foo, .Bar where 1 != 100:" since the where
   // clause only applies to the second case, and this is surprising.
   for (auto cs : stmt->getCases()) {
-    TypeChecker::checkExistentialTypes(ctx, cs);
+    TypeChecker::checkExistentialTypes(ctx, cs, DC);
 
     // The case statement can have multiple case items, each can have a where.
     // If we find a "where", and there is a preceding item without a where, and
@@ -5036,10 +5037,10 @@ void swift::performSyntacticExprDiagnostics(const Expr *E,
 void swift::performStmtDiagnostics(const Stmt *S, DeclContext *DC) {
   auto &ctx = DC->getASTContext();
 
-  TypeChecker::checkExistentialTypes(ctx, const_cast<Stmt *>(S));
-    
+  TypeChecker::checkExistentialTypes(ctx, const_cast<Stmt *>(S), DC);
+
   if (auto switchStmt = dyn_cast<SwitchStmt>(S))
-    checkSwitch(ctx, switchStmt);
+    checkSwitch(ctx, switchStmt, DC);
 
   checkStmtConditionTrailingClosure(ctx, S);
   

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4350,6 +4350,11 @@ void TypeChecker::checkExistentialTypes(Decl *decl) {
   if (!decl || decl->isInvalid())
     return;
 
+  // Skip diagnosing existential `any` requirements in swiftinterfaces.
+  auto sourceFile = decl->getDeclContext()->getParentSourceFile();
+  if (sourceFile && sourceFile->Kind == SourceFileKind::Interface)
+    return;
+
   auto &ctx = decl->getASTContext();
   if (auto *protocolDecl = dyn_cast<ProtocolDecl>(decl)) {
     checkExistentialTypes(ctx, protocolDecl->getTrailingWhereClause());
@@ -4380,8 +4385,14 @@ void TypeChecker::checkExistentialTypes(Decl *decl) {
   decl->walk(visitor);
 }
 
-void TypeChecker::checkExistentialTypes(ASTContext &ctx, Stmt *stmt) {
+void TypeChecker::checkExistentialTypes(ASTContext &ctx, Stmt *stmt,
+                                        DeclContext *DC) {
   if (!stmt)
+    return;
+
+  // Skip diagnosing existential `any` requirements in swiftinterfaces.
+  auto sourceFile = DC->getParentSourceFile();
+  if (sourceFile && sourceFile->Kind == SourceFileKind::Interface)
     return;
 
   ExistentialTypeVisitor visitor(ctx, /*checkStatements=*/true);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -295,7 +295,7 @@ Expr *resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *Context,
 void checkExistentialTypes(Decl *decl);
 
 /// Check for invalid existential types in the given statement.
-void checkExistentialTypes(ASTContext &ctx, Stmt *stmt);
+void checkExistentialTypes(ASTContext &ctx, Stmt *stmt, DeclContext *DC);
 
 /// Check for invalid existential types in the underlying type of
 /// the given type alias.

--- a/test/ModuleInterface/Inputs/existential-any-ignore-missing-in-interface.swiftinterface
+++ b/test/ModuleInterface/Inputs/existential-any-ignore-missing-in-interface.swiftinterface
@@ -1,0 +1,25 @@
+// swift-interface-format-version: 1.0
+// swift-compiler-version: Swift version 5.7-dev (LLVM cd62c186b914a47, Swift d74d00ef63ab637)
+// swift-module-flags: -swift-version 5 -enable-library-evolution -module-name ExistentialAnyMissing
+import Swift
+public protocol P {
+}
+public protocol Q {
+  associatedtype A : ExistentialAnyMissing.P
+}
+public func takesAndReturnsP(_ x: ExistentialAnyMissing.P) -> ExistentialAnyMissing.P
+public func takesAndReturnsOptionalP(_ x: ExistentialAnyMissing.P?) -> ExistentialAnyMissing.P?
+public func takesAndReturnsQ(_ x: ExistentialAnyMissing.Q) -> ExistentialAnyMissing.Q
+public struct S {
+  public var p: ExistentialAnyMissing.P
+  public var maybeP: ExistentialAnyMissing.P?
+  public var q: ExistentialAnyMissing.Q
+  public var maybeQ: ExistentialAnyMissing.Q?
+}
+@inlinable internal func inlinableTakesAny(_ a: Any) {
+  switch a {
+  case is P: break
+  case is Q: break
+  default: break
+  }
+}

--- a/test/ModuleInterface/existential-any.swift
+++ b/test/ModuleInterface/existential-any.swift
@@ -1,0 +1,2 @@
+// Verify that `any` is not required in swiftinterfaces.
+// RUN: %target-swift-frontend -typecheck-module-from-interface %S/Inputs/existential-any-ignore-missing-in-interface.swiftinterface -module-name ExistentialAnyMissing


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/58801

Accept existentials without `any` in swiftinterfaces.

Resolves rdar://93052306