### PR TITLE
[ClangImporter] NFC: extract Swift decl synthesis logic into a separate file

### DIFF
--- a/lib/ClangImporter/CMakeLists.txt
+++ b/lib/ClangImporter/CMakeLists.txt
@@ -13,6 +13,7 @@ add_swift_host_library(swiftClangImporter STATIC
   ClangImporterRequests.cpp
   ClangModuleDependencyScanner.cpp
   ClangSourceBufferImporter.cpp
+  SwiftDeclSynthesizer.cpp
   DWARFImporter.cpp
   ImportDecl.cpp
   ImportEnumInfo.cpp

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -16,9 +16,8 @@
 
 #include "CFTypeInfo.h"
 #include "ImporterImpl.h"
+#include "SwiftDeclSynthesizer.h"
 #include "swift/AST/ASTContext.h"
-#include "swift/AST/ASTDemangler.h"
-#include "swift/AST/ASTMangler.h"
 #include "swift/AST/Attr.h"
 #include "swift/AST/Builtins.h"
 #include "swift/AST/ClangModuleLoader.h"
@@ -35,7 +34,6 @@
 #include "swift/AST/Pattern.h"
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/ProtocolConformance.h"
-#include "swift/AST/SemanticAttrs.h"
 #include "swift/AST/Stmt.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/Types.h"
@@ -46,7 +44,6 @@
 #include "swift/ClangImporter/CXXMethodBridging.h"
 #include "swift/ClangImporter/ClangImporterRequests.h"
 #include "swift/ClangImporter/ClangModule.h"
-#include "swift/Config.h"
 #include "swift/Parse/Lexer.h"
 #include "swift/Parse/Parser.h"
 #include "swift/Strings.h"
@@ -92,133 +89,10 @@ struct AccessorInfo {
   AccessorKind Kind;
 };
 
-enum class MakeStructRawValuedFlags {
-  /// whether to also create an unlabeled init
-  MakeUnlabeledValueInit = 0x01,
-
-  /// whether the raw value should be a let
-  IsLet = 0x02,
-
-  /// whether to mark the rawValue as implicit
-  IsImplicit = 0x04,
-};
-using MakeStructRawValuedOptions = OptionSet<MakeStructRawValuedFlags>;
 } // end anonymous namespace
-
-static MakeStructRawValuedOptions
-getDefaultMakeStructRawValuedOptions() {
-  MakeStructRawValuedOptions opts;
-  opts -= MakeStructRawValuedFlags::MakeUnlabeledValueInit; // default off
-  opts |= MakeStructRawValuedFlags::IsLet;                  // default on
-  opts |= MakeStructRawValuedFlags::IsImplicit;             // default on
-  return opts;
-}
 
 static bool isInSystemModule(const DeclContext *D) {
   return cast<ClangModuleUnit>(D->getModuleScopeContext())->isSystemModule();
-}
-
-static AccessLevel getOverridableAccessLevel(const DeclContext *dc) {
-  return (dc->getSelfClassDecl() ? AccessLevel::Open : AccessLevel::Public);
-}
-
-/// Create a typedpattern(namedpattern(decl))
-static Pattern *createTypedNamedPattern(VarDecl *decl) {
-  ASTContext &Ctx = decl->getASTContext();
-  Type ty = decl->getType();
-
-  Pattern *P = new (Ctx) NamedPattern(decl);
-  P->setType(ty);
-  P->setImplicit();
-  return TypedPattern::createImplicit(Ctx, P, ty);
-}
-
-static Expr *createSelfExpr(AccessorDecl *accessorDecl) {
-  ASTContext &ctx = accessorDecl->getASTContext();
-
-  auto selfDecl = accessorDecl->getImplicitSelfDecl();
-  auto selfRefExpr = new (ctx) DeclRefExpr(selfDecl, DeclNameLoc(),
-                                           /*implicit*/ true);
-
-  if (!accessorDecl->isMutating()) {
-    selfRefExpr->setType(selfDecl->getInterfaceType());
-    return selfRefExpr;
-  }
-  selfRefExpr->setType(LValueType::get(selfDecl->getInterfaceType()));
-
-  auto inoutSelfExpr = new (ctx) InOutExpr(
-      SourceLoc(), selfRefExpr,
-      accessorDecl->mapTypeIntoContext(selfDecl->getValueInterfaceType()),
-      /*isImplicit*/ true);
-  inoutSelfExpr->setType(InOutType::get(selfDecl->getInterfaceType()));
-  return inoutSelfExpr;
-}
-
-static CallExpr *createAccessorImplCallExpr(FuncDecl *accessorImpl,
-                                            Expr *selfExpr,
-                                            DeclRefExpr *keyRefExpr = nullptr) {
-  ASTContext &ctx = accessorImpl->getASTContext();
-
-  auto accessorImplExpr =
-      new (ctx) DeclRefExpr(ConcreteDeclRef(accessorImpl), DeclNameLoc(),
-                            /*Implicit=*/true);
-  accessorImplExpr->setType(accessorImpl->getInterfaceType());
-
-  auto accessorImplDotCallExpr =
-      DotSyntaxCallExpr::create(ctx, accessorImplExpr, SourceLoc(), selfExpr);
-  accessorImplDotCallExpr->setType(accessorImpl->getMethodInterfaceType());
-  accessorImplDotCallExpr->setThrows(false);
-
-  ArgumentList *argList;
-  if (keyRefExpr) {
-    argList = ArgumentList::forImplicitUnlabeled(ctx, {keyRefExpr});
-  } else {
-    argList = ArgumentList::forImplicitUnlabeled(ctx, {});
-  }
-  auto *accessorImplCallExpr =
-      CallExpr::createImplicit(ctx, accessorImplDotCallExpr, argList);
-  accessorImplCallExpr->setType(accessorImpl->getResultInterfaceType());
-  accessorImplCallExpr->setThrows(false);
-  return accessorImplCallExpr;
-}
-
-static DeclRefExpr *createParamRefExpr(AccessorDecl *accessorDecl,
-                                       unsigned index) {
-  ASTContext &ctx = accessorDecl->getASTContext();
-
-  auto paramDecl = accessorDecl->getParameters()->get(index);
-  auto paramRefExpr = new (ctx) DeclRefExpr(paramDecl, DeclNameLoc(),
-                                            /*Implicit=*/true);
-  paramRefExpr->setType(paramDecl->getType());
-  return paramRefExpr;
-}
-
-/// Create a var member for this struct, along with its pattern binding, and add
-/// it as a member
-static std::pair<VarDecl *, PatternBindingDecl *>
-createVarWithPattern(ASTContext &ctx, DeclContext *dc, Identifier name, Type ty,
-                     VarDecl::Introducer introducer, bool isImplicit, AccessLevel access,
-                     AccessLevel setterAccess) {
-  // Create a variable to store the underlying value.
-  auto var = new (ctx) VarDecl(
-      /*IsStatic*/false, introducer,
-      SourceLoc(), name, dc);
-  if (isImplicit)
-    var->setImplicit();
-  var->setInterfaceType(ty);
-  var->setAccess(access);
-  var->setSetterAccess(setterAccess);
-
-  // Create a pattern binding to describe the variable.
-  Pattern *varPattern = createTypedNamedPattern(var);
-  auto *patternBinding = PatternBindingDecl::create(
-      ctx, /*StaticLoc*/ SourceLoc(), StaticSpellingKind::None,
-      /*VarLoc*/ SourceLoc(), varPattern, /*EqualLoc*/ SourceLoc(),
-      /*InitExpr*/ nullptr, dc);
-  if (isImplicit)
-    patternBinding->setImplicit();
-
-  return {var, patternBinding};
 }
 
 static FuncDecl *createFuncOrAccessor(ClangImporter::Implementation &impl,
@@ -249,8 +123,9 @@ static FuncDecl *createFuncOrAccessor(ClangImporter::Implementation &impl,
   return decl;
 }
 
-static void makeComputed(AbstractStorageDecl *storage,
-                         AccessorDecl *getter, AccessorDecl *setter) {
+void ClangImporter::Implementation::makeComputed(AbstractStorageDecl *storage,
+                                                 AccessorDecl *getter,
+                                                 AccessorDecl *setter) {
   assert(getter);
   if (setter) {
     storage->setImplInfo(StorageImplInfo::getMutableComputed());
@@ -536,1031 +411,12 @@ static bool isNSDictionaryMethod(const clang::ObjCMethodDecl *MD,
   return true;
 }
 
-/// Synthesize the body of \c init?(rawValue:RawType) for an imported enum.
-static std::pair<BraceStmt *, bool>
-synthesizeEnumRawValueConstructorBody(AbstractFunctionDecl *afd,
-                                      void *context) {
-  ASTContext &ctx = afd->getASTContext();
-  auto ctorDecl = cast<ConstructorDecl>(afd);
-  auto enumDecl = static_cast<EnumDecl *>(context);
-  auto selfDecl = ctorDecl->getImplicitSelfDecl();
-  auto selfRef = new (ctx) DeclRefExpr(selfDecl, DeclNameLoc(),
-  /*implicit*/true);
-  selfRef->setType(LValueType::get(selfDecl->getType()));
-
-  auto param = ctorDecl->getParameters()->get(0);
-  auto paramRef = new (ctx) DeclRefExpr(param, DeclNameLoc(),
-                                        /*implicit*/ true);
-  paramRef->setType(param->getType());
-
-  auto reinterpretCast
-    = cast<FuncDecl>(
-        getBuiltinValueDecl(ctx, ctx.getIdentifier("reinterpretCast")));
-  auto rawTy = enumDecl->getRawType();
-  auto enumTy = enumDecl->getDeclaredInterfaceType();
-  SubstitutionMap subMap =
-    SubstitutionMap::get(reinterpretCast->getGenericSignature(),
-                         { rawTy, enumTy }, { });
-  ConcreteDeclRef concreteDeclRef(reinterpretCast, subMap);
-  auto reinterpretCastRef
-    = new (ctx) DeclRefExpr(concreteDeclRef, DeclNameLoc(), /*implicit*/ true);
-  // FIXME: Verify ExtInfo state is correct, not working by accident.
-  FunctionType::ExtInfo info;
-  reinterpretCastRef->setType(
-      FunctionType::get({FunctionType::Param(rawTy)}, enumTy, info));
-
-  auto *argList = ArgumentList::forImplicitUnlabeled(ctx, {paramRef});
-  auto reinterpreted = CallExpr::createImplicit(ctx, reinterpretCastRef,
-                                                argList);
-  reinterpreted->setType(enumTy);
-  reinterpreted->setThrows(false);
-
-  auto assign = new (ctx) AssignExpr(selfRef, SourceLoc(), reinterpreted,
-                                     /*implicit*/ true);
-  assign->setType(TupleType::getEmpty(ctx));
-
-  auto ret = new (ctx) ReturnStmt(SourceLoc(), nullptr, /*Implicit=*/true);
-
-  auto body = BraceStmt::create(ctx, SourceLoc(), {assign, ret}, SourceLoc(),
-                                /*implicit*/ true);
-  return { body, /*isTypeChecked=*/true };
-}
-
-// Build the init(rawValue:) initializer for an imported NS_ENUM.
-//   enum NSSomeEnum: RawType {
-//     init?(rawValue: RawType) {
-//       self = Builtin.reinterpretCast(rawValue)
-//     }
-//   }
-// Unlike a standard init(rawValue:) enum initializer, this does a reinterpret
-// cast in order to preserve unknown or future cases from C.
-static ConstructorDecl *
-makeEnumRawValueConstructor(ClangImporter::Implementation &Impl,
-                            EnumDecl *enumDecl) {
-  ASTContext &C = Impl.SwiftContext;
-  auto rawTy = enumDecl->getRawType();
-
-  auto param = new (C) ParamDecl(SourceLoc(),
-                                 SourceLoc(), C.Id_rawValue,
-                                 SourceLoc(), C.Id_rawValue,
-                                 enumDecl);
-  param->setSpecifier(ParamSpecifier::Default);
-  param->setInterfaceType(rawTy);
-
-  auto paramPL = ParameterList::createWithoutLoc(param);
-
-  DeclName name(C, DeclBaseName::createConstructor(), paramPL);
-  auto *ctorDecl =
-    new (C) ConstructorDecl(name, enumDecl->getLoc(),
-                            /*Failable=*/true, /*FailabilityLoc=*/SourceLoc(),
-                            /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
-                            /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(),
-                            paramPL,
-                            /*GenericParams=*/nullptr, enumDecl);
-  ctorDecl->setImplicit();
-  ctorDecl->setAccess(AccessLevel::Public);
-  ctorDecl->setBodySynthesizer(synthesizeEnumRawValueConstructorBody, enumDecl);
-  return ctorDecl;
-}
-
-/// Synthesizer callback for an enum's rawValue getter.
-static std::pair<BraceStmt *, bool>
-synthesizeEnumRawValueGetterBody(AbstractFunctionDecl *afd, void *context) {
-  auto getterDecl = cast<AccessorDecl>(afd);
-  auto enumDecl = static_cast<EnumDecl *>(context);
-  auto rawTy = enumDecl->getRawType();
-  auto enumTy = enumDecl->getDeclaredInterfaceType();
-
-  ASTContext &ctx = getterDecl->getASTContext();
-  auto *selfDecl = getterDecl->getImplicitSelfDecl();
-  auto selfRef = new (ctx) DeclRefExpr(selfDecl, DeclNameLoc(),
-                                       /*implicit*/true);
-  selfRef->setType(selfDecl->getType());
-
-  auto reinterpretCast
-    = cast<FuncDecl>(
-        getBuiltinValueDecl(ctx, ctx.getIdentifier("reinterpretCast")));
-  SubstitutionMap subMap =
-    SubstitutionMap::get(reinterpretCast->getGenericSignature(),
-                         { enumTy, rawTy }, { });
-  ConcreteDeclRef concreteDeclRef(reinterpretCast, subMap);
-
-  auto reinterpretCastRef
-    = new (ctx) DeclRefExpr(concreteDeclRef, DeclNameLoc(), /*implicit*/ true);
-  // FIXME: Verify ExtInfo state is correct, not working by accident.
-  FunctionType::ExtInfo info;
-  reinterpretCastRef->setType(
-      FunctionType::get({FunctionType::Param(enumTy)}, rawTy, info));
-
-  auto *argList = ArgumentList::forImplicitUnlabeled(ctx, {selfRef});
-  auto reinterpreted = CallExpr::createImplicit(ctx, reinterpretCastRef,
-                                                argList);
-  reinterpreted->setType(rawTy);
-  reinterpreted->setThrows(false);
-
-  auto ret = new (ctx) ReturnStmt(SourceLoc(), reinterpreted);
-  auto body = BraceStmt::create(ctx, SourceLoc(), ASTNode(ret), SourceLoc(),
-                                /*implicit*/ true);
-  return { body, /*isTypeChecked=*/true };
-}
-
-// Build the rawValue getter for an imported NS_ENUM.
-//   enum NSSomeEnum: RawType {
-//     var rawValue: RawType {
-//       return Builtin.reinterpretCast(self)
-//     }
-//   }
-// Unlike a standard init(rawValue:) enum initializer, this does a reinterpret
-// cast in order to preserve unknown or future cases from C.
-static void makeEnumRawValueGetter(ClangImporter::Implementation &Impl,
-                                   EnumDecl *enumDecl,
-                                   VarDecl *rawValueDecl) {
-  ASTContext &C = Impl.SwiftContext;
-
-  auto rawTy = enumDecl->getRawType();
-
-  auto *params = ParameterList::createEmpty(C);
-
-  auto getterDecl = AccessorDecl::create(C,
-                     /*FuncLoc=*/SourceLoc(),
-                     /*AccessorKeywordLoc=*/SourceLoc(),
-                     AccessorKind::Get,
-                     rawValueDecl,
-                     /*StaticLoc=*/SourceLoc(),
-                     StaticSpellingKind::None,
-                     /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
-                     /*Throws=*/false,
-                     /*ThrowsLoc=*/SourceLoc(),
-                     /*GenericParams=*/nullptr, params,
-                     rawTy, enumDecl);
-  getterDecl->setImplicit();
-  getterDecl->setIsObjC(false);
-  getterDecl->setIsDynamic(false);
-  getterDecl->setIsTransparent(false);
-
-  getterDecl->setAccess(AccessLevel::Public);
-  getterDecl->setBodySynthesizer(synthesizeEnumRawValueGetterBody, enumDecl);
-  makeComputed(rawValueDecl, getterDecl, nullptr);
-}
-
-/// Synthesizer for the rawValue getter for an imported struct.
-static std::pair<BraceStmt *, bool>
-synthesizeStructRawValueGetterBody(AbstractFunctionDecl *afd, void *context) {
-  auto getterDecl = cast<AccessorDecl>(afd);
-  VarDecl *storedVar = static_cast<VarDecl *>(context);
-
-  ASTContext &ctx = getterDecl->getASTContext();
-  auto *selfDecl = getterDecl->getImplicitSelfDecl();
-  auto selfRef = new (ctx) DeclRefExpr(selfDecl, DeclNameLoc(),
-                                       /*implicit*/true);
-  selfRef->setType(selfDecl->getType());
-
-  auto storedType = storedVar->getInterfaceType();
-  auto storedRef = new (ctx) MemberRefExpr(selfRef, SourceLoc(), storedVar,
-                                           DeclNameLoc(), /*Implicit=*/true,
-                                           AccessSemantics::DirectToStorage);
-  storedRef->setType(storedType);
-
-  Expr *result = storedRef;
-
-  Type computedType = getterDecl->getResultInterfaceType();
-  if (!computedType->isEqual(storedType)) {
-    auto bridge = new (ctx) BridgeFromObjCExpr(storedRef, computedType);
-    bridge->setType(computedType);
-
-    result = CoerceExpr::createImplicit(ctx, bridge, computedType);
-  }
-
-  auto ret = new (ctx) ReturnStmt(SourceLoc(), result);
-  auto body = BraceStmt::create(ctx, SourceLoc(), ASTNode(ret), SourceLoc(),
-                                /*implicit*/ true);
-  return { body, /*isTypeChecked=*/true };
-}
-
-// Build the rawValue getter for a struct type.
-//
-//   struct SomeType: RawRepresentable {
-//     private var _rawValue: ObjCType
-//     var rawValue: SwiftType {
-//       return _rawValue as SwiftType
-//     }
-//   }
-static AccessorDecl *makeStructRawValueGetter(
-                   ClangImporter::Implementation &Impl,
-                   StructDecl *structDecl,
-                   VarDecl *computedVar,
-                   VarDecl *storedVar) {
-  assert(storedVar->hasStorage());
-
-  ASTContext &C = Impl.SwiftContext;
-
-  auto *params = ParameterList::createEmpty(C);
-
-  auto computedType = computedVar->getInterfaceType();
-
-  auto getterDecl = AccessorDecl::create(C,
-                     /*FuncLoc=*/SourceLoc(),
-                     /*AccessorKeywordLoc=*/SourceLoc(),
-                     AccessorKind::Get,
-                     computedVar,
-                     /*StaticLoc=*/SourceLoc(),
-                     StaticSpellingKind::None,
-                     /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
-                     /*Throws=*/false,
-                     /*ThrowsLoc=*/SourceLoc(),
-                     /*GenericParams=*/nullptr, params,
-                     computedType, structDecl);
-  getterDecl->setImplicit();
-  getterDecl->setIsObjC(false);
-  getterDecl->setIsDynamic(false);
-  getterDecl->setIsTransparent(false);
-
-  getterDecl->setAccess(AccessLevel::Public);
-  getterDecl->setBodySynthesizer(synthesizeStructRawValueGetterBody, storedVar);
-  return getterDecl;
-}
-
-static AccessorDecl *makeFieldGetterDecl(ClangImporter::Implementation &Impl,
-                                         NominalTypeDecl *importedDecl,
-                                         VarDecl *importedFieldDecl,
-                                         ClangNode clangNode = ClangNode()) {
-  auto &C = Impl.SwiftContext;
-
-  auto *params = ParameterList::createEmpty(C);
-
-  auto getterType = importedFieldDecl->getInterfaceType();
-  auto getterDecl = AccessorDecl::create(C,
-                     /*FuncLoc=*/importedFieldDecl->getLoc(),
-                     /*AccessorKeywordLoc=*/SourceLoc(),
-                     AccessorKind::Get,
-                     importedFieldDecl,
-                     /*StaticLoc=*/SourceLoc(),
-                     StaticSpellingKind::None,
-                     /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
-                     /*Throws=*/false,
-                     /*ThrowsLoc=*/SourceLoc(),
-                     /*GenericParams=*/nullptr, params,
-                     getterType, importedDecl, clangNode);
-  getterDecl->setAccess(AccessLevel::Public);
-  getterDecl->setIsObjC(false);
-  getterDecl->setIsDynamic(false);
-
-  return getterDecl;
-}
-
-static AccessorDecl *makeFieldSetterDecl(ClangImporter::Implementation &Impl,
-                                         NominalTypeDecl *importedDecl,
-                                         VarDecl *importedFieldDecl,
-                                         ClangNode clangNode = ClangNode()) {
-  auto &C = Impl.SwiftContext;
-  auto newValueDecl = new (C) ParamDecl(SourceLoc(), SourceLoc(),
-                                        Identifier(), SourceLoc(), C.Id_value,
-                                        importedDecl);
-  newValueDecl->setSpecifier(ParamSpecifier::Default);
-  newValueDecl->setInterfaceType(importedFieldDecl->getInterfaceType());
-
-  auto *params = ParameterList::createWithoutLoc(newValueDecl);
-
-  auto voidTy = TupleType::getEmpty(C);
-
-  auto setterDecl = AccessorDecl::create(C,
-                     /*FuncLoc=*/SourceLoc(),
-                     /*AccessorKeywordLoc=*/SourceLoc(),
-                     AccessorKind::Set,
-                     importedFieldDecl,
-                     /*StaticLoc=*/SourceLoc(),
-                     StaticSpellingKind::None,
-                     /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
-                     /*Throws=*/false,
-                     /*ThrowsLoc=*/SourceLoc(),
-                     /*GenericParams=*/nullptr, params,
-                     voidTy, importedDecl, clangNode);
-  setterDecl->setIsObjC(false);
-  setterDecl->setIsDynamic(false);
-  setterDecl->setSelfAccessKind(SelfAccessKind::Mutating);
-  setterDecl->setAccess(AccessLevel::Public);
-
-  return setterDecl;
-}
-
-/// Find the anonymous inner field declaration for the given anonymous field.
-static VarDecl *findAnonymousInnerFieldDecl(VarDecl *importedFieldDecl,
-                                            VarDecl *anonymousFieldDecl) {
-  auto anonymousFieldType = anonymousFieldDecl->getInterfaceType();
-  auto anonymousFieldTypeDecl
-      = anonymousFieldType->getStructOrBoundGenericStruct();
-
-  for (auto decl : anonymousFieldTypeDecl->lookupDirect(
-                       importedFieldDecl->getName())) {
-    if (isa<VarDecl>(decl)) {
-      return cast<VarDecl>(decl);
-    }
-  }
-
-  llvm_unreachable("couldn't find anonymous inner field decl");
-}
-
-/// Synthesize the getter body for an indirect field.
-static std::pair<BraceStmt *, bool>
-synthesizeIndirectFieldGetterBody(AbstractFunctionDecl *afd, void *context) {
-  auto getterDecl = cast<AccessorDecl>(afd);
-  auto anonymousFieldDecl = static_cast<VarDecl *>(context);
-
-  ASTContext &ctx = getterDecl->getASTContext();
-  auto selfDecl = getterDecl->getImplicitSelfDecl();
-  Expr *expr = new (ctx) DeclRefExpr(selfDecl, DeclNameLoc(),
-                                     /*implicit*/true);
-  expr->setType(selfDecl->getInterfaceType());
-
-  expr = new (ctx) MemberRefExpr(expr, SourceLoc(), anonymousFieldDecl,
-                                 DeclNameLoc(), /*implicit*/true);
-  expr->setType(anonymousFieldDecl->getInterfaceType());
-
-  auto importedFieldDecl = cast<VarDecl>(getterDecl->getStorage());
-  auto anonymousInnerFieldDecl =
-      findAnonymousInnerFieldDecl(importedFieldDecl, anonymousFieldDecl);
-  expr = new (ctx) MemberRefExpr(expr, SourceLoc(), anonymousInnerFieldDecl,
-                                 DeclNameLoc(), /*implicit*/true);
-  expr->setType(anonymousInnerFieldDecl->getInterfaceType());
-
-  auto ret = new (ctx) ReturnStmt(SourceLoc(), expr);
-  auto body = BraceStmt::create(ctx, SourceLoc(), ASTNode(ret), SourceLoc(),
-                                /*implicit*/ true);
-  return { body, /*isTypeChecked=*/true };
-}
-
-/// Synthesize the setter body for an indirect field.
-static std::pair<BraceStmt *, bool>
-synthesizeIndirectFieldSetterBody(AbstractFunctionDecl *afd, void *context) {
-  auto setterDecl = cast<AccessorDecl>(afd);
-  auto anonymousFieldDecl = static_cast<VarDecl *>(context);
-
-  ASTContext &ctx = setterDecl->getASTContext();
-  auto selfDecl = setterDecl->getImplicitSelfDecl();
-  Expr *lhs = new (ctx) DeclRefExpr(selfDecl, DeclNameLoc(),
-                                   /*implicit*/true);
-  lhs->setType(LValueType::get(selfDecl->getInterfaceType()));
-
-  lhs = new (ctx) MemberRefExpr(lhs, SourceLoc(), anonymousFieldDecl,
-                                DeclNameLoc(), /*implicit*/true);
-  lhs->setType(LValueType::get(anonymousFieldDecl->getInterfaceType()));
-
-  auto importedFieldDecl = cast<VarDecl>(setterDecl->getStorage());
-  auto anonymousInnerFieldDecl =
-      findAnonymousInnerFieldDecl(importedFieldDecl, anonymousFieldDecl);
-
-  lhs = new (ctx) MemberRefExpr(lhs, SourceLoc(), anonymousInnerFieldDecl,
-                                DeclNameLoc(), /*implicit*/true);
-  lhs->setType(LValueType::get(anonymousInnerFieldDecl->getInterfaceType()));
-
-  auto newValueDecl = setterDecl->getParameters()->get(0);
-
-  auto rhs = new (ctx) DeclRefExpr(newValueDecl, DeclNameLoc(),
-                                  /*implicit*/ true);
-  rhs->setType(newValueDecl->getInterfaceType());
-
-  auto assign = new (ctx) AssignExpr(lhs, SourceLoc(), rhs, /*implicit*/true);
-  assign->setType(TupleType::getEmpty(ctx));
-
-  auto body = BraceStmt::create(ctx, SourceLoc(), { assign }, SourceLoc(),
-                                /*implicit*/ true);
-  return { body, /*isTypeChecked=*/true };
-}
-
-/// Build the indirect field getter and setter.
-///
-/// \code
-/// struct SomeImportedIndirectField {
-///   struct __Unnamed_struct___Anonymous_field_1 {
-///     var myField : Int
-///   }
-///   var __Anonymous_field_1 : __Unnamed_struct___Anonymous_field_1
-///   var myField : Int {
-///     get {
-///       __Anonymous_field_1.myField
-///     }
-///     set(newValue) {
-///       __Anonymous_field_1.myField = newValue
-///     }
-///   }
-/// }
-/// \endcode
-///
-/// \returns a pair of getter and setter function decls.
-static std::pair<AccessorDecl *, AccessorDecl *>
-makeIndirectFieldAccessors(ClangImporter::Implementation &Impl,
-                           const clang::IndirectFieldDecl *indirectField,
-                           ArrayRef<VarDecl *> members,
-                           NominalTypeDecl *importedStructDecl,
-                           VarDecl *importedFieldDecl) {
-  auto &C = Impl.SwiftContext;
-
-  auto getterDecl = makeFieldGetterDecl(Impl,
-                                        importedStructDecl,
-                                        importedFieldDecl);
-  getterDecl->getAttrs().add(new (C) TransparentAttr(/*implicit*/ true));
-
-  auto setterDecl = makeFieldSetterDecl(Impl,
-                                        importedStructDecl,
-                                        importedFieldDecl);
-  setterDecl->getAttrs().add(new (C) TransparentAttr(/*implicit*/ true));
-
-  makeComputed(importedFieldDecl, getterDecl, setterDecl);
-
-  auto containingField = indirectField->chain().front();
-  VarDecl *anonymousFieldDecl = nullptr;
-
-  // Reverse scan of the members because indirect field are generated just
-  // after the corresponding anonymous type, so a reverse scan allows
-  // switching from O(n) to O(1) here.
-  for (auto decl : reverse(members)) {
-    if (decl->getClangDecl() == containingField) {
-      anonymousFieldDecl = cast<VarDecl>(decl);
-      break;
-    }
-  }
-  assert (anonymousFieldDecl && "anonymous field not generated");
-  getterDecl->setBodySynthesizer(synthesizeIndirectFieldGetterBody,
-                                 anonymousFieldDecl);
-  setterDecl->setBodySynthesizer(synthesizeIndirectFieldSetterBody,
-                                 anonymousFieldDecl);
-
-  return { getterDecl, setterDecl };
-}
-
-/// Synthesizer for the body of a union field getter.
-static std::pair<BraceStmt *, bool>
-synthesizeUnionFieldGetterBody(AbstractFunctionDecl *afd, void *context) {
-  auto getterDecl = cast<AccessorDecl>(afd);
-  ASTContext &ctx = getterDecl->getASTContext();
-  auto importedFieldDecl = static_cast<VarDecl *>(context);
-
-  auto selfDecl = getterDecl->getImplicitSelfDecl();
-
-  auto selfRef = new (ctx) DeclRefExpr(selfDecl, DeclNameLoc(),
-                                       /*implicit*/ true);
-  selfRef->setType(selfDecl->getInterfaceType());
-
-  auto reinterpretCast = cast<FuncDecl>(getBuiltinValueDecl(
-      ctx, ctx.getIdentifier("reinterpretCast")));
-
-  ConcreteDeclRef reinterpretCastRef(
-    reinterpretCast,
-    SubstitutionMap::get(reinterpretCast->getGenericSignature(),
-                         {selfDecl->getInterfaceType(),
-                          importedFieldDecl->getInterfaceType()},
-                         ArrayRef<ProtocolConformanceRef>()));
-  auto reinterpretCastRefExpr
-    = new (ctx) DeclRefExpr(reinterpretCastRef, DeclNameLoc(),
-                          /*implicit*/ true);
-  // FIXME: Verify ExtInfo state is correct, not working by accident.
-  FunctionType::ExtInfo info;
-  reinterpretCastRefExpr->setType(
-      FunctionType::get(AnyFunctionType::Param(selfDecl->getInterfaceType()),
-                        importedFieldDecl->getInterfaceType(), info));
-
-  auto *argList = ArgumentList::forImplicitUnlabeled(ctx, {selfRef});
-  auto reinterpreted = CallExpr::createImplicit(ctx, reinterpretCastRefExpr,
-                                                argList);
-  reinterpreted->setType(importedFieldDecl->getInterfaceType());
-  reinterpreted->setThrows(false);
-  auto ret = new (ctx) ReturnStmt(SourceLoc(), reinterpreted);
-  auto body = BraceStmt::create(ctx, SourceLoc(), ASTNode(ret), SourceLoc(),
-                                /*implicit*/ true);
-  return { body, /*isTypeChecked=*/true };
-}
-
-/// Synthesizer for the body of a union field setter.
-static std::pair<BraceStmt *, bool>
-synthesizeUnionFieldSetterBody(AbstractFunctionDecl *afd, void *context) {
-  auto setterDecl = cast<AccessorDecl>(afd);
-  ASTContext &ctx = setterDecl->getASTContext();
-
-  auto inoutSelfDecl = setterDecl->getImplicitSelfDecl();
-
-  auto inoutSelfRef = new (ctx) DeclRefExpr(inoutSelfDecl, DeclNameLoc(),
-                                            /*implicit*/ true);
-  inoutSelfRef->setType(LValueType::get(inoutSelfDecl->getInterfaceType()));
-  auto inoutSelf = new (ctx) InOutExpr(SourceLoc(), inoutSelfRef,
-      setterDecl->mapTypeIntoContext(inoutSelfDecl->getValueInterfaceType()),
-      /*implicit*/ true);
-  inoutSelf->setType(InOutType::get(inoutSelfDecl->getInterfaceType()));
-
-  auto newValueDecl = setterDecl->getParameters()->get(0);
-
-  auto newValueRef = new (ctx) DeclRefExpr(newValueDecl, DeclNameLoc(),
-                                           /*implicit*/ true);
-  newValueRef->setType(newValueDecl->getInterfaceType());
-
-  auto addressofFn = cast<FuncDecl>(getBuiltinValueDecl(
-    ctx, ctx.getIdentifier("addressof")));
-  ConcreteDeclRef addressofFnRef(addressofFn,
-      SubstitutionMap::get(addressofFn->getGenericSignature(),
-                           {inoutSelfDecl->getInterfaceType()},
-                           ArrayRef<ProtocolConformanceRef>()));
-  auto addressofFnRefExpr
-    = new (ctx) DeclRefExpr(addressofFnRef, DeclNameLoc(), /*implicit*/ true);
-  // FIXME: Verify ExtInfo state is correct, not working by accident.
-  FunctionType::ExtInfo addressOfInfo;
-  addressofFnRefExpr->setType(FunctionType::get(
-      AnyFunctionType::Param(inoutSelfDecl->getInterfaceType(), Identifier(),
-                             ParameterTypeFlags().withInOut(true)),
-      ctx.TheRawPointerType, addressOfInfo));
-
-  auto *selfPtrArgs = ArgumentList::forImplicitUnlabeled(ctx, {inoutSelf});
-  auto selfPointer = CallExpr::createImplicit(ctx, addressofFnRefExpr,
-                                              selfPtrArgs);
-  selfPointer->setType(ctx.TheRawPointerType);
-  selfPointer->setThrows(false);
-
-  auto initializeFn = cast<FuncDecl>(getBuiltinValueDecl(
-    ctx, ctx.getIdentifier("initialize")));
-  ConcreteDeclRef initializeFnRef(initializeFn,
-      SubstitutionMap::get(initializeFn->getGenericSignature(),
-                           {newValueDecl->getInterfaceType()},
-                           ArrayRef<ProtocolConformanceRef>()));
-  auto initializeFnRefExpr
-    = new (ctx) DeclRefExpr(initializeFnRef, DeclNameLoc(), /*implicit*/ true);
-  // FIXME: Verify ExtInfo state is correct, not working by accident.
-  FunctionType::ExtInfo initializeInfo;
-  initializeFnRefExpr->setType(FunctionType::get(
-      {AnyFunctionType::Param(newValueDecl->getInterfaceType()),
-       AnyFunctionType::Param(ctx.TheRawPointerType)},
-      TupleType::getEmpty(ctx), initializeInfo));
-
-  auto *initArgs =
-      ArgumentList::forImplicitUnlabeled(ctx, {newValueRef, selfPointer});
-  auto initialize = CallExpr::createImplicit(ctx, initializeFnRefExpr,
-                                             initArgs);
-  initialize->setType(TupleType::getEmpty(ctx));
-  initialize->setThrows(false);
-
-  auto body = BraceStmt::create(ctx, SourceLoc(), { initialize }, SourceLoc(),
-                                /*implicit*/ true);
-  return { body, /*isTypeChecked=*/true };
-}
-
-/// Build the union field getter and setter.
-///
-/// \code
-/// struct SomeImportedUnion {
-///   var myField: Int {
-///     get {
-///       return Builtin.reinterpretCast(self)
-///     }
-///     set(newValue) {
-///       Builtin.initialize(Builtin.addressof(self), newValue))
-///     }
-///   }
-/// }
-/// \endcode
-///
-/// \returns a pair of the getter and setter function decls.
-static std::pair<AccessorDecl *, AccessorDecl *>
-makeUnionFieldAccessors(ClangImporter::Implementation &Impl,
-                        NominalTypeDecl *importedUnionDecl,
-                        VarDecl *importedFieldDecl) {
-  auto &C = Impl.SwiftContext;
-
-  auto getterDecl = makeFieldGetterDecl(Impl,
-                                        importedUnionDecl,
-                                        importedFieldDecl);
-  getterDecl->setBodySynthesizer(synthesizeUnionFieldGetterBody,
-                                 importedFieldDecl);
-  getterDecl->getAttrs().add(new (C) TransparentAttr(/*implicit*/ true));
-
-  auto setterDecl = makeFieldSetterDecl(Impl,
-                                        importedUnionDecl,
-                                        importedFieldDecl);
-  setterDecl->setBodySynthesizer(synthesizeUnionFieldSetterBody,
-                                 importedFieldDecl);
-  setterDecl->getAttrs().add(new (C) TransparentAttr(/*implicit*/ true));
-
-  makeComputed(importedFieldDecl, getterDecl, setterDecl);
-  return { getterDecl, setterDecl };
-}
-
-static clang::DeclarationName
-getAccessorDeclarationName(clang::ASTContext &Ctx,
-                           NominalTypeDecl *structDecl,
-                           VarDecl *fieldDecl,
-                           const char *suffix) {
-  std::string id;
-  llvm::raw_string_ostream IdStream(id);
-  Mangle::ASTMangler mangler;
-  IdStream << "$" << mangler.mangleDeclAsUSR(structDecl, "")
-           << "$" << fieldDecl->getName()
-           << "$" << suffix;
-
-  return clang::DeclarationName(&Ctx.Idents.get(IdStream.str()));
-}
-
-/// Build the bitfield getter and setter using Clang.
-///
-/// \code
-/// static inline int get(RecordType self) {
-///   return self.field;
-/// }
-/// static inline void set(int newValue, RecordType *self) {
-///   self->field = newValue;
-/// }
-/// \endcode
-///
-/// \returns a pair of the getter and setter function decls.
-static std::pair<FuncDecl *, FuncDecl *>
-makeBitFieldAccessors(ClangImporter::Implementation &Impl,
-                      clang::RecordDecl *structDecl,
-                      NominalTypeDecl *importedStructDecl,
-                      clang::FieldDecl *fieldDecl,
-                      VarDecl *importedFieldDecl) {
-  clang::ASTContext &Ctx = Impl.getClangASTContext();
-
-  // Getter: static inline FieldType get(RecordType self);
-  auto recordType = Ctx.getRecordType(structDecl);
-  auto recordPointerType = Ctx.getPointerType(recordType);
-  auto fieldType = fieldDecl->getType();
-
-  auto cGetterName = getAccessorDeclarationName(Ctx, importedStructDecl,
-                                                importedFieldDecl, "getter");
-  auto cGetterType = Ctx.getFunctionType(fieldDecl->getType(),
-                                         recordType,
-                                         clang::FunctionProtoType::ExtProtoInfo());
-  auto cGetterTypeInfo = Ctx.getTrivialTypeSourceInfo(cGetterType);
-  auto cGetterDecl = clang::FunctionDecl::Create(Ctx,
-                                                 structDecl->getDeclContext(),
-                                                 clang::SourceLocation(),
-                                                 clang::SourceLocation(),
-                                                 cGetterName,
-                                                 cGetterType,
-                                                 cGetterTypeInfo,
-                                                 clang::SC_Static);
-  cGetterDecl->setImplicitlyInline();
-  assert(!cGetterDecl->isExternallyVisible());
-
-  auto getterDecl = makeFieldGetterDecl(Impl,
-                                        importedStructDecl,
-                                        importedFieldDecl,
-                                        cGetterDecl);
-
-  // Setter: static inline void set(FieldType newValue, RecordType *self);
-  SmallVector<clang::QualType, 8> cSetterParamTypes;
-  cSetterParamTypes.push_back(fieldType);
-  cSetterParamTypes.push_back(recordPointerType);
-
-  auto cSetterName = getAccessorDeclarationName(Ctx, importedStructDecl,
-                                                importedFieldDecl, "setter");
-  auto cSetterType = Ctx.getFunctionType(Ctx.VoidTy,
-                                         cSetterParamTypes,
-                                         clang::FunctionProtoType::ExtProtoInfo());
-  auto cSetterTypeInfo = Ctx.getTrivialTypeSourceInfo(cSetterType);
-
-  auto cSetterDecl = clang::FunctionDecl::Create(Ctx,
-                                                 structDecl->getDeclContext(),
-                                                 clang::SourceLocation(),
-                                                 clang::SourceLocation(),
-                                                 cSetterName,
-                                                 cSetterType,
-                                                 cSetterTypeInfo,
-                                                 clang::SC_Static);
-  cSetterDecl->setImplicitlyInline();
-  assert(!cSetterDecl->isExternallyVisible());
-
-  auto setterDecl = makeFieldSetterDecl(Impl,
-                                        importedStructDecl,
-                                        importedFieldDecl,
-                                        cSetterDecl);
-
-  makeComputed(importedFieldDecl, getterDecl, setterDecl);
-
-  // Synthesize the getter body
-  {
-    auto cGetterSelfId = nullptr;
-    auto recordTypeInfo = Ctx.getTrivialTypeSourceInfo(recordType);
-    auto cGetterSelf = clang::ParmVarDecl::Create(Ctx, cGetterDecl,
-                                                  clang::SourceLocation(),
-                                                  clang::SourceLocation(),
-                                                  cGetterSelfId,
-                                                  recordType,
-                                                  recordTypeInfo,
-                                                  clang::SC_None,
-                                                  nullptr);
-    cGetterDecl->setParams(cGetterSelf);
-
-    auto cGetterSelfExpr = new (Ctx) clang::DeclRefExpr(Ctx, cGetterSelf, false,
-                                                        recordType,
-                                                        clang::VK_PRValue,
-                                                        clang::SourceLocation());
-    auto cGetterExpr = clang::MemberExpr::CreateImplicit(Ctx,
-                                                         cGetterSelfExpr,
-                                                         /*isarrow=*/ false,
-                                                         fieldDecl,
-                                                         fieldType,
-                                                         clang::VK_PRValue,
-                                                         clang::OK_BitField);
-
-
-    auto cGetterBody = clang::ReturnStmt::Create(Ctx, clang::SourceLocation(),
-                                                   cGetterExpr,
-                                                   nullptr);
-    cGetterDecl->setBody(cGetterBody);
-  }
-
-  // Synthesize the setter body
-  {
-    SmallVector<clang::ParmVarDecl *, 2> cSetterParams;
-    auto fieldTypeInfo = Ctx.getTrivialTypeSourceInfo(fieldType);
-    auto cSetterValue = clang::ParmVarDecl::Create(Ctx, cSetterDecl,
-                                                   clang::SourceLocation(),
-                                                   clang::SourceLocation(),
-                                                   /* nameID? */ nullptr,
-                                                   fieldType,
-                                                   fieldTypeInfo,
-                                                   clang::SC_None,
-                                                   nullptr);
-    cSetterParams.push_back(cSetterValue);
-    auto recordPointerTypeInfo = Ctx.getTrivialTypeSourceInfo(recordPointerType);
-    auto cSetterSelf = clang::ParmVarDecl::Create(Ctx, cSetterDecl,
-                                                  clang::SourceLocation(),
-                                                  clang::SourceLocation(),
-                                                  /* nameID? */ nullptr,
-                                                  recordPointerType,
-                                                  recordPointerTypeInfo,
-                                                  clang::SC_None,
-                                                  nullptr);
-    cSetterParams.push_back(cSetterSelf);
-    cSetterDecl->setParams(cSetterParams);
-
-    auto cSetterSelfExpr = new (Ctx) clang::DeclRefExpr(Ctx, cSetterSelf, false,
-                                                        recordPointerType,
-                                                        clang::VK_PRValue,
-                                                        clang::SourceLocation());
-
-    auto cSetterMemberExpr = clang::MemberExpr::CreateImplicit(Ctx,
-                                                               cSetterSelfExpr,
-                                                               /*isarrow=*/true,
-                                                               fieldDecl,
-                                                               fieldType,
-                                                               clang::VK_LValue,
-                                                               clang::OK_BitField);
-
-    auto cSetterValueExpr = new (Ctx) clang::DeclRefExpr(Ctx, cSetterValue, false,
-                                                         fieldType,
-                                                         clang::VK_PRValue,
-                                                         clang::SourceLocation());
-
-    auto cSetterExpr = clang::BinaryOperator::Create(Ctx,
-                                                     cSetterMemberExpr,
-                                                     cSetterValueExpr,
-                                                     clang::BO_Assign,
-                                                     fieldType,
-                                                     clang::VK_PRValue,
-                                                     clang::OK_Ordinary,
-                                                     clang::SourceLocation(),
-                                                     clang::FPOptionsOverride());
-
-    cSetterDecl->setBody(cSetterExpr);
-  }
-
-  return { getterDecl, setterDecl };
-}
-
-/// Synthesize the body for an struct default initializer.
-static std::pair<BraceStmt *, bool>
-synthesizeStructDefaultConstructorBody(AbstractFunctionDecl *afd,
-                                       void *context) {
-  auto constructor = cast<ConstructorDecl>(afd);
-  ASTContext &ctx = constructor->getASTContext();
-  auto structDecl = static_cast<StructDecl *>(context);
-
-  // We should call into C++ constructors directly.
-  assert(!isa<clang::CXXRecordDecl>(structDecl->getClangDecl()) &&
-         "Should not synthesize a C++ object constructor.");
-
-  // Use a builtin to produce a zero initializer, and assign it to self.
-
-  // Construct the left-hand reference to self.
-  auto *selfDecl = constructor->getImplicitSelfDecl();
-  Expr *lhs = new (ctx) DeclRefExpr(selfDecl, DeclNameLoc(), /*Implicit=*/true);
-  auto selfType = structDecl->getDeclaredInterfaceType();
-  lhs->setType(LValueType::get(selfType));
-
-  auto emptyTuple = TupleType::getEmpty(ctx);
-
-  // Construct the right-hand call to Builtin.zeroInitializer.
-  Identifier zeroInitID = ctx.getIdentifier("zeroInitializer");
-  auto zeroInitializerFunc =
-    cast<FuncDecl>(getBuiltinValueDecl(ctx, zeroInitID));
-  SubstitutionMap subMap =
-    SubstitutionMap::get(zeroInitializerFunc->getGenericSignature(),
-                         llvm::makeArrayRef(selfType), { });
-  ConcreteDeclRef concreteDeclRef(zeroInitializerFunc, subMap);
-  auto zeroInitializerRef =
-    new (ctx) DeclRefExpr(concreteDeclRef, DeclNameLoc(), /*implicit*/ true);
-  // FIXME: Verify ExtInfo state is correct, not working by accident.
-  FunctionType::ExtInfo info;
-  zeroInitializerRef->setType(FunctionType::get({}, selfType, info));
-
-  auto call = CallExpr::createImplicitEmpty(ctx, zeroInitializerRef);
-  call->setType(selfType);
-  call->setThrows(false);
-
-  auto assign = new (ctx) AssignExpr(lhs, SourceLoc(), call, /*implicit*/ true);
-  assign->setType(emptyTuple);
-
-  auto ret = new (ctx) ReturnStmt(SourceLoc(), nullptr, /*Implicit=*/true);
-
-  // Create the function body.
-  auto body = BraceStmt::create(ctx, SourceLoc(), {assign, ret}, SourceLoc());
-  return { body, /*isTypeChecked=*/true };
-}
-
-/// Create a default constructor that initializes a struct to zero.
-static ConstructorDecl *
-createDefaultConstructor(ClangImporter::Implementation &Impl,
-                         NominalTypeDecl *structDecl) {
-  auto &context = Impl.SwiftContext;
-
-  auto emptyPL = ParameterList::createEmpty(context);
-
-  // Create the constructor.
-  DeclName name(context, DeclBaseName::createConstructor(), emptyPL);
-  auto constructor = new (context) ConstructorDecl(
-      name, structDecl->getLoc(),
-      /*Failable=*/false, /*FailabilityLoc=*/SourceLoc(),
-      /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
-      /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(), emptyPL,
-      /*GenericParams=*/nullptr, structDecl);
-
-  constructor->setAccess(AccessLevel::Public);
-
-  // Mark the constructor transparent so that we inline it away completely.
-  constructor->getAttrs().add(new (context) TransparentAttr(/*implicit*/ true));
-
-  constructor->setBodySynthesizer(synthesizeStructDefaultConstructorBody,
-                                  structDecl);
-
-  // We're done.
-  return constructor;
-}
-
-/// Synthesizer callback for the body of a struct value constructor.
-static std::pair<BraceStmt *, bool>
-synthesizeValueConstructorBody(AbstractFunctionDecl *afd, void *context) {
-  auto constructor = cast<ConstructorDecl>(afd);
-  ArrayRef<VarDecl *> members(static_cast<VarDecl **>(context) + 1,
-                              static_cast<uintptr_t*>(context)[0]);
-
-  ASTContext &ctx = constructor->getASTContext();
-
-  // Assign all of the member variables appropriately.
-  SmallVector<ASTNode, 4> stmts;
-
-  auto *selfDecl = constructor->getImplicitSelfDecl();
-
-  // To keep DI happy, initialize stored properties before computed.
-  auto parameters = constructor->getParameters();
-  for (unsigned pass = 0; pass < 2; ++pass) {
-    unsigned paramPos = 0;
-
-    for (unsigned i = 0, e = members.size(); i < e; ++i) {
-      auto var = members[i];
-
-      if (isa_and_nonnull<clang::IndirectFieldDecl>(var->getClangDecl()))
-        continue;
-
-      if (var->hasStorage() == (pass != 0)) {
-        ++paramPos;
-        continue;
-      }
-
-      // Construct left-hand side.
-      Expr *lhs = new (ctx) DeclRefExpr(selfDecl, DeclNameLoc(),
-                                        /*Implicit=*/true);
-      lhs->setType(LValueType::get(selfDecl->getType()));
-
-      auto semantics = (var->hasStorage()
-                        ? AccessSemantics::DirectToStorage
-                        : AccessSemantics::Ordinary);
-
-      lhs = new (ctx) MemberRefExpr(lhs, SourceLoc(), var, DeclNameLoc(),
-                                    /*Implicit=*/true, semantics);
-      lhs->setType(LValueType::get(var->getType()));
-
-      // Construct right-hand side.
-      auto rhs = new (ctx) DeclRefExpr(parameters->get(paramPos),
-                                       DeclNameLoc(), /*Implicit=*/true);
-      rhs->setType(parameters->get(paramPos)->getType());
-
-      // Add assignment.
-      auto assign = new (ctx) AssignExpr(lhs, SourceLoc(), rhs,
-                                         /*Implicit=*/true);
-      assign->setType(TupleType::getEmpty(ctx));
-
-      stmts.push_back(assign);
-      ++paramPos;
-    }
-  }
-
-  auto ret = new (ctx) ReturnStmt(SourceLoc(), nullptr, /*Implicit=*/true);
-  stmts.push_back(ret);
-
-  // Create the function body.
-  auto body = BraceStmt::create(ctx, SourceLoc(), stmts, SourceLoc());
-  return { body, /*isTypeChecked=*/true };
-}
-
-/// Create a constructor that initializes a struct from its members.
-static ConstructorDecl *
-createValueConstructor(ClangImporter::Implementation &Impl,
-                       NominalTypeDecl *structDecl, ArrayRef<VarDecl *> members,
-                       bool wantCtorParamNames, bool wantBody) {
-  auto &context = Impl.SwiftContext;
-
-  // Construct the set of parameters from the list of members.
-  SmallVector<ParamDecl *, 8> valueParameters;
-  for (auto var : members) {
-    if (var->isStatic())
-      continue;
-
-    bool generateParamName = wantCtorParamNames;
-
-    if (var->hasClangNode()) {
-      // TODO create value constructor with indirect fields instead of the
-      // generated __Anonymous_field.
-      if (isa<clang::IndirectFieldDecl>(var->getClangDecl()))
-        continue;
-
-      if (auto clangField = dyn_cast<clang::FieldDecl>(var->getClangDecl()))
-        if (clangField->isAnonymousStructOrUnion() ||
-            clangField->getDeclName().isEmpty())
-          generateParamName = false;
-    }
-
-    Identifier argName = generateParamName ? var->getName() : Identifier();
-    auto param = new (context)
-        ParamDecl(SourceLoc(), SourceLoc(), argName,
-                  SourceLoc(), var->getName(), structDecl);
-    param->setSpecifier(ParamSpecifier::Default);
-    param->setInterfaceType(var->getInterfaceType());
-    Impl.recordImplicitUnwrapForDecl(param, var->isImplicitlyUnwrappedOptional());
-
-    // Don't allow the parameter to accept temporary pointer conversions.
-    param->setNonEphemeralIfPossible();
-
-    valueParameters.push_back(param);
-  }
-
-  auto *paramList = ParameterList::create(context, valueParameters);
-
-  // Create the constructor
-  DeclName name(context, DeclBaseName::createConstructor(), paramList);
-  auto constructor = new (context) ConstructorDecl(
-      name, structDecl->getLoc(),
-      /*Failable=*/false, /*FailabilityLoc=*/SourceLoc(),
-      /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
-      /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(), paramList,
-      /*GenericParams=*/nullptr, structDecl);
-
-  constructor->setAccess(AccessLevel::Public);
-
-  // Make the constructor transparent so we inline it away completely.
-  constructor->getAttrs().add(new (context) TransparentAttr(/*implicit*/ true));
-
-  if (wantBody) {
-    auto memberMemory =
-        context.AllocateUninitialized<uintptr_t>(members.size() + 1);
-    memberMemory[0] = members.size();
-    for (unsigned i : indices(members)) {
-      memberMemory[i+1] = reinterpret_cast<uintptr_t>(members[i]);
-    }
-    constructor->setBodySynthesizer(synthesizeValueConstructorBody,
-                                    memberMemory.data());
-  }
-
-  // We're done.
-  return constructor;
-}
-
-static void addSynthesizedProtocolAttrs(
-    ClangImporter::Implementation &Impl,
-    NominalTypeDecl *nominal,
-    ArrayRef<KnownProtocolKind> synthesizedProtocolAttrs,
-    bool isUnchecked = false) {
-  for (auto kind : synthesizedProtocolAttrs) {
-    nominal->getAttrs().add(new (Impl.SwiftContext)
-                                 SynthesizedProtocolAttr(kind, &Impl,
-                                                         isUnchecked));
-  }
-}
-
-/// Add a synthesized typealias to the given nominal type.
-static void addSynthesizedTypealias(NominalTypeDecl *nominal, Identifier name,
-                                    Type underlyingType) {
+void ClangImporter::Implementation::addSynthesizedTypealias(
+    NominalTypeDecl *nominal, Identifier name, Type underlyingType) {
   auto &ctx = nominal->getASTContext();
 
-  auto typealias = new (ctx) TypeAliasDecl(SourceLoc(), SourceLoc(),
-                                           name, SourceLoc(),
-                                           nullptr, nominal);
+  auto typealias = new (ctx) TypeAliasDecl(SourceLoc(), SourceLoc(), name,
+                                           SourceLoc(), nullptr, nominal);
   typealias->setUnderlyingType(underlyingType);
   typealias->setAccess(AccessLevel::Public);
   typealias->setImplicit();
@@ -1568,290 +424,15 @@ static void addSynthesizedTypealias(NominalTypeDecl *nominal, Identifier name,
   nominal->addMember(typealias);
 }
 
-/// Make a struct declaration into a raw-value-backed struct
-///
-/// \param structDecl the struct to make a raw value for
-/// \param underlyingType the type of the raw value
-/// \param synthesizedProtocolAttrs synthesized protocol attributes to add
-/// \param setterAccess the access level of the raw value's setter
-///
-/// This will perform most of the work involved in making a new Swift struct
-/// be backed by a raw value. This will populated derived protocols and
-/// synthesized protocols, add the new variable and pattern bindings, and
-/// create the inits parameterized over a raw value
-///
-static void makeStructRawValued(
-    ClangImporter::Implementation &Impl, StructDecl *structDecl,
-    Type underlyingType, ArrayRef<KnownProtocolKind> synthesizedProtocolAttrs,
-    MakeStructRawValuedOptions options = getDefaultMakeStructRawValuedOptions(),
-    AccessLevel setterAccess = AccessLevel::Private) {
-  auto &ctx = Impl.SwiftContext;
+void ClangImporter::Implementation::addSynthesizedProtocolAttrs(
+    NominalTypeDecl *nominal,
+    ArrayRef<KnownProtocolKind> synthesizedProtocolAttrs, bool isUnchecked) {
+  auto &ctx = nominal->getASTContext();
 
-  addSynthesizedProtocolAttrs(Impl, structDecl, synthesizedProtocolAttrs);
-
-  // Create a variable to store the underlying value.
-  VarDecl *var;
-  PatternBindingDecl *patternBinding;
-  auto introducer = (options.contains(MakeStructRawValuedFlags::IsLet)
-                     ? VarDecl::Introducer::Let
-                     : VarDecl::Introducer::Var);
-  std::tie(var, patternBinding) = createVarWithPattern(
-      ctx, structDecl, ctx.Id_rawValue, underlyingType, introducer,
-      options.contains(MakeStructRawValuedFlags::IsImplicit),
-      AccessLevel::Public,
-      setterAccess);
-
-  assert(var->hasStorage());
-
-  // Create constructors to initialize that value from a value of the
-  // underlying type.
-  if (options.contains(MakeStructRawValuedFlags::MakeUnlabeledValueInit))
-    structDecl->addMember(
-        createValueConstructor(Impl, structDecl, var,
-                               /*wantCtorParamNames=*/false,
-                               /*wantBody=*/true));
-
-  auto *initRawValue =
-      createValueConstructor(Impl, structDecl, var,
-                             /*wantCtorParamNames=*/true,
-                             /*wantBody=*/true);
-  structDecl->addMember(initRawValue);
-  structDecl->addMember(patternBinding);
-  structDecl->addMember(var);
-
-  addSynthesizedTypealias(structDecl, ctx.Id_RawValue, underlyingType);
-  Impl.RawTypes[structDecl] = underlyingType;
-}
-
-/// Synthesizer callback for a raw value bridging constructor body.
-static std::pair<BraceStmt *, bool>
-synthesizeRawValueBridgingConstructorBody(AbstractFunctionDecl *afd,
-                                          void *context) {
-  auto init = cast<ConstructorDecl>(afd);
-  VarDecl *storedRawValue = static_cast<VarDecl *>(context);
-
-  ASTContext &ctx = init->getASTContext();
-
-  auto selfDecl = init->getImplicitSelfDecl();
-  auto storedType = storedRawValue->getInterfaceType();
-
-  // Construct left-hand side.
-  Expr *lhs = new (ctx) DeclRefExpr(selfDecl, DeclNameLoc(),
-                                    /*Implicit=*/true);
-  lhs->setType(LValueType::get(selfDecl->getType()));
-
-  lhs = new (ctx) MemberRefExpr(lhs, SourceLoc(), storedRawValue,
-                                DeclNameLoc(), /*Implicit=*/true,
-                                AccessSemantics::DirectToStorage);
-  lhs->setType(LValueType::get(storedType));
-
-  // Construct right-hand side.
-  // FIXME: get the parameter from the init, and plug it in here.
-  auto *paramDecl = init->getParameters()->get(0);
-  auto *paramRef = new (ctx) DeclRefExpr(
-      paramDecl, DeclNameLoc(), /*Implicit=*/true);
-  paramRef->setType(paramDecl->getType());
-
-  Expr *rhs = paramRef;
-  if (!storedRawValue->getInterfaceType()->isEqual(paramDecl->getType())) {
-    auto bridge = new (ctx) BridgeToObjCExpr(paramRef, storedType);
-    bridge->setType(storedType);
-
-    rhs = CoerceExpr::createImplicit(ctx, bridge, storedType);
+  for (auto kind : synthesizedProtocolAttrs) {
+    nominal->getAttrs().add(
+        new (ctx) SynthesizedProtocolAttr(kind, this, isUnchecked));
   }
-
-  // Add assignment.
-  auto assign = new (ctx) AssignExpr(lhs, SourceLoc(), rhs,
-                                     /*Implicit=*/true);
-  assign->setType(TupleType::getEmpty(ctx));
-
-  auto ret = new (ctx) ReturnStmt(SourceLoc(), nullptr, /*Implicit=*/true);
-
-  auto body = BraceStmt::create(ctx, SourceLoc(), {assign, ret}, SourceLoc());
-  return { body, /*isTypeChecked=*/true };
-}
-
-/// Create a rawValue-ed constructor that bridges to its underlying storage.
-static ConstructorDecl *createRawValueBridgingConstructor(
-    ClangImporter::Implementation &Impl, StructDecl *structDecl,
-    VarDecl *computedRawValue, VarDecl *storedRawValue, bool wantLabel,
-    bool wantBody) {
-  auto init = createValueConstructor(Impl, structDecl, computedRawValue,
-                                     /*wantCtorParamNames=*/wantLabel,
-                                     /*wantBody=*/false);
-  // Insert our custom init body
-  if (wantBody) {
-    init->setBodySynthesizer(synthesizeRawValueBridgingConstructorBody,
-                             storedRawValue);
-  }
-
-  return init;
-}
-
-/// Make a struct declaration into a raw-value-backed struct, with
-/// bridged computed rawValue property which differs from stored backing
-///
-/// \param structDecl the struct to make a raw value for
-/// \param storedUnderlyingType the type of the stored raw value
-/// \param bridgedType the type of the 'rawValue' computed property bridge
-/// \param synthesizedProtocolAttrs synthesized protocol attributes to add
-///
-/// This will perform most of the work involved in making a new Swift struct
-/// be backed by a stored raw value and computed raw value of bridged type.
-/// This will populated derived protocols and synthesized protocols, add the
-/// new variable and pattern bindings, and create the inits parameterized
-/// over a bridged type that will cast to the stored type, as appropriate.
-///
-static void makeStructRawValuedWithBridge(
-    ClangImporter::Implementation &Impl, StructDecl *structDecl,
-    Type storedUnderlyingType, Type bridgedType,
-    ArrayRef<KnownProtocolKind> synthesizedProtocolAttrs,
-    bool makeUnlabeledValueInit = false) {
-  auto &ctx = Impl.SwiftContext;
-
-  addSynthesizedProtocolAttrs(Impl, structDecl, synthesizedProtocolAttrs);
-
-  auto storedVarName = ctx.getIdentifier("_rawValue");
-  auto computedVarName = ctx.Id_rawValue;
-
-  // Create a variable to store the underlying value.
-  VarDecl *storedVar;
-  PatternBindingDecl *storedPatternBinding;
-  std::tie(storedVar, storedPatternBinding) = createVarWithPattern(
-      ctx, structDecl, storedVarName, storedUnderlyingType,
-      VarDecl::Introducer::Var, /*isImplicit=*/true,
-      AccessLevel::Private,
-      AccessLevel::Private);
-
-  // Create a computed value variable.
-  auto computedVar = new (ctx) VarDecl(
-      /*IsStatic*/false, VarDecl::Introducer::Var,
-      SourceLoc(), computedVarName, structDecl);
-  computedVar->setInterfaceType(bridgedType);
-  computedVar->setImplicit();
-  computedVar->setAccess(AccessLevel::Public);
-  computedVar->setSetterAccess(AccessLevel::Private);
-
-  // Create the getter for the computed value variable.
-  auto computedVarGetter = makeStructRawValueGetter(
-      Impl, structDecl, computedVar, storedVar);
-  makeComputed(computedVar, computedVarGetter, nullptr);
-
-  // Create a pattern binding to describe the variable.
-  Pattern *computedBindingPattern = createTypedNamedPattern(computedVar);
-  auto *computedPatternBinding = PatternBindingDecl::createImplicit(
-      ctx, StaticSpellingKind::None, computedBindingPattern,
-      /*InitExpr*/ nullptr, structDecl);
-
-  auto init = createRawValueBridgingConstructor(Impl, structDecl, computedVar,
-                                                storedVar,
-                                                /*wantLabel*/ true,
-                                                /*wantBody*/ true);
-
-  ConstructorDecl *unlabeledCtor = nullptr;
-  if (makeUnlabeledValueInit)
-    unlabeledCtor = createRawValueBridgingConstructor(
-        Impl, structDecl, computedVar, storedVar,
-        /*wantLabel*/ false, /*wantBody*/true);
-
-  if (unlabeledCtor)
-    structDecl->addMember(unlabeledCtor);
-  structDecl->addMember(init);
-  structDecl->addMember(storedPatternBinding);
-  structDecl->addMember(storedVar);
-  structDecl->addMember(computedPatternBinding);
-  structDecl->addMember(computedVar);
-
-  addSynthesizedTypealias(structDecl, ctx.Id_RawValue, bridgedType);
-  Impl.RawTypes[structDecl] = bridgedType;
-}
-
-/// Build a declaration for an Objective-C subscript getter.
-static AccessorDecl *
-buildSubscriptGetterDecl(ClangImporter::Implementation &Impl,
-                         SubscriptDecl *subscript, const FuncDecl *getter,
-                         Type elementTy, DeclContext *dc, ParamDecl *index) {
-  auto &C = Impl.SwiftContext;
-  auto loc = getter->getLoc();
-
-  auto *params = ParameterList::create(C, index);
-
-  // Create the getter thunk.
-  auto thunk = AccessorDecl::create(C,
-                     /*FuncLoc=*/loc,
-                     /*AccessorKeywordLoc=*/SourceLoc(),
-                     AccessorKind::Get,
-                     subscript,
-                     /*StaticLoc=*/SourceLoc(),
-                     subscript->getStaticSpelling(),
-                     /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
-                     /*Throws=*/false,
-                     /*ThrowsLoc=*/SourceLoc(),
-                     /*GenericParams=*/nullptr,
-                     params, elementTy, dc,
-                     getter->getClangNode());
-
-  thunk->setAccess(getOverridableAccessLevel(dc));
-
-  if (auto objcAttr = getter->getAttrs().getAttribute<ObjCAttr>())
-    thunk->getAttrs().add(objcAttr->clone(C));
-  thunk->setIsObjC(getter->isObjC());
-  thunk->setIsDynamic(getter->isDynamic());
-  // FIXME: Should we record thunks?
-
-  return thunk;
-}
-
-/// Build a declaration for an Objective-C subscript setter.
-static AccessorDecl *
-buildSubscriptSetterDecl(ClangImporter::Implementation &Impl,
-                         SubscriptDecl *subscript, const FuncDecl *setter,
-                         Type elementInterfaceTy,
-                         DeclContext *dc, ParamDecl *index) {
-  auto &C = Impl.SwiftContext;
-  auto loc = setter->getLoc();
-
-  // Objective-C subscript setters are imported with a function type
-  // such as:
-  //
-  //   (self) -> (value, index) -> ()
-  //
-  // Build a setter thunk with the latter signature that maps to the
-  // former.
-  auto valueIndex = setter->getParameters();
-
-  auto paramVarDecl =
-      new (C) ParamDecl(SourceLoc(), SourceLoc(),
-                        Identifier(), loc, valueIndex->get(0)->getName(), dc);
-  paramVarDecl->setSpecifier(ParamSpecifier::Default);
-  paramVarDecl->setInterfaceType(elementInterfaceTy);
-
-  auto valueIndicesPL = ParameterList::create(C, {paramVarDecl, index});
-
-  // Create the setter thunk.
-  auto thunk = AccessorDecl::create(C,
-                     /*FuncLoc=*/setter->getLoc(),
-                     /*AccessorKeywordLoc=*/SourceLoc(),
-                     AccessorKind::Set,
-                     subscript,
-                     /*StaticLoc=*/SourceLoc(),
-                     subscript->getStaticSpelling(),
-                     /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
-                     /*Throws=*/false,
-                     /*ThrowsLoc=*/SourceLoc(),
-                     /*GenericParams=*/nullptr,
-                     valueIndicesPL,
-                     TupleType::getEmpty(C), dc,
-                     setter->getClangNode());
-
-  thunk->setAccess(getOverridableAccessLevel(dc));
-
-  if (auto objcAttr = setter->getAttrs().getAttribute<ObjCAttr>())
-    thunk->getAttrs().add(objcAttr->clone(C));
-  thunk->setIsObjC(setter->isObjC());
-  thunk->setIsDynamic(setter->isDynamic());
-
-  return thunk;
 }
 
 /// Retrieve the element interface type and key param decl of a subscript
@@ -2035,7 +616,7 @@ static bool addErrorDomain(NominalTypeDecl *swiftDecl,
   getterDecl->setIsTransparent(false);
 
   swiftDecl->addMember(errorDomainPropertyDecl);
-  makeComputed(errorDomainPropertyDecl, getterDecl, nullptr);
+  importer.makeComputed(errorDomainPropertyDecl, getterDecl, nullptr);
 
   getterDecl->setImplicit();
   getterDecl->setAccess(AccessLevel::Public);
@@ -2360,6 +941,7 @@ namespace {
     ClangImporter::Implementation &Impl;
     bool forwardDeclaration = false;
     ImportNameVersion version;
+    SwiftDeclSynthesizer synthesizer;
 
     /// The version that we're being asked to import for. May not be the version
     /// the user requested, as we may be forming an alternate for diagnostic
@@ -2495,7 +1077,7 @@ namespace {
   public:
     explicit SwiftDeclConverter(ClangImporter::Implementation &impl,
                                 ImportNameVersion vers)
-      : Impl(impl), version(vers) { }
+      : Impl(impl), version(vers), synthesizer(Impl) { }
 
     bool hadForwardDeclaration() const {
       return forwardDeclaration;
@@ -2973,10 +1555,10 @@ namespace {
         options -= MakeStructRawValuedFlags::IsLet;
         options -= MakeStructRawValuedFlags::IsImplicit;
 
-        makeStructRawValued(Impl, structDecl, underlyingType,
-                            {KnownProtocolKind::RawRepresentable,
-                             KnownProtocolKind::Equatable},
-                            options, /*setterAccess=*/AccessLevel::Public);
+        synthesizer.makeStructRawValued(
+            structDecl, underlyingType,
+            {KnownProtocolKind::RawRepresentable, KnownProtocolKind::Equatable},
+            options, /*setterAccess=*/AccessLevel::Public);
 
         result = structDecl;
         break;
@@ -3034,8 +1616,8 @@ namespace {
               nameForMangling, relatedEntityKind));
 
           // Add inheritance clause.
-          addSynthesizedProtocolAttrs(Impl, errorWrapper,
-                                      {KnownProtocolKind::BridgedStoredNSError});
+          Impl.addSynthesizedProtocolAttrs(
+              errorWrapper, {KnownProtocolKind::BridgedStoredNSError});
 
           // Create the _nsError member.
           //   public let _nsError: NSError
@@ -3049,7 +1631,8 @@ namespace {
           nsErrorProp->setInterfaceType(nsErrorType);
 
           // Create a pattern binding to describe the variable.
-          Pattern *nsErrorPattern = createTypedNamedPattern(nsErrorProp);
+          Pattern *nsErrorPattern =
+              synthesizer.createTypedNamedPattern(nsErrorProp);
 
           auto *nsErrorBinding = PatternBindingDecl::createImplicit(
               C, StaticSpellingKind::None, nsErrorPattern, /*InitExpr*/ nullptr,
@@ -3059,10 +1642,11 @@ namespace {
 
           // Create the _nsError initializer.
           //   public init(_nsError error: NSError)
-          VarDecl *members[1] = { nsErrorProp };
-          auto nsErrorInit = createValueConstructor(Impl, errorWrapper, members,
-                                                    /*wantCtorParamNames=*/true,
-                                                    /*wantBody=*/true);
+          VarDecl *members[1] = {nsErrorProp};
+          auto nsErrorInit =
+              synthesizer.createValueConstructor(errorWrapper, members,
+                                                 /*wantCtorParamNames=*/true,
+                                                 /*wantBody=*/true);
           errorWrapper->addMember(nsErrorInit);
 
           // Add the domain error member.
@@ -3101,19 +1685,20 @@ namespace {
         enumDecl->setInherited(C.AllocateCopy(inheritedTypes));
 
         if (errorWrapper) {
-          addSynthesizedProtocolAttrs(Impl, enumDecl,
-                                      {KnownProtocolKind::ErrorCodeProtocol,
-                                       KnownProtocolKind::RawRepresentable});
+          Impl.addSynthesizedProtocolAttrs(
+              enumDecl, {KnownProtocolKind::ErrorCodeProtocol,
+                         KnownProtocolKind::RawRepresentable});
         } else {
-          addSynthesizedProtocolAttrs(Impl, enumDecl,
-                                      {KnownProtocolKind::RawRepresentable});
+          Impl.addSynthesizedProtocolAttrs(
+              enumDecl, {KnownProtocolKind::RawRepresentable});
         }
 
         // Provide custom implementations of the init(rawValue:) and rawValue
         // conversions that just do a bitcast. We can't reliably filter a
         // C enum without additional knowledge that the type has no
         // undeclared values, and won't ever add cases.
-        auto rawValueConstructor = makeEnumRawValueConstructor(Impl, enumDecl);
+        auto rawValueConstructor =
+            synthesizer.makeEnumRawValueConstructor(enumDecl);
 
         auto varName = C.Id_rawValue;
         auto rawValue = new (C) VarDecl(/*IsStatic*/false,
@@ -3126,19 +1711,19 @@ namespace {
         rawValue->setInterfaceType(underlyingType);
 
         // Create a pattern binding to describe the variable.
-        Pattern *varPattern = createTypedNamedPattern(rawValue);
+        Pattern *varPattern = synthesizer.createTypedNamedPattern(rawValue);
 
         auto *rawValueBinding = PatternBindingDecl::createImplicit(
             C, StaticSpellingKind::None, varPattern, /*InitExpr*/ nullptr,
             enumDecl);
 
-        makeEnumRawValueGetter(Impl, enumDecl, rawValue);
+        synthesizer.makeEnumRawValueGetter(enumDecl, rawValue);
 
         enumDecl->addMember(rawValueConstructor);
         enumDecl->addMember(rawValue);
         enumDecl->addMember(rawValueBinding);
 
-        addSynthesizedTypealias(enumDecl, C.Id_RawValue, underlyingType);
+        Impl.addSynthesizedTypealias(enumDecl, C.Id_RawValue, underlyingType);
         Impl.RawTypes[enumDecl] = underlyingType;
 
         // If we have an error wrapper, finish it up now that its
@@ -3598,7 +2183,8 @@ namespace {
             if (cxxOperatorKind == clang::OO_Star && cxxMethod->param_empty()) {
               // This is a dereference operator. We synthesize a computed
               // property called `pointee` for it.
-              VarDecl *pointeeProperty = makeDereferencedPointeeProperty(MD);
+              VarDecl *pointeeProperty =
+                  synthesizer.makeDereferencedPointeeProperty(MD);
               result->addMember(pointeeProperty);
 
               Impl.markUnavailable(MD, "use .pointee property");
@@ -3614,7 +2200,7 @@ namespace {
                      cxxOperatorKind !=
                          clang::OverloadedOperatorKind::OO_Subscript) {
 
-              auto opFuncDecl = makeOperator(MD, cxxMethod);
+              auto opFuncDecl = synthesizer.makeOperator(MD, cxxMethod);
 
               Impl.addAlternateDecl(MD, opFuncDecl);
 
@@ -3657,28 +2243,29 @@ namespace {
             hasUnreferenceableStorage = true;
             isBitField = true;
 
-            makeBitFieldAccessors(Impl, const_cast<clang::RecordDecl *>(decl),
-                                  result, const_cast<clang::FieldDecl *>(field),
-                                  member);
+            synthesizer.makeBitFieldAccessors(
+                const_cast<clang::RecordDecl *>(decl), result,
+                const_cast<clang::FieldDecl *>(field), member);
           }
         }
 
         if (auto ind = dyn_cast<clang::IndirectFieldDecl>(nd)) {
           // Indirect fields are created as computed property accessible the
           // fields on the anonymous field from which they are injected.
-          makeIndirectFieldAccessors(Impl, ind, members, result, member);
+          synthesizer.makeIndirectFieldAccessors(ind, members, result, member);
         } else if (decl->isUnion() && !isBitField) {
           // Union fields should only be available indirectly via a computed
           // property. Since the union is made of all of the fields at once,
           // this is a trivial accessor that casts self to the correct
           // field type.
-          makeUnionFieldAccessors(Impl, result, member);
+          synthesizer.makeUnionFieldAccessors(result, member);
 
           // Create labeled initializers for unions that take one of the
           // fields, which only initializes the data for that field.
-          auto valueCtor = createValueConstructor(Impl, result, member,
-                                                  /*want param names*/ true,
-                                                  /*wantBody=*/true);
+          auto valueCtor =
+              synthesizer.createValueConstructor(result, member,
+                                                 /*want param names*/ true,
+                                                 /*wantBody=*/true);
           ctors.push_back(valueCtor);
         }
         // TODO: we have a problem lazily looking up members of an unnamed
@@ -3701,7 +2288,7 @@ namespace {
         // Add default constructor for the struct if compiling in C mode.
         // If we're compiling for C++, we'll import the C++ default constructor
         // (if there is one), so we don't need to synthesize one here.
-        ctors.push_back(createDefaultConstructor(Impl, result));
+        ctors.push_back(synthesizer.createDefaultConstructor(result));
       }
 
       // We can assume that it is possible to correctly construct the object by
@@ -3717,10 +2304,10 @@ namespace {
         //
         // If we can completely represent the struct in SIL, leave the body
         // implicit, otherwise synthesize one to call property setters.
-        auto valueCtor =
-            createValueConstructor(Impl, result, members,
-                                   /*want param names*/ true,
-                                   /*want body*/ hasUnreferenceableStorage);
+        auto valueCtor = synthesizer.createValueConstructor(
+            result, members,
+            /*want param names*/ true,
+            /*want body*/ hasUnreferenceableStorage);
         if (!hasUnreferenceableStorage)
           valueCtor->setIsMemberwiseInitializer();
 
@@ -3766,7 +2353,8 @@ namespace {
                   cxxMethodBridging.importNameAsCamelCaseName()))
             continue;
 
-          auto p = makeComputedPropertyFromCXXMethods(getter, setter);
+          auto p =
+              synthesizer.makeComputedPropertyFromCXXMethods(getter, setter);
           // Add computed properties directly because they won't be found from
           // the clang decl during lazy member lookup.
           result->addMember(p);
@@ -3778,8 +2366,8 @@ namespace {
             continue;
 
           auto getterAndSetter = subscriptInfo.second;
-          auto subscript =
-              makeSubscript(getterAndSetter.first, getterAndSetter.second);
+          auto subscript = synthesizer.makeSubscript(getterAndSetter.first,
+                                                     getterAndSetter.second);
           // Also add subscripts directly because they won't be found from the
           // clang decl.
           result->addMember(subscript);
@@ -3857,7 +2445,53 @@ namespace {
       if (!isCxxRecordImportable(decl))
         return nullptr;
 
-      return VisitRecordDecl(decl);
+      auto result = VisitRecordDecl(decl);
+      if (!result)
+        return nullptr;
+
+      // If this struct is a C++ input iterator, we try to synthesize a
+      // conformance to the UnsafeCxxInputIterator protocol (which is defined in
+      // the std overlay). We consider a struct to be an input iterator if it
+      // has this member: `using iterator_category = std::input_iterator_tag`.
+      for (clang::Decl *member : decl->decls()) {
+        if (auto typeDecl = dyn_cast<clang::TypeDecl>(member)) {
+          if (!typeDecl->getIdentifier())
+            continue;
+
+          if (typeDecl->getName() == "iterator_category") {
+            // If this is a typedef or a using-decl, retrieve the underlying
+            // struct decl.
+            clang::CXXRecordDecl *underlyingDecl = nullptr;
+            if (auto typedefDecl = dyn_cast<clang::TypedefNameDecl>(typeDecl)) {
+              auto type = typedefDecl->getUnderlyingType();
+              underlyingDecl = type->getAsCXXRecordDecl();
+            } else {
+              underlyingDecl = dyn_cast<clang::CXXRecordDecl>(typeDecl);
+            }
+            if (underlyingDecl) {
+              auto isInputIteratorDecl = [&](const clang::CXXRecordDecl *base) {
+                return base->isInStdNamespace() && base->getIdentifier() &&
+                       base->getName() == "input_iterator_tag";
+              };
+
+              // Traverse all transitive bases of `underlyingDecl` to check if
+              // it inherits from `std::input_iterator_tag`.
+              bool isInputIterator = isInputIteratorDecl(underlyingDecl);
+              underlyingDecl->forallBases(
+                  [&](const clang::CXXRecordDecl *base) {
+                    if (isInputIteratorDecl(base)) {
+                      isInputIterator = true;
+                      return false;
+                    }
+                    return true;
+                  });
+              llvm::errs();
+            }
+          }
+        }
+      }
+
+      return result;
     }
 
     bool isSpecializationDepthGreaterThan(
@@ -3969,7 +2603,7 @@ namespace {
 
         // Create the global constant.
         bool isStatic = enumKind != EnumKind::Unknown && dc->isTypeContext();
-        auto result = Impl.createConstant(
+        auto result = synthesizer.createConstant(
             name, dc, type, clang::APValue(decl->getInitVal()),
             enumKind == EnumKind::Unknown ? ConstantConvertKind::Construction
                                           : ConstantConvertKind::None,
@@ -4471,39 +3105,6 @@ namespace {
       }
 
       recordObjCOverride(result);
-    }
-    static std::pair<BraceStmt *, bool>
-    synthesizeComputedGetterFromCXXMethod(AbstractFunctionDecl *afd,
-                                          void *context) {
-      auto accessor = cast<AccessorDecl>(afd);
-      auto method = static_cast<FuncDecl *>(context);
-
-      Expr *selfExpr = createSelfExpr(accessor);
-
-      auto *getterImplCallExpr = createAccessorImplCallExpr(method, selfExpr);
-      auto returnStmt = new (method->getASTContext())
-          ReturnStmt(SourceLoc(), getterImplCallExpr);
-      auto body = BraceStmt::create(method->getASTContext(), SourceLoc(),
-                                    {returnStmt}, SourceLoc());
-
-      return {body, /*isTypeChecked=*/true};
-    }
-
-    static std::pair<BraceStmt *, bool>
-    synthesizeComputedSetterFromCXXMethod(AbstractFunctionDecl *afd,
-                                          void *context) {
-      auto setterDecl = cast<AccessorDecl>(afd);
-      auto setterImpl = static_cast<FuncDecl *>(context);
-
-      Expr *selfExpr = createSelfExpr(setterDecl);
-      DeclRefExpr *valueParamRefExpr = createParamRefExpr(setterDecl, 0);
-
-      auto *getterImplCallExpr =
-          createAccessorImplCallExpr(setterImpl, selfExpr, valueParamRefExpr);
-
-      auto body = BraceStmt::create(setterImpl->getASTContext(), SourceLoc(),
-                                    {getterImplCallExpr}, SourceLoc());
-      return {body, /*isTypeChecked=*/true};
     }
 
     Decl *VisitCXXMethodDecl(const clang::CXXMethodDecl *decl) {
@@ -5045,7 +3646,7 @@ namespace {
 
       // FIXME: Fake locations for '{' and '}'?
       propDecl->setIsSetterMutating(false);
-      makeComputed(propDecl, getter, /*setter=*/nullptr);
+      Impl.makeComputed(propDecl, getter, /*setter=*/nullptr);
       addObjCAttribute(propDecl, Impl.importIdentifier(decl->getIdentifier()));
       applyPropertyOwnership(propDecl, inferredObjCPropertyAttrs);
 
@@ -5414,25 +4015,6 @@ namespace {
     /// create the Swift subscript declaration.
     SubscriptDecl *importSubscript(Decl *decl,
                                    const clang::ObjCMethodDecl *objcMethod);
-
-    /// Given either the getter, the setter, or both getter & setter
-    /// for a subscript operation, create the Swift subscript declaration.
-    ///
-    /// \param getter function returning `UnsafePointer<T>`
-    /// \param setter function returning `UnsafeMutablePointer<T>`
-    /// \return subscript declaration
-    SubscriptDecl *makeSubscript(FuncDecl *getter, FuncDecl *setter);
-
-    /// Given an imported C++ dereference operator (`operator*()`), create a
-    /// `pointee` computed property.
-    VarDecl *makeDereferencedPointeeProperty(FuncDecl *dereferenceFunc);
-
-    FuncDecl *makeOperator(FuncDecl *operatorMethod,
-                           clang::CXXMethodDecl *clangOperator);
-
-    VarDecl *makeComputedPropertyFromCXXMethods(FuncDecl *getter,
-                                                FuncDecl *setter);
-
 
     /// Import the accessor and its attributes.
     AccessorDecl *importAccessor(const clang::ObjCMethodDecl *clangAccessor,
@@ -6108,7 +4690,7 @@ namespace {
       // Turn this into a computed property.
       // FIXME: Fake locations for '{' and '}'?
       result->setIsSetterMutating(false);
-      makeComputed(result, getter, setter);
+      Impl.makeComputed(result, getter, setter);
       addObjCAttribute(result, Impl.importIdentifier(decl->getIdentifier()));
       applyPropertyOwnership(result, decl->getPropertyAttributesAsWritten());
 
@@ -6341,7 +4923,7 @@ SwiftDeclConverter::importCFClassType(const clang::TypedefNameDecl *decl,
     theClass->setInherited(Impl.SwiftContext.AllocateCopy(inheritedTypes));
   }
 
-  addSynthesizedProtocolAttrs(Impl, theClass, {KnownProtocolKind::CFObject});
+  Impl.addSynthesizedProtocolAttrs(theClass, {KnownProtocolKind::CFObject});
 
   // Look for bridging attributes on the clang record.  We can
   // just check the most recent redeclaration, which will inherit
@@ -6605,20 +5187,20 @@ SwiftDeclConverter::importSwiftNewtype(const clang::TypedefNameDecl *decl,
     if (unlabeledCtor)
       options |= MakeStructRawValuedFlags::MakeUnlabeledValueInit;
 
-    makeStructRawValued(Impl, structDecl, storedUnderlyingType,
-                        synthesizedProtocols, options);
+    synthesizer.makeStructRawValued(structDecl, storedUnderlyingType,
+                                    synthesizedProtocols, options);
   } else {
     // We need to make a stored rawValue or storage type, and a
     // computed one of bridged type.
-    makeStructRawValuedWithBridge(Impl, structDecl, storedUnderlyingType,
-                                  computedPropertyUnderlyingType,
-                                  synthesizedProtocols,
-                                  /*makeUnlabeledValueInit=*/unlabeledCtor);
+    synthesizer.makeStructRawValuedWithBridge(
+        structDecl, storedUnderlyingType, computedPropertyUnderlyingType,
+        synthesizedProtocols,
+        /*makeUnlabeledValueInit=*/unlabeledCtor);
   }
 
   if (wantsObjCBridgeableTypealias) {
-    addSynthesizedTypealias(structDecl, ctx.Id_ObjectiveCType,
-                            storedUnderlyingType);
+    Impl.addSynthesizedTypealias(structDecl, ctx.Id_ObjectiveCType,
+                                 storedUnderlyingType);
   }
 
   Impl.ImportedDecls[{decl->getCanonicalDecl(), getVersion()}] = structDecl;
@@ -6698,7 +5280,7 @@ SwiftDeclConverter::importOptionConstant(const clang::EnumConstantDecl *decl,
   auto convertKind = ConstantConvertKind::Construction;
   if (isa<EnumDecl>(theStruct))
     convertKind = ConstantConvertKind::ConstructionWithUnwrap;
-  Decl *CD = Impl.createConstant(
+  Decl *CD = synthesizer.createConstant(
       name, theStruct, theStruct->getDeclaredInterfaceType(),
       clang::APValue(decl->getInitVal()), convertKind, /*isStatic*/ true, decl);
   Impl.importAttributes(decl, CD);
@@ -6763,7 +5345,7 @@ Decl *SwiftDeclConverter::importEnumCaseAlias(
     result->setType(original->getInterfaceType());
   }
 
-  Decl *CD = Impl.createConstant(name, importIntoDC, importedEnumTy,
+  Decl *CD = synthesizer.createConstant(name, importIntoDC, importedEnumTy,
                                  result, ConstantConvertKind::None,
                                  /*isStatic*/ true, alias);
   Impl.importAttributes(alias, CD);
@@ -6789,11 +5371,12 @@ SwiftDeclConverter::importAsOptionSetType(DeclContext *dc, Identifier name,
   auto structDecl = Impl.createDeclWithClangNode<StructDecl>(
       decl, AccessLevel::Public, Loc, name, Loc, None, nullptr, dc);
 
-  makeStructRawValued(Impl, structDecl, underlyingType,
-                      {KnownProtocolKind::OptionSet});
+  synthesizer.makeStructRawValued(structDecl, underlyingType,
+                                  {KnownProtocolKind::OptionSet});
   auto selfType = structDecl->getDeclaredInterfaceType();
-  addSynthesizedTypealias(structDecl, ctx.Id_Element, selfType);
-  addSynthesizedTypealias(structDecl, ctx.Id_ArrayLiteralElement, selfType);
+  Impl.addSynthesizedTypealias(structDecl, ctx.Id_Element, selfType);
+  Impl.addSynthesizedTypealias(structDecl, ctx.Id_ArrayLiteralElement,
+                               selfType);
   return structDecl;
 }
 
@@ -7060,7 +5643,7 @@ SwiftDeclConverter::getImplicitProperty(ImportedName importedName,
   if (swiftSetter) property->setIsSetterMutating(swiftSetter->isMutating());
 
   // Make this a computed property.
-  makeComputed(property, swiftGetter, swiftSetter);
+  Impl.makeComputed(property, swiftGetter, swiftSetter);
 
   // Make the property the alternate declaration for the getter.
   Impl.addAlternateDecl(swiftGetter, property);
@@ -7738,9 +6321,9 @@ SwiftDeclConverter::importSubscript(Decl *decl,
       if (existingSubscript->hasClangNode() &&
           !existingSubscript->supportsMutation()) {
         // Create the setter thunk.
-        auto setterThunk = buildSubscriptSetterDecl(
-            Impl, existingSubscript, setter, elementTy,
-            setter->getDeclContext(), setterIndex);
+        auto setterThunk = synthesizer.buildSubscriptSetterDecl(
+            existingSubscript, setter, elementTy, setter->getDeclContext(),
+            setterIndex);
 
         // Set the computed setter.
         existingSubscript->setComputedSetter(setterThunk);
@@ -7787,15 +6370,13 @@ SwiftDeclConverter::importSubscript(Decl *decl,
   subscript->setSetterAccess(access);
 
   // Build the thunks.
-  AccessorDecl *getterThunk =
-      buildSubscriptGetterDecl(Impl, subscript, getter, elementTy,
-                               dc, getterIndex);
+  AccessorDecl *getterThunk = synthesizer.buildSubscriptGetterDecl(
+      subscript, getter, elementTy, dc, getterIndex);
 
   AccessorDecl *setterThunk = nullptr;
   if (setter)
-    setterThunk =
-        buildSubscriptSetterDecl(Impl, subscript, setter, elementTy,
-                                 dc, setterIndex);
+    setterThunk = synthesizer.buildSubscriptSetterDecl(
+        subscript, setter, elementTy, dc, setterIndex);
 
   // Record the subscript as an alternative declaration.
   Impl.addAlternateDecl(associateWithSetter ? setter : getter, subscript);
@@ -7806,7 +6387,7 @@ SwiftDeclConverter::importSubscript(Decl *decl,
     Impl.importAttributes(setterObjCMethod, setterThunk);
 
   subscript->setIsSetterMutating(false);
-  makeComputed(subscript, getterThunk, setterThunk);
+  Impl.makeComputed(subscript, getterThunk, setterThunk);
 
   Impl.recordImplicitUnwrapForDecl(subscript, isIUO);
 
@@ -7848,447 +6429,6 @@ SwiftDeclConverter::importAccessor(const clang::ObjCMethodDecl *clangAccessor,
   Impl.importAttributes(clangAccessor, accessor);
 
   return accessor;
-}
-
-/// Synthesizer callback for a subscript getter or a getter for a
-/// dereference property (`var pointee`). If the getter's implementation returns
-/// an UnsafePointer or UnsafeMutablePointer, it unwraps the pointer and returns
-/// the underlying value.
-static std::pair<BraceStmt *, bool>
-synthesizeUnwrappingGetterBody(AbstractFunctionDecl *afd, void *context) {
-  auto getterDecl = cast<AccessorDecl>(afd);
-  auto getterImpl = static_cast<FuncDecl *>(context);
-
-  ASTContext &ctx = getterDecl->getASTContext();
-
-  Expr *selfExpr = createSelfExpr(getterDecl);
-  DeclRefExpr *keyRefExpr = getterDecl->getParameters()->size() == 0
-                                ? nullptr
-                                : createParamRefExpr(getterDecl, 0);
-
-  Type elementTy = getterDecl->getResultInterfaceType();
-
-  auto *getterImplCallExpr =
-      createAccessorImplCallExpr(getterImpl, selfExpr, keyRefExpr);
-
-  // This default handles C++'s operator[] that returns a value type.
-  Expr *propertyExpr = getterImplCallExpr;
-  PointerTypeKind ptrKind;
-
-  // The following check returns true if the subscript operator returns a C++
-  // reference type. This check actually checks to see if the type is a pointer
-  // type, but this does not apply to C pointers because they are Optional types
-  // when imported. TODO: Use a more obvious check here.
-  if (getterImpl->getResultInterfaceType()->getAnyPointerElementType(ptrKind)) {
-    // `getterImpl` can return either UnsafePointer or UnsafeMutablePointer.
-    // Retrieve the corresponding `.pointee` declaration.
-    VarDecl *pointeePropertyDecl = ctx.getPointerPointeePropertyDecl(ptrKind);
-
-    // Handle operator[] that returns a reference type.
-    SubstitutionMap subMap =
-        SubstitutionMap::get(ctx.getUnsafePointerDecl()->getGenericSignature(),
-                             { elementTy }, { });
-    auto pointeePropertyRefExpr =
-        new (ctx) MemberRefExpr(getterImplCallExpr,
-                                SourceLoc(),
-                                ConcreteDeclRef(pointeePropertyDecl, subMap),
-                                DeclNameLoc(),
-                                /*implicit=*/ true);
-    pointeePropertyRefExpr->setType(elementTy);
-    propertyExpr = pointeePropertyRefExpr;
-  }
-
-  auto returnStmt = new (ctx) ReturnStmt(SourceLoc(),
-                                         propertyExpr,
-                                         /*implicit=*/ true);
-
-  auto body = BraceStmt::create(ctx, SourceLoc(), { returnStmt }, SourceLoc(),
-                                /*implicit=*/ true);
-  return { body, /*isTypeChecked=*/true };
-}
-
-/// Synthesizer callback for a subscript setter.
-static std::pair<BraceStmt *, bool>
-synthesizeSubscriptSetterBody(AbstractFunctionDecl *afd, void *context) {
-  auto setterDecl = cast<AccessorDecl>(afd);
-  auto setterImpl = static_cast<FuncDecl *>(context);
-
-  ASTContext &ctx = setterDecl->getASTContext();
-
-  Expr *selfExpr = createSelfExpr(setterDecl);
-  DeclRefExpr *valueParamRefExpr = createParamRefExpr(setterDecl, 0);
-  DeclRefExpr *keyParamRefExpr = createParamRefExpr(setterDecl, 1);
-
-  Type elementTy = valueParamRefExpr->getDecl()->getInterfaceType();
-
-  auto *setterImplCallExpr = createAccessorImplCallExpr(setterImpl, selfExpr,
-                                                        keyParamRefExpr);
-
-  VarDecl *pointeePropertyDecl = ctx.getPointerPointeePropertyDecl(PTK_UnsafeMutablePointer);
-
-  SubstitutionMap subMap =
-      SubstitutionMap::get(ctx.getUnsafeMutablePointerDecl()->getGenericSignature(),
-                           { elementTy }, { });
-  auto pointeePropertyRefExpr =
-      new (ctx) MemberRefExpr(setterImplCallExpr,
-                              SourceLoc(),
-                              ConcreteDeclRef(pointeePropertyDecl, subMap),
-                              DeclNameLoc(),
-                              /*implicit=*/ true);
-  pointeePropertyRefExpr->setType(LValueType::get(elementTy));
-
-  auto assignExpr = new (ctx) AssignExpr(pointeePropertyRefExpr,
-                                         SourceLoc(),
-                                         valueParamRefExpr,
-                                         /*implicit*/ true);
-  assignExpr->setType(TupleType::getEmpty(ctx));
-
-  auto body = BraceStmt::create(ctx, SourceLoc(), { assignExpr, }, SourceLoc());
-  return { body, /*isTypeChecked=*/true };
-}
-
-VarDecl *
-SwiftDeclConverter::makeComputedPropertyFromCXXMethods(FuncDecl *getter,
-                                                       FuncDecl *setter) {
-  auto &ctx = Impl.SwiftContext;
-  auto dc = getter->getDeclContext();
-
-  assert(isa<clang::CXXMethodDecl>(getter->getClangDecl()) &&
-         (!setter || isa<clang::CXXMethodDecl>(setter->getClangDecl())) &&
-         "Functions passed to makeProperty must be imported C++ method decls.");
-
-  CXXMethodBridging bridgingInfo(
-      cast<clang::CXXMethodDecl>(getter->getClangDecl()));
-  assert(bridgingInfo.classify() == CXXMethodBridging::Kind::getter);
-
-  auto importedName = bridgingInfo.importNameAsCamelCaseName();
-  auto result =
-      new (ctx) VarDecl(false, VarDecl::Introducer::Var, getter->getStartLoc(),
-                        ctx.getIdentifier(importedName), dc);
-  result->setInterfaceType(getter->getResultInterfaceType());
-  result->setAccess(AccessLevel::Public);
-  result->setImplInfo(StorageImplInfo::getMutableComputed());
-
-  AccessorDecl *getterDecl = AccessorDecl::create(
-      ctx, getter->getLoc(), getter->getLoc(), AccessorKind::Get, result,
-      SourceLoc(), StaticSpellingKind::None,
-      /*async*/ false, SourceLoc(),
-      /*throws*/ false, SourceLoc(), nullptr, ParameterList::createEmpty(ctx),
-      getter->getResultInterfaceType(), dc);
-  getterDecl->setAccess(AccessLevel::Public);
-  getterDecl->setImplicit();
-  getterDecl->setIsDynamic(false);
-  getterDecl->setIsTransparent(true);
-  getterDecl->setBodySynthesizer(synthesizeComputedGetterFromCXXMethod, getter);
-  if (getter->isMutating()) {
-    getterDecl->setSelfAccessKind(SelfAccessKind::Mutating);
-    result->setIsGetterMutating(true);
-  }
-
-  AccessorDecl *setterDecl = nullptr;
-  if (setter) {
-    auto paramVarDecl =
-        new (ctx) ParamDecl(SourceLoc(), SourceLoc(), Identifier(), SourceLoc(),
-                            ctx.getIdentifier("newValue"), dc);
-    paramVarDecl->setSpecifier(ParamSpecifier::Default);
-    paramVarDecl->setInterfaceType(getter->getResultInterfaceType());
-
-    auto setterParamList = ParameterList::create(ctx, {paramVarDecl});
-
-    setterDecl = AccessorDecl::create(
-        ctx, setter->getLoc(), setter->getLoc(), AccessorKind::Set, result,
-        SourceLoc(), StaticSpellingKind::None,
-        /*async*/ false, SourceLoc(),
-        /*throws*/ false, SourceLoc(), nullptr, setterParamList,
-        setter->getResultInterfaceType(), dc);
-    setterDecl->setAccess(AccessLevel::Public);
-    setterDecl->setImplicit();
-    setterDecl->setIsDynamic(false);
-    setterDecl->setIsTransparent(true);
-    setterDecl->setBodySynthesizer(synthesizeComputedSetterFromCXXMethod,
-                                   setter);
-
-    if (setter->isMutating()) {
-      setterDecl->setSelfAccessKind(SelfAccessKind::Mutating);
-      result->setIsSetterMutating(true);
-    } else {
-      setterDecl->setSelfAccessKind(SelfAccessKind::NonMutating);
-      result->setIsSetterMutating(false);
-    }
-  }
-
-  makeComputed(result, getterDecl, setterDecl);
-
-  return result;
-}
-
-SubscriptDecl *
-SwiftDeclConverter::makeSubscript(FuncDecl *getter, FuncDecl *setter) {
-  assert((getter || setter) && "getter or setter required to generate subscript");
-
-  // If only a setter (imported from non-const `operator[]`) is defined,
-  // generate both get & set accessors from it.
-  FuncDecl *getterImpl = getter ? getter : setter;
-  FuncDecl *setterImpl = setter;
-
-  // Get the return type wrapped in `Unsafe(Mutable)Pointer<T>`.
-  const auto rawElementTy = getterImpl->getResultInterfaceType();
-  // Unwrap `T`. Use rawElementTy for return by value.
-  const auto elementTy = rawElementTy->getAnyPointerElementType() ?
-                         rawElementTy->getAnyPointerElementType() :
-                         rawElementTy;
-
-  auto &ctx = Impl.SwiftContext;
-  auto bodyParams = getterImpl->getParameters();
-  DeclName name(ctx, DeclBaseName::createSubscript(), bodyParams);
-  auto dc = getterImpl->getDeclContext();
-
-  SubscriptDecl *subscript = SubscriptDecl::createImported(ctx,
-                                                           name,
-                                                           getterImpl->getLoc(),
-                                                           bodyParams,
-                                                           getterImpl->getLoc(),
-                                                           elementTy,
-                                                           dc,
-                                                           getterImpl->getClangNode());
-  subscript->setAccess(AccessLevel::Public);
-
-  AccessorDecl *getterDecl = AccessorDecl::create(ctx,
-                                                  getterImpl->getLoc(),
-                                                  getterImpl->getLoc(),
-                                                  AccessorKind::Get,
-                                                  subscript,
-                                                  SourceLoc(),
-                                                  subscript->getStaticSpelling(),
-                                                  /*async*/ false, SourceLoc(),
-                                                  /*throws*/ false, SourceLoc(),
-                                                  nullptr,
-                                                  bodyParams,
-                                                  elementTy,
-                                                  dc);
-  getterDecl->setAccess(AccessLevel::Public);
-  getterDecl->setImplicit();
-  getterDecl->setIsDynamic(false);
-  getterDecl->setIsTransparent(true);
-  getterDecl->setBodySynthesizer(synthesizeUnwrappingGetterBody, getterImpl);
-
-  if (getterImpl->isMutating()) {
-    getterDecl->setSelfAccessKind(SelfAccessKind::Mutating);
-    subscript->setIsGetterMutating(true);
-  }
-
-  AccessorDecl *setterDecl = nullptr;
-  if (setterImpl) {
-    auto paramVarDecl =
-        new (ctx) ParamDecl(SourceLoc(), SourceLoc(),
-                            Identifier(), SourceLoc(),
-                            ctx.getIdentifier("newValue"), dc);
-    paramVarDecl->setSpecifier(ParamSpecifier::Default);
-    paramVarDecl->setInterfaceType(elementTy);
-
-    auto setterParamList =
-        ParameterList::create(ctx, { paramVarDecl, bodyParams->get(0) });
-
-    setterDecl = AccessorDecl::create(ctx,
-                                      setterImpl->getLoc(),
-                                      setterImpl->getLoc(),
-                                      AccessorKind::Set,
-                                      subscript,
-                                      SourceLoc(),
-                                      subscript->getStaticSpelling(),
-                                      /*async*/ false, SourceLoc(),
-                                      /*throws*/ false, SourceLoc(),
-                                      nullptr,
-                                      setterParamList,
-                                      TupleType::getEmpty(ctx),
-                                      dc);
-    setterDecl->setAccess(AccessLevel::Public);
-    setterDecl->setImplicit();
-    setterDecl->setIsDynamic(false);
-    setterDecl->setIsTransparent(true);
-    setterDecl->setBodySynthesizer(synthesizeSubscriptSetterBody, setterImpl);
-
-    if (setterImpl->isMutating()) {
-      setterDecl->setSelfAccessKind(SelfAccessKind::Mutating);
-      subscript->setIsSetterMutating(true);
-    }
-  }
-
-  makeComputed(subscript, getterDecl, setterDecl);
-
-  // Implicitly unwrap Optional types for T *operator[].
-  Impl.recordImplicitUnwrapForDecl(subscript,
-                                   getterImpl->isImplicitlyUnwrappedOptional());
-
-  return subscript;
-}
-
-VarDecl *
-SwiftDeclConverter::makeDereferencedPointeeProperty(FuncDecl *dereferenceFunc) {
-  auto &ctx = Impl.SwiftContext;
-  auto dc = dereferenceFunc->getDeclContext();
-
-  // Get the return type wrapped in `Unsafe(Mutable)Pointer<T>`.
-  const auto rawElementTy = dereferenceFunc->getResultInterfaceType();
-  // Unwrap `T`. Use rawElementTy for return by value.
-  const auto elementTy = rawElementTy->getAnyPointerElementType()
-                             ? rawElementTy->getAnyPointerElementType()
-                             : rawElementTy;
-
-  auto result = new (ctx)
-      VarDecl(/*isStatic*/ false, VarDecl::Introducer::Var,
-              dereferenceFunc->getStartLoc(), ctx.getIdentifier("pointee"), dc);
-  result->setInterfaceType(elementTy);
-  result->setAccess(AccessLevel::Public);
-  result->setImplInfo(StorageImplInfo::getImmutableComputed());
-
-  AccessorDecl *getterDecl = AccessorDecl::create(
-      ctx, dereferenceFunc->getLoc(), dereferenceFunc->getLoc(),
-      AccessorKind::Get, result, SourceLoc(), StaticSpellingKind::None,
-      /*async*/ false, SourceLoc(),
-      /*throws*/ false, SourceLoc(), nullptr, ParameterList::createEmpty(ctx),
-      elementTy, dc);
-  getterDecl->setAccess(AccessLevel::Public);
-  getterDecl->setImplicit();
-  getterDecl->setIsDynamic(false);
-  getterDecl->setIsTransparent(true);
-  getterDecl->setBodySynthesizer(synthesizeUnwrappingGetterBody,
-                                 dereferenceFunc);
-
-  if (dereferenceFunc->isMutating()) {
-    getterDecl->setSelfAccessKind(SelfAccessKind::Mutating);
-    result->setIsGetterMutating(true);
-  }
-
-  makeComputed(result, getterDecl, /*setter*/ nullptr);
-  return result;
-}
-
-static std::pair<BraceStmt *, bool>
-synthesizeOperatorMethodBody(AbstractFunctionDecl *afd, void *context) {
-  ASTContext &ctx = afd->getASTContext();
-
-  auto funcDecl = cast<FuncDecl>(afd);
-  auto methodDecl =
-      static_cast<FuncDecl *>(context); /* Swift version of CXXMethod */
-
-  SmallVector<Expr *, 8> forwardingParams;
-
-  // We start from +1 since the first param is our lhs. All other params are
-  // forwarded
-  for (auto itr = funcDecl->getParameters()->begin() + 1;
-       itr != funcDecl->getParameters()->end(); itr++) {
-    auto param = *itr;
-    Expr *paramRefExpr =
-        new (ctx) DeclRefExpr(param, DeclNameLoc(), /*Implicit=*/true);
-    paramRefExpr->setType(param->getType());
-
-    if (param->isInOut()) {
-      paramRefExpr->setType(LValueType::get(param->getType()));
-
-      paramRefExpr = new (ctx) InOutExpr(SourceLoc(), paramRefExpr,
-                                         param->getType(), /*isImplicit*/ true);
-      paramRefExpr->setType(InOutType::get(param->getType()));
-    }
-
-    forwardingParams.push_back(paramRefExpr);
-  }
-
-  auto methodExpr =
-      new (ctx) DeclRefExpr(methodDecl, DeclNameLoc(), /*implicit*/ true);
-  methodExpr->setType(methodDecl->getInterfaceType());
-
-  // Lhs parameter
-  auto baseParam = funcDecl->getParameters()->front();
-  Expr *baseExpr =
-      new (ctx) DeclRefExpr(baseParam, DeclNameLoc(), /*implicit*/ true);
-  baseExpr->setType(baseParam->getType());
-  if (baseParam->isInOut()) {
-    baseExpr->setType(LValueType::get(baseParam->getType()));
-
-    baseExpr = new (ctx) InOutExpr(SourceLoc(), baseExpr, baseParam->getType(),
-                                   /*isImplicit*/ true);
-    baseExpr->setType(InOutType::get(baseParam->getType()));
-  }
-
-  auto dotCallExpr =
-      DotSyntaxCallExpr::create(ctx, methodExpr, SourceLoc(), baseExpr);
-  dotCallExpr->setType(methodDecl->getMethodInterfaceType());
-  dotCallExpr->setThrows(false);
-
-  auto *argList = ArgumentList::forImplicitUnlabeled(ctx, forwardingParams);
-  auto callExpr = CallExpr::createImplicit(ctx, dotCallExpr, argList);
-  callExpr->setType(funcDecl->getResultInterfaceType());
-  callExpr->setThrows(false);
-
-  auto returnStmt = new (ctx) ReturnStmt(SourceLoc(), callExpr,
-                                         /*implicit=*/true);
-
-  auto body = BraceStmt::create(ctx, SourceLoc(), {returnStmt}, SourceLoc(),
-                                /*implicit=*/true);
-  return {body, /*isTypeChecked=*/true};
-}
-
-FuncDecl *
-SwiftDeclConverter::makeOperator(FuncDecl *operatorMethod,
-                                 clang::CXXMethodDecl *clangOperator) {
-  auto &ctx = Impl.SwiftContext;
-  auto opName =
-      clang::getOperatorSpelling(clangOperator->getOverloadedOperator());
-  auto paramList = operatorMethod->getParameters();
-  auto genericParamList = operatorMethod->getGenericParams();
-
-  auto opId = ctx.getIdentifier(opName);
-
-  auto parentCtx = operatorMethod->getDeclContext();
-
-  auto lhsParam = new (ctx) ParamDecl(
-          SourceLoc(),
-          SourceLoc(),Identifier(),
-          SourceLoc(),ctx.getIdentifier("lhs"),
-          parentCtx);
-
-  lhsParam->setInterfaceType(operatorMethod->getDeclContext()->getSelfInterfaceType());
-
-  if (operatorMethod->isMutating()) {
-    // This implicitly makes the parameter indirect.
-    lhsParam->setSpecifier(ParamSpecifier::InOut);
-  } else {
-    lhsParam->setSpecifier(ParamSpecifier::Default);
-  }
-
-  SmallVector<ParamDecl *, 4> newParams;
-  newParams.push_back(lhsParam);
-
-  for (auto param : *paramList) {
-    newParams.push_back(param);
-  }
-
-  auto oldArgNames = operatorMethod->getName().getArgumentNames();
-  SmallVector<Identifier, 4> newArgNames;
-  newArgNames.push_back(Identifier());
-
-  for (auto id : oldArgNames) {
-    newArgNames.push_back(id);
-  }
-
-  auto opDeclName = DeclName(
-          ctx,opId,
-          {newArgNames.begin(), newArgNames.end()});
-
-  auto topLevelStaticFuncDecl = FuncDecl::createImplicit(
-      ctx, StaticSpellingKind::None, opDeclName, SourceLoc(),
-      /*Async*/ false, /*Throws*/ false, genericParamList,
-      ParameterList::create(ctx, newParams),
-      operatorMethod->getResultInterfaceType(), parentCtx);
-
-  topLevelStaticFuncDecl->setAccess(AccessLevel::Public);
-  topLevelStaticFuncDecl->setIsDynamic(false);
-  topLevelStaticFuncDecl->setStatic();
-  topLevelStaticFuncDecl->setBodySynthesizer(synthesizeOperatorMethodBody,
-                                             operatorMethod);
-
-  return topLevelStaticFuncDecl;
 }
 
 void SwiftDeclConverter::addProtocols(
@@ -9162,7 +7302,7 @@ ClangImporter::Implementation::importSwiftAttrAttributes(Decl *MappedDecl) {
   if (auto nominal = dyn_cast<NominalTypeDecl>(MappedDecl)) {
     auto sendability = nominal->getAttrs().getEffectiveSendableAttr();
     if (isa_and_nonnull<SendableAttr>(sendability)) {
-      addSynthesizedProtocolAttrs(*this, nominal, {KnownProtocolKind::Sendable},
+      addSynthesizedProtocolAttrs(nominal, {KnownProtocolKind::Sendable},
                                   /*isUnchecked=*/true);
     }
   }
@@ -10074,285 +8214,6 @@ ClangImporter::Implementation::importDeclContextOf(
   // Record this extension so we can find it later.
   extensionPoints[extensionKey] = ext;
   return ext;
-}
-
-static Type getConstantLiteralType(ClangImporter::Implementation &Impl,
-                                   Type type, ConstantConvertKind convertKind) {
-  switch (convertKind) {
-  case ConstantConvertKind::Construction:
-  case ConstantConvertKind::ConstructionWithUnwrap: {
-    auto found = Impl.RawTypes.find(type->getAnyNominal());
-    assert(found != Impl.RawTypes.end());
-    return found->second;
-  }
-
-  default:
-    return type;
-  }
-}
-
-ValueDecl *
-ClangImporter::Implementation::createConstant(Identifier name, DeclContext *dc,
-                                              Type type,
-                                              const clang::APValue &value,
-                                              ConstantConvertKind convertKind,
-                                              bool isStatic,
-                                              ClangNode ClangN) {
-  auto &context = SwiftContext;
-
-  // Create the integer literal value.
-  Expr *expr = nullptr;
-  switch (value.getKind()) {
-  case clang::APValue::AddrLabelDiff:
-  case clang::APValue::Array:
-  case clang::APValue::ComplexFloat:
-  case clang::APValue::ComplexInt:
-  case clang::APValue::FixedPoint:
-  case clang::APValue::Indeterminate:
-  case clang::APValue::LValue:
-  case clang::APValue::MemberPointer:
-  case clang::APValue::None:
-  case clang::APValue::Struct:
-  case clang::APValue::Union:
-  case clang::APValue::Vector:
-    llvm_unreachable("Unhandled APValue kind");
-
-  case clang::APValue::Float:
-  case clang::APValue::Int: {
-    // Print the value.
-    llvm::SmallString<16> printedValueBuf;
-    if (value.getKind() == clang::APValue::Int) {
-      value.getInt().toString(printedValueBuf);
-    } else {
-      assert(value.getFloat().isFinite() && "can't handle infinities or NaNs");
-      value.getFloat().toString(printedValueBuf);
-    }
-    StringRef printedValue = printedValueBuf.str();
-
-    // If this was a negative number, record that and strip off the '-'.
-    bool isNegative = printedValue.front() == '-';
-    if (isNegative)
-      printedValue = printedValue.drop_front();
-
-    auto literalType = getConstantLiteralType(*this, type, convertKind);
-
-    // Create the expression node.
-    StringRef printedValueCopy(context.AllocateCopy(printedValue));
-    if (value.getKind() == clang::APValue::Int) {
-      bool isBool = type->getCanonicalType()->isBool();
-      // Check if "type" is a C++ enum with an underlying type of "bool".
-      if (!isBool && type->getStructOrBoundGenericStruct() &&
-          type->getStructOrBoundGenericStruct()->getClangDecl()) {
-        if (auto enumDecl = dyn_cast<clang::EnumDecl>(
-                type->getStructOrBoundGenericStruct()->getClangDecl())) {
-          isBool = enumDecl->getIntegerType()->isBooleanType();
-        }
-      }
-      if (isBool) {
-        auto *boolExpr = new (context)
-            BooleanLiteralExpr(value.getInt().getBoolValue(), SourceLoc(),
-                               /*Implicit=*/true);
-
-        boolExpr->setBuiltinInitializer(
-          context.getBoolBuiltinInitDecl());
-        boolExpr->setType(literalType);
-
-        expr = boolExpr;
-      } else {
-        auto *intExpr =
-            new (context) IntegerLiteralExpr(printedValueCopy, SourceLoc(),
-                                             /*Implicit=*/true);
-
-        auto *intDecl = literalType->getAnyNominal();
-        intExpr->setBuiltinInitializer(
-          context.getIntBuiltinInitDecl(intDecl));
-        intExpr->setType(literalType);
-
-        expr = intExpr;
-      }
-    } else {
-      auto *floatExpr =
-          new (context) FloatLiteralExpr(printedValueCopy, SourceLoc(),
-                                         /*Implicit=*/true);
-
-      auto maxFloatTypeDecl = context.get_MaxBuiltinFloatTypeDecl();
-      floatExpr->setBuiltinType(
-          maxFloatTypeDecl->getUnderlyingType());
-
-      auto *floatDecl = literalType->getAnyNominal();
-      floatExpr->setBuiltinInitializer(
-        context.getFloatBuiltinInitDecl(floatDecl));
-      floatExpr->setType(literalType);
-
-      expr = floatExpr;
-    }
-
-    if (isNegative)
-      cast<NumberLiteralExpr>(expr)->setNegative(SourceLoc());
-
-    break;
-  }
-  }
-
-  assert(expr);
-  return createConstant(name, dc, type, expr, convertKind, isStatic, ClangN);
-}
-
-
-ValueDecl *
-ClangImporter::Implementation::createConstant(Identifier name, DeclContext *dc,
-                                              Type type, StringRef value,
-                                              ConstantConvertKind convertKind,
-                                              bool isStatic,
-                                              ClangNode ClangN) {
-  auto expr = new (SwiftContext) StringLiteralExpr(value, SourceRange());
-
-  auto literalType = getConstantLiteralType(*this, type, convertKind);
-  auto *stringDecl = literalType->getAnyNominal();
-  expr->setBuiltinInitializer(
-      SwiftContext.getStringBuiltinInitDecl(stringDecl));
-  expr->setType(literalType);
-
-  return createConstant(name, dc, type, expr, convertKind, isStatic, ClangN);
-}
-
-namespace {
-  using ConstantGetterBodyContextData =
-      llvm::PointerIntPair<Expr *, 2, ConstantConvertKind>;
-}
-
-/// Synthesizer callback to synthesize the getter for a constant value.
-static std::pair<BraceStmt *, bool>
-synthesizeConstantGetterBody(AbstractFunctionDecl *afd, void *voidContext) {
-  ASTContext &ctx = afd->getASTContext();
-  auto func = cast<AccessorDecl>(afd);
-  VarDecl *constantVar = cast<VarDecl>(func->getStorage());
-  Type type = func->mapTypeIntoContext(constantVar->getValueInterfaceType());
-
-  auto contextData = ConstantGetterBodyContextData::getFromOpaqueValue(
-      voidContext);
-  Expr *expr = contextData.getPointer();
-  ConstantConvertKind convertKind = contextData.getInt();
-
-  // If we need a conversion, add one now.
-  switch (convertKind) {
-  case ConstantConvertKind::None:
-    break;
-
-  case ConstantConvertKind::Construction:
-  case ConstantConvertKind::ConstructionWithUnwrap: {
-    auto typeRef = TypeExpr::createImplicit(type, ctx);
-
-    // Reference init(rawValue: T)
-    ConstructorDecl *init = nullptr;
-    DeclName initName = DeclName(ctx, DeclBaseName::createConstructor(),
-                                 { ctx.Id_rawValue });
-    auto nominal = type->getAnyNominal();
-    for (auto found : nominal->lookupDirect(initName)) {
-      init = dyn_cast<ConstructorDecl>(found);
-      if (init && init->getDeclContext() == nominal)
-        break;
-    }
-    assert(init && "did not find init(rawValue:)");
-
-    auto initTy = init->getInterfaceType()->removeArgumentLabels(1);
-    auto declRef =
-        new (ctx) DeclRefExpr(init, DeclNameLoc(), /*Implicit=*/true,
-                              AccessSemantics::Ordinary, initTy);
-
-    // (Self) -> ...
-    initTy = initTy->castTo<FunctionType>()->getResult();
-    auto initRef =
-        DotSyntaxCallExpr::create(ctx, declRef, SourceLoc(), typeRef, initTy);
-    initRef->setThrows(false);
-
-    // (rawValue: T) -> ...
-    initTy = initTy->castTo<FunctionType>()->getResult();
-
-    auto *argList = ArgumentList::forImplicitSingle(ctx, ctx.Id_rawValue, expr);
-    auto initCall = CallExpr::createImplicit(ctx, initRef, argList);
-    initCall->setType(initTy);
-    initCall->setThrows(false);
-
-    expr = initCall;
-
-    // Force unwrap if our init(rawValue:) is failable, which is currently
-    // the case with enums.
-    if (convertKind == ConstantConvertKind::ConstructionWithUnwrap) {
-      initTy = initTy->getOptionalObjectType();
-      expr = new (ctx) ForceValueExpr(expr, SourceLoc());
-      expr->setType(initTy);
-    }
-
-    assert(initTy->isEqual(type));
-    break;
-  }
-  }
-
-  // Create the return statement.
-  auto ret = new (ctx) ReturnStmt(SourceLoc(), expr);
-
-  return { BraceStmt::create(ctx, SourceLoc(), ASTNode(ret), SourceLoc()),
-           /*isTypeChecked=*/true };
-}
-
-ValueDecl *
-ClangImporter::Implementation::createConstant(Identifier name, DeclContext *dc,
-                                              Type type, Expr *valueExpr,
-                                              ConstantConvertKind convertKind,
-                                              bool isStatic,
-                                              ClangNode ClangN) {
-  auto &C = SwiftContext;
-
-  VarDecl *var = nullptr;
-  if (ClangN) {
-    var = createDeclWithClangNode<VarDecl>(ClangN, AccessLevel::Public,
-                                           /*IsStatic*/isStatic,
-                                           VarDecl::Introducer::Var,
-                                           SourceLoc(), name, dc);
-  } else {
-    var = new (SwiftContext)
-        VarDecl(/*IsStatic*/isStatic, VarDecl::Introducer::Var,
-                SourceLoc(), name, dc);
-  }
-
-  var->setInterfaceType(type);
-  var->setIsObjC(false);
-  var->setIsDynamic(false);
-
-  auto *params = ParameterList::createEmpty(C);
-
-  // Create the getter function declaration.
-  auto func = AccessorDecl::create(C,
-                     /*FuncLoc=*/SourceLoc(),
-                     /*AccessorKeywordLoc=*/SourceLoc(),
-                     AccessorKind::Get,
-                     var,
-                     /*StaticLoc=*/SourceLoc(),
-                     StaticSpellingKind::None,
-                     /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
-                     /*Throws=*/false,
-                     /*ThrowsLoc=*/SourceLoc(),
-                     /*GenericParams=*/nullptr,
-                     params, type, dc);
-  func->setStatic(isStatic);
-  func->setAccess(getOverridableAccessLevel(dc));
-  func->setIsObjC(false);
-  func->setIsDynamic(false);
-
-  func->setBodySynthesizer(synthesizeConstantGetterBody,
-                           ConstantGetterBodyContextData(valueExpr, convertKind)
-                               .getOpaqueValue());
-
-  // Mark the function transparent so that we inline it away completely.
-  func->getAttrs().add(new (C) TransparentAttr(/*implicit*/ true));
-  auto nonisolatedAttr = new (C) NonisolatedAttr(/*IsImplicit=*/true);
-  var->getAttrs().add(nonisolatedAttr);
-
-  // Set the function up as the getter.
-  makeComputed(var, func, nullptr);
-
-  return var;
 }
 
 /// Create a decl with error type and an "unavailable" attribute on it

--- a/lib/ClangImporter/ImportMacro.cpp
+++ b/lib/ClangImporter/ImportMacro.cpp
@@ -16,6 +16,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "ImporterImpl.h"
+#include "SwiftDeclSynthesizer.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/DiagnosticsClangImporter.h"
 #include "swift/AST/Expr.h"
@@ -73,8 +74,8 @@ createMacroConstant(ClangImporter::Implementation &Impl,
                     bool isStatic,
                     ClangNode ClangN) {
   Impl.ImportedMacroConstants[macro] = {value, type};
-  return Impl.createConstant(name, dc, type, value, convertKind, isStatic,
-                             ClangN);
+  return SwiftDeclSynthesizer(Impl).createConstant(
+      name, dc, type, value, convertKind, isStatic, ClangN);
 }
 
 static ValueDecl *importNumericLiteral(ClangImporter::Implementation &Impl,
@@ -201,9 +202,9 @@ static ValueDecl *importStringLiteral(ClangImporter::Implementation &Impl,
   if (!unicode::isWellFormedUTF8(text))
     return nullptr;
 
-  return Impl.createConstant(name, DC, importTy, text,
-                             ConstantConvertKind::None, /*static*/ false,
-                             ClangN);
+  return SwiftDeclSynthesizer(Impl).createConstant(name, DC, importTy, text,
+                                                   ConstantConvertKind::None,
+                                                   /*static*/ false, ClangN);
 }
 
 static ValueDecl *importLiteral(ClangImporter::Implementation &Impl,

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1101,48 +1101,6 @@ public:
   DeclContext *importDeclContextOf(const clang::Decl *D,
                                    EffectiveClangContext context);
 
-  /// Create a new named constant with the given value.
-  ///
-  /// \param name The name of the constant.
-  /// \param dc The declaration context into which the name will be introduced.
-  /// \param type The type of the named constant.
-  /// \param value The value of the named constant.
-  /// \param convertKind How to convert the constant to the given type.
-  /// \param isStatic Whether the constant should be a static member of \p dc.
-  ValueDecl *createConstant(Identifier name, DeclContext *dc,
-                            Type type, const clang::APValue &value,
-                            ConstantConvertKind convertKind,
-                            bool isStatic,
-                            ClangNode ClangN);
-
-  /// Create a new named constant with the given value.
-  ///
-  /// \param name The name of the constant.
-  /// \param dc The declaration context into which the name will be introduced.
-  /// \param type The type of the named constant.
-  /// \param value The value of the named constant.
-  /// \param convertKind How to convert the constant to the given type.
-  /// \param isStatic Whether the constant should be a static member of \p dc.
-  ValueDecl *createConstant(Identifier name, DeclContext *dc,
-                            Type type, StringRef value,
-                            ConstantConvertKind convertKind,
-                            bool isStatic,
-                            ClangNode ClangN);
-
-  /// Create a new named constant using the given expression.
-  ///
-  /// \param name The name of the constant.
-  /// \param dc The declaration context into which the name will be introduced.
-  /// \param type The type of the named constant.
-  /// \param valueExpr An expression to use as the value of the constant.
-  /// \param convertKind How to convert the constant to the given type.
-  /// \param isStatic Whether the constant should be a static member of \p dc.
-  ValueDecl *createConstant(Identifier name, DeclContext *dc,
-                            Type type, Expr *valueExpr,
-                            ConstantConvertKind convertKind,
-                            bool isStatic,
-                            ClangNode ClangN);
-
   /// Determine whether the given declaration is considered
   /// 'unavailable' in Swift.
   bool isUnavailableInSwift(const clang::Decl *decl) {
@@ -1158,6 +1116,18 @@ public:
   ValueDecl *createUnavailableDecl(Identifier name, DeclContext *dc,
                                    Type type, StringRef UnavailableMessage,
                                    bool isStatic, ClangNode ClangN);
+
+  /// Add a synthesized typealias to the given nominal type.
+  void addSynthesizedTypealias(NominalTypeDecl *nominal, Identifier name,
+                               Type underlyingType);
+
+  void addSynthesizedProtocolAttrs(
+      NominalTypeDecl *nominal,
+      ArrayRef<KnownProtocolKind> synthesizedProtocolAttrs,
+      bool isUnchecked = false);
+
+  void makeComputed(AbstractStorageDecl *storage, AccessorDecl *getter,
+                    AccessorDecl *setter);
 
   /// Retrieve the standard library module.
   ModuleDecl *getStdlibModule();

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -1,0 +1,1959 @@
+//===--- DeclSynthesizer.h - Synthesize helper Swift decls ----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "SwiftDeclSynthesizer.h"
+#include "swift/AST/ASTMangler.h"
+#include "swift/AST/Builtins.h"
+#include "swift/AST/Expr.h"
+#include "swift/AST/ParameterList.h"
+#include "swift/AST/Pattern.h"
+#include "swift/AST/Stmt.h"
+#include "swift/ClangImporter/CXXMethodBridging.h"
+
+using namespace swift;
+using namespace importer;
+
+static Expr *createSelfExpr(AccessorDecl *accessorDecl) {
+  ASTContext &ctx = accessorDecl->getASTContext();
+
+  auto selfDecl = accessorDecl->getImplicitSelfDecl();
+  auto selfRefExpr = new (ctx) DeclRefExpr(selfDecl, DeclNameLoc(),
+                                           /*implicit*/ true);
+
+  if (!accessorDecl->isMutating()) {
+    selfRefExpr->setType(selfDecl->getInterfaceType());
+    return selfRefExpr;
+  }
+  selfRefExpr->setType(LValueType::get(selfDecl->getInterfaceType()));
+
+  auto inoutSelfExpr = new (ctx) InOutExpr(
+      SourceLoc(), selfRefExpr,
+      accessorDecl->mapTypeIntoContext(selfDecl->getValueInterfaceType()),
+      /*isImplicit*/ true);
+  inoutSelfExpr->setType(InOutType::get(selfDecl->getInterfaceType()));
+  return inoutSelfExpr;
+}
+
+static CallExpr *createAccessorImplCallExpr(FuncDecl *accessorImpl,
+                                            Expr *selfExpr,
+                                            DeclRefExpr *keyRefExpr = nullptr) {
+  ASTContext &ctx = accessorImpl->getASTContext();
+
+  auto accessorImplExpr =
+      new (ctx) DeclRefExpr(ConcreteDeclRef(accessorImpl), DeclNameLoc(),
+                            /*Implicit*/ true);
+  accessorImplExpr->setType(accessorImpl->getInterfaceType());
+
+  auto accessorImplDotCallExpr =
+      DotSyntaxCallExpr::create(ctx, accessorImplExpr, SourceLoc(), selfExpr);
+  accessorImplDotCallExpr->setType(accessorImpl->getMethodInterfaceType());
+  accessorImplDotCallExpr->setThrows(false);
+
+  ArgumentList *argList;
+  if (keyRefExpr) {
+    argList = ArgumentList::forImplicitUnlabeled(ctx, {keyRefExpr});
+  } else {
+    argList = ArgumentList::forImplicitUnlabeled(ctx, {});
+  }
+  auto *accessorImplCallExpr =
+      CallExpr::createImplicit(ctx, accessorImplDotCallExpr, argList);
+  accessorImplCallExpr->setType(accessorImpl->getResultInterfaceType());
+  accessorImplCallExpr->setThrows(false);
+  return accessorImplCallExpr;
+}
+
+static DeclRefExpr *createParamRefExpr(AccessorDecl *accessorDecl,
+                                       unsigned index) {
+  ASTContext &ctx = accessorDecl->getASTContext();
+
+  auto paramDecl = accessorDecl->getParameters()->get(index);
+  auto paramRefExpr = new (ctx) DeclRefExpr(paramDecl, DeclNameLoc(),
+                                            /*Implicit*/ true);
+  paramRefExpr->setType(paramDecl->getType());
+  return paramRefExpr;
+}
+
+static AccessorDecl *makeFieldGetterDecl(ClangImporter::Implementation &Impl,
+                                         NominalTypeDecl *importedDecl,
+                                         VarDecl *importedFieldDecl,
+                                         ClangNode clangNode = ClangNode()) {
+  auto &C = Impl.SwiftContext;
+
+  auto *params = ParameterList::createEmpty(C);
+
+  auto getterType = importedFieldDecl->getInterfaceType();
+  auto getterDecl = AccessorDecl::create(
+      C,
+      /*declLoc=*/importedFieldDecl->getLoc(),
+      /*AccessorKeywordLoc=*/SourceLoc(), AccessorKind::Get, importedFieldDecl,
+      /*StaticLoc=*/SourceLoc(), StaticSpellingKind::None,
+      /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
+      /*Throws=*/false,
+      /*ThrowsLoc=*/SourceLoc(),
+      /*GenericParams=*/nullptr, params, getterType, importedDecl, clangNode);
+  getterDecl->setAccess(AccessLevel::Public);
+  getterDecl->setIsObjC(false);
+  getterDecl->setIsDynamic(false);
+
+  return getterDecl;
+}
+
+static AccessorDecl *makeFieldSetterDecl(ClangImporter::Implementation &Impl,
+                                         NominalTypeDecl *importedDecl,
+                                         VarDecl *importedFieldDecl,
+                                         ClangNode clangNode = ClangNode()) {
+  auto &C = Impl.SwiftContext;
+  auto newValueDecl = new (C) ParamDecl(SourceLoc(), SourceLoc(), Identifier(),
+                                        SourceLoc(), C.Id_value, importedDecl);
+  newValueDecl->setSpecifier(ParamSpecifier::Default);
+  newValueDecl->setInterfaceType(importedFieldDecl->getInterfaceType());
+
+  auto *params = ParameterList::createWithoutLoc(newValueDecl);
+
+  auto voidTy = TupleType::getEmpty(C);
+
+  auto setterDecl = AccessorDecl::create(
+      C,
+      /*declLoc=*/SourceLoc(),
+      /*AccessorKeywordLoc=*/SourceLoc(), AccessorKind::Set, importedFieldDecl,
+      /*StaticLoc=*/SourceLoc(), StaticSpellingKind::None,
+      /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
+      /*Throws=*/false,
+      /*ThrowsLoc=*/SourceLoc(),
+      /*GenericParams=*/nullptr, params, voidTy, importedDecl, clangNode);
+  setterDecl->setIsObjC(false);
+  setterDecl->setIsDynamic(false);
+  setterDecl->setSelfAccessKind(SelfAccessKind::Mutating);
+  setterDecl->setAccess(AccessLevel::Public);
+
+  return setterDecl;
+}
+
+std::pair<VarDecl *, PatternBindingDecl *>
+SwiftDeclSynthesizer::createVarWithPattern(DeclContext *dc, Identifier name,
+                                           Type ty,
+                                           VarDecl::Introducer introducer,
+                                           bool isImplicit, AccessLevel access,
+                                           AccessLevel setterAccess) {
+  ASTContext &ctx = ImporterImpl.SwiftContext;
+
+  // Create a variable to store the underlying value.
+  auto var = new (ctx) VarDecl(
+      /*IsStatic*/ false, introducer, SourceLoc(), name, dc);
+  if (isImplicit)
+    var->setImplicit();
+  var->setInterfaceType(ty);
+  var->setAccess(access);
+  var->setSetterAccess(setterAccess);
+
+  // Create a pattern binding to describe the variable.
+  Pattern *varPattern = createTypedNamedPattern(var);
+  auto *patternBinding = PatternBindingDecl::create(
+      ctx, /*StaticLoc*/ SourceLoc(), StaticSpellingKind::None,
+      /*VarLoc*/ SourceLoc(), varPattern, /*EqualLoc*/ SourceLoc(),
+      /*InitExpr*/ nullptr, dc);
+  if (isImplicit)
+    patternBinding->setImplicit();
+
+  return {var, patternBinding};
+}
+
+Pattern *SwiftDeclSynthesizer::createTypedNamedPattern(VarDecl *decl) {
+  ASTContext &Ctx = decl->getASTContext();
+  Type ty = decl->getType();
+
+  Pattern *P = new (Ctx) NamedPattern(decl);
+  P->setType(ty);
+  P->setImplicit();
+  return TypedPattern::createImplicit(Ctx, P, ty);
+}
+
+namespace {
+using ConstantGetterBodyContextData =
+    llvm::PointerIntPair<Expr *, 2, ConstantConvertKind>;
+}
+
+Type SwiftDeclSynthesizer::getConstantLiteralType(
+    Type type, ConstantConvertKind convertKind) {
+  switch (convertKind) {
+  case ConstantConvertKind::Construction:
+  case ConstantConvertKind::ConstructionWithUnwrap: {
+    auto found = ImporterImpl.RawTypes.find(type->getAnyNominal());
+    assert(found != ImporterImpl.RawTypes.end());
+    return found->second;
+  }
+
+  default:
+    return type;
+  }
+}
+
+ValueDecl *SwiftDeclSynthesizer::createConstant(
+    Identifier name, DeclContext *dc, Type type, const clang::APValue &value,
+    ConstantConvertKind convertKind, bool isStatic, ClangNode ClangN) {
+  auto &context = ImporterImpl.SwiftContext;
+
+  // Create the integer literal value.
+  Expr *expr = nullptr;
+  switch (value.getKind()) {
+  case clang::APValue::AddrLabelDiff:
+  case clang::APValue::Array:
+  case clang::APValue::ComplexFloat:
+  case clang::APValue::ComplexInt:
+  case clang::APValue::FixedPoint:
+  case clang::APValue::Indeterminate:
+  case clang::APValue::LValue:
+  case clang::APValue::MemberPointer:
+  case clang::APValue::None:
+  case clang::APValue::Struct:
+  case clang::APValue::Union:
+  case clang::APValue::Vector:
+    llvm_unreachable("Unhandled APValue kind");
+
+  case clang::APValue::Float:
+  case clang::APValue::Int: {
+    // Print the value.
+    llvm::SmallString<16> printedValueBuf;
+    if (value.getKind() == clang::APValue::Int) {
+      value.getInt().toString(printedValueBuf);
+    } else {
+      assert(value.getFloat().isFinite() && "can't handle infinities or NaNs");
+      value.getFloat().toString(printedValueBuf);
+    }
+    StringRef printedValue = printedValueBuf.str();
+
+    // If this was a negative number, record that and strip off the '-'.
+    bool isNegative = printedValue.front() == '-';
+    if (isNegative)
+      printedValue = printedValue.drop_front();
+
+    auto literalType = getConstantLiteralType(type, convertKind);
+
+    // Create the expression node.
+    StringRef printedValueCopy(context.AllocateCopy(printedValue));
+    if (value.getKind() == clang::APValue::Int) {
+      bool isBool = type->getCanonicalType()->isBool();
+      // Check if "type" is a C++ enum with an underlying type of "bool".
+      if (!isBool && type->getStructOrBoundGenericStruct() &&
+          type->getStructOrBoundGenericStruct()->getClangDecl()) {
+        if (auto enumDecl = dyn_cast<clang::EnumDecl>(
+                type->getStructOrBoundGenericStruct()->getClangDecl())) {
+          isBool = enumDecl->getIntegerType()->isBooleanType();
+        }
+      }
+      if (isBool) {
+        auto *boolExpr = new (context)
+            BooleanLiteralExpr(value.getInt().getBoolValue(), SourceLoc(),
+                               /*Implicit=*/true);
+
+        boolExpr->setBuiltinInitializer(context.getBoolBuiltinInitDecl());
+        boolExpr->setType(literalType);
+
+        expr = boolExpr;
+      } else {
+        auto *intExpr =
+            new (context) IntegerLiteralExpr(printedValueCopy, SourceLoc(),
+                                             /*Implicit=*/true);
+
+        auto *intDecl = literalType->getAnyNominal();
+        intExpr->setBuiltinInitializer(context.getIntBuiltinInitDecl(intDecl));
+        intExpr->setType(literalType);
+
+        expr = intExpr;
+      }
+    } else {
+      auto *floatExpr =
+          new (context) FloatLiteralExpr(printedValueCopy, SourceLoc(),
+                                         /*Implicit=*/true);
+
+      auto maxFloatTypeDecl = context.get_MaxBuiltinFloatTypeDecl();
+      floatExpr->setBuiltinType(maxFloatTypeDecl->getUnderlyingType());
+
+      auto *floatDecl = literalType->getAnyNominal();
+      floatExpr->setBuiltinInitializer(
+          context.getFloatBuiltinInitDecl(floatDecl));
+      floatExpr->setType(literalType);
+
+      expr = floatExpr;
+    }
+
+    if (isNegative)
+      cast<NumberLiteralExpr>(expr)->setNegative(SourceLoc());
+
+    break;
+  }
+  }
+
+  assert(expr);
+  return createConstant(name, dc, type, expr, convertKind, isStatic, ClangN);
+}
+
+ValueDecl *SwiftDeclSynthesizer::createConstant(
+    Identifier name, DeclContext *dc, Type type, StringRef value,
+    ConstantConvertKind convertKind, bool isStatic, ClangNode ClangN) {
+  ASTContext &ctx = ImporterImpl.SwiftContext;
+
+  auto expr = new (ctx) StringLiteralExpr(value, SourceRange());
+
+  auto literalType = getConstantLiteralType(type, convertKind);
+  auto *stringDecl = literalType->getAnyNominal();
+  expr->setBuiltinInitializer(ctx.getStringBuiltinInitDecl(stringDecl));
+  expr->setType(literalType);
+
+  return createConstant(name, dc, type, expr, convertKind, isStatic, ClangN);
+}
+
+/// Synthesizer callback to synthesize the getter for a constant value.
+static std::pair<BraceStmt *, bool>
+synthesizeConstantGetterBody(AbstractFunctionDecl *afd, void *voidContext) {
+  ASTContext &ctx = afd->getASTContext();
+  auto func = cast<AccessorDecl>(afd);
+  VarDecl *constantVar = cast<VarDecl>(func->getStorage());
+  Type type = func->mapTypeIntoContext(constantVar->getValueInterfaceType());
+
+  auto contextData =
+      ConstantGetterBodyContextData::getFromOpaqueValue(voidContext);
+  Expr *expr = contextData.getPointer();
+  ConstantConvertKind convertKind = contextData.getInt();
+
+  // If we need a conversion, add one now.
+  switch (convertKind) {
+  case ConstantConvertKind::None:
+    break;
+
+  case ConstantConvertKind::Construction:
+  case ConstantConvertKind::ConstructionWithUnwrap: {
+    auto typeRef = TypeExpr::createImplicit(type, ctx);
+
+    // Reference init(rawValue: T)
+    ConstructorDecl *init = nullptr;
+    DeclName initName =
+        DeclName(ctx, DeclBaseName::createConstructor(), {ctx.Id_rawValue});
+    auto nominal = type->getAnyNominal();
+    for (auto found : nominal->lookupDirect(initName)) {
+      init = dyn_cast<ConstructorDecl>(found);
+      if (init && init->getDeclContext() == nominal)
+        break;
+    }
+    assert(init && "did not find init(rawValue:)");
+
+    auto initTy = init->getInterfaceType()->removeArgumentLabels(1);
+    auto declRef = new (ctx) DeclRefExpr(init, DeclNameLoc(), /*Implicit=*/true,
+                                         AccessSemantics::Ordinary, initTy);
+
+    // (Self) -> ...
+    initTy = initTy->castTo<FunctionType>()->getResult();
+    auto initRef =
+        DotSyntaxCallExpr::create(ctx, declRef, SourceLoc(), typeRef, initTy);
+    initRef->setThrows(false);
+
+    // (rawValue: T) -> ...
+    initTy = initTy->castTo<FunctionType>()->getResult();
+
+    auto *argList = ArgumentList::forImplicitSingle(ctx, ctx.Id_rawValue, expr);
+    auto initCall = CallExpr::createImplicit(ctx, initRef, argList);
+    initCall->setType(initTy);
+    initCall->setThrows(false);
+
+    expr = initCall;
+
+    // Force unwrap if our init(rawValue:) is failable, which is currently
+    // the case with enums.
+    if (convertKind == ConstantConvertKind::ConstructionWithUnwrap) {
+      initTy = initTy->getOptionalObjectType();
+      expr = new (ctx) ForceValueExpr(expr, SourceLoc());
+      expr->setType(initTy);
+    }
+
+    assert(initTy->isEqual(type));
+    break;
+  }
+  }
+
+  // Create the return statement.
+  auto ret = new (ctx) ReturnStmt(SourceLoc(), expr);
+
+  return {BraceStmt::create(ctx, SourceLoc(), ASTNode(ret), SourceLoc()),
+          /*isTypeChecked=*/true};
+}
+
+ValueDecl *SwiftDeclSynthesizer::createConstant(
+    Identifier name, DeclContext *dc, Type type, Expr *valueExpr,
+    ConstantConvertKind convertKind, bool isStatic, ClangNode ClangN) {
+  auto &C = ImporterImpl.SwiftContext;
+
+  VarDecl *var = nullptr;
+  if (ClangN) {
+    var = ImporterImpl.createDeclWithClangNode<VarDecl>(
+        ClangN, AccessLevel::Public,
+        /*IsStatic*/ isStatic, VarDecl::Introducer::Var, SourceLoc(), name, dc);
+  } else {
+    var = new (C) VarDecl(
+        /*IsStatic*/ isStatic, VarDecl::Introducer::Var, SourceLoc(), name, dc);
+  }
+
+  var->setInterfaceType(type);
+  var->setIsObjC(false);
+  var->setIsDynamic(false);
+
+  auto *params = ParameterList::createEmpty(C);
+
+  // Create the getter function declaration.
+  auto func = AccessorDecl::create(
+      C,
+      /*declLoc=*/SourceLoc(),
+      /*AccessorKeywordLoc=*/SourceLoc(), AccessorKind::Get, var,
+      /*StaticLoc=*/SourceLoc(), StaticSpellingKind::None,
+      /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
+      /*Throws=*/false,
+      /*ThrowsLoc=*/SourceLoc(),
+      /*GenericParams=*/nullptr, params, type, dc);
+  func->setStatic(isStatic);
+  func->setAccess(getOverridableAccessLevel(dc));
+  func->setIsObjC(false);
+  func->setIsDynamic(false);
+
+  func->setBodySynthesizer(
+      synthesizeConstantGetterBody,
+      ConstantGetterBodyContextData(valueExpr, convertKind).getOpaqueValue());
+
+  // Mark the function transparent so that we inline it away completely.
+  func->getAttrs().add(new (C) TransparentAttr(/*implicit*/ true));
+  auto nonisolatedAttr = new (C) NonisolatedAttr(/*IsImplicit=*/true);
+  var->getAttrs().add(nonisolatedAttr);
+
+  // Set the function up as the getter.
+  ImporterImpl.makeComputed(var, func, nullptr);
+
+  return var;
+}
+
+// MARK: Struct default initializers
+
+/// Synthesize the body for an struct default initializer.
+static std::pair<BraceStmt *, bool>
+synthesizeStructDefaultConstructorBody(AbstractFunctionDecl *afd,
+                                       void *context) {
+  auto constructor = cast<ConstructorDecl>(afd);
+  ASTContext &ctx = constructor->getASTContext();
+  auto structDecl = static_cast<StructDecl *>(context);
+
+  // We should call into C++ constructors directly.
+  assert(!isa<clang::CXXRecordDecl>(structDecl->getClangDecl()) &&
+         "Should not synthesize a C++ object constructor.");
+
+  // Use a builtin to produce a zero initializer, and assign it to self.
+
+  // Construct the left-hand reference to self.
+  auto *selfDecl = constructor->getImplicitSelfDecl();
+  Expr *lhs = new (ctx) DeclRefExpr(selfDecl, DeclNameLoc(), /*Implicit=*/true);
+  auto selfType = structDecl->getDeclaredInterfaceType();
+  lhs->setType(LValueType::get(selfType));
+
+  auto emptyTuple = TupleType::getEmpty(ctx);
+
+  // Construct the right-hand call to Builtin.zeroInitializer.
+  Identifier zeroInitID = ctx.getIdentifier("zeroInitializer");
+  auto zeroInitializerFunc =
+      cast<FuncDecl>(getBuiltinValueDecl(ctx, zeroInitID));
+  SubstitutionMap subMap =
+      SubstitutionMap::get(zeroInitializerFunc->getGenericSignature(),
+                           llvm::makeArrayRef(selfType), {});
+  ConcreteDeclRef concreteDeclRef(zeroInitializerFunc, subMap);
+  auto zeroInitializerRef =
+      new (ctx) DeclRefExpr(concreteDeclRef, DeclNameLoc(), /*implicit*/ true);
+  // FIXME: Verify ExtInfo state is correct, not working by accident.
+  FunctionType::ExtInfo info;
+  zeroInitializerRef->setType(FunctionType::get({}, selfType, info));
+
+  auto call = CallExpr::createImplicitEmpty(ctx, zeroInitializerRef);
+  call->setType(selfType);
+  call->setThrows(false);
+
+  auto assign = new (ctx) AssignExpr(lhs, SourceLoc(), call, /*implicit*/ true);
+  assign->setType(emptyTuple);
+
+  auto ret = new (ctx) ReturnStmt(SourceLoc(), nullptr, /*Implicit=*/true);
+
+  // Create the function body.
+  auto body = BraceStmt::create(ctx, SourceLoc(), {assign, ret}, SourceLoc());
+  return {body, /*isTypeChecked*/ true};
+}
+
+ConstructorDecl *
+SwiftDeclSynthesizer::createDefaultConstructor(NominalTypeDecl *structDecl) {
+  auto &context = ImporterImpl.SwiftContext;
+
+  auto emptyPL = ParameterList::createEmpty(context);
+
+  // Create the constructor.
+  DeclName name(context, DeclBaseName::createConstructor(), emptyPL);
+  auto constructor = new (context)
+      ConstructorDecl(name, structDecl->getLoc(),
+                      /*Failable=*/false, /*FailabilityLoc=*/SourceLoc(),
+                      /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
+                      /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(), emptyPL,
+                      /*GenericParams=*/nullptr, structDecl);
+
+  constructor->setAccess(AccessLevel::Public);
+
+  // Mark the constructor transparent so that we inline it away completely.
+  constructor->getAttrs().add(new (context) TransparentAttr(/*implicit*/ true));
+
+  constructor->setBodySynthesizer(synthesizeStructDefaultConstructorBody,
+                                  structDecl);
+
+  // We're done.
+  return constructor;
+}
+
+// MARK: Struct value initializers
+
+/// Synthesizer callback for the body of a struct value constructor.
+static std::pair<BraceStmt *, bool>
+synthesizeValueConstructorBody(AbstractFunctionDecl *afd, void *context) {
+  auto constructor = cast<ConstructorDecl>(afd);
+  ArrayRef<VarDecl *> members(static_cast<VarDecl **>(context) + 1,
+                              static_cast<uintptr_t *>(context)[0]);
+
+  ASTContext &ctx = constructor->getASTContext();
+
+  // Assign all of the member variables appropriately.
+  SmallVector<ASTNode, 4> stmts;
+
+  auto *selfDecl = constructor->getImplicitSelfDecl();
+
+  // To keep DI happy, initialize stored properties before computed.
+  auto parameters = constructor->getParameters();
+  for (unsigned pass = 0; pass < 2; ++pass) {
+    unsigned paramPos = 0;
+
+    for (unsigned i = 0, e = members.size(); i < e; ++i) {
+      auto var = members[i];
+
+      if (isa_and_nonnull<clang::IndirectFieldDecl>(var->getClangDecl()))
+        continue;
+
+      if (var->hasStorage() == (pass != 0)) {
+        ++paramPos;
+        continue;
+      }
+
+      // Construct left-hand side.
+      Expr *lhs = new (ctx) DeclRefExpr(selfDecl, DeclNameLoc(),
+                                        /*Implicit=*/true);
+      lhs->setType(LValueType::get(selfDecl->getType()));
+
+      auto semantics = (var->hasStorage() ? AccessSemantics::DirectToStorage
+                                          : AccessSemantics::Ordinary);
+
+      lhs = new (ctx) MemberRefExpr(lhs, SourceLoc(), var, DeclNameLoc(),
+                                    /*Implicit=*/true, semantics);
+      lhs->setType(LValueType::get(var->getType()));
+
+      // Construct right-hand side.
+      auto rhs = new (ctx) DeclRefExpr(parameters->get(paramPos), DeclNameLoc(),
+                                       /*Implicit=*/true);
+      rhs->setType(parameters->get(paramPos)->getType());
+
+      // Add assignment.
+      auto assign = new (ctx) AssignExpr(lhs, SourceLoc(), rhs,
+                                         /*Implicit=*/true);
+      assign->setType(TupleType::getEmpty(ctx));
+
+      stmts.push_back(assign);
+      ++paramPos;
+    }
+  }
+
+  auto ret = new (ctx) ReturnStmt(SourceLoc(), nullptr, /*Implicit=*/true);
+  stmts.push_back(ret);
+
+  // Create the function body.
+  auto body = BraceStmt::create(ctx, SourceLoc(), stmts, SourceLoc());
+  return {body, /*isTypeChecked=*/true};
+}
+
+ConstructorDecl *SwiftDeclSynthesizer::createValueConstructor(
+    NominalTypeDecl *structDecl, ArrayRef<VarDecl *> members,
+    bool wantCtorParamNames, bool wantBody) {
+  auto &context = ImporterImpl.SwiftContext;
+
+  // Construct the set of parameters from the list of members.
+  SmallVector<ParamDecl *, 8> valueParameters;
+  for (auto var : members) {
+    if (var->isStatic())
+      continue;
+
+    bool generateParamName = wantCtorParamNames;
+
+    if (var->hasClangNode()) {
+      // TODO create value constructor with indirect fields instead of the
+      // generated __Anonymous_field.
+      if (isa<clang::IndirectFieldDecl>(var->getClangDecl()))
+        continue;
+
+      if (auto clangField = dyn_cast<clang::FieldDecl>(var->getClangDecl()))
+        if (clangField->isAnonymousStructOrUnion() ||
+            clangField->getDeclName().isEmpty())
+          generateParamName = false;
+    }
+
+    Identifier argName = generateParamName ? var->getName() : Identifier();
+    auto param =
+        new (context) ParamDecl(SourceLoc(), SourceLoc(), argName, SourceLoc(),
+                                var->getName(), structDecl);
+    param->setSpecifier(ParamSpecifier::Default);
+    param->setInterfaceType(var->getInterfaceType());
+    ImporterImpl.recordImplicitUnwrapForDecl(
+        param, var->isImplicitlyUnwrappedOptional());
+
+    // Don't allow the parameter to accept temporary pointer conversions.
+    param->setNonEphemeralIfPossible();
+
+    valueParameters.push_back(param);
+  }
+
+  auto *paramList = ParameterList::create(context, valueParameters);
+
+  // Create the constructor
+  DeclName name(context, DeclBaseName::createConstructor(), paramList);
+  auto constructor = new (context)
+      ConstructorDecl(name, structDecl->getLoc(),
+                      /*Failable=*/false, /*FailabilityLoc=*/SourceLoc(),
+                      /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
+                      /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(), paramList,
+                      /*GenericParams=*/nullptr, structDecl);
+
+  constructor->setAccess(AccessLevel::Public);
+
+  // Make the constructor transparent so we inline it away completely.
+  constructor->getAttrs().add(new (context) TransparentAttr(/*implicit*/ true));
+
+  if (wantBody) {
+    auto memberMemory =
+        context.AllocateUninitialized<uintptr_t>(members.size() + 1);
+    memberMemory[0] = members.size();
+    for (unsigned i : indices(members)) {
+      memberMemory[i + 1] = reinterpret_cast<uintptr_t>(members[i]);
+    }
+    constructor->setBodySynthesizer(synthesizeValueConstructorBody,
+                                    memberMemory.data());
+  }
+
+  // We're done.
+  return constructor;
+}
+
+// MARK: Struct RawValue intializers
+
+/// Synthesizer callback for a raw value bridging constructor body.
+static std::pair<BraceStmt *, bool>
+synthesizeRawValueBridgingConstructorBody(AbstractFunctionDecl *afd,
+                                          void *context) {
+  auto init = cast<ConstructorDecl>(afd);
+  VarDecl *storedRawValue = static_cast<VarDecl *>(context);
+
+  ASTContext &ctx = init->getASTContext();
+
+  auto selfDecl = init->getImplicitSelfDecl();
+  auto storedType = storedRawValue->getInterfaceType();
+
+  // Construct left-hand side.
+  Expr *lhs = new (ctx) DeclRefExpr(selfDecl, DeclNameLoc(),
+                                    /*Implicit=*/true);
+  lhs->setType(LValueType::get(selfDecl->getType()));
+
+  lhs = new (ctx)
+      MemberRefExpr(lhs, SourceLoc(), storedRawValue, DeclNameLoc(),
+                    /*Implicit=*/true, AccessSemantics::DirectToStorage);
+  lhs->setType(LValueType::get(storedType));
+
+  // Construct right-hand side.
+  // FIXME: get the parameter from the init, and plug it in here.
+  auto *paramDecl = init->getParameters()->get(0);
+  auto *paramRef =
+      new (ctx) DeclRefExpr(paramDecl, DeclNameLoc(), /*Implicit=*/true);
+  paramRef->setType(paramDecl->getType());
+
+  Expr *rhs = paramRef;
+  if (!storedRawValue->getInterfaceType()->isEqual(paramDecl->getType())) {
+    auto bridge = new (ctx) BridgeToObjCExpr(paramRef, storedType);
+    bridge->setType(storedType);
+
+    rhs = CoerceExpr::createImplicit(ctx, bridge, storedType);
+  }
+
+  // Add assignment.
+  auto assign = new (ctx) AssignExpr(lhs, SourceLoc(), rhs,
+                                     /*Implicit=*/true);
+  assign->setType(TupleType::getEmpty(ctx));
+
+  auto ret = new (ctx) ReturnStmt(SourceLoc(), nullptr, /*Implicit=*/true);
+
+  auto body = BraceStmt::create(ctx, SourceLoc(), {assign, ret}, SourceLoc());
+  return {body, /*isTypeChecked=*/true};
+}
+
+ConstructorDecl *SwiftDeclSynthesizer::createRawValueBridgingConstructor(
+    StructDecl *structDecl, VarDecl *computedRawValue, VarDecl *storedRawValue,
+    bool wantLabel, bool wantBody) {
+  auto init = createValueConstructor(structDecl, computedRawValue,
+                                     /*wantCtorParamNames=*/wantLabel,
+                                     /*wantBody=*/false);
+  // Insert our custom init body
+  if (wantBody) {
+    init->setBodySynthesizer(synthesizeRawValueBridgingConstructorBody,
+                             storedRawValue);
+  }
+
+  return init;
+}
+
+void SwiftDeclSynthesizer::makeStructRawValuedWithBridge(
+    StructDecl *structDecl, Type storedUnderlyingType, Type bridgedType,
+    ArrayRef<KnownProtocolKind> synthesizedProtocolAttrs,
+    bool makeUnlabeledValueInit) {
+  auto &ctx = ImporterImpl.SwiftContext;
+
+  ImporterImpl.addSynthesizedProtocolAttrs(structDecl,
+                                           synthesizedProtocolAttrs);
+
+  auto storedVarName = ctx.getIdentifier("_rawValue");
+  auto computedVarName = ctx.Id_rawValue;
+
+  // Create a variable to store the underlying value.
+  VarDecl *storedVar;
+  PatternBindingDecl *storedPatternBinding;
+  std::tie(storedVar, storedPatternBinding) = createVarWithPattern(
+      structDecl, storedVarName, storedUnderlyingType, VarDecl::Introducer::Var,
+      /*isImplicit=*/true, AccessLevel::Private, AccessLevel::Private);
+
+  // Create a computed value variable.
+  auto computedVar = new (ctx) VarDecl(
+      /*IsStatic*/ false, VarDecl::Introducer::Var, SourceLoc(),
+      computedVarName, structDecl);
+  computedVar->setInterfaceType(bridgedType);
+  computedVar->setImplicit();
+  computedVar->setAccess(AccessLevel::Public);
+  computedVar->setSetterAccess(AccessLevel::Private);
+
+  // Create the getter for the computed value variable.
+  auto computedVarGetter =
+      makeStructRawValueGetter(structDecl, computedVar, storedVar);
+  ImporterImpl.makeComputed(computedVar, computedVarGetter, nullptr);
+
+  // Create a pattern binding to describe the variable.
+  Pattern *computedBindingPattern = createTypedNamedPattern(computedVar);
+  auto *computedPatternBinding = PatternBindingDecl::createImplicit(
+      ctx, StaticSpellingKind::None, computedBindingPattern,
+      /*InitExpr*/ nullptr, structDecl);
+
+  auto init =
+      createRawValueBridgingConstructor(structDecl, computedVar, storedVar,
+                                        /*wantLabel*/ true,
+                                        /*wantBody*/ true);
+
+  ConstructorDecl *unlabeledCtor = nullptr;
+  if (makeUnlabeledValueInit)
+    unlabeledCtor = createRawValueBridgingConstructor(
+        structDecl, computedVar, storedVar,
+        /*wantLabel*/ false, /*wantBody*/ true);
+
+  if (unlabeledCtor)
+    structDecl->addMember(unlabeledCtor);
+  structDecl->addMember(init);
+  structDecl->addMember(storedPatternBinding);
+  structDecl->addMember(storedVar);
+  structDecl->addMember(computedPatternBinding);
+  structDecl->addMember(computedVar);
+
+  ImporterImpl.addSynthesizedTypealias(structDecl, ctx.Id_RawValue,
+                                       bridgedType);
+  ImporterImpl.RawTypes[structDecl] = bridgedType;
+}
+
+void SwiftDeclSynthesizer::makeStructRawValued(
+    StructDecl *structDecl, Type underlyingType,
+    ArrayRef<KnownProtocolKind> synthesizedProtocolAttrs,
+    MakeStructRawValuedOptions options, AccessLevel setterAccess) {
+  auto &ctx = ImporterImpl.SwiftContext;
+
+  ImporterImpl.addSynthesizedProtocolAttrs(structDecl,
+                                           synthesizedProtocolAttrs);
+
+  // Create a variable to store the underlying value.
+  VarDecl *var;
+  PatternBindingDecl *patternBinding;
+  auto introducer = (options.contains(MakeStructRawValuedFlags::IsLet)
+                         ? VarDecl::Introducer::Let
+                         : VarDecl::Introducer::Var);
+  std::tie(var, patternBinding) = createVarWithPattern(
+      structDecl, ctx.Id_rawValue, underlyingType, introducer,
+      options.contains(MakeStructRawValuedFlags::IsImplicit),
+      AccessLevel::Public, setterAccess);
+
+  assert(var->hasStorage());
+
+  // Create constructors to initialize that value from a value of the
+  // underlying type.
+  if (options.contains(MakeStructRawValuedFlags::MakeUnlabeledValueInit))
+    structDecl->addMember(createValueConstructor(structDecl, var,
+                                                 /*wantCtorParamNames=*/false,
+                                                 /*wantBody=*/true));
+
+  auto *initRawValue = createValueConstructor(structDecl, var,
+                                              /*wantCtorParamNames=*/true,
+                                              /*wantBody=*/true);
+  structDecl->addMember(initRawValue);
+  structDecl->addMember(patternBinding);
+  structDecl->addMember(var);
+
+  ImporterImpl.addSynthesizedTypealias(structDecl, ctx.Id_RawValue,
+                                       underlyingType);
+  ImporterImpl.RawTypes[structDecl] = underlyingType;
+}
+
+// MARK: Unions
+
+/// Synthesizer for the body of a union field getter.
+static std::pair<BraceStmt *, bool>
+synthesizeUnionFieldGetterBody(AbstractFunctionDecl *afd, void *context) {
+  auto getterDecl = cast<AccessorDecl>(afd);
+  ASTContext &ctx = getterDecl->getASTContext();
+  auto importedFieldDecl = static_cast<VarDecl *>(context);
+
+  auto selfDecl = getterDecl->getImplicitSelfDecl();
+
+  auto selfRef = new (ctx) DeclRefExpr(selfDecl, DeclNameLoc(),
+                                       /*implicit*/ true);
+  selfRef->setType(selfDecl->getInterfaceType());
+
+  auto reinterpretCast = cast<FuncDecl>(
+      getBuiltinValueDecl(ctx, ctx.getIdentifier("reinterpretCast")));
+
+  ConcreteDeclRef reinterpretCastRef(
+      reinterpretCast,
+      SubstitutionMap::get(
+          reinterpretCast->getGenericSignature(),
+          {selfDecl->getInterfaceType(), importedFieldDecl->getInterfaceType()},
+          ArrayRef<ProtocolConformanceRef>()));
+  auto reinterpretCastRefExpr =
+      new (ctx) DeclRefExpr(reinterpretCastRef, DeclNameLoc(),
+                            /*implicit*/ true);
+  // FIXME: Verify ExtInfo state is correct, not working by accident.
+  FunctionType::ExtInfo info;
+  reinterpretCastRefExpr->setType(
+      FunctionType::get(AnyFunctionType::Param(selfDecl->getInterfaceType()),
+                        importedFieldDecl->getInterfaceType(), info));
+
+  auto *argList = ArgumentList::forImplicitUnlabeled(ctx, {selfRef});
+  auto reinterpreted =
+      CallExpr::createImplicit(ctx, reinterpretCastRefExpr, argList);
+  reinterpreted->setType(importedFieldDecl->getInterfaceType());
+  reinterpreted->setThrows(false);
+  auto ret = new (ctx) ReturnStmt(SourceLoc(), reinterpreted);
+  auto body = BraceStmt::create(ctx, SourceLoc(), ASTNode(ret), SourceLoc(),
+                                /*implicit*/ true);
+  return {body, /*isTypeChecked*/ true};
+}
+
+/// Synthesizer for the body of a union field setter.
+static std::pair<BraceStmt *, bool>
+synthesizeUnionFieldSetterBody(AbstractFunctionDecl *afd, void *context) {
+  auto setterDecl = cast<AccessorDecl>(afd);
+  ASTContext &ctx = setterDecl->getASTContext();
+
+  auto inoutSelfDecl = setterDecl->getImplicitSelfDecl();
+
+  auto inoutSelfRef = new (ctx) DeclRefExpr(inoutSelfDecl, DeclNameLoc(),
+                                            /*implicit*/ true);
+  inoutSelfRef->setType(LValueType::get(inoutSelfDecl->getInterfaceType()));
+  auto inoutSelf = new (ctx) InOutExpr(
+      SourceLoc(), inoutSelfRef,
+      setterDecl->mapTypeIntoContext(inoutSelfDecl->getValueInterfaceType()),
+      /*implicit*/ true);
+  inoutSelf->setType(InOutType::get(inoutSelfDecl->getInterfaceType()));
+
+  auto newValueDecl = setterDecl->getParameters()->get(0);
+
+  auto newValueRef = new (ctx) DeclRefExpr(newValueDecl, DeclNameLoc(),
+                                           /*implicit*/ true);
+  newValueRef->setType(newValueDecl->getInterfaceType());
+
+  auto addressofFn =
+      cast<FuncDecl>(getBuiltinValueDecl(ctx, ctx.getIdentifier("addressof")));
+  ConcreteDeclRef addressofFnRef(
+      addressofFn, SubstitutionMap::get(addressofFn->getGenericSignature(),
+                                        {inoutSelfDecl->getInterfaceType()},
+                                        ArrayRef<ProtocolConformanceRef>()));
+  auto addressofFnRefExpr =
+      new (ctx) DeclRefExpr(addressofFnRef, DeclNameLoc(), /*implicit*/ true);
+  // FIXME: Verify ExtInfo state is correct, not working by accident.
+  FunctionType::ExtInfo addressOfInfo;
+  addressofFnRefExpr->setType(FunctionType::get(
+      AnyFunctionType::Param(inoutSelfDecl->getInterfaceType(), Identifier(),
+                             ParameterTypeFlags().withInOut(true)),
+      ctx.TheRawPointerType, addressOfInfo));
+
+  auto *selfPtrArgs = ArgumentList::forImplicitUnlabeled(ctx, {inoutSelf});
+  auto selfPointer =
+      CallExpr::createImplicit(ctx, addressofFnRefExpr, selfPtrArgs);
+  selfPointer->setType(ctx.TheRawPointerType);
+  selfPointer->setThrows(false);
+
+  auto initializeFn =
+      cast<FuncDecl>(getBuiltinValueDecl(ctx, ctx.getIdentifier("initialize")));
+  ConcreteDeclRef initializeFnRef(
+      initializeFn, SubstitutionMap::get(initializeFn->getGenericSignature(),
+                                         {newValueDecl->getInterfaceType()},
+                                         ArrayRef<ProtocolConformanceRef>()));
+  auto initializeFnRefExpr =
+      new (ctx) DeclRefExpr(initializeFnRef, DeclNameLoc(), /*implicit*/ true);
+  // FIXME: Verify ExtInfo state is correct, not working by accident.
+  FunctionType::ExtInfo initializeInfo;
+  initializeFnRefExpr->setType(FunctionType::get(
+      {AnyFunctionType::Param(newValueDecl->getInterfaceType()),
+       AnyFunctionType::Param(ctx.TheRawPointerType)},
+      TupleType::getEmpty(ctx), initializeInfo));
+
+  auto *initArgs =
+      ArgumentList::forImplicitUnlabeled(ctx, {newValueRef, selfPointer});
+  auto initialize =
+      CallExpr::createImplicit(ctx, initializeFnRefExpr, initArgs);
+  initialize->setType(TupleType::getEmpty(ctx));
+  initialize->setThrows(false);
+
+  auto body = BraceStmt::create(ctx, SourceLoc(), {initialize}, SourceLoc(),
+                                /*implicit*/ true);
+  return {body, /*isTypeChecked*/ true};
+}
+
+std::pair<AccessorDecl *, AccessorDecl *>
+SwiftDeclSynthesizer::makeUnionFieldAccessors(
+    NominalTypeDecl *importedUnionDecl, VarDecl *importedFieldDecl) {
+  auto &C = ImporterImpl.SwiftContext;
+
+  auto getterDecl =
+      makeFieldGetterDecl(ImporterImpl, importedUnionDecl, importedFieldDecl);
+  getterDecl->setBodySynthesizer(synthesizeUnionFieldGetterBody,
+                                 importedFieldDecl);
+  getterDecl->getAttrs().add(new (C) TransparentAttr(/*implicit*/ true));
+
+  auto setterDecl =
+      makeFieldSetterDecl(ImporterImpl, importedUnionDecl, importedFieldDecl);
+  setterDecl->setBodySynthesizer(synthesizeUnionFieldSetterBody,
+                                 importedFieldDecl);
+  setterDecl->getAttrs().add(new (C) TransparentAttr(/*implicit*/ true));
+
+  ImporterImpl.makeComputed(importedFieldDecl, getterDecl, setterDecl);
+  return {getterDecl, setterDecl};
+}
+
+static clang::DeclarationName
+getAccessorDeclarationName(clang::ASTContext &Ctx, NominalTypeDecl *structDecl,
+                           VarDecl *fieldDecl, const char *suffix) {
+  std::string id;
+  llvm::raw_string_ostream IdStream(id);
+  Mangle::ASTMangler mangler;
+  IdStream << "$" << mangler.mangleDeclAsUSR(structDecl, "") << "$"
+           << fieldDecl->getName() << "$" << suffix;
+
+  return clang::DeclarationName(&Ctx.Idents.get(IdStream.str()));
+}
+
+std::pair<FuncDecl *, FuncDecl *> SwiftDeclSynthesizer::makeBitFieldAccessors(
+    clang::RecordDecl *structDecl, NominalTypeDecl *importedStructDecl,
+    clang::FieldDecl *fieldDecl, VarDecl *importedFieldDecl) {
+  clang::ASTContext &Ctx = ImporterImpl.getClangASTContext();
+
+  // Getter: static inline FieldType get(RecordType self);
+  auto recordType = Ctx.getRecordType(structDecl);
+  auto recordPointerType = Ctx.getPointerType(recordType);
+  auto fieldType = fieldDecl->getType();
+
+  auto cGetterName = getAccessorDeclarationName(Ctx, importedStructDecl,
+                                                importedFieldDecl, "getter");
+  auto cGetterType =
+      Ctx.getFunctionType(fieldDecl->getType(), recordType,
+                          clang::FunctionProtoType::ExtProtoInfo());
+  auto cGetterTypeInfo = Ctx.getTrivialTypeSourceInfo(cGetterType);
+  auto cGetterDecl = clang::FunctionDecl::Create(
+      Ctx, structDecl->getDeclContext(), clang::SourceLocation(),
+      clang::SourceLocation(), cGetterName, cGetterType, cGetterTypeInfo,
+      clang::SC_Static);
+  cGetterDecl->setImplicitlyInline();
+  assert(!cGetterDecl->isExternallyVisible());
+
+  auto getterDecl = makeFieldGetterDecl(ImporterImpl, importedStructDecl,
+                                        importedFieldDecl, cGetterDecl);
+
+  // Setter: static inline void set(FieldType newValue, RecordType *self);
+  SmallVector<clang::QualType, 8> cSetterParamTypes;
+  cSetterParamTypes.push_back(fieldType);
+  cSetterParamTypes.push_back(recordPointerType);
+
+  auto cSetterName = getAccessorDeclarationName(Ctx, importedStructDecl,
+                                                importedFieldDecl, "setter");
+  auto cSetterType = Ctx.getFunctionType(
+      Ctx.VoidTy, cSetterParamTypes, clang::FunctionProtoType::ExtProtoInfo());
+  auto cSetterTypeInfo = Ctx.getTrivialTypeSourceInfo(cSetterType);
+
+  auto cSetterDecl = clang::FunctionDecl::Create(
+      Ctx, structDecl->getDeclContext(), clang::SourceLocation(),
+      clang::SourceLocation(), cSetterName, cSetterType, cSetterTypeInfo,
+      clang::SC_Static);
+  cSetterDecl->setImplicitlyInline();
+  assert(!cSetterDecl->isExternallyVisible());
+
+  auto setterDecl = makeFieldSetterDecl(ImporterImpl, importedStructDecl,
+                                        importedFieldDecl, cSetterDecl);
+
+  ImporterImpl.makeComputed(importedFieldDecl, getterDecl, setterDecl);
+
+  // Synthesize the getter body
+  {
+    auto cGetterSelfId = nullptr;
+    auto recordTypeInfo = Ctx.getTrivialTypeSourceInfo(recordType);
+    auto cGetterSelf = clang::ParmVarDecl::Create(
+        Ctx, cGetterDecl, clang::SourceLocation(), clang::SourceLocation(),
+        cGetterSelfId, recordType, recordTypeInfo, clang::SC_None, nullptr);
+    cGetterDecl->setParams(cGetterSelf);
+
+    auto cGetterSelfExpr = new (Ctx)
+        clang::DeclRefExpr(Ctx, cGetterSelf, false, recordType,
+                           clang::VK_PRValue, clang::SourceLocation());
+    auto cGetterExpr = clang::MemberExpr::CreateImplicit(
+        Ctx, cGetterSelfExpr,
+        /*isarrow=*/false, fieldDecl, fieldType, clang::VK_PRValue,
+        clang::OK_BitField);
+
+    auto cGetterBody = clang::ReturnStmt::Create(Ctx, clang::SourceLocation(),
+                                                 cGetterExpr, nullptr);
+    cGetterDecl->setBody(cGetterBody);
+  }
+
+  // Synthesize the setter body
+  {
+    SmallVector<clang::ParmVarDecl *, 2> cSetterParams;
+    auto fieldTypeInfo = Ctx.getTrivialTypeSourceInfo(fieldType);
+    auto cSetterValue = clang::ParmVarDecl::Create(
+        Ctx, cSetterDecl, clang::SourceLocation(), clang::SourceLocation(),
+        /* nameID? */ nullptr, fieldType, fieldTypeInfo, clang::SC_None,
+        nullptr);
+    cSetterParams.push_back(cSetterValue);
+    auto recordPointerTypeInfo =
+        Ctx.getTrivialTypeSourceInfo(recordPointerType);
+    auto cSetterSelf = clang::ParmVarDecl::Create(
+        Ctx, cSetterDecl, clang::SourceLocation(), clang::SourceLocation(),
+        /* nameID? */ nullptr, recordPointerType, recordPointerTypeInfo,
+        clang::SC_None, nullptr);
+    cSetterParams.push_back(cSetterSelf);
+    cSetterDecl->setParams(cSetterParams);
+
+    auto cSetterSelfExpr = new (Ctx)
+        clang::DeclRefExpr(Ctx, cSetterSelf, false, recordPointerType,
+                           clang::VK_PRValue, clang::SourceLocation());
+
+    auto cSetterMemberExpr = clang::MemberExpr::CreateImplicit(
+        Ctx, cSetterSelfExpr,
+        /*isarrow=*/true, fieldDecl, fieldType, clang::VK_LValue,
+        clang::OK_BitField);
+
+    auto cSetterValueExpr = new (Ctx)
+        clang::DeclRefExpr(Ctx, cSetterValue, false, fieldType,
+                           clang::VK_PRValue, clang::SourceLocation());
+
+    auto cSetterExpr = clang::BinaryOperator::Create(
+        Ctx, cSetterMemberExpr, cSetterValueExpr, clang::BO_Assign, fieldType,
+        clang::VK_PRValue, clang::OK_Ordinary, clang::SourceLocation(),
+        clang::FPOptionsOverride());
+
+    cSetterDecl->setBody(cSetterExpr);
+  }
+
+  return {getterDecl, setterDecl};
+}
+
+/// Find the anonymous inner field declaration for the given anonymous field.
+static VarDecl *findAnonymousInnerFieldDecl(VarDecl *importedFieldDecl,
+                                            VarDecl *anonymousFieldDecl) {
+  auto anonymousFieldType = anonymousFieldDecl->getInterfaceType();
+  auto anonymousFieldTypeDecl =
+      anonymousFieldType->getStructOrBoundGenericStruct();
+
+  for (auto decl :
+       anonymousFieldTypeDecl->lookupDirect(importedFieldDecl->getName())) {
+    if (isa<VarDecl>(decl)) {
+      return cast<VarDecl>(decl);
+    }
+  }
+
+  llvm_unreachable("couldn't find anonymous inner field decl");
+}
+
+// MARK: Indirect fields
+
+/// Synthesize the getter body for an indirect field.
+static std::pair<BraceStmt *, bool>
+synthesizeIndirectFieldGetterBody(AbstractFunctionDecl *afd, void *context) {
+  auto getterDecl = cast<AccessorDecl>(afd);
+  auto anonymousFieldDecl = static_cast<VarDecl *>(context);
+
+  ASTContext &ctx = getterDecl->getASTContext();
+  auto selfDecl = getterDecl->getImplicitSelfDecl();
+  Expr *expr = new (ctx) DeclRefExpr(selfDecl, DeclNameLoc(),
+                                     /*implicit*/ true);
+  expr->setType(selfDecl->getInterfaceType());
+
+  expr = new (ctx) MemberRefExpr(expr, SourceLoc(), anonymousFieldDecl,
+                                 DeclNameLoc(), /*implicit*/ true);
+  expr->setType(anonymousFieldDecl->getInterfaceType());
+
+  auto importedFieldDecl = cast<VarDecl>(getterDecl->getStorage());
+  auto anonymousInnerFieldDecl =
+      findAnonymousInnerFieldDecl(importedFieldDecl, anonymousFieldDecl);
+  expr = new (ctx) MemberRefExpr(expr, SourceLoc(), anonymousInnerFieldDecl,
+                                 DeclNameLoc(), /*implicit*/ true);
+  expr->setType(anonymousInnerFieldDecl->getInterfaceType());
+
+  auto ret = new (ctx) ReturnStmt(SourceLoc(), expr);
+  auto body = BraceStmt::create(ctx, SourceLoc(), ASTNode(ret), SourceLoc(),
+                                /*implicit*/ true);
+  return {body, /*isTypeChecked=*/true};
+}
+
+/// Synthesize the setter body for an indirect field.
+static std::pair<BraceStmt *, bool>
+synthesizeIndirectFieldSetterBody(AbstractFunctionDecl *afd, void *context) {
+  auto setterDecl = cast<AccessorDecl>(afd);
+  auto anonymousFieldDecl = static_cast<VarDecl *>(context);
+
+  ASTContext &ctx = setterDecl->getASTContext();
+  auto selfDecl = setterDecl->getImplicitSelfDecl();
+  Expr *lhs = new (ctx) DeclRefExpr(selfDecl, DeclNameLoc(),
+                                    /*implicit*/ true);
+  lhs->setType(LValueType::get(selfDecl->getInterfaceType()));
+
+  lhs = new (ctx) MemberRefExpr(lhs, SourceLoc(), anonymousFieldDecl,
+                                DeclNameLoc(), /*implicit*/ true);
+  lhs->setType(LValueType::get(anonymousFieldDecl->getInterfaceType()));
+
+  auto importedFieldDecl = cast<VarDecl>(setterDecl->getStorage());
+  auto anonymousInnerFieldDecl =
+      findAnonymousInnerFieldDecl(importedFieldDecl, anonymousFieldDecl);
+
+  lhs = new (ctx) MemberRefExpr(lhs, SourceLoc(), anonymousInnerFieldDecl,
+                                DeclNameLoc(), /*implicit*/ true);
+  lhs->setType(LValueType::get(anonymousInnerFieldDecl->getInterfaceType()));
+
+  auto newValueDecl = setterDecl->getParameters()->get(0);
+
+  auto rhs = new (ctx) DeclRefExpr(newValueDecl, DeclNameLoc(),
+                                   /*implicit*/ true);
+  rhs->setType(newValueDecl->getInterfaceType());
+
+  auto assign = new (ctx) AssignExpr(lhs, SourceLoc(), rhs, /*implicit*/ true);
+  assign->setType(TupleType::getEmpty(ctx));
+
+  auto body = BraceStmt::create(ctx, SourceLoc(), {assign}, SourceLoc(),
+                                /*implicit*/ true);
+  return {body, /*isTypeChecked=*/true};
+}
+
+std::pair<AccessorDecl *, AccessorDecl *>
+SwiftDeclSynthesizer::makeIndirectFieldAccessors(
+    const clang::IndirectFieldDecl *indirectField, ArrayRef<VarDecl *> members,
+    NominalTypeDecl *importedStructDecl, VarDecl *importedFieldDecl) {
+  auto &C = ImporterImpl.SwiftContext;
+
+  auto getterDecl =
+      makeFieldGetterDecl(ImporterImpl, importedStructDecl, importedFieldDecl);
+  getterDecl->getAttrs().add(new (C) TransparentAttr(/*implicit*/ true));
+
+  auto setterDecl =
+      makeFieldSetterDecl(ImporterImpl, importedStructDecl, importedFieldDecl);
+  setterDecl->getAttrs().add(new (C) TransparentAttr(/*implicit*/ true));
+
+  ImporterImpl.makeComputed(importedFieldDecl, getterDecl, setterDecl);
+
+  auto containingField = indirectField->chain().front();
+  VarDecl *anonymousFieldDecl = nullptr;
+
+  // Reverse scan of the members because indirect field are generated just
+  // after the corresponding anonymous type, so a reverse scan allows
+  // switching from O(n) to O(1) here.
+  for (auto decl : reverse(members)) {
+    if (decl->getClangDecl() == containingField) {
+      anonymousFieldDecl = cast<VarDecl>(decl);
+      break;
+    }
+  }
+  assert(anonymousFieldDecl && "anonymous field not generated");
+  getterDecl->setBodySynthesizer(synthesizeIndirectFieldGetterBody,
+                                 anonymousFieldDecl);
+  setterDecl->setBodySynthesizer(synthesizeIndirectFieldSetterBody,
+                                 anonymousFieldDecl);
+
+  return {getterDecl, setterDecl};
+}
+
+// MARK: Enum RawValue initializers
+
+/// Synthesize the body of \c init?(rawValue:RawType) for an imported enum.
+static std::pair<BraceStmt *, bool>
+synthesizeEnumRawValueConstructorBody(AbstractFunctionDecl *afd,
+                                      void *context) {
+  ASTContext &ctx = afd->getASTContext();
+  auto ctorDecl = cast<ConstructorDecl>(afd);
+  auto enumDecl = static_cast<EnumDecl *>(context);
+  auto selfDecl = ctorDecl->getImplicitSelfDecl();
+  auto selfRef = new (ctx) DeclRefExpr(selfDecl, DeclNameLoc(),
+                                       /*implicit*/ true);
+  selfRef->setType(LValueType::get(selfDecl->getType()));
+
+  auto param = ctorDecl->getParameters()->get(0);
+  auto paramRef = new (ctx) DeclRefExpr(param, DeclNameLoc(),
+                                        /*implicit*/ true);
+  paramRef->setType(param->getType());
+
+  auto reinterpretCast = cast<FuncDecl>(
+      getBuiltinValueDecl(ctx, ctx.getIdentifier("reinterpretCast")));
+  auto rawTy = enumDecl->getRawType();
+  auto enumTy = enumDecl->getDeclaredInterfaceType();
+  SubstitutionMap subMap = SubstitutionMap::get(
+      reinterpretCast->getGenericSignature(), {rawTy, enumTy}, {});
+  ConcreteDeclRef concreteDeclRef(reinterpretCast, subMap);
+  auto reinterpretCastRef =
+      new (ctx) DeclRefExpr(concreteDeclRef, DeclNameLoc(), /*implicit*/ true);
+  // FIXME: Verify ExtInfo state is correct, not working by accident.
+  FunctionType::ExtInfo info;
+  reinterpretCastRef->setType(
+      FunctionType::get({FunctionType::Param(rawTy)}, enumTy, info));
+
+  auto *argList = ArgumentList::forImplicitUnlabeled(ctx, {paramRef});
+  auto reinterpreted =
+      CallExpr::createImplicit(ctx, reinterpretCastRef, argList);
+  reinterpreted->setType(enumTy);
+  reinterpreted->setThrows(false);
+
+  auto assign = new (ctx) AssignExpr(selfRef, SourceLoc(), reinterpreted,
+                                     /*implicit*/ true);
+  assign->setType(TupleType::getEmpty(ctx));
+
+  auto ret = new (ctx) ReturnStmt(SourceLoc(), nullptr, /*Implicit=*/true);
+
+  auto body = BraceStmt::create(ctx, SourceLoc(), {assign, ret}, SourceLoc(),
+                                /*implicit*/ true);
+  return {body, /*isTypeChecked=*/true};
+}
+
+ConstructorDecl *
+SwiftDeclSynthesizer::makeEnumRawValueConstructor(EnumDecl *enumDecl) {
+  ASTContext &C = ImporterImpl.SwiftContext;
+  auto rawTy = enumDecl->getRawType();
+
+  auto param = new (C) ParamDecl(SourceLoc(), SourceLoc(), C.Id_rawValue,
+                                 SourceLoc(), C.Id_rawValue, enumDecl);
+  param->setSpecifier(ParamSpecifier::Default);
+  param->setInterfaceType(rawTy);
+
+  auto paramPL = ParameterList::createWithoutLoc(param);
+
+  DeclName name(C, DeclBaseName::createConstructor(), paramPL);
+  auto *ctorDecl = new (C)
+      ConstructorDecl(name, enumDecl->getLoc(),
+                      /*Failable=*/true, /*FailabilityLoc=*/SourceLoc(),
+                      /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
+                      /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(), paramPL,
+                      /*GenericParams=*/nullptr, enumDecl);
+  ctorDecl->setImplicit();
+  ctorDecl->setAccess(AccessLevel::Public);
+  ctorDecl->setBodySynthesizer(synthesizeEnumRawValueConstructorBody, enumDecl);
+  return ctorDecl;
+}
+
+// MARK: Enum RawValue getters & setters
+
+/// Synthesizer callback for an enum's rawValue getter.
+static std::pair<BraceStmt *, bool>
+synthesizeEnumRawValueGetterBody(AbstractFunctionDecl *afd, void *context) {
+  auto getterDecl = cast<AccessorDecl>(afd);
+  auto enumDecl = static_cast<EnumDecl *>(context);
+  auto rawTy = enumDecl->getRawType();
+  auto enumTy = enumDecl->getDeclaredInterfaceType();
+
+  ASTContext &ctx = getterDecl->getASTContext();
+  auto *selfDecl = getterDecl->getImplicitSelfDecl();
+  auto selfRef = new (ctx) DeclRefExpr(selfDecl, DeclNameLoc(),
+                                       /*implicit*/ true);
+  selfRef->setType(selfDecl->getType());
+
+  auto reinterpretCast = cast<FuncDecl>(
+      getBuiltinValueDecl(ctx, ctx.getIdentifier("reinterpretCast")));
+  SubstitutionMap subMap = SubstitutionMap::get(
+      reinterpretCast->getGenericSignature(), {enumTy, rawTy}, {});
+  ConcreteDeclRef concreteDeclRef(reinterpretCast, subMap);
+
+  auto reinterpretCastRef =
+      new (ctx) DeclRefExpr(concreteDeclRef, DeclNameLoc(), /*implicit*/ true);
+  // FIXME: Verify ExtInfo state is correct, not working by accident.
+  FunctionType::ExtInfo info;
+  reinterpretCastRef->setType(
+      FunctionType::get({FunctionType::Param(enumTy)}, rawTy, info));
+
+  auto *argList = ArgumentList::forImplicitUnlabeled(ctx, {selfRef});
+  auto reinterpreted =
+      CallExpr::createImplicit(ctx, reinterpretCastRef, argList);
+  reinterpreted->setType(rawTy);
+  reinterpreted->setThrows(false);
+
+  auto ret = new (ctx) ReturnStmt(SourceLoc(), reinterpreted);
+  auto body = BraceStmt::create(ctx, SourceLoc(), ASTNode(ret), SourceLoc(),
+                                /*implicit*/ true);
+  return {body, /*isTypeChecked=*/true};
+}
+
+// Build the rawValue getter for an imported NS_ENUM.
+//   enum NSSomeEnum: RawType {
+//     var rawValue: RawType {
+//       return Builtin.reinterpretCast(self)
+//     }
+//   }
+// Unlike a standard init(rawValue:) enum initializer, this does a reinterpret
+// cast in order to preserve unknown or future cases from C.
+void SwiftDeclSynthesizer::makeEnumRawValueGetter(EnumDecl *enumDecl,
+                                                  VarDecl *rawValueDecl) {
+  ASTContext &C = ImporterImpl.SwiftContext;
+
+  auto rawTy = enumDecl->getRawType();
+
+  auto *params = ParameterList::createEmpty(C);
+
+  auto getterDecl = AccessorDecl::create(
+      C,
+      /*declLoc=*/SourceLoc(),
+      /*AccessorKeywordLoc=*/SourceLoc(), AccessorKind::Get, rawValueDecl,
+      /*StaticLoc=*/SourceLoc(), StaticSpellingKind::None,
+      /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
+      /*Throws=*/false,
+      /*ThrowsLoc=*/SourceLoc(),
+      /*GenericParams=*/nullptr, params, rawTy, enumDecl);
+  getterDecl->setImplicit();
+  getterDecl->setIsObjC(false);
+  getterDecl->setIsDynamic(false);
+  getterDecl->setIsTransparent(false);
+
+  getterDecl->setAccess(AccessLevel::Public);
+  getterDecl->setBodySynthesizer(synthesizeEnumRawValueGetterBody, enumDecl);
+  ImporterImpl.makeComputed(rawValueDecl, getterDecl, nullptr);
+}
+
+// MARK: Struct RawValue getters
+
+/// Synthesizer for the rawValue getter for an imported struct.
+static std::pair<BraceStmt *, bool>
+synthesizeStructRawValueGetterBody(AbstractFunctionDecl *afd, void *context) {
+  auto getterDecl = cast<AccessorDecl>(afd);
+  VarDecl *storedVar = static_cast<VarDecl *>(context);
+
+  ASTContext &ctx = getterDecl->getASTContext();
+  auto *selfDecl = getterDecl->getImplicitSelfDecl();
+  auto selfRef = new (ctx) DeclRefExpr(selfDecl, DeclNameLoc(),
+                                       /*implicit*/ true);
+  selfRef->setType(selfDecl->getType());
+
+  auto storedType = storedVar->getInterfaceType();
+  auto storedRef = new (ctx)
+      MemberRefExpr(selfRef, SourceLoc(), storedVar, DeclNameLoc(),
+                    /*Implicit=*/true, AccessSemantics::DirectToStorage);
+  storedRef->setType(storedType);
+
+  Expr *result = storedRef;
+
+  Type computedType = getterDecl->getResultInterfaceType();
+  if (!computedType->isEqual(storedType)) {
+    auto bridge = new (ctx) BridgeFromObjCExpr(storedRef, computedType);
+    bridge->setType(computedType);
+
+    result = CoerceExpr::createImplicit(ctx, bridge, computedType);
+  }
+
+  auto ret = new (ctx) ReturnStmt(SourceLoc(), result);
+  auto body = BraceStmt::create(ctx, SourceLoc(), ASTNode(ret), SourceLoc(),
+                                /*implicit*/ true);
+  return {body, /*isTypeChecked=*/true};
+}
+
+AccessorDecl *SwiftDeclSynthesizer::makeStructRawValueGetter(
+    StructDecl *structDecl, VarDecl *computedVar, VarDecl *storedVar) {
+  assert(storedVar->hasStorage());
+
+  ASTContext &C = ImporterImpl.SwiftContext;
+
+  auto *params = ParameterList::createEmpty(C);
+
+  auto computedType = computedVar->getInterfaceType();
+
+  auto getterDecl = AccessorDecl::create(
+      C,
+      /*declLoc=*/SourceLoc(),
+      /*AccessorKeywordLoc=*/SourceLoc(), AccessorKind::Get, computedVar,
+      /*StaticLoc=*/SourceLoc(), StaticSpellingKind::None,
+      /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
+      /*Throws=*/false,
+      /*ThrowsLoc=*/SourceLoc(),
+      /*GenericParams=*/nullptr, params, computedType, structDecl);
+  getterDecl->setImplicit();
+  getterDecl->setIsObjC(false);
+  getterDecl->setIsDynamic(false);
+  getterDecl->setIsTransparent(false);
+
+  getterDecl->setAccess(AccessLevel::Public);
+  getterDecl->setBodySynthesizer(synthesizeStructRawValueGetterBody, storedVar);
+  return getterDecl;
+}
+
+// MARK: ObjC subscripts
+
+AccessorDecl *SwiftDeclSynthesizer::buildSubscriptGetterDecl(
+    SubscriptDecl *subscript, const FuncDecl *getter, Type elementTy,
+    DeclContext *dc, ParamDecl *index) {
+  auto &C = ImporterImpl.SwiftContext;
+  auto loc = getter->getLoc();
+
+  auto *params = ParameterList::create(C, index);
+
+  // Create the getter thunk.
+  auto thunk = AccessorDecl::create(
+      C,
+      /*declLoc=*/loc,
+      /*AccessorKeywordLoc=*/SourceLoc(), AccessorKind::Get, subscript,
+      /*StaticLoc=*/SourceLoc(), subscript->getStaticSpelling(),
+      /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
+      /*Throws=*/false,
+      /*ThrowsLoc=*/SourceLoc(),
+      /*GenericParams=*/nullptr, params, elementTy, dc, getter->getClangNode());
+
+  thunk->setAccess(getOverridableAccessLevel(dc));
+
+  if (auto objcAttr = getter->getAttrs().getAttribute<ObjCAttr>())
+    thunk->getAttrs().add(objcAttr->clone(C));
+  thunk->setIsObjC(getter->isObjC());
+  thunk->setIsDynamic(getter->isDynamic());
+  // FIXME: Should we record thunks?
+
+  return thunk;
+}
+
+AccessorDecl *SwiftDeclSynthesizer::buildSubscriptSetterDecl(
+    SubscriptDecl *subscript, const FuncDecl *setter, Type elementInterfaceTy,
+    DeclContext *dc, ParamDecl *index) {
+  auto &C = ImporterImpl.SwiftContext;
+  auto loc = setter->getLoc();
+
+  // Objective-C subscript setters are imported with a function type
+  // such as:
+  //
+  //   (self) -> (value, index) -> ()
+  //
+  // Build a setter thunk with the latter signature that maps to the
+  // former.
+  auto valueIndex = setter->getParameters();
+
+  auto paramVarDecl = new (C) ParamDecl(SourceLoc(), SourceLoc(), Identifier(),
+                                        loc, valueIndex->get(0)->getName(), dc);
+  paramVarDecl->setSpecifier(ParamSpecifier::Default);
+  paramVarDecl->setInterfaceType(elementInterfaceTy);
+
+  auto valueIndicesPL = ParameterList::create(C, {paramVarDecl, index});
+
+  // Create the setter thunk.
+  auto thunk = AccessorDecl::create(
+      C,
+      /*declLoc=*/setter->getLoc(),
+      /*AccessorKeywordLoc=*/SourceLoc(), AccessorKind::Set, subscript,
+      /*StaticLoc=*/SourceLoc(), subscript->getStaticSpelling(),
+      /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
+      /*Throws=*/false,
+      /*ThrowsLoc=*/SourceLoc(),
+      /*GenericParams=*/nullptr, valueIndicesPL, TupleType::getEmpty(C), dc,
+      setter->getClangNode());
+
+  thunk->setAccess(getOverridableAccessLevel(dc));
+
+  if (auto objcAttr = setter->getAttrs().getAttribute<ObjCAttr>())
+    thunk->getAttrs().add(objcAttr->clone(C));
+  thunk->setIsObjC(setter->isObjC());
+  thunk->setIsDynamic(setter->isDynamic());
+
+  return thunk;
+}
+
+// MARK: C++ subscripts
+
+/// Synthesizer callback for a subscript getter or a getter for a
+/// dereference property (`var pointee`). If the getter's implementation returns
+/// an UnsafePointer or UnsafeMutablePointer, it unwraps the pointer and returns
+/// the underlying value.
+static std::pair<BraceStmt *, bool>
+synthesizeUnwrappingGetterBody(AbstractFunctionDecl *afd, void *context) {
+  auto getterDecl = cast<AccessorDecl>(afd);
+  auto getterImpl = static_cast<FuncDecl *>(context);
+
+  ASTContext &ctx = getterDecl->getASTContext();
+
+  Expr *selfExpr = createSelfExpr(getterDecl);
+  DeclRefExpr *keyRefExpr = getterDecl->getParameters()->size() == 0
+                                ? nullptr
+                                : createParamRefExpr(getterDecl, 0);
+
+  Type elementTy = getterDecl->getResultInterfaceType();
+
+  auto *getterImplCallExpr =
+      createAccessorImplCallExpr(getterImpl, selfExpr, keyRefExpr);
+
+  // This default handles C++'s operator[] that returns a value type.
+  Expr *propertyExpr = getterImplCallExpr;
+  PointerTypeKind ptrKind;
+
+  // The following check returns true if the subscript operator returns a C++
+  // reference type. This check actually checks to see if the type is a pointer
+  // type, but this does not apply to C pointers because they are Optional types
+  // when imported. TODO: Use a more obvious check here.
+  if (getterImpl->getResultInterfaceType()->getAnyPointerElementType(ptrKind)) {
+    // `getterImpl` can return either UnsafePointer or UnsafeMutablePointer.
+    // Retrieve the corresponding `.pointee` declaration.
+    VarDecl *pointeePropertyDecl = ctx.getPointerPointeePropertyDecl(ptrKind);
+
+    // Handle operator[] that returns a reference type.
+    SubstitutionMap subMap = SubstitutionMap::get(
+        ctx.getUnsafePointerDecl()->getGenericSignature(), {elementTy}, {});
+    auto pointeePropertyRefExpr = new (ctx) MemberRefExpr(
+        getterImplCallExpr, SourceLoc(),
+        ConcreteDeclRef(pointeePropertyDecl, subMap), DeclNameLoc(),
+        /*implicit*/ true);
+    pointeePropertyRefExpr->setType(elementTy);
+    propertyExpr = pointeePropertyRefExpr;
+  }
+
+  auto returnStmt = new (ctx) ReturnStmt(SourceLoc(), propertyExpr,
+                                         /*implicit*/ true);
+
+  auto body = BraceStmt::create(ctx, SourceLoc(), {returnStmt}, SourceLoc(),
+                                /*implicit*/ true);
+  return {body, /*isTypeChecked*/ true};
+}
+
+/// Synthesizer callback for a subscript setter.
+static std::pair<BraceStmt *, bool>
+synthesizeSubscriptSetterBody(AbstractFunctionDecl *afd, void *context) {
+  auto setterDecl = cast<AccessorDecl>(afd);
+  auto setterImpl = static_cast<FuncDecl *>(context);
+
+  ASTContext &ctx = setterDecl->getASTContext();
+
+  Expr *selfExpr = createSelfExpr(setterDecl);
+  DeclRefExpr *valueParamRefExpr = createParamRefExpr(setterDecl, 0);
+  DeclRefExpr *keyParamRefExpr = createParamRefExpr(setterDecl, 1);
+
+  Type elementTy = valueParamRefExpr->getDecl()->getInterfaceType();
+
+  auto *setterImplCallExpr =
+      createAccessorImplCallExpr(setterImpl, selfExpr, keyParamRefExpr);
+
+  VarDecl *pointeePropertyDecl =
+      ctx.getPointerPointeePropertyDecl(PTK_UnsafeMutablePointer);
+
+  SubstitutionMap subMap = SubstitutionMap::get(
+      ctx.getUnsafeMutablePointerDecl()->getGenericSignature(), {elementTy},
+      {});
+  auto pointeePropertyRefExpr = new (ctx)
+      MemberRefExpr(setterImplCallExpr, SourceLoc(),
+                    ConcreteDeclRef(pointeePropertyDecl, subMap), DeclNameLoc(),
+                    /*implicit*/ true);
+  pointeePropertyRefExpr->setType(LValueType::get(elementTy));
+
+  auto assignExpr = new (ctx)
+      AssignExpr(pointeePropertyRefExpr, SourceLoc(), valueParamRefExpr,
+                 /*implicit*/ true);
+  assignExpr->setType(TupleType::getEmpty(ctx));
+
+  auto body = BraceStmt::create(ctx, SourceLoc(),
+                                {
+                                    assignExpr,
+                                },
+                                SourceLoc());
+  return {body, /*isTypeChecked*/ true};
+}
+
+SubscriptDecl *SwiftDeclSynthesizer::makeSubscript(FuncDecl *getter,
+                                                   FuncDecl *setter) {
+  assert((getter || setter) &&
+         "getter or setter required to generate subscript");
+
+  // If only a setter (imported from non-const `operator[]`) is defined,
+  // generate both get & set accessors from it.
+  FuncDecl *getterImpl = getter ? getter : setter;
+  FuncDecl *setterImpl = setter;
+
+  // Get the return type wrapped in `Unsafe(Mutable)Pointer<T>`.
+  const auto rawElementTy = getterImpl->getResultInterfaceType();
+  // Unwrap `T`. Use rawElementTy for return by value.
+  const auto elementTy = rawElementTy->getAnyPointerElementType()
+                             ? rawElementTy->getAnyPointerElementType()
+                             : rawElementTy;
+
+  auto &ctx = ImporterImpl.SwiftContext;
+  auto bodyParams = getterImpl->getParameters();
+  DeclName name(ctx, DeclBaseName::createSubscript(), bodyParams);
+  auto dc = getterImpl->getDeclContext();
+
+  SubscriptDecl *subscript = SubscriptDecl::createImported(
+      ctx, name, getterImpl->getLoc(), bodyParams, getterImpl->getLoc(),
+      elementTy, dc, getterImpl->getClangNode());
+  subscript->setAccess(AccessLevel::Public);
+
+  AccessorDecl *getterDecl = AccessorDecl::create(
+      ctx, getterImpl->getLoc(), getterImpl->getLoc(), AccessorKind::Get,
+      subscript, SourceLoc(), subscript->getStaticSpelling(),
+      /*async*/ false, SourceLoc(),
+      /*throws*/ false, SourceLoc(), nullptr, bodyParams, elementTy, dc);
+  getterDecl->setAccess(AccessLevel::Public);
+  getterDecl->setImplicit();
+  getterDecl->setIsDynamic(false);
+  getterDecl->setIsTransparent(true);
+  getterDecl->setBodySynthesizer(synthesizeUnwrappingGetterBody, getterImpl);
+
+  if (getterImpl->isMutating()) {
+    getterDecl->setSelfAccessKind(SelfAccessKind::Mutating);
+    subscript->setIsGetterMutating(true);
+  }
+
+  AccessorDecl *setterDecl = nullptr;
+  if (setterImpl) {
+    auto paramVarDecl =
+        new (ctx) ParamDecl(SourceLoc(), SourceLoc(), Identifier(), SourceLoc(),
+                            ctx.getIdentifier("newValue"), dc);
+    paramVarDecl->setSpecifier(ParamSpecifier::Default);
+    paramVarDecl->setInterfaceType(elementTy);
+
+    auto setterParamList =
+        ParameterList::create(ctx, {paramVarDecl, bodyParams->get(0)});
+
+    setterDecl = AccessorDecl::create(
+        ctx, setterImpl->getLoc(), setterImpl->getLoc(), AccessorKind::Set,
+        subscript, SourceLoc(), subscript->getStaticSpelling(),
+        /*async*/ false, SourceLoc(),
+        /*throws*/ false, SourceLoc(), nullptr, setterParamList,
+        TupleType::getEmpty(ctx), dc);
+    setterDecl->setAccess(AccessLevel::Public);
+    setterDecl->setImplicit();
+    setterDecl->setIsDynamic(false);
+    setterDecl->setIsTransparent(true);
+    setterDecl->setBodySynthesizer(synthesizeSubscriptSetterBody, setterImpl);
+
+    if (setterImpl->isMutating()) {
+      setterDecl->setSelfAccessKind(SelfAccessKind::Mutating);
+      subscript->setIsSetterMutating(true);
+    }
+  }
+
+  ImporterImpl.makeComputed(subscript, getterDecl, setterDecl);
+
+  // Implicitly unwrap Optional types for T *operator[].
+  ImporterImpl.recordImplicitUnwrapForDecl(
+      subscript, getterImpl->isImplicitlyUnwrappedOptional());
+
+  return subscript;
+}
+
+// MARK: C++ dereference operator
+
+VarDecl *SwiftDeclSynthesizer::makeDereferencedPointeeProperty(
+    FuncDecl *dereferenceFunc) {
+  auto &ctx = ImporterImpl.SwiftContext;
+  auto dc = dereferenceFunc->getDeclContext();
+
+  // Get the return type wrapped in `Unsafe(Mutable)Pointer<T>`.
+  const auto rawElementTy = dereferenceFunc->getResultInterfaceType();
+  // Unwrap `T`. Use rawElementTy for return by value.
+  const auto elementTy = rawElementTy->getAnyPointerElementType()
+                             ? rawElementTy->getAnyPointerElementType()
+                             : rawElementTy;
+
+  auto result = new (ctx)
+      VarDecl(/*isStatic*/ false, VarDecl::Introducer::Var,
+              dereferenceFunc->getStartLoc(), ctx.getIdentifier("pointee"), dc);
+  result->setInterfaceType(elementTy);
+  result->setAccess(AccessLevel::Public);
+  result->setImplInfo(StorageImplInfo::getImmutableComputed());
+
+  AccessorDecl *getterDecl = AccessorDecl::create(
+      ctx, dereferenceFunc->getLoc(), dereferenceFunc->getLoc(),
+      AccessorKind::Get, result, SourceLoc(), StaticSpellingKind::None,
+      /*async*/ false, SourceLoc(),
+      /*throws*/ false, SourceLoc(), nullptr, ParameterList::createEmpty(ctx),
+      elementTy, dc);
+  getterDecl->setAccess(AccessLevel::Public);
+  getterDecl->setImplicit();
+  getterDecl->setIsDynamic(false);
+  getterDecl->setIsTransparent(true);
+  getterDecl->setBodySynthesizer(synthesizeUnwrappingGetterBody,
+                                 dereferenceFunc);
+
+  if (dereferenceFunc->isMutating()) {
+    getterDecl->setSelfAccessKind(SelfAccessKind::Mutating);
+    result->setIsGetterMutating(true);
+  }
+
+  ImporterImpl.makeComputed(result, getterDecl, /*setter*/ nullptr);
+  return result;
+}
+
+// MARK: C++ arithmetic operators
+
+static std::pair<BraceStmt *, bool>
+synthesizeOperatorMethodBody(AbstractFunctionDecl *afd, void *context) {
+  ASTContext &ctx = afd->getASTContext();
+
+  auto funcDecl = cast<FuncDecl>(afd);
+  auto methodDecl =
+      static_cast<FuncDecl *>(context); /* Swift version of CXXMethod */
+
+  SmallVector<Expr *, 8> forwardingParams;
+
+  // We start from +1 since the first param is our lhs. All other params are
+  // forwarded
+  for (auto itr = funcDecl->getParameters()->begin() + 1;
+       itr != funcDecl->getParameters()->end(); itr++) {
+    auto param = *itr;
+    Expr *paramRefExpr =
+        new (ctx) DeclRefExpr(param, DeclNameLoc(), /*Implicit*/ true);
+    paramRefExpr->setType(param->getType());
+
+    if (param->isInOut()) {
+      paramRefExpr->setType(LValueType::get(param->getType()));
+
+      paramRefExpr = new (ctx) InOutExpr(SourceLoc(), paramRefExpr,
+                                         param->getType(), /*isImplicit*/ true);
+      paramRefExpr->setType(InOutType::get(param->getType()));
+    }
+
+    forwardingParams.push_back(paramRefExpr);
+  }
+
+  auto methodExpr =
+      new (ctx) DeclRefExpr(methodDecl, DeclNameLoc(), /*implicit*/ true);
+  methodExpr->setType(methodDecl->getInterfaceType());
+
+  // Lhs parameter
+  auto baseParam = funcDecl->getParameters()->front();
+  Expr *baseExpr =
+      new (ctx) DeclRefExpr(baseParam, DeclNameLoc(), /*implicit*/ true);
+  baseExpr->setType(baseParam->getType());
+  if (baseParam->isInOut()) {
+    baseExpr->setType(LValueType::get(baseParam->getType()));
+
+    baseExpr = new (ctx) InOutExpr(SourceLoc(), baseExpr, baseParam->getType(),
+                                   /*isImplicit*/ true);
+    baseExpr->setType(InOutType::get(baseParam->getType()));
+  }
+
+  auto dotCallExpr =
+      DotSyntaxCallExpr::create(ctx, methodExpr, SourceLoc(), baseExpr);
+  dotCallExpr->setType(methodDecl->getMethodInterfaceType());
+  dotCallExpr->setThrows(false);
+
+  auto *argList = ArgumentList::forImplicitUnlabeled(ctx, forwardingParams);
+  auto callExpr = CallExpr::createImplicit(ctx, dotCallExpr, argList);
+  callExpr->setType(funcDecl->getResultInterfaceType());
+  callExpr->setThrows(false);
+
+  auto returnStmt = new (ctx) ReturnStmt(SourceLoc(), callExpr,
+                                         /*implicit*/ true);
+
+  auto body = BraceStmt::create(ctx, SourceLoc(), {returnStmt}, SourceLoc(),
+                                /*implicit*/ true);
+  return {body, /*isTypeChecked*/ true};
+}
+
+FuncDecl *
+SwiftDeclSynthesizer::makeOperator(FuncDecl *operatorMethod,
+                                   clang::CXXMethodDecl *clangOperator) {
+  auto &ctx = ImporterImpl.SwiftContext;
+  auto opName =
+      clang::getOperatorSpelling(clangOperator->getOverloadedOperator());
+  auto paramList = operatorMethod->getParameters();
+  auto genericParamList = operatorMethod->getGenericParams();
+
+  auto opId = ctx.getIdentifier(opName);
+
+  auto parentCtx = operatorMethod->getDeclContext();
+
+  auto lhsParam =
+      new (ctx) ParamDecl(SourceLoc(), SourceLoc(), Identifier(), SourceLoc(),
+                          ctx.getIdentifier("lhs"), parentCtx);
+
+  lhsParam->setInterfaceType(
+      operatorMethod->getDeclContext()->getSelfInterfaceType());
+
+  if (operatorMethod->isMutating()) {
+    // This implicitly makes the parameter indirect.
+    lhsParam->setSpecifier(ParamSpecifier::InOut);
+  } else {
+    lhsParam->setSpecifier(ParamSpecifier::Default);
+  }
+
+  SmallVector<ParamDecl *, 4> newParams;
+  newParams.push_back(lhsParam);
+
+  for (auto param : *paramList) {
+    newParams.push_back(param);
+  }
+
+  auto oldArgNames = operatorMethod->getName().getArgumentNames();
+  SmallVector<Identifier, 4> newArgNames;
+  newArgNames.push_back(Identifier());
+
+  for (auto id : oldArgNames) {
+    newArgNames.push_back(id);
+  }
+
+  auto opDeclName =
+      DeclName(ctx, opId, {newArgNames.begin(), newArgNames.end()});
+
+  auto topLevelStaticFuncDecl = FuncDecl::createImplicit(
+      ctx, StaticSpellingKind::None, opDeclName, SourceLoc(),
+      /*Async*/ false, /*Throws*/ false, genericParamList,
+      ParameterList::create(ctx, newParams),
+      operatorMethod->getResultInterfaceType(), parentCtx);
+
+  topLevelStaticFuncDecl->setAccess(AccessLevel::Public);
+  topLevelStaticFuncDecl->setIsDynamic(false);
+  topLevelStaticFuncDecl->setStatic();
+  topLevelStaticFuncDecl->setBodySynthesizer(synthesizeOperatorMethodBody,
+                                             operatorMethod);
+
+  return topLevelStaticFuncDecl;
+}
+
+// MARK: C++ properties
+
+static std::pair<BraceStmt *, bool>
+synthesizeComputedGetterFromCXXMethod(AbstractFunctionDecl *afd,
+                                      void *context) {
+  auto accessor = cast<AccessorDecl>(afd);
+  auto method = static_cast<FuncDecl *>(context);
+
+  Expr *selfExpr = createSelfExpr(accessor);
+
+  auto *getterImplCallExpr = createAccessorImplCallExpr(method, selfExpr);
+  auto returnStmt =
+      new (method->getASTContext()) ReturnStmt(SourceLoc(), getterImplCallExpr);
+  auto body = BraceStmt::create(method->getASTContext(), SourceLoc(),
+                                {returnStmt}, SourceLoc());
+
+  return {body, /*isTypeChecked*/ true};
+}
+
+static std::pair<BraceStmt *, bool>
+synthesizeComputedSetterFromCXXMethod(AbstractFunctionDecl *afd,
+                                      void *context) {
+  auto setterDecl = cast<AccessorDecl>(afd);
+  auto setterImpl = static_cast<FuncDecl *>(context);
+
+  Expr *selfExpr = createSelfExpr(setterDecl);
+  DeclRefExpr *valueParamRefExpr = createParamRefExpr(setterDecl, 0);
+
+  auto *getterImplCallExpr =
+      createAccessorImplCallExpr(setterImpl, selfExpr, valueParamRefExpr);
+
+  auto body = BraceStmt::create(setterImpl->getASTContext(), SourceLoc(),
+                                {getterImplCallExpr}, SourceLoc());
+  return {body, /*isTypeChecked*/ true};
+}
+
+VarDecl *
+SwiftDeclSynthesizer::makeComputedPropertyFromCXXMethods(FuncDecl *getter,
+                                                         FuncDecl *setter) {
+  auto &ctx = ImporterImpl.SwiftContext;
+  auto dc = getter->getDeclContext();
+
+  assert(isa<clang::CXXMethodDecl>(getter->getClangDecl()) &&
+         (!setter || isa<clang::CXXMethodDecl>(setter->getClangDecl())) &&
+         "Functions passed to makeProperty must be imported C++ method decls.");
+
+  CXXMethodBridging bridgingInfo(
+      cast<clang::CXXMethodDecl>(getter->getClangDecl()));
+  assert(bridgingInfo.classify() == CXXMethodBridging::Kind::getter);
+
+  auto importedName = bridgingInfo.importNameAsCamelCaseName();
+  auto result =
+      new (ctx) VarDecl(false, VarDecl::Introducer::Var, getter->getStartLoc(),
+                        ctx.getIdentifier(importedName), dc);
+  result->setInterfaceType(getter->getResultInterfaceType());
+  result->setAccess(AccessLevel::Public);
+  result->setImplInfo(StorageImplInfo::getMutableComputed());
+
+  AccessorDecl *getterDecl = AccessorDecl::create(
+      ctx, getter->getLoc(), getter->getLoc(), AccessorKind::Get, result,
+      SourceLoc(), StaticSpellingKind::None,
+      /*async*/ false, SourceLoc(),
+      /*throws*/ false, SourceLoc(), nullptr, ParameterList::createEmpty(ctx),
+      getter->getResultInterfaceType(), dc);
+  getterDecl->setAccess(AccessLevel::Public);
+  getterDecl->setImplicit();
+  getterDecl->setIsDynamic(false);
+  getterDecl->setIsTransparent(true);
+  getterDecl->setBodySynthesizer(synthesizeComputedGetterFromCXXMethod, getter);
+  if (getter->isMutating()) {
+    getterDecl->setSelfAccessKind(SelfAccessKind::Mutating);
+    result->setIsGetterMutating(true);
+  }
+
+  AccessorDecl *setterDecl = nullptr;
+  if (setter) {
+    auto paramVarDecl =
+        new (ctx) ParamDecl(SourceLoc(), SourceLoc(), Identifier(), SourceLoc(),
+                            ctx.getIdentifier("newValue"), dc);
+    paramVarDecl->setSpecifier(ParamSpecifier::Default);
+    paramVarDecl->setInterfaceType(getter->getResultInterfaceType());
+
+    auto setterParamList = ParameterList::create(ctx, {paramVarDecl});
+
+    setterDecl = AccessorDecl::create(
+        ctx, setter->getLoc(), setter->getLoc(), AccessorKind::Set, result,
+        SourceLoc(), StaticSpellingKind::None,
+        /*async*/ false, SourceLoc(),
+        /*throws*/ false, SourceLoc(), nullptr, setterParamList,
+        setter->getResultInterfaceType(), dc);
+    setterDecl->setAccess(AccessLevel::Public);
+    setterDecl->setImplicit();
+    setterDecl->setIsDynamic(false);
+    setterDecl->setIsTransparent(true);
+    setterDecl->setBodySynthesizer(synthesizeComputedSetterFromCXXMethod,
+                                   setter);
+
+    if (setter->isMutating()) {
+      setterDecl->setSelfAccessKind(SelfAccessKind::Mutating);
+      result->setIsSetterMutating(true);
+    } else {
+      setterDecl->setSelfAccessKind(SelfAccessKind::NonMutating);
+      result->setIsSetterMutating(false);
+    }
+  }
+
+  ImporterImpl.makeComputed(result, getterDecl, setterDecl);
+
+  return result;
+}

--- a/lib/ClangImporter/SwiftDeclSynthesizer.h
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.h
@@ -1,0 +1,294 @@
+//===--- DeclSynthesizer.h - Synthesize helper Swift decls ------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SWIFT_DECL_SYNTHESIZER_H
+#define SWIFT_SWIFT_DECL_SYNTHESIZER_H
+
+#include "ImporterImpl.h"
+#include "swift/ClangImporter/ClangImporter.h"
+
+namespace swift {
+
+enum class MakeStructRawValuedFlags {
+  /// whether to also create an unlabeled init
+  MakeUnlabeledValueInit = 0x01,
+
+  /// whether the raw value should be a let
+  IsLet = 0x02,
+
+  /// whether to mark the rawValue as implicit
+  IsImplicit = 0x04,
+};
+using MakeStructRawValuedOptions = OptionSet<MakeStructRawValuedFlags>;
+
+inline MakeStructRawValuedOptions getDefaultMakeStructRawValuedOptions() {
+  MakeStructRawValuedOptions opts;
+  opts -= MakeStructRawValuedFlags::MakeUnlabeledValueInit; // default off
+  opts |= MakeStructRawValuedFlags::IsLet;                  // default on
+  opts |= MakeStructRawValuedFlags::IsImplicit;             // default on
+  return opts;
+}
+
+inline AccessLevel getOverridableAccessLevel(const DeclContext *dc) {
+  return (dc->getSelfClassDecl() ? AccessLevel::Open : AccessLevel::Public);
+}
+
+class SwiftDeclSynthesizer {
+private:
+  ClangImporter::Implementation &ImporterImpl;
+
+public:
+  explicit SwiftDeclSynthesizer(ClangImporter::Implementation &Impl)
+      : ImporterImpl(Impl) {}
+
+  /// Create a typedpattern(namedpattern(decl))
+  Pattern *createTypedNamedPattern(VarDecl *decl);
+
+  /// Create a new named constant with the given value.
+  ///
+  /// \param name The name of the constant.
+  /// \param dc The declaration context into which the name will be introduced.
+  /// \param type The type of the named constant.
+  /// \param value The value of the named constant.
+  /// \param convertKind How to convert the constant to the given type.
+  /// \param isStatic Whether the constant should be a static member of \p dc.
+  ValueDecl *createConstant(Identifier name, DeclContext *dc, Type type,
+                            const clang::APValue &value,
+                            ConstantConvertKind convertKind, bool isStatic,
+                            ClangNode ClangN);
+
+  /// Create a new named constant with the given value.
+  ///
+  /// \param name The name of the constant.
+  /// \param dc The declaration context into which the name will be introduced.
+  /// \param type The type of the named constant.
+  /// \param value The value of the named constant.
+  /// \param convertKind How to convert the constant to the given type.
+  /// \param isStatic Whether the constant should be a static member of \p dc.
+  ValueDecl *createConstant(Identifier name, DeclContext *dc, Type type,
+                            StringRef value, ConstantConvertKind convertKind,
+                            bool isStatic, ClangNode ClangN);
+
+  /// Create a new named constant using the given expression.
+  ///
+  /// \param name The name of the constant.
+  /// \param dc The declaration context into which the name will be introduced.
+  /// \param type The type of the named constant.
+  /// \param valueExpr An expression to use as the value of the constant.
+  /// \param convertKind How to convert the constant to the given type.
+  /// \param isStatic Whether the constant should be a static member of \p dc.
+  ValueDecl *createConstant(Identifier name, DeclContext *dc, Type type,
+                            Expr *valueExpr, ConstantConvertKind convertKind,
+                            bool isStatic, ClangNode ClangN);
+
+  /// Create a default constructor that initializes a struct to zero.
+  ConstructorDecl *createDefaultConstructor(NominalTypeDecl *structDecl);
+
+  /// Create a constructor that initializes a struct from its members.
+  ConstructorDecl *createValueConstructor(NominalTypeDecl *structDecl,
+                                          ArrayRef<VarDecl *> members,
+                                          bool wantCtorParamNames,
+                                          bool wantBody);
+
+  /// Create a rawValue-ed constructor that bridges to its underlying storage.
+  ConstructorDecl *createRawValueBridgingConstructor(StructDecl *structDecl,
+                                                     VarDecl *computedRawValue,
+                                                     VarDecl *storedRawValue,
+                                                     bool wantLabel,
+                                                     bool wantBody);
+
+  /// Make a struct declaration into a raw-value-backed struct, with
+  /// bridged computed rawValue property which differs from stored backing
+  ///
+  /// \param structDecl the struct to make a raw value for
+  /// \param storedUnderlyingType the type of the stored raw value
+  /// \param bridgedType the type of the 'rawValue' computed property bridge
+  /// \param synthesizedProtocolAttrs synthesized protocol attributes to add
+  ///
+  /// This will perform most of the work involved in making a new Swift struct
+  /// be backed by a stored raw value and computed raw value of bridged type.
+  /// This will populated derived protocols and synthesized protocols, add the
+  /// new variable and pattern bindings, and create the inits parameterized
+  /// over a bridged type that will cast to the stored type, as appropriate.
+  void makeStructRawValuedWithBridge(
+      StructDecl *structDecl, Type storedUnderlyingType, Type bridgedType,
+      ArrayRef<KnownProtocolKind> synthesizedProtocolAttrs,
+      bool makeUnlabeledValueInit = false);
+
+  /// Make a struct declaration into a raw-value-backed struct
+  ///
+  /// \param structDecl the struct to make a raw value for
+  /// \param underlyingType the type of the raw value
+  /// \param synthesizedProtocolAttrs synthesized protocol attributes to add
+  /// \param setterAccess the access level of the raw value's setter
+  ///
+  /// This will perform most of the work involved in making a new Swift struct
+  /// be backed by a raw value. This will populated derived protocols and
+  /// synthesized protocols, add the new variable and pattern bindings, and
+  /// create the inits parameterized over a raw value
+  ///
+  void makeStructRawValued(StructDecl *structDecl, Type underlyingType,
+                           ArrayRef<KnownProtocolKind> synthesizedProtocolAttrs,
+                           MakeStructRawValuedOptions options =
+                               getDefaultMakeStructRawValuedOptions(),
+                           AccessLevel setterAccess = AccessLevel::Private);
+
+  /// Build the union field getter and setter.
+  ///
+  /// \code
+  /// struct SomeImportedUnion {
+  ///   var myField: Int {
+  ///     get {
+  ///       return Builtin.reinterpretCast(self)
+  ///     }
+  ///     set(newValue) {
+  ///       Builtin.initialize(Builtin.addressof(self), newValue))
+  ///     }
+  ///   }
+  /// }
+  /// \endcode
+  ///
+  /// \returns a pair of the getter and setter function decls.
+  std::pair<AccessorDecl *, AccessorDecl *>
+  makeUnionFieldAccessors(NominalTypeDecl *importedUnionDecl,
+                          VarDecl *importedFieldDecl);
+
+  /// Build the bitfield getter and setter using Clang.
+  ///
+  /// \code
+  /// static inline int get(RecordType self) {
+  ///   return self.field;
+  /// }
+  /// static inline void set(int newValue, RecordType *self) {
+  ///   self->field = newValue;
+  /// }
+  /// \endcode
+  ///
+  /// \returns a pair of the getter and setter function decls.
+  std::pair<FuncDecl *, FuncDecl *> makeBitFieldAccessors(
+      clang::RecordDecl *structDecl, NominalTypeDecl *importedStructDecl,
+      clang::FieldDecl *fieldDecl, VarDecl *importedFieldDecl);
+
+  /// Build the indirect field getter and setter.
+  ///
+  /// \code
+  /// struct SomeImportedIndirectField {
+  ///   struct __Unnamed_struct___Anonymous_field_1 {
+  ///     var myField : Int
+  ///   }
+  ///   var __Anonymous_field_1 : __Unnamed_struct___Anonymous_field_1
+  ///   var myField : Int {
+  ///     get {
+  ///       __Anonymous_field_1.myField
+  ///     }
+  ///     set(newValue) {
+  ///       __Anonymous_field_1.myField = newValue
+  ///     }
+  ///   }
+  /// }
+  /// \endcode
+  ///
+  /// \returns a pair of getter and setter function decls.
+  std::pair<AccessorDecl *, AccessorDecl *>
+  makeIndirectFieldAccessors(const clang::IndirectFieldDecl *indirectField,
+                             ArrayRef<VarDecl *> members,
+                             NominalTypeDecl *importedStructDecl,
+                             VarDecl *importedFieldDecl);
+
+  /// Build the init(rawValue:) initializer for an imported NS_ENUM.
+  ///
+  /// \code
+  /// enum NSSomeEnum: RawType {
+  ///   init?(rawValue: RawType) {
+  ///     self = Builtin.reinterpretCast(rawValue)
+  ///   }
+  /// }
+  /// \endcode
+  ///
+  /// Unlike a standard init(rawValue:) enum initializer, this does a
+  /// reinterpret cast in order to preserve unknown or future cases from C.
+  ConstructorDecl *makeEnumRawValueConstructor(EnumDecl *enumDecl);
+
+  /// Build the rawValue getter for an imported NS_ENUM.
+  ///
+  /// \code
+  /// enum NSSomeEnum: RawType {
+  ///   var rawValue: RawType {
+  ///     return Builtin.reinterpretCast(self)
+  ///   }
+  /// }
+  /// \endcode
+  ///
+  /// Unlike a standard init(rawValue:) enum initializer, this does a
+  /// reinterpret cast in order to preserve unknown or future cases from C.
+  void makeEnumRawValueGetter(EnumDecl *enumDecl, VarDecl *rawValueDecl);
+
+  /// Build the rawValue getter for a struct type.
+  ///
+  /// \code
+  /// struct SomeType: RawRepresentable {
+  ///   private var _rawValue: ObjCType
+  ///   var rawValue: SwiftType {
+  ///     return _rawValue as SwiftType
+  ///   }
+  /// }
+  /// \endcode
+  AccessorDecl *makeStructRawValueGetter(StructDecl *structDecl,
+                                         VarDecl *computedVar,
+                                         VarDecl *storedVar);
+
+  /// Build a declaration for an Objective-C subscript getter.
+  AccessorDecl *buildSubscriptGetterDecl(SubscriptDecl *subscript,
+                                         const FuncDecl *getter, Type elementTy,
+                                         DeclContext *dc, ParamDecl *index);
+
+  /// Build a declaration for an Objective-C subscript setter.
+  AccessorDecl *buildSubscriptSetterDecl(SubscriptDecl *subscript,
+                                         const FuncDecl *setter,
+                                         Type elementInterfaceTy,
+                                         DeclContext *dc, ParamDecl *index);
+
+  /// Given either the getter, the setter, or both getter & setter
+  /// for a subscript operation, create the Swift subscript declaration.
+  ///
+  /// \param getter function returning `UnsafePointer<T>`
+  /// \param setter function returning `UnsafeMutablePointer<T>`
+  /// \return subscript declaration
+  SubscriptDecl *makeSubscript(FuncDecl *getter, FuncDecl *setter);
+
+  /// Given an imported C++ dereference operator (`operator*()`), create a
+  /// `pointee` computed property.
+  ///
+  /// \param dereferenceFunc function returning `Unsafe(Mutable)?Pointer<T>`
+  /// \return computed property declaration
+  VarDecl *makeDereferencedPointeeProperty(FuncDecl *dereferenceFunc);
+
+  FuncDecl *makeOperator(FuncDecl *operatorMethod,
+                         clang::CXXMethodDecl *clangOperator);
+
+  VarDecl *makeComputedPropertyFromCXXMethods(FuncDecl *getter,
+                                              FuncDecl *setter);
+
+private:
+  Type getConstantLiteralType(Type type, ConstantConvertKind convertKind);
+
+  /// Create a var member for this struct, along with its pattern binding, and
+  /// add it as a member.
+  std::pair<VarDecl *, PatternBindingDecl *>
+  createVarWithPattern(DeclContext *dc, Identifier name, Type ty,
+                       VarDecl::Introducer introducer, bool isImplicit,
+                       AccessLevel access, AccessLevel setterAccess);
+};
+
+} // namespace swift
+
+#endif // SWIFT_SWIFT_DECL_SYNTHESIZER_H


### PR DESCRIPTION
`ImportDecl.cpp` contained 10k+ lines of code, which caused slowdowns in incremental compilation and while editing the code in the IDE.

This change extracts a chunk of largely self-contained decl synthesis logic into a separate file.