### PR TITLE
[Diagnostics] Diagnose a mismatch between result builder result and r…

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6173,6 +6173,10 @@ ERROR(result_builder_requires_explicit_var_initialization,none,
 ERROR(cannot_declare_computed_var_in_result_builder,none,
       "cannot declare local %select{lazy|wrapped|computed|observed}0 variable "
       "in result builder", (unsigned))
+ERROR(cannot_convert_result_builder_result_to_return_type,none,
+      "cannot convert result builder result type %0 to return type %1",
+      (Type,Type))
+
 
 //------------------------------------------------------------------------------
 // MARK: Tuple Shuffle Diagnostics

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -796,6 +796,10 @@ bool GenericArgumentsMismatchFailure::diagnoseAsError() {
       break;
     }
 
+    case ConstraintLocator::ResultBuilderBodyResult:
+      diagnostic = diag::cannot_convert_result_builder_result_to_return_type;
+      break;
+
     case ConstraintLocator::AutoclosureResult:
     case ConstraintLocator::ApplyArgToParam:
     case ConstraintLocator::ApplyArgument: {

--- a/test/Constraints/result_builder_diags.swift
+++ b/test/Constraints/result_builder_diags.swift
@@ -838,3 +838,20 @@ func test_rdar89742267() {
     }
   }
 }
+
+// https://github.com/apple/swift/issues/59390
+func test_invalid_result_is_diagnosed() {
+  @resultBuilder
+  struct MyBuilder {
+    static func buildBlock<T1>(_ t1: T1) -> T1 {
+      return t1
+    }
+  }
+
+  struct S<T> {} // expected-note {{arguments to generic parameter 'T' ('Int' and 'String') are expected to be equal}}
+
+  @MyBuilder
+  func test() -> S<String> { // expected-error {{cannot convert result builder result type 'S<Int>' to return type 'S<String>}}
+    S<Int>()
+  }
+}


### PR DESCRIPTION
…eturn type

Add a tailored diagnostic for cases where result builder
result type disagrees with expected contextual return type.

Resolves: https://github.com/apple/swift/issues/59390

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
