### PR TITLE
[5.7][Parseable Output] Emit parseable messages on failure in `CompilerInstance.setup`

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -2072,6 +2072,85 @@ int swift::performFrontend(ArrayRef<const char *> Args,
     PDC.setSuppressOutput(true);
   }
 
+  auto emitParseableBeganMessage = [&Invocation, &Args]() {
+    const auto &IO = Invocation.getFrontendOptions().InputsAndOutputs;
+    const auto OSPid = getpid();
+    const auto ProcInfo = sys::TaskProcessInformation(OSPid);
+
+    // Parseable output clients may not understand the idea of a batch
+    // compilation. We assign each primary in a batch job a quasi process id,
+    // making sure it cannot collide with a real PID (always positive). Non-batch
+    // compilation gets a real OS PID.
+    int64_t Pid = IO.hasUniquePrimaryInput() ? OSPid : QUASI_PID_START;
+
+    if (IO.hasPrimaryInputs()) {
+      IO.forEachPrimaryInputWithIndex([&](const InputFile &Input,
+                                          unsigned idx) -> bool {
+        ArrayRef<InputFile> Inputs(Input);
+        emitBeganMessage(llvm::errs(),
+                         mapFrontendInvocationToAction(Invocation),
+                         constructDetailedTaskDescription(Invocation,
+                                                          Inputs,
+                                                          Args), Pid - idx,
+                         ProcInfo);
+        return false;
+      });
+    } else {
+      // If no primary inputs are present, we are in WMO.
+      emitBeganMessage(llvm::errs(),
+                       mapFrontendInvocationToAction(Invocation),
+                       constructDetailedTaskDescription(Invocation, IO.getAllInputs(), Args),
+                       OSPid, ProcInfo);
+    }
+  };
+
+  auto emitParseableFinishedMessage = [&Invocation, &Args, &FileSpecificDiagnostics](int ExitStatus) {
+    const auto &IO = Invocation.getFrontendOptions().InputsAndOutputs;
+    const auto OSPid = getpid();
+    const auto ProcInfo = sys::TaskProcessInformation(OSPid);
+
+    // Parseable output clients may not understand the idea of a batch
+    // compilation. We assign each primary in a batch job a quasi process id,
+    // making sure it cannot collide with a real PID (always positive). Non-batch
+    // compilation gets a real OS PID.
+    int64_t Pid = IO.hasUniquePrimaryInput() ? OSPid : QUASI_PID_START;
+
+    if (IO.hasPrimaryInputs()) {
+      IO.forEachPrimaryInputWithIndex([&](const InputFile &Input,
+                                          unsigned idx) -> bool {
+        assert(FileSpecificDiagnostics.count(Input.getFileName()) != 0 &&
+               "Expected diagnostic collection for input.");
+
+        // Join all diagnostics produced for this file into a single output.
+        auto PrimaryDiags = FileSpecificDiagnostics.lookup(Input.getFileName());
+        const char *const Delim = "";
+        std::ostringstream JoinedDiags;
+        std::copy(PrimaryDiags.begin(), PrimaryDiags.end(),
+                  std::ostream_iterator<std::string>(JoinedDiags, Delim));
+
+        emitFinishedMessage(llvm::errs(),
+                            mapFrontendInvocationToAction(Invocation),
+                            JoinedDiags.str(), ExitStatus, Pid - idx, ProcInfo);
+        return false;
+      });
+    } else {
+      // If no primary inputs are present, we are in WMO.
+      std::vector<std::string> AllDiagnostics;
+      for (const auto &FileDiagnostics : FileSpecificDiagnostics) {
+        AllDiagnostics.insert(AllDiagnostics.end(),
+                              FileDiagnostics.getValue().begin(),
+                              FileDiagnostics.getValue().end());
+      }
+      const char *const Delim = "";
+      std::ostringstream JoinedDiags;
+      std::copy(AllDiagnostics.begin(), AllDiagnostics.end(),
+                std::ostream_iterator<std::string>(JoinedDiags, Delim));
+      emitFinishedMessage(llvm::errs(),
+                          mapFrontendInvocationToAction(Invocation),
+                          JoinedDiags.str(), ExitStatus, OSPid, ProcInfo);
+    }
+  };
+
   // Because the serialized diagnostics consumer is initialized here,
   // diagnostics emitted above, within CompilerInvocation::parseArgs, are never
   // serialized. This is a non-issue because, in nearly all cases, frontend
@@ -2102,12 +2181,20 @@ int swift::performFrontend(ArrayRef<const char *> Args,
     llvm::EnableStatistics();
   }
 
+
+  if (Invocation.getFrontendOptions().FrontendParseableOutput)
+    emitParseableBeganMessage();
+
   const DiagnosticOptions &diagOpts = Invocation.getDiagnosticOptions();
   bool verifierEnabled = diagOpts.VerifyMode != DiagnosticOptions::NoVerify;
 
   std::string InstanceSetupError;
   if (Instance->setup(Invocation, InstanceSetupError)) {
-    return finishDiagProcessing(1, /*verifierEnabled*/ false);
+    int ReturnCode = 1;
+    if (Invocation.getFrontendOptions().FrontendParseableOutput)
+      emitParseableFinishedMessage(ReturnCode);
+
+    return finishDiagProcessing(ReturnCode, /*verifierEnabled*/ false);
   }
 
   // The compiler instance has been configured; notify our observer.
@@ -2119,38 +2206,6 @@ int swift::performFrontend(ArrayRef<const char *> Args,
     // Suppress printed diagnostic output during the compile if the verifier is
     // enabled.
     PDC.setSuppressOutput(true);
-  }
-
-  if (Invocation.getFrontendOptions().FrontendParseableOutput) {
-   const auto &IO = Invocation.getFrontendOptions().InputsAndOutputs;
-    const auto OSPid = getpid();
-    const auto ProcInfo = sys::TaskProcessInformation(OSPid);
-
-    // Parseable output clients may not understand the idea of a batch
-    // compilation. We assign each primary in a batch job a quasi process id,
-    // making sure it cannot collide with a real PID (always positive). Non-batch
-    // compilation gets a real OS PID.
-    int64_t Pid = IO.hasUniquePrimaryInput() ? OSPid : QUASI_PID_START;
-
-    if (IO.hasPrimaryInputs()) {
-      IO.forEachPrimaryInputWithIndex([&](const InputFile &Input,
-                                          unsigned idx) -> bool {
-        ArrayRef<InputFile> Inputs(Input);
-        emitBeganMessage(llvm::errs(),
-                         mapFrontendInvocationToAction(Invocation),
-                         constructDetailedTaskDescription(Invocation,
-                                                          Inputs,
-                                                          Args), Pid - idx,
-                         ProcInfo);
-        return false;
-      });
-    } else {
-      // If no primary inputs are present, we are in WMO.
-      emitBeganMessage(llvm::errs(),
-                       mapFrontendInvocationToAction(Invocation),
-                       constructDetailedTaskDescription(Invocation, IO.getAllInputs(), Args),
-                       OSPid, ProcInfo);
-    }
   }
 
   int ReturnValue = 0;
@@ -2171,52 +2226,8 @@ int swift::performFrontend(ArrayRef<const char *> Args,
   if (auto *StatsReporter = Instance->getStatsReporter())
     StatsReporter->noteCurrentProcessExitStatus(r);
 
-  if (Invocation.getFrontendOptions().FrontendParseableOutput) {
-    const auto &IO = Invocation.getFrontendOptions().InputsAndOutputs;
-    const auto OSPid = getpid();
-    const auto ProcInfo = sys::TaskProcessInformation(OSPid);
-
-    // Parseable output clients may not understand the idea of a batch
-    // compilation. We assign each primary in a batch job a quasi process id,
-    // making sure it cannot collide with a real PID (always positive). Non-batch
-    // compilation gets a real OS PID.
-    int64_t Pid = IO.hasUniquePrimaryInput() ? OSPid : QUASI_PID_START;
-
-    if (IO.hasPrimaryInputs()) {
-      IO.forEachPrimaryInputWithIndex([&](const InputFile &Input,
-                                          unsigned idx) -> bool {
-        assert(FileSpecificDiagnostics.count(Input.getFileName()) != 0 &&
-               "Expected diagnostic collection for input.");
-
-        // Join all diagnostics produced for this file into a single output.
-        auto PrimaryDiags = FileSpecificDiagnostics.lookup(Input.getFileName());
-        const char *const Delim = "";
-        std::ostringstream JoinedDiags;
-        std::copy(PrimaryDiags.begin(), PrimaryDiags.end(),
-                  std::ostream_iterator<std::string>(JoinedDiags, Delim));
-
-        emitFinishedMessage(llvm::errs(),
-                            mapFrontendInvocationToAction(Invocation),
-                            JoinedDiags.str(), r, Pid - idx, ProcInfo);
-        return false;
-      });
-    } else {
-      // If no primary inputs are present, we are in WMO.
-      std::vector<std::string> AllDiagnostics;
-      for (const auto &FileDiagnostics : FileSpecificDiagnostics) {
-        AllDiagnostics.insert(AllDiagnostics.end(),
-                              FileDiagnostics.getValue().begin(),
-                              FileDiagnostics.getValue().end());
-      }
-      const char *const Delim = "";
-      std::ostringstream JoinedDiags;
-      std::copy(AllDiagnostics.begin(), AllDiagnostics.end(),
-                std::ostream_iterator<std::string>(JoinedDiags, Delim));
-      emitFinishedMessage(llvm::errs(),
-                          mapFrontendInvocationToAction(Invocation),
-                          JoinedDiags.str(), r, OSPid, ProcInfo);
-    }
-  }
+  if (Invocation.getFrontendOptions().FrontendParseableOutput)
+    emitParseableFinishedMessage(r);
 
   return r;
 }

--- a/test/Frontend/parseable_output_early.swift
+++ b/test/Frontend/parseable_output_early.swift
@@ -1,0 +1,9 @@
+// RUN: not %target-swift-frontend(mock-sdk: -sdk %/S/../ModuleInterface/Inputs/BadStdlib.sdk -module-cache-path %/t/module-cache -resource-dir %/S/../ModuleInterface/Inputs/BadStdlib.sdk) -primary-file %s -o %t.out -emit-module -emit-module-path %t.swiftmodule -module-name parseable_output_early -frontend-parseable-output 2>&1 | %FileCheck %s
+
+// CHECK: {{[1-9][0-9]*}}
+// CHECK-NEXT: {
+// CHECK-NEXT:   "kind": "began",
+// CHECK-NEXT:   "name": "compile",
+
+// CHECK:   "kind": "finished",
+// CHECK-NEXT:   "name": "compile",


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/58881
-----------------------------------------------------
FrontendTool sets up diagnostic infrastructure early and suppresses stdout diagnostics if frontend-parseable-output is enabled. It then calls `CompilerInstance.setup` which may fail - if it fails, we exit early. But that means we have not gotten a chance to emit parseable-output.

This change moves emission of the `began` parseable message to before `CompilerInstance.setup`, and ensures that a corresponding `finished` message is emitted if the setup fails.

Resolves rdar://93187783
