### PR TITLE
[Test] Simplify index store test

### DIFF
--- a/test/Index/Store/unit-pcm-dependency-remapped.swift
+++ b/test/Index/Store/unit-pcm-dependency-remapped.swift
@@ -77,7 +77,7 @@ func test() {
 // FILE1-NOT: Unit |{{.*}}ClangModuleA
 // FILE1: Record | user | {{.*}}unit-pcm-dependency-remapped.swift | unit-pcm-dependency-remapped.swift-
 // FILE1-NOT: Unit |{{.*}}ClangModuleA
-// FILE1: DEPEND END (4)
+// FILE1: DEPEND END
 
 // FILE2-NOT: main.swiftmodule-
 


### PR DESCRIPTION
Cherry-picks 5e1e99248213e27e91f82feda1d95ec0affe07c7 (https://github.com/apple/swift/pull/59005) to simplify a fragile test.

-----

The number of dependencies isn't super important for this test - it is
just checking paths are correctly remapped. Remove the check for the
number of dependencies.