### PR TITLE
[cxx-interop] Don't expose async or @_alwaysEmitIntoClient functions

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1112,7 +1112,8 @@ private:
     if (outputLang == OutputLanguageMode::Cxx) {
       // Don't expose async functions or @_alwaysEmitIntoClient functions
       // because they're currently unsupported
-      if (FD->hasAsync() || FD->getAttrs().hasAttribute<AlwaysEmitIntoClientAttr>()) {
+      if (FD->hasAsync() ||
+          FD->getAttrs().hasAttribute<AlwaysEmitIntoClientAttr>()) {
         return;
       }
 

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1110,9 +1110,9 @@ private:
 
   void visitFuncDecl(FuncDecl *FD) {
     if (outputLang == OutputLanguageMode::Cxx) {
-      // Don't expose async functions or transparent functions
+      // Don't expose async functions or @_alwaysEmitIntoClient functions
       // because they're currently unsupported
-      if (FD->hasAsync() || FD->isTransparent()) {
+      if (FD->hasAsync() || FD->getAttrs().hasAttribute<AlwaysEmitIntoClientAttr>()) {
         return;
       }
 

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1110,6 +1110,12 @@ private:
 
   void visitFuncDecl(FuncDecl *FD) {
     if (outputLang == OutputLanguageMode::Cxx) {
+      // Don't expose async functions or transparent functions
+      // because they're currently unsupported
+      if (FD->hasAsync() || FD->isTransparent()) {
+        return;
+      }
+
       // Emit the underlying C signature that matches the Swift ABI
       // in the generated C++ implementation prologue for the module.
       auto funcABI = getModuleProloguePrinter()

--- a/test/Interop/SwiftToCxx/functions/swift-no-expose-unsupported-alwaysEmitInClient-func.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-no-expose-unsupported-alwaysEmitInClient-func.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -module-name Functions -clang-header-expose-public-decls -emit-clang-header-path %t/functions.h
+// RUN: %FileCheck %s < %t/functions.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/functions.h)
+
+// CHECK-NOT: SWIFT_EXTERN bool $s9Functions24alwaysEmitIntoClientFuncyS2bF(bool x) SWIFT_NOEXCEPT SWIFT_CALL; // alwaysEmitIntoClientFunc(_:)
+
+// CHECK:       namespace Functions {
+// CHECK-EMPTY:
+// CHECK-EMPTY:
+// CHECK-EMPTY:
+// CHECK-EMPTY:
+// CHECK-NEXT:  } // namespace Functions
+
+// CHECK-NOT: inline bool alwaysEmitIntoClientFunc(bool x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NOT:   return _impl::$s9Functions24alwaysEmitIntoClientFuncyS2bF(x);
+// CHECK-NOT: }
+
+@_alwaysEmitIntoClient
+public func alwaysEmitIntoClientFunc(_ x: Bool) -> Bool { return !x }

--- a/test/Interop/SwiftToCxx/functions/swift-no-expose-unsupported-async-func.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-no-expose-unsupported-async-func.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Functions -clang-header-expose-public-decls -emit-clang-header-path %t/functions.h
+// RUN: %target-swift-frontend %s -typecheck -module-name Functions -disable-availability-checking -clang-header-expose-public-decls -emit-clang-header-path %t/functions.h
 // RUN: %FileCheck %s < %t/functions.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/functions.h)

--- a/test/Interop/SwiftToCxx/functions/swift-no-expose-unsupported-async-func.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-no-expose-unsupported-async-func.swift
@@ -4,7 +4,6 @@
 
 // RUN: %check-interop-cxx-header-in-clang(%t/functions.h)
 
-// CHECK-NOT: SWIFT_EXTERN bool $s9Functions24alwaysEmitIntoClientFuncyS2bF(bool x) SWIFT_NOEXCEPT SWIFT_CALL; // alwaysEmitIntoClientFunc(_:)
 // CHECK-NOT: SWIFT_EXTERN double $s9Functions9asyncFuncyS2dYaF(double x) SWIFT_NOEXCEPT SWIFT_CALL; // asyncFunc(_:)
 
 // CHECK:       namespace Functions {
@@ -12,19 +11,12 @@
 // CHECK-EMPTY:
 // CHECK-EMPTY:
 // CHECK-EMPTY:
-// CHECK-EMPTY:
-// CHECK-EMPTY:
 // CHECK-NEXT:  } // namespace Functions
-
-// CHECK-NOT: inline bool alwaysEmitIntoClientFunc(bool x) noexcept SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NOT:   return _impl::$s9Functions24alwaysEmitIntoClientFuncyS2bF(x);
-// CHECK-NOT: }
 
 // CHECK-NOT: inline double asyncFunc(double x) noexcept SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NOT:   return _impl::$s9Functions9asyncFuncyS2dYaF(x);
 // CHECK-NOT: }
 
-public func asyncFunc(_ x: Double) async -> Double { return 2 * x }
+// REQUIRES: concurrency
 
-@_alwaysEmitIntoClient
-public func alwaysEmitIntoClientFunc(_ x: Bool) -> Bool { return !x }
+public func asyncFunc(_ x: Double) async -> Double { return 2 * x }

--- a/test/Interop/SwiftToCxx/functions/swift-no-expose-unsupported-func.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-no-expose-unsupported-func.swift
@@ -4,8 +4,8 @@
 
 // RUN: %check-interop-cxx-header-in-clang(%t/functions.h)
 
-// CHECK-NOT: SWIFT_EXTERN double $s9Functions10async_funcyS2dYaF(double x) SWIFT_NOEXCEPT SWIFT_CALL; // async_func(_:)
-// CHECK-NOT: SWIFT_EXTERN bool $s9Functions16transparent_funcyS2bF(bool x) SWIFT_NOEXCEPT SWIFT_CALL; // transparent_func(_:)
+// CHECK-NOT: SWIFT_EXTERN bool $s9Functions24alwaysEmitIntoClientFuncyS2bF(bool x) SWIFT_NOEXCEPT SWIFT_CALL; // alwaysEmitIntoClientFunc(_:)
+// CHECK-NOT: SWIFT_EXTERN double $s9Functions9asyncFuncyS2dYaF(double x) SWIFT_NOEXCEPT SWIFT_CALL; // asyncFunc(_:)
 
 // CHECK:       namespace Functions {
 // CHECK-EMPTY:
@@ -16,15 +16,15 @@
 // CHECK-EMPTY:
 // CHECK-NEXT:  } // namespace Functions
 
-// CHECK-NOT:  inline double async_func(double x) noexcept SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NOT:   return _impl::$s9Functions10async_funcyS2dYaF(x);
+// CHECK-NOT: inline bool alwaysEmitIntoClientFunc(bool x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NOT:   return _impl::$s9Functions24alwaysEmitIntoClientFuncyS2bF(x);
 // CHECK-NOT: }
 
-// CHECK-NOT:  inline bool transparent_func(bool x) noexcept SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NOT:   return _impl::$s9Functions16transparent_funcyS2bF(x);
+// CHECK-NOT: inline double asyncFunc(double x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NOT:   return _impl::$s9Functions9asyncFuncyS2dYaF(x);
 // CHECK-NOT: }
 
-public func async_func(_ x: Double) async -> Double { return 2 * x }
+public func asyncFunc(_ x: Double) async -> Double { return 2 * x }
 
-@_transparent
-public func transparent_func(_ x: Bool) -> Bool { return !x }
+@_alwaysEmitIntoClient
+public func alwaysEmitIntoClientFunc(_ x: Bool) -> Bool { return !x }

--- a/test/Interop/SwiftToCxx/functions/swift-no-expose-unsupported-func.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-no-expose-unsupported-func.swift
@@ -1,0 +1,30 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -module-name Functions -clang-header-expose-public-decls -emit-clang-header-path %t/functions.h
+// RUN: %FileCheck %s < %t/functions.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/functions.h)
+
+// CHECK-NOT: SWIFT_EXTERN double $s9Functions10async_funcyS2dYaF(double x) SWIFT_NOEXCEPT SWIFT_CALL; // async_func(_:)
+// CHECK-NOT: SWIFT_EXTERN bool $s9Functions16transparent_funcyS2bF(bool x) SWIFT_NOEXCEPT SWIFT_CALL; // transparent_func(_:)
+
+// CHECK:       namespace Functions {
+// CHECK-EMPTY:
+// CHECK-EMPTY:
+// CHECK-EMPTY:
+// CHECK-EMPTY:
+// CHECK-EMPTY:
+// CHECK-EMPTY:
+// CHECK-NEXT:  } // namespace Functions
+
+// CHECK-NOT:  inline double async_func(double x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NOT:   return _impl::$s9Functions10async_funcyS2dYaF(x);
+// CHECK-NOT: }
+
+// CHECK-NOT:  inline bool transparent_func(bool x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NOT:   return _impl::$s9Functions16transparent_funcyS2bF(x);
+// CHECK-NOT: }
+
+public func async_func(_ x: Double) async -> Double { return 2 * x }
+
+@_transparent
+public func transparent_func(_ x: Bool) -> Bool { return !x }

--- a/test/Interop/SwiftToCxx/functions/swift-transparent-functions-cxx-bridging.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-transparent-functions-cxx-bridging.swift
@@ -1,0 +1,14 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -module-name Functions -clang-header-expose-public-decls -emit-clang-header-path %t/functions.h
+// RUN: %FileCheck %s < %t/functions.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/functions.h)
+
+// CHECK: SWIFT_EXTERN ptrdiff_t $s9Functions24transparentPrimitiveFuncyS2iF(ptrdiff_t x) SWIFT_NOEXCEPT SWIFT_CALL; // transparentPrimitiveFunc(_:)
+
+// CHECK:      inline swift::Int transparentPrimitiveFunc(swift::Int x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT:   return _impl::$s9Functions24transparentPrimitiveFuncyS2iF(x);
+// CHECK-NEXT: }
+
+@_transparent
+public func transparentPrimitiveFunc(_ x: Int) -> Int { return x * x }

--- a/test/Interop/SwiftToCxx/functions/swift-transparent-functions-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/swift-transparent-functions-execution.cpp
@@ -1,0 +1,22 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %S/swift-transparent-functions-cxx-bridging.swift -typecheck -module-name Functions -clang-header-expose-public-decls -emit-clang-header-path %t/functions.h
+
+// RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-functions-execution.o
+// RUN: %target-interop-build-swift %S/swift-transparent-functions-cxx-bridging.swift -o %t/swift-functions-execution -Xlinker %t/swift-functions-execution.o -module-name Functions -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+
+// RUN: %target-codesign %t/swift-functions-execution
+// RUN: %target-run %t/swift-functions-execution
+
+// REQUIRES: executable_test
+
+#include <cassert>
+#include "functions.h"
+
+int main() {
+    using namespace Functions;
+    
+    assert(transparentPrimitiveFunc(12) == 144);
+
+    return 0;
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Ensure that top-level `async` functions are not exposed to C/C++ because there's currently no support for Swift concurrency being imported into C/C++.

Also, don't expose transparent functions (marked with `@_transparent` attribute) since it's not supported on the clang side.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
