### PR TITLE
Platform: extend `ucrt` with some MSVC extensions

### DIFF
--- a/stdlib/public/Platform/ucrt.modulemap
+++ b/stdlib/public/Platform/ucrt.modulemap
@@ -116,6 +116,16 @@ module ucrt [system] {
     header "process.h"
     export *
   }
+
+  module malloc {
+    header "malloc.h"
+    export *
+  }
+
+  module wchar {
+    header "wchar.h"
+    export *
+  }
 }
 
 module corecrt [system] {


### PR DESCRIPTION
Add some additional modules which become necessary to support the C++
modularization.