### PR TITLE
[stdlib] Switch to using unchecked buffer subscript in low-level Unicode helpers

### DIFF
--- a/stdlib/public/core/UnicodeHelpers.swift
+++ b/stdlib/public/core/UnicodeHelpers.swift
@@ -64,7 +64,7 @@ internal func _decodeUTF8(
 internal func _decodeScalar(
   _ utf16: UnsafeBufferPointer<UInt16>, startingAt i: Int
 ) -> (Unicode.Scalar, scalarLength: Int) {
-  let high = utf16[i]
+  let high = utf16[_unchecked: i]
   if i + 1 >= utf16.count {
     _internalInvariant(!UTF16.isLeadSurrogate(high))
     _internalInvariant(!UTF16.isTrailSurrogate(high))
@@ -76,7 +76,7 @@ internal func _decodeScalar(
     return (Unicode.Scalar(_unchecked: UInt32(high)), 1)
   }
 
-  let low = utf16[i+1]
+  let low = utf16[_unchecked: i+1]
   _internalInvariant(UTF16.isLeadSurrogate(high))
   _internalInvariant(UTF16.isTrailSurrogate(low))
   return (UTF16._decodeSurrogates(high, low), 2)
@@ -207,7 +207,7 @@ extension _StringGuts {
   @inlinable
   internal func fastUTF8ScalarLength(startingAt i: Int) -> Int {
     _internalInvariant(isFastUTF8)
-    let len = _utf8ScalarLength(self.withFastUTF8 { $0[i] })
+    let len = _utf8ScalarLength(self.withFastUTF8 { $0[_unchecked: i] })
     _internalInvariant((1...4) ~= len)
     return len
   }


### PR DESCRIPTION
We expect indices to be already validated by the time these are called, and UBP’s debug-mode checks are compiled into opaque parts of the stdlib.

The big exception is that Swift <5.7 used to not do proper index validation and allowed out-of-bounds accesses. We emulate this behavior for code that was compiled with such a release, and it turns out that these UnsafeBufferPointer checks are interfering with the intended (undefined) behavior in this case. Switching to unchecked accesses will speed up operations for newly built code that will have proper validation up front, while also allowing broken-but-not-trapping code built with Swift 5.6 or earlier to continue "working" as it did before.

rdar://93707276