### PR TITLE
Fix nested generic typerefs applying generic params at the wrong level

### DIFF
--- a/include/swift/AST/ASTDemangler.h
+++ b/include/swift/AST/ASTDemangler.h
@@ -64,6 +64,8 @@ public:
   using BuiltRequirement = swift::Requirement;
   using BuiltSubstitutionMap = swift::SubstitutionMap;
 
+  static constexpr bool needsToPrecomputeParentGenericContextShapes = false;
+
   explicit ASTBuilder(ASTContext &ctx) : Ctx(ctx) {}
 
   ASTContext &getASTContext() { return Ctx; }

--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -354,6 +354,24 @@ struct FieldTypeCollectionResult {
   std::vector<std::string> Errors;
 };
 
+struct TypeRefDecl {
+  std::string mangledName;
+
+  // Only used when building a bound generic typeref, and when the
+  // generic params for all the levels are stored as a flat array.
+  llvm::Optional<std::vector<size_t>> genericParamsPerLevel;
+
+  TypeRefDecl(std::string mangledName, 
+              std::vector<size_t> genericParamsPerLevel)
+      : mangledName(mangledName), 
+        genericParamsPerLevel(genericParamsPerLevel) {}
+
+  TypeRefDecl(std::string mangledName) 
+      : mangledName(mangledName), 
+        genericParamsPerLevel(llvm::None) {}
+
+};
+
 /// An implementation of MetadataReader's BuilderType concept for
 /// building TypeRefs, and parsing field metadata from any images
 /// it has been made aware of.
@@ -366,7 +384,7 @@ class TypeRefBuilder {
 
 public:
   using BuiltType = const TypeRef *;
-  using BuiltTypeDecl = llvm::Optional<std::string>;
+  using BuiltTypeDecl = llvm::Optional<TypeRefDecl>;
   using BuiltProtocolDecl =
       llvm::Optional<std::pair<std::string, bool /*isObjC*/>>;
   using BuiltSubstitution = std::pair<const TypeRef *, const TypeRef *>;
@@ -375,6 +393,8 @@ public:
   using BuiltGenericTypeParam = const GenericTypeParameterTypeRef *;
   using BuiltGenericSignature = const GenericSignatureRef *;
   using BuiltSubstitutionMap = llvm::DenseMap<DepthAndIndex, const TypeRef *>;
+
+  static constexpr bool needsToPrecomputeParentGenericContextShapes = true;
 
   TypeRefBuilder(const TypeRefBuilder &other) = delete;
   TypeRefBuilder &operator=(const TypeRefBuilder &other) = delete;
@@ -433,12 +453,30 @@ public:
     return BuiltinTypeRef::create(*this, mangledName);
   }
 
-  llvm::Optional<std::string> createTypeDecl(Node *node, bool &typeAlias) {
+  BuiltTypeDecl createTypeDecl(Node *node, std::vector<size_t> paramsPerLevel) {
     auto mangling = Demangle::mangleNode(node);
     if (!mangling.isSuccess()) {
       return llvm::None;
     }
-    return mangling.result();
+    return {{mangling.result(), paramsPerLevel}};
+  }
+
+  BuiltTypeDecl createTypeDecl(std::string &&mangledName,
+                               std::vector<size_t> paramsPerLevel) {
+    return {{std::move(mangledName), {paramsPerLevel}}};
+  }
+
+  BuiltTypeDecl createTypeDecl(Node *node, bool &typeAlias) {
+    auto mangling = Demangle::mangleNode(node);
+    if (!mangling.isSuccess()) {
+      return llvm::None;
+    }
+    return {{mangling.result()}};
+  }
+
+  BuiltTypeDecl createTypeDecl(std::string &&mangledName,
+                                             bool &typeAlias) {
+    return {{(mangledName)}};;
   }
 
   BuiltProtocolDecl
@@ -455,24 +493,20 @@ public:
     return std::make_pair(name, true);
   }
 
-  llvm::Optional<std::string> createTypeDecl(std::string &&mangledName,
-                                             bool &typeAlias) {
-    return std::move(mangledName);
+
+  const NominalTypeRef *
+  createNominalType(const BuiltTypeDecl &typeRefDecl) {
+    return NominalTypeRef::create(*this, typeRefDecl->mangledName, nullptr);
   }
 
   const NominalTypeRef *
-  createNominalType(const llvm::Optional<std::string> &mangledName) {
-    return NominalTypeRef::create(*this, *mangledName, nullptr);
-  }
-
-  const NominalTypeRef *
-  createNominalType(const llvm::Optional<std::string> &mangledName,
+  createNominalType(const BuiltTypeDecl &typeRefDecl,
                     const TypeRef *parent) {
-    return NominalTypeRef::create(*this, *mangledName, parent);
+    return NominalTypeRef::create(*this, typeRefDecl->mangledName, parent);
   }
 
   const TypeRef *
-  createTypeAliasType(const llvm::Optional<std::string> &mangledName,
+  createTypeAliasType(const BuiltTypeDecl &typeRefDecl,
                       const TypeRef *parent) {
     // TypeRefs don't contain sugared types
     return nullptr;
@@ -498,17 +532,75 @@ public:
     return nullptr;
   }
 
-  const BoundGenericTypeRef *
-  createBoundGenericType(const llvm::Optional<std::string> &mangledName,
-                         const std::vector<const TypeRef *> &args) {
-    return BoundGenericTypeRef::create(*this, *mangledName, args, nullptr);
+  const BoundGenericTypeRef *createBoundGenericTypeReconstructingParent(
+      const NodePointer node, const TypeRefDecl &decl, size_t shapeIndex,
+      const llvm::ArrayRef<const TypeRef *> &args, size_t argsIndex) {
+    if (!node || !node->hasChildren())
+      return nullptr;
+    
+    auto maybeGenericParamsPerLevel = decl.genericParamsPerLevel;
+    if (!maybeGenericParamsPerLevel)
+      return nullptr;
+
+    auto genericParamsPerLevel = *maybeGenericParamsPerLevel;
+
+    auto kind = node->getKind();
+    // Kinds who have a "BoundGeneric..." variant.
+    if (kind != Node::Kind::Class && kind != Node::Kind::Structure &&
+        kind != Node::Kind::Enum && kind != Node::Kind::Protocol &&
+        kind != Node::Kind::OtherNominalType && kind != Node::Kind::TypeAlias &&
+        kind != Node::Kind::Function)
+      return nullptr;
+    auto mangling = Demangle::mangleNode(node);
+    if (!mangling.isSuccess())
+      return nullptr;
+
+    auto numGenericArgs = genericParamsPerLevel[shapeIndex];
+
+    std::vector<const TypeRef *> genericParams(
+        args.end() - argsIndex - numGenericArgs, args.end() - argsIndex);
+
+    const BoundGenericTypeRef *parent = nullptr;
+    if (node->hasChildren())
+     parent = createBoundGenericTypeReconstructingParent(
+        node->getFirstChild(), decl, --shapeIndex, args, argsIndex + numGenericArgs);
+
+    return BoundGenericTypeRef::create(*this, mangling.result(), genericParams,
+                                       parent);
   }
 
   const BoundGenericTypeRef *
-  createBoundGenericType(const llvm::Optional<std::string> &mangledName,
+  createBoundGenericType(const BuiltTypeDecl &builtTypeDecl,
+                         const llvm::ArrayRef<const TypeRef *> &args) {
+    if (!builtTypeDecl)
+      return nullptr;
+
+    if (!builtTypeDecl->genericParamsPerLevel)
+      return BoundGenericTypeRef::create(*this, builtTypeDecl->mangledName, args, nullptr);
+
+  
+    auto node = Dem.demangleType(builtTypeDecl->mangledName);
+    if (!node || !node->hasChildren() || node->getKind() != Node::Kind::Type)
+      return nullptr;
+
+    auto type = node->getFirstChild();
+    return createBoundGenericTypeReconstructingParent(
+        type, *builtTypeDecl, builtTypeDecl->genericParamsPerLevel->size() - 1, args, 0);
+  }
+
+  const BoundGenericTypeRef *
+  createBoundGenericType(const BuiltTypeDecl &builtTypeDecl,
                          llvm::ArrayRef<const TypeRef *> args,
                          const TypeRef *parent) {
-    return BoundGenericTypeRef::create(*this, *mangledName, args, parent);
+    if (!builtTypeDecl)
+      return nullptr;
+
+    if (!builtTypeDecl->genericParamsPerLevel)
+      return BoundGenericTypeRef::create(*this, builtTypeDecl->mangledName, args,
+                                       parent);
+    assert(parent == nullptr &&
+           "Parent is not null but we're reconstructing the parent!");
+    return createBoundGenericType(builtTypeDecl, args);
   }
 
   const TypeRef *
@@ -627,7 +719,7 @@ public:
     if (protocol->second) {
       return llvm::cast<TypeRef>(createObjCProtocolType(protocol->first));
     } else {
-      return llvm::cast<TypeRef>(createNominalType(protocol->first));
+      return llvm::cast<TypeRef>(createNominalType(TypeRefDecl(protocol->first)));
     }
   }
 

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -30,6 +30,7 @@
 #include "swift/Runtime/HeapObject.h"
 #include "swift/Basic/Unreachable.h"
 
+#include <type_traits>
 #include <vector>
 #include <unordered_map>
 
@@ -2818,8 +2819,14 @@ private:
 
   /// Given a read nominal type descriptor, attempt to build a
   /// nominal type decl from it.
-  BuiltTypeDecl
-  buildNominalTypeDecl(ContextDescriptorRef descriptor) {
+  template <
+      typename T = BuilderType,
+      typename std::enable_if_t<
+          !std::is_same<
+              bool,
+              decltype(T::needsToPrecomputeParentGenericContextShapes)>::value,
+          bool> = true>
+  BuiltTypeDecl buildNominalTypeDecl(ContextDescriptorRef descriptor) {
     // Build the demangling tree from the context tree.
     Demangler dem;
     auto node = buildContextMangling(descriptor, dem);
@@ -2827,6 +2834,41 @@ private:
       return BuiltTypeDecl();
     bool typeAlias = false;
     BuiltTypeDecl decl = Builder.createTypeDecl(node, typeAlias);
+    return decl;
+  }
+
+  template <
+      typename T = BuilderType,
+      typename std::enable_if_t<
+          std::is_same<
+              bool,
+              decltype(T::needsToPrecomputeParentGenericContextShapes)>::value,
+          bool> = true>
+  BuiltTypeDecl buildNominalTypeDecl(ContextDescriptorRef descriptor) {
+    // Build the demangling tree from the context tree.
+    Demangler dem;
+    auto node = buildContextMangling(descriptor, dem);
+    if (!node || node->getKind() != Node::Kind::Type)
+      return BuiltTypeDecl();
+    std::vector<size_t> paramsPerLevel;
+    size_t runningCount = 0;
+    std::function<void(ContextDescriptorRef current, size_t &)> countLevels =
+        [&](ContextDescriptorRef current, size_t &runningCount) {
+          if (auto parentContextRef = readParentContextDescriptor(current))
+            if (parentContextRef->isResolved())
+              if (auto parentContext = parentContextRef->getResolved())
+                countLevels(parentContext, runningCount);
+
+          auto genericContext = current->getGenericContext();
+          if (!genericContext)
+            return;
+          auto contextHeader = genericContext->getGenericContextHeader();
+
+          paramsPerLevel.emplace_back(contextHeader.NumParams - runningCount);
+          runningCount += paramsPerLevel.back();
+        };
+    countLevels(descriptor, runningCount);
+    BuiltTypeDecl decl = Builder.createTypeDecl(node, paramsPerLevel);
     return decl;
   }
 

--- a/stdlib/public/Reflection/TypeRef.cpp
+++ b/stdlib/public/Reflection/TypeRef.cpp
@@ -579,8 +579,35 @@ public:
     genericNode->addChild(unspecializedType, Dem);
     genericNode->addChild(genericArgsList, Dem);
 
-    if (auto parent = BG->getParent())
-      assert(false && "not implemented");
+    auto parent = BG->getParent();
+    if (!parent)
+      return genericNode;
+
+    auto parentNode = visit(parent);
+    if (!parentNode || !parentNode->hasChildren() ||
+        parentNode->getKind() != Node::Kind::Type ||
+        !unspecializedType->hasChildren())
+      return genericNode;
+
+    // Peel off the "Type" node.
+    parentNode = parentNode->getFirstChild();
+
+    auto nominalNode = unspecializedType->getFirstChild();
+
+    if (nominalNode->getNumChildren() != 2)
+      return genericNode;
+
+    // Save identifier for reinsertion later, we have to remove it
+    // so we can insert the parent node as the first child.
+    auto identifierNode = nominalNode->getLastChild();
+
+    // Remove all children.
+    nominalNode->removeChildAt(1);
+    nominalNode->removeChildAt(0);
+
+    // Add the parent we just visited back in, followed by the identifier.
+    nominalNode->addChild(parentNode, Dem);
+    nominalNode->addChild(identifierNode, Dem);
 
     return genericNode;
   }

--- a/unittests/Reflection/TypeRef.cpp
+++ b/unittests/Reflection/TypeRef.cpp
@@ -28,6 +28,17 @@ static const std::string Shmodule = "Shmodule";
 static const std::string MyProtocol = "MyProtocol";
 static const std::string Shmrotocol = "Shmrotocol";
 
+static const TypeRefDecl ABC_decl = {"ABC"};
+static const TypeRefDecl ABCD_decl = {"ABCD"};
+static const TypeRefDecl XYZ_decl = {"XYZ"};
+static const TypeRefDecl Empty_decl = {""};
+static const TypeRefDecl MyClass_decl = {"MyClass"};
+static const TypeRefDecl NotMyClass_decl = {"NotMyClass"};
+static const TypeRefDecl MyModule_decl = {"MyModule"};
+static const TypeRefDecl Shmodule_decl = {"Shmodule"};
+static const TypeRefDecl MyProtocol_decl = {"MyProtocol"};
+static const TypeRefDecl Shmrotocol_decl = {"Shmrotocol"};
+
 using Param = remote::FunctionParam<const TypeRef *>;
 
 TEST(TypeRefTest, UniqueBuiltinTypeRef) {
@@ -44,15 +55,15 @@ TEST(TypeRefTest, UniqueBuiltinTypeRef) {
 TEST(TypeRefTest, UniqueNominalTypeRef) {
   TypeRefBuilder Builder(TypeRefBuilder::ForTesting);
 
-  auto N1 = Builder.createNominalType(ABC, nullptr);
-  auto N2 = Builder.createNominalType(ABC, nullptr);
-  auto N3 = Builder.createNominalType(ABCD, nullptr);
+  auto N1 = Builder.createNominalType(ABC_decl, nullptr);
+  auto N2 = Builder.createNominalType(ABC_decl, nullptr);
+  auto N3 = Builder.createNominalType(ABCD_decl, nullptr);
 
   EXPECT_EQ(N1, N2);
   EXPECT_NE(N2, N3);
 
-  auto N4 = Builder.createNominalType(ABC, N1);
-  auto N5 = Builder.createNominalType(ABC, N1);
+  auto N4 = Builder.createNominalType(ABC_decl, N1);
+  auto N5 = Builder.createNominalType(ABC_decl, N1);
 
   EXPECT_EQ(N4, N5);
 }
@@ -63,18 +74,18 @@ TEST(TypeRefTest, UniqueBoundGenericTypeRef) {
   auto GTP00 = Builder.createGenericTypeParameterType(0, 0);
   auto GTP01 = Builder.createGenericTypeParameterType(0, 1);
 
-  auto BG1 = Builder.createBoundGenericType(ABC, {}, nullptr);
-  auto BG2 = Builder.createBoundGenericType(ABC, {}, nullptr);
-  auto BG3 = Builder.createBoundGenericType(ABCD, {}, nullptr);
+  auto BG1 = Builder.createBoundGenericType(ABC_decl, {}, nullptr);
+  auto BG2 = Builder.createBoundGenericType(ABC_decl, {}, nullptr);
+  auto BG3 = Builder.createBoundGenericType(ABCD_decl, {}, nullptr);
 
   EXPECT_EQ(BG1, BG2);
   EXPECT_NE(BG2, BG3);
 
   std::vector<const TypeRef *> GenericParams { GTP00, GTP01 };
 
-  auto BG4 = Builder.createBoundGenericType(ABC, GenericParams, nullptr);
-  auto BG5 = Builder.createBoundGenericType(ABC, GenericParams, nullptr);
-  auto BG6 = Builder.createBoundGenericType(ABCD, GenericParams, nullptr);
+  auto BG4 = Builder.createBoundGenericType(ABC_decl, GenericParams, nullptr);
+  auto BG5 = Builder.createBoundGenericType(ABC_decl, GenericParams, nullptr);
+  auto BG6 = Builder.createBoundGenericType(ABCD_decl, GenericParams, nullptr);
 
   EXPECT_EQ(BG4, BG5);
   EXPECT_NE(BG5, BG6);
@@ -84,8 +95,8 @@ TEST(TypeRefTest, UniqueBoundGenericTypeRef) {
 TEST(TypeRefTest, UniqueTupleTypeRef) {
   TypeRefBuilder Builder(TypeRefBuilder::ForTesting);
 
-  auto N1 = Builder.createNominalType(ABC, nullptr);
-  auto N2 = Builder.createNominalType(XYZ, nullptr);
+  auto N1 = Builder.createNominalType(ABC_decl, nullptr);
+  auto N2 = Builder.createNominalType(XYZ_decl, nullptr);
 
   std::vector<const TypeRef *> Void;
   auto Void1 = Builder.createTupleType(Void, "");
@@ -111,8 +122,8 @@ TEST(TypeRefTest, UniqueFunctionTypeRef) {
 
   std::vector<const TypeRef *> Void;
   auto VoidResult = Builder.createTupleType(Void, "");
-  Param Param1 = Builder.createNominalType(ABC, nullptr);
-  Param Param2 = Builder.createNominalType(XYZ, nullptr);
+  Param Param1 = Builder.createNominalType(ABC_decl, nullptr);
+  Param Param2 = Builder.createNominalType(XYZ_decl, nullptr);
 
   std::vector<Param> VoidParams;
   std::vector<Param> Parameters1{Param1, Param2};
@@ -296,7 +307,7 @@ TEST(TypeRefTest, UniqueProtocolTypeRef) {
 TEST(TypeRefTest, UniqueMetatypeTypeRef) {
   TypeRefBuilder Builder(TypeRefBuilder::ForTesting);
 
-  auto N1 = Builder.createNominalType(ABC, nullptr);
+  auto N1 = Builder.createNominalType(ABC_decl, nullptr);
   auto M1 = Builder.createMetatypeType(N1, None);
   auto M2 = Builder.createMetatypeType(N1, None);
   auto MM3 = Builder.createMetatypeType(M1, None);
@@ -310,7 +321,7 @@ TEST(TypeRefTest, UniqueMetatypeTypeRef) {
 TEST(TypeRefTest, UniqueExistentialMetatypeTypeRef) {
   TypeRefBuilder Builder(TypeRefBuilder::ForTesting);
 
-  auto N1 = Builder.createNominalType(ABC, nullptr);
+  auto N1 = Builder.createNominalType(ABC_decl, nullptr);
   auto M1 = Builder.createExistentialMetatypeType(N1);
   auto M2 = Builder.createExistentialMetatypeType(N1);
   auto MM3 = Builder.createExistentialMetatypeType(M1);
@@ -335,8 +346,8 @@ TEST(TypeRefTest, UniqueGenericTypeParameterTypeRef) {
 TEST(TypeRefTest, UniqueDependentMemberTypeRef) {
   TypeRefBuilder Builder(TypeRefBuilder::ForTesting);
 
-  auto N1 = Builder.createNominalType(ABC, nullptr);
-  auto N2 = Builder.createNominalType(XYZ, nullptr);
+  auto N1 = Builder.createNominalType(ABC_decl, nullptr);
+  auto N2 = Builder.createNominalType(XYZ_decl, nullptr);
   TypeRefBuilder::BuiltProtocolDecl P1 = std::make_pair(ABC, false);
   TypeRefBuilder::BuiltProtocolDecl P2 = std::make_pair(ABCD, false);
 
@@ -394,8 +405,8 @@ TEST(TypeRefTest, UniqueOpaqueTypeRef) {
 TEST(TypeRefTest, UniqueUnownedStorageType) {
   TypeRefBuilder Builder(TypeRefBuilder::ForTesting);
 
-  auto N1 = Builder.createNominalType(MyClass, nullptr);
-  auto N2 = Builder.createNominalType(NotMyClass, nullptr);
+  auto N1 = Builder.createNominalType(MyClass_decl, nullptr);
+  auto N2 = Builder.createNominalType(NotMyClass_decl, nullptr);
   auto RS1 = Builder.createUnownedStorageType(N1);
   auto RS2 = Builder.createUnownedStorageType(N1);
   auto RS3 = Builder.createUnownedStorageType(N2);
@@ -407,8 +418,8 @@ TEST(TypeRefTest, UniqueUnownedStorageType) {
 TEST(TypeRefTest, UniqueWeakStorageType) {
   TypeRefBuilder Builder(TypeRefBuilder::ForTesting);
 
-  auto N1 = Builder.createNominalType(MyClass, nullptr);
-  auto N2 = Builder.createNominalType(NotMyClass, nullptr);
+  auto N1 = Builder.createNominalType(MyClass_decl, nullptr);
+  auto N2 = Builder.createNominalType(NotMyClass_decl, nullptr);
   auto RS1 = Builder.createWeakStorageType(N1);
   auto RS2 = Builder.createWeakStorageType(N1);
   auto RS3 = Builder.createWeakStorageType(N2);
@@ -420,8 +431,8 @@ TEST(TypeRefTest, UniqueWeakStorageType) {
 TEST(TypeRefTest, UniqueUnmanagedStorageType) {
   TypeRefBuilder Builder(TypeRefBuilder::ForTesting);
 
-  auto N1 = Builder.createNominalType(MyClass, nullptr);
-  auto N2 = Builder.createNominalType(NotMyClass, nullptr);
+  auto N1 = Builder.createNominalType(MyClass_decl, nullptr);
+  auto N2 = Builder.createNominalType(NotMyClass_decl, nullptr);
   auto RS1 = Builder.createUnmanagedStorageType(N1);
   auto RS2 = Builder.createUnmanagedStorageType(N1);
   auto RS3 = Builder.createUnmanagedStorageType(N2);
@@ -436,12 +447,12 @@ TEST(TypeRefTest, UniqueUnmanagedStorageType) {
 TEST(TypeRefTest, UniqueAfterSubstitution) {
   TypeRefBuilder Builder(TypeRefBuilder::ForTesting);
 
-  std::string MangledIntName("Si");
+  TypeRefDecl MangledIntName("Si");
   auto NominalInt = Builder.createNominalType(MangledIntName,
                                               /*parent*/ nullptr);
   std::vector<const TypeRef *> ConcreteArgs { NominalInt, NominalInt };
 
-  std::string MangledName("ABC");
+  TypeRefDecl MangledName("ABC");
 
   auto ConcreteBG = Builder.createBoundGenericType(MangledName,
                                                    ConcreteArgs,
@@ -469,17 +480,17 @@ TEST(TypeRefTest, NestedTypes) {
 
   auto GTP00 = Builder.createGenericTypeParameterType(0, 0);
 
-  std::string ParentName("parent");
+  TypeRefDecl ParentName("parent");
   std::vector<const TypeRef *> ParentArgs { GTP00 };
   auto Parent = Builder.createBoundGenericType(ParentName, ParentArgs,
                                                /*parent*/ nullptr);
 
-  std::string ChildName("child");
+  TypeRefDecl ChildName("child");
   auto Child = Builder.createNominalType(ChildName, Parent);
 
   EXPECT_FALSE(Child->isConcrete());
 
-  std::string SubstName("subst");
+  TypeRefDecl SubstName("subst");
   auto SubstArg = Builder.createNominalType(SubstName, /*parent*/ nullptr);
 
   std::vector<const TypeRef *> SubstParentArgs { SubstArg };
@@ -501,7 +512,7 @@ TEST(TypeRefTest, DeriveSubstitutions) {
   auto GTP00 = Builder.createGenericTypeParameterType(0, 0);
   auto GTP01 = Builder.createGenericTypeParameterType(0, 1);
 
-  std::string NominalName("nominal");
+  TypeRefDecl NominalName("nominal");
   std::vector<const TypeRef *> NominalArgs { GTP00 };
   auto Nominal = Builder.createBoundGenericType(NominalName, NominalArgs,
                                                /*parent*/ nullptr);
@@ -511,10 +522,10 @@ TEST(TypeRefTest, DeriveSubstitutions) {
       {Nominal}, Result, FunctionTypeFlags(),
       FunctionMetadataDifferentiabilityKind::NonDifferentiable, nullptr);
 
-  std::string SubstOneName("subst1");
+  TypeRefDecl SubstOneName("subst1");
   auto SubstOne = Builder.createNominalType(SubstOneName, /*parent*/ nullptr);
 
-  std::string SubstTwoName("subst2");
+  TypeRefDecl SubstTwoName("subst2");
   auto SubstTwo = Builder.createNominalType(SubstTwoName, /*parent*/ nullptr);
 
   GenericArgumentMap Subs;


### PR DESCRIPTION
Generic params of typerefs are supposed to be "attached" on the level
they belong, not as a flat list, unlike other parts of the system. Fix
the application of bound generic params by checking how many were
already applied in the hierarchy and ignoring those already attached.
