### PR TITLE
[5.7] use getConformingProtocols when printing opaque generic types

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -57,6 +57,7 @@
 #include "clang/AST/DeclObjC.h"
 #include "clang/Basic/Module.h"
 #include "clang/Basic/SourceManager.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/ConvertUTF.h"
@@ -6370,10 +6371,16 @@ public:
 
       // Print based on the type.
       Printer << "some ";
-      if (auto inheritedType = decl->getInherited().front().getType())
-        inheritedType->print(Printer, Options);
-      else
+      if (!decl->getConformingProtocols().empty()) {
+        llvm::interleave(decl->getConformingProtocols(), Printer, [&](ProtocolDecl *proto){
+          if (auto printType = proto->getDeclaredType())
+            printType->print(Printer, Options);
+          else
+            Printer << proto->getNameStr();
+        }, " & ");
+      } else {
         Printer << "Any";
+      }
       return;
     }
 

--- a/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/SomeProtocol.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/SomeProtocol.swift
@@ -1,0 +1,131 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name SomeProtocol -emit-module -emit-module-path %t/
+// RUN: %target-swift-symbolgraph-extract -module-name SomeProtocol -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/SomeProtocol.symbols.json
+// RUN: %FileCheck %s --input-file %t/SomeProtocol.symbols.json --check-prefix MULTI
+
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name SomeProtocol -emit-module -emit-module-path %t/SomeProtocol.swiftmodule -emit-symbol-graph -emit-symbol-graph-dir %t/
+// RUN: %{python} -m json.tool %t/SomeProtocol.symbols.json %t/SomeProtocol.formatted.symbols.json
+// RUN: %FileCheck %s --input-file %t/SomeProtocol.formatted.symbols.json
+// RUN: %FileCheck %s --input-file %t/SomeProtocol.formatted.symbols.json --check-prefix MULTI
+
+// Make sure that `some MyProtocol` parameters don't crash swift-symbolgraph-extract, and that it
+// properly renders `some MyProtocol & OtherProtocol` parameters with multiple protocols listed.
+
+public protocol SomeProtocol {}
+
+public func doSomething(with param: some SomeProtocol) {}
+
+public protocol OtherProtocol {}
+
+public func doSomethingElse(with param: some SomeProtocol & OtherProtocol) {}
+
+// CHECK-LABEL:        "precise": "s:12SomeProtocol11doSomething4withyx_tA2ARzlF",
+
+// the functionSignature fragments come before the full fragments, so skip those
+// CHECK:      "functionSignature": {
+// CHECK:      "declarationFragments": [
+
+// CHECK:      "declarationFragments": [
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "kind": "keyword",
+// CHECK-NEXT:          "spelling": "func"
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "kind": "text",
+// CHECK-NEXT:          "spelling": " "
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "kind": "identifier",
+// CHECK-NEXT:          "spelling": "doSomething"
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "kind": "text",
+// CHECK-NEXT:          "spelling": "("
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "kind": "externalParam",
+// CHECK-NEXT:          "spelling": "with"
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "kind": "text",
+// CHECK-NEXT:          "spelling": " "
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "kind": "internalParam",
+// CHECK-NEXT:          "spelling": "param"
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "kind": "text",
+// CHECK-NEXT:          "spelling": ": some "
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "kind": "typeIdentifier",
+// CHECK-NEXT:          "spelling": "SomeProtocol",
+// CHECK-NEXT:          "preciseIdentifier": "s:12SomeProtocolAAP"
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "kind": "text",
+// CHECK-NEXT:          "spelling": ")"
+// CHECK-NEXT:        }
+// CHECK-NEXT:      ],
+
+// MULTI-LABEL:        "precise": "s:12SomeProtocol15doSomethingElse4withyx_tAA05OtherB0RzA2ARzlF",
+
+// the functionSignature fragments come before the full fragments, so skip those
+// MULTI:      "functionSignature": {
+// MULTI:      "declarationFragments": [
+
+// MULTI:      "declarationFragments": [
+// MULTI-NEXT:        {
+// MULTI-NEXT:          "kind": "keyword",
+// MULTI-NEXT:          "spelling": "func"
+// MULTI-NEXT:        },
+// MULTI-NEXT:        {
+// MULTI-NEXT:          "kind": "text",
+// MULTI-NEXT:          "spelling": " "
+// MULTI-NEXT:        },
+// MULTI-NEXT:        {
+// MULTI-NEXT:          "kind": "identifier",
+// MULTI-NEXT:          "spelling": "doSomethingElse"
+// MULTI-NEXT:        },
+// MULTI-NEXT:        {
+// MULTI-NEXT:          "kind": "text",
+// MULTI-NEXT:          "spelling": "("
+// MULTI-NEXT:        },
+// MULTI-NEXT:        {
+// MULTI-NEXT:          "kind": "externalParam",
+// MULTI-NEXT:          "spelling": "with"
+// MULTI-NEXT:        },
+// MULTI-NEXT:        {
+// MULTI-NEXT:          "kind": "text",
+// MULTI-NEXT:          "spelling": " "
+// MULTI-NEXT:        },
+// MULTI-NEXT:        {
+// MULTI-NEXT:          "kind": "internalParam",
+// MULTI-NEXT:          "spelling": "param"
+// MULTI-NEXT:        },
+// MULTI-NEXT:        {
+// MULTI-NEXT:          "kind": "text",
+// MULTI-NEXT:          "spelling": ": some "
+// MULTI-NEXT:        },
+// MULTI-NEXT:        {
+// MULTI-NEXT:          "kind": "typeIdentifier",
+// MULTI-NEXT:          "spelling": "OtherProtocol",
+// MULTI-NEXT:          "preciseIdentifier": "s:12SomeProtocol05OtherB0P"
+// MULTI-NEXT:        },
+// MULTI-NEXT:        {
+// MULTI-NEXT:          "kind": "text",
+// MULTI-NEXT:          "spelling": " & "
+// MULTI-NEXT:        },
+// MULTI-NEXT:        {
+// MULTI-NEXT:          "kind": "typeIdentifier",
+// MULTI-NEXT:          "spelling": "SomeProtocol",
+// MULTI-NEXT:          "preciseIdentifier": "s:12SomeProtocolAAP"
+// MULTI-NEXT:        },
+// MULTI-NEXT:        {
+// MULTI-NEXT:          "kind": "text",
+// MULTI-NEXT:          "spelling": ")"
+// MULTI-NEXT:        }
+// MULTI-NEXT:      ],


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/58991

**Explanation**: When a module defines a function that uses `some MyProtocol` as an argument type, printing the AST from the compiled module will fail. This PR changes the way these opaque types are printed, to use the more-accurate `getConformingProtocols` instead of `getInherited`, which is empty in this circumstance.

**Scope**: Only changes the AST printer, used by module-interface printing and SymbolGraphGen.

**Bug**: rdar://93610106

**Risk**: Low. Should not affect normal compilation. The original issue only affected printing the AST from an already-built module, and the change was verified not to change the behavior for printing from parsed source.

**Testing**: A new lit test, `SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/SomeProtocol.swift`, has been added to verify that emitting a symbol graph from both parsed source and serialized AST works in this situation. Existing tests still pass.