### PR TITLE
Adding actionable note to @main error

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3255,6 +3255,10 @@ ERROR(attr_ApplicationMain_with_script,none,
       "%" SELECT_APPLICATION_MAIN "0 attribute cannot be used in a module that contains "
       "top-level code",
       (unsigned))
+
+NOTE(attr_ApplicationMain_parse_as_library,none,
+     "pass '-parse-as-library' to compiler invocation if this is intentional",
+     ())
 NOTE(attr_ApplicationMain_script_here,none,
      "top-level code defined in this source file",
      ())

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1841,6 +1841,8 @@ bool ModuleDecl::registerEntryPointFile(FileUnit *file, SourceLoc diagLoc,
       if (existingDiagLoc.isValid()) {
         getASTContext().Diags.diagnose(existingDiagLoc,
                            diag::attr_ApplicationMain_script_here);
+        getASTContext().Diags.diagnose(existingDiagLoc,
+                           diag::attr_ApplicationMain_parse_as_library);
       }
     }
   }

--- a/test/attr/ApplicationMain/attr_NSApplicationMain_with_main/main.swift
+++ b/test/attr/ApplicationMain/attr_NSApplicationMain_with_main/main.swift
@@ -1,4 +1,5 @@
 // expected-note{{top-level code defined in this source file}}
+// expected-note@-1{{pass '-parse-as-library' to compiler invocation if this is intentional}}
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify %s %S/delegate.swift
 
 // Serialized partial AST support:

--- a/test/attr/ApplicationMain/attr_UIApplicationMain_with_main/main.swift
+++ b/test/attr/ApplicationMain/attr_UIApplicationMain_with_main/main.swift
@@ -1,4 +1,5 @@
 // expected-note{{top-level code defined in this source file}}
+// expected-note@-1{{pass '-parse-as-library' to compiler invocation if this is intentional}}
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify %s %S/delegate.swift
 
 // REQUIRES: objc_interop

--- a/test/attr/ApplicationMain/attr_main_with_maindotswift/main.swift
+++ b/test/attr/ApplicationMain/attr_main_with_maindotswift/main.swift
@@ -1,4 +1,5 @@
 // expected-note{{top-level code defined in this source file}}
+// expected-note@-1{{pass '-parse-as-library' to compiler invocation if this is intentional}}
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify %s %S/file.swift
 
 hi()


### PR DESCRIPTION
The compiler enters "script" mode if there is a file called
`main.swift`, or if there is only one file. Parsing files as a script
means that anything in the file is interpreted as top-level code, which
is incompatible with a valid @main-annotated struct, so an error is
emitted.

Unfortunately, it is intentional in many cases, and the diagnostic
didn't provide anything actionable to indicate that the explicit main
function is intentional and that the file being passed in is not
actually a top-level context.

The new note indicates that passing `-parse-as-library` to the compiler
invocation will fix it if the explicit main function is intentional.

rdar://89888060
