### PR TITLE
SIL: Allow missing Sendable conformances when building abstraction pattern for function type lowering.

### DIFF
--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -1813,7 +1813,8 @@ const {
       if (conformingReplacementType->isTypeParameter())
         return ProtocolConformanceRef(conformedProtocol);
     
-      return TC.M.lookupConformance(conformingReplacementType, conformedProtocol);
+      return TC.M.lookupConformance(conformingReplacementType, conformedProtocol,
+                                    /*allowMissing*/ true);
     });
 
   auto yieldType = visitor.substYieldType;

--- a/test/SILGen/subst_function_type_missing_sendable.swift
+++ b/test/SILGen/subst_function_type_missing_sendable.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-emit-silgen -warn-concurrency %s
+
+protocol ServerStream {}
+protocol Message {}
+
+struct RPCServerHandlerContext {}
+struct RPCRequestStream<Request: Sendable> {}
+struct RPCResponseStream<Response: Sendable> {}
+
+final class RPCServerHandler<Stream: ServerStream, Request: Message, Response: Message> {
+    /// The actual user function. We are using a bi-directional function shape here and will map the other shapes into this one.
+    private let userFunction: (
+        RPCServerHandlerContext,
+        RPCRequestStream<Request>,
+        RPCResponseStream<Response>
+    ) async throws -> Void
+
+    init(
+        userFunction: @escaping @Sendable (
+            RPCServerHandlerContext,
+            RPCRequestStream<Request>,
+            RPCResponseStream<Response>
+        ) async throws -> Void
+    ) {
+        self.userFunction = userFunction
+    }
+}


### PR DESCRIPTION
Fixes rdar://95979338.