### PR TITLE
[Glibc] Extract `features.h` into a submodule

### DIFF
--- a/stdlib/public/Platform/SwiftGlibc.h.gyb
+++ b/stdlib/public/Platform/SwiftGlibc.h.gyb
@@ -1,8 +1,5 @@
 %{
 headers = [
-  'stdc-predef.h',
-  'features.h',
-
   # C standard library
   'complex.h',
   'ctype.h',

--- a/stdlib/public/Platform/glibc.modulemap.gyb
+++ b/stdlib/public/Platform/glibc.modulemap.gyb
@@ -19,6 +19,12 @@
 /// It's not named just Glibc so that it doesn't conflict in the event of a
 /// future official glibc modulemap.
 module SwiftGlibc [system] {
+  module __features {
+    header "stdc-predef.h"
+    header "features.h"
+    export *
+  }
+
 % if CMAKE_SDK in ["LINUX", "ANDROID", "OPENBSD"]:
       link "m"
 % end


### PR DESCRIPTION
This header is included by multiple different headers. To make sure it's pinned to a specific Clang module, let's extract it into a separate submodule of `SwiftGlibc`.