### PR TITLE
Teach Type Deserialization About Parameterized Protocol Types

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -6361,6 +6361,7 @@ Expected<Type> TypeDeserializer::getTypeCheckedImpl() {
   CASE(SequenceArchetype)
   CASE(GenericTypeParam)
   CASE(ProtocolComposition)
+  CASE(ParameterizedProtocol)
   CASE(Existential)
   CASE(DependentMember)
   CASE(BoundGeneric)

--- a/test/Serialization/Inputs/parameterized_protocol_other.swift
+++ b/test/Serialization/Inputs/parameterized_protocol_other.swift
@@ -1,3 +1,11 @@
 public protocol MySequence<Element> {
   associatedtype Element
 }
+
+public struct MySequenceHolder<Element> {
+  public var seq: any MySequence<Element>
+
+  public init(seq: any MySequence<Element>) {
+    self.seq = seq
+  }
+}

--- a/test/Serialization/parameterized_protocol.swift
+++ b/test/Serialization/parameterized_protocol.swift
@@ -1,7 +1,10 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module %S/Inputs/parameterized_protocol_other.swift -emit-module-path %t/parameterized_protocol_other.swiftmodule
-// RUN: %target-typecheck-verify-swift -I%t
+// RUN: %target-swift-frontend -enable-parameterized-existential-types -emit-module %S/Inputs/parameterized_protocol_other.swift -emit-module-path %t/parameterized_protocol_other.swiftmodule
+// RUN: %target-typecheck-verify-swift -enable-parameterized-existential-types -I%t
 
 import parameterized_protocol_other
 
 func testParameterizedProtocol(_: some MySequence<Int>) {}
+func testParameterizedProtocol(x : any MySequence<Int>) -> MySequenceHolder<Int> {
+  return MySequenceHolder(seq: x)
+}


### PR DESCRIPTION
Clean up a thinko in the original deserialization code by making
the TypeDeserializer aware of parameterized existential types. The
deserialization code paths are already in place, we're just not
calling them!

rdar://93062561