### PR TITLE
platform: restructure visualc module

### DIFF
--- a/docs/WindowsBuild.md
+++ b/docs/WindowsBuild.md
@@ -102,15 +102,15 @@ Set up the `ucrt`, `visualc`, and `WinSDK` modules by:
 
 - copying `ucrt.modulemap` located at `swift/stdlib/public/Platform/ucrt.modulemap` into
   `${UniversalCRTSdkDir}/Include/${UCRTVersion}/ucrt` as `module.modulemap`
-- copying `visualc.modulemap` located at `swift/stdlib/public/Platform/visualc.modulemap` into `${VCToolsInstallDir}/include` as `module.modulemap`
+- copying `vcruntime.modulemap` located at `swift/stdlib/public/Platform/vcruntime.modulemap` into `${VCToolsInstallDir}/include` as `module.modulemap`
 - copying `winsdk.modulemap` located at `swift/stdlib/public/Platform/winsdk.modulemap` into `${UniversalCRTSdkDir}/Include/${UCRTVersion}/um`
-- and setup the `visualc.apinotes` located at `swift/stdlib/public/Platform/visualc.apinotes` into `${VCToolsInstallDir}/include` as `visualc.apinotes`
+- and setup the `vcruntime.apinotes` located at `swift/stdlib/public/Platform/vcruntime.apinotes` into `${VCToolsInstallDir}/include` as `vcruntime.apinotes`
 
 ```cmd
 mklink "%UniversalCRTSdkDir%\Include\%UCRTVersion%\ucrt\module.modulemap" S:\swift\stdlib\public\Platform\ucrt.modulemap
 mklink "%UniversalCRTSdkDir%\Include\%UCRTVersion%\um\module.modulemap" S:\swift\stdlib\public\Platform\winsdk.modulemap
-mklink "%VCToolsInstallDir%\include\module.modulemap" S:\swift\stdlib\public\Platform\visualc.modulemap
-mklink "%VCToolsInstallDir%\include\visualc.apinotes" S:\swift\stdlib\public\Platform\visualc.apinotes
+mklink "%VCToolsInstallDir%\include\module.modulemap" S:\swift\stdlib\public\Platform\vcruntime.modulemap
+mklink "%VCToolsInstallDir%\include\vcruntime.apinotes" S:\swift\stdlib\public\Platform\vcruntime.apinotes
 ```
 
 Warning: Creating the above links usually requires administrator privileges. The quick and easy way to do this is to open a second developer prompt by right clicking whatever shortcut you used to open the first one, choosing Run As Administrator, and pasting the above commands into the resulting window. You can then close the privileged prompt; this is the only step which requires elevation.

--- a/stdlib/public/Platform/vcruntime.apinotes
+++ b/stdlib/public/Platform/vcruntime.apinotes
@@ -1,5 +1,5 @@
 ---
-Name: VisualC
+Name: vcruntime
 Functions:
 - Name: _setjmp
   Availability: nonswift

--- a/stdlib/public/Platform/vcruntime.modulemap
+++ b/stdlib/public/Platform/vcruntime.modulemap
@@ -1,4 +1,4 @@
-//===--- visualc.modulemap ------------------------------------------------===//
+//===--- vcruntime.modulemap ----------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -84,23 +84,28 @@ module _visualc_intrinsics [system] [extern_c] {
   }
 }
 
-module visualc [system] {
-  module SAL {
-    header "sal.h"
-    export *
-  }
+module SAL [system] {
+  header "sal.h"
+  export *
 
-  module vcruntime {
-    header "vcruntime.h"
+  module Concurrency {
+    header "concurrencysal.h"
     export *
   }
+}
+
+module vcruntime [system] {
+  use SAL
+  export SAL
+
+  header "vcruntime.h"
 
   module setjmp {
     header "setjmp.h"
     export *
   }
 
-  module stdint {
+  explicit module stdint {
     header "stdint.h"
     export *
   }

--- a/test/ClangImporter/availability_returns_twice-msvc.swift
+++ b/test/ClangImporter/availability_returns_twice-msvc.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 // REQUIRES: OS=windows-msvc
 
-import visualc
+import vcruntime
 typealias JumpBuffer = _JBTYPE
 
 func test_unavailable_returns_twice_function() {

--- a/test/Interop/Cxx/class/Inputs/memory-layout.h
+++ b/test/Interop/Cxx/class/Inputs/memory-layout.h
@@ -1,8 +1,8 @@
 #ifndef TEST_INTEROP_CXX_CLASS_INPUTS_MEMORY_LAYOUT_H
 #define TEST_INTEROP_CXX_CLASS_INPUTS_MEMORY_LAYOUT_H
 
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 
 class PrivateMemberLayout {
   uint32_t a;

--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -181,8 +181,8 @@ cmake --build "%BuildRoot%\curl" --target install || (exit /b)
 :: Prepare system modules
 copy /y "%SourceRoot%\swift\stdlib\public\Platform\ucrt.modulemap" "%UniversalCRTSdkDir%\Include\%UCRTVersion%\ucrt\module.modulemap" || (exit /b)
 copy /y "%SourceRoot%\swift\stdlib\public\Platform\winsdk.modulemap" "%UniversalCRTSdkDir%\Include\%UCRTVersion%\um\module.modulemap" || (exit /b)
-copy /y "%SourceRoot%\swift\stdlib\public\Platform\visualc.modulemap" "%VCToolsInstallDir%\include\module.modulemap" || (exit /b)
-copy /y "%SourceRoot%\swift\stdlib\public\Platform\visualc.apinotes" "%VCToolsInstallDir%\include\visualc.apinotes" || (exit /b)
+copy /y "%SourceRoot%\swift\stdlib\public\Platform\vcruntime.modulemap" "%VCToolsInstallDir%\include\module.modulemap" || (exit /b)
+copy /y "%SourceRoot%\swift\stdlib\public\Platform\vcruntime.apinotes" "%VCToolsInstallDir%\include\vcruntime.apinotes" || (exit /b)
 
 :: Build Toolchain
 cmake ^

--- a/utils/build-windows.bat
+++ b/utils/build-windows.bat
@@ -170,8 +170,8 @@ setlocal enableextensions enabledelayedexpansion
 
 copy /y "%source_root%\swift\stdlib\public\Platform\ucrt.modulemap" "%UniversalCRTSdkDir%\Include\%UCRTVersion%\ucrt\module.modulemap" %exitOnError%
 copy /y "%source_root%\swift\stdlib\public\Platform\winsdk.modulemap" "%UniversalCRTSdkDir%\Include\%UCRTVersion%\um\module.modulemap" %exitOnError%
-copy /y "%source_root%\swift\stdlib\public\Platform\visualc.modulemap" "%VCToolsInstallDir%\include\module.modulemap" %exitOnError%
-copy /y "%source_root%\swift\stdlib\public\Platform\visualc.apinotes" "%VCToolsInstallDir%\include\visualc.apinotes" %exitOnError%
+copy /y "%source_root%\swift\stdlib\public\Platform\vcruntime.modulemap" "%VCToolsInstallDir%\include\module.modulemap" %exitOnError%
+copy /y "%source_root%\swift\stdlib\public\Platform\vcruntime.apinotes" "%VCToolsInstallDir%\include\vcruntime.apinotes" %exitOnError%
 
 goto :eof
 endlocal


### PR DESCRIPTION
Restructure the `visualc` module into `vcruntime` in order to help
expose the various components (SAL, vcruntime, ucrt, corecrt, STL) for C++
modularization.  Include the `stdint.h` textually to deal with
redefinition of types in clang resources and MSVC.