### PR TITLE
🍒[5.7][Distributed] Fix too restrictive distributed witness isolation checking

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3634,7 +3634,7 @@ public:
   bool isActor() const;
 
   /// Whether this nominal type qualifies as a distributed actor, meaning that
-  /// it is either a distributed actor.
+  /// it is either a distributed actor or a DistributedActor constrained protocol.
   bool isDistributedActor() const;
 
   /// Whether this nominal type qualifies as any actor (plain or distributed).

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9154,7 +9154,7 @@ ActorIsolation swift::getActorIsolationOfContext(DeclContext *dc) {
       auto selfDecl = isolation.getActorInstance();
       auto actorClass = selfDecl->getType()->getReferenceStorageReferent()
           ->getClassOrBoundGenericClass();
-      // FIXME: Doesn't work properly with generics
+      // FIXME: Doesn't work properly with generics #59356
       assert(actorClass && "Bad closure actor isolation?");
       return ActorIsolation::forActorInstance(actorClass)
                 .withPreconcurrency(isolation.preconcurrency());

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3010,12 +3010,12 @@ bool ConformanceChecker::checkActorIsolation(
   if (isDistributed) {
     // Check if the protocol where the requirement originates from
     // is a distributed actor constrained one.
-    auto proto = dyn_cast<ProtocolDecl>(requirement->getDeclContext());
-    if (proto && proto->isDistributedActor()) {
+    if (cast<ProtocolDecl>(requirement->getDeclContext())->isDistributedActor()) {
       // The requirement was declared in a DistributedActor constrained proto.
       //
-      // This means casting up to this `P` won't "strip off" the "distributed-ness"
-      // of the type, and all call-sites will be checking distributed isolation.
+      // This means casting up to this `P` won't "strip off" the
+      // "distributed-ness" of the type, and all call-sites will be checking
+      // distributed isolation.
       //
       // This means that we can actually allow these specific requirements,
       // to be witnessed without the distributed keyword (!), but they won't be
@@ -3031,8 +3031,7 @@ bool ConformanceChecker::checkActorIsolation(
 
       // If the requirement is distributed, we still need to require it on the witness though.
       // We DO allow a non-distributed requirement to be witnessed here though!
-      if (isDistributedDecl(requirement) &&
-          !isDistributedDecl(witness))
+      if (isDistributedDecl(requirement) && !isDistributedDecl(witness))
         missingOptions |= MissingFlags::WitnessDistributed;
     } else {
       // The protocol requirement comes from a normal (non-distributed actor)
@@ -3041,12 +3040,12 @@ bool ConformanceChecker::checkActorIsolation(
 
       // If we're coming from a non-distributed requirement,
       // then the requirement must be 'throws' to accommodate failure.
-      if (!isDistributedDecl(requirement) && !isThrowsDecl(requirement))
+      if (!isThrowsDecl(requirement))
         missingOptions |= MissingFlags::RequirementThrows;
 
-      // If the requirement is distributed, we require a distributed witness
-      if (!isDistributedDecl(witness) &&
-          (isDistributedDecl(requirement) || !missingOptions))
+      // If the witness is distributed, it is able to witness a requirement
+      // only if the requirement is `async throws`.
+      if (!isDistributedDecl(witness) && !missingOptions)
         missingOptions |= MissingFlags::WitnessDistributed;
     }
   }

--- a/test/Distributed/Runtime/distributed_actor_local_only_witness_and_call.swift
+++ b/test/Distributed/Runtime/distributed_actor_local_only_witness_and_call.swift
@@ -1,0 +1,71 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-build-swift -module-name main -Xfrontend -enable-experimental-distributed -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s --color
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// rdar://76038845
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+// FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
+// UNSUPPORTED: OS=windows-msvc
+
+
+import Distributed
+import FakeDistributedActorSystems
+
+typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
+
+protocol LifecycleWatch: DistributedActor where ActorSystem == FakeRoundtripActorSystem {
+  func terminated(actor id: ID) async
+}
+
+extension LifecycleWatch {
+  func watch<T: Codable>(x: Int, _ y: T) async throws {
+    // nothing here
+    print("executed: \(#function) - x = \(x), y = \(y)")
+  }
+
+  distributed func test<T: Codable & Sendable>(x: Int, _ y: T) async throws {
+    print("executed: \(#function)")
+    try await self.watch(x: x, y)
+    print("done executed: \(#function)")
+  }
+}
+
+distributed actor Worker: LifecycleWatch {
+  func terminated(actor id: ID) async {
+    print("terminated (on \(self.id)): \(id)")
+  }
+}
+
+@main struct Main {
+  static func main() async {
+    let worker: any LifecycleWatch = Worker(actorSystem: DefaultDistributedActorSystem())
+    try! await worker.test(x: 42, "on protocol")
+
+    // CHECK: executed: test(x:_:)
+    // CHECK: executed: watch(x:_:) - x = 42, y = on protocol
+    // CHECK: done executed: test(x:_:)
+
+    // FIXME: Actor isolation getting with generics is pending implementation #59356
+    do {
+      let terminatedID = Worker.ID(parse: "<terminated-id>")
+      let __secretlyKnownToBeLocal = worker
+      await __secretlyKnownToBeLocal.terminated(actor: terminatedID)
+
+      // FIXME: Once the above fixme is solved, use this real code instead:
+      //    _ = await worker.whenLocal { __secretlyKnownToBeLocal in
+      //      let terminatedID = Worker.ID(parse: "<terminated-id>")
+      //      return await __secretlyKnownToBeLocal.terminated(actor: terminatedID)
+      //    }
+    }
+    // CHECK: terminated (on ActorAddress(address: "<unique-id>")): ActorAddress(address: "<terminated-id>")
+
+    print("OK") // CHECK: OK
+  }
+}

--- a/test/Distributed/distributed_protocol_isolation.swift
+++ b/test/Distributed/distributed_protocol_isolation.swift
@@ -211,6 +211,22 @@ func test_watchingDA<WDA: TerminationWatchingDA>(da: WDA) async throws {
   try await da.terminated(da: "the terminated func is not distributed")
   // expected-error@-1{{only 'distributed' instance methods can be called on a potentially remote distributed actor}}
   // expected-warning@-2{{no calls to throwing functions occur within 'try' expression}}
+
+//  // FIXME: pending fix of closure isolation checking with actors #59356
+//  await da.whenLocal { __secretlyKnownToBeLocal in
+//    await __secretlyKnownToBeLocal.terminated(da: "local calls are okey!") // OK
+//  }
+}
+
+func test_watchingDA_erased(da: DA_TerminationWatchingDA) async throws {
+  let wda: TerminationWatchingDA = da
+  try await wda.terminated(wda: "the terminated func is not distributed")
+  // expected-error@-1{{only 'distributed' instance methods can be called on a potentially remote distributed actor}}
+  // expected-warning@-2{{no calls to throwing functions occur within 'try' expression}}
+
+  await wda.whenLocal { __secretlyKnownToBeLocal in
+    await __secretlyKnownToBeLocal.terminated(da: "local calls are okey!") // OK
+  }
 }
 
 func test_watchingDA_any(da: any TerminationWatchingDA) async throws {


### PR DESCRIPTION
**Description:** Witness checking is too restrictive for distributed actors conforming to protocols which are already `DistributedActor` constrained. Long discussion of this in #59358 but short version is that this is too restrictive and prevents some APIs, and generally is an omission in the isolation model.
**Risk:** Low, fixes missing ability to conform to DistributedActor constrained protocols from distributed actors. Does not affect any other parts of library or runtime.
**Review by:** @DougGregor
**Testing:** PR Testing, Verifying using custom toolchain in Cluster library.
**Radar:** rdar://94779780
**Original PR:** #59358
**Unblocks:** https://github.com/apple/swift-distributed-actors/pull/961