### PR TITLE
[Docs] Updating Getting started documentation from JIRA to Swift Issues

### DIFF
--- a/docs/HowToGuides/FirstPullRequest.md
+++ b/docs/HowToGuides/FirstPullRequest.md
@@ -15,12 +15,12 @@ contribution process.
 
 In case you don't have something specific you'd like to work on, such as
 implementing something for a Swift Evolution pitch, you could start off by
-working on a bug labeled `StarterBug` on [Swift JIRA][StarterBug]. If the
-bug hasn't been assigned to someone, check the comments in case someone has
+working on a bug labeled `StarterBug` on [Swift repository 'Issues' tab][StarterBug]. 
+If the issue hasn't been assigned to someone, check the comments in case someone has
 already started working on it. If not, feel free to assign it to yourself and
 start working on it!
 
-[StarterBug]: https://bugs.swift.org/issues/?jql=labels%20%3D%20StarterBug%20AND%20(status%20%3D%20Open%20OR%20status%20%3D%20Reopened)%20AND%20project%20%3D%20Swift
+[StarterBug]: https://github.com/apple/swift/issues?q=is%3Aissue+is%3Aopen+label%3AStarterBug
 
 ## Getting Help
 
@@ -159,10 +159,10 @@ to merge your changes. :tada:
 
 That's totally okay! There is no shame in that. You only have limited time and
 energy in a day. If you can, leave a comment on the bug report/pull request
-that you will not be able to continue and unassign yourself from the bug on
-JIRA. Don't worry about trying to explain _why_ you aren't able to contribute
-further. We understand. Unanticipated things come up all the time and you
-should do what _works for you_.
+that you will not be able to continue and unassign yourself from the issue on
+Github. Don't worry about trying to explain _why_ you aren't 
+able to contribute further. We understand. Unanticipated things come up all 
+the time and you should do what _works for you_.
 
 This point also applies if you don't have time right now but hope to get to
 something in the near future. Please don't feel sad or apologetic!

--- a/docs/HowToGuides/GettingStarted.md
+++ b/docs/HowToGuides/GettingStarted.md
@@ -119,7 +119,7 @@ Double-check that running `pwd` prints a path ending with `swift`.
 - If `update-checkout` failed, double-check that the absolute path to your
   working directory does not have non-ASCII characters.
 - If `update-checkout` failed and the absolute path to your working directory
-  had spaces in it, please [file a bug report][Swift JIRA] and change the path
+  had spaces in it, please [file a bug report][Swift Issues] and change the path
   to work around it.
 - Before running `update-checkout`, double-check that `swift` is the only
   repository inside the `swift-project` directory. Otherwise,
@@ -293,9 +293,8 @@ care when moving across branches.
   [meet the minimum required versions](#spot-check-dependencies).
 - Check if there are spaces in the paths being used by `build-script` in
   the log. While `build-script` should work with paths containing spaces,
-  sometimes bugs do slip through, such as
-  [SR-13441](https://bugs.swift.org/browse/SR-13441).
-  If this is the case, please [file a bug report][Swift JIRA] and change the path
+  sometimes bugs do slip through, such as [#55883](https://github.com/apple/swift/issues/55883).
+  If this is the case, please [file a bug report][Swift Issues] and change the path
   to work around it.
 - Check that your `build-script` invocation doesn't have typos. You can compare
   the flags you passed against the supported flags listed by
@@ -305,7 +304,7 @@ care when moving across branches.
   and looking at the first error may be more helpful than simply looking
   at the last error.
 - Check if others have encountered the same issue on the Swift forums or on
-  [Swift JIRA][].
+  [Swift repository 'Issues' tab][Swift Issues].
 - Create a new Swift forums thread in the Development category. Include
   information about your configuration and the errors you are seeing.
   - You can [create a gist](https://gist.github.com) with the entire build
@@ -313,7 +312,7 @@ care when moving across branches.
     build log in the post.
   - Include the output of `utils/update-checkout --dump-hashes`.
 
-[Swift JIRA]: https://bugs.swift.org
+[Swift Issues]: https://github.com/apple/swift/issues
 
 ## Editing code
 
@@ -621,4 +620,4 @@ Make sure you check out the following resources:
 If you see mistakes in the documentation (including typos, not just major
 errors) or identify gaps that you could potentially improve the contributing
 experience, please start a discussion on the forums, submit a pull request
-or file a bug report on [Swift JIRA][]. Thanks!
+or file a bug report on [Swift repository 'Issues' tab][Swift Issues]. Thanks!


### PR DESCRIPTION
<!-- What's in this pull request? -->
Just updating some links in the Getting Started documents.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
