### PR TITLE
[ClangImporter] Supporting changes towards structs with ARC pointers

### DIFF
--- a/test/ClangImporter/objc_bridging.swift
+++ b/test/ClangImporter/objc_bridging.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -verify %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -verify-additional-file %clang-importer-sdk-path/usr/include/objc_structs.h -verify %s
 
 // REQUIRES: objc_interop
 
@@ -62,6 +62,10 @@ func objcStructs(_ s: StructOfNSStrings, sb: StructOfBlocks) {
   // FIXME: Blocks should also be Unmanaged.
   _ = sb.block as Bool // expected-error {{cannot convert value of type '@convention(block) () -> Void' to type 'Bool' in coercion}}
   sb.block() // okay
+
+  // Structs with non-trivial copy/destroy should not be imported
+  _ = WeaksInAStruct() // expected-error {{cannot find 'WeaksInAStruct' in scope}}
+  _ = StrongsInAStruct() // expected-error {{cannot find 'StrongsInAStruct' in scope}}
 }
 
 func test_repair_does_not_interfere_with_conversions() {

--- a/test/Inputs/clang-importer-sdk/usr/include/objc_structs.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/objc_structs.h
@@ -7,3 +7,11 @@ struct StructOfNSStrings {
 struct StructOfBlocks {
   void (^__unsafe_unretained _Nonnull block)(void);
 };
+
+struct StrongsInAStruct { // expected-note {{record 'StrongsInAStruct' is not trivial to copy/destroy}}
+  __strong NSString *nsstr;
+};
+
+struct WeaksInAStruct { // expected-note {{record 'WeaksInAStruct' is not trivial to copy/destroy}}
+  __weak NSString *nsstr;
+};


### PR DESCRIPTION
In order to allow supporting `__strong` (and `__weak`) struct fields,
some parts of the ClangImporter needs to understand them. The changes in
this commit allows the type importer to allow the already supported
`__unsafe_unretained` struct fields, but still reject the `__strong` and
`__weak` fields. Later changes will add support for bridging `__strong`
and `__weak` fields.

All the code should be equivalent to the previous code, and since all
the structs with non-trivial copy/destroy are completely discarded, the
code should not even be hit in any case.

The included modifications in the tests check that the error and the
diagnostics note are produced correctly.