### PR TITLE
[Threading][Runtime] Separate threading error function to fix link on Linux.

### DIFF
--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -67,6 +67,7 @@ set(swift_runtime_sources
     RuntimeInvocationsTracking.cpp
     SwiftDtoa.cpp
     SwiftTLSContext.cpp
+    ThreadingError.cpp
     AccessibleFunction.cpp)
 
 # Acknowledge that the following sources are known.

--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -465,13 +465,3 @@ void swift::swift_abortDisabledUnicodeSupport() {
                     "Unicode normalization data is disabled on this platform");
 
 }
-
-/// Halt because of a problem in the threading library
-SWIFT_ATTRIBUTE_NORETURN
-SWIFT_FORMAT(1, 2)
-void swift::threading::fatal(const char *msg, ...) {
-  va_list val;
-  va_start(val, msg);
-
-  swift::fatalErrorv(0, msg, val);
-}

--- a/stdlib/public/runtime/ThreadingError.cpp
+++ b/stdlib/public/runtime/ThreadingError.cpp
@@ -1,0 +1,25 @@
+//===--- ThreadingError.cpp - Error handling support code -----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Runtime/Debug.h"
+#include "swift/Threading/Errors.h"
+#include <cstdio>
+
+// Handle fatal errors from the threading library
+SWIFT_ATTRIBUTE_NORETURN
+SWIFT_FORMAT(1, 2)
+void swift::threading::fatal(const char *format, ...) {
+  va_list val;
+
+  va_start(val, format);
+  swift::fatalErrorv(0, format, val);
+}


### PR DESCRIPTION
On Linux it seems that the linker objects, probably because of link order, to the definition of `swift::threading::fatal()` being in both static libraries.  Fix by moving `swift::threading::fatal()` to its own file in the main runtime as well as the Concurrency runtime.

Fixes #59444.
