### PR TITLE
[5.7] Sema: Diagnose @_backDeploy attributes on initializers and deinitializers

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1524,6 +1524,9 @@ WARNING(access_control_non_objc_open_member,none,
 
 ERROR(invalid_decl_attribute,none,
       "'%0' attribute cannot be applied to this declaration", (DeclAttribute))
+ERROR(attr_invalid_on_decl_kind,none,
+      "'%0' attribute cannot be applied to %1 declarations",
+      (DeclAttribute, DescriptiveDeclKind))
 ERROR(invalid_decl_modifier,none,
       "%0 modifier cannot be applied to this declaration", (DeclAttribute))
 ERROR(attribute_does_not_apply_to_type,none,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3626,6 +3626,12 @@ void AttributeChecker::checkBackDeployAttrs(ArrayRef<BackDeployAttr *> Attrs) {
       }
     }
 
+    if (isa<DestructorDecl>(D) || isa<ConstructorDecl>(D)) {
+      diagnoseAndRemoveAttr(Attr, diag::attr_invalid_on_decl_kind, Attr,
+                            D->getDescriptiveKind());
+      continue;
+    }
+
     auto AtLoc = Attr->AtLoc;
     auto Platform = Attr->Platform;
 

--- a/test/attr/attr_backDeploy.swift
+++ b/test/attr/attr_backDeploy.swift
@@ -128,6 +128,16 @@ extension TopLevelProtocol {
 @_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' attribute cannot be applied to this declaration}}
 public class CannotBackDeployClass {}
 
+public final class CannotBackDeployClassInitDeinit {
+  @available(macOS 11.0, *)
+  @_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' attribute cannot be applied to initializer declarations}}
+  public init() {}
+
+  @available(macOS 11.0, *)
+  @_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' attribute cannot be applied to deinitializer declarations}}
+  deinit {}
+}
+
 @_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' attribute cannot be applied to this declaration}}
 public struct CannotBackDeployStruct {
   @_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' must not be used on stored properties}}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/59283

Applying the `@_backDeploy` attribute to an initializer currently causes a duplicate symbol error at link time so for now reject it on those declarations for clarity. Also, reject it on deinitializers as well since the attribute cannot have the desired effect on `deinit`.

Resolves rdar://94450734