### PR TITLE
[cxx-interop] Import increment operators

### DIFF
--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1852,6 +1852,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
     case clang::OverloadedOperatorKind::OO_LessLess:
     case clang::OverloadedOperatorKind::OO_GreaterGreater:
     case clang::OverloadedOperatorKind::OO_EqualEqual:
+    case clang::OverloadedOperatorKind::OO_PlusPlus:
     case clang::OverloadedOperatorKind::OO_ExclaimEqual:
     case clang::OverloadedOperatorKind::OO_LessEqual:
     case clang::OverloadedOperatorKind::OO_GreaterEqual:

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -144,7 +144,7 @@ SwiftDeclSynthesizer::createVarWithPattern(DeclContext *dc, Identifier name,
                                            VarDecl::Introducer introducer,
                                            bool isImplicit, AccessLevel access,
                                            AccessLevel setterAccess) {
-  ASTContext &ctx = ImporterImpl.SwiftContext;
+  ASTContext &ctx = dc->getASTContext();
 
   // Create a variable to store the underlying value.
   auto var = new (ctx) VarDecl(
@@ -1717,6 +1717,97 @@ VarDecl *SwiftDeclSynthesizer::makeDereferencedPointeeProperty(
   }
 
   ImporterImpl.makeComputed(result, getterDecl, /*setter*/ nullptr);
+  return result;
+}
+
+// MARK: C++ increment operator
+
+/// Synthesizer callback for a successor function.
+///
+/// \code
+/// var __copy: Self
+/// __copy = self
+/// __copy.__operatorPlusPlus()
+/// return __copy
+/// \endcode
+static std::pair<BraceStmt *, bool>
+synthesizeSuccessorFuncBody(AbstractFunctionDecl *afd, void *context) {
+  auto successorDecl = cast<FuncDecl>(afd);
+  auto incrementImpl = static_cast<FuncDecl *>(context);
+
+  ASTContext &ctx = successorDecl->getASTContext();
+  auto emptyTupleTy = TupleType::getEmpty(ctx);
+  auto returnTy = successorDecl->getResultInterfaceType();
+
+  auto selfDecl = successorDecl->getImplicitSelfDecl();
+  auto selfRefExpr = new (ctx) DeclRefExpr(selfDecl, DeclNameLoc(),
+                                           /*implicit*/ true);
+  selfRefExpr->setType(selfDecl->getInterfaceType());
+
+  // Create a `__copy` variable.
+  VarDecl *copyDecl = nullptr;
+  PatternBindingDecl *patternDecl = nullptr;
+  std::tie(copyDecl, patternDecl) = SwiftDeclSynthesizer::createVarWithPattern(
+      successorDecl, ctx.getIdentifier("__copy"), returnTy,
+      VarDecl::Introducer::Var,
+      /*isImplicit*/ true, AccessLevel::Public, AccessLevel::Public);
+
+  auto copyRefLValueExpr = new (ctx) DeclRefExpr(copyDecl, DeclNameLoc(),
+                                                 /*implicit*/ true);
+  copyRefLValueExpr->setType(LValueType::get(copyDecl->getInterfaceType()));
+
+  auto inoutCopyExpr = new (ctx) InOutExpr(
+      SourceLoc(), copyRefLValueExpr,
+      successorDecl->mapTypeIntoContext(copyDecl->getValueInterfaceType()),
+      /*isImplicit*/ true);
+  inoutCopyExpr->setType(InOutType::get(copyDecl->getInterfaceType()));
+
+  // Copy `self` to `__copy`.
+  auto copyAssignExpr = new (ctx) AssignExpr(copyRefLValueExpr, SourceLoc(),
+                                             selfRefExpr, /*implicit*/ true);
+  copyAssignExpr->setType(emptyTupleTy);
+
+  // Call `operator++`.
+  auto incrementExpr = createAccessorImplCallExpr(incrementImpl, inoutCopyExpr);
+
+  auto copyRefRValueExpr = new (ctx) DeclRefExpr(copyDecl, DeclNameLoc(),
+                                                 /*implicit*/ true);
+  copyRefRValueExpr->setType(copyDecl->getInterfaceType());
+
+  auto returnStmt = new (ctx) ReturnStmt(SourceLoc(), copyRefRValueExpr,
+                                         /*implicit*/ true);
+
+  auto body = BraceStmt::create(ctx, SourceLoc(),
+                                {
+                                    copyDecl,
+                                    patternDecl,
+                                    copyAssignExpr,
+                                    incrementExpr,
+                                    returnStmt,
+                                },
+                                SourceLoc());
+  return {body, /*isTypeChecked*/ true};
+}
+
+FuncDecl *SwiftDeclSynthesizer::makeSuccessorFunc(FuncDecl *incrementFunc) {
+  auto &ctx = ImporterImpl.SwiftContext;
+  auto dc = incrementFunc->getDeclContext();
+
+  auto returnTy = incrementFunc->getImplicitSelfDecl()->getInterfaceType();
+
+  auto nameId = ctx.getIdentifier("successor");
+  auto *params = ParameterList::createEmpty(ctx);
+  DeclName name(ctx, DeclBaseName(nameId), params);
+
+  auto result = FuncDecl::createImplicit(
+      ctx, StaticSpellingKind::None, name, SourceLoc(),
+      /*Async*/ false, /*Throws*/ false,
+      /*GenericParams*/ nullptr, params, returnTy, dc);
+
+  result->setAccess(AccessLevel::Public);
+  result->setIsDynamic(false);
+  result->setBodySynthesizer(synthesizeSuccessorFuncBody, incrementFunc);
+
   return result;
 }
 

--- a/lib/ClangImporter/SwiftDeclSynthesizer.h
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.h
@@ -51,7 +51,14 @@ public:
       : ImporterImpl(Impl) {}
 
   /// Create a typedpattern(namedpattern(decl))
-  Pattern *createTypedNamedPattern(VarDecl *decl);
+  static Pattern *createTypedNamedPattern(VarDecl *decl);
+
+  /// Create a var member for this struct, along with its pattern binding, and
+  /// add it as a member.
+  static std::pair<VarDecl *, PatternBindingDecl *>
+  createVarWithPattern(DeclContext *dc, Identifier name, Type ty,
+                       VarDecl::Introducer introducer, bool isImplicit,
+                       AccessLevel access, AccessLevel setterAccess);
 
   /// Create a new named constant with the given value.
   ///
@@ -272,6 +279,10 @@ public:
   /// \return computed property declaration
   VarDecl *makeDereferencedPointeeProperty(FuncDecl *dereferenceFunc);
 
+  /// Given a C++ pre-increment operator (`operator++()`). create a non-mutating
+  /// function `successor() -> Self`.
+  FuncDecl *makeSuccessorFunc(FuncDecl *incrementFunc);
+
   FuncDecl *makeOperator(FuncDecl *operatorMethod,
                          clang::CXXMethodDecl *clangOperator);
 
@@ -280,13 +291,6 @@ public:
 
 private:
   Type getConstantLiteralType(Type type, ConstantConvertKind convertKind);
-
-  /// Create a var member for this struct, along with its pattern binding, and
-  /// add it as a member.
-  std::pair<VarDecl *, PatternBindingDecl *>
-  createVarWithPattern(DeclContext *dc, Identifier name, Type ty,
-                       VarDecl::Introducer introducer, bool isImplicit,
-                       AccessLevel access, AccessLevel setterAccess);
 };
 
 } // namespace swift

--- a/test/Interop/Cxx/operators/Inputs/member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/member-inline.h
@@ -19,6 +19,11 @@ struct LoadableIntWrapper {
   int operator()(int x, int y) {
     return value + x * y;
   }
+
+  LoadableIntWrapper &operator++() {
+    value++;
+    return *this;
+  }
 };
 
 struct LoadableBoolWrapper {
@@ -43,6 +48,26 @@ struct AddressOnlyIntWrapper {
   int operator()(int x, int y) {
     return value + x * y;
   }
+
+  AddressOnlyIntWrapper &operator++() {
+    value++;
+    return *this;
+  }
+  AddressOnlyIntWrapper operator++(int) {
+    // This shouldn't be called, since we only support pre-increment operators.
+    return AddressOnlyIntWrapper(-777);
+  }
+};
+
+struct HasPostIncrementOperator {
+  HasPostIncrementOperator operator++(int) {
+    return HasPostIncrementOperator();
+  }
+};
+
+struct HasPreIncrementOperatorWithAnotherReturnType {
+  int value = 0;
+  const int &operator++() { return value; }
 };
 
 struct HasDeletedOperator {

--- a/test/Interop/Cxx/operators/member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/member-inline-module-interface.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=MemberInline -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK: struct LoadableIntWrapper {
+// CHECK:   func successor() -> LoadableIntWrapper
 // CHECK:   static func - (lhs: inout LoadableIntWrapper, rhs: LoadableIntWrapper) -> LoadableIntWrapper
 // CHECK:   mutating func callAsFunction() -> Int32
 // CHECK:   mutating func callAsFunction(_ x: Int32) -> Int32

--- a/test/Interop/Cxx/operators/member-inline-typechecker.swift
+++ b/test/Interop/Cxx/operators/member-inline-typechecker.swift
@@ -40,3 +40,9 @@ let nonTrivialValueByVal = nonTrivialIntArrayByVal[1]
 var diffTypesArrayByVal = DifferentTypesArrayByVal()
 let diffTypesResultIntByVal: Int32 = diffTypesArrayByVal[0]
 let diffTypesResultDoubleByVal: Double = diffTypesArrayByVal[0.5]
+
+let postIncrement = HasPostIncrementOperator()
+postIncrement.successor() // expected-error {{value of type 'HasPostIncrementOperator' has no member 'successor'}}
+
+let anotherReturnType = HasPreIncrementOperatorWithAnotherReturnType()
+anotherReturnType.successor() // expected-error {{value of type 'HasPreIncrementOperatorWithAnotherReturnType' has no member 'successor'}}

--- a/test/Interop/Cxx/operators/member-inline.swift
+++ b/test/Interop/Cxx/operators/member-inline.swift
@@ -30,6 +30,19 @@ OperatorsTestSuite.test("LoadableIntWrapper.call (inline)") {
   expectEqual(57, resultTwoArgs)
 }
 
+OperatorsTestSuite.test("LoadableIntWrapper.successor() (inline)") {
+  var wrapper = LoadableIntWrapper(value: 42)
+
+  let result1 = wrapper.successor()
+  expectEqual(43, result1.value)
+  expectEqual(42, wrapper.value) // Calling `successor()` should not mutate `wrapper`.
+
+  let result2 = result1.successor()
+  expectEqual(44, result2.value)
+  expectEqual(43, result1.value)
+  expectEqual(42, wrapper.value)
+}
+
 OperatorsTestSuite.test("LoadableBoolWrapper.exclaim (inline)") {
   var wrapper = LoadableBoolWrapper(value: true)
 
@@ -47,6 +60,19 @@ OperatorsTestSuite.test("AddressOnlyIntWrapper.call (inline)") {
   expectEqual(42, resultNoArgs)
   expectEqual(65, resultOneArg)
   expectEqual(57, resultTwoArgs)
+}
+
+OperatorsTestSuite.test("AddressOnlyIntWrapper.successor() (inline)") {
+  var wrapper = AddressOnlyIntWrapper(0)
+
+  let result1 = wrapper.successor()
+  expectEqual(1, result1.value)
+  expectEqual(0, wrapper.value) // Calling `successor()` should not mutate `wrapper`.
+
+  let result2 = result1.successor()
+  expectEqual(2, result2.value)
+  expectEqual(1, result1.value)
+  expectEqual(0, wrapper.value)
 }
 
 OperatorsTestSuite.test("DerivedFromAddressOnlyIntWrapper.call (inline, base class)") {


### PR DESCRIPTION
C++ pre-increment operator `T& T::operator++()` is mapped into a non-mutating function `successor() -> Self`.

The naming matches existing functions for `UnsafePointer`/`UnsafeMutablePointer`.

The purpose of this is to be used for iterator bridging: C++ requires iterators to define a pre-increment operator (https://en.cppreference.com/w/cpp/named_req/Iterator), which Swift will use to iterate over C++ sequences and collections.