### PR TITLE
[SILGen] NFC: Remove an unused var left by distributed actor changes

### DIFF
--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -2647,8 +2647,6 @@ namespace {
         AccessKind(accessKind) {}
 
     void emitUsingStrategy(AccessStrategy strategy) {
-      auto var = dyn_cast<VarDecl>(Storage);
-
       switch (strategy.getKind()) {
       case AccessStrategy::Storage: {
         auto typeData =


### PR DESCRIPTION

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
