### PR TITLE
[Diagnostics] Diagnose re-labeling failures in ambiguity conditions

### DIFF
--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -536,6 +536,8 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
+
   static RelabelArguments *create(ConstraintSystem &cs,
                                   llvm::ArrayRef<Identifier> correctLabels,
                                   ConstraintLocator *locator);

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -1170,7 +1170,6 @@ func test(arr: [[Int]]) {
   }
 
   arr.map { ($0 as? [Int]).map { A($0) } } // expected-error {{missing argument label 'arg:' in call}} {{36-36=arg: }}
-  // expected-warning@-1 {{conditional cast from '[Int]' to '[Int]' always succeeds}}
 }
 
 func closureWithCaseArchetype<T>(_: T.Type) {

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -902,7 +902,8 @@ func rdar78781552() {
     // expected-error@-1 {{generic struct 'Test' requires that '(((Int) throws -> Bool) throws -> [Int])?' conform to 'RandomAccessCollection'}}
     // expected-error@-2 {{generic parameter 'Content' could not be inferred}} expected-note@-2 {{explicitly specify the generic arguments to fix this issue}}
     // expected-error@-3 {{cannot convert value of type '(((Int) throws -> Bool) throws -> [Int])?' to expected argument type '[(((Int) throws -> Bool) throws -> [Int])?]'}}
-    // expected-error@-4 {{missing argument for parameter 'filter' in call}}
+    // expected-error@-4 {{missing argument label 'data:' in call}}
+    // expected-error@-5 {{missing argument for parameter 'filter' in call}}
   }
 }
 

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -507,6 +507,7 @@ func testLabeledSubscript() {
   // TODO: These ought to work without errors.
   let _ = \AA.[keyPath: k]
   // expected-error@-1 {{cannot convert value of type 'KeyPath<AA, Int>' to expected argument type 'Int'}}
+  // expected-error@-2 {{extraneous argument label 'keyPath:' in call}}
 
   let _ = \AA.[keyPath: \AA.[labeled: 0]] // expected-error {{extraneous argument label 'keyPath:' in call}}
   // expected-error@-1 {{cannot convert value of type 'KeyPath<AA, Int>' to expected argument type 'Int'}}


### PR DESCRIPTION
If all solutions point to the same overload choice that needs
re-labeling it's safe to diagnose it as if there was no ambiguity
because the call site is static.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
