### PR TITLE
[Interop] [SwiftToCxx] New Throw Error Test 

### DIFF
--- a/test/Interop/SwiftToCxx/functions/swift-functions-errors-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/swift-functions-errors-execution.cpp
@@ -1,0 +1,27 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %S/swift-functions-errors.swift -typecheck -module-name Functions -clang-header-expose-public-decls -emit-clang-header-path %t/functions.h
+
+// RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-functions-errors-execution.o
+// RUN: %target-interop-build-swift %S/swift-functions-errors.swift -o %t/swift-functions-errors-execution -Xlinker %t/swift-functions-errors-execution.o -module-name Functions -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+
+// RUN: %target-codesign %t/swift-functions-errors-execution
+// RUN: %target-run %t/swift-functions-errors-execution | %FileCheck %s
+
+// REQUIRES: executable_test
+// XFAIL: *
+
+#include <cassert>
+#include "functions.h"
+
+int main() {
+  static_assert(!noexcept(Functions::emptyThrowFunction()), "noexcept function");
+  static_assert(!noexcept(Functions::throwFunction()), "noexcept function");
+
+  Functions::emptyThrowFunction();
+  Functions::throwFunction();
+  return 0;
+}
+
+// CHECK: passEmptyThrowFunction
+// CHECK-NEXT: passThrowFunction

--- a/test/Interop/SwiftToCxx/functions/swift-functions-errors.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-functions-errors.swift
@@ -1,0 +1,36 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -module-name Functions -clang-header-expose-public-decls -emit-clang-header-path %t/functions.h
+// RUN: %FileCheck %s < %t/functions.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/functions.h)
+
+// CHECK-LABEL: namespace Functions {
+
+// CHECK-LABEL: namespace _impl {
+
+// CHECK: SWIFT_EXTERN void $s9Functions18emptyThrowFunctionyyKF(void) SWIFT_CALL; // emptyThrowFunction()
+// CHECK: SWIFT_EXTERN void $s9Functions13throwFunctionyyKF(void) SWIFT_CALL; // throwFunction()
+
+// CHECK: }
+
+//XFAIL: *
+
+enum NaiveErrors: Error {
+    case returnError
+    case throwError
+}
+
+public func emptyThrowFunction() throws { print("passEmptyThrowFunction") }
+
+// CHECK: inline void emptyThrowFunction() {
+// CHECK: return _impl::$s9Functions18emptyThrowFunctionyyKF();
+// CHECK: }
+
+public func throwFunction() throws {
+    print("passThrowFunction")
+    throw NaiveErrors.throwError
+}
+
+// CHECK: inline void throwFunction() {
+// CHECK: return _impl::$s9Functions13throwFunctionyyKF();
+// CHECK: }


### PR DESCRIPTION
This PR aims to introduce the known issue of Swift functions that thrown don't be translated as such when creating the bridge header file. 

## Given this simple function:
```Swift
public func emptyThrowFunction() throws { print("passEmptyThrowFunction") }
```

### The Expected Signature of `emptyThrowFunction()`:
```c++
SWIFT_EXTERN void $s9Functions18emptyThrowFunctionyyKF(void) SWIFT_CALL; // emptyThrowFunction()
...
inline void emptyThrowFunction() {
    return _impl::$s9Functions18emptyThrowFunctionyyKF();
 }
```

### The Current Signature of `emptyThrowFunction()`:
```C++
SWIFT_EXTERN void $s9Functions18emptyThrowFunctionyyKF(void) SWIFT_NOEXCEPT SWIFT_CALL; // emptyThrowFunction()
...
inline void emptyThrowFunction() noexcept {
  return _impl::$s9Functions18emptyThrowFunctionyyKF();
}
```

This test is marked as `XFAIL: *` since it will fail in any context due to the hardcoded attributes `SWIFT_NOEXCEPT` and `noexcept` on the Swift Compiler.
