### PR TITLE
[5.7][CodeCompletion] Don’t compute type relations if the contextual type is `Any`

### DIFF
--- a/test/IDE/complete_at_top_level.swift
+++ b/test/IDE/complete_at_top_level.swift
@@ -328,7 +328,7 @@ var stringInterp = "\(#^STRING_INTERP_3?check=STRING_INTERP^#)"
 _ = "" + "\(#^STRING_INTERP_4?check=STRING_INTERP^#)" + ""
 // STRING_INTERP: Begin completions
 // STRING_INTERP-DAG: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]/IsSystem: ['(']{#(value): T#}[')'][#Void#];
-// STRING_INTERP-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: FooStruct[#FooStruct#]; name=FooStruct
+// STRING_INTERP-DAG: Decl[Struct]/CurrModule: FooStruct[#FooStruct#]; name=FooStruct
 // STRING_INTERP-DAG: Decl[FreeFunction]/CurrModule/TypeRelation[Invalid]: fooFunc1()[#Void#];
 // STRING_INTERP-DAG: Decl[FreeFunction]/CurrModule: optStr()[#String?#];
 // STRING_INTERP-DAG: Decl[GlobalVar]/Local: fooObject[#FooStruct#];


### PR DESCRIPTION
* **Explanation**: Computing type relations to 'Any' is not very enlightning because everything would be convertible to it. If the contextual type is 'Any', just report all type relations as 'Unknown'. This fixes an issue where we suggest a function signature (i.e. `foo(x:)`) instead of a call (i.e.`foo(x: <#Int#>)`).
* **Scope**: Code completion in places that expect `Any` or a variation of `Any` that involves meta types or `Optional`s
* **Risk**: Low
* **Testing**: Added test cases
* **Issue**: rdar://84684686&64812321
* **Reviewer**: @rintaro on https://github.com/apple/swift/pull/59021