### PR TITLE
add default values for SymbolGraphOptions

### DIFF
--- a/include/swift/SymbolGraphGen/SymbolGraphOptions.h
+++ b/include/swift/SymbolGraphGen/SymbolGraphOptions.h
@@ -21,10 +21,10 @@ namespace symbolgraphgen {
 
 struct SymbolGraphOptions {
   /// The directory to output the symbol graph JSON files.
-  StringRef OutputDir = StringRef{};
+  StringRef OutputDir = {};
 
   /// The target of the module.
-  llvm::Triple Target = llvm::Triple{};
+  llvm::Triple Target = {};
   /// Pretty-print the JSON with newlines and indentation.
   bool PrettyPrint = false;
 

--- a/include/swift/SymbolGraphGen/SymbolGraphOptions.h
+++ b/include/swift/SymbolGraphGen/SymbolGraphOptions.h
@@ -21,33 +21,33 @@ namespace symbolgraphgen {
 
 struct SymbolGraphOptions {
   /// The directory to output the symbol graph JSON files.
-  StringRef OutputDir;
+  StringRef OutputDir = StringRef{};
 
   /// The target of the module.
-  llvm::Triple Target; 
+  llvm::Triple Target = llvm::Triple{};
   /// Pretty-print the JSON with newlines and indentation.
-  bool PrettyPrint;
+  bool PrettyPrint = false;
 
   /// The minimum access level that symbols must have in order to be
   /// included in the graph.
-  AccessLevel MinimumAccessLevel;
+  AccessLevel MinimumAccessLevel = AccessLevel::Public;
 
   /// Emit members gotten through class inheritance or protocol default
   /// implementations with compound, "SYNTHESIZED" USRs.
-  bool EmitSynthesizedMembers;
+  bool EmitSynthesizedMembers = false;
   
   /// Whether to print informational messages when rendering
   /// a symbol graph.
-  bool PrintMessages;
+  bool PrintMessages = false;
   
   /// Whether to skip docs for symbols with compound, "SYNTHESIZED" USRs.
-  bool SkipInheritedDocs;
+  bool SkipInheritedDocs = false;
 
   /// Whether to emit symbols with SPI information.
-  bool IncludeSPISymbols;
+  bool IncludeSPISymbols = false;
 
   /// Whether to include documentation for clang nodes or not.
-  bool IncludeClangDocs;
+  bool IncludeClangDocs = false;
 };
 
 } // end namespace symbolgraphgen

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1260,6 +1260,7 @@ static void ParseSymbolGraphArgs(symbolgraphgen::SymbolGraphOptions &Opts,
   Opts.PrettyPrint = false;
   Opts.EmitSynthesizedMembers = true;
   Opts.PrintMessages = false;
+  Opts.IncludeClangDocs = false;
 }
 
 static bool ParseSearchPathArgs(SearchPathOptions &Opts,

--- a/test/SymbolGraph/ClangImporter/EmitWhileBuilding.swift
+++ b/test/SymbolGraph/ClangImporter/EmitWhileBuilding.swift
@@ -4,6 +4,7 @@
 // RUN: %{python} -m json.tool %t/EmitWhileBuilding.symbols.json %t/EmitWhileBuilding.formatted.symbols.json
 // RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.formatted.symbols.json
 // RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.formatted.symbols.json --check-prefix HEADER
+// RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.formatted.symbols.json --check-prefix LOCATION
 
 // REQUIRES: objc_interop
 
@@ -28,3 +29,6 @@ public enum SwiftEnum {}
 // CHECK-NEXT:           "spelling": "SwiftEnum"
 // CHECK-NEXT:       }
 // CHECK-NEXT:   ],
+
+// ensure that the only nodes with a "location" field are the ones that came from Swift
+// LOCATION-COUNT-2: "location":


### PR DESCRIPTION
Resolves rdar://93780666

Currently, the `IncludeClangDocs` field of `SymbolGraphOptions` is uninitialized when generating a symbol graph during a build. The assumption behind this field is that the branches that it gates would only be run when generating a symbol graph from SourceKit. However, we've noticed a situation where the symbol graph is emitting the partial "location" field during a build on ARM macOS. This PR adds defaults to the `SymbolGraphOptions` struct, as well as manually setting the `IncludeClangDocs` field to `false` when building, to ensure that this code path is never hit during a regular compile.