### PR TITLE
[IRGen] Import ASTDemangler.h in both debug and non-debug

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -21,6 +21,7 @@
 #include "GenStruct.h"
 #include "GenType.h"
 #include "IRBuilder.h"
+#include "swift/AST/ASTDemangler.h"
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/GenericEnvironment.h"
@@ -63,10 +64,6 @@
 #include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Utils/Local.h"
-
-#ifndef NDEBUG
-#include "swift/AST/ASTDemangler.h"
-#endif
 
 using namespace swift;
 using namespace irgen;


### PR DESCRIPTION
This was breaking non-debug builds.

rdar://94234645