### PR TITLE
🍒[5.7] DeadObjectElimination: fix a bug which caused wrong inserted release instructions.

### DIFF
--- a/test/SILOptimizer/dead_alloc_elim.sil
+++ b/test/SILOptimizer/dead_alloc_elim.sil
@@ -669,3 +669,40 @@ bb0:
   return %r : $()
 }
 
+sil @createit : $@convention(thin) () -> @owned Kl
+
+// Check that we don't crash here.
+sil @not_dominating_stores : $@convention(thin) () -> () {
+bb0:
+  %7 = integer_literal $Builtin.Word, 1
+  %10 = alloc_ref [stack] [tail_elems $Kl * %7 : $Builtin.Word] $_ContiguousArrayStorage<Kl>
+  %11 = upcast %10 : $_ContiguousArrayStorage<Kl> to $__ContiguousArrayStorageBase
+  %18 = ref_tail_addr %11 : $__ContiguousArrayStorageBase, $Kl
+  %35 = function_ref @createit : $@convention(thin) () -> @owned Kl
+  cond_br undef, bb1, bb2
+bb1:
+  %36 = apply %35() : $@convention(thin) () -> @owned Kl
+  store %36 to %18 : $*Kl
+  br bb3
+bb2:
+  %46 = apply %35() : $@convention(thin) () -> @owned Kl
+  store %46 to %18 : $*Kl
+  br bb3
+bb3:
+  strong_release %10 : $_ContiguousArrayStorage<Kl>
+  dealloc_stack_ref %10 : $_ContiguousArrayStorage<Kl>
+  %1 = tuple()
+  return %1 : $()
+}
+
+sil @$ss23_ContiguousArrayStorageCfD : $@convention(method) <Element> (@owned _ContiguousArrayStorage<Element>) -> () {
+bb0(%0 : $_ContiguousArrayStorage<Element>):
+  %1 = ref_tail_addr %0 : $_ContiguousArrayStorage<Element>, $Element
+  %2 = address_to_pointer %1 : $*Element to $Builtin.RawPointer
+  %10 = metatype $@thick Element.Type
+  %12 = builtin "destroyArray"<Element>(%10 : $@thick Element.Type, %2 : $Builtin.RawPointer, undef : $Builtin.Word) : $()
+  dealloc_ref %0 : $_ContiguousArrayStorage<Element>
+  %15 = tuple ()
+  return %15 : $()
+}
+


### PR DESCRIPTION
This bug triggered a "instruction isn't dominated by its operand" verifier crash.
Or - if the verifier doesn't run - a crash later in IRGen.

rdar://94376582

This is a cherry-pick of https://github.com/apple/swift/pull/59591