### PR TITLE
[next] Re-enable test that no longer fails

### DIFF
--- a/test/ClangImporter/overlay.swift
+++ b/test/ClangImporter/overlay.swift
@@ -3,8 +3,6 @@
 
 // REQUIRES: objc_interop
 
-// REQUIRES: rdar93135127
-
 // Do not import Foundation! This tests indirect visibility.
 #if REVERSED
 import Redeclaration


### PR DESCRIPTION
This is fixed by e41a9833dc850d5757c000a666cb8876f1e6fd5a
(https://github.com/apple/llvm-project/pull/4801), which properly marks
the decl as demoted.