### PR TITLE
[5.7][docs] clarify docs for load, loadUnaligned and storeBytes

### DIFF
--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -350,6 +350,10 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// Returns a new instance of the given type, read from the buffer pointer's
   /// raw memory at the specified byte offset.
   ///
+  /// The memory at `offset` bytes from this buffer pointer's `baseAddress`
+  /// must be properly aligned for accessing `T` and initialized to `T` or
+  /// another type that is layout compatible with `T`.
+  ///
   /// You can use this method to create new values from the buffer pointer's
   /// underlying bytes. The following example creates two new `Int32`
   /// instances from the memory referenced by the buffer pointer `someBytes`.
@@ -394,10 +398,10 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// underlying bytes. The following example creates two new `Int32`
   /// instances from the memory referenced by the buffer pointer `someBytes`.
   /// The bytes for `a` are copied from the first four bytes of `someBytes`,
-  /// and the bytes for `b` are copied from the next four bytes.
+  /// and the bytes for `b` are copied from the fourth through seventh bytes.
   ///
-  ///     let a = someBytes.load(as: Int32.self)
-  ///     let b = someBytes.load(fromByteOffset: 4, as: Int32.self)
+  ///     let a = someBytes.loadUnaligned(as: Int32.self)
+  ///     let b = someBytes.loadUnaligned(fromByteOffset: 3, as: Int32.self)
   ///
   /// The memory to read for the new instance must not extend beyond the buffer
   /// pointer's memory region---that is, `offset + MemoryLayout<T>.size` must
@@ -405,9 +409,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///
   /// - Parameters:
   ///   - offset: The offset, in bytes, into the buffer pointer's memory at
-  ///     which to begin reading data for the new instance. The buffer pointer
-  ///     plus `offset` must be properly aligned for accessing an instance of
-  ///     type `T`. The default is zero.
+  ///     which to begin reading data for the new instance. The default is zero.
   ///   - type: The type to use for the newly constructed instance. The memory
   ///     must be initialized to a value of a type that is layout compatible
   ///     with `type`.
@@ -455,9 +457,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// - Parameters:
   ///   - value: The value to store as raw bytes.
   ///   - offset: The offset in bytes into the buffer pointer's memory to begin
-  ///     reading data for the new instance. The buffer pointer plus `offset`
-  ///     must be properly aligned for accessing an instance of type `T`. The
-  ///     default is zero.
+  ///     reading data for the new instance. The default is zero.
   ///   - type: The type to use for the newly constructed instance. The memory
   ///     must be initialized to a value of a type that is layout compatible
   ///     with `type`.

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -457,7 +457,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// - Parameters:
   ///   - value: The value to store as raw bytes.
   ///   - offset: The offset in bytes into the buffer pointer's memory to begin
-  ///     reading data for the new instance. The default is zero.
+  ///     writing bytes from the value. The default is zero.
   ///   - type: The type to use for the newly constructed instance. The memory
   ///     must be initialized to a value of a type that is layout compatible
   ///     with `type`.


### PR DESCRIPTION
- removes some outdated or incorrect information.
- improves on the doc-comments modified in https://github.com/apple/swift/pull/41033, where the updates were correct for UnsafeRawPointer, but not so correct for UnsafeRawBufferPointer

Cherry-pick of https://github.com/apple/swift/pull/59187 and https://github.com/apple/swift/pull/59200