### PR TITLE
[5.7] PerformanceDiagnostics: fix a crash when emitting a module

### DIFF
--- a/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
@@ -90,6 +90,9 @@ static bool isEffectFreeArraySemanticCall(SILInstruction *inst) {
 bool PerformanceDiagnostics::visitFunction(SILFunction *function,
                                               PerformanceConstraints perfConstr,
                                               LocWithParent *parentLoc) {
+  if (!function->isDefinition())
+    return false;
+
   ReachingReturnBlocks rrBlocks(function);
   NonErrorHandlingBlocks neBlocks(function);
                                        

--- a/test/SILOptimizer/performance-annotations-crash.swift
+++ b/test/SILOptimizer/performance-annotations-crash.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend -experimental-performance-annotations -experimental-skip-non-inlinable-function-bodies-without-types -emit-module %s -o /dev/null
+
+// Don't crash when emitting a module
+
+@_noAllocation
+func foo() -> Int {
+  return 42
+}
+print(foo())


### PR DESCRIPTION
rdar://93439187

This is a cherry-pick of https://github.com/apple/swift/pull/59124