### PR TITLE
[cxx-interop] Fix a potential dangling pointer in `String(cxxString:)`

### DIFF
--- a/stdlib/public/Cxx/String.swift
+++ b/stdlib/public/Cxx/String.swift
@@ -22,5 +22,6 @@ extension std.string {
 extension String {
   public init(cxxString: std.string) {
     self.init(cString: cxxString.c_str())
+    withExtendedLifetime(cxxString) {}
   }
 }


### PR DESCRIPTION
`cxxString` might get deallocated immediately after `c_str()` call, which would mean that the pointer passed to `String(cString:)` points to invalid memory.

We haven't actually seen this, but let's preemptively add an explicit `withExtendedLifetime` call to avoid running into this in the future.

Similar to https://github.com/apple/swift/pull/59152.