### PR TITLE
Correct complexity statement for Sequence compactMap

### DIFF
--- a/stdlib/public/core/SequenceAlgorithms.swift
+++ b/stdlib/public/core/SequenceAlgorithms.swift
@@ -787,8 +787,7 @@ extension Sequence {
   /// - Returns: An array of the non-`nil` results of calling `transform`
   ///   with each element of the sequence.
   ///
-  /// - Complexity: O(*m* + *n*), where *n* is the length of this sequence
-  ///   and *m* is the length of the result.
+  /// - Complexity: O(*n*), where *n* is the length of this sequence.
   @inlinable // protocol-only
   public func compactMap<ElementOfResult>(
     _ transform: (Element) throws -> ElementOfResult?


### PR DESCRIPTION
<!-- What's in this pull request? -->
This corrects an erroneous statement about the complexity of the `compactMap` function in the `Sequence` protocol.

There error was originally introduced at https://github.com/apple/swift/commit/6f7aecd0302a0d74f2181a187732c627f2895aa0#diff-12859757644da80c942399ba669152a212e379d997c94d70a8063c13ee9caa0eR752 when (what is now called) `compactMap` was broken off from its sibling `flatMap`.

Discussion:

In `compactMap`, the length of the result must be less than or equal to the length of the sequence. Therefore O(m+n) simplifies to O(n).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
