### PR TITLE
[5.7] consider requirements of an underscored protocol to also be underscored (take two)

### DIFF
--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -574,6 +574,56 @@ SymbolGraph::serializeDeclarationFragments(StringRef Key, Type T,
   T->print(Printer, Options);
 }
 
+namespace {
+
+/// Returns the first satisfied protocol requirement for the given decl.
+const ValueDecl *getProtocolRequirement(const ValueDecl *VD) {
+  auto reqs = VD->getSatisfiedProtocolRequirements();
+
+  if (!reqs.empty())
+    return reqs.front();
+  else
+    return nullptr;
+}
+
+/// Returns the protocol that the given decl is a requirement or conformance of, if any.
+const ProtocolDecl *getSourceProtocol(const Decl *D) {
+  const auto *DC = D->getDeclContext();
+
+  // First check to see whether it's declared directly in the protocol decl
+  if (const auto *P = dyn_cast<ProtocolDecl>(DC))
+    return P;
+
+  // Next look at whether it's an extension on a protocol
+  if (const auto *Extension = dyn_cast<ExtensionDecl>(DC)) {
+    if (const auto *ExtendedProtocol = Extension->getExtendedProtocolDecl()) {
+      return ExtendedProtocol;
+    }
+  }
+
+  // Then check to see whether it's an implementation of a protocol requirement
+  if (const auto *VD = dyn_cast<ValueDecl>(D)) {
+    if (const auto *Requirement = getProtocolRequirement(VD)) {
+      if (const auto *P = dyn_cast<ProtocolDecl>(Requirement->getDeclContext())) {
+        return P;
+      }
+    }
+  }
+
+  // If all those didn't work, there's no protocol to fetch
+  return nullptr;
+}
+
+/// Returns whether the given decl is from a protocol, and that protocol has an underscored name.
+bool isFromUnderscoredProtocol(const Decl *D) {
+  if (const auto *P = getSourceProtocol(D))
+    return P->hasUnderscoredNaming();
+
+  return false;
+}
+
+}
+
 bool SymbolGraph::isImplicitlyPrivate(const Decl *D,
                                       bool IgnoreContext) const {
   // Don't record unconditionally private declarations
@@ -582,7 +632,7 @@ bool SymbolGraph::isImplicitlyPrivate(const Decl *D,
   }
 
   // Don't record effectively internal declarations if specified
-  if (D->hasUnderscoredNaming()) {
+  if (D->hasUnderscoredNaming() || isFromUnderscoredProtocol(D)) {
     // Some implicit decls from Clang with underscored names sneak in, so throw those out
     if (const auto *clangD = D->getClangDecl()) {
       if (clangD->isImplicit())

--- a/test/SymbolGraph/Symbols/SkipsPublicUnderscore.swift
+++ b/test/SymbolGraph/Symbols/SkipsPublicUnderscore.swift
@@ -50,7 +50,7 @@ public struct _ShouldntAppear: PublicProtocol, _ProtocolShouldntAppear {
   public struct InnerInnerShouldntAppear {}
   }
 
-  // INTERNAL-DAG: "precise": "s:21SkipsPublicUnderscore15_ShouldntAppearV13someHiddenVarSSvpZ"
+  // INTERNAL-DAG: someHiddenVar
   public static var someHiddenVar: String { "someHiddenVar" }
 }
 

--- a/test/SymbolGraph/Symbols/SkipsPublicUnderscore.swift
+++ b/test/SymbolGraph/Symbols/SkipsPublicUnderscore.swift
@@ -22,8 +22,11 @@ public class SomeClass {
 
 // PUBLIC-NOT: precise:{{.*}}_ProtocolShouldntAppear
 // PUBLIC-NOT: precise:{{.*}}PublicProtocol
+// PUBLIC-NOT: precise:{{.*}}someHiddenVar
 @_show_in_interface
-public protocol _ProtocolShouldntAppear {}
+public protocol _ProtocolShouldntAppear {
+  static var someHiddenVar: String { get }
+}
 
 // PUBLIC-NOT: _ShouldntAppear
 // INTERNAL-DAG: _ShouldntAppear
@@ -46,11 +49,18 @@ public struct _ShouldntAppear: PublicProtocol, _ProtocolShouldntAppear {
   // INTERNAL-DAG: InnerInnerShouldntAppear
   public struct InnerInnerShouldntAppear {}
   }
+
+  // INTERNAL-DAG: "precise": "s:21SkipsPublicUnderscore15_ShouldntAppearV13someHiddenVarSSvpZ"
+  public static var someHiddenVar: String { "someHiddenVar" }
 }
 
 // A public type's relationship to an "internal" protocol
 // shouldn't cause it to be included.
-public struct ShouldAppear: _ProtocolShouldntAppear {}
+public struct ShouldAppear {}
+
+extension ShouldAppear: _ProtocolShouldntAppear {
+  public static var someHiddenVar: String { "someHiddenVar" }
+}
 
 public struct PublicOuter {
   // Nor should an "internal" type's relationship to a "public" protocol.


### PR DESCRIPTION
This is a resubmission of https://github.com/apple/swift/pull/59487 to fix failures in CI caused by non-deterministic ordering in the symbol graph.