### PR TITLE
[cxx-interop] Pass clangSema.TUScope when calling LookupName for availability

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8688,7 +8688,7 @@ getSwiftNameFromClangName(StringRef replacement) {
   clang::LookupResult lookupResult(clangSema, identifier,
                                    clang::SourceLocation(),
                                    clang::Sema::LookupOrdinaryName);
-  if (!clangSema.LookupName(lookupResult, nullptr))
+  if (!clangSema.LookupName(lookupResult, clangSema.TUScope))
     return "";
 
   auto clangDecl = lookupResult.getAsSingle<clang::NamedDecl>();

--- a/test/Interop/Cxx/availability/Inputs/SomeModule.h
+++ b/test/Interop/Cxx/availability/Inputs/SomeModule.h
@@ -1,0 +1,9 @@
+typedef char* NSString;
+
+typedef NSString *NSValueTransformerName __attribute__((swift_wrapper(struct)));
+
+extern "C" NSValueTransformerName const NSUnarchiveFromDataTransformerName
+  __attribute__((availability(macos,introduced=10.3,deprecated=10.14,replacement="NSSecureUnarchiveFromDataTransformerName")))
+  __attribute__((availability(ios,introduced=3.0,deprecated=12.0,replacement="NSSecureUnarchiveFromDataTransformerName")))
+  __attribute__((availability(watchos,introduced=2.0,deprecated=5.0,replacement="NSSecureUnarchiveFromDataTransformerName")))
+  __attribute__((availability(tvos,introduced=9.0,deprecated=12.0,replacement="NSSecureUnarchiveFromDataTransformerName")));

--- a/test/Interop/Cxx/availability/Inputs/module.modulemap
+++ b/test/Interop/Cxx/availability/Inputs/module.modulemap
@@ -1,0 +1,4 @@
+module SomeModule [extern_c] {
+  requires objc
+  header "SomeModule.h"
+}

--- a/test/Interop/Cxx/availability/availability-objcxx-smoke.swift
+++ b/test/Interop/Cxx/availability/availability-objcxx-smoke.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=SomeModule -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop -enable-objc-interop | %FileCheck %s
+
+import SomeModule
+
+// CHECK: @available(swift, obsoleted: 3, renamed: "NSValueTransformerName.unarchiveFromDataTransformerName")


### PR DESCRIPTION
In C++-Interop mode some of the Foundation @availables were not getting
their "renamed:" attributes filled in and this was because of the
LookupName issue as we have seen before where LookupName bails in C++
mode due to a nullptr scope resulting in something not getting imported
completely.

This patch merely passes a TUscope to avert this.

I believe ignoring the existing enum issues this should bring
Foundation with C++-Interop to parity with ObjC-Interop.

