### PR TITLE
[5.7][LangOptions] Remove the option to enable/disable implicit existential opening.

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -334,10 +334,6 @@ namespace swift {
     /// `func f() -> <T> T`.
     bool EnableExperimentalNamedOpaqueTypes = false;
 
-    /// Enable support for implicitly opening existential argument types
-    /// in calls to generic functions.
-    bool EnableOpenedExistentialTypes = false;
-
     /// Enable experimental flow-sensitive concurrent captures.
     bool EnableExperimentalFlowSensitiveConcurrentCaptures = false;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -456,11 +456,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableExperimentalNamedOpaqueTypes |=
       Args.hasArg(OPT_enable_experimental_named_opaque_types);
 
-  Opts.EnableOpenedExistentialTypes =
-    Args.hasFlag(OPT_enable_experimental_opened_existential_types,
-                 OPT_disable_experimental_opened_existential_types,
-                 true);
-
   Opts.EnableExperimentalVariadicGenerics |=
     Args.hasArg(OPT_enable_experimental_variadic_generics);
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1519,10 +1519,6 @@ shouldOpenExistentialCallArgument(
   if (isa_and_nonnull<clang::FunctionTemplateDecl>(callee->getClangDecl()))
     return None;
 
-  ASTContext &ctx = callee->getASTContext();
-  if (!ctx.LangOpts.EnableOpenedExistentialTypes)
-    return None;
-
   // The actual parameter type needs to involve a type variable, otherwise
   // type inference won't be possible.
   if (!paramTy->hasTypeVariable())

--- a/lib/Sema/TypeCheckCodeCompletion.cpp
+++ b/lib/Sema/TypeCheckCodeCompletion.cpp
@@ -486,6 +486,11 @@ TypeChecker::getTypeOfCompletionOperator(DeclContext *DC, Expr *LHS,
   // Build temporary expression to typecheck.
   // We allocate these expressions on the stack because we know they can't
   // escape and there isn't a better way to allocate scratch Expr nodes.
+
+  // Use a placeholder expr for the LHS argument to avoid sending
+  // a pre-type-checked AST through the constraint system.
+  OpaqueValueExpr argExpr(LHS->getSourceRange(), LHSTy,
+                          /*isPlaceholder=*/true);
   UnresolvedDeclRefExpr UDRE(DeclNameRef(opName), refKind, DeclNameLoc(Loc));
   auto *opExpr = TypeChecker::resolveDeclRefExpr(
       &UDRE, DC, /*replaceInvalidRefsWithErrors=*/true);
@@ -497,7 +502,7 @@ TypeChecker::getTypeOfCompletionOperator(DeclContext *DC, Expr *LHS,
     //   (declref_expr name=<opName>)
     //   (argument_list
     //     (<LHS>)))
-    auto *postfixExpr = PostfixUnaryExpr::create(ctx, opExpr, LHS);
+    auto *postfixExpr = PostfixUnaryExpr::create(ctx, opExpr, &argExpr);
     return getTypeOfCompletionOperatorImpl(DC, postfixExpr, referencedDecl);
   }
 
@@ -508,7 +513,7 @@ TypeChecker::getTypeOfCompletionOperator(DeclContext *DC, Expr *LHS,
     //     (<LHS>)
     //     (code_completion_expr)))
     CodeCompletionExpr dummyRHS(Loc);
-    auto *binaryExpr = BinaryExpr::create(ctx, LHS, opExpr, &dummyRHS,
+    auto *binaryExpr = BinaryExpr::create(ctx, &argExpr, opExpr, &dummyRHS,
                                           /*implicit*/ true);
     return getTypeOfCompletionOperatorImpl(DC, binaryExpr, referencedDecl);
   }

--- a/test/Constraints/openExistential.swift
+++ b/test/Constraints/openExistential.swift
@@ -1,5 +1,4 @@
 // RUN: %target-typecheck-verify-swift
-// RUN: %target-typecheck-verify-swift -enable-experimental-opened-existential-types
 
 protocol P { }
 

--- a/test/Constraints/opened_existentials.swift
+++ b/test/Constraints/opened_existentials.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-opened-existential-types
+// RUN: %target-typecheck-verify-swift
 
 protocol Q { }
 

--- a/test/Constraints/opened_existentials_suppression.swift
+++ b/test/Constraints/opened_existentials_suppression.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-opened-existential-types -typecheck -dump-ast -parse-as-library %s | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -dump-ast -parse-as-library %s | %FileCheck %s
 
 protocol P { }
 extension Optional: P where Wrapped: P { }

--- a/test/Constraints/result_builder_availability.swift
+++ b/test/Constraints/result_builder_availability.swift
@@ -1,5 +1,4 @@
 // RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.50
-// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.50 -enable-experimental-opened-existential-types
 
 // REQUIRES: OS=macosx
 

--- a/test/Generics/existential_restrictions.swift
+++ b/test/Generics/existential_restrictions.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-objc-interop -disable-experimental-opened-existential-types
+// RUN: %target-typecheck-verify-swift -enable-objc-interop
 
 protocol P { }
 @objc protocol OP { }
@@ -8,14 +8,14 @@ protocol CP : class { }
   static func createNewOne() -> SP
 }
 
-func fP<T : P>(_ t: T) { }
+func fP<T : P>(_ t: T?) { }
 // expected-note@-1 {{required by global function 'fP' where 'T' = 'any P'}}
 // expected-note@-2 {{required by global function 'fP' where 'T' = 'any OP & P'}}
-func fOP<T : OP>(_ t: T) { }
+func fOP<T : OP>(_ t: T?) { }
 // expected-note@-1 {{required by global function 'fOP' where 'T' = 'any OP & P'}}
 func fOPE(_ t: OP) { }
-func fSP<T : SP>(_ t: T) { }
-func fAO<T : AnyObject>(_ t: T) { }
+func fSP<T : SP>(_ t: T?) { }
+func fAO<T : AnyObject>(_ t: T?) { }
 // expected-note@-1 {{where 'T' = 'any P'}}
 // expected-note@-2 {{where 'T' = 'any CP'}}
 // expected-note@-3 {{where 'T' = 'any OP & P'}}

--- a/test/Interop/Cxx/templates/function-template.swift
+++ b/test/Interop/Cxx/templates/function-template.swift
@@ -1,5 +1,4 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop)
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-cxx-interop -Xfrontend -enable-experimental-opened-existential-types)
 //
 // REQUIRES: executable_test
 

--- a/test/SILGen/opened_existentials.swift
+++ b/test/SILGen/opened_existentials.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-experimental-opened-existential-types %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 public protocol P { }
 


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/59740

* **Explanation**: This feature has been accepted in Swift evolution, so there's no need to have a flag to enable/disable it. This fixes an issue where the feature was not enabled by default in LLDB, because the flag was enabled in `CompilerInvocation.cpp`, but LLDB creates a `LangOptions` instance directly. This change also uses opaque value placeholders where code completion was previously sending a pre-type-checked AST through the constraint system, which tripped an assertion during `shouldOpenExistentialCallArgument` when looking up types for AST nodes that should have been cached in the constraint system.
* **Scope**: This only affects the behavior of argument-to-parameter matching between existential types and type parameters in tools where the feature was previously disabled by default, including LLDB. As the feature is source compatible, this should only allow more code to compile through those tools.
* **Risk**: Low.
* **Testing**: Updated test suite to remove use of the flags.
* **Reviewer**: @xedin 

Resolves: rdar://94730905