### PR TITLE
Reenable UnicodeScalarProperties test

### DIFF
--- a/validation-test/stdlib/UnicodeScalarProperties.swift
+++ b/validation-test/stdlib/UnicodeScalarProperties.swift
@@ -3,7 +3,6 @@
 // REQUIRES: long_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: objc_interop
-// REQUIRES: rdar94270193
 
 @_spi(_Unicode)
 import Swift


### PR DESCRIPTION
This test was disabled here: https://github.com/apple/swift/pull/59222 in 5.7 but should be passing now that https://github.com/apple/swift/pull/59212 was merged.