### PR TITLE
[5.7][CSClosure] Perform syntactic checks on rewritten statements

### DIFF
--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -1196,6 +1196,17 @@ private:
     return nullptr;
   }
 
+  ASTNode visit(Stmt *S) {
+    auto rewritten = ASTVisitor::visit(S);
+    if (!rewritten)
+      return {};
+
+    if (auto *stmt = getAsStmt(rewritten))
+      performStmtDiagnostics(stmt, closure);
+
+    return rewritten;
+  }
+
   void visitDecl(Decl *decl) {
     if (isa<IfConfigDecl>(decl))
       return;

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -405,6 +405,36 @@ func test_type_finder_doesnt_walk_into_inner_closures() {
   }
 }
 
+// rdar://94049113 - compiler accepts non-optional `guard let` in a closure
+func test_non_optional_guard_let_is_diagnosed() {
+  func fn(_: (Int) -> Void) {}
+
+  fn {
+    if true {
+      guard let v = $0 else { // expected-error {{initializer for conditional binding must have Optional type, not 'Int'}}
+        return
+      }
+
+      print(v)
+    }
+  }
+
+  fn {
+    switch $0 {
+    case (let val):
+      fn {
+        guard let x = val else {  // expected-error {{initializer for conditional binding must have Optional type, not 'Int'}}
+          return
+        }
+
+        print($0 + x)
+      }
+
+    default: break
+    }
+  }
+}
+
 // rdar://93796211 (issue#59035) - crash during solution application to fallthrough statement
 func test_fallthrough_stmt() {
   {


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/59134

---

Fix an oversight where syntactic checking was not performed on
any statements in a body of a multi-statement after successful
solution application.

Resolves: rdar://94049113
(cherry picked from commit 953095a9ce041e4e913da13058c9f762c595de04)


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
