### PR TITLE
[cxx-interop] Re-enable C++ stdlib overlay on Linux

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -902,7 +902,14 @@ getClangInvocationFileMapping(ASTContext &ctx) {
       new clang::DiagnosticOptions());
   clang::driver::Driver clangDriver(ctx.ClangImporterOpts.clangPath,
                                     triple.str(), *clangDiags);
-  llvm::opt::InputArgList clangDriverArgs;
+  // Flags passed to Swift with `-Xcc` might affect include paths.
+  unsigned unused1, unused2;
+  std::vector<const char *> clangArgs;
+  for (const auto &each : ctx.ClangImporterOpts.ExtraArgs) {
+    clangArgs.push_back(each.c_str());
+  }
+  llvm::opt::InputArgList clangDriverArgs =
+      clangDriver.getOpts().ParseArgs(clangArgs, unused1, unused2);
   // If an SDK path was explicitly passed to Swift, make sure to pass it to
   // Clang driver as well. It affects the resulting include paths.
   auto sdkPath = ctx.SearchPathOpts.getSDKPath();

--- a/stdlib/public/Cxx/CMakeLists.txt
+++ b/stdlib/public/Cxx/CMakeLists.txt
@@ -135,11 +135,21 @@ add_swift_target_library(swiftstd ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_OVE
     SWIFT_MODULE_DEPENDS_IOS Darwin
     SWIFT_MODULE_DEPENDS_TVOS Darwin
     SWIFT_MODULE_DEPENDS_WATCHOS Darwin
+    SWIFT_MODULE_DEPENDS_LINUX Glibc
 
     SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
     -Xfrontend -enable-experimental-cxx-interop
     -Xfrontend -module-interface-preserve-types-as-written
 
-    LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}" -lc++
-    TARGET_SDKS ALL_APPLE_PLATFORMS # TODO: support other platforms as well
-    INSTALL_IN_COMPONENT sdk-overlay)
+    SWIFT_COMPILE_FLAGS_LINUX
+    # GCC on Linux is usually located under `/usr`.
+    # However, Ubuntu 20.04 ships with another GCC installation under `/`, which does not include libstdc++.
+    # Swift build scripts pass `--sysroot=/` to Clang. By default, Clang tries to find GCC installation under sysroot,
+    # and if it doesn't exist, under `{sysroot}/usr`. On Ubuntu 20.04 and newer, it attempts to use the GCC without the
+    # C++ stdlib, which causes a build failure. To fix that, we tell Clang explicitly to use GCC from `/usr`.
+    -Xcc --gcc-toolchain=/usr
+
+    LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
+    TARGET_SDKS ALL_APPLE_PLATFORMS LINUX
+    INSTALL_IN_COMPONENT sdk-overlay
+    DEPENDS libstdcxx-modulemap)

--- a/test/Interop/Cxx/stdlib/overlay/string.swift
+++ b/test/Interop/Cxx/stdlib/overlay/string.swift
@@ -1,7 +1,7 @@
 // RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
-// REQUIRES: OS=macosx
+// REQUIRES: OS=macosx || OS=linux-gnu
 
 import StdlibUnittest
 import std


### PR DESCRIPTION
It was previously reverted because it didn't work on CentOS 7. Now it works.