### PR TITLE
[Sema] Do not emit cast to unrelated warning from existential to Anyhashable

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5725,7 +5725,13 @@ TypeChecker::couldDynamicallyConformToProtocol(Type type, ProtocolDecl *Proto,
   // we cannot know statically.
   if (type->isExistentialType())
     return true;
-  
+
+  // The underlying concrete type may have a `Hashable` conformance that is
+  // not possible to know statically.
+  if (type->isAnyHashable()) {
+    return true;
+  }
+
   // A generic archetype may have protocol conformances we cannot know
   // statically.
   if (type->is<ArchetypeType>())

--- a/test/Constraints/casts.swift
+++ b/test/Constraints/casts.swift
@@ -693,3 +693,16 @@ func SR_16058_tests() {
   // More than one optionality wrapping
   let _: String? = foo.flatMap { dict.SR16058(_: $0) } as? String // OK
 }
+
+// https://github.com/apple/swift/issues/59405
+func isHashable(_ error: Error) -> Bool {
+  (error as? AnyHashable) != nil // OK
+}
+
+func isHashable_is(_ error: Error) -> Bool {
+  error is AnyHashable // OK
+}
+
+func isHashable_composition(_ error: Error & AnyObject) -> Bool {
+  error is AnyHashable // OK
+}


### PR DESCRIPTION
Checked cast an existential type to `Anyhashable` can be successful at runtime if underlying type conforms to hashable. But at compile time is not possible to know the conformances, so we cannot emit the cast to unrelated warning in this case.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Fixes https://github.com/apple/swift/issues/59405

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
