### PR TITLE
Look to enclosing declarations for @available attributes on @_nonSendable types

### DIFF
--- a/test/ModuleInterface/sendable_availability.swift
+++ b/test/ModuleInterface/sendable_availability.swift
@@ -12,6 +12,16 @@ public struct X { }
 @_nonSendable
 public struct Y { }
 
+@available(macOS 11.0, *)
+extension X {
+  @available(macOS 12.0, *)
+  @_nonSendable
+  public struct A { }
+
+  @_nonSendable
+  public struct B { }
+}
+
 // RUN: %FileCheck %s <%t/Library.swiftinterface
 // CHECK: @available(macOS 11.0, *)
 // CHECK-NEXT: public struct X
@@ -22,6 +32,14 @@ public struct Y { }
 
 // CHECK: @available(*, unavailable)
 // CHECK-NEXT: extension Library.Y{{( )?}}: @unchecked Swift.Sendable {
+
+// CHECK: @available(macOS, unavailable, introduced: 12.0)
+// CHECK-NEXT: @available(*, unavailable)
+// CHECK-NEXT: extension Library.X.A{{( )?}}: @unchecked Swift.Sendable {
+
+// CHECK: @available(macOS, unavailable, introduced: 11.0)
+// CHECK-NEXT: @available(*, unavailable)
+// CHECK-NEXT: extension Library.X.B{{( )?}}: @unchecked Swift.Sendable {
 
 // RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -target %target-cpu-apple-macosx12.0 -DLIBRARY -module-name Library -module-interface-preserve-types-as-written
 // RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -module-name Library


### PR DESCRIPTION
`@_nonSendable` types get a synthesized, unavailable extension that
declares the Sendable conformance. This extension also needs to have
appropriate platform availability for the type that is being marked
non-Sendable, so the platform-specific attributes are copied from the
nominal type declaration. However, for nested types, we might need to
copy those attributes from an enclosing declarations. Do so when
appropriate.

Fixes rdar://90330588.