### PR TITLE
[ConstraintSystem] Allow injecting `callAsFunction` after defaulted arguments

### DIFF
--- a/test/Constraints/callAsFunction.swift
+++ b/test/Constraints/callAsFunction.swift
@@ -8,7 +8,13 @@
 protocol View {}
 struct EmptyView: View {}
 
+enum Align {
+case top, center, bottom
+}
+
 struct MyLayout {
+  init(alignment: Align? = .center, spacing: Double? = 0.0) {}
+
   func callAsFunction<V: View>(content: () -> V) -> MyLayout { .init() }
   func callAsFunction<V: View>(answer: () -> Int,
                                content: () -> V) -> MyLayout { .init() }
@@ -16,13 +22,40 @@ struct MyLayout {
 
 struct Test {
   var body1: MyLayout {
-    MyLayout() {
+    MyLayout(spacing: 1.0) {
       EmptyView() // Ok
     }
   }
 
   var body2: MyLayout {
     MyLayout() {
+      42
+    } content: {
+      EmptyView() // Ok
+    }
+  }
+
+  var body3: MyLayout {
+    MyLayout(alignment: .top) {
+      let x = 42
+      return x
+    } content: {
+      EmptyView() // Ok
+    }
+  }
+
+  var body4: MyLayout {
+    MyLayout(spacing: 1.0) {
+      let x = 42
+      return x
+    } content: {
+      _ = 42
+      return EmptyView() // Ok
+    }
+  }
+
+  var body5: MyLayout {
+    MyLayout(alignment: .bottom, spacing: 1.0) {
       42
     } content: {
       EmptyView() // Ok
@@ -50,4 +83,15 @@ func test_no_filtering_of_overloads() {
       print("Hello")
     }
   }
+}
+
+func test_default_arguments_do_not_interfere() {
+  struct S {
+    init(a: Int? = 42, b: String = "") {}
+    func callAsFunction(_: () -> Void) -> S { S() }
+  }
+
+  _ = S { _ = 42 }
+  _ = S(a: 42) { _ = 42 }
+  _ = S(b: "") { _ = 42 }
 }

--- a/test/Constraints/callAsFunction.swift
+++ b/test/Constraints/callAsFunction.swift
@@ -16,8 +16,10 @@ struct MyLayout {
   init(alignment: Align? = .center, spacing: Double? = 0.0) {}
 
   func callAsFunction<V: View>(content: () -> V) -> MyLayout { .init() }
+  // expected-note@-1 {{where 'V' = 'Int'}}
   func callAsFunction<V: View>(answer: () -> Int,
                                content: () -> V) -> MyLayout { .init() }
+  // expected-note@-2 {{where 'V' = 'Int'}}
 }
 
 struct Test {
@@ -59,6 +61,31 @@ struct Test {
       42
     } content: {
       EmptyView() // Ok
+    }
+  }
+
+  var body6: MyLayout {
+    MyLayout(spacing: 1.0) {
+      _ = EmptyView()
+      return 42
+    } // expected-error {{instance method 'callAsFunction(content:)' requires that 'Int' conform to 'View'}}
+  }
+
+  var body7: MyLayout {
+    MyLayout(alignment: .center) {
+      42
+    } content: {
+      _ = EmptyView()
+      return 42
+    } // expected-error {{instance method 'callAsFunction(answer:content:)' requires that 'Int' conform to 'View'}}
+  }
+
+  var body8: MyLayout {
+    MyLayout {
+      let x = ""
+      return x // expected-error {{cannot convert return expression of type 'String' to return type 'Int'}}
+    } content: {
+      EmptyView()
     }
   }
 }


### PR DESCRIPTION
- Adjust argument matching to be less aggressive while matching misplaced trailing closures
   against defaulted parameters that do not accept trailing closures.

   For example:

   ```swift
   func test(a: Int? = 42, b: String? = nil) {}

   test {
     ...
   }
   ```

  Trailing closure in this case should be marked as "extraneous" instead of matched
   against parameter `a:`.

- If trailing closure is extraneous in a call to `.init` on callable type, let's not attempt to
   to fix it and allow solver to inject `.callAsFunction` first.

Resolves: rdar://problem/94959816

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
