### PR TITLE
[Parse] Fix code completion crash when avoiding skipping

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -7383,7 +7383,8 @@ Parser::parseAbstractFunctionBodyImpl(AbstractFunctionDecl *AFD) {
   // In implicit getter, if a CC token is the first token after '{', it might
   // be a start of an accessor block. Perform special completion for that.
   if (auto accessor = dyn_cast<AccessorDecl>(AFD)) {
-    if (peekToken().is(tok::code_complete) && accessor->isImplicitGetter()) {
+    if (CodeCompletion && peekToken().is(tok::code_complete) &&
+        accessor->isImplicitGetter()) {
       SourceLoc LBraceLoc, RBraceLoc;
       LBraceLoc = consumeToken(tok::l_brace);
       auto *CCE = new (Context) CodeCompletionExpr(Tok.getLoc());

--- a/test/SourceKit/CodeComplete/rdar95772803.swift
+++ b/test/SourceKit/CodeComplete/rdar95772803.swift
@@ -1,0 +1,14 @@
+
+var foo: Double { 1 / 2 }
+var bar: Regex<Substring> { /x/ }
+var baz: Regex<Substring> { / x/ }
+var qux: Regex<Substring> { / x}/ }
+
+// Check that we are not crashing
+// RUN: %sourcekitd-test \
+// RUN: -req=complete -pos=2:18 %s -- -enable-bare-slash-regex %s == \
+// RUN: -req=complete -pos=3:28 %s -- -enable-bare-slash-regex %s == \
+// RUN: -req=complete -pos=4:28 %s -- -enable-bare-slash-regex %s == \
+// RUN: -req=complete -pos=5:28 %s -- -enable-bare-slash-regex %s
+
+// REQUIRES: swift_in_compiler


### PR DESCRIPTION
Fix a crash that could occur when performing completion at the start of an accessor body. Previously we assumed `CodeCompletion` would never be null due to function body skipping in the first pass of code completion. However with the introduction of the ability to avoid skipping in certain cases, it might be now be null if we need to avoid skipping. Found by the stress tester.

rdar://95772803