### PR TITLE
Allow unavailable conformances to non-Sendable protocols during contraction

### DIFF
--- a/test/Generics/superclass_constraint.swift
+++ b/test/Generics/superclass_constraint.swift
@@ -230,5 +230,7 @@ extension Animal: Pony { }
 
 public struct AnimalWrapper<Friend: Animal> { }
 
-// CHECK: Generic signature: <Friend where Friend : Animal, Friend : Pony>
+// FIXME: Generic signature: <Friend where Friend : Animal, Friend : Pony>
+// Generic signature: <Friend where Friend : Animal>
 extension AnimalWrapper: Pony where Friend: Pony { }
+// expected-warning@-1{{redundant conformance constraint 'Animal' : 'Pony'}}

--- a/test/decl/protocol/unavailable.swift
+++ b/test/decl/protocol/unavailable.swift
@@ -1,0 +1,17 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P { }
+
+struct X { }
+
+@available(*, unavailable)
+extension X: P { }
+
+struct Y<T: P> { }
+
+@available(*, unavailable)
+extension Y {
+  // Okay, because the unavailable conformance is used within an
+  // unavailable context.
+  init() where T == X { }
+}


### PR DESCRIPTION
Refusing to acknowledge unavailable conformances at this point in the
requirement machine doesn't allow us to make use of unavailable
conformances from unavailable contexts, something which code currently
depends on. Limit the new filtering behavior to `Sendable` conformances
where we need them, as a narrow fix for this regression. We'll revisit
the approach here later.

Fixes rdar://94154905.
