### PR TITLE
[5.7][stdlib] Improve the mangled names of some @_alwaysEmitIntoClient functions

### DIFF
--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -730,9 +730,9 @@ extension Unsafe${Mutable}BufferPointer {
   @_alwaysEmitIntoClient
   // This custom silgen name is chosen to not interfere with the old ABI
 % if Mutable:
-  @_silgen_name("$_swift_se0333_UnsafeMutableBufferPointer_withMemoryRebound")
+  @_silgen_name("_swift_se0333_UnsafeMutableBufferPointer_withMemoryRebound")
 % else:
-  @_silgen_name("$_swift_se0333_UnsafeBufferPointer_withMemoryRebound")
+  @_silgen_name("_swift_se0333_UnsafeBufferPointer_withMemoryRebound")
 % end
   public func withMemoryRebound<T, Result>(
     to type: T.Type,

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -763,8 +763,9 @@ extension Unsafe${Mutable}BufferPointer {
   }
 
   // This unavailable implementation uses the expected mangled name
-  // of `withMemoryRebound`, and provides an entry point for any
-  // binary compiled against the stlib binary for Swift 5.6 and older.
+  // of `withMemoryRebound<T, Result>(to:_:)`, and provides
+  // an entry point for any binary linked against the stlib binary
+  // for Swift 5.6 and older.
   @available(*, unavailable)
 % if Mutable:
   @_silgen_name("$sSr17withMemoryRebound2to_qd_0_qd__m_qd_0_Sryqd__GKXEtKr0_lF")

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -326,8 +326,9 @@ public struct UnsafePointer<Pointee>: _Pointer {
   }
 
   // This unavailable implementation uses the expected mangled name
-  // of `withMemoryRebound`, and provides an entry point for any
-  // binary compiled against the stlib binary for Swift 5.6 and older.
+  // of `withMemoryRebound<T, Result>(to:capacity:_:)`, and provides
+  // an entry point for any binary linked against the stlib binary
+  // for Swift 5.6 and older.
   @available(*, unavailable)
   @_silgen_name("$sSP17withMemoryRebound2to8capacity_qd_0_qd__m_Siqd_0_SPyqd__GKXEtKr0_lF")
   @usableFromInline
@@ -1032,8 +1033,9 @@ public struct UnsafeMutablePointer<Pointee>: _Pointer {
   }
 
   // This unavailable implementation uses the expected mangled name
-  // of `withMemoryRebound`, and provides an entry point for any
-  // binary compiled against the stlib binary for Swift 5.6 and older.
+  // of `withMemoryRebound<T, Result>(to:capacity:_:)`, and provides
+  // an entry point for any binary linked against the stlib binary
+  // for Swift 5.6 and older.
   @available(*, unavailable)
   @_silgen_name("$sSp17withMemoryRebound2to8capacity_qd_0_qd__m_Siqd_0_Spyqd__GKXEtKr0_lF")
   @usableFromInline

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -1013,7 +1013,7 @@ public struct UnsafeMutablePointer<Pointee>: _Pointer {
   @inlinable
   @_alwaysEmitIntoClient
   // This custom silgen name is chosen to not interfere with the old ABI
-  @_silgen_name("$_swift_se0333_UnsafeMutablePointer_withMemoryRebound")
+  @_silgen_name("_swift_se0333_UnsafeMutablePointer_withMemoryRebound")
   public func withMemoryRebound<T, Result>(
     to type: T.Type,
     capacity count: Int,

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -463,6 +463,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///     with `type`.
   @inlinable
   @_alwaysEmitIntoClient
+  // This custom silgen name is chosen to not interfere with the old ABI
   @_silgen_name("_swift_se0349_UnsafeMutableRawBufferPointer_storeBytes")
   public func storeBytes<T>(
     of value: T, toByteOffset offset: Int = 0, as type: T.Type

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -478,7 +478,7 @@ extension Unsafe${Mutable}RawBufferPointer {
 
   // This unavailable implementation uses the expected mangled name
   // of `storeBytes<T>(of:toByteOffset:as:)`, and provides an entry point for
-  // any binary compiled against the stlib binary for Swift 5.6 and older.
+  // any binary linked against the stlib binary for Swift 5.6 and older.
   @available(*, unavailable)
   @_silgen_name("$sSw10storeBytes2of12toByteOffset2asyx_SixmtlF")
   @usableFromInline func _legacy_se0349_storeBytes<T>(

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -1226,6 +1226,7 @@ public struct UnsafeMutableRawPointer: _Pointer {
   ///   - type: The type of `value`.
   @inlinable
   @_alwaysEmitIntoClient
+  // This custom silgen name is chosen to not interfere with the old ABI
   @_silgen_name("_swift_se0349_UnsafeMutableRawPointer_storeBytes")
   public func storeBytes<T>(
     of value: T, toByteOffset offset: Int = 0, as type: T.Type


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/59797 to the 5.7 branch.

Some mangled names for non-abi functions included $ by mistake.
This PR also improves the explanation for compatibility entry points that use the mangled names of newer, non-abi functions.

No related issue.