### PR TITLE
Tests: Mark test/stdlib/StringCreate.swift as unsupported on back deployment bots

### DIFF
--- a/test/stdlib/StringCreate.swift
+++ b/test/stdlib/StringCreate.swift
@@ -2,8 +2,7 @@
 // REQUIRES: executable_test
 
 // rdar://91405760
-// XFAIL: use_os_stdlib
-// XFAIL: back_deployment_runtime
+// UNSUPPORTED: use_os_stdlib, back_deployment_runtime
 
 import StdlibUnittest
 defer { runAllTests() }


### PR DESCRIPTION
Using XFAIL won't work here because the tests pass on the iOS back deployment bots, resulting in a UPASS.

I was able to take a look at the test binary and rule out both codegen for `if #available(...)` and the optimizer as culprits so the next step is to check if `_stdlib_isOSVersionAtLeast()` is actually busted in the runtime libraries in older versions of macOS.