### PR TITLE
[Sema] Allow optional hole propagation in code completion mode

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1993,11 +1993,16 @@ bool TypeVariableBinding::attempt(ConstraintSystem &cs) const {
   // without any contextual information, so even though `x` would get
   // bound to result type of the chain, underlying type variable wouldn't
   // be resolved, so we need to propagate holes up the conversion chain.
-  if (TypeVar->getImpl().canBindToHole() &&
-      srcLocator->directlyAt<OptionalEvaluationExpr>()) {
-    if (auto objectTy = type->getOptionalObjectType()) {
-      if (auto *typeVar = objectTy->getAs<TypeVariableType>())
-        cs.recordPotentialHole(typeVar);
+  // Also propagate in code completion mode because in some cases code
+  // completion relies on type variable being a potential hole.
+  if (TypeVar->getImpl().canBindToHole()) {
+    if (srcLocator->directlyAt<OptionalEvaluationExpr>() ||
+        cs.isForCodeCompletion()) {
+      if (auto objectTy = type->getOptionalObjectType()) {
+        if (auto *typeVar = objectTy->getAs<TypeVariableType>()) {
+          cs.recordPotentialHole(typeVar);
+        }
+      }
     }
   }
 

--- a/validation-test/IDE/stress_tester_issues_fixed/rdar93127707.swift
+++ b/validation-test/IDE/stress_tester_issues_fixed/rdar93127707.swift
@@ -1,0 +1,9 @@
+// RUN: %swift-ide-test -code-completion -source-filename %s -code-completion-token COMPLETE | %FileCheck %s
+
+struct Foo {
+  var x: Int = {
+    guard let foo = #^COMPLETE^#
+  }()
+}
+
+// CHECK: Decl[Struct]/CurrModule:            Foo[#Foo#];


### PR DESCRIPTION
<!-- What's in this pull request? -->
In some cases code completion relies on optional type var being a potential hole, so enable option hole propagation when solver is in code completion mode.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Fixes #58840.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
