### PR TITLE
[5.7][SE-0361] Enable bound generic extensions.

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -482,13 +482,6 @@ namespace swift {
     // FrontendOptions.
     bool AllowModuleWithCompilerErrors = false;
 
-    /// Enable extensions of (sugared) bound generic types
-    ///
-    /// \code
-    /// extension [Int] { /**/ }
-    /// \endcode
-    bool EnableExperimentalBoundGenericExtensions = true;
-
     /// A helper enum to represent whether or not we customized the default
     /// ASTVerifier behavior via a frontend flag. By default, we do not
     /// customize.

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -487,7 +487,7 @@ namespace swift {
     /// \code
     /// extension [Int] { /**/ }
     /// \endcode
-    bool EnableExperimentalBoundGenericExtensions = false;
+    bool EnableExperimentalBoundGenericExtensions = true;
 
     /// A helper enum to represent whether or not we customized the default
     /// ASTVerifier behavior via a frontend flag. By default, we do not

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -313,10 +313,6 @@ def enable_resilience : Flag<["-"], "enable-resilience">,
 def enable_experimental_async_top_level :
   Flag<["-"], "enable-experimental-async-top-level">,
   HelpText<"Enable experimental concurrency in top-level code">;
-
-def enable_experimental_bound_generic_extensions :
-  Flag<["-"], "enable-experimental-bound-generic-extensions">,
-  HelpText<"Enable experimental support for extensions of bound generic types">;
 }
 
 // HIDDEN FLAGS

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -517,9 +517,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
       Opts.EnableBareSlashRegexLiterals = false;
   }
 
-  Opts.EnableExperimentalBoundGenericExtensions |=
-    Args.hasArg(OPT_enable_experimental_bound_generic_extensions);
-
   Opts.DisableAvailabilityChecking |=
       Args.hasArg(OPT_disable_availability_checking);
   Opts.CheckAPIAvailabilityOnly |=

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2846,16 +2846,5 @@ ExtendedTypeRequest::evaluate(Evaluator &eval, ExtensionDecl *ext) const {
     return error();
   }
 
-  // By default, the user cannot extend a bound generic type, unless it's
-  // referenced via a non-generic typealias type.
-  if (!ext->getASTContext().LangOpts.EnableExperimentalBoundGenericExtensions &&
-      extendedType->isSpecialized() &&
-      !isNonGenericTypeAliasType(extendedType)) {
-    diags.diagnose(ext->getLoc(), diag::extension_specialization,
-                   extendedType->getAnyNominal()->getName())
-         .highlight(extendedRepr->getSourceRange());
-    return error();
-  }
-
   return extendedType;
 }

--- a/test/ModuleInterface/specialized-extension.swift
+++ b/test/ModuleInterface/specialized-extension.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -module-name Test -typecheck -emit-module-interface-path - -enable-experimental-bound-generic-extensions %s -requirement-machine-inferred-signatures=on | %FileCheck %s
+// RUN: %target-swift-frontend -module-name Test -typecheck -emit-module-interface-path - %s -requirement-machine-inferred-signatures=on | %FileCheck %s
 
 public struct Tree<T> {
   public struct Branch<B> {

--- a/test/SILGen/mangling_specialized_extensions.swift
+++ b/test/SILGen/mangling_specialized_extensions.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-experimental-bound-generic-extensions %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
 struct Tree<T> {
   struct Branch<B> {

--- a/test/decl/ext/extensions.swift
+++ b/test/decl/ext/extensions.swift
@@ -40,8 +40,6 @@ func nestingTest6() {
 extension Array {
   func foo() {
     extension Array { // expected-error {{declaration is only valid at file scope}}
-    // FIXME: Confusing error
-    // expected-error@-2 {{constrained extension must be declared on the unspecialized generic type 'Array' with constraints specified by a 'where' clause}}
     }
   }
 }
@@ -347,7 +345,8 @@ extension Tree.LimbContent.Contents {
 }
 
 extension Tree.BoughPayload.Contents {
- // expected-error@-1 {{constrained extension must be declared on the unspecialized generic type 'Nest'}}
+  // expected-error@-1 {{extension of type 'Tree.BoughPayload.Contents' (aka 'Nest<Int>') must be declared as an extension of 'Nest<Int>'}}
+  // expected-note@-2 {{did you mean to extend 'Nest<Int>' instead?}}
 }
 
 // SR-10466 Check 'where' clause when referencing type defined inside extension

--- a/test/decl/ext/generic.swift
+++ b/test/decl/ext/generic.swift
@@ -19,11 +19,9 @@ extension Double : P2 {
 }
 
 extension X<Int, Double, String> {
-// expected-error@-1{{constrained extension must be declared on the unspecialized generic type 'X' with constraints specified by a 'where' clause}}
   let x = 0
   // expected-error@-1 {{extensions must not contain stored properties}}
   static let x = 0
-  // expected-error@-1 {{static stored properties not supported in generic types}}
   func f() -> Int {}
   class C<T> {}
 }

--- a/test/decl/ext/specialize.swift
+++ b/test/decl/ext/specialize.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-bound-generic-extensions
+// RUN: %target-typecheck-verify-swift
 
 extension Array<Int> {
   func someIntFuncOnArray() {}

--- a/test/decl/typealias/generic.swift
+++ b/test/decl/typealias/generic.swift
@@ -307,9 +307,9 @@ func takesSugaredType2(m: GenericClass<Int>.TA<Float>) {
 extension A {}
 
 extension A<T> {}  // expected-error {{generic type 'A' specialized with too few type parameters (got 1, but expected 2)}}
-extension A<Float,Int> {}  // expected-error {{constrained extension must be declared on the unspecialized generic type 'MyType' with constraints specified by a 'where' clause}}
+extension A<Float,Int> {}
 extension C<T> {}  // expected-error {{cannot find type 'T' in scope}}
-extension C<Int> {}  // expected-error {{constrained extension must be declared on the unspecialized generic type 'MyType' with constraints specified by a 'where' clause}}
+extension C<Int> {}
 
 
 protocol ErrorQ {


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/59829

* **Explanation**: This change enables [SE-0361: Bound generic extensions](https://github.com/apple/swift-evolution/blob/main/proposals/0361-bound-generic-extensions.md) and removes the experimental feature flag.
* **Scope**: This is a new language feature with no impact on existing code.
* **Risk**: Low.
* **Testing**: Tests already exist for the new feature. Updated diagnostics for existing tests.