### PR TITLE
[5.7] [stdlib] Mark NFD and NFC as SPI

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -183,6 +183,7 @@ set(SWIFTLIB_ESSENTIAL
   UnicodeParser.swift
   UnicodeScalarProperties.swift
   CharacterProperties.swift # ORDER DEPENDENCY: UnicodeScalarProperties.swift
+  UnicodeSPI.swift
   Unmanaged.swift
   UnmanagedOpaqueString.swift
   UnmanagedString.swift

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -50,6 +50,7 @@
     "UnicodeParser.swift",
     "UnicodeScalar.swift",
     "UnicodeScalarProperties.swift",
+    "UnicodeSPI.swift",
     "UnavailableStringAPIs.swift",
     "UnmanagedOpaqueString.swift",
     "UnmanagedString.swift",

--- a/stdlib/public/core/NFC.swift
+++ b/stdlib/public/core/NFC.swift
@@ -13,12 +13,12 @@
 import SwiftShims
 
 extension Unicode {
-  internal struct _NFC<S: StringProtocol> {
+  internal struct _InternalNFC<S: StringProtocol> {
     let base: S
   }
 }
 
-extension Unicode._NFC {
+extension Unicode._InternalNFC {
   internal struct Iterator {
     var buffer = Unicode._NormDataBuffer()
 
@@ -30,11 +30,11 @@ extension Unicode._NFC {
     // we continue to try and compose following scalars with this composee.
     var composee: Unicode.Scalar? = nil
 
-    var iterator: Unicode._NFD<S>.Iterator
+    var iterator: Unicode._InternalNFD<S>.Iterator
   }
 }
 
-extension Unicode._NFC.Iterator: IteratorProtocol {
+extension Unicode._InternalNFC.Iterator: IteratorProtocol {
   internal func compose(
     _ x: Unicode.Scalar,
     and y: Unicode.Scalar
@@ -210,14 +210,14 @@ extension Unicode._NFC.Iterator: IteratorProtocol {
   }
 }
 
-extension Unicode._NFC: Sequence {
+extension Unicode._InternalNFC: Sequence {
   internal func makeIterator() -> Iterator {
-    Iterator(iterator: base._nfd.makeIterator())
+    Iterator(iterator: base._internalNFD.makeIterator())
   }
 }
 
 extension StringProtocol {
-  internal var _nfc: Unicode._NFC<Self> {
-    Unicode._NFC(base: self)
+  internal var _internalNFC: Unicode._InternalNFC<Self> {
+    Unicode._InternalNFC(base: self)
   }
 }

--- a/stdlib/public/core/NFD.swift
+++ b/stdlib/public/core/NFD.swift
@@ -11,12 +11,12 @@
 //===----------------------------------------------------------------------===//
 
 extension Unicode {
-  internal struct _NFD<S: StringProtocol> {
-    let base: S
+  internal struct _InternalNFD<S: StringProtocol> {
+    let base: S.UnicodeScalarView
   }
 }
 
-extension Unicode._NFD {
+extension Unicode._InternalNFD {
   internal struct Iterator {
     var buffer = Unicode._NormDataBuffer()
 
@@ -28,7 +28,7 @@ extension Unicode._NFD {
   }
 }
 
-extension Unicode._NFD.Iterator: IteratorProtocol {
+extension Unicode._InternalNFD.Iterator: IteratorProtocol {
   internal mutating func decompose(
     _ scalar: Unicode.Scalar,
     with normData: Unicode._NormData
@@ -165,17 +165,17 @@ extension Unicode._NFD.Iterator: IteratorProtocol {
   }
 }
 
-extension Unicode._NFD: Sequence {
+extension Unicode._InternalNFD: Sequence {
   internal func makeIterator() -> Iterator {
     Iterator(
-      index: base.unicodeScalars.startIndex,
-      unicodeScalars: base.unicodeScalars
+      index: base.startIndex,
+      unicodeScalars: base
     )
   }
 }
 
 extension StringProtocol {
-  internal var _nfd: Unicode._NFD<Self> {
-    Unicode._NFD(base: self)
+  internal var _internalNFD: Unicode._InternalNFD<Self> {
+    Unicode._InternalNFD(base: unicodeScalars)
   }
 }

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -988,7 +988,7 @@ extension _StringGutsSlice {
       }
     }
 
-    for scalar in substring._nfc {
+    for scalar in substring._internalNFC {
       try scalar.withUTF8CodeUnits {
         for byte in $0 {
           try f(byte)

--- a/stdlib/public/core/StringComparison.swift
+++ b/stdlib/public/core/StringComparison.swift
@@ -333,8 +333,8 @@ extension _StringGutsSlice {
     with other: _StringGutsSlice,
     expecting: _StringComparisonResult
   ) -> Bool {
-    var iter1 = Substring(self)._nfc.makeIterator()
-    var iter2 = Substring(other)._nfc.makeIterator()
+    var iter1 = Substring(self)._internalNFC.makeIterator()
+    var iter2 = Substring(other)._internalNFC.makeIterator()
 
     var scalar1: Unicode.Scalar? = nil
     var scalar2: Unicode.Scalar? = nil

--- a/stdlib/public/core/UnicodeSPI.swift
+++ b/stdlib/public/core/UnicodeSPI.swift
@@ -1,0 +1,125 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// Unicode.NFD
+//===----------------------------------------------------------------------===//
+
+extension Unicode {
+  @_spi(_Unicode)
+  @available(SwiftStdlib 5.7, *)
+  public struct _NFD {
+    let base: Substring.UnicodeScalarView
+  }
+}
+
+@available(SwiftStdlib 5.7, *)
+extension Unicode._NFD {
+  @_spi(_Unicode)
+  @available(SwiftStdlib 5.7, *)
+  public struct Iterator {
+    var base: Unicode._InternalNFD<Substring>.Iterator
+  }
+}
+
+@available(SwiftStdlib 5.7, *)
+extension Unicode._NFD.Iterator: IteratorProtocol {
+  @_spi(_Unicode)
+  @available(SwiftStdlib 5.7, *)
+  public mutating func next() -> Unicode.Scalar? {
+    base.next()?.scalar
+  }
+}
+
+@available(SwiftStdlib 5.7, *)
+extension Unicode._NFD: Sequence {
+  @_spi(_Unicode)
+  @available(SwiftStdlib 5.7, *)
+  public func makeIterator() -> Iterator {
+    Iterator(base: Unicode._InternalNFD(base: base).makeIterator())
+  }
+}
+
+extension String {
+  @_spi(_Unicode)
+  @available(SwiftStdlib 5.7, *)
+  public var _nfd: Unicode._NFD {
+    Unicode._NFD(base: self[...].unicodeScalars)
+  }
+}
+
+extension Substring {
+  @_spi(_Unicode)
+  @available(SwiftStdlib 5.7, *)
+  public var _nfd: Unicode._NFD {
+    Unicode._NFD(base: unicodeScalars)
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Unicode.NFC
+//===----------------------------------------------------------------------===//
+
+extension Unicode {
+  @_spi(_Unicode)
+  @available(SwiftStdlib 5.7, *)
+  public struct _NFC {
+    let base: Substring.UnicodeScalarView
+  }
+}
+
+@available(SwiftStdlib 5.7, *)
+extension Unicode._NFC {
+  @_spi(_Unicode)
+  @available(SwiftStdlib 5.7, *)
+  public struct Iterator {
+    var base: Unicode._InternalNFC<Substring>.Iterator
+  }
+}
+
+@available(SwiftStdlib 5.7, *)
+extension Unicode._NFC.Iterator: IteratorProtocol {
+  @_spi(_Unicode)
+  @available(SwiftStdlib 5.7, *)
+  public mutating func next() -> Unicode.Scalar? {
+    base.next()
+  }
+}
+
+@available(SwiftStdlib 5.7, *)
+extension Unicode._NFC: Sequence {
+  @_spi(_Unicode)
+  @available(SwiftStdlib 5.7, *)
+  public func makeIterator() -> Iterator {
+    Iterator(
+      base: Unicode._InternalNFC<Substring>.Iterator(
+        iterator: Unicode._InternalNFD<Substring>(base: base).makeIterator()
+      )
+    )
+  }
+}
+
+extension String {
+  @_spi(_Unicode)
+  @available(SwiftStdlib 5.7, *)
+  public var _nfc: Unicode._NFC {
+    Unicode._NFC(base: self[...].unicodeScalars)
+  }
+}
+
+extension Substring {
+  @_spi(_Unicode)
+  @available(SwiftStdlib 5.7, *)
+  public var _nfc: Unicode._NFC {
+    Unicode._NFC(base: unicodeScalars)
+  }
+}


### PR DESCRIPTION
Cherry pick of: https://github.com/apple/swift/pull/42124

This adds a `String._nfc` and `String._nfd` iterator as `@_spi(_Unicode)` for libraries like `_StringProcessing` to use.