### PR TITLE
RequirementMachine: Don't filter out unavailable Sendable conformance if allowMissing=true [5.7]

### DIFF
--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -873,7 +873,8 @@ void NormalProtocolConformance::finishSignatureConformances() {
     if (substTy->hasTypeParameter())
       substTy = getDeclContext()->mapTypeIntoContext(substTy);
 
-    reqConformances.push_back(module->lookupConformance(substTy, reqProto)
+    reqConformances.push_back(module->lookupConformance(substTy, reqProto,
+                                                        /*allowMissing=*/true)
                                   .mapConformanceOutOfContext());
   }
   setSignatureConformances(reqConformances);

--- a/lib/AST/RequirementMachine/ConcreteContraction.cpp
+++ b/lib/AST/RequirementMachine/ConcreteContraction.cpp
@@ -399,7 +399,8 @@ ConcreteContraction::substRequirement(const Requirement &req) const {
       auto conformance = module->lookupConformance(substFirstType, proto,
                                                    allowMissing);
 
-      if (proto->isSpecificProtocol(KnownProtocolKind::Sendable) &&
+      if (!allowMissing &&
+          proto->isSpecificProtocol(KnownProtocolKind::Sendable) &&
           conformance.hasUnavailableConformance()) {
         conformance = ProtocolConformanceRef::forInvalid();
       }

--- a/lib/AST/RequirementMachine/ConcreteTypeWitness.cpp
+++ b/lib/AST/RequirementMachine/ConcreteTypeWitness.cpp
@@ -156,7 +156,8 @@ void PropertyMap::concretizeNestedTypesFromConcreteParent(
     auto conformance = module->lookupConformance(concreteType,
                                                  const_cast<ProtocolDecl *>(proto),
                                                  allowMissing);
-    if (proto->isSpecificProtocol(KnownProtocolKind::Sendable) &&
+    if (!allowMissing &&
+        proto->isSpecificProtocol(KnownProtocolKind::Sendable) &&
         conformance.hasUnavailableConformance()) {
       conformance = ProtocolConformanceRef::forInvalid();
     }

--- a/test/Generics/conditional_conformance_sendable.swift
+++ b/test/Generics/conditional_conformance_sendable.swift
@@ -1,0 +1,31 @@
+// RUN: %target-typecheck-verify-swift
+
+// Conditional conformance edge case. If a type conforms to Sendable
+// conditionally, allow some of those conditional requirements to
+// reference unavailable Sendable conformances when allowMissing=true.
+
+class ConditionalC {}
+
+@available(*, unavailable)
+extension ConditionalC : Sendable {}
+
+struct ConditionalG<T> {}
+
+extension ConditionalG : Sendable where T : Sendable {}
+
+// Strict concurrency checking should reject this since the inherited
+// conformance to Sendable has an unsatisfied conditional requirement.
+protocol ConditionalDerived : Sendable {}
+
+extension ConditionalG : ConditionalDerived {}
+
+protocol ConditionalP {
+  associatedtype Value: ConditionalDerived
+}
+
+// Value is concretized via a conditional conformance of
+// ConditionalG<ConditionalC> to Sendable.
+//
+// The conditional requirement ConditionalC: Sendable is satisfied
+// by an unavailable conformance. But we still allow it in this case.
+extension ConditionalP where Value == ConditionalG<ConditionalC> {}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/59632.

Fixes rdar://problem/94456989.