### PR TITLE
Don't emit `@preconcurrency import` remarks when we're skipping function bodies

### DIFF
--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -279,6 +279,10 @@ static void diagnoseUnnecessaryPreconcurrencyImports(SourceFile &sf) {
   }
 
   ASTContext &ctx = sf.getASTContext();
+
+  if (ctx.TypeCheckerOpts.SkipFunctionBodies != FunctionBodySkipping::None)
+    return;
+
   for (const auto &import : sf.getImports()) {
     if (import.options.contains(ImportFlags::Preconcurrency) &&
         import.importLoc.isValid() &&

--- a/test/Concurrency/predates_concurrency_import_emitmodule.swift
+++ b/test/Concurrency/predates_concurrency_import_emitmodule.swift
@@ -1,0 +1,28 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -swift-version 6 %S/Inputs/StrictModule.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -disable-availability-checking
+
+// RUN: %target-swift-frontend -emit-module -I %t -verify -primary-file %s -emit-module-path %t/predates_concurrency_import_swiftmodule.swiftmodule -experimental-skip-all-function-bodies
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+@preconcurrency import NonStrictModule
+@preconcurrency import StrictModule
+@preconcurrency import OtherActors
+
+// expected-no-warning
+
+func acceptSendable<T: Sendable>(_: T) { }
+
+@available(SwiftStdlib 5.1, *)
+func test(
+  ss: StrictStruct, ns: NonStrictClass, oma: OtherModuleActor,
+  ssc: SomeSendableClass
+) async {
+  acceptSendable(ss)
+  acceptSendable(ns)
+  acceptSendable(oma)
+  acceptSendable(ssc)
+}


### PR DESCRIPTION
This eliminates spurious warnings suggesting that folks remove
`@preconcurrency` from imports that occur during `-emit-module` phases,
because we're skipping function bodies and, therefore, the code that
would depend on the `@preconcurrency` import.

Fixes https://github.com/apple/swift/issues/58183 / rdar://89940926.
