### PR TITLE
Zero trailing bytes of SmallStrings more efficiently

### DIFF
--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -248,27 +248,27 @@ extension _SmallString {
       self = _SmallString()
       return
     }
-    zeroTrailingBytes(of: &_storage, from: len)
+    _zeroTrailingBytes(of: &_storage, from: len)
     self = _SmallString(leading: _storage.0, trailing: _storage.1, count: len)
   }
 }
 
 @inlinable @inline(__always)
-internal func zeroTrailingBytes(
-  of storage: inout _SmallString.RawBitPattern, from len: Int
+internal func _zeroTrailingBytes(
+  of storage: inout _SmallString.RawBitPattern, from index: Int
 ) {
-  _internalInvariant(len > 0)
-  _internalInvariant(len <= _SmallString.capacity)
-  if len <= 0 {
+  _internalInvariant(index > 0)
+  _internalInvariant(index <= _SmallString.capacity)
+  if index <= 0 {
     storage.0 = 0
     storage.1 = 0
-  } else if len <= 8 {
-    let mask0 = (UInt64(bitPattern: ~0) &>> (8 &* (8 &- len)))
+  } else if index <= 8 {
+    let mask0 = (UInt64(bitPattern: ~0) &>> (8 &* (8 &- index)))
     //FIXME: Verify this on big-endian architecture
     storage.0 &= mask0.littleEndian
     storage.1 = 0
   } else {
-    let mask1 = (UInt64(bitPattern: ~0) &>> (8 &* (16 &- len)))
+    let mask1 = (UInt64(bitPattern: ~0) &>> (8 &* (16 &- index)))
     //FIXME: Verify this on big-endian architecture
     storage.1 &= mask1.littleEndian
   }

--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -253,15 +253,10 @@ extension _SmallString {
       _internalInvariant(len <= _SmallString.capacity)
       
       self._storage = (0, 0)
-      withUnsafeMutableBytes(of: &self._storage) { storagePtr in
-        var i = 0
-        while i < len {
-          storagePtr.storeBytes(
-            of: rawBufPtr.load(fromByteOffset: i, as: UInt8.self),
-            as: UInt8.self
-          )
-          i &+= 1
-        }
+      withUnsafeMutablePointer(to: &self._storage) {
+        UnsafeMutableRawPointer($0).copyMemory(
+          from: rawBufPtr.baseAddress!, byteCount: len
+        )
       }
       return len
     }

--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -244,9 +244,9 @@ extension _SmallString {
     var tmp = self._storage
     let len = try withUnsafeMutableBytes(of: &tmp) {
       (rawBufPtr: UnsafeMutableRawBufferPointer) -> Int in
-      var len = try f(rawBufPtr)
+      let len = try f(rawBufPtr)
       
-      if len == 0 {
+      if len <= 0 {
         return 0
       }
       
@@ -261,7 +261,7 @@ extension _SmallString {
       }
       return len
     }
-
+    
     if len == 0 {
       self = _SmallString()
       return

--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -244,6 +244,7 @@ extension _SmallString {
     let len = try withUnsafeMutableBytes(of: &_storage, f)
 
     if len <= 0 {
+      _debugPrecondition(len == 0)
       self = _SmallString()
       return
     }

--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -245,11 +245,11 @@ extension _SmallString {
     let len = try withUnsafeMutableBytes(of: &tmp) {
       (rawBufPtr: UnsafeMutableRawBufferPointer) -> Int in
       let len = try f(rawBufPtr)
-      
+
       if len <= 0 {
         return 0
       }
-      
+
       _internalInvariant(len <= _SmallString.capacity)
       
       self._storage = (0, 0)
@@ -261,12 +261,12 @@ extension _SmallString {
       }
       return len
     }
-    
+
     if len == 0 {
       self = _SmallString()
       return
     }
-    
+
     let (leading, trailing) = self.zeroTerminatedRawCodeUnits
     self = _SmallString(leading: leading, trailing: trailing, count: len)
   }

--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -245,7 +245,7 @@ extension _SmallString {
       (rawBufPtr: UnsafeMutableRawBufferPointer) -> Int in
       let len = try f(rawBufPtr)
       UnsafeMutableRawBufferPointer(
-        rebasing: rawBufPtr[len...]
+        rebasing: rawBufPtr[len..<rawBufPtr.endIndex]
       ).initializeMemory(as: UInt8.self, repeating: 0)
       return len
     }

--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -255,7 +255,8 @@ extension _SmallString {
       self._storage = (0, 0)
       withUnsafeMutablePointer(to: &self._storage) {
         UnsafeMutableRawPointer($0).copyMemory(
-          from: rawBufPtr.baseAddress!, byteCount: len
+          from: rawBufPtr.baseAddress._unsafelyUnwrappedUnchecked,
+          byteCount: len
         )
       }
       return len

--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -263,10 +263,14 @@ internal func zeroTrailingBytes(
     storage.0 = 0
     storage.1 = 0
   } else if len <= 8 {
-    storage.0 &= ((~0) &>> (8 &* (8 &- len)))
+    let mask0 = (UInt64(bitPattern: ~0) &>> (8 &* (8 &- len)))
+    //FIXME: Verify this on big-endian architecture
+    storage.0 &= mask0.littleEndian
     storage.1 = 0
   } else {
-    storage.1 &= ((~0) &>> (8 &* (16 &- len)))
+    let mask1 = (UInt64(bitPattern: ~0) &>> (8 &* (16 &- len)))
+    //FIXME: Verify this on big-endian architecture
+    storage.1 &= mask1.littleEndian
   }
 }
 

--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -253,8 +253,8 @@ extension _SmallString {
   }
 }
 
-@inline(__always)
-private func zeroTrailingBytes(
+@inlinable @inline(__always)
+internal func zeroTrailingBytes(
   of storage: inout _SmallString.RawBitPattern, from len: Int
 ) {
   _internalInvariant(len > 0)

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -2347,4 +2347,26 @@ if #available(SwiftStdlib 5.6, *) {
   }
 }
 
+StringTests.test("SmallString.zeroTrailingBytes") {
+  if #available(SwiftStdlib 5.8, *) {
+    let full: _SmallString.RawBitPattern = (.max, .max)
+    withUnsafeBytes(of: full) {
+      expectTrue($0.allSatisfy({ $0 == 0xff }))
+    }
+
+    let testIndices = [1, 7, 8, _SmallString.capacity]
+    for i in testIndices {
+      // The internal invariants in `zeroTrailingBytes(of:from:)`
+      expectTrue(0 < i && i <= _SmallString.capacity)
+      var bits = full
+      zeroTrailingBytes(of: &bits, from: i)
+      withUnsafeBytes(of: bits) {
+        expectTrue($0[..<i].allSatisfy({ $0 == 0xff }))
+        expectTrue($0[i...].allSatisfy({ $0 == 0 }))
+      }
+      bits = (0, 0)
+    }
+  }
+}
+
 runAllTests()

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -2356,10 +2356,10 @@ StringTests.test("SmallString.zeroTrailingBytes") {
 
     let testIndices = [1, 7, 8, _SmallString.capacity]
     for i in testIndices {
-      // The internal invariants in `zeroTrailingBytes(of:from:)`
+      // The internal invariants in `_zeroTrailingBytes(of:from:)`
       expectTrue(0 < i && i <= _SmallString.capacity)
       var bits = full
-      zeroTrailingBytes(of: &bits, from: i)
+      _zeroTrailingBytes(of: &bits, from: i)
       withUnsafeBytes(of: bits) {
         expectTrue($0[..<i].allSatisfy({ $0 == 0xff }))
         expectTrue($0[i...].allSatisfy({ $0 == 0 }))

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -2358,8 +2358,9 @@ StringTests.test("SmallString.zeroTrailingBytes") {
     for i in testIndices {
       // The internal invariants in `_zeroTrailingBytes(of:from:)`
       expectTrue(0 < i && i <= _SmallString.capacity)
+      print(i)
       var bits = full
-      _zeroTrailingBytes(of: &bits, from: i)
+      _SmallString.zeroTrailingBytes(of: &bits, from: i)
       withUnsafeBytes(of: bits) {
         expectTrue($0[..<i].allSatisfy({ $0 == 0xff }))
         expectTrue($0[i...].allSatisfy({ $0 == 0 }))


### PR DESCRIPTION
Implementation improvements to `_SmallString.withMutableCapacity(_:)` to improve inlinability, code size and performance.

Addresses rdar://96177723.