### PR TITLE
[move-only] Two small fixes

### DIFF
--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -188,7 +188,9 @@ public:
   ///    type. This is done under the assumption that in all cases where we are
   ///    performing these AST queries on SILType, we are not interested in the
   ///    move only-ness of the value (which we can query separately anyways).
-  CanType getASTType() const { return withoutMoveOnly().getRawASTType(); }
+  CanType getASTType() const {
+    return removingMoveOnlyWrapper().getRawASTType();
+  }
 
 private:
   /// Returns the canonical AST type references by this SIL type without looking
@@ -602,33 +604,34 @@ public:
   ///
   /// Canonical way to check if a SILType is move only. Using is/getAs/castTo
   /// will look through moveonly-ness.
-  bool isMoveOnly() const { return getRawASTType()->is<SILMoveOnlyType>(); }
+  bool isMoveOnlyWrapped() const {
+    return getRawASTType()->is<SILMoveOnlyType>();
+  }
 
-  /// Return *this if already move only... otherwise, wrap the current type
-  /// within a move only type wrapper and return that. Idempotent!
-  SILType asMoveOnly() const {
-    if (isMoveOnly())
+  /// If this is already a move only wrapped type, return *this. Otherwise, wrap
+  /// the copyable type in the mov eonly wrapper.
+  SILType addingMoveOnlyWrapper() const {
+    if (isMoveOnlyWrapped())
       return *this;
     auto newType = SILMoveOnlyType::get(getRawASTType());
     return SILType::getPrimitiveType(newType, getCategory());
   }
 
-  /// Return this SILType, removing moveonly-ness.
-  ///
-  /// Is idempotent.
-  SILType withoutMoveOnly() const {
-    if (!isMoveOnly())
+  /// If this is already a copyable type, just return *this. Otherwise, if this
+  /// is a move only wrapped copyable type, return the inner type.
+  SILType removingMoveOnlyWrapper() const {
+    if (!isMoveOnlyWrapped())
       return *this;
     auto moveOnly = getRawASTType()->castTo<SILMoveOnlyType>();
     return SILType::getPrimitiveType(moveOnly->getInnerType(), getCategory());
   }
 
-  /// If \p otherType is move only, return this type that is move only as
-  /// well. Otherwise, returns self. Useful for propagating "move only"-ness
+  /// If \p otherType is move only wrapped, return this type that is move only
+  /// as well. Otherwise, returns self. Useful for propagating "move only"-ness
   /// from a parent type to a subtype.
-  SILType copyMoveOnly(SILType otherType) const {
-    if (otherType.isMoveOnly()) {
-      return asMoveOnly();
+  SILType copyingMoveOnlyWrapper(SILType otherType) const {
+    if (otherType.isMoveOnlyWrapped()) {
+      return addingMoveOnlyWrapper();
     }
     return *this;
   }

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -86,6 +86,8 @@ enum class SILValueCategory : uint8_t {
   Address,
 };
 
+class SILPrinter;
+
 /// SILType - A Swift type that has been lowered to a SIL representation type.
 /// In addition to the Swift type system, SIL adds "address" types that can
 /// reference any Swift type (but cannot take the address of an address). *T
@@ -113,6 +115,8 @@ private:
 
   friend class Lowering::TypeConverter;
   friend struct llvm::DenseMapInfo<SILType>;
+  friend class SILPrinter;
+
 public:
   SILType() = default;
 
@@ -186,6 +190,7 @@ public:
   ///    move only-ness of the value (which we can query separately anyways).
   CanType getASTType() const { return withoutMoveOnly().getRawASTType(); }
 
+private:
   /// Returns the canonical AST type references by this SIL type without looking
   /// through move only. Should only be used by internal utilities of SILType.
   CanType getRawASTType() const { return CanType(value.getPointer()); }

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -532,8 +532,6 @@ static void printSILFunctionNameAndType(llvm::raw_ostream &OS,
 }
 
 namespace {
-  
-class SILPrinter;
 
 // 1. Accumulate opcode-specific comments in this stream.
 // 2. Start emitting comments: lineComments.start()
@@ -597,6 +595,10 @@ protected:
     return opcodeCommentString.size();
   }
 };
+
+} // namespace
+
+namespace swift {
 
 /// SILPrinter class - This holds the internal implementation details of
 /// printing SIL structures.
@@ -2740,7 +2742,8 @@ public:
     }
   }
 };
-} // end anonymous namespace
+
+} // namespace swift
 
 static void printBlockID(raw_ostream &OS, SILBasicBlock *bb) {
   SILPrintContext Ctx(OS);


### PR DESCRIPTION
Specifically, in the first commit, I make SILType::getRawASTType() private. We don't want people touching the Raw AST Type directly. That is a breakage in the abstraction. Second, I renamed some of the move only wrapper APIs to have move only wrapper instead of just move only in the name. This prevents some confusion that we saw in the other PR.