### PR TITLE
Disable validation-test/stdlib/UnicodeScalarProperties.swift because it started failing in CI

### DIFF
--- a/validation-test/stdlib/UnicodeScalarProperties.swift
+++ b/validation-test/stdlib/UnicodeScalarProperties.swift
@@ -3,6 +3,7 @@
 // REQUIRES: long_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: objc_interop
+// REQUIRES: rdar94270193
 
 import StdlibUnittest
 import StdlibUnicodeUnittest


### PR DESCRIPTION
https://github.com/apple/swift/pull/59201 updated the test case and caused it to fail. Disable the test case to investigate.

rdar://94270193