### PR TITLE
[Interop][SwiftToCxx] Emit helper cases class in C++ for Swift enum

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -392,8 +392,20 @@ private:
       ClangValueTypePrinter printer(os, owningPrinter.prologueOS,
                                     owningPrinter.typeMapping,
                                     owningPrinter.interopContext);
-      printer.printValueTypeDecl(
-          ED, /*bodyPrinter=*/[&]() {}); // TODO: (tongjie) print cases
+      printer.printValueTypeDecl(ED, /*bodyPrinter=*/[&]() {
+        ClangSyntaxPrinter syntaxPrinter(os);
+        os << "  enum class cases { ";
+        llvm::interleaveComma(
+            ED->getAllCases(), os, [&](const EnumCaseDecl *caseDecl) {
+              llvm::interleaveComma(
+                  caseDecl->getElements(), os,
+                  [&](const EnumElementDecl *elementDecl) {
+                    syntaxPrinter.printIdentifier(
+                        elementDecl->getBaseIdentifier().str());
+                  });
+            });
+        os << " };\n";
+      });
       os << outOfLineDefinitions;
       outOfLineDefinitions.clear();
       return;

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -394,16 +394,17 @@ private:
                                     owningPrinter.interopContext);
       printer.printValueTypeDecl(ED, /*bodyPrinter=*/[&]() {
         ClangSyntaxPrinter syntaxPrinter(os);
-        os << "  enum class cases { ";
+        os << "  enum class cases {";
         llvm::interleaveComma(
             ED->getAllCases(), os, [&](const EnumCaseDecl *caseDecl) {
               llvm::interleaveComma(caseDecl->getElements(), os,
                                     [&](const EnumElementDecl *elementDecl) {
+                                      os << "\n    ";
                                       syntaxPrinter.printIdentifier(
                                           elementDecl->getNameStr());
                                     });
             });
-        os << " };\n";
+        os << "\n  };\n";
       });
       os << outOfLineDefinitions;
       outOfLineDefinitions.clear();

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -397,12 +397,11 @@ private:
         os << "  enum class cases { ";
         llvm::interleaveComma(
             ED->getAllCases(), os, [&](const EnumCaseDecl *caseDecl) {
-              llvm::interleaveComma(
-                  caseDecl->getElements(), os,
-                  [&](const EnumElementDecl *elementDecl) {
-                    syntaxPrinter.printIdentifier(
-                        elementDecl->getBaseIdentifier().str());
-                  });
+              llvm::interleaveComma(caseDecl->getElements(), os,
+                                    [&](const EnumElementDecl *elementDecl) {
+                                      syntaxPrinter.printIdentifier(
+                                          elementDecl->getNameStr());
+                                    });
             });
         os << " };\n";
       });

--- a/test/Interop/SwiftToCxx/enums/swift-enum-cases-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/swift-enum-cases-in-cxx.swift
@@ -1,0 +1,34 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -module-name Enums -clang-header-expose-public-decls -emit-clang-header-path %t/enums.h
+// RUN: %FileCheck %s < %t/enums.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/enums.h -Wno-unused-private-field -Wno-unused-function)
+
+public enum EnumMultipleElementsInSingleCase { case first, second }
+
+public enum EnumSingleElementInSingleCase {
+    case first
+    case second
+}
+
+public enum EnumCaseIsSwiftKeyword {
+    case first(a: Int)
+    case `protocol`(b: Double)
+}
+
+public enum EnumCaseIsCxxKeyword {
+    case first, second(x: Float)
+    case const
+}
+
+// CHECK: class EnumCaseIsCxxKeyword final {
+// CHECK: enum class cases { first, second, const_ };
+
+// CHECK: class EnumCaseIsSwiftKeyword final {
+// CHECK: enum class cases { first, protocol };
+
+// CHECK: class EnumMultipleElementsInSingleCase final {
+// CHECK: enum class cases { first, second };
+
+// CHECK: class EnumSingleElementInSingleCase final {
+// CHECK: enum class cases { first, second };

--- a/test/Interop/SwiftToCxx/enums/swift-enum-cases-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/swift-enum-cases-in-cxx.swift
@@ -22,13 +22,26 @@ public enum EnumCaseIsCxxKeyword {
 }
 
 // CHECK: class EnumCaseIsCxxKeyword final {
-// CHECK: enum class cases { first, second, const_ };
+// CHECK:      enum class cases {
+// CHECK-NEXT:   first,
+// CHECK-NEXT:   second,
+// CHECK-NEXT:   const_
+// CHECK-NEXT: };
 
 // CHECK: class EnumCaseIsSwiftKeyword final {
-// CHECK: enum class cases { first, protocol };
+// CHECK:      enum class cases {
+// CHECK-NEXT:   first,
+// CHECK-NEXT:   protocol
+// CHECK-NEXT: };
 
 // CHECK: class EnumMultipleElementsInSingleCase final {
-// CHECK: enum class cases { first, second };
+// CHECK:      enum class cases {
+// CHECK-NEXT:   first,
+// CHECK-NEXT:   second
+// CHECK-NEXT: };
 
 // CHECK: class EnumSingleElementInSingleCase final {
-// CHECK: enum class cases { first, second };
+// CHECK:      enum class cases {
+// CHECK-NEXT:   first,
+// CHECK-NEXT:   second
+// CHECK-NEXT: };


### PR DESCRIPTION
<!-- What's in this pull request? -->
Emit Swift enum cases inside generated C++ class. For example, following Swift enum

```swift
public enum Foo { case x, y, z }
```

will have cases in generated C++ header file like this

```c++
class Foo final {
public:
  enum class cases { x, y, z };
};
```

@hyp Could you review this pull request?

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!-- Resolves SR-NNNN. -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
