### PR TITLE
[wrangler] Unconditionally disable test/Distributed/Runtime/distributed_actor_init_local for now

### DIFF
--- a/test/Distributed/Runtime/distributed_actor_init_local.swift
+++ b/test/Distributed/Runtime/distributed_actor_init_local.swift
@@ -9,11 +9,8 @@
 // UNSUPPORTED: back_deployment_runtime
 
 
-// FIXME(distributed): Seems something remains incorrect on 32bit here
-// rdar://92952551
-// UNSUPPORTED: CPU=armv7
-// UNSUPPORTED: CPU=armv7s
-// UNSUPPORTED: CPU=i386
+// FIXME(distributed): Seems something remains incorrect here
+// REQUIRES: rdar92952551
 
 import Distributed
 


### PR DESCRIPTION
We've seen a failure on x86_64 in addition to the archs this is currently disabled.

(https://ci.swift.org/job/oss-swift-5.7_tools-RA_stdlib-DA_test-simulators/324/console)

rdar://92952551
