### PR TITLE
[cxx-interop] Update tests for foreign reference types

### DIFF
--- a/test/Interop/Cxx/foreign-reference/Inputs/move-only.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/move-only.h
@@ -2,10 +2,13 @@
 #define TEST_INTEROP_CXX_FOREIGN_REFERENCE_INPUTS_MOVE_ONLY_H
 
 #include <stdlib.h>
+#if defined(_WIN32)
+inline void *operator new(size_t, void *p) { return p; }
+#else
+#include <new>
+#endif
 
 #include "visibility.h"
-
-inline void *operator new(size_t, void *p) { return p; }
 
 template <class _Tp>
 _Tp &&move(_Tp &t) {

--- a/test/Interop/Cxx/foreign-reference/Inputs/nullable.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/nullable.h
@@ -2,8 +2,11 @@
 #define TEST_INTEROP_CXX_FOREIGN_REFERENCE_INPUTS_NULLABLE_H
 
 #include <stdlib.h>
-
+#if defined(_WIN32)
 inline void *operator new(size_t, void *p) { return p; }
+#else
+#include <new>
+#endif
 
 struct __attribute__((swift_attr("import_as_ref"))) Empty {
   int test() const { return 42; }

--- a/test/Interop/Cxx/foreign-reference/Inputs/pod.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/pod.h
@@ -2,13 +2,16 @@
 #define TEST_INTEROP_CXX_FOREIGN_REFERENCE_INPUTS_POD_H
 
 #include <stdlib.h>
+#if defined(_WIN32)
+inline void *operator new(size_t, void *p) { return p; }
+#else
+#include <new>
+#endif
 
 #include "visibility.h"
 
 template <class From, class To>
 To __swift_interopStaticCast(From from) { return from; }
-
-inline void *operator new(size_t, void *p) { return p; }
 
 SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 

--- a/test/Interop/Cxx/foreign-reference/Inputs/singleton.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/singleton.h
@@ -2,10 +2,13 @@
 #define TEST_INTEROP_CXX_FOREIGN_REFERENCE_INPUTS_SINGLETON_H
 
 #include <stdlib.h>
+#if defined(_WIN32)
+inline void *operator new(size_t, void *p) { return p; }
+#else
+#include <new>
+#endif
 
 #include "visibility.h"
-
-inline void *operator new(size_t, void *p) { return p; }
 
 SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 

--- a/test/Interop/Cxx/foreign-reference/Inputs/witness-table.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/witness-table.h
@@ -2,8 +2,11 @@
 #define TEST_INTEROP_CXX_FOREIGN_REFERENCE_INPUTS_WITNESS_TABLE_H
 
 #include <stdlib.h>
-
+#if defined(_WIN32)
 inline void *operator new(size_t, void *p) { return p; }
+#else
+#include <new>
+#endif
 
 struct __attribute__((swift_attr("import_as_ref"))) CxxLinkedList {
   int value = 3;


### PR DESCRIPTION
This fixes errors in tests:
```
/home/build-user/swift/test/Interop/Cxx/foreign-reference/Inputs/singleton.h:8:14: error: 'operator new' is missing exception specification 'noexcept'
inline void *operator new(size_t, void *p) { return p; }
             ^
/usr/lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/new:173:33: note: previous declaration is here
_GLIBCXX_NODISCARD inline void* operator new(std::size_t, void* __p) _GLIBCXX_USE_NOEXCEPT
```

It is a bit unfortunate that tests outside of `Cxx/stdlib` depend on the C++ stdlib, but I couldn't find a way around that.