### PR TITLE
DeadObjectElimination: fix a bug which caused wrong inserted release instructions.

### DIFF
--- a/test/SILOptimizer/dead_alloc_elim.sil
+++ b/test/SILOptimizer/dead_alloc_elim.sil
@@ -669,3 +669,49 @@ bb0:
   return %r : $()
 }
 
+sil @createit : $@convention(thin) () -> @owned Kl
+
+// Check that we don't crash here.
+sil @not_dominating_stores : $@convention(thin) () -> () {
+bb0:
+  %7 = integer_literal $Builtin.Word, 1
+  %10 = alloc_ref [stack] [tail_elems $Kl * %7 : $Builtin.Word] $_ContiguousArrayStorage<Kl>
+  %11 = upcast %10 : $_ContiguousArrayStorage<Kl> to $__ContiguousArrayStorageBase
+  %18 = ref_tail_addr %11 : $__ContiguousArrayStorageBase, $Kl
+  %35 = function_ref @createit : $@convention(thin) () -> @owned Kl
+  cond_br undef, bb1, bb2
+bb1:
+  %36 = apply %35() : $@convention(thin) () -> @owned Kl
+  store %36 to %18 : $*Kl
+  br bb3
+bb2:
+  %46 = apply %35() : $@convention(thin) () -> @owned Kl
+  store %46 to %18 : $*Kl
+  br bb3
+bb3:
+  strong_release %10 : $_ContiguousArrayStorage<Kl>
+  dealloc_stack_ref %10 : $_ContiguousArrayStorage<Kl>
+  %1 = tuple()
+  return %1 : $()
+}
+
+sil @$ss23_ContiguousArrayStorageCfD : $@convention(method) <Element> (@owned _ContiguousArrayStorage<Element>) -> () {
+bb0(%0 : $_ContiguousArrayStorage<Element>):
+  %1 = ref_tail_addr %0 : $_ContiguousArrayStorage<Element>, $Element
+  %2 = address_to_pointer %1 : $*Element to $Builtin.RawPointer
+  %3 = upcast %0 : $_ContiguousArrayStorage<Element> to $__ContiguousArrayStorageBase
+  %4 = ref_element_addr %3 : $__ContiguousArrayStorageBase, #__ContiguousArrayStorageBase.countAndCapacity
+  %5 = struct_element_addr %4 : $*_ArrayBody, #_ArrayBody._storage
+  %6 = struct_element_addr %5 : $*_SwiftArrayBodyStorage, #_SwiftArrayBodyStorage.count
+  %7 = struct_element_addr %6 : $*Int, #Int._value
+  %8 = load %7 : $*Builtin.Int64
+  %9 = builtin "assumeNonNegative_Int64"(%8 : $Builtin.Int64) : $Builtin.Int64
+  %10 = metatype $@thick Element.Type
+  %11 = builtin "truncOrBitCast_Int64_Word"(%9 : $Builtin.Int64) : $Builtin.Word
+  %12 = builtin "destroyArray"<Element>(%10 : $@thick Element.Type, %2 : $Builtin.RawPointer, %11 : $Builtin.Word) : $()
+  fix_lifetime %0 : $_ContiguousArrayStorage<Element>
+  dealloc_ref %0 : $_ContiguousArrayStorage<Element>
+  %15 = tuple ()
+  return %15 : $()
+}
+


### PR DESCRIPTION
This bug triggered an "instruction isn't dominated by its operand" verifier crash.
Or - if the verifier doesn't run - a crash later in IRGen.

rdar://94376582
