### PR TITLE
tests: re-enable escape-info tests for x86

### DIFF
--- a/test/SILOptimizer/addr_escape_info.sil
+++ b/test/SILOptimizer/addr_escape_info.sil
@@ -2,10 +2,8 @@
 
 // REQUIRES: swift_in_compiler
 
-// REQUIRES: rdar95944300
-
-// rdar92963081
-// UNSUPPORTED: OS=linux-gnu
+// Currently failing on arm: rdar://92963081
+// REQUIRES: CPU=x86_64
 
 sil_stage canonical
 

--- a/test/SILOptimizer/escape_info.sil
+++ b/test/SILOptimizer/escape_info.sil
@@ -2,10 +2,8 @@
 
 // REQUIRES: swift_in_compiler
 
-// REQUIRES: rdar95944300
-
-// rdar92963081
-// UNSUPPORTED: OS=linux-gnu
+// Currently failing on arm: rdar://92963081
+// REQUIRES: CPU=x86_64
 
 sil_stage canonical
 

--- a/test/SILOptimizer/escape_info_objc.sil
+++ b/test/SILOptimizer/escape_info_objc.sil
@@ -4,7 +4,8 @@
 // REQUIRES: objc_interop
 // REQUIRES: PTRSIZE=64
 
-// REQUIRES: rdar95944300
+// Currently failing on arm: rdar://92963081
+// REQUIRES: CPU=x86_64
 
 sil_stage canonical
 

--- a/test/SILOptimizer/ranges.sil
+++ b/test/SILOptimizer/ranges.sil
@@ -2,10 +2,8 @@
 
 // REQUIRES: swift_in_compiler
 
-// REQUIRES: rdar95944300
-
-// rdar92963081
-// UNSUPPORTED: OS=linux-gnu
+// Currently failing on arm: rdar://92963081
+// REQUIRES: CPU=x86_64
 
 sil_stage canonical
 


### PR DESCRIPTION
There is a problem on arm (rdar://92963081) which we need to resolve.
But in the meantime, let's run the tests at least on x86.
