### PR TITLE
[5.7][stdlib] use @_transparent in an appropriate spot

### DIFF
--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -396,7 +396,7 @@ extension Optional: Equatable where Wrapped: Equatable {
   /// - Parameters:
   ///   - lhs: An optional value to compare.
   ///   - rhs: Another optional value to compare.
-  @inlinable
+  @_transparent
   public static func ==(lhs: Wrapped?, rhs: Wrapped?) -> Bool {
     switch (lhs, rhs) {
     case let (l?, r?):


### PR DESCRIPTION
This is is a cherry-pick of https://github.com/apple/swift/pull/59327 to the 5.7 branch.

One of the equality operator definitions on Optional was inconsistently `@inlinable`, while its peers are `@_transparent`. As a consequence, the detailed diagnostics surrounding Optional with `==` and `!=` differ strangely based on minute details. `@_transparent` makes more sense than `@inline(__always)` in the specific case of `==` and `Optional`.

Resolves rdar://95690105