### PR TITLE
[5.7][stdlib] Switch to using unchecked buffer subscript in low-level Unicode helpers

### DIFF
--- a/stdlib/public/core/UnicodeHelpers.swift
+++ b/stdlib/public/core/UnicodeHelpers.swift
@@ -64,7 +64,7 @@ internal func _decodeUTF8(
 internal func _decodeScalar(
   _ utf16: UnsafeBufferPointer<UInt16>, startingAt i: Int
 ) -> (Unicode.Scalar, scalarLength: Int) {
-  let high = utf16[i]
+  let high = utf16[_unchecked: i]
   if i + 1 >= utf16.count {
     _internalInvariant(!UTF16.isLeadSurrogate(high))
     _internalInvariant(!UTF16.isTrailSurrogate(high))
@@ -76,7 +76,7 @@ internal func _decodeScalar(
     return (Unicode.Scalar(_unchecked: UInt32(high)), 1)
   }
 
-  let low = utf16[i+1]
+  let low = utf16[_unchecked: i+1]
   _internalInvariant(UTF16.isLeadSurrogate(high))
   _internalInvariant(UTF16.isTrailSurrogate(low))
   return (UTF16._decodeSurrogates(high, low), 2)
@@ -207,7 +207,7 @@ extension _StringGuts {
   @inlinable
   internal func fastUTF8ScalarLength(startingAt i: Int) -> Int {
     _internalInvariant(isFastUTF8)
-    let len = _utf8ScalarLength(self.withFastUTF8 { $0[i] })
+    let len = _utf8ScalarLength(self.withFastUTF8 { $0[_unchecked: i] })
     _internalInvariant((1...4) ~= len)
     return len
   }


### PR DESCRIPTION
(cherry picked from #59899)

**Description:** This fixes a minor binary compatibility issue by allowing invalid String indices to be passed to some String operations without a runtime trap, as long as the binary was built with Swift 5.6 or earlier. This allows broken code to keep "working" as it did in earlier Standard Library releases, while still allowing us to catch & report the issue for binaries compiled with the new SDK.
**Risk:** Low. This eliminates some low-level checks that were already supposed to have been done by the time this code is called. The primary risk is that in some cases these checks may be our last safety net against out-of-bounds access.
**Review by:** @glessard & @Azoy 
**Testing:** Regular regression testing, plus manual bincompat verification.
**Original PR:** https://github.com/apple/swift/pull/59899
**Issue:** rdar://93707276
