### PR TITLE
🍒[5.7][Distributed] Implement distributed computed properties via special accessor

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -197,7 +197,7 @@ public:
                                              Type GlobalActorBound,
                                              ModuleDecl *Module);
 
-  std::string mangleDistributedThunk(const FuncDecl *thunk);
+  std::string mangleDistributedThunk(const AbstractFunctionDecl *thunk);
 
   /// Mangle a completion handler block implementation function, used for importing ObjC
   /// APIs as async.

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -661,7 +661,7 @@ SIMPLE_DECL_ATTR(_inheritActorContext, InheritActorContext,
 // 117 was 'spawn' and is now unused
 
 CONTEXTUAL_SIMPLE_DECL_ATTR(distributed, DistributedActor,
-  DeclModifier | OnClass | OnFunc | OnVar |
+  DeclModifier | OnClass | OnFunc | OnAccessor | OnVar |
   ABIBreakingToAdd | ABIBreakingToRemove |
   APIBreakingToAdd | APIBreakingToRemove,
   118)

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5113,6 +5113,13 @@ public:
 
   bool hasAnyNativeDynamicAccessors() const;
 
+  /// Does this have a 'distributed' modifier?
+  bool isDistributed() const;
+
+  /// Return a distributed thunk if this computed property is marked as
+  /// 'distributed' and and nullptr otherwise.
+  FuncDecl *getDistributedThunk() const;
+
   // Implement isa/cast/dyncast/etc.
   static bool classof(const Decl *D) {
     return D->getKind() >= DeclKind::First_AbstractStorageDecl &&
@@ -5345,13 +5352,6 @@ public:
 
   /// Is this an "async let" property?
   bool isAsyncLet() const;
-
-  /// Does this have a 'distributed' modifier?
-  bool isDistributed() const;
-
-  /// Return a distributed thunk if this computed property is marked as
-  /// 'distributed' and and nullptr otherwise.
-  FuncDecl *getDistributedThunk() const;
 
   /// Is this var known to be a "local" distributed actor,
   /// if so the implicit throwing ans some isolation checks can be skipped.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -412,7 +412,7 @@ protected:
   SWIFT_INLINE_BITFIELD(SubscriptDecl, VarDecl, 2,
     StaticSpelling : 2
   );
-  SWIFT_INLINE_BITFIELD(AbstractFunctionDecl, ValueDecl, 3+2+8+1+1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD(AbstractFunctionDecl, ValueDecl, 3+2+8+1+1+1+1+1+1+1,
     /// \see AbstractFunctionDecl::BodyKind
     BodyKind : 3,
 
@@ -439,7 +439,11 @@ protected:
 
     /// Whether peeking into this function detected nested type declarations.
     /// This is set when skipping over the decl at parsing.
-    HasNestedTypeDeclarations : 1
+    HasNestedTypeDeclarations : 1,
+
+    /// Whether this function is a distributed thunk for a distributed
+    /// function or computed property.
+    DistributedThunk: 1
   );
 
   SWIFT_INLINE_BITFIELD(FuncDecl, AbstractFunctionDecl, 1+1+2+1+1+2+1,
@@ -6318,6 +6322,7 @@ protected:
     Bits.AbstractFunctionDecl.Throws = Throws;
     Bits.AbstractFunctionDecl.HasSingleExpressionBody = false;
     Bits.AbstractFunctionDecl.HasNestedTypeDeclarations = false;
+    Bits.AbstractFunctionDecl.DistributedThunk = false;
   }
 
   void setBodyKind(BodyKind K) {
@@ -6418,6 +6423,16 @@ public:
 
   /// Returns 'true' if the function is distributed.
   bool isDistributed() const;
+
+  /// Is this a thunk function used to access a distributed method
+  /// or computed property outside of its actor isolation context?
+  bool isDistributedThunk() const {
+    return Bits.AbstractFunctionDecl.DistributedThunk;
+  }
+
+  void setDistributedThunk(bool isThunk) {
+    Bits.AbstractFunctionDecl.DistributedThunk = isThunk;
+  }
 
   /// For a 'distributed' target (func or computed property),
   /// get the 'thunk' responsible for performing the 'remoteCall'.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5345,6 +5345,10 @@ public:
   /// Does this have a 'distributed' modifier?
   bool isDistributed() const;
 
+  /// Return a distributed thunk if this computed property is marked as
+  /// 'distributed' and and nullptr otherwise.
+  FuncDecl *getDistributedThunk() const;
+
   /// Is this var known to be a "local" distributed actor,
   /// if so the implicit throwing ans some isolation checks can be skipped.
   bool isKnownToBeLocal() const;

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4817,6 +4817,9 @@ ERROR(distributed_actor_func_static,none,
 ERROR(distributed_actor_func_not_in_distributed_actor,none,
       "'distributed' method can only be declared within 'distributed actor'",
       ())
+ERROR(distributed_method_requirement_must_be_async_throws,none, // FIXME(distributed): this is an implementation limitation we should lift
+      "'distributed' protocol requirement %0 must currently be declared explicitly 'async throws'",
+      (DeclName))
 ERROR(distributed_actor_user_defined_special_property,none,
       "property %0 cannot be defined explicitly, as it conflicts with "
       "distributed actor synthesized stored property",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4833,6 +4833,9 @@ ERROR(distributed_property_cannot_be_static,none,
 ERROR(distributed_property_can_only_be_computed,none,
       "%0 %1 cannot be 'distributed', only computed properties can",
       (DescriptiveDeclKind, DeclName))
+ERROR(distributed_property_accessor_only_get_can_be_distributed,none,
+      "only 'get' accessors may be 'distributed'",
+      ())
 NOTE(distributed_actor_isolated_property,none,
       "access to %0 %1 is only permitted within distributed actor %2",
       (DescriptiveDeclKind, DeclName, DeclName))

--- a/include/swift/AST/DistributedDecl.h
+++ b/include/swift/AST/DistributedDecl.h
@@ -50,6 +50,11 @@ Type getDistributedActorSystemType(NominalTypeDecl *actor);
 /// Determine the `ID` type for the given actor.
 Type getDistributedActorIDType(NominalTypeDecl *actor);
 
+/// Similar to `getDistributedSerializationRequirementType`, however, from the
+/// perspective of a concrete function. This way we're able to get the
+/// serialization requirement for specific members, also in protocols.
+Type getConcreteReplacementForMemberSerializationRequirement(ValueDecl *member);
+
 /// Get specific 'SerializationRequirement' as defined in 'nominal'
 /// type, which must conform to the passed 'protocol' which is expected
 /// to require the 'SerializationRequirement'.

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -124,6 +124,12 @@ enum class AccessSemantics : uint8_t {
   /// This is an ordinary access to a declaration, using whatever
   /// polymorphism is expected.
   Ordinary,
+
+  /// This is an access to the underlying storage through a distributed thunk.
+  ///
+  /// The declaration must be a 'distributed' computed property used outside
+  /// of its actor isolation context.
+  DistributedThunk,
 };
 
 /// Expr - Base class for all expressions in swift.
@@ -155,11 +161,10 @@ protected:
 
   SWIFT_INLINE_BITFIELD_EMPTY(LiteralExpr, Expr);
   SWIFT_INLINE_BITFIELD_EMPTY(IdentityExpr, Expr);
-  SWIFT_INLINE_BITFIELD(LookupExpr, Expr, 1+1+1+1,
+  SWIFT_INLINE_BITFIELD(LookupExpr, Expr, 1+1+1,
     IsSuper : 1,
     IsImplicitlyAsync : 1,
-    IsImplicitlyThrows : 1,
-    ShouldApplyDistributedThunk: 1
+    IsImplicitlyThrows : 1
   );
   SWIFT_INLINE_BITFIELD_EMPTY(DynamicLookupExpr, LookupExpr);
 
@@ -1656,18 +1661,6 @@ public:
     Bits.LookupExpr.IsImplicitlyThrows = isImplicitlyThrows;
   }
 
-  /// Informs IRGen to that this expression should be applied as its distributed
-  /// thunk, rather than invoking the function directly.
-  ///
-  /// Only intended to be set on distributed get-only computed properties.
-  bool shouldApplyLookupDistributedThunk() const {
-    return Bits.LookupExpr.ShouldApplyDistributedThunk;
-  }
-
-  void setShouldApplyLookupDistributedThunk(bool flag) {
-    Bits.LookupExpr.ShouldApplyDistributedThunk = flag;
-  }
-
   static bool classof(const Expr *E) {
     return E->getKind() >= ExprKind::First_LookupExpr &&
            E->getKind() <= ExprKind::Last_LookupExpr;
@@ -1695,6 +1688,14 @@ public:
   /// does not call the getter or setter.
   AccessSemantics getAccessSemantics() const {
     return (AccessSemantics) Bits.MemberRefExpr.Semantics;
+  }
+
+  /// Informs IRGen to that this member should be applied via its distributed
+  /// thunk, rather than invoking it directly.
+  ///
+  /// Only intended to be set on distributed get-only computed properties.
+  void setAccessViaDistributedThunk() {
+    Bits.MemberRefExpr.Semantics = (unsigned)AccessSemantics::DistributedThunk;
   }
 
   SourceLoc getLoc() const { return NameLoc.getBaseNameLoc(); }

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -155,10 +155,11 @@ protected:
 
   SWIFT_INLINE_BITFIELD_EMPTY(LiteralExpr, Expr);
   SWIFT_INLINE_BITFIELD_EMPTY(IdentityExpr, Expr);
-  SWIFT_INLINE_BITFIELD(LookupExpr, Expr, 1+1+1,
+  SWIFT_INLINE_BITFIELD(LookupExpr, Expr, 1+1+1+1,
     IsSuper : 1,
     IsImplicitlyAsync : 1,
-    IsImplicitlyThrows : 1
+    IsImplicitlyThrows : 1,
+    ShouldApplyDistributedThunk: 1
   );
   SWIFT_INLINE_BITFIELD_EMPTY(DynamicLookupExpr, LookupExpr);
 
@@ -1653,6 +1654,18 @@ public:
   /// networking error.
   void setImplicitlyThrows(bool isImplicitlyThrows) {
     Bits.LookupExpr.IsImplicitlyThrows = isImplicitlyThrows;
+  }
+
+  /// Informs IRGen to that this expression should be applied as its distributed
+  /// thunk, rather than invoking the function directly.
+  ///
+  /// Only intended to be set on distributed get-only computed properties.
+  bool shouldApplyLookupDistributedThunk() const {
+    return Bits.LookupExpr.ShouldApplyDistributedThunk;
+  }
+
+  void setShouldApplyLookupDistributedThunk(bool flag) {
+    Bits.LookupExpr.ShouldApplyDistributedThunk = flag;
   }
 
   static bool classof(const Expr *E) {

--- a/include/swift/AST/StorageImpl.h
+++ b/include/swift/AST/StorageImpl.h
@@ -110,10 +110,6 @@ public:
     /// separately performing a Read into a temporary variable followed by
     /// a Write access back into the storage.
     MaterializeToTemporary,
-
-//    /// The access is to a computed distributed property, and thus the
-//    /// get-accessor is a distributed thunk which may perform a remote call.
-//    DirectToDistributedThunkAccessor,
   };
 
 private:
@@ -153,10 +149,6 @@ public:
     return { dispatched ? DispatchToAccessor : DirectToAccessor, accessor };
   }
 
-//  static AccessStrategy getDistributedGetAccessor(AccessorKind accessor) {
-//    assert(accessor == AccessorKind::Get);
-//    return { DirectToDistributedThunkAccessor, accessor };
-//  }
   static AccessStrategy getMaterializeToTemporary(AccessStrategy read,
                                                   AccessStrategy write) {
     return { read, write };

--- a/include/swift/AST/StorageImpl.h
+++ b/include/swift/AST/StorageImpl.h
@@ -110,6 +110,10 @@ public:
     /// separately performing a Read into a temporary variable followed by
     /// a Write access back into the storage.
     MaterializeToTemporary,
+
+//    /// The access is to a computed distributed property, and thus the
+//    /// get-accessor is a distributed thunk which may perform a remote call.
+//    DirectToDistributedThunkAccessor,
   };
 
 private:
@@ -149,6 +153,10 @@ public:
     return { dispatched ? DispatchToAccessor : DirectToAccessor, accessor };
   }
 
+//  static AccessStrategy getDistributedGetAccessor(AccessorKind accessor) {
+//    assert(accessor == AccessorKind::Get);
+//    return { DirectToDistributedThunkAccessor, accessor };
+//  }
   static AccessStrategy getMaterializeToTemporary(AccessStrategy read,
                                                   AccessStrategy write) {
     return { read, write };

--- a/include/swift/AST/StorageImpl.h
+++ b/include/swift/AST/StorageImpl.h
@@ -110,6 +110,10 @@ public:
     /// separately performing a Read into a temporary variable followed by
     /// a Write access back into the storage.
     MaterializeToTemporary,
+
+    /// The access is to a computed distributed property, and thus the
+    /// get-accessor is a distributed thunk which may perform a remote call.
+    DispatchToDistributedThunk,
   };
 
 private:
@@ -149,6 +153,10 @@ public:
     return { dispatched ? DispatchToAccessor : DirectToAccessor, accessor };
   }
 
+  static AccessStrategy getDistributedThunkDispatchStrategy() {
+    return {DispatchToDistributedThunk, AccessorKind::Get};
+  }
+
   static AccessStrategy getMaterializeToTemporary(AccessStrategy read,
                                                   AccessStrategy write) {
     return { read, write };
@@ -157,7 +165,8 @@ public:
   Kind getKind() const { return TheKind; }
 
   bool hasAccessor() const {
-    return TheKind == DirectToAccessor || TheKind == DispatchToAccessor;
+    return TheKind == DirectToAccessor || TheKind == DispatchToAccessor ||
+           TheKind == DispatchToDistributedThunk;
   }
 
   AccessorKind getAccessor() const {

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1280,11 +1280,13 @@ public:
 /// The thunk is responsible for invoking 'remoteCall' when invoked on a remote
 /// 'distributed actor'.
 class GetDistributedThunkRequest
-    : public SimpleRequest<
-          GetDistributedThunkRequest,
-          FuncDecl *(llvm::PointerUnion<VarDecl *, AbstractFunctionDecl *>),
-          RequestFlags::Cached> {
-  using Originator = llvm::PointerUnion<VarDecl *, AbstractFunctionDecl *>;
+    : public SimpleRequest<GetDistributedThunkRequest,
+                           FuncDecl *(
+                               llvm::PointerUnion<AbstractStorageDecl *,
+                                                  AbstractFunctionDecl *>),
+                           RequestFlags::Cached> {
+  using Originator =
+      llvm::PointerUnion<AbstractStorageDecl *, AbstractFunctionDecl *>;
 
 public:
   using SimpleRequest::SimpleRequest;

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -1279,17 +1279,20 @@ public:
 ///
 /// The thunk is responsible for invoking 'remoteCall' when invoked on a remote
 /// 'distributed actor'.
-class GetDistributedThunkRequest :
-    public SimpleRequest<GetDistributedThunkRequest,
-                         FuncDecl *(AbstractFunctionDecl *),
-                         RequestFlags::Cached> {
+class GetDistributedThunkRequest
+    : public SimpleRequest<
+          GetDistributedThunkRequest,
+          FuncDecl *(llvm::PointerUnion<VarDecl *, AbstractFunctionDecl *>),
+          RequestFlags::Cached> {
+  using Originator = llvm::PointerUnion<VarDecl *, AbstractFunctionDecl *>;
+
 public:
   using SimpleRequest::SimpleRequest;
 
 private:
   friend SimpleRequest;
 
-  FuncDecl *evaluate(Evaluator &evaluator, AbstractFunctionDecl *distributedFunc) const;
+  FuncDecl *evaluate(Evaluator &evaluator, Originator originator) const;
 
 public:
   // Caching

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -137,7 +137,7 @@ SWIFT_REQUEST(TypeChecker, GetDistributedTargetInvocationResultHandlerOnReturnFu
               AbstractFunctionDecl *(NominalTypeDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, GetDistributedThunkRequest,
-              FuncDecl *(llvm::PointerUnion<VarDecl *, AbstractFunctionDecl *>),
+              FuncDecl *(llvm::PointerUnion<AbstractStorageDecl *, AbstractFunctionDecl *>),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, GetDistributedActorIDPropertyRequest,
               VarDecl *(NominalTypeDecl *),

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -137,7 +137,7 @@ SWIFT_REQUEST(TypeChecker, GetDistributedTargetInvocationResultHandlerOnReturnFu
               AbstractFunctionDecl *(NominalTypeDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, GetDistributedThunkRequest,
-              FuncDecl *(AbstractFunctionDecl *),
+              FuncDecl *(llvm::PointerUnion<VarDecl *, AbstractFunctionDecl *>),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, GetDistributedActorIDPropertyRequest,
               VarDecl *(NominalTypeDecl *),

--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -414,8 +414,7 @@ struct SILDeclRef {
                       defaultArgIndex,
                       pointer.get<AutoDiffDerivativeFunctionIdentifier *>());
   }
-  /// Returns the distributed entry point corresponding to the same
-  /// decl.
+  /// Returns the distributed entry point corresponding to the same decl.
   SILDeclRef asDistributed(bool distributed = true) const {
     return SILDeclRef(loc.getOpaqueValue(), kind,
                       /*foreign=*/false,

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -742,6 +742,8 @@ namespace {
 
     void visitVarDecl(VarDecl *VD) {
       printCommon(VD, "var_decl");
+      if (VD->isDistributed())
+        PrintWithColorRAII(OS, DeclModifierColor) << " distributed";
       if (VD->isLet())
         PrintWithColorRAII(OS, DeclModifierColor) << " let";
       if (VD->getAttrs().hasAttribute<LazyAttr>())
@@ -2020,6 +2022,9 @@ public:
 
   void visitMemberRefExpr(MemberRefExpr *E) {
     printCommon(E, "member_ref_expr");
+    if (E->shouldApplyLookupDistributedThunk()) {
+      OS << " distributed";
+    }
     PrintWithColorRAII(OS, DeclColor) << " decl=";
     printDeclRef(E->getMember());
     if (E->getAccessSemantics() != AccessSemantics::Ordinary)

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -255,6 +255,7 @@ static StringRef getAccessSemanticsString(AccessSemantics value) {
     case AccessSemantics::Ordinary: return "ordinary";
     case AccessSemantics::DirectToStorage: return "direct_to_storage";
     case AccessSemantics::DirectToImplementation: return "direct_to_impl";
+    case AccessSemantics::DistributedThunk: return "distributed_thunk";
   }
 
   llvm_unreachable("Unhandled AccessSemantics in switch.");
@@ -2022,9 +2023,6 @@ public:
 
   void visitMemberRefExpr(MemberRefExpr *E) {
     printCommon(E, "member_ref_expr");
-    if (E->shouldApplyLookupDistributedThunk()) {
-      OS << " distributed";
-    }
     PrintWithColorRAII(OS, DeclColor) << " decl=";
     printDeclRef(E->getMember());
     if (E->getAccessSemantics() != AccessSemantics::Ordinary)

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -875,6 +875,9 @@ namespace {
       if (D->isDistributed()) {
         PrintWithColorRAII(OS, ExprModifierColor) << " distributed";
       }
+      if (D->isDistributedThunk()) {
+        PrintWithColorRAII(OS, ExprModifierColor) << " distributed-thunk";
+      }
 
       if (auto fac = D->getForeignAsyncConvention()) {
         OS << " foreign_async=";

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3190,6 +3190,13 @@ void ASTMangler::appendEntity(const ValueDecl *decl) {
   // Handle accessors specially, they are mangled as modifiers on the accessed
   // declaration.
   if (auto accessor = dyn_cast<AccessorDecl>(decl)) {
+    // Distributed thunks associated with computed properties
+    // are currently implemented as accessors but they don't
+    // have to be and that could be changed in the future.
+    //
+    // Let's mangle them as `distributed func`s to make it easier
+    // to change implementation and because runtime needs a function
+    // type associated with the thunk to form a call to it.
     if (accessor->isDistributedThunk()) {
       appendContextOf(decl);
       appendDeclName(accessor->getStorage());

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3190,6 +3190,14 @@ void ASTMangler::appendEntity(const ValueDecl *decl) {
   // Handle accessors specially, they are mangled as modifiers on the accessed
   // declaration.
   if (auto accessor = dyn_cast<AccessorDecl>(decl)) {
+    if (accessor->isDistributedThunk()) {
+      appendContextOf(decl);
+      appendDeclName(accessor->getStorage());
+      appendDeclType(accessor, FunctionMangling);
+      appendOperator("F");
+      return;
+    }
+
     return appendAccessorEntity(
         getCodeForAccessorKind(accessor->getAccessorKind()),
         accessor->getStorage(), accessor->isStatic());

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3484,7 +3484,7 @@ ASTMangler::mangleOpaqueTypeDescriptorRecord(const OpaqueTypeDecl *decl) {
   return finalize();
 }
 
-std::string ASTMangler::mangleDistributedThunk(const FuncDecl *thunk) {
+std::string ASTMangler::mangleDistributedThunk(const AbstractFunctionDecl *thunk) {
   // Marker protocols cannot be checked at runtime, so there is no point
   // in recording them for distributed thunks.
   llvm::SaveAndRestore<bool> savedAllowMarkerProtocols(AllowMarkerProtocols,

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3190,21 +3190,6 @@ void ASTMangler::appendEntity(const ValueDecl *decl) {
   // Handle accessors specially, they are mangled as modifiers on the accessed
   // declaration.
   if (auto accessor = dyn_cast<AccessorDecl>(decl)) {
-    // Distributed thunks associated with computed properties
-    // are currently implemented as accessors but they don't
-    // have to be and that could be changed in the future.
-    //
-    // Let's mangle them as `distributed func`s to make it easier
-    // to change implementation and because runtime needs a function
-    // type associated with the thunk to form a call to it.
-    if (accessor->isDistributedThunk()) {
-      appendContextOf(decl);
-      appendDeclName(accessor->getStorage());
-      appendDeclType(accessor, FunctionMangling);
-      appendOperator("F");
-      return;
-    }
-
     return appendAccessorEntity(
         getCodeForAccessorKind(accessor->getAccessorKind()),
         accessor->getStorage(), accessor->isStatic());
@@ -3504,5 +3489,28 @@ std::string ASTMangler::mangleDistributedThunk(const AbstractFunctionDecl *thunk
   // in recording them for distributed thunks.
   llvm::SaveAndRestore<bool> savedAllowMarkerProtocols(AllowMarkerProtocols,
                                                        false);
+
+  // Since computed property SILDeclRef's refer to the "originator"
+  // of the thunk, we need to mangle distributed thunks of accessors
+  // specially.
+  if (auto *accessor = dyn_cast<AccessorDecl>(thunk)) {
+    // TODO: This needs to use accessor type instead of
+    //       distributed thunk after all SILDeclRefs are switched
+    //       to use "originator" instead of the thunk itself.
+    //
+    // ```
+    // beginMangling();
+    // appendContextOf(thunk);
+    // appendDeclName(accessor->getStorage());
+    // appendDeclType(accessor, FunctionMangling);
+    // appendOperator("F");
+    // appendSymbolKind(SymbolKind::DistributedThunk);
+    // return finalize();
+    // ```
+    auto *storage = accessor->getStorage();
+    thunk = storage->getDistributedThunk();
+    assert(thunk);
+  }
+
   return mangleEntity(thunk, SymbolKind::DistributedThunk);
 }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2259,6 +2259,11 @@ AbstractStorageDecl::getAccessStrategy(AccessSemantics semantics,
     assert(hasStorage());
     return AccessStrategy::getStorage();
 
+  // FIXME: For now `DistributedThunk` behaves just like `Ordinary` but it
+  //        needs a new strategy to be useful.
+  case AccessSemantics::DistributedThunk:
+    LLVM_FALLTHROUGH;
+
   case AccessSemantics::Ordinary:
     // Skip these checks for local variables, both because they're unnecessary
     // and because we won't necessarily have computed access.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2138,6 +2138,17 @@ getDirectReadAccessStrategy(const AbstractStorageDecl *storage) {
   llvm_unreachable("bad impl kind");
 }
 
+//static AccessStrategy
+//getDirectToDistributedThunkAccessorStrategy(const AbstractStorageDecl *storage) {
+//  switch (storage->getReadImpl()) {
+//  case ReadImplKind::Get:
+//    return AccessStrategy::getDistributedGetAccessor(AccessorKind::Get);
+//  default:
+//    llvm_unreachable("bad impl kind for distributed property accessor");
+//  }
+//  llvm_unreachable("bad impl kind for distributed property accessor");
+//}
+
 static AccessStrategy
 getDirectWriteAccessStrategy(const AbstractStorageDecl *storage) {
   switch (storage->getWriteImpl()) {
@@ -2270,6 +2281,14 @@ AbstractStorageDecl::getAccessStrategy(AccessSemantics semantics,
 
       if (shouldUseNativeDynamicDispatch())
         return getOpaqueAccessStrategy(this, accessKind, /*dispatch*/ false);
+
+//      if (auto var = dyn_cast<VarDecl>(this)) {
+//        if (var->isDistributed()) {
+//          fprintf(stderr, "[%s:%d] (%s) DIST STRATEGY!!\n", __FILE__, __LINE__, __FUNCTION__);
+//          var->dump();
+//          return getDirectToDistributedThunkAccessorStrategy(this);
+//        }
+//      }
 
       // If the storage is resilient from the given module and resilience
       // expansion, we cannot use direct access.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2259,10 +2259,8 @@ AbstractStorageDecl::getAccessStrategy(AccessSemantics semantics,
     assert(hasStorage());
     return AccessStrategy::getStorage();
 
-  // FIXME: For now `DistributedThunk` behaves just like `Ordinary` but it
-  //        needs a new strategy to be useful.
   case AccessSemantics::DistributedThunk:
-    LLVM_FALLTHROUGH;
+    return AccessStrategy::getDistributedThunkDispatchStrategy();
 
   case AccessSemantics::Ordinary:
     // Skip these checks for local variables, both because they're unnecessary

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2138,17 +2138,6 @@ getDirectReadAccessStrategy(const AbstractStorageDecl *storage) {
   llvm_unreachable("bad impl kind");
 }
 
-//static AccessStrategy
-//getDirectToDistributedThunkAccessorStrategy(const AbstractStorageDecl *storage) {
-//  switch (storage->getReadImpl()) {
-//  case ReadImplKind::Get:
-//    return AccessStrategy::getDistributedGetAccessor(AccessorKind::Get);
-//  default:
-//    llvm_unreachable("bad impl kind for distributed property accessor");
-//  }
-//  llvm_unreachable("bad impl kind for distributed property accessor");
-//}
-
 static AccessStrategy
 getDirectWriteAccessStrategy(const AbstractStorageDecl *storage) {
   switch (storage->getWriteImpl()) {
@@ -2281,14 +2270,6 @@ AbstractStorageDecl::getAccessStrategy(AccessSemantics semantics,
 
       if (shouldUseNativeDynamicDispatch())
         return getOpaqueAccessStrategy(this, accessKind, /*dispatch*/ false);
-
-//      if (auto var = dyn_cast<VarDecl>(this)) {
-//        if (var->isDistributed()) {
-//          fprintf(stderr, "[%s:%d] (%s) DIST STRATEGY!!\n", __FILE__, __LINE__, __FUNCTION__);
-//          var->dump();
-//          return getDirectToDistributedThunkAccessorStrategy(this);
-//        }
-//      }
 
       // If the storage is resilient from the given module and resilience
       // expansion, we cannot use direct access.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6420,10 +6420,6 @@ bool VarDecl::isAsyncLet() const {
   return getAttrs().hasAttribute<AsyncAttr>();
 }
 
-bool VarDecl::isDistributed() const {
-  return getAttrs().hasAttribute<DistributedActorAttr>();
-}
-
 bool VarDecl::isKnownToBeLocal() const {
   return getAttrs().hasAttribute<KnownToBeLocalAttr>();
 }

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -136,6 +136,37 @@ Type swift::getConcreteReplacementForProtocolActorSystemType(ValueDecl *member) 
   llvm_unreachable("Unable to fetch ActorSystem type!");
 }
 
+Type swift::getConcreteReplacementForMemberSerializationRequirement(
+    ValueDecl *member) {
+  auto &C = member->getASTContext();
+  auto *DC = member->getDeclContext();
+  auto DA = C.getDistributedActorDecl();
+
+  // === When declared inside an actor, we can get the type directly
+  if (auto classDecl = DC->getSelfClassDecl()) {
+    return getDistributedSerializationRequirementType(classDecl, C.getDistributedActorDecl());
+  }
+
+  /// === Maybe the value is declared in a protocol?
+  if (auto protocol = DC->getSelfProtocolDecl()) {
+    GenericSignature signature;
+    if (auto *genericContext = member->getAsGenericContext()) {
+      signature = genericContext->getGenericSignature();
+    } else {
+      signature = DC->getGenericSignatureOfContext();
+    }
+
+    auto SerReqAssocType = DA->getAssociatedType(C.Id_SerializationRequirement)
+                               ->getDeclaredInterfaceType();
+
+    // Note that this may be null, e.g. if we're a distributed func inside
+    // a protocol that did not declare a specific actor system requirement.
+    return signature->getConcreteType(SerReqAssocType);
+  }
+
+  llvm_unreachable("Unable to fetch ActorSystem type!");
+}
+
 Type swift::getDistributedActorSystemType(NominalTypeDecl *actor) {
   assert(!dyn_cast<ProtocolDecl>(actor) &&
          "Use getConcreteReplacementForProtocolActorSystemType instead to get"

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -1361,6 +1361,10 @@ bool AbstractFunctionDecl::isDistributed() const {
   return getAttrs().hasAttribute<DistributedActorAttr>();
 }
 
+bool AbstractStorageDecl::isDistributed() const {
+  return getAttrs().hasAttribute<DistributedActorAttr>();
+}
+
 ConstructorDecl *
 NominalTypeDecl::getDistributedRemoteCallTargetInitFunction() const {
   auto mutableThis = const_cast<NominalTypeDecl *>(this);
@@ -1404,11 +1408,11 @@ AbstractFunctionDecl *ASTContext::getRemoteCallOnDistributedActorSystem(
 /********************** Distributed Actor Properties **************************/
 /******************************************************************************/
 
-FuncDecl *VarDecl::getDistributedThunk() const {
+FuncDecl *AbstractStorageDecl::getDistributedThunk() const {
   if (!isDistributed())
     return nullptr;
 
-  auto mutableThis = const_cast<VarDecl *>(this);
+  auto mutableThis = const_cast<AbstractStorageDecl *>(this);
   return evaluateOrDefault(getASTContext().evaluator,
                            GetDistributedThunkRequest{mutableThis}, nullptr);
 }

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -1404,6 +1404,15 @@ AbstractFunctionDecl *ASTContext::getRemoteCallOnDistributedActorSystem(
 /********************** Distributed Actor Properties **************************/
 /******************************************************************************/
 
+FuncDecl *VarDecl::getDistributedThunk() const {
+  if (!isDistributed())
+    return nullptr;
+
+  auto mutableThis = const_cast<VarDecl *>(this);
+  return evaluateOrDefault(getASTContext().evaluator,
+                           GetDistributedThunkRequest{mutableThis}, nullptr);
+}
+
 FuncDecl*
 AbstractFunctionDecl::getDistributedThunk() const {
   if (!isDistributed())

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1766,9 +1766,6 @@ void SILGenModule::visitVarDecl(VarDecl *vd) {
   if (vd->hasStorage())
     addGlobalVariable(vd);
 
-  fprintf(stderr, "[%s:%d] (%s) VISIT VAR DECL\n", __FILE__, __LINE__, __FUNCTION__);
-  vd->dump();
-
   vd->visitEmittedAccessors([&](AccessorDecl *accessor) {
     emitFunction(accessor);
   });
@@ -1835,7 +1832,6 @@ SILGenModule::canStorageUseStoredKeyPathComponent(AbstractStorageDecl *decl,
   case AccessStrategy::DirectToAccessor:
   case AccessStrategy::DispatchToAccessor:
   case AccessStrategy::MaterializeToTemporary:
-//  case AccessStrategy::DirectToDistributedThunkAccessor:
     return false;
   }
   llvm_unreachable("unhandled strategy");

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1832,6 +1832,7 @@ SILGenModule::canStorageUseStoredKeyPathComponent(AbstractStorageDecl *decl,
   case AccessStrategy::DirectToAccessor:
   case AccessStrategy::DispatchToAccessor:
   case AccessStrategy::MaterializeToTemporary:
+  case AccessStrategy::DispatchToDistributedThunk:
     return false;
   }
   llvm_unreachable("unhandled strategy");

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1766,6 +1766,9 @@ void SILGenModule::visitVarDecl(VarDecl *vd) {
   if (vd->hasStorage())
     addGlobalVariable(vd);
 
+  fprintf(stderr, "[%s:%d] (%s) VISIT VAR DECL\n", __FILE__, __LINE__, __FUNCTION__);
+  vd->dump();
+
   vd->visitEmittedAccessors([&](AccessorDecl *accessor) {
     emitFunction(accessor);
   });
@@ -1832,6 +1835,7 @@ SILGenModule::canStorageUseStoredKeyPathComponent(AbstractStorageDecl *decl,
   case AccessStrategy::DirectToAccessor:
   case AccessStrategy::DispatchToAccessor:
   case AccessStrategy::MaterializeToTemporary:
+//  case AccessStrategy::DirectToDistributedThunkAccessor:
     return false;
   }
   llvm_unreachable("unhandled strategy");

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1087,7 +1087,7 @@ public:
 
     // If this is a direct reference to a vardecl, just emit its value directly.
     // Recursive references to callable declarations are allowed.
-    if (isa<VarDecl>(e->getDecl())) {
+    if (auto var = dyn_cast<VarDecl>(e->getDecl())) {
       visitExpr(e);
       return;
     }
@@ -1123,6 +1123,8 @@ public:
 
     /// Some special handling may be necessary for thunks:
     if (callSite && callSite->shouldApplyDistributedThunk()) {
+      fprintf(stderr, "[%s:%d] (%s) SHOULD APPLY DIST THUNK\n", __FILE__, __LINE__, __FUNCTION__);
+
       if (auto distributedThunk = cast<AbstractFunctionDecl>(e->getDecl())->getDistributedThunk()) {
         constant = SILDeclRef(distributedThunk).asDistributed();
       }
@@ -5366,6 +5368,7 @@ static Callee getBaseAccessorFunctionRef(SILGenFunction &SGF,
                                          ArgumentSource &selfValue,
                                          bool isSuper,
                                          bool isDirectUse,
+                                         bool isDistributed,
                                          SubstitutionMap subs,
                                          bool isOnSelfParameter) {
   auto *decl = cast<AbstractFunctionDecl>(constant.getDecl());
@@ -5445,12 +5448,13 @@ emitSpecializedAccessorFunctionRef(SILGenFunction &SGF,
                                    ArgumentSource &selfValue,
                                    bool isSuper,
                                    bool isDirectUse,
+                                   bool isDistributed,
                                    bool isOnSelfParameter)
 {
   // Get the accessor function. The type will be a polymorphic function if
   // the Self type is generic.
   Callee callee = getBaseAccessorFunctionRef(SGF, loc, constant, selfValue,
-                                             isSuper, isDirectUse,
+                                             isSuper, isDirectUse, isDistributed,
                                              substitutions, isOnSelfParameter);
   
   // Collect captures if the accessor has them.
@@ -5762,15 +5766,23 @@ SILDeclRef SILGenModule::getAccessorDeclRef(AccessorDecl *accessor) {
 RValue SILGenFunction::emitGetAccessor(SILLocation loc, SILDeclRef get,
                                        SubstitutionMap substitutions,
                                        ArgumentSource &&selfValue, bool isSuper,
-                                       bool isDirectUse,
+                                       bool isDirectUse, bool isDistributed,
                                        PreparedArguments &&subscriptIndices,
-                                       SGFContext c, bool isOnSelfParameter) {
+                                       SGFContext c,
+                                       bool isOnSelfParameter) {
   // Scope any further writeback just within this operation.
   FormalEvaluationScope writebackScope(*this);
 
+  auto constant = get;
+
+//  if (isDistributed) {
+//    get.dump();
+//    assert(false && "should use dist thunk");
+//  }
+
   Callee getter = emitSpecializedAccessorFunctionRef(
-      *this, loc, get, substitutions, selfValue, isSuper, isDirectUse,
-      isOnSelfParameter);
+      *this, loc, constant, substitutions, selfValue, isSuper, isDirectUse,
+      isDistributed, isOnSelfParameter);
   bool hasSelf = (bool)selfValue;
   CanAnyFunctionType accessType = getter.getSubstFormalType();
 
@@ -5803,7 +5815,7 @@ void SILGenFunction::emitSetAccessor(SILLocation loc, SILDeclRef set,
 
   Callee setter = emitSpecializedAccessorFunctionRef(
       *this, loc, set, substitutions, selfValue, isSuper, isDirectUse,
-      isOnSelfParameter);
+      /*isDistributed=*/false, isOnSelfParameter);
   bool hasSelf = (bool)selfValue;
   CanAnyFunctionType accessType = setter.getSubstFormalType();
 
@@ -5838,14 +5850,14 @@ void SILGenFunction::emitSetAccessor(SILLocation loc, SILDeclRef set,
 ManagedValue SILGenFunction::emitAddressorAccessor(
     SILLocation loc, SILDeclRef addressor, SubstitutionMap substitutions,
     ArgumentSource &&selfValue, bool isSuper, bool isDirectUse,
-    PreparedArguments &&subscriptIndices, SILType addressType,
-    bool isOnSelfParameter) {
+    bool isDistributed, PreparedArguments &&subscriptIndices,
+    SILType addressType, bool isOnSelfParameter) {
   // Scope any further writeback just within this operation.
   FormalEvaluationScope writebackScope(*this);
 
   Callee callee = emitSpecializedAccessorFunctionRef(
       *this, loc, addressor, substitutions, selfValue, isSuper, isDirectUse,
-      isOnSelfParameter);
+      isDistributed,  isOnSelfParameter);
   bool hasSelf = (bool)selfValue;
   CanAnyFunctionType accessType = callee.getSubstFormalType();
 
@@ -5900,7 +5912,9 @@ SILGenFunction::emitCoroutineAccessor(SILLocation loc, SILDeclRef accessor,
   Callee callee =
     emitSpecializedAccessorFunctionRef(*this, loc, accessor,
                                        substitutions, selfValue,
-                                       isSuper, isDirectUse, isOnSelfParameter);
+                                       isSuper, isDirectUse,
+                                       /*isDistributed=*/false,
+                                       isOnSelfParameter);
 
   // We're already in a full formal-evaluation scope.
   // Make a dead writeback scope; applyCoroutine won't try to pop this.

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1087,7 +1087,7 @@ public:
 
     // If this is a direct reference to a vardecl, just emit its value directly.
     // Recursive references to callable declarations are allowed.
-    if (auto var = dyn_cast<VarDecl>(e->getDecl())) {
+    if (isa<VarDecl>(e->getDecl())) {
       visitExpr(e);
       return;
     }
@@ -1123,8 +1123,6 @@ public:
 
     /// Some special handling may be necessary for thunks:
     if (callSite && callSite->shouldApplyDistributedThunk()) {
-      fprintf(stderr, "[%s:%d] (%s) SHOULD APPLY DIST THUNK\n", __FILE__, __LINE__, __FUNCTION__);
-
       if (auto distributedThunk = cast<AbstractFunctionDecl>(e->getDecl())->getDistributedThunk()) {
         constant = SILDeclRef(distributedThunk).asDistributed();
       }
@@ -5773,15 +5771,8 @@ RValue SILGenFunction::emitGetAccessor(SILLocation loc, SILDeclRef get,
   // Scope any further writeback just within this operation.
   FormalEvaluationScope writebackScope(*this);
 
-  auto constant = get;
-
-//  if (isDistributed) {
-//    get.dump();
-//    assert(false && "should use dist thunk");
-//  }
-
   Callee getter = emitSpecializedAccessorFunctionRef(
-      *this, loc, constant, substitutions, selfValue, isSuper, isDirectUse,
+      *this, loc, get, substitutions, selfValue, isSuper, isDirectUse,
       isDistributed, isOnSelfParameter);
   bool hasSelf = (bool)selfValue;
   CanAnyFunctionType accessType = getter.getSubstFormalType();

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -5366,7 +5366,6 @@ static Callee getBaseAccessorFunctionRef(SILGenFunction &SGF,
                                          ArgumentSource &selfValue,
                                          bool isSuper,
                                          bool isDirectUse,
-                                         bool isDistributed,
                                          SubstitutionMap subs,
                                          bool isOnSelfParameter) {
   auto *decl = cast<AbstractFunctionDecl>(constant.getDecl());
@@ -5446,13 +5445,12 @@ emitSpecializedAccessorFunctionRef(SILGenFunction &SGF,
                                    ArgumentSource &selfValue,
                                    bool isSuper,
                                    bool isDirectUse,
-                                   bool isDistributed,
                                    bool isOnSelfParameter)
 {
   // Get the accessor function. The type will be a polymorphic function if
   // the Self type is generic.
   Callee callee = getBaseAccessorFunctionRef(SGF, loc, constant, selfValue,
-                                             isSuper, isDirectUse, isDistributed,
+                                             isSuper, isDirectUse,
                                              substitutions, isOnSelfParameter);
   
   // Collect captures if the accessor has them.
@@ -5764,7 +5762,7 @@ SILDeclRef SILGenModule::getAccessorDeclRef(AccessorDecl *accessor) {
 RValue SILGenFunction::emitGetAccessor(SILLocation loc, SILDeclRef get,
                                        SubstitutionMap substitutions,
                                        ArgumentSource &&selfValue, bool isSuper,
-                                       bool isDirectUse, bool isDistributed,
+                                       bool isDirectUse,
                                        PreparedArguments &&subscriptIndices,
                                        SGFContext c,
                                        bool isOnSelfParameter) {
@@ -5773,7 +5771,7 @@ RValue SILGenFunction::emitGetAccessor(SILLocation loc, SILDeclRef get,
 
   Callee getter = emitSpecializedAccessorFunctionRef(
       *this, loc, get, substitutions, selfValue, isSuper, isDirectUse,
-      isDistributed, isOnSelfParameter);
+      isOnSelfParameter);
   bool hasSelf = (bool)selfValue;
   CanAnyFunctionType accessType = getter.getSubstFormalType();
 
@@ -5806,7 +5804,7 @@ void SILGenFunction::emitSetAccessor(SILLocation loc, SILDeclRef set,
 
   Callee setter = emitSpecializedAccessorFunctionRef(
       *this, loc, set, substitutions, selfValue, isSuper, isDirectUse,
-      /*isDistributed=*/false, isOnSelfParameter);
+      isOnSelfParameter);
   bool hasSelf = (bool)selfValue;
   CanAnyFunctionType accessType = setter.getSubstFormalType();
 
@@ -5841,14 +5839,14 @@ void SILGenFunction::emitSetAccessor(SILLocation loc, SILDeclRef set,
 ManagedValue SILGenFunction::emitAddressorAccessor(
     SILLocation loc, SILDeclRef addressor, SubstitutionMap substitutions,
     ArgumentSource &&selfValue, bool isSuper, bool isDirectUse,
-    bool isDistributed, PreparedArguments &&subscriptIndices,
+    PreparedArguments &&subscriptIndices,
     SILType addressType, bool isOnSelfParameter) {
   // Scope any further writeback just within this operation.
   FormalEvaluationScope writebackScope(*this);
 
   Callee callee = emitSpecializedAccessorFunctionRef(
       *this, loc, addressor, substitutions, selfValue, isSuper, isDirectUse,
-      isDistributed,  isOnSelfParameter);
+      isOnSelfParameter);
   bool hasSelf = (bool)selfValue;
   CanAnyFunctionType accessType = callee.getSubstFormalType();
 
@@ -5904,7 +5902,6 @@ SILGenFunction::emitCoroutineAccessor(SILLocation loc, SILDeclRef accessor,
     emitSpecializedAccessorFunctionRef(*this, loc, accessor,
                                        substitutions, selfValue,
                                        isSuper, isDirectUse,
-                                       /*isDistributed=*/false,
                                        isOnSelfParameter);
 
   // We're already in a full formal-evaluation scope.

--- a/lib/SILGen/SILGenDistributed.cpp
+++ b/lib/SILGen/SILGenDistributed.cpp
@@ -213,6 +213,7 @@ void SILGenFunction::emitDistActorIdentityInit(ConstructorDecl *ctor,
   initializeProperty(*this, loc, borrowedSelfArg, var, temp);
 }
 
+// TODO(distributed): rename to DistributedActorID
 InitializeDistActorIdentity::InitializeDistActorIdentity(ConstructorDecl *ctor,
                                        ManagedValue actorSelf)
                                        : ctor(ctor),

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3501,6 +3501,23 @@ getIdForKeyPathComponentComputedProperty(SILGenModule &SGM,
     // stable identifier.
     return SGM.getFunction(getterRef, NotForDefinition);
   }
+//  case AccessStrategy::DirectToDistributedThunkAccessor: {
+//    assert(false && "dont need this");
+//    // Locate the distributed thunk for the getter of this property
+//    fprintf(stderr, "[%s:%d] (%s) CHECKING.... DirectToDistributedThunkAccessor\n", __FILE__, __LINE__, __FUNCTION__);
+//    auto representativeDecl = getRepresentativeAccessorForKeyPath(storage);
+//    assert(representativeDecl->isDistributed());
+//    fprintf(stderr, "[%s:%d] (%s) OK, representative is DIST\n", __FILE__, __LINE__, __FUNCTION__);
+//
+//    auto getterThunkRef = SILDeclRef(representativeDecl->getDistributedThunk(),
+//                                     SILDeclRef::Kind::Func,
+//                                     /*isForeign=*/false,
+//                                     /*isDistributed=*/true);
+//    fprintf(stderr, "[%s:%d] (%s) THUNK\n", __FILE__, __LINE__, __FUNCTION__);
+//    getterThunkRef.dump();
+//
+//    return SGM.getFunction(getterThunkRef, NotForDefinition);
+//  }
   case AccessStrategy::DispatchToAccessor: {
     // Identify the property by its vtable or wtable slot.
     return SGM.getAccessorDeclRef(getRepresentativeAccessorForKeyPath(storage));

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3505,6 +3505,14 @@ getIdForKeyPathComponentComputedProperty(SILGenModule &SGM,
     // Identify the property by its vtable or wtable slot.
     return SGM.getAccessorDeclRef(getRepresentativeAccessorForKeyPath(storage));
   }
+
+  case AccessStrategy::DispatchToDistributedThunk: {
+    auto thunkRef = SILDeclRef(cast<VarDecl>(storage)->getDistributedThunk(),
+                               SILDeclRef::Kind::Func,
+                               /*isForeign=*/false,
+                               /*isDistributed=*/true);
+    return SGM.getFunction(thunkRef, NotForDefinition);
+  }
   }
   llvm_unreachable("unhandled access strategy");
 }

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3501,23 +3501,6 @@ getIdForKeyPathComponentComputedProperty(SILGenModule &SGM,
     // stable identifier.
     return SGM.getFunction(getterRef, NotForDefinition);
   }
-//  case AccessStrategy::DirectToDistributedThunkAccessor: {
-//    assert(false && "dont need this");
-//    // Locate the distributed thunk for the getter of this property
-//    fprintf(stderr, "[%s:%d] (%s) CHECKING.... DirectToDistributedThunkAccessor\n", __FILE__, __LINE__, __FUNCTION__);
-//    auto representativeDecl = getRepresentativeAccessorForKeyPath(storage);
-//    assert(representativeDecl->isDistributed());
-//    fprintf(stderr, "[%s:%d] (%s) OK, representative is DIST\n", __FILE__, __LINE__, __FUNCTION__);
-//
-//    auto getterThunkRef = SILDeclRef(representativeDecl->getDistributedThunk(),
-//                                     SILDeclRef::Kind::Func,
-//                                     /*isForeign=*/false,
-//                                     /*isDistributed=*/true);
-//    fprintf(stderr, "[%s:%d] (%s) THUNK\n", __FILE__, __LINE__, __FUNCTION__);
-//    getterThunkRef.dump();
-//
-//    return SGM.getFunction(getterThunkRef, NotForDefinition);
-//  }
   case AccessStrategy::DispatchToAccessor: {
     // Identify the property by its vtable or wtable slot.
     return SGM.getAccessorDeclRef(getRepresentativeAccessorForKeyPath(storage));

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1444,6 +1444,7 @@ public:
                          SubstitutionMap substitutions,
                          ArgumentSource &&optionalSelfValue, bool isSuper,
                          bool isDirectAccessorUse,
+                         bool isDistributed,
                          PreparedArguments &&optionalSubscripts, SGFContext C,
                          bool isOnSelfParameter);
 
@@ -1477,7 +1478,8 @@ public:
   ManagedValue emitAddressorAccessor(
       SILLocation loc, SILDeclRef addressor, SubstitutionMap substitutions,
       ArgumentSource &&optionalSelfValue, bool isSuper,
-      bool isDirectAccessorUse, PreparedArguments &&optionalSubscripts,
+      bool isDirectAccessorUse, bool isDistributed,
+      PreparedArguments &&optionalSubscripts,
       SILType addressType, bool isOnSelfParameter);
 
   CleanupHandle emitCoroutineAccessor(SILLocation loc, SILDeclRef accessor,

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1444,7 +1444,6 @@ public:
                          SubstitutionMap substitutions,
                          ArgumentSource &&optionalSelfValue, bool isSuper,
                          bool isDirectAccessorUse,
-                         bool isDistributed,
                          PreparedArguments &&optionalSubscripts, SGFContext C,
                          bool isOnSelfParameter);
 
@@ -1478,7 +1477,7 @@ public:
   ManagedValue emitAddressorAccessor(
       SILLocation loc, SILDeclRef addressor, SubstitutionMap substitutions,
       ArgumentSource &&optionalSelfValue, bool isSuper,
-      bool isDirectAccessorUse, bool isDistributed,
+      bool isDirectAccessorUse,
       PreparedArguments &&optionalSubscripts,
       SILType addressType, bool isOnSelfParameter);
 

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -3386,13 +3386,14 @@ void LValue::addMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
 
     void emitUsingDistributedThunk() {
       auto *var = cast<VarDecl>(Storage);
-      SILDeclRef accessor(var->getDistributedThunk(), SILDeclRef::Kind::Func,
+      SILDeclRef accessor(var->getAccessor(AccessorKind::Get),
+                          SILDeclRef::Kind::Func,
                           /*isForeign=*/false, /*isDistributed=*/true);
 
       auto typeData = getLogicalStorageTypeData(
           SGF.getTypeExpansionContext(), SGF.SGM, AccessKind, FormalRValueType);
 
-      asImpl().emitUsingGetterSetter(accessor, /*isDirect=*/false, typeData);
+      asImpl().emitUsingGetterSetter(accessor, /*isDirect=*/true, typeData);
     }
 
   } emitter(SGF, loc, var, subs, isSuper, accessKind,

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1291,6 +1291,7 @@ namespace {
     SILDeclRef Accessor;
     bool IsSuper;
     bool IsDirectAccessorUse;
+    bool IsDistributedAccessor;
     bool IsOnSelfParameter;
     SubstitutionMap Substitutions;
     Optional<ActorIsolation> ActorIso;
@@ -1298,7 +1299,9 @@ namespace {
   public:
     AccessorBasedComponent(PathComponent::KindTy kind,
                            AbstractStorageDecl *decl, SILDeclRef accessor,
-                           bool isSuper, bool isDirectAccessorUse,
+                           bool isSuper,
+                           bool isDirectAccessorUse,
+                           bool isDistributedAccessor,
                            SubstitutionMap substitutions,
                            CanType baseFormalType, LValueTypeData typeData,
                            ArgumentList *argListForDiagnostics,
@@ -1309,7 +1312,9 @@ namespace {
                 std::move(indices)),
           Accessor(accessor), IsSuper(isSuper),
           IsDirectAccessorUse(isDirectAccessorUse),
-          IsOnSelfParameter(isOnSelfParameter), Substitutions(substitutions),
+          IsDistributedAccessor(isDistributedAccessor),
+          IsOnSelfParameter(isOnSelfParameter),
+          Substitutions(substitutions),
           ActorIso(actorIso) {}
 
     AccessorBasedComponent(const AccessorBasedComponent &copied,
@@ -1319,6 +1324,7 @@ namespace {
         Accessor(copied.Accessor),
         IsSuper(copied.IsSuper),
         IsDirectAccessorUse(copied.IsDirectAccessorUse),
+        IsDistributedAccessor(copied.IsDistributedAccessor),
         IsOnSelfParameter(copied.IsOnSelfParameter),
         Substitutions(copied.Substitutions),
         ActorIso(copied.ActorIso) {}
@@ -1334,7 +1340,9 @@ namespace {
 
      GetterSetterComponent(AbstractStorageDecl *decl,
                            SILDeclRef accessor,
-                           bool isSuper, bool isDirectAccessorUse,
+                           bool isSuper,
+                           bool isDirectAccessorUse,
+                           bool isDistributedAccessor,
                            SubstitutionMap substitutions,
                            CanType baseFormalType,
                            LValueTypeData typeData,
@@ -1343,10 +1351,16 @@ namespace {
                            bool isOnSelfParameter,
                            Optional<ActorIsolation> actorIso)
       : AccessorBasedComponent(GetterSetterKind, decl, accessor, isSuper,
-                               isDirectAccessorUse, substitutions,
+                               isDirectAccessorUse, isDistributedAccessor,
+                               substitutions,
                                baseFormalType, typeData, subscriptArgList,
-                               std::move(indices), isOnSelfParameter, actorIso)
+                               std::move(indices), isOnSelfParameter,
+                               actorIso)
     {
+       if (isDistributedAccessor) {
+         fprintf(stderr, "[%s:%d] (%s) DIST ACCESSOR GOOD!\n", __FILE__, __LINE__, __FUNCTION__);
+         decl->dump();
+       }
       assert(getAccessorDecl()->isGetterOrSetter());
     }
     
@@ -1457,6 +1471,7 @@ namespace {
              ArgumentSource &&value, ManagedValue base) && override {
       assert(getAccessorDecl()->isSetter());
       assert(!ActorIso && "no support for cross-actor set operations");
+      assert(!IsDistributedAccessor && "setters cannot be 'distributed'");
       SILDeclRef setter = Accessor;
 
       if (canRewriteSetAsPropertyWrapperInit(SGF) &&
@@ -1636,6 +1651,11 @@ namespace {
                ManagedValue base, SGFContext c) && override {
       assert(getAccessorDecl()->isGetter());
 
+      if (IsDistributedAccessor) {
+        fprintf(stderr, "[%s:%d] (%s) EMIT DIST GETTER\n", __FILE__, __LINE__, __FUNCTION__);
+        base.dump();
+      }
+
       SILDeclRef getter = Accessor;
       ExecutorBreadcrumb prevExecutor;
       RValue rvalue;
@@ -1650,7 +1670,8 @@ namespace {
 
         rvalue = SGF.emitGetAccessor(
             loc, getter, Substitutions, std::move(args.base), IsSuper,
-            IsDirectAccessorUse, std::move(args.Indices), c, IsOnSelfParameter);
+            IsDirectAccessorUse, IsDistributedAccessor, std::move(args.Indices), c,
+            IsOnSelfParameter);
 
       } // End the evaluation scope before any hop back to the current executor.
 
@@ -1792,14 +1813,17 @@ namespace {
     SILType SubstFieldType;
   public:
      AddressorComponent(AbstractStorageDecl *decl, SILDeclRef accessor,
-                        bool isSuper, bool isDirectAccessorUse,
+                        bool isSuper,
+                        bool isDirectAccessorUse,
+                        bool isDistributed,
                         SubstitutionMap substitutions,
                         CanType baseFormalType, LValueTypeData typeData,
                         SILType substFieldType,
                         ArgumentList *argListForDiagnostics,
                         PreparedArguments &&indices, bool isOnSelfParameter)
       : AccessorBasedComponent(AddressorKind, decl, accessor, isSuper,
-                               isDirectAccessorUse, substitutions,
+                               isDirectAccessorUse, isDistributed,
+                               substitutions,
                                baseFormalType, typeData,
                                argListForDiagnostics, std::move(indices),
                                isOnSelfParameter),
@@ -1821,8 +1845,8 @@ namespace {
             std::move(*this).prepareAccessorArgs(SGF, loc, base, Accessor);
         addr = SGF.emitAddressorAccessor(
             loc, Accessor, Substitutions, std::move(args.base), IsSuper,
-            IsDirectAccessorUse, std::move(args.Indices), SubstFieldType,
-            IsOnSelfParameter);
+            IsDirectAccessorUse, IsDistributedAccessor, std::move(args.Indices),
+            SubstFieldType, IsOnSelfParameter);
       }
 
       // Enter an unsafe access scope for the access.
@@ -1914,7 +1938,8 @@ namespace {
                                bool isOnSelfParameter)
         : AccessorBasedComponent(
               CoroutineAccessorKind, decl, accessor, isSuper,
-              isDirectAccessorUse, substitutions, baseFormalType, typeData,
+              isDirectAccessorUse, /*isDistributed=*/false,
+              substitutions, baseFormalType, typeData,
               argListForDiagnostics, std::move(indices), isOnSelfParameter) {}
 
     using AccessorBasedComponent::AccessorBasedComponent;
@@ -2640,6 +2665,7 @@ namespace {
 
     void emitUsingStrategy(AccessStrategy strategy) {
       auto var = dyn_cast<VarDecl>(Storage);
+      bool isDistributed = var && var->isDistributed();
 
       switch (strategy.getKind()) {
       case AccessStrategy::Storage: {
@@ -2650,10 +2676,15 @@ namespace {
       }
 
       case AccessStrategy::DirectToAccessor:
-        return asImpl().emitUsingAccessor(strategy.getAccessor(), true);
+        return asImpl()
+            .emitUsingAccessor(strategy.getAccessor(),
+                               /*isDirect=*/true,
+                               isDistributed);
 
       case AccessStrategy::DispatchToAccessor:
-        return asImpl().emitUsingAccessor(strategy.getAccessor(), false);
+        return asImpl().emitUsingAccessor(strategy.getAccessor(),
+                                          /*isDirect=*/false,
+                                          isDistributed);
 
       case AccessStrategy::MaterializeToTemporary: {
         auto typeData = getLogicalStorageTypeData(
@@ -2666,20 +2697,26 @@ namespace {
       llvm_unreachable("unknown kind");
     }
 
-    void emitUsingAccessor(AccessorKind accessorKind, bool isDirect) {
+    void emitUsingAccessor(AccessorKind accessorKind,
+                           bool isDirect,
+                           bool isDistributed) {
       auto accessor =
         SGF.SGM.getAccessorDeclRef(Storage->getOpaqueAccessor(accessorKind));
 
       switch (accessorKind) {
-      case AccessorKind::Get:
       case AccessorKind::Set: {
+        assert(!isDistributed && "setters must not be 'distributed'");
+        LLVM_FALLTHROUGH;
+      }
+      case AccessorKind::Get: {
         auto typeData = getLogicalStorageTypeData(
             SGF.getTypeExpansionContext(), SGF.SGM, AccessKind, FormalRValueType);
-        return asImpl().emitUsingGetterSetter(accessor, isDirect, typeData);
+        return asImpl().emitUsingGetterSetter(accessor, isDirect, isDistributed, typeData);
       }
 
       case AccessorKind::Address:
       case AccessorKind::MutableAddress: {
+        assert(!isDistributed);
         auto typeData =
             getPhysicalStorageTypeData(SGF.getTypeExpansionContext(), SGF.SGM,
                                        AccessKind, Storage, FormalRValueType);
@@ -2688,6 +2725,7 @@ namespace {
 
       case AccessorKind::Read:
       case AccessorKind::Modify: {
+        assert(!isDistributed);
         auto typeData =
             getPhysicalStorageTypeData(SGF.getTypeExpansionContext(), SGF.SGM,
                                        AccessKind, Storage, FormalRValueType);
@@ -2782,7 +2820,8 @@ void LValue::addNonMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
       SILType storageType =
         SGF.getLoweredType(Storage->getType()).getAddressType();
       LV.add<AddressorComponent>(Storage, addressor,
-                                 /*isSuper=*/false, isDirect, Subs,
+                                 /*isSuper=*/false, isDirect,
+                                 /*isDistributed=*/false, Subs,
                                  CanType(), typeData, storageType, nullptr,
                                  PreparedArguments(),
                                  /* isOnSelfParameter */ false);
@@ -2797,12 +2836,15 @@ void LValue::addNonMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
           PreparedArguments(), /*isOnSelfParameter*/ false);
     }
 
-    void emitUsingGetterSetter(SILDeclRef accessor, bool isDirect,
+    void emitUsingGetterSetter(SILDeclRef accessor,
+                               bool isDirect,
+                               bool isDistributed,
                                LValueTypeData typeData) {
       LV.add<GetterSetterComponent>(
           Storage, accessor,
-          /*isSuper=*/false, isDirect, Subs, CanType(), typeData, nullptr,
-          PreparedArguments(), /* isOnSelfParameter */ false,
+          /*isSuper=*/false, isDirect, isDistributed, Subs, CanType(), typeData,
+          nullptr, PreparedArguments(),
+          /*isOnSelfParameter=*/false,
           ActorIso);
     }
 
@@ -3276,7 +3318,8 @@ struct MemberStorageAccessEmitter : AccessEmitter<Impl, StorageType> {
     SILType varStorageType = SGF.SGM.Types.getSubstitutedStorageType(
         SGF.getTypeExpansionContext(), Storage, FormalRValueType);
 
-    LV.add<AddressorComponent>(Storage, addressor, IsSuper, isDirect, Subs,
+    LV.add<AddressorComponent>(Storage, addressor, IsSuper, isDirect,
+                               /*isDistributed=*/false, Subs,
                                BaseFormalType, typeData, varStorageType,
                                ArgListForDiagnostics, std::move(Indices),
                                IsOnSelfParameter);
@@ -3290,12 +3333,14 @@ struct MemberStorageAccessEmitter : AccessEmitter<Impl, StorageType> {
         ArgListForDiagnostics, std::move(Indices), IsOnSelfParameter);
   }
 
-  void emitUsingGetterSetter(SILDeclRef accessor, bool isDirect,
+  void emitUsingGetterSetter(SILDeclRef accessor,
+                             bool isDirect,
+                             bool isDistributed,
                              LValueTypeData typeData) {
     LV.add<GetterSetterComponent>(
-        Storage, accessor, IsSuper, isDirect, Subs, BaseFormalType, typeData,
-        ArgListForDiagnostics, std::move(Indices), IsOnSelfParameter,
-        ActorIso);
+        Storage, accessor, IsSuper, isDirect, isDistributed, Subs,
+        BaseFormalType, typeData, ArgListForDiagnostics, std::move(Indices),
+        IsOnSelfParameter, ActorIso);
   }
 
   void emitUsingMaterialization(AccessStrategy readStrategy,

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1357,10 +1357,6 @@ namespace {
                                std::move(indices), isOnSelfParameter,
                                actorIso)
     {
-       if (isDistributedAccessor) {
-         fprintf(stderr, "[%s:%d] (%s) DIST ACCESSOR GOOD!\n", __FILE__, __LINE__, __FUNCTION__);
-         decl->dump();
-       }
       assert(getAccessorDecl()->isGetterOrSetter());
     }
     
@@ -1650,11 +1646,6 @@ namespace {
     RValue get(SILGenFunction &SGF, SILLocation loc,
                ManagedValue base, SGFContext c) && override {
       assert(getAccessorDecl()->isGetter());
-
-      if (IsDistributedAccessor) {
-        fprintf(stderr, "[%s:%d] (%s) EMIT DIST GETTER\n", __FILE__, __LINE__, __FUNCTION__);
-        base.dump();
-      }
 
       SILDeclRef getter = Accessor;
       ExecutorBreadcrumb prevExecutor;
@@ -2664,7 +2655,6 @@ namespace {
         AccessKind(accessKind) {}
 
     void emitUsingStrategy(AccessStrategy strategy) {
-      auto var = dyn_cast<VarDecl>(Storage);
       bool isDistributed = var && var->isDistributed();
 
       switch (strategy.getKind()) {

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1291,7 +1291,6 @@ namespace {
     SILDeclRef Accessor;
     bool IsSuper;
     bool IsDirectAccessorUse;
-    bool IsDistributedAccessor;
     bool IsOnSelfParameter;
     SubstitutionMap Substitutions;
     Optional<ActorIsolation> ActorIso;
@@ -1301,7 +1300,6 @@ namespace {
                            AbstractStorageDecl *decl, SILDeclRef accessor,
                            bool isSuper,
                            bool isDirectAccessorUse,
-                           bool isDistributedAccessor,
                            SubstitutionMap substitutions,
                            CanType baseFormalType, LValueTypeData typeData,
                            ArgumentList *argListForDiagnostics,
@@ -1312,7 +1310,6 @@ namespace {
                 std::move(indices)),
           Accessor(accessor), IsSuper(isSuper),
           IsDirectAccessorUse(isDirectAccessorUse),
-          IsDistributedAccessor(isDistributedAccessor),
           IsOnSelfParameter(isOnSelfParameter),
           Substitutions(substitutions),
           ActorIso(actorIso) {}
@@ -1324,7 +1321,6 @@ namespace {
         Accessor(copied.Accessor),
         IsSuper(copied.IsSuper),
         IsDirectAccessorUse(copied.IsDirectAccessorUse),
-        IsDistributedAccessor(copied.IsDistributedAccessor),
         IsOnSelfParameter(copied.IsOnSelfParameter),
         Substitutions(copied.Substitutions),
         ActorIso(copied.ActorIso) {}
@@ -1342,7 +1338,6 @@ namespace {
                            SILDeclRef accessor,
                            bool isSuper,
                            bool isDirectAccessorUse,
-                           bool isDistributedAccessor,
                            SubstitutionMap substitutions,
                            CanType baseFormalType,
                            LValueTypeData typeData,
@@ -1351,8 +1346,7 @@ namespace {
                            bool isOnSelfParameter,
                            Optional<ActorIsolation> actorIso)
       : AccessorBasedComponent(GetterSetterKind, decl, accessor, isSuper,
-                               isDirectAccessorUse, isDistributedAccessor,
-                               substitutions,
+                               isDirectAccessorUse, substitutions,
                                baseFormalType, typeData, subscriptArgList,
                                std::move(indices), isOnSelfParameter,
                                actorIso)
@@ -1467,7 +1461,6 @@ namespace {
              ArgumentSource &&value, ManagedValue base) && override {
       assert(getAccessorDecl()->isSetter());
       assert(!ActorIso && "no support for cross-actor set operations");
-      assert(!IsDistributedAccessor && "setters cannot be 'distributed'");
       SILDeclRef setter = Accessor;
 
       if (canRewriteSetAsPropertyWrapperInit(SGF) &&
@@ -1661,7 +1654,7 @@ namespace {
 
         rvalue = SGF.emitGetAccessor(
             loc, getter, Substitutions, std::move(args.base), IsSuper,
-            IsDirectAccessorUse, IsDistributedAccessor, std::move(args.Indices), c,
+            IsDirectAccessorUse, std::move(args.Indices), c,
             IsOnSelfParameter);
 
       } // End the evaluation scope before any hop back to the current executor.
@@ -1806,14 +1799,13 @@ namespace {
      AddressorComponent(AbstractStorageDecl *decl, SILDeclRef accessor,
                         bool isSuper,
                         bool isDirectAccessorUse,
-                        bool isDistributed,
                         SubstitutionMap substitutions,
                         CanType baseFormalType, LValueTypeData typeData,
                         SILType substFieldType,
                         ArgumentList *argListForDiagnostics,
                         PreparedArguments &&indices, bool isOnSelfParameter)
       : AccessorBasedComponent(AddressorKind, decl, accessor, isSuper,
-                               isDirectAccessorUse, isDistributed,
+                               isDirectAccessorUse,
                                substitutions,
                                baseFormalType, typeData,
                                argListForDiagnostics, std::move(indices),
@@ -1836,7 +1828,7 @@ namespace {
             std::move(*this).prepareAccessorArgs(SGF, loc, base, Accessor);
         addr = SGF.emitAddressorAccessor(
             loc, Accessor, Substitutions, std::move(args.base), IsSuper,
-            IsDirectAccessorUse, IsDistributedAccessor, std::move(args.Indices),
+            IsDirectAccessorUse, std::move(args.Indices),
             SubstFieldType, IsOnSelfParameter);
       }
 
@@ -1929,7 +1921,7 @@ namespace {
                                bool isOnSelfParameter)
         : AccessorBasedComponent(
               CoroutineAccessorKind, decl, accessor, isSuper,
-              isDirectAccessorUse, /*isDistributed=*/false,
+              isDirectAccessorUse,
               substitutions, baseFormalType, typeData,
               argListForDiagnostics, std::move(indices), isOnSelfParameter) {}
 
@@ -2655,8 +2647,6 @@ namespace {
         AccessKind(accessKind) {}
 
     void emitUsingStrategy(AccessStrategy strategy) {
-      bool isDistributed = var && var->isDistributed();
-
       switch (strategy.getKind()) {
       case AccessStrategy::Storage: {
         auto typeData =
@@ -2668,13 +2658,11 @@ namespace {
       case AccessStrategy::DirectToAccessor:
         return asImpl()
             .emitUsingAccessor(strategy.getAccessor(),
-                               /*isDirect=*/true,
-                               isDistributed);
+                               /*isDirect=*/true);
 
       case AccessStrategy::DispatchToAccessor:
         return asImpl().emitUsingAccessor(strategy.getAccessor(),
-                                          /*isDirect=*/false,
-                                          isDistributed);
+                                          /*isDirect=*/false);
 
       case AccessStrategy::MaterializeToTemporary: {
         auto typeData = getLogicalStorageTypeData(
@@ -2691,25 +2679,22 @@ namespace {
     }
 
     void emitUsingAccessor(AccessorKind accessorKind,
-                           bool isDirect,
-                           bool isDistributed) {
+                           bool isDirect) {
       auto accessor =
         SGF.SGM.getAccessorDeclRef(Storage->getOpaqueAccessor(accessorKind));
 
       switch (accessorKind) {
       case AccessorKind::Set: {
-        assert(!isDistributed && "setters must not be 'distributed'");
         LLVM_FALLTHROUGH;
       }
       case AccessorKind::Get: {
         auto typeData = getLogicalStorageTypeData(
             SGF.getTypeExpansionContext(), SGF.SGM, AccessKind, FormalRValueType);
-        return asImpl().emitUsingGetterSetter(accessor, isDirect, isDistributed, typeData);
+        return asImpl().emitUsingGetterSetter(accessor, isDirect, typeData);
       }
 
       case AccessorKind::Address:
       case AccessorKind::MutableAddress: {
-        assert(!isDistributed);
         auto typeData =
             getPhysicalStorageTypeData(SGF.getTypeExpansionContext(), SGF.SGM,
                                        AccessKind, Storage, FormalRValueType);
@@ -2718,7 +2703,6 @@ namespace {
 
       case AccessorKind::Read:
       case AccessorKind::Modify: {
-        assert(!isDistributed);
         auto typeData =
             getPhysicalStorageTypeData(SGF.getTypeExpansionContext(), SGF.SGM,
                                        AccessKind, Storage, FormalRValueType);
@@ -2813,8 +2797,7 @@ void LValue::addNonMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
       SILType storageType =
         SGF.getLoweredType(Storage->getType()).getAddressType();
       LV.add<AddressorComponent>(Storage, addressor,
-                                 /*isSuper=*/false, isDirect,
-                                 /*isDistributed=*/false, Subs,
+                                 /*isSuper=*/false, isDirect, Subs,
                                  CanType(), typeData, storageType, nullptr,
                                  PreparedArguments(),
                                  /* isOnSelfParameter */ false);
@@ -2831,11 +2814,10 @@ void LValue::addNonMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
 
     void emitUsingGetterSetter(SILDeclRef accessor,
                                bool isDirect,
-                               bool isDistributed,
                                LValueTypeData typeData) {
       LV.add<GetterSetterComponent>(
           Storage, accessor,
-          /*isSuper=*/false, isDirect, isDistributed, Subs, CanType(), typeData,
+          /*isSuper=*/false, isDirect, Subs, CanType(), typeData,
           nullptr, PreparedArguments(),
           /*isOnSelfParameter=*/false,
           ActorIso);
@@ -3316,8 +3298,7 @@ struct MemberStorageAccessEmitter : AccessEmitter<Impl, StorageType> {
     SILType varStorageType = SGF.SGM.Types.getSubstitutedStorageType(
         SGF.getTypeExpansionContext(), Storage, FormalRValueType);
 
-    LV.add<AddressorComponent>(Storage, addressor, IsSuper, isDirect,
-                               /*isDistributed=*/false, Subs,
+    LV.add<AddressorComponent>(Storage, addressor, IsSuper, isDirect, Subs,
                                BaseFormalType, typeData, varStorageType,
                                ArgListForDiagnostics, std::move(Indices),
                                IsOnSelfParameter);
@@ -3333,10 +3314,9 @@ struct MemberStorageAccessEmitter : AccessEmitter<Impl, StorageType> {
 
   void emitUsingGetterSetter(SILDeclRef accessor,
                              bool isDirect,
-                             bool isDistributed,
                              LValueTypeData typeData) {
     LV.add<GetterSetterComponent>(
-        Storage, accessor, IsSuper, isDirect, isDistributed, Subs,
+        Storage, accessor, IsSuper, isDirect, Subs,
         BaseFormalType, typeData, ArgListForDiagnostics, std::move(Indices),
         IsOnSelfParameter, ActorIso);
   }
@@ -3412,8 +3392,7 @@ void LValue::addMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
       auto typeData = getLogicalStorageTypeData(
           SGF.getTypeExpansionContext(), SGF.SGM, AccessKind, FormalRValueType);
 
-      asImpl().emitUsingGetterSetter(accessor, /*isDirect=*/false,
-                                     /*isDistributed=*/true, typeData);
+      asImpl().emitUsingGetterSetter(accessor, /*isDirect=*/false, typeData);
     }
 
   } emitter(SGF, loc, var, subs, isSuper, accessKind,

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -4445,7 +4445,7 @@ void SILGenFunction::emitProtocolWitness(
     if (requirement.hasDecl()) {
       if ((!getActorIsolation(requirement.getDecl()).isDistributedActor()) ||
           (isa<FuncDecl>(requirement.getDecl()) &&
-              witness.getFuncDecl()->isDistributed())) {
+              requirement.getFuncDecl()->isDistributed())) {
         auto thunk = cast<AbstractFunctionDecl>(witness.getDecl())
                          ->getDistributedThunk();
         witness = SILDeclRef(thunk).asDistributed();

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -4435,15 +4435,22 @@ void SILGenFunction::emitProtocolWitness(
   SmallVector<ManagedValue, 8> origParams;
   collectThunkParams(loc, origParams);
 
-  // If the witness is isolated to a distributed actor, but the requirement is
-  // not, go through the distributed thunk.
   if (witness.hasDecl() &&
-      getActorIsolation(witness.getDecl()).isDistributedActor() &&
-      requirement.hasDecl() &&
-      !getActorIsolation(requirement.getDecl()).isDistributedActor()) {
-    witness = SILDeclRef(
-        cast<AbstractFunctionDecl>(witness.getDecl())->getDistributedThunk())
-          .asDistributed();
+      getActorIsolation(witness.getDecl()).isDistributedActor()) {
+    // We witness protocol requirements using the distributed thunk, when:
+    // - the witness is isolated to a distributed actor, but the requirement is not
+    // - the requirement is a distributed func, and therefore can only be witnessed
+    //   by a distributed func; we handle this by witnessing the requirement with the thunk
+    // FIXME(distributed): this limits us to only allow distributed explicitly throwing async requirements... we need to fix this somehow.
+    if (requirement.hasDecl()) {
+      if ((!getActorIsolation(requirement.getDecl()).isDistributedActor()) ||
+          (isa<FuncDecl>(requirement.getDecl()) &&
+              witness.getFuncDecl()->isDistributed())) {
+        auto thunk = cast<AbstractFunctionDecl>(witness.getDecl())
+                         ->getDistributedThunk();
+        witness = SILDeclRef(thunk).asDistributed();
+      }
+    }
   } else if (enterIsolation) {
     // If we are supposed to enter the actor, do so now by hopping to the
     // actor.

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -1161,6 +1161,12 @@ public:
       SGM.emitPropertyWrapperBackingInitializer(vd);
     }
 
+    if (auto *thunk = vd->getDistributedThunk()) {
+      auto thunkRef = SILDeclRef(thunk).asDistributed();
+      SGM.emitFunctionDefinition(thunkRef,
+                                 SGM.getFunction(thunkRef, ForDefinition));
+    }
+
     visitAbstractStorageDecl(vd);
   }
 
@@ -1287,6 +1293,13 @@ public:
         return;
       }
     }
+
+    if (auto *thunk = vd->getDistributedThunk()) {
+      auto thunkRef = SILDeclRef(thunk).asDistributed();
+      SGM.emitFunctionDefinition(thunkRef,
+                                 SGM.getFunction(thunkRef, ForDefinition));
+    }
+
     visitAbstractStorageDecl(vd);
   }
 

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -701,6 +701,7 @@ static FuncDecl *createDistributedThunkFunction(FuncDecl *func) {
       genericParamList, params,
       func->getResultInterfaceType(), DC);
   thunk->setSynthesized(true);
+  thunk->setDistributedThunk(true);
   thunk->getAttrs().add(new (C) NonisolatedAttr(/*isImplicit=*/true));
 
   if (isa<ClassDecl>(DC))

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -695,25 +695,10 @@ static FuncDecl *createDistributedThunkFunction(FuncDecl *func) {
   }
   ParameterList *params = ParameterList::create(C, paramDecls); // = funcParams->clone(C);
 
-  FuncDecl *thunk = nullptr;
-  if (auto *accessor = dyn_cast<AccessorDecl>(func)) {
-    auto *distributedVar = cast<VarDecl>(accessor->getStorage());
-
-    thunk = AccessorDecl::create(
-        C, /*declLoc=*/accessor->getLoc(), /*accessorKeywordLoc=*/SourceLoc(),
-        AccessorKind::Get, distributedVar,
-        /*staticLoc=*/SourceLoc(), StaticSpellingKind::None,
-        /*async=*/true, /*asyncLoc=*/SourceLoc(),
-        /*throws=*/true, /*throwsLoc=*/SourceLoc(), genericParamList, params,
-        func->getResultInterfaceType(), accessor->getDeclContext());
-
-    thunk->setImplicit();
-  } else {
-    thunk = FuncDecl::createImplicit(
-        C, swift::StaticSpellingKind::None, func->getName(), SourceLoc(),
-        /*async=*/true, /*throws=*/true, genericParamList, params,
-        func->getResultInterfaceType(), DC);
-  }
+  FuncDecl *thunk = FuncDecl::createImplicit(
+      C, swift::StaticSpellingKind::None, thunkName, SourceLoc(),
+      /*async=*/true, /*throws=*/true, genericParamList, params,
+      func->getResultInterfaceType(), DC);
 
   assert(thunk && "couldn't create a distributed thunk");
 

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -758,7 +758,6 @@ FuncDecl *GetDistributedThunkRequest::evaluate(
     return nullptr;
 
   auto &C = distributedTarget->getASTContext();
-  auto DC = distributedTarget->getDeclContext();
 
   if (!getConcreteReplacementForProtocolActorSystemType(distributedTarget)) {
     // Don't synthesize thunks, unless there is a *concrete* ActorSystem.
@@ -781,9 +780,6 @@ FuncDecl *GetDistributedThunkRequest::evaluate(
     // we won't be emitting the offending decl after all.
     if (!C.getLoadedModule(C.Id_Distributed))
       return nullptr;
-
-    auto nominal = DC->getSelfNominalTypeDecl(); // NOTE: Always from DC
-    assert(nominal);
 
     // --- Prepare the "distributed thunk" which does the "maybe remote" dance:
     return createDistributedThunkFunction(func);

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -613,8 +613,13 @@ static FuncDecl *createDistributedThunkFunction(FuncDecl *func) {
   auto &C = func->getASTContext();
   auto DC = func->getDeclContext();
 
-  auto systemTy = getConcreteReplacementForProtocolActorSystemType(func);
-  assert(systemTy &&
+  // NOTE: So we don't need a thunk in the protocol, we should call the underlying
+  // thing instead, which MUST have a thunk, since it must be a distributed func as well...
+  if (dyn_cast<ProtocolDecl>(DC)) {
+    return nullptr;
+  }
+
+  assert(getConcreteReplacementForProtocolActorSystemType(func) &&
          "Thunk synthesis must have concrete actor system type available");
 
   DeclName thunkName = func->getName();

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -644,7 +644,18 @@ static FuncDecl *createDistributedThunkFunction(FuncDecl *func) {
   assert(getConcreteReplacementForProtocolActorSystemType(func) &&
          "Thunk synthesis must have concrete actor system type available");
 
-  DeclName thunkName = func->getName();
+  DeclName thunkName;
+
+  // Since accessors don't have names, let's generate one based on
+  // the computed property.
+  if (auto *accessor = dyn_cast<AccessorDecl>(func)) {
+    auto *var = accessor->getStorage();
+    thunkName = DeclName(C, var->getBaseName(),
+                         /*argumentNames=*/ArrayRef<Identifier>());
+  } else {
+    // Let's use the name of a 'distributed func'
+    thunkName = func->getName();
+  }
 
   // --- Prepare generic parameters
   GenericParamList *genericParamList = nullptr;
@@ -774,10 +785,21 @@ addDistributedActorCodableConformance(
 /*********************** SYNTHESIS ENTRY POINTS *******************************/
 /******************************************************************************/
 
-FuncDecl *GetDistributedThunkRequest::evaluate(
-    Evaluator &evaluator, AbstractFunctionDecl *distributedTarget) const {
-  if (!distributedTarget->isDistributed())
-    return nullptr;
+FuncDecl *GetDistributedThunkRequest::evaluate(Evaluator &evaluator,
+                                               Originator originator) const {
+  AbstractFunctionDecl *distributedTarget = nullptr;
+  if (auto *var = originator.dyn_cast<VarDecl *>()) {
+    if (!var->isDistributed())
+      return nullptr;
+
+    distributedTarget = var->getAccessor(AccessorKind::Get);
+  } else {
+    distributedTarget = originator.get<AbstractFunctionDecl *>();
+    if (!distributedTarget->isDistributed())
+      return nullptr;
+  }
+
+  assert(distributedTarget);
 
   auto &C = distributedTarget->getASTContext();
 

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -806,14 +806,18 @@ addDistributedActorCodableConformance(
 FuncDecl *GetDistributedThunkRequest::evaluate(Evaluator &evaluator,
                                                Originator originator) const {
   AbstractFunctionDecl *distributedTarget = nullptr;
-  if (auto *var = originator.dyn_cast<VarDecl *>()) {
-    if (!var->isDistributed())
+  if (auto *storage = originator.dyn_cast<AbstractStorageDecl *>()) {
+    if (!storage->isDistributed())
       return nullptr;
 
-    if (checkDistributedActorProperty(var, /*diagnose=*/false))
-      return nullptr;
+    if (auto *var = dyn_cast<VarDecl>(storage)) {
+      if (checkDistributedActorProperty(var, /*diagnose=*/false))
+        return nullptr;
 
-    distributedTarget = var->getAccessor(AccessorKind::Get);
+      distributedTarget = var->getAccessor(AccessorKind::Get);
+    } else {
+      llvm_unreachable("unsupported storage kind");
+    }
   } else {
     distributedTarget = originator.get<AbstractFunctionDecl *>();
     if (!distributedTarget->isDistributed())

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -792,6 +792,9 @@ FuncDecl *GetDistributedThunkRequest::evaluate(Evaluator &evaluator,
     if (!var->isDistributed())
       return nullptr;
 
+    if (checkDistributedActorProperty(var, /*diagnose=*/false))
+      return nullptr;
+
     distributedTarget = var->getAccessor(AccessorKind::Get);
   } else {
     distributedTarget = originator.get<AbstractFunctionDecl *>();
@@ -815,7 +818,8 @@ FuncDecl *GetDistributedThunkRequest::evaluate(Evaluator &evaluator,
   // we must avoid synthesis of the thunk because it'd also have errors,
   // giving an ugly user experience (errors in implicit code).
   if (distributedTarget->getInterfaceType()->hasError() ||
-      checkDistributedFunction(distributedTarget)) {
+      (!isa<AccessorDecl>(distributedTarget) &&
+       checkDistributedFunction(distributedTarget))) {
     return nullptr;
   }
 

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -238,9 +238,6 @@ deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
     }
 
     auto returnLocalPropertyAccess = new (C) ReturnStmt(sloc, localPropertyAccess, implicit);
-
-    fprintf(stderr, "[%s:%d] (%s) LOCAL BRANCH\n", __FILE__, __LINE__, __FUNCTION__);
-    returnLocalPropertyAccess->dump();
     localBranchStmt =
         BraceStmt::create(C, sloc, {returnLocalPropertyAccess}, sloc, implicit);
   } else {

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -224,10 +224,6 @@ deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
 
     auto var = accessor->getStorage();
 
-    auto varRef = UnresolvedDeclRefExpr::createImplicit(C, var->getName());
-    auto funcDeclRef =
-        UnresolvedDotExpr::createImplicit(C, selfRefExpr, var->getBaseName());
-
     Expr *localPropertyAccess = new (C) MemberRefExpr(
         selfRefExpr, sloc, ConcreteDeclRef(var), dloc, implicit);
     localPropertyAccess =

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1428,7 +1428,10 @@ static void diagRecursivePropertyAccess(const Expr *E, const DeclContext *DC) {
           if (MRE->getAccessSemantics() == AccessSemantics::Ordinary) {
             bool shouldDiagnose = false;
             // Warn about any property access in the getter.
-            if (Accessor->isGetter())
+            //
+            // Distributed thunks have to refer to the "local" version
+            // of the property directly with implicit `self.` base.
+            if (Accessor->isGetter() && !Accessor->isDistributedThunk())
               shouldDiagnose = !isStore;
             // Warn about stores in the setter, but allow loads.
             if (Accessor->isSetter())

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1428,10 +1428,7 @@ static void diagRecursivePropertyAccess(const Expr *E, const DeclContext *DC) {
           if (MRE->getAccessSemantics() == AccessSemantics::Ordinary) {
             bool shouldDiagnose = false;
             // Warn about any property access in the getter.
-            //
-            // Distributed thunks have to refer to the "local" version
-            // of the property directly with implicit `self.` base.
-            if (Accessor->isGetter() && !Accessor->isDistributedThunk())
+            if (Accessor->isGetter())
               shouldDiagnose = !isStore;
             // Warn about stores in the setter, but allow loads.
             if (Accessor->isSetter())

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5783,7 +5783,6 @@ void AttributeChecker::visitDistributedActorAttr(DistributedActorAttr *attr) {
 
     // distributed func must be declared inside an distributed actor
     auto selfTy = dc->getSelfTypeInContext();
-
     if (!selfTy->isDistributedActor()) {
       auto diagnostic = diagnoseAndRemoveAttr(
         attr, diag::distributed_actor_func_not_in_distributed_actor);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5783,6 +5783,7 @@ void AttributeChecker::visitDistributedActorAttr(DistributedActorAttr *attr) {
 
     // distributed func must be declared inside an distributed actor
     auto selfTy = dc->getSelfTypeInContext();
+
     if (!selfTy->isDistributedActor()) {
       auto diagnostic = diagnoseAndRemoveAttr(
         attr, diag::distributed_actor_func_not_in_distributed_actor);
@@ -5792,6 +5793,24 @@ void AttributeChecker::visitDistributedActorAttr(DistributedActorAttr *attr) {
                                                                  diagnostic);
       }
       return;
+    }
+
+    // Diagnose for the limitation that we currently have to require distributed
+    // actor constrained protocols to declare the distributed requirements as
+    // 'async throws'
+    // FIXME: rdar://95949498 allow requirements to not declare explicit async/throws in protocols; those effects are implicit in any case
+    if (isa<ProtocolDecl>(dc)) {
+      if (!funcDecl->hasAsync() || !funcDecl->hasThrows()) {
+        auto diag = funcDecl->diagnose(diag::distributed_method_requirement_must_be_async_throws,
+                           funcDecl->getName());
+        if (!funcDecl->hasAsync()) {
+          diag.fixItInsertAfter(funcDecl->getThrowsLoc(), " async");
+        }
+        if (!funcDecl->hasThrows()) {
+          diag.fixItInsertAfter(funcDecl->getThrowsLoc(), " throws");
+        }
+        return;
+      }
     }
   }
 }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2321,7 +2321,7 @@ namespace {
           if (auto lookupExpr = dyn_cast_or_null<LookupExpr>(context)) {
             if (auto memberRef = dyn_cast<MemberRefExpr>(lookupExpr)) {
               memberRef->setImplicitlyThrows(true);
-              memberRef->setShouldApplyLookupDistributedThunk(true);
+              memberRef->setAccessViaDistributedThunk();
             } else {
               llvm_unreachable("expected distributed prop to be a MemberRef");
             }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3859,8 +3859,13 @@ bool HasIsolatedSelfRequest::evaluate(
     return false;
 
   // For accessors, consider the storage declaration.
-  if (auto accessor = dyn_cast<AccessorDecl>(value))
-    value = accessor->getStorage();
+  if (auto accessor = dyn_cast<AccessorDecl>(value)) {
+    // distributed thunks are accessors only in spirit and
+    // should be handled as regular functions from isolation
+    // perspective.
+    if (!accessor->isDistributedThunk())
+      value = accessor->getStorage();
+  }
 
   // Check whether this member can be isolated to an actor at all.
   auto memberIsolation = getMemberIsolationPropagation(value);

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2258,8 +2258,6 @@ namespace {
         // But computed distributed properties are okay,
         // and treated the same as a distributed func.
         if (var && var->isDistributed()) {
-          fprintf(stderr, "[%s:%d] (%s) HERE\n", __FILE__, __LINE__, __FUNCTION__);
-          var->dump();
           bool explicitlyThrowing = false;
           if (auto getter = var->getAccessor(swift::AccessorKind::Get)) {
             explicitlyThrowing = getter->hasThrows();
@@ -2310,25 +2308,18 @@ namespace {
       // is it an access to a property?
       if (isPropOrSubscript(decl)) {
         // Cannot reference properties or subscripts of distributed actors.
-        fprintf(stderr, "[%s:%d] (%s) prop\n", __FILE__, __LINE__, __FUNCTION__);
         if (isDistributed) {
-          fprintf(stderr, "[%s:%d] (%s) prop is dist\n", __FILE__, __LINE__, __FUNCTION__);
-
           bool setThrows = false;
           bool usesDistributedThunk = false;
           if (auto access = checkDistributedAccess(declLoc, decl, context)) {
             std::tie(setThrows, usesDistributedThunk) = *access;
           } else {
-            fprintf(stderr, "[%s:%d] (%s) prop is dist -> NOPE \n", __FILE__, __LINE__, __FUNCTION__);
             return AsyncMarkingResult::NotDistributed;
           }
 
           // distributed computed property access, mark it throws + async
           if (auto lookupExpr = dyn_cast_or_null<LookupExpr>(context)) {
             if (auto memberRef = dyn_cast<MemberRefExpr>(lookupExpr)) {
-              fprintf(stderr, "[%s:%d] (%s) SET DISTRIBUTED MEMBER REF\n", __FILE__, __LINE__, __FUNCTION__);
-              memberRef->dump();
-
               memberRef->setImplicitlyThrows(true);
               memberRef->setShouldApplyLookupDistributedThunk(true);
             } else {
@@ -2397,7 +2388,6 @@ namespace {
         if (isDistributed) {
           if (auto access = checkDistributedAccess(declLoc, decl, context)) {
             std::tie(setThrows, usesDistributedThunk) = *access;
-            fprintf(stderr, "[%s:%d] (%s) USE THUNK\n", __FILE__, __LINE__, __FUNCTION__);
           } else {
             return AsyncMarkingResult::NotDistributed;
           }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -431,10 +431,11 @@ static bool varIsSafeAcrossActors(const ModuleDecl *fromModule,
     if (var->getAttrs().hasAttribute<NonisolatedAttr>())
       return true;
 
-    // If it's distributed, it's not okay.
-    if (auto nominalParent = var->getDeclContext()->getSelfNominalTypeDecl())
+    // If it's distributed, generally variable access is not okay...
+    if (auto nominalParent = var->getDeclContext()->getSelfNominalTypeDecl()) {
       if (nominalParent->isDistributedActor())
         return false;
+    }
 
     // If it's actor-isolated but in the same module, then it's OK too.
     return (fromModule == var->getDeclContext()->getParentModule());
@@ -2242,15 +2243,7 @@ namespace {
     Optional<std::pair<bool, bool>>
     checkDistributedAccess(SourceLoc declLoc, ValueDecl *decl,
                            Expr *context) {
-      // Cannot reference properties or subscripts of distributed actors.
-      if (isPropOrSubscript(decl)) {
-        ctx.Diags.diagnose(
-            declLoc, diag::distributed_actor_isolated_non_self_reference,
-            decl->getDescriptiveKind(), decl->getName());
-        noteIsolatedActorMember(decl, context);
-        return None;
-      }
-
+      // If base of the call is 'local' we permit skip distributed checks.
       if (auto baseSelf = findReferencedBaseSelf(context)) {
         if (baseSelf->getAttrs().hasAttribute<KnownToBeLocalAttr>()) {
         return std::make_pair(
@@ -2259,20 +2252,48 @@ namespace {
         }
       }
 
-      // Check that we have a distributed function.
-      auto func = dyn_cast<AbstractFunctionDecl>(decl);
-      if (!func || !func->isDistributed()) {
-        ctx.Diags.diagnose(declLoc,
-                           diag::distributed_actor_isolated_method)
-          .fixItInsert(decl->getAttributeInsertionLoc(true), "distributed ");
+      // Cannot reference subscripts, or stored properties.
+      auto var = dyn_cast<VarDecl>(decl);
+      if (isa<SubscriptDecl>(decl) || var) {
+        // But computed distributed properties are okay,
+        // and treated the same as a distributed func.
+        if (var && var->isDistributed()) {
+          fprintf(stderr, "[%s:%d] (%s) HERE\n", __FILE__, __LINE__, __FUNCTION__);
+          var->dump();
+          bool explicitlyThrowing = false;
+          if (auto getter = var->getAccessor(swift::AccessorKind::Get)) {
+            explicitlyThrowing = getter->hasThrows();
+          }
+          return std::make_pair(
+              /*setThrows*/!explicitlyThrowing,
+              /*isDistributedThunk=*/true);
+        }
 
+        // otherwise, it was a normal property or subscript and therefore illegal
+        ctx.Diags.diagnose(
+            declLoc, diag::distributed_actor_isolated_non_self_reference,
+            decl->getDescriptiveKind(), decl->getName());
         noteIsolatedActorMember(decl, context);
         return None;
       }
 
-      return std::make_pair(
-          /*setThrows=*/!func->hasThrows(),
-          /*isDistributedThunk=*/true);
+      // Check that we have a distributed function or computed property.
+      if (auto afd = dyn_cast<AbstractFunctionDecl>(decl)) {
+        if (!afd->isDistributed()) {
+          ctx.Diags.diagnose(declLoc,
+                             diag::distributed_actor_isolated_method)
+              .fixItInsert(decl->getAttributeInsertionLoc(true), "distributed ");
+
+          noteIsolatedActorMember(decl, context);
+          return None;
+        }
+
+        return std::make_pair(
+            /*setThrows=*/!afd->hasThrows(),
+            /*isDistributedThunk=*/true);
+      }
+
+      return std::make_pair(/*setThrows=*/false, /*distributedThunk=*/false);
     }
 
     /// Attempts to identify and mark a valid cross-actor use of a synchronous
@@ -2289,8 +2310,34 @@ namespace {
       // is it an access to a property?
       if (isPropOrSubscript(decl)) {
         // Cannot reference properties or subscripts of distributed actors.
-        if (isDistributed && !checkDistributedAccess(declLoc, decl, context))
-          return AsyncMarkingResult::NotDistributed;
+        fprintf(stderr, "[%s:%d] (%s) prop\n", __FILE__, __LINE__, __FUNCTION__);
+        if (isDistributed) {
+          fprintf(stderr, "[%s:%d] (%s) prop is dist\n", __FILE__, __LINE__, __FUNCTION__);
+
+          bool setThrows = false;
+          bool usesDistributedThunk = false;
+          if (auto access = checkDistributedAccess(declLoc, decl, context)) {
+            std::tie(setThrows, usesDistributedThunk) = *access;
+          } else {
+            fprintf(stderr, "[%s:%d] (%s) prop is dist -> NOPE \n", __FILE__, __LINE__, __FUNCTION__);
+            return AsyncMarkingResult::NotDistributed;
+          }
+
+          // distributed computed property access, mark it throws + async
+          if (auto lookupExpr = dyn_cast_or_null<LookupExpr>(context)) {
+            if (auto memberRef = dyn_cast<MemberRefExpr>(lookupExpr)) {
+              fprintf(stderr, "[%s:%d] (%s) SET DISTRIBUTED MEMBER REF\n", __FILE__, __LINE__, __FUNCTION__);
+              memberRef->dump();
+
+              memberRef->setImplicitlyThrows(true);
+              memberRef->setShouldApplyLookupDistributedThunk(true);
+            } else {
+              llvm_unreachable("expected distributed prop to be a MemberRef");
+            }
+          } else {
+            llvm_unreachable("expected distributed prop to have LookupExpr");
+          }
+        }
 
         if (auto declRef = dyn_cast_or_null<DeclRefExpr>(context)) {
           if (usageEnv(declRef) == VarRefUseEnv::Read) {
@@ -2348,10 +2395,12 @@ namespace {
         bool setThrows = false;
         bool usesDistributedThunk = false;
         if (isDistributed) {
-          if (auto access = checkDistributedAccess(declLoc, decl, context))
+          if (auto access = checkDistributedAccess(declLoc, decl, context)) {
             std::tie(setThrows, usesDistributedThunk) = *access;
-          else
+            fprintf(stderr, "[%s:%d] (%s) USE THUNK\n", __FILE__, __LINE__, __FUNCTION__);
+          } else {
             return AsyncMarkingResult::NotDistributed;
+          }
         }
 
         // Mark call as implicitly 'async', and also potentially as

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3854,11 +3854,7 @@ bool HasIsolatedSelfRequest::evaluate(
 
   // For accessors, consider the storage declaration.
   if (auto accessor = dyn_cast<AccessorDecl>(value)) {
-    // distributed thunks are accessors only in spirit and
-    // should be handled as regular functions from isolation
-    // perspective.
-    if (!accessor->isDistributedThunk())
-      value = accessor->getStorage();
+    value = accessor->getStorage();
   }
 
   // Check whether this member can be isolated to an actor at all.

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1612,7 +1612,6 @@ namespace  {
 
     UNINTERESTING_ATTR(UnsafeInheritExecutor)
     UNINTERESTING_ATTR(CompilerInitialized)
-
 #undef UNINTERESTING_ATTR
 
     void visitAvailableAttr(AvailableAttr *attr) {

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2880,6 +2880,7 @@ public:
     }
 
     TypeChecker::checkDeclAttributes(FD);
+    TypeChecker::checkDistributedFunc(FD);
 
     if (!checkOverrides(FD)) {
       // If a method has an 'override' keyword but does not

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -421,9 +421,9 @@ static bool checkDistributedTargetResultType(
             addCodableFixIt(resultNominalType, diag);
           }
         }
-
-        return true;
-      }
+      } // end if: diagnose
+      
+      return true;
     }
   }
 

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -702,6 +702,13 @@ void TypeChecker::checkDistributedActor(SourceFile *SF, NominalTypeDecl *nominal
   (void)nominal->getDistributedActorIDProperty();
 }
 
+void TypeChecker::checkDistributedFunc(FuncDecl *func) {
+  if (!func->isDistributed())
+    return;
+
+  swift::checkDistributedFunction(func);
+}
+
 llvm::SmallPtrSet<ProtocolDecl *, 2>
 swift::getDistributedSerializationRequirementProtocols(
     NominalTypeDecl *nominal, ProtocolDecl *protocol) {

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -26,6 +26,7 @@
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/TypeVisitor.h"
 #include "swift/AST/ExistentialLayout.h"
+#include "swift/Basic/Defer.h"
 
 using namespace swift;
 
@@ -598,23 +599,26 @@ bool swift::checkDistributedActorProperty(VarDecl *var, bool diagnose) {
 
   /// === Check if the declaration is a valid combination of attributes
   if (var->isStatic()) {
-    var->diagnose(diag::distributed_property_cannot_be_static,
-                      var->getName());
+    if (diagnose)
+      var->diagnose(diag::distributed_property_cannot_be_static,
+                    var->getName());
     // TODO(distributed): fixit, offer removing the static keyword
     return true;
   }
 
   // it is not a computed property
   if (var->isLet() || var->hasStorageOrWrapsStorage()) {
-    var->diagnose(diag::distributed_property_can_only_be_computed,
-                  var->getDescriptiveKind(), var->getName());
+    if (diagnose)
+      var->diagnose(diag::distributed_property_can_only_be_computed,
+                    var->getDescriptiveKind(), var->getName());
     return true;
   }
 
   // distributed properties cannot have setters
   if (var->getWriteImpl() != swift::WriteImplKind::Immutable) {
-    var->diagnose(diag::distributed_property_can_only_be_computed_get_only,
-                  var->getName());
+    if (diagnose)
+      var->diagnose(diag::distributed_property_can_only_be_computed_get_only,
+                    var->getName());
     return true;
   }
 

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -502,9 +502,25 @@ bool CheckDistributedFunctionRequest::evaluate(
     serializationRequirements = getDistributedSerializationRequirementProtocols(
         getDistributedActorSystemType(actor)->getAnyNominal(),
         C.getProtocol(KnownProtocolKind::DistributedActorSystem));
+  } else if (isa<ProtocolDecl>(DC)) {
+    if (auto seqReqTy =
+        getConcreteReplacementForMemberSerializationRequirement(func)) {
+      auto seqReqTyDes = seqReqTy->castTo<ExistentialType>()->getConstraintType()->getDesugaredType();
+      for (auto req : flattenDistributedSerializationTypeToRequiredProtocols(seqReqTyDes)) {
+        serializationRequirements.insert(req);
+      }
+    }
+
+    // The distributed actor constrained protocol has no serialization requirements
+    // or actor system defined, so these will only be enforced, by implementations
+    // of DAs conforming to it, skip checks here.
+    if (serializationRequirements.empty()) {
+      return false;
+    }
   } else {
-    llvm_unreachable("Cannot handle types other than extensions and actor "
-                     "declarations in distributed function checking.");
+    llvm_unreachable("Distributed function detected in type other than extension, "
+                     "distributed actor, or protocol! This should not be possible "
+                     ", please file a bug.");
   }
 
   // If the requirement is exactly `Codable` we diagnose it ia bit nicer.
@@ -652,11 +668,22 @@ void TypeChecker::checkDistributedActor(SourceFile *SF, NominalTypeDecl *nominal
   // If applicable, this will create the default 'init(transport:)' initializer
   (void)nominal->getDefaultInitializer();
 
+
   for (auto member : nominal->getMembers()) {
     // --- Ensure all thunks
     if (auto func = dyn_cast<AbstractFunctionDecl>(member)) {
       if (!func->isDistributed())
         continue;
+
+      if (!isa<ProtocolDecl>(nominal)) {
+        auto systemTy = getConcreteReplacementForProtocolActorSystemType(func);
+        if (!systemTy || systemTy->hasError()) {
+          nominal->diagnose(
+              diag::distributed_actor_conformance_missing_system_type,
+              nominal->getName());
+          return;
+        }
+      }
 
       if (auto thunk = func->getDistributedThunk()) {
         SF->DelayedFunctions.push_back(thunk);

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -482,7 +482,12 @@ bool swift::checkDistributedFunction(AbstractFunctionDecl *func) {
 
 bool CheckDistributedFunctionRequest::evaluate(
     Evaluator &evaluator, AbstractFunctionDecl *func) const {
-  assert(func->isDistributed());
+  if (auto *accessor = dyn_cast<AccessorDecl>(func)) {
+    auto *var = cast<VarDecl>(accessor->getStorage());
+    assert(var->isDistributed() && accessor->isGetter());
+  } else {
+    assert(func->isDistributed());
+  }
 
   auto &C = func->getASTContext();
   auto DC = func->getDeclContext();
@@ -670,6 +675,18 @@ void TypeChecker::checkDistributedActor(SourceFile *SF, NominalTypeDecl *nominal
 
 
   for (auto member : nominal->getMembers()) {
+    // A distributed computed property needs to have a thunk for
+    // its getter accessor.
+    if (auto *var = dyn_cast<VarDecl>(member)) {
+      if (!var->isDistributed())
+        continue;
+
+      if (auto thunk = var->getDistributedThunk())
+        SF->DelayedFunctions.push_back(thunk);
+
+      continue;
+    }
+
     // --- Ensure all thunks
     if (auto func = dyn_cast<AbstractFunctionDecl>(member)) {
       if (!func->isDistributed())

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1104,6 +1104,9 @@ diagnosePotentialOpaqueTypeUnavailability(SourceRange ReferenceRange,
 /// Type check a 'distributed actor' declaration.
 void checkDistributedActor(SourceFile *SF, NominalTypeDecl *decl);
 
+/// Type check a single 'distributed func' declaration.
+void checkDistributedFunc(FuncDecl *func);
+
 void checkConcurrencyAvailability(SourceRange ReferenceRange,
                                   const DeclContext *ReferenceDC);
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3309,6 +3309,7 @@ public:
     bool overriddenAffectsABI, needsNewVTableEntry, isTransparent;
     DeclID opaqueReturnTypeID;
     bool isUserAccessible;
+    bool isDistributedThunk;
     ArrayRef<uint64_t> nameAndDependencyIDs;
 
     if (!isAccessor) {
@@ -3327,6 +3328,7 @@ public:
                                           needsNewVTableEntry,
                                           opaqueReturnTypeID,
                                           isUserAccessible,
+                                          isDistributedThunk,
                                           nameAndDependencyIDs);
     } else {
       decls_block::AccessorLayout::readRecord(scratch, contextID, isImplicit,
@@ -3344,6 +3346,7 @@ public:
                                               rawAccessLevel,
                                               needsNewVTableEntry,
                                               isTransparent,
+                                              isDistributedThunk,
                                               nameAndDependencyIDs);
     }
 
@@ -3519,6 +3522,8 @@ public:
 
     if (!isAccessor)
       fn->setUserAccessible(isUserAccessible);
+
+    fn->setDistributedThunk(isDistributedThunk);
 
     return fn;
   }

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 693; // existential Any and AnyObject
+const uint16_t SWIFTMODULE_VERSION_MINOR = 696; // `distributed thunk` bit on `AbstractFunctionDecl`
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -965,6 +965,48 @@ namespace decls_block {
 #include "DeclTypeRecordNodes.def"
   };
 
+  namespace detail {
+  enum TypeRecords : uint16_t {
+#define TYPE(Id) Id##_TYPE = decls_block::RecordKind::Id##_TYPE,
+#include "DeclTypeRecordNodes.def"
+  };
+
+  template <TypeRecords Record>
+  class TypeRecordDispatch {};
+
+  template <TypeRecords RecordCode, typename ...Ts>
+  struct code { public: constexpr static TypeRecords value = RecordCode; };
+
+  struct function_deserializer {
+    static llvm::Expected<Type>
+    deserialize(ModuleFile &MF, SmallVectorImpl<uint64_t> &scratch,
+                StringRef blobData, bool isGeneric);
+  };
+
+#define TYPE_LAYOUT_IMPL(LAYOUT, ...)                                          \
+  using LAYOUT = BCRecordLayout<__VA_ARGS__>;                                  \
+  template <>                                                                  \
+  class detail::TypeRecordDispatch<                                            \
+      detail::code<detail::TypeRecords::__VA_ARGS__>::value> {                 \
+    friend class swift::ModuleFile;                                            \
+    static llvm::Expected<Type>                                                \
+    deserialize(ModuleFile &MF,                                                \
+                llvm::SmallVectorImpl<uint64_t> &scratch,                      \
+                StringRef blobData);                                           \
+  }
+  } // namespace detail
+
+/// This \c TYPE_LAYOUT(...) macro replaces the usual \c BCRecordLayout coding
+/// structures below by enforcing structural checks for the definition of
+/// deserialization members. If you forget to define a \c TYPE_LAYOUT(...) for a
+/// \c TYPE(...) there will be a gnarly SFINAE error pointing at it in
+/// DeclTypeRecordNodes.def.
+///
+/// This macro pairs with \c DESERIALIZE_TYPE(...) in Deserialization.cpp such
+/// that if you forget \c DESERIALIZE_TYPE(...) you will come up
+/// with a linker error.
+#define TYPE_LAYOUT(LAYOUT, ...) TYPE_LAYOUT_IMPL(LAYOUT, __VA_ARGS__)
+
   using ClangTypeLayout = BCRecordLayout<
     CLANG_TYPE,
     BCArray<BCVBR<6>>
@@ -976,52 +1018,53 @@ namespace decls_block {
   >;
 
   /// A placeholder for invalid types
-  using ErrorTypeLayout = BCRecordLayout<
+  TYPE_LAYOUT(ErrorTypeLayout,
     ERROR_TYPE,
     TypeIDField // original type (if any)
-  >;
+  );
 
-  using BuiltinAliasTypeLayout = BCRecordLayout<
+  TYPE_LAYOUT(BuiltinAliasTypeLayout,
     BUILTIN_ALIAS_TYPE,
     DeclIDField, // typealias decl
     TypeIDField  // canonical type (a fallback)
-  >;
+  );
 
-  using TypeAliasTypeLayout = BCRecordLayout<
+  TYPE_LAYOUT(TypeAliasTypeLayout,
     NAME_ALIAS_TYPE,
-    DeclIDField,      // typealias decl
-    TypeIDField,      // parent type
-    TypeIDField,      // underlying type
-    TypeIDField,      // substituted type
+    DeclIDField,           // typealias decl
+    TypeIDField,           // parent type
+    TypeIDField,           // underlying type
+    TypeIDField,           // substituted type
     SubstitutionMapIDField // substitution map
-  >;
+  );
 
-  using GenericTypeParamTypeLayout = BCRecordLayout<GENERIC_TYPE_PARAM_TYPE,
+  TYPE_LAYOUT(GenericTypeParamTypeLayout,
+    GENERIC_TYPE_PARAM_TYPE,
     BCFixed<1>,  // type sequence?
     DeclIDField, // generic type parameter decl or depth
     BCVBR<4> // index + 1, or zero if we have a generic type
             // parameter decl
-  >;
+  );
 
-  using DependentMemberTypeLayout = BCRecordLayout<
+  TYPE_LAYOUT(DependentMemberTypeLayout,
     DEPENDENT_MEMBER_TYPE,
-    TypeIDField,      // base type
-    DeclIDField       // associated type decl
-  >;
-  using NominalTypeLayout = BCRecordLayout<
+    TypeIDField, // base type
+    DeclIDField  // associated type decl
+  );
+  TYPE_LAYOUT(NominalTypeLayout,
     NOMINAL_TYPE,
     DeclIDField, // decl
     TypeIDField  // parent
-  >;
+  );
 
-  using ParenTypeLayout = BCRecordLayout<
+  TYPE_LAYOUT(ParenTypeLayout,
     PAREN_TYPE,
-    TypeIDField         // inner type
-  >;
+    TypeIDField // inner type
+  );
 
-  using TupleTypeLayout = BCRecordLayout<
+  TYPE_LAYOUT(TupleTypeLayout,
     TUPLE_TYPE
-  >;
+  );
 
   using TupleTypeEltLayout = BCRecordLayout<
     TUPLE_TYPE_ELT,
@@ -1029,19 +1072,19 @@ namespace decls_block {
     TypeIDField         // type
   >;
 
-  using FunctionTypeLayout = BCRecordLayout<
+  TYPE_LAYOUT(FunctionTypeLayout,
     FUNCTION_TYPE,
-    TypeIDField, // output
+    TypeIDField,                     // output
     FunctionTypeRepresentationField, // representation
-    ClangTypeIDField, // type
-    BCFixed<1>,  // noescape?
-    BCFixed<1>,   // concurrent?
-    BCFixed<1>,   // async?
-    BCFixed<1>,   // throws?
-    DifferentiabilityKindField, // differentiability kind
-    TypeIDField   // global actor
+    ClangTypeIDField,                // type
+    BCFixed<1>,                      // noescape?
+    BCFixed<1>,                      // concurrent?
+    BCFixed<1>,                      // async?
+    BCFixed<1>,                      // throws?
+    DifferentiabilityKindField,      // differentiability kind
+    TypeIDField                      // global actor
     // trailed by parameters
-  >;
+  );
 
   using FunctionParamLayout = BCRecordLayout<
     FUNCTION_PARAM,
@@ -1057,154 +1100,156 @@ namespace decls_block {
     BCFixed<1>           // compileTimeConst
   >;
 
-  using MetatypeTypeLayout = BCRecordLayout<
+  TYPE_LAYOUT(MetatypeTypeLayout,
     METATYPE_TYPE,
-    TypeIDField,                       // instance type
-    MetatypeRepresentationField        // representation
-  >;
+    TypeIDField,                // instance type
+    MetatypeRepresentationField // representation
+  );
 
-  using ExistentialMetatypeTypeLayout = BCRecordLayout<
+  TYPE_LAYOUT(ExistentialMetatypeTypeLayout,
     EXISTENTIAL_METATYPE_TYPE,
-    TypeIDField,                       // instance type
-    MetatypeRepresentationField        // representation
-  >;
+    TypeIDField,                // instance type
+    MetatypeRepresentationField // representation
+  );
 
-  using PrimaryArchetypeTypeLayout = BCRecordLayout<
+  TYPE_LAYOUT(PrimaryArchetypeTypeLayout,
     PRIMARY_ARCHETYPE_TYPE,
     GenericSignatureIDField, // generic environment
     TypeIDField              // interface type
-  >;
+  );
 
-  using OpenedArchetypeTypeLayout = BCRecordLayout<
+  TYPE_LAYOUT(OpenedArchetypeTypeLayout,
     OPENED_ARCHETYPE_TYPE,
     TypeIDField,            // the existential type
     TypeIDField,            // the interface type
     GenericSignatureIDField // generic signature
-  >;
+  );
 
-  using OpaqueArchetypeTypeLayout = BCRecordLayout<
+  TYPE_LAYOUT(OpaqueArchetypeTypeLayout,
     OPAQUE_ARCHETYPE_TYPE,
     DeclIDField,           // the opaque type decl
     TypeIDField,           // the interface type
     SubstitutionMapIDField // the arguments
-  >;
-  
-  using SequenceArchetypeTypeLayout = BCRecordLayout<
+  );
+
+  TYPE_LAYOUT(SequenceArchetypeTypeLayout,
     SEQUENCE_ARCHETYPE_TYPE,
     GenericSignatureIDField, // generic environment
     TypeIDField              // interface type
-  >;
+  );
 
-  using DynamicSelfTypeLayout = BCRecordLayout<
+  TYPE_LAYOUT(DynamicSelfTypeLayout,
     DYNAMIC_SELF_TYPE,
-    TypeIDField          // self type
-  >;
+    TypeIDField // self type
+  );
 
-  using ProtocolCompositionTypeLayout = BCRecordLayout<
+  TYPE_LAYOUT(ProtocolCompositionTypeLayout,
     PROTOCOL_COMPOSITION_TYPE,
     BCFixed<1>,          // has AnyObject constraint
     BCArray<TypeIDField> // protocols
-  >;
+  );
 
-  using ParameterizedProtocolTypeLayout = BCRecordLayout<
+  TYPE_LAYOUT(ParameterizedProtocolTypeLayout,
     PARAMETERIZED_PROTOCOL_TYPE,
     TypeIDField,         // base
     BCArray<TypeIDField> // arguments
-  >;
+  );
 
-  using BoundGenericTypeLayout = BCRecordLayout<
+  TYPE_LAYOUT(BoundGenericTypeLayout,
     BOUND_GENERIC_TYPE,
-    DeclIDField, // generic decl
-    TypeIDField, // parent
+    DeclIDField,         // generic decl
+    TypeIDField,         // parent
     BCArray<TypeIDField> // generic arguments
-  >;
+  );
 
-  using GenericFunctionTypeLayout = BCRecordLayout<
+  TYPE_LAYOUT(GenericFunctionTypeLayout,
     GENERIC_FUNCTION_TYPE,
-    TypeIDField,         // output
+    TypeIDField,                     // output
     FunctionTypeRepresentationField, // representation
-    BCFixed<1>,          // concurrent?
-    BCFixed<1>,          // async?
-    BCFixed<1>,          // throws?
-    DifferentiabilityKindField, // differentiability kind
-    TypeIDField,         // global actor
-    GenericSignatureIDField // generic signture
+    BCFixed<1>,                      // concurrent?
+    BCFixed<1>,                      // async?
+    BCFixed<1>,                      // throws?
+    DifferentiabilityKindField,      // differentiability kind
+    TypeIDField,                     // global actor
+    GenericSignatureIDField          // generic signature
 
     // trailed by parameters
-  >;
+  );
 
-  using SILFunctionTypeLayout = BCRecordLayout<
+  TYPE_LAYOUT(SILFunctionTypeLayout,
     SIL_FUNCTION_TYPE,
     BCFixed<1>,                         // concurrent?
     BCFixed<1>,                         // async?
-    SILCoroutineKindField, // coroutine kind
-    ParameterConventionField, // callee convention
+    SILCoroutineKindField,              // coroutine kind
+    ParameterConventionField,           // callee convention
     SILFunctionTypeRepresentationField, // representation
-    BCFixed<1>,            // pseudogeneric?
-    BCFixed<1>,            // noescape?
-    DifferentiabilityKindField, // differentiability kind
-    BCFixed<1>,            // error result?
-    BCVBR<6>,              // number of parameters
-    BCVBR<5>,              // number of yields
-    BCVBR<5>,              // number of results
-    GenericSignatureIDField, // invocation generic signature
-    SubstitutionMapIDField, // invocation substitutions
-    SubstitutionMapIDField, // pattern substitutions
-    ClangTypeIDField,      // clang function type, for foreign conventions
-    BCArray<TypeIDField>   // parameter types/conventions, alternating
-                           // followed by result types/conventions, alternating
-                           // followed by error result type/convention
+    BCFixed<1>,                         // pseudogeneric?
+    BCFixed<1>,                         // noescape?
+    DifferentiabilityKindField,         // differentiability kind
+    BCFixed<1>,                         // error result?
+    BCVBR<6>,                           // number of parameters
+    BCVBR<5>,                           // number of yields
+    BCVBR<5>,                           // number of results
+    GenericSignatureIDField,            // invocation generic signature
+    SubstitutionMapIDField,             // invocation substitutions
+    SubstitutionMapIDField,             // pattern substitutions
+    ClangTypeIDField,    // clang function type, for foreign conventions
+    BCArray<TypeIDField> // parameter types/conventions, alternating
+                          // followed by result types/conventions, alternating
+                          // followed by error result type/convention
     // Optionally a protocol conformance (for witness_methods)
     // Optionally a substitution map (for substituted function types)
-  >;
-  
-  using SILBlockStorageTypeLayout = BCRecordLayout<
+  );
+
+  TYPE_LAYOUT(SILBlockStorageTypeLayout,
     SIL_BLOCK_STORAGE_TYPE,
-    TypeIDField            // capture type
-  >;
+    TypeIDField // capture type
+  );
+
+  TYPE_LAYOUT(SILMoveOnlyTypeLayout,
+    SIL_MOVE_ONLY_TYPE,
+    TypeIDField            // inner type
+  );
 
   using SILLayoutLayout = BCRecordLayout<
     SIL_LAYOUT,
     GenericSignatureIDField,    // generic signature
+    BCFixed<1>,                 // captures generic env
     BCVBR<8>,                   // number of fields
     BCArray<TypeIDWithBitField> // field types with mutability
   >;
 
-  using SILBoxTypeLayout = BCRecordLayout<
+  TYPE_LAYOUT(SILBoxTypeLayout,
     SIL_BOX_TYPE,
-    SILLayoutIDField,     // layout
+    SILLayoutIDField,      // layout
     SubstitutionMapIDField // substitutions
-  >;
+  );
 
-  template <unsigned Code>
-  using SyntaxSugarTypeLayout = BCRecordLayout<
-    Code,
-    TypeIDField // element type
-  >;
+#define SYNTAX_SUGAR_TYPE_LAYOUT(LAYOUT, CODE)                                 \
+  TYPE_LAYOUT(LAYOUT, CODE, TypeIDField)
 
-  using ArraySliceTypeLayout = SyntaxSugarTypeLayout<ARRAY_SLICE_TYPE>;
-  using OptionalTypeLayout = SyntaxSugarTypeLayout<OPTIONAL_TYPE>;
-  using VariadicSequenceTypeLayout = SyntaxSugarTypeLayout<VARIADIC_SEQUENCE_TYPE>;
-  using ExistentialTypeLayout =
-      SyntaxSugarTypeLayout<EXISTENTIAL_TYPE>;
+  SYNTAX_SUGAR_TYPE_LAYOUT(ArraySliceTypeLayout, ARRAY_SLICE_TYPE);
+  SYNTAX_SUGAR_TYPE_LAYOUT(OptionalTypeLayout, OPTIONAL_TYPE);
+  SYNTAX_SUGAR_TYPE_LAYOUT(VariadicSequenceTypeLayout, VARIADIC_SEQUENCE_TYPE);
+  SYNTAX_SUGAR_TYPE_LAYOUT(ExistentialTypeLayout, EXISTENTIAL_TYPE);
 
-  using DictionaryTypeLayout = BCRecordLayout<
+  TYPE_LAYOUT(DictionaryTypeLayout,
     DICTIONARY_TYPE,
     TypeIDField, // key type
     TypeIDField  // value type
-  >;
+  );
 
-  using ReferenceStorageTypeLayout = BCRecordLayout<
+  TYPE_LAYOUT(ReferenceStorageTypeLayout,
     REFERENCE_STORAGE_TYPE,
     ReferenceOwnershipField, // ownership
     TypeIDField              // implementation type
-  >;
+  );
 
-  using UnboundGenericTypeLayout = BCRecordLayout<
+  TYPE_LAYOUT(UnboundGenericTypeLayout,
     UNBOUND_GENERIC_TYPE,
     DeclIDField, // generic decl
     TypeIDField  // parent
-  >;
+  );
 
   using TypeAliasLayout = BCRecordLayout<
     TYPE_ALIAS_DECL,
@@ -1404,6 +1449,7 @@ namespace decls_block {
     BCFixed<1>,   // requires a new vtable slot
     DeclIDField,  // opaque result type decl
     BCFixed<1>,   // isUserAccessible?
+    BCFixed<1>,   // is distributed thunk
     BCArray<IdentifierIDField> // name components,
                                // followed by TypeID dependencies
     // The record is trailed by:
@@ -1455,6 +1501,7 @@ namespace decls_block {
     AccessLevelField, // access level
     BCFixed<1>,   // requires a new vtable slot
     BCFixed<1>,   // is transparent
+    BCFixed<1>,   // is distributed thunk
     BCArray<IdentifierIDField> // name components,
                                // followed by TypeID dependencies
     // The record is trailed by:
@@ -1608,7 +1655,8 @@ namespace decls_block {
 
   using AnyPatternLayout = BCRecordLayout<
     ANY_PATTERN,
-    TypeIDField  // type
+    TypeIDField, // type
+    BCFixed<1>   // isAsyncLet
     // FIXME: is the type necessary?
   >;
 
@@ -2038,6 +2086,10 @@ namespace decls_block {
     BC_AVAIL_TUPLE, // OS version
     BCVBR<5>        // platform
   >;
+
+#undef SYNTAX_SUGAR_TYPE_LAYOUT
+#undef TYPE_LAYOUT
+#undef TYPE_LAYOUT_IMPL
 }
 
 /// Returns the encoding kind for the given decl.

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3888,6 +3888,7 @@ public:
                            fn->needsNewVTableEntry(),
                            S.addDeclRef(fn->getOpaqueResultTypeDecl()),
                            fn->isUserAccessible(),
+                           fn->isDistributedThunk(),
                            nameComponentsAndDependencies);
 
     writeGenericParams(fn->getGenericParams());
@@ -3999,6 +4000,7 @@ public:
                                rawAccessLevel,
                                fn->needsNewVTableEntry(),
                                fn->isTransparent(),
+                               fn->isDistributedThunk(),
                                dependencies);
 
     writeGenericParams(fn->getGenericParams());

--- a/stdlib/public/Distributed/DistributedActorSystem.swift
+++ b/stdlib/public/Distributed/DistributedActorSystem.swift
@@ -74,7 +74,7 @@ public protocol DistributedActorSystem: Sendable {
   /// to the same actor.
   func assignID<Act>(_ actorType: Act.Type) -> ActorID
     where Act: DistributedActor,
-    Act.ID == ActorID
+          Act.ID == ActorID
 
   /// Invoked during a distributed actor's initialization, as soon as it becomes fully initialized.
   ///
@@ -93,7 +93,7 @@ public protocol DistributedActorSystem: Sendable {
   /// - Parameter actor: reference to the (local) actor that was just fully initialized.
   func actorReady<Act>(_ actor: Act)
     where Act: DistributedActor,
-    Act.ID == ActorID
+          Act.ID == ActorID
 
   /// Called during when a distributed actor is deinitialized, or fails to initialize completely (e.g. by throwing
   /// out of an `init` that did not completely initialize all of the the actors stored properties yet).

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_computedProperty.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_computedProperty.swift
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-build-swift -module-name main -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s --color
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// rdar://76038845
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+// FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
+// UNSUPPORTED: windows
+
+import Distributed
+import FakeDistributedActorSystems
+
+typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
+
+distributed actor Greeter {
+  distributed var theDistributedProperty: String {
+    "Patrik the Seastar"
+  }
+}
+
+func test() async throws {
+  let system = DefaultDistributedActorSystem()
+
+  let local = Greeter(actorSystem: system)
+  let ref = try Greeter.resolve(id: local.id, using: system)
+
+  let reply = try await ref.theDistributedProperty
+  // CHECK: >> remoteCall: on:main.Greeter, target:main.Greeter.name, invocation:FakeInvocationEncoder(genericSubs: [], arguments: [], returnType: Optional(Swift.String), errorType: nil), throwing:Swift.Never, returning:Swift.String
+  // CHECK: << remoteCall return: Patrick the Seastar
+  print("reply: \(reply)")
+  // CHECK: reply: Echo: Caplin
+}
+
+@main struct Main {
+  static func main() async {
+    try! await test()
+  }
+}

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_computedProperty.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_computedProperty.swift
@@ -21,7 +21,7 @@ typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
 
 distributed actor Greeter {
   distributed var theDistributedProperty: String {
-    "Patrik the Seastar"
+    "Patrick the Seastar"
   }
 }
 
@@ -32,10 +32,10 @@ func test() async throws {
   let ref = try Greeter.resolve(id: local.id, using: system)
 
   let reply = try await ref.theDistributedProperty
-  // CHECK: >> remoteCall: on:main.Greeter, target:main.Greeter.name, invocation:FakeInvocationEncoder(genericSubs: [], arguments: [], returnType: Optional(Swift.String), errorType: nil), throwing:Swift.Never, returning:Swift.String
+  // CHECK: >> remoteCall: on:main.Greeter, target:main.Greeter.theDistributedProperty(), invocation:FakeInvocationEncoder(genericSubs: [], arguments: [], returnType: Optional(Swift.String), errorType: nil), throwing:Swift.Never, returning:Swift.String
   // CHECK: << remoteCall return: Patrick the Seastar
   print("reply: \(reply)")
-  // CHECK: reply: Echo: Caplin
+  // CHECK: reply: Patrick the Seastar
 }
 
 @main struct Main {

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_through_generic.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_through_generic.swift
@@ -1,0 +1,165 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-build-swift -module-name main -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s --color --dump-input=always
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// rdar://76038845
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+// FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
+// UNSUPPORTED: OS=windows-msvc
+
+import Distributed
+import FakeDistributedActorSystems
+
+
+typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
+
+protocol DistributedWorker: DistributedActor where ActorSystem == DefaultDistributedActorSystem {
+  associatedtype WorkItem: Sendable & Codable
+  associatedtype WorkResult: Sendable & Codable
+
+  // distributed requirement currently is forced to be `async throws`...
+  // FIXME(distributed): requirements don't have to be async throws,
+  //                     distributed makes them implicitly async throws anyway...
+  distributed func submit(work: WorkItem) async throws -> WorkResult
+
+  // non distributed requirements can be witnessed with _normal_ functions
+  func sync(work: WorkItem) -> WorkResult
+  func async(work: WorkItem) async -> WorkResult
+  func syncThrows(work: WorkItem) throws -> WorkResult
+  func asyncThrows(work: WorkItem) async throws -> WorkResult
+}
+
+distributed actor TheWorker: DistributedWorker {
+  typealias ActorSystem = DefaultDistributedActorSystem
+  typealias WorkItem = String
+  typealias WorkResult = String
+
+  distributed func submit(work: WorkItem) async throws -> WorkResult {
+    "\(#function): \(work)"
+  }
+
+  func sync(work: WorkItem) -> WorkResult {
+    return "\(#function): \(work)"
+  }
+  func async(work: WorkItem) async -> WorkResult {
+    return "\(#function): \(work)"
+  }
+  func syncThrows(work: WorkItem) throws -> WorkResult {
+    return "\(#function): \(work)"
+  }
+  func asyncThrows(work: WorkItem) async throws -> WorkResult {
+    return "\(#function): \(work)"
+  }
+}
+
+func test_generic(system: DefaultDistributedActorSystem) async throws {
+  let localW = TheWorker(actorSystem: system)
+  let remoteW = try! TheWorker.resolve(id: localW.id, using: system)
+  precondition(__isRemoteActor(remoteW))
+
+  // direct calls work ok:
+  let replyDirect = try await remoteW.submit(work: "Direct")
+  print("reply direct: \(replyDirect)")
+  // CHECK: >> remoteCall: on:main.TheWorker, target:main.TheWorker.submit(work:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Direct"], returnType: Optional(Swift.String), errorType: Optional(Swift.Error)), throwing:Swift.Error, returning:Swift.String
+  // CHECK: reply direct: submit(work:): Direct
+
+  func callWorker<W: DistributedWorker>(w: W) async throws -> String where W.WorkItem == String, W.WorkResult == String {
+    try await w.submit(work: "Hello")
+  }
+  let reply = try await callWorker(w: remoteW)
+  print("reply (remote): \(reply)")
+  // CHECK: >> remoteCall: on:main.TheWorker, target:main.TheWorker.submit(work:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Hello"], returnType: Optional(Swift.String), errorType: Optional(Swift.Error)), throwing:Swift.Error, returning:Swift.String
+  // CHECK: << remoteCall return: submit(work:): Hello
+  // CHECK: reply (remote): submit(work:): Hello
+
+  let replyLocal = try await callWorker(w: localW)
+  print("reply (local): \(replyLocal)")
+  // CHECK-NOT: >> remoteCall
+  // CHECK: reply (local): submit(work:): Hello
+}
+
+func test_whenLocal(system: DefaultDistributedActorSystem) async throws {
+  let localW = TheWorker(actorSystem: system)
+  let remoteW = try! TheWorker.resolve(id: localW.id, using: system)
+  precondition(__isRemoteActor(remoteW))
+
+  do {
+    let replySync = await remoteW.whenLocal { __secretlyKnownToBeLocal in
+      __secretlyKnownToBeLocal.sync(work: "test")
+    }
+    print("replySync (remote): \(replySync)")
+    // CHECK: replySync (remote): nil
+
+    let replySyncThrows = try await remoteW.whenLocal { __secretlyKnownToBeLocal in
+      try __secretlyKnownToBeLocal.syncThrows(work: "test")
+    }
+    print("replySyncThrows (remote): \(replySyncThrows)")
+    // CHECK: replySyncThrows (remote): nil
+
+    let replyAsync = await remoteW.whenLocal { __secretlyKnownToBeLocal in
+      await __secretlyKnownToBeLocal.async(work: "test")
+    }
+    print("replyAsync (remote): \(replyAsync)")
+    // CHECK: replyAsync (remote): nil
+
+    let replyAsyncThrows = try await remoteW.whenLocal { __secretlyKnownToBeLocal in
+      try await __secretlyKnownToBeLocal.asyncThrows(work: "test")
+    }
+    print("replyAsyncThrows (remote): \(replyAsyncThrows)")
+    // CHECK: replyAsyncThrows (remote): nil
+  }
+  // ==== ----------------------------------------------------------------------
+
+  do {
+    let replyDistSubmit = try await localW.whenLocal { __secretlyKnownToBeLocal in
+      try await __secretlyKnownToBeLocal.submit(work: "local-test")
+    }
+    print("replyDistSubmit (local): \(replyDistSubmit ?? "nil")")
+    // CHECK-NOT: >> remoteCall
+    // CHECK: replyDistSubmit (local): submit(work:): local-test
+
+    let replySyncLocal = await localW.whenLocal { __secretlyKnownToBeLocal in
+      __secretlyKnownToBeLocal.sync(work: "local-test")
+    }
+    print("replySyncLocal (local): \(replySyncLocal ?? "nil")")
+    // CHECK-NOT: >> remoteCall
+    // CHECK: replySyncLocal (local): sync(work:): local-test
+
+    let replySyncThrowsLocal = try await localW.whenLocal { __secretlyKnownToBeLocal in
+      try __secretlyKnownToBeLocal.syncThrows(work: "local-test")
+    }
+    print("replySyncThrowsLocal (local): \(replySyncThrowsLocal ?? "nil")")
+    // CHECK-NOT: >> remoteCall
+    // CHECK: replySyncThrowsLocal (local): syncThrows(work:): local-test
+
+    let replyAsyncLocal = await localW.whenLocal { __secretlyKnownToBeLocal in
+      await __secretlyKnownToBeLocal.async(work: "local-test")
+    }
+    print("replyAsyncLocal (local): \(replyAsyncLocal ?? "nil")")
+    // CHECK-NOT: >> remoteCall
+    // CHECK: replyAsyncLocal (local): async(work:): local-test
+
+    let replyAsyncThrowsLocal = try await localW.whenLocal { __secretlyKnownToBeLocal in
+      try await __secretlyKnownToBeLocal.asyncThrows(work: "local-test")
+    }
+    print("replyAsyncThrowsLocal (local): \(replyAsyncThrowsLocal ?? "nil")")
+    // CHECK-NOT: >> remoteCall
+    // CHECK: replyAsyncThrowsLocal (local): asyncThrows(work:): local-test
+  }
+}
+
+@main struct Main {
+  static func main() async {
+    let system = DefaultDistributedActorSystem()
+    try! await test_generic(system: system)
+    print("==== ---------------------------------------------------")
+    try! await test_whenLocal(system: system)
+  }
+}

--- a/test/Distributed/distributed_actor_generic_actor_distributed_call.swift
+++ b/test/Distributed/distributed_actor_generic_actor_distributed_call.swift
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-swift-frontend -typecheck -verify -disable-availability-checking -I %t 2>&1 %s
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+import Distributed
+import FakeDistributedActorSystems
+
+@available(SwiftStdlib 5.5, *)
+typealias DefaultDistributedActorSystem = FakeActorSystem
+
+import Distributed
+
+protocol DistributedWorker: DistributedActor {
+  associatedtype WorkItem: Sendable & Codable
+  associatedtype WorkResult: Sendable & Codable
+
+  distributed func submit(work: WorkItem) async throws -> WorkResult
+}
+
+distributed actor TheWorker: DistributedWorker {
+  typealias ActorSystem = FakeActorSystem
+  typealias WorkItem = String
+  typealias WorkResult = String
+
+  distributed func submit(work: WorkItem) async throws -> WorkResult {
+    work
+  }
+}
+
+distributed actor WorkerPool<Worker: DistributedWorker> {
+  typealias ActorSystem = FakeActorSystem
+  typealias WorkItem = Worker.WorkItem
+  typealias WorkResult = Worker.WorkResult
+
+  func submit(work: WorkItem) async throws -> WorkResult {
+    let worker = try await self.selectWorker()
+    return try await worker.submit(work: work)
+  }
+
+  func selectWorker() async throws -> Worker {
+    fatalError()
+  }
+}

--- a/test/Distributed/distributed_actor_inference.swift
+++ b/test/Distributed/distributed_actor_inference.swift
@@ -42,11 +42,13 @@ protocol DP {
 }
 
 protocol DPOK: DistributedActor {
-  distributed func hello()  // ok
+  distributed func hello() // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
+  // expected-error@-1{{'distributed' protocol requirement 'hello()' must currently be declared explicitly 'async throws'}}
 }
 
 protocol DPOK2: DPOK {
-  distributed func again()  // ok
+  distributed func again() // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
+  // expected-error@-1{{'distributed' protocol requirement 'again()' must currently be declared explicitly 'async throws'}}
 }
 
 enum SomeNotActorEnum_5 {

--- a/test/Distributed/distributed_actor_isolation.swift
+++ b/test/Distributed/distributed_actor_isolation.swift
@@ -42,6 +42,23 @@ distributed actor DistributedActor_1 {
   distributed let letProperty: String = "" // expected-error{{property 'letProperty' cannot be 'distributed', only computed properties can}}
   distributed var varProperty: String = "" // expected-error{{property 'varProperty' cannot be 'distributed', only computed properties can}}
 
+  distributed var computed: String {
+    "computed"
+  }
+
+  distributed var computedNotCodable: NotCodableValue { // expected-error{{result type 'NotCodableValue' of distributed property 'computedNotCodable' does not conform to serialization requirement 'Codable'}}
+    .init()
+  }
+
+  distributed var getSet: String { // expected-error{{'distributed' computed property 'getSet' cannot have setter}}
+    get {
+      "computed"
+    }
+    set {
+      _ = newValue
+    }
+  }
+
   distributed static func distributedStatic() {} // expected-error{{'distributed' method cannot be 'static'}}
   distributed class func distributedClass() {}
   // expected-error@-1{{class methods are only allowed within classes; use 'static' to declare a static method}}

--- a/test/Distributed/distributed_actor_protocol_isolation.swift
+++ b/test/Distributed/distributed_actor_protocol_isolation.swift
@@ -37,15 +37,18 @@ protocol MixedProtoDistributedActor: DistributedActor {
   func localThrows() throws
   func localAsyncThrows() async throws
 
-  distributed func dist()
-  distributed func distAsync() async
+//  distributed func dist() // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
+//  distributed func distAsync() async // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
   distributed func distAsyncThrows() async throws
 }
 
 protocol DistProtoDistributedActor: DistributedActor {
-  distributed func dist()
-  distributed func distAsync() async
-  distributed func distThrows() throws
+  distributed func dist() // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
+  // expected-error@-1{{'distributed' protocol requirement 'dist()' must currently be declared explicitly 'async throws'}}
+  distributed func distAsync() async // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
+  // expected-error@-1{{'distributed' protocol requirement 'distAsync()' must currently be declared explicitly 'async throws'}}
+  distributed func distThrows() throws // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
+  // expected-error@-1{{'distributed' protocol requirement 'distThrows()' must currently be declared explicitly 'async throws'}}
   distributed func distAsyncThrows() async throws
 }
 

--- a/test/Distributed/distributed_actor_system_missing.swift
+++ b/test/Distributed/distributed_actor_system_missing.swift
@@ -18,6 +18,7 @@ distributed actor DA {
   // Note to add the typealias is diagnosed on the protocol:
   // _Distributed.DistributedActor:3:20: note: diagnostic produced elsewhere: protocol requires nested type 'ActorSystem'; do you want to add it?
 }
+
 // When an actor declares a typealias for a system, but that system does not exist,
 // we need to fail gracefully, rather than crash trying to use the non-existing type.
 //

--- a/test/Distributed/distributed_actor_system_missing.swift
+++ b/test/Distributed/distributed_actor_system_missing.swift
@@ -18,3 +18,14 @@ distributed actor DA {
   // Note to add the typealias is diagnosed on the protocol:
   // _Distributed.DistributedActor:3:20: note: diagnostic produced elsewhere: protocol requires nested type 'ActorSystem'; do you want to add it?
 }
+// When an actor declares a typealias for a system, but that system does not exist,
+// we need to fail gracefully, rather than crash trying to use the non-existing type.
+//
+// Test case for: https://github.com/apple/swift/issues/58663
+distributed actor Server { // expected-error 2 {{distributed actor 'Server' does not declare ActorSystem it can be used with.}}
+  // expected-note@-1{{you can provide a module-wide default actor system by declaring:}}
+  typealias ActorSystem = DoesNotExistDataSystem
+  // expected-error@-1{{cannot find type 'DoesNotExistDataSystem' in scope}}
+  typealias SerializationRequirement = any Codable
+  distributed func send() { }
+}

--- a/test/Distributed/distributed_actor_var_implicitly_async_throws.swift
+++ b/test/Distributed/distributed_actor_var_implicitly_async_throws.swift
@@ -33,15 +33,17 @@ distributed actor D {
     "dist"
   }
 
-  // OK:
+  // FIXME: The following should be accepted.
+  /*
   distributed var distGet: String {
     get distributed {
       "okey"
     }
   }
+  */
 
-  distributed var distSetGet: String {
-    set distributed {
+  distributed var distSetGet: String { // expected-error {{'distributed' computed property 'distSetGet' cannot have setter}}
+    set distributed { // expected-error {{expected '{' to start setter definition}}
       _ = newValue
     }
     get distributed {

--- a/test/Distributed/distributed_actor_var_implicitly_async_throws.swift
+++ b/test/Distributed/distributed_actor_var_implicitly_async_throws.swift
@@ -33,6 +33,22 @@ distributed actor D {
     "dist"
   }
 
+  // OK:
+  distributed var distGet: String {
+    get distributed {
+      "okey"
+    }
+  }
+
+  distributed var distSetGet: String {
+    set distributed {
+      _ = newValue
+    }
+    get distributed {
+      "okey"
+    }
+  }
+
   // expected-error@+1{{'distributed' property 'hello' cannot be 'static'}}
   static distributed var hello: String {
     "nope!"

--- a/test/Distributed/distributed_protocol_isolation.swift
+++ b/test/Distributed/distributed_protocol_isolation.swift
@@ -25,11 +25,15 @@ protocol DistProtocol: DistributedActor {
   // expected-note@-3{{distributed actor-isolated instance method 'local()' declared here}}
   // expected-note@-4{{distributed actor-isolated instance method 'local()' declared here}}
 
-  distributed func dist() -> String
-  distributed func dist(string: String) -> String
+  distributed func dist() -> String // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
+  // expected-error@-1{{'distributed' protocol requirement 'dist()' must currently be declared explicitly 'async throws'}}
+  distributed func dist(string: String) -> String // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
+  // expected-error@-1{{'distributed' protocol requirement 'dist(string:)' must currently be declared explicitly 'async throws'}}
 
-  distributed func distAsync() async -> String
-  distributed func distThrows() throws -> String
+  distributed func distAsync() async -> String // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
+  // expected-error@-1{{'distributed' protocol requirement 'distAsync()' must currently be declared explicitly 'async throws'}}
+  distributed func distThrows() throws -> String // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
+  // expected-error@-1{{'distributed' protocol requirement 'distThrows()' must currently be declared explicitly 'async throws'}}
   distributed func distAsyncThrows() async throws -> String
 }
 
@@ -253,8 +257,9 @@ func test_watchingDA_any(da: any TerminationWatchingDA) async throws {
 // MARK: Error cases
 
 protocol ErrorCases: DistributedActor {
-  distributed func unexpectedAsyncThrows() -> String
-  // expected-note@-1{{protocol requires function 'unexpectedAsyncThrows()' with type '() -> String'; do you want to add a stub?}}
+  distributed func unexpectedAsyncThrows() -> String // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
+  // expected-error@-1{{'distributed' protocol requirement 'unexpectedAsyncThrows()' must currently be declared explicitly 'async throws'}}
+  // expected-note@-2{{protocol requires function 'unexpectedAsyncThrows()' with type '() -> String'; do you want to add a stub?}}
 }
 
 distributed actor BadGreeter: ErrorCases {

--- a/test/Distributed/distributed_protocols_distributed_func_serialization_requirements.swift
+++ b/test/Distributed/distributed_protocols_distributed_func_serialization_requirements.swift
@@ -29,6 +29,41 @@ distributed actor SpecifyRequirement: NoSerializationRequirementYet {
   distributed func testAT() async throws -> NotCodable {
     .init()
   }
+
+}
+
+protocol ProtocolWithChecksSystem: DistributedActor
+  where ActorSystem == FakeActorSystem {
+  // expected-error@+1{{result type 'NotCodable' of distributed instance method 'testAT' does not conform to serialization requirement 'Codable'}}
+  distributed func testAT() async throws -> NotCodable
+}
+distributed actor ProtocolWithChecksSystemDA: ProtocolWithChecksSystem {
+  // expected-error@+1{{result type 'NotCodable' of distributed instance method 'testAT' does not conform to serialization requirement 'Codable'}}
+  distributed func testAT() async throws -> NotCodable { .init() }
+}
+
+protocol ProtocolWithChecksSeqReq: DistributedActor
+  where Self.SerializationRequirement == Codable {
+  // expected-error@+1{{result type 'NotCodable' of distributed instance method 'testAT' does not conform to serialization requirement 'Codable'}}
+  distributed func testAT() async throws -> NotCodable
+}
+distributed actor ProtocolWithChecksSeqReqDA_MissingSystem: ProtocolWithChecksSeqReq {
+  // expected-error@-1{{distributed actor 'ProtocolWithChecksSeqReqDA_MissingSystem' does not declare ActorSystem it can be used with.}}
+  // expected-note@-2{{you can provide a module-wide default actor system by declaring:}}
+  // expected-error@-3{{type 'ProtocolWithChecksSeqReqDA_MissingSystem' does not conform to protocol 'ProtocolWithChecksSeqReq'}}
+  //
+  // expected-error@-5{{distributed actor 'ProtocolWithChecksSeqReqDA_MissingSystem' does not declare ActorSystem it can be used with.}}
+
+  // Entire conformance is doomed, so we didn't proceed to checking the functions; that's fine
+  distributed func testAT() async throws -> NotCodable { .init() }
+}
+
+distributed actor ProtocolWithChecksSeqReqDA: ProtocolWithChecksSeqReq {
+  typealias ActorSystem = FakeActorSystem
+  // ok, since FakeActorSystem.SerializationRequirement == ProtocolWithChecksSeqReq.SerializationRequirement
+
+  // expected-error@+1{{result type 'NotCodable' of distributed instance method 'testAT' does not conform to serialization requirement 'Codable'}}
+  distributed func testAT() async throws -> NotCodable { .init() }
 }
 
 extension NoSerializationRequirementYet {

--- a/test/Distributed/distributed_protocols_distributed_func_serialization_requirements.swift
+++ b/test/Distributed/distributed_protocols_distributed_func_serialization_requirements.swift
@@ -10,8 +10,11 @@ import FakeDistributedActorSystems
 struct NotCodable {}
 
 protocol NoSerializationRequirementYet: DistributedActor {
+  distributed func test() -> NotCodable // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
+  // expected-error@-1{{'distributed' protocol requirement 'test()' must currently be declared explicitly 'async throws'}}
+
   // OK, no serialization requirement yet
-  distributed func test() -> NotCodable
+  distributed func testAT() async throws -> NotCodable
 }
 
 distributed actor SpecifyRequirement: NoSerializationRequirementYet {
@@ -22,6 +25,10 @@ distributed actor SpecifyRequirement: NoSerializationRequirementYet {
     .init()
   }
 
+  // expected-error@+1{{result type 'NotCodable' of distributed instance method 'testAT' does not conform to serialization requirement 'Codable'}}
+  distributed func testAT() async throws -> NotCodable {
+    .init()
+  }
 }
 
 extension NoSerializationRequirementYet {

--- a/test/decl/protocol/special/DistributedActor.swift
+++ b/test/decl/protocol/special/DistributedActor.swift
@@ -64,8 +64,9 @@ distributed actor D4 {
 }
 
 protocol P1: DistributedActor {
-  distributed func dist() -> String
-  // expected-note@-1{{'dist()' declared here}}
+  distributed func dist() -> String // FIXME(distributed): rdar://95949498 currently we are limited to explicitly 'async throws' protocol requirements that are distributed funcs
+  // expected-error@-1{{'distributed' protocol requirement 'dist()' must currently be declared explicitly 'async throws'}}
+  // expected-note@-2{{'dist()' declared here}}
 }
 
 distributed actor D5: P1 {


### PR DESCRIPTION
**Description:** Implements computed distributed get-only properties using a special accessor implementation approach. This implements a missing piece of the distributed feature, by @xedin 
**Risk:** Low, unlocks missing functionality and does not affect existing code.
**Review by:** @DougGregor 
**Testing:** PR testing on CI
**Original PR:** https://github.com/apple/swift/pull/59700
**Radar:** rdar://91283164

Depends on #59736 for a clean cherry pick; 
Let's first merge https://github.com/apple/swift/pull/59736 which also has addressed the comments by now, and then this and it'll apply cleanly 👍 