### PR TITLE
[SILOpt] Used SetVector for fast contains check.

### DIFF
--- a/include/swift/SILOptimizer/Analysis/Reachability.h
+++ b/include/swift/SILOptimizer/Analysis/Reachability.h
@@ -149,7 +149,7 @@ protected:
 ///     Effect effectForPhi(SILBasicBlock *);
 ///
 ///     /// The uses from which reachability will begin.
-///     ArrayRef<SILInstruction *> gens();
+///     iterable gens();
 /// }
 template <typename Effects>
 class IterativeBackwardReachability final {


### PR DESCRIPTION
IterableBackwardReachability just requires an iterable list of gens.  ShrinkBorrowScope, LexicalDestroyHoisting, and SSADestroyHoisting all need to be able to check whether a given instruction is scope ending quickly.  Use a SmallSetVector rather than a SmallVector for the gens in all three.
