### PR TITLE
[ASTPrinter] Print the desugared constraint type following the `any` keyword.

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -285,6 +285,9 @@ struct PrintOptions {
   /// types.
   bool PrintExplicitAny = false;
 
+  /// Whether to desugar the constraint for an existential type.
+  bool DesugarExistentialConstraint = false;
+
   /// Whether to skip keywords with a prefix of underscore such as __consuming.
   bool SkipUnderscoredKeywords = false;
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -6211,7 +6211,12 @@ public:
     if (Options.PrintExplicitAny)
       Printer << "any ";
 
-    visit(T->getConstraintType());
+    // FIXME: The desugared type is used here only to support
+    // existential types with protocol typealiases in Swift
+    // interfaces. Verifying that the underlying type of a
+    // protocol typealias is a constriant type is fundamentally
+    // circular, so the desugared type should be written in source.
+    visit(T->getConstraintType()->getDesugaredType());
   }
 
   void visitLValueType(LValueType *T) {

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -156,6 +156,7 @@ PrintOptions PrintOptions::printSwiftInterfaceFile(ModuleDecl *ModuleToPrint,
   result.AlwaysTryPrintParameterLabels = true;
   result.PrintSPIs = printSPIs;
   result.PrintExplicitAny = true;
+  result.DesugarExistentialConstraint = true;
 
   // We should print __consuming, __owned, etc for the module interface file.
   result.SkipUnderscoredKeywords = false;
@@ -6216,7 +6217,11 @@ public:
     // interfaces. Verifying that the underlying type of a
     // protocol typealias is a constriant type is fundamentally
     // circular, so the desugared type should be written in source.
-    visit(T->getConstraintType()->getDesugaredType());
+    if (Options.DesugarExistentialConstraint) {
+      visit(T->getConstraintType()->getDesugaredType());
+    } else {
+      visit(T->getConstraintType());
+    }
   }
 
   void visitLValueType(LValueType *T) {

--- a/test/ModuleInterface/existential-any.swift
+++ b/test/ModuleInterface/existential-any.swift
@@ -38,3 +38,11 @@ public struct S {
   // CHECK: public var q: any main.Q
   public var q: any Q
 }
+
+
+public protocol ProtocolTypealias {
+  typealias A = P
+}
+
+// CHECK: public func dependentExistential<T>(value: (T) -> any main.P) where T : main.ProtocolTypealias
+public func dependentExistential<T: ProtocolTypealias>(value: (T) -> T.A) {}


### PR DESCRIPTION
Currently, a protocol typealias with an underlying constraint type (i.e. a protocol or protocol composition) can be used as an existential type by accessing the alias through a type parameter, e.g.

```swift
protocol P1 {
  typealias A = P2
}

protocol P2 {}

func generic<T: P1>(value: (T) -> T.A) {} // okay
```

However, verifying that the underlying type of `T.A` is a constraint type is a circular computation in the general case, which is needed to use the `any` keyword. Resolving `T.A` where `T` is a type parameter needs a full generic signature to access the requirements on `T`, but a full generic signature needs the existential type verification.

This is an issue when `T.A` is written in source, but `any` is automatically printed in Swift interfaces. For now, simply print the underlying constraint type.

Resolves: rdar://93780361 