### PR TITLE
Revert "Gating failing SILOptimizer tests"

### DIFF
--- a/test/SILOptimizer/addr_escape_info.sil
+++ b/test/SILOptimizer/addr_escape_info.sil
@@ -2,8 +2,6 @@
 
 // REQUIRES: swift_in_compiler
 
-// REQUIRES: rdar92963081
-
 sil_stage canonical
 
 import Builtin

--- a/test/SILOptimizer/escape_info.sil
+++ b/test/SILOptimizer/escape_info.sil
@@ -2,8 +2,6 @@
 
 // REQUIRES: swift_in_compiler
 
-// REQUIRES: rdar92963081
-
 sil_stage canonical
 
 import Builtin

--- a/test/SILOptimizer/ranges.sil
+++ b/test/SILOptimizer/ranges.sil
@@ -2,8 +2,6 @@
 
 // REQUIRES: swift_in_compiler
 
-// REQUIRES: rdar92963081
-
 sil_stage canonical
 
 // CHECK-LABEL: Instruction range in basic_test:


### PR DESCRIPTION
This reverts commit 3be4a03a1ca51c9a70e07cb8a8fd24534a3a5721.

The tests were failing on linux because of C++ string interop is now used in Function.name.
As Function.name now returns a StringRef, this should not be a problem anymore.

Though, the underlying problem is not fixed.

rdar://92963081