### PR TITLE
Sema: Improve availability diagnostics when `-target-min-inlining-version min` is specified

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5547,9 +5547,15 @@ ERROR(availability_decl_only_version_newer, none,
       "%0 is only available in %1 %2 or newer",
       (DeclName, StringRef, llvm::VersionTuple))
 
-WARNING(availability_decl_only_version_newer_warn, none,
-        "%0 is only available in %1 %2 or newer",
-        (DeclName, StringRef, llvm::VersionTuple))
+ERROR(availability_decl_only_version_newer_for_clients, none,
+      "%0 is only available in %1 %2 or newer; clients of %3 may have a lower"
+      " deployment target",
+      (DeclName, StringRef, llvm::VersionTuple, ModuleDecl *))
+
+WARNING(availability_decl_only_version_newer_for_clients_warn, none,
+        "%0 is only available in %1 %2 or newer; clients of %3 may have a lower"
+        " deployment target",
+        (DeclName, StringRef, llvm::VersionTuple, ModuleDecl *))
 
 ERROR(availability_opaque_types_only_version_newer, none,
       "'some' return types are only available in %0 %1 or newer",

--- a/test/attr/attr_inlinable_available.swift
+++ b/test/attr/attr_inlinable_available.swift
@@ -97,6 +97,28 @@ public protocol AfterDeploymentTargetProto {}
 @available(macOS, unavailable)
 public protocol UnavailableProto {}
 
+// MARK: - Class definitions
+
+public class NoAvailableClass {}
+
+@available(macOS 10.9, *)
+public class BeforeInliningTargetClass {}
+
+@available(macOS 10.10, *)
+public class AtInliningTargetClass {}
+
+@available(macOS 10.14.5, *)
+public class BetweenTargetsClass {}
+
+@available(macOS 10.15, *)
+public class AtDeploymentTargetClass {}
+
+@available(macOS 11, *)
+public class AfterDeploymentTargetClass {}
+
+@available(macOS, unavailable)
+public class UnavailableClass {}
+
 
 // MARK: - Internal functions
 
@@ -1163,6 +1185,40 @@ enum InternalNoAvailableEnumWithTypeAliases { // expected-note {{add @available 
   public typealias F = AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add @available attribute to enclosing type alias}}
 }
 
+// MARK: - Class inheritance
+
+// FIXME: Duplicate 'add @available' emitted when classes are nested in a decl
+
+public enum NoAvailableEnumWithClasses {
+  public class InheritsNoAvailable: NoAvailableClass {}
+  public class InheritsBeforeInliningTarget: BeforeInliningTargetClass {}
+  public class InheritsAtInliningTarget: AtInliningTargetClass {}
+  public class InheritsBetweenTargets: BetweenTargetsClass {} // expected-error {{'BetweenTargetsClass' is only available in macOS 10.14.5 or newer}} expected-note 2 {{add @available attribute to enclosing class}}
+  public class InheritsAtDeploymentTarget: AtDeploymentTargetClass {} // expected-error {{'AtDeploymentTargetClass' is only available in macOS 10.15 or newer}} expected-note 2 {{add @available attribute to enclosing class}}
+  public class InheritsAfterDeploymentTarget: AfterDeploymentTargetClass {} // expected-error {{'AfterDeploymentTargetClass' is only available in macOS 11 or newer}} expected-note 2 {{add @available attribute to enclosing class}}
+}
+
+@_spi(Private)
+public enum SPIEnumWithClasses {
+  public class InheritsNoAvailable: NoAvailableClass {}
+  public class InheritsBeforeInliningTarget: BeforeInliningTargetClass {}
+  public class InheritsAtInliningTarget: AtInliningTargetClass {}
+  public class InheritsBetweenTargets: BetweenTargetsClass {}
+  public class InheritsAtDeploymentTarget: AtDeploymentTargetClass {}
+  // FIXME: Duplicate 'add @available' note is emitted
+  public class InheritsAfterDeploymentTarget: AfterDeploymentTargetClass {} // expected-error {{'AfterDeploymentTargetClass' is only available in}} expected-note 2 {{add @available attribute to enclosing class}}
+}
+
+@available(macOS, unavailable)
+public enum UnavailableEnumWithClasses {
+  public class InheritsNoAvailable: NoAvailableClass {}
+  public class InheritsBeforeInliningTarget: BeforeInliningTargetClass {}
+  public class InheritsAtInliningTarget: AtInliningTargetClass {}
+  public class InheritsBetweenTargets: BetweenTargetsClass {}
+  public class InheritsAtDeploymentTarget: AtDeploymentTargetClass {}
+  public class InheritsAfterDeploymentTarget: AfterDeploymentTargetClass {} // expected-error {{'AfterDeploymentTargetClass' is only available in}} expected-note 2 {{add @available attribute to enclosing class}}
+  public class InheritsUnavailable: UnavailableClass {}
+}
 
 // MARK: - Top-level code
 

--- a/test/attr/attr_inlinable_available.swift
+++ b/test/attr/attr_inlinable_available.swift
@@ -34,7 +34,7 @@
 
 
 // NON_MIN: error: expected error not produced
-// NON_MIN: {'BetweenTargets' is only available in macOS 10.14.5 or newer}
+// NON_MIN: {'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}
 
 
 // MARK: - Struct definitions
@@ -162,8 +162,8 @@ public func deployedUseNoAvailable( // expected-note 5 {{add @available attribut
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
-  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}}
-  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}}
+  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}}
+  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}}
   _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 ) {
   defer {
@@ -187,8 +187,8 @@ public func deployedUseBeforeInliningTarget(
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
-  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}}
-  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}}
+  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}}
+  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}}
   _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 ) {
   defer {
@@ -212,8 +212,8 @@ public func deployedUseAtInliningTarget(
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
-  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}}
-  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}}
+  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}}
+  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}}
   _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 ) {
   defer {
@@ -238,7 +238,7 @@ public func deployedUseBetweenTargets(
   _: BeforeInliningTarget,
   _: AtInliningTarget,
   _: BetweenTargets,
-  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}}
+  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}}
   _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 ) {
   defer {
@@ -366,19 +366,19 @@ public func spiDeployedUseNoAvailable( // expected-note 3 {{add @available attri
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
-  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}}
-  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}}
+  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}}
+  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}}
   _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 ) {
   defer {
-    _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}} expected-note {{add 'if #available'}}
+    _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}} expected-note {{add 'if #available'}}
     _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
   }
   _ = NoAvailable()
   _ = BeforeInliningTarget()
   _ = AtInliningTarget()
-  _ = BetweenTargets() // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}} expected-note {{add 'if #available'}}
-  _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}} expected-note {{add 'if #available'}}
+  _ = BetweenTargets() // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}} expected-note {{add 'if #available'}}
+  _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}} expected-note {{add 'if #available'}}
   _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
 
   if #available(macOS 10.14.5, *) {
@@ -397,19 +397,19 @@ public func spiDeployedUseNoAvailable( // expected-note 3 {{add @available attri
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
-  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}}
-  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}}
+  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}}
+  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}}
   _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 ) {
   defer {
-    _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}} expected-note {{add 'if #available'}}
+    _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}} expected-note {{add 'if #available'}}
     _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
   }
   _ = NoAvailable()
   _ = BeforeInliningTarget()
   _ = AtInliningTarget()
-  _ = BetweenTargets() // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}} expected-note {{add 'if #available'}}
-  _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}} expected-note {{add 'if #available'}}
+  _ = BetweenTargets() // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}} expected-note {{add 'if #available'}}
+  _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}} expected-note {{add 'if #available'}}
   _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
 
   if #available(macOS 10.14.5, *) {
@@ -428,19 +428,19 @@ public func spiDeployedUseNoAvailable( // expected-note 3 {{add @available attri
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
-  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}}
-  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}}
+  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}}
+  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}}
   _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 ) {
   defer {
-    _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}} expected-note {{add 'if #available'}}
+    _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}} expected-note {{add 'if #available'}}
     _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
   }
   _ = NoAvailable()
   _ = BeforeInliningTarget()
   _ = AtInliningTarget()
-  _ = BetweenTargets() // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}} expected-note {{add 'if #available'}}
-  _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}} expected-note {{add 'if #available'}}
+  _ = BetweenTargets() // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}} expected-note {{add 'if #available'}}
+  _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}} expected-note {{add 'if #available'}}
   _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
 
   if #available(macOS 10.14.5, *) {
@@ -460,18 +460,18 @@ public func spiDeployedUseNoAvailable( // expected-note 3 {{add @available attri
   _: BeforeInliningTarget,
   _: AtInliningTarget,
   _: BetweenTargets,
-  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}}
+  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}}
   _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 ) {
   defer {
-    _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}} expected-note {{add 'if #available'}}
+    _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}} expected-note {{add 'if #available'}}
     _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
   }
   _ = NoAvailable()
   _ = BeforeInliningTarget()
   _ = AtInliningTarget()
   _ = BetweenTargets()
-  _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}} expected-note {{add 'if #available'}}
+  _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}} expected-note {{add 'if #available'}}
   _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
 
   if #available(macOS 10.15, *) {
@@ -589,19 +589,19 @@ public func spiDeployedUseNoAvailable( // expected-note 3 {{add @available attri
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
-  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}}
-  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}}
+  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}}
+  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}}
   _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 ) {
   defer {
-    _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}} expected-note {{add 'if #available'}}
+    _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}} expected-note {{add 'if #available'}}
     _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
   }
   _ = NoAvailable()
   _ = BeforeInliningTarget()
   _ = AtInliningTarget()
-  _ = BetweenTargets() // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}} expected-note {{add 'if #available'}}
-  _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}} expected-note {{add 'if #available'}}
+  _ = BetweenTargets() // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}} expected-note {{add 'if #available'}}
+  _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}} expected-note {{add 'if #available'}}
   _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
 
   if #available(macOS 10.14.5, *) {
@@ -626,19 +626,19 @@ public func backDeployedToInliningTarget(
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
-  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}}
-  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}}
+  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}}
+  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}}
   _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 ) {
   defer {
-    _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}} expected-note {{add 'if #available'}}
+    _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}} expected-note {{add 'if #available'}}
     _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
   }
   _ = NoAvailable()
   _ = BeforeInliningTarget()
   _ = AtInliningTarget()
-  _ = BetweenTargets() // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}} expected-note {{add 'if #available'}}
-  _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}} expected-note {{add 'if #available'}}
+  _ = BetweenTargets() // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}} expected-note {{add 'if #available'}}
+  _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}} expected-note {{add 'if #available'}}
   _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
 
   if #available(macOS 10.14.5, *) {
@@ -661,8 +661,8 @@ public func defaultArgsUseNoAvailable( // expected-note 3 {{add @available attri
   _: Any = NoAvailable.self,
   _: Any = BeforeInliningTarget.self,
   _: Any = AtInliningTarget.self,
-  _: Any = BetweenTargets.self, // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}}
-  _: Any = AtDeploymentTarget.self, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}}
+  _: Any = BetweenTargets.self, // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}}
+  _: Any = AtDeploymentTarget.self, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}}
   _: Any = AfterDeploymentTarget.self // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 ) {}
 
@@ -700,8 +700,8 @@ public struct PublicStruct { // expected-note 13 {{add @available attribute}}
   public var aPublic: NoAvailable,
              bPublic: BeforeInliningTarget,
              cPublic: AtInliningTarget,
-             dPublic: BetweenTargets, // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}}
-             ePublic: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}}
+             dPublic: BetweenTargets, // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}}
+             ePublic: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}}
              fPublic: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 
   @available(macOS 10.14.5, *)
@@ -709,7 +709,7 @@ public struct PublicStruct { // expected-note 13 {{add @available attribute}}
              bPublicAvailBetween: BeforeInliningTarget,
              cPublicAvailBetween: AtInliningTarget,
              dPublicAvailBetween: BetweenTargets,
-             ePublicAvailBetween: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}}
+             ePublicAvailBetween: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}}
              fPublicAvailBetween: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 
   // The inferred types of public properties are exposed.
@@ -752,7 +752,7 @@ public struct PublicStruct { // expected-note 13 {{add @available attribute}}
       _ = BeforeInliningTarget()
       _ = AtInliningTarget()
       _ = BetweenTargets()
-      _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}} expected-note {{add 'if #available'}}
+      _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}} expected-note {{add 'if #available'}}
       _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
 
       if #available(macOS 10.15, *) {
@@ -835,24 +835,24 @@ public struct PublicStructWithWrappers { // expected-note 4 {{add @available att
   public var aPublic: NoAvailable,
              bPublic: BeforeInliningTarget,
              cPublic: AtInliningTarget,
-             dPublic: BetweenTargets, // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}}
-             ePublic: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}}
+             dPublic: BetweenTargets, // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}}
+             ePublic: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}}
              fPublic: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 
   // Property initializers are exposed in frozen structs.
   public var aPublicInit: Any = NoAvailable(),
              bPublicInit: Any = BeforeInliningTarget(),
              cPublicInit: Any = AtInliningTarget(),
-             dPublicInit: Any = BetweenTargets(), // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}}
-             ePublicInit: Any = AtDeploymentTarget(), // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}}
+             dPublicInit: Any = BetweenTargets(), // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}}
+             ePublicInit: Any = AtDeploymentTarget(), // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}}
              fPublicInit: Any = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 
   // Internal declarations are also exposed in frozen structs.
   var aInternal: NoAvailable = .init(),
       bInternal: BeforeInliningTarget = .init(),
       cInternal: AtInliningTarget = .init(),
-      dInternal: BetweenTargets = .init(), // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}}
-      eInternal: AtDeploymentTarget = .init(), // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}}
+      dInternal: BetweenTargets = .init(), // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}}
+      eInternal: AtDeploymentTarget = .init(), // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}}
       fInternal: AfterDeploymentTarget = .init() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 }
 
@@ -949,18 +949,18 @@ extension BetweenTargets {
   fileprivate func fileprivateFunc1() {}
 }
 
-// expected-warning@+1 {{'BetweenTargets' is only available in macOS 10.14.5 or newer}} expected-note@+1 {{add @available attribute to enclosing extension}}
+// expected-warning@+1 {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}} expected-note@+1 {{add @available attribute to enclosing extension}}
 extension BetweenTargets {
   public func publicFunc1() {}
 }
 
-// expected-warning@+1 {{'BetweenTargets' is only available in macOS 10.14.5 or newer}} expected-note@+1 {{add @available attribute to enclosing extension}}
+// expected-warning@+1 {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}} expected-note@+1 {{add @available attribute to enclosing extension}}
 extension BetweenTargets {
   @usableFromInline
   internal func usableFromInlineFunc1() {}
 }
 
-// expected-warning@+1 {{'BetweenTargets' is only available in macOS 10.14.5 or newer}} expected-note@+1 {{add @available attribute to enclosing extension}}
+// expected-warning@+1 {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}} expected-note@+1 {{add @available attribute to enclosing extension}}
 extension BetweenTargets {
   internal func internalFunc2() {}
   private func privateFunc2() {}
@@ -969,14 +969,14 @@ extension BetweenTargets {
 }
 
 // An extension with more availability than BetweenTargets.
-// expected-error@+2 {{'BetweenTargets' is only available in macOS 10.14.5 or newer}}
+// expected-error@+2 {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}}
 @available(macOS 10.10, *)
 extension BetweenTargets {
   public func publicFunc3() {}
 }
 
 // FIXME: Can we prevent this warning when SPI members are the reason the extension is exported?
-// expected-warning@+1 {{'BetweenTargets' is only available in macOS 10.14.5 or newer}} expected-note@+1 {{add @available attribute to enclosing extension}}
+// expected-warning@+1 {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}} expected-note@+1 {{add @available attribute to enclosing extension}}
 extension BetweenTargets {
   @_spi(Private)
   public func spiFunc1() {}
@@ -1025,6 +1025,11 @@ extension BetweenTargetsInternal {
   public func publicFunc() {}
 }
 
+// expected-warning@+1 {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}} expected-note@+1 {{add @available attribute to enclosing extension}}
+extension AtDeploymentTarget {
+  public func publicFunc() {}
+}
+
 // expected-error@+1 {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note@+1 {{add @available attribute to enclosing extension}}
 extension AfterDeploymentTarget {}
 
@@ -1057,8 +1062,8 @@ public protocol PublicProto {}
 extension NoAvailable: PublicProto {}
 extension BeforeInliningTarget: PublicProto {}
 extension AtInliningTarget: PublicProto {}
-extension BetweenTargets: PublicProto {} // expected-warning {{'BetweenTargets' is only available in macOS 10.14.5 or newer}} expected-note {{add @available attribute to enclosing extension}}
-extension AtDeploymentTarget: PublicProto {} // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}} expected-note {{add @available attribute to enclosing extension}}
+extension BetweenTargets: PublicProto {} // expected-warning {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}} expected-note {{add @available attribute to enclosing extension}}
+extension AtDeploymentTarget: PublicProto {} // expected-warning {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}} expected-note {{add @available attribute to enclosing extension}}
 extension AfterDeploymentTarget: PublicProto {} // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add @available attribute to enclosing extension}}
 
 
@@ -1068,8 +1073,8 @@ public protocol NoAvailableProtoWithAssoc { // expected-note 3 {{add @available 
   associatedtype A: NoAvailableProto
   associatedtype B: BeforeInliningTargetProto
   associatedtype C: AtInliningTargetProto
-  associatedtype D: BetweenTargetsProto // expected-error {{'BetweenTargetsProto' is only available in macOS 10.14.5 or newer}}
-  associatedtype E: AtDeploymentTargetProto // expected-error {{'AtDeploymentTargetProto' is only available in macOS 10.15 or newer}}
+  associatedtype D: BetweenTargetsProto // expected-error {{'BetweenTargetsProto' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}}
+  associatedtype E: AtDeploymentTargetProto // expected-error {{'AtDeploymentTargetProto' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}}
   associatedtype F: AfterDeploymentTargetProto // expected-error {{'AfterDeploymentTargetProto' is only available in}}
 }
 
@@ -1078,8 +1083,8 @@ public protocol BeforeInliningTargetProtoWithAssoc {
   associatedtype A: NoAvailableProto
   associatedtype B: BeforeInliningTargetProto
   associatedtype C: AtInliningTargetProto
-  associatedtype D: BetweenTargetsProto // expected-error {{'BetweenTargetsProto' is only available in macOS 10.14.5 or newer}}
-  associatedtype E: AtDeploymentTargetProto // expected-error {{'AtDeploymentTargetProto' is only available in macOS 10.15 or newer}}
+  associatedtype D: BetweenTargetsProto // expected-error {{'BetweenTargetsProto' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}}
+  associatedtype E: AtDeploymentTargetProto // expected-error {{'AtDeploymentTargetProto' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}}
   associatedtype F: AfterDeploymentTargetProto // expected-error {{'AfterDeploymentTargetProto' is only available in}}
 }
 
@@ -1088,8 +1093,8 @@ public protocol AtInliningTargetProtoWithAssoc {
   associatedtype A: NoAvailableProto
   associatedtype B: BeforeInliningTargetProto
   associatedtype C: AtInliningTargetProto
-  associatedtype D: BetweenTargetsProto // expected-error {{'BetweenTargetsProto' is only available in macOS 10.14.5 or newer}}
-  associatedtype E: AtDeploymentTargetProto // expected-error {{'AtDeploymentTargetProto' is only available in macOS 10.15 or newer}}
+  associatedtype D: BetweenTargetsProto // expected-error {{'BetweenTargetsProto' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}}
+  associatedtype E: AtDeploymentTargetProto // expected-error {{'AtDeploymentTargetProto' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}}
   associatedtype F: AfterDeploymentTargetProto // expected-error {{'AfterDeploymentTargetProto' is only available in}}
 }
 
@@ -1099,7 +1104,7 @@ public protocol BetweenTargetsProtoWithAssoc {
   associatedtype B: BeforeInliningTargetProto
   associatedtype C: AtInliningTargetProto
   associatedtype D: BetweenTargetsProto
-  associatedtype E: AtDeploymentTargetProto // expected-error {{'AtDeploymentTargetProto' is only available in macOS 10.15 or newer}}
+  associatedtype E: AtDeploymentTargetProto // expected-error {{'AtDeploymentTargetProto' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}}
   associatedtype F: AfterDeploymentTargetProto // expected-error {{'AfterDeploymentTargetProto' is only available in}}
 }
 
@@ -1150,8 +1155,8 @@ public enum PublicNoAvailableEnumWithTypeAliases { // expected-note 3 {{add @ava
   public typealias A = NoAvailable
   public typealias B = BeforeInliningTarget
   public typealias C = AtInliningTarget
-  public typealias D = BetweenTargets // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}} expected-note {{add @available attribute to enclosing type alias}}
-  public typealias E = AtDeploymentTarget // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}} expected-note {{add @available attribute to enclosing type alias}}
+  public typealias D = BetweenTargets // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}} expected-note {{add @available attribute to enclosing type alias}}
+  public typealias E = AtDeploymentTarget // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}} expected-note {{add @available attribute to enclosing type alias}}
   public typealias F = AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add @available attribute to enclosing type alias}}
 }
 
@@ -1193,8 +1198,8 @@ public enum NoAvailableEnumWithClasses {
   public class InheritsNoAvailable: NoAvailableClass {}
   public class InheritsBeforeInliningTarget: BeforeInliningTargetClass {}
   public class InheritsAtInliningTarget: AtInliningTargetClass {}
-  public class InheritsBetweenTargets: BetweenTargetsClass {} // expected-error {{'BetweenTargetsClass' is only available in macOS 10.14.5 or newer}} expected-note 2 {{add @available attribute to enclosing class}}
-  public class InheritsAtDeploymentTarget: AtDeploymentTargetClass {} // expected-error {{'AtDeploymentTargetClass' is only available in macOS 10.15 or newer}} expected-note 2 {{add @available attribute to enclosing class}}
+  public class InheritsBetweenTargets: BetweenTargetsClass {} // expected-error {{'BetweenTargetsClass' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}} expected-note 2 {{add @available attribute to enclosing class}}
+  public class InheritsAtDeploymentTarget: AtDeploymentTargetClass {} // expected-error {{'AtDeploymentTargetClass' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}} expected-note 2 {{add @available attribute to enclosing class}}
   public class InheritsAfterDeploymentTarget: AfterDeploymentTargetClass {} // expected-error {{'AfterDeploymentTargetClass' is only available in macOS 11 or newer}} expected-note 2 {{add @available attribute to enclosing class}}
 }
 

--- a/test/attr/attr_inlinable_available.swift
+++ b/test/attr/attr_inlinable_available.swift
@@ -5,39 +5,36 @@
 // inlinable bodies will ever see.
 //
 // Test that we use the right version floor in the right places.
-//
-// To keep this test multi-platform, we only check fragments of diagnostics that
-// don't include platform names or versions.
 
-// REQUIRES: swift_stable_abi
+// REQUIRES: OS=macosx
 
 // Primary execution of this test. Uses the default minimum inlining version,
 // which is the version when Swift was introduced.
-// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-library-evolution -target %target-next-stable-abi-triple -target-min-inlining-version min
+// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-library-evolution -module-name Test -target %target-next-stable-abi-triple -target-min-inlining-version min
 
 
 // FIXME: Re-enable with rdar://91387029
 // Check that `-library-level api` implies `-target-min-inlining-version min`
-// RUN/: %target-typecheck-verify-swift -swift-version 5 -enable-library-evolution -target %target-next-stable-abi-triple -library-level api
+// RUN/: %target-typecheck-verify-swift -swift-version 5 -enable-library-evolution -module-name Test -target %target-next-stable-abi-triple -library-level api
 
 
 // Check that these rules are only applied when requested and that at least some
 // diagnostics are not present without it.
-// RUN: not %target-typecheck-verify-swift -swift-version 5 -target %target-next-stable-abi-triple 2>&1 | %FileCheck --check-prefix NON_MIN %s
+// RUN: not %target-typecheck-verify-swift -swift-version 5 -enable-library-evolution -module-name Test -target %target-next-stable-abi-triple 2>&1 | %FileCheck --check-prefix NON_MIN %s
 
 
 // Check that -target-min-inlining-version overrides -library-level, allowing
 // library owners to disable this behavior for API libraries if needed.
-// RUN: not %target-typecheck-verify-swift -swift-version 5 -target %target-next-stable-abi-triple -target-min-inlining-version target -library-level api 2>&1 | %FileCheck --check-prefix NON_MIN %s
+// RUN: not %target-typecheck-verify-swift -swift-version 5 -enable-library-evolution -module-name Test -target %target-next-stable-abi-triple -target-min-inlining-version target -library-level api 2>&1 | %FileCheck --check-prefix NON_MIN %s
 
 
 // Check that we respect -target-min-inlining-version by cranking it up high
 // enough to suppress any possible errors.
-// RUN: %target-swift-frontend -typecheck -disable-objc-attr-requires-foundation-module %s -swift-version 5 -enable-library-evolution -target %target-next-stable-abi-triple -target-min-inlining-version 42.0
+// RUN: %target-swift-frontend -typecheck -disable-objc-attr-requires-foundation-module %s -swift-version 5 -enable-library-evolution -module-name Test -target %target-next-stable-abi-triple -target-min-inlining-version 42.0
 
 
 // NON_MIN: error: expected error not produced
-// NON_MIN: {'BetweenTargets' is only available in}
+// NON_MIN: {'BetweenTargets' is only available in macOS 10.14.5 or newer}
 
 
 // MARK: - Struct definitions
@@ -48,35 +45,32 @@ public struct NoAvailable {
   @usableFromInline internal init() {}
 }
 
-@available(macOS 10.9, iOS 7.0, tvOS 8.0, watchOS 1.0, *)
+@available(macOS 10.9, *)
 public struct BeforeInliningTarget {
   @usableFromInline internal init() {}
 }
 
-@available(macOS 10.10, iOS 8.0, tvOS 9.0, watchOS 2.0, *)
+@available(macOS 10.10, *)
 public struct AtInliningTarget {
   @usableFromInline internal init() {}
 }
 
-@available(macOS 10.14.5, iOS 12.3, tvOS 12.3, watchOS 5.3, *)
+@available(macOS 10.14.5, *)
 public struct BetweenTargets {
   @usableFromInline internal init() {}
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, *)
 public struct AtDeploymentTarget {
   @usableFromInline internal init() {}
 }
 
-@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
+@available(macOS 11, *)
 public struct AfterDeploymentTarget {
   @usableFromInline internal init() {}
 }
 
 @available(macOS, unavailable)
-@available(iOS, unavailable)
-@available(tvOS, unavailable)
-@available(watchOS, unavailable)
 public struct Unavailable {
   @usableFromInline internal init() {}
 }
@@ -85,25 +79,22 @@ public struct Unavailable {
 
 public protocol NoAvailableProto {}
 
-@available(macOS 10.9, iOS 7.0, tvOS 8.0, watchOS 1.0, *)
+@available(macOS 10.9, *)
 public protocol BeforeInliningTargetProto {}
 
-@available(macOS 10.10, iOS 8.0, tvOS 9.0, watchOS 2.0, *)
+@available(macOS 10.10, *)
 public protocol AtInliningTargetProto {}
 
-@available(macOS 10.14.5, iOS 12.3, tvOS 12.3, watchOS 5.3, *)
+@available(macOS 10.14.5, *)
 public protocol BetweenTargetsProto {}
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, *)
 public protocol AtDeploymentTargetProto {}
 
-@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
+@available(macOS 11, *)
 public protocol AfterDeploymentTargetProto {}
 
 @available(macOS, unavailable)
-@available(iOS, unavailable)
-@available(tvOS, unavailable)
-@available(watchOS, unavailable)
 public protocol UnavailableProto {}
 
 
@@ -120,20 +111,20 @@ internal func internalFn( // expected-note 3 {{add @available attribute to enclo
   _: AtInliningTarget,
   _: BetweenTargets,
   _: AtDeploymentTarget,
-  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
+  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 ) {
   defer {
     _ = AtDeploymentTarget()
-    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
   }
   _ = NoAvailable()
   _ = BeforeInliningTarget()
   _ = AtInliningTarget()
   _ = BetweenTargets()
   _ = AtDeploymentTarget()
-  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
 
-  if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+  if #available(macOS 11, *) {
     _ = AfterDeploymentTarget()
   }
 }
@@ -149,127 +140,127 @@ public func deployedUseNoAvailable( // expected-note 5 {{add @available attribut
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
-  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in}}
-  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in}}
-  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
+  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}}
+  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}}
+  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 ) {
   defer {
     _ = AtDeploymentTarget()
-    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
   }
   _ = NoAvailable()
   _ = BeforeInliningTarget()
   _ = AtInliningTarget()
   _ = BetweenTargets()
   _ = AtDeploymentTarget()
-  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
 
-  if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+  if #available(macOS 11, *) {
     _ = AfterDeploymentTarget()
   }
 }
 
-@available(macOS 10.9, iOS 7.0, tvOS 8.0, watchOS 1.0, *)
+@available(macOS 10.9, *)
 public func deployedUseBeforeInliningTarget(
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
-  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in}}
-  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in}}
-  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
+  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}}
+  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}}
+  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 ) {
   defer {
     _ = AtDeploymentTarget()
-    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
   }
   _ = NoAvailable()
   _ = BeforeInliningTarget()
   _ = AtInliningTarget()
   _ = BetweenTargets()
   _ = AtDeploymentTarget()
-  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
 
-  if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+  if #available(macOS 11, *) {
     _ = AfterDeploymentTarget()
   }
 }
 
-@available(macOS 10.10, iOS 8.0, tvOS 9.0, watchOS 2.0, *)
+@available(macOS 10.10, *)
 public func deployedUseAtInliningTarget(
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
-  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in}}
-  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in}}
-  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
+  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}}
+  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}}
+  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 ) {
   defer {
     _ = AtDeploymentTarget()
-    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
   }
   _ = NoAvailable()
   _ = BeforeInliningTarget()
   _ = AtInliningTarget()
   _ = BetweenTargets()
   _ = AtDeploymentTarget()
-  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
 
-  if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+  if #available(macOS 11, *) {
     _ = AfterDeploymentTarget()
   }
 }
 
-@available(macOS 10.14.5, iOS 12.3, tvOS 12.3, watchOS 5.3, *)
+@available(macOS 10.14.5, *)
 public func deployedUseBetweenTargets(
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
   _: BetweenTargets,
-  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in}}
-  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
+  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}}
+  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 ) {
   defer {
     _ = AtDeploymentTarget()
-    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
   }
   _ = NoAvailable()
   _ = BeforeInliningTarget()
   _ = AtInliningTarget()
   _ = BetweenTargets()
   _ = AtDeploymentTarget()
-  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
 
-  if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+  if #available(macOS 11, *) {
     _ = AfterDeploymentTarget()
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, *)
 public func deployedUseAtDeploymentTarget(
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
   _: BetweenTargets,
   _: AtDeploymentTarget,
-  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
+  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 ) {
   defer {
     _ = AtDeploymentTarget()
-    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
   }
   _ = NoAvailable()
   _ = BeforeInliningTarget()
   _ = AtInliningTarget()
   _ = BetweenTargets()
   _ = AtDeploymentTarget()
-  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
 
-  if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+  if #available(macOS 11, *) {
     _ = AfterDeploymentTarget()
   }
 }
 
-@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
+@available(macOS 11, *)
 public func deployedUseAfterDeploymentTarget(
   _: NoAvailable,
   _: BeforeInliningTarget,
@@ -291,9 +282,6 @@ public func deployedUseAfterDeploymentTarget(
 }
 
 @available(macOS, unavailable)
-@available(iOS, unavailable)
-@available(tvOS, unavailable)
-@available(watchOS, unavailable)
 public func alwaysUnavailable(
   _: NoAvailable,
   _: BeforeInliningTarget,
@@ -305,17 +293,17 @@ public func alwaysUnavailable(
 ) {
   defer {
     _ = AtDeploymentTarget()
-    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
   }
   _ = NoAvailable()
   _ = BeforeInliningTarget()
   _ = AtInliningTarget()
   _ = BetweenTargets()
   _ = AtDeploymentTarget()
-  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
   _ = Unavailable()
   
-  if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+  if #available(macOS 11, *) {
     _ = AfterDeploymentTarget()
   }
 }
@@ -327,20 +315,20 @@ public func spiDeployedUseNoAvailable( // expected-note 3 {{add @available attri
   _: AtInliningTarget,
   _: BetweenTargets,
   _: AtDeploymentTarget,
-  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
+  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 ) {
   defer {
     _ = AtDeploymentTarget()
-    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
   }
   _ = NoAvailable()
   _ = BeforeInliningTarget()
   _ = AtInliningTarget()
   _ = BetweenTargets()
   _ = AtDeploymentTarget()
-  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
 
-  if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+  if #available(macOS 11, *) {
     _ = AfterDeploymentTarget()
   }
 }
@@ -356,148 +344,148 @@ public func spiDeployedUseNoAvailable( // expected-note 3 {{add @available attri
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
-  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in}}
-  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in}}
-  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
+  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}}
+  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}}
+  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 ) {
   defer {
-    _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
-    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+    _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}} expected-note {{add 'if #available'}}
+    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
   }
   _ = NoAvailable()
   _ = BeforeInliningTarget()
   _ = AtInliningTarget()
-  _ = BetweenTargets() // expected-error {{'BetweenTargets' is only available in}} expected-note {{add 'if #available'}}
-  _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
-  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+  _ = BetweenTargets() // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}} expected-note {{add 'if #available'}}
+  _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}} expected-note {{add 'if #available'}}
+  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
 
-  if #available(macOS 10.14.5, iOS 12.3, tvOS 12.3, watchOS 5.3, *) {
+  if #available(macOS 10.14.5, *) {
     _ = BetweenTargets()
   }
-  if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+  if #available(macOS 10.15, *) {
     _ = AtDeploymentTarget()
   }
-  if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+  if #available(macOS 11, *) {
     _ = AfterDeploymentTarget()
   }
 }
 
-@available(macOS 10.9, iOS 7.0, tvOS 8.0, watchOS 1.0, *)
+@available(macOS 10.9, *)
 @inlinable public func inlinedUseBeforeInliningTarget(
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
-  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in}}
-  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in}}
-  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
+  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}}
+  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}}
+  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 ) {
   defer {
-    _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
-    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+    _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}} expected-note {{add 'if #available'}}
+    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
   }
   _ = NoAvailable()
   _ = BeforeInliningTarget()
   _ = AtInliningTarget()
-  _ = BetweenTargets() // expected-error {{'BetweenTargets' is only available in}} expected-note {{add 'if #available'}}
-  _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
-  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+  _ = BetweenTargets() // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}} expected-note {{add 'if #available'}}
+  _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}} expected-note {{add 'if #available'}}
+  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
 
-  if #available(macOS 10.14.5, iOS 12.3, tvOS 12.3, watchOS 5.3, *) {
+  if #available(macOS 10.14.5, *) {
     _ = BetweenTargets()
   }
-  if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+  if #available(macOS 10.15, *) {
     _ = AtDeploymentTarget()
   }
-  if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+  if #available(macOS 11, *) {
     _ = AfterDeploymentTarget()
   }
 }
 
-@available(macOS 10.10, iOS 8.0, tvOS 9.0, watchOS 2.0, *)
+@available(macOS 10.10, *)
 @inlinable public func inlinedUseAtInliningTarget(
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
-  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in}}
-  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in}}
-  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
+  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}}
+  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}}
+  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 ) {
   defer {
-    _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
-    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+    _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}} expected-note {{add 'if #available'}}
+    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
   }
   _ = NoAvailable()
   _ = BeforeInliningTarget()
   _ = AtInliningTarget()
-  _ = BetweenTargets() // expected-error {{'BetweenTargets' is only available in}} expected-note {{add 'if #available'}}
-  _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
-  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+  _ = BetweenTargets() // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}} expected-note {{add 'if #available'}}
+  _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}} expected-note {{add 'if #available'}}
+  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
 
-  if #available(macOS 10.14.5, iOS 12.3, tvOS 12.3, watchOS 5.3, *) {
+  if #available(macOS 10.14.5, *) {
     _ = BetweenTargets()
   }
-  if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+  if #available(macOS 10.15, *) {
     _ = AtDeploymentTarget()
   }
-  if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+  if #available(macOS 11, *) {
     _ = AfterDeploymentTarget()
   }
 }
 
-@available(macOS 10.14.5, iOS 12.3, tvOS 12.3, watchOS 5.3, *)
+@available(macOS 10.14.5, *)
 @inlinable public func inlinedUseBetweenTargets(
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
   _: BetweenTargets,
-  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in}}
-  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
+  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}}
+  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 ) {
   defer {
-    _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
-    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+    _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}} expected-note {{add 'if #available'}}
+    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
   }
   _ = NoAvailable()
   _ = BeforeInliningTarget()
   _ = AtInliningTarget()
   _ = BetweenTargets()
-  _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
-  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+  _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}} expected-note {{add 'if #available'}}
+  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
 
-  if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+  if #available(macOS 10.15, *) {
     _ = AtDeploymentTarget()
   }
-  if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+  if #available(macOS 11, *) {
     _ = AfterDeploymentTarget()
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, *)
 @inlinable public func inlinedUseAtDeploymentTarget(
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
   _: BetweenTargets,
   _: AtDeploymentTarget,
-  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
+  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 ) {
   defer {
     _ = AtDeploymentTarget()
-    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
   }
   _ = NoAvailable()
   _ = BeforeInliningTarget()
   _ = AtInliningTarget()
   _ = BetweenTargets()
   _ = AtDeploymentTarget()
-  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
 
-  if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+  if #available(macOS 11, *) {
     _ = AfterDeploymentTarget()
   }
 }
 
-@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
+@available(macOS 11, *)
 @inlinable public func inlinedUseAfterDeploymentTarget(
   _: NoAvailable,
   _: BeforeInliningTarget,
@@ -519,9 +507,6 @@ public func spiDeployedUseNoAvailable( // expected-note 3 {{add @available attri
 }
 
 @available(macOS, unavailable)
-@available(iOS, unavailable)
-@available(tvOS, unavailable)
-@available(watchOS, unavailable)
 @inlinable public func inlinedAlwaysUnavailable(
   _: NoAvailable,
   _: BeforeInliningTarget,
@@ -533,17 +518,17 @@ public func spiDeployedUseNoAvailable( // expected-note 3 {{add @available attri
 ) {
   defer {
     _ = AtDeploymentTarget()
-    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
   }
   _ = NoAvailable()
   _ = BeforeInliningTarget()
   _ = AtInliningTarget()
   _ = BetweenTargets()
   _ = AtDeploymentTarget()
-  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
   _ = Unavailable()
 
-  if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+  if #available(macOS 11, *) {
     _ = AfterDeploymentTarget()
   }
 }
@@ -555,20 +540,20 @@ public func spiDeployedUseNoAvailable( // expected-note 3 {{add @available attri
   _: AtInliningTarget,
   _: BetweenTargets,
   _: AtDeploymentTarget,
-  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
+  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 ) {
   defer {
     _ = AtDeploymentTarget()
-    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
   }
   _ = NoAvailable()
   _ = BeforeInliningTarget()
   _ = AtInliningTarget()
   _ = BetweenTargets()
   _ = AtDeploymentTarget()
-  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
 
-  if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+  if #available(macOS 11, *) {
     _ = AfterDeploymentTarget()
   }
 }
@@ -582,28 +567,28 @@ public func spiDeployedUseNoAvailable( // expected-note 3 {{add @available attri
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
-  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in}}
-  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in}}
-  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
+  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}}
+  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}}
+  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 ) {
   defer {
-    _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
-    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+    _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}} expected-note {{add 'if #available'}}
+    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
   }
   _ = NoAvailable()
   _ = BeforeInliningTarget()
   _ = AtInliningTarget()
-  _ = BetweenTargets() // expected-error {{'BetweenTargets' is only available in}} expected-note {{add 'if #available'}}
-  _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
-  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+  _ = BetweenTargets() // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}} expected-note {{add 'if #available'}}
+  _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}} expected-note {{add 'if #available'}}
+  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
 
-  if #available(macOS 10.14.5, iOS 12.3, tvOS 12.3, watchOS 5.3, *) {
+  if #available(macOS 10.14.5, *) {
     _ = BetweenTargets()
   }
-  if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+  if #available(macOS 10.15, *) {
     _ = AtDeploymentTarget()
   }
-  if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+  if #available(macOS 11, *) {
     _ = AfterDeploymentTarget()
   }
 }
@@ -613,34 +598,34 @@ public func spiDeployedUseNoAvailable( // expected-note 3 {{add @available attri
 
 // @_backDeploy acts like @inlinable.
 
-@available(macOS 10.10, iOS 8.0, tvOS 9.0, watchOS 2.0, *)
-@_backDeploy(before: macOS 999.0, iOS 999.0, tvOS 999.0, watchOS 999.0)
+@available(macOS 10.10, *)
+@_backDeploy(before: macOS 999.0)
 public func backDeployedToInliningTarget(
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
-  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in}}
-  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in}}
-  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
+  _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}}
+  _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}}
+  _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 ) {
   defer {
-    _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
-    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+    _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}} expected-note {{add 'if #available'}}
+    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
   }
   _ = NoAvailable()
   _ = BeforeInliningTarget()
   _ = AtInliningTarget()
-  _ = BetweenTargets() // expected-error {{'BetweenTargets' is only available in}} expected-note {{add 'if #available'}}
-  _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
-  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+  _ = BetweenTargets() // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}} expected-note {{add 'if #available'}}
+  _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}} expected-note {{add 'if #available'}}
+  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
 
-  if #available(macOS 10.14.5, iOS 12.3, tvOS 12.3, watchOS 5.3, *) {
+  if #available(macOS 10.14.5, *) {
     _ = BetweenTargets()
   }
-  if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+  if #available(macOS 10.15, *) {
     _ = AtDeploymentTarget()
   }
-  if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+  if #available(macOS 11, *) {
     _ = AfterDeploymentTarget()
   }
 }
@@ -654,22 +639,19 @@ public func defaultArgsUseNoAvailable( // expected-note 3 {{add @available attri
   _: Any = NoAvailable.self,
   _: Any = BeforeInliningTarget.self,
   _: Any = AtInliningTarget.self,
-  _: Any = BetweenTargets.self, // expected-error {{'BetweenTargets' is only available in}}
-  _: Any = AtDeploymentTarget.self, // expected-error {{'AtDeploymentTarget' is only available in}}
-  _: Any = AfterDeploymentTarget.self // expected-error {{'AfterDeploymentTarget' is only available in}}
+  _: Any = BetweenTargets.self, // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}}
+  _: Any = AtDeploymentTarget.self, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}}
+  _: Any = AfterDeploymentTarget.self // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 ) {}
 
 @available(macOS, unavailable)
-@available(iOS, unavailable)
-@available(tvOS, unavailable)
-@available(watchOS, unavailable)
 public func defaultArgsUseUnavailable(
   _: Any = NoAvailable.self,
   _: Any = BeforeInliningTarget.self,
   _: Any = AtInliningTarget.self,
   _: Any = BetweenTargets.self,
   _: Any = AtDeploymentTarget.self,
-  _: Any = AfterDeploymentTarget.self, // expected-error {{'AfterDeploymentTarget' is only available in}}
+  _: Any = AfterDeploymentTarget.self, // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
   _: Any = Unavailable.self
 ) {}
 
@@ -680,7 +662,7 @@ public func spiDefaultArgsUseNoAvailable( // expected-note 1 {{add @available at
   _: Any = AtInliningTarget.self,
   _: Any = BetweenTargets.self,
   _: Any = AtDeploymentTarget.self,
-  _: Any = AfterDeploymentTarget.self // expected-error {{'AfterDeploymentTarget' is only available in}}
+  _: Any = AfterDeploymentTarget.self // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 ) {}
 
 @propertyWrapper
@@ -696,17 +678,17 @@ public struct PublicStruct { // expected-note 13 {{add @available attribute}}
   public var aPublic: NoAvailable,
              bPublic: BeforeInliningTarget,
              cPublic: AtInliningTarget,
-             dPublic: BetweenTargets, // expected-error {{'BetweenTargets' is only available in}}
-             ePublic: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in}}
-             fPublic: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
+             dPublic: BetweenTargets, // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}}
+             ePublic: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}}
+             fPublic: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 
-  @available(macOS 10.14.5, iOS 12.3, tvOS 12.3, watchOS 5.3, *)
+  @available(macOS 10.14.5, *)
   public var aPublicAvailBetween: NoAvailable,
              bPublicAvailBetween: BeforeInliningTarget,
              cPublicAvailBetween: AtInliningTarget,
              dPublicAvailBetween: BetweenTargets,
-             ePublicAvailBetween: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in}}
-             fPublicAvailBetween: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
+             ePublicAvailBetween: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}}
+             fPublicAvailBetween: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 
   // The inferred types of public properties are exposed.
   public var aPublicInferred = NoAvailable(),
@@ -714,15 +696,15 @@ public struct PublicStruct { // expected-note 13 {{add @available attribute}}
              cPublicInferred = AtInliningTarget(),
              dPublicInferred = BetweenTargets(), // FIXME: Inferred type should be diagnosed
              ePublicInferred = AtDeploymentTarget(), // FIXME: Inferred type should be diagnosed
-             fPublicInferred = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}}
+             fPublicInferred = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 
-  @available(macOS 10.14.5, iOS 12.3, tvOS 12.3, watchOS 5.3, *)
+  @available(macOS 10.14.5, *)
   public var aPublicInferredAvailBetween = NoAvailable(),
              bPublicInferredAvailBetween = BeforeInliningTarget(),
              cPublicInferredAvailBetween = AtInliningTarget(),
              dPublicInferredAvailBetween = BetweenTargets(),
              ePublicInferredAvailBetween = AtDeploymentTarget(), // FIXME: Inferred type should be diagnosed
-             fPublicInferredAvailBetween = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}}
+             fPublicInferredAvailBetween = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
   
   // Property initializers are not exposed.
   public var aPublicInit: Any = NoAvailable(),
@@ -730,7 +712,7 @@ public struct PublicStruct { // expected-note 13 {{add @available attribute}}
              cPublicInit: Any = AtInliningTarget(),
              dPublicInit: Any = BetweenTargets(),
              ePublicInit: Any = AtDeploymentTarget(),
-             fPublicInit: Any = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}}
+             fPublicInit: Any = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
   
   // Internal declarations are not exposed.
   var aInternal: NoAvailable = .init(),
@@ -738,9 +720,9 @@ public struct PublicStruct { // expected-note 13 {{add @available attribute}}
       cInternal: AtInliningTarget = .init(),
       dInternal: BetweenTargets = .init(),
       eInternal: AtDeploymentTarget = .init(),
-      fInternal: AfterDeploymentTarget = .init() // expected-error {{'AfterDeploymentTarget' is only available in}}
+      fInternal: AfterDeploymentTarget = .init() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 
-  @available(macOS 10.14.5, iOS 12.3, tvOS 12.3, watchOS 5.3, *)
+  @available(macOS 10.14.5, *)
   public internal(set) var internalSetter: Void {
     @inlinable get {
       // Public inlinable getter acts like @inlinable
@@ -748,13 +730,13 @@ public struct PublicStruct { // expected-note 13 {{add @available attribute}}
       _ = BeforeInliningTarget()
       _ = AtInliningTarget()
       _ = BetweenTargets()
-      _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
-      _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+      _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}} expected-note {{add 'if #available'}}
+      _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
 
-      if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+      if #available(macOS 10.15, *) {
         _ = AtDeploymentTarget()
       }
-      if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+      if #available(macOS 11, *) {
         _ = AfterDeploymentTarget()
       }
     }
@@ -765,9 +747,9 @@ public struct PublicStruct { // expected-note 13 {{add @available attribute}}
       _ = AtInliningTarget()
       _ = BetweenTargets()
       _ = AtDeploymentTarget()
-      _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+      _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
 
-      if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+      if #available(macOS 11, *) {
         _ = AfterDeploymentTarget()
       }
     }
@@ -780,9 +762,9 @@ public struct PublicStruct { // expected-note 13 {{add @available attribute}}
     _ = AtInliningTarget()
     _ = BetweenTargets()
     _ = AtDeploymentTarget()
-    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+    _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
     
-    if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+    if #available(macOS 11, *) {
       _ = AfterDeploymentTarget()
     }
   }
@@ -796,7 +778,7 @@ public struct PublicStructWithWrappers { // expected-note 4 {{add @available att
   @PropertyWrapper public var cExplicitInit = AtInliningTarget()
   @PropertyWrapper public var dExplicitInit = BetweenTargets() // FIXME: Inferred type should be diagnosed
   @PropertyWrapper public var eExplicitInit = AtDeploymentTarget() // FIXME: Inferred type should be diagnosed
-  @PropertyWrapper public var fExplicitInit = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}}
+  @PropertyWrapper public var fExplicitInit = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
   
   // The property type is inferred from the initializer expression. The
   // expressions themselves will not be exposed.
@@ -805,7 +787,7 @@ public struct PublicStructWithWrappers { // expected-note 4 {{add @available att
   @PropertyWrapper(AtInliningTarget()) public var cExplicitInitAlt
   @PropertyWrapper(BetweenTargets()) public var dExplicitInitAlt  // FIXME: Inferred type should be diagnosed
   @PropertyWrapper(AtDeploymentTarget()) public var ePExplicitInitAlt  // FIXME: Inferred type should be diagnosed
-  @PropertyWrapper(AfterDeploymentTarget()) public var fExplicitInitAlt // expected-error {{'AfterDeploymentTarget' is only available in}}
+  @PropertyWrapper(AfterDeploymentTarget()) public var fExplicitInitAlt // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 
   // The property type is explicitly `Any` and the initializer expressions are
   // not exposed.
@@ -814,7 +796,7 @@ public struct PublicStructWithWrappers { // expected-note 4 {{add @available att
   @PropertyWrapper public var cAny: Any = AtInliningTarget()
   @PropertyWrapper public var dAny: Any = BetweenTargets()
   @PropertyWrapper public var eAny: Any = AtDeploymentTarget()
-  @PropertyWrapper public var fAny: Any = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}}
+  @PropertyWrapper public var fAny: Any = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 
   // The property type is explicitly `Any` and the initializer expressions are
   // not exposed.
@@ -823,7 +805,7 @@ public struct PublicStructWithWrappers { // expected-note 4 {{add @available att
   @PropertyWrapper(AtInliningTarget()) public var cAnyAlt: Any
   @PropertyWrapper(BetweenTargets()) public var dAnyAlt: Any
   @PropertyWrapper(AtDeploymentTarget()) public var eAnyAlt: Any
-  @PropertyWrapper(AfterDeploymentTarget()) public var fAnyAlt: Any // expected-error {{'AfterDeploymentTarget' is only available in}}
+  @PropertyWrapper(AfterDeploymentTarget()) public var fAnyAlt: Any // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 }
 
 @frozen public struct FrozenPublicStruct { // expected-note 9 {{add @available attribute}}
@@ -831,38 +813,35 @@ public struct PublicStructWithWrappers { // expected-note 4 {{add @available att
   public var aPublic: NoAvailable,
              bPublic: BeforeInliningTarget,
              cPublic: AtInliningTarget,
-             dPublic: BetweenTargets, // expected-error {{'BetweenTargets' is only available in}}
-             ePublic: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in}}
-             fPublic: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
+             dPublic: BetweenTargets, // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}}
+             ePublic: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}}
+             fPublic: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 
   // Property initializers are exposed in frozen structs.
   public var aPublicInit: Any = NoAvailable(),
              bPublicInit: Any = BeforeInliningTarget(),
              cPublicInit: Any = AtInliningTarget(),
-             dPublicInit: Any = BetweenTargets(), // expected-error {{'BetweenTargets' is only available in}}
-             ePublicInit: Any = AtDeploymentTarget(), // expected-error {{'AtDeploymentTarget' is only available in}}
-             fPublicInit: Any = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}}
+             dPublicInit: Any = BetweenTargets(), // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}}
+             ePublicInit: Any = AtDeploymentTarget(), // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}}
+             fPublicInit: Any = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 
   // Internal declarations are also exposed in frozen structs.
   var aInternal: NoAvailable = .init(),
       bInternal: BeforeInliningTarget = .init(),
       cInternal: AtInliningTarget = .init(),
-      dInternal: BetweenTargets = .init(), // expected-error {{'BetweenTargets' is only available in}}
-      eInternal: AtDeploymentTarget = .init(), // expected-error {{'AtDeploymentTarget' is only available in}}
-      fInternal: AfterDeploymentTarget = .init() // expected-error {{'AfterDeploymentTarget' is only available in}}
+      dInternal: BetweenTargets = .init(), // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}}
+      eInternal: AtDeploymentTarget = .init(), // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}}
+      fInternal: AfterDeploymentTarget = .init() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 }
 
 @available(macOS, unavailable)
-@available(iOS, unavailable)
-@available(tvOS, unavailable)
-@available(watchOS, unavailable)
 public struct UnavailablePublicStruct {
   public var aPublic: NoAvailable,
              bPublic: BeforeInliningTarget,
              cPublic: AtInliningTarget,
              dPublic: BetweenTargets,
              ePublic: AtDeploymentTarget,
-             fPublic: AfterDeploymentTarget, // expected-error {{'AfterDeploymentTarget' is only available in}}
+             fPublic: AfterDeploymentTarget, // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
              gPublic: Unavailable
 
   public var aPublicInit: Any = NoAvailable(),
@@ -870,7 +849,7 @@ public struct UnavailablePublicStruct {
              cPublicInit: Any = AtInliningTarget(),
              dPublicInit: Any = BetweenTargets(),
              ePublicInit: Any = AtDeploymentTarget(),
-             fPublicInit: Any = AfterDeploymentTarget(), // expected-error {{'AfterDeploymentTarget' is only available in}}
+             fPublicInit: Any = AfterDeploymentTarget(), // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
              gPublicInit: Any = Unavailable()
 
   var aInternal: NoAvailable = .init(),
@@ -878,7 +857,7 @@ public struct UnavailablePublicStruct {
       cInternal: AtInliningTarget = .init(),
       dInternal: BetweenTargets = .init(),
       eInternal: AtDeploymentTarget = .init(),
-      fInternal: AfterDeploymentTarget = .init(), // expected-error {{'AfterDeploymentTarget' is only available in}}
+      fInternal: AfterDeploymentTarget = .init(), // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
       gInternal: Unavailable = .init()
 }
 
@@ -889,21 +868,21 @@ public struct SPIStruct { // expected-note 3 {{add @available attribute}}
              cPublic: AtInliningTarget,
              dPublic: BetweenTargets,
              ePublic: AtDeploymentTarget,
-             fPublic: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
+             fPublic: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 
   public var aPublicInit: Any = NoAvailable(),
              bPublicInit: Any = BeforeInliningTarget(),
              cPublicInit: Any = AtInliningTarget(),
              dPublicInit: Any = BetweenTargets(),
              ePublicInit: Any = AtDeploymentTarget(),
-             fPublicInit: Any = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}}
+             fPublicInit: Any = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 
   var aInternal: NoAvailable = .init(),
       bInternal: BeforeInliningTarget = .init(),
       cInternal: AtInliningTarget = .init(),
       dInternal: BetweenTargets = .init(),
       eInternal: AtDeploymentTarget = .init(),
-      fInternal: AfterDeploymentTarget = .init() // expected-error {{'AfterDeploymentTarget' is only available in}}
+      fInternal: AfterDeploymentTarget = .init() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 }
 
 internal struct InternalStruct { // expected-note 2 {{add @available attribute}}
@@ -913,14 +892,14 @@ internal struct InternalStruct { // expected-note 2 {{add @available attribute}}
       cInternal: AtInliningTarget = .init(),
       dInternal: BetweenTargets = .init(),
       eInternal: AtDeploymentTarget = .init(),
-      fInternal: AfterDeploymentTarget = .init() // expected-error {{'AfterDeploymentTarget' is only available in}}
+      fInternal: AfterDeploymentTarget = .init() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 
   @PropertyWrapper(NoAvailable()) var aWrapped: Any
   @PropertyWrapper(BeforeInliningTarget()) var bWrapped: Any
   @PropertyWrapper(AtInliningTarget()) var cWrapped: Any
   @PropertyWrapper(BetweenTargets()) var dWrapped: Any
   @PropertyWrapper(AtDeploymentTarget()) var eWrapped: Any
-  @PropertyWrapper(AfterDeploymentTarget()) var fWrapped: Any // expected-error {{'AfterDeploymentTarget' is only available in}}
+  @PropertyWrapper(AfterDeploymentTarget()) var fWrapped: Any // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
 }
 
 
@@ -948,18 +927,18 @@ extension BetweenTargets {
   fileprivate func fileprivateFunc1() {}
 }
 
-// expected-warning@+1 {{'BetweenTargets' is only available in}} expected-note@+1 {{add @available attribute to enclosing extension}}
+// expected-warning@+1 {{'BetweenTargets' is only available in macOS 10.14.5 or newer}} expected-note@+1 {{add @available attribute to enclosing extension}}
 extension BetweenTargets {
   public func publicFunc1() {}
 }
 
-// expected-warning@+1 {{'BetweenTargets' is only available in}} expected-note@+1 {{add @available attribute to enclosing extension}}
+// expected-warning@+1 {{'BetweenTargets' is only available in macOS 10.14.5 or newer}} expected-note@+1 {{add @available attribute to enclosing extension}}
 extension BetweenTargets {
   @usableFromInline
   internal func usableFromInlineFunc1() {}
 }
 
-// expected-warning@+1 {{'BetweenTargets' is only available in}} expected-note@+1 {{add @available attribute to enclosing extension}}
+// expected-warning@+1 {{'BetweenTargets' is only available in macOS 10.14.5 or newer}} expected-note@+1 {{add @available attribute to enclosing extension}}
 extension BetweenTargets {
   internal func internalFunc2() {}
   private func privateFunc2() {}
@@ -968,14 +947,14 @@ extension BetweenTargets {
 }
 
 // An extension with more availability than BetweenTargets.
-// expected-error@+2 {{'BetweenTargets' is only available in}}
-@available(macOS 10.10, iOS 8.0, tvOS 9.0, watchOS 2.0, *)
+// expected-error@+2 {{'BetweenTargets' is only available in macOS 10.14.5 or newer}}
+@available(macOS 10.10, *)
 extension BetweenTargets {
   public func publicFunc3() {}
 }
 
 // FIXME: Can we prevent this warning when SPI members are the reason the extension is exported?
-// expected-warning@+1 {{'BetweenTargets' is only available in}} expected-note@+1 {{add @available attribute to enclosing extension}}
+// expected-warning@+1 {{'BetweenTargets' is only available in macOS 10.14.5 or newer}} expected-note@+1 {{add @available attribute to enclosing extension}}
 extension BetweenTargets {
   @_spi(Private)
   public func spiFunc1() {}
@@ -990,9 +969,6 @@ extension BetweenTargets {
 }
 
 @available(macOS, unavailable)
-@available(iOS, unavailable)
-@available(tvOS, unavailable)
-@available(watchOS, unavailable)
 extension BetweenTargets {
   public func inheritsUnavailable(
     _: NoAvailable,
@@ -1013,12 +989,12 @@ extension BetweenTargets { // expected-note 1 {{add @available attribute to encl
     _: AtInliningTarget,
     _: BetweenTargets,
     _: AtDeploymentTarget,
-    _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}}
+    _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
   ) { }
 }
 
 // Same availability as BetweenTargets but internal instead of public.
-@available(macOS 10.14.5, iOS 12.3, tvOS 12.3, watchOS 5.3, *)
+@available(macOS 10.14.5, *)
 internal struct BetweenTargetsInternal {}
 
 // OK, extensions on internal types are never visible externally.
@@ -1027,17 +1003,17 @@ extension BetweenTargetsInternal {
   public func publicFunc() {}
 }
 
-// expected-error@+1 {{'AfterDeploymentTarget' is only available in}} expected-note@+1 {{add @available attribute to enclosing extension}}
+// expected-error@+1 {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note@+1 {{add @available attribute to enclosing extension}}
 extension AfterDeploymentTarget {}
 
-// expected-error@+1 {{'AfterDeploymentTarget' is only available in}} expected-note@+1 {{add @available attribute to enclosing extension}}
+// expected-error@+1 {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note@+1 {{add @available attribute to enclosing extension}}
 extension AfterDeploymentTarget {
   internal func internalFunc1() {}
   private func privateFunc1() {}
   fileprivate func fileprivateFunc1() {}
 }
 
-// expected-error@+1 {{'AfterDeploymentTarget' is only available in}} expected-note@+1 {{add @available attribute to enclosing extension}}
+// expected-error@+1 {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note@+1 {{add @available attribute to enclosing extension}}
 extension AfterDeploymentTarget {
   public func publicFunc1() {}
 }
@@ -1052,16 +1028,16 @@ extension BeforeInliningTarget: InternalProto {}
 extension AtInliningTarget: InternalProto {}
 extension BetweenTargets: InternalProto {}
 extension AtDeploymentTarget: InternalProto {}
-extension AfterDeploymentTarget: InternalProto {} // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add @available attribute to enclosing extension}}
+extension AfterDeploymentTarget: InternalProto {} // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add @available attribute to enclosing extension}}
 
 public protocol PublicProto {}
 
 extension NoAvailable: PublicProto {}
 extension BeforeInliningTarget: PublicProto {}
 extension AtInliningTarget: PublicProto {}
-extension BetweenTargets: PublicProto {} // expected-warning {{'BetweenTargets' is only available in}} expected-note {{add @available attribute to enclosing extension}}
-extension AtDeploymentTarget: PublicProto {} // expected-error {{'AtDeploymentTarget' is only available in}} expected-note {{add @available attribute to enclosing extension}}
-extension AfterDeploymentTarget: PublicProto {} // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add @available attribute to enclosing extension}}
+extension BetweenTargets: PublicProto {} // expected-warning {{'BetweenTargets' is only available in macOS 10.14.5 or newer}} expected-note {{add @available attribute to enclosing extension}}
+extension AtDeploymentTarget: PublicProto {} // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}} expected-note {{add @available attribute to enclosing extension}}
+extension AfterDeploymentTarget: PublicProto {} // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add @available attribute to enclosing extension}}
 
 
 // MARK: - Associated types
@@ -1070,42 +1046,42 @@ public protocol NoAvailableProtoWithAssoc { // expected-note 3 {{add @available 
   associatedtype A: NoAvailableProto
   associatedtype B: BeforeInliningTargetProto
   associatedtype C: AtInliningTargetProto
-  associatedtype D: BetweenTargetsProto // expected-error {{'BetweenTargetsProto' is only available in}}
-  associatedtype E: AtDeploymentTargetProto // expected-error {{'AtDeploymentTargetProto' is only available in}}
+  associatedtype D: BetweenTargetsProto // expected-error {{'BetweenTargetsProto' is only available in macOS 10.14.5 or newer}}
+  associatedtype E: AtDeploymentTargetProto // expected-error {{'AtDeploymentTargetProto' is only available in macOS 10.15 or newer}}
   associatedtype F: AfterDeploymentTargetProto // expected-error {{'AfterDeploymentTargetProto' is only available in}}
 }
 
-@available(macOS 10.9, iOS 7.0, tvOS 8.0, watchOS 1.0, *)
+@available(macOS 10.9, *)
 public protocol BeforeInliningTargetProtoWithAssoc {
   associatedtype A: NoAvailableProto
   associatedtype B: BeforeInliningTargetProto
   associatedtype C: AtInliningTargetProto
-  associatedtype D: BetweenTargetsProto // expected-error {{'BetweenTargetsProto' is only available in}}
-  associatedtype E: AtDeploymentTargetProto // expected-error {{'AtDeploymentTargetProto' is only available in}}
+  associatedtype D: BetweenTargetsProto // expected-error {{'BetweenTargetsProto' is only available in macOS 10.14.5 or newer}}
+  associatedtype E: AtDeploymentTargetProto // expected-error {{'AtDeploymentTargetProto' is only available in macOS 10.15 or newer}}
   associatedtype F: AfterDeploymentTargetProto // expected-error {{'AfterDeploymentTargetProto' is only available in}}
 }
 
-@available(macOS 10.10, iOS 8.0, tvOS 9.0, watchOS 2.0, *)
+@available(macOS 10.10, *)
 public protocol AtInliningTargetProtoWithAssoc {
   associatedtype A: NoAvailableProto
   associatedtype B: BeforeInliningTargetProto
   associatedtype C: AtInliningTargetProto
-  associatedtype D: BetweenTargetsProto // expected-error {{'BetweenTargetsProto' is only available in}}
-  associatedtype E: AtDeploymentTargetProto // expected-error {{'AtDeploymentTargetProto' is only available in}}
+  associatedtype D: BetweenTargetsProto // expected-error {{'BetweenTargetsProto' is only available in macOS 10.14.5 or newer}}
+  associatedtype E: AtDeploymentTargetProto // expected-error {{'AtDeploymentTargetProto' is only available in macOS 10.15 or newer}}
   associatedtype F: AfterDeploymentTargetProto // expected-error {{'AfterDeploymentTargetProto' is only available in}}
 }
 
-@available(macOS 10.14.5, iOS 12.3, tvOS 12.3, watchOS 5.3, *)
+@available(macOS 10.14.5, *)
 public protocol BetweenTargetsProtoWithAssoc {
   associatedtype A: NoAvailableProto
   associatedtype B: BeforeInliningTargetProto
   associatedtype C: AtInliningTargetProto
   associatedtype D: BetweenTargetsProto
-  associatedtype E: AtDeploymentTargetProto // expected-error {{'AtDeploymentTargetProto' is only available in}}
+  associatedtype E: AtDeploymentTargetProto // expected-error {{'AtDeploymentTargetProto' is only available in macOS 10.15 or newer}}
   associatedtype F: AfterDeploymentTargetProto // expected-error {{'AfterDeploymentTargetProto' is only available in}}
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+@available(macOS 10.15, *)
 public protocol AtDeploymentTargetProtoWithAssoc {
   associatedtype A: NoAvailableProto
   associatedtype B: BeforeInliningTargetProto
@@ -1115,7 +1091,7 @@ public protocol AtDeploymentTargetProtoWithAssoc {
   associatedtype F: AfterDeploymentTargetProto // expected-error {{'AfterDeploymentTargetProto' is only available in}}
 }
 
-@available(macOS 11, iOS 14, tvOS 14, watchOS 7, *)
+@available(macOS 11, *)
 public protocol AfterDeploymentTargetProtoWithAssoc {
   associatedtype A: NoAvailableProto
   associatedtype B: BeforeInliningTargetProto
@@ -1126,9 +1102,6 @@ public protocol AfterDeploymentTargetProtoWithAssoc {
 }
 
 @available(macOS, unavailable)
-@available(iOS, unavailable)
-@available(tvOS, unavailable)
-@available(watchOS, unavailable)
 public protocol UnavailableProtoWithAssoc {
   associatedtype A: NoAvailableProto
   associatedtype B: BeforeInliningTargetProto
@@ -1155,22 +1128,19 @@ public enum PublicNoAvailableEnumWithTypeAliases { // expected-note 3 {{add @ava
   public typealias A = NoAvailable
   public typealias B = BeforeInliningTarget
   public typealias C = AtInliningTarget
-  public typealias D = BetweenTargets // expected-error {{'BetweenTargets' is only available in}} expected-note {{add @available attribute to enclosing type alias}}
-  public typealias E = AtDeploymentTarget // expected-error {{'AtDeploymentTarget' is only available in}} expected-note {{add @available attribute to enclosing type alias}}
-  public typealias F = AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add @available attribute to enclosing type alias}}
+  public typealias D = BetweenTargets // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer}} expected-note {{add @available attribute to enclosing type alias}}
+  public typealias E = AtDeploymentTarget // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer}} expected-note {{add @available attribute to enclosing type alias}}
+  public typealias F = AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add @available attribute to enclosing type alias}}
 }
 
 @available(macOS, unavailable)
-@available(iOS, unavailable)
-@available(tvOS, unavailable)
-@available(watchOS, unavailable)
 public enum UnavailableEnumWithTypeAliases {
   public typealias A = NoAvailable
   public typealias B = BeforeInliningTarget
   public typealias C = AtInliningTarget
   public typealias D = BetweenTargets
   public typealias E = AtDeploymentTarget
-  public typealias F = AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add @available attribute to enclosing type alias}}
+  public typealias F = AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add @available attribute to enclosing type alias}}
   public typealias G = Unavailable
 }
 
@@ -1181,7 +1151,7 @@ public enum SPIEnumWithTypeAliases { // expected-note 1 {{add @available attribu
   public typealias C = AtInliningTarget
   public typealias D = BetweenTargets
   public typealias E = AtDeploymentTarget
-  public typealias F = AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add @available attribute to enclosing type alias}}
+  public typealias F = AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add @available attribute to enclosing type alias}}
 }
 
 enum InternalNoAvailableEnumWithTypeAliases { // expected-note {{add @available attribute to enclosing enum}}
@@ -1190,7 +1160,7 @@ enum InternalNoAvailableEnumWithTypeAliases { // expected-note {{add @available 
   public typealias C = AtInliningTarget
   public typealias D = BetweenTargets
   public typealias E = AtDeploymentTarget
-  public typealias F = AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add @available attribute to enclosing type alias}}
+  public typealias F = AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add @available attribute to enclosing type alias}}
 }
 
 
@@ -1200,16 +1170,16 @@ enum InternalNoAvailableEnumWithTypeAliases { // expected-note {{add @available 
 // a non-inlinable function.
 defer {
   _ = AtDeploymentTarget()
-  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+  _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
 }
 _ = NoAvailable()
 _ = BeforeInliningTarget()
 _ = AtInliningTarget()
 _ = BetweenTargets()
 _ = AtDeploymentTarget()
-_ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in}} expected-note {{add 'if #available'}}
+_ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
 
-if #available(macOS 11, iOS 14, tvOS 14, watchOS 7, *) {
+if #available(macOS 11, *) {
   _ = AfterDeploymentTarget()
 }
 


### PR DESCRIPTION
Reword diagnostics about potentially unavailable decls to improve clarity for authors of API libraries. When decls are diagnosed as potentially unavailable on an OS earlier than the deployment target, the message will now indicate that the issue would be faced by clients of the module.

For example, suppose these declarations were part of an API module named `Test` with a deployment target of 10.15 on macOS. When building `Test`, the diagnostic emitted in the body of the inlinable function `foo()` now indicates that although `bar()` is available to `Test`, it is not necessarily available to the clients of `Test`: 

```swift
@available(macOS 10.15, *)
public func bar() { ... }

@available(macOS 10.14, *)
@inlinable func foo() {
  bar() // error: 'bar' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target
}
```
Resolves rdar://93466875
