### PR TITLE
[NFC][Test] Update Constraints/diag_ambiguities.swift for Swift version 5.

### DIFF
--- a/test/Constraints/diag_ambiguities.swift
+++ b/test/Constraints/diag_ambiguities.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -swift-version 5
 
 func f0(_ i: Int, _ d: Double) {} // expected-note{{found this candidate}}
 func f0(_ d: Double, _ i: Int) {} // expected-note{{found this candidate}}
@@ -43,7 +43,7 @@ func rdar29907555(_ value: Any!) -> String {
 }
 
 struct SR3715 {
-  var overloaded: Int!
+  var overloaded: Int! // expected-note {{implicitly unwrapped property 'overloaded' declared here}}
 
   func overloaded(_ x: Int) {}
   func overloaded(_ x: Float) {}
@@ -52,6 +52,10 @@ struct SR3715 {
 
   func test() {
     take([overloaded])
+    // expected-warning@-1 {{coercion of implicitly unwrappable value of type 'Int?' to 'Any' does not unwrap optional}}
+    // expected-note@-2 {{provide a default value to avoid this warning}}
+    // expected-note@-3 {{force-unwrap the value to avoid this warning}}
+    // expected-note@-4 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}
   }
 }
 


### PR DESCRIPTION
Swift 5 adds a new warning to this test.

Resolves: rdar://70496798