### PR TITLE
[5.7][TypeChecker] Don’t crash if a `ExplicitCastExpr` doesn’t have a cast type

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3229,7 +3229,7 @@ public:
       maybeDiagParameterizedExistentialErasure(EE, Where);
     }
     if (auto *CC = dyn_cast<ExplicitCastExpr>(E)) {
-      if (!isa<CoerceExpr>(CC) &&
+      if (!isa<CoerceExpr>(CC) && CC->getCastType() &&
           CC->getCastType()->hasParameterizedExistential()) {
         SourceLoc loc = CC->getCastTypeRepr() ? CC->getCastTypeRepr()->getLoc()
                                               : E->getLoc();

--- a/validation-test/compiler_crashers_2_fixed/rdar95629905.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar95629905.swift
@@ -1,0 +1,19 @@
+// RUN: %target-typecheck-verify-swift
+
+@resultBuilder
+struct ViewBuilder {
+  static func buildBlock(_ x: Int) -> Int { x }
+}
+
+func test(_: () -> Void) -> Int {
+  return 42
+}
+
+struct MyView {
+  @ViewBuilder var body: Int {
+    test {
+      "ab" is Unknown // expected-error{{cannot find type 'Unknown' in scope}}
+      print("x")
+    }
+  }
+}


### PR DESCRIPTION
* **Explanation**: If the type of an `ExplicitCastExpr` is not valid, it is a null type, which causes a crash when checking if the cast type has parameterized existentials. This PR contains a minimal fix for the crash by checking for `nullptr` first.
* **Scope**: Type checking of `is` checks with invalid types in result builders
* **Risk**: Very low, any code that is affected by this changed behavior previously crashed the compiler
* **Testing**: Added regression test case
* **Issue**: rdar://95629905
* **Reviewer**: @xedin on https://github.com/apple/swift/pull/59664