### PR TITLE
[cxx-interop] Fix libstdc++ build failure on CentOS 7

### DIFF
--- a/stdlib/public/Cxx/libstdcxx.h
+++ b/stdlib/public/Cxx/libstdcxx.h
@@ -33,7 +33,6 @@
 #include "array"
 #include "atomic"
 #include "chrono"
-#include "codecvt"
 #include "condition_variable"
 #include "forward_list"
 #include "future"
@@ -50,6 +49,11 @@
 #include "type_traits"
 #include "unordered_map"
 #include "unordered_set"
+
+// libstdc++ 4.8.5 bundled with CentOS 7 does not include corecvt.
+#if __has_include("codecvt")
+#include "codecvt"
+#endif
 
 // C++17 and newer:
 


### PR DESCRIPTION
CentOS 7 is shipped with an outdated version of libstdc++, which does not include `codecvt` stdlib header.
Let's wrap the `#include` with `#if __has_include`.