### PR TITLE
[android] Update to LTS NDK 23c

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,7 +315,7 @@ set(SWIFT_ANDROID_API_LEVEL "" CACHE STRING
 
 set(SWIFT_ANDROID_NDK_PATH "" CACHE STRING
   "Path to the directory that contains the Android NDK tools that are executable on the build machine")
-set(SWIFT_ANDROID_NDK_CLANG_VERSION "12.0.8" CACHE STRING
+set(SWIFT_ANDROID_NDK_CLANG_VERSION "12.0.9" CACHE STRING
   "The Clang version to use when building for Android.")
 set(SWIFT_ANDROID_DEPLOY_DEVICE_PATH "" CACHE STRING
   "Path on an Android device where build products will be pushed. These are used when running the test suite against the device")

--- a/docs/Android.md
+++ b/docs/Android.md
@@ -1,8 +1,8 @@
 # Getting Started with Swift on Android
 
-The Swift stdlib can be compiled for Android armv7, x86_64, and aarch64 targets,
-which makes it possible to execute Swift code on a mobile device running
-Android or an emulator. This guide explains:
+The Swift standard library (stdlib) can be compiled for Android armv7, x86_64,
+and aarch64 targets, which makes it possible to execute Swift code on a mobile
+device running Android or an emulator. This guide explains:
 
 1. How to run a simple "Hello, world" program on your Android device.
 2. How to run the Swift test suite on an Android device.
@@ -12,7 +12,7 @@ bug using https://bugs.swift.org/.
 
 ## FAQ
 
-Let's answer a few frequently asked questions right off the bat:
+Let's answer a frequently asked question right off the bat:
 
 ### Does this mean I can write Android applications in Swift?
 
@@ -30,32 +30,44 @@ Swift-to-Java bridging.
 To follow along with this guide, you'll need:
 
 1. A Linux environment capable of building Swift from source, preferably
-   Ubuntu 18.04 or Ubuntu 16.04. Before attempting to build for Android,
+   Ubuntu 20.04 or Ubuntu 18.04. Before attempting to build for Android,
    please make sure you are able to build for Linux by following the
    instructions in the Swift project README.
-2. The latest version of the Android NDK (r23b at the time of this writing),
+2. The latest build of the Swift compiler for your Linux distro, available at
+   https://www.swift.org/download/ or sometimes your distro package manager.
+3. The latest version of the Android LTS NDK (r23c at the time of this writing),
    available to download here:
-   https://developer.android.com/ndk/downloads/index.html.
-3. An Android device with remote debugging enabled or the emulator. We require
+   https://developer.android.com/ndk/downloads
+4. An Android device with remote debugging enabled or the emulator. We require
    remote debugging in order to deploy built stdlib products to the device. You
    may turn on remote debugging by following the official instructions:
-   https://developer.chrome.com/devtools/docs/remote-debugging.
+   https://developer.chrome.com/devtools/docs/remote-debugging .
 
 ## "Hello, world" on Android
 
-### 1. Building the Swift stdlib for Android
+### 1. Building the standalone Swift stdlib for Android
 
-Enter your Swift directory, then run the build script, passing the path to the
-Android NDK:
+Enter your Swift directory, check out the tag corresponding to the prebuilt
+Swift compiler, then run the build script, passing the path to the Android NDK
+and the prebuilt Swift toolchain (add --skip-early-swift-driver if you already
+have a Swift toolchain in your path):
 
 ```
-$ NDK_PATH=path/to/android-ndk-r23b
+$ NDK_PATH=path/to/android-ndk-r23c
+$ SWIFT_PATH=path/to/swift-DEVELOPMENT-SNAPSHOT-2022-05-31-a-ubuntu20.04/usr/bin
+$ git checkout swift-DEVELOPMENT-SNAPSHOT-2022-05-31-a
 $ utils/build-script \
     -R \                                       # Build in ReleaseAssert mode.
     --android \                                # Build for Android.
     --android-ndk $NDK_PATH \                  # Path to an Android NDK.
-    --android-arch armv7 \                     # Optionally specify Android architecture, alternately aarch64 or x86_64
-    --android-api-level 21                     # The Android API level to target. Swift only supports 21 or greater.
+    --android-arch aarch64 \                   # Optionally specify Android architecture, alternately armv7 or x86_64
+    --android-api-level 21 \                   # The Android API level to target. Swift only supports 21 or greater.
+    --stdlib-deployment-targets=android-aarch64 \ # Only cross-compile the stdlib for Android, ie don't build the native stdlib for Linux
+    --native-swift-tools-path=$SWIFT_PATH \    # Path to your prebuilt Swift compiler
+    --native-clang-tools-path=$SWIFT_PATH \    # Path to a prebuilt clang compiler, one comes with the Swift toolchain
+    --build-swift-tools=0 \                    # Don't build the Swift compiler and other host tools
+    --build-llvm=0 \                           # Don't build the LLVM libraries, but generate some CMake files needed by the Swift stdlib build
+    --skip-build-cmark                         # Don't build the CommonMark library that's only needed by the Swift compiler
 ```
 
 ### 2. Compiling `hello.swift` to run on an Android device
@@ -66,15 +78,16 @@ Create a simple Swift file named `hello.swift`:
 print("Hello, Android")
 ```
 
-Then use the built Swift compiler from the previous step to compile a Swift
+Then use the standalone Swift stdlib from the previous step to compile a Swift
 source file, targeting Android:
 
 ```
-$ NDK_PATH="path/to/android-ndk-r23b"
-$ build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swiftc \          # The Swift compiler built in the previous step
+$ NDK_PATH="path/to/android-ndk-r23c"
+$ SWIFT_PATH=path/to/swift-DEVELOPMENT-SNAPSHOT-2022-05-31-a-ubuntu20.04/usr/bin
+$ $SWIFT_PATH/swiftc \                                               # The prebuilt Swift compiler you downloaded
                                                                      # The location of the tools used to build Android binaries
     -tools-directory ${NDK_PATH}/toolchains/llvm/prebuilt/linux-x86_64/bin/ \
-    -target armv7-unknown-linux-androideabi21 \                      # Targeting Android armv7 at API 21
+    -target aarch64-unknown-linux-android21 \                        # Targeting Android aarch64 at API 21
     -sdk ${NDK_PATH}/toolchains/llvm/prebuilt/linux-x86_64/sysroot \ # The SDK is the Android unified sysroot and the resource-dir is where you just built the Swift stdlib.
     -resource-dir build/Ninja-ReleaseAssert/swift-linux-x86_64/lib/swift
     hello.swift
@@ -111,12 +124,15 @@ $ adb push build/Ninja-ReleaseAssert/swift-linux-x86_64/lib/swift/android/libswi
 $ adb push build/Ninja-ReleaseAssert/swift-linux-x86_64/lib/swift/android/libswiftGlibc.so /data/local/tmp
 $ adb push build/Ninja-ReleaseAssert/swift-linux-x86_64/lib/swift/android/libswiftSwiftOnoneSupport.so /data/local/tmp
 $ adb push build/Ninja-ReleaseAssert/swift-linux-x86_64/lib/swift/android/libswiftRemoteMirror.so /data/local/tmp
+$ adb push build/Ninja-ReleaseAssert/swift-linux-x86_64/lib/swift/android/libswift_Concurrency.so /data/local/tmp
+$ adb push build/Ninja-ReleaseAssert/swift-linux-x86_64/lib/swift/android/libdispatch.so /data/local/tmp
+$ adb push build/Ninja-ReleaseAssert/swift-linux-x86_64/lib/swift/android/libBlocksRuntime.so /data/local/tmp
 ```
 
 In addition, you'll also need to copy the Android NDK's libc++:
 
 ```
-$ adb push /path/to/android-ndk-r23b/sources/cxx-stl/llvm-libc++/libs/armeabi-v7a/libc++_shared.so /data/local/tmp
+$ adb push /path/to/android-ndk-r23c/sources/cxx-stl/llvm-libc++/libs/arm64-v8a/libc++_shared.so /data/local/tmp
 ```
 
 Finally, you'll need to copy the `hello` executable you built in the
@@ -157,9 +173,12 @@ device. As in part three, you'll need to connect your Android device via USB:
 ```
 $ utils/build-script \
   -R \                               # Build in ReleaseAssert mode.
-  -T \                               # Run all tests, including on the Android device (add --host-test to only run Android tests on the linux host).
+  -T \                               # Run all tests, including on the Android device (add --host-test to only run Android tests on the Linux host).
   --android \                        # Build for Android.
-  --android-ndk ~/android-ndk-r23b \  # Path to an Android NDK.
-  --android-arch armv7 \             # Optionally specify Android architecture, alternately aarch64
+  --android-ndk ~/android-ndk-r23c \  # Path to an Android NDK.
+  --android-arch aarch64 \           # Optionally specify Android architecture, alternately armv7
   --android-api-level 21
 ```
+
+This will build the Swift compiler and other host tools first, so expect a much
+longer build.


### PR DESCRIPTION
Also, switch the build instructions in the doc to the much more common AArch64, add instructions to cross-compile a standalone stdlib with a prebuilt toolchain, and add missing Concurrency library and its dependencies to the list of Swift libraries to copy over.

@drodriguez, should be an easy review since it's mostly doc changes, but the Android CI will need its LTS NDK updated to 23c for this pull not to break it. 