### PR TITLE
[5.7] caches: tweak the Windows toolchain build

### DIFF
--- a/cmake/caches/Windows-arm64.cmake
+++ b/cmake/caches/Windows-arm64.cmake
@@ -66,6 +66,8 @@ set(LLVM_TOOL_LLVM_SHLIB_BUILD NO CACHE BOOL "")
 # Avoid swig dependency for lldb
 set(LLDB_ALLOW_STATIC_BINDINGS YES CACHE BOOL "")
 set(LLDB_USE_STATIC_BINDINGS YES CACHE BOOL "")
+set(LLDB_ENABLE_PYTHON YES CACHE BOOL "")
+set(LLDB_EMBED_PYTHON_HOME NO CACHE BOOL "")
 
 # This requires perl which may not be available on Windows
 set(SWIFT_INCLUDE_DOCS NO CACHE BOOL "")

--- a/cmake/caches/Windows-x86_64.cmake
+++ b/cmake/caches/Windows-x86_64.cmake
@@ -66,6 +66,8 @@ set(LLVM_TOOL_LLVM_SHLIB_BUILD NO CACHE BOOL "")
 # Avoid swig dependency for lldb
 set(LLDB_ALLOW_STATIC_BINDINGS YES CACHE BOOL "")
 set(LLDB_USE_STATIC_BINDINGS YES CACHE BOOL "")
+set(LLDB_ENABLE_PYTHON YES CACHE BOOL "")
+set(LLDB_EMBED_PYTHON_HOME NO CACHE BOOL "")
 
 # This requires perl which may not be available on Windows
 set(SWIFT_INCLUDE_DOCS NO CACHE BOOL "")


### PR DESCRIPTION
Update the toolchain configuration to disable the python home embedding.
This should allow us to be more freestanding of the python location and
give us better control of the python library being used.

(cherry picked from commit 699202656a2b2ffa4f4ff4a718927c6722e0d460)

Nominating this for the 5.7 release.

This is a fairly important change for Windows - it changes the way that we build LLDB.  It is completely isolated to Windows and a build time configuration change strictly limited to LLDB on Windows.  This change has been on main for a while and should be stable, so I expect this to be low risk for Windows.  This change enables some basic functionality with LLDB in VSCode.