### PR TITLE
[SwiftSyntax] Allow enabling bare slash regex parsing in swift-syntax-parser-test

### DIFF
--- a/test/Syntax/Parser/unterminated_regex.swift
+++ b/test/Syntax/Parser/unterminated_regex.swift
@@ -1,4 +1,4 @@
-// RUN: %swift-syntax-parser-test -dump-diags %s | %FileCheck %s
+// RUN: %swift-syntax-parser-test -dump-diags --swift-version 5 --enable-bare-slash-regex %s | %FileCheck %s
 // CHECK: 6:21 Error: unterminated regex literal
 // CHECK: 1 error(s) 0 warnings(s) 0 note(s)
 

--- a/tools/swift-syntax-parser-test/swift-syntax-parser-test.cpp
+++ b/tools/swift-syntax-parser-test/swift-syntax-parser-test.cpp
@@ -54,6 +54,15 @@ Filename(cl::Positional, cl::desc("source file"), cl::Required);
 static cl::opt<unsigned>
 NumParses("n", cl::desc("number of invocations"), cl::init(1));
 
+static cl::opt<std::string>
+    SwiftVersion("swift-version",
+                 cl::desc("Interpret input according to a specific Swift "
+                          "language version number"));
+
+static cl::opt<bool>
+    EnableBareSlashRegex("enable-bare-slash-regex",
+                         cl::desc("Enable or disable the use of forward slash "
+                                  "regular-expression literal syntax"));
 }
 
 namespace {
@@ -136,8 +145,14 @@ makeNode(const swiftparse_syntax_node_t *raw_node, StringRef source) {
 
 static swiftparse_client_node_t
 parse(StringRef source, swiftparse_node_handler_t node_handler,
+      StringRef swift_version, bool enable_bare_slash_regex,
       swiftparse_diagnostic_handler_t diag_handler = nullptr) {
   swiftparse_parser_t parser = swiftparse_parser_create();
+  if (!swift_version.empty()) {
+    swiftparse_parser_set_language_version(parser, swift_version.str().c_str());
+  }
+  swiftparse_parser_set_enable_bare_slash_regex_literal(
+      parser, enable_bare_slash_regex);
   swiftparse_parser_set_node_handler(parser, node_handler);
   swiftparse_parser_set_diagnostic_handler(parser, diag_handler);
   swiftparse_client_node_t top =
@@ -146,13 +161,15 @@ parse(StringRef source, swiftparse_node_handler_t node_handler,
   return top;
 }
 
-static int dumpTree(StringRef source) {
+static int dumpTree(StringRef source, StringRef swiftVersion,
+                    bool enableBareSlashRegex) {
   swiftparse_node_handler_t nodeHandler =
     ^swiftparse_client_node_t(const swiftparse_syntax_node_t *raw_node) {
       return makeNode(raw_node, source);
     };
 
-  std::unique_ptr<SPNode> top = convertClientNode(parse(source, nodeHandler));
+  std::unique_ptr<SPNode> top = convertClientNode(
+      parse(source, nodeHandler, swiftVersion, enableBareSlashRegex));
   top->dump(outs());
 
   return 0;
@@ -217,16 +234,18 @@ static void printDiagInfo(const swiftparser_diagnostic_t diag,
 }
 
 static int dumpDiagnostics(StringRef source, llvm::SourceMgr &SM,
-                           unsigned BufferId) {
+                           unsigned BufferId, StringRef swiftVersion,
+                           bool enableBareSlashRegex) {
   swiftparse_node_handler_t nodeHandler =
   ^swiftparse_client_node_t(const swiftparse_syntax_node_t *raw_node) {
     return makeNode(raw_node, source);
   };
   std::shared_ptr<PrintDiagData> pData = std::make_shared<PrintDiagData>();
-  convertClientNode(parse(source, nodeHandler,
+  convertClientNode(parse(
+      source, nodeHandler, swiftVersion, enableBareSlashRegex,
       ^(const swiftparser_diagnostic_t diag) {
-    printDiagInfo(diag, SM, BufferId, const_cast<PrintDiagData&>(*pData));
-  }));
+        printDiagInfo(diag, SM, BufferId, const_cast<PrintDiagData &>(*pData));
+      }));
   return 0;
 }
 
@@ -255,7 +274,8 @@ static void printTimeRecord(unsigned numInvoks, const TimeRecord &total,
   OS << '\n';
 }
 
-static int timeParsing(StringRef source, unsigned numInvoks) {
+static int timeParsing(StringRef source, unsigned numInvoks,
+                       StringRef swiftVersion, bool enableBareSlashRegex) {
   swiftparse_node_handler_t nodeHandler =
     ^swiftparse_client_node_t(const swiftparse_syntax_node_t *raw_node) {
       return nullptr;
@@ -264,7 +284,7 @@ static int timeParsing(StringRef source, unsigned numInvoks) {
   Timer timer;
   timer.startTimer();
   for (unsigned i = 0; i != numInvoks; ++i) {
-    parse(source, nodeHandler);
+    parse(source, nodeHandler, swiftVersion, enableBareSlashRegex);
   }
   timer.stopTimer();
 
@@ -288,10 +308,13 @@ int main(int argc, char *argv[]) {
   auto BufferId = SM.AddNewSourceBuffer(std::move(*fileBufOrErr), SMLoc());
   switch (options::Action) {
   case ActionType::DumpTree:
-    return dumpTree(source);
+    return dumpTree(source, options::SwiftVersion,
+                    options::EnableBareSlashRegex);
   case ActionType::Time:
-    return timeParsing(source, options::NumParses);
+    return timeParsing(source, options::NumParses, options::SwiftVersion,
+                       options::EnableBareSlashRegex);
   case ActionType::Diagnostics:
-    return dumpDiagnostics(source, SM, BufferId);
+    return dumpDiagnostics(source, SM, BufferId, options::SwiftVersion,
+                           options::EnableBareSlashRegex);
   }
 }


### PR DESCRIPTION
https://github.com/apple/swift-syntax/pull/448 disabled bare slash regex parsing by default but I forgot to enable it for the `unterminated_regex.swift` test case that was added after that PR ran its tests.