### PR TITLE
[Sema] Allow TreatArrayLiteralAsDictionary fix to handle literals with more than one element

### DIFF
--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -708,10 +708,13 @@ public:
   }
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
+    return diagnose(*commonFixes.front().first);
+  }
 
-  static TreatArrayLiteralAsDictionary *create(ConstraintSystem &cs,
-                                               Type dictionaryTy, Type arrayTy,
-                                               ConstraintLocator *loc);
+  static TreatArrayLiteralAsDictionary *attempt(ConstraintSystem &cs,
+                                                Type dictionaryTy, Type arrayTy,
+                                                ConstraintLocator *loc);
 
   static bool classof(ConstraintFix *fix) {
     return fix->getKind() == FixKind::TreatArrayLiteralAsDictionary;

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -173,12 +173,37 @@ bool TreatArrayLiteralAsDictionary::diagnose(const Solution &solution,
 }
 
 TreatArrayLiteralAsDictionary *
-TreatArrayLiteralAsDictionary::create(ConstraintSystem &cs,
-                                      Type dictionaryTy, Type arrayTy,
-                                      ConstraintLocator *locator) {
-  assert(getAsExpr<ArrayExpr>(locator->getAnchor())->getNumElements() <= 1);
+TreatArrayLiteralAsDictionary::attempt(ConstraintSystem &cs, Type dictionaryTy,
+                                       Type arrayTy,
+                                       ConstraintLocator *locator) {
+  if (!cs.isArrayType(arrayTy))
+    return nullptr;
+
+  // Determine the ArrayExpr from the locator.
+  auto *expr = getAsExpr(simplifyLocatorToAnchor(locator));
+  if (!expr)
+    return nullptr;
+
+  if (auto *AE = dyn_cast<AssignExpr>(expr))
+    expr = AE->getSrc();
+
+  auto *arrayExpr = dyn_cast<ArrayExpr>(expr);
+  if (!arrayExpr)
+    return nullptr;
+
+  // This fix only applies if the array is used as a dictionary.
+  auto unwrappedDict = dictionaryTy->lookThroughAllOptionalTypes();
+  if (unwrappedDict->isTypeVariableOrMember())
+    return nullptr;
+
+  if (!TypeChecker::conformsToKnownProtocol(
+          unwrappedDict, KnownProtocolKind::ExpressibleByDictionaryLiteral,
+          cs.DC->getParentModule()))
+    return nullptr;
+
+  auto arrayLoc = cs.getConstraintLocator(arrayExpr);
   return new (cs.getAllocator())
-      TreatArrayLiteralAsDictionary(cs, dictionaryTy, arrayTy, locator);
+      TreatArrayLiteralAsDictionary(cs, dictionaryTy, arrayTy, arrayLoc);
 }
 
 bool MarkExplicitlyEscaping::diagnose(const Solution &solution,

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -371,6 +371,7 @@ func rdar21078316() {
   var foo : [String : String]?
   var bar : [(String, String)]?
   bar = foo.map { ($0, $1) }  // expected-error {{contextual closure type '([String : String]) throws -> [(String, String)]' expects 1 argument, but 2 were used in closure body}}
+  // expected-error@-1{{cannot convert value of type '(Dictionary<String, String>, _)' to closure result type '[(String, String)]'}}
 }
 
 

--- a/test/Constraints/dictionary_literal.swift
+++ b/test/Constraints/dictionary_literal.swift
@@ -175,6 +175,8 @@ class S59215 {
     // expected-note@-1{{did you mean to use a dictionary literal instead?}} {{17-18=:}}
     m["a"] = [1 , 1] //expected-error{{dictionary of type '[String : String]' cannot be used with array literal}}
     // expected-note@-1{{did you mean to use a dictionary literal instead?}} {{17-18=:}}
+    m["a"] = Optional(["", ""]) //expected-error{{dictionary of type '[String : String]' cannot be used with array literal}}
+    // expected-note@-1{{did you mean to use a dictionary literal instead?}} {{26-27=:}}
   }
 }
 

--- a/test/Constraints/dictionary_literal.swift
+++ b/test/Constraints/dictionary_literal.swift
@@ -85,28 +85,24 @@ var _: [Float: Int] = [1] // expected-error {{dictionary of type '[Float : Int]'
 
 var _: [Int: Int] = ["foo"] // expected-error {{dictionary of type '[Int : Int]' cannot be initialized with array literal}}
 // expected-note@-1 {{did you mean to use a dictionary literal instead?}} {{27-27=: <#value#>}}
-// expected-error@-2 {{cannot convert value of type 'String' to expected dictionary key type 'Int'}}
 
 var _ = useDictStringInt(["Key"]) // expected-error {{dictionary of type 'DictStringInt' cannot be used with array literal}}
 // expected-note@-1 {{did you mean to use a dictionary literal instead?}} {{32-32=: <#value#>}}
 
 var _ = useDictStringInt([4]) // expected-error {{dictionary of type 'DictStringInt' cannot be used with array literal}}
 // expected-note@-1 {{did you mean to use a dictionary literal instead?}} {{28-28=: <#value#>}}
-// expected-error@-2 {{cannot convert value of type 'Int' to expected dictionary key type 'DictStringInt.Key' (aka 'String')}}
 
 var _: [[Int: Int]] = [[5]] // expected-error {{dictionary of type '[Int : Int]' cannot be used with array literal}}
 // expected-note@-1 {{did you mean to use a dictionary literal instead?}} {{26-26=: <#value#>}}
 
 var _: [[Int: Int]] = [["bar"]] // expected-error {{dictionary of type '[Int : Int]' cannot be used with array literal}}
 // expected-note@-1 {{did you mean to use a dictionary literal instead?}} {{30-30=: <#value#>}}
-// expected-error@-2 {{cannot convert value of type 'String' to expected dictionary key type 'Int'}}
 
 assignDict = [1] // expected-error {{dictionary of type '[Int : Int]' cannot be used with array literal}}
 // expected-note@-1 {{did you mean to use a dictionary literal instead?}} {{16-16=: <#value#>}}
 
 assignDict = [""] // expected-error {{dictionary of type '[Int : Int]' cannot be used with array literal}}
 // expected-note@-1 {{did you mean to use a dictionary literal instead?}} {{17-17=: <#value#>}}
-// expected-error@-2 {{cannot convert value of type 'String' to expected dictionary key type 'Int'}}
 
 func arrayLiteralDictionaryMismatch<T>(a: inout T) where T: ExpressibleByDictionaryLiteral, T.Key == Int, T.Value == Int {
   a = [] // expected-error {{use [:] to get an empty dictionary literal}} {{8-8=:}}
@@ -116,7 +112,6 @@ func arrayLiteralDictionaryMismatch<T>(a: inout T) where T: ExpressibleByDiction
 
   a = [""] // expected-error {{dictionary of type 'T' cannot be used with array literal}}
   // expected-note@-1 {{did you mean to use a dictionary literal instead?}} {{10-10=: <#value#>}}
-  // expected-error@-2 {{cannot convert value of type 'String' to expected dictionary key type 'Int'}}
 }
 
 
@@ -167,3 +162,33 @@ func rdar32330004_2() -> [String: Any] {
   // expected-error@-1 {{dictionary of type '[String : Any]' cannot be used with array literal}}
   // expected-note@-2 {{did you mean to use a dictionary literal instead?}} {{14-15=:}} {{24-25=:}} {{34-35=:}} {{46-47=:}}
 }
+
+// https://github.com/apple/swift/issues/59215
+class S59215 {
+  var m: [String: [String: String]] = [:]
+  init() {
+    m["a"] = ["", 1] //expected-error{{dictionary of type '[String : String]' cannot be used with array literal}}
+    // expected-note@-1{{did you mean to use a dictionary literal instead?}} {{17-18=:}}
+    m["a"] = [1 , ""] //expected-error{{dictionary of type '[String : String]' cannot be used with array literal}}
+    // expected-note@-1{{did you mean to use a dictionary literal instead?}} {{17-18=:}}
+    m["a"] = ["", ""] //expected-error{{dictionary of type '[String : String]' cannot be used with array literal}}
+    // expected-note@-1{{did you mean to use a dictionary literal instead?}} {{17-18=:}}
+    m["a"] = [1 , 1] //expected-error{{dictionary of type '[String : String]' cannot be used with array literal}}
+    // expected-note@-1{{did you mean to use a dictionary literal instead?}} {{17-18=:}}
+  }
+}
+
+func f59215(_ a: [String: String]) {}
+f59215(["", 1]) //expected-error{{dictionary of type '[String : String]' cannot be used with array literal}}
+// expected-note@-1{{did you mean to use a dictionary literal instead?}} {{11-12=:}}
+f59215([1 , ""]) //expected-error{{dictionary of type '[String : String]' cannot be used with array literal}}
+// expected-note@-1{{did you mean to use a dictionary literal instead?}} {{11-12=:}}
+f59215([1 , 1]) //expected-error{{dictionary of type '[String : String]' cannot be used with array literal}}
+// expected-note@-1{{did you mean to use a dictionary literal instead?}} {{11-12=:}}
+f59215(["", ""]) //expected-error{{dictionary of type '[String : String]' cannot be used with array literal}}
+// expected-note@-1{{did you mean to use a dictionary literal instead?}} {{11-12=:}}
+
+f59215(["", "", "", ""]) //expected-error{{dictionary of type '[String : String]' cannot be used with array literal}}
+// expected-note@-1{{did you mean to use a dictionary literal instead?}} {{11-12=:}} {{19-20=:}}
+f59215(["", "", "", ""]) //expected-error{{dictionary of type '[String : String]' cannot be used with array literal}}
+// expected-note@-1{{did you mean to use a dictionary literal instead?}} {{11-12=:}} {{19-20=:}}

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -506,7 +506,7 @@ func rdar85166519() {
 
   var _: [Int: AnyObject] = [ // expected-error {{dictionary of type '[Int : AnyObject]' cannot be initialized with array literal}}
     // expected-note@-1 {{did you mean to use a dictionary literal instead?}}
-    v?.addingReportingOverflow(0) // expected-error {{cannot convert value of type '(partialValue: Int, overflow: Bool)?' to expected dictionary key type 'Int'}}
+    v?.addingReportingOverflow(0)
   ]
 }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
This enables recording `TreatArrayLiteralAsDictionary` for every literal sized array where before only size 1 where recorded which in the cases of the issue reported lead to an unhandled ambiguity. 
Also, by allowing the fix to be recorded, if there is a fix for the dictionary being used as array literal this skips recording fixes for mismatching element types as it adds more verbosity and confusion to the diagnostics and the correlation between array literal elements and dictionary key/value can be unclear and skipping this allows the diagnostic to focus on suggesting the use of the correct dictionary literal. I did thought back and fourth for some time with this part, so let me know what you think.
An NFC item is the move of the attempt to repair logic to the fix method `attempt`. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves https://github.com/apple/swift/issues/59215.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
