### PR TITLE
Fix some typos in `AsyncThrowingStream.swift` docs

### DIFF
--- a/stdlib/public/BackDeployConcurrency/AsyncThrowingStream.swift
+++ b/stdlib/public/BackDeployConcurrency/AsyncThrowingStream.swift
@@ -199,7 +199,7 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
     let storage: _Storage
 
     /// Resume the task awaiting the next iteration point by having it return
-    /// nomally from its suspension point with a given element.
+    /// normally from its suspension point with a given element.
     ///
     /// - Parameter value: The value to yield from the continuation.
     /// - Returns: A `YieldResult` that indicates the success or failure of the
@@ -453,7 +453,7 @@ extension AsyncThrowingStream.Continuation {
   }
 
   /// Resume the task awaiting the next iteration point by having it return
-  /// nomally from its suspension point.
+  /// normally from its suspension point.
   ///
   /// - Returns: A `YieldResult` that indicates the success or failure of the
   ///   yield operation.


### PR DESCRIPTION
nomally -> normally