### PR TITLE
Potential fix for --xcode build on M1.

### DIFF
--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -171,7 +171,7 @@ function(add_swift_compiler_modules_library name)
   endforeach()
 
   # Create a static library containing all module object files.
-  add_library(${name} STATIC ${all_obj_files})
+  add_library(${name} STATIC force_lib.c ${all_obj_files})
   add_dependencies(${name} ${all_module_targets})
   set_target_properties(${name} PROPERTIES LINKER_LANGUAGE CXX)
   set_property(GLOBAL APPEND PROPERTY SWIFT_BUILDTREE_EXPORTS ${name})

--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -171,7 +171,14 @@ function(add_swift_compiler_modules_library name)
   endforeach()
 
   # Create a static library containing all module object files.
-  add_library(${name} STATIC force_lib.c ${all_obj_files})
+  if (XCODE)
+    # Xcode does not compile libraries that contain only object files.
+    # Therefore, it fails to create the static library. As a workaround,
+    # we add an empty source file force_lib.c to the target.
+    add_library(${name} STATIC force_lib.c ${all_obj_files})
+  else()
+    add_library(${name} STATIC ${all_obj_files})
+  endif()
   add_dependencies(${name} ${all_module_targets})
   set_target_properties(${name} PROPERTIES LINKER_LANGUAGE CXX)
   set_property(GLOBAL APPEND PROPERTY SWIFT_BUILDTREE_EXPORTS ${name})

--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -175,22 +175,12 @@ function(add_swift_compiler_modules_library name)
     # Xcode does not compile libraries that contain only object files.
     # Therefore, it fails to create the static library. As a workaround,
     # we add an empty source file force_lib.c to the target.
-    add_library(${name} STATIC force_lib.c ${all_obj_files})
-  else()
-    add_library(${name} STATIC ${all_obj_files})
+    set(all_obj_files force_lib.c ${all_obj_files})
   endif()
+  add_library(${name} STATIC ${all_obj_files})
   add_dependencies(${name} ${all_module_targets})
   set_target_properties(${name} PROPERTIES LINKER_LANGUAGE CXX)
   set_property(GLOBAL APPEND PROPERTY SWIFT_BUILDTREE_EXPORTS ${name})
-
-  # Xcode does not compile libraries that contain only object files.
-  # Therefore, it fails to create the static library. As a workaround,
-  # we add a dummy script phase to the target.
-  if (XCODE)
-    add_custom_command(TARGET ${name} POST_BUILD 
-      COMMAND ""
-      COMMENT "Dummy script phase to force building this target")
-  endif()
 endfunction()
 
 

--- a/SwiftCompilerSources/force_lib.c
+++ b/SwiftCompilerSources/force_lib.c
@@ -1,0 +1,14 @@
+//===--- force_lib.c ------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Dummy source file to force CMake generated SwiftInTheCompiler.xcodeproj to sucessfully build static
+/// libraries containing only object fies for "bootstrap" process building Swift sources into compiler.

--- a/SwiftCompilerSources/force_lib.c
+++ b/SwiftCompilerSources/force_lib.c
@@ -10,5 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// Dummy source file to force CMake generated SwiftInTheCompiler.xcodeproj to sucessfully build static
-/// libraries containing only object fies for "bootstrap" process building Swift sources into compiler.
+/// Dummy source file to force CMake generated SwiftInTheCompiler.xcodeproj
+/// to sucessfully build static libraries conatining only object files used
+/// during "bootstrap" process to link Swift sources into the compiler.


### PR DESCRIPTION
Hi Apple,

I've been having difficulties building the Swift compiler on an M1 for some time now. This small CMake fix seems to resolve the problem and carry relatively little risk of regression. The problem was the generated `SwiftInTheCompiler.xcodeproj` was silently failing to build the static libraries containing Swift sources used in the bootstrapping process to link them into the compiler. This seems to be a feature of Xcode when the target doesn't contain a "Compile Sources" build phase and only links object files (I have no idea why this would be specific to M1.) By creating a dummy source file and including it in the project this forces Xcode to build the static library and subsequent bootstrapping stages can proceed.

I'm using Xcode 13.4 & 13.2.1, CMake 3.23.1 & 3.20.1