### PR TITLE
Sema: Use the availability of the extended nominal as a floor for the availability of extensions

### DIFF
--- a/include/swift/AST/Availability.h
+++ b/include/swift/AST/Availability.h
@@ -93,6 +93,18 @@ public:
     return getLowerEndpoint() >= Other.getLowerEndpoint();
   }
 
+  // Returns true if all the versions in the Other range are versions in this
+  // range and the ranges are not equal.
+  bool isSupersetOf(const VersionRange &Other) const {
+    if (isEmpty() || Other.isAll())
+      return false;
+
+    if (isAll() || Other.isEmpty())
+      return true;
+
+    return getLowerEndpoint() < Other.getLowerEndpoint();
+  }
+
   /// Mutates this range to be a best-effort underapproximation of
   /// the intersection of itself and Other. This is the
   /// meet operation (greatest lower bound) in the version range lattice.
@@ -244,8 +256,15 @@ public:
   /// Returns true if \p other makes stronger guarantees than this context.
   ///
   /// That is, `a.isContainedIn(b)` implies `a.union(b) == b`.
-  bool isContainedIn(AvailabilityContext other) const {
+  bool isContainedIn(const AvailabilityContext &other) const {
     return OSVersion.isContainedIn(other.OSVersion);
+  }
+
+  /// Returns true if \p other is a strict subset of this context.
+  ///
+  /// That is, `a.isSupersetOf(b)` implies `a != b` and `a.union(b) == a`.
+  bool isSupersetOf(const AvailabilityContext &other) const {
+    return OSVersion.isSupersetOf(other.OSVersion);
   }
 
   /// Returns true if this context has constraints that make it impossible to
@@ -272,7 +291,7 @@ public:
   ///
   /// As an example, this is used when figuring out the required availability
   /// for a type that references multiple nominal decls.
-  void intersectWith(AvailabilityContext other) {
+  void intersectWith(const AvailabilityContext &other) {
     OSVersion.intersectWith(other.getOSVersion());
   }
 
@@ -283,7 +302,7 @@ public:
   /// treating some invalid deployment environments as available.
   ///
   /// As an example, this is used for the true branch of `#available`.
-  void constrainWith(AvailabilityContext other) {
+  void constrainWith(const AvailabilityContext &other) {
     OSVersion.constrainWith(other.getOSVersion());
   }
 
@@ -295,7 +314,7 @@ public:
   ///
   /// As an example, this is used for the else branch of a conditional with
   /// multiple `#available` checks.
-  void unionWith(AvailabilityContext other) {
+  void unionWith(const AvailabilityContext &other) {
     OSVersion.unionWith(other.getOSVersion());
   }
 

--- a/lib/AST/TypeRefinementContext.cpp
+++ b/lib/AST/TypeRefinementContext.cpp
@@ -64,13 +64,13 @@ TypeRefinementContext::createForDecl(ASTContext &Ctx, Decl *D,
       TypeRefinementContext(Ctx, D, Parent, SrcRange, Info, ExplicitInfo);
 }
 
-TypeRefinementContext *TypeRefinementContext::createForAPIBoundary(
+TypeRefinementContext *TypeRefinementContext::createForDeclImplicit(
     ASTContext &Ctx, Decl *D, TypeRefinementContext *Parent,
     const AvailabilityContext &Info, SourceRange SrcRange) {
   assert(D);
   assert(Parent);
   return new (Ctx) TypeRefinementContext(
-      Ctx, IntroNode(D, Reason::APIBoundary), Parent, SrcRange, Info,
+      Ctx, IntroNode(D, Reason::DeclImplicit), Parent, SrcRange, Info,
       AvailabilityContext::alwaysAvailable());
 }
 
@@ -180,7 +180,7 @@ void TypeRefinementContext::dump(raw_ostream &OS, SourceManager &SrcMgr) const {
 SourceLoc TypeRefinementContext::getIntroductionLoc() const {
   switch (getReason()) {
   case Reason::Decl:
-  case Reason::APIBoundary:
+  case Reason::DeclImplicit:
     return Node.getAsDecl()->getLoc();
 
   case Reason::IfStmtThenBranch:
@@ -294,7 +294,7 @@ TypeRefinementContext::getAvailabilityConditionVersionSourceRange(
       Node.getAsWhileStmt()->getCond(), Platform, Version);
 
   case Reason::Root:
-  case Reason::APIBoundary:
+  case Reason::DeclImplicit:
     return SourceRange();
   }
 
@@ -308,7 +308,7 @@ void TypeRefinementContext::print(raw_ostream &OS, SourceManager &SrcMgr,
 
   OS << " versions=" << AvailabilityInfo.getOSVersion().getAsString();
 
-  if (getReason() == Reason::Decl || getReason() == Reason::APIBoundary) {
+  if (getReason() == Reason::Decl || getReason() == Reason::DeclImplicit) {
     Decl *D = Node.getAsDecl();
     OS << " decl=";
     if (auto VD = dyn_cast<ValueDecl>(D)) {
@@ -350,8 +350,8 @@ StringRef TypeRefinementContext::getReasonName(Reason R) {
   case Reason::Decl:
     return "decl";
 
-  case Reason::APIBoundary:
-    return "api_boundary";
+  case Reason::DeclImplicit:
+    return "decl_implicit";
 
   case Reason::IfStmtThenBranch:
     return "if_then";

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -1850,21 +1850,8 @@ public:
     });
 
     Where = wasWhere.withExported(hasExportedMembers);
-
-    // When diagnosing potential unavailability of the extended type, downgrade
-    // the diagnostics to warnings when the extension decl has no declared
-    // availability and the required availability is more than the deployment
-    // target.
-    DeclAvailabilityFlags extendedTypeFlags = None;
-    auto annotatedRange =
-        AvailabilityInference::annotatedAvailableRange(ED, ED->getASTContext());
-    if (!annotatedRange.hasValue())
-      extendedTypeFlags |= DeclAvailabilityFlag::
-          WarnForPotentialUnavailabilityBeforeDeploymentTarget;
-
     checkType(ED->getExtendedType(), ED->getExtendedTypeRepr(), ED,
-              ExportabilityReason::ExtensionWithPublicMembers,
-              extendedTypeFlags);
+              ExportabilityReason::ExtensionWithPublicMembers);
 
     // 3) If the extension contains exported members or defines conformances,
     // the 'where' clause must only name exported types.

--- a/test/Sema/availability_refinement_contexts_target_min_inlining.swift
+++ b/test/Sema/availability_refinement_contexts_target_min_inlining.swift
@@ -11,8 +11,8 @@
 // CHECK-tvos: {{^}}(root versions=[9.0,+Inf)
 // CHECK-watchos: {{^}}(root versions=[2.0,+Inf)
 
-// CHECK-macosx-NEXT: {{^}}  (api_boundary versions=[10.15.0,+Inf) decl=foo()
-// CHECK-ios-NEXT: {{^}}  (api_boundary versions=[13.0.0,+Inf) decl=foo()
-// CHECK-tvos-NEXT: {{^}}  (api_boundary versions=[13.0.0,+Inf) decl=foo()
-// CHECK-watchos-NEXT: {{^}}  (api_boundary versions=[6.0.0,+Inf) decl=foo()
+// CHECK-macosx-NEXT: {{^}}  (decl_implicit versions=[10.15.0,+Inf) decl=foo()
+// CHECK-ios-NEXT: {{^}}  (decl_implicit versions=[13.0.0,+Inf) decl=foo()
+// CHECK-tvos-NEXT: {{^}}  (decl_implicit versions=[13.0.0,+Inf) decl=foo()
+// CHECK-watchos-NEXT: {{^}}  (decl_implicit versions=[6.0.0,+Inf) decl=foo()
 func foo() {}

--- a/test/Sema/availability_refinement_contexts_target_min_inlining_maccatalyst.swift
+++ b/test/Sema/availability_refinement_contexts_target_min_inlining_maccatalyst.swift
@@ -11,5 +11,5 @@
 // Verify that -target-min-inlining-version min implies 13.1 on macCatalyst.
 
 // CHECK: {{^}}(root versions=[13.1,+Inf)
-// CHECK-NEXT: {{^}}  (api_boundary versions=[14.4.0,+Inf) decl=foo()
+// CHECK-NEXT: {{^}}  (decl_implicit versions=[14.4.0,+Inf) decl=foo()
 func foo() {}

--- a/test/attr/attr_inlinable_available.swift
+++ b/test/attr/attr_inlinable_available.swift
@@ -929,70 +929,112 @@ internal struct InternalStruct { // expected-note 2 {{add @available attribute}}
 
 //
 // Extensions are externally visible if they extend a public type and (1) have
-// public members or (2) declare a conformance to a public protocol. Externally
-// visible extensions should be typechecked with the inlining target.
+// public members or (2) declare a conformance to a public protocol.
+//
+// Extensions without explicit availability that are externally visible use an
+// implied floor of either the availability of the extended type or the
+// deployment target, whichever is more available. This is a special rule
+// designed as a convenience to library authors who have written quite a bit of
+// code without annotating availability on their extensions and getting away
+// with it because previously the deployment target was always used as the
+// floor.
+//
+// Extensions without explicit availability that are not visible externally are
+// checked using an implied floor of the deployment target.
 //
 
-// OK, NoAvailable is always available, both internally and externally.
+
+// MARK: Extensions on NoAvailable
+
 extension NoAvailable {}
-extension NoAvailable {
-  public func publicFunc1() {}
+
+extension NoAvailable { // expected-note {{add @available attribute to enclosing extension}}
+  func internalFuncInExtension( // expected-note {{add @available attribute to enclosing instance method}}
+    _: NoAvailable,
+    _: BeforeInliningTarget,
+    _: AtInliningTarget,
+    _: BetweenTargets,
+    _: AtDeploymentTarget,
+    _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
+  ) {}
 }
 
-// OK, no public members and BetweenTargets is always available internally.
+extension NoAvailable { // expected-note 3 {{add @available attribute to enclosing extension}}
+  public func publicFuncInExtension( // expected-note 3 {{add @available attribute to enclosing instance method}}
+    _: NoAvailable,
+    _: BeforeInliningTarget,
+    _: AtInliningTarget,
+    _: BetweenTargets, // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}}
+    _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}}
+    _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
+  ) {}
+}
+
+// MARK: Extensions on BetweenTargets
+
 extension BetweenTargets {}
 
-// OK, no public members and BetweenTargets is always available internally.
-extension BetweenTargets {
-  internal func internalFunc1() {}
-  private func privateFunc1() {}
-  fileprivate func fileprivateFunc1() {}
+extension BetweenTargets { // expected-note {{add @available attribute to enclosing extension}}
+  func internalFuncInExtension( // expected-note {{add @available attribute to enclosing instance method}}
+    _: NoAvailable,
+    _: BeforeInliningTarget,
+    _: AtInliningTarget,
+    _: BetweenTargets,
+    _: AtDeploymentTarget,
+    _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
+  ) {}
 }
 
-// expected-warning@+1 {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}} expected-note@+1 {{add @available attribute to enclosing extension}}
-extension BetweenTargets {
-  public func publicFunc1() {}
+extension BetweenTargets { // expected-note 2 {{add @available attribute to enclosing extension}}
+  public func publicFuncInExtension( // expected-note 2 {{add @available attribute to enclosing instance method}}
+    _: NoAvailable,
+    _: BeforeInliningTarget,
+    _: AtInliningTarget,
+    _: BetweenTargets,
+    _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}}
+    _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
+  ) {}
 }
 
-// expected-warning@+1 {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}} expected-note@+1 {{add @available attribute to enclosing extension}}
+@available(macOS 10.15, *)
 extension BetweenTargets {
-  @usableFromInline
-  internal func usableFromInlineFunc1() {}
+  public func publicFuncInExtensionWithExplicitAvailability( // expected-note {{add @available attribute to enclosing instance method}}
+    _: NoAvailable,
+    _: BeforeInliningTarget,
+    _: AtInliningTarget,
+    _: BetweenTargets,
+    _: AtDeploymentTarget,
+    _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
+  ) {}
 }
 
-// expected-warning@+1 {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}} expected-note@+1 {{add @available attribute to enclosing extension}}
-extension BetweenTargets {
-  internal func internalFunc2() {}
-  private func privateFunc2() {}
-  fileprivate func fileprivateFunc2() {}
-  public func publicFunc2() {}
-}
-
-// An extension with more availability than BetweenTargets.
-// expected-error@+2 {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}}
-@available(macOS 10.10, *)
-extension BetweenTargets {
-  public func publicFunc3() {}
-}
-
-// FIXME: Can we prevent this warning when SPI members are the reason the extension is exported?
-// expected-warning@+1 {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}} expected-note@+1 {{add @available attribute to enclosing extension}}
-extension BetweenTargets {
-  @_spi(Private)
-  public func spiFunc1() {}
+extension BetweenTargets { // expected-note {{add @available attribute to enclosing extension}}
+  @available(macOS 10.15, *)
+  public func publicFuncWithExplicitAvailabilityInExtension(
+    _: NoAvailable,
+    _: BeforeInliningTarget,
+    _: AtInliningTarget,
+    _: BetweenTargets,
+    _: AtDeploymentTarget,
+    _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
+  ) {}
 }
 
 @_spi(Private)
-extension BetweenTargets {
-  internal func internalFunc3() {}
-  private func privateFunc3() {}
-  fileprivate func fileprivateFunc3() {}
-  public func spiFunc2() {}
+extension BetweenTargets { // expected-note {{add @available attribute to enclosing extension}}
+  public func inheritedSPIFuncInExtension( // expected-note {{add @available attribute to enclosing instance method}}
+    _: NoAvailable,
+    _: BeforeInliningTarget,
+    _: AtInliningTarget,
+    _: BetweenTargets,
+    _: AtDeploymentTarget,
+    _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
+  ) {}
 }
 
 @available(macOS, unavailable)
 extension BetweenTargets {
-  public func inheritsUnavailable(
+  public func inheritsUnavailableFuncInExtension(
     _: NoAvailable,
     _: BeforeInliningTarget,
     _: AtInliningTarget,
@@ -1000,49 +1042,96 @@ extension BetweenTargets {
     _: AtDeploymentTarget,
     _: AfterDeploymentTarget,
     _: Unavailable
-  ) { }
+  ) {}
 }
 
-@_spi(Private)
-extension BetweenTargets { // expected-note 1 {{add @available attribute to enclosing extension}}
-  public func inheritsSPINoAvailable( // expected-note 1 {{add @available attribute to enclosing instance method}}
+// This extension is explicitly more available than BetweenTargets but because
+// it only contains internal members, the availability floor is still the
+// deployment target.
+@available(macOS 10.10, *)
+extension BetweenTargets {
+  func internalFuncInExcessivelyAvailableExtension() {}
+}
+
+extension BetweenTargets {
+  @available(macOS 10.10, *)
+  func excessivelyAvailableInternalFuncInExtension() {}
+}
+
+@available(macOS 10.10, *)
+extension BetweenTargets { // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}}
+  public func publicFuncInExcessivelyAvailableExtension() {}
+}
+
+// MARK: Extensions on BetweenTargetsInternal
+
+// Same availability as BetweenTargets but internal instead of public.
+@available(macOS 10.14.5, *)
+internal struct BetweenTargetsInternal {}
+
+extension BetweenTargetsInternal {}
+
+extension BetweenTargetsInternal { // expected-note {{add @available attribute to enclosing extension}}
+  func internalFuncInExtension( // expected-note {{add @available attribute to enclosing instance method}}
     _: NoAvailable,
     _: BeforeInliningTarget,
     _: AtInliningTarget,
     _: BetweenTargets,
     _: AtDeploymentTarget,
     _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
-  ) { }
+  ) {}
 }
 
-// Same availability as BetweenTargets but internal instead of public.
-@available(macOS 10.14.5, *)
-internal struct BetweenTargetsInternal {}
-
-// OK, extensions on internal types are never visible externally.
-extension BetweenTargetsInternal {}
-extension BetweenTargetsInternal {
-  public func publicFunc() {}
+extension BetweenTargetsInternal { // expected-note {{add @available attribute to enclosing extension}}
+  public func publicFuncInExtension( // expected-note {{add @available attribute to enclosing instance method}}
+    _: NoAvailable,
+    _: BeforeInliningTarget,
+    _: AtInliningTarget,
+    _: BetweenTargets,
+    _: AtDeploymentTarget,
+    _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
+  ) {}
 }
 
-// expected-warning@+1 {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}} expected-note@+1 {{add @available attribute to enclosing extension}}
-extension AtDeploymentTarget {
-  public func publicFunc() {}
-}
+// MARK: Extensions on AfterDeploymentTarget
 
 // expected-error@+1 {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note@+1 {{add @available attribute to enclosing extension}}
 extension AfterDeploymentTarget {}
 
-// expected-error@+1 {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note@+1 {{add @available attribute to enclosing extension}}
-extension AfterDeploymentTarget {
-  internal func internalFunc1() {}
-  private func privateFunc1() {}
-  fileprivate func fileprivateFunc1() {}
+// expected-error@+1 {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
+extension AfterDeploymentTarget { // expected-note 2 {{add @available attribute to enclosing extension}}
+  func internalFuncInExtension( // expected-note {{add @available attribute to enclosing instance method}}
+    _: NoAvailable,
+    _: BeforeInliningTarget,
+    _: AtInliningTarget,
+    _: BetweenTargets,
+    _: AtDeploymentTarget,
+    _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
+  ) {}
 }
 
-// expected-error@+1 {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note@+1 {{add @available attribute to enclosing extension}}
+// expected-error@+1 {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
+extension AfterDeploymentTarget { // expected-note 2 {{add @available attribute to enclosing extension}}
+  public func publicFuncInExtension( // expected-note {{add @available attribute to enclosing instance method}}
+    _: NoAvailable,
+    _: BeforeInliningTarget,
+    _: AtInliningTarget,
+    _: BetweenTargets,
+    _: AtDeploymentTarget,
+    _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
+  ) {}
+}
+
+@available(macOS 11, *)
 extension AfterDeploymentTarget {
-  public func publicFunc1() {}
+  public func publicFuncInExtensionWithExplicitAvailability(
+    _: NoAvailable,
+    _: BeforeInliningTarget,
+    _: AtInliningTarget,
+    _: BetweenTargets,
+    _: AtDeploymentTarget,
+    _: AfterDeploymentTarget
+  ) {}
 }
 
 
@@ -1062,8 +1151,8 @@ public protocol PublicProto {}
 extension NoAvailable: PublicProto {}
 extension BeforeInliningTarget: PublicProto {}
 extension AtInliningTarget: PublicProto {}
-extension BetweenTargets: PublicProto {} // expected-warning {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}} expected-note {{add @available attribute to enclosing extension}}
-extension AtDeploymentTarget: PublicProto {} // expected-warning {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}} expected-note {{add @available attribute to enclosing extension}}
+extension BetweenTargets: PublicProto {}
+extension AtDeploymentTarget: PublicProto {}
 extension AfterDeploymentTarget: PublicProto {} // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add @available attribute to enclosing extension}}
 
 


### PR DESCRIPTION
Many API libraries contain public extension decls that don't specify availability because they introduce additional members to the extended type in the same releases that the extended type was declared. Others contain extensions where the extension itself does not have declared availability but each of the members do. In both cases, the code works as written because extension members cannot be used without referencing the extended type.

```swift
@available(macOS 11, *)
struct S { }

// No availability, but every member of this extension has existed since `S` was introduced.
extension S {
  public func foo() { }
}

// No availability on the extension, but every public member has its own availability annotation. 
extension S {
  @available(macOS 12, *)
  public func bar() { }
}

```

With `-target-min-inlining-version min` specified, these extensions are diagnosed because the default availability floor for public decls is lowered below the deployment target. 

The changes in this PR make the compiler use the availability of the extended nominal as a floor when checking availability in an extension decl to avoid unnecessary diagnostics for API libraries.

Resolves rdar://93630782