### PR TITLE
[5.7][Parseable Output] Generate valid output for files of unknown types

### DIFF
--- a/lib/Basic/ParseableOutput.cpp
+++ b/lib/Basic/ParseableOutput.cpp
@@ -42,6 +42,7 @@ template <> struct ScalarEnumerationTraits<file_types::ID> {
       std::string typeName = file_types::getTypeName(ty).str();
       out.enumCase(value, typeName.c_str(), ty);
     });
+    out.enumCase(value, "unknown", file_types::ID::TY_INVALID);
   }
 };
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -601,6 +601,7 @@ static swift::file_types::ID computeFileTypeForPath(const StringRef Path) {
     // then iterate over all preceeding possible extension variants.
     while (llvm::sys::path::has_extension(PathStem)) {
       auto NextExtension = llvm::sys::path::extension(PathStem);
+      PathStem = llvm::sys::path::stem(PathStem);
       Extension = NextExtension.str() + Extension;
       FileType = file_types::lookupTypeForExtension(Extension);
       if (FileType != swift::file_types::ID::TY_INVALID)

--- a/test/Frontend/parseable_output_unknown_file_type.swift
+++ b/test/Frontend/parseable_output_unknown_file_type.swift
@@ -1,0 +1,38 @@
+// RUN: %target-swift-frontend -primary-file %s %S/Inputs/filelist-other.swift -o %t.out -module-name parseable_output -empty-abi-descriptor -emit-abi-descriptor-path %t.abi.weird_file_extension -emit-module -emit-module-path %t.swiftmodule -frontend-parseable-output 2>&1 | %FileCheck %s
+
+// CHECK: {{[1-9][0-9]*}}
+// CHECK-NEXT: {
+// CHECK-NEXT:   "kind": "began",
+// CHECK-NEXT:   "name": "compile",
+// CHECK:        "inputs": [
+// CHECK-NEXT:       "{{.*[\\/]}}parseable_output_unknown_file_type.swift"
+// CHECK:        "outputs": [
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "type": "image",
+// CHECK-NEXT:         "path": "{{.*[\\/]}}parseable_output_unknown_file_type.swift.tmp.out"
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "type": "swiftmodule",
+// CHECK-NEXT:         "path": "{{.*[\\/]}}parseable_output_unknown_file_type.swift.tmp.swiftmodule"
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:         "type": "unknown",
+// CHECK-NEXT:         "path": "{{.*[\\/]}}parseable_output_unknown_file_type.swift.tmp.abi.weird_file_extension"
+// CHECK-NEXT:       }
+// CHECK-NEXT:     ],
+// CHECK-NEXT:     "pid": [[PID:[0-9]*]]
+// CHECK-NEXT:     "process": {
+// CHECK-NEXT:       "real_pid": [[PID]]
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+
+// CHECK-NEXT: {{[1-9][0-9]*}}
+// CHECK-NEXT: {
+// CHECK-NEXT:   "kind": "finished",
+// CHECK-NEXT:   "name": "compile",
+// CHECK-NEXT:   "pid": [[PID]],
+// CHECK-NEXT:   "process": {
+// CHECK-NEXT:     "real_pid": [[PID]]
+// CHECK-NEXT:   },
+// CHECK-NEXT:   "exit-status": 0
+// CHECK-NEXT: }


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/59256
---------------------------------
When we encounter an input or output with an unknown extension 'TY_INVALID', still produce valid JSON specifying the type as "unknown" instead of either crashing or producing malformed JSON.

Resolves rdar://94348593
