### PR TITLE
Frontend: Introduce the `-enable-ad-hoc-availability` flag

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -164,6 +164,10 @@ namespace swift {
     /// Only check the availability of the API, ignore function bodies.
     bool CheckAPIAvailabilityOnly = false;
 
+    /// Causes the compiler to treat declarations available at the current
+    /// runtime OS version as potentially unavailable.
+    bool EnableAdHocAvailability = false;
+
     /// Should conformance availability violations be diagnosed as errors?
     bool EnableConformanceAvailabilityErrors = false;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -1064,5 +1064,9 @@ def clang_header_expose_public_decls:
   Flag<["-"], "clang-header-expose-public-decls">,
   HelpText<"Expose all public declarations in the generated clang header">,
   Flags<[FrontendOption, HelpHidden]>;
+  
+def enable_ad_hoc_availability :
+  Flag<["-"], "enable-ad-hoc-availability">,
+  HelpText<"Enable experimental support for ad hoc availability">;
 
 } // end let Flags = [FrontendOption, NoDriverOption, HelpHidden]

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1002,13 +1002,17 @@ bool Decl::isWeakImported(ModuleDecl *fromModule) const {
   if (isAlwaysWeakImported())
     return true;
 
-  auto containingContext = getAvailabilityForLinkage();
-  if (containingContext.isAlwaysAvailable())
+  auto availability = getAvailabilityForLinkage();
+  if (availability.isAlwaysAvailable())
     return false;
 
-  auto fromContext = AvailabilityContext::forDeploymentTarget(
-      fromModule->getASTContext());
-  return !fromContext.isContainedIn(containingContext);
+  auto &ctx = fromModule->getASTContext();
+  auto deploymentTarget = AvailabilityContext::forDeploymentTarget(ctx);
+
+  if (ctx.LangOpts.EnableAdHocAvailability)
+    return !availability.isSupersetOf(deploymentTarget);
+
+  return !deploymentTarget.isContainedIn(availability);
 }
 
 GenericContext::GenericContext(DeclContextKind Kind, DeclContext *Parent,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -490,6 +490,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
       Args.hasArg(OPT_disable_availability_checking);
   Opts.CheckAPIAvailabilityOnly |=
       Args.hasArg(OPT_check_api_availability_only);
+  Opts.EnableAdHocAvailability |=
+      Args.hasArg(OPT_enable_ad_hoc_availability);
 
   if (auto A = Args.getLastArg(OPT_enable_conformance_availability_errors,
                                OPT_disable_conformance_availability_errors)) {

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -385,9 +385,13 @@ bool SILFunction::isWeakImported() const {
   if (Availability.isAlwaysAvailable())
     return false;
 
-  auto fromContext = AvailabilityContext::forDeploymentTarget(
-      getASTContext());
-  return !fromContext.isContainedIn(Availability);
+  auto deploymentTarget =
+      AvailabilityContext::forDeploymentTarget(getASTContext());
+
+  if (getASTContext().LangOpts.EnableAdHocAvailability)
+    return !Availability.isSupersetOf(deploymentTarget);
+
+  return !deploymentTarget.isContainedIn(Availability);
 }
 
 SILBasicBlock *SILFunction::createBasicBlock() {

--- a/test/IRGen/weak_import_availability.swift
+++ b/test/IRGen/weak_import_availability.swift
@@ -2,11 +2,10 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/weak_import_availability_helper.swiftmodule -parse-as-library %S/Inputs/weak_import_availability_helper.swift -enable-library-evolution
 //
 // RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir | %FileCheck %s --check-prefix=CHECK-OLD
-// RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir -target x86_64-apple-macosx10.50 | %FileCheck %s --check-prefix=CHECK-NEW
-// RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir -target x86_64-apple-macosx10.60 | %FileCheck %s --check-prefix=CHECK-NEW
+// RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir -target %target-cpu-apple-macosx10.50 | %FileCheck %s --check-prefix=CHECK-NEW
+// RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir -target %target-cpu-apple-macosx10.60 | %FileCheck %s --check-prefix=CHECK-NEW
 
 // REQUIRES: OS=macosx
-// REQUIRES: CPU=x86_64
 
 import weak_import_availability_helper
 

--- a/test/IRGen/weak_import_availability.swift
+++ b/test/IRGen/weak_import_availability.swift
@@ -5,6 +5,9 @@
 // RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir -target %target-cpu-apple-macosx10.50 | %FileCheck %s --check-prefix=CHECK-NEW
 // RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir -target %target-cpu-apple-macosx10.60 | %FileCheck %s --check-prefix=CHECK-NEW
 
+// RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir -target %target-cpu-apple-macosx10.50 -enable-ad-hoc-availability | %FileCheck %s --check-prefix=CHECK-OLD
+// RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir -target %target-cpu-apple-macosx10.60 -enable-ad-hoc-availability | %FileCheck %s --check-prefix=CHECK-NEW
+
 // REQUIRES: OS=macosx
 
 import weak_import_availability_helper


### PR DESCRIPTION
When developing a module for an OS or SDK, one may use declarations from other modules that were recently introduced in the in-development OS. Those declarations will be annotated as available at the deployment target of the client module and yet the symbols for that declaration are not available in all development builds of that OS. If the module strongly links those symbols, it will crash on older development builds of the OS. The `-enable-experimental-ad-hoc-availability` flag is designed to give developers the option of weakly linking all symbols in other modules that were introduced at the deployment target.
    
This change introduces the basic change in linking behavior but does not address typechecking. Use of the declarations that are made unavailable in this mode will need to be diagnosed and developers will need a way to detect the unavailability at runtime before use.
    
Resolves rdar://96011550