### PR TITLE
tests: unmark test as XFAIL on Windows

### DIFF
--- a/test/DebugInfo/local-vars.swift.gyb
+++ b/test/DebugInfo/local-vars.swift.gyb
@@ -2,9 +2,6 @@
 // test only verifies that the variables show up in the debug info at
 // all. There are other tests testing liveness and representation.
 
-// rdar://problem/57611302
-// XFAIL: OS=windows-msvc
-
 // RUN: %gyb %s -o %t.swift
 // RUN: %target-swift-frontend %t.swift -g -emit-ir -o - | %FileCheck %t.swift
 // RUN: %target-swift-frontend %t.swift -g -c -o %t.o


### PR DESCRIPTION
This passes on the rebranch.  Unmark it as XFAIL on Windows to get the test suite passing.