### PR TITLE
[5.7][Test] Do not load string processing when recovery is disabled

### DIFF
--- a/test/Index/skip-loaded-internal.swift
+++ b/test/Index/skip-loaded-internal.swift
@@ -3,10 +3,10 @@
 // RUN: mkdir -p %t/Frameworks/lib2.framework/Modules/lib2.swiftmodule
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -emit-module -emit-module-source-info -module-name lib2 -o %t/Frameworks/lib2.framework/Modules/lib2.swiftmodule/%module-target-triple.swiftmodule %t/lib2.swift
-// RUN: %target-swift-frontend -emit-module -emit-module-source-info -module-name lib -o %t/Frameworks/lib.framework/Modules/lib.swiftmodule/%module-target-triple.swiftmodule %t/lib.swift -Fsystem %t/Frameworks
+// RUN: %target-swift-frontend -emit-module -emit-module-source-info -module-name lib2 -o %t/Frameworks/lib2.framework/Modules/lib2.swiftmodule/%module-target-triple.swiftmodule %t/lib2.swift -disable-experimental-string-processing
+// RUN: %target-swift-frontend -emit-module -emit-module-source-info -module-name lib -o %t/Frameworks/lib.framework/Modules/lib.swiftmodule/%module-target-triple.swiftmodule %t/lib.swift -Fsystem %t/Frameworks -disable-experimental-string-processing
 
-// RUN: %target-swift-frontend -typecheck -index-system-modules -index-ignore-stdlib -index-store-path %t/idx -Fsystem %t/Frameworks %t/main.swift -disable-deserialization-recovery
+// RUN: %target-swift-frontend -typecheck -index-system-modules -index-ignore-stdlib -index-store-path %t/idx -Fsystem %t/Frameworks %t/main.swift -disable-deserialization-recovery -disable-experimental-string-processing
 
 //--- main.swift
 import lib


### PR DESCRIPTION
Cherry-picks aa93af21beffac49e16411abbc7e2521d7839d3f (https://github.com/apple/swift/pull/59087) to avoid a potential erroneous test failure.

-----

This test specifically disables serialization recovery, but that can
cause issues when loading the experimental string processing library. We
don't use it in the test, so just disable it for now.