### PR TITLE
[C++-Interop] Fix EffectiveClangContext for NS_OPTIONS EnumDecl lookup.

### DIFF
--- a/lib/ClangImporter/SwiftLookupTable.h
+++ b/lib/ClangImporter/SwiftLookupTable.h
@@ -21,6 +21,7 @@
 #include "swift/Basic/LLVM.h"
 #include "swift/AST/Identifier.h"
 #include "clang/AST/Decl.h"
+#include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclObjC.h"
 #include "clang/Serialization/ASTBitCodes.h"
 #include "clang/Serialization/ModuleFileExtension.h"
@@ -197,6 +198,8 @@ public:
       DC = omDecl->getCanonicalDecl();
     } else if (auto fDecl = dyn_cast<clang::FunctionDecl>(dc)) {
       DC = fDecl->getCanonicalDecl();
+    } else if (auto externCDecl = dyn_cast<clang::LinkageSpecDecl>(dc)) {
+      DC = externCDecl->getLexicalDeclContext();
     } else {
       assert(isa<clang::TranslationUnitDecl>(dc) ||
              isa<clang::LinkageSpecDecl>(dc) ||

--- a/test/Interop/Cxx/enum/Inputs/c-enums-NS_OPTIONS.h
+++ b/test/Interop/Cxx/enum/Inputs/c-enums-NS_OPTIONS.h
@@ -1,0 +1,29 @@
+// Enum usage that is bitwise-able and assignable in C++, aka how CF_OPTIONS
+// does things.
+
+#if __has_attribute(enum_extensibility)
+#define __CF_ENUM_ATTRIBUTES __attribute__((enum_extensibility(open)))
+#define __CF_CLOSED_ENUM_ATTRIBUTES __attribute__((enum_extensibility(closed)))
+#define __CF_OPTIONS_ATTRIBUTES __attribute__((flag_enum,enum_extensibility(open)))
+#else
+#define __CF_ENUM_ATTRIBUTES
+#define __CF_CLOSED_ENUM_ATTRIBUTES
+#define __CF_OPTIONS_ATTRIBUTES
+#endif
+
+// explicitly use extern "C" rather than setting it in the modulemap file as
+// would be the case with Foundation's modulemap.
+extern "C" {
+
+#define CF_OPTIONS(_type, _name) _type __attribute__((availability(swift, unavailable))) _name; enum __CF_OPTIONS_ATTRIBUTES : _name
+#define NS_OPTIONS(_type, _name) CF_OPTIONS(_type, _name)
+
+typedef unsigned long NSUInteger;
+
+typedef NS_OPTIONS(NSUInteger, NSBinarySearchingOptions) {
+	NSBinarySearchingFirstEqual = (1UL << 8),
+	NSBinarySearchingLastEqual = (1UL << 9),
+	NSBinarySearchingInsertionIndex = (1UL << 10),
+};
+
+}

--- a/test/Interop/Cxx/enum/Inputs/module.modulemap
+++ b/test/Interop/Cxx/enum/Inputs/module.modulemap
@@ -17,3 +17,8 @@ module CenumsWithOptionsOmit {
   header "c-enums-withOptions-omit.h"
   requires cplusplus
 }
+
+module CenumsNSOptions {
+  header "c-enums-NS_OPTIONS.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/enum/c-enums-NS_OPTIONS.swift
+++ b/test/Interop/Cxx/enum/c-enums-NS_OPTIONS.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=CenumsNSOptions -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
+// REQUIRES: objc_interop
+
+import CenumsNSOptions
+
+// CHECK: typealias NSBinarySearchingOptions = UInt
+// CHECK-NEXT: struct NSBinarySearchingOptions : OptionSet, @unchecked Sendable {
+// CHECK-NEXT:   init(rawValue: UInt)
+// CHECK-NEXT:   let rawValue: UInt
+// CHECK-NEXT:   typealias RawValue = UInt
+// CHECK-NEXT:   typealias Element = NSBinarySearchingOptions
+// CHECK-NEXT:   typealias ArrayLiteralElement = NSBinarySearchingOptions
+// CHECK-NEXT:   static var firstEqual: NSBinarySearchingOptions { get }
+// CHECK-NEXT:   @available(swift, obsoleted: 3, renamed: "firstEqual")
+// CHECK-NEXT:   static var FirstEqual: NSBinarySearchingOptions { get }
+// CHECK-NEXT:   static var lastEqual: NSBinarySearchingOptions { get }
+// CHECK-NEXT:   @available(swift, obsoleted: 3, renamed: "lastEqual")
+// CHECK-NEXT:   static var LastEqual: NSBinarySearchingOptions { get }
+// CHECK-NEXT:   static var insertionIndex: NSBinarySearchingOptions { get }
+// CHECK-NEXT:   @available(swift, obsoleted: 3, renamed: "insertionIndex")
+// CHECK-NEXT:   static var InsertionIndex: NSBinarySearchingOptions { get }
+// CHECK-NEXT: }


### PR DESCRIPTION
This patch fixes an issue with C++-Interop that has been making it so
that enums under interop were not getting properly looked up and
therefore not getting imported. The reason for this was that the proper
DeclContext was not getting applied when grabbing the decls use by
VisitDecls later in the ClangImporter.

The lookup code at SwiftLookupTable::lookup is given a clang TU which is
what implcitly gets turned into an EffectiveClangContext. The
EffectiveClangContext is the piece that decides which DeclContext to
use. In the case of an extern "C" (ie LinkageSpecDecl), the
EffectiveClangContext was not traversing inside the lexical scope of the
extern "C" as the context for searching the EnumDecl (the NS_OPTIONS
Enum).

This patch adds new behavior when EffectiveClangContext is given a
LinkageSpecDecl. It sets the DeclContext to the lexical decl context.

With this fix in place in the presence of C++-Interop we not only import
the NS_OPTIONS typedef properly, but we also import the enum (and
therefore the EnumConstants) correctly (which are used for getting to
the flags for populating the NS_OPTIONS bitfields.

