### PR TITLE
stdlib: Obsolete some deprecated SPI that are no longer used by corelibs-foundation

### DIFF
--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -407,28 +407,28 @@ extension _StringGuts {
     return !isSmall && isFastUTF8 && isASCII
   }
 
-  @available(*, deprecated)
-  public // SPI(corelibs-foundation)
-  var _isContiguousUTF16: Bool {
+  // FIXME: Previously used by swift-corelibs-foundation. Aging for removal.
+  @available(*, unavailable)
+  public var _isContiguousUTF16: Bool {
     return false
   }
 
-  // FIXME: Remove. Still used by swift-corelibs-foundation
+  // FIXME: Mark as obsoleted. Still used by swift-corelibs-foundation.
   @available(*, deprecated)
   public var startASCII: UnsafeMutablePointer<UInt8> {
     return UnsafeMutablePointer(mutating: _object.fastUTF8.baseAddress!)
   }
 
-  // FIXME: Remove. Still used by swift-corelibs-foundation
-  @available(*, deprecated)
+  // FIXME: Previously used by swift-corelibs-foundation. Aging for removal.
+  @available(*, unavailable)
   public var startUTF16: UnsafeMutablePointer<UTF16.CodeUnit> {
     fatalError("Not contiguous UTF-16")
   }
 }
 
-@available(*, deprecated)
-public // SPI(corelibs-foundation)
-func _persistCString(_ p: UnsafePointer<CChar>?) -> [CChar]? {
+// FIXME: Previously used by swift-corelibs-foundation. Aging for removal.
+@available(*, unavailable)
+public func _persistCString(_ p: UnsafePointer<CChar>?) -> [CChar]? {
   guard let s = p else { return nil }
   let bytesToCopy = UTF8._nullCodeUnitOffset(in: s) + 1 // +1 for the terminating NUL
   let result = [CChar](unsafeUninitializedCapacity: bytesToCopy) { buf, initedCount in

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -94,4 +94,11 @@ Func UnsafePointer.withMemoryRebound(to:capacity:_:) has been removed
 Func UnsafeMutableRawBufferPointer.storeBytes(of:toByteOffset:as:) has been removed
 Func UnsafeMutableRawPointer.storeBytes(of:toByteOffset:as:) has been removed
 
+// These haven't actually been removed; they are simply marked unavailable.
+// This seems to be a false positive in the ABI checker. This is not an ABI
+// break because the symbols are still present.
+Var _StringGuts._isContiguousUTF16 has been removed
+Var _StringGuts.startUTF16 has been removed
+Func _persistCString(_:) has been removed
+
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)


### PR DESCRIPTION
Uses of these were removed in https://github.com/apple/swift-corelibs-foundation/commit/df7f9f5dfa64b72bc4b470bbc234350b44f0cf3a.

"swift-corelibs-foundation" is meant for non-Apple platforms, and from what I can gather, we do not promise ABI compatibility with underscored public API that are not `@inlinable`.