### PR TITLE
[SwiftCompilerSources][build] Fix build with `SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT=NO`

### DIFF
--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -83,6 +83,10 @@ function(add_swift_compiler_modules_library name)
     list(APPEND swift_compile_options "-O" "-cross-module-optimization")
   endif()
 
+  if(NOT SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT)
+    list(APPEND swift_compile_options "-Xfrontend" "-disable-legacy-type-info")
+  endif()
+
   get_bootstrapping_path(build_dir ${CMAKE_CURRENT_BINARY_DIR} "${ALS_BOOTSTRAPPING}")
 
   set(sdk_option "")
@@ -230,7 +234,7 @@ else()
         list(APPEND b1_deps copy-libstdcxx-modulemap-bootstrapping1 copy-libstdcxx-header-bootstrapping1)
       endif()
     endif()
-    if(SWIFT_HOST_VARIANT_SDK IN_LIST SWIFT_DARWIN_PLATFORMS)
+    if(SWIFT_HOST_VARIANT_SDK IN_LIST SWIFT_DARWIN_PLATFORMS AND SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT)
       set(platform ${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR})
       set(compatibility_libs
           "swiftCompatibility50-${platform}"


### PR DESCRIPTION
This allows building SwiftCompilerSources with stdlib compatibility disabled.

Fixes errors like this:
```
[699/716] Building swift module Basic
FAILED: bootstrapping1/SwiftCompilerSources/Basic.o /Users/egorzh/Builds.noindex/swift/swift-release/bootstrapping1/SwiftCompilerSources/Basic.o
cd /Volumes/Projects/swift/swift/SwiftCompilerSources && /Users/egorzh/Builds.noindex/swift/swift-release/bootstrapping0/bin/swiftc -c -o /Users/egorzh/Builds.noindex/swift/swift-release/bootstrapping1/SwiftCompilerSources/Basic.o -sdk /Applications/Xcodes/XcodeSummit.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.0.sdk -target x86_64-apple-macosx10.9 -module-name Basic -emit-module -emit-module-path /Users/egorzh/Builds.noindex/swift/swift-release/bootstrapping1/SwiftCompilerSources/Basic.swiftmodule -parse-as-library /Volumes/Projects/swift/swift/SwiftCompilerSources/Sources/Basic/SourceLoc.swift /Volumes/Projects/swift/swift/SwiftCompilerSources/Sources/Basic/Utils.swift -wmo -Xfrontend -validate-tbd-against-ir=none -Xfrontend -enable-cxx-interop -Xcc -UIBOutlet -Xcc -UIBAction -Xcc -UIBInspectable -O -cross-module-optimization -Xcc -I -Xcc /Volumes/Projects/swift/swift/include -Xcc -I -Xcc /Users/egorzh/Builds.noindex/swift/swift-release/include -I /Users/egorzh/Builds.noindex/swift/swift-release/bootstrapping1/SwiftCompilerSources
<unknown>:0: error: IR generation failure: Cannot read legacy layout file at '/Users/egorzh/Builds.noindex/swift/swift-release/bootstrapping0/lib/swift/macosx/layouts-x86_64.yaml'
ninja: build stopped: subcommand failed.
```