### PR TITLE
[next] Generalise interop tests that only care about name and types

### DIFF
--- a/test/Interop/C/function/emit-called-inline-function-irgen.swift
+++ b/test/Interop/C/function/emit-called-inline-function-irgen.swift
@@ -13,10 +13,10 @@ import EmitCalledInlineFunction
 // C99-DAG: define internal i32 @calledFromSwift()
 // C99-DAG: define internal i32 @calledTransitively()
 
-// CXX-DAG: define linkonce_odr{{( dso_local)?}} i32 @{{_Z15calledFromSwiftv|"\?calledFromSwift@@YAHXZ"}}()
-// CXX-DAG: define linkonce_odr{{( dso_local)?}} i32 @{{_Z18calledTransitivelyv|"\?calledTransitively@@YAHXZ"}}()
-// CXX-DAG: define linkonce_odr{{( dso_local)?}} i32 @{{_ZN1C32memberFunctionCalledTransitivelyEv|"\?memberFunctionCalledTransitively@C@@QEAAHXZ"}}(%class.C* nonnull align 1 dereferenceable(1) %this)
-// CXX-DAG: define linkonce_odr{{( dso_local)?}} i32 @{{_Z29calledTransitivelyFromVarInitv|"\?calledTransitivelyFromVarInit@@YAHXZ"}}()
+// CXX-DAG: define {{.*}}i32 @{{_Z15calledFromSwiftv|"\?calledFromSwift@@YAHXZ"}}()
+// CXX-DAG: define {{.*}}i32 @{{_Z18calledTransitivelyv|"\?calledTransitively@@YAHXZ"}}()
+// CXX-DAG: define {{.*}}i32 @{{_ZN1C32memberFunctionCalledTransitivelyEv|"\?memberFunctionCalledTransitively@C@@QEAAHXZ"}}(%class.C* {{.*}})
+// CXX-DAG: define {{.*}}i32 @{{_Z29calledTransitivelyFromVarInitv|"\?calledTransitivelyFromVarInit@@YAHXZ"}}()
 
 calledFromSwift()
 

--- a/test/Interop/Cxx/class/constructors-irgen.swift
+++ b/test/Interop/Cxx/class/constructors-irgen.swift
@@ -96,7 +96,7 @@ public func createTemplatedConstructor() {
   // ITANIUM_X64: call void @_ZN20TemplatedConstructorC1I7ArgTypeEET_(%struct.TemplatedConstructor* [[OBJ_AS_STRUCT]], i32 [[IVAL]])
   // ITANIUM_X64: ret void
   
-  // ITANIUM_X64-LABEL: define linkonce_odr void @_ZN20TemplatedConstructorC1I7ArgTypeEET_(%struct.TemplatedConstructor* nonnull align 4 dereferenceable(4) {{.*}}, i32 {{.*}})
+  // ITANIUM_X64-LABEL: define {{.*}}void @_ZN20TemplatedConstructorC1I7ArgTypeEET_(%struct.TemplatedConstructor* {{.*}}, i32 {{.*}})
   
   // ITANIUM_ARM-LABEL: define protected swiftcc void @"$ss26createTemplatedConstructoryyF"()
   // ITANIUM_ARM: [[OBJ:%.*]] = alloca %TSo20TemplatedConstructorV
@@ -105,7 +105,7 @@ public func createTemplatedConstructor() {
   // ITANIUM_ARM:  call %struct.TemplatedConstructor* @_ZN20TemplatedConstructorC2I7ArgTypeEET_(%struct.TemplatedConstructor* [[OBJ_AS_STRUCT]], [1 x i32] [[IVAL]])
   // ITANIUM_ARM: ret void
   
-  // ITANIUM_ARM-LABEL: define linkonce_odr %struct.TemplatedConstructor* @_ZN20TemplatedConstructorC2I7ArgTypeEET_(%struct.TemplatedConstructor* nonnull returned align 4 dereferenceable(4) {{.*}}, [1 x i32] {{.*}})
+  // ITANIUM_ARM-LABEL: define {{.*}}%struct.TemplatedConstructor* @_ZN20TemplatedConstructorC2I7ArgTypeEET_(%struct.TemplatedConstructor* {{.*}}, [1 x i32] {{.*}})
 
   // MICROSOFT_X64-LABEL: define dllexport swiftcc void @"$ss26createTemplatedConstructoryyF"()
   // MICROSOFT_X64: [[OBJ:%.*]] = alloca %TSo20TemplatedConstructorV
@@ -114,6 +114,6 @@ public func createTemplatedConstructor() {
   // MICROSOFT_X64: call %struct.TemplatedConstructor* @"??$?0UArgType@@@TemplatedConstructor@@QEAA@UArgType@@@Z"(%struct.TemplatedConstructor* [[OBJ_AS_STRUCT]], i32 [[IVAL]])
   // MICROSOFT_X64: ret void
   
-  // MICROSOFT_X64-LABEL: define linkonce_odr dso_local %struct.TemplatedConstructor* @"??$?0UArgType@@@TemplatedConstructor@@QEAA@UArgType@@@Z"(%struct.TemplatedConstructor* nonnull returned align 4 dereferenceable(4) {{.*}}, i32 {{.*}})
+  // MICROSOFT_X64-LABEL: define {{.*}}%struct.TemplatedConstructor* @"??$?0UArgType@@@TemplatedConstructor@@QEAA@UArgType@@@Z"(%struct.TemplatedConstructor* {{.*}}, i32 {{.*}})
   let templated = TemplatedConstructor(ArgType())
 }

--- a/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-function-from-nested-calls-irgen.swift
+++ b/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-function-from-nested-calls-irgen.swift
@@ -4,7 +4,7 @@ import ConstructorCallsFunctionFromNestedCalls
 
 let a = Hold42WithLongInitCallGraph()
 
-// CHECK-DAG: define linkonce_odr{{( dso_local)?}} i32 @{{_Z11get42Level1v|"\?get42Level1@@YAHXZ"}}
-// CHECK-DAG: define linkonce_odr{{( dso_local)?}} i32 @{{_Z11get42Level2v|"\?get42Level2@@YAHXZ"}}
-// CHECK-DAG: define linkonce_odr{{( dso_local)?}} i32 @{{_Z11get42Level3v|"\?get42Level3@@YAHXZ"}}
-// CHECK-DAG: define linkonce_odr{{( dso_local)?}} i32 @{{_Z11get42Level4v|"\?get42Level4@@YAHXZ"}}
+// CHECK-DAG: define {{.*}}i32 @{{_Z11get42Level1v|"\?get42Level1@@YAHXZ"}}
+// CHECK-DAG: define {{.*}}i32 @{{_Z11get42Level2v|"\?get42Level2@@YAHXZ"}}
+// CHECK-DAG: define {{.*}}i32 @{{_Z11get42Level3v|"\?get42Level3@@YAHXZ"}}
+// CHECK-DAG: define {{.*}}i32 @{{_Z11get42Level4v|"\?get42Level4@@YAHXZ"}}

--- a/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-function-from-nested-struct-irgen.swift
+++ b/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-function-from-nested-struct-irgen.swift
@@ -11,5 +11,5 @@ let b = HoldMemberThatHoldsMemberThatHolds42()
 
 let sum = a.holder.m + b.holder.holder.m
 
-// CHECK-DAG: define linkonce_odr{{( dso_local)?}} i32 @{{_Z9incrementi|"\?increment@@YAHH@Z"}}(i32 %t)
-// CHECK-DAG: define linkonce_odr{{( dso_local)?}} i32 @{{_Z5get42v|"\?get42@@YAHXZ"}}
+// CHECK-DAG: define {{.*}}i32 @{{_Z9incrementi|"\?increment@@YAHH@Z"}}(i32 {{.*}})
+// CHECK-DAG: define {{.*}}i32 @{{_Z5get42v|"\?get42@@YAHXZ"}}

--- a/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-function-irgen.swift
+++ b/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-function-irgen.swift
@@ -11,6 +11,6 @@ let b = Hold23()
 
 let sum = a.m + b.m
 
-// CHECK-DAG: define linkonce_odr{{( dso_local)?}} i32 @{{_Z9incrementi|"\?increment@@YAHH@Z"}}(i32 %t)
-// CHECK-DAG: define linkonce_odr{{( dso_local)?}} i32 @{{_Z5get42v|"\?get42@@YAHXZ"}}
-// CHECK-DAG: define linkonce_odr{{( dso_local)?}} i32 @{{_Z15passThroughArgTIiET_S0_|"\?\?\$passThroughArgT@H@@YAHH@Z"}}
+// CHECK-DAG: define {{.*}}i32 @{{_Z9incrementi|"\?increment@@YAHH@Z"}}(i32 {{.*}})
+// CHECK-DAG: define {{.*}}i32 @{{_Z5get42v|"\?get42@@YAHXZ"}}
+// CHECK-DAG: define {{.*}}i32 @{{_Z15passThroughArgTIiET_S0_|"\?\?\$passThroughArgT@H@@YAHH@Z"}}

--- a/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-method-irgen.swift
+++ b/test/Interop/Cxx/class/inline-function-codegen/constructor-calls-method-irgen.swift
@@ -6,4 +6,4 @@ public func getIncrementorValue() -> CInt {
   return callConstructor(41)
 }
 
-// CHECK: define linkonce_odr{{( dso_local)?}} i32 @{{_ZN11Incrementor9incrementEi|"\?increment@Incrementor@@QEAAHH@Z"}}(%struct.Incrementor* nonnull align 1 dereferenceable(1) %this, i32 %t)
+// CHECK: define {{.*}}i32 @{{_ZN11Incrementor9incrementEi|"\?increment@Incrementor@@QEAAHH@Z"}}(%struct.Incrementor* {{.*}}, i32 {{.*}})

--- a/test/Interop/Cxx/class/inline-function-codegen/field-init-calls-function-irgen.swift
+++ b/test/Interop/Cxx/class/inline-function-codegen/field-init-calls-function-irgen.swift
@@ -6,4 +6,4 @@ public func getInitializedField() -> CInt {
   return initializeField()
 }
 
-// CHECK: define linkonce_odr{{( dso_local)?}} i32 @{{_Z9incrementi|"\?increment@@YAHH@Z"}}(i32 %t)
+// CHECK: define {{.*}}i32 @{{_Z9incrementi|"\?increment@@YAHH@Z"}}(i32 {{.*}})

--- a/test/Interop/Cxx/class/inline-function-codegen/method-calls-function-irgen.swift
+++ b/test/Interop/Cxx/class/inline-function-codegen/method-calls-function-irgen.swift
@@ -6,4 +6,4 @@ public func getValueFromMethod() -> CInt {
   return callMethod(41)
 }
 
-// CHECK: define linkonce_odr{{( dso_local)?}} i32 @{{_Z9incrementi|"\?increment@@YAHH@Z"}}(i32 %t)
+// CHECK: define {{.*}}i32 @{{_Z9incrementi|"\?increment@@YAHH@Z"}}(i32 {{.*}})

--- a/test/Interop/Cxx/class/inline-function-codegen/method-calls-method-from-nested-struct-irgen.swift
+++ b/test/Interop/Cxx/class/inline-function-codegen/method-calls-method-from-nested-struct-irgen.swift
@@ -6,4 +6,4 @@ public func getValueFromMethod() -> CInt {
   return callMethod(41)
 }
 
-// CHECK: define linkonce_odr{{( dso_local)?}} i32 @{{_ZN13IncrementUser11Incrementor9incrementEi|"\?increment@Incrementor@IncrementUser@@QEAAHH@Z"}}(%"struct.IncrementUser::Incrementor"* nonnull align 1 dereferenceable(1) %this, i32 %t)
+// CHECK: define {{.*}}i32 @{{_ZN13IncrementUser11Incrementor9incrementEi|"\?increment@Incrementor@IncrementUser@@QEAAHH@Z"}}(%"struct.IncrementUser::Incrementor"* {{.*}}, i32 {{.*}})

--- a/test/Interop/Cxx/class/inline-function-codegen/method-calls-method-irgen.swift
+++ b/test/Interop/Cxx/class/inline-function-codegen/method-calls-method-irgen.swift
@@ -6,4 +6,4 @@ public func getValueFromMethod() -> CInt {
   return callMethod(41)
 }
 
-// CHECK: define linkonce_odr{{( dso_local)?}} i32 @{{_ZN11Incrementor9incrementEi|"\?increment@Incrementor@@QEAAHH@Z"}}(%struct.Incrementor* nonnull align 1 dereferenceable(1) %this, i32 %t)
+// CHECK: define {{.*}}i32 @{{_ZN11Incrementor9incrementEi|"\?increment@Incrementor@@QEAAHH@Z"}}(%struct.Incrementor*{{.*}}, i32{{.*}})

--- a/test/Interop/Cxx/class/inline-function-codegen/static-var-init-calls-function-irgen.swift
+++ b/test/Interop/Cxx/class/inline-function-codegen/static-var-init-calls-function-irgen.swift
@@ -8,4 +8,4 @@ public func getInitializedStaticVar() -> CInt {
   return initializeStaticVar()
 }
 
-// CHECK: define linkonce_odr{{( dso_local)?}} i32 @{{_Z9incrementi|"\?increment@@YAHH@Z"}}(i32 %t)
+// CHECK: define {{.*}}i32 @{{_Z9incrementi|"\?increment@@YAHH@Z"}}(i32{{.*}})

--- a/test/Interop/Cxx/static/static-member-func-irgen.swift
+++ b/test/Interop/Cxx/static/static-member-func-irgen.swift
@@ -6,18 +6,18 @@ public func callStaticMemberFunc() -> CInt {
   return WithStaticMemberFunc.staticMemberFunc()
 }
 
-// CHECK: define {{(protected |dllexport )?}}swiftcc i32 @"$s4main20callStaticMemberFuncs5Int32VyF"()
+// CHECK: define {{.*}}i32 @"$s4main20callStaticMemberFuncs5Int32VyF"()
 // CHECK: [[VALUE:%.*]] = call i32 @{{_ZN20WithStaticMemberFunc16staticMemberFuncEv|"\?staticMemberFunc@WithStaticMemberFunc@@SAHXZ"}}()
 // CHECK: ret i32 [[VALUE]]
 
-// CHECK: declare {{(dso_local )?}}i32 @{{_ZN20WithStaticMemberFunc16staticMemberFuncEv|"\?staticMemberFunc@WithStaticMemberFunc@@SAHXZ"}}()
+// CHECK: declare {{.*}}i32 @{{_ZN20WithStaticMemberFunc16staticMemberFuncEv|"\?staticMemberFunc@WithStaticMemberFunc@@SAHXZ"}}()
 
 public func callStaticMemberFuncAddr() -> CInt {
   return WithStaticMemberFunc.getStaticMemberFuncAddress()!()
 }
 
-// CHECK: define {{(protected |dllexport )?}}swiftcc i32 @"$s4main24callStaticMemberFuncAddrs5Int32VyF"()
+// CHECK: define {{.*}}i32 @"$s4main24callStaticMemberFuncAddrs5Int32VyF"()
 // CHECK: call i32 ()* @{{_ZN20WithStaticMemberFunc26getStaticMemberFuncAddressEv|"\?getStaticMemberFuncAddress@WithStaticMemberFunc@@SAP6AHXZXZ"}}()
 
-// CHECK: declare {{(dso_local )?}}i32 ()* @{{_ZN20WithStaticMemberFunc26getStaticMemberFuncAddressEv|"\?getStaticMemberFuncAddress@WithStaticMemberFunc@@SAP6AHXZXZ"}}()
+// CHECK: declare {{.*}}i32 ()* @{{_ZN20WithStaticMemberFunc26getStaticMemberFuncAddressEv|"\?getStaticMemberFuncAddress@WithStaticMemberFunc@@SAP6AHXZXZ"}}()
 

--- a/test/Interop/Cxx/static/static-var-irgen.swift
+++ b/test/Interop/Cxx/static/static-var-irgen.swift
@@ -23,42 +23,42 @@ public func initStaticVars() -> CInt {
 // CHECK: @{{_ZL25staticConstexprNonTrivial|staticConstexprNonTrivial}} = internal constant %class.NonTrivial { i32 8192 }, align 4
 
 // CHECK: define internal void @{{__cxx_global_var_init|"\?\?__EstaticVarInit@@YAXXZ"}}()
-// CHECK: %call = call i32 @{{_Z13makeStaticVarv|"\?makeStaticVar@@YAHXZ"}}()
+// CHECK: %call = call {{.*}}i32 @{{_Z13makeStaticVarv|"\?makeStaticVar@@YAHXZ"}}()
 // CHECK: store i32 %call, i32* @{{_ZL13staticVarInit|staticVarInit}}, align 4
 
-// CHECK: declare{{( dso_local)?}} i32 @{{_Z13makeStaticVarv|"\?makeStaticVar@@YAHXZ"}}()
+// CHECK: declare {{.*}}i32 @{{_Z13makeStaticVarv|"\?makeStaticVar@@YAHXZ"}}()
 
 // CHECK: define internal void @{{__cxx_global_var_init.1|"\?\?__EstaticVarInlineInit@@YAXXZ"}}()
-// CHECK: %call = call i32 @{{_Z19inlineMakeStaticVarv|"\?inlineMakeStaticVar@@YAHXZ"}}()
+// CHECK: %call = call {{.*}}i32 @{{_Z19inlineMakeStaticVarv|"\?inlineMakeStaticVar@@YAHXZ"}}()
 // CHECK: store i32 %call, i32* @{{_ZL19staticVarInlineInit|staticVarInlineInit}}, align 4
 
-// CHECK: define linkonce_odr{{( dso_local)?}} i32 @{{_Z19inlineMakeStaticVarv|"\?inlineMakeStaticVar@@YAHXZ"}}()
+// CHECK: define {{.*}}i32 @{{_Z19inlineMakeStaticVarv|"\?inlineMakeStaticVar@@YAHXZ"}}()
 // CHECK: ret i32 8
 
 // CHECK: define internal void @{{__cxx_global_var_init.2|"\?\?__EstaticConstInit@@YAXXZ"}}()
-// CHECK: %call = call i32 @{{_Z15makeStaticConstv|"\?makeStaticConst@@YAHXZ"}}()
+// CHECK: %call = call {{.*}}i32 @{{_Z15makeStaticConstv|"\?makeStaticConst@@YAHXZ"}}()
 // CHECK: store i32 %call, i32* @{{_ZL15staticConstInit|staticConstInit}}, align 4
 
-// CHECK: declare{{( dso_local)?}} i32 @{{_Z15makeStaticConstv|"\?makeStaticConst@@YAHXZ"}}()
+// CHECK: declare {{.*}}i32 @{{_Z15makeStaticConstv|"\?makeStaticConst@@YAHXZ"}}()
 
 // CHECK: define internal void @{{__cxx_global_var_init.3|"\?\?__EstaticConstInlineInit@@YAXXZ"}}()
-// CHECK: %call = call i32 @{{_Z21inlineMakeStaticConstv|"\?inlineMakeStaticConst@@YAHXZ"}}()
+// CHECK: %call = call {{.*}}i32 @{{_Z21inlineMakeStaticConstv|"\?inlineMakeStaticConst@@YAHXZ"}}()
 // CHECK: store i32 %call, i32* @{{_ZL21staticConstInlineInit|staticConstInlineInit}}, align 4
 
-// CHECK: define linkonce_odr{{( dso_local)?}} i32 @{{_Z21inlineMakeStaticConstv|"\?inlineMakeStaticConst@@YAHXZ"}}()
+// CHECK: define {{.*}}i32 @{{_Z21inlineMakeStaticConstv|"\?inlineMakeStaticConst@@YAHXZ"}}()
 // CHECK: ret i32 16
 
 // CHECK: define internal void @{{__cxx_global_var_init.4|"\?\?__EstaticNonTrivial@@YAXXZ"}}()
-// CHECK: call {{void|%class.NonTrivial\*}} {{@_ZN10NonTrivialC[12]Ei\(%class.NonTrivial\* nonnull align 4 dereferenceable\(4\) @_ZL16staticNonTrivial, i32 1024\)|@"\?\?0NonTrivial@@QEAA@H@Z"\(%class.NonTrivial\* nonnull align 4 dereferenceable\(4\) @staticNonTrivial, i32 1024\)}}
+// CHECK: call{{.*}} {{void|%class.NonTrivial\*}} {{@_ZN10NonTrivialC[12]Ei\(%class.NonTrivial\* .*@_ZL16staticNonTrivial, i32 .*1024\)|@"\?\?0NonTrivial@@QEAA@H@Z"\(%class.NonTrivial\* .*@staticNonTrivial, i32 .*1024\)}}
 
 // CHECK: define internal void @{{__cxx_global_var_init.5|"\?\?__EstaticConstNonTrivial@@YAXXZ"}}()
-// CHECK: call {{void|%class.NonTrivial\*}} {{@_ZN10NonTrivialC[12]Ei\(%class.NonTrivial\* nonnull align 4 dereferenceable\(4\) @_ZL21staticConstNonTrivial, i32 2048\)|@"\?\?0NonTrivial@@QEAA@H@Z"\(%class.NonTrivial\* nonnull align 4 dereferenceable\(4\) @staticConstNonTrivial, i32 2048\)}}
+// CHECK: call{{.*}} {{void|%class.NonTrivial\*}} {{@_ZN10NonTrivialC[12]Ei\(%class.NonTrivial\* .*@_ZL21staticConstNonTrivial, i32 .*2048\)|@"\?\?0NonTrivial@@QEAA@H@Z"\(%class.NonTrivial\* .*@staticConstNonTrivial, i32 .*2048\)}}
 
 public func readStaticVar() -> CInt {
   return staticVar
 }
 
-// CHECK: define {{(protected |dllexport )?}}swiftcc i32 @"$s4main13readStaticVars5Int32VyF"()
+// CHECK: define {{.*}}i32 @"$s4main13readStaticVars5Int32VyF"()
 // CHECK: [[VALUE:%.*]] = load i32, i32* getelementptr inbounds (%Ts5Int32V, %Ts5Int32V* bitcast (i32* @{{_ZL9staticVar|staticVar}} to %Ts5Int32V*), i32 0, i32 0), align 4
 // CHECK: ret i32 [[VALUE]]
 
@@ -66,14 +66,14 @@ public func writeStaticVar(_ v: CInt) {
   staticVar = v
 }
 
-// CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main14writeStaticVaryys5Int32VF"(i32 %0)
+// CHECK: define {{.*}}void @"$s4main14writeStaticVaryys5Int32VF"(i32 {{.*}}%0)
 // CHECK: store i32 %0, i32* getelementptr inbounds (%Ts5Int32V, %Ts5Int32V* bitcast (i32* @{{_ZL9staticVar|staticVar}} to %Ts5Int32V*), i32 0, i32 0), align 4
 
 public func readStaticNonTrivial() -> NonTrivial {
   return staticNonTrivial
 }
 
-// CHECK: define {{(protected |dllexport )?}}swiftcc i32 @"$s4main20readStaticNonTrivialSo0dE0VyF"()
+// CHECK: define {{.*}}i32 @"$s4main20readStaticNonTrivialSo0dE0VyF"()
 // CHECK: [[VALUE:%.*]] = load i32, i32* getelementptr inbounds (%TSo10NonTrivialV, %TSo10NonTrivialV* bitcast (%class.NonTrivial* @{{_ZL16staticNonTrivial|staticNonTrivial}} to %TSo10NonTrivialV*), i32 0, i32 0, i32 0), align 4
 // CHECK: ret i32 [[VALUE]]
 
@@ -81,7 +81,7 @@ public func writeStaticNonTrivial(_ i: NonTrivial) {
   staticNonTrivial = i
 }
 
-// CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main21writeStaticNonTrivialyySo0dE0VF"(i32 %0)
+// CHECK: define {{.*}}void @"$s4main21writeStaticNonTrivialyySo0dE0VF"(i32 {{.*}}%0)
 // CHECK: store i32 %0, i32* getelementptr inbounds (%TSo10NonTrivialV, %TSo10NonTrivialV* bitcast (%class.NonTrivial* @{{_ZL16staticNonTrivial|staticNonTrivial}} to %TSo10NonTrivialV*), i32 0, i32 0, i32 0), align 4
 
 func modifyInout(_ c: inout CInt) {
@@ -91,7 +91,7 @@ func modifyInout(_ c: inout CInt) {
 public func passingVarAsInout() {
   modifyInout(&staticVar)
 }
-// CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main17passingVarAsInoutyyF"()
+// CHECK: define {{.*}}void @"$s4main17passingVarAsInoutyyF"()
 // CHECK: call swiftcc void @"$s4main11modifyInoutyys5Int32VzF"(%Ts5Int32V* nocapture dereferenceable(4) bitcast (i32* @{{_ZL9staticVar|staticVar}} to %Ts5Int32V*))
 
 // CHECK: define internal void @_GLOBAL__sub_I__swift_imported_modules_()

--- a/test/Interop/Cxx/templates/class-template-uninstantiatable-members-irgen.swift
+++ b/test/Interop/Cxx/templates/class-template-uninstantiatable-members-irgen.swift
@@ -8,11 +8,11 @@ import ClassTemplateInstantiationErrors
 // CHECK: ret void
 
 // CHECK-LABEL: define {{.*}}i32 @{{_ZN21CannotBeInstantiantedI10IntWrapperE8incValueEv|"\?incValue@\?\$CannotBeInstantianted@UIntWrapper@@@@QEAAHXZ"}}(%struct.CannotBeInstantianted*
-// CHECK: call i32 @{{_ZN21CannotBeInstantiantedI10IntWrapperE6getOneEv|"\?getOne@\?\$CannotBeInstantianted@UIntWrapper@@@@QEAAHXZ"}}(%struct.CannotBeInstantianted*
+// CHECK: call {{.*}}i32 @{{_ZN21CannotBeInstantiantedI10IntWrapperE6getOneEv|"\?getOne@\?\$CannotBeInstantianted@UIntWrapper@@@@QEAAHXZ"}}(%struct.CannotBeInstantianted*
 // CHECK: ret i32
 
 // CHECK-LABEL: define {{.*}}i32 @{{_ZN21CannotBeInstantiantedI10IntWrapperE8incValueES0_|"\?incValue@\?\$CannotBeInstantianted@UIntWrapper@@@@QEAAHUIntWrapper@@@Z"}}(%struct.CannotBeInstantianted* {{.*}}, {{i32|i64|\[1 x i32\]|\%struct\.IntWrapper\* byval\(\%struct\.IntWrapper\)}}
-// CHECK: call i32 @{{_ZN21CannotBeInstantiantedI10IntWrapperE6getOneEv|"\?getOne@\?\$CannotBeInstantianted@UIntWrapper@@@@QEAAHXZ"}}(%struct.CannotBeInstantianted*
+// CHECK: call {{.*}}i32 @{{_ZN21CannotBeInstantiantedI10IntWrapperE6getOneEv|"\?getOne@\?\$CannotBeInstantianted@UIntWrapper@@@@QEAAHXZ"}}(%struct.CannotBeInstantianted*
 // CHECK: ret i32
 
 // CHECK-LABEL: define {{.*}}i32 @{{_ZN21CannotBeInstantiantedI10IntWrapperE6getOneEv|"\?getOne@\?\$CannotBeInstantianted@UIntWrapper@@@@QEAAHXZ"}}(%struct.CannotBeInstantianted*

--- a/test/Interop/Cxx/templates/function-template-irgen.swift
+++ b/test/Interop/Cxx/templates/function-template-irgen.swift
@@ -6,7 +6,7 @@ import FunctionTemplates
 // CHECK: [[RET_VAL:%.*]] = call i32 @{{_Z16passThroughConstIiEKT_S0_|"\?\?\$passThroughConst@H@@YA\?BHH@Z"}}(i32 %0)
 // CHECK: ret i32 [[RET_VAL]]
 
-// CHECK-LABEL: define linkonce_odr {{.*}}i32 @{{_Z16passThroughConstIiEKT_S0_|"\?\?\$passThroughConst@H@@YA\?BHH@Z"}}(i32 %value)
+// CHECK-LABEL: define {{.*}}i32 @{{_Z16passThroughConstIiEKT_S0_|"\?\?\$passThroughConst@H@@YA\?BHH@Z"}}(i32 {{.*}}%value)
 public func testPassThroughConst(x: Int32) -> Int32 {
   return passThroughConst(x)
 }
@@ -15,7 +15,7 @@ public func testPassThroughConst(x: Int32) -> Int32 {
 // CHECK: [[RET_VAL:%.*]] = call i32 @{{_Z11passThroughIiET_S0_|"\?\?\$passThrough@H@@YAHH@Z"}}(i32 %0)
 // CHECK: ret i32 [[RET_VAL]]
 
-// CHECK-LABEL: define linkonce_odr {{.*}}i32 @{{_Z11passThroughIiET_S0_|"\?\?\$passThrough@H@@YAHH@Z"}}(i32 %value)
+// CHECK-LABEL: define {{.*}}i32 @{{_Z11passThroughIiET_S0_|"\?\?\$passThrough@H@@YAHH@Z"}}(i32 {{.*}}%value)
 public func testPassThrough(x: Int32) -> Int32 {
   return passThrough(x)
 }
@@ -24,7 +24,7 @@ public func testPassThrough(x: Int32) -> Int32 {
 // CHECK: [[OUT_VAL:%.*]] = call i32 @{{_Z18addMixedTypeParamsIiiET_S0_T0_|"\?\?\$addMixedTypeParams@HH@@YAHHH@Z"}}(i32 %0, i32 %0)
 // CHECK: ret i32 [[OUT_VAL]]
 
-// CHECK-LABEL: define linkonce_odr {{.*}}i32 @{{_Z18addMixedTypeParamsIiiET_S0_T0_|"\?\?\$addMixedTypeParams@HH@@YAHHH@Z"}}(i32 %a, i32 %b)
+// CHECK-LABEL: define {{.*}}i32 @{{_Z18addMixedTypeParamsIiiET_S0_T0_|"\?\?\$addMixedTypeParams@HH@@YAHHH@Z"}}(i32 {{.*}}%a, i32 {{.*}}%b)
 public func testAddMixedTypeParams(x: Int32) -> Int32 {
   return addMixedTypeParams(x, x)
 }
@@ -33,7 +33,7 @@ public func testAddMixedTypeParams(x: Int32) -> Int32 {
 // CHECK: [[OUT_VAL:%.*]] = call i32 @{{_Z17addSameTypeParamsIiET_S0_S0_|"\?\?\$addSameTypeParams@H@@YAHHH@Z"}}(i32 %0, i32 %0)
 // CHECK: ret i32 [[OUT_VAL]]
 
-// CHECK-LABEL: define linkonce_odr {{.*}}i32 @{{_Z17addSameTypeParamsIiET_S0_S0_|"\?\?\$addSameTypeParams@H@@YAHHH@Z"}}(i32 %a, i32 %b)
+// CHECK-LABEL: define {{.*}}i32 @{{_Z17addSameTypeParamsIiET_S0_S0_|"\?\?\$addSameTypeParams@H@@YAHHH@Z"}}(i32 {{.*}}%a, i32 {{.*}}%b)
 public func testAddSameTypeParams(x: Int32) -> Int32 {
   return addSameTypeParams(x, x)
 }


### PR DESCRIPTION
Due to a now default-enabled `undef` pass (llvm/llvm-project
1b1c8d83d3567a60280291c0adb95d1d60335509), a whole bunch of interop
IRGen tests are failing due to missing `undefs`, even though they don't
matter in these tests at all. Add regex matches so that these tests just
check for the name and types of the functions they care about.