### PR TITLE
[swift-ide-test] Print first 20 actual output lines when test in batch completion fails

### DIFF
--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -67,9 +67,10 @@
 #include "llvm/Support/ManagedStatic.h"
 #include <system_error>
 
+#include <algorithm>
+#include <chrono>
 #include <random>
 #include <string>
-#include <chrono>
 
 using namespace swift;
 using namespace ide;
@@ -1623,6 +1624,17 @@ static int doBatchCodeCompletion(const CompilerInvocation &InitInvok,
         for (auto arg : FileCheckArgs)
           llvm::errs() << " " << arg;
         llvm::errs() << "\n";
+        llvm::errs() << "Code completion results:\n";
+        SmallVector<StringRef, 20> ResultLines;
+        llvm::SplitString(ResultStr, ResultLines, "\n");
+        for (size_t LineNo = 0;
+             LineNo < std::min(ResultLines.size(), static_cast<size_t>(20));
+             LineNo++) {
+          llvm::errs() << ResultLines[LineNo] << '\n';
+        }
+        if (ResultLines.size() > 20) {
+          llvm::errs() << " + " << (ResultLines.size() - 20) << " more lines\n";
+        }
       }
     }
 


### PR DESCRIPTION
I found this really useful to understand what’s going wrong
