### PR TITLE
Tests: Add XFAIL-ing test/Driver/static-stdlib-linux-lld.swift

### DIFF
--- a/test/Driver/static-stdlib-linux-lld.swift
+++ b/test/Driver/static-stdlib-linux-lld.swift
@@ -1,0 +1,12 @@
+// Statically link a "hello world" program
+// REQUIRES: OS=linux-gnu
+// REQUIRES: static_stdlib
+// REQUIRES: lld_lto
+// XFAIL: *
+print("hello world!")
+// RUN: %empty-directory(%t)
+// RUN: %target-swiftc_driver -static-stdlib -use-ld=lld %import-static-libdispatch -o %t/static-stdlib-lld %s
+// RUN: %t/static-stdlib-lld | %FileCheck %s
+// RUN: ldd %t/static-stdlib-lld | %FileCheck %s --check-prefix=LDD
+// CHECK: hello world!
+// LDD-NOT: libswiftCore.so


### PR DESCRIPTION
`-use-ld=lld` and `-static-stdlib` combination is now brokwn due to
duplicate symbous for unicode properties impls between stdlib and
StringProcessing library, which is recently defaulted.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
