### PR TITLE
[c++-interop] Providing information about enum types from inferDefaultArgument

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5744,6 +5744,10 @@ public:
     Bits.ParamDecl.defaultArgumentKind = static_cast<unsigned>(K);
   }
 
+  void setDefaultArgumentKind(ArgumentAttrs K) {
+    setDefaultArgumentKind(K.argumentKind);
+  }
+
   bool isNoImplicitCopy() const {
     return getAttrs().hasAttribute<NoImplicitCopyAttr>();
   }

--- a/include/swift/AST/DefaultArgumentKind.h
+++ b/include/swift/AST/DefaultArgumentKind.h
@@ -17,7 +17,9 @@
 #ifndef SWIFT_DEFAULTARGUMENTKIND_H
 #define SWIFT_DEFAULTARGUMENTKIND_H
 
+#include "llvm/ADT/StringRef.h"
 #include <cstdint>
+#include <string>
 
 namespace llvm {
 class StringRef;
@@ -51,6 +53,40 @@ enum class DefaultArgumentKind : uint8_t {
 #include "swift/AST/MagicIdentifierKinds.def"
 };
 enum { NumDefaultArgumentKindBits = 4 };
+
+struct ArgumentAttrs {
+  DefaultArgumentKind argumentKind;
+  bool isUnavailableInSwift = false;
+  llvm::StringRef CXXOptionsEnumName = "";
+
+  ArgumentAttrs(DefaultArgumentKind argumentKind,
+                bool isUnavailableInSwift = false,
+                llvm::StringRef CXXOptionsEnumName = "")
+      : argumentKind(argumentKind), isUnavailableInSwift(isUnavailableInSwift),
+        CXXOptionsEnumName(CXXOptionsEnumName) {}
+
+  bool operator !=(const DefaultArgumentKind &rhs) const {
+    return argumentKind != rhs;
+  }
+
+  bool operator==(const DefaultArgumentKind &rhs) const {
+    return argumentKind == rhs;
+  }
+
+  bool hasDefaultArg() const {
+    return argumentKind != DefaultArgumentKind::None;
+  }
+
+  bool hasAlternateCXXOptionsEnumName() const {
+    return !CXXOptionsEnumName.empty() && isUnavailableInSwift;
+  }
+
+  llvm::StringRef getAlternateCXXOptionsEnumName() const {
+    assert(hasAlternateCXXOptionsEnumName() &&
+           "Expected a C++ Options type for C++-Interop but found none.");
+    return CXXOptionsEnumName;
+  }
+};
 
 } // end namespace swift
 

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -869,16 +869,18 @@ static bool omitNeedlessWordsInFunctionName(
     StringRef argumentName;
     if (i < argumentNames.size())
       argumentName = argumentNames[i];
-    bool hasDefaultArg =
+    auto argumentAttrs =
         ClangImporter::Implementation::inferDefaultArgument(
             param->getType(),
             getParamOptionality(param, !nonNullArgs.empty() && nonNullArgs[i]),
             nameImporter.getIdentifier(baseName), argumentName, i == 0,
-            isLastParameter, nameImporter) != DefaultArgumentKind::None;
+            isLastParameter, nameImporter);
 
-    paramTypes.push_back(getClangTypeNameForOmission(clangCtx,
-                                                     param->getOriginalType())
-                            .withDefaultArgument(hasDefaultArg));
+    paramTypes.push_back(
+        (argumentAttrs.hasAlternateCXXOptionsEnumName()
+             ? OmissionTypeName(argumentAttrs.getAlternateCXXOptionsEnumName())
+             : getClangTypeNameForOmission(clangCtx, param->getOriginalType()))
+            .withDefaultArgument(argumentAttrs.hasDefaultArg()));
   }
 
   // Find the property names.

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -20,6 +20,7 @@
 #include "swift/ABI/MetadataValues.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/DefaultArgumentKind.h"
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/DiagnosticsClangImporter.h"
 #include "swift/AST/ExistentialLayout.h"
@@ -2410,7 +2411,7 @@ static bool isObjCMethodResultAudited(const clang::Decl *decl) {
           decl->hasAttr<clang::ObjCReturnsInnerPointerAttr>());
 }
 
-DefaultArgumentKind ClangImporter::Implementation::inferDefaultArgument(
+ArgumentAttrs ClangImporter::Implementation::inferDefaultArgument(
     clang::QualType type, OptionalTypeKind clangOptionality,
     DeclBaseName baseName, StringRef argumentLabel, bool isFirstParameter,
     bool isLastParameter, NameImporter &nameImporter) {
@@ -2455,10 +2456,29 @@ DefaultArgumentKind ClangImporter::Implementation::inferDefaultArgument(
       // If we've taken this branch it means we have an enum type, and it is
       // likely an integer or NSInteger that is being used by NS/CF_OPTIONS to
       // behave like a C enum in the presence of C++.
-      auto enumName = typedefType->getDecl()->getDeclName().getAsString();
+      auto enumName = typedefType->getDecl()->getName();
+      ArgumentAttrs argumentAttrs(DefaultArgumentKind::None, true, enumName);
       for (auto word : llvm::reverse(camel_case::getWords(enumName))) {
-        if (camel_case::sameWordIgnoreFirstCase(word, "options"))
-          return DefaultArgumentKind::EmptyArray;
+        if (camel_case::sameWordIgnoreFirstCase(word, "options")) {
+          argumentAttrs.argumentKind = DefaultArgumentKind::EmptyArray;
+          return argumentAttrs;
+        }
+        if (camel_case::sameWordIgnoreFirstCase(word, "units"))
+          return argumentAttrs;
+        if (camel_case::sameWordIgnoreFirstCase(word, "domain"))
+          return argumentAttrs;
+        if (camel_case::sameWordIgnoreFirstCase(word, "action"))
+          return argumentAttrs;
+        if (camel_case::sameWordIgnoreFirstCase(word, "controlevents"))
+          return argumentAttrs;
+        if (camel_case::sameWordIgnoreFirstCase(word, "state"))
+          return argumentAttrs;
+        if (camel_case::sameWordIgnoreFirstCase(word, "unit"))
+          return argumentAttrs;
+        if (camel_case::sameWordIgnoreFirstCase(word, "scrollposition"))
+          return argumentAttrs;
+        if (camel_case::sameWordIgnoreFirstCase(word, "edge"))
+          return argumentAttrs;
       }
     }
   }

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1397,7 +1397,7 @@ public:
 
   /// Attempt to infer a default argument for a parameter with the
   /// given Clang \c type, \c baseName, and optionality.
-  static DefaultArgumentKind
+  static ArgumentAttrs
   inferDefaultArgument(clang::QualType type, OptionalTypeKind clangOptionality,
                        DeclBaseName baseName, StringRef argumentLabel,
                        bool isFirstParameter, bool isLastParameter,

--- a/test/Interop/Cxx/enum/Inputs/c-enums-withOptions-omit.h
+++ b/test/Interop/Cxx/enum/Inputs/c-enums-withOptions-omit.h
@@ -6,3 +6,33 @@ enum : NSEnumerationOptions { NSEnumerationConcurrent, NSEnumerationReverse };
 @interface NSSet
 - (void)enumerateObjectsWithOptions:(NSEnumerationOptions)opts ;
 @end
+
+typedef int __attribute__((availability(swift, unavailable))) NSOrderedCollectionDifferenceCalculationOptions;
+enum : NSOrderedCollectionDifferenceCalculationOptions {
+  NSOrderedCollectionDifferenceCalculationOptions1,
+  NSOrderedCollectionDifferenceCalculationOptions2
+};
+
+typedef int __attribute__((availability(swift, unavailable))) NSCalendarUnit;
+enum : NSCalendarUnit { NSCalendarUnit1, NSCalendarUnit2 };
+
+typedef int __attribute__((availability(swift, unavailable))) NSSearchPathDomainMask;
+enum : NSSearchPathDomainMask { NSSearchPathDomainMask1, NSSearchPathDomainMask2 };
+
+typedef int __attribute__((availability(swift, unavailable))) NSControlCharacterAction;
+enum : NSControlCharacterAction { NSControlCharacterAction1, NSControlCharacterAction2 };
+
+typedef int __attribute__((availability(swift, unavailable))) UIControlState;
+enum : UIControlState { UIControlState1, UIControlState2 };
+
+typedef int __attribute__((availability(swift, unavailable))) UITableViewCellStateMask;
+enum : UITableViewCellStateMask { UITableViewCellStateMask1, UITableViewCellStateMask2 };
+
+@interface TestsForEnhancedOmitNeedlessWords
+- (void)differenceFromArray:(int)other withOptions:(NSOrderedCollectionDifferenceCalculationOptions)options ;
+- (unsigned)minimumRangeOfUnit:(NSCalendarUnit)unit;
+- (unsigned)URLForDirectory:(unsigned)directory inDomain:(NSSearchPathDomainMask)domain ;
+- (unsigned)layoutManager:(unsigned)layoutManager shouldUseAction:(NSControlCharacterAction)action ;
+- (void)setBackButtonBackgroundImage:(unsigned)backgroundImage forState:(UIControlState)state ;
+- (void)willTransitionToState:(UITableViewCellStateMask)state ;
+@end

--- a/test/Interop/Cxx/enum/c-enums-withOptions-omit.swift
+++ b/test/Interop/Cxx/enum/c-enums-withOptions-omit.swift
@@ -7,3 +7,53 @@ import CenumsWithOptionsOmit
 // CHECK-NEXT: class func enumerateObjects(options
 // CHECK-NEXT: func enumerateObjects(options
 // CHECK-NEXT: @available(swift, obsoleted: 3, renamed: "enumerateObjects(options:)")
+
+// CHECK: class TestsForEnhancedOmitNeedlessWords {
+
+// Tests for withOptions -> 'with options'
+// CHECK-NEXT:  class func difference(fromArray other: Int32, with options: NSOrderedCollectionDifferenceCalculationOptions = [])
+// CHECK-NEXT:  func difference(fromArray other: Int32, with options: NSOrderedCollectionDifferenceCalculationOptions = [])
+// CHECK-NEXT:  @available(swift, obsoleted: 3, renamed: "difference(fromArray:with:)")
+// CHECK-NEXT: class func differenceFromArray(_ other: Int32, withOptions options: NSOrderedCollectionDifferenceCalculationOptions = [])
+// CHECK-NEXT: @available(swift, obsoleted: 3, renamed: "difference(fromArray:with:)")
+// CHECK-NEXT: func differenceFromArray(_ other: Int32, withOptions options: NSOrderedCollectionDifferenceCalculationOptions = [])
+
+// Tests for ofUnit -> 'of unit'
+// CHECK-NEXT: class func minimumRange(of unit: NSCalendarUnit) -> UInt32
+// CHECK-NEXT: func minimumRange(of unit: NSCalendarUnit) -> UInt32
+// CHECK-NEXT: @available(swift, obsoleted: 3, renamed: "minimumRange(of:)")
+// CHECK-NEXT: class func minimumRangeOfUnit(_ unit: NSCalendarUnit) -> UInt32
+// CHECK-NEXT: @available(swift, obsoleted: 3, renamed: "minimumRange(of:)")
+// CHECK-NEXT: func minimumRangeOfUnit(_ unit: NSCalendarUnit) -> UInt32
+
+// Tests for inDomain -> 'in domain'
+// CHECK-NEXT: class func url(forDirectory directory: UInt32, in domain: NSSearchPathDomainMask) -> UInt32
+// CHECK-NEXT: func url(forDirectory directory: UInt32, in domain: NSSearchPathDomainMask) -> UInt32
+// CHECK-NEXT: @available(swift, obsoleted: 3, renamed: "url(forDirectory:in:)")
+// CHECK-NEXT: class func URLForDirectory(_ directory: UInt32, inDomain domain: NSSearchPathDomainMask) -> UInt32
+// CHECK-NEXT: @available(swift, obsoleted: 3, renamed: "url(forDirectory:in:)")
+// CHECK-NEXT: func URLForDirectory(_ directory: UInt32, inDomain domain: NSSearchPathDomainMask) -> UInt32
+
+// Tests for shouldUseAction -> 'shouldUse action'
+// CHECK-NEXT: class func layoutManager(_ layoutManager: UInt32, shouldUse action: NSControlCharacterAction) -> UInt32
+// CHECK-NEXT: func layoutManager(_ layoutManager: UInt32, shouldUse action: NSControlCharacterAction) -> UInt32
+// CHECK-NEXT: @available(swift, obsoleted: 3, renamed: "layoutManager(_:shouldUse:)")
+// CHECK-NEXT: class func layoutManager(_ layoutManager: UInt32, shouldUseAction action: NSControlCharacterAction) -> UInt32
+// CHECK-NEXT: @available(swift, obsoleted: 3, renamed: "layoutManager(_:shouldUse:)")
+// CHECK-NEXT: func layoutManager(_ layoutManager: UInt32, shouldUseAction action: NSControlCharacterAction) -> UInt32
+
+// Tests for forState -> 'for state'
+// CHECK-NEXT: class func setBackButtonBackgroundImage(_ backgroundImage: UInt32, for state: UIControlState)
+// CHECK-NEXT: func setBackButtonBackgroundImage(_ backgroundImage: UInt32, for state: UIControlState)
+// CHECK-NEXT: @available(swift, obsoleted: 3, renamed: "setBackButtonBackgroundImage(_:for:)")
+// CHECK-NEXT: class func setBackButtonBackgroundImage(_ backgroundImage: UInt32, forState state: UIControlState)
+// CHECK-NEXT: @available(swift, obsoleted: 3, renamed: "setBackButtonBackgroundImage(_:for:)")
+// CHECK-NEXT: func setBackButtonBackgroundImage(_ backgroundImage: UInt32, forState state: UIControlState)
+
+// Tests for toState -> 'to state'
+// CHECK-NEXT: class func willTransition(to state: UITableViewCellStateMask)
+// CHECK-NEXT: func willTransition(to state: UITableViewCellStateMask)
+// CHECK-NEXT: @available(swift, obsoleted: 3, renamed: "willTransition(to:)")
+// CHECK-NEXT: class func willTransitionToState(_ state: UITableViewCellStateMask)
+// CHECK-NEXT: @available(swift, obsoleted: 3, renamed: "willTransition(to:)")
+// CHECK-NEXT: func willTransitionToState(_ state: UITableViewCellStateMask)


### PR DESCRIPTION
When ClangImporter::Implementation::inferDefaultArgument processes
func/method arguments as part of omitNeedlessWordsInFunctionName it
processes information about how the typenames for the parameters related
to the parameter names to form a parameter names list. The parameter
names list is used to determine if the argument label for a function
should be clipped based on the typename. So for example a type like
NSOrderedCollectionDifferenceCalculationOptions would cause a label
ending with "Options" to get clipped so that for instance "withOptions"
becomes simply "with".

Unfortunately in the context of C++-Interop, the typename for the
parameter often resolves to what the type backing the typedef or enum is
and not the actual name of the typedef
(so `typedef NSUInteger NSOrderedCollectionDifferenceCalculationOptions`
 resolves to a name of NSUInteger rather than
 NSOrderedCollectionDifferenceCalculationOptions).

This patch seeks to collect a bit more information when processing
NS_OPTIONS typedefs and providing that to the calling
omitNeedlessWordsInFunctionName to handle more inteligently.

In practice this fixes anywhere in Foundatio where

`withOptions: NSOrderedCollectionDifferenceCalculationOptions` is used.


NOTE: This is a work in progress. Still trying to figure out how to reduce a good test case. 
