### PR TITLE
RequirementMachine: Concrete contraction needs to substitute the parent type of a subject type sometimes [5.7]

### DIFF
--- a/lib/AST/RequirementMachine/MinimalConformances.cpp
+++ b/lib/AST/RequirementMachine/MinimalConformances.cpp
@@ -263,6 +263,7 @@ MinimalConformances::decomposeTermIntoConformanceRuleLeftHandSides(
   bool simplified = System.simplify(term, &steps);
   if (!simplified) {
     llvm::errs() << "Term does not conform to protocol: " << term << "\n";
+    System.dump(llvm::errs());
     abort();
   }
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -242,21 +242,8 @@ bool TypeResolution::areSameType(Type type1, Type type2) const {
     }
   }
 
-  // Otherwise, perform a structural check.
   assert(stage == TypeResolutionStage::Structural);
-
-  // FIXME: We should be performing a deeper equality check here.
-  // If both refer to associated types with the same name, they'll implicitly
-  // be considered equivalent.
-  auto depMem1 = type1->getAs<DependentMemberType>();
-  if (!depMem1) return false;
-
-  auto depMem2 = type2->getAs<DependentMemberType>();
-  if (!depMem2) return false;
-
-  if (depMem1->getName() != depMem2->getName()) return false;
-
-  return areSameType(depMem1->getBase(), depMem2->getBase());
+  return false;
 }
 
 Type TypeChecker::getOptionalType(SourceLoc loc, Type elementType) {

--- a/test/Generics/rdar94150249.swift
+++ b/test/Generics/rdar94150249.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
+
+protocol P1 {
+  associatedtype Value
+}
+
+protocol P2 {
+  associatedtype Value
+}
+
+class G<Value> : P2 {}
+
+protocol P3 {}
+
+extension P1 where Value: P2 {
+  typealias Element = Value.Value
+
+  // Make sure we can resolve 'Element' to 'V' on the left hand side of 'Element: P3'.
+
+  // CHECK-LABEL: .P1 extension.set()@
+  // CHECK-NEXT: Generic signature: <Self, V where Self : P1, V : P3, Self.[P1]Value == G<V>>
+  func set<V>() where Element: P3, Value == G<V> {
+    takeP3(V.self)
+  }
+}
+
+func takeP3<T : P3>(_: T.Type) {}

--- a/test/Generics/rdar94150249.swift
+++ b/test/Generics/rdar94150249.swift
@@ -12,14 +12,16 @@ class G<Value> : P2 {}
 
 protocol P3 {}
 
+class C {}
+
 extension P1 where Value: P2 {
   typealias Element = Value.Value
 
   // Make sure we can resolve 'Element' to 'V' on the left hand side of 'Element: P3'.
 
   // CHECK-LABEL: .P1 extension.set()@
-  // CHECK-NEXT: Generic signature: <Self, V where Self : P1, V : P3, Self.[P1]Value == G<V>>
-  func set<V>() where Element: P3, Value == G<V> {
+  // CHECK-NEXT: Generic signature: <Self, V where Self : P1, V : C, V : P3, Self.[P1]Value == G<V>>
+  func set<V>() where Element: P3 & C, Value == G<V> {
     takeP3(V.self)
   }
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/59310.

If you have generic parameters `<T, U>` and requirements of the form:

- `T : P`
- `T == ConcreteType<U>`
- `T.[P]U : SomeClass`
- `T.[P]U : SomeProto`

And furthermore SomeClass does not conform to SomeProto, we can't leave `T.[P]U : SomeClass` unsubstituted; we still have to replace `T` with `ConcreteType<U>` to transform the latter two requirements into:

- `U : SomeClass`
- `U : SomeProto`

"Concrete contraction" is easily the hackiest part of the Requirement Machine; I need to come up with a more principled solution for the problem that it solves sooner or later.

Fixes rdar://problem/94150249.