### PR TITLE
Strip `Sendable` from existential types in `@preconcurrency` mangling.

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -951,6 +951,67 @@ Type TypeBase::stripConcurrency(bool recurse, bool dropGlobalActor) {
     return newFnType;
   }
 
+  if (auto existentialType = getAs<ExistentialType>()) {
+    auto newConstraintType = existentialType->getConstraintType()
+        ->stripConcurrency(recurse, dropGlobalActor);
+    if (newConstraintType.getPointer() ==
+            existentialType->getConstraintType().getPointer())
+      return Type(this);
+
+    return ExistentialType::get(newConstraintType);
+  }
+
+  if (auto protocolType = getAs<ProtocolType>()) {
+    if (protocolType->getDecl()->isSpecificProtocol(
+            KnownProtocolKind::Sendable))
+      return ProtocolCompositionType::get(getASTContext(), { }, false);
+
+    return Type(this);
+  }
+
+  if (auto protocolCompositionType = getAs<ProtocolCompositionType>()) {
+    SmallVector<Type, 4> newMembers;
+    auto members = protocolCompositionType->getMembers();
+    for (unsigned i : indices(members)) {
+      auto memberType = members[i];
+      auto newMemberType =
+          memberType->stripConcurrency(recurse, dropGlobalActor);
+      if (!newMembers.empty()) {
+        newMembers.push_back(newMemberType);
+        continue;
+      }
+
+      if (memberType.getPointer() != newMemberType.getPointer()) {
+        newMembers.append(members.begin(), members.begin() + i);
+        newMembers.push_back(newMemberType);
+        continue;
+      }
+    }
+
+    if (!newMembers.empty()) {
+      return ProtocolCompositionType::get(
+          getASTContext(), newMembers,
+          protocolCompositionType->hasExplicitAnyObject());
+    }
+
+    return Type(this);
+  }
+
+  if (auto existentialMetatype = getAs<ExistentialMetatypeType>()) {
+    auto instanceType = existentialMetatype->getExistentialInstanceType();
+    auto newInstanceType =
+        instanceType->stripConcurrency(recurse, dropGlobalActor);
+    if (instanceType.getPointer() != newInstanceType.getPointer()) {
+      Optional<MetatypeRepresentation> repr;
+      if (existentialMetatype->hasRepresentation())
+        repr = existentialMetatype->getRepresentation();
+      return ExistentialMetatypeType::get(
+          newInstanceType, repr, getASTContext());
+    }
+
+    return Type(this);
+  }
+
   return Type(this);
 }
 

--- a/test/SILGen/mangling_predates_concurrency.swift
+++ b/test/SILGen/mangling_predates_concurrency.swift
@@ -7,3 +7,13 @@
 public func excitingFunction<T: Sendable>(value: T, body: (@Sendable () -> Void)?) -> (@MainActor () -> Void) {
   { }
 }
+
+public protocol P { }
+
+// CHECK: sil [ossa] @$s29mangling_predates_concurrency13lotsOfChangesyyXlSgyp_AA1P_pypXpAaD_XlXptF
+@preconcurrency public func lotsOfChanges(
+  _: Sendable, _: P & Sendable, _: Sendable.Type,
+  _: (AnyObject & Sendable & P).Type
+) -> (AnyObject & Sendable)? {
+  nil
+}


### PR DESCRIPTION
* Explanation: Fixes an ABI bug where @preconcurrency doesn’t eliminate Sendable from existential types or existential meta types, causing mangled name changes when Swift frameworks adopt Sendable.
* Scope of Issue: Affects APIs that have added Sendable existential types and are marked `@preconcurrency`.
* Origination: With the original implementation of `@preconcurrency`.
* Risk: Low. This extends existing logic to drop Sendable from generic requirements to also modify existentials. 
* Original pull request: https://github.com/apple/swift/pull/59635
* Bug: rdar://91966505.
