### PR TITLE
[ConstraintSystem] Improve type variable printing in the type inference algorithm debug output

### DIFF
--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -558,6 +558,18 @@ private:
   /// Check whether the given binding set covers any of the
   /// literal protocols associated with this type variable.
   void determineLiteralCoverage();
+  
+  StringRef getLiteralBindingKind(LiteralBindingKind K) const {
+  #define ENTRY(Kind, String) case LiteralBindingKind::Kind: return String
+    switch (K) {
+    ENTRY(None, "none");
+    ENTRY(Collection, "collection");
+    ENTRY(Float, "float");
+    ENTRY(Atom, "atom");
+    }
+  #undef ENTRY
+  }
+  
 };
 
 } // end namespace inference

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -588,6 +588,19 @@ public:
 
   /// Print the type variable to the given output stream.
   void print(llvm::raw_ostream &OS);
+  
+private:
+  StringRef getTypeVariableOptions(TypeVariableOptions TVO) const {
+  #define ENTRY(Kind, String) case TypeVariableOptions::Kind: return String
+    switch (TVO) {
+    ENTRY(TVO_CanBindToLValue, "lvalue");
+    ENTRY(TVO_CanBindToInOut, "inout");
+    ENTRY(TVO_CanBindToNoEscape, "noescape");
+    ENTRY(TVO_CanBindToHole, "hole");
+    ENTRY(TVO_PrefersSubtypeBinding, "");
+    }
+  #undef ENTRY
+  }
 };
 
 namespace constraints {

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1620,17 +1620,26 @@ void BindingSet::dump(llvm::raw_ostream &out, unsigned indent) const {
   PO.PrintTypesForDebugging = true;
 
   out.indent(indent);
+  std::vector<std::string> attributes;
   if (isDirectHole())
-    out << "hole ";
+    attributes.push_back("hole");
   if (isPotentiallyIncomplete())
-    out << "potentially_incomplete ";
+    attributes.push_back("potentially_incomplete");
   if (isDelayed())
-    out << "delayed ";
+    attributes.push_back("delayed");
   if (isSubtypeOfExistentialType())
-    out << "subtype_of_existential ";
+    attributes.push_back("subtype_of_existential");
   auto literalKind = getLiteralKind();
-  if (literalKind != LiteralBindingKind::None)
-    out << "literal=" << static_cast<int>(literalKind) << " ";
+  if (literalKind != LiteralBindingKind::None) {
+    auto literalAttrStr = ("[literal: " + getLiteralBindingKind(literalKind)
+                        + "]").str();
+    attributes.push_back(literalAttrStr);
+  }
+  if (!attributes.empty()) {
+    out << "[attributes: ";
+    interleave(attributes, out, ", ");
+    out << "] ";
+  }
   if (involvesTypeVariables()) {
     out << "involves_type_vars=[";
     interleave(AdjacentVars,

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1671,9 +1671,11 @@ void BindingSet::dump(llvm::raw_ostream &out, unsigned indent) const {
     out << type.getString(PO);
   };
 
-  out << "bindings={";
+  out << "[with possible bindings: ";
   interleave(Bindings, printBinding, [&]() { out << "; "; });
-  out << "}";
+  if (Bindings.empty())
+    out << "<empty>";
+  out << "]";
 
   if (!Defaults.empty()) {
     out << " defaults={";

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1641,16 +1641,16 @@ void BindingSet::dump(llvm::raw_ostream &out, unsigned indent) const {
     out << "] ";
   }
   if (involvesTypeVariables()) {
-    out << "involves_type_vars=[";
+    out << "[involves_type_vars: ";
     interleave(AdjacentVars,
                [&](const auto *typeVar) { out << typeVar->getString(PO); },
-               [&out]() { out << " "; });
+               [&out]() { out << ", "; });
     out << "] ";
   }
 
   auto numDefaultable = getNumViableDefaultableBindings();
   if (numDefaultable > 0)
-    out << "#defaultable_bindings=" << numDefaultable << " ";
+    out << "#defaultable_bindings: " << numDefaultable << " ";
 
   auto printBinding = [&](const PotentialBinding &binding) {
     auto type = binding.BindingType;
@@ -1678,14 +1678,14 @@ void BindingSet::dump(llvm::raw_ostream &out, unsigned indent) const {
   out << "]";
 
   if (!Defaults.empty()) {
-    out << " defaults={";
+    out << "[defaults: ";
     for (const auto &entry : Defaults) {
       auto *constraint = entry.second;
       PotentialBinding binding{constraint->getSecondType(),
                                AllowedBindingKind::Exact, constraint};
       printBinding(binding);
     }
-    out << "}";
+    out << "] ";
   }
 }
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1416,14 +1416,23 @@ void ConstraintSystem::print(raw_ostream &out) const {
   for (auto tv : typeVariables) {
     out.indent(2);
     Type(tv).print(out, PO);
+    SmallVector<TypeVariableOptions, 4> bindingOptions;
     if (tv->getImpl().canBindToLValue())
-      out << " [lvalue allowed]";
+      bindingOptions.push_back(TypeVariableOptions::TVO_CanBindToLValue);
     if (tv->getImpl().canBindToInOut())
-      out << " [inout allowed]";
+      bindingOptions.push_back(TypeVariableOptions::TVO_CanBindToInOut);
     if (tv->getImpl().canBindToNoEscape())
-      out << " [noescape allowed]";
+      bindingOptions.push_back(TypeVariableOptions::TVO_CanBindToNoEscape);
     if (tv->getImpl().canBindToHole())
-      out << " [hole allowed]";
+      bindingOptions.push_back(TypeVariableOptions::TVO_CanBindToHole);
+    if (!bindingOptions.empty()) {
+      out << " [allows bindings to: ";
+      interleave(bindingOptions, out,
+                 [&](TypeVariableOptions option) {
+                    (out << tv->getImpl().getTypeVariableOptions(option));},
+                 ", ");
+                 out << "]";
+    }
     auto rep = getRepresentative(tv);
     if (rep == tv) {
       if (auto fixed = getFixedType(tv)) {


### PR DESCRIPTION
These changes reformat and expand the type variables printed in the type inference algorithm debug output. The allowed binding properties, type variable attributes, potential bindings, and other relevant output have been edited to clearly group and state their information for improved readability.

For example, the following type variables:
```
$T1 [lvalue allowed] [noescape allowed] delayed bindings={} @ locator@0x13d054598 [OverloadedDeclRef@/...]
$T2 [noescape allowed] delayed literal=3 bindings={} @ locator@0x13d058948 [IntegerLiteral@/...]
```

will now read as: 

```
$T1 [allows bindings to: lvalue, noescape] [attributes: delayed] [with possible bindings: <empty>]  @ locator@0x13a2e3398 [OverloadedDeclRef@/...]
$T2 [allows bindings to: noescape] [attributes: delayed, [literal: atom]] [with possible bindings: <empty>]  @ locator@0x13a2e4948 [IntegerLiteral@/...]
```
