### PR TITLE
[5.7] Diagnose Availability for Parameterized Existential Types

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -868,6 +868,10 @@ public:
   /// swift_isUniquelyReferenced functions.
   AvailabilityContext getObjCIsUniquelyReferencedAvailability();
 
+  /// Get the runtime availability of metadata manipulation runtime functions
+  /// for extended existential types.
+  AvailabilityContext getParameterizedExistentialRuntimeAvailability();
+
   /// Get the runtime availability of features introduced in the Swift 5.2
   /// compiler for the target platform.
   AvailabilityContext getSwift52Availability();

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5606,6 +5606,11 @@ ERROR(availability_concurrency_only_version_newer, none,
       "concurrency is only available in %0 %1 or newer",
       (StringRef, llvm::VersionTuple))
 
+ERROR(availability_parameterized_protocol_only_version_newer, none,
+      "runtime support for parameterized protocol types is only available in "
+      "%0 %1 or newer",
+      (StringRef, llvm::VersionTuple))
+
 NOTE(availability_guard_with_version_check, none,
      "add 'if #available' version check", ())
 

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -163,7 +163,10 @@ public:
     /// type sequence
     HasTypeSequence = 0x1000,
 
-    Last_Property = HasTypeSequence
+    /// This type contains a parameterized existential type \c any P<T>.
+    HasParameterizedExistential = 0x2000,
+
+    Last_Property = HasParameterizedExistential
   };
   enum { BitWidth = countBitsUsed(Property::Last_Property) };
 
@@ -222,6 +225,12 @@ public:
   bool hasPlaceholder() const { return Bits & HasPlaceholder; }
 
   bool hasTypeSequence() const { return Bits & HasTypeSequence; }
+
+  /// Does a type with these properties structurally contain a
+  /// parameterized existential type?
+  bool hasParameterizedExistential() const {
+    return Bits & HasParameterizedExistential;
+  }
 
   /// Returns the set of properties present in either set.
   friend RecursiveTypeProperties operator|(Property lhs, Property rhs) {
@@ -624,6 +633,11 @@ public:
 
   bool hasTypeSequence() const {
     return getRecursiveProperties().hasTypeSequence();
+  }
+
+  /// Determine whether the type involves a parameterized existential type.
+  bool hasParameterizedExistential() const {
+    return getRecursiveProperties().hasParameterizedExistential();
   }
 
   /// Determine whether the type involves the given opened existential

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3440,6 +3440,8 @@ ExistentialMetatypeType::get(Type T, Optional<MetatypeRepresentation> repr,
     T = existential->getConstraintType();
 
   auto properties = T->getRecursiveProperties();
+  if (T->is<ParameterizedProtocolType>())
+    properties |= RecursiveTypeProperties::HasParameterizedExistential;
   auto arena = getArena(properties);
 
   unsigned reprKey;
@@ -3535,7 +3537,7 @@ isAnyFunctionTypeCanonical(ArrayRef<AnyFunctionType::Param> params,
 static RecursiveTypeProperties
 getGenericFunctionRecursiveProperties(ArrayRef<AnyFunctionType::Param> params,
                                       Type result) {
-  static_assert(RecursiveTypeProperties::BitWidth == 13,
+  static_assert(RecursiveTypeProperties::BitWidth == 14,
                 "revisit this if you add new recursive type properties");
   RecursiveTypeProperties properties;
 
@@ -4124,7 +4126,7 @@ CanSILFunctionType SILFunctionType::get(
   void *mem = ctx.Allocate(bytes, alignof(SILFunctionType));
 
   RecursiveTypeProperties properties;
-  static_assert(RecursiveTypeProperties::BitWidth == 13,
+  static_assert(RecursiveTypeProperties::BitWidth == 14,
                 "revisit this if you add new recursive type properties");
   for (auto &param : params)
     properties |= param.getInterfaceType()->getRecursiveProperties();
@@ -4242,6 +4244,8 @@ Type ExistentialType::get(Type constraint, bool forceExistential) {
   assert(constraint->isConstraintType());
 
   auto properties = constraint->getRecursiveProperties();
+  if (constraint->is<ParameterizedProtocolType>())
+    properties |= RecursiveTypeProperties::HasParameterizedExistential;
   auto arena = getArena(properties);
 
   auto &entry = C.getImpl().getArena(arena).ExistentialTypes[constraint];

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -394,6 +394,11 @@ AvailabilityContext ASTContext::getObjCIsUniquelyReferencedAvailability() {
   return getSwift56Availability();
 }
 
+AvailabilityContext
+ASTContext::getParameterizedExistentialRuntimeAvailability() {
+  return getSwift57Availability();
+}
+
 AvailabilityContext ASTContext::getSwift52Availability() {
   auto target = LangOpts.Target;
 

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -15,11 +15,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "TypeCheckAvailability.h"
-#include "TypeCheckConcurrency.h"
-#include "TypeChecker.h"
-#include "TypeCheckObjC.h"
 #include "MiscDiagnostics.h"
+#include "TypeCheckConcurrency.h"
+#include "TypeCheckObjC.h"
+#include "TypeChecker.h"
 #include "swift/AST/ASTWalker.h"
+#include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/Initializer.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/Pattern.h"
@@ -2749,6 +2750,74 @@ bool isSubscriptReturningString(const ValueDecl *D, ASTContext &Context) {
   return resultTy->isString();
 }
 
+static bool diagnosePotentialParameterizedProtocolUnavailability(
+    SourceRange ReferenceRange, const DeclContext *ReferenceDC,
+    const UnavailabilityReason &Reason) {
+  ASTContext &Context = ReferenceDC->getASTContext();
+
+  auto RequiredRange = Reason.getRequiredOSVersionRange();
+  {
+    auto Err = Context.Diags.diagnose(
+        ReferenceRange.Start,
+        diag::availability_parameterized_protocol_only_version_newer,
+        prettyPlatformString(targetPlatform(Context.LangOpts)),
+        Reason.getRequiredOSVersionRange().getLowerEndpoint());
+
+    // Direct a fixit to the error if an existing guard is nearly-correct
+    if (fixAvailabilityByNarrowingNearbyVersionCheck(
+            ReferenceRange, ReferenceDC, RequiredRange, Context, Err))
+      return true;
+  }
+  fixAvailability(ReferenceRange, ReferenceDC, RequiredRange, Context);
+  return true;
+}
+
+bool swift::diagnoseParameterizedProtocolAvailability(
+    SourceRange ReferenceRange, const DeclContext *ReferenceDC) {
+  // Check the availability of parameterized existential runtime support.
+  ASTContext &ctx = ReferenceDC->getASTContext();
+  if (ctx.LangOpts.DisableAvailabilityChecking)
+    return false;
+
+  if (!shouldCheckAvailability(ReferenceDC->getAsDecl()))
+    return false;
+
+  auto runningOS = TypeChecker::overApproximateAvailabilityAtLocation(
+      ReferenceRange.Start, ReferenceDC);
+  auto availability = ctx.getParameterizedExistentialRuntimeAvailability();
+  if (!runningOS.isContainedIn(availability)) {
+    return diagnosePotentialParameterizedProtocolUnavailability(
+        ReferenceRange, ReferenceDC,
+        UnavailabilityReason::requiresVersionRange(
+            availability.getOSVersion()));
+  }
+  return false;
+}
+
+static void
+maybeDiagParameterizedExistentialErasure(ErasureExpr *EE,
+                                         const ExportContext &Where) {
+  if (auto *OE = dyn_cast<OpaqueValueExpr>(EE->getSubExpr())) {
+    auto *OAT = OE->getType()->getAs<OpenedArchetypeType>();
+    if (!OAT)
+      return;
+
+    auto opened = OAT->getGenericEnvironment()->getOpenedExistentialType();
+    if (!opened || !opened->hasParameterizedExistential())
+      return;
+
+    (void)diagnoseParameterizedProtocolAvailability(EE->getLoc(),
+                                                    Where.getDeclContext());
+  }
+
+  if (EE->getType() &&
+      EE->getType()->isAny() &&
+      EE->getSubExpr()->getType()->hasParameterizedExistential()) {
+    (void)diagnoseParameterizedProtocolAvailability(EE->getLoc(),
+                                                    Where.getDeclContext());
+  }
+}
+
 bool swift::diagnoseExplicitUnavailability(
     const ValueDecl *D,
     SourceRange R,
@@ -2964,6 +3033,17 @@ public:
       auto Range = RLE->getSourceRange();
       diagnoseDeclRefAvailability(Context.getRegexDecl(), Range);
       diagnoseDeclRefAvailability(RLE->getInitializer(), Range);
+    }
+    if (auto *EE = dyn_cast<ErasureExpr>(E)) {
+      maybeDiagParameterizedExistentialErasure(EE, Where);
+    }
+    if (auto *CC = dyn_cast<ExplicitCastExpr>(E)) {
+      if (!isa<CoerceExpr>(CC) &&
+          CC->getCastType()->hasParameterizedExistential()) {
+        SourceLoc loc = CC->getCastTypeRepr() ? CC->getCastTypeRepr()->getLoc()
+                                              : E->getLoc();
+        diagnoseParameterizedProtocolAvailability(loc, Where.getDeclContext());
+      }
     }
     if (auto KP = dyn_cast<KeyPathExpr>(E)) {
       maybeDiagKeyPath(KP);
@@ -3739,7 +3819,12 @@ public:
 
     ModuleDecl *useModule = Where.getDeclContext()->getParentModule();
     auto subs = ty->getContextSubstitutionMap(useModule, ty->getDecl());
-    (void) diagnoseSubstitutionMapAvailability(Loc, subs, Where);
+    (void)diagnoseSubstitutionMapAvailability(
+        Loc, subs, Where,
+        /*depTy=*/Type(),
+        /*replacementTy=*/Type(),
+        /*useConformanceAvailabilityErrorsOption=*/false,
+        /*suppressParameterizationCheckForOptional=*/ty->isOptional());
     return Action::Continue;
   }
 
@@ -3768,6 +3853,19 @@ public:
             ctx.Diags.diagnose(Loc, diag::unexportable_clang_function_type, T);
           }
         }
+      }
+    }
+
+    if (auto *TT = T->getAs<TupleType>()) {
+      for (auto component : TT->getElementTypes()) {
+        // Let the walker find inner tuple types, we only want to diagnose
+        // non-compound components.
+        if (component->is<TupleType>())
+          continue;
+
+        if (component->hasParameterizedExistential())
+          (void)diagnoseParameterizedProtocolAvailability(
+              Loc, Where.getDeclContext());
       }
     }
 
@@ -3885,13 +3983,26 @@ swift::diagnoseSubstitutionMapAvailability(SourceLoc loc,
                                            SubstitutionMap subs,
                                            const ExportContext &where,
                                            Type depTy, Type replacementTy,
-                                           bool useConformanceAvailabilityErrorsOption) {
+                                           bool useConformanceAvailabilityErrorsOption,
+                                           bool suppressParameterizationCheckForOptional) {
   bool hadAnyIssues = false;
   for (ProtocolConformanceRef conformance : subs.getConformances()) {
     if (diagnoseConformanceAvailability(loc, conformance, where,
                                         depTy, replacementTy,
                                         useConformanceAvailabilityErrorsOption))
       hadAnyIssues = true;
+  }
+
+  // If we're looking at \c (any P)? (or any other depth of optional) then
+  // there's no availability problem.
+  if (suppressParameterizationCheckForOptional)
+    return hadAnyIssues;
+
+  for (auto replacement : subs.getReplacementTypes()) {
+    if (replacement->hasParameterizedExistential())
+      if (diagnoseParameterizedProtocolAvailability(loc,
+                                                    where.getDeclContext()))
+        hadAnyIssues = true;
   }
   return hadAnyIssues;
 }

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -223,13 +223,14 @@ diagnoseConformanceAvailability(SourceLoc loc,
                                 Type replacementTy=Type(),
                                 bool useConformanceAvailabilityErrorsOption = false);
 
-bool
-diagnoseSubstitutionMapAvailability(SourceLoc loc,
-                                    SubstitutionMap subs,
-                                    const ExportContext &context,
-                                    Type depTy=Type(),
-                                    Type replacementTy=Type(),
-                                    bool useConformanceAvailabilityErrorsOption = false);
+bool diagnoseSubstitutionMapAvailability(
+    SourceLoc loc,
+    SubstitutionMap subs, 
+    const ExportContext &context,
+    Type depTy = Type(),
+    Type replacementTy = Type(),
+    bool useConformanceAvailabilityErrorsOption = false,
+    bool suppressParameterizationCheckForOptional = false);
 
 /// Diagnose uses of unavailable declarations. Returns true if a diagnostic
 /// was emitted.
@@ -265,6 +266,11 @@ bool diagnoseExplicitUnavailability(
     const ExtensionDecl *ext,
     const ExportContext &where,
     bool useConformanceAvailabilityErrorsOption = false);
+
+/// Diagnose uses of the runtime features of parameterized protools. Returns
+/// \c true if a diagnostic was emitted.
+bool diagnoseParameterizedProtocolAvailability(SourceRange loc,
+                                               const DeclContext *DC);
 
 /// Check if \p decl has a introduction version required by -require-explicit-availability
 void checkExplicitAvailability(Decl *decl);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5053,6 +5053,17 @@ void ConformanceChecker::ensureRequirementsAreSatisfied() {
   if (where.isImplicit())
     return;
 
+  Conformance->forEachTypeWitness([&](const AssociatedTypeDecl *assoc,
+                                      Type type, TypeDecl *typeDecl) -> bool {
+    // Make sure any associated type witnesses don't make reference to a
+    // parameterized existential type, or we're going to have trouble at
+    // runtime.
+    if (type->hasParameterizedExistential())
+      (void)diagnoseParameterizedProtocolAvailability(typeDecl->getLoc(),
+                                                      where.getDeclContext());
+    return false;
+  });
+
   for (auto req : proto->getRequirementSignature().getRequirements()) {
     if (req.getKind() == RequirementKind::Conformance) {
       auto depTy = req.getFirstType();

--- a/test/Constraints/parameterized_existential_metatypes.swift
+++ b/test/Constraints/parameterized_existential_metatypes.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-parameterized-existential-types
+// RUN: %target-typecheck-verify-swift -enable-parameterized-existential-types -disable-availability-checking
 //
 // FIXME: Merge this file with existential_metatypes.swift once -enable-parameterized-existential-types becomes the default
 

--- a/test/Interpreter/parameterized_existentials.swift
+++ b/test/Interpreter/parameterized_existentials.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-Xfrontend -enable-parameterized-existential-types)
+// RUN: %target-run-simple-swift(-Xfrontend -enable-parameterized-existential-types -Xfrontend -disable-availability-checking)
 // REQUIRES: executable_test
 
 import StdlibUnittest

--- a/test/RemoteAST/parameterized_existentials.swift
+++ b/test/RemoteAST/parameterized_existentials.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-remoteast-test -enable-parameterized-existential-types %s | %FileCheck %s
+// RUN: %target-swift-remoteast-test -enable-parameterized-existential-types -disable-availability-checking %s | %FileCheck %s
 
 // REQUIRES: swift-remoteast-test
 

--- a/test/SILGen/parameterized_existentials.swift
+++ b/test/SILGen/parameterized_existentials.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -module-name parameterized -enable-parameterized-existential-types %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -module-name parameterized -enable-parameterized-existential-types -disable-availability-checking %s | %FileCheck %s
 
 protocol P<T, U, V> {
   associatedtype T

--- a/test/SILOptimizer/cast_folding_parameterized_protocol.swift
+++ b/test/SILOptimizer/cast_folding_parameterized_protocol.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -emit-sil -enable-parameterized-existential-types -O -o - | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-sil -enable-parameterized-existential-types -disable-availability-checking -O -o - | %FileCheck %s
 
 public protocol P<T> {
   associatedtype T

--- a/test/Sema/availability_parameterized_existential.swift
+++ b/test/Sema/availability_parameterized_existential.swift
@@ -4,6 +4,8 @@
 // Make sure we do not emit availability errors or warnings when -disable-availability-checking is passed
 // RUN: not %target-swift-frontend -target %target-cpu-apple-macosx10.50 -typecheck -disable-objc-attr-requires-foundation-module -enable-parameterized-existential-types -disable-availability-checking %s 2>&1 | %FileCheck %s '--implicit-check-not=error:'
 
+// REQUIRES: OS=macosx
+
 func hedge() {
   struct Value {}
   

--- a/test/Sema/availability_parameterized_existential.swift
+++ b/test/Sema/availability_parameterized_existential.swift
@@ -1,0 +1,108 @@
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.50 -disable-objc-attr-requires-foundation-module -enable-parameterized-existential-types
+// RUN: not %target-swift-frontend -target %target-cpu-apple-macosx10.50 -disable-objc-attr-requires-foundation-module -enable-parameterized-existential-types -typecheck %s 2>&1 | %FileCheck %s '--implicit-check-not=<unknown>:0'
+
+// Make sure we do not emit availability errors or warnings when -disable-availability-checking is passed
+// RUN: not %target-swift-frontend -target %target-cpu-apple-macosx10.50 -typecheck -disable-objc-attr-requires-foundation-module -enable-parameterized-existential-types -disable-availability-checking %s 2>&1 | %FileCheck %s '--implicit-check-not=error:'
+
+func hedge() {
+  struct Value {}
+  
+  // We rely on not allowing nesting of extensions, so test to make sure
+  // this emits an error.
+  // CHECK:error: declaration is only valid at file scope
+  extension Value { } // expected-error {{declaration is only valid at file scope}}
+}
+
+protocol P<T> {
+  associatedtype T
+}
+
+struct Wrapper<T> {}
+
+func identity<T>(_ x: any P<T>) -> any P<T> { return x } // OK
+func unwrapUnwrap<T>(_ x: (any P<T>)???) -> (any P<T>)? { return x!! } // OK
+
+func erase<T>(_ x: any P<T>) -> Any { return x } // expected-error {{runtime support for parameterized protocol types is only available in}}
+// expected-note@-1 {{add @available attribute to enclosing global function}}
+// expected-note@-2 {{add 'if #available' version check}}
+
+func eraseOptional<T>(_ x: (any P<T>)?) -> Any { return x }
+// expected-note@-1 {{add @available attribute to enclosing global function}}
+// expected-error@-2 {{runtime support for parameterized protocol types is only available in}}
+// expected-note@-3 {{add 'if #available' version check}}
+// expected-warning@-4 {{expression implicitly coerced from '(any P<T>)?' to 'Any'}}
+// expected-note@-5 {{provide a default value to avoid this warning}}
+// expected-note@-6 {{force-unwrap the value to avoid this warning}}
+// expected-note@-7 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}
+
+func eraseOptional2<T>(_ x: (any P<T>)?) -> Any { return x as Any }
+// expected-note@-1 {{add @available attribute to enclosing global function}}
+// expected-error@-2 {{runtime support for parameterized protocol types is only available in}}
+// expected-note@-3 {{add 'if #available' version check}}
+
+func tupleOut<T>() -> (any P<T>, Int) { return tupleOut() } // expected-error {{runtime support for parameterized protocol types is only available in}}
+// expected-note@-1 {{add @available attribute to enclosing global function}}
+func tupleIn<T>(_ xs: (any P<T>, Int)) -> Int { return tupleIn(xs) } // expected-error {{runtime support for parameterized protocol types is only available in}}
+// expected-note@-1 {{add @available attribute to enclosing global function}}
+func wrap<T>(_ x: any P<T>) -> Wrapper<any P<T>> { return wrap(x) } // expected-error {{runtime support for parameterized protocol types is only available in}}
+// expected-note@-1 {{add @available attribute to enclosing global function}}
+func optionalWrap<T>(_ x: any P<T>) -> Wrapper<(any P<T>)?> { return optionalWrap(x) } // expected-error {{runtime support for parameterized protocol types is only available in}}
+// expected-note@-1 {{add @available attribute to enclosing global function}}
+
+struct UnavailableWitness: P { // expected-note {{add @available attribute to enclosing struct}}
+  typealias T = any P<String> // expected-error {{runtime support for parameterized protocol types is only available in}}
+  // expected-note@-1 {{add @available attribute to enclosing type alias}}
+}
+
+struct UnavailableOptionalWitness: P { // expected-note {{add @available attribute to enclosing struct}}
+  typealias T = (any P<String>)? // expected-error {{runtime support for parameterized protocol types is only available in}}
+  // expected-note@-1 {{add @available attribute to enclosing type alias}}
+}
+
+struct UnavailableWrappedWitness: P { // expected-note 2 {{add @available attribute to enclosing struct}}
+  typealias T = Wrapper<any P<String>> // expected-error 2 {{runtime support for parameterized protocol types is only available in}}
+  // expected-note@-1 2 {{add @available attribute to enclosing type alias}}
+}
+
+struct ParameterizedMembers { // expected-note {{add @available attribute to enclosing struct}}
+  var ok: any P<String>
+  var okOptional: (any P<String>)?
+
+  var broken: Wrapper<(any P<String>)?> // expected-error {{runtime support for parameterized protocol types is only available in}}
+}
+
+func casts() { // expected-note 5 {{add @available attribute to enclosing global function}}
+  struct Value: P { typealias T = String }
+
+  let _ = Value() as any P<String> // OK
+  let _ = Value() as! any P<String>
+  // expected-warning@-1 {{forced cast from 'Value' to 'any P<String>' always succeeds; did you mean to use 'as'?}}
+  // expected-error@-2 {{runtime support for parameterized protocol types is only available in}}
+  // expected-note@-3 {{add 'if #available' version check}}
+
+  let _ = Value() is any P<String>
+  // expected-warning@-1 {{'is' test is always true}}
+  // expected-error@-2 {{runtime support for parameterized protocol types is only available in}}
+  // expected-note@-3 {{add 'if #available' version check}}
+
+  let _ = Value() is (any P<String>)???
+  // expected-warning@-1 {{'is' test is always true}}
+  // expected-error@-2 {{runtime support for parameterized protocol types is only available in}}
+  // expected-note@-3 {{add 'if #available' version check}}
+
+  let _ = Value() as! (any P<String>, Int)
+  // expected-warning@-1 {{cast from 'Value' to unrelated type '(any P<String>, Int)' always fails}}
+  // expected-error@-2 2 {{runtime support for parameterized protocol types is only available in}}
+  // expected-note@-3 2 {{add 'if #available' version check}}
+}
+
+// FIXME: It's a little aggressive to also ban metatypes.
+func metatypes<T>(_ x: T.Type) {  // expected-note 2 {{add @available attribute to enclosing global function}}
+  metatypes((any P<T>).self)
+  // expected-error@-1 {{runtime support for parameterized protocol types is only available in}}
+  // expected-note@-2 {{add 'if #available' version check}}
+
+  metatypes((any P<T>.Type).self)
+  // expected-error@-1 {{runtime support for parameterized protocol types is only available in}}
+  // expected-note@-2 {{add 'if #available' version check}}
+}


### PR DESCRIPTION
Cherry pick of #58655 

-----------

Usages of parameterized existential types that involve runtime type metadata to resolve must be gated on the appropriate OS version in which those features have landed. This means the following usage classes must appear gated:

- Checked casts (is, as?, as!)
- As arguments to generic types (`Foo<any P<T>>`)
- As type witnesses to protocol conformances
- In erasure expressions (and optional-to-any erasure expressions)
- In metatypes
- Tuples

What does this leave?

- Concrete usages
  - `any P<T>` as a parameter or result type
  - Any amount of optional types around existential types
  - Static casts (as)

It's worth calling out the fact that usages of parameterized existential types in tuples are banned but usages in struct members are not. This is due to the fact that Tuple identity and runtime layout is determined by a metadata query against each component type. Whereas for a struct, the opaque type layout does not depend upon the type metadata of the fields at runtime, and the identity of the struct is determined nominally rather than structurally.

Practically, this means that one can work around the lack of tuples by defining a struct with an equivalent type structure as fields:

```
struct AdHocEraser { var x: any P<T> }
```

rdar://92197245