### PR TITLE
[SwiftSyntax] Parse regex literals using a fallback lexer implemented in C++

### DIFF
--- a/include/swift/Parse/SyntaxRegexFallbackLexing.h
+++ b/include/swift/Parse/SyntaxRegexFallbackLexing.h
@@ -1,0 +1,21 @@
+//===--- SyntaxRegexFallbackLexing.h --------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+namespace swift {
+/// SwiftSyntax parsing currently doesn't link against
+/// SwiftExperimentalStringProcessing and is thus missing the regex lexing
+/// functions defined in it. This registers a fallback regex-lexing function
+/// implemented in C++ that is sufficient to generate a valid SwiftSyntax tree.
+/// The regex parser registered by this function will accept all regex literals
+/// and is not suited for normal compilation.
+void registerSyntaxFallbackRegexParser();
+} // end namespace swift

--- a/lib/Parse/CMakeLists.txt
+++ b/lib/Parse/CMakeLists.txt
@@ -24,7 +24,8 @@ add_swift_host_library(swiftParse STATIC
   ParseType.cpp
   PersistentParserState.cpp
   SyntaxParsingCache.cpp
-  SyntaxParsingContext.cpp)
+  SyntaxParsingContext.cpp
+  SyntaxRegexFallbackLexing.cpp)
 _swift_gyb_target_sources(swiftParse PRIVATE
     ParsedSyntaxBuilders.cpp.gyb
     ParsedSyntaxNodes.cpp.gyb

--- a/lib/Parse/SyntaxRegexFallbackLexing.cpp
+++ b/lib/Parse/SyntaxRegexFallbackLexing.cpp
@@ -1,0 +1,153 @@
+//===--- SyntaxRegexFallbackLexing.cpp ------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Parse/SyntaxRegexFallbackLexing.h"
+#include "swift/AST/DiagnosticEngine.h"
+#include "swift/AST/DiagnosticsParse.h"
+#include "swift/Parse/Lexer.h"
+#include "swift/Parse/RegexParserBridging.h"
+#include <mutex>
+
+using namespace swift;
+
+template <typename... DiagArgTypes, typename... ArgTypes>
+static void diagnose(BridgedOptionalDiagnosticEngine bridgedDiag,
+                     const char *ptr, Diag<DiagArgTypes...> DiagID,
+                     ArgTypes &&...Args) {
+  if (auto *Diag = static_cast<DiagnosticEngine *>(bridgedDiag.object)) {
+    Diag->diagnose(SourceLoc(llvm::SMLoc::getFromPointer(ptr)), DiagID,
+                   std::forward<ArgTypes>(Args)...);
+  }
+}
+
+bool syntaxparse_lexRegexLiteral(
+    const char **InputPtr, const char *BufferEnd, bool MustBeRegex,
+    BridgedOptionalDiagnosticEngine BridgedDiagEngine) {
+
+  const char *Ptr = *InputPtr;
+
+  // Count leading '#'.
+  while (*Ptr == '#') {
+    ++Ptr;
+  }
+  if (*Ptr != '/') {
+    // This wasn't a regex literal.
+    return true;
+  }
+
+  unsigned customDelimiterLen = Ptr - *InputPtr;
+
+  ++Ptr;
+
+  // If the delimiter allows multi-line, try skipping over any whitespace to a
+  // newline character. If we can do that, we enter multi-line mode.
+  bool allowsMultiline = customDelimiterLen != 0;
+  const char *firstNewline = nullptr;
+  if (allowsMultiline) {
+    while (Ptr != BufferEnd) {
+      switch (*Ptr) {
+      case ' ':
+      case '\t':
+        ++Ptr;
+        continue;
+      case '\r':
+      case '\n':
+        firstNewline = Ptr;
+        break;
+      default:
+        break;
+      }
+      break;
+    }
+  }
+
+  bool isMultilineLiteral = (firstNewline != nullptr);
+
+  while (true) {
+    switch (*Ptr++) {
+    case '\r':
+    case '\n':
+      if (!isMultilineLiteral) {
+        diagnose(BridgedDiagEngine, Ptr, diag::lex_regex_literal_unterminated);
+        *InputPtr = Ptr - 1;
+        return false;
+      }
+      break;
+    case '\\':
+      if (Ptr != BufferEnd) {
+        if (!isMultilineLiteral && (*Ptr == '\r' || *Ptr == '\n')) {
+          diagnose(BridgedDiagEngine, Ptr, diag::lex_regex_literal_unterminated);
+          *InputPtr = Ptr - 1;
+          return false;
+        }
+        if (validateUTF8CharacterAndAdvance(Ptr, BufferEnd) == ~0U)
+          diagnose(BridgedDiagEngine, Ptr, diag::lex_invalid_utf8);
+      }
+      break;
+    case '/': {
+      const char *AfterSlashPos = Ptr;
+
+      // Eat '#' up to the open delimeter length.
+      while (*Ptr == '#' && (Ptr - AfterSlashPos) <= customDelimiterLen) {
+        ++Ptr;
+      }
+
+      if ((Ptr - AfterSlashPos) != customDelimiterLen) {
+        // '#' count didn't match. Reset the cursor after the '/' and move on.
+        Ptr = AfterSlashPos;
+        break;
+      }
+
+      // Found the closing delimiter. Finish.
+      *InputPtr = Ptr;
+      return false;
+    }
+    case '\0': {
+      if (Ptr - 1 == BufferEnd) {
+        // Reached to EOF.
+        diagnose(BridgedDiagEngine, Ptr, diag::lex_regex_literal_unterminated);
+        // In multi-line mode, we don't want to skip over what is likely
+        // otherwise valid Swift code, so resume from the first newline.
+        *InputPtr = firstNewline ? firstNewline : (Ptr - 1);
+        return false;
+      }
+
+      // TODO: Warn to match the behavior of String literal lexer?
+      // For now, just ignore them.
+      break;
+    }
+    default: {
+      --Ptr;
+      if (validateUTF8CharacterAndAdvance(Ptr, BufferEnd) == ~0U)
+        diagnose(BridgedDiagEngine, Ptr, diag::lex_invalid_utf8);
+      break;
+    }
+    }
+  }
+}
+
+bool syntaxparse_parseRegexLiteral(const char *InputPtr, unsigned *VersionOut,
+                                   void *CaptureStructureOut,
+                                   unsigned CaptureStructureSize,
+                                   BridgedSourceLoc DiagnosticBaseLoc,
+                                   BridgedDiagnosticEngine BridgedDiagEngine) {
+  *VersionOut = ~0u;
+  return /*hasError*/ false;
+}
+
+void swift::registerSyntaxFallbackRegexParser() {
+  static std::once_flag flag;
+  std::call_once(flag, []() {
+    Parser_registerRegexLiteralLexingFn(syntaxparse_lexRegexLiteral);
+    Parser_registerRegexLiteralParsingFn(syntaxparse_parseRegexLiteral);
+  });
+}

--- a/test/Syntax/round_trip_regex.swift
+++ b/test/Syntax/round_trip_regex.swift
@@ -1,0 +1,33 @@
+// RUN: %empty-directory(%t)
+// RUN: %swift-syntax-test -input-source-filename %s -parse-gen -fail-on-parse-error > %t/afterRoundtrip.swift
+// RUN: diff -u %s %t/afterRoundtrip.swift
+
+_ = /abc/
+_ = #/abc/#
+_ = ##/abc/##
+
+func foo<T>(_ x: T...) {}
+foo(/abc/, #/abc/#, ##/abc/##)
+
+let arr = [/abc/, #/abc/#, ##/abc/##]
+
+_ = /\w+/.self
+_ = #/\w+/#.self
+_ = ##/\w+/##.self
+
+_ = /#\/\#\\/
+_ = #/#/\/\#\\/#
+_ = ##/#|\|\#\\/##
+
+_ = #/
+multiline
+/#
+
+_ = #/
+double
+multiline
+/#
+
+_ = #/
+\
+/#

--- a/test/Syntax/round_trip_regex_escape_newline.swift
+++ b/test/Syntax/round_trip_regex_escape_newline.swift
@@ -1,0 +1,10 @@
+// RUN: %empty-directory(%t)
+// RUN: not %swift-syntax-test -input-source-filename %s -parse-gen -fail-on-parse-error > %t/afterRoundtrip.swift 2> %t/errors.swift
+// RUN: diff -u %s %t/afterRoundtrip.swift
+// RUN: cat %t/errors.swift | %FileCheck %s
+
+// Escaping newlines is not supported
+_ = /\
+/
+
+// CHECK: 7:7: error: unterminated regex literal

--- a/test/Syntax/round_trip_regex_invalid.swift
+++ b/test/Syntax/round_trip_regex_invalid.swift
@@ -1,0 +1,16 @@
+// RUN: %empty-directory(%t)
+// RUN: %swift-syntax-test -input-source-filename %s -parse-gen > %t/afterRoundtrip.swift
+// RUN: diff -u %s %t/afterRoundtrip.swift
+
+_ = /abc
+_ = #/abc
+_ = #/abc/
+_ = ##/abc/#
+
+_ #/x
+/#
+_ #/
+x/#
+
+_ //#
+_ /x/#

--- a/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
+++ b/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
@@ -21,6 +21,7 @@
 #include "swift/Basic/SourceManager.h"
 #include "swift/Parse/Parser.h"
 #include "swift/Parse/SyntaxParseActions.h"
+#include "swift/Parse/SyntaxRegexFallbackLexing.h"
 #include "swift/Syntax/Serialization/SyntaxSerialization.h"
 #include "swift/Syntax/SyntaxNodes.h"
 #include "swift/Subsystems.h"
@@ -478,6 +479,7 @@ struct SynParserDiagConsumer: public DiagnosticConsumer {
 };
 
 swiftparse_client_node_t SynParser::parse(const char *source, size_t len) {
+  registerSyntaxFallbackRegexParser();
   SourceManager SM;
   unsigned bufID = SM.addNewSourceBuffer(llvm::MemoryBuffer::getMemBuffer(
       StringRef(source, len), "syntax_parse_source"));
@@ -488,6 +490,10 @@ swiftparse_client_node_t SynParser::parse(const char *source, size_t len) {
   // Disable name lookups during parsing.
   // Not ready yet:
   // langOpts.EnableASTScopeLookup = true;
+
+  // Always enable bare /.../ regex literal in syntax parser.
+  langOpts.EnableExperimentalStringProcessing = true;
+  langOpts.EnableBareSlashRegexLiterals = true;
 
   auto parseActions =
     std::make_shared<CLibParseActions>(*this, SM, bufID);

--- a/tools/swift-syntax-test/swift-syntax-test.cpp
+++ b/tools/swift-syntax-test/swift-syntax-test.cpp
@@ -28,6 +28,7 @@
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
 #include "swift/Parse/Lexer.h"
 #include "swift/Parse/Parser.h"
+#include "swift/Parse/SyntaxRegexFallbackLexing.h"
 #include "swift/Subsystems.h"
 #include "swift/Syntax/Serialization/SyntaxDeserialization.h"
 #include "swift/Syntax/Serialization/SyntaxSerialization.h"
@@ -190,6 +191,12 @@ VerifySyntaxTree("verify-syntax-tree",
                  llvm::cl::desc("Emit warnings for unknown nodes"),
                  llvm::cl::cat(Category),
                  llvm::cl::init(true));
+
+static llvm::cl::opt<bool> FailOnParseError(
+    "fail-on-parse-error",
+    llvm::cl::desc("Exit with a non-zero exit code if there was a parsing "
+                   "error (including unknown syntax nodes)"),
+    llvm::cl::cat(Category), llvm::cl::init(false));
 
 static llvm::cl::opt<bool>
 Visual("v",
@@ -536,6 +543,8 @@ struct ParseInfo {
   SourceFile *SF;
   SyntaxParsingCache *SyntaxCache;
   std::string Diags;
+  /// Whether parsing produced any diagnostics with severity error.
+  bool DidHaveError;
 };
 
 /// Parse the given input file (incrementally if an old syntax tree was
@@ -543,6 +552,7 @@ struct ParseInfo {
 int parseFile(
     const char *MainExecutablePath, const StringRef InputFileName,
     llvm::function_ref<int(ParseInfo)> ActionSpecificCallback) {
+  registerSyntaxFallbackRegexParser();
   // The cache needs to be a heap allocated pointer since we construct it inside
   // an if block but need to keep it alive until the end of the function.
   SyntaxParsingCache *SyntaxCache = nullptr;
@@ -581,6 +591,8 @@ int parseFile(
   Invocation.getLangOptions().ParseForSyntaxTreeOnly = true;
   Invocation.getLangOptions().VerifySyntaxTree = options::VerifySyntaxTree;
   Invocation.getLangOptions().DisablePoundIfEvaluation = true;
+  Invocation.getLangOptions().EnableExperimentalStringProcessing = true;
+  Invocation.getLangOptions().EnableBareSlashRegexLiterals = true;
 
   Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(InputFileName);
 
@@ -643,13 +655,32 @@ int parseFile(
     }
   }
 
-  int ActionSpecificExitCode =
-    ActionSpecificCallback({SF, SyntaxCache, DiagOS.str()});
+  int ActionSpecificExitCode = ActionSpecificCallback(
+      {SF, SyntaxCache, DiagOS.str(), DiagConsumer.didErrorOccur()});
   if (ActionSpecificExitCode != EXIT_SUCCESS) {
     return ActionSpecificExitCode;
   } else {
     return InternalExitCode;
   }
+}
+
+static bool printDiags(ParseInfo info) {
+  if (!options::DiagsOutputFilename.empty()) {
+    std::error_code errorCode;
+    llvm::raw_fd_ostream os(options::DiagsOutputFilename, errorCode,
+                            llvm::sys::fs::OF_None);
+    if (errorCode) {
+      llvm::errs() << "error opening file '" << options::DiagsOutputFilename
+                   << "': " << errorCode.message() << '\n';
+      return false;
+    }
+    if (!info.Diags.empty())
+      os << info.Diags << '\n';
+  } else {
+    if (!info.Diags.empty())
+      llvm::errs() << info.Diags << '\n';
+  }
+  return true;
 }
 
 int doFullLexRoundTrip(const StringRef InputFilename) {
@@ -711,6 +742,9 @@ int doFullParseRoundTrip(const char *MainExecutablePath,
   return parseFile(MainExecutablePath, InputFile,
     [](ParseInfo info) -> int {
     info.SF->getSyntaxRoot().print(llvm::outs(), {});
+    if (options::FailOnParseError && info.DidHaveError) {
+      return EXIT_FAILURE;
+    }
     return EXIT_SUCCESS;
   });
 }
@@ -736,22 +770,13 @@ int doSerializeRawTree(const char *MainExecutablePath,
       llvm::outs() << "\n";
     }
 
-    if (!options::DiagsOutputFilename.empty()) {
-      std::error_code errorCode;
-      llvm::raw_fd_ostream os(options::DiagsOutputFilename, errorCode,
-                              llvm::sys::fs::OF_None);
-      if (errorCode) {
-        llvm::errs() << "error opening file '" << options::DiagsOutputFilename
-          << "': " << errorCode.message() << '\n';
-        return EXIT_FAILURE;
-      }
-      if (!info.Diags.empty())
-        os << info.Diags << '\n';
-    } else {
-      if (!info.Diags.empty())
-        llvm::errs() << info.Diags << '\n';
+    if (!printDiags(info)) {
+      return EXIT_FAILURE;
     }
 
+    if (options::FailOnParseError && info.DidHaveError) {
+      return EXIT_FAILURE;
+    }
     return EXIT_SUCCESS;
   });
 }
@@ -771,8 +796,13 @@ int doDeserializeRawTree(const char *MainExecutablePath,
 }
 
 int doParseOnly(const char *MainExecutablePath, const StringRef InputFile) {
-  return parseFile(MainExecutablePath, InputFile,
-    [](ParseInfo info) {
+  return parseFile(MainExecutablePath, InputFile, [](ParseInfo info) {
+    if (!printDiags(info)) {
+      return EXIT_FAILURE;
+    }
+    if (options::FailOnParseError && info.DidHaveError) {
+      return EXIT_FAILURE;
+    }
     return info.SF ? EXIT_SUCCESS : EXIT_FAILURE;
   });
 }
@@ -785,6 +815,12 @@ int dumpParserGen(const char *MainExecutablePath, const StringRef InputFile) {
     Opts.Visual = options::Visual;
     Opts.PrintTrivialNodeKind = options::PrintTrivialNodeKind;
     info.SF->getSyntaxRoot().print(llvm::outs(), Opts);
+    if (!printDiags(info)) {
+      return EXIT_FAILURE;
+    }
+    if (options::FailOnParseError && info.DidHaveError) {
+      return EXIT_FAILURE;
+    }
     return EXIT_SUCCESS;
   });
 }
@@ -802,6 +838,10 @@ int dumpEOFSourceLoc(const char *MainExecutablePath,
     auto StartLoc = SourceMgr.getLocForBufferStart(BufferId);
     auto EndLoc = SourceMgr.getLocForOffset(BufferId, AbPos.getOffset());
 
+    if (!printDiags(info)) {
+      return EXIT_FAILURE;
+    }
+
     // To ensure the correctness of position when translated to line & column
     // pair.
     if (SourceMgr.getLocOffsetInBuffer(EndLoc, BufferId) != AbPos.getOffset()) {
@@ -809,6 +849,9 @@ int dumpEOFSourceLoc(const char *MainExecutablePath,
       return EXIT_FAILURE;
     }
     llvm::outs() << CharSourceRange(SourceMgr, StartLoc, EndLoc).str();
+    if (options::FailOnParseError && info.DidHaveError) {
+      return EXIT_FAILURE;
+    }
     return EXIT_SUCCESS;
   });
 }


### PR DESCRIPTION
`libInternalSwiftSyntaxParser.dylib` currently doesn’t link against `SwiftExperimentalStringProcessing`, so it can’t use the regex lexing functions defined within. This caused SwiftSyntax to fail if the source code contained regex literals.

Implement a fallback regex lexing function in C++ and use it for SwiftSyntax parsing.

rdar://93580240
