### PR TITLE
[Later][Distributed] allow extensions where Self: DA, but the extended protocol is not DA explicitly

### DIFF
--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -209,21 +209,33 @@ swift::getAssociatedDistributedInvocationDecoderDecodeNextArgumentFunction(
   assert(thunk);
   auto &C = thunk->getASTContext();
 
-  auto *actor = thunk->getDeclContext()->getSelfNominalTypeDecl();
-  if (!actor)
-    return nullptr;
-  if (!actor->isDistributedActor())
-    return nullptr;
+  fprintf(stderr, "[%s:%d] (%s) look for decodeNext for...\n", __FILE__, __LINE__, __FUNCTION__);
+  thunk->dump();
+
+//  auto *actor = thunk->getDeclContext()->getSelfNominalTypeDecl();
+//  if (!actor) {
+//    fprintf(stderr, "[%s:%d] (%s) null actor\n", __FILE__, __LINE__, __FUNCTION__);
+//    return nullptr;
+//  }
+//  if (!actor->isDistributedActor()) {
+//    fprintf(stderr, "[%s:%d] (%s) actor is not DA\n", __FILE__, __LINE__, __FUNCTION__);
+//    actor->dump();
+//    return nullptr;
+//  }
 
   auto systemTy = getConcreteReplacementForProtocolActorSystemType(thunk);
-  if (!systemTy)
+  if (!systemTy) {
+    fprintf(stderr, "[%s:%d] (%s) no system\n", __FILE__, __LINE__, __FUNCTION__);
     return nullptr;
+  }
 
   auto decoderTy =
       getDistributedActorSystemInvocationDecoderType(
           systemTy->getAnyNominal());
-  if (!decoderTy)
+  if (!decoderTy) {
+    fprintf(stderr, "[%s:%d] (%s) no decoder type\n", __FILE__, __LINE__, __FUNCTION__);
     return nullptr;
+  }
 
   return C.getDecodeNextArgumentOnDistributedInvocationDecoder(
       decoderTy->getAnyNominal());
@@ -1360,6 +1372,9 @@ AbstractFunctionDecl::getDistributedThunk() const {
 
 VarDecl*
 NominalTypeDecl::getDistributedActorSystemProperty() const {
+  fprintf(stderr, "[%s:%d] (%s) get actorSystem from...\n", __FILE__, __LINE__, __FUNCTION__);
+  this->dump();
+
   if (!isDistributedActor())
     return nullptr;
 

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -211,8 +211,8 @@ deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
   auto func = static_cast<FuncDecl *>(context);
   auto funcDC = func->getDeclContext();
   NominalTypeDecl *nominal = funcDC->getSelfNominalTypeDecl();
-  assert(nominal && nominal->isDistributedActor() &&
-         "Distributed function must be part of distributed actor");
+//  assert(nominal && nominal->isDistributedActor() &&
+//         "Distributed function must be part of distributed actor");
 
   auto selfDecl = thunk->getImplicitSelfDecl();
   selfDecl->getAttrs().add(new (C) KnownToBeLocalAttr(implicit));
@@ -863,6 +863,9 @@ FuncDecl *GetDistributedThunkRequest::evaluate(Evaluator &evaluator,
 
     auto nominal = DC->getSelfNominalTypeDecl(); // NOTE: Always from DC
     assert(nominal);
+
+    fprintf(stderr, "[%s:%d] (%s) CONTEXT FOR THE THUNK:\n", __FILE__, __LINE__, __FUNCTION__);
+    func->getDeclContext()->dumpContext();
 
     // --- Prepare the "distributed thunk" which does the "maybe remote" dance:
     return createDistributedThunkFunction(func);

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -183,21 +183,28 @@ void swift::addCodableFixIt(
 
 bool IsDistributedActorRequest::evaluate(
     Evaluator &evaluator, NominalTypeDecl *nominal) const {
+  fprintf(stderr, "[%s:%d] (%s) IS DA [%s] or not....?\n", __FILE__, __LINE__, __FUNCTION__, nominal->getNameStr().str().c_str());
+  nominal->dump();
+
   // Protocols are actors if they inherit from `DistributedActor`.
   if (auto protocol = dyn_cast<ProtocolDecl>(nominal)) {
     auto &ctx = protocol->getASTContext();
     auto *distributedActorProtocol = ctx.getDistributedActorDecl();
-    return (protocol == distributedActorProtocol ||
-            protocol->inheritsFrom(distributedActorProtocol));
+    auto isDistributedActor = protocol == distributedActorProtocol ||
+            protocol->inheritsFrom(distributedActorProtocol);
+    fprintf(stderr, "[%s:%d] (%s) [%s]  IS DIST: %d\n", __FILE__, __LINE__, __FUNCTION__, nominal->getNameStr().str().c_str(), protocol == distributedActorProtocol);
+    fprintf(stderr, "[%s:%d] (%s) [%s] INH DIST: %d\n", __FILE__, __LINE__, __FUNCTION__, nominal->getNameStr().str().c_str(), protocol->inheritsFrom(distributedActorProtocol));
+    return isDistributedActor;
   }
 
   // Class declarations are 'distributed actors' if they are declared with
   // 'distributed actor'
-  auto classDecl = dyn_cast<ClassDecl>(nominal);
-  if(!classDecl)
-    return false;
+  if(auto classDecl = dyn_cast<ClassDecl>(nominal)) {
+    fprintf(stderr, "[%s:%d] (%s) IS DIST: %d\n", __FILE__, __LINE__, __FUNCTION__, classDecl->isExplicitDistributedActor());
+    return classDecl->isExplicitDistributedActor();
+  }
 
-  return classDecl->isExplicitDistributedActor();
+  return false;
 }
 
 // ==== ------------------------------------------------------------------------

--- a/test/Distributed/Runtime/distributed_func_in_extension_where_self_is_distributed_actor.swift
+++ b/test/Distributed/Runtime/distributed_func_in_extension_where_self_is_distributed_actor.swift
@@ -1,0 +1,54 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-build-swift -module-name main  -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s --color
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// rdar://76038845
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+import Distributed
+import FakeDistributedActorSystems
+
+protocol GamePlayer: Sendable, Identifiable where ID == FakeActorSystem.ActorID {
+  func makeMove() async throws -> String
+}
+extension GamePlayer where Self: DistributedActor, ActorSystem == FakeActorSystem {
+  distributed func startGame(with opponent: String) -> String {
+    "game with \(opponent)"
+  }
+}
+
+distributed actor FishPlayer: GamePlayer {
+  typealias ActorSystem = FakeActorSystem
+  distributed func makeMove() async throws -> String {
+    "move"
+  }
+}
+
+typealias DefaultDistributedActorSystem = FakeActorSystem
+
+// ==== Execute ----------------------------------------------------------------
+
+func test() async throws {
+  let system = DefaultDistributedActorSystem()
+
+  let fish = FishPlayer(actorSystem: system)
+
+  let opponentName = "Caplin"
+  let game = try await fish.startGame(with: opponentName)
+  print("game: game with \(opponentName)") // CHECK: game: game with Caplin
+
+  print("done") // CHECK: done
+}
+
+@main struct Main {
+  static func main() async {
+    try! await test()
+  }
+}
+

--- a/test/Distributed/distributed_extensions_where_self_distributed_actor.swift
+++ b/test/Distributed/distributed_extensions_where_self_distributed_actor.swift
@@ -1,0 +1,32 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unknown -disable-availability-checking -I %t 2>&1 %s
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+import Distributed
+import FakeDistributedActorSystems
+
+@available(SwiftStdlib 5.7, *)
+typealias DefaultDistributedActorSystem = FakeActorSystem
+
+// Reproducer for: rdar://91857262
+// Being able to use protocols and extend them conditionally with
+// `where Self: DistributedActor` and adding distributed methods onto them then.
+protocol GamePlayer: Sendable, Identifiable where ID == FakeActorSystem.ActorID {
+    func makeMove() async throws -> String
+}
+extension GamePlayer where Self: DistributedActor, ActorSystem == FakeActorSystem {
+    distributed func startGame(with opponent: String) {}
+}
+
+distributed actor FishPlayer: GamePlayer {
+    typealias ActorSystem = FakeActorSystem
+    distributed func makeMove() async throws -> String {
+        "move"
+    }
+}
+
+func test(player: FishPlayer) async throws {
+    try await player.startGame(with: "Caplin")
+}


### PR DESCRIPTION
rdar://91857262

This is actually pretty tricky so leaving it for now but will get back to it.

The issue is about:

```swift
protocol GamePlayer: Sendable, Identifiable where ID == FakeActorSystem.ActorID {
...
}
extension GamePlayer where Self: DistributedActor, ActorSystem == FakeActorSystem {
  distributed func startGame(with opponent: String) -> String { ... }
}

distributed actor FishPlayer: GamePlayer {
  typealias ActorSystem = FakeActorSystem
}
```

so we should be able to call `startGame` on the FishPlayer -- it is guaranteed to be right; but in order to synthesize the `thunk` for the `startGame` in the extension (!) we need to call to the protocol's `actorSystem` property, which we don't handle well today.


```
Assertion failed: (systemProperty && "Unable to find 'actorSystem' property"), function deriveBodyDistributed_thunk, file CodeSynthesisDistributedActor.cpp, line 300.
```

Some attempts in PR but this is incomplete, only showing the issue.
