### PR TITLE
Sema: Fix capture lifetime issue in protocol conformance sendable mismatch [5.7]

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4198,8 +4198,10 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
       if (behavior != DiagnosticBehavior::Ignore) {
         bool isError = behavior < DiagnosticBehavior::Warning;
         
+        // Avoid relying on the lifetime of 'this'.
+        const DeclContext *DC = this->DC;
         diagnoseOrDefer(requirement, isError,
-                        [this, requirement, witness, sendFrom](
+                        [DC, requirement, witness, sendFrom](
                           NormalProtocolConformance *conformance) {
           diagnoseSendabilityErrorBasedOn(conformance->getProtocol(), sendFrom,
                                           [&](DiagnosticBehavior limit) {

--- a/test/Concurrency/sendable_witness_check_delayed.swift
+++ b/test/Concurrency/sendable_witness_check_delayed.swift
@@ -1,0 +1,16 @@
+// RUN: %target-typecheck-verify-swift
+
+// This triggers a conformance check with SuppressDiagnostics=true.
+let x = S().f {}
+
+protocol P {
+  associatedtype A
+
+  func f(_: A) -> Int // expected-note {{expected sendability to match requirement here}}
+}
+
+struct S : P {
+  typealias A = () -> ()
+  func f(_: @Sendable () -> ()) -> Int { return 0 }
+  // expected-warning@-1 {{sendability of function types in instance method 'f' does not match requirement in protocol 'P'}}
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/59558.

The closure passed in to diagnoseOrDefer() outlives the ConformanceChecker
instance, so instead of capturing 'this', pull out the 'DC' instance
variable directly.