### PR TITLE
Correct the expected output in an example

### DIFF
--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -1878,7 +1878,7 @@ extension BinaryInteger {
 ///     print(Int16.max.binaryString)
 ///     // Prints "0b01111111_11111111"
 ///     print((101 as UInt8).binaryString)
-///     // Prints "0b11001001"
+///     // Prints "0b01100101"
 ///
 /// The `binaryString` implementation uses the static `bitWidth` property and
 /// the right shift operator (`>>`), both of which are available to any type


### PR DESCRIPTION
Confirmed in a REPL that the new value is correct:

```
  1> extension FixedWidthInteger { 
  2.     var binaryString: String { 
  3.         var result: [String] = [] 
  4.         for i in 0..<(Self.bitWidth / 8) { 
  5.             let byte = UInt8(truncatingIfNeeded: self >> (i * 8)) 
  6.             let byteString = String(byte, radix: 2) 
  7.             let padding = String(repeating: "0", 
  8.             count: 8 - byteString.count) 
  9.             result.append(padding + byteString) 
 10.         } 
 11.         return "0b" + result.reversed().joined(separator: "_") 
 12.     } 
 13. }
 14>  
 15> Int16.max.binaryString
$R0: String = "0b01111111_11111111"
 16> print((101 as UInt8).binaryString)
0b01100101
```