### PR TITLE
[cxx-interop] Extend libstdc++ modulemap

### DIFF
--- a/stdlib/public/Cxx/std/libstdcxx.h
+++ b/stdlib/public/Cxx/std/libstdcxx.h
@@ -55,6 +55,17 @@
 #include "codecvt"
 #endif
 
+// Deprecated C-compatibility headers:
+
+// libstdc++ 4.8.5 bundled with CentOS 7 does not include stdlib.h.
+#if __has_include("stdlib.h")
+#include "stdlib.h"
+#endif
+// libstdc++ 4.8.5 bundled with CentOS 7 does not include math.h.
+#if __has_include("math.h")
+#include "math.h"
+#endif
+
 // C++17 and newer:
 
 #if __has_include("any")

--- a/stdlib/public/Cxx/std/libstdcxx.modulemap
+++ b/stdlib/public/Cxx/std/libstdcxx.modulemap
@@ -21,11 +21,84 @@ module std {
   requires cplusplus
   export *
 
+  module complex_h {
+    header "complex.h"
+    export ccomplex
+    export *
+  }
+  module tgmath_h {
+    header "tgmath.h"
+    export ccomplex
+    export cmath
+    export *
+  }
+
   /// C compatibility headers.
   module compat {
     module cassert {
       header "cassert"
-      requires cplusplus
+      export *
+    }
+    module cerrno {
+      header "cerrno"
+      export *
+    }
+    module cctype {
+      header "cctype"
+      export *
+    }
+    module cfloat {
+      header "cfloat"
+      export *
+    }
+    module ciso646 {
+      header "ciso646"
+      export *
+    }
+    module climits {
+      header "climits"
+      export *
+    }
+    module cmath {
+      header "cmath"
+      export *
+    }
+    module cstdarg {
+      header "cstdarg"
+      export *
+    }
+    module cstddef {
+      header "cstddef"
+      export *
+    }
+    module cstdio {
+      header "cstdio"
+      export *
+    }
+    module cstdlib {
+      header "cstdlib"
+      export *
+    }
+    module cstring {
+      header "cstring"
+      export *
+    }
+    module ctime {
+      header "ctime"
+      export *
+    }
+    module ctgmath {
+      header "ctgmath"
+      export ccomplex
+      export cmath
+      export *
+    }
+    module cwchar {
+      header "cwchar"
+      export *
+    }
+    module cwctype {
+      header "cwctype"
       export *
     }
   }

--- a/stdlib/public/Platform/glibc.modulemap.gyb
+++ b/stdlib/public/Platform/glibc.modulemap.gyb
@@ -18,7 +18,7 @@
 ///
 /// It's not named just Glibc so that it doesn't conflict in the event of a
 /// future official glibc modulemap.
-module SwiftGlibc [system] {
+module SwiftGlibc [system] [no_undeclared_includes] {
 % if CMAKE_SDK in ["LINUX", "ANDROID", "OPENBSD"]:
       link "m"
 % end

--- a/test/Interop/Cxx/stdlib/libstdcxx-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/libstdcxx-module-interface.swift
@@ -10,6 +10,8 @@
 // This test is specific to libstdc++ and only runs on platforms where libstdc++ is used.
 // REQUIRES: OS=linux-gnu
 
+// CHECK-STD: import std.compat
+
 // CHECK-STD: enum std {
 // CHECK-STRING:   struct {{__CxxTemplateInstNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE|__CxxTemplateInstSs}} {
 // CHECK-STRING:     typealias value_type = std.__CxxTemplateInstSt11char_traitsIcE.char_type


### PR DESCRIPTION
The modulemap needs to include the headers even if they are not supposed to be used directly from Swift:

If a C++ header is being imported into Swift, and the header includes a stdlib header, clang needs to correctly deduce that the stdlib header is a part of the stdlib module, and not a part of the C++ module that we're importing.