### PR TITLE
[5.7][CodeCompletion] Avoid crash for not recommended item without a decl

### DIFF
--- a/test/IDE/complete_diagnostics_concurrency.swift
+++ b/test/IDE/complete_diagnostics_concurrency.swift
@@ -30,3 +30,11 @@ func testActor(obj: MyActor) async {
 // ACTOR-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: receiveNonSendable({#arg: MyNonSendable#})[' async'][#Void#]; name=receiveNonSendable(arg:); diagnostics=warning:actor-isolated 'receiveNonSendable(arg:)' should only be referenced from inside the actor{{$}}
 // ACTOR: End completions
 }
+
+func testClosure(obj: (Int) async -> Void) {
+  obj(#^CLOSURE_CALL^#)
+// FIXME: Emit diagnostics
+// CLOSURE_CALL: Begin completions
+// CLOSURE_CALL-DAG: Pattern/CurrModule/Flair[ArgLabels]/NotRecommended: ['(']{#Int#}[')'][' async'][#Void#]; name={{$}}
+// CLOSURE_CALL: End completions
+}


### PR DESCRIPTION
Cherry-pick #59490 into `release/5.7`

* **Explanation**: Generating diagnostics for "not recommended" items requires an associated declaration. However, there are cases such as function call pattern items where there's no associated decl because the callee is an expression. Ideally it should emit a diagnostic, but for now, to avoid the crash, don't emit diagnostics unless the item has the associated decl.
* **Scope**: Code completion
* **Risk**: Low. Just adding a nullptr check
* **Issues**: rdar://95306033
* **Testing**: Added a regression test case
* **Reviewer**: Ben Barham (@bnbarham)