### PR TITLE
[5.7] Don't consider marker protocols when mangling associated type refs.

### DIFF
--- a/test/IRGen/marker_protocol.swift
+++ b/test/IRGen/marker_protocol.swift
@@ -78,3 +78,10 @@ struct Foo: SelfConstrainedProtocol {
     Foo(x: 123)
   }
 }
+
+protocol P2 {
+  associatedtype Foo
+}
+
+// CHECK: define{{.*}}$s15marker_protocol3fooyy3FooQz_xtAA1PRzAA2P2RzlF
+func foo<T: P & P2>(_: T.Foo, _: T) { }


### PR DESCRIPTION
Associated type references can be mangled without reference to the
protocol they are in when there is only one protocol to which the
base type conforms. Because marker protocols can never have associated
types, don't consider them in this computation. This allows marker
protocols to be added more freely to, e.g., generic type requirements.

Fixes rdar://95994469.
