### PR TITLE
[5.7][CSClosure] Fix handling of property wrapped pattern bindings

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8895,6 +8895,9 @@ ExprWalker::rewriteTarget(SolutionApplicationTarget target) {
   } else if (auto patternBinding = target.getAsPatternBinding()) {
     ConstraintSystem &cs = solution.getConstraintSystem();
     for (unsigned index : range(patternBinding->getNumPatternEntries())) {
+      if (patternBinding->isInitializerChecked(index))
+        continue;
+
       // Find the solution application target for this.
       auto knownTarget = *cs.getSolutionApplicationTarget(
           {patternBinding, index});

--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -427,6 +427,9 @@ private:
         locator, LocatorPathElt::SyntacticElement(patternBinding));
 
     for (unsigned index : range(patternBinding->getNumPatternEntries())) {
+      if (patternBinding->isInitializerChecked(index))
+        continue;
+
       auto *pattern = TypeChecker::resolvePattern(
           patternBinding->getPattern(index), patternBinding->getDeclContext(),
           /*isStmtCondition=*/true);
@@ -501,6 +504,9 @@ private:
     auto index =
         locator->castLastElementTo<LocatorPathElt::PatternBindingElement>()
             .getIndex();
+
+    if (patternBinding->isInitializerChecked(index))
+      return;
 
     auto contextualPattern =
         ContextualPattern::forPatternBindingDecl(patternBinding, index);

--- a/validation-test/Sema/type_checker_crashers_fixed/issue59294.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/issue59294.swift
@@ -1,0 +1,42 @@
+// RUN: %target-typecheck-verify-swift
+
+// https://github.com/apple/swift/issues/59294
+
+@propertyWrapper
+struct WrapperValue<Value> {
+  var value: Value
+  init(wrappedValue: Value) {
+    self.value = wrappedValue
+  }
+
+  var projectedValue: Self {
+    return self
+  }
+
+  var wrappedValue: Value {
+    get {
+      self.value
+    }
+    set {
+      self.value = newValue
+    }
+  }
+
+  func printValue() {
+    print(value)
+  }
+}
+
+
+class Test {
+  static func test() {
+    return [0, 1, 2].compactMap { _ in // expected-error {{unexpected non-void return value in void function}} expected-note {{did you mean to add a return type?}}
+      @WrapperValue var value: Bool? = false
+      if value != nil {
+        return false
+      }
+
+      return value ?? false
+    }
+  }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/59300

---

Property wrappers trigger initializer synthesis. Synthesized
initializers should not be re-typechecked when encountered e.g.
 while re-solving closure with a different contextual type.

Resolves: https://github.com/apple/swift/issues/59294
Resolves: rdar://94506352
(cherry picked from commit 066bbd18eb6cfbe081aafd621c84c1b1ab403708)


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
