### PR TITLE
[5.7][Test] Reenable reflect_task.swift on Darwin.

### DIFF
--- a/test/Concurrency/Reflection/reflect_task.swift
+++ b/test/Concurrency/Reflection/reflect_task.swift
@@ -9,8 +9,6 @@
 // REQUIRES: concurrency
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
-//
-// UNSUPPORTED: OS=macosx,ios,watchos,tvos
 
 import Swift
 import _Concurrency


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/59285 to release/5.7.

This test was temporarily disabled while Remote Mirror was being upgraded to handle task escalation, but it works now.

rdar://94454729