### PR TITLE
[WIP] #transcription(of:)

### DIFF
--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -214,5 +214,11 @@ REMARK(remark_save_cache, none,
 ERROR(unknown_attribute,none,
       "unknown attribute '%0'", (StringRef))
 
+//------------------------------------------------------------------------------
+// MARK: magic identifier diagnostics
+//------------------------------------------------------------------------------
+ERROR(magic_identifier_cannot_parse_args,none,
+      "unable to parse the arguments to literal expression %0", (StringRef))
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -83,6 +83,8 @@ ERROR(magic_identifier_invalid_arg_name,none,
 ERROR(magic_identifier_unknown_arg_name,none,
       "unknown argument name %0 passed to literal expression %1",
       (StringRef, StringRef))
+ERROR(magic_identifier_must_be_default_arg_value,none,
+      "#transcription(of:) is only valid as a default argument value", ())
 WARNING(magic_identifier_poor_transcription,none,
         "this expression's source representation cannot be found; a generic "
         "string literal will be substituted", ())

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -71,6 +71,22 @@ ERROR(inout_argument_alias,none,
 NOTE(previous_inout_alias,none,
       "previous aliasing argument", ())
 
+ERROR(magic_identifier_missing_arg,none,
+      "missing argument for parameter %0 of literal expression %1",
+      (StringRef, StringRef))
+ERROR(magic_identifier_unexpected_arg,none,
+      "unexpected argument for parameter %0 of literal expression %1",
+      (StringRef, StringRef))
+ERROR(magic_identifier_invalid_arg_name,none,
+      "invalid argument name %0 passed to literal expression %1",
+      (StringRef, StringRef))
+ERROR(magic_identifier_unknown_arg_name,none,
+      "unknown argument name %0 passed to literal expression %1",
+      (StringRef, StringRef))
+WARNING(magic_identifier_poor_transcription,none,
+        "this expression's source representation cannot be found; a generic "
+        "string literal will be substituted", ())
+
 ERROR(unimplemented_generator_witnesses,none,
       "protocol conformance emission for generator coroutines is unimplemented",
       ())

--- a/include/swift/AST/MagicIdentifierKinds.def
+++ b/include/swift/AST/MagicIdentifierKinds.def
@@ -46,6 +46,11 @@
 #define MAGIC_IDENTIFIER_DEPRECATED_TOKEN(NAME, TOKEN) MAGIC_IDENTIFIER_TOKEN(NAME, TOKEN)
 #endif
 
+// Used when a magic identifier takes an argument.
+#ifndef MAGIC_IDENTIFIER_TAKES_ARGUMENT
+#define MAGIC_IDENTIFIER_TAKES_ARGUMENT(NAME)
+#endif
+
 
 
 //
@@ -77,6 +82,11 @@ MAGIC_STRING_IDENTIFIER(FilePathSpelledAsFile, "#file", PoundFileExpr)
 MAGIC_STRING_IDENTIFIER(Function, "#function", PoundFunctionExpr)
   MAGIC_IDENTIFIER_TOKEN(Function, pound_function)
   MAGIC_IDENTIFIER_DEPRECATED_TOKEN(Function, kw___FUNCTION__)
+
+/// The \c #function magic identifier literal.
+MAGIC_STRING_IDENTIFIER(Transcription, "#transcription", PoundTranscriptionExpr)
+  MAGIC_IDENTIFIER_TOKEN(Transcription, pound_transcription)
+  MAGIC_IDENTIFIER_TAKES_ARGUMENT(Transcription)
 
 
 
@@ -114,3 +124,4 @@ MAGIC_POINTER_IDENTIFIER(DSOHandle, "#dsohandle", PoundDsohandleExpr)
 #undef MAGIC_POINTER_IDENTIFIER
 #undef MAGIC_IDENTIFIER_TOKEN
 #undef MAGIC_IDENTIFIER_DEPRECATED_TOKEN
+#undef MAGIC_IDENTIFIER_TAKES_ARGUMENT

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1659,6 +1659,9 @@ public:
   DeclNameRef parseDeclNameRef(DeclNameLoc &loc, const Diagnostic &diag,
                                DeclNameOptions flags);
 
+  ParserResult<Expr>
+  parseMagicIdentifierLiteral(MagicIdentifierLiteralExpr::Kind Kind);
+
   ParserResult<Expr> parseExprIdentifier();
   Expr *parseExprEditorPlaceholder(Token PlaceholderTok,
                                    Identifier PlaceholderId);

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -806,6 +806,8 @@ ArgumentList *Expr::getArgs() const {
     return DSE->getArgs();
   if (auto *OLE = dyn_cast<ObjectLiteralExpr>(this))
     return OLE->getArgs();
+  if (auto *MILE = dyn_cast<MagicIdentifierLiteralExpr>(this))
+    return MILE->getArgs();
   return nullptr;
 }
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5427,7 +5427,7 @@ synthesizeDependentTypeThunkParamForwarding(AbstractFunctionDecl *afd, void *con
                                                       specParamTy);
     }
 
-    forwardingParams.push_back(Argument(SourceLoc(), Identifier(), argExpr));
+    forwardingParams.push_back(Argument::unlabeled(argExpr));
     paramIndex++;
   }
 
@@ -5558,7 +5558,7 @@ synthesizeForwardingThunkBody(AbstractFunctionDecl *afd, void *context) {
       paramRefExpr->setType(InOutType::get(param->getType()));
     }
 
-    forwardingParams.push_back(Argument(SourceLoc(), Identifier(), paramRefExpr));
+    forwardingParams.push_back(Argument::unlabeled(paramRefExpr));
   }
 
   Expr *specializedFuncDeclRef = new (ctx) DeclRefExpr(ConcreteDeclRef(specializedFuncDecl),

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2372,8 +2372,8 @@ Parser::parseMagicIdentifierLiteral(MagicIdentifierLiteralExpr::Kind Kind) {
       auto args = parseArgumentList(tok::l_paren, tok::r_paren,
                                     /*isExprBasic=*/false);
       if (args.isParseError()) {
-        // TODO: @Transcribed -- diagnostics
-        // diagnose(Tok, ...);
+        auto kindString = MagicIdentifierLiteralExpr::getKindString(Kind);
+        diagnose(Tok, diag::magic_identifier_cannot_parse_args, kindString);
         return makeParserError();
       } else {
         argList = args.getPtrOrNull();

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3404,7 +3404,7 @@ Parser::parseTrailingClosures(bool isExprBasic, SourceRange calleeRange,
         CodeCompletion->completeLabeledTrailingClosure(CCExpr, Tok.isAtStartOfLine());
       consumeToken(tok::code_complete);
       result.setHasCodeCompletionAndIsError();
-      closures.emplace_back(SourceLoc(), Identifier(), CCExpr);
+      closures.push_back(Argument::unlabeled(CCExpr));
       continue;
     }
 

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -2075,10 +2075,10 @@ buildTranscriptionLiteral(SILGenFunction &SGF, SGFContext C,
       // Not a default argument and/or value didn't look like an identifier.
       // Resolve the source code of the magic identifier's argument instead.
       // This is syntactically acceptable, but it is unlikely to produce a
-      // useful string, so warn.
+      // useful string, so emit an error.
       auto exprRange = arg.getExpr()->getSourceRange();
       SGF.SGM.diagnose(exprRange.Start,
-                       diag::magic_identifier_poor_transcription);
+                       diag::magic_identifier_must_be_default_arg_value);
       transcription = transcribe(SGF, ctx, exprRange);
     }
   }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -12463,7 +12463,7 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
 
     if (!ArgumentLists.count(argumentsLoc)) {
       auto *argList = ArgumentList::createImplicit(
-          getASTContext(), {Argument(SourceLoc(), Identifier(), nullptr)},
+          getASTContext(), {Argument::unlabeled(nullptr)},
           /*firstTrailingClosureIndex=*/None,
           AllocationArena::ConstraintSolver);
       ArgumentLists.insert({argumentsLoc, argList});

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -113,7 +113,8 @@ ArgumentList *swift::buildForwardingArgumentList(ArrayRef<ParamDecl *> params,
       assert(ref->getType()->isEqual(type));
       ref = VarargExpansionExpr::createParamExpansion(ctx, ref);
     }
-    args.emplace_back(SourceLoc(), param->getArgumentName(), ref);
+    args.emplace_back(SourceLoc(), param->getArgumentName(),
+                      param->getParameterName(), ref);
   }
   return ArgumentList::createImplicit(ctx, args);
 }

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -388,22 +388,22 @@ synthesizeStubBody(AbstractFunctionDecl *fn, void *) {
   className->setType(staticStringType);
 
   auto *initName = new (ctx) MagicIdentifierLiteralExpr(
-    MagicIdentifierLiteralExpr::Function, loc, /*Implicit=*/true);
+    MagicIdentifierLiteralExpr::Function, loc, nullptr, nullptr, /*Implicit=*/true);
   initName->setType(staticStringType);
   initName->setBuiltinInitializer(staticStringInit);
 
   auto *file = new (ctx) MagicIdentifierLiteralExpr(
-    MagicIdentifierLiteralExpr::FileID, loc, /*Implicit=*/true);
+    MagicIdentifierLiteralExpr::FileID, loc, nullptr, nullptr, /*Implicit=*/true);
   file->setType(staticStringType);
   file->setBuiltinInitializer(staticStringInit);
 
   auto *line = new (ctx) MagicIdentifierLiteralExpr(
-    MagicIdentifierLiteralExpr::Line, loc, /*Implicit=*/true);
+    MagicIdentifierLiteralExpr::Line, loc, nullptr, nullptr, /*Implicit=*/true);
   line->setType(uintType);
   line->setBuiltinInitializer(uintInit);
 
   auto *column = new (ctx) MagicIdentifierLiteralExpr(
-    MagicIdentifierLiteralExpr::Column, loc, /*Implicit=*/true);
+    MagicIdentifierLiteralExpr::Column, loc, nullptr, nullptr, /*Implicit=*/true);
   column->setType(uintType);
   column->setBuiltinInitializer(uintInit);
 

--- a/lib/Sema/DerivedConformanceDistributedActor.cpp
+++ b/lib/Sema/DerivedConformanceDistributedActor.cpp
@@ -149,7 +149,7 @@ deriveBodyDistributed_doInvokeOnReturn(AbstractFunctionDecl *afd, void *arg) {
             /*argLabels=*/
             {C.getIdentifier("fromByteOffset"), C.getIdentifier("as")}),
         ArgumentList::createImplicit(
-            C, {Argument(sloc, C.getIdentifier("as"),
+            C, {Argument(sloc, C.getIdentifier("as"), C.getIdentifier("type"),
                          new (C) DeclRefExpr(ConcreteDeclRef(returnTypeParam),
                                              dloc, implicit))}));
 

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -552,6 +552,8 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
                     "Swift 5 #file < #function");
       static_assert(Kind::FilePathSpelledAsFile < Kind::DSOHandle,
                     "Swift 5 #file < #dsohandle");
+      static_assert(Kind::FilePathSpelledAsFile < Kind::Transcription,
+                    "Swift 5 #file < #transcription");
 
       // The rules are all commutative, so we will take the greater of the two
       // kinds.

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -208,6 +208,7 @@ getActualDefaultArgKind(uint8_t raw) {
   CASE(EmptyArray)
   CASE(EmptyDictionary)
   CASE(StoredProperty)
+  CASE(Transcription)
 #undef CASE
   }
   return None;

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -500,6 +500,7 @@ enum class DefaultArgumentKind : uint8_t {
   EmptyArray,
   EmptyDictionary,
   StoredProperty,
+  Transcription,
 };
 using DefaultArgumentField = BCFixed<4>;
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1302,6 +1302,7 @@ static uint8_t getRawStableDefaultArgumentKind(swift::DefaultArgumentKind kind) 
   CASE(EmptyArray)
   CASE(EmptyDictionary)
   CASE(StoredProperty)
+  CASE(Transcription)
 #undef CASE
   }
 

--- a/test/SILGen/magic_identifier_transcription.swift
+++ b/test/SILGen/magic_identifier_transcription.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+func f(_ expression: Bool, transcription: String = #transcription(of: expression)) { }
+
+func g() {
+    f(1 + 1 == 2)
+    
+    // CHECK: string_literal utf8 "1 + 1 == 2"
+}

--- a/utils/gyb_syntax_support/ExprNodes.py
+++ b/utils/gyb_syntax_support/ExprNodes.py
@@ -164,6 +164,19 @@ EXPR_NODES = [
              Child('PoundDsohandle', kind='PoundDsohandleToken'),
          ]),
 
+    # A #transcription expression.
+    Node('PoundTranscriptionExpr', kind='Expr',
+         traits=['Parenthesized'],
+         children=[
+             Child('PoundTranscription', kind='PoundTranscriptionToken'),
+             Child('LeftParen', kind='LeftParenToken'),
+             Child('Kind', kind='ContextualKeywordToken',
+                   text_choices=['of']),
+             Child('Colon', kind='ColonToken'),
+             Child('ParameterName', kind='Expr'),
+             Child('RightParen', kind='RightParenToken'),
+         ]),
+
     # symbolic-reference-expression -> identifier generic-argument-clause?
     Node('SymbolicReferenceExpr', kind='Expr',
          children=[

--- a/utils/gyb_syntax_support/NodeSerializationCodes.py
+++ b/utils/gyb_syntax_support/NodeSerializationCodes.py
@@ -261,6 +261,7 @@ SYNTAX_NODE_SERIALIZATION_CODES = {
     'BackDeployAttributeSpecList' : 257,
     'BackDeployVersionList' : 258,
     'BackDeployVersionArgument' : 259,
+    'PoundTranscriptionExpr': 260,
 }
 
 

--- a/utils/gyb_syntax_support/Token.py
+++ b/utils/gyb_syntax_support/Token.py
@@ -289,6 +289,8 @@ SYNTAX_TOKENS = [
                  serialization_code=71),
     PoundKeyword('PoundAssert', 'assert', text='#assert',
                  serialization_code=117),
+    PoundKeyword('PoundTranscription', 'transcription', text='#transcription',
+                 serialization_code=125),
 
     PoundDirectiveKeyword('PoundSourceLocation', 'sourceLocation',
                           text='#sourceLocation', serialization_code=65),


### PR DESCRIPTION
<!-- What's in this pull request? -->
**⚠️ This PR is a work in progress.**

This change introduces a new magic identifier literal, `#transcription(of:)`, that can provide the source representation of either an argument to the same function or an arbitrary expression. The former case is more useful. Consider `assert()`:

```swift
public func assert(
  _ condition: @autoclosure () -> Bool,
  _ message: @autoclosure () -> String = String(),
  file: StaticString = #file, line: UInt = #line
) {
  if !condition() {
    print("Assertion failed: \(message)")
    abort()
  }
}
```

This function checks `condition()`, and if `false` it emits a diagnostic and terminates the program. In C, `assert()` includes the source code corresponding to its condition argument; in Swift, this is currently impossible. `#transcription(of:)` makes it possible:

```swift
public func assert(
  _ condition: @autoclosure () -> Bool,
  _ message: @autoclosure () -> String = #transcription(of: condition),
  file: StaticString = #file, line: UInt = #line
) {
  if !condition() {
    print("Assertion failed: \(message)")
    abort()
  }
}
```

Now, suddenly, `assert()` prints the expression that failed rather than a generic or empty string! 🥳

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://15581564.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
