### PR TITLE
[Test] Add a hack to prevent a very odd tail bug

### DIFF
--- a/test/Driver/filelists.swift
+++ b/test/Driver/filelists.swift
@@ -76,9 +76,10 @@
 // RUN: %empty-directory(%t)
 // RUN: echo "int dummy;" >%t/a.cpp
 // RUN: %target-clang -c %t/a.cpp -o %t/a.o
-// RUN: %swiftc_driver -save-temps -driver-print-jobs %S/../Inputs/empty.swift %t/a.o -lto=llvm-full -target x86_64-apple-macosx10.9 -driver-filelist-threshold=0 -o filelist 2>&1 | tee %t/forFilelistCapture | %FileCheck -check-prefix FILELIST %s
-// RUN: tail -2 %t/forFilelistCapture | head -1 | sed 's/.*-output-filelist //' | sed 's/ .*//' > %t/output-filelist
-// RUN: tail -1 %t/forFilelistCapture | sed 's/.*-filelist //' | sed 's/ .*//' > %t/input-filelist
+// RUN: %swiftc_driver -save-temps -driver-print-jobs %S/../Inputs/empty.swift %t/a.o -lto=llvm-full -target x86_64-apple-macosx10.9 -driver-filelist-threshold=0 -o filelist 2>&1 | tee -a %t/forFilelistCapture | %FileCheck -check-prefix FILELIST %s
+// RUN: echo "# A comment so it's less likely this file will be 4096 in size\n" >> %t/forFilelistCapture
+// RUN: tail -3 %t/forFilelistCapture | head -1 | sed 's/.*-output-filelist //' | sed 's/ .*//' > %t/output-filelist
+// RUN: tail -2 %t/forFilelistCapture | head -1 | sed 's/.*-filelist //' | sed 's/ .*//' > %t/input-filelist
 // RUN: cat $(cat %t/output-filelist) | %FileCheck -check-prefix OUTPUT-FILELIST-CONTENTS %s
 // RUN: cat $(cat %t/input-filelist)  | %FileCheck -check-prefix INPUT-FILELIST-CONTENTS %s
 


### PR DESCRIPTION
`test/Driver/filelists.swift` writes out the swift driver jobs to a file
called `%t/forFilelistCapture`. We then `tail -2 | head -1` that file to
get the first line, run some seds, and expect that to the output file
list (eg. from the swift-frontend command). Unfortunately if that file
happens to end up being 4096 in length, `tail` skips the first line and
thus the seds run on *second* line. That produces `/usr/bin/ld` instead,
which obviously doesn't contain the output files!

Add a comment to the end of the file so that it's unlikely to be 4096
in length. Technically we could still hit it if we removed a bunch of
arguments, but this is fine until that bug is fixed.