### PR TITLE
[cxx-interop][SwiftCompilerSources] Remove `getCopiedBridgedStringRef` and `freeBridgedStringRef`

### DIFF
--- a/SwiftCompilerSources/Sources/Basic/Utils.swift
+++ b/SwiftCompilerSources/Sources/Basic/Utils.swift
@@ -46,12 +46,6 @@ extension BridgedStringRef {
     let buffer = UnsafeBufferPointer<UInt8>(start: data, count: Int(length))
     return String(decoding: buffer, as: UTF8.self)
   }
-
-  public func takeString() -> String {
-    let str = string
-    freeBridgedStringRef(self)
-    return str
-  }
 }
 
 extension String {

--- a/SwiftCompilerSources/Sources/SIL/Type.swift
+++ b/SwiftCompilerSources/Sources/SIL/Type.swift
@@ -50,7 +50,9 @@ public struct Type : CustomStringConvertible, CustomReflectable {
     return idx >= 0 ? idx : nil
   }
 
-  public var description: String { SILType_debugDescription(bridged).takeString() }
+  public var description: String {
+    String(_cxxString: SILType_debugDescription(bridged))
+  }
 
   public var customMirror: Mirror { Mirror(self, children: []) }
 }

--- a/include/swift/Basic/BridgingUtils.h
+++ b/include/swift/Basic/BridgingUtils.h
@@ -46,22 +46,6 @@ getBridgedCharSourceRange(const CharSourceRange &range) {
   return {range.getStart(), range.getByteLength()};
 }
 
-/// Copies the string in an malloc'ed memory and the caller is responsible for
-/// freeing it. 'freeBridgedStringRef()' is available in 'BasicBridging.h'
-inline BridgedStringRef
-getCopiedBridgedStringRef(std::string str, bool removeTrailingNewline = false) {
-  // A couple of mallocs are needed for passing a std::string to Swift. But
-  // it's currently only used or debug descriptions. So, its' maybe not so bad -
-  // for now.
-  // TODO: find a better way to pass std::strings to Swift.
-  llvm::StringRef strRef(str);
-  if (removeTrailingNewline)
-    strRef.consume_back("\n");
-  llvm::MallocAllocator allocator;
-  llvm::StringRef copy = strRef.copy(allocator);
-  return getBridgedStringRef(copy);
-}
-
 } // namespace swift
 
 #endif

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -247,7 +247,7 @@ OptionalBridgedOperand SILValue_firstUse(BridgedValue value);
 BridgedType SILValue_getType(BridgedValue value);
 BridgedOwnership SILValue_getOwnership(BridgedValue value);
 
-BridgedStringRef SILType_debugDescription(BridgedType);
+std::string SILType_debugDescription(BridgedType);
 SwiftInt SILType_isAddress(BridgedType);
 SwiftInt SILType_isTrivial(BridgedType, BridgedFunction);
 SwiftInt SILType_isReferenceCounted(BridgedType type, BridgedFunction);

--- a/lib/Basic/BasicBridging.cpp
+++ b/lib/Basic/BasicBridging.cpp
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/Basic/BridgingUtils.h"
-#include "swift/Basic/LLVM.h"
 #include "llvm/Support/raw_ostream.h"
 
 using namespace swift;
@@ -23,9 +22,4 @@ using namespace swift;
 void OStream_write(BridgedOStream os, BridgedStringRef str) {
   static_cast<raw_ostream *>(os.streamAddr)
       ->write((const char *)(str.data), str.length);
-}
-
-/// Frees a string which was allocated by getCopiedBridgedStringRef.
-void freeBridgedStringRef(BridgedStringRef str) {
-  llvm::MallocAllocator().Deallocate(str.data, str.length);
 }

--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -383,11 +383,12 @@ BridgedOwnership SILValue_getOwnership(BridgedValue value) {
 //                            SILType
 //===----------------------------------------------------------------------===//
 
-BridgedStringRef SILType_debugDescription(BridgedType type) {
+std::string SILType_debugDescription(BridgedType type) {
   std::string str;
   llvm::raw_string_ostream os(str);
   castToSILType(type).print(os);
-  return getCopiedBridgedStringRef(str, /*removeTrailingNewline*/ true);
+  str.pop_back(); // Remove trailing newline.
+  return str;
 }
 
 SwiftInt SILType_isAddress(BridgedType type) {


### PR DESCRIPTION
`std::string`s can now be passed directly between Swift and C++.

rdar://83361087
