### PR TITLE
Revert "[cxx-interop][SwiftCompilerSources] Fix conversion between `std::string` and `Swift.String`"

### DIFF
--- a/SwiftCompilerSources/Sources/Basic/Utils.swift
+++ b/SwiftCompilerSources/Sources/Basic/Utils.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 @_exported import BasicBridging
-import std
 
 //===----------------------------------------------------------------------===//
 //                              StringRef
@@ -60,13 +59,6 @@ extension String {
     return str.withUTF8 { buffer in
       return c(BridgedStringRef(data: buffer.baseAddress, length: buffer.count))
     }
-  }
-
-  /// Underscored to avoid name collision with the std overlay.
-  /// To be replaced with an overlay call once the CI uses SDKs built with Swift 5.8.
-  public init(_cxxString s: std.string) {
-    self.init(cString: s.c_str())
-    withExtendedLifetime(s) {}
   }
 }
 

--- a/SwiftCompilerSources/Sources/SIL/BasicBlock.swift
+++ b/SwiftCompilerSources/Sources/SIL/BasicBlock.swift
@@ -25,7 +25,8 @@ final public class BasicBlock : ListNode, CustomStringConvertible, HasShortDescr
   public var function: Function { SILBasicBlock_getFunction(bridged).function }
 
   public var description: String {
-    String(_cxxString: SILBasicBlock_debugDescription(bridged))
+    var s = SILBasicBlock_debugDescription(bridged)
+    return String(cString: s.c_str())
   }
   public var shortDescription: String { name }
 

--- a/SwiftCompilerSources/Sources/SIL/Function.swift
+++ b/SwiftCompilerSources/Sources/SIL/Function.swift
@@ -21,7 +21,8 @@ final public class Function : CustomStringConvertible, HasShortDescription {
   }
 
   final public var description: String {
-    String(_cxxString: SILFunction_debugDescription(bridged))
+    var s = SILFunction_debugDescription(bridged)
+    return String(cString: s.c_str())
   }
 
   public var shortDescription: String { name.string }

--- a/SwiftCompilerSources/Sources/SIL/GlobalVariable.swift
+++ b/SwiftCompilerSources/Sources/SIL/GlobalVariable.swift
@@ -19,7 +19,8 @@ final public class GlobalVariable : CustomStringConvertible, HasShortDescription
   }
 
   public var description: String {
-    String(_cxxString: SILGlobalVariable_debugDescription(bridged))
+    var s = SILGlobalVariable_debugDescription(bridged)
+    return String(cString: s.c_str())
   }
 
   public var shortDescription: String { name.string }

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -38,7 +38,8 @@ public class Instruction : ListNode, CustomStringConvertible, Hashable {
   final public var function: Function { block.function }
 
   final public var description: String {
-    String(_cxxString: SILNode_debugDescription(bridgedNode))
+    var s = SILNode_debugDescription(bridgedNode)
+    return String(cString: s.c_str())
   }
 
   final public var operands: OperandArray {
@@ -142,7 +143,8 @@ public class SingleValueInstruction : Instruction, Value {
 
 public final class MultipleValueInstructionResult : Value {
   final public var description: String {
-    String(_cxxString: SILNode_debugDescription(bridgedNode))
+    var s = SILNode_debugDescription(bridgedNode)
+    return String(cString: s.c_str())
   }
 
   public var instruction: Instruction {

--- a/SwiftCompilerSources/Sources/SIL/Value.swift
+++ b/SwiftCompilerSources/Sources/SIL/Value.swift
@@ -81,7 +81,8 @@ public enum Ownership {
 
 extension Value {
   public var description: String {
-    String(_cxxString: SILNode_debugDescription(bridgedNode))
+    var s = SILNode_debugDescription(bridgedNode)
+    return String(cString: s.c_str())
   }
 
   public var uses: UseList {

--- a/test/SILOptimizer/addr_escape_info.sil
+++ b/test/SILOptimizer/addr_escape_info.sil
@@ -2,6 +2,9 @@
 
 // REQUIRES: swift_in_compiler
 
+// rdar92963081
+// UNSUPPORTED: OS=linux-gnu
+
 sil_stage canonical
 
 import Builtin

--- a/test/SILOptimizer/escape_info.sil
+++ b/test/SILOptimizer/escape_info.sil
@@ -2,6 +2,9 @@
 
 // REQUIRES: swift_in_compiler
 
+// rdar92963081
+// UNSUPPORTED: OS=linux-gnu
+
 
 sil_stage canonical
 

--- a/test/SILOptimizer/ranges.sil
+++ b/test/SILOptimizer/ranges.sil
@@ -2,6 +2,9 @@
 
 // REQUIRES: swift_in_compiler
 
+// rdar92963081
+// UNSUPPORTED: OS=linux-gnu
+
 
 sil_stage canonical
 


### PR DESCRIPTION
This reverts commit be711e387f3ed1c79a96bc221d6e0cd4aed46a2d.

That change triggers a compiler assertion on Linux:
```
[1161/1307][ 88%][457.362s] Building swift module Basic
FAILED: bootstrapping1/SwiftCompilerSources/Basic.o 
cd /home/build-user/swift/SwiftCompilerSources && /home/build-user/build/buildbot_incremental_lsan/swift-linux-x86_64/bootstrapping0/bin/swiftc -c -o /home/build-user/build/buildbot_incremental_lsan/swift-linux-x86_64/bootstrapping1/SwiftCompilerSources/Basic.o -target x86_64-unknown-linux-gnu -module-name Basic -emit-module -emit-module-path /home/build-user/build/buildbot_incremental_lsan/swift-linux-x86_64/bootstrapping1/SwiftCompilerSources/Basic.swiftmodule -parse-as-library /home/build-user/swift/SwiftCompilerSources/Sources/Basic/SourceLoc.swift /home/build-user/swift/SwiftCompilerSources/Sources/Basic/Utils.swift -wmo -Xfrontend -validate-tbd-against-ir=none -Xfrontend -enable-cxx-interop -Xcc -UIBOutlet -Xcc -UIBAction -Xcc -UIBInspectable -O -cross-module-optimization -Xcc -I -Xcc /home/build-user/swift/include -Xcc -I -Xcc /home/build-user/build/buildbot_incremental_lsan/swift-linux-x86_64/include -I /home/build-user/build/buildbot_incremental_lsan/swift-linux-x86_64/bootstrapping1/SwiftCompilerSources
<unknown>:0: warning: unable to perform implicit import of "_Concurrency" module: no such module found
swift-frontend: /home/build-user/swift/lib/Sema/ConstraintSystem.cpp:1454: std::pair<Type, Type> swift::constraints::ConstraintSystem::getTypeOfReference(swift::ValueDecl *, swift::FunctionRefKind, swift::constraints::ConstraintLocatorBuilder, swift::DeclContext *): Assertion `func->isOperator() && "Lookup should only find operators"' failed.
Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the project and the crash backtrace.
Stack dump:
0.	Program arguments: /home/build-user/build/buildbot_incremental_lsan/swift-linux-x86_64/bootstrapping0/bin/swift-frontend -frontend -c /home/build-user/swift/SwiftCompilerSources/Sources/Basic/SourceLoc.swift /home/build-user/swift/SwiftCompilerSources/Sources/Basic/Utils.swift -emit-module-path /home/build-user/build/buildbot_incremental_lsan/swift-linux-x86_64/bootstrapping1/SwiftCompilerSources/Basic.swiftmodule -emit-module-doc-path /home/build-user/build/buildbot_incremental_lsan/swift-linux-x86_64/bootstrapping1/SwiftCompilerSources/Basic.swiftdoc -emit-module-source-info-path /home/build-user/build/buildbot_incremental_lsan/swift-linux-x86_64/bootstrapping1/SwiftCompilerSources/Basic.swiftsourceinfo -target x86_64-unknown-linux-gnu -disable-objc-interop -I /home/build-user/build/buildbot_incremental_lsan/swift-linux-x86_64/bootstrapping1/SwiftCompilerSources -O -validate-tbd-against-ir=none -enable-cxx-interop -Xcc -UIBOutlet -Xcc -UIBAction -Xcc -UIBInspectable -Xcc -I -Xcc /home/build-user/swift/include -Xcc -I -Xcc /home/build-user/build/buildbot_incremental_lsan/swift-linux-x86_64/include -parse-as-library -module-name Basic -cross-module-optimization -o /home/build-user/build/buildbot_incremental_lsan/swift-linux-x86_64/bootstrapping1/SwiftCompilerSources/Basic.o
1.	Swift version 5.8-dev (LLVM fdfb8ac496e4538, Swift c6a95c6fb6cdb63)
2.	Compiling with the current language version
3.	While evaluating request TypeCheckSourceFileRequest(source_file "/home/build-user/swift/SwiftCompilerSources/Sources/Basic/Utils.swift")
4.	While evaluating request TypeCheckFunctionBodyRequest(Basic.(file).StringRef.==@/home/build-user/swift/SwiftCompilerSources/Sources/Basic/Utils.swift:29:22)
5.	While type-checking statement at [/home/build-user/swift/SwiftCompilerSources/Sources/Basic/Utils.swift:29:68 - line:35:3] RangeText="{
    let lhsBuffer = UnsafeBufferPointer<UInt8>(start: lhs._bridged.data, count: Int(lhs._bridged.length))
    return rhs.withUTF8Buffer { (rhsBuffer: UnsafeBufferPointer<UInt8>) in
      if lhsBuffer.count != rhsBuffer.count { return false }
      return lhsBuffer.elementsEqual(rhsBuffer, by: ==)
    }
  "
6.	While type-checking statement at [/home/build-user/swift/SwiftCompilerSources/Sources/Basic/Utils.swift:31:5 - line:34:5] RangeText="return rhs.withUTF8Buffer { (rhsBuffer: UnsafeBufferPointer<UInt8>) in
      if lhsBuffer.count != rhsBuffer.count { return false }
      return lhsBuffer.elementsEqual(rhsBuffer, by: ==)
    "
7.	While type-checking expression at [/home/build-user/swift/SwiftCompilerSources/Sources/Basic/Utils.swift:31:12 - line:34:5] RangeText="rhs.withUTF8Buffer { (rhsBuffer: UnsafeBufferPointer<UInt8>) in
      if lhsBuffer.count != rhsBuffer.count { return false }
      return lhsBuffer.elementsEqual(rhsBuffer, by: ==)
    "
8.	While type-checking-target starting at /home/build-user/swift/SwiftCompilerSources/Sources/Basic/Utils.swift:31:16
Stack dump without symbol names (ensure you have llvm-symbolizer in your PATH or set the environment var `LLVM_SYMBOLIZER_PATH` to point to it):
```
