### PR TITLE
[Constraint solver] Don't adjust types in calls to @preconcurrency functions

### DIFF
--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1839,9 +1839,6 @@ public:
     SILFunctionConventions substConv(substTy, F.getModule());
     unsigned appliedArgStartIdx =
         substConv.getNumSILArguments() - PAI->getNumArguments();
-    bool isSendableAndStageIsCanonical =
-        PAI->getFunctionType()->isSendable() &&
-        F.getModule().getStage() >= SILStage::Canonical;
     for (auto p : llvm::enumerate(PAI->getArguments())) {
       requireSameType(
           p.value()->getType(),
@@ -1849,14 +1846,6 @@ public:
                                        F.getTypeExpansionContext()),
           "applied argument types do not match suffix of function type's "
           "inputs");
-
-      // TODO: Expand this to also be true for address only types.
-      if (isSendableAndStageIsCanonical)
-        require(
-            !p.value()->getType().getASTType()->is<SILBoxType>() ||
-                p.value()->getType().getSILBoxFieldType(&F).isAddressOnly(F),
-            "Concurrent partial apply in canonical SIL with a loadable box "
-            "type argument?!");
     }
 
     // The arguments to the result function type must match the prefix of the

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5706,8 +5706,17 @@ ArgumentList *ExprRewriter::coerceCallArguments(
   // Quickly test if any further fix-ups for the argument types are necessary.
   auto matches = args->matches(params, [&](Expr *E) { return cs.getType(E); });
   if (matches && !shouldInjectWrappedValuePlaceholder &&
-      !paramInfo.anyContextualInfo())
+      !paramInfo.anyContextualInfo()) {
+    // Propagate preconcurrency to any closure arguments.
+    if (preconcurrency) {
+      for (const auto &arg : *args) {
+        Expr *argExpr = arg.getExpr();
+        applyContextualClosureFlags(argExpr, false, false, preconcurrency);
+      }
+    }
+
     return args;
+  }
 
   // Determine the parameter bindings that were applied.
   auto *locatorPtr = cs.getConstraintLocator(locator);

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -103,10 +103,8 @@ template <typename... ArgTypes>
 InFlightDiagnostic
 FailureDiagnostic::emitDiagnosticAt(ArgTypes &&... Args) const {
   auto &DE = getASTContext().Diags;
-  auto behavior = isWarning ? DiagnosticBehavior::Warning
-                            : DiagnosticBehavior::Unspecified;
   return std::move(DE.diagnose(std::forward<ArgTypes>(Args)...)
-                     .limitBehavior(behavior));
+                     .limitBehavior(behaviorLimit));
 }
 
 Expr *FailureDiagnostic::findParentExpr(const Expr *subExpr) const {

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -42,17 +42,19 @@ class FunctionArgApplyInfo;
 class FailureDiagnostic {
   const Solution &S;
   ConstraintLocator *Locator;
-  bool isWarning;
+  DiagnosticBehavior behaviorLimit;
 
 public:
   FailureDiagnostic(const Solution &solution, ConstraintLocator *locator,
-                    bool isWarning = false)
-      : S(solution), Locator(locator), isWarning(isWarning) {}
+                    DiagnosticBehavior behaviorLimit =
+                        DiagnosticBehavior::Unspecified)
+      : S(solution), Locator(locator), behaviorLimit(behaviorLimit) {}
 
   FailureDiagnostic(const Solution &solution, ASTNode anchor,
-                    bool isWarning = false)
+                    DiagnosticBehavior behaviorLimit =
+                        DiagnosticBehavior::Unspecified)
       : FailureDiagnostic(solution, solution.getConstraintLocator(anchor),
-                          isWarning) { }
+                          behaviorLimit) { }
 
   virtual ~FailureDiagnostic();
 
@@ -605,7 +607,9 @@ class ContextualFailure : public FailureDiagnostic {
 
 public:
   ContextualFailure(const Solution &solution, Type lhs, Type rhs,
-                    ConstraintLocator *locator, bool isWarning = false)
+                    ConstraintLocator *locator,
+                    DiagnosticBehavior behaviorLimit =
+                        DiagnosticBehavior::Unspecified)
       : ContextualFailure(
             solution,
             locator->isForContextualType()
@@ -613,12 +617,13 @@ public:
                       .getPurpose()
                 : solution.getConstraintSystem().getContextualTypePurpose(
                       locator->getAnchor()),
-            lhs, rhs, locator, isWarning) {}
+            lhs, rhs, locator, behaviorLimit) {}
 
   ContextualFailure(const Solution &solution, ContextualTypePurpose purpose,
                     Type lhs, Type rhs, ConstraintLocator *locator,
-                    bool isWarning = false)
-      : FailureDiagnostic(solution, locator, isWarning), CTP(purpose),
+                    DiagnosticBehavior behaviorLimit =
+                        DiagnosticBehavior::Unspecified)
+      : FailureDiagnostic(solution, locator, behaviorLimit), CTP(purpose),
         RawFromType(lhs), RawToType(rhs) {
     assert(lhs && "Expected a valid 'from' type");
     assert(rhs && "Expected a valid 'to' type");
@@ -759,8 +764,9 @@ public:
   AttributedFuncToTypeConversionFailure(const Solution &solution, Type fromType,
                                         Type toType, ConstraintLocator *locator,
                                         AttributeKind attributeKind,
-                                        bool isWarning = false)
-      : ContextualFailure(solution, fromType, toType, locator, isWarning),
+                                        DiagnosticBehavior behaviorLimit =
+                                            DiagnosticBehavior::Unspecified)
+      : ContextualFailure(solution, fromType, toType, locator, behaviorLimit),
         attributeKind(attributeKind) {}
 
   bool diagnoseAsError() override;
@@ -784,8 +790,8 @@ class DroppedGlobalActorFunctionAttr final : public ContextualFailure {
 public:
   DroppedGlobalActorFunctionAttr(const Solution &solution, Type fromType,
                                  Type toType, ConstraintLocator *locator,
-                                 bool isWarning)
-    : ContextualFailure(solution, fromType, toType, locator, isWarning) { }
+                                 DiagnosticBehavior behaviorLimit)
+    : ContextualFailure(solution, fromType, toType, locator, behaviorLimit) { }
 
   bool diagnoseAsError() override;
 };
@@ -1955,8 +1961,9 @@ class ArgumentMismatchFailure : public ContextualFailure {
 public:
   ArgumentMismatchFailure(const Solution &solution, Type argType,
                           Type paramType, ConstraintLocator *locator,
-                          bool warning = false)
-      : ContextualFailure(solution, argType, paramType, locator, warning),
+                          DiagnosticBehavior behaviorLimit =
+                              DiagnosticBehavior::Unspecified)
+      : ContextualFailure(solution, argType, paramType, locator, behaviorLimit),
         Info(*getFunctionArgApplyInfo(getLocator())) {}
 
   bool diagnoseAsError() override;
@@ -2135,8 +2142,9 @@ public:
                                 ConstraintLocator *locator, Type fromType,
                                 Type toType,
                                 ConversionRestrictionKind conversionKind,
-                                bool warning)
-      : ArgumentMismatchFailure(solution, fromType, toType, locator, warning),
+                                DiagnosticBehavior behaviorLimit)
+      : ArgumentMismatchFailure(
+            solution, fromType, toType, locator, behaviorLimit),
         ConversionKind(conversionKind) {
   }
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -544,6 +544,10 @@ static bool isSendableClosure(
     if (forActorIsolation && explicitClosure->inheritsActorContext()) {
       return false;
     }
+
+    if (explicitClosure->isIsolatedByPreconcurrency() &&
+        !shouldDiagnoseExistingDataRaces(closure->getParent()))
+      return false;
   }
 
   if (auto type = closure->getType()) {
@@ -3981,11 +3985,18 @@ bool swift::contextRequiresStrictConcurrencyChecking(
 
   while (!dc->isModuleScopeContext()) {
     if (auto closure = dyn_cast<AbstractClosureExpr>(dc)) {
-      // A closure with an explicit global actor or nonindependent
+      // A closure with an explicit global actor, async, or Sendable
       // uses concurrency features.
       if (auto explicitClosure = dyn_cast<ClosureExpr>(closure)) {
         if (getExplicitGlobalActor(const_cast<ClosureExpr *>(explicitClosure)))
           return true;
+
+        // Don't take any more cues if this only got its type information by
+        // being provided to a `@preconcurrency` operation.
+        if (explicitClosure->isIsolatedByPreconcurrency()) {
+          dc = dc->getParent();
+          continue;
+        }
 
         if (auto type = getType(closure)) {
           if (auto fnType = type->getAs<AnyFunctionType>())
@@ -4590,7 +4601,7 @@ static AnyFunctionType *applyUnsafeConcurrencyToFunctionType(
     if (addSendable || addMainActor) {
       newParamType = applyUnsafeConcurrencyToParameterType(
         param.getPlainType(), addSendable, addMainActor);
-    } else if (stripConcurrency) {
+    } else if (stripConcurrency && numApplies == 0) {
       newParamType = param.getPlainType()->stripConcurrency(
           /*recurse=*/false, /*dropGlobalActor=*/numApplies == 0);
     }

--- a/test/Concurrency/actor_call_implicitly_async.swift
+++ b/test/Concurrency/actor_call_implicitly_async.swift
@@ -298,7 +298,7 @@ func blender(_ peeler : () -> Void) {
   // expected-warning@-1 3{{non-sendable type 'Any' passed in call to global actor 'BananaActor'-isolated function cannot cross actor boundary}}
 
   blender((peelBanana))
-  // expected-error@-1{{converting function value of type '@BananaActor () -> ()' to '() -> Void' loses global actor 'BananaActor'}}
+  // expected-warning@-1{{converting function value of type '@BananaActor () -> ()' to '() -> Void' loses global actor 'BananaActor'}}
   await wisk(peelBanana)
   // expected-warning@-1{{non-sendable type 'Any' passed in call to global actor 'BananaActor'-isolated function cannot cross actor boundary}}
 

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -463,7 +463,7 @@ func testGlobalActorClosures() {
     return 17
   }
 
-  acceptConcurrentClosure { @SomeGlobalActor in 5 } // expected-error{{converting function value of type '@SomeGlobalActor @Sendable () -> Int' to '@Sendable () -> Int' loses global actor 'SomeGlobalActor'}}
+  acceptConcurrentClosure { @SomeGlobalActor in 5 } // expected-warning{{converting function value of type '@SomeGlobalActor @Sendable () -> Int' to '@Sendable () -> Int' loses global actor 'SomeGlobalActor'}}
 }
 
 @available(SwiftStdlib 5.1, *)

--- a/test/Concurrency/global_actor_function_types.swift
+++ b/test/Concurrency/global_actor_function_types.swift
@@ -130,8 +130,8 @@ func testTypesConcurrencyContext() async {
   let f1 = onSomeGlobalActor
   let f2 = onSomeGlobalActorUnsafe
 
-  let _: () -> Int = f1 // expected-error{{converting function value of type '@SomeGlobalActor () -> Int' to '() -> Int' loses global actor 'SomeGlobalActor'}}
-  let _: () -> Int = f2 // expected-error{{converting function value of type '@SomeGlobalActor () -> Int' to '() -> Int' loses global actor 'SomeGlobalActor'}}
+  let _: () -> Int = f1 // expected-warning{{converting function value of type '@SomeGlobalActor () -> Int' to '() -> Int' loses global actor 'SomeGlobalActor'}}
+  let _: () -> Int = f2 // expected-warning{{converting function value of type '@SomeGlobalActor () -> Int' to '() -> Int' loses global actor 'SomeGlobalActor'}}
 
   // expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
   _ = f1() //expected-note{{calls to let 'f1' from outside of its actor context are implicitly asynchronous}}

--- a/test/SIL/concurrentclosure_capture_verify_canonical_loadable.sil
+++ b/test/SIL/concurrentclosure_capture_verify_canonical_loadable.sil
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-sil-opt  %s
+// RUN: %target-sil-opt  %s
 
 // REQUIRES: concurrency
 

--- a/test/SILGen/preconcurrency.swift
+++ b/test/SILGen/preconcurrency.swift
@@ -14,8 +14,8 @@ func testModuleMethodWithSendable(any: Any) {
 
   // CHECK: function_ref @$s14preconcurrency1fyyypF : $@convention(thin) (@in_guaranteed Sendable) -> ()
   let _ = preconcurrency.f
-  // f(any)
-  // preconcurrency.f(any)
+  f(any)
+  preconcurrency.f(any)
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s14preconcurrency30testInstanceMethodWithSendable1c3anyyAA1CC_yptF : $@convention(thin) (@guaranteed C, @in_guaranteed Any) -> () {
@@ -25,5 +25,5 @@ func testInstanceMethodWithSendable(c: C, any: Any) {
   let _ = c.f
   let _ = C.f
   let _ = C.g
-//  c.f(any)
+  c.f(any)
 }


### PR DESCRIPTION
When calling a `@preconcurrency` function, don't adjust the types of parameters, because SILGen considers such calls to be invalid and will assert. Instead, suppress or alter diagnostics later on to deal with `Sendable` and global-actor mismatches.

Fix rdar://95995193