### PR TITLE
[Runtime] Don't try to demangle unprefixed untrusted names. Remove operator new/delete hackery.

### DIFF
--- a/stdlib/public/runtime/Heap.cpp
+++ b/stdlib/public/runtime/Heap.cpp
@@ -133,30 +133,3 @@ static void swift_slowDeallocImpl(void *ptr, size_t alignMask) {
 void swift::swift_slowDealloc(void *ptr, size_t bytes, size_t alignMask) {
   swift_slowDeallocImpl(ptr, alignMask);
 }
-
-#if defined(__APPLE__) && defined(__MACH__) && SWIFT_STDLIB_HAS_DARWIN_LIBMALLOC
-// On Darwin, define our own, hidden operator new/delete implementations. We
-// don't want to pick up any overrides that come from other code, but we also
-// don't want to expose our overrides to any other code. We can't do this
-// directly in C++, as the compiler has an implicit prototype with default
-// visibility. However, if we implement them as C functions using the C++
-// mangled names, the compiler accepts them without complaint, and the linker
-// still links all internal uses with these overrides.
-
-__attribute__((visibility(("hidden")))) extern "C" void *_Znwm(size_t size) {
-  return swift_slowAlloc(size, MALLOC_ALIGN_MASK);
-}
-
-__attribute__((visibility(("hidden")))) extern "C" void _ZdlPv(void *ptr) {
-  swift_slowDeallocImpl(ptr, MALLOC_ALIGN_MASK);
-}
-
-__attribute__((visibility(("hidden")))) extern "C" void *_Znam(size_t size) {
-  return swift_slowAlloc(size, MALLOC_ALIGN_MASK);
-}
-
-__attribute__((visibility(("hidden")))) extern "C" void _ZdaPv(void *ptr) {
-  swift_slowDeallocImpl(ptr, MALLOC_ALIGN_MASK);
-}
-
-#endif


### PR DESCRIPTION
The operator new/delete overrides aren't working out due to inconsistent inlining of std::string creation/deletion. We can end up creating one with the global new but destroying it with our local delete. If they aren't compatible, this crashes.

Instead, avoid problematic new/delete activity coming from lookup of ObjC class names. Names passed to getObjCClassByMangledName must either have a standard mangled name prefix, start with a digit (for unprefixed mangled names) or use the convenience dot syntax. Check for those up front and immediately reject anything else. This has the added bonus of failing more quickly for non-Swift names.

rdar://93863030