### PR TITLE
[next] Add Default argument for hasFlag

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -607,7 +607,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   // Determine whether string processing is enabled
   Opts.EnableExperimentalStringProcessing =
     Args.hasFlag(OPT_enable_experimental_string_processing,
-                 OPT_disable_experimental_string_processing);
+                 OPT_disable_experimental_string_processing, /*Default=*/true);
 
   // Add a future feature if it is not already implied by the language version.
   auto addFutureFeatureIfNotImplied = [&](Feature feature) {


### PR DESCRIPTION
llvm/llvm-project removed the default for the `Default` argument in
522712e2d241ea33575a9c7a60ad582634f04f0d. Specify it directly in the
call to `hasFlag`.