### PR TITLE
[SourceKit] Fix typo in SwiftDocSupport.cpp

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -266,7 +266,7 @@ static void initDocGenericParams(const Decl *D, DocEntityInfo &Info,
 
   // If we have a synthesized target, map from its base type into the this
   // declaration's innermost type context, or if we're dealing with the
-  // synthesized extention itself rather than a member, into its extended
+  // synthesized extension itself rather than a member, into its extended
   // nominal (the extension's own requirements shouldn't be considered in the
   // substitution).
   unsigned TypeContextDepth = 0;


### PR DESCRIPTION
extention -> extension
