### PR TITLE
[5.7][CSClosure] Specify stack capacity of a `SmallVector`

### DIFF
--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -38,7 +38,7 @@ Expr *getVoidExpr(ASTContext &ctx) {
 /// Find any type variable references inside of an AST node.
 class TypeVariableRefFinder : public ASTWalker {
   /// A stack of all closures the walker encountered so far.
-  SmallVector<DeclContext *> ClosureDCs;
+  SmallVector<DeclContext *, 2> ClosureDCs;
 
   ConstraintSystem &CS;
   ASTNode Parent;


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/59026

----

`SmallVector` has two template arguments, so both have to be
specified.

Resolves: rdar://93769727
(cherry picked from commit 3977c89e8a97c2b84ee2477293d752c03d42fbcd)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
