### PR TITLE
[cxx-interop] Fix assertion failure when looking up C++ operators

### DIFF
--- a/test/Interop/Cxx/operators/non-member-inline-typechecker.swift
+++ b/test/Interop/Cxx/operators/non-member-inline-typechecker.swift
@@ -22,6 +22,13 @@ let resultExclaimEqual = lhs != rhs
 let resultLessEqual = lhs <= rhs
 let resultGreaterEqual = lhs >= rhs
 
+public func ==(ptr: UnsafePointer<UInt8>, count: Int) -> Bool {
+  let lhs = UnsafeBufferPointer<UInt8>(start: ptr, count: count)
+  let rhs = UnsafeBufferPointer<UInt8>(start: ptr, count: count)
+  return lhs.elementsEqual(rhs, by: ==)
+}
+
+
 var lhsBool = LoadableBoolWrapper(value: true)
 var rhsBool = LoadableBoolWrapper(value: false)
 


### PR DESCRIPTION
Previously when looking up a C++ operator (e.g. `==`), `ClangImporter::Implementation::lookupValue` returned a Swift function with a generated name (e.g. `func __operatorEqualEqual`), while the caller expected the result to be a Swift operator (e.g. `func ==`).

This change makes sure that we're returning a synthesized Swift operator when looking for a C++ operator.

This fixes an assertion failure in the typechecker:
```
swift-frontend: /home/build-user/swift/lib/Sema/ConstraintSystem.cpp:1454: std::pair<Type, Type> swift::constraints::ConstraintSystem::getTypeOfReference(swift::ValueDecl *, swift::FunctionRefKind, swift::constraints::ConstraintLocatorBuilder, swift::DeclContext *): Assertion `func->isOperator() && "Lookup should only find operators"' failed.
```