### PR TITLE
[test] Fix tests who aren't using %target-cpu

### DIFF
--- a/test/Concurrency/Backdeploy/weak_linking.swift
+++ b/test/Concurrency/Backdeploy/weak_linking.swift
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -target x86_64-apple-macosx12.0 -module-name main -emit-ir -o %t/new.ir
+// RUN: %target-swift-frontend %s -target %target-cpu-apple-macosx12.0 -module-name main -emit-ir -o %t/new.ir
 // RUN: %FileCheck %s --check-prefix=NEW < %t/new.ir
-// RUN: %target-swift-frontend %s -target x86_64-apple-macosx10.15 -module-name main -emit-ir -o %t/old.ir -disable-availability-checking
+// RUN: %target-swift-frontend %s -target %target-cpu-apple-macosx10.15 -module-name main -emit-ir -o %t/old.ir -disable-availability-checking
 // RUN: %FileCheck %s --check-prefix=OLD < %t/old.ir
-// RUN: %target-swift-frontend %s -target x86_64-apple-macosx10.15 -O -module-name main -emit-ir -o %t/optimized.ir -disable-availability-checking
+// RUN: %target-swift-frontend %s -target %target-cpu-apple-macosx10.15 -O -module-name main -emit-ir -o %t/optimized.ir -disable-availability-checking
 // RUN: %FileCheck %s --check-prefix=OPTIMIZED < %t/optimized.ir
 
 

--- a/test/IRGen/swift_async_extended_frame_info.swift
+++ b/test/IRGen/swift_async_extended_frame_info.swift
@@ -8,6 +8,7 @@
 // RUN: %target-swift-frontend -disable-availability-checking -swift-async-frame-pointer=always -target x86_64-apple-macosx12 %s -S | %FileCheck  -check-prefix=ALWAYS %s
 
 // REQUIRES: OS=macosx
+// REQUIRES: CPU=x86_64
 
 public func someAsyncFunction() async {
 }

--- a/test/ScanDependencies/batch_module_scan_versioned.swift
+++ b/test/ScanDependencies/batch_module_scan_versioned.swift
@@ -5,16 +5,16 @@
 
 // RUN: echo "[{" > %/t/inputs/input.json
 // RUN: echo "\"clangModuleName\": \"G\"," >> %/t/inputs/input.json
-// RUN: echo "\"arguments\": \"-Xcc -target -Xcc x86_64-apple-macosx11.0\"," >> %/t/inputs/input.json
+// RUN: echo "\"arguments\": \"-Xcc -target -Xcc %target-cpu-apple-macosx11.0\"," >> %/t/inputs/input.json
 // RUN: echo "\"output\": \"%/t/outputs/G_110.pcm.json\"" >> %/t/inputs/input.json
 // RUN: echo "}," >> %/t/inputs/input.json
 // RUN: echo "{" >> %/t/inputs/input.json
 // RUN: echo "\"clangModuleName\": \"G\"," >> %/t/inputs/input.json
-// RUN: echo "\"arguments\": \"-Xcc -target -Xcc x86_64-apple-macosx10.9\"," >> %/t/inputs/input.json
+// RUN: echo "\"arguments\": \"-Xcc -target -Xcc %target-cpu-apple-macosx10.9\"," >> %/t/inputs/input.json
 // RUN: echo "\"output\": \"%/t/outputs/G_109.pcm.json\"" >> %/t/inputs/input.json
 // RUN: echo "}]" >> %/t/inputs/input.json
 
-// RUN: %target-swift-frontend -scan-dependencies -disable-implicit-concurrency-module-import -target x86_64-apple-macosx11.0 -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 -batch-scan-input-file %/t/inputs/input.json
+// RUN: %target-swift-frontend -scan-dependencies -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -target %target-cpu-apple-macosx11.0 -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 -batch-scan-input-file %/t/inputs/input.json
 
 // Check the contents of the JSON output
 // RUN: %FileCheck %s -check-prefix=CHECK-PCM109 < %t/outputs/G_109.pcm.json

--- a/validation-test/Sema/rdar84879566.swift
+++ b/validation-test/Sema/rdar84879566.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck -target x86_64-apple-macosx10.15 -swift-version 5 %S/Inputs/rdar84879566_invalid_decls.swift -primary-file %s -verify
+// RUN: %target-swift-frontend -typecheck -target %target-cpu-apple-macosx10.15 -swift-version 5 %S/Inputs/rdar84879566_invalid_decls.swift -primary-file %s -verify
 // REQUIRES: OS=macosx
 
 protocol Tupled {


### PR DESCRIPTION
These tests were failing to find `_StringProcessing` for x86_64 on an arm64 bot who was explicitly not building x86_64 modules (how these weren't failing for things like the stdlib or other modules amazes me). Most of the changes are just using `%target-cpu` in the test files, but the IRGen test seems to explicitly want x86_64, so add a require.

Resolves: rdar://95121796