### PR TITLE
[Serialization] Disallow overriding swiftmodules per tag logic in release builds

### DIFF
--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -311,6 +311,7 @@ static ValidationInfo validateControlBlock(
       // Tagged compilers should only load modules if they were
       // produced by the exact same compiler tag.
 
+#ifndef NDEBUG
       // Disable this restriction for compiler testing by setting this
       // env var to any value.
       static const char* ignoreRevision =
@@ -323,14 +324,16 @@ static ValidationInfo validateControlBlock(
       // revision.
       static const char* forcedDebugRevision =
         ::getenv("SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION");
+#else // NDEBUG
+      static const char* forcedDebugRevision = nullptr;
+#endif
 
       bool isCompilerTagged = forcedDebugRevision ||
         !version::Version::getCurrentCompilerVersion().empty();
-
-      StringRef moduleRevision = blobData;
       if (isCompilerTagged) {
         StringRef compilerRevision = forcedDebugRevision ?
           forcedDebugRevision : version::getSwiftRevision();
+        StringRef moduleRevision = blobData;
         if (moduleRevision != compilerRevision)
           result.status = Status::RevisionIncompatible;
       }

--- a/test/Serialization/restrict-swiftmodule-to-revision.swift
+++ b/test/Serialization/restrict-swiftmodule-to-revision.swift
@@ -1,3 +1,6 @@
+/// Tagged compilers should only load swiftmodules built by the same compiler tag.
+// REQUIRES: asserts
+
 // RUN: %empty-directory(%t/cache)
 // RUN: %empty-directory(%t/build)
 // RUN: %{python} %utils/split_file.py -o %t %s


### PR DESCRIPTION
Move some testing logic to builds with asserts only and make sure it's not used in production where tracking env var is almost impossible.