### PR TITLE
[CSApply] Fixed type-checked subexpression output bug for multi-state…

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8993,10 +8993,16 @@ ExprWalker::rewriteTarget(SolutionApplicationTarget target) {
     result.setExpr(resultExpr);
 
     if (cs.isDebugMode()) {
+      // If target is a multi-statement closure or
+      // a tap expression, expression will not be fully
+      // type checked until these types are visited in
+      // processDelayed().
       auto &log = llvm::errs();
-      log << "---Type-checked expression---\n";
-      resultExpr->dump(log);
-      log << "\n";
+      if (!ClosuresToTypeCheck.empty() || !TapsToTypeCheck.empty()) {
+        log << "---Partially type-checked expression---\n";
+        resultExpr->dump(log);
+        log << "\n";
+      }
     }
   }
 
@@ -9057,6 +9063,13 @@ Optional<SolutionApplicationTarget> ConstraintSystem::applySolution(
     return None;
 
   rewriter.finalize();
+  
+  if (isDebugMode()) {
+    auto &log = llvm::errs();
+    log << "---Fully type-checked expression---\n";
+    resultTarget->getAsExpr()->dump(log);
+    log << "\n";
+  }
 
   return resultTarget;
 }


### PR DESCRIPTION
…ment closures

<!-- What's in this pull request? -->
Previously the type-checked subexpressions of a multi-statement closure were being printed with only partial bindings. This fix ensures that subexpressions are printed with all of their type-checked bindings. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
