### PR TITLE
[5.7][SourceKit] Guard DependencyStamps with a lock

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -308,12 +308,20 @@ class ASTBuildOperation
   /// can be determined at construction time of the \c ASTBuildOperation.
   const std::vector<FileContent> FileContents;
 
+  /// Guards \c DependencyStamps. This prevents reading from \c DependencyStamps
+  /// while it is being modified. It does not provide any ordering gurantees
+  /// that \c DependencyStamps have been computed in \c buildASTUnit before they
+  /// are accessed in \c matchesSourceState but that's fine (see comment on
+  /// \c DependencyStamps).
+  llvm::sys::Mutex DependencyStampsMtx;
+
   /// \c DependencyStamps contains the stamps of all module depenecies needed
   /// for the AST build. These stamps are only known after the AST is built.
   /// Before the AST has been built, we thus assume that all dependency stamps
   /// match. This seems to be a reasonable assumption since the dependencies
   /// shouldn't change (much) in the time between an \c ASTBuildOperation is
   /// created and until it produced an AST.
+  /// Must only be accessed if \c DependencyStampsMtx has been claimed.
   SmallVector<std::pair<std::string, BufferStamp>, 8> DependencyStamps = {};
 
   /// The ASTManager from which this operation got scheduled. Used to update
@@ -898,6 +906,8 @@ bool ASTBuildOperation::matchesSourceState(
     }
   }
 
+  llvm::sys::ScopedLock L(DependencyStampsMtx);
+
   for (auto &Dependency : DependencyStamps) {
     if (Dependency.second !=
         ASTManager->Impl.getBufferStamp(Dependency.first, OtherFileSystem))
@@ -1069,9 +1079,12 @@ ASTUnitRef ASTBuildOperation::buildASTUnit(std::string &Error) {
   collectModuleDependencies(CompIns.getMainModule(), Visited, Filenames);
   // FIXME: There exists a small window where the module file may have been
   // modified after compilation finished and before we get its stamp.
-  for (auto &Filename : Filenames) {
-    DependencyStamps.push_back(std::make_pair(
-        Filename, ASTManager->Impl.getBufferStamp(Filename, FileSystem)));
+  {
+    llvm::sys::ScopedLock L(DependencyStampsMtx);
+    for (auto &Filename : Filenames) {
+      DependencyStamps.push_back(std::make_pair(
+          Filename, ASTManager->Impl.getBufferStamp(Filename, FileSystem)));
+    }
   }
 
   // Since we only typecheck the primary file (plus referenced constructs


### PR DESCRIPTION
* **Explanation**: We might run into situations where `matchesSourceState` reads `DependencyStamps` while they are being written in `buildASTUnit`, causing a crash. Guard `DependencyStamps` by a mutex to avoid this problem. We don’t need to provide any ordering guarantees about whether `DependencyStamps` have been computed in are accessed because we already assume that the dependencies shouldn't change (much) in the time between an `ASTBuildOperation` is created and until it produced an AST. I made sure that the mutex can’t introduce deadlocks.
* **Scope**: Non code-completion SourceKit requests
* **Risk**: Low
* **Issue**: rdar://92748564
* **Reviewer**: @bnbarham on https://github.com/apple/swift/pull/58681