### PR TITLE
[5.7] [test] Update Regex type for flattened captures

### DIFF
--- a/test/StringProcessing/Sema/regex_literal_type_inference.swift
+++ b/test/StringProcessing/Sema/regex_literal_type_inference.swift
@@ -33,7 +33,7 @@ let r7 = #/(?:(?:(.(.(.)*)?))*?)?/#
 //               ^ 1
 //                 ^ 2
 //                   ^ 3
-let _: Regex<(Substring, Substring??, Substring???, Substring????)>.Type = type(of: r7)
+let _: Regex<(Substring, Substring?, Substring?, Substring?)>.Type = type(of: r7)
 
 let r8 = #/well(?<theres_no_single_element_tuple_what_can_we>do)/#
 let _: Regex<(Substring, theres_no_single_element_tuple_what_can_we: Substring)>.Type = type(of: r8)


### PR DESCRIPTION
Update for latest string processing changes (https://github.com/apple/swift-experimental-string-processing/pull/552).