### PR TITLE
[cxx-interop] Do not warn about missing libstdc++ on Android

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -881,6 +881,9 @@ getClangInvocationFileMapping(ASTContext &ctx) {
   // We currently only need this when building for Linux.
   if (!triple.isOSLinux())
     return {};
+  // Android uses libc++.
+  if (triple.isAndroid())
+    return {};
 
   auto clangDiags = clang::CompilerInstance::createDiagnostics(
       new clang::DiagnosticOptions());


### PR DESCRIPTION
Android uses libc++.

This fixes a few tests on Android.