### PR TITLE
[5.7][ASTPrinter] Don't print 'any' in Swift interfaces.

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -156,7 +156,6 @@ PrintOptions PrintOptions::printSwiftInterfaceFile(ModuleDecl *ModuleToPrint,
       PrintOptions::FunctionRepresentationMode::Full;
   result.AlwaysTryPrintParameterLabels = true;
   result.PrintSPIs = printSPIs;
-  result.PrintExplicitAny = true;
   result.DesugarExistentialConstraint = true;
 
   // We should print __consuming, __owned, etc for the module interface file.

--- a/test/ModuleInterface/existential-any.swift
+++ b/test/ModuleInterface/existential-any.swift
@@ -14,28 +14,28 @@ public protocol Q {
   associatedtype A: P
 }
 
-// CHECK: public func takesAndReturnsP(_ x: any main.P) -> any main.P
+// CHECK: public func takesAndReturnsP(_ x: main.P) -> main.P
 public func takesAndReturnsP(_ x: P) -> P {
   return x
 }
 
-// CHECK: public func takesAndReturnsOptionalP(_ x: (any main.P)?) -> (any main.P)?
+// CHECK: public func takesAndReturnsOptionalP(_ x: main.P?) -> main.P?
 public func takesAndReturnsOptionalP(_ x: P?) -> P? {
   return x
 }
 
-// CHECK: public func takesAndReturnsQ(_ x: any main.Q) -> any main.Q
+// CHECK: public func takesAndReturnsQ(_ x: main.Q) -> main.Q
 public func takesAndReturnsQ(_ x: any Q) -> any Q {
   return x
 }
 
 // CHECK: public struct S
 public struct S {
-  // CHECK: public var p: any main.P
+  // CHECK: public var p: main.P
   public var p: P
-  // CHECK: public var maybeP: (any main.P)?
+  // CHECK: public var maybeP: main.P?
   public var maybeP: P?
-  // CHECK: public var q: any main.Q
+  // CHECK: public var q: main.Q
   public var q: any Q
 }
 
@@ -44,5 +44,5 @@ public protocol ProtocolTypealias {
   typealias A = P
 }
 
-// CHECK: public func dependentExistential<T>(value: (T) -> any main.P) where T : main.ProtocolTypealias
+// CHECK: public func dependentExistential<T>(value: (T) -> main.P) where T : main.ProtocolTypealias
 public func dependentExistential<T: ProtocolTypealias>(value: (T) -> T.A) {}

--- a/test/ModuleInterface/features.swift
+++ b/test/ModuleInterface/features.swift
@@ -88,7 +88,7 @@ public class OldSchool2: MP {
 // CHECK: public struct UsesRP {
 public struct UsesRP {
   // CHECK: #if compiler(>=5.3) && $RethrowsProtocol
-  // CHECK-NEXT:  public var value: (any FeatureTest.RP)? {
+  // CHECK-NEXT:  public var value: FeatureTest.RP? {
   // CHECK-NOT: #if compiler(>=5.3) && $RethrowsProtocol
   // CHECK: get
   public var value: RP? {

--- a/test/ModuleInterface/top-level-Type-and-Protocol.swift
+++ b/test/ModuleInterface/top-level-Type-and-Protocol.swift
@@ -19,7 +19,7 @@ public func usesType(_ x: Type) {}
 // CHECK: public func genericProtocol<T>(_ x: T) where T : MyModule.`Protocol`
 public func genericProtocol<T: Protocol>(_ x: T) {}
 
-// CHECK: public func existentialProtocol(_ x: any MyModule.`Protocol`)
+// CHECK: public func existentialProtocol(_ x: MyModule.`Protocol`)
 public func existentialProtocol(_ x: Protocol) {}
 
 // CHECK: public struct Parent {


### PR DESCRIPTION
This effectively reverts https://github.com/apple/swift/pull/58772, while keeping the test changes to ensure `any` isn't required in Swift interfaces.

Resolves: rdar://96158328