### PR TITLE
[Distributed] Disable test while we investigate arm64e issue

### DIFF
--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_through_generic.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_through_generic.swift
@@ -7,6 +7,9 @@
 // REQUIRES: concurrency
 // REQUIRES: distributed
 
+// FIXME: rdar://96520492 Test fails on specific config: Tools Opt+Assert, Stdlib Opt+DebInfo+Assert, iOS_arm64e
+// UNSUPPORTED: CPU=arm64e
+
 // rdar://76038845
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_through_generic_and_inner.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_through_generic_and_inner.swift
@@ -11,6 +11,9 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
+// FIXME: rdar://96520224 Test fails on specific config: Tools Opt+Assert, Stdlib Opt+DebInfo+Assert, iOS_arm64e
+// UNSUPPORTED: CPU=arm64e
+
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
 // UNSUPPORTED: OS=windows-msvc
 


### PR DESCRIPTION
Disables test added in https://github.com/apple/swift/pull/59874 on arm64e only.

No idea how come these tests fail on this specific platform (iOS + arm64e, only on device, not on simulator it seems).
Will need some help here to investigate I think... disabling until then.

There was also some follow-ups from https://github.com/apple/swift/pull/59874 review anyway, so we can do those together.