### PR TITLE
[build] Merge Clang's features.json from binary directory, handle values

### DIFF
--- a/lib/Option/CMakeLists.txt
+++ b/lib/Option/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(swiftOption PRIVATE
 
 set(features_merger "${SWIFT_SOURCE_DIR}/utils/merge-features.py")
 set(features_file_swift_src "${CMAKE_CURRENT_SOURCE_DIR}/features.json")
-set(features_file_clang_src "${LLVM_MAIN_SRC_DIR}/../clang/tools/driver/features.json")
+set(features_file_clang_src "${LLVM_BINARY_DIR}/share/clang/features.json")
 set(features_file_dest "${CMAKE_BINARY_DIR}/share/swift/features.json")
 
 add_custom_command(

--- a/utils/merge-features.py
+++ b/utils/merge-features.py
@@ -52,7 +52,12 @@ def read_features(from_file, add_prefix):
         if "name" not in feature:
             invalid_file(from_file, "missing name in features list")
 
-        features.append({"name": add_prefix + feature["name"]})
+        new_feature = {"name": add_prefix + feature["name"]}
+
+        if "value" in feature:
+            new_feature.update({"value" : feature["value"]})
+
+        features.append(new_feature)
     return features
 
 


### PR DESCRIPTION
This patch picks up the features.json file from Clang's build directory instead of the source directory and takes into account the new "value" key. This is necessary due to https://github.com/apple/llvm-project/pull/4803.

rdar://91377604

cherry picked from PR [f9c5c45e](https://github.com/apple/swift/pull/59280)