### PR TITLE
AST: Never query the map with non-root archetypes in `QueryTypeSubsti…

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -65,6 +65,13 @@ Type QueryTypeSubstitutionMap::operator()(SubstitutableType *type) const {
 
 Type
 QueryTypeSubstitutionMapOrIdentity::operator()(SubstitutableType *type) const {
+  // FIXME: Type::subst should not be pass in non-root archetypes.
+  // Consider only root archetypes.
+  if (auto *archetype = dyn_cast<ArchetypeType>(type)) {
+    if (!archetype->isRoot())
+      return Type();
+  }
+
   auto key = type->getCanonicalType()->castTo<SubstitutableType>();
   auto known = substitutions.find(key);
   if (known != substitutions.end() && known->second)

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -2582,17 +2582,15 @@ CanSILFunctionType swift::buildSILFunctionThunkType(
   }
 
   auto substTypeHelper = [&](SubstitutableType *type) -> Type {
+    // FIXME: Type::subst should not pass in non-root archetypes.
+    // Consider only root archetypes.
+    if (auto *archetype = dyn_cast<ArchetypeType>(type)) {
+      if (!archetype->isRoot())
+        return Type();
+    }
+
     if (CanType(type) == openedExistential)
       return newArchetype;
-
-    // If a nested archetype is rooted on our opened existential, fail:
-    // Type::subst attempts to substitute the parent of a nested archetype
-    // only if it fails to find a replacement for the nested one.
-    if (auto *opened = dyn_cast<OpenedArchetypeType>(type)) {
-      if (openedExistential->isEqual(opened->getRoot())) {
-        return nullptr;
-      }
-    }
 
     return Type(type).subst(contextSubs);
   };

--- a/test/SILOptimizer/mandatory_inlining_open_existential.swift
+++ b/test/SILOptimizer/mandatory_inlining_open_existential.swift
@@ -1,0 +1,31 @@
+// RUN: %target-swift-frontend -emit-sil -O -primary-file %s | %FileCheck %s
+
+// FIXME: Ideally, this should be a sil-opt test, but TypeRepr cannot model
+// types like '(@opened("...") P).Assoc' as of now.
+
+protocol P {
+  associatedtype Assoc: P
+
+  func f() -> Self.Assoc
+}
+
+// CHECK-LABEL: sil hidden [always_inline] @$s35mandatory_inlining_open_existential6callee1pAA1P_pAaD_p_tF
+// CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access {{%[0-9]+}} : $*P to $*[[OPENED_TY:@opened\("[-A-F0-9]+"\) P]]
+// CHECK: [[WITNESS:%[0-9]+]] = witness_method $[[OPENED_TY]], #P.f : <Self where Self : P> (Self) -> () -> Self.Assoc
+// CHECK: [[RESULT:%[0-9]+]] = init_existential_addr {{%[0-9]+}} : $*P, $([[OPENED_TY]]).Assoc
+// CHECK: apply [[WITNESS]]<[[OPENED_TY]]>([[RESULT]], [[OPENED]])
+// CHECK: }
+@inline(__always)
+func callee(p: any P) -> any P {
+  return p.f()
+}
+
+// CHECK-LABEL: sil hidden @$s35mandatory_inlining_open_existential6caller1pAA1P_pAaD_p_tF
+// CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access {{%[0-9]+}} : $*P to $*[[OPENED_TY:@opened\("[-A-F0-9]+"\) P]]
+// CHECK: [[WITNESS:%[0-9]+]] = witness_method $[[OPENED_TY]], #P.f : <Self where Self : P> (Self) -> () -> Self.Assoc
+// CHECK: [[RESULT:%[0-9]+]] = init_existential_addr {{%[0-9]+}} : $*P, $([[OPENED_TY]]).Assoc
+// CHECK: apply [[WITNESS]]<[[OPENED_TY]]>([[RESULT]], [[OPENED]])
+// CHECK: }
+func caller(p: any P) -> any P {
+  return callee(p: p)
+}


### PR DESCRIPTION
…tutionMapOrIdentity`

This makes `SILCloner::getASTTypeInClonedContext` and `getTypeInClonedContext`,
which use `QueryTypeSubstitutionMapOrIdentity`, work for nested opened archetypes
and consequently fixes inlining of instructions involving these archetypes.

Fixes:
  rdar://93252455 (Compiler Crash in DCE::markValueLive(swift::SILValue))
  rdar://93035200 (Compile error building generics in optimized mode.)

(cherry picked from commit 21500abe25c6bd1c1425be5391c082e87fb76a23)
