### PR TITLE
Unique the debug info function declarations for Swift runtime failure…  …

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -135,6 +135,7 @@ class IRGenDebugInfoImpl : public IRGenDebugInfo {
   llvm::DenseMap<TypeBase *, llvm::TrackingMDNodeRef> DITypeCache;
   llvm::DenseMap<const void *, llvm::TrackingMDNodeRef> DIModuleCache;
   llvm::StringMap<llvm::TrackingMDNodeRef> DIFileCache;
+  llvm::StringMap<llvm::TrackingMDNodeRef> RuntimeErrorFnCache;
   TrackingDIRefMap DIRefMap;
   TrackingDIRefMap InnerTypeCache;
   /// \}
@@ -2113,13 +2114,20 @@ void IRGenDebugInfoImpl::addFailureMessageToCurrentLoc(IRBuilder &Builder,
 
   llvm::DISubroutineType *DIFnTy = DBuilder.createSubroutineType(nullptr);
 
-  std::string FuncName = "Swift runtime failure: ";
-  FuncName += failureMsg;
-
-  llvm::DISubprogram *TrapSP = DBuilder.createFunction(
-      MainModule, FuncName, StringRef(), TrapLoc->getFile(), 0, DIFnTy, 0,
-      llvm::DINode::FlagArtificial, llvm::DISubprogram::SPFlagDefinition,
-      nullptr, nullptr, nullptr);
+  llvm::DISubprogram *TrapSP;
+  auto It = RuntimeErrorFnCache.find(failureMsg);
+  if (It != RuntimeErrorFnCache.end())
+    TrapSP = llvm::cast<llvm::DISubprogram>(It->second);
+  else {
+    std::string FuncName = "Swift runtime failure: ";
+    FuncName += failureMsg;
+    llvm::DIFile *File = getOrCreateFile({});
+    TrapSP = DBuilder.createFunction(
+        File, FuncName, StringRef(), File, 0,
+        DIFnTy, 0, llvm::DINode::FlagArtificial,
+        llvm::DISubprogram::SPFlagDefinition, nullptr, nullptr, nullptr);
+    RuntimeErrorFnCache.insert({failureMsg, llvm::TrackingMDNodeRef(TrapSP)});
+  }
 
   ScopeCache[TrapSc] = llvm::TrackingMDNodeRef(TrapSP);
   LastScope = TrapSc;

--- a/test/DebugInfo/runtime-failure.swift
+++ b/test/DebugInfo/runtime-failure.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend %s -emit-ir -g -o - | %FileCheck %s
+
+public func f(_ input: Int) -> Int {
+  return input * 2 + 1
+}
+
+// CHECK: distinct !DISubprogram(name: "Swift runtime failure: arithmetic overflow"
+// CHECK-SAME: scope: ![[FILE:[0-9]+]]
+// CHECK-SAME: file: ![[FILE]]
+// CHECK-NOT: "Swift runtime failure: arithmetic overflow"


### PR DESCRIPTION
… messages.

This reduces the size of the debug info of (random benchmark)
_StringProcessing.o by 1600 bytes. Modules with more arithmetic should
benefit more.

rdar://94060085
