### PR TITLE
[Interop] [SwiftToCxx] Using the hardcode noexcept flags on the compiler only to non throwing functions 

### DIFF
--- a/include/swift/IRGen/IRABIDetailsProvider.h
+++ b/include/swift/IRGen/IRABIDetailsProvider.h
@@ -47,6 +47,16 @@ public:
     SizeType alignment;
   };
 
+  /// Information about any ABI additional parameters.
+  struct ABIAdditionalParam {
+    enum class ABIParameterRole { Self, Error };
+
+    ABIParameterRole role;
+    TypeDecl *type;
+  };
+
+  SmallVector<ABIAdditionalParam, 1> ABIAdditionalParams;
+
   /// Returns the size and alignment for the given type, or \c None if the type
   /// is not a fixed layout type.
   llvm::Optional<SizeAndAlignment>
@@ -98,6 +108,10 @@ public:
   /// Returns EnumElementDecls (enum cases) in their declaration order with
   /// their tag indices from the given EnumDecl
   llvm::MapVector<EnumElementDecl *, unsigned> getEnumTagMapping(EnumDecl *ED);
+
+  /// Returns the additional params if they exist after lowering the function.
+  SmallVector<ABIAdditionalParam, 1>
+  getFunctionABIAdditionalParams(AbstractFunctionDecl *fd);
 
 private:
   std::unique_ptr<IRABIDetailsProviderImpl> impl;

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -472,6 +472,9 @@ public:
   SILFunction *getDynamicallyReplacedFunction() const {
     return ReplacedFunction;
   }
+
+  static SILFunction *getFunction(SILDeclRef ref, SILModule &M);
+
   void setDynamicallyReplacedFunction(SILFunction *f) {
     assert(ReplacedFunction == nullptr && "already set");
     assert(!hasObjCReplacement());

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -43,6 +43,7 @@
 #include "clang/AST/DeclObjC.h"
 #include "clang/Basic/CharInfo.h"
 #include "clang/Basic/SourceManager.h"
+#include "SwiftToClangInteropContext.h"
 
 using namespace swift;
 using namespace swift::objc_translation;
@@ -937,6 +938,28 @@ private:
     StringRef symbolName;
   };
 
+  // Converts the array of ABIAdditionalParam into an array of AdditionalParam
+  void convertABIAdditionalParams(
+      AbstractFunctionDecl *FD, Type resultTy,
+      llvm::SmallVector<IRABIDetailsProvider::ABIAdditionalParam, 1> ABIparams,
+      llvm::SmallVector<DeclAndTypeClangFunctionPrinter::AdditionalParam, 2>
+          &params) {
+    for (auto param : ABIparams) {
+      if (param.role ==
+          IRABIDetailsProvider::ABIAdditionalParam::ABIParameterRole::Self)
+        params.push_back(
+            {DeclAndTypeClangFunctionPrinter::AdditionalParam::Role::Self,
+             resultTy->getASTContext().getOpaquePointerType(),
+             /*isIndirect=*/
+             isa<FuncDecl>(FD) ? cast<FuncDecl>(FD)->isMutating() : false});
+      if (param.role ==
+          IRABIDetailsProvider::ABIAdditionalParam::ABIParameterRole::Error)
+        params.push_back(
+            {DeclAndTypeClangFunctionPrinter::AdditionalParam::Role::Error,
+             resultTy->getASTContext().getOpaquePointerType()});
+    }
+  }
+
   // Print out the extern C Swift ABI function signature.
   FuncionSwiftABIInformation printSwiftABIFunctionSignatureAsCxxFunction(
       AbstractFunctionDecl *FD, Optional<FunctionType *> givenFuncType = None,
@@ -962,7 +985,9 @@ private:
     DeclAndTypeClangFunctionPrinter funcPrinter(os, owningPrinter.prologueOS,
                                                 owningPrinter.typeMapping,
                                                 owningPrinter.interopContext);
-    llvm::SmallVector<DeclAndTypeClangFunctionPrinter::AdditionalParam, 1>
+    auto ABIparams = owningPrinter.interopContext.getIrABIDetails()
+                         .getFunctionABIAdditionalParams(FD);
+    llvm::SmallVector<DeclAndTypeClangFunctionPrinter::AdditionalParam, 2>
         additionalParams;
     if (selfTypeDeclContext && !isa<ConstructorDecl>(FD)) {
       additionalParams.push_back(
@@ -971,6 +996,9 @@ private:
            /*isIndirect=*/
            isa<FuncDecl>(FD) ? cast<FuncDecl>(FD)->isMutating() : false});
     }
+    if (funcTy->isThrowing() && !ABIparams.empty())
+      convertABIAdditionalParams(FD, resultTy, ABIparams, additionalParams);
+
     funcPrinter.printFunctionSignature(
         FD, funcABI.getSymbolName(), resultTy,
         DeclAndTypeClangFunctionPrinter::FunctionSignatureKind::CFunctionProto,
@@ -978,7 +1006,9 @@ private:
     // Swift functions can't throw exceptions, we can only
     // throw them from C++ when emitting C++ inline thunks for the Swift
     // functions.
-    os << " SWIFT_NOEXCEPT";
+    // FIXME: Support throwing exceptions for Swift errors.
+    if (!funcTy->isThrowing())
+      os << " SWIFT_NOEXCEPT";
     if (!funcABI.useCCallingConvention())
       os << " SWIFT_CALL";
     printAvailability(FD);
@@ -1013,16 +1043,25 @@ private:
     DeclAndTypeClangFunctionPrinter funcPrinter(os, owningPrinter.prologueOS,
                                                 owningPrinter.typeMapping,
                                                 owningPrinter.interopContext);
+    llvm::SmallVector<DeclAndTypeClangFunctionPrinter::AdditionalParam, 2>
+        additionalParams;
+    auto ABIparams = owningPrinter.interopContext.getIrABIDetails()
+                         .getFunctionABIAdditionalParams(FD);
+    if (funcTy->isThrowing() && !ABIparams.empty())
+      convertABIAdditionalParams(FD, resultTy, ABIparams, additionalParams);
+
     funcPrinter.printFunctionSignature(
         FD, FD->getName().getBaseIdentifier().get(), resultTy,
         DeclAndTypeClangFunctionPrinter::FunctionSignatureKind::CxxInlineThunk);
     // FIXME: Support throwing exceptions for Swift errors.
-    os << " noexcept";
+    if (!funcTy->isThrowing())
+      os << " noexcept";
     printFunctionClangAttributes(FD, funcTy);
     printAvailability(FD);
     os << " {\n";
     funcPrinter.printCxxThunkBody(funcABI.getSymbolName(), resultTy,
-                                  FD->getParameters());
+                                  FD->getParameters(), additionalParams,
+                                  funcTy->isThrowing());
     os << "}\n";
   }
 

--- a/lib/PrintAsClang/PrintAsClang.cpp
+++ b/lib/PrintAsClang/PrintAsClang.cpp
@@ -320,6 +320,7 @@ static void writePrologue(raw_ostream &out, ASTContext &ctx,
   emitMacro("SWIFT_CALL", "__attribute__((swiftcall))");
   emitMacro("SWIFT_INDIRECT_RESULT", "__attribute__((swift_indirect_result))");
   emitMacro("SWIFT_CONTEXT", "__attribute__((swift_context))");
+  emitMacro("SWIFT_ERROR_RESULT", "__attribute__((swift_error_result))");
   // SWIFT_NOEXCEPT applies 'noexcept' in C++ mode only.
   emitCxxConditional(
       out, [&] { emitMacro("SWIFT_NOEXCEPT", "noexcept"); },

--- a/lib/PrintAsClang/PrintClangFunction.h
+++ b/lib/PrintAsClang/PrintClangFunction.h
@@ -15,6 +15,7 @@
 
 #include "swift/AST/Type.h"
 #include "swift/Basic/LLVM.h"
+#include "swift/IRGen/IRABIDetailsProvider.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/StringRef.h"
@@ -52,7 +53,7 @@ public:
 
   /// Information about any additional parameters.
   struct AdditionalParam {
-    enum class Role { Self };
+    enum class Role { Self, Error };
 
     Role role;
     Type type;
@@ -83,7 +84,8 @@ public:
   /// Swift function.
   void printCxxThunkBody(StringRef swiftSymbolName, Type resultTy,
                          const ParameterList *params,
-                         ArrayRef<AdditionalParam> additionalParams = {});
+                         ArrayRef<AdditionalParam> additionalParams = {},
+                         bool hasThrows = false);
 
   /// Print the Swift method as C++ method declaration/definition, including
   /// constructors.

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -21,6 +21,7 @@
 #include "swift/SIL/SILProfiler.h"
 #include "swift/SIL/CFG.h"
 #include "swift/SIL/PrettyStackTrace.h"
+#include "../../SILGen/SILGen.h"
 #include "swift/AST/Availability.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/Module.h"
@@ -873,4 +874,9 @@ visitArgEffects(std::function<void(int, bool, ArgEffectKind)> c) const {
     c(idx, (flags & EffectsFlagDerived) != 0, kind);
     idx++;
   }
+}
+
+SILFunction *SILFunction::getFunction(SILDeclRef ref, SILModule &M) {
+  swift::Lowering::SILGenModule SILGenModule(M, ref.getModuleContext());
+  return SILGenModule.getFunction(ref, swift::NotForDefinition);
 }

--- a/test/Interop/SwiftToCxx/functions/swift-functions-errors-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/swift-functions-errors-execution.cpp
@@ -9,7 +9,6 @@
 // RUN: %target-run %t/swift-functions-errors-execution | %FileCheck %s
 
 // REQUIRES: executable_test
-// XFAIL: *
 
 #include <cassert>
 #include "functions.h"

--- a/test/Interop/SwiftToCxx/functions/swift-functions-errors.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-functions-errors.swift
@@ -8,14 +8,12 @@
 
 // CHECK-LABEL: namespace _impl {
 
-// CHECK: SWIFT_EXTERN void $s9Functions18emptyThrowFunctionyyKF(void) SWIFT_CALL; // emptyThrowFunction()
-// CHECK: SWIFT_EXTERN void $s9Functions13throwFunctionyyKF(void) SWIFT_CALL; // throwFunction()
+// CHECK: SWIFT_EXTERN void $s9Functions18emptyThrowFunctionyyKF(SWIFT_CONTEXT void * _Nonnull _self, SWIFT_ERROR_RESULT void ** _error) SWIFT_CALL; // emptyThrowFunction()
+// CHECK: SWIFT_EXTERN void $s9Functions13throwFunctionyyKF(SWIFT_CONTEXT void * _Nonnull _self, SWIFT_ERROR_RESULT void ** _error) SWIFT_CALL; // throwFunction()
 
 // CHECK: }
 
-//XFAIL: *
-
-enum NaiveErrors: Error {
+enum NaiveErrors : Error {
     case returnError
     case throwError
 }
@@ -23,7 +21,9 @@ enum NaiveErrors: Error {
 public func emptyThrowFunction() throws { print("passEmptyThrowFunction") }
 
 // CHECK: inline void emptyThrowFunction() {
-// CHECK: return _impl::$s9Functions18emptyThrowFunctionyyKF();
+// CHECK: void* opaqueError = nullptr;
+// CHECK: void* self = nullptr;
+// CHECK: return _impl::$s9Functions18emptyThrowFunctionyyKF(self, &opaqueError);
 // CHECK: }
 
 public func throwFunction() throws {
@@ -32,5 +32,7 @@ public func throwFunction() throws {
 }
 
 // CHECK: inline void throwFunction() {
-// CHECK: return _impl::$s9Functions13throwFunctionyyKF();
+// CHECK: void* opaqueError = nullptr;
+// CHECK: void* self = nullptr;
+// CHECK: return _impl::$s9Functions13throwFunctionyyKF(self, &opaqueError);
 // CHECK: }

--- a/test/PrintAsCxx/empty.swift
+++ b/test/PrintAsCxx/empty.swift
@@ -80,6 +80,7 @@
 // CHECK-LABEL: # define SWIFT_CALL __attribute__((swiftcall))
 // CHECK:       # define SWIFT_INDIRECT_RESULT __attribute__((swift_indirect_result))
 // CHECK:       # define SWIFT_CONTEXT __attribute__((swift_context))
+// CHECK:       # define SWIFT_ERROR_RESULT __attribute__((swift_error_result))
 
 // CHECK-LABEL: #if defined(__OBJC__)
 // CHECK-NEXT:  #if __has_feature(modules)


### PR DESCRIPTION
This PR aims to modify the use of the hardcode flags that, so far, represented an unreal behavior from Swift functions that assume that every function doesn't throw an exception. The tests introduced by this [PR](https://github.com/apple/swift/compare/main...Robertorosmaninho:cxx-interop/SwiftToCxxErrorHandling?expand=1#59217) show the need for a new implementation to handle thrown functions.

This PR enable the tests [swift-functions-errors.swift](https://github.com/apple/swift/compare/main...Robertorosmaninho:interop/SwiftToCxxErrorHandling?expand=1#diff-95751b9663a6f895f190092c7a3a130983b4f5b21ee32c50dfbfe7f34a92a438) and [swift-functions-errors-execution.cpp](https://github.com/apple/swift/compare/main...Robertorosmaninho:interop/SwiftToCxxErrorHandling?expand=1#diff-6e56f9a7dcc273e66801494f1c061fea4dc4a6e90ace005f2c4968f652a51c09) and check that are correctly passing.

The main idea of this PR is to insert a condition to print the SWIFT_NOEXCEPT and the noexcept on the functions inside the bridging header files generated by Swift to interop with C++. This PR also introduces a trivial error type as an argument on a thrown function.