### PR TITLE
[rebranch] Remove check for minor version

### DIFF
--- a/lib/SymbolGraphGen/JSON.cpp
+++ b/lib/SymbolGraphGen/JSON.cpp
@@ -53,10 +53,11 @@ void swift::symbolgraphgen::serialize(const llvm::Triple &T,
       OS.attribute("name", T.getOSTypeName(T.getOS()));
 
       llvm::VersionTuple OSVersion = T.getOSVersion();
-
-      OS.attributeBegin("minimumVersion");
-      serialize(OSVersion, OS);
-      OS.attributeEnd();
+      if (!OSVersion.empty()) {
+        OS.attributeBegin("minimumVersion");
+        serialize(OSVersion, OS);
+        OS.attributeEnd();
+      }
     });
   });
 }

--- a/test/SymbolGraph/Module/Module.swift
+++ b/test/SymbolGraph/Module/Module.swift
@@ -1,8 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -module-name SymbolGraphModule -emit-module -emit-module-path %t/
 // RUN: %target-swift-symbolgraph-extract -module-name SymbolGraphModule -I %t -pretty-print -output-dir %t
-// RUN: %FileCheck %s --input-file %t/SymbolGraphModule.symbols.json
-
+// RUN: %FileCheck %s --input-file %t/SymbolGraphModule.symbols.json --check-prefix=CHECK --check-prefix=CHECK-%target-os
 public struct S {
   public var x: Int
 }
@@ -14,6 +13,15 @@ public struct S {
 // CHECK:        vendor
 // CHECK-NEXT:   operatingSystem
 // CHECK-NEXT:     name
-// CHECK-NEXT:     minimumVersion
-// CHECK-NEXT:       major
-// CHECK-NEXT:       minor
+// CHECK-macosx-NEXT:  minimumVersion
+// CHECK-ios-NEXT:     minimumVersion
+// CHECK-tvos-NEXT:    minimumVersion
+// CHECK-watchos-NEXT: minimumVersion
+// CHECK-macosx-NEXT:    major
+// CHECK-ios-NEXT:       major
+// CHECK-tvos-NEXT:      major
+// CHECK-watchos-NEXT:   major
+// CHECK-macosx-NEXT:    minor
+// CHECK-ios-NEXT:       minor
+// CHECK-tvos-NEXT:      minor
+// CHECK-watchos-NEXT:   minor


### PR DESCRIPTION
Minor isn't provided in the `Triple` for Linux, so it's no longer added
to the output.