### PR TITLE
[Concurrency] fix grammatically incorrect phrase in TaskGroup.swift

### DIFF
--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -574,7 +574,7 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   ///     return collected
   ///
   /// Awaiting on an empty group
-  /// immediate returns `nil` without suspending.
+  /// immediately returns `nil` without suspending.
   ///
   /// You can also use a `for`-`await`-`in` loop to collect results of a task group:
   ///


### PR DESCRIPTION
- fixed a grammatically incorrect phrase in stdlib / public / Concurrency / `TaskGroup.swift`
- cc. @amartini51 

```swift
/// Awaiting on an empty group
/// **immediate** returns `nil` without suspending.
→ this should be **immediately**
```