### PR TITLE
Change diagnostic error thrown for when string interpolations aren't closed by a parenthesis

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1356,6 +1356,11 @@ ERROR(expected_type_after_as,none,
 ERROR(string_interpolation_extra,none,
       "extra tokens after interpolated string expression", ())
 
+// String interpolation isnt closed by a )
+// ie: `let west = "ye \("`
+ERROR(string_interpolation_unclosed, none,
+      "string interpolation needs to be closed by a )", ())
+
 // Interpolations with parameter labels or multiple values
 WARNING(string_interpolation_list_changing,none,
       "interpolating multiple values will not form a tuple in Swift 5", ())

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -132,8 +132,6 @@ NOTE(lex_comment_start,none,
 
 ERROR(lex_unterminated_string,none,
       "unterminated string literal", ())
-NOTE(lex_unterminated_string_fix_it,none,
-      "add end quotes to string literal", ())
 ERROR(lex_invalid_escape,none,
        "invalid escape sequence in literal", ())
 ERROR(lex_invalid_u_escape,none,

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1362,8 +1362,6 @@ ERROR(string_interpolation_extra,none,
 // ie: `let west = "ye \("`
 ERROR(string_interpolation_unclosed, none,
       "expected ')' at end of string interpolation", ())
-NOTE(string_interpolation_unclosed_fix_it, none,
-      "add ')' to end of interpolation statement", ())
 
 // Interpolations with parameter labels or multiple values
 WARNING(string_interpolation_list_changing,none,

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1359,7 +1359,9 @@ ERROR(string_interpolation_extra,none,
 // String interpolation isnt closed by a )
 // ie: `let west = "ye \("`
 ERROR(string_interpolation_unclosed, none,
-      "string interpolation needs to be closed by a )", ())
+      "expected ')' at end of string interpolation", ())
+NOTE(string_interpolation_unclosed_fix_it, none,
+      "add ')' to end of interpolation statement", ())
 
 // Interpolations with parameter labels or multiple values
 WARNING(string_interpolation_list_changing,none,

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1359,7 +1359,7 @@ ERROR(string_interpolation_extra,none,
 // String interpolation isnt closed by a )
 // ie: `let west = "ye \("`
 ERROR(string_interpolation_unclosed, none,
-      "expected ')' at end of string interpolation", ())
+      "cannot find ')' to match this opening '(' in string interpolation", ())
 
 // Interpolations with parameter labels or multiple values
 WARNING(string_interpolation_list_changing,none,

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -132,6 +132,8 @@ NOTE(lex_comment_start,none,
 
 ERROR(lex_unterminated_string,none,
       "unterminated string literal", ())
+NOTE(lex_unterminated_string_fix_it,none,
+      "add end quotes to string literal", ())
 ERROR(lex_invalid_escape,none,
        "invalid escape sequence in literal", ())
 ERROR(lex_invalid_u_escape,none,

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1359,7 +1359,7 @@ ERROR(string_interpolation_extra,none,
 // String interpolation isnt closed by a )
 // ie: `let west = "ye \("`
 ERROR(string_interpolation_unclosed, none,
-      "cannot find ')' to match this opening '(' in string interpolation", ())
+      "cannot find ')' to match opening '(' in string interpolation", ())
 
 // Interpolations with parameter labels or multiple values
 WARNING(string_interpolation_list_changing,none,

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1884,23 +1884,12 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
         // Successfully scanned the body of the expression literal.
         ++CurPtr;
         continue;
+      } else if (!isMultilineString) {
+        diagnose(CurPtr, diag::lex_unterminated_string);
+        diagnose(CurPtr, diag::string_interpolation_unclosed);
       } else if (*CurPtr == '\r' || *CurPtr == '\n') {
-        if (IsMultilineString) {
-          // The only case we reach here is unterminated single line string in the
-          // interpolation. For better recovery, go on after emitting an error.
-          diagnose(CurPtr, diag::string_interpolation_unclosed);
-          diagnose(--TmpPtr, diag::opening_paren);
-          if (CurPtr != BufferEnd) diagnose(CurPtr, diag::lex_unterminated_string);
-          wasErroneous = true;
-          continue;
-        } else {
-          diagnose(CurPtr, diag::string_interpolation_unclosed);
-          diagnose(--TmpPtr, diag::opening_paren);
-          if (*CurPtr != ')') diagnose(CurPtr, diag::lex_unterminated_string);
-          return formToken(tok::unknown, TokStart);
-        }
-      } else {
-        diagnose(TokStart, diag::lex_unterminated_string);
+        diagnose(CurPtr, diag::lex_unterminated_string);
+        diagnose(CurPtr, diag::string_interpolation_unclosed);
         return formToken(tok::unknown, TokStart);
       }
     }

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1893,12 +1893,12 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
           wasErroneous = true;
           continue;
         } else {
-          const char *fixItLoc = CurPtr - 1;
-          if (*fixItLoc == QuoteChar) {
-            fixItLoc -= CustomDelimiterLen;
+          // location of the end of the interpolation expression
+          const char *interpolationEndLoc = CurPtr - 1;
+          if (*interpolationEndLoc == QuoteChar) {
+            interpolationEndLoc -= CustomDelimiterLen;
           }
-          diagnose(fixItLoc, diag::string_interpolation_unclosed);
-              .fixItInsert(Lexer::getSourceLoc(fixItLoc), ")");
+          diagnose(interpolationEndLoc, diag::string_interpolation_unclosed);
           return formToken(tok::unknown, TokStart);
         }
       } else {

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1889,7 +1889,6 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
         diagnose(CurPtr, diag::string_interpolation_unclosed);
         diagnose(--TmpPtr, diag::opening_paren);
 
-        wasErroneous = true;
         continue;
       } else if (*CurPtr == '\r' || *CurPtr == '\n' || CurPtr == BufferEnd) {
         // The only case we reach here is unterminated single line string in the

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1891,7 +1891,9 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
         wasErroneous = true;
         continue;
       } else {
-        diagnose(TokStart, diag::string_interpolation_unclosed);
+        diagnose(CurPtr, diag::string_interpolation_unclosed);
+        diagnose(CurPtr, diag::string_interpolation_unclosed_fix_it);
+            .fixItInsert(Lexer::getSourceLoc(CurPtr), ")");
         return formToken(tok::unknown, TokStart);
       }
     }

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1888,15 +1888,15 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
         // The only case we reach here is unterminated single line string in the
         // interpolation. For better recovery, go on after emitting an error.
         diagnose(CurPtr, diag::string_interpolation_unclosed);
+        diagnose(CurPtr, diag::lex_unterminated_string);
         wasErroneous = true;
         continue;
       } else {
-        diagnose(CurPtr, diag::string_interpolation_unclosed);
         const char *fixItLoc = CurPtr - 1;
         if (*fixItLoc == QuoteChar) {
           fixItLoc -= CustomDelimiterLen;
         }
-        diagnose(fixItLoc, diag::string_interpolation_unclosed_fix_it)
+        diagnose(fixItLoc, diag::string_interpolation_unclosed);
             .fixItInsert(Lexer::getSourceLoc(fixItLoc), ")");
         return formToken(tok::unknown, TokStart);
       }

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1902,6 +1902,7 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
     if (((*CurPtr == '\r' || *CurPtr == '\n') && !IsMultilineString)
         || CurPtr == BufferEnd) {
       diagnose(TokStart, diag::lex_unterminated_string);
+      char* endQuotes[] = isMultilineString ? "\"\"\"" : "\"";
       return formToken(tok::unknown, TokStart);
     }
 

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1905,7 +1905,7 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
         wasErroneous = true;
 
         continue;
-        return formToken(tok::unknown, TokStart)
+        return formToken(tok::unknown, TokStart);
       }
     }
 

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1892,8 +1892,9 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
         continue;
       } else {
         diagnose(CurPtr, diag::string_interpolation_unclosed);
-        diagnose(CurPtr, diag::string_interpolation_unclosed_fix_it)
-            .fixItInsert(Lexer::getSourceLoc(CurPtr), ")");
+        char* tmpDiagnosePtr = CurPtr - CustomDelimiterLen;
+        diagnose(tmpDiagnosePtr, diag::string_interpolation_unclosed_fix_it)
+            .fixItInsert(Lexer::getSourceLoc(tmpDiagnosePtr), ")");
         return formToken(tok::unknown, TokStart);
       }
     }

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1892,7 +1892,7 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
         continue;
       } else {
         diagnose(CurPtr, diag::string_interpolation_unclosed);
-        diagnose(CurPtr, diag::string_interpolation_unclosed_fix_it);
+        diagnose(CurPtr, diag::string_interpolation_unclosed_fix_it)
             .fixItInsert(Lexer::getSourceLoc(CurPtr), ")");
         return formToken(tok::unknown, TokStart);
       }

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1889,11 +1889,13 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
           // The only case we reach here is unterminated single line string in the
           // interpolation. For better recovery, go on after emitting an error.
           diagnose(CurPtr, diag::string_interpolation_unclosed);
+          diagnose(--TmpPtr, diagnose::opening_paren);
           diagnose(CurPtr, diag::lex_unterminated_string);
           wasErroneous = true;
           continue;
         } else {
           diagnose(CurPtr, diag::string_interpolation_unclosed);
+          diagnose(--TmpPtr, diagnose::opening_paren);
           return formToken(tok::unknown, TokStart);
         }
       } else {

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1890,7 +1890,7 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
         diagnose(--TmpPtr, diag::opening_paren);
 
         return formToken(tok::unknown, TokStart);
-      } else if (*CurPtr == '\r' || *CurPtr == '\n' || *CurPtr == BufferEnd) {
+      } else if (*CurPtr == '\r' || *CurPtr == '\n' || CurPtr == BufferEnd) {
         // The only case we reach here is unterminated single line string in the
         // interpolation. For better recovery, go on after emitting an error.
         diagnose(CurPtr, diag::lex_unterminated_string);

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1899,10 +1899,10 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
           diagnose(CurPtr, diag::string_interpolation_unclosed);
           diagnose(--TmpPtr, diag::opening_paren);
         }
-            
-      // As a fallback, just emit an unterminated string error.
-      diagnose(TokStart, diag::lex_unterminated_string);
-      return formToken(tok::unknown, TokStart);
+
+        // As a fallback, just emit an unterminated string error.
+        diagnose(TokStart, diag::lex_unterminated_string);
+        return formToken(tok::unknown, TokStart);
       }
     }
 

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1895,7 +1895,7 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
           continue;
         } else {
           diagnose(CurPtr, diag::string_interpolation_unclosed);
-          diagnose(--TmpPtr, diagnose::opening_paren);
+          diagnose(--TmpPtr, diag::opening_paren);
           return formToken(tok::unknown, TokStart);
         }
       } else {

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1887,7 +1887,7 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
       } else if ((*CurPtr == '\r' || *CurPtr == '\n') && IsMultilineString) {
         // The only case we reach here is unterminated single line string in the
         // interpolation. For better recovery, go on after emitting an error.
-        diagnose(CurPtr, diag::lex_unterminated_string);
+        diagnose(CurPtr, diag::string_interpolation_unclosed);
         wasErroneous = true;
         continue;
       } else {

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1885,11 +1885,11 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
         ++CurPtr;
         continue;
       } else if (!isMultilineString) {
-        diagnose(CurPtr, diag::lex_unterminated_string);
+        diagnose(TokStart, diag::lex_unterminated_string);
         diagnose(CurPtr, diag::string_interpolation_unclosed);
         diagnose(--TmpPtr, diag::opening_paren);
 
-        continue;
+        return formToken(tok::unknown, TokStart);
       } else if (*CurPtr == '\r' || *CurPtr == '\n' || CurPtr == BufferEnd) {
         // The only case we reach here is unterminated single line string in the
         // interpolation. For better recovery, go on after emitting an error.
@@ -1901,8 +1901,7 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
         continue;
       } else {
         // As a fallback, just emit an unterminated string error.
-        diagnose(CurPtr, diag::lex_unterminated_string);
-        wasErroneous = true;
+        diagnose(Tokstart, diag::lex_unterminated_string);
 
         return formToken(tok::unknown, TokStart);
       }

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1890,7 +1890,7 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
         diagnose(--TmpPtr, diag::opening_paren);
 
         return formToken(tok::unknown, TokStart);
-      } else if (*CurPtr == '\r' || *CurPtr == '\n') {
+      } else if (*CurPtr == '\r' || *CurPtr == '\n' || *CurPtr == BufferEnd) {
         // The only case we reach here is unterminated single line string in the
         // interpolation. For better recovery, go on after emitting an error.
         diagnose(CurPtr, diag::lex_unterminated_string);

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1889,7 +1889,8 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
         diagnose(CurPtr, diag::string_interpolation_unclosed);
         diagnose(--TmpPtr, diag::opening_paren);
 
-        return formToken(tok::unknown, TokStart);
+        wasErroneous = true;
+        continue;
       } else if (*CurPtr == '\r' || *CurPtr == '\n' || CurPtr == BufferEnd) {
         // The only case we reach here is unterminated single line string in the
         // interpolation. For better recovery, go on after emitting an error.
@@ -1898,13 +1899,13 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
         diagnose(--TmpPtr, diag::opening_paren);
 
         wasErroneous = true;
-        return formToken(tok::unknown, TokStart);
+        continue;
       } else {
         // As a fallback, just emit an unterminated string error.
         diagnose(CurPtr, diag::lex_unterminated_string);
         wasErroneous = true;
 
-        continue;
+        return formToken(tok::unknown, TokStart);
       }
     }
 

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1900,10 +1900,11 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
         wasErroneous = true;
         return formToken(tok::unknown, TokStart);
       } else {
-        // As a fallback, just emit an unterminated string error
+        // As a fallback, just emit an unterminated string error.
         diagnose(CurPtr, diag::lex_unterminated_string);
         wasErroneous = true;
 
+        continue;
         return formToken(tok::unknown, TokStart)
       }
     }

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1886,7 +1886,7 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
         continue;
       } else {
         if ((*CurPtr == '\r' || *CurPtr == '\n') && IsMultilineString) {
-          diagnose(CurPtr, diag::string_interpolation_unclosed);
+          diagnose(--TmpPtr, diag::string_interpolation_unclosed);
           diagnose(--TmpPtr, diag::opening_paren);
 
           // The only case we reach here is unterminated single line string in
@@ -1896,7 +1896,7 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
           wasErroneous = true;
           continue;
         } else if (!IsMultilineString || CurPtr == BufferEnd) {
-          diagnose(CurPtr, diag::string_interpolation_unclosed);
+          diagnose(--TmpPtr, diag::string_interpolation_unclosed);
           diagnose(--TmpPtr, diag::opening_paren);
         }
 

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1892,9 +1892,12 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
         continue;
       } else {
         diagnose(CurPtr, diag::string_interpolation_unclosed);
-        char* tmpDiagnosePtr = CurPtr - CustomDelimiterLen;
-        diagnose(tmpDiagnosePtr, diag::string_interpolation_unclosed_fix_it)
-            .fixItInsert(Lexer::getSourceLoc(tmpDiagnosePtr), ")");
+        char *fixItLoc = CurPtr - 1;
+        if (*fixItLoc == QuoteChar) {
+          fixItLoc -= CustomDelimiterLen;
+        }
+        diagnose(fixItLoc, diag::string_interpolation_unclosed_fix_it)
+            .fixItInsert(Lexer::getSourceLoc(fixItLoc), ")");
         return formToken(tok::unknown, TokStart);
       }
     }

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1896,6 +1896,7 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
         } else {
           diagnose(CurPtr, diag::string_interpolation_unclosed);
           diagnose(--TmpPtr, diag::opening_paren);
+          if (*CurPtr != ')') diagnose(CurPtr, diag::lex_unterminated_string);
           return formToken(tok::unknown, TokStart);
         }
       } else {

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1886,20 +1886,20 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
         continue;
       } else if (*CurPtr == '\r' || *CurPtr == '\n') {
         if (IsMultilineString) {
-        // The only case we reach here is unterminated single line string in the
-        // interpolation. For better recovery, go on after emitting an error.
-        diagnose(CurPtr, diag::string_interpolation_unclosed);
-        diagnose(CurPtr, diag::lex_unterminated_string);
-        wasErroneous = true;
-        continue;
+          // The only case we reach here is unterminated single line string in the
+          // interpolation. For better recovery, go on after emitting an error.
+          diagnose(CurPtr, diag::string_interpolation_unclosed);
+          diagnose(CurPtr, diag::lex_unterminated_string);
+          wasErroneous = true;
+          continue;
         } else {
-        const char *fixItLoc = CurPtr - 1;
-        if (*fixItLoc == QuoteChar) {
-          fixItLoc -= CustomDelimiterLen;
-        }
-        diagnose(fixItLoc, diag::string_interpolation_unclosed);
-            .fixItInsert(Lexer::getSourceLoc(fixItLoc), ")");
-        return formToken(tok::unknown, TokStart);
+          const char *fixItLoc = CurPtr - 1;
+          if (*fixItLoc == QuoteChar) {
+            fixItLoc -= CustomDelimiterLen;
+          }
+          diagnose(fixItLoc, diag::string_interpolation_unclosed);
+              .fixItInsert(Lexer::getSourceLoc(fixItLoc), ")");
+          return formToken(tok::unknown, TokStart);
         }
       } else {
         diagnose(TokStart, diag::lex_unterminated_string);

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1884,20 +1884,25 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
         // Successfully scanned the body of the expression literal.
         ++CurPtr;
         continue;
-      } else if ((*CurPtr == '\r' || *CurPtr == '\n') && IsMultilineString) {
+      } else if (*CurPtr == '\r' || *CurPtr == '\n') {
+        if (IsMultilineString) {
         // The only case we reach here is unterminated single line string in the
         // interpolation. For better recovery, go on after emitting an error.
         diagnose(CurPtr, diag::string_interpolation_unclosed);
         diagnose(CurPtr, diag::lex_unterminated_string);
         wasErroneous = true;
         continue;
-      } else {
+        } else {
         const char *fixItLoc = CurPtr - 1;
         if (*fixItLoc == QuoteChar) {
           fixItLoc -= CustomDelimiterLen;
         }
         diagnose(fixItLoc, diag::string_interpolation_unclosed);
             .fixItInsert(Lexer::getSourceLoc(fixItLoc), ")");
+        return formToken(tok::unknown, TokStart);
+        }
+      } else {
+        diagnose(TokStart, diag::lex_unterminated_string);
         return formToken(tok::unknown, TokStart);
       }
     }

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1887,11 +1887,11 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
       } else if ((*CurPtr == '\r' || *CurPtr == '\n') && IsMultilineString) {
         // The only case we reach here is unterminated single line string in the
         // interpolation. For better recovery, go on after emitting an error.
-        diagnose(CurPtr, diag::lex_unterminated_string);
+        diagnose(CurPtr, diag::string_interpolation_unclosed);
         wasErroneous = true;
         continue;
       } else {
-        diagnose(TokStart, diag::lex_unterminated_string);
+        diagnose(TokStart, diag::string_interpolation_unclosed);
         return formToken(tok::unknown, TokStart);
       }
     }

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1892,7 +1892,7 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
         continue;
       } else {
         diagnose(CurPtr, diag::string_interpolation_unclosed);
-        char *fixItLoc = CurPtr - 1;
+        char *fixItLoc = (char *)CurPtr - 1;
         if (*fixItLoc == QuoteChar) {
           fixItLoc -= CustomDelimiterLen;
         }

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1890,7 +1890,7 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
           // interpolation. For better recovery, go on after emitting an error.
           diagnose(CurPtr, diag::string_interpolation_unclosed);
           diagnose(--TmpPtr, diag::opening_paren);
-          diagnose(CurPtr, diag::lex_unterminated_string);
+          if (CurPtr == BufferEnd) diagnose(CurPtr, diag::lex_unterminated_string);
           wasErroneous = true;
           continue;
         } else {

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1887,7 +1887,6 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
       } else {
         if ((*CurPtr == '\r' || *CurPtr == '\n') && IsMultilineString) {
           diagnose(--TmpPtr, diag::string_interpolation_unclosed);
-          diagnose(--TmpPtr, diag::opening_paren);
 
           // The only case we reach here is unterminated single line string in
           // the interpolation. For better recovery, go on after emitting
@@ -1897,7 +1896,6 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
           continue;
         } else if (!IsMultilineString || CurPtr == BufferEnd) {
           diagnose(--TmpPtr, diag::string_interpolation_unclosed);
-          diagnose(--TmpPtr, diag::opening_paren);
         }
 
         // As a fallback, just emit an unterminated string error.

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1887,10 +1887,22 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
       } else if (!isMultilineString) {
         diagnose(CurPtr, diag::lex_unterminated_string);
         diagnose(CurPtr, diag::string_interpolation_unclosed);
+        diagnose(--TmpPtr, diag::opening_paren);
+
+        return formToken(tok::unknown, TokStart);
       } else if (*CurPtr == '\r' || *CurPtr == '\n') {
         diagnose(CurPtr, diag::lex_unterminated_string);
         diagnose(CurPtr, diag::string_interpolation_unclosed);
+        diagnose(--TmpPtr, diag::opening_paren);
+
+        wasErroneous = true;
+        continue;
         return formToken(tok::unknown, TokStart);
+      } else {
+        // as a fallback, just emit an unterminated string error
+        diagnose(CurPtr, diag::lex_unterminated_string);
+        wasErroneous = true;
+        continue;
       }
     }
 

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1891,18 +1891,20 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
 
         return formToken(tok::unknown, TokStart);
       } else if (*CurPtr == '\r' || *CurPtr == '\n') {
+        // The only case we reach here is unterminated single line string in the
+        // interpolation. For better recovery, go on after emitting an error.
         diagnose(CurPtr, diag::lex_unterminated_string);
         diagnose(CurPtr, diag::string_interpolation_unclosed);
         diagnose(--TmpPtr, diag::opening_paren);
 
         wasErroneous = true;
-        continue;
         return formToken(tok::unknown, TokStart);
       } else {
-        // as a fallback, just emit an unterminated string error
+        // As a fallback, just emit an unterminated string error
         diagnose(CurPtr, diag::lex_unterminated_string);
         wasErroneous = true;
-        continue;
+
+        return formToken(tok::unknown, TokStart)
       }
     }
 

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1890,7 +1890,7 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
           // interpolation. For better recovery, go on after emitting an error.
           diagnose(CurPtr, diag::string_interpolation_unclosed);
           diagnose(--TmpPtr, diag::opening_paren);
-          if (CurPtr == BufferEnd) diagnose(CurPtr, diag::lex_unterminated_string);
+          if (CurPtr != BufferEnd) diagnose(CurPtr, diag::lex_unterminated_string);
           wasErroneous = true;
           continue;
         } else {

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1893,12 +1893,7 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
           wasErroneous = true;
           continue;
         } else {
-          // location of the end of the interpolation expression
-          const char *interpolationEndLoc = CurPtr - 1;
-          if (*interpolationEndLoc == QuoteChar) {
-            interpolationEndLoc -= CustomDelimiterLen;
-          }
-          diagnose(interpolationEndLoc, diag::string_interpolation_unclosed);
+          diagnose(CurPtr, diag::string_interpolation_unclosed);
           return formToken(tok::unknown, TokStart);
         }
       } else {

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1902,7 +1902,6 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
     if (((*CurPtr == '\r' || *CurPtr == '\n') && !IsMultilineString)
         || CurPtr == BufferEnd) {
       diagnose(TokStart, diag::lex_unterminated_string);
-      char* endQuotes[] = isMultilineString ? "\"\"\"" : "\"";
       return formToken(tok::unknown, TokStart);
     }
 

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1892,7 +1892,7 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
         continue;
       } else {
         diagnose(CurPtr, diag::string_interpolation_unclosed);
-        char *fixItLoc = (char *)CurPtr - 1;
+        const char *fixItLoc = CurPtr - 1;
         if (*fixItLoc == QuoteChar) {
           fixItLoc -= CustomDelimiterLen;
         }

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1880,30 +1880,30 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
       // Consume tokens until we hit the corresponding ')'.
       CurPtr = skipToEndOfInterpolatedExpression(TmpPtr, BufferEnd,
                                                  IsMultilineString);
-        if (*CurPtr == ')') {
-            // Successfully scanned the body of the expression literal.
-            ++CurPtr;
-            continue;
-        } else {
-            if ((*CurPtr == '\r' || *CurPtr == '\n') && IsMultilineString) {
-                diagnose(CurPtr, diag::string_interpolation_unclosed);
-                diagnose(--TmpPtr, diag::opening_paren);
-                
-                // The only case we reach here is unterminated single line string in
-                // the interpolation. For better recovery, go on after emitting
-                // an error.
-                diagnose(CurPtr, diag::lex_unterminated_string);
-                wasErroneous = true;
-                continue;
-            } else if (!IsMultilineString || CurPtr == BufferEnd) {
-                diagnose(CurPtr, diag::string_interpolation_unclosed);
-                diagnose(--TmpPtr, diag::opening_paren);
-            }
-            
-            // As a fallback, just emit an unterminated string error.
-            diagnose(TokStart, diag::lex_unterminated_string);
-            return formToken(tok::unknown, TokStart);
+      if (*CurPtr == ')') {
+        // Successfully scanned the body of the expression literal.
+        ++CurPtr;
+        continue;
+      } else {
+        if ((*CurPtr == '\r' || *CurPtr == '\n') && IsMultilineString) {
+          diagnose(CurPtr, diag::string_interpolation_unclosed);
+          diagnose(--TmpPtr, diag::opening_paren);
+
+          // The only case we reach here is unterminated single line string in
+          // the interpolation. For better recovery, go on after emitting
+          // an error.
+          diagnose(CurPtr, diag::lex_unterminated_string);
+          wasErroneous = true;
+          continue;
+        } else if (!IsMultilineString || CurPtr == BufferEnd) {
+          diagnose(CurPtr, diag::string_interpolation_unclosed);
+          diagnose(--TmpPtr, diag::opening_paren);
         }
+            
+      // As a fallback, just emit an unterminated string error.
+      diagnose(TokStart, diag::lex_unterminated_string);
+      return formToken(tok::unknown, TokStart);
+      }
     }
 
     // String literals cannot have \n or \r in them (unless multiline).

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1889,7 +1889,7 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
           // The only case we reach here is unterminated single line string in the
           // interpolation. For better recovery, go on after emitting an error.
           diagnose(CurPtr, diag::string_interpolation_unclosed);
-          diagnose(--TmpPtr, diagnose::opening_paren);
+          diagnose(--TmpPtr, diag::opening_paren);
           diagnose(CurPtr, diag::lex_unterminated_string);
           wasErroneous = true;
           continue;

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1887,7 +1887,7 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
       } else if ((*CurPtr == '\r' || *CurPtr == '\n') && IsMultilineString) {
         // The only case we reach here is unterminated single line string in the
         // interpolation. For better recovery, go on after emitting an error.
-        diagnose(CurPtr, diag::string_interpolation_unclosed);
+        diagnose(CurPtr, diag::lex_unterminated_string);
         wasErroneous = true;
         continue;
       } else {

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1905,7 +1905,6 @@ void Lexer::lexStringLiteral(unsigned CustomDelimiterLen) {
         wasErroneous = true;
 
         continue;
-        return formToken(tok::unknown, TokStart);
       }
     }
 

--- a/test/Parse/multiline_errors.swift
+++ b/test/Parse/multiline_errors.swift
@@ -126,14 +126,14 @@ _ = "hello\("""
             world
             """
             )!"
-            // expected-error@-4 {{string interpolation needs to be closed by a )}}
+            // expected-error@-4 {{expected ')' at end of string interpolation}}
             // expected-error@-2 {{unterminated string literal}}
 
 _ = "hello\(
             """
             world
             """)!"
-            // expected-error@-4 {{string interpolation needs to be closed by a )}}
+            // expected-error@-4 {{expected ')' at end of string interpolation}}
             // expected-error@-2 {{unterminated string literal}}
 
 _ = """
@@ -190,4 +190,4 @@ let _ = """
   \("bar
   baz
   """
-  // expected-error@-3 {{string interpolation needs to be closed by a )}}
+  // expected-error@-3 {{expected ')' at end of string interpolation}}

--- a/test/Parse/multiline_errors.swift
+++ b/test/Parse/multiline_errors.swift
@@ -126,14 +126,14 @@ _ = "hello\("""
             world
             """
             )!"
-            // expected-error@-2 {{expected ')' at end of string interpolation}}
+            // expected-error@-2 {{expected ')' at end of string interpolation}} expected-note @-4 {{to match this opening '('}}
             // expected-error@-2 {{unterminated string literal}}
 
 _ = "hello\(
             """
             world
             """)!"
-            // expected-error@-4 {{expected ')' at end of string interpolation}}
+            // expected-error@-4 {{expected ')' at end of string interpolation}} expected-note @-4 {{to match this opening '('}}
             // expected-error@-2 {{unterminated string literal}}
 
 _ = """
@@ -190,4 +190,4 @@ let _ = """
   \("bar
   baz
   """
-  // expected-error@-3 {{expected ')' at end of string interpolation}}
+  // expected-error@-3 {{expected ')' at end of string interpolation}} expected-note @-3 {{to match this opening '('}}

--- a/test/Parse/multiline_errors.swift
+++ b/test/Parse/multiline_errors.swift
@@ -126,14 +126,14 @@ _ = "hello\("""
             world
             """
             )!"
-            // expected-error@-4 {{unterminated string literal}}
+            // expected-error@-4 {{string interpolation needs to be closed by a )}}
             // expected-error@-2 {{unterminated string literal}}
 
 _ = "hello\(
             """
             world
             """)!"
-            // expected-error@-4 {{unterminated string literal}}
+            // expected-error@-4 {{string interpolation needs to be closed by a )}}
             // expected-error@-2 {{unterminated string literal}}
 
 _ = """
@@ -190,4 +190,4 @@ let _ = """
   \("bar
   baz
   """
-  // expected-error@-3 {{unterminated string literal}}
+  // expected-error@-3 {{string interpolation needs to be closed by a )}}

--- a/test/Parse/multiline_errors.swift
+++ b/test/Parse/multiline_errors.swift
@@ -126,7 +126,7 @@ _ = "hello\("""
             world
             """
             )!"
-            // expected-error@-4 {{cannot find ')' to match this opening '(' in string interpolation}}
+            // expected-error@-4 {{cannot find ')' to match opening '(' in string interpolation}}
             // expected-error@-5 {{unterminated string literal}}
             // expected-error@-3 {{unterminated string literal}}
 
@@ -134,7 +134,7 @@ _ = "hello\(
             """
             world
             """)!"
-            // expected-error@-4 {{cannot find ')' to match this opening '(' in string interpolation}}
+            // expected-error@-4 {{cannot find ')' to match opening '(' in string interpolation}}
             // expected-error@-5 {{unterminated string literal}}
             // expected-error@-3 {{unterminated string literal}}
 
@@ -192,5 +192,6 @@ let _ = """
   \("bar
   baz
   """
-  // expected-error@-3 {{cannot find ')' to match this opening '(' in string interpolation}}
+  // expected-error@-3 {{cannot find ')' to match opening '(' in string interpolation}}
   // expected-error@-4 {{unterminated string literal}}
+

--- a/test/Parse/multiline_errors.swift
+++ b/test/Parse/multiline_errors.swift
@@ -126,14 +126,14 @@ _ = "hello\("""
             world
             """
             )!"
-            // expected-error@-4 {{expected ')' at end of string interpolation}}
+            // expected-error@-2 {{expected ')' at end of string interpolation}} expected-note@-2 {{add ')' to end of interpolation statement}} {{16-16=)}}
             // expected-error@-2 {{unterminated string literal}}
 
 _ = "hello\(
             """
             world
             """)!"
-            // expected-error@-4 {{expected ')' at end of string interpolation}}
+            // expected-error@-4 {{expected ')' at end of string interpolation}} expected-note@-4 {{add ')' to end of interpolation statement}} {{13-13=)}}
             // expected-error@-2 {{unterminated string literal}}
 
 _ = """

--- a/test/Parse/multiline_errors.swift
+++ b/test/Parse/multiline_errors.swift
@@ -126,14 +126,14 @@ _ = "hello\("""
             world
             """
             )!"
-            // expected-error@-2 {{expected ')' at end of string interpolation}} {{15-15=)}}
+            // expected-error@-2 {{expected ')' at end of string interpolation}}
             // expected-error@-2 {{unterminated string literal}}
 
 _ = "hello\(
             """
             world
             """)!"
-            // expected-error@-4 {{expected ')' at end of string interpolation}} {{12-12=)}}
+            // expected-error@-4 {{expected ')' at end of string interpolation}}
             // expected-error@-2 {{unterminated string literal}}
 
 _ = """

--- a/test/Parse/multiline_errors.swift
+++ b/test/Parse/multiline_errors.swift
@@ -126,14 +126,14 @@ _ = "hello\("""
             world
             """
             )!"
-            // expected-error@-2 {{expected ')' at end of string interpolation}} expected-note@-2 {{add ')' to end of interpolation statement}} {{16-16=)}}
+            // expected-error@-2 {{expected ')' at end of string interpolation}} {{15-15=)}}
             // expected-error@-2 {{unterminated string literal}}
 
 _ = "hello\(
             """
             world
             """)!"
-            // expected-error@-4 {{expected ')' at end of string interpolation}} expected-note@-4 {{add ')' to end of interpolation statement}} {{13-13=)}}
+            // expected-error@-4 {{expected ')' at end of string interpolation}} {{12-12=)}}
             // expected-error@-2 {{unterminated string literal}}
 
 _ = """

--- a/test/Parse/multiline_errors.swift
+++ b/test/Parse/multiline_errors.swift
@@ -166,14 +166,12 @@ _ = """
   // expected-error@-2 {{escaped newline at the last line is not allowed}} {{6-7=}}
 
 _ = """
-  foo\
-  """
+  foo\  """
   // expected-error@-1 {{escaped newline at the last line is not allowed}} {{6-7=}}
 
 _ = """
   foo\
-
-  """ // OK because LF + CR is two new lines.
+  """ // OK because LF + CR is two new lines.
 
 _ = """
 \

--- a/test/Parse/multiline_errors.swift
+++ b/test/Parse/multiline_errors.swift
@@ -126,7 +126,7 @@ _ = "hello\("""
             world
             """
             )!"
-            // expected-error@-2 {{cannot find ')' to match this opening '(' in string interpolation}}
+            // expected-error@-4 {{cannot find ')' to match this opening '(' in string interpolation}}
             // expected-error@-5 {{unterminated string literal}}
             // expected-error@-3 {{unterminated string literal}}
 
@@ -166,12 +166,14 @@ _ = """
   // expected-error@-2 {{escaped newline at the last line is not allowed}} {{6-7=}}
 
 _ = """
-  foo\  """
+  foo\
+  """
   // expected-error@-1 {{escaped newline at the last line is not allowed}} {{6-7=}}
 
 _ = """
   foo\
-  """ // OK because LF + CR is two new lines.
+
+  """ // OK because LF + CR is two new lines.
 
 _ = """
 \

--- a/test/Parse/multiline_errors.swift
+++ b/test/Parse/multiline_errors.swift
@@ -126,7 +126,7 @@ _ = "hello\("""
             world
             """
             )!"
-            // expected-error@-2 {{expected ')' at end of string interpolation}} expected-note @-4 {{to match this opening '('}}
+            // expected-error@-2 {{cannot find ')' to match this opening '(' in string interpolation}}
             // expected-error@-5 {{unterminated string literal}}
             // expected-error@-3 {{unterminated string literal}}
 
@@ -134,7 +134,7 @@ _ = "hello\(
             """
             world
             """)!"
-            // expected-error@-4 {{expected ')' at end of string interpolation}} expected-note @-4 {{to match this opening '('}}
+            // expected-error@-4 {{cannot find ')' to match this opening '(' in string interpolation}}
             // expected-error@-5 {{unterminated string literal}}
             // expected-error@-3 {{unterminated string literal}}
 
@@ -192,5 +192,5 @@ let _ = """
   \("bar
   baz
   """
-  // expected-error@-3 {{expected ')' at end of string interpolation}} expected-note @-3 {{to match this opening '('}}
+  // expected-error@-3 {{cannot find ')' to match this opening '(' in string interpolation}}
   // expected-error@-4 {{unterminated string literal}}

--- a/test/Parse/multiline_errors.swift
+++ b/test/Parse/multiline_errors.swift
@@ -127,14 +127,16 @@ _ = "hello\("""
             """
             )!"
             // expected-error@-2 {{expected ')' at end of string interpolation}} expected-note @-4 {{to match this opening '('}}
-            // expected-error@-2 {{unterminated string literal}}
+            // expected-error@-5 {{unterminated string literal}}
+            // expected-error@-3 {{unterminated string literal}}
 
 _ = "hello\(
             """
             world
             """)!"
             // expected-error@-4 {{expected ')' at end of string interpolation}} expected-note @-4 {{to match this opening '('}}
-            // expected-error@-2 {{unterminated string literal}}
+            // expected-error@-5 {{unterminated string literal}}
+            // expected-error@-3 {{unterminated string literal}}
 
 _ = """
   line one \ non-whitespace

--- a/test/Parse/multiline_errors.swift
+++ b/test/Parse/multiline_errors.swift
@@ -191,3 +191,4 @@ let _ = """
   baz
   """
   // expected-error@-3 {{expected ')' at end of string interpolation}} expected-note @-3 {{to match this opening '('}}
+  // expected-error@-4 {{unterminated string literal}}

--- a/test/Parse/string_literal_eof1.swift
+++ b/test/Parse/string_literal_eof1.swift
@@ -2,5 +2,5 @@
 
 // NOTE: DO NOT add a newline at EOF.
 // expected-error@+2 {{unterminated string literal}}
-// expected-error@+1 {{expected ')' at end of string interpolation}} expected-note @+1 {{to match this opening '('}}
+// expected-error@+1 {{cannot find ')' to match this opening '(' in string interpolation}}
 _ = "foo\(

--- a/test/Parse/string_literal_eof1.swift
+++ b/test/Parse/string_literal_eof1.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift
 
 // NOTE: DO NOT add a newline at EOF.
-// expected-error@+1 {{expected ')' at end of string interpolation}}
+// expected-error@+1 {{expected ')' at end of string interpolation}} expected-note @+1 {{add ')' to end of interpolation statement}} {{11-11=)}}
 _ = "foo\(

--- a/test/Parse/string_literal_eof1.swift
+++ b/test/Parse/string_literal_eof1.swift
@@ -2,5 +2,5 @@
 
 // NOTE: DO NOT add a newline at EOF.
 // expected-error@+2 {{unterminated string literal}}
-// expected-error@+1 {{cannot find ')' to match this opening '(' in string interpolation}}
+// expected-error@+1 {{cannot find ')' to match opening '(' in string interpolation}}
 _ = "foo\(

--- a/test/Parse/string_literal_eof1.swift
+++ b/test/Parse/string_literal_eof1.swift
@@ -1,5 +1,6 @@
 // RUN: %target-typecheck-verify-swift
 
 // NOTE: DO NOT add a newline at EOF.
+// expected-error@+2 {{unterminated string literal}}
 // expected-error@+1 {{expected ')' at end of string interpolation}} expected-note @+1 {{to match this opening '('}}
 _ = "foo\(

--- a/test/Parse/string_literal_eof1.swift
+++ b/test/Parse/string_literal_eof1.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift
 
 // NOTE: DO NOT add a newline at EOF.
-// expected-error@+1 {{expected ')' at end of string interpolation}} expected-note @+1 {{add ')' to end of interpolation statement}} {{11-11=)}}
+// expected-error@+1 {{expected ')' at end of string interpolation}} {{10-10=)}}
 _ = "foo\(

--- a/test/Parse/string_literal_eof1.swift
+++ b/test/Parse/string_literal_eof1.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift
 
 // NOTE: DO NOT add a newline at EOF.
-// expected-error@+1 {{unterminated string literal}}
+// expected-error@+1 {{string interpolation needs to be closed by a )}}
 _ = "foo\(

--- a/test/Parse/string_literal_eof1.swift
+++ b/test/Parse/string_literal_eof1.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift
 
 // NOTE: DO NOT add a newline at EOF.
-// expected-error@+1 {{string interpolation needs to be closed by a )}}
+// expected-error@+1 {{expected ')' at end of string interpolation}}
 _ = "foo\(

--- a/test/Parse/string_literal_eof1.swift
+++ b/test/Parse/string_literal_eof1.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift
 
 // NOTE: DO NOT add a newline at EOF.
-// expected-error@+1 {{expected ')' at end of string interpolation}} {{10-10=)}}
+// expected-error@+1 {{expected ')' at end of string interpolation}}
 _ = "foo\(

--- a/test/Parse/string_literal_eof1.swift
+++ b/test/Parse/string_literal_eof1.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift
 
 // NOTE: DO NOT add a newline at EOF.
-// expected-error@+1 {{expected ')' at end of string interpolation}}
+// expected-error@+1 {{expected ')' at end of string interpolation}} expected-note @+1 {{to match this opening '('}}
 _ = "foo\(

--- a/test/Parse/string_literal_eof2.swift
+++ b/test/Parse/string_literal_eof2.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift
 
 // NOTE: DO NOT add a newline at EOF.
-// expected-error@+2 {{expected ')' at end of string interpolation}} {{14-14=)}}
+// expected-error@+2 {{expected ')' at end of string interpolation}}
 // expected-error@+1 {{unterminated string literal}}
 _ = "foo\("bar

--- a/test/Parse/string_literal_eof2.swift
+++ b/test/Parse/string_literal_eof2.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift
 
 // NOTE: DO NOT add a newline at EOF.
-// expected-error@+2 {{expected ')' at end of string interpolation}} expected-note @+2 {{to match this opening '('}}
+// expected-error@+2 {{cannot find ')' to match this opening '(' in string interpolation}}
 // expected-error@+1 {{unterminated string literal}}
 _ = "foo\("bar

--- a/test/Parse/string_literal_eof2.swift
+++ b/test/Parse/string_literal_eof2.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift
 
 // NOTE: DO NOT add a newline at EOF.
-// expected-error@+2 {{cannot find ')' to match this opening '(' in string interpolation}}
+// expected-error@+2 {{cannot find ')' to match opening '(' in string interpolation}}
 // expected-error@+1 {{unterminated string literal}}
 _ = "foo\("bar

--- a/test/Parse/string_literal_eof2.swift
+++ b/test/Parse/string_literal_eof2.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift
 
 // NOTE: DO NOT add a newline at EOF.
-// expected-error@+1 {{unterminated string literal}}
+// expected-error@+1 {{expected ')' at end of string interpolation}}
 _ = "foo\("bar

--- a/test/Parse/string_literal_eof2.swift
+++ b/test/Parse/string_literal_eof2.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift
 
 // NOTE: DO NOT add a newline at EOF.
-// expected-error@+2 {{expected ')' at end of string interpolation}}
+// expected-error@+2 {{expected ')' at end of string interpolation}} expected-note @+2 {{to match this opening '('}}
 // expected-error@+1 {{unterminated string literal}}
 _ = "foo\("bar

--- a/test/Parse/string_literal_eof2.swift
+++ b/test/Parse/string_literal_eof2.swift
@@ -1,6 +1,5 @@
 // RUN: %target-typecheck-verify-swift
 
 // NOTE: DO NOT add a newline at EOF.
-// expected-error@+2 {{expected ')' at end of string interpolation}} 
-// expected-note @+1 {{add ')' to end of interpolation statement}} {{15-15=)}}
+// expected-error@+1 {{expected ')' at end of string interpolation}} {{14-14=)}}
 _ = "foo\("bar

--- a/test/Parse/string_literal_eof2.swift
+++ b/test/Parse/string_literal_eof2.swift
@@ -1,5 +1,6 @@
 // RUN: %target-typecheck-verify-swift
 
 // NOTE: DO NOT add a newline at EOF.
-// expected-error@+1 {{expected ')' at end of string interpolation}}
+// expected-error@+2 {{expected ')' at end of string interpolation}} 
+// expected-note @+1 {{add ')' to end of interpolation statement}} {{15-15=)}}
 _ = "foo\("bar

--- a/test/Parse/string_literal_eof2.swift
+++ b/test/Parse/string_literal_eof2.swift
@@ -1,5 +1,6 @@
 // RUN: %target-typecheck-verify-swift
 
 // NOTE: DO NOT add a newline at EOF.
-// expected-error@+1 {{expected ')' at end of string interpolation}} {{14-14=)}}
+// expected-error@+2 {{expected ')' at end of string interpolation}} {{14-14=)}}
+// expected-error@+1 {{unterminated string literal}}
 _ = "foo\("bar

--- a/test/Parse/string_literal_eof5.swift
+++ b/test/Parse/string_literal_eof5.swift
@@ -2,7 +2,7 @@
 
 // NOTE: DO NOT add a newline at EOF.
 // expected-error@+2 {{unterminated string literal}}
-// expected-error@+4 {{cannot find ')' to match this opening '(' in string interpolation}}
+// expected-error@+3 {{cannot find ')' to match this opening '(' in string interpolation}}
 _ = """
     foo
     \(

--- a/test/Parse/string_literal_eof5.swift
+++ b/test/Parse/string_literal_eof5.swift
@@ -1,8 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 
 // NOTE: DO NOT add a newline at EOF.
-// expected-note @+5 {{add ')' to end of interpolation statement}} {{1-1=)}}
-// expected-error@+4 {{expected ')' at end of string interpolation}}
+// expected-error@+3 {{expected ')' at end of string interpolation}} {{7-7=)}}
 _ = """
     foo
     \(

--- a/test/Parse/string_literal_eof5.swift
+++ b/test/Parse/string_literal_eof5.swift
@@ -2,7 +2,7 @@
 
 // NOTE: DO NOT add a newline at EOF.
 // expected-error@+2 {{unterminated string literal}}
-// expected-error@+3 {{cannot find ')' to match this opening '(' in string interpolation}}
+// expected-error@+3 {{cannot find ')' to match opening '(' in string interpolation}}
 _ = """
     foo
     \(

--- a/test/Parse/string_literal_eof5.swift
+++ b/test/Parse/string_literal_eof5.swift
@@ -1,7 +1,8 @@
 // RUN: %target-typecheck-verify-swift
 
 // NOTE: DO NOT add a newline at EOF.
-// expected-error@+1 {{expected ')' at end of string interpolation}}
+// expected-note @+4 {{add ')' to end of interpolation statement}} {{7-7=)}}
+// expected-error@+3 {{expected ')' at end of string interpolation}}
 _ = """
     foo
     \(

--- a/test/Parse/string_literal_eof5.swift
+++ b/test/Parse/string_literal_eof5.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 
 // NOTE: DO NOT add a newline at EOF.
-// expected-error@+3 {{expected ')' at end of string interpolation}}
+// expected-error@+3 {{expected ')' at end of string interpolation}} expected-note @+3 {{to match this opening '('}}
 _ = """
     foo
     \(

--- a/test/Parse/string_literal_eof5.swift
+++ b/test/Parse/string_literal_eof5.swift
@@ -2,7 +2,7 @@
 
 // NOTE: DO NOT add a newline at EOF.
 // expected-error@+2 {{unterminated string literal}}
-// expected-error@+3 {{expected ')' at end of string interpolation}} expected-note @+3 {{to match this opening '('}}
+// expected-error@+4 {{expected ')' at end of string interpolation}} expected-note @+3 {{to match this opening '('}}
 _ = """
     foo
     \(

--- a/test/Parse/string_literal_eof5.swift
+++ b/test/Parse/string_literal_eof5.swift
@@ -1,6 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 
 // NOTE: DO NOT add a newline at EOF.
+// expected-error@+2 {{unterminated string literal}}
 // expected-error@+3 {{expected ')' at end of string interpolation}} expected-note @+3 {{to match this opening '('}}
 _ = """
     foo

--- a/test/Parse/string_literal_eof5.swift
+++ b/test/Parse/string_literal_eof5.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 
 // NOTE: DO NOT add a newline at EOF.
-// expected-error@+1 {{string interpolation needs to be closed by a )}}
+// expected-error@+1 {{expected ')' at end of string interpolation}}
 _ = """
     foo
     \(

--- a/test/Parse/string_literal_eof5.swift
+++ b/test/Parse/string_literal_eof5.swift
@@ -1,8 +1,8 @@
 // RUN: %target-typecheck-verify-swift
 
 // NOTE: DO NOT add a newline at EOF.
-// expected-note @+4 {{add ')' to end of interpolation statement}} {{7-7=)}}
-// expected-error@+3 {{expected ')' at end of string interpolation}}
+// expected-note @+5 {{add ')' to end of interpolation statement}} {{1-1=)}}
+// expected-error@+4 {{expected ')' at end of string interpolation}}
 _ = """
     foo
     \(

--- a/test/Parse/string_literal_eof5.swift
+++ b/test/Parse/string_literal_eof5.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 
 // NOTE: DO NOT add a newline at EOF.
-// expected-error@+1 {{unterminated string literal}}
+// expected-error@+1 {{string interpolation needs to be closed by a )}}
 _ = """
     foo
     \(

--- a/test/Parse/string_literal_eof5.swift
+++ b/test/Parse/string_literal_eof5.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 
 // NOTE: DO NOT add a newline at EOF.
-// expected-error@+3 {{expected ')' at end of string interpolation}} {{7-7=)}}
+// expected-error@+3 {{expected ')' at end of string interpolation}}
 _ = """
     foo
     \(

--- a/test/Parse/string_literal_eof5.swift
+++ b/test/Parse/string_literal_eof5.swift
@@ -2,7 +2,7 @@
 
 // NOTE: DO NOT add a newline at EOF.
 // expected-error@+2 {{unterminated string literal}}
-// expected-error@+4 {{expected ')' at end of string interpolation}} expected-note @+3 {{to match this opening '('}}
+// expected-error@+4 {{cannot find ')' to match this opening '(' in string interpolation}}
 _ = """
     foo
     \(

--- a/test/Parse/string_literal_eof6.swift
+++ b/test/Parse/string_literal_eof6.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 
 // NOTE: DO NOT add a newline at EOF.
-// expected-error@+1 {{expected ')' at end of string interpolation}}
+// expected-error@+3 {{expected ')' at end of string interpolation}} expected-note @+3 {{add ')' to end of interpolation statement}} {{11-11=)}}
 _ = """
     foo
     \("bar

--- a/test/Parse/string_literal_eof6.swift
+++ b/test/Parse/string_literal_eof6.swift
@@ -1,8 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 
 // NOTE: DO NOT add a newline at EOF.
-// expected-error@+4 {{expected ')' at end of string interpolation}}
-// expected-error@+1 {{unterminated string literal}}
+// expected-error@+1 {{expected ')' at end of string interpolation}}
 _ = """
     foo
     \("bar

--- a/test/Parse/string_literal_eof6.swift
+++ b/test/Parse/string_literal_eof6.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 
 // NOTE: DO NOT add a newline at EOF.
-// expected-error@+3 {{expected ')' at end of string interpolation}} {{10-10=)}}
+// expected-error@+3 {{expected ')' at end of string interpolation}}
 _ = """
     foo
     \("bar

--- a/test/Parse/string_literal_eof6.swift
+++ b/test/Parse/string_literal_eof6.swift
@@ -2,7 +2,7 @@
 
 // NOTE: DO NOT add a newline at EOF.
 // expected-error@+2 {{unterminated string literal}}
-// expected-error@+3 {{expected ')' at end of string interpolation}} expected-note @+3 {{to match this opening '('}}
+// expected-error@+3 {{cannot find ')' to match this opening '(' in string interpolation}}
 _ = """
     foo
     \("bar

--- a/test/Parse/string_literal_eof6.swift
+++ b/test/Parse/string_literal_eof6.swift
@@ -1,6 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 
 // NOTE: DO NOT add a newline at EOF.
+// expected-error@+2 {{unterminated string literal}}
 // expected-error@+3 {{expected ')' at end of string interpolation}} expected-note @+3 {{to match this opening '('}}
 _ = """
     foo

--- a/test/Parse/string_literal_eof6.swift
+++ b/test/Parse/string_literal_eof6.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 
 // NOTE: DO NOT add a newline at EOF.
-// expected-error@+3 {{expected ')' at end of string interpolation}} expected-note @+3 {{add ')' to end of interpolation statement}} {{11-11=)}}
+// expected-error@+3 {{expected ')' at end of string interpolation}} {{10-10=)}}
 _ = """
     foo
     \("bar

--- a/test/Parse/string_literal_eof6.swift
+++ b/test/Parse/string_literal_eof6.swift
@@ -1,6 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 
 // NOTE: DO NOT add a newline at EOF.
+// expected-error@+4 {{expected ')' at end of string interpolation}}
 // expected-error@+1 {{unterminated string literal}}
 _ = """
     foo

--- a/test/Parse/string_literal_eof6.swift
+++ b/test/Parse/string_literal_eof6.swift
@@ -2,7 +2,7 @@
 
 // NOTE: DO NOT add a newline at EOF.
 // expected-error@+2 {{unterminated string literal}}
-// expected-error@+3 {{cannot find ')' to match this opening '(' in string interpolation}}
+// expected-error@+3 {{cannot find ')' to match opening '(' in string interpolation}}
 _ = """
     foo
     \("bar

--- a/test/Parse/string_literal_eof6.swift
+++ b/test/Parse/string_literal_eof6.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 
 // NOTE: DO NOT add a newline at EOF.
-// expected-error@+3 {{expected ')' at end of string interpolation}}
+// expected-error@+3 {{expected ')' at end of string interpolation}} expected-note @+3 {{to match this opening '('}}
 _ = """
     foo
     \("bar

--- a/test/Parse/string_literal_eof7.swift
+++ b/test/Parse/string_literal_eof7.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift
 
-// expected-error@+4 {{expected ')' at end of string interpolation}}
+// expected-error@+4 {{expected ')' at end of string interpolation}} expected-note @+4 {{to match this opening '('}}
 // expected-error@+1 {{unterminated string literal}}
 _ = """
     foo

--- a/test/Parse/string_literal_eof7.swift
+++ b/test/Parse/string_literal_eof7.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift
 
-// expected-error@+4 {{expected ')' at end of string interpolation}} expected-note @+4 {{to match this opening '('}}
+// expected-error@+4 {{cannot find ')' to match this opening '(' in string interpolation}}
 // expected-error@+1 {{unterminated string literal}} expected-error@+3 {{unterminated string literal}}
 _ = """
     foo

--- a/test/Parse/string_literal_eof7.swift
+++ b/test/Parse/string_literal_eof7.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift
 
-// expected-error@+4 {{string interpolation needs to be closed by a )}}
+// expected-error@+4 {{expected ')' at end of string interpolation}}
 // expected-error@+1 {{unterminated string literal}}
 _ = """
     foo

--- a/test/Parse/string_literal_eof7.swift
+++ b/test/Parse/string_literal_eof7.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 
 // expected-error@+4 {{expected ')' at end of string interpolation}} expected-note @+4 {{to match this opening '('}}
-// expected-error@+1 {{unterminated string literal}}
+// expected-error@+1 {{unterminated string literal}} expected-error@+3 {{unterminated string literal}}
 _ = """
     foo
     \("bar

--- a/test/Parse/string_literal_eof7.swift
+++ b/test/Parse/string_literal_eof7.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift
 
-// expected-error@+4 {{unterminated string literal}}
+// expected-error@+4 {{string interpolation needs to be closed by a )}}
 // expected-error@+1 {{unterminated string literal}}
 _ = """
     foo

--- a/test/Parse/string_literal_eof7.swift
+++ b/test/Parse/string_literal_eof7.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift
 
-// expected-error@+4 {{cannot find ')' to match this opening '(' in string interpolation}}
+// expected-error@+4 {{cannot find ')' to match opening '(' in string interpolation}}
 // expected-error@+1 {{unterminated string literal}} expected-error@+3 {{unterminated string literal}}
 _ = """
     foo

--- a/test/Parse/unclosed-string-interpolation.swift
+++ b/test/Parse/unclosed-string-interpolation.swift
@@ -2,14 +2,26 @@
 
 let mid = "pete"
 
-_ = "mid == \(pete" // expected-error {{expected ')' at end of string interpolation}} expected-note {{to match this opening '('}}
-let theGoat = "kanye \(" // expected-error {{expected ')' at end of string interpolation}} expected-note {{to match this opening '('}}
-let equation1 = "2 + 2 = \(2 + 2" // expected-error {{expected ')' at end of string interpolation}} expected-note {{to match this opening '('}}
+_ = "mid == \(pete" 
+// expected-error @-1 {{expected ')' at end of string interpolation}} expected-note @-1 {{to match this opening '('}}
+
+let theGoat = "kanye \("
+// expected-error @-1 {{expected ')' at end of string interpolation}} expected-note @-1 {{to match this opening '('}}
+
+let equation1 = "2 + 2 = \(2 + 2" 
+// expected-error @-1 {{expected ')' at end of string interpolation}} expected-note @-1 {{to match this opening '('}}
 
 _ = """
 \(
 """
 // expected-error @-2 {{expected ')' at end of string interpolation}} expected-note @-2 {{to match this opening '('}}
 
-let s = "\(x"; print(x) // expected-error {{expected ')' at end of string interpolation}} expected-note {{to match this opening '('}}
-let zzz = "\(x; print(x) // expected-error {{expected ')' at end of string interpolation}} expected-note {{to match this opening '('}}
+let s = "\(x"; print(x) 
+// expected-error @-1 {{expected ')' at end of string interpolation}} expected-note @-1 {{to match this opening '('}}
+
+let zzz = "\(x; print(x)
+// expected-error @-1 {{expected ')' at end of string interpolation}} expected-note @-1 {{to match this opening '('}}
+
+let goatedAlbum = "The Life Of \("Pablo"
+// expected-error @-1 {{expected ')' at end of string interpolation}} expected-note @-1 {{to match this opening '('}}
+// expected-error @-1 {{unterminated string literal}}

--- a/test/Parse/unclosed-string-interpolation.swift
+++ b/test/Parse/unclosed-string-interpolation.swift
@@ -26,7 +26,7 @@ let goatedAlbum = "The Life Of \("Pablo"
 // expected-error @-1 {{cannot find ')' to match this opening '(' in string interpolation}}
 // expected-error @-2 {{unterminated string literal}}
 
-// expected-error @+4 {{cannot find ')' to match this opening '(' in string interpolation}}
+// expected-error @+3 {{cannot find ')' to match this opening '(' in string interpolation}}
 // expected-error @+1 {{unterminated string literal}}
 _ = """
 \(

--- a/test/Parse/unclosed-string-interpolation.swift
+++ b/test/Parse/unclosed-string-interpolation.swift
@@ -4,24 +4,30 @@ let mid = "pete"
 
 _ = "mid == \(pete" 
 // expected-error @-1 {{expected ')' at end of string interpolation}} expected-note @-1 {{to match this opening '('}}
+// expected-error @-2 {{unterminated string literal}}
 
 let theGoat = "kanye \("
 // expected-error @-1 {{expected ')' at end of string interpolation}} expected-note @-1 {{to match this opening '('}}
+// expected-error @-2 {{unterminated string literal}}
 
 let equation1 = "2 + 2 = \(2 + 2" 
 // expected-error @-1 {{expected ')' at end of string interpolation}} expected-note @-1 {{to match this opening '('}}
+// expected-error @-2 {{unterminated string literal}}
 
 let s = "\(x"; print(x) 
 // expected-error @-1 {{expected ')' at end of string interpolation}} expected-note @-1 {{to match this opening '('}}
+// expected-error @-2 {{unterminated string literal}}
 
 let zzz = "\(x; print(x)
 // expected-error @-1 {{expected ')' at end of string interpolation}} expected-note @-1 {{to match this opening '('}}
+// expected-error @-2 {{unterminated string literal}}
 
 let goatedAlbum = "The Life Of \("Pablo"
 // expected-error @-1 {{expected ')' at end of string interpolation}} expected-note @-1 {{to match this opening '('}}
-// expected-error @-1 {{unterminated string literal}}
+// expected-error @-2 {{unterminated string literal}}
 
+// expected-error @+4 {{expected ')' at end of string interpolation}} expected-note @+3 {{to match this opening '('}}
+// expected-error @+1 {{unterminated string literal}}
 _ = """
 \(
 """
-// expected-error @-2 {{expected ')' at end of string interpolation}} expected-note @-2 {{to match this opening '('}}

--- a/test/Parse/unclosed-string-interpolation.swift
+++ b/test/Parse/unclosed-string-interpolation.swift
@@ -2,11 +2,14 @@
 
 let mid = "pete"
 
-_ = "mid == \(pete" // expected-error {{expected ')' at end of string interpolation}}
-let theGoat = "kanye \(" // expected-error {{expected ')' at end of string interpolation}}
-let equation1 = "2 + 2 = \(2 + 2" // expected-error {{expected ')' at end of string interpolation}}
+_ = "mid == \(pete" // expected-error {{expected ')' at end of string interpolation}} expected-note {{to match this opening '('}}
+let theGoat = "kanye \(" // expected-error {{expected ')' at end of string interpolation}} expected-note {{to match this opening '('}}
+let equation1 = "2 + 2 = \(2 + 2" // expected-error {{expected ')' at end of string interpolation}} expected-note {{to match this opening '('}}
 
 _ = """
 \(
 """
-// expected-error @-2 {{expected ')' at end of string interpolation}}
+// expected-error @-2 {{expected ')' at end of string interpolation}} expected-note @-2 {{to match this opening '('}}
+
+let s = "\(x"; print(x) // expected-error {{expected ')' at end of string interpolation}} expected-note {{to match this opening '('}}
+let zzz = "\(x; print(x) // expected-error {{expected ')' at end of string interpolation}} expected-note {{to match this opening '('}}

--- a/test/Parse/unclosed-string-interpolation.swift
+++ b/test/Parse/unclosed-string-interpolation.swift
@@ -3,30 +3,30 @@
 let mid = "pete"
 
 _ = "mid == \(pete" 
-// expected-error @-1 {{expected ')' at end of string interpolation}} expected-note @-1 {{to match this opening '('}}
+// expected-error @-1 {{cannot find ')' to match this opening '(' in string interpolation}}
 // expected-error @-2 {{unterminated string literal}}
 
 let theGoat = "kanye \("
-// expected-error @-1 {{expected ')' at end of string interpolation}} expected-note @-1 {{to match this opening '('}}
+// expected-error @-1 {{cannot find ')' to match this opening '(' in string interpolation}}
 // expected-error @-2 {{unterminated string literal}}
 
 let equation1 = "2 + 2 = \(2 + 2" 
-// expected-error @-1 {{expected ')' at end of string interpolation}} expected-note @-1 {{to match this opening '('}}
+// expected-error @-1 {{cannot find ')' to match this opening '(' in string interpolation}}
 // expected-error @-2 {{unterminated string literal}}
 
 let s = "\(x"; print(x) 
-// expected-error @-1 {{expected ')' at end of string interpolation}} expected-note @-1 {{to match this opening '('}}
+// expected-error @-1 {{cannot find ')' to match this opening '(' in string interpolation}}
 // expected-error @-2 {{unterminated string literal}}
 
 let zzz = "\(x; print(x)
-// expected-error @-1 {{expected ')' at end of string interpolation}} expected-note @-1 {{to match this opening '('}}
+// expected-error @-1 {{cannot find ')' to match this opening '(' in string interpolation}}
 // expected-error @-2 {{unterminated string literal}}
 
 let goatedAlbum = "The Life Of \("Pablo"
-// expected-error @-1 {{expected ')' at end of string interpolation}} expected-note @-1 {{to match this opening '('}}
+// expected-error @-1 {{cannot find ')' to match this opening '(' in string interpolation}}
 // expected-error @-2 {{unterminated string literal}}
 
-// expected-error @+4 {{expected ')' at end of string interpolation}} expected-note @+3 {{to match this opening '('}}
+// expected-error @+4 {{cannot find ')' to match this opening '(' in string interpolation}}
 // expected-error @+1 {{unterminated string literal}}
 _ = """
 \(

--- a/test/Parse/unclosed-string-interpolation.swift
+++ b/test/Parse/unclosed-string-interpolation.swift
@@ -3,30 +3,30 @@
 let mid = "pete"
 
 _ = "mid == \(pete" 
-// expected-error @-1 {{cannot find ')' to match this opening '(' in string interpolation}}
+// expected-error @-1 {{cannot find ')' to match opening '(' in string interpolation}}
 // expected-error @-2 {{unterminated string literal}}
 
 let theGoat = "kanye \("
-// expected-error @-1 {{cannot find ')' to match this opening '(' in string interpolation}}
+// expected-error @-1 {{cannot find ')' to match opening '(' in string interpolation}}
 // expected-error @-2 {{unterminated string literal}}
 
 let equation1 = "2 + 2 = \(2 + 2" 
-// expected-error @-1 {{cannot find ')' to match this opening '(' in string interpolation}}
+// expected-error @-1 {{cannot find ')' to match opening '(' in string interpolation}}
 // expected-error @-2 {{unterminated string literal}}
 
 let s = "\(x"; print(x) 
-// expected-error @-1 {{cannot find ')' to match this opening '(' in string interpolation}}
+// expected-error @-1 {{cannot find ')' to match opening '(' in string interpolation}}
 // expected-error @-2 {{unterminated string literal}}
 
 let zzz = "\(x; print(x)
-// expected-error @-1 {{cannot find ')' to match this opening '(' in string interpolation}}
+// expected-error @-1 {{cannot find ')' to match opening '(' in string interpolation}}
 // expected-error @-2 {{unterminated string literal}}
 
 let goatedAlbum = "The Life Of \("Pablo"
-// expected-error @-1 {{cannot find ')' to match this opening '(' in string interpolation}}
+// expected-error @-1 {{cannot find ')' to match opening '(' in string interpolation}}
 // expected-error @-2 {{unterminated string literal}}
 
-// expected-error @+3 {{cannot find ')' to match this opening '(' in string interpolation}}
+// expected-error @+3 {{cannot find ')' to match opening '(' in string interpolation}}
 // expected-error @+1 {{unterminated string literal}}
 _ = """
 \(

--- a/test/Parse/unclosed-string-interpolation.swift
+++ b/test/Parse/unclosed-string-interpolation.swift
@@ -11,11 +11,6 @@ let theGoat = "kanye \("
 let equation1 = "2 + 2 = \(2 + 2" 
 // expected-error @-1 {{expected ')' at end of string interpolation}} expected-note @-1 {{to match this opening '('}}
 
-_ = """
-\(
-"""
-// expected-error @-2 {{expected ')' at end of string interpolation}} expected-note @-2 {{to match this opening '('}}
-
 let s = "\(x"; print(x) 
 // expected-error @-1 {{expected ')' at end of string interpolation}} expected-note @-1 {{to match this opening '('}}
 
@@ -25,3 +20,8 @@ let zzz = "\(x; print(x)
 let goatedAlbum = "The Life Of \("Pablo"
 // expected-error @-1 {{expected ')' at end of string interpolation}} expected-note @-1 {{to match this opening '('}}
 // expected-error @-1 {{unterminated string literal}}
+
+_ = """
+\(
+"""
+// expected-error @-2 {{expected ')' at end of string interpolation}} expected-note @-2 {{to match this opening '('}}

--- a/test/Parse/unclosed-string-interpolation.swift
+++ b/test/Parse/unclosed-string-interpolation.swift
@@ -1,0 +1,12 @@
+// RUN: %target-typecheck-verify-swift
+
+let mid = "pete"
+
+_ = "mid == \(pete" // expected-error {{expected ')' at end of string interpolation}}
+let theGoat = "kanye \(" // expected-error {{expected ')' at end of string interpolation}}
+let equation1 = "2 + 2 = \(2 + 2" // expected-error {{expected ')' at end of string interpolation}}
+
+_ = """
+\(
+"""
+// expected-error @-2 {{expected ')' at end of string interpolation}}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -475,9 +475,9 @@ func stringliterals(_ d: [String: Int]) {
   let x = 4
   "Hello \(x+1) world"  // expected-warning {{string literal is unused}}
   
-  "Error: \(x+1"; // expected-error {{expected ')' at end of string interpolation}} expected-note {{add ')' to end of interpolation statement}} {{158-158=)}}
+  "Error: \(x+1"; // expected-error {{expected ')' at end of string interpolation}} {{157-157=)}}
   
-  "Error: \(x+1   // expected-error {{expected ')' at end of string interpolation}} expected-note {{add ')' to end of interpolation statement}} {{19-19=)}}
+  "Error: \(x+1   // expected-error {{expected ')' at end of string interpolation}} {{18-18=)}}
   ;    // expected-error {{';' statements are not allowed}}
 
   // rdar://14050788 [DF] String Interpolations can't contain quotes
@@ -488,15 +488,15 @@ func stringliterals(_ d: [String: Int]) {
   "test \("quoted-paren (")"
   "test \("\\")"
   "test \("\n")"
-  "test \("\")" // expected-error {{expected ')' at end of string interpolation}} expected-note {{add ')' to end of interpolation statement}} {{17-17=)}}
+  "test \("\")" // expected-error {{expected ')' at end of string interpolation}} {{16-16=)}}
 
   "test \
   // expected-error @-1 {{unterminated string literal}} expected-error @-1 {{invalid escape sequence in literal}}
   "test \("\
-  // expected-error @-1 {{expected ')' at end of string interpolation}} expected-note @-1 {{add ')' to end of interpolation statement}} {{13-13=)}}
+  // expected-error @-1 {{expected ')' at end of string interpolation}} {{12-12=)}}
   "test newline \("something" +
     "something else")"
-  // expected-error @-2 {{expected ')' at end of string interpolation}} expected-note @-2 {{add ')' to end of interpolation statement}} {{32-32=)}}
+  // expected-error @-2 {{expected ')' at end of string interpolation}} {{31-31=)}}
   // expected-error @-2 {{unterminated string literal}}
 
   // expected-warning @+2 {{variable 'x2' was never used; consider replacing with '_' or removing it}}
@@ -940,10 +940,10 @@ let _ = 0xFFF_FFFF_FFFF_FFFF as Int64
 
 // rdar://problem/20289969 - string interpolation with comment containing ')' or '"'
 let _ = "foo \(42 /* ) " ) */)"
-let _ = "foo \(foo // )  " // expected-error {{expected ')' at end of string interpolation}} expected-note {{add ')' to end of interpolation statement}} {{20-20=)}}
+let _ = "foo \(foo // )  " // expected-error {{expected ')' at end of string interpolation}} {{19-19=)}}
 let _ = "foo \(42 /*
                    * multiline comment
                    */)end"
-// expected-error @-3 {{expected ')' at end of string interpolation}} expected-note @-3 {{add ')' to end of interpolation statement}} {{19-19=)}}
+// expected-error @-3 {{expected ')' at end of string interpolation}} {{18-18=)}}
 // expected-error @-2 {{expected expression}}
 // expected-error @-3 {{unterminated string literal}}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -475,9 +475,9 @@ func stringliterals(_ d: [String: Int]) {
   let x = 4
   "Hello \(x+1) world"  // expected-warning {{string literal is unused}}
   
-  "Error: \(x+1"; // expected-error {{unterminated string literal}}
+  "Error: \(x+1"; // expected-error {{string interpolation needs to be closed by a )}}
   
-  "Error: \(x+1   // expected-error {{unterminated string literal}}
+  "Error: \(x+1   // expected-error {{string interpolation needs to be closed by a )}}
   ;    // expected-error {{';' statements are not allowed}}
 
   // rdar://14050788 [DF] String Interpolations can't contain quotes
@@ -488,15 +488,15 @@ func stringliterals(_ d: [String: Int]) {
   "test \("quoted-paren (")"
   "test \("\\")"
   "test \("\n")"
-  "test \("\")" // expected-error {{unterminated string literal}}
+  "test \("\")" // expected-error {{string interpolation needs to be closed by a )}}
 
   "test \
   // expected-error @-1 {{unterminated string literal}} expected-error @-1 {{invalid escape sequence in literal}}
   "test \("\
-  // expected-error @-1 {{unterminated string literal}}
+  // expected-error @-1 {{string interpolation needs to be closed by a )}}
   "test newline \("something" +
     "something else")"
-  // expected-error @-2 {{unterminated string literal}} expected-error @-1 {{unterminated string literal}}
+  // expected-error @-2 {{string interpolation needs to be closed by a )}} expected-error @-1 {{unterminated string literal}}
 
   // expected-warning @+2 {{variable 'x2' was never used; consider replacing with '_' or removing it}}
   // expected-error @+1 {{unterminated string literal}}
@@ -939,10 +939,10 @@ let _ = 0xFFF_FFFF_FFFF_FFFF as Int64
 
 // rdar://problem/20289969 - string interpolation with comment containing ')' or '"'
 let _ = "foo \(42 /* ) " ) */)"
-let _ = "foo \(foo // )  " // expected-error {{unterminated string literal}}
+let _ = "foo \(foo // )  " // expected-error {{string interpolation needs to be closed by a )}}
 let _ = "foo \(42 /*
                    * multiline comment
                    */)end"
-// expected-error @-3 {{unterminated string literal}}
+// expected-error @-3 {{string interpolation needs to be closed by a )}}
 // expected-error @-2 {{expected expression}}
 // expected-error @-3 {{unterminated string literal}}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -475,9 +475,9 @@ func stringliterals(_ d: [String: Int]) {
   let x = 4
   "Hello \(x+1) world"  // expected-warning {{string literal is unused}}
   
-  "Error: \(x+1"; // expected-error {{expected ')' at end of string interpolation}} expected-note {{add ')' to end of interpolation statement}} {{16-16=)}}
+  "Error: \(x+1"; // expected-error {{expected ')' at end of string interpolation}} expected-note {{add ')' to end of interpolation statement}} {{156-156=)}}
   
-  "Error: \(x+1   // expected-error {{expected ')' at end of string interpolation}} expected-note {{add ')' to end of interpolation statement}} {{16-16=)}}
+  "Error: \(x+1   // expected-error {{expected ')' at end of string interpolation}} expected-note {{add ')' to end of interpolation statement}} {{19-19=)}}
   ;    // expected-error {{';' statements are not allowed}}
 
   // rdar://14050788 [DF] String Interpolations can't contain quotes
@@ -488,7 +488,7 @@ func stringliterals(_ d: [String: Int]) {
   "test \("quoted-paren (")"
   "test \("\\")"
   "test \("\n")"
-  "test \("\")" // expected-error {{expected ')' at end of string interpolation}} expected-note {{add ')' to end of interpolation statement}} {{16-16=)}}
+  "test \("\")" // expected-error {{expected ')' at end of string interpolation}} expected-note {{add ')' to end of interpolation statement}} {{17-17=)}}
 
   "test \
   // expected-error @-1 {{unterminated string literal}} expected-error @-1 {{invalid escape sequence in literal}}
@@ -940,10 +940,10 @@ let _ = 0xFFF_FFFF_FFFF_FFFF as Int64
 
 // rdar://problem/20289969 - string interpolation with comment containing ')' or '"'
 let _ = "foo \(42 /* ) " ) */)"
-let _ = "foo \(foo // )  " // expected-error {{expected ')' at end of string interpolation}} expected-note {{add ')' to end of interpolation statement}} {{19-19=)}}
+let _ = "foo \(foo // )  " // expected-error {{expected ')' at end of string interpolation}} expected-note {{add ')' to end of interpolation statement}} {{20-20=)}}
 let _ = "foo \(42 /*
                    * multiline comment
                    */)end"
-// expected-error @-3 {{expected ')' at end of string interpolation}} expected-note @-3 {{add ')' to end of interpolation statement}} {{18-18=)}}
+// expected-error @-3 {{expected ')' at end of string interpolation}} expected-note @-3 {{add ')' to end of interpolation statement}} {{19-19=)}}
 // expected-error @-2 {{expected expression}}
 // expected-error @-3 {{unterminated string literal}}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -475,9 +475,9 @@ func stringliterals(_ d: [String: Int]) {
   let x = 4
   "Hello \(x+1) world"  // expected-warning {{string literal is unused}}
   
-  "Error: \(x+1"; // expected-error {{expected ')' at end of string interpolation}}
+  "Error: \(x+1"; // expected-error {{expected ')' at end of string interpolation}} expected-note {{add ')' to end of interpolation statement}} {{16-16=)}}
   
-  "Error: \(x+1   // expected-error {{expected ')' at end of string interpolation}}
+  "Error: \(x+1   // expected-error {{expected ')' at end of string interpolation}} expected-note {{add ')' to end of interpolation statement}} {{16-16=)}}
   ;    // expected-error {{';' statements are not allowed}}
 
   // rdar://14050788 [DF] String Interpolations can't contain quotes
@@ -488,15 +488,16 @@ func stringliterals(_ d: [String: Int]) {
   "test \("quoted-paren (")"
   "test \("\\")"
   "test \("\n")"
-  "test \("\")" // expected-error {{expected ')' at end of string interpolation}}
+  "test \("\")" // expected-error {{expected ')' at end of string interpolation}} expected-note {{add ')' to end of interpolation statement}} {{16-16=)}}
 
   "test \
   // expected-error @-1 {{unterminated string literal}} expected-error @-1 {{invalid escape sequence in literal}}
   "test \("\
-  // expected-error @-1 {{expected ')' at end of string interpolation}}
+  // expected-error @-1 {{expected ')' at end of string interpolation}} expected-note @-1 {{add ')' to end of interpolation statement}} {{13-13=)}}
   "test newline \("something" +
     "something else")"
-  // expected-error @-2 {{expected ')' at end of string interpolation}} expected-error @-1 {{unterminated string literal}}
+  // expected-error @-2 {{expected ')' at end of string interpolation}} expected-note @-2 {{add ')' to end of interpolation statement}} {{32-32=)}}
+  // expected-error @-2 {{unterminated string literal}}
 
   // expected-warning @+2 {{variable 'x2' was never used; consider replacing with '_' or removing it}}
   // expected-error @+1 {{unterminated string literal}}
@@ -939,10 +940,10 @@ let _ = 0xFFF_FFFF_FFFF_FFFF as Int64
 
 // rdar://problem/20289969 - string interpolation with comment containing ')' or '"'
 let _ = "foo \(42 /* ) " ) */)"
-let _ = "foo \(foo // )  " // expected-error {{expected ')' at end of string interpolation}}
+let _ = "foo \(foo // )  " // expected-error {{expected ')' at end of string interpolation}} expected-note {{add ')' to end of interpolation statement}} {{19-19=)}}
 let _ = "foo \(42 /*
                    * multiline comment
                    */)end"
-// expected-error @-3 {{expected ')' at end of string interpolation}}
+// expected-error @-3 {{expected ')' at end of string interpolation}} expected-note @-3 {{add ')' to end of interpolation statement}} {{18-18=)}}
 // expected-error @-2 {{expected expression}}
 // expected-error @-3 {{unterminated string literal}}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -475,9 +475,9 @@ func stringliterals(_ d: [String: Int]) {
   let x = 4
   "Hello \(x+1) world"  // expected-warning {{string literal is unused}}
   
-  "Error: \(x+1"; // expected-error {{string interpolation needs to be closed by a )}}
+  "Error: \(x+1"; // expected-error {{expected ')' at end of string interpolation}}
   
-  "Error: \(x+1   // expected-error {{string interpolation needs to be closed by a )}}
+  "Error: \(x+1   // expected-error {{expected ')' at end of string interpolation}}
   ;    // expected-error {{';' statements are not allowed}}
 
   // rdar://14050788 [DF] String Interpolations can't contain quotes
@@ -488,15 +488,15 @@ func stringliterals(_ d: [String: Int]) {
   "test \("quoted-paren (")"
   "test \("\\")"
   "test \("\n")"
-  "test \("\")" // expected-error {{string interpolation needs to be closed by a )}}
+  "test \("\")" // expected-error {{expected ')' at end of string interpolation}}
 
   "test \
   // expected-error @-1 {{unterminated string literal}} expected-error @-1 {{invalid escape sequence in literal}}
   "test \("\
-  // expected-error @-1 {{string interpolation needs to be closed by a )}}
+  // expected-error @-1 {{expected ')' at end of string interpolation}}
   "test newline \("something" +
     "something else")"
-  // expected-error @-2 {{string interpolation needs to be closed by a )}} expected-error @-1 {{unterminated string literal}}
+  // expected-error @-2 {{expected ')' at end of string interpolation}} expected-error @-1 {{unterminated string literal}}
 
   // expected-warning @+2 {{variable 'x2' was never used; consider replacing with '_' or removing it}}
   // expected-error @+1 {{unterminated string literal}}
@@ -939,10 +939,10 @@ let _ = 0xFFF_FFFF_FFFF_FFFF as Int64
 
 // rdar://problem/20289969 - string interpolation with comment containing ')' or '"'
 let _ = "foo \(42 /* ) " ) */)"
-let _ = "foo \(foo // )  " // expected-error {{string interpolation needs to be closed by a )}}
+let _ = "foo \(foo // )  " // expected-error {{expected ')' at end of string interpolation}}
 let _ = "foo \(42 /*
                    * multiline comment
                    */)end"
-// expected-error @-3 {{string interpolation needs to be closed by a )}}
+// expected-error @-3 {{expected ')' at end of string interpolation}}
 // expected-error @-2 {{expected expression}}
 // expected-error @-3 {{unterminated string literal}}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -476,10 +476,10 @@ func stringliterals(_ d: [String: Int]) {
   "Hello \(x+1) world"  // expected-warning {{string literal is unused}}
   
   // expected-error @+1 {{unterminated string literal}}
-  "Error: \(x+1"; // expected-error {{expected ')' at end of string interpolation}} expected-note {{to match this opening '('}}
+  "Error: \(x+1"; // expected-error {{cannot find ')' to match this opening '(' in string interpolation}}
 
   // expected-error @+1 {{unterminated string literal}}
-  "Error: \(x+1   // expected-error {{expected ')' at end of string interpolation}} expected-note {{to match this opening '('}}
+  "Error: \(x+1   // expected-error {{cannot find ')' to match this opening '(' in string interpolation}}
   ;    // expected-error {{';' statements are not allowed}}
 
   // rdar://14050788 [DF] String Interpolations can't contain quotes
@@ -490,15 +490,15 @@ func stringliterals(_ d: [String: Int]) {
   "test \("quoted-paren (")"
   "test \("\\")"
   "test \("\n")"
-  "test \("\")" // expected-error {{expected ')' at end of string interpolation}} expected-note {{to match this opening '('}} expected-error {{unterminated string literal}}
+  "test \("\")" // expected-error {{cannot find ')' to match this opening '(' in string interpolation}} expected-error {{unterminated string literal}}
 
   "test \
   // expected-error @-1 {{unterminated string literal}} expected-error @-1 {{invalid escape sequence in literal}}
   "test \("\
-  // expected-error @-1 {{expected ')' at end of string interpolation}} expected-note @-1 {{to match this opening '('}} expected-error @-1 {{unterminated string literal}}
+  // expected-error @-1 {{cannot find ')' to match this opening '(' in string interpolation}} expected-error @-1 {{unterminated string literal}}
   "test newline \("something" +
     "something else")"
-  // expected-error @-2 {{expected ')' at end of string interpolation}} expected-note @-2 {{to match this opening '('}}
+  // expected-error @-2 {{cannot find ')' to match this opening '(' in string interpolation}}
   // expected-error @-2 {{unterminated string literal}} expected-error @-3 {{unterminated string literal}}
 
   // expected-warning @+2 {{variable 'x2' was never used; consider replacing with '_' or removing it}}
@@ -942,10 +942,10 @@ let _ = 0xFFF_FFFF_FFFF_FFFF as Int64
 
 // rdar://problem/20289969 - string interpolation with comment containing ')' or '"'
 let _ = "foo \(42 /* ) " ) */)"
-let _ = "foo \(foo // )  " // expected-error {{expected ')' at end of string interpolation}} expected-note {{to match this opening '('}} expected-error {{unterminated string literal}}
+let _ = "foo \(foo // )  " // expected-error {{cannot find ')' to match this opening '(' in string interpolation}} expected-error {{unterminated string literal}}
 let _ = "foo \(42 /*
                    * multiline comment
                    */)end"
-// expected-error @-3 {{expected ')' at end of string interpolation}} expected-note @-3 {{to match this opening '('}} expected-error @-3 {{unterminated string literal}}
+// expected-error @-3 {{cannot find ')' to match this opening '(' in string interpolation}} expected-error @-3 {{unterminated string literal}}
 // expected-error @-2 {{expected expression}}
 // expected-error @-3 {{unterminated string literal}}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -476,10 +476,10 @@ func stringliterals(_ d: [String: Int]) {
   "Hello \(x+1) world"  // expected-warning {{string literal is unused}}
   
   // expected-error @+1 {{unterminated string literal}}
-  "Error: \(x+1"; // expected-error {{cannot find ')' to match this opening '(' in string interpolation}}
+  "Error: \(x+1"; // expected-error {{cannot find ')' to match opening '(' in string interpolation}}
 
   // expected-error @+1 {{unterminated string literal}}
-  "Error: \(x+1   // expected-error {{cannot find ')' to match this opening '(' in string interpolation}}
+  "Error: \(x+1   // expected-error {{cannot find ')' to match opening '(' in string interpolation}}
   ;    // expected-error {{';' statements are not allowed}}
 
   // rdar://14050788 [DF] String Interpolations can't contain quotes
@@ -490,15 +490,15 @@ func stringliterals(_ d: [String: Int]) {
   "test \("quoted-paren (")"
   "test \("\\")"
   "test \("\n")"
-  "test \("\")" // expected-error {{cannot find ')' to match this opening '(' in string interpolation}} expected-error {{unterminated string literal}}
+  "test \("\")" // expected-error {{cannot find ')' to match opening '(' in string interpolation}} expected-error {{unterminated string literal}}
 
   "test \
   // expected-error @-1 {{unterminated string literal}} expected-error @-1 {{invalid escape sequence in literal}}
   "test \("\
-  // expected-error @-1 {{cannot find ')' to match this opening '(' in string interpolation}} expected-error @-1 {{unterminated string literal}}
+  // expected-error @-1 {{cannot find ')' to match opening '(' in string interpolation}} expected-error @-1 {{unterminated string literal}}
   "test newline \("something" +
     "something else")"
-  // expected-error @-2 {{cannot find ')' to match this opening '(' in string interpolation}}
+  // expected-error @-2 {{cannot find ')' to match opening '(' in string interpolation}}
   // expected-error @-2 {{unterminated string literal}} expected-error @-3 {{unterminated string literal}}
 
   // expected-warning @+2 {{variable 'x2' was never used; consider replacing with '_' or removing it}}
@@ -942,10 +942,10 @@ let _ = 0xFFF_FFFF_FFFF_FFFF as Int64
 
 // rdar://problem/20289969 - string interpolation with comment containing ')' or '"'
 let _ = "foo \(42 /* ) " ) */)"
-let _ = "foo \(foo // )  " // expected-error {{cannot find ')' to match this opening '(' in string interpolation}} expected-error {{unterminated string literal}}
+let _ = "foo \(foo // )  " // expected-error {{cannot find ')' to match opening '(' in string interpolation}} expected-error {{unterminated string literal}}
 let _ = "foo \(42 /*
                    * multiline comment
                    */)end"
-// expected-error @-3 {{cannot find ')' to match this opening '(' in string interpolation}} expected-error @-3 {{unterminated string literal}}
+// expected-error @-3 {{cannot find ')' to match opening '(' in string interpolation}} expected-error @-3 {{unterminated string literal}}
 // expected-error @-2 {{expected expression}}
 // expected-error @-3 {{unterminated string literal}}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -475,7 +475,7 @@ func stringliterals(_ d: [String: Int]) {
   let x = 4
   "Hello \(x+1) world"  // expected-warning {{string literal is unused}}
   
-  "Error: \(x+1"; // expected-error {{expected ')' at end of string interpolation}} expected-note {{add ')' to end of interpolation statement}} {{156-156=)}}
+  "Error: \(x+1"; // expected-error {{expected ')' at end of string interpolation}} expected-note {{add ')' to end of interpolation statement}} {{158-158=)}}
   
   "Error: \(x+1   // expected-error {{expected ')' at end of string interpolation}} expected-note {{add ')' to end of interpolation statement}} {{19-19=)}}
   ;    // expected-error {{';' statements are not allowed}}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -475,8 +475,10 @@ func stringliterals(_ d: [String: Int]) {
   let x = 4
   "Hello \(x+1) world"  // expected-warning {{string literal is unused}}
   
+  // expected-error @+1 {{unterminated string literal}}
   "Error: \(x+1"; // expected-error {{expected ')' at end of string interpolation}} expected-note {{to match this opening '('}}
-  
+
+  // expected-error @+1 {{unterminated string literal}}
   "Error: \(x+1   // expected-error {{expected ')' at end of string interpolation}} expected-note {{to match this opening '('}}
   ;    // expected-error {{';' statements are not allowed}}
 
@@ -488,16 +490,16 @@ func stringliterals(_ d: [String: Int]) {
   "test \("quoted-paren (")"
   "test \("\\")"
   "test \("\n")"
-  "test \("\")" // expected-error {{expected ')' at end of string interpolation}} expected-note {{to match this opening '('}}
+  "test \("\")" // expected-error {{expected ')' at end of string interpolation}} expected-note {{to match this opening '('}} expected-error {{unterminated string literal}}
 
   "test \
   // expected-error @-1 {{unterminated string literal}} expected-error @-1 {{invalid escape sequence in literal}}
   "test \("\
-  // expected-error @-1 {{expected ')' at end of string interpolation}} expected-note @-1 {{to match this opening '('}}
+  // expected-error @-1 {{expected ')' at end of string interpolation}} expected-note @-1 {{to match this opening '('}} expected-error @-1 {{unterminated string literal}}
   "test newline \("something" +
     "something else")"
   // expected-error @-2 {{expected ')' at end of string interpolation}} expected-note @-2 {{to match this opening '('}}
-  // expected-error @-2 {{unterminated string literal}}
+  // expected-error @-2 {{unterminated string literal}} expected-error @-3 {{unterminated string literal}}
 
   // expected-warning @+2 {{variable 'x2' was never used; consider replacing with '_' or removing it}}
   // expected-error @+1 {{unterminated string literal}}
@@ -940,10 +942,10 @@ let _ = 0xFFF_FFFF_FFFF_FFFF as Int64
 
 // rdar://problem/20289969 - string interpolation with comment containing ')' or '"'
 let _ = "foo \(42 /* ) " ) */)"
-let _ = "foo \(foo // )  " // expected-error {{expected ')' at end of string interpolation}} expected-note {{to match this opening '('}}
+let _ = "foo \(foo // )  " // expected-error {{expected ')' at end of string interpolation}} expected-note {{to match this opening '('}} expected-error {{unterminated string literal}}
 let _ = "foo \(42 /*
                    * multiline comment
                    */)end"
-// expected-error @-3 {{expected ')' at end of string interpolation}} expected-note @-3 {{to match this opening '('}}
+// expected-error @-3 {{expected ')' at end of string interpolation}} expected-note @-3 {{to match this opening '('}} expected-error @-3 {{unterminated string literal}}
 // expected-error @-2 {{expected expression}}
 // expected-error @-3 {{unterminated string literal}}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -475,9 +475,9 @@ func stringliterals(_ d: [String: Int]) {
   let x = 4
   "Hello \(x+1) world"  // expected-warning {{string literal is unused}}
   
-  "Error: \(x+1"; // expected-error {{expected ')' at end of string interpolation}}
+  "Error: \(x+1"; // expected-error {{expected ')' at end of string interpolation}} expected-note {{to match this opening '('}}
   
-  "Error: \(x+1   // expected-error {{expected ')' at end of string interpolation}} 
+  "Error: \(x+1   // expected-error {{expected ')' at end of string interpolation}} expected-note {{to match this opening '('}}
   ;    // expected-error {{';' statements are not allowed}}
 
   // rdar://14050788 [DF] String Interpolations can't contain quotes
@@ -488,15 +488,15 @@ func stringliterals(_ d: [String: Int]) {
   "test \("quoted-paren (")"
   "test \("\\")"
   "test \("\n")"
-  "test \("\")" // expected-error {{expected ')' at end of string interpolation}}
+  "test \("\")" // expected-error {{expected ')' at end of string interpolation}} expected-note {{to match this opening '('}}
 
   "test \
   // expected-error @-1 {{unterminated string literal}} expected-error @-1 {{invalid escape sequence in literal}}
   "test \("\
-  // expected-error @-1 {{expected ')' at end of string interpolation}}
+  // expected-error @-1 {{expected ')' at end of string interpolation}} expected-note @-1 {{to match this opening '('}}
   "test newline \("something" +
     "something else")"
-  // expected-error @-2 {{expected ')' at end of string interpolation}}
+  // expected-error @-2 {{expected ')' at end of string interpolation}} expected-note @-2 {{to match this opening '('}}
   // expected-error @-2 {{unterminated string literal}}
 
   // expected-warning @+2 {{variable 'x2' was never used; consider replacing with '_' or removing it}}
@@ -940,10 +940,10 @@ let _ = 0xFFF_FFFF_FFFF_FFFF as Int64
 
 // rdar://problem/20289969 - string interpolation with comment containing ')' or '"'
 let _ = "foo \(42 /* ) " ) */)"
-let _ = "foo \(foo // )  " // expected-error {{expected ')' at end of string interpolation}}
+let _ = "foo \(foo // )  " // expected-error {{expected ')' at end of string interpolation}} expected-note {{to match this opening '('}}
 let _ = "foo \(42 /*
                    * multiline comment
                    */)end"
-// expected-error @-3 {{expected ')' at end of string interpolation}}
+// expected-error @-3 {{expected ')' at end of string interpolation}} expected-note @-3 {{to match this opening '('}}
 // expected-error @-2 {{expected expression}}
 // expected-error @-3 {{unterminated string literal}}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -475,9 +475,9 @@ func stringliterals(_ d: [String: Int]) {
   let x = 4
   "Hello \(x+1) world"  // expected-warning {{string literal is unused}}
   
-  "Error: \(x+1"; // expected-error {{expected ')' at end of string interpolation}} {{157-157=)}}
+  "Error: \(x+1"; // expected-error {{expected ')' at end of string interpolation}}
   
-  "Error: \(x+1   // expected-error {{expected ')' at end of string interpolation}} {{18-18=)}}
+  "Error: \(x+1   // expected-error {{expected ')' at end of string interpolation}} 
   ;    // expected-error {{';' statements are not allowed}}
 
   // rdar://14050788 [DF] String Interpolations can't contain quotes
@@ -488,15 +488,15 @@ func stringliterals(_ d: [String: Int]) {
   "test \("quoted-paren (")"
   "test \("\\")"
   "test \("\n")"
-  "test \("\")" // expected-error {{expected ')' at end of string interpolation}} {{16-16=)}}
+  "test \("\")" // expected-error {{expected ')' at end of string interpolation}}
 
   "test \
   // expected-error @-1 {{unterminated string literal}} expected-error @-1 {{invalid escape sequence in literal}}
   "test \("\
-  // expected-error @-1 {{expected ')' at end of string interpolation}} {{12-12=)}}
+  // expected-error @-1 {{expected ')' at end of string interpolation}}
   "test newline \("something" +
     "something else")"
-  // expected-error @-2 {{expected ')' at end of string interpolation}} {{31-31=)}}
+  // expected-error @-2 {{expected ')' at end of string interpolation}}
   // expected-error @-2 {{unterminated string literal}}
 
   // expected-warning @+2 {{variable 'x2' was never used; consider replacing with '_' or removing it}}
@@ -940,10 +940,10 @@ let _ = 0xFFF_FFFF_FFFF_FFFF as Int64
 
 // rdar://problem/20289969 - string interpolation with comment containing ')' or '"'
 let _ = "foo \(42 /* ) " ) */)"
-let _ = "foo \(foo // )  " // expected-error {{expected ')' at end of string interpolation}} {{19-19=)}}
+let _ = "foo \(foo // )  " // expected-error {{expected ')' at end of string interpolation}}
 let _ = "foo \(42 /*
                    * multiline comment
                    */)end"
-// expected-error @-3 {{expected ')' at end of string interpolation}} {{18-18=)}}
+// expected-error @-3 {{expected ')' at end of string interpolation}}
 // expected-error @-2 {{expected expression}}
 // expected-error @-3 {{unterminated string literal}}


### PR DESCRIPTION
This pull request changes the diagnostic error thrown when a string interpolation isn't closed by a parenthesis properly (ie: `let x = "g \("`)

Previously, it would blurt out `unterminated string literal`, with these changes it'll instead throw `expected ')' at end of string interpolation`