### PR TITLE
[SwiftCompilerSources] Require very recent Swift compiler in `HOSTTOOLS` mode

### DIFF
--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -209,7 +209,7 @@ else()
         message(FATAL_ERROR "The Swift compiler (${CMAKE_Swift_COMPILER}) differs from the Swift compiler in SWIFT_NATIVE_SWIFT_TOOLS_PATH (${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/swiftc).")
       endif()
 
-      set(min_supported_swift_version 5.5)
+      set(min_supported_swift_version 5.8)
       if(CMAKE_Swift_COMPILER_VERSION VERSION_LESS "${min_supported_swift_version}")
         message(FATAL_ERROR
             "Outdated Swift compiler: building with host tools requires Swift ${min_supported_swift_version} or newer. "

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -594,7 +594,7 @@ enable-asan
 swift-stdlib-build-type=RelWithDebInfo
 
 # Don't do bootstrapping to speed up the build
-bootstrapping=hosttools
+# TODO: use bootstrapping=hosttools
 
 
 [preset: buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx]
@@ -1403,7 +1403,7 @@ debug-swift
 no-swift-stdlib-assertions
 
 # Don't do bootstrapping to speed up the build
-bootstrapping=hosttools
+# TODO: use bootstrapping=hosttools
 
 
 [preset: buildbot_osx_package,tools=DA,stdlib=R,use_os_runtime]
@@ -2274,7 +2274,7 @@ debug-llvm
 debug-swift
 
 # Don't do bootstrapping to speed up the build
-bootstrapping=hosttools
+# TODO: use bootstrapping=hosttools
 
 
 #===------------------------------------------------------------------------===#
@@ -2295,7 +2295,7 @@ swift-stdlib-build-type=RelWithDebInfo
 swift-stdlib-enable-assertions=true
 
 # Don't do bootstrapping to speed up the build
-bootstrapping=hosttools
+# TODO: use bootstrapping=hosttools
 
 
 #===------------------------------------------------------------------------===#


### PR DESCRIPTION
To use new C++ interop features in SwiftCompilerSources, we need a very recent Swift compiler when building with host tools.

This does not affect non-HOSTTOOLS builds.