### PR TITLE
[5.7][PreCheckExpr] Don't silence errors while resolving types for 'litera…

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3793,6 +3793,19 @@ NeverNullType TypeResolver::resolveImplicitlyUnwrappedOptionalType(
   if (doDiag && !options.contains(TypeResolutionFlags::SilenceErrors)) {
     // Prior to Swift 5, we allow 'as T!' and turn it into a disjunction.
     if (getASTContext().isSwiftVersionAtLeast(5)) {
+      // Mark this repr as invalid. This is the only way to indicate that
+      // something went wrong without supressing checking other reprs in
+      // the same type. For example:
+      //
+      // struct S<T, U> { ... }
+      //
+      // _ = S<Int!, String!>(...)
+      //
+      // Compiler should diagnose both `Int!` and `String!` as invalid,
+      // but returning `ErrorType` from here would stop type resolution
+      // after `Int!`.
+      repr->setInvalid();
+
       diagnose(repr->getStartLoc(),
                diag::implicitly_unwrapped_optional_in_illegal_position)
           .fixItReplace(repr->getExclamationLoc(), "?");

--- a/test/Sema/diag_erroneous_iuo.swift
+++ b/test/Sema/diag_erroneous_iuo.swift
@@ -61,11 +61,8 @@ func genericFunctionSigil<T>(
 }
 
 func genericFunctionSigilArray<T>(
-  // FIXME: We validate these types multiple times resulting in multiple diagnostics
   iuo: [T!] // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{10-11=?}}
-  // expected-error@-1 {{'!' is not allowed here; perhaps '?' was intended?}}{{10-11=?}}
 ) -> [T!] { // expected-error {{'!' is not allowed here; perhaps '?' was intended?}}{{8-9=?}}
-  // expected-error@-1 {{'!' is not allowed here; perhaps '?' was intended?}}{{8-9=?}}
   return iuo
 }
 

--- a/test/type/types.swift
+++ b/test/type/types.swift
@@ -194,3 +194,12 @@ var _: sr5505 = sr5505 // expected-error {{cannot find type 'sr5505' in scope}}
 typealias A = (inout Int ..., Int ... = [42, 12]) -> Void // expected-error {{'inout' must not be used on variadic parameters}}
                                                           // expected-error@-1 {{only a single element can be variadic}} {{35-39=}}
                                                           // expected-error@-2 {{default argument not permitted in a tuple type}} {{39-49=}}
+
+// rdar://94888357 - failed to produce a diagnostic when type is used incorrectly
+func rdar94888357() {
+  struct S<T> { // expected-note {{generic type 'S' declared here}}
+    init(_ str: String) {}
+  }
+
+  let _ = S<String, String>("") // expected-error {{generic type 'S' specialized with too many type parameters (got 2, but expected 1)}}
+}


### PR DESCRIPTION
…l via coercion' transform

Cherry-pick of https://github.com/apple/swift/pull/59685

---

Since `resolveType` caches its results, silencing errors would mean
that the error would be lost and each subsequent call to `resolveType`
would get `ErrorType` back. This ultimately leads to the compiler
failing to produce a diagnostic when invalid type is used in `init`
call.

These changes include marking IUO reprs found in incorrect positions,
such as generic arguments, as invalid right before diagnosing them as
errors, this helps to prevent type resolution from producing duplicate
diagnostics.

Resolves: rdar://94888357

(cherry picked from commit 601a1dd42cf90e09de191af02d1cd6f3ceab2f3d)
(cherry picked from commit 5ac81820358eac46e271ae6780e8bcf9ca8c63f0)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
