### PR TITLE
[cxx interoperability] Turn off non subscript templated operators

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -78,7 +78,6 @@
 #include <algorithm>
 #include <string>
 #include <memory>
-#include <string>
 
 using namespace swift;
 using namespace importer;

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2577,17 +2577,6 @@ namespace {
       if (!dc)
         return nullptr;
 
-      bool isOperator = decl->getDeclName().getNameKind() ==
-                        clang::DeclarationName::CXXOperatorName;
-      bool isNonSubscriptOperator =
-          isOperator && (decl->getDeclName().getCXXOverloadedOperator() !=
-                         clang::OO_Subscript);
-
-      // For now, we don't support non-subscript operators which are templated
-      if (isNonSubscriptOperator && decl->isTemplated()) {
-        return nullptr;
-      }
-
       auto aliasedDecl =
           Impl.importDecl(decl->getAliasedNamespace(), getActiveSwiftVersion());
       if (!aliasedDecl)
@@ -4163,6 +4152,17 @@ namespace {
           Impl.importDeclContextOf(decl, importedName.getEffectiveContext());
       if (!dc)
         return nullptr;
+
+      bool isOperator = decl->getDeclName().getNameKind() ==
+                        clang::DeclarationName::CXXOperatorName;
+      bool isNonSubscriptOperator =
+          isOperator && (decl->getDeclName().getCXXOverloadedOperator() !=
+                         clang::OO_Subscript);
+
+      // For now, we don't support non-subscript operators which are templated
+      if (isNonSubscriptOperator && decl->isTemplated()) {
+        return nullptr;
+      }
 
       // Handle cases where 2 CXX methods differ strictly in "constness"
       // In such a case append a suffix ("Mutating") to the mutable version

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2577,6 +2577,17 @@ namespace {
       if (!dc)
         return nullptr;
 
+      bool isOperator = decl->getDeclName().getNameKind() ==
+                        clang::DeclarationName::CXXOperatorName;
+      bool isNonSubscriptOperator =
+          isOperator && (decl->getDeclName().getCXXOverloadedOperator() !=
+                         clang::OO_Subscript);
+
+      // For now, we don't support non-subscript operators which are templated
+      if (isNonSubscriptOperator && decl->isTemplated()) {
+        return nullptr;
+      }
+
       auto aliasedDecl =
           Impl.importDecl(decl->getAliasedNamespace(), getActiveSwiftVersion());
       if (!aliasedDecl)

--- a/test/Interop/Cxx/operators/Inputs/member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/member-inline.h
@@ -186,11 +186,24 @@ template<class T> struct TemplatedArrayByVal {
   T ts[];
   T operator[](int i) { return ts[i]; }
 };
+
 typedef TemplatedArrayByVal<double> TemplatedDoubleArrayByVal;
 
-struct TemplatedSubscriptArrayByVal {
+template <class T>
+struct TemplatedByVal {
+  T val;
+  TemplatedByVal<T> operator+(TemplatedByVal other) {
+    return TemplatedByVal{.val = val + other.val};
+  }
+};
+
+struct TemplatedOperatorArrayByVal {
   int *ptr;
   template<class T> T operator[](T i) { return ptr[i]; }
+  template <class T>
+  T *operator+(T i) {
+    return ptr + i;
+  }
 };
 
 struct NonTrivial {

--- a/test/Interop/Cxx/operators/member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/member-inline-module-interface.swift
@@ -133,11 +133,14 @@
 // CHECK: }
 // CHECK: typealias TemplatedDoubleArrayByVal = __CxxTemplateInst19TemplatedArrayByValIdE
 
+// CHECK: struct TemplatedByVal<T> {
+// CHECK-NEXT: }
 
-// CHECK: struct TemplatedSubscriptArrayByVal {
+// CHECK: struct TemplatedOperatorArrayByVal {
 // CHECK:   subscript(i: T) -> T { mutating get }
 // CHECK:   @available(*, unavailable, message: "use subscript")
 // CHECK:   mutating func __operatorSubscriptConst<T>(_ i: T) -> T
+// CHECK-NOT: mutating func __operatorPlus<T>(_ i: T) -> UnsafeMutablePointer<T>
 // CHECK: }
 
 // CHECK: struct NonTrivialArrayByVal {


### PR DESCRIPTION
We've updated how CXX operators get imported into swift. We don't currently support templated operators aside from the subscript operator.