### PR TITLE
[5.7][CodeCompletion] Suggest 'in' after expression in closure

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -813,6 +813,12 @@ static void addStmtKeywords(CodeCompletionResultSink &Sink, DeclContext *DC,
   auto AddStmtKeyword = [&](StringRef Name, CodeCompletionKeywordKind Kind) {
     if (!MaybeFuncBody && Kind == CodeCompletionKeywordKind::kw_return)
       return;
+
+    // 'in' keyword is added in 'addClosureSignatureKeywordsIfApplicable' if
+    // needed.
+    if (Kind == CodeCompletionKeywordKind::kw_in)
+      return;
+
     addKeyword(Sink, Name, Kind, "", flair);
   };
 #define STMT_KEYWORD(kw) AddStmtKeyword(#kw, CodeCompletionKeywordKind::kw_##kw);
@@ -893,6 +899,18 @@ static void addAnyTypeKeyword(CodeCompletionResultSink &Sink, Type T) {
   Builder.addTypeAnnotation(T, PrintOptions());
 }
 
+static void
+addClosureSignatureKeywordsIfApplicable(CodeCompletionResultSink &Sink,
+                                        DeclContext *DC) {
+  ClosureExpr *closure = dyn_cast<ClosureExpr>(DC);
+  if (!closure)
+    return;
+  if (closure->getInLoc().isValid())
+    return;
+
+  addKeyword(Sink, "in", CodeCompletionKeywordKind::kw_in);
+}
+
 void CodeCompletionCallbacksImpl::addKeywords(CodeCompletionResultSink &Sink,
                                               bool MaybeFuncBody) {
   switch (Kind) {
@@ -947,6 +965,8 @@ void CodeCompletionCallbacksImpl::addKeywords(CodeCompletionResultSink &Sink,
     addDeclKeywords(Sink, CurDeclContext,
                     Context.LangOpts.EnableExperimentalConcurrency);
     addStmtKeywords(Sink, CurDeclContext, MaybeFuncBody);
+    addClosureSignatureKeywordsIfApplicable(Sink, CurDeclContext);
+
     LLVM_FALLTHROUGH;
   case CompletionKind::ReturnStmtExpr:
   case CompletionKind::YieldStmtExpr:
@@ -971,6 +991,11 @@ void CodeCompletionCallbacksImpl::addKeywords(CodeCompletionResultSink &Sink,
     break;
 
   case CompletionKind::PostfixExpr:
+    // Suggest 'in' for '{ value <HERE>'.
+    if (HasSpace)
+      addClosureSignatureKeywordsIfApplicable(Sink, CurDeclContext);
+
+    break;
   case CompletionKind::CaseStmtBeginning:
   case CompletionKind::TypeIdentifierWithDot:
   case CompletionKind::TypeIdentifierWithoutDot:

--- a/test/IDE/complete_at_top_level_library.swift
+++ b/test/IDE/complete_at_top_level_library.swift
@@ -56,7 +56,6 @@ protocol MyProtocol {}
 // LIBRARY-DAG: Keyword[repeat]/None/Flair[ExprAtFileScope]: repeat; name=repeat
 // LIBRARY-DAG: Keyword[else]/None/Flair[ExprAtFileScope]: else; name=else
 // LIBRARY-DAG: Keyword[for]/None/Flair[ExprAtFileScope]: for; name=for
-// LIBRARY-DAG: Keyword[in]/None/Flair[ExprAtFileScope]: in; name=in
 // LIBRARY-DAG: Keyword[while]/None/Flair[ExprAtFileScope]: while; name=while
 // LIBRARY-DAG: Keyword[break]/None/Flair[ExprAtFileScope]: break; name=break
 // LIBRARY-DAG: Keyword[continue]/None/Flair[ExprAtFileScope]: continue; name=continue
@@ -133,7 +132,6 @@ protocol MyProtocol {}
 // SCRIPT-DAG: Keyword[repeat]/None:               repeat; name=repeat
 // SCRIPT-DAG: Keyword[else]/None:                 else; name=else
 // SCRIPT-DAG: Keyword[for]/None:                  for; name=for
-// SCRIPT-DAG: Keyword[in]/None:                   in; name=in
 // SCRIPT-DAG: Keyword[while]/None:                while; name=while
 // SCRIPT-DAG: Keyword[break]/None:                break; name=break
 // SCRIPT-DAG: Keyword[continue]/None:             continue; name=continue

--- a/test/IDE/complete_keywords.swift
+++ b/test/IDE/complete_keywords.swift
@@ -4,6 +4,9 @@
 // KW_RETURN: Keyword[return]/None: return{{; name=.+$}}
 // KW_NO_RETURN-NOT: Keyword[return]
 
+// KW_IN: Keyword[in]/None: in{{; name=.+$}}
+// KW_NO_IN-NOT: Keyword[in]
+
 // KW_DECL: Begin completions
 // KW_DECL-DAG: Keyword[class]/None: class{{; name=.+$}}
 // KW_DECL-DAG: Keyword/None: convenience{{; name=.+$}}
@@ -157,7 +160,6 @@
 // KW_DECL_STMT_TOPLEVEL-DAG: Keyword[do]/None: do{{; name=.+$}}
 // KW_DECL_STMT_TOPLEVEL-DAG: Keyword[else]/None: else{{; name=.+$}}
 // KW_DECL_STMT_TOPLEVEL-DAG: Keyword[for]/None: for{{; name=.+$}}
-// KW_DECL_STMT_TOPLEVEL-DAG: Keyword[in]/None: in{{; name=.+$}}
 // KW_DECL_STMT_TOPLEVEL-DAG: Keyword[while]/None: while{{; name=.+$}}
 // KW_DECL_STMT_TOPLEVEL-DAG: Keyword[break]/None: break{{; name=.+$}}
 // KW_DECL_STMT_TOPLEVEL-DAG: Keyword[continue]/None: continue{{; name=.+$}}
@@ -230,7 +232,6 @@
 // KW_DECL_STMT-DAG: Keyword[do]/None: do{{; name=.+$}}
 // KW_DECL_STMT-DAG: Keyword[else]/None: else{{; name=.+$}}
 // KW_DECL_STMT-DAG: Keyword[for]/None: for{{; name=.+$}}
-// KW_DECL_STMT-DAG: Keyword[in]/None: in{{; name=.+$}}
 // KW_DECL_STMT-DAG: Keyword[while]/None: while{{; name=.+$}}
 // KW_DECL_STMT-DAG: Keyword[break]/None: break{{; name=.+$}}
 // KW_DECL_STMT-DAG: Keyword[continue]/None: continue{{; name=.+$}}
@@ -302,15 +303,15 @@
 // KW_EXPR_NEG-NOT: Keyword{{.*}}break
 // KW_EXPR_NEG: End completions
 
-#^TOP_LEVEL_1?check=KW_DECL_STMT_TOPLEVEL;check=KW_NO_RETURN^#
+#^TOP_LEVEL_1?check=KW_DECL_STMT_TOPLEVEL;check=KW_NO_RETURN;check=KW_NO_IN^#
 
 for _ in 1...10 {
-  #^TOP_LEVEL_2?check=KW_DECL_STMT;check=KW_NO_RETURN^#
+  #^TOP_LEVEL_2?check=KW_DECL_STMT;check=KW_NO_RETURN;check=KW_NO_IN^#
 }
 
-if true {} #^TOP_LEVEL_AFTER_IF_1?check=KW_DECL_STMT_TOPLEVEL;check=KW_NO_RETURN^#
+if true {} #^TOP_LEVEL_AFTER_IF_1?check=KW_DECL_STMT_TOPLEVEL;check=KW_NO_RETURN;check=KW_NO_IN^#
 if true {} 
-#^TOP_LEVEL_AFTER_IF_2?check=KW_DECL_STMT_TOPLEVEL;check=KW_NO_RETURN^#
+#^TOP_LEVEL_AFTER_IF_2?check=KW_DECL_STMT_TOPLEVEL;check=KW_NO_RETURN;check=KW_NO_IN^#
 
 
 if true {} else #^TOP_LEVEL_AFTER_IF_ELSE_1?check=AFTER_IF_ELSE^# {}
@@ -319,60 +320,60 @@ if true {} else #^TOP_LEVEL_AFTER_IF_ELSE_1?check=AFTER_IF_ELSE^# {}
 // AFTER_IF_ELSE: Keyword[if]/None: if;
 
 func testAfterIf1() {
-  if true {} #^AFTER_IF_1?check=KW_DECL_STMT;check=KW_RETURN^#
+  if true {} #^AFTER_IF_1?check=KW_DECL_STMT;check=KW_RETURN;check=KW_NO_IN^#
 }
 func testAfterIfElse1() {
   if true {} else #^AFTER_IF_ELSE_1?check=AFTER_IF_ELSE^# {}
 }
 
 func testInFuncBody1() {
-  #^IN_FUNC_BODY_1?check=KW_DECL_STMT;check=KW_RETURN^#
+  #^IN_FUNC_BODY_1?check=KW_DECL_STMT;check=KW_RETURN;check=KW_NO_IN^#
 }
 
 struct InStructFunc {
   func testInFuncBody2() {
-    #^IN_FUNC_BODY_2?check=KW_DECL_STMT;check=KW_RETURN^#
+    #^IN_FUNC_BODY_2?check=KW_DECL_STMT;check=KW_RETURN;check=KW_NO_IN^#
   }
 }
 
 enum InEnumFunc {
   func testInFuncBody3() {
-    #^IN_FUNC_BODY_3?check=KW_DECL_STMT;check=KW_RETURN^#
+    #^IN_FUNC_BODY_3?check=KW_DECL_STMT;check=KW_RETURN;check=KW_NO_IN^#
   }
 }
 
 class InClassFunc {
   func testInFuncBody4() {
-    #^IN_FUNC_BODY_4?check=KW_DECL_STMT;check=KW_RETURN^#
+    #^IN_FUNC_BODY_4?check=KW_DECL_STMT;check=KW_RETURN;check=KW_NO_IN^#
   }
 }
 
 class InClassFunc {
   class Nested {
     func testInFuncBody5() {
-      #^IN_FUNC_BODY_5?check=KW_DECL_STMT;check=KW_RETURN^#
+      #^IN_FUNC_BODY_5?check=KW_DECL_STMT;check=KW_RETURN;check=KW_NO_IN^#
     }
   }
 }
 
 func testInClosure1() {
-  { #^IN_CLOSURE_1?check=KW_DECL_STMT;check=KW_RETURN^# }
+  { #^IN_CLOSURE_1?check=KW_DECL_STMT;check=KW_RETURN;check=KW_IN^# }
 }
 func testInClosure2() {
-  { #^IN_CLOSURE_2?check=KW_DECL_STMT;check=KW_RETURN^#
+  { #^IN_CLOSURE_2?check=KW_DECL_STMT;check=KW_RETURN;check=KW_IN^#
 }
 struct InVarClosureInit {
-  let x = { #^IN_CLOSURE_3?check=KW_DECL_STMT;check=KW_RETURN^# }()
+  let x = { #^IN_CLOSURE_3?check=KW_DECL_STMT;check=KW_RETURN;check=KW_IN^# }()
 }
 
-{ #^IN_CLOSURE_4?check=KW_DECL_STMT;check=KW_RETURN^# }
+{ #^IN_CLOSURE_4?check=KW_DECL_STMT;check=KW_RETURN;check=KW_IN^# }
 
 struct InSubscript {
-  subscript(x: Int) -> Int { #^IN_SUBSCRIPT_1?check=KW_DECL_STMT;check=KW_RETURN^# }
+  subscript(x: Int) -> Int { #^IN_SUBSCRIPT_1?check=KW_DECL_STMT;check=KW_RETURN;check=KW_NO_IN^# }
 }
 
 struct InInit {
-  init?() { #^IN_INIT_1?check=KW_DECL_STMT;check=KW_RETURN^# }
+  init?() { #^IN_INIT_1?check=KW_DECL_STMT;check=KW_RETURN;check=KW_NO_IN^# }
 }
 
 struct InStruct {

--- a/test/IDE/complete_rdar80489548.swift
+++ b/test/IDE/complete_rdar80489548.swift
@@ -1,0 +1,26 @@
+// RUN: %empty-directory(%t.ccp)
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+
+// KW_IN: Keyword[in]/None: in{{; name=.+$}}
+// KW_NO_IN-NOT: Keyword[in]
+
+func test(value: [Int]) {
+  value.map { #^NOIN_IMMEDIATE?check=KW_IN^# }
+
+  value.map { value#^NOIN_AFTER_EXPR_NOSPCACE?check=KW_NO_IN^# }
+  value.map { value #^NOIN_AFTER_EXPR?check=KW_IN^# }
+  value.map { value
+    #^NOIN_NEWLINE?check=KW_IN^#
+  }
+
+  value.map { value in #^IN_AFTER_IN?check=KW_NO_IN^# }
+  value.map { value in
+    #^IN_NEWLINE?check=KW_NO_IN^#
+  }
+
+  #^FUNCBODY_STMT?check=KW_NO_IN^#
+  value #^FUNCBODY_POSTFIX?check=KW_NO_IN^#
+}
+
+#^GLOBAL_STMT?check=KW_NO_IN^#
+value #^GLOBAL_POSTFIX?check=KW_NO_IN^#


### PR DESCRIPTION
Cherry-pick #58550 into `release/5.7`

* **Explanation**: Suggest 'in' in code completion after an expression even without a newline.   `func test(value: [Int]) { value.map { value <HERE> } }`, in this case `value` in the closure is ambiguous between an expression referring the outer function parameter, or a parameter declaration in the closure. Previously, code completion only considered the former and suggest the members of '[Int]', but not 'in' keyword. As a result, when the user actually want to type 'in' here, they needed to hit 'esc' to cancel the code completion. In this change, suggest 'in' keyword even without a newline, as long as the current decl context is a closure and it doesn't have 'in' in it. Also previously 'in' was suggested even outside the closure and even it already had the explict 'in'. This PR limit suggesting 'in' inside closures without explicit 'in'.
* **Scope**: Code completion after expressions inside closures
* **Risk**: Low
* **Issues**: rdar://80489548
* **Testing**: Added regression test cases
* **Reviewer**: Alex Hoppen (@ahoppen)
