### PR TITLE
[5.7][build-script] Cross-compile sourcekit-lsp for arm64

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/indexstoredb.py
+++ b/utils/swift_build_support/swift_build_support/products/indexstoredb.py
@@ -60,6 +60,9 @@ class IndexStoreDB(product.Product):
     def install(self, host_target):
         pass
 
+    def has_cross_compile_hosts(self):
+        return False
+
     @classmethod
     def get_dependencies(cls):
         return [cmark.CMark,
@@ -105,18 +108,24 @@ def run_build_script_helper(action, host_target, product, args,
     elif args.enable_tsan:
         helper_cmd.extend(['--sanitize', 'thread'])
 
-    if not product.is_darwin_host(
-            host_target) and product.is_cross_compile_target(host_target):
-        helper_cmd.extend(['--cross-compile-host', host_target])
-        build_toolchain_path = install_destdir + args.install_prefix
-        resource_dir = '%s/lib/swift' % build_toolchain_path
-        helper_cmd += [
-            '--cross-compile-config',
-            targets.StdlibDeploymentTarget.get_target_for_name(host_target).platform
-            .swiftpm_config(args, output_dir=build_toolchain_path,
-                            swift_toolchain=toolchain_path,
-                            resource_path=resource_dir)
-        ]
+    # Pass Cross compile host info
+    if product.has_cross_compile_hosts():
+        if product.is_darwin_host(host_target):
+            if len(args.cross_compile_hosts) != 1:
+                raise RuntimeError("Cross-Compiling indexstoredb to multiple " +
+                                   "targets is not supported")
+            helper_cmd += ['--cross-compile-host', args.cross_compile_hosts[0]]
+        elif product.is_cross_compile_target(host_target):
+            helper_cmd.extend(['--cross-compile-host', host_target])
+            build_toolchain_path = install_destdir + args.install_prefix
+            resource_dir = '%s/lib/swift' % build_toolchain_path
+            helper_cmd += [
+                '--cross-compile-config',
+                targets.StdlibDeploymentTarget.get_target_for_name(host_target).platform
+                .swiftpm_config(args, output_dir=build_toolchain_path,
+                                swift_toolchain=toolchain_path,
+                                resource_path=resource_dir)
+            ]
 
     if action == 'install' and product.product_name() == "sourcekitlsp":
         helper_cmd.extend([

--- a/utils/swift_build_support/swift_build_support/products/product.py
+++ b/utils/swift_build_support/swift_build_support/products/product.py
@@ -244,6 +244,9 @@ class Product(object):
         return self.args.cross_compile_hosts and \
             host_target in self.args.cross_compile_hosts
 
+    def has_cross_compile_hosts(self):
+        return self.args.cross_compile_hosts
+
     def generate_darwin_toolchain_file(self, platform, arch):
         shell.makedirs(self.build_dir)
         toolchain_file = os.path.join(self.build_dir, 'BuildScriptToolchain.cmake')

--- a/utils/swift_build_support/swift_build_support/products/swiftdriver.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftdriver.py
@@ -21,7 +21,6 @@ from . import llbuild
 from . import llvm
 from . import product
 from . import swift
-from . import swiftpm
 from . import xctest
 from .. import shell
 from .. import targets
@@ -128,7 +127,7 @@ def run_build_script_helper(action, host_target, product, args):
             '--lit-test-dir', lit_test_dir
         ]
     # Pass Cross compile host info
-    if swiftpm.SwiftPM.has_cross_compile_hosts(args):
+    if product.has_cross_compile_hosts():
         if product.is_darwin_host(host_target):
             helper_cmd += ['--cross-compile-hosts']
             for cross_compile_host in args.cross_compile_hosts:

--- a/utils/swift_build_support/swift_build_support/products/swiftpm.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftpm.py
@@ -93,7 +93,7 @@ class SwiftPM(product.Product):
             ]
 
         # Pass Cross compile host info
-        if self.has_cross_compile_hosts(self.args):
+        if self.has_cross_compile_hosts():
             if self.is_darwin_host(host_target):
                 helper_cmd += ['--cross-compile-hosts']
                 for cross_compile_host in self.args.cross_compile_hosts:
@@ -132,10 +132,6 @@ class SwiftPM(product.Product):
 
     def should_install(self, host_target):
         return self.args.install_swiftpm
-
-    @classmethod
-    def has_cross_compile_hosts(self, args):
-        return args.cross_compile_hosts
 
     def install(self, host_target):
         install_destdir = self.host_install_destdir(host_target)


### PR DESCRIPTION
* **Explanation**: Currently, when building an open source toolchain, SourceKit-LSP is only built for x86_64. Copy the cross-compilation config from swiftpm.py to also produce a fat sourcekit-lsp executable for both x86_64 and arm64.
* **Scope**: The way SourceKit-LSP is built in open source toolchains
* **Risk**: These changes to the build process are always a little risky, but I think we should be able to catch any issues once the next open source toolchain is released
* **Testing**: Verified that the binary produced by https://github.com/apple/swift/pull/59046 was fat (x86_64 and arm64) and ran on arm64
* **Issue**: rdar://78039145
* **Reviewer**: @benlangmuir, @buttaface on https://github.com/apple/swift/pull/59046

---

Companion of https://github.com/apple/sourcekit-lsp/pull/561.