### PR TITLE
[5.7][ConstraintSystem] Use '# of overloads' as a tie-breaker in ambiguities

### DIFF
--- a/test/Constraints/diag_ambiguities.swift
+++ b/test/Constraints/diag_ambiguities.swift
@@ -88,3 +88,24 @@ func %% (_ lhs: Float, _ rhs: Float) -> Float {
 func SR15053<T : Numeric>(_ a: T, _ b: T) {
   (a + b) %% 2 // expected-error {{cannot convert value of type 'T' to expected argument type 'Int'}}
 }
+
+// rdar://94360230 - diagnosing 'filter' instead of ambiguity in its body
+func test_diagnose_deepest_ambiguity() {
+  struct S {
+    func ambiguous(_: Int = 0) -> Bool { true }     // expected-note 2 {{found this candidate}}
+    func ambiguous(_: String = "") -> Bool { true } // expected-note 2 {{found this candidate}}
+  }
+
+  func test_single(arr: [S]) {
+    arr.filter { $0.ambiguous() } // expected-error {{ambiguous use of 'ambiguous'}}
+  }
+
+  func test_multi(arr: [S]) {
+    arr.filter {
+      if true {
+        print($0.ambiguous()) // expected-error {{ambiguous use of 'ambiguous'}}
+      }
+      return true
+    }
+  }
+}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -559,8 +559,8 @@ struct SpecialPi {} // Type with no implicit construction.
 
 var pi_s: SpecialPi
 
-func getPi() -> Float {}
-func getPi() -> Double {}
+func getPi() -> Float {}  // expected-note 3 {{found this candidate}}
+func getPi() -> Double {} // expected-note 3 {{found this candidate}}
 func getPi() -> SpecialPi {}
 
 enum Empty { }
@@ -582,12 +582,12 @@ func conversionTest(_ a: inout Double, b: inout Int) {
   var pi_d1 = Double(pi_d)
   var pi_s1 = SpecialPi(pi_s) // expected-error {{argument passed to call that takes no arguments}}
 
-  var pi_f2 = Float(getPi()) // expected-error {{ambiguous use of 'init(_:)'}}
-  var pi_d2 = Double(getPi()) // expected-error {{ambiguous use of 'init(_:)'}}
+  var pi_f2 = Float(getPi()) // expected-error {{ambiguous use of 'getPi()'}}
+  var pi_d2 = Double(getPi()) // expected-error {{ambiguous use of 'getPi()'}}
   var pi_s2: SpecialPi = getPi() // no-warning
   
   var float = Float.self
-  var pi_f3 = float.init(getPi()) // expected-error {{ambiguous use of 'init(_:)'}}
+  var pi_f3 = float.init(getPi()) // expected-error {{ambiguous use of 'getPi()'}}
   var pi_f4 = float.init(pi_f)
 
   var e = Empty(f) // expected-warning {{variable 'e' inferred to have type 'Empty', which is an enum with no cases}} expected-note {{add an explicit type annotation to silence this warning}}  {{8-8=: Empty}}


### PR DESCRIPTION
The deepest expression is the one that introduced the ambiguity into
the chain, so depth and index should be deciding factors and number of
overloads - a tie-breaker, while choosing what to diagnose.

Resolves: rdar://94360230
(cherry picked from commit 8f69b9f2e0ba0647840b834187e62e7021f7b607)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
