### PR TITLE
[Interop][SwiftToCxx] Implement enum case switching

### DIFF
--- a/include/swift/IRGen/IRABIDetailsProvider.h
+++ b/include/swift/IRGen/IRABIDetailsProvider.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_IRGEN_IRABIDETAILSPROVIDER_H
 #define SWIFT_IRGEN_IRABIDETAILSPROVIDER_H
 
+#include "swift/AST/Decl.h"
 #include "swift/AST/Type.h"
 #include "clang/AST/CharUnits.h"
 #include "llvm/ADT/Optional.h"
@@ -92,6 +93,10 @@ public:
   /// Returns the function signature that is used for the the type metadata
   /// access function.
   FunctionABISignature getTypeMetadataAccessFunctionSignature();
+
+  /// Returns EnumElementDecls (enum cases) in their declaration order with
+  /// their tag indices from the given EnumDecl
+  std::map<EnumElementDecl *, unsigned> getEnumTagMapping(EnumDecl *ED);
 
 private:
   std::unique_ptr<IRABIDetailsProviderImpl> impl;

--- a/include/swift/IRGen/IRABIDetailsProvider.h
+++ b/include/swift/IRGen/IRABIDetailsProvider.h
@@ -16,6 +16,7 @@
 #include "swift/AST/Decl.h"
 #include "swift/AST/Type.h"
 #include "clang/AST/CharUnits.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
@@ -96,7 +97,7 @@ public:
 
   /// Returns EnumElementDecls (enum cases) in their declaration order with
   /// their tag indices from the given EnumDecl
-  std::map<EnumElementDecl *, unsigned> getEnumTagMapping(EnumDecl *ED);
+  llvm::MapVector<EnumElementDecl *, unsigned> getEnumTagMapping(EnumDecl *ED);
 
 private:
   std::unique_ptr<IRABIDetailsProviderImpl> impl;

--- a/lib/IRGen/IRABIDetailsProvider.cpp
+++ b/lib/IRGen/IRABIDetailsProvider.cpp
@@ -12,6 +12,7 @@
 
 #include "swift/IRGen/IRABIDetailsProvider.h"
 #include "FixedTypeInfo.h"
+#include "GenEnum.h"
 #include "GenType.h"
 #include "IRGen.h"
 #include "IRGenModule.h"
@@ -122,6 +123,19 @@ public:
     return {returnTy, {paramTy}};
   }
 
+  std::map<EnumElementDecl *, unsigned> getEnumTagMapping(EnumDecl *ED) {
+    std::map<EnumElementDecl *, unsigned> elements;
+    auto &enumImplStrat = getEnumImplStrategy(
+        IGM, ED->getDeclaredType()->getCanonicalType());
+
+    for (auto *element : ED->getAllElements()) {
+      auto tagIdx = enumImplStrat.getTagIndex(element);
+      elements.insert({element, tagIdx});
+    }
+
+    return elements;
+  }
+
 private:
   Lowering::TypeConverter typeConverter;
   // Default silOptions are sufficient, as we don't need to generated SIL.
@@ -161,4 +175,9 @@ bool IRABIDetailsProvider::enumerateDirectPassingRecordMembers(
 IRABIDetailsProvider::FunctionABISignature
 IRABIDetailsProvider::getTypeMetadataAccessFunctionSignature() {
   return impl->getTypeMetadataAccessFunctionSignature();
+}
+
+std::map<EnumElementDecl *, unsigned>
+IRABIDetailsProvider::getEnumTagMapping(EnumDecl *ED) {
+  return impl->getEnumTagMapping(ED);
 }

--- a/lib/IRGen/IRABIDetailsProvider.cpp
+++ b/lib/IRGen/IRABIDetailsProvider.cpp
@@ -123,8 +123,8 @@ public:
     return {returnTy, {paramTy}};
   }
 
-  std::map<EnumElementDecl *, unsigned> getEnumTagMapping(EnumDecl *ED) {
-    std::map<EnumElementDecl *, unsigned> elements;
+  llvm::MapVector<EnumElementDecl *, unsigned> getEnumTagMapping(EnumDecl *ED) {
+    llvm::MapVector<EnumElementDecl *, unsigned> elements;
     auto &enumImplStrat = getEnumImplStrategy(
         IGM, ED->getDeclaredType()->getCanonicalType());
 
@@ -177,7 +177,7 @@ IRABIDetailsProvider::getTypeMetadataAccessFunctionSignature() {
   return impl->getTypeMetadataAccessFunctionSignature();
 }
 
-std::map<EnumElementDecl *, unsigned>
+llvm::MapVector<EnumElementDecl *, unsigned>
 IRABIDetailsProvider::getEnumTagMapping(EnumDecl *ED) {
   return impl->getEnumTagMapping(ED);
 }

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -413,14 +413,11 @@ private:
       os << "  inline operator cases() const {\n";
       os << "    switch (_getEnumTag()) {\n";
       for (const auto &pair : elementTagMapping) {
-        if (pair == *elementTagMapping.crbegin()) {
-          os << "      case " << pair.second << ": default: return cases::";
-        } else {
-          os << "      case " << pair.second << ": return cases::";
-        }
+        os << "      case " << pair.second << ": return cases::";
         syntaxPrinter.printIdentifier(pair.first->getNameStr());
         os << ";\n";
       }
+      os << "      default: abort();\n";
       os << "    }\n"; // switch's closing bracket
       os << "  }\n";   // operator cases()'s closing bracket
 

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -396,6 +396,11 @@ private:
       auto elementTagMapping =
           owningPrinter.interopContext.getIrABIDetails().getEnumTagMapping(ED);
 
+      if (elementTagMapping.empty()) {
+        os << "\n";
+        return;
+      }
+
       os << "  enum class cases {\n";
       for (const auto &pair : elementTagMapping) {
         os << "    ";
@@ -403,11 +408,6 @@ private:
         os << ",\n";
       }
       os << "  };\n"; // enum class cases' closing bracket
-
-      if (elementTagMapping.empty()) {
-        os << "\n";
-        return;
-      }
 
       // Printing operator cases()
       os << "  inline operator cases() const {\n";

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -15,6 +15,7 @@
 #include "PrimitiveTypeMapping.h"
 #include "PrintClangFunction.h"
 #include "PrintClangValueType.h"
+#include "SwiftToClangInteropContext.h"
 
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTMangler.h"
@@ -31,6 +32,7 @@
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/TypeVisitor.h"
 #include "swift/IDE/CommentConversion.h"
+#include "swift/IRGen/IRABIDetailsProvider.h"
 #include "swift/IRGen/Linking.h"
 #include "swift/Parse/Lexer.h"
 #include "swift/Parse/Parser.h"
@@ -384,30 +386,65 @@ private:
     os << "@end\n";
   }
 
+  void visitEnumDeclCxx(EnumDecl *ED) {
+    // FIXME: Print enum's availability
+    ClangValueTypePrinter printer(os, owningPrinter.prologueOS,
+                                  owningPrinter.typeMapping,
+                                  owningPrinter.interopContext);
+    printer.printValueTypeDecl(ED, /*bodyPrinter=*/[&]() {
+      ClangSyntaxPrinter syntaxPrinter(os);
+      auto elementTagMapping =
+          owningPrinter.interopContext.getIrABIDetails().getEnumTagMapping(ED);
+
+      os << "  enum class cases {\n";
+      for (const auto &pair : elementTagMapping) {
+        os << "    ";
+        syntaxPrinter.printIdentifier(pair.first->getNameStr());
+        os << ",\n";
+      }
+      os << "  };\n"; // enum class cases' closing bracket
+
+      if (elementTagMapping.empty()) {
+        os << "\n";
+        return;
+      }
+
+      // Printing operator cases()
+      os << "  inline operator cases() const {\n";
+      os << "    switch (_getEnumTag()) {\n";
+      for (const auto &pair : elementTagMapping) {
+        if (pair == *elementTagMapping.crbegin()) {
+          os << "      case " << pair.second << ": default: return cases::";
+        } else {
+          os << "      case " << pair.second << ": return cases::";
+        }
+        syntaxPrinter.printIdentifier(pair.first->getNameStr());
+        os << ";\n";
+      }
+      os << "    }\n"; // switch's closing bracket
+      os << "  }\n";   // operator cases()'s closing bracket
+
+      // Printing predicates
+      for (const auto &pair : elementTagMapping) {
+        os << "  inline bool is";
+        auto name = pair.first->getNameStr().str();
+        name[0] = std::toupper(name[0]);
+        os << name << "() const {\n";
+        os << "    return *this == cases::";
+        syntaxPrinter.printIdentifier(pair.first->getNameStr());
+        os << ";\n  }\n";
+      }
+      os << "\n";
+    });
+    os << outOfLineDefinitions;
+    outOfLineDefinitions.clear();
+  }
+
   void visitEnumDecl(EnumDecl *ED) {
     printDocumentationComment(ED);
 
     if (outputLang == OutputLanguageMode::Cxx) {
-      // FIXME: Print enum's availability
-      ClangValueTypePrinter printer(os, owningPrinter.prologueOS,
-                                    owningPrinter.typeMapping,
-                                    owningPrinter.interopContext);
-      printer.printValueTypeDecl(ED, /*bodyPrinter=*/[&]() {
-        ClangSyntaxPrinter syntaxPrinter(os);
-        os << "  enum class cases {";
-        llvm::interleaveComma(
-            ED->getAllCases(), os, [&](const EnumCaseDecl *caseDecl) {
-              llvm::interleaveComma(caseDecl->getElements(), os,
-                                    [&](const EnumElementDecl *elementDecl) {
-                                      os << "\n    ";
-                                      syntaxPrinter.printIdentifier(
-                                          elementDecl->getNameStr());
-                                    });
-            });
-        os << "\n  };\n";
-      });
-      os << outOfLineDefinitions;
-      outOfLineDefinitions.clear();
+      visitEnumDeclCxx(ED);
       return;
     }
 

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -395,6 +395,10 @@ private:
       ClangSyntaxPrinter syntaxPrinter(os);
       auto elementTagMapping =
           owningPrinter.interopContext.getIrABIDetails().getEnumTagMapping(ED);
+      // Sort cases based on their assigned tag indices
+      llvm::stable_sort(elementTagMapping, [](const auto &p1, const auto &p2) {
+        return p1.second < p2.second;
+      });
 
       if (elementTagMapping.empty()) {
         os << "\n";
@@ -417,6 +421,7 @@ private:
         syntaxPrinter.printIdentifier(pair.first->getNameStr());
         os << ";\n";
       }
+      // TODO: change to Swift's fatalError when it's available in C++
       os << "      default: abort();\n";
       os << "    }\n"; // switch's closing bracket
       os << "  }\n";   // operator cases()'s closing bracket

--- a/lib/PrintAsClang/PrintClangValueType.cpp
+++ b/lib/PrintAsClang/PrintClangValueType.cpp
@@ -202,7 +202,25 @@ void ClangValueTypePrinter::printValueTypeDecl(
     os << ".getOpaquePointer()";
   os << "; }\n";
   os << "\n";
-
+  // Print out helper function for getting enum tag for enum type
+  if (isa<EnumDecl>(typeDecl)) {
+    // FIXME: (tongjie) return type should be unsigned
+    os << "  inline int _getEnumTag() const {\n";
+    os << "    auto metadata = " << cxx_synthesis::getCxxImplNamespaceName()
+       << "::";
+    printer.printSwiftTypeMetadataAccessFunctionCall(typeMetadataFuncName);
+    os << ";\n";
+    os << "    auto *vwTable = ";
+    printer.printValueWitnessTableAccessFromTypeMetadata("metadata");
+    os << ";\n";
+    os << "    const auto *enumVWTable = reinterpret_cast<";
+    ClangSyntaxPrinter(os).printSwiftImplQualifier();
+    os << "EnumValueWitnessTable";
+    os << " *>(vwTable);\n";
+    os << "    return enumVWTable->getEnumTag(_getOpaquePointer(), "
+          "metadata._0);\n";
+    os << "  }\n";
+  }
   // Print out the storage for the value type.
   os << "  ";
   if (isOpaqueLayout) {

--- a/lib/PrintAsClang/PrintSwiftToClangCoreScaffold.cpp
+++ b/lib/PrintAsClang/PrintSwiftToClangCoreScaffold.cpp
@@ -62,11 +62,12 @@ static void printKnownType(
   printKnownStruct(typeMapping, os, name, typeRecord);
 }
 
-static void printValueWitnessTableFunctionType(raw_ostream &os, StringRef name,
-                                               StringRef returnType,
-                                               std::string paramTypes,
-                                               uint16_t ptrauthDisc) {
-  os << "using ValueWitness" << name << "Ty = " << returnType
+static void
+printValueWitnessTableFunctionType(raw_ostream &os, StringRef prefix,
+                                   StringRef name, StringRef returnType,
+                                   std::string paramTypes,
+                                   uint16_t ptrauthDisc) {
+  os << "using " << prefix << name << "Ty = " << returnType
      << "(* __ptrauth_swift_value_witness_function_pointer(" << ptrauthDisc
      << "))(" << paramTypes << ");\n";
 }
@@ -87,7 +88,7 @@ static void printValueWitnessTable(raw_ostream &os) {
   membersOS << "  " << type << " " << #lowerId << ";\n";
 #define FUNCTION_VALUE_WITNESS(lowerId, upperId, returnType, paramTypes)       \
   printValueWitnessTableFunctionType(                                          \
-      os, #upperId, returnType, makeParams paramTypes,                         \
+      os, "ValueWitness", #upperId, returnType, makeParams paramTypes,         \
       SpecialPointerAuthDiscriminators::upperId);                              \
   membersOS << "  ValueWitness" << #upperId << "Ty _Nonnull " << #lowerId      \
             << ";\n";
@@ -102,7 +103,32 @@ static void printValueWitnessTable(raw_ostream &os) {
 #define VOID_TYPE "void"
 #include "swift/ABI/ValueWitness.def"
 
-  os << "\nstruct ValueWitnessTable {\n" << membersOS.str() << "};\n";
+  os << "\nstruct ValueWitnessTable {\n" << membersOS.str() << "};\n\n";
+  membersOS.str().clear();
+
+#define WANT_ONLY_ENUM_VALUE_WITNESSES
+#define DATA_VALUE_WITNESS(lowerId, upperId, type)                             \
+  membersOS << "  " << type << " " << #lowerId << ";\n";
+#define FUNCTION_VALUE_WITNESS(lowerId, upperId, returnType, paramTypes)       \
+  printValueWitnessTableFunctionType(                                          \
+      os, "EnumValueWitness", #upperId, returnType, makeParams paramTypes,     \
+      SpecialPointerAuthDiscriminators::upperId);                              \
+  membersOS << "  EnumValueWitness" << #upperId << "Ty _Nonnull " << #lowerId  \
+            << ";\n";
+#define MUTABLE_VALUE_TYPE "void * _Nonnull"
+#define IMMUTABLE_VALUE_TYPE "const void * _Nonnull"
+#define MUTABLE_BUFFER_TYPE "void * _Nonnull"
+#define IMMUTABLE_BUFFER_TYPE "const void * _Nonnull"
+#define TYPE_TYPE "void * _Nonnull"
+#define SIZE_TYPE "size_t"
+#define INT_TYPE "int"
+#define UINT_TYPE "unsigned"
+#define VOID_TYPE "void"
+#include "swift/ABI/ValueWitness.def"
+
+  os << "\nstruct EnumValueWitnessTable {\n"
+     << "  ValueWitnessTable vwTable;\n"
+     << membersOS.str() << "};\n\n";
 }
 
 static void printTypeMetadataResponseType(SwiftToClangInteropContext &ctx,

--- a/test/Inputs/clang-importer-sdk/usr/include/stdlib.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/stdlib.h
@@ -16,4 +16,6 @@ void free(void *);
 ldiv_t ldiv(long int, long int);
 lldiv_t lldiv(long long int, long long int);
 
+_Noreturn void abort(void);
+
 #endif // SDK_STDLIB_H

--- a/test/Interop/SwiftToCxx/core/swift-impl-defs-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/core/swift-impl-defs-in-cxx.swift
@@ -47,6 +47,18 @@
 // CHECK-NEXT:  unsigned extraInhabitantCount;
 // CHECK-NEXT: };
 // CHECK-EMPTY:
+// CHECK-NEXT: using EnumValueWitnessGetEnumTagTy = int(* __ptrauth_swift_value_witness_function_pointer(41909))(const void * _Nonnull, void * _Nonnull);
+// CHECK-NEXT: using EnumValueWitnessDestructiveProjectEnumDataTy = void(* __ptrauth_swift_value_witness_function_pointer(1053))(void * _Nonnull, void * _Nonnull);
+// CHECK-NEXT: using EnumValueWitnessDestructiveInjectEnumTagTy = void(* __ptrauth_swift_value_witness_function_pointer(45796))(void * _Nonnull, unsigned, void * _Nonnull);
+// CHECK-EMPTY:
+// CHECK-NEXT: struct EnumValueWitnessTable {
+// CHECK-NEXT:   ValueWitnessTable vwTable;
+// CHECK-NEXT:   EnumValueWitnessGetEnumTagTy _Nonnull getEnumTag;
+// CHECK-NEXT:   EnumValueWitnessDestructiveProjectEnumDataTy _Nonnull destructiveProjectEnumData;
+// CHECK-NEXT:   EnumValueWitnessDestructiveInjectEnumTagTy _Nonnull destructiveInjectEnumTag;
+// CHECK-NEXT: };
+// CHECK-EMPTY:
+// CHECK-EMPTY:
 // CHECK-NEXT: #ifdef __cplusplus
 // CHECK-NEXT: }
 // CHECK-NEXT: #endif

--- a/test/Interop/SwiftToCxx/enums/swift-enum-case-functions-execution.cpp
+++ b/test/Interop/SwiftToCxx/enums/swift-enum-case-functions-execution.cpp
@@ -1,0 +1,182 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %S/swift-enum-case-functions.swift -typecheck -module-name Enums -clang-header-expose-public-decls -emit-clang-header-path %t/enums.h
+
+// RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-enums-execution.o
+// RUN: %target-interop-build-swift %S/swift-enum-case-functions.swift -o %t/swift-enums-execution -Xlinker %t/swift-enums-execution.o -module-name Enums -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+
+// RUN: %target-codesign %t/swift-enums-execution
+// RUN: %target-run %t/swift-enums-execution
+
+// REQUIRES: executable_test
+// UNSUPPORTED: CPU=arm64e
+
+#include <cassert>
+#include "enums.h"
+
+using namespace Enums;
+
+void cxxCheckEnum(const DataCase &e) {
+    assert(e.isOne());
+}
+
+void cxxCheckEnum(const CLikeEnum &e) {
+    switch (e) {
+        case CLikeEnum::cases::one:
+            assert(checkCLikeEnum(e, 1));
+            assert(e.isOne());
+            break;
+        case CLikeEnum::cases::two:
+            assert(checkCLikeEnum(e, 2));
+            assert(e.isTwo());
+            break;
+        case CLikeEnum::cases::three:
+            assert(checkCLikeEnum(e, 3));
+            assert(e.isThree());
+            break;
+    }
+}
+
+void cxxCheckEnum(const CharOrSectionMarker &e) {
+    switch (e) {
+        case CharOrSectionMarker::cases::Paragraph:
+            assert(checkCharOrSectionMarker(e, 1));
+            assert(e.isParagraph());
+            break;
+        case CharOrSectionMarker::cases::Char:
+            assert(checkCharOrSectionMarker(e, 2));
+            assert(e.isChar());
+            break;
+        case CharOrSectionMarker::cases::Chapter:
+            assert(checkCharOrSectionMarker(e, 3));
+            assert(e.isChapter());
+            break;
+    }
+}
+
+void cxxCheckEnum(const IntOrInfinity &e) {
+    switch (e) {
+        case IntOrInfinity::cases::NegInfinity:
+            assert(checkIntOrInfinity(e, 1));
+            assert(e.isNegInfinity());
+            break;
+        case IntOrInfinity::cases::Int:
+            assert(checkIntOrInfinity(e, 2));
+            assert(e.isInt());
+            break;
+        case IntOrInfinity::cases::PosInfinity:
+            assert(checkIntOrInfinity(e, 3));
+            assert(e.isPosInfinity());
+            break;
+    }
+}
+
+void cxxCheckEnum(const TerminalChar &e) {
+    switch (e) {
+        case TerminalChar::cases::Plain:
+            assert(checkTerminalChar(e, 1));
+            assert(e.isPlain());
+            break;
+        case TerminalChar::cases::Bold:
+            assert(checkTerminalChar(e, 2));
+            assert(e.isBold());
+            break;
+        case TerminalChar::cases::Underline:
+            assert(checkTerminalChar(e, 3));
+            assert(e.isUnderline());
+            break;
+        case TerminalChar::cases::Blink:
+            assert(checkTerminalChar(e, 4));
+            assert(e.isBlink());
+            break;
+        case TerminalChar::cases::Empty:
+            assert(checkTerminalChar(e, 5));
+            assert(e.isEmpty());
+            break;
+        case TerminalChar::cases::Cursor:
+            assert(checkTerminalChar(e, 6));
+            assert(e.isCursor());
+            break;
+    }
+}
+
+void cxxCheckEnum(const IntDoubleOrBignum &e) {
+    switch (e) {
+        case IntDoubleOrBignum::cases::Int:
+            assert(checkIntDoubleOrBignum(e, 1));
+            assert(e.isInt());
+            break;
+        case IntDoubleOrBignum::cases::Double:
+            assert(checkIntDoubleOrBignum(e, 2));
+            assert(e.isDouble());
+            break;
+        case IntDoubleOrBignum::cases::Bignum:
+            assert(checkIntDoubleOrBignum(e, 3));
+            assert(e.isBignum());
+            break;
+    }
+}
+
+int main() {
+    {
+        auto e1 = makeDataCase();
+        cxxCheckEnum(e1);
+    }
+
+    {
+        auto e1 = makeCLikeEnum(1);
+        auto e2 = makeCLikeEnum(2);
+        auto e3 = makeCLikeEnum(3);
+
+        cxxCheckEnum(e1);
+        cxxCheckEnum(e2);
+        cxxCheckEnum(e3);
+    }
+
+    {
+        auto e1 = makeCharOrSectionMarker(1);
+        auto e2 = makeCharOrSectionMarker(2);
+        auto e3 = makeCharOrSectionMarker(3);
+
+        cxxCheckEnum(e1);
+        cxxCheckEnum(e2);
+        cxxCheckEnum(e3);
+    }
+
+    {
+        auto e1 = makeIntOrInfinity(1);
+        auto e2 = makeIntOrInfinity(2);
+        auto e3 = makeIntOrInfinity(3);
+
+        cxxCheckEnum(e1);
+        cxxCheckEnum(e2);
+        cxxCheckEnum(e3);
+    }
+
+    {
+        auto e1 = makeTerminalChar(1);
+        auto e2 = makeTerminalChar(2);
+        auto e3 = makeTerminalChar(3);
+        auto e4 = makeTerminalChar(4);
+        auto e5 = makeTerminalChar(5);
+        auto e6 = makeTerminalChar(6);
+
+        cxxCheckEnum(e1);
+        cxxCheckEnum(e2);
+        cxxCheckEnum(e3);
+        cxxCheckEnum(e4);
+        cxxCheckEnum(e5);
+        cxxCheckEnum(e6);
+    }
+
+    {
+        auto e1 = makeIntDoubleOrBignum(1);
+        auto e2 = makeIntDoubleOrBignum(2);
+        auto e3 = makeIntDoubleOrBignum(3);
+
+        cxxCheckEnum(e1);
+        cxxCheckEnum(e2);
+        cxxCheckEnum(e3);
+    }
+    return  0;
+}

--- a/test/Interop/SwiftToCxx/enums/swift-enum-case-functions.swift
+++ b/test/Interop/SwiftToCxx/enums/swift-enum-case-functions.swift
@@ -193,17 +193,17 @@ public func checkIntDoubleOrBignum(_ x: IntDoubleOrBignum, tag: Int) -> Bool {
 
 // CHECK:      inline operator cases() const {
 // CHECK-NEXT:   switch (_getEnumTag()) {
-// CHECK-NEXT:     case 1: return cases::Paragraph;
 // CHECK-NEXT:     case 0: return cases::Char;
+// CHECK-NEXT:     case 1: return cases::Paragraph;
 // CHECK-NEXT:     case 2: return cases::Chapter;
 // CHECK-NEXT:     default: abort();
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
-// CHECK-NEXT: inline bool isParagraph() const {
-// CHECK-NEXT:   return *this == cases::Paragraph;
-// CHECK-NEXT: }
 // CHECK-NEXT: inline bool isChar() const {
 // CHECK-NEXT:   return *this == cases::Char;
+// CHECK-NEXT: }
+// CHECK-NEXT: inline bool isParagraph() const {
+// CHECK-NEXT:   return *this == cases::Paragraph;
 // CHECK-NEXT: }
 // CHECK-NEXT: inline bool isChapter() const {
 // CHECK-NEXT:   return *this == cases::Chapter;
@@ -263,17 +263,17 @@ public func checkIntDoubleOrBignum(_ x: IntDoubleOrBignum, tag: Int) -> Bool {
 
 // CHECK:      inline operator cases() const {
 // CHECK-NEXT:   switch (_getEnumTag()) {
-// CHECK-NEXT:     case 1: return cases::NegInfinity;
 // CHECK-NEXT:     case 0: return cases::Int;
+// CHECK-NEXT:     case 1: return cases::NegInfinity;
 // CHECK-NEXT:     case 2: return cases::PosInfinity;
 // CHECK-NEXT:     default: abort();
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
-// CHECK-NEXT: inline bool isNegInfinity() const {
-// CHECK-NEXT:   return *this == cases::NegInfinity;
-// CHECK-NEXT: }
 // CHECK-NEXT: inline bool isInt() const {
 // CHECK-NEXT:   return *this == cases::Int;
+// CHECK-NEXT: }
+// CHECK-NEXT: inline bool isNegInfinity() const {
+// CHECK-NEXT:   return *this == cases::NegInfinity;
 // CHECK-NEXT: }
 // CHECK-NEXT: inline bool isPosInfinity() const {
 // CHECK-NEXT:   return *this == cases::PosInfinity;
@@ -289,17 +289,14 @@ public func checkIntDoubleOrBignum(_ x: IntDoubleOrBignum, tag: Int) -> Bool {
 
 // CHECK:      inline operator cases() const {
 // CHECK-NEXT:   switch (_getEnumTag()) {
-// CHECK-NEXT:     case 4: return cases::Cursor;
 // CHECK-NEXT:     case 0: return cases::Plain;
 // CHECK-NEXT:     case 1: return cases::Bold;
 // CHECK-NEXT:     case 2: return cases::Underline;
 // CHECK-NEXT:     case 3: return cases::Blink;
+// CHECK-NEXT:     case 4: return cases::Cursor;
 // CHECK-NEXT:     case 5: return cases::Empty;
 // CHECK-NEXT:     default: abort();
 // CHECK-NEXT:   }
-// CHECK-NEXT: }
-// CHECK-NEXT: inline bool isCursor() const {
-// CHECK-NEXT:   return *this == cases::Cursor;
 // CHECK-NEXT: }
 // CHECK-NEXT: inline bool isPlain() const {
 // CHECK-NEXT:   return *this == cases::Plain;
@@ -312,6 +309,9 @@ public func checkIntDoubleOrBignum(_ x: IntDoubleOrBignum, tag: Int) -> Bool {
 // CHECK-NEXT: }
 // CHECK-NEXT: inline bool isBlink() const {
 // CHECK-NEXT:   return *this == cases::Blink;
+// CHECK-NEXT: }
+// CHECK-NEXT: inline bool isCursor() const {
+// CHECK-NEXT:   return *this == cases::Cursor;
 // CHECK-NEXT: }
 // CHECK-NEXT: inline bool isEmpty() const {
 // CHECK-NEXT:   return *this == cases::Empty;

--- a/test/Interop/SwiftToCxx/enums/swift-enum-case-functions.swift
+++ b/test/Interop/SwiftToCxx/enums/swift-enum-case-functions.swift
@@ -169,7 +169,8 @@ public func checkIntDoubleOrBignum(_ x: IntDoubleOrBignum, tag: Int) -> Bool {
 // CHECK-NEXT:   switch (_getEnumTag()) {
 // CHECK-NEXT:     case 0: return cases::one;
 // CHECK-NEXT:     case 1: return cases::two;
-// CHECK-NEXT:     case 2: default: return cases::three;
+// CHECK-NEXT:     case 2: return cases::three;
+// CHECK-NEXT:     default: abort();
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 // CHECK-NEXT: inline bool isOne() const {
@@ -194,7 +195,8 @@ public func checkIntDoubleOrBignum(_ x: IntDoubleOrBignum, tag: Int) -> Bool {
 // CHECK-NEXT:   switch (_getEnumTag()) {
 // CHECK-NEXT:     case 1: return cases::Paragraph;
 // CHECK-NEXT:     case 0: return cases::Char;
-// CHECK-NEXT:     case 2: default: return cases::Chapter;
+// CHECK-NEXT:     case 2: return cases::Chapter;
+// CHECK-NEXT:     default: abort();
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 // CHECK-NEXT: inline bool isParagraph() const {
@@ -217,7 +219,8 @@ public func checkIntDoubleOrBignum(_ x: IntDoubleOrBignum, tag: Int) -> Bool {
 
 // CHECK:      inline operator cases() const {
 // CHECK-NEXT:   switch (_getEnumTag()) {
-// CHECK-NEXT:     case 0: default: return cases::one;
+// CHECK-NEXT:     case 0: return cases::one;
+// CHECK-NEXT:     default: abort();
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 // CHECK-NEXT: inline bool isOne() const {
@@ -236,7 +239,8 @@ public func checkIntDoubleOrBignum(_ x: IntDoubleOrBignum, tag: Int) -> Bool {
 // CHECK-NEXT:   switch (_getEnumTag()) {
 // CHECK-NEXT:     case 0: return cases::Int;
 // CHECK-NEXT:     case 1: return cases::Double;
-// CHECK-NEXT:     case 2: default: return cases::Bignum;
+// CHECK-NEXT:     case 2: return cases::Bignum;
+// CHECK-NEXT:     default: abort();
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 // CHECK-NEXT: inline bool isInt() const {
@@ -261,7 +265,8 @@ public func checkIntDoubleOrBignum(_ x: IntDoubleOrBignum, tag: Int) -> Bool {
 // CHECK-NEXT:   switch (_getEnumTag()) {
 // CHECK-NEXT:     case 1: return cases::NegInfinity;
 // CHECK-NEXT:     case 0: return cases::Int;
-// CHECK-NEXT:     case 2: default: return cases::PosInfinity;
+// CHECK-NEXT:     case 2: return cases::PosInfinity;
+// CHECK-NEXT:     default: abort();
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 // CHECK-NEXT: inline bool isNegInfinity() const {
@@ -289,7 +294,8 @@ public func checkIntDoubleOrBignum(_ x: IntDoubleOrBignum, tag: Int) -> Bool {
 // CHECK-NEXT:     case 1: return cases::Bold;
 // CHECK-NEXT:     case 2: return cases::Underline;
 // CHECK-NEXT:     case 3: return cases::Blink;
-// CHECK-NEXT:     case 5: default: return cases::Empty;
+// CHECK-NEXT:     case 5: return cases::Empty;
+// CHECK-NEXT:     default: abort();
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 // CHECK-NEXT: inline bool isCursor() const {

--- a/test/Interop/SwiftToCxx/enums/swift-enum-case-functions.swift
+++ b/test/Interop/SwiftToCxx/enums/swift-enum-case-functions.swift
@@ -1,0 +1,318 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -module-name Enums -clang-header-expose-public-decls -emit-clang-header-path %t/enums.h
+// RUN: %FileCheck %s < %t/enums.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/enums.h -Wno-unused-private-field -Wno-unused-function)
+
+// test case-related member functions: operator cases() and isXYZ predicates
+
+public enum DataCase { case one(_ x: Int) }
+
+public func makeDataCase() -> DataCase { return .one(10) }
+
+public enum CLikeEnum { case one, two, three }
+
+public func makeCLikeEnum(_ tag: Int) -> CLikeEnum {
+    switch tag {
+    case 1:
+        return .one
+    case 2:
+        return .two
+    default:
+        return .three
+    }
+}
+
+public func checkCLikeEnum(_ x: CLikeEnum, tag: Int) -> Bool {
+    switch x {
+    case .one:
+        return tag == 1
+    case .two:
+        return tag == 2
+    case .three:
+        return ![1, 2].contains(tag)
+    }
+}
+
+public enum CharOrSectionMarker {
+    case Paragraph
+    case Char(Unicode.Scalar)
+    case Chapter
+}
+
+public func makeCharOrSectionMarker(_ tag: Int) -> CharOrSectionMarker {
+    switch tag {
+    case 1:
+        return .Paragraph
+    case 2:
+        return .Char("🍎")
+    default:
+        return .Chapter
+    }
+}
+
+public func checkCharOrSectionMarker(_ x: CharOrSectionMarker, tag: Int) -> Bool {
+    switch x {
+    case .Paragraph:
+        return tag == 1
+    case .Char:
+        return tag == 2
+    case .Chapter:
+        return ![1, 2].contains(tag)
+    }
+}
+
+public enum IntOrInfinity {
+    case NegInfinity
+    case Int(Int)
+    case PosInfinity
+}
+
+public func makeIntOrInfinity(_ tag: Int) -> IntOrInfinity {
+    switch tag {
+    case 1:
+        return .NegInfinity
+    case 2:
+        return .Int(123)
+    default:
+        return .PosInfinity
+    }
+}
+
+public func checkIntOrInfinity(_ x: IntOrInfinity, tag: Int) -> Bool {
+    switch x {
+    case .NegInfinity:
+        return tag == 1
+    case .Int:
+        return tag == 2
+    case .PosInfinity:
+        return ![1, 2].contains(tag)
+    }
+}
+
+public enum TerminalChar {
+    case Cursor
+    case Plain(Unicode.Scalar)
+    case Bold(Unicode.Scalar)
+    case Underline(Unicode.Scalar)
+    case Blink(Unicode.Scalar)
+    case Empty
+}
+
+public func makeTerminalChar(_ tag: Int) -> TerminalChar {
+    switch tag {
+    case 1:
+        return .Plain("P")
+    case 2:
+        return .Bold("B")
+    case 3:
+        return .Underline("U")
+    case 4:
+        return .Blink("L")
+    case 5:
+        return .Empty
+    default:
+        return .Cursor
+    }
+}
+
+public func checkTerminalChar(_ x: TerminalChar, tag: Int) -> Bool {
+    switch x {
+    case .Plain:
+        return tag == 1
+    case .Bold:
+        return tag == 2
+    case .Underline:
+        return tag == 3
+    case .Blink:
+        return tag == 4
+    case .Empty:
+        return tag == 5
+    case .Cursor:
+        return ![1, 2, 3, 4, 5].contains(tag)
+    }
+}
+
+public class Bignum {}
+
+public enum IntDoubleOrBignum {
+    case Int(Int)
+    case Double(Double)
+    case Bignum(Bignum)
+}
+
+public func makeIntDoubleOrBignum(_ tag: Int) -> IntDoubleOrBignum {
+    switch tag {
+    case 1:
+        return .Int(10)
+    case 2:
+        return .Double(3.14)
+    default:
+        return .Bignum(Bignum())
+    }
+}
+
+public func checkIntDoubleOrBignum(_ x: IntDoubleOrBignum, tag: Int) -> Bool {
+    switch x {
+    case .Int:
+        return tag == 1
+    case .Double:
+        return tag == 2
+    case .Bignum:
+        return ![1, 2].contains(tag)
+    }
+}
+
+// CHECK: class CLikeEnum final {
+
+// CHECK:      inline operator cases() const {
+// CHECK-NEXT:   switch (_getEnumTag()) {
+// CHECK-NEXT:     case 0: return cases::one;
+// CHECK-NEXT:     case 1: return cases::two;
+// CHECK-NEXT:     case 2: default: return cases::three;
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+// CHECK-NEXT: inline bool isOne() const {
+// CHECK-NEXT:   return *this == cases::one;
+// CHECK-NEXT: }
+// CHECK-NEXT: inline bool isTwo() const {
+// CHECK-NEXT:   return *this == cases::two;
+// CHECK-NEXT: }
+// CHECK-NEXT: inline bool isThree() const {
+// CHECK-NEXT:   return *this == cases::three;
+// CHECK-NEXT: }
+// CHECK:      inline int _getEnumTag() const {
+// CHECK-NEXT:   auto metadata = _impl::$s5Enums9CLikeEnumOMa(0);
+// CHECK-NEXT:   auto *vwTable = *(reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1);
+// CHECK-NEXT:   const auto *enumVWTable = reinterpret_cast<swift::_impl::EnumValueWitnessTable *>(vwTable);
+// CHECK-NEXT:   return enumVWTable->getEnumTag(_getOpaquePointer(), metadata._0);
+// CHECK-NEXT: }
+
+// CHECK: class CharOrSectionMarker final {
+
+// CHECK:      inline operator cases() const {
+// CHECK-NEXT:   switch (_getEnumTag()) {
+// CHECK-NEXT:     case 1: return cases::Paragraph;
+// CHECK-NEXT:     case 0: return cases::Char;
+// CHECK-NEXT:     case 2: default: return cases::Chapter;
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+// CHECK-NEXT: inline bool isParagraph() const {
+// CHECK-NEXT:   return *this == cases::Paragraph;
+// CHECK-NEXT: }
+// CHECK-NEXT: inline bool isChar() const {
+// CHECK-NEXT:   return *this == cases::Char;
+// CHECK-NEXT: }
+// CHECK-NEXT: inline bool isChapter() const {
+// CHECK-NEXT:   return *this == cases::Chapter;
+// CHECK-NEXT: }
+// CHECK:      inline int _getEnumTag() const {
+// CHECK-NEXT:   auto metadata = _impl::$s5Enums19CharOrSectionMarkerOMa(0);
+// CHECK-NEXT:   auto *vwTable = *(reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1);
+// CHECK-NEXT:   const auto *enumVWTable = reinterpret_cast<swift::_impl::EnumValueWitnessTable *>(vwTable);
+// CHECK-NEXT:   return enumVWTable->getEnumTag(_getOpaquePointer(), metadata._0);
+// CHECK-NEXT: }
+
+// CHECK: class DataCase final {
+
+// CHECK:      inline operator cases() const {
+// CHECK-NEXT:   switch (_getEnumTag()) {
+// CHECK-NEXT:     case 0: default: return cases::one;
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+// CHECK-NEXT: inline bool isOne() const {
+// CHECK-NEXT:   return *this == cases::one;
+// CHECK-NEXT: }
+// CHECK:      inline int _getEnumTag() const {
+// CHECK-NEXT:   auto metadata = _impl::$s5Enums8DataCaseOMa(0);
+// CHECK-NEXT:   auto *vwTable = *(reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1);
+// CHECK-NEXT:   const auto *enumVWTable = reinterpret_cast<swift::_impl::EnumValueWitnessTable *>(vwTable);
+// CHECK-NEXT:   return enumVWTable->getEnumTag(_getOpaquePointer(), metadata._0);
+// CHECK-NEXT: }
+
+// CHECK: class IntDoubleOrBignum final {
+
+// CHECK:      inline operator cases() const {
+// CHECK-NEXT:   switch (_getEnumTag()) {
+// CHECK-NEXT:     case 0: return cases::Int;
+// CHECK-NEXT:     case 1: return cases::Double;
+// CHECK-NEXT:     case 2: default: return cases::Bignum;
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+// CHECK-NEXT: inline bool isInt() const {
+// CHECK-NEXT:   return *this == cases::Int;
+// CHECK-NEXT: }
+// CHECK-NEXT: inline bool isDouble() const {
+// CHECK-NEXT:   return *this == cases::Double;
+// CHECK-NEXT: }
+// CHECK-NEXT: inline bool isBignum() const {
+// CHECK-NEXT:   return *this == cases::Bignum;
+// CHECK-NEXT: }
+// CHECK:      inline int _getEnumTag() const {
+// CHECK-NEXT:   auto metadata = _impl::$s5Enums17IntDoubleOrBignumOMa(0);
+// CHECK-NEXT:   auto *vwTable = *(reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1);
+// CHECK-NEXT:   const auto *enumVWTable = reinterpret_cast<swift::_impl::EnumValueWitnessTable *>(vwTable);
+// CHECK-NEXT:   return enumVWTable->getEnumTag(_getOpaquePointer(), metadata._0);
+// CHECK-NEXT: }
+
+// CHECK: class IntOrInfinity final {
+
+// CHECK:      inline operator cases() const {
+// CHECK-NEXT:   switch (_getEnumTag()) {
+// CHECK-NEXT:     case 1: return cases::NegInfinity;
+// CHECK-NEXT:     case 0: return cases::Int;
+// CHECK-NEXT:     case 2: default: return cases::PosInfinity;
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+// CHECK-NEXT: inline bool isNegInfinity() const {
+// CHECK-NEXT:   return *this == cases::NegInfinity;
+// CHECK-NEXT: }
+// CHECK-NEXT: inline bool isInt() const {
+// CHECK-NEXT:   return *this == cases::Int;
+// CHECK-NEXT: }
+// CHECK-NEXT: inline bool isPosInfinity() const {
+// CHECK-NEXT:   return *this == cases::PosInfinity;
+// CHECK-NEXT: }
+// CHECK:      inline int _getEnumTag() const {
+// CHECK-NEXT:   auto metadata = _impl::$s5Enums13IntOrInfinityOMa(0);
+// CHECK-NEXT:   auto *vwTable = *(reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1);
+// CHECK-NEXT:   const auto *enumVWTable = reinterpret_cast<swift::_impl::EnumValueWitnessTable *>(vwTable);
+// CHECK-NEXT:   return enumVWTable->getEnumTag(_getOpaquePointer(), metadata._0);
+// CHECK-NEXT: }
+
+// CHECK: class TerminalChar final {
+
+// CHECK:      inline operator cases() const {
+// CHECK-NEXT:   switch (_getEnumTag()) {
+// CHECK-NEXT:     case 4: return cases::Cursor;
+// CHECK-NEXT:     case 0: return cases::Plain;
+// CHECK-NEXT:     case 1: return cases::Bold;
+// CHECK-NEXT:     case 2: return cases::Underline;
+// CHECK-NEXT:     case 3: return cases::Blink;
+// CHECK-NEXT:     case 5: default: return cases::Empty;
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+// CHECK-NEXT: inline bool isCursor() const {
+// CHECK-NEXT:   return *this == cases::Cursor;
+// CHECK-NEXT: }
+// CHECK-NEXT: inline bool isPlain() const {
+// CHECK-NEXT:   return *this == cases::Plain;
+// CHECK-NEXT: }
+// CHECK-NEXT: inline bool isBold() const {
+// CHECK-NEXT:   return *this == cases::Bold;
+// CHECK-NEXT: }
+// CHECK-NEXT: inline bool isUnderline() const {
+// CHECK-NEXT:   return *this == cases::Underline;
+// CHECK-NEXT: }
+// CHECK-NEXT: inline bool isBlink() const {
+// CHECK-NEXT:   return *this == cases::Blink;
+// CHECK-NEXT: }
+// CHECK-NEXT: inline bool isEmpty() const {
+// CHECK-NEXT:   return *this == cases::Empty;
+// CHECK-NEXT: }
+// CHECK:      inline int _getEnumTag() const {
+// CHECK-NEXT:   auto metadata = _impl::$s5Enums12TerminalCharOMa(0);
+// CHECK-NEXT:   auto *vwTable = *(reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1);
+// CHECK-NEXT:   const auto *enumVWTable = reinterpret_cast<swift::_impl::EnumValueWitnessTable *>(vwTable);
+// CHECK-NEXT:   return enumVWTable->getEnumTag(_getOpaquePointer(), metadata._0);
+// CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/enums/swift-enum-cases-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/swift-enum-cases-in-cxx.swift
@@ -23,8 +23,8 @@ public enum EnumCaseIsCxxKeyword {
 
 // CHECK: class EnumCaseIsCxxKeyword final {
 // CHECK:      enum class cases {
-// CHECK-NEXT:   first,
 // CHECK-NEXT:   second,
+// CHECK-NEXT:   first,
 // CHECK-NEXT:   const_
 // CHECK-NEXT: };
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
This is a follow-up of pull request https://github.com/apple/swift/pull/59669. This pull request implements `operator cases()` and various predicates.

For example, following Swift enum

```swift
public enum Foo { case x, y }
```

will have member functions in the generated C++ header file like this

```c++
class Foo final {
public:
  enum class cases {
    x,
    y
  };
  operator cases() const {
    switch (_getEnumTag()) {
      case 0: return cases::x;
      case 1: default: return cases::y;
    }
  }
  bool isX() const {
    return *this == cases::x;
  }
  bool isY() const {
    return *this == cases::y;
  }
};
```

Other changes:

- Print `EnumValueWitnessTable` struct when printing C++ interop scaffold;
- Add `_getEnumTag` helper function for retrieving the tag from enum value witness table.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!-- Resolves SR-NNNN. -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
