### PR TITLE
Inconvenienced actors, continued

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3569,7 +3569,7 @@ ERROR(designated_init_in_extension,none,
       "designated initializer cannot be declared in an extension of %0; "
       "did you mean this to be a convenience initializer?",
       (DeclName))
-ERROR(cfclass_designated_init_in_extension,none,
+ERROR(designated_init_in_extension_no_convenience_tip,none,
       "designated initializer cannot be declared in an extension of %0",
       (DeclName))
 ERROR(no_convenience_keyword_init,none,

--- a/test/Concurrency/Runtime/Inputs/MysteryInit.swift
+++ b/test/Concurrency/Runtime/Inputs/MysteryInit.swift
@@ -1,19 +1,43 @@
+import Foundation
 
 // This input is useful to ensure the delegation status of
 // an actor's initializer does not affect ABI stability
-public actor BigFoot {
 
-  public let name: String
+public protocol NamedEntity: Actor {
+  nonisolated var name: String? { get }
+}
+
+public actor BigFoot: NamedEntity {
+
+  public nonisolated let name: String?
 
   private init(withName name: String) {
     self.name = name
   }
 
-  public init?() {
+  public init() {
   #if DELEGATES
     self.init(withName: "Sasquatch")
   #else
-    return nil
+    self.name = nil
+  #endif
+  }
+}
+
+
+@objc public actor BigFootObjC: NSObject, NamedEntity {
+
+  public nonisolated let name: String?
+
+  private init(withName name: String) {
+    self.name = name
+  }
+
+  @objc public override init() {
+  #if DELEGATES
+    self.init(withName: "Sasquatch")
+  #else
+    self.name = nil
   #endif
   }
 }

--- a/test/Concurrency/Runtime/actor_init_abi.swift
+++ b/test/Concurrency/Runtime/actor_init_abi.swift
@@ -47,6 +47,7 @@
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
+// REQUIRES: objc_interop
 
 // rdar://76038845
 // REQUIRES: concurrency_runtime
@@ -54,16 +55,30 @@
 
 import MysteryInit
 
-@main
-struct Main {
-  static func main() {
-    switch BigFoot() {
+// NOTE: the number of myth/real checks in this function (in either mode) should
+// match the number of times `test` is called. The -NOT check is there to catch
+// any mistakes in updating the test.
+func test(_ bigFoot: any NamedEntity) {
+  switch bigFoot.name {
     case .none:
       print("bigfoot is myth")
       // CHECK-NO-DELEGATES: bigfoot is myth
+      // CHECK-NO-DELEGATES: bigfoot is myth
+
+      // CHECK-NO-DELEGATES-NOT: bigfoot
     default:
       print("bigfoot is real")
       // CHECK-DELEGATES: bigfoot is real
+      // CHECK-DELEGATES: bigfoot is real
+
+      // CHECK-DELEGATES-NOT: bigfoot
     }
+}
+
+@main
+struct Main {
+  static func main() {
+    test(BigFoot())
+    test(BigFootObjC())
   }
 }

--- a/test/decl/class/actor/basic.swift
+++ b/test/decl/class/actor/basic.swift
@@ -46,4 +46,10 @@ extension A2 {
 
   class subscript(i: Int) -> Int { i } // expected-error{{class subscripts are only allowed within classes; use 'static' to declare a static subscript}}
   static subscript(s: String) -> String { s }
+
+  init(delegates: ()) {
+    self.init()
+  }
+
+  init(doesNotDelegate: ()) {} // expected-error {{designated initializer cannot be declared in an extension of 'A2'}}
 }

--- a/test/decl/class/actor/initializers.swift
+++ b/test/decl/class/actor/initializers.swift
@@ -1,0 +1,36 @@
+// RUN: %target-swift-frontend -swift-version 5 -disable-availability-checking -emit-sil -verify %s
+
+// check the initializer kinds for protocols and their extensions
+
+protocol GoodActor {
+  init()
+  init(with: Int)
+}
+
+extension GoodActor {
+  init() {
+    self.init(with: 0)
+  }
+
+  init(with: Int) {} // expected-error {{'self.init' isn't called on all paths before returning from initializer}}
+}
+
+actor Myself: GoodActor {
+  var x: Int
+
+  init(with val: Int) {
+    self.x = val
+  }
+}
+
+actor SomebodyElse: GoodActor {
+  var x: Int
+
+  init(with val: Int) {
+    self.x = val
+  }
+
+  init() {
+    self.x = 0
+  }
+}


### PR DESCRIPTION
CI auto-merged https://github.com/apple/swift/pull/41083 before it was completely ready. I thought force-pushing a commit would cancel the auto-merge but it didn't 🤷🏼 

This PR adds some fixes and more testing to that PR. Namely, that PR allowed designated inits in extensions of actors, but that's not resilient in general. So this PR goes and re-bans that capability.