### PR TITLE
[5.7][SourceKit] Add whether a property is dynamic

### DIFF
--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -158,9 +158,9 @@ struct ResolvedCursorInfo {
   Type ContainerType;
   Stmt *TrailingStmt = nullptr;
   Expr *TrailingExpr = nullptr;
-  /// If this is a call, whether it is "dynamic", see ide::isDynamicCall.
+  /// It this is a ref, whether it is "dynamic". See \c ide::isDynamicRef.
   bool IsDynamic = false;
-  /// If this is a call, the types of the base (multiple in the case of
+  /// If this is a dynamic ref, the types of the base (multiple in the case of
   /// protocol composition).
   SmallVector<NominalTypeDecl *, 1> ReceiverTypes;
 
@@ -607,11 +607,22 @@ bool isBeingCalled(ArrayRef<Expr*> ExprStack);
 /// stack in eg. the case of a `DotSyntaxCallExpr`).
 Expr *getBase(ArrayRef<Expr *> ExprStack);
 
-/// Assuming that we have a call, returns whether or not it is "dynamic" based
-/// on its base expression and decl of the callee. Note that this is not
-/// Swift's "dynamic" modifier (`ValueDecl::isDynamic`), but rathar "can call a
-/// function in a conformance/subclass".
-bool isDynamicCall(Expr *Base, ValueDecl *D);
+/// Returns whether or not \p D could be overridden, eg. it's a member of a
+/// protocol, a non-final method in a class, etc.
+bool isDeclOverridable(ValueDecl *D);
+
+/// Given a reference to a member \p D and its \p Base expression, return
+/// whether that declaration could be dynamic, ie. may resolve to some other
+/// declaration. Note that while the decl itself itself may be overridable, a
+/// reference to it is not necessarily "dynamic". Furthermore,  is *not* the
+/// `dynamic` keyword.
+///
+/// A simple example is `SomeType.classMethod()`. `classMethod`
+/// is itself overridable, but that particular reference to it *has* to be the
+/// one in `SomeType`. Contrast that to `type(of: foo).classMethod()` where
+/// `classMethod` could be any `classMethod` up or down the hierarchy from the
+/// type of the \p Base expression.
+bool isDynamicRef(Expr *Base, ValueDecl *D);
 
 /// Adds the resolved nominal types of \p Base to \p Types.
 void getReceiverType(Expr *Base,

--- a/lib/IDE/IDERequests.cpp
+++ b/lib/IDE/IDERequests.cpp
@@ -119,9 +119,9 @@ bool CursorInfoResolver::tryResolve(ValueDecl *D, TypeDecl *CtorTyRef,
     }
   }
 
-  if (isBeingCalled(ExprStack)) {
-    if (Expr *BaseE = getBase(ExprStack)) {
-      CursorInfo.IsDynamic = isDynamicCall(BaseE, D);
+  if (Expr *BaseE = getBase(ExprStack)) {
+    if (isDynamicRef(BaseE, D)) {
+      CursorInfo.IsDynamic = true;
       ide::getReceiverType(BaseE, CursorInfo.ReceiverTypes);
     }
   }

--- a/lib/IDE/Utils.cpp
+++ b/lib/IDE/Utils.cpp
@@ -1252,12 +1252,44 @@ Expr *swift::ide::getBase(ArrayRef<Expr *> ExprStack) {
   return Base;
 }
 
-bool swift::ide::isDynamicCall(Expr *Base, ValueDecl *D) {
-  auto TyD = D->getDeclContext()->getSelfNominalTypeDecl();
-  if (!TyD)
+bool swift::ide::isDeclOverridable(ValueDecl *D) {
+  auto *NTD = D->getDeclContext()->getSelfNominalTypeDecl();
+  if (!NTD)
     return false;
 
-  if (isa<StructDecl>(TyD) || isa<EnumDecl>(TyD) || D->isFinal())
+  // Only classes and protocols support overridding by subtypes.
+  if (!(isa<ClassDecl>(NTD) || isa<ProtocolDecl>(NTD)))
+    return false;
+
+  // Decls where either they themselves are final or their containing type is
+  // final cannot be overridden. Actors cannot be subclassed and thus the given
+  // decl also can't be overridden.
+  if (D->isFinal() || NTD->isFinal() || NTD->isActor())
+    return false;
+
+  // No need to check accessors here - willSet/didSet are not "overridable",
+  // but that's already covered by the `isFinal` check above (they are both
+  // final).
+
+  // Static functions on classes cannot be overridden. Static functions on
+  // structs and enums are already covered by the more general check above.
+  if (isa<ClassDecl>(NTD)) {
+    if (auto *FD = dyn_cast<FuncDecl>(D)) {
+      if (FD->isStatic() &&
+          FD->getCorrectStaticSpelling() == StaticSpellingKind::KeywordStatic)
+        return false;
+    } else if (auto *ASD = dyn_cast<AbstractStorageDecl>(D)) {
+      if (ASD->isStatic() &&
+          ASD->getCorrectStaticSpelling() == StaticSpellingKind::KeywordStatic)
+        return false;
+    }
+  }
+
+  return true;
+}
+
+bool swift::ide::isDynamicRef(Expr *Base, ValueDecl *D) {
+  if (!isDeclOverridable(D))
     return false;
 
   // super.method()
@@ -1268,19 +1300,17 @@ bool swift::ide::isDynamicCall(Expr *Base, ValueDecl *D) {
   if (Base->isSuperExpr())
     return false;
 
-  // `SomeType.staticOrClassMethod()`
+  // `SomeType.staticOrClassMethod()` spelled directly, so this must be a ref
+  // to this exact decl.
   if (isa<TypeExpr>(Base))
     return false;
 
-  // `type(of: foo).staticOrClassMethod()`, not "dynamic" if the instance type
-  // is a struct/enum or if it is a class and the function is a static method
-  // (rather than a class method).
+  // `type(of: foo).staticOrClassMethod()`. A static method may be "dynamic"
+  // here, but not if the instance type is a struct/enum.
   if (auto IT = Base->getType()->getAs<MetatypeType>()) {
     auto InstanceType = IT->getInstanceType();
     if (InstanceType->getStructOrBoundGenericStruct() ||
         InstanceType->getEnumOrBoundGenericEnum())
-      return false;
-    if (InstanceType->getClassOrBoundGenericClass() && D->isFinal())
       return false;
   }
 

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -922,6 +922,7 @@ private:
   }
   bool reportPseudoAccessor(AbstractStorageDecl *D, AccessorKind AccKind,
                             bool IsRef, SourceLoc Loc);
+  bool reportIsDynamicRef(ValueDecl *D, IndexSymbol &Info);
 
   bool finishCurrentEntity() {
     Entity CurrEnt = EntitiesStack.pop_back_val();
@@ -1336,24 +1337,6 @@ bool IndexSwiftASTWalker::reportRelatedTypeRef(const TypeLoc &Ty, SymbolRoleSet 
   return true;
 }
 
-static bool isDynamicVarAccessorOrFunc(ValueDecl *D, SymbolInfo symInfo) {
-  if (auto NTD = D->getDeclContext()->getSelfNominalTypeDecl()) {
-    bool isClassOrProtocol = isa<ClassDecl>(NTD) || isa<ProtocolDecl>(NTD);
-    bool isInternalAccessor =
-      symInfo.SubKind == SymbolSubKind::SwiftAccessorWillSet ||
-      symInfo.SubKind == SymbolSubKind::SwiftAccessorDidSet ||
-      symInfo.SubKind == SymbolSubKind::SwiftAccessorAddressor ||
-      symInfo.SubKind == SymbolSubKind::SwiftAccessorMutableAddressor;
-    if (isClassOrProtocol &&
-        symInfo.Kind != SymbolKind::StaticMethod &&
-        !isInternalAccessor &&
-        !D->isFinal()) {
-      return true;
-    }
-  }
-  return false;
-}
-
 bool IndexSwiftASTWalker::reportPseudoAccessor(AbstractStorageDecl *D,
                                                AccessorKind AccKind, bool IsRef,
                                                SourceLoc Loc) {
@@ -1377,7 +1360,7 @@ bool IndexSwiftASTWalker::reportPseudoAccessor(AbstractStorageDecl *D,
     Info.symInfo.SubKind = getSubKindForAccessor(AccKind);
     Info.roles |= (SymbolRoleSet)SymbolRole::Implicit;
     Info.group = "";
-    if (isDynamicVarAccessorOrFunc(D, Info.symInfo)) {
+    if (ide::isDeclOverridable(D)) {
       Info.roles |= (SymbolRoleSet)SymbolRole::Dynamic;
     }
     return false;
@@ -1569,6 +1552,27 @@ bool IndexSwiftASTWalker::reportRef(ValueDecl *D, SourceLoc Loc,
   return finishCurrentEntity();
 }
 
+bool IndexSwiftASTWalker::reportIsDynamicRef(ValueDecl *D, IndexSymbol &Info) {
+  Expr *BaseE = ide::getBase(ExprStack);
+  if (!BaseE)
+    return false;
+
+  if (!ide::isDynamicRef(BaseE, D))
+    return false;
+
+  Info.roles |= (unsigned)SymbolRole::Dynamic;
+
+  SmallVector<NominalTypeDecl *, 1> Types;
+  ide::getReceiverType(BaseE, Types);
+  for (auto *ReceiverTy : Types) {
+    if (addRelation(Info, (SymbolRoleSet) SymbolRole::RelationReceivedBy,
+                    ReceiverTy))
+      return true;
+  }
+
+  return false;
+}
+
 bool IndexSwiftASTWalker::reportImplicitConformance(ValueDecl *witness, ValueDecl *requirement,
                                                     Decl *container) {
   if (!shouldIndex(witness, /*IsRef=*/true))
@@ -1658,7 +1662,7 @@ bool IndexSwiftASTWalker::initFuncDeclIndexSymbol(FuncDecl *D,
   if (initIndexSymbol(D, D->getLoc(/*SerializedOK*/false), /*IsRef=*/false, Info))
     return true;
 
-  if (isDynamicVarAccessorOrFunc(D, Info.symInfo)) {
+  if (ide::isDeclOverridable(D)) {
     Info.roles |= (SymbolRoleSet)SymbolRole::Dynamic;
   }
 
@@ -1702,20 +1706,9 @@ bool IndexSwiftASTWalker::initFuncRefIndexSymbol(ValueDecl *D, SourceLoc Loc,
       return true;
   }
 
-  Expr *BaseE = ide::getBase(ExprStack);
-  if (!BaseE)
-    return false;
+  if (reportIsDynamicRef(D, Info))
+    return true;
 
-  if (ide::isDynamicCall(BaseE, D))
-    Info.roles |= (unsigned)SymbolRole::Dynamic;
-
-  SmallVector<NominalTypeDecl *, 1> Types;
-  ide::getReceiverType(BaseE, Types);
-  for (auto *ReceiverTy : Types) {
-    if (addRelation(Info, (SymbolRoleSet) SymbolRole::RelationReceivedBy,
-                    ReceiverTy))
-      return true;
-  }
   return false;
 }
 
@@ -1739,6 +1732,9 @@ bool IndexSwiftASTWalker::initVarRefIndexSymbols(Expr *CurrentE, ValueDecl *D,
   case swift::AccessKind::Write:
     Info.roles |= (unsigned)SymbolRole::Write;
   }
+
+  if (reportIsDynamicRef(D, Info))
+    return true;
 
   return false;
 }

--- a/test/Index/Store/record-sourcefile.swift
+++ b/test/Index/Store/record-sourcefile.swift
@@ -7,9 +7,9 @@
 // CHECK: record-sourcefile.swift
 // CHECK: ------------
 // CHECK: struct/Swift | S1 | s:4file2S1V | <no-cgname> | Def,Ref,RelCont -
-// CHECK: instance-method/acc-get/Swift | getter:property | s:4file2S1V8propertySivg | <no-cgname> | Def,Ref,Call,Impl,RelChild,RelRec,RelCall,RelAcc,RelCont -
+// CHECK: instance-method/acc-get/Swift | getter:property | s:4file2S1V8propertySivg | <no-cgname> | Def,Ref,Call,Impl,RelChild,RelCall,RelAcc,RelCont -
 // CHECK: instance-property/Swift | property | [[property_USR:s:4file2S1V8propertySivp]] | <no-cgname> | Def,Ref,Read,RelChild,RelCont -
-// CHECK: static-method/acc-get/Swift | getter:staticProperty | s:4file2S1V14staticPropertySivgZ | <no-cgname> | Def,Ref,Call,Impl,RelChild,RelRec,RelCall,RelAcc,RelCont -
+// CHECK: static-method/acc-get/Swift | getter:staticProperty | s:4file2S1V14staticPropertySivgZ | <no-cgname> | Def,Ref,Call,Impl,RelChild,RelCall,RelAcc,RelCont -
 // CHECK: static-property/Swift | staticProperty | s:{{.*}} | <no-cgname> | Def,Ref,Read,RelChild,RelCont -
 // CHECK: instance-property/Swift | computedPropertyGetSet | s:{{.*}} | <no-cgname> | Def,RelChild -
 // CHECK: struct/Swift | Int | s:Si | <no-cgname> | Ref,RelCont -
@@ -83,9 +83,8 @@ struct S1 {
 // CHECK-NEXT: RelChild | [[S1_USR]]
   func method() {
     _ = self
-// CHECK: [[@LINE+4]]:9 | instance-method/acc-get/Swift | s:{{.*}} | Ref,Call,Impl,RelRec,RelCall,RelCont | rel: 2
+// CHECK: [[@LINE+3]]:9 | instance-method/acc-get/Swift | s:{{.*}} | Ref,Call,Impl,RelCall,RelCont | rel: 1
 // CHECK-NEXT: RelCall,RelCont | [[method_USR]]
-// CHECK-NEXT: RelRec | [[S1_USR]]
 // CHECK: [[@LINE+1]]:9 | instance-property/Swift | s:{{.*}} | Ref,Read,RelCont | rel: 1
     _ = property
   }
@@ -93,10 +92,9 @@ struct S1 {
 // CHECK: [[@LINE+2]]:15 | static-method/Swift | [[staticMethod_USR:s:.*]] | Def,RelChild | rel: 1
 // CHECK-NEXT: RelChild | [[S1_USR]]
   static func staticMethod() {
-// CHECK: [[@LINE+5]]:9 | struct/Swift | s:{{.*}} | Ref,RelCont | rel: 1
-// CHECK: [[@LINE+4]]:12 | static-method/acc-get/Swift | s:{{.*}} | Ref,Call,Impl,RelRec,RelCall,RelCont | rel: 2
+// CHECK: [[@LINE+4]]:9 | struct/Swift | s:{{.*}} | Ref,RelCont | rel: 1
+// CHECK: [[@LINE+3]]:12 | static-method/acc-get/Swift | s:{{.*}} | Ref,Call,Impl,RelCall,RelCont | rel: 1
 // CHECK-NEXT: RelCall,RelCont | [[staticMethod_USR]]
-// CHECK-NEXT: RelRec | [[S1_USR]]
 // CHECK: [[@LINE+1]]:12 | static-property/Swift | s:{{.*}} | Ref,Read,RelCont | rel: 1
     _ = S1.staticProperty
   }

--- a/test/Index/index_callasfunction.swift
+++ b/test/Index/index_callasfunction.swift
@@ -18,30 +18,24 @@ let global = 1
 
 add3(global)
 // CHECK: [[@LINE-1]]:1 | variable/Swift | add3 | [[add3]] | Ref,Read |
-// CHECK: [[@LINE-2]]:5 | instance-method/Swift | callAsFunction(_:) | [[callAsFunc1]] | Ref,Call,RelRec | rel: 1
-// CHECK:   RelRec | struct/Swift | Adder |
-// CHECK: [[@LINE-4]]:6 | variable/Swift | global | {{.*}} | Ref,Read |
+// CHECK: [[@LINE-2]]:5 | instance-method/Swift | callAsFunction(_:) | [[callAsFunc1]] | Ref,Call | rel: 0
+// CHECK: [[@LINE-3]]:6 | variable/Swift | global | {{.*}} | Ref,Read |
 
 add3(x: 10, y: 11)
 // CHECK: [[@LINE-1]]:1 | variable/Swift | add3 | [[add3]] | Ref,Read |
-// CHECK: [[@LINE-2]]:5 | instance-method/Swift | callAsFunction(x:y:) | [[callAsFunc2]] | Ref,Call,RelRec | rel: 1
-// CHECK:   RelRec | struct/Swift | Adder |
+// CHECK: [[@LINE-2]]:5 | instance-method/Swift | callAsFunction(x:y:) | [[callAsFunc2]] | Ref,Call | rel: 0
 
 func getAdder(_ base: Int) -> Adder { return Adder(base: base) }
 // CHECK: [[@LINE-1]]:6 | function/Swift | getAdder(_:) | [[getAdder:.*]] | Def | rel: 0
 
 getAdder(5)(10)
 // CHECK: [[@LINE-1]]:1 | function/Swift | getAdder(_:) | [[getAdder]] | Ref,Call | rel: 0
-// CHECK: [[@LINE-2]]:12 | instance-method/Swift | callAsFunction(_:) | [[callAsFunc1]] | Ref,Call,RelRec | rel: 1
-// CHECK:   RelRec | struct/Swift | Adder |
+// CHECK: [[@LINE-2]]:12 | instance-method/Swift | callAsFunction(_:) | [[callAsFunc1]] | Ref,Call | rel: 0
 
 getAdder(5)(x: 1, y: 42)
 // CHECK: [[@LINE-1]]:1 | function/Swift | getAdder(_:) | [[getAdder]] | Ref,Call | rel: 0
-// CHECK: [[@LINE-2]]:12 | instance-method/Swift | callAsFunction(x:y:) | [[callAsFunc2]] | Ref,Call,RelRec | rel: 1
-// CHECK:   RelRec | struct/Swift | Adder |
+// CHECK: [[@LINE-2]]:12 | instance-method/Swift | callAsFunction(x:y:) | [[callAsFunc2]] | Ref,Call | rel: 0
 
 ((add3.callAsFunction)(x: 5, y: 10))(x: 1, y: 42)
-// CHECK: [[@LINE-1]]:8 | instance-method/Swift | callAsFunction(x:y:) | [[callAsFunc2]] | Ref,Call,RelRec | rel: 1
-// CHECK:   RelRec | struct/Swift | Adder |
-// CHECK: [[@LINE-3]]:37 | instance-method/Swift | callAsFunction(x:y:) | [[callAsFunc2]] | Ref,Call,RelRec | rel: 1
-// CHECK:   RelRec | struct/Swift | Adder |
+// CHECK: [[@LINE-1]]:8 | instance-method/Swift | callAsFunction(x:y:) | [[callAsFunc2]] | Ref,Call | rel: 0
+// CHECK: [[@LINE-2]]:37 | instance-method/Swift | callAsFunction(x:y:) | [[callAsFunc2]] | Ref,Call | rel: 0

--- a/test/Index/index_curry_thunk.swift
+++ b/test/Index/index_curry_thunk.swift
@@ -6,7 +6,7 @@ struct SomeStruct {
 
 func test(s: SomeStruct) {
   s.simple { }
-  // CHECK: [[@LINE-1]]:5 | instance-method/Swift | simple(_:) | s:14swift_ide_test10SomeStructV6simpleyyyyXEF | Ref,Call,RelRec,RelCall,RelCont | rel: 2
+  // CHECK: [[@LINE-1]]:5 | instance-method/Swift | simple(_:) | s:14swift_ide_test10SomeStructV6simpleyyyyXEF | Ref,Call,RelCall,RelCont | rel: 1
   (((s).simple)) { }
-  // CHECK: [[@LINE-1]]:9 | instance-method/Swift | simple(_:) | s:14swift_ide_test10SomeStructV6simpleyyyyXEF | Ref,Call,RelRec,RelCall,RelCont | rel: 2
+  // CHECK: [[@LINE-1]]:9 | instance-method/Swift | simple(_:) | s:14swift_ide_test10SomeStructV6simpleyyyyXEF | Ref,Call,RelCall,RelCont | rel: 1
 }

--- a/test/Index/index_keypath_member_lookup.swift
+++ b/test/Index/index_keypath_member_lookup.swift
@@ -49,7 +49,7 @@ func testRead1(r: Lens<Rectangle>, a: Lens<[Int]>) {
 
 // => implicit dynamicMember subscript (topLeft)
 // CHECK: [[TL_LINE]]:8 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Read,Impl,RelCont | rel: 1
-// CHECK: [[TL_LINE]]:8 | instance-method/acc-get/Swift | getter:subscript(dynamicMember:) | [[SUB_GET_USR]] | Ref,Call,Impl,RelRec,RelCall,RelCont | rel: 2
+// CHECK: [[TL_LINE]]:8 | instance-method/acc-get/Swift | getter:subscript(dynamicMember:) | [[SUB_GET_USR]] | Ref,Call,Impl,RelCall,RelCont | rel: 1
 
 // => property topLeft
 // CHECK: [[TL_LINE]]:9 | instance-property/Swift | topLeft | [[TL_USR]] | Ref,Read,RelCont | rel: 1
@@ -60,7 +60,7 @@ func testRead1(r: Lens<Rectangle>, a: Lens<[Int]>) {
 
 // => implicit dynamicMember subscript (bottomRight)
 // CHECK: [[BR_LINE]]:8 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Read,Impl,RelCont | rel: 1
-// CHECK: [[BR_LINE]]:8 | instance-method/acc-get/Swift | getter:subscript(dynamicMember:) | [[SUB_GET_USR]] | Ref,Call,Impl,RelRec,RelCall,RelCont | rel: 2
+// CHECK: [[BR_LINE]]:8 | instance-method/acc-get/Swift | getter:subscript(dynamicMember:) | [[SUB_GET_USR]] | Ref,Call,Impl,RelCall,RelCont | rel: 1
 
 // => property bottomRight
 // CHECK: [[BR_LINE]]:9 | instance-property/Swift | bottomRight | [[BR_USR]] | Ref,Read,RelCont | rel: 1
@@ -68,7 +68,7 @@ func testRead1(r: Lens<Rectangle>, a: Lens<[Int]>) {
 
 // => implicit dynamicMember subscript (y)
 // CHECK: [[BR_LINE]]:20 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Read,Impl,RelCont | rel: 1
-// CHECK: [[BR_LINE]]:20 | instance-method/acc-get/Swift | getter:subscript(dynamicMember:) | [[SUB_GET_USR]] | Ref,Call,Impl,RelRec,RelCall,RelCont | rel: 2
+// CHECK: [[BR_LINE]]:20 | instance-method/acc-get/Swift | getter:subscript(dynamicMember:) | [[SUB_GET_USR]] | Ref,Call,Impl,RelCall,RelCont | rel: 1
 
 // => property y
 // CHECK: [[BR_LINE]]:21 | instance-property/Swift | y | [[PY_USR]] | Ref,Read,RelCont | rel: 1
@@ -79,7 +79,7 @@ func testRead1(r: Lens<Rectangle>, a: Lens<[Int]>) {
 
 // => implicit dynamicMember subscript
 // CHECK: [[A_LINE]]:8 | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB_USR]] | Ref,Read,Impl,RelCont | rel: 1
-// CHECK: [[A_LINE]]:8 | instance-method/acc-get/Swift | getter:subscript(dynamicMember:) | [[SUB_GET_USR]] | Ref,Call,Impl,RelRec,RelCall,RelCont | rel: 2
+// CHECK: [[A_LINE]]:8 | instance-method/acc-get/Swift | getter:subscript(dynamicMember:) | [[SUB_GET_USR]] | Ref,Call,Impl,RelCall,RelCont | rel: 1
 
 // => subscript [Int]
 // CHECK: [[A_LINE]]:8 | instance-property/subscript/Swift | subscript(_:) | s:SayxSicip | Ref,Read,RelCont | rel: 1
@@ -155,7 +155,7 @@ extension Foo {
   // CHECK-NEXT: RelChild,RelAcc | instance-property/subscript/Swift | subscript(dynamicMember:) | [[SUB2_USR]]
 
     prop[keyPath: keyPath]
-    // CHECK: [[@LINE-1]]:5 | instance-property/Swift | prop | [[PROP_USR]] | Ref,Read,RelCont | rel: 1
+    // CHECK: [[@LINE-1]]:5 | instance-property/Swift | prop | [[PROP_USR]] | Ref,Read,Dyn,RelCont | rel: 1
   }
 }
 

--- a/test/Index/index_static_funcs.swift
+++ b/test/Index/index_static_funcs.swift
@@ -5,13 +5,13 @@
 protocol SwiftProto {
 // CHECK: [[@LINE-1]]:10 | protocol/Swift | SwiftProto | [[Proto_USR:.*]] | Def | rel: 0
   static func staticMethod()
-  // CHECK: [[@LINE-1]]:15 | static-method/Swift | staticMethod() | [[ProtoStaticMethod_USR:.*]] | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:15 | static-method/Swift | staticMethod() | [[ProtoStaticMethod_USR:.*]] | Def,Dyn,RelChild | rel: 1
 }
 
 protocol SwiftProtoSame {
 // CHECK: [[@LINE-1]]:10 | protocol/Swift | SwiftProtoSame | [[ProtoSame_USR:.*]] | Def | rel: 0
   static func staticMethod()
-  // CHECK: [[@LINE-1]]:15 | static-method/Swift | staticMethod() | [[ProtoSameStaticMethod_USR:.*]] | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:15 | static-method/Swift | staticMethod() | [[ProtoSameStaticMethod_USR:.*]] | Def,Dyn,RelChild | rel: 1
 }
 
 protocol SwiftProtoOther {}
@@ -40,25 +40,20 @@ enum SwiftEnum: SwiftProtoComposed {
 
 func directCalls() {
   SwiftClass.staticMethod()
-  // CHECK: [[@LINE-1]]:14 | static-method/Swift | staticMethod() | [[ClassStaticMethod_USR]] | Ref,Call,RelRec,RelCall,RelCont | rel: 2
-  // CHECK-DAG: RelRec | class/Swift | SwiftClass | [[Class_USR]]
+  // CHECK: [[@LINE-1]]:14 | static-method/Swift | staticMethod() | [[ClassStaticMethod_USR]] | Ref,Call,RelCall,RelCont | rel: 1
   SwiftClass.classMethod()
-  // CHECK: [[@LINE-1]]:14 | class-method/Swift | classMethod() | [[ClassClassMethod_USR]] | Ref,Call,RelRec,RelCall,RelCont | rel: 2
-  // CHECK-DAG: RelRec | class/Swift | SwiftClass | [[Class_USR]]
+  // CHECK: [[@LINE-1]]:14 | class-method/Swift | classMethod() | [[ClassClassMethod_USR]] | Ref,Call,RelCall,RelCont | rel: 1
 
   SwiftStruct.staticMethod()
-  // CHECK: [[@LINE-1]]:15 | static-method/Swift | staticMethod() | [[StructStaticMethod_USR]] | Ref,Call,RelRec,RelCall,RelCont | rel: 2
-  // CHECK-DAG: RelRec | struct/Swift | SwiftStruct | [[Struct_USR]]
+  // CHECK: [[@LINE-1]]:15 | static-method/Swift | staticMethod() | [[StructStaticMethod_USR]] | Ref,Call,RelCall,RelCont | rel: 1
 
   SwiftEnum.staticMethod()
-  // CHECK: [[@LINE-1]]:13 | static-method/Swift | staticMethod() | [[EnumStaticMethod_USR]] | Ref,Call,RelRec,RelCall,RelCont | rel: 2
-  // CHECK-DAG: RelRec | enum/Swift | SwiftEnum | [[Enum_USR]]
+  // CHECK: [[@LINE-1]]:13 | static-method/Swift | staticMethod() | [[EnumStaticMethod_USR]] | Ref,Call,RelCall,RelCont | rel: 1
 }
 
 func typeofClass(c: SwiftClass) {
   type(of: c).staticMethod()
-  // CHECK: [[@LINE-1]]:15 | static-method/Swift | staticMethod() | [[ClassStaticMethod_USR]] | Ref,Call,RelRec,RelCall,RelCont | rel: 2
-  // CHECK: RelRec | class/Swift | SwiftClass | [[Class_USR]]
+  // CHECK: [[@LINE-1]]:15 | static-method/Swift | staticMethod() | [[ClassStaticMethod_USR]] | Ref,Call,RelCall,RelCont | rel: 1
   type(of: c).classMethod()
   // CHECK: [[@LINE-1]]:15 | class-method/Swift | classMethod() | [[ClassClassMethod_USR]] | Ref,Call,Dyn,RelRec,RelCall,RelCont | rel: 2
   // CHECK: RelRec | class/Swift | SwiftClass | [[Class_USR]]
@@ -66,14 +61,12 @@ func typeofClass(c: SwiftClass) {
 
 func typeofStruct(s: SwiftStruct) {
   type(of: s).staticMethod()
-  // CHECK: [[@LINE-1]]:15 | static-method/Swift | staticMethod() | [[StructStaticMethod_USR]] | Ref,Call,RelRec,RelCall,RelCont | rel: 2
-  // CHECK: RelRec | struct/Swift | SwiftStruct | [[Struct_USR]]
+  // CHECK: [[@LINE-1]]:15 | static-method/Swift | staticMethod() | [[StructStaticMethod_USR]] | Ref,Call,RelCall,RelCont | rel: 1
 }
 
 func typeofEnum(e: SwiftEnum) {
   type(of: e).staticMethod()
-  // CHECK: [[@LINE-1]]:15 | static-method/Swift | staticMethod() | [[EnumStaticMethod_USR]] | Ref,Call,RelRec,RelCall,RelCont | rel: 2
-  // CHECK: RelRec | enum/Swift | SwiftEnum | [[Enum_USR]]
+  // CHECK: [[@LINE-1]]:15 | static-method/Swift | staticMethod() | [[EnumStaticMethod_USR]] | Ref,Call,RelCall,RelCont | rel: 1
 }
 
 func typeofProtocol(proto: SwiftProto) {

--- a/test/Index/roles.swift
+++ b/test/Index/roles.swift
@@ -16,24 +16,21 @@ let x = 2
 var y = x + 1
 // CHECK: [[@LINE-1]]:5 | variable/Swift | y | s:14swift_ide_test1ySivp | Def | rel: 0
 // CHECK: [[@LINE-2]]:9 | variable/Swift | x | s:14swift_ide_test1xSivp | Ref,Read,RelCont | rel: 1
-// CHECK: [[@LINE-3]]:11 | static-method/infix-operator/Swift | +(_:_:) | s:Si1poiyS2i_SitFZ | Ref,Call,RelRec,RelCont | rel: 2
+// CHECK: [[@LINE-3]]:11 | static-method/infix-operator/Swift | +(_:_:) | s:Si1poiyS2i_SitFZ | Ref,Call,RelCont | rel: 1
 // CHECK-NEXT: RelCont | variable/Swift | y | s:14swift_ide_test1ySivp
-// CHECK-NEXT: RelRec | struct/Swift | Int | s:Si
 
 // Read of x + Write of y
 y = x + 1
 // CHECK: [[@LINE-1]]:1 | variable/Swift | y | s:14swift_ide_test1ySivp | Ref,Writ | rel: 0
 // CHECK: [[@LINE-2]]:5 | variable/Swift | x | s:14swift_ide_test1xSivp | Ref,Read | rel: 0
-// CHECK: [[@LINE-3]]:7 | static-method/infix-operator/Swift | +(_:_:) | s:Si1poiyS2i_SitFZ | Ref,Call,RelRec | rel: 1
-// CHECK-NEXT: RelRec | struct/Swift | Int | s:Si
+// CHECK: [[@LINE-3]]:7 | static-method/infix-operator/Swift | +(_:_:) | s:Si1poiyS2i_SitFZ | Ref,Call | rel: 0
 
 
 // Read of y + Write of y
 y += x
 // CHECK: [[@LINE-1]]:1 | variable/Swift | y | s:14swift_ide_test1ySivp | Ref,Read,Writ | rel: 0
-// CHECK: [[@LINE-2]]:3 | static-method/infix-operator/Swift | +=(_:_:) | s:Si2peoiyySiz_SitFZ | Ref,Call,RelRec | rel: 1
-// CHECK-NEXT: RelRec | struct/Swift | Int | s:Si
-// CHECK: [[@LINE-4]]:6 | variable/Swift | x | s:14swift_ide_test1xSivp | Ref,Read | rel: 0
+// CHECK: [[@LINE-2]]:3 | static-method/infix-operator/Swift | +=(_:_:) | s:Si2peoiyySiz_SitFZ | Ref,Call | rel: 0
+// CHECK: [[@LINE-3]]:6 | variable/Swift | x | s:14swift_ide_test1xSivp | Ref,Read | rel: 0
 
 var z: Int {
 // CHECK: [[@LINE-1]]:5 | variable/Swift | z | s:14swift_ide_test1zSivp | Def | rel: 0
@@ -117,15 +114,12 @@ struct AStruct {
     x += 1
     // CHECK: [[@LINE-1]]:5 | instance-property/Swift | x | [[AStruct_x_USR]] | Ref,Read,Writ,RelCont | rel: 1
     // CHECK-NEXT: RelCont | instance-method/Swift | aMethod() | s:14swift_ide_test7AStructV7aMethodyyF
-    // CHECK: [[@LINE-3]]:5 | instance-method/acc-get/Swift | getter:x | s:14swift_ide_test7AStructV1xSivg | Ref,Call,Impl,RelRec,RelCall,RelCont | rel: 2
+    // CHECK: [[@LINE-3]]:5 | instance-method/acc-get/Swift | getter:x | s:14swift_ide_test7AStructV1xSivg | Ref,Call,Impl,RelCall,RelCont | rel: 1
     // CHECK-NEXT: RelCall,RelCont | instance-method/Swift | aMethod() | s:14swift_ide_test7AStructV7aMethodyyF
-    // CHECK-NEXT: RelRec | struct/Swift | AStruct | [[AStruct_USR]]
-    // CHECK: [[@LINE-6]]:5 | instance-method/acc-set/Swift | setter:x | s:14swift_ide_test7AStructV1xSivs | Ref,Call,Impl,RelRec,RelCall,RelCont | rel: 2
+    // CHECK: [[@LINE-5]]:5 | instance-method/acc-set/Swift | setter:x | s:14swift_ide_test7AStructV1xSivs | Ref,Call,Impl,RelCall,RelCont | rel: 1
     // CHECK-NEXT: RelCall,RelCont | instance-method/Swift | aMethod() | s:14swift_ide_test7AStructV7aMethodyyF
-    // CHECK-NEXT: RelRec | struct/Swift | AStruct | [[AStruct_USR]]
-    // CHECK: [[@LINE-9]]:7 | static-method/infix-operator/Swift | +=(_:_:) | s:Si2peoiyySiz_SitFZ | Ref,Call,RelRec,RelCall,RelCont | rel: 2
+    // CHECK: [[@LINE-7]]:7 | static-method/infix-operator/Swift | +=(_:_:) | s:Si2peoiyySiz_SitFZ | Ref,Call,RelCall,RelCont | rel: 1
     // CHECK-NEXT: RelCall,RelCont | instance-method/Swift | aMethod() | s:14swift_ide_test7AStructV7aMethodyyF
-    // CHECK-NEXT: RelRec | struct/Swift | Int | s:Si
   }
 
   // RelationChildOf, RelationAccessorOf
@@ -185,24 +179,32 @@ let _ = AClass.foo
 let _ = AClass(x: 1).foo
 // CHECK: [[@LINE-1]]:22 | instance-method/Swift | foo() | [[AClass_foo_USR]] | Ref | rel: 0
 let _ = AClass(x: 1)[1]
-// CHECK: [[@LINE-1]]:21 | instance-property/subscript/Swift | subscript(_:) | [[AClass_subscript_USR]] | Ref,Read | rel: 0
-// CHECK: [[@LINE-2]]:21 | instance-method/acc-get/Swift | getter:subscript(_:) | [[AClass_subscript_get_USR]] | Ref,Call,Dyn,Impl,RelRec | rel: 1
+// CHECK: [[@LINE-1]]:21 | instance-property/subscript/Swift | subscript(_:) | [[AClass_subscript_USR]] | Ref,Read,Dyn,RelRec | rel: 1
+// CHECK-NEXT: RelRec | class/Swift | AClass | [[AClass_USR]]
+// CHECK: [[@LINE-3]]:21 | instance-method/acc-get/Swift | getter:subscript(_:) | [[AClass_subscript_get_USR]] | Ref,Call,Dyn,Impl,RelRec | rel: 1
+// CHECK-NEXT: RelRec | class/Swift | AClass | [[AClass_USR]]
 let _ = AClass(x: 1)[1] = 2
-// CHECK: [[@LINE-1]]:21 | instance-property/subscript/Swift | subscript(_:) | [[AClass_subscript_USR]] | Ref,Writ | rel: 0
-// CHECK: [[@LINE-2]]:21 | instance-method/acc-set/Swift | setter:subscript(_:) | [[AClass_subscript_set_USR]] | Ref,Call,Dyn,Impl,RelRec | rel: 1
+// CHECK: [[@LINE-1]]:21 | instance-property/subscript/Swift | subscript(_:) | [[AClass_subscript_USR]] | Ref,Writ,Dyn,RelRec | rel: 1
+// CHECK-NEXT: RelRec | class/Swift | AClass | [[AClass_USR]]
+// CHECK: [[@LINE-3]]:21 | instance-method/acc-set/Swift | setter:subscript(_:) | [[AClass_subscript_set_USR]] | Ref,Call,Dyn,Impl,RelRec | rel: 1
+// CHECK-NEXT: RelRec | class/Swift | AClass | [[AClass_USR]]
 
 extension AClass {
   func test_property_refs1() -> AStruct {
     // CHECK: [[@LINE-1]]:8 | instance-method/Swift | test_property_refs1() | [[test_property_refs1_USR:.*]] | Def,Dyn,RelChild | rel: 1
     _ = y
-    // CHECK: [[@LINE-1]]:9 | instance-property/Swift | y | [[AClass_y_USR]] | Ref,Read,RelCont | rel: 1
-    // CHECK: [[@LINE-2]]:9 | instance-method/acc-get/Swift | getter:y | [[AClass_y_get_USR]] | Ref,Call,Dyn,Impl,RelRec,RelCall,RelCont | rel: 2
+    // CHECK: [[@LINE-1]]:9 | instance-property/Swift | y | [[AClass_y_USR]] | Ref,Read,Dyn,RelRec,RelCont | rel: 2
+    // CHECK-NEXT: RelCont | instance-method/Swift | test_property_refs1() | [[test_property_refs1_USR]]
+    // CHECK-NEXT: RelRec | class/Swift | AClass | [[AClass_USR]]
+    // CHECK: [[@LINE-4]]:9 | instance-method/acc-get/Swift | getter:y | [[AClass_y_get_USR]] | Ref,Call,Dyn,Impl,RelRec,RelCall,RelCont | rel: 2
     // CHECK-NEXT: RelCall,RelCont | instance-method/Swift | test_property_refs1() | [[test_property_refs1_USR]]
     // CHECK-NEXT: RelRec | class/Swift | AClass | [[AClass_USR]]
 
     return y
-    // CHECK: [[@LINE-1]]:12 | instance-property/Swift | y | [[AClass_y_USR]] | Ref,Read,RelCont | rel: 1
-    // CHECK: [[@LINE-2]]:12 | instance-method/acc-get/Swift | getter:y | [[AClass_y_get_USR]] | Ref,Call,Dyn,Impl,RelRec,RelCall,RelCont | rel: 2
+    // CHECK: [[@LINE-1]]:12 | instance-property/Swift | y | [[AClass_y_USR]] | Ref,Read,Dyn,RelRec,RelCont | rel: 2
+    // CHECK-NEXT: RelCont | instance-method/Swift | test_property_refs1() | [[test_property_refs1_USR]]
+    // CHECK-NEXT: RelRec | class/Swift | AClass | [[AClass_USR]]
+    // CHECK: [[@LINE-4]]:12 | instance-method/acc-get/Swift | getter:y | [[AClass_y_get_USR]] | Ref,Call,Dyn,Impl,RelRec,RelCall,RelCont | rel: 2
     // CHECK-NEXT: RelCall,RelCont | instance-method/Swift | test_property_refs1() | [[test_property_refs1_USR]]
     // CHECK-NEXT: RelRec | class/Swift | AClass | [[AClass_USR]]
   }
@@ -210,14 +212,18 @@ extension AClass {
   func test_property_refs2() -> Int {
     // CHECK: [[@LINE-1]]:8 | instance-method/Swift | test_property_refs2() | [[test_property_refs2_USR:.*]] | Def,Dyn,RelChild | rel: 1
     _ = computed_p
-    // CHECK: [[@LINE-1]]:9 | instance-property/Swift | computed_p | [[AClass_computed_p_USR]] | Ref,Read,RelCont | rel: 1
-    // CHECK: [[@LINE-2]]:9 | instance-method/acc-get/Swift | getter:computed_p | [[AClass_computed_p_get_USR]] | Ref,Call,Dyn,Impl,RelRec,RelCall,RelCont | rel: 2
+    // CHECK: [[@LINE-1]]:9 | instance-property/Swift | computed_p | [[AClass_computed_p_USR]] | Ref,Read,Dyn,RelRec,RelCont | rel: 2
+    // CHECK-NEXT: RelCont | instance-method/Swift | test_property_refs2() | [[test_property_refs2_USR]]
+    // CHECK-NEXT: RelRec | class/Swift | AClass | [[AClass_USR]]
+    // CHECK: [[@LINE-4]]:9 | instance-method/acc-get/Swift | getter:computed_p | [[AClass_computed_p_get_USR]] | Ref,Call,Dyn,Impl,RelRec,RelCall,RelCont | rel: 2
     // CHECK-NEXT: RelCall,RelCont | instance-method/Swift | test_property_refs2() | [[test_property_refs2_USR]]
     // CHECK-NEXT: RelRec | class/Swift | AClass | [[AClass_USR]]
 
     return computed_p
-    // CHECK: [[@LINE-1]]:12 | instance-property/Swift | computed_p | [[AClass_computed_p_USR]] | Ref,Read,RelCont | rel: 1
-    // CHECK: [[@LINE-2]]:12 | instance-method/acc-get/Swift | getter:computed_p | [[AClass_computed_p_get_USR]] | Ref,Call,Dyn,Impl,RelRec,RelCall,RelCont | rel: 2
+    // CHECK: [[@LINE-1]]:12 | instance-property/Swift | computed_p | [[AClass_computed_p_USR]] | Ref,Read,Dyn,RelRec,RelCont | rel: 2
+    // CHECK-NEXT: RelCont | instance-method/Swift | test_property_refs2() | [[test_property_refs2_USR]]
+    // CHECK-NEXT: RelRec | class/Swift | AClass | [[AClass_USR]]
+    // CHECK: [[@LINE-4]]:12 | instance-method/acc-get/Swift | getter:computed_p | [[AClass_computed_p_get_USR]] | Ref,Call,Dyn,Impl,RelRec,RelCall,RelCont | rel: 2
     // CHECK-NEXT: RelCall,RelCont | instance-method/Swift | test_property_refs2() | [[test_property_refs2_USR]]
     // CHECK-NEXT: RelRec | class/Swift | AClass | [[AClass_USR]]
   }
@@ -250,7 +256,7 @@ class ImplementsX : X, Y {
 
 func TestX(x: X) {
   _ = x.reqProp
-  // CHECK: [[@LINE-1]]:9 | instance-property/Swift | reqProp | [[reqProp_USR]] | Ref,Read,RelCont | rel: 1
+  // CHECK: [[@LINE-1]]:9 | instance-property/Swift | reqProp | [[reqProp_USR]] | Ref,Read,Dyn,RelRec,RelCont | rel: 2
 }
 
 protocol AProtocol {
@@ -334,23 +340,23 @@ var anInstance = AClass(x: 1)
 
 anInstance.y.x = anInstance.y.x
 // CHECK: [[@LINE-1]]:1 | variable/Swift | anInstance | s:14swift_ide_test10anInstanceAA6AClassCvp | Ref,Read | rel: 0
-// CHECK: [[@LINE-2]]:12 | instance-property/Swift | y | [[AClass_y_USR]] | Ref,Read,Writ | rel: 0
+// CHECK: [[@LINE-2]]:12 | instance-property/Swift | y | [[AClass_y_USR]] | Ref,Read,Writ,Dyn,RelRec | rel: 1
 // CHECK: [[@LINE-3]]:14 | instance-property/Swift | x | [[AStruct_x_USR]] | Ref,Writ | rel: 0
 // CHECK: [[@LINE-4]]:18 | variable/Swift | anInstance | s:14swift_ide_test10anInstanceAA6AClassCvp | Ref,Read | rel: 0
-// CHECK: [[@LINE-5]]:29 | instance-property/Swift | y | [[AClass_y_USR]] | Ref,Read | rel: 0
+// CHECK: [[@LINE-5]]:29 | instance-property/Swift | y | [[AClass_y_USR]] | Ref,Read,Dyn,RelRec | rel: 1
 // CHECK: [[@LINE-6]]:31 | instance-property/Swift | x | [[AStruct_x_USR]] | Ref,Read | rel: 0
 
 anInstance.y.aMethod()
 // CHECK: [[@LINE-1]]:1 | variable/Swift | anInstance | s:14swift_ide_test10anInstanceAA6AClassCvp | Ref,Read | rel: 0
-// CHECK: [[@LINE-2]]:12 | instance-property/Swift | y | [[AClass_y_USR]] | Ref,Read,Writ | rel: 0
+// CHECK: [[@LINE-2]]:12 | instance-property/Swift | y | [[AClass_y_USR]] | Ref,Read,Writ,Dyn,RelRec | rel: 1
 // CHECK: [[@LINE-3]]:14 | instance-method/Swift | aMethod() | s:14swift_ide_test7AStructV7aMethodyyF | Ref,Call | rel: 0
 
 // FIXME Write role of z occurrence on the RHS?
 anInstance.z[1] = anInstance.z[0]
 // CHECK: [[@LINE-1]]:1 | variable/Swift | anInstance | s:14swift_ide_test10anInstanceAA6AClassCvp | Ref,Read | rel: 0
-// CHECK: [[@LINE-2]]:12 | instance-property/Swift | z | s:14swift_ide_test6AClassC1zSaySiGvp | Ref,Read,Writ | rel: 0
+// CHECK: [[@LINE-2]]:12 | instance-property/Swift | z | s:14swift_ide_test6AClassC1zSaySiGvp | Ref,Read,Writ,Dyn,RelRec | rel: 1
 // CHECK: [[@LINE-3]]:19 | variable/Swift | anInstance | s:14swift_ide_test10anInstanceAA6AClassCvp | Ref,Read | rel: 0
-// CHECK: [[@LINE-4]]:30 | instance-property/Swift | z | s:14swift_ide_test6AClassC1zSaySiGvp | Ref,Read,Writ | rel: 0
+// CHECK: [[@LINE-4]]:30 | instance-property/Swift | z | s:14swift_ide_test6AClassC1zSaySiGvp | Ref,Read,Writ,Dyn,RelRec | rel: 1
 
 let otherInstance = AStruct(x: 1)
 // CHECK: [[@LINE-1]]:29 | instance-property/Swift | x | [[AStruct_x_USR]] | Ref,RelCont | rel: 1
@@ -366,7 +372,7 @@ let _ = otherInstance[0]
 
 let _ = anInstance[0]
 // CHECK: [[@LINE-1]]:9 | variable/Swift | anInstance | s:14swift_ide_test10anInstanceAA6AClassCvp | Ref,Read | rel: 0
-// CHECK: [[@LINE-2]]:19 | instance-property/subscript/Swift | subscript(_:) | [[AClass_subscript_USR]] | Ref,Read | rel: 0
+// CHECK: [[@LINE-2]]:19 | instance-property/subscript/Swift | subscript(_:) | [[AClass_subscript_USR]] | Ref,Read,Dyn,RelRec | rel: 1
 
 let aSubInstance: AClass = ASubClass(x: 1)
 // CHECK: [[@LINE-1]]:5 | variable/Swift | aSubInstance | s:14swift_ide_test12aSubInstanceAA6AClassCvp | Def | rel: 0
@@ -433,7 +439,7 @@ enum MyEnum {
 }
 
 MyEnum().enum_func()
-// CHECK: [[@LINE-1]]:10 | instance-method/Swift | enum_func() | [[MyEnum_enum_func_USR]] | Ref,Call,RelRec | rel: 1
+// CHECK: [[@LINE-1]]:10 | instance-method/Swift | enum_func() | [[MyEnum_enum_func_USR]] | Ref,Call | rel: 0
 
 class ClassWithFinals {
   final var prop : Int { get { return 0} }

--- a/test/SourceKit/CursorInfo/cursor_dynamic.swift
+++ b/test/SourceKit/CursorInfo/cursor_dynamic.swift
@@ -1,20 +1,34 @@
 protocol ProtoA {
+  var protoMember: Int { get }
+  static var staticProtoMember: Int { get }
   func method()
   static func staticMethod()
 }
 
+extension ProtoA {
+  static var staticProtoMember: Int { get { 1 } }
+  static func staticMethod() {}
+}
+
 class ClassB: ProtoA {
+  var protoMember: Int { get { 1 } }
+  class var classMember: Int { get { 1 } }
   let immutableMember: Int = 1
   var mutableMember: Int = 1
   func method() {}
-  static func staticMethod() {}
   class func classMethod() {}
   final func finalMethod() {}
 }
 
-class ClassC: ClassB {}
+class ClassC: ClassB {
+  static var staticProtoMember: Int { get { 1 } }
+  static func staticMethod() {}
+}
 
 class ClassD: ClassC {
+  override var protoMember: Int { get { 1 } }
+  override class var classMember: Int { get { 1 } }
+
   override var mutableMember: Int {
     get {
       return super.mutableMember
@@ -25,118 +39,265 @@ class ClassD: ClassC {
   }
 
   override func method() {
+    // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):11 %s -- %s | %FileCheck -check-prefix=CHECK-SUPER %s
     super.method()
+    // CHECK-SUPER: s:14cursor_dynamic6ClassBC6methodyyF
+    // CHECK-SUPER-NOT: DYNAMIC
   }
 
   override class func classMethod() {}
 }
 
 struct StructE: ProtoA {
+  let protoMember: Int = 1
+  static let staticProtoMember: Int = 1
+
   func method() {}
 
   static func staticMethod() {}
 }
 
-func direct() {
+func directRefs() {
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):14 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSBSTATICMEM %s
+  _ = ClassB.staticProtoMember
+  // CHECK-CLASSBSTATICMEM: s:14cursor_dynamic6ProtoAPAAE06staticC6MemberSivpZ
+  // CHECK-CLASSBSTATICMEM-NOT: DYNAMIC
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):14 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSBCLASSMEM %s
+  _ = ClassB.classMember
+  // CHECK-CLASSBCLASSMEM: s:14cursor_dynamic6ClassBC11classMemberSivpZ
+  // CHECK-CLASSBCLASSMEM-NOT: DYNAMIC
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):10 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSBSTATIC %s
   ClassB.staticMethod()
+  // CHECK-CLASSBSTATIC: s:14cursor_dynamic6ProtoAPAAE12staticMethodyyFZ
+  // CHECK-CLASSBSTATIC-NOT: DYNAMIC
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):10 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSBCLASS %s
   ClassB.classMethod()
+  // CHECK-CLASSBCLASS: s:14cursor_dynamic6ClassBC11classMethodyyFZ
+  // CHECK-CLASSBCLASS-NOT: DYNAMIC
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):14 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSCSTATICMEM %s
+  _ = ClassC.staticProtoMember
+  // CHECK-CLASSCSTATICMEM: s:14cursor_dynamic6ClassCC17staticProtoMemberSivpZ
+  // CHECK-CLASSCSTATICMEM-NOT: DYNAMIC
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):14 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSCCLASSMEM %s
+  _ = ClassC.classMember
+  // CHECK-CLASSCCLASSMEM: s:14cursor_dynamic6ClassBC11classMemberSivpZ
+  // CHECK-CLASSCCLASSMEM-NOT: DYNAMIC
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):10 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSCSTATIC %s
+  ClassC.staticMethod()
+  // CHECK-CLASSCSTATIC: s:14cursor_dynamic6ClassCC12staticMethodyyFZ
+  // CHECK-CLASSCSTATIC-NOT: DYNAMIC
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):10 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSCCLASS %s
+  ClassC.classMethod()
+  // CHECK-CLASSCCLASS: s:14cursor_dynamic6ClassBC11classMethodyyFZ
+  // CHECK-CLASSCCLASS-NOT: DYNAMIC
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):14 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSDCLASSMEM %s
+  _ = ClassD.classMember
+  // CHECK-CLASSDCLASSMEM: s:14cursor_dynamic6ClassDC11classMemberSivpZ
+  // CHECK-CLASSDCLASSMEM-NOT: DYNAMIC
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):10 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSDCLASS %s
   ClassD.classMethod()
+  // CHECK-CLASSDCLASS: s:14cursor_dynamic6ClassDC11classMethodyyFZ
+  // CHECK-CLASSDCLASS-NOT: DYNAMIC
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):15 %s -- %s | %FileCheck -check-prefix=CHECK-STRUCTESTATICMEM %s
+  _ = StructE.staticProtoMember
+  // CHECK-STRUCTESTATICMEM: s:14cursor_dynamic7StructEV17staticProtoMemberSivpZ
+  // CHECK-STRUCTESTATICMEM-NOT: DYNAMIC
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):11 %s -- %s | %FileCheck -check-prefix=CHECK-STRUCTESTATIC %s
   StructE.staticMethod()
+  // CHECK-STRUCTESTATIC: s:14cursor_dynamic7StructEV12staticMethodyyFZ
+  // CHECK-STRUCTESTATIC-NOT: DYNAMIC
 }
 
-func protoCalls(p: ProtoA) {
+func protoRefs(p: ProtoA) {
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):9 %s -- %s | %FileCheck -check-prefix=CHECK-PROTOMEM %s
+  _ = p.protoMember
+  // CHECK-PROTOMEM: s:14cursor_dynamic6ProtoAP11protoMemberSivp
+  // CHECK-PROTOMEM: DYNAMIC
+  // CHECK-PROTOMEM: RECEIVERS BEGIN
+  // CHECK-PROTOMEM-NEXT: s:14cursor_dynamic6ProtoAP
+  // CHECK-PROTOMEM-NEXT: RECEIVERS END
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):5 %s -- %s | %FileCheck -check-prefix=CHECK-PROTOMETHOD %s
   p.method()
+  // CHECK-PROTOMETHOD: s:14cursor_dynamic6ProtoAP6methodyyF
+  // CHECK-PROTOMETHOD: DYNAMIC
+  // CHECK-PROTOMETHOD: RECEIVERS BEGIN
+  // CHECK-PROTOMETHOD-NEXT: s:14cursor_dynamic6ProtoAP
+  // CHECK-PROTOMETHOD-NEXT: RECEIVERS END
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):19 %s -- %s | %FileCheck -check-prefix=CHECK-PROTOSTATICMEM %s
+  _ = type(of: p).staticProtoMember
+  // CHECK-PROTOSTATICMEM: s:14cursor_dynamic6ProtoAP06staticC6MemberSivpZ
+  // CHECK-PROTOSTATICMEM: DYNAMIC
+  // CHECK-PROTOSTATICMEM: RECEIVERS BEGIN
+  // CHECK-PROTOSTATICMEM-NEXT: s:14cursor_dynamic6ProtoAP
+  // CHECK-PROTOSTATICMEM-NEXT: RECEIVERS END
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):19 %s -- %s | %FileCheck -check-prefix=CHECK-PROTOSTATIC %s
   type(of: p).staticMethod()
+  // CHECK-PROTOSTATIC: s:14cursor_dynamic6ProtoAP12staticMethodyyFZ
+  // CHECK-PROTOSTATIC: DYNAMIC
+  // CHECK-PROTOSTATIC: RECEIVERS BEGIN
+  // CHECK-PROTOSTATIC-NEXT: s:14cursor_dynamic6ProtoAP
+  // CHECK-PROTOSTATIC-NEXT: RECEIVERS END
 }
 
-func classCalls(c: ClassC) {
+func protoGenericRefs<T>(p: T) where T: ProtoA {
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):9 %s -- %s | %FileCheck -check-prefix=CHECK-GENPROTOMEM %s
+  _ = p.protoMember
+  // CHECK-GENPROTOMEM: s:14cursor_dynamic6ProtoAP11protoMemberSivp
+  // CHECK-GENPROTOMEM: DYNAMIC
+  // TODO: Return receiver USRs for generics
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):5 %s -- %s | %FileCheck -check-prefix=CHECK-GENPROTOMETHOD %s
+  p.method()
+  // CHECK-GENPROTOMETHOD: s:14cursor_dynamic6ProtoAP6methodyyF
+  // CHECK-GENPROTOMETHOD: DYNAMIC
+  // TODO: Return receiver USRs for generics
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):19 %s -- %s | %FileCheck -check-prefix=CHECK-GENPROTOSTATICMEM %s
+  _ = type(of: p).staticProtoMember
+  // CHECK-GENPROTOSTATICMEM: s:14cursor_dynamic6ProtoAP06staticC6MemberSivpZ
+  // CHECK-GENPROTOSTATICMEM: DYNAMIC
+  // TODO: Return receiver USRs for generics
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):15 %s -- %s | %FileCheck -check-prefix=CHECK-GENPROTOTOSTATIC %s
+  type(of: p).staticMethod()
+  // CHECK-GENPROTOTOSTATIC: s:14cursor_dynamic6ProtoAP12staticMethodyyFZ
+  // CHECK-GENPROTOTOSTATIC: DYNAMIC
+  // TODO: Return receiver USRs for generics
+}
+
+func classRefs(c: ClassC, d: ClassD) {
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):9 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSCPROTOMEM %s
+  _ = c.protoMember
+  // CHECK-CLASSCPROTOMEM: s:14cursor_dynamic6ClassBC11protoMemberSivp
+  // CHECK-CLASSCPROTOMEM: DYNAMIC
+  // CHECK-CLASSCPROTOMEM: RECEIVERS BEGIN
+  // CHECK-CLASSCPROTOMEM-NEXT: s:14cursor_dynamic6ClassCC
+  // CHECK-CLASSCPROTOMEM-NEXT: RECEIVERS END
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):9 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSCIMMEMBER %s
   _ = c.immutableMember
+  // CHECK-CLASSCIMMEMBER: s:14cursor_dynamic6ClassBC15immutableMemberSivp
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):9 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSCMEMBERREAD %s
   _ = c.mutableMember
+  // CHECK-CLASSCMEMBERREAD: s:14cursor_dynamic6ClassBC13mutableMemberSivp
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):5 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSCMEMBERWRITE %s
   c.mutableMember = 1
+  // CHECK-CLASSCMEMBERWRITE: s:14cursor_dynamic6ClassBC13mutableMemberSivp
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):5 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSCMETHOD %s
   c.method()
+  // CHECK-CLASSCMETHOD: s:14cursor_dynamic6ClassBC6methodyyF
+  // CHECK-CLASSCMETHOD: DYNAMIC
+  // CHECK-CLASSCMETHOD: RECEIVERS BEGIN
+  // CHECK-CLASSCMETHOD-NEXT: s:14cursor_dynamic6ClassCC
+  // CHECK-CLASSCMETHOD-NEXT: RECEIVERS END
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):19 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSCTOSTATICMEM %s
+  _ = type(of: c).staticProtoMember
+  // CHECK-CLASSCTOSTATICMEM: s:14cursor_dynamic6ClassCC17staticProtoMemberSivpZ
+  // CHECK-CLASSCTOSTATICMEM-NOT: DYNAMIC
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):19 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSCTOCLASSMEM %s
+  _ = type(of: c).classMember
+  // CHECK-CLASSCTOCLASSMEM: s:14cursor_dynamic6ClassBC11classMemberSivpZ
+  // CHECK-CLASSCTOCLASSMEM: DYNAMIC
+  // CHECK-CLASSCTOCLASSMEM: RECEIVERS BEGIN
+  // CHECK-CLASSCTOCLASSMEM-NEXT: s:14cursor_dynamic6ClassCC
+  // CHECK-CLASSCTOCLASSMEM-NEXT: RECEIVERS END
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):15 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSCTOSTATIC %s
   type(of: c).staticMethod()
+  // CHECK-CLASSCTOSTATIC: s:14cursor_dynamic6ClassCC12staticMethodyyFZ
+  // CHECK-CLASSCTOSTATIC-NOT: DYNAMIC
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):15 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSCTOCLASS %s
   type(of: c).classMethod()
+  // CHECK-CLASSCTOCLASS: s:14cursor_dynamic6ClassBC11classMethodyyFZ
+  // CHECK-CLASSCTOCLASS: DYNAMIC
+  // CHECK-CLASSCTOCLASS: RECEIVERS BEGIN
+  // CHECK-CLASSCTOCLASS-NEXT: s:14cursor_dynamic6ClassCC
+  // CHECK-CLASSCTOCLASS-NEXT: RECEIVERS END
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):5 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSCFINAL %s
   c.finalMethod()
+  // CHECK-CLASSCFINAL: s:14cursor_dynamic6ClassBC11finalMethodyyF
+  // CHECK-CLASSCFINAL-NOT: DYNAMIC
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):9 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSDPROTOMEM %s
+  _ = d.protoMember
+  // CHECK-CLASSDPROTOMEM: s:14cursor_dynamic6ClassDC11protoMemberSivp
+  // CHECK-CLASSDPROTOMEM: DYNAMIC
+  // CHECK-CLASSDPROTOMEM: RECEIVERS BEGIN
+  // CHECK-CLASSDPROTOMEM-NEXT: s:14cursor_dynamic6ClassDC
+  // CHECK-CLASSDPROTOMEM-NEXT: RECEIVERS END
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):9 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSDMEMBERREAD %s
+  _ = d.mutableMember
+  // CHECK-CLASSDMEMBERREAD: s:14cursor_dynamic6ClassBC13mutableMemberSivp
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):5 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSDMEMBERWRITE %s
+  d.mutableMember = 1
+  // CHECK-CLASSDMEMBERWRITE: s:14cursor_dynamic6ClassBC13mutableMemberSivp
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):5 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSDMETHOD %s
+  d.method()
+  // CHECK-CLASSDMETHOD: s:14cursor_dynamic6ClassDC6methodyyF
+  // CHECK-CLASSDMETHOD: DYNAMIC
+  // CHECK-CLASSDMETHOD: RECEIVERS BEGIN
+  // CHECK-CLASSDMETHOD-NEXT: s:14cursor_dynamic6ClassDC
+  // CHECK-CLASSDMETHOD-NEXT: RECEIVERS END
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):19 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSDTOCLASSMEM %s
+  _ = type(of: d).classMember
+  // CHECK-CLASSDTOCLASSMEM: s:14cursor_dynamic6ClassDC11classMemberSivpZ
+  // CHECK-CLASSDTOCLASSMEM: DYNAMIC
+  // CHECK-CLASSDTOCLASSMEM: RECEIVERS BEGIN
+  // CHECK-CLASSDTOCLASSMEM-NEXT: s:14cursor_dynamic6ClassDC
+  // CHECK-CLASSDTOCLASSMEM-NEXT: RECEIVERS END
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):15 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSDTOCLASS %s
+  type(of: d).classMethod()
+  // CHECK-CLASSDTOCLASS: s:14cursor_dynamic6ClassDC11classMethodyyFZ
+  // CHECK-CLASSDTOCLASS: DYNAMIC
+  // CHECK-CLASSDTOCLASS: RECEIVERS BEGIN
+  // CHECK-CLASSDTOCLASS-NEXT: s:14cursor_dynamic6ClassDC
+  // CHECK-CLASSDTOCLASS-NEXT: RECEIVERS END
 }
 
-func structCalls(e: StructE) {
+func structRefs(e: StructE) {
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):9 %s -- %s | %FileCheck -check-prefix=CHECK-STRUCTMEM %s
+  _ = e.protoMember
+  // CHECK-STRUCTMEM: s:14cursor_dynamic7StructEV11protoMemberSivp
+  // CHECK-STRUCTMEM-NOT: DYNAMIC
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):5 %s -- %s | %FileCheck -check-prefix=CHECK-STRUCTMETHOD %s
   e.method()
+  // CHECK-STRUCTMETHOD: s:14cursor_dynamic7StructEV6methodyyF
+  // CHECK-STRUCTMETHOD-NOT: DYNAMIC
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):19 %s -- %s | %FileCheck -check-prefix=CHECK-STRUCTTOSTATICMEM %s
+  _ = type(of: e).staticProtoMember
+  // CHECK-STRUCTTOSTATICMEM: s:14cursor_dynamic7StructEV17staticProtoMemberSivpZ
+  // CHECK-STRUCTTOSTATICMEM-NOT: DYNAMIC
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):15 %s -- %s | %FileCheck -check-prefix=CHECK-STRUCTTOSTATIC %s
   type(of: e).staticMethod()
+  // CHECK-STRUCTTOSTATIC: s:14cursor_dynamic7StructEV12staticMethodyyFZ
+  // CHECK-STRUCTOTSTATIC-NOT: DYNAMIC
 }
-
-// RUN: %sourcekitd-test -req=cursor -pos=28:11 %s -- %s | %FileCheck -check-prefix=CHECK-SUPER %s
-// CHECK-SUPER: s:14cursor_dynamic6ClassBC6methodyyF
-// CHECK-SUPER-NOT: DYNAMIC
-
-// RUN: %sourcekitd-test -req=cursor -pos=41:10 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSSTATIC %s
-// CHECK-CLASSSTATIC: s:14cursor_dynamic6ClassBC12staticMethodyyFZ
-// CHECK-CLASSSTATIC-NOT: DYNAMIC
-
-// RUN: %sourcekitd-test -req=cursor -pos=42:10 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSCLASS %s
-// CHECK-CLASSCLASS: s:14cursor_dynamic6ClassBC11classMethodyyFZ
-// CHECK-CLASSCLASS-NOT: DYNAMIC
-
-// RUN: %sourcekitd-test -req=cursor -pos=43:10 %s -- %s | %FileCheck -check-prefix=CHECK-SUBCLASSCLASS %s
-// CHECK-SUBCLASSCLASS: s:14cursor_dynamic6ClassDC11classMethodyyFZ
-// CHECK-SUBCLASSCLASS-NOT: DYNAMIC
-
-// RUN: %sourcekitd-test -req=cursor -pos=44:11 %s -- %s | %FileCheck -check-prefix=CHECK-STRUCTSTATIC %s
-// CHECK-STRUCTSTATIC: s:14cursor_dynamic7StructEV12staticMethodyyFZ
-// CHECK-STRUCTSTATIC-NOT: DYNAMIC
-
-// RUN: %sourcekitd-test -req=cursor -pos=48:5 %s -- %s | %FileCheck -check-prefix=CHECK-PROTOMETHOD %s
-// CHECK-PROTOMETHOD: s:14cursor_dynamic6ProtoAP6methodyyF
-// CHECK-PROTOMETHOD: DYNAMIC
-// CHECK-PROTOMETHOD: RECEIVERS BEGIN
-// CHECK-PROTOMETHOD-NEXT: s:14cursor_dynamic6ProtoAP
-// CHECK-PROTOMETHOD-NEXT: RECEIVERS END
-
-// RUN: %sourcekitd-test -req=cursor -pos=49:15 %s -- %s | %FileCheck -check-prefix=CHECK-PROTOTOSTATIC %s
-// CHECK-PROTOTOSTATIC: s:14cursor_dynamic6ProtoAP12staticMethodyyFZ
-// CHECK-PROTOTOSTATIC: DYNAMIC
-// CHECK-PROTOSTATIC: RECEIVERS BEGIN
-// CHECK-PROTOSTATIC-NEXT: s:14cursor_dynamic6ProtoAP
-// CHECK-PROTOSTATIC-NEXT: RECEIVERS END
-
-// RUN: %sourcekitd-test -req=cursor -pos=53:9 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSIMMEMBER %s
-// CHECK-CLASSIMMEMBER: s:14cursor_dynamic6ClassBC15immutableMemberSivp
-// rdar://75645572 should include getter without dynamic (or maybe we just skip returning in that case
-// since it would only be used to find overrides)
-
-// RUN: %sourcekitd-test -req=cursor -pos=54:9 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSMEMBERREAD %s
-// CHECK-CLASSMEMBERREAD: s:14cursor_dynamic6ClassBC13mutableMemberSivp
-// rdar://75645572 should include getter with dynamic
-
-// RUN: %sourcekitd-test -req=cursor -pos=55:5 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSMEMBERWRITE %s
-// CHECK-CLASSMEMBERWRITE: s:14cursor_dynamic6ClassBC13mutableMemberSivp
-// rdar://75645572 should include setter with dynamic
-
-// RUN: %sourcekitd-test -req=cursor -pos=56:5 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSMETHOD %s
-// CHECK-CLASSMETHOD: s:14cursor_dynamic6ClassBC6methodyyF
-// CHECK-CLASSMETHOD: DYNAMIC
-// CHECK-CLASSMETHOD: RECEIVERS BEGIN
-// CHECK-CLASSMETHOD-NEXT: s:14cursor_dynamic6ClassCC
-// CHECK-CLASSMETHOD-NEXT: RECEIVERS END
-
-// RUN: %sourcekitd-test -req=cursor -pos=57:15 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSTOSTATIC %s
-// CHECK-CLASSTOSTATIC: s:14cursor_dynamic6ClassBC12staticMethodyyFZ
-// CHECK-CLASSTOSTATIC-NOT: DYNAMIC
-
-// RUN: %sourcekitd-test -req=cursor -pos=58:15 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSTOCLASS %s
-// CHECK-CLASSTOCLASS: s:14cursor_dynamic6ClassBC11classMethodyyFZ
-// CHECK-CLASSTOCLASS: DYNAMIC
-// CHECK-CLASSTOCLASS: RECEIVERS BEGIN
-// CHECK-CLASSTOCLASS-NEXT: s:14cursor_dynamic6ClassCC
-// CHECK-CLASSTOCLASS-NEXT: RECEIVERS END
-
-// RUN: %sourcekitd-test -req=cursor -pos=59:5 %s -- %s | %FileCheck -check-prefix=CHECK-CLASSFINAL %s
-// CHECK-CLASSFINAL: s:14cursor_dynamic6ClassBC11finalMethodyyF
-// CHECK-CLASSFINAL-NOT: DYNAMIC
-
-// RUN: %sourcekitd-test -req=cursor -pos=63:5 %s -- %s | %FileCheck -check-prefix=CHECK-STRUCTMETHOD %s
-// CHECK-STRUCTMETHOD: s:14cursor_dynamic7StructEV6methodyyF
-// CHECK-STRUCTMETHOD-NOT: DYNAMIC
-
-// RUN: %sourcekitd-test -req=cursor -pos=64:15 %s -- %s | %FileCheck -check-prefix=CHECK-STRUCTTOSTATIC %s
-// CHECK-STRUCTTOSTATIC: s:14cursor_dynamic7StructEV12staticMethodyyFZ
-// CHECK-STRUCTOTSTATIC-NOT: DYNAMIC

--- a/test/SourceKit/Indexing/index.swift.response
+++ b/test/SourceKit/Indexing/index.swift.response
@@ -333,6 +333,8 @@
           key.usr: <usr>,
           key.line: 38,
           key.column: 9,
+          key.receiver_usr: "s:5index2CCC",
+          key.is_dynamic: 1,
           key.entities: [
             {
               key.kind: source.lang.swift.ref.function.accessor.getter,
@@ -366,8 +368,7 @@
           key.name: "smeth()",
           key.usr: <usr>,
           key.line: 40,
-          key.column: 6,
-          key.receiver_usr: "s:5index2CCC"
+          key.column: 6
         },
         {
           key.kind: source.lang.swift.ref.enum,
@@ -844,8 +845,7 @@
                   key.name: "+(_:_:)",
                   key.usr: <usr>,
                   key.line: 86,
-                  key.column: 8,
-                  key.receiver_usr: "s:Si"
+                  key.column: 8
                 }
               ]
             },
@@ -904,6 +904,8 @@
           key.usr: <usr>,
           key.line: 92,
           key.column: 14,
+          key.receiver_usr: "s:5index16ComputedPropertyC",
+          key.is_dynamic: 1,
           key.entities: [
             {
               key.kind: source.lang.swift.ref.function.accessor.getter,
@@ -922,6 +924,8 @@
           key.usr: <usr>,
           key.line: 93,
           key.column: 10,
+          key.receiver_usr: "s:5index16ComputedPropertyC",
+          key.is_dynamic: 1,
           key.entities: [
             {
               key.kind: source.lang.swift.ref.function.accessor.getter,
@@ -940,6 +944,8 @@
           key.usr: <usr>,
           key.line: 94,
           key.column: 6,
+          key.receiver_usr: "s:5index16ComputedPropertyC",
+          key.is_dynamic: 1,
           key.entities: [
             {
               key.kind: source.lang.swift.ref.function.accessor.setter,
@@ -958,6 +964,8 @@
           key.usr: <usr>,
           key.line: 96,
           key.column: 10,
+          key.receiver_usr: "s:5index3CC2C",
+          key.is_dynamic: 1,
           key.entities: [
             {
               key.kind: source.lang.swift.ref.function.accessor.getter,
@@ -976,6 +984,8 @@
           key.usr: <usr>,
           key.line: 97,
           key.column: 6,
+          key.receiver_usr: "s:5index3CC2C",
+          key.is_dynamic: 1,
           key.entities: [
             {
               key.kind: source.lang.swift.ref.function.accessor.setter,
@@ -1085,8 +1095,7 @@
           key.name: "sfoo()",
           key.usr: <usr>,
           key.line: 112,
-          key.column: 16,
-          key.receiver_usr: "s:5index2S2V"
+          key.column: 16
         }
       ],
       key.effective_access: source.decl.effective_access.internal
@@ -1179,8 +1188,7 @@
               key.name: "foo()",
               key.usr: <usr>,
               key.line: 123,
-              key.column: 11,
-              key.receiver_usr: "s:5index2B1C"
+              key.column: 11
             }
           ],
           key.attributes: [
@@ -1255,8 +1263,7 @@
           key.name: "sfoo()",
           key.usr: <usr>,
           key.line: 130,
-          key.column: 5,
-          key.receiver_usr: "s:5index2S2V"
+          key.column: 5
         }
       ],
       key.effective_access: source.decl.effective_access.internal
@@ -1367,8 +1374,7 @@
               key.name: "init(x:)",
               key.usr: <usr>,
               key.line: 145,
-              key.column: 11,
-              key.receiver_usr: "s:5index3CC4C"
+              key.column: 11
             }
           ],
           key.effective_access: source.decl.effective_access.internal
@@ -1448,6 +1454,11 @@
                   key.line: 153,
                   key.column: 7
                 }
+              ],
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.final
+                }
               ]
             },
             {
@@ -1463,6 +1474,11 @@
                   key.usr: <usr>,
                   key.line: 156,
                   key.column: 7
+                }
+              ],
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.final
                 }
               ]
             }
@@ -1514,7 +1530,12 @@
               key.name: "didSet:S1",
               key.usr: <usr>,
               key.line: 170,
-              key.column: 5
+              key.column: 5,
+              key.attributes: [
+                {
+                  key.attribute: source.decl.attribute.final
+                }
+              ]
             }
           ],
           key.effective_access: source.decl.effective_access.internal

--- a/test/SourceKit/Indexing/index_effective_access_level.swift.response
+++ b/test/SourceKit/Indexing/index_effective_access_level.swift.response
@@ -440,7 +440,6 @@
                   key.usr: "s:28index_effective_access_level21PublicPropertyWrapperV12wrappedValuexvs",
                   key.line: 56,
                   key.column: 14,
-                  key.receiver_usr: "s:28index_effective_access_level21PublicPropertyWrapperV",
                   key.is_implicit: 1
                 }
               ]

--- a/test/SourceKit/Indexing/index_forbid_typecheck.swift.response
+++ b/test/SourceKit/Indexing/index_forbid_typecheck.swift.response
@@ -88,7 +88,6 @@
               key.usr: "s:16forbid_typecheck6ClsSecC6memberSivg",
               key.line: 5,
               key.column: 20,
-              key.receiver_usr: "s:16forbid_typecheck6ClsSecC",
               key.is_implicit: 1
             }
           ]

--- a/test/SourceKit/Indexing/index_operators.swift.response
+++ b/test/SourceKit/Indexing/index_operators.swift.response
@@ -111,8 +111,7 @@
               key.name: "-(_:_:)",
               key.usr: "s:15index_operators7StructBV1soiyA2C_ACtFZ",
               key.line: 17,
-              key.column: 19,
-              key.receiver_usr: "s:15index_operators7StructBV"
+              key.column: 19
             }
           ],
           key.effective_access: source.decl.effective_access.internal


### PR DESCRIPTION
Cherry-picks 8889daedceaaf537f237619cdbde45a68e6864de (https://github.com/apple/swift/pull/58775). Clients relying on the `is_dynamic` property of a cursor info request to then further perform further lookups (to eg. show overrides where applicable) would previously miss doing so for properties declared in an interface or classes. This change adds `is_dynamic` in these cases.

-----

Properties can also be specified in a protocol/overridden by subclasses,
so they should also be classed as "dynamic" in these cases.

Removed receiver USRs when *not* dynamic, since it's not used for
anything in that case and should be equivalent to the container anyway.

Resolves rdar://92882348.