### PR TITLE
[move-only-wrapper] A few small mechanical fixes before the main no-implicit-copy rebase PR

### DIFF
--- a/include/swift/SIL/AbstractionPattern.h
+++ b/include/swift/SIL/AbstractionPattern.h
@@ -1257,11 +1257,11 @@ public:
 
   /// Given that the value being abstracted is a move only type, return the
   /// abstraction pattern with the move only bit removed.
-  AbstractionPattern withoutMoveOnly() const;
+  AbstractionPattern removingMoveOnlyWrapper() const;
 
   /// Given that the value being abstracted is not a move only type, return the
   /// abstraction pattern with the move only bit added.
-  AbstractionPattern withMoveOnly() const;
+  AbstractionPattern addingMoveOnlyWrapper() const;
 
   /// Given that the value being abstracted is a tuple type, return
   /// the abstraction pattern for its object type.

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1299,14 +1299,16 @@ public:
   MoveOnlyWrapperToCopyableValueInst *
   createOwnedMoveOnlyWrapperToCopyableValue(SILLocation loc, SILValue src) {
     return insert(new (getModule()) MoveOnlyWrapperToCopyableValueInst(
-        *F, getSILDebugLocation(loc), src, OwnershipKind::Owned));
+        *F, getSILDebugLocation(loc), src,
+        MoveOnlyWrapperToCopyableValueInst::Owned));
   }
 
   MoveOnlyWrapperToCopyableValueInst *
   createGuaranteedMoveOnlyWrapperToCopyableValue(SILLocation loc,
                                                  SILValue src) {
     return insert(new (getModule()) MoveOnlyWrapperToCopyableValueInst(
-        *F, getSILDebugLocation(loc), src, OwnershipKind::Guaranteed));
+        *F, getSILDebugLocation(loc), src,
+        MoveOnlyWrapperToCopyableValueInst::Guaranteed));
   }
 
   UnconditionalCheckedCastInst *

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -296,7 +296,7 @@ public:
     IsInfiniteType_t isInfinite() const {
       return IsInfiniteType_t((Flags & InfiniteFlag) != 0);
     }
-    IsMoveOnly_t isMoveOnly() const {
+    IsMoveOnly_t isMoveOnlyWrapped() const {
       return IsMoveOnly_t((Flags & MoveOnlyFlag) != 0);
     }
 

--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -401,7 +401,7 @@ AbstractionPattern::getTupleElementType(unsigned index) const {
   llvm_unreachable("bad kind");
 }
 
-AbstractionPattern AbstractionPattern::withoutMoveOnly() const {
+AbstractionPattern AbstractionPattern::removingMoveOnlyWrapper() const {
   switch (getKind()) {
   case Kind::Invalid:
     llvm_unreachable("querying invalid abstraction pattern!");
@@ -435,7 +435,7 @@ AbstractionPattern AbstractionPattern::withoutMoveOnly() const {
   llvm_unreachable("bad kind");
 }
 
-AbstractionPattern AbstractionPattern::withMoveOnly() const {
+AbstractionPattern AbstractionPattern::addingMoveOnlyWrapper() const {
   switch (getKind()) {
   case Kind::Invalid:
     llvm_unreachable("querying invalid abstraction pattern!");

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1921,15 +1921,11 @@ public:
 
   void visitMoveOnlyWrapperToCopyableValueInst(
       MoveOnlyWrapperToCopyableValueInst *I) {
-    switch (I->getForwardingOwnershipKind()) {
-    case OwnershipKind::None:
-    case OwnershipKind::Any:
-    case OwnershipKind::Unowned:
-      llvm_unreachable("Move only values are always non-trivial");
-    case OwnershipKind::Owned:
+    switch (I->getInitialKind()) {
+    case MoveOnlyWrapperToCopyableValueInst::Owned:
       *this << "[owned] ";
       break;
-    case OwnershipKind::Guaranteed:
+    case MoveOnlyWrapperToCopyableValueInst::Guaranteed:
       *this << "[guaranteed] ";
       break;
     }

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2558,7 +2558,11 @@ TypeConverter::getTypeLowering(SILType type,
                                CanGenericSignature sig) {
   // The type lowering for a type parameter relies on its context.
   assert(sig || !type.getASTType()->hasTypeParameter());
-  auto loweredType = type.getASTType();
+
+  // We use the Raw AST type to ensure that moveonlywrapped values use the move
+  // only type lowering. This ensures that trivial moveonlywrapped values are
+  // not trivial.
+  auto loweredType = type.getRawASTType();
   auto isTypeExpansionSensitive = loweredType->hasOpaqueArchetype()
                                       ? IsTypeExpansionSensitive
                                       : IsNotTypeExpansionSensitive;

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -697,7 +697,7 @@ namespace {
     RetTy visitSILMoveOnlyType(CanSILMoveOnlyType type,
                                AbstractionPattern origType,
                                IsTypeExpansionSensitive_t isSensitive) {
-      AbstractionPattern innerAbstraction = origType.withoutMoveOnly();
+      AbstractionPattern innerAbstraction = origType.removingMoveOnlyWrapper();
       CanType innerType = type->getInnerType();
       auto &lowering =
           TC.getTypeLowering(innerAbstraction, innerType, Expansion);


### PR DESCRIPTION
In this PR, I am committing a few small mechanical changes that I was able to slice off from the main PR where I rebase no-implicit-copy on top of the move only wrapper type system changes. This is to make that PR easier to review. The changes in this PR are:

1. I renamed some methods on AbstractionPattern and TypeLowering to match variants on SILType.
2. I changed TypeLowering lookup to use getRawASTType() instead of getASTType(). This ensures that trivial move only wrapped types get the MoveOnly type lowering instead of the Trivial type lowering (and thus are treated as non-trivial).
3. I fixed a few issues around MoveOnlyWrapperToCopyableValue. Specifically: a. In earlier PRs I made this inst a FirstArgForwarding inst but did not inherit from FirstArgForwarding* causing some weird memory corruption issues due to layout differences. b. I originally printed out [owned] or [guaranteed] on the instruction based off of the actual forwarded ownership kind. This caused crashes later when printing once ownership lowering changed the forwarded ownership kind to None. Instead, I added a kind that is fixed on the instruction. In a future PR, I am probably going to rename the kind to a more informative name since these are actually semantically about ending the lifetime of the instruction or escaping to use it as a guaranteed parameter. I just want to do the rename in a later commit to avoid doing a bunch of renaming in the forthcoming main rebase PR.