### PR TITLE
stop cloning swift-cmark twice

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -71,8 +71,6 @@
             "remote": { "id": "apple/swift-docc-symbolkit" } },
         "swift-markdown": {
             "remote": { "id": "apple/swift-markdown" } },
-        "swift-cmark-gfm": {
-            "remote": { "id": "apple/swift-cmark" } },
         "swift-nio": {
             "remote": { "id": "apple/swift-nio" } },
         "swift-nio-ssl": {
@@ -120,7 +118,6 @@
                 "swift-docc-render-artifact": "main",
                 "swift-docc-symbolkit": "main",
                 "swift-markdown": "main",
-                "swift-cmark-gfm": "gfm",
                 "swift-nio": "2.31.2",
                 "swift-nio-ssl": "2.15.0",
                 "swift-experimental-string-processing": "swift/main"
@@ -162,7 +159,6 @@
                 "swift-docc-render-artifact": "main",
                 "swift-docc-symbolkit": "main",
                 "swift-markdown": "main",
-                "swift-cmark-gfm": "gfm",
                 "swift-nio": "2.31.2",
                 "swift-nio-ssl": "2.15.0",
                 "swift-experimental-string-processing": "swift/main"


### PR DESCRIPTION
Resolves rdar://90461570

Now that [the Swift toolchain builds with swift-cmark/gfm](https://github.com/apple/swift/pull/40188) and [swift-markdown uses the "cmark" directory to load swift-cmark](https://github.com/apple/swift-markdown/pull/47), we can stop cloning swift-cmark twice in `update-checkout`. This PR removes the extra "swift-cmark-gfm" clone from update-checkout-config, since it's no longer necessary.