### PR TITLE
[5.7] [Parse] Avoid skipping bodies with `/.../` regex literals

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -1390,7 +1390,7 @@ namespace swift {
     DiagnosticEngine &getDiags() { return QueueEngine; }
 
     /// Retrieve the underlying engine which will receive the diagnostics.
-    DiagnosticEngine &getUnderlyingDiags() { return UnderlyingEngine; }
+    DiagnosticEngine &getUnderlyingDiags() const { return UnderlyingEngine; }
 
     /// Clear this queue and erase all diagnostics recorded.
     void clear() {

--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -180,7 +180,7 @@ class Lexer {
   /// Retrieve the underlying diagnostic engine we emit diagnostics to. Note
   /// this should only be used for diagnostics not concerned with the current
   /// token.
-  DiagnosticEngine *getUnderlyingDiags() {
+  DiagnosticEngine *getUnderlyingDiags() const {
     return DiagQueue ? &DiagQueue->getUnderlyingDiags() : nullptr;
   }
 
@@ -218,7 +218,10 @@ public:
   /// \param Parent the parent lexer that scans the whole buffer
   /// \param BeginState start of the subrange
   /// \param EndState end of the subrange
-  Lexer(Lexer &Parent, State BeginState, State EndState);
+  /// \param EnableDiagnostics Whether to inherit the diagnostic engine of
+  /// \p Parent. If \c false, diagnostics will be disabled.
+  Lexer(const Lexer &Parent, State BeginState, State EndState,
+        bool EnableDiagnostics = true);
 
   /// Returns true if this lexer will produce a code completion token.
   bool isCodeCompletion() const {

--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -644,6 +644,12 @@ private:
   void lexStringLiteral(unsigned CustomDelimiterLen = 0);
   void lexEscapedIdentifier();
 
+  /// Attempt to scan a regex literal, returning the end pointer, or `nullptr`
+  /// if a regex literal cannot be scanned.
+  const char *tryScanRegexLiteral(const char *TokStart, bool MustBeRegex,
+                                  DiagnosticEngine *Diags,
+                                  bool &CompletelyErroneous) const;
+
   /// Attempt to lex a regex literal, returning true if lexing should continue,
   /// false if this is not a regex literal.
   bool tryLexRegexLiteral(const char *TokStart);

--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -580,6 +580,13 @@ public:
                             : LexerForwardSlashRegexMode::Tentative) {}
   };
 
+  /// Checks whether a given token could potentially contain the start of an
+  /// unskippable `/.../` regex literal. Such tokens need to go through the
+  /// parser, as they may become regex literal tokens. This includes operator
+  /// tokens such as `!/` which could be split into prefix `!` on a regex
+  /// literal.
+  bool isPotentialUnskippableBareSlashRegexLiteral(const Token &Tok) const;
+
 private:
   /// Nul character meaning kind.
   enum class NulCharacterKind {

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -715,13 +715,6 @@ public:
   /// plain Tok.is(T1) check).
   bool skipUntilTokenOrEndOfLine(tok T1, tok T2 = tok::NUM_TOKENS);
 
-  /// Skip a braced block (e.g. function body). The current token must be '{'.
-  /// Returns \c true if the parser hit the eof before finding matched '}'.
-  ///
-  /// Set \c HasNestedTypeDeclarations to true if a token for a type
-  /// declaration is detected in the skipped block.
-  bool skipBracedBlock(bool &HasNestedTypeDeclarations);
-
   /// Skip over SIL decls until we encounter the start of a Swift decl or eof.
   void skipSILUntilSwiftDecl();
 
@@ -1000,6 +993,8 @@ public:
   bool canDelayMemberDeclParsing(bool &HasOperatorDeclarations,
                                  bool &HasNestedClassDeclarations);
 
+  bool canDelayFunctionBodyParsing(bool &HasNestedTypeDeclarations);
+
   bool delayParsingDeclList(SourceLoc LBLoc, SourceLoc &RBLoc,
                             IterableDeclContext *IDC);
 
@@ -1210,9 +1205,7 @@ public:
                                        bool &hasEffectfulGet,
                                        AccessorKind currentKind,
                                        SourceLoc const& currentLoc);
-  
-  void consumeAbstractFunctionBody(AbstractFunctionDecl *AFD,
-                                   const DeclAttributes &Attrs);
+
   ParserResult<FuncDecl> parseDeclFunc(SourceLoc StaticLoc,
                                        StaticSpellingKind StaticSpelling,
                                        ParseDeclOptions Flags,

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1972,27 +1972,18 @@ const char *Lexer::findEndOfCurlyQuoteStringLiteral(const char *Body,
   }
 }
 
-bool Lexer::tryLexRegexLiteral(const char *TokStart) {
+const char *Lexer::tryScanRegexLiteral(const char *TokStart, bool MustBeRegex,
+                                       DiagnosticEngine *Diags,
+                                       bool &CompletelyErroneous) const {
   // We need to have experimental string processing enabled, and have the
   // parsing logic for regex literals available.
   if (!LangOpts.EnableExperimentalStringProcessing || !regexLiteralLexingFn)
-    return false;
+    return nullptr;
 
-  bool MustBeRegex = true;
   bool IsForwardSlash = (*TokStart == '/');
 
   // Check if we're able to lex a `/.../` regex.
   if (IsForwardSlash) {
-    switch (ForwardSlashRegexMode) {
-    case LexerForwardSlashRegexMode::None:
-      return false;
-    case LexerForwardSlashRegexMode::Tentative:
-      MustBeRegex = false;
-      break;
-    case LexerForwardSlashRegexMode::Always:
-      break;
-    }
-
     // For `/.../` regex literals, we need to ban space and tab at the start of
     // a regex to avoid ambiguity with operator chains, e.g:
     //
@@ -2010,23 +2001,25 @@ bool Lexer::tryLexRegexLiteral(const char *TokStart) {
     case ' ':
     case '\t': {
       if (!MustBeRegex)
-        return false;
+        return nullptr;
 
-      // We must have a regex, so emit an error for space and tab.
-      StringRef DiagChar;
-      switch (*RegexContentStart) {
-      case ' ':
-        DiagChar = "space";
-        break;
-      case '\t':
-        DiagChar = "tab";
-        break;
-      default:
-        llvm_unreachable("Unhandled case");
+      if (Diags) {
+        // We must have a regex, so emit an error for space and tab.
+        StringRef DiagChar;
+        switch (*RegexContentStart) {
+        case ' ':
+          DiagChar = "space";
+          break;
+        case '\t':
+          DiagChar = "tab";
+          break;
+        default:
+          llvm_unreachable("Unhandled case");
+        }
+        Diags->diagnose(getSourceLoc(RegexContentStart),
+                        diag::lex_regex_literal_invalid_starting_char, DiagChar)
+            .fixItInsert(getSourceLoc(RegexContentStart), "\\");
       }
-      diagnose(RegexContentStart, diag::lex_regex_literal_invalid_starting_char,
-               DiagChar)
-          .fixItInsert(getSourceLoc(RegexContentStart), "\\");
       break;
     }
     default:
@@ -2039,14 +2032,13 @@ bool Lexer::tryLexRegexLiteral(const char *TokStart) {
   // - CompletelyErroneous will be set if there was an error that cannot be
   //   recovered from.
   auto *Ptr = TokStart;
-  bool CompletelyErroneous = regexLiteralLexingFn(
-      &Ptr, BufferEnd, MustBeRegex,
-      getBridgedOptionalDiagnosticEngine(getTokenDiags()));
+  CompletelyErroneous = regexLiteralLexingFn(
+      &Ptr, BufferEnd, MustBeRegex, getBridgedOptionalDiagnosticEngine(Diags));
 
   // If we didn't make any lexing progress, this isn't a regex literal and we
   // should fallback to lexing as something else.
   if (Ptr == TokStart)
-    return false;
+    return nullptr;
 
   // If we're lexing `/.../`, error if we ended on the opening of a comment.
   // We prefer to lex the comment as it's more likely than not that is what
@@ -2054,10 +2046,12 @@ bool Lexer::tryLexRegexLiteral(const char *TokStart) {
   // TODO: This should be sunk into the Swift library.
   if (IsForwardSlash && Ptr[-1] == '/' && (*Ptr == '*' || *Ptr == '/')) {
     if (!MustBeRegex)
-      return false;
+      return nullptr;
 
-    diagnose(TokStart, diag::lex_regex_literal_unterminated);
-
+    if (Diags) {
+      Diags->diagnose(getSourceLoc(TokStart),
+                      diag::lex_regex_literal_unterminated);
+    }
     // Move the pointer back to the '/' of the comment.
     Ptr--;
   }
@@ -2090,7 +2084,7 @@ bool Lexer::tryLexRegexLiteral(const char *TokStart) {
 
         // Invalid, so bail.
         if (GroupDepth == 0)
-          return false;
+          return nullptr;
 
         GroupDepth -= 1;
         break;
@@ -2103,9 +2097,32 @@ bool Lexer::tryLexRegexLiteral(const char *TokStart) {
       }
     }
   }
+  assert(Ptr > TokStart && Ptr <= BufferEnd);
+  return Ptr;
+}
+
+bool Lexer::tryLexRegexLiteral(const char *TokStart) {
+  bool IsForwardSlash = (*TokStart == '/');
+  bool MustBeRegex = true;
+
+  if (IsForwardSlash) {
+    switch (ForwardSlashRegexMode) {
+    case LexerForwardSlashRegexMode::None:
+      return false;
+    case LexerForwardSlashRegexMode::Tentative:
+      MustBeRegex = false;
+      break;
+    case LexerForwardSlashRegexMode::Always:
+      break;
+    }
+  }
+  bool CompletelyErroneous = false;
+  auto *Ptr = tryScanRegexLiteral(TokStart, MustBeRegex, getTokenDiags(),
+                                  CompletelyErroneous);
+  if (!Ptr)
+    return false;
 
   // Update to point to where we ended regex lexing.
-  assert(Ptr > TokStart && Ptr <= BufferEnd);
   CurPtr = Ptr;
 
   // If the lexing was completely erroneous, form an unknown token.

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -246,9 +246,11 @@ Lexer::Lexer(const LangOptions &Options, const SourceManager &SourceMgr,
   initialize(Offset, EndOffset);
 }
 
-Lexer::Lexer(Lexer &Parent, State BeginState, State EndState)
+Lexer::Lexer(const Lexer &Parent, State BeginState, State EndState,
+             bool EnableDiagnostics)
     : Lexer(PrincipalTag(), Parent.LangOpts, Parent.SourceMgr, Parent.BufferID,
-            Parent.getUnderlyingDiags(), Parent.LexMode,
+            EnableDiagnostics ? Parent.getUnderlyingDiags() : nullptr,
+            Parent.LexMode,
             Parent.IsHashbangAllowed
                 ? HashbangMode::Allowed
                 : HashbangMode::Disallowed,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4119,11 +4119,13 @@ static unsigned skipUntilMatchingRBrace(Parser &P,
                                         bool &HasPoundDirective,
                                         bool &HasOperatorDeclarations,
                                         bool &HasNestedClassDeclarations,
-                                        bool &HasNestedTypeDeclarations) {
+                                        bool &HasNestedTypeDeclarations,
+                                        bool &HasPotentialRegexLiteral) {
   HasPoundDirective = false;
   HasOperatorDeclarations = false;
   HasNestedClassDeclarations = false;
   HasNestedTypeDeclarations = false;
+  HasPotentialRegexLiteral = false;
 
   unsigned OpenBraces = 1;
 
@@ -4145,6 +4147,18 @@ static unsigned skipUntilMatchingRBrace(Parser &P,
 
     HasNestedTypeDeclarations |= P.Tok.isAny(tok::kw_class, tok::kw_struct,
                                              tok::kw_enum);
+
+    // HACK: Bail if we encounter what could potentially be a regex literal.
+    // This is necessary as:
+    // - We might encounter an invalid Swift token that might be valid in a
+    // regex.
+    // - Such a literal could contain a literal `}`, which should not be treated
+    // as an end brace.
+    // FIXME: We should be able to handle `/.../` regex literals in the lexer.
+    if (P.L->isPotentialUnskippableBareSlashRegexLiteral(P.Tok)) {
+      HasPotentialRegexLiteral = true;
+      return OpenBraces;
+    }
 
     if (P.consumeIf(tok::l_brace)) {
       ++OpenBraces;
@@ -5452,12 +5466,14 @@ bool Parser::canDelayMemberDeclParsing(bool &HasOperatorDeclarations,
   CancellableBacktrackingScope BackTrack(*this);
   bool HasPoundDirective;
   bool HasNestedTypeDeclarations;
+  bool HasPotentialRegexLiteral;
   skipUntilMatchingRBrace(*this,
                           HasPoundDirective,
                           HasOperatorDeclarations,
                           HasNestedClassDeclarations,
-                          HasNestedTypeDeclarations);
-  if (!HasPoundDirective)
+                          HasNestedTypeDeclarations,
+                          HasPotentialRegexLiteral);
+  if (!HasPoundDirective && !HasPotentialRegexLiteral)
     BackTrack.cancelBacktrack();
   return !BackTrack.willBacktrack();
 }
@@ -6133,25 +6149,31 @@ static ParameterList *parseOptionalAccessorArgument(SourceLoc SpecifierLoc,
   return ParameterList::create(P.Context, StartLoc, param, EndLoc);
 }
 
-bool Parser::skipBracedBlock(bool &HasNestedTypeDeclarations) {
+bool Parser::canDelayFunctionBodyParsing(bool &HasNestedTypeDeclarations) {
+  // If explicitly disabled, respect the flag.
+  if (!isDelayedParsingEnabled() && !isCodeCompletionFirstPass())
+    return false;
+
   SyntaxParsingContext disabled(SyntaxContext);
   SyntaxContext->disable();
-  consumeToken(tok::l_brace);
 
-  // We don't care if a skipped function body contained any of these, so
-  // just ignore them.
+  // Skip until the matching right curly bracket; If it has a potential regex
+  // literal, we can't skip. We don't care others, so just ignore them;
+  CancellableBacktrackingScope BackTrack(*this);
+  consumeToken(tok::l_brace);
   bool HasPoundDirectives;
   bool HasOperatorDeclarations;
   bool HasNestedClassDeclarations;
+  bool HasPotentialRegexLiteral;
+  skipUntilMatchingRBrace(*this, HasPoundDirectives, HasOperatorDeclarations,
+                          HasNestedClassDeclarations, HasNestedTypeDeclarations,
+                          HasPotentialRegexLiteral);
+  if (HasPotentialRegexLiteral)
+    return false;
 
-  unsigned OpenBraces = skipUntilMatchingRBrace(*this,
-                                                HasPoundDirectives,
-                                                HasOperatorDeclarations,
-                                                HasNestedClassDeclarations,
-                                                HasNestedTypeDeclarations);
-  if (consumeIf(tok::r_brace))
-    --OpenBraces;
-  return OpenBraces != 0;
+  BackTrack.cancelBacktrack();
+  consumeIf(tok::r_brace);
+  return true;
 }
 
 void Parser::skipSILUntilSwiftDecl() {
@@ -7136,30 +7158,6 @@ Parser::parseDeclVar(ParseDeclOptions Flags,
   return makeResult(Status);
 }
 
-void Parser::consumeAbstractFunctionBody(AbstractFunctionDecl *AFD,
-                                         const DeclAttributes &Attrs) {
-  auto BeginParserPosition = getParserPosition();
-  SourceRange BodyRange;
-  BodyRange.Start = Tok.getLoc();
-
-  // Advance the parser to the end of the block; '{' ... '}'.
-  bool HasNestedTypeDeclarations;
-  skipBracedBlock(HasNestedTypeDeclarations);
-
-  BodyRange.End = PreviousLoc;
-
-  AFD->setBodyDelayed(BodyRange);
-  AFD->setHasNestedTypeDeclarations(HasNestedTypeDeclarations);
-
-  if (isCodeCompletionFirstPass() &&
-      SourceMgr.rangeContainsCodeCompletionLoc(BodyRange)) {
-    State->setCodeCompletionDelayedDeclState(
-        SourceMgr, L->getBufferID(),
-        CodeCompletionDelayedDeclKind::FunctionBody,
-        PD_Default, AFD, BodyRange, BeginParserPosition.PreviousLoc);
-  }
-}
-
 /// Parse a 'func' declaration, returning null on error.  The caller
 /// handles this case and does recovery as appropriate.
 ///
@@ -7472,12 +7470,41 @@ void Parser::parseAbstractFunctionBody(AbstractFunctionDecl *AFD) {
   // If we can delay parsing this body, or this is the first pass of code
   // completion, skip until the end. If we encounter a code completion token
   // while skipping, we'll make a note of it.
-  if (isDelayedParsingEnabled() || isCodeCompletionFirstPass()) {
-    consumeAbstractFunctionBody(AFD, AFD->getAttrs());
+  auto BodyPreviousLoc = PreviousLoc;
+  SourceRange BodyRange(Tok.getLoc());
+  auto setCodeCompletionDelayedDeclStateIfNeeded = [&] {
+    if (!isCodeCompletionFirstPass() ||
+        !SourceMgr.rangeContainsCodeCompletionLoc(BodyRange)) {
+      return;
+    }
+    if (State->hasCodeCompletionDelayedDeclState())
+      State->takeCodeCompletionDelayedDeclState();
+    State->setCodeCompletionDelayedDeclState(
+        SourceMgr, L->getBufferID(),
+        CodeCompletionDelayedDeclKind::FunctionBody,
+        PD_Default, AFD, BodyRange, BodyPreviousLoc);
+  };
+
+  bool HasNestedTypeDeclarations;
+  if (canDelayFunctionBodyParsing(HasNestedTypeDeclarations)) {
+    BodyRange.End = PreviousLoc;
+
+    assert(SourceMgr.isBeforeInBuffer(BodyRange.Start, BodyRange.End) ||
+           BodyRange.Start == BodyRange.End &&
+           "At least '{' should be consumed");
+
+    AFD->setBodyDelayed(BodyRange);
+    AFD->setHasNestedTypeDeclarations(HasNestedTypeDeclarations);
+
+    setCodeCompletionDelayedDeclStateIfNeeded();
     return;
   }
 
   (void)parseAbstractFunctionBodyImpl(AFD);
+  assert(BodyRange.Start == AFD->getBodySourceRange().Start &&
+         "The start of the body should be the 'l_brace' token above");
+  BodyRange = AFD->getBodySourceRange();
+  setCodeCompletionDelayedDeclStateIfNeeded();
 }
 
 BodyAndFingerprint

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -886,6 +886,8 @@ void Parser::tryLexRegexLiteral(bool forUnappliedOperator) {
 
   // Check to see if we have a regex literal `/.../`, optionally with a prefix
   // operator e.g `!/.../`.
+  // NOTE: If you change this logic you must also change the logic in
+  // isPotentialUnskippableBareSlashRegexLiteral.
   bool mustBeRegex = false;
   switch (Tok.getKind()) {
   case tok::oper_prefix:

--- a/test/StringProcessing/Parse/forward-slash-regex-skipping-allowed.swift
+++ b/test/StringProcessing/Parse/forward-slash-regex-skipping-allowed.swift
@@ -1,0 +1,51 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -parse -enable-bare-slash-regex -disable-availability-checking -experimental-skip-all-function-bodies -stats-output-dir %t %s
+// RUN: %{python} %utils/process-stats-dir.py --set-csv-baseline %t/stats.csv %t
+// RUN: %FileCheck -input-file %t/stats.csv %s
+
+// REQUIRES: swift_in_compiler
+
+// Make sure we can skip in all of the below cases.
+
+// We don't appear to output a stats entry when it is 0.
+// CHECK-NOT: {{"Parse.NumFunctionsParsed"}}
+
+// Balanced `{}`, so okay.
+func a() { / {}/ }
+func b() { / \{}/ }
+func c() { / {"{"}/ }
+
+// Some cases of infix '/' that we should continue to skip.
+func d() {
+  _ = 1 / 2 + 3 * 4
+  _ = 1 / 2 / 3 / 4
+}
+func e() {
+  let arr = [1, 2, 3]
+  _ = arr.reduce(0, /) / 2
+
+  func foo(_ i: Int, _ fn: () -> Void) {}
+  foo(1 / 2 / 3, { print("}}}{{{") })
+}
+
+// Some cases of prefix '/' that we should continue to skip.
+prefix operator /
+prefix func / <T> (_ x: T) -> T { x }
+
+enum E {
+  case e
+  func foo<T>(_ x: T) {}
+}
+
+func f() {
+  _ = /E.e
+  (/E.e).foo(/0)
+
+  func foo<T, U>(_ x: T, _ y: U) {}
+  foo((/E.e), /E.e)
+  foo((/)(E.e), /E.e)
+
+  func bar<T>(_ x: T) -> Int { 0 }
+  _ = bar(/E.e) / 2
+}

--- a/test/StringProcessing/Parse/forward-slash-regex-skipping-invalid.swift
+++ b/test/StringProcessing/Parse/forward-slash-regex-skipping-invalid.swift
@@ -1,0 +1,70 @@
+// RUN: %target-typecheck-verify-swift -enable-bare-slash-regex -disable-availability-checking -experimental-skip-all-function-bodies
+// RUN: %target-typecheck-verify-swift -enable-bare-slash-regex -disable-availability-checking -experimental-skip-non-inlinable-function-bodies-without-types
+// RUN: %target-typecheck-verify-swift -enable-bare-slash-regex -disable-availability-checking -experimental-skip-non-inlinable-function-bodies
+
+// REQUIRES: swift_in_compiler
+
+// We don't consider this a regex literal when skipping as it has an initial
+// space.
+func a() { _ = / x*/ } // expected-error {{unexpected end of block comment}}
+
+// Same because of unbalanced ')'
+func b() { _ = /x)*/ } // expected-error {{unexpected end of block comment}}
+
+// These also fail the heuristic, but have unbalanced `{` `}`, so we don't skip.
+func c() { _ = / x}*/ } // expected-error {{regex literal may not start with space; add backslash to escape}}
+func d() { _ = / x{*/ } // expected-error {{regex literal may not start with space; add backslash to escape}}
+
+// Unterminated, and unbalanced `{}`.
+func e() {
+  _ = /         }
+  // expected-error@-1 {{unterminated regex literal}}
+  // expected-error@-2 {{regex literal may not start with space; add backslash to escape}}
+}
+func f() {
+  _ = /         {
+  // expected-error@-1 {{unterminated regex literal}}
+  // expected-error@-2 {{regex literal may not start with space; add backslash to escape}}
+}
+func g() {
+  _ = /x         }
+} // expected-error {{extraneous '}' at top level}}
+func h() {
+  _ = /x         {
+  } // The above cannot a regex literal so we skip; this `}` is to balance things out.
+}
+func i() {
+  _ = /x "[abc]     {
+  // expected-error@-1 {{unterminated string literal}}
+}
+func j() {
+  _ = /^ [abc]     {
+  // expected-error@-1 {{unterminated regex literal}}
+}
+func k() {
+  _ = /^ "[abc]     {
+  // expected-error@-1 {{unterminated string literal}}
+}
+func l() {
+  _ = /^    } abc     {
+  // expected-error@-1 {{unterminated regex literal}}
+}
+func m() {
+  _ = / "
+  // expected-error@-1 {{unterminated string literal}}
+  }
+} // expected-error {{extraneous '}' at top level}}
+
+// Unbalanced `}`, make sure we don't consider the string literal `{`.
+func n() { / "{"}/ } // expected-error {{regex literal may not start with space; add backslash to escape}}
+
+func err1() { _ = / 0xG}/ }
+// expected-error@-1 {{regex literal may not start with space; add backslash to escape}}
+func err2() { _ = / 0oG}/ }
+// expected-error@-1 {{regex literal may not start with space; add backslash to escape}}
+func err3() { _ = / {"/ }
+// expected-error@-1 {{regex literal may not start with space; add backslash to escape}}
+func err4() { _ = / {'/ }
+// expected-error@-1 {{regex literal may not start with space; add backslash to escape}}
+func err5() { _ = / {<#placeholder#>/ }
+// expected-error@-1 {{regex literal may not start with space; add backslash to escape}}

--- a/test/StringProcessing/Parse/forward-slash-regex-skipping.swift
+++ b/test/StringProcessing/Parse/forward-slash-regex-skipping.swift
@@ -1,0 +1,130 @@
+// RUN: %target-typecheck-verify-swift -enable-bare-slash-regex -disable-availability-checking -experimental-skip-all-function-bodies
+// RUN: %target-typecheck-verify-swift -enable-bare-slash-regex -disable-availability-checking -experimental-skip-non-inlinable-function-bodies-without-types
+// RUN: %target-typecheck-verify-swift -enable-bare-slash-regex -disable-availability-checking -experimental-skip-non-inlinable-function-bodies
+
+// REQUIRES: swift_in_compiler
+
+// Make sure we properly handle `/.../` regex literals in skipped function
+// bodies. Currently we detect them and avoid skipping, but in the future we
+// ought to be able to skip over them.
+
+prefix operator ^^
+prefix func ^^ <T>(_ x: T) -> T { x }
+
+struct A {
+  static let r = /test":"(.*?)"/
+}
+struct B {
+  static let r = /x*/
+}
+
+struct C {
+  func foo() {
+    let r = /x*/
+  }
+}
+
+struct D {
+  func foo() {
+    func bar() {
+      let r = /x}}*/
+    }
+  }
+}
+
+func a() { _ = /abc}}*/ }
+func b() { _ = /\// }
+func c() { _ = /\\/ }
+func d() { _ = ^^/x}}*/ }
+func e() { _ = (^^/x}}*/) }
+func f() { _ = ^^/^x}}*/ }
+func g() { _ = "\(/x}}*/)" }
+func h() { _ = "\(^^/x}}*/)" }
+
+func i() {
+  func foo<T>(_ x: T, y: T) {}
+  foo(/}}*/, y: /"/)
+}
+
+func j() {
+  _ = {
+    0
+    /x}}} /
+    2
+  }
+}
+
+func k() {
+  _ = 2
+  / 1 / .bitWidth
+}
+func l() {
+  _ = 2
+  /x}*/ .self
+}
+func m() {
+  _ = 2
+  / 1 /
+    .bitWidth
+}
+func n() {
+  _ = 2
+  /x} /
+    .bitWidth
+}
+func o() {
+  _ = /x// comment
+}
+func p() {
+  _ = /x // comment
+}
+func q() {
+  _ = /x/*comment*/
+}
+func r() { _ = /[(0)]/ }
+func s() { _ = /(x)/ }
+func t() { _ = /[)]/ }
+func u() { _ = /[a\])]/ }
+func v() { _ = /([)])/ }
+func w() { _ = /]]][)]/ }
+
+func x() { _ = /,/ }
+func y() { _ = /}/ }
+func z() { _ = /]/ }
+func a1() { _ = /:/ }
+func a2() { _ = /;/ }
+func a3() { _ = /)/ }
+func a4() { _ = / / } // expected-error {{regex literal may not start with space; add backslash to escape}}
+func a5() { _ = /\ / }
+
+prefix operator /
+prefix func / <T> (_ x: T) -> T { x }
+
+enum E {
+  case e
+  func foo<T>(_ x: T) {}
+}
+
+func a6() {
+  func foo<T, U>(_ x: T, _ y: U) {}
+  foo(/E.e, /E.e) // expected-error {{expected ',' separator}}
+}
+
+// Make sure we don't emit errors for these.
+func err1() { _ = /0xG/ }
+func err2() { _ = /0oG/ }
+func err3() { _ = /"/ }
+func err4() { _ = /'/ }
+func err5() { _ = /<#placeholder#>/ }
+
+func err6() { _ = ^^/0xG/ }
+func err7() { _ = ^^/0oG/ }
+func err8() { _ = ^^/"/ }
+func err9() { _ = ^^/'/ }
+func err10() { _ = ^^/<#placeholder#>/ }
+
+func err11() { _ = (^^/0xG/) }
+func err12() { _ = (^^/0oG/) }
+func err13() { _ = (^^/"/) }
+func err14() { _ = (^^/'/) }
+func err15() { _ = (^^/<#placeholder#>/) }


### PR DESCRIPTION
*5.7 cherry-pick of https://github.com/apple/swift/pull/59641*

While skipping, if we encounter a token that looks like it could be the start of a `/.../` regex literal, fall back to parsing the function or type body normally, as such a token could become a regex literal. As such, it could treat `{` and `}` as literal, or otherwise have contents that would be lexically invalid Swift.

To avoid falling back in too many cases, we apply the existing regex literal heuristics. Cases that pass the heuristic fall back to regular parsing. Cases that fail the heuristic are further checked to make sure they wouldn't contain an unbalanced `{` or `}`, but otherwise are allowed to be skipped. This allows us to continue skipping for most occurrences of infix and prefix `/`.

This is meant as a lower risk workaround to fix the the issue, we ought to go back to handling regex literals in the lexer.

Resolves https://github.com/apple/swift/issues/59493
Resolves rdar://95354010