### PR TITLE
Change message of `invalid_iboutlet` and `invalid_ibinspectable` to reflect accurate usage

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1406,8 +1406,6 @@ ERROR(transparent_in_protocols_not_supported,none,
 ERROR(transparent_in_classes_not_supported,none,
       "'@_transparent' attribute is not supported on declarations within classes", ())
 
-ERROR(invalid_iboutlet,none,
-      "only instance properties can be declared @IBOutlet", ())
 ERROR(iboutlet_nonobjc_class,none,
       "@IBOutlet property cannot %select{have|be an array of}0 "
       "non-'@objc' class type %1", (bool, Type))
@@ -1429,8 +1427,8 @@ NOTE(note_make_implicitly_unwrapped_optional,none,
 ERROR(invalid_ibdesignable_extension,none,
       "@IBDesignable can only be applied to classes and extensions "
       "of classes", ())
-ERROR(invalid_ibinspectable,none,
-      "only instance properties can be declared @%0", (StringRef))
+ERROR(attr_must_be_used_on_class_instance,none,
+      "only class instance properties can be declared @%0", (StringRef))
 ERROR(invalid_ibaction_decl,none,
       "only instance methods can be declared @%0", (StringRef))
 ERROR(invalid_ibaction_result,none,

--- a/include/swift/Migrator/FixitFilter.h
+++ b/include/swift/Migrator/FixitFilter.h
@@ -51,13 +51,12 @@ struct FixitFilter {
       return false;
     // The following interact badly with the swift migrator by removing @IB*
     // attributes when there is some unrelated type issue.
-    if (Info.ID == diag::invalid_iboutlet.ID ||
-        Info.ID == diag::iboutlet_nonobjc_class.ID ||
+    if (Info.ID == diag::iboutlet_nonobjc_class.ID ||
         Info.ID == diag::iboutlet_nonobjc_protocol.ID ||
         Info.ID == diag::iboutlet_nonobject_type.ID ||
         Info.ID == diag::iboutlet_only_mutable.ID ||
         Info.ID == diag::invalid_ibdesignable_extension.ID ||
-        Info.ID == diag::invalid_ibinspectable.ID ||
+        Info.ID == diag::attr_must_be_used_on_class_instance.ID ||
         Info.ID == diag::invalid_ibaction_decl.ID)
       return false;
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -633,7 +633,7 @@ void AttributeChecker::visitIBInspectableAttr(IBInspectableAttr *attr) {
   auto *VD = cast<VarDecl>(D);
   if (!VD->getDeclContext()->getSelfClassDecl() || VD->isStatic())
     diagnoseAndRemoveAttr(attr, diag::attr_must_be_used_on_class_instance,
-                                 attr->getAttrName());
+                          attr->getAttrName());
 }
 
 void AttributeChecker::visitGKInspectableAttr(GKInspectableAttr *attr) {
@@ -641,7 +641,7 @@ void AttributeChecker::visitGKInspectableAttr(GKInspectableAttr *attr) {
   auto *VD = cast<VarDecl>(D);
   if (!VD->getDeclContext()->getSelfClassDecl() || VD->isStatic())
     diagnoseAndRemoveAttr(attr, diag::attr_must_be_used_on_class_instance,
-                                 attr->getAttrName());
+                          attr->getAttrName());
 }
 
 static Optional<Diag<bool,Type>>
@@ -691,7 +691,7 @@ void AttributeChecker::visitIBOutletAttr(IBOutletAttr *attr) {
   auto *VD = cast<VarDecl>(D);
   if (!VD->getDeclContext()->getSelfClassDecl() || VD->isStatic())
     diagnoseAndRemoveAttr(attr, diag::attr_must_be_used_on_class_instance,
-                                 attr->getAttrName());
+                          attr->getAttrName());
 
   if (!VD->isSettable(nullptr)) {
     // Allow non-mutable IBOutlet properties in module interfaces,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -632,7 +632,7 @@ void AttributeChecker::visitIBInspectableAttr(IBInspectableAttr *attr) {
   // Only instance properties can be 'IBInspectable'.
   auto *VD = cast<VarDecl>(D);
   if (!VD->getDeclContext()->getSelfClassDecl() || VD->isStatic())
-    diagnoseAndRemoveAttr(attr, diag::invalid_ibinspectable,
+    diagnoseAndRemoveAttr(attr, diag::attr_must_be_used_on_class_instance,
                                  attr->getAttrName());
 }
 
@@ -640,7 +640,7 @@ void AttributeChecker::visitGKInspectableAttr(GKInspectableAttr *attr) {
   // Only instance properties can be 'GKInspectable'.
   auto *VD = cast<VarDecl>(D);
   if (!VD->getDeclContext()->getSelfClassDecl() || VD->isStatic())
-    diagnoseAndRemoveAttr(attr, diag::invalid_ibinspectable,
+    diagnoseAndRemoveAttr(attr, diag::attr_must_be_used_on_class_instance,
                                  attr->getAttrName());
 }
 
@@ -690,7 +690,8 @@ void AttributeChecker::visitIBOutletAttr(IBOutletAttr *attr) {
   // Only instance properties can be 'IBOutlet'.
   auto *VD = cast<VarDecl>(D);
   if (!VD->getDeclContext()->getSelfClassDecl() || VD->isStatic())
-    diagnoseAndRemoveAttr(attr, diag::invalid_iboutlet);
+    diagnoseAndRemoveAttr(attr, diag::attr_must_be_used_on_class_instance,
+                                 attr->getAttrName());
 
   if (!VD->isSettable(nullptr)) {
     // Allow non-mutable IBOutlet properties in module interfaces,

--- a/test/attr/attr_iboutlet.swift
+++ b/test/attr/attr_iboutlet.swift
@@ -4,7 +4,7 @@
 import Foundation
 
 // expected-error@+1 {{@IBOutlet property cannot have non-object type 'Int'}}
-@IBOutlet // expected-error {{only instance properties can be declared @IBOutlet}} {{1-11=}}
+@IBOutlet // expected-error {{only class instance properties can be declared @IBOutlet}} {{1-11=}}
 var iboutlet_global: Int?
 
 @IBOutlet // expected-error {{@IBOutlet may only be used on 'var' declarations}} {{1-11=}}
@@ -22,7 +22,7 @@ class IBOutletWrapperTy {
 
   @IBOutlet
   class var staticValue: IBOutletWrapperTy? = 52  // expected-error {{cannot convert value of type 'Int' to specified type 'IBOutletWrapperTy?'}}
-  // expected-error@-2 {{only instance properties can be declared @IBOutlet}} {{3-12=}}
+  // expected-error@-2 {{only class instance properties can be declared @IBOutlet}} {{3-12=}}
   // expected-error@-2 {{class stored properties not supported}}
 
   @IBOutlet // expected-error {{@IBOutlet may only be used on 'var' declarations}} {{3-13=}}

--- a/test/attr/attributes.swift
+++ b/test/attr/attributes.swift
@@ -40,12 +40,16 @@ class Inspect {
   @IBInspectable func foo() {} // expected-error {{@IBInspectable may only be used on 'var' declarations}} {{3-18=}}
   @GKInspectable func foo2() {} // expected-error {{@GKInspectable may only be used on 'var' declarations}} {{3-18=}}
 
-  @IBInspectable class var cval: Int { return 0 } // expected-error {{only instance properties can be declared @IBInspectable}} {{3-18=}}
-  @GKInspectable class var cval2: Int { return 0 } // expected-error {{only instance properties can be declared @GKInspectable}} {{3-18=}}
+  @IBInspectable class var cval: Int { return 0 } // expected-error {{only class instance properties can be declared @IBInspectable}} {{3-18=}}
+  @GKInspectable class var cval2: Int { return 0 } // expected-error {{only class instance properties can be declared @GKInspectable}} {{3-18=}}
 }
-@IBInspectable var ibinspectable_global : Int // expected-error {{only instance properties can be declared @IBInspectable}} {{1-16=}}
-@GKInspectable var gkinspectable_global : Int // expected-error {{only instance properties can be declared @GKInspectable}} {{1-16=}}
+@IBInspectable var ibinspectable_global : Int // expected-error {{only class instance properties can be declared @IBInspectable}} {{1-16=}}
+@GKInspectable var gkinspectable_global : Int // expected-error {{only class instance properties can be declared @GKInspectable}} {{1-16=}}
 
+struct inspectableWithStruct {
+  @IBInspectable var IBInspectableInStruct: Int // expected-error {{only class instance properties can be declared @IBInspectable}} {{3-18=}}
+  @GKInspectable var GKInspectableInStruct: Int // expected-error {{only class instance properties can be declared @GKInspectable}} {{3-18=}}
+}
 
 func foo(x: @convention(block) Int) {} // expected-error {{@convention attribute only applies to function types}}
 func foo(x: @convention(block) (Int) -> Int) {}


### PR DESCRIPTION
The current error message for when `@GKInspectable`, `@IBInspectable`, and `@IBOutlet` is `only instance properties can be declared @GKInspectable / @IBInspectable / @IBOutlet`, however it doesn't reflect that it should be an instance property of a class, just that it should be an instance property, though those attributes are only allowed to be used for instance properties of a class type.

This pull request changes the message so that it should reflect the attribute should be used on a class instance property.