### PR TITLE
Fix source range computation of regex literals for diagnostics

### DIFF
--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -2677,6 +2677,16 @@ Token Lexer::getTokenAtLocation(const SourceManager &SM, SourceLoc Loc,
   // we need to lex just the comment token.
   Lexer L(FakeLangOpts, SM, BufferID, nullptr, LexerMode::Swift,
           HashbangMode::Allowed, CRM);
+
+  if (SM.isRegexLiteralStart(Loc)) {
+    // HACK: If this was previously lexed as a regex literal, make sure we
+    // re-lex with forward slash regex literals enabled to make sure we get an
+    // accurate length. We can force EnableExperimentalStringProcessing on, as
+    // we know it must have been enabled to parse the regex in the first place.
+    FakeLangOpts.EnableExperimentalStringProcessing = true;
+    L.ForwardSlashRegexMode = LexerForwardSlashRegexMode::Always;
+  }
+
   L.restoreState(State(Loc));
   return L.peekNextToken();
 }

--- a/lib/Parse/ParseRegex.cpp
+++ b/lib/Parse/ParseRegex.cpp
@@ -54,6 +54,8 @@ ParserResult<Expr> Parser::parseExprRegexLiteral() {
                             /*diagBaseLoc*/ getBridgedSourceLoc(Tok.getLoc()),
                             getBridgedDiagnosticEngine(&Diags));
   auto loc = consumeToken();
+  SourceMgr.recordRegexLiteralStartLoc(loc);
+
   if (hadError) {
     return makeParserResult(new (Context) ErrorExpr(loc));
   }

--- a/test/StringProcessing/Sema/regex_literal_diagnostics.swift
+++ b/test/StringProcessing/Sema/regex_literal_diagnostics.swift
@@ -1,0 +1,20 @@
+// RUN: %target-typecheck-verify-swift -enable-bare-slash-regex -disable-availability-checking
+
+// REQUIRES: swift_in_compiler
+
+postfix operator ^^
+postfix func ^^ <T> (_ x: T) -> T { x }
+
+prefix operator !!
+prefix func !! <T> (_ x: T) -> T { x }
+
+// rdar://92469692 - Make sure we get a correct fix-it location here.
+func foo<T>(_ x: T, y: Int) {} // expected-note 3{{'foo(_:y:)' declared here}}
+foo(/a/) // expected-error {{missing argument for parameter 'y' in call}} {{8-8=, y: <#Int#>}}
+foo(/, /) // expected-error {{missing argument for parameter 'y' in call}} {{9-9=, y: <#Int#>}}
+foo(/a/^^) // expected-error {{missing argument for parameter 'y' in call}} {{10-10=, y: <#Int#>}}
+
+func bar<T>(x: Int, _ y: T) {} // expected-note 3{{'bar(x:_:)' declared here}}
+bar(/a/) // expected-error {{missing argument for parameter 'x' in call}} {{5-5=x: <#Int#>, }}
+bar(/, /) // expected-error {{missing argument for parameter 'x' in call}} {{5-5=x: <#Int#>, }}
+bar(!!/a/) // expected-error {{missing argument for parameter 'x' in call}} {{5-5=x: <#Int#>, }}


### PR DESCRIPTION
Start recording the locations of regex literals on the SourceManager, and using this information to re-lex them as regex literals. This is unfortunately needed to ensure we correctly compute source ranges for diagnostic logic.

rdar://92469692
