### PR TITLE
Tests: Fix `SilencePreconcurrency.swiftinterface` on ARM Macs

### DIFF
--- a/test/ModuleInterface/SilencePreconcurrency.swiftinterface
+++ b/test/ModuleInterface/SilencePreconcurrency.swiftinterface
@@ -1,5 +1,5 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -target x86_64-apple-macos10.9 -module-name SilencePreconcurrency
+// swift-module-flags: -module-name SilencePreconcurrency
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -compile-module-from-interface -o %/t/SilencePreconcurrency.swiftmodule %s -verify


### PR DESCRIPTION
Adjust the `swift-module-flags` of the `SilencePreconcurrency.swiftinterface` test case to avoid over-specifying a target with a specific arch. This test currently fails when the locally built compiler lacks x86_64 support.
