### PR TITLE
[Test] Reenable reflect_task.swift on Darwin.

### DIFF
--- a/test/Concurrency/Reflection/reflect_task.swift
+++ b/test/Concurrency/Reflection/reflect_task.swift
@@ -9,8 +9,6 @@
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
-//
-// UNSUPPORTED: OS=macosx, OS=ios, OS=watchos, OS=tvos
 
 import Swift
 import _Concurrency


### PR DESCRIPTION
This test was temporarily disabled while Remote Mirror was being upgraded to handle task escalation, but it works now.

rdar://94454729