### PR TITLE
[stdlib] Revise doc comments to be clearer in ArraySlice.swift

### DIFF
--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -96,10 +96,10 @@
 ///
 /// Here's an implementation of those steps:
 ///
-///     if let i = absences.firstIndex(where: { $0 > 0 }) {                 // 1
-///         let absencesAfterFirst = absences[(i + 1)...]                   // 2
-///         if let j = absencesAfterFirst.firstIndex(where: { $0 > 0 }) {   // 3
-///             print("The first day with absences had \(absences[i]).")    // 4
+///     if let i = absences.firstIndex(where: { $0 > 0 }) {                 // step 1
+///         let absencesAfterFirst = absences[(i + 1)...]                   // step 2
+///         if let j = absencesAfterFirst.firstIndex(where: { $0 > 0 }) {   // step 3
+///             print("The first day with absences had \(absences[i]).")    // step 4
 ///             print("The second day with absences had \(absences[j]).")
 ///         }
 ///     }


### PR DESCRIPTION
- When I first saw the number `1` in the first comment below, I thought it was the value of `i`, because `i` is actually `1`.
- I think it'd be better adding `"step"` explicitly in those comments to prevent misreading.

```swift
if let i = absences.firstIndex(where: { $0 > 0 }) {                 // 1 → step 1
    let absencesAfterFirst = absences[(i + 1)...]                   // 2 → step 2
    if let j = absencesAfterFirst.firstIndex(where: { $0 > 0 }) {   // 3 → step 3
        print("The first day with absences had \(absences[i]).")    // 4 → step 4
        print("The second day with absences had \(absences[j]).")
    }
}
// Prints "The first day with absences had 2."
// Prints "The second day with absences had 4."
```