### PR TITLE
[5.7] [stdlib] Fix the name mangling for UnsafeMutableRawPointer.storeBytes

### DIFF
--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -1247,7 +1247,7 @@ public struct UnsafeMutableRawPointer: _Pointer {
   // of `storeBytes<T>(of:toByteOffset:as:)`, and provides an entry point for
   // any binary compiled against the stlib binary for Swift 5.6 and older.
   @available(*, unavailable)
-  @_silgen_name("sSv10storeBytes2of12toByteOffset2asyx_SixmtlF")
+  @_silgen_name("$sSv10storeBytes2of12toByteOffset2asyx_SixmtlF")
   @usableFromInline func _legacy_se0349_storeBytes<T>(
     of value: T, toByteOffset offset: Int = 0, as type: T.Type
   ) {


### PR DESCRIPTION
The name mangling for storeBytes is missing `$`.

Cherry-pick of https://github.com/apple/swift/pull/59788

rdar://96151815
