### PR TITLE
[AutoDiff][stdlib] Conform `Array.DifferentiableView` to several collection protocols

### DIFF
--- a/stdlib/public/Differentiation/ArrayDifferentiation.swift
+++ b/stdlib/public/Differentiation/ArrayDifferentiation.swift
@@ -169,6 +169,48 @@ where Element: AdditiveArithmetic & Differentiable {
   }
 }
 
+extension Array.DifferentiableView:
+  BidirectionalCollection,
+  Collection,
+  MutableCollection,
+  RandomAccessCollection,
+  RangeReplaceableCollection,
+  Sequence
+where Element: Differentiable {
+  public typealias Element = Array<Element>.Element
+  public typealias Index = Array<Element>.Index
+  public typealias Indices = Array<Element>.Indices
+  public typealias SubSequence = Array<Element>.SubSequence
+
+  @inlinable
+  public subscript(position: Array<Element>.Index) -> Element {
+    _read { yield base[position] }
+    set { base[position] = newValue }
+  }
+
+  @inlinable
+  public subscript(bounds: Range<Array<Element>.Index>) -> Self.SubSequence {
+    _read { yield base[bounds] }
+    set { base[bounds] = newValue }
+  }
+
+  @inlinable
+  public mutating func replaceSubrange<C>(
+    _ subrange: Range<Self.Index>, with newElements: C
+  ) where C : Collection, Self.Element == C.Element {
+    self[subrange] = Self.SubSequence(newElements)
+  }
+
+  @inlinable
+  public var startIndex: Index { base.startIndex }
+
+  @inlinable
+  public var endIndex: Index { base.endIndex }
+
+  @inlinable
+  public init() { self.init(.init()) }
+}
+
 /// Makes `Array` differentiable as the product manifold of `Element`
 /// multiplied with itself `count` times.
 extension Array: Differentiable where Element: Differentiable {


### PR DESCRIPTION
<!-- What's in this pull request? -->
This extension comes from [Swift for TensorFlow](https://github.com/s4tf/s4tf/blob/81e84dc8d611e0cb18d58baac52121de1cb9b434/Sources/TensorFlow/StdlibExtensions.swift#L218-L256), which extended `Array.DifferentiableView`. It lets a differentiable view conform to `PointwiseMultiplicative` and be subscripted. It is also a partial workaround for [SR-14008](https://github.com/apple/swift-package-manager/issues/4454).

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
