### PR TITLE
Adjust types for `@preconcurrency` in the `@_implementationOnly` override

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3602,6 +3602,13 @@ AttributeChecker::visitImplementationOnlyAttr(ImplementationOnlyAttr *attr) {
         overrideInterfaceFuncTy->getResult(), overrideInterfaceInfo);
   }
 
+  // If @preconcurrency is involved, strip concurrency from the types before
+  // comparing them.
+  if (overridden->preconcurrency() || VD->preconcurrency()) {
+    derivedInterfaceTy = derivedInterfaceTy->stripConcurrency(true, false);
+    overrideInterfaceTy = overrideInterfaceTy->stripConcurrency(true, false);
+  }
+
   if (!derivedInterfaceTy->isEqual(overrideInterfaceTy)) {
     diagnose(VD, diag::implementation_only_override_changed_type,
              overrideInterfaceTy);

--- a/test/Concurrency/Inputs/ImplementationOnlyDefs.swift
+++ b/test/Concurrency/Inputs/ImplementationOnlyDefs.swift
@@ -1,0 +1,12 @@
+open class BSuper {
+  public init() { }
+}
+
+open class BSub: BSuper {
+  public override init() { }
+}
+
+open class C {
+  @preconcurrency open func f(_: @escaping @Sendable () -> Void) { }
+  @preconcurrency open func g(_: @escaping @Sendable () -> Void) -> BSuper { BSuper() }
+}

--- a/test/Concurrency/preconcurrency_implementationonly_override.swift
+++ b/test/Concurrency/preconcurrency_implementationonly_override.swift
@@ -1,0 +1,16 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/ImplementationOnlyDefs.swiftmodule -module-name ImplementationOnlyDefs %S/Inputs/ImplementationOnlyDefs.swift
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -I %t
+
+// REQUIRES: concurrency
+
+@_implementationOnly import ImplementationOnlyDefs
+
+class D: C {
+  @_implementationOnly
+  override func f(_: @escaping () -> Void) { }
+
+  @_implementationOnly
+  override func g(_: @escaping () -> Void) -> BSub { BSub() }
+  // expected-error@-1{{'@_implementationOnly' override must have the same type as the declaration it overrides ('(@escaping () -> Void) -> BSuper')}}
+}


### PR DESCRIPTION
Fixes rdar://96338926.
