### PR TITLE
[rebranch] Fix compile error caused by new AttrBuilder API

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -2923,7 +2923,7 @@ llvm::CallInst *IRBuilder::CreateCall(const FunctionPointer &fn,
   if (auto func = dyn_cast<llvm::Function>(fn.getRawPointer())) {
     for (unsigned argIndex = 0; argIndex < func->arg_size(); ++argIndex) {
       if (func->hasParamAttribute(argIndex, llvm::Attribute::StructRet)) {
-        llvm::AttrBuilder builder;
+        llvm::AttrBuilder builder(func->getContext());
         builder.addStructRetAttr(nullptr);
         attrs = attrs.addParamAttributes(func->getContext(), argIndex, builder);
       }


### PR DESCRIPTION
`AttrBuilder` now requires a `LLVMContext &` to be passed in, fix up the
use added in `main`.