### PR TITLE
[cxx-interop][SwiftCompilerSources] Use `swift::CharSourceRange` instead of `BridgedCharSourceRange`

### DIFF
--- a/SwiftCompilerSources/Sources/AST/DiagnosticEngine.swift
+++ b/SwiftCompilerSources/Sources/AST/DiagnosticEngine.swift
@@ -81,7 +81,7 @@ public struct DiagnosticEngine {
                        fixIts: [DiagnosticFixIt] = []) {
 
     let bridgedSourceLoc: swift.SourceLoc = position.bridged
-    let bridgedHighlightRange: BridgedCharSourceRange = highlight.bridged
+    let bridgedHighlightRange: swift.CharSourceRange = highlight.bridged
     var bridgedArgs: [BridgedDiagnosticArgument] = []
     var bridgedFixIts: [BridgedDiagnosticFixIt] = []
 

--- a/SwiftCompilerSources/Sources/Basic/SourceLoc.swift
+++ b/SwiftCompilerSources/Sources/Basic/SourceLoc.swift
@@ -49,27 +49,27 @@ extension Optional where Wrapped == SourceLoc {
 
 public struct CharSourceRange {
   private let start: SourceLoc
-  private let byteLength: Int
+  private let byteLength: UInt32
 
-  public init(start: SourceLoc, byteLength: Int) {
+  public init(start: SourceLoc, byteLength: UInt32) {
     self.start = start
     self.byteLength = byteLength
   }
 
-  public init?(bridged: BridgedCharSourceRange) {
-    guard let start = SourceLoc(bridged: bridged.start) else {
+  public init?(bridged: swift.CharSourceRange) {
+    guard let start = SourceLoc(bridged: bridged.getStart()) else {
       return nil
     }
-    self.init(start: start, byteLength: bridged.byteLength)
+    self.init(start: start, byteLength: bridged.getByteLength())
   }
 
-  public var bridged: BridgedCharSourceRange {
-    .init(start: start.bridged, byteLength: byteLength)
+  public var bridged: swift.CharSourceRange {
+    .init(start.bridged, byteLength)
   }
 }
 
 extension Optional where Wrapped == CharSourceRange {
-  public var bridged: BridgedCharSourceRange {
-    self?.bridged ?? .init(start: .init(), byteLength: 0)
+  public var bridged: swift.CharSourceRange {
+    self?.bridged ?? .init(.init(), 0)
   }
 }

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -68,7 +68,7 @@ typedef struct {
 // FIXME: Can we bridge InFlightDiagnostic?
 void DiagnosticEngine_diagnose(BridgedDiagnosticEngine, swift::SourceLoc loc,
                                BridgedDiagID diagID, BridgedArrayRef arguments,
-                               BridgedCharSourceRange highlight,
+                               swift::CharSourceRange highlight,
                                BridgedArrayRef fixIts);
 
 bool DiagnosticEngine_hadAnyError(BridgedDiagnosticEngine);

--- a/include/swift/Basic/BasicBridging.h
+++ b/include/swift/Basic/BasicBridging.h
@@ -40,15 +40,6 @@ void OStream_write(BridgedOStream os, BridgedStringRef str);
 
 void freeBridgedStringRef(BridgedStringRef str);
 
-//===----------------------------------------------------------------------===//
-// Source location
-//===----------------------------------------------------------------------===//
-
-typedef struct {
-  swift::SourceLoc start;
-  SwiftInt byteLength;
-} BridgedCharSourceRange;
-
 SWIFT_END_NULLABILITY_ANNOTATIONS
 
 #endif

--- a/include/swift/Basic/BridgingUtils.h
+++ b/include/swift/Basic/BridgingUtils.h
@@ -36,16 +36,6 @@ inline llvm::ArrayRef<T> getArrayRef(BridgedArrayRef bridged) {
   return {static_cast<const T *>(bridged.data), bridged.numElements};
 }
 
-inline CharSourceRange
-getCharSourceRange(const BridgedCharSourceRange &bridged) {
-  return CharSourceRange(bridged.start, bridged.byteLength);
-}
-
-inline BridgedCharSourceRange
-getBridgedCharSourceRange(const CharSourceRange &range) {
-  return {range.getStart(), range.getByteLength()};
-}
-
 } // namespace swift
 
 #endif

--- a/lib/AST/ASTBridging.cpp
+++ b/lib/AST/ASTBridging.cpp
@@ -41,7 +41,7 @@ void DiagnosticEngine_diagnose(
     BridgedDiagnosticEngine bridgedEngine, SourceLoc loc,
     BridgedDiagID bridgedDiagID,
     BridgedArrayRef /*BridgedDiagnosticArgument*/ bridgedArguments,
-    BridgedCharSourceRange bridgedHighlight,
+    CharSourceRange highlight,
     BridgedArrayRef /*BridgedDiagnosticFixIt*/ bridgedFixIts) {
   auto *D = getDiagnosticEngine(bridgedEngine);
 
@@ -54,7 +54,6 @@ void DiagnosticEngine_diagnose(
   auto inflight = D->diagnose(loc, diagID, arguments);
 
   // Add highlight.
-  auto highlight = getCharSourceRange(bridgedHighlight);
   if (highlight.isValid()) {
     inflight.highlightChars(highlight.getStart(), highlight.getEnd());
   }


### PR DESCRIPTION
This removes some of the bridging code and replaces it with C++ calls.

rdar://83361087