### PR TITLE
[lit] Support executable and non-executable tests with C++ Interop

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -709,6 +709,8 @@ elif swift_test_mode == 'only_executable':
 elif swift_test_mode == 'only_non_executable':
     config.available_features.add("nonexecutable_test")
 elif swift_test_mode == 'with_cxx_interop':
+    config.available_features.add("nonexecutable_test")
+    config.available_features.add("executable_test")
     config.available_features.add("with_cxx_interop")
     config.swift_frontend_test_options += ' -enable-experimental-cxx-interop'
     config.swift_driver_test_options += ' -Xfrontend -enable-experimental-cxx-interop'


### PR DESCRIPTION
In #59120 I did not realize that I was filtering tests that required
executable or non-executable features, so many tests were being skipped.

This change should recover both sets of tests and it allows us to test
C++ interop in a lot more cases.

Sadly this raises the number of failing tests with C++ interop to 425.

