### PR TITLE
Introduce FUTURE_FEATURE definitions for features staged in Swift 6.

### DIFF
--- a/include/swift/Basic/Feature.h
+++ b/include/swift/Basic/Feature.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_BASIC_FEATURES_H
 #define SWIFT_BASIC_FEATURES_H
 
+#include "llvm/ADT/Optional.h"
 #include "llvm/ADT/StringRef.h"
 
 namespace swift {
@@ -51,9 +52,16 @@ inline bool featureImpliesFeature(Feature feature, Feature implied) {
   return (unsigned) feature < (unsigned) implied;
 }
 
+/// Get the feature corresponding to this "future" feature, if there is one.
+llvm::Optional<Feature> getFutureFeature(llvm::StringRef name);
+
 /// Get the feature corresponding to this "experimental" feature, if there is
 /// one.
 llvm::Optional<Feature> getExperimentalFeature(llvm::StringRef name);
+
+/// Get the major language version in which this feature was introduced, or
+/// \c None if it does not have such a version.
+llvm::Optional<unsigned> getFeatureLanguageVersion(Feature feature);
 
 }
 

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -90,6 +90,7 @@ SUPPRESSIBLE_LANGUAGE_FEATURE(UnavailableFromAsync, 0, "@_unavailableFromAsync",
 SUPPRESSIBLE_LANGUAGE_FEATURE(NoAsyncAvailability, 340, "@available(*, noasync)", true)
 
 FUTURE_FEATURE(ConciseMagicFile, 274, 6)
+FUTURE_FEATURE(ForwardTrailingClosures, 286, 6)
 
 EXPERIMENTAL_FEATURE(StaticAssert)
 EXPERIMENTAL_FEATURE(VariadicGenerics)

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -48,6 +48,12 @@
   LANGUAGE_FEATURE(FeatureName, SENumber, Description, Option)
 #endif
 
+#ifndef FUTURE_FEATURE
+#  define FUTURE_FEATURE(FeatureName, SENumber, Version)   \
+     LANGUAGE_FEATURE(FeatureName, SENumber, #FeatureName, \
+                      langOpts.hasFeature(#FeatureName))
+#endif
+
 #ifndef EXPERIMENTAL_FEATURE
 #  define EXPERIMENTAL_FEATURE(FeatureName)  \
      LANGUAGE_FEATURE(FeatureName, 0, #FeatureName, \
@@ -83,6 +89,8 @@ SUPPRESSIBLE_LANGUAGE_FEATURE(PrimaryAssociatedTypes2, 346, "Primary associated 
 SUPPRESSIBLE_LANGUAGE_FEATURE(UnavailableFromAsync, 0, "@_unavailableFromAsync", true)
 SUPPRESSIBLE_LANGUAGE_FEATURE(NoAsyncAvailability, 340, "@available(*, noasync)", true)
 
+FUTURE_FEATURE(ConciseMagicFile, 274, 6)
+
 EXPERIMENTAL_FEATURE(StaticAssert)
 EXPERIMENTAL_FEATURE(VariadicGenerics)
 EXPERIMENTAL_FEATURE(NamedOpaqueTypes)
@@ -92,5 +100,6 @@ EXPERIMENTAL_FEATURE(OneWayClosureParameters)
 EXPERIMENTAL_FEATURE(TypeWitnessSystemInference)
 
 #undef EXPERIMENTAL_FEATURE
+#undef FUTURE_FEATURE
 #undef SUPPRESSIBLE_LANGUAGE_FEATURE
 #undef LANGUAGE_FEATURE

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -91,6 +91,7 @@ SUPPRESSIBLE_LANGUAGE_FEATURE(NoAsyncAvailability, 340, "@available(*, noasync)"
 
 FUTURE_FEATURE(ConciseMagicFile, 274, 6)
 FUTURE_FEATURE(ForwardTrailingClosures, 286, 6)
+FUTURE_FEATURE(BareSlashRegexLiterals, 354, 6)
 
 EXPERIMENTAL_FEATURE(StaticAssert)
 EXPERIMENTAL_FEATURE(VariadicGenerics)

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -529,10 +529,6 @@ namespace swift {
     /// Enables dumping type witness systems from associated type inference.
     bool DumpTypeWitnessSystems = false;
 
-    /// Enables `/.../` syntax regular-expression literals. This requires
-    /// experimental string processing. Note this does not affect `#/.../#`.
-    bool EnableBareSlashRegexLiterals = false;
-
     /// Sets the target we are building for and updates platform conditions
     /// to match.
     ///

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -354,6 +354,9 @@ namespace swift {
     /// The set of features that have been enabled.
     llvm::SmallSet<Feature, 2> Features;
 
+    /// Temporary flag to support LLDB's transition to using \c Features.
+    bool EnableBareSlashRegexLiterals = false;
+
     /// Use Clang function types for computing canonical types.
     /// If this option is false, the clang function types will still be computed
     /// but will not be used for checking type equality.

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3003,6 +3003,14 @@ static bool usesFeatureConciseMagicFile(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureForwardTrailingClosures(Decl *decl) {
+  return false;
+}
+
+static bool usesFeatureBareSlashRegexLiterals(Decl *decl) {
+  return false;
+}
+
 static bool usesFeatureVariadicGenerics(Decl *decl) {
   return false;
 }
@@ -3024,10 +3032,6 @@ static bool usesFeatureOneWayClosureParameters(Decl *decl) {
 }
 
 static bool usesFeatureTypeWitnessSystemInference(Decl *decl) {
-  return false;
-}
-
-static bool usesFeatureForwardTrailingClosures(Decl *decl) {
   return false;
 }
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2999,6 +2999,10 @@ static bool usesFeatureNoAsyncAvailability(Decl *decl) {
    return decl->getAttrs().getNoAsync(decl->getASTContext()) != nullptr;
 }
 
+static bool usesFeatureConciseMagicFile(Decl *decl) {
+  return false;
+}
+
 static bool usesFeatureVariadicGenerics(Decl *decl) {
   return false;
 }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3027,6 +3027,10 @@ static bool usesFeatureTypeWitnessSystemInference(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureForwardTrailingClosures(Decl *decl) {
+  return false;
+}
+
 static void
 suppressingFeatureNoAsyncAvailability(PrintOptions &options,
                                       llvm::function_ref<void()> action) {

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -229,6 +229,10 @@ bool LangOptions::hasFeature(Feature feature) const {
   if (Features.contains(feature))
     return true;
 
+  if (feature == Feature::BareSlashRegexLiterals &&
+      EnableBareSlashRegexLiterals)
+    return true;
+
   if (auto version = getFeatureLanguageVersion(feature))
     return isSwiftVersionAtLeast(*version);
 

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -23,6 +23,7 @@
 #include "swift/Config.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/raw_ostream.h"
 #include <limits.h>
 
@@ -228,10 +229,16 @@ bool LangOptions::hasFeature(Feature feature) const {
   if (Features.contains(feature))
     return true;
 
+  if (auto version = getFeatureLanguageVersion(feature))
+    return isSwiftVersionAtLeast(*version);
+
   return false;
 }
 
 bool LangOptions::hasFeature(llvm::StringRef featureName) const {
+  if (auto feature = getFutureFeature(featureName))
+    return hasFeature(*feature);
+
   if (auto feature = getExperimentalFeature(featureName))
     return hasFeature(*feature);
 
@@ -423,6 +430,15 @@ bool swift::isSuppressibleFeature(Feature feature) {
   llvm_unreachable("covered switch");
 }
 
+llvm::Optional<Feature> swift::getFutureFeature(llvm::StringRef name) {
+  return llvm::StringSwitch<Optional<Feature>>(name)
+#define LANGUAGE_FEATURE(FeatureName, SENumber, Description, Option)
+#define FUTURE_FEATURE(FeatureName, SENumber, Version) \
+                   .Case(#FeatureName, Feature::FeatureName)
+#include "swift/Basic/Features.def"
+                   .Default(None);
+}
+
 llvm::Optional<Feature> swift::getExperimentalFeature(llvm::StringRef name) {
   return llvm::StringSwitch<Optional<Feature>>(name)
 #define LANGUAGE_FEATURE(FeatureName, SENumber, Description, Option)
@@ -430,6 +446,16 @@ llvm::Optional<Feature> swift::getExperimentalFeature(llvm::StringRef name) {
                    .Case(#FeatureName, Feature::FeatureName)
 #include "swift/Basic/Features.def"
                    .Default(None);
+}
+
+llvm::Optional<unsigned> swift::getFeatureLanguageVersion(Feature feature) {
+  switch (feature) {
+#define LANGUAGE_FEATURE(FeatureName, SENumber, Description, Option)
+#define FUTURE_FEATURE(FeatureName, SENumber, Version) \
+  case Feature::FeatureName: return Version;
+#include "swift/Basic/Features.def"
+  default: return None;
+  }
 }
 
 DiagnosticBehavior LangOptions::getAccessNoteFailureLimit() const {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -486,25 +486,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
       = A->getOption().matches(OPT_enable_deserialization_recovery);
   }
 
-  // Whether '/.../' regex literals are enabled. This implies experimental
-  // string processing.
-  if (Args.hasArg(OPT_enable_bare_slash_regex)) {
-    Opts.EnableBareSlashRegexLiterals = true;
-    Opts.EnableExperimentalStringProcessing = true;
-  }
-
-  // Experimental string processing.
-  if (auto A = Args.getLastArg(OPT_enable_experimental_string_processing,
-                               OPT_disable_experimental_string_processing)) {
-    Opts.EnableExperimentalStringProcessing =
-        A->getOption().matches(OPT_enable_experimental_string_processing);
-
-    // When experimental string processing is explicitly disabled, also disable
-    // forward slash regex `/.../`.
-    if (!Opts.EnableExperimentalStringProcessing)
-      Opts.EnableBareSlashRegexLiterals = false;
-  }
-
   Opts.EnableExperimentalBoundGenericExtensions |=
     Args.hasArg(OPT_enable_experimental_bound_generic_extensions);
 
@@ -632,6 +613,12 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     Opts.addCustomConditionalCompilationFlag(A->getValue());
   }
 
+  // Determine whether string processing is enabled
+  Opts.EnableExperimentalStringProcessing =
+    Args.hasFlag(OPT_enable_experimental_string_processing,
+                 OPT_disable_experimental_string_processing,
+                 Args.hasArg(OPT_enable_bare_slash_regex));
+
   // Add a future feature if it is not already implied by the language version.
   auto addFutureFeatureIfNotImplied = [&](Feature feature) {
     // Check if this feature was introduced already in this language version.
@@ -646,6 +633,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   // Map historical flags over to future features.
   if (Args.hasArg(OPT_enable_experimental_concise_pound_file))
     addFutureFeatureIfNotImplied(Feature::ConciseMagicFile);
+  if (Args.hasArg(OPT_enable_bare_slash_regex))
+    addFutureFeatureIfNotImplied(Feature::BareSlashRegexLiterals);
 
   for (const Arg *A : Args.filtered(OPT_enable_experimental_feature)) {
     // If this is a known experimental feature, allow it in +Asserts

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -881,7 +881,8 @@ UnresolvedDeclRefExpr *Parser::parseExprOperator() {
 }
 
 void Parser::tryLexRegexLiteral(bool forUnappliedOperator) {
-  if (!Context.LangOpts.EnableBareSlashRegexLiterals)
+  if (!Context.LangOpts.hasFeature(Feature::BareSlashRegexLiterals) ||
+      !Context.LangOpts.EnableExperimentalStringProcessing)
     return;
 
   // Check to see if we have a regex literal `/.../`, optionally with a prefix

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1114,7 +1114,7 @@ getMagicIdentifierLiteralKind(tok Kind, const LangOptions &Opts) {
   switch (Kind) {
   case tok::pound_file:
     // TODO: Enable by default at the next source break. (SR-13199)
-    return Opts.EnableConcisePoundFile
+    return Opts.hasFeature(Feature::ConciseMagicFile)
          ? MagicIdentifierLiteralExpr::FileIDSpelledAsFile
          : MagicIdentifierLiteralExpr::FilePathSpelledAsFile;
 #define MAGIC_IDENTIFIER_TOKEN(NAME, TOKEN) \

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -472,7 +472,7 @@ static bool matchCallArgumentsImpl(
       // way to successfully match arguments to parameters.
       if (!parameterRequiresArgument(params, paramInfo, paramIdx) &&
           !param.getPlainType()->getASTContext().LangOpts
-              .isSwiftVersionAtLeast(6) &&
+              .hasFeature(Feature::ForwardTrailingClosures) &&
           anyParameterRequiresArgument(
               params, paramInfo, paramIdx + 1,
               nextArgIdx + 1 < numArgs
@@ -934,7 +934,7 @@ static bool requiresBothTrailingClosureDirections(
 
   // If backward matching is disabled, only scan forward.
   ASTContext &ctx = params.front().getPlainType()->getASTContext();
-  if (ctx.LangOpts.isSwiftVersionAtLeast(6))
+  if (ctx.LangOpts.hasFeature(Feature::ForwardTrailingClosures))
     return false;
 
   // If there are at least two parameters that meet the backward scan's

--- a/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
+++ b/tools/libSwiftSyntaxParser/libSwiftSyntaxParser.cpp
@@ -512,9 +512,7 @@ swiftparse_client_node_t SynParser::parse(const char *source, size_t len) {
 
   // Always enable bare /.../ regex literal in syntax parser.
   langOpts.EnableExperimentalStringProcessing = true;
-  if (EnableBareSlashRegexLiteral && *EnableBareSlashRegexLiteral) {
-    langOpts.EnableBareSlashRegexLiterals = true;
-  }
+  langOpts.Features.insert(Feature::BareSlashRegexLiterals);
   if (EffectiveLanguageVersion) {
     langOpts.EffectiveLanguageVersion = *EffectiveLanguageVersion;
   }

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -4305,7 +4305,7 @@ int main(int argc, char *argv[]) {
     InitInvok.getLangOptions().EnableExperimentalStringProcessing = true;
   }
   if (options::EnableBareSlashRegexLiterals) {
-    InitInvok.getLangOptions().EnableBareSlashRegexLiterals = true;
+    InitInvok.getLangOptions().Features.insert(Feature::BareSlashRegexLiterals);
     InitInvok.getLangOptions().EnableExperimentalStringProcessing = true;
   }
 

--- a/tools/swift-syntax-test/swift-syntax-test.cpp
+++ b/tools/swift-syntax-test/swift-syntax-test.cpp
@@ -592,7 +592,7 @@ int parseFile(
   Invocation.getLangOptions().VerifySyntaxTree = options::VerifySyntaxTree;
   Invocation.getLangOptions().DisablePoundIfEvaluation = true;
   Invocation.getLangOptions().EnableExperimentalStringProcessing = true;
-  Invocation.getLangOptions().EnableBareSlashRegexLiterals = true;
+  Invocation.getLangOptions().Features.insert(Feature::BareSlashRegexLiterals);
 
   Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(InputFileName);
 


### PR DESCRIPTION
Using the same feature set logic as experimental features, provide
feature names for "future" features, which are changes that will
become available with Swift 6. Use the feature check when determining
whether to implementation the feature instead of a language version
check, and map existing flags for these features (when available) over
to the feature set.

As an internal implementation detail, this makes it easier to reason
about when specific features are enabled (or not). If we decide to go
with piecemeal adoption support for features, it can provide an
alternative path to enabling features that feeds this mechanism.

Use this mechanism for concise `#file`, forward-scan trailing closures,
and bare slash regex literals.