### PR TITLE
ABIChecker: for decls with @_originallyDefinedIn, use original module names in ABI descriptors

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -297,7 +297,8 @@ public:
 
   std::string mangleTypeAsContextUSR(const NominalTypeDecl *type);
 
-  std::string mangleAnyDecl(const ValueDecl *Decl, bool prefix);
+  std::string mangleAnyDecl(const ValueDecl *Decl, bool prefix,
+                            bool respectOriginallyDefinedIn = false);
   std::string mangleDeclAsUSR(const ValueDecl *Decl, StringRef USRPrefix);
 
   std::string mangleAccessorEntityAsUSR(AccessorKind kind,

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -209,6 +209,9 @@ struct PrintOptions {
   /// \see FileUnit::getExportedModuleName
   bool UseExportedModuleNames = false;
 
+  /// Use the original module name to qualify a symbol.
+  bool UseOriginallyDefinedInModuleNames = false;
+
   /// Print Swift.Array and Swift.Optional with sugared syntax
   /// ([] and ?), even if there are no sugar type nodes.
   bool SynthesizeSugarOnTypes = false;

--- a/lib/APIDigester/ModuleAnalyzerNodes.cpp
+++ b/lib/APIDigester/ModuleAnalyzerNodes.cpp
@@ -17,6 +17,7 @@ namespace {
 static PrintOptions getTypePrintOpts(CheckerOptions CheckerOpts) {
   PrintOptions Opts;
   Opts.SynthesizeSugarOnTypes = true;
+  Opts.UseOriginallyDefinedInModuleNames = true;
   if (!CheckerOpts.Migrator) {
     // We should always print fully qualified type names for checking either
     // API or ABI stability.
@@ -1096,7 +1097,8 @@ static StringRef calculateMangledName(SDKContext &Ctx, ValueDecl *VD) {
     return Ctx.buffer(attr->Name);
   }
   Mangle::ASTMangler NewMangler;
-  return Ctx.buffer(NewMangler.mangleAnyDecl(VD, true));
+  return Ctx.buffer(NewMangler.mangleAnyDecl(VD, true,
+                                    /*bool respectOriginallyDefinedIn*/true));
 }
 
 static StringRef calculateLocation(SDKContext &SDKCtx, Decl *D) {

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -759,9 +759,12 @@ std::string ASTMangler::mangleTypeAsUSR(Type Ty) {
   return finalize();
 }
 
-std::string ASTMangler::mangleAnyDecl(const ValueDecl *Decl, bool prefix) {
+std::string
+ASTMangler::mangleAnyDecl(const ValueDecl *Decl,
+                          bool prefix,
+                          bool respectOriginallyDefinedIn) {
   DWARFMangling = true;
-  RespectOriginallyDefinedIn = false;
+  RespectOriginallyDefinedIn = respectOriginallyDefinedIn;
   if (prefix) {
     beginMangling();
   } else {

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -5303,6 +5303,16 @@ class TypePrinter : public TypeVisitor<TypePrinter> {
       Name = Mod->getASTContext().getIdentifier(ExportedModuleName);
     }
 
+    if (Options.UseOriginallyDefinedInModuleNames) {
+      Decl *D = Ty->getDecl();
+      for (auto attr: D->getAttrs().getAttributes<OriginallyDefinedInAttr>()) {
+        Name = Mod->getASTContext()
+          .getIdentifier(const_cast<OriginallyDefinedInAttr*>(attr)
+                         ->OriginalModuleName);
+        break;
+      }
+    }
+
     Printer.printModuleRef(Mod, Name);
     Printer << ".";
   }

--- a/test/api-digester/Inputs/cake.swift
+++ b/test/api-digester/Inputs/cake.swift
@@ -145,3 +145,9 @@ public func emitIntoClientFunc() {}
 
 @_silgen_name("silgenName")
 public func silgenNamedFunc() {}
+
+@available(OSX 10.7, *)
+@_originallyDefinedIn(module: "Bread", OSX 10.9)
+public class SinkingClass {
+  public init() {}
+}

--- a/test/api-digester/Outputs/cake-abi.json
+++ b/test/api-digester/Outputs/cake-abi.json
@@ -1637,6 +1637,40 @@
       },
       {
         "kind": "TypeDecl",
+        "name": "SinkingClass",
+        "printedName": "SinkingClass",
+        "children": [
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "SinkingClass",
+                "printedName": "Bread.SinkingClass",
+                "usr": "s:4cake12SinkingClassC"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:4cake12SinkingClassCACycfc",
+            "mangledName": "$s5Bread12SinkingClassCACycfc",
+            "moduleName": "cake",
+            "init_kind": "Designated"
+          }
+        ],
+        "declKind": "Class",
+        "usr": "s:4cake12SinkingClassC",
+        "mangledName": "$s5Bread12SinkingClassC",
+        "moduleName": "cake",
+        "intro_Macosx": "10.7",
+        "declAttributes": [
+          "OriginallyDefinedIn",
+          "Available"
+        ]
+      },
+      {
+        "kind": "TypeDecl",
         "name": "Int",
         "printedName": "Int",
         "children": [

--- a/test/api-digester/Outputs/cake.json
+++ b/test/api-digester/Outputs/cake.json
@@ -1498,6 +1498,40 @@
       },
       {
         "kind": "TypeDecl",
+        "name": "SinkingClass",
+        "printedName": "SinkingClass",
+        "children": [
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "SinkingClass",
+                "printedName": "Bread.SinkingClass",
+                "usr": "s:4cake12SinkingClassC"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:4cake12SinkingClassCACycfc",
+            "mangledName": "$s5Bread12SinkingClassCACycfc",
+            "moduleName": "cake",
+            "init_kind": "Designated"
+          }
+        ],
+        "declKind": "Class",
+        "usr": "s:4cake12SinkingClassC",
+        "mangledName": "$s5Bread12SinkingClassC",
+        "moduleName": "cake",
+        "intro_Macosx": "10.7",
+        "declAttributes": [
+          "OriginallyDefinedIn",
+          "Available"
+        ]
+      },
+      {
+        "kind": "TypeDecl",
         "name": "Int",
         "printedName": "Int",
         "children": [


### PR DESCRIPTION
rdar://93615410
