### PR TITLE
[SwiftSyntax] Fix assertion failure if regex literal was not terminated at the end of the file

### DIFF
--- a/lib/Parse/SyntaxRegexFallbackLexing.cpp
+++ b/lib/Parse/SyntaxRegexFallbackLexing.cpp
@@ -114,7 +114,7 @@ bool syntaxparse_lexRegexLiteral(
     case '\0': {
       if (Ptr - 1 == BufferEnd) {
         // Reached to EOF.
-        diagnose(BridgedDiagEngine, Ptr, diag::lex_regex_literal_unterminated);
+        diagnose(BridgedDiagEngine, Ptr - 1, diag::lex_regex_literal_unterminated);
         // In multi-line mode, we don't want to skip over what is likely
         // otherwise valid Swift code, so resume from the first newline.
         *InputPtr = firstNewline ? firstNewline : (Ptr - 1);

--- a/test/Syntax/Parser/unterminated_multiline_regex.swift
+++ b/test/Syntax/Parser/unterminated_multiline_regex.swift
@@ -1,0 +1,6 @@
+// RUN: %swift-syntax-parser-test -dump-diags %s | %FileCheck %s
+// CHECK: 7:1 Error: unterminated regex literal
+// CHECK: 1 error(s) 0 warnings(s) 0 note(s)
+
+#/
+unterminatedLiteral

--- a/test/Syntax/Parser/unterminated_regex.swift
+++ b/test/Syntax/Parser/unterminated_regex.swift
@@ -1,0 +1,6 @@
+// RUN: %swift-syntax-parser-test -dump-diags %s | %FileCheck %s
+// CHECK: 6:21 Error: unterminated regex literal
+// CHECK: 1 error(s) 0 warnings(s) 0 note(s)
+
+// IMPORTANT: This file must not contain a trailing newline
+/unterminatedLiteral


### PR DESCRIPTION
Fixes a SwiftSyntax parsing assertion failure if there is a regex literal at the end of the file. I.e. either a single line regex literal in a file without a trailing newline or a multi-line regex literal.

This does not crash in non-assert builds.