### PR TITLE
CSGen, SILGen: Fix delegations to `Optional` initializers

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -4158,23 +4158,31 @@ RValue RValueEmitter::visitRebindSelfInConstructorExpr(
   auto ctorDecl = cast<ConstructorDecl>(selfDecl->getDeclContext());
   auto selfIfaceTy = ctorDecl->getDeclContext()->getSelfInterfaceType();
   auto selfTy = ctorDecl->mapTypeIntoContext(selfIfaceTy);
-  
-  auto newSelfTy = E->getSubExpr()->getType();
-  bool outerIsOptional = false;
-  bool innerIsOptional = false;
-  auto objTy = newSelfTy->getOptionalObjectType();
-  if (objTy) {
-    outerIsOptional = true;
-    newSelfTy = objTy;
 
-    // "try? self.init()" can give us two levels of optional if the initializer
-    // we delegate to is failable.
-    objTy = newSelfTy->getOptionalObjectType();
-    if (objTy) {
-      innerIsOptional = true;
-      newSelfTy = objTy;
+  bool isChaining; // Ignored
+  auto *otherCtor = E->getCalledConstructor(isChaining)->getDecl();
+  assert(otherCtor);
+
+  auto getOptionalityDepth = [](Type ty) {
+    unsigned level = 0;
+    Type objTy = ty->getOptionalObjectType();
+    while (objTy) {
+      ++level;
+      objTy = objTy->getOptionalObjectType();
     }
-  }
+
+    return level;
+  };
+
+  // The optionality depth of the 'new self' value. This can be '2' if the ctor
+  // we are delegating/chaining to is both throwing and failable, or more if
+  // 'self' is optional.
+  auto srcOptionalityDepth = getOptionalityDepth(E->getSubExpr()->getType());
+
+  // The optionality depth of the result type of the enclosing initializer in
+  // this context.
+  const auto destOptionalityDepth = getOptionalityDepth(
+      ctorDecl->mapTypeIntoContext(ctorDecl->getResultInterfaceType()));
 
   // The subexpression consumes the current 'self' binding.
   assert(SGF.SelfInitDelegationState == SILGenFunction::NormalSelf
@@ -4191,13 +4199,25 @@ RValue RValueEmitter::visitRebindSelfInConstructorExpr(
     SGF.emitAddressOfLocalVarDecl(E, selfDecl, selfTy->getCanonicalType(),
                                   SGFAccessKind::Write).getLValueAddress();
 
-  // Handle a nested optional case (see above).
-  if (innerIsOptional)
+  // Flatten a nested optional if 'new self' is a deeper optional than we
+  // can return.
+  if (srcOptionalityDepth > destOptionalityDepth) {
+    assert(destOptionalityDepth > 0);
+    assert(otherCtor->isFailable() && otherCtor->hasThrows());
+
+    --srcOptionalityDepth;
     newSelf = flattenOptional(SGF, E, newSelf);
 
-  // If both the delegated-to initializer and our enclosing initializer can
-  // fail, deal with the failure.
-  if (outerIsOptional && ctorDecl->isFailable()) {
+    assert(srcOptionalityDepth == destOptionalityDepth &&
+           "Flattening a single level was not enough?");
+  }
+
+  // If the enclosing ctor is failable and the optionality depths match, switch
+  // on 'new self' to either return 'nil' or continue with the projected value.
+  if (srcOptionalityDepth == destOptionalityDepth && ctorDecl->isFailable()) {
+    assert(destOptionalityDepth > 0);
+    assert(otherCtor->isFailable() || otherCtor->hasThrows());
+
     SILBasicBlock *someBB = SGF.createBasicBlock();
 
     auto hasValue = SGF.emitDoesOptionalHaveValue(E, newSelf.getValue());
@@ -4216,7 +4236,7 @@ RValue RValueEmitter::visitRebindSelfInConstructorExpr(
                                     SGF.getTypeLowering(newSelf.getType()),
                                                     SGFContext());
   }
-  
+
   // If we called a constructor that requires a downcast, perform the downcast.
   auto destTy = SGF.getLoweredType(selfTy);
   if (newSelf.getType() != destTy) {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2175,23 +2175,18 @@ namespace {
 
       // The constructor was opened with the allocating type, not the
       // initializer type. Map the former into the latter.
-      auto resultTy = solution.simplifyType(openedFullType);
+      auto *resultTy =
+          solution.simplifyType(openedFullType)->castTo<FunctionType>();
 
-      auto selfTy = getBaseType(resultTy->castTo<FunctionType>());
-
-      // Also replace the result type with the base type, so that calls
-      // to constructors defined in a superclass will know to cast the
-      // result to the derived type.
-      resultTy = resultTy->replaceCovariantResultType(selfTy, 2);
+      const auto selfTy = getBaseType(resultTy);
 
       ParameterTypeFlags flags;
       if (!selfTy->hasReferenceSemantics())
         flags = flags.withInOut(true);
 
       auto selfParam = AnyFunctionType::Param(selfTy, Identifier(), flags);
-      resultTy = FunctionType::get({selfParam},
-                                   resultTy->castTo<FunctionType>()->getResult(),
-                                   resultTy->castTo<FunctionType>()->getExtInfo());
+      resultTy = FunctionType::get({selfParam}, resultTy->getResult(),
+                                   resultTy->getExtInfo());
 
       // Build the constructor reference.
       Expr *ctorRef = cs.cacheType(

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1718,9 +1718,48 @@ namespace {
       if (!optTy)
         return Type();
 
-      // Prior to Swift 5, 'try?' always adds an additional layer of optionality,
-      // even if the sub-expression was already optional.
-      if (CS.getASTContext().LangOpts.isSwiftVersionAtLeast(5)) {
+      bool isDelegationToOptionalInit = false;
+      {
+        Expr *e = expr->getSubExpr();
+        while (true) {
+          e = e->getSemanticsProvidingExpr();
+
+          // Look through force-value expressions.
+          if (auto *FVE = dyn_cast<ForceValueExpr>(e)) {
+            e = FVE->getSubExpr();
+            continue;
+          }
+
+          break;
+        }
+
+        if (auto *CE = dyn_cast<CallExpr>(e)) {
+          if (auto *UDE = dyn_cast<UnresolvedDotExpr>(CE->getFn())) {
+            if (!CS.getType(UDE->getBase())->is<AnyMetatypeType>()) {
+              auto overload =
+                  CS.findSelectedOverloadFor(CS.getConstraintLocator(
+                      UDE, ConstraintLocator::ConstructorMember));
+              if (overload) {
+                auto *decl = overload->choice.getDeclOrNull();
+                if (decl && isa<ConstructorDecl>(decl) &&
+                    decl->getDeclContext()
+                        ->getSelfNominalTypeDecl()
+                        ->isOptionalDecl())
+                  isDelegationToOptionalInit = true;
+              }
+            }
+          }
+        }
+      }
+
+      // Prior to Swift 5, 'try?' always adds an additional layer of
+      // optionality, even if the sub-expression was already optional.
+      //
+      // NB Keep adding the additional layer in Swift 5 and on if this 'try?'
+      // applies to a delegation to an 'Optional' initializer, or else we won't
+      // discern the difference between a failure and a constructed value.
+      if (CS.getASTContext().LangOpts.isSwiftVersionAtLeast(5) &&
+          !isDelegationToOptionalInit) {
         CS.addConstraint(ConstraintKind::Conversion,
                          CS.getType(expr->getSubExpr()), optTy,
                          CS.getConstraintLocator(expr));

--- a/test/SILGen/init_delegation_optional.swift
+++ b/test/SILGen/init_delegation_optional.swift
@@ -1,0 +1,28 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+extension Optional {
+  init(nonFailable1: ()) {
+    self = .none
+  }
+
+  // CHECK-LABEL: sil hidden [ossa] @$sSq24init_delegation_optionalE12nonFailable2xSgyt_tcfC
+  init(nonFailable2: ()) {
+    // CHECK: bb0([[OUT:%[0-9]+]] : $*Optional<Wrapped>, [[SELF_META:%[0-9]+]] : $@thin Optional<Wrapped>.Type):
+    // CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var Optional<τ_0_0> } <Wrapped>, var
+    // CHECK-NEXT: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
+    // CHECK-NEXT: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: [[PB:%[0-9]+]] = project_box [[SELF_LIFETIME]]
+    // CHECK: [[RESULT_ADDR:%[0-9]+]] = alloc_stack $Optional<Wrapped>
+    // CHECK: [[DELEG_INIT:%[0-9]+]] = function_ref @$sSq24init_delegation_optionalE12nonFailable1xSgyt_tcfC
+    // CHECK-NEXT: apply [[DELEG_INIT]]<Wrapped>([[RESULT_ADDR]], [[SELF_META]])
+    self.init(nonFailable1: ())
+    // CHECK-NEXT: copy_addr [take] [[RESULT_ADDR]] to [[PB]]
+    // CHECK-NEXT: dealloc_stack [[RESULT_ADDR]]
+    // CHECK-NEXT: copy_addr [[PB]] to [initialization] [[OUT]]
+    // CHECK-NEXT: end_borrow [[SELF_LIFETIME]]
+    // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: [[RET:%[0-9]+]] = tuple ()
+    // CHECK-NEXT: return [[RET]] : $()
+    // CHECK-NEXT: }
+  }
+}

--- a/test/SILGen/init_delegation_optional.swift
+++ b/test/SILGen/init_delegation_optional.swift
@@ -25,4 +25,141 @@ extension Optional {
     // CHECK-NEXT: return [[RET]] : $()
     // CHECK-NEXT: }
   }
+
+  // CHECK-LABEL: sil hidden [ossa] @$sSq24init_delegation_optionalE9failable1xSgSgyt_tcfC
+  init?(failable1: ()) {
+    // CHECK: bb0([[OUT:%[0-9]+]] : $*Optional<Optional<Wrapped>>, [[SELF_META:%[0-9]+]] : $@thin Optional<Wrapped>.Type):
+    // CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var Optional<τ_0_0> } <Wrapped>, var
+    // CHECK-NEXT: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
+    // CHECK-NEXT: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: [[PB:%[0-9]+]] = project_box [[SELF_LIFETIME]]
+    // CHECK: [[RESULT_ADDR:%[0-9]+]] = alloc_stack $Optional<Wrapped>
+    // CHECK: [[DELEG_INIT:%[0-9]+]] = function_ref @$sSq24init_delegation_optionalE12nonFailable1xSgyt_tcfC
+    // CHECK-NEXT: apply [[DELEG_INIT]]<Wrapped>([[RESULT_ADDR]], [[SELF_META]])
+    self.init(nonFailable1: ())
+    // CHECK-NEXT: copy_addr [take] [[RESULT_ADDR]] to [[PB]]
+    // CHECK-NEXT: dealloc_stack [[RESULT_ADDR]]
+    // CHECK-NEXT: [[OUT_SOME_ADDR:%[0-9]+]] = init_enum_data_addr [[OUT]] : {{.*}}, #Optional.some!enumelt
+    // CHECK-NEXT: copy_addr [[PB]] to [initialization] [[OUT_SOME_ADDR]]
+    // CHECK-NEXT: inject_enum_addr [[OUT]] : {{.*}}, #Optional.some!enumelt
+    // CHECK-NEXT: end_borrow [[SELF_LIFETIME]]
+    // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: br bb2
+    //
+    // FIXME: Dead branch
+    // CHECK: bb1:
+    //
+    // CHECK: bb2:
+    // CHECK-NEXT: [[RET:%[0-9]+]] = tuple ()
+    // CHECK-NEXT: return [[RET]] : $()
+    // CHECK-NEXT: }
+  }
+
+  // CHECK-LABEL: sil hidden [ossa] @$sSq24init_delegation_optionalE9failable2xSgSgyt_tcfC
+  init?(failable2: ()) {
+    // CHECK: bb0([[OUT:%[0-9]+]] : $*Optional<Optional<Wrapped>>, [[SELF_META:%[0-9]+]] : $@thin Optional<Wrapped>.Type):
+    // CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var Optional<τ_0_0> } <Wrapped>, var
+    // CHECK-NEXT: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
+    // CHECK-NEXT: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: [[PB:%[0-9]+]] = project_box [[SELF_LIFETIME]]
+    // CHECK: [[OPT_RESULT_ADDR:%[0-9]+]] = alloc_stack $Optional<Optional<Wrapped>>
+    // CHECK: [[DELEG_INIT:%[0-9]+]] = function_ref @$sSq24init_delegation_optionalE9failable1xSgSgyt_tcfC
+    // CHECK-NEXT: apply [[DELEG_INIT]]<Wrapped>([[OPT_RESULT_ADDR]], [[SELF_META]])
+    self.init(failable1: ())
+    // CHECK: [[SELECT:%[0-9]+]] = select_enum_addr [[OPT_RESULT_ADDR]]
+    // CHECK-NEXT: cond_br [[SELECT]], [[SOME_BB:bb[0-9]]], [[NONE_BB:bb[0-9]]]
+    //
+    // CHECK: [[NONE_BB]]:
+    // CHECK-NEXT: destroy_addr [[OPT_RESULT_ADDR]]
+    // CHECK-NEXT: dealloc_stack [[OPT_RESULT_ADDR]]
+    // CHECK-NEXT: br bb3
+    //
+    // CHECK: [[SOME_BB]]:
+    // CHECK-NEXT: [[RESULT_ADDR:%[0-9]+]] = unchecked_take_enum_data_addr [[OPT_RESULT_ADDR]] : {{.*}}, #Optional.some!enumelt
+    // CHECK-NEXT: copy_addr [take] [[RESULT_ADDR]] to [[PB]]
+    // CHECK-NEXT: dealloc_stack [[OPT_RESULT_ADDR]]
+    // CHECK-NEXT: [[OUT_SOME_ADDR:%[0-9]+]] = init_enum_data_addr [[OUT]] : {{.*}}, #Optional.some!enumelt
+    // CHECK-NEXT: copy_addr [[PB]] to [initialization] [[OUT_SOME_ADDR]]
+    // CHECK-NEXT: inject_enum_addr [[OUT]] : {{.*}}, #Optional.some!enumelt
+    // CHECK-NEXT: end_borrow [[SELF_LIFETIME]]
+    // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: br bb4
+    //
+    // CHECK: bb3:
+    // CHECK-NEXT: end_borrow [[SELF_LIFETIME]]
+    // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: inject_enum_addr [[OUT]] : {{.*}}, #Optional.none!enumelt
+    // CHECK-NEXT: br bb4
+    //
+    // CHECK: bb4:
+    // CHECK-NEXT: [[RET:%[0-9]+]] = tuple ()
+    // CHECK-NEXT: return [[RET]] : $()
+    // CHECK-NEXT: }
+  }
+}
+
+extension Optional where Wrapped == Optional<Bool> {
+  // CHECK-LABEL: sil hidden [ossa] @$sSq24init_delegation_optionalSbSgRszlE13SpecFailable1ABSgSgyt_tcfC
+  init?(SpecFailable1: ()) {
+    // CHECK: bb0([[SELF_META:%[0-9]+]] : $@thin Optional<Optional<Bool>>.Type):
+    // CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var Optional<Optional<Bool>> }, var
+    // CHECK-NEXT: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
+    // CHECK-NEXT: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: [[PB:%[0-9]+]] = project_box [[SELF_LIFETIME]]
+    // CHECK: [[RESULT_ADDR:%[0-9]+]] = alloc_stack $Optional<Optional<Bool>>
+    // CHECK: [[DELEG_INIT:%[0-9]+]] = function_ref @$sSq24init_delegation_optionalE12nonFailable1xSgyt_tcfC
+    // CHECK-NEXT: apply [[DELEG_INIT]]<Bool?>([[RESULT_ADDR]], [[SELF_META]])
+    // CHECK-NEXT: [[RESULT:%[0-9]+]] = load [trivial] [[RESULT_ADDR]]
+    // CHECK-NEXT: assign [[RESULT]] to [[PB]]
+    // CHECK-NEXT: dealloc_stack [[RESULT_ADDR]]
+    // CHECK-NEXT: [[RESULT:%[0-9]+]] = load [trivial] [[PB]]
+    // CHECK-NEXT: [[INJECT_INTO_OPT:%[0-9]+]] = enum $Optional<Optional<Optional<Bool>>>, #Optional.some!enumelt, [[RESULT]]
+    // CHECK-NEXT: end_borrow [[SELF_LIFETIME]]
+    // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: br bb2([[INJECT_INTO_OPT]] : $Optional<Optional<Optional<Bool>>>)
+    //
+    // FIXME: Dead branch
+    // CHECK: bb1:
+    //
+    // CHECK: bb2([[RET:%[0-9]+]] : $Optional<Optional<Optional<Bool>>>):
+    // CHECK-NEXT: return [[RET]]
+    // CHECK-NEXT: }
+    self.init(nonFailable1: ())
+  }
+
+  // CHECK-LABEL: sil hidden [ossa] @$sSq24init_delegation_optionalSbSgRszlE13SpecFailable2ABSgSgyt_tcfC
+  init?(SpecFailable2: ()) {
+    // CHECK: bb0([[SELF_META:%[0-9]+]] : $@thin Optional<Optional<Bool>>.Type):
+    // CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var Optional<Optional<Bool>> }, var
+    // CHECK-NEXT: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
+    // CHECK-NEXT: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: [[PB:%[0-9]+]] = project_box [[SELF_LIFETIME]]
+    // CHECK: [[DELEG_INIT:%[0-9]+]] = function_ref @$sSq24init_delegation_optionalSbSgRszlE13SpecFailable1ABSgSgyt_tcfC
+    // CHECK-NEXT: [[OPT_RESULT:%[0-9]+]] = apply [[DELEG_INIT]]([[SELF_META]])
+    // CHECK: [[SELECT:%[0-9]+]] = select_enum [[OPT_RESULT]]
+    // CHECK-NEXT: cond_br [[SELECT]], [[SOME_BB:bb[0-9]]], [[NONE_BB:bb[0-9]]]
+    //
+    // CHECK: [[NONE_BB]]:
+    // CHECK-NEXT: br bb3
+    //
+    // CHECK: [[SOME_BB]]:
+    // CHECK-NEXT: [[RESULT:%[0-9]+]] = unchecked_enum_data [[OPT_RESULT]] : {{.*}}, #Optional.some!enumelt
+    // CHECK-NEXT: assign [[RESULT]] to [[PB]]
+    // CHECK-NEXT: [[RESULT:%[0-9]+]] = load [trivial] [[PB]]
+    // CHECK-NEXT: [[INJECT_INTO_OPT:%[0-9]+]] = enum $Optional<Optional<Optional<Bool>>>, #Optional.some!enumelt, [[RESULT]]
+    // CHECK-NEXT: end_borrow [[SELF_LIFETIME]]
+    // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: br bb4([[INJECT_INTO_OPT]] : $Optional<Optional<Optional<Bool>>>)
+    //
+    // CHECK: bb3:
+    // CHECK-NEXT: end_borrow [[SELF_LIFETIME]]
+    // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: [[NIL:%[0-9]+]] = enum $Optional<Optional<Optional<Bool>>>, #Optional.none!enumelt
+    // CHECK-NEXT: br bb4([[NIL]] : $Optional<Optional<Optional<Bool>>>)
+    //
+    // CHECK: bb4([[RET:%[0-9]+]] : $Optional<Optional<Optional<Bool>>>):
+    // CHECK-NEXT: return [[RET]]
+    // CHECK-NEXT: }
+    self.init(SpecFailable1: ())
+  }
 }

--- a/test/SILGen/init_delegation_optional.swift
+++ b/test/SILGen/init_delegation_optional.swift
@@ -1,4 +1,9 @@
-// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+// 'try?' on delegations to 'Optional' initializers should never flatten
+// optionals, or else we do not discern the difference between a failure and a
+// constructed value. Run in compatibility modes that disable and enable
+// the flattening to verify this.
+// RUN: %target-swift-emit-silgen %s -swift-version 5 | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -swift-version 4.2 | %FileCheck %s
 
 extension Optional {
   init(nonFailable1: ()) {
@@ -96,6 +101,262 @@ extension Optional {
     // CHECK-NEXT: return [[RET]] : $()
     // CHECK-NEXT: }
   }
+
+  init(throws: ()) throws {
+    self = .none
+  }
+
+  // CHECK-LABEL: sil hidden [ossa] @$sSq24init_delegation_optionalE9failable3xSgSgyt_tcfC
+  init?(failable3: ()) {
+    // CHECK: bb0([[OUT:%[0-9]+]] : $*Optional<Optional<Wrapped>>, [[SELF_META:%[0-9]+]] : $@thin Optional<Wrapped>.Type):
+    // CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var Optional<τ_0_0> } <Wrapped>, var
+    // CHECK-NEXT: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
+    // CHECK-NEXT: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: [[PB:%[0-9]+]] = project_box [[SELF_LIFETIME]]
+    // CHECK: [[OPT_RESULT_ADDR:%[0-9]+]] = alloc_stack $Optional<Optional<Wrapped>>
+    // CHECK-NEXT: [[OPT_RESULT_DATA_ADDR:%[0-9]+]] = init_enum_data_addr [[OPT_RESULT_ADDR]] : {{.*}}, #Optional.some!enumelt
+    // CHECK: [[DELEG_INIT:%[0-9]+]] = function_ref @$sSq24init_delegation_optionalE6throwsxSgyt_tKcfC
+    // CHECK-NEXT: try_apply [[DELEG_INIT]]<Wrapped>([[OPT_RESULT_DATA_ADDR]], [[SELF_META]]) : {{.*}}, normal [[SUCC_BB:bb[0-9]+]], error [[ERROR_BB:bb[0-9]+]]
+    try? self.init(throws: ())
+    //
+    // CHECK: [[SUCC_BB]]
+    // CHECK-NEXT: inject_enum_addr [[OPT_RESULT_ADDR]] : {{.*}}, #Optional.some!enumelt
+    // CHECK-NEXT: br bb2
+    //
+    // CHECK: bb2:
+    // CHECK: [[SELECT:%[0-9]+]] = select_enum_addr [[OPT_RESULT_ADDR]]
+    // CHECK-NEXT: cond_br [[SELECT]], [[SOME_BB:bb[0-9]]], [[NONE_BB:bb[0-9]]]
+    //
+    // CHECK: [[NONE_BB]]:
+    // CHECK-NEXT: destroy_addr [[OPT_RESULT_ADDR]]
+    // CHECK-NEXT: dealloc_stack [[OPT_RESULT_ADDR]]
+    // CHECK-NEXT: br bb5
+    //
+    // CHECK: [[SOME_BB]]:
+    // CHECK-NEXT: [[RESULT_ADDR:%[0-9]+]] = unchecked_take_enum_data_addr [[OPT_RESULT_ADDR]] : {{.*}}, #Optional.some!enumelt
+    // CHECK-NEXT: copy_addr [take] [[RESULT_ADDR]] to [[PB]]
+    // CHECK-NEXT: dealloc_stack [[OPT_RESULT_ADDR]]
+    // CHECK-NEXT: [[OUT_DATA_ADDR:%[0-9]+]] = init_enum_data_addr [[OUT]] : {{.*}}, #Optional.some!enumelt
+    // CHECK-NEXT: copy_addr [[PB]] to [initialization] [[OUT_DATA_ADDR]]
+    // CHECK-NEXT: inject_enum_addr [[OUT]] : {{.*}}, #Optional.some!enumelt
+    // CHECK-NEXT: end_borrow [[SELF_LIFETIME]]
+    // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: br bb6
+    //
+    // CHECK: bb5:
+    // CHECK-NEXT: end_borrow [[SELF_LIFETIME]]
+    // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: inject_enum_addr [[OUT]] : {{.*}}, #Optional.none!enumelt
+    // CHECK-NEXT: br bb6
+    //
+    // CHECK: bb6:
+    // CHECK-NEXT: [[RET:%[0-9]+]] = tuple ()
+    // CHECK-NEXT: return [[RET]] : $()
+    //
+    // CHECK: bb7([[ERR:%[0-9]+]] : @owned $Error):
+    // CHECK-NEXT: destroy_value [[ERR]]
+    // CHECK-NEXT: inject_enum_addr [[OPT_RESULT_ADDR]] : {{.*}}, #Optional.none!enumelt
+    // CHECK-NEXT: br bb2
+    //
+    // CHECK: [[ERROR_BB]]([[ERR:%[0-9]+]] : @owned $Error):
+    // CHECK-NEXT: br bb7([[ERR]] : $Error)
+    // CHECK-NEXT: }
+  }
+
+  init?(failableAndThrows: ()) throws {
+    self = .none
+  }
+
+  // CHECK-LABEL: sil hidden [ossa] @$sSq24init_delegation_optionalE9failable4xSgSgyt_tcfC
+  init?(failable4: ()) {
+    // CHECK: bb0([[OUT:%[0-9]+]] : $*Optional<Optional<Wrapped>>, [[SELF_META:%[0-9]+]] : $@thin Optional<Wrapped>.Type):
+    // CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var Optional<τ_0_0> } <Wrapped>, var
+    // CHECK-NEXT: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
+    // CHECK-NEXT: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: [[PB:%[0-9]+]] = project_box [[SELF_LIFETIME]]
+    // CHECK: [[OPT_OPT_RESULT_ADDR:%[0-9]+]] = alloc_stack $Optional<Optional<Optional<Wrapped>>>
+    // CHECK-NEXT: [[OPT_OPT_RESULT_DATA_ADDR:%[0-9]+]] = init_enum_data_addr [[OPT_OPT_RESULT_ADDR]] : {{.*}}, #Optional.some!enumelt
+    // CHECK: [[DELEG_INIT:%[0-9]+]] = function_ref @$sSq24init_delegation_optionalE17failableAndThrowsxSgSgyt_tKcfC
+    // CHECK-NEXT: try_apply [[DELEG_INIT]]<Wrapped>([[OPT_OPT_RESULT_DATA_ADDR]], [[SELF_META]]) : {{.*}}, normal [[SUCC_BB:bb[0-9]+]], error [[ERROR_BB:bb[0-9]+]]
+    try? self.init(failableAndThrows: ())
+    //
+    // CHECK: [[SUCC_BB]]
+    // CHECK-NEXT: inject_enum_addr [[OPT_OPT_RESULT_ADDR]] : {{.*}}, #Optional.some!enumelt
+    // CHECK-NEXT: br bb2
+    //
+    // CHECK: bb2:
+    // CHECK-NEXT: [[OPT_RESULT_ADDR:%[0-9]+]] = alloc_stack $Optional<Optional<Wrapped>>
+    // CHECK-NEXT: switch_enum_addr [[OPT_OPT_RESULT_ADDR]] : {{.*}}, case #Optional.some!enumelt: [[OPT_OPT_SOME_BB:bb[0-9]]], case #Optional.none!enumelt: [[OPT_OPT_NONE_BB:bb[0-9]]]
+    //
+    // CHECK: [[OPT_OPT_SOME_BB]]:
+    // CHECK-NEXT: [[DATA_ADDR:%[0-9]+]] = unchecked_take_enum_data_addr [[OPT_OPT_RESULT_ADDR]] : {{.*}}, #Optional.some!enumelt
+    // CHECK-NEXT: copy_addr [[DATA_ADDR]] to [initialization] [[OPT_RESULT_ADDR]]
+    // CHECK-NEXT: destroy_addr [[DATA_ADDR]]
+    // CHECK-NEXT: br bb5
+    //
+    // CHECK: [[OPT_OPT_NONE_BB]]:
+    // CHECK-NEXT: inject_enum_addr [[OPT_RESULT_ADDR]] : {{.*}}, #Optional.none!enumelt
+    // CHECK-NEXT: br bb5
+    //
+    // CHECK: bb5:
+    // CHECK: [[SELECT:%[0-9]+]] = select_enum_addr [[OPT_RESULT_ADDR]]
+    // CHECK-NEXT: cond_br [[SELECT]], [[OPT_SOME_BB:bb[0-9]]], [[OPT_NONE_BB:bb[0-9]]]
+    //
+    // CHECK: [[OPT_NONE_BB]]:
+    // CHECK-NEXT: destroy_addr [[OPT_RESULT_ADDR]]
+    // CHECK-NEXT: dealloc_stack [[OPT_RESULT_ADDR]]
+    // CHECK-NEXT: dealloc_stack [[OPT_OPT_RESULT_ADDR]]
+    // CHECK-NEXT: br bb8
+    //
+    // CHECK: [[OPT_SOME_BB]]:
+    // CHECK-NEXT: [[RESULT_ADDR:%[0-9]+]] = unchecked_take_enum_data_addr [[OPT_RESULT_ADDR]] : $*Optional<Optional<Wrapped>>, #Optional.some!enumelt
+    // CHECK-NEXT: copy_addr [take] [[RESULT_ADDR]] to [[PB]]
+    // CHECK-NEXT: dealloc_stack [[OPT_RESULT_ADDR]]
+    // CHECK-NEXT: dealloc_stack [[OPT_OPT_RESULT_ADDR]]
+    // CHECK-NEXT: [[OUT_DATA_ADDR:%[0-9]+]] = init_enum_data_addr [[OUT]] : {{.*}}, #Optional.some!enumelt
+    // CHECK-NEXT: copy_addr [[PB]] to [initialization] [[OUT_DATA_ADDR]]
+    // CHECK-NEXT: inject_enum_addr [[OUT]] : {{.*}}, #Optional.some!enumelt
+    // CHECK-NEXT: end_borrow [[SELF_LIFETIME]]
+    // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: br bb9
+    //
+    // CHECK: bb8:
+    // CHECK-NEXT: end_borrow [[SELF_LIFETIME]]
+    // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: inject_enum_addr [[OUT]] : {{.*}}, #Optional.none!enumelt
+    // CHECK-NEXT: br bb9
+    //
+    // CHECK: bb9:
+    // CHECK-NEXT: [[RET:%[0-9]+]] = tuple ()
+    // CHECK-NEXT: return [[RET]] : $()
+    //
+    // CHECK: bb10([[ERROR:%[0-9]+]] : @owned $Error):
+    // CHECK-NEXT: destroy_value [[ERROR]]
+    // CHECK-NEXT: inject_enum_addr [[OPT_OPT_RESULT_ADDR]] : {{.*}}, #Optional.none!enumelt
+    // CHECK-NEXT: br bb2
+    //
+    // CHECK: [[ERROR_BB]]([[ERROR:%[0-9]+]] : @owned $Error):
+    // CHECK-NEXT: br bb10([[ERROR]] : $Error)
+    // CHECK-NEXT: }
+  }
+
+  // CHECK-LABEL: sil hidden [ossa] @$sSq24init_delegation_optionalE9failable5xSgSgyt_tcfC
+  init?(failable5: ()) {
+    // CHECK: bb0([[OUT:%[0-9]+]] : $*Optional<Optional<Wrapped>>, [[SELF_META:%[0-9]+]] : $@thin Optional<Wrapped>.Type):
+    // CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var Optional<τ_0_0> } <Wrapped>, var
+    // CHECK-NEXT: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
+    // CHECK-NEXT: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: [[PB:%[0-9]+]] = project_box [[SELF_LIFETIME]]
+    // CHECK: [[OPT_RESULT_ADDR:%[0-9]+]] = alloc_stack $Optional<Optional<Wrapped>>
+    // CHECK-NEXT: [[OPT_RESULT_DATA_ADDR:%[0-9]+]] = init_enum_data_addr [[OPT_RESULT_ADDR]] : {{.*}}, #Optional.some!enumelt
+    // CHECK-NEXT: [[TMP_OPT_RESULT_ADDR:%[0-9]+]] = alloc_stack $Optional<Optional<Wrapped>>
+    // CHECK: [[DELEG_INIT:%[0-9]+]] = function_ref @$sSq24init_delegation_optionalE17failableAndThrowsxSgSgyt_tKcfC
+    // CHECK-NEXT: try_apply [[DELEG_INIT]]<Wrapped>([[TMP_OPT_RESULT_ADDR]], [[SELF_META]]) : {{.*}}, normal [[SUCC_BB:bb[0-9]+]], error [[ERROR_BB:bb[0-9]+]]
+    try? self.init(failableAndThrows: ())!
+    //
+    // CHECK: [[SUCC_BB]]
+    // CHECK-NEXT: switch_enum_addr [[TMP_OPT_RESULT_ADDR]] : {{.*}}, case #Optional.some!enumelt: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
+    //
+    // CHECK: [[NONE_BB]]:
+    // CHECK: unreachable
+    //
+    // CHECK: [[SOME_BB]]:
+    // CHECK-NEXT: [[TMP_RESULT_ADDR:%[0-9]+]] = unchecked_take_enum_data_addr [[TMP_OPT_RESULT_ADDR]] : {{.*}}, #Optional.some!enumelt
+    // CHECK-NEXT: copy_addr [take] [[TMP_RESULT_ADDR]] to [initialization] [[OPT_RESULT_DATA_ADDR]]
+    // CHECK-NEXT: inject_enum_addr [[OPT_RESULT_ADDR]] : {{.*}}, #Optional.some!enumelt
+    // CHECK-NEXT: dealloc_stack [[TMP_OPT_RESULT_ADDR]]
+    // CHECK-NEXT: br bb4
+    //
+    // CHECK: bb4:
+    // CHECK: [[SELECT:%[0-9]+]] = select_enum_addr [[OPT_RESULT_ADDR]]
+    // CHECK-NEXT: cond_br [[SELECT]], [[SOME_BB:bb[0-9]]], [[NONE_BB:bb[0-9]]]
+    //
+    // CHECK: [[NONE_BB]]:
+    // CHECK-NEXT: destroy_addr [[OPT_RESULT_ADDR]]
+    // CHECK-NEXT: dealloc_stack [[OPT_RESULT_ADDR]]
+    // CHECK-NEXT: br bb7
+    //
+    // CHECK: [[SOME_BB]]:
+    // CHECK-NEXT: [[RESULT_ADDR:%[0-9]+]] = unchecked_take_enum_data_addr [[OPT_RESULT_ADDR]] : {{.*}}, #Optional.some!enumelt
+    // CHECK-NEXT: copy_addr [take] [[RESULT_ADDR]] to [[PB]]
+    // CHECK-NEXT: dealloc_stack [[OPT_RESULT_ADDR]]
+    // CHECK-NEXT: [[OUT_DATA_ADDR:%[0-9]+]] = init_enum_data_addr [[OUT]] : {{.*}}, #Optional.some!enumelt
+    // CHECK-NEXT: copy_addr [[PB]] to [initialization] [[OUT_DATA_ADDR]]
+    // CHECK-NEXT: inject_enum_addr [[OUT]] : {{.*}}, #Optional.some!enumelt
+    // CHECK-NEXT: end_borrow [[SELF_LIFETIME]]
+    // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: br bb8
+    //
+    // CHECK: bb7:
+    // CHECK-NEXT: end_borrow [[SELF_LIFETIME]]
+    // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: inject_enum_addr [[OUT]] : {{.*}}, #Optional.none!enumelt
+    // CHECK-NEXT: br bb8
+    //
+    // CHECK: bb8:
+    // CHECK-NEXT: [[RET:%[0-9]+]] = tuple ()
+    // CHECK-NEXT: return [[RET]] : $()
+    //
+    // CHECK: bb9([[ERROR:%[0-9]+]] : @owned $Error):
+    // CHECK-NEXT: destroy_value [[ERROR]]
+    // CHECK-NEXT: inject_enum_addr [[OPT_RESULT_ADDR]] : {{.*}}, #Optional.none!enumelt
+    // CHECK-NEXT: br bb4
+    //
+    // CHECK: [[ERROR_BB]]([[ERROR:%[0-9]+]] : @owned $Error):
+    // CHECK-NEXT: dealloc_stack [[TMP_OPT_RESULT_ADDR]]
+    // CHECK-NEXT: br bb9([[ERROR]] : $Error)
+    // CHECK-NEXT: }
+  }
+
+  // CHECK-LABEL: sil hidden [ossa] @$sSq24init_delegation_optionalE9failable6xSgSgyt_tcfC
+  init?(failable6: ()) {
+    // CHECK: bb0([[OUT:%[0-9]+]] : $*Optional<Optional<Wrapped>>, [[SELF_META:%[0-9]+]] : $@thin Optional<Wrapped>.Type):
+    // CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_box $<τ_0_0> { var Optional<τ_0_0> } <Wrapped>, var
+    // CHECK-NEXT: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
+    // CHECK-NEXT: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: [[PB:%[0-9]+]] = project_box [[SELF_LIFETIME]]
+    // CHECK: [[OPT_RESULT_ADDR:%[0-9]+]] = alloc_stack $Optional<Optional<Wrapped>>
+    // CHECK: [[DELEG_INIT:%[0-9]+]] = function_ref @$sSq24init_delegation_optionalE17failableAndThrowsxSgSgyt_tKcfC
+    // CHECK-NEXT: try_apply [[DELEG_INIT]]<Wrapped>([[OPT_RESULT_ADDR]], [[SELF_META]]) : {{.*}}, normal [[SUCC_BB:bb[0-9]+]], error [[ERROR_BB:bb[0-9]+]]
+    try! self.init(failableAndThrows: ())
+    //
+    // CHECK: [[SUCC_BB]]
+    // CHECK: [[SELECT:%[0-9]+]] = select_enum_addr [[OPT_RESULT_ADDR]]
+    // CHECK-NEXT: cond_br [[SELECT]], [[SOME_BB:bb[0-9]]], [[NONE_BB:bb[0-9]]]
+    //
+    // CHECK: [[NONE_BB]]:
+    // CHECK-NEXT: destroy_addr [[OPT_RESULT_ADDR]]
+    // CHECK-NEXT: dealloc_stack [[OPT_RESULT_ADDR]]
+    // CHECK-NEXT: br bb4
+    //
+    // CHECK: [[SOME_BB]]:
+    // CHECK-NEXT: [[RESULT_ADDR:%[0-9]+]] = unchecked_take_enum_data_addr [[OPT_RESULT_ADDR]] : {{.*}}, #Optional.some!enumelt
+    // CHECK-NEXT: copy_addr [take] [[RESULT_ADDR]] to [[PB]]
+    // CHECK-NEXT: dealloc_stack [[OPT_RESULT_ADDR]]
+    // CHECK-NEXT: [[OUT_DATA_ADDR:%[0-9]+]] = init_enum_data_addr [[OUT]] : {{.*}}, #Optional.some!enumelt
+    // CHECK-NEXT: copy_addr [[PB]] to [initialization] [[OUT_DATA_ADDR]]
+    // CHECK-NEXT: inject_enum_addr [[OUT]] : {{.*}}, #Optional.some!enumelt
+    // CHECK-NEXT: end_borrow [[SELF_LIFETIME]]
+    // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: br bb5
+    //
+    // CHECK: bb4:
+    // CHECK-NEXT: end_borrow [[SELF_LIFETIME]]
+    // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: inject_enum_addr [[OUT]] : {{.*}}, #Optional.none!enumelt
+    // CHECK-NEXT: br bb5
+    //
+    // CHECK: bb5:
+    // CHECK-NEXT: [[RET:%[0-9]+]] = tuple ()
+    // CHECK-NEXT: return [[RET]] : $()
+    //
+    // CHECK: bb6({{%[0-9]+}} : @owned $Error):
+    // CHECK: unreachable
+    //
+    // CHECK: [[ERROR_BB]]([[ERROR:%[0-9]+]] : @owned $Error):
+    // CHECK: br bb6([[ERROR]] : $Error)
+    // CHECK-NEXT: }
+  }
 }
 
 extension Optional where Wrapped == Optional<Bool> {
@@ -161,5 +422,69 @@ extension Optional where Wrapped == Optional<Bool> {
     // CHECK-NEXT: return [[RET]]
     // CHECK-NEXT: }
     self.init(SpecFailable1: ())
+  }
+
+  init?(SpecFailableAndThrows: ()) throws {
+    self = .none
+  }
+
+  // CHECK_LABEL: sil hidden [ossa] @$sSq24init_delegation_optionalSbSgRszlE13SpecFailable3ABSgSgyt_tcfC
+  init?(SpecFailable3: ()) {
+    // CHECK: bb0([[SELF_META:%[0-9]+]] : $@thin Optional<Optional<Bool>>.Type):
+    // CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var Optional<Optional<Bool>> }, var
+    // CHECK-NEXT: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
+    // CHECK-NEXT: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: [[PB:%[0-9]+]] = project_box [[SELF_LIFETIME]]
+    // CHECK: [[DELEG_INIT:%[0-9]+]] = function_ref @$sSq24init_delegation_optionalSbSgRszlE21SpecFailableAndThrowsABSgSgyt_tKcfC
+    // CHECK-NEXT: try_apply [[DELEG_INIT]]([[SELF_META]]) : {{.*}}, normal [[SUCC_BB:bb[0-9]+]], error [[ERROR_BB:bb[0-9]+]]
+    //
+    // CHECK: [[SUCC_BB]]([[OPT_RESULT:%[0-9]+]] : $Optional<Optional<Optional<Bool>>>):
+    // CHECK-NEXT: [[INJECT_INTO_OPT:%[0-9]+]] = enum $Optional<Optional<Optional<Optional<Bool>>>>, #Optional.some!enumelt, [[OPT_RESULT]]
+    // CHECK-NEXT: br bb2([[INJECT_INTO_OPT]] : $Optional<Optional<Optional<Optional<Bool>>>>)
+    //
+    // CHECK: bb2([[OPT_OPT_RESULT:%[0-9]+]] : $Optional<Optional<Optional<Optional<Bool>>>>):
+    // CHECK-NEXT: switch_enum [[OPT_OPT_RESULT]] : {{.*}}, case #Optional.some!enumelt: [[OPT_OPT_SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[OPT_OPT_NONE_BB:bb[0-9]+]]
+    //
+    // CHECK: [[OPT_OPT_SOME_BB]]([[OPT_RESULT:%[0-9]+]] : $Optional<Optional<Optional<Bool>>>):
+    // CHECK-NEXT: br bb5([[OPT_RESULT]] : $Optional<Optional<Optional<Bool>>>)
+    //
+    // CHECK: [[OPT_OPT_NONE_BB]]:
+    // CHECK-NEXT: [[NIL:%[0-9]+]] = enum $Optional<Optional<Optional<Bool>>>, #Optional.none!enumelt
+    // CHECK-NEXT: br bb5([[NIL]] : $Optional<Optional<Optional<Bool>>>)
+    //
+    // CHECK: bb5([[OPT_RESULT:%[0-9]+]] : $Optional<Optional<Optional<Bool>>>):
+    // CHECK: [[SELECT:%[0-9]+]] = select_enum [[OPT_RESULT]]
+    // CHECK-NEXT: cond_br [[SELECT]], [[OPT_SOME_BB:bb[0-9]+]], [[OPT_NONE_BB:bb[0-9]+]]
+    //
+    // CHECK: [[OPT_NONE_BB]]:
+    // CHECK-NEXT: br bb8
+    //
+    // CHECK: [[OPT_SOME_BB]]:
+    // CHECK-NEXT: [[RESULT:%[0-9]+]] = unchecked_enum_data [[OPT_RESULT]] : {{.*}}, #Optional.some!enumelt
+    // CHECK-NEXT: assign [[RESULT]] to [[PB]]
+    // CHECK-NEXT: [[RESULT:%[0-9]+]] = load [trivial] [[PB]]
+    // CHECK-NEXT: [[INJECT_INTO_OPT:%[0-9]+]] = enum $Optional<Optional<Optional<Bool>>>, #Optional.some!enumelt, [[RESULT]]
+    // CHECK-NEXT: end_borrow [[SELF_LIFETIME]]
+    // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: br bb9([[INJECT_INTO_OPT]] : $Optional<Optional<Optional<Bool>>>)
+    //
+    // CHECK: bb8:
+    // CHECK-NEXT: end_borrow [[SELF_LIFETIME]]
+    // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
+    // CHECK-NEXT: [[NIL:%[0-9]+]] = enum $Optional<Optional<Optional<Bool>>>, #Optional.none!enumelt
+    // CHECK-NEXT: br bb9([[NIL]] : $Optional<Optional<Optional<Bool>>>)
+    //
+    // CHECK: bb9([[RET:%[0-9]+]] : $Optional<Optional<Optional<Bool>>>):
+    // CHECK-NEXT: return [[RET]]
+    //
+    // CHECK: bb10([[ERROR:%[0-9]+]] : @owned $Error):
+    // CHECK-NEXT: destroy_value [[ERROR]]
+    // CHECK-NEXT: [[NIL:%[0-9]+]] = enum $Optional<Optional<Optional<Optional<Bool>>>>, #Optional.none!enumelt
+    // CHECK-NEXT: br bb2([[NIL]] : $Optional<Optional<Optional<Optional<Bool>>>>)
+    //
+    // CHECK: [[ERROR_BB]]([[ERROR:%[0-9]+]] : @owned $Error):
+    // CHECK-NEXT: br bb10([[ERROR]] : $Error)
+    // CHECK-NEXT: }
+    try? self.init(SpecFailableAndThrows: ())
   }
 }

--- a/test/SILGen/initializers.swift
+++ b/test/SILGen/initializers.swift
@@ -165,86 +165,94 @@ func unwrap(_ x: Int) throws -> Int { return x }
 struct ThrowStruct {
   var x: Canary
 
-  init(fail: ()) throws { x = Canary() }
+  init(throws: ()) throws { x = Canary() }
 
-  init(noFail: ()) { x = Canary() }
+  init(noThrows: ()) { x = Canary() }
 
-  init(failBeforeDelegation: Int) throws {
-    try unwrap(failBeforeDelegation)
-    self.init(noFail: ())
+  init(throwsBeforeDelegation: Int) throws {
+    try unwrap(throwsBeforeDelegation)
+    self.init(noThrows: ())
   }
 
-  init(failBeforeOrDuringDelegation: Int) throws {
-    try unwrap(failBeforeOrDuringDelegation)
-    try self.init(fail: ())
+  init(throwsBeforeOrDuringDelegation: Int) throws {
+    try unwrap(throwsBeforeOrDuringDelegation)
+    try self.init(throws: ())
   }
 
-  init(failBeforeOrDuringDelegation2: Int) throws {
-    try self.init(failBeforeDelegation: unwrap(failBeforeOrDuringDelegation2))
+  init(throwsBeforeOrDuringDelegation2: Int) throws {
+    try self.init(throwsBeforeDelegation: unwrap(throwsBeforeOrDuringDelegation2))
   }
 
-  init(failDuringDelegation: Int) throws {
-    try self.init(fail: ())
+  init(throwsDuringDelegation: Int) throws {
+    try self.init(throws: ())
   }
 
-  init(failAfterDelegation: Int) throws {
-    self.init(noFail: ())
-    try unwrap(failAfterDelegation)
+  init(throwsAfterDelegation: Int) throws {
+    self.init(noThrows: ())
+    try unwrap(throwsAfterDelegation)
   }
 
-  init(failDuringOrAfterDelegation: Int) throws {
-    try self.init(fail: ())
-    try unwrap(failDuringOrAfterDelegation)
+  init(throwsDuringOrAfterDelegation: Int) throws {
+    try self.init(throws: ())
+    try unwrap(throwsDuringOrAfterDelegation)
   }
 
-  init(failBeforeOrAfterDelegation: Int) throws {
-    try unwrap(failBeforeOrAfterDelegation)
-    self.init(noFail: ())
-    try unwrap(failBeforeOrAfterDelegation)
+  init(throwsBeforeOrAfterDelegation: Int) throws {
+    try unwrap(throwsBeforeOrAfterDelegation)
+    self.init(noThrows: ())
+    try unwrap(throwsBeforeOrAfterDelegation)
   }
 
-  init?(throwsToOptional: Int) {
-    try? self.init(failDuringDelegation: throwsToOptional)
+  init(throwsBeforeSelfReplacement: Int) throws {
+    try unwrap(throwsBeforeSelfReplacement)
+    self = ThrowStruct(noThrows: ())
   }
 
-  init(throwsToIUO: Int) {
-    try! self.init(failDuringDelegation: throwsToIUO)
+  init(throwsDuringSelfReplacement: Int) throws {
+    try self = ThrowStruct(throws: ())
   }
 
-  init?(throwsToOptionalThrows: Int) throws {
-    try? self.init(fail: ())
+  init(throwsAfterSelfReplacement: Int) throws {
+    self = ThrowStruct(noThrows: ())
+    try unwrap(throwsAfterSelfReplacement)
   }
 
-  init(throwsOptionalToThrows: Int) throws {
-    self.init(throwsToOptional: throwsOptionalToThrows)!
+  init(nonFailable: ()) {
+    try! self.init(throws: ())
   }
 
-  init?(throwsOptionalToOptional: Int) {
-    try! self.init(throwsToOptionalThrows: throwsOptionalToOptional)
+  init(nonFailable2: ()) throws {
+    self.init(failable: ())!
   }
 
-  init(failBeforeSelfReplacement: Int) throws {
-    try unwrap(failBeforeSelfReplacement)
-    self = ThrowStruct(noFail: ())
+  init?(failableAndThrows: ()) throws {
+    self.init(noThrows: ())
   }
 
-  init(failDuringSelfReplacement: Int) throws {
-    try self = ThrowStruct(fail: ())
+  init?(failable: ()) {
+    try? self.init(throws: ())
   }
 
-  init(failAfterSelfReplacement: Int) throws {
-    self = ThrowStruct(noFail: ())
-    try unwrap(failAfterSelfReplacement)
+  init?(failable2: ()) {
+    try! self.init(failableAndThrows: ())
+  }
+
+  init?(failable3: ()) {
+    try? self.init(failableAndThrows: ())!
+  }
+
+  init?(failable4: ()) {
+    try? self.init(failableAndThrows: ())
   }
 }
 
 extension ThrowStruct {
-  init(failInExtension: ()) throws {
-    try self.init(fail: failInExtension)
+  init(throwsInExtension: ()) throws {
+    try self.init(throws: throwsInExtension)
   }
 
   init(assignInExtension: ()) throws {
-    try self = ThrowStruct(fail: ())
+    try self = ThrowStruct(throws: ())
   }
 }
 

--- a/test/SILGen/initializers.swift
+++ b/test/SILGen/initializers.swift
@@ -438,6 +438,33 @@ class FailableBaseClass {
     self.init(failBeforeFullInitialization: ())! // unnecessary-but-correct '!'
   }
 
+  // Optional to non-optional
+  //
+  // CHECK-LABEL: sil hidden [ossa] @$s21failable_initializers17FailableBaseClassC21failDuringDelegation3ACSgyt_tcfC
+  // CHECK: bb0([[SELF_META:%[0-9]+]] : $@thick FailableBaseClass.Type):
+  // CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var FailableBaseClass }, let, name "self"
+  // CHECK-NEXT: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
+  // CHECK-NEXT: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
+  // CHECK-NEXT: [[PB_BOX:%[0-9]+]] = project_box [[SELF_LIFETIME]]
+  // CHECK: [[DELEG_INIT:%[0-9]+]] = class_method [[SELF_META]] : $@thick FailableBaseClass.Type, #FailableBaseClass.init!allocator
+  // CHECK-NEXT: [[RESULT:%[0-9]+]] = apply [[DELEG_INIT]]([[SELF_META]])
+  // CHECK-NEXT: assign [[RESULT]] to [[PB_BOX]]
+  // CHECK-NEXT: [[RESULT_COPY:%[0-9]+]] = load [copy] [[PB_BOX]]
+  // CHECK-NEXT: [[INJECT_INTO_OPT:%[0-9]+]] = enum $Optional<FailableBaseClass>, #Optional.some!enumelt, [[RESULT_COPY]]
+  // CHECK-NEXT: end_borrow [[SELF_LIFETIME]]
+  // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
+  // CHECK-NEXT: br bb2([[INJECT_INTO_OPT]] : $Optional<FailableBaseClass>)
+  //
+  // FIXME: Dead block
+  // CHECK: bb1:
+  //
+  // CHECK: bb2([[ARG:%[0-9]+]] : @owned $Optional<FailableBaseClass>):
+  // CHECK-NEXT: return [[ARG]]
+  // CHECK-NEXT: }
+  convenience init?(failDuringDelegation3: ()) {
+    self.init(noFail: ())
+  }
+
   // IUO to IUO
   convenience init!(noFailDuringDelegation: ()) {
     self.init(failDuringDelegation2: ())! // unnecessary-but-correct '!'

--- a/test/SILGen/initializers.swift
+++ b/test/SILGen/initializers.swift
@@ -229,10 +229,82 @@ struct ThrowStruct {
     self.init(noThrows: ())
   }
 
+  // CHECK-LABEL: sil hidden [ossa] @$s21failable_initializers11ThrowStructV0A0ACSgyt_tcfC
+  // CHECK: bb0([[SELF_META:%[0-9]+]] : $@thin ThrowStruct.Type):
+  // CHECK: [[DELEG_INIT:%[0-9]+]] = function_ref @$s21failable_initializers11ThrowStructV6throwsACyt_tKcfC
+  // CHECK-NEXT: try_apply [[DELEG_INIT]]([[SELF_META]]) : $@convention(method) (@thin ThrowStruct.Type) -> (@owned ThrowStruct, @error Error), normal [[SUCC_BB:bb[0-9]+]], error [[ERROR_BB:bb[0-9]+]]
+  //
+  // CHECK: [[SUCC_BB]]([[RESULT:%[0-9]+]] : @owned $ThrowStruct):
+  // CHECK-NEXT: [[INJECT_INTO_OPT:%[0-9]+]] = enum $Optional<ThrowStruct>, #Optional.some!enumelt, [[RESULT]]
+  // CHECK-NEXT: br bb2([[INJECT_INTO_OPT]] : $Optional<ThrowStruct>)
+  //
+  // CHECK: bb2([[OPT_RESULT:%[0-9]+]] : @owned $Optional<ThrowStruct>):
+  // CHECK: [[SELECT:%[0-9]+]] = select_enum [[OPT_RESULT]]
+  // CHECK-NEXT: cond_br [[SELECT]], [[SOME_BB:bb[0-9]+]], [[NONE_BB:bb[0-9]+]]
+  //
+  // CHECK: [[NONE_BB]]:
+  // CHECK-NEXT: destroy_value [[OPT_RESULT]]
+  // CHECK-NEXT: br bb5
+  //
+  // CHECK: [[SOME_BB]]:
+  // CHECK-NEXT: [[RESULT:%[0-9]+]] = unchecked_enum_data [[OPT_RESULT]] : {{.*}}, #Optional.some!enumelt
+  // CHECK-NEXT: assign [[RESULT]] to [[DEST:%[0-9]+]]
+  // CHECK-NEXT: [[RESULT_CP:%[0-9]+]] = load [copy] [[DEST]]
+  // CHECK-NEXT: [[INJECT_INTO_OPT:%[0-9]+]] = enum $Optional<ThrowStruct>, #Optional.some!enumelt, [[RESULT_CP]]
+  // CHECK: br bb6([[INJECT_INTO_OPT]] : $Optional<ThrowStruct>)
+  //
+  // CHECK: bb5:
+  // CHECK: [[NIL:%[0-9]+]] = enum $Optional<ThrowStruct>, #Optional.none!enumelt
+  // CHECK-NEXT: br bb6([[NIL]] : $Optional<ThrowStruct>)
+  //
+  // CHECK: bb6([[RET:%[0-9]+]] : @owned $Optional<ThrowStruct>):
+  // CHECK-NEXT: return [[RET]]
+  //
+  // CHECK: bb7([[ERR:%[0-9]+]] : @owned $Error):
+  // CHECK-NEXT: destroy_value [[ERR]]
+  // CHECK-NEXT: [[NIL:%[0-9]+]] = enum $Optional<ThrowStruct>, #Optional.none!enumelt
+  // CHECK-NEXT: br bb2([[NIL]] : $Optional<ThrowStruct>)
+  //
+  // CHECK: [[ERROR_BB]]([[ERR:%[0-9]+]] : @owned $Error):
+  // CHECK-NEXT: br bb7([[ERR]] : $Error)
+  // CHECK-NEXT: }
   init?(failable: ()) {
     try? self.init(throws: ())
   }
 
+  // CHECK-LABEL: sil hidden [ossa] @$s21failable_initializers11ThrowStructV9failable2ACSgyt_tcfC
+  // CHECK: bb0([[SELF_META:%[0-9]+]] : $@thin ThrowStruct.Type):
+  // CHECK: [[DELEG_INIT:%[0-9]+]] = function_ref @$s21failable_initializers11ThrowStructV0A9AndThrowsACSgyt_tKcfC
+  // CHECK-NEXT: try_apply [[DELEG_INIT]]([[SELF_META]]) : $@convention(method) (@thin ThrowStruct.Type) -> (@owned Optional<ThrowStruct>, @error Error), normal [[SUCC_BB:bb[0-9]+]], error [[ERROR_BB:bb[0-9]+]]
+  //
+  // CHECK: [[SUCC_BB]]([[OPT_RESULT:%[0-9]+]] : @owned $Optional<ThrowStruct>):
+  // CHECK: [[SELECT:%[0-9]+]] = select_enum [[OPT_RESULT]]
+  // CHECK-NEXT: cond_br [[SELECT]], [[SOME_BB:bb[0-9]+]], [[NONE_BB:bb[0-9]+]]
+  //
+  // CHECK: [[NONE_BB]]:
+  // CHECK-NEXT: destroy_value [[OPT_RESULT]]
+  // CHECK-NEXT: br bb4
+  //
+  // CHECK: [[SOME_BB]]:
+  // CHECK-NEXT: [[RESULT:%[0-9]+]] = unchecked_enum_data [[OPT_RESULT]] : $Optional<ThrowStruct>, #Optional.some!enumelt
+  // CHECK-NEXT: assign [[RESULT]] to [[DEST:%[0-9]+]]
+  // CHECK-NEXT: [[RESULT_CP:%[0-9]+]] = load [copy] [[DEST]]
+  // CHECK-NEXT: [[INJECT_INTO_OPT:%[0-9]+]] = enum $Optional<ThrowStruct>, #Optional.some!enumelt, [[RESULT_CP]]
+  // CHECK: br bb5([[INJECT_INTO_OPT]] : $Optional<ThrowStruct>)
+  //
+  // CHECK: bb4:
+  // CHECK: [[NIL:%[0-9]+]] = enum $Optional<ThrowStruct>, #Optional.none!enumelt
+  // CHECK-NEXT: br bb5([[NIL]] : $Optional<ThrowStruct>)
+  //
+  // CHECK: bb5([[RET:%[0-9]+]] : @owned $Optional<ThrowStruct>):
+  // CHECK-NEXT: return [[RET]]
+  //
+  // CHECK: bb6([[ERR:%[0-9]+]] : @owned $Error):
+  // CHECK: unreachable
+  //
+  // CHECK: [[ERROR_BB]]([[ERR:%[0-9]+]] : @owned $Error):
+  // CHECK-NEXT: br bb6([[ERR]] : $Error)
+  // CHECK-NEXT: }
   init?(failable2: ()) {
     try! self.init(failableAndThrows: ())
   }
@@ -241,6 +313,55 @@ struct ThrowStruct {
     try? self.init(failableAndThrows: ())!
   }
 
+  // CHECK-LABEL: sil hidden [ossa] @$s21failable_initializers11ThrowStructV9failable4ACSgyt_tcfC
+  // CHECK: bb0([[SELF_META:%[0-9]+]] : $@thin ThrowStruct.Type):
+  // CHECK: [[DELEG_INIT:%[0-9]+]] = function_ref @$s21failable_initializers11ThrowStructV0A9AndThrowsACSgyt_tKcfC
+  // CHECK-NEXT: try_apply [[DELEG_INIT]]([[SELF_META]]) : $@convention(method) (@thin ThrowStruct.Type) -> (@owned Optional<ThrowStruct>, @error Error), normal [[SUCC_BB:bb[0-9]+]], error [[ERROR_BB:bb[0-9]+]]
+  //
+  // CHECK: [[SUCC_BB]]([[OPT_RESULT:%[0-9]+]] : @owned $Optional<ThrowStruct>):
+  // CHECK-NEXT: [[INJECT_INTO_OPT:%[0-9]+]] = enum {{.*}}, #Optional.some!enumelt, [[OPT_RESULT]]
+  // CHECK-NEXT: br bb2([[INJECT_INTO_OPT]] : $Optional<Optional<ThrowStruct>>)
+  //
+  // CHECK: bb2([[OPT_OPT_RESULT:%[0-9]+]] : @owned $Optional<Optional<ThrowStruct>>):
+  // CHECK-NEXT: switch_enum [[OPT_OPT_RESULT]] : {{.*}}, case #Optional.some!enumelt: [[OPT_OPT_SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[OPT_OPT_NONE_BB:bb[0-9]+]]
+  //
+  // CHECK: [[OPT_OPT_SOME_BB]]([[OPT_RESULT:%[0-9]+]] : @owned $Optional<ThrowStruct>):
+  // CHECK-NEXT: br bb5([[OPT_RESULT]] : $Optional<ThrowStruct>)
+  //
+  // CHECK: [[OPT_OPT_NONE_BB]]:
+  // CHECK-NEXT: [[NIL:%[0-9]+]] = enum $Optional<ThrowStruct>, #Optional.none!enumelt
+  // CHECK-NEXT: br bb5([[NIL]] : $Optional<ThrowStruct>)
+  //
+  // CHECK: bb5([[OPT_RESULT:%[0-9]+]] : @owned $Optional<ThrowStruct>):
+  // CHECK: [[SELECT:%[0-9]+]] = select_enum [[OPT_RESULT]]
+  // CHECK-NEXT: cond_br [[SELECT]], [[OPT_SOME_BB:bb[0-9]+]], [[OPT_NONE_BB:bb[0-9]+]]
+  //
+  // CHECK: [[OPT_NONE_BB]]:
+  // CHECK-NEXT: destroy_value [[OPT_RESULT]]
+  // CHECK-NEXT: br bb8
+  //
+  // CHECK: [[OPT_SOME_BB]]:
+  // CHECK-NEXT: [[RESULT:%[0-9]+]] = unchecked_enum_data [[OPT_RESULT]] : {{.*}}, #Optional.some!enumelt
+  // CHECK-NEXT: assign [[RESULT]] to [[DEST:%[0-9]+]]
+  // CHECK-NEXT: [[RESULT_CP:%[0-9]+]] = load [copy] [[DEST]]
+  // CHECK-NEXT: [[INJECT_INTO_OPT:%[0-9]+]] = enum $Optional<ThrowStruct>, #Optional.some!enumelt, [[RESULT_CP]]
+  // CHECK: br bb9([[INJECT_INTO_OPT]] : $Optional<ThrowStruct>)
+  //
+  // CHECK: bb8:
+  // CHECK: [[NIL:%[0-9]+]] = enum $Optional<ThrowStruct>, #Optional.none!enumelt
+  // CHECK-NEXT: br bb9([[NIL]] : $Optional<ThrowStruct>)
+  //
+  // CHECK: bb9([[RET:%[0-9]+]] : @owned $Optional<ThrowStruct>):
+  // CHECK-NEXT: return [[RET]]
+  //
+  // CHECK: bb10([[ERR:%[0-9]+]] : @owned $Error):
+  // CHECK-NEXT: destroy_value [[ERR]]
+  // CHECK-NEXT: [[NIL:%[0-9]+]] = enum $Optional<Optional<ThrowStruct>>, #Optional.none!enumelt
+  // CHECK-NEXT: br bb2([[NIL]] : $Optional<Optional<ThrowStruct>>)
+  //
+  // CHECK: [[ERROR_BB]]([[ERR:%[0-9]+]] : @owned $Error):
+  // CHECK-NEXT: br bb10([[ERR]] : $Error)
+  // CHECK-NEXT: }
   init?(failable4: ()) {
     try? self.init(failableAndThrows: ())
   }


### PR DESCRIPTION
Resolves #57012 and more.

There remains a family of malfunctioning edge cases that I'm not sure what to make of. Specifically, when the constructed `Optional` value is force-unwrapped:

```swift
extension Optional {
  init(nonFailable: Void) { ... }
  init?(failable: Void) { ... }

  init(delegation1: Void) {
    self.init(nonFailable: ())! // this
  }

   init(delegation2: Void) {
    self.init(failable: ())!! // or this
  }
}

extension Optional where Wrapped == Optional<Bool> {
  init(delegation3: Void) {
    self.init(nonFailable: ())!! // or this
  }
}
```

I guess we should either deal with them using optional injections or ban them.
