### PR TITLE
use getConformingProtocols when printing opaque generic types

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -57,6 +57,7 @@
 #include "clang/AST/DeclObjC.h"
 #include "clang/Basic/Module.h"
 #include "clang/Basic/SourceManager.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/ConvertUTF.h"
@@ -6388,26 +6389,15 @@ public:
       // Print based on the type.
       Printer << "some ";
       if (!decl->getConformingProtocols().empty()) {
-        ArrayRef<ProtocolDecl *> protocols = decl->getConformingProtocols();
-        bool printed = false;
-        for (unsigned i = 0, e = protocols.size(); i < e; i++) {
-          if (auto printType = protocols[i]->getDeclaredType()) {
-            if (printed)
-              Printer << " & ";
-
+        llvm::interleave(decl->getConformingProtocols(), Printer, [&](ProtocolDecl *proto){
+          if (auto printType = proto->getDeclaredType())
             printType->print(Printer, Options);
-
-            printed = true;
-          }
-        }
-
-        // Short-circuit if we printed anything - it's still possible that the protocol(s) didn't
-        // have a valid type, so we still want to print *something*
-        if (printed)
-          return;
+          else
+            Printer << proto->getNameStr();
+        }, " & ");
+      } else {
+        Printer << "Any";
       }
-
-      Printer << "Any";
       return;
     }
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -6387,10 +6387,27 @@ public:
 
       // Print based on the type.
       Printer << "some ";
-      if (auto inheritedType = decl->getInherited().front().getType())
-        inheritedType->print(Printer, Options);
-      else
-        Printer << "Any";
+      if (!decl->getConformingProtocols().empty()) {
+        ArrayRef<ProtocolDecl *> protocols = decl->getConformingProtocols();
+        bool printed = false;
+        for (unsigned i = 0, e = protocols.size(); i < e; i++) {
+          if (auto printType = protocols[i]->getDeclaredType()) {
+            if (printed)
+              Printer << " & ";
+
+            printType->print(Printer, Options);
+
+            printed = true;
+          }
+        }
+
+        // Short-circuit if we printed anything - it's still possible that the protocol(s) didn't
+        // have a valid type, so we still want to print *something*
+        if (printed)
+          return;
+      }
+
+      Printer << "Any";
       return;
     }
 

--- a/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/SomeProtocol.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/SomeProtocol.swift
@@ -1,0 +1,131 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name SomeProtocol -emit-module -emit-module-path %t/
+// RUN: %target-swift-symbolgraph-extract -module-name SomeProtocol -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/SomeProtocol.symbols.json
+// RUN: %FileCheck %s --input-file %t/SomeProtocol.symbols.json --check-prefix MULTI
+
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name SomeProtocol -emit-module -emit-module-path %t/SomeProtocol.swiftmodule -emit-symbol-graph -emit-symbol-graph-dir %t/
+// RUN: %{python} -m json.tool %t/SomeProtocol.symbols.json %t/SomeProtocol.formatted.symbols.json
+// RUN: %FileCheck %s --input-file %t/SomeProtocol.formatted.symbols.json
+// RUN: %FileCheck %s --input-file %t/SomeProtocol.formatted.symbols.json --check-prefix MULTI
+
+// Make sure that `some MyProtocol` parameters don't crash swift-symbolgraph-extract, and that it
+// properly renders `some MyProtocol & OtherProtocol` parameters with multiple protocols listed.
+
+public protocol SomeProtocol {}
+
+public func doSomething(with param: some SomeProtocol) {}
+
+public protocol OtherProtocol {}
+
+public func doSomethingElse(with param: some SomeProtocol & OtherProtocol) {}
+
+// CHECK-LABEL:        "precise": "s:12SomeProtocol11doSomething4withyx_tA2ARzlF",
+
+// the functionSignature fragments come before the full fragments, so skip those
+// CHECK:      "functionSignature": {
+// CHECK:      "declarationFragments": [
+
+// CHECK:      "declarationFragments": [
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "kind": "keyword",
+// CHECK-NEXT:          "spelling": "func"
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "kind": "text",
+// CHECK-NEXT:          "spelling": " "
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "kind": "identifier",
+// CHECK-NEXT:          "spelling": "doSomething"
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "kind": "text",
+// CHECK-NEXT:          "spelling": "("
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "kind": "externalParam",
+// CHECK-NEXT:          "spelling": "with"
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "kind": "text",
+// CHECK-NEXT:          "spelling": " "
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "kind": "internalParam",
+// CHECK-NEXT:          "spelling": "param"
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "kind": "text",
+// CHECK-NEXT:          "spelling": ": some "
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "kind": "typeIdentifier",
+// CHECK-NEXT:          "spelling": "SomeProtocol",
+// CHECK-NEXT:          "preciseIdentifier": "s:12SomeProtocolAAP"
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "kind": "text",
+// CHECK-NEXT:          "spelling": ")"
+// CHECK-NEXT:        }
+// CHECK-NEXT:      ],
+
+// MULTI-LABEL:        "precise": "s:12SomeProtocol15doSomethingElse4withyx_tAA05OtherB0RzA2ARzlF",
+
+// the functionSignature fragments come before the full fragments, so skip those
+// MULTI:      "functionSignature": {
+// MULTI:      "declarationFragments": [
+
+// MULTI:      "declarationFragments": [
+// MULTI-NEXT:        {
+// MULTI-NEXT:          "kind": "keyword",
+// MULTI-NEXT:          "spelling": "func"
+// MULTI-NEXT:        },
+// MULTI-NEXT:        {
+// MULTI-NEXT:          "kind": "text",
+// MULTI-NEXT:          "spelling": " "
+// MULTI-NEXT:        },
+// MULTI-NEXT:        {
+// MULTI-NEXT:          "kind": "identifier",
+// MULTI-NEXT:          "spelling": "doSomethingElse"
+// MULTI-NEXT:        },
+// MULTI-NEXT:        {
+// MULTI-NEXT:          "kind": "text",
+// MULTI-NEXT:          "spelling": "("
+// MULTI-NEXT:        },
+// MULTI-NEXT:        {
+// MULTI-NEXT:          "kind": "externalParam",
+// MULTI-NEXT:          "spelling": "with"
+// MULTI-NEXT:        },
+// MULTI-NEXT:        {
+// MULTI-NEXT:          "kind": "text",
+// MULTI-NEXT:          "spelling": " "
+// MULTI-NEXT:        },
+// MULTI-NEXT:        {
+// MULTI-NEXT:          "kind": "internalParam",
+// MULTI-NEXT:          "spelling": "param"
+// MULTI-NEXT:        },
+// MULTI-NEXT:        {
+// MULTI-NEXT:          "kind": "text",
+// MULTI-NEXT:          "spelling": ": some "
+// MULTI-NEXT:        },
+// MULTI-NEXT:        {
+// MULTI-NEXT:          "kind": "typeIdentifier",
+// MULTI-NEXT:          "spelling": "OtherProtocol",
+// MULTI-NEXT:          "preciseIdentifier": "s:12SomeProtocol05OtherB0P"
+// MULTI-NEXT:        },
+// MULTI-NEXT:        {
+// MULTI-NEXT:          "kind": "text",
+// MULTI-NEXT:          "spelling": " & "
+// MULTI-NEXT:        },
+// MULTI-NEXT:        {
+// MULTI-NEXT:          "kind": "typeIdentifier",
+// MULTI-NEXT:          "spelling": "SomeProtocol",
+// MULTI-NEXT:          "preciseIdentifier": "s:12SomeProtocolAAP"
+// MULTI-NEXT:        },
+// MULTI-NEXT:        {
+// MULTI-NEXT:          "kind": "text",
+// MULTI-NEXT:          "spelling": ")"
+// MULTI-NEXT:        }
+// MULTI-NEXT:      ],


### PR DESCRIPTION
Resolves rdar://93610106

When printing a function with an opaque `some MyProtocol` type in its argument list from a serialized AST, the current mechanism to print that protocol fails. This PR updates that code to use a check that works on both source files and serialized ASTs.