### PR TITLE
[CodeCompletion] Cache 'async'-ness of free functions

### DIFF
--- a/include/swift/AST/DiagnosticsIDE.def
+++ b/include/swift/AST/DiagnosticsIDE.def
@@ -17,21 +17,21 @@
 
 ERROR(ide_async_in_nonasync_context, none,
       "async %0 used in a context that does not support concurrency",
-      (DeclName))
+      (StringRef))
 
 // NOTE: This is WARNING because this is emitted for cross actor references with
 // non-'Sendable' types. That is optionally ('-warn-concurrency') warning in
 // Swift 5.5.
 WARNING(ide_cross_actor_reference_swift5, none,
         "actor-isolated %0 should only be referenced from inside the actor",
-        (DeclName))
+        (StringRef))
 
 WARNING(ide_redundant_import, none,
-        "module %0 is already imported", (DeclName))
+        "module %0 is already imported", (StringRef))
 
 // FIXME: Inform which other 'import' this module came from.
 NOTE(ide_redundant_import_indirect, none,
-     "module %0 is already imported via another module import", (DeclName))
+     "module %0 is already imported via another module import", (StringRef))
 
 WARNING(ide_availability_softdeprecated, Deprecation,
         "%select{getter for |setter for |}0%1 will be deprecated"
@@ -45,6 +45,10 @@ WARNING(ide_availability_softdeprecated_rename, Deprecation,
         " in %select{a future version|%select{a future version of %3|%3 %5}4}2"
         ": renamed to '%6'",
         (unsigned, DeclName, bool, StringRef, bool, llvm::VersionTuple, StringRef))
+
+WARNING(ide_recursive_accessor_reference,none,
+        "attempting to %select{access|modify}1 %0 within its own "
+        "%select{getter|setter}1", (StringRef, bool))
 
 //===----------------------------------------------------------------------===//
 

--- a/include/swift/IDE/CodeCompletionConsumer.h
+++ b/include/swift/IDE/CodeCompletionConsumer.h
@@ -30,7 +30,8 @@ public:
   handleResultsAndModules(CodeCompletionContext &context,
                           ArrayRef<RequestedCachedModule> requestedModules,
                           const ExpectedTypeContext *TypeContext,
-                          const DeclContext *DC) = 0;
+                          const DeclContext *DC,
+                          bool CanCurrDeclContextHandleAsync) = 0;
 };
 
 /// A simplified code completion consumer interface that clients can use to get
@@ -42,7 +43,8 @@ struct SimpleCachingCodeCompletionConsumer : public CodeCompletionConsumer {
   void handleResultsAndModules(CodeCompletionContext &context,
                                ArrayRef<RequestedCachedModule> requestedModules,
                                const ExpectedTypeContext *TypeContext,
-                               const DeclContext *DCForModules) override;
+                               const DeclContext *DCForModules,
+                               bool CanCurrDeclContextHandleAsync) override;
 
   /// Clients should override this method to receive \p Results.
   virtual void handleResults(CodeCompletionContext &context) = 0;

--- a/include/swift/IDE/CodeCompletionResult.h
+++ b/include/swift/IDE/CodeCompletionResult.h
@@ -341,6 +341,10 @@ class ContextFreeCodeCompletionResult {
   NullTerminatedStringRef DiagnosticMessage;
   NullTerminatedStringRef FilterName;
 
+  /// If the result represents a \c ValueDecl the name by which this decl should
+  /// be refered to in diagnostics.
+  NullTerminatedStringRef NameForDiagnostics;
+
 public:
   /// Memberwise initializer. \p AssociatedKInd is opaque and will be
   /// interpreted based on \p Kind. If \p KnownOperatorKind is \c None and the
@@ -361,13 +365,15 @@ public:
       ContextFreeNotRecommendedReason NotRecommended,
       CodeCompletionDiagnosticSeverity DiagnosticSeverity,
       NullTerminatedStringRef DiagnosticMessage,
-      NullTerminatedStringRef FilterName)
+      NullTerminatedStringRef FilterName,
+      NullTerminatedStringRef NameForDiagnostics)
       : Kind(Kind), KnownOperatorKind(KnownOperatorKind), IsSystem(IsSystem),
         CompletionString(CompletionString), ModuleName(ModuleName),
         BriefDocComment(BriefDocComment), AssociatedUSRs(AssociatedUSRs),
         ResultType(ResultType), NotRecommended(NotRecommended),
         DiagnosticSeverity(DiagnosticSeverity),
-        DiagnosticMessage(DiagnosticMessage), FilterName(FilterName) {
+        DiagnosticMessage(DiagnosticMessage), FilterName(FilterName),
+        NameForDiagnostics(NameForDiagnostics) {
     this->AssociatedKind.Opaque = AssociatedKind;
     assert((NotRecommended == ContextFreeNotRecommendedReason::None) ==
                (DiagnosticSeverity == CodeCompletionDiagnosticSeverity::None) &&
@@ -491,6 +497,10 @@ public:
 
   NullTerminatedStringRef getFilterName() const { return FilterName; }
 
+  NullTerminatedStringRef getNameForDiagnostics() const {
+    return NameForDiagnostics;
+  }
+
   bool isOperator() const {
     if (getKind() == CodeCompletionResultKind::Declaration) {
       switch (getAssociatedDeclKind()) {
@@ -528,11 +538,6 @@ class CodeCompletionResult {
   ContextualNotRecommendedReason NotRecommended : 4;
   static_assert(int(ContextualNotRecommendedReason::MAX_VALUE) < 1 << 4, "");
 
-  CodeCompletionDiagnosticSeverity DiagnosticSeverity : 3;
-  static_assert(int(CodeCompletionDiagnosticSeverity::MAX_VALUE) < 1 << 3, "");
-
-  NullTerminatedStringRef DiagnosticMessage;
-
   /// The number of bytes to the left of the code completion point that
   /// should be erased first if this completion string is inserted in the
   /// editor buffer.
@@ -553,14 +558,10 @@ private:
                        SemanticContextKind SemanticContext,
                        CodeCompletionFlair Flair, uint8_t NumBytesToErase,
                        CodeCompletionResultTypeRelation TypeDistance,
-                       ContextualNotRecommendedReason NotRecommended,
-                       CodeCompletionDiagnosticSeverity DiagnosticSeverity,
-                       NullTerminatedStringRef DiagnosticMessage)
+                       ContextualNotRecommendedReason NotRecommended)
       : ContextFree(ContextFree), SemanticContext(SemanticContext),
         Flair(Flair.toRaw()), NotRecommended(NotRecommended),
-        DiagnosticSeverity(DiagnosticSeverity),
-        DiagnosticMessage(DiagnosticMessage), NumBytesToErase(NumBytesToErase),
-        TypeDistance(TypeDistance) {}
+        NumBytesToErase(NumBytesToErase), TypeDistance(TypeDistance) {}
 
 public:
   /// Enrich a \c ContextFreeCodeCompletionResult with the following contextual
@@ -578,9 +579,7 @@ public:
                        const ExpectedTypeContext *TypeContext,
                        const DeclContext *DC,
                        const USRBasedTypeContext *USRTypeContext,
-                       ContextualNotRecommendedReason NotRecommended,
-                       CodeCompletionDiagnosticSeverity DiagnosticSeverity,
-                       NullTerminatedStringRef DiagnosticMessage);
+                       ContextualNotRecommendedReason NotRecommended);
 
   const ContextFreeCodeCompletionResult &getContextFreeResult() const {
     return ContextFree;
@@ -699,37 +698,23 @@ public:
     return getContextFreeResult().getAssociatedUSRs();
   }
 
-  /// Get the contextual diagnostic severity. This disregards context-free
-  /// diagnostics.
-  CodeCompletionDiagnosticSeverity getContextualDiagnosticSeverity() const {
-    return DiagnosticSeverity;
-  }
+  /// Get the contextual diagnostic severity and message. This disregards
+  /// context-free diagnostics.
+  std::pair<CodeCompletionDiagnosticSeverity, NullTerminatedStringRef>
+  getContextualDiagnosticSeverityAndMessage(SmallVectorImpl<char> &Scratch,
+                                            const ASTContext &Ctx) const;
 
-  /// Get the contextual diagnostic message. This disregards context-free
-  /// diagnostics.
-  NullTerminatedStringRef getContextualDiagnosticMessage() const {
-    return DiagnosticMessage;
-  }
-
-  /// Return the contextual diagnostic severity if there was a contextual
-  /// diagnostic. If there is no contextual diagnostic, return the context-free
-  /// diagnostic severity.
-  CodeCompletionDiagnosticSeverity getDiagnosticSeverity() const {
+  /// Return the contextual diagnostic severity and message if there was a
+  /// contextual diagnostic. If there is no contextual diagnostic, return the
+  /// context-free diagnostic severity and message.
+  std::pair<CodeCompletionDiagnosticSeverity, NullTerminatedStringRef>
+  getDiagnosticSeverityAndMessage(SmallVectorImpl<char> &Scratch,
+                                  const ASTContext &Ctx) const {
     if (NotRecommended != ContextualNotRecommendedReason::None) {
-      return DiagnosticSeverity;
+      return getContextualDiagnosticSeverityAndMessage(Scratch, Ctx);
     } else {
-      return getContextFreeResult().getDiagnosticSeverity();
-    }
-  }
-
-  /// Return the contextual diagnostic message if there was a contextual
-  /// diagnostic. If there is no contextual diagnostic, return the context-free
-  /// diagnostic message.
-  NullTerminatedStringRef getDiagnosticMessage() const {
-    if (NotRecommended != ContextualNotRecommendedReason::None) {
-      return DiagnosticMessage;
-    } else {
-      return getContextFreeResult().getDiagnosticMessage();
+      return std::make_pair(getContextFreeResult().getDiagnosticSeverity(),
+                            getContextFreeResult().getDiagnosticMessage());
     }
   }
 

--- a/include/swift/IDE/CompletionInstance.h
+++ b/include/swift/IDE/CompletionInstance.h
@@ -46,7 +46,7 @@ makeCodeCompletionMemoryBuffer(const llvm::MemoryBuffer *origBuf,
 /// The result returned via the callback from the perform*Operation methods.
 struct CompletionInstanceResult {
   /// The compiler instance that is prepared for the second pass.
-  CompilerInstance &CI;
+  std::shared_ptr<CompilerInstance> CI;
   /// Whether an AST was reused.
   bool DidReuseAST;
   /// Whether the CompletionInstance found a code completion token in the source
@@ -87,14 +87,14 @@ class CompletionInstance {
 
   std::mutex mtx;
 
-  std::unique_ptr<CompilerInstance> CachedCI;
+  std::shared_ptr<CompilerInstance> CachedCI;
   llvm::hash_code CachedArgHash;
   llvm::sys::TimePoint<> DependencyCheckedTimestamp;
   llvm::StringMap<llvm::hash_code> InMemoryDependencyHash;
   unsigned CachedReuseCount = 0;
   std::atomic<bool> CachedCIShouldBeInvalidated;
 
-  void cacheCompilerInstance(std::unique_ptr<CompilerInstance> CI,
+  void cacheCompilerInstance(std::shared_ptr<CompilerInstance> CI,
                              llvm::hash_code ArgsHash);
 
   bool shouldCheckDependencies() const;

--- a/include/swift/IDE/CompletionLookup.h
+++ b/include/swift/IDE/CompletionLookup.h
@@ -254,6 +254,10 @@ public:
 
   void setIdealExpectedType(Type Ty) { expectedTypeContext.setIdealType(Ty); }
 
+  bool canCurrDeclContextHandleAsync() const {
+    return CanCurrDeclContextHandleAsync;
+  }
+
   void setCanCurrDeclContextHandleAsync(bool CanCurrDeclContextHandleAsync) {
     this->CanCurrDeclContextHandleAsync = CanCurrDeclContextHandleAsync;
   }

--- a/include/swift/IDE/SwiftCompletionInfo.h
+++ b/include/swift/IDE/SwiftCompletionInfo.h
@@ -20,8 +20,7 @@ namespace swift {
 namespace ide {
 
 struct SwiftCompletionInfo {
-  swift::ASTContext *swiftASTContext = nullptr;
-  const swift::CompilerInvocation *invocation = nullptr;
+  std::shared_ptr<CompilerInstance> compilerInstance = nullptr;
   CodeCompletionContext *completionContext = nullptr;
 };
 

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1359,7 +1359,8 @@ void swift::ide::deliverCompletionResults(
                                /*Sink=*/nullptr);
 
   Consumer.handleResultsAndModules(CompletionContext, RequestedModules,
-                                   Lookup.getExpectedTypeContext(), DC);
+                                   Lookup.getExpectedTypeContext(), DC,
+                                   Lookup.canCurrDeclContextHandleAsync());
 }
 
 bool CodeCompletionCallbacksImpl::trySolverCompletion(bool MaybeFuncBody) {

--- a/lib/IDE/CodeCompletionConsumer.cpp
+++ b/lib/IDE/CodeCompletionConsumer.cpp
@@ -87,8 +87,7 @@ static MutableArrayRef<CodeCompletionResult *> copyCodeCompletionResults(
         *contextFreeResult, SemanticContextKind::OtherModule,
         CodeCompletionFlair(),
         /*numBytesToErase=*/0, TypeContext, DC, &USRTypeContext,
-        ContextualNotRecommendedReason::None,
-        CodeCompletionDiagnosticSeverity::None, /*DiagnosticMessage=*/"");
+        ContextualNotRecommendedReason::None);
     targetSink.Results.push_back(contextualResult);
   }
 

--- a/lib/IDE/CodeCompletionDiagnostics.h
+++ b/lib/IDE/CodeCompletionDiagnostics.h
@@ -29,13 +29,17 @@ bool getContextFreeCompletionDiagnostics(
     ContextFreeNotRecommendedReason reason, const ValueDecl *D,
     CodeCompletionDiagnosticSeverity &severity, llvm::raw_ostream &Out);
 
-/// Populate \p severity and \p Out with the contextual diagnostics for \p D.
+/// Populate \p severity and \p Out with the contextual for \p reason.
+/// \p NameForDiagnostic is the name of the decl that produced this diagnostic.
+/// \p Ctx is a context that's purely used to have a reference to a diagnostic
+/// engine.
 /// See \c NotRecommendedReason for an explaination of context-free vs.
 /// contextual diagnostics.
 /// Returns \c true if it fails to generate the diagnostics.
 bool getContextualCompletionDiagnostics(
-    ContextualNotRecommendedReason reason, const ValueDecl *D,
-    CodeCompletionDiagnosticSeverity &severity, llvm::raw_ostream &Out);
+    ContextualNotRecommendedReason Reason, StringRef NameForDiagnostics,
+    CodeCompletionDiagnosticSeverity &Severity, llvm::raw_ostream &Out,
+    const ASTContext &Ctx);
 
 } // namespace ide
 } // namespace swift

--- a/lib/IDE/CodeCompletionResultBuilder.cpp
+++ b/lib/IDE/CodeCompletionResultBuilder.cpp
@@ -164,35 +164,8 @@ CodeCompletionResult *CodeCompletionResultBuilder::takeResult() {
         *ContextFreeResult, SemanticContextKind::None, CodeCompletionFlair(),
         /*NumBytesToErase=*/0, /*TypeContext=*/nullptr,
         /*DC=*/nullptr, /*USRTypeContext=*/nullptr,
-        ContextualNotRecommendedReason::None,
-        CodeCompletionDiagnosticSeverity::None, "");
+        ContextualNotRecommendedReason::None);
   } else {
-    CodeCompletionDiagnosticSeverity ContextualDiagnosticSeverity =
-        CodeCompletionDiagnosticSeverity::None;
-    NullTerminatedStringRef ContextualDiagnosticMessage;
-    if (ContextualNotRecReason != ContextualNotRecommendedReason::None) {
-      // FIXME: We should generate the message lazily.
-      //
-      // NOTE(rdar://95306033): dyn_cast_or_null because 'nullptr' happens in
-      // cases like:
-      //
-      //   func test(fn: () async -> Void) { fn(#HERE#) }
-      //
-      // In this case, it's 'InvalidAsyncContext' but there's no associated decl
-      // because the callee is a random expression.
-      // FIXME: Emit a diagnostic even without an associated decl.
-      if (const auto *VD = dyn_cast_or_null<ValueDecl>(AssociatedDecl)) {
-        CodeCompletionDiagnosticSeverity severity;
-        SmallString<256> message;
-        llvm::raw_svector_ostream messageOS(message);
-        if (!getContextualCompletionDiagnostics(ContextualNotRecReason, VD,
-                                                severity, messageOS)) {
-          ContextualDiagnosticSeverity = severity;
-          ContextualDiagnosticMessage =
-              NullTerminatedStringRef(message, Allocator);
-        }
-      }
-    }
     assert(
         ContextFreeResult != nullptr &&
         "ContextFreeResult should have been constructed by the switch above");
@@ -202,8 +175,7 @@ CodeCompletionResult *CodeCompletionResultBuilder::takeResult() {
     // for USRTypeContext.
     return new (Allocator) CodeCompletionResult(
         *ContextFreeResult, SemanticContext, Flair, NumBytesToErase,
-        TypeContext, DC, /*USRTypeContext=*/nullptr, ContextualNotRecReason,
-        ContextualDiagnosticSeverity, ContextualDiagnosticMessage);
+        TypeContext, DC, /*USRTypeContext=*/nullptr, ContextualNotRecReason);
   }
 }
 

--- a/lib/IDE/CodeCompletionResultBuilder.cpp
+++ b/lib/IDE/CodeCompletionResultBuilder.cpp
@@ -128,7 +128,7 @@ CodeCompletionResult *CodeCompletionResultBuilder::takeResult() {
     }
 
     ContextFreeResult = ContextFreeCodeCompletionResult::createDeclResult(
-        Sink, CCS, AssociatedDecl, ModuleName,
+        Sink, CCS, AssociatedDecl, IsAsync, ModuleName,
         NullTerminatedStringRef(BriefDocComment, Allocator),
         copyAssociatedUSRs(Allocator, AssociatedDecl), ResultType,
         ContextFreeNotRecReason, ContextFreeDiagnosticSeverity,
@@ -145,7 +145,7 @@ CodeCompletionResult *CodeCompletionResultBuilder::takeResult() {
   case CodeCompletionResultKind::Pattern:
     ContextFreeResult =
         ContextFreeCodeCompletionResult::createPatternOrBuiltInOperatorResult(
-            Sink, Kind, CCS, CodeCompletionOperatorKind::None,
+            Sink, Kind, CCS, CodeCompletionOperatorKind::None, IsAsync,
             NullTerminatedStringRef(BriefDocComment, Allocator), ResultType,
             ContextFreeNotRecReason, ContextFreeDiagnosticSeverity,
             ContextFreeDiagnosticMessage);
@@ -164,6 +164,7 @@ CodeCompletionResult *CodeCompletionResultBuilder::takeResult() {
         *ContextFreeResult, SemanticContextKind::None, CodeCompletionFlair(),
         /*NumBytesToErase=*/0, /*TypeContext=*/nullptr,
         /*DC=*/nullptr, /*USRTypeContext=*/nullptr,
+        /*CanCurrDeclContextHandleAsync=*/false,
         ContextualNotRecommendedReason::None);
   } else {
     assert(
@@ -175,7 +176,8 @@ CodeCompletionResult *CodeCompletionResultBuilder::takeResult() {
     // for USRTypeContext.
     return new (Allocator) CodeCompletionResult(
         *ContextFreeResult, SemanticContext, Flair, NumBytesToErase,
-        TypeContext, DC, /*USRTypeContext=*/nullptr, ContextualNotRecReason);
+        TypeContext, DC, /*USRTypeContext=*/nullptr,
+        CanCurrDeclContextHandleAsync, ContextualNotRecReason);
   }
 }
 

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -43,6 +43,7 @@ class CodeCompletionResultBuilder {
   CodeCompletionFlair Flair;
   unsigned NumBytesToErase = 0;
   const Decl *AssociatedDecl = nullptr;
+  bool IsAsync = false;
   Optional<CodeCompletionLiteralKind> LiteralKind;
   CodeCompletionKeywordKind KeywordKind = CodeCompletionKeywordKind::None;
   unsigned CurrentNestingLevel = 0;
@@ -63,6 +64,7 @@ class CodeCompletionResultBuilder {
   /// type relation to \c ResultType.
   const ExpectedTypeContext *TypeContext = nullptr;
   const DeclContext *DC = nullptr;
+  bool CanCurrDeclContextHandleAsync = false;
 
   void addChunkWithText(CodeCompletionString::Chunk::ChunkKind Kind,
                         StringRef Text);
@@ -113,6 +115,8 @@ public:
 
   void setAssociatedDecl(const Decl *D);
 
+  void setIsAsync(bool IsAsync) { this->IsAsync = IsAsync; }
+
   void setLiteralKind(CodeCompletionLiteralKind kind) { LiteralKind = kind; }
   void setKeywordKind(CodeCompletionKeywordKind kind) { KeywordKind = kind; }
   void setContextFreeNotRecommended(ContextFreeNotRecommendedReason Reason) {
@@ -147,6 +151,10 @@ public:
                       const DeclContext *DC) {
     this->TypeContext = &TypeContext;
     this->DC = DC;
+  }
+
+  void setCanCurrDeclContextHandleAsync(bool CanCurrDeclContextHandleAsync) {
+    this->CanCurrDeclContextHandleAsync = CanCurrDeclContextHandleAsync;
   }
 
   void withNestedGroup(CodeCompletionString::Chunk::ChunkKind Kind,

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -824,14 +824,15 @@ void CompletionLookup::addVarDeclRef(const VarDecl *VD,
   }
   bool implicitlyAsync = false;
   analyzeActorIsolation(VD, VarType, implicitlyAsync, NotRecommended);
-  if (!isForCaching() && !NotRecommended && implicitlyAsync &&
-      !CanCurrDeclContextHandleAsync) {
-    NotRecommended = ContextualNotRecommendedReason::InvalidAsyncContext;
+  bool explicitlyAsync = false;
+  if (auto accessor = VD->getEffectfulGetAccessor()) {
+    explicitlyAsync = accessor->hasAsync();
   }
-
   CodeCompletionResultBuilder Builder(
       Sink, CodeCompletionResultKind::Declaration,
       getSemanticContext(VD, Reason, dynamicLookupInfo));
+  Builder.setIsAsync(explicitlyAsync || implicitlyAsync);
+  Builder.setCanCurrDeclContextHandleAsync(CanCurrDeclContextHandleAsync);
   Builder.setAssociatedDecl(VD);
   addLeadingDot(Builder);
   addValueBaseName(Builder, Name);
@@ -1228,11 +1229,8 @@ void CompletionLookup::addFunctionCallPattern(
     else
       addTypeAnnotation(Builder, AFT->getResult(), genericSig);
 
-    if (!isForCaching() && AFT->hasExtInfo() && AFT->isAsync() &&
-        !CanCurrDeclContextHandleAsync) {
-      Builder.setContextualNotRecommended(
-          ContextualNotRecommendedReason::InvalidAsyncContext);
-    }
+    Builder.setIsAsync(AFT->hasExtInfo() && AFT->isAsync());
+    Builder.setCanCurrDeclContextHandleAsync(CanCurrDeclContextHandleAsync);
   };
 
   if (!AFD || !AFD->getInterfaceType()->is<AnyFunctionType>()) {
@@ -1346,19 +1344,14 @@ void CompletionLookup::addMethodCall(const FuncDecl *FD,
   bool implictlyAsync = false;
   analyzeActorIsolation(FD, AFT, implictlyAsync, NotRecommended);
 
-  if (!isForCaching() && !NotRecommended &&
-      !IsImplicitlyCurriedInstanceMethod &&
-      ((AFT && AFT->isAsync()) || implictlyAsync) &&
-      !CanCurrDeclContextHandleAsync) {
-    NotRecommended = ContextualNotRecommendedReason::InvalidAsyncContext;
-  }
-
   // Add the method, possibly including any default arguments.
   auto addMethodImpl = [&](bool includeDefaultArgs = true,
                            bool trivialTrailingClosure = false) {
     CodeCompletionResultBuilder Builder(
         Sink, CodeCompletionResultKind::Declaration,
         getSemanticContext(FD, Reason, dynamicLookupInfo));
+    Builder.setIsAsync(implictlyAsync || (AFT->hasExtInfo() && AFT->isAsync()));
+    Builder.setCanCurrDeclContextHandleAsync(CanCurrDeclContextHandleAsync);
     Builder.setAssociatedDecl(FD);
 
     if (IsSuperRefExpr && CurrentMethod &&
@@ -1547,11 +1540,9 @@ void CompletionLookup::addConstructorCall(const ConstructorDecl *CD,
       addTypeAnnotation(Builder, *Result, CD->getGenericSignatureOfContext());
     }
 
-    if (!isForCaching() && ConstructorType->isAsync() &&
-        !CanCurrDeclContextHandleAsync) {
-      Builder.setContextualNotRecommended(
-          ContextualNotRecommendedReason::InvalidAsyncContext);
-    }
+    Builder.setIsAsync(ConstructorType->hasExtInfo() &&
+                       ConstructorType->isAsync());
+    Builder.setCanCurrDeclContextHandleAsync(CanCurrDeclContextHandleAsync);
   };
 
   if (ConstructorType && shouldAddItemWithoutDefaultArgs(CD))
@@ -1610,14 +1601,11 @@ void CompletionLookup::addSubscriptCall(const SubscriptDecl *SD,
   bool implictlyAsync = false;
   analyzeActorIsolation(SD, subscriptType, implictlyAsync, NotRecommended);
 
-  if (!isForCaching() && !NotRecommended && implictlyAsync &&
-      !CanCurrDeclContextHandleAsync) {
-    NotRecommended = ContextualNotRecommendedReason::InvalidAsyncContext;
-  }
-
   CodeCompletionResultBuilder Builder(
       Sink, CodeCompletionResultKind::Declaration,
       getSemanticContext(SD, Reason, dynamicLookupInfo));
+  Builder.setIsAsync(implictlyAsync);
+  Builder.setCanCurrDeclContextHandleAsync(CanCurrDeclContextHandleAsync);
   Builder.setAssociatedDecl(SD);
 
   if (NotRecommended)

--- a/test/IDE/complete_cache_notrecommended.swift
+++ b/test/IDE/complete_cache_notrecommended.swift
@@ -20,12 +20,8 @@ import MyModule
 
 func testSync() -> Int{
     #^GLOBAL_IN_SYNC^#
-// FIXME: 'globalAsyncFunc()' *should* be "NotRecommended" because  it's 'async'
-// The curently behavior is due to completion cache. We should remember
-// 'async'-ness in the cache. (rdar://78317170)
-
 // GLOBAL_IN_SYNC: Begin completions
-// GLOBAL_IN_SYNC-DAG: Decl[FreeFunction]/OtherModule[MyModule]/TypeRelation[Convertible]: globalAsyncFunc()[' async'][#Int#];
+// GLOBAL_IN_SYNC-DAG: Decl[FreeFunction]/OtherModule[MyModule]/NotRecommended/TypeRelation[Convertible]: globalAsyncFunc()[' async'][#Int#];
 // GLOBAL_IN_SYNC-DAG: Decl[FreeFunction]/OtherModule[MyModule]/NotRecommended: deprecatedFunc()[#Void#];
 // GLOBAL_IN_SYNC-DAG: Decl[Actor]/OtherModule[MyModule]:  MyActor[#MyActor#];
 // GLOBAL_IN_SYNC: End completions

--- a/test/IDE/complete_diagnostics_concurrency.swift
+++ b/test/IDE/complete_diagnostics_concurrency.swift
@@ -34,6 +34,30 @@ func testActor(obj: MyActor) async {
 func testClosure(obj: (Int) async -> Void) {
   obj(#^CLOSURE_CALL^#)
 // CLOSURE_CALL: Begin completions
-// CLOSURE_CALL-DAG: Pattern/CurrModule/Flair[ArgLabels]/NotRecommended: ['(']{#Int#}[')'][' async'][#Void#]; name=; diagnostics=error:async function used in a context that does not support concurrency 
+// CLOSURE_CALL-DAG: Pattern/CurrModule/Flair[ArgLabels]/NotRecommended: ['(']{#Int#}[')'][' async'][#Void#]; name=; diagnostics=error:async function used in a context that does not support concurrency
 // CLOSURE_CALL: End completions
+}
+
+func test() {
+  struct Foo {
+    var value: String? {
+      get async { nil }
+    }
+  }
+
+  var globalValue: String? {
+    get async { nil }
+  }
+
+  let foo = Foo()
+  foo.#^EXPLICITLY_ASYNC_PROPERTY^#
+// EXPLICITLY_ASYNC_PROPERTY: Begin completions
+// EXPLICITLY_ASYNC_PROPERTY-DAG: Decl[InstanceVar]/CurrNominal/NotRecommended: value[#String?#][' async']; name=value; diagnostics=error:async 'value' used in a context that does not support concurrency
+// EXPLICITLY_ASYNC_PROPERTY: End completions
+
+  #^EXPLICIT_GLOBAL_VAR^#
+// EXPLICIT_GLOBAL_VAR: Begin completions
+// EXPLICIT_GLOBAL_VAR-DAG: Decl[LocalVar]/Local/NotRecommended: globalValue[#String?#][' async']; name=globalValue; diagnostics=error:async 'globalValue' used in a context that does not support concurrency
+// EXPLICIT_GLOBAL_VAR: End completions
+
 }

--- a/test/IDE/complete_diagnostics_concurrency.swift
+++ b/test/IDE/complete_diagnostics_concurrency.swift
@@ -33,8 +33,7 @@ func testActor(obj: MyActor) async {
 
 func testClosure(obj: (Int) async -> Void) {
   obj(#^CLOSURE_CALL^#)
-// FIXME: Emit diagnostics
 // CLOSURE_CALL: Begin completions
-// CLOSURE_CALL-DAG: Pattern/CurrModule/Flair[ArgLabels]/NotRecommended: ['(']{#Int#}[')'][' async'][#Void#]; name={{$}}
+// CLOSURE_CALL-DAG: Pattern/CurrModule/Flair[ArgLabels]/NotRecommended: ['(']{#Int#}[')'][' async'][#Void#]; name=; diagnostics=error:async function used in a context that does not support concurrency 
 // CLOSURE_CALL: End completions
 }

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -134,15 +134,16 @@ bool SourceKit::CodeCompletion::addCustomCompletions(
     auto *contextFreeResult =
         ContextFreeCodeCompletionResult::createPatternOrBuiltInOperatorResult(
             sink.swiftSink, CodeCompletionResultKind::Pattern, completionString,
-            CodeCompletionOperatorKind::None, /*BriefDocComment=*/"",
-            CodeCompletionResultType::unknown(),
+            CodeCompletionOperatorKind::None, /*IsAsync=*/false,
+            /*BriefDocComment=*/"", CodeCompletionResultType::unknown(),
             ContextFreeNotRecommendedReason::None,
             CodeCompletionDiagnosticSeverity::None, /*DiagnosticMessage=*/"");
     auto *swiftResult = new (sink.allocator) CodeCompletion::SwiftResult(
         *contextFreeResult, SemanticContextKind::Local,
         CodeCompletionFlairBit::ExpressionSpecific,
         /*NumBytesToErase=*/0, /*TypeContext=*/nullptr, /*DC=*/nullptr,
-        /*USRTypeContext=*/nullptr, ContextualNotRecommendedReason::None);
+        /*USRTypeContext=*/nullptr, /*CanCurrDeclContextHandleAsync=*/false,
+        ContextualNotRecommendedReason::None);
 
     CompletionBuilder builder(sink, *swiftResult);
     builder.setCustomKind(customCompletion.Kind);
@@ -1165,8 +1166,8 @@ Completion *CompletionBuilder::finish() {
         new (sink.allocator) ContextFreeCodeCompletionResult(
             contextFreeBase.getKind(),
             contextFreeBase.getOpaqueAssociatedKind(), opKind,
-            contextFreeBase.isSystem(), newCompletionString,
-            contextFreeBase.getModuleName(),
+            contextFreeBase.isSystem(), contextFreeBase.isAsync(),
+            newCompletionString, contextFreeBase.getModuleName(),
             contextFreeBase.getBriefDocComment(),
             contextFreeBase.getAssociatedUSRs(),
             contextFreeBase.getResultType(),

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -76,10 +76,11 @@ std::vector<Completion *> SourceKit::CodeCompletion::extendCompletions(
     const Options &options, Completion *prefix, bool clearFlair) {
 
   ImportDepth depth;
-  if (info.swiftASTContext) {
+  if (info.compilerInstance) {
     // Build import depth map.
-    depth = ImportDepth(*info.swiftASTContext,
-                        info.invocation->getFrontendOptions());
+    depth = ImportDepth(
+        info.compilerInstance->getASTContext(),
+        info.compilerInstance->getInvocation().getFrontendOptions());
   }
 
   if (info.completionContext)

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -142,8 +142,7 @@ bool SourceKit::CodeCompletion::addCustomCompletions(
         *contextFreeResult, SemanticContextKind::Local,
         CodeCompletionFlairBit::ExpressionSpecific,
         /*NumBytesToErase=*/0, /*TypeContext=*/nullptr, /*DC=*/nullptr,
-        /*USRTypeContext=*/nullptr, ContextualNotRecommendedReason::None,
-        CodeCompletionDiagnosticSeverity::None, /*DiagnosticMessage=*/"");
+        /*USRTypeContext=*/nullptr, ContextualNotRecommendedReason::None);
 
     CompletionBuilder builder(sink, *swiftResult);
     builder.setCustomKind(customCompletion.Kind);
@@ -1173,8 +1172,8 @@ Completion *CompletionBuilder::finish() {
             contextFreeBase.getResultType(),
             contextFreeBase.getNotRecommendedReason(),
             contextFreeBase.getDiagnosticSeverity(),
-            contextFreeBase.getDiagnosticMessage(),
-            newFilterName);
+            contextFreeBase.getDiagnosticMessage(), newFilterName,
+            contextFreeBase.getNameForDiagnostics());
     newBase = base.withContextFreeResultSemanticContextAndFlair(
         *contextFreeResult, semanticContext, flair, sink.swiftSink);
   }

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -910,6 +910,7 @@ static void transformAndForwardResults(
         ContextFreeCodeCompletionResult::createPatternOrBuiltInOperatorResult(
             innerSink.swiftSink, CodeCompletionResultKind::BuiltinOperator,
             completionString, CodeCompletionOperatorKind::None,
+            /*IsAsync=*/false,
             /*BriefDocComment=*/"", CodeCompletionResultType::notApplicable(),
             ContextFreeNotRecommendedReason::None,
             CodeCompletionDiagnosticSeverity::None,
@@ -919,6 +920,7 @@ static void transformAndForwardResults(
         CodeCompletionFlairBit::ExpressionSpecific,
         exactMatch ? exactMatch->getNumBytesToErase() : 0,
         /*TypeContext=*/nullptr, /*DC=*/nullptr, /*USRTypeContext=*/nullptr,
+        /*CanCurrDeclContextHandleAsync=*/false,
         ContextualNotRecommendedReason::None);
 
     SwiftCompletionInfo info;

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -919,8 +919,7 @@ static void transformAndForwardResults(
         CodeCompletionFlairBit::ExpressionSpecific,
         exactMatch ? exactMatch->getNumBytesToErase() : 0,
         /*TypeContext=*/nullptr, /*DC=*/nullptr, /*USRTypeContext=*/nullptr,
-        ContextualNotRecommendedReason::None,
-        CodeCompletionDiagnosticSeverity::None, /*DiagnosticMessage=*/"");
+        ContextualNotRecommendedReason::None);
 
     SwiftCompletionInfo info;
     std::vector<Completion *> extended = extendCompletions(

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -4226,7 +4226,8 @@ int main(int argc, char *argv[]) {
             *contextFreeResult, SemanticContextKind::OtherModule,
             CodeCompletionFlair(),
             /*numBytesToErase=*/0, /*TypeContext=*/nullptr, /*DC=*/nullptr,
-            /*USRTypeContext=*/nullptr, ContextualNotRecommendedReason::None);
+            /*USRTypeContext=*/nullptr, /*CanCurrDeclContextHandleAsync=*/false,
+            ContextualNotRecommendedReason::None);
         contextualResults.push_back(contextualResult);
       }
       auto CompInstance = std::make_unique<CompilerInstance>();

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1082,11 +1082,10 @@ doConformingMethodList(const CompilerInvocation &InitInvok,
       });
 }
 
-static void
-printCodeCompletionResultsImpl(ArrayRef<CodeCompletionResult *> Results,
-                               llvm::raw_ostream &OS, bool IncludeKeywords,
-                               bool IncludeComments, bool IncludeSourceText,
-                               bool PrintAnnotatedDescription) {
+static void printCodeCompletionResultsImpl(
+    ArrayRef<CodeCompletionResult *> Results, llvm::raw_ostream &OS,
+    bool IncludeKeywords, bool IncludeComments, bool IncludeSourceText,
+    bool PrintAnnotatedDescription, const ASTContext &Ctx) {
   unsigned NumResults = 0;
   for (auto Result : Results) {
     if (!IncludeKeywords &&
@@ -1129,10 +1128,13 @@ printCodeCompletionResultsImpl(ArrayRef<CodeCompletionResult *> Results,
       OS << "; comment=" << comment;
     }
 
-    if (Result->getDiagnosticSeverity() !=
+    SmallString<256> Scratch;
+    auto DiagSeverityAndMessage =
+        Result->getDiagnosticSeverityAndMessage(Scratch, Ctx);
+    if (DiagSeverityAndMessage.first !=
         CodeCompletionDiagnosticSeverity::None) {
       OS << "; diagnostics=" << comment;
-      switch (Result->getDiagnosticSeverity()) {
+      switch (DiagSeverityAndMessage.first) {
       case CodeCompletionDiagnosticSeverity::Error:
         OS << "error";
         break;
@@ -1148,7 +1150,8 @@ printCodeCompletionResultsImpl(ArrayRef<CodeCompletionResult *> Results,
       case CodeCompletionDiagnosticSeverity::None:
         llvm_unreachable("none");
       }
-      OS << ":" << Result->getDiagnosticMessage();
+      SmallString<256> Scratch;
+      OS << ":" << DiagSeverityAndMessage.second;
     }
 
     OS << "\n";
@@ -1164,7 +1167,8 @@ static int printCodeCompletionResults(
       CancellableResult, [&](CodeCompleteResult &Result) {
         printCodeCompletionResultsImpl(
             Result.ResultSink.Results, llvm::outs(), IncludeKeywords,
-            IncludeComments, IncludeSourceText, PrintAnnotatedDescription);
+            IncludeComments, IncludeSourceText, PrintAnnotatedDescription,
+            *Result.Info.swiftASTContext);
         return 0;
       });
 }
@@ -1540,10 +1544,10 @@ static int doBatchCodeCompletion(const CompilerInvocation &InitInvok,
           case CancellableResultKind::Success: {
             wasASTContextReused =
                 Result->Info.completionContext->ReusingASTContext;
-            printCodeCompletionResultsImpl(Result->ResultSink.Results, OS,
-                                           IncludeKeywords, IncludeComments,
-                                           IncludeSourceText,
-                                           CodeCompletionAnnotateResults);
+            printCodeCompletionResultsImpl(
+                Result->ResultSink.Results, OS, IncludeKeywords,
+                IncludeComments, IncludeSourceText,
+                CodeCompletionAnnotateResults, *Result->Info.swiftASTContext);
             break;
           }
           case CancellableResultKind::Failure:
@@ -4222,14 +4226,15 @@ int main(int argc, char *argv[]) {
             *contextFreeResult, SemanticContextKind::OtherModule,
             CodeCompletionFlair(),
             /*numBytesToErase=*/0, /*TypeContext=*/nullptr, /*DC=*/nullptr,
-            /*USRTypeContext=*/nullptr, ContextualNotRecommendedReason::None,
-            CodeCompletionDiagnosticSeverity::None, /*DiagnosticMessage=*/"");
+            /*USRTypeContext=*/nullptr, ContextualNotRecommendedReason::None);
         contextualResults.push_back(contextualResult);
       }
+      auto CompInstance = std::make_unique<CompilerInstance>();
       printCodeCompletionResultsImpl(
           contextualResults, llvm::outs(), options::CodeCompletionKeywords,
           options::CodeCompletionComments, options::CodeCompletionSourceText,
-          options::CodeCompletionAnnotateResults);
+          options::CodeCompletionAnnotateResults,
+          CompInstance->getASTContext());
     }
 
     return 0;

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1168,7 +1168,7 @@ static int printCodeCompletionResults(
         printCodeCompletionResultsImpl(
             Result.ResultSink.Results, llvm::outs(), IncludeKeywords,
             IncludeComments, IncludeSourceText, PrintAnnotatedDescription,
-            *Result.Info.swiftASTContext);
+            Result.Info.compilerInstance->getASTContext());
         return 0;
       });
 }
@@ -1547,7 +1547,8 @@ static int doBatchCodeCompletion(const CompilerInvocation &InitInvok,
             printCodeCompletionResultsImpl(
                 Result->ResultSink.Results, OS, IncludeKeywords,
                 IncludeComments, IncludeSourceText,
-                CodeCompletionAnnotateResults, *Result->Info.swiftASTContext);
+                CodeCompletionAnnotateResults,
+                Result->Info.compilerInstance->getASTContext());
             break;
           }
           case CancellableResultKind::Failure:


### PR DESCRIPTION
Store whether a result is async in the `ContextFreeCodeCompletionResult` and determine whether an async method is used in a sync context when promoting the context free result to a contextual result.

rdar://78317170