### PR TITLE
[cxx-interop][SwiftCompilerSources] Workaround for `std::string` crash on arm64 Linux

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/BasicBlock.swift
+++ b/SwiftCompilerSources/Sources/SIL/BasicBlock.swift
@@ -25,7 +25,8 @@ final public class BasicBlock : ListNode, CustomStringConvertible, HasShortDescr
   public var function: Function { SILBasicBlock_getFunction(bridged).function }
 
   public var description: String {
-    String(_cxxString: SILBasicBlock_debugDescription(bridged))
+    let stdString = SILBasicBlock_debugDescription(bridged)
+    return String(_cxxString: stdString)
   }
   public var shortDescription: String { name }
 

--- a/SwiftCompilerSources/Sources/SIL/Function.swift
+++ b/SwiftCompilerSources/Sources/SIL/Function.swift
@@ -21,7 +21,8 @@ final public class Function : CustomStringConvertible, HasShortDescription {
   }
 
   final public var description: String {
-    String(_cxxString: SILFunction_debugDescription(bridged))
+    let stdString = SILFunction_debugDescription(bridged)
+    return String(_cxxString: stdString)
   }
 
   public var shortDescription: String { name.string }

--- a/SwiftCompilerSources/Sources/SIL/GlobalVariable.swift
+++ b/SwiftCompilerSources/Sources/SIL/GlobalVariable.swift
@@ -19,7 +19,8 @@ final public class GlobalVariable : CustomStringConvertible, HasShortDescription
   }
 
   public var description: String {
-    String(_cxxString: SILGlobalVariable_debugDescription(bridged))
+    let stdString = SILGlobalVariable_debugDescription(bridged)
+    return String(_cxxString: stdString)
   }
 
   public var shortDescription: String { name.string }

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -38,7 +38,8 @@ public class Instruction : ListNode, CustomStringConvertible, Hashable {
   final public var function: Function { block.function }
 
   final public var description: String {
-    String(_cxxString: SILNode_debugDescription(bridgedNode))
+    let stdString = SILNode_debugDescription(bridgedNode)
+    return String(_cxxString: stdString)
   }
 
   final public var operands: OperandArray {
@@ -142,7 +143,8 @@ public class SingleValueInstruction : Instruction, Value {
 
 public final class MultipleValueInstructionResult : Value {
   final public var description: String {
-    String(_cxxString: SILNode_debugDescription(bridgedNode))
+    let stdString = SILNode_debugDescription(bridgedNode)
+    return String(_cxxString: stdString)
   }
 
   public var instruction: Instruction {

--- a/SwiftCompilerSources/Sources/SIL/Value.swift
+++ b/SwiftCompilerSources/Sources/SIL/Value.swift
@@ -81,7 +81,8 @@ public enum Ownership {
 
 extension Value {
   public var description: String {
-    String(_cxxString: SILNode_debugDescription(bridgedNode))
+    let stdString = SILNode_debugDescription(bridgedNode)
+    return String(_cxxString: stdString)
   }
 
   public var uses: UseList {

--- a/test/SILOptimizer/addr_escape_info.sil
+++ b/test/SILOptimizer/addr_escape_info.sil
@@ -2,9 +2,6 @@
 
 // REQUIRES: swift_in_compiler
 
-// rdar92963081
-// UNSUPPORTED: OS=linux-gnu
-
 sil_stage canonical
 
 import Builtin

--- a/test/SILOptimizer/escape_info.sil
+++ b/test/SILOptimizer/escape_info.sil
@@ -2,9 +2,6 @@
 
 // REQUIRES: swift_in_compiler
 
-// rdar92963081
-// UNSUPPORTED: OS=linux-gnu
-
 sil_stage canonical
 
 import Builtin

--- a/test/SILOptimizer/ranges.sil
+++ b/test/SILOptimizer/ranges.sil
@@ -2,9 +2,6 @@
 
 // REQUIRES: swift_in_compiler
 
-// rdar92963081
-// UNSUPPORTED: OS=linux-gnu
-
 sil_stage canonical
 
 // CHECK-LABEL: Instruction range in basic_test:


### PR DESCRIPTION
`std::string` constructor crashes when called from `SILBridging.cpp`, likely due to a miscompile. This is a workaround that fixes the crash.