### PR TITLE
[Distributed] Implement distributed computed properties via special accessor

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -197,7 +197,7 @@ public:
                                              Type GlobalActorBound,
                                              ModuleDecl *Module);
 
-  std::string mangleDistributedThunk(const FuncDecl *thunk);
+  std::string mangleDistributedThunk(const AbstractFunctionDecl *thunk);
 
   /// Mangle a completion handler block implementation function, used for importing ObjC
   /// APIs as async.

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -664,7 +664,7 @@ SIMPLE_DECL_ATTR(_inheritActorContext, InheritActorContext,
 // 117 was 'spawn' and is now unused
 
 CONTEXTUAL_SIMPLE_DECL_ATTR(distributed, DistributedActor,
-  DeclModifier | OnClass | OnFunc | OnVar |
+  DeclModifier | OnClass | OnFunc | OnAccessor | OnVar |
   ABIBreakingToAdd | ABIBreakingToRemove |
   APIBreakingToAdd | APIBreakingToRemove,
   118)

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5123,6 +5123,13 @@ public:
 
   bool hasAnyNativeDynamicAccessors() const;
 
+  /// Does this have a 'distributed' modifier?
+  bool isDistributed() const;
+
+  /// Return a distributed thunk if this computed property is marked as
+  /// 'distributed' and and nullptr otherwise.
+  FuncDecl *getDistributedThunk() const;
+
   // Implement isa/cast/dyncast/etc.
   static bool classof(const Decl *D) {
     return D->getKind() >= DeclKind::First_AbstractStorageDecl &&
@@ -5355,13 +5362,6 @@ public:
 
   /// Is this an "async let" property?
   bool isAsyncLet() const;
-
-  /// Does this have a 'distributed' modifier?
-  bool isDistributed() const;
-
-  /// Return a distributed thunk if this computed property is marked as
-  /// 'distributed' and and nullptr otherwise.
-  FuncDecl *getDistributedThunk() const;
 
   /// Is this var known to be a "local" distributed actor,
   /// if so the implicit throwing ans some isolation checks can be skipped.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5355,6 +5355,10 @@ public:
   /// Does this have a 'distributed' modifier?
   bool isDistributed() const;
 
+  /// Return a distributed thunk if this computed property is marked as
+  /// 'distributed' and and nullptr otherwise.
+  FuncDecl *getDistributedThunk() const;
+
   /// Is this var known to be a "local" distributed actor,
   /// if so the implicit throwing ans some isolation checks can be skipped.
   bool isKnownToBeLocal() const;

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -412,7 +412,7 @@ protected:
   SWIFT_INLINE_BITFIELD(SubscriptDecl, VarDecl, 2,
     StaticSpelling : 2
   );
-  SWIFT_INLINE_BITFIELD(AbstractFunctionDecl, ValueDecl, 3+2+8+1+1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD(AbstractFunctionDecl, ValueDecl, 3+2+8+1+1+1+1+1+1+1,
     /// \see AbstractFunctionDecl::BodyKind
     BodyKind : 3,
 
@@ -439,7 +439,11 @@ protected:
 
     /// Whether peeking into this function detected nested type declarations.
     /// This is set when skipping over the decl at parsing.
-    HasNestedTypeDeclarations : 1
+    HasNestedTypeDeclarations : 1,
+
+    /// Whether this function is a distributed thunk for a distributed
+    /// function or computed property.
+    DistributedThunk: 1
   );
 
   SWIFT_INLINE_BITFIELD(FuncDecl, AbstractFunctionDecl, 1+1+2+1+1+2+1,
@@ -6335,6 +6339,7 @@ protected:
     Bits.AbstractFunctionDecl.Throws = Throws;
     Bits.AbstractFunctionDecl.HasSingleExpressionBody = false;
     Bits.AbstractFunctionDecl.HasNestedTypeDeclarations = false;
+    Bits.AbstractFunctionDecl.DistributedThunk = false;
   }
 
   void setBodyKind(BodyKind K) {
@@ -6432,6 +6437,16 @@ public:
 
   /// Returns 'true' if the function is distributed.
   bool isDistributed() const;
+
+  /// Is this a thunk function used to access a distributed method
+  /// or computed property outside of its actor isolation context?
+  bool isDistributedThunk() const {
+    return Bits.AbstractFunctionDecl.DistributedThunk;
+  }
+
+  void setDistributedThunk(bool isThunk) {
+    Bits.AbstractFunctionDecl.DistributedThunk = isThunk;
+  }
 
   /// For a 'distributed' target (func or computed property),
   /// get the 'thunk' responsible for performing the 'remoteCall'.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4804,6 +4804,9 @@ ERROR(distributed_property_cannot_be_static,none,
 ERROR(distributed_property_can_only_be_computed,none,
       "%0 %1 cannot be 'distributed', only computed properties can",
       (DescriptiveDeclKind, DeclName))
+ERROR(distributed_property_accessor_only_get_can_be_distributed,none,
+      "only 'get' accessors may be 'distributed'",
+      ())
 NOTE(distributed_actor_isolated_property,none,
       "access to %0 %1 is only permitted within distributed actor %2",
       (DescriptiveDeclKind, DeclName, DeclName))

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -124,6 +124,12 @@ enum class AccessSemantics : uint8_t {
   /// This is an ordinary access to a declaration, using whatever
   /// polymorphism is expected.
   Ordinary,
+
+  /// This is an access to the underlying storage through a distributed thunk.
+  ///
+  /// The declaration must be a 'distributed' computed property used outside
+  /// of its actor isolation context.
+  DistributedThunk,
 };
 
 /// Expr - Base class for all expressions in swift.
@@ -155,11 +161,10 @@ protected:
 
   SWIFT_INLINE_BITFIELD_EMPTY(LiteralExpr, Expr);
   SWIFT_INLINE_BITFIELD_EMPTY(IdentityExpr, Expr);
-  SWIFT_INLINE_BITFIELD(LookupExpr, Expr, 1+1+1+1,
+  SWIFT_INLINE_BITFIELD(LookupExpr, Expr, 1+1+1,
     IsSuper : 1,
     IsImplicitlyAsync : 1,
-    IsImplicitlyThrows : 1,
-    ShouldApplyDistributedThunk: 1
+    IsImplicitlyThrows : 1
   );
   SWIFT_INLINE_BITFIELD_EMPTY(DynamicLookupExpr, LookupExpr);
 
@@ -1656,18 +1661,6 @@ public:
     Bits.LookupExpr.IsImplicitlyThrows = isImplicitlyThrows;
   }
 
-  /// Informs IRGen to that this expression should be applied as its distributed
-  /// thunk, rather than invoking the function directly.
-  ///
-  /// Only intended to be set on distributed get-only computed properties.
-  bool shouldApplyLookupDistributedThunk() const {
-    return Bits.LookupExpr.ShouldApplyDistributedThunk;
-  }
-
-  void setShouldApplyLookupDistributedThunk(bool flag) {
-    Bits.LookupExpr.ShouldApplyDistributedThunk = flag;
-  }
-
   static bool classof(const Expr *E) {
     return E->getKind() >= ExprKind::First_LookupExpr &&
            E->getKind() <= ExprKind::Last_LookupExpr;
@@ -1695,6 +1688,14 @@ public:
   /// does not call the getter or setter.
   AccessSemantics getAccessSemantics() const {
     return (AccessSemantics) Bits.MemberRefExpr.Semantics;
+  }
+
+  /// Informs IRGen to that this member should be applied via its distributed
+  /// thunk, rather than invoking it directly.
+  ///
+  /// Only intended to be set on distributed get-only computed properties.
+  void setAccessViaDistributedThunk() {
+    Bits.MemberRefExpr.Semantics = (unsigned)AccessSemantics::DistributedThunk;
   }
 
   SourceLoc getLoc() const { return NameLoc.getBaseNameLoc(); }

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -155,10 +155,11 @@ protected:
 
   SWIFT_INLINE_BITFIELD_EMPTY(LiteralExpr, Expr);
   SWIFT_INLINE_BITFIELD_EMPTY(IdentityExpr, Expr);
-  SWIFT_INLINE_BITFIELD(LookupExpr, Expr, 1+1+1,
+  SWIFT_INLINE_BITFIELD(LookupExpr, Expr, 1+1+1+1,
     IsSuper : 1,
     IsImplicitlyAsync : 1,
-    IsImplicitlyThrows : 1
+    IsImplicitlyThrows : 1,
+    ShouldApplyDistributedThunk: 1
   );
   SWIFT_INLINE_BITFIELD_EMPTY(DynamicLookupExpr, LookupExpr);
 
@@ -1653,6 +1654,18 @@ public:
   /// networking error.
   void setImplicitlyThrows(bool isImplicitlyThrows) {
     Bits.LookupExpr.IsImplicitlyThrows = isImplicitlyThrows;
+  }
+
+  /// Informs IRGen to that this expression should be applied as its distributed
+  /// thunk, rather than invoking the function directly.
+  ///
+  /// Only intended to be set on distributed get-only computed properties.
+  bool shouldApplyLookupDistributedThunk() const {
+    return Bits.LookupExpr.ShouldApplyDistributedThunk;
+  }
+
+  void setShouldApplyLookupDistributedThunk(bool flag) {
+    Bits.LookupExpr.ShouldApplyDistributedThunk = flag;
   }
 
   static bool classof(const Expr *E) {

--- a/include/swift/AST/StorageImpl.h
+++ b/include/swift/AST/StorageImpl.h
@@ -110,10 +110,6 @@ public:
     /// separately performing a Read into a temporary variable followed by
     /// a Write access back into the storage.
     MaterializeToTemporary,
-
-//    /// The access is to a computed distributed property, and thus the
-//    /// get-accessor is a distributed thunk which may perform a remote call.
-//    DirectToDistributedThunkAccessor,
   };
 
 private:
@@ -153,10 +149,6 @@ public:
     return { dispatched ? DispatchToAccessor : DirectToAccessor, accessor };
   }
 
-//  static AccessStrategy getDistributedGetAccessor(AccessorKind accessor) {
-//    assert(accessor == AccessorKind::Get);
-//    return { DirectToDistributedThunkAccessor, accessor };
-//  }
   static AccessStrategy getMaterializeToTemporary(AccessStrategy read,
                                                   AccessStrategy write) {
     return { read, write };

--- a/include/swift/AST/StorageImpl.h
+++ b/include/swift/AST/StorageImpl.h
@@ -110,6 +110,10 @@ public:
     /// separately performing a Read into a temporary variable followed by
     /// a Write access back into the storage.
     MaterializeToTemporary,
+
+//    /// The access is to a computed distributed property, and thus the
+//    /// get-accessor is a distributed thunk which may perform a remote call.
+//    DirectToDistributedThunkAccessor,
   };
 
 private:
@@ -149,6 +153,10 @@ public:
     return { dispatched ? DispatchToAccessor : DirectToAccessor, accessor };
   }
 
+//  static AccessStrategy getDistributedGetAccessor(AccessorKind accessor) {
+//    assert(accessor == AccessorKind::Get);
+//    return { DirectToDistributedThunkAccessor, accessor };
+//  }
   static AccessStrategy getMaterializeToTemporary(AccessStrategy read,
                                                   AccessStrategy write) {
     return { read, write };

--- a/include/swift/AST/StorageImpl.h
+++ b/include/swift/AST/StorageImpl.h
@@ -110,6 +110,10 @@ public:
     /// separately performing a Read into a temporary variable followed by
     /// a Write access back into the storage.
     MaterializeToTemporary,
+
+    /// The access is to a computed distributed property, and thus the
+    /// get-accessor is a distributed thunk which may perform a remote call.
+    DispatchToDistributedThunk,
   };
 
 private:
@@ -149,6 +153,10 @@ public:
     return { dispatched ? DispatchToAccessor : DirectToAccessor, accessor };
   }
 
+  static AccessStrategy getDistributedThunkDispatchStrategy() {
+    return {DispatchToDistributedThunk, AccessorKind::Get};
+  }
+
   static AccessStrategy getMaterializeToTemporary(AccessStrategy read,
                                                   AccessStrategy write) {
     return { read, write };
@@ -157,7 +165,8 @@ public:
   Kind getKind() const { return TheKind; }
 
   bool hasAccessor() const {
-    return TheKind == DirectToAccessor || TheKind == DispatchToAccessor;
+    return TheKind == DirectToAccessor || TheKind == DispatchToAccessor ||
+           TheKind == DispatchToDistributedThunk;
   }
 
   AccessorKind getAccessor() const {

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1237,17 +1237,20 @@ public:
 ///
 /// The thunk is responsible for invoking 'remoteCall' when invoked on a remote
 /// 'distributed actor'.
-class GetDistributedThunkRequest :
-    public SimpleRequest<GetDistributedThunkRequest,
-                         FuncDecl *(AbstractFunctionDecl *),
-                         RequestFlags::Cached> {
+class GetDistributedThunkRequest
+    : public SimpleRequest<
+          GetDistributedThunkRequest,
+          FuncDecl *(llvm::PointerUnion<VarDecl *, AbstractFunctionDecl *>),
+          RequestFlags::Cached> {
+  using Originator = llvm::PointerUnion<VarDecl *, AbstractFunctionDecl *>;
+
 public:
   using SimpleRequest::SimpleRequest;
 
 private:
   friend SimpleRequest;
 
-  FuncDecl *evaluate(Evaluator &evaluator, AbstractFunctionDecl *distributedFunc) const;
+  FuncDecl *evaluate(Evaluator &evaluator, Originator originator) const;
 
 public:
   // Caching

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1238,11 +1238,13 @@ public:
 /// The thunk is responsible for invoking 'remoteCall' when invoked on a remote
 /// 'distributed actor'.
 class GetDistributedThunkRequest
-    : public SimpleRequest<
-          GetDistributedThunkRequest,
-          FuncDecl *(llvm::PointerUnion<VarDecl *, AbstractFunctionDecl *>),
-          RequestFlags::Cached> {
-  using Originator = llvm::PointerUnion<VarDecl *, AbstractFunctionDecl *>;
+    : public SimpleRequest<GetDistributedThunkRequest,
+                           FuncDecl *(
+                               llvm::PointerUnion<AbstractStorageDecl *,
+                                                  AbstractFunctionDecl *>),
+                           RequestFlags::Cached> {
+  using Originator =
+      llvm::PointerUnion<AbstractStorageDecl *, AbstractFunctionDecl *>;
 
 public:
   using SimpleRequest::SimpleRequest;

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -127,7 +127,7 @@ SWIFT_REQUEST(TypeChecker, GetDistributedTargetInvocationResultHandlerOnReturnFu
               AbstractFunctionDecl *(NominalTypeDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, GetDistributedThunkRequest,
-              FuncDecl *(llvm::PointerUnion<VarDecl *, AbstractFunctionDecl *>),
+              FuncDecl *(llvm::PointerUnion<AbstractStorageDecl *, AbstractFunctionDecl *>),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, GetDistributedActorIDPropertyRequest,
               VarDecl *(NominalTypeDecl *),

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -127,7 +127,7 @@ SWIFT_REQUEST(TypeChecker, GetDistributedTargetInvocationResultHandlerOnReturnFu
               AbstractFunctionDecl *(NominalTypeDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, GetDistributedThunkRequest,
-              FuncDecl *(AbstractFunctionDecl *),
+              FuncDecl *(llvm::PointerUnion<VarDecl *, AbstractFunctionDecl *>),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, GetDistributedActorIDPropertyRequest,
               VarDecl *(NominalTypeDecl *),

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -255,6 +255,7 @@ static StringRef getAccessSemanticsString(AccessSemantics value) {
     case AccessSemantics::Ordinary: return "ordinary";
     case AccessSemantics::DirectToStorage: return "direct_to_storage";
     case AccessSemantics::DirectToImplementation: return "direct_to_impl";
+    case AccessSemantics::DistributedThunk: return "distributed_thunk";
   }
 
   llvm_unreachable("Unhandled AccessSemantics in switch.");
@@ -2035,9 +2036,6 @@ public:
 
   void visitMemberRefExpr(MemberRefExpr *E) {
     printCommon(E, "member_ref_expr");
-    if (E->shouldApplyLookupDistributedThunk()) {
-      OS << " distributed";
-    }
     PrintWithColorRAII(OS, DeclColor) << " decl=";
     printDeclRef(E->getMember());
     if (E->getAccessSemantics() != AccessSemantics::Ordinary)

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -878,6 +878,9 @@ namespace {
       if (D->isDistributed()) {
         PrintWithColorRAII(OS, ExprModifierColor) << " distributed";
       }
+      if (D->isDistributedThunk()) {
+        PrintWithColorRAII(OS, ExprModifierColor) << " distributed-thunk";
+      }
 
       if (auto fac = D->getForeignAsyncConvention()) {
         OS << " foreign_async=";

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -745,6 +745,8 @@ namespace {
 
     void visitVarDecl(VarDecl *VD) {
       printCommon(VD, "var_decl");
+      if (VD->isDistributed())
+        PrintWithColorRAII(OS, DeclModifierColor) << " distributed";
       if (VD->isLet())
         PrintWithColorRAII(OS, DeclModifierColor) << " let";
       if (VD->getAttrs().hasAttribute<LazyAttr>())
@@ -2033,6 +2035,9 @@ public:
 
   void visitMemberRefExpr(MemberRefExpr *E) {
     printCommon(E, "member_ref_expr");
+    if (E->shouldApplyLookupDistributedThunk()) {
+      OS << " distributed";
+    }
     PrintWithColorRAII(OS, DeclColor) << " decl=";
     printDeclRef(E->getMember());
     if (E->getAccessSemantics() != AccessSemantics::Ordinary)

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3486,7 +3486,7 @@ ASTMangler::mangleOpaqueTypeDescriptorRecord(const OpaqueTypeDecl *decl) {
   return finalize();
 }
 
-std::string ASTMangler::mangleDistributedThunk(const FuncDecl *thunk) {
+std::string ASTMangler::mangleDistributedThunk(const AbstractFunctionDecl *thunk) {
   // Marker protocols cannot be checked at runtime, so there is no point
   // in recording them for distributed thunks.
   llvm::SaveAndRestore<bool> savedAllowMarkerProtocols(AllowMarkerProtocols,

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3192,6 +3192,14 @@ void ASTMangler::appendEntity(const ValueDecl *decl) {
   // Handle accessors specially, they are mangled as modifiers on the accessed
   // declaration.
   if (auto accessor = dyn_cast<AccessorDecl>(decl)) {
+    if (accessor->isDistributedThunk()) {
+      appendContextOf(decl);
+      appendDeclName(accessor->getStorage());
+      appendDeclType(accessor, FunctionMangling);
+      appendOperator("F");
+      return;
+    }
+
     return appendAccessorEntity(
         getCodeForAccessorKind(accessor->getAccessorKind()),
         accessor->getStorage(), accessor->isStatic());

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3192,6 +3192,13 @@ void ASTMangler::appendEntity(const ValueDecl *decl) {
   // Handle accessors specially, they are mangled as modifiers on the accessed
   // declaration.
   if (auto accessor = dyn_cast<AccessorDecl>(decl)) {
+    // Distributed thunks associated with computed properties
+    // are currently implemented as accessors but they don't
+    // have to be and that could be changed in the future.
+    //
+    // Let's mangle them as `distributed func`s to make it easier
+    // to change implementation and because runtime needs a function
+    // type associated with the thunk to form a call to it.
     if (accessor->isDistributedThunk()) {
       appendContextOf(decl);
       appendDeclName(accessor->getStorage());

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6455,10 +6455,6 @@ bool VarDecl::isAsyncLet() const {
   return getAttrs().hasAttribute<AsyncAttr>();
 }
 
-bool VarDecl::isDistributed() const {
-  return getAttrs().hasAttribute<DistributedActorAttr>();
-}
-
 bool VarDecl::isKnownToBeLocal() const {
   return getAttrs().hasAttribute<KnownToBeLocalAttr>();
 }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2272,6 +2272,11 @@ AbstractStorageDecl::getAccessStrategy(AccessSemantics semantics,
     assert(hasStorage());
     return AccessStrategy::getStorage();
 
+  // FIXME: For now `DistributedThunk` behaves just like `Ordinary` but it
+  //        needs a new strategy to be useful.
+  case AccessSemantics::DistributedThunk:
+    LLVM_FALLTHROUGH;
+
   case AccessSemantics::Ordinary:
     // Skip these checks for local variables, both because they're unnecessary
     // and because we won't necessarily have computed access.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2151,6 +2151,17 @@ getDirectReadAccessStrategy(const AbstractStorageDecl *storage) {
   llvm_unreachable("bad impl kind");
 }
 
+//static AccessStrategy
+//getDirectToDistributedThunkAccessorStrategy(const AbstractStorageDecl *storage) {
+//  switch (storage->getReadImpl()) {
+//  case ReadImplKind::Get:
+//    return AccessStrategy::getDistributedGetAccessor(AccessorKind::Get);
+//  default:
+//    llvm_unreachable("bad impl kind for distributed property accessor");
+//  }
+//  llvm_unreachable("bad impl kind for distributed property accessor");
+//}
+
 static AccessStrategy
 getDirectWriteAccessStrategy(const AbstractStorageDecl *storage) {
   switch (storage->getWriteImpl()) {
@@ -2283,6 +2294,14 @@ AbstractStorageDecl::getAccessStrategy(AccessSemantics semantics,
 
       if (shouldUseNativeDynamicDispatch())
         return getOpaqueAccessStrategy(this, accessKind, /*dispatch*/ false);
+
+//      if (auto var = dyn_cast<VarDecl>(this)) {
+//        if (var->isDistributed()) {
+//          fprintf(stderr, "[%s:%d] (%s) DIST STRATEGY!!\n", __FILE__, __LINE__, __FUNCTION__);
+//          var->dump();
+//          return getDirectToDistributedThunkAccessorStrategy(this);
+//        }
+//      }
 
       // If the storage is resilient from the given module and resilience
       // expansion, we cannot use direct access.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2272,10 +2272,8 @@ AbstractStorageDecl::getAccessStrategy(AccessSemantics semantics,
     assert(hasStorage());
     return AccessStrategy::getStorage();
 
-  // FIXME: For now `DistributedThunk` behaves just like `Ordinary` but it
-  //        needs a new strategy to be useful.
   case AccessSemantics::DistributedThunk:
-    LLVM_FALLTHROUGH;
+    return AccessStrategy::getDistributedThunkDispatchStrategy();
 
   case AccessSemantics::Ordinary:
     // Skip these checks for local variables, both because they're unnecessary

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2151,17 +2151,6 @@ getDirectReadAccessStrategy(const AbstractStorageDecl *storage) {
   llvm_unreachable("bad impl kind");
 }
 
-//static AccessStrategy
-//getDirectToDistributedThunkAccessorStrategy(const AbstractStorageDecl *storage) {
-//  switch (storage->getReadImpl()) {
-//  case ReadImplKind::Get:
-//    return AccessStrategy::getDistributedGetAccessor(AccessorKind::Get);
-//  default:
-//    llvm_unreachable("bad impl kind for distributed property accessor");
-//  }
-//  llvm_unreachable("bad impl kind for distributed property accessor");
-//}
-
 static AccessStrategy
 getDirectWriteAccessStrategy(const AbstractStorageDecl *storage) {
   switch (storage->getWriteImpl()) {
@@ -2294,14 +2283,6 @@ AbstractStorageDecl::getAccessStrategy(AccessSemantics semantics,
 
       if (shouldUseNativeDynamicDispatch())
         return getOpaqueAccessStrategy(this, accessKind, /*dispatch*/ false);
-
-//      if (auto var = dyn_cast<VarDecl>(this)) {
-//        if (var->isDistributed()) {
-//          fprintf(stderr, "[%s:%d] (%s) DIST STRATEGY!!\n", __FILE__, __LINE__, __FUNCTION__);
-//          var->dump();
-//          return getDirectToDistributedThunkAccessorStrategy(this);
-//        }
-//      }
 
       // If the storage is resilient from the given module and resilience
       // expansion, we cannot use direct access.

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -1333,6 +1333,15 @@ AbstractFunctionDecl *ASTContext::getRemoteCallOnDistributedActorSystem(
 /********************** Distributed Actor Properties **************************/
 /******************************************************************************/
 
+FuncDecl *VarDecl::getDistributedThunk() const {
+  if (!isDistributed())
+    return nullptr;
+
+  auto mutableThis = const_cast<VarDecl *>(this);
+  return evaluateOrDefault(getASTContext().evaluator,
+                           GetDistributedThunkRequest{mutableThis}, nullptr);
+}
+
 FuncDecl*
 AbstractFunctionDecl::getDistributedThunk() const {
   if (!isDistributed())

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -1290,6 +1290,10 @@ bool AbstractFunctionDecl::isDistributed() const {
   return getAttrs().hasAttribute<DistributedActorAttr>();
 }
 
+bool AbstractStorageDecl::isDistributed() const {
+  return getAttrs().hasAttribute<DistributedActorAttr>();
+}
+
 ConstructorDecl *
 NominalTypeDecl::getDistributedRemoteCallTargetInitFunction() const {
   auto mutableThis = const_cast<NominalTypeDecl *>(this);
@@ -1333,11 +1337,11 @@ AbstractFunctionDecl *ASTContext::getRemoteCallOnDistributedActorSystem(
 /********************** Distributed Actor Properties **************************/
 /******************************************************************************/
 
-FuncDecl *VarDecl::getDistributedThunk() const {
+FuncDecl *AbstractStorageDecl::getDistributedThunk() const {
   if (!isDistributed())
     return nullptr;
 
-  auto mutableThis = const_cast<VarDecl *>(this);
+  auto mutableThis = const_cast<AbstractStorageDecl *>(this);
   return evaluateOrDefault(getASTContext().evaluator,
                            GetDistributedThunkRequest{mutableThis}, nullptr);
 }

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1839,6 +1839,7 @@ SILGenModule::canStorageUseStoredKeyPathComponent(AbstractStorageDecl *decl,
   case AccessStrategy::DirectToAccessor:
   case AccessStrategy::DispatchToAccessor:
   case AccessStrategy::MaterializeToTemporary:
+  case AccessStrategy::DispatchToDistributedThunk:
     return false;
   }
   llvm_unreachable("unhandled strategy");

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1773,6 +1773,9 @@ void SILGenModule::visitVarDecl(VarDecl *vd) {
   if (vd->hasStorage())
     addGlobalVariable(vd);
 
+  fprintf(stderr, "[%s:%d] (%s) VISIT VAR DECL\n", __FILE__, __LINE__, __FUNCTION__);
+  vd->dump();
+
   vd->visitEmittedAccessors([&](AccessorDecl *accessor) {
     emitFunction(accessor);
   });
@@ -1839,6 +1842,7 @@ SILGenModule::canStorageUseStoredKeyPathComponent(AbstractStorageDecl *decl,
   case AccessStrategy::DirectToAccessor:
   case AccessStrategy::DispatchToAccessor:
   case AccessStrategy::MaterializeToTemporary:
+//  case AccessStrategy::DirectToDistributedThunkAccessor:
     return false;
   }
   llvm_unreachable("unhandled strategy");

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1773,9 +1773,6 @@ void SILGenModule::visitVarDecl(VarDecl *vd) {
   if (vd->hasStorage())
     addGlobalVariable(vd);
 
-  fprintf(stderr, "[%s:%d] (%s) VISIT VAR DECL\n", __FILE__, __LINE__, __FUNCTION__);
-  vd->dump();
-
   vd->visitEmittedAccessors([&](AccessorDecl *accessor) {
     emitFunction(accessor);
   });
@@ -1842,7 +1839,6 @@ SILGenModule::canStorageUseStoredKeyPathComponent(AbstractStorageDecl *decl,
   case AccessStrategy::DirectToAccessor:
   case AccessStrategy::DispatchToAccessor:
   case AccessStrategy::MaterializeToTemporary:
-//  case AccessStrategy::DirectToDistributedThunkAccessor:
     return false;
   }
   llvm_unreachable("unhandled strategy");

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -5375,7 +5375,6 @@ static Callee getBaseAccessorFunctionRef(SILGenFunction &SGF,
                                          ArgumentSource &selfValue,
                                          bool isSuper,
                                          bool isDirectUse,
-                                         bool isDistributed,
                                          SubstitutionMap subs,
                                          bool isOnSelfParameter) {
   auto *decl = cast<AbstractFunctionDecl>(constant.getDecl());
@@ -5455,13 +5454,12 @@ emitSpecializedAccessorFunctionRef(SILGenFunction &SGF,
                                    ArgumentSource &selfValue,
                                    bool isSuper,
                                    bool isDirectUse,
-                                   bool isDistributed,
                                    bool isOnSelfParameter)
 {
   // Get the accessor function. The type will be a polymorphic function if
   // the Self type is generic.
   Callee callee = getBaseAccessorFunctionRef(SGF, loc, constant, selfValue,
-                                             isSuper, isDirectUse, isDistributed,
+                                             isSuper, isDirectUse,
                                              substitutions, isOnSelfParameter);
   
   // Collect captures if the accessor has them.
@@ -5773,7 +5771,7 @@ SILDeclRef SILGenModule::getAccessorDeclRef(AccessorDecl *accessor) {
 RValue SILGenFunction::emitGetAccessor(SILLocation loc, SILDeclRef get,
                                        SubstitutionMap substitutions,
                                        ArgumentSource &&selfValue, bool isSuper,
-                                       bool isDirectUse, bool isDistributed,
+                                       bool isDirectUse,
                                        PreparedArguments &&subscriptIndices,
                                        SGFContext c,
                                        bool isOnSelfParameter) {
@@ -5782,7 +5780,7 @@ RValue SILGenFunction::emitGetAccessor(SILLocation loc, SILDeclRef get,
 
   Callee getter = emitSpecializedAccessorFunctionRef(
       *this, loc, get, substitutions, selfValue, isSuper, isDirectUse,
-      isDistributed, isOnSelfParameter);
+      isOnSelfParameter);
   bool hasSelf = (bool)selfValue;
   CanAnyFunctionType accessType = getter.getSubstFormalType();
 
@@ -5815,7 +5813,7 @@ void SILGenFunction::emitSetAccessor(SILLocation loc, SILDeclRef set,
 
   Callee setter = emitSpecializedAccessorFunctionRef(
       *this, loc, set, substitutions, selfValue, isSuper, isDirectUse,
-      /*isDistributed=*/false, isOnSelfParameter);
+      isOnSelfParameter);
   bool hasSelf = (bool)selfValue;
   CanAnyFunctionType accessType = setter.getSubstFormalType();
 
@@ -5850,14 +5848,14 @@ void SILGenFunction::emitSetAccessor(SILLocation loc, SILDeclRef set,
 ManagedValue SILGenFunction::emitAddressorAccessor(
     SILLocation loc, SILDeclRef addressor, SubstitutionMap substitutions,
     ArgumentSource &&selfValue, bool isSuper, bool isDirectUse,
-    bool isDistributed, PreparedArguments &&subscriptIndices,
+    PreparedArguments &&subscriptIndices,
     SILType addressType, bool isOnSelfParameter) {
   // Scope any further writeback just within this operation.
   FormalEvaluationScope writebackScope(*this);
 
   Callee callee = emitSpecializedAccessorFunctionRef(
       *this, loc, addressor, substitutions, selfValue, isSuper, isDirectUse,
-      isDistributed,  isOnSelfParameter);
+      isOnSelfParameter);
   bool hasSelf = (bool)selfValue;
   CanAnyFunctionType accessType = callee.getSubstFormalType();
 
@@ -5913,7 +5911,6 @@ SILGenFunction::emitCoroutineAccessor(SILLocation loc, SILDeclRef accessor,
     emitSpecializedAccessorFunctionRef(*this, loc, accessor,
                                        substitutions, selfValue,
                                        isSuper, isDirectUse,
-                                       /*isDistributed=*/false,
                                        isOnSelfParameter);
 
   // We're already in a full formal-evaluation scope.

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1090,7 +1090,7 @@ public:
 
     // If this is a direct reference to a vardecl, just emit its value directly.
     // Recursive references to callable declarations are allowed.
-    if (auto var = dyn_cast<VarDecl>(e->getDecl())) {
+    if (isa<VarDecl>(e->getDecl())) {
       visitExpr(e);
       return;
     }
@@ -1126,8 +1126,6 @@ public:
 
     /// Some special handling may be necessary for thunks:
     if (callSite && callSite->shouldApplyDistributedThunk()) {
-      fprintf(stderr, "[%s:%d] (%s) SHOULD APPLY DIST THUNK\n", __FILE__, __LINE__, __FUNCTION__);
-
       if (auto distributedThunk = cast<AbstractFunctionDecl>(e->getDecl())->getDistributedThunk()) {
         constant = SILDeclRef(distributedThunk).asDistributed();
       }
@@ -5782,15 +5780,8 @@ RValue SILGenFunction::emitGetAccessor(SILLocation loc, SILDeclRef get,
   // Scope any further writeback just within this operation.
   FormalEvaluationScope writebackScope(*this);
 
-  auto constant = get;
-
-//  if (isDistributed) {
-//    get.dump();
-//    assert(false && "should use dist thunk");
-//  }
-
   Callee getter = emitSpecializedAccessorFunctionRef(
-      *this, loc, constant, substitutions, selfValue, isSuper, isDirectUse,
+      *this, loc, get, substitutions, selfValue, isSuper, isDirectUse,
       isDistributed, isOnSelfParameter);
   bool hasSelf = (bool)selfValue;
   CanAnyFunctionType accessType = getter.getSubstFormalType();

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1090,7 +1090,7 @@ public:
 
     // If this is a direct reference to a vardecl, just emit its value directly.
     // Recursive references to callable declarations are allowed.
-    if (isa<VarDecl>(e->getDecl())) {
+    if (auto var = dyn_cast<VarDecl>(e->getDecl())) {
       visitExpr(e);
       return;
     }
@@ -1126,6 +1126,8 @@ public:
 
     /// Some special handling may be necessary for thunks:
     if (callSite && callSite->shouldApplyDistributedThunk()) {
+      fprintf(stderr, "[%s:%d] (%s) SHOULD APPLY DIST THUNK\n", __FILE__, __LINE__, __FUNCTION__);
+
       if (auto distributedThunk = cast<AbstractFunctionDecl>(e->getDecl())->getDistributedThunk()) {
         constant = SILDeclRef(distributedThunk).asDistributed();
       }
@@ -5375,6 +5377,7 @@ static Callee getBaseAccessorFunctionRef(SILGenFunction &SGF,
                                          ArgumentSource &selfValue,
                                          bool isSuper,
                                          bool isDirectUse,
+                                         bool isDistributed,
                                          SubstitutionMap subs,
                                          bool isOnSelfParameter) {
   auto *decl = cast<AbstractFunctionDecl>(constant.getDecl());
@@ -5454,12 +5457,13 @@ emitSpecializedAccessorFunctionRef(SILGenFunction &SGF,
                                    ArgumentSource &selfValue,
                                    bool isSuper,
                                    bool isDirectUse,
+                                   bool isDistributed,
                                    bool isOnSelfParameter)
 {
   // Get the accessor function. The type will be a polymorphic function if
   // the Self type is generic.
   Callee callee = getBaseAccessorFunctionRef(SGF, loc, constant, selfValue,
-                                             isSuper, isDirectUse,
+                                             isSuper, isDirectUse, isDistributed,
                                              substitutions, isOnSelfParameter);
   
   // Collect captures if the accessor has them.
@@ -5771,15 +5775,23 @@ SILDeclRef SILGenModule::getAccessorDeclRef(AccessorDecl *accessor) {
 RValue SILGenFunction::emitGetAccessor(SILLocation loc, SILDeclRef get,
                                        SubstitutionMap substitutions,
                                        ArgumentSource &&selfValue, bool isSuper,
-                                       bool isDirectUse,
+                                       bool isDirectUse, bool isDistributed,
                                        PreparedArguments &&subscriptIndices,
-                                       SGFContext c, bool isOnSelfParameter) {
+                                       SGFContext c,
+                                       bool isOnSelfParameter) {
   // Scope any further writeback just within this operation.
   FormalEvaluationScope writebackScope(*this);
 
+  auto constant = get;
+
+//  if (isDistributed) {
+//    get.dump();
+//    assert(false && "should use dist thunk");
+//  }
+
   Callee getter = emitSpecializedAccessorFunctionRef(
-      *this, loc, get, substitutions, selfValue, isSuper, isDirectUse,
-      isOnSelfParameter);
+      *this, loc, constant, substitutions, selfValue, isSuper, isDirectUse,
+      isDistributed, isOnSelfParameter);
   bool hasSelf = (bool)selfValue;
   CanAnyFunctionType accessType = getter.getSubstFormalType();
 
@@ -5812,7 +5824,7 @@ void SILGenFunction::emitSetAccessor(SILLocation loc, SILDeclRef set,
 
   Callee setter = emitSpecializedAccessorFunctionRef(
       *this, loc, set, substitutions, selfValue, isSuper, isDirectUse,
-      isOnSelfParameter);
+      /*isDistributed=*/false, isOnSelfParameter);
   bool hasSelf = (bool)selfValue;
   CanAnyFunctionType accessType = setter.getSubstFormalType();
 
@@ -5847,14 +5859,14 @@ void SILGenFunction::emitSetAccessor(SILLocation loc, SILDeclRef set,
 ManagedValue SILGenFunction::emitAddressorAccessor(
     SILLocation loc, SILDeclRef addressor, SubstitutionMap substitutions,
     ArgumentSource &&selfValue, bool isSuper, bool isDirectUse,
-    PreparedArguments &&subscriptIndices, SILType addressType,
-    bool isOnSelfParameter) {
+    bool isDistributed, PreparedArguments &&subscriptIndices,
+    SILType addressType, bool isOnSelfParameter) {
   // Scope any further writeback just within this operation.
   FormalEvaluationScope writebackScope(*this);
 
   Callee callee = emitSpecializedAccessorFunctionRef(
       *this, loc, addressor, substitutions, selfValue, isSuper, isDirectUse,
-      isOnSelfParameter);
+      isDistributed,  isOnSelfParameter);
   bool hasSelf = (bool)selfValue;
   CanAnyFunctionType accessType = callee.getSubstFormalType();
 
@@ -5909,7 +5921,9 @@ SILGenFunction::emitCoroutineAccessor(SILLocation loc, SILDeclRef accessor,
   Callee callee =
     emitSpecializedAccessorFunctionRef(*this, loc, accessor,
                                        substitutions, selfValue,
-                                       isSuper, isDirectUse, isOnSelfParameter);
+                                       isSuper, isDirectUse,
+                                       /*isDistributed=*/false,
+                                       isOnSelfParameter);
 
   // We're already in a full formal-evaluation scope.
   // Make a dead writeback scope; applyCoroutine won't try to pop this.

--- a/lib/SILGen/SILGenDistributed.cpp
+++ b/lib/SILGen/SILGenDistributed.cpp
@@ -212,6 +212,7 @@ void SILGenFunction::emitDistActorIdentityInit(ConstructorDecl *ctor,
   initializeProperty(*this, loc, borrowedSelfArg, var, temp);
 }
 
+// TODO(distributed): rename to DistributedActorID
 InitializeDistActorIdentity::InitializeDistActorIdentity(ConstructorDecl *ctor,
                                        ManagedValue actorSelf)
                                        : ctor(ctor),

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3504,23 +3504,6 @@ getIdForKeyPathComponentComputedProperty(SILGenModule &SGM,
     // stable identifier.
     return SGM.getFunction(getterRef, NotForDefinition);
   }
-//  case AccessStrategy::DirectToDistributedThunkAccessor: {
-//    assert(false && "dont need this");
-//    // Locate the distributed thunk for the getter of this property
-//    fprintf(stderr, "[%s:%d] (%s) CHECKING.... DirectToDistributedThunkAccessor\n", __FILE__, __LINE__, __FUNCTION__);
-//    auto representativeDecl = getRepresentativeAccessorForKeyPath(storage);
-//    assert(representativeDecl->isDistributed());
-//    fprintf(stderr, "[%s:%d] (%s) OK, representative is DIST\n", __FILE__, __LINE__, __FUNCTION__);
-//
-//    auto getterThunkRef = SILDeclRef(representativeDecl->getDistributedThunk(),
-//                                     SILDeclRef::Kind::Func,
-//                                     /*isForeign=*/false,
-//                                     /*isDistributed=*/true);
-//    fprintf(stderr, "[%s:%d] (%s) THUNK\n", __FILE__, __LINE__, __FUNCTION__);
-//    getterThunkRef.dump();
-//
-//    return SGM.getFunction(getterThunkRef, NotForDefinition);
-//  }
   case AccessStrategy::DispatchToAccessor: {
     // Identify the property by its vtable or wtable slot.
     return SGM.getAccessorDeclRef(getRepresentativeAccessorForKeyPath(storage));

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3508,6 +3508,14 @@ getIdForKeyPathComponentComputedProperty(SILGenModule &SGM,
     // Identify the property by its vtable or wtable slot.
     return SGM.getAccessorDeclRef(getRepresentativeAccessorForKeyPath(storage));
   }
+
+  case AccessStrategy::DispatchToDistributedThunk: {
+    auto thunkRef = SILDeclRef(cast<VarDecl>(storage)->getDistributedThunk(),
+                               SILDeclRef::Kind::Func,
+                               /*isForeign=*/false,
+                               /*isDistributed=*/true);
+    return SGM.getFunction(thunkRef, NotForDefinition);
+  }
   }
   llvm_unreachable("unhandled access strategy");
 }

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3504,6 +3504,23 @@ getIdForKeyPathComponentComputedProperty(SILGenModule &SGM,
     // stable identifier.
     return SGM.getFunction(getterRef, NotForDefinition);
   }
+//  case AccessStrategy::DirectToDistributedThunkAccessor: {
+//    assert(false && "dont need this");
+//    // Locate the distributed thunk for the getter of this property
+//    fprintf(stderr, "[%s:%d] (%s) CHECKING.... DirectToDistributedThunkAccessor\n", __FILE__, __LINE__, __FUNCTION__);
+//    auto representativeDecl = getRepresentativeAccessorForKeyPath(storage);
+//    assert(representativeDecl->isDistributed());
+//    fprintf(stderr, "[%s:%d] (%s) OK, representative is DIST\n", __FILE__, __LINE__, __FUNCTION__);
+//
+//    auto getterThunkRef = SILDeclRef(representativeDecl->getDistributedThunk(),
+//                                     SILDeclRef::Kind::Func,
+//                                     /*isForeign=*/false,
+//                                     /*isDistributed=*/true);
+//    fprintf(stderr, "[%s:%d] (%s) THUNK\n", __FILE__, __LINE__, __FUNCTION__);
+//    getterThunkRef.dump();
+//
+//    return SGM.getFunction(getterThunkRef, NotForDefinition);
+//  }
   case AccessStrategy::DispatchToAccessor: {
     // Identify the property by its vtable or wtable slot.
     return SGM.getAccessorDeclRef(getRepresentativeAccessorForKeyPath(storage));

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1444,6 +1444,7 @@ public:
                          SubstitutionMap substitutions,
                          ArgumentSource &&optionalSelfValue, bool isSuper,
                          bool isDirectAccessorUse,
+                         bool isDistributed,
                          PreparedArguments &&optionalSubscripts, SGFContext C,
                          bool isOnSelfParameter);
 
@@ -1477,7 +1478,8 @@ public:
   ManagedValue emitAddressorAccessor(
       SILLocation loc, SILDeclRef addressor, SubstitutionMap substitutions,
       ArgumentSource &&optionalSelfValue, bool isSuper,
-      bool isDirectAccessorUse, PreparedArguments &&optionalSubscripts,
+      bool isDirectAccessorUse, bool isDistributed,
+      PreparedArguments &&optionalSubscripts,
       SILType addressType, bool isOnSelfParameter);
 
   CleanupHandle emitCoroutineAccessor(SILLocation loc, SILDeclRef accessor,

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1444,7 +1444,6 @@ public:
                          SubstitutionMap substitutions,
                          ArgumentSource &&optionalSelfValue, bool isSuper,
                          bool isDirectAccessorUse,
-                         bool isDistributed,
                          PreparedArguments &&optionalSubscripts, SGFContext C,
                          bool isOnSelfParameter);
 
@@ -1478,7 +1477,7 @@ public:
   ManagedValue emitAddressorAccessor(
       SILLocation loc, SILDeclRef addressor, SubstitutionMap substitutions,
       ArgumentSource &&optionalSelfValue, bool isSuper,
-      bool isDirectAccessorUse, bool isDistributed,
+      bool isDirectAccessorUse,
       PreparedArguments &&optionalSubscripts,
       SILType addressType, bool isOnSelfParameter);
 

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1291,6 +1291,7 @@ namespace {
     SILDeclRef Accessor;
     bool IsSuper;
     bool IsDirectAccessorUse;
+    bool IsDistributedAccessor;
     bool IsOnSelfParameter;
     SubstitutionMap Substitutions;
     Optional<ActorIsolation> ActorIso;
@@ -1298,7 +1299,9 @@ namespace {
   public:
     AccessorBasedComponent(PathComponent::KindTy kind,
                            AbstractStorageDecl *decl, SILDeclRef accessor,
-                           bool isSuper, bool isDirectAccessorUse,
+                           bool isSuper,
+                           bool isDirectAccessorUse,
+                           bool isDistributedAccessor,
                            SubstitutionMap substitutions,
                            CanType baseFormalType, LValueTypeData typeData,
                            ArgumentList *argListForDiagnostics,
@@ -1309,7 +1312,9 @@ namespace {
                 std::move(indices)),
           Accessor(accessor), IsSuper(isSuper),
           IsDirectAccessorUse(isDirectAccessorUse),
-          IsOnSelfParameter(isOnSelfParameter), Substitutions(substitutions),
+          IsDistributedAccessor(isDistributedAccessor),
+          IsOnSelfParameter(isOnSelfParameter),
+          Substitutions(substitutions),
           ActorIso(actorIso) {}
 
     AccessorBasedComponent(const AccessorBasedComponent &copied,
@@ -1319,6 +1324,7 @@ namespace {
         Accessor(copied.Accessor),
         IsSuper(copied.IsSuper),
         IsDirectAccessorUse(copied.IsDirectAccessorUse),
+        IsDistributedAccessor(copied.IsDistributedAccessor),
         IsOnSelfParameter(copied.IsOnSelfParameter),
         Substitutions(copied.Substitutions),
         ActorIso(copied.ActorIso) {}
@@ -1334,7 +1340,9 @@ namespace {
 
      GetterSetterComponent(AbstractStorageDecl *decl,
                            SILDeclRef accessor,
-                           bool isSuper, bool isDirectAccessorUse,
+                           bool isSuper,
+                           bool isDirectAccessorUse,
+                           bool isDistributedAccessor,
                            SubstitutionMap substitutions,
                            CanType baseFormalType,
                            LValueTypeData typeData,
@@ -1343,10 +1351,16 @@ namespace {
                            bool isOnSelfParameter,
                            Optional<ActorIsolation> actorIso)
       : AccessorBasedComponent(GetterSetterKind, decl, accessor, isSuper,
-                               isDirectAccessorUse, substitutions,
+                               isDirectAccessorUse, isDistributedAccessor,
+                               substitutions,
                                baseFormalType, typeData, subscriptArgList,
-                               std::move(indices), isOnSelfParameter, actorIso)
+                               std::move(indices), isOnSelfParameter,
+                               actorIso)
     {
+       if (isDistributedAccessor) {
+         fprintf(stderr, "[%s:%d] (%s) DIST ACCESSOR GOOD!\n", __FILE__, __LINE__, __FUNCTION__);
+         decl->dump();
+       }
       assert(getAccessorDecl()->isGetterOrSetter());
     }
     
@@ -1457,6 +1471,7 @@ namespace {
              ArgumentSource &&value, ManagedValue base) && override {
       assert(getAccessorDecl()->isSetter());
       assert(!ActorIso && "no support for cross-actor set operations");
+      assert(!IsDistributedAccessor && "setters cannot be 'distributed'");
       SILDeclRef setter = Accessor;
 
       if (canRewriteSetAsPropertyWrapperInit(SGF) &&
@@ -1636,6 +1651,11 @@ namespace {
                ManagedValue base, SGFContext c) && override {
       assert(getAccessorDecl()->isGetter());
 
+      if (IsDistributedAccessor) {
+        fprintf(stderr, "[%s:%d] (%s) EMIT DIST GETTER\n", __FILE__, __LINE__, __FUNCTION__);
+        base.dump();
+      }
+
       SILDeclRef getter = Accessor;
       ExecutorBreadcrumb prevExecutor;
       RValue rvalue;
@@ -1650,7 +1670,8 @@ namespace {
 
         rvalue = SGF.emitGetAccessor(
             loc, getter, Substitutions, std::move(args.base), IsSuper,
-            IsDirectAccessorUse, std::move(args.Indices), c, IsOnSelfParameter);
+            IsDirectAccessorUse, IsDistributedAccessor, std::move(args.Indices), c,
+            IsOnSelfParameter);
 
       } // End the evaluation scope before any hop back to the current executor.
 
@@ -1792,14 +1813,17 @@ namespace {
     SILType SubstFieldType;
   public:
      AddressorComponent(AbstractStorageDecl *decl, SILDeclRef accessor,
-                        bool isSuper, bool isDirectAccessorUse,
+                        bool isSuper,
+                        bool isDirectAccessorUse,
+                        bool isDistributed,
                         SubstitutionMap substitutions,
                         CanType baseFormalType, LValueTypeData typeData,
                         SILType substFieldType,
                         ArgumentList *argListForDiagnostics,
                         PreparedArguments &&indices, bool isOnSelfParameter)
       : AccessorBasedComponent(AddressorKind, decl, accessor, isSuper,
-                               isDirectAccessorUse, substitutions,
+                               isDirectAccessorUse, isDistributed,
+                               substitutions,
                                baseFormalType, typeData,
                                argListForDiagnostics, std::move(indices),
                                isOnSelfParameter),
@@ -1821,8 +1845,8 @@ namespace {
             std::move(*this).prepareAccessorArgs(SGF, loc, base, Accessor);
         addr = SGF.emitAddressorAccessor(
             loc, Accessor, Substitutions, std::move(args.base), IsSuper,
-            IsDirectAccessorUse, std::move(args.Indices), SubstFieldType,
-            IsOnSelfParameter);
+            IsDirectAccessorUse, IsDistributedAccessor, std::move(args.Indices),
+            SubstFieldType, IsOnSelfParameter);
       }
 
       // Enter an unsafe access scope for the access.
@@ -1914,7 +1938,8 @@ namespace {
                                bool isOnSelfParameter)
         : AccessorBasedComponent(
               CoroutineAccessorKind, decl, accessor, isSuper,
-              isDirectAccessorUse, substitutions, baseFormalType, typeData,
+              isDirectAccessorUse, /*isDistributed=*/false,
+              substitutions, baseFormalType, typeData,
               argListForDiagnostics, std::move(indices), isOnSelfParameter) {}
 
     using AccessorBasedComponent::AccessorBasedComponent;
@@ -2639,6 +2664,9 @@ namespace {
         AccessKind(accessKind) {}
 
     void emitUsingStrategy(AccessStrategy strategy) {
+      auto var = dyn_cast<VarDecl>(Storage);
+      bool isDistributed = var && var->isDistributed();
+
       switch (strategy.getKind()) {
       case AccessStrategy::Storage: {
         auto typeData =
@@ -2648,10 +2676,15 @@ namespace {
       }
 
       case AccessStrategy::DirectToAccessor:
-        return asImpl().emitUsingAccessor(strategy.getAccessor(), true);
+        return asImpl()
+            .emitUsingAccessor(strategy.getAccessor(),
+                               /*isDirect=*/true,
+                               isDistributed);
 
       case AccessStrategy::DispatchToAccessor:
-        return asImpl().emitUsingAccessor(strategy.getAccessor(), false);
+        return asImpl().emitUsingAccessor(strategy.getAccessor(),
+                                          /*isDirect=*/false,
+                                          isDistributed);
 
       case AccessStrategy::MaterializeToTemporary: {
         auto typeData = getLogicalStorageTypeData(
@@ -2664,20 +2697,26 @@ namespace {
       llvm_unreachable("unknown kind");
     }
 
-    void emitUsingAccessor(AccessorKind accessorKind, bool isDirect) {
+    void emitUsingAccessor(AccessorKind accessorKind,
+                           bool isDirect,
+                           bool isDistributed) {
       auto accessor =
         SGF.SGM.getAccessorDeclRef(Storage->getOpaqueAccessor(accessorKind));
 
       switch (accessorKind) {
-      case AccessorKind::Get:
       case AccessorKind::Set: {
+        assert(!isDistributed && "setters must not be 'distributed'");
+        LLVM_FALLTHROUGH;
+      }
+      case AccessorKind::Get: {
         auto typeData = getLogicalStorageTypeData(
             SGF.getTypeExpansionContext(), SGF.SGM, AccessKind, FormalRValueType);
-        return asImpl().emitUsingGetterSetter(accessor, isDirect, typeData);
+        return asImpl().emitUsingGetterSetter(accessor, isDirect, isDistributed, typeData);
       }
 
       case AccessorKind::Address:
       case AccessorKind::MutableAddress: {
+        assert(!isDistributed);
         auto typeData =
             getPhysicalStorageTypeData(SGF.getTypeExpansionContext(), SGF.SGM,
                                        AccessKind, Storage, FormalRValueType);
@@ -2686,6 +2725,7 @@ namespace {
 
       case AccessorKind::Read:
       case AccessorKind::Modify: {
+        assert(!isDistributed);
         auto typeData =
             getPhysicalStorageTypeData(SGF.getTypeExpansionContext(), SGF.SGM,
                                        AccessKind, Storage, FormalRValueType);
@@ -2780,7 +2820,8 @@ void LValue::addNonMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
       SILType storageType =
         SGF.getLoweredType(Storage->getType()).getAddressType();
       LV.add<AddressorComponent>(Storage, addressor,
-                                 /*isSuper=*/false, isDirect, Subs,
+                                 /*isSuper=*/false, isDirect,
+                                 /*isDistributed=*/false, Subs,
                                  CanType(), typeData, storageType, nullptr,
                                  PreparedArguments(),
                                  /* isOnSelfParameter */ false);
@@ -2795,12 +2836,15 @@ void LValue::addNonMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
           PreparedArguments(), /*isOnSelfParameter*/ false);
     }
 
-    void emitUsingGetterSetter(SILDeclRef accessor, bool isDirect,
+    void emitUsingGetterSetter(SILDeclRef accessor,
+                               bool isDirect,
+                               bool isDistributed,
                                LValueTypeData typeData) {
       LV.add<GetterSetterComponent>(
           Storage, accessor,
-          /*isSuper=*/false, isDirect, Subs, CanType(), typeData, nullptr,
-          PreparedArguments(), /* isOnSelfParameter */ false,
+          /*isSuper=*/false, isDirect, isDistributed, Subs, CanType(), typeData,
+          nullptr, PreparedArguments(),
+          /*isOnSelfParameter=*/false,
           ActorIso);
     }
 
@@ -3274,7 +3318,8 @@ struct MemberStorageAccessEmitter : AccessEmitter<Impl, StorageType> {
     SILType varStorageType = SGF.SGM.Types.getSubstitutedStorageType(
         SGF.getTypeExpansionContext(), Storage, FormalRValueType);
 
-    LV.add<AddressorComponent>(Storage, addressor, IsSuper, isDirect, Subs,
+    LV.add<AddressorComponent>(Storage, addressor, IsSuper, isDirect,
+                               /*isDistributed=*/false, Subs,
                                BaseFormalType, typeData, varStorageType,
                                ArgListForDiagnostics, std::move(Indices),
                                IsOnSelfParameter);
@@ -3288,12 +3333,14 @@ struct MemberStorageAccessEmitter : AccessEmitter<Impl, StorageType> {
         ArgListForDiagnostics, std::move(Indices), IsOnSelfParameter);
   }
 
-  void emitUsingGetterSetter(SILDeclRef accessor, bool isDirect,
+  void emitUsingGetterSetter(SILDeclRef accessor,
+                             bool isDirect,
+                             bool isDistributed,
                              LValueTypeData typeData) {
     LV.add<GetterSetterComponent>(
-        Storage, accessor, IsSuper, isDirect, Subs, BaseFormalType, typeData,
-        ArgListForDiagnostics, std::move(Indices), IsOnSelfParameter,
-        ActorIso);
+        Storage, accessor, IsSuper, isDirect, isDistributed, Subs,
+        BaseFormalType, typeData, ArgListForDiagnostics, std::move(Indices),
+        IsOnSelfParameter, ActorIso);
   }
 
   void emitUsingMaterialization(AccessStrategy readStrategy,

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -3386,13 +3386,14 @@ void LValue::addMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
 
     void emitUsingDistributedThunk() {
       auto *var = cast<VarDecl>(Storage);
-      SILDeclRef accessor(var->getDistributedThunk(), SILDeclRef::Kind::Func,
+      SILDeclRef accessor(var->getAccessor(AccessorKind::Get),
+                          SILDeclRef::Kind::Func,
                           /*isForeign=*/false, /*isDistributed=*/true);
 
       auto typeData = getLogicalStorageTypeData(
           SGF.getTypeExpansionContext(), SGF.SGM, AccessKind, FormalRValueType);
 
-      asImpl().emitUsingGetterSetter(accessor, /*isDirect=*/false, typeData);
+      asImpl().emitUsingGetterSetter(accessor, /*isDirect=*/true, typeData);
     }
 
   } emitter(SGF, loc, var, subs, isSuper, accessKind,

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1357,10 +1357,6 @@ namespace {
                                std::move(indices), isOnSelfParameter,
                                actorIso)
     {
-       if (isDistributedAccessor) {
-         fprintf(stderr, "[%s:%d] (%s) DIST ACCESSOR GOOD!\n", __FILE__, __LINE__, __FUNCTION__);
-         decl->dump();
-       }
       assert(getAccessorDecl()->isGetterOrSetter());
     }
     
@@ -1650,11 +1646,6 @@ namespace {
     RValue get(SILGenFunction &SGF, SILLocation loc,
                ManagedValue base, SGFContext c) && override {
       assert(getAccessorDecl()->isGetter());
-
-      if (IsDistributedAccessor) {
-        fprintf(stderr, "[%s:%d] (%s) EMIT DIST GETTER\n", __FILE__, __LINE__, __FUNCTION__);
-        base.dump();
-      }
 
       SILDeclRef getter = Accessor;
       ExecutorBreadcrumb prevExecutor;
@@ -2664,7 +2655,6 @@ namespace {
         AccessKind(accessKind) {}
 
     void emitUsingStrategy(AccessStrategy strategy) {
-      auto var = dyn_cast<VarDecl>(Storage);
       bool isDistributed = var && var->isDistributed();
 
       switch (strategy.getKind()) {

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1291,7 +1291,6 @@ namespace {
     SILDeclRef Accessor;
     bool IsSuper;
     bool IsDirectAccessorUse;
-    bool IsDistributedAccessor;
     bool IsOnSelfParameter;
     SubstitutionMap Substitutions;
     Optional<ActorIsolation> ActorIso;
@@ -1301,7 +1300,6 @@ namespace {
                            AbstractStorageDecl *decl, SILDeclRef accessor,
                            bool isSuper,
                            bool isDirectAccessorUse,
-                           bool isDistributedAccessor,
                            SubstitutionMap substitutions,
                            CanType baseFormalType, LValueTypeData typeData,
                            ArgumentList *argListForDiagnostics,
@@ -1312,7 +1310,6 @@ namespace {
                 std::move(indices)),
           Accessor(accessor), IsSuper(isSuper),
           IsDirectAccessorUse(isDirectAccessorUse),
-          IsDistributedAccessor(isDistributedAccessor),
           IsOnSelfParameter(isOnSelfParameter),
           Substitutions(substitutions),
           ActorIso(actorIso) {}
@@ -1324,7 +1321,6 @@ namespace {
         Accessor(copied.Accessor),
         IsSuper(copied.IsSuper),
         IsDirectAccessorUse(copied.IsDirectAccessorUse),
-        IsDistributedAccessor(copied.IsDistributedAccessor),
         IsOnSelfParameter(copied.IsOnSelfParameter),
         Substitutions(copied.Substitutions),
         ActorIso(copied.ActorIso) {}
@@ -1342,7 +1338,6 @@ namespace {
                            SILDeclRef accessor,
                            bool isSuper,
                            bool isDirectAccessorUse,
-                           bool isDistributedAccessor,
                            SubstitutionMap substitutions,
                            CanType baseFormalType,
                            LValueTypeData typeData,
@@ -1351,8 +1346,7 @@ namespace {
                            bool isOnSelfParameter,
                            Optional<ActorIsolation> actorIso)
       : AccessorBasedComponent(GetterSetterKind, decl, accessor, isSuper,
-                               isDirectAccessorUse, isDistributedAccessor,
-                               substitutions,
+                               isDirectAccessorUse, substitutions,
                                baseFormalType, typeData, subscriptArgList,
                                std::move(indices), isOnSelfParameter,
                                actorIso)
@@ -1467,7 +1461,6 @@ namespace {
              ArgumentSource &&value, ManagedValue base) && override {
       assert(getAccessorDecl()->isSetter());
       assert(!ActorIso && "no support for cross-actor set operations");
-      assert(!IsDistributedAccessor && "setters cannot be 'distributed'");
       SILDeclRef setter = Accessor;
 
       if (canRewriteSetAsPropertyWrapperInit(SGF) &&
@@ -1661,7 +1654,7 @@ namespace {
 
         rvalue = SGF.emitGetAccessor(
             loc, getter, Substitutions, std::move(args.base), IsSuper,
-            IsDirectAccessorUse, IsDistributedAccessor, std::move(args.Indices), c,
+            IsDirectAccessorUse, std::move(args.Indices), c,
             IsOnSelfParameter);
 
       } // End the evaluation scope before any hop back to the current executor.
@@ -1806,14 +1799,13 @@ namespace {
      AddressorComponent(AbstractStorageDecl *decl, SILDeclRef accessor,
                         bool isSuper,
                         bool isDirectAccessorUse,
-                        bool isDistributed,
                         SubstitutionMap substitutions,
                         CanType baseFormalType, LValueTypeData typeData,
                         SILType substFieldType,
                         ArgumentList *argListForDiagnostics,
                         PreparedArguments &&indices, bool isOnSelfParameter)
       : AccessorBasedComponent(AddressorKind, decl, accessor, isSuper,
-                               isDirectAccessorUse, isDistributed,
+                               isDirectAccessorUse,
                                substitutions,
                                baseFormalType, typeData,
                                argListForDiagnostics, std::move(indices),
@@ -1836,7 +1828,7 @@ namespace {
             std::move(*this).prepareAccessorArgs(SGF, loc, base, Accessor);
         addr = SGF.emitAddressorAccessor(
             loc, Accessor, Substitutions, std::move(args.base), IsSuper,
-            IsDirectAccessorUse, IsDistributedAccessor, std::move(args.Indices),
+            IsDirectAccessorUse, std::move(args.Indices),
             SubstFieldType, IsOnSelfParameter);
       }
 
@@ -1929,7 +1921,7 @@ namespace {
                                bool isOnSelfParameter)
         : AccessorBasedComponent(
               CoroutineAccessorKind, decl, accessor, isSuper,
-              isDirectAccessorUse, /*isDistributed=*/false,
+              isDirectAccessorUse,
               substitutions, baseFormalType, typeData,
               argListForDiagnostics, std::move(indices), isOnSelfParameter) {}
 
@@ -2655,8 +2647,6 @@ namespace {
         AccessKind(accessKind) {}
 
     void emitUsingStrategy(AccessStrategy strategy) {
-      bool isDistributed = var && var->isDistributed();
-
       switch (strategy.getKind()) {
       case AccessStrategy::Storage: {
         auto typeData =
@@ -2668,13 +2658,11 @@ namespace {
       case AccessStrategy::DirectToAccessor:
         return asImpl()
             .emitUsingAccessor(strategy.getAccessor(),
-                               /*isDirect=*/true,
-                               isDistributed);
+                               /*isDirect=*/true);
 
       case AccessStrategy::DispatchToAccessor:
         return asImpl().emitUsingAccessor(strategy.getAccessor(),
-                                          /*isDirect=*/false,
-                                          isDistributed);
+                                          /*isDirect=*/false);
 
       case AccessStrategy::MaterializeToTemporary: {
         auto typeData = getLogicalStorageTypeData(
@@ -2691,25 +2679,22 @@ namespace {
     }
 
     void emitUsingAccessor(AccessorKind accessorKind,
-                           bool isDirect,
-                           bool isDistributed) {
+                           bool isDirect) {
       auto accessor =
         SGF.SGM.getAccessorDeclRef(Storage->getOpaqueAccessor(accessorKind));
 
       switch (accessorKind) {
       case AccessorKind::Set: {
-        assert(!isDistributed && "setters must not be 'distributed'");
         LLVM_FALLTHROUGH;
       }
       case AccessorKind::Get: {
         auto typeData = getLogicalStorageTypeData(
             SGF.getTypeExpansionContext(), SGF.SGM, AccessKind, FormalRValueType);
-        return asImpl().emitUsingGetterSetter(accessor, isDirect, isDistributed, typeData);
+        return asImpl().emitUsingGetterSetter(accessor, isDirect, typeData);
       }
 
       case AccessorKind::Address:
       case AccessorKind::MutableAddress: {
-        assert(!isDistributed);
         auto typeData =
             getPhysicalStorageTypeData(SGF.getTypeExpansionContext(), SGF.SGM,
                                        AccessKind, Storage, FormalRValueType);
@@ -2718,7 +2703,6 @@ namespace {
 
       case AccessorKind::Read:
       case AccessorKind::Modify: {
-        assert(!isDistributed);
         auto typeData =
             getPhysicalStorageTypeData(SGF.getTypeExpansionContext(), SGF.SGM,
                                        AccessKind, Storage, FormalRValueType);
@@ -2813,8 +2797,7 @@ void LValue::addNonMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
       SILType storageType =
         SGF.getLoweredType(Storage->getType()).getAddressType();
       LV.add<AddressorComponent>(Storage, addressor,
-                                 /*isSuper=*/false, isDirect,
-                                 /*isDistributed=*/false, Subs,
+                                 /*isSuper=*/false, isDirect, Subs,
                                  CanType(), typeData, storageType, nullptr,
                                  PreparedArguments(),
                                  /* isOnSelfParameter */ false);
@@ -2831,11 +2814,10 @@ void LValue::addNonMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
 
     void emitUsingGetterSetter(SILDeclRef accessor,
                                bool isDirect,
-                               bool isDistributed,
                                LValueTypeData typeData) {
       LV.add<GetterSetterComponent>(
           Storage, accessor,
-          /*isSuper=*/false, isDirect, isDistributed, Subs, CanType(), typeData,
+          /*isSuper=*/false, isDirect, Subs, CanType(), typeData,
           nullptr, PreparedArguments(),
           /*isOnSelfParameter=*/false,
           ActorIso);
@@ -3316,8 +3298,7 @@ struct MemberStorageAccessEmitter : AccessEmitter<Impl, StorageType> {
     SILType varStorageType = SGF.SGM.Types.getSubstitutedStorageType(
         SGF.getTypeExpansionContext(), Storage, FormalRValueType);
 
-    LV.add<AddressorComponent>(Storage, addressor, IsSuper, isDirect,
-                               /*isDistributed=*/false, Subs,
+    LV.add<AddressorComponent>(Storage, addressor, IsSuper, isDirect, Subs,
                                BaseFormalType, typeData, varStorageType,
                                ArgListForDiagnostics, std::move(Indices),
                                IsOnSelfParameter);
@@ -3333,10 +3314,9 @@ struct MemberStorageAccessEmitter : AccessEmitter<Impl, StorageType> {
 
   void emitUsingGetterSetter(SILDeclRef accessor,
                              bool isDirect,
-                             bool isDistributed,
                              LValueTypeData typeData) {
     LV.add<GetterSetterComponent>(
-        Storage, accessor, IsSuper, isDirect, isDistributed, Subs,
+        Storage, accessor, IsSuper, isDirect, Subs,
         BaseFormalType, typeData, ArgListForDiagnostics, std::move(Indices),
         IsOnSelfParameter, ActorIso);
   }
@@ -3412,8 +3392,7 @@ void LValue::addMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
       auto typeData = getLogicalStorageTypeData(
           SGF.getTypeExpansionContext(), SGF.SGM, AccessKind, FormalRValueType);
 
-      asImpl().emitUsingGetterSetter(accessor, /*isDirect=*/false,
-                                     /*isDistributed=*/true, typeData);
+      asImpl().emitUsingGetterSetter(accessor, /*isDirect=*/false, typeData);
     }
 
   } emitter(SGF, loc, var, subs, isSuper, accessKind,

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -1161,6 +1161,12 @@ public:
       SGM.emitPropertyWrapperBackingInitializer(vd);
     }
 
+    if (auto *thunk = vd->getDistributedThunk()) {
+      auto thunkRef = SILDeclRef(thunk).asDistributed();
+      SGM.emitFunctionDefinition(thunkRef,
+                                 SGM.getFunction(thunkRef, ForDefinition));
+    }
+
     visitAbstractStorageDecl(vd);
   }
 
@@ -1287,6 +1293,13 @@ public:
         return;
       }
     }
+
+    if (auto *thunk = vd->getDistributedThunk()) {
+      auto thunkRef = SILDeclRef(thunk).asDistributed();
+      SGM.emitFunctionDefinition(thunkRef,
+                                 SGM.getFunction(thunkRef, ForDefinition));
+    }
+
     visitAbstractStorageDecl(vd);
   }
 

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -725,11 +725,28 @@ static FuncDecl *createDistributedThunkFunction(FuncDecl *func) {
   }
   ParameterList *params = ParameterList::create(C, paramDecls); // = funcParams->clone(C);
 
-  auto thunk = FuncDecl::createImplicit(
-      C, swift::StaticSpellingKind::None, thunkName, SourceLoc(),
-      /*async=*/true, /*throws=*/true,
-      genericParamList, params,
-      func->getResultInterfaceType(), DC);
+  FuncDecl *thunk = nullptr;
+  if (auto *accessor = dyn_cast<AccessorDecl>(func)) {
+    auto *distributedVar = cast<VarDecl>(accessor->getStorage());
+
+    thunk = AccessorDecl::create(
+        C, /*declLoc=*/accessor->getLoc(), /*accessorKeywordLoc=*/SourceLoc(),
+        AccessorKind::Get, distributedVar,
+        /*staticLoc=*/SourceLoc(), StaticSpellingKind::None,
+        /*async=*/true, /*asyncLoc=*/SourceLoc(),
+        /*throws=*/true, /*throwsLoc=*/SourceLoc(), genericParamList, params,
+        func->getResultInterfaceType(), accessor->getDeclContext());
+
+    thunk->setImplicit();
+  } else {
+    thunk = FuncDecl::createImplicit(
+        C, swift::StaticSpellingKind::None, func->getName(), SourceLoc(),
+        /*async=*/true, /*throws=*/true, genericParamList, params,
+        func->getResultInterfaceType(), DC);
+  }
+
+  assert(thunk && "couldn't create a distributed thunk");
+
   thunk->setSynthesized(true);
   thunk->setDistributedThunk(true);
   thunk->getAttrs().add(new (C) NonisolatedAttr(/*isImplicit=*/true));

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -725,25 +725,10 @@ static FuncDecl *createDistributedThunkFunction(FuncDecl *func) {
   }
   ParameterList *params = ParameterList::create(C, paramDecls); // = funcParams->clone(C);
 
-  FuncDecl *thunk = nullptr;
-  if (auto *accessor = dyn_cast<AccessorDecl>(func)) {
-    auto *distributedVar = cast<VarDecl>(accessor->getStorage());
-
-    thunk = AccessorDecl::create(
-        C, /*declLoc=*/accessor->getLoc(), /*accessorKeywordLoc=*/SourceLoc(),
-        AccessorKind::Get, distributedVar,
-        /*staticLoc=*/SourceLoc(), StaticSpellingKind::None,
-        /*async=*/true, /*asyncLoc=*/SourceLoc(),
-        /*throws=*/true, /*throwsLoc=*/SourceLoc(), genericParamList, params,
-        func->getResultInterfaceType(), accessor->getDeclContext());
-
-    thunk->setImplicit();
-  } else {
-    thunk = FuncDecl::createImplicit(
-        C, swift::StaticSpellingKind::None, func->getName(), SourceLoc(),
-        /*async=*/true, /*throws=*/true, genericParamList, params,
-        func->getResultInterfaceType(), DC);
-  }
+  FuncDecl *thunk = FuncDecl::createImplicit(
+      C, swift::StaticSpellingKind::None, thunkName, SourceLoc(),
+      /*async=*/true, /*throws=*/true, genericParamList, params,
+      func->getResultInterfaceType(), DC);
 
   assert(thunk && "couldn't create a distributed thunk");
 

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -216,7 +216,6 @@ deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
 
   auto selfDecl = thunk->getImplicitSelfDecl();
   selfDecl->getAttrs().add(new (C) KnownToBeLocalAttr(implicit));
-  auto selfRefExpr = new (C) DeclRefExpr(selfDecl, dloc, implicit);
 
   // === return type
   Type returnTy = func->getResultInterfaceType();
@@ -242,8 +241,8 @@ deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
   Type remoteCallTargetTy = RCT->getDeclaredInterfaceType();
 
   // === __isRemoteActor(self)
-  ArgumentList *isRemoteArgs =
-      ArgumentList::forImplicitSingle(C, /*label=*/Identifier(), selfRefExpr);
+  ArgumentList *isRemoteArgs = ArgumentList::forImplicitSingle(
+      C, /*label=*/Identifier(), new (C) DeclRefExpr(selfDecl, dloc, implicit));
 
   FuncDecl *isRemoteFn = C.getIsRemoteDistributedActor();
   assert(isRemoteFn && "Could not find 'is remote' function, is the "
@@ -254,23 +253,53 @@ deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
       CallExpr::createImplicit(C, isRemoteDeclRef, isRemoteArgs);
 
   // === local branch ----------------------------------------------------------
-  // -- forward arguments
-  SmallVector<Expr*, 4> forwardingParams;
-  forwardParameters(thunk, forwardingParams);
-  auto funcRef = UnresolvedDeclRefExpr::createImplicit(C, func->getName());
-  auto forwardingArgList = ArgumentList::forImplicitCallTo(funcRef->getName(), forwardingParams, C);
+  BraceStmt *localBranchStmt;
+  if (auto accessor = dyn_cast<AccessorDecl>(func)) {
+    auto selfRefExpr = new (C) DeclRefExpr(selfDecl, dloc, implicit);
 
-  auto funcDeclRef =
-      UnresolvedDotExpr::createImplicit(C, selfRefExpr, func->getBaseName());
-  Expr *localFuncCall = CallExpr::createImplicit(C, funcDeclRef, forwardingArgList);
-  localFuncCall = AwaitExpr::createImplicit(C, sloc, localFuncCall);
-  if (func->hasThrows()) {
-    localFuncCall = TryExpr::createImplicit(C, sloc, localFuncCall);
+    auto var = accessor->getStorage();
+
+    auto varRef = UnresolvedDeclRefExpr::createImplicit(C, var->getName());
+    auto funcDeclRef =
+        UnresolvedDotExpr::createImplicit(C, selfRefExpr, var->getBaseName());
+
+    Expr *localPropertyAccess = new (C) MemberRefExpr(
+        selfRefExpr, sloc, ConcreteDeclRef(var), dloc, implicit);
+    localPropertyAccess =
+        AwaitExpr::createImplicit(C, sloc, localPropertyAccess);
+    if (accessor->hasThrows()) {
+      localPropertyAccess =
+          TryExpr::createImplicit(C, sloc, localPropertyAccess);
+    }
+
+    auto returnLocalPropertyAccess = new (C) ReturnStmt(sloc, localPropertyAccess, implicit);
+
+    fprintf(stderr, "[%s:%d] (%s) LOCAL BRANCH\n", __FILE__, __LINE__, __FUNCTION__);
+    returnLocalPropertyAccess->dump();
+    localBranchStmt =
+        BraceStmt::create(C, sloc, {returnLocalPropertyAccess}, sloc, implicit);
+  } else {
+    // normal function
+    auto selfRefExpr = new (C) DeclRefExpr(selfDecl, dloc, implicit);
+
+    // -- forward arguments
+    SmallVector<Expr*, 4> forwardingParams;
+    forwardParameters(thunk, forwardingParams);
+    auto funcRef = UnresolvedDeclRefExpr::createImplicit(C, func->getName());
+    auto forwardingArgList = ArgumentList::forImplicitCallTo(funcRef->getName(), forwardingParams, C);
+    auto funcDeclRef =
+        UnresolvedDotExpr::createImplicit(C, selfRefExpr, func->getBaseName());
+
+    Expr *localFuncCall = CallExpr::createImplicit(C, funcDeclRef, forwardingArgList);
+    localFuncCall = AwaitExpr::createImplicit(C, sloc, localFuncCall);
+    if (func->hasThrows()) {
+      localFuncCall = TryExpr::createImplicit(C, sloc, localFuncCall);
+    }
+    auto returnLocalFuncCall = new (C) ReturnStmt(sloc, localFuncCall, implicit);
+
+    localBranchStmt =
+        BraceStmt::create(C, sloc, {returnLocalFuncCall}, sloc, implicit);
   }
-  auto returnLocalFuncCall = new (C) ReturnStmt(sloc, localFuncCall, implicit);
-  auto localBranchStmt = 
-      BraceStmt::create(C, sloc, {returnLocalFuncCall}, sloc, implicit);
-
   // === remote branch  --------------------------------------------------------
   SmallVector<ASTNode, 8> remoteBranchStmts;
   // --- self.actorSystem

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -273,9 +273,6 @@ deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
     }
 
     auto returnLocalPropertyAccess = new (C) ReturnStmt(sloc, localPropertyAccess, implicit);
-
-    fprintf(stderr, "[%s:%d] (%s) LOCAL BRANCH\n", __FILE__, __LINE__, __FUNCTION__);
-    returnLocalPropertyAccess->dump();
     localBranchStmt =
         BraceStmt::create(C, sloc, {returnLocalPropertyAccess}, sloc, implicit);
   } else {

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -731,6 +731,7 @@ static FuncDecl *createDistributedThunkFunction(FuncDecl *func) {
       genericParamList, params,
       func->getResultInterfaceType(), DC);
   thunk->setSynthesized(true);
+  thunk->setDistributedThunk(true);
   thunk->getAttrs().add(new (C) NonisolatedAttr(/*isImplicit=*/true));
 
   if (isa<ClassDecl>(DC))

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -259,10 +259,6 @@ deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
 
     auto var = accessor->getStorage();
 
-    auto varRef = UnresolvedDeclRefExpr::createImplicit(C, var->getName());
-    auto funcDeclRef =
-        UnresolvedDotExpr::createImplicit(C, selfRefExpr, var->getBaseName());
-
     Expr *localPropertyAccess = new (C) MemberRefExpr(
         selfRefExpr, sloc, ConcreteDeclRef(var), dloc, implicit);
     localPropertyAccess =

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -822,6 +822,9 @@ FuncDecl *GetDistributedThunkRequest::evaluate(Evaluator &evaluator,
     if (!var->isDistributed())
       return nullptr;
 
+    if (checkDistributedActorProperty(var, /*diagnose=*/false))
+      return nullptr;
+
     distributedTarget = var->getAccessor(AccessorKind::Get);
   } else {
     distributedTarget = originator.get<AbstractFunctionDecl *>();
@@ -846,7 +849,8 @@ FuncDecl *GetDistributedThunkRequest::evaluate(Evaluator &evaluator,
   // we must avoid synthesis of the thunk because it'd also have errors,
   // giving an ugly user experience (errors in implicit code).
   if (distributedTarget->getInterfaceType()->hasError() ||
-      checkDistributedFunction(distributedTarget)) {
+      (!isa<AccessorDecl>(distributedTarget) &&
+       checkDistributedFunction(distributedTarget))) {
     return nullptr;
   }
 

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1424,10 +1424,7 @@ static void diagRecursivePropertyAccess(const Expr *E, const DeclContext *DC) {
           if (MRE->getAccessSemantics() == AccessSemantics::Ordinary) {
             bool shouldDiagnose = false;
             // Warn about any property access in the getter.
-            //
-            // Distributed thunks have to refer to the "local" version
-            // of the property directly with implicit `self.` base.
-            if (Accessor->isGetter() && !Accessor->isDistributedThunk())
+            if (Accessor->isGetter())
               shouldDiagnose = !isStore;
             // Warn about stores in the setter, but allow loads.
             if (Accessor->isSetter())

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1424,7 +1424,10 @@ static void diagRecursivePropertyAccess(const Expr *E, const DeclContext *DC) {
           if (MRE->getAccessSemantics() == AccessSemantics::Ordinary) {
             bool shouldDiagnose = false;
             // Warn about any property access in the getter.
-            if (Accessor->isGetter())
+            //
+            // Distributed thunks have to refer to the "local" version
+            // of the property directly with implicit `self.` base.
+            if (Accessor->isGetter() && !Accessor->isDistributedThunk())
               shouldDiagnose = !isStore;
             // Warn about stores in the setter, but allow loads.
             if (Accessor->isSetter())

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3905,11 +3905,7 @@ bool HasIsolatedSelfRequest::evaluate(
 
   // For accessors, consider the storage declaration.
   if (auto accessor = dyn_cast<AccessorDecl>(value)) {
-    // distributed thunks are accessors only in spirit and
-    // should be handled as regular functions from isolation
-    // perspective.
-    if (!accessor->isDistributedThunk())
-      value = accessor->getStorage();
+    value = accessor->getStorage();
   }
 
   // Check whether this member can be isolated to an actor at all.

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3910,8 +3910,13 @@ bool HasIsolatedSelfRequest::evaluate(
     return false;
 
   // For accessors, consider the storage declaration.
-  if (auto accessor = dyn_cast<AccessorDecl>(value))
-    value = accessor->getStorage();
+  if (auto accessor = dyn_cast<AccessorDecl>(value)) {
+    // distributed thunks are accessors only in spirit and
+    // should be handled as regular functions from isolation
+    // perspective.
+    if (!accessor->isDistributedThunk())
+      value = accessor->getStorage();
+  }
 
   // Check whether this member can be isolated to an actor at all.
   auto memberIsolation = getMemberIsolationPropagation(value);

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2302,35 +2302,12 @@ namespace {
         }
       }
 
-      // Cannot reference subscripts, or stored properties.
-      auto var = dyn_cast<VarDecl>(decl);
-      if (isa<SubscriptDecl>(decl) || var) {
-        // But computed distributed properties are okay,
-        // and treated the same as a distributed func.
-        if (var && var->isDistributed()) {
-          bool explicitlyThrowing = false;
-          if (auto getter = var->getAccessor(swift::AccessorKind::Get)) {
-            explicitlyThrowing = getter->hasThrows();
-          }
-          return std::make_pair(
-              /*setThrows*/!explicitlyThrowing,
-              /*isDistributedThunk=*/true);
-        }
-
-        // otherwise, it was a normal property or subscript and therefore illegal
-        ctx.Diags.diagnose(
-            declLoc, diag::distributed_actor_isolated_non_self_reference,
-            decl->getDescriptiveKind(), decl->getName());
-        noteIsolatedActorMember(decl, context);
-        return None;
-      }
-
       // Check that we have a distributed function or computed property.
       if (auto afd = dyn_cast<AbstractFunctionDecl>(decl)) {
         if (!afd->isDistributed()) {
-          ctx.Diags.diagnose(declLoc,
-                             diag::distributed_actor_isolated_method)
-              .fixItInsert(decl->getAttributeInsertionLoc(true), "distributed ");
+          ctx.Diags.diagnose(declLoc, diag::distributed_actor_isolated_method)
+              .fixItInsert(decl->getAttributeInsertionLoc(true),
+                           "distributed ");
 
           noteIsolatedActorMember(decl, context);
           return None;
@@ -2341,7 +2318,24 @@ namespace {
             /*isDistributedThunk=*/true);
       }
 
-      return std::make_pair(/*setThrows=*/false, /*distributedThunk=*/false);
+      if (auto *var = dyn_cast<VarDecl>(decl)) {
+        if (var->isDistributed()) {
+          bool explicitlyThrowing = false;
+          if (auto getter = var->getAccessor(swift::AccessorKind::Get)) {
+            explicitlyThrowing = getter->hasThrows();
+          }
+          return std::make_pair(
+              /*setThrows*/ !explicitlyThrowing,
+              /*isDistributedThunk=*/true);
+        }
+      }
+
+      // This is either non-distributed variable, subscript, or something else.
+      ctx.Diags.diagnose(declLoc,
+                         diag::distributed_actor_isolated_non_self_reference,
+                         decl->getDescriptiveKind(), decl->getName());
+      noteIsolatedActorMember(decl, context);
+      return None;
     }
 
     /// Attempts to identify and mark a valid cross-actor use of a synchronous

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -431,10 +431,11 @@ static bool varIsSafeAcrossActors(const ModuleDecl *fromModule,
     if (var->getAttrs().hasAttribute<NonisolatedAttr>())
       return true;
 
-    // If it's distributed, it's not okay.
-    if (auto nominalParent = var->getDeclContext()->getSelfNominalTypeDecl())
+    // If it's distributed, generally variable access is not okay...
+    if (auto nominalParent = var->getDeclContext()->getSelfNominalTypeDecl()) {
       if (nominalParent->isDistributedActor())
         return false;
+    }
 
     // If it's actor-isolated but in the same module, then it's OK too.
     return (fromModule == var->getDeclContext()->getParentModule());
@@ -2292,15 +2293,7 @@ namespace {
     Optional<std::pair<bool, bool>>
     checkDistributedAccess(SourceLoc declLoc, ValueDecl *decl,
                            Expr *context) {
-      // Cannot reference properties or subscripts of distributed actors.
-      if (isPropOrSubscript(decl)) {
-        ctx.Diags.diagnose(
-            declLoc, diag::distributed_actor_isolated_non_self_reference,
-            decl->getDescriptiveKind(), decl->getName());
-        noteIsolatedActorMember(decl, context);
-        return None;
-      }
-
+      // If base of the call is 'local' we permit skip distributed checks.
       if (auto baseSelf = findReferencedBaseSelf(context)) {
         if (baseSelf->getAttrs().hasAttribute<KnownToBeLocalAttr>()) {
         return std::make_pair(
@@ -2309,20 +2302,48 @@ namespace {
         }
       }
 
-      // Check that we have a distributed function.
-      auto func = dyn_cast<AbstractFunctionDecl>(decl);
-      if (!func || !func->isDistributed()) {
-        ctx.Diags.diagnose(declLoc,
-                           diag::distributed_actor_isolated_method)
-          .fixItInsert(decl->getAttributeInsertionLoc(true), "distributed ");
+      // Cannot reference subscripts, or stored properties.
+      auto var = dyn_cast<VarDecl>(decl);
+      if (isa<SubscriptDecl>(decl) || var) {
+        // But computed distributed properties are okay,
+        // and treated the same as a distributed func.
+        if (var && var->isDistributed()) {
+          fprintf(stderr, "[%s:%d] (%s) HERE\n", __FILE__, __LINE__, __FUNCTION__);
+          var->dump();
+          bool explicitlyThrowing = false;
+          if (auto getter = var->getAccessor(swift::AccessorKind::Get)) {
+            explicitlyThrowing = getter->hasThrows();
+          }
+          return std::make_pair(
+              /*setThrows*/!explicitlyThrowing,
+              /*isDistributedThunk=*/true);
+        }
 
+        // otherwise, it was a normal property or subscript and therefore illegal
+        ctx.Diags.diagnose(
+            declLoc, diag::distributed_actor_isolated_non_self_reference,
+            decl->getDescriptiveKind(), decl->getName());
         noteIsolatedActorMember(decl, context);
         return None;
       }
 
-      return std::make_pair(
-          /*setThrows=*/!func->hasThrows(),
-          /*isDistributedThunk=*/true);
+      // Check that we have a distributed function or computed property.
+      if (auto afd = dyn_cast<AbstractFunctionDecl>(decl)) {
+        if (!afd->isDistributed()) {
+          ctx.Diags.diagnose(declLoc,
+                             diag::distributed_actor_isolated_method)
+              .fixItInsert(decl->getAttributeInsertionLoc(true), "distributed ");
+
+          noteIsolatedActorMember(decl, context);
+          return None;
+        }
+
+        return std::make_pair(
+            /*setThrows=*/!afd->hasThrows(),
+            /*isDistributedThunk=*/true);
+      }
+
+      return std::make_pair(/*setThrows=*/false, /*distributedThunk=*/false);
     }
 
     /// Attempts to identify and mark a valid cross-actor use of a synchronous
@@ -2339,8 +2360,34 @@ namespace {
       // is it an access to a property?
       if (isPropOrSubscript(decl)) {
         // Cannot reference properties or subscripts of distributed actors.
-        if (isDistributed && !checkDistributedAccess(declLoc, decl, context))
-          return AsyncMarkingResult::NotDistributed;
+        fprintf(stderr, "[%s:%d] (%s) prop\n", __FILE__, __LINE__, __FUNCTION__);
+        if (isDistributed) {
+          fprintf(stderr, "[%s:%d] (%s) prop is dist\n", __FILE__, __LINE__, __FUNCTION__);
+
+          bool setThrows = false;
+          bool usesDistributedThunk = false;
+          if (auto access = checkDistributedAccess(declLoc, decl, context)) {
+            std::tie(setThrows, usesDistributedThunk) = *access;
+          } else {
+            fprintf(stderr, "[%s:%d] (%s) prop is dist -> NOPE \n", __FILE__, __LINE__, __FUNCTION__);
+            return AsyncMarkingResult::NotDistributed;
+          }
+
+          // distributed computed property access, mark it throws + async
+          if (auto lookupExpr = dyn_cast_or_null<LookupExpr>(context)) {
+            if (auto memberRef = dyn_cast<MemberRefExpr>(lookupExpr)) {
+              fprintf(stderr, "[%s:%d] (%s) SET DISTRIBUTED MEMBER REF\n", __FILE__, __LINE__, __FUNCTION__);
+              memberRef->dump();
+
+              memberRef->setImplicitlyThrows(true);
+              memberRef->setShouldApplyLookupDistributedThunk(true);
+            } else {
+              llvm_unreachable("expected distributed prop to be a MemberRef");
+            }
+          } else {
+            llvm_unreachable("expected distributed prop to have LookupExpr");
+          }
+        }
 
         if (auto declRef = dyn_cast_or_null<DeclRefExpr>(context)) {
           if (usageEnv(declRef) == VarRefUseEnv::Read) {
@@ -2398,10 +2445,12 @@ namespace {
         bool setThrows = false;
         bool usesDistributedThunk = false;
         if (isDistributed) {
-          if (auto access = checkDistributedAccess(declLoc, decl, context))
+          if (auto access = checkDistributedAccess(declLoc, decl, context)) {
             std::tie(setThrows, usesDistributedThunk) = *access;
-          else
+            fprintf(stderr, "[%s:%d] (%s) USE THUNK\n", __FILE__, __LINE__, __FUNCTION__);
+          } else {
             return AsyncMarkingResult::NotDistributed;
+          }
         }
 
         // Mark call as implicitly 'async', and also potentially as

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2308,8 +2308,6 @@ namespace {
         // But computed distributed properties are okay,
         // and treated the same as a distributed func.
         if (var && var->isDistributed()) {
-          fprintf(stderr, "[%s:%d] (%s) HERE\n", __FILE__, __LINE__, __FUNCTION__);
-          var->dump();
           bool explicitlyThrowing = false;
           if (auto getter = var->getAccessor(swift::AccessorKind::Get)) {
             explicitlyThrowing = getter->hasThrows();
@@ -2360,25 +2358,18 @@ namespace {
       // is it an access to a property?
       if (isPropOrSubscript(decl)) {
         // Cannot reference properties or subscripts of distributed actors.
-        fprintf(stderr, "[%s:%d] (%s) prop\n", __FILE__, __LINE__, __FUNCTION__);
         if (isDistributed) {
-          fprintf(stderr, "[%s:%d] (%s) prop is dist\n", __FILE__, __LINE__, __FUNCTION__);
-
           bool setThrows = false;
           bool usesDistributedThunk = false;
           if (auto access = checkDistributedAccess(declLoc, decl, context)) {
             std::tie(setThrows, usesDistributedThunk) = *access;
           } else {
-            fprintf(stderr, "[%s:%d] (%s) prop is dist -> NOPE \n", __FILE__, __LINE__, __FUNCTION__);
             return AsyncMarkingResult::NotDistributed;
           }
 
           // distributed computed property access, mark it throws + async
           if (auto lookupExpr = dyn_cast_or_null<LookupExpr>(context)) {
             if (auto memberRef = dyn_cast<MemberRefExpr>(lookupExpr)) {
-              fprintf(stderr, "[%s:%d] (%s) SET DISTRIBUTED MEMBER REF\n", __FILE__, __LINE__, __FUNCTION__);
-              memberRef->dump();
-
               memberRef->setImplicitlyThrows(true);
               memberRef->setShouldApplyLookupDistributedThunk(true);
             } else {
@@ -2447,7 +2438,6 @@ namespace {
         if (isDistributed) {
           if (auto access = checkDistributedAccess(declLoc, decl, context)) {
             std::tie(setThrows, usesDistributedThunk) = *access;
-            fprintf(stderr, "[%s:%d] (%s) USE THUNK\n", __FILE__, __LINE__, __FUNCTION__);
           } else {
             return AsyncMarkingResult::NotDistributed;
           }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2371,7 +2371,7 @@ namespace {
           if (auto lookupExpr = dyn_cast_or_null<LookupExpr>(context)) {
             if (auto memberRef = dyn_cast<MemberRefExpr>(lookupExpr)) {
               memberRef->setImplicitlyThrows(true);
-              memberRef->setShouldApplyLookupDistributedThunk(true);
+              memberRef->setAccessViaDistributedThunk();
             } else {
               llvm_unreachable("expected distributed prop to be a MemberRef");
             }

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1612,7 +1612,6 @@ namespace  {
 
     UNINTERESTING_ATTR(UnsafeInheritExecutor)
     UNINTERESTING_ATTR(CompilerInitialized)
-
 #undef UNINTERESTING_ATTR
 
     void visitAvailableAttr(AvailableAttr *attr) {

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -421,9 +421,9 @@ static bool checkDistributedTargetResultType(
             addCodableFixIt(resultNominalType, diag);
           }
         }
-
-        return true;
-      }
+      } // end if: diagnose
+      
+      return true;
     }
   }
 

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -26,6 +26,7 @@
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/TypeVisitor.h"
 #include "swift/AST/ExistentialLayout.h"
+#include "swift/Basic/Defer.h"
 
 using namespace swift;
 
@@ -583,23 +584,26 @@ bool swift::checkDistributedActorProperty(VarDecl *var, bool diagnose) {
 
   /// === Check if the declaration is a valid combination of attributes
   if (var->isStatic()) {
-    var->diagnose(diag::distributed_property_cannot_be_static,
-                      var->getName());
+    if (diagnose)
+      var->diagnose(diag::distributed_property_cannot_be_static,
+                    var->getName());
     // TODO(distributed): fixit, offer removing the static keyword
     return true;
   }
 
   // it is not a computed property
   if (var->isLet() || var->hasStorageOrWrapsStorage()) {
-    var->diagnose(diag::distributed_property_can_only_be_computed,
-                  var->getDescriptiveKind(), var->getName());
+    if (diagnose)
+      var->diagnose(diag::distributed_property_can_only_be_computed,
+                    var->getDescriptiveKind(), var->getName());
     return true;
   }
 
   // distributed properties cannot have setters
   if (var->getWriteImpl() != swift::WriteImplKind::Immutable) {
-    var->diagnose(diag::distributed_property_can_only_be_computed_get_only,
-                  var->getName());
+    if (diagnose)
+      var->diagnose(diag::distributed_property_can_only_be_computed_get_only,
+                    var->getName());
     return true;
   }
 

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -483,7 +483,12 @@ bool swift::checkDistributedFunction(AbstractFunctionDecl *func) {
 
 bool CheckDistributedFunctionRequest::evaluate(
     Evaluator &evaluator, AbstractFunctionDecl *func) const {
-  assert(func->isDistributed());
+  if (auto *accessor = dyn_cast<AccessorDecl>(func)) {
+    auto *var = cast<VarDecl>(accessor->getStorage());
+    assert(var->isDistributed() && accessor->isGetter());
+  } else {
+    assert(func->isDistributed());
+  }
 
   auto &C = func->getASTContext();
   auto DC = func->getDeclContext();
@@ -654,6 +659,18 @@ void TypeChecker::checkDistributedActor(SourceFile *SF, NominalTypeDecl *nominal
   (void)nominal->getDefaultInitializer();
 
   for (auto member : nominal->getMembers()) {
+    // A distributed computed property needs to have a thunk for
+    // its getter accessor.
+    if (auto *var = dyn_cast<VarDecl>(member)) {
+      if (!var->isDistributed())
+        continue;
+
+      if (auto thunk = var->getDistributedThunk())
+        SF->DelayedFunctions.push_back(thunk);
+
+      continue;
+    }
+
     // --- Ensure all thunks
     if (auto func = dyn_cast<AbstractFunctionDecl>(member)) {
       if (!func->isDistributed())

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3320,6 +3320,7 @@ public:
     bool overriddenAffectsABI, needsNewVTableEntry, isTransparent;
     DeclID opaqueReturnTypeID;
     bool isUserAccessible;
+    bool isDistributedThunk;
     ArrayRef<uint64_t> nameAndDependencyIDs;
 
     if (!isAccessor) {
@@ -3338,6 +3339,7 @@ public:
                                           needsNewVTableEntry,
                                           opaqueReturnTypeID,
                                           isUserAccessible,
+                                          isDistributedThunk,
                                           nameAndDependencyIDs);
     } else {
       decls_block::AccessorLayout::readRecord(scratch, contextID, isImplicit,
@@ -3355,6 +3357,7 @@ public:
                                               rawAccessLevel,
                                               needsNewVTableEntry,
                                               isTransparent,
+                                              isDistributedThunk,
                                               nameAndDependencyIDs);
     }
 
@@ -3530,6 +3533,8 @@ public:
 
     if (!isAccessor)
       fn->setUserAccessible(isUserAccessible);
+
+    fn->setDistributedThunk(isDistributedThunk);
 
     return fn;
   }

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 695; // existential Any and AnyObject
+const uint16_t SWIFTMODULE_VERSION_MINOR = 696; // `distributed thunk` bit on `AbstractFunctionDecl`
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1451,6 +1451,7 @@ namespace decls_block {
     BCFixed<1>,   // requires a new vtable slot
     DeclIDField,  // opaque result type decl
     BCFixed<1>,   // isUserAccessible?
+    BCFixed<1>,   // is distributed thunk
     BCArray<IdentifierIDField> // name components,
                                // followed by TypeID dependencies
     // The record is trailed by:
@@ -1502,6 +1503,7 @@ namespace decls_block {
     AccessLevelField, // access level
     BCFixed<1>,   // requires a new vtable slot
     BCFixed<1>,   // is transparent
+    BCFixed<1>,   // is distributed thunk
     BCArray<IdentifierIDField> // name components,
                                // followed by TypeID dependencies
     // The record is trailed by:

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3891,6 +3891,7 @@ public:
                            fn->needsNewVTableEntry(),
                            S.addDeclRef(fn->getOpaqueResultTypeDecl()),
                            fn->isUserAccessible(),
+                           fn->isDistributedThunk(),
                            nameComponentsAndDependencies);
 
     writeGenericParams(fn->getGenericParams());
@@ -4002,6 +4003,7 @@ public:
                                rawAccessLevel,
                                fn->needsNewVTableEntry(),
                                fn->isTransparent(),
+                               fn->isDistributedThunk(),
                                dependencies);
 
     writeGenericParams(fn->getGenericParams());

--- a/stdlib/public/Distributed/DistributedActorSystem.swift
+++ b/stdlib/public/Distributed/DistributedActorSystem.swift
@@ -79,7 +79,7 @@ public protocol DistributedActorSystem: Sendable {
   /// to the same actor.
   func assignID<Act>(_ actorType: Act.Type) -> ActorID
     where Act: DistributedActor,
-    Act.ID == ActorID
+          Act.ID == ActorID
 
   /// Invoked during a distributed actor's initialization, as soon as it becomes fully initialized.
   ///
@@ -98,7 +98,7 @@ public protocol DistributedActorSystem: Sendable {
   /// - Parameter actor: reference to the (local) actor that was just fully initialized.
   func actorReady<Act>(_ actor: Act)
     where Act: DistributedActor,
-    Act.ID == ActorID
+          Act.ID == ActorID
 
   /// Called during when a distributed actor is deinitialized, or fails to initialize completely (e.g. by throwing
   /// out of an `init` that did not completely initialize all of the actors stored properties yet).

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_computedProperty.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_computedProperty.swift
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-build-swift -module-name main -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s --color
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// rdar://76038845
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+// FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
+// UNSUPPORTED: windows
+
+import Distributed
+import FakeDistributedActorSystems
+
+typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
+
+distributed actor Greeter {
+  distributed var theDistributedProperty: String {
+    "Patrik the Seastar"
+  }
+}
+
+func test() async throws {
+  let system = DefaultDistributedActorSystem()
+
+  let local = Greeter(actorSystem: system)
+  let ref = try Greeter.resolve(id: local.id, using: system)
+
+  let reply = try await ref.theDistributedProperty
+  // CHECK: >> remoteCall: on:main.Greeter, target:main.Greeter.name, invocation:FakeInvocationEncoder(genericSubs: [], arguments: [], returnType: Optional(Swift.String), errorType: nil), throwing:Swift.Never, returning:Swift.String
+  // CHECK: << remoteCall return: Patrick the Seastar
+  print("reply: \(reply)")
+  // CHECK: reply: Echo: Caplin
+}
+
+@main struct Main {
+  static func main() async {
+    try! await test()
+  }
+}

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_computedProperty.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_computedProperty.swift
@@ -21,7 +21,7 @@ typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
 
 distributed actor Greeter {
   distributed var theDistributedProperty: String {
-    "Patrik the Seastar"
+    "Patrick the Seastar"
   }
 }
 
@@ -32,10 +32,10 @@ func test() async throws {
   let ref = try Greeter.resolve(id: local.id, using: system)
 
   let reply = try await ref.theDistributedProperty
-  // CHECK: >> remoteCall: on:main.Greeter, target:main.Greeter.name, invocation:FakeInvocationEncoder(genericSubs: [], arguments: [], returnType: Optional(Swift.String), errorType: nil), throwing:Swift.Never, returning:Swift.String
+  // CHECK: >> remoteCall: on:main.Greeter, target:main.Greeter.theDistributedProperty(), invocation:FakeInvocationEncoder(genericSubs: [], arguments: [], returnType: Optional(Swift.String), errorType: nil), throwing:Swift.Never, returning:Swift.String
   // CHECK: << remoteCall return: Patrick the Seastar
   print("reply: \(reply)")
-  // CHECK: reply: Echo: Caplin
+  // CHECK: reply: Patrick the Seastar
 }
 
 @main struct Main {

--- a/test/Distributed/distributed_actor_isolation.swift
+++ b/test/Distributed/distributed_actor_isolation.swift
@@ -42,6 +42,23 @@ distributed actor DistributedActor_1 {
   distributed let letProperty: String = "" // expected-error{{property 'letProperty' cannot be 'distributed', only computed properties can}}
   distributed var varProperty: String = "" // expected-error{{property 'varProperty' cannot be 'distributed', only computed properties can}}
 
+  distributed var computed: String {
+    "computed"
+  }
+
+  distributed var computedNotCodable: NotCodableValue { // expected-error{{result type 'NotCodableValue' of distributed property 'computedNotCodable' does not conform to serialization requirement 'Codable'}}
+    .init()
+  }
+
+  distributed var getSet: String { // expected-error{{'distributed' computed property 'getSet' cannot have setter}}
+    get {
+      "computed"
+    }
+    set {
+      _ = newValue
+    }
+  }
+
   distributed static func distributedStatic() {} // expected-error{{'distributed' method cannot be 'static'}}
   distributed class func distributedClass() {}
   // expected-error@-1{{class methods are only allowed within classes; use 'static' to declare a static method}}

--- a/test/Distributed/distributed_actor_var_implicitly_async_throws.swift
+++ b/test/Distributed/distributed_actor_var_implicitly_async_throws.swift
@@ -33,15 +33,17 @@ distributed actor D {
     "dist"
   }
 
-  // OK:
+  // FIXME: The following should be accepted.
+  /*
   distributed var distGet: String {
     get distributed {
       "okey"
     }
   }
+  */
 
-  distributed var distSetGet: String {
-    set distributed {
+  distributed var distSetGet: String { // expected-error {{'distributed' computed property 'distSetGet' cannot have setter}}
+    set distributed { // expected-error {{expected '{' to start setter definition}}
       _ = newValue
     }
     get distributed {

--- a/test/Distributed/distributed_actor_var_implicitly_async_throws.swift
+++ b/test/Distributed/distributed_actor_var_implicitly_async_throws.swift
@@ -33,6 +33,22 @@ distributed actor D {
     "dist"
   }
 
+  // OK:
+  distributed var distGet: String {
+    get distributed {
+      "okey"
+    }
+  }
+
+  distributed var distSetGet: String {
+    set distributed {
+      _ = newValue
+    }
+    get distributed {
+      "okey"
+    }
+  }
+
   // expected-error@+1{{'distributed' property 'hello' cannot be 'static'}}
   static distributed var hello: String {
     "nope!"


### PR DESCRIPTION
This is an alternative implementation of distributed computed properties that introduces
a new `DistributedThunk` accessor kind, new access strategy, and semantics.

A reference to a getter of a distributed computed property is transparently replaced by
its thunk during SILGen (the semantics are the same for both distributed methods and
distributed computed properties).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

rdar://91283164 