### PR TITLE
RequirementMachine: Relax assertions in verifyRewriteSystem() [5.7]

### DIFF
--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -556,7 +556,8 @@ void RewriteSystem::verifyRewriteRules(ValidityPolicy policy) const {
         ASSERT_RULE(symbol.getKind() != Symbol::Kind::GenericParam);
       }
 
-      if (index != 0 && index != lhs.size() - 1) {
+      if (!rule.isLHSSimplified() &&
+          index != 0 && index != lhs.size() - 1) {
         ASSERT_RULE(symbol.getKind() != Symbol::Kind::Protocol);
       }
     }
@@ -591,7 +592,8 @@ void RewriteSystem::verifyRewriteRules(ValidityPolicy policy) const {
         ASSERT_RULE(symbol.getKind() != Symbol::Kind::GenericParam);
       }
 
-      if (index != 0 && !rule.isRHSSimplified()) {
+      if (!rule.isRHSSimplified() &&
+          index != 0) {
         ASSERT_RULE(symbol.getKind() != Symbol::Kind::Protocol);
       }
     }

--- a/test/Generics/rdar94746399.swift
+++ b/test/Generics/rdar94746399.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
+
+// CHECK-LABEL: .P1@
+// CHECK-NEXT: Requirement signature: <Self where Self == Self.[P1]T.[P2]T, Self.[P1]T : P2>
+protocol P1 {
+  associatedtype T: P2 where T.T == Self
+}
+
+// CHECK-LABEL: .P2@
+// CHECK-NEXT: Requirement signature: <Self where Self == Self.[P2]T.[P1]T, Self.[P2]T : P1>
+protocol P2 {
+  associatedtype T: P1 where T.T == Self
+}
+
+class SomeClass {}
+
+// CHECK-LABEL: .P3@
+// CHECK-NEXT: Requirement signature: <Self where Self : P2, Self.[P2]T : SomeClass>
+protocol P3: P2 where T: SomeClass {}
+
+protocol P4 {
+  associatedtype T
+}
+
+// CHECK-LABEL: .foo@
+// CHECK-NEXT: Generic signature: <T where T : P4, T.[P4]T : P1, T.[P4]T.[P1]T : P3>
+func foo<T: P4>(_: T) where T.T: P1, T.T.T: P3 {}


### PR DESCRIPTION
Fixes rdar://problem/94746399.

The strict assertions here are always true for non-simplified rules, but the old minimal conformances algorithm relied on them being true even for simplified rules, which was hard to guarantee. These invariants were established by extra logic in the completion procedure. Unfortunately, someone found a counter-example. Luckily, everything works in that specific example.

Note that we already did this once (https://github.com/apple/swift/pull/59557). This relaxes the verify assert further.

On the main branch I reworked the minimal conformances algorithm to not look at rewrite loops at all, in PR https://github.com/apple/swift/pull/59861 and https://github.com/apple/swift/pull/59900, and the weird logic in the completion procedure is now gone there.

However on 5.7 I'm keeping everything the same as before, just relaxing the assertion. If this causes any more problems we can cherry pick the rework of minimal conformances to 5.7, but I'd rather not do that at this point since it's a larger change.