### PR TITLE
[Concurrency] Settable prop reqs cannot be witnessed by actors

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4659,6 +4659,9 @@ ERROR(actor_isolated_witness,none,
      "%select{|distributed }0%1 %2 %3 cannot be used to satisfy %4 protocol "
      "requirement",
      (bool, ActorIsolation, DescriptiveDeclKind, DeclName, ActorIsolation))
+ERROR(actor_isolated_mutable_property_witness,none,
+     "%0 %1 %2 cannot be used to satisfy settable property protocol requirement",
+     (ActorIsolation, DescriptiveDeclKind, DeclName))
 ERROR(actor_cannot_conform_to_global_actor_protocol,none,
       "actor %0 cannot conform to global actor isolated protocol %1",
       (Type, Type))

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5127,9 +5127,7 @@ void ConformanceChecker::resolveValueWitnesses() {
       if (auto enteringIsolation = checkActorIsolation(requirement, witness)) {
 
         if (auto var = dyn_cast<VarDecl>(witness)) {
-          fprintf(stderr, "[%s:%d] (%s) NOPE\n", __FILE__, __LINE__, __FUNCTION__);
           if (var->getWriteImpl() != WriteImplKind::Immutable) {
-          fprintf(stderr, "[%s:%d] (%s) NOPE!!!\n", __FILE__, __LINE__, __FUNCTION__);
             Conformance->setInvalid();
           }
         } else {

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -118,7 +118,17 @@ protocol MainCounter {
 
 struct InferredFromConformance: MainCounter {
   var counter = 0
+  var ticker: Int { // this is ok, only because this is in a struct
+    get { 1 }
+    set {}
+  }
+}
+
+class InferredFromConformanceClass: MainCounter {
+  var counter = 0
+  // expected-warning@-1{{actor-isolated property 'counter' cannot be used to satisfy settable property protocol requirement}}
   var ticker: Int {
+    // expected-warning@-1{{actor-isolated property 'ticker' cannot be used to satisfy settable property protocol requirement}}
     get { 1 }
     set {}
   }

--- a/test/Concurrency/actor_isolation_settable_property_via_protocol.swift
+++ b/test/Concurrency/actor_isolation_settable_property_via_protocol.swift
@@ -1,0 +1,38 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -I %t  -disable-availability-checking -warn-concurrency -parse-as-library
+// REQUIRES: concurrency
+
+actor A1 {
+  var pa = 0
+  // expected-error@-1{{actor-isolated property 'pa' cannot be used to satisfy settable property protocol requirement}}
+  // expected-note@-2{{mutation of this property is only permitted within the actor}}
+}
+
+actor A2 {
+  var pa: Int {
+    // expected-error@-1{{actor-isolated property 'pa' cannot be used to satisfy settable property protocol requirement}}
+    get async { 1 }
+    set { _ = newValue }
+    // expected-error@-1{{'set' accessor is not allowed on property with 'get' accessor that is 'async' or 'throws'}}
+  }
+}
+
+protocol PA: Actor {
+  var pa: Int { get set }
+}
+extension A1: PA {}
+extension A2: PA {}
+
+func test_a1(act: A1) async {
+  await act.pa = 222
+  // expected-error@-1{{actor-isolated property 'pa' can not be mutated from a non-isolated context}}
+  // expected-warning@-2{{no 'async' operations occur within 'await' expression}}
+
+  // ==== Access through protocol ----------------------------------------------
+
+  await (act as any PA).pa = 42 // Not allowed since act does not even conform to PA to begin with
+
+  let anyPA: any PA = act
+  await anyPA.pa = 777 // Not allowed since act does not even conform to PA to begin with
+}


### PR DESCRIPTION
This fixes a hole in actor isolation.

This actually is similar to a hole that distributed actors were preventing more aggressively -- the ability to "cast up" to a protocol and then use it to make an non-isolated access to a property.

The fix is simple, we must not allow such conformances, because they'd require an `async setter` which do not exist.

Resolves https://github.com/apple/swift/issues/59573
Resolves rdar://95509917