### PR TITLE
[5.7][stdlib] Work around binary compatibility issues with String index validation fixes in 5.7

### DIFF
--- a/stdlib/public/SwiftShims/RuntimeShims.h
+++ b/stdlib/public/SwiftShims/RuntimeShims.h
@@ -116,6 +116,20 @@ SWIFT_RUNTIME_STDLIB_SPI
 __swift_bool _swift_stdlib_getCurrentStackBounds(__swift_uintptr_t *outBegin,
                                                  __swift_uintptr_t *outEnd);
 
+/// A value representing a version number for the Standard Library.
+typedef struct {
+  __swift_uint32_t _value;
+} _SwiftStdlibVersion;
+
+/// Checks if the currently running executable was built using a Swift release
+/// matching or exceeding the specified Standard Library version number. This
+/// can be used to stage behavioral changes in the Standard Library, preventing
+/// them from causing compatibility issues with existing binaries.
+SWIFT_RUNTIME_STDLIB_INTERNAL
+__swift_bool _swift_stdlib_isExecutableLinkedOnOrAfter(
+  _SwiftStdlibVersion version
+) __attribute__((const));
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/stdlib/public/core/Assert.swift
+++ b/stdlib/public/core/Assert.swift
@@ -325,6 +325,40 @@ internal func _internalInvariant_5_1(
 #endif
 }
 
+/// Library precondition checks with a linked-on-or-after check, allowing the
+/// addition of new preconditions while maintaining compatibility with older
+/// binaries.
+///
+/// This version of `_precondition` only traps if the condition returns false
+/// **and** the current executable was built with a Swift Standard Library
+/// version equal to or greater than the supplied version.
+@_transparent
+internal func _precondition(
+  ifLinkedOnOrAfter version: _SwiftStdlibVersion,
+  _ condition: @autoclosure () -> Bool,
+  _ message: StaticString = StaticString(),
+  file: StaticString = #file, line: UInt = #line
+) {
+  // Delay the linked-on-or-after check until after we know we have a failed
+  // condition, so that we don't slow down the usual case too much.
+
+  // Note: this is an internal function, so `_isDebugAssertConfiguration` is
+  // expected to evaluate (at compile time) to true in production builds of the
+  // stdlib. The other branches are kept in case the stdlib is built with an
+  // unusual configuration.
+  if _isDebugAssertConfiguration() {
+    if _slowPath(!condition()) {
+      guard _isExecutableLinkedOnOrAfter(version) else { return }
+      _assertionFailure("Fatal error", message, file: file, line: line,
+        flags: _fatalErrorFlags())
+    }
+  } else if _isReleaseAssertConfiguration() {
+    let error = (!condition() && _isExecutableLinkedOnOrAfter(version))
+    Builtin.condfail_message(error._value, message.unsafeRawPointer)
+  }
+}
+
+
 @usableFromInline @_transparent
 internal func _internalInvariantFailure(
   _ message: StaticString = StaticString(),

--- a/stdlib/public/core/Availability.swift
+++ b/stdlib/public/core/Availability.swift
@@ -59,3 +59,48 @@ public func _stdlib_isOSVersionAtLeastOrVariantVersionAtLeast(
   return _stdlib_isOSVersionAtLeast(major, minor, patch)
 }
 #endif
+
+public typealias _SwiftStdlibVersion = SwiftShims._SwiftStdlibVersion
+
+/// Return true if the main executable was linked with an SDK version
+/// corresponding to the given Swift Stdlib release, or later. Otherwise, return
+/// false.
+///
+/// This is useful to maintain compatibility with older binaries after a
+/// behavioral change in the stdlib.
+///
+/// This function must not be called from inlinable code.
+@inline(__always)
+internal func _isExecutableLinkedOnOrAfter(
+  _ stdlibVersion: _SwiftStdlibVersion
+) -> Bool {
+#if SWIFT_RUNTIME_OS_VERSIONING
+  return _swift_stdlib_isExecutableLinkedOnOrAfter(stdlibVersion)
+#else
+  return true
+#endif
+}
+
+extension _SwiftStdlibVersion {
+  @_alwaysEmitIntoClient
+  public static var v5_6_0: Self { Self(_value: 0x050600) }
+
+  @_alwaysEmitIntoClient
+  public static var v5_7_0: Self { Self(_value: 0x050700) }
+
+  @available(SwiftStdlib 5.7, *)
+  public static var current: Self { .v5_7_0 }
+}
+
+@available(SwiftStdlib 5.7, *)
+extension _SwiftStdlibVersion: CustomStringConvertible {
+  @available(SwiftStdlib 5.7, *)
+  public var description: String {
+    let major = _value >> 16
+    let minor = (_value >> 8) & 0xFF
+    let patch = _value & 0xFF
+    return "\(major).\(minor).\(patch)"
+  }
+}
+
+

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -83,10 +83,16 @@ extension String: BidirectionalCollection {
   ///   `startIndex`.
   /// - Returns: The index value immediately before `i`.
   public func index(before i: Index) -> Index {
-    let i = _guts.validateInclusiveCharacterIndex(i)
+    // FIXME: This method used to not properly validate indices before 5.7;
+    // temporarily allow older binaries to keep invoking undefined behavior as
+    // before.
+    let i = _guts.validateInclusiveCharacterIndex_5_7(i)
+
     // Note: Aligning an index may move it closer towards the `startIndex`, so
     // the `i > startIndex` check needs to come after rounding.
-    _precondition(i > startIndex, "String index is out of bounds")
+    _precondition(
+      ifLinkedOnOrAfter: .v5_7_0,
+      i > startIndex, "String index is out of bounds")
 
     return _uncheckedIndex(before: i)
   }
@@ -137,7 +143,10 @@ extension String: BidirectionalCollection {
 
     // TODO: known-ASCII and single-scalar-grapheme fast path, etc.
 
-    var i = _guts.validateInclusiveCharacterIndex(i)
+    // FIXME: This method used to not properly validate indices before 5.7;
+    // temporarily allow older binaries to keep invoking undefined behavior as
+    // before.
+    var i = _guts.validateInclusiveCharacterIndex_5_7(i)
 
     if distance >= 0 {
       for _ in stride(from: 0, to: distance, by: 1) {
@@ -209,10 +218,14 @@ extension String: BidirectionalCollection {
     // ensure our behavior exactly matches the documentation above. We do need
     // to ensure it has a matching encoding, though. The same goes for `start`,
     // which is used to determine whether the limit applies at all.
+
     let limit = _guts.ensureMatchingEncoding(limit)
     let start = _guts.ensureMatchingEncoding(i)
 
-    var i = _guts.validateInclusiveCharacterIndex(i)
+    // FIXME: This method used to not properly validate indices before 5.7;
+    // temporarily allow older binaries to keep invoking undefined behavior as
+    // before.
+    var i = _guts.validateInclusiveCharacterIndex_5_7(i)
 
     if distance >= 0 {
       for _ in stride(from: 0, to: distance, by: 1) {
@@ -245,8 +258,11 @@ extension String: BidirectionalCollection {
     // Note: Prior to Swift 5.7, this function used to be inlinable, forwarding
     // to `BidirectionalCollection._distance(from:to:)`.
 
-    let start = _guts.validateInclusiveCharacterIndex(start)
-    let end = _guts.validateInclusiveCharacterIndex(end)
+    // FIXME: This method used to not properly validate indices before 5.7;
+    // temporarily allow older binaries to keep invoking undefined behavior as
+    // before.
+    let start = _guts.validateInclusiveCharacterIndex_5_7(start)
+    let end = _guts.validateInclusiveCharacterIndex_5_7(end)
 
     // TODO: known-ASCII and single-scalar-grapheme fast path, etc.
 

--- a/stdlib/public/core/StringIndexConversions.swift
+++ b/stdlib/public/core/StringIndexConversions.swift
@@ -51,15 +51,13 @@ extension String.Index {
   ///   - target: The string referenced by the resulting index.
   public init?(_ sourcePosition: String.Index, within target: String) {
     // As a special exception, we allow `sourcePosition` to be an UTF-16 index
-    // when `self` is a UTF-8 string, to preserve compatibility with (broken)
-    // code that keeps using indices from a bridged string after converting the
-    // string to a native representation. Such indices are invalid, but
-    // returning nil here can break code that appeared to work fine for ASCII
-    // strings in Swift releases prior to 5.7.
-    guard
-      let i = target._guts.ensureMatchingEncodingNoTrap(sourcePosition),
-      target._isValidIndex(i)
-    else { return nil }
+    // when `self` is a UTF-8 string (or vice versa), to preserve compatibility
+    // with (broken) code that keeps using indices from a bridged string after
+    // converting the string to a native representation. Such indices are
+    // invalid, but returning nil here can break code that appeared to work fine
+    // for ASCII strings in Swift releases prior to 5.7.
+    let i = target._guts.ensureMatchingEncoding(sourcePosition)
+    guard target._isValidIndex(i) else { return nil }
     self = i._characterAligned
   }
 
@@ -111,15 +109,13 @@ extension String.Index {
     }
     if let str = target as? Substring {
       // As a special exception, we allow `sourcePosition` to be an UTF-16 index
-      // when `self` is a UTF-8 string, to preserve compatibility with (broken)
-      // code that keeps using indices from a bridged string after converting
-      // the string to a native representation. Such indices are invalid, but
-      // returning nil here can break code that appeared to work fine for ASCII
-      // strings in Swift releases prior to 5.7.
-      guard
-        let i = str._wholeGuts.ensureMatchingEncodingNoTrap(sourcePosition),
-        str._isValidIndex(i)
-      else { return nil }
+      // when `self` is a UTF-8 string (or vice versa), to preserve
+      // compatibility with (broken) code that keeps using indices from a
+      // bridged string after converting the string to a native representation.
+      // Such indices are invalid, but returning nil here can break code that
+      // appeared to work fine for ASCII strings in Swift releases prior to 5.7.
+      let i = str._wholeGuts.ensureMatchingEncoding(sourcePosition)
+      guard str._isValidIndex(i) else { return nil }
       self = i
       return
     }

--- a/stdlib/public/core/StringIndexValidation.swift
+++ b/stdlib/public/core/StringIndexValidation.swift
@@ -342,3 +342,100 @@ extension _StringGuts {
     return Range(_uncheckedBounds: (l, u))
   }
 }
+
+// Temporary additions to deal with binary compatibility issues with existing
+// binaries that accidentally pass invalid indices to String APIs in cases that
+// were previously undiagnosed.
+//
+// FIXME: Remove these after a release or two.
+extension _StringGuts {
+  /// A version of `validateInclusiveSubscalarIndex` that only traps if the main
+  /// executable was linked with Swift Stdlib version 5.7 or better. This is
+  /// used to work around binary compatibility problems with existing apps that
+  /// pass invalid indices to String APIs.
+  internal func validateInclusiveSubscalarIndex_5_7(
+    _ i: String.Index
+  ) -> String.Index {
+    let i = ensureMatchingEncoding(i)
+    _precondition(
+      ifLinkedOnOrAfter: .v5_7_0,
+      i._encodedOffset <= count,
+      "String index is out of bounds")
+    return i
+  }
+
+  /// A version of `validateInclusiveScalarIndex` that only traps if the main
+  /// executable was linked with Swift Stdlib version 5.7 or better. This is
+  /// used to work around binary compatibility problems with existing apps that
+  /// pass invalid indices to String APIs.
+  internal func validateInclusiveScalarIndex_5_7(
+    _ i: String.Index
+  ) -> String.Index {
+    if isFastScalarIndex(i) {
+      _precondition(
+        ifLinkedOnOrAfter: .v5_7_0,
+        i._encodedOffset <= count,
+        "String index is out of bounds")
+      return i
+    }
+
+    return scalarAlign(validateInclusiveSubscalarIndex_5_7(i))
+  }
+
+  /// A version of `validateSubscalarRange` that only traps if the main
+  /// executable was linked with Swift Stdlib version 5.7 or better. This is
+  /// used to work around binary compatibility problems with existing apps that
+  /// pass invalid indices to String APIs.
+  internal func validateSubscalarRange_5_7(
+    _ range: Range<String.Index>
+  ) -> Range<String.Index> {
+    let upper = ensureMatchingEncoding(range.upperBound)
+    let lower = ensureMatchingEncoding(range.lowerBound)
+
+    _precondition(upper <= endIndex && lower <= upper,
+      "String index range is out of bounds")
+
+    return Range(_uncheckedBounds: (lower, upper))
+  }
+
+  /// A version of `validateScalarRange` that only traps if the main executable
+  /// was linked with Swift Stdlib version 5.7 or better. This is used to work
+  /// around binary compatibility problems with existing apps that pass invalid
+  /// indices to String APIs.
+  internal func validateScalarRange_5_7(
+    _ range: Range<String.Index>
+  ) -> Range<String.Index> {
+    if
+      isFastScalarIndex(range.lowerBound), isFastScalarIndex(range.upperBound)
+    {
+      _precondition(
+        ifLinkedOnOrAfter: .v5_7_0,
+        range.upperBound._encodedOffset <= count,
+        "String index range is out of bounds")
+      return range
+    }
+
+    let r = validateSubscalarRange_5_7(range)
+    return Range(
+      _uncheckedBounds: (scalarAlign(r.lowerBound), scalarAlign(r.upperBound)))
+  }
+
+  /// A version of `validateInclusiveCharacterIndex` that only traps if the main
+  /// executable was linked with Swift Stdlib version 5.7 or better. This is
+  /// used to work around binary compatibility problems with existing apps that
+  /// pass invalid indices to String APIs.
+  internal func validateInclusiveCharacterIndex_5_7(
+    _ i: String.Index
+  ) -> String.Index {
+    if isFastCharacterIndex(i) {
+      _precondition(
+        ifLinkedOnOrAfter: .v5_7_0,
+        i._encodedOffset <= count,
+        "String index is out of bounds")
+      return i
+    }
+
+    return roundDownToNearestCharacter(
+      scalarAlign(validateInclusiveSubscalarIndex_5_7(i)))
+  }
+}

--- a/stdlib/public/core/StringUTF8View.swift
+++ b/stdlib/public/core/StringUTF8View.swift
@@ -360,15 +360,13 @@ extension String.UTF8View.Index {
     // Note: This method used to be inlinable until Swift 5.7.
 
     // As a special exception, we allow `idx` to be an UTF-16 index when `self`
-    // is a UTF-8 string, to preserve compatibility with (broken) code that
-    // keeps using indices from a bridged string after converting the string to
-    // a native representation. Such indices are invalid, but returning nil here
-    // can break code that appeared to work fine for ASCII strings in Swift
-    // releases prior to 5.7.
-    guard
-      let idx = target._guts.ensureMatchingEncodingNoTrap(idx),
-      idx._encodedOffset <= target._guts.count
-    else { return nil }
+    // is a UTF-8 string (or vice versa), to preserve compatibility with
+    // (broken) code that keeps using indices from a bridged string after
+    // converting the string to a native representation. Such indices are
+    // invalid, but returning nil here can break code that appeared to work fine
+    // for ASCII strings in Swift releases prior to 5.7.
+    let idx = target._guts.ensureMatchingEncoding(idx)
+    guard idx._encodedOffset <= target._guts.count else { return nil }
 
     if _slowPath(target._guts.isForeign) {
       guard idx._foreignIsWithin(target) else { return nil }

--- a/stdlib/public/runtime/EnvironmentVariables.cpp
+++ b/stdlib/public/runtime/EnvironmentVariables.cpp
@@ -93,6 +93,36 @@ static uint8_t parse_uint8_t(const char *name,
   return n;
 }
 
+static uint32_t parse_uint32_t(const char *name,
+                               const char *value,
+                               uint32_t defaultValue) {
+  if (!value)
+    return defaultValue;
+  char *end;
+  long long n = strtoll(value, &end, 0);
+  if (*end != '\0') {
+    swift::warning(RuntimeErrorFlagNone,
+                   "Warning: cannot parse value %s=%s, defaulting to %u.\n",
+                   name, value, defaultValue);
+    return defaultValue;
+  }
+
+  if (n < 0) {
+    swift::warning(RuntimeErrorFlagNone,
+                   "Warning: %s=%s out of bounds, clamping to 0.\n",
+                   name, value);
+    return 0;
+  }
+  if (n > UINT32_MAX) {
+    swift::warning(RuntimeErrorFlagNone,
+                   "Warning: %s=%s out of bounds, clamping to %d.\n",
+                   name, value, UINT32_MAX);
+    return UINT32_MAX;
+  }
+
+  return n;
+}
+
 // Print a list of all the environment variables. Lazy initialization makes
 // this a bit odd, but the use of these variables in the metadata system means
 // it's almost certain to run early.

--- a/stdlib/public/runtime/EnvironmentVariables.def
+++ b/stdlib/public/runtime/EnvironmentVariables.def
@@ -69,4 +69,7 @@ VARIABLE(SWIFT_DEBUG_RUNTIME_EXCLUSIVITY_LOGGING, bool, false,
 
 #endif
 
+VARIABLE(SWIFT_BINARY_COMPATIBILITY_VERSION, uint32_t, 0,
+        "Set the binary compatibility level of the Swift Standard Library")
+
 #undef VARIABLE

--- a/test/stdlib/StringIndex_bincompat.swift
+++ b/test/stdlib/StringIndex_bincompat.swift
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -g %s -o %t/StringIndex
+// RUN: %target-codesign %t/StringIndex
+// RUN: env %env-SWIFT_BINARY_COMPATIBILITY_VERSION=0x050600 %target-run %t/StringIndex %S/Inputs/
+
+// REQUIRES: executable_test
+// UNSUPPORTED: freestanding
+// UNSUPPORTED: use_os_stdlib || back_deployment_runtime
+// UNSUPPORTED: swift_stdlib_asserts
+
+// In 5.7, a number of String APIs started performing stronger index validation,
+// eliminating issues such as out of bounds memory accesses when members are
+// given invalid indices. The environment variable
+// SWIFT_BINARY_COMPATIBILITY_VERSION above forces the stdlib's bincompat
+// version to 5.6 so that we can test older behavior.
+//
+// We can only test old behavior that doesn't lead to undefined behavior,
+// though.
+
+import StdlibUnittest
+
+var suite = TestSuite("StringIndexBinCompatTests")
+defer { runAllTests() }
+
+suite.test("String.index(before:) on an index near the start") {
+  let string = "😲 hi"
+  let i = string.utf8.index(after: string.utf8.startIndex)
+  expectEqual(string.index(before: i), string.startIndex)
+}

--- a/test/stdlib/StringTraps.swift
+++ b/test/stdlib/StringTraps.swift
@@ -4,8 +4,12 @@
 //
 // RUN: %target-codesign %t/a.out_Debug
 // RUN: %target-codesign %t/a.out_Release
-// RUN: %target-run %t/a.out_Debug
-// RUN: %target-run %t/a.out_Release
+// RUN: env %env-SWIFT_BINARY_COMPATIBILITY_VERSION=0x050700 %target-run %t/a.out_Debug
+// RUN: env %env-SWIFT_BINARY_COMPATIBILITY_VERSION=0x050700 %target-run %t/a.out_Release
+
+// Note: the environment variable above forces the stdlib's bincompat version to
+// 5.7 so that we can test new behavior even if the SDK we're using predates it.
+
 // REQUIRES: executable_test
 // UNSUPPORTED: OS=wasi
 
@@ -351,116 +355,5 @@ StringTraps.test("UTF8View foreign index(before:) trap on i == startIndex")
   var i = s.utf8.startIndex
   expectCrashLater()
   i = s.utf8.index(before: i)
-}
-#endif
-
-#if _runtime(_ObjC)
-if #available(SwiftStdlib 5.7, *) {
-  let native = "🫱🏼‍🫲🏽 a 🧑🏽‍🌾 b"
-  let cocoa = ("🫱🏼‍🫲🏽 a 🧑🏽‍🌾 b" as NSString) as String
-
-  let goodIndices: [String.Index] = [
-    native.startIndex,
-    native.unicodeScalars.startIndex,
-    native.utf8.startIndex,
-    native.utf16.startIndex,
-  ]
-
-  StringTraps.test("Start index encoding").forEach(in: goodIndices) { i in
-    // The startIndex works fine in both encodings.
-    print(i)
-    expectEqual(cocoa[i], native[i])
-  }
-
-  let badIndices: [String.Index] = [
-    native.index(native.startIndex, offsetBy: 3),
-    native.unicodeScalars.index(native.startIndex, offsetBy: 3),
-    native.utf8.index(native.startIndex, offsetBy: 3),
-    native.utf16.index(native.startIndex, offsetBy: 3),
-  ]
-
-  StringTraps.test("String.subscript/encoding trap")
-  .forEach(in: badIndices) { i in
-    print(i)
-    expectCrashLater()
-    print(cocoa[i])
-  }
-
-  StringTraps.test("String.index(after:)/encoding trap")
-  .forEach(in: badIndices) { i in
-    print(i)
-    expectCrashLater()
-    print(cocoa.index(after: i))
-  }
-
-  StringTraps.test("String.index(before:)/encoding trap")
-  .forEach(in: badIndices) { i in
-    print(i)
-    expectCrashLater()
-    print(cocoa.index(before: i))
-  }
-
-  StringTraps.test("String.UnicodeScalarView.subscript/encoding trap")
-  .forEach(in: badIndices) { i in
-    print(i)
-    expectCrashLater()
-    print(cocoa.unicodeScalars[i])
-  }
-
-  StringTraps.test("String.UnicodeScalarView.index(after:)/encoding trap")
-  .forEach(in: badIndices) { i in
-    print(i)
-    expectCrashLater()
-    print(cocoa.unicodeScalars.index(after: i))
-  }
-
-  StringTraps.test("String.UnicodeScalarView.index(before:)/encoding trap")
-  .forEach(in: badIndices) { i in
-    print(i)
-    expectCrashLater()
-    print(cocoa.unicodeScalars.index(before: i))
-  }
-
-  StringTraps.test("String.UTF8View.subscript/encoding trap")
-  .forEach(in: badIndices) { i in
-    print(i)
-    expectCrashLater()
-    print(cocoa.utf8[i])
-  }
-
-  StringTraps.test("String.UTF8View.index(after:)/encoding trap")
-  .forEach(in: badIndices) { i in
-    print(i)
-    expectCrashLater()
-    print(cocoa.utf8.index(after: i))
-  }
-
-  StringTraps.test("String.UTF8View.index(before:)/encoding trap")
-  .forEach(in: badIndices) { i in
-    print(i)
-    expectCrashLater()
-    print(cocoa.utf8.index(before: i))
-  }
-
-  StringTraps.test("String.UTF16View.subscript/encoding trap")
-  .forEach(in: badIndices) { i in
-    print(i)
-    expectCrashLater()
-    print(cocoa.utf16[i])
-  }
-
-  StringTraps.test("String.UTF16View.index(after:)/encoding trap")
-  .forEach(in: badIndices) { i in
-    print(i)
-    expectCrashLater()
-    print(cocoa.utf16.index(after: i))
-  }
-
-  StringTraps.test("String.UTF16View.index(before:)/encoding trap")
-  .forEach(in: badIndices) { i in
-    print(i)
-    expectCrashLater()
-    print(cocoa.utf16.index(before: i))
-  }
 }
 #endif


### PR DESCRIPTION
(Cherry picked from #58954)

* **Explanation:**  Swift 5.7 added stronger index validation for `String`, so some illegal cases that previously triggered inconsistently diagnosed out of bounds accesses now result in reliable runtime errors. Similarly, attempts at applying an index originally vended by a UTF-8 string on a UTF-16 string now result in a reliable runtime error.

    As is usually the case, adding new traps to the stdlib exposes some existing code that contains previously undiagnosed / unreliably diagnosed coding issues. This change allows invalid code inside binaries built with earlier versions of the stdlib to continue running with the 5.7 library by disabling some of the new traps based on the version of Swift the binary was built with.

    In the case of an index encoding mismatch, allow transcoding of string storage regardless of the direction of the mismatch. (Previously we only allowed transcoding a UTF-8 string to UTF-16.)

* **Scope:** `String` in the Standard Library; binary compatibility.

* **Risk:** Medium. While the change is relatively large, it merely loosens the Stdlib's preconditions, allowing entry points to succeed in more cases. The primary risk has to do with the introduction of the new bincompat checks, especially as they come with a new stdlib/runtime interface through `SwiftShims` additions.

* **Issue:** rdar://93379333

* **Reviewer:** @glessard
