### PR TITLE
[5.7][SymbolGraphGen] only include the given symbol for qualified imports

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -940,7 +940,10 @@ inline SourceLoc extractNearestSourceLoc(const ModuleDecl *mod) {
 }
 
 /// Collects modules that this module imports via `@_exported import`.
-void collectParsedExportedImports(const ModuleDecl *M, SmallPtrSetImpl<ModuleDecl *> &Imports);
+void collectParsedExportedImports(const ModuleDecl *M,
+                                  SmallPtrSetImpl<ModuleDecl *> &Imports,
+                                  SmallVectorImpl<Decl *> &Decls,
+                                  bool AddQualifiedImportModules = false);
 
 } // end namespace swift
 

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -942,8 +942,7 @@ inline SourceLoc extractNearestSourceLoc(const ModuleDecl *mod) {
 /// Collects modules that this module imports via `@_exported import`.
 void collectParsedExportedImports(const ModuleDecl *M,
                                   SmallPtrSetImpl<ModuleDecl *> &Imports,
-                                  SmallVectorImpl<Decl *> &Decls,
-                                  bool AddQualifiedImportModules = false);
+                                  llvm::SmallDenseMap<ModuleDecl *, SmallPtrSet<Decl *, 4>, 4> &QualifiedImports);
 
 } // end namespace swift
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -790,30 +790,30 @@ bool ModuleDecl::shouldCollectDisplayDecls() const {
 
 void swift::collectParsedExportedImports(const ModuleDecl *M,
                                          SmallPtrSetImpl<ModuleDecl *> &Imports,
-                                         SmallVectorImpl<Decl *> &Decls,
-                                         bool AddQualifiedImportModules) {
+                                         llvm::SmallDenseMap<ModuleDecl *, SmallPtrSet<Decl *, 4>, 4> &QualifiedImports) {
   for (const FileUnit *file : M->getFiles()) {
     if (const SourceFile *source = dyn_cast<SourceFile>(file)) {
       if (source->hasImports()) {
         for (auto import : source->getImports()) {
           if (import.options.contains(ImportFlags::Exported) &&
               import.module.importedModule->shouldCollectDisplayDecls()) {
+            auto *TheModule = import.module.importedModule;
+
             if (import.module.getAccessPath().size() > 0) {
-              if (AddQualifiedImportModules &&
-                  !Imports.contains(import.module.importedModule)) {
-                Imports.insert(import.module.importedModule);
+              if (QualifiedImports.find(TheModule) == QualifiedImports.end()) {
+                QualifiedImports.try_emplace(TheModule);
               }
               auto collectDecls = [&](ValueDecl *VD,
                                       DeclVisibilityKind reason) {
                 if (reason == DeclVisibilityKind::VisibleAtTopLevel)
-                  Decls.push_back(VD);
+                  QualifiedImports[TheModule].insert(VD);
               };
               auto consumer = makeDeclConsumer(std::move(collectDecls));
-              import.module.importedModule->lookupVisibleDecls(
+              TheModule->lookupVisibleDecls(
                   import.module.getAccessPath(), consumer,
                   NLKind::UnqualifiedLookup);
-            } else if (!Imports.contains(import.module.importedModule)) {
-              Imports.insert(import.module.importedModule);
+            } else if (!Imports.contains(TheModule)) {
+              Imports.insert(TheModule);
             }
           }
         }
@@ -970,7 +970,12 @@ SourceFile::getExternalRawLocsForDecl(const Decl *D) const {
 void ModuleDecl::getDisplayDecls(SmallVectorImpl<Decl*> &Results, bool Recursive) const {
   if (Recursive && isParsedModule(this)) {
     SmallPtrSet<ModuleDecl *, 4> Modules;
-    collectParsedExportedImports(this, Modules, Results);
+    llvm::SmallDenseMap<ModuleDecl *, SmallPtrSet<Decl *, 4>, 4> QualifiedImports;
+    collectParsedExportedImports(this, Modules, QualifiedImports);
+    for (const auto &QI : QualifiedImports) {
+      auto &Decls = QI.getSecond();
+      Results.append(Decls.begin(), Decls.end());
+    }
     for (const ModuleDecl *import : Modules) {
       import->getDisplayDecls(Results, Recursive);
     }

--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -732,7 +732,7 @@ bool SymbolGraph::isUnconditionallyUnavailableOnAllPlatforms(const Decl *D) cons
 bool SymbolGraph::canIncludeDeclAsNode(const Decl *D) const {
   // If this decl isn't in this module or module that this module imported with `@_exported`, don't record it,
   // as it will appear elsewhere in its module's symbol graph.
-  if (D->getModuleContext()->getName() != M.getName() && !Walker.isFromExportedImportedModule(D)) {
+  if (D->getModuleContext()->getName() != M.getName() && !Walker.isConsideredExportedImported(D)) {
     return false;
   }
 

--- a/lib/SymbolGraphGen/SymbolGraphASTWalker.h
+++ b/lib/SymbolGraphGen/SymbolGraphASTWalker.h
@@ -96,6 +96,10 @@ struct SymbolGraphASTWalker : public SourceEntityWalker {
   virtual bool walkToDeclPre(Decl *D, CharSourceRange Range) override;
     
   // MARK: - Utilities
+
+  /// Returns whether the given declaration was itself imported via an `@_exported import`
+  /// statement, or if it is an extension or child symbol of something else that was.
+  virtual bool isConsideredExportedImported(const Decl *D) const;
   
   /// Returns whether the given declaration comes from an `@_exported import` module.
   virtual bool isFromExportedImportedModule(const Decl *D) const;

--- a/lib/SymbolGraphGen/SymbolGraphASTWalker.h
+++ b/lib/SymbolGraphGen/SymbolGraphASTWalker.h
@@ -49,6 +49,8 @@ struct SymbolGraphASTWalker : public SourceEntityWalker {
     
   const SmallPtrSet<ModuleDecl *, 4> ExportedImportedModules;
 
+  const llvm::SmallDenseMap<ModuleDecl *, SmallPtrSet<Decl *, 4>, 4> QualifiedExportedImports;
+
   /// The symbol graph for the main module of interest.
   SymbolGraph MainGraph;
 
@@ -59,6 +61,7 @@ struct SymbolGraphASTWalker : public SourceEntityWalker {
   
   SymbolGraphASTWalker(ModuleDecl &M,
                        const SmallPtrSet<ModuleDecl *, 4> ExportedImportedModules,
+                       const llvm::SmallDenseMap<ModuleDecl *, SmallPtrSet<Decl *, 4>, 4> QualifiedExportedImports,
                        const SymbolGraphOptions &Options);
   virtual ~SymbolGraphASTWalker() {}
 
@@ -96,6 +99,9 @@ struct SymbolGraphASTWalker : public SourceEntityWalker {
   
   /// Returns whether the given declaration comes from an `@_exported import` module.
   virtual bool isFromExportedImportedModule(const Decl *D) const;
+
+  /// Returns whether the given declaration was imported via an `@_exported import <type>` declaration.
+  virtual bool isQualifiedExportedImport(const Decl *D) const;
 
   /// Returns whether the given module is an `@_exported import` module.
   virtual bool isExportedImportedModule(const ModuleDecl *M) const;

--- a/lib/SymbolGraphGen/SymbolGraphGen.cpp
+++ b/lib/SymbolGraphGen/SymbolGraphGen.cpp
@@ -59,7 +59,8 @@ symbolgraphgen::emitSymbolGraphForModule(ModuleDecl *M,
   swift::getTopLevelDeclsForDisplay(M, ModuleDecls, /*recursive*/true);
   
   SmallPtrSet<ModuleDecl *, 4> ExportedImportedModules;
-  swift::collectParsedExportedImports(M, ExportedImportedModules);
+  swift::collectParsedExportedImports(M, ExportedImportedModules, ModuleDecls,
+                                      /*AddQualifiedImportModules*/ true);
 
   if (Options.PrintMessages)
     llvm::errs() << ModuleDecls.size()

--- a/test/SymbolGraph/Module/ExportedImport.swift
+++ b/test/SymbolGraph/Module/ExportedImport.swift
@@ -1,13 +1,17 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %S/Inputs/ExportedImport/A.swift -module-name A -emit-module -emit-module-path %t/A.swiftmodule
+// RUN: %target-swift-frontend %S/Inputs/ExportedImport/B.swift -module-name B -emit-module -emit-module-path %t/B.swiftmodule
 // RUN: %target-swift-frontend %s -module-name ExportedImport -emit-module -emit-module-path /dev/null -I %t -emit-symbol-graph -emit-symbol-graph-dir %t/
 // RUN: %FileCheck %s --input-file %t/ExportedImport.symbols.json
 // RUN: ls %t | %FileCheck %s --check-prefix FILES
 
 @_exported import A
+@_exported import struct B.StructOne
 
-// CHECK: "precise":"s:1A11SymbolFromAV"
 // CHECK-NOT: InternalSymbolFromA
+// CHECK-NOT: StructTwo
+// CHECK-DAG: "precise":"s:1A11SymbolFromAV"
+// CHECK-DAG: "precise":"s:1B9StructOneV"
 
 // FIXME: Symbols from `@_exported import` do not get emitted when using swift-symbolgraph-extract
 // This is tracked by https://bugs.swift.org/browse/SR-15921.

--- a/test/SymbolGraph/Module/Inputs/ExportedImport/B.swift
+++ b/test/SymbolGraph/Module/Inputs/ExportedImport/B.swift
@@ -1,0 +1,3 @@
+public struct StructOne {}
+
+public struct StructTwo {}

--- a/test/SymbolGraph/Module/Inputs/QualifiedImportWithExtensions/A.swift
+++ b/test/SymbolGraph/Module/Inputs/QualifiedImportWithExtensions/A.swift
@@ -1,0 +1,3 @@
+public struct StructOne {}
+
+public struct StructTwo {}

--- a/test/SymbolGraph/Module/Inputs/QualifiedImportWithExtensions/A.swift
+++ b/test/SymbolGraph/Module/Inputs/QualifiedImportWithExtensions/A.swift
@@ -1,3 +1,5 @@
-public struct StructOne {}
+public struct StructOne {
+    public init() {}
+}
 
 public struct StructTwo {}

--- a/test/SymbolGraph/Module/QualifiedImportWithExtensions.swift
+++ b/test/SymbolGraph/Module/QualifiedImportWithExtensions.swift
@@ -1,0 +1,26 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %S/Inputs/QualifiedImportWithExtensions/A.swift -module-name A -emit-module -emit-module-path %t/A.swiftmodule
+// RUN: %target-swift-frontend %s -module-name QualifiedImportWithExtensions -emit-module -emit-module-path /dev/null -I %t -emit-symbol-graph -emit-symbol-graph-dir %t/
+// RUN: %FileCheck %s --input-file %t/QualifiedImportWithExtensions.symbols.json
+// RUN: %FileCheck %s --input-file %t/QualifiedImportWithExtensions@A.symbols.json --check-prefix EXT
+
+@_exported import struct A.StructOne
+import A
+
+// An extension to a type that's been re-exported with a qualified import should appear in the
+// main symbol graph.
+extension A.StructOne {
+    public struct ExtendedStruct {}
+}
+
+// An extension to a type that's _not_ been re-exported should still appear in the extension symbol
+// graph, even if a different type from that module has been re-exported.
+extension A.StructTwo {
+    public struct InnerStruct {}
+}
+
+// CHECK: ExtendedStruct
+// CHECK-NOT: InnerStruct
+
+// EXT: InnerStruct
+// EXT-NOT: ExtendedStruct

--- a/test/SymbolGraph/Module/QualifiedImportWithExtensions.swift
+++ b/test/SymbolGraph/Module/QualifiedImportWithExtensions.swift
@@ -19,8 +19,13 @@ extension A.StructTwo {
     public struct InnerStruct {}
 }
 
-// CHECK: ExtendedStruct
+// Make sure that the `ExtendedStruct` type is present, and also that `StructOne`'s initializer is
+// present as well. The `InnerStruct` type should not be present since it's extending a type
+// that's not being re-exported.
+
 // CHECK-NOT: InnerStruct
+// CHECK-DAG: ExtendedStruct
+// CHECK-DAG: "precise":"s:1A9StructOneVACycfc"
 
 // EXT: InnerStruct
 // EXT-NOT: ExtendedStruct


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/59852

**Description**: When a library re-exports a module with `@_exported import`, the symbol graph includes the symbols from that module. However, when only a single symbol is re-exported with `@_exported import <type>`, the symbol graph still includes all the symbols from the other module, even though only the one symbol is present in the re-exported API. This PR checks for imports that are re-exporting a single symbol and handles them separately.
**Risk**: Low for compilation, medium for the symbol graph. The modifications are specific to SymbolGraphGen, but they are somewhat extensive. However, regular compilation should not be affected.
**Review by**: @franklinsch 
**Testing**: Automated tests have been added and updated, and all existing ones still pass.
**Original PR**: https://github.com/apple/swift/pull/59852
**Issue**: rdar://96309088