### PR TITLE
[cxx-interop] Import iterator dereference operators

### DIFF
--- a/test/Interop/Cxx/operators/Inputs/member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/member-inline.h
@@ -274,4 +274,25 @@ struct DerivedFromReadWriteIntArray : ReadWriteIntArray {};
 
 struct DerivedFromNonTrivialArrayByVal : NonTrivialArrayByVal {};
 
+struct Iterator {
+private:
+  int value = 123;
+public:
+  int &operator*() { return value; }
+};
+
+struct ConstIterator {
+private:
+  int value = 234;
+public:
+  const int &operator*() const { return value; }
+};
+
+struct ConstIteratorByVal {
+private:
+  int value = 456;
+public:
+  int operator*() const { return value; }
+};
+
 #endif

--- a/test/Interop/Cxx/operators/member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/member-inline-module-interface.swift
@@ -190,3 +190,21 @@
 // CHECK:   subscript(x: Int32) -> NonTrivial { get }
 // CHECK:   mutating func __operatorSubscriptConst(_ x: Int32) -> NonTrivial
 // CHECK: }
+
+// CHECK: struct Iterator {
+// CHECK:   var pointee: Int32 { mutating get }
+// CHECK:   @available(*, unavailable, message: "use .pointee property")
+// CHECK:   mutating func __operatorStar() -> UnsafeMutablePointer<Int32>
+// CHECK: }
+
+// CHECK: struct ConstIterator {
+// CHECK:   var pointee: Int32 { get }
+// CHECK:   @available(*, unavailable, message: "use .pointee property")
+// CHECK:   func __operatorStar() -> UnsafePointer<Int32>
+// CHECK: }
+
+// CHECK: struct ConstIteratorByVal {
+// CHECK:   var pointee: Int32 { get }
+// CHECK:   @available(*, unavailable, message: "use .pointee property")
+// CHECK:   func __operatorStar() -> Int32
+// CHECK: }

--- a/test/Interop/Cxx/operators/member-inline.swift
+++ b/test/Interop/Cxx/operators/member-inline.swift
@@ -240,4 +240,22 @@ OperatorsTestSuite.test("PtrToPtr.subscript (inline)") {
 //  expectEqual(23, arr[0])
 //}
 
+OperatorsTestSuite.test("Iterator.pointee") {
+  var iter = Iterator()
+  let res = iter.pointee
+  expectEqual(123, res)
+}
+
+OperatorsTestSuite.test("ConstIterator.pointee") {
+  let iter = ConstIterator()
+  let res = iter.pointee
+  expectEqual(234, res)
+}
+
+OperatorsTestSuite.test("ConstIteratorByVal.pointee") {
+  let iter = ConstIteratorByVal()
+  let res = iter.pointee
+  expectEqual(456, res)
+}
+
 runAllTests()


### PR DESCRIPTION
C++ iterator dereference operator is mapped to a Swift computed property called `pointee`.

For example:
```cpp
struct ConstIterator {
  // ...
  const int &operator*() const { /* ... */ }
};
```
is imported as
```swift
struct ConstIterator {
  var pointee: Int32 { get }
  @available(*, unavailable, message: "use .pointee property")
  func __operatorStar() -> UnsafePointer<Int32>
}
```