### PR TITLE
[cxx-interop] Add tests for `operator++()` that returns `void`

### DIFF
--- a/test/Interop/Cxx/operators/Inputs/member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/member-inline.h
@@ -70,7 +70,12 @@ struct HasPostIncrementOperator {
 
 struct HasPreIncrementOperatorWithAnotherReturnType {
   int value = 0;
-  const int &operator++() { return value; }
+  const int &operator++() { return ++value; }
+};
+
+struct HasPreIncrementOperatorWithVoidReturnType {
+  int value = 0;
+  void operator++() { ++value; }
 };
 
 struct HasDeletedOperator {

--- a/test/Interop/Cxx/operators/member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/member-inline-module-interface.swift
@@ -18,6 +18,17 @@
 // CHECK:   mutating func callAsFunction(_ x: Int32, _ y: Int32) -> Int32
 // CHECK: }
 
+// CHECK: struct HasPostIncrementOperator {
+// CHECK: }
+
+// CHECK: struct HasPreIncrementOperatorWithAnotherReturnType {
+// CHECK:   func successor() -> HasPreIncrementOperatorWithAnotherReturnType
+// CHECK: }
+
+// CHECK: struct HasPreIncrementOperatorWithVoidReturnType {
+// CHECK:   func successor() -> HasPreIncrementOperatorWithVoidReturnType
+// CHECK: }
+
 // CHECK: struct HasDeletedOperator {
 // CHECK: }
 

--- a/test/Interop/Cxx/operators/member-inline-typechecker.swift
+++ b/test/Interop/Cxx/operators/member-inline-typechecker.swift
@@ -43,3 +43,9 @@ let diffTypesResultDoubleByVal: Double = diffTypesArrayByVal[0.5]
 
 let postIncrement = HasPostIncrementOperator()
 postIncrement.successor() // expected-error {{value of type 'HasPostIncrementOperator' has no member 'successor'}}
+
+let anotherReturnType = HasPreIncrementOperatorWithAnotherReturnType()
+let anotherReturnTypeResult: HasPreIncrementOperatorWithAnotherReturnType = anotherReturnType.successor()
+
+let voidReturnType = HasPreIncrementOperatorWithVoidReturnType()
+let voidReturnTypeResult: HasPreIncrementOperatorWithVoidReturnType = voidReturnType.successor()

--- a/test/Interop/Cxx/operators/member-inline.swift
+++ b/test/Interop/Cxx/operators/member-inline.swift
@@ -84,6 +84,32 @@ OperatorsTestSuite.test("AddressOnlyIntWrapper.successor() (inline)") {
   expectEqual(0, wrapper.value)
 }
 
+OperatorsTestSuite.test("HasPreIncrementOperatorWithAnotherReturnType.successor() (inline)") {
+  var wrapper = HasPreIncrementOperatorWithAnotherReturnType()
+
+  let result1 = wrapper.successor()
+  expectEqual(1, result1.value)
+  expectEqual(0, wrapper.value) // Calling `successor()` should not mutate `wrapper`.
+
+  let result2 = result1.successor()
+  expectEqual(2, result2.value)
+  expectEqual(1, result1.value)
+  expectEqual(0, wrapper.value)
+}
+
+OperatorsTestSuite.test("HasPreIncrementOperatorWithVoidReturnType.successor() (inline)") {
+  var wrapper = HasPreIncrementOperatorWithVoidReturnType()
+
+  let result1 = wrapper.successor()
+  expectEqual(1, result1.value)
+  expectEqual(0, wrapper.value) // Calling `successor()` should not mutate `wrapper`.
+
+  let result2 = result1.successor()
+  expectEqual(2, result2.value)
+  expectEqual(1, result1.value)
+  expectEqual(0, wrapper.value)
+}
+
 OperatorsTestSuite.test("DerivedFromAddressOnlyIntWrapper.call (inline, base class)") {
   var wrapper = DerivedFromAddressOnlyIntWrapper(42)
 


### PR DESCRIPTION
This pattern was discovered on `llvm::detail::SafeIntIterator` (`llvm/ADT/Sequence.h:153`):
```cpp
  // Pre Increment/Decrement
  void operator++() { offset(1); }
  void operator--() { offset(-1); }
```

Previous patch: https://github.com/apple/swift/pull/59643.

rdar://95684692