### PR TITLE
[SwiftCompilerSources][build] Require recent Swift compiler in `HOSTTOOLS` mode

### DIFF
--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -204,6 +204,19 @@ else()
       message(FATAL_ERROR "Need a swift toolchain building swift compiler sources")
     endif()
 
+    if(${BOOTSTRAPPING_MODE} STREQUAL "HOSTTOOLS")
+      if(NOT SWIFT_EXEC_FOR_SWIFT_MODULES STREQUAL CMAKE_Swift_COMPILER)
+        message(FATAL_ERROR "The Swift compiler (${CMAKE_Swift_COMPILER}) differs from the Swift compiler in SWIFT_NATIVE_SWIFT_TOOLS_PATH (${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/swiftc).")
+      endif()
+
+      set(min_supported_swift_version 5.5)
+      if(CMAKE_Swift_COMPILER_VERSION VERSION_LESS "${min_supported_swift_version}")
+        message(FATAL_ERROR
+            "Outdated Swift compiler: building with host tools requires Swift ${min_supported_swift_version} or newer. "
+            "Please update your Swift toolchain or switch BOOTSTRAPPING_MODE to BOOTSTRAPPING(-WITH-HOSTLIBS)? or OFF.")
+      endif()
+    endif()
+
     add_swift_compiler_modules_library(swiftCompilerModules
       SWIFT_EXEC "${SWIFT_EXEC_FOR_SWIFT_MODULES}")
 


### PR DESCRIPTION
Some code in SwiftCompilerSources, especially the parts that use C++ interop, triggers bugs in older versions of the Swift compiler. To make sure that `HOSTTOOLS` builds don't produce obscure compiler errors or crashes, let's require a relatively new Swift compiler for `HOSTTOOLS` build.

Since the CI currently uses Xcode 13.0 beta, let's require Swift 5.5 for now to avoid breaking the CI.