### PR TITLE
[5.7][ASTPrinter] Simplify archetype printing by visiting the interface type.

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -6240,6 +6240,12 @@ bool TypeBase::hasSimpleTypeRepr() const {
   case TypeKind::OpenedArchetype:
     return false;
 
+  case TypeKind::PrimaryArchetype: {
+    auto archetype = cast<const PrimaryArchetypeType>(this);
+    auto interface = archetype->getInterfaceType();
+    return interface->hasSimpleTypeRepr();
+  }
+
   case TypeKind::ProtocolComposition: {
     // 'Any', 'AnyObject' and single protocol compositions are simple
     auto composition = cast<const ProtocolCompositionType>(this);

--- a/test/Generics/opaque_archetype_concrete_requirement.swift
+++ b/test/Generics/opaque_archetype_concrete_requirement.swift
@@ -30,7 +30,7 @@ struct DefinesOpaqueP1 : P {
 struct ConcreteHasP<T : P1, TT : P2, TU> {}
 
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=ConcreteHasP
-// CHECK-NEXT: Generic signature: <T, TT, TU where T == some P1, TT == (some P1).T, TU == (some P1).U>
+// CHECK-NEXT: Generic signature: <T, TT, TU where T == some P1, TT == (some P1).[P1]T, TU == (some P1).[P1]U>
 extension ConcreteHasP where T == DefinesOpaqueP1.T, TT == T.T, TU == T.U {
   func checkSameType1(_ t: TT) -> DefinesOpaqueP1.T.T { return t }
   func checkSameType2(_ u: TU) -> DefinesOpaqueP1.T.U { return u }
@@ -47,7 +47,7 @@ protocol HasP {
 }
 
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=HasP
-// CHECK-NEXT: Generic signature: <Self where Self : HasP, Self.[HasP]T == some P1, Self.[HasP]U == G<(some P1).T>>
+// CHECK-NEXT: Generic signature: <Self where Self : HasP, Self.[HasP]T == some P1, Self.[HasP]U == G<(some P1).[P1]T>>
 extension HasP where T == DefinesOpaqueP1.T, U == G<T.T> {
   func checkSameType1(_ t: T.T) -> DefinesOpaqueP1.T.T { return t }
   func checkSameType2(_ u: T.U) -> DefinesOpaqueP1.T.U { return u }

--- a/test/type/opaque_parameters.swift
+++ b/test/type/opaque_parameters.swift
@@ -6,6 +6,7 @@ protocol Q {
   associatedtype A: P & Equatable
 
   func f() -> A
+  func takesA(_: A)
 }
 
 extension Int: P { }
@@ -16,17 +17,24 @@ extension Array: Q where Element: P, Element: Equatable {
   func f() -> Element {
     return first!
   }
+
+  func takesA(_: Element) {}
 }
 
 extension Set: Q where Element: P, Element: Equatable { // expected-warning {{redundant conformance constraint 'Element' : 'Equatable'}}
   func f() -> Element {
     return first!
   }
+
+  func takesA(_: Element) {}
 }
 
 // expected-note@+2{{where 'some Q' = 'Int'}}
 // expected-note@+1{{in call to function 'takesQ'}}
 func takesQ(_ q: some Q) -> Bool {
+  // expected-error@+1 {{cannot convert value of type 'Int' to expected argument type '(some Q).A'}}
+  q.takesA(1)
+
   return q.f() == q.f()
 }
 


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/59233

* **Explanation**: This change simplifies the archetype printing code by visiting the interface type, and fixes an issue where `<<anonymous>>` was printed in diagnostics for opaque parameter types.
* **Scope**: The only change in behavior is for primary archetypes whose interface type is declared with `some`.
* **Risk**: Low.
* **Testing**: Added new tests that previously printed `<<anonymous>>` in the error message.
* **Reviewer**: @slavapestov

Resolves: rdar://91959195