### PR TITLE
[DNM] Cater for case when existential to open is a "var".

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1501,6 +1501,10 @@ shouldOpenExistentialCallArgument(
     adjustments |= OpenedExistentialAdjustmentFlags::InOut;
   }
 
+  // The argument may be a "var" instead of a "let".
+  if (auto lv = dyn_cast<LValueType>(argTy->getCanonicalType()))
+    argTy = lv->getObjectType();
+
   // The argument type needs to be an existential type or metatype thereof.
   if (!argTy->isAnyExistentialType())
     return None;

--- a/test/Constraints/opened_existentials.swift
+++ b/test/Constraints/opened_existentials.swift
@@ -25,6 +25,10 @@ func testSimpleExistentialOpening(p: any P, pq: any P & Q, c: any Collection) {
   let pa = acceptGeneric(p)
   let _: Int = pa // expected-error{{cannot convert value of type '(any Q)?' to specified type 'Int'}}
 
+  var vp = p
+  let vpa = acceptGeneric(vp)
+  let _: Int = vpa // expected-error{{cannot convert value of type '(any Q)?' to specified type 'Int'}}
+
   let pqa = acceptGeneric(pq)
   let _: Int = pqa  // expected-error{{cannot convert value of type '(any Q)?' to specified type 'Int'}}
 


### PR DESCRIPTION
Hi Apple,

There I was having trouble getting the compiler to open my existential and I discovered it seems to be because my existential value was in a "var" rather than a "let". I have no insight into whether this change is the correct thing to do but it seems to resolve the problem I was seeing.