### PR TITLE
Disable match-module-cache-with-compiler.swift test on Linux

### DIFF
--- a/test/SourceKit/Misc/match-module-cache-with-compiler.swift
+++ b/test/SourceKit/Misc/match-module-cache-with-compiler.swift
@@ -2,6 +2,10 @@
 // NOTE: Do not change this test without a review from @akyrtzi
 
 // REQUIRES: shell
+
+// https://github.com/apple/swift/issues/58786
+// UNSUPPORTED: OS=linux-gnu
+
 // RUN: %empty-directory(%t)
 
 // RUN: COMPILER_ARGS=( \


### PR DESCRIPTION
https://github.com/apple/swift/issues/58786