### PR TITLE
Simplify unit-one-sourcefile-remapped.swift round trip testing

### DIFF
--- a/test/Index/Store/unit-one-sourcefile-remapped.swift
+++ b/test/Index/Store/unit-one-sourcefile-remapped.swift
@@ -20,4 +20,3 @@
 // ROUNDTRIP: --------
 // ROUNDTRIP: main-path: SOURCE_DIR{{/|\\}}test{{/|\\}}Index{{/|\\}}Store{{/|\\}}unit-one-sourcefile-remapped.swift
 // ROUNDTRIP-NOT: work-dir: REMAPPED_OUT_DIR
-// ROUNDTRIP-NOT: out-file: REMAPPED_OUT_DIR


### PR DESCRIPTION
No longer test the round trip remapping for the output file - we'll be
changing the reader to preserve the canonical output file path instead
of converting it back to local. Once all of the changes are complete, we
can swap this to verify it is canonical, but indexstore-db will also
check this with its own tests.
