### PR TITLE
AST: Fix debug info mangling of opaque result types with @_originallyDefinedIn

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -633,6 +633,7 @@ std::string ASTMangler::mangleTypeForDebugger(Type Ty, GenericSignature sig) {
                                         "mangling type for debugger", Ty);
 
   DWARFMangling = true;
+  RespectOriginallyDefinedIn = false;
   OptimizeProtocolNames = false;
   beginMangling();
 
@@ -651,6 +652,7 @@ std::string ASTMangler::mangleTypeForTypeName(Type type) {
 
 std::string ASTMangler::mangleDeclType(const ValueDecl *decl) {
   DWARFMangling = true;
+  RespectOriginallyDefinedIn = false;
   beginMangling();
   
   appendDeclType(decl);
@@ -742,6 +744,7 @@ std::string ASTMangler::mangleTypeAsContextUSR(const NominalTypeDecl *type) {
 
 std::string ASTMangler::mangleTypeAsUSR(Type Ty) {
   DWARFMangling = true;
+  RespectOriginallyDefinedIn = false;
   beginMangling();
 
   Ty = getTypeForDWARFMangling(Ty);
@@ -758,6 +761,7 @@ std::string ASTMangler::mangleTypeAsUSR(Type Ty) {
 
 std::string ASTMangler::mangleAnyDecl(const ValueDecl *Decl, bool prefix) {
   DWARFMangling = true;
+  RespectOriginallyDefinedIn = false;
   if (prefix) {
     beginMangling();
   } else {
@@ -1032,6 +1036,14 @@ void ASTMangler::appendOpaqueDeclName(const OpaqueTypeDecl *opaqueDecl) {
   if (canSymbolicReference(opaqueDecl)) {
     appendSymbolicReference(opaqueDecl);
   } else if (auto namingDecl = opaqueDecl->getNamingDecl()) {
+    // Set this to true temporarily, even if we're doing DWARF
+    // mangling for debug info, where it is false. Otherwise,
+    // the mangled opaque result type name will not be able to
+    // be looked up, since we rely on an exact match with the
+    // ABI name.
+    llvm::SaveAndRestore<bool> savedRespectOriginallyDefinedIn(
+        RespectOriginallyDefinedIn, true);
+
     appendEntity(namingDecl);
     appendOperator("QO");
   } else {
@@ -2269,10 +2281,11 @@ void ASTMangler::appendModule(const ModuleDecl *module,
   // Use the module real name in mangling; this is the physical name
   // of the module on-disk, which can be different if -module-alias is
   // used.
+  //
   // For example, if a module Foo has 'import Bar', and '-module-alias Bar=Baz'
   // was passed, the name 'Baz' will be used for mangling besides loading.
   StringRef ModName = module->getRealName().str();
-  if (!DWARFMangling &&
+  if (RespectOriginallyDefinedIn &&
       module->getABIName() != module->getName()) { // check if the ABI name is set
     ModName = module->getABIName().str();
   }
@@ -2281,7 +2294,7 @@ void ASTMangler::appendModule(const ModuleDecl *module,
   if (ModName == STDLIB_NAME) {
     if (useModuleName.empty()) {
       appendOperator("s");
-    } else if (DWARFMangling) {
+    } else if (!RespectOriginallyDefinedIn) {
       appendOperator("s");
     } else {
       appendIdentifier(useModuleName);
@@ -2298,11 +2311,11 @@ void ASTMangler::appendModule(const ModuleDecl *module,
     return appendOperator("SC");
   }
 
-  // Enabling DWARFMangling indicate the mangled names are not part of the ABI,
-  // probably used by the debugger or IDE (USR). These mangled names will not be
-  // demangled successfully if we use the original module name instead of the
-  // actual module name.
-  if (!useModuleName.empty() && !DWARFMangling)
+  // Disabling RespectOriginallyDefinedIn indicate the mangled names are not part
+  // of the ABI, probably used by the debugger or IDE (USR). These mangled names
+  // will not be demangled successfully if we use the original module name instead
+  // of the actual module name.
+  if (!useModuleName.empty() && RespectOriginallyDefinedIn)
     appendIdentifier(useModuleName);
   else
     appendIdentifier(ModName);

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -163,7 +163,7 @@ bool SILType::isNoReturnFunction(SILModule &M,
 }
 
 std::string SILType::getMangledName() const {
-  Mangle::ASTMangler mangler(false/*use dwarf mangling*/);
+  Mangle::ASTMangler mangler;
   return mangler.mangleTypeWithoutPrefix(getASTType());
 }
 

--- a/test/ModuleInterface/originally-defined-attr-opaque-result.swift
+++ b/test/ModuleInterface/originally-defined-attr-opaque-result.swift
@@ -5,6 +5,9 @@
 // RUN: %target-swift-emit-module-interface(%t/CoreChef.swiftinterface) %s -module-name CoreChef -I %t -disable-availability-checking -DLIB
 // RUN: %target-swift-typecheck-module-from-interface(%t/CoreChef.swiftinterface) -module-name CoreChef -I %t -disable-availability-checking
 
+// Also build the module itself with -g to exercise debug info round tripping.
+// RUN: %target-swift-frontend -emit-ir -g %s -I %t -disable-availability-checking
+
 // RUN: %FileCheck %s < %t/CoreChef.swiftinterface
 
 // REQUIRES: OS=macosx


### PR DESCRIPTION
If a function's parameter or return types involve nominal types that
have been moved across modules using @_originallyDefinedIn, we must
take care to always mangle the opaque result type's name using the
original module names and not the current module names.

This was a problem with DWARF mangling, which normally disables
@_originallyDefinedIn for other purposes. Make sure to always
temporarily re-enable it when mangling an opaque result type.

Fixes rdar://problem/93822207.