### PR TITLE
Drop 'Sendable' when converting to Clang types. 

### DIFF
--- a/lib/AST/ClangTypeConverter.cpp
+++ b/lib/AST/ClangTypeConverter.cpp
@@ -449,6 +449,11 @@ clang::QualType ClangTypeConverter::visitProtocolType(ProtocolType *type) {
   auto proto = type->getDecl();
   auto &clangCtx = ClangASTContext;
 
+  // Strip 'Sendable'.
+  auto strippedType = type->stripConcurrency(false, false);
+  if (strippedType.getPointer() != type)
+    return convert(strippedType);
+
   if (!proto->isObjC())
     return clang::QualType();
 
@@ -702,6 +707,11 @@ ClangTypeConverter::visitSILBlockStorageType(SILBlockStorageType *type) {
 
 clang::QualType
 ClangTypeConverter::visitProtocolCompositionType(ProtocolCompositionType *type) {
+  // Strip 'Sendable'.
+  auto strippedType = type->stripConcurrency(false, false);
+  if (strippedType.getPointer() != type)
+    return convert(strippedType);
+
   // Any will be lowered to AnyObject, so we return the same result.
   if (type->isAny())
     return getClangIdType(ClangASTContext);

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -303,7 +303,9 @@ ExistentialLayout::ExistentialLayout(CanProtocolCompositionType type) {
       protoDecl = parameterized->getProtocol();
       containsParameterized = true;
     }
-    containsNonObjCProtocol |= !protoDecl->isObjC();
+    containsNonObjCProtocol |=
+        !protoDecl->isObjC() &&
+        !protoDecl->isSpecificProtocol(KnownProtocolKind::Sendable);
     protocols.push_back(protoDecl);
   }
 }

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -951,6 +951,67 @@ Type TypeBase::stripConcurrency(bool recurse, bool dropGlobalActor) {
     return newFnType;
   }
 
+  if (auto existentialType = getAs<ExistentialType>()) {
+    auto newConstraintType = existentialType->getConstraintType()
+        ->stripConcurrency(recurse, dropGlobalActor);
+    if (newConstraintType.getPointer() ==
+            existentialType->getConstraintType().getPointer())
+      return Type(this);
+
+    return ExistentialType::get(newConstraintType);
+  }
+
+  if (auto protocolType = getAs<ProtocolType>()) {
+    if (protocolType->getDecl()->isSpecificProtocol(
+            KnownProtocolKind::Sendable))
+      return ProtocolCompositionType::get(getASTContext(), { }, false);
+
+    return Type(this);
+  }
+
+  if (auto protocolCompositionType = getAs<ProtocolCompositionType>()) {
+    SmallVector<Type, 4> newMembers;
+    auto members = protocolCompositionType->getMembers();
+    for (unsigned i : indices(members)) {
+      auto memberType = members[i];
+      auto newMemberType =
+          memberType->stripConcurrency(recurse, dropGlobalActor);
+      if (!newMembers.empty()) {
+        newMembers.push_back(newMemberType);
+        continue;
+      }
+
+      if (memberType.getPointer() != newMemberType.getPointer()) {
+        newMembers.append(members.begin(), members.begin() + i);
+        newMembers.push_back(newMemberType);
+        continue;
+      }
+    }
+
+    if (!newMembers.empty()) {
+      return ProtocolCompositionType::get(
+          getASTContext(), newMembers,
+          protocolCompositionType->hasExplicitAnyObject());
+    }
+
+    return Type(this);
+  }
+
+  if (auto existentialMetatype = getAs<ExistentialMetatypeType>()) {
+    auto instanceType = existentialMetatype->getExistentialInstanceType();
+    auto newInstanceType =
+        instanceType->stripConcurrency(recurse, dropGlobalActor);
+    if (instanceType.getPointer() != newInstanceType.getPointer()) {
+      Optional<MetatypeRepresentation> repr;
+      if (existentialMetatype->hasRepresentation())
+        repr = existentialMetatype->getRepresentation();
+      return ExistentialMetatypeType::get(
+          newInstanceType, repr, getASTContext());
+    }
+
+    return Type(this);
+  }
+
   return Type(this);
 }
 

--- a/test/IRGen/Inputs/objc_protocol_sendable.h
+++ b/test/IRGen/Inputs/objc_protocol_sendable.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
 
 @interface A: NSObject
-- (id <NSObject>)foo NS_SWIFT_SENDABLE;
+- (id <NSObject>)foo __attribute__((swift_attr("@Sendable")));
 @end

--- a/test/IRGen/Inputs/objc_protocol_sendable.h
+++ b/test/IRGen/Inputs/objc_protocol_sendable.h
@@ -1,0 +1,5 @@
+#import <Foundation/Foundation.h>
+
+@interface A: NSObject
+- (id <NSObject>)foo NS_SWIFT_SENDABLE;
+@end

--- a/test/IRGen/objc_protocol_sendable.swift
+++ b/test/IRGen/objc_protocol_sendable.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend -emit-ir %s -swift-version 5 -import-objc-header %S/Inputs/objc_protocol_sendable.h | %IRGenFileCheck %s
+
+// REQUIRES: objc_interop
+// REQUIRES: concurrency
+
+// CHECK: define{{.*}}s22objc_protocol_sendable4test1aySo1AC_tF
+public func test(a: A) {
+  a.foo()
+}

--- a/test/SILGen/mangling_predates_concurrency.swift
+++ b/test/SILGen/mangling_predates_concurrency.swift
@@ -7,3 +7,13 @@
 public func excitingFunction<T: Sendable>(value: T, body: (@Sendable () -> Void)?) -> (@MainActor () -> Void) {
   { }
 }
+
+public protocol P { }
+
+// CHECK: sil [ossa] @$s29mangling_predates_concurrency13lotsOfChangesyyXlSgyp_AA1P_pypXpAaD_XlXptF
+@preconcurrency public func lotsOfChanges(
+  _: Sendable, _: P & Sendable, _: Sendable.Type,
+  _: (AnyObject & Sendable & P).Type
+) -> (AnyObject & Sendable)? {
+  nil
+}


### PR DESCRIPTION
* Explanation: Fixes an IR generation bug where adopting Sendable as part of the existential result of an Objective-C method would cause the compiler to crash.
* Scope of Issue: Affects Objective-C methods or properties that have added Sendable to their existential result/parameter types.
* Origination: With the implementation of Sendable in Objective-C.
* Risk: Low. This extends the logic mapping Swift existential types to Objective-C by stripping off Sendable, building on the logic introduced by https://github.com/apple/swift/pull/59636.
* Original pull request: https://github.com/apple/swift/pull/59638
* Bug report: rdar://94824682.