### PR TITLE
[ConstraintSystem] Improve initial constraints printing in the type inference algorithm debug output

### DIFF
--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -852,7 +852,10 @@ public:
   /// Clone the given constraint.
   Constraint *clone(ConstraintSystem &cs) const;
 
-  void print(llvm::raw_ostream &Out, SourceManager *sm) const;
+  /// Print constraint placed on type and constraint properties.
+  ///
+  /// \c skipLocator skips printing of locators.
+  void print(llvm::raw_ostream &Out, SourceManager *sm, bool skipLocator = false) const;
 
   SWIFT_DEBUG_DUMPER(dump(SourceManager *SM));
 

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -322,7 +322,7 @@ Constraint *Constraint::clone(ConstraintSystem &cs) const {
   llvm_unreachable("Unhandled ConstraintKind in switch.");
 }
 
-void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm) const {
+void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm, bool skipLocator) const {
   // Print all type variables as $T0 instead of _ here.
   PrintOptions PO;
   PO.PrintTypesForDebugging = true;
@@ -352,7 +352,8 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm) const {
                    Out << ">  [favored]  ";
                  else
                    Out << ">             ";
-                 constraint->print(Out, sm);
+                 constraint->print(Out, sm,
+                   /*skipLocator=*/constraint->getLocator() == Locator);
                },
                [&] { Out << "\n"; });
     return;
@@ -522,7 +523,7 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm) const {
     fix->print(Out);
   }
 
-  if (Locator) {
+  if (Locator && !skipLocator) {
     Out << " [[";
     Locator->dump(sm, Out);
     Out << "]];";

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -343,8 +343,21 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm, bool skipLocat
       Out << "]]";
     }
     Out << ":\n";
+    
+    // Sort constraints by favored, unmarked, disabled
+    // for printing only.
+    std::vector<Constraint *> sortedConstraints(getNestedConstraints().begin(),
+                                                getNestedConstraints().end());
+    llvm::sort(sortedConstraints,
+               [](const Constraint *lhs, const Constraint *rhs) {
+                 if (lhs->isFavored() != rhs->isFavored())
+                   return lhs->isFavored();
+                 if (lhs->isDisabled() != rhs->isDisabled())
+                   return rhs->isDisabled();
+                 return false;
+               });
 
-    interleave(getNestedConstraints(),
+    interleave(sortedConstraints,
                [&](Constraint *constraint) {
                  if (constraint->isDisabled())
                    Out << ">  [disabled] ";

--- a/test/Constraints/overload_filtering_objc.swift
+++ b/test/Constraints/overload_filtering_objc.swift
@@ -25,10 +25,10 @@ func testOptional(obj: P) {
 
 
 func test_double_cgfloat_conversion_filtering(d: Double, cgf: CGFloat) {
-  // CHECK: [favored] $T{{.*}} bound to decl CoreGraphics.(file).CGFloat.init(_:)@{{.*}} : (CGFloat.Type) -> (Double) -> CGFloat {{.*}} -> implicit conversion [Double-to-CGFloat] -> apply function -> constructor member
+  // CHECK: [favored] $T{{.*}} bound to decl CoreGraphics.(file).CGFloat.init(_:)@{{.*}} : (CGFloat.Type) -> (Double) -> CGFloat
   let _: CGFloat = d
 
-  // CHECK: [favored] $T{{.*}} bound to decl CoreGraphics.(file).Double extension.init(_:)@{{.*}} : (Double.Type) -> (CGFloat) -> Double {{.*}} -> implicit conversion [CGFloat-to-Double] -> apply function -> constructor member
+  // CHECK: [favored] $T{{.*}} bound to decl CoreGraphics.(file).Double extension.init(_:)@{{.*}} : (Double.Type) -> (CGFloat) -> Double
   let _: Double = cgf
 
   func test_optional_cgf(_: CGFloat??) {
@@ -37,9 +37,9 @@ func test_double_cgfloat_conversion_filtering(d: Double, cgf: CGFloat) {
   func test_optional_double(_: Double??) {
   }
 
-  // CHECK: [favored] $T{{.*}} bound to decl CoreGraphics.(file).CGFloat.init(_:)@{{.*}} : (CGFloat.Type) -> (Double) -> CGFloat {{.*}} -> implicit conversion [Double-to-CGFloat] -> apply function -> constructor member
+  // CHECK: [favored] $T{{.*}} bound to decl CoreGraphics.(file).CGFloat.init(_:)@{{.*}} : (CGFloat.Type) -> (Double) -> CGFloat
   test_optional_cgf(d)
 
-  // CHECK: [favored] $T{{.*}} bound to decl CoreGraphics.(file).Double extension.init(_:)@{{.*}} : (Double.Type) -> (CGFloat) -> Double {{.*}} -> implicit conversion [CGFloat-to-Double] -> apply function -> constructor member
+  // CHECK: [favored] $T{{.*}} bound to decl CoreGraphics.(file).Double extension.init(_:)@{{.*}} : (Double.Type) -> (CGFloat) -> Double
   test_optional_double(cgf)
 }


### PR DESCRIPTION
These changes reduce and reformat the initial constraints printed by the type inference algorithm's debug output. By reducing repetitive locators and better sorting the constraints, the possible constraints are easier to follow.

For example, the following disjunctions:

```
Inactive Constraints:
  disjunction [[locator@0x13b1cf000 [OverloadedDeclRef@/Users/amritpankaur/test.swift:53:5]]]:
>  [favored]  $T0 bound to decl Swift.(file).String extension.+ : (String.Type) -> (String, String) -> String [[locator@0x13b1cf000 [OverloadedDeclRef@/Users/amritpankaur/test.swift:53:5]]];
>             $T0 bound to decl Swift.(file).Duration extension.+ : (Duration.Type) -> (Duration, Duration) -> Duration [[locator@0x13b1cf000 [OverloadedDeclRef@/Users/amritpankaur/test.swift:53:5]]];
>             ... // additional constraints
>             $T0 bound to decl Swift.(file).UInt extension.+ : (UInt.Type) -> (UInt, UInt) -> UInt [[locator@0x13b1cf000 [OverloadedDeclRef@/Users/amritpankaur/test.swift:53:5]]];
>  [favored]  $T0 bound to decl Swift.(file).Int extension.+ : (Int.Type) -> (Int, Int) -> Int [[locator@0x13b1cf000 [OverloadedDeclRef@/Users/amritpankaur/test.swift:53:5]]];
>             $T0 bound to decl _Concurrency.(file).Instant extension.+ : (ContinuousClock.Instant.Type) -> (ContinuousClock.Instant, Duration) -> ContinuousClock.Instant [[locator@0x13b1cf000 [OverloadedDeclRef@/Users/amritpankaur/test.swift:53:5]]];
>             ... // additional constraints
```

will now print as:

```
Inactive Constraints:
  disjunction [[locator@0x13aaa7800 [OverloadedDeclRef@/Users/amritpankaur/test.swift:53:5]]]:
>  [favored]  $T0 bound to decl Swift.(file).String extension.+ : (String.Type) -> (String, String) -> String
>  [favored]  $T0 bound to decl Swift.(file).Int extension.+ : (Int.Type) -> (Int, Int) -> Int
>             $T0 bound to decl Swift.(file).Duration extension.+ : (Duration.Type) -> (Duration, Duration) -> Duration
>             ... // additional constraints
```
