### PR TITLE
[PreCheckExpr] Don't silence errors while resolving types for 'literal via coercion' transform

### DIFF
--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -961,6 +961,9 @@ namespace {
 
     /// Simplify constructs like `UInt32(1)` into `1 as UInt32` if
     /// the type conforms to the expected literal protocol.
+    ///
+    /// \returns Either a transformed expression, or `ErrorExpr` upon type
+    /// resolution failure, or `nullptr` if transformation is not applicable.
     Expr *simplifyTypeConstructionWithLiteralArg(Expr *E);
 
     /// Whether the current expression \p E is in a context that might turn out
@@ -1431,8 +1434,9 @@ namespace {
         return KPE;
       }
 
-      if (auto *simplified = simplifyTypeConstructionWithLiteralArg(expr))
-        return simplified;
+      if (auto *result = simplifyTypeConstructionWithLiteralArg(expr)) {
+        return isa<ErrorExpr>(result) ? nullptr : result;
+      }
 
       // If we find an unresolved member chain, wrap it in an
       // UnresolvedMemberChainResultExpr (unless this has already been done).
@@ -2081,12 +2085,8 @@ Expr *PreCheckExpression::simplifyTypeConstructionWithLiteralArg(Expr *E) {
   if (auto precheckedTy = typeExpr->getInstanceType()) {
     castTy = precheckedTy;
   } else {
-    const auto options =
-        TypeResolutionOptions(TypeResolverContext::InExpression) |
-        TypeResolutionFlags::SilenceErrors;
-
     const auto result = TypeResolution::resolveContextualType(
-        typeExpr->getTypeRepr(), DC, options,
+        typeExpr->getTypeRepr(), DC, TypeResolverContext::InExpression,
         [](auto unboundTy) {
           // FIXME: Don't let unbound generic types escape type resolution.
           // For now, just return the unbound generic type.
@@ -2097,7 +2097,9 @@ Expr *PreCheckExpression::simplifyTypeConstructionWithLiteralArg(Expr *E) {
         PlaceholderType::get);
 
     if (result->hasError())
-      return nullptr;
+      return new (getASTContext())
+          ErrorExpr(typeExpr->getSourceRange(), result, typeExpr);
+
     castTy = result;
   }
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3790,6 +3790,19 @@ NeverNullType TypeResolver::resolveImplicitlyUnwrappedOptionalType(
   if (doDiag && !options.contains(TypeResolutionFlags::SilenceErrors)) {
     // Prior to Swift 5, we allow 'as T!' and turn it into a disjunction.
     if (getASTContext().isSwiftVersionAtLeast(5)) {
+      // Mark this repr as invalid. This is the only way to indicate that
+      // something went wrong without supressing checking other reprs in
+      // the same type. For example:
+      //
+      // struct S<T, U> { ... }
+      //
+      // _ = S<Int!, String!>(...)
+      //
+      // Compiler should diagnose both `Int!` and `String!` as invalid,
+      // but returning `ErrorType` from here would stop type resolution
+      // after `Int!`.
+      repr->setInvalid();
+
       diagnose(repr->getStartLoc(),
                diag::implicitly_unwrapped_optional_in_illegal_position)
           .fixItReplace(repr->getExclamationLoc(), "?");

--- a/test/Sema/diag_erroneous_iuo.swift
+++ b/test/Sema/diag_erroneous_iuo.swift
@@ -61,11 +61,8 @@ func genericFunctionSigil<T>(
 }
 
 func genericFunctionSigilArray<T>(
-  // FIXME: We validate these types multiple times resulting in multiple diagnostics
   iuo: [T!] // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{10-11=?}}
-  // expected-error@-1 {{'!' is not allowed here; perhaps '?' was intended?}}{{10-11=?}}
 ) -> [T!] { // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{8-9=?}}
-  // expected-error@-1 {{'!' is not allowed here; perhaps '?' was intended?}}{{8-9=?}}
   return iuo
 }
 

--- a/test/type/types.swift
+++ b/test/type/types.swift
@@ -194,3 +194,12 @@ var _: sr5505 = sr5505 // expected-error {{cannot find type 'sr5505' in scope}}
 typealias A = (inout Int ..., Int ... = [42, 12]) -> Void // expected-error {{'inout' must not be used on variadic parameters}}
                                                           // expected-error@-1 {{only a single element can be variadic}} {{35-39=}}
                                                           // expected-error@-2 {{default argument not permitted in a tuple type}} {{39-49=}}
+
+// rdar://94888357 - failed to produce a diagnostic when type is used incorrectly
+func rdar94888357() {
+  struct S<T> { // expected-note {{generic type 'S' declared here}}
+    init(_ str: String) {}
+  }
+
+  let _ = S<String, String>("") // expected-error {{generic type 'S' specialized with too many type parameters (got 2, but expected 1)}}
+}


### PR DESCRIPTION
Since `resolveType` caches its results, silencing errors would mean
that the error would be lost and each subsequent call to `resolveType`
would get `ErrorType` back. This ultimately leads to the compiler
failing to produce a diagnostic when invalid type is used in `init`
call.

These changes include marking IUO reprs found in incorrect positions,
such as generic arguments, as invalid right before diagnosing them as 
errors, this helps to prevent type resolution from producing duplicate 
diagnostics.

Resolves: rdar://94888357


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
