### PR TITLE
Update CppInteroperabilityManifesto.md

### DIFF
--- a/docs/CppInteroperability/CppInteroperabilityManifesto.md
+++ b/docs/CppInteroperability/CppInteroperabilityManifesto.md
@@ -184,7 +184,7 @@ that pick different sides, forcing the user to choose.
 
 Swift/C++ interoperability builds on top of the Swift/C interoperability, so it
 helps to be familiar with [Swift's strategy for importing C
-modules](HowSwiftImportsCAPIs.md).
+modules](../HowSwiftImportsCAPIs.md).
 
 # Importing C++ APIs into Swift
 


### PR DESCRIPTION
"fixing" link to HowSwiftImportsCAPIs.md.  It's one level up.

<!-- What's in this pull request? -->
Link to HowSwiftImportsCAPIs.md needs to redirect one directory higher.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
