### PR TITLE
[ConstraintSystem] Remove `ConstraintSystemFlags::ReusePrecheckedType`.

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1530,10 +1530,6 @@ enum class ConstraintSystemFlags {
   /// left in-tact.
   AllowUnresolvedTypeVariables = 0x04,
 
-  /// If set, constraint system always reuses type of pre-typechecked
-  /// expression, and doesn't dig into its subexpressions.
-  ReusePrecheckedType = 0x08,
-
   /// If set, verbose output is enabled for this constraint system.
   ///
   /// Note that this flag is automatically applied to all constraint systems,
@@ -1542,16 +1538,16 @@ enum class ConstraintSystemFlags {
   /// \c DebugConstraintSolverAttempt. Finally, it can also be automatically
   /// enabled for a pre-configured set of expressions on line numbers by setting
   /// \c DebugConstraintSolverOnLines.
-  DebugConstraints = 0x10,
+  DebugConstraints = 0x08,
 
   /// Don't try to type check closure bodies, and leave them unchecked. This is
   /// used for source tooling functionalities.
-  LeaveClosureBodyUnchecked = 0x20,
+  LeaveClosureBodyUnchecked = 0x10,
 
   /// If set, we are solving specifically to determine the type of a
   /// CodeCompletionExpr, and should continue in the presence of errors wherever
   /// possible.
-  ForCodeCompletion = 0x40,
+  ForCodeCompletion = 0x20,
 
   /// Include Clang function types when checking equality for function types.
   ///
@@ -1562,10 +1558,10 @@ enum class ConstraintSystemFlags {
   /// should be treated as semantically different, as they may have different
   /// calling conventions, say due to Clang attributes such as
   /// `__attribute__((ns_consumed))`.
-  UseClangFunctionTypes = 0x80,
+  UseClangFunctionTypes = 0x40,
 
   /// When set, ignore async/sync mismatches
-  IgnoreAsyncSyncMismatch = 0x100,
+  IgnoreAsyncSyncMismatch = 0x80,
 };
 
 /// Options that affect the constraint system as a whole.
@@ -3790,10 +3786,6 @@ public:
 
   bool shouldSuppressDiagnostics() const {
     return Options.contains(ConstraintSystemFlags::SuppressDiagnostics);
-  }
-
-  bool shouldReusePrecheckedType() const {
-    return Options.contains(ConstraintSystemFlags::ReusePrecheckedType);
   }
 
   /// Whether we are solving to determine the possible types of a

--- a/lib/Sema/TypeCheckCodeCompletion.cpp
+++ b/lib/Sema/TypeCheckCodeCompletion.cpp
@@ -109,13 +109,11 @@ namespace {
 /// FIXME: Remove this.
 class SanitizeExpr : public ASTWalker {
   ASTContext &C;
-  bool ShouldReusePrecheckedType;
   llvm::SmallDenseMap<OpaqueValueExpr *, Expr *, 4> OpenExistentials;
 
 public:
-  SanitizeExpr(ASTContext &C,
-               bool shouldReusePrecheckedType)
-    : C(C), ShouldReusePrecheckedType(shouldReusePrecheckedType) { }
+  SanitizeExpr(ASTContext &C)
+    : C(C) { }
 
   std::pair<bool, ArgumentList *>
   walkToArgumentListPre(ArgumentList *argList) override {
@@ -126,12 +124,6 @@ public:
 
   std::pair<bool, Expr *> walkToExprPre(Expr *expr) override {
     while (true) {
-
-      // If we should reuse pre-checked types, don't sanitize the expression
-      // if it's already type-checked.
-      if (ShouldReusePrecheckedType && expr->getType())
-        return { false, expr };
-
       // OpenExistentialExpr contains OpaqueValueExpr in its sub expression.
       if (auto OOE = dyn_cast<OpenExistentialExpr>(expr)) {
         auto archetypeVal = OOE->getOpaqueValue();
@@ -301,8 +293,7 @@ getTypeOfExpressionWithoutApplying(Expr *&expr, DeclContext *dc,
                                  FreeTypeVariableBinding allowFreeTypeVariables) {
   auto &Context = dc->getASTContext();
 
-  expr = expr->walk(SanitizeExpr(Context,
-                                 /*shouldReusePrecheckedType=*/false));
+  expr = expr->walk(SanitizeExpr(Context));
 
   FrontendStatsTracer StatsTracer(Context.Stats,
                                   "typecheck-expr-no-apply", expr);
@@ -400,8 +391,7 @@ getTypeOfCompletionOperatorImpl(DeclContext *DC, Expr *expr,
                                   "typecheck-completion-operator", expr);
   PrettyStackTraceExpr stackTrace(Context, "type-checking", expr);
 
-  expr = expr->walk(SanitizeExpr(Context,
-                                 /*shouldReusePrecheckedType=*/false));
+  expr = expr->walk(SanitizeExpr(Context));
 
   ConstraintSystemOptions options;
   options |= ConstraintSystemFlags::SuppressDiagnostics;
@@ -576,8 +566,7 @@ bool TypeChecker::typeCheckForCodeCompletion(
     return false;
 
   if (auto *expr = getAsExpr(node)) {
-    node = expr->walk(SanitizeExpr(Context,
-                                   /*shouldReusePrecheckedType=*/false));
+    node = expr->walk(SanitizeExpr(Context));
   }
 
   CompletionContextFinder contextAnalyzer(node, DC);
@@ -773,7 +762,7 @@ swift::getTypeOfCompletionOperator(DeclContext *DC, Expr *LHS,
 bool swift::typeCheckExpression(DeclContext *DC, Expr *&parsedExpr) {
   auto &ctx = DC->getASTContext();
 
-  parsedExpr = parsedExpr->walk(SanitizeExpr(ctx, /*shouldReusePrecheckedType=*/false));
+  parsedExpr = parsedExpr->walk(SanitizeExpr(ctx));
 
   DiagnosticSuppression suppression(ctx.Diags);
   auto resultTy = TypeChecker::typeCheckExpression(

--- a/lib/Sema/TypeCheckCodeCompletion.cpp
+++ b/lib/Sema/TypeCheckCodeCompletion.cpp
@@ -401,11 +401,10 @@ getTypeOfCompletionOperatorImpl(DeclContext *DC, Expr *expr,
   PrettyStackTraceExpr stackTrace(Context, "type-checking", expr);
 
   expr = expr->walk(SanitizeExpr(Context,
-                                 /*shouldReusePrecheckedType=*/true));
+                                 /*shouldReusePrecheckedType=*/false));
 
   ConstraintSystemOptions options;
   options |= ConstraintSystemFlags::SuppressDiagnostics;
-  options |= ConstraintSystemFlags::ReusePrecheckedType;
   options |= ConstraintSystemFlags::LeaveClosureBodyUnchecked;
 
   // Construct a constraint system from this expression.


### PR DESCRIPTION
This change removes the last use of `ConstraintSystemFlags::ReusePrecheckedType` in operator code completion, and removes the option altogether from the constraint system.

Now that operator code completion uses an opaque value placeholder with the pre-checked type, code completion no longer needs to send a type checked AST through the constraint system, which was very brittle. Opaque value placeholder expressions were designed to be used as a placeholder for a fully type checked expression, making this a better approach for code completion paths that haven't yet been ported to solver-based completion.