### PR TITLE
[ToolingLibs] Build tooling libs with libswift

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -730,6 +730,7 @@ set(SWIFT_INCLUDE_DIR "${CMAKE_CURRENT_BINARY_DIR}/include")
 set(SWIFT_RUNTIME_OUTPUT_INTDIR "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/bin")
 set(SWIFT_LIBRARY_OUTPUT_INTDIR "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/lib")
 if("${SWIFT_NATIVE_SWIFT_TOOLS_PATH}" STREQUAL "")
+  # This is the normal case. We are not cross-compiling.
   set(SWIFT_NATIVE_SWIFT_TOOLS_PATH "${SWIFT_RUNTIME_OUTPUT_INTDIR}")
   set(SWIFT_EXEC_FOR_SWIFT_MODULES "${CMAKE_Swift_COMPILER}")
 elseif(BOOTSTRAPPING_MODE MATCHES "BOOTSTRAPPING.*")
@@ -744,6 +745,12 @@ elseif(BOOTSTRAPPING_MODE MATCHES "BOOTSTRAPPING.*")
   else()
     set(BOOTSTRAPPING_MODE "HOSTTOOLS")
   endif()
+elseif(BOOTSTRAPPING_MODE STREQUAL "HOSTTOOLS")
+  # We are building using a pre-installed host toolchain but not bootstrapping
+  # the Swift modules. This happens when building using 'build-tooling-libs'
+  # where we haven't built a new Swift compiler. Use the Swift compiler from the
+  # pre-installed host toolchain to build the Swift modules.
+  set(SWIFT_EXEC_FOR_SWIFT_MODULES "${CMAKE_Swift_COMPILER}")
 endif()
 
 if(BOOTSTRAPPING_MODE MATCHES "HOSTTOOLS|.*-WITH-HOSTLIBS")

--- a/utils/build-tooling-libs
+++ b/utils/build-tooling-libs
@@ -172,6 +172,7 @@ class Builder(object):
             "-DSWIFT_HOST_VARIANT_SDK=" + host_sdk,
             "-DSWIFT_HOST_VARIANT_ARCH=" + self.arch,
             "-DCMAKE_Swift_COMPILER_TARGET=" + host_triple,
+            "-DCMAKE_Swift_COMPILER=" + self.toolchain.swiftc,
             "-DCMAKE_C_FLAGS=" + llvm_c_flags,
             "-DCMAKE_CXX_FLAGS=" + llvm_c_flags,
         ]
@@ -262,6 +263,13 @@ class Builder(object):
             "-DCLANG_INCLUDE_TESTS=FALSE",
             "-DSWIFT_INCLUDE_TESTS=FALSE",
         ]
+        cmake_args += [
+            "-DBOOTSTRAPPING_MODE=HOSTTOOLS",
+            "-DEXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR=" +
+            os.path.join(SWIFT_SOURCE_ROOT,
+                         "swift-experimental-string-processing"),
+        ]
+
         llvm_src_path = os.path.join(SWIFT_SOURCE_ROOT, "llvm") \
             if isSwiftContainedInLLVMProject \
             else os.path.join(SWIFT_SOURCE_ROOT, "llvm-project", "llvm")


### PR DESCRIPTION
* In CMakeLists.txt, use `CMAKE_Swift_COMPILER` to build `SwiftCompilerModules` when `BOOTSTRAPPING_MODE` is `HOSTTOOLS`
* In `utils/build-tooling-libs`, specify necessary CMake options to enable libswift integration
