### PR TITLE
[5.7][Immediate]: Workaround for loading Foundation in immediate mode

### DIFF
--- a/lib/Immediate/Immediate.cpp
+++ b/lib/Immediate/Immediate.cpp
@@ -201,7 +201,12 @@ bool swift::immediate::autolinkImportedModules(ModuleDecl *M,
 
   M->collectLinkLibraries(addLinkLibrary);
 
-  // Workaround for rdar://94645534
+  // Workaround for rdar://94645534.
+  //
+  // The framework layout of Foundation has changed in 13.0, causing unresolved symbol
+  // errors to libswiftFoundation in immediate mode when running on older OS versions
+  // with a 13.0 SDK. This workaround scans through the list of dependencies and
+  // manually adds libswiftFoundation if necessary.
   if (Target.isMacOSX() && Target.getOSMajorVersion() < 13) {
     bool linksFoundation = std::any_of(AllLinkLibraries.begin(),
         AllLinkLibraries.end(), [](auto &Lib) {

--- a/lib/Immediate/Immediate.cpp
+++ b/lib/Immediate/Immediate.cpp
@@ -207,6 +207,7 @@ bool swift::immediate::autolinkImportedModules(ModuleDecl *M,
   // errors to libswiftFoundation in immediate mode when running on older OS versions
   // with a 13.0 SDK. This workaround scans through the list of dependencies and
   // manually adds libswiftFoundation if necessary.
+  auto &Target = M->getASTContext().LangOpts.Target;
   if (Target.isMacOSX() && Target.getOSMajorVersion() < 13) {
     bool linksFoundation = std::any_of(AllLinkLibraries.begin(),
         AllLinkLibraries.end(), [](auto &Lib) {


### PR DESCRIPTION
Cherry picked from https://github.com/apple/swift/pull/59730.

Explanation: The framework layout of Foundation has changed in 13.0, causing unresolved symbol errors to `libswiftFoundation` in immediate mode when running on older OS versions with a 13.0 SDK. This workaround scans through the list of dependencies and manually adds `libswiftFoundation` if necessary.
Scope: Immediate mode
Risk: Low
Testing: Local testing
Reviewer: @nate-chandler 
Issue: rdar://94645534
