### PR TITLE
Threading: repair the 32-bit Windows builds

### DIFF
--- a/include/swift/Threading/Impl/Win32.h
+++ b/include/swift/Threading/Impl/Win32.h
@@ -88,7 +88,7 @@ inline void lazy_mutex_unsafe_unlock(lazy_mutex_handle &handle) {
 
 // .. Once ...................................................................
 
-typedef std::atomic<int64_t> once_t;
+typedef std::atomic<intptr_t> once_t;
 
 void once_slow(once_t &predicate, void (*fn)(void *), void *context);
 


### PR DESCRIPTION
This repairs the Windows x86 SDK build after #59287.  Use `intptr_t`
rather than the explicitly sized integer as this is always guaranteed to
be the size of the pointer width (irrespective of LP64/LP32 or
LLP64/LLP32).  Since this impacts only the once predicate, this
shouldn't impact any assumptions around structure sizes.