### PR TITLE
Fix assert always triggering in `sourcekitd-repl`

### DIFF
--- a/tools/SourceKit/tools/sourcekitd-repl/sourcekitd-repl.cpp
+++ b/tools/SourceKit/tools/sourcekitd-repl/sourcekitd-repl.cpp
@@ -90,10 +90,11 @@ using Convert = ConvertForWcharSize<sizeof(wchar_t)>;
 
 static void convertFromUTF8(llvm::StringRef utf8,
                             llvm::SmallVectorImpl<wchar_t> &out) {
+  size_t original_out_size = out.size();
   size_t reserve = out.size() + utf8.size();
   out.resize_for_overwrite(reserve);
   const char *utf8_begin = utf8.begin();
-  wchar_t *wide_begin = out.end();
+  wchar_t *wide_begin = out.begin() + original_out_size;
   auto res = Convert::ConvertFromUTF8(&utf8_begin, utf8.end(),
                                       &wide_begin, out.data() + reserve,
                                       lenientConversion);
@@ -104,10 +105,11 @@ static void convertFromUTF8(llvm::StringRef utf8,
 
 static void convertToUTF8(llvm::ArrayRef<wchar_t> wide,
                           llvm::SmallVectorImpl<char> &out) {
+  size_t original_out_size = out.size();
   size_t reserve = out.size() + wide.size()*4;
   out.resize_for_overwrite(reserve);
   const wchar_t *wide_begin = wide.begin();
-  char *utf8_begin = out.end();
+  char *utf8_begin = out.begin() + original_out_size;
   auto res = Convert::ConvertToUTF8(&wide_begin, wide.end(),
                                     &utf8_begin, out.data() + reserve,
                                     lenientConversion);


### PR DESCRIPTION
PR #41550 changed from using `SmallVector::set_size` to `resize_for_overwrite` and `truncate`, but in `sourcekitd-repl` changing from `reserve` changes the size just prior to getting the `end()` of the output array, resulting in the UTF8 conversion retrieving the end of the resized output array, rather than the end of the array prior to resizing. As a result the asserts at lines 101 and 116 always trigger with `res == targetExhausted`.

The conversion needs to begin at the original output's end.