### PR TITLE
Several fixes for performance diagnostics

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -1133,7 +1133,7 @@ Some kinds need arguments, which precede ``Tf``.
   spec-arg ::= identifier
   spec-arg ::= type
 
-  SPEC-INFO ::= FRAGILE? PASSID
+  SPEC-INFO ::= MT-REMOVED? FRAGILE? PASSID
 
   PASSID ::= '0'                             // AllocBoxToStack,
   PASSID ::= '1'                             // ClosureSpecializer,
@@ -1141,6 +1141,8 @@ Some kinds need arguments, which precede ``Tf``.
   PASSID ::= '3'                             // CapturePropagation,
   PASSID ::= '4'                             // FunctionSignatureOpts,
   PASSID ::= '5'                             // GenericSpecializer,
+
+  MT-REMOVED ::= 'm'                         // non-generic metatype arguments are removed in the specialized function
 
   FRAGILE ::= 'q'
 

--- a/include/swift/Demangling/DemangleNodes.def
+++ b/include/swift/Demangling/DemangleNodes.def
@@ -344,5 +344,7 @@ NODE(UniqueExtendedExistentialTypeShapeSymbolicReference)
 NODE(NonUniqueExtendedExistentialTypeShapeSymbolicReference)
 NODE(SymbolicExtendedExistentialType)
 
+NODE(MetatypeParamsRemoved)
+
 #undef CONTEXT_NODE
 #undef NODE

--- a/include/swift/SIL/GenericSpecializationMangler.h
+++ b/include/swift/SIL/GenericSpecializationMangler.h
@@ -90,7 +90,19 @@ public:
 
   std::string mangleNotReabstracted(SubstitutionMap subs);
 
-  std::string mangleReabstracted(SubstitutionMap subs, bool alternativeMangling);
+  /// Mangle a generic specialization with re-abstracted parameters.
+  ///
+  /// Re-abstracted means that indirect (generic) parameters/returns are
+  /// converted to direct parameters/returns.
+  ///
+  /// This is the default for generic specializations.
+  ///
+  /// \param alternativeMangling   true for specialized functions with a
+  ///                              differet resilience expansion.
+  /// \param metatyeParamsRemoved  true if non-generic metatype parameters are
+  ///                              removed in the specialized function.
+  std::string mangleReabstracted(SubstitutionMap subs, bool alternativeMangling,
+                                 bool metatyeParamsRemoved = false);
 
   std::string mangleForDebugInfo(GenericSignature sig, SubstitutionMap subs,
                                  bool forInlining);

--- a/include/swift/SILOptimizer/Utils/Generics.h
+++ b/include/swift/SILOptimizer/Utils/Generics.h
@@ -62,6 +62,11 @@ class ReabstractionInfo {
   /// argument has a trivial type.
   SmallBitVector TrivialArgs;
 
+  /// A 1-bit means that the argument is a metatype argument. The argument is
+  /// dropped and replaced by a `metatype` instruction in the entry block.
+  /// Only used if `dropMetatypeArgs` is true.
+  SmallBitVector droppedMetatypeArgs;
+
   /// Set to true if the function has a re-abstracted (= converted from
   /// indirect to direct) resilient argument or return type. This can happen if
   /// the function is compiled within the type's resilience domain, i.e. in
@@ -79,6 +84,10 @@ class ReabstractionInfo {
   /// specializer.
   bool ConvertIndirectToDirect;
 
+  /// If true, drop metatype arguments.
+  /// See `droppedMetatypeArgs`.
+  bool dropMetatypeArgs = false;
+  
   /// The first NumResults bits in Conversions refer to formal indirect
   /// out-parameters.
   unsigned NumFormalIndirectResults;
@@ -191,6 +200,7 @@ public:
                     SubstitutionMap ParamSubs,
                     IsSerialized_t Serialized,
                     bool ConvertIndirectToDirect = true,
+                    bool dropMetatypeArgs = false,
                     OptRemark::Emitter *ORE = nullptr);
 
   /// Constructs the ReabstractionInfo for generic function \p Callee with
@@ -242,6 +252,16 @@ public:
 
   /// Returns true if there are any conversions from indirect to direct values.
   bool hasConversions() const { return Conversions.any(); }
+
+  /// Returns true if the argument at `ArgIdx` is a dropped metatype argument.
+  /// See `droppedMetatypeArgs`.
+  bool isDroppedMetatypeArg(unsigned ArgIdx) const {
+    return droppedMetatypeArgs.test(ArgIdx);
+  }
+
+  /// Returns true if there are any dropped metatype arguments.
+  /// See `droppedMetatypeArgs`.
+  bool hasDroppedMetatypeArgs() const { return droppedMetatypeArgs.any(); }
 
   /// Remove the arguments of a partial apply, leaving the arguments for the
   /// partial apply result function.

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -3040,6 +3040,7 @@ NodePointer Demangler::addFuncSpecParamNumber(NodePointer Param,
 }
 
 NodePointer Demangler::demangleSpecAttributes(Node::Kind SpecKind) {
+  bool metatypeParamsRemoved = nextIf('m');
   bool isSerialized = nextIf('q');
 
   int PassID = (int)nextChar() - '0';
@@ -3047,6 +3048,10 @@ NodePointer Demangler::demangleSpecAttributes(Node::Kind SpecKind) {
     return nullptr;
 
   NodePointer SpecNd = createNode(SpecKind);
+
+  if (metatypeParamsRemoved)
+    SpecNd->addChild(createNode(Node::Kind::MetatypeParamsRemoved), *this);
+
   if (isSerialized)
     SpecNd->addChild(createNode(Node::Kind::IsSerialized),
                      *this);

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -496,6 +496,7 @@ private:
     case Node::Kind::SILBoxMutableField:
     case Node::Kind::SILBoxImmutableField:
     case Node::Kind::IsSerialized:
+    case Node::Kind::MetatypeParamsRemoved:
     case Node::Kind::SpecializationPassID:
     case Node::Kind::Static:
     case Node::Kind::Subscript:
@@ -1127,7 +1128,8 @@ void NodePrinter::printSpecializationPrefix(NodePointer node,
   for (NodePointer child : *node) {
     switch (child->getKind()) {
       case Node::Kind::SpecializationPassID:
-        // We skip the SpecializationPassID since it does not contain any
+      case Node::Kind::MetatypeParamsRemoved:
+        // We skip those nodes since it does not contain any
         // information that is useful to our users.
         break;
 
@@ -1548,6 +1550,9 @@ NodePointer NodePrinter::print(NodePointer Node, unsigned depth,
     return nullptr;
   case Node::Kind::IsSerialized:
     Printer << "serialized";
+    return nullptr;
+  case Node::Kind::MetatypeParamsRemoved:
+    Printer << "metatypes-removed";
     return nullptr;
   case Node::Kind::GenericSpecializationParam:
     print(Node->getChild(0), depth + 1);

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -446,6 +446,11 @@ ManglingError Remangler::mangleIsSerialized(Node *node, unsigned depth) {
   return ManglingError::Success;
 }
 
+ManglingError Remangler::mangleMetatypeParamsRemoved(Node *node, unsigned depth) {
+  Buffer << "m";
+  return ManglingError::Success;
+}
+
 ManglingError
 Remangler::mangleFunctionSignatureSpecializationReturn(Node *node,
                                                        unsigned depth) {

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -2801,6 +2801,11 @@ ManglingError Remangler::mangleIsSerialized(Node *node, unsigned depth) {
   return ManglingError::Success;
 }
 
+ManglingError Remangler::mangleMetatypeParamsRemoved(Node *node, unsigned depth) {
+  Buffer << 'm';
+  return ManglingError::Success;
+}
+
 ManglingError Remangler::mangleStatic(Node *node, unsigned depth) {
   RETURN_IF_ERROR(mangleSingleChildNode(node, depth + 1));
   Buffer << 'Z';

--- a/lib/SIL/Utils/GenericSpecializationMangler.cpp
+++ b/lib/SIL/Utils/GenericSpecializationMangler.cpp
@@ -105,13 +105,18 @@ mangleNotReabstracted(SubstitutionMap subs) {
 }
                                   
 std::string GenericSpecializationMangler::
-mangleReabstracted(SubstitutionMap subs, bool alternativeMangling) {
+mangleReabstracted(SubstitutionMap subs, bool alternativeMangling,
+                   bool metatyeParamsRemoved) {
   beginMangling();
   appendSubstitutions(getGenericSignature(), subs);
   
   // See ReabstractionInfo::hasConvertedResilientParams for why and when to use
   // the alternative mangling.
-  appendSpecializationOperator(alternativeMangling ? "TB" : "Tg");
+  if (metatyeParamsRemoved) {
+    appendSpecializationOperator(alternativeMangling ? "TBm" : "Tgm");
+  } else {
+    appendSpecializationOperator(alternativeMangling ? "TB" : "Tg");
+  }
   return finalize();
 }
 

--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -596,6 +596,8 @@ RuntimeEffect swift::getRuntimeEffect(SILInstruction *inst, SILType &impactType)
   case SILInstructionKind::AllocGlobalInst: {
     SILType glTy = cast<AllocGlobalInst>(inst)->getReferencedGlobal()->
                       getLoweredType();
+    if (glTy.isLoadable(*inst->getFunction()))
+      return RuntimeEffect::NoEffect;
     if (glTy.hasOpaqueArchetype()) {
       impactType = glTy;
       return RuntimeEffect::Allocating | RuntimeEffect::MetaData;

--- a/lib/SILOptimizer/IRGenTransforms/TargetConstantFolding.cpp
+++ b/lib/SILOptimizer/IRGenTransforms/TargetConstantFolding.cpp
@@ -67,9 +67,6 @@ private:
     // Scan all instructions in the module for constant foldable instructions.
     for (SILFunction &function : *module) {
     
-      if (!function.shouldOptimize())
-        continue;
-    
       bool changed = false;
       for (SILBasicBlock &block : function) {
         InstructionDeleter deleter;

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -978,6 +978,9 @@ SILPassPipelinePlan::getOnonePassPipeline(const SILOptions &Options) {
   P.startPipeline("Rest of Onone");
   P.addUsePrespecialized();
 
+  // Needed to fold MemoryLayout constants in performance-annotated functions.
+  P.addTargetConstantFolding();
+
   // Has only an effect if the -assume-single-thread option is specified.
   if (P.getOptions().AssumeSingleThreaded) {
     P.addAssumeSingleThreaded();

--- a/lib/SILOptimizer/Transforms/GenericSpecializer.cpp
+++ b/lib/SILOptimizer/Transforms/GenericSpecializer.cpp
@@ -226,10 +226,20 @@ void MandatoryGenericSpecializer::run() {
       continue;
 
     // Perform generic specialization and other related optimzations.
-    bool changed = optimize(func, cha);
 
-    if (changed)
-      invalidateAnalysis(func, SILAnalysis::InvalidationKind::Everything);
+    // To avoid phase ordering problems of the involved optimizations, iterate
+    // until we reach a fixed point.
+    // This should always happen, but to be on the save side, limit the number
+    // of iterations to 10 (which is more than enough - usually the loop runs
+    // 1 to 3 times).
+    for (int i = 0; i < 10; i++) {
+      bool changed = optimize(func, cha);
+      if (changed) {
+        invalidateAnalysis(func, SILAnalysis::InvalidationKind::Everything);
+      } else {
+        break;
+      }
+    }
 
     // Continue specializing called functions.
     for (SILBasicBlock &block : *func) {

--- a/lib/SILOptimizer/Utils/GenericCloner.cpp
+++ b/lib/SILOptimizer/Utils/GenericCloner.cpp
@@ -105,6 +105,12 @@ void GenericCloner::populateCloned() {
           entryArgs.push_back(ASI);
           return true;
         }
+      } else if (ReInfo.isDroppedMetatypeArg(ArgIdx)) {
+        // Replace the metatype argument with an `metatype` instruction in the
+        // entry block.
+        auto *mtInst = getBuilder().createMetatype(Loc, mappedType);
+        entryArgs.push_back(mtInst);
+        return true;
       } else {
         // Handle arguments for formal parameters.
         unsigned paramIdx = ArgIdx - origConv.getSILArgIndexOfFirstParam();

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -359,6 +359,7 @@ $S18resilient_protocol21ResilientBaseProtocolTL ---> protocol requirements base 
 $S1t1PP10AssocType2_AA1QTn ---> associated conformance descriptor for t.P.AssocType2: t.Q
 $S1t1PP10AssocType2_AA1QTN ---> default associated conformance accessor for t.P.AssocType2: t.Q
 $s4Test6testityyxlFAA8MystructV_TB5 ---> generic specialization <Test.Mystruct> of Test.testit<A>(A) -> ()
+$sSUss17FixedWidthIntegerRzrlEyxqd__cSzRd__lufCSu_SiTgm5 ---> generic specialization <Swift.UInt, Swift.Int> of (extension in Swift):Swift.UnsignedInteger< where A: Swift.FixedWidthInteger>.init<A where A1: Swift.BinaryInteger>(A1) -> A
 $sSD5IndexVy__GD ---> $sSD5IndexVy__GD
 $s4test3StrCACycfC ---> {T:$s4test3StrCACycfc} test.Str.__allocating_init() -> test.Str
 $s18keypaths_inlinable13KeypathStructV8computedSSvpACTKq  ---> key path getter for keypaths_inlinable.KeypathStruct.computed : Swift.String : keypaths_inlinable.KeypathStruct, serialized

--- a/test/Driver/loaded_module_trace_nocrash.swift
+++ b/test/Driver/loaded_module_trace_nocrash.swift
@@ -4,10 +4,10 @@
 // RUN: mkdir -p %t/Mods/Foo.swiftmodule
 // RUN: mkdir -p %t/Mods/Bar.swiftmodule
 
-// RUN: %target-swift-frontend %s -DFoo -emit-module -o %t/Mods/Foo.swiftmodule/armv7s-apple-ios.swiftmodule -emit-module-interface-path %t/Mods/Foo.swiftmodule/armv7s-apple-ios.swiftinterface -target armv7s-apple-ios10 -module-name Foo -enable-library-evolution -parse-stdlib
-// RUN: %target-swift-frontend %s -DFoo -emit-module -o %t/Mods/Foo.swiftmodule/arm.swiftmodule -emit-module-interface-path %t/Mods/Foo.swiftmodule/arm.swiftinterface -target arm-apple-ios10 -module-name Foo -enable-library-evolution -parse-stdlib
-// RUN: %target-swift-frontend %s -DBar -typecheck -emit-module-interface-path %t/Mods/Bar.swiftmodule/arm.swiftinterface -I %t/Mods -target arm-apple-ios10 -module-name Bar -enable-library-evolution -parse-stdlib
-// RUN: %target-swift-frontend %s -DFooBar -typecheck -emit-loaded-module-trace-path - -I %t/Mods -target armv7s-apple-ios10 -parse-stdlib
+// RUN: %target-swift-frontend %s -DFoo -emit-module -o %t/Mods/Foo.swiftmodule/armv7s-apple-ios.swiftmodule -emit-module-interface-path %t/Mods/Foo.swiftmodule/armv7s-apple-ios.swiftinterface -target armv7s-apple-ios10 -module-name Foo -enable-library-evolution -parse-stdlib -Xllvm -sil-disable-pass=target-constant-folding
+// RUN: %target-swift-frontend %s -DFoo -emit-module -o %t/Mods/Foo.swiftmodule/arm.swiftmodule -emit-module-interface-path %t/Mods/Foo.swiftmodule/arm.swiftinterface -target arm-apple-ios10 -module-name Foo -enable-library-evolution -parse-stdlib -Xllvm -sil-disable-pass=target-constant-folding
+// RUN: %target-swift-frontend %s -DBar -typecheck -emit-module-interface-path %t/Mods/Bar.swiftmodule/arm.swiftinterface -I %t/Mods -target arm-apple-ios10 -module-name Bar -enable-library-evolution -parse-stdlib -Xllvm -sil-disable-pass=target-constant-folding
+// RUN: %target-swift-frontend %s -DFooBar -typecheck -emit-loaded-module-trace-path - -I %t/Mods -target armv7s-apple-ios10 -parse-stdlib -Xllvm -sil-disable-pass=target-constant-folding
 
 #if Foo
 #endif

--- a/test/SILOptimizer/memory-layout.swift
+++ b/test/SILOptimizer/memory-layout.swift
@@ -1,0 +1,35 @@
+// RUN: %target-swift-frontend -experimental-performance-annotations %s -O -sil-verify-all -module-name=test -emit-sil | %FileCheck %s
+
+// Check that constant propagation of MemoryLayout is also done at -Onone to ensure that
+// no metadate is created at runtime - which would violate the performance annotation.
+
+// CHECK-LABEL: sil [no_locks] @$s4test7getSizeSiyF
+// CHECK:         [[I:%[0-9]+]] = integer_literal {{.*}}, 4
+// CHECK:         [[S:%[0-9]+]] = struct {{.*}}([[I]]
+// CHECK:         return [[S]]
+// CHECK:       } // end sil function '$s4test7getSizeSiyF'
+@_noLocks
+public func getSize() -> Int {
+  return MemoryLayout<Int32>.size
+}
+
+// CHECK-LABEL: sil [no_locks] @$s4test12getAlignmentSiyF
+// CHECK:         [[I:%[0-9]+]] = integer_literal {{.*}}, 4
+// CHECK:         [[S:%[0-9]+]] = struct {{.*}}([[I]]
+// CHECK:         return [[S]]
+// CHECK:       } // end sil function '$s4test12getAlignmentSiyF'
+@_noLocks
+public func getAlignment() -> Int {
+  return MemoryLayout<Int32>.alignment
+}
+
+// CHECK-LABEL: sil [no_locks] @$s4test9getStrideSiyF
+// CHECK:         [[I:%[0-9]+]] = integer_literal {{.*}}, 4
+// CHECK:         [[S:%[0-9]+]] = struct {{.*}}([[I]]
+// CHECK:         return [[S]]
+// CHECK:       } // end sil function '$s4test9getStrideSiyF'
+@_noLocks
+public func getStride() -> Int {
+  return MemoryLayout<Int32>.stride
+}
+

--- a/test/SILOptimizer/performance-annotations.swift
+++ b/test/SILOptimizer/performance-annotations.swift
@@ -139,6 +139,18 @@ func callFuncWithMetatypeArg() {
   metatypeArg(Int.self, false)                // expected-note {{called from here}}
 }
 
+@_noAllocation
+func intConversion() {
+  let x = 42
+  _ = UInt(x)
+}
+
+@_noAllocation
+func integerRange() {
+  for _ in 0 ..< 10 {
+  }
+}
+
 struct GenStruct<A> {
   var a: A
 }

--- a/test/SILOptimizer/performance-annotations.swift
+++ b/test/SILOptimizer/performance-annotations.swift
@@ -163,3 +163,41 @@ func globalWithInitializer(x: MyStruct) {
   _ = MyStruct.v         // expected-note {{called from here}}
 }
 
+@_noAllocation
+func callBadClosure(closure: ()->Int) -> Int {
+  return closure()
+}
+
+@_noAllocation
+func badClosure() {
+  _ = callBadClosure(closure: { // expected-note {{called from here}}
+     _ = Cl()                   // expected-error {{Using type 'Cl' can cause metadata allocation or locks}}
+     return 42
+    })
+}
+
+func badClosure2() {
+  _ = callBadClosure(closure: { // expected-note {{called from here}}
+     _ = Cl()                   // expected-error {{Using type 'Cl' can cause metadata allocation or locks}}
+     return 42
+    })
+}
+
+@_noAllocation
+func callGoodClosure(closure: ()->Int) -> Int {
+  return closure()
+}
+
+@_noAllocation
+func goodClosure() {
+  _ = callBadClosure(closure: {
+     return 42
+    })
+}
+
+func goodClosure2() {
+  _ = callBadClosure(closure: {
+     return 42
+    })
+}
+

--- a/test/SILOptimizer/performance-annotations.swift
+++ b/test/SILOptimizer/performance-annotations.swift
@@ -1,6 +1,5 @@
 // RUN: %target-swift-frontend -experimental-performance-annotations -emit-sil %s -o /dev/null -verify
 // REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
-// REQUIRES: rdar90495704
 
 protocol P {
   func protoMethod(_ a: Int) -> Int
@@ -32,6 +31,8 @@ struct AllocatingStr : P {
   }
 }
 
+/* Currently disabled: rdar://90495704
+
 func noRTCallsForArrayGet(_ a: [Str], _ i: Int) -> Int {
   return a[i].x
 }
@@ -40,6 +41,7 @@ func noRTCallsForArrayGet(_ a: [Str], _ i: Int) -> Int {
 func callArrayGet(_ a: [Str]) -> Int {
   return noRTCallsForArrayGet(a, 0)
 }
+*/
 
 @_noLocks
 func arcOperations(_ x: Cl) -> Cl {

--- a/test/SILOptimizer/performance-annotations.swift
+++ b/test/SILOptimizer/performance-annotations.swift
@@ -148,3 +148,18 @@ func memoryLayout() -> Int? {
   return MemoryLayout<GenStruct<Int>>.size
 }
 
+class H {
+  var hash: Int { 27 }
+}
+
+struct MyStruct {
+  static var v: Int = {  // expected-note {{called from here}}
+    return H().hash      // expected-error {{Using type 'H' can cause metadata allocation or locks}}
+  }()
+}
+
+@_noAllocation
+func globalWithInitializer(x: MyStruct) {
+  _ = MyStruct.v         // expected-note {{called from here}}
+}
+

--- a/test/SILOptimizer/performance-annotations.swift
+++ b/test/SILOptimizer/performance-annotations.swift
@@ -139,3 +139,12 @@ func callFuncWithMetatypeArg() {
   metatypeArg(Int.self, false)                // expected-note {{called from here}}
 }
 
+struct GenStruct<A> {
+  var a: A
+}
+
+@_noAllocation
+func memoryLayout() -> Int? {
+  return MemoryLayout<GenStruct<Int>>.size
+}
+

--- a/test/SILOptimizer/performance-annotations.swift
+++ b/test/SILOptimizer/performance-annotations.swift
@@ -131,3 +131,11 @@ func testGlobalWithComplexInit() -> Int {
   return Str.s3 // expected-note {{called from here}}
 }
 
+func metatypeArg<T>(_ t: T.Type, _ b: Bool) { // expected-error {{Using type 'Int' can cause metadata allocation or locks}}
+}
+
+@_noAllocation
+func callFuncWithMetatypeArg() {
+  metatypeArg(Int.self, false)                // expected-note {{called from here}}
+}
+

--- a/test/SILOptimizer/target-const-prop.swift
+++ b/test/SILOptimizer/target-const-prop.swift
@@ -34,47 +34,46 @@ public func noConstantSize<T>(_ t: T.Type) -> Int {
   return MemoryLayout<T>.size
 }
 
-// Check that there is not constant propagation if optimizations are disabled.
-// This is important for the runtime check to make sure that we are comparing
+// It's important to not constant propagate here to make sure that we are comparing
 // SIL constant propagated values with IRGen values.
 
-// CHECK-LABEL: sil {{.*}} @$s4test7getSizeSiyF
-// CHECK:         builtin "sizeof"<S>
-// CHECK:       } // end sil function '$s4test7getSizeSiyF' 
+// CHECK-LABEL: sil {{.*}} @$s4test7getSizeySixmlF
+// CHECK:         builtin "sizeof"<T>
+// CHECK:       } // end sil function '$s4test7getSizeySixmlF' 
 @_optimize(none)
-func getSize() -> Int {
-  return MemoryLayout<S>.size
+func getSize<T>(_ t: T.Type) -> Int {
+  return MemoryLayout<T>.size
 }
 
-// CHECK-LABEL: sil {{.*}} @$s4test12getAlignmentSiyF
-// CHECK:         builtin "alignof"<S>
-// CHECK:       } // end sil function '$s4test12getAlignmentSiyF' 
+// CHECK-LABEL: sil {{.*}} @$s4test12getAlignmentySixmlF
+// CHECK:         builtin "alignof"<T>
+// CHECK:       } // end sil function '$s4test12getAlignmentySixmlF' 
 @_optimize(none)
-func getAlignment() -> Int {
-  return MemoryLayout<S>.alignment
+func getAlignment<T>(_ t: T.Type) -> Int {
+  return MemoryLayout<T>.alignment
 }
 
-// CHECK-LABEL: sil {{.*}} @$s4test9getStrideSiyF
-// CHECK:         builtin "strideof"<S>
-// CHECK:       } // end sil function '$s4test9getStrideSiyF' 
+// CHECK-LABEL: sil {{.*}} @$s4test9getStrideySixmlF
+// CHECK:         builtin "strideof"<T>
+// CHECK:       } // end sil function '$s4test9getStrideySixmlF' 
 @_optimize(none)
-func getStride() -> Int {
-  return MemoryLayout<S>.stride
+func getStride<T>(_ t: T.Type) -> Int {
+  return MemoryLayout<T>.stride
 }
 
 @inline(never)
 func testit() {
   // CHECK-OUTPUT: size: true
-  print("size: \(S.size == getSize())")
+  print("size: \(S.size == getSize(S.self))")
 
   // CHECK-OUTPUT: alignment: true
-  print("alignment: \(S.alignment == getAlignment())")
+  print("alignment: \(S.alignment == getAlignment(S.self))")
 
   // CHECK-OUTPUT: stride: true
-  print("stride: \(S.stride == getStride())")
+  print("stride: \(S.stride == getStride(S.self))")
 
   // CHECK-OUTPUT: doubleSize: true
-  print("doubleSize: \(S.doubleSize == getSize() * 2)")
+  print("doubleSize: \(S.doubleSize == getSize(S.self) * 2)")
 }
 
 testit()

--- a/test/Serialization/target-incompatible.swift
+++ b/test/Serialization/target-incompatible.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %swift -target x86_64-unknown-darwin14 -o %t/mips-template.swiftmodule -parse-stdlib -emit-module -module-name mips %S/../Inputs/empty.swift
+// RUN: %swift -target x86_64-unknown-darwin14 -o %t/mips-template.swiftmodule -parse-stdlib -emit-module -module-name mips -Xllvm -sil-disable-pass=target-constant-folding %S/../Inputs/empty.swift
 // RUN: %{python} -u %S/Inputs/binary_sub.py x86_64-unknown-darwin14 mips64-unknown-darwin14 < %t/mips-template.swiftmodule > %t/mips.swiftmodule
 // RUN: not %target-swift-frontend -I %t -typecheck -parse-stdlib %s -DMIPS 2>&1 | %FileCheck -check-prefix=CHECK-MIPS %s
 
-// RUN: %swift -target x86_64-unknown-darwin14 -o %t/solaris-template.swiftmodule -parse-stdlib -emit-module -module-name solaris %S/../Inputs/empty.swift
+// RUN: %swift -target x86_64-unknown-darwin14 -o %t/solaris-template.swiftmodule -parse-stdlib -emit-module -module-name solaris -Xllvm -sil-disable-pass=target-constant-folding %S/../Inputs/empty.swift
 // RUN: %{python} -u %S/Inputs/binary_sub.py x86_64-unknown-darwin14 x86_64-unknown-solaris8 < %t/solaris-template.swiftmodule > %t/solaris.swiftmodule
 // RUN: not %target-swift-frontend -I %t -typecheck -parse-stdlib %s -DSOLARIS 2>&1 | %FileCheck -check-prefix=CHECK-SOLARIS %s
 
@@ -17,11 +17,11 @@
 
 // These checks should still hold with -enable-library-evolution.
 
-// RUN: %swift -target x86_64-unknown-darwin14 -o %t/mips-template.swiftmodule -parse-stdlib -emit-module -module-name mips %S/../Inputs/empty.swift -enable-library-evolution
+// RUN: %swift -target x86_64-unknown-darwin14 -o %t/mips-template.swiftmodule -parse-stdlib -emit-module -module-name mips -Xllvm -sil-disable-pass=target-constant-folding %S/../Inputs/empty.swift -enable-library-evolution
 // RUN: %{python} -u %S/Inputs/binary_sub.py x86_64-unknown-darwin14 mips64-unknown-darwin14 < %t/mips-template.swiftmodule > %t/mips.swiftmodule
 // RUN: not %target-swift-frontend -I %t -typecheck -parse-stdlib %s -DMIPS 2>&1 | %FileCheck -check-prefix=CHECK-MIPS %s
 
-// RUN: %swift -target x86_64-unknown-darwin14 -o %t/solaris-template.swiftmodule -parse-stdlib -emit-module -module-name solaris %S/../Inputs/empty.swift -enable-library-evolution
+// RUN: %swift -target x86_64-unknown-darwin14 -o %t/solaris-template.swiftmodule -parse-stdlib -emit-module -module-name solaris -Xllvm -sil-disable-pass=target-constant-folding %S/../Inputs/empty.swift -enable-library-evolution
 // RUN: %{python} -u %S/Inputs/binary_sub.py x86_64-unknown-darwin14 x86_64-unknown-solaris8 < %t/solaris-template.swiftmodule > %t/solaris.swiftmodule
 // RUN: not %target-swift-frontend -I %t -typecheck -parse-stdlib %s -DSOLARIS 2>&1 | %FileCheck -check-prefix=CHECK-SOLARIS %s
 

--- a/test/sil-passpipeline-dump/basic.test-sh
+++ b/test/sil-passpipeline-dump/basic.test-sh
@@ -10,5 +10,5 @@
 // CHECK-NEXT:               "ownership-model-eliminator" ]
 // CHECK: ---
 // CHECK: name:            Rest of Onone
-// CHECK: passes:          [ "use-prespecialized", "sil-debuginfo-gen" ]
+// CHECK: passes:          [ "use-prespecialized", "target-constant-folding", "sil-debuginfo-gen" ]
 // CHECK: ...


### PR DESCRIPTION
Fixes several cases of missing errors and false alarms.
The fixes are mostly in the MandatoryGenericSpecializer pass, so that the generated code avoids locks and allocations.
A few fixes are directly in the PerformanceDiagnostics pass - in cases where the generated code is okay, but just the (not) emitted errors were wrong.

For details see the commit messages.

rdar://94388453
rdar://94729207
rdar://94780620
rdar://94833845
rdar://94836837