### PR TITLE
[stdlib] Add overload to String(reflecting:) for metatypes

### DIFF
--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -771,6 +771,58 @@ extension String {
     self.init()
     _debugPrint_unlocked(subject, &self)
   }
+
+  // Overload for metatypes because the generic function above goes through
+  // various hoops that are unnecessary for printing metatypes.
+
+  /// Creates a string with a detailed representation of the given value,
+  /// suitable for debugging.
+  ///
+  /// Use this initializer to convert an instance of any type to its custom
+  /// debugging representation. The initializer creates the string
+  /// representation of `instance` in one of the following ways, depending on
+  /// its protocol conformance:
+  ///
+  /// - If `subject` conforms to the `CustomDebugStringConvertible` protocol,
+  ///   the result is `subject.debugDescription`.
+  /// - If `subject` conforms to the `CustomStringConvertible` protocol, the
+  ///   result is `subject.description`.
+  /// - If `subject` conforms to the `TextOutputStreamable` protocol, the
+  ///   result is obtained by calling `subject.write(to: s)` on an empty
+  ///   string `s`.
+  /// - An unspecified result is supplied automatically by the Swift standard
+  ///   library.
+  ///
+  /// For example, this custom `Point` struct uses the default representation
+  /// supplied by the standard library.
+  ///
+  ///     struct Point {
+  ///         let x: Int, y: Int
+  ///     }
+  ///
+  ///     let p = Point(x: 21, y: 30)
+  ///     print(String(reflecting: p))
+  ///     // Prints "p: Point = {
+  ///     //           x = 21
+  ///     //           y = 30
+  ///     //         }"
+  ///
+  /// After adding `CustomDebugStringConvertible` conformance by implementing
+  /// the `debugDescription` property, `Point` provides its own custom
+  /// debugging representation.
+  ///
+  ///     extension Point: CustomDebugStringConvertible {
+  ///         var debugDescription: String {
+  ///             return "Point(x: \(x), y: \(y))"
+  ///         }
+  ///     }
+  ///
+  ///     print(String(reflecting: p))
+  ///     // Prints "Point(x: 21, y: 30)"
+  @_alwaysEmitIntoClient
+  public init<Subject>(reflecting subject: Subject.Type) {
+    self = _typeName(subject, qualified: true)
+  }
 }
 
 #if SWIFT_ENABLE_REFLECTION


### PR DESCRIPTION
<!-- What's in this pull request? -->
Taking the lead from https://github.com/apple/swift/pull/39726, this PR adds a fast path to `String(reflecting:)` for metatypes to avoid unnecessary protocol conformance checks and `Mirror` creation.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
