### PR TITLE
[AST] Teach `computeNominalType` about nested ObjC protocols

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4288,7 +4288,11 @@ static Type computeNominalType(NominalTypeDecl *decl, DeclTypeKind kind) {
   // If `decl` is a nested type, find the parent type.
   Type ParentTy;
   DeclContext *dc = decl->getDeclContext();
-  if (!isa<ProtocolDecl>(decl) && dc->isTypeContext()) {
+  bool isObjCProtocol = isa<ProtocolDecl>(decl) && decl->hasClangNode();
+
+  // Objective-C protocols, unlike Swift protocols, could be nested
+  // in other types.
+  if ((isObjCProtocol || !isa<ProtocolDecl>(decl)) && dc->isTypeContext()) {
     switch (kind) {
     case DeclTypeKind::DeclaredType: {
       if (auto *nominal = dc->getSelfNominalTypeDecl())

--- a/test/ClangImporter/Inputs/nested_protocol_name.h
+++ b/test/ClangImporter/Inputs/nested_protocol_name.h
@@ -1,9 +1,12 @@
+@import Foundation;
+
 @protocol TrunkBranchProtocol;
 
 __attribute__((objc_root_class))
 @interface Trunk
 - (instancetype)init;
 - (void)addLimb:(id<TrunkBranchProtocol>)limb;
+- (void)addLimbs:(NSArray<id<TrunkBranchProtocol>> *)limbs;
 @end
 
 // NS_SWIFT_NAME(Trunk.Branch)

--- a/test/ClangImporter/nested_protocol_name.swift
+++ b/test/ClangImporter/nested_protocol_name.swift
@@ -11,8 +11,9 @@
 
 // HEADER: class Trunk {
 // HEADER:   init!()
-// HEADER:   class func addLimb(_ limb: Branch!)
-// HEADER:   func addLimb(_ limb: Branch!)
+// HEADER:   class func addLimb(_ limb: Trunk.Branch!)
+// HEADER:   func addLimb(_ limb: Trunk.Branch!)
+// HEADER:   func addLimbs(_ limbs: [Trunk.Branch]!)
 // HEADER: }
 // HEADER: // NS_SWIFT_NAME(Trunk.Branch)
 // HEADER: protocol Branch {
@@ -22,6 +23,11 @@
 func grow(_ branch: Trunk.Branch, from trunk: Trunk) {
   branch.flower()
   trunk.addLimb(branch)
+}
+
+// rdar://95084142 - crash while matching existential types
+func grow_multiple(_ branches: [Trunk.Branch], from trunk: Trunk) {
+  trunk.addLimbs(branches) // ok
 }
 
 class SturdyBranch: Trunk.Branch {


### PR DESCRIPTION
Objective-C protocols unlike their Swift counterparts could be
nested in other types, so `computeNominalType` has to fetch a
parent for such protocols (if any) just like importer does.

Resolves: rdar://95084142

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
