### PR TITLE
Unique the debug info function declarations for Swift runtime failure…

### DIFF
--- a/test/DebugInfo/runtime-failure.swift
+++ b/test/DebugInfo/runtime-failure.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend %s -emit-ir -g -o - | %FileCheck %s
+
+public func f(_ input: Int) -> Int {
+  return input * 2 + 1
+}
+
+// CHECK: distinct !DISubprogram(name: "Swift runtime failure: arithmetic overflow"
+// CHECK-SAME: scope: ![[FILE:[0-9]+]]
+// CHECK-SAME: file: ![[FILE]]
+// CHECK-NOT: "Swift runtime failure: arithmetic overflow"


### PR DESCRIPTION
… messages.

This reduces the size of the debug info of (random benchmark)
_StringProcessing.o by 1600 bytes. Modules with more arithmetic should
benefit more.

rdar://94060085

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
