### PR TITLE
[cmake] OpenBSD uses libc++.

### DIFF
--- a/cmake/modules/SwiftCXXUtils.cmake
+++ b/cmake/modules/SwiftCXXUtils.cmake
@@ -2,6 +2,5 @@
 set(SWIFT_LIBSTDCXX_PLATFORMS
     "LINUX"
     "FREEBSD"
-    "OPENBSD"
     "CYGWIN"
     "HAIKU")


### PR DESCRIPTION
Therefore, do not generate a libstdcxx.modulemap. See also #58497.

cc @egorzhdan 