### PR TITLE
[test] Explicitly specify --cmake %cmake for build_lld.test

### DIFF
--- a/validation-test/BuildSystem/build_lld.test
+++ b/validation-test/BuildSystem/build_lld.test
@@ -1,6 +1,6 @@
 # RUN: %empty-directory(%t)
 # RUN: mkdir -p %t
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --build-lld 2>&1 | %FileCheck %s
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --cmake %cmake --build-lld 2>&1 | %FileCheck %s
 
 # REQUIRES: standalone_build
 


### PR DESCRIPTION
I believe this was causing CMake to get built for the test case and make the test case take ~5min on Linux instead of ~15sec.