### PR TITLE
[interop][SwiftToCxx] emit instance property getters for structs

### DIFF
--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -662,8 +662,9 @@ void swift::printModuleContentsAsCxx(
   std::string modulePrologueBuf;
   llvm::raw_string_ostream prologueOS{modulePrologueBuf};
 
+  // FIXME: Use getRequiredAccess once @expose is supported.
   ModuleWriter writer(moduleOS, prologueOS, imports, M, interopContext,
-                      getRequiredAccess(M), OutputLanguageMode::Cxx);
+                      AccessLevel::Public, OutputLanguageMode::Cxx);
   writer.write();
 
   os << "#ifndef SWIFT_PRINTED_CORE\n";

--- a/lib/PrintAsClang/PrintAsClang.cpp
+++ b/lib/PrintAsClang/PrintAsClang.cpp
@@ -317,6 +317,7 @@ static void writePrologue(raw_ostream &out, ASTContext &ctx,
   };
   emitMacro("SWIFT_CALL", "__attribute__((swiftcall))");
   emitMacro("SWIFT_INDIRECT_RESULT", "__attribute__((swift_indirect_result))");
+  emitMacro("SWIFT_CONTEXT", "__attribute__((swift_context))");
   // SWIFT_NOEXCEPT applies 'noexcept' in C++ mode only.
   emitCxxConditional(
       out, [&] { emitMacro("SWIFT_NOEXCEPT", "noexcept"); },

--- a/lib/PrintAsClang/PrintClangValueType.h
+++ b/lib/PrintAsClang/PrintClangValueType.h
@@ -16,6 +16,7 @@
 #include "OutputLanguageMode.h"
 #include "swift/AST/Type.h"
 #include "swift/Basic/LLVM.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace swift {
@@ -37,7 +38,8 @@ public:
 
   /// Print the C++ class definition that
   /// corresponds to the given structure or enum declaration.
-  void printValueTypeDecl(const NominalTypeDecl *typeDecl);
+  void printValueTypeDecl(const NominalTypeDecl *typeDecl,
+                          llvm::function_ref<void(void)> bodyPrinter);
 
   /// Print the pararameter type that referes to a Swift struct type in C/C++.
   void printValueTypeParameterType(const NominalTypeDecl *type,
@@ -49,7 +51,7 @@ public:
   void
   printParameterCxxToCUseScaffold(bool isIndirect, const NominalTypeDecl *type,
                                   llvm::function_ref<void()> cxxParamPrinter,
-                                  bool isInOut);
+                                  bool isInOut, bool isSelf);
 
   /// Print the return type that refers to a Swift struct type in C/C++.
   void printValueTypeReturnType(const NominalTypeDecl *typeDecl,

--- a/test/Interop/SwiftToC/functions/swift-function-argument-keyword-in-c.swift
+++ b/test/Interop/SwiftToC/functions/swift-function-argument-keyword-in-c.swift
@@ -4,4 +4,4 @@
 
 // CHECK: SWIFT_EXTERN void $s9Functions19testKeywordArgument8registerySi_tF(ptrdiff_t register_) SWIFT_NOEXCEPT SWIFT_CALL;
 
-func testKeywordArgument(register: Int) { }
+public func testKeywordArgument(register: Int) { }

--- a/test/Interop/SwiftToCxx/functions/swift-function-argument-keyword-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-function-argument-keyword-in-cxx.swift
@@ -7,5 +7,5 @@
 // CHECK: inline void testKeywordArgument(swift::Int register_) noexcept
 // CHECK-NEXT: return _impl::$s9Functions19testKeywordArgument8registerySi_tF(register_);
 
-func testKeywordArgument(register: Int) {
+public func testKeywordArgument(register: Int) {
 }

--- a/test/Interop/SwiftToCxx/properties/getter-in-cxx-execution.cpp
+++ b/test/Interop/SwiftToCxx/properties/getter-in-cxx-execution.cpp
@@ -1,0 +1,57 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %S/getter-in-cxx.swift -typecheck -module-name Properties -clang-header-expose-public-decls -emit-clang-header-path %t/properties.h
+
+// RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-props-execution.o
+// RUN: %target-interop-build-swift %S/getter-in-cxx.swift -o %t/swift-props-execution -Xlinker %t/swift-props-execution.o -module-name Properties -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+
+// RUN: %target-codesign %t/swift-props-execution
+// RUN: %target-run %t/swift-props-execution | %FileCheck %s
+
+// REQUIRES: executable_test
+
+#include <assert.h>
+#include "properties.h"
+
+int main() {
+  using namespace Properties;
+
+  auto smallStructWithGetter = createSmallStructWithGetter();
+  assert(smallStructWithGetter.getStoredInt() == 21);
+  assert(smallStructWithGetter.getComputedInt() == 23);
+
+  auto largeStruct = smallStructWithGetter.getLargeStruct();
+  assert(largeStruct.getX1() == 46);
+  assert(largeStruct.getX2() == 1);
+  assert(largeStruct.getX3() == 2);
+  assert(largeStruct.getX4() == 3);
+  assert(largeStruct.getX5() == 4);
+  assert(largeStruct.getX6() == 5);
+
+  auto largeStruct2 = largeStruct.getAnotherLargeStruct();
+  assert(largeStruct2.getX1() == 11);
+  assert(largeStruct2.getX2() == 42);
+  assert(largeStruct2.getX3() == -0xFFF);
+  assert(largeStruct2.getX4() == 0xbad);
+  assert(largeStruct2.getX5() == 5);
+  assert(largeStruct2.getX6() == 0);
+
+  auto firstSmallStruct = largeStruct.getFirstSmallStruct();
+  assert(firstSmallStruct.getX() == 65);
+
+  auto smallStruct2 = smallStructWithGetter.getSmallStruct();
+  assert(smallStruct2.getStoredInt() == 0xFAE);
+  assert(smallStruct2.getComputedInt() == (0xFAE + 2));
+
+  {
+    StructWithRefCountStoredProp structWithRefCountStoredProp =
+      createStructWithRefCountStoredProp();
+    auto anotherOne = structWithRefCountStoredProp.getAnother();
+    (void)anotherOne;
+  }
+// CHECK:      create RefCountedClass 0
+// CHECK-NEXT: create RefCountedClass 1
+// CHECK-NEXT: destroy RefCountedClass 1
+// CHECK-NEXT: destroy RefCountedClass 0
+  return 0;
+}

--- a/test/Interop/SwiftToCxx/properties/getter-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/properties/getter-in-cxx.swift
@@ -1,0 +1,146 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -module-name Properties -clang-header-expose-public-decls -emit-clang-header-path %t/properties.h
+// RUN: %FileCheck %s < %t/properties.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/properties.h)
+
+public struct FirstSmallStruct {
+    public let x: UInt32
+}
+
+// CHECK: class FirstSmallStruct final {
+// CHECK: public:
+// CHECK:   inline FirstSmallStruct(FirstSmallStruct &&) = default;
+// CHECK-NEXT:   inline uint32_t getX() const;
+// CHECK-NEXT:   private:
+
+// CHECK: inline uint32_t FirstSmallStruct::getX() const {
+// CHECK-NEXT: return _impl::$s10Properties16FirstSmallStructV1xs6UInt32Vvg(_impl::swift_interop_passDirect_Properties_FirstSmallStruct(_getOpaquePointer()));
+// CHECK-NEXT: }
+
+public struct LargeStruct {
+    public let x1, x2, x3, x4, x5, x6: Int
+
+    public var anotherLargeStruct: LargeStruct {
+        return LargeStruct(x1: 11, x2: 42, x3: -0xFFF, x4: 0xbad, x5: 5, x6: 0)
+    }
+
+    public var firstSmallStruct: FirstSmallStruct {
+        return FirstSmallStruct(x: 65)
+    }
+}
+
+// CHECK: class LargeStruct final {
+// CHECK: public:
+// CHECK: inline LargeStruct(LargeStruct &&) = default;
+// CHECK-NEXT: inline swift::Int getX1() const;
+// CHECK-NEXT: inline swift::Int getX2() const;
+// CHECK-NEXT: inline swift::Int getX3() const;
+// CHECK-NEXT: inline swift::Int getX4() const;
+// CHECK-NEXT: inline swift::Int getX5() const;
+// CHECK-NEXT: inline swift::Int getX6() const;
+// CHECK-NEXT: inline LargeStruct getAnotherLargeStruct() const;
+// CHECK-NEXT: inline FirstSmallStruct getFirstSmallStruct() const;
+// CHECK-NEXT: private:
+
+// CHECK:      inline swift::Int LargeStruct::getX1() const {
+// CHECK-NEXT: return _impl::$s10Properties11LargeStructV2x1Sivg(_getOpaquePointer());
+// CHECK-NEXT: }
+// CHECK-NEXT: inline swift::Int LargeStruct::getX2() const {
+// CHECK-NEXT: return _impl::$s10Properties11LargeStructV2x2Sivg(_getOpaquePointer());
+// CHECK-NEXT: }
+// CHECK-NEXT: inline swift::Int LargeStruct::getX3() const {
+// CHECK-NEXT: return _impl::$s10Properties11LargeStructV2x3Sivg(_getOpaquePointer());
+// CHECK-NEXT: }
+// CHECK-NEXT: inline swift::Int LargeStruct::getX4() const {
+// CHECK-NEXT: return _impl::$s10Properties11LargeStructV2x4Sivg(_getOpaquePointer());
+// CHECK-NEXT: }
+// CHECK-NEXT: inline swift::Int LargeStruct::getX5() const {
+// CHECK-NEXT: return _impl::$s10Properties11LargeStructV2x5Sivg(_getOpaquePointer());
+// CHECK-NEXT: }
+// CHECK-NEXT: inline swift::Int LargeStruct::getX6() const {
+// CHECK-NEXT: return _impl::$s10Properties11LargeStructV2x6Sivg(_getOpaquePointer());
+// CHECK-NEXT: }
+// CHECK-NEXT: inline LargeStruct LargeStruct::getAnotherLargeStruct() const {
+// CHECK-NEXT: return _impl::_impl_LargeStruct::returnNewValue([&](void * _Nonnull result) {
+// CHECK-NEXT:   _impl::$s10Properties11LargeStructV07anotherbC0ACvg(result, _getOpaquePointer());
+// CHECK-NEXT: });
+// CHECK-NEXT: }
+// CHECK-NEXT: inline FirstSmallStruct LargeStruct::getFirstSmallStruct() const {
+// CHECK-NEXT: return _impl::_impl_FirstSmallStruct::returnNewValue([&](char * _Nonnull result) {
+// CHECK-NEXT:   _impl::swift_interop_returnDirect_Properties_FirstSmallStruct(result, _impl::$s10Properties11LargeStructV010firstSmallC0AA05FirsteC0Vvg(_getOpaquePointer()));
+// CHECK-NEXT: });
+// CHECK-NEXT: }
+
+public struct SmallStructWithGetters {
+    public let storedInt: UInt32
+    public var computedInt: Int {
+        return Int(storedInt) + 2
+    }
+
+    public var largeStruct: LargeStruct {
+        return LargeStruct(x1: computedInt * 2, x2: 1, x3: 2, x4: 3, x5: 4, x6: 5)
+    }
+
+    public var smallStruct: SmallStructWithGetters {
+        return SmallStructWithGetters(storedInt: 0xFAE);
+    }
+}
+
+// CHECK: class SmallStructWithGetters final {
+// CHECK: public:
+// CHECK:   inline SmallStructWithGetters(SmallStructWithGetters &&) = default;
+// CHECK-NEXT:  inline uint32_t getStoredInt() const;
+// CHECK-NEXT:  inline swift::Int getComputedInt() const;
+// CHECK-NEXT:  inline LargeStruct getLargeStruct() const;
+// CHECK-NEXT:  inline SmallStructWithGetters getSmallStruct() const;
+// CHECK-NEXT: private:
+
+// CHECK:      inline uint32_t SmallStructWithGetters::getStoredInt() const {
+// CHECK-NEXT: return _impl::$s10Properties22SmallStructWithGettersV9storedInts6UInt32Vvg(_impl::swift_interop_passDirect_Properties_SmallStructWithGetters(_getOpaquePointer()));
+// CHECK-NEXT: }
+// CHECK-NEXT: inline swift::Int SmallStructWithGetters::getComputedInt() const {
+// CHECK-NEXT: return _impl::$s10Properties22SmallStructWithGettersV11computedIntSivg(_impl::swift_interop_passDirect_Properties_SmallStructWithGetters(_getOpaquePointer()));
+// CHECK-NEXT: }
+// CHECK-NEXT: inline LargeStruct SmallStructWithGetters::getLargeStruct() const {
+// CHECK-NEXT: return _impl::_impl_LargeStruct::returnNewValue([&](void * _Nonnull result) {
+// CHECK-NEXT:   _impl::$s10Properties22SmallStructWithGettersV05largeC0AA05LargeC0Vvg(result, _impl::swift_interop_passDirect_Properties_SmallStructWithGetters(_getOpaquePointer()));
+// CHECK-NEXT: });
+// CHECK-NEXT: }
+// CHECK-NEXT: inline SmallStructWithGetters SmallStructWithGetters::getSmallStruct() const {
+// CHECK-NEXT: return _impl::_impl_SmallStructWithGetters::returnNewValue([&](char * _Nonnull result) {
+// CHECK-NEXT:   _impl::swift_interop_returnDirect_Properties_SmallStructWithGetters(result, _impl::$s10Properties22SmallStructWithGettersV05smallC0ACvg(_impl::swift_interop_passDirect_Properties_SmallStructWithGetters(_getOpaquePointer())));
+// CHECK-NEXT: });
+// CHECK-NEXT: }
+
+public func createSmallStructWithGetter() -> SmallStructWithGetters {
+    return SmallStructWithGetters(storedInt: 21)
+}
+
+private class RefCountedClass {
+    let x: Int
+
+    init(x: Int) {
+        self.x = x
+        print("create RefCountedClass \(x)")
+    }
+    deinit {
+        print("destroy RefCountedClass \(x)")
+    }
+}
+
+public struct StructWithRefCountStoredProp {
+    private let storedRef: RefCountedClass
+
+    public init(x: Int) {
+        storedRef = RefCountedClass(x: x)
+    }
+
+    public var another: StructWithRefCountStoredProp {
+        return StructWithRefCountStoredProp(x: 1)
+    }
+}
+
+public func createStructWithRefCountStoredProp() -> StructWithRefCountStoredProp {
+    return StructWithRefCountStoredProp(x: 0)
+}

--- a/test/Interop/SwiftToCxx/structs/swift-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/swift-struct-in-cxx.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend %s -typecheck -module-name Structs -clang-header-expose-public-decls -emit-clang-header-path %t/structs.h
 // RUN: %FileCheck %s < %t/structs.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/structs.h -Wno-unused-private-field)
+// RUN: %check-interop-cxx-header-in-clang(%t/structs.h -Wno-unused-private-field -Wno-unused-function)
 
 // CHECK: namespace Structs {
 // CHECK: namespace _impl {

--- a/test/PrintAsCxx/empty.swift
+++ b/test/PrintAsCxx/empty.swift
@@ -73,6 +73,10 @@
 // CHECK-NEXT:  # define IBSegueAction
 // CHECK-NEXT:  #endif
 
+// CHECK-LABEL: # define SWIFT_CALL __attribute__((swiftcall))
+// CHECK:       # define SWIFT_INDIRECT_RESULT __attribute__((swift_indirect_result))
+// CHECK:       # define SWIFT_CONTEXT __attribute__((swift_context))
+
 // CHECK-LABEL: #if defined(__OBJC__)
 // CHECK-NEXT:  #if __has_feature(modules)
 


### PR DESCRIPTION
Follow-up patches will add support for static properties, availability, doc comments, setters, mutation accessors, different naming scheme (e.g. `is` instead of `get`).