### PR TITLE
[5.7][SourceKit] Update for primary associated types

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3532,8 +3532,9 @@ void PrintAST::printPrimaryAssociatedTypes(ProtocolDecl *decl) {
       [&](AssociatedTypeDecl *assocType) {
         Printer.callPrintStructurePre(PrintStructureKind::GenericParameter,
                                       assocType);
-        Printer.printName(assocType->getName(),
-                          PrintNameContext::GenericParameter);
+        Printer.printTypeRef(assocType->getDeclaredInterfaceType(), assocType,
+                             assocType->getName(),
+                             PrintNameContext::GenericParameter);
         Printer.printStructurePost(PrintStructureKind::GenericParameter,
                                    assocType);
       },

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -180,6 +180,21 @@ bool SemaAnnotator::walkToDeclPreProper(Decl *D) {
       if (!ReportParamList(ParamList))
         return false;
     }
+
+    if (auto proto = dyn_cast<ProtocolDecl>(VD)) {
+      // Report a primary associated type as a references to the associated type
+      // declaration.
+      for (auto parsedName : proto->getPrimaryAssociatedTypeNames()) {
+        Identifier name = parsedName.first;
+        SourceLoc loc = parsedName.second;
+        if (auto assocTypeDecl = proto->getAssociatedType(name)) {
+          passReference(assocTypeDecl,
+                        assocTypeDecl->getDeclaredInterfaceType(),
+                        DeclNameLoc(loc),
+                        ReferenceMetaData(SemaReferenceKind::TypeRef, None));
+        }
+      }
+    }
   } else if (auto *ED = dyn_cast<ExtensionDecl>(D)) {
     SourceRange SR = SourceRange();
     if (auto *repr = ED->getExtendedTypeRepr())

--- a/test/Index/roles.swift
+++ b/test/Index/roles.swift
@@ -504,3 +504,11 @@ func `escapedName`(`x`: Int) {}
 // CHECK: [[@LINE-1]]:1 | function/Swift | escapedName(x:) | {{.*}} | Ref,Call | rel: 0
 `escapedName`(`x`:)
 // CHECK: [[@LINE-1]]:1 | function/Swift | escapedName(x:) | {{.*}} | Ref | rel: 0
+
+protocol WithPrimary<Assoc> {
+// CHECK: [[@LINE-1]]:22 | type-alias/associated-type/Swift | Assoc | {{.*}} | Ref | rel: 0
+// CHECK: [[@LINE-2]]:10 | protocol/Swift | WithPrimary | {{.*}} | Def | rel: 0
+  associatedtype Assoc
+// CHECK: [[@LINE-1]]:18 | type-alias/associated-type/Swift | Assoc | {{.*}} | Def,RelChild | rel: 1
+// CHECK-NEXT: RelChild | protocol/Swift | WithPrimary | {{.*}}
+}

--- a/test/SourceKit/CursorInfo/cursor_generics.swift
+++ b/test/SourceKit/CursorInfo/cursor_generics.swift
@@ -30,6 +30,10 @@ public struct HostRecord<IPType: IP> {
     }
 }
 
+public protocol Proto<Assoc> {
+  associatedtype Assoc
+}
+
 // RUN: %sourcekitd-test -req=cursor -pos=1:10 %s -- %s | %FileCheck -check-prefix=CHECK1 %s
 // CHECK1: <Declaration>func testGenerics&lt;T&gt;(x: <Type usr="s:15cursor_generics12testGenerics1xyx_tlF1TL_xmfp">T</Type>)</Declaration>
 
@@ -52,3 +56,16 @@ public struct HostRecord<IPType: IP> {
 // RUN: %sourcekitd-test -req=cursor -pos=29:22 %s -- %s | %FileCheck -check-prefix=CHECK_IP_TYPE %s
 // CHECK_IP_TYPE: source.lang.swift.ref.generic_type_param
 // CHECK_IP_TYPE: <Declaration>IPType : <Type usr="s:15cursor_generics2IPP">IP</Type></Declaration>
+
+// RUN: %sourcekitd-test -req=cursor -cursor-action -pos=33:23 %s -- %s | %FileCheck --check-prefixes=CHECK_ASSOC_COMMON,CHECK_ASSOC_PRIMARY %s
+// RUN: %sourcekitd-test -req=cursor -cursor-action -pos=34:18 %s -- %s | %FileCheck --check-prefixes=CHECK_ASSOC_COMMON,CHECK_ASSOC_DECL %s
+// CHECK_ASSOC_PRIMARY: source.lang.swift.ref.associatedtype
+// CHECK_ASSOC_DECL: source.lang.swift.decl.associatedtype
+// CHECK_ASSOC_COMMON: Assoc
+// CHECK_ASSOC_COMMON: Self.Assoc.Type
+// CHECK_ASSOC_COMMON: <Declaration>associatedtype Assoc</Declaration>
+// CHECK_ASSOC_COMMON: <decl.associatedtype><syntaxtype.keyword>associatedtype</syntaxtype.keyword> <decl.name>Assoc</decl.name></decl.associatedtype>
+// CHECK_ASSOC_COMMON:      ACTIONS BEGIN
+// CHECK_ASSOC_COMMON-NEXT: source.refactoring.kind.rename.global
+// CHECK_ASSOC_COMMON-NEXT: Global Rename
+// CHECK_ASSOC_COMMON-NEXT: ACTIONS END

--- a/test/SourceKit/InterfaceGen/Inputs/swift_mod.swift
+++ b/test/SourceKit/InterfaceGen/Inputs/swift_mod.swift
@@ -9,3 +9,7 @@ public func pub_function() {}
 internal func int_function() {}
 fileprivate func fp_function() {}
 private func priv_function() {}
+
+public protocol MyProto<Assoc> {
+  associatedtype Assoc
+}

--- a/test/SourceKit/InterfaceGen/gen_swift_module.swift.from_swiftinterface.response
+++ b/test/SourceKit/InterfaceGen/gen_swift_module.swift.from_swiftinterface.response
@@ -4,6 +4,11 @@ public class MyClass {
     public func pub_method()
 }
 
+public protocol MyProto<Assoc> {
+
+    associatedtype Assoc
+}
+
 public func pub_function()
 
 
@@ -46,15 +51,51 @@ public func pub_function()
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 64,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 73,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 81,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 95,
+    key.length: 14
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 110,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 119,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 126,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 69,
+    key.offset: 131,
     key.length: 12
   }
 ]
-<<NULL>>
+[
+  {
+    key.kind: source.lang.swift.ref.associatedtype,
+    key.offset: 81,
+    key.length: 5
+  }
+]
 [
   {
     key.kind: source.lang.swift.decl.class,
@@ -93,16 +134,45 @@ public func pub_function()
     ]
   },
   {
-    key.kind: source.lang.swift.decl.function.free,
+    key.kind: source.lang.swift.decl.protocol,
     key.accessibility: source.lang.swift.accessibility.public,
-    key.name: "pub_function()",
+    key.name: "MyProto",
     key.offset: 64,
-    key.length: 19,
-    key.nameoffset: 69,
-    key.namelength: 14,
+    key.length: 53,
+    key.nameoffset: 73,
+    key.namelength: 7,
+    key.bodyoffset: 89,
+    key.bodylength: 27,
     key.attributes: [
       {
         key.offset: 57,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ],
+    key.substructure: [
+      {
+        key.kind: source.lang.swift.decl.associatedtype,
+        key.accessibility: source.lang.swift.accessibility.public,
+        key.name: "Assoc",
+        key.offset: 95,
+        key.length: 20,
+        key.nameoffset: 110,
+        key.namelength: 5
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.function.free,
+    key.accessibility: source.lang.swift.accessibility.public,
+    key.name: "pub_function()",
+    key.offset: 126,
+    key.length: 19,
+    key.nameoffset: 131,
+    key.namelength: 14,
+    key.attributes: [
+      {
+        key.offset: 119,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }

--- a/test/SourceKit/InterfaceGen/gen_swift_module.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_swift_module.swift.response
@@ -5,6 +5,11 @@ public class MyClass {
     public func pub_method()
 }
 
+public protocol MyProto<Assoc> {
+
+    associatedtype Assoc
+}
+
 public func pub_function()
 
 
@@ -57,11 +62,41 @@ public func pub_function()
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 89,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 98,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 106,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 120,
+    key.length: 14
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 135,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 144,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 151,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 94,
+    key.offset: 156,
     key.length: 12
   }
 ]
@@ -71,6 +106,11 @@ public func pub_function()
     key.offset: 7,
     key.length: 17,
     key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.associatedtype,
+    key.offset: 106,
+    key.length: 5
   }
 ]
 [
@@ -111,16 +151,45 @@ public func pub_function()
     ]
   },
   {
-    key.kind: source.lang.swift.decl.function.free,
+    key.kind: source.lang.swift.decl.protocol,
     key.accessibility: source.lang.swift.accessibility.public,
-    key.name: "pub_function()",
+    key.name: "MyProto",
     key.offset: 89,
-    key.length: 19,
-    key.nameoffset: 94,
-    key.namelength: 14,
+    key.length: 53,
+    key.nameoffset: 98,
+    key.namelength: 7,
+    key.bodyoffset: 114,
+    key.bodylength: 27,
     key.attributes: [
       {
         key.offset: 82,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ],
+    key.substructure: [
+      {
+        key.kind: source.lang.swift.decl.associatedtype,
+        key.accessibility: source.lang.swift.accessibility.public,
+        key.name: "Assoc",
+        key.offset: 120,
+        key.length: 20,
+        key.nameoffset: 135,
+        key.namelength: 5
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.function.free,
+    key.accessibility: source.lang.swift.accessibility.public,
+    key.name: "pub_function()",
+    key.offset: 151,
+    key.length: 19,
+    key.nameoffset: 156,
+    key.namelength: 14,
+    key.attributes: [
+      {
+        key.offset: 144,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }


### PR DESCRIPTION
Cherry-pick #58973 into release/5.7

* **Explanation**: Update SourceKit for SE-0346 (primary associated types). InterfaceGen reports a primary associated type as a reference to the 'associatedtype' declaration. CursorInfo on a primary associated type returns information of the 'associatedtype' declaration
* **Scope**: SourceKit
* **Risk**: Low. Minimal and straight forward change
* **Issues**: rdar://93275458
* **Testing**: Added regression test cases
* **Reviewer**: Ben Barham (@bnbarham)