### PR TITLE
AST: Remove unnecessary superclass bound check in SubstitutionMap::lookupConformance()

### DIFF
--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -359,15 +359,6 @@ SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
   if (auto directConformance = getSignatureConformance(type, proto))
     return *directConformance;
 
-  // Check whether the superclass conforms.
-  if (auto superclass = genericSig->getSuperclassBound(type)) {
-    LookUpConformanceInSignature lookup(getGenericSignature().getPointer());
-    auto substType = type.subst(*this);
-    if (auto conformance = lookup(type->getCanonicalType(), substType, proto)){
-      return conformance;
-    }
-  }
-
   // If the type doesn't conform to this protocol, the result isn't formed
   // from these requirements.
   if (!genericSig->requiresProtocol(type, proto)) {
@@ -378,7 +369,6 @@ SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
   auto accessPath =
     genericSig->getConformanceAccessPath(type, proto);
 
-  // Fall through because we cannot yet evaluate an access path.
   ProtocolConformanceRef conformance;
   for (const auto &step : accessPath) {
     // For the first step, grab the initial conformance.


### PR DESCRIPTION
Just a small cleanup. The only thing that was relying on it on accident seems to be AutoDiff.