### PR TITLE
Make TypeRefBuilder::getFieldTypeInfo iterate over images in a smarter manner

### DIFF
--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -24,6 +24,7 @@
 #include "swift/Reflection/TypeLowering.h"
 #include "swift/Reflection/TypeRef.h"
 #include "llvm/ADT/Optional.h"
+#include "llvm/ADT/SmallVector.h"
 #include <iomanip>
 #include <iostream>
 #include <ostream>
@@ -264,6 +265,7 @@ struct ReflectionInfo {
   GenericSection ReflectionString;
   GenericSection Conformance;
   MultiPayloadEnumSection MultiPayloadEnum;
+  llvm::SmallVector<llvm::StringRef, 1> PotentialModuleNames;
 };
 
 struct ClosureContextInfo {
@@ -833,13 +835,15 @@ public:
 private:
   std::vector<ReflectionInfo> ReflectionInfos;
 
-  /// Index of the next Reflection Info that should be processed.
-  /// This assumes that Reflection Infos are never removed from the vector.
-  size_t FirstUnprocessedReflectionInfoIndex = 0;
-    
+  /// Indexes of Reflection Infos we've already processed.
+  llvm::DenseSet<size_t> ProcessedReflectionInfoIndexes;
+
   llvm::Optional<std::string> normalizeReflectionName(RemoteRef<char> name);
   bool reflectionNameMatches(RemoteRef<char> reflectionName,
                              StringRef searchName);
+  void populateFieldTypeInfoCacheWithReflectionAtIndex(size_t Index);
+  llvm::Optional<RemoteRef<FieldDescriptor>>
+  findFieldDescriptorAtIndex(size_t Index, const std::string &MangledName);
 
 public:
   RemoteRef<char> readTypeRef(uint64_t remoteAddr);
@@ -1562,7 +1566,6 @@ private:
                                      mangledTypeName};
     }
   };
-
 public:
   template <template <typename Runtime> class ObjCInteropKind,
             unsigned PointerSize>

--- a/stdlib/public/Reflection/TypeRef.cpp
+++ b/stdlib/public/Reflection/TypeRef.cpp
@@ -583,8 +583,35 @@ public:
     genericNode->addChild(unspecializedType, Dem);
     genericNode->addChild(genericArgsList, Dem);
 
-    if (auto parent = BG->getParent())
-      assert(false && "not implemented");
+    auto parent = BG->getParent();
+    if (!parent)
+      return genericNode;
+
+    auto parentNode = visit(parent);
+    if (!parentNode || !parentNode->hasChildren() ||
+        parentNode->getKind() != Node::Kind::Type ||
+        !unspecializedType->hasChildren())
+      return genericNode;
+
+    // Peel off the "Type" node.
+    parentNode = parentNode->getFirstChild();
+
+    auto nominalNode = unspecializedType->getFirstChild();
+
+    if (nominalNode->getNumChildren() != 2)
+      return genericNode;
+
+    // Save identifier for reinsertion later, we have to remove it
+    // so we can insert the parent node as the first child.
+    auto identifierNode = nominalNode->getLastChild();
+
+    // Remove all children.
+    nominalNode->removeChildAt(1);
+    nominalNode->removeChildAt(0);
+
+    // Add the parent we just visited back in, followed by the identifier.
+    nominalNode->addChild(parentNode, Dem);
+    nominalNode->addChild(identifierNode, Dem);
 
     return genericNode;
   }

--- a/stdlib/public/Reflection/TypeRefBuilder.cpp
+++ b/stdlib/public/Reflection/TypeRefBuilder.cpp
@@ -193,14 +193,69 @@ const TypeRef *TypeRefBuilder::lookupSuperclass(const TypeRef *TR) {
   return Unsubstituted->subst(*this, *SubstMap);
 }
 
-RemoteRef<FieldDescriptor>
-TypeRefBuilder::getFieldTypeInfo(const TypeRef *TR) {
+static llvm::Optional<StringRef> FindOutermostModuleName(NodePointer Node) {
+  if (!Node)
+    return {};
+  // Breadth first search until we find the module name so we find the outermost
+  // one.
+  llvm::SmallVector<NodePointer, 8> Queue;
+  Queue.push_back(Node);
+  // Instead of removing items from the front of the queue we just iterate over
+  // them.
+  for (size_t i = 0; i < Queue.size(); ++i) {
+    NodePointer Current = Queue[i];
+    if (Current->getKind() == Node::Kind::Module) {
+      if (Current->hasText())
+        return Current->getText();
+      else
+        return {};
+    }
+    for (auto Child : *Current)
+      Queue.push_back(Child);
+  }
+  return {};
+}
+
+void TypeRefBuilder::populateFieldTypeInfoCacheWithReflectionAtIndex(
+    size_t Index) {
+  if (ProcessedReflectionInfoIndexes.contains(Index))
+    return;
+
+  const auto &Info = ReflectionInfos[Index];
+  for (auto FD : Info.Field) {
+    if (!FD->hasMangledTypeName())
+      continue;
+    auto CandidateMangledName = readTypeRef(FD, FD->MangledTypeName);
+    if (auto NormalizedName = normalizeReflectionName(CandidateMangledName)) {
+      FieldTypeInfoCache[std::move(*NormalizedName)] = FD;
+    }
+  }
+
+  ProcessedReflectionInfoIndexes.insert(Index);
+}
+
+llvm::Optional<RemoteRef<FieldDescriptor>>
+TypeRefBuilder::findFieldDescriptorAtIndex(size_t Index,
+                                           const std::string &MangledName) {
+  populateFieldTypeInfoCacheWithReflectionAtIndex(Index);
+  auto Found = FieldTypeInfoCache.find(MangledName);
+  if (Found != FieldTypeInfoCache.end()) {
+    return Found->second;
+  }
+  return llvm::None;
+}
+
+RemoteRef<FieldDescriptor> TypeRefBuilder::getFieldTypeInfo(const TypeRef *TR) {
   const std::string *MangledName;
-  if (auto N = dyn_cast<NominalTypeRef>(TR))
+  NodePointer Node;
+  Demangler Dem;
+  if (auto N = dyn_cast<NominalTypeRef>(TR)) {
+    Node = N->getDemangling(Dem);
     MangledName = &N->getMangledName();
-  else if (auto BG = dyn_cast<BoundGenericTypeRef>(TR))
+  } else if (auto BG = dyn_cast<BoundGenericTypeRef>(TR)) {
+    Node = BG->getDemangling(Dem);
     MangledName = &BG->getMangledName();
-  else
+  } else
     return nullptr;
 
   // Try the cache.
@@ -208,25 +263,23 @@ TypeRefBuilder::getFieldTypeInfo(const TypeRef *TR) {
   if (Found != FieldTypeInfoCache.end())
     return Found->second;
 
-  // On failure, fill out the cache, ReflectionInfo by ReflectionInfo,
-  // until we find the field desciptor we're looking for.
-  while (FirstUnprocessedReflectionInfoIndex < ReflectionInfos.size()) {
-    auto &Info = ReflectionInfos[FirstUnprocessedReflectionInfoIndex];
-    for (auto FD : Info.Field) {
-      if (!FD->hasMangledTypeName())
-        continue;
-      auto CandidateMangledName = readTypeRef(FD, FD->MangledTypeName);
-      if (auto NormalizedName = normalizeReflectionName(CandidateMangledName))
-        FieldTypeInfoCache[std::move(*NormalizedName)] = FD;
-    }
+  // Heuristic: find the outermost Module node available, and try to parse the
+  // ReflectionInfos with a matching name first.
+  auto ModuleName = FindOutermostModuleName(Node);
+  // If we couldn't find a module name or the type is imported (__C module) we
+  // don't any useful information on which image to look for the type.
+  if (ModuleName && ModuleName != llvm::StringRef("__C"))
+    for (size_t i = 0; i < ReflectionInfos.size(); ++i)
+      if (llvm::is_contained(ReflectionInfos[i].PotentialModuleNames,
+                             ModuleName))
+        if (auto FD = findFieldDescriptorAtIndex(i, *MangledName))
+          return *FD;
 
-    // Since we're done with the current ReflectionInfo, increment early in
-    // case we get a cache hit.
-    ++FirstUnprocessedReflectionInfoIndex;
-    Found = FieldTypeInfoCache.find(*MangledName);
-    if (Found != FieldTypeInfoCache.end())
-      return Found->second;
-  }
+  // On failure, fill out the cache, ReflectionInfo by ReflectionInfo,
+  // until we find the field descriptor we're looking for.
+  for (size_t i = 0; i < ReflectionInfos.size(); ++i)
+    if (auto FD = findFieldDescriptorAtIndex(i, *MangledName))
+      return *FD;
 
   return nullptr;
 }

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -238,14 +238,15 @@ swift_reflection_addReflectionInfo(SwiftReflectionContextRef ContextRef,
   }
 
   ReflectionInfo ContextInfo{
-    sectionFromInfo<FieldDescriptorIterator>(Info, Info.field),
-    sectionFromInfo<AssociatedTypeIterator>(Info, Info.associated_types),
-    sectionFromInfo<BuiltinTypeDescriptorIterator>(Info, Info.builtin_types),
-    sectionFromInfo<CaptureDescriptorIterator>(Info, Info.capture),
-    sectionFromInfo<const void *>(Info, Info.type_references),
-    sectionFromInfo<const void *>(Info, Info.reflection_strings),
-    ReflectionSection<const void *>(nullptr, 0),
-    ReflectionSection<MultiPayloadEnumDescriptorIterator>(0, 0)};
+      sectionFromInfo<FieldDescriptorIterator>(Info, Info.field),
+      sectionFromInfo<AssociatedTypeIterator>(Info, Info.associated_types),
+      sectionFromInfo<BuiltinTypeDescriptorIterator>(Info, Info.builtin_types),
+      sectionFromInfo<CaptureDescriptorIterator>(Info, Info.capture),
+      sectionFromInfo<const void *>(Info, Info.type_references),
+      sectionFromInfo<const void *>(Info, Info.reflection_strings),
+      ReflectionSection<const void *>(nullptr, 0),
+      ReflectionSection<MultiPayloadEnumDescriptorIterator>(0, 0),
+      {}};
 
   Context->addReflectionInfo(ContextInfo);
 }
@@ -264,10 +265,11 @@ void swift_reflection_addReflectionMappingInfo(
       reflectionSectionFromLocalAndRemote<CaptureDescriptorIterator>(
           Info.capture),
       reflectionSectionFromLocalAndRemote<const void *>(Info.type_references),
-      reflectionSectionFromLocalAndRemote<const void *>(Info.reflection_strings),
+      reflectionSectionFromLocalAndRemote<const void *>(
+          Info.reflection_strings),
       ReflectionSection<const void *>(nullptr, 0),
-      MultiPayloadEnumSection(0, 0)
-  };
+      MultiPayloadEnumSection(0, 0),
+      {}};
 
   Context->addReflectionInfo(ContextInfo);
 }


### PR DESCRIPTION
Description: Currently, whenever we're asked to retrieve a particular `FieldDescriptor` for a `TypeRef`, we naively parse all the `ReflectionInfos` in the order they were registered (caching everything) until we find the one we're looking for. This can be very costly for the debugger, as we may be reading memory from a remote target. This patch introduces a heuristic to prioritize this search by processing first `ReflectionInfos` where the `FieldDescriptor` we're looking for is likely to be. If the heuristic fails, we fallback to the old behavior. In profiling debugging large apps, this has significant impact on the time to stop on the first breakpoint.
Risk: Low. If the heuristic fails we fall back to the old behavior.
Testing: Swift reflection tests plus all lldb tests that use frame variable.
Original PR: https://github.com/apple/swift/pull/59802 plus `Typeref.cpp` changes from https://github.com/apple/swift/pull/59262
Issue: rdar://87889973