### PR TITLE
[SymbolGraphGen] Add filename and module name to symbols' doc comments

### DIFF
--- a/test/SourceKit/CursorInfo/cursor_info_multi_module.swift
+++ b/test/SourceKit/CursorInfo/cursor_info_multi_module.swift
@@ -58,7 +58,9 @@ func test() {
 // CHECK-NORMAL-NEXT:       },
 // CHECK-NORMAL-NEXT:       "text": "Comment from A"
 // CHECK-NORMAL-NEXT:     }
-// CHECK-NORMAL-NEXT:   ]
+// CHECK-NORMAL-NEXT:   ],
+// CHECK-NORMAL-NEXT:   "module": "somemod",
+// CHECK-NORMAL-NEXT:   "uri": "file://{{.*}}cursor_info_multi_module.swift"
 // CHECK-NORMAL-NEXT: },
 // CHECK-NORMAL:      "location": {
 // CHECK-NORMAL-NEXT:   "position": {
@@ -87,7 +89,9 @@ func test() {
 // CHECK-BEFORE-NEXT:       },
 // CHECK-BEFORE-NEXT:       "text": "Comment from B"
 // CHECK-BEFORE-NEXT:     }
-// CHECK-BEFORE-NEXT:   ]
+// CHECK-BEFORE-NEXT:   ],
+// CHECK-BEFORE-NEXT:   "module": "somemod",
+// CHECK-BEFORE-NEXT:   "uri": "file://{{.*}}cursor_info_multi_module.swift"
 // CHECK-BEFORE-NEXT: },
 // CHECK-BEFORE:      "location": {
 // CHECK-BEFORE-NEXT:   "position": {
@@ -117,7 +121,9 @@ func test() {
 // CHECK-IN-NEXT:       },
 // CHECK-IN-NEXT:       "text": "Comment from #sourceLocation"
 // CHECK-IN-NEXT:     }
-// CHECK-IN-NEXT:   ]
+// CHECK-IN-NEXT:   ],
+// CHECK-IN-NEXT:   "module": "somemod",
+// CHECK-IN-NEXT:   "uri": "file://doesnotexist.swift"
 // CHECK-IN-NEXT: },
 // CHECK-IN:      "location": {
 // CHECK-IN-NEXT:   "position": {
@@ -146,7 +152,9 @@ func test() {
 // CHECK-AFTER-NEXT:       },
 // CHECK-AFTER-NEXT:       "text": "Comment from B"
 // CHECK-AFTER-NEXT:     }
-// CHECK-AFTER-NEXT:   ]
+// CHECK-AFTER-NEXT:   ],
+// CHECK-AFTER-NEXT:   "module": "somemod",
+// CHECK-AFTER-NEXT:   "uri": "file://{{.*}}cursor_info_multi_module.swift"
 // CHECK-AFTER-NEXT: },
 // CHECK-AFTER:      "location": {
 // CHECK-AFTER-NEXT:   "position": {

--- a/test/SourceKit/CursorInfo/cursor_symbol_graph_objc.swift
+++ b/test/SourceKit/CursorInfo/cursor_symbol_graph_objc.swift
@@ -89,7 +89,9 @@ func test(s: ObjCStruct) {
 // CHECK-FUNC:           {
 // CHECK-FUNC:             "text": "someFunc doc"
 // CHECK-FUNC:           }
-// CHECK-FUNC:         ]
+// CHECK-FUNC:         ],
+// CHECK-FUNC:         "module": "MyMod",
+// CHECK-FUNC:         "uri": "file://{{.*}}mod{{\\\\|/}}M.h"
 // CHECK-FUNC:       },
 // CHECK-FUNC:       "functionSignature": {
 // CHECK-FUNC:         "returns": [
@@ -164,7 +166,9 @@ struct ObjCStruct {
   // CHECK-SINGLE1-NEXT:      {
   // CHECK-SINGLE1-NEXT:        "text": "single line doc"
   // CHECK-SINGLE1-NEXT:      }
-  // CHECK-SINGLE1-NEXT:    ]
+  // CHECK-SINGLE1-NEXT:    ],
+  // CHECK-SINGLE1-NEXT:    "module": "MyMod",
+  // CHECK-SINGLE1-NEXT:    "uri": "file://{{.*}}mod{{\\\\|/}}M.h"
   // CHECK-SINGLE1-NEXT:  }
 
   //! single line doc
@@ -174,7 +178,9 @@ struct ObjCStruct {
   // CHECK-SINGLE2-NEXT:      {
   // CHECK-SINGLE2-NEXT:        "text": "single line doc"
   // CHECK-SINGLE2-NEXT:      }
-  // CHECK-SINGLE2-NEXT:    ]
+  // CHECK-SINGLE2-NEXT:    ],
+  // CHECK-SINGLE2-NEXT:    "module": "MyMod",
+  // CHECK-SINGLE2-NEXT:    "uri": "file://{{.*}}mod{{\\\\|/}}M.h"
   // CHECK-SINGLE2-NEXT:  }
 
   /** single line block doc */
@@ -184,7 +190,9 @@ struct ObjCStruct {
   // CHECK-BLOCK1-NEXT:      {
   // CHECK-BLOCK1-NEXT:        "text": "single line block doc "
   // CHECK-BLOCK1-NEXT:      }
-  // CHECK-BLOCK1-NEXT:    ]
+  // CHECK-BLOCK1-NEXT:    ],
+  // CHECK-BLOCK1-NEXT:    "module": "MyMod",
+  // CHECK-BLOCK1-NEXT:    "uri": "file://{{.*}}mod{{\\\\|/}}M.h"
   // CHECK-BLOCK1-NEXT:  }
 
   /*! single line block doc */
@@ -194,7 +202,9 @@ struct ObjCStruct {
   // CHECK-BLOCK2-NEXT:      {
   // CHECK-BLOCK2-NEXT:        "text": "single line block doc "
   // CHECK-BLOCK2-NEXT:      }
-  // CHECK-BLOCK2-NEXT:    ]
+  // CHECK-BLOCK2-NEXT:    ],
+  // CHECK-BLOCK2-NEXT:    "module": "MyMod",
+  // CHECK-BLOCK2-NEXT:    "uri": "file://{{.*}}mod{{\\\\|/}}M.h"
   // CHECK-BLOCK2-NEXT:  }
 
   /**
@@ -220,7 +230,9 @@ struct ObjCStruct {
   // DISABLED-CHECK-ART-NEXT:      {
   // DISABLED-CHECK-ART-NEXT:        "text": "   "
   // DISABLED-CHECK-ART-NEXT:      }
-  // DISABLED-CHECK-ART-NEXT:    ]
+  // DISABLED-CHECK-ART-NEXT:    ],
+  // DISABLED-CHECK-ART-NEXT:    "module": "MyMod",
+  // DISABLED-CHECK-ART-NEXT:    "uri": "file://{{.*}}mod{{\\\\|/}}M.h"
   // DISABLED-CHECK-ART-NEXT:  }
 
   /// doc1
@@ -237,7 +249,9 @@ struct ObjCStruct {
   // CHECK-MIXED-TYPE-NEXT:      {
   // CHECK-MIXED-TYPE-NEXT:        "text": "doc2 last"
   // CHECK-MIXED-TYPE-NEXT:      }
-  // CHECK-MIXED-TYPE-NEXT:    ]
+  // CHECK-MIXED-TYPE-NEXT:    ],
+  // CHECK-MIXED-TYPE-NEXT:    "module": "MyMod",
+  // CHECK-MIXED-TYPE-NEXT:    "uri": "file://{{.*}}mod{{\\\\|/}}M.h"
   // CHECK-MIXED-TYPE-NEXT:  }
 
   /// doc1
@@ -274,7 +288,9 @@ struct ObjCStruct {
   // DISABLED-CHECK-MIXED-DOC-NEXT:      {
   // DISABLED-CHECK-MIXED-DOC-NEXT:        "text": "doc3"
   // DISABLED-CHECK-MIXED-DOC-NEXT:      }
-  // DISABLED-CHECK-MIXED-DOC-NEXT:    ]
+  // DISABLED-CHECK-MIXED-DOC-NEXT:    ],
+  // DISABLED-CHECK-MIXED-DOC-NEXT:    "module": "MyMod",
+  // DISABLED-CHECK-MIXED-DOC-NEXT:    "uri": "file://{{.*}}mod{{\\\\|/}}M.h"
   // DISABLED-CHECK-MIXED-DOC-NEXT:  }
 };
 

--- a/test/SymbolGraph/Symbols/Mixins/DocComment/BlockStyle.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DocComment/BlockStyle.swift
@@ -2,177 +2,25 @@
 // Only add text to the bottom of this file
 // or you are going to have a bad time.
 
-// SINGLESAMELINE-LABEL: "precise": "s:10BlockStyle14SingleSameLineV"
-// SINGLESAMELINE:       "docComment": {
-// SINGLESAMELINE-NEXT:    "lines": [
-// SINGLESAMELINE-NEXT:      {
-// SINGLESAMELINE-NEXT:        "range": {
-// SINGLESAMELINE-NEXT:          "start": {
-// SINGLESAMELINE-NEXT:            "line": 23,
-// SINGLESAMELINE-NEXT:            "character": 4
-// SINGLESAMELINE-NEXT:          },
-// SINGLESAMELINE-NEXT:          "end": {
-// SINGLESAMELINE-NEXT:            "line": 23,
-// SINGLESAMELINE-NEXT:            "character": 21
-// SINGLESAMELINE-NEXT:          }
-// SINGLESAMELINE-NEXT:        },
-// SINGLESAMELINE-NEXT:        "text": "Single Same Line "
-// SINGLESAMELINE-NEXT:      }
-// SINGLESAMELINE-NEXT:    ]
-// SINGLESAMELINE-NEXT:  },
-
 /** Single Same Line */
 public struct SingleSameLine {}
-
-// EMPTY-LABEL: "precise": "s:10BlockStyle5EmptyV"
-// EMPTY:       "docComment": {
-// EMPTY-NEXT:    "lines": []
-// EMPTY-NEXT:  },
 
 /***/
 public struct Empty {}
 
-// EMPTYWITHNEWLINE-LABEL: "precise": "s:10BlockStyle16EmptyWithNewLineV"
-// EMPTHWITHNEWLINE:       "docComment": {
-// EMPTHWITHNEWLINE-NEXT:    "lines": [
-// EMPTHWITHNEWLINE-NEXT:      {
-// EMPTHWITHNEWLINE-NEXT:        "range": {
-// EMPTHWITHNEWLINE-NEXT:          "start": {
-// EMPTHWITHNEWLINE-NEXT:            "line": 54,
-// EMPTHWITHNEWLINE-NEXT:            "character": 1
-// EMPTHWITHNEWLINE-NEXT:          },
-// EMPTHWITHNEWLINE-NEXT:          "end": {
-// EMPTHWITHNEWLINE-NEXT:            "line": 54,
-// EMPTHWITHNEWLINE-NEXT:            "character": 1
-// EMPTHWITHNEWLINE-NEXT:          }
-// EMPTHWITHNEWLINE-NEXT:        },
-// EMPTHWITHNEWLINE-NEXT:        "text": ""
-// EMPTHWITHNEWLINE-NEXT:      }
-// EMPTHWITHNEWLINE-NEXT:    ]
-// EMPTHWITHNEWLINE-NEXT:  },
-
 /**
  */
 public struct EmptyWithNewLine {}
-
-// SINGLELINE-LABEL: "precise": "s:10BlockStyle10SingleLineV"
-// SINGLELINE:       "docComment": {
-// SINGLELINE-NEXT:    "lines": [
-// SINGLELINE-NEXT:      {
-// SINGLELINE-NEXT:        "range": {
-// SINGLELINE-NEXT:          "start": {
-// SINGLELINE-NEXT:            "line": 90,
-// SINGLELINE-NEXT:            "character": 1
-// SINGLELINE-NEXT:          },
-// SINGLELINE-NEXT:          "end": {
-// SINGLELINE-NEXT:            "line": 90,
-// SINGLELINE-NEXT:            "character": 13
-// SINGLELINE-NEXT:          }
-// SINGLELINE-NEXT:        },
-// SINGLELINE-NEXT:        "text": "Single line."
-// SINGLELINE-NEXT:      },
-// SINGLELINE-NEXT:      {
-// SINGLELINE-NEXT:        "range": {
-// SINGLELINE-NEXT:          "start": {
-// SINGLELINE-NEXT:            "line": 91,
-// SINGLELINE-NEXT:            "character": 1
-// SINGLELINE-NEXT:          },
-// SINGLELINE-NEXT:          "end": {
-// SINGLELINE-NEXT:            "line": 91,
-// SINGLELINE-NEXT:            "character": 1
-// SINGLELINE-NEXT:          }
-// SINGLELINE-NEXT:        },
-// SINGLELINE-NEXT:        "text": ""
-// SINGLELINE-NEXT:      }
-// SINGLELINE-NEXT:    ]
-// SINGLELINE-NEXT:  },
 
 /**
  Single line.
  */
 public struct SingleLine {}
 
-// SINGLELINEWITHART-LABEL: "precise": "s:10BlockStyle17SingleLineWithArtV"
-// SINGLELINEWITHART:       "docComment": {
-// SINGLELINEWITHART-NEXT:    "lines": [
-// SINGLELINEWITHART-NEXT:      {
-// SINGLELINEWITHART-NEXT:        "range": {
-// SINGLELINEWITHART-NEXT:          "start": {
-// SINGLELINEWITHART-NEXT:            "line": 127,
-// SINGLELINEWITHART-NEXT:            "character": 3
-// SINGLELINEWITHART-NEXT:          },
-// SINGLELINEWITHART-NEXT:          "end": {
-// SINGLELINEWITHART-NEXT:            "line": 127,
-// SINGLELINEWITHART-NEXT:            "character": 24
-// SINGLELINEWITHART-NEXT:          }
-// SINGLELINEWITHART-NEXT:        },
-// SINGLELINEWITHART-NEXT:        "text": "Single line with art."
-// SINGLELINEWITHART-NEXT:      },
-// SINGLELINEWITHART-NEXT:      {
-// SINGLELINEWITHART-NEXT:        "range": {
-// SINGLELINEWITHART-NEXT:          "start": {
-// SINGLELINEWITHART-NEXT:            "line": 128,
-// SINGLELINEWITHART-NEXT:            "character": 0
-// SINGLELINEWITHART-NEXT:          },
-// SINGLELINEWITHART-NEXT:          "end": {
-// SINGLELINEWITHART-NEXT:            "line": 128,
-// SINGLELINEWITHART-NEXT:            "character": 1
-// SINGLELINEWITHART-NEXT:          }
-// SINGLELINEWITHART-NEXT:        },
-// SINGLELINEWITHART-NEXT:        "text": " "
-// SINGLELINEWITHART-NEXT:      }
-// SINGLELINEWITHART-NEXT:    ]
-// SINGLELINEWITHART-NEXT:  },
-
 /**
  * Single line with art.
  */
 public struct SingleLineWithArt {}
-
-// TWOLINES-LABEL: "precise": "s:10BlockStyle8TwoLinesV"
-// TWOLINES:       "docComment": {
-// TWOLINES-NEXT:    "lines": [
-// TWOLINES-NEXT:      {
-// TWOLINES-NEXT:        "range": {
-// TWOLINES-NEXT:          "start": {
-// TWOLINES-NEXT:            "line": 177,
-// TWOLINES-NEXT:            "character": 1
-// TWOLINES-NEXT:          },
-// TWOLINES-NEXT:          "end": {
-// TWOLINES-NEXT:            "line": 177,
-// TWOLINES-NEXT:            "character": 4
-// TWOLINES-NEXT:          }
-// TWOLINES-NEXT:        },
-// TWOLINES-NEXT:        "text": "Two"
-// TWOLINES-NEXT:      },
-// TWOLINES-NEXT:      {
-// TWOLINES-NEXT:        "range": {
-// TWOLINES-NEXT:          "start": {
-// TWOLINES-NEXT:            "line": 178,
-// TWOLINES-NEXT:            "character": 1
-// TWOLINES-NEXT:          },
-// TWOLINES-NEXT:          "end": {
-// TWOLINES-NEXT:            "line": 178,
-// TWOLINES-NEXT:            "character": 7
-// TWOLINES-NEXT:          }
-// TWOLINES-NEXT:        },
-// TWOLINES-NEXT:        "text": "lines."
-// TWOLINES-NEXT:      },
-// TWOLINES-NEXT:      {
-// TWOLINES-NEXT:        "range": {
-// TWOLINES-NEXT:          "start": {
-// TWOLINES-NEXT:            "line": 179,
-// TWOLINES-NEXT:            "character": 1
-// TWOLINES-NEXT:          },
-// TWOLINES-NEXT:          "end": {
-// TWOLINES-NEXT:            "line": 179,
-// TWOLINES-NEXT:            "character": 1
-// TWOLINES-NEXT:          }
-// TWOLINES-NEXT:        },
-// TWOLINES-NEXT:        "text": ""
-// TWOLINES-NEXT:      }
-// TWOLINES-NEXT:    ]
-// TWOLINES-NEXT:  },
 
 /**
  Two
@@ -180,100 +28,10 @@ public struct SingleLineWithArt {}
  */
 public struct TwoLines {}
 
-// LARGEINDENT-LABEL: "precise": "s:10BlockStyle11LargeIndentV"
-// LARGEINDENT:       "docComment": {
-// LARGEINDENT-NEXT:    "lines": [
-// LARGEINDENT-NEXT:      {
-// LARGEINDENT-NEXT:        "range": {
-// LARGEINDENT-NEXT:          "start": {
-// LARGEINDENT-NEXT:            "line": 215,
-// LARGEINDENT-NEXT:            "character": 5
-// LARGEINDENT-NEXT:          },
-// LARGEINDENT-NEXT:          "end": {
-// LARGEINDENT-NEXT:            "line": 215,
-// LARGEINDENT-NEXT:            "character": 17
-// LARGEINDENT-NEXT:          }
-// LARGEINDENT-NEXT:        },
-// LARGEINDENT-NEXT:        "text": "Large Indent"
-// LARGEINDENT-NEXT:      },
-// LARGEINDENT-NEXT:      {
-// LARGEINDENT-NEXT:        "range": {
-// LARGEINDENT-NEXT:          "start": {
-// LARGEINDENT-NEXT:            "line": 216,
-// LARGEINDENT-NEXT:            "character": 1
-// LARGEINDENT-NEXT:          },
-// LARGEINDENT-NEXT:          "end": {
-// LARGEINDENT-NEXT:            "line": 216,
-// LARGEINDENT-NEXT:            "character": 1
-// LARGEINDENT-NEXT:          }
-// LARGEINDENT-NEXT:        },
-// LARGEINDENT-NEXT:        "text": ""
-// LARGEINDENT-NEXT:      }
-// LARGEINDENT-NEXT:    ]
-// LARGEINDENT-NEXT:  }
-
 /**
      Large Indent
  */
 public struct LargeIndent {}
-
-// TWOLINESBETWEENBLANK-LABEL: "precise": "s:10BlockStyle20TwoLinesBetweenBlankV"
-// TWOLINESBETWEENBLANK:       "docComment": {
-// TWOLINESBETWEENBLANK-NEXT:    "lines": [
-// TWOLINESBETWEENBLANK-NEXT:      {
-// TWOLINESBETWEENBLANK-NEXT:        "range": {
-// TWOLINESBETWEENBLANK-NEXT:          "start": {
-// TWOLINESBETWEENBLANK-NEXT:            "line": 278,
-// TWOLINESBETWEENBLANK-NEXT:            "character": 1
-// TWOLINESBETWEENBLANK-NEXT:          },
-// TWOLINESBETWEENBLANK-NEXT:          "end": {
-// TWOLINESBETWEENBLANK-NEXT:            "line": 278,
-// TWOLINESBETWEENBLANK-NEXT:            "character": 10
-// TWOLINESBETWEENBLANK-NEXT:          }
-// TWOLINESBETWEENBLANK-NEXT:        },
-// TWOLINESBETWEENBLANK-NEXT:        "text": "Two lines"
-// TWOLINESBETWEENBLANK-NEXT:      },
-// TWOLINESBETWEENBLANK-NEXT:      {
-// TWOLINESBETWEENBLANK-NEXT:        "range": {
-// TWOLINESBETWEENBLANK-NEXT:          "start": {
-// TWOLINESBETWEENBLANK-NEXT:            "line": 279,
-// TWOLINESBETWEENBLANK-NEXT:            "character": 0
-// TWOLINESBETWEENBLANK-NEXT:          },
-// TWOLINESBETWEENBLANK-NEXT:          "end": {
-// TWOLINESBETWEENBLANK-NEXT:            "line": 279,
-// TWOLINESBETWEENBLANK-NEXT:            "character": 0
-// TWOLINESBETWEENBLANK-NEXT:          }
-// TWOLINESBETWEENBLANK-NEXT:        },
-// TWOLINESBETWEENBLANK-NEXT:        "text": ""
-// TWOLINESBETWEENBLANK-NEXT:      },
-// TWOLINESBETWEENBLANK-NEXT:      {
-// TWOLINESBETWEENBLANK-NEXT:        "range": {
-// TWOLINESBETWEENBLANK-NEXT:          "start": {
-// TWOLINESBETWEENBLANK-NEXT:            "line": 280,
-// TWOLINESBETWEENBLANK-NEXT:            "character": 1
-// TWOLINESBETWEENBLANK-NEXT:          },
-// TWOLINESBETWEENBLANK-NEXT:          "end": {
-// TWOLINESBETWEENBLANK-NEXT:            "line": 280,
-// TWOLINESBETWEENBLANK-NEXT:            "character": 14
-// TWOLINESBETWEENBLANK-NEXT:          }
-// TWOLINESBETWEENBLANK-NEXT:        },
-// TWOLINESBETWEENBLANK-NEXT:        "text": "Between Blank"
-// TWOLINESBETWEENBLANK-NEXT:      },
-// TWOLINESBETWEENBLANK-NEXT:      {
-// TWOLINESBETWEENBLANK-NEXT:        "range": {
-// TWOLINESBETWEENBLANK-NEXT:          "start": {
-// TWOLINESBETWEENBLANK-NEXT:            "line": 281,
-// TWOLINESBETWEENBLANK-NEXT:            "character": 1
-// TWOLINESBETWEENBLANK-NEXT:          },
-// TWOLINESBETWEENBLANK-NEXT:          "end": {
-// TWOLINESBETWEENBLANK-NEXT:            "line": 281,
-// TWOLINESBETWEENBLANK-NEXT:            "character": 1
-// TWOLINESBETWEENBLANK-NEXT:          }
-// TWOLINESBETWEENBLANK-NEXT:        },
-// TWOLINESBETWEENBLANK-NEXT:        "text": ""
-// TWOLINESBETWEENBLANK-NEXT:      }
-// TWOLINESBETWEENBLANK-NEXT:    ]
-// TWOLINESBETWEENBLANK-NEXT:  },
 
 /**
  Two lines
@@ -282,101 +40,11 @@ public struct LargeIndent {}
  */
 public struct TwoLinesBetweenBlank {}
 
-// LEADINGBLANK-LABEL: "precise": "s:10BlockStyle12LeadingBlankV"
-// LEADINGBLANK:       "docComment": {
-// LEADINGBLANK-NEXT:    "lines": [
-// LEADINGBLANK-NEXT:      {
-// LEADINGBLANK-NEXT:        "range": {
-// LEADINGBLANK-NEXT:          "start": {
-// LEADINGBLANK-NEXT:            "line": 330,
-// LEADINGBLANK-NEXT:            "character": 0
-// LEADINGBLANK-NEXT:          },
-// LEADINGBLANK-NEXT:          "end": {
-// LEADINGBLANK-NEXT:            "line": 330,
-// LEADINGBLANK-NEXT:            "character": 0
-// LEADINGBLANK-NEXT:          }
-// LEADINGBLANK-NEXT:        },
-// LEADINGBLANK-NEXT:        "text": ""
-// LEADINGBLANK-NEXT:      },
-// LEADINGBLANK-NEXT:      {
-// LEADINGBLANK-NEXT:        "range": {
-// LEADINGBLANK-NEXT:          "start": {
-// LEADINGBLANK-NEXT:            "line": 331,
-// LEADINGBLANK-NEXT:            "character": 1
-// LEADINGBLANK-NEXT:          },
-// LEADINGBLANK-NEXT:          "end": {
-// LEADINGBLANK-NEXT:            "line": 331,
-// LEADINGBLANK-NEXT:            "character": 14
-// LEADINGBLANK-NEXT:          }
-// LEADINGBLANK-NEXT:        },
-// LEADINGBLANK-NEXT:        "text": "Leading Blank"
-// LEADINGBLANK-NEXT:      },
-// LEADINGBLANK-NEXT:      {
-// LEADINGBLANK-NEXT:        "range": {
-// LEADINGBLANK-NEXT:          "start": {
-// LEADINGBLANK-NEXT:            "line": 332,
-// LEADINGBLANK-NEXT:            "character": 1
-// LEADINGBLANK-NEXT:          },
-// LEADINGBLANK-NEXT:          "end": {
-// LEADINGBLANK-NEXT:            "line": 332,
-// LEADINGBLANK-NEXT:            "character": 1
-// LEADINGBLANK-NEXT:          }
-// LEADINGBLANK-NEXT:        },
-// LEADINGBLANK-NEXT:        "text": ""
-// LEADINGBLANK-NEXT:      }
-// LEADINGBLANK-NEXT:    ]
-// LEADINGBLANK-NEXT:  },
-
 /**
 
  Leading Blank
  */
 public struct LeadingBlank {}
-
-// TRAILINGBLANK-LABEL: "precise": "s:10BlockStyle13TrailingBlankV"
-// TRAILINGBLANK:       "docComment": {
-// TRAILINGBLANK-NEXT:    "lines": [
-// TRAILINGBLANK-NEXT:      {
-// TRAILINGBLANK-NEXT:        "range": {
-// TRAILINGBLANK-NEXT:          "start": {
-// TRAILINGBLANK-NEXT:            "line": 381,
-// TRAILINGBLANK-NEXT:            "character": 1
-// TRAILINGBLANK-NEXT:          },
-// TRAILINGBLANK-NEXT:          "end": {
-// TRAILINGBLANK-NEXT:            "line": 381,
-// TRAILINGBLANK-NEXT:            "character": 15
-// TRAILINGBLANK-NEXT:          }
-// TRAILINGBLANK-NEXT:        },
-// TRAILINGBLANK-NEXT:        "text": "Trailing Blank"
-// TRAILINGBLANK-NEXT:      },
-// TRAILINGBLANK-NEXT:      {
-// TRAILINGBLANK-NEXT:        "range": {
-// TRAILINGBLANK-NEXT:          "start": {
-// TRAILINGBLANK-NEXT:            "line": 382,
-// TRAILINGBLANK-NEXT:            "character": 0
-// TRAILINGBLANK-NEXT:          },
-// TRAILINGBLANK-NEXT:          "end": {
-// TRAILINGBLANK-NEXT:            "line": 382,
-// TRAILINGBLANK-NEXT:            "character": 0
-// TRAILINGBLANK-NEXT:          }
-// TRAILINGBLANK-NEXT:        },
-// TRAILINGBLANK-NEXT:        "text": ""
-// TRAILINGBLANK-NEXT:      },
-// TRAILINGBLANK-NEXT:      {
-// TRAILINGBLANK-NEXT:        "range": {
-// TRAILINGBLANK-NEXT:          "start": {
-// TRAILINGBLANK-NEXT:            "line": 383,
-// TRAILINGBLANK-NEXT:            "character": 1
-// TRAILINGBLANK-NEXT:          },
-// TRAILINGBLANK-NEXT:          "end": {
-// TRAILINGBLANK-NEXT:            "line": 383,
-// TRAILINGBLANK-NEXT:            "character": 1
-// TRAILINGBLANK-NEXT:          }
-// TRAILINGBLANK-NEXT:        },
-// TRAILINGBLANK-NEXT:        "text": ""
-// TRAILINGBLANK-NEXT:      }
-// TRAILINGBLANK-NEXT:    ]
-// TRAILINGBLANK-NEXT:  },
 
 /**
  Trailing Blank
@@ -384,102 +52,12 @@ public struct LeadingBlank {}
  */
 public struct TrailingBlank {}
 
-// BOUNDBLANK-LABEL: "precise": "s:10BlockStyle10BoundBlankV"
-// BOUNDBLANK:       "docComment": {
-// BOUNDBLANK-NEXT:    "lines": [
-// BOUNDBLANK-NEXT:      {
-// BOUNDBLANK-NEXT:        "range": {
-// BOUNDBLANK-NEXT:          "start": {
-// BOUNDBLANK-NEXT:            "line": 445,
-// BOUNDBLANK-NEXT:            "character": 0
-// BOUNDBLANK-NEXT:          },
-// BOUNDBLANK-NEXT:          "end": {
-// BOUNDBLANK-NEXT:            "line": 445,
-// BOUNDBLANK-NEXT:            "character": 0
-// BOUNDBLANK-NEXT:          }
-// BOUNDBLANK-NEXT:        },
-// BOUNDBLANK-NEXT:        "text": ""
-// BOUNDBLANK-NEXT:      },
-// BOUNDBLANK-NEXT:      {
-// BOUNDBLANK-NEXT:        "range": {
-// BOUNDBLANK-NEXT:          "start": {
-// BOUNDBLANK-NEXT:            "line": 446,
-// BOUNDBLANK-NEXT:            "character": 1
-// BOUNDBLANK-NEXT:          },
-// BOUNDBLANK-NEXT:          "end": {
-// BOUNDBLANK-NEXT:            "line": 446,
-// BOUNDBLANK-NEXT:            "character": 12
-// BOUNDBLANK-NEXT:          }
-// BOUNDBLANK-NEXT:        },
-// BOUNDBLANK-NEXT:        "text": "Bound Blank"
-// BOUNDBLANK-NEXT:      },
-// BOUNDBLANK-NEXT:      {
-// BOUNDBLANK-NEXT:        "range": {
-// BOUNDBLANK-NEXT:          "start": {
-// BOUNDBLANK-NEXT:            "line": 447,
-// BOUNDBLANK-NEXT:            "character": 0
-// BOUNDBLANK-NEXT:          },
-// BOUNDBLANK-NEXT:          "end": {
-// BOUNDBLANK-NEXT:            "line": 447,
-// BOUNDBLANK-NEXT:            "character": 0
-// BOUNDBLANK-NEXT:          }
-// BOUNDBLANK-NEXT:        },
-// BOUNDBLANK-NEXT:        "text": ""
-// BOUNDBLANK-NEXT:      },
-// BOUNDBLANK-NEXT:      {
-// BOUNDBLANK-NEXT:        "range": {
-// BOUNDBLANK-NEXT:          "start": {
-// BOUNDBLANK-NEXT:            "line": 448,
-// BOUNDBLANK-NEXT:            "character": 1
-// BOUNDBLANK-NEXT:          },
-// BOUNDBLANK-NEXT:          "end": {
-// BOUNDBLANK-NEXT:            "line": 448,
-// BOUNDBLANK-NEXT:            "character": 1
-// BOUNDBLANK-NEXT:          }
-// BOUNDBLANK-NEXT:        },
-// BOUNDBLANK-NEXT:        "text": ""
-// BOUNDBLANK-NEXT:      }
-// BOUNDBLANK-NEXT:    ]
-// BOUNDBLANK-NEXT:  },
-
 /**
 
  Bound Blank
 
  */
 public struct BoundBlank {}
-
-// ALLINDENTED-LABEL: "precise": "s:10BlockStyle11AllIndentedV"
-// ALLINDENTED:       "docComment": {
-// ALLINDENTED-NEXT:    "lines": [
-// ALLINDENTED-NEXT:      {
-// ALLINDENTED-NEXT:        "range": {
-// ALLINDENTED-NEXT:          "start": {
-// ALLINDENTED-NEXT:            "line": 484,
-// ALLINDENTED-NEXT:            "character": 5
-// ALLINDENTED-NEXT:          },
-// ALLINDENTED-NEXT:          "end": {
-// ALLINDENTED-NEXT:            "line": 484,
-// ALLINDENTED-NEXT:            "character": 18
-// ALLINDENTED-NEXT:          }
-// ALLINDENTED-NEXT:        },
-// ALLINDENTED-NEXT:        "text": "All indented."
-// ALLINDENTED-NEXT:      },
-// ALLINDENTED-NEXT:      {
-// ALLINDENTED-NEXT:        "range": {
-// ALLINDENTED-NEXT:          "start": {
-// ALLINDENTED-NEXT:            "line": 485,
-// ALLINDENTED-NEXT:            "character": 5
-// ALLINDENTED-NEXT:          },
-// ALLINDENTED-NEXT:          "end": {
-// ALLINDENTED-NEXT:            "line": 485,
-// ALLINDENTED-NEXT:            "character": 5
-// ALLINDENTED-NEXT:          }
-// ALLINDENTED-NEXT:        },
-// ALLINDENTED-NEXT:        "text": ""
-// ALLINDENTED-NEXT:      }
-// ALLINDENTED-NEXT:    ]
-// ALLINDENTED-NEXT:  },
 
     /**
      All indented.
@@ -498,3 +76,425 @@ public struct BoundBlank {}
 // RUN: %FileCheck %s --input-file %t/BlockStyle.symbols.json --check-prefix=TWOLINESBETWEENBLANK
 // RUN: %FileCheck %s --input-file %t/BlockStyle.symbols.json --check-prefix=LEADINGBLANK
 // RUN: %FileCheck %s --input-file %t/BlockStyle.symbols.json --check-prefix=TRAILINGBLANK
+
+// SINGLESAMELINE-LABEL: "precise": "s:10BlockStyle14SingleSameLineV"
+// SINGLESAMELINE:       "docComment": {
+// SINGLESAMELINE-NEXT:    "lines": [
+// SINGLESAMELINE-NEXT:      {
+// SINGLESAMELINE-NEXT:        "range": {
+// SINGLESAMELINE-NEXT:          "start": {
+// SINGLESAMELINE-NEXT:            "line": 4,
+// SINGLESAMELINE-NEXT:            "character": 4
+// SINGLESAMELINE-NEXT:          },
+// SINGLESAMELINE-NEXT:          "end": {
+// SINGLESAMELINE-NEXT:            "line": 4,
+// SINGLESAMELINE-NEXT:            "character": 21
+// SINGLESAMELINE-NEXT:          }
+// SINGLESAMELINE-NEXT:        },
+// SINGLESAMELINE-NEXT:        "text": "Single Same Line "
+// SINGLESAMELINE-NEXT:      }
+// SINGLESAMELINE-NEXT:    ]
+// SINGLESAMELINE-NEXT:  },
+
+// EMPTY-LABEL: "precise": "s:10BlockStyle5EmptyV"
+// EMPTY:       "docComment": {
+// EMPTY-NEXT:    "lines": []
+// EMPTY-NEXT:  },
+
+// EMPTYWITHNEWLINE-LABEL: "precise": "s:10BlockStyle16EmptyWithNewLineV"
+// EMPTYWITHNEWLINE:       "docComment": {
+// EMPTYWITHNEWLINE-NEXT:    "lines": [
+// EMPTYWITHNEWLINE-NEXT:      {
+// EMPTYWITHNEWLINE-NEXT:        "range": {
+// EMPTYWITHNEWLINE-NEXT:          "start": {
+// EMPTYWITHNEWLINE-NEXT:            "line": 11,
+// EMPTYWITHNEWLINE-NEXT:            "character": 1
+// EMPTYWITHNEWLINE-NEXT:          },
+// EMPTYWITHNEWLINE-NEXT:          "end": {
+// EMPTYWITHNEWLINE-NEXT:            "line": 11,
+// EMPTYWITHNEWLINE-NEXT:            "character": 1
+// EMPTYWITHNEWLINE-NEXT:          }
+// EMPTYWITHNEWLINE-NEXT:        },
+// EMPTYWITHNEWLINE-NEXT:        "text": ""
+// EMPTYWITHNEWLINE-NEXT:      }
+// EMPTYWITHNEWLINE-NEXT:    ]
+// EMPTYWITHNEWLINE-NEXT:  },
+
+// SINGLELINE-LABEL: "precise": "s:10BlockStyle10SingleLineV"
+// SINGLELINE:       "docComment": {
+// SINGLELINE-NEXT:    "lines": [
+// SINGLELINE-NEXT:      {
+// SINGLELINE-NEXT:        "range": {
+// SINGLELINE-NEXT:          "start": {
+// SINGLELINE-NEXT:            "line": 15,
+// SINGLELINE-NEXT:            "character": 1
+// SINGLELINE-NEXT:          },
+// SINGLELINE-NEXT:          "end": {
+// SINGLELINE-NEXT:            "line": 15,
+// SINGLELINE-NEXT:            "character": 13
+// SINGLELINE-NEXT:          }
+// SINGLELINE-NEXT:        },
+// SINGLELINE-NEXT:        "text": "Single line."
+// SINGLELINE-NEXT:      },
+// SINGLELINE-NEXT:      {
+// SINGLELINE-NEXT:        "range": {
+// SINGLELINE-NEXT:          "start": {
+// SINGLELINE-NEXT:            "line": 16,
+// SINGLELINE-NEXT:            "character": 1
+// SINGLELINE-NEXT:          },
+// SINGLELINE-NEXT:          "end": {
+// SINGLELINE-NEXT:            "line": 16,
+// SINGLELINE-NEXT:            "character": 1
+// SINGLELINE-NEXT:          }
+// SINGLELINE-NEXT:        },
+// SINGLELINE-NEXT:        "text": ""
+// SINGLELINE-NEXT:      }
+// SINGLELINE-NEXT:    ]
+// SINGLELINE-NEXT:  },
+
+// SINGLELINEWITHART-LABEL: "precise": "s:10BlockStyle17SingleLineWithArtV"
+// SINGLELINEWITHART:       "docComment": {
+// SINGLELINEWITHART-NEXT:    "lines": [
+// SINGLELINEWITHART-NEXT:      {
+// SINGLELINEWITHART-NEXT:        "range": {
+// SINGLELINEWITHART-NEXT:          "start": {
+// SINGLELINEWITHART-NEXT:            "line": 20,
+// SINGLELINEWITHART-NEXT:            "character": 3
+// SINGLELINEWITHART-NEXT:          },
+// SINGLELINEWITHART-NEXT:          "end": {
+// SINGLELINEWITHART-NEXT:            "line": 20,
+// SINGLELINEWITHART-NEXT:            "character": 24
+// SINGLELINEWITHART-NEXT:          }
+// SINGLELINEWITHART-NEXT:        },
+// SINGLELINEWITHART-NEXT:        "text": "Single line with art."
+// SINGLELINEWITHART-NEXT:      },
+// SINGLELINEWITHART-NEXT:      {
+// SINGLELINEWITHART-NEXT:        "range": {
+// SINGLELINEWITHART-NEXT:          "start": {
+// SINGLELINEWITHART-NEXT:            "line": 21,
+// SINGLELINEWITHART-NEXT:            "character": 0
+// SINGLELINEWITHART-NEXT:          },
+// SINGLELINEWITHART-NEXT:          "end": {
+// SINGLELINEWITHART-NEXT:            "line": 21,
+// SINGLELINEWITHART-NEXT:            "character": 1
+// SINGLELINEWITHART-NEXT:          }
+// SINGLELINEWITHART-NEXT:        },
+// SINGLELINEWITHART-NEXT:        "text": " "
+// SINGLELINEWITHART-NEXT:      }
+// SINGLELINEWITHART-NEXT:    ]
+// SINGLELINEWITHART-NEXT:  },
+
+// TWOLINES-LABEL: "precise": "s:10BlockStyle8TwoLinesV"
+// TWOLINES:       "docComment": {
+// TWOLINES-NEXT:    "lines": [
+// TWOLINES-NEXT:      {
+// TWOLINES-NEXT:        "range": {
+// TWOLINES-NEXT:          "start": {
+// TWOLINES-NEXT:            "line": 25,
+// TWOLINES-NEXT:            "character": 1
+// TWOLINES-NEXT:          },
+// TWOLINES-NEXT:          "end": {
+// TWOLINES-NEXT:            "line": 25,
+// TWOLINES-NEXT:            "character": 4
+// TWOLINES-NEXT:          }
+// TWOLINES-NEXT:        },
+// TWOLINES-NEXT:        "text": "Two"
+// TWOLINES-NEXT:      },
+// TWOLINES-NEXT:      {
+// TWOLINES-NEXT:        "range": {
+// TWOLINES-NEXT:          "start": {
+// TWOLINES-NEXT:            "line": 26,
+// TWOLINES-NEXT:            "character": 1
+// TWOLINES-NEXT:          },
+// TWOLINES-NEXT:          "end": {
+// TWOLINES-NEXT:            "line": 26,
+// TWOLINES-NEXT:            "character": 7
+// TWOLINES-NEXT:          }
+// TWOLINES-NEXT:        },
+// TWOLINES-NEXT:        "text": "lines."
+// TWOLINES-NEXT:      },
+// TWOLINES-NEXT:      {
+// TWOLINES-NEXT:        "range": {
+// TWOLINES-NEXT:          "start": {
+// TWOLINES-NEXT:            "line": 27,
+// TWOLINES-NEXT:            "character": 1
+// TWOLINES-NEXT:          },
+// TWOLINES-NEXT:          "end": {
+// TWOLINES-NEXT:            "line": 27,
+// TWOLINES-NEXT:            "character": 1
+// TWOLINES-NEXT:          }
+// TWOLINES-NEXT:        },
+// TWOLINES-NEXT:        "text": ""
+// TWOLINES-NEXT:      }
+// TWOLINES-NEXT:    ]
+// TWOLINES-NEXT:  },
+
+// LARGEINDENT-LABEL: "precise": "s:10BlockStyle11LargeIndentV"
+// LARGEINDENT:       "docComment": {
+// LARGEINDENT-NEXT:    "lines": [
+// LARGEINDENT-NEXT:      {
+// LARGEINDENT-NEXT:        "range": {
+// LARGEINDENT-NEXT:          "start": {
+// LARGEINDENT-NEXT:            "line": 31,
+// LARGEINDENT-NEXT:            "character": 5
+// LARGEINDENT-NEXT:          },
+// LARGEINDENT-NEXT:          "end": {
+// LARGEINDENT-NEXT:            "line": 31,
+// LARGEINDENT-NEXT:            "character": 17
+// LARGEINDENT-NEXT:          }
+// LARGEINDENT-NEXT:        },
+// LARGEINDENT-NEXT:        "text": "Large Indent"
+// LARGEINDENT-NEXT:      },
+// LARGEINDENT-NEXT:      {
+// LARGEINDENT-NEXT:        "range": {
+// LARGEINDENT-NEXT:          "start": {
+// LARGEINDENT-NEXT:            "line": 32,
+// LARGEINDENT-NEXT:            "character": 1
+// LARGEINDENT-NEXT:          },
+// LARGEINDENT-NEXT:          "end": {
+// LARGEINDENT-NEXT:            "line": 32,
+// LARGEINDENT-NEXT:            "character": 1
+// LARGEINDENT-NEXT:          }
+// LARGEINDENT-NEXT:        },
+// LARGEINDENT-NEXT:        "text": ""
+// LARGEINDENT-NEXT:      }
+// LARGEINDENT-NEXT:    ]
+// LARGEINDENT-NEXT:  }
+
+// TWOLINESBETWEENBLANK-LABEL: "precise": "s:10BlockStyle20TwoLinesBetweenBlankV"
+// TWOLINESBETWEENBLANK:       "docComment": {
+// TWOLINESBETWEENBLANK-NEXT:    "lines": [
+// TWOLINESBETWEENBLANK-NEXT:      {
+// TWOLINESBETWEENBLANK-NEXT:        "range": {
+// TWOLINESBETWEENBLANK-NEXT:          "start": {
+// TWOLINESBETWEENBLANK-NEXT:            "line": 36,
+// TWOLINESBETWEENBLANK-NEXT:            "character": 1
+// TWOLINESBETWEENBLANK-NEXT:          },
+// TWOLINESBETWEENBLANK-NEXT:          "end": {
+// TWOLINESBETWEENBLANK-NEXT:            "line": 36,
+// TWOLINESBETWEENBLANK-NEXT:            "character": 10
+// TWOLINESBETWEENBLANK-NEXT:          }
+// TWOLINESBETWEENBLANK-NEXT:        },
+// TWOLINESBETWEENBLANK-NEXT:        "text": "Two lines"
+// TWOLINESBETWEENBLANK-NEXT:      },
+// TWOLINESBETWEENBLANK-NEXT:      {
+// TWOLINESBETWEENBLANK-NEXT:        "range": {
+// TWOLINESBETWEENBLANK-NEXT:          "start": {
+// TWOLINESBETWEENBLANK-NEXT:            "line": 37,
+// TWOLINESBETWEENBLANK-NEXT:            "character": 0
+// TWOLINESBETWEENBLANK-NEXT:          },
+// TWOLINESBETWEENBLANK-NEXT:          "end": {
+// TWOLINESBETWEENBLANK-NEXT:            "line": 37,
+// TWOLINESBETWEENBLANK-NEXT:            "character": 0
+// TWOLINESBETWEENBLANK-NEXT:          }
+// TWOLINESBETWEENBLANK-NEXT:        },
+// TWOLINESBETWEENBLANK-NEXT:        "text": ""
+// TWOLINESBETWEENBLANK-NEXT:      },
+// TWOLINESBETWEENBLANK-NEXT:      {
+// TWOLINESBETWEENBLANK-NEXT:        "range": {
+// TWOLINESBETWEENBLANK-NEXT:          "start": {
+// TWOLINESBETWEENBLANK-NEXT:            "line": 38,
+// TWOLINESBETWEENBLANK-NEXT:            "character": 1
+// TWOLINESBETWEENBLANK-NEXT:          },
+// TWOLINESBETWEENBLANK-NEXT:          "end": {
+// TWOLINESBETWEENBLANK-NEXT:            "line": 38,
+// TWOLINESBETWEENBLANK-NEXT:            "character": 14
+// TWOLINESBETWEENBLANK-NEXT:          }
+// TWOLINESBETWEENBLANK-NEXT:        },
+// TWOLINESBETWEENBLANK-NEXT:        "text": "Between Blank"
+// TWOLINESBETWEENBLANK-NEXT:      },
+// TWOLINESBETWEENBLANK-NEXT:      {
+// TWOLINESBETWEENBLANK-NEXT:        "range": {
+// TWOLINESBETWEENBLANK-NEXT:          "start": {
+// TWOLINESBETWEENBLANK-NEXT:            "line": 39,
+// TWOLINESBETWEENBLANK-NEXT:            "character": 1
+// TWOLINESBETWEENBLANK-NEXT:          },
+// TWOLINESBETWEENBLANK-NEXT:          "end": {
+// TWOLINESBETWEENBLANK-NEXT:            "line": 39,
+// TWOLINESBETWEENBLANK-NEXT:            "character": 1
+// TWOLINESBETWEENBLANK-NEXT:          }
+// TWOLINESBETWEENBLANK-NEXT:        },
+// TWOLINESBETWEENBLANK-NEXT:        "text": ""
+// TWOLINESBETWEENBLANK-NEXT:      }
+// TWOLINESBETWEENBLANK-NEXT:    ]
+// TWOLINESBETWEENBLANK-NEXT:  },
+
+// LEADINGBLANK-LABEL: "precise": "s:10BlockStyle12LeadingBlankV"
+// LEADINGBLANK:       "docComment": {
+// LEADINGBLANK-NEXT:    "lines": [
+// LEADINGBLANK-NEXT:      {
+// LEADINGBLANK-NEXT:        "range": {
+// LEADINGBLANK-NEXT:          "start": {
+// LEADINGBLANK-NEXT:            "line": 43,
+// LEADINGBLANK-NEXT:            "character": 0
+// LEADINGBLANK-NEXT:          },
+// LEADINGBLANK-NEXT:          "end": {
+// LEADINGBLANK-NEXT:            "line": 43,
+// LEADINGBLANK-NEXT:            "character": 0
+// LEADINGBLANK-NEXT:          }
+// LEADINGBLANK-NEXT:        },
+// LEADINGBLANK-NEXT:        "text": ""
+// LEADINGBLANK-NEXT:      },
+// LEADINGBLANK-NEXT:      {
+// LEADINGBLANK-NEXT:        "range": {
+// LEADINGBLANK-NEXT:          "start": {
+// LEADINGBLANK-NEXT:            "line": 44,
+// LEADINGBLANK-NEXT:            "character": 1
+// LEADINGBLANK-NEXT:          },
+// LEADINGBLANK-NEXT:          "end": {
+// LEADINGBLANK-NEXT:            "line": 44,
+// LEADINGBLANK-NEXT:            "character": 14
+// LEADINGBLANK-NEXT:          }
+// LEADINGBLANK-NEXT:        },
+// LEADINGBLANK-NEXT:        "text": "Leading Blank"
+// LEADINGBLANK-NEXT:      },
+// LEADINGBLANK-NEXT:      {
+// LEADINGBLANK-NEXT:        "range": {
+// LEADINGBLANK-NEXT:          "start": {
+// LEADINGBLANK-NEXT:            "line": 45,
+// LEADINGBLANK-NEXT:            "character": 1
+// LEADINGBLANK-NEXT:          },
+// LEADINGBLANK-NEXT:          "end": {
+// LEADINGBLANK-NEXT:            "line": 45,
+// LEADINGBLANK-NEXT:            "character": 1
+// LEADINGBLANK-NEXT:          }
+// LEADINGBLANK-NEXT:        },
+// LEADINGBLANK-NEXT:        "text": ""
+// LEADINGBLANK-NEXT:      }
+// LEADINGBLANK-NEXT:    ]
+// LEADINGBLANK-NEXT:  },
+
+// TRAILINGBLANK-LABEL: "precise": "s:10BlockStyle13TrailingBlankV"
+// TRAILINGBLANK:       "docComment": {
+// TRAILINGBLANK-NEXT:    "lines": [
+// TRAILINGBLANK-NEXT:      {
+// TRAILINGBLANK-NEXT:        "range": {
+// TRAILINGBLANK-NEXT:          "start": {
+// TRAILINGBLANK-NEXT:            "line": 49,
+// TRAILINGBLANK-NEXT:            "character": 1
+// TRAILINGBLANK-NEXT:          },
+// TRAILINGBLANK-NEXT:          "end": {
+// TRAILINGBLANK-NEXT:            "line": 49,
+// TRAILINGBLANK-NEXT:            "character": 15
+// TRAILINGBLANK-NEXT:          }
+// TRAILINGBLANK-NEXT:        },
+// TRAILINGBLANK-NEXT:        "text": "Trailing Blank"
+// TRAILINGBLANK-NEXT:      },
+// TRAILINGBLANK-NEXT:      {
+// TRAILINGBLANK-NEXT:        "range": {
+// TRAILINGBLANK-NEXT:          "start": {
+// TRAILINGBLANK-NEXT:            "line": 50,
+// TRAILINGBLANK-NEXT:            "character": 0
+// TRAILINGBLANK-NEXT:          },
+// TRAILINGBLANK-NEXT:          "end": {
+// TRAILINGBLANK-NEXT:            "line": 50,
+// TRAILINGBLANK-NEXT:            "character": 0
+// TRAILINGBLANK-NEXT:          }
+// TRAILINGBLANK-NEXT:        },
+// TRAILINGBLANK-NEXT:        "text": ""
+// TRAILINGBLANK-NEXT:      },
+// TRAILINGBLANK-NEXT:      {
+// TRAILINGBLANK-NEXT:        "range": {
+// TRAILINGBLANK-NEXT:          "start": {
+// TRAILINGBLANK-NEXT:            "line": 51,
+// TRAILINGBLANK-NEXT:            "character": 1
+// TRAILINGBLANK-NEXT:          },
+// TRAILINGBLANK-NEXT:          "end": {
+// TRAILINGBLANK-NEXT:            "line": 51,
+// TRAILINGBLANK-NEXT:            "character": 1
+// TRAILINGBLANK-NEXT:          }
+// TRAILINGBLANK-NEXT:        },
+// TRAILINGBLANK-NEXT:        "text": ""
+// TRAILINGBLANK-NEXT:      }
+// TRAILINGBLANK-NEXT:    ]
+// TRAILINGBLANK-NEXT:  },
+
+// BOUNDBLANK-LABEL: "precise": "s:10BlockStyle10BoundBlankV"
+// BOUNDBLANK:       "docComment": {
+// BOUNDBLANK-NEXT:    "lines": [
+// BOUNDBLANK-NEXT:      {
+// BOUNDBLANK-NEXT:        "range": {
+// BOUNDBLANK-NEXT:          "start": {
+// BOUNDBLANK-NEXT:            "line": 55,
+// BOUNDBLANK-NEXT:            "character": 0
+// BOUNDBLANK-NEXT:          },
+// BOUNDBLANK-NEXT:          "end": {
+// BOUNDBLANK-NEXT:            "line": 55,
+// BOUNDBLANK-NEXT:            "character": 0
+// BOUNDBLANK-NEXT:          }
+// BOUNDBLANK-NEXT:        },
+// BOUNDBLANK-NEXT:        "text": ""
+// BOUNDBLANK-NEXT:      },
+// BOUNDBLANK-NEXT:      {
+// BOUNDBLANK-NEXT:        "range": {
+// BOUNDBLANK-NEXT:          "start": {
+// BOUNDBLANK-NEXT:            "line": 56,
+// BOUNDBLANK-NEXT:            "character": 1
+// BOUNDBLANK-NEXT:          },
+// BOUNDBLANK-NEXT:          "end": {
+// BOUNDBLANK-NEXT:            "line": 56,
+// BOUNDBLANK-NEXT:            "character": 12
+// BOUNDBLANK-NEXT:          }
+// BOUNDBLANK-NEXT:        },
+// BOUNDBLANK-NEXT:        "text": "Bound Blank"
+// BOUNDBLANK-NEXT:      },
+// BOUNDBLANK-NEXT:      {
+// BOUNDBLANK-NEXT:        "range": {
+// BOUNDBLANK-NEXT:          "start": {
+// BOUNDBLANK-NEXT:            "line": 57,
+// BOUNDBLANK-NEXT:            "character": 0
+// BOUNDBLANK-NEXT:          },
+// BOUNDBLANK-NEXT:          "end": {
+// BOUNDBLANK-NEXT:            "line": 57,
+// BOUNDBLANK-NEXT:            "character": 0
+// BOUNDBLANK-NEXT:          }
+// BOUNDBLANK-NEXT:        },
+// BOUNDBLANK-NEXT:        "text": ""
+// BOUNDBLANK-NEXT:      },
+// BOUNDBLANK-NEXT:      {
+// BOUNDBLANK-NEXT:        "range": {
+// BOUNDBLANK-NEXT:          "start": {
+// BOUNDBLANK-NEXT:            "line": 58,
+// BOUNDBLANK-NEXT:            "character": 1
+// BOUNDBLANK-NEXT:          },
+// BOUNDBLANK-NEXT:          "end": {
+// BOUNDBLANK-NEXT:            "line": 58,
+// BOUNDBLANK-NEXT:            "character": 1
+// BOUNDBLANK-NEXT:          }
+// BOUNDBLANK-NEXT:        },
+// BOUNDBLANK-NEXT:        "text": ""
+// BOUNDBLANK-NEXT:      }
+// BOUNDBLANK-NEXT:    ]
+// BOUNDBLANK-NEXT:  },
+
+// ALLINDENTED-LABEL: "precise": "s:10BlockStyle11AllIndentedV"
+// ALLINDENTED:       "docComment": {
+// ALLINDENTED-NEXT:    "lines": [
+// ALLINDENTED-NEXT:      {
+// ALLINDENTED-NEXT:        "range": {
+// ALLINDENTED-NEXT:          "start": {
+// ALLINDENTED-NEXT:            "line": 62,
+// ALLINDENTED-NEXT:            "character": 5
+// ALLINDENTED-NEXT:          },
+// ALLINDENTED-NEXT:          "end": {
+// ALLINDENTED-NEXT:            "line": 62,
+// ALLINDENTED-NEXT:            "character": 18
+// ALLINDENTED-NEXT:          }
+// ALLINDENTED-NEXT:        },
+// ALLINDENTED-NEXT:        "text": "All indented."
+// ALLINDENTED-NEXT:      },
+// ALLINDENTED-NEXT:      {
+// ALLINDENTED-NEXT:        "range": {
+// ALLINDENTED-NEXT:          "start": {
+// ALLINDENTED-NEXT:            "line": 63,
+// ALLINDENTED-NEXT:            "character": 5
+// ALLINDENTED-NEXT:          },
+// ALLINDENTED-NEXT:          "end": {
+// ALLINDENTED-NEXT:            "line": 63,
+// ALLINDENTED-NEXT:            "character": 5
+// ALLINDENTED-NEXT:          }
+// ALLINDENTED-NEXT:        },
+// ALLINDENTED-NEXT:        "text": ""
+// ALLINDENTED-NEXT:      }
+// ALLINDENTED-NEXT:    ]
+// ALLINDENTED-NEXT:  },

--- a/test/SymbolGraph/Symbols/Mixins/DocComment/BlockStyle.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DocComment/BlockStyle.swift
@@ -79,6 +79,8 @@ public struct BoundBlank {}
 
 // SINGLESAMELINE-LABEL: "precise": "s:10BlockStyle14SingleSameLineV"
 // SINGLESAMELINE:       "docComment": {
+// SINGLESAMELINE-NEXT:    "uri": "file://{{.*}}BlockStyle.swift",
+// SINGLESAMELINE-NEXT:    "module": "BlockStyle",
 // SINGLESAMELINE-NEXT:    "lines": [
 // SINGLESAMELINE-NEXT:      {
 // SINGLESAMELINE-NEXT:        "range": {
@@ -98,11 +100,15 @@ public struct BoundBlank {}
 
 // EMPTY-LABEL: "precise": "s:10BlockStyle5EmptyV"
 // EMPTY:       "docComment": {
+// EMPTY-NEXT:    "uri": "file://{{.*}}BlockStyle.swift",
+// EMPTY-NEXT:    "module": "BlockStyle",
 // EMPTY-NEXT:    "lines": []
 // EMPTY-NEXT:  },
 
 // EMPTYWITHNEWLINE-LABEL: "precise": "s:10BlockStyle16EmptyWithNewLineV"
 // EMPTYWITHNEWLINE:       "docComment": {
+// EMPTYWITHNEWLINE-NEXT:    "uri": "file://{{.*}}BlockStyle.swift",
+// EMPTYWITHNEWLINE-NEXT:    "module": "BlockStyle",
 // EMPTYWITHNEWLINE-NEXT:    "lines": [
 // EMPTYWITHNEWLINE-NEXT:      {
 // EMPTYWITHNEWLINE-NEXT:        "range": {
@@ -122,6 +128,8 @@ public struct BoundBlank {}
 
 // SINGLELINE-LABEL: "precise": "s:10BlockStyle10SingleLineV"
 // SINGLELINE:       "docComment": {
+// SINGLELINE-NEXT:    "uri": "file://{{.*}}BlockStyle.swift",
+// SINGLELINE-NEXT:    "module": "BlockStyle",
 // SINGLELINE-NEXT:    "lines": [
 // SINGLELINE-NEXT:      {
 // SINGLELINE-NEXT:        "range": {
@@ -154,6 +162,8 @@ public struct BoundBlank {}
 
 // SINGLELINEWITHART-LABEL: "precise": "s:10BlockStyle17SingleLineWithArtV"
 // SINGLELINEWITHART:       "docComment": {
+// SINGLELINEWITHART-NEXT:    "uri": "file://{{.*}}BlockStyle.swift",
+// SINGLELINEWITHART-NEXT:    "module": "BlockStyle",
 // SINGLELINEWITHART-NEXT:    "lines": [
 // SINGLELINEWITHART-NEXT:      {
 // SINGLELINEWITHART-NEXT:        "range": {
@@ -186,6 +196,8 @@ public struct BoundBlank {}
 
 // TWOLINES-LABEL: "precise": "s:10BlockStyle8TwoLinesV"
 // TWOLINES:       "docComment": {
+// TWOLINES-NEXT:    "uri": "file://{{.*}}BlockStyle.swift",
+// TWOLINES-NEXT:    "module": "BlockStyle",
 // TWOLINES-NEXT:    "lines": [
 // TWOLINES-NEXT:      {
 // TWOLINES-NEXT:        "range": {
@@ -231,6 +243,8 @@ public struct BoundBlank {}
 
 // LARGEINDENT-LABEL: "precise": "s:10BlockStyle11LargeIndentV"
 // LARGEINDENT:       "docComment": {
+// LARGEINDENT-NEXT:    "uri": "file://{{.*}}BlockStyle.swift",
+// LARGEINDENT-NEXT:    "module": "BlockStyle",
 // LARGEINDENT-NEXT:    "lines": [
 // LARGEINDENT-NEXT:      {
 // LARGEINDENT-NEXT:        "range": {
@@ -263,6 +277,8 @@ public struct BoundBlank {}
 
 // TWOLINESBETWEENBLANK-LABEL: "precise": "s:10BlockStyle20TwoLinesBetweenBlankV"
 // TWOLINESBETWEENBLANK:       "docComment": {
+// TWOLINESBETWEENBLANK-NEXT:    "uri": "file://{{.*}}BlockStyle.swift",
+// TWOLINESBETWEENBLANK-NEXT:    "module": "BlockStyle",
 // TWOLINESBETWEENBLANK-NEXT:    "lines": [
 // TWOLINESBETWEENBLANK-NEXT:      {
 // TWOLINESBETWEENBLANK-NEXT:        "range": {
@@ -321,6 +337,8 @@ public struct BoundBlank {}
 
 // LEADINGBLANK-LABEL: "precise": "s:10BlockStyle12LeadingBlankV"
 // LEADINGBLANK:       "docComment": {
+// LEADINGBLANK-NEXT:    "uri": "file://{{.*}}BlockStyle.swift",
+// LEADINGBLANK-NEXT:    "module": "BlockStyle",
 // LEADINGBLANK-NEXT:    "lines": [
 // LEADINGBLANK-NEXT:      {
 // LEADINGBLANK-NEXT:        "range": {
@@ -366,6 +384,8 @@ public struct BoundBlank {}
 
 // TRAILINGBLANK-LABEL: "precise": "s:10BlockStyle13TrailingBlankV"
 // TRAILINGBLANK:       "docComment": {
+// TRAILINGBLANK-NEXT:    "uri": "file://{{.*}}BlockStyle.swift",
+// TRAILINGBLANK-NEXT:    "module": "BlockStyle",
 // TRAILINGBLANK-NEXT:    "lines": [
 // TRAILINGBLANK-NEXT:      {
 // TRAILINGBLANK-NEXT:        "range": {
@@ -411,6 +431,8 @@ public struct BoundBlank {}
 
 // BOUNDBLANK-LABEL: "precise": "s:10BlockStyle10BoundBlankV"
 // BOUNDBLANK:       "docComment": {
+// BOUNDBLANK-NEXT:    "uri": "file://{{.*}}BlockStyle.swift",
+// BOUNDBLANK-NEXT:    "module": "BlockStyle",
 // BOUNDBLANK-NEXT:    "lines": [
 // BOUNDBLANK-NEXT:      {
 // BOUNDBLANK-NEXT:        "range": {
@@ -469,6 +491,8 @@ public struct BoundBlank {}
 
 // ALLINDENTED-LABEL: "precise": "s:10BlockStyle11AllIndentedV"
 // ALLINDENTED:       "docComment": {
+// ALLINDENTED-NEXT:    "uri": "file://{{.*}}BlockStyle.swift",
+// ALLINDENTED-NEXT:    "module": "BlockStyle",
 // ALLINDENTED-NEXT:    "lines": [
 // ALLINDENTED-NEXT:      {
 // ALLINDENTED-NEXT:        "range": {

--- a/test/SymbolGraph/Symbols/Mixins/DocComment/LineStyle.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DocComment/LineStyle.swift
@@ -1,3 +1,39 @@
+// ATTN: The RUN lines and associated tests are at the bottom of the file, to
+// keep the source locations stable.
+
+/// Single line.
+public struct SingleLine {}
+
+/// Two
+/// lines.
+public struct TwoLines {}
+
+/// Two lines
+///
+/// Around Blank
+public struct TwoLinesAroundBlank {}
+
+///
+public struct Empty {}
+
+///
+///
+///
+public struct MultiEmpty {}
+
+///
+/// Leading Blank
+public struct LeadingBlank {}
+
+/// Trailing Blank
+///
+public struct TrailingBlank {}
+
+///
+/// Bound Blank
+///
+public struct BoundBlank {}
+
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -module-name LineStyle -emit-module-path %t/LineStyle.swiftmodule
 // RUN: %target-swift-symbolgraph-extract -module-name LineStyle -I %t -pretty-print -output-dir %t
@@ -15,11 +51,11 @@
 // SINGLELINE-NEXT:      {
 // SINGLELINE-NEXT:        "range": {
 // SINGLELINE-NEXT:          "start": {
-// SINGLELINE-NEXT:            "line": 30,
+// SINGLELINE-NEXT:            "line": 3,
 // SINGLELINE-NEXT:            "character": 4
 // SINGLELINE-NEXT:          },
 // SINGLELINE-NEXT:          "end": {
-// SINGLELINE-NEXT:            "line": 30,
+// SINGLELINE-NEXT:            "line": 3,
 // SINGLELINE-NEXT:            "character": 16
 // SINGLELINE-NEXT:          }
 // SINGLELINE-NEXT:        },
@@ -28,20 +64,17 @@
 // SINGLELINE-NEXT:    ]
 // SINGLELINE-NEXT:  }
 
-/// Single line.
-public struct SingleLine {}
-
 // TWOLINES-LABEL: "precise": "s:9LineStyle8TwoLinesV"
 // TWOLINES:       "docComment": {
 // TWOLINES-NEXT:    "lines": [
 // TWOLINES-NEXT:      {
 // TWOLINES-NEXT:        "range": {
 // TWOLINES-NEXT:          "start": {
-// TWOLINES-NEXT:            "line": 65,
+// TWOLINES-NEXT:            "line": 6,
 // TWOLINES-NEXT:            "character": 4
 // TWOLINES-NEXT:          },
 // TWOLINES-NEXT:          "end": {
-// TWOLINES-NEXT:            "line": 65,
+// TWOLINES-NEXT:            "line": 6,
 // TWOLINES-NEXT:            "character": 7
 // TWOLINES-NEXT:          }
 // TWOLINES-NEXT:        },
@@ -50,11 +83,11 @@ public struct SingleLine {}
 // TWOLINES-NEXT:      {
 // TWOLINES-NEXT:        "range": {
 // TWOLINES-NEXT:          "start": {
-// TWOLINES-NEXT:            "line": 66,
+// TWOLINES-NEXT:            "line": 7,
 // TWOLINES-NEXT:            "character": 4
 // TWOLINES-NEXT:          },
 // TWOLINES-NEXT:          "end": {
-// TWOLINES-NEXT:            "line": 66,
+// TWOLINES-NEXT:            "line": 7,
 // TWOLINES-NEXT:            "character": 10
 // TWOLINES-NEXT:          }
 // TWOLINES-NEXT:        },
@@ -63,21 +96,17 @@ public struct SingleLine {}
 // TWOLINES-NEXT:    ]
 // TWOLINES-NEXT:  },
 
-/// Two
-/// lines.
-public struct TwoLines {}
-
 // TWOLINESAROUNDBLANK-LABEL: "precise": "s:9LineStyle19TwoLinesAroundBlankV"
 // TWOLINESAROUNDBLANK:       "docComment": {
 // TWOLINESAROUNDBLANK-NEXT:    "lines": [
 // TWOLINESAROUNDBLANK-NEXT:      {
 // TWOLINESAROUNDBLANK-NEXT:        "range": {
 // TWOLINESAROUNDBLANK-NEXT:          "start": {
-// TWOLINESAROUNDBLANK-NEXT:            "line": 114,
+// TWOLINESAROUNDBLANK-NEXT:            "line": 10,
 // TWOLINESAROUNDBLANK-NEXT:            "character": 4
 // TWOLINESAROUNDBLANK-NEXT:          },
 // TWOLINESAROUNDBLANK-NEXT:          "end": {
-// TWOLINESAROUNDBLANK-NEXT:            "line": 114,
+// TWOLINESAROUNDBLANK-NEXT:            "line": 10,
 // TWOLINESAROUNDBLANK-NEXT:            "character": 13
 // TWOLINESAROUNDBLANK-NEXT:          }
 // TWOLINESAROUNDBLANK-NEXT:        },
@@ -86,11 +115,11 @@ public struct TwoLines {}
 // TWOLINESAROUNDBLANK-NEXT:      {
 // TWOLINESAROUNDBLANK-NEXT:        "range": {
 // TWOLINESAROUNDBLANK-NEXT:          "start": {
-// TWOLINESAROUNDBLANK-NEXT:            "line": 115,
+// TWOLINESAROUNDBLANK-NEXT:            "line": 11,
 // TWOLINESAROUNDBLANK-NEXT:            "character": 3
 // TWOLINESAROUNDBLANK-NEXT:          },
 // TWOLINESAROUNDBLANK-NEXT:          "end": {
-// TWOLINESAROUNDBLANK-NEXT:            "line": 115,
+// TWOLINESAROUNDBLANK-NEXT:            "line": 11,
 // TWOLINESAROUNDBLANK-NEXT:            "character": 3
 // TWOLINESAROUNDBLANK-NEXT:          }
 // TWOLINESAROUNDBLANK-NEXT:        },
@@ -99,11 +128,11 @@ public struct TwoLines {}
 // TWOLINESAROUNDBLANK-NEXT:      {
 // TWOLINESAROUNDBLANK-NEXT:        "range": {
 // TWOLINESAROUNDBLANK-NEXT:          "start": {
-// TWOLINESAROUNDBLANK-NEXT:            "line": 116,
+// TWOLINESAROUNDBLANK-NEXT:            "line": 12,
 // TWOLINESAROUNDBLANK-NEXT:            "character": 4
 // TWOLINESAROUNDBLANK-NEXT:          },
 // TWOLINESAROUNDBLANK-NEXT:          "end": {
-// TWOLINESAROUNDBLANK-NEXT:            "line": 116,
+// TWOLINESAROUNDBLANK-NEXT:            "line": 12,
 // TWOLINESAROUNDBLANK-NEXT:            "character": 16
 // TWOLINESAROUNDBLANK-NEXT:          }
 // TWOLINESAROUNDBLANK-NEXT:        },
@@ -112,22 +141,17 @@ public struct TwoLines {}
 // TWOLINESAROUNDBLANK-NEXT:    ]
 // TWOLINESAROUNDBLANK-NEXT:  }
 
-/// Two lines
-///
-/// Around Blank
-public struct TwoLinesAroundBlank {}
-
 // EMPTY-LABEL: "precise": "s:9LineStyle5EmptyV"
 // EMPTY:       "docComment": {
 // EMPTY-NEXT:    "lines": [
 // EMPTY-NEXT:      {
 // EMPTY-NEXT:        "range": {
 // EMPTY-NEXT:          "start": {
-// EMPTY-NEXT:            "line": 138,
+// EMPTY-NEXT:            "line": 15,
 // EMPTY-NEXT:            "character": 3
 // EMPTY-NEXT:          },
 // EMPTY-NEXT:          "end": {
-// EMPTY-NEXT:            "line": 138,
+// EMPTY-NEXT:            "line": 15,
 // EMPTY-NEXT:            "character": 3
 // EMPTY-NEXT:          }
 // EMPTY-NEXT:        },
@@ -136,20 +160,17 @@ public struct TwoLinesAroundBlank {}
 // EMPTY-NEXT:    ]
 // EMPTY-NEXT:  },
 
-///
-public struct Empty {}
-
 // MULTIEMPTY-LABEL: "precise": "s:9LineStyle10MultiEmptyV"
 // MULTIEMPTY:       "docComment": {
 // MULTIEMPTY-NEXT:    "lines": [
 // MULTIEMPTY-NEXT:      {
 // MULTIEMPTY-NEXT:        "range": {
 // MULTIEMPTY-NEXT:          "start": {
-// MULTIEMPTY-NEXT:            "line": 186,
+// MULTIEMPTY-NEXT:            "line": 18,
 // MULTIEMPTY-NEXT:            "character": 3
 // MULTIEMPTY-NEXT:          },
 // MULTIEMPTY-NEXT:          "end": {
-// MULTIEMPTY-NEXT:            "line": 186,
+// MULTIEMPTY-NEXT:            "line": 18,
 // MULTIEMPTY-NEXT:            "character": 3
 // MULTIEMPTY-NEXT:          }
 // MULTIEMPTY-NEXT:        },
@@ -158,11 +179,11 @@ public struct Empty {}
 // MULTIEMPTY-NEXT:      {
 // MULTIEMPTY-NEXT:        "range": {
 // MULTIEMPTY-NEXT:          "start": {
-// MULTIEMPTY-NEXT:            "line": 187,
+// MULTIEMPTY-NEXT:            "line": 19,
 // MULTIEMPTY-NEXT:            "character": 3
 // MULTIEMPTY-NEXT:          },
 // MULTIEMPTY-NEXT:          "end": {
-// MULTIEMPTY-NEXT:            "line": 187,
+// MULTIEMPTY-NEXT:            "line": 19,
 // MULTIEMPTY-NEXT:            "character": 3
 // MULTIEMPTY-NEXT:          }
 // MULTIEMPTY-NEXT:        },
@@ -171,11 +192,11 @@ public struct Empty {}
 // MULTIEMPTY-NEXT:      {
 // MULTIEMPTY-NEXT:        "range": {
 // MULTIEMPTY-NEXT:          "start": {
-// MULTIEMPTY-NEXT:            "line": 188,
+// MULTIEMPTY-NEXT:            "line": 20,
 // MULTIEMPTY-NEXT:            "character": 3
 // MULTIEMPTY-NEXT:          },
 // MULTIEMPTY-NEXT:          "end": {
-// MULTIEMPTY-NEXT:            "line": 188,
+// MULTIEMPTY-NEXT:            "line": 20,
 // MULTIEMPTY-NEXT:            "character": 3
 // MULTIEMPTY-NEXT:          }
 // MULTIEMPTY-NEXT:        },
@@ -184,22 +205,17 @@ public struct Empty {}
 // MULTIEMPTY-NEXT:    ]
 // MULTIEMPTY-NEXT:  },
 
-///
-///
-///
-public struct MultiEmpty {}
-
 // LEADINGBLANK-LABEL: "precise": "s:9LineStyle12LeadingBlankV",
 // LEADINGBLANK:       "docComment": {
 // LEADINGBLANK-NEXT:    "lines": [
 // LEADINGBLANK-NEXT:      {
 // LEADINGBLANK-NEXT:        "range": {
 // LEADINGBLANK-NEXT:          "start": {
-// LEADINGBLANK-NEXT:            "line": 223,
+// LEADINGBLANK-NEXT:            "line": 23,
 // LEADINGBLANK-NEXT:            "character": 3
 // LEADINGBLANK-NEXT:          },
 // LEADINGBLANK-NEXT:          "end": {
-// LEADINGBLANK-NEXT:            "line": 223,
+// LEADINGBLANK-NEXT:            "line": 23,
 // LEADINGBLANK-NEXT:            "character": 3
 // LEADINGBLANK-NEXT:          }
 // LEADINGBLANK-NEXT:        },
@@ -208,11 +224,11 @@ public struct MultiEmpty {}
 // LEADINGBLANK-NEXT:      {
 // LEADINGBLANK-NEXT:        "range": {
 // LEADINGBLANK-NEXT:          "start": {
-// LEADINGBLANK-NEXT:            "line": 224,
+// LEADINGBLANK-NEXT:            "line": 24,
 // LEADINGBLANK-NEXT:            "character": 4
 // LEADINGBLANK-NEXT:          },
 // LEADINGBLANK-NEXT:          "end": {
-// LEADINGBLANK-NEXT:            "line": 224,
+// LEADINGBLANK-NEXT:            "line": 24,
 // LEADINGBLANK-NEXT:            "character": 17
 // LEADINGBLANK-NEXT:          }
 // LEADINGBLANK-NEXT:        },
@@ -221,21 +237,17 @@ public struct MultiEmpty {}
 // LEADINGBLANK-NEXT:    ]
 // LEADINGBLANK-NEXT:  }
 
-///
-/// Leading Blank
-public struct LeadingBlank {}
-
 // TRAILINGBLANK-LABEL: "precise": "s:9LineStyle13TrailingBlankV"
 // TRAILINGBLANK:       "docComment": {
 // TRAILINGBLANK-NEXT:    "lines": [
 // TRAILINGBLANK-NEXT:      {
 // TRAILINGBLANK-NEXT:        "range": {
 // TRAILINGBLANK-NEXT:          "start": {
-// TRAILINGBLANK-NEXT:            "line": 259,
+// TRAILINGBLANK-NEXT:            "line": 27,
 // TRAILINGBLANK-NEXT:            "character": 4
 // TRAILINGBLANK-NEXT:          },
 // TRAILINGBLANK-NEXT:          "end": {
-// TRAILINGBLANK-NEXT:            "line": 259,
+// TRAILINGBLANK-NEXT:            "line": 27,
 // TRAILINGBLANK-NEXT:            "character": 18
 // TRAILINGBLANK-NEXT:          }
 // TRAILINGBLANK-NEXT:        },
@@ -244,11 +256,11 @@ public struct LeadingBlank {}
 // TRAILINGBLANK-NEXT:      {
 // TRAILINGBLANK-NEXT:        "range": {
 // TRAILINGBLANK-NEXT:          "start": {
-// TRAILINGBLANK-NEXT:            "line": 260,
+// TRAILINGBLANK-NEXT:            "line": 28,
 // TRAILINGBLANK-NEXT:            "character": 3
 // TRAILINGBLANK-NEXT:          },
 // TRAILINGBLANK-NEXT:          "end": {
-// TRAILINGBLANK-NEXT:            "line": 260,
+// TRAILINGBLANK-NEXT:            "line": 28,
 // TRAILINGBLANK-NEXT:            "character": 3
 // TRAILINGBLANK-NEXT:          }
 // TRAILINGBLANK-NEXT:        },
@@ -257,21 +269,17 @@ public struct LeadingBlank {}
 // TRAILINGBLANK-NEXT:    ]
 // TRAILINGBLANK-NEXT:  },
 
-/// Trailing Blank
-///
-public struct TrailingBlank {} 
-
 // BOUNDBLANK-LABEL: "precise": "s:9LineStyle10BoundBlankV"
 // BOUNDBLANK:       "docComment": {
 // BOUNDBLANK-NEXT:    "lines": [
 // BOUNDBLANK-NEXT:      {
 // BOUNDBLANK-NEXT:        "range": {
 // BOUNDBLANK-NEXT:          "start": {
-// BOUNDBLANK-NEXT:            "line": 308,
+// BOUNDBLANK-NEXT:            "line": 31,
 // BOUNDBLANK-NEXT:            "character": 3
 // BOUNDBLANK-NEXT:          },
 // BOUNDBLANK-NEXT:          "end": {
-// BOUNDBLANK-NEXT:            "line": 308,
+// BOUNDBLANK-NEXT:            "line": 31,
 // BOUNDBLANK-NEXT:            "character": 3
 // BOUNDBLANK-NEXT:          }
 // BOUNDBLANK-NEXT:        },
@@ -280,11 +288,11 @@ public struct TrailingBlank {}
 // BOUNDBLANK-NEXT:      {
 // BOUNDBLANK-NEXT:        "range": {
 // BOUNDBLANK-NEXT:          "start": {
-// BOUNDBLANK-NEXT:            "line": 309,
+// BOUNDBLANK-NEXT:            "line": 32,
 // BOUNDBLANK-NEXT:            "character": 3
 // BOUNDBLANK-NEXT:          },
 // BOUNDBLANK-NEXT:          "end": {
-// BOUNDBLANK-NEXT:            "line": 309,
+// BOUNDBLANK-NEXT:            "line": 32,
 // BOUNDBLANK-NEXT:            "character": 15
 // BOUNDBLANK-NEXT:          }
 // BOUNDBLANK-NEXT:        },
@@ -293,11 +301,11 @@ public struct TrailingBlank {}
 // BOUNDBLANK-NEXT:      {
 // BOUNDBLANK-NEXT:        "range": {
 // BOUNDBLANK-NEXT:          "start": {
-// BOUNDBLANK-NEXT:            "line": 310,
+// BOUNDBLANK-NEXT:            "line": 33,
 // BOUNDBLANK-NEXT:            "character": 3
 // BOUNDBLANK-NEXT:          },
 // BOUNDBLANK-NEXT:          "end": {
-// BOUNDBLANK-NEXT:            "line": 310,
+// BOUNDBLANK-NEXT:            "line": 33,
 // BOUNDBLANK-NEXT:            "character": 3
 // BOUNDBLANK-NEXT:          }
 // BOUNDBLANK-NEXT:        },
@@ -305,8 +313,3 @@ public struct TrailingBlank {}
 // BOUNDBLANK-NEXT:      }
 // BOUNDBLANK-NEXT:    ]
 // BOUNDBLANK-NEXT:  },
-
-///
-/// Bound Blank
-///
-public struct BoundBlank {}

--- a/test/SymbolGraph/Symbols/Mixins/DocComment/LineStyle.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DocComment/LineStyle.swift
@@ -47,6 +47,8 @@ public struct BoundBlank {}
 
 // SINGLELINE-LABEL: "precise": "s:9LineStyle06SingleA0V"
 // SINGLELINE:       "docComment": {
+// SINGLELINE-NEXT:    "uri": "file://{{.*}}LineStyle.swift",
+// SINGLELINE-NEXT:    "module": "LineStyle",
 // SINGLELINE-NEXT:    "lines": [
 // SINGLELINE-NEXT:      {
 // SINGLELINE-NEXT:        "range": {
@@ -66,6 +68,8 @@ public struct BoundBlank {}
 
 // TWOLINES-LABEL: "precise": "s:9LineStyle8TwoLinesV"
 // TWOLINES:       "docComment": {
+// TWOLINES-NEXT:    "uri": "file://{{.*}}LineStyle.swift",
+// TWOLINES-NEXT:    "module": "LineStyle",
 // TWOLINES-NEXT:    "lines": [
 // TWOLINES-NEXT:      {
 // TWOLINES-NEXT:        "range": {
@@ -98,6 +102,8 @@ public struct BoundBlank {}
 
 // TWOLINESAROUNDBLANK-LABEL: "precise": "s:9LineStyle19TwoLinesAroundBlankV"
 // TWOLINESAROUNDBLANK:       "docComment": {
+// TWOLINESAROUNDBLANK-NEXT:    "uri": "file://{{.*}}LineStyle.swift",
+// TWOLINESAROUNDBLANK-NEXT:    "module": "LineStyle",
 // TWOLINESAROUNDBLANK-NEXT:    "lines": [
 // TWOLINESAROUNDBLANK-NEXT:      {
 // TWOLINESAROUNDBLANK-NEXT:        "range": {
@@ -143,6 +149,8 @@ public struct BoundBlank {}
 
 // EMPTY-LABEL: "precise": "s:9LineStyle5EmptyV"
 // EMPTY:       "docComment": {
+// EMPTY-NEXT:    "uri": "file://{{.*}}LineStyle.swift",
+// EMPTY-NEXT:    "module": "LineStyle",
 // EMPTY-NEXT:    "lines": [
 // EMPTY-NEXT:      {
 // EMPTY-NEXT:        "range": {
@@ -162,6 +170,8 @@ public struct BoundBlank {}
 
 // MULTIEMPTY-LABEL: "precise": "s:9LineStyle10MultiEmptyV"
 // MULTIEMPTY:       "docComment": {
+// MULTIEMPTY-NEXT:    "uri": "file://{{.*}}LineStyle.swift",
+// MULTIEMPTY-NEXT:    "module": "LineStyle",
 // MULTIEMPTY-NEXT:    "lines": [
 // MULTIEMPTY-NEXT:      {
 // MULTIEMPTY-NEXT:        "range": {
@@ -207,6 +217,8 @@ public struct BoundBlank {}
 
 // LEADINGBLANK-LABEL: "precise": "s:9LineStyle12LeadingBlankV",
 // LEADINGBLANK:       "docComment": {
+// LEADINGBLANK-NEXT:    "uri": "file://{{.*}}LineStyle.swift",
+// LEADINGBLANK-NEXT:    "module": "LineStyle",
 // LEADINGBLANK-NEXT:    "lines": [
 // LEADINGBLANK-NEXT:      {
 // LEADINGBLANK-NEXT:        "range": {
@@ -239,6 +251,8 @@ public struct BoundBlank {}
 
 // TRAILINGBLANK-LABEL: "precise": "s:9LineStyle13TrailingBlankV"
 // TRAILINGBLANK:       "docComment": {
+// TRAILINGBLANK-NEXT:    "uri": "file://{{.*}}LineStyle.swift",
+// TRAILINGBLANK-NEXT:    "module": "LineStyle",
 // TRAILINGBLANK-NEXT:    "lines": [
 // TRAILINGBLANK-NEXT:      {
 // TRAILINGBLANK-NEXT:        "range": {
@@ -271,6 +285,8 @@ public struct BoundBlank {}
 
 // BOUNDBLANK-LABEL: "precise": "s:9LineStyle10BoundBlankV"
 // BOUNDBLANK:       "docComment": {
+// BOUNDBLANK-NEXT:    "uri": "file://{{.*}}LineStyle.swift",
+// BOUNDBLANK-NEXT:    "module": "LineStyle",
 // BOUNDBLANK-NEXT:    "lines": [
 // BOUNDBLANK-NEXT:      {
 // BOUNDBLANK-NEXT:        "range": {

--- a/test/SymbolGraph/Symbols/Mixins/DocComment/SourceModule.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DocComment/SourceModule.swift
@@ -1,0 +1,96 @@
+// FYI: The lit commands and FileCheck statements are at the bottom of the file, to be resilient
+// against changes to the doc comment format.
+
+public protocol P {
+   /// same module doc
+   func something()
+}
+
+public struct NoDocOverride: Hashable, P {
+   public func hash(into: inout Hasher) {}
+   public func something() {}
+}
+
+public struct Override: Hashable, P {
+   /// override of doc from Swift
+   public func hash(into: inout Hasher) {}
+   /// override of doc from same module symbol
+   public func something() {}
+}
+
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name SourceModule -emit-module-path %t/SourceModule.swiftmodule
+// RUN: %target-swift-symbolgraph-extract -module-name SourceModule -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/SourceModule.symbols.json --check-prefix=NO-OVERRIDE-SAME
+// RUN: %FileCheck %s --input-file %t/SourceModule.symbols.json --check-prefix=NO-OVERRIDE-OTHER
+// RUN: %FileCheck %s --input-file %t/SourceModule.symbols.json --check-prefix=OVERRIDE-SAME
+// RUN: %FileCheck %s --input-file %t/SourceModule.symbols.json --check-prefix=OVERRIDE-OTHER
+
+// NO-OVERRIDE-SAME-LABEL: "precise": "s:12SourceModule13NoDocOverrideV9somethingyyF"
+// NO-OVERRIDE-SAME:      "docComment": {
+// NO-OVERRIDE-SAME-NEXT:        "uri": "file://{{.*}}SourceModule.swift",
+// NO-OVERRIDE-SAME-NEXT:        "module": "SourceModule",
+// NO-OVERRIDE-SAME-NEXT:        "lines": [
+// NO-OVERRIDE-SAME-NEXT:          {
+// NO-OVERRIDE-SAME-NEXT:            "range": {
+// NO-OVERRIDE-SAME-NEXT:              "start": {
+// NO-OVERRIDE-SAME-NEXT:                "line": 4,
+// NO-OVERRIDE-SAME-NEXT:                "character": 7
+// NO-OVERRIDE-SAME-NEXT:              },
+// NO-OVERRIDE-SAME-NEXT:              "end": {
+// NO-OVERRIDE-SAME-NEXT:                "line": 4,
+// NO-OVERRIDE-SAME-NEXT:                "character": 22
+// NO-OVERRIDE-SAME-NEXT:              }
+// NO-OVERRIDE-SAME-NEXT:            },
+// NO-OVERRIDE-SAME-NEXT:            "text": "same module doc"
+// NO-OVERRIDE-SAME-NEXT:          }
+// NO-OVERRIDE-SAME-NEXT:        ]
+// NO-OVERRIDE-SAME-NEXT:      }
+
+// NO-OVERRIDE-OTHER-LABEL: "precise": "s:12SourceModule13NoDocOverrideV4hash4intoys6HasherVz_tF"
+// NO-OVERRIDE-OTHER:      "docComment": {
+// NO-OVERRIDE-OTHER-NEXT:        "module": "Swift",
+// NO-OVERRIDE-OTHER-NEXT:        "lines": [
+// actual doc comment lines skipped because they're from the stdlib
+
+// OVERRIDE-SAME-LABEL: "precise": "s:12SourceModule8OverrideV9somethingyyF",
+// OVERRIDE-SAME:      "docComment": {
+// OVERRIDE-SAME-NEXT:        "uri": "file://{{.*}}SourceModule.swift",
+// OVERRIDE-SAME-NEXT:        "module": "SourceModule",
+// OVERRIDE-SAME-NEXT:        "lines": [
+// OVERRIDE-SAME-NEXT:          {
+// OVERRIDE-SAME-NEXT:            "range": {
+// OVERRIDE-SAME-NEXT:              "start": {
+// OVERRIDE-SAME-NEXT:                "line": 16,
+// OVERRIDE-SAME-NEXT:                "character": 7
+// OVERRIDE-SAME-NEXT:              },
+// OVERRIDE-SAME-NEXT:              "end": {
+// OVERRIDE-SAME-NEXT:                "line": 16,
+// OVERRIDE-SAME-NEXT:                "character": 46
+// OVERRIDE-SAME-NEXT:              }
+// OVERRIDE-SAME-NEXT:            },
+// OVERRIDE-SAME-NEXT:            "text": "override of doc from same module symbol"
+// OVERRIDE-SAME-NEXT:          }
+// OVERRIDE-SAME-NEXT:        ]
+// OVERRIDE-SAME-NEXT:      }
+
+// OVERRIDE-OTHER-LABEL: "precise": "s:12SourceModule8OverrideV4hash4intoys6HasherVz_tF",
+// OVERRIDE-OTHER:      "docComment": {
+// OVERRIDE-OTHER-NEXT:        "uri": "file://{{.*}}SourceModule.swift",
+// OVERRIDE-OTHER-NEXT:        "module": "SourceModule",
+// OVERRIDE-OTHER-NEXT:        "lines": [
+// OVERRIDE-OTHER-NEXT:          {
+// OVERRIDE-OTHER-NEXT:            "range": {
+// OVERRIDE-OTHER-NEXT:              "start": {
+// OVERRIDE-OTHER-NEXT:                "line": 14,
+// OVERRIDE-OTHER-NEXT:                "character": 7
+// OVERRIDE-OTHER-NEXT:              },
+// OVERRIDE-OTHER-NEXT:              "end": {
+// OVERRIDE-OTHER-NEXT:                "line": 14,
+// OVERRIDE-OTHER-NEXT:                "character": 33
+// OVERRIDE-OTHER-NEXT:              }
+// OVERRIDE-OTHER-NEXT:            },
+// OVERRIDE-OTHER-NEXT:            "text": "override of doc from Swift"
+// OVERRIDE-OTHER-NEXT:          }
+// OVERRIDE-OTHER-NEXT:        ]
+// OVERRIDE-OTHER-NEXT:      },


### PR DESCRIPTION
Resolves rdar://81190369

Currently, doc comments in the symbol graph only include information about line/column numbers when referring to its location. However, if docs are inherited (and source information is available), these locations may point to a different file than the one for the symbol's declaration. In addition, the inherited doc comment might have been written with its original module in mind, for example by using Swift-DocC symbol links that point to other symbols in the module. These symbols may not be able to resolve in the inheriting module, which causes spurious errors when building documentation.

This PR adds two new sub-fields to the `docComment` field: `uri` and `module`. The `uri` field points to the file from which the doc comment was declared, and the `module` field indicates which module it's in. This can be used for more accurate diagnostics (even in docs are inherited within the same module) and to determine when a doc comment is inherited from a different module than the one being documented.