### PR TITLE
[CSClosure] Fix handling of property wrapped pattern bindings

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8892,6 +8892,9 @@ ExprWalker::rewriteTarget(SolutionApplicationTarget target) {
   } else if (auto patternBinding = target.getAsPatternBinding()) {
     ConstraintSystem &cs = solution.getConstraintSystem();
     for (unsigned index : range(patternBinding->getNumPatternEntries())) {
+      if (patternBinding->isInitializerChecked(index))
+        continue;
+
       // Find the solution application target for this.
       auto knownTarget = *cs.getSolutionApplicationTarget(
           {patternBinding, index});

--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -427,6 +427,9 @@ private:
         locator, LocatorPathElt::SyntacticElement(patternBinding));
 
     for (unsigned index : range(patternBinding->getNumPatternEntries())) {
+      if (patternBinding->isInitializerChecked(index))
+        continue;
+
       auto *pattern = TypeChecker::resolvePattern(
           patternBinding->getPattern(index), patternBinding->getDeclContext(),
           /*isStmtCondition=*/true);
@@ -501,6 +504,9 @@ private:
     auto index =
         locator->castLastElementTo<LocatorPathElt::PatternBindingElement>()
             .getIndex();
+
+    if (patternBinding->isInitializerChecked(index))
+      return;
 
     auto contextualPattern =
         ContextualPattern::forPatternBindingDecl(patternBinding, index);

--- a/test/Constraints/diag_ambiguities.swift
+++ b/test/Constraints/diag_ambiguities.swift
@@ -88,3 +88,24 @@ func %% (_ lhs: Float, _ rhs: Float) -> Float {
 func SR15053<T : Numeric>(_ a: T, _ b: T) {
   (a + b) %% 2 // expected-error {{cannot convert value of type 'T' to expected argument type 'Int'}}
 }
+
+// rdar://94360230 - diagnosing 'filter' instead of ambiguity in its body
+func test_diagnose_deepest_ambiguity() {
+  struct S {
+    func ambiguous(_: Int = 0) -> Bool { true }     // expected-note 2 {{found this candidate}}
+    func ambiguous(_: String = "") -> Bool { true } // expected-note 2 {{found this candidate}}
+  }
+
+  func test_single(arr: [S]) {
+    arr.filter { $0.ambiguous() } // expected-error {{ambiguous use of 'ambiguous'}}
+  }
+
+  func test_multi(arr: [S]) {
+    arr.filter {
+      if true {
+        print($0.ambiguous()) // expected-error {{ambiguous use of 'ambiguous'}}
+      }
+      return true
+    }
+  }
+}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -562,8 +562,8 @@ struct SpecialPi {} // Type with no implicit construction.
 
 var pi_s: SpecialPi
 
-func getPi() -> Float {}
-func getPi() -> Double {}
+func getPi() -> Float {}  // expected-note 3 {{found this candidate}}
+func getPi() -> Double {} // expected-note 3 {{found this candidate}}
 func getPi() -> SpecialPi {}
 
 enum Empty { }
@@ -585,12 +585,12 @@ func conversionTest(_ a: inout Double, b: inout Int) {
   var pi_d1 = Double(pi_d)
   var pi_s1 = SpecialPi(pi_s) // expected-error {{argument passed to call that takes no arguments}}
 
-  var pi_f2 = Float(getPi()) // expected-error {{ambiguous use of 'init(_:)'}}
-  var pi_d2 = Double(getPi()) // expected-error {{ambiguous use of 'init(_:)'}}
+  var pi_f2 = Float(getPi()) // expected-error {{ambiguous use of 'getPi()'}}
+  var pi_d2 = Double(getPi()) // expected-error {{ambiguous use of 'getPi()'}}
   var pi_s2: SpecialPi = getPi() // no-warning
   
   var float = Float.self
-  var pi_f3 = float.init(getPi()) // expected-error {{ambiguous use of 'init(_:)'}}
+  var pi_f3 = float.init(getPi()) // expected-error {{ambiguous use of 'getPi()'}}
   var pi_f4 = float.init(pi_f)
 
   var e = Empty(f) // expected-warning {{variable 'e' inferred to have type 'Empty', which is an enum with no cases}} expected-note {{add an explicit type annotation to silence this warning}}  {{8-8=: Empty}}

--- a/validation-test/Sema/type_checker_crashers_fixed/issue59294.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/issue59294.swift
@@ -1,0 +1,42 @@
+// RUN: %target-typecheck-verify-swift
+
+// https://github.com/apple/swift/issues/59294
+
+@propertyWrapper
+struct WrapperValue<Value> {
+  var value: Value
+  init(wrappedValue: Value) {
+    self.value = wrappedValue
+  }
+
+  var projectedValue: Self {
+    return self
+  }
+
+  var wrappedValue: Value {
+    get {
+      self.value
+    }
+    set {
+      self.value = newValue
+    }
+  }
+
+  func printValue() {
+    print(value)
+  }
+}
+
+
+class Test {
+  static func test() {
+    return [0, 1, 2].compactMap { _ in // expected-error {{unexpected non-void return value in void function}} expected-note {{did you mean to add a return type?}}
+      @WrapperValue var value: Bool? = false
+      if value != nil {
+        return false
+      }
+
+      return value ?? false
+    }
+  }
+}


### PR DESCRIPTION
Property wrappers trigger initializer synthesis. Synthesized
initializers should not be re-typechecked when encountered e.g.
 while re-solving closure with a different contextual type.

Resolves: https://github.com/apple/swift/issues/59294
Resolves: rdar://94506352

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
