### PR TITLE
[5.7][cmake] Prevent test failures by disabling LTO for swift runtime

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -1635,6 +1635,12 @@ function(add_swift_target_library name)
         BACK_DEPLOYMENT_LIBRARY)
   set(SWIFTLIB_multiple_parameter_options
         C_COMPILE_FLAGS
+        C_COMPILE_FLAGS_IOS
+        C_COMPILE_FLAGS_OSX
+        C_COMPILE_FLAGS_TVOS
+        C_COMPILE_FLAGS_WATCHOS
+        C_COMPILE_FLAGS_LINUX
+        C_COMPILE_FLAGS_WINDOWS
         DEPENDS
         FILE_DEPENDS
         FRAMEWORK_DEPENDS
@@ -1867,7 +1873,7 @@ function(add_swift_target_library name)
            ${SWIFTLIB_FRAMEWORK_DEPENDS_IOS_TVOS})
     endif()
 
-    # Collect architecutre agnostic compiler flags
+    # Collect architecture agnostic swift compiler flags
     set(swiftlib_swift_compile_flags_all ${SWIFTLIB_SWIFT_COMPILE_FLAGS})
     if(${sdk} STREQUAL OSX)
       list(APPEND swiftlib_swift_compile_flags_all
@@ -2022,6 +2028,27 @@ function(add_swift_target_library name)
       # Add PrivateFrameworks, rdar://28466433
       set(swiftlib_c_compile_flags_all ${SWIFTLIB_C_COMPILE_FLAGS})
       set(swiftlib_link_flags_all ${SWIFTLIB_LINK_FLAGS})
+
+      # Collect architecture agnostic c compiler flags
+      if(${sdk} STREQUAL OSX)
+        list(APPEND swiftlib_c_compile_flags_all
+             ${SWIFTLIB_C_COMPILE_FLAGS_OSX})
+      elseif(${sdk} STREQUAL IOS OR ${sdk} STREQUAL IOS_SIMULATOR)
+        list(APPEND swiftlib_c_compile_flags_all
+             ${SWIFTLIB_C_COMPILE_FLAGS_IOS})
+      elseif(${sdk} STREQUAL TVOS OR ${sdk} STREQUAL TVOS_SIMULATOR)
+        list(APPEND swiftlib_c_compile_flags_all
+             ${SWIFTLIB_C_COMPILE_FLAGS_TVOS})
+      elseif(${sdk} STREQUAL WATCHOS OR ${sdk} STREQUAL WATCHOS_SIMULATOR)
+        list(APPEND swiftlib_c_compile_flags_all
+             ${SWIFTLIB_C_COMPILE_FLAGS_WATCHOS})
+      elseif(${sdk} STREQUAL LINUX)
+        list(APPEND swiftlib_c_compile_flags_all
+             ${SWIFTLIB_C_COMPILE_FLAGS_LINUX})
+      elseif(${sdk} STREQUAL WINDOWS)
+        list(APPEND swiftlib_c_compile_flags_all
+             ${SWIFTLIB_C_COMPILE_FLAGS_WINDOWS})
+      endif()
 
       # Add flags to prepend framework search paths for the parallel framework
       # hierarchy rooted at /System/iOSSupport/...

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -104,11 +104,14 @@ if(SWIFT_BUILD_STDLIB OR SWIFT_BUILD_REMOTE_MIRROR)
     list(APPEND swift_demangling_cflags -DSWIFT_STDLIB_HAS_TYPE_PRINTING)
   endif()
 
+  # Gold LTO is unsupported. To prevent tests from failing when building
+  # with LTO, force swiftDemangling library to compile without LTO for Linux.
   add_swift_target_library(swiftDemangling OBJECT_LIBRARY
     ${swiftDemanglingSources}
     C_COMPILE_FLAGS
       -DswiftCore_EXPORTS
       ${swift_demangling_cflags}
+    C_COMPILE_FLAGS_LINUX -fno-lto
     INSTALL_IN_COMPONENT never_install)
 
   add_swift_target_library(swiftDemanglingCR OBJECT_LIBRARY

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -130,10 +130,13 @@ foreach(sdk ${SWIFT_SDKS})
 endforeach()
 
 
+# Gold LTO is unsupported. To prevent tests from failing when building
+# with LTO, force swift runtime to compile without LTO for Linux.
 add_swift_target_library(swiftImageRegistrationObjectELF
                   OBJECT_LIBRARY IS_STDLIB IS_STDLIB_CORE
                   SwiftRT-ELF.cpp
                   C_COMPILE_FLAGS ${SWIFT_RUNTIME_CORE_CXX_FLAGS}
+                  C_COMPILE_FLAGS_LINUX -fno-lto
                   LINK_FLAGS ${SWIFT_RUNTIME_CORE_LINK_FLAGS}
                   TARGET_SDKS ${ELFISH_SDKS}
                   SWIFT_COMPILE_FLAGS ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}


### PR DESCRIPTION
<!-- What's in this pull request? -->
We build a unified LLVM build with Swift and when enabling LTO, swift validation test suite fails for several ELF tests.  The swift compiler defaults to the gold linker in these tests and fails to recognize bitcode files as inputs.  This is also known issue for gold LTO as documented here (https://github.com/apple/swift/blob/main/lib/Driver/UnixToolChains.cpp#L166-L168). To prevent such test failures, prevent certain libraries, `swiftrt` and `swiftDemangling` from compiling with LTO when targeting Linux.

This change should should not affect anyone who don't build w/ LTO, and is a bug fix for those who try to build w/ LTO that targets Linux. This change was tested locally. 

(cherry picked from #59425 commit a81bb11f35912b08355865232688d7e9cff4eeaa)

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
