### PR TITLE
Drop 'Sendable' when converting to Clang types. 

### DIFF
--- a/lib/AST/ClangTypeConverter.cpp
+++ b/lib/AST/ClangTypeConverter.cpp
@@ -449,6 +449,11 @@ clang::QualType ClangTypeConverter::visitProtocolType(ProtocolType *type) {
   auto proto = type->getDecl();
   auto &clangCtx = ClangASTContext;
 
+  // Strip 'Sendable'.
+  auto strippedType = type->stripConcurrency(false, false);
+  if (strippedType.getPointer() != type)
+    return convert(strippedType);
+
   if (!proto->isObjC())
     return clang::QualType();
 
@@ -702,6 +707,11 @@ ClangTypeConverter::visitSILBlockStorageType(SILBlockStorageType *type) {
 
 clang::QualType
 ClangTypeConverter::visitProtocolCompositionType(ProtocolCompositionType *type) {
+  // Strip 'Sendable'.
+  auto strippedType = type->stripConcurrency(false, false);
+  if (strippedType.getPointer() != type)
+    return convert(strippedType);
+
   // Any will be lowered to AnyObject, so we return the same result.
   if (type->isAny())
     return getClangIdType(ClangASTContext);

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -306,7 +306,9 @@ ExistentialLayout::ExistentialLayout(CanProtocolCompositionType type) {
       protoDecl = parameterized->getProtocol();
       containsParameterized = true;
     }
-    containsNonObjCProtocol |= !protoDecl->isObjC();
+    containsNonObjCProtocol |=
+        !protoDecl->isObjC() &&
+        !protoDecl->isSpecificProtocol(KnownProtocolKind::Sendable);
     protocols.push_back(protoDecl);
   }
 }

--- a/test/IRGen/Inputs/objc_protocol_sendable.h
+++ b/test/IRGen/Inputs/objc_protocol_sendable.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
 
 @interface A: NSObject
-- (id <NSObject>)foo NS_SWIFT_SENDABLE;
+- (id <NSObject>)foo __attribute__((swift_attr("@Sendable")));
 @end

--- a/test/IRGen/Inputs/objc_protocol_sendable.h
+++ b/test/IRGen/Inputs/objc_protocol_sendable.h
@@ -1,0 +1,5 @@
+#import <Foundation/Foundation.h>
+
+@interface A: NSObject
+- (id <NSObject>)foo NS_SWIFT_SENDABLE;
+@end

--- a/test/IRGen/objc_protocol_sendable.swift
+++ b/test/IRGen/objc_protocol_sendable.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend -emit-ir %s -swift-version 5 -import-objc-header %S/Inputs/objc_protocol_sendable.h | %IRGenFileCheck %s
+
+// REQUIRES: objc_interop
+// REQUIRES: concurrency
+
+// CHECK: define{{.*}}s22objc_protocol_sendable4test1aySo1AC_tF
+public func test(a: A) {
+  a.foo()
+}

--- a/test/SILGen/mangling_predates_concurrency.swift
+++ b/test/SILGen/mangling_predates_concurrency.swift
@@ -7,3 +7,13 @@
 public func excitingFunction<T: Sendable>(value: T, body: (@Sendable () -> Void)?) -> (@MainActor () -> Void) {
   { }
 }
+
+public protocol P { }
+
+// CHECK: sil [ossa] @$s29mangling_predates_concurrency13lotsOfChangesyyXlSgyp_AA1P_pypXpAaD_XlXptF
+@preconcurrency public func lotsOfChanges(
+  _: Sendable, _: P & Sendable, _: Sendable.Type,
+  _: (AnyObject & Sendable & P).Type
+) -> (AnyObject & Sendable)? {
+  nil
+}


### PR DESCRIPTION
Fixes rdar://94824682.
