### PR TITLE
Ignore Sendable conformances in PrintAsClang

### DIFF
--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -433,8 +433,10 @@ public:
     bool allRequirementsSatisfied = true;
 
     for (auto proto : PD->getInheritedProtocols()) {
-      assert(proto->isObjC());
-      allRequirementsSatisfied &= require(proto);
+      if (printer.shouldInclude(proto)) {
+        assert(proto->isObjC());
+        allRequirementsSatisfied &= require(proto);
+      }
     }
 
     if (!allRequirementsSatisfied)

--- a/test/PrintAsObjC/protocols.swift
+++ b/test/PrintAsObjC/protocols.swift
@@ -25,7 +25,7 @@ import objc_generics
 
 // CHECK-LABEL: @protocol B <A>
 // CHECK-NEXT: @end
-@objc protocol B : A {}
+@objc protocol B : A, Sendable {}
 
 // CHECK-LABEL: @protocol CompletionAndAsync
 // CHECK-NEXT: - (void)helloWithCompletion:(void (^ _Nonnull)(BOOL))completion;


### PR DESCRIPTION
PrintAsClang previously tried to print Sendable conformances, which tripped an assertion and failed. Skip them instead.

Fixes rdar://95241184.