### PR TITLE
[5.7] Retract ~= for regex.

### DIFF
--- a/test/StringProcessing/Parse/forward-slash-regex.swift
+++ b/test/StringProcessing/Parse/forward-slash-regex.swift
@@ -253,8 +253,6 @@ _ = 0. / 1 / 2 // expected-error {{expected member name following '.'}}
 _ = 0 . / 1 / 2 // expected-error {{expected member name following '.'}}
 
 switch "" {
-case /x/:
-  break
 case _ where /x/:
   // expected-error@-1 {{cannot convert value of type 'Regex<Substring>' to expected condition type 'Bool'}}
   break


### PR DESCRIPTION
We'd like to provide this, but we haven't been able to reach agreement on what the semantics actually ought to be. The original version used wholeMatch; contains is arguably more flexible, but feels less natural when compared to how ~= is used for other types in the language.
    
Additionally, we'd like to investigate the possibility of using named captures to effect bindings in case statements in the future, and we don't want to wall ourselves off from that until we've had time to think about it some more.
