### PR TITLE
Temporarily disable test/StringProcessing/Parse/forward-slash-regex-s…

### DIFF
--- a/test/StringProcessing/Parse/forward-slash-regex-skipping-allowed.swift
+++ b/test/StringProcessing/Parse/forward-slash-regex-skipping-allowed.swift
@@ -5,6 +5,7 @@
 // RUN: %FileCheck -input-file %t/stats.csv %s
 
 // REQUIRES: swift_in_compiler
+// REQUIRES: rdar95806819
 
 // Make sure we can skip in all of the below cases.
 


### PR DESCRIPTION
…kipping-allowed.swift

Test fails after:
Merge pull request #59641 from hamishknight/no-skip-slash
Commit e610a69dacb1b3822dac63abb2057cf9d802ca8c by github
