### PR TITLE
Fix async_let playground transform

### DIFF
--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -576,12 +576,14 @@ public:
       } else if (auto *D = Element.dyn_cast<Decl *>()) {
         D->walk(CF);
         if (auto *PBD = dyn_cast<PatternBindingDecl>(D)) {
-          if (VarDecl *VD = PBD->getSingleVar()) {
-            if (VD->getParentInitializer()) {
-              Added<Stmt *> Log = logVarDecl(VD);
-              if (*Log) {
-                Elements.insert(Elements.begin() + (EI + 1), *Log);
-                ++EI;
+          if (!PBD->isAsyncLet()) {
+            if (VarDecl *VD = PBD->getSingleVar()) {
+              if (VD->getParentInitializer()) {
+                Added<Stmt *> Log = logVarDecl(VD);
+                if (*Log) {
+                  Elements.insert(Elements.begin() + (EI + 1), *Log);
+                  ++EI;
+                }
               }
             }
           }

--- a/test/PlaygroundTransform/async_let.swift
+++ b/test/PlaygroundTransform/async_let.swift
@@ -1,0 +1,52 @@
+// RUN: %empty-directory(%t)
+// RUN: cp %s %t/main.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -Xfrontend -playground -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -Xfrontend -pc-macro -Xfrontend -playground -o %t/main2 -I=%t %t/PlaygroundSupport.o %t/main.swift
+// RUN: %target-codesign %t/main2
+// RUN: %target-run %t/main2 | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+
+// rdar://76038845
+// REQUIRES: concurrency_runtime
+// UNSUPPORTED: back_deployment_runtime
+
+import PlaygroundSupport
+
+func factorial(_ x : Int) async -> Int {
+    if x < 1 {
+        return 1
+    }
+    return await x * factorial(x - 1)
+}
+
+async let fac4 = factorial(4)
+print(await fac4)
+
+//             return await x * factorial(x - 1)
+// CHECK:      [22:{{[[:digit:]]+}}-22:{{[[:digit:]]+}}] __builtin_log[='1']
+
+//             return await x * factorial(x - 1)
+// CHECK:      [24:{{[[:digit:]]+}}-24:{{[[:digit:]]+}}] __builtin_log[='1']
+
+//             return await x * factorial(x - 1)
+// CHECK:      [24:{{[[:digit:]]+}}-24:{{[[:digit:]]+}}] __builtin_log[='2']
+
+//             return await x * factorial(x - 1)
+// CHECK:      [24:{{[[:digit:]]+}}-24:{{[[:digit:]]+}}] __builtin_log[='6']
+
+//             return await x * factorial(x - 1)
+// CHECK:      [24:{{[[:digit:]]+}}-24:{{[[:digit:]]+}}] __builtin_log[='24']
+
+//             func factorial(_ x : Int) { ... }
+// CHECK-NEXT: [20:{{[[:digit:]]+}}-25:{{[[:digit:]]+}}] __builtin_log_scope_exit
+
+// (actually print the thing)
+// CHECK-NEXT: 24
+
+//             print(await fac4)
+// CHECK-NEXT: [28:{{[[:digit:]]+}}-28:{{[[:digit:]]+}}] __builtin_postPrint


### PR DESCRIPTION
Async-let pattern-binding-decls can't be logged since they haven't been
await'd yet. This patch fixes it so the playground transform doesn't try
to log the async-let PBD.

Without this fix, you'll get an error like the following;
```
error: expression is 'async' but is not marked with 'await'
  async let asyncVar = asyncFn1()
            ^~~~~~~~
            await
```

rdar://85311228