### PR TITLE
[CodeCompletion] Don't print '_' external parameter name in filterName

### DIFF
--- a/lib/IDE/CodeCompletionResultPrinter.cpp
+++ b/lib/IDE/CodeCompletionResultPrinter.cpp
@@ -496,6 +496,10 @@ static void printCodeCompletionResultFilterName(
       case ChunkKind::DeclIntroducer:
         ++i;
         continue;
+      case ChunkKind::ParameterDeclExternalName:
+        // Skip '_' parameter external name.
+        shouldPrint = shouldPrint && C.hasText() && C.getText() != "_";
+        break;
       case ChunkKind::CallArgumentTypeBegin:
       case ChunkKind::ParameterDeclTypeBegin:
       case ChunkKind::TypeAnnotationBegin:

--- a/test/IDE/complete_annotation.swift
+++ b/test/IDE/complete_annotation.swift
@@ -135,9 +135,15 @@ protocol BaseP {
   var value: MyStruct
 }
 class BaseC {
+  func baseMethod(x: Int) -> Int { }
+  func baseMethodWithName(x y: Int) -> Int { }
+  func baseMethodWithEmptyName(_ y: Int) -> Int { }
+
   func baseMethodAsync(x: Int) async -> Int { }
   func genericAsyncThrowsConstraint<T, U>(x: T) async throws -> U.Element where U: Collection, U.Element == Int {}
   subscript(index: Int) -> (Int) -> Int { }
+  subscript(withName index: Int) -> Float { }
+  subscript(_ index: String) -> String { }
 }
 class DerivedC: BaseC, BaseP {
   #^OVERRIDE^#
@@ -145,9 +151,14 @@ class DerivedC: BaseC, BaseP {
 // OVERRIDE-DAG: Keyword[func]/None:                 <keyword>func</keyword>; typename=; name=func; sourcetext=func
 // OVERRIDE-DAG: Decl[InstanceMethod]/Super:         <name>protoMethod</name>() -&gt; (<typeid.sys>UInt8</typeid.sys>) -&gt; <typeid.sys>Void</typeid.sys>; typename=; name=protoMethod(); sourcetext=func protoMethod() -> (UInt8) -> Void {\n<#code#>\n}
 // OVERRIDE-DAG: Decl[InstanceVar]/Super:            <name>value</name>: <typeid.user>MyStruct</typeid.user>; typename=; name=value; sourcetext=var value: MyStruct
+// OVERRIDE-DAG: Decl[InstanceMethod]/Super:         <name>baseMethod</name>(<param><param.label>x</param.label>: <param.type><typeid.sys>Int</typeid.sys></param.type></param>) -&gt; <typeid.sys>Int</typeid.sys>; typename=; name=baseMethod(x:); sourcetext=override func baseMethod(x: Int) -> Int {\n<#code#>\n}
+// OVERRIDE-DAG: Decl[InstanceMethod]/Super:         <name>baseMethodWithName</name>(<param><param.label>x</param.label> <param.param>y</param.param>: <param.type><typeid.sys>Int</typeid.sys></param.type></param>) -&gt; <typeid.sys>Int</typeid.sys>; typename=; name=baseMethodWithName(x:); sourcetext=override func baseMethodWithName(x y: Int) -> Int {\n<#code#>\n}
+// OVERRIDE-DAG: Decl[InstanceMethod]/Super:         <name>baseMethodWithEmptyName</name>(<param><param.label>_</param.label> <param.param>y</param.param>: <param.type><typeid.sys>Int</typeid.sys></param.type></param>) -&gt; <typeid.sys>Int</typeid.sys>; typename=; name=baseMethodWithEmptyName(:); sourcetext=override func baseMethodWithEmptyName(_ y: Int) -> Int {\n<#code#>\n}
 // OVERRIDE-DAG: Decl[InstanceMethod]/Super:         <name>baseMethodAsync</name>(<param><param.label>x</param.label>: <param.type><typeid.sys>Int</typeid.sys></param.type></param>) <keyword>async</keyword> -&gt; <typeid.sys>Int</typeid.sys>; typename=; name=baseMethodAsync(x:); sourcetext=override func baseMethodAsync(x: Int) async -> Int {\n<#code#>\n}
 // OVERRIDE-DAG: Decl[InstanceMethod]/Super:         <name>genericAsyncThrowsConstraint</name>&lt;T, U&gt;(<param><param.label>x</param.label>: <param.type><typeid.user>T</typeid.user></param.type></param>) <keyword>async</keyword> <keyword>throws</keyword> -&gt; <typeid.user>U</typeid.user>.<typeid.sys>Element</typeid.sys> <keyword>where</keyword> <typeid.user>U</typeid.user> : <typeid.sys>Collection</typeid.sys>, <typeid.user>U</typeid.user>.<typeid.sys>Element</typeid.sys> == <typeid.sys>Int</typeid.sys>; typename=; name=genericAsyncThrowsConstraint(x:); sourcetext=override func genericAsyncThrowsConstraint<T, U>(x: T) async throws -> U.Element where U : Collection, U.Element == Int {\n<#code#>\n}
 // OVERRIDE-DAG: Decl[Subscript]/Super:              <name>subscript</name>(<param><param.param>index</param.param>: <param.type><typeid.sys>Int</typeid.sys></param.type></param>) -&gt; (<typeid.sys>Int</typeid.sys>) -&gt; <typeid.sys>Int</typeid.sys>; typename=; name=subscript(:); sourcetext=override subscript(index: Int) -> (Int) -> Int {\n<#code#>\n}
+// OVERRIDE-DAG: Decl[Subscript]/Super:              <name>subscript</name>(<param><param.label>withName</param.label> <param.param>index</param.param>: <param.type><typeid.sys>Int</typeid.sys></param.type></param>) -&gt; <typeid.sys>Float</typeid.sys>; typename=; name=subscript(withName:); sourcetext=override subscript(withName index: Int) -> Float {\n<#code#>\n}
+// OVERRIDE-DAG: Decl[Subscript]/Super:              <name>subscript</name>(<param><param.param>index</param.param>: <param.type><typeid.sys>String</typeid.sys></param.type></param>) -&gt; <typeid.sys>String</typeid.sys>; typename=; name=subscript(:); sourcetext=override subscript(index: String) -> String {\n<#code#>\n}
 // OVERRIDE-DAG: Decl[Constructor]/Super:            <name>init</name>(); typename=; name=init(); sourcetext=override init() {\n<#code#>\n}
 // OVERRIDE: End completions
 }

--- a/test/IDE/complete_member_decls_from_parent_decl_context.swift
+++ b/test/IDE/complete_member_decls_from_parent_decl_context.swift
@@ -607,13 +607,13 @@ class SR627_BaseClass<T> {
 class SR627_Subclass: SR627_BaseClass<String> {
   #^SR627_SUBCLASS^#
 // SR627_SUBCLASS: Begin completions
-// SR627_SUBCLASS-DAG: Decl[InstanceMethod]/Super:         override func myFunction(_ x: String) -> String? {|}; name=myFunction(_:)
+// SR627_SUBCLASS-DAG: Decl[InstanceMethod]/Super:         override func myFunction(_ x: String) -> String? {|}; name=myFunction(:)
 // SR627_SUBCLASS: End completions
 }
 
 class SR627_SubSubclass: SR627_Subclass {
   #^SR627_SUB_SUBCLASS^#
   // SR627_SUB_SUBCLASS: Begin completions
-  // SR627_SUB_SUBCLASS-DAG: Decl[InstanceMethod]/Super:         override func myFunction(_ x: String) -> String? {|}; name=myFunction(_:)
+  // SR627_SUB_SUBCLASS-DAG: Decl[InstanceMethod]/Super:         override func myFunction(_ x: String) -> String? {|}; name=myFunction(:)
   // SR627_SUB_SUBCLASS: End completions
 }


### PR DESCRIPTION
in override completions. `_` as a filterName is not something clients expect. This align with function call completions.

But, unlike call-site completions, we do need `_` in the source text. So instead of mark the chunk "annotation", make an exception in `printCodeCompletionResultFilterName()`.

rdar://91892610
