### PR TITLE
Add missing `warnUntilSwift(6)`

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3573,11 +3573,13 @@ diagnoseDeclUnavailableFromAsync(const ValueDecl *D, SourceRange R,
     return false;
 
   ASTContext &ctx = Where.getDeclContext()->getASTContext();
+  // @available(noasync) spelling
   if (const AvailableAttr *attr = D->getAttrs().getNoAsync(ctx)) {
     SourceLoc diagLoc = call ? call->getLoc() : R.Start;
     auto diag = ctx.Diags.diagnose(diagLoc, diag::async_unavailable_decl,
                                    D->getDescriptiveKind(), D->getBaseName(),
                                    attr->Message);
+    diag.warnUntilSwiftVersion(6);
 
     if (!attr->Rename.empty()) {
       fixItAvailableAttrRename(diag, R, D, attr, call);
@@ -3590,7 +3592,7 @@ diagnoseDeclUnavailableFromAsync(const ValueDecl *D, SourceRange R,
 
   if (!hasUnavailableAttr)
     return false;
-  // @available(noasync) spelling
+  // @_unavailableFromAsync spelling
   const UnavailableFromAsyncAttr *attr =
       D->getAttrs().getAttribute<UnavailableFromAsyncAttr>();
   SourceLoc diagLoc = call ? call->getLoc() : R.Start;

--- a/test/Concurrency/unavailable_from_async.swift
+++ b/test/Concurrency/unavailable_from_async.swift
@@ -64,7 +64,7 @@ func makeAsyncClosuresSynchronously(bop: inout Bop) -> (() async -> Void) {
     bop.foo()     // expected-warning@:9{{'foo' is unavailable from asynchronous contexts}}
     bop.muppet()  // expected-warning@:9{{'muppet' is unavailable from asynchronous contexts}}
     unavailableFunction() // expected-warning@:5{{'unavailableFunction' is unavailable from asynchronous contexts}}
-    noasyncFunction() // expected-error@:5{{'noasyncFunction' is unavailable from asynchronous contexts}}
+    noasyncFunction() // expected-warning@:5{{'noasyncFunction' is unavailable from asynchronous contexts}}
 
     // Can use them from synchronous closures
     _ = { Bop() }()
@@ -89,7 +89,7 @@ func asyncFunc() async { // expected-error{{asynchronous global function 'asyncF
   bop.foo()     // expected-warning@:7{{'foo' is unavailable from asynchronous contexts}}
   bop.muppet()  // expected-warning@:7{{'muppet' is unavailable from asynchronous contexts}}
   unavailableFunction() // expected-warning@:3{{'unavailableFunction' is unavailable from asynchronous contexts}}
-  noasyncFunction() // expected-error@:3{{'noasyncFunction' is unavailable from asynchronous contexts}}
+  noasyncFunction() // expected-warning@:3{{'noasyncFunction' is unavailable from asynchronous contexts}}
 
   // Unavailable global function
   foo()         // expected-warning{{'foo' is unavailable from asynchronous contexts}}
@@ -113,7 +113,7 @@ func asyncFunc() async { // expected-error{{asynchronous global function 'asyncF
       bop.muppet()    // expected-warning@:11{{'muppet' is unavailable from asynchronous contexts}}
       _ = Bop()       // expected-warning@:11{{'init' is unavailable from asynchronous contexts; Use Bop(a: Int) instead}}
       unavailableFunction() // expected-warning@:7{{'unavailableFunction' is unavailable from asynchronous contexts}}
-      noasyncFunction() // expected-error@:7{{'noasyncFunction' is unavailable from asynchronous contexts}}
+      noasyncFunction() // expected-warning@:7{{'noasyncFunction' is unavailable from asynchronous contexts}}
     }
   }
 
@@ -123,7 +123,7 @@ func asyncFunc() async { // expected-error{{asynchronous global function 'asyncF
     bop.foo()     // expected-warning@:9{{'foo' is unavailable from asynchronous contexts}}
     bop.muppet()  // expected-warning@:9{{'muppet' is unavailable from asynchronous contexts}}
     unavailableFunction() // expected-warning@:5{{'unavailableFunction' is unavailable from asynchronous contexts}}
-    noasyncFunction() // expected-error@:5{{'noasyncFunction' is unavailable from asynchronous contexts}}
+    noasyncFunction() // expected-warning@:5{{'noasyncFunction' is unavailable from asynchronous contexts}}
 
     _ = {
       foo()

--- a/test/attr/attr_availability_noasync.swift
+++ b/test/attr/attr_availability_noasync.swift
@@ -27,16 +27,16 @@ actor IOActor {
 
 @available(SwiftStdlib 5.5, *)
 func asyncFunc() async {
-    // expected-error@+1{{global function 'basicNoAsync' is unavailable from asynchronous contexts}}
+    // expected-warning@+1{{global function 'basicNoAsync' is unavailable from asynchronous contexts; this is an error in Swift 6}}
     basicNoAsync()
 
-    // expected-error@+1{{global function 'messageNoAsync' is unavailable from asynchronous contexts; a message from the author}}
+    // expected-warning@+1{{global function 'messageNoAsync' is unavailable from asynchronous contexts; a message from the author}}
     messageNoAsync()
 
-    // expected-error@+1{{global function 'renamedNoAsync' is unavailable from asynchronous contexts}}{{5-19=asyncReplacement}}
+    // expected-warning@+1{{global function 'renamedNoAsync' is unavailable from asynchronous contexts}}{{5-19=asyncReplacement}}
     renamedNoAsync() { _ in }
 
-    // expected-error@+1{{global function 'readStringFromIO' is unavailable from asynchronous contexts}}{{13-29=IOActor.readString}}
+    // expected-warning@+1{{global function 'readStringFromIO' is unavailable from asynchronous contexts}}{{13-29=IOActor.readString}}
     let _ = readStringFromIO()
 }
 


### PR DESCRIPTION
Missed setting a diagnostic as a warning until swift 6, resulting in
noasync functions being emitted as errors in Swift 5.x. This fixes that
so they are only warnings until Swift 6.

Since `@_unavailableFromAsync` is serialized as `@available(*, noasync)`
in the swiftinterface/swiftmodule, this affects functions that are
imported from other modules as well.

https://github.com/apple/swift/issues/59748
Resolves: rdar://96065121
