### PR TITLE
[IRGen] Emit missing `sret` for function arguments

### DIFF
--- a/test/Interop/Cxx/class/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/Inputs/module.modulemap
@@ -102,3 +102,8 @@ module ForwardDeclaredCxxRecord {
   header "forward-declared-cxx-record.h"
   requires cplusplus
 }
+
+module ReturnsLargeClass {
+  header "returns-large-class.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/class/Inputs/returns-large-class.h
+++ b/test/Interop/Cxx/class/Inputs/returns-large-class.h
@@ -1,0 +1,22 @@
+#ifndef TEST_INTEROP_CXX_CLASS_INPUTS_RETURNS_LARGE_CLASS_H
+#define TEST_INTEROP_CXX_CLASS_INPUTS_RETURNS_LARGE_CLASS_H
+
+struct LargeClass {
+  long long a1 = 0;
+  long long a2 = 0;
+  long long a3 = 0;
+  long long a4 = 0;
+  long long a5 = 0;
+  long long a6 = 0;
+  long long a7 = 0;
+  long long a8 = 0;
+};
+
+LargeClass funcReturnsLargeClass() {
+  LargeClass l;
+  l.a2 = 2;
+  l.a6 = 6;
+  return l;
+}
+
+#endif // TEST_INTEROP_CXX_CLASS_INPUTS_RETURNS_LARGE_CLASS_H

--- a/test/Interop/Cxx/class/returns-large-class-irgen.swift
+++ b/test/Interop/Cxx/class/returns-large-class-irgen.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-emit-ir -I %S/Inputs -enable-experimental-cxx-interop %s -validate-tbd-against-ir=none | %FileCheck %s
+
+// This test verifies that Swift correctly emits IR calls to C++ functions that
+// had Named Return Value Optimization applied to them. The first argument of
+// such functions has `sret` attribute. When calling them, the first
+// parameter should be wrapped in `sret(...)`.
+
+import ReturnsLargeClass
+
+func foo() -> LargeClass {
+  let x = funcReturnsLargeClass()
+  return x
+}
+
+foo()
+
+// CHECK: call swiftcc void @"$s4main3fooSo10LargeClassVyF"(%TSo10LargeClassV* noalias nocapture sret(%TSo10LargeClassV) %{{.*}})
+
+// The C++ function:
+// CHECK: define{{( dso_local)?}} void @{{_Z21funcReturnsLargeClassv|"\?funcReturnsLargeClass@@YA\?AULargeClass@@XZ"}}({{%struct.LargeClass\*|ptr}} noalias sret(%struct.LargeClass){{( align .*)?}} %{{.*}})

--- a/test/Interop/Cxx/class/returns-large-class.swift
+++ b/test/Interop/Cxx/class/returns-large-class.swift
@@ -1,0 +1,22 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none)
+
+// REQUIRES: executable_test
+
+// This test verifies that Swift correctly handles calls to C++ functions that
+// had Named Return Value Optimization applied to them.
+
+import StdlibUnittest
+import ReturnsLargeClass
+
+var LargeTypes = TestSuite("Large C++ Return Types")
+
+LargeTypes.test("NRVO") {
+  let x = funcReturnsLargeClass()
+
+  expectEqual(0, x.a1)
+  expectEqual(2, x.a2)
+  expectEqual(6, x.a6)
+  expectEqual(0, x.a7)
+}
+
+runAllTests()

--- a/test/Interop/Cxx/operators/member-inline.swift
+++ b/test/Interop/Cxx/operators/member-inline.swift
@@ -52,12 +52,14 @@ OperatorsTestSuite.test("LoadableIntWrapper.successor() (inline)") {
   expectEqual(42, wrapper.value)
 }
 
+#if !os(Windows)    // SR-13129
 OperatorsTestSuite.test("LoadableBoolWrapper.exclaim (inline)") {
   var wrapper = LoadableBoolWrapper(value: true)
 
   let resultExclaim = !wrapper
   expectEqual(false, resultExclaim.value)
 }
+#endif
 
 OperatorsTestSuite.test("AddressOnlyIntWrapper.call (inline)") {
   var wrapper = AddressOnlyIntWrapper(42)

--- a/test/SILOptimizer/addr_escape_info.sil
+++ b/test/SILOptimizer/addr_escape_info.sil
@@ -2,9 +2,6 @@
 
 // REQUIRES: swift_in_compiler
 
-// Currently failing on arm: rdar://92963081
-// REQUIRES: CPU=x86_64
-
 sil_stage canonical
 
 import Builtin

--- a/test/SILOptimizer/escape_info.sil
+++ b/test/SILOptimizer/escape_info.sil
@@ -2,9 +2,6 @@
 
 // REQUIRES: swift_in_compiler
 
-// Currently failing on arm: rdar://92963081
-// REQUIRES: CPU=x86_64
-
 sil_stage canonical
 
 import Builtin

--- a/test/SILOptimizer/ranges.sil
+++ b/test/SILOptimizer/ranges.sil
@@ -2,9 +2,6 @@
 
 // REQUIRES: swift_in_compiler
 
-// Currently failing on arm: rdar://92963081
-// REQUIRES: CPU=x86_64
-
 sil_stage canonical
 
 // CHECK-LABEL: Instruction range in basic_test:


### PR DESCRIPTION
If the IR representation of a C++ function takes an `SRet` parameter instead of a return value, Swift needs to wrap the corresponding argument with `sret(...)` on call site.

This fixes SILOptimizer crashes on arm64.

rdar://92963081