### PR TITLE
[CodeCompletion] Annotate variables with effectful getters

### DIFF
--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -870,6 +870,16 @@ void CompletionLookup::addVarDeclRef(const VarDecl *VD,
 
   if (isUnresolvedMemberIdealType(VarType))
     Builder.addFlair(CodeCompletionFlairBit::ExpressionSpecific);
+
+  if (auto Accessor = VD->getEffectfulGetAccessor()) {
+    if (auto AFT = getTypeOfMember(Accessor, dynamicLookupInfo)->getAs<AnyFunctionType>()) {
+      if (Accessor->hasImplicitSelfDecl()) {
+        AFT = AFT->getResult()->getAs<AnyFunctionType>();
+        assert(AFT);
+      }
+      addEffectsSpecifiers(Builder, AFT, Accessor);
+    }
+  }
 }
 
 /// Return whether \p param has a non-desirable default value for code

--- a/test/IDE/complete_effectful_accessor.swift
+++ b/test/IDE/complete_effectful_accessor.swift
@@ -1,0 +1,51 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+
+var globalAsyncVar: Int {
+  get async {
+    42
+  }
+}
+
+var globalAsyncThrowingVar: Int {
+  get async throws {
+    42
+  }
+}
+
+struct Foo {
+  var asyncProperty: Int {
+    get async {
+      42
+    }
+  }
+
+  var asyncThrowingProperty: Int {
+    get async throws {
+      42
+    }
+  }
+
+  func asyncFunc() async -> Int { 42 }
+  func asyncThrowingFunc() async throws -> Int { 42 }
+
+  func testMember(f: Foo) async throws {
+    f.#^MEMBER^#
+  }
+
+  func testGlobal() async throws {
+    #^GLOBAL^#
+  }
+}
+
+// MEMBER: Begin completions
+// MEMBER-DAG: Decl[InstanceVar]/CurrNominal:      asyncProperty[#Int#][' async'];
+// MEMBER-DAG: Decl[InstanceVar]/CurrNominal:      asyncThrowingProperty[#Int#][' async'][' throws'];
+// MEMBER-DAG: Decl[InstanceMethod]/CurrNominal:   asyncFunc()[' async'][#Int#];
+// MEMBER-DAG: Decl[InstanceMethod]/CurrNominal:   asyncThrowingFunc()[' async'][' throws'][#Int#];
+// MEMBER: End completions
+
+// GLOBAL: Begin completions
+// GLOBAL-DAG: Decl[GlobalVar]/CurrModule:         globalAsyncVar[#Int#][' async'];
+// GLOBAL-DAG: Decl[GlobalVar]/CurrModule:         globalAsyncThrowingVar[#Int#][' async'][' throws']
+// GLOBAL: End completions


### PR DESCRIPTION
Previously, we weren’t annotation code completion results for variables with async or throwing getters as 'async' or 'throws'.

rdar://93085311