### PR TITLE
[5.7][wrangler] Unconditionally disable test/Distributed/Runtime/distributed_actor_init_local for now

### DIFF
--- a/test/Distributed/Runtime/distributed_actor_init_local.swift
+++ b/test/Distributed/Runtime/distributed_actor_init_local.swift
@@ -8,9 +8,8 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-// FIXME(distributed): 5.7 branches seem to be missing something; as `main + 32bit watch` does not crash on DA usage with the local testing actor system, but 5.7 does.
-// rdar://92952551
-// UNSUPPORTED: OS=watchos
+// FIXME(distributed): Seems something remains incorrect here
+// REQUIRES: rdar92952551
 
 import Distributed
 


### PR DESCRIPTION
(cherry picked from commit ba525375c68d7200f8e8c2bb185fc3688a58b7fa)

We've seen a failure on x86_64 in addition to the archs this is currently disabled.

(https://ci.swift.org/job/oss-swift-5.7_tools-RA_stdlib-DA_test-simulators/324/console)

rdar://92952551