### PR TITLE
[interop][SwiftToCxx] Gather initial struct layout information and em…

### DIFF
--- a/include/swift/IRGen/IRABIDetailsProvider.h
+++ b/include/swift/IRGen/IRABIDetailsProvider.h
@@ -1,0 +1,53 @@
+//===--- IRABIDetailsProvider.h - Get ABI details for decls -----*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_IRGEN_IRABIDETAILSPROVIDER_H
+#define SWIFT_IRGEN_IRABIDETAILSPROVIDER_H
+
+#include "llvm/ADT/Optional.h"
+#include <stdint.h>
+#include <utility>
+
+namespace swift {
+
+class IRGenOptions;
+class ModuleDecl;
+class NominalTypeDecl;
+
+class IRABIDetailsProviderImpl;
+
+/// Provides access to the IRGen-based queries that can be performed on
+/// declarations to get their various ABI details.
+class IRABIDetailsProvider {
+public:
+  IRABIDetailsProvider(ModuleDecl &mod, const IRGenOptions &opts);
+  ~IRABIDetailsProvider();
+
+  using SizeType = uint64_t;
+
+  struct SizeAndAlignment {
+    SizeType size;
+    SizeType alignment;
+  };
+
+  /// Returns the size and alignment for the given type, or \c None if the type
+  /// is not a fixed layout type.
+  llvm::Optional<SizeAndAlignment>
+  getTypeSizeAlignment(const NominalTypeDecl *TD);
+
+private:
+  std::unique_ptr<IRABIDetailsProviderImpl> impl;
+};
+
+} // namespace swift
+
+#endif

--- a/include/swift/PrintAsClang/PrintAsClang.h
+++ b/include/swift/PrintAsClang/PrintAsClang.h
@@ -18,22 +18,24 @@
 #include "swift/AST/Identifier.h"
 
 namespace swift {
-  class ModuleDecl;
-  class ValueDecl;
+class IRGenOptions;
+class ModuleDecl;
+class ValueDecl;
 
-  /// Print the exposed declarations in a module into a Clang header.
-  ///
-  /// The Objective-C compatible declarations are printed into a block that
-  /// ensures that those declarations are only usable when the header is
-  /// compiled in Objective-C mode.
-  /// The C++ compatible declarations are printed into a block that ensures
-  /// that those declarations are only usable when the header is compiled in
-  /// C++ mode.
-  ///
-  /// Returns true on error.
-  bool printAsClangHeader(raw_ostream &out, ModuleDecl *M,
-                          StringRef bridgingHeader,
-                          bool ExposePublicDeclsInClangHeader);
+/// Print the exposed declarations in a module into a Clang header.
+///
+/// The Objective-C compatible declarations are printed into a block that
+/// ensures that those declarations are only usable when the header is
+/// compiled in Objective-C mode.
+/// The C++ compatible declarations are printed into a block that ensures
+/// that those declarations are only usable when the header is compiled in
+/// C++ mode.
+///
+/// Returns true on error.
+bool printAsClangHeader(raw_ostream &out, ModuleDecl *M,
+                        StringRef bridgingHeader,
+                        bool ExposePublicDeclsInClangHeader,
+                        const IRGenOptions &irGenOpts);
 }
 
 #endif

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -180,13 +180,14 @@ static bool writeSIL(SILModule &SM, const PrimarySpecificPaths &PSPs,
 /// \see swift::printAsClangHeader
 static bool printAsClangHeaderIfNeeded(StringRef outputPath, ModuleDecl *M,
                                        StringRef bridgingHeader,
-                                       bool ExposePublicDeclsInClangHeader) {
+                                       bool ExposePublicDeclsInClangHeader,
+                                       const IRGenOptions &irGenOpts) {
   if (outputPath.empty())
     return false;
   return withOutputFile(
       M->getDiags(), outputPath, [&](raw_ostream &out) -> bool {
         return printAsClangHeader(out, M, bridgingHeader,
-                                  ExposePublicDeclsInClangHeader);
+                                  ExposePublicDeclsInClangHeader, irGenOpts);
       });
 }
 
@@ -859,7 +860,7 @@ static bool emitAnyWholeModulePostTypeCheckSupplementaryOutputs(
     hadAnyError |= printAsClangHeaderIfNeeded(
         Invocation.getClangHeaderOutputPathForAtMostOnePrimary(),
         Instance.getMainModule(), BridgingHeaderPathForPrint,
-        opts.ExposePublicDeclsInClangHeader);
+        opts.ExposePublicDeclsInClangHeader, Invocation.getIRGenOptions());
   }
 
   // Only want the header if there's been any errors, ie. there's not much

--- a/lib/IRGen/CMakeLists.txt
+++ b/lib/IRGen/CMakeLists.txt
@@ -40,6 +40,7 @@ add_swift_host_library(swiftIRGen STATIC
   GenTuple.cpp
   GenType.cpp
   GenValueWitness.cpp
+  IRABIDetailsProvider.cpp
   IRGen.cpp
   IRGenDebugInfo.cpp
   IRGenFunction.cpp

--- a/lib/IRGen/IRABIDetailsProvider.cpp
+++ b/lib/IRGen/IRABIDetailsProvider.cpp
@@ -1,0 +1,67 @@
+//===--- IRABIDetailsProvider.cpp - Get ABI details for decls ---*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/IRGen/IRABIDetailsProvider.h"
+#include "FixedTypeInfo.h"
+#include "GenType.h"
+#include "IRGen.h"
+#include "IRGenModule.h"
+
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/IRGenOptions.h"
+#include "swift/AST/Types.h"
+#include "swift/SIL/SILModule.h"
+
+using namespace swift;
+using namespace irgen;
+
+namespace swift {
+
+class IRABIDetailsProviderImpl {
+public:
+  IRABIDetailsProviderImpl(ModuleDecl &mod, const IRGenOptions &opts)
+      : typeConverter(mod),
+        silMod(SILModule::createEmptyModule(&mod, typeConverter, silOpts)),
+        IRGen(opts, *silMod), IGM(IRGen, IRGen.createTargetMachine()) {}
+
+  llvm::Optional<IRABIDetailsProvider::SizeAndAlignment>
+  getTypeSizeAlignment(const NominalTypeDecl *TD) {
+    auto *TI = &IGM.getTypeInfoForUnlowered(TD->getDeclaredTypeInContext());
+    auto *fixedTI = dyn_cast<FixedTypeInfo>(TI);
+    if (!fixedTI)
+      return None;
+    return IRABIDetailsProvider::SizeAndAlignment{
+        fixedTI->getFixedSize().getValue(),
+        fixedTI->getFixedAlignment().getValue()};
+  }
+
+private:
+  Lowering::TypeConverter typeConverter;
+  // Default silOptions are sufficient, as we don't need to generated SIL.
+  SILOptions silOpts;
+  std::unique_ptr<SILModule> silMod;
+  IRGenerator IRGen;
+  IRGenModule IGM;
+};
+
+} // namespace swift
+
+IRABIDetailsProvider::IRABIDetailsProvider(ModuleDecl &mod,
+                                           const IRGenOptions &opts)
+    : impl(std::make_unique<IRABIDetailsProviderImpl>(mod, opts)) {}
+
+IRABIDetailsProvider::~IRABIDetailsProvider() {}
+
+llvm::Optional<IRABIDetailsProvider::SizeAndAlignment>
+IRABIDetailsProvider::getTypeSizeAlignment(const NominalTypeDecl *TD) {
+  return impl->getTypeSizeAlignment(TD);
+}

--- a/lib/PrintAsClang/CMakeLists.txt
+++ b/lib/PrintAsClang/CMakeLists.txt
@@ -6,11 +6,13 @@ add_swift_host_library(swiftPrintAsClang STATIC
   PrimitiveTypeMapping.cpp
   PrintAsClang.cpp
   PrintClangFunction.cpp
-  PrintClangValueType.cpp)
+  PrintClangValueType.cpp
+  SwiftToClangInteropContext.cpp)
 target_link_libraries(swiftPrintAsClang PRIVATE
   swiftAST
   swiftClangImporter
   swiftFrontend
-  swiftIDE)
+  swiftIDE
+  swiftIRGen)
 
 set_swift_llvm_is_available(swiftPrintAsClang)

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -332,7 +332,7 @@ private:
     if (outputLang != OutputLanguageMode::Cxx)
       return;
     // FIXME: Print struct's availability.
-    ClangValueTypePrinter printer(os);
+    ClangValueTypePrinter printer(os, owningPrinter.interopContext);
     printer.printStructDecl(SD);
   }
 

--- a/lib/PrintAsClang/DeclAndTypePrinter.h
+++ b/lib/PrintAsClang/DeclAndTypePrinter.h
@@ -27,6 +27,7 @@ namespace swift {
 
 class PrimitiveTypeMapping;
 class ValueDecl;
+class SwiftToClangInteropContext;
 
 /// Responsible for printing a Swift Decl or Type in Objective-C, to be
 /// included in a Swift module's ObjC compatibility header.
@@ -43,6 +44,7 @@ private:
   raw_ostream &prologueOS;
   const DelayedMemberSet &delayedMembers;
   PrimitiveTypeMapping &typeMapping;
+  SwiftToClangInteropContext &interopContext;
   AccessLevel minRequiredAccess;
   OutputLanguageMode outputLang;
 
@@ -56,11 +58,12 @@ private:
 public:
   DeclAndTypePrinter(ModuleDecl &mod, raw_ostream &out, raw_ostream &prologueOS,
                      DelayedMemberSet &delayed,
-                     PrimitiveTypeMapping &typeMapping, AccessLevel access,
-                     OutputLanguageMode outputLang)
+                     PrimitiveTypeMapping &typeMapping,
+                     SwiftToClangInteropContext &interopContext,
+                     AccessLevel access, OutputLanguageMode outputLang)
       : M(mod), os(out), prologueOS(prologueOS), delayedMembers(delayed),
-        typeMapping(typeMapping), minRequiredAccess(access),
-        outputLang(outputLang) {}
+        typeMapping(typeMapping), interopContext(interopContext),
+        minRequiredAccess(access), outputLang(outputLang) {}
 
   /// Returns true if \p VD should be included in a compatibility header for
   /// the options the printer was constructed with.

--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -131,10 +131,11 @@ class ModuleWriter {
 public:
   ModuleWriter(raw_ostream &os, raw_ostream &prologueOS,
                llvm::SmallPtrSetImpl<ImportModuleTy> &imports, ModuleDecl &mod,
-               AccessLevel access, OutputLanguageMode outputLang)
+               SwiftToClangInteropContext &interopContext, AccessLevel access,
+               OutputLanguageMode outputLang)
       : os(os), imports(imports), M(mod),
-        printer(M, os, prologueOS, delayedMembers, typeMapping, access,
-                outputLang),
+        printer(M, os, prologueOS, delayedMembers, typeMapping, interopContext,
+                access, outputLang),
         outputLangMode(outputLang) {}
 
   /// Returns true if we added the decl's module to the import set, false if
@@ -638,26 +639,25 @@ static AccessLevel getRequiredAccess(const ModuleDecl &M) {
   return M.isExternallyConsumed() ? AccessLevel::Public : AccessLevel::Internal;
 }
 
-void
-swift::printModuleContentsAsObjC(raw_ostream &os,
-                                 llvm::SmallPtrSetImpl<ImportModuleTy> &imports,
-                                 ModuleDecl &M) {
+void swift::printModuleContentsAsObjC(
+    raw_ostream &os, llvm::SmallPtrSetImpl<ImportModuleTy> &imports,
+    ModuleDecl &M, SwiftToClangInteropContext &interopContext) {
   llvm::raw_null_ostream prologueOS;
-  ModuleWriter(os, prologueOS, imports, M, getRequiredAccess(M),
+  ModuleWriter(os, prologueOS, imports, M, interopContext, getRequiredAccess(M),
                OutputLanguageMode::ObjC)
       .write();
 }
 
 void swift::printModuleContentsAsCxx(
     raw_ostream &os, llvm::SmallPtrSetImpl<ImportModuleTy> &imports,
-    ModuleDecl &M) {
+    ModuleDecl &M, SwiftToClangInteropContext &interopContext) {
   std::string moduleContentsBuf;
   llvm::raw_string_ostream moduleOS{moduleContentsBuf};
   std::string modulePrologueBuf;
   llvm::raw_string_ostream prologueOS{modulePrologueBuf};
 
-  ModuleWriter(moduleOS, prologueOS, imports, M, getRequiredAccess(M),
-               OutputLanguageMode::Cxx)
+  ModuleWriter(moduleOS, prologueOS, imports, M, interopContext,
+               getRequiredAccess(M), OutputLanguageMode::Cxx)
       .write();
 
   // FIXME: refactor.

--- a/lib/PrintAsClang/ModuleContentsWriter.h
+++ b/lib/PrintAsClang/ModuleContentsWriter.h
@@ -24,6 +24,7 @@ namespace clang {
 
 namespace swift {
 class ModuleDecl;
+class SwiftToClangInteropContext;
 
 using ImportModuleTy = PointerUnion<ModuleDecl*, const clang::Module*>;
 
@@ -31,13 +32,15 @@ using ImportModuleTy = PointerUnion<ModuleDecl*, const clang::Module*>;
 /// \p imports along the way.
 void printModuleContentsAsObjC(raw_ostream &os,
                                llvm::SmallPtrSetImpl<ImportModuleTy> &imports,
-                               ModuleDecl &M);
+                               ModuleDecl &M,
+                               SwiftToClangInteropContext &interopContext);
 
 /// Prints the declarations of \p M to \p os in C++ language mode and collects
 /// imports in \p imports along the way.
 void printModuleContentsAsCxx(raw_ostream &os,
                               llvm::SmallPtrSetImpl<ImportModuleTy> &imports,
-                              ModuleDecl &M);
+                              ModuleDecl &M,
+                              SwiftToClangInteropContext &interopContext);
 
 } // end namespace swift
 

--- a/lib/PrintAsClang/PrintClangValueType.h
+++ b/lib/PrintAsClang/PrintClangValueType.h
@@ -19,12 +19,15 @@
 namespace swift {
 
 class StructDecl;
+class SwiftToClangInteropContext;
 
 /// Responsible for printing a Swift struct or enum decl or in C or C++ mode, to
 /// be included in a Swift module's generated clang header.
 class ClangValueTypePrinter {
 public:
-  ClangValueTypePrinter(raw_ostream &os) : os(os) {}
+  ClangValueTypePrinter(raw_ostream &os,
+                        SwiftToClangInteropContext &interopContext)
+      : os(os), interopContext(interopContext) {}
 
   /// Print the C struct thunk or the C++ class definition that
   /// corresponds to the given structure declaration.
@@ -32,6 +35,7 @@ public:
 
 private:
   raw_ostream &os;
+  SwiftToClangInteropContext &interopContext;
 };
 
 } // end namespace swift

--- a/lib/PrintAsClang/SwiftToClangInteropContext.cpp
+++ b/lib/PrintAsClang/SwiftToClangInteropContext.cpp
@@ -1,0 +1,28 @@
+//===--- SwiftToClangInteropContext.cpp - Interop context -------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "SwiftToClangInteropContext.h"
+#include "swift/IRGen/IRABIDetailsProvider.h"
+
+using namespace swift;
+
+SwiftToClangInteropContext::SwiftToClangInteropContext(
+    ModuleDecl &mod, const IRGenOptions &irGenOpts)
+    : mod(mod), irGenOpts(irGenOpts) {}
+
+SwiftToClangInteropContext::~SwiftToClangInteropContext() {}
+
+IRABIDetailsProvider &SwiftToClangInteropContext::getIrABIDetails() {
+  if (!irABIDetails)
+    irABIDetails = std::make_unique<IRABIDetailsProvider>(mod, irGenOpts);
+  return *irABIDetails;
+}

--- a/lib/PrintAsClang/SwiftToClangInteropContext.h
+++ b/lib/PrintAsClang/SwiftToClangInteropContext.h
@@ -1,0 +1,43 @@
+//===--- SwiftToClangInteropContext.h - Interop context ---------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_PRINTASCLANG_SWIFTTOCLANGINTEROPCONTEXT_H
+#define SWIFT_PRINTASCLANG_SWIFTTOCLANGINTEROPCONTEXT_H
+
+#include <memory>
+
+namespace swift {
+
+class IRABIDetailsProvider;
+class IRGenOptions;
+class ModuleDecl;
+
+/// The \c SwiftToClangInteropContext class is responsible for providing
+/// access to the other required subsystems of the compiler during the emission
+/// of a clang header. It provides access to the other subsystems lazily to
+/// ensure avoid any additional setup cost that's not required.
+class SwiftToClangInteropContext {
+public:
+  SwiftToClangInteropContext(ModuleDecl &mod, const IRGenOptions &irGenOpts);
+  ~SwiftToClangInteropContext();
+
+  IRABIDetailsProvider &getIrABIDetails();
+
+private:
+  ModuleDecl &mod;
+  const IRGenOptions &irGenOpts;
+  std::unique_ptr<IRABIDetailsProvider> irABIDetails;
+};
+
+} // end namespace swift
+
+#endif

--- a/test/Interop/SwiftToCxx/structs/swift-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/swift-struct-in-cxx.swift
@@ -2,19 +2,25 @@
 // RUN: %target-swift-frontend %s -typecheck -module-name Structs -clang-header-expose-public-decls -emit-clang-header-path %t/structs.h
 // RUN: %FileCheck %s < %t/structs.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/structs.h)
+// RUN: %check-interop-cxx-header-in-clang(%t/structs.h -Wno-unused-private-field)
 
 // CHECK: namespace Structs {
 
 // CHECK:      class StructWithIntField final {
+// CHECK-NEXT: private:
+// CHECK-NEXT:   alignas(8) char _storage[8];
 // CHECK-NEXT: };
-struct StructWithIntField {
-  let field: Int
+public struct StructWithIntField {
+  let field: Int64
 }
 
 // Special name gets renamed in C++.
 // CHECK: class register_ final {
-struct register {
+// CHECK: alignas(8) char _storage[16];
+// CHECK-NEXT: };
+public struct register {
+  let field1: Int64
+  let field2: Int64
 }
 
 // CHECK: } // namespace Structs

--- a/test/Interop/SwiftToCxx/structs/zero-sized-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/zero-sized-struct-in-cxx.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -emit-ir -module-name Structs -clang-header-expose-public-decls -emit-clang-header-path %t/structs.h
+// RUN: %FileCheck %s < %t/structs.h
+
+// CHECK: namespace Structs {
+
+// CHECK-NOT: ZeroSizedStruct
+
+public struct ZeroSizedStruct {}
+
+// CHECK: } // namespace Structs

--- a/test/Interop/SwiftToCxx/structs/zero-sized-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/zero-sized-struct-in-cxx.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -emit-ir -module-name Structs -clang-header-expose-public-decls -emit-clang-header-path %t/structs.h
+// RUN: %target-swift-frontend %s -typecheck -module-name Structs -clang-header-expose-public-decls -emit-clang-header-path %t/structs.h
 // RUN: %FileCheck %s < %t/structs.h
 
 // CHECK: namespace Structs {


### PR DESCRIPTION
…it struct stubs with storage in C++

This change extends the clang header printer to start emitting C++ classes for Swift struct types with the correct struct layout in them (size + alignment)

Note: the current header emission logic does not yet force SILGen/IRGen, so we will only emit types when the compiler gets to IRGen. This is something that will be addressed in the future (we should probably require SILGen/IRGen for header emission?)