### PR TITLE
[5.7][TypeChecker] SE-0352: Require coercion if result type contains exist…

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6357,5 +6357,19 @@ ERROR(attr_incompatible_with_back_deploy,none,
       "'%0' cannot be applied to a back deployed %1",
       (DeclAttribute, DescriptiveDeclKind))
 
+//------------------------------------------------------------------------------
+// MARK: Implicit opening of existential types
+//------------------------------------------------------------------------------
+
+ERROR(result_requires_explicit_coercion,none,
+      "inferred result type %0 requires explicit coercion due to "
+      "loss of generic requirements",
+      (Type))
+
+NOTE(candidate_result_requires_explicit_coercion,none,
+     "inferred result type %0 requires explicit coercion due to "
+     "loss of generic requirements",
+     (Type))
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -386,6 +386,10 @@ enum class FixKind : uint8_t {
   /// Ignore a type mismatch while trying to infer generic parameter type
   /// from default expression.
   IgnoreDefaultExprTypeMismatch,
+
+  /// Coerce a result type of a call to a particular existential type
+  /// by adding `as any <#Type#>`.
+  AddExplicitExistentialCoercion,
 };
 
 class ConstraintFix {
@@ -2923,6 +2927,37 @@ public:
   static bool classof(const ConstraintFix *fix) {
     return fix->getKind() == FixKind::IgnoreDefaultExprTypeMismatch;
   }
+};
+
+class AddExplicitExistentialCoercion final : public ConstraintFix {
+  Type ErasedResultType;
+
+  AddExplicitExistentialCoercion(ConstraintSystem &cs, Type erasedResultTy,
+                                 ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::AddExplicitExistentialCoercion, locator),
+        ErasedResultType(erasedResultTy) {}
+
+public:
+  std::string getName() const override {
+    return "add explicit existential type coercion";
+  }
+
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  static bool
+  isRequired(ConstraintSystem &cs, Type resultTy,
+             ArrayRef<std::pair<TypeVariableType *, OpenedArchetypeType *>>
+                 openedExistentials,
+             ConstraintLocatorBuilder locator);
+
+  static bool isRequired(ConstraintSystem &cs, Type resultTy,
+                         llvm::function_ref<Optional<Type>(TypeVariableType *)>
+                             findExistentialType,
+                         ConstraintLocatorBuilder locator);
+
+  static AddExplicitExistentialCoercion *create(ConstraintSystem &cs,
+                                                Type resultTy,
+                                                ConstraintLocator *locator);
 };
 
 } // end namespace constraints

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -8104,3 +8104,54 @@ bool DefaultExprTypeMismatch::diagnoseAsError() {
 
   return true;
 }
+
+bool MissingExplicitExistentialCoercion::diagnoseAsError() {
+  auto diagnostic = emitDiagnostic(diag::result_requires_explicit_coercion,
+                                   ErasedResultType);
+  fixIt(diagnostic);
+  return true;
+}
+
+bool MissingExplicitExistentialCoercion::diagnoseAsNote() {
+  auto diagnostic = emitDiagnostic(
+      diag::candidate_result_requires_explicit_coercion, ErasedResultType);
+  fixIt(diagnostic);
+  return true;
+}
+
+bool MissingExplicitExistentialCoercion::fixItRequiresParens() const {
+  auto anchor = getAsExpr(getRawAnchor());
+
+  // If it's a member reference an an existential metatype, let's
+  // use the parent "call" expression.
+  if (auto *UDE = dyn_cast_or_null<UnresolvedDotExpr>(anchor))
+    anchor = findParentExpr(UDE);
+
+  if (!anchor)
+    return false;
+
+  const auto &solution = getSolution();
+  return llvm::any_of(
+      solution.OpenedExistentialTypes,
+      [&anchor](const auto &openedExistential) {
+        if (auto openedLoc = simplifyLocatorToAnchor(openedExistential.first)) {
+          return anchor == getAsExpr(openedLoc);
+        }
+        return false;
+      });
+}
+
+void MissingExplicitExistentialCoercion::fixIt(
+    InFlightDiagnostic &diagnostic) const {
+  bool requiresParens = fixItRequiresParens();
+
+  auto callRange = getSourceRange();
+
+  if (requiresParens)
+    diagnostic.fixItInsert(callRange.Start, "(");
+
+  auto printOpts = PrintOptions::forDiagnosticArguments();
+  diagnostic.fixItInsertAfter(callRange.End,
+                              "as " + ErasedResultType->getString(printOpts) +
+                                  (requiresParens ? ")" : ""));
+}

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2693,6 +2693,53 @@ public:
   bool diagnoseAsError() override;
 };
 
+/// Diagnose situations where inferring existential type for result of
+/// a call would result in loss of generic requirements.
+///
+/// \code
+/// protocol P {
+///  associatedtype A
+/// }
+///
+/// protocol Q {
+///  associatedtype B: P where B.A == Int
+/// }
+///
+/// func getB<T: Q>(_: T) -> T.B { ... }
+///
+/// func test(v: any Q) {
+///   let _ = getB(v) // <- produces `any P` which looses A == Int
+/// }
+/// \endcode
+class MissingExplicitExistentialCoercion final : public FailureDiagnostic {
+  Type ErasedResultType;
+
+public:
+  MissingExplicitExistentialCoercion(const Solution &solution,
+                                     Type erasedResultTy,
+                                     ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator),
+        ErasedResultType(resolveType(erasedResultTy)) {}
+
+  SourceRange getSourceRange() const override {
+    auto rawAnchor = getRawAnchor();
+    return {rawAnchor.getStartLoc(), rawAnchor.getEndLoc()};
+  }
+
+  bool diagnoseAsError() override;
+  bool diagnoseAsNote() override;
+
+private:
+  void fixIt(InFlightDiagnostic &diagnostic) const;
+
+  /// Determine whether the fix-it to add `as any ...` requires parens.
+  ///
+  /// Parens are required to avoid suppressing existential opening
+  /// if result of the call is passed as an argument to another call
+  /// that requires such opening.
+  bool fixItRequiresParens() const;
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -21,6 +21,8 @@
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/Type.h"
 #include "swift/AST/Types.h"
+#include "swift/AST/ExistentialLayout.h"
+#include "swift/AST/RequirementSignature.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Sema/ConstraintLocator.h"
 #include "swift/Sema/ConstraintSystem.h"
@@ -2136,4 +2138,238 @@ IgnoreDefaultExprTypeMismatch::create(ConstraintSystem &cs, Type argType,
                                       ConstraintLocator *locator) {
   return new (cs.getAllocator())
       IgnoreDefaultExprTypeMismatch(cs, argType, paramType, locator);
+}
+
+bool AddExplicitExistentialCoercion::diagnose(const Solution &solution,
+                                              bool asNote) const {
+  MissingExplicitExistentialCoercion failure(solution, ErasedResultType,
+                                             getLocator());
+  return failure.diagnose(asNote);
+}
+
+bool AddExplicitExistentialCoercion::isRequired(
+    ConstraintSystem &cs, Type resultTy,
+    llvm::function_ref<Optional<Type>(TypeVariableType *)> findExistentialType,
+    ConstraintLocatorBuilder locator) {
+  using ExistentialTypeFinder =
+      llvm::function_ref<Optional<Type>(TypeVariableType *)>;
+
+  struct CoercionChecker : public TypeWalker {
+    bool RequiresCoercion = false;
+
+    ConstraintSystem &cs;
+    ExistentialTypeFinder GetExistentialType;
+
+    CoercionChecker(ConstraintSystem &cs,
+                    ExistentialTypeFinder getExistentialType)
+        : cs(cs), GetExistentialType(getExistentialType) {}
+
+    Action walkToTypePre(Type componentTy) override {
+      // In cases where result references a member type, we need to check
+      // whether such type would is resolved to concrete or not.
+      if (auto *member = componentTy->getAs<DependentMemberType>()) {
+        auto memberBaseTy = getBaseTypeOfDependentMemberChain(member);
+
+        auto typeVar = memberBaseTy->getAs<TypeVariableType>();
+        if (!typeVar)
+          return Action::SkipChildren;
+
+        // If the base is an opened existential type, let's see whether
+        // erase would produce an existential in this case and if so,
+        // we need to check whether any requirements are going to be lost
+        // in process.
+
+        auto existentialType = GetExistentialType(typeVar);
+        if (!existentialType)
+          return Action::SkipChildren;
+
+        auto erasedMemberTy = typeEraseOpenedExistentialReference(
+            Type(member), *existentialType, typeVar, TypePosition::Covariant);
+
+        // If result is an existential type and the base has `where` clauses
+        // associated with its associated types, the call needs a coercion.
+        if (erasedMemberTy->isExistentialType() &&
+            hasConstrainedAssociatedTypes(member, *existentialType)) {
+          RequiresCoercion = true;
+          return Action::Stop;
+        }
+
+        return Action::SkipChildren;
+      }
+
+      // The case where there is a direct access to opened existential type
+      // e.g. `$T` or `[$T]`.
+      if (auto *typeVar = componentTy->getAs<TypeVariableType>()) {
+        if (auto existentialType = GetExistentialType(typeVar)) {
+          RequiresCoercion |= hasAnyConstrainedAssociatedTypes(
+              (*existentialType)->getExistentialLayout());
+          return RequiresCoercion ? Action::Stop : Action::SkipChildren;
+        }
+      }
+
+      return Action::Continue;
+    }
+
+  private:
+    /// Check whether the given member type has any of its associated
+    /// types constrained by requirements associated with the given
+    /// existential type.
+    static bool hasConstrainedAssociatedTypes(DependentMemberType *member,
+                                              Type existentialTy) {
+      auto layout = existentialTy->getExistentialLayout();
+      for (auto *protocol : layout.getProtocols()) {
+        auto requirementSig = protocol->getRequirementSignature();
+        if (hasConstrainedAssociatedTypes(member,
+                                          requirementSig.getRequirements()))
+          return true;
+      }
+      return false;
+    }
+
+    /// Check whether the given member type has any of its associated
+    /// types constrained by the given requirement set.
+    static bool
+    hasConstrainedAssociatedTypes(DependentMemberType *member,
+                                  ArrayRef<Requirement> requirements) {
+      for (const auto &req : requirements) {
+        switch (req.getKind()) {
+        case RequirementKind::Superclass:
+        case RequirementKind::Conformance:
+        case RequirementKind::Layout: {
+          if (isAnchoredOn(req.getFirstType(), member->getAssocType()))
+            return true;
+          break;
+        }
+
+        case RequirementKind::SameType: {
+          auto lhsTy = req.getFirstType();
+          auto rhsTy = req.getSecondType();
+
+          if (isAnchoredOn(lhsTy, member->getAssocType()) ||
+              isAnchoredOn(rhsTy, member->getAssocType()))
+            return true;
+
+          break;
+        }
+        }
+      }
+
+      return false;
+    }
+
+    /// Check whether any of the protocols mentioned in the given
+    /// existential layout have constraints associated with their
+    /// associated types via a `where` clause, for example:
+    /// `associatedtype A: P where A.B == Int`
+    static bool hasAnyConstrainedAssociatedTypes(ExistentialLayout layout) {
+      for (auto *protocol : layout.getProtocols()) {
+        auto requirementSig = protocol->getRequirementSignature();
+        for (const auto &req : requirementSig.getRequirements()) {
+          switch (req.getKind()) {
+          case RequirementKind::Conformance:
+          case RequirementKind::Layout:
+          case RequirementKind::Superclass: {
+            if (getMemberChainDepth(req.getFirstType()) > 1)
+              return true;
+            break;
+          }
+
+          case RequirementKind::SameType:
+            auto lhsTy = req.getFirstType();
+            auto rhsTy = req.getSecondType();
+
+            if (getMemberChainDepth(lhsTy) > 1 ||
+                getMemberChainDepth(rhsTy) > 1)
+              return true;
+
+            break;
+          }
+        }
+      }
+      return false;
+    }
+
+    /// Check whether the given type is a dependent member type and
+    /// is anchored on the given associated type e.g. type is `A.B.C`
+    /// and associated type is `A.B`.
+    static bool isAnchoredOn(Type type, AssociatedTypeDecl *assocTy,
+                             unsigned depth = 0) {
+      if (auto *member = type->getAs<DependentMemberType>()) {
+        if (member->getAssocType() == assocTy)
+          return depth > 0;
+
+        return isAnchoredOn(member->getBase(), assocTy, depth + 1);
+      }
+
+      return false;
+    }
+
+    static unsigned getMemberChainDepth(Type type, unsigned currDepth = 0) {
+      if (auto *memberTy = type->getAs<DependentMemberType>())
+        return getMemberChainDepth(memberTy->getBase(), currDepth + 1);
+      return currDepth;
+    }
+
+    static Type getBaseTypeOfDependentMemberChain(DependentMemberType *member) {
+      if (!member->getBase())
+        return member;
+
+      auto base = member->getBase();
+
+      if (auto *DMT = base->getAs<DependentMemberType>())
+        return getBaseTypeOfDependentMemberChain(DMT);
+
+      return base;
+    }
+  };
+
+  // First, let's check whether coercion is already there.
+  if (auto *anchor = getAsExpr(locator.getAnchor())) {
+    // If this is erasure related to `Self`, let's look through
+    // the call, if any.
+    if (isa<UnresolvedDotExpr>(anchor)) {
+      auto parentExpr = cs.getParentExpr(anchor);
+      if (parentExpr && isa<CallExpr>(parentExpr))
+        anchor = parentExpr;
+    }
+
+    auto *parent = cs.getParentExpr(anchor);
+    // Support both `as` and `as!` coercions.
+    if (parent &&
+        (isa<CoerceExpr>(parent) || isa<ForcedCheckedCastExpr>(parent)))
+      return false;
+  }
+
+  CoercionChecker check(cs, findExistentialType);
+  resultTy.walk(check);
+
+  return check.RequiresCoercion;
+}
+
+bool AddExplicitExistentialCoercion::isRequired(
+    ConstraintSystem &cs, Type resultTy,
+    ArrayRef<std::pair<TypeVariableType *, OpenedArchetypeType *>>
+        openedExistentials,
+    ConstraintLocatorBuilder locator) {
+  return isRequired(
+      cs, resultTy,
+      [&](TypeVariableType *typeVar) -> Optional<Type> {
+        auto opened =
+            llvm::find_if(openedExistentials, [&typeVar](const auto &entry) {
+              return typeVar == entry.first;
+            });
+
+        if (opened == openedExistentials.end())
+          return None;
+
+        return opened->second->getExistentialType();
+      },
+      locator);
+}
+
+AddExplicitExistentialCoercion *
+AddExplicitExistentialCoercion::create(ConstraintSystem &cs, Type resultTy,
+                                       ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      AddExplicitExistentialCoercion(cs, resultTy, locator);
 }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1479,13 +1479,14 @@ shouldOpenExistentialCallArgument(
     return None;
 
   // An argument expression that explicitly coerces to an existential
-  // disables the implicit opening of the existential.
+  // disables the implicit opening of the existential unless it's
+  // wrapped in parens.
   if (argExpr) {
     if (auto argCast = dyn_cast<ExplicitCastExpr>(
             argExpr->getSemanticsProvidingExpr())) {
       if (auto typeRepr = argCast->getCastTypeRepr()) {
         if (auto toType = cs.getType(typeRepr)) {
-          if (toType->isAnyExistentialType())
+          if (!isa<ParenExpr>(argExpr) && toType->isAnyExistentialType())
             return None;
         }
       }
@@ -11438,6 +11439,18 @@ ConstraintSystem::simplifyApplicableFnConstraint(
             result2, opened.second->getExistentialType(), opened.first,
             TypePosition::Covariant);
       }
+
+      // If result type has any erased existential types it requires explicit
+      // `as` coercion.
+      if (AddExplicitExistentialCoercion::isRequired(
+              *this, func2->getResult(), openedExistentials, locator)) {
+        if (!shouldAttemptFixes())
+          return SolutionKind::Error;
+
+        if (recordFix(AddExplicitExistentialCoercion::create(
+                *this, result2, getConstraintLocator(locator))))
+          return SolutionKind::Error;
+      }
     }
 
     // The result types are equivalent.
@@ -13065,6 +13078,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::DropAsyncAttribute:
   case FixKind::AllowSwiftToCPointerConversion:
   case FixKind::AllowTupleLabelMismatch:
+  case FixKind::AddExplicitExistentialCoercion:
     llvm_unreachable("handled elsewhere");
   }
 

--- a/test/decl/protocol/existential_member_accesses_self_assoctype.swift
+++ b/test/decl/protocol/existential_member_accesses_self_assoctype.swift
@@ -694,7 +694,7 @@ protocol MiscTestsProto {
 do {
   func miscTests(_ arg: any MiscTestsProto) {
     var r: any Sequence & IteratorProtocol = arg.getR()
-    r.makeIterator() // expected-warning {{result of call to 'makeIterator()' is unused}}
+    r.makeIterator() // expected-error {{inferred result type 'any IteratorProtocol' requires explicit coercion due to loss of generic requirements}} {{19-19=as any IteratorProtocol}}
     r.next() // expected-warning {{result of call to 'next()' is unused}}
     r.nonexistent() // expected-error {{value of type 'any IteratorProtocol & Sequence' has no member 'nonexistent'}}
 


### PR DESCRIPTION
…ential(s) that would loose generic requirements

Cherry-pick of https://github.com/apple/swift/pull/42559

---

Implements SE-0352 revision - require explicit `as` coercion when existential
erasure loses information.

For example:

```swift
protocol P {
  associatedtype A
}

protocol Q {
  associatedtype B: P where B.A == Int
}

func getB<T: Q>(_: T) -> T.B { ... }

func test(v: any Q) {
  let _ = getB(v) // <- produces `any P` which loses A == Int
}
```

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
