### PR TITLE
[Gardening] fix typo "supercede" -> "supersede"

### DIFF
--- a/lib/SymbolGraphGen/AvailabilityMixin.cpp
+++ b/lib/SymbolGraphGen/AvailabilityMixin.cpp
@@ -134,7 +134,7 @@ Availability::updateFromParent(const Availability &Parent) {
 
   // Allow filling from the parent.
   // For replacement, we will consider a parent's
-  // earlier deprecation to supercede a child's later deprecation.
+  // earlier deprecation to supersede a child's later deprecation.
   if (!Deprecated) {
     Deprecated = Parent.Deprecated;
   } else if (Parent.Deprecated && *Parent.Deprecated < *Deprecated) {

--- a/stdlib/public/Concurrency/MainActor.swift
+++ b/stdlib/public/Concurrency/MainActor.swift
@@ -46,7 +46,7 @@ import Swift
 extension MainActor {
   /// Execute the given body closure on the main actor.
   ///
-  /// Historical ABI entry point, superceded by the Sendable version that is
+  /// Historical ABI entry point, superseded by the Sendable version that is
   /// also inlined to back-deploy a semantic fix where this operation would
   /// not hop back at the end.
   @usableFromInline


### PR DESCRIPTION
- found some misspelled word `"supercede"` → `"supersede"` 😉
- checked the entire Swift repo and fixed 2 files.
  - swift / stdlib / public / Concurrency / MainActor.swift
  - swift / lib / SymbolGraphGen / AvailabilityMixin.cpp