### PR TITLE
[SwiftSyntax] Build a static verison of the parser lib on Darwin

### DIFF
--- a/tools/libSwiftSyntaxParser/CMakeLists.txt
+++ b/tools/libSwiftSyntaxParser/CMakeLists.txt
@@ -1,57 +1,90 @@
 include(SwiftWindowsSupport)
 swift_swap_compiler_if_needed("SwiftSyntaxParser")
 
-# Use an 'internal' name, this is primarily intended for SwiftSyntax to import.
-set(SYNTAX_PARSER_LIB_NAME "_InternalSwiftSyntaxParser")
+function(create_parser_library target_name lib_name type)
+  set(SYNTAX_PARSER_LIB_NAME "${lib_name}")
 
-set(LLVM_EXPORTED_SYMBOL_FILE
-    ${CMAKE_CURRENT_SOURCE_DIR}/libSwiftSyntaxParser.exports)
+  set(LLVM_EXPORTED_SYMBOL_FILE
+      ${CMAKE_CURRENT_SOURCE_DIR}/libSwiftSyntaxParser.exports)
 
-add_swift_host_library(libSwiftSyntaxParser SHARED
-  c-include-check.c
-  libSwiftSyntaxParser.cpp
-  HAS_SWIFT_MODULES
-  LLVM_LINK_COMPONENTS support)
-if(NOT SWIFT_BUILT_STANDALONE AND NOT CMAKE_C_COMPILER_ID MATCHES Clang)
-  add_dependencies(libSwiftSyntaxParser clang)
-endif()
-target_link_libraries(libSwiftSyntaxParser PRIVATE
-  swiftParse
-  swiftCompilerModules_SwiftSyntax)
-set_target_properties(libSwiftSyntaxParser
-    PROPERTIES
-    OUTPUT_NAME ${SYNTAX_PARSER_LIB_NAME})
-
-add_llvm_symbol_exports(libSwiftSyntaxParser ${LLVM_EXPORTED_SYMBOL_FILE})
-
-# Adds -dead_strip option
-add_link_opts(libSwiftSyntaxParser)
-
-if (SWIFT_LIBPARSER_VER)
-  set(SWIFTSYNTAX_PARSER_VERSION_STRING "${SWIFT_LIBPARSER_VER}")
-else()
-  set(SWIFTSYNTAX_PARSER_VERSION_STRING "${SWIFT_COMPILER_VERSION}")
-endif()
-
-if(SWIFTSYNTAX_PARSER_VERSION_STRING)
-  if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
-    set(LIBPARSER_LINK_FLAGS " -Wl,-compatibility_version -Wl,1")
-    set(LIBPARSER_LINK_FLAGS "${LIBPARSER_LINK_FLAGS} -Wl,-current_version -Wl,${SWIFTSYNTAX_PARSER_VERSION_STRING}")
-    set_property(TARGET libSwiftSyntaxParser APPEND_STRING PROPERTY
-                 LINK_FLAGS ${LIBPARSER_LINK_FLAGS})
-  else()
-    set_target_properties(libSwiftSyntaxParser
-      PROPERTIES
-      VERSION ${SWIFTSYNTAX_PARSER_VERSION_STRING})
+  set(HAS_SWIFT_MODULES "HAS_SWIFT_MODULES")
+  if ("${type}" STREQUAL relocatable_object_file)
+    # The -r linker option to produce a relocatable object file is not compatible with dead-stripping, so disable it.
+    set(LLVM_NO_DEAD_STRIP TRUE)
+    set(SWIFT_DISABLE_DEAD_STRIPPING TRUE)
+    # Because the resulting static library will be linked by another process, we don't need to add the rpath flags for the host stdlib.
+    set(HAS_SWIFT_MODULES "")
   endif()
-endif()
+  add_swift_host_library("${target_name}" SHARED
+    c-include-check.c
+    libSwiftSyntaxParser.cpp
+    "${HAS_SWIFT_MODULES}"
+    LLVM_LINK_COMPONENTS support)
+  if(NOT SWIFT_BUILT_STANDALONE AND NOT CMAKE_C_COMPILER_ID MATCHES Clang)
+    add_dependencies("${target_name}" clang)
+  endif()
+  target_link_libraries("${target_name}" PRIVATE
+    swiftParse
+    swiftCompilerModules_SwiftSyntax)
+  set_target_properties("${target_name}"
+      PROPERTIES
+      OUTPUT_NAME ${SYNTAX_PARSER_LIB_NAME})
 
-set_property(TARGET libSwiftSyntaxParser APPEND_STRING PROPERTY
-  COMPILE_FLAGS " -fblocks")
-if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  target_link_libraries(libSwiftSyntaxParser PRIVATE
-    BlocksRuntime)
-endif()
+  add_llvm_symbol_exports("${target_name}" ${LLVM_EXPORTED_SYMBOL_FILE})
+
+  # Adds -dead_strip option
+  add_link_opts("${target_name}")
+
+  if ("${type}" STREQUAL relocatable_object_file)
+    # CMake does not support building static libraries that contain transitively referenced symbols by default.
+    # Perform the following workaround:
+    #  * Request a build of a shared library (aka. dylib) from CMake. This makes sure that all transitive dependencies are included in the linker invocation.
+    #  * Pass -r to the linker to produce a relocatable object file instead of a dylib
+    #  * Run libtool (below) to generate a static library from the relocatable object file, which we install into the toolchain.
+    
+    #  Add autolinking directives for C(++) libraries to avoid consumers having to add them manually
+    target_compile_options("${target_name}" PRIVATE
+      "SHELL:-Xclang --dependent-lib=c++"
+      "SHELL:-Xclang --dependent-lib=ncurses"
+      "SHELL:-Xclang --dependent-lib=z"
+    )
+
+    # -Wl,-r passes -r to the linker, which causes a relocatable object file to be created instead of a dylib
+    # -Wl,-x passes -x to the linker, which causes non-global symbols to not occur in the relocatable object file.
+    target_link_options("${target_name}" PRIVATE -Wl,-r -Wl,-x)
+    # Since we aren't producing a dylib anymore because of -Wl,-r, we should change the file extension
+    set_target_properties("${target_name}" PROPERTIES SUFFIX ".o")
+  endif()
+
+  if (SWIFT_LIBPARSER_VER)
+    set(SWIFTSYNTAX_PARSER_VERSION_STRING "${SWIFT_LIBPARSER_VER}")
+  else()
+    set(SWIFTSYNTAX_PARSER_VERSION_STRING "${SWIFT_COMPILER_VERSION}")
+  endif()
+
+  if(SWIFTSYNTAX_PARSER_VERSION_STRING)
+    if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
+      set(LIBPARSER_LINK_FLAGS " -Wl,-compatibility_version -Wl,1")
+      set(LIBPARSER_LINK_FLAGS "${LIBPARSER_LINK_FLAGS} -Wl,-current_version -Wl,${SWIFTSYNTAX_PARSER_VERSION_STRING}")
+      set_property(TARGET "${target_name}" APPEND_STRING PROPERTY
+                   LINK_FLAGS ${LIBPARSER_LINK_FLAGS})
+    else()
+      set_target_properties("${target_name}"
+        PROPERTIES
+        VERSION ${SWIFTSYNTAX_PARSER_VERSION_STRING})
+    endif()
+  endif()
+
+  set_property(TARGET "${target_name}" APPEND_STRING PROPERTY
+    COMPILE_FLAGS " -fblocks")
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    target_link_libraries("${target_name}" PRIVATE
+      BlocksRuntime)
+  endif()
+endfunction()
+
+# Use an 'internal' name, this is primarily intended for SwiftSyntax to import.
+create_parser_library(libSwiftSyntaxParser _InternalSwiftSyntaxParser dylib)
 
 add_dependencies(parser-lib libSwiftSyntaxParser)
 swift_install_in_component(TARGETS libSwiftSyntaxParser
@@ -59,5 +92,27 @@ swift_install_in_component(TARGETS libSwiftSyntaxParser
   LIBRARY DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}" COMPONENT parser-lib
   RUNTIME DESTINATION "bin" COMPONENT parser-lib)
 swift_install_in_component(DIRECTORY "${SWIFT_MAIN_INCLUDE_DIR}/swift-c/SyntaxParser/"
-                           DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/${SYNTAX_PARSER_LIB_NAME}"
+                           DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/_InternalSwiftSyntaxParser"
                            COMPONENT parser-lib)
+
+if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
+  # TODO: Building the parser library as a static library has only been tested on Darwin so far because we only need the static library 
+  # to distribute it as an xcframework for SwiftSyntax and xcframework dependencies in SwiftPM are only supported on Darwin at the moment.
+  # Building and static linking the parser library on Linux might be possible, trivial.
+
+  # Build the parser library as a relocatable object file
+  create_parser_library(libSwiftSyntaxParserRelocatableObject _InternalSwiftSyntaxParserRelocatableObject relocatable_object_file)
+
+  # Create a static library from the relocatable object file.
+  add_custom_command_target(target_name 
+    CUSTOM_TARGET_NAME libSwiftSyntaxParserStatic
+    COMMAND "libtool" "-static" "-o" "lib_InternalSwiftSyntaxParser.a" "$<TARGET_FILE:libSwiftSyntaxParserRelocatableObject>"
+    OUTPUT lib_InternalSwiftSyntaxParser.a
+    DEPENDS libSwiftSyntaxParserRelocatableObject
+  )
+
+  # Install the static library
+  add_dependencies(parser-lib "${target_name}")
+  swift_install_in_component(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/lib_InternalSwiftSyntaxParser.a
+    DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}" COMPONENT parser-lib)
+endif()

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3626,7 +3626,12 @@ if [[ ${#LIPO_SRC_DIRS[@]} -gt 0 ]]; then
         else
             LIPO_PATH="${HOST_LIPO}"
         fi
-        call "${SWIFT_SOURCE_DIR}"/utils/recursive-lipo --lipo=${LIPO_PATH} --copy-subdirs="$(get_host_install_prefix ${host})lib/swift $(get_host_install_prefix ${host})lib/swift_static" --explicit-src-files="$(get_host_install_prefix ${host})lib/swift/${host%%-*}/lib_InternalSwiftScan.dylib $(get_host_install_prefix ${host})lib/swift/${host%%-*}/lib_InternalSwiftSyntaxParser.dylib" --destination="$(get_host_install_destdir ${mergedHost})" ${LIPO_SRC_DIRS[@]}
+        call "${SWIFT_SOURCE_DIR}"/utils/recursive-lipo \
+        --lipo=${LIPO_PATH} \
+        --copy-subdirs="$(get_host_install_prefix ${host})lib/swift $(get_host_install_prefix ${host})lib/swift_static" \
+        --explicit-src-files="$(get_host_install_prefix ${host})lib/swift/${host%%-*}/lib_InternalSwiftScan.dylib $(get_host_install_prefix ${host})lib/swift/${host%%-*}/lib_InternalSwiftSyntaxParser.dylib $(get_host_install_prefix ${host})lib/swift/${host%%-*}/lib_InternalSwiftSyntaxParser.a" \
+        --destination="$(get_host_install_destdir ${mergedHost})" \
+        ${LIPO_SRC_DIRS[@]}
 
         if [[ $(should_execute_action "${mergedHost}-lipo") ]]; then
             # Build and test the lipo-ed package.


### PR DESCRIPTION
As a first step to link SwiftSyntax statically against the parser library, build a static version of the parser library as part of a toolchain build. Unfortunately CMake doesn't support building static libraries that contain all transitive dependencies. Thus, I’m applyin the following workaround
- Request a build of a shared library (aka. dylib) from CMake. This makes sure that all transitive dependencies are included in the linker invocation.
-  Pass `-r` to the linker to produce a relocatable object file instead of a dylib
- Run `libtool` to generate a static library from the relocatable object file, which we install into the toolchain.

### Resulting binary size

The resulting static library is rather large (~150MB), so I went ahead and compared the size of the resulting `lit-test-helper` binary in the SwiftSyntax project to the binary sizes produced by the static parser library vendored by https://github.com/keith/StaticInternalSwiftSyntaxParser/releases/tag/5.6. The results are quite interesting



  | @keith’s static library | This PR
-- | -- | --
x86 | 56MB | 22MB
x86 + dead strip | 43MB | 22MB
arm64 | 51MB | 20MB
arm64 + dead strip | 39MB | 20MB
fat | 107MB | 111MB
fat + dead strip | 81MB | 86MB

The interesting takeaways are
- When building for a single arch, dead stripping seems to not be required anymore since this PR distributes a proper static library and not a relocatable object file 🎉 
- The fat binaries are bigger than the two single arch binaries combined. I suspect this is a bug in SwiftPM and filed https://github.com/apple/swift-package-manager/issues/5557