### PR TITLE
Add `Task.sleep(for: Duration)`

### DIFF
--- a/stdlib/public/Concurrency/TaskSleepDuration.swift
+++ b/stdlib/public/Concurrency/TaskSleepDuration.swift
@@ -154,7 +154,7 @@ extension Task where Success == Never, Failure == Never {
   ///
   /// - Parameter duration: The duration to wait.
   @available(SwiftStdlib 5.7, *)
-  public static func sleep(
+  public static func sleep(for duration: Duration) async throws {
     for duration: Duration
   ) async throws {
     try await sleep(until: .now + duration, clock: .continuous)

--- a/stdlib/public/Concurrency/TaskSleepDuration.swift
+++ b/stdlib/public/Concurrency/TaskSleepDuration.swift
@@ -152,6 +152,7 @@ extension Task where Success == Never, Failure == Never {
   ///
   ///       try await Task.sleep(for: .seconds(3))
   ///
+  /// - Parameter duration: The duration to wait, in seconds.
   @available(SwiftStdlib 5.7, *)
   public static func sleep(
     for duration: Duration

--- a/stdlib/public/Concurrency/TaskSleepDuration.swift
+++ b/stdlib/public/Concurrency/TaskSleepDuration.swift
@@ -142,4 +142,20 @@ extension Task where Success == Never, Failure == Never {
   ) async throws {
     try await clock.sleep(until: deadline, tolerance: tolerance)
   }
+  
+  /// Suspends the current task for the given duration.
+  ///
+  /// If the task is canceled before the time ends, this function throws 
+  /// `CancellationError`.
+  ///
+  /// This function doesn't block the underlying thread.
+  ///
+  ///       try await Task.sleep(for: .seconds(3))
+  ///
+  @available(SwiftStdlib 5.7, *)
+  public static func sleep(
+    for duration: Duration
+  ) async throws {
+    try await sleep(until: .now + duration, clock: .continuous)
+  }
 }

--- a/stdlib/public/Concurrency/TaskSleepDuration.swift
+++ b/stdlib/public/Concurrency/TaskSleepDuration.swift
@@ -143,7 +143,7 @@ extension Task where Success == Never, Failure == Never {
     try await clock.sleep(until: deadline, tolerance: tolerance)
   }
   
-  /// Suspends the current task for the given duration.
+  /// Suspends the current task for the given duration on a continuous clock.
   ///
   /// If the task is canceled before the time ends, this function throws 
   /// `CancellationError`.

--- a/stdlib/public/Concurrency/TaskSleepDuration.swift
+++ b/stdlib/public/Concurrency/TaskSleepDuration.swift
@@ -145,7 +145,7 @@ extension Task where Success == Never, Failure == Never {
   
   /// Suspends the current task for the given duration on a continuous clock.
   ///
-  /// If the task is canceled before the time ends, this function throws 
+  /// If the task is cancelled before the time ends, this function throws 
   /// `CancellationError`.
   ///
   /// This function doesn't block the underlying thread.

--- a/stdlib/public/Concurrency/TaskSleepDuration.swift
+++ b/stdlib/public/Concurrency/TaskSleepDuration.swift
@@ -155,8 +155,6 @@ extension Task where Success == Never, Failure == Never {
   /// - Parameter duration: The duration to wait.
   @available(SwiftStdlib 5.7, *)
   public static func sleep(for duration: Duration) async throws {
-    for duration: Duration
-  ) async throws {
     try await sleep(until: .now + duration, clock: .continuous)
   }
 }

--- a/stdlib/public/Concurrency/TaskSleepDuration.swift
+++ b/stdlib/public/Concurrency/TaskSleepDuration.swift
@@ -152,7 +152,7 @@ extension Task where Success == Never, Failure == Never {
   ///
   ///       try await Task.sleep(for: .seconds(3))
   ///
-  /// - Parameter duration: The duration to wait, in seconds.
+  /// - Parameter duration: The duration to wait.
   @available(SwiftStdlib 5.7, *)
   public static func sleep(
     for duration: Duration


### PR DESCRIPTION
This PR introduces missing functionality from [SE-0329](https://github.com/apple/swift-evolution/blob/a51c13579dbb7256641c1be005fb6a74b80793e0/proposals/0329-clock-instant-duration.md), namely the `Task.sleep` helper that takes a `Duration`.

I PRed against `main` but this should also be pulled into 5.7.

/cc @phausler