### PR TITLE
Emit Sendable diagnostics in actor-like deinits only in 'complete' checking mode

### DIFF
--- a/lib/SILOptimizer/Mandatory/FlowIsolation.cpp
+++ b/lib/SILOptimizer/Mandatory/FlowIsolation.cpp
@@ -511,6 +511,18 @@ static bool diagnoseNonSendableFromDeinit(ModuleDecl *module,
                                           RefElementAddrInst *inst) {
   VarDecl *var = inst->getField();
   Type ty = var->getType();
+  DeclContext* dc = inst->getFunction()->getDeclContext();
+
+// FIXME: we should emit diagnostics in other modes using:
+//
+//  if (!shouldDiagnoseExistingDataRaces(dc))
+//    return false;
+//
+// but until we decide how we want to handle isolated state from deinits,
+// we're going to limit the noise to complete mode for now.
+  if (dc->getASTContext().LangOpts.StrictConcurrencyLevel
+      != StrictConcurrency::Complete)
+      return false;
 
   if (isSendableType(module, ty))
     return false;

--- a/test/Concurrency/flow_isolation_nonstrict.swift
+++ b/test/Concurrency/flow_isolation_nonstrict.swift
@@ -1,0 +1,30 @@
+// RUN: %target-swift-frontend -strict-concurrency=targeted -swift-version 5 -parse-as-library -emit-sil -verify %s
+
+class NonSendableType {
+  var x: Int = 0
+  func f() {}
+}
+
+// rdar://94699928 - don't emit sendable diagnostics in non-'complete' mode
+// for deinits of actor or global-actor isolated types
+
+@available(SwiftStdlib 5.1, *)
+@MainActor class AwesomeUIView {}
+
+@available(SwiftStdlib 5.1, *)
+class CheckDeinitFromClass: AwesomeUIView {
+  var ns: NonSendableType?
+  deinit {
+    ns?.f()
+    ns = nil
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+actor CheckDeinitFromActor {
+  var ns: NonSendableType?
+  deinit {
+    ns?.f()
+    ns = nil
+  }
+}


### PR DESCRIPTION
The flow-isolation pass was not respecting the new strict-concurrency checking mode.
Since the Sendable diagnostics in these deinits are very noisy, I'm moving them to only
be emitted in 'complete' mode. The reason why they're so noisy is that any class that
inherits from a `@MainActor`-constrained class will have these diagnostics emitted when
trying to access its own `@MainActor`-isolated members.

This is needed, even during the `deinit`, because multiple instances of a `@MainActor`-isolated
class might have stored properties that refer to the same state.

This change specifically avoids emitting these diagnostics even in 'targeted' mode because
I'd like to take more time to reconsider the ergonomics of these deinits.

resolves rdar://94699928