### PR TITLE
[AST Mangler] Don't mangle marker protocols in retroactive conformances.

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1686,6 +1686,9 @@ void ASTMangler::appendRetroactiveConformances(SubstitutionMap subMap,
 
   unsigned numProtocolRequirements = 0;
   for (auto conformance : subMap.getConformances()) {
+    if (conformance.isInvalid())
+      continue;
+
     if (conformance.getRequirement()->isMarkerProtocol())
       continue;
 

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1637,6 +1637,10 @@ static bool isRetroactiveConformance(const RootProtocolConformance *root) {
     return false; // self-conformances are never retroactive. nor are builtin.
   }
 
+  // Don't consider marker protocols at all.
+  if (conformance->getProtocol()->isMarkerProtocol())
+    return false;
+
   return conformance->isRetroactive();
 }
 
@@ -1682,6 +1686,9 @@ void ASTMangler::appendRetroactiveConformances(SubstitutionMap subMap,
 
   unsigned numProtocolRequirements = 0;
   for (auto conformance : subMap.getConformances()) {
+    if (conformance.getRequirement()->isMarkerProtocol())
+      continue;
+
     SWIFT_DEFER {
       ++numProtocolRequirements;
     };

--- a/test/IRGen/marker_protocol.swift
+++ b/test/IRGen/marker_protocol.swift
@@ -57,9 +57,14 @@ public func markerInDictionary() -> Any {
 // CHECK: swiftcc void @"$s15marker_protocol7genericyyxAA1PRzlF"(%swift.opaque* noalias nocapture %0, %swift.type* %T)
 public func generic<T: P>(_: T) { }
 
+public struct GenericType<T: Hashable & P> { }
+
+// CHECK-LABEL: @"$s15marker_protocol11testGeneric1i5arrayySi_SaySiGtF"(
 public func testGeneric(i: Int, array: [Int]) {
   generic(i)
   generic(array)
+  // CHECK: __swift_instantiateConcreteTypeFromMangledName{{.*}}$s15marker_protocol11GenericTypeVySaySiGGmMD
+  print(GenericType<[Int]>.self)
 }
 
 // Forming an existential involving a marker protocol would crash the compiler


### PR DESCRIPTION
Fixes a crash in IR generation, where we would try to emit metadata
referencing a marker protocol, rdar://92285294 and rdar://89942373 / SR-15919 / #58180
