### PR TITLE
[CodeCompletion] Don’t compute type relations if the contextual type is `Any`

### DIFF
--- a/lib/IDE/CodeCompletionResultType.cpp
+++ b/lib/IDE/CodeCompletionResultType.cpp
@@ -305,11 +305,33 @@ TypeRelation USRBasedTypeContext::ContextualType::typeRelation(
 
 // MARK: - CodeCompletionResultType
 
+/// Returns \c true if \p Ty is the 'Any' type or some type that is sufficiently
+/// similar to Any, like the 'Any' metatype or an optional type wrapping 'Any'.
+static bool isEssentiallyAnyType(Type Ty) {
+  while (true) {
+    if (auto MT = Ty->getAs<AnyMetatypeType>()) {
+      Ty = MT->getInstanceType();
+    } else if (auto OT = Ty->getOptionalObjectType()) {
+      Ty = OT;
+    } else {
+      break;
+    }
+  }
+  return Ty->isAny();
+}
+
 static TypeRelation calculateTypeRelation(Type Ty, Type ExpectedTy,
                                           const DeclContext &DC) {
   if (Ty.isNull() || ExpectedTy.isNull() || Ty->is<ErrorType>() ||
       ExpectedTy->is<ErrorType>())
     return TypeRelation::Unrelated;
+
+  /// Computing type relations to 'Any' is not very enlightning because
+  /// everything would be convertible to it. If the contextual type is 'Any',
+  /// just report all type relations as 'Unknown'.
+  if (isEssentiallyAnyType(ExpectedTy)) {
+    return TypeRelation::Unknown;
+  }
 
   // Equality/Conversion of GenericTypeParameterType won't account for
   // requirements – ignore them

--- a/test/IDE/complete_at_top_level.swift
+++ b/test/IDE/complete_at_top_level.swift
@@ -328,7 +328,7 @@ var stringInterp = "\(#^STRING_INTERP_3?check=STRING_INTERP^#)"
 _ = "" + "\(#^STRING_INTERP_4?check=STRING_INTERP^#)" + ""
 // STRING_INTERP: Begin completions
 // STRING_INTERP-DAG: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]/IsSystem: ['(']{#(value): T#}[')'][#Void#];
-// STRING_INTERP-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: FooStruct[#FooStruct#]; name=FooStruct
+// STRING_INTERP-DAG: Decl[Struct]/CurrModule: FooStruct[#FooStruct#]; name=FooStruct
 // STRING_INTERP-DAG: Decl[FreeFunction]/CurrModule/TypeRelation[Invalid]: fooFunc1()[#Void#];
 // STRING_INTERP-DAG: Decl[FreeFunction]/CurrModule: optStr()[#String?#];
 // STRING_INTERP-DAG: Decl[GlobalVar]/Local: fooObject[#FooStruct#];


### PR DESCRIPTION
Computing type relations to 'Any' is not very enlightning because everything would be convertible to it. If the contextual type is 'Any', just report all type relations as 'Unknown'.

rdar://64812321
rdar://84684686