### PR TITLE
[CSApply] A couple of locator adjustments to support updated Double<->CGFloat conversion

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3528,9 +3528,12 @@ namespace {
       expr->setInitializer(witness);
 
       auto elementType = expr->getElementType();
-      for (auto &element : expr->getElements()) {
-        element = coerceToType(element, elementType,
-                               cs.getConstraintLocator(element));
+
+      for (unsigned i = 0, n = expr->getNumElements(); i != n; ++i) {
+        expr->setElement(
+            i, coerceToType(expr->getElement(i), elementType,
+                            cs.getConstraintLocator(
+                                expr, {LocatorPathElt::TupleElement(i)})));
       }
 
       return expr;

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3481,9 +3481,11 @@ namespace {
 
       auto elementType = expr->getElementType();
 
-      for (auto &element : expr->getElements()) {
-        element = coerceToType(element, elementType,
-                               cs.getConstraintLocator(element));
+      for (unsigned i = 0, n = expr->getNumElements(); i != n; ++i) {
+        expr->setElement(
+            i, coerceToType(expr->getElement(i), elementType,
+                            cs.getConstraintLocator(
+                                expr, {LocatorPathElt::TupleElement(i)})));
       }
 
       return expr;

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3735,10 +3735,12 @@ namespace {
       expr->setCondExpr(cond);
 
       // Coerce the then/else branches to the common type.
-      expr->setThenExpr(coerceToType(expr->getThenExpr(), resultTy,
-                               cs.getConstraintLocator(expr->getThenExpr())));
-      expr->setElseExpr(coerceToType(expr->getElseExpr(), resultTy,
-                                 cs.getConstraintLocator(expr->getElseExpr())));
+      expr->setThenExpr(coerceToType(
+          expr->getThenExpr(), resultTy,
+          cs.getConstraintLocator(expr, LocatorPathElt::TernaryBranch(true))));
+      expr->setElseExpr(coerceToType(
+          expr->getElseExpr(), resultTy,
+          cs.getConstraintLocator(expr, LocatorPathElt::TernaryBranch(false))));
 
       return expr;
     }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -429,6 +429,11 @@ ConstraintLocator *ConstraintSystem::getImplicitValueConversionLocator(
   SmallVector<LocatorPathElt, 4> path;
   auto anchor = root.getLocatorParts(path);
   {
+    if (isExpr<DictionaryExpr>(anchor) && path.size() > 1) {
+      // Drop everything except for first `tuple element #`.
+      path.pop_back_n(path.size() - 1);
+    }
+
     // Drop any value-to-optional conversions that were applied along the
     // way to reach this one.
     while (!path.empty()) {

--- a/test/Constraints/implicit_double_cgfloat_conversion.swift
+++ b/test/Constraints/implicit_double_cgfloat_conversion.swift
@@ -217,9 +217,17 @@ func test_multi_argument_conversion_with_optional(d: Double, cgf: CGFloat) {
   test(cgf, d) // Ok (CGFloat -> Double and Double? -> CGFloat?)
 }
 
-func test_array_literal_as_call_argument() {
+extension CGFloat: Hashable {
+  public func hash(into hasher: inout Hasher) { fatalError() }
+}
+
+func test_collection_literals_as_call_arguments() {
   enum E {
     case test_arr([CGFloat])
+    case test_dict_key([CGFloat: String])
+    case test_dict_value([String: CGFloat])
+    case test_arr_nested([String: [[CGFloat]: String]])
+    case test_dict_nested([String: [String: CGFloat]])
   }
 
   struct Container {
@@ -233,5 +241,9 @@ func test_array_literal_as_call_argument() {
 
   func test(cont: inout Container, point: Point) {
     cont.prop = .test_arr([point.x]) // Ok
+    cont.prop = .test_dict_key([point.y: ""]) // Ok
+    cont.prop = .test_dict_value(["": point.y]) // Ok
+    cont.prop = .test_arr_nested(["": [[point.x]: ""]]) // Ok
+    cont.prop = .test_dict_nested(["": ["": point.x]]) // Ok
   }
 }

--- a/test/Constraints/implicit_double_cgfloat_conversion.swift
+++ b/test/Constraints/implicit_double_cgfloat_conversion.swift
@@ -247,3 +247,16 @@ func test_collection_literals_as_call_arguments() {
     cont.prop = .test_dict_nested(["": ["": point.x]]) // Ok
   }
 }
+
+func assignments_with_and_without_optionals() {
+  class C {
+    var prop: CGFloat = 0
+  }
+
+  func test(c: C?, v: Double) {
+    c?.prop = v / 2.0 // Ok
+
+    let copy = c!
+    copy.prop = Optional(v) ?? 0 // Ok
+  }
+}

--- a/test/Constraints/implicit_double_cgfloat_conversion.swift
+++ b/test/Constraints/implicit_double_cgfloat_conversion.swift
@@ -216,3 +216,22 @@ func test_multi_argument_conversion_with_optional(d: Double, cgf: CGFloat) {
 
   test(cgf, d) // Ok (CGFloat -> Double and Double? -> CGFloat?)
 }
+
+func test_array_literal_as_call_argument() {
+  enum E {
+    case test_arr([CGFloat])
+  }
+
+  struct Container {
+    var prop: E
+  }
+
+  struct Point {
+    var x: Double
+    var y: Double
+  }
+
+  func test(cont: inout Container, point: Point) {
+    cont.prop = .test_arr([point.x]) // Ok
+  }
+}

--- a/test/Constraints/implicit_double_cgfloat_conversion.swift
+++ b/test/Constraints/implicit_double_cgfloat_conversion.swift
@@ -253,10 +253,12 @@ func assignments_with_and_without_optionals() {
     var prop: CGFloat = 0
   }
 
-  func test(c: C?, v: Double) {
+  func test(c: C?, v: Double, cgf: CGFloat) {
     c?.prop = v / 2.0 // Ok
+    c?.prop = (false ? cgf : v)
 
     let copy = c!
     copy.prop = Optional(v) ?? 0 // Ok
+    copy.prop = (true ? cgf : (false ? v : cgf))
   }
 }


### PR DESCRIPTION
https://github.com/apple/swift/pull/59762 made it possible to use Double<->CGFloat conversions in different 
arguments positions of the same call, but it didn't account for the fact that 
some locators are constructed incorrectly by `ExprRewriter` during solution 
application. 

This PR adjusts locators for the following situations:

- Array/dictionary element coercions adjusted to use `<collection> -> tuple element #` locator;
- Assignment source -> destination type coercion is adjusted to use assignment expression 
   itself since this is where the conversion constraint is placed (which is also very helpful for diagnostics).

Resolves: rdar://96469597
Resolves: rdar://96477064 
Resolves: rdar://96477058
Resolves: https://github.com/apple/swift/issues/59932

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
