### PR TITLE
[CodeCompletion] Avoid crash for not recommended item without a decl

### DIFF
--- a/test/IDE/complete_diagnostics_concurrency.swift
+++ b/test/IDE/complete_diagnostics_concurrency.swift
@@ -30,3 +30,11 @@ func testActor(obj: MyActor) async {
 // ACTOR-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: receiveNonSendable({#arg: MyNonSendable#})[' async'][#Void#]; name=receiveNonSendable(arg:); diagnostics=warning:actor-isolated 'receiveNonSendable(arg:)' should only be referenced from inside the actor{{$}}
 // ACTOR: End completions
 }
+
+func testClosure(obj: (Int) async -> Void) {
+  obj(#^CLOSURE_CALL^#)
+// FIXME: Emit diagnostics
+// CLOSURE_CALL: Begin completions
+// CLOSURE_CALL-DAG: Pattern/CurrModule/Flair[ArgLabels]/NotRecommended: ['(']{#Int#}[')'][' async'][#Void#]; name={{$}}
+// CLOSURE_CALL: End completions
+}


### PR DESCRIPTION
Generating diagnostics for "not recommended" items requires an associated declaration. However, cases like this:

```swift
  func test(fn: (Int) async -> Void) {
    fn(#^HERE^#)
  }
```

For the function call pattern item, there's no associated decl because the callee is an expression. Ideally it should emit a diagnostic, but for now, to avoid the crash, don't emit diagnostics unless the item has the associated decl.

rdar://95306033
