### PR TITLE
[Distributed] Be able to synthesize actorSystem prop from request

### DIFF
--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -338,11 +338,11 @@ ValueDecl *DerivedConformance::getDerivableRequirement(NominalTypeDecl *nominal,
       return getRequirement(KnownProtocolKind::Actor);
 
     // DistributedActor.id
-    if(name.isSimpleName(ctx.Id_id))
+    if (name.isSimpleName(ctx.Id_id))
       return getRequirement(KnownProtocolKind::DistributedActor);
 
     // DistributedActor.actorSystem
-    if(name.isSimpleName(ctx.Id_actorSystem))
+    if (name.isSimpleName(ctx.Id_actorSystem))
       return getRequirement(KnownProtocolKind::DistributedActor);
 
     return nullptr;


### PR DESCRIPTION
Resolves rdar://95186443

A bit confused why it happens, but we sometimes (only in a real and "big project", the cluster) and a rather complex `distributed actor`, end up issuing a request for the distributed `actorSystem` property, before the `DerivedConformance` infrastructure had a chance to run.

We had this also with the `id` property which was causing mayhem before, which is why we moved it out here to be lazily computed upon a request.

This change adds the same style of synthesis the `id` property already has, to the `actorSystem`. We used to have this, but moved to `DerivedConformance` style, but that is not enough it seems as it is too lazy (!), because we might end up type checking a distributed `thunk` before that derived synthesis has had a chance to run.

This also takes care of the explicit strict order the `id` and `actorSystem` must be in:

- if `id` is synthesized first:
  - `id` always does "force to be first"
  - `actorSystem` finds `id` and uses it as `hint: id` which means "insert actorSystem AFTER id", so the order is correct
- If `actorSystem` is synthesized first... (new)
  - the system does NOT find `id`, and passes `hint: null`; we insert at head then
  - as the ID gets synthesized, it forces to be first as well; so we end up with: `id`, `actorSystem` all good.