### PR TITLE
[next] Temporarily disable tgmath.swift.gyb

### DIFF
--- a/test/stdlib/tgmath.swift.gyb
+++ b/test/stdlib/tgmath.swift.gyb
@@ -17,6 +17,8 @@
 // RUN: %line-directive %t/tgmath.swift -- %target-run %t/a.out
 // REQUIRES: executable_test
 
+// REQUIRES: rdar94452524
+
 #if canImport(Darwin)
   import Darwin.C.tgmath
 #elseif canImport(Glibc)


### PR DESCRIPTION
Disable `test/stdlib/tgmath.swift.gyb` while it's being looked into in
order to unblock CI.