### PR TITLE
[IDE] Skip walking serialized non-visible extension decls

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2923,8 +2923,16 @@ bool FileUnit::walk(ASTWalker &walker) {
       !walker.shouldWalkSerializedTopLevelInternalDecls();
   for (Decl *D : Decls) {
     if (SkipInternal) {
+      // Ignore if the decl isn't visible
       if (auto *VD = dyn_cast<ValueDecl>(D)) {
         if (!VD->isAccessibleFrom(nullptr))
+          continue;
+      }
+
+      // Also ignore if the extended nominal isn't visible
+      if (auto *ED = dyn_cast<ExtensionDecl>(D)) {
+        auto *ND = ED->getExtendedNominal();
+        if (ND && !ND->isAccessibleFrom(nullptr))
           continue;
       }
     }

--- a/test/Index/skip-loaded-internal.swift
+++ b/test/Index/skip-loaded-internal.swift
@@ -1,0 +1,26 @@
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/Frameworks/lib.framework/Modules/lib.swiftmodule
+// RUN: mkdir -p %t/Frameworks/lib2.framework/Modules/lib2.swiftmodule
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module -emit-module-source-info -module-name lib2 -o %t/Frameworks/lib2.framework/Modules/lib2.swiftmodule/%module-target-triple.swiftmodule %t/lib2.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-source-info -module-name lib -o %t/Frameworks/lib.framework/Modules/lib.swiftmodule/%module-target-triple.swiftmodule %t/lib.swift -Fsystem %t/Frameworks
+
+// RUN: %target-swift-frontend -typecheck -index-system-modules -index-ignore-stdlib -index-store-path %t/idx -Fsystem %t/Frameworks %t/main.swift -disable-deserialization-recovery
+
+//--- main.swift
+import lib
+
+//--- lib.swift
+@_implementationOnly import lib2
+
+struct InternalS {
+  func structFunc(p: Lib2S) {}
+}
+
+extension InternalS {
+  func extensionFunc(p: Lib2S) {}
+}
+
+//--- lib2.swift
+public struct Lib2S {}


### PR DESCRIPTION
fec7a0b79b2a2318118dc4696ddb5a3410b10114 skipped all non-visible
`ValueDecls` but missed `ExtensionDecls`, which have the same issue.
Make sure to skip these too.

Resolves rdar://91279771.
