### PR TITLE
[5.7-04182022][Parseable Output] Compute file extensions using full extension strings & emit output in WMO

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -588,6 +588,29 @@ mapFrontendInvocationToAction(const CompilerInvocation &Invocation) {
   // StaticLinkJob, DynamicLinkJob
 }
 
+// TODO: Apply elsewhere in the compiler
+static swift::file_types::ID computeFileTypeForPath(const StringRef Path) {
+  if (!llvm::sys::path::has_extension(Path))
+    return swift::file_types::ID::TY_INVALID;
+
+  auto Extension = llvm::sys::path::extension(Path).str();
+  auto FileType = file_types::lookupTypeForExtension(Extension);
+  if (FileType == swift::file_types::ID::TY_INVALID) {
+    auto PathStem = llvm::sys::path::stem(Path);
+    // If this path has a multiple '.' extension (e.g. .abi.json),
+    // then iterate over all preceeding possible extension variants.
+    while (llvm::sys::path::has_extension(PathStem)) {
+      auto NextExtension = llvm::sys::path::extension(PathStem);
+      Extension = NextExtension.str() + Extension;
+      FileType = file_types::lookupTypeForExtension(Extension);
+      if (FileType != swift::file_types::ID::TY_INVALID)
+        break;
+    }
+  }
+
+  return FileType;
+}
+
 static DetailedTaskDescription
 constructDetailedTaskDescription(const CompilerInvocation &Invocation,
                                  ArrayRef<InputFile> PrimaryInputs,
@@ -612,20 +635,15 @@ constructDetailedTaskDescription(const CompilerInvocation &Invocation,
   for (const auto &input : PrimaryInputs) {
     // Main outputs
     auto OutputFile = input.outputFilename();
-    if (!OutputFile.empty()) {
-      Outputs.push_back(OutputPair(file_types::lookupTypeForExtension(
-                                       llvm::sys::path::extension(OutputFile)),
-                                   OutputFile));
-    }
+    if (!OutputFile.empty())
+      Outputs.push_back(OutputPair(computeFileTypeForPath(OutputFile), OutputFile));
 
     // Supplementary outputs
     const auto &primarySpecificFiles = input.getPrimarySpecificPaths();
     const auto &supplementaryOutputPaths =
         primarySpecificFiles.SupplementaryOutputs;
     supplementaryOutputPaths.forEachSetOutput([&](const std::string &output) {
-      Outputs.push_back(OutputPair(file_types::lookupTypeForExtension(
-                                       llvm::sys::path::extension(output)),
-                                   output));
+      Outputs.push_back(OutputPair(computeFileTypeForPath(output), output));
     });
   }
   return DetailedTaskDescription{Executable, Arguments, CommandLine, Inputs,

--- a/test/Frontend/parseable_output.swift
+++ b/test/Frontend/parseable_output.swift
@@ -1,12 +1,12 @@
-// RUN: %target-swift-frontend -primary-file %s %S/Inputs/filelist-other.swift -o %t.out -module-name parseable_output -emit-module -emit-module-path %t.swiftmodule -serialize-diagnostics -serialize-diagnostics-path %t.dia -frontend-parseable-output 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s %S/Inputs/filelist-other.swift -o %t.out -module-name parseable_output -empty-abi-descriptor -emit-abi-descriptor-path %t.abi.json -emit-module -emit-module-path %t.swiftmodule -serialize-diagnostics -serialize-diagnostics-path %t.dia -frontend-parseable-output 2>&1 | %FileCheck %s
 // Check without primary files (WMO):
-// RUN: %target-swift-frontend %s %S/Inputs/filelist-other.swift -o %t.out -module-name parseable_output -emit-module -emit-module-path %t.swiftmodule -serialize-diagnostics -serialize-diagnostics-path %t.dia -frontend-parseable-output 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend %s %S/Inputs/filelist-other.swift -o %t.out -module-name parseable_output -empty-abi-descriptor -emit-abi-descriptor-path %t.abi.json -emit-module -emit-module-path %t.swiftmodule -serialize-diagnostics -serialize-diagnostics-path %t.dia -frontend-parseable-output 2>&1 | %FileCheck %s
 
 // CHECK: {{[1-9][0-9]*}}
 // CHECK-NEXT: {
 // CHECK-NEXT:   "kind": "began",
 // CHECK-NEXT:   "name": "compile",
-// CHECK-NEXT:   "command": "{{.*[\\/]}}swift-frontend{{(\.exe)?}}{{.*}} {{.*[\\/]}}parseable_output.swift {{.*[\\/]}}filelist-other.swift -o {{.*[\\/]}}parseable_output.swift.tmp.out -module-name parseable_output -emit-module -emit-module-path {{.*[\\/]}}parseable_output.swift.tmp.swiftmodule -serialize-diagnostics -serialize-diagnostics-path {{.*[\\/]}}parseable_output.swift.tmp.dia -frontend-parseable-output",
+// CHECK-NEXT:   "command": "{{.*[\\/]}}swift-frontend{{(\.exe)?}}{{.*}} {{.*[\\/]}}parseable_output.swift {{.*[\\/]}}filelist-other.swift -o {{.*[\\/]}}parseable_output.swift.tmp.out -module-name parseable_output -empty-abi-descriptor -emit-abi-descriptor-path {{.*[\\/]}}parseable_output.swift.tmp.abi.json -emit-module -emit-module-path {{.*[\\/]}}parseable_output.swift.tmp.swiftmodule -serialize-diagnostics -serialize-diagnostics-path {{.*[\\/]}}parseable_output.swift.tmp.dia -frontend-parseable-output",
 // CHECK-NEXT:   "command_executable": "{{.*[\\/]}}swift{{(-frontend|c)?(\.exe)?}}",
 // CHECK-NEXT:   "command_arguments": [
 // CHECK:          "{{.*[\\/]}}parseable_output.swift",
@@ -14,6 +14,9 @@
 // CHECK-NEXT:     "{{.*[\\/]}}parseable_output.swift.tmp.out",
 // CHECK-NEXT:     "-module-name",
 // CHECK-NEXT:     "parseable_output",
+// CHECK-NEXT:     "-empty-abi-descriptor",
+// CHECK-NEXT:     "-emit-abi-descriptor-path",
+// CHECK-NEXT:     "{{.*[\\/]}}parseable_output.swift.tmp.abi.json",
 // CHECK-NEXT:     "-emit-module",
 // CHECK-NEXT:     "-emit-module-path",
 // CHECK-NEXT:     "{{.*[\\/]}}parseable_output.swift.tmp.swiftmodule",
@@ -36,6 +39,10 @@
 // CHECK-NEXT:       {
 // CHECK-NEXT:         "type": "diagnostics",
 // CHECK-NEXT:         "path": "{{.*[\\/]}}parseable_output.swift.tmp.dia"
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "type": "abi-baseline-json",
+// CHECK-NEXT:         "path": "{{.*[\\/]}}parseable_output.swift.tmp.abi.json"
 // CHECK-NEXT:       }
 // CHECK-NEXT:     ],
 // CHECK-NEXT:     "pid": [[PID:[0-9]*]]

--- a/test/Frontend/parseable_output.swift
+++ b/test/Frontend/parseable_output.swift
@@ -1,25 +1,30 @@
-// RUN: %target-swift-frontend -primary-file %s -o %t.out -emit-module -emit-module-path %t.swiftmodule -frontend-parseable-output 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s %S/Inputs/filelist-other.swift -o %t.out -module-name parseable_output -emit-module -emit-module-path %t.swiftmodule -serialize-diagnostics -serialize-diagnostics-path %t.dia -frontend-parseable-output 2>&1 | %FileCheck %s
+// Check without primary files (WMO):
+// RUN: %target-swift-frontend %s %S/Inputs/filelist-other.swift -o %t.out -module-name parseable_output -emit-module -emit-module-path %t.swiftmodule -serialize-diagnostics -serialize-diagnostics-path %t.dia -frontend-parseable-output 2>&1 | %FileCheck %s
 
 // CHECK: {{[1-9][0-9]*}}
 // CHECK-NEXT: {
 // CHECK-NEXT:   "kind": "began",
 // CHECK-NEXT:   "name": "compile",
-// CHECK-NEXT:   "command": "{{.*[\\/]}}swift-frontend{{(\.exe)?}}{{.*}}-primary-file {{.*[\\/]}}parseable_output.swift -o {{.*[\\/]}}parseable_output.swift.tmp.out  -emit-module -emit-module-path {{.*[\\/]}}parseable_output.swift.tmp.swiftmodule -frontend-parseable-output",
+// CHECK-NEXT:   "command": "{{.*[\\/]}}swift-frontend{{(\.exe)?}}{{.*}} {{.*[\\/]}}parseable_output.swift {{.*[\\/]}}filelist-other.swift -o {{.*[\\/]}}parseable_output.swift.tmp.out -module-name parseable_output -emit-module -emit-module-path {{.*[\\/]}}parseable_output.swift.tmp.swiftmodule -serialize-diagnostics -serialize-diagnostics-path {{.*[\\/]}}parseable_output.swift.tmp.dia -frontend-parseable-output",
 // CHECK-NEXT:   "command_executable": "{{.*[\\/]}}swift{{(-frontend|c)?(\.exe)?}}",
 // CHECK-NEXT:   "command_arguments": [
-// CHECK:          "-primary-file",
-// CHECK-NEXT:     "{{.*[\\/]}}parseable_output.swift",
+// CHECK:          "{{.*[\\/]}}parseable_output.swift",
 // CHECK:          "-o",
 // CHECK-NEXT:     "{{.*[\\/]}}parseable_output.swift.tmp.out",
+// CHECK-NEXT:     "-module-name",
+// CHECK-NEXT:     "parseable_output",
 // CHECK-NEXT:     "-emit-module",
 // CHECK-NEXT:     "-emit-module-path",
 // CHECK-NEXT:     "{{.*[\\/]}}parseable_output.swift.tmp.swiftmodule",
+// CHECK-NEXT:     "-serialize-diagnostics",
+// CHECK-NEXT:     "-serialize-diagnostics-path"
+// CHECK-NEXT:     "{{.*[\\/]}}parseable_output.swift.tmp.dia",
 // CHECK-NEXT:     "-frontend-parseable-output"
 // CHECK-NEXT:   ],
 // CHECK-NEXT:   "inputs": [
 // CHECK-NEXT:       "{{.*[\\/]}}parseable_output.swift"
-// CHECK-NEXT:     ],
-// CHECK-NEXT:     "outputs": [
+// CHECK:        "outputs": [
 // CHECK-NEXT:       {
 // CHECK-NEXT:         "type": "image",
 // CHECK-NEXT:         "path": "{{.*[\\/]}}parseable_output.swift.tmp.out"
@@ -27,6 +32,10 @@
 // CHECK-NEXT:       {
 // CHECK-NEXT:         "type": "swiftmodule",
 // CHECK-NEXT:         "path": "{{.*[\\/]}}parseable_output.swift.tmp.swiftmodule"
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "type": "diagnostics",
+// CHECK-NEXT:         "path": "{{.*[\\/]}}parseable_output.swift.tmp.dia"
 // CHECK-NEXT:       }
 // CHECK-NEXT:     ],
 // CHECK-NEXT:     "pid": [[PID:[0-9]*]]

--- a/test/Frontend/parseable_output_error.swift
+++ b/test/Frontend/parseable_output_error.swift
@@ -1,4 +1,6 @@
 // RUN: not %target-swift-frontend -primary-file %s -o %t.out -emit-module -emit-module-path %t.swiftmodule -frontend-parseable-output 2>&1 | %FileCheck %s
+// Check without primary files (WMO):
+// RUN: not %target-swift-frontend %s -o %t.out -emit-module -emit-module-path %t.swiftmodule -frontend-parseable-output 2>&1 | %FileCheck %s
 
 func foo() {
     return 11;
@@ -7,11 +9,10 @@ func foo() {
 // CHECK-NEXT: {
 // CHECK-NEXT:   "kind": "began",
 // CHECK-NEXT:   "name": "compile",
-// CHECK-NEXT:   "command": "{{.*[\\/]}}swift-frontend{{(\.exe)?}}{{.*}}-primary-file {{.*[\\/]}}parseable_output_error.swift -o {{.*[\\/]}}parseable_output_error.swift.tmp.out  -emit-module -emit-module-path {{.*[\\/]}}parseable_output_error.swift.tmp.swiftmodule -frontend-parseable-output",
+// CHECK-NEXT:   "command": "{{.*[\\/]}}swift-frontend{{(\.exe)?}}{{.*}} {{.*[\\/]}}parseable_output_error.swift -o {{.*[\\/]}}parseable_output_error.swift.tmp.out  -emit-module -emit-module-path {{.*[\\/]}}parseable_output_error.swift.tmp.swiftmodule -frontend-parseable-output",
 // CHECK-NEXT:   "command_executable": "{{.*[\\/]}}swift{{(-frontend|c)?(\.exe)?}}",
 // CHECK-NEXT:   "command_arguments": [
-// CHECK:          "-primary-file",
-// CHECK-NEXT:     "{{.*[\\/]}}parseable_output_error.swift",
+// CHECK:     "{{.*[\\/]}}parseable_output_error.swift",
 // CHECK-NEXT:     "-o",
 // CHECK-NEXT:     "{{.*[\\/]}}parseable_output_error.swift.tmp.out",
 // CHECK-NEXT:     "-emit-module",
@@ -43,7 +44,7 @@ func foo() {
 // CHECK-NEXT:   "kind": "finished",
 // CHECK-NEXT:   "name": "compile",
 // CHECK-NEXT:   "pid": [[PID]],
-// CHECK-NEXT:   "output": "{{.*[\\/]}}parseable_output_error.swift:4:12: error: unexpected non-void return value in void function{{.*}}return 11;{{.*[\\/]}}parseable_output_error.swift:4:12: note: did you mean to add a return type?{{.*}}return 11;
+// CHECK-NEXT:   "output": "{{.*[\\/]}}parseable_output_error.swift:6:12: error: unexpected non-void return value in void function{{.*}}return 11;{{.*[\\/]}}parseable_output_error.swift:6:12: note: did you mean to add a return type?{{.*}}return 11;
 // CHECK-NEXT:   "process": {
 // CHECK-NEXT:     "real_pid": [[PID]]
 // CHECK-NEXT:   },


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/58422
---------------------------------------------------------
Cherry-pick of https://github.com/apple/swift/pull/58865
---------------------------------------------------------
---------------------------------------------------------

• Explanation: Generation of valid JSON output for compiler frontend's parseable output depends on being able to determine file types of inputs and outputs of compilation tasks. The compiler defines multiple file kinds with multiple . extensions, such as .abi.json or .private.swiftinterface, but existing code attempts to compute file outputs only using the trailing suffix of the path after the last .. This led to some file kinds not being recognized, which led to us not being able to generate valid JSON.
• Scope of Issue: Compilation tasks launched by build systems that consume parseable-output that specify certain output kinds (for example an ABI descriptor) and fail, do not result in visible error diagnostics being emitted.
• Origination: This particular case was not handled in the implementation of frontend-emitted parseable-output which only started being used recently. The problem of determining file kinds using only the trailing . suffix is more-general in the compiler and needs to be addressed separately. This fix is narrow and specific to generation of parseable-output JSON.
• Risk: Low
• Automated Testing: Automated test added to the compiler test suite

5.7 Cherry-pick PR: https://github.com/apple/swift/pull/58868
Resolves rdar://92961252

---------------------------------------------------------

• Explanation: Frontend-emitted parseable-output did not previously emit messages for whole-module jobs because its original intent was to emit messages describing batch compilation jobs. We recently started using frontend-emitted parseable-output and require that it also emit messages for WMO compiler tasks for consistency. This change adds emission of JSON parseable-output messages for WMO compiler jobs. It is already merged for `release/5.7`, but the above fix is built on top of the fix here so it is worth bringing them both together.
• Scope of Issue: Failing WMO compilation tasks launched by build systems consuming frontend-emitted parseable-output did not previously emit error messages.
• Origination: This particular case was not handled in the implementation of frontend-emitted parseable-output which only started being used recently.
• Risk: Low 

This was previously cherry-picked into 5.7 in https://github.com/apple/swift/pull/58471
Resolves rdar://91999048 