### PR TITLE
[Distributed] use implicit to detect compiler made fields

### DIFF
--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -636,7 +636,7 @@ void swift::checkDistributedActorProperties(const NominalTypeDecl *decl) {
 
   for (auto member : decl->getMembers()) {
     if (auto prop = dyn_cast<VarDecl>(member)) {
-      if (prop->isSynthesized())
+      if (prop->isImplicit())
         continue;
 
       auto id = prop->getName();

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -629,8 +629,8 @@ bool swift::checkDistributedActorProperty(VarDecl *var, bool diagnose) {
 void swift::checkDistributedActorProperties(const NominalTypeDecl *decl) {
   auto &C = decl->getASTContext();
 
-  if (isa<ProtocolDecl>(decl)) {
-    // protocols don't matter for stored property checking
+  if (isa<ProtocolDecl>(decl) || isa<ExtensionDecl>(decl)) {
+    // protocols and extensions don't matter for stored property checking
     return;
   }
 

--- a/test/Distributed/Inputs/FakeDistributedActorSystems.swift
+++ b/test/Distributed/Inputs/FakeDistributedActorSystems.swift
@@ -398,3 +398,12 @@ func __isRemoteActor(_ actor: AnyObject) -> Bool
 func __isLocalActor(_ actor: AnyObject) -> Bool {
   return !__isRemoteActor(actor)
 }
+
+@available(SwiftStdlib 5.7, *)
+public distributed actor FakeActorSystemGreeter {
+  public typealias ActorSystem = FakeActorSystem
+
+  public func greet(_ name: String) -> String {
+    "Hello, \(name)!"
+  }
+}

--- a/test/Distributed/distributed_extension_on_distributed_cross_module.swift
+++ b/test/Distributed/distributed_extension_on_distributed_cross_module.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unknown -disable-availability-checking -I %t 2>&1 %s
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+import Distributed
+import FakeDistributedActorSystems
+
+@available(SwiftStdlib 5.5, *)
+typealias DefaultDistributedActorSystem = FakeActorSystem
+
+extension FakeActorSystemGreeter {
+  distributed func hola(_ name: String) -> String {
+    "Hola, \(name)!"
+  }
+}
+
+


### PR DESCRIPTION
Work on rdar://95658795

The detection of "please don't declare those explicitly" is broken cross module, because the `synthesized` flag is never serialized or carried into swift interfaces. Instead we can rely on other flags.