### PR TITLE
[test] New test mode to execute all tests with C++ interop enabled.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -219,6 +219,7 @@ set(TEST_MODES
     optimize_none_with_implicit_dynamic
     optimize_with_implicit_dynamic
     only_executable only_non_executable
+    with_cxx_interop
 )
 set(TEST_SUBSETS
     primary

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -708,6 +708,10 @@ elif swift_test_mode == 'only_executable':
     config.limit_to_features.add("executable_test")
 elif swift_test_mode == 'only_non_executable':
     config.available_features.add("nonexecutable_test")
+elif swift_test_mode == 'with_cxx_interop':
+    config.available_features.add("with_cxx_interop")
+    config.swift_frontend_test_options += ' -enable-experimental-cxx-interop'
+    config.swift_driver_test_options += ' -Xfrontend -enable-experimental-cxx-interop'
 else:
     lit_config.fatal("Unknown test mode %r" % swift_test_mode)
 


### PR DESCRIPTION
To improve the reliability of the C++ interop, a new test mode is added
to the existing ones. The new mode enables the usage of
`--enable-cxx-interop` in every test invocation of the frontend and the
driver.

This can be used after a `build-script` or similar had been successful, and then one can do `ninja -C <path/to/build/dir> -- check-swift-validation-with_cxx_interop` to execute all tests with C++ interop enabled.

The ideal situation would be that with and without the C++ interop the
test should not fail. Currently around 283 tests seems to still fail.

