### PR TITLE
Handle undefs in a few utilities used in RLE

### DIFF
--- a/include/swift/SILOptimizer/Utils/LoadStoreOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/LoadStoreOptUtils.h
@@ -257,6 +257,8 @@ public:
   SILValue materialize(SILInstruction *Inst) {
     if (CoveringValue)
       return SILValue();
+    if (isa<SILUndef>(Base))
+      return Base;
     auto Val = Base;
     auto InsertPt = getInsertAfterPoint(Base).getValue();
     SILBuilderWithScope Builder(InsertPt);

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -1683,6 +1683,9 @@ SILBasicBlock::iterator swift::replaceSingleUse(Operand *use, SILValue newValue,
 }
 
 SILValue swift::makeCopiedValueAvailable(SILValue value, SILBasicBlock *inBlock) {
+  if (isa<SILUndef>(value))
+    return value;
+
   if (!value->getFunction()->hasOwnership())
     return value;
 
@@ -1698,6 +1701,9 @@ SILValue swift::makeCopiedValueAvailable(SILValue value, SILBasicBlock *inBlock)
 }
 
 SILValue swift::makeValueAvailable(SILValue value, SILBasicBlock *inBlock) {
+  if (isa<SILUndef>(value))
+    return value;
+
   if (!value->getFunction()->hasOwnership())
     return value;
 

--- a/test/SILOptimizer/redundant_load_elim.sil
+++ b/test/SILOptimizer/redundant_load_elim.sil
@@ -1270,3 +1270,22 @@ bb0:
   dealloc_stack_ref %1 : $AX
   return %5 : $Int32
 }
+
+sil @read_emptytuple : $@convention(thin) (@in_guaranteed ()) -> ()
+
+// CHECK-LABEL: sil @emptytuple_promotion :
+// CHECK: store
+// CHECK-LABEL: } // end sil function 'emptytuple_promotion'
+sil @emptytuple_promotion : $@convention(thin) () -> () {
+bb0:
+  %stk2 = alloc_stack $()
+  store undef to %stk2 : $*()
+  br bb1
+
+bb1:
+  %ld = load %stk2 : $*()
+  dealloc_stack %stk2 : $*()
+  %r = tuple ()
+  return %r : $()
+}
+


### PR DESCRIPTION
We should not be seeing undef running values in RLE. But since we can't enforce zero undefs in the SILVerifier today, handle them gracefully in these utilities. 