### PR TITLE
[Serialization] Pass along allow errors/skip bodies flags

### DIFF
--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -433,7 +433,8 @@ public:
   static bool buildSwiftModuleFromSwiftInterface(
       SourceManager &SourceMgr, DiagnosticEngine &Diags,
       const SearchPathOptions &SearchPathOpts, const LangOptions &LangOpts,
-      const ClangImporterOptions &ClangOpts, StringRef CacheDir,
+      const ClangImporterOptions &ClangOpts,
+      const TypeCheckerOptions &TypeCheckerOpts, StringRef CacheDir,
       StringRef PrebuiltCacheDir, StringRef BackupInterfaceDir,
       StringRef ModuleName, StringRef InPath,
       StringRef OutPath, StringRef ABIOutputPath,
@@ -468,6 +469,7 @@ private:
   void
   inheritOptionsForBuildingInterface(const SearchPathOptions &SearchPathOpts,
                                      const LangOptions &LangOpts,
+                                     const TypeCheckerOptions &TypeCheckerOpts,
                                      RequireOSSAModules_t requireOSSAModules);
   bool extractSwiftInterfaceVersionAndArgs(CompilerInvocation &subInvocation,
                                            SmallVectorImpl<const char *> &SubArgs,
@@ -479,6 +481,7 @@ public:
       SourceManager &SM, DiagnosticEngine *Diags,
       const SearchPathOptions &searchPathOpts, const LangOptions &langOpts,
       const ClangImporterOptions &clangImporterOpts,
+      const TypeCheckerOptions &typeCheckerOpts,
       ModuleInterfaceLoaderOptions LoaderOpts, bool buildModuleCacheDirIfAbsent,
       StringRef moduleCachePath, StringRef prebuiltCachePath,
       StringRef backupModuleInterfaceDir,

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -1416,7 +1416,7 @@ swift::dependencies::performModuleScan(CompilerInstance &instance,
   ModuleInterfaceLoaderOptions LoaderOpts(FEOpts);
   InterfaceSubContextDelegateImpl ASTDelegate(
       ctx.SourceMgr, &ctx.Diags, ctx.SearchPathOpts, ctx.LangOpts,
-      ctx.ClangImporterOpts, LoaderOpts,
+      ctx.ClangImporterOpts, ctx.TypeCheckerOpts, LoaderOpts,
       /*buildModuleCacheDirIfAbsent*/ false, ModuleCachePath,
       FEOpts.PrebuiltModuleCachePath,
       FEOpts.BackupModuleInterfaceDir,
@@ -1516,7 +1516,7 @@ swift::dependencies::performBatchModuleScan(
             allModules;
         InterfaceSubContextDelegateImpl ASTDelegate(
             ctx.SourceMgr, &ctx.Diags, ctx.SearchPathOpts, ctx.LangOpts,
-            ctx.ClangImporterOpts, LoaderOpts,
+            ctx.ClangImporterOpts, ctx.TypeCheckerOpts, LoaderOpts,
             /*buildModuleCacheDirIfAbsent*/ false, ModuleCachePath,
             FEOpts.PrebuiltModuleCachePath,
             FEOpts.BackupModuleInterfaceDir,
@@ -1586,7 +1586,7 @@ swift::dependencies::performBatchModulePrescan(
             allModules;
         InterfaceSubContextDelegateImpl ASTDelegate(
             ctx.SourceMgr, &ctx.Diags, ctx.SearchPathOpts, ctx.LangOpts,
-            ctx.ClangImporterOpts, LoaderOpts,
+            ctx.ClangImporterOpts, ctx.TypeCheckerOpts, LoaderOpts,
             /*buildModuleCacheDirIfAbsent*/ false, ModuleCachePath,
             FEOpts.PrebuiltModuleCachePath,
             FEOpts.BackupModuleInterfaceDir,

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -583,7 +583,8 @@ bool CompilerInstance::setUpModuleLoaders() {
     ModuleInterfaceLoaderOptions LoaderOpts(FEOpts);
     InterfaceSubContextDelegateImpl ASTDelegate(
         Context->SourceMgr, &Context->Diags, Context->SearchPathOpts,
-        Context->LangOpts, Context->ClangImporterOpts, LoaderOpts,
+        Context->LangOpts, Context->ClangImporterOpts,
+        Context->TypeCheckerOpts, LoaderOpts,
         /*buildModuleCacheDirIfAbsent*/ false, ModuleCachePath,
         FEOpts.PrebuiltModuleCachePath,
         FEOpts.BackupModuleInterfaceDir,
@@ -1318,7 +1319,7 @@ static void countStatsPostSILOpt(UnifiedStatsReporter &Stats,
 
 bool CompilerInstance::performSILProcessing(SILModule *silModule) {
   if (performMandatorySILPasses(Invocation, silModule) &&
-      !Invocation.getFrontendOptions().AllowModuleWithCompilerErrors)
+      !Invocation.getLangOptions().AllowModuleWithCompilerErrors)
     return true;
 
   {

--- a/lib/Frontend/ModuleInterfaceBuilder.cpp
+++ b/lib/Frontend/ModuleInterfaceBuilder.cpp
@@ -252,7 +252,8 @@ bool ModuleInterfaceBuilder::buildSwiftModuleInternal(
     };
 
     SubInstance.performSema();
-    if (SubInstance.getASTContext().hadError()) {
+    if (SubInstance.getASTContext().hadError() &&
+        !SubInstance.getASTContext().LangOpts.AllowModuleWithCompilerErrors) {
       LLVM_DEBUG(llvm::dbgs() << "encountered errors\n");
       return std::make_error_code(std::errc::not_supported);
     }
@@ -309,7 +310,8 @@ bool ModuleInterfaceBuilder::buildSwiftModuleInternal(
       LLVM_DEBUG(llvm::dbgs() << "encountered errors\n");
       return std::make_error_code(std::errc::not_supported);
     }
-    if (SubInstance.getDiags().hadAnyError()) {
+    if (SubInstance.getDiags().hadAnyError() &&
+        !SubInstance.getASTContext().LangOpts.AllowModuleWithCompilerErrors) {
       return std::make_error_code(std::errc::not_supported);
     }
     return std::error_code();

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -916,7 +916,7 @@ class ModuleInterfaceLoaderImpl {
     }
     InterfaceSubContextDelegateImpl astDelegate(
         ctx.SourceMgr, &ctx.Diags, ctx.SearchPathOpts, ctx.LangOpts,
-        ctx.ClangImporterOpts, Opts,
+        ctx.ClangImporterOpts, ctx.TypeCheckerOpts, Opts,
         /*buildModuleCacheDirIfAbsent*/ true, cacheDir, prebuiltCacheDir,
         backupInterfaceDir,
         /*serializeDependencyHashes*/ false, trackSystemDependencies,
@@ -1226,7 +1226,8 @@ bool ModuleInterfaceCheckerImpl::tryEmitForwardingModule(
 bool ModuleInterfaceLoader::buildSwiftModuleFromSwiftInterface(
     SourceManager &SourceMgr, DiagnosticEngine &Diags,
     const SearchPathOptions &SearchPathOpts, const LangOptions &LangOpts,
-    const ClangImporterOptions &ClangOpts, StringRef CacheDir,
+    const ClangImporterOptions &ClangOpts,
+    const TypeCheckerOptions &TypeCheckerOpts, StringRef CacheDir,
     StringRef PrebuiltCacheDir, StringRef BackupInterfaceDir,
     StringRef ModuleName, StringRef InPath,
     StringRef OutPath, StringRef ABIOutputPath,
@@ -1234,8 +1235,8 @@ bool ModuleInterfaceLoader::buildSwiftModuleFromSwiftInterface(
     bool TrackSystemDependencies, ModuleInterfaceLoaderOptions LoaderOpts,
     RequireOSSAModules_t RequireOSSAModules) {
   InterfaceSubContextDelegateImpl astDelegate(
-      SourceMgr, &Diags, SearchPathOpts, LangOpts, ClangOpts, LoaderOpts,
-      /*CreateCacheDirIfAbsent*/ true, CacheDir, PrebuiltCacheDir,
+      SourceMgr, &Diags, SearchPathOpts, LangOpts, ClangOpts, TypeCheckerOpts,
+      LoaderOpts, /*CreateCacheDirIfAbsent*/ true, CacheDir, PrebuiltCacheDir,
       BackupInterfaceDir,
       SerializeDependencyHashes, TrackSystemDependencies, RequireOSSAModules);
   ModuleInterfaceBuilder builder(SourceMgr, &Diags, astDelegate, InPath,
@@ -1278,6 +1279,7 @@ void ModuleInterfaceLoader::collectVisibleTopLevelModuleNames(
 
 void InterfaceSubContextDelegateImpl::inheritOptionsForBuildingInterface(
     const SearchPathOptions &SearchPathOpts, const LangOptions &LangOpts,
+    const TypeCheckerOptions &TypeCheckerOpts,
     RequireOSSAModules_t RequireOSSAModules) {
   GenericArgs.push_back("-frontend");
   // Start with a genericSubInvocation that copies various state from our
@@ -1364,6 +1366,15 @@ void InterfaceSubContextDelegateImpl::inheritOptionsForBuildingInterface(
       std::string pair = (llvm::Twine(lhs) + "=" + rhs).str();
       GenericArgs.push_back(ArgSaver.save(pair));
   });
+
+  genericSubInvocation.getTypeCheckerOptions().SkipFunctionBodies =
+      TypeCheckerOpts.SkipFunctionBodies;
+
+  // It could be the case that building a swiftinterface depends on a local
+  // module, which may have errors. This will *always* crash unless allowing
+  // errors is passed down.
+  genericSubInvocation.getLangOptions().AllowModuleWithCompilerErrors =
+      LangOpts.AllowModuleWithCompilerErrors;
 }
 
 bool InterfaceSubContextDelegateImpl::extractSwiftInterfaceVersionAndArgs(
@@ -1439,6 +1450,7 @@ InterfaceSubContextDelegateImpl::InterfaceSubContextDelegateImpl(
     SourceManager &SM, DiagnosticEngine *Diags,
     const SearchPathOptions &searchPathOpts, const LangOptions &langOpts,
     const ClangImporterOptions &clangImporterOpts,
+    const TypeCheckerOptions &typeCheckerOpts,
     ModuleInterfaceLoaderOptions LoaderOpts, bool buildModuleCacheDirIfAbsent,
     StringRef moduleCachePath, StringRef prebuiltCachePath,
     StringRef backupModuleInterfaceDir,
@@ -1446,7 +1458,7 @@ InterfaceSubContextDelegateImpl::InterfaceSubContextDelegateImpl(
     RequireOSSAModules_t requireOSSAModules)
     : SM(SM), Diags(Diags), ArgSaver(Allocator) {
   genericSubInvocation.setMainExecutablePath(LoaderOpts.mainExecutablePath);
-  inheritOptionsForBuildingInterface(searchPathOpts, langOpts,
+  inheritOptionsForBuildingInterface(searchPathOpts, langOpts, typeCheckerOpts,
                                      requireOSSAModules);
   // Configure front-end input.
   auto &SubFEOpts = genericSubInvocation.getFrontendOptions();

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -425,7 +425,7 @@ static bool buildModuleFromInterface(CompilerInstance &Instance) {
   return ModuleInterfaceLoader::buildSwiftModuleFromSwiftInterface(
       Instance.getSourceMgr(), Instance.getDiags(),
       Invocation.getSearchPathOptions(), Invocation.getLangOptions(),
-      Invocation.getClangImporterOptions(),
+      Invocation.getClangImporterOptions(), Invocation.getTypeCheckerOptions(),
       Invocation.getClangModuleCachePath(), PrebuiltCachePath,
       FEOpts.BackupModuleInterfaceDir,
       Invocation.getModuleName(), InputPath, Invocation.getOutputFilename(), ABIPath,

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2675,7 +2675,11 @@ public:
     if (!decl)
       return;
 
-    if (IsInvalid) {
+    // Output an error to ensure SILGen will definitely not run when the AST
+    // is invalid. Skip if there's already been an error - a diagnostic that
+    // includes this decl may currently be in the process of being output.
+    // Prefer that diagnostic over this one.
+    if (IsInvalid && !ctx.Diags.hadAnyError()) {
       decl->setInvalidBit();
 
       DeclName name;

--- a/test/ModuleInterface/allow-errors-applies-to-interface.swift
+++ b/test/ModuleInterface/allow-errors-applies-to-interface.swift
@@ -1,0 +1,40 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -module-name B -emit-module -emit-module-path %t/mods/B.swiftmodule -experimental-allow-module-with-compiler-errors -experimental-skip-all-function-bodies -module-cache-path %t/mcp %t/B.swift
+// RUN: %target-swift-frontend -module-name C -emit-module -emit-module-path %t/mods/C.swiftmodule -experimental-allow-module-with-compiler-errors -experimental-skip-all-function-bodies -I%t/mods -module-cache-path %t/mcp %t/C.swift
+// RUN: %target-swift-frontend -module-name C -emit-module -emit-module-path %t/mods/C.swiftmodule -experimental-allow-module-with-compiler-errors -experimental-skip-all-function-bodies -I%t/mods -module-cache-path %t/mcp %t/C.swift
+
+//--- mods/A.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -swift-version 5 -enable-library-evolution -module-name A -debug-forbid-typecheck-prefix NOTYPECHECK
+
+import Swift
+import B
+
+public struct FromA: ProtoFromB {
+  public func badMethod(arg: Int) -> Int
+}
+
+@inlinable public func topLeveLFromA() -> Int {
+  let NOTYPECHECK_local = 1
+  return NOTYPECHECK_local
+}
+
+//--- B.swift
+public protocol ProtoFromB {
+  func badMethod(arg: missing) -> Int
+}
+
+public struct StructFromB {
+  public field: missing
+}
+
+//--- C.swift
+import A
+import B
+
+public func fromC(a: FromA) {
+  _ = a.badMethod(arg: 1)
+  _ = StructFromB()
+}

--- a/test/Serialization/AllowErrors/invalid-init.swift
+++ b/test/Serialization/AllowErrors/invalid-init.swift
@@ -1,0 +1,24 @@
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/mods
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -module-name A -emit-module -emit-module-path %t/mods/A.swiftmodule -experimental-allow-module-with-compiler-errors %t/A.swift
+// RUN: %target-swift-frontend -module-name B -emit-module -emit-module-path %t/mods/B.swiftmodule -experimental-allow-module-with-compiler-errors -I%t/mods %t/B.swift 2>&1 | %FileCheck %s
+
+//--- A.swift
+public struct StructFromA {
+  public func badMethod(arg: missing) {}
+}
+
+//--- B.swift
+import A
+
+public func test() {
+  // The init is internal so we expect to get a diagnostic for that. But
+  // deserializing `StructFromA` could potentially output a diagnostic for the
+  // error type on `field`. Make sure that we don't crash and that there is a
+  // diagnostic for the internal init.
+  _ = StructFromA()
+  // CHECK: error: 'StructFromA' initializer is inaccessible due to 'internal' protection level
+}
+


### PR DESCRIPTION
Building swiftinterface's should use the allow errors and skip bodies
flags of the main compilation. Consider a swiftinterface A that depends
on a module B. If B is built allowing errors then deserialization while
building the module for A should not fail if there are in fact errors.

Resolves rdar://84515859.