### PR TITLE
Disable escape_info SIL tests

### DIFF
--- a/test/SILOptimizer/addr_escape_info.sil
+++ b/test/SILOptimizer/addr_escape_info.sil
@@ -2,6 +2,8 @@
 
 // REQUIRES: swift_in_compiler
 
+// REQUIRES: rdar95944300
+
 // rdar92963081
 // UNSUPPORTED: OS=linux-gnu
 

--- a/test/SILOptimizer/escape_info.sil
+++ b/test/SILOptimizer/escape_info.sil
@@ -2,6 +2,8 @@
 
 // REQUIRES: swift_in_compiler
 
+// REQUIRES: rdar95944300
+
 // rdar92963081
 // UNSUPPORTED: OS=linux-gnu
 

--- a/test/SILOptimizer/escape_info_objc.sil
+++ b/test/SILOptimizer/escape_info_objc.sil
@@ -4,6 +4,8 @@
 // REQUIRES: objc_interop
 // REQUIRES: PTRSIZE=64
 
+// REQUIRES: rdar95944300
+
 sil_stage canonical
 
 import Builtin

--- a/test/SILOptimizer/ranges.sil
+++ b/test/SILOptimizer/ranges.sil
@@ -2,6 +2,8 @@
 
 // REQUIRES: swift_in_compiler
 
+// REQUIRES: rdar95944300
+
 // rdar92963081
 // UNSUPPORTED: OS=linux-gnu
 


### PR DESCRIPTION
These tests are crashing when printing SIL from SwiftCompilerSource.

rdar://95944300 macOS - Apple Silicon; test failures

Probably after
https://github.com/apple/swift/commit/ba42be5fcf2d663a589a3f5e4efe0ffcffb101fa
Merge pull request #59665 from eeckstein/target-constprop 
SILOptimizer: add a pass to perform target specific constant folding.