### PR TITLE
[cxx-interop] Enable a test on Linux

### DIFF
--- a/test/Interop/Cxx/stdlib/use-std-vector.swift
+++ b/test/Interop/Cxx/stdlib/use-std-vector.swift
@@ -3,11 +3,11 @@
 // REQUIRES: executable_test
 //
 // Enable this everywhere once we have a solution for modularizing libstdc++: rdar://87654514
-// REQUIRES: OS=macosx
+// REQUIRES: OS=macosx || OS=linux-gnu
 
 import StdlibUnittest
 import StdVector
-import CxxStdlib.vector
+import CxxStdlib
 
 var StdVectorTestSuite = TestSuite("StdVector")
 


### PR DESCRIPTION
This test no longer causes a crash on Linux, so let's try enabling it.