### PR TITLE
SILGen: Use ObjC types to lower async completion handler arguments.

### DIFF
--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -217,6 +217,17 @@ SILFunction *SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
     }
     return maybeCompletionHandlerOrigTy.getValue();
   }();
+  
+  // Bridge the block type, so that if it is formally expressed in terms of
+  // bridged Swift types, we still lower the parameters to their ultimate
+  // ObjC types.
+  completionHandlerOrigTy = Types
+    .getBridgedFunctionType(AbstractionPattern(origFormalType.getGenericSignatureOrNull(),
+                                               completionHandlerOrigTy),
+                            completionHandlerOrigTy,
+                            Bridgeability::Full,
+                            SILFunctionTypeRepresentation::Block);
+
   auto blockParams = completionHandlerOrigTy.getParams();
 
   // Build up the implementation function type, which matches the

--- a/test/SILGen/objc_async_defined_in_swift_any.swift
+++ b/test/SILGen/objc_async_defined_in_swift_any.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-emit-silgen(mock-sdk: %clang-importer-sdk) -disable-availability-checking -verify %s
+// REQUIRES: concurrency
+// REQUIRES: objc_interop
+
+import Foundation 
+@objc public protocol TAService {
+    func removeKey() async -> Any
+}
+
+class FakeService : TAService {
+    func removeKey() async -> Any {
+        return ""
+    }
+}
+
+class FakeClassHolder {
+    var service : TAService = FakeService()
+
+    func removeKey(_ key: String) async {
+        _ = await self.service.removeKey()
+    }
+}


### PR DESCRIPTION
An `@objc` interface defined from Swift may have a formal type in terms of its
Swift bridged types, but we want to lower the SIL-level completion handler
implementation according to the actual ObjC types that will be passed at runtime.
Fixes rdar://93112430