### PR TITLE
[SE-0338] Implement Sendable checking for SE-0338

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4657,6 +4657,7 @@ ERROR(isolated_parameter_not_actor,none,
 
 WARNING(non_sendable_param_type,none,
         "non-sendable type %0 %select{passed in call to %4 %2 %3|"
+        "exiting %4 context in call to non-isolated %2 %3|"
         "passed in implicitly asynchronous call to %4 %2 %3|"
         "in parameter of %4 %2 %3 satisfying protocol requirement|"
         "in parameter of %4 overriding %2 %3|"
@@ -4668,6 +4669,7 @@ WARNING(non_sendable_call_param_type,none,
         (Type, bool, ActorIsolation))
 WARNING(non_sendable_result_type,none,
         "non-sendable type %0 returned by %select{call to %4 %2 %3|"
+        "call from %4 context to non-isolated %2 %3|"
         "implicitly asynchronous call to %4 %2 %3|"
         "%4 %2 %3 satisfying protocol requirement|"
         "%4 overriding %2 %3|"
@@ -4680,6 +4682,7 @@ WARNING(non_sendable_call_result_type,none,
 WARNING(non_sendable_property_type,none,
         "non-sendable type %0 in %select{"
         "%select{asynchronous access to %5 %1 %2|"
+        "asynchronous access from %5 context to non-isolated %1 %2|"
         "implicitly asynchronous access to %5 %1 %2|"
         "conformance of %5 %1 %2 to protocol requirement|"
         "%5 overriding %1 %2|"

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4658,8 +4658,8 @@ ERROR(isolated_parameter_not_actor,none,
 WARNING(non_sendable_param_type,none,
         "non-sendable type %0 %select{passed in call to %4 %2 %3|"
         "passed in implicitly asynchronous call to %4 %2 %3|"
-        "in parameter of %4 %2 %3 satisfying non-isolated protocol "
-        "requirement|"
+        "in parameter of %4 %2 %3 satisfying protocol requirement|"
+        "in parameter of %4 overriding %2 %3|"
         "in parameter of %4 '@objc' %2 %3}1 cannot cross actor boundary",
         (Type, unsigned, DescriptiveDeclKind, DeclName, ActorIsolation))
 WARNING(non_sendable_call_param_type,none,
@@ -4669,7 +4669,8 @@ WARNING(non_sendable_call_param_type,none,
 WARNING(non_sendable_result_type,none,
         "non-sendable type %0 returned by %select{call to %4 %2 %3|"
         "implicitly asynchronous call to %4 %2 %3|"
-        "%4 %2 %3 satisfying non-isolated protocol requirement|"
+        "%4 %2 %3 satisfying protocol requirement|"
+        "%4 overriding %2 %3|"
         "%4 '@objc' %2 %3}1 cannot cross actor boundary",
         (Type, unsigned, DescriptiveDeclKind, DeclName, ActorIsolation))
 WARNING(non_sendable_call_result_type,none,
@@ -4680,7 +4681,8 @@ WARNING(non_sendable_property_type,none,
         "non-sendable type %0 in %select{"
         "%select{asynchronous access to %5 %1 %2|"
         "implicitly asynchronous access to %5 %1 %2|"
-        "conformance of %5 %1 %2 to non-isolated protocol requirement|"
+        "conformance of %5 %1 %2 to protocol requirement|"
+        "%5 overriding %1 %2|"
         "%5 '@objc' %1 %2}4|captured local %1 %2}3 cannot "
         "cross %select{actor|task}3 boundary",
         (Type, DescriptiveDeclKind, DeclName, bool, unsigned, ActorIsolation))

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -75,6 +75,9 @@ enum class SendableCheckReason {
   /// A reference to an actor from outside that actor.
   CrossActor,
 
+  /// Exiting an actor to non-isolated async code.
+  ExitingActor,
+
   /// A synchronous operation that was "promoted" to an asynchronous one
   /// because it was out of the actor's domain.
   SynchronousAsAsync,
@@ -271,7 +274,8 @@ public:
 /// \returns true if an problem was detected, false otherwise.
 bool diagnoseNonSendableTypesInReference(
     ConcreteDeclRef declRef, const DeclContext *fromDC, SourceLoc loc,
-    SendableCheckReason refKind);
+    SendableCheckReason refKind,
+    Optional<ActorIsolation> knownIsolation = None);
 
 /// Produce a diagnostic for a missing conformance to Sendable.
 void diagnoseMissingSendableConformance(

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -83,6 +83,9 @@ enum class SendableCheckReason {
   /// actor isolation.
   Conformance,
 
+  /// An override of a function.
+  Override,
+
   /// The declaration is being exposed to Objective-C.
   ObjC,
 };

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2955,6 +2955,10 @@ bool ConformanceChecker::checkActorIsolation(
     requirementIsolation = requirementIsolation.subst(subs);
   }
 
+  SourceLoc loc = witness->getLoc();
+  if (loc.isInvalid())
+    loc = Conformance->getLoc();
+
   auto refResult = ActorReferenceResult::forReference(
       getConcreteWitness(), witness->getLoc(), DC, None, None,
       None, requirementIsolation);
@@ -2972,7 +2976,8 @@ bool ConformanceChecker::checkActorIsolation(
     return false;
 
   case ActorReferenceResult::ExitsActorToNonisolated:
-    // FIXME: SE-0338 would diagnose this.
+    diagnoseNonSendableTypesInReference(
+        getConcreteWitness(), DC, loc, SendableCheckReason::Conformance);
     return false;
 
   case ActorReferenceResult::EntersActor:
@@ -3016,10 +3021,6 @@ bool ConformanceChecker::checkActorIsolation(
 
   // If we aren't missing anything, do a Sendable check and move on.
   if (!missingOptions) {
-    SourceLoc loc = witness->getLoc();
-    if (loc.isInvalid())
-      loc = Conformance->getLoc();
-
     // FIXME: Disable Sendable checking when the witness is an initializer
     // that is explicitly marked nonisolated.
     if (isa<ConstructorDecl>(witness) &&

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -223,7 +223,7 @@ protocol AsyncProto {
 }
 
 extension A1: AsyncProto {
-  func asyncMethod(_: NotConcurrent) async { } // expected-warning{{non-sendable type 'NotConcurrent' in parameter of actor-isolated instance method 'asyncMethod' satisfying non-isolated protocol requirement cannot cross actor boundary}}
+  func asyncMethod(_: NotConcurrent) async { } // expected-warning{{non-sendable type 'NotConcurrent' in parameter of actor-isolated instance method 'asyncMethod' satisfying protocol requirement cannot cross actor boundary}}
 }
 
 protocol MainActorProto {
@@ -232,7 +232,7 @@ protocol MainActorProto {
 
 class SomeClass: MainActorProto {
   @SomeGlobalActor
-  func asyncMainMethod(_: NotConcurrent) async { } // expected-warning{{non-sendable type 'NotConcurrent' in parameter of global actor 'SomeGlobalActor'-isolated instance method 'asyncMainMethod' satisfying non-isolated protocol requirement cannot cross actor boundary}}
+  func asyncMainMethod(_: NotConcurrent) async { } // expected-warning{{non-sendable type 'NotConcurrent' in parameter of global actor 'SomeGlobalActor'-isolated instance method 'asyncMainMethod' satisfying protocol requirement cannot cross actor boundary}}
 }
 
 // ----------------------------------------------------------------------

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -4,6 +4,7 @@
 
 @available(SwiftStdlib 5.1, *)
 struct NS1 { }
+// expected-note@-1 2{{consider making struct 'NS1' conform to the 'Sendable' protocol}}
 
 @available(SwiftStdlib 5.1, *)
 @available(*, unavailable)
@@ -69,9 +70,20 @@ public protocol MyProto {
 }
 
 @available(SwiftStdlib 5.1, *)
+func nonisolatedAsyncFunc1(_: NS1) async { }
+
+@available(SwiftStdlib 5.1, *)
+func nonisolatedAsyncFunc2() async -> NS1 { NS1() }
+
+@available(SwiftStdlib 5.1, *)
 public actor MyActor: MyProto {
   public func foo<F>(aFoo: F) async where F: Sendable { }
   public func bar<B>(aBar: B) async where B: Sendable { }
+
+  func g(ns1: NS1) async {
+    await nonisolatedAsyncFunc1(ns1) // expected-warning{{non-sendable type 'NS1' exiting actor-isolated context in call to non-isolated global function 'nonisolatedAsyncFunc1' cannot cross actor boundary}}
+    _ = await nonisolatedAsyncFunc2() // expected-warning{{non-sendable type 'NS1' returned by call from actor-isolated context to non-isolated global function 'nonisolatedAsyncFunc2()' cannot cross actor boundary}}
+  }
 }
 
 // rdar://82452688 - make sure sendable checking doesn't fire for a capture

--- a/test/Concurrency/sendable_conformance_checking.swift
+++ b/test/Concurrency/sendable_conformance_checking.swift
@@ -40,9 +40,9 @@ protocol AsyncProtocolWithNotSendable {
 // actor's domain.
 @available(SwiftStdlib 5.1, *)
 actor A3: AsyncProtocolWithNotSendable {
-  func f() async -> NotSendable { NotSendable() } // expected-warning{{non-sendable type 'NotSendable' returned by actor-isolated instance method 'f()' satisfying non-isolated protocol requirement cannot cross actor boundary}}
+  func f() async -> NotSendable { NotSendable() } // expected-warning{{non-sendable type 'NotSendable' returned by actor-isolated instance method 'f()' satisfying protocol requirement cannot cross actor boundary}}
 
-  var prop: NotSendable { // expected-warning{{non-sendable type 'NotSendable' in conformance of actor-isolated property 'prop' to non-isolated protocol requirement cannot cross actor boundary}}
+  var prop: NotSendable { // expected-warning{{non-sendable type 'NotSendable' in conformance of actor-isolated property 'prop' to protocol requirement cannot cross actor boundary}}
     get async {
       NotSendable()
     }
@@ -53,9 +53,9 @@ actor A3: AsyncProtocolWithNotSendable {
 // actor's domain.
 @available(SwiftStdlib 5.1, *)
 actor A4: AsyncProtocolWithNotSendable {
-  func f() -> NotSendable { NotSendable() } // expected-warning{{non-sendable type 'NotSendable' returned by actor-isolated instance method 'f()' satisfying non-isolated protocol requirement cannot cross actor boundary}}
+  func f() -> NotSendable { NotSendable() } // expected-warning{{non-sendable type 'NotSendable' returned by actor-isolated instance method 'f()' satisfying protocol requirement cannot cross actor boundary}}
 
-  var prop: NotSendable { // expected-warning{{non-sendable type 'NotSendable' in conformance of actor-isolated property 'prop' to non-isolated protocol requirement cannot cross actor boundary}}
+  var prop: NotSendable { // expected-warning{{non-sendable type 'NotSendable' in conformance of actor-isolated property 'prop' to protocol requirement cannot cross actor boundary}}
     get {
       NotSendable()
     }
@@ -98,9 +98,9 @@ protocol AsyncThrowingProtocolWithNotSendable {
 // actor's domain.
 @available(SwiftStdlib 5.1, *)
 actor A7: AsyncThrowingProtocolWithNotSendable {
-  func f() async -> NotSendable { NotSendable() } // expected-warning{{non-sendable type 'NotSendable' returned by actor-isolated instance method 'f()' satisfying non-isolated protocol requirement cannot cross actor boundary}}
+  func f() async -> NotSendable { NotSendable() } // expected-warning{{non-sendable type 'NotSendable' returned by actor-isolated instance method 'f()' satisfying protocol requirement cannot cross actor boundary}}
 
-  var prop: NotSendable { // expected-warning{{non-sendable type 'NotSendable' in conformance of actor-isolated property 'prop' to non-isolated protocol requirement cannot cross actor boundary}}
+  var prop: NotSendable { // expected-warning{{non-sendable type 'NotSendable' in conformance of actor-isolated property 'prop' to protocol requirement cannot cross actor boundary}}
     get async {
       NotSendable()
     }
@@ -111,9 +111,9 @@ actor A7: AsyncThrowingProtocolWithNotSendable {
 // actor's domain.
 @available(SwiftStdlib 5.1, *)
 actor A8: AsyncThrowingProtocolWithNotSendable {
-  func f() -> NotSendable { NotSendable() } // expected-warning{{non-sendable type 'NotSendable' returned by actor-isolated instance method 'f()' satisfying non-isolated protocol requirement cannot cross actor boundary}}
+  func f() -> NotSendable { NotSendable() } // expected-warning{{non-sendable type 'NotSendable' returned by actor-isolated instance method 'f()' satisfying protocol requirement cannot cross actor boundary}}
 
-  var prop: NotSendable { // expected-warning{{non-sendable type 'NotSendable' in conformance of actor-isolated property 'prop' to non-isolated protocol requirement cannot cross actor boundary}}
+  var prop: NotSendable { // expected-warning{{non-sendable type 'NotSendable' in conformance of actor-isolated property 'prop' to protocol requirement cannot cross actor boundary}}
     get {
       NotSendable()
     }

--- a/test/Concurrency/sendable_conformance_checking.swift
+++ b/test/Concurrency/sendable_conformance_checking.swift
@@ -2,7 +2,7 @@
 // REQUIRES: concurrency
 
 @available(SwiftStdlib 5.1, *)
-class NotSendable { // expected-note 8{{class 'NotSendable' does not conform to the 'Sendable' protocol}}
+class NotSendable { // expected-note 9{{class 'NotSendable' does not conform to the 'Sendable' protocol}}
 }
 
 @available(SwiftStdlib 5.1, *)
@@ -13,6 +13,8 @@ extension NotSendable: Sendable { }
 protocol IsolatedWithNotSendableRequirements: Actor {
   func f() -> NotSendable
   var prop: NotSendable { get }
+
+  func fAsync() async -> NotSendable
 }
 
 // Okay, everything is isolated the same way
@@ -20,6 +22,7 @@ protocol IsolatedWithNotSendableRequirements: Actor {
 actor A1: IsolatedWithNotSendableRequirements {
   func f() -> NotSendable { NotSendable() }
   var prop: NotSendable { NotSendable() }
+  func fAsync() async -> NotSendable { NotSendable() }
 }
 
 // Okay, sendable checking occurs when calling through the protocol
@@ -28,6 +31,9 @@ actor A1: IsolatedWithNotSendableRequirements {
 actor A2: IsolatedWithNotSendableRequirements {
   nonisolated func f() -> NotSendable { NotSendable() }
   nonisolated var prop: NotSendable { NotSendable() }
+
+  nonisolated func fAsync() async -> NotSendable { NotSendable() }
+  // expected-warning@-1{{non-sendable type 'NotSendable' returned by nonisolated instance method 'fAsync()' satisfying protocol requirement cannot cross actor boundary}}
 }
 
 @available(SwiftStdlib 5.1, *)

--- a/test/Concurrency/sendable_override_checking.swift
+++ b/test/Concurrency/sendable_override_checking.swift
@@ -1,0 +1,28 @@
+// RUN: %target-typecheck-verify-swift
+// REQUIRES: concurrency
+
+@available(SwiftStdlib 5.1, *)
+class NotSendable { // expected-note 2{{class 'NotSendable' does not conform to the 'Sendable' protocol}}
+}
+
+@available(SwiftStdlib 5.1, *)
+@available(*, unavailable)
+extension NotSendable: Sendable { }
+
+@available(SwiftStdlib 5.1, *)
+class Super {
+  func f(_: NotSendable) async { }
+  @MainActor func g1(_: NotSendable) { }
+  @MainActor func g2(_: NotSendable) async { }
+}
+
+@available(SwiftStdlib 5.1, *)
+class Sub: Super {
+  @MainActor override func f(_: NotSendable) async { }
+  // expected-warning@-1{{non-sendable type 'NotSendable' in parameter of main actor-isolated overriding instance method 'f' cannot cross actor boundary}}
+
+  nonisolated override func g1(_: NotSendable) { } // okay, synchronous
+
+  nonisolated override func g2(_: NotSendable) async { }
+  // expected-warning@-1{{non-sendable type 'NotSendable' in parameter of nonisolated overriding instance method 'g2' cannot cross actor boundary}}
+}

--- a/test/Concurrency/unsafe_inherit_executor.swift
+++ b/test/Concurrency/unsafe_inherit_executor.swift
@@ -21,7 +21,7 @@ struct A {
 }
 
 
-class NonSendableObject {
+class NonSendableObject { // expected-note{{class 'NonSendableObject' does not conform to the 'Sendable' protocol}}
   var property = 0
 }
 
@@ -31,7 +31,7 @@ func useNonSendable(object: NonSendableObject) async {}
 actor MyActor {
   var object = NonSendableObject()
   func foo() async {
-    // This should not be diagnosed when we implement SE-0338 checking.
+    // expected-warning@+1{{non-sendable type 'NonSendableObject' exiting actor-isolated context in call to non-isolated global function 'useNonSendable(object:)' cannot cross actor boundary}}
     await useNonSendable(object: self.object)
   }
 }

--- a/test/Distributed/distributed_protocol_isolation.swift
+++ b/test/Distributed/distributed_protocol_isolation.swift
@@ -128,7 +128,7 @@ protocol Server {
 }
 actor MyServer : Server {
   // expected-note@+1{{consider making generic parameter 'Message' conform to the 'Sendable' protocol}} {{29-29=, Sendable}}
-  func send<Message: Codable>(message: Message) throws -> String { "" }  // expected-warning{{non-sendable type 'Message' in parameter of actor-isolated instance method 'send(message:)' satisfying non-isolated protocol requirement cannot cross actor boundary}}
+  func send<Message: Codable>(message: Message) throws -> String { "" }  // expected-warning{{non-sendable type 'Message' in parameter of actor-isolated instance method 'send(message:)' satisfying protocol requirement cannot cross actor boundary}}
 }
 
 protocol AsyncThrowsAll {


### PR DESCRIPTION
Implement most of the remaining places where `Sendable` checking is missing, but is required by either SE-0302 or SE-0338, including:

* When exiting an actor-isolated context to a non-isolated async context
* Overriding a function with a different actor isolation
* Witnessing a requirement with a function/property that has different actor isolation than the requirement

Tracked by rdar://93930900