### PR TITLE
[Serialization] Bump SWIFTMODULE_VERSION_MINOR to avoid conflict with SDK's swiftmodule.

### DIFF
--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 690; // remove unused type nodes
+const uint16_t SWIFTMODULE_VERSION_MINOR = 691; // bump to avoid conflict
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///


### PR DESCRIPTION
This space intentionally left blank.