### PR TITLE
[5.7][Parseable Output] Compute file extensions using full extension strings

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -588,6 +588,29 @@ mapFrontendInvocationToAction(const CompilerInvocation &Invocation) {
   // StaticLinkJob, DynamicLinkJob
 }
 
+// TODO: Apply elsewhere in the compiler
+static swift::file_types::ID computeFileTypeForPath(const StringRef Path) {
+  if (!llvm::sys::path::has_extension(Path))
+    return swift::file_types::ID::TY_INVALID;
+
+  auto Extension = llvm::sys::path::extension(Path).str();
+  auto FileType = file_types::lookupTypeForExtension(Extension);
+  if (FileType == swift::file_types::ID::TY_INVALID) {
+    auto PathStem = llvm::sys::path::stem(Path);
+    // If this path has a multiple '.' extension (e.g. .abi.json),
+    // then iterate over all preceeding possible extension variants.
+    while (llvm::sys::path::has_extension(PathStem)) {
+      auto NextExtension = llvm::sys::path::extension(PathStem);
+      Extension = NextExtension.str() + Extension;
+      FileType = file_types::lookupTypeForExtension(Extension);
+      if (FileType != swift::file_types::ID::TY_INVALID)
+        break;
+    }
+  }
+
+  return FileType;
+}
+
 static DetailedTaskDescription
 constructDetailedTaskDescription(const CompilerInvocation &Invocation,
                                  ArrayRef<InputFile> PrimaryInputs,
@@ -612,20 +635,15 @@ constructDetailedTaskDescription(const CompilerInvocation &Invocation,
   for (const auto &input : PrimaryInputs) {
     // Main outputs
     auto OutputFile = input.outputFilename();
-    if (!OutputFile.empty()) {
-      Outputs.push_back(OutputPair(file_types::lookupTypeForExtension(
-                                       llvm::sys::path::extension(OutputFile)),
-                                   OutputFile));
-    }
+    if (!OutputFile.empty())
+      Outputs.push_back(OutputPair(computeFileTypeForPath(OutputFile), OutputFile));
 
     // Supplementary outputs
     const auto &primarySpecificFiles = input.getPrimarySpecificPaths();
     const auto &supplementaryOutputPaths =
         primarySpecificFiles.SupplementaryOutputs;
     supplementaryOutputPaths.forEachSetOutput([&](const std::string &output) {
-      Outputs.push_back(OutputPair(file_types::lookupTypeForExtension(
-                                       llvm::sys::path::extension(output)),
-                                   output));
+      Outputs.push_back(OutputPair(computeFileTypeForPath(output), output));
     });
   }
   return DetailedTaskDescription{Executable, Arguments, CommandLine, Inputs,

--- a/test/Frontend/parseable_output.swift
+++ b/test/Frontend/parseable_output.swift
@@ -1,12 +1,12 @@
-// RUN: %target-swift-frontend -primary-file %s %S/Inputs/filelist-other.swift -o %t.out -module-name parseable_output -emit-module -emit-module-path %t.swiftmodule -serialize-diagnostics -serialize-diagnostics-path %t.dia -frontend-parseable-output 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s %S/Inputs/filelist-other.swift -o %t.out -module-name parseable_output -empty-abi-descriptor -emit-abi-descriptor-path %t.abi.json -emit-module -emit-module-path %t.swiftmodule -serialize-diagnostics -serialize-diagnostics-path %t.dia -frontend-parseable-output 2>&1 | %FileCheck %s
 // Check without primary files (WMO):
-// RUN: %target-swift-frontend %s %S/Inputs/filelist-other.swift -o %t.out -module-name parseable_output -emit-module -emit-module-path %t.swiftmodule -serialize-diagnostics -serialize-diagnostics-path %t.dia -frontend-parseable-output 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend %s %S/Inputs/filelist-other.swift -o %t.out -module-name parseable_output -empty-abi-descriptor -emit-abi-descriptor-path %t.abi.json -emit-module -emit-module-path %t.swiftmodule -serialize-diagnostics -serialize-diagnostics-path %t.dia -frontend-parseable-output 2>&1 | %FileCheck %s
 
 // CHECK: {{[1-9][0-9]*}}
 // CHECK-NEXT: {
 // CHECK-NEXT:   "kind": "began",
 // CHECK-NEXT:   "name": "compile",
-// CHECK-NEXT:   "command": "{{.*[\\/]}}swift-frontend{{(\.exe)?}}{{.*}} {{.*[\\/]}}parseable_output.swift {{.*[\\/]}}filelist-other.swift -o {{.*[\\/]}}parseable_output.swift.tmp.out -module-name parseable_output -emit-module -emit-module-path {{.*[\\/]}}parseable_output.swift.tmp.swiftmodule -serialize-diagnostics -serialize-diagnostics-path {{.*[\\/]}}parseable_output.swift.tmp.dia -frontend-parseable-output",
+// CHECK-NEXT:   "command": "{{.*[\\/]}}swift-frontend{{(\.exe)?}}{{.*}} {{.*[\\/]}}parseable_output.swift {{.*[\\/]}}filelist-other.swift -o {{.*[\\/]}}parseable_output.swift.tmp.out -module-name parseable_output -empty-abi-descriptor -emit-abi-descriptor-path {{.*[\\/]}}parseable_output.swift.tmp.abi.json -emit-module -emit-module-path {{.*[\\/]}}parseable_output.swift.tmp.swiftmodule -serialize-diagnostics -serialize-diagnostics-path {{.*[\\/]}}parseable_output.swift.tmp.dia -frontend-parseable-output",
 // CHECK-NEXT:   "command_executable": "{{.*[\\/]}}swift{{(-frontend|c)?(\.exe)?}}",
 // CHECK-NEXT:   "command_arguments": [
 // CHECK:          "{{.*[\\/]}}parseable_output.swift",
@@ -14,6 +14,9 @@
 // CHECK-NEXT:     "{{.*[\\/]}}parseable_output.swift.tmp.out",
 // CHECK-NEXT:     "-module-name",
 // CHECK-NEXT:     "parseable_output",
+// CHECK-NEXT:     "-empty-abi-descriptor",
+// CHECK-NEXT:     "-emit-abi-descriptor-path",
+// CHECK-NEXT:     "{{.*[\\/]}}parseable_output.swift.tmp.abi.json",
 // CHECK-NEXT:     "-emit-module",
 // CHECK-NEXT:     "-emit-module-path",
 // CHECK-NEXT:     "{{.*[\\/]}}parseable_output.swift.tmp.swiftmodule",
@@ -36,6 +39,10 @@
 // CHECK-NEXT:       {
 // CHECK-NEXT:         "type": "diagnostics",
 // CHECK-NEXT:         "path": "{{.*[\\/]}}parseable_output.swift.tmp.dia"
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "type": "abi-baseline-json",
+// CHECK-NEXT:         "path": "{{.*[\\/]}}parseable_output.swift.tmp.abi.json"
 // CHECK-NEXT:       }
 // CHECK-NEXT:     ],
 // CHECK-NEXT:     "pid": [[PID:[0-9]*]]


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/58865
----------------------------------------------------------
Generation of valid JSON output for parseable output depends on being able to determine file types of inputs and outputs of compilation tasks. FileTypes.def defines multiple file kinds with multiple . extensions, such as .abi.json or .features.json, but existing code attempted to compute file outputs only using the trailing suffix of the path after the last .. This led to some files not being recognized, which led to us not being able to generate valid JSON.

We have this problem broadly in other places in the compiler but I wanted to have a narrow fix for this release first.

Resolves rdar://92961252
