### PR TITLE
[cxx-interop] Do not run `SIL/verify_all_overlays.py` on `std`

### DIFF
--- a/validation-test/SIL/verify_all_overlays.py
+++ b/validation-test/SIL/verify_all_overlays.py
@@ -23,6 +23,10 @@ for module_file in os.listdir(sdk_overlay_dir):
     # Skip the standard library because it's tested elsewhere.
     if module_name == "Swift":
         continue
+    # Skip the C++ standard library overlay because it's not yet shipped
+    # in any released SDK.
+    if module_name == "std":
+        continue
     # TODO(TF-1229): Fix the "_Differentiation" module.
     if module_name == "_Differentiation":
         continue


### PR DESCRIPTION
rdar://93420692