### PR TITLE
[5.7][Parser] Allow parsing `any` in structural position within enum associated value types.

### DIFF
--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -1643,8 +1643,7 @@ bool Parser::canParseTypeTupleBody() {
 
       // If the tuple element starts with "ident :", then it is followed
       // by a type annotation.
-      if (Tok.canBeArgumentLabel() && 
-          (peekToken().is(tok::colon) || peekToken().canBeArgumentLabel())) {
+      if (startsParameterName(/*isClosure=*/false)) {
         consumeToken();
         if (Tok.canBeArgumentLabel()) {
           consumeToken();

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -320,3 +320,12 @@ func testNestedMetatype() {
   let _: (any (P.Type)).Type = (any P.Type).self
   let _: ((any (P.Type))).Type = (any P.Type).self
 }
+
+func testEnumAssociatedValue() {
+  enum E {
+    case c1((any HasAssoc) -> Void)
+    // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}
+    case c2((HasAssoc) -> Void)
+    case c3((P) -> Void)
+  }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/58950

* **Explanation**: `any` does not parse in structural types within enum associated value types. This change allows the following code to compile:

```swift
protocol P {}

enum E {
  case hello((any P) -> Void)
}
```

* **Scope**: This change simply calls into `Parser::startsParameterName`, which already supports looking for contextual `any` and `some`, instead of repeating the code without checking for contextual keywords in `Parser::canParseTypeTupleBody`.
* **Risk**: Low.
* **Testing**: Added new unit tests.
* **Reviewer**: @DougGregor

Resolves: rdar://93382182