### PR TITLE
Don't consider marker protocols when mangling associated type refs.

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2925,6 +2925,21 @@ void ASTMangler::appendGenericSignatureParts(
   appendOperator("r", StringRef(OpStorage.data(), OpStorage.size()));
 }
 
+/// Determine whether an associated type reference into the given set of
+/// protocols is unambiguous.
+static bool associatedTypeRefIsUnambiguous(ArrayRef<ProtocolDecl *> protocols) {
+  unsigned numProtocols = 0;
+  for (auto proto : protocols) {
+    // Skip marker protocols, which cannot have associated types.
+    if (proto->isMarkerProtocol())
+      continue;
+
+    ++numProtocols;
+  }
+
+  return numProtocols <= 1;
+}
+
 // If the base type is known to have a single protocol conformance
 // in the current generic context, then we don't need to disambiguate the
 // associated type name by protocol.
@@ -2934,7 +2949,7 @@ ASTMangler::dropProtocolFromAssociatedType(DependentMemberType *dmt,
   auto baseTy = dmt->getBase();
   bool unambiguous =
       (!dmt->getAssocType() ||
-       sig->getRequiredProtocols(baseTy).size() <= 1);
+       associatedTypeRefIsUnambiguous(sig->getRequiredProtocols(baseTy)));
 
   if (auto *baseDMT = baseTy->getAs<DependentMemberType>())
     baseTy = dropProtocolFromAssociatedType(baseDMT, sig);
@@ -2970,7 +2985,8 @@ void ASTMangler::appendAssociatedTypeName(DependentMemberType *dmt,
     // in the current generic context, then we don't need to disambiguate the
     // associated type name by protocol.
     if (!OptimizeProtocolNames || !sig ||
-        sig->getRequiredProtocols(dmt->getBase()).size() > 1) {
+        !associatedTypeRefIsUnambiguous(
+            sig->getRequiredProtocols(dmt->getBase()))) {
       appendAnyGenericType(assocTy->getProtocol());
     }
     return;

--- a/test/IRGen/marker_protocol.swift
+++ b/test/IRGen/marker_protocol.swift
@@ -78,3 +78,10 @@ struct Foo: SelfConstrainedProtocol {
     Foo(x: 123)
   }
 }
+
+protocol P2 {
+  associatedtype Foo
+}
+
+// CHECK: define{{.*}}$s15marker_protocol3fooyy3FooQz_xtAA1PRzAA2P2RzlF
+func foo<T: P & P2>(_: T.Foo, _: T) { }


### PR DESCRIPTION
Associated type references can be mangled without reference to the
protocol they are in when there is only one protocol to which the
base type conforms. Because marker protocols can never have associated
types, don't consider them in this computation. This allows marker
protocols to be added more freely to, e.g., generic type requirements.

Fixes rdar://95994469.
