### PR TITLE
[move-function-value] When searching for uses to emit notes about in a sub-loop from the move, skip destroy_value.

### DIFF
--- a/test/SILOptimizer/move_function_kills_copyable_values.sil
+++ b/test/SILOptimizer/move_function_kills_copyable_values.sil
@@ -1,0 +1,47 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -o - -sil-move-kills-copyable-values-checker -verify %s
+
+// This file is meant for specific SIL patterns that may be hard to produce with
+// the current swift frontend but have reproduced before and we want to make
+// sure keep on working.
+
+import Builtin
+
+class Klass {}
+
+struct Int {
+  var _value: Builtin.Int64
+}
+
+enum Optional<T> {
+case none
+case some(T)
+}
+
+// Make sure that we only emit an error on the use within the loop and not on
+// the destroy_value along the exit edge of the loop.
+sil [ossa] @useInLoopWithDestroyOutOfLoop : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass):
+  debug_value %0 : $Klass, let, name "x", argno 1
+  %2 = begin_borrow [lexical] %0 : $Klass // expected-error {{'y' used after being moved}}
+  debug_value %2 : $Klass, let, name "y"
+  %4 = copy_value %2 : $Klass
+  %5 = move_value [allows_diagnostics] %4 : $Klass // expected-note {{move here}}
+  destroy_value %5 : $Klass
+  br bb1
+
+bb1:
+  switch_enum undef : $Optional<Int>, case #Optional.some!enumelt: bb2, case #Optional.none!enumelt: bb3
+
+bb2(%58 : $Int):
+  %59 = copy_value %2 : $Klass
+  %60 = begin_borrow [lexical] %59 : $Klass // expected-note {{use here}}
+  debug_value %60 : $Klass, let, name "m"
+  end_borrow %60 : $Klass
+  destroy_value %59 : $Klass
+  br bb1
+
+bb3:
+  end_borrow %2 : $Klass
+  %67 = tuple ()
+  return %67 : $()
+}


### PR DESCRIPTION
Once we have detected that we have a use after a move, we do a second pass over
the function looking for uses that are later than the move but are in
sub-loop. In such a case, the use will not be a boundary use but will be LiveOut
due to the loop circularity. In such a case, we need to match what we do
normally with pruned liveness, namely ignore destroy_value uses.

This fixes a false positive note where we emitted an additional remark on a
destroy_value.
