### PR TITLE
[5.7-04182022][Runtime] Define our own hidden global new/delete on Darwin.

### DIFF
--- a/stdlib/public/runtime/Heap.cpp
+++ b/stdlib/public/runtime/Heap.cpp
@@ -119,7 +119,7 @@ void *swift::swift_slowAlloc(size_t size, size_t alignMask) {
 // i.e. 0 < alignment <= _minAllocationAlignment:
 //   The runtime may use either `free` or AlignedFree as long as it is
 //   consistent with allocation with the same alignment.
-void swift::swift_slowDealloc(void *ptr, size_t bytes, size_t alignMask) {
+static void swift_slowDeallocImpl(void *ptr, size_t alignMask) {
   if (alignMask <= MALLOC_ALIGN_MASK) {
 #if defined(__APPLE__) && SWIFT_STDLIB_HAS_DARWIN_LIBMALLOC
     malloc_zone_free(DEFAULT_ZONE(), ptr);
@@ -130,3 +130,34 @@ void swift::swift_slowDealloc(void *ptr, size_t bytes, size_t alignMask) {
     AlignedFree(ptr);
   }
 }
+
+void swift::swift_slowDealloc(void *ptr, size_t bytes, size_t alignMask) {
+  swift_slowDeallocImpl(ptr, alignMask);
+}
+
+#if defined(__APPLE__) && defined(__MACH__) && SWIFT_STDLIB_HAS_DARWIN_LIBMALLOC
+// On Darwin, define our own, hidden operator new/delete implementations. We
+// don't want to pick up any overrides that come from other code, but we also
+// don't want to expose our overrides to any other code. We can't do this
+// directly in C++, as the compiler has an implicit prototype with default
+// visibility. However, if we implement them as C functions using the C++
+// mangled names, the compiler accepts them without complaint, and the linker
+// still links all internal uses with these overrides.
+
+__attribute__((visibility(("hidden")))) extern "C" void *_Znwm(size_t size) {
+  return swift_slowAlloc(size, MALLOC_ALIGN_MASK);
+}
+
+__attribute__((visibility(("hidden")))) extern "C" void _ZdlPv(void *ptr) {
+  swift_slowDeallocImpl(ptr, MALLOC_ALIGN_MASK);
+}
+
+__attribute__((visibility(("hidden")))) extern "C" void *_Znam(size_t size) {
+  return swift_slowAlloc(size, MALLOC_ALIGN_MASK);
+}
+
+__attribute__((visibility(("hidden")))) extern "C" void _ZdaPv(void *ptr) {
+  swift_slowDeallocImpl(ptr, MALLOC_ALIGN_MASK);
+}
+
+#endif


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/58911/ to release/5.7-04182022.

On Darwin, define our own, hidden operator new/delete implementations. We don't want to pick up any overrides that come from other code, but we also don't want to expose our overrides to any other code. We can't do this directly in C++, as the compiler has an implicit prototype with default visibility. However, if we implement them as C functions using the C++ mangled names, the compiler accepts them without complaint, and the linker still links all internal uses with these overrides.

rdar://92795919