### PR TITLE
[5.7][CodeCompletion] Don't suggest initializers on existential types

### DIFF
--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -1565,6 +1565,10 @@ void CompletionLookup::addConstructorCallsForType(
   if (!Sink.addInitsToTopLevel)
     return;
 
+  // Existential types cannot be instantiated. e.g. 'MyProtocol()'.
+  if (type->isExistentialType())
+    return;
+
   // 'AnyObject' is not initializable.
   // FIXME: Should we do this in 'AnyObjectLookupRequest'?
   if (type->isAnyObject())
@@ -2017,9 +2021,10 @@ void CompletionLookup::foundDecl(ValueDecl *D, DeclVisibilityKind Reason,
 
     if (auto *GP = dyn_cast<GenericTypeParamDecl>(D)) {
       addGenericTypeParamRef(GP, Reason, dynamicLookupInfo);
-      for (auto *protocol : GP->getConformingProtocols())
-        addConstructorCallsForType(protocol->getDeclaredInterfaceType(),
-                                   GP->getName(), Reason, dynamicLookupInfo);
+      auto type =
+          CurrDeclContext->mapTypeIntoContext(GP->getDeclaredInterfaceType());
+      addConstructorCallsForType(type, GP->getName(), Reason,
+                                 dynamicLookupInfo);
       return;
     }
 

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -365,9 +365,15 @@ static void collectPossibleCalleesByQualifiedLookup(
   if (!baseInstanceTy->mayHaveMembers())
     return;
 
-  // 'AnyObject' is not initializable.
-  if (baseInstanceTy->isAnyObject() && name == DeclNameRef::createConstructor())
-    return;
+  if (name == DeclNameRef::createConstructor()) {
+    // Existential types cannot be instantiated. e.g. 'MyProtocol()'.
+    if (baseInstanceTy->isExistentialType())
+      return;
+
+    // 'AnyObject' is not initializable.
+    if (baseInstanceTy->isAnyObject())
+      return;
+  }
 
   // Make sure we've resolved implicit members.
   namelookup::installSemanticMembersIfNeeded(baseInstanceTy, name);

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -1194,7 +1194,7 @@ static void lookupVisibleDeclsImpl(VisibleDeclConsumer &Consumer,
       if (!isa<PatternBindingInitializer>(DC) ||
           !cast<PatternBindingInitializer>(DC)->getInitializedLazyVar())
         LS = LS.withOnMetatype();
-      DC = DC->getParent();
+      DC = DC->getParentForLookup();
     }
 
     // We don't look for generic parameters if we are in the context of a
@@ -1210,7 +1210,7 @@ static void lookupVisibleDeclsImpl(VisibleDeclConsumer &Consumer,
 
     if (auto *SE = dyn_cast<SubscriptDecl>(DC)) {
       ExtendedType = SE->getDeclContext()->getSelfTypeInContext();
-      DC = DC->getParent();
+      DC = DC->getParentForLookup();
       if (SE->isStatic())
         LS = LS.withOnMetatype();
     } else if (auto *AFD = dyn_cast<AbstractFunctionDecl>(DC)) {
@@ -1238,7 +1238,7 @@ static void lookupVisibleDeclsImpl(VisibleDeclConsumer &Consumer,
 
       if (AFD->getDeclContext()->isTypeContext()) {
         ExtendedType = AFD->getDeclContext()->getSelfTypeInContext();
-        DC = DC->getParent();
+        DC = DC->getParentForLookup();
 
         if (auto *FD = dyn_cast<FuncDecl>(AFD))
           if (FD->isStatic())
@@ -1288,7 +1288,7 @@ static void lookupVisibleDeclsImpl(VisibleDeclConsumer &Consumer,
       MemberReason = DeclVisibilityKind::MemberOfOutsideNominal;
     }
 
-    DC = DC->getParent();
+    DC = DC->getParentForLookup();
   }
 
   if (auto SF = dyn_cast<SourceFile>(DC)) {

--- a/test/IDE/complete_init.swift
+++ b/test/IDE/complete_init.swift
@@ -81,13 +81,12 @@ func testTopLevel() {
 // TOP_LEVEL_0-DAG: Decl[Constructor]/CurrModule:    E({#x: A#})[#E#]{{; name=.+}}
 // TOP_LEVEL_0-DAG: Decl[Constructor]/CurrModule:    F({#x: A#})[#F#]{{; name=.+}}
 // TOP_LEVEL_0-DAG: Decl[Constructor]/CurrModule:    F()[#F#]{{; name=.+}}
-// TOP_LEVEL_0-DAG: Decl[Constructor]/CurrModule:    G({#x: A#})[#G#]{{; name=.+}}
 // TOP_LEVEL_0-DAG: Decl[Constructor]/CurrModule:    H({#x: A#})[#H#]{{; name=.+}}
-// TOP_LEVEL_0-DAG: Decl[Constructor]/CurrModule:    I({#x: A#})[#I#]{{; name=.+}}
-// TOP_LEVEL_0-DAG: Decl[Constructor]/CurrModule:    I({#y: A#})[#I#]{{; name=.+}}
 // TOP_LEVEL_0-DAG: Decl[Constructor]/CurrModule:    J()[#A#]{{; name=.+}}
 // TOP_LEVEL_0: End completions
 // NEGATIVE_TOP_LEVEL_0-NOT: Decl[Constructor]/CurrModule:    E()
+// NEGATIVE_TOP_LEVEL_0-NOT: Decl[Constructor]/CurrModule:    G(
+// NEGATIVE_TOP_LEVEL_0-NOT: Decl[Constructor]/CurrModule:    I(
 
 func testQualified0() {
   K.#^K_QUALIFIED_0^#

--- a/test/IDE/complete_rdar94369218.swift
+++ b/test/IDE/complete_rdar94369218.swift
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-ide-test -batch-code-completion -code-complete-inits-in-postfix-expr -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+
+protocol MyProto {
+  init(value: String)
+}
+
+extension MyProto where Self == MyStruct {
+  init(arg: String) { self = Self(value: arg) }
+}
+
+struct MyStruct: MyProto {
+  init(value: String) {}
+}
+
+func test1() {
+  #^GLOBALEXPR^#
+// GLOBALEXPR: Begin completions
+// GLOBALEXPR-NOT: name=MyProto(
+// GLOBALEXPR-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
+// GLOBALEXPR-DAG: Decl[Constructor]/CurrModule:       MyStruct({#value: String#})[#MyStruct#]; name=MyStruct(value:)
+// GLOBALEXPR-DAG: Decl[Constructor]/CurrModule:       MyStruct({#arg: String#})[#MyStruct#]; name=MyStruct(arg:)
+// GLOBALEXPR-DAG: Decl[Protocol]/CurrModule/Flair[RareType]: MyProto[#MyProto#]; name=MyProto
+// GLOBALEXPR-NOT: name=MyProto(
+// GLOBALEXPR: End completions
+}
+
+func test2() {
+  _ = MyProto(#^PROTOCOL_AFTER_PAREN^#
+// PROTOCOL_AFTER_PAREN: Begin completions
+// PROTOCOL_AFTER_PAREN-NOT: name=arg: 
+// PROTOCOL_AFTER_PAREN-NOT: name=value: 
+// PROTOCOL_AFTER_PAREN: End completions
+}
+
+func test3<MyGeneric: MyProto>() {
+  class Inner {
+    func test() {
+      #^GENERICEXPR^#
+// GENERICEXPR: Decl[GenericTypeParam]/Local:       MyGeneric[#MyGeneric#]; name=MyGeneric
+// GENERICEXPR: Decl[Constructor]/Local:            MyGeneric({#value: String#})[#MyProto#]; name=MyGeneric(value:)
+// GENERICEXPR: Decl[Constructor]/Local:            MyGeneric({#arg: String#})[#MyStruct#]; name=MyGeneric(arg:)
+    }
+  }
+}


### PR DESCRIPTION
Cherry-pick #59265 into `release/5.7`

* **Explanation**: Previously, `MyProtocol(<HERE>` and global completions with initializers (i.e. `addinitstotoplevel`) showed all initializers from objc classes. However, protocol types (i.e. existential types) cannot be instantiated, so we should NOT be providing any initializers on existential types. 
* **Scope**: Code completion for protocols.
* **Risk**: Low. Just adding early bailout for `type->isExistentialType()` condition.
* **Issues**: rdar://94369218
* **Testing**: Added regression test cases
* **Reviewer**: Ben Barham (@bnbarham)
