### PR TITLE
Better unused async let fix-its

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5849,18 +5849,23 @@ NOTE(fixit_for_unused_setter_parameter, none,
 
 WARNING(pbd_never_used, NoUsage,
         "initialization of %select{variable|immutable value}1 %0 was never used"
-        "; consider replacing with assignment to '_' or removing it",
-        (Identifier, unsigned))
+        "%select{|; consider replacing with assignment to '_' or removing it}2",
+        (Identifier, unsigned, bool))
 
+NOTE(fixit_async_let_unused_cancel, none,
+     "replace with assignment to '_' to cancel and await the task", ())
+
+NOTE(fixit_async_let_unused_run, none,
+     "explicitly await the result to run task to completion", ())
 
 WARNING(capture_never_used, NoUsage,
         "capture %0 was never used",
         (Identifier))
 
 WARNING(variable_never_used, NoUsage,
-        "%select{variable|immutable value}1 %0 was never used; "
-        "consider replacing with '_' or removing it",
-        (Identifier, unsigned))
+        "%select{variable|immutable value}1 %0 was never used"
+        "%select{|; consider replacing with '_' or removing it}2",
+        (Identifier, unsigned, bool))
 WARNING(immutable_value_never_used_but_assigned, NoUsage,
         "immutable value %0 was never used; consider removing it",
         (Identifier))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5848,9 +5848,11 @@ NOTE(fixit_for_unused_setter_parameter, none,
      "did you mean to use %0 instead of accessing the property's current value?", (Identifier))
 
 WARNING(pbd_never_used, NoUsage,
-        "initialization of %select{variable|immutable value}1 %0 was never used"
-        "%select{|; consider replacing with assignment to '_' or removing it}2",
-        (Identifier, unsigned, bool))
+        "initialization of %select{variable|immutable value}1 %0 was never used",
+        (Identifier, unsigned))
+
+NOTE(fixit_assign_to_underscore, none,
+     "consider replacing with '_' or removing it", ())
 
 NOTE(fixit_async_let_unused_cancel, none,
      "replace with assignment to '_' to cancel and await the task", ())
@@ -5863,9 +5865,8 @@ WARNING(capture_never_used, NoUsage,
         (Identifier))
 
 WARNING(variable_never_used, NoUsage,
-        "%select{variable|immutable value}1 %0 was never used"
-        "%select{|; consider replacing with '_' or removing it}2",
-        (Identifier, unsigned, bool))
+        "%select{variable|immutable value}1 %0 was never used",
+        (Identifier, unsigned))
 WARNING(immutable_value_never_used_but_assigned, NoUsage,
         "immutable value %0 was never used; consider removing it",
         (Identifier))

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3095,7 +3095,7 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
                 pbd->getStartLoc(),
                 pbd->getPattern(0)->getEndLoc());
             Diags.diagnose(var->getLoc(), diag::pbd_never_used,
-                           var->getName(), varKind, /*withfixit*/false);
+                           var->getName(), varKind);
 
             Diags.diagnose(var->getLoc(), diag::fixit_async_let_unused_cancel)
               .fixItReplace(var->getLoc(), "_");
@@ -3106,7 +3106,8 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
                 pbd->getStartLoc(),
                 pbd->getPattern(0)->getEndLoc());
             Diags.diagnose(var->getLoc(), diag::pbd_never_used,
-                           var->getName(), varKind, /*withfixit*/true)
+                           var->getName(), varKind);
+            Diags.diagnose(var->getLoc(), diag::fixit_assign_to_underscore)
               .fixItReplace(replaceRange, "_");
           }
           continue;
@@ -3200,9 +3201,10 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
 
         if (foundVP) {
           unsigned varKind = var->isLet();
-          Diags
-              .diagnose(var->getLoc(), diag::variable_never_used,
-                        var->getName(), varKind, /*hasFixit*/true)
+          Diags.diagnose(var->getLoc(), diag::variable_never_used,
+                        var->getName(), varKind);
+
+          Diags.diagnose(var->getLoc(), diag::fixit_assign_to_underscore)
               .fixItReplace(foundVP->getSourceRange(), "_");
           continue;
         }
@@ -3219,7 +3221,7 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
 
         if (var->isAsyncLet()) {
           Diags.diagnose(var->getLoc(), diag::variable_never_used,
-                         var->getName(), varKind, /*hasFixit*/false);
+                         var->getName(), varKind);
 
           Diags.diagnose(var->getLoc(), diag::fixit_async_let_unused_cancel)
               .fixItReplace(var->getLoc(), "_");
@@ -3227,7 +3229,9 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
         } else {
           // Just rewrite the one variable with a _.
           Diags.diagnose(var->getLoc(), diag::variable_never_used,
-                         var->getName(), varKind, /*hasFixit*/true)
+                         var->getName(), varKind);
+
+          Diags.diagnose(var->getLoc(), diag::fixit_assign_to_underscore)
             .fixItReplace(var->getLoc(), "_");
         }
       }

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3091,24 +3091,22 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
           unsigned varKind = var->isLet();
 
           if (pbd->isAsyncLet()) {
-            SourceRange pbdVarNameRange(
-                pbd->getStartLoc(),
-                pbd->getPattern(0)->getEndLoc());
-            Diags.diagnose(var->getLoc(), diag::pbd_never_used,
-                           var->getName(), varKind);
+            SourceRange pbdVarNameRange(pbd->getStartLoc(),
+                                        pbd->getPattern(0)->getEndLoc());
+            Diags.diagnose(var->getLoc(), diag::pbd_never_used, var->getName(),
+                           varKind);
 
             Diags.diagnose(var->getLoc(), diag::fixit_async_let_unused_cancel)
-              .fixItReplace(var->getLoc(), "_");
+                .fixItReplace(var->getLoc(), "_");
 
             Diags.diagnose(var->getLoc(), diag::fixit_async_let_unused_run);
           } else {
-            SourceRange replaceRange(
-                pbd->getStartLoc(),
-                pbd->getPattern(0)->getEndLoc());
-            Diags.diagnose(var->getLoc(), diag::pbd_never_used,
-                           var->getName(), varKind);
+            SourceRange replaceRange(pbd->getStartLoc(),
+                                     pbd->getPattern(0)->getEndLoc());
+            Diags.diagnose(var->getLoc(), diag::pbd_never_used, var->getName(),
+                           varKind);
             Diags.diagnose(var->getLoc(), diag::fixit_assign_to_underscore)
-              .fixItReplace(replaceRange, "_");
+                .fixItReplace(replaceRange, "_");
           }
           continue;
         }
@@ -3202,7 +3200,7 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
         if (foundVP) {
           unsigned varKind = var->isLet();
           Diags.diagnose(var->getLoc(), diag::variable_never_used,
-                        var->getName(), varKind);
+                         var->getName(), varKind);
 
           Diags.diagnose(var->getLoc(), diag::fixit_assign_to_underscore)
               .fixItReplace(foundVP->getSourceRange(), "_");
@@ -3232,7 +3230,7 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
                          var->getName(), varKind);
 
           Diags.diagnose(var->getLoc(), diag::fixit_assign_to_underscore)
-            .fixItReplace(var->getLoc(), "_");
+              .fixItReplace(var->getLoc(), "_");
         }
       }
       continue;

--- a/test/ClangImporter/versioned_canimport.swift
+++ b/test/ClangImporter/versioned_canimport.swift
@@ -16,15 +16,21 @@ import Simple
 
 func canImportVersioned() {
 #if canImport(Simple, _underlyingVersion: 3.3)
-  let a = 1  // expected-warning {{initialization of immutable value 'a' was never used; consider replacing with assignment to '_' or removing it}}
+  let a = 1
+  // expected-warning@-1 {{initialization of immutable value 'a' was never used}}
+  // expected-note@-2 {{consider replacing with '_' or removing it}}{{3-8=_}}
 #endif
 
 #if canImport(Simple, _underlyingVersion: 1830.100)
-  let b = 1  // expected-warning {{initialization of immutable value 'b' was never used; consider replacing with assignment to '_' or removing it}}
+  let b = 1
+  // expected-warning@-1 {{initialization of immutable value 'b' was never used}}
+  // expected-note@-2 {{consider replacing with '_' or removing it}}{{3-8=_}}
 #endif
 
 #if canImport(Simple, _underlyingVersion: 1830.11)
-  let c = 1  // expected-warning {{initialization of immutable value 'c' was never used; consider replacing with assignment to '_' or removing it}}
+  let c = 1
+  // expected-warning@-1 {{initialization of immutable value 'c' was never used}}
+  // expected-note@-2 {{consider replacing with '_' or removing it}}{{3-8=_}}
 #endif
 }
 

--- a/test/Compatibility/exhaustive_switch.swift
+++ b/test/Compatibility/exhaustive_switch.swift
@@ -135,7 +135,8 @@ func s(a: A, b: B) {
     break
 
   case (.B(_), let b):
-  // expected-warning@-1 {{immutable value 'b' was never used; consider replacing with '_' or removing it}}
+  // expected-warning@-1 {{immutable value 'b' was never used}}
+  // expected-note@-2 {{consider replacing with '_' or removing it}}{{16-21=_}}
     break
 
   case (.C, _), (.D, _):

--- a/test/Concurrency/sr15049.swift
+++ b/test/Concurrency/sr15049.swift
@@ -3,7 +3,9 @@
 
 func testAsyncSequenceTypedPatternSendable<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int, Seq: Sendable {
    async let result: Int = seq.reduce(0) { $0 + $1 } // OK
-   // expected-warning@-1{{immutable value 'result' was never used; consider replacing with '_' or removing it}}
+   // expected-warning@-1{{immutable value 'result' was never used}}
+   // expected-note@-2{{replace with assignment to '_' to cancel and await the task}}{{14-20=_}}
+   // expected-note@-3{{explicitly await the result to run task to completion}}
 }
 
 func testAsyncSequenceTypedPattern1Sendable<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int, Seq: Sendable {
@@ -12,7 +14,9 @@ func testAsyncSequenceTypedPattern1Sendable<Seq: AsyncSequence>(_ seq: Seq) asyn
 
 func testAsyncSequenceSendable<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int, Seq: Sendable {
    async let result = seq.reduce(0) { $0 + $1 } // OK
-   // expected-warning@-1{{initialization of immutable value 'result' was never used; consider replacing with assignment to '_' or removing it}}
+   // expected-warning@-1{{initialization of immutable value 'result' was never used}}
+   // expected-note@-2{{replace with assignment to '_' to cancel and await the task}}{{14-20=_}}
+   // expected-note@-3{{explicitly await the result to run task to completion}}
 }
 
 func testAsyncSequence1Sendable<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int, Seq: Sendable {
@@ -21,8 +25,11 @@ func testAsyncSequence1Sendable<Seq: AsyncSequence>(_ seq: Seq) async throws whe
 
 func testAsyncSequenceTypedPattern<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int { // expected-note{{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{54-54=, Sendable}}
    async let result: Int = seq.reduce(0) { $0 + $1 } // OK
-   // expected-warning@-1{{immutable value 'result' was never used; consider replacing with '_' or removing it}}
-   // expected-warning@-2{{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
+   // expected-warning@-1{{immutable value 'result' was never used}}
+   // expected-note@-2{{replace with assignment to '_' to cancel and await the task}}{{14-20=_}}
+   // expected-note@-3{{explicitly await the result to run task to completion}}
+   // expected-warning@-4{{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
+
 }
 
 func testAsyncSequenceTypedPattern1<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int { // expected-note{{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{55-55=, Sendable}}
@@ -32,8 +39,10 @@ func testAsyncSequenceTypedPattern1<Seq: AsyncSequence>(_ seq: Seq) async throws
 
 func testAsyncSequence<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int { // expected-note{{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{42-42=, Sendable}}
    async let result = seq.reduce(0) { $0 + $1 } // OK
-   // expected-warning@-1{{initialization of immutable value 'result' was never used; consider replacing with assignment to '_' or removing it}}
-   // expected-warning@-2{{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
+   // expected-warning@-1{{initialization of immutable value 'result' was never used}}
+   // expected-note@-2{{replace with assignment to '_' to cancel and await the task}}{{14-20=_}}
+   // expected-note@-3{{explicitly await the result to run task to completion}}
+   // expected-warning@-4{{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
 }
 
 func testAsyncSequence1<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int { // expected-note{{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{43-43=, Sendable}}

--- a/test/Concurrency/sr15049.swift
+++ b/test/Concurrency/sr15049.swift
@@ -52,7 +52,9 @@ func testAsyncSequence1<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.E
 
 func testAsyncSequence3<Seq>(_ seq: Seq) async throws where Seq: AsyncSequence, Seq.Element == Int { // expected-note{{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{28-28=: Sendable}}
    async let result = seq // expected-warning{{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
-   //expected-warning@-1{{initialization of immutable value 'result' was never used; consider replacing with assignment to '_' or removing it}}
+   //expected-warning@-1{{initialization of immutable value 'result' was never used}}
+   //expected-note@-2{{replace with assignment to '_' to cancel and await the task}}{{14-20=_}}
+   //expected-note@-3{{explicitly await the result to run task to completion}}
 }
 
 func testAsyncSequence4<Seq>(_ seq: Seq) async throws where Seq: AsyncSequence, Seq.Element == Int { // expected-note{{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{28-28=: Sendable}}

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -131,7 +131,9 @@ default:
 
 // <rdar://problem/19382878> Introduce new x? pattern
 switch Optional(42) {
-case let x?: break // expected-warning{{immutable value 'x' was never used; consider replacing with '_' or removing it}} {{10-11=_}}
+case let x?: break
+// expected-warning@-1{{immutable value 'x' was never used}}
+// expected-note@-2 {{consider replacing with '_' or removing it}}{{10-11=_}}
 case nil: break
 }
 
@@ -189,8 +191,13 @@ case x ?? 42: break // match value
 default: break
 }
 
-for (var x) in 0...100 {} // expected-warning{{variable 'x' was never used; consider replacing with '_' or removing it}}
-for var x in 0...100 {}  // rdar://20167543 expected-warning{{variable 'x' was never used; consider replacing with '_' or removing it}}
+for (var x) in 0...100 {}
+// expected-warning@-1 {{variable 'x' was never used}}
+// expected-note@-2 {{consider replacing with '_' or removing it}}{{6-11=_}}
+
+for var x in 0...100 {}  // rdar://20167543
+// expected-warning@-1 {{variable 'x' was never used}}
+// expected-note@-2 {{consider replacing with '_' or removing it}}{{5-10=_}}
 for (let x) in 0...100 { _ = x} // expected-error {{'let' pattern cannot appear nested in an already immutable context}}
 
 var (let y) = 42  // expected-error {{'let' cannot appear nested inside another 'var' or 'let' pattern}}
@@ -488,19 +495,25 @@ func rdar63510989() {
   func test(e: E) {
     if case .single(_ as Value) = e {} // Ok
     if case .single(let v as Value) = e {} // Ok
-    // expected-warning@-1 {{immutable value 'v' was never used; consider replacing with '_' or removing it}}
+    // expected-warning@-1 {{immutable value 'v' was never used}}
+    // expected-note@-2 {{consider replacing with '_' or removing it}}{{25-26=_}}
     if case .double(_ as Value) = e {} // Ok
     if case .double(let v as Value) = e {} // Ok
-    // expected-warning@-1 {{immutable value 'v' was never used; consider replacing with '_' or removing it}}
+    // expected-warning@-1 {{immutable value 'v' was never used}}
+    // expected-note@-2 {{consider replacing with '_' or removing it}}{{25-26=_}}
     if case .double(let v as Value?) = e {} // Ok
-    // expected-warning@-1 {{immutable value 'v' was never used; consider replacing with '_' or removing it}}
+    // expected-warning@-1 {{immutable value 'v' was never used}}
+    // expected-note@-2 {{consider replacing with '_' or removing it}}{{25-26=_}}
     if case .triple(_ as Value) = e {} // Ok
     if case .triple(let v as Value) = e {} // Ok
-    // expected-warning@-1 {{immutable value 'v' was never used; consider replacing with '_' or removing it}}
+    // expected-warning@-1 {{immutable value 'v' was never used}}
+    // expected-note@-2 {{consider replacing with '_' or removing it}}{{25-26=_}}
     if case .triple(let v as Value?) = e {} // Ok
-    // expected-warning@-1 {{immutable value 'v' was never used; consider replacing with '_' or removing it}}
+    // expected-warning@-1 {{immutable value 'v' was never used}}
+    // expected-note@-2 {{consider replacing with '_' or removing it}}{{25-26=_}}
     if case .triple(let v as Value??) = e {} // Ok
-    // expected-warning@-1 {{immutable value 'v' was never used; consider replacing with '_' or removing it}}
+    // expected-warning@-1 {{immutable value 'v' was never used}}
+    // expected-note@-2 {{consider replacing with '_' or removing it}}{{25-26=_}}
   }
 }
 

--- a/test/Constraints/result_builder_invalid_vars.swift
+++ b/test/Constraints/result_builder_invalid_vars.swift
@@ -46,6 +46,7 @@ dummy {
 
 dummy {
   @resultBuilder var attributedVar: Int = 123 // expected-error {{@resultBuilder' attribute cannot be applied to this declaration}}
-  // expected-warning@-1 {{variable 'attributedVar' was never used; consider replacing with '_' or removing it}}
+  // expected-warning@-1 {{variable 'attributedVar' was never used}}
+  // expected-note@-2 {{consider replacing with '_' or removing it}}
   ()
 }

--- a/test/Generics/associated_types.swift
+++ b/test/Generics/associated_types.swift
@@ -18,7 +18,9 @@ struct Z : Fooable {
   func foo(_ x: Float) {}
 
   func blah() {
-    var a : AssocType // expected-warning {{variable 'a' was never used; consider replacing with '_' or removing it}} {{9-10=_}}
+    var a : AssocType
+    // expected-warning@-1 {{variable 'a' was never used}}
+    // expected-note@-2 {{consider replacing with '_' or removing it}} {{9-10=_}}
   }
 
   func blarg() -> AssocType {}

--- a/test/ModuleInterface/ossa-modules/Inputs/sdk-test-stdlib-no-ossa-referent-no-rebuild-remark.swift
+++ b/test/ModuleInterface/ossa-modules/Inputs/sdk-test-stdlib-no-ossa-referent-no-rebuild-remark.swift
@@ -3,6 +3,7 @@ import Swift
 
 func main() {
   let f = foo() // expected-warning {{initialization of immutable value 'f' was never used}}
+                // expected-note@-1{{consider replacing with '_'}}
 }
 
 main()

--- a/test/ModuleInterface/ossa-modules/Inputs/sdk-test-stdlib-no-ossa-referent-with-rebuild-remark.swift
+++ b/test/ModuleInterface/ossa-modules/Inputs/sdk-test-stdlib-no-ossa-referent-with-rebuild-remark.swift
@@ -7,6 +7,7 @@ import Swift // expected-remark {{rebuilding module 'Swift'}}
 
 func main() {
   let f = foo() // expected-warning {{initialization of immutable value 'f' was never used}}
+                // expected-note @-1 {{consider replacing with '_'}}
 }
 
 main()

--- a/test/NameLookup/edge-cases.swift
+++ b/test/NameLookup/edge-cases.swift
@@ -17,5 +17,5 @@ func multipleLocalResults2() {
   func other() -> B {}
   let result = other()
   takesB(result)
-  let other: Int = 123 // expected-warning {{never used}}
+  let other: Int = 123 // expected-warning {{never used}} expected-note {{consider replacing}}
 }

--- a/test/NameLookup/name_lookup.swift
+++ b/test/NameLookup/name_lookup.swift
@@ -588,7 +588,8 @@ func foo1() {
 // SR-4082
 func foo2() {
   let x = 5
-  if x < 0, let x = Optional(1) { } // expected-warning {{immutable value 'x' was never used; consider replacing with '_' or removing it}}
+  if x < 0, let x = Optional(1) { } // expected-warning {{immutable value 'x' was never used}}
+                                    // expected-note@-1 {{consider replacing with '_' or removing it}}
 }
 
 struct Person {

--- a/test/NameLookup/name_lookup2.swift
+++ b/test/NameLookup/name_lookup2.swift
@@ -138,9 +138,10 @@ func overloadtest(x: Int) {
 }
 
 func localtest() {
-  func shadowbug() { 
+  func shadowbug() {
     var Foo = 10
-    // expected-warning@-1 {{initialization of variable 'Foo' was never used; consider replacing with assignment to '_' or removing it}}
+    // expected-warning@-1 {{initialization of variable 'Foo' was never used}}
+    // expected-note@-2 {{consider replacing with '_' or removing it}}
     func g() {
       struct S {
         // FIXME: Swap these two lines to crash our broken lookup.
@@ -204,7 +205,8 @@ class ForwardReference {
 
   func test() {
     x = 0
-    var x: Float = 0.0 // expected-warning{{variable 'x' was never used; consider replacing with '_' or removing it}}
+    var x: Float = 0.0 // expected-warning{{variable 'x' was never used}}
+                       // expected-note@-1 {{consider replacing with '_' or removing it}}
   }
 }
 

--- a/test/Parse/init_deinit.swift
+++ b/test/Parse/init_deinit.swift
@@ -98,13 +98,15 @@ func fooFunc() {
 
 func barFunc() {
   var x : () = { () -> () in
-    // expected-warning@-1 {{variable 'x' was never used; consider replacing with '_' or removing it}}
+    // expected-warning@-1 {{variable 'x' was never used}}
+    // expected-note@-2 {{consider replacing with '_' or removing it}}
     init() {} // expected-error {{initializers may only be declared within a type}}
     return
   } ()
 
   var y : () = { () -> () in
-    // expected-warning@-1 {{variable 'y' was never used; consider replacing with '_' or removing it}}
+    // expected-warning@-1 {{variable 'y' was never used}}
+    // expected-note@-2 {{consider replacing with '_' or removing it}}
     deinit {} // expected-error {{deinitializers may only be declared within a class or actor}}
     return
   } ()

--- a/test/Parse/matching_patterns.swift
+++ b/test/Parse/matching_patterns.swift
@@ -47,7 +47,9 @@ case 1 + (_): // expected-error{{'_' can only appear in a pattern or on the left
 }
 
 switch (x,x) {
-case (var a, var a): // expected-error {{invalid redeclaration of 'a'}} expected-note {{'a' previously declared here}} expected-warning {{variable 'a' was never used; consider replacing with '_' or removing it}} expected-warning {{variable 'a' was never used; consider replacing with '_' or removing it}}
+case (var a, var a): // expected-error@:18 {{invalid redeclaration of 'a'}} expected-note@:11 {{'a' previously declared here}}
+// expected-warning@-1 {{variable 'a' was never used}} expected-note@-1 {{consider replacing with '_' or removing it}}{{7-12=_}}
+// expected-warning@-2 {{variable 'a' was never used}} expected-note@-2 {{consider replacing with '_' or removing it}}{{14-19=_}}
   fallthrough
 case _: // expected-warning {{case is already handled by previous patterns; consider removing it}}
   ()

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -313,7 +313,8 @@ struct SS SS : Multi {
     // expected-error @-1 {{found an unexpected second identifier in variable declaration; is there an accidental break?}}
     // expected-note @-2 {{join the identifiers together}} {{9-12=cd}}
     // expected-note @-3 {{join the identifiers together with camel-case}} {{9-12=cD}}
-    // expected-warning @-4 {{initialization of variable 'c' was never used; consider replacing with assignment to '_' or removing it}}
+    // expected-warning @-4 {{initialization of variable 'c' was never used}}
+    // expected-note @-5 {{consider replacing with '_' or removing it}}
     
     let _ = 0
   }

--- a/test/Parse/self_rebinding.swift
+++ b/test/Parse/self_rebinding.swift
@@ -53,7 +53,8 @@ class MyCls {
     func something() {}
 
     func test() {
-        // expected-warning @+1 {{initialization of immutable value 'self' was never used}}
+        // expected-warning @+2 {{initialization of immutable value 'self' was never used}}
+        // expected-note @+1 {{consider replacing with '_' or removing it}}{{9-19=_}}
         let `self` = Writer() // Even if `self` is shadowed,
         something() // this should still refer `MyCls.something`.
     }

--- a/test/Parse/switch.swift
+++ b/test/Parse/switch.swift
@@ -28,7 +28,9 @@ func parseError4(x: Int) {
 
 func parseError5(x: Int) {
   switch x {
-  case let z // expected-error {{expected ':' after 'case'}} expected-warning {{immutable value 'z' was never used}} {{8-13=_}}
+  case let z // expected-error {{expected ':' after 'case'}}
+             // expected-warning@-1 {{immutable value 'z' was never used}}
+             // expected-note@-2 {{consider replacing with '_' or removing}}{{8-13=_}}
   }
 }
 
@@ -197,28 +199,33 @@ default:
 var t = (1, 2)
 
 switch t {
-case (var a, 2), (1, _): // expected-error {{'a' must be bound in every pattern}} expected-warning {{variable 'a' was never used; consider replacing with '_' or removing it}}
+case (var a, 2), (1, _): // expected-error {{'a' must be bound in every pattern}}
+                         // expected-warning@-1 {{variable 'a' was never used}} expected-note@-1 {{consider replacing with '_' or removing it}}
   ()
 
 case (_, 2), (var a, _): // expected-error {{'a' must be bound in every pattern}}
   ()
 
-case (var a, 2), (1, var b): // expected-error {{'a' must be bound in every pattern}} expected-error {{'b' must be bound in every pattern}} expected-warning {{variable 'a' was never used; consider replacing with '_' or removing it}}
+case (var a, 2), (1, var b): // expected-error {{'a' must be bound in every pattern}} expected-error {{'b' must be bound in every pattern}}
+                             // expected-warning@-1 {{variable 'a' was never used}} expected-note@-1 {{consider replacing with '_' or removing it}}
   ()
 
-case (var a, 2): // expected-error {{'case' label in a 'switch' must have at least one executable statement}} {{17-17= break}} expected-warning {{variable 'a' was never used; consider replacing with '_' or removing it}}
+case (var a, 2): // expected-error {{'case' label in a 'switch' must have at least one executable statement}} {{17-17= break}}
+                 // expected-warning@-1 {{variable 'a' was never used}} expected-note@-1 {{consider replacing with '_' or removing it}}
 case (1, _):
   ()
 
 case (_, 2): // expected-error {{'case' label in a 'switch' must have at least one executable statement}} {{13-13= break}}
-case (1, var a): // expected-warning {{variable 'a' was never used; consider replacing with '_' or removing it}}
+case (1, var a): // expected-warning {{variable 'a' was never used}} expected-note{{consider replacing with '_' or removing it}}
   ()
 
-case (var a, 2): // expected-error {{'case' label in a 'switch' must have at least one executable statement}} {{17-17= break}} expected-warning {{variable 'a' was never used; consider replacing with '_' or removing it}}
-case (1, var b): // expected-warning {{variable 'b' was never used; consider replacing with '_' or removing it}}
+case (var a, 2): // expected-error {{'case' label in a 'switch' must have at least one executable statement}} {{17-17= break}}
+                 // expected-warning@-1 {{variable 'a' was never used}}
+                 // expected-note@-2 {{consider replacing with '_' or removing it}}
+case (1, var b): // expected-warning {{variable 'b' was never used}} expected-note {{consider replacing with '_' or removing it}}
   ()
 
-case (1, let b): // let bindings expected-warning {{immutable value 'b' was never used; consider replacing with '_' or removing it}}
+case (1, let b): // expected-warning {{immutable value 'b' was never used}} expected-note {{consider replacing with '_' or removing it}}
   ()
 
 case (_, 2), (let a, _): // expected-error {{'a' must be bound in every pattern}} expected-warning {{case is already handled by previous patterns; consider removing it}}
@@ -228,14 +235,17 @@ case (_, 2), (let a, _): // expected-error {{'a' must be bound in every pattern}
 case (_, 2), (1, _):
   ()
   
-case (_, var a), (_, var a): // expected-warning {{variable 'a' was never used; consider replacing with '_' or removing it}}
-  // expected-warning@-1 {{case is already handled by previous patterns; consider removing it}}
+case (_, var a), (_, var a):
+  // expected-warning@-1 {{variable 'a' was never used}} expected-note@-1 {{consider replacing with '_' or removing it}}
   // expected-warning@-2 {{case is already handled by previous patterns; consider removing it}}
+  // expected-warning@-3 {{case is already handled by previous patterns; consider removing it}}
   ()
   
-case (var a, var b), (var b, var a): // expected-warning {{variable 'a' was never used; consider replacing with '_' or removing it}} expected-warning {{variable 'b' was never used; consider replacing with '_' or removing it}}
-  // expected-warning@-1 {{case is already handled by previous patterns; consider removing it}}
-  // expected-warning@-2 {{case is already handled by previous patterns; consider removing it}}
+case (var a, var b), (var b, var a):
+  // expected-warning@-1 {{variable 'a' was never used}} expected-note@-1 {{consider replacing with '_' or removing it}}
+  // expected-warning@-2 {{variable 'b' was never used}} expected-note@-2 {{consider replacing with '_' or removing it}}
+  // expected-warning@-3 {{case is already handled by previous patterns; consider removing it}}
+  // expected-warning@-4 {{case is already handled by previous patterns; consider removing it}}
   ()
 
 case (_, 2): // expected-error {{'case' label in a 'switch' must have at least one executable statement}} {{13-13= break}}

--- a/test/Parse/versioned_canimport.swift
+++ b/test/Parse/versioned_canimport.swift
@@ -33,11 +33,13 @@ func canImportVersioned() {
 #endif
 
 #if canImport(Foo, _version: 4)
-  let d = 1 // expected-warning {{initialization of immutable value 'd' was never used; consider replacing with assignment to '_' or removing it}}
+  let d = 1 // expected-warning {{initialization of immutable value 'd' was never used}}
+            // expected-note@-1 {{consider replacing with '_' or removing it}}
 #endif
 
 #if canImport(Foo, _version: 113.33)
-  let e = 1 // expected-warning {{initialization of immutable value 'e' was never used; consider replacing with assignment to '_' or removing it}}
+  let e = 1 // expected-warning {{initialization of immutable value 'e' was never used}}
+            // expected-note@-1 {{consider replacing with '_' or removing it}}
 #endif
 
 #if canImport(Foo, _underlyingVersion: 113.33)
@@ -45,15 +47,18 @@ func canImportVersioned() {
 #endif
 
 #if canImport(Foo, _version: 113.329)
-  let f = 1 // expected-warning {{initialization of immutable value 'f' was never used; consider replacing with assignment to '_' or removing it}}
+  let f = 1 // expected-warning {{initialization of immutable value 'f' was never used}}
+            // expected-note@-1 {{consider replacing with '_' or removing it}}
 #endif
 
 #if canImport(Foo, _version: 113.330)
-  let g = 1 // expected-warning {{initialization of immutable value 'g' was never used; consider replacing with assignment to '_' or removing it}}
+  let g = 1 // expected-warning {{initialization of immutable value 'g' was never used}}
+            // expected-note@-1 {{consider replacing with '_' or removing it}}
 #endif
 
 #if canImport(Foo)
-  let h = 1 // expected-warning {{initialization of immutable value 'h' was never used; consider replacing with assignment to '_' or removing it}}
+  let h = 1 // expected-warning {{initialization of immutable value 'h' was never used}}
+            // expected-note@-1 {{consider replacing with '_' or removing it}}
 #endif
 }
 
@@ -67,10 +72,12 @@ func canImportVersionedString() {
 #endif
 
 #if canImport(Foo, _version: "4")
-  let d = 1 // expected-warning {{initialization of immutable value 'd' was never used; consider replacing with assignment to '_' or removing it}}
+  let d = 1 // expected-warning {{initialization of immutable value 'd' was never used}}
+            // expected-note@-1 {{consider replacing with '_' or removing it}}
 #endif
 
 #if canImport(Foo, _version: "113.33")
-  let e = 1 // expected-warning {{initialization of immutable value 'e' was never used; consider replacing with assignment to '_' or removing it}}
+  let e = 1 // expected-warning {{initialization of immutable value 'e' was never used}}
+  // expected-note@-1 {{consider replacing with '_' or removing it}}
 #endif
 }

--- a/test/SILGen/capture_order.swift
+++ b/test/SILGen/capture_order.swift
@@ -159,7 +159,8 @@ class rdar40600800 {
 
     func innerFunction() {
       let closure = {
-      // expected-warning@-1 {{initialization of immutable value 'closure' was never used; consider replacing with assignment to '_' or removing it}}
+      // expected-warning@-1 {{initialization of immutable value 'closure' was never used}}
+      // expected-note@-2 {{consider replacing with '_' or removing it}}
         callback() // expected-note {{captured here}}
       }
     }

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -884,7 +884,8 @@ func testOptionalTryThatNeverThrows() {
 // CHECK-NEXT: br [[DONE]]
 // CHECK: } // end sil function '$s6errors18testOptionalTryVaryyF'
 func testOptionalTryVar() {
-  var cat = try? make_a_cat() // expected-warning {{initialization of variable 'cat' was never used; consider replacing with assignment to '_' or removing it}}
+  var cat = try? make_a_cat() // expected-warning {{initialization of variable 'cat' was never used}}
+                              // expected-note@-1 {{consider replacing with '_' or removing it}}
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s6errors26testOptionalTryAddressOnly{{.*}}F
@@ -934,7 +935,8 @@ func testOptionalTryAddressOnly<T>(_ obj: T) {
 // CHECK-NEXT: br [[DONE]]
 // CHECK: } // end sil function '$s6errors29testOptionalTryAddressOnlyVaryyxlF'
 func testOptionalTryAddressOnlyVar<T>(_ obj: T) {
-  var copy = try? dont_return(obj) // expected-warning {{initialization of variable 'copy' was never used; consider replacing with assignment to '_' or removing it}}
+  var copy = try? dont_return(obj) // expected-warning {{initialization of variable 'copy' was never used}}
+                                   // expected-note@-1 {{consider replacing with '_' or removing it}}
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s6errors23testOptionalTryMultipleyyF
@@ -991,7 +993,8 @@ func testOptionalTryNeverFails() {
 // CHECK-NEXT:   return [[VOID]] : $()
 // CHECK-NEXT: } // end sil function '$s6errors28testOptionalTryNeverFailsVaryyF'
 func testOptionalTryNeverFailsVar() {
-  var unit: ()? = try? () // expected-warning {{no calls to throwing functions occur within 'try' expression}} expected-warning {{variable 'unit' was never used; consider replacing with '_' or removing it}}
+  var unit: ()? = try? () // expected-warning {{no calls to throwing functions occur within 'try' expression}} expected-warning {{variable 'unit' was never used}}
+                          // expected-note@-1 {{consider replacing with '_' or removing it}}
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s6errors36testOptionalTryNeverFailsAddressOnly{{.*}}F
@@ -1024,7 +1027,8 @@ func testOptionalTryNeverFailsAddressOnly<T>(_ obj: T) {
 // CHECK-NEXT:   return [[VOID]] : $()
 // CHECK: } // end sil function '$s6errors13OtherErrorSubCACycfC'
 func testOptionalTryNeverFailsAddressOnlyVar<T>(_ obj: T) {
-  var copy = try? obj // expected-warning {{no calls to throwing functions occur within 'try' expression}} expected-warning {{initialization of variable 'copy' was never used; consider replacing with assignment to '_' or removing it}}
+  var copy = try? obj // expected-warning {{no calls to throwing functions occur within 'try' expression}} expected-warning {{initialization of variable 'copy' was never used}}
+                      // expected-note@-1 {{consider replacing with '_' or removing it}}
 }
 
 class SomeErrorClass : Error { }

--- a/test/SILGen/objc_access_notes.swift
+++ b/test/SILGen/objc_access_notes.swift
@@ -512,6 +512,7 @@ extension Hoozit {
   // CHECK-LABEL: sil hidden [ossa] @$s11objc_thunks6HoozitC6doubleACSd_tcfC : $@convention(method) (Double, @thick Hoozit.Type) -> @owned Hoozit
   convenience init(double d: Double) {
     var x = X()       // expected-warning {{initialization of variable 'x' was never used}}
+                      // expected-note@-1 {{consider replacing}}
     self.init(int:Int(d))
     other()
   }

--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -223,7 +223,8 @@ func existentials(_ i: Int, dp: DerivedProtocol) {
   var b : Any
   b = ()
 
-  // expected-warning @+1 {{variable 'c' was never used}} {{7-8=_}}
+  // expected-warning @+2 {{variable 'c' was never used}}
+  // expected-note @+1 {{consider replacing with '_' or removing it}}{{7-8=_}}
   var c : Any   // no uses.
   
   // expected-warning @+1 {{variable 'd1' was never mutated}} {{3-6=let}}
@@ -877,7 +878,8 @@ struct MyMutabilityImplementation : TestMutabilityProtocol {
 func testLocalProperties(_ b : Int) -> Int {
   // expected-note @+1 {{change 'let' to 'var' to make it mutable}} {{3-6=var}}
   let x : Int
-  let y : Int // never assigned is ok    expected-warning {{immutable value 'y' was never used}} {{7-8=_}}
+  let y : Int // never assigned is ok    expected-warning {{immutable value 'y' was never used}}
+  // expected-note @-1 {{consider replacing with '_' or removing it}} {{7-8=_}}
 
   x = b
   x = b    // expected-error {{immutable value 'x' may only be initialized once}}
@@ -899,7 +901,8 @@ func testAddressOnlyProperty<T>(_ b : T) -> T {
   // expected-note @+1 {{change 'let' to 'var' to make it mutable}} {{3-6=var}}
   let x : T  // expected-note {{change 'let' to 'var' to make it mutable}}
   let y : T
-  let z : T   // never assigned is ok.  expected-warning {{immutable value 'z' was never used}} {{7-8=_}}
+  let z : T   // never assigned is ok.  expected-warning {{immutable value 'z' was never used}}
+              // expected-note @-1 {{consider replacing with '_' or removing it}} {{7-8=_}}
   x = b
   y = b
   x = b   // expected-error {{immutable value 'x' may only be initialized once}}

--- a/test/Sema/api-availability-only.swift
+++ b/test/Sema/api-availability-only.swift
@@ -45,7 +45,8 @@ public func apiFunc(s : NewProto) { // expected-error {{'NewProto' is only avail
   // expected-note @+1 {{add 'if #available' version check}}
   let _ = NewStruct() // expected-error {{'NewStruct' is only available in macOS 11.0 or newer}}
 
-  // expected-note @+2 {{add 'if #available' version check}}
+  // expected-note @+3 {{add 'if #available' version check}}
+  // expected-note @+2 {{consider replacing with '_'}}
   // expected-warning @+1 {{initialization of immutable value 'a' was never used}}
   let a = NewStruct() // expected-error {{'NewStruct' is only available in macOS 11.0 or newer}}
 

--- a/test/Sema/diag_use_before_declaration.swift
+++ b/test/Sema/diag_use_before_declaration.swift
@@ -18,7 +18,8 @@ func test() {
   guard let bar = foo else {
     return
   }
-  let foo = String(bar) // expected-warning {{initialization of immutable value 'foo' was never used; consider replacing with assignment to '_' or removing it}}
+  let foo = String(bar) // expected-warning {{initialization of immutable value 'foo' was never used}}
+  // expected-note@-1 {{consider replacing with '_' or removing it}}
 }
 
 // SR-7660
@@ -26,7 +27,8 @@ class C {
   var variable: Int?
   func f() {
     guard let _ = variable else { return }
-    let variable = 1 // expected-warning {{initialization of immutable value 'variable' was never used; consider replacing with assignment to '_' or removing it}}
+    let variable = 1 // expected-warning {{initialization of immutable value 'variable' was never used}}
+    // expected-note@-1 {{consider replacing with '_' or removing it}}
   }
 }
 
@@ -62,10 +64,12 @@ func nested_scope_2() {
     let x = 11
     do {
       let _ = x
-      let x = 111 // expected-warning {{initialization of immutable value 'x' was never used; consider replacing with assignment to '_' or removing it}}
+      let x = 111 // expected-warning {{initialization of immutable value 'x' was never used}}
+                  // expected-note@-1 {{consider replacing with '_' or removing it}}
     }
   }
-  let x = 1  // expected-warning {{initialization of immutable value 'x' was never used; consider replacing with assignment to '_' or removing it}}
+  let x = 1  // expected-warning {{initialization of immutable value 'x' was never used}}
+             // expected-note@-1 {{consider replacing with '_' or removing it}}
 }
 
 func nested_scope_3() {
@@ -73,9 +77,11 @@ func nested_scope_3() {
   do {
     do {
       let _ = x
-      let x = 111 // expected-warning {{initialization of immutable value 'x' was never used; consider replacing with assignment to '_' or removing it}}
+      let x = 111 // expected-warning {{initialization of immutable value 'x' was never used}}
+                  // expected-note@-1 {{consider replacing with '_' or removing it}}
     }
-    let x = 11 // expected-warning {{initialization of immutable value 'x' was never used; consider replacing with assignment to '_' or removing it}}
+    let x = 11 // expected-warning {{initialization of immutable value 'x' was never used}}
+               // expected-note@-1 {{consider replacing with '_' or removing it}}
   }
 }
 
@@ -88,7 +94,8 @@ class Ty {
 
   func fn() {
     let _ = v
-    let v = 1 // expected-warning {{initialization of immutable value 'v' was never used; consider replacing with assignment to '_' or removing it}}
+    let v = 1 // expected-warning {{initialization of immutable value 'v' was never used}}
+              // expected-note@-1 {{consider replacing with '_' or removing it}}
   }
 }
 
@@ -100,7 +107,8 @@ let g = 0
 
 func file_scope_1() {
   let _ = g
-  let g = 1 // expected-warning {{initialization of immutable value 'g' was never used; consider replacing with assignment to '_' or removing it}}
+  let g = 1 // expected-warning {{initialization of immutable value 'g' was never used}}
+            // expected-note@-1 {{consider replacing with '_' or removing it}}
 }
 
 func file_scope_2() {
@@ -114,7 +122,8 @@ func file_scope_2() {
 
 func module_scope_1() {
   let _ = print // Legal use of func print declared in Swift Standard Library
-  let print = "something" // expected-warning {{initialization of immutable value 'print' was never used; consider replacing with assignment to '_' or removing it}}
+  let print = "something" // expected-warning {{initialization of immutable value 'print' was never used}}
+                          // expected-note@-1 {{consider replacing with '_' or removing it}}
 }
 
 func module_scope_2() {

--- a/test/Sema/diag_variable_used_in_initial.swift
+++ b/test/Sema/diag_variable_used_in_initial.swift
@@ -4,7 +4,8 @@ class A1 {
   func foo1() -> Int {}
   func foo2() {
     var foo1 = foo1()
-    // expected-warning@-1 {{initialization of variable 'foo1' was never used; consider replacing with assignment to '_' or removing it}}
+    // expected-warning@-1 {{initialization of variable 'foo1' was never used}}
+    // expected-note@-2 {{consider replacing with '_' or removing it}}
   }
 }
 
@@ -12,14 +13,16 @@ class A2 {
   var foo1 = 2
   func foo2() {
     var foo1 = foo1
-    // expected-warning@-1 {{initialization of variable 'foo1' was never used; consider replacing with assignment to '_' or removing it}}
+    // expected-warning@-1 {{initialization of variable 'foo1' was never used}}
+    // expected-note@-2 {{consider replacing with '_' or removing it}}
   }
 }
 
 class A3 {
   func foo2() {
     var foo1 = foo1()
-    // expected-warning@-1 {{initialization of variable 'foo1' was never used; consider replacing with assignment to '_' or removing it}}
+    // expected-warning@-1 {{initialization of variable 'foo1' was never used}}
+    // expected-note@-2 {{consider replacing with '_' or removing it}}
   }
   func foo1() -> Int {}
 }
@@ -36,14 +39,16 @@ func localContext() {
     func foo1() -> Int {}
     func foo2() {
       var foo1 = foo1()
-      // expected-warning@-1 {{initialization of variable 'foo1' was never used; consider replacing with assignment to '_' or removing it}}
+      // expected-warning@-1 {{initialization of variable 'foo1' was never used}}
+      // expected-note@-2 {{consider replacing with '_' or removing it}}
     }
 
     class A6 {
       func foo1() -> Int {}
       func foo2() {
         var foo1 = foo1()
-        // expected-warning@-1 {{initialization of variable 'foo1' was never used; consider replacing with assignment to '_' or removing it}}
+        // expected-warning@-1 {{initialization of variable 'foo1' was never used}}
+        // expected-note@-2 {{consider replacing with '_' or removing it}}
       }
     }
 

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -153,7 +153,8 @@ func s(a: A, b: B) {
     break
 
   case (.B(_), let b):
-  // expected-warning@-1 {{immutable value 'b' was never used; consider replacing with '_' or removing it}}
+  // expected-warning@-1 {{immutable value 'b' was never used}}
+  // expected-note@-2 {{consider replacing with '_' or removing it}}
     break
 
   case (.C, _), (.D, _):

--- a/test/Sema/redeclaration-checking.swift
+++ b/test/Sema/redeclaration-checking.swift
@@ -12,11 +12,11 @@ func test1() {
 }
 
 func test2() {
-  let x = 123 // expected-warning {{never used}}
+  let x = 123 // expected-warning {{never used}} expected-note {{consider replacing}}
   func f() {}
   struct S {}
   do {
-    let x = 321 // expected-warning {{never used}}
+    let x = 321 // expected-warning {{never used}} expected-note {{consider replacing}}
     func f() {}
     struct S {}
   }
@@ -63,40 +63,40 @@ func stmtTest() {
   if case (let x, let x)? = n {}
   // expected-note@-1 {{'x' previously declared here}}
   // expected-error@-2 {{invalid redeclaration of 'x'}}
-  // expected-warning@-3 2{{never used}}
+  // expected-warning@-3 2{{never used}} expected-note@-3 2{{consider replacing}}
 
   for case (let x, let x) in [(Int, Int)]() {}
   // expected-note@-1 {{'x' previously declared here}}
   // expected-error@-2 {{invalid redeclaration of 'x'}}
-  // expected-warning@-3 2{{never used}}
+  // expected-warning@-3 2{{never used}} expected-note@-3 2{{consider replacing}}
 
   switch n {
   case (let x, let x)?: _ = ()
   // expected-note@-1 {{'x' previously declared here}}
   // expected-error@-2 {{invalid redeclaration of 'x'}}
-  // expected-warning@-3 2{{never used}}
+  // expected-warning@-3 2{{never used}} expected-note@-3 2{{consider replacing}}
   case nil: _ = ()
   }
 
   while case (let x, let x)? = n {}
   // expected-note@-1 {{'x' previously declared here}}
   // expected-error@-2 {{invalid redeclaration of 'x'}}
-  // expected-warning@-3 2{{never used}}
+  // expected-warning@-3 2{{never used}} expected-note@-3 2{{consider replacing}}
 
   guard case (let x, let x)? = n else {}
   // expected-note@-1 {{'x' previously declared here}}
   // expected-error@-2 {{invalid redeclaration of 'x'}}
-  // expected-warning@-3 2{{never used}}
+  // expected-warning@-3 2{{never used}} expected-note@-3 2{{consider replacing}}
 
   do {} catch MyError.error(let x, let x) {}
   // expected-note@-1 {{'x' previously declared here}}
   // expected-error@-2 {{invalid redeclaration of 'x'}}
-  // expected-warning@-3 2{{never used}}
+  // expected-warning@-3 2{{never used}} expected-note@-3 2{{consider replacing}}
   // expected-warning@-4 {{unreachable}}
 }
 
 func fullNameTest() {
-  let x = 123 // expected-warning {{never used}}
+  let x = 123 // expected-warning {{never used}} expected-note {{consider replacing}}
   func x() {}
 }
 

--- a/test/attr/attr_dynamic_callable.swift
+++ b/test/attr/attr_dynamic_callable.swift
@@ -37,12 +37,14 @@ func testCallable(
 ) {
   _ = a()
   let a1 = a(1, 2, 3, 4) // expected-warning {{initialization of immutable value 'a1' was never used}}
+  // expected-note@-1 {{consider replacing}}
 
   b()
   b(1, 2, 3, 4.0)
 
   _ = try? c()
   let c1 = try! c("hello", "world") // expected-warning {{initialization of immutable value 'c1' was never used}}
+  // expected-note@-1 {{consider replacing}}
 
   d()
   d(1, 2.0, 3)

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -163,7 +163,8 @@ class subject_staticVar1 {
 func subject_freeFunc() {
   @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
   var subject_localVar: Int
-  // expected-warning@-1 {{variable 'subject_localVar' was never used; consider replacing with '_' or removing it}}
+  // expected-warning@-1 {{variable 'subject_localVar' was never used}}
+  // expected-note@-2 {{consider replacing with '_' or removing it}}
 
   @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
   func subject_nestedFreeFunc() {
@@ -174,7 +175,8 @@ func subject_freeFunc() {
 func subject_genericFunc<T>(t: T) {
   @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
   var subject_localVar: Int
-  // expected-warning@-1 {{variable 'subject_localVar' was never used; consider replacing with '_' or removing it}}
+  // expected-warning@-1 {{variable 'subject_localVar' was never used}}
+  // expected-note@-2 {{consider replacing with '_' or removing it}}
 
   @objc // expected-error {{@objc can only be used with members of classes, @objc protocols, and concrete extensions of classes}} {{3-9=}}
   func subject_instanceFunc() {}

--- a/test/decl/func/throwing_functions.swift
+++ b/test/decl/func/throwing_functions.swift
@@ -118,7 +118,8 @@ var c4 : () -> Int = {() throws -> Int in 0} // expected-error{{invalid conversi
 var c5 : () -> Int = { try c2() } // expected-error{{invalid conversion from throwing function of type '() throws -> Int' to non-throwing function type '() -> Int'}}
 var c6 : () throws -> Int = { do { _ = try c2() } ; return 0 }
 var c7 : () -> Int = { do { try c2() } ; return 0 } // expected-error{{invalid conversion from throwing function of type '() throws -> Int' to non-throwing function type '() -> Int'}}
-var c8 : () -> Int = { do { _ = try c2()  } catch _ { var x = 0 } ; return 0 } // expected-warning {{initialization of variable 'x' was never used; consider replacing with assignment to '_' or removing it}}
+var c8 : () -> Int = { do { _ = try c2()  } catch _ { var x = 0 } ; return 0 } // expected-warning {{initialization of variable 'x' was never used}}
+                                                                               // expected-note@-1 {{consider replacing with '_' or removing it}}
 var c9 : () -> Int = { do { try c2()  } catch Exception.A { var x = 0 } ; return 0 }// expected-error{{invalid conversion from throwing function of type '() throws -> Int' to non-throwing function type '() -> Int'}}
 var c10 : () -> Int = { throw Exception.A; return 0 } // expected-error{{invalid conversion from throwing function of type '() throws -> Int' to non-throwing function type '() -> Int'}}
 var c11 : () -> Int = { try! c2() }

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -96,7 +96,8 @@ var implicitGet1: X {
 
 var implicitGet2: Int {
   var zzz = 0
-  // expected-warning@-1 {{initialization of variable 'zzz' was never used; consider replacing with assignment to '_' or removing it}}
+  // expected-warning@-1 {{initialization of variable 'zzz' was never used}}
+  // expected-note@-2 {{consider replacing with '_' or removing it}}
   // For the purpose of this test, any other function attribute work as well.
   @inline(__always)
   func foo() {}
@@ -413,7 +414,8 @@ var x23: Int, x24: Int { // expected-error{{'var' declarations with multiple var
 
 var x25: Int { // expected-error{{'var' declarations with multiple variables cannot have explicit getters/setters}}
   return 42
-}, x26: Int // expected-warning{{variable 'x26' was never used; consider replacing with '_' or removing it}}
+}, x26: Int // expected-warning{{variable 'x26' was never used}}
+            // expected-note@-1 {{consider replacing with '_' or removing it}}
 
 // Properties of struct/enum/extensions
 struct S {
@@ -669,7 +671,8 @@ class SelfRefProperties {
     }
     set {
       markUsed(setter) // no-warning
-      var unused = setter + setter // expected-warning {{initialization of variable 'unused' was never used; consider replacing with assignment to '_' or removing it}} {{7-17=_}}
+      var unused = setter + setter // expected-warning {{initialization of variable 'unused' was never used}}
+      // expected-note@-1 {{consider replacing with '_' or removing it}} {{7-17=_}}
       setter = newValue // expected-warning {{attempting to modify 'setter' within its own setter}}
       // expected-note@-1 {{access 'self' explicitly to silence this warning}} {{7-7=self.}}
     }
@@ -1300,10 +1303,12 @@ class SR_10995 {
   func sr_10995_foo() {
     let doubleOptionalNever = makeDoubleOptionalNever() // expected-warning {{constant 'doubleOptionalNever' inferred to have type 'Never??', which may be unexpected}}
     // expected-note@-1 {{add an explicit type annotation to silence this warning}} {{28-28=: Never??}}
-    // expected-warning@-2 {{initialization of immutable value 'doubleOptionalNever' was never used; consider replacing with assignment to '_' or removing it}}
+    // expected-warning@-2 {{initialization of immutable value 'doubleOptionalNever' was never used}}
+    // expected-note@-3 {{consider replacing with '_' or removing it}}
     let singleOptionalNever = makeSingleOptionalNever() // expected-warning {{constant 'singleOptionalNever' inferred to have type 'Never?', which may be unexpected}} 
     // expected-note@-1 {{add an explicit type annotation to silence this warning}} {{28-28=: Never?}}
-    // expected-warning@-2 {{initialization of immutable value 'singleOptionalNever' was never used; consider replacing with assignment to '_' or removing it}}
+    // expected-warning@-2 {{initialization of immutable value 'singleOptionalNever' was never used}}
+    // expected-note@-3 {{consider replacing with '_' or removing it}}
   }
 }
 

--- a/test/decl/var/usage.swift
+++ b/test/decl/var/usage.swift
@@ -5,7 +5,8 @@
 // <rdar://problem/18876585> Compiler should warn me if I set a parameter as 'var' but never modify it
 
 func basicTests() -> Int {
-  let x = 42 // expected-warning {{immutable value 'x' was never used; consider replacing with assignment to '_' or removing it}} {{3-8=_}}
+  let x = 42 // expected-warning {{immutable value 'x' was never used}}
+             // expected-note@-1 {{consider replacing with '_' or removing it}} {{3-8=_}}
   var y = 12 // expected-warning {{variable 'y' was never mutated; consider changing to 'let' constant}} {{3-6=let}}
   _ = 42 // ok
   _ = 42 // ok
@@ -69,7 +70,8 @@ func nestedFunction() -> Int {
   
   func g() {
     x = 97
-    var q = 27  // expected-warning {{variable 'q' was never used}} {{5-10=_}}
+    var q = 27  // expected-warning {{variable 'q' was never used}}
+                // expected-note@-1 {{consider replacing with '_' or removing it}} {{5-10=_}}
   }
   g()
   
@@ -313,9 +315,11 @@ func testFixitsInStatementsWithPatterns(_ a : Int?) {
 
 // <rdar://22774938> QoI: "never used" in an "if let" should rewrite expression to use != nil
 func test(_ a : Int?, b : Any) {
-  if true == true, let x = a {   // expected-warning {{immutable value 'x' was never used; consider replacing with '_' or removing it}} {{20-25=_}}
+  if true == true, let x = a {   // expected-warning {{immutable value 'x' was never used}}
+                                 // expected-note@-1{{consider replacing with '_' or removing it}} {{20-25=_}}
   }
-  if let x = a, let y = a {  // expected-warning {{immutable value 'x' was never used; consider replacing with '_' or removing it}} {{6-11=_}}
+  if let x = a, let y = a {  // expected-warning {{immutable value 'x' was never used}}
+                             // expected-note@-1{{consider replacing with '_' or removing it}} {{6-11=_}}
     _ = y
   }
 
@@ -365,7 +369,10 @@ func test(_ a : Int?, b : Any) {
   if let bbb = (try? throwingBB()) as? Int {} // expected-warning {{value 'bbb' was defined but never used; consider replacing with boolean test}} {{6-16=}} {{36-39=is}}
 
   let cc: (Any?, Any) = (1, 2)
-  if let (cc1, cc2) = cc as? (Int, Int) {} // expected-warning {{immutable value 'cc1' was never used; consider replacing with '_' or removing it}} expected-warning {{immutable value 'cc2' was never used; consider replacing with '_' or removing it}}
+  if let (cc1, cc2) = cc as? (Int, Int) {} // expected-warning {{immutable value 'cc1' was never used}}
+                                           // expected-note@-1 {{consider replacing with '_' or removing it}}
+                                           // expected-warning@-2 {{immutable value 'cc2' was never used}}
+                                           // expected-note@-3 {{consider replacing with '_' or removing it}}
 
   // SR-1112
   let xxx: Int? = 0
@@ -382,10 +389,14 @@ func test(_ a : Int?, b : Any) {
 }
 
 func test2() {
-  let a = 4 // expected-warning {{initialization of immutable value 'a' was never used; consider replacing with assignment to '_' or removing it}} {{3-8=_}}
-  var ( b ) = 6 // expected-warning {{initialization of variable 'b' was never used; consider replacing with assignment to '_' or removing it}} {{3-12=_}}
-  var c: Int = 4 // expected-warning {{variable 'c' was never used; consider replacing with '_' or removing it}} {{7-8=_}}
-  let (d): Int = 9 // expected-warning {{immutable value 'd' was never used; consider replacing with '_' or removing it}} {{8-9=_}}
+  let a = 4 // expected-warning {{initialization of immutable value 'a' was never used}}
+            // expected-note@-1{{consider replacing with '_' or removing it}} {{3-8=_}}
+  var ( b ) = 6 // expected-warning {{initialization of variable 'b' was never used}}
+                // expected-note@-1{{consider replacing with '_' or removing it}} {{3-12=_}}
+  var c: Int = 4 // expected-warning {{variable 'c' was never used}}
+                 // expected-note@-1{{consider replacing with '_' or removing it}} {{7-8=_}}
+  let (d): Int = 9 // expected-warning {{immutable value 'd' was never used}}
+                   // expected-note@-1{{consider replacing with '_' or removing it}} {{8-9=_}}
 }
 
 let optionalString: String? = "check"
@@ -400,7 +411,8 @@ var unNeededVar = false
 if unNeededVar {}
 guard let foo = optionalAny else {}
 
-for i in 0..<10 { // expected-warning {{immutable value 'i' was never used; consider replacing with '_' or removing it}} {{5-6=_}}
+for i in 0..<10 { // expected-warning {{immutable value 'i' was never used}}
+                  // expected-note@-1{{consider replacing with '_' or removing it}} {{5-6=_}}
    print("")
 }
 
@@ -468,7 +480,8 @@ extension MemberGetterExtension {
 
 func testLocalFunc() {
   var unusedVar = 0
-  // expected-warning@-1 {{initialization of variable 'unusedVar' was never used; consider replacing with assignment to '_' or removing it}}
+  // expected-warning@-1 {{initialization of variable 'unusedVar' was never used}}
+  // expected-note@-2 {{consider replacing with '_' or removing it}}
 
   var notMutatedVar = 0
   // expected-warning@-1 {{variable 'notMutatedVar' was never mutated; consider changing to 'let' constant}}
@@ -506,35 +519,50 @@ func testVariablesBoundInPatterns() {
   // introducer stripped by the fixit. All other cases are currently too
   // complicated for the VarDeclUsageChecker.
   switch StringB.simple(b: true) {
-  case .simple(b: let b) where false: // expected-warning {{immutable value 'b' was never used; consider replacing with '_' or removing it}} {{19-24=_}}
+  case .simple(b: let b) where false: // expected-warning {{immutable value 'b' was never used}}
+                                      // expected-note@-1 {{consider replacing with '_' or removing it}} {{19-24=_}}
     break
-  case .simple(b: var b) where false: // expected-warning {{variable 'b' was never used; consider replacing with '_' or removing it}} {{19-24=_}}
+  case .simple(b: var b) where false: // expected-warning {{variable 'b' was never used}}
+                                      // expected-note@-1 {{consider replacing with '_' or removing it}} {{19-24=_}}
     break
-  case var .simple(b: b): // expected-warning {{variable 'b' was never used; consider replacing with '_' or removing it}} {{23-24=_}}
+  case var .simple(b: b): // expected-warning {{variable 'b' was never used}}
+                          // expected-note@-1 {{consider replacing with '_' or removing it}} {{23-24=_}}
     break
   case .tuple(b: let (b1, b2)) where false:
-    // expected-warning@-1 {{immutable value 'b1' was never used; consider replacing with '_' or removing it}} {{23-25=_}}
-    // expected-warning@-2 {{immutable value 'b2' was never used; consider replacing with '_' or removing it}} {{27-29=_}}
+    // expected-warning@-1 {{immutable value 'b1' was never used}}
+    // expected-note@-2 {{consider replacing with '_' or removing it}} {{23-25=_}}
+    // expected-warning@-3 {{immutable value 'b2' was never used}}
+    // expected-note@-4 {{consider replacing with '_' or removing it}} {{27-29=_}}
     break
   case .tuple(b: (let b1, let b2)) where false:
-    // expected-warning@-1 {{immutable value 'b1' was never used; consider replacing with '_' or removing it}} {{19-25=_}}
-    // expected-warning@-2 {{immutable value 'b2' was never used; consider replacing with '_' or removing it}} {{27-33=_}}
+    // expected-warning@-1 {{immutable value 'b1' was never used}}
+    // expected-note@-2 {{consider replacing with '_' or removing it}} {{19-25=_}}
+    // expected-warning@-3 {{immutable value 'b2' was never used}}
+    // expected-note@-4 {{consider replacing with '_' or removing it}} {{27-33=_}}
     break
   case .tuple(b: (var b1, var b2)) where false:
-    // expected-warning@-1 {{variable 'b1' was never used; consider replacing with '_' or removing it}} {{19-25=_}}
-    // expected-warning@-2 {{variable 'b2' was never used; consider replacing with '_' or removing it}} {{27-33=_}}
+    // expected-warning@-1 {{variable 'b1' was never used}}
+    // expected-note@-2 {{consider replacing with '_' or removing it}} {{19-25=_}}
+    // expected-warning@-3 {{variable 'b2' was never used}}
+    // expected-note@-4 {{consider replacing with '_' or removing it}} {{27-33=_}}
     break
   case var .tuple(b: (b1, b2)) where false:
-    // expected-warning@-1 {{variable 'b1' was never used; consider replacing with '_' or removing it}} {{23-25=_}}
-    // expected-warning@-2 {{variable 'b2' was never used; consider replacing with '_' or removing it}} {{27-29=_}}
+    // expected-warning@-1 {{variable 'b1' was never used}}
+    // expected-note@-2 {{consider replacing with '_' or removing it}} {{23-25=_}}
+    // expected-warning@-3 {{variable 'b2' was never used}}
+    // expected-note@-4 {{consider replacing with '_' or removing it}} {{27-29=_}}
     break
-  case .tuple(b: let b): // expected-warning {{immutable value 'b' was never used; consider replacing with '_' or removing it}} {{18-23=_}}
+  case .tuple(b: let b): // expected-warning {{immutable value 'b' was never used}}
+                         // expected-note@-1 {{consider replacing with '_' or removing it}} {{18-23=_}}
     break
-  case .optional(b: let x?) where false: // expected-warning {{immutable value 'x' was never used; consider replacing with '_' or removing it}} {{25-26=_}}
+  case .optional(b: let x?) where false: // expected-warning {{immutable value 'x' was never used}}
+                                         // expected-note@-1 {{consider replacing with '_' or removing it}} {{25-26=_}}
     break
-  case .optional(b: let .some(x)) where false: // expected-warning {{immutable value 'x' was never used; consider replacing with '_' or removing it}} {{31-32=_}}
+  case .optional(b: let .some(x)) where false: // expected-warning {{immutable value 'x' was never used}}
+                                               // expected-note@-1 {{consider replacing with '_' or removing it}} {{31-32=_}}
     break
-  case let .optional(b: x?): // expected-warning {{immutable value 'x' was never used; consider replacing with '_' or removing it}} {{25-26=_}}
+  case let .optional(b: x?): // expected-warning {{immutable value 'x' was never used}}
+                             // expected-note@-1 {{consider replacing with '_' or removing it}} {{25-26=_}}
     break
   case let .optional(b: .none): // expected-warning {{'let' pattern has no effect; sub-pattern didn't bind any variables}} {{8-12=}}
     break

--- a/test/decl/var/variables.swift
+++ b/test/decl/var/variables.swift
@@ -37,7 +37,8 @@ var (self7a, self7b) = (self7b, self7a)
 var self8 = 0
 func testShadowing() {
   var self8 = self8
-  // expected-warning@-1 {{initialization of variable 'self8' was never used; consider replacing with assignment to '_' or removing it}}
+  // expected-warning@-1 {{initialization of variable 'self8' was never used}}
+  // expected-note@-2 {{consider replacing with '_' or removing it}}
 }
 
 var (paren) = 0
@@ -134,5 +135,6 @@ if true {
 // ASTScope assertion
 func patternBindingWithTwoEntries() {
   let x2 = 1, (_, _) = (1, 2)
-  // expected-warning@-1 {{immutable value 'x2' was never used; consider replacing with '_' or removing it}}
+  // expected-warning@-1 {{immutable value 'x2' was never used}}
+  // expected-note@-2 {{consider replacing with '_' or removing it}}
 }

--- a/test/diagnostics/no_warnings_as_errors.swift
+++ b/test/diagnostics/no_warnings_as_errors.swift
@@ -3,10 +3,10 @@
 
 
 // This test verifies that the -no-warnings-as-errors option nullifies the effect of the -warnings-as-errors option
-// CHECK-WARNING-NOT: error: initialization of immutable value 'c' was never used;
-// CHECK-WARNING: warning: initialization of immutable value 'c' was never used;
-// CHECK-ERROR-NOT: warning: initialization of immutable value 'c' was never used;
-// CHECK-ERROR: error: initialization of immutable value 'c' was never used;
+// CHECK-WARNING-NOT: error: initialization of immutable value 'c' was never used
+// CHECK-WARNING: warning: initialization of immutable value 'c' was never used
+// CHECK-ERROR-NOT: warning: initialization of immutable value 'c' was never used
+// CHECK-ERROR: error: initialization of immutable value 'c' was never used
 func b() {
   let c = 2
 }

--- a/test/expr/cast/array_iteration.swift
+++ b/test/expr/cast/array_iteration.swift
@@ -12,7 +12,8 @@ rootView.subviews = v
 
 _ = rootView.subviews as! [View]
 
-for view in rootView.subviews as! [View] { // expected-warning{{immutable value 'view' was never used; consider replacing with '_' or removing it}}
+for view in rootView.subviews as! [View] { // expected-warning{{immutable value 'view' was never used}}
+                                           // expected-note@-1 {{consider replacing with '_' or removing it}}
   doFoo()
 }
 
@@ -30,18 +31,21 @@ _ = ao as! [View] // works
 
 var b = Array<(String, Int)>()
 
-for x in b { // expected-warning{{immutable value 'x' was never used; consider replacing with '_' or removing it}}
+for x in b { // expected-warning{{immutable value 'x' was never used}}
+             // expected-note@-1 {{consider replacing with '_' or removing it}}
   doFoo()
 }
 
 var c : Array<(String, Int)>! = Array()
 
-for x in c { // expected-warning{{immutable value 'x' was never used; consider replacing with '_' or removing it}}
+for x in c { // expected-warning{{immutable value 'x' was never used}}
+             // expected-note@-1 {{consider replacing with '_' or removing it}}
   doFoo()
 }
 
 var d : Array<(String, Int)>? = Array()
 
-for x in d! { // expected-warning{{immutable value 'x' was never used; consider replacing with '_' or removing it}}
+for x in d! { // expected-warning{{immutable value 'x' was never used}}
+              // expected-note@-1 {{consider replacing with '_' or removing it}}
   doFoo()
 }

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -381,7 +381,8 @@ extension SomeClass {
 
 // <rdar://problem/16955318> Observed variable in a closure triggers an assertion
 var closureWithObservedProperty: () -> () = {
-  var a: Int = 42 { // expected-warning {{variable 'a' was never used; consider replacing with '_' or removing it}}
+  var a: Int = 42 { // expected-warning {{variable 'a' was never used}}
+                    // expected-note@-1 {{consider replacing with '_' or removing it}}
   willSet {
     _ = "Will set a to \(newValue)"
   }
@@ -477,7 +478,7 @@ var f = { (s: Undeclared) -> Int in 0 } // expected-error {{cannot find type 'Un
 func r21375863() {
   var width = 0 // expected-warning {{variable 'width' was never mutated}}
   var height = 0 // expected-warning {{variable 'height' was never mutated}}
-  var bufs: [[UInt8]] = (0..<4).map { _ -> [asdf] in  // expected-error {{cannot find type 'asdf' in scope}} expected-warning {{variable 'bufs' was never used}}
+  var bufs: [[UInt8]] = (0..<4).map { _ -> [asdf] in  // expected-error {{cannot find type 'asdf' in scope}} expected-warning {{variable 'bufs' was never used}} expected-note {{consider replacing with '_'}}
     [UInt8](repeating: 0, count: width*height)
   }
 }

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -246,7 +246,8 @@ func test_as_2() {
 func test_lambda() {
   // A simple closure.
   var a = { (value: Int) -> () in markUsed(value+1) }
-  // expected-warning@-1 {{initialization of variable 'a' was never used; consider replacing with assignment to '_' or removing it}}
+  // expected-warning@-1 {{initialization of variable 'a' was never used}}
+  // expected-note@-2 {{consider replacing with '_' or removing it}}{{3-8=_}}
 
   // A recursive lambda.
   var fib = { (n: Int) -> Int in
@@ -501,7 +502,8 @@ func stringliterals(_ d: [String: Int]) {
   // expected-error @-2 {{cannot find ')' to match opening '(' in string interpolation}}
   // expected-error @-2 {{unterminated string literal}} expected-error @-3 {{unterminated string literal}}
 
-  // expected-warning @+2 {{variable 'x2' was never used; consider replacing with '_' or removing it}}
+  // expected-warning @+3 {{variable 'x2' was never used}}
+  // expected-note @+2 {{consider replacing with '_' or removing it}}{{7-9=_}}
   // expected-error @+1 {{unterminated string literal}}
   var x2 : () = ("hello" + "
   ;

--- a/test/expr/postfix/dot/init_ref_delegation.swift
+++ b/test/expr/postfix/dot/init_ref_delegation.swift
@@ -338,7 +338,8 @@ class TestNestedExpr {
 
   convenience init(a: Int) {
     let x: () = self.init() // expected-error {{initializer delegation ('self.init') cannot be nested in another statement}}
-    // expected-warning@-1 {{immutable value 'x' was never used; consider replacing with '_' or removing it}}
+    // expected-warning@-1 {{immutable value 'x' was never used}}
+    // expected-note@-2 {{consider replacing with '_' or removing it}}
   }
 
   convenience init(b: Int) {
@@ -352,7 +353,8 @@ class TestNestedExpr {
 
   convenience init(d: Int) {
     let x: () = self.init(fail: true)! // expected-error {{initializer delegation ('self.init') cannot be nested in another statement}}
-    // expected-warning@-1 {{immutable value 'x' was never used; consider replacing with '_' or removing it}}
+    // expected-warning@-1 {{immutable value 'x' was never used}}
+    // expected-note@-2 {{consider replacing with '_' or removing it}}
   }
 
   convenience init(e: Int) {
@@ -366,7 +368,8 @@ class TestNestedExpr {
 
   convenience init(g: Int) {
     let x: () = try! self.init(error: true) // expected-error {{initializer delegation ('self.init') cannot be nested in another statement}}
-    // expected-warning@-1 {{immutable value 'x' was never used; consider replacing with '_' or removing it}}
+    // expected-warning@-1 {{immutable value 'x' was never used}}
+    // expected-note@-2 {{consider replacing with '_' or removing it}}
   }
 
   convenience init(h: Int) {
@@ -411,7 +414,8 @@ class TestNestedExpr {
 class TestNestedExprSub : TestNestedExpr {
   init(a: Int) {
     let x: () = super.init() // expected-error {{initializer chaining ('super.init') cannot be nested in another statement}}
-    // expected-warning@-1 {{immutable value 'x' was never used; consider replacing with '_' or removing it}}
+    // expected-warning@-1 {{immutable value 'x' was never used}}
+    // expected-note@-2 {{consider replacing with '_' or removing it}}
   }
 
   init(b: Int) {
@@ -425,7 +429,8 @@ class TestNestedExprSub : TestNestedExpr {
 
   init(d: Int) {
     let x: () = super.init(fail: true)! // expected-error {{initializer chaining ('super.init') cannot be nested in another statement}}
-    // expected-warning@-1 {{immutable value 'x' was never used; consider replacing with '_' or removing it}}
+    // expected-warning@-1 {{immutable value 'x' was never used}}
+    // expected-note@-2 {{consider replacing with '_' or removing it}}
   }
 
   init(e: Int) {
@@ -439,7 +444,8 @@ class TestNestedExprSub : TestNestedExpr {
 
   init(g: Int) {
     let x: () = try! super.init(error: true) // expected-error {{initializer chaining ('super.init') cannot be nested in another statement}}
-    // expected-warning@-1 {{immutable value 'x' was never used; consider replacing with '_' or removing it}}
+    // expected-warning@-1 {{immutable value 'x' was never used}}
+    // expected-note@-2 {{consider replacing with '_' or removing it}}
   }
 
   init(h: Int) {

--- a/test/stmt/errors.swift
+++ b/test/stmt/errors.swift
@@ -137,7 +137,7 @@ func eleven_one() {
     do {
       try thrower()
     // FIXME: suppress the double-emission of the 'always true' warning
-    } catch let e as Error { // expected-warning {{immutable value 'e' was never used}} {{17-18=_}} expected-warning 2 {{'as' test is always true}}
+    } catch let e as Error { // expected-warning {{immutable value 'e' was never used}} expected-note {{consider replacing with '_'}} {{17-18=_}} expected-warning 2 {{'as' test is always true}}
     }
   }
 }

--- a/test/stmt/if_while_var.swift
+++ b/test/stmt/if_while_var.swift
@@ -108,22 +108,24 @@ if case let y? = someInteger { _ = y }  // expected-error {{'?' pattern cannot m
 
 // Test multiple clauses on "if let".
 if let x = opt, let y = opt, x != y,
-   let a = opt, var b = opt { // expected-warning {{immutable value 'a' was never used; consider replacing with '_' or removing it}} expected-warning {{variable 'b' was never used; consider replacing with '_' or removing it}}
+   let a = opt, var b = opt { // expected-warning {{immutable value 'a' was never used}} expected-note {{consider replacing with '_' or removing it}} expected-warning {{variable 'b' was never used}} expected-note {{consider replacing with '_' or removing it}}
 }
 
 // Leading boolean conditional.
 if 1 != 2, let x = opt,
    y = opt,  // expected-error {{expected 'let' in conditional}} {{4-4=let }}
    x != y,
-   let a = opt, var b = opt { // expected-warning {{immutable value 'a' was never used; consider replacing with '_' or removing it}} expected-warning {{variable 'b' was never used; consider replacing with '_' or removing it}}
+   let a = opt, var b = opt { // expected-warning {{immutable value 'a' was never used}} expected-note {{consider replacing with '_' or removing it}} expected-warning {{variable 'b' was never used}} expected-note {{consider replacing with '_' or removing it}}
 }
 
 // <rdar://problem/20457938> typed pattern is not allowed on if/let condition
-if 1 != 2, let x : Int? = opt {} // expected-warning {{immutable value 'x' was never used; consider replacing with '_' or removing it}}
-// expected-warning @-1 {{explicitly specified type 'Int?' adds an additional level of optional to the initializer, making the optional check always succeed}} {{20-24=Int}}
+if 1 != 2, let x : Int? = opt {} // expected-warning {{immutable value 'x' was never used}}
+// expected-note@-1 {{consider replacing with '_' or removing it}}
+// expected-warning @-2 {{explicitly specified type 'Int?' adds an additional level of optional to the initializer, making the optional check always succeed}} {{20-24=Int}}
 
-if 1 != 2, case let x? : Int? = 42 {} // expected-warning {{immutable value 'x' was never used; consider replacing with '_' or removing it}}
-// expected-warning @-1 {{non-optional expression of type 'Int' used in a check for optionals}}
+if 1 != 2, case let x? : Int? = 42 {} // expected-warning {{immutable value 'x' was never used}}
+// expected-note@-1 {{consider replacing with '_' or removing it}}
+// expected-warning @-2 {{non-optional expression of type 'Int' used in a check for optionals}}
 
 
 
@@ -132,7 +134,8 @@ if 1 != 2, case let x? : Int? = 42 {} // expected-warning {{immutable value 'x' 
 if 1 != 2, { // expected-error {{cannot convert value of type '() -> ()' to expected condition type 'Bool'}}
 } // expected-error {{expected '{' after 'if' condition}}
 if 1 != 2, 4 == 57 {}
-if 1 != 2, 4 == 57, let x = opt {} // expected-warning {{immutable value 'x' was never used; consider replacing with '_' or removing it}}
+if 1 != 2, 4 == 57, let x = opt {} // expected-warning {{immutable value 'x' was never used}}
+                                   // expected-note@-1 {{consider replacing with '_' or removing it}}
 
 // Test that these don't cause the parser to crash.
 if true { if a == 0; {} }   // expected-error {{cannot find 'a' in scope}} expected-error {{expected '{' after 'if' condition}}

--- a/test/stmt/rdar40400251.swift
+++ b/test/stmt/rdar40400251.swift
@@ -21,7 +21,8 @@ func foo(_ e: E2) {
     // expected-error@-1 {{switch must be exhaustive}}
     // expected-note@-2 {{add missing case: '.bar(_)'}}
 
-    case .foo(let tuple): break // expected-warning {{immutable value 'tuple' was never used; consider replacing with '_' or removing it}}
+    case .foo(let tuple): break // expected-warning {{immutable value 'tuple' was never used}}
+                                // expected-note@-1 {{consider replacing with '_' or removing it}}
     case .baz: break
   }
 }

--- a/test/stmt/statements.swift
+++ b/test/stmt/statements.swift
@@ -167,7 +167,8 @@ func missing_semicolons() {
   func g() {}
   g() w += 1             // expected-error{{consecutive statements}} {{6-6=;}}
   var z = w"hello"    // expected-error{{consecutive statements}} {{12-12=;}} expected-warning {{string literal is unused}}
-  // expected-warning@-1 {{initialization of variable 'z' was never used; consider replacing with assignment to '_' or removing it}}
+  // expected-warning@-1 {{initialization of variable 'z' was never used}}
+  // expected-note@-2 {{consider replacing with '_' or removing it}}
   class  C {}class  C2 {} // expected-error{{consecutive statements}} {{14-14=;}}
   struct S {}struct S2 {} // expected-error{{consecutive statements}} {{14-14=;}}
   func j() {}func k() {}  // expected-error{{consecutive statements}} {{14-14=;}}

--- a/validation-test/compiler_crashers_2_fixed/sr11509.swift
+++ b/validation-test/compiler_crashers_2_fixed/sr11509.swift
@@ -12,7 +12,8 @@ public struct Wrapper<Value> {
 
 func functionScope() {
   let scopedValue = 3 // expected-note {{'scopedValue' declared here}}
-  // expected-warning@-1 {{initialization of immutable value 'scopedValue' was never used; consider replacing with assignment to '_' or removing it}}
+  // expected-warning@-1 {{initialization of immutable value 'scopedValue' was never used}}
+  // expected-note@-2 {{consider replacing with '_' or removing it}}
   
   enum StaticScope { // expected-note {{type declared here}}
     @Wrapper(someValue: scopedValue) static var foo: String? // expected-error {{enum declaration cannot close over value 'scopedValue' defined in outer scope}}

--- a/validation-test/compiler_crashers_fixed/00040-std-function-func-swift-constraints-solution-computesubstitutions.swift
+++ b/validation-test/compiler_crashers_fixed/00040-std-function-func-swift-constraints-solution-computesubstitutions.swift
@@ -12,5 +12,6 @@
 
 func d<b: Sequence, e>(c : b) -> e? where Optional<e> == b.Iterator.Element {
   for mx : e? in c { // expected-warning {{immutable value 'mx' was never used}}
+  // expected-note@-1 {{consider replacing with '_'}}
   }
 }


### PR DESCRIPTION
The primary goal of the PR is to update the diagnostic for unused `async let` constants so that it doesn't only recommend replacing the name with an underscore, but actually provides some context about what it means to do that vs awaiting the variable name. Specifically, that an underscore name means you will cancel and await it while the explicit await will not cancel the await.

While updating the diagnostic, it makes some sense to break off the `; consider replacing with '_' or removing it` part of the diagnostic to a separate note. This is for consistency, but also presents better in Xcode.

rdar://93781502