### PR TITLE
🍒[5.7][Distributed] Be able to synthesize actorSystem prop from request

### DIFF
--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -65,7 +65,8 @@ using namespace swift;
 /********************** Distributed Actor Properties **************************/
 /******************************************************************************/
 
-VarDecl* swift::lookupDistributedActorProperty(NominalTypeDecl *decl, DeclName name) {
+VarDecl*
+swift::lookupDistributedActorProperty(NominalTypeDecl *decl, DeclName name) {
   assert(decl && "decl was null");
   auto &C = decl->getASTContext();
 

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -338,11 +338,11 @@ ValueDecl *DerivedConformance::getDerivableRequirement(NominalTypeDecl *nominal,
       return getRequirement(KnownProtocolKind::Actor);
 
     // DistributedActor.id
-    if(name.isSimpleName(ctx.Id_id))
+    if (name.isSimpleName(ctx.Id_id))
       return getRequirement(KnownProtocolKind::DistributedActor);
 
     // DistributedActor.actorSystem
-    if(name.isSimpleName(ctx.Id_actorSystem))
+    if (name.isSimpleName(ctx.Id_actorSystem))
       return getRequirement(KnownProtocolKind::DistributedActor);
 
     return nullptr;


### PR DESCRIPTION
**Description:** We need to be able to trigger synthesis from this request, as sometimes we may end up typechecking a distributed thunk, before `DerivedConformance` has a chance to run. Since we were not doing this for system (but were doing it for id), this triggered missing actor system crashes at compile time in more complex projects.

More details in: https://github.com/apple/swift/pull/59460

**Risk:** Low, this replicates a very simple property synthesis in a way we know how to do and have been doing for a long time in distributed actors for IDs. If the usual derived conformance synthesis runs, this is still fine. And we should find a way to de duplicate this, but it seems we cannot rely on Derived Conformance -- as we learnt the hard way with the `id` property before already.
**Review by:** @DougGregor
**Testing:** CI testing and verified with this compiler on a real project (swift-distributed-actors) where lack of this caused unpredictable crashes.
**Original PR:** https://github.com/apple/swift/pull/59460
**Radar:** rdar://95186443
