### PR TITLE
Disable running watchOS simulator (32-bit) test by default

### DIFF
--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -1079,7 +1079,7 @@ def create_argument_parser():
            help='skip testing iOS 32 bit simulator targets')
     option('--skip-test-watchos-32bit-simulator',
            toggle_false('test_watchos_32bit_simulator'),
-           default=True,
+           default=False,
            help='skip testing watchOS 32 bit simulator targets')
     option('--skip-test-ios-host',
            toggle_false('test_ios_host'),

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -240,7 +240,7 @@ EXPECTED_DEFAULTS = {
     'test_freebsd': False,
     'test_ios': False,
     'test_ios_32bit_simulator': False,
-    'test_watchos_32bit_simulator': True,
+    'test_watchos_32bit_simulator': False,
     'test_ios_host': False,
     'test_ios_simulator': False,
     'test_linux': False,


### PR DESCRIPTION
(cherry picked from commit d5ff3960f4c007d78bc0b58e556d8edc4d6d3812)