### PR TITLE
[Test] Require asserts in Sema/implicit-import-in-inlinable-code.swift

### DIFF
--- a/test/Sema/implicit-import-in-inlinable-code.swift
+++ b/test/Sema/implicit-import-in-inlinable-code.swift
@@ -16,6 +16,8 @@
 /// In Swift 6, it's an error.
 // RUN: %target-swift-frontend -emit-module %t/clientFileA-Swift6.swift %t/clientFileB.swift -module-name client -o %t/client.swiftmodule -I %t -verify -swift-version 6
 
+// REQUIRES: asserts
+
 // BEGIN empty.swift
 
 // BEGIN libA.swift


### PR DESCRIPTION
One of its run lines includes `-swift-version 6` which is only allowed in asserts builds currently.

rdar://96341389
