### PR TITLE
[5.7] re-exported synthesized extensions need to go under the base module

### DIFF
--- a/lib/SymbolGraphGen/SymbolGraphASTWalker.cpp
+++ b/lib/SymbolGraphGen/SymbolGraphASTWalker.cpp
@@ -68,7 +68,7 @@ SymbolGraph *SymbolGraphASTWalker::getModuleSymbolGraph(const Decl *D) {
     return &MainGraph;
   }
   
-  if (isFromExportedImportedModule(D)) {
+  if (isExportedImportedModule(M)) {
     return &MainGraph;
   }
   
@@ -231,9 +231,12 @@ bool SymbolGraphASTWalker::walkToDeclPre(Decl *D, CharSourceRange Range) {
 }
 
 bool SymbolGraphASTWalker::isFromExportedImportedModule(const Decl* D) const {
-    auto *M = D->getModuleContext();
-    
-    return llvm::any_of(ExportedImportedModules, [&M](const auto *MD) {
-        return areModulesEqual(M, MD->getModuleContext());
-    });
+  auto *M = D->getModuleContext();
+  return isExportedImportedModule(M);
+}
+
+bool SymbolGraphASTWalker::isExportedImportedModule(const ModuleDecl *M) const {
+  return llvm::any_of(ExportedImportedModules, [&M](const auto *MD) {
+    return areModulesEqual(M, MD->getModuleContext());
+  });
 }

--- a/lib/SymbolGraphGen/SymbolGraphASTWalker.h
+++ b/lib/SymbolGraphGen/SymbolGraphASTWalker.h
@@ -96,6 +96,9 @@ struct SymbolGraphASTWalker : public SourceEntityWalker {
   
   /// Returns whether the given declaration comes from an `@_exported import` module.
   virtual bool isFromExportedImportedModule(const Decl *D) const;
+
+  /// Returns whether the given module is an `@_exported import` module.
+  virtual bool isExportedImportedModule(const ModuleDecl *M) const;
 };
 
 } // end namespace symbolgraphgen

--- a/test/SymbolGraph/Module/Inputs/ThirdOrder/A.swift
+++ b/test/SymbolGraph/Module/Inputs/ThirdOrder/A.swift
@@ -1,0 +1,1 @@
+public struct SomeStruct {}

--- a/test/SymbolGraph/Module/Inputs/ThirdOrder/B.swift
+++ b/test/SymbolGraph/Module/Inputs/ThirdOrder/B.swift
@@ -1,0 +1,5 @@
+import A
+
+public extension SomeStruct {
+    struct InnerStruct: Equatable {}
+}

--- a/test/SymbolGraph/Module/ThirdOrder.swift
+++ b/test/SymbolGraph/Module/ThirdOrder.swift
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %S/Inputs/ThirdOrder/A.swift -module-name A -emit-module -emit-module-path %t/A.swiftmodule
+// RUN: %target-swift-frontend %S/Inputs/ThirdOrder/B.swift -module-name B -emit-module -emit-module-path %t/B.swiftmodule -I %t
+// RUN: %target-swift-frontend %s -module-name ThirdOrder -emit-module -emit-module-path %t/ThirdOrder.swiftmodule -I %t -emit-symbol-graph -emit-symbol-graph-dir %t
+// RUN: %FileCheck %s --input-file %t/ThirdOrder.symbols.json --check-prefix BASE
+// RUN: %FileCheck %s --input-file %t/ThirdOrder@A.symbols.json --check-prefix EXT
+
+// Module B extends a symbol from module A that includes a synthesized symbol.
+// To ensure that we track source modules correctly, we need to make sure that
+// the synthesized equality operators don't appear in the ThirdOrder symbol graph.
+
+@_exported import B
+
+// BASE-NOT: "s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:1A10SomeStructV1BE05InnerB0V"
+// EXT: "s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:1A10SomeStructV1BE05InnerB0V"


### PR DESCRIPTION
**Explanation**: `@_exported import`s which include an extension of a foreign type, which itself introduces synthesized symbols, currently sort those synthesized symbols incorrectly, creating a situation where a symbol isn't in the same symbol graph as its parent. The check for whether a decl is from a module being re-exported incorrectly uses the decl's module instead of the calculated extension module. This PR updates that logic.

**Scope**: Affects symbol graph generation for projects in the situation mentioned above.

**Bug**: rdar://93928003

**Risk**: Low. The changes are restricted to SymbolGraphGen, and should not affect normal compilation.

**Testing**: A new lit test, `SymbolGraph/Module/ThirdOrder.swift`, has been added to verify this behavior. Existing automated tests still pass.