### PR TITLE
[CSClosure] Fix crash in `fallthrough` statement checking

### DIFF
--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -404,3 +404,23 @@ func test_type_finder_doesnt_walk_into_inner_closures() {
     return x
   }
 }
+
+// rdar://93796211 (issue#59035) - crash during solution application to fallthrough statement
+func test_fallthrough_stmt() {
+  {
+    var collector: [Void] = []
+    for _: Void in [] {
+      switch (() as Void?, ()) {
+      case (let a?, let b):
+        // expected-warning@-1 {{constant 'b' inferred to have type '()', which may be unexpected}}
+        // expected-note@-2 {{add an explicit type annotation to silence this warning}}
+        collector.append(a)
+        fallthrough
+      case (nil,    let b):
+        // expected-warning@-1 {{constant 'b' inferred to have type '()', which may be unexpected}}
+        // expected-note@-2 {{add an explicit type annotation to silence this warning}}
+        collector.append(b)
+      }
+    }
+  }()
+}


### PR DESCRIPTION
`fallthrough` requires both source and destination `case`
"preambles" be type-checked before it could be validated,
which means that solution application for `case` statements
in a `switch` has to be split in two - preamble first and
bodies afterwards.

Resolves: https://github.com/apple/swift/issues/59035
Resolves: rdar://93796211

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
