### PR TITLE
DiagnoseInfiniteRecursion: improve detection in (potentially) overridden class methods

### DIFF
--- a/lib/SILOptimizer/Mandatory/DiagnoseInfiniteRecursion.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseInfiniteRecursion.cpp
@@ -71,6 +71,13 @@ static bool isRecursiveCall(FullApplySite applySite) {
 
   if (auto *CMI = dyn_cast<ClassMethodInst>(callee)) {
 
+    SILModule &module = parentFunc->getModule();
+    CanType classType = CMI->getOperand()->getType().getASTType();
+    if (auto mt = dyn_cast<MetatypeType>(classType)) {
+      classType = mt.getInstanceType();
+    }
+    ClassDecl *classDecl = classType.getClassOrBoundGenericClass();
+
     // FIXME: If we're not inside the module context of the method,
     // we may have to deserialize vtables.  If the serialized tables
     // are damaged, the pass will crash.
@@ -78,24 +85,36 @@ static bool isRecursiveCall(FullApplySite applySite) {
     // Though, this has the added bonus of not looking into vtables
     // outside the current module.  Because we're not doing IPA, let
     // alone cross-module IPA, this is all well and good.
-    SILModule &module = parentFunc->getModule();
-    CanType classType = CMI->getOperand()->getType().getASTType();
-    ClassDecl *classDecl = classType.getClassOrBoundGenericClass();
     if (classDecl && classDecl->getModuleContext() != module.getSwiftModule())
       return false;
 
-    if (!calleesAreStaticallyKnowable(module, CMI->getMember()))
-      return false;
-
-    // The "statically knowable" check just means that we have all the
-    // callee candidates available for analysis. We still need to check
-    // if the current function has a known override point.
-    auto *methodDecl = CMI->getMember().getAbstractFunctionDecl();
-    if (methodDecl->isOverridden())
-      return false;
-
     SILFunction *method = getTargetClassMethod(module, classDecl, CMI);
-    return method == parentFunc;
+    if (method != parentFunc)
+      return false;
+
+    SILDeclRef member = CMI->getMember();
+    if (calleesAreStaticallyKnowable(module, member) &&
+        // The "statically knowable" check just means that we have all the
+        // callee candidates available for analysis. We still need to check
+        // if the current function has a known override point.
+        !member.getAbstractFunctionDecl()->isOverridden()) {
+      return true;
+    }
+
+    // Even if the method is (or could be) overridden, it's a recursive call if
+    // it's called on the self argument:
+    // ```
+    // class X {
+    //   // Even if foo() is overridden in a derived class, it'll end up in an
+    //   // infinite recursion if initially called on an instance of `X`.
+    //   func foo() { foo() }
+    // }
+    // ```
+    if (parentFunc->hasSelfParam() &&
+        CMI->getOperand() == SILValue(parentFunc->getSelfArgument())) {
+      return true;
+    }
+    return false;
   }
 
   if (auto *WMI = dyn_cast<WitnessMethodInst>(callee)) {

--- a/test/SILOptimizer/infinite_recursion.swift
+++ b/test/SILOptimizer/infinite_recursion.swift
@@ -242,11 +242,11 @@ class S {
     return a() // expected-warning {{function call causes an infinite recursion}}
   }
 
-  func b() { // No warning - has a known override.
+  func b() {
     var i = 0
     repeat {
       i += 1
-      b()
+      b() // expected-warning {{function call causes an infinite recursion}}
     } while (i > 5)
   }
 
@@ -270,6 +270,12 @@ class T: S {
     set {
       self.bar = newValue // expected-warning {{function call causes an infinite recursion}}
     }
+  }
+}
+
+public class U {
+  required convenience init(x: Int) {
+    self.init(x: x) // expected-warning {{function call causes an infinite recursion}}
   }
 }
 


### PR DESCRIPTION
 Even if a class method is (or could be) overridden, it's a recursive call if it's called on the self argument:

```
class X {
  // Even if foo() is overridden in a derived class, it'll end up in an
  // infinite recursion if initially called on an instance of `X`.
  func foo() { foo() }
}
```

rdar://89076581
