### PR TITLE
ModuleInterface: Fix use-after-free when cloning SPI attributes

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1949,8 +1949,8 @@ SPIAccessControlAttr::create(ASTContext &context,
 
 SPIAccessControlAttr *SPIAccessControlAttr::clone(ASTContext &C,
                                                   bool implicit) const {
-  auto *attr = new (C) SPIAccessControlAttr(
-      implicit ? SourceLoc() : AtLoc, implicit ? SourceRange() : getRange(),
+  auto *attr = SPIAccessControlAttr::create(
+      C, implicit ? SourceLoc() : AtLoc, implicit ? SourceRange() : getRange(),
       getSPIGroups());
   attr->setImplicit(implicit);
   return attr;


### PR DESCRIPTION
Fixes a regression from https://github.com/apple/swift/pull/59128.

Resolves rdar://94176931.
