### PR TITLE
Fix Crash When Constrained Existential Concretizes 'Self'

### DIFF
--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -304,7 +304,23 @@ GenericEnvironment::getOrCreateArchetypeFromInterfaceType(Type depType) {
     }
   };
 
-  if (requirements.concreteType) {
+  auto canUseConcreteType = [&](Type concreteType) -> bool {
+    // No concrete type - there's nothing to use.
+    if (!concreteType)
+      return false;
+
+    // The `Self` type of an opened existential cannot be
+    // concretely substituted.
+    if (getKind() == GenericEnvironment::Kind::OpenedExistential)
+      if (auto gpTy = depType->getAs<GenericTypeParamType>())
+        if (gpTy->isEqual(getGenericParams().back()))
+          return false;
+
+    return true;
+  };
+
+
+  if (canUseConcreteType(requirements.concreteType)) {
     return substForRequirements(requirements.concreteType);
   }
 

--- a/test/type/parameterized_existential.swift
+++ b/test/type/parameterized_existential.swift
@@ -92,3 +92,13 @@ func protocolCompositionNotSupported1(_: SomeProto & Sequence<Int>) {}
 
 func protocolCompositionNotSupported2(_: any SomeProto & Sequence<Int>) {}
 // expected-error@-1 {{non-protocol, non-class type 'Sequence<Int>' cannot be used within a protocol-constrained type}}
+
+protocol Concretize<T> {
+  associatedtype T where T == Self
+}
+
+extension String : Concretize {}
+
+func foo(_ x: any Concretize<String>) {
+  print(x)
+}


### PR DESCRIPTION
Prevent the generic environment of an opened existential from concretizing
the 'Self' type.

rdar://95804338