### PR TITLE
[IRGen] Use existential AnyObject throughout IRGen.

### DIFF
--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -1499,7 +1499,7 @@ emitAssociatedTypeMetadataRecord(const RootProtocolConformance *conformance) {
 void IRGenModule::emitBuiltinReflectionMetadata() {
   if (getSwiftModule()->isStdlibModule()) {
     BuiltinTypes.insert(Context.TheNativeObjectType);
-    BuiltinTypes.insert(Context.getAnyObjectConstraint());
+    BuiltinTypes.insert(Context.getAnyObjectType());
     BuiltinTypes.insert(Context.TheBridgeObjectType);
     BuiltinTypes.insert(Context.TheRawPointerType);
     BuiltinTypes.insert(Context.TheUnsafeValueBufferType);

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -3232,7 +3232,7 @@ public:
     }
     case SILFunctionType::Representation::Block:
       // All block types look like AnyObject.
-      return C.getAnyObjectConstraint();
+      return C.getAnyObjectType();
     }
 
     llvm_unreachable("Not a valid SILFunctionType.");
@@ -3353,7 +3353,7 @@ namespace {
           || t == C.TheNativeObjectType
           || t == C.TheBridgeObjectType
           || t == C.TheRawPointerType
-          || t == C.getAnyObjectConstraint())
+          || t == C.getAnyObjectType())
         return true;
       if (auto intTy = dyn_cast<BuiltinIntegerType>(t)) {
         auto width = intTy->getWidth();
@@ -3435,7 +3435,7 @@ namespace {
       }
       case SILFunctionType::Representation::Block:
         // All block types look like AnyObject.
-        return emitFromValueWitnessTable(C.getAnyObjectConstraint());
+        return emitFromValueWitnessTable(C.getAnyObjectType());
       }
 
       llvm_unreachable("Not a valid SILFunctionType.");
@@ -3478,7 +3478,7 @@ namespace {
       case ReferenceCounting::ObjC:
       case ReferenceCounting::Block:
       case ReferenceCounting::Unknown:
-        return emitFromValueWitnessTable(IGF.IGM.Context.getAnyObjectConstraint());
+        return emitFromValueWitnessTable(IGF.IGM.Context.getAnyObjectType());
 
       case ReferenceCounting::Bridge:
       case ReferenceCounting::Error:

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -477,7 +477,7 @@ namespace {
         if (auto superclassType = genericSig->getSuperclassBound(type))
           return superclassType;
         assert(genericSig->requiresClass(type));
-        return TC.Context.getAnyObjectConstraint();
+        return TC.Context.getAnyObjectType();
       }
 
       return type;


### PR DESCRIPTION
Previously, some places used `getAnyObjectConstraint` and others used `getAnyObjectType`. This inconsistency lead to IRGen crashes.

The only remaining callers of `getAnyObjectConstraint` are for generic requirements or inheritance clauses.

Resolves: rdar://95945015