### PR TITLE
Remove a FIXME from validation-test/stdlib/FixedPoint.swift.gyb

### DIFF
--- a/validation-test/stdlib/FixedPoint.swift.gyb
+++ b/validation-test/stdlib/FixedPoint.swift.gyb
@@ -1,9 +1,8 @@
 // RUN: %target-run-stdlib-swiftgyb
 // REQUIRES: executable_test
 
-// FIXME: [SR-14363]
-//   FixedPoint.swift.gyb slowed down with -Onone copy propagation
-//   We should be able to move this out of long_test once fixed.
+// This is in long_test because it takes about 30s to build.
+// Most of that time is in TypeChecker::typeCheckExpression.
 // REQUIRES: long_test
 
 import StdlibUnittest


### PR DESCRIPTION
Leave this test in long_test because it takes so long to compile. This
issue has nothing to do with the FIXME comment.
