### PR TITLE
[Tests] Make OS features consistent

### DIFF
--- a/test/AutoDiff/compiler_crashers_fixed/rdar71191415-nested-differentiation-of-extension-method-optimized.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/rdar71191415-nested-differentiation-of-extension-method-optimized.swift
@@ -1,7 +1,7 @@
 // RUN: %target-build-swift -O %s
 
 // FIXME(rdar://89055298)
-// UNSUPPORTED: linux
+// UNSUPPORTED: OS=linux-gnu
 
 // rdar://71191415
 

--- a/test/Concurrency/Reflection/reflect_task.swift
+++ b/test/Concurrency/Reflection/reflect_task.swift
@@ -10,7 +10,7 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 //
-// UNSUPPORTED: OS=macosx,ios,watchos,tvos
+// UNSUPPORTED: OS=macosx, OS=ios, OS=watchos, OS=tvos
 
 import Swift
 import _Concurrency

--- a/test/Concurrency/Runtime/async_taskgroup_asynciterator_semantics.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_asynciterator_semantics.swift
@@ -3,7 +3,7 @@
 // REQUIRES: concurrency
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
-// UNSUPPORTED: linux
+// UNSUPPORTED: OS=linux-gnu
 
 // REQUIRES: rdar86028226
 

--- a/test/Concurrency/Runtime/async_taskgroup_is_asyncsequence.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_is_asyncsequence.swift
@@ -7,7 +7,7 @@
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
 
-// UNSUPPORTED: linux
+// UNSUPPORTED: OS=linux-gnu
 
 @available(SwiftStdlib 5.1, *)
 func test_taskGroup_is_asyncSequence() async {

--- a/test/Concurrency/Runtime/executor_deinit1.swift
+++ b/test/Concurrency/Runtime/executor_deinit1.swift
@@ -7,7 +7,7 @@
 // UNSUPPORTED: back_deployment_runtime
 
 // https://bugs.swift.org/browse/SR-14461
-// UNSUPPORTED: linux
+// UNSUPPORTED: OS=linux-gnu
 
 // REQUIRES: rdar78325660
 

--- a/test/DebugInfo/local-vars.swift.gyb
+++ b/test/DebugInfo/local-vars.swift.gyb
@@ -3,7 +3,7 @@
 // all. There are other tests testing liveness and representation.
 
 // rdar://problem/57611302
-// XFAIL: windows
+// XFAIL: OS=windows-msvc
 
 // RUN: %gyb %s -o %t.swift
 // RUN: %target-swift-frontend %t.swift -g -emit-ir -o - | %FileCheck %t.swift

--- a/test/Distributed/Runtime/distributed_actor_cross_module_final_class_adhoc_requirement_not_optimized_away.swift
+++ b/test/Distributed/Runtime/distributed_actor_cross_module_final_class_adhoc_requirement_not_optimized_away.swift
@@ -13,7 +13,7 @@
 // UNSUPPORTED: back_deployment_runtime
 
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
-// UNSUPPORTED: windows
+// UNSUPPORTED: OS=windows-msvc
 
 import Distributed
 import FakeDistributedActorSystems

--- a/test/Distributed/Runtime/distributed_actor_deinit.swift
+++ b/test/Distributed/Runtime/distributed_actor_deinit.swift
@@ -8,7 +8,7 @@
 // UNSUPPORTED: back_deployment_runtime
 
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
-// UNSUPPORTED: windows
+// UNSUPPORTED: OS=windows-msvc
 
 import Distributed
 

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_echo.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_echo.swift
@@ -12,7 +12,7 @@
 // UNSUPPORTED: back_deployment_runtime
 
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
-// UNSUPPORTED: windows
+// UNSUPPORTED: OS=windows-msvc
 
 import Distributed
 import FakeDistributedActorSystems

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_empty.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_empty.swift
@@ -12,7 +12,7 @@
 // UNSUPPORTED: back_deployment_runtime
 
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
-// UNSUPPORTED: windows
+// UNSUPPORTED: OS=windows-msvc
 
 import Distributed
 import FakeDistributedActorSystems

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_genericFunc.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_genericFunc.swift
@@ -12,7 +12,7 @@
 // UNSUPPORTED: back_deployment_runtime
 
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
-// UNSUPPORTED: windows
+// UNSUPPORTED: OS=windows-msvc
 
 import Distributed
 import FakeDistributedActorSystems

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_hello.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_hello.swift
@@ -12,7 +12,7 @@
 // UNSUPPORTED: back_deployment_runtime
 
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
-// UNSUPPORTED: windows
+// UNSUPPORTED: OS=windows-msvc
 
 import Distributed
 import FakeDistributedActorSystems

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_take.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_take.swift
@@ -12,7 +12,7 @@
 // UNSUPPORTED: back_deployment_runtime
 
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
-// UNSUPPORTED: windows
+// UNSUPPORTED: OS=windows-msvc
 
 import Distributed
 import FakeDistributedActorSystems

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_takeThrowReturn.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_takeThrowReturn.swift
@@ -12,7 +12,7 @@
 // UNSUPPORTED: back_deployment_runtime
 
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
-// UNSUPPORTED: windows
+// UNSUPPORTED: OS=windows-msvc
 
 import Distributed
 import FakeDistributedActorSystems

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_take_two.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_take_two.swift
@@ -12,7 +12,7 @@
 // UNSUPPORTED: back_deployment_runtime
 
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
-// UNSUPPORTED: windows
+// UNSUPPORTED: OS=windows-msvc
 
 import Distributed
 import FakeDistributedActorSystems

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_throw.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_throw.swift
@@ -12,7 +12,7 @@
 // UNSUPPORTED: back_deployment_runtime
 
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
-// UNSUPPORTED: windows
+// UNSUPPORTED: OS=windows-msvc
 
 import Distributed
 import FakeDistributedActorSystems

--- a/test/Distributed/Runtime/distributed_actor_hop_to.swift
+++ b/test/Distributed/Runtime/distributed_actor_hop_to.swift
@@ -12,7 +12,7 @@
 // UNSUPPORTED: back_deployment_runtime
 
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
-// UNSUPPORTED: windows
+// UNSUPPORTED: OS=windows-msvc
 
 
 import Distributed

--- a/test/Distributed/Runtime/distributed_actor_in_other_module.swift
+++ b/test/Distributed/Runtime/distributed_actor_in_other_module.swift
@@ -12,7 +12,7 @@
 // UNSUPPORTED: back_deployment_runtime
 
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
-// UNSUPPORTED: windows
+// UNSUPPORTED: OS=windows-msvc
 
 // REQUIRES: rdar92277324
 

--- a/test/Distributed/Runtime/distributed_actor_remoteCall.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall.swift
@@ -12,7 +12,7 @@
 // UNSUPPORTED: back_deployment_runtime
 
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
-// UNSUPPORTED: windows
+// UNSUPPORTED: OS=windows-msvc
 
 import Distributed
 

--- a/test/Distributed/Runtime/distributed_actor_remoteCallTarget_demanglingTargetNames.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCallTarget_demanglingTargetNames.swift
@@ -12,7 +12,7 @@
 // UNSUPPORTED: back_deployment_runtime
 
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
-// UNSUPPORTED: windows
+// UNSUPPORTED: OS=windows-msvc
 
 import Distributed
 import FakeDistributedActorSystems

--- a/test/Distributed/Runtime/distributed_actor_remoteCall_roundtrip.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall_roundtrip.swift
@@ -14,7 +14,7 @@
 // UNSUPPORTED: back_deployment_runtime
 
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
-// UNSUPPORTED: windows
+// UNSUPPORTED: OS=windows-msvc
 
 import Distributed
 import FakeDistributedActorSystems

--- a/test/Distributed/Runtime/distributed_actor_whenLocal.swift
+++ b/test/Distributed/Runtime/distributed_actor_whenLocal.swift
@@ -12,7 +12,7 @@
 // UNSUPPORTED: back_deployment_runtime
 
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
-// UNSUPPORTED: windows
+// UNSUPPORTED: OS=windows-msvc
 
 import Distributed
 

--- a/test/Driver/Dependencies/embed-bitcode-parallel-fine.swift
+++ b/test/Driver/Dependencies/embed-bitcode-parallel-fine.swift
@@ -1,5 +1,5 @@
 // Windows doesn't support parallel execution yet
-// XFAIL: windows
+// XFAIL: OS=windows-msvc
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/one-way-fine/* %t
 // RUN: touch -t 201401240005 %t/*

--- a/test/Driver/Dependencies/one-way-parallel-fine.swift
+++ b/test/Driver/Dependencies/one-way-parallel-fine.swift
@@ -1,5 +1,5 @@
 // Windows doesn't support parallel execution yet
-// XFAIL: windows
+// XFAIL: OS=windows-msvc
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/one-way-fine/* %t
 // RUN: touch -t 201401240005 %t/*

--- a/test/Driver/Dependencies/only-skip-once.swift
+++ b/test/Driver/Dependencies/only-skip-once.swift
@@ -1,4 +1,4 @@
-// XFAIL: linux, openbsd, windows
+// XFAIL: OS=linux-gnu, OS=openbsd, OS=windows-msvc
 
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/only-skip-once/* %t

--- a/test/Driver/batch_mode_bridging_pch.swift
+++ b/test/Driver/batch_mode_bridging_pch.swift
@@ -1,4 +1,3 @@
-// XFAIL: win32
 // RUN: %empty-directory(%t)
 // RUN: touch %t/file-01.swift %t/file-02.swift %t/file-03.swift
 // RUN: echo 'public func main() {}' >%t/main.swift

--- a/test/Driver/environment.swift
+++ b/test/Driver/environment.swift
@@ -1,5 +1,5 @@
 // UNSUPPORTED: objc_interop
-// UNSUPPORTED: windows
+// UNSUPPORTED: OS=windows-msvc
 // Apple's "System Integrity Protection" makes this test fail on OS X.
 
 // RUN: %swift_driver_plain -sdk "" -target x86_64-unknown-gnu-linux -L/foo/ -driver-use-frontend-path %S/Inputs/print-var.sh %s LD_LIBRARY_PATH | %FileCheck -check-prefix=CHECK${LD_LIBRARY_PATH+_LAX} %s

--- a/test/Driver/filelists.swift
+++ b/test/Driver/filelists.swift
@@ -1,4 +1,4 @@
-// UNSUPPORTED: windows
+// UNSUPPORTED: OS=windows-msvc
 // RUN: %empty-directory(%t)
 // RUN: touch %t/a.swift %t/b.swift %t/c.swift
 

--- a/test/Driver/frontend.swift
+++ b/test/Driver/frontend.swift
@@ -1,5 +1,5 @@
 // RUN: %swiftc_driver %s -### 2>&1 | %FileCheck %s
 
-// UNSUPPORTED: windows
+// UNSUPPORTED: OS=windows-msvc
 // CHECK: swift-frontend
 

--- a/test/Driver/fuzzer.swift
+++ b/test/Driver/fuzzer.swift
@@ -1,4 +1,4 @@
-// UNSUPPORTED: windows
+// UNSUPPORTED: OS=windows-msvc
 // UNSUPPORTED: CPU=powerpc64le
 // RUN: %swiftc_driver -driver-print-jobs -sanitize=fuzzer,address -target x86_64-apple-macosx10.9 -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ %s | %FileCheck -check-prefix=LIBFUZZER_OSX %s
 // RUN: %swiftc_driver -driver-print-jobs -sanitize=fuzzer,address -target x86_64-unknown-linux-gnu -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ %s | %FileCheck -check-prefix=LIBFUZZER_LINUX %s

--- a/test/Driver/loaded_module_trace_nocrash.swift
+++ b/test/Driver/loaded_module_trace_nocrash.swift
@@ -1,4 +1,4 @@
-// UNSUPPORTED: -windows-msvc
+// UNSUPPORTED: OS=windows-msvc
 
 // RUN: %empty-directory(%t)
 // RUN: mkdir -p %t/Mods/Foo.swiftmodule

--- a/test/Driver/loaded_module_trace_swiftinterface.swift
+++ b/test/Driver/loaded_module_trace_swiftinterface.swift
@@ -1,4 +1,4 @@
-// UNSUPPORTED: -windows-msvc
+// UNSUPPORTED: OS=windows-msvc
 // REQUIRES: SR13034
 
 // 1) If there is no swiftmodule, use the swiftinterface

--- a/test/Driver/macabi-environment.swift
+++ b/test/Driver/macabi-environment.swift
@@ -1,6 +1,6 @@
 // Tests to check that the driver finds standard library in the macabi environment.
 
-// UNSUPPORTED: windows
+// UNSUPPORTED: OS=windows-msvc
 
 // RUN: %swiftc_driver -sdk "" -sdk "" -driver-print-jobs -target x86_64-apple-ios13.1-macabi -sdk %S/../Inputs/clang-importer-sdk %s | %FileCheck -check-prefix=IOS13-MACABI %s
 // IOS13-MACABI: bin/swift

--- a/test/Driver/parseable_output.swift
+++ b/test/Driver/parseable_output.swift
@@ -1,6 +1,6 @@
 // RUN: %swiftc_driver_plain -emit-executable %s -o %t.out -emit-module -emit-module-path %t.swiftmodule -emit-objc-header-path %t.h -serialize-diagnostics -emit-dependencies -parseable-output -driver-skip-execution 2>&1 | %FileCheck %s
 
-// XFAIL: freebsd, openbsd, linux
+// XFAIL: OS=freebsd, OS=openbsd, OS=linux-gnu
 
 // CHECK: {{[1-9][0-9]*}}
 // CHECK-NEXT: {

--- a/test/Driver/parseable_output_unicode.swift
+++ b/test/Driver/parseable_output_unicode.swift
@@ -2,7 +2,7 @@
 // RUN: cat "%S/Inputs/unicode.txt" >> %t.rsp
 // RUN: %swiftc_driver_plain -emit-executable @%t.rsp -o %t.out -emit-module -emit-module-path %t.swiftmodule -emit-objc-header-path %t.h -serialize-diagnostics -emit-dependencies -parseable-output -driver-skip-execution 2>&1 | %FileCheck %s
 
-// XFAIL: freebsd, openbsd, linux
+// XFAIL: OS=freebsd, OS=openbsd, OS=linux-gnu
 
 // CHECK: {{[1-9][0-9]*}}
 // CHECK-NEXT: {

--- a/test/Driver/pipe_round_robin.swift.gyb
+++ b/test/Driver/pipe_round_robin.swift.gyb
@@ -1,5 +1,5 @@
 // Windows doesn't track/use read() and poll()
-// UNSUPPORTED: windows
+// UNSUPPORTED: OS=windows-msvc
 // This test is unreliable on busy machines.
 // ALLOW_RETRIES: 5
 // RUN: %empty-directory(%t/manyfuncs)

--- a/test/Driver/sdk-apple.swift
+++ b/test/Driver/sdk-apple.swift
@@ -1,4 +1,4 @@
-// XFAIL: freebsd, openbsd, linux, windows
+// XFAIL: OS=freebsd, OS=openbsd, OS=linux-gnu, OS=windows-msvc
 
 // Test SDK detection for immediate mode.
 // RUN: %empty-directory(%t)

--- a/test/IDE/print_clang_header_i386.swift
+++ b/test/IDE/print_clang_header_i386.swift
@@ -1,7 +1,7 @@
 // REQUIRES: OS=macosx
 // REQUIRES: CPU=x86_64
 // FIXME: rdar://problem/19648117 Needs splitting objc parts out
-// XFAIL: linux, freebsd
+// XFAIL: OS=linux-gnu, OS=freebsd
 
 // RUN: echo '#include "header-to-print.h"' > %t.i386.m
 // RUN: %empty-directory(%t)

--- a/test/IRGen/abitypes.swift
+++ b/test/IRGen/abitypes.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/abi %s -emit-ir -enable-objc-interop | %FileCheck -check-prefix=%target-cpu-%target-os-abi %s
 
 // FIXME: rdar://problem/19648117 Needs splitting objc parts out
-// XFAIL: linux, windows, openbsd
+// XFAIL: OS=linux-gnu, OS=windows-msvc, OS=openbsd
 
 import gadget
 import Foundation

--- a/test/Interpreter/shebang-direct.swift
+++ b/test/Interpreter/shebang-direct.swift
@@ -6,4 +6,4 @@
 // RUN: %t.shebang.swift a b c | %FileCheck -check-prefix=THREE-ARGS %S/shebang-env.swift
 
 // REQUIRES: swift_interpreter
-// UNSUPPORTED: linux
+// UNSUPPORTED: OS=linux-gnu

--- a/test/ModuleInterface/BadStdlib.swiftinterface
+++ b/test/ModuleInterface/BadStdlib.swiftinterface
@@ -16,4 +16,4 @@ import ClangMod
 public func useHasPointer(_: HasPointer)
 
 // FIXME: SR-14489
-// UNSUPPORTED: windows
+// UNSUPPORTED: OS=windows-msvc

--- a/test/ModuleInterface/swift_build_sdk_interfaces/compiler-crash.test-sh
+++ b/test/ModuleInterface/swift_build_sdk_interfaces/compiler-crash.test-sh
@@ -1,5 +1,5 @@
 # For its Windows counterpart, see compiler-crash-windows.test-sh
-UNSUPPORTED: windows
+UNSUPPORTED: OS=windows-msvc
 
 RUN: not %swift_build_sdk_interfaces -sdk %S/Inputs/mock-sdk/ -o %t/output -debug-crash-compiler 2>&1 | %FileCheck %s
 

--- a/test/Prototypes/CollectionTransformers.swift
+++ b/test/Prototypes/CollectionTransformers.swift
@@ -200,7 +200,7 @@ import Darwin
 import Dispatch
 
 // FIXME: port to Linux.
-// XFAIL: linux, windows, openbsd
+// XFAIL: OS=linux-gnu, OS=windows-msvc, OS=openbsd
 
 // A wrapper for pthread_t with platform-independent interface.
 public struct _stdlib_pthread_t : Equatable, Hashable {

--- a/test/Reflection/box_descriptors.sil
+++ b/test/Reflection/box_descriptors.sil
@@ -3,10 +3,10 @@
 // RUN: %target-swift-reflection-dump -binary-filename %t/capture_descriptors%{target-shared-library-suffix} | %FileCheck %s
 
 // SR-10758
-// UNSUPPORTED: linux
+// UNSUPPORTED: OS=linux-gnu
 
 // SR-12893
-// XFAIL: openbsd
+// XFAIL: OS=openbsd
 
 sil_stage canonical
 

--- a/test/Reflection/capture_descriptors.sil
+++ b/test/Reflection/capture_descriptors.sil
@@ -2,7 +2,7 @@
 // REQUIRES: no_asan
 
 // SR-12893
-// XFAIL: openbsd
+// XFAIL: OS=openbsd
 // UNSUPPORTED: OS=linux-android, OS=linux-androideabi
 
 // RUN: %empty-directory(%t)

--- a/test/Reflection/conformance_descriptors.swift
+++ b/test/Reflection/conformance_descriptors.swift
@@ -1,4 +1,4 @@
-// UNSUPPORTED: windows
+// UNSUPPORTED: OS=windows-msvc
 
 // Temporarily disable on AArch64 Linux (rdar://88451721)
 // UNSUPPORTED: OS=linux-gnu && CPU=aarch64

--- a/test/Reflection/typeref_decoding_imported.swift
+++ b/test/Reflection/typeref_decoding_imported.swift
@@ -1,7 +1,7 @@
 // XFAIL: OS=windows-msvc
 
 // SR-12893
-// XFAIL: openbsd
+// XFAIL: OS=openbsd
 
 // RUN: %empty-directory(%t)
 

--- a/test/SILOptimizer/addr_escape_info.sil
+++ b/test/SILOptimizer/addr_escape_info.sil
@@ -3,7 +3,7 @@
 // REQUIRES: swift_in_compiler
 
 // rdar92963081
-// UNSUPPORTED: linux
+// UNSUPPORTED: OS=linux-gnu
 
 sil_stage canonical
 

--- a/test/SILOptimizer/escape_info.sil
+++ b/test/SILOptimizer/escape_info.sil
@@ -3,7 +3,7 @@
 // REQUIRES: swift_in_compiler
 
 // rdar92963081
-// UNSUPPORTED: linux
+// UNSUPPORTED: OS=linux-gnu
 
 
 sil_stage canonical

--- a/test/SILOptimizer/no-external-defs-onone.sil
+++ b/test/SILOptimizer/no-external-defs-onone.sil
@@ -7,7 +7,7 @@
 // CHECK-NOT: public_external_unused_test
 
 // TODO: update check line for the hidden_external_test for Windows.
-// UNSUPPORTED: windows
+// UNSUPPORTED: OS=windows-msvc
 
 sil public_external [serialized] @public_external_test : $@convention(thin)  () -> () {
   %0 = tuple()

--- a/test/SILOptimizer/ranges.sil
+++ b/test/SILOptimizer/ranges.sil
@@ -3,7 +3,7 @@
 // REQUIRES: swift_in_compiler
 
 // rdar92963081
-// UNSUPPORTED: linux
+// UNSUPPORTED: OS=linux-gnu
 
 
 sil_stage canonical

--- a/test/Sanitizers/asan/recover.swift
+++ b/test/Sanitizers/asan/recover.swift
@@ -1,6 +1,6 @@
 // REQUIRES: executable_test
 // REQUIRES: asan_runtime
-// UNSUPPORTED: windows
+// UNSUPPORTED: OS=windows-msvc
 
 // Check with recovery instrumentation and the runtime option to continue execution.
 // RUN: %target-swiftc_driver %s -target %sanitizers-target-triple -g -sanitize=address -sanitize-recover=address -import-objc-header %S/asan_interface.h -emit-ir -o %t.asan_recover.ll

--- a/test/Sanitizers/tsan/actor_counters.swift
+++ b/test/Sanitizers/tsan/actor_counters.swift
@@ -5,8 +5,8 @@
 // REQUIRES: libdispatch
 // REQUIRES: tsan_runtime
 // UNSUPPORTED: use_os_stdlib
-// UNSUPPORTED: linux
-// UNSUPPORTED: windows
+// UNSUPPORTED: OS=linux-gnu
+// UNSUPPORTED: OS=windows-msvc
 
 // REQUIRES: rdar83246843
 

--- a/test/Sanitizers/tsan/objc_async.swift
+++ b/test/Sanitizers/tsan/objc_async.swift
@@ -7,8 +7,8 @@
 // REQUIRES: concurrency
 // REQUIRES: objc_interop
 // REQUIRES: tsan_runtime
-// UNSUPPORTED: linux
-// UNSUPPORTED: windows
+// UNSUPPORTED: OS=linux-gnu
+// UNSUPPORTED: OS=windows-msvc
 
 // rdar://76038845
 // UNSUPPORTED: use_os_stdlib

--- a/test/decl/result_builder_fixits.swift
+++ b/test/decl/result_builder_fixits.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -disable-availability-checking
-// UNSUPPORTED: windows
+// UNSUPPORTED: OS=windows-msvc
 // Line-feeds in Fix-Its fail to check on Windows.
 
 @resultBuilder

--- a/test/multifile/protocol-conformance-redundant.swift
+++ b/test/multifile/protocol-conformance-redundant.swift
@@ -6,7 +6,7 @@
 // RUN: %target-run %t/main %t/%target-library-name(Def) %t/%target-library-name(Ext) 2>&1 | %FileCheck %s
 
 // REQUIRES: executable_test
-// XFAIL: windows
+// XFAIL: OS=windows-msvc
 
 // CHECK: Warning: 'main.Sub' conforms to protocol 'Hello', but it also inherits conformance from 'Def.Super'.  Relying on a particular conformance is undefined behaviour.
 // CHECK: Hello

--- a/test/stdlib/simd_diagnostics.swift
+++ b/test/stdlib/simd_diagnostics.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 
 // FIXME: No simd module on linux rdar://problem/20795411
-// XFAIL: linux, windows, openbsd
+// XFAIL: OS=linux-gnu, OS=windows-msvc, OS=openbsd
 // XFAIL: OS=wasi
 
 import simd

--- a/validation-test/SILOptimizer/large_string_array.swift.gyb
+++ b/validation-test/SILOptimizer/large_string_array.swift.gyb
@@ -2,7 +2,7 @@
 // RUN: %gyb %s > %t/main.swift
 
 // https://bugs.swift.org/browse/SR-14460
-// UNSUPPORTED: linux
+// UNSUPPORTED: OS=linux-gnu
 
 // The compiler should finish in less than 1 minute. To give some slack,
 // specify a timeout of 5 minutes.

--- a/validation-test/Sema/type_checker_perf/fast/rdar23620262.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar23620262.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
 // REQUIRES: tools-release,no_asan
 
-// UNSUPPORTED: linux
+// UNSUPPORTED: OS=linux-gnu
 
 // expected-no-diagnostics
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar54580427.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar54580427.swift
@@ -1,7 +1,7 @@
 // RUN: %scale-test --begin 1 --end 20 --step 1 --select NumLeafScopes %s -Xfrontend=-solver-expression-time-threshold=1
 // REQUIRES: asserts,no_asan
 
-// UNSUPPORTED: linux
+// UNSUPPORTED: OS=linux-gnu
 
 enum Val {
   case d([String: Val])

--- a/validation-test/execution/dsohandle-multi-module.swift
+++ b/validation-test/execution/dsohandle-multi-module.swift
@@ -8,7 +8,7 @@
 
 // REQUIRES: executable_test
 
-// UNSUPPORTED: linux
+// UNSUPPORTED: OS=linux-gnu
 
 import first
 import second

--- a/validation-test/stdlib/SIMDParameterPassing.swift.gyb
+++ b/validation-test/stdlib/SIMDParameterPassing.swift.gyb
@@ -18,7 +18,7 @@
 
 // REQUIRES: executable_test
 // REQUIRES: long_test
-// XFAIL: linux
+// XFAIL: OS=linux-gnu
 
 import StdlibUnittest
 import simd


### PR DESCRIPTION
lit.py currently allows any substring of `target_triple` to be used as a
feature in REQUIRES/UNSUPPORTED/XFAIL. This results in various forms of
the OS spread across the tests and is also somewhat confusing since they
aren't actually listed in the available features.

Modify all OS-related features to use the `OS=` version that Swift adds
instead. We can later remove `config.target_triple` so that these don't
the non-OS versions don't work in the first place.