### PR TITLE
Sema: Infer the availability of extensions using the extended type instead of just the nominal

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -582,10 +582,10 @@ private:
     // This rule is a convenience for library authors who have written
     // extensions without specifying availabilty on the extension itself.
     if (auto *ED = dyn_cast<ExtensionDecl>(D)) {
-      auto *Nominal = ED->getExtendedNominal();
-      if (Nominal && !hasActiveAvailableAttribute(D, Context)) {
+      auto ET = ED->getExtendedType();
+      if (ET && !hasActiveAvailableAttribute(D, Context)) {
         EffectiveAvailability.intersectWith(
-            swift::AvailabilityInference::availableRange(Nominal, Context));
+            swift::AvailabilityInference::inferForType(ET));
 
         // We want to require availability to be specified on extensions of
         // types that would be potentially unavailable to the module containing

--- a/test/Incremental/Verifier/single-file-private/AnyObject.swift
+++ b/test/Incremental/Verifier/single-file-private/AnyObject.swift
@@ -16,6 +16,7 @@ import Foundation
 // expected-provides {{NSObject}}
 // expected-provides {{Selector}}
 // expected-provides {{Bool}}
+// expected-provides {{ObjCBool}}
 // expected-provides {{==}}
 // expected-provides {{Equatable}}
 // expected-provides {{Hasher}}

--- a/test/attr/attr_inlinable_available.swift
+++ b/test/attr/attr_inlinable_available.swift
@@ -1134,6 +1134,36 @@ extension AfterDeploymentTarget {
   ) {}
 }
 
+// MARK: Extensions on nested types
+
+@available(macOS 10.14.5, *)
+public enum BetweenTargetsEnum {
+  public struct Nested {}
+}
+
+extension BetweenTargetsEnum.Nested {}
+
+extension BetweenTargetsEnum.Nested { // expected-note {{add @available attribute to enclosing extension}}
+  func internalFuncInExtension( // expected-note {{add @available attribute to enclosing instance method}}
+    _: NoAvailable,
+    _: BeforeInliningTarget,
+    _: AtInliningTarget,
+    _: BetweenTargets,
+    _: AtDeploymentTarget,
+    _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
+  ) {}
+}
+
+extension BetweenTargetsEnum.Nested { // expected-note 2 {{add @available attribute to enclosing extension}}
+  public func publicFuncInExtension( // expected-note 2 {{add @available attribute to enclosing instance method}}
+    _: NoAvailable,
+    _: BeforeInliningTarget,
+    _: AtInliningTarget,
+    _: BetweenTargets,
+    _: AtDeploymentTarget, // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}}
+    _: AfterDeploymentTarget // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}}
+  ) {}
+}
 
 // MARK: Protocol conformances
 


### PR DESCRIPTION
This ensures availability is inferred correctly for nested types.

Resolves rdar://94851069