### PR TITLE
[Threading] Use raw gettid syscall for older glibc compatibility

### DIFF
--- a/include/swift/Threading/Impl/Linux/ulock.h
+++ b/include/swift/Threading/Impl/Linux/ulock.h
@@ -46,7 +46,7 @@ typedef std::int32_t ulock_t;
 inline int ulock_get_tid(void) {
   static __thread int tid;
   if (tid == 0)
-    tid = gettid();
+    tid = syscall(SYS_gettid);
   return tid;
 }
 


### PR DESCRIPTION
`gettid` wrapper was added in glibc 2.30, and Ubuntu 18.04 uses glibc 2.27, so use raw syscall instead of it.

This fixes Ubuntu 18.04 build failure: https://ci.swift.org/job/oss-swift-package-ubuntu-18_04/552/
