### PR TITLE
[android][test] Fix several tests on the Android CI

### DIFF
--- a/test/Driver/Dependencies/only-skip-once.swift
+++ b/test/Driver/Dependencies/only-skip-once.swift
@@ -1,4 +1,4 @@
-// XFAIL: OS=linux-gnu, OS=openbsd, OS=windows-msvc
+// XFAIL: OS=linux-gnu, OS=openbsd, OS=windows-msvc, OS=linux-android, OS=linux-androideabi
 
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/only-skip-once/* %t

--- a/test/Driver/parseable_output.swift
+++ b/test/Driver/parseable_output.swift
@@ -1,6 +1,6 @@
 // RUN: %swiftc_driver_plain -emit-executable %s -o %t.out -emit-module -emit-module-path %t.swiftmodule -emit-objc-header-path %t.h -serialize-diagnostics -emit-dependencies -parseable-output -driver-skip-execution 2>&1 | %FileCheck %s
 
-// XFAIL: OS=freebsd, OS=openbsd, OS=linux-gnu
+// XFAIL: OS=freebsd, OS=openbsd, OS=linux-gnu, OS=linux-android, OS=linux-androideabi
 
 // CHECK: {{[1-9][0-9]*}}
 // CHECK-NEXT: {

--- a/test/Driver/parseable_output_unicode.swift
+++ b/test/Driver/parseable_output_unicode.swift
@@ -2,7 +2,7 @@
 // RUN: cat "%S/Inputs/unicode.txt" >> %t.rsp
 // RUN: %swiftc_driver_plain -emit-executable @%t.rsp -o %t.out -emit-module -emit-module-path %t.swiftmodule -emit-objc-header-path %t.h -serialize-diagnostics -emit-dependencies -parseable-output -driver-skip-execution 2>&1 | %FileCheck %s
 
-// XFAIL: OS=freebsd, OS=openbsd, OS=linux-gnu
+// XFAIL: OS=freebsd, OS=openbsd, OS=linux-gnu, OS=linux-android, OS=linux-androideabi
 
 // CHECK: {{[1-9][0-9]*}}
 // CHECK-NEXT: {

--- a/test/Driver/sdk-apple.swift
+++ b/test/Driver/sdk-apple.swift
@@ -1,4 +1,4 @@
-// XFAIL: OS=freebsd, OS=openbsd, OS=linux-gnu, OS=windows-msvc
+// XFAIL: OS=freebsd, OS=openbsd, OS=linux-gnu, OS=windows-msvc, OS=linux-android, OS=linux-androideabi
 
 // Test SDK detection for immediate mode.
 // RUN: %empty-directory(%t)

--- a/test/IDE/print_clang_header_i386.swift
+++ b/test/IDE/print_clang_header_i386.swift
@@ -1,7 +1,6 @@
 // REQUIRES: OS=macosx
 // REQUIRES: CPU=x86_64
 // FIXME: rdar://problem/19648117 Needs splitting objc parts out
-// XFAIL: OS=linux-gnu, OS=freebsd
 
 // RUN: echo '#include "header-to-print.h"' > %t.i386.m
 // RUN: %empty-directory(%t)

--- a/test/IRGen/abitypes.swift
+++ b/test/IRGen/abitypes.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/abi %s -emit-ir -enable-objc-interop | %FileCheck -check-prefix=%target-cpu-%target-os-abi %s
 
 // FIXME: rdar://problem/19648117 Needs splitting objc parts out
-// XFAIL: OS=linux-gnu, OS=windows-msvc, OS=openbsd
+// XFAIL: OS=linux-gnu, OS=windows-msvc, OS=openbsd, OS=linux-android, OS=linux-androideabi
 
 import gadget
 import Foundation

--- a/test/Interop/Cxx/foreign-reference/error-in-generic-context.swift
+++ b/test/Interop/Cxx/foreign-reference/error-in-generic-context.swift
@@ -1,6 +1,8 @@
 // RUN: rm -rf %t
 // RUN: split-file %s %t
 // RUN: not %target-swift-frontend -emit-ir -I %t/Inputs  %t/test.swift  -enable-experimental-cxx-interop 2>&1 | %FileCheck %s
+//
+// XFAIL: OS=linux-android, OS=linux-androideabi
 
 //--- Inputs/module.modulemap
 module Test {

--- a/test/Interop/Cxx/foreign-reference/move-only-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/move-only-irgen.swift
@@ -1,4 +1,6 @@
 // RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -validate-tbd-against-ir=none -disable-llvm-verify | %FileCheck %s
+//
+// XFAIL: OS=linux-android, OS=linux-androideabi
 
 import MoveOnly
 

--- a/test/Interop/Cxx/foreign-reference/move-only-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/move-only-module-interface.swift
@@ -1,4 +1,6 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=MoveOnly -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
+//
+// XFAIL: OS=linux-android, OS=linux-androideabi
 
 // CHECK: class MoveOnly {
 // CHECK-NOT: init

--- a/test/Interop/Cxx/foreign-reference/move-only-silgen.swift
+++ b/test/Interop/Cxx/foreign-reference/move-only-silgen.swift
@@ -1,4 +1,6 @@
 // RUN: %target-swift-emit-silgen %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
+//
+// XFAIL: OS=linux-android, OS=linux-androideabi
 
 import MoveOnly
 

--- a/test/Interop/Cxx/foreign-reference/nullable-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/nullable-module-interface.swift
@@ -1,4 +1,6 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=Nullable -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
+//
+// XFAIL: OS=linux-android, OS=linux-androideabi
 
 // CHECK: class Empty {
 // CHECK:   func test() -> Int32

--- a/test/Interop/Cxx/foreign-reference/pod-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/pod-irgen.swift
@@ -1,4 +1,6 @@
 // RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -validate-tbd-against-ir=none -disable-llvm-verify | %FileCheck %s
+//
+// XFAIL: OS=linux-android, OS=linux-androideabi
 
 import POD
 

--- a/test/Interop/Cxx/foreign-reference/pod-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/pod-module-interface.swift
@@ -1,4 +1,6 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=POD -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
+//
+// XFAIL: OS=linux-android, OS=linux-androideabi
 
 // CHECK: class Empty {
 // CHECK-NOT: init

--- a/test/Interop/Cxx/foreign-reference/pod-silgen.swift
+++ b/test/Interop/Cxx/foreign-reference/pod-silgen.swift
@@ -1,4 +1,6 @@
 // RUN: %target-swift-emit-silgen %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
+//
+// XFAIL: OS=linux-android, OS=linux-androideabi
 
 import POD
 

--- a/test/Interop/Cxx/foreign-reference/singleton-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/singleton-irgen.swift
@@ -1,4 +1,6 @@
 // RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -validate-tbd-against-ir=none -disable-llvm-verify | %FileCheck %s
+//
+// XFAIL: OS=linux-android, OS=linux-androideabi
 
 import Singleton
 

--- a/test/Interop/Cxx/foreign-reference/singleton-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/singleton-module-interface.swift
@@ -1,4 +1,6 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=Singleton -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
+//
+// XFAIL: OS=linux-android, OS=linux-androideabi
 
 // CHECK: class DeletedDtor {
 // CHECK-NOT: init

--- a/test/Interop/Cxx/foreign-reference/singleton-silgen.swift
+++ b/test/Interop/Cxx/foreign-reference/singleton-silgen.swift
@@ -1,4 +1,6 @@
 // RUN: %target-swift-emit-silgen %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
+//
+// XFAIL: OS=linux-android, OS=linux-androideabi
 
 import Singleton
 

--- a/test/Prototypes/CollectionTransformers.swift
+++ b/test/Prototypes/CollectionTransformers.swift
@@ -200,7 +200,7 @@ import Darwin
 import Dispatch
 
 // FIXME: port to Linux.
-// XFAIL: OS=linux-gnu, OS=windows-msvc, OS=openbsd
+// XFAIL: OS=linux-gnu, OS=windows-msvc, OS=openbsd, OS=linux-android
 
 // A wrapper for pthread_t with platform-independent interface.
 public struct _stdlib_pthread_t : Equatable, Hashable {

--- a/test/Reflection/box_descriptors.sil
+++ b/test/Reflection/box_descriptors.sil
@@ -3,7 +3,7 @@
 // RUN: %target-swift-reflection-dump -binary-filename %t/capture_descriptors%{target-shared-library-suffix} | %FileCheck %s
 
 // SR-10758
-// UNSUPPORTED: OS=linux-gnu
+// UNSUPPORTED: OS=linux-gnu, OS=linux-android, OS=linux-androideabi
 
 // SR-12893
 // XFAIL: OS=openbsd

--- a/test/SIL/clang-function-types-android.swift
+++ b/test/SIL/clang-function-types-android.swift
@@ -6,10 +6,10 @@ import ctypes
 
 public func f(g: @convention(c, cType: "void (*)(size_t)") (Int) -> ()) { g(0) }
 
-// CHECK-32: sil @$s4main1f1gyySiXzC9_ZTSPFvjE_tF : $@convention(thin) (@convention(c, cType: "void (*)(unsigned int)") @noescape (Int) -> ()) -> () {
-// CHECK-32: bb0(%0 : $@convention(c, cType: "void (*)(unsigned int)") @noescape (Int) -> ()):
-// CHECK-32:   debug_value %0 : $@convention(c, cType: "void (*)(unsigned int)") @noescape (Int) -> (), let, name "g", argno 1 // id: %1
+// CHECK-32: sil @$s4main1f1gyySiXzC9_ZTSPFvjE_tF : $@convention(thin) (@convention(c, cType: "void (*)(unsigned int)") (Int) -> ()) -> () {
+// CHECK-32: bb0(%0 : $@convention(c, cType: "void (*)(unsigned int)") (Int) -> ()):
+// CHECK-32:   debug_value %0 : $@convention(c, cType: "void (*)(unsigned int)") (Int) -> (), let, name "g", argno 1 // id: %1
 
-// CHECK-64: sil @$s4main1f1gyySiXzC9_ZTSPFvmE_tF : $@convention(thin) (@convention(c, cType: "void (*)(unsigned long)") @noescape (Int) -> ()) -> () {
-// CHECK-64: bb0(%0 : $@convention(c, cType: "void (*)(unsigned long)") @noescape (Int) -> ()):
-// CHECK-64:   debug_value %0 : $@convention(c, cType: "void (*)(unsigned long)") @noescape (Int) -> (), let, name "g", argno 1 // id: %1
+// CHECK-64: sil @$s4main1f1gyySiXzC9_ZTSPFvmE_tF : $@convention(thin) (@convention(c, cType: "void (*)(unsigned long)") (Int) -> ()) -> () {
+// CHECK-64: bb0(%0 : $@convention(c, cType: "void (*)(unsigned long)") (Int) -> ()):
+// CHECK-64:   debug_value %0 : $@convention(c, cType: "void (*)(unsigned long)") (Int) -> (), let, name "g", argno 1 // id: %1

--- a/test/SILOptimizer/concat_string_literals.64.swift
+++ b/test/SILOptimizer/concat_string_literals.64.swift
@@ -5,6 +5,10 @@
 // We have a separate test for 32-bit architectures.
 // REQUIRES: PTRSIZE=64
 
+// The string tag was recently shifted to the second byte on Android AArch64,
+// so these tests will need to be adapted for that.
+// XFAIL: OS=linux-android && CPU=aarch64
+
 // NOTE: 25185.byteSwapped = 0x62 'a', 0x61 'b'
 // CHECK-LABEL: test_ascii_scalar_scalar2
 // CHECK:  ret { i64, %swift.bridge* } { i64 25185, %swift.bridge* inttoptr (i64 -{{[0-9]+}} to %swift.bridge*) }

--- a/test/Sanitizers/tsan/objc_async.swift
+++ b/test/Sanitizers/tsan/objc_async.swift
@@ -7,8 +7,6 @@
 // REQUIRES: concurrency
 // REQUIRES: objc_interop
 // REQUIRES: tsan_runtime
-// UNSUPPORTED: OS=linux-gnu
-// UNSUPPORTED: OS=windows-msvc
 
 // rdar://76038845
 // UNSUPPORTED: use_os_stdlib

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1966,7 +1966,7 @@ def source_compiler_rt_libs(path):
                                         and config.compiler_rt_platform in lib])
 
 compiler_rt_dir = make_path(test_resource_dir, 'clang', 'lib',
-                            platform.system().lower() if not kIsAndroid else 'android')
+                            platform.system().lower())
 source_compiler_rt_libs(compiler_rt_dir)
 
 def check_runtime_libs(features_to_check):

--- a/test/stdlib/simd_diagnostics.swift
+++ b/test/stdlib/simd_diagnostics.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 
 // FIXME: No simd module on linux rdar://problem/20795411
-// XFAIL: OS=linux-gnu, OS=windows-msvc, OS=openbsd
+// XFAIL: OS=linux-gnu, OS=windows-msvc, OS=openbsd, OS=linux-android, OS=linux-androideabi
 // XFAIL: OS=wasi
 
 import simd

--- a/validation-test/SILOptimizer/large_string_array.swift.gyb
+++ b/validation-test/SILOptimizer/large_string_array.swift.gyb
@@ -13,7 +13,7 @@
 
 // REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 // REQUIRES: long_test
-// REQUIRES: CPU=arm64 || CPU=x86_64
+// REQUIRES: CPU=arm64 || CPU=x86_64 || CPU=aarch64
 
 // Check if the optimizer can optimize the whole array into a statically
 // initialized global

--- a/validation-test/stdlib/SIMDParameterPassing.swift.gyb
+++ b/validation-test/stdlib/SIMDParameterPassing.swift.gyb
@@ -18,7 +18,7 @@
 
 // REQUIRES: executable_test
 // REQUIRES: long_test
-// XFAIL: OS=linux-gnu
+// XFAIL: OS=linux-gnu, OS=linux-android
 
 import StdlibUnittest
 import simd


### PR DESCRIPTION
- #58975 switched many tests from XFAIL on linux to linux-gnu, so seven fail on the Android CI and two natively. They are now explicitly excluded.
- #39605 added several C++ Interop tests, 11 of which fail on the Android CI, so disable them for now.
- #42478 removed the @noescape attribute for the non-Android `SIL/clang-function-types` tests, so I remove it for Android too.
- My pull #40779 moved the Swift pointer tags to the second byte, so `SILOptimizer/concat_string_literals.64` will need to be updated for that, disabled it for now.
- Compiler-rt moved the directory in which it places those libraries for Android, llvm/llvm-project@a68ccba, so lit.cfg is updated for that.

Also, these five tests were all disabled on `linux` before #58975 but [pass on the Android CI now](https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android-arm64/lastBuild/console), so I left them enabled for Android. Maybe they should be enabled for linux-gnu too:

AutoDiff/compiler_crashers_fixed/rdar71191415-nested-differentiation-of-extension-method-optimized
SILOptimizer/addr_escape_info
SILOptimizer/escape_info
SILOptimizer/ranges
Sema/type_checker_perf/fast/rdar54580427

Another 5-10 tests are now enabled natively on Android, I will kick off a native build and test run of the toolchain with the next trunk snapshot tag and update this pull to disable them again if any fail.

Once this pull gets these tests fixed, all that remains is [the 11 C++ Interop foreign reference tests that have been failing on the Android CI](https://github.com/apple/swift/pull/59120#issuecomment-1142599391) since they were added late last year. I can simply disable them all for Android, or if @zoecarver has any suggestions, we could try to fix them.

@bnbarham, you modified most of these tests, let me know what you think.

@compnerd and @drodriguez, trying to get the Android CI passing again, feedback welcome.