### PR TITLE
[5.7][Sema] Use `ExistentialType` for `Any` and `AnyObject`.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -537,7 +537,7 @@ public:
   /// Retrieve the declaration of Swift.Error.
   ProtocolDecl *getErrorDecl() const;
   CanType getErrorExistentialType() const;
-  
+
 #define KNOWN_STDLIB_TYPE_DECL(NAME, DECL_CLASS, NUM_GENERIC_PARAMS) \
   /** Retrieve the declaration of Swift.NAME. */ \
   DECL_CLASS *get##NAME##Decl() const; \
@@ -561,7 +561,13 @@ public:
   /// Retrieve the declaration of the "pointee" property of a pointer type.
   VarDecl *getPointerPointeePropertyDecl(PointerTypeKind ptrKind) const;
 
-  /// Retrieve the type Swift.AnyObject.
+  /// Retrieve the type Swift.Any as an existential type.
+  CanType getAnyExistentialType() const;
+
+  /// Retrieve the type Swift.AnyObject as a constraint.
+  CanType getAnyObjectConstraint() const;
+
+  /// Retrieve the type Swift.AnyObject as an existential type.
   CanType getAnyObjectType() const;
 
 #define KNOWN_SDK_TYPE_DECL(MODULE, NAME, DECL_CLASS, NUM_GENERIC_PARAMS) \

--- a/include/swift/AST/ASTSynthesis.h
+++ b/include/swift/AST/ASTSynthesis.h
@@ -54,7 +54,7 @@ enum SingletonTypeSynthesizer {
 inline Type synthesizeType(SynthesisContext &SC,
                            SingletonTypeSynthesizer kind) {
   switch (kind) {
-  case _any: return SC.Context.TheAnyType;
+  case _any: return SC.Context.getAnyExistentialType();
   case _bridgeObject: return SC.Context.TheBridgeObjectType;
   case _error: return SC.Context.getErrorExistentialType();
   case _executor: return SC.Context.TheExecutorType;

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -5420,7 +5420,12 @@ public:
 
   bool shouldPrintWithAny() const { return PrintWithAny; }
 
-  void forcePrintWithAny(bool value) { PrintWithAny = value; }
+  void forcePrintWithAny(llvm::function_ref<void(Type)> print) {
+    bool oldValue = PrintWithAny;
+    PrintWithAny = true;
+    print(this);
+    PrintWithAny = oldValue;
+  }
 
   bool requiresClass() const {
     if (auto protocol = ConstraintType->getAs<ProtocolType>())

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -5398,16 +5398,29 @@ struct ExistentialTypeGeneralization {
 class ExistentialType final : public TypeBase {
   Type ConstraintType;
 
+  /// Whether to print this existential type with the 'any' keyword,
+  /// e.g. in diagnostics.
+  ///
+  /// Any and AnyObject need not use 'any', and they are printed
+  /// in diagnostics without 'any' unless wrapped in MetatypeType.
+  /// This field should only be used by TypePrinter.
+  bool PrintWithAny;
+
   ExistentialType(Type constraintType,
+                  bool printWithAny,
                   const ASTContext *canonicalContext,
                   RecursiveTypeProperties properties)
       : TypeBase(TypeKind::Existential, canonicalContext, properties),
-        ConstraintType(constraintType) {}
+        ConstraintType(constraintType), PrintWithAny(printWithAny) {}
 
 public:
-  static Type get(Type constraint, bool forceExistential = false);
+  static Type get(Type constraint);
 
   Type getConstraintType() const { return ConstraintType; }
+
+  bool shouldPrintWithAny() const { return PrintWithAny; }
+
+  void forcePrintWithAny(bool value) { PrintWithAny = value; }
 
   bool requiresClass() const {
     if (auto protocol = ConstraintType->getAs<ProtocolType>())

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -6224,7 +6224,7 @@ public:
     // interfaces. Verifying that the underlying type of a
     // protocol typealias is a constriant type is fundamentally
     // circular, so the desugared type should be written in source.
-    if (Options.DesugarExistentialConstraint) {
+    if (Options.DesugarExistentialConstraint && !T->isAnyObject()) {
       visit(T->getConstraintType()->getDesugaredType());
     } else {
       visit(T->getConstraintType());

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -5581,38 +5581,30 @@ public:
     }
 
     Type instanceType = T->getInstanceType();
-    bool didPrintInstanceType = false;
-    if (Options.PrintExplicitAny) {
-      if (T->is<ExistentialMetatypeType>()) {
-        Printer << "any ";
+    if (Options.PrintExplicitAny && T->is<ExistentialMetatypeType>()) {
+      Printer << "any ";
 
-        // FIXME: We need to replace nested existential metatypes so that
-        // we don't print duplicate 'any'. This will be unnecessary once
-        // ExistentialMetatypeType is split into ExistentialType(MetatypeType).
-        instanceType = Type(instanceType).transform([](Type type) -> Type {
-          if (auto existential = type->getAs<ExistentialMetatypeType>())
-            return MetatypeType::get(existential->getInstanceType());
+      // FIXME: We need to replace nested existential metatypes so that
+      // we don't print duplicate 'any'. This will be unnecessary once
+      // ExistentialMetatypeType is split into ExistentialType(MetatypeType).
+      printWithParensIfNotSimple(instanceType.transform([](Type type) -> Type {
+        if (auto existential = type->getAs<ExistentialMetatypeType>())
+          return MetatypeType::get(existential->getInstanceType());
 
-          return type;
-        });
-      } else if (auto existential = instanceType->getAs<ExistentialType>()) {
-        // The 'any' keyword is needed to distinguish between existential
-        // metatypes and singleton metatypes. However, 'any' usually isn't
-        // printed for Any and AnyObject, because it's unnecessary to write
-        // 'any' with these specific constraints. Set a bit on the existential
-        // type to force printing with 'any' for metatypes. This bit doesn't
-        // matter for anything other than printing.
-        if (!existential->shouldPrintWithAny()) {
-          existential->forcePrintWithAny(true);
-          printWithParensIfNotSimple(existential);
-          existential->forcePrintWithAny(false);
-          didPrintInstanceType = true;
-        }
-      }
-    }
-
-    if (!didPrintInstanceType)
+        return type;
+      }));
+    } else if (T->is<MetatypeType>() && instanceType->is<ExistentialType>()) {
+      // The 'any' keyword is needed to distinguish between existential
+      // metatypes and singleton metatypes. However, 'any' usually isn't
+      // printed for Any and AnyObject, because it's unnecessary to write
+      // 'any' with these specific constraints. Force printing with 'any'
+      // for the existential instance type in this case.
+      instanceType->getAs<ExistentialType>()->forcePrintWithAny([&](Type ty) {
+        printWithParensIfNotSimple(ty);
+      });
+    } else {
       printWithParensIfNotSimple(instanceType);
+    }
 
     // We spell normal metatypes of existential types as .Protocol.
     if (isa<MetatypeType>(T) &&

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -5145,7 +5145,7 @@ class TypePrinter : public TypeVisitor<TypePrinter> {
         llvm_unreachable("bad opaque-return-type printing mode");
       }
     } else if (auto existential = dyn_cast<ExistentialType>(T.getPointer())) {
-      if (!Options.PrintExplicitAny)
+      if (!Options.PrintExplicitAny || !existential->shouldPrintWithAny())
         return isSimpleUnderPrintOptions(existential->getConstraintType());
     } else if (auto existential = dyn_cast<ExistentialMetatypeType>(T.getPointer())) {
       if (!Options.PrintExplicitAny)
@@ -5581,6 +5581,7 @@ public:
     }
 
     Type instanceType = T->getInstanceType();
+    bool didPrintInstanceType = false;
     if (Options.PrintExplicitAny) {
       if (T->is<ExistentialMetatypeType>()) {
         Printer << "any ";
@@ -5594,18 +5595,24 @@ public:
 
           return type;
         });
-      } else if (instanceType->isAny() || instanceType->isAnyObject()) {
-        // FIXME: 'any' is needed to distinguish between '(any Any).Type'
-        // and 'any Any.Type'. However, this combined with the above hack
-        // to replace nested existential metatypes with metatypes causes
-        // a bug in printing nested existential metatypes for Any and AnyObject,
-        // e.g. 'any (any Any).Type.Type'. This will be fixed by using
-        // ExistentialType for Any and AnyObject.
-        instanceType = ExistentialType::get(instanceType, /*forceExistential=*/true);
+      } else if (auto existential = instanceType->getAs<ExistentialType>()) {
+        // The 'any' keyword is needed to distinguish between existential
+        // metatypes and singleton metatypes. However, 'any' usually isn't
+        // printed for Any and AnyObject, because it's unnecessary to write
+        // 'any' with these specific constraints. Set a bit on the existential
+        // type to force printing with 'any' for metatypes. This bit doesn't
+        // matter for anything other than printing.
+        if (!existential->shouldPrintWithAny()) {
+          existential->forcePrintWithAny(true);
+          printWithParensIfNotSimple(existential);
+          existential->forcePrintWithAny(false);
+          didPrintInstanceType = true;
+        }
       }
     }
 
-    printWithParensIfNotSimple(instanceType);
+    if (!didPrintInstanceType)
+      printWithParensIfNotSimple(instanceType);
 
     // We spell normal metatypes of existential types as .Protocol.
     if (isa<MetatypeType>(T) &&
@@ -6217,7 +6224,7 @@ public:
   }
 
   void visitExistentialType(ExistentialType *T) {
-    if (Options.PrintExplicitAny)
+    if (Options.PrintExplicitAny && T->shouldPrintWithAny())
       Printer << "any ";
 
     // FIXME: The desugared type is used here only to support

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -682,7 +682,7 @@ namespace {
       if (wantsAdditionalAnyObjectRequirement) {
         Requirement req(RequirementKind::Conformance,
                         TheGenericParamList->getParams()[0]->getInterfaceType(),
-                        ctx.getAnyObjectType());
+                        ctx.getAnyObjectConstraint());
         addedRequirements.push_back(req);
       }
       for (auto gp : TheGenericParamList->getParams()) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2847,7 +2847,7 @@ static Type mapSignatureFunctionType(ASTContext &ctx, Type type,
     // Functions and subscripts cannot overload differing only in opaque return
     // types. Replace the opaque type with `Any`.
     if (type->is<OpaqueTypeArchetypeType>()) {
-      type = ProtocolCompositionType::get(ctx, {}, /*hasAnyObject*/ false);
+      type = ctx.getAnyExistentialType();
     }
 
     return mapSignatureParamType(ctx, type);

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -158,7 +158,10 @@ bool TypeBase::isStructurallyUninhabited() {
 }
 
 bool TypeBase::isAny() {
-  return isEqual(getASTContext().TheAnyType);
+  Type constraint = this;
+  if (auto existential = constraint->getAs<ExistentialType>())
+    constraint = existential->getConstraintType();
+  return constraint->isEqual(getASTContext().TheAnyType);
 }
 
 bool TypeBase::isPlaceholder() {

--- a/lib/AST/TypeJoinMeet.cpp
+++ b/lib/AST/TypeJoinMeet.cpp
@@ -45,6 +45,10 @@ struct TypeJoin : CanTypeVisitor<TypeJoin, CanType> {
   // For convenience, TheAnyType from ASTContext;
   CanType TheAnyType;
 
+  CanType getAnyExistentialType() {
+    return ExistentialType::get(TheAnyType)->getCanonicalType();
+  }
+
   TypeJoin(CanType First) : First(First), Unimplemented(CanType()) {
     assert(First && "Unexpected null type!");
     TheAnyType = First->getASTContext().TheAnyType;
@@ -112,10 +116,10 @@ public:
 
     // Likewise, rather than making every visitor deal with Any,
     // always dispatch to the protocol composition side of the join.
-    if (first->is<ProtocolCompositionType>())
+    if (first->is<ProtocolCompositionType>() || first->is<ExistentialType>())
       return TypeJoin(second).visit(first);
 
-    if (second->is<ProtocolCompositionType>())
+    if (second->is<ProtocolCompositionType>() || second->is<ExistentialType>())
       return TypeJoin(first).visit(second);
 
     // Otherwise the first type might be an optional (or not), so
@@ -166,7 +170,7 @@ CanType TypeJoin::visitErrorType(CanType second) {
 CanType TypeJoin::visitTupleType(CanType second) {
   assert(First != second);
 
-  return TheAnyType;
+  return getAnyExistentialType();
 }
 
 CanType TypeJoin::visitEnumType(CanType second) {
@@ -184,7 +188,7 @@ CanType TypeJoin::visitStructType(CanType second) {
 
   // FIXME: When possible we should return a protocol or protocol
   // composition.
-  return TheAnyType;
+  return getAnyExistentialType();
 }
 
 CanType TypeJoin::visitClassType(CanType second) {
@@ -240,7 +244,7 @@ CanType TypeJoin::visitMetatypeType(CanType second) {
   assert(First != second);
 
   if (First->getKind() != second->getKind())
-    return TheAnyType;
+    return getAnyExistentialType();
 
   auto firstInstance =
       First->castTo<AnyMetatypeType>()->getInstanceType()->getCanonicalType();
@@ -258,7 +262,7 @@ CanType TypeJoin::visitExistentialMetatypeType(CanType second) {
   assert(First != second);
 
   if (First->getKind() != second->getKind())
-    return TheAnyType;
+    return getAnyExistentialType();
 
   auto firstInstance =
       First->castTo<AnyMetatypeType>()->getInstanceType()->getCanonicalType();
@@ -276,7 +280,7 @@ CanType TypeJoin::visitExistentialType(CanType second) {
   assert(First != second);
 
   if (First->getKind() != second->getKind())
-    return TheAnyType;
+    return getAnyExistentialType();
 
   auto firstConstraint = First->castTo<ExistentialType>()
       ->getConstraintType()->getCanonicalType();
@@ -293,7 +297,7 @@ CanType TypeJoin::visitExistentialType(CanType second) {
 CanType TypeJoin::visitModuleType(CanType second) {
   assert(First != second);
 
-  return TheAnyType;
+  return getAnyExistentialType();
 }
 
 CanType TypeJoin::visitDynamicSelfType(CanType second) {
@@ -312,7 +316,7 @@ CanType TypeJoin::visitDependentMemberType(CanType second) {
   assert(First != second);
 
   if (First->getKind() != second->getKind())
-    return TheAnyType;
+    return getAnyExistentialType();
 
   return Unimplemented;
 }
@@ -326,7 +330,7 @@ CanType TypeJoin::visitFunctionType(CanType second) {
     if (secondFnTy->getExtInfo().isNoEscape()) {
       return Nonexistent;
     } else {
-      return TheAnyType;
+      return getAnyExistentialType();
     }
   }
 
@@ -362,7 +366,7 @@ CanType TypeJoin::visitGenericFunctionType(CanType second) {
   assert(First != second);
 
   if (First->getKind() != second->getKind())
-    return TheAnyType;
+    return getAnyExistentialType();
 
   return Unimplemented;
 }
@@ -412,7 +416,7 @@ CanType TypeJoin::visitProtocolCompositionType(CanType second) {
     if (fnTy && fnTy->getExtInfo().isNoEscape())
       return Nonexistent;
 
-    return TheAnyType;
+    return getAnyExistentialType();
   }
 
   assert(First != second);
@@ -482,7 +486,7 @@ CanType TypeJoin::visitBuiltinType(CanType second) {
   assert(First != second);
 
   // BuiltinType with any non-equal type results in Any.
-  return TheAnyType;
+  return getAnyExistentialType();
 }
 
 } // namespace

--- a/lib/AST/TypeJoinMeet.cpp
+++ b/lib/AST/TypeJoinMeet.cpp
@@ -416,7 +416,7 @@ CanType TypeJoin::visitProtocolCompositionType(CanType second) {
     if (fnTy && fnTy->getExtInfo().isNoEscape())
       return Nonexistent;
 
-    return getAnyExistentialType();
+    return TheAnyType;
   }
 
   assert(First != second);

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5414,7 +5414,7 @@ static ValueDecl *addThunkForDependentTypes(FuncDecl *oldDecl,
     // If the un-specialized function had a parameter with type "Any" preserve
     // that parameter. Otherwise, use the new function parameter.
     auto oldParamType = oldDecl->getParameters()->get(parameterIndex)->getType();
-    if (oldParamType->isEqual(newDecl->getASTContext().TheAnyType)) {
+    if (oldParamType->isEqual(newDecl->getASTContext().getAnyExistentialType())) {
       updatedAnyParams = true;
       auto newParam =
           ParamDecl::cloneWithoutType(newDecl->getASTContext(), newFnParam);
@@ -5429,7 +5429,7 @@ static ValueDecl *addThunkForDependentTypes(FuncDecl *oldDecl,
   // If we don't need this thunk, bail out.
   if (!updatedAnyParams &&
       !oldDecl->getResultInterfaceType()->isEqual(
-          oldDecl->getASTContext().TheAnyType))
+          oldDecl->getASTContext().getAnyExistentialType()))
     return newDecl;
 
   auto fixedParams =
@@ -5437,8 +5437,8 @@ static ValueDecl *addThunkForDependentTypes(FuncDecl *oldDecl,
 
   Type fixedResultType;
   if (oldDecl->getResultInterfaceType()->isEqual(
-          oldDecl->getASTContext().TheAnyType))
-    fixedResultType = oldDecl->getASTContext().TheAnyType;
+          oldDecl->getASTContext().getAnyExistentialType()))
+    fixedResultType = oldDecl->getASTContext().getAnyExistentialType();
   else
     fixedResultType = newDecl->getResultInterfaceType();
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8161,7 +8161,7 @@ Optional<GenericParamList *> SwiftDeclConverter::importObjCGenericParams(
     }
     if (inherited.empty()) {
       inherited.push_back(
-        TypeLoc::withoutLoc(Impl.SwiftContext.getAnyObjectType()));
+        TypeLoc::withoutLoc(Impl.SwiftContext.getAnyObjectConstraint()));
     }
     genericParamDecl->setInherited(Impl.SwiftContext.AllocateCopy(inherited));
 

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -907,7 +907,7 @@ namespace {
       if (type->isSugared())                                                   \
         return Visit(type->desugar());                                         \
       if (type->isDependentType())                                             \
-        return Impl.SwiftContext.TheAnyType;                                   \
+        return Impl.SwiftContext.getAnyExistentialType();                      \
       return Type();                                                           \
     }
     MAYBE_SUGAR_TYPE(TypeOfExpr)
@@ -1251,7 +1251,7 @@ namespace {
       if (type->isObjCIdType()) {
         return { Impl.SwiftContext.getAnyObjectType(),
                  ImportHint(ImportHint::ObjCBridged,
-                            Impl.SwiftContext.TheAnyType)};
+                            Impl.SwiftContext.getAnyExistentialType())};
       }
 
       return { importedType, ImportHint::ObjCPointer };
@@ -2368,7 +2368,7 @@ ParameterList *ClangImporter::Implementation::importFunctionParameterList(
   if (isVariadic) {
     auto paramTy =
         BoundGenericType::get(SwiftContext.getArrayDecl(), Type(),
-                              {SwiftContext.TheAnyType});
+                              {SwiftContext.getAnyExistentialType()});
     auto name = SwiftContext.getIdentifier("varargs");
     auto param = new (SwiftContext) ParamDecl(SourceLoc(), SourceLoc(),
                                               Identifier(), SourceLoc(),

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -1501,7 +1501,7 @@ emitAssociatedTypeMetadataRecord(const RootProtocolConformance *conformance) {
 void IRGenModule::emitBuiltinReflectionMetadata() {
   if (getSwiftModule()->isStdlibModule()) {
     BuiltinTypes.insert(Context.TheNativeObjectType);
-    BuiltinTypes.insert(Context.getAnyObjectType());
+    BuiltinTypes.insert(Context.getAnyObjectConstraint());
     BuiltinTypes.insert(Context.TheBridgeObjectType);
     BuiltinTypes.insert(Context.TheRawPointerType);
     BuiltinTypes.insert(Context.TheUnsafeValueBufferType);

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -3233,7 +3233,7 @@ public:
     }
     case SILFunctionType::Representation::Block:
       // All block types look like AnyObject.
-      return C.getAnyObjectType();
+      return C.getAnyObjectConstraint();
     }
 
     llvm_unreachable("Not a valid SILFunctionType.");
@@ -3354,7 +3354,7 @@ namespace {
           || t == C.TheNativeObjectType
           || t == C.TheBridgeObjectType
           || t == C.TheRawPointerType
-          || t == C.getAnyObjectType())
+          || t == C.getAnyObjectConstraint())
         return true;
       if (auto intTy = dyn_cast<BuiltinIntegerType>(t)) {
         auto width = intTy->getWidth();
@@ -3436,7 +3436,7 @@ namespace {
       }
       case SILFunctionType::Representation::Block:
         // All block types look like AnyObject.
-        return emitFromValueWitnessTable(C.getAnyObjectType());
+        return emitFromValueWitnessTable(C.getAnyObjectConstraint());
       }
 
       llvm_unreachable("Not a valid SILFunctionType.");
@@ -3479,7 +3479,7 @@ namespace {
       case ReferenceCounting::ObjC:
       case ReferenceCounting::Block:
       case ReferenceCounting::Unknown:
-        return emitFromValueWitnessTable(IGF.IGM.Context.getAnyObjectType());
+        return emitFromValueWitnessTable(IGF.IGM.Context.getAnyObjectConstraint());
 
       case ReferenceCounting::Bridge:
       case ReferenceCounting::Error:

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1136,6 +1136,9 @@ private:
   /// Returns whether \p ty is the C type \c CFTypeRef, or some typealias
   /// thereof.
   bool isCFTypeRef(Type ty) {
+    if (auto existential = dyn_cast<ExistentialType>(ty.getPointer()))
+      ty = existential->getConstraintType();
+
     const TypeAliasDecl *TAD = nullptr;
     while (auto aliasTy = dyn_cast<TypeAliasType>(ty.getPointer())) {
       TAD = aliasTy->getDecl();
@@ -1816,8 +1819,7 @@ private:
 
   void visitExistentialType(ExistentialType *ET,
                             Optional<OptionalTypeKind> optionalKind) {
-    visitExistentialType(ET, optionalKind,
-        /*isMetatype=*/ET->getConstraintType()->is<AnyMetatypeType>());
+    visitPart(ET->getConstraintType(), optionalKind);
   }
 
   void visitExistentialMetatypeType(ExistentialMetatypeType *MT,

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -442,7 +442,7 @@ namespace {
         if (auto superclassType = genericSig->getSuperclassBound(type))
           return superclassType;
         assert(genericSig->requiresClass(type));
-        return TC.Context.getAnyObjectType();
+        return TC.Context.getAnyObjectConstraint();
       }
 
       return type;

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -2992,8 +2992,7 @@ public:
     // metatype with the same constraint type as its existential operand.
     auto formalInstanceTy
       = MI->getType().castTo<ExistentialMetatypeType>().getInstanceType();
-    if (formalInstanceTy->isConstraintType() &&
-        !(formalInstanceTy->isAny() || formalInstanceTy->isAnyObject())) {
+    if (formalInstanceTy->isConstraintType()) {
       require(MI->getOperand()->getType().is<ExistentialType>(),
               "existential_metatype operand must be an existential type");
       formalInstanceTy =

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2048,8 +2048,7 @@ namespace {
         if (auto nom = keyPathTy->getAs<NominalType>()) {
           // AnyKeyPath is <T> rvalue T -> rvalue Any?
           if (nom->isAnyKeyPath()) {
-            valueTy = ProtocolCompositionType::get(cs.getASTContext(), {},
-                                                  /*explicit anyobject*/ false);
+            valueTy = ctx.getAnyExistentialType();
             valueTy = OptionalType::get(valueTy);
             resultIsLValue = false;
             base = cs.coerceToRValue(base);
@@ -2079,8 +2078,7 @@ namespace {
 
           if (keyPathBGT->isPartialKeyPath()) {
             // PartialKeyPath<T> is rvalue T -> rvalue Any
-            valueTy = ProtocolCompositionType::get(cs.getASTContext(), {},
-                                                 /*explicit anyobject*/ false);
+            valueTy = ctx.getAnyExistentialType();
             resultIsLValue = false;
             base = cs.coerceToRValue(base);
           } else {

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -421,7 +421,7 @@ bool RequirementFailure::diagnoseAsNote() {
   // Layout requirement doesn't have a second type, let's always
   // `AnyObject`.
   auto requirementTy = req.getKind() == RequirementKind::Layout
-                           ? getASTContext().getAnyObjectType()
+                           ? getASTContext().getAnyObjectConstraint()
                            : req.getSecondType();
 
   emitDiagnosticAt(reqDC->getAsDecl(), getDiagnosticAsNote(), getLHS(),

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1806,8 +1806,7 @@ public:
                                       ConstraintLocator *locator)
       : ContextualFailure(solution, type, protocolType, locator),
         Context(context) {
-    assert(protocolType->is<ProtocolType>() ||
-           protocolType->is<ProtocolCompositionType>());
+    assert(protocolType->isExistentialType());
   }
 
   bool diagnoseAsError() override;

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1564,7 +1564,7 @@ namespace {
       auto &ctx = CS.getASTContext();
       auto typeOperation = getTypeOperation(expr, ctx);
       if (typeOperation != TypeOperation::None)
-        return ctx.TheAnyType;
+        return ctx.getAnyExistentialType();
 
       // If this is `Builtin.trigger_fallback_diagnostic()`, fail
       // without producing any diagnostics, in order to test fallback error.
@@ -1907,7 +1907,7 @@ namespace {
 
       // The array element type defaults to 'Any'.
       CS.addConstraint(ConstraintKind::Defaultable, arrayElementTy,
-                       CS.getASTContext().TheAnyType, locator);
+                       CS.getASTContext().getAnyExistentialType(), locator);
 
       return arrayTy;
     }
@@ -2071,7 +2071,7 @@ namespace {
       // The dictionary value type defaults to 'Any'.
       if (dictionaryValueTy->isTypeVariableOrMember()) {
         CS.addConstraint(ConstraintKind::Defaultable, dictionaryValueTy,
-                         ctx.TheAnyType, locator);
+                         ctx.getAnyExistentialType(), locator);
       }
 
       return dictionaryTy;
@@ -3619,7 +3619,7 @@ namespace {
           llvm_unreachable("Unexpected result from join - it should not have been computable!");
 
         // The return value is unimportant.
-        return MetatypeType::get(ctx.TheAnyType)->getCanonicalType();
+        return MetatypeType::get(ctx.getAnyExistentialType())->getCanonicalType();
       }
       }
       llvm_unreachable("unhandled operation");

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10752,8 +10752,7 @@ ConstraintSystem::simplifyKeyPathApplicationConstraint(
   if (keyPathTy->isAnyKeyPath()) {
     // Read-only keypath, whose projected value is upcast to `Any?`.
     // The root type can be anything.
-    Type resultTy = ProtocolCompositionType::get(getASTContext(), {},
-                                                /*explicit AnyObject*/ false);
+    Type resultTy = getASTContext().getAnyExistentialType();
     resultTy = OptionalType::get(resultTy);
     return matchTypes(resultTy, valueTy, ConstraintKind::Bind,
                       subflags, locator);
@@ -10793,8 +10792,7 @@ ConstraintSystem::simplifyKeyPathApplicationConstraint(
 
     if (bgt->isPartialKeyPath()) {
       // Read-only keypath, whose projected value is upcast to `Any`.
-      auto resultTy = ProtocolCompositionType::get(getASTContext(), {},
-                                                  /*explicit AnyObject*/ false);
+      auto resultTy = getASTContext().getAnyExistentialType();
 
       if (!matchRoot(ConstraintKind::Conversion))
         return SolutionKind::Error;
@@ -11842,7 +11840,7 @@ ConstraintSystem::simplifyDynamicCallableApplicableFnConstraint(
 
   // Argument type can default to `Any`.
   addConstraint(ConstraintKind::Defaultable, argumentType,
-                ctx.TheAnyType, locator);
+                ctx.getAnyExistentialType(), locator);
 
   auto *baseArgLoc = getConstraintLocator(
       loc->getAnchor(),
@@ -13386,7 +13384,7 @@ void ConstraintSystem::addConstraint(Requirement req,
   }
 
   if (conformsToAnyObject) {
-    auto anyObject = getASTContext().getAnyObjectType();
+    auto anyObject = getASTContext().getAnyObjectConstraint();
     addConstraint(ConstraintKind::ConformsTo, firstType, anyObject, locator);
   }
 }

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1794,7 +1794,7 @@ bool TypeChecker::getDefaultGenericArgumentsString(
       }
 
       if (hasExplicitAnyObject)
-        members.push_back(typeDecl->getASTContext().getAnyObjectType());
+        members.push_back(typeDecl->getASTContext().getAnyObjectConstraint());
 
       auto type = ProtocolCompositionType::get(typeDecl->getASTContext(),
                                                members, hasExplicitAnyObject);

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3572,7 +3572,27 @@ TypeResolver::resolveIdentifierType(IdentTypeRepr *IdType,
     auto *typeAlias = dyn_cast<TypeAliasType>(result.getPointer());
     if (typeAlias && typeAlias->is<ExistentialType>() &&
         typeAlias->getDecl()->hasClangNode()) {
-      return typeAlias->getAs<ExistentialType>()->getConstraintType();
+      auto constraint = typeAlias->getAs<ExistentialType>()->getConstraintType();
+
+      // FIXME: Hack! CFTypeRef, which is a typealias to AnyObject,
+      // has special handling when printing as ObjC, so the typealias
+      // sugar needs to be preserved. See `isCFTypeRef` in PrintAsClang.cpp.
+      //
+      // We can eliminate this hack by fixing the issues with PR #41147,
+      // which added logic to the ClangImporter for when to import as an
+      // existential versus a constraint, but it was reverted in #41207
+      // because it was missing some cases of wrapping in ExistentialType.
+      auto module = typeAlias->getDecl()->getDeclContext()->getParentModule();
+      if ((module->getName().is("Foundation") ||
+          module->getName().is("CoreFoundation")) &&
+          typeAlias->getDecl()->getName() == getASTContext().getIdentifier("CFTypeRef")) {
+        return TypeAliasType::get(typeAlias->getDecl(),
+                                  typeAlias->getParent(),
+                                  typeAlias->getSubstitutionMap(),
+                                  constraint);
+      }
+
+      return constraint;
     }
   }
 

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 692; // add @objc protocol methods to objc method tables
+const uint16_t SWIFTMODULE_VERSION_MINOR = 693; // existential Any and AnyObject
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/test/Constraints/existential_metatypes.swift
+++ b/test/Constraints/existential_metatypes.swift
@@ -46,8 +46,7 @@ class Dryer : WashingMachine {}
 class HairDryer {}
 
 let a: Toaster.Type.Protocol = Toaster.Type.self
-// FIXME: the existential metatype below should be spelled 'any Any.Type.Type'
-let b: Any.Type.Type = Toaster.Type.self // expected-error {{cannot convert value of type '(any Toaster.Type).Type' to specified type 'any (any Any).Type.Type'}}
+let b: Any.Type.Type = Toaster.Type.self // expected-error {{cannot convert value of type '(any Toaster.Type).Type' to specified type 'any Any.Type.Type'}}
 let c: Any.Type.Protocol = Toaster.Type.self // expected-error {{cannot convert value of type '(any Toaster.Type).Type' to specified type '(any Any.Type).Type'}}
 let d: Toaster.Type.Type = WashingMachine.Type.self
 let e: Any.Type.Type = WashingMachine.Type.self


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/41909

Note that the main PR is not merged yet because passing lldb tests depends on an lldb change that has to land on `llvm-project:swift/release/5.7` first.

* **Explanation**: This change models existential `Any` and `AnyObject` using `ExistentialType`, just like all other existential types. Previously, these two existential types still were modeled with `ProtocolCompositionType` because they're not required to be written with `any`, but this allowed using `any` on these types in conformance constraint context, e.g.

```swift
func generic<T>(value: T) where T: any Any { ... } // okay??
```

This also caused type resolution to not know the difference between `(any Any).Type` and `any Any.Type`, as described in https://github.com/apple/swift/issues/58367.

Note that `Any` and `AnyObject` still do not print with `any` in the ASTPrinter, except when it's needed to distinguish between the existential metatype and the singleton metatype, e.g. `any Any.Type` vs `(any Any).Type`.
* **Scope**: This affects the frontend representation of code using `Any` and `AnyObject` as existential types.
* **Risk**: Low.
* **Testing**: Passed CI tests and the source compatibility suite. The `ExistentialType` representation itself has already been shipped in Swift 5.6 and thoroughly tested.
* **Reviewer**: @slavapestov

Resolves: rdar://94370283, https://github.com/apple/swift/issues/58367