### PR TITLE
[5.7-04182022][Parseable Output] Compute file extensions using full extension strings

### DIFF
--- a/test/Frontend/parseable_output.swift
+++ b/test/Frontend/parseable_output.swift
@@ -1,16 +1,24 @@
-// RUN: %target-swift-frontend -primary-file %s -o %t.out -emit-module -emit-module-path %t.swiftmodule -frontend-parseable-output 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s %S/Inputs/filelist-other.swift -o %t.out -module-name parseable_output -empty-abi-descriptor -emit-abi-descriptor-path %t.abi.json -emit-module -emit-module-path %t.swiftmodule -serialize-diagnostics -serialize-diagnostics-path %t.dia -frontend-parseable-output 2>&1 | %FileCheck %s
+// Check without primary files (WMO):
+// RUN: %target-swift-frontend %s %S/Inputs/filelist-other.swift -o %t.out -module-name parseable_output -empty-abi-descriptor -emit-abi-descriptor-path %t.abi.json -emit-module -emit-module-path %t.swiftmodule -serialize-diagnostics -serialize-diagnostics-path %t.dia -frontend-parseable-output 2>&1 | %FileCheck %s
+
 
 // CHECK: {{[1-9][0-9]*}}
 // CHECK-NEXT: {
 // CHECK-NEXT:   "kind": "began",
 // CHECK-NEXT:   "name": "compile",
-// CHECK-NEXT:   "command": "{{.*[\\/]}}swift-frontend{{(\.exe)?}}{{.*}}-primary-file {{.*[\\/]}}parseable_output.swift -o {{.*[\\/]}}parseable_output.swift.tmp.out  -emit-module -emit-module-path {{.*[\\/]}}parseable_output.swift.tmp.swiftmodule -frontend-parseable-output",
+// CHECK-NEXT:   "command": "{{.*[\\/]}}swift-frontend{{(\.exe)?}}{{.*}} {{.*[\\/]}}parseable_output.swift {{.*[\\/]}}filelist-other.swift -o {{.*[\\/]}}parseable_output.swift.tmp.out -module-name parseable_output -empty-abi-descriptor -emit-abi-descriptor-path {{.*[\\/]}}parseable_output.swift.tmp.abi.json -emit-module -emit-module-path {{.*[\\/]}}parseable_output.swift.tmp.swiftmodule -serialize-diagnostics -serialize-diagnostics-path {{.*[\\/]}}parseable_output.swift.tmp.dia -frontend-parseable-output",
 // CHECK-NEXT:   "command_executable": "{{.*[\\/]}}swift{{(-frontend|c)?(\.exe)?}}",
 // CHECK-NEXT:   "command_arguments": [
 // CHECK:          "-primary-file",
 // CHECK-NEXT:     "{{.*[\\/]}}parseable_output.swift",
 // CHECK:          "-o",
 // CHECK-NEXT:     "{{.*[\\/]}}parseable_output.swift.tmp.out",
+// CHECK-NEXT:     "-module-name",
+// CHECK-NEXT:     "parseable_output",
+// CHECK-NEXT:     "-empty-abi-descriptor",
+// CHECK-NEXT:     "-emit-abi-descriptor-path",
+// CHECK-NEXT:     "{{.*[\\/]}}parseable_output.swift.tmp.abi.json",
 // CHECK-NEXT:     "-emit-module",
 // CHECK-NEXT:     "-emit-module-path",
 // CHECK-NEXT:     "{{.*[\\/]}}parseable_output.swift.tmp.swiftmodule",
@@ -27,6 +35,14 @@
 // CHECK-NEXT:       {
 // CHECK-NEXT:         "type": "swiftmodule",
 // CHECK-NEXT:         "path": "{{.*[\\/]}}parseable_output.swift.tmp.swiftmodule"
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "type": "diagnostics",
+// CHECK-NEXT:         "path": "{{.*[\\/]}}parseable_output.swift.tmp.dia"
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "type": "abi-baseline-json",
+// CHECK-NEXT:         "path": "\/Volumes\/Data\/GHWorkspace1\/build\/Ninja-RelWithDebInfoAssert\/swift-macosx-x86_64\/test-macosx-x86_64\/Frontend\/Output\/parseable_output.swift.tmp.abi.json"
 // CHECK-NEXT:       }
 // CHECK-NEXT:     ],
 // CHECK-NEXT:     "pid": [[PID:[0-9]*]]


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/58422
Cherry-pick of https://github.com/apple/swift/pull/58865
-------------------------------------------------------
-------------------------------------------------------
Frontend emitting parsable output, as implemented, emitted began/finished messages on a per-primary basis. Which means that -frontend-parseable-output had no effect in contexts where no primary inputs are specified, such as WMO. This change fixes that by also emitting began/finished messages when no primary outputs are specified.

This was previously cherry-picked into 5.7 in https://github.com/apple/swift/pull/58471
Resolves rdar://91999048

-------------------------------------------------------
Generation of valid JSON output for parseable output depends on being able to determine file types of inputs and outputs of compilation tasks. FileTypes.def defines multiple file kinds with multiple . extensions, such as .abi.json or .features.json, but existing code attempted to compute file outputs only using the trailing suffix of the path after the last .. This led to some files not being recognized, which led to us not being able to generate valid JSON.

We have this problem broadly in other places in the compiler but I wanted to have a narrow fix for this release first.

5.7 Cherry-pick PR: https://github.com/apple/swift/pull/58868
Resolves rdar://92961252
