### PR TITLE
[ClangImporter] Use clang getDefaultLanguageStandard

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -576,20 +576,9 @@ importer::getNormalInvocationArguments(
 
   {
     const clang::LangStandard &stdcxx =
-#if defined(CLANG_DEFAULT_STD_CXX)
-        *clang::LangStandard::getLangStandardForName(CLANG_DEFAULT_STD_CXX);
-#else
-        clang::LangStandard::getLangStandardForKind(
-            clang::LangStandard::lang_gnucxx14);
-#endif
-
+        clang::LangStandard::getDefaultLanguageStandard(clang::Language::ObjCXX, triple);
     const clang::LangStandard &stdc =
-#if defined(CLANG_DEFAULT_STD_C)
-        *clang::LangStandard::getLangStandardForName(CLANG_DEFAULT_STD_C);
-#else
-        clang::LangStandard::getLangStandardForKind(
-            clang::LangStandard::lang_gnu11);
-#endif
+        clang::LangStandard::getDefaultLanguageStandard(clang::Language::ObjC, triple);
 
     invocationArgStrs.insert(invocationArgStrs.end(), {
       (Twine("-std=") + StringRef(EnableCXXInterop ? stdcxx.getName()

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -558,6 +558,7 @@ importer::getNormalInvocationArguments(
 
   bool EnableCXXInterop = LangOpts.EnableCXXInterop;
 
+  clang::Language interopLanguage;
   if (LangOpts.EnableObjCInterop) {
     invocationArgStrs.insert(invocationArgStrs.end(), {"-fobjc-arc"});
     // TODO: Investigate whether 7.0 is a suitable default version.
@@ -565,24 +566,22 @@ importer::getNormalInvocationArguments(
       invocationArgStrs.insert(invocationArgStrs.end(),
                                {"-fobjc-runtime=ios-7.0"});
 
+    interopLanguage = EnableCXXInterop ? clang::Language::ObjCXX : clang::Language::ObjC;
     invocationArgStrs.insert(invocationArgStrs.end(), {
       "-x", EnableCXXInterop ? "objective-c++" : "objective-c",
     });
   } else {
+    interopLanguage = EnableCXXInterop ? clang::Language::CXX : clang::Language::C;
     invocationArgStrs.insert(invocationArgStrs.end(), {
       "-x", EnableCXXInterop ? "c++" : "c",
     });
   }
 
   {
-    const clang::LangStandard &stdcxx =
-        clang::LangStandard::getDefaultLanguageStandard(clang::Language::ObjCXX, triple);
-    const clang::LangStandard &stdc =
-        clang::LangStandard::getDefaultLanguageStandard(clang::Language::ObjC, triple);
-
+    const clang::LangStandard &std =
+        clang::LangStandard::getDefaultLanguageStandard(interopLanguage, triple);
     invocationArgStrs.insert(invocationArgStrs.end(), {
-      (Twine("-std=") + StringRef(EnableCXXInterop ? stdcxx.getName()
-                                                   : stdc.getName())).str()
+      (Twine("-std=") + StringRef(std.getName())).str()
     });
   }
 


### PR DESCRIPTION
This moves the logic for selecting the default language standard into Clang, instead of duplicating it.
This is intended to make the reliance on `CLANG_DEFAULT_STD_C(XX)` less fragile, since clang-side refactors caused problems there.

This currently preserves the same standard versions without this change if either of:
- `CLANG_DEFAULT_STD_C(XX)` is set
- ObjC interop is enabled

Questions for reviewers:
- Do we consider it good to have this completely tied to clang? It ensures we'll always be in synch, but it also means that by default we get updated possibly without knowing.
- Is it fine that this bumps the default standards when Objective-C interop is disabled?
- Is it fine that in general, this lets the C vs Objective-C and C++ vs Objective-C++ standard diverge.

Future question, I guess: Should it be possible to explicitly specify the clang importer standard version in some way?