### PR TITLE
[Interop][SwiftToCxx] Fix small enum tests

### DIFF
--- a/test/Interop/SwiftToCxx/enums/small-enums-generated-stub-64bit.swift
+++ b/test/Interop/SwiftToCxx/enums/small-enums-generated-stub-64bit.swift
@@ -1,0 +1,33 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -module-name Enums -clang-header-expose-public-decls -emit-clang-header-path %t/enums.h
+// RUN: %FileCheck %s < %t/enums.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/enums.h -Wno-unused-private-field -Wno-unused-function)
+
+// REQUIRES: PTRSIZE=64
+
+public enum Small {
+    case first(Int)
+    case second(Double)
+}
+
+public func passThroughSmall(_ en: Small) -> Small {
+    return en
+}
+
+// CHECK:      struct swift_interop_stub_Enums_Small {
+// CHECK-NEXT:   uint64_t _1;
+// CHECK-NEXT:   uint8_t _2;
+// CHECK-NEXT: };
+
+// CHECK:      static inline void swift_interop_returnDirect_Enums_Small(char * _Nonnull result, struct swift_interop_stub_Enums_Small value) __attribute__((always_inline)) {
+// CHECK-NEXT:   memcpy(result + 0, &value._1, 8);
+// CHECK-NEXT:   memcpy(result + 8, &value._2, 1);
+// CHECK-NEXT: }
+
+// CHECK:      static inline struct swift_interop_stub_Enums_Small swift_interop_passDirect_Enums_Small(const char * _Nonnull value) __attribute__((always_inline)) {
+// CHECK-NEXT:   struct swift_interop_stub_Enums_Small result;
+// CHECK-NEXT:   memcpy(&result._1, value + 0, 8);
+// CHECK-NEXT:   memcpy(&result._2, value + 8, 1);
+// CHECK-NEXT:   return result;
+// CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/enums/small-enums-pass-return-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/small-enums-pass-return-in-cxx.swift
@@ -67,22 +67,7 @@ public func inoutSmall(_ en: inout Small, _ x: Int) {
 // CHECK: SWIFT_EXTERN void $s5Enums10inoutSmallyyAA0C0Oz_SitF(char * _Nonnull en, ptrdiff_t x) SWIFT_NOEXCEPT SWIFT_CALL; // inoutSmall(_:_:)
 // CHECK: SWIFT_EXTERN void $s5Enums9inoutTinyyyAA0C0Oz_SitF(char * _Nonnull en, ptrdiff_t x) SWIFT_NOEXCEPT SWIFT_CALL; // inoutTiny(_:_:)
 
-// CHECK:      struct swift_interop_stub_Enums_Small {
-// CHECK-NEXT:   uint64_t _1;
-// CHECK-NEXT:   uint8_t _2;
-// CHECK-NEXT: };
-
-// CHECK:      static inline void swift_interop_returnDirect_Enums_Small(char * _Nonnull result, struct swift_interop_stub_Enums_Small value) __attribute__((always_inline)) {
-// CHECK-NEXT:   memcpy(result + 0, &value._1, 8);
-// CHECK-NEXT:   memcpy(result + 8, &value._2, 1);
-// CHECK-NEXT: }
-
-// CHECK:      static inline struct swift_interop_stub_Enums_Small swift_interop_passDirect_Enums_Small(const char * _Nonnull value) __attribute__((always_inline)) {
-// CHECK-NEXT:   struct swift_interop_stub_Enums_Small result;
-// CHECK-NEXT:   memcpy(&result._1, value + 0, 8);
-// CHECK-NEXT:   memcpy(&result._2, value + 8, 1);
-// CHECK-NEXT:   return result;
-// CHECK-NEXT: }
+// The check for generated stub is currently moved to small-enums-generated-stub-64bit.swift
 
 // CHECK: SWIFT_EXTERN struct swift_interop_stub_Enums_Small $s5Enums9makeSmallyAA0C0OSiF(ptrdiff_t x) SWIFT_NOEXCEPT SWIFT_CALL; // makeSmall(_:)
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Limit some tests for small enum to 64bit platform only

@hyp Could you please review/test this PR?

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!-- Resolves SR-NNNN. -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
