### PR TITLE
[LangOptions] Remove the option to enable/disable implicit existential opening.

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -313,10 +313,6 @@ namespace swift {
     /// Enable experimental concurrency model.
     bool EnableExperimentalConcurrency = false;
 
-    /// Enable support for implicitly opening existential argument types
-    /// in calls to generic functions.
-    bool EnableOpenedExistentialTypes = false;
-
     /// Disable experimental ClangImporter diagnostics.
     bool DisableExperimentalClangImporterDiagnostics = false;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -450,11 +450,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableExperimentalConcurrency |=
     Args.hasArg(OPT_enable_experimental_concurrency);
 
-  Opts.EnableOpenedExistentialTypes =
-    Args.hasFlag(OPT_enable_experimental_opened_existential_types,
-                 OPT_disable_experimental_opened_existential_types,
-                 true);
-
   Opts.EnableInferPublicSendable |=
     Args.hasFlag(OPT_enable_infer_public_concurrent_value,
                  OPT_disable_infer_public_concurrent_value,

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1519,10 +1519,6 @@ shouldOpenExistentialCallArgument(
   if (isa_and_nonnull<clang::FunctionTemplateDecl>(callee->getClangDecl()))
     return None;
 
-  ASTContext &ctx = callee->getASTContext();
-  if (!ctx.LangOpts.EnableOpenedExistentialTypes)
-    return None;
-
   // The actual parameter type needs to involve a type variable, otherwise
   // type inference won't be possible.
   if (!paramTy->hasTypeVariable())

--- a/test/Constraints/openExistential.swift
+++ b/test/Constraints/openExistential.swift
@@ -1,5 +1,4 @@
 // RUN: %target-typecheck-verify-swift
-// RUN: %target-typecheck-verify-swift -enable-experimental-opened-existential-types
 
 protocol P { }
 

--- a/test/Constraints/opened_existentials.swift
+++ b/test/Constraints/opened_existentials.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-opened-existential-types
+// RUN: %target-typecheck-verify-swift
 
 protocol Q { }
 

--- a/test/Constraints/opened_existentials_suppression.swift
+++ b/test/Constraints/opened_existentials_suppression.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-opened-existential-types -typecheck -dump-ast -parse-as-library %s | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -dump-ast -parse-as-library %s | %FileCheck %s
 
 protocol P { }
 extension Optional: P where Wrapped: P { }

--- a/test/Constraints/result_builder_availability.swift
+++ b/test/Constraints/result_builder_availability.swift
@@ -1,5 +1,4 @@
 // RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.50
-// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.50 -enable-experimental-opened-existential-types
 
 // REQUIRES: OS=macosx
 

--- a/test/Generics/existential_restrictions.swift
+++ b/test/Generics/existential_restrictions.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-objc-interop -disable-experimental-opened-existential-types
+// RUN: %target-typecheck-verify-swift -enable-objc-interop
 
 protocol P { }
 @objc protocol OP { }
@@ -8,14 +8,14 @@ protocol CP : class { }
   static func createNewOne() -> SP
 }
 
-func fP<T : P>(_ t: T) { }
+func fP<T : P>(_ t: T?) { }
 // expected-note@-1 {{required by global function 'fP' where 'T' = 'any P'}}
 // expected-note@-2 {{required by global function 'fP' where 'T' = 'any OP & P'}}
-func fOP<T : OP>(_ t: T) { }
+func fOP<T : OP>(_ t: T?) { }
 // expected-note@-1 {{required by global function 'fOP' where 'T' = 'any OP & P'}}
 func fOPE(_ t: OP) { }
-func fSP<T : SP>(_ t: T) { }
-func fAO<T : AnyObject>(_ t: T) { }
+func fSP<T : SP>(_ t: T?) { }
+func fAO<T : AnyObject>(_ t: T?) { }
 // expected-note@-1 {{where 'T' = 'any P'}}
 // expected-note@-2 {{where 'T' = 'any CP'}}
 // expected-note@-3 {{where 'T' = 'any OP & P'}}

--- a/test/Interop/Cxx/templates/function-template.swift
+++ b/test/Interop/Cxx/templates/function-template.swift
@@ -1,6 +1,5 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xfrontend -enable-experimental-opened-existential-types)
-//
+
 // REQUIRES: executable_test
 
 import FunctionTemplates

--- a/test/SILGen/opened_existentials.swift
+++ b/test/SILGen/opened_existentials.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-experimental-opened-existential-types %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 public protocol P { }
 


### PR DESCRIPTION
This feature has been accepted in Swift evolution, so there's no need to have a flag to enable/disable it. This also fixes an issue where the feature was not enabled by default in LLDB.

This change also uses opaque value placeholders where code completion was previously sending a pre-type-checked AST through the constraint system, which tripped an assertion during `shouldOpenExistentialCallArgument` when looking up types for AST nodes that should have been cached in the constraint system.

Resolves: rdar://94730905