### PR TITLE
Add #if os(Darwin) shorthand for checking for Darwin platforms

### DIFF
--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -202,10 +202,7 @@ checkPlatformCondition(PlatformConditionKind Kind, StringRef Value) const {
 
   if (Kind == PlatformConditionKind::OS && Value == "Darwin") {
     // "Darwin" is an alias for all Darwin platforms.
-    return checkPlatformCondition(Kind, "OSX") ||
-           checkPlatformCondition(Kind, "iOS") ||
-           checkPlatformCondition(Kind, "tvOS") ||
-           checkPlatformCondition(Kind, "watchOS");
+    return Target.isOSDarwin();
   }
 
   // When compiling for iOS we consider "macCatalyst" to be a

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -54,6 +54,7 @@ static const SupportedConditionalValue SupportedConditionalCompilationOSs[] = {
   "Cygwin",
   "Haiku",
   "WASI",
+  "Darwin", // All inclusive for all Darwin platforms.
 };
 
 static const SupportedConditionalValue SupportedConditionalCompilationArches[] = {
@@ -264,6 +265,13 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
   // Set the "os" platform condition.
   switch (Target.getOS()) {
   case llvm::Triple::Darwin:
+    addPlatformConditionValue(PlatformConditionKind::OS, "Darwin");
+    if (
+      Target.getOS() != llvm::Triple::MacOSX || 
+      Target.getOS() != llvm::Triple::TvOS ||
+      Target.getOS() != llvm::Triple::WatchOS ||
+      Target.getOS() != llvm::Triple::IOS ||
+      ) break;
   case llvm::Triple::MacOSX:
     addPlatformConditionValue(PlatformConditionKind::OS, "OSX");
     break;

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -270,7 +270,7 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
       Target.getOS() != llvm::Triple::MacOSX || 
       Target.getOS() != llvm::Triple::TvOS ||
       Target.getOS() != llvm::Triple::WatchOS ||
-      Target.getOS() != llvm::Triple::IOS ||
+      Target.getOS() != llvm::Triple::IOS
       ) break;
   case llvm::Triple::MacOSX:
     addPlatformConditionValue(PlatformConditionKind::OS, "OSX");

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -200,6 +200,14 @@ checkPlatformCondition(PlatformConditionKind Kind, StringRef Value) const {
   if (Kind == PlatformConditionKind::OS && Value == "macOS")
     return checkPlatformCondition(Kind, "OSX");
 
+  if (Kind == PlatformConditionKind::OS && Value == "Darwin") {
+    // "Darwin" is an alias for all Darwin platforms.
+    return checkPlatformCondition(Kind, "macOS") ||
+           checkPlatformCondition(Kind, "iOS") ||
+           checkPlatformCondition(Kind, "tvOS") ||
+           checkPlatformCondition(Kind, "watchOS");
+  }
+
   // When compiling for iOS we consider "macCatalyst" to be a
   // synonym of "macabi". This enables the use of
   // #if targetEnvironment(macCatalyst) as a compilation
@@ -266,12 +274,7 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
   switch (Target.getOS()) {
   case llvm::Triple::Darwin:
     addPlatformConditionValue(PlatformConditionKind::OS, "Darwin");
-    if (
-      Target.getOS() != llvm::Triple::MacOSX || 
-      Target.getOS() != llvm::Triple::TvOS ||
-      Target.getOS() != llvm::Triple::WatchOS ||
-      Target.getOS() != llvm::Triple::IOS
-      ) break;
+    break;
   case llvm::Triple::MacOSX:
     addPlatformConditionValue(PlatformConditionKind::OS, "OSX");
     break;

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -202,7 +202,7 @@ checkPlatformCondition(PlatformConditionKind Kind, StringRef Value) const {
 
   if (Kind == PlatformConditionKind::OS && Value == "Darwin") {
     // "Darwin" is an alias for all Darwin platforms.
-    return checkPlatformCondition(Kind, "macOS") ||
+    return checkPlatformCondition(Kind, "OSX") ||
            checkPlatformCondition(Kind, "iOS") ||
            checkPlatformCondition(Kind, "tvOS") ||
            checkPlatformCondition(Kind, "watchOS");
@@ -273,8 +273,6 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
   // Set the "os" platform condition.
   switch (Target.getOS()) {
   case llvm::Triple::Darwin:
-    addPlatformConditionValue(PlatformConditionKind::OS, "Darwin");
-    break;
   case llvm::Triple::MacOSX:
     addPlatformConditionValue(PlatformConditionKind::OS, "OSX");
     break;

--- a/test/Parse/ConditionalCompilation/if_darwin.swift
+++ b/test/Parse/ConditionalCompilation/if_darwin.swift
@@ -1,0 +1,14 @@
+// RUN: %swift -target arm64-apple-ios8.0 -disable-legacy-type-info -parse-stdlib -enable-objc-interop -disable-objc-attr-requires-foundation-module -I %S/Inputs/usr/include -emit-ir %s -o - | %FileCheck %s -check-prefix CHECK-MACHO
+
+// REQUIRES: OS=ios
+
+#if os(Darwin)
+func xDarwinFunc() {
+
+}
+#else
+func someOtherPlatformFunc() {}
+#endif
+
+xDarwinFunc()
+someOtherPlatformFunc() // expected-error {{cannot find 'someOtherPlatformFunc' in scope}}

--- a/test/Parse/ConditionalCompilation/if_darwin.swift
+++ b/test/Parse/ConditionalCompilation/if_darwin.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -target arm64-apple-ios8.0
+// RUN: %swift -typecheck %s -verify -target arm64-apple-ios8.0
 
 // REQUIRES: OS=ios
 

--- a/test/Parse/ConditionalCompilation/if_darwin.swift
+++ b/test/Parse/ConditionalCompilation/if_darwin.swift
@@ -1,6 +1,7 @@
-// RUN: %swift -typecheck %s -verify -target arm64-apple-ios8.0
-
-// REQUIRES: OS=ios
+// RUN: %swift -typecheck %s -verify -target arm64-apple-ios8.0 -parse-stdlib
+// RUN: %swift -typecheck %s -verify -target arm64-apple-tvos9 -parse-stdlib
+// RUN: %swift -typecheck %s -verify -target i386-apple-watchos4.0 -parse-stdlib
+// RUN: %swift -typecheck %s -verify -target x86_64-apple-macos11.0 -parse-stdlib
 
 #if os(Darwin)
 func xDarwinFunc() {}
@@ -8,5 +9,13 @@ func xDarwinFunc() {}
 func someOtherPlatformFunc() {}
 #endif
 
+#if !os(Darwin) 
+let someNum = 3
+#endif
+
 xDarwinFunc()
 someOtherPlatformFunc() // expected-error {{cannot find 'someOtherPlatformFunc' in scope}}
+
+func anotherFunc() -> Int {
+    return someNum // expected-error {{cannot find 'someNum' in scope}}
+}

--- a/test/Parse/ConditionalCompilation/if_darwin.swift
+++ b/test/Parse/ConditionalCompilation/if_darwin.swift
@@ -10,12 +10,18 @@ func someOtherPlatformFunc() {}
 #endif
 
 #if !os(Darwin) 
-let someNum = 3
+struct SomeNonDarwinType {}
 #endif
 
+#if os(Darwin)
 xDarwinFunc()
 someOtherPlatformFunc() // expected-error {{cannot find 'someOtherPlatformFunc' in scope}}
+#endif
 
-func anotherFunc() -> Int {
-    return someNum // expected-error {{cannot find 'someNum' in scope}}
+#if os(Darwin)
+let x = SomeNonDarwinType() // expected-error {{cannot find 'SomeNonDarwinType' in scope}}
+#else
+func NonDarwinTypeReturningFunc() -> SomeNonDarwinType {
+    return SomeNonDarwinType()
 }
+#endif

--- a/test/Parse/ConditionalCompilation/if_darwin.swift
+++ b/test/Parse/ConditionalCompilation/if_darwin.swift
@@ -1,11 +1,9 @@
-// RUN: %swift -target arm64-apple-ios8.0 -disable-legacy-type-info -parse-stdlib -enable-objc-interop -disable-objc-attr-requires-foundation-module -I %S/Inputs/usr/include -emit-ir %s -o - | %FileCheck %s -check-prefix CHECK-MACHO
+// RUN: %target-typecheck-verify-swift -target arm64-apple-ios8.0
 
 // REQUIRES: OS=ios
 
 #if os(Darwin)
-func xDarwinFunc() {
-
-}
+func xDarwinFunc() {}
 #else
 func someOtherPlatformFunc() {}
 #endif


### PR DESCRIPTION
This PR adds support for `Darwin` as a platform that can be used in a `#if os` statement, so the following code:
```swift
#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
import Darwin
#endif
```

You could instead do: 
```swift
#if os(Darwin)
import Darwin
#endif
```