### PR TITLE
[stdlib] Fix func signature spacing in Equatable.swift

### DIFF
--- a/stdlib/public/core/Equatable.swift
+++ b/stdlib/public/core/Equatable.swift
@@ -217,7 +217,7 @@ extension Equatable {
 ///         }
 ///     }
 ///
-///     func ==(lhs: IntegerRef, rhs: IntegerRef) -> Bool {
+///     func == (lhs: IntegerRef, rhs: IntegerRef) -> Bool {
 ///         return lhs.value == rhs.value
 ///     }
 ///


### PR DESCRIPTION
- standardizes spacing of an operator(==) func signature in Equatable.swift
  - (ref.) #3698

```diff
- func ==(...
+ func == (...
```