### PR TITLE
[5.7][Index] Consider construction of enums with associated values as a function call

### DIFF
--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -874,10 +874,23 @@ static void analyzeRenameScope(ValueDecl *VD, Optional<RenameRefInfo> RefInfo,
   }
 
   auto *Scope = VD->getDeclContext();
-  // If the context is a top-level code decl, there may be other sibling
-  // decls that the renamed symbol is visible from
-  if (isa<TopLevelCodeDecl>(Scope))
+  // There may be sibling decls that the renamed symbol is visible from.
+  switch (Scope->getContextKind()) {
+  case DeclContextKind::GenericTypeDecl:
+  case DeclContextKind::ExtensionDecl:
+  case DeclContextKind::TopLevelCodeDecl:
+  case DeclContextKind::SubscriptDecl:
+  case DeclContextKind::EnumElementDecl:
+  case DeclContextKind::AbstractFunctionDecl:
     Scope = Scope->getParent();
+    break;
+  case DeclContextKind::AbstractClosureExpr:
+  case DeclContextKind::Initializer:
+  case DeclContextKind::SerializedLocal:
+  case DeclContextKind::Module:
+  case DeclContextKind::FileUnit:
+    break;
+  }
 
   Scopes.push_back(Scope);
 }

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -1532,7 +1532,7 @@ bool IndexSwiftASTWalker::reportRef(ValueDecl *D, SourceLoc Loc,
   if (!shouldIndex(D, /*IsRef=*/true))
     return true; // keep walking
 
-  if (isa<AbstractFunctionDecl>(D)) {
+  if (isa<AbstractFunctionDecl>(D) || isa<EnumElementDecl>(D)) {
     if (initFuncRefIndexSymbol(D, Loc, Info))
       return true;
   } else if (isa<AbstractStorageDecl>(D)) {

--- a/test/Index/local.swift
+++ b/test/Index/local.swift
@@ -39,7 +39,7 @@ func foo(a: Int, b: Int, c: Int) {
     let _ = LocalEnum.foo(x: LocalStruct())
     // LOCAL: [[@LINE-1]]:13 | enum(local)/Swift | LocalEnum | [[LocalEnum_USR]] | Ref,RelCont | rel: 1
     // CHECK-NOT: [[@LINE-2]]:13 | enum(local)/Swift | LocalEnum | {{.*}} | Ref,RelCont | rel: 1
-    // LOCAL: [[@LINE-3]]:23 | enumerator(local)/Swift | foo(x:) | [[LocalEnum_foo_USR]] | Ref,RelCont | rel: 1
+    // LOCAL: [[@LINE-3]]:23 | enumerator(local)/Swift | foo(x:) | [[LocalEnum_foo_USR]] | Ref,Call,RelRec,RelCall,RelCont | rel: 2
     // CHECK-NOT: [[@LINE-4]]:23 | enumerator(local)/Swift | foo(x:) | {{.*}} | Ref,RelCont | rel: 1
     // LOCAL: [[@LINE-5]]:30 | struct(local)/Swift | LocalStruct | [[LocalStruct_USR]] | Ref,RelCont | rel: 1
     // CHECK-NOT: [[@LINE-6]]:30 | struct(local)/Swift | LocalStruct | {{.*}} | Ref,RelCont | rel: 1

--- a/test/SourceKit/Indexing/index_enum_case.swift.response
+++ b/test/SourceKit/Indexing/index_enum_case.swift.response
@@ -139,7 +139,8 @@
       key.name: "two(a:)",
       key.usr: "s:15index_enum_case1EO3twoyACSS_tcACmF",
       key.line: 21,
-      key.column: 13
+      key.column: 13,
+      key.receiver_usr: "s:15index_enum_case1EO"
     },
     {
       key.kind: source.lang.swift.decl.function.free,

--- a/test/refactoring/rename/Outputs/enum/first.swift.expected
+++ b/test/refactoring/rename/Outputs/enum/first.swift.expected
@@ -1,0 +1,12 @@
+enum Foo {
+  case primary(with: Int)
+  case second
+}
+
+func test() {
+  let _ = Foo.primary(with: 1)
+  let _ = Foo.primary
+  let _ = Foo.second
+}
+
+

--- a/test/refactoring/rename/Outputs/enum/second.swift.expected
+++ b/test/refactoring/rename/Outputs/enum/second.swift.expected
@@ -1,0 +1,12 @@
+enum Foo {
+  case first(associated: Int)
+  case secondary
+}
+
+func test() {
+  let _ = Foo.first(associated: 1)
+  let _ = Foo.first
+  let _ = Foo.secondary
+}
+
+

--- a/test/refactoring/rename/Outputs/localEnum/north.swift.expected
+++ b/test/refactoring/rename/Outputs/localEnum/north.swift.expected
@@ -1,0 +1,9 @@
+func boop() {
+  enum LocalEnum {
+    case east
+    case south
+  }
+
+  print(LocalEnum.east)
+}
+

--- a/test/refactoring/rename/enum.swift
+++ b/test/refactoring/rename/enum.swift
@@ -1,0 +1,25 @@
+enum Foo {
+  case first(associated: Int)
+  case second
+}
+
+func test() {
+  let _ = Foo.first(associated: 1)
+  let _ = Foo.first
+  let _ = Foo.second
+}
+
+// RUN: %empty-directory(%t.result)
+// RUN: %refactor -rename -source-filename %s -pos=2:8 -new-name 'primary(with:)' > %t.result/first_def.swift
+// RUN: diff -u %S/Outputs/enum/first.swift.expected %t.result/first_def.swift
+// RUN: %refactor -rename -source-filename %s -pos=7:15 -new-name 'primary(with:)' > %t.result/first_ref.swift
+// RUN: diff -u %S/Outputs/enum/first.swift.expected %t.result/first_ref.swift
+// RUN: %refactor -rename -source-filename %s -pos=7:21 -new-name 'primary(with:)' > %t.result/first_ref_assoc.swift
+// RUN: diff -u %S/Outputs/enum/first.swift.expected %t.result/first_ref_assoc.swift
+// RUN: %refactor -rename -source-filename %s -pos=8:15 -new-name 'primary(with:)' > %t.result/first_ref_base.swift
+// RUN: diff -u %S/Outputs/enum/first.swift.expected %t.result/first_ref_assoc.swift
+
+// RUN: %refactor -rename -source-filename %s -pos=3:8 -new-name 'secondary' > %t.result/second_def.swift
+// RUN: diff -u %S/Outputs/enum/second.swift.expected %t.result/second_def.swift
+// RUN: %refactor -rename -source-filename %s -pos=9:15 -new-name 'secondary' > %t.result/second_ref.swift
+// RUN: diff -u %S/Outputs/enum/second.swift.expected %t.result/second_ref.swift

--- a/test/refactoring/rename/localEnum.swift
+++ b/test/refactoring/rename/localEnum.swift
@@ -1,0 +1,14 @@
+func boop() {
+  enum LocalEnum {
+    case north
+    case south
+  }
+
+  print(LocalEnum.north)
+}
+
+// RUN: %empty-directory(%t.result)
+// RUN: %refactor -rename -source-filename %s -pos=3:10 -new-name east > %t.result/north_def.swift
+// RUN: diff -u %S/Outputs/localEnum/north.swift.expected %t.result/north_def.swift
+// RUN: %refactor -rename -source-filename %s -pos=7:19 -new-name east > %t.result/north_ref.swift
+// RUN: diff -u %S/Outputs/localEnum/north.swift.expected %t.result/north_ref.swift


### PR DESCRIPTION
* **Explanation**:  For enum cases with associated values, their construction is modelled by a function. E.g. if you have
```swift
enum Foo {
  case first(associated: Int)
}
```

then `Foo.first` is a function of type `(Int) -> Foo`. But if you write `Foo.first(associated: 2)` in source code, we consider this construct as a referenced, not a call. This causes us to miss renaming of associated value labels during local refactoring.
* **Scope**: Rename of enums with associated values
* **Risk**: Discussed with @bnbarham and we agreed that the chance of breaking anything is fairly low
* **Testing**: Added regression tests
* **Issue**: rdar://84061868, rdar://89836229
* **Reviewer**: @bnbarham on https://github.com/apple/swift/pull/58746
