### PR TITLE
[TypeChecker/CodeCompletion] Re-introduce expression sanitization bef…

### DIFF
--- a/lib/Sema/TypeCheckCodeCompletion.cpp
+++ b/lib/Sema/TypeCheckCodeCompletion.cpp
@@ -571,6 +571,11 @@ bool TypeChecker::typeCheckForCodeCompletion(
   if (!node)
     return false;
 
+  if (auto *expr = getAsExpr(node)) {
+    node = expr->walk(SanitizeExpr(Context,
+                                   /*shouldReusePrecheckedType=*/false));
+  }
+
   CompletionContextFinder contextAnalyzer(node, DC);
 
   // If there was no completion expr (e.g. if the code completion location was

--- a/validation-test/IDE/stress_tester_issues_fixed/rdar94619388.swift
+++ b/validation-test/IDE/stress_tester_issues_fixed/rdar94619388.swift
@@ -1,0 +1,8 @@
+// RUN: %swift-ide-test -code-completion -source-filename %s -code-completion-token COMPLETE
+
+func foo(closure: (String) -> Void) -> String? {
+  return nil
+}
+
+func test() {
+  if let key = foo(closure: { str in str.suffix(2) == #^COMPLETE^#


### PR DESCRIPTION
…ore solving

A call to `SanitizeExpr` has been incorrectly removed from
`typeCheckForCodeCompletion` by refactoring to use `ASTNode`.

It is still required because fallback calls could have partially
type-checked AST.

Resolves: https://github.com/apple/swift/issues/59315
Resolves: rdar://94619388

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
