### PR TITLE
Sema: Check conditional requirements in inferTypeWitnessesViaValueWitnesses()

### DIFF
--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -211,9 +211,10 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitnesses(
     // so won't be affected by whatever answer inference comes up with.
     auto *module = dc->getParentModule();
     auto checkConformance = [&](ProtocolDecl *proto) {
-      auto otherConf = module->lookupConformance(conformance->getType(),
-                                                 proto);
-      return (otherConf && otherConf.getConditionalRequirements().empty());
+      auto typeInContext = dc->mapTypeIntoContext(conformance->getType());
+      auto otherConf = TypeChecker::conformsToProtocol(
+          typeInContext, proto, module);
+      return !otherConf.isInvalid();
     };
 
     // First check the extended protocol itself.
@@ -249,8 +250,10 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitnesses(
     // type can't use it regardless of what associated types we end up
     // inferring, skip the witness.
     if (auto extension = dyn_cast<ExtensionDecl>(witness->getDeclContext()))
-      if (!isExtensionUsableForInference(extension))
+      if (!isExtensionUsableForInference(extension)) {
+        LLVM_DEBUG(llvm::dbgs() << "Extension not usable for inference\n");
         continue;
+      }
 
     // Try to resolve the type witness via this value witness.
     auto witnessResult = inferTypeWitnessesViaValueWitness(req, witness);

--- a/test/decl/protocol/req/associated_type_protocol_extension.swift
+++ b/test/decl/protocol/req/associated_type_protocol_extension.swift
@@ -1,0 +1,18 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P {
+  associatedtype Body: P
+  var body: Body { get }
+}
+
+// The S: P conformance should pick up 'var body'
+// from 'extension PP'.
+struct S<T> {}
+extension S : P, PP where T : P {}
+
+protocol PP : P {}
+extension PP {
+  var body: Never { fatalError() }
+}
+
+extension Never : PP {}

--- a/test/decl/protocol/req/missing_conformance.swift
+++ b/test/decl/protocol/req/missing_conformance.swift
@@ -129,6 +129,8 @@ struct S5: P14 { // expected-error {{type 'S5' does not conform to protocol 'P14
 }
 
 // SR-12759
+
+// Note: the conformance to collection should succeed
 struct CountSteps1<T> : Collection {
   init(count: Int) { self.count = count }
   var count: Int


### PR DESCRIPTION
Otherwise, a conditional conformance could not rely on a default
implementation in a protocol extension.

Fixes rdar://problem/91451771.