### PR TITLE
Fixes for unavailable superclass conformances

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -631,11 +631,18 @@ public:
   /// might include "missing" conformances, which are synthesized for some
   /// protocols as an error recovery mechanism.
   ///
+  /// \param allowUnavailable When \c true, the resulting conformance reference
+  /// might include "unavailable" conformances, meaning that the conformance
+  /// cannot actually be used and will be diagnosed if used later. Pass
+  /// \c false here for queries that want to determine whether the conformance
+  /// is likely to be usable.
+  ///
   /// \returns The result of the conformance search, which will be
   /// None if the type does not conform to the protocol or contain a
   /// ProtocolConformanceRef if it does conform.
   ProtocolConformanceRef lookupConformance(Type type, ProtocolDecl *protocol,
-                                           bool allowMissing = false);
+                                           bool allowMissing = false,
+                                           bool allowUnavailable = true);
 
   /// Look for the conformance of the given existential type to the given
   /// protocol.

--- a/include/swift/AST/ProtocolConformanceRef.h
+++ b/include/swift/AST/ProtocolConformanceRef.h
@@ -107,6 +107,10 @@ public:
   }
 
   /// Determine whether this conformance (or a conformance it depends on)
+  /// involves an always-unavailable conformance.
+  bool hasUnavailableConformance() const;
+
+  /// Determine whether this conformance (or a conformance it depends on)
   /// involves a "missing" conformance anywhere. Such conformances
   /// cannot be depended on to always exist.
   bool hasMissingConformance(ModuleDecl *module) const;

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -41,7 +41,7 @@ DeclContext *ConformanceLookupTable::ConformanceSource::getDeclContext() const {
     return getImpliedSource()->Source.getDeclContext();
 
   case ConformanceEntryKind::Synthesized:
-    return getSynthesizedDecl();
+    return getSynthesizedDeclContext();
   }
 
   llvm_unreachable("Unhandled ConformanceEntryKind in switch.");
@@ -240,6 +240,14 @@ void ConformanceLookupTable::inheritConformances(ClassDecl *classDecl,
   llvm::SmallPtrSet<ProtocolDecl *, 4> protocols;
   auto addInheritedConformance = [&](ConformanceEntry *entry) {
     auto protocol = entry->getProtocol();
+
+    // Don't add unavailable conformances.
+    if (auto dc = entry->Source.getDeclContext()) {
+      if (auto ext = dyn_cast<ExtensionDecl>(dc)) {
+        if (AvailableAttr::isUnavailable(ext))
+          return;
+      }
+    }
 
     // Don't add redundant conformances here. This is merely an
     // optimization; resolveConformances() would zap the duplicates
@@ -812,7 +820,8 @@ DeclContext *ConformanceLookupTable::getConformingContext(
         if (superclassTy->is<ErrorType>())
           return nullptr;
         auto inheritedConformance = module->lookupConformance(
-            superclassTy, protocol);
+            superclassTy, protocol, /*allowMissing=*/false,
+            /*allowUnavailable=*/false);
         if (inheritedConformance)
           return superclassDecl;
       } while ((superclassDecl = superclassDecl->getSuperclassDecl()));
@@ -927,10 +936,11 @@ ConformanceLookupTable::getConformance(NominalTypeDecl *nominal,
   return entry->Conformance.get<ProtocolConformance *>();
 }
 
-void ConformanceLookupTable::addSynthesizedConformance(NominalTypeDecl *nominal,
-                                                       ProtocolDecl *protocol) {
+void ConformanceLookupTable::addSynthesizedConformance(
+    NominalTypeDecl *nominal, ProtocolDecl *protocol,
+    DeclContext *conformanceDC) {
   addProtocol(protocol, nominal->getLoc(),
-              ConformanceSource::forSynthesized(nominal));
+              ConformanceSource::forSynthesized(conformanceDC));
 }
 
 void ConformanceLookupTable::registerProtocolConformance(
@@ -956,7 +966,7 @@ void ConformanceLookupTable::registerProtocolConformance(
   auto inherited = dyn_cast<InheritedProtocolConformance>(conformance);
   ConformanceSource source
     = inherited   ? ConformanceSource::forInherited(cast<ClassDecl>(nominal)) :
-      synthesized ? ConformanceSource::forSynthesized(nominal) :
+      synthesized ? ConformanceSource::forSynthesized(dc) :
                     ConformanceSource::forExplicit(dc);
 
   ASTContext &ctx = nominal->getASTContext();

--- a/lib/AST/ConformanceLookupTable.h
+++ b/lib/AST/ConformanceLookupTable.h
@@ -120,10 +120,10 @@ class ConformanceLookupTable : public ASTAllocated<ConformanceLookupTable> {
 
     /// Create a synthesized conformance.
     ///
-    /// The given nominal type declaration will get a synthesized
+    /// The given declaration context (for a type) will get a synthesized
     /// conformance to the requested protocol.
-    static ConformanceSource forSynthesized(NominalTypeDecl *typeDecl) {
-      return ConformanceSource(typeDecl, ConformanceEntryKind::Synthesized);
+    static ConformanceSource forSynthesized(DeclContext *dc) {
+      return ConformanceSource(dc, ConformanceEntryKind::Synthesized);
     }
 
     /// Return a new conformance source with the given location of "@unchecked".
@@ -188,9 +188,9 @@ class ConformanceLookupTable : public ASTAllocated<ConformanceLookupTable> {
 
     /// For a synthesized conformance, retrieve the nominal type decl
     /// that will receive the conformance.
-    NominalTypeDecl *getSynthesizedDecl() const {
+    DeclContext *getSynthesizedDeclContext() const {
       assert(getKind() == ConformanceEntryKind::Synthesized);
-      return static_cast<NominalTypeDecl *>(Storage.getPointer());
+      return static_cast<DeclContext *>(Storage.getPointer());
     }
 
     /// Get the declaration context that this conformance will be
@@ -428,7 +428,8 @@ public:
 
   /// Add a synthesized conformance to the lookup table.
   void addSynthesizedConformance(NominalTypeDecl *nominal,
-                                 ProtocolDecl *protocol);
+                                 ProtocolDecl *protocol,
+                                 DeclContext *conformanceDC);
 
   /// Register an externally-supplied protocol conformance.
   void registerProtocolConformance(ProtocolConformance *conformance,

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -1270,7 +1270,8 @@ void NominalTypeDecl::prepareConformanceTable() const {
   auto addSynthesized = [&](KnownProtocolKind kind) {
     if (auto *proto = getASTContext().getProtocol(kind)) {
       if (protocols.count(proto) == 0) {
-        ConformanceTable->addSynthesizedConformance(mutableThis, proto);
+        ConformanceTable->addSynthesizedConformance(
+            mutableThis, proto, mutableThis);
         protocols.insert(proto);
       }
     }

--- a/lib/AST/RequirementMachine/ConcreteContraction.cpp
+++ b/lib/AST/RequirementMachine/ConcreteContraction.cpp
@@ -275,8 +275,10 @@ Optional<Type> ConcreteContraction::substTypeParameterRec(
       // 'allowMissing' value here is actually irrelevant.
       auto conformance = ((*substBaseType)->isTypeParameter()
                           ? ProtocolConformanceRef(proto)
-                          : module->lookupConformance(*substBaseType, proto,
-                                                      /*allowMissing=*/false));
+                          : module->lookupConformance(
+                              *substBaseType, proto,
+                              /*allowMissing=*/false,
+                              /*allowUnavailable=*/false));
 
       // The base type doesn't conform, in which case the requirement remains
       // unsubstituted.
@@ -391,7 +393,7 @@ ConcreteContraction::substRequirement(const Requirement &req) const {
 
     if (!substFirstType->isTypeParameter() &&
         !module->lookupConformance(substFirstType, proto,
-                                   allowMissing)) {
+                                   allowMissing, /*allowUnavailable=*/false)) {
       // Handle the case of <T where T : P, T : C> where C is a class and
       // C does not conform to P by leaving the conformance requirement
       // unsubstituted.

--- a/lib/AST/RequirementMachine/ConcreteTypeWitness.cpp
+++ b/lib/AST/RequirementMachine/ConcreteTypeWitness.cpp
@@ -156,7 +156,7 @@ void PropertyMap::concretizeNestedTypesFromConcreteParent(
     auto conformance = module->lookupConformance(concreteType,
                                                  const_cast<ProtocolDecl *>(proto),
                                                  allowMissing);
-    if (conformance.isInvalid()) {
+    if (conformance.isInvalid() || conformance.hasUnavailableConformance()) {
       // For superclass rules, it is totally fine to have a signature like:
       //
       // protocol P {}

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4359,7 +4359,8 @@ ProtocolConformance *GetImplicitSendableRequest::evaluate(
       auto classModule = classDecl->getParentModule();
       if (auto inheritedConformance = TypeChecker::conformsToProtocol(
               classDecl->mapTypeIntoContext(superclass),
-              proto, classModule, /*allowMissing=*/false)) {
+              proto, classModule, /*allowMissing=*/false,
+              /*allowUnavailable=*/false)) {
         inheritedConformance = inheritedConformance
             .mapConformanceOutOfContext();
         if (inheritedConformance.isConcrete()) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3388,7 +3388,8 @@ void ConformanceChecker::recordTypeWitness(AssociatedTypeDecl *assocType,
     auto overriddenConformance =
       DC->getParentModule()->lookupConformance(Adoptee,
                                                overridden->getProtocol(),
-                                               /*allowMissing=*/true);
+                                               /*allowMissing=*/true,
+                                               /*allowUnavailable=*/false);
     if (overriddenConformance.isInvalid() ||
         !overriddenConformance.isConcrete())
       continue;

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5614,9 +5614,10 @@ TypeChecker::containsProtocol(Type T, ProtocolDecl *Proto, ModuleDecl *M,
 
 ProtocolConformanceRef
 TypeChecker::conformsToProtocol(Type T, ProtocolDecl *Proto, ModuleDecl *M,
-                                bool allowMissing) {
+                                bool allowMissing, bool allowUnavailable) {
   // Look up conformance in the module.
-  auto lookupResult = M->lookupConformance(T, Proto, allowMissing);
+  auto lookupResult = M->lookupConformance(
+      T, Proto, allowMissing, allowUnavailable);
   if (lookupResult.isInvalid()) {
     return ProtocolConformanceRef::forInvalid();
   }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -803,7 +803,8 @@ ProtocolConformanceRef containsProtocol(Type T, ProtocolDecl *Proto,
 /// protocol \c Proto, or \c None.
 ProtocolConformanceRef conformsToProtocol(Type T, ProtocolDecl *Proto,
                                           ModuleDecl *M,
-                                          bool allowMissing = true);
+                                          bool allowMissing = true,
+                                          bool allowUnavailable = true);
 
 /// Check whether the type conforms to a given known protocol.
 bool conformsToKnownProtocol(Type type, KnownProtocolKind protocol,

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -374,3 +374,10 @@ func testSender(
   sender.sendPtr(ptr)
   sender.sendStringArray(stringArray)
 }
+
+// Sendable checking
+public struct SomeWrapper<T: AuditedNonSendable> {
+  public let unit: T
+}
+
+extension SomeWrapper: Sendable where T: Sendable {}

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -95,3 +95,12 @@ func f() async {
     n.pointee += 1
   }
 }
+
+// Make sure the generic signature doesn't minimize away Sendable requirements.
+@_nonSendable class NSClass { }
+
+struct WrapClass<T: NSClass> {
+  var t: T
+}
+
+extension WrapClass: Sendable where T: Sendable { }

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -104,3 +104,12 @@ struct WrapClass<T: NSClass> {
 }
 
 extension WrapClass: Sendable where T: Sendable { }
+
+// Make sure we don't inherit the unavailable Sendable conformance from
+// our superclass.
+class SendableSubclass: NSClass, @unchecked Sendable { }
+
+@available(SwiftStdlib 5.1, *)
+func testSubclassing(obj: SendableSubclass) async {
+  acceptCV(obj) // okay!
+}

--- a/test/Generics/superclass_constraint.swift
+++ b/test/Generics/superclass_constraint.swift
@@ -221,3 +221,14 @@ public struct Barn<T: Teddy> {
   // CHECK: Generic signature: <T, S where T : Teddy>
   public func foo<S>(_: S, _: Barn<T>, _: Paddock<T>) {}
 }
+
+
+public class Animal { }
+
+@available(*, unavailable, message: "Not a pony")
+extension Animal: Pony { }
+
+public struct AnimalWrapper<Friend: Animal> { }
+
+// CHECK: Generic signature: <Friend where Friend : Animal, Friend : Pony>
+extension AnimalWrapper: Pony where Friend: Pony { }

--- a/test/decl/protocol/req/recursion.swift
+++ b/test/decl/protocol/req/recursion.swift
@@ -73,7 +73,7 @@ protocol PI {
 }
 
 struct SI<A: PI> : I where A : I, A.T == SI<A> {
-// expected-error@-1 3{{generic struct 'SI' has self-referential generic requirements}}
+// expected-error@-1 5{{generic struct 'SI' has self-referential generic requirements}}
   func ggg<T : I>(t: T.Type) -> T {
     return T()
   }
@@ -104,5 +104,5 @@ struct SU<A: P> where A.T == SU {
 }
 
 struct SIU<A: PI> : I where A : I, A.T == SIU {
-// expected-error@-1 3{{generic struct 'SIU' has self-referential generic requirements}}
+// expected-error@-1 5{{generic struct 'SIU' has self-referential generic requirements}}
 }

--- a/validation-test/compiler_crashers_2_fixed/0161-sr6569.swift
+++ b/validation-test/compiler_crashers_2_fixed/0161-sr6569.swift
@@ -6,7 +6,7 @@ protocol P {
 
 struct Type<Param> {}
 extension Type: P where Param: P, Param.A == Type<Param> {
-  // expected-error@-1 6{{extension of generic struct 'Type' has self-referential generic requirements}}
+  // expected-error@-1 8{{extension of generic struct 'Type' has self-referential generic requirements}}
   // expected-note@-2 6{{through reference here}}
   // expected-error@-3 {{type 'Type<Param>' does not conform to protocol 'P'}}
   typealias A = Param


### PR DESCRIPTION
Introduce two related fixes to avoid using the unavailable conformance of a superclass as if it should be inherited by the subclasses. This is incorrect, because subclasses could define their own conformance to the same protocol. The two places are:

* Requirement machine: don't canonicalize away conformance requirements based on an unavailable conformance of a superclass requirement
* Conformance lookup table: don't inherit unavailable conformances

Fixes rdar://91853658 and rdar://89992569