### PR TITLE
platform: correct header for `ssse3`

### DIFF
--- a/stdlib/public/Platform/visualc.modulemap
+++ b/stdlib/public/Platform/visualc.modulemap
@@ -58,7 +58,7 @@ module _visualc_intrinsics [system] [extern_c] {
 
     explicit module ssse3 {
       export sse3
-      header "tmmintrinh"
+      header "tmmintrin.h"
     }
 
     explicit module sse4_1 {


### PR DESCRIPTION
Correct the header spelling for the ssse3 module.  The suffix was
incorrect which was ignored as a result.  This was identified by the
`modularize` tool from clang-tools-extras.