### PR TITLE
[Concurrency] Use #fileID instead of #file so we don't get full paths.

### DIFF
--- a/stdlib/public/Concurrency/Deque.swift
+++ b/stdlib/public/Concurrency/Deque.swift
@@ -417,7 +417,7 @@ struct _Deque<Element> {
 internal func _internalInvariant(
   _ condition: @autoclosure () -> Bool,
   _ message: @autoclosure () -> String = String(),
-  file: StaticString = #file, line: UInt = #line
+  file: StaticString = #fileID, line: UInt = #line
 ) {
   #if INTERNAL_CHECKS_ENABLED
   assert(condition(), message(), file: file, line: line)

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -136,7 +136,7 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   /// the operation closure.
   @discardableResult
   public func withValue<R>(_ valueDuringOperation: Value, operation: () async throws -> R,
-                           file: String = #file, line: UInt = #line) async rethrows -> R {
+                           file: String = #fileID, line: UInt = #line) async rethrows -> R {
     // check if we're not trying to bind a value from an illegal context; this may crash
     _checkIllegalTaskLocalBindingWithinWithTaskGroup(file: file, line: line)
 
@@ -161,7 +161,7 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   /// the operation closure.
   @discardableResult
   public func withValue<R>(_ valueDuringOperation: Value, operation: () throws -> R,
-                           file: String = #file, line: UInt = #line) rethrows -> R {
+                           file: String = #fileID, line: UInt = #line) rethrows -> R {
     // check if we're not trying to bind a value from an illegal context; this may crash
     _checkIllegalTaskLocalBindingWithinWithTaskGroup(file: file, line: line)
 


### PR DESCRIPTION
Fixes rdar://93246032.
