### PR TITLE
[cxx-interop][SwiftCompilerSources] Fix conversion between `std::string` and `Swift.String`

### DIFF
--- a/SwiftCompilerSources/Sources/Basic/Utils.swift
+++ b/SwiftCompilerSources/Sources/Basic/Utils.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 @_exported import BasicBridging
+import std
 
 //===----------------------------------------------------------------------===//
 //                              StringRef
@@ -59,6 +60,13 @@ extension String {
     return str.withUTF8 { buffer in
       return c(BridgedStringRef(data: buffer.baseAddress, length: buffer.count))
     }
+  }
+
+  /// Underscored to avoid name collision with the std overlay.
+  /// To be replaced with an overlay call once the CI uses SDKs built with Swift 5.8.
+  public init(_cxxString s: std.string) {
+    self.init(cString: s.c_str())
+    withExtendedLifetime(s) {}
   }
 }
 

--- a/SwiftCompilerSources/Sources/SIL/BasicBlock.swift
+++ b/SwiftCompilerSources/Sources/SIL/BasicBlock.swift
@@ -25,8 +25,7 @@ final public class BasicBlock : ListNode, CustomStringConvertible, HasShortDescr
   public var function: Function { SILBasicBlock_getFunction(bridged).function }
 
   public var description: String {
-    var s = SILBasicBlock_debugDescription(bridged)
-    return String(cString: s.c_str())
+    String(_cxxString: SILBasicBlock_debugDescription(bridged))
   }
   public var shortDescription: String { name }
 

--- a/SwiftCompilerSources/Sources/SIL/Function.swift
+++ b/SwiftCompilerSources/Sources/SIL/Function.swift
@@ -21,8 +21,7 @@ final public class Function : CustomStringConvertible, HasShortDescription {
   }
 
   final public var description: String {
-    var s = SILFunction_debugDescription(bridged)
-    return String(cString: s.c_str())
+    String(_cxxString: SILFunction_debugDescription(bridged))
   }
 
   public var shortDescription: String { name.string }

--- a/SwiftCompilerSources/Sources/SIL/GlobalVariable.swift
+++ b/SwiftCompilerSources/Sources/SIL/GlobalVariable.swift
@@ -19,8 +19,7 @@ final public class GlobalVariable : CustomStringConvertible, HasShortDescription
   }
 
   public var description: String {
-    var s = SILGlobalVariable_debugDescription(bridged)
-    return String(cString: s.c_str())
+    String(_cxxString: SILGlobalVariable_debugDescription(bridged))
   }
 
   public var shortDescription: String { name.string }

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -38,8 +38,7 @@ public class Instruction : ListNode, CustomStringConvertible, Hashable {
   final public var function: Function { block.function }
 
   final public var description: String {
-    var s = SILNode_debugDescription(bridgedNode)
-    return String(cString: s.c_str())
+    String(_cxxString: SILNode_debugDescription(bridgedNode))
   }
 
   final public var operands: OperandArray {
@@ -143,8 +142,7 @@ public class SingleValueInstruction : Instruction, Value {
 
 public final class MultipleValueInstructionResult : Value {
   final public var description: String {
-    var s = SILNode_debugDescription(bridgedNode)
-    return String(cString: s.c_str())
+    String(_cxxString: SILNode_debugDescription(bridgedNode))
   }
 
   public var instruction: Instruction {

--- a/SwiftCompilerSources/Sources/SIL/Value.swift
+++ b/SwiftCompilerSources/Sources/SIL/Value.swift
@@ -81,8 +81,7 @@ public enum Ownership {
 
 extension Value {
   public var description: String {
-    var s = SILNode_debugDescription(bridgedNode)
-    return String(cString: s.c_str())
+    String(_cxxString: SILNode_debugDescription(bridgedNode))
   }
 
   public var uses: UseList {

--- a/test/SILOptimizer/addr_escape_info.sil
+++ b/test/SILOptimizer/addr_escape_info.sil
@@ -2,9 +2,6 @@
 
 // REQUIRES: swift_in_compiler
 
-// rdar92963081
-// UNSUPPORTED: OS=linux-gnu
-
 sil_stage canonical
 
 import Builtin

--- a/test/SILOptimizer/escape_info.sil
+++ b/test/SILOptimizer/escape_info.sil
@@ -2,9 +2,6 @@
 
 // REQUIRES: swift_in_compiler
 
-// rdar92963081
-// UNSUPPORTED: OS=linux-gnu
-
 
 sil_stage canonical
 

--- a/test/SILOptimizer/ranges.sil
+++ b/test/SILOptimizer/ranges.sil
@@ -2,9 +2,6 @@
 
 // REQUIRES: swift_in_compiler
 
-// rdar92963081
-// UNSUPPORTED: OS=linux-gnu
-
 
 sil_stage canonical
 


### PR DESCRIPTION
This fixes a dangling pointer issue when creating a `Swift.String` from `std::string`.

Also fixes a warning:
```
warning: variable 's' was never mutated; consider changing to 'let' constant
    var s = SILBasicBlock_debugDescription(bridged)
    ~~~ ^
    let
```

rdar://92963081
rdar://93053488