### PR TITLE
[c++-interop] Adding options set struct to go with the typedef's enum bit set.

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -39,6 +39,7 @@
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclObjCCommon.h"
 #include "clang/AST/DeclTemplate.h"
+#include "clang/AST/Type.h"
 #include "clang/AST/TypeVisitor.h"
 #include "clang/Basic/Builtins.h"
 #include "clang/Lex/Preprocessor.h"

--- a/test/Interop/Cxx/enum/c-enums-withOptions-omit.swift
+++ b/test/Interop/Cxx/enum/c-enums-withOptions-omit.swift
@@ -3,6 +3,13 @@
 
 import CenumsWithOptionsOmit
 
+// CHECK: struct NSEnumerationOptions : OptionSet {
+// CHECK-NEXT:   init(rawValue: Int32)
+// CHECK-NEXT:   let rawValue: Int32
+// CHECK-NEXT:   typealias RawValue = Int32
+// CHECK-NEXT:   typealias Element = NSEnumerationOptions
+// CHECK-NEXT:   typealias ArrayLiteralElement = NSEnumerationOptions
+
 // CHECK: class NSSet {
 // CHECK-NEXT: class func enumerateObjects(options
 // CHECK-NEXT: func enumerateObjects(options


### PR DESCRIPTION

This does not work yet, but it is a proof of concept for now.

