### PR TITLE
Test support for indirect enums in RemoteMirror

### DIFF
--- a/validation-test/Reflection/reflect_Enum_MultiPayload_value_indirect.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_value_indirect.swift
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Enum_MultiPayload_value
+// RUN: %target-codesign %t/reflect_Enum_MultiPayload_value
+
+// RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_MultiPayload_value | tee /dev/stderr | %FileCheck %s --check-prefix=CHECK --check-prefix=X%target-ptrsize --dump-input=fail
+
+// REQUIRES: reflection_test_support
+// REQUIRES: objc_interop
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+
+import SwiftReflectionTest
+
+
+indirect enum MPEWithInts {
+case stampA
+case envelopeA(Int64)
+case stampB
+case envelopeB(Double)
+case stampC
+case envelopeC((Int32, Int32))
+case stampD
+case stampE
+}
+
+indirect enum SPEWithMPEPayload {
+case payloadA(MPEWithInts)
+case alsoA
+case alsoB
+case alsoC
+case alsoD
+}
+
+
+reflect(enumValue: SPEWithMPEPayload.payloadA(.stampB))
+
+// CHECK: Reflecting an enum value.
+// CHECK-NEXT: Type reference:
+// CHECK-NEXT: (enum reflect_Enum_MultiPayload_value.SPEWithMPEPayload)
+// CHECK-NEXT: Value: .payloadA(.stampB)
+
+doneReflecting()
+
+// CHECK: Done.
+

--- a/validation-test/Reflection/reflect_Enum_value.swift
+++ b/validation-test/Reflection/reflect_Enum_value.swift
@@ -369,7 +369,7 @@ reflect(enumValue: OneIndirectPayload.child(.leafF))
 // CHECK: Reflecting an enum value.
 // CHECK-NEXT: Type reference:
 // CHECK-NEXT: (enum reflect_Enum_value.OneIndirectPayload)
-// CHECK-NEXT: Value: .child(_)
+// CHECK-NEXT: Value: .child(.leafF)
 
 reflect(enumValue: OneIndirectPayload.leafF)
 


### PR DESCRIPTION
Exercise dumping indirect enums using RemoteMirror.

An indirect enum stores all payloads as strong references to closure contexts stored on the heap. RemoteMirror already has facilities to look through strong references, determine the type of heap instances, and can identify closure contexts and their contents. So it's possible to evaluate indirect enums using the current RemoteMirror APIs. This PR is adding some tests that exercise indirect enums.

(I also hope to use this as a test bed to see if further API additions would simplify working with enums.)

Resolves rdar://94667049