### PR TITLE
Revert "[Autolink Extract] Keep a set of linker flags instead of vector"

### DIFF
--- a/test/AutolinkExtract/import.swift
+++ b/test/AutolinkExtract/import.swift
@@ -1,15 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swiftc_driver -emit-module -emit-module-path %t/empty.swiftmodule -module-name empty -module-link-name empty %S/empty.swift
 // RUN: %target-swiftc_driver -c %s -I %t -o %t/import_experimental.o
-// RUN: %target-swiftc_driver -c %s -I %t -o %t/import_experimental_again.o
-// RUN: %target-swift-autolink-extract %t/import_experimental.o %t/import_experimental_again.o -o - | %FileCheck --check-prefix CHECK-%target-object-format %s
-
-// RUN: %target-swift-autolink-extract %t/import_experimental.o %t/import_experimental_again.o -o - | %FileCheck --check-prefix UNIQUE %s
+// RUN: %target-swift-autolink-extract %t/import_experimental.o -o - | %FileCheck --check-prefix CHECK-%target-object-format %s
 
 // REQUIRES: autolink-extract
-
-// UNIQUE-COUNT-1: -lempty
-// UNIQUE-COUNT-1: -lswiftCore
 
 // CHECK-elf-DAG: -lswiftCore
 // CHECK-elf-DAG: -lempty


### PR DESCRIPTION
Reverts apple/swift#58800

@compnerd brought up a good issue with this approach. Going to try something else shortly. 