### PR TITLE
[CXX Interoperability] Stop re-importing FuncDecl when FuncDecl is imported before parent record

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4982,7 +4982,7 @@ ValueDecl *cloneBaseMemberDecl(ValueDecl *decl, DeclContext *newContext) {
     // support these we need to tell Swift to type check the synthesized bodies.
     // TODO: we also currently don't support static functions. That shouldn't be
     // too hard.
-    if (fn->isStatic() ||
+    if (fn->isStatic() || cast<clang::FunctionDecl>(fn->getClangDecl())->isOverloadedOperator() ||
         (fn->getClangDecl() &&
          isa<clang::FunctionTemplateDecl>(fn->getClangDecl())))
       return nullptr;

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4982,7 +4982,7 @@ ValueDecl *cloneBaseMemberDecl(ValueDecl *decl, DeclContext *newContext) {
     // support these we need to tell Swift to type check the synthesized bodies.
     // TODO: we also currently don't support static functions. That shouldn't be
     // too hard.
-    if (fn->isStatic() || cast<clang::FunctionDecl>(fn->getClangDecl())->isOverloadedOperator() ||
+    if (fn->isStatic() ||
         (fn->getClangDecl() &&
          isa<clang::FunctionTemplateDecl>(fn->getClangDecl())))
       return nullptr;

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2772,6 +2772,13 @@ namespace {
       if (!dc)
         return nullptr;
 
+      // We may have already imported this function decl before we imported the
+      // parent record. In such a case it's important we don't re-import.
+      auto known = Impl.ImportedDecls.find({decl, getVersion()});
+      if (known != Impl.ImportedDecls.end()) {
+        return known->second;
+      }
+
       bool isOperator = decl->getDeclName().getNameKind() ==
                         clang::DeclarationName::CXXOperatorName;
       bool isNonSubscriptOperator =

--- a/test/Interop/Cxx/operators/Inputs/member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/member-inline.h
@@ -49,6 +49,9 @@ struct AddressOnlyIntWrapper {
     return value + x * y;
   }
 
+  AddressOnlyIntWrapper operator-(AddressOnlyIntWrapper rhs) const {
+    return AddressOnlyIntWrapper(value + rhs.value);
+  }
   AddressOnlyIntWrapper &operator++() {
     value++;
     return *this;

--- a/test/Interop/Cxx/operators/Inputs/member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/member-inline.h
@@ -50,7 +50,7 @@ struct AddressOnlyIntWrapper {
   }
 
   AddressOnlyIntWrapper operator-(AddressOnlyIntWrapper rhs) const {
-    return AddressOnlyIntWrapper(value + rhs.value);
+    return AddressOnlyIntWrapper(value - rhs.value);
   }
   AddressOnlyIntWrapper &operator++() {
     value++;

--- a/test/Interop/Cxx/operators/member-inline.swift
+++ b/test/Interop/Cxx/operators/member-inline.swift
@@ -16,6 +16,15 @@ OperatorsTestSuite.test("LoadableIntWrapper.minus (inline)") {
 
   expectEqual(19, result.value)
 }
+
+OperatorsTestSuite.test("AddressOnlyIntWrapper.minus") {
+   let lhs = AddressOnlyIntWrapper(42)
+   let rhs = AddressOnlyIntWrapper(23)
+
+   let result = lhs - rhs
+
+   expectEqual(19, result.value)
+}
 #endif
 
 OperatorsTestSuite.test("LoadableIntWrapper.call (inline)") {
@@ -49,14 +58,6 @@ OperatorsTestSuite.test("LoadableBoolWrapper.exclaim (inline)") {
   let resultExclaim = !wrapper
   expectEqual(false, resultExclaim.value)
 }
-
-OperatorsTestSuite.test("AddressOnlyIntWrapper.minus") {
-   let lhs = AddressOnlyIntWrapper(42)
-   let rhs = AddressOnlyIntWrapper(23)
-
-   let result = lhs - rhs
-   expectEqual(19, result.value)
- }
 
 OperatorsTestSuite.test("AddressOnlyIntWrapper.call (inline)") {
   var wrapper = AddressOnlyIntWrapper(42)

--- a/test/Interop/Cxx/operators/member-inline.swift
+++ b/test/Interop/Cxx/operators/member-inline.swift
@@ -50,6 +50,14 @@ OperatorsTestSuite.test("LoadableBoolWrapper.exclaim (inline)") {
   expectEqual(false, resultExclaim.value)
 }
 
+OperatorsTestSuite.test("AddressOnlyIntWrapper.minus") {
+   let lhs = AddressOnlyIntWrapper(42)
+   let rhs = AddressOnlyIntWrapper(23)
+
+   let result = lhs - rhs
+   expectEqual(19, result.value)
+ }
+
 OperatorsTestSuite.test("AddressOnlyIntWrapper.call (inline)") {
   var wrapper = AddressOnlyIntWrapper(42)
 
@@ -256,14 +264,6 @@ OperatorsTestSuite.test("PtrToPtr.subscript (inline)") {
   arr[0]![0] = ptr
   expectEqual(23, arr[0]![0]![0])
 }
-
-OperatorsTestSuite.test("AddressOnlyIntWrapper.minus") {
-   let lhs = AddressOnlyIntWrapper(42)
-   let rhs = AddressOnlyIntWrapper(23)
-
-   let result = lhs - rhs
-   expectEqual(19, result.value)
- }
 
 // TODO: this causes a crash (does it also crash on main?)
 //OperatorsTestSuite.test("TemplatedSubscriptArrayByVal.subscript (inline)") {

--- a/test/Interop/Cxx/operators/member-inline.swift
+++ b/test/Interop/Cxx/operators/member-inline.swift
@@ -8,7 +8,7 @@ import StdlibUnittest
 var OperatorsTestSuite = TestSuite("Operators")
 
 #if !os(Windows)    // SR-13129
-OperatorsTestSuite.test("LoadableIntWrapper.plus (inline)") {
+OperatorsTestSuite.test("LoadableIntWrapper.minus (inline)") {
   var lhs = LoadableIntWrapper(value: 42)
   let rhs = LoadableIntWrapper(value: 23)
 
@@ -256,6 +256,14 @@ OperatorsTestSuite.test("PtrToPtr.subscript (inline)") {
   arr[0]![0] = ptr
   expectEqual(23, arr[0]![0]![0])
 }
+
+OperatorsTestSuite.test("AddressOnlyIntWrapper.minus") {
+   let lhs = AddressOnlyIntWrapper(42)
+   let rhs = AddressOnlyIntWrapper(23)
+
+   let result = lhs - rhs
+   expectEqual(19, result.value)
+ }
 
 // TODO: this causes a crash (does it also crash on main?)
 //OperatorsTestSuite.test("TemplatedSubscriptArrayByVal.subscript (inline)") {


### PR DESCRIPTION
We saw a test case failing when 2 records contain the same operator. This occurs because when the first operator is called, we import the record associated with that operator but we also import the _function_ for the 2nd record. So if we have 2 records `Foo` and `Bar` and both implement `operator-`, after calling `Foo`'s `operator-` we would have imported

1. `Foo`
2. `Foo.operator-`
3. `Bar.operator-`

Then when we call `Bar.operator-` we try importing `Bar` record & then import the operator again. So that ends up with


1. `Foo`
2. `Foo.operator-`
3. `Bar.operator-`
4. `Bar`
5. `Bar.operator-`

which causes there to be 2 imports of the same operator (`FuncDecl`)

This patch checks to see if the `FuncDecl` was previously imported and returns early if it has been

Thanks @egorzhdan and @zoecarver for helping me debug this one :p 