### PR TITLE
[5.7][ConstraintSystem] A couple of improvements to multi-statement closure handling

### DIFF
--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -528,6 +528,8 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
+
   static RelabelArguments *create(ConstraintSystem &cs,
                                   llvm::ArrayRef<Identifier> correctLabels,
                                   ConstraintLocator *locator);

--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -440,7 +440,7 @@ private:
 
     cs.addConstraint(
         ConstraintKind::Conversion, elementType, initType,
-        cs.getConstraintLocator(contextualLocator,
+        cs.getConstraintLocator(sequenceLocator,
                                 ConstraintLocator::SequenceElementType));
 
     // Reference the makeIterator witness.
@@ -449,9 +449,10 @@ private:
 
     Type makeIteratorType =
         cs.createTypeVariable(locator, TVO_CanBindToNoEscape);
-    cs.addValueWitnessConstraint(LValueType::get(sequenceType), makeIterator,
-                                 makeIteratorType, closure,
-                                 FunctionRefKind::Compound, contextualLocator);
+    cs.addValueWitnessConstraint(
+        LValueType::get(sequenceType), makeIterator, makeIteratorType,
+        closure, FunctionRefKind::Compound,
+        cs.getConstraintLocator(sequenceLocator, ConstraintLocator::Witness));
 
     // After successful constraint generation, let's record
     // solution application target with all relevant information.

--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -1177,10 +1177,6 @@ private:
     if (isa<IfConfigDecl>(decl))
       return;
 
-    // Variable declaration would be handled by a pattern binding.
-    if (isa<VarDecl>(decl))
-      return;
-
     // Generate constraints for pattern binding declarations.
     if (auto patternBinding = dyn_cast<PatternBindingDecl>(decl)) {
       SolutionApplicationTarget target(patternBinding);

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1188,6 +1188,12 @@ public:
       : InvalidMemberRefFailure(solution, baseType, memberName, locator) {}
 
   SourceLoc getLoc() const override {
+    auto *locator = getLocator();
+
+    if (locator->findLast<LocatorPathElt::ClosureBodyElement>()) {
+      return constraints::getLoc(getAnchor());
+    }
+
     // Diagnostic should point to the member instead of its base expression.
     return constraints::getLoc(getRawAnchor());
   }

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -242,6 +242,38 @@ bool RelabelArguments::diagnose(const Solution &solution, bool asNote) const {
   return failure.diagnose(asNote);
 }
 
+bool RelabelArguments::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  SmallPtrSet<ValueDecl *, 4> overloadChoices;
+
+  // First, let's find overload choice associated with each
+  // re-labeling fix.
+  for (const auto &fix : commonFixes) {
+    auto &solution = *fix.first;
+
+    auto calleeLocator = solution.getCalleeLocator(getLocator());
+    if (!calleeLocator)
+      return false;
+
+    auto overloadChoice = solution.getOverloadChoiceIfAvailable(calleeLocator);
+    if (!overloadChoice)
+      return false;
+
+    auto *decl = overloadChoice->choice.getDeclOrNull();
+    if (!decl)
+      return false;
+
+    (void)overloadChoices.insert(decl);
+  }
+
+  // If all of the fixes point to the same overload choice then it's
+  // exactly the same issue since the call site is static.
+  if (overloadChoices.size() == 1)
+    return diagnose(*commonFixes.front().first);
+
+  return false;
+}
+
 RelabelArguments *
 RelabelArguments::create(ConstraintSystem &cs,
                          llvm::ArrayRef<Identifier> correctLabels,

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -942,13 +942,10 @@ StepResult ConjunctionStep::resume(bool prevFailed) {
         // and scoring information.
         Snapshot.reset();
 
-        // Restore original scores of outer context before
-        // trying to produce a combined solution.
-        restoreOriginalScores();
-
         // Apply all of the information deduced from the
         // conjunction (up to the point of ambiguity)
         // back to the outer context and form a joined solution.
+        unsigned numSolutions = 0;
         for (auto &solution : Solutions) {
           ConstraintSystem::SolverScope scope(CS);
 
@@ -958,34 +955,47 @@ StepResult ConjunctionStep::resume(bool prevFailed) {
           // of the constraint system, so they have to be
           // restored right afterwards because score of the
           // element does contribute to the overall score.
-          restoreOriginalScores();
+          restoreBestScore();
+          restoreCurrentScore(solution.getFixedScore());
 
           // Transform all of the unbound outer variables into
           // placeholders since we are not going to solve for
           // each ambguous solution.
-          for (auto *typeVar : CS.getTypeVariables()) {
-            if (!typeVar->getImpl().hasRepresentativeOrFixed()) {
-              CS.assignFixedType(
-                  typeVar, PlaceholderType::get(CS.getASTContext(), typeVar));
+          {
+            unsigned numHoles = 0;
+            for (auto *typeVar : CS.getTypeVariables()) {
+              if (!typeVar->getImpl().hasRepresentativeOrFixed()) {
+                CS.assignFixedType(
+                    typeVar, PlaceholderType::get(CS.getASTContext(), typeVar));
+                ++numHoles;
+              }
             }
+            CS.increaseScore(SK_Hole, numHoles);
           }
+
+          if (CS.worseThanBestSolution())
+            continue;
 
           // Note that `worseThanBestSolution` isn't checked
           // here because `Solutions` were pre-filtered, and
           // outer score is the same for all of them.
           OuterSolutions.push_back(CS.finalize());
+          ++numSolutions;
         }
 
-        return done(/*isSuccess=*/true);
+        return done(/*isSuccess=*/numSolutions > 0);
       }
+
+      auto solution = Solutions.pop_back_val();
+      auto score = solution.getFixedScore();
 
       // Restore outer type variables and prepare to solve
       // constraints associated with outer context together
       // with information deduced from the conjunction.
-      Snapshot->setupOuterContext(Solutions.pop_back_val());
+      Snapshot->setupOuterContext(std::move(solution));
 
-      // Pretend that conjunction never happend.
-      restoreOuterState();
+      // Pretend that conjunction never happened.
+      restoreOuterState(score);
 
       // Now that all of the information from the conjunction has
       // been applied, let's attempt to solve the outer scope.
@@ -997,10 +1007,11 @@ StepResult ConjunctionStep::resume(bool prevFailed) {
   return take(prevFailed);
 }
 
-void ConjunctionStep::restoreOuterState() const {
+void ConjunctionStep::restoreOuterState(const Score &solutionScore) const {
   // Restore best/current score, since upcoming step is going to
   // work with outer scope in relation to the conjunction.
-  restoreOriginalScores();
+  restoreBestScore();
+  restoreCurrentScore(solutionScore);
 
   // Active all of the previously out-of-scope constraints
   // because conjunction can propagate type information up

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -960,6 +960,16 @@ StepResult ConjunctionStep::resume(bool prevFailed) {
           // element does contribute to the overall score.
           restoreOriginalScores();
 
+          // Transform all of the unbound outer variables into
+          // placeholders since we are not going to solve for
+          // each ambguous solution.
+          for (auto *typeVar : CS.getTypeVariables()) {
+            if (!typeVar->getImpl().hasRepresentativeOrFixed()) {
+              CS.assignFixedType(
+                  typeVar, PlaceholderType::get(CS.getASTContext(), typeVar));
+            }
+          }
+
           // Note that `worseThanBestSolution` isn't checked
           // here because `Solutions` were pre-filtered, and
           // outer score is the same for all of them.

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -962,8 +962,11 @@ public:
 
     // Restore best score only if conjunction fails because
     // successful outcome should keep a score set by `restoreOuterState`.
-    if (HadFailure)
-      restoreOriginalScores();
+    if (HadFailure) {
+      auto solutionScore = Score();
+      restoreBestScore();
+      restoreCurrentScore(solutionScore);
+    }
 
     if (OuterTimeRemaining) {
       auto anchor = OuterTimeRemaining->first;
@@ -1015,16 +1018,19 @@ protected:
 
 private:
   /// Restore best and current scores as they were before conjunction.
-  void restoreOriginalScores() const {
-    CS.solverState->BestScore = BestScore;
+  void restoreCurrentScore(const Score &solutionScore) const {
     CS.CurrentScore = CurrentScore;
+    CS.increaseScore(SK_Fix, solutionScore.Data[SK_Fix]);
+    CS.increaseScore(SK_Hole, solutionScore.Data[SK_Hole]);
   }
+
+  void restoreBestScore() const { CS.solverState->BestScore = BestScore; }
 
   // Restore constraint system state before conjunction.
   //
   // Note that this doesn't include conjunction constraint
   // itself because we don't want to re-solve it.
-  void restoreOuterState() const;
+  void restoreOuterState(const Score &solutionScore) const;
 };
 
 } // end namespace constraints

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -1170,7 +1170,6 @@ func test(arr: [[Int]]) {
   }
 
   arr.map { ($0 as? [Int]).map { A($0) } } // expected-error {{missing argument label 'arg:' in call}} {{36-36=arg: }}
-  // expected-warning@-1 {{conditional cast from '[Int]' to '[Int]' always succeeds}}
 }
 
 func closureWithCaseArchetype<T>(_: T.Type) {

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -902,7 +902,8 @@ func rdar78781552() {
     // expected-error@-1 {{generic struct 'Test' requires that '(((Int) throws -> Bool) throws -> [Int])?' conform to 'RandomAccessCollection'}}
     // expected-error@-2 {{generic parameter 'Content' could not be inferred}} expected-note@-2 {{explicitly specify the generic arguments to fix this issue}}
     // expected-error@-3 {{cannot convert value of type '(((Int) throws -> Bool) throws -> [Int])?' to expected argument type '[(((Int) throws -> Bool) throws -> [Int])?]'}}
-    // expected-error@-4 {{missing argument for parameter 'filter' in call}}
+    // expected-error@-4 {{missing argument label 'data:' in call}}
+    // expected-error@-5 {{missing argument for parameter 'filter' in call}}
   }
 }
 

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -350,3 +350,18 @@ func test_no_crash_with_circular_ref_due_to_error() {
     return 0
   }
 }
+
+func test_diagnosing_on_missing_member_in_case() {
+  enum E {
+    case one
+  }
+
+  func test(_: (E) -> Void) {}
+
+  test {
+    switch $0 {
+    case .one: break
+    case .unknown: break // expected-error {{type 'E' has no member 'unknown'}}
+    }
+  }
+}

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -379,3 +379,28 @@ func test_diagnosing_on_missing_member_in_case() {
     }
   }
 }
+
+// Type finder shouldn't bring external closure result type
+// into the scope of an inner closure e.g. while solving
+// init of pattern binding `x`.
+func test_type_finder_doesnt_walk_into_inner_closures() {
+  func test<T>(fn: () -> T) -> T { fn() }
+
+  _ = test { // Ok
+    let x = test {
+      42
+    }
+
+    let _ = test {
+      test { "" }
+    }
+
+    // multi-statement
+    let _ = test {
+      _ = 42
+      return test { "" }
+    }
+
+    return x
+  }
+}

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -234,6 +234,20 @@ func test_local_function_capturing_vars() {
   }
 }
 
+func test_test_invalid_redeclaration() {
+  func test(_: () -> Void) {
+  }
+
+  test {
+    let foo = 0 // expected-note {{'foo' previously declared here}}
+    let foo = foo // expected-error {{invalid redeclaration of 'foo'}}
+  }
+
+  test {
+    let (foo, foo) = (5, 6) // expected-error {{invalid redeclaration of 'foo'}} expected-note {{'foo' previously declared here}}
+  }
+}
+
 func test_pattern_ambiguity_doesnot_crash_compiler() {
   enum E {
   case hello(result: Int) // expected-note 2 {{found this candidate}}

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -507,6 +507,7 @@ func testLabeledSubscript() {
   // TODO: These ought to work without errors.
   let _ = \AA.[keyPath: k]
   // expected-error@-1 {{cannot convert value of type 'KeyPath<AA, Int>' to expected argument type 'Int'}}
+  // expected-error@-2 {{extraneous argument label 'keyPath:' in call}}
 
   let _ = \AA.[keyPath: \AA.[labeled: 0]] // expected-error {{extraneous argument label 'keyPath:' in call}}
   // expected-error@-1 {{cannot convert value of type 'KeyPath<AA, Int>' to expected argument type 'Int'}}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/58915
Cherry-pick of https://github.com/apple/swift/pull/58905
Cherry-pick of https://github.com/apple/swift/pull/58834
Cherry-pick of https://github.com/apple/swift/pull/58768


---

-  Conjunction: Transform all unbound outer variables into placeholders during ambiguity
    
   Since there is no solver follow-up after ambiguity has been detected in the body of a closure,
   let's just mark all of the unbound type variables as holes while forming a solution, otherwise
   `CS.finalize()` would crash with `Solver left free type variables`.

- Improve diagnostic precision by attaching  missing member diagnostic to an affected pattern/statement.

- Conjunction: Propagate fix and hole scores to outer solution

  While producing a combined solution, let's reflect the number of
  fixes and holes discovered in the conjunction, that way it would
  be possible to filter solutions and keep track of the fact that
  there were issues in the conjunction.

- Diagnose invalid re-declarations in multi-statement closures

- Fix per-element variable finder to correctly handle return statements

    Type finder is still allowed to walk into closures to find any
    referenced variables, but it should bring external result type
    into scope only if a particular `return` belongs to the same
    closure as the element.

- Diagnose re-labeling failures in ambiguity conditions

Resolves: rdar://92854767

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
