### PR TITLE
Diagnose @Sendable on actor-isolated synchronous functions. 

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4563,6 +4563,9 @@ ERROR(effectful_keypath_component,none,
 ERROR(local_function_executed_concurrently,none,
       "concurrently-executed %0 %1 must be marked as '@Sendable'",
       (DescriptiveDeclKind, DeclName))
+ERROR(sendable_isolated_sync_function,none,
+      "%0 synchronous %1 %2 cannot be marked as '@Sendable'",
+      (ActorIsolation, DescriptiveDeclKind, DeclName))
 ERROR(concurrent_access_of_local_capture,none,
       "%select{mutation of|reference to}0 captured %1 %2 in "
       "concurrently-executing code",

--- a/test/Concurrency/Backdeploy/mangling.swift
+++ b/test/Concurrency/Backdeploy/mangling.swift
@@ -12,10 +12,10 @@
 // RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 %s -o %t/test_mangling -Xfrontend -disable-availability-checking
 // RUN: %target-run %t/test_mangling
 
-// REQUIRESx: CPU=x86_64
 // REQUIRES: OS=macosx
 // REQUIRES: executable_test
 // REQUIRES: concurrency_runtime
+// UNSUPPORTED: back_deployment_runtime
 
 actor MyActor { }
 

--- a/test/Concurrency/Backdeploy/objc_actor.swift
+++ b/test/Concurrency/Backdeploy/objc_actor.swift
@@ -5,6 +5,7 @@
 // REQUIRES: OS=macosx
 // REQUIRES: executable_test
 // REQUIRES: concurrency_runtime
+// UNSUPPORTED: back_deployment_runtime
 
 import Foundation
 

--- a/test/Concurrency/sendable_functions.swift
+++ b/test/Concurrency/sendable_functions.swift
@@ -1,0 +1,23 @@
+// RUN: %target-typecheck-verify-swift
+// REQUIRES: concurrency
+
+
+@Sendable func globalFunc() { }
+
+actor A {
+  var state: Bool = false
+  
+  @Sendable func f() { // expected-warning{{actor-isolated synchronous instance method 'f()' cannot be marked as '@Sendable'}}
+    state = true
+  }
+
+  @Sendable nonisolated func g() { }
+
+  @Sendable func fAsync() async {
+    state = true
+  }
+}
+
+@MainActor @Sendable func globalActorFunc() { } // expected-warning{{main actor-isolated synchronous global function 'globalActorFunc()' cannot be marked as '@Sendable'}}
+
+@MainActor @Sendable func globalActorFuncAsync() async { }

--- a/test/Concurrency/sendable_functions.swift
+++ b/test/Concurrency/sendable_functions.swift
@@ -4,6 +4,7 @@
 
 @Sendable func globalFunc() { }
 
+@available(SwiftStdlib 5.1, *)
 actor A {
   var state: Bool = false
   
@@ -18,6 +19,8 @@ actor A {
   }
 }
 
+@available(SwiftStdlib 5.1, *)
 @MainActor @Sendable func globalActorFunc() { } // expected-warning{{main actor-isolated synchronous global function 'globalActorFunc()' cannot be marked as '@Sendable'}}
 
+@available(SwiftStdlib 5.1, *)
 @MainActor @Sendable func globalActorFuncAsync() async { }


### PR DESCRIPTION
There is no way for these functions to be Sendable, so diagnose attempts
to make them so. This closes a hole in Sendable checking.

Fixes rdar://94623729.