### PR TITLE
[cxx-interop] Remove "enable-cxx-interop" flag again.

### DIFF
--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -75,7 +75,7 @@ function(add_swift_compiler_modules_library name)
 
   set(swift_compile_options
       "-Xfrontend" "-validate-tbd-against-ir=none"
-      "-Xfrontend" "-enable-cxx-interop"
+      "-Xfrontend" "-enable-experimental-cxx-interop"
       "-Xcc" "-UIBOutlet" "-Xcc" "-UIBAction" "-Xcc" "-UIBInspectable")
 
   if(CMAKE_BUILD_TYPE STREQUAL Debug)

--- a/SwiftCompilerSources/Package.swift
+++ b/SwiftCompilerSources/Package.swift
@@ -17,7 +17,7 @@ private extension Target {
   static let defaultSwiftSettings: [SwiftSetting] = [
     .unsafeFlags([
       "-Xfrontend", "-validate-tbd-against-ir=none",
-      "-Xfrontend", "-enable-cxx-interop",
+      "-Xfrontend", "-enable-experimental-cxx-interop",
       // Bridging modules and headers
       "-Xcc", "-I", "-Xcc", "../include",
       "-cross-module-optimization"

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -831,11 +831,6 @@ def emit_sorted_sil : Flag<["-"], "emit-sorted-sil">,
 def emit_syntax : Flag<["-"], "emit-syntax">,
   HelpText<"Parse input file(s) and emit the Syntax tree(s) as JSON">, ModeOpt;
 
-def enable_cxx_interop :
-  Flag<["-"], "enable-cxx-interop">,
-  HelpText<"Alias for -enable-experimental-cxx-interop">,
-  Flags<[FrontendOption, HelpHidden]>;
-
 def cxx_interop_getters_setters_as_properties :
   Flag<["-"], "cxx-interop-getters-setters-as-properties">,
   HelpText<"Import getters and setters as computed properties in Swift">,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -807,8 +807,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     Opts.ClangTarget = llvm::Triple(A->getValue());
   }
 
-  Opts.EnableCXXInterop |= Args.hasArg(OPT_enable_experimental_cxx_interop) ||
-                           Args.hasArg(OPT_enable_cxx_interop);
+  Opts.EnableCXXInterop |= Args.hasArg(OPT_enable_experimental_cxx_interop);
   Opts.EnableObjCInterop =
       Args.hasFlag(OPT_enable_objc_interop, OPT_disable_objc_interop,
                    Target.isOSDarwin());


### PR DESCRIPTION
This is my second attempt to do this after it was reverted here: https://github.com/apple/swift/pull/42279