### PR TITLE
Permanently disable test/Concurrency/Runtime/clock.swift

### DIFF
--- a/test/Concurrency/Runtime/clock.swift
+++ b/test/Concurrency/Runtime/clock.swift
@@ -9,6 +9,9 @@
 // UNSUPPORTED: back_deployment_runtime
 // UNSUPPORTED: back_deploy_concurrency
 
+// This test is disabled because it seems to require dedicated CPU access:
+// REQUIRES: rdar94451729
+
 import _Concurrency
 import StdlibUnittest
 


### PR DESCRIPTION
There is still an open radar for the author to consider deleting
the test or reimagining it somehow:
rdar:94451729 (Swift CI: Concurrency/Runtime/clock.swift failed despite increased timeout)
