### PR TITLE
[ConstraintSystem] Improve ast printing in the type inference algorithm debug output

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2590,12 +2590,6 @@ public:
     }
     Indent -= 2;
 
-    // If we printed any args, then print the closing ')' on a new line,
-    // otherwise print inline with the '(argument_list'.
-    if (!argList->empty()) {
-      OS << '\n';
-      OS.indent(Indent);
-    }
     PrintWithColorRAII(OS, ParenthesisColor) << ')';
 
     if (indent)

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2012,15 +2012,7 @@ public:
       << E->getDecls()[0]->getBaseName();
     PrintWithColorRAII(OS, ExprModifierColor)
       << " number_of_decls=" << E->getDecls().size()
-      << " function_ref=" << getFunctionRefKindStr(E->getFunctionRefKind())
-      << " decls=[\n";
-    interleave(E->getDecls(),
-               [&](ValueDecl *D) {
-                 OS.indent(Indent + 2);
-                 D->dumpRef(PrintWithColorRAII(OS, DeclModifierColor).getOS());
-               },
-               [&] { PrintWithColorRAII(OS, DeclModifierColor) << ",\n"; });
-    PrintWithColorRAII(OS, ExprModifierColor) << "]";
+      << " function_ref=" << getFunctionRefKindStr(E->getFunctionRefKind());
     PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
   void visitUnresolvedDeclRefExpr(UnresolvedDeclRefExpr *E) {

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1386,6 +1386,7 @@ void ConstraintSystem::print(raw_ostream &out, Expr *E) const {
   };
 
   E->dump(out, getTypeOfExpr, getTypeOfTypeRepr, getTypeOfKeyPathComponent);
+  out << "\n";
 }
 
 void ConstraintSystem::print(raw_ostream &out) const {


### PR DESCRIPTION
This reduces the output produced during AST printing in the type inference algorithm debug output by eliminating the list of overloaded decl references, as this information appears later under Inactive Constraints, where it is more useful.

For example, the following:

```
(binary_expr type='$T3' location=/Users/amritpankaur/test.swift:53:5 range=[/Users/amritpankaur/test.swift:53:1 - line:53:7]
  (overloaded_decl_ref_expr type='$T0' location=/Users/amritpankaur/test.swift:53:5 range=[/Users/amritpankaur/test.swift:53:5 - line:53:5] name=+ number_of_decls=34 function_ref=single decls=[
    Swift.(file).String extension.+,
    Swift.(file).Duration extension.+,
    Swift.(file).Float16 extension.+,
    Swift.(file).Float extension.+,
    Swift.(file).Double extension.+,
    Swift.(file).UInt8 extension.+,
    Swift.(file).Int8 extension.+,
    Swift.(file).UInt16 extension.+,
    Swift.(file).Int16 extension.+,
    Swift.(file).UInt32 extension.+,
    Swift.(file).Int32 extension.+,
    Swift.(file).UInt64 extension.+,
    Swift.(file).Int64 extension.+,
    Swift.(file).UInt extension.+,
    Swift.(file).Int extension.+,
    ... // 20 additional dec references )
  (argument_list implicit
    (argument
      (string_literal_expr type='$T1' location=/Users/amritpankaur/test.swift:53:1 range=[/Users/amritpankaur/test.swift:53:1 - line:53:1] encoding=utf8 value="a" builtin_initializer=**NULL** initializer=**NULL**))
    (argument
      (integer_literal_expr type='$T2' location=/Users/amritpankaur/test.swift:53:7 range=[/Users/amritpankaur/test.swift:53:7 - line:53:7] value=2 builtin_initializer=**NULL** initializer=**NULL**))
  ))
```

is reduced to :

```
(binary_expr type='$T3' location=/Users/amritpankaur/test.swift:53:5 range=[/Users/amritpankaur/test.swift:53:1 - line:53:7]
  (overloaded_decl_ref_expr type='$T0' location=/Users/amritpankaur/test.swift:53:5 range=[/Users/amritpankaur/test.swift:53:5 - line:53:5] name=+ number_of_decls=34 function_ref=single)
  (argument_list implicit
    (argument
      (string_literal_expr type='$T1' location=/Users/amritpankaur/test.swift:53:1 range=[/Users/amritpankaur/test.swift:53:1 - line:53:1] encoding=utf8 value="a" builtin_initializer=**NULL** initializer=**NULL**))
    (argument
      (integer_literal_expr type='$T2' location=/Users/amritpankaur/test.swift:53:7 range=[/Users/amritpankaur/test.swift:53:7 - line:53:7] value=2 builtin_initializer=**NULL** initializer=**NULL**))))
```


This reduction will make the printed AST easier to read.

