### PR TITLE
[WIP] Extend _playgroundPrintHook to allow multiple tools to add their own hooks

### DIFF
--- a/stdlib/public/SwiftShims/swift/shims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/swift/shims/CMakeLists.txt
@@ -8,6 +8,7 @@ set(sources
   LibcOverlayShims.h
   LibcShims.h
   MetadataSections.h
+  PrintHook.h
   Random.h
   RefCount.h
   Reflection.h

--- a/stdlib/public/SwiftShims/swift/shims/PrintHook.h
+++ b/stdlib/public/SwiftShims/swift/shims/PrintHook.h
@@ -1,0 +1,43 @@
+//===--- PrintHook.h ------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_STDLIB_SHIMS_PRINTHOOK_H
+#define SWIFT_STDLIB_SHIMS_PRINTHOOK_H
+
+#include "Visibility.h"
+#include "SwiftStdbool.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+SWIFT_RUNTIME_STDLIB_SPI
+__swift_bool _swift_isPrintHookInstalled(void);
+
+SWIFT_RUNTIME_STDLIB_SPI
+void _swift_installPrintHook(
+  void __attribute__((swiftcall)) (* hook)(
+    const char *message,
+    __swift_bool isDebug,
+    __attribute__((swift_context)) void *context
+  ),
+  void *hookContext
+);
+
+SWIFT_RUNTIME_STDLIB_SPI
+void _swift_invokePrintHooks(const char *message, __swift_bool isDebug);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif

--- a/stdlib/public/SwiftShims/swift/shims/module.modulemap
+++ b/stdlib/public/SwiftShims/swift/shims/module.modulemap
@@ -7,6 +7,7 @@ module SwiftShims {
   header "KeyPath.h"
   header "LibcShims.h"
   header "MetadataSections.h"
+  header "PrintHook.h"
   header "Random.h"
   header "RefCount.h"
   header "Reflection.h"

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -617,8 +617,38 @@ extension Unicode.Scalar: TextOutputStreamable {
   }
 }
 
+/// A hook function called by `print()` and `debugPrint()`.
+///
+/// - Parameters:
+///   - message: The message being printed.
+///   - isDebug: Whether or not `debugPrint()` is the caller.
+@available(SwiftStdlib 5.8, *)
+public typealias _PrintHook = (_ message: String, _ isDebug: Bool) -> Void
+
+@available(SwiftStdlib 5.8, *)
+@_silgen_name("_swift_installPrintHook")
+private func __installPrintHook(_ hook: @escaping _PrintHook)
+
+/// Install a hook in `print()` and `debugPrint()` for other components to print
+/// through.
+///
+/// - Parameters:
+///   - name: A unique name for the hook being installed. Reverse-DNS notation
+///     (e.g. `"org.swift.example-project"`) is recommended.
+///   - hook: The hook function to install.
+///
+/// - Warning: This function is not thread-safe. Print hooks should be set up
+///   as early as possible and should not be subsequently modified.
+@available(SwiftStdlib 5.8, *)
+public func _installPrintHook(
+  _ hook: @escaping _PrintHook
+) {
+  __installPrintHook(hook)
+}
+
 /// A hook for playgrounds to print through.
-public var _playgroundPrintHook: ((String) -> Void)? = nil
+@available(*, deprecated, message: "Use _installPrintHook(_:) instead.")
+public var _playgroundPrintHook: ((String) -> Void)?
 
 internal struct _TeeStream<L: TextOutputStream, R: TextOutputStream>
   : TextOutputStream

--- a/stdlib/public/stubs/CMakeLists.txt
+++ b/stdlib/public/stubs/CMakeLists.txt
@@ -2,6 +2,7 @@ set(swift_stubs_sources
     Assert.cpp
     GlobalObjects.cpp
     LibcShims.cpp
+    PrintHook.cpp
     Random.cpp
     Stubs.cpp
     ThreadLocalStorage.cpp

--- a/stdlib/public/stubs/PrintHook.cpp
+++ b/stdlib/public/stubs/PrintHook.cpp
@@ -1,0 +1,52 @@
+//===--- PrintHook.cpp ----------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/shims/PrintHook.h"
+
+#include "swift/Basic/Lazy.h"
+#include "swift/Runtime/Concurrent.h"
+#include "swift/Runtime/HeapObject.h"
+
+using namespace swift;
+
+struct PrintHook {
+  void SWIFT_CC(swift) (* function)(const char *, bool, SWIFT_CONTEXT void *);
+  void *context;
+};
+static Lazy<ConcurrentReadableArray<PrintHook>> printHookList;
+
+bool _swift_isPrintHookInstalled(void) {
+  return printHookList->snapshot().count() != 0;
+}
+
+void _swift_installPrintHook(
+  void SWIFT_CC(swift) (* hook)(
+    const char *message,
+    bool isDebug,
+    SWIFT_CONTEXT void *context
+  ),
+  void *hookContext
+) {
+  if (hookContext) {
+    hookContext = swift_unknownObjectRetain(hookContext);
+  }
+  PrintHook newHook { hook, hookContext };
+  printHookList->push_back(newHook);
+}
+
+void _swift_invokePrintHooks(const char *message, bool isDebug) {
+  for (const PrintHook& hook : printHookList->snapshot()) {
+    if (hook.function) {
+      (* hook.function)(message, isDebug, hook.context);
+    }
+  }
+}

--- a/test/stdlib/Print.swift
+++ b/test/stdlib/Print.swift
@@ -73,4 +73,37 @@ PrintTests.test("PlaygroundPrintHook") {
   expectEqual("%!1!2!3!4!\n%\n", printed)
 }
 
+PrintTests.test("PrintHooks") {
+  guard #available(SwiftStdlib 5.8, *) else {
+    return
+  }
+  
+  var printed = ""
+  var isDebug = false
+  _installPrintHook { message, debug in
+    printed = message
+    isDebug = debug
+  }
+
+  var s0 = ""
+  print("", 1, 2, 3, 4, "", separator: "|", to: &s0)
+  expectEqual("|1|2|3|4|\n", s0)
+  expectFalse(isDebug)
+  print("%\(s0)%")
+  expectEqual("%|1|2|3|4|\n%\n", printed)
+  expectFalse(isDebug)
+
+  printed = ""
+  var s1 = ""
+  print("", 1, 2, 3, 4, "", separator: "!", to: &s1)
+  expectEqual("", printed)
+  expectFalse(isDebug)
+  print("%\(s1)%")
+  expectEqual("%!1!2!3!4!\n%\n", printed)
+  expectFalse(isDebug)
+
+  debugPrint("")
+  expectTrue(isDebug)
+}
+
 runAllTests()


### PR DESCRIPTION
**⚠️ This PR is a work in progress.**

<!-- What's in this pull request? -->
This PR extends the `_playgroundPrintHook` mechanism to allow multiple hooks.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!-- Resolves SR-NNNN. -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
