### PR TITLE
Emit actor hop as part of call to the getter.

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -5780,13 +5780,15 @@ SILDeclRef SILGenModule::getAccessorDeclRef(AccessorDecl *accessor) {
 }
 
 /// Emit a call to a getter.
-RValue SILGenFunction::emitGetAccessor(SILLocation loc, SILDeclRef get,
-                                       SubstitutionMap substitutions,
-                                       ArgumentSource &&selfValue, bool isSuper,
-                                       bool isDirectUse,
-                                       PreparedArguments &&subscriptIndices,
-                                       SGFContext c,
-                                       bool isOnSelfParameter) {
+RValue SILGenFunction::emitGetAccessor(
+    SILLocation loc, SILDeclRef get,
+    SubstitutionMap substitutions,
+    ArgumentSource &&selfValue, bool isSuper,
+    bool isDirectUse,
+    PreparedArguments &&subscriptIndices,
+    SGFContext c,
+    bool isOnSelfParameter,
+    Optional<ImplicitActorHopTarget> implicitActorHopTarget) {
   // Scope any further writeback just within this operation.
   FormalEvaluationScope writebackScope(*this);
 
@@ -5797,6 +5799,9 @@ RValue SILGenFunction::emitGetAccessor(SILLocation loc, SILDeclRef get,
   CanAnyFunctionType accessType = getter.getSubstFormalType();
 
   CallEmission emission(*this, std::move(getter), std::move(writebackScope));
+  if (implicitActorHopTarget)
+    emission.setImplicitlyAsync(implicitActorHopTarget);
+
   // Self ->
   if (hasSelf) {
     emission.addSelfParam(loc, std::move(selfValue),

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1440,12 +1440,14 @@ public:
                                         CanType baseFormalType,
                                         SILDeclRef accessor);
 
-  RValue emitGetAccessor(SILLocation loc, SILDeclRef getter,
-                         SubstitutionMap substitutions,
-                         ArgumentSource &&optionalSelfValue, bool isSuper,
-                         bool isDirectAccessorUse,
-                         PreparedArguments &&optionalSubscripts, SGFContext C,
-                         bool isOnSelfParameter);
+  RValue emitGetAccessor(
+      SILLocation loc, SILDeclRef getter,
+      SubstitutionMap substitutions,
+      ArgumentSource &&optionalSelfValue, bool isSuper,
+      bool isDirectAccessorUse,
+      PreparedArguments &&optionalSubscripts, SGFContext C,
+      bool isOnSelfParameter,
+      Optional<ImplicitActorHopTarget> implicitActorHopTarget = None);
 
   void emitSetAccessor(SILLocation loc, SILDeclRef setter,
                        SubstitutionMap substitutions,

--- a/test/SILGen/hop_to_executor_async_prop.swift
+++ b/test/SILGen/hop_to_executor_async_prop.swift
@@ -83,8 +83,8 @@ struct GlobalCat {
 // CHECK:  bb0([[CAT:%[0-9]+]] : @guaranteed $Cat):
 // CHECK:    [[GENERIC_EXEC:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none
 // CHECK:    hop_to_executor [[GENERIC_EXEC]] :
-// CHECK:    hop_to_executor [[CAT]] : $Cat
 // CHECK:    [[CAT_GETTER:%[0-9]+]] = class_method [[CAT]] : $Cat, #Cat.computedSweater!getter : (isolated Cat) -> () -> Sweater, $@convention(method) (@guaranteed Cat) -> @owned Sweater
+// CHECK:    hop_to_executor [[CAT]] : $Cat
 // CHECK:    [[SWEATER1_REF:%[0-9]+]] = apply [[CAT_GETTER]]([[CAT]]) : $@convention(method) (@guaranteed Cat) -> @owned Sweater
 // CHECK:    hop_to_executor [[GENERIC_EXEC]]
 // CHECK:    [[SWEATER1:%[0-9]+]] = begin_borrow [[SWEATER1_REF]] : $Sweater
@@ -92,15 +92,13 @@ struct GlobalCat {
 // CHECK:    [[CAT2_REF:%[0-9]+]] = copy_value [[SWEATER1_OWNER]] : $Cat
 // CHECK:    end_borrow [[SWEATER1]] : $Sweater
 // CHECK:    destroy_value [[SWEATER1_REF]] : $Sweater
-// CHECK:    [[CAT2:%[0-9]+]] = begin_borrow [[CAT2_REF]] : $Cat
 
-// CHECK:    hop_to_executor [[CAT2]] : $Cat
 // CHECK:    [[CAT2_FOR_LOAD:%[0-9]+]] = begin_borrow [[CAT2_REF]] : $Cat
 // CHECK:    [[CAT2_GETTER:%[0-9]+]] = class_method [[CAT2_FOR_LOAD]] : $Cat, #Cat.computedSweater!getter : (isolated Cat) -> () -> Sweater, $@convention(method) (@guaranteed Cat) -> @owned Sweater
+// CHECK:    hop_to_executor [[CAT2_FOR_LOAD]] : $Cat
 // CHECK:    [[SWEATER2_OWNER:%[0-9]+]] = apply [[CAT2_GETTER]]([[CAT2_FOR_LOAD]]) : $@convention(method) (@guaranteed Cat) -> @owned Sweater
-// CHECK:    end_borrow [[CAT2_FOR_LOAD]] : $Cat
-// CHECK:    end_borrow [[CAT2]] : $Cat
 // CHECK:    hop_to_executor [[GENERIC_EXEC]]
+// CHECK:    end_borrow [[CAT2_FOR_LOAD]] : $Cat
 
 // CHECK:    destroy_value [[CAT2_REF]] : $Cat
 // CHECK:    return [[SWEATER2_OWNER]] : $Sweater
@@ -114,6 +112,9 @@ func accessSweaterOfSweater(cat : Cat) async -> Sweater {
 // CHECK:  bb0([[CAT:%[0-9]+]] : @guaranteed $Cat):
 // CHECK:    [[GENERIC_EXEC:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none
 // CHECK:    hop_to_executor [[GENERIC_EXEC]] :
+
+// CHECK:    [[GETTER:%[0-9]+]] = class_method [[CAT]] : $Cat, #Cat.leader!getter : (Cat) -> () -> String, $@convention(method) (@guaranteed Cat) -> @owned String
+
 // CHECK:    [[GLOBAL_CAT_SHARED:%[0-9]+]] = function_ref @$s4test9GlobalCatV6sharedAA0C0Cvau : $@convention(thin) () -> Builtin.RawPointer
 // CHECK:    [[GLOBAL_CAT_RAWPTR:%[0-9]+]] = apply [[GLOBAL_CAT_SHARED]]() : $@convention(thin) () -> Builtin.RawPointer
 // CHECK:    [[GLOBAL_CAT_ADDR:%[0-9]+]] = pointer_to_address [[GLOBAL_CAT_RAWPTR]] : $Builtin.RawPointer to [strict] $*Cat
@@ -121,10 +122,9 @@ func accessSweaterOfSweater(cat : Cat) async -> Sweater {
 // CHECK:    [[GLOBAL_CAT:%[0-9]+]] = begin_borrow [[GLOBAL_CAT_REF]] : $Cat
 
 // CHECK:    hop_to_executor [[GLOBAL_CAT]] : $Cat
-// CHECK:    [[GETTER:%[0-9]+]] = class_method [[CAT]] : $Cat, #Cat.leader!getter : (Cat) -> () -> String, $@convention(method) (@guaranteed Cat) -> @owned String
 // CHECK:    [[THE_STRING:%[0-9]+]] = apply [[GETTER]]([[CAT]]) : $@convention(method) (@guaranteed Cat) -> @owned String
-// CHECK:    end_borrow [[GLOBAL_CAT]] : $Cat
 // CHECK:    hop_to_executor [[GENERIC_EXEC]]
+// CHECK:    end_borrow [[GLOBAL_CAT]] : $Cat
 // CHECK:    destroy_value [[GLOBAL_CAT_REF]] : $Cat
 // CHECK:    return [[THE_STRING]] : $String
 // CHECK: } // end sil function '$s4test26accessGlobalIsolatedMember3catSSAA3CatC_tYaF'
@@ -162,6 +162,9 @@ actor Dog {
     // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC24accessGlobalComputedPropSiyYaF : $@convention(method) @async (@guaranteed Dog) -> Int {
     // CHECK:  bb0([[SELF:%[0-9]+]] : @guaranteed $Dog):
     // CHECK:    hop_to_executor [[SELF]] : $Dog
+
+    // CHECK:    [[SOMEBIRB_GETTER:%[0-9]+]] = function_ref @$s4test8someBirbAA0C0Cvg : $@convention(thin) () -> @owned Birb
+
     // CHECK:    [[SHARED_REF_FN:%[0-9]+]] = function_ref @$s4test9GlobalCatV6sharedAA0C0Cvau : $@convention(thin) () -> Builtin.RawPointer
     // CHECK:    [[SHARED_REF:%[0-9]+]] = apply [[SHARED_REF_FN]]() : $@convention(thin) () -> Builtin.RawPointer
     // CHECK:    [[SHARED_CAT_ADDR:%[0-9]+]] = pointer_to_address [[SHARED_REF]] : $Builtin.RawPointer to [strict] $*Cat
@@ -169,22 +172,15 @@ actor Dog {
     // CHECK:    [[BORROWED_CAT:%[0-9]+]] = begin_borrow [[CAT]] : $Cat
 
     // CHECK:    hop_to_executor [[BORROWED_CAT]] : $Cat
-    // CHECK:    [[SOMEBIRB_GETTER:%[0-9]+]] = function_ref @$s4test8someBirbAA0C0Cvg : $@convention(thin) () -> @owned Birb
     // CHECK:    [[BIRB:%[0-9]+]] = apply [[SOMEBIRB_GETTER]]() : $@convention(thin) () -> @owned Birb
-    // CHECK:    end_borrow [[BORROWED_CAT:%[0-9]+]] : $Cat
 
     // CHECK:    hop_to_executor [[SELF]] : $Dog
-    // CHECK:    [[BORROWED_BIRB:%[0-9]+]] = begin_borrow [[BIRB]] : $Birb
-    // CHECK:    hop_to_executor [[BORROWED_BIRB]] : $Birb
     // CHECK:    [[BORROWED_BIRB_FOR_LOAD:%[0-9]+]] = begin_borrow [[BIRB]] : $Birb
     // CHECK:    [[FEATHER_GETTER:%[0-9]+]] = class_method [[BORROWED_BIRB_FOR_LOAD]] : $Birb, #Birb.feathers!getter : (isolated Birb) -> () -> Int, $@convention(method) (@guaranteed Birb) -> Int
+    // CHECK:    hop_to_executor [[BORROWED_BIRB_FOR_LOAD]] : $Birb
     // CHECK:    [[THE_INT:%[0-9]+]] = apply [[FEATHER_GETTER]]([[BORROWED_BIRB_FOR_LOAD]]) : $@convention(method) (@guaranteed Birb) -> Int
-    // CHECK:    end_borrow [[BORROWED_BIRB_FOR_LOAD]] : $Birb
-    // CHECK:    end_borrow [[BORROWED_BIRB]] : $Birb
 
     // CHECK:    hop_to_executor [[SELF]] : $Dog
-    // CHECK:    destroy_value [[BIRB]] : $Birb
-    // CHECK:    destroy_value [[CAT]] : $Cat
     // CHECK:    return [[THE_INT]] : $Int
     // CHECK: } // end sil function '$s4test3DogC24accessGlobalComputedPropSiyYaF'
     func accessGlobalComputedProp() async -> Int {
@@ -195,19 +191,15 @@ actor Dog {
     // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC21accessWrappedProperty3catSiAA3CatC_tYaF : $@convention(method) @async (@guaranteed Cat, @guaranteed Dog) -> Int {
     // CHECK:  bb0([[CAT:%[0-9]+]] : @guaranteed $Cat, [[SELF:%[0-9]+]] : @guaranteed $Dog):
     // CHECK:    hop_to_executor [[SELF]] : $Dog
-    // CHECK:    hop_to_executor [[CAT]] : $Cat
     // CHECK:    [[CAT_GETTER:%[0-9]+]] = class_method [[CAT]] : $Cat, #Cat.bestFriend!getter : (isolated Cat) -> () -> Birb, $@convention(method) (@guaranteed Cat) -> @owned Birb
+    // CHECK:    hop_to_executor [[CAT]] : $Cat
     // CHECK:    [[BIRB_REF:%[0-9]+]] = apply [[CAT_GETTER]]([[CAT]]) : $@convention(method) (@guaranteed Cat) -> @owned Birb
     // CHECK:    hop_to_executor [[SELF]] : $Dog
-    // CHECK:    [[BIRB:%[0-9]+]] = begin_borrow [[BIRB_REF]] : $Birb
-    // CHECK:    hop_to_executor [[BIRB]] : $Birb
     // CHECK:    [[BIRB_FOR_LOAD:%[0-9]+]] = begin_borrow [[BIRB_REF]] : $Birb
     // CHECK:    [[BIRB_GETTER:%[0-9]+]] = class_method [[BIRB_FOR_LOAD]] : $Birb, #Birb.feathers!getter : (isolated Birb) -> () -> Int, $@convention(method) (@guaranteed Birb) -> Int
+    // CHECK:    hop_to_executor [[BIRB_FOR_LOAD]] : $Birb
     // CHECK:    [[THE_INT:%[0-9]+]] = apply [[BIRB_GETTER]]([[BIRB_FOR_LOAD]]) : $@convention(method) (@guaranteed Birb) -> Int
-    // CHECK:    end_borrow [[BIRB_FOR_LOAD]] : $Birb
-    // CHECK:    end_borrow [[BIRB]] : $Birb
     // CHECK:    hop_to_executor [[SELF]] : $Dog
-    // CHECK:    destroy_value [[BIRB_REF]] : $Birb
     // CHECK:    return [[THE_INT]] : $Int
     // CHECK: } // end sil function '$s4test3DogC21accessWrappedProperty3catSiAA3CatC_tYaF'
     func accessWrappedProperty(cat : Cat) async -> Int {
@@ -219,17 +211,13 @@ actor Dog {
     // CHECK:   hop_to_executor [[SELF:%[0-9]+]] : $Dog
     // CHECK:   [[INIT:%[0-9]+]] = function_ref @$s4test3CatCACycfC : $@convention(method) (@thick Cat.Type) -> @owned Cat
     // CHECK:   [[CAT_REF:%[0-9]+]] = apply [[INIT]]({{%[0-9]+}}) : $@convention(method) (@thick Cat.Type) -> @owned Cat
-    // CHECK:   [[CAT_BORROW_FOR_HOP:%[0-9]+]] = begin_borrow [[CAT_REF]] : $Cat
 
-    // CHECK:   hop_to_executor [[CAT_BORROW_FOR_HOP]] : $Cat
     // CHECK:   [[CAT_BORROW_FOR_LOAD:%[0-9]+]] = begin_borrow [[CAT_REF]] : $Cat
     // CHECK:   [[GETTER:%[0-9]+]] = class_method [[CAT_BORROW_FOR_LOAD]] : $Cat, #Cat.storedBool!getter : (isolated Cat) -> () -> Bool, $@convention(method) (@guaranteed Cat) -> Bool
+    // CHECK:   hop_to_executor [[CAT_BORROW_FOR_LOAD]] : $Cat
     // CHECK:   [[THE_BOOL:%[0-9]+]] = apply [[GETTER]]([[CAT_BORROW_FOR_LOAD]]) : $@convention(method) (@guaranteed Cat) -> Bool
-    // CHECK:   end_borrow [[CAT_BORROW_FOR_LOAD]] : $Cat
-    // CHECK:   end_borrow [[CAT_BORROW_FOR_HOP]] : $Cat
 
     // CHECK:   hop_to_executor [[SELF]] : $Dog
-    // CHECK:   destroy_value [[CAT_REF]] : $Cat
     // CHECK:   return [[THE_BOOL]] : $Bool
     // CHECK: } // end sil function '$s4test3DogC16accessFromRValueSbyYaF'
     func accessFromRValue() async -> Bool {
@@ -241,27 +229,23 @@ actor Dog {
     // CHECK:   hop_to_executor [[SELF:%[0-9]+]] : $Dog
     // CHECK:   [[INIT:%[0-9]+]] = function_ref @$s4test3CatCACycfC : $@convention(method) (@thick Cat.Type) -> @owned Cat
     // CHECK:   [[CAT_REF:%[0-9]+]] = apply [[INIT]]({{%[0-9]+}}) : $@convention(method) (@thick Cat.Type) -> @owned Cat
-    // CHECK:   [[CAT_BORROW_FOR_HOP:%[0-9]+]] = begin_borrow [[CAT_REF]] : $Cat
 
-    // CHECK:   hop_to_executor [[CAT_BORROW_FOR_HOP]] : $Cat
     // CHECK:   [[CAT_BORROW_FOR_LOAD:%[0-9]+]] = begin_borrow [[CAT_REF]] : $Cat
     // CHECK:   [[FRIEND_GETTER:%[0-9]+]] = class_method [[CAT_BORROW_FOR_LOAD]] : $Cat, #Cat.friend!getter : (isolated Cat) -> () -> Cat, $@convention(method) (@guaranteed Cat) -> @owned Cat
+    // CHECK:   hop_to_executor [[CAT_BORROW_FOR_LOAD]] : $Cat
     // CHECK:   [[FRIEND_REF:%[0-9]+]] = apply [[FRIEND_GETTER]]([[CAT_BORROW_FOR_LOAD]]) : $@convention(method) (@guaranteed Cat) -> @owned Cat
-    // CHECK:   end_borrow [[CAT_BORROW_FOR_LOAD]] : $Cat
-    // CHECK:   end_borrow [[CAT_BORROW_FOR_HOP]] : $Cat
-
     // CHECK:   hop_to_executor [[SELF]] : $Dog
-    // CHECK:   destroy_value [[CAT_REF]] : $Cat
-    // CHECK:   [[FRIEND_BORROW_FOR_HOP:%[0-9]+]] = begin_borrow [[FRIEND_REF]] : $Cat
+    // CHECK:   end_borrow [[CAT_BORROW_FOR_LOAD]] : $Cat
 
-    // CHECK:   hop_to_executor [[FRIEND_BORROW_FOR_HOP]] : $Cat
+    // CHECK:   destroy_value [[CAT_REF]] : $Cat
+
     // CHECK:   [[FRIEND_BORROW_FOR_LOAD:%[0-9]+]] = begin_borrow [[FRIEND_REF]] : $Cat
     // CHECK:   [[BOOL_GETTER:%[0-9]+]] = class_method [[FRIEND_BORROW_FOR_LOAD]] : $Cat, #Cat.storedBool!getter : (isolated Cat) -> () -> Bool, $@convention(method) (@guaranteed Cat) -> Bool
+    // CHECK:   hop_to_executor [[FRIEND_BORROW_FOR_LOAD]] : $Cat
     // CHECK:   [[THE_BOOL:%[0-9]+]] = apply [[BOOL_GETTER]]([[FRIEND_BORROW_FOR_LOAD]]) : $@convention(method) (@guaranteed Cat) -> Bool
-    // CHECK:   end_borrow [[FRIEND_BORROW_FOR_LOAD]] : $Cat
-    // CHECK:   end_borrow [[FRIEND_BORROW_FOR_HOP]] : $Cat
 
     // CHECK:   hop_to_executor [[SELF]] : $Dog
+    // CHECK:   end_borrow [[FRIEND_BORROW_FOR_LOAD]] : $Cat
     // CHECK:   destroy_value [[FRIEND_REF]] : $Cat
     // CHECK:   return [[THE_BOOL]] : $Bool
     // CHECK: } // end sil function '$s4test3DogC23accessFromRValueChainedSbyYaF'
@@ -275,8 +259,8 @@ actor Dog {
     // CHECK:   hop_to_executor [[DOG]] : $Dog
     // CHECK:   [[INTEGER1:%[0-9]+]] = apply {{%[0-9]+}}({{%[0-9]+}}, {{%[0-9]+}}) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
 
-    // CHECK:   hop_to_executor [[CAT]] : $Cat
     // CHECK:   [[SUBSCRIPT_FN:%[0-9]+]] = class_method [[CAT]] : $Cat, #Cat.subscript!getter : (isolated Cat) -> (Int) -> Cat, $@convention(method) (Int, @guaranteed Cat) -> @owned Cat
+    // CHECK:   hop_to_executor [[CAT]] : $Cat
     // CHECK:   [[OTHER_CAT:%[0-9]+]] = apply [[SUBSCRIPT_FN]]([[INTEGER1]], [[CAT]]) : $@convention(method) (Int, @guaranteed Cat) -> @owned Cat
 
     // CHECK:   hop_to_executor [[DOG]] : $Dog
@@ -291,29 +275,25 @@ actor Dog {
     // CHECK:   [[RVALUE_CAT_REF:%[0-9]+]] = apply {{%[0-9]+}}({{%[0-9]+}}) : $@convention(method) (@thick Cat.Type) -> @owned Cat
     // CHECK:   [[LIT_ONE:%[0-9]+]] = integer_literal $Builtin.IntLiteral, 1
     // CHECK:   [[INT_ONE:%[0-9]+]] = apply {{%[0-9]+}}([[LIT_ONE]], {{%[0-9]+}}) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
-    // CHECK:   [[RVALUE_CAT:%[0-9]+]] = begin_borrow [[RVALUE_CAT_REF]] : $Cat
 
-    // CHECK:   hop_to_executor [[RVALUE_CAT]] : $Cat
     // CHECK:   [[RVALUE_CAT_FOR_LOAD:%[0-9]+]] = begin_borrow [[RVALUE_CAT_REF]] : $Cat
     // CHECK:   [[RVALUE_CAT_SUBSCRIPT:%[0-9]+]] = class_method [[RVALUE_CAT_FOR_LOAD]] : $Cat, #Cat.subscript!getter : (isolated Cat) -> (Int) -> Cat, $@convention(method) (Int, @guaranteed Cat) -> @owned Cat
+    // CHECK:   hop_to_executor [[RVALUE_CAT_FOR_LOAD]] : $Cat
     // CHECK:   [[FIRST_CAT_REF:%[0-9]+]] = apply [[RVALUE_CAT_SUBSCRIPT]]([[INT_ONE]], [[RVALUE_CAT_FOR_LOAD]]) : $@convention(method) (Int, @guaranteed Cat) -> @owned Cat
-    // CHECK:   end_borrow [[RVALUE_CAT_FOR_LOAD]] : $Cat
-    // CHECK:   end_borrow [[RVALUE_CAT]] : $Cat
-
     // CHECK:   hop_to_executor [[SELF]] : $Dog
+    // CHECK:   end_borrow [[RVALUE_CAT_FOR_LOAD]] : $Cat
+
     // CHECK:   destroy_value [[RVALUE_CAT_REF]] : $Cat
     // CHECK:   [[LIT_TWO:%[0-9]+]] = integer_literal $Builtin.IntLiteral, 2
     // CHECK:   [[INT_TWO:%[0-9]+]] = apply {{%[0-9]+}}([[LIT_TWO]], {{%[0-9]+}}) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
-    // CHECK:   [[FIRST_CAT:%[0-9]+]] = begin_borrow [[FIRST_CAT_REF]] : $Cat
 
-    // CHECK:   hop_to_executor [[FIRST_CAT]] : $Cat
     // CHECK:   [[FIRST_CAT_FOR_LOAD:%[0-9]+]] = begin_borrow [[FIRST_CAT_REF]] : $Cat
     // CHECK:   [[FIRST_CAT_SUBSCRIPT:%[0-9]+]] = class_method [[FIRST_CAT_FOR_LOAD]] : $Cat, #Cat.subscript!getter : (isolated Cat) -> (Int) -> Cat, $@convention(method) (Int, @guaranteed Cat) -> @owned Cat
+    // CHECK:   hop_to_executor [[FIRST_CAT_FOR_LOAD]] : $Cat
     // CHECK:   [[SECOND_CAT_REF:%[0-9]+]] = apply [[FIRST_CAT_SUBSCRIPT]]([[INT_TWO]], [[FIRST_CAT_FOR_LOAD]]) : $@convention(method) (Int, @guaranteed Cat) -> @owned Cat
-    // CHECK:   end_borrow [[FIRST_CAT_FOR_LOAD]] : $Cat
-    // CHECK:   end_borrow [[FIRST_CAT]] : $Cat
-
     // CHECK:   hop_to_executor [[SELF]] : $Dog
+    // CHECK:   end_borrow [[FIRST_CAT_FOR_LOAD]] : $Cat
+
     // CHECK:   destroy_value [[FIRST_CAT_REF]] : $Cat
     // CHECK:   return [[SECOND_CAT_REF]] : $Cat
     // CHECK: } // end sil function '$s4test3DogC27accessRValueNestedSubscriptAA3CatCyYaF'
@@ -327,16 +307,14 @@ actor Dog {
     // CHECK:     hop_to_executor [[SELF]] : $Dog
     // CHECK:     [[BOX_GETTER:%[0-9]+]] = class_method [[BOX]] : $CatBox, #CatBox.cat!getter : (CatBox) -> () -> Cat, $@convention(method) (@guaranteed CatBox) -> @owned Cat
     // CHECK:     [[CAT_REF:%[0-9]+]] = apply [[BOX_GETTER]]([[BOX]]) : $@convention(method) (@guaranteed CatBox) -> @owned Cat
-    // CHECK:     [[CAT:%[0-9]+]] = begin_borrow [[CAT_REF]] : $Cat
 
-    // CHECK:     hop_to_executor [[CAT]] : $Cat
     // CHECK:     [[CAT_FOR_LOAD:%[0-9]+]] = begin_borrow [[CAT_REF:%[0-9]+]] : $Cat
     // CHECK:     [[GETTER:%[0-9]+]] = class_method [[CAT_FOR_LOAD]] : $Cat, #Cat.storedBool!getter : (isolated Cat) -> () -> Bool, $@convention(method) (@guaranteed Cat) -> Bool
+    // CHECK:     hop_to_executor [[CAT_FOR_LOAD]] : $Cat
     // CHECK:     [[THE_BOOL:%[0-9]+]] = apply [[GETTER]]([[CAT_FOR_LOAD]]) : $@convention(method) (@guaranteed Cat) -> Bool
-    // CHECK:     end_borrow [[CAT_FOR_LOAD]] : $Cat
-    // CHECK:     end_borrow [[CAT]] : $Cat
-
     // CHECK:     hop_to_executor [[SELF]] : $Dog
+    // CHECK:     end_borrow [[CAT_FOR_LOAD]] : $Cat
+
     // CHECK:     destroy_value [[CAT_REF]] : $Cat
     // CHECK:    return [[THE_BOOL]] : $Bool
     // CHECK: } // end sil function '$s4test3DogC33accessStoredPropFromRefProjection3boxSbAA6CatBoxC_tYaF'
@@ -348,8 +326,8 @@ actor Dog {
     // CHECK:  bb0([[CAT:%[0-9]+]] : @guaranteed $Cat, [[SELF:%[0-9]+]] : @guaranteed $Dog):
     // CHECK:    hop_to_executor [[SELF]] : $Dog
 
-    // CHECK:    hop_to_executor [[CAT]] : $Cat
     // CHECK:    [[CAT_GETTER:%[0-9]+]] = class_method [[CAT]] : $Cat, #Cat.computedSweater!getter : (isolated Cat) -> () -> Sweater, $@convention(method) (@guaranteed Cat) -> @owned Sweater
+    // CHECK:    hop_to_executor [[CAT]] : $Cat
     // CHECK:    [[SWEATER1_REF:%[0-9]+]] = apply [[CAT_GETTER]]([[CAT]]) : $@convention(method) (@guaranteed Cat) -> @owned Sweater
 
     // CHECK:    hop_to_executor [[SELF]] : $Dog
@@ -358,16 +336,14 @@ actor Dog {
     // CHECK:    [[CAT2_REF:%[0-9]+]] = copy_value [[SWEATER1_OWNER]] : $Cat
     // CHECK:    end_borrow [[SWEATER1]] : $Sweater
     // CHECK:    destroy_value [[SWEATER1_REF]] : $Sweater
-    // CHECK:    [[CAT2:%[0-9]+]] = begin_borrow [[CAT2_REF]] : $Cat
 
-    // CHECK:    hop_to_executor [[CAT2]] : $Cat
     // CHECK:    [[CAT2_FOR_LOAD:%[0-9]+]] = begin_borrow [[CAT2_REF]] : $Cat
     // CHECK:    [[CAT2_GETTER:%[0-9]+]] = class_method [[CAT2_FOR_LOAD]] : $Cat, #Cat.computedSweater!getter : (isolated Cat) -> () -> Sweater, $@convention(method) (@guaranteed Cat) -> @owned Sweater
+    // CHECK:    hop_to_executor [[CAT2_FOR_LOAD]] : $Cat
     // CHECK:    [[SWEATER2_OWNER:%[0-9]+]] = apply [[CAT2_GETTER]]([[CAT2_FOR_LOAD]]) : $@convention(method) (@guaranteed Cat) -> @owned Sweater
-    // CHECK:    end_borrow [[CAT2_FOR_LOAD]] : $Cat
-    // CHECK:    end_borrow [[CAT2]] : $Cat
 
     // CHECK:    hop_to_executor [[SELF]] : $Dog
+    // CHECK:    end_borrow [[CAT2_FOR_LOAD]] : $Cat
     // CHECK:    destroy_value [[CAT2_REF]] : $Cat
     // CHECK:    return [[SWEATER2_OWNER]] : $Sweater
     // CHECK: } // end sil function '$s4test3DogC015accessSweaterOfD03catAA0D0VAA3CatC_tYaF'
@@ -380,18 +356,16 @@ actor Dog {
     // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC13accessCatList3catAA0D0CAG_tYaF : $@convention(method) @async (@guaranteed Cat, @guaranteed Dog) -> @owned Cat {
     // CHECK:  bb0([[CAT:%[0-9]+]] : @guaranteed $Cat, [[SELF:%[0-9]+]] : @guaranteed $Dog):
     // CHECK:    hop_to_executor [[SELF]] : $Dog
-    // CHECK:    hop_to_executor [[CAT]] : $Cat
     // CHECK:    [[CAT_GETTER:%[0-9]+]] = class_method [[CAT]] : $Cat, #Cat.friend!getter : (isolated Cat) -> () -> Cat, $@convention(method) (@guaranteed Cat) -> @owned Cat
+    // CHECK:    hop_to_executor [[CAT]] : $Cat
     // CHECK:    [[FRIEND1_REF:%[0-9]+]] = apply [[CAT_GETTER]]([[CAT]]) : $@convention(method) (@guaranteed Cat) -> @owned Cat
     // CHECK:    hop_to_executor [[SELF]] : $Dog
-    // CHECK:    [[FRIEND1:%[0-9]+]] = begin_borrow [[FRIEND1_REF]] : $Cat
-    // CHECK:    hop_to_executor [[FRIEND1]] : $Cat
     // CHECK:    [[FRIEND1_FOR_LOAD:%[0-9]+]] = begin_borrow [[FRIEND1_REF]] : $Cat
     // CHECK:    [[FRIEND1_GETTER:%[0-9]+]] = class_method [[FRIEND1_FOR_LOAD]] : $Cat, #Cat.friend!getter : (isolated Cat) -> () -> Cat, $@convention(method) (@guaranteed Cat) -> @owned Cat
+    // CHECK:    hop_to_executor [[FRIEND1_FOR_LOAD]] : $Cat
     // CHECK:    [[FRIEND2_REF:%[0-9]+]] = apply [[FRIEND1_GETTER]]([[FRIEND1_FOR_LOAD]]) : $@convention(method) (@guaranteed Cat) -> @owned Cat
-    // CHECK:    end_borrow [[FRIEND1_FOR_LOAD]] : $Cat
-    // CHECK:    end_borrow [[FRIEND1]] : $Cat
     // CHECK:    hop_to_executor [[SELF]] : $Dog
+    // CHECK:    end_borrow [[FRIEND1_FOR_LOAD]] : $Cat
     // CHECK:    destroy_value [[FRIEND1_REF]] : $Cat
     // CHECK:    return [[FRIEND2_REF]] : $Cat
     // CHECK: } // end sil function '$s4test3DogC13accessCatList3catAA0D0CAG_tYaF'
@@ -405,12 +379,12 @@ actor Dog {
     // CHECK:    hop_to_executor [[SELF]] : $Dog
     // CHECK:    [[FRIEND1_STACK:%[0-9]+]] = alloc_stack $Optional<Cat>
 
-    // CHECK:    hop_to_executor [[CAT]] : $Cat
     // CHECK:    [[MAYBE_GETTER:%[0-9]+]] = class_method [[CAT]] : $Cat, #Cat.maybeFriend!getter : (isolated Cat) -> () -> Cat?, $@convention(method) (@guaranteed Cat) -> @owned Optional<Cat>
+    // CHECK:    hop_to_executor [[CAT]] : $Cat
     // CHECK:    [[MAYBE_FRIEND:%[0-9]+]] = apply [[MAYBE_GETTER]]([[CAT]]) : $@convention(method) (@guaranteed Cat) -> @owned Optional<Cat>
+    // CHECK:    hop_to_executor [[SELF]] : $Dog
     // CHECK:    store [[MAYBE_FRIEND]] to [init] [[FRIEND1_STACK]] : $*Optional<Cat>
 
-    // CHECK:    hop_to_executor [[SELF]] : $Dog
     // CHECK:    [[IS_SOME:%[0-9]+]] = select_enum_addr [[FRIEND1_STACK]] : $*Optional<Cat>
     // CHECK:    cond_br [[IS_SOME]], bb1, bb3
 
@@ -418,14 +392,12 @@ actor Dog {
     // CHECK:    [[FRIEND1_ADDR:%[0-9]+]] = unchecked_take_enum_data_addr [[FRIEND1_STACK]] : $*Optional<Cat>, #Optional.some!enumelt
     // CHECK:    [[FRIEND1_REF:%[0-9]+]] = load [copy] [[FRIEND1_ADDR]] : $*Cat
     // CHECK:    destroy_addr [[FRIEND1_STACK]] : $*Optional<Cat>
-    // CHECK:    [[FRIEND1:%[0-9]+]] = begin_borrow [[FRIEND1_REF]] : $Cat
-    // CHECK:    hop_to_executor [[FRIEND1]] : $Cat
     // CHECK:    [[FRIEND1_FOR_LOAD:%[0-9]+]] = begin_borrow [[FRIEND1_REF]] : $Cat
     // CHECK:    [[FRIEND1_GETTER:%[0-9]+]] = class_method [[FRIEND1_FOR_LOAD]] : $Cat, #Cat.friend!getter : (isolated Cat) -> () -> Cat, $@convention(method) (@guaranteed Cat) -> @owned Cat
+    // CHECK:    hop_to_executor [[FRIEND1_FOR_LOAD]] : $Cat
     // CHECK:    [[FRIEND2_REF:%[0-9]+]] = apply [[FRIEND1_GETTER]]([[FRIEND1_FOR_LOAD]]) : $@convention(method) (@guaranteed Cat) -> @owned Cat
-    // CHECK:    end_borrow [[FRIEND1_FOR_LOAD]] : $Cat
-    // CHECK:    end_borrow [[FRIEND1]] : $Cat
     // CHECK:    hop_to_executor [[SELF]] : $Dog
+    // CHECK:    end_borrow [[FRIEND1_FOR_LOAD]] : $Cat
     // CHECK:    destroy_value [[FRIEND1_REF]] : $Cat
     // CHECK:    [[FRIEND2_OPTIONAL:%[0-9]+]] = enum $Optional<Cat>, #Optional.some!enumelt, [[FRIEND2_REF]] : $Cat
     // CHECK:    dealloc_stack [[FRIEND1_STACK]] : $*Optional<Cat>
@@ -436,6 +408,21 @@ actor Dog {
     func accessOptionalCatList(cat : Cat) async -> Cat? {
         return await cat.maybeFriend?.friend
     }
+
+    // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC22accessOptionalViaIfLet3catAA3CatCSgAG_tYaF : $@convention(method) @async (@guaranteed Cat, @guaranteed Dog) -> @owned Optional<Cat>
+    // CHECK:  bb0([[CAT:%[0-9]+]] : @guaranteed $Cat, [[SELF:%[0-9]+]] : @guaranteed $Dog):
+    func accessOptionalViaIfLet(cat: Cat) async -> Cat? {
+        // CHECK: hop_to_executor [[SELF]] : $Dog
+        // CHECK: [[METHOD:%.*]] = class_method [[CAT]] : $Cat, #Cat.maybeFriend!getter : (isolated Cat) -> () -> Cat?, $@convention(method) (@guaranteed Cat) -> @owned Optional<Cat>
+        // CHECK: hop_to_executor [[CAT]] : $Cat                       // id: %6
+        // CHECK: [[RESULT:%.*]] = apply [[METHOD]]([[CAT]]) : $@convention(method) (@guaranteed Cat) -> @owned Optional<Cat>
+        // CHECK: hop_to_executor [[SELF]] : $Dog
+        // CHECK: switch_enum [[RESULT]]
+        if let friend = await cat.maybeFriend {
+            return friend
+        }
+        return nil
+    } // CHECK: } // end sil function '$s4test3DogC22accessOptionalViaIfLet3catAA3CatCSgAG_tYaF'
 } // END OF DOG ACTOR
 
 class Point {


### PR DESCRIPTION
When emitting a call to the getter for storage, emit the actor hop (and
hop back) as part of the call itself, rather than around the whole
initialization. This address a bug involving initialization with an
optional binding in an `if let`, where the hop-back would only be
performed on the non-nil branch.

Fixes rdar://96487805 / FB10562197
