### PR TITLE
Revert "Merge pull request #58983 from apple/egorzhdan/cxx-overlay-linux"

### DIFF
--- a/stdlib/public/Cxx/CMakeLists.txt
+++ b/stdlib/public/Cxx/CMakeLists.txt
@@ -135,21 +135,11 @@ add_swift_target_library(swiftstd ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_OVE
     SWIFT_MODULE_DEPENDS_IOS Darwin
     SWIFT_MODULE_DEPENDS_TVOS Darwin
     SWIFT_MODULE_DEPENDS_WATCHOS Darwin
-    SWIFT_MODULE_DEPENDS_LINUX Glibc
 
     SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
     -Xfrontend -enable-experimental-cxx-interop
     -Xfrontend -module-interface-preserve-types-as-written
 
-    SWIFT_COMPILE_FLAGS_LINUX
-    # GCC on Linux is usually located under `/usr`.
-    # However, Ubuntu 20.04 ships with another GCC installation under `/`, which does not include libstdc++.
-    # Swift build scripts pass `--sysroot=/` to Clang. By default, Clang tries to find GCC installation under sysroot,
-    # and if it doesn't exist, under `{sysroot}/usr`. On Ubuntu 20.04 and newer, it attempts to use the GCC without the
-    # C++ stdlib, which causes a build failure. To fix that, we tell Clang explicitly to use GCC from `/usr`.
-    -Xcc --gcc-toolchain=/usr
-
-    LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-    TARGET_SDKS ALL_APPLE_PLATFORMS LINUX
-    INSTALL_IN_COMPONENT sdk-overlay
-    DEPENDS libstdcxx-modulemap)
+    LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}" -lc++
+    TARGET_SDKS ALL_APPLE_PLATFORMS # TODO: support other platforms as well
+    INSTALL_IN_COMPONENT sdk-overlay)

--- a/test/Interop/Cxx/stdlib/overlay/string.swift
+++ b/test/Interop/Cxx/stdlib/overlay/string.swift
@@ -1,7 +1,7 @@
 // RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: OS=macosx
 
 import StdlibUnittest
 import std


### PR DESCRIPTION
https://github.com/apple/swift/pull/58983 caused builds to start failing on CentOS 7 (https://ci.swift.org/job/oss-swift-package-centos-7/582/console) with the following error message. I’m reverting the PR for now to unblock CI.

```
/home/build-user/swift/stdlib/public/Cxx/std.swift:13:19: error: underlying Objective-C module 'std' not found
@_exported import std // Clang module
                  ^
/home/build-user/swift/stdlib/public/Cxx/String.swift:13:15: error: no type named 'string' in module 'std'
extension std.string {
              ^
/home/build-user/swift/stdlib/public/Cxx/String.swift:23:30: error: no type named 'string' in module 'std'
  public init(cxxString: std.string) {
```

rdar://94605043