### PR TITLE
NFC, extract param & return type for type metadata access function to…

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -4352,6 +4352,14 @@ IRGenModule::getAddrOfObjCResilientClassStub(ClassDecl *classDecl,
   return getAddrOfLLVMVariable(entity, forDefinition, DebugTypeInfo());
 }
 
+llvm::IntegerType *IRGenModule::getTypeMetadataRequestParamTy() {
+  return SizeTy;
+}
+
+llvm::StructType *IRGenModule::getTypeMetadataResponseTy() {
+  return TypeMetadataResponseTy;
+}
+
 /// Fetch the type metadata access function for a non-generic type.
 llvm::Function *
 IRGenModule::getAddrOfTypeMetadataAccessFunction(CanType type,
@@ -4367,8 +4375,9 @@ IRGenModule::getAddrOfTypeMetadataAccessFunction(CanType type,
     return entry;
   }
 
-  llvm::Type *params[] = { SizeTy }; // MetadataRequest
-  auto fnType = llvm::FunctionType::get(TypeMetadataResponseTy, params, false);
+  llvm::Type *params[] = {getTypeMetadataRequestParamTy()}; // MetadataRequest
+  auto fnType =
+      llvm::FunctionType::get(getTypeMetadataResponseTy(), params, false);
   Signature signature(fnType, llvm::AttributeList(), SwiftCC);
   LinkInfo link = LinkInfo::get(*this, entity, forDefinition);
   entry = createFunction(*this, link, signature);

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -874,6 +874,9 @@ public:
   llvm::PointerType *getValueWitnessTablePtrTy();
   llvm::PointerType *getEnumValueWitnessTablePtrTy();
 
+  llvm::IntegerType *getTypeMetadataRequestParamTy();
+  llvm::StructType *getTypeMetadataResponseTy();
+
   void unimplemented(SourceLoc, StringRef Message);
   [[noreturn]]
   void fatal_unimplemented(SourceLoc, StringRef Message);


### PR DESCRIPTION
… accessors for reuse

They will be reused to provide information about the signature of the type metadata access function to the Clang printer for C++ interop
