### PR TITLE
Sema: Downgrade diagnostics about inheritance from a less available type when `-target-min-inlining-version min` is specified

### DIFF
--- a/test/attr/attr_inlinable_available.swift
+++ b/test/attr/attr_inlinable_available.swift
@@ -1290,6 +1290,11 @@ public enum NoAvailableEnumWithClasses {
   public class InheritsBetweenTargets: BetweenTargetsClass {} // expected-error {{'BetweenTargetsClass' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}} expected-note 2 {{add @available attribute to enclosing class}}
   public class InheritsAtDeploymentTarget: AtDeploymentTargetClass {} // expected-error {{'AtDeploymentTargetClass' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}} expected-note 2 {{add @available attribute to enclosing class}}
   public class InheritsAfterDeploymentTarget: AfterDeploymentTargetClass {} // expected-error {{'AfterDeploymentTargetClass' is only available in macOS 11 or newer}} expected-note 2 {{add @available attribute to enclosing class}}
+  
+  // As a special case, downgrade the less available superclasses diagnostic for
+  // `@usableFromInline` classes.
+  @usableFromInline
+  class UFIInheritsBetweenTargets: BetweenTargetsClass {} // expected-warning {{'BetweenTargetsClass' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}} expected-note 2 {{add @available attribute to enclosing class}}
 }
 
 @_spi(Private)


### PR DESCRIPTION
As a concession to source compatibility for API libraries, downgrade diagnostics about inheritance from a less available type when the following conditions are met:
1. The inherited type is only potentially unavailable before the deployment target.
2. The inheriting type is `@usableFromInline`.

Resolves rdar://92747826
