### PR TITLE
[DO NOT MERGE] Always use fallback type check for code completion

### DIFF
--- a/lib/IDE/AfterPoundExprCompletion.cpp
+++ b/lib/IDE/AfterPoundExprCompletion.cpp
@@ -29,7 +29,7 @@ void AfterPoundExprCompletion::sawSolutionImpl(const constraints::Solution &S) {
 
   // If ExpectedTy is a duplicate of any other result, ignore this solution.
   auto IsEqual = [&](const Result &R) {
-    return R.ExpectedTy->isEqual(ExpectedTy);
+    return nullableTypesEqual(R.ExpectedTy, ExpectedTy);
   };
   if (!llvm::any_of(Results, IsEqual)) {
     bool SingleExprBody = isImplicitSingleExpressionReturn(CS, CompletionExpr);

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1393,7 +1393,7 @@ bool CodeCompletionCallbacksImpl::trySolverCompletion(bool MaybeFuncBody) {
     // switch case where there control expression is invalid). Having normal
     // typechecking still resolve even these cases would be beneficial for
     // tooling in general though.
-    if (!Lookup.gotCallback())
+//    if (!Lookup.gotCallback())
       Lookup.fallbackTypeCheck(CurDeclContext);
   };
 

--- a/lib/IDE/DotExprCompletion.cpp
+++ b/lib/IDE/DotExprCompletion.cpp
@@ -22,7 +22,7 @@ using namespace swift::constraints;
 using namespace swift::ide;
 
 void DotExprTypeCheckCompletionCallback::fallbackTypeCheck(DeclContext *DC) {
-  assert(!gotCallback());
+//  assert(!gotCallback());
 
   // Default to checking the completion expression in isolation.
   Expr *fallbackExpr = CompletionExpr;

--- a/lib/IDE/TypeCheckCompletionCallback.cpp
+++ b/lib/IDE/TypeCheckCompletionCallback.cpp
@@ -21,7 +21,7 @@ using namespace swift::ide;
 using namespace swift::constraints;
 
 void TypeCheckCompletionCallback::fallbackTypeCheck(DeclContext *DC) {
-  assert(!GotCallback);
+//  assert(!GotCallback);
 
   CompletionContextFinder finder(DC);
   if (!finder.hasCompletionExpr())


### PR DESCRIPTION
Always use the fallback case for code completion. This highly regresses quality of results but allows us to check if the stress tester finds any crashes in the fallback case that were previously hidden because we didn’t need to enter the fallback case.