### PR TITLE
RequirementMachine: Relax assertion in verifyRewriteSystem()

### DIFF
--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -591,7 +591,7 @@ void RewriteSystem::verifyRewriteRules(ValidityPolicy policy) const {
         ASSERT_RULE(symbol.getKind() != Symbol::Kind::GenericParam);
       }
 
-      if (index != 0) {
+      if (index != 0 && !rule.isRHSSimplified()) {
         ASSERT_RULE(symbol.getKind() != Symbol::Kind::Protocol);
       }
     }

--- a/test/Generics/rdar94854326.swift
+++ b/test/Generics/rdar94854326.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
+
+protocol P1  {
+  associatedtype T: P2 where T.T == Self
+}
+
+protocol P2 {
+  associatedtype T
+}
+
+protocol P3: P2 {}
+
+protocol P4 {
+  associatedtype T
+}
+
+// CHECK-LABEL: .G@
+// CHECK-NEXT: Generic signature: <T where T : P4, T.[P4]T : P1, T.[P4]T.[P1]T : P3>
+class G<T: P4> where T.T: P1, T.T.T: P3 {}

--- a/test/Generics/rdar94980084.swift
+++ b/test/Generics/rdar94980084.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
+
+struct G<Value> {}
+
+protocol P {
+  associatedtype T
+}
+
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=G
+// CHECK-NEXT: <Value where Value : P, Value.[P]T : CaseIterable, Value.[P]T.[CaseIterable]AllCases : RandomAccessCollection>
+extension G where Value: P, Value.T: CaseIterable, Value.T.AllCases: RandomAccessCollection {}


### PR DESCRIPTION
We can end up with a rule that has a protocol symbol on the right hand side:

    X.Y.Z => X.W.[P]

This will occur if X.W.[P] was obtained by simplifying a term X.W.U.V via
a rule (U.V => [P]), and before completion discovers a rule
(X.W.[P] => X.W).

Fixes rdar://problem/94854326, rdar://problem/94980084.