### PR TITLE
Allow associated type witnesses to have missing Sendable conformances.

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4588,7 +4588,10 @@ swift::checkTypeWitness(Type type, AssociatedTypeDecl *assocType,
 
   // Check protocol conformances.
   for (const auto reqProto : sig->getRequiredProtocols(depTy)) {
-    if (module->lookupConformance(contextType, reqProto)
+    if (module->lookupConformance(
+            contextType, reqProto,
+            /*allowMissing=*/reqProto->isSpecificProtocol(
+                KnownProtocolKind::Sendable))
             .isInvalid())
       return CheckTypeWitnessResult(reqProto->getDeclaredInterfaceType());
 

--- a/test/Concurrency/sendable_associated_type.swift
+++ b/test/Concurrency/sendable_associated_type.swift
@@ -1,0 +1,18 @@
+// RUN: %target-typecheck-verify-swift -strict-concurrency=complete
+// REQUIRES: concurrency
+
+class C1 { } // expected-note{{class 'C1' does not conform to the 'Sendable' protocol}}
+@_nonSendable class C2 { } // expected-note{{conformance of 'C2' to 'Sendable' has been explicitly marked unavailable here}}
+
+protocol TestProtocol {
+  associatedtype Value: Sendable
+}
+
+struct Test1: TestProtocol { // expected-warning{{type 'Test1.Value' (aka 'C1') does not conform to the 'Sendable' protocol}}
+  typealias Value = C1
+}
+
+struct Test2: TestProtocol { // expected-warning{{conformance of 'C2' to 'Sendable' is unavailable}}
+  // expected-note@-1{{in associated type 'Self.Value' (inferred as 'C2')}}
+  typealias Value = C2
+}


### PR DESCRIPTION
Fixes #58197 / rdar://90348980.
