### PR TITLE
[5.7][TypeChecker] Rework type-checking of `for-in` statements

### DIFF
--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -743,8 +743,8 @@ class ForEachStmt : public LabeledStmt {
 
   // Set by Sema:
   ProtocolConformanceRef sequenceConformance = ProtocolConformanceRef();
-  VarDecl *iteratorVar = nullptr;
-  Expr *iteratorVarRef = nullptr;
+  PatternBindingDecl *iteratorVar = nullptr;
+  Expr *nextCall = nullptr;
   OpaqueValueExpr *elementExpr = nullptr;
   Expr *convertElementExpr = nullptr;
 
@@ -759,11 +759,11 @@ public:
     setPattern(Pat);
   }
 
-  void setIteratorVar(VarDecl *var) { iteratorVar = var; }
-  VarDecl *getIteratorVar() const { return iteratorVar; }
+  void setIteratorVar(PatternBindingDecl *var) { iteratorVar = var; }
+  PatternBindingDecl *getIteratorVar() const { return iteratorVar; }
 
-  void setIteratorVarRef(Expr *var) { iteratorVarRef = var; }
-  Expr *getIteratorVarRef() const { return iteratorVarRef; }
+  void setNextCall(Expr *next) { nextCall = next; }
+  Expr *getNextCall() const { return nextCall; }
 
   void setElementExpr(OpaqueValueExpr *expr) { elementExpr = expr; }
   OpaqueValueExpr *getElementExpr() const { return elementExpr; }
@@ -802,8 +802,12 @@ public:
   /// by this foreach loop, as it was written in the source code and
   /// subsequently type-checked. To determine the semantic behavior of this
   /// expression to extract a range, use \c getRangeInit().
-  Expr *getSequence() const { return Sequence; }
-  void setSequence(Expr *S) { Sequence = S; }
+  Expr *getParsedSequence() const { return Sequence; }
+  void setParsedSequence(Expr *S) { Sequence = S; }
+
+  /// Type-checked version of the sequence or nullptr if this statement
+  /// yet to be type-checked.
+  Expr *getTypeCheckedSequence() const;
 
   /// getBody - Retrieve the body of the loop.
   BraceStmt *getBody() const { return Body; }

--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -137,11 +137,6 @@ enum class ConstraintKind : char {
   /// name, and the type of that member, when referenced as a value, is the
   /// second type.
   UnresolvedValueMember,
-  /// The first type conforms to the protocol in which the member requirement
-  /// resides. Once the conformance is resolved, the value witness will be
-  /// determined, and the type of that witness, when referenced as a value,
-  /// will be bound to the second type.
-  ValueWitness,
   /// The first type can be defaulted to the second (which currently
   /// cannot be dependent).  This is more like a type property than a
   /// relational constraint.
@@ -411,18 +406,11 @@ class Constraint final : public llvm::ilist_node<Constraint>,
       /// The type of the member.
       Type Second;
 
-      union {
-        /// If non-null, the name of a member of the first type is that
-        /// being related to the second type.
-        ///
-        /// Used for ValueMember an UnresolvedValueMember constraints.
-        DeclNameRef Name;
-
-        /// If non-null, the member being referenced.
-        ///
-        /// Used for ValueWitness constraints.
-        ValueDecl *Ref;
-      } Member;
+      /// If non-null, the name of a member of the first type is that
+      /// being related to the second type.
+      ///
+      /// Used for ValueMember an UnresolvedValueMember constraints.
+      DeclNameRef Name;
 
       /// The DC in which the use appears.
       DeclContext *UseDC;
@@ -536,12 +524,6 @@ public:
                                   DeclContext *useDC,
                                   FunctionRefKind functionRefKind,
                                   ConstraintLocator *locator);
-
-  /// Create a new value witness constraint.
-  static Constraint *createValueWitness(
-      ConstraintSystem &cs, ConstraintKind kind, Type first, Type second,
-      ValueDecl *requirement, DeclContext *useDC,
-      FunctionRefKind functionRefKind, ConstraintLocator *locator);
 
   /// Create an overload-binding constraint.
   static Constraint *createBindOverload(ConstraintSystem &cs, Type type, 
@@ -690,7 +672,6 @@ public:
 
     case ConstraintKind::ValueMember:
     case ConstraintKind::UnresolvedValueMember:
-    case ConstraintKind::ValueWitness:
     case ConstraintKind::PropertyWrapper:
       return ConstraintClassification::Member;
 
@@ -730,7 +711,6 @@ public:
 
     case ConstraintKind::ValueMember:
     case ConstraintKind::UnresolvedValueMember:
-    case ConstraintKind::ValueWitness:
       return Member.First;
 
     case ConstraintKind::SyntacticElement:
@@ -752,7 +732,6 @@ public:
 
     case ConstraintKind::ValueMember:
     case ConstraintKind::UnresolvedValueMember:
-    case ConstraintKind::ValueWitness:
       return Member.Second;
 
     default:
@@ -778,20 +757,13 @@ public:
   DeclNameRef getMember() const {
     assert(Kind == ConstraintKind::ValueMember ||
            Kind == ConstraintKind::UnresolvedValueMember);
-    return Member.Member.Name;
-  }
-
-  /// Retrieve the requirement being referenced by a value witness constraint.
-  ValueDecl *getRequirement() const {
-    assert(Kind == ConstraintKind::ValueWitness);
-    return Member.Member.Ref;
+    return Member.Name;
   }
 
   /// Determine the kind of function reference we have for a member reference.
   FunctionRefKind getFunctionRefKind() const {
     if (Kind == ConstraintKind::ValueMember ||
-        Kind == ConstraintKind::UnresolvedValueMember ||
-        Kind == ConstraintKind::ValueWitness)
+        Kind == ConstraintKind::UnresolvedValueMember)
       return static_cast<FunctionRefKind>(TheFunctionRefKind);
 
     // Conservative answer: drop all of the labels.
@@ -851,8 +823,7 @@ public:
   /// Retrieve the DC in which the member was used.
   DeclContext *getMemberUseDC() const {
     assert(Kind == ConstraintKind::ValueMember ||
-           Kind == ConstraintKind::UnresolvedValueMember ||
-           Kind == ConstraintKind::ValueWitness);
+           Kind == ConstraintKind::UnresolvedValueMember);
     return Member.UseDC;
   }
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -80,6 +80,10 @@ Optional<constraints::SolutionApplicationTarget>
 typeCheckExpression(constraints::SolutionApplicationTarget &target,
                     OptionSet<TypeCheckExprFlags> options);
 
+Optional<constraints::SolutionApplicationTarget>
+typeCheckTarget(constraints::SolutionApplicationTarget &target,
+                OptionSet<TypeCheckExprFlags> options);
+
 Type typeCheckParameterDefault(Expr *&, DeclContext *, Type, bool);
 
 } // end namespace TypeChecker
@@ -953,13 +957,8 @@ struct CaseLabelItemInfo {
 /// Describes information about a for-each loop that needs to be tracked
 /// within the constraint system.
 struct ForEachStmtInfo {
-  ForEachStmt *stmt;
-
   /// The type of the sequence.
   Type sequenceType;
-
-  /// The type of the iterator.
-  Type iteratorType;
 
   /// The type of an element in the sequence.
   Type elementType;
@@ -967,8 +966,11 @@ struct ForEachStmtInfo {
   /// The type of the pattern that matches the elements.
   Type initType;
 
-  /// The "where" expression, if there is one.
-  Expr *whereExpr;
+  /// Implicit `$iterator = <sequence>.makeIterator()`
+  PatternBindingDecl *makeIteratorVar;
+
+  /// Implicit `$iterator.next()` call.
+  Expr *nextCall;
 };
 
 /// Key to the constraint solver's mapping from AST nodes to their corresponding
@@ -1660,6 +1662,7 @@ public:
     caseLabelItem,
     patternBinding,
     uninitializedVar,
+    forEachStmt,
   } kind;
 
 private:
@@ -1711,8 +1714,6 @@ private:
           /// The index into the pattern binding declaration, if any.
           unsigned patternBindingIndex;
         } initialization;
-
-        ForEachStmtInfo forEachStmt;
       };
     } expression;
 
@@ -1747,6 +1748,14 @@ private:
       /// Type associated with the declaration.
       Type type;
     } uninitializedVar;
+
+    struct {
+      ForEachStmt *stmt;
+      DeclContext *dc;
+      Pattern *pattern;
+      bool bindPatternVarsOneWay;
+      ForEachStmtInfo info;
+    } forEachStmt;
 
     PatternBindingDecl *patternBinding;
   };
@@ -1831,6 +1840,14 @@ public:
     uninitializedVar.type = patternTy;
   }
 
+  SolutionApplicationTarget(ForEachStmt *stmt, DeclContext *dc,
+                            bool bindPatternVarsOneWay)
+    : kind(Kind::forEachStmt) {
+    forEachStmt.stmt = stmt;
+    forEachStmt.dc = dc;
+    forEachStmt.bindPatternVarsOneWay = bindPatternVarsOneWay;
+  }
+
   /// Form a target for the initialization of a pattern from an expression.
   static SolutionApplicationTarget forInitialization(
       Expr *initializer, DeclContext *dc, Type patternType, Pattern *pattern,
@@ -1843,11 +1860,10 @@ public:
       PatternBindingDecl *patternBinding, unsigned patternBindingIndex,
       bool bindPatternVarsOneWay);
 
-  /// Form a target for a for-each loop.
+  /// Form a target for a for-in loop.
   static SolutionApplicationTarget forForEachStmt(
-      ForEachStmt *stmt, ProtocolDecl *sequenceProto, DeclContext *dc,
-      bool bindPatternVarsOneWay,
-      ContextualTypePurpose purpose = CTP_ForEachStmt);
+      ForEachStmt *stmt, DeclContext *dc,
+      bool bindPatternVarsOneWay);
 
   /// Form a target for a property with an attached property wrapper that is
   /// initialized out-of-line.
@@ -1872,6 +1888,39 @@ public:
     return {expr, dc, pattern, patternTy};
   }
 
+  /// This is useful for code completion.
+  ASTNode getAsASTNode() const {
+    switch (kind) {
+    case Kind::expression:
+      return expression.expression;
+
+    case Kind::closure:
+      return closure.closure;
+
+    case Kind::function: {
+      auto ref = *getAsFunction();
+      if (auto *func = ref.getAbstractFunctionDecl())
+        return func;
+      return ref.getAbstractClosureExpr();
+    }
+
+    case Kind::forEachStmt:
+      return getAsForEachStmt();
+
+    case Kind::stmtCondition:
+      return ASTNode();
+
+    case Kind::caseLabelItem:
+      return *getAsCaseLabelItem();
+
+    case Kind::patternBinding:
+      return getAsPatternBinding();
+
+    case Kind::uninitializedVar:
+      return getAsUninitializedVar();
+    }
+  }
+
   Expr *getAsExpr() const {
     switch (kind) {
     case Kind::expression:
@@ -1883,6 +1932,7 @@ public:
     case Kind::caseLabelItem:
     case Kind::patternBinding:
     case Kind::uninitializedVar:
+    case Kind::forEachStmt:
       return nullptr;
     }
     llvm_unreachable("invalid expression type");
@@ -1915,6 +1965,9 @@ public:
 
       return uninitializedVar.binding->getInitContext(uninitializedVar.index);
     }
+
+    case Kind::forEachStmt:
+      return forEachStmt.dc;
     }
     llvm_unreachable("invalid decl context type");
   }
@@ -1994,9 +2047,7 @@ public:
 
   /// Whether this target is for a for-in statement.
   bool isForEachStmt() const {
-    return kind == Kind::expression &&
-           (getExprContextualTypePurpose() == CTP_ForEachStmt ||
-            getExprContextualTypePurpose() == CTP_ForEachSequence);
+    return kind == Kind::forEachStmt;
   }
 
   /// Whether this is an initialization for an Optional.Some pattern.
@@ -2021,7 +2072,13 @@ public:
   /// Whether to bind the types of any variables within the pattern via
   /// one-way constraints.
   bool shouldBindPatternVarsOneWay() const {
-    return kind == Kind::expression && expression.bindPatternVarsOneWay;
+    if (kind == Kind::expression)
+      return expression.bindPatternVarsOneWay;
+
+    if (kind == Kind::forEachStmt)
+      return forEachStmt.bindPatternVarsOneWay;
+
+    return false;
   }
 
   /// Whether or not an opaque value placeholder should be injected into the
@@ -2075,12 +2132,12 @@ public:
 
   const ForEachStmtInfo &getForEachStmtInfo() const {
     assert(isForEachStmt());
-    return expression.forEachStmt;
+    return forEachStmt.info;
   }
 
   ForEachStmtInfo &getForEachStmtInfo() {
     assert(isForEachStmt());
-    return expression.forEachStmt;
+    return forEachStmt.info;
   }
 
   /// Whether this context infers an opaque return type.
@@ -2106,6 +2163,11 @@ public:
       return;
     }
 
+    if (kind == Kind::forEachStmt) {
+      forEachStmt.pattern = pattern;
+      return;
+    }
+
     assert(kind == Kind::expression);
     assert(expression.contextualPurpose == CTP_Initialization ||
            expression.contextualPurpose == CTP_ForEachStmt ||
@@ -2122,6 +2184,7 @@ public:
     case Kind::caseLabelItem:
     case Kind::patternBinding:
     case Kind::uninitializedVar:
+    case Kind::forEachStmt:
       return None;
 
     case Kind::function:
@@ -2138,6 +2201,7 @@ public:
     case Kind::caseLabelItem:
     case Kind::patternBinding:
     case Kind::uninitializedVar:
+    case Kind::forEachStmt:
       return None;
 
     case Kind::stmtCondition:
@@ -2154,6 +2218,7 @@ public:
     case Kind::stmtCondition:
     case Kind::patternBinding:
     case Kind::uninitializedVar:
+    case Kind::forEachStmt:
       return None;
 
     case Kind::caseLabelItem:
@@ -2170,6 +2235,7 @@ public:
     case Kind::stmtCondition:
     case Kind::caseLabelItem:
     case Kind::uninitializedVar:
+    case Kind::forEachStmt:
       return nullptr;
 
     case Kind::patternBinding:
@@ -2186,6 +2252,7 @@ public:
     case Kind::stmtCondition:
     case Kind::caseLabelItem:
     case Kind::patternBinding:
+    case Kind::forEachStmt:
       return nullptr;
 
     case Kind::uninitializedVar:
@@ -2202,10 +2269,28 @@ public:
     case Kind::stmtCondition:
     case Kind::caseLabelItem:
     case Kind::patternBinding:
+    case Kind::forEachStmt:
       return nullptr;
 
     case Kind::uninitializedVar:
       return uninitializedVar.declaration.dyn_cast<Pattern *>();
+    }
+    llvm_unreachable("invalid case label type");
+  }
+
+  ForEachStmt *getAsForEachStmt() const {
+    switch (kind) {
+    case Kind::expression:
+    case Kind::closure:
+    case Kind::function:
+    case Kind::stmtCondition:
+    case Kind::caseLabelItem:
+    case Kind::patternBinding:
+    case Kind::uninitializedVar:
+      return nullptr;
+
+    case Kind::forEachStmt:
+      return forEachStmt.stmt;
     }
     llvm_unreachable("invalid case label type");
   }
@@ -2218,6 +2303,7 @@ public:
     case Kind::stmtCondition:
     case Kind::caseLabelItem:
     case Kind::patternBinding:
+    case Kind::forEachStmt:
       return nullptr;
 
     case Kind::uninitializedVar:
@@ -2234,6 +2320,7 @@ public:
     case Kind::stmtCondition:
     case Kind::caseLabelItem:
     case Kind::patternBinding:
+    case Kind::forEachStmt:
       return nullptr;
 
     case Kind::uninitializedVar:
@@ -2250,6 +2337,7 @@ public:
     case Kind::stmtCondition:
     case Kind::caseLabelItem:
     case Kind::patternBinding:
+    case Kind::forEachStmt:
       return 0;
 
     case Kind::uninitializedVar:
@@ -2297,6 +2385,18 @@ public:
       }
       return uninitializedVar.declaration.get<Pattern *>()->getSourceRange();
     }
+
+    // For-in statement target doesn't cover the body.
+    case Kind::forEachStmt:
+      auto *stmt = forEachStmt.stmt;
+      SourceLoc startLoc = stmt->getForLoc();
+      SourceLoc endLoc = stmt->getParsedSequence()->getEndLoc();
+
+      if (auto *whereExpr = stmt->getWhere()) {
+        endLoc = whereExpr->getEndLoc();
+      }
+
+      return {startLoc, endLoc};
     }
     llvm_unreachable("invalid target type");
   }
@@ -2329,6 +2429,9 @@ public:
       }
       return uninitializedVar.declaration.get<Pattern *>()->getLoc();
     }
+
+    case Kind::forEachStmt:
+      return forEachStmt.stmt->getStartLoc();
     }
     llvm_unreachable("invalid target type");
   }
@@ -3168,6 +3271,10 @@ private:
   swift::TypeChecker::typeCheckExpression(
       SolutionApplicationTarget &target, OptionSet<TypeCheckExprFlags> options);
 
+  friend Optional<SolutionApplicationTarget>
+  swift::TypeChecker::typeCheckTarget(SolutionApplicationTarget &target,
+                                      OptionSet<TypeCheckExprFlags> options);
+
   friend Type swift::TypeChecker::typeCheckParameterDefault(Expr *&,
                                                             DeclContext *, Type,
                                                             bool);
@@ -3895,26 +4002,6 @@ public:
                                    useDC, functionRefKind,
                                    getConstraintLocator(locator)));
       }
-      break;
-    }
-  }
-
-  /// Add a value witness constraint to the constraint system.
-  void addValueWitnessConstraint(
-      Type baseTy, ValueDecl *requirement, Type memberTy, DeclContext *useDC,
-      FunctionRefKind functionRefKind, ConstraintLocatorBuilder locator) {
-    assert(baseTy);
-    assert(memberTy);
-    assert(requirement);
-    assert(useDC);
-    switch (simplifyValueWitnessConstraint(
-        ConstraintKind::ValueWitness, baseTy, requirement, memberTy, useDC,
-        functionRefKind, TMF_GenerateConstraints, locator)) {
-    case SolutionKind::Unsolved:
-      llvm_unreachable("Unsolved result when generating constraints!");
-
-    case SolutionKind::Solved:
-    case SolutionKind::Error:
       break;
     }
   }

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1569,14 +1569,14 @@ public:
     }
     printRec(S->getPattern());
     OS << '\n';
-    printRec(S->getSequence());
+    printRec(S->getParsedSequence());
     OS << '\n';
     if (S->getIteratorVar()) {
       printRec(S->getIteratorVar());
       OS << '\n';
     }
-    if (S->getIteratorVarRef()) {
-      printRec(S->getIteratorVarRef());
+    if (S->getNextCall()) {
+      printRec(S->getNextCall());
       OS << '\n';
     }
     if (S->getConvertElementExpr()) {

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -994,7 +994,7 @@ void SwitchStmtScope::expandAScopeThatDoesNotCreateANewInsertionPoint(
 
 void ForEachStmtScope::expandAScopeThatDoesNotCreateANewInsertionPoint(
     ScopeCreator &scopeCreator) {
-  scopeCreator.addToScopeTree(stmt->getSequence(), this);
+  scopeCreator.addToScopeTree(stmt->getParsedSequence(), this);
 
   // Add a child describing the scope of the pattern.
   // In error cases such as:

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1590,11 +1590,28 @@ Stmt *Traversal::visitForEachStmt(ForEachStmt *S) {
 
   // The iterator decl is built directly on top of the sequence
   // expression, so don't visit both.
-  if (Expr *Sequence = S->getSequence()) {
-    if ((Sequence = doIt(Sequence)))
-      S->setSequence(Sequence);
-    else
-      return nullptr;
+  //
+  // If for-in is already type-checked, the type-checked version
+  // of the sequence is going to be visited as part of `iteratorVar`.
+  if (S->getTypeCheckedSequence()) {
+    if (auto IteratorVar = S->getIteratorVar()) {
+      if (doIt(IteratorVar))
+        return nullptr;
+    }
+
+    if (auto NextCall = S->getNextCall()) {
+      if ((NextCall = doIt(NextCall)))
+        S->setNextCall(NextCall);
+      else
+        return nullptr;
+    }
+  } else {
+    if (Expr *Sequence = S->getParsedSequence()) {
+      if ((Sequence = doIt(Sequence)))
+        S->setParsedSequence(Sequence);
+      else
+        return nullptr;
+    }
   }
 
   if (Expr *Where = S->getWhere()) {
@@ -1607,18 +1624,6 @@ Stmt *Traversal::visitForEachStmt(ForEachStmt *S) {
   if (auto IteratorNext = S->getConvertElementExpr()) {
     if ((IteratorNext = doIt(IteratorNext)))
       S->setConvertElementExpr(IteratorNext);
-    else
-      return nullptr;
-  }
-
-  if (auto IteratorVar = S->getIteratorVar()) {
-    if (doIt(IteratorVar))
-      return nullptr;
-  }
-
-  if (auto IteratorVarRef = S->getIteratorVarRef()) {
-    if ((IteratorVarRef = doIt(IteratorVarRef)))
-      S->setIteratorVarRef(IteratorVarRef);
     else
       return nullptr;
   }

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -3110,7 +3110,7 @@ void FindLocalVal::visitForEachStmt(ForEachStmt *S) {
   if (!isReferencePointInRange(S->getSourceRange()))
     return;
   visit(S->getBody());
-  if (!isReferencePointInRange(S->getSequence()->getSourceRange()))
+  if (!isReferencePointInRange(S->getParsedSequence()->getSourceRange()))
     checkPattern(S->getPattern(), DeclVisibilityKind::LocalVariable);
 }
 

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -301,6 +301,10 @@ void ForEachStmt::setPattern(Pattern *p) {
   Pat->markOwnedByStatement(this);
 }
 
+Expr *ForEachStmt::getTypeCheckedSequence() const {
+  return iteratorVar ? iteratorVar->getInit(/*index=*/0) : nullptr;
+}
+
 DoCatchStmt *DoCatchStmt::create(ASTContext &ctx, LabeledStmtInfo labelInfo,
                                  SourceLoc doLoc, Stmt *body,
                                  ArrayRef<CaseStmt *> catches,

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -1088,7 +1088,7 @@ class ExprContextAnalyzer {
       break;
     }
     case StmtKind::ForEach:
-      if (auto SEQ = cast<ForEachStmt>(Parent)->getSequence()) {
+      if (auto SEQ = cast<ForEachStmt>(Parent)->getParsedSequence()) {
         if (containsTarget(SEQ)) {
           recordPossibleType(Context.getSequenceType());
         }

--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -2246,7 +2246,7 @@ private:
         if (Range.isValid() && overlapsTarget(Range))
           return IndentContext {ForLoc, !OutdentChecker::hasOutdent(SM, P)};
       }
-      if (auto *E = FS->getSequence()) {
+      if (auto *E = FS->getParsedSequence()) {
         SourceRange Range = FS->getInLoc();
         widenOrSet(Range, E->getSourceRange());
         if (Range.isValid() && isTargetContext(Range)) {

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -747,8 +747,8 @@ std::pair<bool, Stmt *> ModelASTWalker::walkToStmtPre(Stmt *S) {
                                  charSourceRangeFromSourceRange(SM, ElemRange));
       }
     }
-    if (ForEachS->getSequence())
-      addExprElem(SyntaxStructureElementKind::Expr, ForEachS->getSequence(),SN);
+    if (auto *S = ForEachS->getParsedSequence())
+      addExprElem(SyntaxStructureElementKind::Expr, S, SN);
     pushStructureNode(SN, S);
 
   } else if (auto *WhileS = dyn_cast<WhileStmt>(S)) {

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -189,8 +189,6 @@ namespace {
 #define STMT(ID, BASE) void visit##ID##Stmt(ID##Stmt *S);
 #include "swift/AST/StmtNodes.def"
 
-    void visitAsyncForEachStmt(ForEachStmt *S);
-
     ASTContext &getASTContext() { return SGF.getASTContext(); }
 
     SILBasicBlock *createBasicBlock() { return SGF.createBasicBlock(); }
@@ -1020,267 +1018,12 @@ void StmtEmitter::visitRepeatWhileStmt(RepeatWhileStmt *S) {
   SGF.BreakContinueDestStack.pop_back();
 }
 
-void StmtEmitter::visitAsyncForEachStmt(ForEachStmt *S) {
-
-  // Dig out information about the sequence conformance.
-  auto sequenceConformance = S->getSequenceConformance();
-  Type sequenceType = S->getSequence()->getType();
-  
-  auto asyncSequenceProto =
-      SGF.getASTContext().getProtocol(KnownProtocolKind::AsyncSequence);
-  auto sequenceSubs = SubstitutionMap::getProtocolSubstitutions(
-      asyncSequenceProto, sequenceType, sequenceConformance);
-
-  // Emit the 'generator' variable that we'll be using for iteration.
-  LexicalScope OuterForScope(SGF, CleanupLocation(S));
-  {
-    auto initialization =
-        SGF.emitInitializationForVarDecl(S->getIteratorVar(), false);
-    SILLocation loc = SILLocation(S->getSequence());
-
-    // Compute the reference to the AsyncSequence's makeAsyncSequence().
-    FuncDecl *makeGeneratorReq = 
-      SGF.getASTContext().getAsyncSequenceMakeAsyncIterator();
-    ConcreteDeclRef makeGeneratorRef(makeGeneratorReq, sequenceSubs);
-
-    // Call makeAsyncSequence().
-    RValue result = SGF.emitApplyMethod(
-        loc, makeGeneratorRef, ArgumentSource(S->getSequence()),
-        PreparedArguments(ArrayRef<AnyFunctionType::Param>({})),
-        SGFContext(initialization.get()));
-    if (!result.isInContext()) {
-      ArgumentSource(SILLocation(S->getSequence()),
-                     std::move(result).ensurePlusOne(SGF, loc))
-          .forwardInto(SGF, initialization.get());
-    }
-  }
-
-  // If we ever reach an unreachable point, stop emitting statements.
-  // This will need revision if we ever add goto.
-  if (!SGF.B.hasValidInsertionPoint()) return;
-  
-  // If generator's optional result is address-only, create a stack allocation
-  // to hold the results.  This will be initialized on every entry into the loop
-  // header and consumed by the loop body. On loop exit, the terminating value
-  // will be in the buffer.
-  CanType optTy;
-  if (S->getConvertElementExpr()) {
-    optTy = S->getConvertElementExpr()->getType()->getCanonicalType();
-  } else {
-    optTy = OptionalType::get(S->getSequenceConformance().getTypeWitnessByName(
-                                  S->getSequence()->getType(),
-                                  SGF.getASTContext().Id_Element))
-                ->getCanonicalType();
-  }
-  auto &optTL = SGF.getTypeLowering(optTy);
-  SILValue addrOnlyBuf;
-  ManagedValue nextBufOrValue;
-
-  if (optTL.isAddressOnly() && SGF.silConv.useLoweredAddresses())
-    addrOnlyBuf = SGF.emitTemporaryAllocation(S, optTL.getLoweredType());
-
-  // Create a new basic block and jump into it.
-  JumpDest loopDest = createJumpDest(S->getBody());
-  SGF.B.emitBlock(loopDest.getBlock(), S);
-
-  // Compute the reference to the the generator's next() && cancel().
-  auto generatorProto =
-      SGF.getASTContext().getProtocol(KnownProtocolKind::AsyncIteratorProtocol);
-  ValueDecl *generatorNextReq = generatorProto->getSingleRequirement(
-      DeclName(SGF.getASTContext(), SGF.getASTContext().Id_next,
-               ArrayRef<Identifier>()));
-  auto generatorAssocType =
-      asyncSequenceProto->getAssociatedType(SGF.getASTContext().Id_AsyncIterator);
-  auto generatorMemberRef = DependentMemberType::get(
-      asyncSequenceProto->getSelfInterfaceType(), generatorAssocType);
-  auto generatorType = sequenceConformance.getAssociatedType(
-      sequenceType, generatorMemberRef);
-  auto generatorConformance = sequenceConformance.getAssociatedConformance(
-      sequenceType, generatorMemberRef, generatorProto);
-  auto generatorSubs = SubstitutionMap::getProtocolSubstitutions(
-      generatorProto, generatorType, generatorConformance);
-  ConcreteDeclRef generatorNextRef(generatorNextReq, generatorSubs);
-
-  // Set the destinations for 'break' and 'continue'.
-  JumpDest endDest = createJumpDest(S->getBody());
-  SGF.BreakContinueDestStack.push_back({ S, endDest, loopDest });
-  
-
-  auto buildArgumentSource = [&]() {
-    if (cast<FuncDecl>(generatorNextRef.getDecl())->getSelfAccessKind() ==
-        SelfAccessKind::Mutating) {
-      LValue lv =
-          SGF.emitLValue(S->getIteratorVarRef(), SGFAccessKind::ReadWrite);
-      return ArgumentSource(S, std::move(lv));
-    }
-    LValue lv =
-        SGF.emitLValue(S->getIteratorVarRef(), SGFAccessKind::OwnedObjectRead);
-    return ArgumentSource(
-        S, SGF.emitLoadOfLValue(S->getIteratorVarRef(), std::move(lv),
-                                SGFContext().withFollowingSideEffects()));
-  };
-
-  auto buildElementRValue = [&](SILLocation loc, SGFContext ctx) {
-    RValue result;
-    result = SGF.emitApplyMethod(
-        loc, generatorNextRef, buildArgumentSource(),
-        PreparedArguments(ArrayRef<AnyFunctionType::Param>({})),
-        S->getElementExpr() ? SGFContext() : ctx);
-    if (S->getElementExpr()) {
-      SILGenFunction::OpaqueValueRAII pushOpaqueValue(
-          SGF, S->getElementExpr(),
-          std::move(result).getAsSingleValue(SGF, loc));
-      result = SGF.emitRValue(S->getConvertElementExpr(), ctx);
-    }
-    return result;
-  };
-
-  // Then emit the loop destination block.
-  //
-  // Advance the generator.  Use a scope to ensure that any temporary stack
-  // allocations in the subexpression are immediately released.
-  if (optTL.isAddressOnly() && SGF.silConv.useLoweredAddresses()) {
-    // Create the initialization outside of the innerForScope so that the
-    // innerForScope doesn't clean it up.
-    auto nextInit = SGF.useBufferAsTemporary(addrOnlyBuf, optTL);
-    {
-      ArgumentScope innerForScope(SGF, SILLocation(S));
-      SILLocation loc = SILLocation(S);
-      RValue result = buildElementRValue(loc, SGFContext(nextInit.get()));
-      if (!result.isInContext()) {
-        ArgumentSource(SILLocation(S->getSequence()),
-                       std::move(result).ensurePlusOne(SGF, loc))
-            .forwardInto(SGF, nextInit.get());
-      }
-      innerForScope.pop();
-    }
-    nextBufOrValue = nextInit->getManagedAddress();
-  } else {
-    ArgumentScope innerForScope(SGF, SILLocation(S));
-    nextBufOrValue = innerForScope.popPreservingValue(
-        buildElementRValue(SILLocation(S), SGFContext())
-            .getAsSingleValue(SGF, SILLocation(S)));
-  }
-
-  SILBasicBlock *failExitingBlock = createBasicBlock();
-  SwitchEnumBuilder switchEnumBuilder(SGF.B, S, nextBufOrValue);
-
-  switchEnumBuilder.addOptionalSomeCase(
-      createBasicBlock(), loopDest.getBlock(),
-      [&](ManagedValue inputValue, SwitchCaseFullExpr &&scope) {
-        SGF.emitProfilerIncrement(S->getBody());
-
-        // Emit the loop body.
-        // The declared variable(s) for the current element are destroyed
-        // at the end of each loop iteration.
-        {
-          Scope innerForScope(SGF.Cleanups, CleanupLocation(S->getBody()));
-          // Emit the initialization for the pattern.  If any of the bound
-          // patterns
-          // fail (because this is a 'for case' pattern with a refutable
-          // pattern,
-          // the code should jump to the continue block.
-          InitializationPtr initLoopVars =
-              SGF.emitPatternBindingInitialization(S->getPattern(), loopDest);
-
-          // If we had a loadable "next" generator value, we know it is present.
-          // Get the value out of the optional, and wrap it up with a cleanup so
-          // that any exits out of this scope properly clean it up.
-          //
-          // *NOTE* If we do not have an address only value, then inputValue is
-          // *already properly unwrapped.
-          if (optTL.isAddressOnly() && SGF.silConv.useLoweredAddresses()) {
-            inputValue = SGF.emitUncheckedGetOptionalValueFrom(
-                S, inputValue, optTL, SGFContext(initLoopVars.get()));
-          }
-
-          if (!inputValue.isInContext())
-            RValue(SGF, S, optTy.getOptionalObjectType(), inputValue)
-                .forwardInto(SGF, S, initLoopVars.get());
-
-          // Now that the pattern has been initialized, check any where
-          // condition.
-          // If it fails, loop around as if 'continue' happened.
-          if (auto *Where = S->getWhere()) {
-            auto cond = SGF.emitCondition(Where, /*invert*/ true);
-            // If self is null, branch to the epilog.
-            cond.enterTrue(SGF);
-            SGF.Cleanups.emitBranchAndCleanups(loopDest, Where, {});
-            cond.exitTrue(SGF);
-            cond.complete(SGF);
-          }
-
-          visit(S->getBody());
-        }
-
-        // If we emitted an unreachable in the body, we will not have a valid
-        // insertion point. Just return early.
-        if (!SGF.B.hasValidInsertionPoint()) {
-          scope.unreachableExit();
-          return;
-        }
-
-        // Otherwise, associate the loop body's closing brace with this branch.
-        RegularLocation L(S->getBody());
-        L.pointToEnd();
-        scope.exitAndBranch(L);
-      },
-      SGF.loadProfilerCount(S->getBody()));
-
-  // We add loop fail block, just to be defensive about intermediate
-  // transformations performing cleanups at scope.exit(). We still jump to the
-  // contBlock.
-  switchEnumBuilder.addOptionalNoneCase(
-      createBasicBlock(), failExitingBlock,
-      [&](ManagedValue inputValue, SwitchCaseFullExpr &&scope) {
-        assert(!inputValue && "None should not be passed an argument!");
-        scope.exitAndBranch(S);
-      },
-      SGF.loadProfilerCount(S));
-
-  std::move(switchEnumBuilder).emit();
-
-  SGF.B.emitBlock(failExitingBlock);
-  emitOrDeleteBlock(SGF, endDest, S);
-  SGF.BreakContinueDestStack.pop_back();
-}
-
 void StmtEmitter::visitForEachStmt(ForEachStmt *S) {
-  if (S->getAwaitLoc().isValid()) {
-    visitAsyncForEachStmt(S);
-    return;
-  }
-
-  // Dig out information about the sequence conformance.
-  auto sequenceConformance = S->getSequenceConformance();
-  Type sequenceType = S->getSequence()->getType();
-  
-  auto sequenceProto =
-      SGF.getASTContext().getProtocol(KnownProtocolKind::Sequence);
-  auto sequenceSubs = SubstitutionMap::getProtocolSubstitutions(
-      sequenceProto, sequenceType, sequenceConformance);
-
   // Emit the 'iterator' variable that we'll be using for iteration.
   LexicalScope OuterForScope(SGF, CleanupLocation(S));
   {
-    auto initialization =
-        SGF.emitInitializationForVarDecl(S->getIteratorVar(), false);
-    SILLocation loc = SILLocation(S->getSequence());
-
-    // Compute the reference to the Sequence's makeIterator().
-    FuncDecl *makeIteratorReq = SGF.getASTContext().getSequenceMakeIterator();
-    ConcreteDeclRef makeIteratorRef(makeIteratorReq, sequenceSubs);
-
-    // Call makeIterator().
-    RValue result = SGF.emitApplyMethod(
-        loc, makeIteratorRef, ArgumentSource(S->getSequence()),
-        PreparedArguments(ArrayRef<AnyFunctionType::Param>({})),
-        SGFContext(initialization.get()));
-    if (!result.isInContext()) {
-      ArgumentSource(SILLocation(S->getSequence()),
-                     std::move(result).ensurePlusOne(SGF, loc))
-          .forwardInto(SGF, initialization.get());
-    }
+    SGF.emitPatternBinding(S->getIteratorVar(),
+                           /*index=*/0);
   }
 
   // If we ever reach an unreachable point, stop emitting statements.
@@ -1291,11 +1034,7 @@ void StmtEmitter::visitForEachStmt(ForEachStmt *S) {
   // to hold the results.  This will be initialized on every entry into the loop
   // header and consumed by the loop body. On loop exit, the terminating value
   // will be in the buffer.
-  CanType optTy =
-      OptionalType::get(
-          S->getSequenceConformance().getTypeWitnessByName(
-              S->getSequence()->getType(), SGF.getASTContext().Id_Element))
-          ->getCanonicalType();
+  CanType optTy = S->getNextCall()->getType()->getCanonicalType();
   auto &optTL = SGF.getTypeLowering(optTy);
 
   SILValue addrOnlyBuf;
@@ -1313,45 +1052,11 @@ void StmtEmitter::visitForEachStmt(ForEachStmt *S) {
   JumpDest endDest = createJumpDest(S->getBody());
   SGF.BreakContinueDestStack.push_back({ S, endDest, loopDest });
 
-  // Compute the reference to the the iterator's next().
-  auto iteratorProto =
-      SGF.getASTContext().getProtocol(KnownProtocolKind::IteratorProtocol);
-  ValueDecl *iteratorNextReq = iteratorProto->getSingleRequirement(
-      DeclName(SGF.getASTContext(), SGF.getASTContext().Id_next,
-               ArrayRef<Identifier>()));
-  auto iteratorAssocType =
-      sequenceProto->getAssociatedType(SGF.getASTContext().Id_Iterator);
-  auto iteratorMemberRef = DependentMemberType::get(
-      sequenceProto->getSelfInterfaceType(), iteratorAssocType);
-  auto iteratorType = sequenceConformance.getAssociatedType(
-      sequenceType, iteratorMemberRef);
-  auto iteratorConformance = sequenceConformance.getAssociatedConformance(
-      sequenceType, iteratorMemberRef, iteratorProto);
-  auto iteratorSubs = SubstitutionMap::getProtocolSubstitutions(
-      iteratorProto, iteratorType, iteratorConformance);
-  ConcreteDeclRef iteratorNextRef(iteratorNextReq, iteratorSubs);
-
-  auto buildArgumentSource = [&]() {
-    if (cast<FuncDecl>(iteratorNextRef.getDecl())->getSelfAccessKind() ==
-        SelfAccessKind::Mutating) {
-      LValue lv =
-          SGF.emitLValue(S->getIteratorVarRef(), SGFAccessKind::ReadWrite);
-      return ArgumentSource(S, std::move(lv));
-    }
-    LValue lv =
-        SGF.emitLValue(S->getIteratorVarRef(), SGFAccessKind::OwnedObjectRead);
-    return ArgumentSource(
-        S, SGF.emitLoadOfLValue(S->getIteratorVarRef(), std::move(lv),
-                                SGFContext().withFollowingSideEffects()));
-  };
-
   bool hasElementConversion = S->getElementExpr();
-  auto buildElementRValue = [&](SILLocation loc, SGFContext ctx) {
+  auto buildElementRValue = [&](SGFContext ctx) {
     RValue result;
-    result = SGF.emitApplyMethod(
-        loc, iteratorNextRef, buildArgumentSource(),
-        PreparedArguments(ArrayRef<AnyFunctionType::Param>({})),
-        hasElementConversion ? SGFContext() : ctx);
+    result = SGF.emitRValue(S->getNextCall(),
+                            hasElementConversion ? SGFContext() : ctx);
     return result;
   };
 
@@ -1367,9 +1072,9 @@ void StmtEmitter::visitForEachStmt(ForEachStmt *S) {
     {
       ArgumentScope innerForScope(SGF, SILLocation(S));
       SILLocation loc = SILLocation(S);
-      RValue result = buildElementRValue(loc, SGFContext(nextInit.get()));
+      RValue result = buildElementRValue(SGFContext(nextInit.get()));
       if (!result.isInContext()) {
-        ArgumentSource(SILLocation(S->getSequence()),
+        ArgumentSource(SILLocation(S->getTypeCheckedSequence()),
                        std::move(result).ensurePlusOne(SGF, loc))
             .forwardInto(SGF, nextInit.get());
       }
@@ -1379,7 +1084,7 @@ void StmtEmitter::visitForEachStmt(ForEachStmt *S) {
   } else {
     ArgumentScope innerForScope(SGF, SILLocation(S));
     nextBufOrElement = innerForScope.popPreservingValue(
-        buildElementRValue(SILLocation(S), SGFContext())
+        buildElementRValue(SGFContext())
             .getAsSingleValue(SGF, SILLocation(S)));
   }
 

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -847,24 +847,10 @@ protected:
       return nullptr;
     }
 
-    // For-each statements require the Sequence protocol. If we don't have
-    // it (which generally means the standard library isn't loaded), fall
-    // out of the result-builder path entirely to let normal type checking
-    // take care of this.
-    auto sequenceProto = TypeChecker::getProtocol(
-        dc->getASTContext(), forEachStmt->getForLoc(),
-        forEachStmt->getAwaitLoc().isValid() ? 
-          KnownProtocolKind::AsyncSequence : KnownProtocolKind::Sequence);
-    if (!sequenceProto) {
-      if (!unhandledNode)
-        unhandledNode = forEachStmt;
-      return nullptr;
-    }
-
     // Generate constraints for the loop header. This also wires up the
     // types for the patterns.
     auto target = SolutionApplicationTarget::forForEachStmt(
-        forEachStmt, sequenceProto, dc, /*bindPatternVarsOneWay=*/true);
+        forEachStmt, dc, /*bindPatternVarsOneWay=*/true);
     if (cs) {
       if (cs->generateConstraints(target, FreeTypeVariableBinding::Disallow)) {
         hadError = true;

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8584,109 +8584,110 @@ static Optional<SolutionApplicationTarget> applySolutionToInitialization(
 ///
 /// \returns the resulting initialization expression.
 static Optional<SolutionApplicationTarget> applySolutionToForEachStmt(
-    Solution &solution, SolutionApplicationTarget target, Expr *sequence) {
+    Solution &solution, SolutionApplicationTarget target,
+    llvm::function_ref<
+        Optional<SolutionApplicationTarget>(SolutionApplicationTarget)>
+        rewriteTarget) {
   auto resultTarget = target;
   auto &forEachStmtInfo = resultTarget.getForEachStmtInfo();
+  auto *stmt = target.getAsForEachStmt();
+  auto *parsedSequence = stmt->getParsedSequence();
+  bool isAsync = stmt->getAwaitLoc().isValid();
 
   // Simplify the various types.
-  forEachStmtInfo.elementType =
-      solution.simplifyType(forEachStmtInfo.elementType);
-  forEachStmtInfo.iteratorType =
-      solution.simplifyType(forEachStmtInfo.iteratorType);
-  forEachStmtInfo.initType =
-      solution.simplifyType(forEachStmtInfo.initType);
   forEachStmtInfo.sequenceType =
       solution.simplifyType(forEachStmtInfo.sequenceType);
+  forEachStmtInfo.elementType =
+      solution.simplifyType(forEachStmtInfo.elementType);
+  forEachStmtInfo.initType =
+      solution.simplifyType(forEachStmtInfo.initType);
 
-  // Coerce the sequence to the sequence type.
   auto &cs = solution.getConstraintSystem();
-  auto locator = cs.getConstraintLocator(target.getAsExpr());
-  sequence = solution.coerceToType(
-     sequence, forEachStmtInfo.sequenceType, locator);
-  if (!sequence)
-    return None;
-
-  resultTarget.setExpr(sequence);
-
   auto *dc = target.getDeclContext();
 
-  // Get the conformance of the sequence type to the Sequence protocol.
-  auto stmt = forEachStmtInfo.stmt;
-  auto sequenceProto = TypeChecker::getProtocol(
-      cs.getASTContext(), stmt->getForLoc(), 
-      stmt->getAwaitLoc().isValid() ? 
-        KnownProtocolKind::AsyncSequence : KnownProtocolKind::Sequence);
-  auto sequenceConformance = TypeChecker::conformsToProtocol(
-      forEachStmtInfo.sequenceType, sequenceProto, dc->getParentModule());
-  assert(!sequenceConformance.isInvalid() &&
-         "Couldn't find sequence conformance");
+  // First, let's apply the solution to the sequence expression.
+  {
+    auto *makeIteratorVar = forEachStmtInfo.makeIteratorVar;
+
+    auto makeIteratorTarget =
+        *cs.getSolutionApplicationTarget({makeIteratorVar, /*index=*/0});
+
+    auto rewrittenTarget = rewriteTarget(makeIteratorTarget);
+    if (!rewrittenTarget)
+      return None;
+
+    // Set type-checked initializer and mark it as such.
+    {
+      makeIteratorVar->setInit(/*index=*/0, rewrittenTarget->getAsExpr());
+      makeIteratorVar->setInitializerChecked(/*index=*/0);
+    }
+
+    stmt->setIteratorVar(makeIteratorVar);
+  }
+
+  // Now, `$iterator.next()` call.
+  {
+    auto nextTarget =
+        *cs.getSolutionApplicationTarget(forEachStmtInfo.nextCall);
+
+    auto rewrittenTarget = rewriteTarget(nextTarget);
+    if (!rewrittenTarget)
+      return None;
+
+    Expr *nextCall = rewrittenTarget->getAsExpr();
+    // Wrap a call to `next()` into `try await` since `AsyncIteratorProtocol`
+    // requirement is `async throws`
+    if (isAsync) {
+      auto &ctx = cs.getASTContext();
+      auto nextRefType =
+          solution
+              .getResolvedType(
+                  cast<ApplyExpr>(cast<AwaitExpr>(nextCall)->getSubExpr())
+                      ->getFn())
+              ->castTo<FunctionType>();
+
+      // If the inferred witness is throwing, we need to wrap the call
+      // into `try` expression.
+      if (nextRefType->isThrowing())
+        nextCall = TryExpr::createImplicit(ctx, /*tryLoc=*/SourceLoc(),
+                                           nextCall, nextCall->getType());
+    }
+
+    stmt->setNextCall(nextCall);
+  }
 
   // Coerce the pattern to the element type.
-  TypeResolutionOptions options(TypeResolverContext::ForEachStmt);
-  options |= TypeResolutionFlags::OverrideType;
+  {
+    TypeResolutionOptions options(TypeResolverContext::ForEachStmt);
+    options |= TypeResolutionFlags::OverrideType;
 
-  // Apply the solution to the pattern as well.
-  auto contextualPattern = target.getContextualPattern();
-  if (auto coercedPattern = TypeChecker::coercePatternToType(
-          contextualPattern, forEachStmtInfo.initType, options)) {
+    // Apply the solution to the pattern as well.
+    auto contextualPattern = target.getContextualPattern();
+    auto coercedPattern = TypeChecker::coercePatternToType(
+        contextualPattern, forEachStmtInfo.initType, options);
+    if (!coercedPattern)
+      return None;
+
+    stmt->setPattern(coercedPattern);
     resultTarget.setPattern(coercedPattern);
-  } else {
-    return None;
   }
 
   // Apply the solution to the filtering condition, if there is one.
-  if (forEachStmtInfo.whereExpr) {
-    auto *boolDecl = dc->getASTContext().getBoolDecl();
-    assert(boolDecl);
-    Type boolType = boolDecl->getDeclaredInterfaceType();
-    assert(boolType);
+  if (auto *whereExpr = stmt->getWhere()) {
+    auto whereTarget = *cs.getSolutionApplicationTarget(whereExpr);
 
-    SolutionApplicationTarget whereTarget(
-        forEachStmtInfo.whereExpr, dc, CTP_Condition, boolType,
-        /*isDiscarded=*/false);
-    auto newWhereTarget = cs.applySolution(solution, whereTarget);
-    if (!newWhereTarget)
+    auto rewrittenTarget = rewriteTarget(whereTarget);
+    if (!rewrittenTarget)
       return None;
 
-    forEachStmtInfo.whereExpr = newWhereTarget->getAsExpr();
+    stmt->setWhere(rewrittenTarget->getAsExpr());
   }
-
-  // Invoke iterator() to get an iterator from the sequence.
-  ASTContext &ctx = cs.getASTContext();
-  VarDecl *iterator;
-  Type nextResultType = OptionalType::get(forEachStmtInfo.elementType);
-  {
-    // Create a local variable to capture the iterator.
-    std::string name;
-    if (auto np = dyn_cast_or_null<NamedPattern>(stmt->getPattern()))
-      name = "$"+np->getBoundName().str().str();
-    name += "$generator";
-
-    iterator = new (ctx) VarDecl(
-        /*IsStatic*/ false, VarDecl::Introducer::Var, stmt->getInLoc(),
-        ctx.getIdentifier(name), dc);
-    iterator->setInterfaceType(
-        forEachStmtInfo.iteratorType->mapTypeOutOfContext());
-    iterator->setImplicit();
-
-    auto genPat = new (ctx) NamedPattern(iterator);
-    genPat->setImplicit();
-
-    // TODO: test/DebugInfo/iteration.swift requires this extra info to
-    // be around.
-    PatternBindingDecl::createImplicit(
-        ctx, StaticSpellingKind::None, genPat,
-        new (ctx) OpaqueValueExpr(stmt->getInLoc(), nextResultType),
-        dc, /*VarLoc*/ stmt->getForLoc());
-  }
-
-  // Create the iterator variable.
-  auto *varRef = TypeChecker::buildCheckedRefExpr(
-      iterator, dc, DeclNameLoc(stmt->getInLoc()), /*implicit*/ true);
 
   // Convert that Optional<Element> value to the type of the pattern.
   auto optPatternType = OptionalType::get(forEachStmtInfo.initType);
+  Type nextResultType = OptionalType::get(forEachStmtInfo.elementType);
   if (!optPatternType->isEqual(nextResultType)) {
+    ASTContext &ctx = cs.getASTContext();
     OpaqueValueExpr *elementExpr = new (ctx) OpaqueValueExpr(
         stmt->getInLoc(), nextResultType->getOptionalObjectType(),
         /*isPlaceholder=*/true);
@@ -8702,13 +8703,25 @@ static Optional<SolutionApplicationTarget> applySolutionToForEachStmt(
     stmt->setConvertElementExpr(convertElementExpr);
   }
 
-  // Write the result back into the AST.
-  stmt->setSequence(resultTarget.getAsExpr());
-  stmt->setPattern(resultTarget.getContextualPattern().getPattern());
-  stmt->setSequenceConformance(sequenceConformance);
-  stmt->setWhere(forEachStmtInfo.whereExpr);
-  stmt->setIteratorVar(iterator);
-  stmt->setIteratorVarRef(varRef);
+  // Get the conformance of the sequence type to the Sequence protocol.
+  {
+    auto sequenceProto = TypeChecker::getProtocol(
+        cs.getASTContext(), stmt->getForLoc(),
+        stmt->getAwaitLoc().isValid() ? KnownProtocolKind::AsyncSequence
+                                      : KnownProtocolKind::Sequence);
+
+    auto type = forEachStmtInfo.sequenceType->getRValueType();
+    if (type->isExistentialType()) {
+      auto *contextualLoc = solution.getConstraintLocator(
+          parsedSequence, LocatorPathElt::ContextualType(CTP_ForEachSequence));
+      type = Type(solution.OpenedExistentialTypes[contextualLoc]);
+    }
+    auto sequenceConformance = TypeChecker::conformsToProtocol(
+        type, sequenceProto, dc->getParentModule());
+    assert(!sequenceConformance.isInvalid() &&
+           "Couldn't find sequence conformance");
+    stmt->setSequenceConformance(sequenceConformance);
+  }
 
   return resultTarget;
 }
@@ -8747,21 +8760,12 @@ ExprWalker::rewriteTarget(SolutionApplicationTarget target) {
       break;
     }
 
-    case CTP_ForEachStmt:
-    case CTP_ForEachSequence: {
-      auto forEachResultTarget = applySolutionToForEachStmt(
-          solution, target, rewrittenExpr);
-      if (!forEachResultTarget)
-        return None;
-
-      result = *forEachResultTarget;
-      break;
-    }
-
     case CTP_Unused:
     case CTP_CaseStmt:
     case CTP_ReturnStmt:
     case CTP_ExprPattern:
+    case CTP_ForEachStmt:
+    case CTP_ForEachSequence:
     case swift::CTP_ReturnSingleExpr:
     case swift::CTP_YieldByValue:
     case swift::CTP_YieldByReference:
@@ -8940,6 +8944,21 @@ ExprWalker::rewriteTarget(SolutionApplicationTarget target) {
     }
 
     return None;
+  } else if (auto *forEach = target.getAsForEachStmt()) {
+    auto forEachResultTarget = applySolutionToForEachStmt(
+        solution, target, [&](SolutionApplicationTarget target) {
+          auto resultTarget = rewriteTarget(target);
+          if (resultTarget) {
+            if (auto expr = resultTarget->getAsExpr())
+              solution.setExprTypes(expr);
+          }
+
+          return resultTarget;
+        });
+    if (!forEachResultTarget)
+      return None;
+
+    result = *forEachResultTarget;
   } else {
     auto fn = *target.getAsFunction();
     if (rewriteFunction(fn))
@@ -9218,6 +9237,9 @@ SolutionApplicationTarget SolutionApplicationTarget::walk(ASTWalker &walker) {
     return *this;
 
   case Kind::uninitializedVar:
+    return *this;
+
+  case Kind::forEachStmt:
     return *this;
   }
 

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1467,7 +1467,6 @@ void PotentialBindings::infer(Constraint *constraint) {
 
   case ConstraintKind::ValueMember:
   case ConstraintKind::UnresolvedValueMember:
-  case ConstraintKind::ValueWitness:
   case ConstraintKind::PropertyWrapper: {
     // If current type variable represents a member type of some reference,
     // it would be bound once member is resolved either to a actual member

--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -284,14 +284,6 @@ ElementInfo makeElement(ASTNode node, ConstraintLocator *locator,
   return std::make_tuple(node, context, isDiscarded, locator);
 }
 
-static ProtocolDecl *getSequenceProtocol(ASTContext &ctx, SourceLoc loc,
-                                         bool inAsyncContext) {
-  return TypeChecker::getProtocol(ctx, loc,
-                                  inAsyncContext
-                                      ? KnownProtocolKind::AsyncSequence
-                                      : KnownProtocolKind::Sequence);
-}
-
 /// Statement visitor that generates constraints for a given closure body.
 class SyntacticElementConstraintGenerator
     : public StmtVisitor<SyntacticElementConstraintGenerator, void> {
@@ -382,120 +374,18 @@ private:
   ///
   /// - From sequence to pattern, when pattern has no type information.
   void visitForEachPattern(Pattern *pattern, ForEachStmt *forEachStmt) {
-    auto &ctx = cs.getASTContext();
+    auto target = SolutionApplicationTarget::forForEachStmt(
+        forEachStmt, context.getAsDeclContext(),
+        /*bindTypeVarsOneWay=*/false);
 
-    bool isAsync = forEachStmt->getAwaitLoc().isValid();
-
-    // Verify pattern.
-    {
-      auto contextualPattern =
-          ContextualPattern::forRawPattern(pattern, context.getAsDeclContext());
-      Type patternType = TypeChecker::typeCheckPattern(contextualPattern);
-
-      if (patternType->hasError()) {
-        hadError = true;
-        return;
-      }
-    }
-
-    auto *sequenceProto =
-        getSequenceProtocol(ctx, forEachStmt->getForLoc(), isAsync);
-    if (!sequenceProto) {
+    if (cs.generateConstraints(target, FreeTypeVariableBinding::Disallow)) {
       hadError = true;
       return;
     }
-
-    auto *contextualLocator = cs.getConstraintLocator(
-        locator, LocatorPathElt::ContextualType(CTP_ForEachStmt));
-
-    // Generate constraints to initialize the pattern.
-    auto initType =
-        cs.generateConstraints(pattern, contextualLocator,
-                               /*shouldBindPatternOneWay=*/false,
-                               /*patternBinding=*/nullptr, /*patternIndex=*/0);
-
-    if (!initType) {
-      hadError = true;
-      return;
-    }
-
-    // Let's generate constraints for sequence associated with `for-in`
-    // statement. We can't do that separately because pattern can inform
-    // a type of the sequence e.g. `for in i: Int8 in 0 ..< 8 { ... }`
-
-    auto *sequenceExpr = forEachStmt->getSequence();
-    auto *sequenceLocator = cs.getConstraintLocator(sequenceExpr);
-
-    {
-      SolutionApplicationTarget target(
-          sequenceExpr, context.getAsDeclContext(), CTP_ForEachSequence,
-          sequenceProto->getDeclaredInterfaceType(),
-          /*isDiscarded=*/false);
-
-      if (cs.generateConstraints(target, FreeTypeVariableBinding::Disallow)) {
-        hadError = true;
-        return;
-      }
-
-      cs.setSolutionApplicationTarget(sequenceExpr, target);
-    }
-
-    Type sequenceType =
-        cs.createTypeVariable(sequenceLocator, TVO_CanBindToNoEscape);
-    // This "workaround" warrants an explanation for posterity.
-    //
-    // The reason why we can't simplify use \c getType(sequenceExpr) here
-    // is due to how dependent member types are handled by \c simplifyTypeImpl
-    // - if the base type didn't change (and it wouldn't because it's a fully
-    // resolved concrete type) after simplification attempt the
-    // whole dependent member type would be just re-created without attempting
-    // to resolve it, so we have to use an intermediary here so that
-    // \c elementType and \c iteratorType can be resolved correctly.
-    cs.addConstraint(ConstraintKind::Conversion, cs.getType(sequenceExpr),
-                     sequenceType, sequenceLocator);
-
-    auto elementAssocType = sequenceProto->getAssociatedType(ctx.Id_Element);
-    Type elementType = DependentMemberType::get(sequenceType, elementAssocType);
-
-    auto iteratorAssocType = sequenceProto->getAssociatedType(
-        isAsync ? ctx.Id_AsyncIterator : ctx.Id_Iterator);
-    Type iteratorType =
-        DependentMemberType::get(sequenceType, iteratorAssocType);
-
-    cs.addConstraint(
-        ConstraintKind::Conversion, elementType, initType,
-        cs.getConstraintLocator(sequenceLocator,
-                                ConstraintLocator::SequenceElementType));
-
-    // Reference the makeIterator witness.
-    FuncDecl *makeIterator = isAsync ? ctx.getAsyncSequenceMakeAsyncIterator()
-                                     : ctx.getSequenceMakeIterator();
-
-    Type makeIteratorType =
-        cs.createTypeVariable(locator, TVO_CanBindToNoEscape);
-    cs.addValueWitnessConstraint(LValueType::get(sequenceType), makeIterator,
-                                 makeIteratorType, context.getAsDeclContext(),
-                                 FunctionRefKind::Compound, contextualLocator);
 
     // After successful constraint generation, let's record
     // solution application target with all relevant information.
-    {
-      auto target = SolutionApplicationTarget::forForEachStmt(
-          forEachStmt, sequenceProto, context.getAsDeclContext(),
-          /*bindTypeVarsOneWay=*/false,
-          /*contextualPurpose=*/CTP_ForEachSequence);
-
-      auto &targetInfo = target.getForEachStmtInfo();
-
-      targetInfo.sequenceType = sequenceType;
-      targetInfo.elementType = elementType;
-      targetInfo.iteratorType = iteratorType;
-      targetInfo.initType = initType;
-
-      target.setPattern(pattern);
-
-      cs.setSolutionApplicationTarget(forEachStmt, target);
-    }
+    cs.setSolutionApplicationTarget(forEachStmt, target);
   }
 
   void visitCaseItemPattern(Pattern *pattern, ContextualTypeInfo context) {
@@ -805,28 +695,10 @@ private:
 
     // For-each pattern.
     //
-    // Note that we don't record a sequence here, it would
-    // be handled together with pattern because pattern can
+    // Note that we don't record a sequence or where clause here,
+    // they would be handled together with pattern because pattern can
     // inform a type of sequence element e.g. `for i: Int8 in 0 ..< 8`
-    {
-      Pattern *pattern = TypeChecker::resolvePattern(forEachStmt->getPattern(),
-                                                     context.getAsDeclContext(),
-                                                     /*isStmtCondition=*/false);
-
-      if (!pattern) {
-        hadError = true;
-        return;
-      }
-
-      elements.push_back(makeElement(pattern, stmtLoc));
-    }
-
-    // `where` clause if any.
-    if (auto *whereClause = forEachStmt->getWhere()) {
-      elements.push_back(
-          makeElement(whereClause, stmtLoc, getContextForCondition()));
-    }
-
+    elements.push_back(makeElement(forEachStmt->getPattern(), stmtLoc));
     // Body of the `for-in` loop.
     elements.push_back(makeElement(forEachStmt->getBody(), stmtLoc));
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2327,7 +2327,12 @@ bool AddExplicitExistentialCoercion::isRequired(
   if (auto *anchor = getAsExpr(locator.getAnchor())) {
     // If this is erasure related to `Self`, let's look through
     // the call, if any.
-    if (isa<UnresolvedDotExpr>(anchor)) {
+    if (auto *UDE = dyn_cast<UnresolvedDotExpr>(anchor)) {
+      // If this is an implicit `makeIterator` call, let's skip the check.
+      if (UDE->isImplicit() &&
+          cs.getContextualTypePurpose(UDE->getBase()) == CTP_ForEachSequence)
+        return false;
+
       auto parentExpr = cs.getParentExpr(anchor);
       if (parentExpr && isa<CallExpr>(parentExpr))
         anchor = parentExpr;

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3886,44 +3886,115 @@ static bool generateInitPatternConstraints(
   return false;
 }
 
-/// Generate constraints for a for-each statement.
 static Optional<SolutionApplicationTarget>
 generateForEachStmtConstraints(
-    ConstraintSystem &cs, SolutionApplicationTarget target, Expr *sequence) {
+  ConstraintSystem &cs, SolutionApplicationTarget target) {
+  ASTContext &ctx = cs.getASTContext();
   auto forEachStmtInfo = target.getForEachStmtInfo();
-  ForEachStmt *stmt = forEachStmtInfo.stmt;
+  ForEachStmt *stmt = target.getAsForEachStmt();
   bool isAsync = stmt->getAwaitLoc().isValid();
-
-  auto locator = cs.getConstraintLocator(sequence);
+  auto *sequenceExpr = stmt->getParsedSequence();
+  auto *dc = target.getDeclContext();
   auto contextualLocator = cs.getConstraintLocator(
-      sequence, LocatorPathElt::ContextualType(CTP_ForEachStmt));
+      sequenceExpr, LocatorPathElt::ContextualType(CTP_ForEachSequence));
 
   // The expression type must conform to the Sequence protocol.
   auto sequenceProto = TypeChecker::getProtocol(
-      cs.getASTContext(), stmt->getForLoc(), 
-      isAsync ? 
-      KnownProtocolKind::AsyncSequence : KnownProtocolKind::Sequence);
-  if (!sequenceProto) {
+      cs.getASTContext(), stmt->getForLoc(),
+      isAsync ? KnownProtocolKind::AsyncSequence : KnownProtocolKind::Sequence);
+  if (!sequenceProto)
     return None;
+
+  std::string name;
+  {
+    if (auto np = dyn_cast_or_null<NamedPattern>(stmt->getPattern()))
+      name = "$"+np->getBoundName().str().str();
+    name += "$generator";
   }
 
-  Type sequenceType = cs.createTypeVariable(locator, TVO_CanBindToNoEscape);
-  cs.addConstraint(ConstraintKind::Conversion, cs.getType(sequence),
-                   sequenceType, locator);
-  cs.addConstraint(ConstraintKind::ConformsTo, sequenceType,
-                   sequenceProto->getDeclaredInterfaceType(),
-                   contextualLocator);
+  auto *makeIteratorVar = new (ctx)
+      VarDecl(/*isStatic=*/false, VarDecl::Introducer::Var,
+              sequenceExpr->getStartLoc(), ctx.getIdentifier(name), dc);
+  makeIteratorVar->setImplicit();
 
-  // Check the element pattern.
-  ASTContext &ctx = cs.getASTContext();
-  auto dc = target.getDeclContext();
+  // First, let's form a call from sequence to `.makeIterator()` and save
+  // that in a special variable which is going to be used by SILGen.
+  {
+    FuncDecl *makeIterator = isAsync ? ctx.getAsyncSequenceMakeAsyncIterator()
+                                     : ctx.getSequenceMakeIterator();
+
+    auto *makeIteratorRef = UnresolvedDotExpr::createImplicit(
+        ctx, sequenceExpr, makeIterator->getName());
+    makeIteratorRef->setFunctionRefKind(FunctionRefKind::SingleApply);
+
+    auto *makeIteratorCall =
+        CallExpr::createImplicitEmpty(ctx, makeIteratorRef);
+
+    Pattern *pattern = NamedPattern::createImplicit(ctx, makeIteratorVar);
+    auto *PB = PatternBindingDecl::createImplicit(
+        ctx, StaticSpellingKind::None, pattern, makeIteratorCall, dc);
+
+    auto makeIteratorTarget = SolutionApplicationTarget::forInitialization(
+        makeIteratorCall, dc, /*patternType=*/Type(), PB, /*index=*/0,
+        /*shouldBindPatternsOneWay=*/false);
+
+    cs.setContextualType(
+        sequenceExpr,
+        TypeLoc::withoutLoc(sequenceProto->getDeclaredInterfaceType()),
+        CTP_ForEachSequence);
+
+    if (cs.generateConstraints(makeIteratorTarget,
+                               FreeTypeVariableBinding::Disallow))
+      return None;
+
+    forEachStmtInfo.makeIteratorVar = PB;
+
+    // Type of sequence expression has to conform to Sequence protocol.
+    {
+      cs.addConstraint(ConstraintKind::ConformsTo, cs.getType(sequenceExpr),
+                       sequenceProto->getDeclaredInterfaceType(),
+                       contextualLocator);
+
+      forEachStmtInfo.sequenceType = cs.getType(sequenceExpr);
+    }
+
+    cs.setSolutionApplicationTarget({PB, /*index=*/0}, makeIteratorTarget);
+  }
+
+  // Now, result type of `.makeIterator()` is used to form a call to
+  // `.next()`. `next()` is called on each iteration of the loop.
+  {
+    auto *nextRef = UnresolvedDotExpr::createImplicit(
+      ctx,
+      new (ctx) DeclRefExpr(makeIteratorVar, DeclNameLoc(),
+                            /*Implicit=*/true),
+      ctx.Id_next, /*labels=*/ArrayRef<Identifier>());
+    nextRef->setFunctionRefKind(FunctionRefKind::SingleApply);
+
+    Expr *nextCall = CallExpr::createImplicitEmpty(ctx, nextRef);
+
+    // `next` is always async but witness might not be throwing
+    if (isAsync) {
+      nextCall =
+          AwaitExpr::createImplicit(ctx, /*awaitLoc=*/SourceLoc(), nextCall);
+    }
+
+    SolutionApplicationTarget nextTarget(nextCall, dc, CTP_Unused,
+                                         /*contextualType=*/Type(),
+                                         /*isDiscarded=*/false);
+    if (cs.generateConstraints(nextTarget, FreeTypeVariableBinding::Disallow))
+      return None;
+
+    forEachStmtInfo.nextCall = nextTarget.getAsExpr();
+    cs.setSolutionApplicationTarget(forEachStmtInfo.nextCall, nextTarget);
+  }
+
   Pattern *pattern = TypeChecker::resolvePattern(stmt->getPattern(), dc,
-                                                 /*isStmtCondition*/false);
+                                                 /*isStmtCondition*/ false);
   if (!pattern)
     return None;
 
-  auto contextualPattern =
-      ContextualPattern::forRawPattern(pattern, dc);
+  auto contextualPattern = ContextualPattern::forRawPattern(pattern, dc);
   Type patternType = TypeChecker::typeCheckPattern(contextualPattern);
   if (patternType->hasError()) {
     return None;
@@ -3931,48 +4002,32 @@ generateForEachStmtConstraints(
 
   // Collect constraints from the element pattern.
   auto elementLocator = cs.getConstraintLocator(
-    contextualLocator, ConstraintLocator::SequenceElementType);
-  Type initType = cs.generateConstraints(
-      pattern, contextualLocator, target.shouldBindPatternVarsOneWay(),
-      nullptr, 0);
+      sequenceExpr, ConstraintLocator::SequenceElementType);
+  Type initType =
+      cs.generateConstraints(pattern, elementLocator,
+                             target.shouldBindPatternVarsOneWay(), nullptr, 0);
   if (!initType)
     return None;
 
   // Add a conversion constraint between the element type of the sequence
   // and the type of the element pattern.
-  auto elementAssocType =
-      sequenceProto->getAssociatedType(cs.getASTContext().Id_Element);
-  Type elementType = DependentMemberType::get(sequenceType, elementAssocType);
-  cs.addConstraint(ConstraintKind::Conversion, elementType, initType,
-                   elementLocator);
-
-  // Determine the iterator type.
-  auto iteratorAssocType =
-      sequenceProto->getAssociatedType(isAsync ? 
-        cs.getASTContext().Id_AsyncIterator : cs.getASTContext().Id_Iterator);
-  Type iteratorType = DependentMemberType::get(sequenceType, iteratorAssocType);
-
-  // The iterator type must conform to IteratorProtocol.
-  ProtocolDecl *iteratorProto = TypeChecker::getProtocol(
-      cs.getASTContext(), stmt->getForLoc(),
-      isAsync ? 
-        KnownProtocolKind::AsyncIteratorProtocol : KnownProtocolKind::IteratorProtocol);
-  if (!iteratorProto)
-    return None;
-
-  // Reference the makeIterator witness.
-  FuncDecl *makeIterator = isAsync ? 
-    ctx.getAsyncSequenceMakeAsyncIterator() : ctx.getSequenceMakeIterator();
-  
-  Type makeIteratorType =
-      cs.createTypeVariable(locator, TVO_CanBindToNoEscape);
-  cs.addValueWitnessConstraint(
-      LValueType::get(sequenceType), makeIterator,
-      makeIteratorType, dc, FunctionRefKind::Compound,
-      contextualLocator);
+  auto *elementTypeLoc = cs.getConstraintLocator(
+      elementLocator, ConstraintLocator::OptionalPayload);
+  auto elementType = cs.createTypeVariable(elementTypeLoc,
+                                           /*flags=*/0);
+  {
+    auto nextType = cs.getType(forEachStmtInfo.nextCall);
+    // Note that `OptionalObject` is not used here. This is due to inference
+    // behavior where it would bind `elementType` to the `initType` before
+    // resolving `optional object` constraint which is sometimes too eager.
+    cs.addConstraint(ConstraintKind::Conversion, nextType,
+                     OptionalType::get(elementType), elementTypeLoc);
+    cs.addConstraint(ConstraintKind::Conversion, elementType, initType,
+                     elementLocator);
+  }
 
   // Generate constraints for the "where" expression, if there is one.
-  if (forEachStmtInfo.whereExpr) {
+  if (auto *whereExpr = stmt->getWhere()) {
     auto *boolDecl = dc->getASTContext().getBoolDecl();
     if (!boolDecl)
       return None;
@@ -3981,23 +4036,20 @@ generateForEachStmtConstraints(
     if (!boolType)
       return None;
 
-    SolutionApplicationTarget whereTarget(
-        forEachStmtInfo.whereExpr, dc, CTP_Condition, boolType,
-        /*isDiscarded=*/false);
+    SolutionApplicationTarget whereTarget(whereExpr, dc, CTP_Condition,
+                                          boolType,
+                                          /*isDiscarded=*/false);
     if (cs.generateConstraints(whereTarget, FreeTypeVariableBinding::Disallow))
       return None;
 
-    cs.setContextualType(forEachStmtInfo.whereExpr,
-                         TypeLoc::withoutLoc(boolType), CTP_Condition);
-
-    forEachStmtInfo.whereExpr = whereTarget.getAsExpr();
+    cs.setSolutionApplicationTarget(whereExpr, whereTarget);
+    cs.setContextualType(whereExpr, TypeLoc::withoutLoc(boolType),
+                         CTP_Condition);
   }
 
   // Populate all of the information for a for-each loop.
   forEachStmtInfo.elementType = elementType;
-  forEachStmtInfo.iteratorType = iteratorType;
   forEachStmtInfo.initType = initType;
-  forEachStmtInfo.sequenceType = sequenceType;
   target.setPattern(pattern);
   target.getForEachStmtInfo() = forEachStmtInfo;
   return target;
@@ -4080,16 +4132,6 @@ bool ConstraintSystem::generateConstraints(
     if (target.getExprContextualTypePurpose() == CTP_Initialization &&
         generateInitPatternConstraints(*this, target, expr)) {
       return true;
-    }
-
-    // For a for-each statement, generate constraints for the pattern, where
-    // clause, and sequence traversal.
-    if (target.getExprContextualTypePurpose() == CTP_ForEachStmt) {
-      auto resultTarget = generateForEachStmtConstraints(*this, target, expr);
-      if (!resultTarget)
-        return true;
-
-      target = *resultTarget;
     }
 
     if (isDebugMode()) {
@@ -4186,6 +4228,17 @@ bool ConstraintSystem::generateConstraints(
 
       return !patternType;
     }
+  }
+
+  case SolutionApplicationTarget::Kind::forEachStmt: {
+    // For a for-each statement, generate constraints for the pattern, where
+    // clause, and sequence traversal.
+    auto resultTarget = generateForEachStmtConstraints(*this, target);
+    if (!resultTarget)
+      return true;
+
+    target = *resultTarget;
+    return false;
   }
   }
 }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2185,7 +2185,6 @@ ConstraintSystem::matchTupleTypes(TupleType *tuple1, TupleType *tuple2,
   case ConstraintKind::SelfObjectOfProtocol:
   case ConstraintKind::UnresolvedValueMember:
   case ConstraintKind::ValueMember:
-  case ConstraintKind::ValueWitness:
   case ConstraintKind::BridgingConversion:
   case ConstraintKind::OneWayEqual:
   case ConstraintKind::OneWayBindParam:
@@ -2349,7 +2348,6 @@ static bool matchFunctionRepresentations(FunctionType::ExtInfo einfo1,
   case ConstraintKind::SelfObjectOfProtocol:
   case ConstraintKind::UnresolvedValueMember:
   case ConstraintKind::ValueMember:
-  case ConstraintKind::ValueWitness:
   case ConstraintKind::OneWayEqual:
   case ConstraintKind::OneWayBindParam:
   case ConstraintKind::DefaultClosureType:
@@ -2796,7 +2794,6 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
   case ConstraintKind::SelfObjectOfProtocol:
   case ConstraintKind::UnresolvedValueMember:
   case ConstraintKind::ValueMember:
-  case ConstraintKind::ValueWitness:
   case ConstraintKind::BridgingConversion:
   case ConstraintKind::OneWayEqual:
   case ConstraintKind::OneWayBindParam:
@@ -3222,8 +3219,13 @@ ConstraintSystem::matchDeepEqualityTypes(Type type1, Type type2,
     auto opaque1 = cast<OpaqueTypeArchetypeType>(arch1);
     auto opaque2 = cast<OpaqueTypeArchetypeType>(arch2);
     assert(opaque1->getDecl() == opaque2->getDecl());
-    assert(opaque1->getCanonicalInterfaceType(arch1->getInterfaceType())->isEqual(
-               opaque2->getCanonicalInterfaceType(arch2->getInterfaceType())));
+
+    // It's possible to declare a generic requirement like Self == Self.Iterator
+    // where both types are going to be opaque.
+    if (!opaque1->getCanonicalInterfaceType(arch1->getInterfaceType())
+             ->isEqual(
+                 opaque2->getCanonicalInterfaceType(arch2->getInterfaceType())))
+      return getTypeMatchFailure(locator);
 
     auto args1 = opaque1->getSubstitutions().getReplacementTypes();
     auto args2 = opaque2->getSubstitutions().getReplacementTypes();
@@ -5351,6 +5353,19 @@ bool ConstraintSystem::repairFailures(
     if (isFixedRequirement(reqLoc, rhs))
       return true;
 
+    // If this is a requirement on sequence of for-in statement where one
+    // of the sides is a completely resolved dependent member, skip it
+    // since the issue is with the conformance to `Sequence`, otherwise
+    // dependent member would have been substituted.
+    if (auto *UDE = getAsExpr<UnresolvedDotExpr>(anchor)) {
+      if (UDE->isImplicit() &&
+          getContextualTypePurpose(UDE->getBase()) == CTP_ForEachSequence) {
+        if ((lhs->is<DependentMemberType>() && !lhs->hasTypeVariable()) ||
+            (rhs->is<DependentMemberType>() && !rhs->hasTypeVariable()))
+          return true;
+      }
+    }
+
     if (auto *fix = fixRequirementFailure(*this, lhs, rhs, anchor, path)) {
       recordFixedRequirement(reqLoc, rhs);
       conversionsOrFixes.push_back(fix);
@@ -6019,7 +6034,6 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
     case ConstraintKind::SelfObjectOfProtocol:
     case ConstraintKind::UnresolvedValueMember:
     case ConstraintKind::ValueMember:
-    case ConstraintKind::ValueWitness:
     case ConstraintKind::OneWayEqual:
     case ConstraintKind::OneWayBindParam:
     case ConstraintKind::DefaultClosureType:
@@ -7136,6 +7150,16 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
   } break;
   case ConstraintKind::ConformsTo:
   case ConstraintKind::LiteralConformsTo: {
+    // If existential type is used as a for-in sequence, let's open it
+    // and check whether underlying type conforms to `Sequence`.
+    if (type->isExistentialType()) {
+      if (auto elt = loc->getLastElementAs<LocatorPathElt::ContextualType>()) {
+        if (elt->getPurpose() == CTP_ForEachSequence) {
+          type = openExistentialType(type, loc).first;
+        }
+      }
+    }
+
     // Check whether this type conforms to the protocol.
     auto conformance = DC->getParentModule()->lookupConformance(
         type, protocol, /*allowMissing=*/true);
@@ -9099,8 +9123,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
         markMemberTypeAsPotentialHole(memberTy);
         return SolutionKind::Solved;
       }
-    } else if ((kind == ConstraintKind::ValueMember ||
-                kind == ConstraintKind::ValueWitness) &&
+    } else if (kind == ConstraintKind::ValueMember &&
                baseObjTy->getMetatypeInstanceType()->isPlaceholder()) {
       // If base type is a "hole" there is no reason to record any
       // more "member not found" fixes for chained member references.
@@ -9258,6 +9281,35 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
         return type;
       });
 
+      auto success = [&]() -> SolutionKind {
+        // Record a hole for memberTy to make it possible to form solutions
+        // when contextual result type cannot be deduced e.g. `let _ = x.foo`.
+        if (auto *memberTypeVar = memberTy->getAs<TypeVariableType>()) {
+          if (getFixedType(memberTypeVar)) {
+            // If member has been bound before the base and the base was
+            // incorrect at that (e.g. fallback to default `Any` type),
+            // then we need to re-activate all of the constraints
+            // associated with this member reference otherwise some of
+            // the constraints could be left unchecked in inactive state.
+            // This is especially important for key path expressions because
+            // `key path` constraint can't be retired until all components
+            // are simplified.
+            addTypeVariableConstraintsToWorkList(memberTypeVar);
+          } else if (locator->isLastElement<LocatorPathElt::PatternMatch>()) {
+            // Let's handle member patterns specifically because they use
+            // equality instead of argument application constraint, so allowing
+            // them to bind member could mean missing valid hole positions in
+            // the pattern.
+            assignFixedType(memberTypeVar, PlaceholderType::get(getASTContext(),
+                                                                memberTypeVar));
+          } else {
+            recordPotentialHole(memberTypeVar);
+          }
+        }
+
+        return SolutionKind::Solved;
+      };
+
       bool alreadyDiagnosed = (result.OverallResult ==
                                MemberLookupResult::ErrorAlreadyDiagnosed);
       auto *fix = DefineMemberBasedOnUse::create(*this, baseTy, member,
@@ -9275,42 +9327,37 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
       if (instanceTy->isAny() || instanceTy->isAnyObject())
         impact += 5;
 
-      // Increasing the impact for missing member in any argument position so it
-      // doesn't affect situations where there are another fixes involved.
       auto *anchorExpr = getAsExpr(locator->getAnchor());
-      if (anchorExpr && getArgumentLocator(anchorExpr)) {
-        impact += 5;
+      if (anchorExpr) {
+        if (auto *UDE = dyn_cast<UnresolvedDotExpr>(anchorExpr)) {
+          // The issue is related to a missing `Sequence` protocol
+          // conformance if either `makeIterator` or `next` are missing.
+          if (UDE->isImplicit()) {
+            // Missing `makeIterator` since the base is sequence expression.
+            if (getContextualTypePurpose(UDE->getBase()) == CTP_ForEachSequence)
+              return success();
+
+            // Missing `next` where the base is result of `makeIterator`.
+            if (auto *base = dyn_cast<DeclRefExpr>(UDE->getBase())) {
+              if (auto var = dyn_cast_or_null<VarDecl>(base->getDecl())) {
+                if (var->getNameStr().contains("$generator") &&
+                    UDE->getName().getBaseIdentifier() == Context.Id_next)
+                  return success();
+              }
+            }
+          }
+        }
+
+        // Increasing the impact for missing member in any argument position so
+        // it doesn't affect situations where there are another fixes involved.
+        if (getArgumentLocator(anchorExpr))
+          impact += 5;
       }
 
       if (recordFix(fix, impact))
         return SolutionKind::Error;
 
-      // Record a hole for memberTy to make it possible to form solutions
-      // when contextual result type cannot be deduced e.g. `let _ = x.foo`.
-      if (auto *memberTypeVar = memberTy->getAs<TypeVariableType>()) {
-        if (getFixedType(memberTypeVar)) {
-          // If member has been bound before the base and the base was
-          // incorrect at that (e.g. fallback to default `Any` type),
-          // then we need to re-activate all of the constraints
-          // associated with this member reference otherwise some of
-          // the constraints could be left unchecked in inactive state.
-          // This is especially important for key path expressions because
-          // `key path` constraint can't be retired until all components
-          // are simplified.
-          addTypeVariableConstraintsToWorkList(memberTypeVar);
-        } else if (locator->isLastElement<LocatorPathElt::PatternMatch>()) {
-          // Let's handle member patterns specifically because they use
-          // equality instead of argument application constraint, so allowing
-          // them to bind member could mean missing valid hole positions in
-          // the pattern.
-          assignFixedType(memberTypeVar,
-                          PlaceholderType::get(getASTContext(), memberTypeVar));
-        } else {
-          recordPotentialHole(memberTypeVar);
-        }
-      }
-
-      return SolutionKind::Solved;
+      return success();
     };
 
     if (baseObjTy->getOptionalObjectType()) {
@@ -9496,67 +9543,6 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
     return fixMissingMember(origBaseTy, memberTy, locator);
   }
   return SolutionKind::Error;
-}
-
-ConstraintSystem::SolutionKind
-ConstraintSystem::simplifyValueWitnessConstraint(
-    ConstraintKind kind, Type baseType, ValueDecl *requirement, Type memberType,
-    DeclContext *useDC, FunctionRefKind functionRefKind,
-    TypeMatchOptions flags, ConstraintLocatorBuilder locator) {
-  // We'd need to record original base type because it might be a type
-  // variable representing another missing member.
-  auto origBaseType = baseType;
-
-  auto formUnsolved = [&] {
-    // If requested, generate a constraint.
-    if (flags.contains(TMF_GenerateConstraints)) {
-      auto *witnessConstraint = Constraint::createValueWitness(
-          *this, kind, origBaseType, memberType, requirement, useDC,
-          functionRefKind, getConstraintLocator(locator));
-
-      addUnsolvedConstraint(witnessConstraint);
-      return SolutionKind::Solved;
-    }
-
-    return SolutionKind::Unsolved;
-  };
-
-  // Resolve the base type, if we can. If we can't resolve the base type,
-  // then we can't solve this constraint.
-  Type baseObjectType = getFixedTypeRecursive(
-      baseType, flags, /*wantRValue=*/true);
-  if (baseObjectType->isTypeVariableOrMember()) {
-    return formUnsolved();
-  }
-
-  // Check conformance to the protocol. If it doesn't conform, this constraint
-  // fails. Don't attempt to fix it.
-  // FIXME: Look in the constraint system to see if we've resolved the
-  // conformance already?
-  auto proto = requirement->getDeclContext()->getSelfProtocolDecl();
-  assert(proto && "Value witness constraint for a non-requirement");
-  auto conformance = useDC->getParentModule()->lookupConformance(
-      baseObjectType, proto);
-  if (!conformance) {
-    // The conformance failed, so mark the member type as a "hole". We cannot
-    // do anything further here.
-    if (!shouldAttemptFixes())
-      return SolutionKind::Error;
-
-    recordAnyTypeVarAsPotentialHole(memberType);
-
-    return SolutionKind::Solved;
-  }
-
-  // Reference the requirement.
-  Type resolvedBaseType = simplifyType(baseType, flags);
-  if (resolvedBaseType->isTypeVariableOrMember())
-    return formUnsolved();
-
-  auto choice = OverloadChoice(resolvedBaseType, requirement, functionRefKind);
-  resolveOverload(getConstraintLocator(locator), memberType, choice,
-                  useDC);
-  return SolutionKind::Solved;
 }
 
 ConstraintSystem::SolutionKind ConstraintSystem::simplifyDefaultableConstraint(
@@ -13212,7 +13198,6 @@ ConstraintSystem::addConstraintImpl(ConstraintKind kind, Type first,
 
   case ConstraintKind::ValueMember:
   case ConstraintKind::UnresolvedValueMember:
-  case ConstraintKind::ValueWitness:
   case ConstraintKind::BindOverload:
   case ConstraintKind::Disjunction:
   case ConstraintKind::Conjunction:
@@ -13702,16 +13687,6 @@ ConstraintSystem::simplifyConstraint(const Constraint &constraint) {
                                     constraint.getFunctionRefKind(),
                                     /*outerAlternatives=*/{},
                                     /*flags*/ None, constraint.getLocator());
-
-  case ConstraintKind::ValueWitness:
-    return simplifyValueWitnessConstraint(constraint.getKind(),
-                                          constraint.getFirstType(),
-                                          constraint.getRequirement(),
-                                          constraint.getSecondType(),
-                                          constraint.getMemberUseDC(),
-                                          constraint.getFunctionRefKind(),
-                                          /*flags*/ None,
-                                          constraint.getLocator());
 
   case ConstraintKind::Defaultable:
     return simplifyDefaultableConstraint(constraint.getFirstType(),

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1552,15 +1552,16 @@ void ConstraintSystem::solveForCodeCompletion(
 
 bool ConstraintSystem::solveForCodeCompletion(
     SolutionApplicationTarget &target, SmallVectorImpl<Solution> &solutions) {
-  auto *expr = target.getAsExpr();
-  // Tell the constraint system what the contextual type is.
-  setContextualType(expr, target.getExprContextualTypeLoc(),
-                    target.getExprContextualTypePurpose());
+  if (auto *expr = target.getAsExpr()) {
+    // Tell the constraint system what the contextual type is.
+    setContextualType(expr, target.getExprContextualTypeLoc(),
+                      target.getExprContextualTypePurpose());
 
-  // Set up the expression type checker timer.
-  Timer.emplace(expr, *this);
+    // Set up the expression type checker timer.
+    Timer.emplace(expr, *this);
 
-  shrink(expr);
+    shrink(expr);
+  }
 
   if (isDebugMode()) {
     auto &log = llvm::errs();

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -90,7 +90,6 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second,
 
   case ConstraintKind::ValueMember:
   case ConstraintKind::UnresolvedValueMember:
-  case ConstraintKind::ValueWitness:
     llvm_unreachable("Wrong constructor for member constraint");
 
   case ConstraintKind::Defaultable:
@@ -150,7 +149,6 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second, Type Third,
   case ConstraintKind::ApplicableFunction:
   case ConstraintKind::DynamicCallableApplicableFunction:
   case ConstraintKind::ValueMember:
-  case ConstraintKind::ValueWitness:
   case ConstraintKind::UnresolvedValueMember:
   case ConstraintKind::Defaultable:
   case ConstraintKind::BindOverload:
@@ -192,28 +190,6 @@ Constraint::Constraint(ConstraintKind kind, Type first, Type second,
   TheFunctionRefKind = static_cast<unsigned>(functionRefKind);
   assert(getFunctionRefKind() == functionRefKind);
   assert(member && "Member constraint has no member");
-  assert(useDC && "Member constraint has no use DC");
-
-  std::copy(typeVars.begin(), typeVars.end(), getTypeVariablesBuffer().begin());
-}
-
-Constraint::Constraint(ConstraintKind kind, Type first, Type second,
-                       ValueDecl *requirement, DeclContext *useDC,
-                       FunctionRefKind functionRefKind,
-                       ConstraintLocator *locator,
-                       SmallPtrSetImpl<TypeVariableType *> &typeVars)
-    : Kind(kind), HasRestriction(false), IsActive(false), IsDisabled(false),
-      IsDisabledForPerformance(false), RememberChoice(false), IsFavored(false),
-      IsIsolated(false), NumTypeVariables(typeVars.size()), Locator(locator) {
-  Member.First = first;
-  Member.Second = second;
-  Member.Member.Ref = requirement;
-  Member.UseDC = useDC;
-  TheFunctionRefKind = static_cast<unsigned>(functionRefKind);
-
-  assert(kind == ConstraintKind::ValueWitness);
-  assert(getFunctionRefKind() == functionRefKind);
-  assert(requirement && "Value witness constraint has no requirement");
   assert(useDC && "Member constraint has no use DC");
 
   std::copy(typeVars.begin(), typeVars.end(), getTypeVariablesBuffer().begin());
@@ -323,11 +299,6 @@ Constraint *Constraint::clone(ConstraintSystem &cs) const {
     return createMember(cs, getKind(), getFirstType(), getSecondType(),
                         getMember(), getMemberUseDC(), getFunctionRefKind(),
                         getLocator());
-
-  case ConstraintKind::ValueWitness:
-    return createValueWitness(
-        cs, getKind(), getFirstType(), getSecondType(), getRequirement(),
-        getMemberUseDC(), getFunctionRefKind(), getLocator());
 
   case ConstraintKind::Disjunction:
     return createDisjunction(
@@ -509,14 +480,6 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm) const {
     Out << "[(implicit) ." << getMember() << ": value] == ";
     break;
 
-  case ConstraintKind::ValueWitness: {
-    auto requirement = getRequirement();
-    auto selfNominal = requirement->getDeclContext()->getSelfNominalTypeDecl();
-    Out << "[." << selfNominal->getName() << "::" << requirement->getName()
-        << ": witness] == ";
-    break;
-  }
-
   case ConstraintKind::Defaultable:
     Out << " can default to ";
     break;
@@ -674,7 +637,6 @@ gatherReferencedTypeVars(Constraint *constraint,
   case ConstraintKind::Subtype:
   case ConstraintKind::UnresolvedValueMember:
   case ConstraintKind::ValueMember:
-  case ConstraintKind::ValueWitness:
   case ConstraintKind::DynamicTypeOf:
   case ConstraintKind::EscapableFunctionOf:
   case ConstraintKind::OpenedExistentialOf:
@@ -817,26 +779,6 @@ Constraint *Constraint::createMember(ConstraintSystem &cs, ConstraintKind kind,
   unsigned size = totalSizeToAlloc<TypeVariableType*>(typeVars.size());
   void *mem = cs.getAllocator().Allocate(size, alignof(Constraint));
   return new (mem) Constraint(kind, first, second, member, useDC,
-                              functionRefKind, locator, typeVars);
-}
-
-Constraint *Constraint::createValueWitness(
-    ConstraintSystem &cs, ConstraintKind kind, Type first, Type second,
-    ValueDecl *requirement, DeclContext *useDC,
-    FunctionRefKind functionRefKind, ConstraintLocator *locator) {
-  assert(kind == ConstraintKind::ValueWitness);
-
-  // Collect type variables.
-  SmallPtrSet<TypeVariableType *, 4> typeVars;
-  if (first->hasTypeVariable())
-    first->getTypeVariables(typeVars);
-  if (second->hasTypeVariable())
-    second->getTypeVariables(typeVars);
-
-  // Create the constraint.
-  unsigned size = totalSizeToAlloc<TypeVariableType*>(typeVars.size());
-  void *mem = cs.getAllocator().Allocate(size, alignof(Constraint));
-  return new (mem) Constraint(kind, first, second, requirement, useDC,
                               functionRefKind, locator, typeVars);
 }
 

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3753,7 +3753,7 @@ static void checkStmtConditionTrailingClosure(ASTContext &ctx, const Stmt *S) {
   } else if (auto SS = dyn_cast<SwitchStmt>(S)) {
     checkStmtConditionTrailingClosure(ctx, SS->getSubjectExpr());
   } else if (auto FES = dyn_cast<ForEachStmt>(S)) {
-    checkStmtConditionTrailingClosure(ctx, FES->getSequence());
+    checkStmtConditionTrailingClosure(ctx, FES->getParsedSequence());
     checkStmtConditionTrailingClosure(ctx, FES->getWhere());
   } else if (auto DCS = dyn_cast<DoCatchStmt>(S)) {
     for (auto CS : DCS->getCatches())
@@ -5359,22 +5359,10 @@ bool swift::diagnoseUnhandledThrowsInAsyncContext(DeclContext *dc,
   if (!forEach->getAwaitLoc().isValid())
     return false;
 
-  auto &ctx = dc->getASTContext();
-
-  auto sequenceProto = TypeChecker::getProtocol(
-      ctx, forEach->getForLoc(), KnownProtocolKind::AsyncSequence);
-
-  if (!sequenceProto)
-    return false;
-
-  // fetch the sequence out of the statement
-  // else wise the value is potentially unresolved
-  auto Ty = forEach->getSequence()->getType();
-  auto module = dc->getParentModule();
-  auto conformanceRef = module->lookupConformance(Ty, sequenceProto);
-
+  auto conformanceRef = forEach->getSequenceConformance();
   if (conformanceRef.hasEffect(EffectKind::Throws) &&
       forEach->getTryLoc().isInvalid()) {
+    auto &ctx = dc->getASTContext();
     ctx.Diags
         .diagnose(forEach->getAwaitLoc(), diag::throwing_call_unhandled, "call")
         .fixItInsert(forEach->getAwaitLoc(), "try");

--- a/lib/Sema/PCMacro.cpp
+++ b/lib/Sema/PCMacro.cpp
@@ -224,7 +224,7 @@ public:
 
       // point at the for stmt, to look nice
       SourceLoc StartLoc = FES->getStartLoc();
-      SourceLoc EndLoc = FES->getSequence()->getEndLoc();
+      SourceLoc EndLoc = FES->getParsedSequence()->getEndLoc();
       // FIXME: get the 'end' of the for stmt
       // if (FD->getResultTypeRepr()) {
       //   EndLoc = FD->getResultTypeSourceRange().End;

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -2129,19 +2129,27 @@ bool ConstraintSystem::preCheckTarget(SolutionApplicationTarget &target,
   }
 
   if (target.isForEachStmt()) {
-    auto &info = target.getForEachStmtInfo();
+    auto *stmt = target.getAsForEachStmt();
 
-    if (info.whereExpr)
-      hadErrors |= preCheckExpression(info.whereExpr, DC,
+    auto *sequenceExpr = stmt->getParsedSequence();
+    auto *whereExpr = stmt->getWhere();
+
+    hadErrors |= preCheckExpression(sequenceExpr, DC,
+                                    /*replaceInvalidRefsWithErrors=*/true,
+                                    /*leaveClosureBodiesUnchecked=*/false);
+
+    if (whereExpr) {
+      hadErrors |= preCheckExpression(whereExpr, DC,
                                       /*replaceInvalidRefsWithErrors=*/true,
                                       /*leaveClosureBodiesUnchecked=*/false);
+    }
 
     // Update sequence and where expressions to pre-checked versions.
     if (!hadErrors) {
-      info.stmt->setSequence(target.getAsExpr());
+      stmt->setParsedSequence(sequenceExpr);
 
-      if (info.whereExpr)
-        info.stmt->setWhere(info.whereExpr);
+      if (whereExpr)
+        stmt->setWhere(whereExpr);
     }
   }
 

--- a/lib/Sema/TypeCheckCodeCompletion.cpp
+++ b/lib/Sema/TypeCheckCodeCompletion.cpp
@@ -562,29 +562,20 @@ bool TypeChecker::typeCheckForCodeCompletion(
     llvm::function_ref<void(const Solution &)> callback) {
   auto *DC = target.getDeclContext();
   auto &Context = DC->getASTContext();
-
-  auto *expr = target.getAsExpr();
-  if (!expr)
-    return false;
-
   // First of all, let's check whether given target expression
   // does indeed have the code completion location in it.
   {
-    auto range = expr->getSourceRange();
+    auto range = target.getSourceRange();
     if (range.isInvalid() ||
         !Context.SourceMgr.rangeContainsCodeCompletionLoc(range))
       return false;
   }
 
-  FrontendStatsTracer StatsTracer(Context.Stats,
-                                  "typecheck-for-code-completion", expr);
-  PrettyStackTraceExpr stackTrace(Context, "code-completion", expr);
+  auto node = target.getAsASTNode();
+  if (!node)
+    return false;
 
-  expr = expr->walk(SanitizeExpr(Context,
-                                 /*shouldReusePrecheckedType=*/false));
-  target.setExpr(expr);
-
-  CompletionContextFinder contextAnalyzer(expr, DC);
+  CompletionContextFinder contextAnalyzer(node, DC);
 
   // If there was no completion expr (e.g. if the code completion location was
   // among tokens that were skipped over during parser error recovery) bail.
@@ -678,7 +669,10 @@ bool TypeChecker::typeCheckForCodeCompletion(
   // Determine the best subexpression to use based on the collected context
   // of the code completion expression.
   if (auto fallback = contextAnalyzer.getFallbackCompletionExpr()) {
-    assert(fallback->E != expr);
+    if (auto *expr = target.getAsExpr()) {
+      assert(fallback->E != expr);
+      (void)expr;
+    }
     SolutionApplicationTarget completionTarget(fallback->E,
                                                fallback->DC, CTP_Unused,
                                                /*contextualType=*/Type(),

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -292,22 +292,29 @@ public:
 
 void constraints::performSyntacticDiagnosticsForTarget(
     const SolutionApplicationTarget &target,
-    bool isExprStmt, bool disableExprAvailabiltyChecking) {
+    bool isExprStmt, bool disableExprAvailabilityChecking) {
   auto *dc = target.getDeclContext();
   switch (target.kind) {
   case SolutionApplicationTarget::Kind::expression: {
     // First emit diagnostics for the main expression.
     performSyntacticExprDiagnostics(target.getAsExpr(), dc,
-                                    isExprStmt, disableExprAvailabiltyChecking);
-
-    // If this is a for-in statement, we also need to check the where clause if
-    // present.
-    if (target.isForEachStmt()) {
-      if (auto *whereExpr = target.getForEachStmtInfo().whereExpr)
-        performSyntacticExprDiagnostics(whereExpr, dc, /*isExprStmt*/ false);
-    }
+                                    isExprStmt, disableExprAvailabilityChecking);
     return;
   }
+
+  case SolutionApplicationTarget::Kind::forEachStmt: {
+    auto *stmt = target.getAsForEachStmt();
+
+    // First emit diagnostics for the main expression.
+    performSyntacticExprDiagnostics(stmt->getTypeCheckedSequence(), dc,
+                                    isExprStmt,
+                                    disableExprAvailabilityChecking);
+
+    if (auto *whereExpr = stmt->getWhere())
+      performSyntacticExprDiagnostics(whereExpr, dc, /*isExprStmt*/ false);
+    return;
+  }
+
   case SolutionApplicationTarget::Kind::function: {
     FunctionSyntacticDiagnosticWalker walker(dc);
     target.getFunctionBody()->walk(walker);
@@ -341,6 +348,9 @@ Type TypeChecker::typeCheckExpression(Expr *&expr, DeclContext *dc,
   return expr->getType();
 }
 
+/// FIXME: In order to remote this function both \c FrontendStatsTracer
+/// and \c PrettyStackTrace* have to be updated to accept `ASTNode`
+// instead of each individual syntactic element types.
 Optional<SolutionApplicationTarget>
 TypeChecker::typeCheckExpression(SolutionApplicationTarget &target,
                                  TypeCheckExprOptions options) {
@@ -350,7 +360,18 @@ TypeChecker::typeCheckExpression(SolutionApplicationTarget &target,
                                   target.getAsExpr());
   PrettyStackTraceExpr stackTrace(Context, "type-checking", target.getAsExpr());
 
-  // First, pre-check the expression, validating any types that occur in the
+  return typeCheckTarget(target, options);
+}
+
+Optional<SolutionApplicationTarget>
+TypeChecker::typeCheckTarget(SolutionApplicationTarget &target,
+                             TypeCheckExprOptions options) {
+  DeclContext *dc = target.getDeclContext();
+  auto &Context = dc->getASTContext();
+  PrettyStackTraceLocation stackTrace(Context, "type-checking-target",
+                                      target.getLoc());
+
+  // First, pre-check the target, validating any types that occur in the
   // expression and folding sequence expressions.
   if (ConstraintSystem::preCheckTarget(
           target, /*replaceInvalidRefsWithErrors=*/true,
@@ -358,15 +379,13 @@ TypeChecker::typeCheckExpression(SolutionApplicationTarget &target,
     return None;
   }
 
-  auto *expr = target.getAsExpr();
-
-  // Check whether given expression has a code completion token which requires
+  // Check whether given target has a code completion token which requires
   // special handling.
   if (Context.CompletionCallback &&
-      typeCheckForCodeCompletion(target, /*needsPrecheck*/false,
+      typeCheckForCodeCompletion(target, /*needsPrecheck*/ false,
                                  [&](const constraints::Solution &S) {
-        Context.CompletionCallback->sawSolution(S);
-      }))
+                                   Context.CompletionCallback->sawSolution(S);
+                                 }))
     return None;
 
   // Construct a constraint system from this expression.
@@ -380,18 +399,18 @@ TypeChecker::typeCheckExpression(SolutionApplicationTarget &target,
 
   ConstraintSystem cs(dc, csOptions);
 
-  // Tell the constraint system what the contextual type is.  This informs
-  // diagnostics and is a hint for various performance optimizations.
-  cs.setContextualType(
-      expr,
-      target.getExprContextualTypeLoc(),
-      target.getExprContextualTypePurpose());
+  if (auto *expr = target.getAsExpr()) {
+    // Tell the constraint system what the contextual type is.  This informs
+    // diagnostics and is a hint for various performance optimizations.
+    cs.setContextualType(expr, target.getExprContextualTypeLoc(),
+                         target.getExprContextualTypePurpose());
 
-  // Try to shrink the system by reducing disjunction domains. This
-  // goes through every sub-expression and generate its own sub-system, to
-  // try to reduce the domains of those subexpressions.
-  cs.shrink(expr);
-  target.setExpr(expr);
+    // Try to shrink the system by reducing disjunction domains. This
+    // goes through every sub-expression and generate its own sub-system, to
+    // try to reduce the domains of those subexpressions.
+    cs.shrink(expr);
+    target.setExpr(expr);
+  }
 
   // If the client can handle unresolved type variables, leave them in the
   // system.
@@ -399,10 +418,8 @@ TypeChecker::typeCheckExpression(SolutionApplicationTarget &target,
 
   // Attempt to solve the constraint system.
   auto viable = cs.solve(target, allowFreeTypeVariables);
-  if (!viable) {
-    target.setExpr(expr);
+  if (!viable)
     return None;
-  }
 
   // Apply this solution to the constraint system.
   // FIXME: This shouldn't be necessary.
@@ -415,7 +432,6 @@ TypeChecker::typeCheckExpression(SolutionApplicationTarget &target,
     // Failure already diagnosed, above, as part of applying the solution.
     return None;
   }
-  Expr *result = resultTarget->getAsExpr();
 
   // Unless the client has disabled them, perform syntactic checks on the
   // expression now.
@@ -426,7 +442,6 @@ TypeChecker::typeCheckExpression(SolutionApplicationTarget &target,
         options.contains(TypeCheckExprFlags::DisableExprAvailabilityChecking));
   }
 
-  resultTarget->setExpr(result);
   return *resultTarget;
 }
 
@@ -805,6 +820,8 @@ bool TypeChecker::typeCheckPatternBinding(PatternBindingDecl *PBD,
 
 bool TypeChecker::typeCheckForEachBinding(DeclContext *dc, ForEachStmt *stmt) {
   auto &Context = dc->getASTContext();
+  FrontendStatsTracer statsTracer(Context.Stats, "typecheck-for-each", stmt);
+  PrettyStackTraceStmt stackTrace(Context, "type-checking-for-each", stmt);
 
   auto failed = [&]() -> bool {
     // Invalidate the pattern and the var decl.
@@ -817,16 +834,9 @@ bool TypeChecker::typeCheckForEachBinding(DeclContext *dc, ForEachStmt *stmt) {
     return true;
   };
 
-  auto sequenceProto = TypeChecker::getProtocol(
-      dc->getASTContext(), stmt->getForLoc(), 
-      stmt->getAwaitLoc().isValid() ? 
-        KnownProtocolKind::AsyncSequence : KnownProtocolKind::Sequence);
-  if (!sequenceProto)
-    return failed();
-
   auto target = SolutionApplicationTarget::forForEachStmt(
-      stmt, sequenceProto, dc, /*bindPatternVarsOneWay=*/false);
-  if (!typeCheckExpression(target))
+      stmt, dc, /*bindPatternVarsOneWay=*/false);
+  if (!typeCheckTarget(target))
     return failed();
 
   // Check to see if the sequence expr is throwing (in async context),

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -1768,6 +1768,9 @@ public:
   void diagnoseUnhandledThrowSite(DiagnosticEngine &Diags, ASTNode E,
                                   bool isTryCovered,
                                   const PotentialEffectReason &reason) {
+    if (E.isImplicit())
+      return;
+
     switch (getKind()) {
     case Kind::PotentiallyHandled:
       if (IsNonExhaustiveCatch) {
@@ -1947,6 +1950,9 @@ public:
   void diagnoseUnhandledAsyncSite(DiagnosticEngine &Diags, ASTNode node,
                                   Optional<PotentialEffectReason> maybeReason,
                                   bool forAwait = false) {
+    if (node.isImplicit())
+      return;
+
     switch (getKind()) {
     case Kind::PotentiallyHandled: {
       Diags.diagnose(node.getStartLoc(), diag::async_in_nonasync_function,

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -601,6 +601,10 @@ Optional<constraints::SolutionApplicationTarget>
 typeCheckExpression(constraints::SolutionApplicationTarget &target,
                     TypeCheckExprOptions options = TypeCheckExprOptions());
 
+Optional<constraints::SolutionApplicationTarget>
+typeCheckTarget(constraints::SolutionApplicationTarget &target,
+                TypeCheckExprOptions options = TypeCheckExprOptions());
+
 /// Return the type of operator function for specified LHS, or a null
 /// \c Type on error.
 FunctionType *getTypeOfCompletionOperator(DeclContext *DC, Expr *LHS,

--- a/test/AutoDiff/SILOptimizer/differentiation_control_flow_diagnostics.swift
+++ b/test/AutoDiff/SILOptimizer/differentiation_control_flow_diagnostics.swift
@@ -164,14 +164,14 @@ enum Tree : Differentiable & AdditiveArithmetic {
   }
 }
 
+// TODO(TF-957): Improve non-differentiability errors for for-in loops
+// (`Collection.makeIterator` and `IteratorProtocol.next`).
 // expected-error @+1 {{function is not differentiable}}
 @differentiable(reverse)
 // expected-note @+1 {{when differentiating this function definition}}
 func loop_array(_ array: [Float]) -> Float {
+// expected-note @-1 {{cannot differentiate through a non-differentiable result; do you want to use 'withoutDerivative(at:)'?}} {{12-12=withoutDerivative(at: }} {{17-17=)}}
   var result: Float = 1
-  // TODO(TF-957): Improve non-differentiability errors for for-in loops
-  // (`Collection.makeIterator` and `IteratorProtocol.next`).
-  // expected-note @+1 {{cannot differentiate through a non-differentiable result; do you want to use 'withoutDerivative(at:)'?}} {{12-12=withoutDerivative(at: }} {{17-17=)}}
   for x in array {
     result = result * x
   }

--- a/test/Interpreter/statements.swift
+++ b/test/Interpreter/statements.swift
@@ -51,3 +51,13 @@ print(guardvalue)
 print("done");
 // CHECK-LABEL: done
 
+func testAnyCollection(_ c: any Collection) {
+  for v in c {
+    print(v)
+  }
+}
+
+testAnyCollection([1, 2.0, "Hello"])
+// CHECK-NEXT: 1
+// CHECK-NEXT: 2.0
+// CHECK-NEXT: Hello

--- a/test/SILGen/foreach.swift
+++ b/test/SILGen/foreach.swift
@@ -111,15 +111,15 @@ func trivialStructBreak(_ xx: [Int]) {
 // CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_LIFETIME]]
 // CHECK:   [[BORROWED_ARRAY_STACK:%.*]] = alloc_stack $Array<Int>
 // CHECK:   store [[ARRAY_COPY:%.*]] to [init] [[BORROWED_ARRAY_STACK]]
-// CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = witness_method $Array<Int>, #Sequence.makeIterator : <Self where Self : Sequence> (__owned Self) -> () -> Self.Iterator : $@convention(witness_method: Sequence) <τ_0_0 where τ_0_0 : Sequence> (@in τ_0_0) -> @out τ_0_0.Iterator
+// CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = function_ref @$sSlss16IndexingIteratorVyxG0B0RtzrlE04makeB0ACyF : $@convention(method) <τ_0_0 where τ_0_0 : Collection, τ_0_0.Iterator == IndexingIterator<τ_0_0>> (@in τ_0_0) -> @out IndexingIterator<τ_0_0>
 // CHECK:   apply [[MAKE_ITERATOR_FUNC]]<[Int]>([[PROJECT_ITERATOR_BOX]], [[BORROWED_ARRAY_STACK]])
 // CHECK:   br [[LOOP_DEST:bb[0-9]+]]
 //
 // CHECK: [[LOOP_DEST]]:
 // CHECK:   [[GET_ELT_STACK:%.*]] = alloc_stack $Optional<Int>
 // CHECK:   [[WRITE:%.*]] = begin_access [modify] [unknown] [[PROJECT_ITERATOR_BOX]] : $*IndexingIterator<Array<Int>>
-// CHECK:   [[FUNC_REF:%.*]] = witness_method $IndexingIterator<Array<Int>>, #IteratorProtocol.next : <Self where Self : IteratorProtocol> (inout Self) -> () -> Self.Element? : $@convention(witness_method: IteratorProtocol) <τ_0_0 where τ_0_0 : IteratorProtocol> (@inout τ_0_0) -> @out Optional<τ_0_0.Element>
-// CHECK:   apply [[FUNC_REF]]<IndexingIterator<Array<Int>>>([[GET_ELT_STACK]], [[WRITE]])
+// CHECK:   [[FUNC_REF:%.*]] = function_ref @$ss16IndexingIteratorV4next7ElementQzSgyF : $@convention(method) <τ_0_0 where τ_0_0 : Collection> (@inout IndexingIterator<τ_0_0>) -> @out Optional<τ_0_0.Element>
+// CHECK:   apply [[FUNC_REF]]<[Int]>([[GET_ELT_STACK]], [[WRITE]])
 // CHECK:   [[IND_VAR:%.*]] = load [trivial] [[GET_ELT_STACK]]
 // CHECK:   switch_enum [[IND_VAR]] : $Optional<Int>, case #Optional.some!enumelt: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
 //
@@ -213,15 +213,15 @@ func existentialBreak(_ xx: [P]) {
 // CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_LIFETIME]]
 // CHECK:   [[BORROWED_ARRAY_STACK:%.*]] = alloc_stack $Array<P>
 // CHECK:   store [[ARRAY_COPY:%.*]] to [init] [[BORROWED_ARRAY_STACK]]
-// CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = witness_method $Array<P>, #Sequence.makeIterator : <Self where Self : Sequence> (__owned Self) -> () -> Self.Iterator : $@convention(witness_method: Sequence) <τ_0_0 where τ_0_0 : Sequence> (@in τ_0_0) -> @out τ_0_0.Iterator
+// CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = function_ref @$sSlss16IndexingIteratorVyxG0B0RtzrlE04makeB0ACyF : $@convention(method) <τ_0_0 where τ_0_0 : Collection, τ_0_0.Iterator == IndexingIterator<τ_0_0>> (@in τ_0_0) -> @out IndexingIterator<τ_0_0>
 // CHECK:   apply [[MAKE_ITERATOR_FUNC]]<[P]>([[PROJECT_ITERATOR_BOX]], [[BORROWED_ARRAY_STACK]])
 // CHECK:   [[ELT_STACK:%.*]] = alloc_stack $Optional<P>
 // CHECK:   br [[LOOP_DEST:bb[0-9]+]]
 //
 // CHECK: [[LOOP_DEST]]:
 // CHECK:   [[WRITE:%.*]] = begin_access [modify] [unknown] [[PROJECT_ITERATOR_BOX]] : $*IndexingIterator<Array<P>>
-// CHECK:   [[FUNC_REF:%.*]] = witness_method $IndexingIterator<Array<P>>, #IteratorProtocol.next : <Self where Self : IteratorProtocol> (inout Self) -> () -> Self.Element? : $@convention(witness_method: IteratorProtocol) <τ_0_0 where τ_0_0 : IteratorProtocol> (@inout τ_0_0) -> @out Optional<τ_0_0.Element>
-// CHECK:   apply [[FUNC_REF]]<IndexingIterator<Array<P>>>([[ELT_STACK]], [[WRITE]])
+// CHECK:   [[FUNC_REF:%.*]] = function_ref @$ss16IndexingIteratorV4next7ElementQzSgyF : $@convention(method) <τ_0_0 where τ_0_0 : Collection> (@inout IndexingIterator<τ_0_0>) -> @out Optional<τ_0_0.Element>
+// CHECK:   apply [[FUNC_REF]]<[P]>([[ELT_STACK]], [[WRITE]])
 // CHECK:   switch_enum_addr [[ELT_STACK]] : $*Optional<P>, case #Optional.some!enumelt: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
 //
 // CHECK: [[SOME_BB]]:
@@ -375,15 +375,15 @@ func genericStructBreak<T>(_ xx: [GenericStruct<T>]) {
 // CHECK:   [[PROJECT_ITERATOR_BOX:%.*]] = project_box [[ITERATOR_LIFETIME]]
 // CHECK:   [[BORROWED_ARRAY_STACK:%.*]] = alloc_stack $Array<GenericStruct<T>>
 // CHECK:   store [[ARRAY_COPY:%.*]] to [init] [[BORROWED_ARRAY_STACK]]
-// CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = witness_method $Array<GenericStruct<T>>, #Sequence.makeIterator : <Self where Self : Sequence> (__owned Self) -> () -> Self.Iterator : $@convention(witness_method: Sequence) <τ_0_0 where τ_0_0 : Sequence> (@in τ_0_0) -> @out τ_0_0.Iterator
+// CHECK:   [[MAKE_ITERATOR_FUNC:%.*]] = function_ref @$sSlss16IndexingIteratorVyxG0B0RtzrlE04makeB0ACyF : $@convention(method) <τ_0_0 where τ_0_0 : Collection, τ_0_0.Iterator == IndexingIterator<τ_0_0>> (@in τ_0_0) -> @out IndexingIterator<τ_0_0>
 // CHECK:   apply [[MAKE_ITERATOR_FUNC]]<[GenericStruct<T>]>([[PROJECT_ITERATOR_BOX]], [[BORROWED_ARRAY_STACK]])
 // CHECK:   [[ELT_STACK:%.*]] = alloc_stack $Optional<GenericStruct<T>>
 // CHECK:   br [[LOOP_DEST:bb[0-9]+]]
 //
 // CHECK: [[LOOP_DEST]]:
 // CHECK:   [[WRITE:%.*]] = begin_access [modify] [unknown] [[PROJECT_ITERATOR_BOX]] : $*IndexingIterator<Array<GenericStruct<T>>>
-// CHECK:   [[FUNC_REF:%.*]] = witness_method $IndexingIterator<Array<GenericStruct<T>>>, #IteratorProtocol.next : <Self where Self : IteratorProtocol> (inout Self) -> () -> Self.Element? : $@convention(witness_method: IteratorProtocol) <τ_0_0 where τ_0_0 : IteratorProtocol> (@inout τ_0_0) -> @out Optional<τ_0_0.Element>
-// CHECK:   apply [[FUNC_REF]]<IndexingIterator<Array<GenericStruct<T>>>>([[ELT_STACK]], [[WRITE]])
+// CHECK:   [[FUNC_REF:%.*]] = function_ref @$ss16IndexingIteratorV4next7ElementQzSgyF : $@convention(method) <τ_0_0 where τ_0_0 : Collection> (@inout IndexingIterator<τ_0_0>) -> @out Optional<τ_0_0.Element>
+// CHECK:   apply [[FUNC_REF]]<[GenericStruct<T>]>([[ELT_STACK]], [[WRITE]])
 // CHECK:   switch_enum_addr [[ELT_STACK]] : $*Optional<GenericStruct<T>>, case #Optional.some!enumelt: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
 //
 // CHECK: [[SOME_BB]]:

--- a/test/SILGen/foreach_async.swift
+++ b/test/SILGen/foreach_async.swift
@@ -81,10 +81,8 @@ struct AsyncLazySequence<S: Sequence>: AsyncSequence {
 // CHECK: [[LOOP_DEST]]:
 // CHECK:   [[NEXT_RESULT:%.*]] = alloc_stack $Optional<Int>
 // CHECK:   [[MUTATION:%.*]] = begin_access
-// CHECK:   [[WITNESS_METHOD:%.*]] = witness_method $AsyncLazySequence<Array<Int>>.Iterator, #AsyncIteratorProtocol.next : <Self where Self : AsyncIteratorProtocol> (inout Self) -> () async throws -> Self.Element? : $@convention(witness_method: AsyncIteratorProtocol) @async <τ_0_0 where τ_0_0 : AsyncIteratorProtocol> (@inout τ_0_0) -> (@out Optional<τ_0_0.Element>, @error Error)
-// CHECK:   try_apply [[WITNESS_METHOD]]<AsyncLazySequence<[Int]>.Iterator>([[NEXT_RESULT]], [[MUTATION]]) : $@convention(witness_method: AsyncIteratorProtocol) @async <τ_0_0 where τ_0_0 : AsyncIteratorProtocol> (@inout τ_0_0) -> (@out Optional<τ_0_0.Element>, @error Error), normal [[NORMAL_BB:bb[0-9]+]], error [[ERROR_BB:bb[0-9]+]]
-
-// CHECK: [[NORMAL_BB]]([[VAR:%.*]] : $()):
+// CHECK:   [[WITNESS_METHOD:%.*]] = function_ref @$s13foreach_async17AsyncLazySequenceV8IteratorV4next7ElementQzSgyYaF : $@convention(method) @async <τ_0_0 where τ_0_0 : Sequence> (@inout AsyncLazySequence<τ_0_0>.Iterator) -> @out Optional<τ_0_0.Element>
+// CHECK:   apply [[WITNESS_METHOD]]<[Int]>([[NEXT_RESULT]], [[MUTATION]]) : $@convention(method) @async <τ_0_0 where τ_0_0 : Sequence> (@inout AsyncLazySequence<τ_0_0>.Iterator) -> @out Optional<τ_0_0.Element>
 // CHECK:   end_access [[MUTATION]]
 // CHECK:   switch_enum [[IND_VAR:%.*]] : $Optional<Int>, case #Optional.some!enumelt: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
 
@@ -95,9 +93,6 @@ struct AsyncLazySequence<S: Sequence>: AsyncSequence {
 // CHECK: [[NONE_BB]]:
 // CHECK:   funcEnd
 // CHECK    return
-
-// CHECK: [[ERROR_BB]]([[VAR:%.*]] : @owned $Error):
-// CHECK:    unreachable
 // CHECK: } // end sil function '$s13foreach_async13trivialStructyyAA17AsyncLazySequenceVySaySiGGYaF'
 func trivialStruct(_ xx: AsyncLazySequence<[Int]>) async {
   for await x in xx {
@@ -116,10 +111,8 @@ func trivialStruct(_ xx: AsyncLazySequence<[Int]>) async {
 // CHECK: [[LOOP_DEST]]:
 // CHECK:   [[NEXT_RESULT:%.*]] = alloc_stack $Optional<Int>
 // CHECK:   [[MUTATION:%.*]] = begin_access
-// CHECK:   [[WITNESS_METHOD:%.*]] = witness_method $AsyncLazySequence<Array<Int>>.Iterator, #AsyncIteratorProtocol.next : <Self where Self : AsyncIteratorProtocol> (inout Self) -> () async throws -> Self.Element? : $@convention(witness_method: AsyncIteratorProtocol) @async <τ_0_0 where τ_0_0 : AsyncIteratorProtocol> (@inout τ_0_0) -> (@out Optional<τ_0_0.Element>, @error Error)
-// CHECK:   try_apply [[WITNESS_METHOD]]<AsyncLazySequence<[Int]>.Iterator>([[NEXT_RESULT]], [[MUTATION]]) : $@convention(witness_method: AsyncIteratorProtocol) @async <τ_0_0 where τ_0_0 : AsyncIteratorProtocol> (@inout τ_0_0) -> (@out Optional<τ_0_0.Element>, @error Error), normal [[NORMAL_BB:bb[0-9]+]], error [[ERROR_BB:bb[0-9]+]]
-
-// CHECK: [[NORMAL_BB]]([[VAR:%.*]] : $()):
+// CHECK:   [[WITNESS_METHOD:%.*]] = function_ref @$s13foreach_async17AsyncLazySequenceV8IteratorV4next7ElementQzSgyYaF : $@convention(method) @async <τ_0_0 where τ_0_0 : Sequence> (@inout AsyncLazySequence<τ_0_0>.Iterator) -> @out Optional<τ_0_0.Element>
+// CHECK:   apply [[WITNESS_METHOD]]<[Int]>([[NEXT_RESULT]], [[MUTATION]]) : $@convention(method) @async <τ_0_0 where τ_0_0 : Sequence> (@inout AsyncLazySequence<τ_0_0>.Iterator) -> @out Optional<τ_0_0.Element>
 // CHECK:   end_access [[MUTATION]]
 // CHECK:   switch_enum [[IND_VAR:%.*]] : $Optional<Int>, case #Optional.some!enumelt: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
 
@@ -138,9 +131,6 @@ func trivialStruct(_ xx: AsyncLazySequence<[Int]>) async {
 // CHECK: [[NONE_BB]]:
 // CHECK:   funcEnd
 // CHECK    return
-
-// CHECK: [[ERROR_BB]]([[VAR:%.*]] : @owned $Error):
-// CHECK:    unreachable
 // CHECK: } // end sil function '$s13foreach_async21trivialStructContinueyyAA17AsyncLazySequenceVySaySiGGYaF'
 
 func trivialStructContinue(_ xx: AsyncLazySequence<[Int]>) async {
@@ -178,10 +168,8 @@ func trivialStructBreak(_ xx: AsyncLazySequence<[Int]>) async {
 // CHECK: [[LOOP_DEST]]:
 // CHECK:   [[NEXT_RESULT:%.*]] = alloc_stack $Optional<Int>
 // CHECK:   [[MUTATION:%.*]] = begin_access
-// CHECK:   [[WITNESS_METHOD:%.*]] = witness_method $AsyncLazySequence<Array<Int>>.Iterator, #AsyncIteratorProtocol.next : <Self where Self : AsyncIteratorProtocol> (inout Self) -> () async throws -> Self.Element? : $@convention(witness_method: AsyncIteratorProtocol) @async <τ_0_0 where τ_0_0 : AsyncIteratorProtocol> (@inout τ_0_0) -> (@out Optional<τ_0_0.Element>, @error Error)
-// CHECK:   try_apply [[WITNESS_METHOD]]<AsyncLazySequence<[Int]>.Iterator>([[NEXT_RESULT]], [[MUTATION]]) : $@convention(witness_method: AsyncIteratorProtocol) @async <τ_0_0 where τ_0_0 : AsyncIteratorProtocol> (@inout τ_0_0) -> (@out Optional<τ_0_0.Element>, @error Error), normal [[NORMAL_BB:bb[0-9]+]], error [[ERROR_BB:bb[0-9]+]]
-
-// CHECK: [[NORMAL_BB]]([[VAR:%.*]] : $()):
+// CHECK:   [[WITNESS_METHOD:%.*]] = function_ref @$s13foreach_async17AsyncLazySequenceV8IteratorV4next7ElementQzSgyYaF : $@convention(method) @async <τ_0_0 where τ_0_0 : Sequence> (@inout AsyncLazySequence<τ_0_0>.Iterator) -> @out Optional<τ_0_0.Element>
+// CHECK:   apply [[WITNESS_METHOD]]<[Int]>([[NEXT_RESULT]], [[MUTATION]]) : $@convention(method) @async <τ_0_0 where τ_0_0 : Sequence> (@inout AsyncLazySequence<τ_0_0>.Iterator) -> @out Optional<τ_0_0.Element>
 // CHECK:   end_access [[MUTATION]]
 // CHECK:   switch_enum [[IND_VAR:%.*]] : $Optional<Int>, case #Optional.some!enumelt: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
 

--- a/test/SILGen/statements.swift
+++ b/test/SILGen/statements.swift
@@ -167,9 +167,8 @@ func for_loops2() {
   // rdar://problem/19316670
   // CHECK: alloc_stack $Optional<MyClass>
   // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown]
-  // CHECK: [[NEXT:%[0-9]+]] = witness_method $IndexingIterator<Array<MyClass>>, #IteratorProtocol.next : <Self where Self : IteratorProtocol> (inout Self) -> () -> Self.Element? : $@convention(witness_method: IteratorProtocol) <τ_0_0 where τ_0_0 : IteratorProtocol> (@inout τ_0_0) -> @out Optional<τ_0_0.Element>
-  // CHECK-NEXT: apply [[NEXT]]<IndexingIterator<Array<MyClass>>>
-  // CHECK: class_method [[OBJ:%[0-9]+]] : $MyClass, #MyClass.foo :
+  // CHECK: [[NEXT:%[0-9]+]] = function_ref @$ss16IndexingIteratorV4next7ElementQzSgyF : $@convention(method) <τ_0_0 where τ_0_0 : Collection> (@inout IndexingIterator<τ_0_0>) -> @out Optional<τ_0_0.Element>
+  // CHECK-NEXT: apply [[NEXT]]<[MyClass]>
   let objects = [MyClass(), MyClass() ]
   for obj in objects {
     obj.foo()

--- a/test/SILOptimizer/inline_addressor.swift
+++ b/test/SILOptimizer/inline_addressor.swift
@@ -17,7 +17,6 @@ var totalsum = nonTrivialInit(true)
 //CHECK-NOT: WZ
 //CHECK-NOT: totalsum
 //CHECK-NOT: inputval
-//CHECK: {{^}$}}
 func testit(_ x: Int) {
 	for _ in 0...10000000 {
 		totalsum += inputval

--- a/test/decl/var/async_let.swift
+++ b/test/decl/var/async_let.swift
@@ -9,7 +9,6 @@ func test() async {
 
 struct X {
   async let x = 1 // expected-error{{'async let' can only be used on local declarations}}
-  // FIXME: expected-error@-1{{'async' call cannot occur in a property initializer}}
 }
 
 func testAsyncFunc() async {

--- a/test/expr/unary/async_await.swift
+++ b/test/expr/unary/async_await.swift
@@ -196,10 +196,9 @@ func testAsyncLet() async throws {
   _ = await x5
 }
 
-// expected-note@+1 4{{add 'async' to function 'testAsyncLetOutOfAsync()' to make it asynchronous}} {{30-30= async}}
+// expected-note@+1 3{{add 'async' to function 'testAsyncLetOutOfAsync()' to make it asynchronous}} {{30-30= async}}
 func testAsyncLetOutOfAsync() {
   async let x = 1 // expected-error{{'async let' in a function that does not support concurrency}}
-  // FIXME: expected-error@-1{{'async' call in a function that does not support concurrency}}
 
   _ = await x  // expected-error{{'async let' in a function that does not support concurrency}}
   _ = x // expected-error{{'async let' in a function that does not support concurrency}}

--- a/test/stmt/async.swift
+++ b/test/stmt/async.swift
@@ -7,9 +7,8 @@ func omnom(_ x: Int)
 
 func f() async -> Int { 0 }
 
-func syncContext() {        // expected-note 4 {{add 'async' to function 'syncContext()' to make it asynchronous}}
+func syncContext() {        // expected-note 3 {{add 'async' to function 'syncContext()' to make it asynchronous}}
     _ = await f()           // expected-error{{'async' call in a function that does not support concurrency}}
     async let y = await f() // expected-error{{'async let' in a function that does not support concurrency}}
-                            // expected-error@-1{{'async' call in a function that does not support concurrency}}
     await omnom(y)          // expected-error{{'async let' in a function that does not support concurrency}}
 }

--- a/test/stmt/foreach.swift
+++ b/test/stmt/foreach.swift
@@ -60,8 +60,8 @@ func patterns(gir: GoodRange<Int>, gtr: GoodTupleIterator) {
   var sumf : Float
   for i : Int in gir { sum = sum + i }
   for i in gir { sum = sum + i }
-  for f : Float in gir { sum = sum + f } // expected-error{{cannot convert sequence element type 'GoodRange<Int>.Element' (aka 'Int') to expected type 'Float'}}
-  for f : ElementProtocol in gir { } // expected-error {{sequence element type 'GoodRange<Int>.Element' (aka 'Int') does not conform to expected protocol 'ElementProtocol'}}
+  for f : Float in gir { sum = sum + f } // expected-error{{cannot convert sequence element type 'Int' to expected type 'Float'}}
+  for f : ElementProtocol in gir { } // expected-error {{sequence element type 'Int' does not conform to expected protocol 'ElementProtocol'}}
 
   for (i, f) : (Int, Float) in gtr { sum = sum + i }
 
@@ -73,7 +73,7 @@ func patterns(gir: GoodRange<Int>, gtr: GoodTupleIterator) {
 
   for (i, _) : (Int, Float) in gtr { sum = sum + i }
 
-  for (i, _) : (Int, Int) in gtr { sum = sum + i } // expected-error{{cannot convert sequence element type 'GoodTupleIterator.Element' (aka '(Int, Float)') to expected type '(Int, Int)'}}
+  for (i, _) : (Int, Int) in gtr { sum = sum + i } // expected-error{{cannot convert sequence element type '(Int, Float)' to expected type '(Int, Int)'}}
 
   for (i, f) in gtr {}
 }
@@ -175,10 +175,16 @@ func testOptionalSequence() {
   }
 }
 
-// FIXME: Should this be allowed?
 func testExistentialSequence(s: any Sequence) {
-  for x in s { // expected-error {{type 'any Sequence' cannot conform to 'Sequence'}} expected-note {{only concrete types such as structs, enums and classes can conform to protocols}}
+  for x in s {
     _ = x
+  }
+}
+
+// rdar://92177656 - implicit existential opening should work with for-in loops
+func testForEachWithAnyCollection(c: any Collection) {
+  for v in c {
+    print(v)
   }
 }
 
@@ -238,3 +244,4 @@ func testForEachWhereWithClosure(_ x: [Int]) {
   for i in x where foo({ i.byteSwapped == 5 }) {}
   for i in x where x.contains(where: { $0.byteSwapped == i }) {}
 }
+


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/59003

---

Change the way how `for-in` statements are type-checked, where a lot of
information has to be recorded in a statement in order for SILGen to generate
appropriate calls to `makeIterator` and `next` witnesses.

Instead of just finding a witness, solver would now:

- Synthesize:
  - Iterator variable with its initializer - `$generator = <sequence>.makeIterator()`;
  - Call to `$generator.next()` which is called by each loop iteration;
- Verify that type of pattern is convertible to type of `next()`

Doing so significantly simplifies SILGen, removes the need to carry type information
in `ForEachStmt` and enables iterating over existential types.

Resolves: rdar://92177656

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
