### PR TITLE
[5.7][Diagnostics] Diagnose conflicting pattern variables

### DIFF
--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -390,6 +390,10 @@ enum class FixKind : uint8_t {
   /// Coerce a result type of a call to a particular existential type
   /// by adding `as any <#Type#>`.
   AddExplicitExistentialCoercion,
+
+  /// For example `.a(let x), .b(let x)` where `x` gets bound to different
+  /// types.
+  RenameConflictingPatternVariables,
 };
 
 class ConstraintFix {
@@ -2958,6 +2962,50 @@ public:
   static AddExplicitExistentialCoercion *create(ConstraintSystem &cs,
                                                 Type resultTy,
                                                 ConstraintLocator *locator);
+};
+
+class RenameConflictingPatternVariables final
+    : public ConstraintFix,
+      private llvm::TrailingObjects<RenameConflictingPatternVariables,
+                                    VarDecl *> {
+  friend TrailingObjects;
+
+  Type ExpectedType;
+  unsigned NumConflicts;
+
+  RenameConflictingPatternVariables(ConstraintSystem &cs, Type expectedTy,
+                                    ArrayRef<VarDecl *> conflicts,
+                                    ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::RenameConflictingPatternVariables, locator),
+        ExpectedType(expectedTy), NumConflicts(conflicts.size()) {
+    std::uninitialized_copy(conflicts.begin(), conflicts.end(),
+                            getConflictingBuffer().begin());
+  }
+
+  MutableArrayRef<VarDecl *> getConflictingBuffer() {
+    return {getTrailingObjects<VarDecl *>(), NumConflicts};
+  }
+
+public:
+  std::string getName() const override { return "rename pattern variables"; }
+
+  ArrayRef<VarDecl *> getConflictingVars() const {
+    return {getTrailingObjects<VarDecl *>(), NumConflicts};
+  }
+
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
+    return diagnose(*commonFixes.front().first);
+  }
+
+  static RenameConflictingPatternVariables *
+  create(ConstraintSystem &cs, Type expectedTy, ArrayRef<VarDecl *> conflicts,
+         ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::RenameConflictingPatternVariables;
+  }
 };
 
 } // end namespace constraints

--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -338,6 +338,8 @@ public:
         hadError = true;
         return;
       }
+
+      caseItem->setPattern(pattern, /*resolved=*/true);
     }
 
     // Let's generate constraints for pattern + where clause.
@@ -780,8 +782,6 @@ private:
       }
     }
 
-    bindSwitchCasePatternVars(context.getAsDeclContext(), caseStmt);
-
     auto *caseLoc = cs.getConstraintLocator(
         locator, LocatorPathElt::SyntacticElement(caseStmt));
 
@@ -805,10 +805,8 @@ private:
             locator->castLastElementTo<LocatorPathElt::SyntacticElement>()
                 .asStmt());
 
-        for (auto caseBodyVar : caseStmt->getCaseBodyVariablesOrEmptyArray()) {
-          auto parentVar = caseBodyVar->getParentVarDecl();
-          assert(parentVar && "Case body variables always have parents");
-          cs.setType(caseBodyVar, cs.getType(parentVar));
+        if (recordInferredSwitchCasePatternVars(caseStmt)) {
+          hadError = true;
         }
       }
 
@@ -934,6 +932,75 @@ private:
     auto parentElt =
         locator->getLastElementAs<LocatorPathElt::SyntacticElement>();
     return parentElt ? parentElt->getElement().isStmt(kind) : false;
+  }
+
+  bool recordInferredSwitchCasePatternVars(CaseStmt *caseStmt) {
+    llvm::SmallDenseMap<Identifier, SmallVector<VarDecl *, 2>, 4> patternVars;
+
+    auto recordVar = [&](VarDecl *var) {
+      if (!var->hasName())
+        return;
+      patternVars[var->getName()].push_back(var);
+    };
+
+    for (auto &caseItem : caseStmt->getMutableCaseLabelItems()) {
+      assert(caseItem.isPatternResolved());
+
+      auto *pattern = caseItem.getPattern();
+      pattern->forEachVariable([&](VarDecl *var) { recordVar(var); });
+    }
+
+    for (auto bodyVar : caseStmt->getCaseBodyVariablesOrEmptyArray()) {
+      if (!bodyVar->hasName())
+        continue;
+
+      const auto &variants = patternVars[bodyVar->getName()];
+
+      auto getType = [&](VarDecl *var) {
+        auto type = cs.simplifyType(cs.getType(var));
+        assert(!type->hasTypeVariable());
+        return type;
+      };
+
+      switch (variants.size()) {
+      case 0:
+        break;
+
+      case 1:
+        // If there is only one choice here, let's use it directly.
+        cs.setType(bodyVar, getType(variants.front()));
+        break;
+
+      default: {
+        // If there are multiple choices it could only mean multiple
+        // patterns e.g. `.a(let x), .b(let x), ...:`. Let's join them.
+        Type joinType = getType(variants.front());
+
+        SmallVector<VarDecl *, 2> conflicts;
+        for (auto *var : llvm::drop_begin(variants)) {
+          auto varType = getType(var);
+          // Type mismatch between different patterns.
+          if (!joinType->isEqual(varType))
+            conflicts.push_back(var);
+        }
+
+        if (!conflicts.empty()) {
+          if (!cs.shouldAttemptFixes())
+            return true;
+
+          // dfdf
+          auto *locator = cs.getConstraintLocator(bodyVar);
+          if (cs.recordFix(RenameConflictingPatternVariables::create(
+                  cs, joinType, conflicts, locator)))
+            return true;
+        }
+
+        cs.setType(bodyVar, joinType);
+      }
+      }
+    }
+
+    return false;
   }
 };
 }
@@ -1341,6 +1408,8 @@ private:
         hadError = true;
       }
     }
+
+    bindSwitchCasePatternVars(context.getAsDeclContext(), caseStmt);
 
     for (auto *expected : caseStmt->getCaseBodyVariablesOrEmptyArray()) {
       assert(expected->hasName());

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -8173,3 +8173,12 @@ void MissingExplicitExistentialCoercion::fixIt(
                               "as " + ErasedResultType->getString(printOpts) +
                                   (requiresParens ? ")" : ""));
 }
+
+bool ConflictingPatternVariables::diagnoseAsError() {
+  for (auto *var : Vars) {
+    emitDiagnosticAt(var->getStartLoc(),
+                     diag::type_mismatch_multiple_pattern_list, getType(var),
+                     ExpectedType);
+  }
+  return true;
+}

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2740,6 +2740,41 @@ private:
   bool fixItRequiresParens() const;
 };
 
+/// Diagnose situations where pattern variables with the same name
+/// have conflicting types:
+///
+/// \code
+/// enum E {
+/// case a(Int)
+/// case b(String)
+/// }
+///
+/// func test(e: E) {
+///   switch e {
+///    case .a(let x), .b(let x): ...
+///   }
+/// }
+/// \endcode
+///
+/// In this example `x` is bound to `Int` and `String` at the same
+/// time which is incorrect.
+class ConflictingPatternVariables final : public FailureDiagnostic {
+  Type ExpectedType;
+  SmallVector<VarDecl *, 4> Vars;
+
+public:
+  ConflictingPatternVariables(const Solution &solution, Type expectedTy,
+                              ArrayRef<VarDecl *> conflicts,
+                              ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator),
+        ExpectedType(resolveType(expectedTy)),
+        Vars(conflicts.begin(), conflicts.end()) {
+    assert(!Vars.empty());
+  }
+
+  bool diagnoseAsError() override;
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2378,3 +2378,21 @@ AddExplicitExistentialCoercion::create(ConstraintSystem &cs, Type resultTy,
   return new (cs.getAllocator())
       AddExplicitExistentialCoercion(cs, resultTy, locator);
 }
+
+bool RenameConflictingPatternVariables::diagnose(const Solution &solution,
+                                                 bool asNote) const {
+  ConflictingPatternVariables failure(solution, ExpectedType,
+                                      getConflictingVars(), getLocator());
+  return failure.diagnose(asNote);
+}
+
+RenameConflictingPatternVariables *
+RenameConflictingPatternVariables::create(ConstraintSystem &cs, Type expectedTy,
+                                          ArrayRef<VarDecl *> conflicts,
+                                          ConstraintLocator *locator) {
+  unsigned size = totalSizeToAlloc<VarDecl *>(conflicts.size());
+  void *mem = cs.getAllocator().Allocate(
+      size, alignof(RenameConflictingPatternVariables));
+  return new (mem)
+      RenameConflictingPatternVariables(cs, expectedTy, conflicts, locator);
+}

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -12895,7 +12895,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::SpecifyTypeForPlaceholder:
   case FixKind::AllowAutoClosurePointerConversion:
   case FixKind::IgnoreKeyPathContextualMismatch:
-  case FixKind::NotCompileTimeConst: {
+  case FixKind::NotCompileTimeConst:
+  case FixKind::RenameConflictingPatternVariables: {
     return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
   }
 

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -483,3 +483,35 @@ func test_missing_conformance_diagnostics_in_for_sequence() {
     }
   }
 }
+
+func test_conflicting_pattern_vars() {
+  enum E {
+  case a(Int, String)
+  case b(String, Int)
+  }
+
+  func fn(_: (E) -> Void) {}
+  func fn<T>(_: (E) -> T) {}
+
+  func test(e: E) {
+    fn {
+      switch $0 {
+      case .a(let x, let y),
+           .b(let x, let y):
+        // expected-error@-1 {{pattern variable bound to type 'String', expected type 'Int'}}
+        // expected-error@-2 {{pattern variable bound to type 'Int', expected type 'String'}}
+        _ = x
+        _ = y
+      }
+    }
+
+    fn {
+      switch $0 {
+      case .a(let x, let y),
+           .b(let y, let x): // Ok
+        _ = x
+        _ = y
+      }
+    }
+  }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/59210

---

Diagnose situations where pattern variables with the same name
have conflicting types:

```swift
enum E {
case a(Int)
case b(String)
}

func fn(_: () -> Void) {}

func test(e: E) {
  fn {
    switch e {
    case .a(let x), .b(let x): ...
    }
  }
}
```

In this example `x` is bound to `Int` and `String` at the same
time which is incorrect.

(cherry picked from commit f15a0b16cb83fde2cfc3b437dc5cff6e8f7963c3)
(cherry picked from commit 62ba74950c4669bc0a63178acb10cce2700761b2)
(cherry picked from commit 9c8bebe4f8f93ea4f56f7f018070e216f67c027b)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
