### PR TITLE
Actually slice things in _StringGutsSlice (5.7 cherry pick)

### DIFF
--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -946,10 +946,11 @@ extension _StringGutsSlice {
   }
 
   internal func _withNFCCodeUnits(_ f: (UInt8) throws -> Void) rethrows {
+    let substring = String(_guts)[range]
     // Fast path: If we're already NFC (or ASCII), then we don't need to do
     // anything at all.
     if _fastPath(_guts.isNFC) {
-      try String(_guts).utf8.forEach(f)
+      try substring.utf8.forEach(f)
       return
     }
 
@@ -962,7 +963,7 @@ extension _StringGutsSlice {
       // Because we have access to the fastUTF8, we can go through that instead
       // of accessing the UTF8 view on String.
       if isNFCQC {
-        try _guts.withFastUTF8 {
+        try withFastUTF8 {
           for byte in $0 {
             try f(byte)
           }
@@ -971,7 +972,7 @@ extension _StringGutsSlice {
         return
       }
     } else {
-      for scalar in String(_guts).unicodeScalars {
+      for scalar in substring.unicodeScalars {
         if !_isScalarNFCQC(scalar, &prevCCC) {
           isNFCQC = false
           break
@@ -979,7 +980,7 @@ extension _StringGutsSlice {
       }
 
       if isNFCQC {
-        for byte in String(_guts).utf8 {
+        for byte in substring.utf8 {
           try f(byte)
         }
 
@@ -987,7 +988,7 @@ extension _StringGutsSlice {
       }
     }
 
-    for scalar in String(_guts)._nfc {
+    for scalar in substring._nfc {
       try scalar.withUTF8CodeUnits {
         for byte in $0 {
           try f(byte)


### PR DESCRIPTION
Cherry pick of https://github.com/apple/swift/pull/58948

During the ICU removal we accidentally dropped checking the bounds on Substrings in some cases, particularly hashing. This resulted in Substrings that compared equal but hashed differently, causing crashes when using them as keys or putting them in sets. This change fixes that by slicing the temporary String we use to get access to the NFC data, and adds tests to make sure it stays fixed.

rdar://87371813
https://github.com/apple/swift/issues/59388
https://github.com/apple/swift/issues/59066