### PR TITLE
[refactoring] Run refactoring tests on Linux

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -312,6 +312,8 @@ if 'gmalloc' in lit_config.params:
     config.environment['MALLOC_LOG_FILE'] = '/dev/null'
     config.available_features.add('gmalloc')
 
+config.python_unquoted = sys.executable
+config.python = shell_quote(config.python_unquoted)
 config.swift_frontend = inferSwiftBinary('swift-frontend')
 config.swift = inferSwiftBinary('swift')
 config.swiftc = inferSwiftBinary('swiftc')
@@ -482,8 +484,8 @@ config.substitutions.append( ('%llvm_obj_root', config.llvm_obj_root) )
 config.substitutions.append( ('%llvm_src_root', config.llvm_src_root) )
 config.substitutions.append( ('%swift_obj_root', config.swift_obj_root) )
 config.substitutions.append( ('%swift_src_root', config.swift_src_root) )
-config.substitutions.append( ('%{python}', shell_quote(sys.executable)) )
-config.substitutions.append( ('%{python.unquoted}', sys.executable) )
+config.substitutions.append( ('%{python}', config.python) )
+config.substitutions.append( ('%{python.unquoted}', config.python_unquoted) )
 config.substitutions.append( ('%mcp_opt', mcp_opt) )
 config.substitutions.append( ('%swift_driver_plain', "%r" % config.swift) )
 config.substitutions.append( ('%swiftc_driver_plain', "%r" % config.swiftc) )

--- a/test/refactoring/lit.local.cfg
+++ b/test/refactoring/lit.local.cfg
@@ -1,7 +1,3 @@
-if 'OS=macosx' not in config.available_features:
-    config.unsupported = True
-
-else:
-    config.substitutions.append(('%refactor-check-compiles', '{} -swift-refactor {} -swift-frontend {} -temp-dir %t {}'.format(config.refactor_check_compiles, config.swift_refactor, config.swift_frontend, config.resource_dir_opt)))
-    config.substitutions.append(('%refactor', '{} {}'.format(config.swift_refactor,
-        config.resource_dir_opt)))
+config.substitutions.append(('%refactor-check-compiles', '{} -swift-refactor {} -swift-frontend {} -temp-dir %t {}'.format(config.refactor_check_compiles, config.swift_refactor, config.swift_frontend, config.resource_dir_opt)))
+config.substitutions.append(('%refactor', '{} {}'.format(config.swift_refactor,
+    config.resource_dir_opt)))

--- a/test/refactoring/lit.local.cfg
+++ b/test/refactoring/lit.local.cfg
@@ -1,3 +1,2 @@
-config.substitutions.append(('%refactor-check-compiles', '{} -swift-refactor {} -swift-frontend {} -temp-dir %t {}'.format(config.refactor_check_compiles, config.swift_refactor, config.swift_frontend, config.resource_dir_opt)))
-config.substitutions.append(('%refactor', '{} {}'.format(config.swift_refactor,
-    config.resource_dir_opt)))
+config.substitutions.append((r'%refactor-check-compiles', f'{config.python} {config.refactor_check_compiles} -swift-refactor {config.swift_refactor} -swift-frontend {config.swift_frontend} -temp-dir %t {config.resource_dir_opt}'))
+config.substitutions.append((r'%refactor', f'{config.swift_refactor} {config.resource_dir_opt}'))


### PR DESCRIPTION
Refactoring tests have been disabled on Linux but I can’t find a reason why that should be the case. Enable them on all platforms.

rdar://92982631