### PR TITLE
[next] Fixes for various test failures on rebranch

### DIFF
--- a/include/swift/Serialization/SerializationOptions.h
+++ b/include/swift/Serialization/SerializationOptions.h
@@ -29,9 +29,9 @@ namespace swift {
     SerializationOptions &operator=(SerializationOptions &&) = default;
     ~SerializationOptions() = default;
 
-    const char *OutputPath = nullptr;
-    const char *DocOutputPath = nullptr;
-    const char *SourceInfoOutputPath = nullptr;
+    StringRef OutputPath;
+    StringRef DocOutputPath;
+    StringRef SourceInfoOutputPath;
     std::string ABIDescriptorPath;
     bool emptyABIDescriptor = false;
     llvm::VersionTuple UserModuleVersion;

--- a/lib/Driver/FrontendUtil.cpp
+++ b/lib/Driver/FrontendUtil.cpp
@@ -46,7 +46,7 @@ static void removeSupplementaryOutputs(llvm::opt::ArgList &ArgList) {
 
   for (llvm::opt::Arg *Arg : ArgList.getArgs()) {
     if (!Arg)
-      return;
+      continue;
 
     const llvm::opt::Option &Opt = Arg->getOption();
     if (Opt.hasFlag(options::SupplementaryOutput))
@@ -57,6 +57,7 @@ static void removeSupplementaryOutputs(llvm::opt::ArgList &ArgList) {
     ArgList.eraseArg(Specifier);
   }
 }
+
 bool swift::driver::getSingleFrontendInvocationFromDriverArguments(
     ArrayRef<const char *> Argv, DiagnosticEngine &Diags,
     llvm::function_ref<bool(ArrayRef<const char *> FrontendArgs)> Action,

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -140,9 +140,9 @@ SerializationOptions CompilerInvocation::computeSerializationOptions(
   const FrontendOptions &opts = getFrontendOptions();
 
   SerializationOptions serializationOpts;
-  serializationOpts.OutputPath = outs.ModuleOutputPath.c_str();
-  serializationOpts.DocOutputPath = outs.ModuleDocOutputPath.c_str();
-  serializationOpts.SourceInfoOutputPath = outs.ModuleSourceInfoOutputPath.c_str();
+  serializationOpts.OutputPath = outs.ModuleOutputPath;
+  serializationOpts.DocOutputPath = outs.ModuleDocOutputPath;
+  serializationOpts.SourceInfoOutputPath = outs.ModuleSourceInfoOutputPath;
   serializationOpts.GroupInfoPath = opts.GroupInfoPath.c_str();
   if (opts.SerializeBridgingHeader && !outs.ModuleOutputPath.empty())
     serializationOpts.ImportedHeader = opts.ImplicitObjCHeaderPath;

--- a/lib/Frontend/ModuleInterfaceBuilder.cpp
+++ b/lib/Frontend/ModuleInterfaceBuilder.cpp
@@ -273,7 +273,7 @@ bool ModuleInterfaceBuilder::buildSwiftModuleInternal(
     // optimization pipeline.
     SerializationOptions SerializationOpts;
     std::string OutPathStr = OutPath.str();
-    SerializationOpts.OutputPath = OutPathStr.c_str();
+    SerializationOpts.OutputPath = OutPathStr;
     SerializationOpts.ModuleLinkName = FEOpts.ModuleLinkName;
     SerializationOpts.AutolinkForceLoad =
       !subInvocation.getIRGenOptions().ForceLoadSymbolName.empty();

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1333,7 +1333,7 @@ static bool serializeSIB(SILModule *SM, const PrimarySpecificPaths &PSPs,
   assert(!moduleOutputPath.empty() && "must have an output path");
 
   SerializationOptions serializationOpts;
-  serializationOpts.OutputPath = moduleOutputPath.c_str();
+  serializationOpts.OutputPath = moduleOutputPath;
   serializationOpts.SerializeAllSIL = true;
   serializationOpts.IsSIB = true;
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -5892,7 +5892,7 @@ void swift::serializeToBuffers(
   std::unique_ptr<llvm::MemoryBuffer> *moduleSourceInfoBuffer,
   const SILModule *M) {
 
-  assert(!withNullAsEmptyStringRef(options.OutputPath).empty());
+  assert(!options.OutputPath.empty());
   {
     FrontendStatsTracer tracer(getContext(DC).Stats,
                                "Serialization, swiftmodule, to buffer");
@@ -5911,10 +5911,11 @@ void swift::serializeToBuffers(
     emitABIDescriptor(DC, options);
     if (moduleBuffer)
       *moduleBuffer = std::make_unique<llvm::SmallVectorMemoryBuffer>(
-                        std::move(buf), options.OutputPath);
+          std::move(buf), options.OutputPath,
+          /*RequiresNullTerminator=*/false);
   }
 
-  if (!withNullAsEmptyStringRef(options.DocOutputPath).empty()) {
+  if (!options.DocOutputPath.empty()) {
     FrontendStatsTracer tracer(getContext(DC).Stats,
                                "Serialization, swiftdoc, to buffer");
     llvm::SmallString<1024> buf;
@@ -5928,10 +5929,11 @@ void swift::serializeToBuffers(
     });
     if (moduleDocBuffer)
       *moduleDocBuffer = std::make_unique<llvm::SmallVectorMemoryBuffer>(
-                           std::move(buf), options.DocOutputPath);
+          std::move(buf), options.DocOutputPath,
+          /*RequiresNullTerminator=*/false);
   }
 
-  if (!withNullAsEmptyStringRef(options.SourceInfoOutputPath).empty()) {
+  if (!options.SourceInfoOutputPath.empty()) {
     FrontendStatsTracer tracer(getContext(DC).Stats,
                                "Serialization, swiftsourceinfo, to buffer");
     llvm::SmallString<1024> buf;
@@ -5945,7 +5947,8 @@ void swift::serializeToBuffers(
     });
     if (moduleSourceInfoBuffer)
       *moduleSourceInfoBuffer = std::make_unique<llvm::SmallVectorMemoryBuffer>(
-          std::move(buf), options.SourceInfoOutputPath);
+          std::move(buf), options.SourceInfoOutputPath,
+          /*RequiresNullTerminator=*/false);
   }
 }
 
@@ -5954,12 +5957,12 @@ void swift::serialize(ModuleOrSourceFile DC,
                       const symbolgraphgen::SymbolGraphOptions &symbolGraphOptions,
                       const SILModule *M,
                       const fine_grained_dependencies::SourceFileDepGraph *DG) {
-  assert(!withNullAsEmptyStringRef(options.OutputPath).empty());
+  assert(!options.OutputPath.empty());
 
-  if (StringRef(options.OutputPath) == "-") {
+  if (options.OutputPath == "-") {
     // Special-case writing to stdout.
     Serializer::writeToStream(llvm::outs(), DC, M, options, DG);
-    assert(withNullAsEmptyStringRef(options.DocOutputPath).empty());
+    assert(options.DocOutputPath.empty());
     return;
   }
 
@@ -5974,7 +5977,7 @@ void swift::serialize(ModuleOrSourceFile DC,
   if (hadError)
     return;
 
-  if (!withNullAsEmptyStringRef(options.DocOutputPath).empty()) {
+  if (!options.DocOutputPath.empty()) {
     (void)withOutputFile(getContext(DC).Diags,
                          options.DocOutputPath,
                          [&](raw_ostream &out) {
@@ -5985,7 +5988,7 @@ void swift::serialize(ModuleOrSourceFile DC,
     });
   }
 
-  if (!withNullAsEmptyStringRef(options.SourceInfoOutputPath).empty()) {
+  if (!options.SourceInfoOutputPath.empty()) {
     (void)withOutputFile(getContext(DC).Diags,
                          options.SourceInfoOutputPath,
                          [&](raw_ostream &out) {

--- a/test/DebugInfo/async-args.swift
+++ b/test/DebugInfo/async-args.swift
@@ -10,10 +10,10 @@ func withGenericArg<T>(_ msg: T) async {
   // This odd debug info is part of a contract with CoroSplit/CoroFrame to fix
   // this up after coroutine splitting.
   // CHECK-LABEL: {{^define .*}} @"$s1M14withGenericArgyyxYalF"(%swift.context* swiftasync %0
-  // CHECK: call void @llvm.dbg.declare(metadata %swift.type** %
-  // CHECK-SAME:   metadata ![[TAU:[0-9]+]], metadata !DIExpression()
-  // CHECK: call void @llvm.dbg.declare(metadata %swift.opaque** %
-  // CHECK-SAME:   metadata ![[MSG:[0-9]+]], metadata !DIExpression(DW_OP_deref))
+  // CHECK: call void @llvm.dbg.declare(metadata %swift.context* %0
+  // CHECK-SAME:   metadata ![[MSG:[0-9]+]], metadata !DIExpression(DW_OP_plus_uconst, {{.*}}DW_OP_deref))
+  // CHECK: call void @llvm.dbg.declare(metadata %swift.context* %0
+  // CHECK-SAME:   metadata ![[TAU:[0-9]+]], metadata !DIExpression(DW_OP_plus_uconst,
 
   await forceSplit()
   // CHECK-LABEL: {{^define .*}} @"$s1M14withGenericArgyyxYalFTQ0_"(i8* swiftasync %0)

--- a/test/PrintAsObjC/Inputs/arc-conventions.m
+++ b/test/PrintAsObjC/Inputs/arc-conventions.m
@@ -1,7 +1,7 @@
 @import Foundation;
 #import "swift.h"
 
-int main() {
+int main(void) {
   @autoreleasepool {
     Test *test = [[Test alloc] init];
     id result = [test initAllTheThings]; // CHECK: method called

--- a/test/ScanDependencies/module_deps_cache_reuse.swift
+++ b/test/ScanDependencies/module_deps_cache_reuse.swift
@@ -111,11 +111,11 @@ import SubE
 // CHECK-NEXT: "-frontend"
 // CHECK-NEXT: "-only-use-extra-clang-opts
 // CHECK-NOT: "BUILD_DIR/bin/clang"
-// CHECK-NEXT: "-Xcc"
+// CHECK: "-Xcc"
 // CHECK-NEXT: "-fsyntax-only",
-// CHECK:      "-fsystem-module",
-// CHECK-NEXT: "-emit-pcm",
-// CHECK-NEXT: "-module-name",
+// CHECK: "-fsystem-module",
+// CHECK: "-emit-pcm",
+// CHECK: "-module-name",
 // CHECK-NEXT: "C"
 
 /// --------Swift module E
@@ -129,7 +129,7 @@ import SubE
 // CHECK-SAME: E.swiftinterface
 
 /// --------Swift module F
-// CHECK:      "modulePath": "F.swiftmodule",
+// CHECK-LABEL: "modulePath": "F.swiftmodule",
 // CHECK-NEXT: "sourceFiles": [
 // CHECK-NEXT: ],
 // CHECK-NEXT: "directDependencies": [

--- a/test/Sema/availability_and_delayed_parsing.swift
+++ b/test/Sema/availability_and_delayed_parsing.swift
@@ -21,7 +21,7 @@
 
 @available(macOS 10.12, *)
 public func foo() { }
-// TRC-API: (root versions=[10.10.0,+Inf)
+// TRC-API: (root versions=[10.10,+Inf)
 // TRC-API:   (decl versions=[10.12,+Inf) decl=foo()
 
 #if canImport(Swift)

--- a/test/Sema/availability_refinement_contexts.swift
+++ b/test/Sema/availability_refinement_contexts.swift
@@ -3,7 +3,7 @@
 
 // REQUIRES: OS=macosx
 
-// CHECK: {{^}}(root versions=[10.{{[0-9]+}}.0,+Inf)
+// CHECK: {{^}}(root versions=[10.{{[0-9]+}},+Inf)
 
 // CHECK-NEXT: {{^}}  (decl versions=[10.51,+Inf) decl=SomeClass
 // CHECK-NEXT: {{^}}    (decl versions=[10.52,+Inf) decl=someMethod()

--- a/test/Sema/availability_refinement_contexts_target_min_inlining.swift
+++ b/test/Sema/availability_refinement_contexts_target_min_inlining.swift
@@ -11,8 +11,8 @@
 // CHECK-tvos: {{^}}(root versions=[9.0,+Inf)
 // CHECK-watchos: {{^}}(root versions=[2.0,+Inf)
 
-// CHECK-macosx-NEXT: {{^}}  (api_boundary versions=[10.15.0,+Inf) decl=foo()
-// CHECK-ios-NEXT: {{^}}  (api_boundary versions=[13.0.0,+Inf) decl=foo()
-// CHECK-tvos-NEXT: {{^}}  (api_boundary versions=[13.0.0,+Inf) decl=foo()
-// CHECK-watchos-NEXT: {{^}}  (api_boundary versions=[6.0.0,+Inf) decl=foo()
+// CHECK-macosx-NEXT: {{^}}  (api_boundary versions=[10.15,+Inf) decl=foo()
+// CHECK-ios-NEXT: {{^}}  (api_boundary versions=[13.0,+Inf) decl=foo()
+// CHECK-tvos-NEXT: {{^}}  (api_boundary versions=[13.0,+Inf) decl=foo()
+// CHECK-watchos-NEXT: {{^}}  (api_boundary versions=[6.0,+Inf) decl=foo()
 func foo() {}

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -1434,7 +1434,7 @@ protocol HasMethodF {
 
 class TriesToConformWithFunctionIntroducedOn10_51 : HasMethodF {
   @available(OSX, introduced: 10.51)
-  func f(_ p: Int) { } // expected-error {{protocol 'HasMethodF' requires 'f' to be available in macOS 10.50.0 and newer}}
+  func f(_ p: Int) { } // expected-error {{protocol 'HasMethodF' requires 'f' to be available in macOS 10.50 and newer}}
 }
 
 
@@ -1450,7 +1450,7 @@ class SuperHasMethodF {
     func f(_ p: Int) { } // expected-note {{'f' declared here}}
 }
 
-class TriesToConformWithPotentiallyUnavailableFunctionInSuperClass : SuperHasMethodF, HasMethodF { // expected-error {{protocol 'HasMethodF' requires 'f' to be available in macOS 10.50.0 and newer}}
+class TriesToConformWithPotentiallyUnavailableFunctionInSuperClass : SuperHasMethodF, HasMethodF { // expected-error {{protocol 'HasMethodF' requires 'f' to be available in macOS 10.50 and newer}}
   // The conformance here is generating an error on f in the super class.
 }
 
@@ -1474,7 +1474,7 @@ class ConformsByOverridingFunctionInSuperClass : SuperHasMethodF, HasMethodF {
 class HasNoMethodF1 { }
 extension HasNoMethodF1 : HasMethodF {
   @available(OSX, introduced: 10.51)
-  func f(_ p: Int) { } // expected-error {{protocol 'HasMethodF' requires 'f' to be available in macOS 10.50.0 and newer}}
+  func f(_ p: Int) { } // expected-error {{protocol 'HasMethodF' requires 'f' to be available in macOS 10.50 and newer}}
 }
 
 class HasNoMethodF2 { }

--- a/test/SymbolGraph/Module/Module.swift
+++ b/test/SymbolGraph/Module/Module.swift
@@ -14,7 +14,6 @@ public struct S {
 // CHECK:        vendor
 // CHECK-NEXT:   operatingSystem
 // CHECK-NEXT:     name
-// CHECK-NEXT:     minimumVersion 
+// CHECK-NEXT:     minimumVersion
 // CHECK-NEXT:       major
 // CHECK-NEXT:       minor
-// CHECK-NEXT:       patch

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -3111,12 +3111,9 @@ void serializeSyntaxTreeAsJson(
   auto StartClock = clock();
   // 4096 is a heuristic buffer size that appears to usually be able to fit an
   // incremental syntax tree
-  size_t ReserveBufferSize = 4096;
-  std::string SyntaxTreeString;
-  SyntaxTreeString.reserve(ReserveBufferSize);
+  llvm::SmallString<4096> SyntaxTreeString;
   {
-    llvm::raw_string_ostream SyntaxTreeStream(SyntaxTreeString);
-    SyntaxTreeStream.SetBufferSize(ReserveBufferSize);
+    llvm::raw_svector_ostream SyntaxTreeStream(SyntaxTreeString);
     swift::json::Output::UserInfoMap JsonUserInfo;
     swift::json::Output SyntaxTreeOutput(SyntaxTreeStream, JsonUserInfo,
                                          /*PrettyPrint=*/false);

--- a/tools/sil-func-extractor/SILFunctionExtractor.cpp
+++ b/tools/sil-func-extractor/SILFunctionExtractor.cpp
@@ -356,7 +356,7 @@ int main(int argc, char **argv) {
     }
 
     SerializationOptions serializationOpts;
-    serializationOpts.OutputPath = OutputFile.c_str();
+    serializationOpts.OutputPath = OutputFile;
     serializationOpts.SerializeAllSIL = true;
     serializationOpts.IsSIB = true;
 

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -817,7 +817,7 @@ int main(int argc, char **argv) {
     }
 
     SerializationOptions serializationOpts;
-    serializationOpts.OutputPath = OutputFile.c_str();
+    serializationOpts.OutputPath = OutputFile;
     serializationOpts.SerializeAllSIL = EmitSIB;
     serializationOpts.IsSIB = EmitSIB;
 


### PR DESCRIPTION
Mostly just small test fixes. The only code changes are a mistake I made in fixing a compilation error (798134f605a21bf73e89c45c23558e94f2fd1b77) and 427a689a966343a99b67ae81c7d1f31decfbe16b which replaces some `const char *` fields with `StringRef` to fix an overload resolution.

@xymus f2bd6ce9cbe93287cd0119441ebb05060c3f067f
@ahoppen a6a6ae456ae549edcc9ee2da387802b9e46e0198
@artemcm f05fab3f3c03cae715859bf41dbb69b70d8ac392
@adrian-prantl 50ecb47a4605edceb9a884791c910394535ec907
@nkcsgexi 427a689a966343a99b67ae81c7d1f31decfbe16b
