### PR TITLE
[5.7][CSClosure] Fix crash in `fallthrough` statement checking

### DIFF
--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -1394,7 +1394,15 @@ private:
       }
 
       auto caseStmt = cast<CaseStmt>(rawCase.get<Stmt *>());
-      visitCaseStmt(caseStmt);
+      // Body of the `case` statement can contain a `fallthrough`
+      // statement that requires both source and destination
+      // `case` preambles to be type-checked, so bodies of `case`
+      // statements should be visited after preambles.
+      visitCaseStmtPreamble(caseStmt);
+    }
+
+    for (auto *caseStmt : switchStmt->getCases()) {
+      visitCaseStmtBody(caseStmt);
 
       // Check restrictions on '@unknown'.
       if (caseStmt->hasUnknownAttr()) {
@@ -1421,7 +1429,7 @@ private:
     return doStmt;
   }
 
-  ASTNode visitCaseStmt(CaseStmt *caseStmt) {
+  void visitCaseStmtPreamble(CaseStmt *caseStmt) {
     // Translate the patterns and guard expressions for each case label item.
     for (auto &caseItem : caseStmt->getMutableCaseLabelItems()) {
       SolutionApplicationTarget caseTarget(&caseItem, closure);
@@ -1437,11 +1445,16 @@ private:
           solution.getType(prev)->mapTypeOutOfContext());
       expected->setInterfaceType(type);
     }
+  }
 
-    // Translate the body.
+  void visitCaseStmtBody(CaseStmt *caseStmt) {
     auto *newBody = visit(caseStmt->getBody()).get<Stmt *>();
     caseStmt->setBody(cast<BraceStmt>(newBody));
+  }
 
+  ASTNode visitCaseStmt(CaseStmt *caseStmt) {
+    visitCaseStmtPreamble(caseStmt);
+    visitCaseStmtBody(caseStmt);
     return caseStmt;
   }
 

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -404,3 +404,23 @@ func test_type_finder_doesnt_walk_into_inner_closures() {
     return x
   }
 }
+
+// rdar://93796211 (issue#59035) - crash during solution application to fallthrough statement
+func test_fallthrough_stmt() {
+  {
+    var collector: [Void] = []
+    for _: Void in [] {
+      switch (() as Void?, ()) {
+      case (let a?, let b):
+        // expected-warning@-1 {{constant 'b' inferred to have type '()', which may be unexpected}}
+        // expected-note@-2 {{add an explicit type annotation to silence this warning}}
+        collector.append(a)
+        fallthrough
+      case (nil,    let b):
+        // expected-warning@-1 {{constant 'b' inferred to have type '()', which may be unexpected}}
+        // expected-note@-2 {{add an explicit type annotation to silence this warning}}
+        collector.append(b)
+      }
+    }
+  }()
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/59059

--- 

`fallthrough` requires both source and destination `case`
"preambles" be type-checked before it could be validated,
which means that solution application for `case` statements
in a `switch` has to be split in two - preamble first and
bodies afterwards.

Resolves: https://github.com/apple/swift/issues/59035
Resolves: rdar://93796211
(cherry picked from commit 4e9992c26108886a03089030e4496ea9b434cb54)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
