### PR TITLE
[CSSimplify] If function types mismatch on labels record a contextual…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3140,13 +3140,12 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
       return result;
   }
 
-  if (hasLabelingFailures) {
-    SmallVector<Identifier, 4> correctLabels;
-    for (const auto &param : func2Params)
-      correctLabels.push_back(param.getLabel());
+  if (hasLabelingFailures && !hasFixFor(loc)) {
+    ConstraintFix *fix =
+        loc->isLastElement<LocatorPathElt::ApplyArgToParam>()
+            ? AllowArgumentMismatch::create(*this, func1, func2, loc)
+            : ContextualMismatch::create(*this, func1, func2, loc);
 
-    auto *fix = RelabelArguments::create(*this, correctLabels,
-                                         getConstraintLocator(argumentLocator));
     if (recordFix(fix))
       return getTypeMatchFailure(argumentLocator);
   }

--- a/validation-test/Sema/type_checker_crashers_fixed/issue59058.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/issue59058.swift
@@ -1,0 +1,38 @@
+// RUN: %target-typecheck-verify-swift
+
+// https://github.com/apple/swift/issues/59058
+
+struct MPSGraphTensor { }
+
+struct MPSGraph {
+  func addition(
+    _ primaryTensor: MPSGraphTensor,
+    _ secondaryTensor: MPSGraphTensor,
+    name: String?
+  ) {
+
+  }
+}
+
+struct Tensor<T> {} // expected-note {{type declared here}}
+
+struct _ExecutionContext {
+  func performBinaryOp<T>(
+    _ lhs: Tensor<T>,
+    _ rhs: Tensor<T>,
+    _ op: (MPSGraphTensor, MPSGraphTensor, String?) -> MPSGraphTensor
+  ) -> Tensor<T> {
+    fatalError()
+  }
+}
+
+public enum _RawTFEager {
+  public static func addV2<T>( // expected-error {{method cannot be declared public because its parameter uses an internal type}}
+    _ x: Tensor<T>
+  ) -> Tensor<T> {
+    return _ExecutionContext.performBinaryOp(x, x, MPSGraph.addition)
+    // expected-error@-1 {{instance member 'performBinaryOp' cannot be used on type '_ExecutionContext'; did you mean to use a value of this type instead?}}
+    // expected-error@-2 {{instance member 'addition' cannot be used on type 'MPSGraph'; did you mean to use a value of this type instead?}}
+    // expected-error@-3 {{cannot convert value of type '(MPSGraphTensor, MPSGraphTensor, String?) -> ()' to expected argument type '(MPSGraphTensor, MPSGraphTensor, String?) -> MPSGraphTensor'}}
+  }
+}


### PR DESCRIPTION
… mismatch

`RelabelArguments` cannot possibly diagnose this issue because there
are no argument lists in this case. Let's report contextual mismatch
instead.

Resolves: https://github.com/apple/swift/issues/59058

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
