### PR TITLE
[IRGen] NFC: Remove unused parameter from `bindPolymorphicArgumentsFromComponentIndices`

### DIFF
--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -70,7 +70,6 @@ enum KeyPathAccessor {
 
 static void
 bindPolymorphicArgumentsFromComponentIndices(IRGenFunction &IGF,
-                                     const KeyPathPatternComponent &component,
                                      GenericEnvironment *genericEnv,
                                      ArrayRef<GenericRequirement> requirements,
                                      llvm::Value *args,
@@ -238,7 +237,7 @@ getAccessorForComputedComponent(IRGenModule &IGM,
       break;
     }
     auto componentArgsBufSize = params.claimNext();
-    bindPolymorphicArgumentsFromComponentIndices(IGF, component,
+    bindPolymorphicArgumentsFromComponentIndices(IGF,
                                                  genericEnv, requirements,
                                                  componentArgsBuf,
                                                  componentArgsBufSize,
@@ -395,7 +394,7 @@ getWitnessTableForComputedComponent(IRGenModule &IGM,
       auto params = IGF.collectParameters();
       auto componentArgsBuf = params.claimNext();
       auto componentArgsBufSize = params.claimNext();
-      bindPolymorphicArgumentsFromComponentIndices(IGF, component,
+      bindPolymorphicArgumentsFromComponentIndices(IGF,
                                      genericEnv, requirements,
                                      componentArgsBuf,
                                      componentArgsBufSize,
@@ -449,7 +448,7 @@ getWitnessTableForComputedComponent(IRGenModule &IGM,
       auto sourceArgsBuf = params.claimNext();
       auto destArgsBuf = params.claimNext();
       auto componentArgsBufSize = params.claimNext();
-      bindPolymorphicArgumentsFromComponentIndices(IGF, component,
+      bindPolymorphicArgumentsFromComponentIndices(IGF,
                                      genericEnv, requirements,
                                      sourceArgsBuf,
                                      componentArgsBufSize,


### PR DESCRIPTION
This hasn't been used since 02b23d0d96b65299a390df83caf624a25dfc1dc7

I started refactoring keypath accessor things to get rid of re-thunking in IRGen&SILGen and make IRGen the single source of the keypath calling convention. Draft patch set is [here](https://github.com/swiftwasm/swift/pull/4657)