### PR TITLE
[CodeCompletion] Rename DotExprCompletion -> PostfixCompletion

### DIFF
--- a/include/swift/IDE/PostfixCompletion.h
+++ b/include/swift/IDE/PostfixCompletion.h
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef SWIFT_IDE_DOTEXPRCODECOMPLETION_H
-#define SWIFT_IDE_DOTEXPRCODECOMPLETION_H
+#ifndef SWIFT_IDE_POSTFIXCOMPLETION_H
+#define SWIFT_IDE_POSTFIXCOMPLETION_H
 
 #include "swift/IDE/CodeCompletionConsumer.h"
 #include "swift/IDE/CodeCompletionContext.h"
@@ -23,7 +23,7 @@ namespace ide {
 /// Used to collect and store information needed to perform member completion
 /// (\c CompletionKind::DotExpr ) from the solutions formed during expression
 /// type-checking.
-class DotExprTypeCheckCompletionCallback : public TypeCheckCompletionCallback {
+class PostfixCompletionCallback : public TypeCheckCompletionCallback {
   struct Result {
     Type BaseTy;
     ValueDecl *BaseDecl;
@@ -46,8 +46,7 @@ class DotExprTypeCheckCompletionCallback : public TypeCheckCompletionCallback {
   void sawSolutionImpl(const constraints::Solution &solution) override;
 
 public:
-  DotExprTypeCheckCompletionCallback(CodeCompletionExpr *CompletionExpr,
-                                     DeclContext *DC)
+  PostfixCompletionCallback(CodeCompletionExpr *CompletionExpr, DeclContext *DC)
       : CompletionExpr(CompletionExpr), DC(DC) {}
 
   /// Typecheck the code completion expression in isolation, calling
@@ -62,4 +61,4 @@ public:
 } // end namespace ide
 } // end namespace swift
 
-#endif // SWIFT_IDE_DOTEXPRCODECOMPLETION_H
+#endif // SWIFT_IDE_POSTFIXCOMPLETION_H

--- a/lib/IDE/CMakeLists.txt
+++ b/lib/IDE/CMakeLists.txt
@@ -1,15 +1,16 @@
 
 add_swift_host_library(swiftIDE STATIC
   AfterPoundExprCompletion.cpp
+  APIDigesterData.cpp
   ArgumentCompletion.cpp
   CodeCompletion.cpp
   CodeCompletionCache.cpp
-  CodeCompletionContext.cpp
   CodeCompletionConsumer.cpp
+  CodeCompletionContext.cpp
   CodeCompletionDiagnostics.cpp
+  CodeCompletionResult.cpp
   CodeCompletionResultBuilder.cpp
   CodeCompletionResultPrinter.cpp
-  CodeCompletionResult.cpp
   CodeCompletionResultType.cpp
   CodeCompletionString.cpp
   CodeCompletionStringPrinter.cpp
@@ -20,26 +21,25 @@ add_swift_host_library(swiftIDE STATIC
   CompletionOverrideLookup.cpp
   ConformingMethodList.cpp
   DependencyChecking.cpp
-  DotExprCompletion.cpp
   ExprCompletion.cpp
   ExprContextAnalysis.cpp
   Formatting.cpp
   FuzzyStringMatcher.cpp
-  Refactoring.cpp
+  IDERequests.cpp
+  IDETypeChecking.cpp
+  ImportDepth.cpp
   KeyPathCompletion.cpp
   ModuleInterfacePrinting.cpp
+  PostfixCompletion.cpp
+  Refactoring.cpp
   REPLCodeCompletion.cpp
+  SourceEntityWalker.cpp
   SwiftSourceDocInfo.cpp
   SyntaxModel.cpp
   TypeCheckCompletionCallback.cpp
+  TypeContextInfo.cpp
   UnresolvedMemberCompletion.cpp
   Utils.cpp
-  IDETypeChecking.cpp
-  ImportDepth.cpp
-  APIDigesterData.cpp
-  SourceEntityWalker.cpp
-  TypeContextInfo.cpp
-  IDERequests.cpp
   )
 target_link_libraries(swiftIDE PRIVATE
   swiftAST

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -40,9 +40,9 @@
 #include "swift/IDE/CodeCompletionStringPrinter.h"
 #include "swift/IDE/CompletionLookup.h"
 #include "swift/IDE/CompletionOverrideLookup.h"
-#include "swift/IDE/DotExprCompletion.h"
 #include "swift/IDE/ExprCompletion.h"
 #include "swift/IDE/KeyPathCompletion.h"
+#include "swift/IDE/PostfixCompletion.h"
 #include "swift/IDE/TypeCheckCompletionCallback.h"
 #include "swift/IDE/UnresolvedMemberCompletion.h"
 #include "swift/IDE/Utils.h"
@@ -1402,8 +1402,7 @@ bool CodeCompletionCallbacksImpl::trySolverCompletion(bool MaybeFuncBody) {
     assert(CodeCompleteTokenExpr);
     assert(CurDeclContext);
 
-    DotExprTypeCheckCompletionCallback Lookup(CodeCompleteTokenExpr,
-                                              CurDeclContext);
+    PostfixCompletionCallback Lookup(CodeCompleteTokenExpr, CurDeclContext);
     typeCheckWithLookup(Lookup);
 
     addKeywords(CompletionContext.getResultSink(), MaybeFuncBody);

--- a/lib/IDE/PostfixCompletion.cpp
+++ b/lib/IDE/PostfixCompletion.cpp
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "swift/IDE/DotExprCompletion.h"
+#include "swift/IDE/PostfixCompletion.h"
 #include "swift/IDE/CodeCompletion.h"
 #include "swift/IDE/CompletionLookup.h"
 #include "swift/Sema/CompletionContextFinder.h"
@@ -21,7 +21,7 @@ using namespace swift;
 using namespace swift::constraints;
 using namespace swift::ide;
 
-void DotExprTypeCheckCompletionCallback::fallbackTypeCheck(DeclContext *DC) {
+void PostfixCompletionCallback::fallbackTypeCheck(DeclContext *DC) {
   assert(!gotCallback());
 
   // Default to checking the completion expression in isolation.
@@ -44,7 +44,7 @@ void DotExprTypeCheckCompletionCallback::fallbackTypeCheck(DeclContext *DC) {
                              [&](const Solution &S) { sawSolution(S); });
 }
 
-void DotExprTypeCheckCompletionCallback::sawSolutionImpl(
+void PostfixCompletionCallback::sawSolutionImpl(
     const constraints::Solution &S) {
   auto &CS = S.getConstraintSystem();
   auto *ParsedExpr = CompletionExpr->getBase();
@@ -96,7 +96,7 @@ void DotExprTypeCheckCompletionCallback::sawSolutionImpl(
   }
 }
 
-void DotExprTypeCheckCompletionCallback::deliverResults(
+void PostfixCompletionCallback::deliverResults(
     Expr *BaseExpr, DeclContext *DC, SourceLoc DotLoc, bool IsInSelector,
     CodeCompletionContext &CompletionCtx, CodeCompletionConsumer &Consumer) {
   ASTContext &Ctx = DC->getASTContext();


### PR DESCRIPTION
Rename `DotExprCompletion` to `PostfixCompletion` in preparation for https://github.com/apple/swift/pull/42280 to keep that PR smaller.

Also sort files in IDE’s CMakeList.txt because the current random order annoyed me 😉 