### PR TITLE
Remove the grapheme cache from String.Index

### DIFF
--- a/stdlib/public/core/LegacyABI.swift
+++ b/stdlib/public/core/LegacyABI.swift
@@ -80,6 +80,30 @@ extension String {
   ) { fatalError() }
 }
 
+// The grapheme cache was removed in Swift 5.7 but these functions must be kept
+// because references to them have been inlined in Foundation and other places.
+extension String.Index {
+  @available(*, unavailable)
+  @usableFromInline
+  internal var characterStride: Int? {
+    return nil
+  }
+
+  @available(*, unavailable)
+  @usableFromInline
+  internal init(
+    encodedOffset: Int, transcodedOffset: Int, characterStride: Int
+  ) {
+    self.init(encodedOffset: encodedOffset, transcodedOffset: transcodedOffset)
+  }
+
+  @available(*, unavailable)
+  @usableFromInline
+  internal init(encodedOffset pos: Int, characterStride char: Int) {
+    self.init(encodedOffset: pos, transcodedOffset: 0)
+  }
+}
+
 extension String.UTF16View {
   // Swift 5.x: This was accidentally shipped as inlinable, but was never used
   // from an inlinable context. The definition is kept around for technical ABI

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -71,10 +71,8 @@ extension String: BidirectionalCollection {
     // TODO: known-ASCII fast path, single-scalar-grapheme fast path, etc.
     let stride = _characterStride(startingAt: i)
     let nextOffset = i._encodedOffset &+ stride
-    let nextIndex = Index(_encodedOffset: nextOffset)._characterAligned
-    let nextStride = _characterStride(startingAt: nextIndex)
-    let r = Index(encodedOffset: nextOffset, characterStride: nextStride)
-    return _guts.markEncoding(r._characterAligned)
+    let r = Index(_encodedOffset: nextOffset)._characterAligned
+    return _guts.markEncoding(r)
   }
 
   /// Returns the position immediately before the given index.
@@ -111,7 +109,7 @@ extension String: BidirectionalCollection {
     let stride = _characterStride(endingAt: i)
     let priorOffset = i._encodedOffset &- stride
 
-    let r = Index(encodedOffset: priorOffset, characterStride: stride)
+    let r = Index(_encodedOffset: priorOffset)
     return _guts.markEncoding(r._characterAligned)
   }
 
@@ -330,9 +328,6 @@ extension String: BidirectionalCollection {
   internal func _characterStride(startingAt i: Index) -> Int {
     // Prior to Swift 5.7, this function used to be inlinable.
     _internalInvariant_5_1(i._isScalarAligned)
-
-    // Fast check if it's already been measured, otherwise check resiliently
-    if let d = i.characterStride { return d }
 
     if i == endIndex { return 0 }
 

--- a/stdlib/public/core/StringGraphemeBreaking.swift
+++ b/stdlib/public/core/StringGraphemeBreaking.swift
@@ -111,7 +111,7 @@ extension _StringGuts {
       // Already aligned, or grapheme breaking returned an unexpected result.
       return i._characterAligned
     }
-    let r = String.Index(encodedOffset: start, characterStride: stride)
+    let r = String.Index(_encodedOffset: start)
     return markEncoding(r._characterAligned)
   }
 
@@ -159,7 +159,7 @@ extension _StringGuts {
       // Already aligned, or grapheme breaking returned an unexpected result.
       return i
     }
-    var r = String.Index(encodedOffset: prior, characterStride: stride)
+    var r = String.Index(_encodedOffset: prior)
     if bounds.lowerBound._isCharacterAligned {
       r = r._characterAligned
     } else {

--- a/stdlib/public/core/StringGutsRangeReplaceable.swift
+++ b/stdlib/public/core/StringGutsRangeReplaceable.swift
@@ -512,10 +512,7 @@ extension _StringGuts {
       _encodedOffset: newBounds.lowerBound
     )._scalarAligned._knownUTF8
 
-    // Preserve character alignment flag if possible
-    if startIndex._isCharacterAligned,
-      (oldRange.lowerBound > oldBounds.lowerBound ||
-        isOnGraphemeClusterBoundary(newStart)) {
+    if isOnGraphemeClusterBoundary(newStart) {
       newStart = newStart._characterAligned
     }
 

--- a/stdlib/public/core/StringGutsRangeReplaceable.swift
+++ b/stdlib/public/core/StringGutsRangeReplaceable.swift
@@ -483,14 +483,10 @@ extension _StringGuts {
       let newUTF8Count =
         oldUTF8Count + newUTF8Subrange.count - oldUTF8SubrangeCount
 
-      // Get the character stride in the entire string, not just the substring.
-      // (Characters in a substring may end beyond the bounds of it.)
-      let newStride = _opaqueCharacterStride(startingAt: utf8StartOffset)
-
       startIndex = String.Index(
         encodedOffset: utf8StartOffset,
-        transcodedOffset: 0,
-        characterStride: newStride)._scalarAligned._knownUTF8
+        transcodedOffset: 0)._scalarAligned._knownUTF8
+
       if isOnGraphemeClusterBoundary(startIndex) {
         startIndex = startIndex._characterAligned
       }
@@ -512,33 +508,18 @@ extension _StringGuts {
         oldBounds.lowerBound,
         oldBounds.upperBound &+ newRange.count &- oldRange.count))
 
-    // Update `startIndex` if necessary. The replacement may have invalidated
-    // its cached character stride and character alignment flag, but not its
-    // stored offset, encoding, or scalar alignment.
-    //
-    // We are exploiting the fact that mutating the string _after_ the scalar
-    // following the end of the character at `startIndex` cannot possibly change
-    // the length of that character. (This is true because `index(after:)` never
-    // needs to look ahead by more than one Unicode scalar.)
-    let oldStride = startIndex.characterStride ?? 0
-    if oldRange.lowerBound <= oldBounds.lowerBound &+ oldStride {
-      // Get the character stride in the entire string, not just the substring.
-      // (Characters in a substring may end beyond the bounds of it.)
-      let newStride = _opaqueCharacterStride(startingAt: newBounds.lowerBound)
-      var newStart = String.Index(
-        encodedOffset: newBounds.lowerBound,
-        characterStride: newStride
-      )._scalarAligned._knownUTF8
+    var newStart = String.Index(
+      _encodedOffset: newBounds.lowerBound
+    )._scalarAligned._knownUTF8
 
-      // Preserve character alignment flag if possible
-      if startIndex._isCharacterAligned,
-        (oldRange.lowerBound > oldBounds.lowerBound ||
-         isOnGraphemeClusterBoundary(newStart)) {
-        newStart = newStart._characterAligned
-      }
-
-      startIndex = newStart
+    // Preserve character alignment flag if possible
+    if startIndex._isCharacterAligned,
+      (oldRange.lowerBound > oldBounds.lowerBound ||
+        isOnGraphemeClusterBoundary(newStart)) {
+      newStart = newStart._characterAligned
     }
+
+    startIndex = newStart
 
     // Update `endIndex`.
     if newBounds.upperBound != endIndex._encodedOffset {

--- a/stdlib/public/core/StringIndex.swift
+++ b/stdlib/public/core/StringIndex.swift
@@ -23,12 +23,11 @@ String's Index has the following layout:
  └──────────┴────────────────╨────────────────────────╨───────┘
                              └────── resilient ───────┘
 
-Position, transcoded offset, and flags are fully exposed in the ABI. Grapheme
-cache and reserved bits are partially resilient: the fact that there are 11 bits
-with a default value of `0` is ABI, but not the layout, construction, or
-interpretation of those bits. Inlinable code should not set a non-zero value to
-resilient bits: doing so breaks future evolution as the meaning of those bits
-isn't frozen.
+Position, transcoded offset, and flags are fully exposed in the ABI. Reserved 
+bits are partially resilient: the fact that there are 11 bits with a default 
+value of `0` is ABI, but not the layout, construction, or interpretation of 
+those bits. Inlinable code should not set a non-zero value to resilient bits: 
+doing so breaks future evolution as the meaning of those bits isn't frozen.
 
 - position aka `encodedOffset`: A 48-bit offset into the string's code units
 
@@ -118,7 +117,8 @@ extension String.Index {
   }
 
   /// This used to return the cached stride value if it was set, however since
-  /// the cache was removed in Swift 5.7 we just return nil
+  /// the cache and references to it were removed in Swift 5.7 we just return
+  /// nil to maintain ABI
   @usableFromInline
   internal var characterStride: Int? {
     return nil
@@ -165,6 +165,8 @@ extension String.Index {
     self.init(encodedOffset: offset, transcodedOffset: 0)
   }
 
+  /// This constructor used to set the `characterStride` cache, however it was
+  /// removed in Swift 5.7 so this constructor is kept for ABI reasons only
   @usableFromInline
   internal init(
     encodedOffset: Int, transcodedOffset: Int, characterStride: Int
@@ -172,6 +174,8 @@ extension String.Index {
     self.init(encodedOffset: encodedOffset, transcodedOffset: transcodedOffset)
   }
 
+  /// This constructor used to set the `characterStride` cache, however it was
+  /// removed in Swift 5.7 so this constructor is kept for ABI reasons only
   @usableFromInline
   internal init(encodedOffset pos: Int, characterStride char: Int) {
     self.init(encodedOffset: pos, transcodedOffset: 0, characterStride: char)

--- a/stdlib/public/core/StringIndex.swift
+++ b/stdlib/public/core/StringIndex.swift
@@ -116,15 +116,6 @@ extension String.Index {
     return Int(truncatingIfNeeded: orderingValue & 0x3)
   }
 
-  /// This used to return the cached stride value if it was set, however since
-  /// the cache and references to it were removed in Swift 5.7 we just return
-  /// nil to maintain ABI
-  @available(*, unavailable)
-  @usableFromInline
-  internal var characterStride: Int? {
-    return nil
-  }
-
   @inlinable @inline(__always)
   internal init(encodedOffset: Int, transcodedOffset: Int) {
     let pos = UInt64(truncatingIfNeeded: encodedOffset)
@@ -164,24 +155,6 @@ extension String.Index {
   @inlinable @inline(__always)
   internal init(_encodedOffset offset: Int) {
     self.init(encodedOffset: offset, transcodedOffset: 0)
-  }
-
-  /// This constructor used to set the `characterStride` cache, however it was
-  /// removed in Swift 5.7 so this constructor is kept for ABI reasons only
-  @available(*, unavailable)
-  @usableFromInline
-  internal init(
-    encodedOffset: Int, transcodedOffset: Int, characterStride: Int
-  ) {
-    self.init(encodedOffset: encodedOffset, transcodedOffset: transcodedOffset)
-  }
-
-  /// This constructor used to set the `characterStride` cache, however it was
-  /// removed in Swift 5.7 so this constructor is kept for ABI reasons only
-  @available(*, unavailable)
-  @usableFromInline
-  internal init(encodedOffset pos: Int, characterStride char: Int) {
-    self.init(encodedOffset: pos, transcodedOffset: 0)
   }
 
   #if !INTERNAL_CHECKS_ENABLED

--- a/stdlib/public/core/StringIndex.swift
+++ b/stdlib/public/core/StringIndex.swift
@@ -119,6 +119,7 @@ extension String.Index {
   /// This used to return the cached stride value if it was set, however since
   /// the cache and references to it were removed in Swift 5.7 we just return
   /// nil to maintain ABI
+  @available(*, unavailable)
   @usableFromInline
   internal var characterStride: Int? {
     return nil
@@ -167,6 +168,7 @@ extension String.Index {
 
   /// This constructor used to set the `characterStride` cache, however it was
   /// removed in Swift 5.7 so this constructor is kept for ABI reasons only
+  @available(*, unavailable)
   @usableFromInline
   internal init(
     encodedOffset: Int, transcodedOffset: Int, characterStride: Int
@@ -176,9 +178,10 @@ extension String.Index {
 
   /// This constructor used to set the `characterStride` cache, however it was
   /// removed in Swift 5.7 so this constructor is kept for ABI reasons only
+  @available(*, unavailable)
   @usableFromInline
   internal init(encodedOffset pos: Int, characterStride char: Int) {
-    self.init(encodedOffset: pos, transcodedOffset: 0, characterStride: char)
+    self.init(encodedOffset: pos, transcodedOffset: 0)
   }
 
   #if !INTERNAL_CHECKS_ENABLED

--- a/stdlib/public/core/StringIndex.swift
+++ b/stdlib/public/core/StringIndex.swift
@@ -16,18 +16,17 @@ import SwiftShims
 
 String's Index has the following layout:
 
- ┌──────────┬────────────────╥────────────────┬───────╥───────┐
- │ b63:b16  │      b15:b14   ║     b13:b8     │ b7:b4 ║ b3:b0 │
- ├──────────┼────────────────╫────────────────┼───────╫───────┤
- │ position │ transc. offset ║ grapheme cache │ rsvd  ║ flags │
- └──────────┴────────────────╨────────────────┴───────╨───────┘
+ ┌──────────┬────────────────╥────────────────────────╥───────┐
+ │ b63:b16  │      b15:b14   ║         b13:b4         ║ b3:b0 │
+ ├──────────┼────────────────╫────────────────────────╫───────┤
+ │ position │ transc. offset ║        reserved        ║ flags │
+ └──────────┴────────────────╨────────────────────────╨───────┘
                              └────── resilient ───────┘
 
 Position, transcoded offset, and flags are fully exposed in the ABI. Grapheme
 cache and reserved bits are partially resilient: the fact that there are 11 bits
 with a default value of `0` is ABI, but not the layout, construction, or
-interpretation of those bits. All use of grapheme cache should be behind
-non-inlinable function calls. Inlinable code should not set a non-zero value to
+interpretation of those bits. Inlinable code should not set a non-zero value to
 resilient bits: doing so breaks future evolution as the meaning of those bits
 isn't frozen.
 
@@ -37,13 +36,10 @@ isn't frozen.
 
 <resilience barrier>
 
-- grapheme cache: A 6-bit value remembering the distance to the next extended
-  grapheme cluster boundary, or 0 if unknown. The value stored (if any) must be
-  calculated assuming that the index addresses a boundary itself, i.e., without
-  looking back at scalars preceding the index. (Substrings that don't start on a
-  `Character` boundary heavily rely on this.)
+- Previously b13:8 contained a cache of the stride to the next character 
+  boundary (Removed in Swift 5.7)
 
-- reserved: 4 unused bits available for future flags etc. The meaning of each
+- reserved: 10 unused bits available for future flags etc. The meaning of each
   bit may change between stdlib versions. These must be set to zero if
   constructing an index in inlinable code.
 
@@ -121,10 +117,11 @@ extension String.Index {
     return Int(truncatingIfNeeded: orderingValue & 0x3)
   }
 
+  /// This used to return the cached stride value if it was set, however since
+  /// the cache was removed in Swift 5.7 we just return nil
   @usableFromInline
   internal var characterStride: Int? {
-    let value = (_rawBits & 0x3F00) &>> 8
-    return value > 0 ? Int(truncatingIfNeeded: value) : nil
+    return nil
   }
 
   @inlinable @inline(__always)
@@ -173,9 +170,6 @@ extension String.Index {
     encodedOffset: Int, transcodedOffset: Int, characterStride: Int
   ) {
     self.init(encodedOffset: encodedOffset, transcodedOffset: transcodedOffset)
-    if _slowPath(characterStride > 0x3F) { return }
-    self._rawBits |= UInt64(truncatingIfNeeded: characterStride &<< 8)
-    self._invariantCheck()
   }
 
   @usableFromInline

--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -233,11 +233,8 @@ extension Substring: StringProtocol {
     let nextOffset = Swift.min(
       i._encodedOffset &+ stride,
       endIndex._encodedOffset)
-    let nextIndex = Index(_encodedOffset: nextOffset)._scalarAligned
-    let nextStride = _characterStride(startingAt: nextIndex)
 
-    var r = Index(
-      encodedOffset: nextOffset, characterStride: nextStride)._scalarAligned
+    var r = Index(_encodedOffset: nextOffset)._scalarAligned
 
     // Don't set the `_isCharacterAligned` bit in indices of exotic substrings
     // whose startIndex isn't aligned on a grapheme cluster boundary. (Their
@@ -287,9 +284,7 @@ extension Substring: StringProtocol {
     let priorOffset = i._encodedOffset &- priorStride
     _internalInvariant(priorOffset >= startIndex._encodedOffset)
 
-    var r = Index(
-      encodedOffset: priorOffset, characterStride: priorStride
-    )._scalarAligned
+    var r = Index(_encodedOffset: priorOffset)._scalarAligned
 
     // Don't set the `_isCharacterAligned` bit in indices of exotic substrings
     // whose startIndex isn't aligned on a grapheme cluster boundary. (Their
@@ -564,10 +559,6 @@ extension Substring {
   internal func _characterStride(startingAt i: Index) -> Int {
     _internalInvariant(i._isScalarAligned)
     _internalInvariant(i._encodedOffset <= _wholeGuts.count)
-
-    // If the index has a character stride, it reflects the stride assuming that
-    // it addresses a `Character` boundary, which is exactly what we want.
-    if let d = i.characterStride { return d }
 
     if i._encodedOffset == endIndex._encodedOffset { return 0 }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Currently `String.Index` contains a cache of the stride to the next character boundary. This is primarily used in the case where a user calls `formIndex(after:)` followed by `subscript` repetitively over the string. Both calls require knowing the stride to the next character so work was being duplicated, leading to the addition of a cache storing the stride. However with the implementation of the grapheme breaking algorithm directly in the stdlib and the more common iterator case having it's own implementation we decided to see how removing the cache would affect performance and it seems like there is very little difference

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
