### PR TITLE
[5.7] RequirementMachine: Teach concrete contraction about nested associated types

### DIFF
--- a/lib/AST/RequirementMachine/ConcreteContraction.cpp
+++ b/lib/AST/RequirementMachine/ConcreteContraction.cpp
@@ -139,7 +139,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/AST/Decl.h"
-#include "swift/AST/GenericParamKey.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/Requirement.h"
 #include "swift/AST/Type.h"
@@ -152,24 +151,48 @@
 using namespace swift;
 using namespace rewriting;
 
+/// Strip associated types from types used as keys to erase differences between
+/// resolved types coming from the parent generic signature and unresolved types
+/// coming from user-written requirements.
+static CanType stripBoundDependentMemberTypes(Type t) {
+  if (auto *depMemTy = t->getAs<DependentMemberType>()) {
+    return CanType(DependentMemberType::get(
+      stripBoundDependentMemberTypes(depMemTy->getBase()),
+      depMemTy->getName()));
+  }
+
+  return t->getCanonicalType();
+}
+
 namespace {
 
 /// Utility class to store some shared state.
 class ConcreteContraction {
   bool Debug;
 
-  llvm::SmallDenseMap<GenericParamKey,
-                      llvm::SmallDenseSet<Type, 1>> ConcreteTypes;
-  llvm::SmallDenseMap<GenericParamKey,
-                      llvm::SmallDenseSet<Type, 1>> Superclasses;
-  llvm::SmallDenseMap<GenericParamKey,
-                      llvm::SmallVector<ProtocolDecl *, 1>> Conformances;
+  llvm::SmallDenseMap<CanType, llvm::SmallDenseSet<Type, 1>> ConcreteTypes;
+  llvm::SmallDenseMap<CanType, llvm::SmallDenseSet<Type, 1>> Superclasses;
+  llvm::SmallDenseMap<CanType, llvm::SmallVector<ProtocolDecl *, 1>> Conformances;
 
-  Optional<Type> substTypeParameter(GenericTypeParamType *rootParam,
-                                    DependentMemberType *memberType,
-                                    Type concreteType) const;
-  Type substTypeParameter(Type type,
-                          bool subjectTypeOfConformance=false) const;
+  enum Position {
+    /// Base type of some other type appearing in a requirement.
+    BaseType,
+
+    /// Subject type of a conformance requirement.
+    ConformanceRequirement,
+
+    /// Subject type of a superclass requirement.
+    SuperclassRequirement,
+
+    /// Subject type of a same-type requirement.
+    SameTypeRequirement,
+
+    /// Some other position.
+    Other
+  };
+
+  Optional<Type> substTypeParameterRec(Type type, Position position) const;
+  Type substTypeParameter(Type type, Position position) const;
   Type substType(Type type) const;
   Requirement substRequirement(const Requirement &req) const;
 
@@ -201,67 +224,99 @@ public:
 /// to be some subclass of SomeClass which does conform to Sequence;
 /// this is perfectly valid, and we cannot substitute the 'T.Element'
 /// requirement. In this case, this method returns None.
-Optional<Type> ConcreteContraction::substTypeParameter(
-    GenericTypeParamType *rootParam,
-    DependentMemberType *memberType,
-    Type concreteType) const {
-  if (memberType == nullptr)
-    return concreteType;
+Optional<Type> ConcreteContraction::substTypeParameterRec(
+    Type type, Position position) const {
 
-  auto baseType = memberType->getBase()->getAs<DependentMemberType>();
-  auto substBaseType = substTypeParameter(rootParam, baseType, concreteType);
-  if (!substBaseType)
-    return None;
+  // If the requirement is of the form 'T == C' or 'T : C', don't
+  // substitute T, since then we end up with 'C == C' or 'C : C',
+  // losing the requirement.
+  if (position == Position::BaseType ||
+      position == Position::ConformanceRequirement) {
 
-  // A resolved DependentMemberType stores an associated type declaration.
-  //
-  // Handle this by looking up the corresponding type witness in the base
-  // type's conformance to the associated type's protocol.
-  if (auto *assocType = memberType->getAssocType()) {
-    auto *proto = assocType->getProtocol();
-    auto *module = proto->getParentModule();
+    Type concreteType;
+    {
+      auto found = ConcreteTypes.find(stripBoundDependentMemberTypes(type));
+      if (found != ConcreteTypes.end() && found->second.size() == 1)
+        concreteType = *found->second.begin();
+    }
 
-    auto conformance = ((*substBaseType)->isTypeParameter()
-                        ? ProtocolConformanceRef(proto)
-                        : module->lookupConformance(*substBaseType, proto,
-                                                    /*allowMissing=*/true));
+    Type superclass;
+    {
+      auto found = Superclasses.find(stripBoundDependentMemberTypes(type));
+      if (found != Superclasses.end() && found->second.size() == 1)
+        superclass = *found->second.begin();
+    }
 
-    // The base type doesn't conform, in which case the requirement remains
-    // unsubstituted.
-    if (!conformance) {
+    // If we have both, prefer the concrete type requirement since it is more
+    // specific.
+    if (!concreteType && superclass)
+      concreteType = superclass;
+
+    if (concreteType) {
+      return concreteType;
+    }
+  }
+
+  if (auto *memberType = type->getAs<DependentMemberType>()) {
+    auto baseType = memberType->getBase();
+    auto substBaseType = substTypeParameterRec(baseType, Position::BaseType);
+    if (!substBaseType)
+      return None;
+
+    // A resolved DependentMemberType stores an associated type declaration.
+    //
+    // Handle this by looking up the corresponding type witness in the base
+    // type's conformance to the associated type's protocol.
+    if (auto *assocType = memberType->getAssocType()) {
+      auto *proto = assocType->getProtocol();
+      auto *module = proto->getParentModule();
+
+      // The 'Sendable' protocol does not declare any associated types, so the
+      // 'allowMissing' value here is actually irrelevant.
+      auto conformance = ((*substBaseType)->isTypeParameter()
+                          ? ProtocolConformanceRef(proto)
+                          : module->lookupConformance(*substBaseType, proto,
+                                                      /*allowMissing=*/false));
+
+      // The base type doesn't conform, in which case the requirement remains
+      // unsubstituted.
+      if (!conformance) {
+        if (Debug) {
+          llvm::dbgs() << "@@@ " << substBaseType << " does not conform to "
+                       << proto->getName() << "\n";
+        }
+        return None;
+      }
+
+      return assocType->getDeclaredInterfaceType()
+                      ->castTo<DependentMemberType>()
+                      ->substBaseType(module, *substBaseType);
+    }
+
+    // An unresolved DependentMemberType stores an identifier. Handle this
+    // by performing a name lookup into the base type.
+    SmallVector<TypeDecl *, 2> concreteDecls;
+    lookupConcreteNestedType(*substBaseType, memberType->getName(), concreteDecls);
+
+    auto *typeDecl = findBestConcreteNestedType(concreteDecls);
+    if (typeDecl == nullptr) {
+      // The base type doesn't contain a member type with this name, in which
+      // case the requirement remains unsubstituted.
       if (Debug) {
-        llvm::dbgs() << "@@@ " << substBaseType << " does not conform to "
-                     << proto->getName() << "\n";
+        llvm::dbgs() << "@@@ Lookup of " << memberType->getName() << " failed on "
+                     << *substBaseType << "\n";
       }
       return None;
     }
 
-    return assocType->getDeclaredInterfaceType()
-                    ->castTo<DependentMemberType>()
-                    ->substBaseType(module, *substBaseType);
+    // Substitute the base type into the member type.
+    auto *dc = typeDecl->getDeclContext();
+    auto subMap = (*substBaseType)->getContextSubstitutionMap(
+        dc->getParentModule(), dc);
+    return typeDecl->getDeclaredInterfaceType().subst(subMap);
   }
 
-  // An unresolved DependentMemberType stores an identifier. Handle this
-  // by performing a name lookup into the base type.
-  SmallVector<TypeDecl *, 2> concreteDecls;
-  lookupConcreteNestedType(*substBaseType, memberType->getName(), concreteDecls);
-
-  auto *typeDecl = findBestConcreteNestedType(concreteDecls);
-  if (typeDecl == nullptr) {
-    // The base type doesn't contain a member type with this name, in which
-    // case the requirement remains unsubstituted.
-    if (Debug) {
-      llvm::dbgs() << "@@@ Lookup of " << memberType->getName() << " failed on "
-                   << *substBaseType << "\n";
-    }
-    return None;
-  }
-
-  // Substitute the base type into the member type.
-  auto *dc = typeDecl->getDeclContext();
-  auto subMap = (*substBaseType)->getContextSubstitutionMap(
-      dc->getParentModule(), dc);
-  return typeDecl->getDeclaredInterfaceType().subst(subMap);
+  return None;
 }
 
 /// Replace the generic parameter at the root of \p type, which must be a
@@ -273,48 +328,10 @@ Optional<Type> ConcreteContraction::substTypeParameter(
 /// itself does not become concrete when it's superclass-constrained, unless
 /// it is the subject of a conformance requirement.
 Type ConcreteContraction::substTypeParameter(
-    Type type, bool subjectTypeOfConformance) const {
+    Type type, Position position) const {
   assert(type->isTypeParameter());
 
-  auto rootParam = type->getRootGenericParam();
-  auto key = GenericParamKey(rootParam);
-
-  Type concreteType;
-  {
-    auto found = ConcreteTypes.find(key);
-    if (found != ConcreteTypes.end() && found->second.size() == 1)
-      concreteType = *found->second.begin();
-  }
-
-  Type superclass;
-  {
-    auto found = Superclasses.find(key);
-    if (found != Superclasses.end() && found->second.size() == 1)
-      superclass = *found->second.begin();
-  }
-
-  if (!concreteType && !superclass)
-    return type;
-
-  // If we have both, prefer the concrete type requirement since it is more
-  // specific.
-  if (!concreteType) {
-    assert(superclass);
-
-    // For a superclass requirement, don't substitute the generic parameter
-    // itself, only nested types thereof -- unless it's the subject type of
-    // a conformance requirement.
-    if (type->is<GenericTypeParamType>() &&
-        !subjectTypeOfConformance)
-      return type;
-
-    concreteType = superclass;
-  }
-
-  auto result = substTypeParameter(
-      rootParam, type->getAs<DependentMemberType>(),
-      concreteType);
-
+  auto result = substTypeParameterRec(type, position);
   if (!result)
     return type;
 
@@ -328,7 +345,7 @@ Type ConcreteContraction::substType(Type type) const {
         if (!type->isTypeParameter())
           return None;
 
-        return substTypeParameter(type);
+        return substTypeParameter(type, Position::Other);
       });
 }
 
@@ -340,14 +357,10 @@ ConcreteContraction::substRequirement(const Requirement &req) const {
   switch (req.getKind()) {
   case RequirementKind::Superclass:
   case RequirementKind::SameType: {
-    auto substFirstType = firstType;
-
-    // If the requirement is of the form 'T == C' or 'T : C', don't
-    // substitute T, since then we end up with 'C == C' or 'C : C',
-    // losing the requirement.
-    if (!firstType->is<GenericTypeParamType>()) {
-      substFirstType = substTypeParameter(firstType);
-    }
+    auto position = (req.getKind() == RequirementKind::Superclass
+                     ? Position::SuperclassRequirement
+                     : Position::SameTypeRequirement);
+    auto substFirstType = substTypeParameter(firstType, position);
 
     auto secondType = req.getSecondType();
     auto substSecondType = substType(secondType);
@@ -359,7 +372,7 @@ ConcreteContraction::substRequirement(const Requirement &req) const {
 
   case RequirementKind::Conformance: {
     auto substFirstType = substTypeParameter(
-        firstType, /*subjectTypeOfConformance=*/true);
+        firstType, Position::ConformanceRequirement);
 
     auto *proto = req.getProtocolDecl();
     auto *module = proto->getParentModule();
@@ -373,11 +386,8 @@ ConcreteContraction::substRequirement(const Requirement &req) const {
     // 'T : Sendable' would be incorrect; we want to ensure that we only admit
     // subclasses of 'C' which are 'Sendable'.
     bool allowMissing = false;
-    if (auto *rootParam = firstType->getAs<GenericTypeParamType>()) {
-      auto key = GenericParamKey(rootParam);
-      if (ConcreteTypes.count(key) > 0)
-        allowMissing = true;
-    }
+    if (ConcreteTypes.count(stripBoundDependentMemberTypes(firstType)) > 0)
+      allowMissing = true;
 
     if (!substFirstType->isTypeParameter() &&
         !module->lookupConformance(substFirstType, proto,
@@ -398,7 +408,7 @@ ConcreteContraction::substRequirement(const Requirement &req) const {
   }
 
   case RequirementKind::Layout: {
-    auto substFirstType = substTypeParameter(firstType);
+    auto substFirstType = substTypeParameter(firstType, Position::Other);
     if (!substFirstType->isTypeParameter() &&
         !substFirstType->satisfiesClassConstraint() &&
         req.getLayoutConstraint()->isClass()) {
@@ -422,22 +432,18 @@ hasResolvedMemberTypeOfInterestingParameter(Type type) const {
         return false;
 
       auto baseTy = memberTy->getBase();
-      if (auto *genericParam = baseTy->getAs<GenericTypeParamType>()) {
-        GenericParamKey key(genericParam);
+      Type concreteType;
+      {
+        auto found = ConcreteTypes.find(stripBoundDependentMemberTypes(baseTy));
+        if (found != ConcreteTypes.end() && found->second.size() == 1)
+          return true;
+      }
 
-        Type concreteType;
-        {
-          auto found = ConcreteTypes.find(key);
-          if (found != ConcreteTypes.end() && found->second.size() == 1)
-            return true;
-        }
-
-        Type superclass;
-        {
-          auto found = Superclasses.find(key);
-          if (found != Superclasses.end() && found->second.size() == 1)
-            return true;
-        }
+      Type superclass;
+      {
+        auto found = Superclasses.find(stripBoundDependentMemberTypes(baseTy));
+        if (found != Superclasses.end() && found->second.size() == 1)
+          return true;
       }
     }
 
@@ -470,9 +476,21 @@ bool ConcreteContraction::preserveSameTypeRequirement(
   if (req.getKind() != RequirementKind::SameType)
     return false;
 
-  if (Superclasses.find(req.getFirstType()->getRootGenericParam())
-      == Superclasses.end())
+  // One of the parent types of this type parameter should be subject
+  // to a superclass requirement.
+  auto type = req.getFirstType();
+  while (true) {
+    if (Superclasses.find(stripBoundDependentMemberTypes(type))
+        != Superclasses.end())
+      break;
+
+    if (auto *memberType = type->getAs<DependentMemberType>()) {
+      type = memberType->getBase();
+      continue;
+    }
+
     return false;
+  }
 
   if (hasResolvedMemberTypeOfInterestingParameter(req.getFirstType()) ||
       hasResolvedMemberTypeOfInterestingParameter(req.getSecondType()))
@@ -500,8 +518,7 @@ bool ConcreteContraction::performConcreteContraction(
     assert(subjectType->isTypeParameter() &&
            "You forgot to call desugarRequirement()");
 
-    auto genericParam = subjectType->getAs<GenericTypeParamType>();
-    if (!genericParam)
+    if (!subjectType->is<GenericTypeParamType>())
       continue;
 
     auto kind = req.req.getKind();
@@ -514,7 +531,8 @@ bool ConcreteContraction::performConcreteContraction(
       if (constraintType->isTypeParameter())
         break;
 
-      ConcreteTypes[GenericParamKey(genericParam)].insert(constraintType);
+      ConcreteTypes[stripBoundDependentMemberTypes(subjectType)]
+          .insert(constraintType);
       break;
     }
     case RequirementKind::Superclass: {
@@ -522,12 +540,14 @@ bool ConcreteContraction::performConcreteContraction(
       assert(!constraintType->isTypeParameter() &&
              "You forgot to call desugarRequirement()");
 
-      Superclasses[GenericParamKey(genericParam)].insert(constraintType);
+      Superclasses[stripBoundDependentMemberTypes(subjectType)]
+          .insert(constraintType);
       break;
     }
     case RequirementKind::Conformance: {
       auto *protoDecl = req.req.getProtocolDecl();
-      Conformances[GenericParamKey(genericParam)].push_back(protoDecl);
+      Conformances[stripBoundDependentMemberTypes(subjectType)]
+          .push_back(protoDecl);
 
       break;
     }
@@ -553,9 +573,9 @@ bool ConcreteContraction::performConcreteContraction(
       if (auto otherSuperclassTy = proto->getSuperclass()) {
         if (Debug) {
           llvm::dbgs() << "@ Subject type of superclass requirement "
-                       << "τ_" << subjectType.Depth << "_" << subjectType.Index
-                       << " : " << superclassTy << " conforms to "
-                       << proto->getName() << " which has a superclass bound "
+                       << "τ_" << subjectType << " : " << superclassTy
+                       << " conforms to "<< proto->getName()
+                       << " which has a superclass bound "
                        << otherSuperclassTy << "\n";
         }
 
@@ -574,8 +594,7 @@ bool ConcreteContraction::performConcreteContraction(
   if (Debug) {
     llvm::dbgs() << "@ Concrete types: @\n";
     for (auto pair : ConcreteTypes) {
-      llvm::dbgs() << "- τ_" << pair.first.Depth
-                   << "_" << pair.first.Index;
+      llvm::dbgs() << pair.first;
       if (pair.second.size() == 1) {
         llvm::dbgs() << " == " << *pair.second.begin() << "\n";
       } else {
@@ -585,8 +604,7 @@ bool ConcreteContraction::performConcreteContraction(
 
     llvm::dbgs() << "@ Superclasses: @\n";
     for (auto pair : Superclasses) {
-      llvm::dbgs() << "- τ_" << pair.first.Depth
-                   << "_" << pair.first.Index;
+      llvm::dbgs() << pair.first;
       if (pair.second.size() == 1) {
         llvm::dbgs() << " : " << *pair.second.begin() << "\n";
       } else {

--- a/lib/AST/RequirementMachine/ConcreteContraction.cpp
+++ b/lib/AST/RequirementMachine/ConcreteContraction.cpp
@@ -518,9 +518,6 @@ bool ConcreteContraction::performConcreteContraction(
     assert(subjectType->isTypeParameter() &&
            "You forgot to call desugarRequirement()");
 
-    if (!subjectType->is<GenericTypeParamType>())
-      continue;
-
     auto kind = req.req.getKind();
     switch (kind) {
     case RequirementKind::SameType: {

--- a/test/Generics/concrete_conformances_in_protocol.swift
+++ b/test/Generics/concrete_conformances_in_protocol.swift
@@ -1,7 +1,5 @@
+// RUN: %target-typecheck-verify-swift
 // RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
-
-// rdar://problem/88135912
-// XFAIL: *
 
 protocol P {
   associatedtype T
@@ -15,6 +13,7 @@ struct S : P {
 
 protocol R0 {
   associatedtype A where A : P, A == S
+  // expected-warning@-1 {{redundant conformance constraint 'S' : 'P'}}
 }
 
 ////
@@ -27,6 +26,7 @@ struct G<T> : P {}
 protocol R1 {
   associatedtype A
   associatedtype B where B : P, B == G<A>
+  // expected-warning@-1 {{redundant conformance constraint 'G<Self.A>' : 'P'}}
 }
 
 // CHECK-LABEL: concrete_conformances_in_protocol.(file).R2@
@@ -34,6 +34,7 @@ protocol R1 {
 
 protocol R2 {
   associatedtype A where A : P, A == G<B>
+  // expected-warning@-1 {{redundant conformance constraint 'G<Self.B>' : 'P'}}
   associatedtype B
 }
 
@@ -51,6 +52,7 @@ struct GG<T : P> : PP {}
 protocol RR3 {
   associatedtype A : P
   associatedtype B where B : PP, B == GG<A>
+  // expected-warning@-1 {{redundant conformance constraint 'GG<Self.A>' : 'PP'}}
 }
 
 // CHECK-LABEL: concrete_conformances_in_protocol.(file).RR4@
@@ -58,6 +60,7 @@ protocol RR3 {
 
 protocol RR4 {
   associatedtype A where A : PP, A == GG<B>
+  // expected-warning@-1 {{redundant conformance constraint 'GG<Self.B>' : 'PP'}}
   associatedtype B : P
 }
 
@@ -67,6 +70,7 @@ protocol RR4 {
 protocol RR5 {
   associatedtype A : PP
   associatedtype B where B : PP, B == GG<A.T>
+  // expected-warning@-1 {{redundant conformance constraint 'GG<Self.A.T>' : 'PP'}}
 }
 
 // CHECK-LABEL: concrete_conformances_in_protocol.(file).RR6@
@@ -74,5 +78,24 @@ protocol RR5 {
 
 protocol RR6 {
   associatedtype A where A : PP, A == GG<B.T>
+  // expected-warning@-1 {{redundant conformance constraint 'GG<Self.B.T>' : 'PP'}}
   associatedtype B : PP
 }
+
+protocol P1 {
+  associatedtype T : P1
+}
+
+struct GGG<U : P1> : P1 {
+  typealias T = GGG<GGG<U>>
+}
+
+// CHECK-LABEL: concrete_conformances_in_protocol.(file).P2@
+// CHECK-LABEL: Requirement signature: <Self where Self.[P2]T == GGG<Self.[P2]U>, Self.[P2]U : P1>
+
+protocol P2 {
+  associatedtype T : P1 where T == GGG<U>
+  // expected-warning@-1 {{redundant conformance constraint 'GGG<Self.U>' : 'P1'}}
+  associatedtype U : P1
+}
+

--- a/test/Generics/concrete_same_type_versus_anyobject.swift
+++ b/test/Generics/concrete_same_type_versus_anyobject.swift
@@ -25,7 +25,7 @@ extension G2 where U == S, U : AnyObject {}
 // CHECK: ExtensionDecl line={{.*}} base=G2
 // CHECK-NEXT: Generic signature: <U where U == C>
 extension G2 where U == C, U : AnyObject {}
-// expected-warning@-1 {{redundant constraint 'C' : 'AnyObject'}}
+// expected-warning@-1 {{redundant constraint 'U' : 'AnyObject'}}
 
 // CHECK: ExtensionDecl line={{.*}} base=G2
 // CHECK-NEXT: Generic signature: <U where U : C>

--- a/test/Generics/conditional_requirement_inference_in_protocol.swift
+++ b/test/Generics/conditional_requirement_inference_in_protocol.swift
@@ -1,18 +1,22 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=verify -requirement-machine-inferred-signatures=verify
-// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=verify -requirement-machine-inferred-signatures=verify 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=on -requirement-machine-inferred-signatures=on
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=on -requirement-machine-inferred-signatures=on 2>&1 | %FileCheck %s
+
+// FIXME: The redundant conformance warnings here should not be emitted, since
+// these requirements participate in conditional requirement inference.
 
 // CHECK-LABEL: conditional_requirement_inference_in_protocol.(file).Good@
 // CHECK-LABEL: Requirement signature: <Self where Self.[Good]T == [Self.[Good]U], Self.[Good]U : Equatable>
 
 protocol Good {
-  associatedtype T : Equatable // expected-warning {{redundant conformance constraint 'Self.T' : 'Equatable'}}
-  associatedtype U : Equatable where T == Array<U> // expected-note {{conformance constraint 'Self.T' : 'Equatable' implied here}}
+  associatedtype T : Equatable // expected-warning {{redundant conformance constraint 'Array<Self.U>' : 'Equatable'}}
+  associatedtype U : Equatable where T == Array<U>
+  // expected-warning@-1 {{redundant conformance constraint 'Self.U' : 'Equatable'}}
 }
 
 // CHECK-LABEL: conditional_requirement_inference_in_protocol.(file).Bad@
-// CHECK-LABEL: Requirement signature: <Self where Self.[Bad]T == [Self.[Bad]U]>
+// CHECK-LABEL: Requirement signature: <Self where Self.[Bad]T == [Self.[Bad]U], Self.[Bad]U : Equatable>
 
 protocol Bad {
-  associatedtype T : Equatable // expected-warning {{redundant conformance constraint 'Self.T' : 'Equatable'}}
-  associatedtype U where T == Array<U> // expected-note {{conformance constraint 'Self.T' : 'Equatable' implied here}}
+  associatedtype T : Equatable // expected-warning {{redundant conformance constraint 'Array<Self.U>' : 'Equatable'}}
+  associatedtype U where T == Array<U>
 }

--- a/test/Generics/derived_via_concrete_in_protocol.swift
+++ b/test/Generics/derived_via_concrete_in_protocol.swift
@@ -1,9 +1,5 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=off
-// RUN: %target-swift-frontend -debug-generic-signatures -typecheck %s -requirement-machine-protocol-signatures=off 2>&1 | %FileCheck %s
-
-// FIXME: Implement concrete contraction for the Requirement Machine's
-// RequirementSignatureRequest to get this to pass without turning off
-// -requirement-machine-protocol-signatures.
+// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=on
+// RUN: %target-swift-frontend -debug-generic-signatures -typecheck %s -requirement-machine-protocol-signatures=on 2>&1 | %FileCheck %s
 
 protocol P24 {
   associatedtype C: P20
@@ -29,8 +25,8 @@ class X3 { }
 // CHECK-NEXT: Requirement signature: <Self where Self.[P25a]A == X24<Self.[P25a]B>, Self.[P25a]B : P20>
 // CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.[P25a]A == X24<τ_0_0.[P25a]B>, τ_0_0.[P25a]B : P20>
 protocol P25a {
-  associatedtype A: P24 // expected-warning{{redundant conformance constraint 'Self.A' : 'P24'}}
-  associatedtype B: P20 where A == X24<B> // expected-note{{conformance constraint 'Self.A' : 'P24' implied here}}
+  associatedtype A: P24 // expected-warning{{redundant conformance constraint 'X24<Self.B>' : 'P24'}}
+  associatedtype B: P20 where A == X24<B>
 }
 
 // CHECK-LABEL: .P25b@
@@ -45,9 +41,9 @@ protocol P25b {
 // CHECK-NEXT: Requirement signature: <Self where Self.[P27a]A == X26<Self.[P27a]B>, Self.[P27a]B : X3>
 // CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.[P27a]A == X26<τ_0_0.[P27a]B>, τ_0_0.[P27a]B : X3>
 protocol P27a {
-  associatedtype A: P26 // expected-warning{{redundant conformance constraint 'Self.A' : 'P26'}}
+  associatedtype A: P26 // expected-warning{{redundant conformance constraint 'X26<Self.B>' : 'P26'}}
 
-  associatedtype B: X3 where A == X26<B> // expected-note{{conformance constraint 'Self.A' : 'P26' implied here}}
+  associatedtype B: X3 where A == X26<B>
 }
 
 // CHECK-LABEL: .P27b@

--- a/test/Generics/non_confluent.swift
+++ b/test/Generics/non_confluent.swift
@@ -43,11 +43,12 @@ struct S<U : P1> : P1 {
   typealias T = S<S<U>>
 }
 
-protocol P3 {
+protocol P3Base {
+  associatedtype T : P1
+  associatedtype U : P1
+}
+
+protocol P3 : P3Base where T == S<U> {
 // expected-error@-1 {{cannot build rewrite system for protocol; rule length limit exceeded}}
 // expected-note@-2 {{failed rewrite rule is [P3:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[concrete: S<S<S<S<S<S<S<S<S<S<S<S<S<S<[P3:U]>>>>>>>>>>>>>>] => [P3:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T]}}
-
-  associatedtype T : P1 where T == S<U>
-// expected-error@-1 {{type 'Self.U' does not conform to protocol 'P1'}}
-  associatedtype U : P1
 }

--- a/test/Generics/rdar91594361.swift
+++ b/test/Generics/rdar91594361.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-inferred-signatures=on 2>&1 | %FileCheck %s
+
+protocol P1 {
+  associatedtype T
+}
+
+protocol P2 {
+  associatedtype T : P3
+}
+
+protocol P3 {}
+
+struct G<T : P3> : P2 {}
+
+extension P1 where T : P2 {
+  // CHECK-LABEL: .foo@
+  // CHECK-NEXT: <Self, X where Self : P1, X : P3, Self.[P1]T == G<X>>
+  func foo<X>(_: X) where T == G<X> {}
+}
+

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=verify -requirement-machine-inferred-signatures=off
-// RUN: not %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=verify -requirement-machine-inferred-signatures=on 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -requirement-machine-protocol-signatures=on -requirement-machine-inferred-signatures=verify
+// RUN: not %target-swift-frontend -typecheck %s -debug-generic-signatures -requirement-machine-protocol-signatures=on -requirement-machine-inferred-signatures=on 2>&1 | %FileCheck %s
 
 protocol P1 { 
   func p1()

--- a/test/Generics/requirement_machine_diagnostics.swift
+++ b/test/Generics/requirement_machine_diagnostics.swift
@@ -295,18 +295,18 @@ func sameTypeConflicts() {
     fatalError()
   }
 
-  // expected-error@+1{{no type for 'T.Bar.Foo' can satisfy both 'T.Bar.Foo == X' and 'T.Bar.Foo == Z'}}
   func fail4<T: Barrable>(_ t: T) -> (Y, Z)
     where
     T.Bar == Y,
     T.Bar.Foo == Z {
+    // expected-error@-1{{generic signature requires types 'Y.Foo' (aka 'X') and 'Z' to be the same}}
     fatalError()
   }
 
-  // expected-error@+1{{no type for 'T.Bar.Foo' can satisfy both 'T.Bar.Foo == X' and 'T.Bar.Foo == Z'}}
   func fail5<T: Barrable>(_ t: T) -> (Y, Z)
     where
     T.Bar.Foo == Z,
+    // expected-error@-1{{generic signature requires types 'Y.Foo' (aka 'X') and 'Z' to be the same}}
     T.Bar == Y {
     fatalError()
   }

--- a/test/attr/accessibility_where_clause.swift
+++ b/test/attr/accessibility_where_clause.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=off
+// RUN: %target-typecheck-verify-swift -requirement-machine-inferred-signatures=on
 
 public class OuterClass {
   class InnerClass {}
@@ -16,9 +16,6 @@ public protocol PublicProto2 {
 //
 // FIXME: Once we no longer do that, come up with another strategy
 // to make the above diagnose.
-
-// FIXME: Get this working with the Requirement Machine, or decide that it should
-// be unsupported: rdar://90469477
 
 extension PublicProto2 where Self.T : OuterClass, Self.U == Self.T.InnerClass {
   public func cannotBePublic() {}

--- a/validation-test/compiler_crashers_2_fixed/rdar56398071.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar56398071.swift
@@ -1,6 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir -requirement-machine-protocol-signatures=off
-
-// TODO: Get this to pass with  -requirement-machine-protocol-signatures=on.
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -requirement-machine-protocol-signatures=on
 
 public protocol WrappedSignedInteger: SignedInteger where Stride == Int {
     typealias WrappedInteger = Int

--- a/validation-test/compiler_crashers_2_fixed/sr11639.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr11639.swift
@@ -1,6 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -primary-file %s -debug-generic-signatures -requirement-machine-protocol-signatures=off 2>&1 | %FileCheck %s
-
-// FIXME: Get this working with -requirement-machine-protocol-signatures=on again
+// RUN: %target-swift-frontend -emit-ir -primary-file %s -debug-generic-signatures -requirement-machine-protocol-signatures=on 2>&1 | %FileCheck %s
 
 public protocol FooProtocol {
   associatedtype Bar


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/58553

Concrete contraction is a hacky pre-processing pass to eliminate conformance
requirements that are made concrete; eg, if you have

    <T, U where T : P, T : G<U>, U : Q>

We eliminate `T : P` if `G<U> : P`.

Generalize this to handle type parameters as well, so that

    <T, U where T.X : P, T.X : G<U>, U : Q>

becomes

    <T, U where T.X : G<U>, U : Q>

This fixes a regression with the test case in test/Generics/rdar91594361.swift.

Fixes rdar://problem/91594361.