### PR TITLE
[Threading] Support 32-bit platforms for C11 threads and pthreads.

### DIFF
--- a/include/swift/Threading/Impl/C11.h
+++ b/include/swift/Threading/Impl/C11.h
@@ -148,13 +148,13 @@ inline void lazy_mutex_unsafe_unlock(lazy_mutex_handle &handle) {
 
 // .. Once ...................................................................
 
-typedef std::atomic<std::int64_t> once_t;
+typedef std::atomic<std::intptr_t> once_t;
 
 void once_slow(once_t &predicate, void (*fn)(void *), void *context);
 
 inline void once_impl(once_t &predicate, void (*fn)(void *), void *context) {
   // Sadly we can't use call_once() for this (no context)
-  if (std::atomic_load_explicit(&predicate, std::memory_order_acquire) < 0)
+  if (predicate.load(std::memory_order_acquire) < 0)
     return;
 
   once_slow(predicate, fn, context);

--- a/include/swift/Threading/Impl/Pthreads.h
+++ b/include/swift/Threading/Impl/Pthreads.h
@@ -131,7 +131,7 @@ inline void lazy_mutex_unsafe_unlock(lazy_mutex_handle &handle) {
 
 // .. Once ...................................................................
 
-using once_t = std::atomic<std::int64_t>;
+using once_t = std::atomic<std::intptr_t>;
 
 void once_slow(once_t &predicate, void (*fn)(void *), void *context);
 

--- a/lib/Threading/C11.cpp
+++ b/lib/Threading/C11.cpp
@@ -64,13 +64,13 @@ bool swift::threading_impl::thread_is_main() {
 
 void swift::threading_impl::once_slow(once_t &predicate, void (*fn)(void *),
                                       void *context) {
-  std::int64_t zero = 0;
-  if (std::atomic_compare_exchange_strong_explicit(&predicate, &zero, 1,
-                                                   std::memory_order_relaxed,
-                                                   std::memory_order_relaxed)) {
+  std::intptr_t zero = 0;
+  if (predicate.compare_exchange_strong(zero, (std::intptr_t)1,
+                                        std::memory_order_relaxed,
+                                        std::memory_order_relaxed)) {
     fn(context);
 
-    std::atomic_store_explicit(&predicate, -1, std::memory_order_release);
+    predicate.store((std::intptr_t)-1, std::memory_order_release);
 
     helper.once_lock();
     helper.once_unlock();
@@ -79,8 +79,7 @@ void swift::threading_impl::once_slow(once_t &predicate, void (*fn)(void *),
   }
 
   helper.once_lock();
-  while (std::atomic_load_explicit(&predicate, std::memory_order_acquire) >=
-         0) {
+  while (predicate.load(std::memory_order_acquire) >= (std::intptr_t)0) {
     helper.once_wait();
   }
   helper.once_unlock();

--- a/lib/Threading/Pthreads.cpp
+++ b/lib/Threading/Pthreads.cpp
@@ -55,13 +55,13 @@ bool swift::threading_impl::thread_is_main() {
 
 void swift::threading_impl::once_slow(once_t &predicate, void (*fn)(void *),
                                       void *context) {
-  std::int64_t zero = 0;
-  if (predicate.compare_exchange_strong(zero, (std::int64_t)1,
+  std::intptr_t zero = 0;
+  if (predicate.compare_exchange_strong(zero, (std::intptr_t)1,
                                         std::memory_order_relaxed,
                                         std::memory_order_relaxed)) {
     fn(context);
 
-    predicate.store((std::int64_t)-1, std::memory_order_release);
+    predicate.store((std::intptr_t)-1, std::memory_order_release);
 
     pthread_mutex_lock(&onceMutex);
     pthread_mutex_unlock(&onceMutex);
@@ -70,7 +70,7 @@ void swift::threading_impl::once_slow(once_t &predicate, void (*fn)(void *),
   }
 
   pthread_mutex_lock(&onceMutex);
-  while (predicate.load(std::memory_order_acquire) >= (std::int64_t)0) {
+  while (predicate.load(std::memory_order_acquire) >= (std::intptr_t)0) {
     pthread_cond_wait(&onceCond, &onceMutex);
   }
   pthread_mutex_unlock(&onceMutex);


### PR DESCRIPTION
We just need to change the type from `int64_t` to `intptr_t`.

rdar://95523756
