### PR TITLE
[CSApply] Don't attempt covariant result type erasure when parameters use dynamic `Self`.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1720,7 +1720,8 @@ namespace {
         return forceUnwrapIfExpected(result, memberLocator);
       }
 
-      if (member->getInterfaceType()->hasDynamicSelfType()) {
+      auto *func = dyn_cast<FuncDecl>(member);
+      if (func && func->getResultInterfaceType()->hasDynamicSelfType()) {
         refTy = refTy->replaceCovariantResultType(containerTy, 2);
         adjustedRefTy = adjustedRefTy->replaceCovariantResultType(
             containerTy, 2);

--- a/test/SILGen/dynamic_self.swift
+++ b/test/SILGen/dynamic_self.swift
@@ -519,6 +519,17 @@ public class CaptureTwoValuesTest {
   }
 }
 
+
+final class Final {
+  static func useSelf(_ body: (Self) -> ()) {}
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s12dynamic_self13testNoErasureyyyAA5FinalCXEF : $@convention(thin) (@noescape @callee_guaranteed (@guaranteed Final) -> ()) -> () {
+func testNoErasure(_ body: (Final) -> ()) {
+  // CHECK: function_ref @$s12dynamic_self5FinalC7useSelfyyyACXDXEFZ : $@convention(method) (@noescape @callee_guaranteed (@guaranteed Final) -> (), @thick Final.Type) -> ()
+  return Final.useSelf(body)
+}
+
 // CHECK-LABEL: sil_witness_table hidden X: P module dynamic_self {
 // CHECK: method #P.f: {{.*}} : @$s12dynamic_self1XCAA1PA2aDP1f{{[_0-9a-zA-Z]*}}FTW
 

--- a/test/Sema/dynamic_self_implicit_conversions.swift
+++ b/test/Sema/dynamic_self_implicit_conversions.swift
@@ -74,3 +74,10 @@ extension Generic where T == Never {
     _ = Generic()[]
   }
 }
+
+final class Final {
+  static func useSelf(_ body: (Self) -> ()) {}
+}
+func testNoErasure(_ body: (Final) -> ()) {
+  return Final.useSelf(body)
+}


### PR DESCRIPTION
Otherwise, the following code crashes, because `buildMemberRef` attempts covariant result type erasure of `Final.useSelf` but there is no `Self` in the result type:

```swift
final class Final {
  static func useSelf(_ body: (Self) -> ()) {}
}
func testNoErasure(_ body: (Final) -> ()) {
  return Final.useSelf(body)
}
```

This code used to build successfully in Swift 5.5, and started crashing in Swift 5.6. This change adjusts the condition for performing covariant result type erasure to only the case where the member is a `FuncDecl` with a use of dynamic `Self` in the result type. Member references to `VarDecl`s are handled before this case, and I think `buildMemberRef` only needs to do covariant result type erasure for `FuncDecl`s after that point.

Resolves: rdar://89099887