### PR TITLE
build: optionalise LLVM dependency

### DIFF
--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -250,8 +250,8 @@ endmacro()
 #     The product name, e.g. Swift or SourceKit. Used as prefix for some
 #     cmake variables.
 macro(swift_common_standalone_build_config product)
-  swift_common_standalone_build_config_llvm(${product})
   if(SWIFT_INCLUDE_TOOLS)
+    swift_common_standalone_build_config_llvm(${product})
     swift_common_standalone_build_config_clang(${product})
     swift_common_standalone_build_config_cmark(${product})
   endif()


### PR DESCRIPTION
When building just the standard library, LLVM is not a required
dependency.  This moves towards dropping that dependency in the
case that the tools are not being built.