### PR TITLE
[1/3][Distributed] Make distributed thunks the witnesses, fix calls on generic DAs

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4791,6 +4791,9 @@ ERROR(distributed_actor_func_static,none,
 ERROR(distributed_actor_func_not_in_distributed_actor,none,
       "'distributed' method can only be declared within 'distributed actor'",
       ())
+ERROR(distributed_method_requirement_must_be_async_throws,none, // FIXME(distributed): this is an implementation limitation we should lift
+      "'distributed' protocol requirement %0 must currently be declared explicitly 'async throws'",
+      (DeclName))
 ERROR(distributed_actor_user_defined_special_property,none,
       "property %0 cannot be defined explicitly, as it conflicts with "
       "distributed actor synthesized stored property",

--- a/include/swift/AST/DistributedDecl.h
+++ b/include/swift/AST/DistributedDecl.h
@@ -47,6 +47,11 @@ Type getDistributedActorSystemType(NominalTypeDecl *actor);
 /// Determine the `ID` type for the given actor.
 Type getDistributedActorIDType(NominalTypeDecl *actor);
 
+/// Similar to `getDistributedSerializationRequirementType`, however, from the
+/// perspective of a concrete function. This way we're able to get the
+/// serialization requirement for specific members, also in protocols.
+Type getConcreteReplacementForMemberSerializationRequirement(ValueDecl *member);
+
 /// Get specific 'SerializationRequirement' as defined in 'nominal'
 /// type, which must conform to the passed 'protocol' which is expected
 /// to require the 'SerializationRequirement'.

--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -414,8 +414,7 @@ struct SILDeclRef {
                       defaultArgIndex,
                       pointer.get<AutoDiffDerivativeFunctionIdentifier *>());
   }
-  /// Returns the distributed entry point corresponding to the same
-  /// decl.
+  /// Returns the distributed entry point corresponding to the same decl.
   SILDeclRef asDistributed(bool distributed = true) const {
     return SILDeclRef(loc.getOpaqueValue(), kind,
                       /*foreign=*/false,

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -96,6 +96,37 @@ Type swift::getConcreteReplacementForProtocolActorSystemType(ValueDecl *member) 
   llvm_unreachable("Unable to fetch ActorSystem type!");
 }
 
+Type swift::getConcreteReplacementForMemberSerializationRequirement(
+    ValueDecl *member) {
+  auto &C = member->getASTContext();
+  auto *DC = member->getDeclContext();
+  auto DA = C.getDistributedActorDecl();
+
+  // === When declared inside an actor, we can get the type directly
+  if (auto classDecl = DC->getSelfClassDecl()) {
+    return getDistributedSerializationRequirementType(classDecl, C.getDistributedActorDecl());
+  }
+
+  /// === Maybe the value is declared in a protocol?
+  if (auto protocol = DC->getSelfProtocolDecl()) {
+    GenericSignature signature;
+    if (auto *genericContext = member->getAsGenericContext()) {
+      signature = genericContext->getGenericSignature();
+    } else {
+      signature = DC->getGenericSignatureOfContext();
+    }
+
+    auto SerReqAssocType = DA->getAssociatedType(C.Id_SerializationRequirement)
+                               ->getDeclaredInterfaceType();
+
+    // Note that this may be null, e.g. if we're a distributed func inside
+    // a protocol that did not declare a specific actor system requirement.
+    return signature->getConcreteType(SerReqAssocType);
+  }
+
+  llvm_unreachable("Unable to fetch ActorSystem type!");
+}
+
 Type swift::getDistributedActorSystemType(NominalTypeDecl *actor) {
   assert(!dyn_cast<ProtocolDecl>(actor) &&
          "Use getConcreteReplacementForProtocolActorSystemType instead to get"

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -4439,15 +4439,22 @@ void SILGenFunction::emitProtocolWitness(
   SmallVector<ManagedValue, 8> origParams;
   collectThunkParams(loc, origParams);
 
-  // If the witness is isolated to a distributed actor, but the requirement is
-  // not, go through the distributed thunk.
   if (witness.hasDecl() &&
-      getActorIsolation(witness.getDecl()).isDistributedActor() &&
-      requirement.hasDecl() &&
-      !getActorIsolation(requirement.getDecl()).isDistributedActor()) {
-    witness = SILDeclRef(
-        cast<AbstractFunctionDecl>(witness.getDecl())->getDistributedThunk())
-          .asDistributed();
+      getActorIsolation(witness.getDecl()).isDistributedActor()) {
+    // We witness protocol requirements using the distributed thunk, when:
+    // - the witness is isolated to a distributed actor, but the requirement is not
+    // - the requirement is a distributed func, and therefore can only be witnessed
+    //   by a distributed func; we handle this by witnessing the requirement with the thunk
+    // FIXME(distributed): this limits us to only allow distributed explicitly throwing async requirements... we need to fix this somehow.
+    if (requirement.hasDecl()) {
+      if ((!getActorIsolation(requirement.getDecl()).isDistributedActor()) ||
+          (isa<FuncDecl>(requirement.getDecl()) &&
+              witness.getFuncDecl()->isDistributed())) {
+        auto thunk = cast<AbstractFunctionDecl>(witness.getDecl())
+                         ->getDistributedThunk();
+        witness = SILDeclRef(thunk).asDistributed();
+      }
+    }
   } else if (enterIsolation) {
     // If we are supposed to enter the actor, do so now by hopping to the
     // actor.

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -648,8 +648,13 @@ static FuncDecl *createDistributedThunkFunction(FuncDecl *func) {
   auto &C = func->getASTContext();
   auto DC = func->getDeclContext();
 
-  auto systemTy = getConcreteReplacementForProtocolActorSystemType(func);
-  assert(systemTy &&
+  // NOTE: So we don't need a thunk in the protocol, we should call the underlying
+  // thing instead, which MUST have a thunk, since it must be a distributed func as well...
+  if (dyn_cast<ProtocolDecl>(DC)) {
+    return nullptr;
+  }
+
+  assert(getConcreteReplacementForProtocolActorSystemType(func) &&
          "Thunk synthesis must have concrete actor system type available");
 
   DeclName thunkName = func->getName();

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -503,9 +503,25 @@ bool CheckDistributedFunctionRequest::evaluate(
     serializationRequirements = getDistributedSerializationRequirementProtocols(
         getDistributedActorSystemType(actor)->getAnyNominal(),
         C.getProtocol(KnownProtocolKind::DistributedActorSystem));
+  } else if (isa<ProtocolDecl>(DC)) {
+    if (auto seqReqTy =
+        getConcreteReplacementForMemberSerializationRequirement(func)) {
+      auto seqReqTyDes = seqReqTy->castTo<ExistentialType>()->getConstraintType()->getDesugaredType();
+      for (auto req : flattenDistributedSerializationTypeToRequiredProtocols(seqReqTyDes)) {
+        serializationRequirements.insert(req);
+      }
+    }
+
+    // The distributed actor constrained protocol has no serialization requirements
+    // or actor system defined, so these will only be enforced, by implementations
+    // of DAs conforming to it, skip checks here.
+    if (serializationRequirements.empty()) {
+      return false;
+    }
   } else {
-    llvm_unreachable("Cannot handle types other than extensions and actor "
-                     "declarations in distributed function checking.");
+    llvm_unreachable("Distributed function detected in type other than extension, "
+                     "distributed actor, or protocol! This should not be possible "
+                     ", please file a bug.");
   }
 
   // If the requirement is exactly `Codable` we diagnose it ia bit nicer.
@@ -653,11 +669,22 @@ void TypeChecker::checkDistributedActor(SourceFile *SF, NominalTypeDecl *nominal
   // If applicable, this will create the default 'init(transport:)' initializer
   (void)nominal->getDefaultInitializer();
 
+
   for (auto member : nominal->getMembers()) {
     // --- Ensure all thunks
     if (auto func = dyn_cast<AbstractFunctionDecl>(member)) {
       if (!func->isDistributed())
         continue;
+
+      if (!isa<ProtocolDecl>(nominal)) {
+        auto systemTy = getConcreteReplacementForProtocolActorSystemType(func);
+        if (!systemTy || systemTy->hasError()) {
+          nominal->diagnose(
+              diag::distributed_actor_conformance_missing_system_type,
+              nominal->getName());
+          return;
+        }
+      }
 
       if (auto thunk = func->getDistributedThunk()) {
         SF->DelayedFunctions.push_back(thunk);

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_through_generic.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_through_generic.swift
@@ -1,0 +1,165 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-build-swift -module-name main -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s --color --dump-input=always
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// rdar://76038845
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+// FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
+// UNSUPPORTED: OS=windows-msvc
+
+import Distributed
+import FakeDistributedActorSystems
+
+
+typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
+
+protocol DistributedWorker: DistributedActor where ActorSystem == DefaultDistributedActorSystem {
+  associatedtype WorkItem: Sendable & Codable
+  associatedtype WorkResult: Sendable & Codable
+
+  // distributed requirement currently is forced to be `async throws`...
+  // FIXME(distributed): requirements don't have to be async throws,
+  //                     distributed makes them implicitly async throws anyway...
+  distributed func submit(work: WorkItem) async throws -> WorkResult
+
+  // non distributed requirements can be witnessed with _normal_ functions
+  func sync(work: WorkItem) -> WorkResult
+  func async(work: WorkItem) async -> WorkResult
+  func syncThrows(work: WorkItem) throws -> WorkResult
+  func asyncThrows(work: WorkItem) async throws -> WorkResult
+}
+
+distributed actor TheWorker: DistributedWorker {
+  typealias ActorSystem = DefaultDistributedActorSystem
+  typealias WorkItem = String
+  typealias WorkResult = String
+
+  distributed func submit(work: WorkItem) async throws -> WorkResult {
+    "\(#function): \(work)"
+  }
+
+  func sync(work: WorkItem) -> WorkResult {
+    return "\(#function): \(work)"
+  }
+  func async(work: WorkItem) async -> WorkResult {
+    return "\(#function): \(work)"
+  }
+  func syncThrows(work: WorkItem) throws -> WorkResult {
+    return "\(#function): \(work)"
+  }
+  func asyncThrows(work: WorkItem) async throws -> WorkResult {
+    return "\(#function): \(work)"
+  }
+}
+
+func test_generic(system: DefaultDistributedActorSystem) async throws {
+  let localW = TheWorker(actorSystem: system)
+  let remoteW = try! TheWorker.resolve(id: localW.id, using: system)
+  precondition(__isRemoteActor(remoteW))
+
+  // direct calls work ok:
+  let replyDirect = try await remoteW.submit(work: "Direct")
+  print("reply direct: \(replyDirect)")
+  // CHECK: >> remoteCall: on:main.TheWorker, target:main.TheWorker.submit(work:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Direct"], returnType: Optional(Swift.String), errorType: Optional(Swift.Error)), throwing:Swift.Error, returning:Swift.String
+  // CHECK: reply direct: submit(work:): Direct
+
+  func callWorker<W: DistributedWorker>(w: W) async throws -> String where W.WorkItem == String, W.WorkResult == String {
+    try await w.submit(work: "Hello")
+  }
+  let reply = try await callWorker(w: remoteW)
+  print("reply (remote): \(reply)")
+  // CHECK: >> remoteCall: on:main.TheWorker, target:main.TheWorker.submit(work:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Hello"], returnType: Optional(Swift.String), errorType: Optional(Swift.Error)), throwing:Swift.Error, returning:Swift.String
+  // CHECK: << remoteCall return: submit(work:): Hello
+  // CHECK: reply (remote): submit(work:): Hello
+
+  let replyLocal = try await callWorker(w: localW)
+  print("reply (local): \(replyLocal)")
+  // CHECK-NOT: >> remoteCall
+  // CHECK: reply (local): submit(work:): Hello
+}
+
+func test_whenLocal(system: DefaultDistributedActorSystem) async throws {
+  let localW = TheWorker(actorSystem: system)
+  let remoteW = try! TheWorker.resolve(id: localW.id, using: system)
+  precondition(__isRemoteActor(remoteW))
+
+  do {
+    let replySync = await remoteW.whenLocal { __secretlyKnownToBeLocal in
+      __secretlyKnownToBeLocal.sync(work: "test")
+    }
+    print("replySync (remote): \(replySync)")
+    // CHECK: replySync (remote): nil
+
+    let replySyncThrows = try await remoteW.whenLocal { __secretlyKnownToBeLocal in
+      try __secretlyKnownToBeLocal.syncThrows(work: "test")
+    }
+    print("replySyncThrows (remote): \(replySyncThrows)")
+    // CHECK: replySyncThrows (remote): nil
+
+    let replyAsync = await remoteW.whenLocal { __secretlyKnownToBeLocal in
+      await __secretlyKnownToBeLocal.async(work: "test")
+    }
+    print("replyAsync (remote): \(replyAsync)")
+    // CHECK: replyAsync (remote): nil
+
+    let replyAsyncThrows = try await remoteW.whenLocal { __secretlyKnownToBeLocal in
+      try await __secretlyKnownToBeLocal.asyncThrows(work: "test")
+    }
+    print("replyAsyncThrows (remote): \(replyAsyncThrows)")
+    // CHECK: replyAsyncThrows (remote): nil
+  }
+  // ==== ----------------------------------------------------------------------
+
+  do {
+    let replyDistSubmit = try await localW.whenLocal { __secretlyKnownToBeLocal in
+      try await __secretlyKnownToBeLocal.submit(work: "local-test")
+    }
+    print("replyDistSubmit (local): \(replyDistSubmit ?? "nil")")
+    // CHECK-NOT: >> remoteCall
+    // CHECK: replyDistSubmit (local): submit(work:): local-test
+
+    let replySyncLocal = await localW.whenLocal { __secretlyKnownToBeLocal in
+      __secretlyKnownToBeLocal.sync(work: "local-test")
+    }
+    print("replySyncLocal (local): \(replySyncLocal ?? "nil")")
+    // CHECK-NOT: >> remoteCall
+    // CHECK: replySyncLocal (local): sync(work:): local-test
+
+    let replySyncThrowsLocal = try await localW.whenLocal { __secretlyKnownToBeLocal in
+      try __secretlyKnownToBeLocal.syncThrows(work: "local-test")
+    }
+    print("replySyncThrowsLocal (local): \(replySyncThrowsLocal ?? "nil")")
+    // CHECK-NOT: >> remoteCall
+    // CHECK: replySyncThrowsLocal (local): syncThrows(work:): local-test
+
+    let replyAsyncLocal = await localW.whenLocal { __secretlyKnownToBeLocal in
+      await __secretlyKnownToBeLocal.async(work: "local-test")
+    }
+    print("replyAsyncLocal (local): \(replyAsyncLocal ?? "nil")")
+    // CHECK-NOT: >> remoteCall
+    // CHECK: replyAsyncLocal (local): async(work:): local-test
+
+    let replyAsyncThrowsLocal = try await localW.whenLocal { __secretlyKnownToBeLocal in
+      try await __secretlyKnownToBeLocal.asyncThrows(work: "local-test")
+    }
+    print("replyAsyncThrowsLocal (local): \(replyAsyncThrowsLocal ?? "nil")")
+    // CHECK-NOT: >> remoteCall
+    // CHECK: replyAsyncThrowsLocal (local): asyncThrows(work:): local-test
+  }
+}
+
+@main struct Main {
+  static func main() async {
+    let system = DefaultDistributedActorSystem()
+    try! await test_generic(system: system)
+    print("==== ---------------------------------------------------")
+    try! await test_whenLocal(system: system)
+  }
+}

--- a/test/Distributed/distributed_actor_generic_actor_distributed_call.swift
+++ b/test/Distributed/distributed_actor_generic_actor_distributed_call.swift
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-swift-frontend -typecheck -verify -disable-availability-checking -I %t 2>&1 %s
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+import Distributed
+import FakeDistributedActorSystems
+
+@available(SwiftStdlib 5.5, *)
+typealias DefaultDistributedActorSystem = FakeActorSystem
+
+import Distributed
+
+protocol DistributedWorker: DistributedActor {
+  associatedtype WorkItem: Sendable & Codable
+  associatedtype WorkResult: Sendable & Codable
+
+  distributed func submit(work: WorkItem) async throws -> WorkResult
+}
+
+distributed actor TheWorker: DistributedWorker {
+  typealias ActorSystem = FakeActorSystem
+  typealias WorkItem = String
+  typealias WorkResult = String
+
+  distributed func submit(work: WorkItem) async throws -> WorkResult {
+    work
+  }
+}
+
+distributed actor WorkerPool<Worker: DistributedWorker> {
+  typealias ActorSystem = FakeActorSystem
+  typealias WorkItem = Worker.WorkItem
+  typealias WorkResult = Worker.WorkResult
+
+  func submit(work: WorkItem) async throws -> WorkResult {
+    let worker = try await self.selectWorker()
+    return try await worker.submit(work: work)
+  }
+
+  func selectWorker() async throws -> Worker {
+    fatalError()
+  }
+}

--- a/test/Distributed/distributed_actor_inference.swift
+++ b/test/Distributed/distributed_actor_inference.swift
@@ -42,11 +42,13 @@ protocol DP {
 }
 
 protocol DPOK: DistributedActor {
-  distributed func hello()  // ok
+  distributed func hello() // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
+  // expected-error@-1{{'distributed' protocol requirement 'hello()' must currently be declared explicitly 'async throws'}}
 }
 
 protocol DPOK2: DPOK {
-  distributed func again()  // ok
+  distributed func again() // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
+  // expected-error@-1{{'distributed' protocol requirement 'again()' must currently be declared explicitly 'async throws'}}
 }
 
 enum SomeNotActorEnum_5 {

--- a/test/Distributed/distributed_actor_protocol_isolation.swift
+++ b/test/Distributed/distributed_actor_protocol_isolation.swift
@@ -37,15 +37,18 @@ protocol MixedProtoDistributedActor: DistributedActor {
   func localThrows() throws
   func localAsyncThrows() async throws
 
-  distributed func dist()
-  distributed func distAsync() async
+//  distributed func dist() // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
+//  distributed func distAsync() async // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
   distributed func distAsyncThrows() async throws
 }
 
 protocol DistProtoDistributedActor: DistributedActor {
-  distributed func dist()
-  distributed func distAsync() async
-  distributed func distThrows() throws
+  distributed func dist() // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
+  // expected-error@-1{{'distributed' protocol requirement 'dist()' must currently be declared explicitly 'async throws'}}
+  distributed func distAsync() async // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
+  // expected-error@-1{{'distributed' protocol requirement 'distAsync()' must currently be declared explicitly 'async throws'}}
+  distributed func distThrows() throws // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
+  // expected-error@-1{{'distributed' protocol requirement 'distThrows()' must currently be declared explicitly 'async throws'}}
   distributed func distAsyncThrows() async throws
 }
 

--- a/test/Distributed/distributed_actor_system_missing.swift
+++ b/test/Distributed/distributed_actor_system_missing.swift
@@ -18,3 +18,14 @@ distributed actor DA {
   // Note to add the typealias is diagnosed on the protocol:
   // _Distributed.DistributedActor:3:20: note: diagnostic produced elsewhere: protocol requires nested type 'ActorSystem'; do you want to add it?
 }
+// When an actor declares a typealias for a system, but that system does not exist,
+// we need to fail gracefully, rather than crash trying to use the non-existing type.
+//
+// Test case for: https://github.com/apple/swift/issues/58663
+distributed actor Server { // expected-error 2 {{distributed actor 'Server' does not declare ActorSystem it can be used with.}}
+  // expected-note@-1{{you can provide a module-wide default actor system by declaring:}}
+  typealias ActorSystem = DoesNotExistDataSystem
+  // expected-error@-1{{cannot find type 'DoesNotExistDataSystem' in scope}}
+  typealias SerializationRequirement = any Codable
+  distributed func send() { }
+}

--- a/test/Distributed/distributed_protocol_isolation.swift
+++ b/test/Distributed/distributed_protocol_isolation.swift
@@ -25,11 +25,15 @@ protocol DistProtocol: DistributedActor {
   // expected-note@-3{{distributed actor-isolated instance method 'local()' declared here}}
   // expected-note@-4{{distributed actor-isolated instance method 'local()' declared here}}
 
-  distributed func dist() -> String
-  distributed func dist(string: String) -> String
+  distributed func dist() -> String // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
+  // expected-error@-1{{'distributed' protocol requirement 'dist()' must currently be declared explicitly 'async throws'}}
+  distributed func dist(string: String) -> String // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
+  // expected-error@-1{{'distributed' protocol requirement 'dist(string:)' must currently be declared explicitly 'async throws'}}
 
-  distributed func distAsync() async -> String
-  distributed func distThrows() throws -> String
+  distributed func distAsync() async -> String // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
+  // expected-error@-1{{'distributed' protocol requirement 'distAsync()' must currently be declared explicitly 'async throws'}}
+  distributed func distThrows() throws -> String // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
+  // expected-error@-1{{'distributed' protocol requirement 'distThrows()' must currently be declared explicitly 'async throws'}}
   distributed func distAsyncThrows() async throws -> String
 }
 
@@ -253,8 +257,9 @@ func test_watchingDA_any(da: any TerminationWatchingDA) async throws {
 // MARK: Error cases
 
 protocol ErrorCases: DistributedActor {
-  distributed func unexpectedAsyncThrows() -> String
-  // expected-note@-1{{protocol requires function 'unexpectedAsyncThrows()' with type '() -> String'; do you want to add a stub?}}
+  distributed func unexpectedAsyncThrows() -> String // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
+  // expected-error@-1{{'distributed' protocol requirement 'unexpectedAsyncThrows()' must currently be declared explicitly 'async throws'}}
+  // expected-note@-2{{protocol requires function 'unexpectedAsyncThrows()' with type '() -> String'; do you want to add a stub?}}
 }
 
 distributed actor BadGreeter: ErrorCases {

--- a/test/Distributed/distributed_protocols_distributed_func_serialization_requirements.swift
+++ b/test/Distributed/distributed_protocols_distributed_func_serialization_requirements.swift
@@ -10,8 +10,11 @@ import FakeDistributedActorSystems
 struct NotCodable {}
 
 protocol NoSerializationRequirementYet: DistributedActor {
+  distributed func test() -> NotCodable // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
+  // expected-error@-1{{'distributed' protocol requirement 'test()' must currently be declared explicitly 'async throws'}}
+
   // OK, no serialization requirement yet
-  distributed func test() -> NotCodable
+  distributed func testAT() async throws -> NotCodable
 }
 
 distributed actor SpecifyRequirement: NoSerializationRequirementYet {
@@ -22,6 +25,10 @@ distributed actor SpecifyRequirement: NoSerializationRequirementYet {
     .init()
   }
 
+  // expected-error@+1{{result type 'NotCodable' of distributed instance method 'testAT' does not conform to serialization requirement 'Codable'}}
+  distributed func testAT() async throws -> NotCodable {
+    .init()
+  }
 }
 
 extension NoSerializationRequirementYet {

--- a/test/decl/protocol/special/DistributedActor.swift
+++ b/test/decl/protocol/special/DistributedActor.swift
@@ -64,8 +64,9 @@ distributed actor D4 {
 }
 
 protocol P1: DistributedActor {
-  distributed func dist() -> String
-  // expected-note@-1{{'dist()' declared here}}
+  distributed func dist() -> String // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
+  // expected-error@-1{{'distributed' protocol requirement 'dist()' must currently be declared explicitly 'async throws'}}
+  // expected-note@-2{{'dist()' declared here}}
 }
 
 distributed actor D5: P1 {


### PR DESCRIPTION
Implements calls on generic distributed actors, by fixing how the witness is found: it must be the thunk.

Resolves rdar://95829405