### PR TITLE
SILGen: Emit calls to default argument generators at the right abstraction level [5.7]

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3436,8 +3436,7 @@ void DelayedArgument::emitDefaultArgument(SILGenFunction &SGF,
   auto value = SGF.emitApplyOfDefaultArgGenerator(info.loc,
                                                   info.defaultArgsOwner,
                                                   info.destIndex,
-                                                  info.resultType,
-                                                  info.origResultType);
+                                                  info.resultType);
 
   SmallVector<ManagedValue, 4> loweredArgs;
   SmallVector<DelayedArgument, 4> delayedArgs;

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2337,11 +2337,10 @@ RValue RValueEmitter::visitTupleElementExpr(TupleElementExpr *E,
 
 RValue
 SILGenFunction::emitApplyOfDefaultArgGenerator(SILLocation loc,
-                                             ConcreteDeclRef defaultArgsOwner,
-                                             unsigned destIndex,
-                                             CanType resultType,
-                                             AbstractionPattern origResultType,
-                                             SGFContext C) {
+                                               ConcreteDeclRef defaultArgsOwner,
+                                               unsigned destIndex,
+                                               CanType resultType,
+                                               SGFContext C) {
   SILDeclRef generator 
     = SILDeclRef::getDefaultArgGenerator(defaultArgsOwner.getDecl(),
                                          destIndex);
@@ -2352,6 +2351,11 @@ SILGenFunction::emitApplyOfDefaultArgGenerator(SILLocation loc,
   SubstitutionMap subs;
   if (fnType->isPolymorphic())
     subs = defaultArgsOwner.getSubstitutions();
+
+  auto constantInfo = SGM.Types.getConstantInfo(
+      TypeExpansionContext::minimal(), generator);
+  AbstractionPattern origResultType =
+      constantInfo.FormalPattern.getFunctionResultType();
 
   auto substFnType =
       fnType->substGenericArgs(SGM.M, subs, getTypeExpansionContext());

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1678,7 +1678,6 @@ public:
                                         ConcreteDeclRef defaultArgsOwner,
                                         unsigned destIndex,
                                         CanType resultType,
-                                        AbstractionPattern origResultType,
                                         SGFContext C = SGFContext());
 
   RValue emitApplyOfStoredPropertyInitializer(

--- a/test/SILGen/default_arguments_concrete.swift
+++ b/test/SILGen/default_arguments_concrete.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-emit-silgen %s
+
+func calleeWithEmptyTuple<A>(_: A = ()) {}
+func calleeWithLoadable<A>(_: A = 3) {}
+func calleeWithAddressOnly<A>(_: A = (3 as Any)) {}
+func calleeWithTupleOfLoadable<A>(_: A = (3, 4)) {}
+func calleeWithTupleOfAddressOnly<A>(_: A = (3 as Any, 4 as Any)) {}
+func calleeWithTupleOfMixed<A>(_: A = (3, 4 as Any)) {}
+
+func testConcreteDefaultArguments() {
+  calleeWithEmptyTuple()
+  calleeWithLoadable()
+  calleeWithAddressOnly()
+  calleeWithTupleOfLoadable()
+  calleeWithTupleOfAddressOnly()
+  calleeWithTupleOfMixed()
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/59218.

Fixes rdar://problem/90717725 / https://bugs.swift.org/browse/SR-16051.