### PR TITLE
ModuleInterface: Fix decl attribute corruption in private swiftinterfaces

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1156,6 +1156,8 @@ public:
                                       SourceRange range,
                                       ArrayRef<Identifier> spiGroups);
 
+  SPIAccessControlAttr *clone(ASTContext &C, bool implicit) const;
+
   /// Name of SPIs declared by the attribute.
   ///
   /// Note: A single SPI name per attribute is currently supported but this
@@ -1712,12 +1714,15 @@ public:
   }
 };
 
-/// Describe a symbol was originally defined in another module. For example, given
+/// Describes a symbol that was originally defined in another module. For
+/// example, given the following declaration:
+///
 /// \code
 /// @_originallyDefinedIn(module: "Original", OSX 10.15) var foo: Int
 /// \endcode
 ///
-/// Where variable Foo has originally defined in another module called Original prior to OSX 10.15
+/// The variable \p foo was originally defined in another module called
+/// \p Original prior to OSX 10.15
 class OriginallyDefinedInAttr: public DeclAttribute {
 public:
   OriginallyDefinedInAttr(SourceLoc AtLoc, SourceRange Range,
@@ -1729,6 +1734,8 @@ public:
       OriginalModuleName(OriginalModuleName),
       Platform(Platform),
       MovedVersion(MovedVersion) {}
+
+  OriginallyDefinedInAttr *clone(ASTContext &C, bool implicit) const;
 
   // The original module name.
   const StringRef OriginalModuleName;

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1720,6 +1720,13 @@ OriginallyDefinedInAttr::isActivePlatform(const ASTContext &ctx) const {
   return None;
 }
 
+OriginallyDefinedInAttr *OriginallyDefinedInAttr::clone(ASTContext &C,
+                                                        bool implicit) const {
+  return new (C) OriginallyDefinedInAttr(
+      implicit ? SourceLoc() : AtLoc, implicit ? SourceRange() : getRange(),
+      OriginalModuleName, Platform, MovedVersion, implicit);
+}
+
 bool AvailableAttr::isLanguageVersionSpecific() const {
   if (PlatformAgnostic ==
       PlatformAgnosticAvailabilityKind::SwiftVersionSpecific)
@@ -1938,6 +1945,15 @@ SPIAccessControlAttr::create(ASTContext &context,
   unsigned size = totalSizeToAlloc<Identifier>(spiGroups.size());
   void *mem = context.Allocate(size, alignof(SPIAccessControlAttr));
   return new (mem) SPIAccessControlAttr(atLoc, range, spiGroups);
+}
+
+SPIAccessControlAttr *SPIAccessControlAttr::clone(ASTContext &C,
+                                                  bool implicit) const {
+  auto *attr = new (C) SPIAccessControlAttr(
+      implicit ? SourceLoc() : AtLoc, implicit ? SourceRange() : getRange(),
+      getSPIGroups());
+  attr->setImplicit(implicit);
+  return attr;
 }
 
 DifferentiableAttr::DifferentiableAttr(bool implicit, SourceLoc atLoc,

--- a/test/ModuleInterface/synthesized-conformances.swift
+++ b/test/ModuleInterface/synthesized-conformances.swift
@@ -14,6 +14,19 @@ public enum HasRawValue: Int {
   // CHECK-DAG: }
 } // CHECK: {{^}$}}
 
+// CHECK-LABEL: @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+// CHECK-NEXT: public enum HasRawValueAndAvailability : Swift.Int {
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+public enum HasRawValueAndAvailability: Int {
+  // CHECK-NEXT: case a, b, c
+  case a, b, c
+  // CHECK-DAG: public typealias RawValue = Swift.Int
+  // CHECK-DAG: public init?(rawValue: Swift.Int)
+  // CHECK-DAG: public var rawValue: Swift.Int {
+  // CHECK-DAG:   get{{$}}
+  // CHECK-DAG: }
+} // CHECK: {{^}$}}
+
 @objc public enum ObjCEnum: Int32 {
   case a, b = 5, c
 }
@@ -48,6 +61,13 @@ extension NoRawValueWithExplicitHashable : Hashable {
 // CHECK: extension synthesized.HasRawValue : Swift.Equatable {}
 // CHECK: extension synthesized.HasRawValue : Swift.Hashable {}
 // CHECK: extension synthesized.HasRawValue : Swift.RawRepresentable {}
+
+// CHECK: @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+// CHECK-NEXT: extension synthesized.HasRawValueAndAvailability : Swift.Equatable {}
+// CHECK: @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+// CHECK-NEXT: extension synthesized.HasRawValueAndAvailability : Swift.Hashable {}
+// CHECK: @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+// CHECK-NEXT: extension synthesized.HasRawValueAndAvailability : Swift.RawRepresentable {}
 
 // CHECK: extension synthesized.ObjCEnum : Swift.Equatable {}
 // CHECK: extension synthesized.ObjCEnum : Swift.Hashable {}


### PR DESCRIPTION
Erroneous declaration attributes were sometimes being printed in the private swiftinterfaces of modules because the changes from https://github.com/apple/swift/pull/42276 were effectively corrupting the attribute list for any decl with sythesized conformances (e.g. `Equatable`, `Hashable`). It is necessary to clone the attributes before adding them to the synthesized conformance extension decls.

Resolves rdar://94009296
