### PR TITLE
Add `-index-ignore-clang-modules` flag to prevent indexing Clang modules

### DIFF
--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -99,6 +99,9 @@ public:
   /// Emit index data for imported serialized swift system modules.
   bool IndexSystemModules = false;
 
+  /// Avoid emitting index data for imported clang modules (pcms).
+  bool IndexIgnoreClangModules = false;
+
   /// If indexing system modules, don't index the stdlib.
   bool IndexIgnoreStdlib = false;
 

--- a/include/swift/Index/IndexRecord.h
+++ b/include/swift/Index/IndexRecord.h
@@ -34,6 +34,9 @@ namespace index {
 ///
 /// \param indexStorePath The location to write the indexing data to.
 ///
+/// \param indexClangModules If true, emit index data for imported clang modules
+/// (pcms).
+///
 /// \param indexSystemModules If true, emit index data for imported serialized
 /// swift system modules.
 ///
@@ -48,9 +51,9 @@ namespace index {
 ///
 /// \param pathRemapper Remapper to use for paths in index data.
 bool indexAndRecord(SourceFile *primarySourceFile, StringRef indexUnitToken,
-                    StringRef indexStorePath, bool indexSystemModules,
-                    bool skipStdlib, bool isDebugCompilation,
-                    StringRef targetTriple,
+                    StringRef indexStorePath, bool indexClangModules,
+                    bool indexSystemModules, bool skipStdlib,
+                    bool isDebugCompilation, StringRef targetTriple,
                     const DependencyTracker &dependencyTracker,
                     const PathRemapper &pathRemapper);
 
@@ -69,6 +72,9 @@ bool indexAndRecord(SourceFile *primarySourceFile, StringRef indexUnitToken,
 ///
 /// \param indexStorePath The location to write the indexing data to.
 ///
+/// \param indexClangModules If true, emit index data for imported clang modules
+/// (pcms).
+///
 /// \param indexSystemModules If true, emit index data for imported serialized
 /// swift system modules.
 ///
@@ -84,8 +90,9 @@ bool indexAndRecord(SourceFile *primarySourceFile, StringRef indexUnitToken,
 /// \param pathRemapper Remapper to use for paths in index data.
 bool indexAndRecord(ModuleDecl *module, ArrayRef<std::string> indexUnitTokens,
                     StringRef moduleUnitToken, StringRef indexStorePath,
-                    bool indexSystemModules, bool skipStdlib,
-                    bool isDebugCompilation, StringRef targetTriple,
+                    bool indexClangModules, bool indexSystemModules,
+                    bool skipStdlib, bool isDebugCompilation,
+                    StringRef targetTriple,
                     const DependencyTracker &dependencyTracker,
                     const PathRemapper &pathRemapper);
 // FIXME: indexUnitTokens could be StringRef, but that creates an impedance

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1253,6 +1253,10 @@ def index_unit_output_path : Separate<["-"], "index-unit-output-path">,
   Flags<[FrontendOption, ArgumentIsPath]>, MetaVarName<"<path>">,
   HelpText<"Use <path> as the output path in the produced index data.">;
 
+def index_ignore_clang_modules : Flag<["-"], "index-ignore-clang-modules">,
+  Flags<[FrontendOption]>,
+  HelpText<"Avoid indexing clang modules (pcms)">;
+
 def index_ignore_system_modules : Flag<["-"], "index-ignore-system-modules">,
   Flags<[NoInteractiveOption]>,
   HelpText<"Avoid indexing system modules">;

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -573,6 +573,7 @@ ToolChain::constructInvocation(const CompileJobAction &job,
     context.Args.AddLastArg(Arguments, options::OPT_index_store_path);
     if (!context.Args.hasArg(options::OPT_index_ignore_system_modules))
       Arguments.push_back("-index-system-modules");
+    context.Args.AddLastArg(Arguments, options::OPT_index_ignore_clang_modules);
   }
 
   if (context.Args.hasArg(options::OPT_debug_info_store_invocation) ||

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -69,6 +69,7 @@ bool ArgsToFrontendOptionsConverter::convert(
   if (const Arg *A = Args.getLastArg(OPT_bridging_header_directory_for_print)) {
     Opts.BridgingHeaderDirForPrint = A->getValue();
   }
+  Opts.IndexIgnoreClangModules |= Args.hasArg(OPT_index_ignore_clang_modules);
   Opts.IndexSystemModules |= Args.hasArg(OPT_index_system_modules);
   Opts.IndexIgnoreStdlib |= Args.hasArg(OPT_index_ignore_stdlib);
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1760,7 +1760,9 @@ static void emitIndexDataForSourceFile(SourceFile *PrimarySourceFile,
     if (OutputFile.empty())
       OutputFile = PSPs.OutputFilename;
     (void) index::indexAndRecord(PrimarySourceFile, OutputFile,
-                                 opts.IndexStorePath, opts.IndexSystemModules,
+                                 opts.IndexStorePath,
+                                 !opts.IndexIgnoreClangModules,
+                                 opts.IndexSystemModules,
                                  opts.IndexIgnoreStdlib, isDebugCompilation,
                                  Invocation.getTargetTriple(),
                                  *Instance.getDependencyTracker(),
@@ -1775,6 +1777,7 @@ static void emitIndexDataForSourceFile(SourceFile *PrimarySourceFile,
                                  opts.InputsAndOutputs
                                    .copyIndexUnitOutputFilenames(),
                                  moduleToken, opts.IndexStorePath,
+                                 !opts.IndexIgnoreClangModules,
                                  opts.IndexSystemModules,
                                  opts.IndexIgnoreStdlib,
                                  isDebugCompilation,

--- a/lib/Index/IndexRecord.cpp
+++ b/lib/Index/IndexRecord.cpp
@@ -376,6 +376,7 @@ getModuleInfoFromOpaqueModule(clang::index::writer::OpaqueModule mod,
 static bool
 emitDataForSwiftSerializedModule(ModuleDecl *module,
                                  StringRef indexStorePath,
+                                 bool indexClangModules,
                                  bool indexSystemModules,
                                  bool skipStdlib,
                                  StringRef targetTriple,
@@ -387,6 +388,7 @@ emitDataForSwiftSerializedModule(ModuleDecl *module,
 
 static void addModuleDependencies(ArrayRef<ImportedModule> imports,
                                   StringRef indexStorePath,
+                                  bool indexClangModules,
                                   bool indexSystemModules,
                                   bool skipStdlib,
                                   StringRef targetTriple,
@@ -424,7 +426,8 @@ static void addModuleDependencies(ArrayRef<ImportedModule> imports,
           bool withoutUnitName = true;
           if (FU->getKind() == FileUnitKind::ClangModule) {
             auto clangModUnit = cast<ClangModuleUnit>(LFU);
-            if (!clangModUnit->isSystemModule() || indexSystemModules) {
+            if ((!clangModUnit->isSystemModule() || indexSystemModules)
+                && indexClangModules) {
               withoutUnitName = false;
               if (auto clangMod = clangModUnit->getUnderlyingClangModule()) {
                 moduleName = clangMod->getTopLevelModuleName();
@@ -443,6 +446,7 @@ static void addModuleDependencies(ArrayRef<ImportedModule> imports,
             if (mod->isSystemModule() && indexSystemModules &&
                 (!skipStdlib || !mod->isStdlibModule())) {
               emitDataForSwiftSerializedModule(mod, indexStorePath,
+                                               indexClangModules,
                                                indexSystemModules, skipStdlib,
                                                targetTriple, clangCI, diags,
                                                unitWriter,
@@ -472,6 +476,7 @@ static void addModuleDependencies(ArrayRef<ImportedModule> imports,
 static bool
 emitDataForSwiftSerializedModule(ModuleDecl *module,
                                  StringRef indexStorePath,
+                                 bool indexClangModules,
                                  bool indexSystemModules,
                                  bool skipStdlib,
                                  StringRef targetTriple,
@@ -596,9 +601,10 @@ emitDataForSwiftSerializedModule(ModuleDecl *module,
   module->getImportedModules(imports, {ModuleDecl::ImportFilterKind::Exported,
                                        ModuleDecl::ImportFilterKind::Default});
   StringScratchSpace moduleNameScratch;
-  addModuleDependencies(imports, indexStorePath, indexSystemModules, skipStdlib,
-                        targetTriple, clangCI, diags, unitWriter,
-                        moduleNameScratch, pathRemapper, initialFile);
+  addModuleDependencies(imports, indexStorePath, indexClangModules,
+                        indexSystemModules, skipStdlib, targetTriple, clangCI,
+                        diags, unitWriter, moduleNameScratch, pathRemapper,
+                        initialFile);
 
   if (unitWriter.write(error)) {
     diags.diagnose(SourceLoc(), diag::error_write_index_unit, error);
@@ -610,9 +616,9 @@ emitDataForSwiftSerializedModule(ModuleDecl *module,
 
 static bool
 recordSourceFileUnit(SourceFile *primarySourceFile, StringRef indexUnitToken,
-                     StringRef indexStorePath, bool indexSystemModules,
-                     bool skipStdlib, bool isDebugCompilation,
-                     StringRef targetTriple,
+                     StringRef indexStorePath, bool indexClangModules,
+                     bool indexSystemModules, bool skipStdlib,
+                     bool isDebugCompilation, StringRef targetTriple,
                      ArrayRef<const clang::FileEntry *> fileDependencies,
                      const clang::CompilerInstance &clangCI,
                      const PathRemapper &pathRemapper,
@@ -638,9 +644,10 @@ recordSourceFileUnit(SourceFile *primarySourceFile, StringRef indexUnitToken,
                 ModuleDecl::ImportFilterKind::Default,
                 ModuleDecl::ImportFilterKind::ImplementationOnly});
   StringScratchSpace moduleNameScratch;
-  addModuleDependencies(imports, indexStorePath, indexSystemModules, skipStdlib,
-                        targetTriple, clangCI, diags, unitWriter,
-                        moduleNameScratch, pathRemapper, primarySourceFile);
+  addModuleDependencies(imports, indexStorePath, indexClangModules,
+                        indexSystemModules, skipStdlib, targetTriple, clangCI,
+                        diags, unitWriter, moduleNameScratch, pathRemapper,
+                        primarySourceFile);
 
   // File dependencies.
   for (auto *F : fileDependencies)
@@ -690,6 +697,7 @@ collectFileDependencies(llvm::SetVector<const clang::FileEntry *> &result,
 bool index::indexAndRecord(SourceFile *primarySourceFile,
                            StringRef indexUnitToken,
                            StringRef indexStorePath,
+                           bool indexClangModules,
                            bool indexSystemModules,
                            bool skipStdlib,
                            bool isDebugCompilation,
@@ -720,7 +728,8 @@ bool index::indexAndRecord(SourceFile *primarySourceFile,
 #endif
 
   return recordSourceFileUnit(primarySourceFile, indexUnitToken,
-                              indexStorePath, indexSystemModules, skipStdlib,
+                              indexStorePath, indexClangModules,
+                              indexSystemModules, skipStdlib,
                               isDebugCompilation, targetTriple,
                               fileDependencies.getArrayRef(),
                               clangCI, pathRemapper, diags);
@@ -730,6 +739,7 @@ bool index::indexAndRecord(ModuleDecl *module,
                            ArrayRef<std::string> indexUnitTokens,
                            StringRef moduleUnitToken,
                            StringRef indexStorePath,
+                           bool indexClangModules,
                            bool indexSystemModules,
                            bool skipStdlib,
                            bool isDebugCompilation,
@@ -768,7 +778,8 @@ bool index::indexAndRecord(ModuleDecl *module,
         return true;
       }
       if (recordSourceFileUnit(SF, indexUnitTokens[unitIndex],
-                               indexStorePath, indexSystemModules, skipStdlib,
+                               indexStorePath, indexClangModules,
+                               indexSystemModules, skipStdlib,
                                isDebugCompilation, targetTriple,
                                fileDependencies.getArrayRef(),
                                clangCI, pathRemapper, diags))

--- a/lib/Index/IndexRecord.cpp
+++ b/lib/Index/IndexRecord.cpp
@@ -426,16 +426,16 @@ static void addModuleDependencies(ArrayRef<ImportedModule> imports,
           bool withoutUnitName = true;
           if (FU->getKind() == FileUnitKind::ClangModule) {
             auto clangModUnit = cast<ClangModuleUnit>(LFU);
-            if ((!clangModUnit->isSystemModule() || indexSystemModules)) {
-              withoutUnitName = !indexClangModules;
-              if (auto clangMod = clangModUnit->getUnderlyingClangModule()) {
-                moduleName = clangMod->getTopLevelModuleName();
-                // FIXME: clang's -Rremarks do not seem to go through Swift's
-                // diagnostic emitter.
-                if (indexClangModules)
-                  clang::index::emitIndexDataForModuleFile(clangMod,
-                                                           clangCI, unitWriter);
-              }
+            bool shouldIndexModule = indexClangModules &&
+                (!clangModUnit->isSystemModule() || indexSystemModules);
+            withoutUnitName = !shouldIndexModule;
+            if (auto clangMod = clangModUnit->getUnderlyingClangModule()) {
+              moduleName = clangMod->getTopLevelModuleName();
+              // FIXME: clang's -Rremarks do not seem to go through Swift's
+              // diagnostic emitter.
+              if (shouldIndexModule)
+                clang::index::emitIndexDataForModuleFile(clangMod,
+                                                         clangCI, unitWriter);
             }
           } else {
             // Serialized AST file.

--- a/lib/Index/IndexRecord.cpp
+++ b/lib/Index/IndexRecord.cpp
@@ -426,15 +426,15 @@ static void addModuleDependencies(ArrayRef<ImportedModule> imports,
           bool withoutUnitName = true;
           if (FU->getKind() == FileUnitKind::ClangModule) {
             auto clangModUnit = cast<ClangModuleUnit>(LFU);
-            if ((!clangModUnit->isSystemModule() || indexSystemModules)
-                && indexClangModules) {
-              withoutUnitName = false;
+            if ((!clangModUnit->isSystemModule() || indexSystemModules)) {
+              withoutUnitName = !indexClangModules;
               if (auto clangMod = clangModUnit->getUnderlyingClangModule()) {
                 moduleName = clangMod->getTopLevelModuleName();
                 // FIXME: clang's -Rremarks do not seem to go through Swift's
                 // diagnostic emitter.
-                clang::index::emitIndexDataForModuleFile(clangMod,
-                                                         clangCI, unitWriter);
+                if (indexClangModules)
+                  clang::index::emitIndexDataForModuleFile(clangMod,
+                                                           clangCI, unitWriter);
               }
             }
           } else {

--- a/test/Index/Store/unit-pcm-dependency.swift
+++ b/test/Index/Store/unit-pcm-dependency.swift
@@ -1,11 +1,11 @@
 // RUN: rm -rf %t
 // RUN: %target-swift-frontend -disable-implicit-concurrency-module-import -index-store-path %t/idx -primary-file %s -o %t/s1.o -I %S/Inputs -typecheck -module-cache-path %t/mcp -enable-objc-interop
-// RUN: c-index-test core -print-unit %t/idx | %FileCheck %s -check-prefix=FILE1
+// RUN: c-index-test core -print-unit %t/idx | %FileCheck %s -check-prefixes=FILE1,FILE1-PCM
 
 // If the module cache already exists, the pcm gets indexed.
 // RUN: rm -rf %t/idx
 // RUN: %target-swift-frontend -disable-implicit-concurrency-module-import -index-store-path %t/idx -primary-file %s -o %t/s1.o -I %S/Inputs -typecheck -module-cache-path %t/mcp -enable-objc-interop
-// RUN: c-index-test core -print-unit %t/idx | %FileCheck %s -check-prefix=FILE1
+// RUN: c-index-test core -print-unit %t/idx | %FileCheck %s -check-prefixes=FILE1,FILE1-PCM
 
 // FIXME: index the bridging header!
 
@@ -13,8 +13,18 @@
 // RUN: echo 'import ClangModuleA' > %t/s2.swift
 // RUN: %target-swift-frontend -disable-implicit-concurrency-module-import -index-store-path %t/idx %s %t/s2.swift -o %t/s1.o -o %t/s2.o -I %S/Inputs -c -emit-module -module-name main -emit-module-path %t/main.swiftmodule -module-cache-path %t/mcp -enable-objc-interop
 // RUN: c-index-test core -print-unit %t/idx > %t/both.txt
-// RUN: %FileCheck %s -check-prefix=FILE1 < %t/both.txt
-// RUN: %FileCheck %s -check-prefix=FILE2 < %t/both.txt
+// RUN: %FileCheck %s -check-prefixes=FILE1,FILE1-PCM < %t/both.txt
+// RUN: %FileCheck %s -check-prefixes=FILE2,FILE2-PCM < %t/both.txt
+
+
+// Test -index-ignore-clang-modules.
+
+// RUN: %empty-directory(%t)
+// RUN: echo 'import ClangModuleA' > %t/s2.swift
+// RUN: %target-swift-frontend -disable-implicit-concurrency-module-import -index-store-path %t/idx -index-ignore-clang-modules %s %t/s2.swift -o %t/s1.o -o %t/s2.o -I %S/Inputs -c -emit-module -module-name main -emit-module-path %t/main.swiftmodule -module-cache-path %t/mcp -enable-objc-interop
+// RUN: c-index-test core -print-unit %t/idx > %t/both.txt
+// RUN: %FileCheck %s -check-prefixes=FILE1,FILE1-IGNORE < %t/both.txt --dump-input-filter all
+// RUN: %FileCheck %s -check-prefixes=FILE2,FILE2-IGNORE < %t/both.txt
 
 
 import ClangModuleB
@@ -26,22 +36,26 @@ func test() {
   funcB()
 }
 
-// FILE1: ClangModuleA-
-// FILE1: --------
-// FILE1: is-system: 0
-// FILE1: has-main: 0
-// FILE1: DEPEND START
-// FILE1: Record | user | {{.*}}ClangModuleA.h | ClangModuleA.h-
-// FILE1: DEPEND END
+// FILE1-IGNORE-NOT: ClangModuleA-
 
-// FILE1: ClangModuleB-
-// FILE1: --------
-// FILE1: is-system: 0
-// FILE1: has-main: 0
-// FILE1: DEPEND START
-// FILE1: Unit | user | ClangModuleA | {{.*}}ClangModuleA-{{.*}}.pcm | ClangModuleA-{{.*}}.pcm-
-// FILE1: Record | user | {{.*}}ClangModuleB.h | ClangModuleB.h-
-// FILE1: DEPEND END
+// FILE1-PCM: ClangModuleA-
+// FILE1-PCM: --------
+// FILE1-PCM: is-system: 0
+// FILE1-PCM: has-main: 0
+// FILE1-PCM: DEPEND START
+// FILE1-PCM: Record | user | {{.*}}ClangModuleA.h | ClangModuleA.h-
+// FILE1-PCM: DEPEND END
+
+// FILE1-IGNORE-NOT: ClangModuleB-
+
+// FILE1-PCM: ClangModuleB-
+// FILE1-PCM: --------
+// FILE1-PCM: is-system: 0
+// FILE1-PCM: has-main: 0
+// FILE1-PCM: DEPEND START
+// FILE1-PCM: Unit | user | ClangModuleA | {{.*}}ClangModuleA-{{.*}}.pcm | ClangModuleA-{{.*}}.pcm-
+// FILE1-PCM: Record | user | {{.*}}ClangModuleB.h | ClangModuleB.h-
+// FILE1-PCM: DEPEND END
 
 // FILE1: s1.o-
 // FILE1: --------
@@ -51,8 +65,10 @@ func test() {
 // FILE1-NOT: Unit |{{.*}}ClangModuleA
 // FILE1: Unit | system | Swift | {{.*}}Swift.swiftmodule
 // FILE1-NOT: Unit |{{.*}}ClangModuleA
-// FILE1: Unit | user | ClangModuleB | {{.*}}ClangModuleB-{{[A-Z0-9]*}}.pcm | ClangModuleB-{{[A-Z0-9]*}}.pcm-
-// FILE1: Unit | user | ClangModuleC | {{.*}}ClangModuleC-{{[A-Z0-9]*}}.pcm | ClangModuleC-{{[A-Z0-9]*}}.pcm-
+// FILE1-PCM: Unit | user | ClangModuleB | {{.*}}ClangModuleB-{{[A-Z0-9]*}}.pcm | ClangModuleB-{{[A-Z0-9]*}}.pcm-
+// FILE1-PCM: Unit | user | ClangModuleC | {{.*}}ClangModuleC-{{[A-Z0-9]*}}.pcm | ClangModuleC-{{[A-Z0-9]*}}.pcm-
+// FILE1-IGNORE: Unit | user | ClangModuleB | {{.*}}ClangModuleB-{{[A-Z0-9]*}}.pcm
+// FILE1-IGNORE: Unit | user | Sub1 | {{.*}}ClangModuleC-{{[A-Z0-9]*}}.pcm
 // FILE1-NOT: Unit |{{.*}}ClangModuleA
 // FILE1: Record | user | {{.*}}unit-pcm-dependency.swift | unit-pcm-dependency.swift-
 // FILE1-NOT: Unit |{{.*}}ClangModuleA
@@ -71,7 +87,8 @@ func test() {
 // FILE2: Unit | system | Swift | {{.*}}Swift.swiftmodule
 // FILE2-NOT: Unit |{{.*}}ClangModuleB
 // FILE2-NOT: Record
-// FILE2: Unit | user | ClangModuleA | {{.*}}ClangModuleA-{{[A-Z0-9]*}}.pcm | ClangModuleA-{{[A-Z0-9]*}}.pcm-
+// FILE2-PCM: Unit | user | ClangModuleA | {{.*}}ClangModuleA-{{[A-Z0-9]*}}.pcm | ClangModuleA-{{[A-Z0-9]*}}.pcm-
+// FILE2-IGNORE: Unit | user | ClangModuleA | {{.*}}ClangModuleA-{{[A-Z0-9]*}}.pcm
 // FILE2: Record | user | {{.*}}s2.swift | s2.swift-
 // FILE2-NOT: Unit |{{.*}}ClangModuleB
 // FILE2-NOT: Record

--- a/test/Index/Store/unit-pcm-dependency.swift
+++ b/test/Index/Store/unit-pcm-dependency.swift
@@ -68,7 +68,7 @@ func test() {
 // FILE1-PCM: Unit | user | ClangModuleB | {{.*}}ClangModuleB-{{[A-Z0-9]*}}.pcm | ClangModuleB-{{[A-Z0-9]*}}.pcm-
 // FILE1-PCM: Unit | user | ClangModuleC | {{.*}}ClangModuleC-{{[A-Z0-9]*}}.pcm | ClangModuleC-{{[A-Z0-9]*}}.pcm-
 // FILE1-IGNORE: Unit | user | ClangModuleB | {{.*}}ClangModuleB-{{[A-Z0-9]*}}.pcm
-// FILE1-IGNORE: Unit | user | Sub1 | {{.*}}ClangModuleC-{{[A-Z0-9]*}}.pcm
+// FILE1-IGNORE: Unit | user | ClangModuleC | {{.*}}ClangModuleC-{{[A-Z0-9]*}}.pcm
 // FILE1-NOT: Unit |{{.*}}ClangModuleA
 // FILE1: Record | user | {{.*}}unit-pcm-dependency.swift | unit-pcm-dependency.swift-
 // FILE1-NOT: Unit |{{.*}}ClangModuleA


### PR DESCRIPTION
This flag avoids indexing imported clang modules (PCMs), similar to the `-index-ignore-system-modules` except it applies to the Clang PCMs.

This flag is useful to avoid repeated indexing of the same Clang PCM during remote builds - useful with explicit module (PCMs) builds that execute remotely, where the build system will index the PCM once during its generation and there's no need to ever index it again.