### PR TITLE
[interop][SwiftToCxx] Add initial support for passing/returning enums

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -386,6 +386,19 @@ private:
 
   void visitEnumDecl(EnumDecl *ED) {
     printDocumentationComment(ED);
+
+    if (outputLang == OutputLanguageMode::Cxx) {
+      // FIXME: Print enum's availability
+      ClangValueTypePrinter printer(os, owningPrinter.prologueOS,
+                                    owningPrinter.typeMapping,
+                                    owningPrinter.interopContext);
+      printer.printValueTypeDecl(
+          ED, /*bodyPrinter=*/[&]() {}); // TODO: (tongjie) print cases
+      os << outOfLineDefinitions;
+      outOfLineDefinitions.clear();
+      return;
+    }
+
     os << "typedef ";
     StringRef customName = getNameForObjC(ED, CustomNamesOnly);
     if (customName.empty()) {

--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -240,7 +240,7 @@ public:
   }
   
   void forwardDeclare(const EnumDecl *ED) {
-    // FIXME: (tongjie) do we need this?
+    // TODO: skip for now; will overhaul the forward decals for c++ in the future
     if (outputLangMode == swift::OutputLanguageMode::Cxx) {
       return;
     }

--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -240,6 +240,11 @@ public:
   }
   
   void forwardDeclare(const EnumDecl *ED) {
+    // FIXME: (tongjie) do we need this?
+    if (outputLangMode == swift::OutputLanguageMode::Cxx) {
+      return;
+    }
+
     assert(ED->isObjC() || ED->hasClangNode());
     
     forwardDeclare(ED, [&]{
@@ -595,7 +600,9 @@ public:
       const Decl *D = declsToWrite.back();
       bool success = true;
 
-      if (outputLangMode == OutputLanguageMode::Cxx) {
+      if (auto ED = dyn_cast<EnumDecl>(D)) {
+        success = writeEnum(ED);
+      } else if (outputLangMode == OutputLanguageMode::Cxx) {
         if (auto FD = dyn_cast<FuncDecl>(D))
           success = writeFunc(FD);
         if (auto SD = dyn_cast<StructDecl>(D))
@@ -606,8 +613,6 @@ public:
           success = writeClass(CD);
         else if (auto PD = dyn_cast<ProtocolDecl>(D))
           success = writeProtocol(PD);
-        else if (auto ED = dyn_cast<EnumDecl>(D))
-          success = writeEnum(ED);
         else if (auto ED = dyn_cast<FuncDecl>(D))
           success = writeFunc(ED);
         else

--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -240,7 +240,8 @@ public:
   }
   
   void forwardDeclare(const EnumDecl *ED) {
-    // TODO: skip for now; will overhaul the forward decals for c++ in the future
+    // TODO: skip for now; will overhaul the forward decals for c++ in the
+    // future
     if (outputLangMode == swift::OutputLanguageMode::Cxx) {
       return;
     }

--- a/lib/PrintAsClang/PrintClangFunction.h
+++ b/lib/PrintAsClang/PrintClangFunction.h
@@ -102,6 +102,8 @@ private:
       Type type, StringRef name, bool isInOut, bool isIndirect = false,
       llvm::Optional<AdditionalParam::Role> paramRole = None);
 
+  bool hasKnownOptionalNullableCxxMapping(Type type);
+
   raw_ostream &os;
   raw_ostream &cPrologueOS;
   PrimitiveTypeMapping &typeMapping;

--- a/test/Interop/SwiftToCxx/enums/large-enums-pass-return-in-cxx-execution.cpp
+++ b/test/Interop/SwiftToCxx/enums/large-enums-pass-return-in-cxx-execution.cpp
@@ -1,0 +1,33 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %S/large-enums-pass-return-in-cxx.swift -typecheck -module-name Enums -clang-header-expose-public-decls -emit-clang-header-path %t/enums.h
+
+// RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-enums-execution.o
+// RUN: %target-interop-build-swift %S/large-enums-pass-return-in-cxx.swift -o %t/swift-enums-execution -Xlinker %t/swift-enums-execution.o -module-name Enums -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+
+// RUN: %target-codesign %t/swift-enums-execution
+// RUN: %target-run %t/swift-enums-execution | %FileCheck %s
+
+// REQUIRES: executable_test
+
+#include <cassert>
+#include <cstdint>
+#include "enums.h"
+
+int main() {
+    using namespace Enums;
+
+    // sizeof(generated cxx class) = 1 + max(sizeof(case) for all cases) + padding
+    static_assert(sizeof(Large) == 56, "MemoryLayout<Large>.stride == 56");
+
+    auto large = makeLarge(-1);
+    printLarge(large);
+    // CHECK: Large.second
+    inoutLarge(large, 10);
+    printLarge(large);
+    // CHECK: Large.first(-1, -2, -3, -4, -5, -6)
+    printLarge(passThroughLarge(large));
+    // CHECK: Large.first(-1, -2, -3, -4, -5, -6)
+
+    return 0;
+}

--- a/test/Interop/SwiftToCxx/enums/large-enums-pass-return-in-cxx-execution.cpp
+++ b/test/Interop/SwiftToCxx/enums/large-enums-pass-return-in-cxx-execution.cpp
@@ -9,6 +9,7 @@
 // RUN: %target-run %t/swift-enums-execution | %FileCheck %s
 
 // REQUIRES: executable_test
+// UNSUPPORTED: CPU=arm64e
 
 #include <cassert>
 #include <cstdint>

--- a/test/Interop/SwiftToCxx/enums/large-enums-pass-return-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/large-enums-pass-return-in-cxx.swift
@@ -1,0 +1,62 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -module-name Enums -clang-header-expose-public-decls -emit-clang-header-path %t/enums.h
+// RUN: %FileCheck %s < %t/enums.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/enums.h -Wno-unused-private-field -Wno-unused-function)
+
+public enum Large {
+    case first(Int64, Int64, Int64, Int64, Int64, Int64)
+    case second
+}
+
+public func makeLarge(_ x: Int) -> Large {
+    return x >= 0 ? .first(0, 1, 2, 3, 4, 5) : .second
+}
+
+public func printLarge(_ en: Large) {
+    switch en {
+    case let .first(a, b, c, d, e, f):
+        let x = (a, b, c, d, e, f)
+        print("Large.first\(x)")
+    case .second:
+        print("Large.second")
+    }
+}
+
+public func passThroughLarge(_ en: Large) -> Large {
+    return en
+}
+
+public func inoutLarge(_ en: inout Large, _ x: Int) {
+    if x >= 0 {
+        en = .first(-1, -2, -3, -4, -5, -6)
+    } else {
+        en = .second
+    }
+}
+
+// CHECK: SWIFT_EXTERN void $s5Enums10inoutLargeyyAA0C0Oz_SitF(void * _Nonnull en, ptrdiff_t x) SWIFT_NOEXCEPT SWIFT_CALL; // inoutLarge(_:_:)
+// CHECK: SWIFT_EXTERN void $s5Enums9makeLargeyAA0C0OSiF(SWIFT_INDIRECT_RESULT void * _Nonnull, ptrdiff_t x) SWIFT_NOEXCEPT SWIFT_CALL; // makeLarge(_:)
+// CHECK: SWIFT_EXTERN void $s5Enums16passThroughLargeyAA0D0OADF(SWIFT_INDIRECT_RESULT void * _Nonnull, const void * _Nonnull en) SWIFT_NOEXCEPT SWIFT_CALL; // passThroughLarge(_:)
+// CHECK: SWIFT_EXTERN void $s5Enums10printLargeyyAA0C0OF(const void * _Nonnull en) SWIFT_NOEXCEPT SWIFT_CALL; // printLarge(_:)
+// CHECK: class Large final {
+
+// CHECK:      inline void inoutLarge(Large& en, swift::Int x) noexcept {
+// CHECK-NEXT:   return _impl::$s5Enums10inoutLargeyyAA0C0Oz_SitF(_impl::_impl_Large::getOpaquePointer(en), x);
+// CHECK-NEXT: }
+
+// CHECK:      inline Large makeLarge(swift::Int x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT:   return _impl::_impl_Large::returnNewValue([&](void * _Nonnull result) {
+// CHECK-NEXT:     _impl::$s5Enums9makeLargeyAA0C0OSiF(result, x);
+// CHECK-NEXT:   });
+// CHECK-NEXT: }
+
+// CHECK:      inline Large passThroughLarge(const Large& en) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT:   return _impl::_impl_Large::returnNewValue([&](void * _Nonnull result) {
+// CHECK-NEXT:     _impl::$s5Enums16passThroughLargeyAA0D0OADF(result, _impl::_impl_Large::getOpaquePointer(en));
+// CHECK-NEXT:   });
+// CHECK-NEXT: }
+
+// CHECK:      inline void printLarge(const Large& en) noexcept {
+// CHECK-NEXT:   return _impl::$s5Enums10printLargeyyAA0C0OF(_impl::_impl_Large::getOpaquePointer(en));
+// CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/enums/small-enums-pass-return-in-cxx-execution.cpp
+++ b/test/Interop/SwiftToCxx/enums/small-enums-pass-return-in-cxx-execution.cpp
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %S/small-enums-pass-return-in-cxx.swift -typecheck -module-name Enums -clang-header-expose-public-decls -emit-clang-header-path %t/enums.h
+
+// RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-enums-execution.o
+// RUN: %target-interop-build-swift %S/small-enums-pass-return-in-cxx.swift -o %t/swift-enums-execution -Xlinker %t/swift-enums-execution.o -module-name Enums -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+
+// RUN: %target-codesign %t/swift-enums-execution
+// RUN: %target-run %t/swift-enums-execution | %FileCheck %s
+
+// REQUIRES: executable_test
+
+#include <cassert>
+#include <cstddef>
+#include "enums.h"
+
+#define MAX(a, b) ((a) >= (b) ? (a) : (b))
+
+int main() {
+    using namespace Enums;
+
+    // sizeof(generated cxx class) = 1 + max(sizeof(case) for all cases) + padding
+    static_assert(sizeof(Tiny) == 1, "MemoryLayout<Tiny>.stride == 1");
+    static_assert(sizeof(Small) == 16, "MemoryLayout<Small>.stride == 16");
+
+    auto tiny = makeTiny(10);
+    printTiny(tiny);
+    // CHECK: Tiny.first
+    inoutTiny(tiny, -1);
+    printTiny(tiny);
+    // CHECK: Tiny.second
+    printTiny(passThroughTiny(tiny));
+    // CHECK: Tiny.second
+
+    auto small = makeSmall(-3);
+    printSmall(small);
+    // CHECK: Small.second(3.0)
+    inoutSmall(small, 100);
+    printSmall(small);
+    // CHECK: Small.first(100)
+    printSmall(passThroughSmall(small));
+    // CHECK: Small.first(100)
+
+    return 0;
+}

--- a/test/Interop/SwiftToCxx/enums/small-enums-pass-return-in-cxx-execution.cpp
+++ b/test/Interop/SwiftToCxx/enums/small-enums-pass-return-in-cxx-execution.cpp
@@ -9,6 +9,7 @@
 // RUN: %target-run %t/swift-enums-execution | %FileCheck %s
 
 // REQUIRES: executable_test
+// UNSUPPORTED: CPU=arm64e
 
 #include <cassert>
 #include <cstddef>

--- a/test/Interop/SwiftToCxx/enums/small-enums-pass-return-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/small-enums-pass-return-in-cxx.swift
@@ -66,7 +66,40 @@ public func inoutSmall(_ en: inout Small, _ x: Int) {
 
 // CHECK: SWIFT_EXTERN void $s5Enums10inoutSmallyyAA0C0Oz_SitF(char * _Nonnull en, ptrdiff_t x) SWIFT_NOEXCEPT SWIFT_CALL; // inoutSmall(_:_:)
 // CHECK: SWIFT_EXTERN void $s5Enums9inoutTinyyyAA0C0Oz_SitF(char * _Nonnull en, ptrdiff_t x) SWIFT_NOEXCEPT SWIFT_CALL; // inoutTiny(_:_:)
+
+// CHECK:      struct swift_interop_stub_Enums_Small {
+// CHECK-NEXT:   uint64_t _1;
+// CHECK-NEXT:   uint8_t _2;
+// CHECK-NEXT: };
+
+// CHECK:      static inline void swift_interop_returnDirect_Enums_Small(char * _Nonnull result, struct swift_interop_stub_Enums_Small value) __attribute__((always_inline)) {
+// CHECK-NEXT:   memcpy(result + 0, &value._1, 8);
+// CHECK-NEXT:   memcpy(result + 8, &value._2, 1);
+// CHECK-NEXT: }
+
+// CHECK:      static inline struct swift_interop_stub_Enums_Small swift_interop_passDirect_Enums_Small(const char * _Nonnull value) __attribute__((always_inline)) {
+// CHECK-NEXT:   struct swift_interop_stub_Enums_Small result;
+// CHECK-NEXT:   memcpy(&result._1, value + 0, 8);
+// CHECK-NEXT:   memcpy(&result._2, value + 8, 1);
+// CHECK-NEXT:   return result;
+// CHECK-NEXT: }
+
 // CHECK: SWIFT_EXTERN struct swift_interop_stub_Enums_Small $s5Enums9makeSmallyAA0C0OSiF(ptrdiff_t x) SWIFT_NOEXCEPT SWIFT_CALL; // makeSmall(_:)
+
+// CHECK:      struct swift_interop_stub_Enums_Tiny {
+// CHECK-NEXT:   uint8_t _1;
+// CHECK-NEXT: };
+
+// CHECK:      static inline void swift_interop_returnDirect_Enums_Tiny(char * _Nonnull result, struct swift_interop_stub_Enums_Tiny value) __attribute__((always_inline)) {
+// CHECK-NEXT:   memcpy(result + 0, &value._1, 1);
+// CHECK-NEXT: }
+
+// CHECK:      static inline struct swift_interop_stub_Enums_Tiny swift_interop_passDirect_Enums_Tiny(const char * _Nonnull value) __attribute__((always_inline)) {
+// CHECK-NEXT:   struct swift_interop_stub_Enums_Tiny result;
+// CHECK-NEXT:   memcpy(&result._1, value + 0, 1);
+// CHECK-NEXT:   return result;
+// CHECK-NEXT: }
+
 // CHECK: SWIFT_EXTERN struct swift_interop_stub_Enums_Tiny $s5Enums8makeTinyyAA0C0OSiF(ptrdiff_t x) SWIFT_NOEXCEPT SWIFT_CALL; // makeTiny(_:)
 // CHECK: SWIFT_EXTERN struct swift_interop_stub_Enums_Small $s5Enums16passThroughSmallyAA0D0OADF(struct swift_interop_stub_Enums_Small en) SWIFT_NOEXCEPT SWIFT_CALL; // passThroughSmall(_:)
 // CHECK: SWIFT_EXTERN struct swift_interop_stub_Enums_Tiny $s5Enums15passThroughTinyyAA0D0OADF(struct swift_interop_stub_Enums_Tiny en) SWIFT_NOEXCEPT SWIFT_CALL; // passThroughTiny(_:)

--- a/test/Interop/SwiftToCxx/enums/small-enums-pass-return-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/small-enums-pass-return-in-cxx.swift
@@ -1,0 +1,116 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -module-name Enums -clang-header-expose-public-decls -emit-clang-header-path %t/enums.h
+// RUN: %FileCheck %s < %t/enums.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/enums.h -Wno-unused-private-field -Wno-unused-function)
+
+public enum Tiny {
+    case first
+    case second
+}
+
+public func makeTiny(_ x: Int) -> Tiny {
+    return x >= 0 ? .first : .second
+}
+
+public func printTiny(_ en: Tiny) {
+    switch en {
+    case .first:
+        print("Tiny.first")
+    case .second:
+        print("Tiny.second")
+    }
+}
+
+public func passThroughTiny(_ en: Tiny) -> Tiny {
+    return en
+}
+
+public func inoutTiny(_ en: inout Tiny, _ x: Int) {
+    if x >= 0 {
+        en = .first
+    } else {
+        en = .second
+    }
+}
+
+public enum Small {
+    case first(Int)
+    case second(Double)
+}
+
+public func makeSmall(_ x: Int) -> Small {
+    return x >= 0 ? .first(x) : .second(Double(-x))
+}
+
+public func printSmall(_ en: Small) {
+    switch en {
+    case let .first(x):
+        print("Small.first(\(x))")
+    case let .second(x):
+        print("Small.second(\(x))")
+    }
+}
+
+public func passThroughSmall(_ en: Small) -> Small {
+    return en
+}
+
+public func inoutSmall(_ en: inout Small, _ x: Int) {
+    if x >= 0 {
+        en = .first(x)
+    } else {
+        en = .second(Double(x - 1))
+    }
+}
+
+// CHECK: SWIFT_EXTERN void $s5Enums10inoutSmallyyAA0C0Oz_SitF(char * _Nonnull en, ptrdiff_t x) SWIFT_NOEXCEPT SWIFT_CALL; // inoutSmall(_:_:)
+// CHECK: SWIFT_EXTERN void $s5Enums9inoutTinyyyAA0C0Oz_SitF(char * _Nonnull en, ptrdiff_t x) SWIFT_NOEXCEPT SWIFT_CALL; // inoutTiny(_:_:)
+// CHECK: SWIFT_EXTERN struct swift_interop_stub_Enums_Small $s5Enums9makeSmallyAA0C0OSiF(ptrdiff_t x) SWIFT_NOEXCEPT SWIFT_CALL; // makeSmall(_:)
+// CHECK: SWIFT_EXTERN struct swift_interop_stub_Enums_Tiny $s5Enums8makeTinyyAA0C0OSiF(ptrdiff_t x) SWIFT_NOEXCEPT SWIFT_CALL; // makeTiny(_:)
+// CHECK: SWIFT_EXTERN struct swift_interop_stub_Enums_Small $s5Enums16passThroughSmallyAA0D0OADF(struct swift_interop_stub_Enums_Small en) SWIFT_NOEXCEPT SWIFT_CALL; // passThroughSmall(_:)
+// CHECK: SWIFT_EXTERN struct swift_interop_stub_Enums_Tiny $s5Enums15passThroughTinyyAA0D0OADF(struct swift_interop_stub_Enums_Tiny en) SWIFT_NOEXCEPT SWIFT_CALL; // passThroughTiny(_:)
+// CHECK: SWIFT_EXTERN void $s5Enums10printSmallyyAA0C0OF(struct swift_interop_stub_Enums_Small en) SWIFT_NOEXCEPT SWIFT_CALL; // printSmall(_:)
+// CHECK: SWIFT_EXTERN void $s5Enums9printTinyyyAA0C0OF(struct swift_interop_stub_Enums_Tiny en) SWIFT_NOEXCEPT SWIFT_CALL; // printTiny(_:)
+// CHECK: class Small final {
+// CHECK: class Tiny final {
+
+// CHECK:      inline void inoutSmall(Small& en, swift::Int x) noexcept {
+// CHECK-NEXT:   return _impl::$s5Enums10inoutSmallyyAA0C0Oz_SitF(_impl::_impl_Small::getOpaquePointer(en), x);
+// CHECK-NEXT: }
+
+// CHECK:      inline void inoutTiny(Tiny& en, swift::Int x) noexcept {
+// CHECK-NEXT:   return _impl::$s5Enums9inoutTinyyyAA0C0Oz_SitF(_impl::_impl_Tiny::getOpaquePointer(en), x);
+// CHECK-NEXT: }
+
+// CHECK:      inline Small makeSmall(swift::Int x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT:   return _impl::_impl_Small::returnNewValue([&](char * _Nonnull result) {
+// CHECK-NEXT:     _impl::swift_interop_returnDirect_Enums_Small(result, _impl::$s5Enums9makeSmallyAA0C0OSiF(x));
+// CHECK-NEXT:   });
+// CHECK-NEXT: }
+
+// CHECK:      inline Tiny makeTiny(swift::Int x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT:   return _impl::_impl_Tiny::returnNewValue([&](char * _Nonnull result) {
+// CHECK-NEXT:     _impl::swift_interop_returnDirect_Enums_Tiny(result, _impl::$s5Enums8makeTinyyAA0C0OSiF(x));
+// CHECK-NEXT:   });
+// CHECK-NEXT: }
+
+// CHECK:      inline Small passThroughSmall(const Small& en) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT:   return _impl::_impl_Small::returnNewValue([&](char * _Nonnull result) {
+// CHECK-NEXT:     _impl::swift_interop_returnDirect_Enums_Small(result, _impl::$s5Enums16passThroughSmallyAA0D0OADF(_impl::swift_interop_passDirect_Enums_Small(_impl::_impl_Small::getOpaquePointer(en))));
+// CHECK-NEXT:   });
+// CHECK-NEXT: }
+
+// CHECK:      inline Tiny passThroughTiny(const Tiny& en) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT:   return _impl::_impl_Tiny::returnNewValue([&](char * _Nonnull result) {
+// CHECK-NEXT:     _impl::swift_interop_returnDirect_Enums_Tiny(result, _impl::$s5Enums15passThroughTinyyAA0D0OADF(_impl::swift_interop_passDirect_Enums_Tiny(_impl::_impl_Tiny::getOpaquePointer(en))));
+// CHECK-NEXT:   });
+// CHECK-NEXT: }
+
+// CHECK:      inline void printSmall(const Small& en) noexcept {
+// CHECK-NEXT:   return _impl::$s5Enums10printSmallyyAA0C0OF(_impl::swift_interop_passDirect_Enums_Small(_impl::_impl_Small::getOpaquePointer(en)));
+// CHECK-NEXT: }
+
+// CHECK:      inline void printTiny(const Tiny& en) noexcept {
+// CHECK-NEXT:   return _impl::$s5Enums9printTinyyyAA0C0OF(_impl::swift_interop_passDirect_Enums_Tiny(_impl::_impl_Tiny::getOpaquePointer(en)));
+// CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/enums/zero-sized-enum-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/zero-sized-enum-in-cxx.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -module-name Enums -clang-header-expose-public-decls -emit-clang-header-path %t/enums.h
+// RUN: %FileCheck %s < %t/enums.h
+
+public enum EmptyEnum {}
+public enum SingleCaseEnum { case first }
+
+// CHECK: namespace Enums {
+// CHECK-NOT: EmptyEnum
+// CHECK-NOT: SingleCaseEnum
+// CHECK: } // namespace Enums


### PR DESCRIPTION
<!-- What's in this pull request? -->
Add initial support for passing/returning Swift enums between Swift and C++:

- Unify logic for Swift structs and enums since they behave similarly
- Modify existing enum-related functions to support C++ interop mode
- Create necessary test cases

@hyp Could you review this pull request? I also got some questions and I believe they're shown below.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!-- Resolves SR-NNNN. -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
