### PR TITLE
DiagnosticEngine: Print `any` in 'aka' types

### DIFF
--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -737,7 +737,7 @@ static void formatDiagnosticArgument(StringRef Modifier,
         llvm::SmallString<256> AkaText;
         llvm::raw_svector_ostream OutAka(AkaText);
 
-        OutAka << getAkaTypeForDisplay(type);
+        getAkaTypeForDisplay(type)->print(OutAka, printOptions);
         Out << llvm::format(FormatOpts.AKAFormatString.c_str(),
                             typeName.c_str(), AkaText.c_str());
       } else {

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -544,11 +544,11 @@ func testStrangeSelectors(obj: StrangeSelectors) {
 
 func testProtocolQualified(_ obj: CopyableNSObject, cell: CopyableSomeCell,
                            plainObj: NSObject, plainCell: SomeCell) {
-  _ = obj as NSObject // expected-error {{'CopyableNSObject' (aka 'NSCopying & NSObjectProtocol') is not convertible to 'NSObject'}} 
+  _ = obj as NSObject // expected-error {{'CopyableNSObject' (aka 'any NSCopying & NSObjectProtocol') is not convertible to 'NSObject'}}
   // expected-note@-1 {{did you mean to use 'as!' to force downcast?}} {{11-13=as!}}
   _ = obj as NSObjectProtocol
   _ = obj as NSCopying
-  _ = obj as SomeCell // expected-error {{'CopyableNSObject' (aka 'NSCopying & NSObjectProtocol') is not convertible to 'SomeCell'}}
+  _ = obj as SomeCell // expected-error {{'CopyableNSObject' (aka 'any NSCopying & NSObjectProtocol') is not convertible to 'SomeCell'}}
   // expected-note@-1 {{did you mean to use 'as!' to force downcast?}} {{11-13=as!}}
 
   _ = cell as NSObject
@@ -556,8 +556,8 @@ func testProtocolQualified(_ obj: CopyableNSObject, cell: CopyableSomeCell,
   _ = cell as NSCopying
   _ = cell as SomeCell
   
-  _ = plainObj as CopyableNSObject // expected-error {{cannot convert value of type 'NSObject' to type 'CopyableNSObject' (aka 'NSCopying & NSObjectProtocol') in coercion}}
-  _ = plainCell as CopyableSomeCell // expected-error {{cannot convert value of type 'SomeCell' to type 'CopyableSomeCell' (aka 'SomeCell & NSCopying') in coercion}}
+  _ = plainObj as CopyableNSObject // expected-error {{cannot convert value of type 'NSObject' to type 'CopyableNSObject' (aka 'any NSCopying & NSObjectProtocol') in coercion}}
+  _ = plainCell as CopyableSomeCell // expected-error {{cannot convert value of type 'SomeCell' to type 'CopyableSomeCell' (aka 'any SomeCell & NSCopying') in coercion}}
 }
 
 extension Printing {

--- a/test/ClangImporter/protocol_metatype_object_conversion.swift
+++ b/test/ClangImporter/protocol_metatype_object_conversion.swift
@@ -14,4 +14,4 @@ func takesProtocol(_ x: Protocol) {}
 takesProtocol(ObjCProto.self)
 takesProtocol(ObjCProto2.self)
 takesProtocol(NonObjCProto.self) // expected-error{{cannot convert value of type '(any NonObjCProto).Type' to expected argument type 'Protocol'}}
-takesProtocol(TwoObjCProtos.self) // expected-error{{cannot convert value of type '(any TwoObjCProtos).Type' (aka '(ObjCProto & ObjCProto2).Protocol') to expected argument type 'Protocol'}}
+takesProtocol(TwoObjCProtos.self) // expected-error{{cannot convert value of type '(any TwoObjCProtos).Type' (aka '(any ObjCProto & ObjCProto2).Type') to expected argument type 'Protocol'}}

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -485,8 +485,8 @@ func protocol_composition(_ c: ProtocolP & ProtocolQ, _ c1: ProtocolP & Composit
   _ = c1 as? ConcretePQ1 // OK
   _ = c1 as? ConcretePPQ1 // Ok
   _ = c1 as? NotConforms // Ok
-  _ = c1 as? StructNotComforms // expected-warning {{cast from 'any ProtocolP & Composition' (aka 'ProtocolP & ProtocolP1 & ProtocolQ1') to unrelated type 'StructNotComforms' always fails}}
-  _ = c1 as? NotConformsFinal // expected-warning {{cast from 'any ProtocolP & Composition' (aka 'ProtocolP & ProtocolP1 & ProtocolQ1') to unrelated type 'NotConformsFinal' always fails}}
+  _ = c1 as? StructNotComforms // expected-warning {{cast from 'any ProtocolP & Composition' (aka 'any ProtocolP & ProtocolP1 & ProtocolQ1') to unrelated type 'StructNotComforms' always fails}}
+  _ = c1 as? NotConformsFinal // expected-warning {{cast from 'any ProtocolP & Composition' (aka 'any ProtocolP & ProtocolP1 & ProtocolQ1') to unrelated type 'NotConformsFinal' always fails}}
 }
 
 // SR-13899

--- a/test/Constraints/metatypes.swift
+++ b/test/Constraints/metatypes.swift
@@ -12,7 +12,7 @@ let test4 : AnyClass = B.self
 struct S {}
 
 let test5 : S.Type = S.self
-let test6 : AnyClass = S.self // expected-error {{cannot convert value of type 'S.Type' to specified type 'AnyClass' (aka 'AnyObject.Type')}}
+let test6 : AnyClass = S.self // expected-error {{cannot convert value of type 'S.Type' to specified type 'AnyClass' (aka 'any AnyObject.Type')}}
 
 func acceptMeta<T>(_ meta: T.Type) { }
 acceptMeta(A) // expected-error {{expected member name or constructor call after type name}}

--- a/test/Sema/diag_metatype_cast_to_reference_no_objc.swift
+++ b/test/Sema/diag_metatype_cast_to_reference_no_objc.swift
@@ -3,6 +3,6 @@
 class C {}
 
 func test(c: AnyClass) {
-  let _: AnyObject = c // expected-error {{value of type 'AnyClass' (aka 'AnyObject.Type') expected to be instance of class or class-constrained type}}
+  let _: AnyObject = c // expected-error {{value of type 'AnyClass' (aka 'any AnyObject.Type') expected to be instance of class or class-constrained type}}
   let _: AnyObject = C.self // expected-error {{value of type 'C.Type' expected to be instance of class or class-constrained type}}
 }

--- a/test/decl/protocol/conforms/failure.swift
+++ b/test/decl/protocol/conforms/failure.swift
@@ -214,7 +214,7 @@ protocol P11 {
   associatedtype A: Equatable
   // FIXME: Should not resolve witness for 'method', but Type::subst doesn't care
   // about conditional requirements when querying type witnesses.
-  // expected-note@+1 {{protocol requires function 'method()' with type '() -> Conformer.A' (aka '() -> Array<P11>'); do you want to add a stub?}}
+  // expected-note@+1 {{protocol requires function 'method()' with type '() -> Conformer.A' (aka '() -> Array<any P11>'); do you want to add a stub?}}
   func method() -> A
 }
 do {
@@ -223,7 +223,7 @@ do {
     // expected-error@-2 {{type 'any P11' does not conform to protocol 'Equatable'}} // FIXME: Crappy diagnostics
     // expected-error@-3 {{'P11' requires that 'any P11' conform to 'Equatable'}}
     // expected-note@-4 {{requirement specified as 'any P11' : 'Equatable'}}
-    // expected-note@-5 {{requirement from conditional conformance of 'Conformer.A' (aka 'Array<P11>') to 'Equatable'}}
+    // expected-note@-5 {{requirement from conditional conformance of 'Conformer.A' (aka 'Array<any P11>') to 'Equatable'}}
     typealias A = Array<any P11>
   }
 }

--- a/test/expr/postfix/call/construction.swift
+++ b/test/expr/postfix/call/construction.swift
@@ -119,5 +119,5 @@ func constructExistentialValue(_ pm: P.Type) {
 typealias P1_and_P2 = P & P2
 func constructExistentialCompositionValue(_ pm: (P & P2).Type) {
   _ = pm.init(int: 5)
-  _ = P1_and_P2(int: 5) // expected-error{{type 'any P1_and_P2' (aka 'P & P2') cannot be instantiated}}
+  _ = P1_and_P2(int: 5) // expected-error{{type 'any P1_and_P2' (aka 'any P & P2') cannot be instantiated}}
 }

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -334,7 +334,7 @@ func testEnumAssociatedValue() {
 
 // https://github.com/apple/swift/issues/58920
 typealias Iterator = any IteratorProtocol
-var example: any Iterator = 5 // expected-error{{redundant 'any' has no effect on existential type 'Iterator' (aka 'IteratorProtocol')}} {{14-18=}} 
+var example: any Iterator = 5 // expected-error{{redundant 'any' has no effect on existential type 'Iterator' (aka 'any IteratorProtocol')}} {{14-18=}} 
 // expected-error@-1{{value of type 'Int' does not conform to specified type 'IteratorProtocol'}}
 var example1: any (any IteratorProtocol) = 5 // expected-error{{redundant 'any' has no effect on existential type 'any IteratorProtocol'}} {{15-19=}}
 // expected-error@-1{{value of type 'Int' does not conform to specified type 'IteratorProtocol'}}


### PR DESCRIPTION
We ought to be passing the same options we use for printing type arguments. Besides `any`, doing so also mirrors type qualification and inclusion of function convention attributes in 'aka' types, which makes sense.