### PR TITLE
[5.7] Turn on Parameterized Existentials in Metatypes

### DIFF
--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -288,11 +288,11 @@ public:
     case Context::GenericRequirement:
       return true;
     case Context::ExistentialConstraint:
+    case Context::MetatypeBase:
       return opts.EnableParameterizedExistentialTypes;
     case Context::None:
     case Context::TypeAliasDecl:
     case Context::GenericTypeAliasDecl:
-    case Context::MetatypeBase:
     case Context::InExpression:
     case Context::ExplicitCastExpr:
     case Context::ForEachStmt:

--- a/test/Constraints/parameterized_existential_metatypes.swift
+++ b/test/Constraints/parameterized_existential_metatypes.swift
@@ -1,0 +1,31 @@
+// RUN: %target-typecheck-verify-swift -enable-parameterized-existential-types
+//
+// FIXME: Merge this file with existential_metatypes.swift once -enable-parameterized-existential-types becomes the default
+
+protocol P<T> {
+  associatedtype T
+}
+
+protocol Q<T> {
+  associatedtype T
+}
+
+protocol PP<U>: P<Self.U.T> {
+  associatedtype U: P<U>
+}
+
+var qp: (any Q<Int>).Type
+var pp: (any P<Int>).Type = qp // expected-error{{cannot convert value of type '(any Q<Int>).Type' to specified type '(any P<Int>).Type'}}
+
+var qt: any Q<Int>.Type
+qt = qp // expected-error{{cannot assign value of type '(any Q<Int>).Type' to type 'any Q<Int>.Type'}}
+qp = qt // expected-error{{cannot assign value of type 'any Q<Int>.Type' to type '(any Q<Int>).Type'}}
+var pt: any P<Int>.Type = qt // expected-error{{cannot convert value of type 'any Q<Int>.Type' to specified type 'any P<Int>.Type'}}
+pt = pp // expected-error{{cannot assign value of type '(any P<Int>).Type' to type 'any P<Int>.Type'}}
+pp = pt // expected-error{{cannot assign value of type 'any P<Int>.Type' to type '(any P<Int>).Type'}}
+
+var ppp: (any PP<Int>).Type
+pp = ppp // expected-error{{cannot assign value of type '(any PP<Int>).Type' to type '(any P<Int>).Type'}}
+
+var ppt: any PP<Int>.Type
+pt = ppt


### PR DESCRIPTION
These were accidentally left off - turn them on subject to the
-enable-parameterized-existential-types flag.