### PR TITLE
[Distributed] Improved diagnosis (and no crash) on non-existend AS decl

### DIFF
--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -865,6 +865,13 @@ FuncDecl *GetDistributedThunkRequest::evaluate(Evaluator &evaluator,
     return nullptr;
   }
 
+  auto systemTy = getConcreteReplacementForProtocolActorSystemType(distributedTarget);
+  if (!systemTy || !systemTy->getAnyNominal()) {
+    // If the declared actor system type is illegal (e.g. non-existing type),
+    // bail out before trying to synthesize the thunk.
+    return nullptr;
+  }
+
   if (auto func = dyn_cast<FuncDecl>(distributedTarget)) {
     // not via `ensureDistributedModuleLoaded` to avoid generating a warning,
     // we won't be emitting the offending decl after all.
@@ -970,6 +977,16 @@ NormalProtocolConformance *GetDistributedActorImplicitCodableRequest::evaluate(
   auto classDecl = dyn_cast<ClassDecl>(nominal);
   if (!classDecl) {
     // we only synthesize the conformance for concrete actors
+    return nullptr;
+  }
+
+  auto systemTy = getDistributedActorSystemType(nominal);
+  if (!systemTy || !systemTy->getAnyNominal()) {
+    return nullptr;
+  }
+
+  auto idTy = getDistributedActorIDType(nominal);
+  if (!idTy || !idTy->getAnyNominal()) {
     return nullptr;
   }
 

--- a/test/Distributed/distributed_actor_system_nonexisting_decl.swift
+++ b/test/Distributed/distributed_actor_system_nonexisting_decl.swift
@@ -1,0 +1,26 @@
+// RUN: %target-typecheck-verify-swift -warn-concurrency -disable-availability-checking
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+import Distributed
+
+
+// This system does not exist: but we should not crash, but just diagnose about it:
+typealias DefaultDistributedActorSystem = ClusterSystem // expected-error{{cannot find type 'ClusterSystem' in scope}}
+
+distributed actor MyActor {
+  // expected-error@-1{{distributed actor 'MyActor' does not declare ActorSystem it can be used with.}}
+  // expected-note@-2{{you can provide a module-wide default actor system by declaring:}}
+
+  distributed var foo: String {
+    return "xyz"
+  }
+}
+
+distributed actor BadSystemActor {
+  // expected-error@-1{{distributed actor 'BadSystemActor' does not declare ActorSystem it can be used with.}}
+  // expected-note@-2{{you can provide a module-wide default actor system by declaring:}}
+
+  // This system does not exist: but we should not crash, but just diagnose about it:
+  typealias ActorSystem = ClusterSystem // expected-error{{cannot find type 'ClusterSystem' in scope}}
+}


### PR DESCRIPTION
Resolves https://github.com/apple/swift/issues/58663
Resolves  rdar://92757561

Previously we would get an ugly crash trying to synthesize a thunk while the system type was illegal.
Now we just nicely diagnose the problem.