### PR TITLE
[ASTContext] Fix unordered member initialization warning (NFC)

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -608,10 +608,10 @@ ASTContext::ASTContext(
     : LangOpts(langOpts), TypeCheckerOpts(typeckOpts), SILOpts(silOpts),
       SearchPathOpts(SearchPathOpts), ClangImporterOpts(ClangImporterOpts),
       SymbolGraphOpts(SymbolGraphOpts), SourceMgr(SourceMgr), Diags(Diags),
-      PreModuleImportCallback(PreModuleImportCallback),
       evaluator(Diags, langOpts), TheBuiltinModule(createBuiltinModule(*this)),
       StdlibModuleName(getIdentifier(STDLIB_NAME)),
       SwiftShimsModuleName(getIdentifier(SWIFT_SHIMS_NAME)),
+      PreModuleImportCallback(PreModuleImportCallback),
       TheErrorType(new (*this, AllocationArena::Permanent) ErrorType(
           *this, Type(), RecursiveTypeProperties::HasError)),
       TheUnresolvedType(new (*this, AllocationArena::Permanent)


### PR DESCRIPTION
This patch should fix a warning triggered because `PreModuleImportCallback`
is initialized before other `ASTContext` members.

Signed-off-by: Med Ismail Bennani <medismail.bennani@gmail.com>