### PR TITLE
[cxx-interop] Import attributes on inherited C++ methods

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1269,6 +1269,13 @@ public:
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DAK_Effects;
   }
+
+  EffectsAttr *clone(ASTContext &ctx) const {
+    if (getKind() == EffectsKind::Custom) {
+      return new (ctx) EffectsAttr(customString);
+    }
+    return new (ctx) EffectsAttr(getKind());
+  }
 };
 
 
@@ -2301,6 +2308,13 @@ public:
   void add(DeclAttribute *Attr) {
     Attr->Next = DeclAttrs;
     DeclAttrs = Attr;
+  }
+
+  /// Add multiple constructed DeclAttributes to this list.
+  void add(DeclAttributes &Attrs) {
+    for (auto attr : Attrs) {
+      add(attr);
+    }
   }
 
   // Iterator interface over DeclAttribute objects.

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4851,6 +4851,51 @@ makeBaseClassMemberAccessors(DeclContext *declContext,
   return {getterDecl, setterDecl};
 }
 
+// Clone attributes that have been imported from Clang.
+DeclAttributes cloneImportedAttributes(ValueDecl *decl, ASTContext &context) {
+  auto attrs = DeclAttributes();
+  for (auto attr : decl->getAttrs()) {
+    switch (attr->getKind()) {
+    case DAK_Available: {
+      attrs.add(cast<AvailableAttr>(attr)->clone(context, true));
+      break;
+    }
+    case DAK_Custom: {
+      if (CustomAttr *cAttr = cast<CustomAttr>(attr)) {
+        attrs.add(CustomAttr::create(context, SourceLoc(), cAttr->getTypeExpr(),
+                                     cAttr->getInitContext(), cAttr->getArgs(),
+                                     true));
+      }
+      break;
+    }
+    case DAK_DiscardableResult: {
+      attrs.add(new (context) DiscardableResultAttr(true));
+      break;
+    }
+    case DAK_Effects: {
+      attrs.add(cast<EffectsAttr>(attr)->clone(context));
+      break;
+    }
+    case DAK_Final: {
+      attrs.add(new (context) FinalAttr(true));
+      break;
+    }
+    case DAK_Transparent: {
+      attrs.add(new (context) TransparentAttr(true));
+      break;
+    }
+    case DAK_WarnUnqualifiedAccess: {
+      attrs.add(new (context) WarnUnqualifiedAccessAttr(true));
+      break;
+    }
+    default:
+      break;
+    }
+  }
+
+  return attrs;
+}
+
 ValueDecl *cloneBaseMemberDecl(ValueDecl *decl, DeclContext *newContext) {
   if (auto fn = dyn_cast<FuncDecl>(decl)) {
     // TODO: function templates are specialized during type checking so to
@@ -4862,11 +4907,14 @@ ValueDecl *cloneBaseMemberDecl(ValueDecl *decl, DeclContext *newContext) {
          isa<clang::FunctionTemplateDecl>(fn->getClangDecl())))
       return nullptr;
 
+    ASTContext &context = decl->getASTContext();
     auto out = FuncDecl::createImplicit(
-        fn->getASTContext(), fn->getStaticSpelling(), fn->getName(),
+        context, fn->getStaticSpelling(), fn->getName(),
         fn->getNameLoc(), fn->hasAsync(), fn->hasThrows(),
         fn->getGenericParams(), fn->getParameters(),
         fn->getResultInterfaceType(), newContext);
+    auto inheritedAttributes = cloneImportedAttributes(decl, context);
+    out->getAttrs().add(inheritedAttributes);
     out->copyFormalAccessFrom(fn);
     out->setBodySynthesizer(synthesizeBaseClassMethodBody, fn);
     out->setSelfAccessKind(fn->getSelfAccessKind());

--- a/test/Interop/Cxx/class/inheritance/Inputs/functions.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/functions.h
@@ -33,6 +33,12 @@ struct Base {
   }
 
   static const char *staticInBase() { return "Base::staticInBase"; }
+
+  int renamed(int i) __attribute__((swift_name("swiftRenamed(input:)"))) {
+    return i * 2;
+  }
+
+  void pure() const __attribute__((pure)) {}
 };
 
 struct OtherBase {

--- a/test/Interop/Cxx/class/inheritance/functions-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/functions-module-interface.swift
@@ -1,52 +1,94 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=Functions -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -print-implicit-attrs -module-to-print=Functions -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK:      struct NonTrivial {
 // CHECK-NEXT:   init()
+// CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func inNonTrivial() -> UnsafePointer<CChar>!
+// CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func inNonTrivialWithArgs(_ a: Int32, _ b: Int32) -> UnsafePointer<CChar>!
 // CHECK-NEXT: }
 
 // CHECK-NEXT: struct Base {
 // CHECK-NEXT:   init()
+// CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   mutating func mutatingInBase() -> UnsafePointer<CChar>!
+// CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func constInBase() -> UnsafePointer<CChar>!
+// CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func takesArgsInBase(_ a: Int32, _ b: Int32, _ c: Int32) -> UnsafePointer<CChar>!
+// CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func takesNonTrivialInBase(_ a: NonTrivial) -> UnsafePointer<CChar>!
+// CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func returnsNonTrivialInBase() -> NonTrivial
+// CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func templateInBase<T>(_ t: T) -> UnsafePointer<CChar>!
+// CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   static func staticInBase() -> UnsafePointer<CChar>!
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   mutating func swiftRenamed(input i: Int32) -> Int32
+// CHECK-NEXT:   @available(swift, obsoleted: 3, renamed: "swiftRenamed(input:)")
+// CHECK-NEXT:   mutating func renamed(_ i: Int32) -> Int32
+// CHECK-NEXT:   @_effects(readonly) func pure()
 // CHECK-NEXT: }
 
 // CHECK-NEXT: struct OtherBase {
 // CHECK-NEXT:   init()
+// CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func inOtherBase() -> UnsafePointer<CChar>!
 // CHECK-NEXT: }
 
 // CHECK-NEXT: struct Derived {
 // CHECK-NEXT:   init()
+// CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func inDerived() -> UnsafePointer<CChar>!
+// CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   mutating func mutatingInBase() -> UnsafePointer<CChar>?
+// CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func constInBase() -> UnsafePointer<CChar>?
+// CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func takesArgsInBase(_ a: Int32, _ b: Int32, _ c: Int32) -> UnsafePointer<CChar>?
+// CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func takesNonTrivialInBase(_ a: NonTrivial) -> UnsafePointer<CChar>?
+// CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func returnsNonTrivialInBase() -> NonTrivial
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   mutating func swiftRenamed(input i: Int32) -> Int32
+// CHECK-NEXT:   @available(swift, obsoleted: 3, renamed: "swiftRenamed(input:)")
+// CHECK-NEXT:   mutating func renamed(_ i: Int32) -> Int32
+// CHECK-NEXT:   @_effects(readonly) func pure()
+// CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func inOtherBase() -> UnsafePointer<CChar>?
 // CHECK-NEXT: }
 
 // CHECK-NEXT: struct DerivedFromDerived {
 // CHECK-NEXT:   init()
+// CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func topLevel() -> UnsafePointer<CChar>!
+// CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func inDerived() -> UnsafePointer<CChar>?
+// CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   mutating func mutatingInBase() -> UnsafePointer<CChar>?
+// CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func constInBase() -> UnsafePointer<CChar>?
+// CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func takesArgsInBase(_ a: Int32, _ b: Int32, _ c: Int32) -> UnsafePointer<CChar>?
+// CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func takesNonTrivialInBase(_ a: NonTrivial) -> UnsafePointer<CChar>?
+// CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func returnsNonTrivialInBase() -> NonTrivial
+// CHECK-NEXT:   @discardableResult
+// CHECK-NEXT:   mutating func swiftRenamed(input i: Int32) -> Int32
+// CHECK-NEXT:   @available(swift, obsoleted: 3, renamed: "swiftRenamed(input:)")
+// CHECK-NEXT:   mutating func renamed(_ i: Int32) -> Int32
+// CHECK-NEXT:   @_effects(readonly) func pure()
+// CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func inOtherBase() -> UnsafePointer<CChar>?
 // CHECK-NEXT: }
 
 // CHECK-NEXT: struct DerivedFromNonTrivial {
 // CHECK-NEXT:   init()
+// CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func inNonTrivial() -> UnsafePointer<CChar>?
+// CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func inNonTrivialWithArgs(_ a: Int32, _ b: Int32) -> UnsafePointer<CChar>?
 // CHECK-NEXT: }


### PR DESCRIPTION
We now copy the `DeclAttributes` that are created when mapping Clang attributes to Swift attributes.

Fixes #58460