### PR TITLE
[android][test] Don't set lit's config.target_env_prefix when running natively on Android

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1457,7 +1457,6 @@ elif (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'openbsd', 'windows-
       config.target_shared_library_suffix = ".so"
       config.target_sdk_name = "android"
       config.target_cc_options = "-fPIE"
-      config.target_env_prefix = 'ANDROID_CHILD_'
     else:
       lit_config.note("Testing Linux " + config.variant_triple)
       config.target_object_format = "elf"


### PR DESCRIPTION
This broke in #41741, putting it back the way it was.

@lorentey, this broke several tests when running the compiler validation suite natively on an Android device, as [I had removed this prefix a couple years ago when `kIsAndroid` is true](https://github.com/apple/swift/pull/27167/files#r324139507), but this line inadvertently added it back.