### PR TITLE
[Distributed] cleanup existential check in SerReq checking

### DIFF
--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -316,12 +316,9 @@ swift::getDistributedSerializationRequirements(
   if (existentialRequirementTy->isAny())
     return true; // we're done here, any means there are no requirements
 
-  if (auto alias = dyn_cast<TypeAliasType>(existentialRequirementTy.getPointer())) {
-    auto ty = alias->getDesugaredType();
-    if (isa<ClassType>(ty) || isa<StructType>(ty) || isa<EnumType>(ty)) {
-      // SerializationRequirement cannot be class or struct nowadays
-      return false;
-    }
+  if (!existentialRequirementTy->isExistentialType()) {
+    // SerializationRequirement must be an existential type
+    return false;
   }
 
   ExistentialType *serialReqType = existentialRequirementTy


### PR DESCRIPTION
Review followup for [Distributed] Require that SerReq can only be used with protocols #42348

Following up on review comments in https://github.com/apple/swift/pull/42348#discussion_r849777370
Is this right now @hborla @xedin ?

I wanted to also follow up on what @DougGregor said there but I wasn't entirely sure how exactly do understand the hint there 🤔 