### PR TITLE
[cxx-interop] Fix crash while importing `operator++()` that returns `void`

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2191,11 +2191,7 @@ namespace {
               MD->overwriteAccess(AccessLevel::Private);
             } else if (cxxOperatorKind ==
                        clang::OverloadedOperatorKind::OO_PlusPlus) {
-              auto selfTy = result->getSelfInterfaceType();
-              auto returnTy =
-                  MD->getResultInterfaceType()->getAnyPointerElementType();
-              if (cxxMethod->param_empty() &&
-                  selfTy->getCanonicalType() == returnTy->getCanonicalType()) {
+              if (cxxMethod->param_empty()) {
                 // This is a pre-increment operator. We synthesize a
                 // non-mutating function called `successor() -> Self`.
                 FuncDecl *successorFunc = synthesizer.makeSuccessorFunc(MD);

--- a/test/Interop/Cxx/operators/member-inline-typechecker.swift
+++ b/test/Interop/Cxx/operators/member-inline-typechecker.swift
@@ -43,6 +43,3 @@ let diffTypesResultDoubleByVal: Double = diffTypesArrayByVal[0.5]
 
 let postIncrement = HasPostIncrementOperator()
 postIncrement.successor() // expected-error {{value of type 'HasPostIncrementOperator' has no member 'successor'}}
-
-let anotherReturnType = HasPreIncrementOperatorWithAnotherReturnType()
-anotherReturnType.successor() // expected-error {{value of type 'HasPreIncrementOperatorWithAnotherReturnType' has no member 'successor'}}


### PR DESCRIPTION
I will add new tests in a separate change. Submitting this PR to unblock the CI.

rdar://95684692