### PR TITLE
Calling `@_unsafeInheritExecutor` functions doesn't exit the current actor

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5053,7 +5053,9 @@ ActorReferenceResult ActorReferenceResult::forReference(
   if (!declIsolation.isActorIsolated()) {
     // If the declaration is asynchronous and we are in an actor-isolated
     // context (of any kind), then we exit the actor to the nonisolated context.
-    if (isAsyncDecl(declRef) && contextIsolation.isActorIsolated())
+    if (isAsyncDecl(declRef) && contextIsolation.isActorIsolated() &&
+        !declRef.getDecl()->getAttrs()
+            .hasAttribute<UnsafeInheritExecutorAttr>())
       return forExitsActorToNonisolated(contextIsolation);
 
     // Otherwise, we stay in the same concurrency domain, whether on an actor

--- a/test/Concurrency/unsafe_inherit_executor.swift
+++ b/test/Concurrency/unsafe_inherit_executor.swift
@@ -21,7 +21,7 @@ struct A {
 }
 
 
-class NonSendableObject { // expected-note{{class 'NonSendableObject' does not conform to the 'Sendable' protocol}}
+class NonSendableObject {
   var property = 0
 }
 
@@ -31,7 +31,6 @@ func useNonSendable(object: NonSendableObject) async {}
 actor MyActor {
   var object = NonSendableObject()
   func foo() async {
-    // expected-warning@+1{{non-sendable type 'NonSendableObject' exiting actor-isolated context in call to non-isolated global function 'useNonSendable(object:)' cannot cross actor boundary}}
     await useNonSendable(object: self.object)
   }
 }


### PR DESCRIPTION
Fixes a spurious warning reported by rdar://95777456.
