### PR TITLE
[5.7] SILGen: Complete initialization of FinalContext in ConversionInitialization::tryPeephole

### DIFF
--- a/lib/SILGen/Conversion.h
+++ b/lib/SILGen/Conversion.h
@@ -231,13 +231,6 @@ canPeepholeConversions(SILGenFunction &SGF,
                        const Conversion &outerConversion,
                        const Conversion &innerConversion);
 
-ManagedValue emitPeepholedConversions(SILGenFunction &SGF, SILLocation loc,
-                                      const Conversion &outerConversion,
-                                      const Conversion &innerConversion,
-                                      ConversionPeepholeHint hint,
-                                      SGFContext C,
-                                      ValueProducerRef produceValue);
-
 /// An initialization where we ultimately want to apply a conversion to
 /// the value before completing the initialization.
 ///
@@ -354,8 +347,6 @@ public:
   void finishInitialization(SILGenFunction &SGF) override {
     assert(getState() == Initialized);
     State = Finished;
-    if (OwnedSubInitialization)
-      OwnedSubInitialization->finishInitialization(SGF);
   }
 };
 

--- a/test/SILGen/literal_closure_reabstraction_with_peephole.swift
+++ b/test/SILGen/literal_closure_reabstraction_with_peephole.swift
@@ -1,0 +1,32 @@
+// RUN: %target-swift-emit-silgen -verify %s
+
+fileprivate typealias Closure = () -> Void
+
+func crash1() {
+    let closure1: Closure? = nil
+    let closure2: Closure? = nil
+    let closure3: Closure? = nil
+    print("Closures: \(String(describing: closure1)), \(String(describing: closure2)), \(String(describing: closure3))")
+   
+    let closure = closure1 ?? closure2 ?? closure3
+
+    print("\(#line): \(String(describing: closure))")
+    closure?() // <- EXC_BAD_ACCESS
+    assert(closure == nil)
+}
+
+func crash2() {
+    let closure1: Closure? = nil
+    let closure2: Closure? = nil
+    let closure3: Closure? = { }
+    print("Closures: \(String(describing: closure1)), \(String(describing: closure2)), \(String(describing: closure3))")
+
+    let closure = closure1 ?? closure2 ?? closure3
+
+    print("\(#line): \(String(describing: closure))")
+    closure?() // <- EXC_BAD_ACCESS
+    assert(closure != nil)
+}
+
+crash1()
+crash2()


### PR DESCRIPTION
The callers to ConversionInitialization::tryPeephole assume that, if the conversion peephole
succeeded, that the peepholed result was fully emitted into the initialization. However, if
the ConversionInitialization sat on top of an in-memory initialization, then tryPeephole would
only set the value of the ConversionInitialization, without forwarding the value into the underlying
initialization, causing code generation to proceed leaving the underlying memory uninitialized.
This problem becomes exposed now when literal closures are emitted with a return value that is
indirectly returned and also reabstracted, and the return expression undergoes a ping-pong reabstraction
pair: we see through the conversions and peephole away the reabstractions, but fail to emplace the
result in the indirect return slot.

Fixes rdar://92654098