### PR TITLE
[SE-0361] Enable bound generic extensions.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1907,9 +1907,6 @@ ERROR(extension_access_with_conformances,none,
       "protocol conformances", (DeclAttribute))
 ERROR(extension_metatype,none,
       "cannot extend a metatype %0", (Type))
-ERROR(extension_specialization,none,
-      "constrained extension must be declared on the unspecialized generic "
-      "type %0 with constraints specified by a 'where' clause", (Identifier))
 ERROR(extension_placeholder,none,
       "cannot extend a type that contains placeholders", ())
 ERROR(extension_stored_property,none,

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -101,13 +101,6 @@ EXPERIMENTAL_FEATURE(MoveOnly)
 EXPERIMENTAL_FEATURE(OneWayClosureParameters)
 EXPERIMENTAL_FEATURE(TypeWitnessSystemInference)
 
-/// Enable extensions of (sugared) bound generic types
-///
-/// \code
-/// extension [Int] { /**/ }
-/// \endcode
-EXPERIMENTAL_FEATURE(BoundGenericExtensions)
-
 /// Whether to enable experimental differentiable programming features:
 /// `@differentiable` declaration attribute, etc.
 EXPERIMENTAL_FEATURE(DifferentiableProgramming)

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -317,10 +317,6 @@ def enable_resilience : Flag<["-"], "enable-resilience">,
 def enable_experimental_async_top_level :
   Flag<["-"], "enable-experimental-async-top-level">,
   HelpText<"Enable experimental concurrency in top-level code">;
-
-def enable_experimental_bound_generic_extensions :
-  Flag<["-"], "enable-experimental-bound-generic-extensions">,
-  HelpText<"Enable experimental support for extensions of bound generic types">;
 }
 
 // HIDDEN FLAGS

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3035,10 +3035,6 @@ static bool usesFeatureTypeWitnessSystemInference(Decl *decl) {
   return false;
 }
 
-static bool usesFeatureBoundGenericExtensions(Decl *decl) {
-  return false;
-}
-
 static bool usesFeatureDifferentiableProgramming(Decl *decl) {
   return false;
 }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -656,8 +656,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     Opts.Features.insert(Feature::OneWayClosureParameters);
   if (Args.hasArg(OPT_enable_experimental_associated_type_inference))
     Opts.Features.insert(Feature::TypeWitnessSystemInference);
-  if (Args.hasArg(OPT_enable_experimental_bound_generic_extensions))
-    Opts.Features.insert(Feature::BoundGenericExtensions);
   if (Args.hasArg(OPT_enable_experimental_forward_mode_differentiation))
     Opts.Features.insert(Feature::ForwardModeDifferentiation);
   if (Args.hasArg(OPT_enable_experimental_additive_arithmetic_derivation))

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2846,17 +2846,5 @@ ExtendedTypeRequest::evaluate(Evaluator &eval, ExtensionDecl *ext) const {
     return error();
   }
 
-  // By default, the user cannot extend a bound generic type, unless it's
-  // referenced via a non-generic typealias type.
-  if (!ext->getASTContext().LangOpts.hasFeature(
-          Feature::BoundGenericExtensions) &&
-      extendedType->isSpecialized() &&
-      !isNonGenericTypeAliasType(extendedType)) {
-    diags.diagnose(ext->getLoc(), diag::extension_specialization,
-                   extendedType->getAnyNominal()->getName())
-         .highlight(extendedRepr->getSourceRange());
-    return error();
-  }
-
   return extendedType;
 }

--- a/test/ModuleInterface/specialized-extension.swift
+++ b/test/ModuleInterface/specialized-extension.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name Test -enable-experimental-bound-generic-extensions
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name Test
 // RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name Test
 // RUN: %FileCheck %s < %t.swiftinterface
 

--- a/test/SILGen/mangling_specialized_extensions.swift
+++ b/test/SILGen/mangling_specialized_extensions.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-experimental-bound-generic-extensions %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 struct Tree<T> {
   struct Branch<B> {

--- a/test/decl/ext/extensions.swift
+++ b/test/decl/ext/extensions.swift
@@ -40,8 +40,6 @@ func nestingTest6() {
 extension Array {
   func foo() {
     extension Array { // expected-error {{declaration is only valid at file scope}}
-    // FIXME: Confusing error
-    // expected-error@-2 {{constrained extension must be declared on the unspecialized generic type 'Array' with constraints specified by a 'where' clause}}
     }
   }
 }
@@ -347,7 +345,8 @@ extension Tree.LimbContent.Contents {
 }
 
 extension Tree.BoughPayload.Contents {
- // expected-error@-1 {{constrained extension must be declared on the unspecialized generic type 'Nest'}}
+  // expected-error@-1 {{extension of type 'Tree.BoughPayload.Contents' (aka 'Nest<Int>') must be declared as an extension of 'Nest<Int>'}}
+  // expected-note@-2 {{did you mean to extend 'Nest<Int>' instead?}}
 }
 
 // SR-10466 Check 'where' clause when referencing type defined inside extension

--- a/test/decl/ext/generic.swift
+++ b/test/decl/ext/generic.swift
@@ -19,11 +19,9 @@ extension Double : P2 {
 }
 
 extension X<Int, Double, String> {
-// expected-error@-1{{constrained extension must be declared on the unspecialized generic type 'X' with constraints specified by a 'where' clause}}
   let x = 0
   // expected-error@-1 {{extensions must not contain stored properties}}
   static let x = 0
-  // expected-error@-1 {{static stored properties not supported in generic types}}
   func f() -> Int {}
   class C<T> {}
 }

--- a/test/decl/ext/specialize.swift
+++ b/test/decl/ext/specialize.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-bound-generic-extensions
+// RUN: %target-typecheck-verify-swift
 
 extension Array<Int> {
   func someIntFuncOnArray() {}

--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -307,9 +307,9 @@ func takesSugaredType2(m: GenericClass<Int>.TA<Float>) {
 extension A {}
 
 extension A<T> {}  // expected-error {{generic type 'A' specialized with too few type parameters (got 1, but expected 2)}}
-extension A<Float,Int> {}  // expected-error {{constrained extension must be declared on the unspecialized generic type 'MyType' with constraints specified by a 'where' clause}}
+extension A<Float,Int> {}
 extension C<T> {}  // expected-error {{cannot find type 'T' in scope}}
-extension C<Int> {}  // expected-error {{constrained extension must be declared on the unspecialized generic type 'MyType' with constraints specified by a 'where' clause}}
+extension C<Int> {}
 
 
 protocol ErrorQ {


### PR DESCRIPTION
Enables [SE-0361: Bound generic extensions](https://github.com/apple/swift-evolution/blob/main/proposals/0361-bound-generic-extensions.md).