### PR TITLE
Increase expectation slop for clock tests

### DIFF
--- a/test/Concurrency/Runtime/clock.swift
+++ b/test/Concurrency/Runtime/clock.swift
@@ -23,7 +23,7 @@ var tests = TestSuite("Time")
       }
       // give a reasonable range of expected elapsed time
       expectGT(elapsed, .milliseconds(90))
-      expectLT(elapsed, .milliseconds(200))
+      expectLT(elapsed, .milliseconds(1000))
     }
 
     tests.test("ContinuousClock sleep with tolerance") {
@@ -33,7 +33,7 @@ var tests = TestSuite("Time")
       }
       // give a reasonable range of expected elapsed time
       expectGT(elapsed, .milliseconds(90))
-      expectLT(elapsed, .milliseconds(300))
+      expectLT(elapsed, .milliseconds(2000))
     }
 
     tests.test("ContinuousClock sleep longer") {
@@ -41,7 +41,7 @@ var tests = TestSuite("Time")
         try! await Task.sleep(until: .now + .seconds(1), clock: .continuous)
       }
       expectGT(elapsed, .seconds(1) - .milliseconds(90))
-      expectLT(elapsed, .seconds(1) + .milliseconds(200))
+      expectLT(elapsed, .seconds(1) + .milliseconds(1000))
     }
 
     tests.test("SuspendingClock sleep") {
@@ -51,7 +51,7 @@ var tests = TestSuite("Time")
       }
       // give a reasonable range of expected elapsed time
       expectGT(elapsed, .milliseconds(90))
-      expectLT(elapsed, .milliseconds(200))
+      expectLT(elapsed, .milliseconds(1000))
     }
 
     tests.test("SuspendingClock sleep with tolerance") {
@@ -61,7 +61,7 @@ var tests = TestSuite("Time")
       }
       // give a reasonable range of expected elapsed time
       expectGT(elapsed, .milliseconds(90))
-      expectLT(elapsed, .milliseconds(300))
+      expectLT(elapsed, .milliseconds(2000))
     }
 
     tests.test("SuspendingClock sleep longer") {
@@ -69,7 +69,7 @@ var tests = TestSuite("Time")
         try! await Task.sleep(until: .now + .seconds(1), clock: .suspending)
       }
       expectGT(elapsed, .seconds(1) - .milliseconds(90))
-      expectLT(elapsed, .seconds(1) + .milliseconds(200))
+      expectLT(elapsed, .seconds(1) + .milliseconds(1000))
     }
 
     tests.test("duration addition") {


### PR DESCRIPTION
Sadly server load makes some of the clock tests fail; heavier loads on the CI servers means that scheduling may get delayed even without tolerances (which is expected behavior). This increases the slop in the tests to ensure they are remotely reasonable by increasing the timeout to 10x of the sleep duration (which hopefully should be reasonable in almost all cases)

Resolves: rdar://94158711