### PR TITLE
Disallow async IBAction methods

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1433,8 +1433,6 @@ ERROR(invalid_ibinspectable,none,
       "only instance properties can be declared @%0", (StringRef))
 ERROR(invalid_ibaction_decl,none,
       "only instance methods can be declared @%0", (StringRef))
-ERROR(invalid_ibaction_decl_async,none,
-      "@%0 instance methods cannot be async", (StringRef))
 ERROR(invalid_ibaction_result,none,
       "methods declared @%0 must %select{|not }1return a value", (StringRef, bool))
 ERROR(invalid_ibaction_argument_count,none,
@@ -1466,11 +1464,12 @@ ERROR(cdecl_empty_name,none,
       "@_cdecl symbol name cannot be empty", ())
 ERROR(cdecl_throws,none,
       "raising errors from @_cdecl functions is not supported", ())
-ERROR(cdecl_async,none,
-      "@_cdecl functions cannot be asynchronous", ())
 
 ERROR(attr_methods_only,none,
       "only methods can be declared %0", (DeclAttribute))
+ERROR(attr_decl_async,none,
+      "@%0 %1 cannot be asynchronous", (StringRef, DescriptiveDeclKind))
+
 ERROR(access_control_in_protocol,none,
       "%0 modifier cannot be used in protocols", (DeclAttribute))
 NOTE(access_control_in_protocol_detail,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1433,6 +1433,8 @@ ERROR(invalid_ibinspectable,none,
       "only instance properties can be declared @%0", (StringRef))
 ERROR(invalid_ibaction_decl,none,
       "only instance methods can be declared @%0", (StringRef))
+ERROR(invalid_ibaction_decl_async,none,
+      "@%0 instance methods cannot be async", (StringRef))
 ERROR(invalid_ibaction_result,none,
       "methods declared @%0 must %select{|not }1return a value", (StringRef, bool))
 ERROR(invalid_ibaction_argument_count,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1451,6 +1451,8 @@ NOTE(fixit_rename_in_swift,none,
      "change Swift name to %0", (DeclName))
 NOTE(fixit_rename_in_objc,none,
      "change Objective-C selector to %0", (ObjCSelector))
+NOTE(remove_async_add_task,none,
+     "remove 'async' and wrap in 'Task' to use concurrency in %0", (DeclName))
 ERROR(no_objc_tagged_pointer_not_class_protocol,none,
       "@unsafe_no_objc_tagged_pointer can only be applied to class protocols",
       ())

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -504,6 +504,9 @@ validateIBActionSignature(ASTContext &ctx, DeclAttribute *attr,
   if (FD->isAsyncContext()) {
     ctx.Diags.diagnose(FD->getAsyncLoc(), diag::attr_decl_async,
         attr->getAttrName(), FD->getDescriptiveKind());
+
+    ctx.Diags.diagnose(FD->getAsyncLoc(), diag::remove_async_add_task,
+                       FD->getName());
     valid = false;
   }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -475,6 +475,68 @@ void AttributeChecker::visitDynamicAttr(DynamicAttr *attr) {
     diagnoseAndRemoveAttr(attr, diag::dynamic_with_transparent);
 }
 
+/// Replaces asynchronous IBActionAttr/IBSegueActionAttr function declarations
+/// with a synchronous function. The body of the original function is moved
+/// inside of a task executed on the MainActor
+static void emitFixItIBActionRemoveAsync(ASTContext &ctx, const FuncDecl &FD) {
+  // If we don't have an async loc for some reason, things will explode
+  if (!FD.getAsyncLoc())
+    return;
+
+  std::string replacement = "";
+
+  // attributes, function name and everything up to `async` (exclusive)
+  replacement += CharSourceRange(ctx.SourceMgr,
+      FD.getSourceRangeIncludingAttrs().Start,
+      FD.getAsyncLoc()).str();
+
+  CharSourceRange returnType = Lexer::getCharSourceRangeFromSourceRange(ctx.SourceMgr,
+      FD.getResultTypeSourceRange());
+
+
+  // If we have a return type, include that here
+  if (returnType.isValid()) {
+    replacement += (llvm::Twine("-> ") + Lexer::getCharSourceRangeFromSourceRange(ctx.SourceMgr,
+          FD.getResultTypeSourceRange()).str()).str();
+  }
+
+
+  if (!FD.hasBody()) {
+    // If we don't have any body, the sourcelocs won't work and will result in
+    // crashes, so just swap out what we can
+
+    SourceLoc endLoc = returnType.isValid() ? returnType.getEnd() : FD.getAsyncLoc();
+    ctx.Diags.diagnose(FD.getAsyncLoc(), diag::remove_async_add_task,
+        FD.getName())
+      .fixItReplace(SourceRange(FD.getSourceRangeIncludingAttrs().Start, endLoc),
+          replacement);
+    return;
+  }
+
+  if (returnType.isValid())
+    replacement += " "; // insert space between type name and lbrace
+
+  replacement += "{\nTask { @MainActor in";
+
+  // If the body of the function is just "{}", there isn't anything to wrap.
+  // stepping over the braces to grab just the body will result in the `Start`
+  // location of the source range to come after the `End` of the range, and we
+  // will overflow. Dance around this by just appending the end of the fix to
+  // the replacement.
+  if (FD.getBody()->getLBraceLoc() != FD.getBody()->getRBraceLoc().getAdvancedLocOrInvalid(-1)) {
+    // We actually have a body, so add that to the string
+    CharSourceRange functionBody(ctx.SourceMgr,
+        FD.getBody()->getLBraceLoc().getAdvancedLocOrInvalid(1),
+        FD.getBody()->getRBraceLoc().getAdvancedLocOrInvalid(-1));
+    replacement += functionBody.str();
+  }
+  replacement += " }\n}";
+
+  ctx.Diags.diagnose(FD.getAsyncLoc(), diag::remove_async_add_task, FD.getName())
+    .fixItReplace(SourceRange(FD.getSourceRangeIncludingAttrs().Start,
+          FD.getBody()->getRBraceLoc()), replacement);
+}
+
 static bool
 validateIBActionSignature(ASTContext &ctx, DeclAttribute *attr,
                           const FuncDecl *FD, unsigned minParameters,
@@ -504,9 +566,7 @@ validateIBActionSignature(ASTContext &ctx, DeclAttribute *attr,
   if (FD->isAsyncContext()) {
     ctx.Diags.diagnose(FD->getAsyncLoc(), diag::attr_decl_async,
         attr->getAttrName(), FD->getDescriptiveKind());
-
-    ctx.Diags.diagnose(FD->getAsyncLoc(), diag::remove_async_add_task,
-                       FD->getName());
+    emitFixItIBActionRemoveAsync(ctx, *FD);
     valid = false;
   }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -486,30 +486,34 @@ static void emitFixItIBActionRemoveAsync(ASTContext &ctx, const FuncDecl &FD) {
   std::string replacement = "";
 
   // attributes, function name and everything up to `async` (exclusive)
-  replacement += CharSourceRange(ctx.SourceMgr,
-      FD.getSourceRangeIncludingAttrs().Start,
-      FD.getAsyncLoc()).str();
+  replacement +=
+      CharSourceRange(ctx.SourceMgr, FD.getSourceRangeIncludingAttrs().Start,
+                      FD.getAsyncLoc())
+          .str();
 
-  CharSourceRange returnType = Lexer::getCharSourceRangeFromSourceRange(ctx.SourceMgr,
-      FD.getResultTypeSourceRange());
-
+  CharSourceRange returnType = Lexer::getCharSourceRangeFromSourceRange(
+      ctx.SourceMgr, FD.getResultTypeSourceRange());
 
   // If we have a return type, include that here
   if (returnType.isValid()) {
-    replacement += (llvm::Twine("-> ") + Lexer::getCharSourceRangeFromSourceRange(ctx.SourceMgr,
-          FD.getResultTypeSourceRange()).str()).str();
+    replacement +=
+        (llvm::Twine("-> ") + Lexer::getCharSourceRangeFromSourceRange(
+                                  ctx.SourceMgr, FD.getResultTypeSourceRange())
+                                  .str())
+            .str();
   }
-
 
   if (!FD.hasBody()) {
     // If we don't have any body, the sourcelocs won't work and will result in
     // crashes, so just swap out what we can
 
-    SourceLoc endLoc = returnType.isValid() ? returnType.getEnd() : FD.getAsyncLoc();
-    ctx.Diags.diagnose(FD.getAsyncLoc(), diag::remove_async_add_task,
-        FD.getName())
-      .fixItReplace(SourceRange(FD.getSourceRangeIncludingAttrs().Start, endLoc),
-          replacement);
+    SourceLoc endLoc =
+        returnType.isValid() ? returnType.getEnd() : FD.getAsyncLoc();
+    ctx.Diags
+        .diagnose(FD.getAsyncLoc(), diag::remove_async_add_task, FD.getName())
+        .fixItReplace(
+            SourceRange(FD.getSourceRangeIncludingAttrs().Start, endLoc),
+            replacement);
     return;
   }
 
@@ -523,18 +527,21 @@ static void emitFixItIBActionRemoveAsync(ASTContext &ctx, const FuncDecl &FD) {
   // location of the source range to come after the `End` of the range, and we
   // will overflow. Dance around this by just appending the end of the fix to
   // the replacement.
-  if (FD.getBody()->getLBraceLoc() != FD.getBody()->getRBraceLoc().getAdvancedLocOrInvalid(-1)) {
+  if (FD.getBody()->getLBraceLoc() !=
+      FD.getBody()->getRBraceLoc().getAdvancedLocOrInvalid(-1)) {
     // We actually have a body, so add that to the string
-    CharSourceRange functionBody(ctx.SourceMgr,
-        FD.getBody()->getLBraceLoc().getAdvancedLocOrInvalid(1),
+    CharSourceRange functionBody(
+        ctx.SourceMgr, FD.getBody()->getLBraceLoc().getAdvancedLocOrInvalid(1),
         FD.getBody()->getRBraceLoc().getAdvancedLocOrInvalid(-1));
     replacement += functionBody.str();
   }
   replacement += " }\n}";
 
-  ctx.Diags.diagnose(FD.getAsyncLoc(), diag::remove_async_add_task, FD.getName())
-    .fixItReplace(SourceRange(FD.getSourceRangeIncludingAttrs().Start,
-          FD.getBody()->getRBraceLoc()), replacement);
+  ctx.Diags
+      .diagnose(FD.getAsyncLoc(), diag::remove_async_add_task, FD.getName())
+      .fixItReplace(SourceRange(FD.getSourceRangeIncludingAttrs().Start,
+                                FD.getBody()->getRBraceLoc()),
+                    replacement);
 }
 
 static bool
@@ -565,7 +572,7 @@ validateIBActionSignature(ASTContext &ctx, DeclAttribute *attr,
 
   if (FD->isAsyncContext()) {
     ctx.Diags.diagnose(FD->getAsyncLoc(), diag::attr_decl_async,
-        attr->getAttrName(), FD->getDescriptiveKind());
+                       attr->getAttrName(), FD->getDescriptiveKind());
     emitFixItIBActionRemoveAsync(ctx, *FD);
     valid = false;
   }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -530,6 +530,12 @@ void AttributeChecker::visitIBActionAttr(IBActionAttr *attr) {
     return;
   }
 
+  if (FD->isAsyncContext()) {
+    diagnoseAndRemoveAttr(attr, diag::invalid_ibaction_decl_async,
+                          attr->getAttrName());
+    return;
+  }
+
   if (isRelaxedIBAction(Ctx))
     // iOS, tvOS, and watchOS allow 0-2 parameters to an @IBAction method.
     validateIBActionSignature(Ctx, attr, FD, /*minParams=*/0, /*maxParams=*/2);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -501,6 +501,12 @@ validateIBActionSignature(ASTContext &ctx, DeclAttribute *attr,
     valid = false;
   }
 
+  if (FD->isAsyncContext()) {
+    ctx.Diags.diagnose(FD->getAsyncLoc(), diag::attr_decl_async,
+        attr->getAttrName(), FD->getDescriptiveKind());
+    valid = false;
+  }
+
   // We don't need to check here that parameter or return types are
   // ObjC-representable; IsObjCRequest will validate that.
 
@@ -526,12 +532,6 @@ void AttributeChecker::visitIBActionAttr(IBActionAttr *attr) {
   const FuncDecl *FD = cast<FuncDecl>(D);
   if (!FD->isPotentialIBActionTarget()) {
     diagnoseAndRemoveAttr(attr, diag::invalid_ibaction_decl,
-                          attr->getAttrName());
-    return;
-  }
-
-  if (FD->isAsyncContext()) {
-    diagnoseAndRemoveAttr(attr, diag::invalid_ibaction_decl_async,
                           attr->getAttrName());
     return;
   }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2972,10 +2972,9 @@ public:
       if (isRepresentableInObjC(FD, reason, asyncConvention, errorConvention)) {
         if (FD->hasAsync()) {
           FD->setForeignAsyncConvention(*asyncConvention);
-          getASTContext().Diags.diagnose(CDeclAttr->getLocation(),
-                                         diag::attr_decl_async,
-                                         CDeclAttr->getAttrName(),
-                                         FD->getDescriptiveKind());
+          getASTContext().Diags.diagnose(
+              CDeclAttr->getLocation(), diag::attr_decl_async,
+              CDeclAttr->getAttrName(), FD->getDescriptiveKind());
         } else if (FD->hasThrows()) {
           FD->setForeignErrorConvention(*errorConvention);
           getASTContext().Diags.diagnose(CDeclAttr->getLocation(),

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2973,7 +2973,9 @@ public:
         if (FD->hasAsync()) {
           FD->setForeignAsyncConvention(*asyncConvention);
           getASTContext().Diags.diagnose(CDeclAttr->getLocation(),
-                                         diag::cdecl_async);
+                                         diag::attr_decl_async,
+                                         CDeclAttr->getAttrName(),
+                                         FD->getDescriptiveKind());
         } else if (FD->hasThrows()) {
           FD->setForeignErrorConvention(*errorConvention);
           getASTContext().Diags.diagnose(CDeclAttr->getLocation(),

--- a/test/attr/attr_cdecl_async.swift
+++ b/test/attr/attr_cdecl_async.swift
@@ -2,6 +2,6 @@
 
 // REQUIRES: concurrency
 
-@_cdecl("async") // expected-error{{@_cdecl functions cannot be asynchronous}}
+@_cdecl("async") // expected-error{{@_cdecl global function cannot be asynchronous}}
 func asynchronous() async { }
 

--- a/test/attr/attr_ibaction.swift
+++ b/test/attr/attr_ibaction.swift
@@ -43,7 +43,7 @@ class IBActionWrapperTy {
   func evenMoreMagic(_: AnyObject) -> () {} // no-warning
 
   @available(macOS 10.15, *)
-  @IBAction // expected-error {{@IBAction instance methods cannot be async}}
+  @IBAction // expected-error@+1 {{@IBAction instance method cannot be async}}
   func asyncIBAction(_: AnyObject) async -> () {}
 }
 

--- a/test/attr/attr_ibaction.swift
+++ b/test/attr/attr_ibaction.swift
@@ -41,6 +41,10 @@ class IBActionWrapperTy {
   func moreMagic(_: AnyObject) -> () {} // no-warning
   @objc @IBAction
   func evenMoreMagic(_: AnyObject) -> () {} // no-warning
+
+  @available(macOS 10.15, *)
+  @IBAction // expected-error {{@IBAction instance methods cannot be async}}
+  func asyncIBAction(_: AnyObject) async -> () {}
 }
 
 struct S { }

--- a/test/attr/attr_ibaction.swift
+++ b/test/attr/attr_ibaction.swift
@@ -43,8 +43,11 @@ class IBActionWrapperTy {
   func evenMoreMagic(_: AnyObject) -> () {} // no-warning
 
   @available(macOS 10.15, *)
-  @IBAction // expected-error@+1 {{@IBAction instance method cannot be async}}
+  @IBAction
   func asyncIBAction(_: AnyObject) async -> () {}
+  // expected-error@-1 {{@IBAction instance method cannot be async}}
+  // expected-note@-2 {{remove 'async' and wrap in 'Task' to use concurrency in 'asyncIBAction'}}
+
 }
 
 struct S { }

--- a/test/attr/attr_ibaction.swift
+++ b/test/attr/attr_ibaction.swift
@@ -42,11 +42,24 @@ class IBActionWrapperTy {
   @objc @IBAction
   func evenMoreMagic(_: AnyObject) -> () {} // no-warning
 
-  @available(macOS 10.15, *)
+  @available(SwiftStdlib 5.5, *)
   @IBAction
-  func asyncIBAction(_: AnyObject) async -> () {}
+  func asyncIBActionNoSpace(_: AnyObject) async -> () {}
   // expected-error@-1 {{@IBAction instance method cannot be async}}
-  // expected-note@-2 {{remove 'async' and wrap in 'Task' to use concurrency in 'asyncIBAction'}}
+  // expected-note@-2 {{remove 'async' and wrap in 'Task' to use concurrency in 'asyncIBActionNoSpace'}}{{45:3-47:57=@available(SwiftStdlib 5.5, *)\n  @IBAction\n  func asyncIBActionNoSpace(_: AnyObject) -> () {\nTask { @MainActor in \}\n\}}}
+
+  @available(SwiftStdlib 5.5, *)
+  @IBAction
+  func asyncIBActionWithFullBody(_: AnyObject) async {
+      print("Hello World")
+  }
+  // expected-error@-3 {{@IBAction instance method cannot be async}}
+  // expected-note@-4 {{remove 'async' and wrap in 'Task' to use concurrency in 'asyncIBActionWithFullBody'}}{{51:3-55:4=@available(SwiftStdlib 5.5, *)\n  @IBAction\n  func asyncIBActionWithFullBody(_: AnyObject) {\nTask { @MainActor in\n      print("Hello World")\n  \}\n\}}}
+
+  @available(SwiftStdlib 5.5, *) @IBAction func asyncIBActionNoBody(_: AnyObject) async
+  // expected-error@-1 {{expected '{' in body of function declaration}}
+  // expected-error@-2 {{@IBAction instance method cannot be asynchronous}}
+  // expected-note@-3 {{remove 'async' and wrap in 'Task' to use concurrency in 'asyncIBActionNoBody}}{{3-88=@available(SwiftStdlib 5.5, *) @IBAction func asyncIBActionNoBody(_: AnyObject)}}
 
 }
 

--- a/test/attr/attr_ibsegueaction.swift
+++ b/test/attr/attr_ibsegueaction.swift
@@ -45,6 +45,11 @@ class IBActionWrapperTy {
   func moreMagic(_: AnyObject, _: AnyObject, _: AnyObject) -> AnyObject {} // no-warning
   @objc @IBSegueAction
   func evenMoreMagic(_: AnyObject, _: AnyObject, _: AnyObject) -> AnyObject {} // no-warning
+
+  @available(SwiftStdlib 5.5, *) @IBSegueAction
+  func process(_: AnyObject, _: AnyObject, _: AnyObject) async -> AnyObject { }
+  // expected-error@-1 {{@IBSegueAction instance method cannot be asynchronous}}
+  // expected-note@-2 {{remove 'async' and wrap in 'Task' to use concurrency in 'process'}}{{49:3-50:80=@available(SwiftStdlib 5.5, *) @IBSegueAction\n  func process(_: AnyObject, _: AnyObject, _: AnyObject) -> AnyObject {\nTask { @MainActor in \}\n\}}}
 }
 
 struct S { }


### PR DESCRIPTION
The IBAction signature does not allow completion handlers, so making
IBAction methods async doesn't make sense. Disallowing it statically so
it doesn't just break people when they try.

Resolves: rdar://83259194