### PR TITLE
[stdlib] Add missing terminating quotation character in examples

### DIFF
--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -18,7 +18,7 @@ extension MutableCollection where Self: BidirectionalCollection {
   ///     var characters: [Character] = ["C", "a", "f", "é"]
   ///     characters.reverse()
   ///     print(characters)
-  ///     // Prints "["é", "f", "a", "C"]
+  ///     // Prints "["é", "f", "a", "C"]"
   ///
   /// - Complexity: O(*n*), where *n* is the number of elements in the
   ///   collection.

--- a/stdlib/public/core/Zip.swift
+++ b/stdlib/public/core/Zip.swift
@@ -24,7 +24,7 @@
 ///         print("\(word): \(number)")
 ///     }
 ///     // Prints "one: 1"
-///     // Prints "two: 2
+///     // Prints "two: 2"
 ///     // Prints "three: 3"
 ///     // Prints "four: 4"
 ///
@@ -64,7 +64,7 @@ public func zip<Sequence1, Sequence2>(
 ///         print("\(word): \(number)")
 ///     }
 ///     // Prints "one: 1"
-///     // Prints "two: 2
+///     // Prints "two: 2"
 ///     // Prints "three: 3"
 ///     // Prints "four: 4"
 @frozen // generic-performance


### PR DESCRIPTION
- I found some missing `"` in `Zip.swift` and `Reverse.swift` 🧐