### PR TITLE
Update IRABIDetailsProvider.h

### DIFF
--- a/include/swift/IRGen/IRABIDetailsProvider.h
+++ b/include/swift/IRGen/IRABIDetailsProvider.h
@@ -14,7 +14,8 @@
 #define SWIFT_IRGEN_IRABIDETAILSPROVIDER_H
 
 #include "llvm/ADT/Optional.h"
-#include <stdint.h>
+#include <cstdint>
+#include <memory>
 #include <utility>
 
 namespace swift {


### PR DESCRIPTION
Add missing include, prefer C++ include over C include for standard integer types.