### PR TITLE
[5.7] Use platform versions in getSwift57Availability.

### DIFF
--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -512,7 +512,20 @@ AvailabilityContext ASTContext::getSwift56Availability() {
 }
 
 AvailabilityContext ASTContext::getSwift57Availability() {
-  return getSwiftFutureAvailability();
+  auto target = LangOpts.Target;
+
+  if (target.isMacOSX()) {
+    return AvailabilityContext(
+        VersionRange::allGTE(llvm::VersionTuple(13, 0, 0)));
+  } else if (target.isiOS()) {
+    return AvailabilityContext(
+        VersionRange::allGTE(llvm::VersionTuple(16, 0, 0)));
+  } else if (target.isWatchOS()) {
+    return AvailabilityContext(
+        VersionRange::allGTE(llvm::VersionTuple(9, 0, 0)));
+  } else {
+    return AvailabilityContext::alwaysAvailable();
+  }
 }
 
 AvailabilityContext ASTContext::getSwiftFutureAvailability() {


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/59552 .

It is used by getParameterizedExistentialRuntimeAvailability.
