### PR TITLE
[5.7][CodeCompletion] Don't suggest initializers on 'AnyObject'

### DIFF
--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -1565,6 +1565,11 @@ void CompletionLookup::addConstructorCallsForType(
   if (!Sink.addInitsToTopLevel)
     return;
 
+  // 'AnyObject' is not initializable.
+  // FIXME: Should we do this in 'AnyObjectLookupRequest'?
+  if (type->isAnyObject())
+    return;
+
   assert(CurrDeclContext);
 
   auto results =

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -365,6 +365,10 @@ static void collectPossibleCalleesByQualifiedLookup(
   if (!baseInstanceTy->mayHaveMembers())
     return;
 
+  // 'AnyObject' is not initializable.
+  if (baseInstanceTy->isAnyObject() && name == DeclNameRef::createConstructor())
+    return;
+
   // Make sure we've resolved implicit members.
   namelookup::installSemanticMembersIfNeeded(baseInstanceTy, name);
 

--- a/test/IDE/complete_dynamic_lookup.swift
+++ b/test/IDE/complete_dynamic_lookup.swift
@@ -56,6 +56,9 @@
 // RUN: %FileCheck %s -check-prefix=DL_CLASS_DOT < %t.dl.txt
 // RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.dl.txt
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -I %t -disable-objc-attr-requires-foundation-module -code-completion-token=INITIALIZE_PAREN | %FileCheck %s -check-prefix=INITIALIZE_PAREN
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -I %t -disable-objc-attr-requires-foundation-module -code-completion-token=GLOBAL_WITHINIT -code-complete-inits-in-postfix-expr | %FileCheck %s -check-prefix=GLOBAL_WITHINIT
+
 // REQUIRES: objc_interop
 
 import foo_swift_module
@@ -490,4 +493,17 @@ func testAnyObjectClassMethods1(_ dl: AnyObject) {
 
 func testAnyObjectClassMethods2(_ dl: AnyObject) {
   type(of: dl).#^DL_CLASS_DOT_1^#
+}
+
+func testAnyObjectInitialize() {
+  AnyObject(#^INITIALIZE_PAREN^#)
+// INITIALIZE_PAREN-NOT: Flair[ArgLabels]
+// INITIALIZE_PAREN-NOT: name=int:
+}
+
+func testGlobalInitializer() {
+  #^GLOBAL_WITHINIT^#
+// GLOBAL_WITHINIT-NOT: name=AnyObject(
+// GLOBAL_WITHINIT-DAG: Decl[TypeAlias]/OtherModule[Swift]/IsSystem: AnyObject[#Builtin.AnyObject#]; name=AnyObject
+// GLOBAL_WITHINIT-NOT: name=AnyObject(
 }


### PR DESCRIPTION
Cherry-pick #58883 into `release/5.7`

* **Explanation**: Previously, `AnyObject(<HERE>` and global completions with initializers (i.e. `addinitstotoplevel`) showed all initializers from objc classes. However, `AnyObject` cannot be instantiated, so we should NOT be providing any initializers on `AnyObject` type. 
* **Scope**: Code completion for `AnyObject`
* **Risk**: Low. Just adding early bailout for `type->isAnyObject()` condition.
* **Issues**: rdar://93059166
* **Testing**: Added regression test cases
* **Reviewer**: Ben Barham (@bnbarham)