### PR TITLE
Handle ParamDecls and VarDecls in Argument Matching Diagnostics

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4896,9 +4896,13 @@ bool ConstraintSystem::repairFailures(
           if (!(overload && overload->choice.isDecl()))
             return true;
 
-          if (!getParameterList(overload->choice.getDecl())
-                   ->get(applyLoc->getParamIdx())
-                   ->getTypeOfDefaultExpr())
+          // Ignore decls that don't have meaningful parameter lists - this
+          // matches variables and parameters with function types.
+          auto *paramList = getParameterList(overload->choice.getDecl());
+          if (!paramList)
+            return true;
+
+          if (!paramList->get(applyLoc->getParamIdx())->getTypeOfDefaultExpr())
             return true;
         }
       }

--- a/test/Constraints/argument_matching.swift
+++ b/test/Constraints/argument_matching.swift
@@ -1782,3 +1782,10 @@ func testExtraTrailingClosure() {
   func qux(x: () -> Void, y: () -> Void, z: () -> Void) {} // expected-note {{'qux(x:y:z:)' declared here}}
   qux() {} m: {} y: {} n: {} z: {} o: {} // expected-error@:6 {{extra trailing closures at positions #2, #4, #6 in call}}
 }
+
+// rdar://93922410 - argument-to-parameter doesn't handle applies of ParamDecls
+func rdar93922410(_ completion: (Int?) -> Void) { // expected-note {{'completion' declared here}}
+  _ = {
+    return completion() // expected-error {{missing argument for parameter #1 in call}}
+  }
+}


### PR DESCRIPTION
These don't produce meaningful ParameterLists for this analysis to
consider. Bail instead of crashing.

rdar://93922410
