### PR TITLE
[Test] Fix the ordering of `await try` -> `try await` in actor_counters.swift

### DIFF
--- a/test/Concurrency/Runtime/actor_counters.swift
+++ b/test/Concurrency/Runtime/actor_counters.swift
@@ -65,7 +65,7 @@ func runTest(numCounters: Int, numWorkers: Int, numIterations: Int) async {
   for i in 0..<numWorkers {
     workers.append(
       Task.detached(priority: randomPriority) { [counters] in
-        await try! Task.sleep(nanoseconds: UInt64.random(in: 0..<100) * 1_000_000)
+        try! await Task.sleep(nanoseconds: UInt64.random(in: 0..<100) * 1_000_000)
         await worker(identity: i, counters: counters, numIterations: numIterations)
       }
     )


### PR DESCRIPTION
- I found a red-syntax-error block in `actor_counters.swift` file. (committed at https://github.com/apple/swift/commit/a39de0693f0152dc917edd1c99afad41790a2356)
- According to the proposal [[SE-0296] Async/await - Await expressions](https://github.com/apple/swift-evolution/blob/main/proposals/0296-async-await.md#await-expressions) and https://github.com/apple/swift/commit/3c38ffe0ea232b81b8dfd8077bc502fff14e5662 commit (which is the same context),
I replaced `await try!` with `try! await`

```swift
// - 
await try! Task.sleep(nanoseconds: UInt64.random(in: 0..<100) * 1_000_000)
// +
try! await Task.sleep(nanoseconds: UInt64.random(in: 0..<100) * 1_000_000)
```