### PR TITLE
[5.7] Disable test Interpreter/convenience_init_peer_delegation.swift

### DIFF
--- a/test/Interpreter/convenience_init_peer_delegation.swift
+++ b/test/Interpreter/convenience_init_peer_delegation.swift
@@ -28,6 +28,9 @@
 // REQUIRES: objc_interop
 // XFAIL: CPU=arm64e
 
+// rdar://92102119
+// REQUIRES: swift_test_mode_optimize_none
+
 import Darwin
 
 class Base {


### PR DESCRIPTION
Disable test in optimized mode. It fails on some bots.

rdar://92102119
