### PR TITLE
[DeclCollector] Handle pound diagnostic decl in addMembersToRoot

### DIFF
--- a/lib/APIDigester/ModuleAnalyzerNodes.cpp
+++ b/lib/APIDigester/ModuleAnalyzerNodes.cpp
@@ -1834,6 +1834,8 @@ SwiftDeclCollector::addMembersToRoot(SDKNode *Root, IterableDeclContext *Context
       // All containing variables should have been handled.
     } else if (isa<IfConfigDecl>(Member)) {
       // All containing members should have been handled.
+    } else if (isa<PoundDiagnosticDecl>(Member)) {
+      // All containing members should have been handled.
     } else if (isa<DestructorDecl>(Member)) {
       // deinit has no impact.
     } else if (isa<MissingMemberDecl>(Member)) {


### PR DESCRIPTION
<!-- What's in this pull request? -->
Simply handle pound diagnostic decl in `addMembersToRoot`. Not sure this need some kind of testing, it is just to avoid dump this kind of decl in the compilation output.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Fixes #58832

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
