### PR TITLE
[Docs] Add note for intel users when setting up clion

### DIFF
--- a/docs/HowToGuides/GettingStarted.md
+++ b/docs/HowToGuides/GettingStarted.md
@@ -376,6 +376,7 @@ In project settings, locate `Build, Execution, Deployment > CMake`. You will nee
     - `-D SWIFT_PATH_TO_CMARK_BUILD=SOME_PATH/swift-project/build/Ninja-RelWithDebInfoAssert/cmark-macosx-arm64 -D LLVM_DIR=SOME_PATH/swift-project/build/Ninja-RelWithDebInfoAssert/llvm-macosx-arm64/lib/cmake/llvm -D Clang_DIR=SOME_PATH/swift-project/build/Ninja-RelWithDebInfoAssert/llvm-macosx-arm64/lib/cmake/clang -D CMAKE_BUILD_TYPE=RelWithDebInfoAssert -G Ninja -S .`
     - replace the `SOME_PATH` to the path where your `swift-project` directory is
     - the CMAKE_BUILD_TYPE should match the build configuration name, so if you named this profile `RelWithDebInfo` the CMAKE_BUILD_TYPE should also be `RelWithDebInfo`
+    - **Note**: If you're using an intel machine to build swift, you'll need to replace the architecture in the options. (ex: `arm64` with `x86_64`)
 
 With this done, CLion should be able to successfully import the project and have full autocomplete and code navigation powers.
 


### PR DESCRIPTION
This pull request addresses any hassle that an intel user might face while following the already-written documentation on setting up CLion to work with swift. This was added because while following the documentation, a new user (such as myself) might get confused as to why their llvm or clang build isn't showing up.

