### PR TITLE
[docs] fix a parameter description for storeBytes

### DIFF
--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -457,7 +457,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// - Parameters:
   ///   - value: The value to store as raw bytes.
   ///   - offset: The offset in bytes into the buffer pointer's memory to begin
-  ///     reading data for the new instance. The default is zero.
+  ///     writing bytes from the value. The default is zero.
   ///   - type: The type to use for the newly constructed instance. The memory
   ///     must be initialized to a value of a type that is layout compatible
   ///     with `type`.


### PR DESCRIPTION
- this description has had the wrong polarity for years