### PR TITLE
[5.7] add default values for SymbolGraphOptions

### DIFF
--- a/include/swift/SymbolGraphGen/SymbolGraphOptions.h
+++ b/include/swift/SymbolGraphGen/SymbolGraphOptions.h
@@ -21,33 +21,33 @@ namespace symbolgraphgen {
 
 struct SymbolGraphOptions {
   /// The directory to output the symbol graph JSON files.
-  StringRef OutputDir;
+  StringRef OutputDir = {};
 
   /// The target of the module.
-  llvm::Triple Target; 
+  llvm::Triple Target = {};
   /// Pretty-print the JSON with newlines and indentation.
-  bool PrettyPrint;
+  bool PrettyPrint = false;
 
   /// The minimum access level that symbols must have in order to be
   /// included in the graph.
-  AccessLevel MinimumAccessLevel;
+  AccessLevel MinimumAccessLevel = AccessLevel::Public;
 
   /// Emit members gotten through class inheritance or protocol default
   /// implementations with compound, "SYNTHESIZED" USRs.
-  bool EmitSynthesizedMembers;
+  bool EmitSynthesizedMembers = false;
   
   /// Whether to print informational messages when rendering
   /// a symbol graph.
-  bool PrintMessages;
+  bool PrintMessages = false;
   
   /// Whether to skip docs for symbols with compound, "SYNTHESIZED" USRs.
-  bool SkipInheritedDocs;
+  bool SkipInheritedDocs = false;
 
   /// Whether to emit symbols with SPI information.
-  bool IncludeSPISymbols;
+  bool IncludeSPISymbols = false;
 
   /// Whether to include documentation for clang nodes or not.
-  bool IncludeClangDocs;
+  bool IncludeClangDocs = false;
 };
 
 } // end namespace symbolgraphgen

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1297,6 +1297,7 @@ static void ParseSymbolGraphArgs(symbolgraphgen::SymbolGraphOptions &Opts,
   Opts.PrettyPrint = false;
   Opts.EmitSynthesizedMembers = true;
   Opts.PrintMessages = false;
+  Opts.IncludeClangDocs = false;
 }
 
 static bool ParseSearchPathArgs(SearchPathOptions &Opts,

--- a/test/SymbolGraph/ClangImporter/EmitWhileBuilding.swift
+++ b/test/SymbolGraph/ClangImporter/EmitWhileBuilding.swift
@@ -4,6 +4,7 @@
 // RUN: %{python} -m json.tool %t/EmitWhileBuilding.symbols.json %t/EmitWhileBuilding.formatted.symbols.json
 // RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.formatted.symbols.json
 // RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.formatted.symbols.json --check-prefix HEADER
+// RUN: %FileCheck %s --input-file %t/EmitWhileBuilding.formatted.symbols.json --check-prefix LOCATION
 
 // REQUIRES: objc_interop
 
@@ -28,3 +29,6 @@ public enum SwiftEnum {}
 // CHECK-NEXT:           "spelling": "SwiftEnum"
 // CHECK-NEXT:       }
 // CHECK-NEXT:   ],
+
+// ensure that the only nodes with a "location" field are the ones that came from Swift
+// LOCATION-COUNT-2: "location":


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/59037

**Explanation**: The `IncludeClangDocs` field of `SymbolGraphOptions` is uninitialized when generating symbol graphs during compilation. On Intel, this reads the value as `false`. However, on ARM (at least ARM macOS), this reads the value as `true`. This PR adds default values to `SymbolGraphOptions`, as well as explicitly sets `IncludeClangDocs` to false when generating symbol graphs during compilation.

**Scope**: Only has an effect when generating symbol graphs. Should not affect normal compilation.

**Bug**: rdar://93780666

**Risk**: Very low. The change sets values that were assumed to have already been set anyway. The values only have an effect when symbol graphs are requested; the only effect during normal compilation is the potential extra assignment when initializing the `CompilerInvocation`.

**Testing**: The lit test `SymbolGraph/ClangImporter/EmitWhileBuilding.swift` has been updated to ensure that Clang symbols do not emit a `location` field. This field was erroneously being emitted on ARM Macs. Existing automated tests still pass.