### PR TITLE
stdlib: Reinstate an invariant check that used to not compile

### DIFF
--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -67,10 +67,7 @@ internal struct _ArrayBuffer<Element>: _ArrayBufferProtocol {
   ) -> _ArrayBuffer<U> {
     _internalInvariant(_isClassOrObjCExistential(Element.self))
     _internalInvariant(_isClassOrObjCExistential(U.self))
-    
-    // FIXME: can't check that U is derived from Element pending
-    // <rdar://problem/20028320> generic metatype casting doesn't work
-    // _internalInvariant(U.self is Element.Type)
+    _internalInvariant(U.self is Element.Type)
 
     return _ArrayBuffer<U>(
       storage: _ArrayBridgeStorage(native: _native._storage, isFlagged: true))


### PR DESCRIPTION
This issue appears to have been fixed. We have test coverage for generic metatype casts at least [here](https://github.com/apple/swift/blob/5f6b1262ff9440ea7d8d7bb2e5a89b4219717fa2/test/SILGen/metatype_casts.swift#L5), [here](https://github.com/apple/swift/blob/5f6b1262ff9440ea7d8d7bb2e5a89b4219717fa2/test/Casting/Casts.swift#L712), [here](https://github.com/apple/swift/blob/5f6b1262ff9440ea7d8d7bb2e5a89b4219717fa2/test/Constraints/casts.swift#L188) and [here](https://github.com/apple/swift/blob/5f6b1262ff9440ea7d8d7bb2e5a89b4219717fa2/test/Interpreter/generic_casts.swift#L105).
