### PR TITLE
[cxx-interop] Allow conforming C++ APIs that return IUO to Swift protocols

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -754,7 +754,9 @@ swift::matchWitness(
           OptionalAdjustment(std::get<2>(types)));
       }
 
-      if (!req->isObjC() && reqTypeIsIUO != witnessTypeIsIUO)
+      if (!req->isObjC() &&
+          !isa_and_nonnull<clang::CXXMethodDecl>(witness->getClangDecl()) &&
+          reqTypeIsIUO != witnessTypeIsIUO)
         return RequirementMatch(witness, MatchKind::TypeConflict, witnessType);
 
       if (auto result = matchTypes(std::get<0>(types), std::get<1>(types))) {

--- a/test/Interop/Cxx/class/Inputs/protocol-conformance.h
+++ b/test/Interop/Cxx/class/Inputs/protocol-conformance.h
@@ -28,4 +28,14 @@ struct Trivial {
   char test3(int, unsigned) { return 42; }
 };
 
+struct ReturnsNullableValue {
+  const int *returnPointer() { return nullptr; }
+};
+
+struct ReturnsNonNullValue {
+  const int *returnPointer() __attribute__((returns_nonnull)) {
+    return (int *)this;
+  }
+};
+
 #endif // TEST_INTEROP_CXX_CLASS_INPUTS_PROTOCOL_CONFORMANCE_H

--- a/test/Interop/Cxx/class/protocol-conformance-typechecker.swift
+++ b/test/Interop/Cxx/class/protocol-conformance-typechecker.swift
@@ -11,3 +11,18 @@ protocol HasReturn42 {
 extension ConformsToProtocol : HasReturn42 {}
 
 extension DoesNotConformToProtocol : HasReturn42 {} // expected-error {{'DoesNotConformToProtocol' does not conform to protocol}}
+
+
+protocol HasReturnNullable {
+  mutating func returnPointer() -> UnsafePointer<Int32>?
+}
+
+// HasReturnNullable's returnNullable returns an implicitly unwrapped optional:
+//   mutating func returnPointer() -> UnsafePointer<Int32>!
+extension ReturnsNullableValue: HasReturnNullable {}
+
+protocol HasReturnNonNull {
+  mutating func returnPointer() -> UnsafePointer<Int32>
+}
+
+extension ReturnsNonNullValue: HasReturnNonNull {}


### PR DESCRIPTION
If a C++ method returns a pointer and is not annotated with `returns_nonnull`, ClangImporter imports its return type as implicitly unwrapped optional `UnsafePointer<T>!`. This happens, for example, for `begin()`/`end()` methods of C++ collection types.

We would like to be able to conform C++ collections to `Swift.Sequence`/`Swift.Collection`/... To make this work, we create Swift protocols that require `func begin() -> RawIterator` and `func end() -> RawIterator` where `RawIterator` is an associated type.

The problem is that currently if `RawIterator` is `UnsafePointer<T>?`, `begin()`/`end()` methods that return an implicitly unwrapped optional `UnsafePointer<T>!` won't satisfy the requirements. This change fixes that.