### PR TITLE
[CursorInfo] References should not include shadowed declarations

### DIFF
--- a/lib/IDE/IDERequests.cpp
+++ b/lib/IDE/IDERequests.cpp
@@ -172,12 +172,18 @@ ResolvedCursorInfo CursorInfoResolver::resolve(SourceLoc Loc) {
   assert(Loc.isValid());
   LocToResolve = Loc;
   CursorInfo.Loc = Loc;
+
   walk(SrcFile);
-  auto ShorthandShadowedDecl = ShorthandShadowedDecls[CursorInfo.ValueD];
-  while (ShorthandShadowedDecl) {
-    CursorInfo.ShorthandShadowedDecls.push_back(ShorthandShadowedDecl);
-    ShorthandShadowedDecl = ShorthandShadowedDecls[ShorthandShadowedDecl];
+
+  if (!CursorInfo.IsRef) {
+    // If we have a definition, add any decls that it potentially shadows
+    auto ShorthandShadowedDecl = ShorthandShadowedDecls[CursorInfo.ValueD];
+    while (ShorthandShadowedDecl) {
+      CursorInfo.ShorthandShadowedDecls.push_back(ShorthandShadowedDecl);
+      ShorthandShadowedDecl = ShorthandShadowedDecls[ShorthandShadowedDecl];
+    }
   }
+
   return CursorInfo;
 }
 

--- a/test/SourceKit/CursorInfo/closure_capture.swift
+++ b/test/SourceKit/CursorInfo/closure_capture.swift
@@ -1,78 +1,97 @@
 func takeClosure(_ closure: () -> Void) {}
 
+// RUN: %sourcekitd-test -req=cursor -pos=%(line+1):13 %s -- %s | %FileCheck %s --check-prefix=SIMPLE_PARAM -D#FUNCSTART=%(line+1)
 func simple(bar: Int) {
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):18 %s -- %s | %FileCheck %s --check-prefix=SIMPLE_CAPTURE -D#FUNCSTART=%(line-1)
   takeClosure { [bar] in
+    // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):11 %s -- %s | %FileCheck %s --check-prefix=SIMPLE_REF -D#FUNCSTART=%(line-3)
     print(bar)
   }
 }
 
-// RUN: %sourcekitd-test -req=cursor -pos=3:13 %s -- %s | %FileCheck %s --check-prefix=SIMPLE_PARAM
-// SIMPLE_PARAM: source.lang.swift.decl.var.parameter (3:13-3:16)
+// SIMPLE_PARAM: source.lang.swift.decl.var.parameter ([[#FUNCSTART]]:13-[[#FUNCSTART]]:16)
 // SIMPLE_PARAM: SECONDARY SYMBOLS BEGIN
 // There should be no secondary symbols
 // SIMPLE_PARAM-NEXT: SECONDARY SYMBOLS END
 
-// RUN: %sourcekitd-test -req=cursor -pos=4:18 %s -- %s | %FileCheck %s --check-prefix=SIMPLE_CAPTURE
-// SIMPLE_CAPTURE: source.lang.swift.decl.var.local (4:18-4:21)
+// SIMPLE_CAPTURE: source.lang.swift.decl.var.local ([[#FUNCSTART+2]]:18-[[#FUNCSTART+2]]:21)
 // SIMPLE_CAPTURE: SECONDARY SYMBOLS BEGIN
-// SIMPLE_CAPTURE: source.lang.swift.ref.var.local (3:13-3:16)
+// SIMPLE_CAPTURE: source.lang.swift.ref.var.local ([[#FUNCSTART]]:13-[[#FUNCSTART]]:16)
 
-// RUN: %sourcekitd-test -req=cursor -pos=5:11 %s -- %s | %FileCheck %s --check-prefix=SIMPLE_REF
-// SIMPLE_REF: source.lang.swift.ref.var.local (4:18-4:21)
+// SIMPLE_REF: source.lang.swift.ref.var.local ([[#FUNCSTART+2]]:18-[[#FUNCSTART+2]]:21)
 // SIMPLE_REF: SECONDARY SYMBOLS BEGIN
-// SIMPLE_REF: source.lang.swift.ref.var.local (3:13-3:16)
+// SIMPLE_REF-NEXT: SECONDARY SYMBOLS END
 
 func doubleNested(bar: Int) {
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):18 %s -- %s | %FileCheck %s --check-prefix=DOUBLE_NESTED_FIRST_CAPTURE -D#FUNCSTART=%(line-1)
   takeClosure { [bar] in
+    // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):20 %s -- %s | %FileCheck %s --check-prefix=DOUBLE_NESTED_SECOND_CAPTURE -D#FUNCSTART=%(line-3)
     takeClosure { [bar] in
+      // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):13 %s -- %s | %FileCheck %s --check-prefix=DOUBLE_NESTED_REF -D#FUNCSTART=%(line-5)
       print(bar)
     }
   }
 }
 
-// RUN: %sourcekitd-test -req=cursor -pos=26:18 %s -- %s | %FileCheck %s --check-prefix=DOUBLE_NESTED_FIRST_CAPTURE
-// DOUBLE_NESTED_FIRST_CAPTURE: source.lang.swift.decl.var.local (26:18-26:21)
+// DOUBLE_NESTED_FIRST_CAPTURE: source.lang.swift.decl.var.local ([[#FUNCSTART+2]]:18-[[#FUNCSTART+2]]:21)
 // DOUBLE_NESTED_FIRST_CAPTURE: SECONDARY SYMBOLS BEGIN
-// DOUBLE_NESTED_FIRST_CAPTURE: source.lang.swift.ref.var.local (25:19-25:22)
+// DOUBLE_NESTED_FIRST_CAPTURE: source.lang.swift.ref.var.local ([[#FUNCSTART]]:19-[[#FUNCSTART]]:22)
 
-// RUN: %sourcekitd-test -req=cursor -pos=27:20 %s -- %s | %FileCheck %s --check-prefix=DOUBLE_NESTED_SECOND_CAPTURE
-// DOUBLE_NESTED_SECOND_CAPTURE: source.lang.swift.decl.var.local (27:20-27:23)
+// DOUBLE_NESTED_SECOND_CAPTURE: source.lang.swift.decl.var.local ([[#FUNCSTART+4]]:20-[[#FUNCSTART+4]]:23)
 // DOUBLE_NESTED_SECOND_CAPTURE: SECONDARY SYMBOLS BEGIN
-// DOUBLE_NESTED_SECOND_CAPTURE: source.lang.swift.ref.var.local (26:18-26:21)
-// DOUBLE_NESTED_SECOND_CAPTURE: source.lang.swift.ref.var.local (25:19-25:22)
+// DOUBLE_NESTED_SECOND_CAPTURE: source.lang.swift.ref.var.local ([[#FUNCSTART+2]]:18-[[#FUNCSTART+2]]:21)
+// DOUBLE_NESTED_SECOND_CAPTURE: source.lang.swift.ref.var.local ([[#FUNCSTART]]:19-[[#FUNCSTART]]:22)
 
-// RUN: %sourcekitd-test -req=cursor -pos=28:13 %s -- %s | %FileCheck %s --check-prefix=DOUBLE_NESTED_REF
-// DOUBLE_NESTED_REF: source.lang.swift.ref.var.local (27:20-27:23)
+// DOUBLE_NESTED_REF: source.lang.swift.ref.var.local ([[#FUNCSTART+4]]:20-[[#FUNCSTART+4]]:23)
 // DOUBLE_NESTED_REF: SECONDARY SYMBOLS BEGIN
-// DOUBLE_NESTED_REF: source.lang.swift.ref.var.local (26:18-26:21)
-// DOUBLE_NESTED_REF: source.lang.swift.ref.var.local (25:19-25:22)
+// DOUBLE_NESTED_REF-NEXT: SECONDARY SYMBOLS END
 
 // Make sure we don't report secondary symbols if the variable is captured explicitly using '='
 func explicitCapture(bar: Int) {
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+2):18 %s -- %s | %FileCheck %s --check-prefix=EXPLICIT_CAPTURE -D#FUNCSTART=%(line-1)
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):24 %s -- %s | %FileCheck %s --check-prefix=EXPLICIT_CAPTURE_PARAM_REF -D#FUNCSTART=%(line-2)
   takeClosure { [bar = bar] in
+    // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):11 %s -- %s | %FileCheck %s --check-prefix=EXPLICIT_CAPTURE_REF -D#FUNCSTART=%(line-4)
     print(bar)
   }
 }
 
-// RUN: %sourcekitd-test -req=cursor -pos=53:11 %s -- %s | %FileCheck %s --check-prefix=EXPLICIT_CAPTURE_REF
-// EXPLICIT_CAPTURE_REF: source.lang.swift.ref.var.local (52:18-52:21)
+// EXPLICIT_CAPTURE: source.lang.swift.decl.var.local ([[#FUNCSTART+3]]:18-[[#FUNCSTART+3]]:21)
+// EXPLICIT_CAPTURE: SECONDARY SYMBOLS BEGIN
+// EXPLICIT_CAPTURE-NEXT: SECONDARY SYMBOLS END
+
+// EXPLICIT_CAPTURE_PARAM_REF: source.lang.swift.ref.var.local ([[#FUNCSTART]]:22-[[#FUNCSTART]]:25)
+// EXPLICIT_CAPTURE_PARAM_REF: SECONDARY SYMBOLS BEGIN
+// EXPLICIT_CAPTURE_PARAM_REF-NEXT: SECONDARY SYMBOLS END
+
+// EXPLICIT_CAPTURE_REF: source.lang.swift.ref.var.local ([[#FUNCSTART+3]]:18-[[#FUNCSTART+3]]:21)
 // EXPLICIT_CAPTURE_REF: SECONDARY SYMBOLS BEGIN
 // There should be no secondary symbols
 // EXPLICIT_CAPTURE_REF-NEXT: SECONDARY SYMBOLS END
 
 func multipleCaptures(bar: Int, baz: Int) {
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+2):18 %s -- %s | %FileCheck %s --check-prefix=MULTIPLE_CAPTURES_BAR -D#FUNCSTART=%(line-1)
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):23 %s -- %s | %FileCheck %s --check-prefix=MULTIPLE_CAPTURES_BAZ -D#FUNCSTART=%(line-2)
   takeClosure { [bar, baz] in
+    // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):11 %s -- %s | %FileCheck %s --check-prefix=MULTIPLE_CAPTURES_BAR_REF -D#FUNCSTART=%(line-4)
     print(bar)
+    // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):11 %s -- %s | %FileCheck %s --check-prefix=MULTIPLE_CAPTURES_BAZ_REF -D#FUNCSTART=%(line-6)
     print(baz)
   }
 }
 
-// RUN: %sourcekitd-test -req=cursor -pos=65:11 %s -- %s | %FileCheck %s --check-prefix=MULTIPLE_CAPTURES_BAR
-// MULTIPLE_CAPTURES_BAR: source.lang.swift.ref.var.local (64:18-64:21)
+// MULTIPLE_CAPTURES_BAR: source.lang.swift.decl.var.local ([[#FUNCSTART+3]]:18-[[#FUNCSTART+3]]:21)
 // MULTIPLE_CAPTURES_BAR: SECONDARY SYMBOLS BEGIN
-// MULTIPLE_CAPTURES_BAR.lang.swift.ref.var.local (63:23-63:26)
+// MULTIPLE_CAPTURES_BAR: source.lang.swift.ref.var.local ([[#FUNCSTART]]:23-[[#FUNCSTART]]:26)
 
-// RUN: %sourcekitd-test -req=cursor -pos=66:11 %s -- %s | %FileCheck %s --check-prefix=MULTIPLE_CAPTURES_BAZ
-// MULTIPLE_CAPTURES_BAZ: source.lang.swift.ref.var.local (64:23-64:26)
+// MULTIPLE_CAPTURES_BAZ: source.lang.swift.decl.var.local ([[#FUNCSTART+3]]:23-[[#FUNCSTART+3]]:26)
 // MULTIPLE_CAPTURES_BAZ: SECONDARY SYMBOLS BEGIN
-// MULTIPLE_CAPTURES_BAZ.lang.swift.ref.var.local (63:33-63:36)
+// MULTIPLE_CAPTURES_BAZ: source.lang.swift.ref.var.local ([[#FUNCSTART]]:33-[[#FUNCSTART]]:36)
+
+// MULTIPLE_CAPTURES_BAR_REF: source.lang.swift.ref.var.local ([[#FUNCSTART+3]]:18-[[#FUNCSTART+3]]:21)
+// MULTIPLE_CAPTURES_BAR_REF: SECONDARY SYMBOLS BEGIN
+// MULTIPLE_CAPTURES_BAR_REF-NEXT: SECONDARY SYMBOLS END
+
+// MULTIPLE_CAPTURES_BAZ_REF: source.lang.swift.ref.var.local ([[#FUNCSTART+3]]:23-[[#FUNCSTART+3]]:26)
+// MULTIPLE_CAPTURES_BAZ_REF: SECONDARY SYMBOLS BEGIN
+// MULTIPLE_CAPTURES_BAZ_REF-NEXT: SECONDARY SYMBOLS END

--- a/test/SourceKit/CursorInfo/shorthand_if_let.swift
+++ b/test/SourceKit/CursorInfo/shorthand_if_let.swift
@@ -1,108 +1,133 @@
+// RUN: %sourcekitd-test -req=cursor -pos=%(line+1):13 %s -- %s | %FileCheck %s --check-prefix=SIMPLE_PARAM -D#FUNCSTART=%(line+1)
 func simple(bar: Int?) {
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):10 %s -- %s | %FileCheck %s --check-prefix=SIMPLE_CAPTURE -D#FUNCSTART=%(line-1)
   if let bar {
+    // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):11 %s -- %s | %FileCheck %s --check-prefix=SIMPLE_REF -D#FUNCSTART=%(line-3)
     print(bar)
   }
 }
 
-// RUN: %sourcekitd-test -req=cursor -pos=1:13 %s -- %s | %FileCheck %s --check-prefix=SIMPLE_PARAM
-// SIMPLE_PARAM: source.lang.swift.decl.var.parameter (1:13-1:16)
+// SIMPLE_PARAM: source.lang.swift.decl.var.parameter ([[#FUNCSTART]]:13-[[#FUNCSTART]]:16)
 // SIMPLE_PARAM: Int
 // SIMPLE_PARAM: SECONDARY SYMBOLS BEGIN
 // There should be no secondary symbols
 // SIMPLE_PARAM-NEXT: SECONDARY SYMBOLS END
 
-// RUN: %sourcekitd-test -req=cursor -pos=2:10 %s -- %s | %FileCheck %s --check-prefix=SIMPLE_CAPTURE
-// SIMPLE_CAPTURE: source.lang.swift.decl.var.local (2:10-2:13)
+// SIMPLE_CAPTURE: source.lang.swift.decl.var.local ([[#FUNCSTART+2]]:10-[[#FUNCSTART+2]]:13)
 // SIMPLE_CAPTURE: Int
 // SIMPLE_CAPTURE: SECONDARY SYMBOLS BEGIN
-// SIMPLE_CAPTURE: source.lang.swift.ref.var.local (1:13-1:16)
+// SIMPLE_CAPTURE: source.lang.swift.ref.var.local ([[#FUNCSTART]]:13-[[#FUNCSTART]]:16)
 // SIMPLE_CAPTURE: Int?
 
-// RUN: %sourcekitd-test -req=cursor -pos=3:11 %s -- %s | %FileCheck %s --check-prefix=SIMPLE_REF
-// SIMPLE_REF: source.lang.swift.ref.var.local (2:10-2:13)
+// SIMPLE_REF: source.lang.swift.ref.var.local ([[#FUNCSTART+2]]:10-[[#FUNCSTART+2]]:13)
 // SIMPLE_REF: Int
 // SIMPLE_REF: SECONDARY SYMBOLS BEGIN
-// SIMPLE_REF: source.lang.swift.ref.var.local (1:13-1:16)
-// SIMPLE_REF: Int?
+// SIMPLE_REF-NEXT: SECONDARY SYMBOLS END
 
 func doubleNested(bar: Int??) {
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):10 %s -- %s | %FileCheck %s --check-prefix=DOUBLE_NESTED_FIRST_CAPTURE -D#FUNCSTART=%(line-1)
   if let bar {
+    // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):12 %s -- %s | %FileCheck %s --check-prefix=DOUBLE_NESTED_SECOND_CAPTURE -D#FUNCSTART=%(line-3)
     if let bar {
+      // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):13 %s -- %s | %FileCheck %s --check-prefix=DOUBLE_NESTED_REF -D#FUNCSTART=%(line-5)
       print(bar)
     }
   }
 }
 
-// RUN: %sourcekitd-test -req=cursor -pos=29:10 %s -- %s | %FileCheck %s --check-prefix=DOUBLE_NESTED_FIRST_CAPTURE
-// DOUBLE_NESTED_FIRST_CAPTURE: source.lang.swift.decl.var.local (29:10-29:13)
+// DOUBLE_NESTED_FIRST_CAPTURE: source.lang.swift.decl.var.local ([[#FUNCSTART+2]]:10-[[#FUNCSTART+2]]:13)
 // DOUBLE_NESTED_FIRST_CAPTURE: Int?
 // DOUBLE_NESTED_FIRST_CAPTURE: SECONDARY SYMBOLS BEGIN
-// DOUBLE_NESTED_FIRST_CAPTURE: source.lang.swift.ref.var.local (28:19-28:22)
+// DOUBLE_NESTED_FIRST_CAPTURE: source.lang.swift.ref.var.local ([[#FUNCSTART]]:19-[[#FUNCSTART]]:22)
 // DOUBLE_NESTED_FIRST_CAPTURE: Int??
 
-// RUN: %sourcekitd-test -req=cursor -pos=30:12 %s -- %s | %FileCheck %s --check-prefix=DOUBLE_NESTED_SECOND_CAPTURE
-// DOUBLE_NESTED_SECOND_CAPTURE: source.lang.swift.decl.var.local (30:12-30:15)
+// DOUBLE_NESTED_SECOND_CAPTURE: source.lang.swift.decl.var.local ([[#FUNCSTART+4]]:12-[[#FUNCSTART+4]]:15)
 // DOUBLE_NESTED_SECOND_CAPTURE: Int
 // DOUBLE_NESTED_SECOND_CAPTURE: SECONDARY SYMBOLS BEGIN
-// DOUBLE_NESTED_SECOND_CAPTURE: source.lang.swift.ref.var.local (29:10-29:13)
+// DOUBLE_NESTED_SECOND_CAPTURE: source.lang.swift.ref.var.local ([[#FUNCSTART+2]]:10-[[#FUNCSTART+2]]:13)
 // DOUBLE_NESTED_SECOND_CAPTURE: Int?
-// DOUBLE_NESTED_SECOND_CAPTURE: source.lang.swift.ref.var.local (28:19-28:22)
+// DOUBLE_NESTED_SECOND_CAPTURE: source.lang.swift.ref.var.local ([[#FUNCSTART]]:19-[[#FUNCSTART]]:22)
 // DOUBLE_NESTED_SECOND_CAPTURE: Int??
 
-// RUN: %sourcekitd-test -req=cursor -pos=31:13 %s -- %s | %FileCheck %s --check-prefix=DOUBLE_NESTED_REF
-// DOUBLE_NESTED_REF: source.lang.swift.ref.var.local (30:12-30:15)
+// DOUBLE_NESTED_REF: source.lang.swift.ref.var.local ([[#FUNCSTART+4]]:12-[[#FUNCSTART+4]]:15)
 // DOUBLE_NESTED_REF: Int
 // DOUBLE_NESTED_REF: SECONDARY SYMBOLS BEGIN
-// DOUBLE_NESTED_REF: source.lang.swift.ref.var.local (29:10-29:13)
-// DOUBLE_NESTED_REF: Int?
-// DOUBLE_NESTED_REF: source.lang.swift.ref.var.local (28:19-28:22)
-// DOUBLE_NESTED_REF: Int??
+// DOUBLE_NESTED_REF-NEXT: SECONDARY SYMBOLS END
 
 // Make sure we don't report secondary symbols if the variable is captured explicitly using '='
 func explicitCapture(bar: Int?) {
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+2):10 %s -- %s | %FileCheck %s --check-prefix=EXPLICIT_CAPTURE -D#FUNCSTART=%(line-1)
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):16 %s -- %s | %FileCheck %s --check-prefix=EXPLICIT_CAPTURE_PARAM_REF -D#FUNCSTART=%(line-2)
   if let bar = bar {
+    // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):11 %s -- %s | %FileCheck %s --check-prefix=EXPLICIT_CAPTURE_REF -D#FUNCSTART=%(line-4)
     print(bar)
   }
 }
 
-// RUN: %sourcekitd-test -req=cursor -pos=64:11 %s -- %s | %FileCheck %s --check-prefix=EXPLICIT_CAPTURE_REF
-// EXPLICIT_CAPTURE_REF: source.lang.swift.ref.var.local (63:10-63:13)
+// EXPLICIT_CAPTURE: source.lang.swift.decl.var.local ([[#FUNCSTART+3]]:10-[[#FUNCSTART+3]]:13)
+// EXPLICIT_CAPTURE: Int
+// EXPLICIT_CAPTURE: SECONDARY SYMBOLS BEGIN
+// EXPLICIT_CAPTURE-NEXT: SECONDARY SYMBOLS END
+
+// EXPLICIT_CAPTURE_PARAM_REF: source.lang.swift.ref.var.local ([[#FUNCSTART]]:22-[[#FUNCSTART]]:25)
+// EXPLICIT_CAPTURE_PARAM_REF: Int?
+// EXPLICIT_CAPTURE_PARAM_REF: SECONDARY SYMBOLS BEGIN
+// EXPLICIT_CAPTURE_PARAM_REF-NEXT: SECONDARY SYMBOLS END
+
+// EXPLICIT_CAPTURE_REF: source.lang.swift.ref.var.local ([[#FUNCSTART+3]]:10-[[#FUNCSTART+3]]:13)
 // EXPLICIT_CAPTURE_REF: Int
 // EXPLICIT_CAPTURE_REF: SECONDARY SYMBOLS BEGIN
-// There should be no secondary symbols
 // EXPLICIT_CAPTURE_REF-NEXT: SECONDARY SYMBOLS END
 
 func multipleShorthand(bar: Int?, baz: Int?) {
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+2):10 %s -- %s | %FileCheck %s --check-prefix=MULTIPLE_SHORTHAND_BAR -D#FUNCSTART=%(line-1)
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):19 %s -- %s | %FileCheck %s --check-prefix=MULTIPLE_SHORTHAND_BAZ -D#FUNCSTART=%(line-2)
   if let bar, let baz {
+    // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):11 %s -- %s | %FileCheck %s --check-prefix=MULTIPLE_SHORTHAND_BAR_REF -D#FUNCSTART=%(line-4)
     print(bar)
+    // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):11 %s -- %s | %FileCheck %s --check-prefix=MULTIPLE_SHORTHAND_BAZ_REF -D#FUNCSTART=%(line-6)
     print(baz)
   }
 }
 
-// RUN: %sourcekitd-test -req=cursor -pos=77:11 %s -- %s | %FileCheck %s --check-prefix=MULTIPLE_SHORTHAND_BAR
-// MULTIPLE_SHORTHAND_BAR: source.lang.swift.ref.var.local (76:10-76:13)
+// MULTIPLE_SHORTHAND_BAR: source.lang.swift.decl.var.local ([[#FUNCSTART+3]]:10-[[#FUNCSTART+3]]:13)
 // MULTIPLE_SHORTHAND_BAR: Int
 // MULTIPLE_SHORTHAND_BAR: SECONDARY SYMBOLS BEGIN
-// MULTIPLE_SHORTHAND_BAR.lang.swift.ref.var.local (75:23-75:26)
+// MULTIPLE_SHORTHAND_BAR.lang.swift.ref.var.local ([[#FUNCSTART]]:24-[[#FUNCSTART]]:27)
 // MULTIPLE_SHORTHAND_BAR: Int?
 
-// RUN: %sourcekitd-test -req=cursor -pos=78:11 %s -- %s | %FileCheck %s --check-prefix=MULTIPLE_SHORTHAND_BAZ
-// MULTIPLE_SHORTHAND_BAZ: source.lang.swift.ref.var.local (76:19-76:22)
+// MULTIPLE_SHORTHAND_BAZ: source.lang.swift.decl.var.local ([[#FUNCSTART+3]]:19-[[#FUNCSTART+3]]:22)
 // MULTIPLE_SHORTHAND_BAZ: Int
 // MULTIPLE_SHORTHAND_BAZ: SECONDARY SYMBOLS BEGIN
-// MULTIPLE_SHORTHAND_BAZ.lang.swift.ref.var.local (63:33-63:36)
+// MULTIPLE_SHORTHAND_BAZ.lang.swift.ref.var.local ([[#FUNCSTART]]:35-[[#FUNCSTART]]:38)
 // MULTIPLE_SHORTHAND_BAZ: Int?
 
+// MULTIPLE_SHORTHAND_BAR_REF: source.lang.swift.ref.var.local ([[#FUNCSTART+3]]:10-[[#FUNCSTART+3]]:13)
+// MULTIPLE_SHORTHAND_BAR_REF: Int
+// MULTIPLE_SHORTHAND_BAR_REF: SECONDARY SYMBOLS BEGIN
+// MULTIPLE_SHORTHAND_BAR_REF-NEXT: SECONDARY SYMBOLS END
+
+// MULTIPLE_SHORTHAND_BAZ_REF: source.lang.swift.ref.var.local ([[#FUNCSTART+3]]:19-[[#FUNCSTART+3]]:22)
+// MULTIPLE_SHORTHAND_BAZ_REF: Int
+// MULTIPLE_SHORTHAND_BAZ_REF: SECONDARY SYMBOLS BEGIN
+// MULTIPLE_SHORTHAND_BAZ_REF-NEXT: SECONDARY SYMBOLS END
+
 func guardLet(bar: Int?) {
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):13 %s -- %s | %FileCheck %s --check-prefix=GUARD_LET -D#FUNCSTART=%(line-1)
   guard let bar else {
     return
   }
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):9 %s -- %s | %FileCheck %s --check-prefix=GUARD_LET_REF -D#FUNCSTART=%(line-5)
   print(bar)
 }
 
-// RUN: %sourcekitd-test -req=cursor -pos=100:9 %s -- %s | %FileCheck %s --check-prefix=GUARD_LET
-// GUARD_LET: source.lang.swift.ref.var.local (97:13-97:16)
+// GUARD_LET: source.lang.swift.decl.var.local ([[#FUNCSTART+2]]:13-[[#FUNCSTART+2]]:16)
 // GUARD_LET: Int
 // GUARD_LET: SECONDARY SYMBOLS BEGIN
-// GUARD_LET.lang.swift.ref.var.local (96:15-96:18)
+// GUARD_LET: source.lang.swift.ref.var.local ([[#FUNCSTART]]:15-[[#FUNCSTART]]:18)
 // GUARD_LET: Int?
+
+// GUARD_LET_REF: source.lang.swift.ref.var.local ([[#FUNCSTART+2]]:13-[[#FUNCSTART+2]]:16)
+// GUARD_LET_REF: Int
+// GUARD_LET_REF: SECONDARY SYMBOLS BEGIN
+// GUARD_LET_REF-NEXT: SECONDARY SYMBOLS END


### PR DESCRIPTION
Cursor info on a reference to a decl that shadows other decls should not
include those decls in the secondary symbols. They should only be
added on the decl itself, if that particular location is *also* the
reference to the shadowed decl (eg. in a shorthand if let or closure
capture).

Resolves rdar://96305891.