### PR TITLE
[3/3][Distributed] Remove dist requirement explicit async throws limitation

### DIFF
--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -193,6 +193,9 @@ ActorIsolation getActorIsolation(ValueDecl *value);
 /// Determine how the given declaration context is isolated.
 ActorIsolation getActorIsolationOfContext(DeclContext *dc);
 
+/// Check if both the value, and context are isolated to the same actor.
+bool isSameActorIsolated(ValueDecl *value, DeclContext *dc);
+
 /// Determines whether this function's body uses flow-sensitive isolation.
 bool usesFlowSensitiveIsolation(AbstractFunctionDecl const *fn);
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4794,9 +4794,6 @@ ERROR(distributed_actor_func_static,none,
 ERROR(distributed_actor_func_not_in_distributed_actor,none,
       "'distributed' method can only be declared within 'distributed actor'",
       ())
-ERROR(distributed_method_requirement_must_be_async_throws,none, // FIXME(distributed): this is an implementation limitation we should lift
-      "'distributed' protocol requirement %0 must currently be declared explicitly 'async throws'",
-      (DeclName))
 ERROR(distributed_actor_user_defined_special_property,none,
       "property %0 cannot be defined explicitly, as it conflicts with "
       "distributed actor synthesized stored property",

--- a/include/swift/AST/DistributedDecl.h
+++ b/include/swift/AST/DistributedDecl.h
@@ -15,8 +15,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef SWIFT_DECL_TYPECHECKDISTRIBUTED_H
-#define SWIFT_DECL_TYPECHECKDISTRIBUTED_H
+#ifndef SWIFT_DECL_DISTRIBUTEDDECL_H
+#define SWIFT_DECL_DISTRIBUTEDDECL_H
 
 #include "swift/AST/ConcreteDeclRef.h"
 #include "swift/AST/DiagnosticEngine.h"
@@ -129,4 +129,6 @@ extractDistributedSerializationRequirements(
 
 }
 
-#endif /* SWIFT_DECL_TYPECHECKDISTRIBUTED_H */
+// ==== ------------------------------------------------------------------------
+
+#endif /* SWIFT_DECL_DISTRIBUTEDDECL_H */

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -243,6 +243,7 @@ std::string ASTMangler::mangleWitnessThunk(
       appendOperator("TW");
     }
   }
+
   return finalize();
 }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9254,6 +9254,13 @@ ActorIsolation swift::getActorIsolationOfContext(DeclContext *dc) {
   return ActorIsolation::forUnspecified();
 }
 
+bool swift::isSameActorIsolated(ValueDecl *value, DeclContext *dc) {
+    auto valueIsolation = getActorIsolation(value);
+    auto dcIsolation = getActorIsolationOfContext(dc);
+    return valueIsolation.isActorIsolated() && dcIsolation.isActorIsolated() &&
+           valueIsolation.getActor() == dcIsolation.getActor();
+}
+
 ClangNode Decl::getClangNodeImpl() const {
   assert(Bits.Decl.FromClang);
   void * const *ptr = nullptr;

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1559,7 +1559,11 @@ void swift::simple_display(
     llvm::raw_ostream &out, const ActorIsolation &state) {
   switch (state) {
     case ActorIsolation::ActorInstance:
-      out << "actor-isolated to instance of " << state.getActor()->getName();
+      out << "actor-isolated to instance of ";
+      if (state.isDistributedActor()) {
+        out << "distributed ";
+      }
+      out << "actor " << state.getActor()->getName();
       break;
 
     case ActorIsolation::Independent:

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -7172,7 +7172,7 @@ Parser::parseDeclVar(ParseDeclOptions Flags,
 ///
 /// \verbatim
 ///   decl-func:
-///     attribute-list? ('static' | 'class')? 'mutating'? 'func' 
+///     attribute-list? ('static' | 'class' | 'distributed')? 'mutating'? 'func'
 ///               any-identifier generic-params? func-signature where-clause?
 ///               stmt-brace?
 /// \endverbatim
@@ -7256,7 +7256,7 @@ ParserResult<FuncDecl> Parser::parseDeclFunc(SourceLoc StaticLoc,
   }
 
   DebuggerContextChange DCC(*this, SimpleName, DeclKind::Func);
-  
+
   // Parse the generic-params, if present.
   GenericParamList *GenericParams;
   auto GenericParamResult = maybeParseGenericParams();

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -2112,7 +2112,7 @@ static CanSILFunctionType getSILFunctionType(
                         .withConcurrent(isSendable)
                         .withAsync(isAsync)
                         .build();
-  
+
   return SILFunctionType::get(genericSig, silExtInfo, coroutineKind,
                               calleeConvention, inputs, yields,
                               results, errorResult,

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -4352,7 +4352,7 @@ getWitnessFunctionRef(SILGenFunction &SGF,
                       SILLocation loc) {
   switch (witnessKind) {
   case WitnessDispatchKind::Static:
-    if (auto *derivativeId = witness.getDerivativeFunctionIdentifier()) {
+    if (auto *derivativeId = witness.getDerivativeFunctionIdentifier()) { // TODO Maybe we need check here too
       auto originalFn =
           SGF.emitGlobalFunctionRef(loc, witness.asAutoDiffOriginalFunction());
       auto *loweredParamIndices = autodiff::getLoweredParameterIndices(
@@ -4439,23 +4439,7 @@ void SILGenFunction::emitProtocolWitness(
   SmallVector<ManagedValue, 8> origParams;
   collectThunkParams(loc, origParams);
 
-  if (witness.hasDecl() &&
-      getActorIsolation(witness.getDecl()).isDistributedActor()) {
-    // We witness protocol requirements using the distributed thunk, when:
-    // - the witness is isolated to a distributed actor, but the requirement is not
-    // - the requirement is a distributed func, and therefore can only be witnessed
-    //   by a distributed func; we handle this by witnessing the requirement with the thunk
-    // FIXME(distributed): this limits us to only allow distributed explicitly throwing async requirements... we need to fix this somehow.
-    if (requirement.hasDecl()) {
-      if ((!getActorIsolation(requirement.getDecl()).isDistributedActor()) ||
-          (isa<FuncDecl>(requirement.getDecl()) &&
-              witness.getFuncDecl()->isDistributed())) {
-        auto thunk = cast<AbstractFunctionDecl>(witness.getDecl())
-                         ->getDistributedThunk();
-        witness = SILDeclRef(thunk).asDistributed();
-      }
-    }
-  } else if (enterIsolation) {
+  if (enterIsolation) {
     // If we are supposed to enter the actor, do so now by hopping to the
     // actor.
     Optional<ManagedValue> actorSelf;

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -672,7 +672,7 @@ static FuncDecl *createDistributedThunkFunction(FuncDecl *func) {
 
   // NOTE: So we don't need a thunk in the protocol, we should call the underlying
   // thing instead, which MUST have a thunk, since it must be a distributed func as well...
-  if (dyn_cast<ProtocolDecl>(DC)) {
+  if (isa<ProtocolDecl>(DC)) {
     return nullptr;
   }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5910,24 +5910,6 @@ void AttributeChecker::visitDistributedActorAttr(DistributedActorAttr *attr) {
       }
       return;
     }
-
-    // Diagnose for the limitation that we currently have to require distributed
-    // actor constrained protocols to declare the distributed requirements as
-    // 'async throws'
-    // FIXME: rdar://95949498 allow requirements to not declare explicit async/throws in protocols; those effects are implicit in any case
-    if (isa<ProtocolDecl>(dc)) {
-      if (!funcDecl->hasAsync() || !funcDecl->hasThrows()) {
-        auto diag = funcDecl->diagnose(diag::distributed_method_requirement_must_be_async_throws,
-                           funcDecl->getName());
-        if (!funcDecl->hasAsync()) {
-          diag.fixItInsertAfter(funcDecl->getThrowsLoc(), " async");
-        }
-        if (!funcDecl->hasThrows()) {
-          diag.fixItInsertAfter(funcDecl->getThrowsLoc(), " throws");
-        }
-        return;
-      }
-    }
   }
 }
 

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_through_generic.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_through_generic.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
 // RUN: %target-build-swift -module-name main -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
-// RUN: %target-run %t/a.out | %FileCheck %s --color --dump-input=always
+// RUN: %target-run %t/a.out | %FileCheck %s --color
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
@@ -17,23 +17,45 @@
 import Distributed
 import FakeDistributedActorSystems
 
-
 typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
+
+protocol PlainWorker {
+  associatedtype WorkItem: Sendable & Codable
+  associatedtype WorkResult: Sendable & Codable
+
+  /// Can be witnessed by a distributed actor method:
+  func asyncThrows(work: WorkItem) async throws -> WorkResult
+}
 
 protocol DistributedWorker: DistributedActor where ActorSystem == DefaultDistributedActorSystem {
   associatedtype WorkItem: Sendable & Codable
   associatedtype WorkResult: Sendable & Codable
 
-  // distributed requirement currently is forced to be `async throws`...
-  // FIXME(distributed): requirements don't have to be async throws,
-  //                     distributed makes them implicitly async throws anyway...
-  distributed func submit(work: WorkItem) async throws -> WorkResult
+  distributed func dist_sync(work: WorkItem) -> WorkResult
+  distributed func dist_async(work: WorkItem) async -> WorkResult
+  distributed func dist_syncThrows(work: WorkItem) throws -> WorkResult
+  distributed func dist_asyncThrows(work: WorkItem) async throws -> WorkResult
 
   // non distributed requirements can be witnessed with _normal_ functions
   func sync(work: WorkItem) -> WorkResult
   func async(work: WorkItem) async -> WorkResult
   func syncThrows(work: WorkItem) throws -> WorkResult
   func asyncThrows(work: WorkItem) async throws -> WorkResult
+
+  func asyncThrowsReq_witnessDistributed_sync(work: WorkItem) async throws -> WorkResult
+  func asyncThrowsReq_witnessDistributed_async(work: WorkItem) async throws -> WorkResult
+  func asyncThrowsReq_witnessDistributed_syncThrows(work: WorkItem) async throws -> WorkResult
+  func asyncThrowsReq_witnessDistributed_asyncThrows(work: WorkItem) async throws -> WorkResult
+}
+
+distributed actor ThePlainWorker: PlainWorker {
+  typealias ActorSystem = DefaultDistributedActorSystem
+  typealias WorkItem = String
+  typealias WorkResult = String
+
+  distributed func asyncThrows(work: WorkItem) async throws -> WorkResult {
+    return "\(#function): \(work)"
+  }
 }
 
 distributed actor TheWorker: DistributedWorker {
@@ -41,7 +63,16 @@ distributed actor TheWorker: DistributedWorker {
   typealias WorkItem = String
   typealias WorkResult = String
 
-  distributed func submit(work: WorkItem) async throws -> WorkResult {
+  distributed func dist_sync(work: WorkItem) -> WorkResult {
+    "\(#function): \(work)"
+  }
+  distributed func dist_async(work: WorkItem) async -> WorkResult {
+    "\(#function): \(work)"
+  }
+  distributed func dist_syncThrows(work: WorkItem) throws -> WorkResult {
+    "\(#function): \(work)"
+  }
+  distributed func dist_asyncThrows(work: WorkItem) async throws -> WorkResult {
     "\(#function): \(work)"
   }
 
@@ -57,6 +88,20 @@ distributed actor TheWorker: DistributedWorker {
   func asyncThrows(work: WorkItem) async throws -> WorkResult {
     return "\(#function): \(work)"
   }
+
+  distributed func asyncThrowsReq_witnessDistributed_sync(work: WorkItem) -> WorkResult {
+    return "\(#function): \(work)"
+  }
+  distributed func asyncThrowsReq_witnessDistributed_async(work: WorkItem) async -> WorkResult {
+    return "\(#function): \(work)"
+  }
+  distributed func asyncThrowsReq_witnessDistributed_syncThrows(work: WorkItem) throws -> WorkResult {
+    return "\(#function): \(work)"
+  }
+  distributed func asyncThrowsReq_witnessDistributed_asyncThrows(work: WorkItem) async throws -> WorkResult {
+    return "\(#function): \(work)"
+  }
+
 }
 
 func test_generic(system: DefaultDistributedActorSystem) async throws {
@@ -65,24 +110,164 @@ func test_generic(system: DefaultDistributedActorSystem) async throws {
   precondition(__isRemoteActor(remoteW))
 
   // direct calls work ok:
-  let replyDirect = try await remoteW.submit(work: "Direct")
-  print("reply direct: \(replyDirect)")
-  // CHECK: >> remoteCall: on:main.TheWorker, target:main.TheWorker.submit(work:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Direct"], returnType: Optional(Swift.String), errorType: Optional(Swift.Error)), throwing:Swift.Error, returning:Swift.String
-  // CHECK: reply direct: submit(work:): Direct
-
-  func callWorker<W: DistributedWorker>(w: W) async throws -> String where W.WorkItem == String, W.WorkResult == String {
-    try await w.submit(work: "Hello")
+  do {
+    let reply = try await remoteW.dist_sync(work: "Direct")
+    print("replySync direct (remote): \(reply)")
+    // CHECK: >> remoteCall: on:main.TheWorker, target:main.TheWorker.dist_sync(work:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Direct"], returnType: Optional(Swift.String), errorType: nil), throwing:Swift.Never, returning:Swift.String
+    // CHECK: replySync direct (remote): dist_sync(work:): Direct
   }
-  let reply = try await callWorker(w: remoteW)
-  print("reply (remote): \(reply)")
-  // CHECK: >> remoteCall: on:main.TheWorker, target:main.TheWorker.submit(work:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Hello"], returnType: Optional(Swift.String), errorType: Optional(Swift.Error)), throwing:Swift.Error, returning:Swift.String
-  // CHECK: << remoteCall return: submit(work:): Hello
-  // CHECK: reply (remote): submit(work:): Hello
+  print("==== ----------------------------------------------------------------")
 
-  let replyLocal = try await callWorker(w: localW)
-  print("reply (local): \(replyLocal)")
-  // CHECK-NOT: >> remoteCall
-  // CHECK: reply (local): submit(work:): Hello
+  do {
+    let reply = try await remoteW.dist_async(work: "Direct")
+    print("replyAsync direct (remote): \(reply)")
+    // CHECK: >> remoteCall: on:main.TheWorker, target:main.TheWorker.dist_async(work:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Direct"], returnType: Optional(Swift.String), errorType: nil), throwing:Swift.Never, returning:Swift.String
+    // CHECK: replyAsync direct (remote): dist_async(work:): Direct
+  }
+  print("==== ----------------------------------------------------------------")
+
+  do {
+    let reply = try await remoteW.dist_syncThrows(work: "Direct")
+    print("replyThrows direct (remote): \(reply)")
+    // CHECK: >> remoteCall: on:main.TheWorker, target:main.TheWorker.dist_syncThrows(work:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Direct"], returnType: Optional(Swift.String), errorType: Optional(Swift.Error)), throwing:Swift.Error, returning:Swift.String
+    // CHECK: replyThrows direct (remote): dist_syncThrows(work:): Direct
+  }
+  print("==== ----------------------------------------------------------------")
+
+  do {
+    let reply = try await remoteW.dist_asyncThrows(work: "Direct")
+    print("replyAsyncThrows direct (remote): \(reply)")
+    // CHECK: >> remoteCall: on:main.TheWorker, target:main.TheWorker.dist_asyncThrows(work:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Direct"], returnType: Optional(Swift.String), errorType: Optional(Swift.Error)), throwing:Swift.Error, returning:Swift.String
+    // CHECK: replyAsyncThrows direct (remote): dist_asyncThrows(work:): Direct
+  }
+  print("==== ----------------------------------------------------------------")
+
+
+  func call_dist_sync<W: DistributedWorker>(w: W) async throws -> String where W.WorkItem == String, W.WorkResult == String {
+    try await w.dist_sync(work: "Hello")
+  }
+  do {
+    let reply = try await call_dist_sync(w: remoteW)
+    print("reply (remote): \(reply)")
+    // CHECK: >> remoteCall: on:main.TheWorker, target:main.TheWorker.dist_sync(work:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Hello"], returnType: Optional(Swift.String), errorType: nil), throwing:Swift.Never, returning:Swift.String
+    // CHECK: << remoteCall return: dist_sync(work:): Hello
+    // CHECK: reply (remote): dist_sync(work:): Hello
+
+    let replyLocal = try await call_dist_sync(w: localW)
+    print("reply (local): \(replyLocal)")
+    // CHECK-NOT: >> remoteCall
+    // CHECK: reply (local): dist_sync(work:): Hello
+  }
+  print("==== ----------------------------------------------------------------")
+
+  func call_dist_async<W: DistributedWorker>(w: W) async throws -> String where W.WorkItem == String, W.WorkResult == String {
+    try await w.dist_async(work: "Hello")
+  }
+  do {
+    let reply = try await call_dist_async(w: remoteW)
+    print("reply (remote): \(reply)")
+    // CHECK: >> remoteCall: on:main.TheWorker, target:main.TheWorker.dist_async(work:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Hello"], returnType: Optional(Swift.String), errorType: nil), throwing:Swift.Never, returning:Swift.String
+    // CHECK: << remoteCall return: dist_async(work:): Hello
+    // CHECK: reply (remote): dist_async(work:): Hello
+
+    let replyLocal = try await call_dist_async(w: localW)
+    print("reply (local): \(replyLocal)")
+    // CHECK-NOT: >> remoteCall
+    // CHECK: reply (local): dist_async(work:): Hello
+  }
+  print("==== ----------------------------------------------------------------")
+
+  func call_dist_throws<W: DistributedWorker>(w: W) async throws -> String where W.WorkItem == String, W.WorkResult == String {
+    try await w.dist_syncThrows(work: "Hello")
+  }
+  do {
+    let reply = try await call_dist_throws(w: remoteW)
+    print("reply (remote): \(reply)")
+    // CHECK: >> remoteCall: on:main.TheWorker, target:main.TheWorker.dist_syncThrows(work:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Hello"], returnType: Optional(Swift.String), errorType: Optional(Swift.Error)), throwing:Swift.Error, returning:Swift.String
+    // CHECK: << remoteCall return: dist_syncThrows(work:): Hello
+    // CHECK: reply (remote): dist_syncThrows(work:): Hello
+
+    let replyLocal = try await call_dist_throws(w: localW)
+    print("reply (local): \(replyLocal)")
+    // CHECK-NOT: >> remoteCall
+    // CHECK: reply (local): dist_syncThrows(work:): Hello
+  }
+  print("==== ----------------------------------------------------------------")
+
+  func call_dist_asyncThrows<W: DistributedWorker>(w: W) async throws -> String where W.WorkItem == String, W.WorkResult == String {
+    try await w.dist_asyncThrows(work: "Hello")
+  }
+  do {
+    let reply = try await call_dist_asyncThrows(w: remoteW)
+    print("reply (remote): \(reply)")
+    // CHECK: >> remoteCall: on:main.TheWorker, target:main.TheWorker.dist_asyncThrows(work:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Hello"], returnType: Optional(Swift.String), errorType: Optional(Swift.Error)), throwing:Swift.Error, returning:Swift.String
+    // CHECK: << remoteCall return: dist_asyncThrows(work:): Hello
+    // CHECK: reply (remote): dist_asyncThrows(work:): Hello
+
+    let replyLocal = try await call_dist_asyncThrows(w: localW)
+    print("reply (local): \(replyLocal)")
+    // CHECK-NOT: >> remoteCall
+    // CHECK: reply (local): dist_asyncThrows(work:): Hello
+  }
+  print("==== ----------------------------------------------------------------")
+  print("=====================================================================")
+
+  // These tests verify that we can call these methods if we "peel off" distributed
+  // isolation, and they'll end up invoking the distributed witnesses. Though the
+  // distributedness of those witnesses never actually is used remotely, but at
+  // least check we invoke the right methods.
+
+  func call_requirement_witnessedByDistributed_sync<W: DistributedWorker>(w: W) async throws -> String where W.WorkItem == String, W.WorkResult == String {
+    try await w.whenLocal { __secretlyKnownToBeLocal in
+      try await __secretlyKnownToBeLocal.asyncThrowsReq_witnessDistributed_sync(work: "Hello")
+    }!
+  }
+  do {
+    let replyLocal = try await call_requirement_witnessedByDistributed_sync(w: localW)
+    print("reply (local): \(replyLocal)")
+    // CHECK-NOT: >> remoteCall
+    // CHECK: reply (local): asyncThrowsReq_witnessDistributed_sync(work:): Hello
+  }
+  print("==== ----------------------------------------------------------------")
+
+  func call_requirement_witnessedByDistributed_async<W: DistributedWorker>(w: W) async throws -> String where W.WorkItem == String, W.WorkResult == String {
+    try await w.whenLocal { __secretlyKnownToBeLocal in
+      try await __secretlyKnownToBeLocal.asyncThrowsReq_witnessDistributed_async(work: "Hello")
+    }!
+  }
+  do {
+    let replyLocal = try await call_requirement_witnessedByDistributed_async(w: localW)
+    print("reply (local): \(replyLocal)")
+    // CHECK-NOT: >> remoteCall
+    // CHECK: reply (local): asyncThrowsReq_witnessDistributed_async(work:): Hello
+  }
+  print("==== ----------------------------------------------------------------")
+
+  func call_requirement_witnessedByDistributed_syncThrows<W: DistributedWorker>(w: W) async throws -> String where W.WorkItem == String, W.WorkResult == String {
+    try await w.whenLocal { __secretlyKnownToBeLocal in
+      try await __secretlyKnownToBeLocal.asyncThrowsReq_witnessDistributed_syncThrows(work: "Hello")
+    }!
+  }
+  do {
+    let replyLocal = try await call_requirement_witnessedByDistributed_syncThrows(w: localW)
+    print("reply (local): \(replyLocal)")
+    // CHECK-NOT: >> remoteCall
+    // CHECK: reply (local): asyncThrowsReq_witnessDistributed_syncThrows(work:): Hello
+  }
+  print("==== ----------------------------------------------------------------")
+
+  func call_requirement_witnessedByDistributed_asyncThrows<W: DistributedWorker>(w: W) async throws -> String where W.WorkItem == String, W.WorkResult == String {
+    try await w.whenLocal { __secretlyKnownToBeLocal in
+      try await __secretlyKnownToBeLocal.asyncThrowsReq_witnessDistributed_asyncThrows(work: "Hello")
+    }!
+  }
+  do {
+    let replyLocal = try await call_requirement_witnessedByDistributed_asyncThrows(w: localW)
+    print("reply (local): \(replyLocal)")
+    // CHECK-NOT: >> remoteCall
+    // CHECK: reply (local): asyncThrowsReq_witnessDistributed_asyncThrows(work:): Hello
+  }
+  print("==== ----------------------------------------------------------------")
 }
 
 func test_whenLocal(system: DefaultDistributedActorSystem) async throws {
@@ -119,11 +304,11 @@ func test_whenLocal(system: DefaultDistributedActorSystem) async throws {
 
   do {
     let replyDistSubmit = try await localW.whenLocal { __secretlyKnownToBeLocal in
-      try await __secretlyKnownToBeLocal.submit(work: "local-test")
+      try await __secretlyKnownToBeLocal.dist_sync(work: "local-test")
     }
-    print("replyDistSubmit (local): \(replyDistSubmit ?? "nil")")
+    print("replyDistSync (local): \(replyDistSubmit ?? "nil")")
     // CHECK-NOT: >> remoteCall
-    // CHECK: replyDistSubmit (local): submit(work:): local-test
+    // CHECK: replyDistSync (local): dist_sync(work:): local-test
 
     let replySyncLocal = await localW.whenLocal { __secretlyKnownToBeLocal in
       __secretlyKnownToBeLocal.sync(work: "local-test")
@@ -155,11 +340,45 @@ func test_whenLocal(system: DefaultDistributedActorSystem) async throws {
   }
 }
 
+func test_generic_plain(system: DefaultDistributedActorSystem) async throws {
+  let localW = ThePlainWorker(actorSystem: system)
+  let remoteW = try! ThePlainWorker.resolve(id: localW.id, using: system)
+  precondition(__isRemoteActor(remoteW))
+
+  // direct calls work ok:
+  do {
+    let reply = try await remoteW.asyncThrows(work: "Direct")
+    print("replySync direct (remote): \(reply)")
+    // CHECK: >> remoteCall: on:main.ThePlainWorker, target:main.ThePlainWorker.asyncThrows(work:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Direct"], returnType: Optional(Swift.String), errorType: Optional(Swift.Error)), throwing:Swift.Error, returning:Swift.String
+    // CHECK: replySync direct (remote): asyncThrows(work:): Direct
+  }
+  print("==== ----------------------------------------------------------------")
+
+  func call_plainWorker<W: PlainWorker>(w: W) async throws -> String where W.WorkItem == String, W.WorkResult == String {
+    try await w.asyncThrows(work: "Hello")
+  }
+  do {
+    let reply = try await call_plainWorker(w: remoteW)
+    print("reply (remote): \(reply)")
+    // CHECK: >> remoteCall: on:main.ThePlainWorker, target:main.ThePlainWorker.asyncThrows(work:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Hello"], returnType: Optional(Swift.String), errorType: Optional(Swift.Error)), throwing:Swift.Error, returning:Swift.String
+    // CHECK: << remoteCall return: asyncThrows(work:): Hello
+    // CHECK: reply (remote): asyncThrows(work:): Hello
+
+    let replyLocal = try await call_plainWorker(w: localW)
+    print("reply (local): \(replyLocal)")
+    // CHECK-NOT: >> remoteCall
+    // CHECK: reply (local): asyncThrows(work:): Hello
+  }
+}
+
 @main struct Main {
   static func main() async {
     let system = DefaultDistributedActorSystem()
+    print("===================================================================")
     try! await test_generic(system: system)
-    print("==== ---------------------------------------------------")
+    print("===================================================================")
     try! await test_whenLocal(system: system)
+    print("===================================================================")
+    try! await test_generic_plain(system: system)
   }
 }

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_through_generic_and_inner.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_through_generic_and_inner.swift
@@ -1,0 +1,100 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-build-swift -module-name main  -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s --color
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// rdar://76038845
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+// FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
+// UNSUPPORTED: OS=windows-msvc
+
+import Distributed
+import FakeDistributedActorSystems
+
+typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
+
+protocol Greeting: DistributedActor {
+  distributed func greeting() -> String
+  distributed func greetingAsyncThrows() async throws -> String
+}
+
+extension Greeting {
+  func greetLocal(name: String) async throws {
+    try await print("\(greetingAsyncThrows()), \(name)!") // requirement is async throws, things work
+  }
+
+  func greetLocal2(name: String) {
+    print("\(greeting()), \(name)!")
+  }
+}
+
+extension Greeting where SerializationRequirement == Codable {
+  // okay, uses Codable to transfer arguments.
+  distributed func greetDistributed(name: String) async throws {
+    // okay, we're on the actor
+    try await greetLocal(name: name)
+  }
+
+  distributed func greetDistributed2(name: String) async throws {
+    // okay, we're on the actor
+    greetLocal2(name: name)
+  }
+
+  func greetDistributedNon(name: String) async throws {
+    // okay, we're on the actor
+    greetLocal2(name: name)
+  }
+}
+
+extension Greeting where SerializationRequirement == Codable {
+  nonisolated func greetAliceALot() async throws {
+    try await greetDistributed(name: "Alice") // okay, via Codable
+    let rawGreeting = try await greeting() // okay, via Self's serialization requirement
+    // greetLocal(name: "Alice") // would be error: only 'distributed' instance methods can be called on a potentially remote distributed actor}}
+  }
+}
+
+distributed actor Greeter: Greeting {
+  distributed func greeting() -> String {
+    "Hello"
+  }
+
+  distributed func greetingAsyncThrows() -> String {
+    noop() // no await needed, we're in the same actor
+    return "Hello from AsyncThrows"
+  }
+
+  func callNoop() {
+    noop() // no await needed, we're in the same actor
+  }
+
+  distributed func noop() {
+    // nothing
+  }
+}
+
+func test() async throws {
+  let system = DefaultDistributedActorSystem()
+  let g = Greeter(actorSystem: system)
+
+  let greeting = try await g.greeting()
+  print("greeting(): \(greeting)") // CHECK: greeting(): Hello
+
+  try await g.greetDistributed(name: "Caplin")
+  // CHECK: Hello from AsyncThrows, Caplin!
+
+  try await g.greetDistributed2(name: "Caplin")
+  // CHECK: Hello, Caplin!
+}
+
+@main struct Main {
+  static func main() async {
+    try! await test()
+  }
+}

--- a/test/Distributed/distributed_actor_inference.swift
+++ b/test/Distributed/distributed_actor_inference.swift
@@ -42,13 +42,11 @@ protocol DP {
 }
 
 protocol DPOK: DistributedActor {
-  distributed func hello() // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
-  // expected-error@-1{{'distributed' protocol requirement 'hello()' must currently be declared explicitly 'async throws'}}
+  distributed func hello()
 }
 
 protocol DPOK2: DPOK {
-  distributed func again() // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
-  // expected-error@-1{{'distributed' protocol requirement 'again()' must currently be declared explicitly 'async throws'}}
+  distributed func again()
 }
 
 enum SomeNotActorEnum_5 {

--- a/test/Distributed/distributed_actor_protocol_isolation.swift
+++ b/test/Distributed/distributed_actor_protocol_isolation.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/Inputs/FakeDistributedActorSystems.swift
-// RUN: %target-swift-frontend -typecheck -verify -disable-availability-checking -I %t 2>&1 %s
+// RUN: %target-swift-frontend-emit-module -I %t -emit-module-path %t/distributed_actor_protocol_isolation.swiftmodule -module-name distributed_actor_protocol_isolation -disable-availability-checking %s
+// X: %target-swift-frontend -typecheck -verify -disable-availability-checking -I %t 2>&1 %s
 // REQUIRES: concurrency
 // REQUIRES: distributed
 
@@ -9,117 +10,28 @@ import FakeDistributedActorSystems
 
 typealias DefaultDistributedActorSystem = FakeActorSystem
 
-// ==== ------------------------------------------------------------------------
-// MARK: Protocols
-
-protocol LocalProto {
-  func local()
-  // expected-note@-1 2{{mark the protocol requirement 'local()' 'async throws' to allow actor-isolated conformances}}
-
-  func localAsync() async
-  // expected-note@-1 2{{mark the protocol requirement 'localAsync()' 'throws' to allow actor-isolated conformances}}{{26-26= throws}}
-
-  func localThrows() throws
-  // expected-note@-1 2{{mark the protocol requirement 'localThrows()' 'async' to allow actor-isolated conformances}}{{22-22=async }}
-
-  func localAsyncThrows() async throws
-  // expected-note@-1{{'localAsyncThrows()' declared here}}
+protocol Greeting: DistributedActor {
+  distributed func greeting() -> String
 }
 
-// TODO(distributed): It should be possible for a distributed actor to conform to this protocol (!),
-//    along with known to be local and proper checking, this can be made safe, and then we have full
-//    protocol oriented programming capabilities for our actors, without having to suddenly
-//    expose everything as distributed (!); rdar://84587437
-protocol MixedProtoDistributedActor: DistributedActor {
-  // only callable on a "known to be local" distributed actor:
-  func local()
-  func localAsync() async
-  func localThrows() throws
-  func localAsyncThrows() async throws
-
-//  distributed func dist() // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
-//  distributed func distAsync() async // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
-  distributed func distAsyncThrows() async throws
+extension Greeting {
+  func greetLocal(name: String) {
+    print("\(greeting()), \(name)!") // okay, we're on the actor
+  }
 }
 
-protocol DistProtoDistributedActor: DistributedActor {
-  distributed func dist() // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
-  // expected-error@-1{{'distributed' protocol requirement 'dist()' must currently be declared explicitly 'async throws'}}
-  distributed func distAsync() async // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
-  // expected-error@-1{{'distributed' protocol requirement 'distAsync()' must currently be declared explicitly 'async throws'}}
-  distributed func distThrows() throws // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
-  // expected-error@-1{{'distributed' protocol requirement 'distThrows()' must currently be declared explicitly 'async throws'}}
-  distributed func distAsyncThrows() async throws
+extension Greeting where SerializationRequirement == Codable {
+  // okay, uses Codable to transfer arguments.
+  distributed func greetDistributed(name: String) {
+    // okay, we're on the actor
+    greetLocal(name: name)
+  }
 }
 
-// ==== ------------------------------------------------------------------------
-// MARK: Actors
-
-distributed actor DAL: LocalProto {
-  func local() {}
-  // expected-error@-1{{distributed actor-isolated instance method 'local()' cannot be used to satisfy nonisolated protocol requirement}}
-  // expected-note@-2{{add 'nonisolated' to 'local()' to make this instance method not isolated to the actor}}
-  func localAsync() async {}
-  // expected-error@-1{{distributed actor-isolated instance method 'localAsync()' cannot be used to satisfy nonisolated protocol requirement}}
-  // expected-note@-2{{add 'nonisolated' to 'localAsync()' to make this instance method not isolated to the actor}}
-  func localThrows() throws {}
-  // expected-error@-1{{distributed actor-isolated instance method 'localThrows()' cannot be used to satisfy nonisolated protocol requirement}}
-  // expected-note@-2{{add 'nonisolated' to 'localThrows()' to make this instance method not isolated to the actor}}
-  func localAsyncThrows() async throws {}
-  // expected-error@-1{{distributed actor-isolated instance method 'localAsyncThrows()' cannot be used to satisfy nonisolated protocol requirement}}
-  // expected-note@-2{{add 'nonisolated' to 'localAsyncThrows()' to make this instance method not isolated to the actor}}
-  // expected-note@-3{{add 'distributed' to 'localAsyncThrows()' to make this instance method satisfy the protocol requirement}}
-}
-
-distributed actor DAD: LocalProto {
-  distributed func local() {}
-  // expected-error@-1{{actor-isolated distributed instance method 'local()' cannot be used to satisfy nonisolated protocol requirement}}
-
-  distributed func localAsync() async {}
-  // expected-error@-1{{actor-isolated distributed instance method 'localAsync()' cannot be used to satisfy nonisolated protocol requirement}}
-
-  distributed func localThrows() throws {}
-  // expected-error@-1{{actor-isolated distributed instance method 'localThrows()' cannot be used to satisfy nonisolated protocol requirement}}
-
-  distributed func localAsyncThrows() async throws {} // ok!
-}
-
-// ==== ------------------------------------------------------------------------
-
-distributed actor DA2: DistProtoDistributedActor {
-  func local() {}
-  // expected-note@-1{{distributed actor-isolated instance method 'local()' declared here}}
-  func localAsync() async {}
-  // expected-note@-1{{distributed actor-isolated instance method 'localAsync()' declared here}}
-  func localAsyncThrows() async throws {}
-  // expected-note@-1{{distributed actor-isolated instance method 'localAsyncThrows()' declared here}}
-
-  distributed func dist() {}
-  distributed func distAsync() async {}
-  distributed func distThrows() throws {}
-  distributed func distAsyncThrows() async throws {}
-}
-
-func testDA2(da: DA2) async throws {
-  da.local() // expected-error{{only 'distributed' instance methods can be called on a potentially remote distributed actor}}
-  await da.localAsync() // expected-error{{only 'distributed' instance methods can be called on a potentially remote distributed actor}}
-  try await da.localAsyncThrows() // expected-error{{only 'distributed' instance methods can be called on a potentially remote distributed actor}}
-
-  try await da.dist()
-  try await da.distAsync()
-  try await da.distThrows()
-  try await da.distAsyncThrows()
-}
-
-func testDA2_butKnownToBeLocal(da: DA2) async throws {
-  try await da.whenLocal { __secretlyKnownToBeLocal in
-    __secretlyKnownToBeLocal.local()
-    await __secretlyKnownToBeLocal.localAsync()
-    try await __secretlyKnownToBeLocal.localAsyncThrows()
-
-    __secretlyKnownToBeLocal.dist()
-    await __secretlyKnownToBeLocal.distAsync()
-    try __secretlyKnownToBeLocal.distThrows()
-    try await __secretlyKnownToBeLocal.distAsyncThrows()
+extension Greeting {
+  nonisolated func greetAliceALot() async throws {
+//    try await greetDistributed(name: "Alice") // okay, via Codable
+//    let rawGreeting = try await greeting() // okay, via Self's serialization requirement
+//    greetLocal(name: "Alice") // expected-error{{only 'distributed' instance methods can be called on a potentially remote distributed actor}}
   }
 }

--- a/test/Distributed/distributed_protocol_isolation.swift
+++ b/test/Distributed/distributed_protocol_isolation.swift
@@ -25,15 +25,11 @@ protocol DistProtocol: DistributedActor {
   // expected-note@-3{{distributed actor-isolated instance method 'local()' declared here}}
   // expected-note@-4{{distributed actor-isolated instance method 'local()' declared here}}
 
-  distributed func dist() -> String // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
-  // expected-error@-1{{'distributed' protocol requirement 'dist()' must currently be declared explicitly 'async throws'}}
-  distributed func dist(string: String) -> String // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
-  // expected-error@-1{{'distributed' protocol requirement 'dist(string:)' must currently be declared explicitly 'async throws'}}
+  distributed func dist() -> String
+  distributed func dist(string: String) -> String
 
-  distributed func distAsync() async -> String // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
-  // expected-error@-1{{'distributed' protocol requirement 'distAsync()' must currently be declared explicitly 'async throws'}}
-  distributed func distThrows() throws -> String // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
-  // expected-error@-1{{'distributed' protocol requirement 'distThrows()' must currently be declared explicitly 'async throws'}}
+  distributed func distAsync() async -> String
+  distributed func distThrows() throws -> String
   distributed func distAsyncThrows() async throws -> String
 }
 
@@ -251,22 +247,6 @@ func test_watchingDA_any(da: any TerminationWatchingDA) async throws {
   try await da.terminated(da: "the terminated func is not distributed")
   // expected-error@-1{{only 'distributed' instance methods can be called on a potentially remote distributed actor}}
   // expected-warning@-2{{no calls to throwing functions occur within 'try' expression}}
-}
-
-// ==== ------------------------------------------------------------------------
-// MARK: Error cases
-
-protocol ErrorCases: DistributedActor {
-  distributed func unexpectedAsyncThrows() -> String // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
-  // expected-error@-1{{'distributed' protocol requirement 'unexpectedAsyncThrows()' must currently be declared explicitly 'async throws'}}
-  // expected-note@-2{{protocol requires function 'unexpectedAsyncThrows()' with type '() -> String'; do you want to add a stub?}}
-}
-
-distributed actor BadGreeter: ErrorCases {
-  // expected-error@-1{{type 'BadGreeter' does not conform to protocol 'ErrorCases'}}
-
-  distributed func unexpectedAsyncThrows() async throws -> String { "" }
-  // expected-note@-1{{candidate is 'async', but protocol requirement is not}}
 }
 
 // ==== ------------------------------------------------------------------------

--- a/test/Distributed/distributed_protocols_distributed_func_serialization_requirements.swift
+++ b/test/Distributed/distributed_protocols_distributed_func_serialization_requirements.swift
@@ -10,8 +10,7 @@ import FakeDistributedActorSystems
 struct NotCodable {}
 
 protocol NoSerializationRequirementYet: DistributedActor {
-  distributed func test() -> NotCodable // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
-  // expected-error@-1{{'distributed' protocol requirement 'test()' must currently be declared explicitly 'async throws'}}
+  distributed func test() -> NotCodable
 
   // OK, no serialization requirement yet
   distributed func testAT() async throws -> NotCodable

--- a/test/SILGen/distributed_thunk.swift
+++ b/test/SILGen/distributed_thunk.swift
@@ -1,4 +1,4 @@
-// RUN:  %target-swift-emit-silgen %s -enable-experimental-distributed -disable-availability-checking | %FileCheck %s 
+// RUN: %target-swift-emit-silgen %s -enable-experimental-distributed -disable-availability-checking | %FileCheck %s
 // REQUIRES: concurrency
 // REQUIRES: distributed
 
@@ -24,7 +24,7 @@ protocol ServerProto {
 
 extension DA: ServerProto {
   // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s17distributed_thunk2DACAA11ServerProtoA2aDP11doSomethingyyYaKFTW : $@convention(witness_method: ServerProto) @async (@in_guaranteed DA) -> @error Error
-  // CHECK-NOT: hop_to_executor
+  // TODO: we do hop here actually; ...-NOT: hop_to_executor
   // CHECK: function_ref @$s17distributed_thunk2DAC11doSomethingyyYaKFTE
   // CHECK: return
   distributed func doSomething() { }
@@ -54,7 +54,7 @@ distributed actor DA4: ServerProto {
   typealias ActorSystem = LocalTestingDistributedActorSystem
 
   // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s17distributed_thunk3DA4CAA11ServerProtoA2aDP11doSomethingyyYaKFTW
-  // CHECK-NOT: hop_to_executor
+  // TODO: we do hop here actually; ...-NOT: hop_to_executor
   // CHECK-NOT: return
   // CHECK: function_ref @$s17distributed_thunk3DA4C11doSomethingyyYaKFTE
   distributed func doSomething() throws { }

--- a/test/decl/protocol/special/DistributedActor.swift
+++ b/test/decl/protocol/special/DistributedActor.swift
@@ -64,9 +64,8 @@ distributed actor D4 {
 }
 
 protocol P1: DistributedActor {
-  distributed func dist() -> String // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
-  // expected-error@-1{{'distributed' protocol requirement 'dist()' must currently be declared explicitly 'async throws'}}
-  // expected-note@-2{{'dist()' declared here}}
+  distributed func dist() -> String
+  // expected-note@-1{{'dist()' declared here}}
 }
 
 distributed actor D5: P1 {


### PR DESCRIPTION
Depends on:
- #59711
- #59718

### Summary

With this, distributed funcs in protocols are fully functional.

This now correctly implements witnesses and also respects isolation as to when the distributed thunk must be called and when not etc.

This is correct and future proof wrt. any way we'd implement `local` in the future as well, because:

- unlike a concrete distributed actor; even in presence of the "whenLocal" and any potential `local` work, the distributedness _cannot_ be peeled off from a protocol requirement!

- This is because even if we declared the witness as a plain func... the witness is **always allowed to** implement a distributed func requirement using: no effects, async, or throws (or a mix of them)
  - As such... given `any SomeDAProtocol` even if that is a `any _local SomeDAProtocol` can **cannot** ever strip off the implicit async and throws effects from a distributed call on a protocol -- because we don't know (at call sites) how the method was implemented -- and if it was a local actor... we must assume the worst case anyway and `try await` such calls.
  - This does not get into the way of usefulness of the `_local` work -- which's primary purpose is access to NOT-distributed members, which all work as previously.


**Risk:** Low, only impacts distributed funcs in protocols; and is well tested now with runtime (actually calling) tests
**Review:** @DougGregor @xedin 
**Testing:** CI testing, will verify on cluster project manually as well

Resolves rdar://95949498