### PR TITLE
🍒[5.7] prevent nonisolated mutation of isolated properties through an existential

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1667,6 +1667,11 @@ namespace {
         return recordMutableVarParent(parent, inout->getSubExpr());
       }
 
+      // Look through an expression that opens an existential
+      if (auto openExist = dyn_cast<OpenExistentialExpr>(subExpr)) {
+        return recordMutableVarParent(parent, openExist->getSubExpr());
+      }
+
       return false;
     }
 

--- a/test/Concurrency/actor_existentials.swift
+++ b/test/Concurrency/actor_existentials.swift
@@ -1,0 +1,69 @@
+// RUN: %target-typecheck-verify-swift  -disable-availability-checking
+// REQUIRES: concurrency
+
+protocol P: Actor {
+  func f()
+  var prop: Int { get set } // expected-note 2 {{mutation of this property is only permitted within the actor}}
+}
+
+actor A: P {
+  var prop: Int = 0 // expected-note 2 {{mutation of this property is only permitted within the actor}}
+  func f() {}
+}
+
+func from_isolated_existential1(_ x: isolated any P) {
+  x.f()
+  x.prop += 1
+  x.prop = 100
+}
+
+func from_isolated_existential2(_ x: isolated any P) async {
+  x.f()
+  x.prop += 1
+  x.prop = 100
+}
+
+func from_nonisolated(_ x: any P) async {
+  await x.f()
+  x.prop += 1 // expected-error {{actor-isolated property 'prop' can not be mutated from a non-isolated context}}
+  x.prop = 100 // expected-error {{actor-isolated property 'prop' can not be mutated from a non-isolated context}}
+}
+
+func from_concrete(_ x: A) async {
+  x.prop += 1 // expected-error {{actor-isolated property 'prop' can not be mutated from a non-isolated context}}
+  x.prop = 100 // expected-error {{actor-isolated property 'prop' can not be mutated from a non-isolated context}}
+}
+
+func from_isolated_concrete(_ x: isolated A) async {
+  x.prop += 1
+  x.prop = 100
+}
+
+
+// from https://github.com/apple/swift/issues/59573
+actor Act {
+    var i = 0 // expected-note {{mutation of this property is only permitted within the actor}}
+}
+let act = Act()
+
+func bad() async {
+    // expected-warning@+2 {{no 'async' operations occur within 'await' expression}}
+    // expected-error@+1 {{actor-isolated property 'i' can not be mutated from a non-isolated context}}
+    await act.i = 666
+}
+
+protocol Proto: Actor {
+    var i: Int { get set } // expected-note 2 {{mutation of this property is only permitted within the actor}}
+}
+extension Act: Proto {}
+
+func good() async {
+    // expected-warning@+2 {{no 'async' operations occur within 'await' expression}}
+    // expected-error@+1 {{actor-isolated property 'i' can not be mutated from a non-isolated context}}
+    await (act as any Proto).i = 42
+    let aIndirect: any Proto = act
+
+    // expected-warning@+2 {{no 'async' operations occur within 'await' expression}}
+    // expected-error@+1 {{actor-isolated property 'i' can not be mutated from a non-isolated context}}
+    await aIndirect.i = 777
+}


### PR DESCRIPTION
Description: This fixes a hole in actor isolation. Accessing a get/set property in a Actor constrained protocol was allowed but this is illegal and would have produced a race. The fix is to patch the typechecker's isolation checking to make sure it can see through an OpenExistentialExpr.
Risk: Low. It's a very simple fix that should only be an improvement to the typechecker.
Importance: Moderate. Existing code using this was bypassing actor isolation and could be crashing with race conditions
Review by: @DougGregor @ktoso 
Testing: PR testing
Original PR: https://github.com/apple/swift/pull/59655
Radar: rdar://95509917
Issue: https://github.com/apple/swift/issues/59573