### PR TITLE
[5.7][CSSimplify] Disfavor choices that have injected `callAsFunction`

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11402,6 +11402,7 @@ ConstraintSystem::simplifyApplicableFnConstraint(
             FunctionType::get(trailingClosureTypes, callAsFunctionResultTy,
                               FunctionType::ExtInfo());
 
+        increaseScore(SK_DisfavoredOverload);
         // Form an unsolved constraint to apply trailing closures to a
         // callable type produced by `.init`. This constraint would become
         // active when `callableType` is bound.

--- a/test/Constraints/result_builder_callAsFunction.swift
+++ b/test/Constraints/result_builder_callAsFunction.swift
@@ -1,0 +1,36 @@
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.15 -swift-version 5 -debug-constraints > %t.log 2>&1
+// RUN: %FileCheck %s < %t.log
+
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+protocol View {}
+protocol Callable {}
+
+struct EmptyView : View {}
+
+@resultBuilder struct ViewBuilder {
+  static func buildBlock<Content>(_ content: Content) -> Content where Content : View { fatalError() }
+}
+
+extension Callable {
+  func callAsFunction<T: View>(@ViewBuilder _: () -> T) -> some View { EmptyView() }
+}
+
+struct MyView<Content> : View {
+  init(v: Int, @ViewBuilder _: () -> Content) {}
+}
+
+extension MyView : Callable where Content == EmptyView {
+  init(v: Int) {}
+}
+
+// CHECK: (overload set choice binding $T6 := (Int) -> MyView<{{.*}}>)
+// CHECK-NEXT: (increasing score due to disfavored overload)
+// CHECK-NEXT: (solution is worse than the best solution)
+
+func test() -> some View {
+  return MyView(v: 42) {
+    return EmptyView()
+  }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/58953

---

Ambiguities like:

```
struct S {
  init(v: Int) {}
  init(v: Int, _: () -> Void) {}

  func callAsFunction(_: () -> Void) {}
}

S(v: 42) {
}
```

Should always be resolved in favor of choice that doesn't require
injection of `.callAsFunction`, so let's try to avoid solving if
such an overload has already been found.

(cherry picked from commit 7898b5a0883f66efdcd6b14d66d8bca09e742d4e)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
