### PR TITLE
[5.7][Swift Static Mirror] When resolving an external type's conformance, report the underlying type's mangled name

### DIFF
--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -1352,16 +1352,24 @@ private:
           (const char *)contextDescriptorFieldAddress,
           *contextDescriptorOffset);
 
-      // Instead of a type descriptor this may just be a symbol reference, check that first
+      // Instead of a type descriptor this may just be a reference to an external, check that first
       if (auto symbol = OpaqueDynamicSymbolResolver(remote::RemoteAddress(contextTypeDescriptorAddress))) {
         if (!symbol->isResolved()) {
-          mangledTypeName = symbol->getSymbol().str();
           Demangle::Context Ctx;
           auto demangledRoot =
-              Ctx.demangleSymbolAsNode(mangledTypeName);
+            Ctx.demangleSymbolAsNode(symbol->getSymbol().str());
           assert(demangledRoot->getKind() == Node::Kind::Global);
-          typeName =
-              nodeToString(demangledRoot->getChild(0)->getChild(0));
+          auto nomTypeDescriptorRoot = demangledRoot->getChild(0);
+          assert(nomTypeDescriptorRoot->getKind() == Node::Kind::NominalTypeDescriptor);
+          auto typeRoot = nomTypeDescriptorRoot->getChild(0);
+          typeName = nodeToString(typeRoot);
+
+          auto typeMangling = Demangle::mangleNode(typeRoot);
+          if (!typeMangling.isSuccess())
+            mangledTypeName = "";
+          else
+            mangledTypeName = typeMangling.result();
+
           return std::make_pair(mangledTypeName, typeName);
         } else if (symbol->getOffset()) {
           // If symbol is empty and has an offset, this is the resolved remote address

--- a/test/Reflection/conformance_descriptors_of_external_types.swift
+++ b/test/Reflection/conformance_descriptors_of_external_types.swift
@@ -26,4 +26,4 @@ extension testModAClass : myTestProto {}
 // CHECK: CONFORMANCES:
 // CHECK: =============
 // CHECK-DAG:  (__C.testModAClass) : ExternalConformanceCheck.myTestProto
-// CHECK-DAG: _$s8testModB0aB7BStructVMn (testModB.testModBStruct) : ExternalConformanceCheck.myTestProto
+// CHECK-DAG: 8testModB0aB7BStructV (testModB.testModBStruct) : ExternalConformanceCheck.myTestProto


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/59822
---------------------------------------------------------------------
Instead of the mangled name of the nominal type descriptor.

Resolves rdar://95990054
