### PR TITLE
[CSApply] Generalize fully type-checked target printing

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -9189,12 +9189,13 @@ Optional<SolutionApplicationTarget> ConstraintSystem::applySolution(
     return None;
   
   if (isDebugMode()) {
-  // If we had partially type-checked expressions, lets print
-  // fully type-checked expression after processDelayed is done.
-    if (needsPostProcessing) {
+    // If we had partially type-checked expressions, lets print
+    // fully type-checked target after processDelayed is done.
+    auto node = target.getAsASTNode();
+    if (node && needsPostProcessing) {
       auto &log = llvm::errs();
-      log << "---Fully type-checked expression---\n";
-      resultTarget->getAsExpr()->dump(log);
+      log << "---Fully type-checked target---\n";
+      node.dump(log);
       log << "\n";
     }
   }


### PR DESCRIPTION
Changes `Fully type-checked` output to print any target that
could be represented as an ASTNode.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
