### PR TITLE
[stdlib] Enable variable lifetimes.

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -2069,7 +2069,6 @@ function(add_swift_target_library name)
   # behavior for their requirements.
   if (SWIFTLIB_IS_STDLIB)
     list(APPEND SWIFTLIB_SWIFT_COMPILE_FLAGS "-warn-implicit-overrides")
-    list(APPEND SWIFTLIB_SWIFT_COMPILE_FLAGS "-Xfrontend;-enable-lexical-lifetimes=false")
   endif()
 
   if (NOT SWIFTLIB_IMPORTS_NON_OSSA)


### PR DESCRIPTION
Enable variable lifetimes in the stdlib and make some basic types have eager-move semantics.

Minor optimization changes and stdlib annotations to support the change.