### PR TITLE
Tests: XFAIL test/stdlib/StringCreate.swift

### DIFF
--- a/test/stdlib/StringCreate.swift
+++ b/test/stdlib/StringCreate.swift
@@ -1,6 +1,10 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
+// rdar://91405760
+// XFAIL: use_os_stdlib
+// XFAIL: back_deployment_runtime
+
 import StdlibUnittest
 defer { runAllTests() }
 


### PR DESCRIPTION
XFAIL test/stdlib/StringCreate.swift on the back deployment bots until the failures there can be investigated further.