### PR TITLE
[interop][SwiftToCxx] Pass struct to function as inout

### DIFF
--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -63,7 +63,7 @@ bool isKnownCType(Type t, PrimitiveTypeMapping &typeMapping) {
 // native Swift function/method.
 class CFunctionSignatureTypePrinter
     : public TypeVisitor<CFunctionSignatureTypePrinter, void,
-                         Optional<OptionalTypeKind>>,
+                         Optional<OptionalTypeKind>, bool>,
       private ClangSyntaxPrinter {
 public:
   CFunctionSignatureTypePrinter(raw_ostream &os, raw_ostream &cPrologueOS,
@@ -87,30 +87,33 @@ public:
     return true;
   }
 
-  void visitType(TypeBase *Ty, Optional<OptionalTypeKind> optionalKind) {
+  void visitType(TypeBase *Ty, Optional<OptionalTypeKind> optionalKind,
+                 bool isInOutParam) {
     assert(Ty->getDesugaredType() == Ty && "unhandled sugared type");
     os << "/* ";
     Ty->print(os);
     os << " */";
   }
 
-  void visitTupleType(TupleType *TT, Optional<OptionalTypeKind> optionalKind) {
+  void visitTupleType(TupleType *TT, Optional<OptionalTypeKind> optionalKind,
+                      bool isInOutParam) {
     assert(TT->getNumElements() == 0);
     // FIXME: Handle non-void type.
     os << "void";
   }
 
   void visitTypeAliasType(TypeAliasType *aliasTy,
-                          Optional<OptionalTypeKind> optionalKind) {
+                          Optional<OptionalTypeKind> optionalKind,
+                          bool isInOutParam) {
     const TypeAliasDecl *alias = aliasTy->getDecl();
     if (printIfKnownSimpleType(alias, optionalKind))
       return;
 
-    visitPart(aliasTy->getSinglyDesugaredType(), optionalKind);
+    visitPart(aliasTy->getSinglyDesugaredType(), optionalKind, isInOutParam);
   }
 
-  void visitStructType(StructType *ST,
-                       Optional<OptionalTypeKind> optionalKind) {
+  void visitStructType(StructType *ST, Optional<OptionalTypeKind> optionalKind,
+                       bool isInOutParam) {
     const StructDecl *SD = ST->getStructOrBoundGenericStruct();
 
     // Handle known type names.
@@ -121,18 +124,24 @@ public:
       if (languageMode != OutputLanguageMode::Cxx &&
           interopContext.getIrABIDetails().shouldPassIndirectly(ST)) {
         // FIXME: it would be nice to print out the C struct type here.
-        os << "const void * _Nonnull";
+        if (isInOutParam) {
+          os << "void * _Nonnull";
+        } else {
+          os << "const void * _Nonnull";
+        }
+
       } else {
         ClangValueTypePrinter(os, cPrologueOS, typeMapping, interopContext)
-            .printValueTypeParameterType(SD, languageMode);
+            .printValueTypeParameterType(SD, languageMode, isInOutParam);
       }
     } else
       ClangValueTypePrinter(os, cPrologueOS, typeMapping, interopContext)
           .printValueTypeReturnType(SD, languageMode);
   }
 
-  void visitPart(Type Ty, Optional<OptionalTypeKind> optionalKind) {
-    TypeVisitor::visit(Ty, optionalKind);
+  void visitPart(Type Ty, Optional<OptionalTypeKind> optionalKind,
+                 bool isInOutParam) {
+    TypeVisitor::visit(Ty, optionalKind, isInOutParam);
   }
 
 private:
@@ -157,10 +166,16 @@ void DeclAndTypeClangFunctionPrinter::printFunctionSignature(
     // see DeclAndTypePrinter::print.
     CFunctionSignatureTypePrinter typePrinter(os, cPrologueOS, typeMapping,
                                               outputLang, interopContext);
-    typePrinter.visit(ty, optionalKind);
+    typePrinter.visit(ty, optionalKind, isInOutParam);
 
     if (isInOutParam) {
-      os << (outputLang == OutputLanguageMode::Cxx ? " &" : " *");
+      if (outputLang == OutputLanguageMode::Cxx &&
+          isKnownCxxType(ty, typeMapping)) {
+        os << " &";
+      } else if (outputLang == OutputLanguageMode::ObjC &&
+                 isKnownCType(ty, typeMapping)) {
+        os << " *";
+      }
     }
 
     if (!name.empty()) {
@@ -182,7 +197,9 @@ void DeclAndTypeClangFunctionPrinter::printFunctionSignature(
     CFunctionSignatureTypePrinter typePrinter(
         os, cPrologueOS, typeMapping, outputLang, interopContext,
         FunctionSignatureTypeUse::ReturnType);
-    typePrinter.visit(objTy, retKind);
+    // Pass false because it's a parameter for indirect return.
+    // Not an actual parameter, which means it can never be inout
+    typePrinter.visit(objTy, retKind, false);
   } else {
     os << "void";
   }
@@ -236,11 +253,14 @@ void DeclAndTypeClangFunctionPrinter::printCxxToCFunctionParameterUse(
       ClangValueTypePrinter(os, cPrologueOS, typeMapping, interopContext)
           .printParameterCxxToCUseScaffold(
               interopContext.getIrABIDetails().shouldPassIndirectly(type),
-              structDecl, namePrinter);
+              structDecl, namePrinter, param->isInOut());
       return;
     }
   }
   // Primitive types are passed directly without any conversions.
+  if (param->isInOut()) {
+    os << "&";
+  }
   namePrinter();
 }
 
@@ -261,10 +281,6 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
         os << ", ";
       size_t index = 1;
       interleaveComma(*params, os, [&](const ParamDecl *param) {
-        if (param->isInOut()) {
-          os << "&";
-        }
-
         if (param->hasName()) {
           printCxxToCFunctionParameterUse(param, param->getName().str());
         } else {

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -85,7 +85,8 @@ public:
     os << knownTypeInfo->name;
     if (knownTypeInfo->canBeNullable) {
       printNullability(optionalKind);
-    } else if (isInOutParam) {
+    }
+    if (isInOutParam) {
       os << (languageMode == swift::OutputLanguageMode::Cxx ? " &" : " *");
     }
     return true;

--- a/lib/PrintAsClang/PrintClangValueType.h
+++ b/lib/PrintAsClang/PrintClangValueType.h
@@ -41,13 +41,15 @@ public:
 
   /// Print the pararameter type that referes to a Swift struct type in C/C++.
   void printValueTypeParameterType(const NominalTypeDecl *type,
-                                   OutputLanguageMode outputLang);
+                                   OutputLanguageMode outputLang,
+                                   bool isInOutParam);
 
   /// Print the use of a C++ struct/enum parameter value as it's passed to the
   /// underlying C function that represents the native Swift function.
   void
   printParameterCxxToCUseScaffold(bool isIndirect, const NominalTypeDecl *type,
-                                  llvm::function_ref<void()> cxxParamPrinter);
+                                  llvm::function_ref<void()> cxxParamPrinter,
+                                  bool isInOut);
 
   /// Print the return type that refers to a Swift struct type in C/C++.
   void printValueTypeReturnType(const NominalTypeDecl *typeDecl,

--- a/test/Interop/SwiftToCxx/functions/swift-primitive-inout-functions-cxx-bridging.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-primitive-inout-functions-cxx-bridging.swift
@@ -7,6 +7,7 @@
 // CHECK: SWIFT_EXTERN void $s9Functions8inOutIntyySizF(ptrdiff_t * x) SWIFT_NOEXCEPT SWIFT_CALL; // inOutInt(_:)
 // CHECK: SWIFT_EXTERN void $s9Functions11inOutTwoIntyySiz_SiztF(ptrdiff_t * x, ptrdiff_t * y) SWIFT_NOEXCEPT SWIFT_CALL; // inOutTwoInt(_:_:)
 // CHECK: SWIFT_EXTERN void $s9Functions13inOutTwoParamyySbz_SdztF(bool * x, double * y) SWIFT_NOEXCEPT SWIFT_CALL; // inOutTwoParam(_:_:)
+// CHECK: SWIFT_EXTERN void $s9Functions24inoutTypeWithNullabilityyySVzF(void const * _Nonnull * x) SWIFT_NOEXCEPT SWIFT_CALL; // inoutTypeWithNullability(_:)
 
 // CHECK:      inline void inOutInt(swift::Int & x) noexcept {
 // CHECK-NEXT:   return _impl::$s9Functions8inOutIntyySizF(&x);
@@ -20,6 +21,11 @@
 // CHECK-NEXT:   return _impl::$s9Functions13inOutTwoParamyySbz_SdztF(&x, &y);
 // CHECK-NEXT: }
 
+// CHECK:      inline void inoutTypeWithNullability(void const * _Nonnull & x) noexcept {
+// CHECK-NEXT:   return _impl::$s9Functions24inoutTypeWithNullabilityyySVzF(&x);
+// CHECK-NEXT: }
+
+
 public func inOutInt(_ x: inout Int) { x = Int() }
 
 public func inOutTwoInt(_ x: inout Int, _ y: inout Int) {
@@ -30,4 +36,8 @@ public func inOutTwoInt(_ x: inout Int, _ y: inout Int) {
 public func inOutTwoParam(_ x: inout Bool, _ y: inout Double) {
     y = 3.14
     x = !x
+}
+
+public func inoutTypeWithNullability(_ x: inout UnsafeRawPointer) {
+    x += 1
 }

--- a/test/Interop/SwiftToCxx/functions/swift-primitive-inout-functions-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/swift-primitive-inout-functions-execution.cpp
@@ -39,4 +39,12 @@ int main() {
         assert(x);
         assert(y == 3.14);
     }
+
+    {
+        char c[2] = {'A', 'B'};
+        const void *p = &c[0];
+        assert(*static_cast<const char *>(p) == 'A');
+        inoutTypeWithNullability(p);
+        assert(*static_cast<const char *>(p) == 'B');
+    }
 }

--- a/test/Interop/SwiftToCxx/structs/large-structs-pass-return-indirect-in-cxx-execution.cpp
+++ b/test/Interop/SwiftToCxx/structs/large-structs-pass-return-indirect-in-cxx-execution.cpp
@@ -24,5 +24,13 @@ int main() {
   StructSeveralI64 structSeveralI64_copy = passThroughStructSeveralI64(100, returnNewStructSeveralI64(11), 6.0);
   printStructSeveralI64(structSeveralI64_copy);
 // CHECK-NEXT: StructSeveralI64.1 = 11, .2 = 100, .3 = -17, .4 = -12345612, .5 = -65529
+
+  auto myStruct = returnNewStructSeveralI64(99);
+  printStructSeveralI64(myStruct);
+// CHECK-NEXT: StructSeveralI64.1 = 99, .2 = 0, .3 = -17, .4 = 12345612, .5 = -65535
+
+  inoutStructSeveralI64(myStruct);
+  printStructSeveralI64(myStruct);
+// CHECK-NEXT: StructSeveralI64.1 = -1, .2 = -2, .3 = -3, .4 = -4, .5 = -5
   return 0;
 }

--- a/test/Interop/SwiftToCxx/structs/large-structs-pass-return-indirect-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/large-structs-pass-return-indirect-in-cxx.swift
@@ -5,9 +5,10 @@
 // RUN: %check-interop-cxx-header-in-clang(%t/structs.h)
 
 public struct StructSeveralI64 {
-    let x1, x2, x3, x4, x5: Int64
+    var x1, x2, x3, x4, x5: Int64
 }
 
+// CHECK: SWIFT_EXTERN void $s7Structs21inoutStructSeveralI64yyAA0cdE0VzF(void * _Nonnull s) SWIFT_NOEXCEPT SWIFT_CALL; // inoutStructSeveralI64(_:)
 // CHECK: class StructSeveralI64 final {
 
 public func returnNewStructSeveralI64(i: Int64) -> StructSeveralI64 {
@@ -21,6 +22,19 @@ public func passThroughStructSeveralI64(i: Int64, _ x: StructSeveralI64, j: Floa
 public func printStructSeveralI64(_ x: StructSeveralI64) {
     print("StructSeveralI64.1 = \(x.x1), .2 = \(x.x2), .3 = \(x.x3), .4 = \(x.x4), .5 = \(x.x5)")
 }
+
+public func inoutStructSeveralI64(_ s: inout StructSeveralI64) {
+    s.x1 = -1
+    s.x2 = -2
+    s.x3 = -3
+    s.x4 = -4
+    s.x5 = -5
+}
+
+// CHECK:      inline void inoutStructSeveralI64(StructSeveralI64& s) noexcept {
+// CHECK-NEXT:   return _impl::$s7Structs21inoutStructSeveralI64yyAA0cdE0VzF(_impl::_impl_StructSeveralI64::getOpaquePointer(s));
+// CHECK-NEXT: }
+
 
 // CHECK: inline StructSeveralI64 passThroughStructSeveralI64(int64_t i, const StructSeveralI64& x, float j) noexcept SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return _impl::_impl_StructSeveralI64::returnNewValue([&](void * _Nonnull result) {

--- a/test/Interop/SwiftToCxx/structs/small-structs-pass-return-direct-in-cxx-execution.cpp
+++ b/test/Interop/SwiftToCxx/structs/small-structs-pass-return-direct-in-cxx-execution.cpp
@@ -47,5 +47,18 @@ int main() {
   auto structDoubleAndFloat = returnNewStructDoubleAndFloat(floatValue, doubleValue);
   assert(getStructDoubleAndFloat_x(structDoubleAndFloat) == doubleValue);
   assert(getStructDoubleAndFloat_y(structDoubleAndFloat) == floatValue);
+
+  // s = StructOneI16AndOneStruct(x: 0xFF, y: StructTwoI32(x: 5, y: 72))
+  auto s = returnNewStructOneI16AndOneStruct();
+  // s2 = StructTwoI32(x: 10, y: 20)
+  auto s2 = returnNewStructTwoI32(10);
+  inoutStructOneI16AndOneStruct(s, s2);
+  printStructStructTwoI32_and_OneI16AndOneStruct(s2, s);
+// CHECK-NEXT: StructTwoI32.x = 10, y = 20
+// CHECK-NEXT: StructOneI16AndOneStruct.x = 205, y.x = 10, y.y = 20
+
+  inoutStructDoubleAndFloat(structDoubleAndFloat);
+  assert(getStructDoubleAndFloat_x(structDoubleAndFloat) == doubleValue * floatValue);
+  assert(getStructDoubleAndFloat_y(structDoubleAndFloat) == floatValue / 10);
   return 0;
 }

--- a/test/Interop/SwiftToCxx/structs/small-structs-pass-return-direct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/small-structs-pass-return-direct-in-cxx.swift
@@ -13,8 +13,8 @@ public struct StructTwoI32 {
 }
 
 public struct StructOneI16AndOneStruct {
-    let x: Int16
-    let y: StructTwoI32
+    var x: Int16
+    var y: StructTwoI32
 }
 
 public struct StructU16AndPointer {
@@ -23,9 +23,12 @@ public struct StructU16AndPointer {
 }
 
 public struct StructDoubleAndFloat {
-    let x: Double
-    let y: Float
+    var x: Double
+    var y: Float
 }
+
+// CHECK: SWIFT_EXTERN void $s7Structs25inoutStructDoubleAndFloatyyAA0cdeF0VzF(char * _Nonnull s) SWIFT_NOEXCEPT SWIFT_CALL; // inoutStructDoubleAndFloat(_:)
+// CHECK: SWIFT_EXTERN void $s7Structs020inoutStructOneI16AnddC0yyAA0cdefdC0Vz_AA0C6TwoI32VtF(char * _Nonnull s, struct swift_interop_stub_Structs_StructTwoI32 s2) SWIFT_NOEXCEPT SWIFT_CALL; // inoutStructOneI16AndOneStruct(_:_:)
 
 // CHECK: class StructDoubleAndFloat final {
 
@@ -64,6 +67,11 @@ public func printStructStructTwoI32_and_OneI16AndOneStruct(_ y: StructTwoI32, _ 
     print("StructOneI16AndOneStruct.x = \(x.x), y.x = \(x.y.x), y.y = \(x.y.y)")
 }
 
+public func inoutStructOneI16AndOneStruct(_ s: inout StructOneI16AndOneStruct, _ s2: StructTwoI32) {
+    s.x -= 50
+    s.y = s2
+}
+
 public func returnNewStructU16AndPointer(_ x: UnsafeMutableRawPointer) -> StructU16AndPointer {
     return StructU16AndPointer(x: 55, y: x)
 }
@@ -79,6 +87,11 @@ public func returnNewStructDoubleAndFloat(_ y: Float, _ x: Double) -> StructDoub
 public func getStructDoubleAndFloat_x(_ x: StructDoubleAndFloat) -> Double { return x.x }
 
 public func getStructDoubleAndFloat_y(_ x: StructDoubleAndFloat) -> Float { return x.y }
+
+public func inoutStructDoubleAndFloat(_ s: inout StructDoubleAndFloat) {
+    s.x *= Double(s.y)
+    s.y /= 10
+}
 
 // CHECK: inline double getStructDoubleAndFloat_x(const StructDoubleAndFloat& x) noexcept SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return _impl::$s7Structs25getStructDoubleAndFloat_xySdAA0cdeF0VF(_impl::swift_interop_passDirect_Structs_StructDoubleAndFloat(_impl::_impl_StructDoubleAndFloat::getOpaquePointer(x)));
@@ -97,6 +110,16 @@ public func getStructDoubleAndFloat_y(_ x: StructDoubleAndFloat) -> Float { retu
 
 // CHECK: inline void * _Nonnull getStructU16AndPointer_y(const StructU16AndPointer& x) noexcept SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return _impl::$s7Structs24getStructU16AndPointer_yySvAA0cdeF0VF(_impl::swift_interop_passDirect_Structs_StructU16AndPointer(_impl::_impl_StructU16AndPointer::getOpaquePointer(x)));
+// CHECK-NEXT: }
+
+
+// CHECK:      inline void inoutStructDoubleAndFloat(StructDoubleAndFloat& s) noexcept {
+// CHECK-NEXT:   return _impl::$s7Structs25inoutStructDoubleAndFloatyyAA0cdeF0VzF(_impl::_impl_StructDoubleAndFloat::getOpaquePointer(s));
+// CHECK-NEXT: }
+
+
+// CHECK:      inline void inoutStructOneI16AndOneStruct(StructOneI16AndOneStruct& s, const StructTwoI32& s2) noexcept {
+// CHECK-NEXT:   return _impl::$s7Structs020inoutStructOneI16AnddC0yyAA0cdefdC0Vz_AA0C6TwoI32VtF(_impl::_impl_StructOneI16AndOneStruct::getOpaquePointer(s), _impl::swift_interop_passDirect_Structs_StructTwoI32(_impl::_impl_StructTwoI32::getOpaquePointer(s2)));
 // CHECK-NEXT: }
 
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
This pull request supports passing a `struct` type into a function as an `inout` parameter.

@hyp Could you please review this pull request?

Here is an overview of changes I've made:

- When the parameter is `inout`, the Swift struct `MyStruct` will be printed as `MyStruct &` in the C++ function signature (the `const` qualifier is removed compared to a non-`inout` parameter).

- If the struct is a "small struct" (i.e., need direct pass):

  - In `inout` mode, the underlying C interface will take a `char * _Nonnull` directly instead of a C stub struct value (similar to `inout` mode for primitives).

  - In `inout` mode, the C++ function body will pass the pointer obtained from `getOpaquePointer()` directly to the underlying C interface instead of making a C stub struct first and passing that stub by value.

  - Please point out if I did something wrong here. This approach passed tests, but I am not sure if I can pass the pointer directly, or I need to make that C stub struct a local variable, pass the address of the C stub struct, and somehow copy the result back to the C++ struct.

- If the struct is a "large struct" (i.e., need indirect pass):

  - In `inout` mode, the underlying C interface will take a `void * _Nonnull` instead of `const void * _Nonnull` in non-`inout` mode.

- Add some parameters to `CFunctionSignatureTypePrinter` class, `ClangValueTypePrinter::printValueTypeParameterType` and `ClangValueTypePrinter::printParameterCxxToCUseScaffold` functions to support the new feature

- Add some tests


<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!-- Resolves SR-NNNN. -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
