### PR TITLE
[CodeCompletion] Eliminate LeaveClosureBodiesUnchecked for solver-based code completion

### DIFF
--- a/include/swift/IDE/PostfixCompletion.h
+++ b/include/swift/IDE/PostfixCompletion.h
@@ -35,6 +35,11 @@ class PostfixCompletionCallback : public TypeCheckCompletionCallback {
     /// Whether the surrounding context is async and thus calling async
     /// functions is supported.
     bool IsInAsyncContext;
+
+    /// Actor isolations that were determined during constraint solving but that
+    /// haven't been saved to the AST.
+    llvm::DenseMap<AbstractClosureExpr *, ClosureActorIsolation>
+        ClosureActorIsolations;
   };
 
   CodeCompletionExpr *CompletionExpr;

--- a/lib/IDE/ArgumentCompletion.cpp
+++ b/lib/IDE/ArgumentCompletion.cpp
@@ -88,6 +88,15 @@ void ArgumentTypeCheckCompletionCallback::sawSolutionImpl(const Solution &S) {
   while (ParentCall && ParentCall->getArgs() == nullptr) {
     ParentCall = CS.getParentExpr(ParentCall);
   }
+  if (auto TV = S.getType(CompletionExpr)->getAs<TypeVariableType>()) {
+    auto Locator = TV->getImpl().getLocator();
+    if (Locator->isLastElement<LocatorPathElt::PatternMatch>()) {
+      // The code completion token is inside a pattern, which got rewritten from
+      // a call by ResolvePattern. Thus, we aren't actually inside a call.
+      // Rest 'ParentCall' to nullptr to reflect that.
+      ParentCall = nullptr;
+    }
+  }
 
   if (!ParentCall || ParentCall == CompletionExpr) {
     // We might not have a call that contains the code completion expression if

--- a/lib/IDE/PostfixCompletion.cpp
+++ b/lib/IDE/PostfixCompletion.cpp
@@ -58,6 +58,9 @@ getClosureActorIsolation(const Solution &S, AbstractClosureExpr *ACE) {
         return Ty;
       }
     }
+    if (!S.hasType(E)) {
+      return Type();
+    }
     return getTypeForCompletion(S, E);
   };
   auto getClosureActorIsolationThunk = [&S](AbstractClosureExpr *ACE) {

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1175,6 +1175,7 @@ Parser::parseExprPostfixSuffix(ParserResult<Expr> Result, bool isExprBasic,
       //   [.foo(), <HERE> .bar()]
       // '.bar()' is probably not a part of the inserting element. Moreover,
       // having suffixes doesn't help type inference in any way.
+
       return Result;
     }
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2393,6 +2393,12 @@ namespace {
       // function, to set the type of the pattern.
       auto setType = [&](Type type) {
         CS.setType(pattern, type);
+        if (auto PE = dyn_cast<ExprPattern>(pattern)) {
+          // Set the type of the pattern's sub-expression as well, so code
+          // completion can retrieve the expression's type in case it is a code
+          // completion token.
+          CS.setType(PE->getSubExpr(), type);
+        }
         return type;
       };
 

--- a/lib/Sema/TypeCheckCodeCompletion.cpp
+++ b/lib/Sema/TypeCheckCodeCompletion.cpp
@@ -307,7 +307,9 @@ getTypeOfExpressionWithoutApplying(Expr *&expr, DeclContext *dc,
 
   ConstraintSystemOptions options;
   options |= ConstraintSystemFlags::SuppressDiagnostics;
-  options |= ConstraintSystemFlags::LeaveClosureBodyUnchecked;
+  if (!Context.CompletionCallback) {
+    options |= ConstraintSystemFlags::LeaveClosureBodyUnchecked;
+  }
 
   // Construct a constraint system from this expression.
   ConstraintSystem cs(dc, options);
@@ -400,7 +402,6 @@ getTypeOfCompletionOperatorImpl(DeclContext *DC, Expr *expr,
 
   ConstraintSystemOptions options;
   options |= ConstraintSystemFlags::SuppressDiagnostics;
-  options |= ConstraintSystemFlags::LeaveClosureBodyUnchecked;
 
   // Construct a constraint system from this expression.
   ConstraintSystem CS(DC, options);
@@ -612,8 +613,9 @@ bool TypeChecker::typeCheckForCodeCompletion(
     options |= ConstraintSystemFlags::AllowFixes;
     options |= ConstraintSystemFlags::SuppressDiagnostics;
     options |= ConstraintSystemFlags::ForCodeCompletion;
-    options |= ConstraintSystemFlags::LeaveClosureBodyUnchecked;
-
+    if (!Context.CompletionCallback) {
+      options |= ConstraintSystemFlags::LeaveClosureBodyUnchecked;
+    }
 
     ConstraintSystem cs(DC, options);
 

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -2421,8 +2421,9 @@ bool TypeCheckASTNodeAtLocRequest::evaluate(
     }
   }
 
-  TypeChecker::typeCheckASTNode(finder.getRef(), DC,
-                                /*LeaveBodyUnchecked=*/true);
+  bool LeaveBodyUnchecked = !ctx.CompletionCallback;
+
+  TypeChecker::typeCheckASTNode(finder.getRef(), DC, LeaveBodyUnchecked);
   return false;
 }
 

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -2393,6 +2393,8 @@ bool TypeCheckASTNodeAtLocRequest::evaluate(
     }
   }
 
+  bool LeaveBodyUnchecked = !ctx.CompletionCallback;
+
   // The enclosing closure might be a single expression closure or a function
   // builder closure. In such cases, the body elements are type checked with
   // the closure itself. So we need to try type checking the enclosing closure
@@ -2416,12 +2418,15 @@ bool TypeCheckASTNodeAtLocRequest::evaluate(
       auto ActorIsolation = determineClosureActorIsolation(
           CE, __Expr_getType, __AbstractClosureExpr_getActorIsolation);
       CE->setActorIsolation(ActorIsolation);
+      if (!LeaveBodyUnchecked) {
+        // Type checking the parent closure also type checked this node.
+        // Nothing to do anymore.
+        return false;
+      }
       if (CE->getBodyState() != ClosureExpr::BodyState::ReadyForTypeChecking)
         return false;
     }
   }
-
-  bool LeaveBodyUnchecked = !ctx.CompletionCallback;
 
   TypeChecker::typeCheckASTNode(finder.getRef(), DC, LeaveBodyUnchecked);
   return false;

--- a/test/IDE/complete_in_closures.swift
+++ b/test/IDE/complete_in_closures.swift
@@ -416,3 +416,83 @@ func testClosureInPatternBindingInit() {
   // CLOSURE_IN_PATTERN_BINDING: End completion
 
 }
+
+func testSwitchInClosure() {
+  func executeClosure(closure: () -> Void) {}
+
+  struct Boredom {
+    static func doNothing() {}
+  }
+
+  enum MyEnum {
+    case first
+    case second
+  }
+
+  let item: MyEnum? = nil
+  executeClosure(closure: {
+    switch item {
+    case .#^SWITCH_IN_CLOSURE^#first:
+      break
+    case .second:
+      Boredom.doNothing()
+    }
+  })
+
+// SWITCH_IN_CLOSURE: Begin completions
+// SWITCH_IN_CLOSURE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: first[#MyEnum#];
+// SWITCH_IN_CLOSURE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: second[#MyEnum#];
+// SWITCH_IN_CLOSURE: End completions
+}
+
+func testSwitchWithAssociatedValueInClosure() {
+  func executeClosure(closure: () -> Void) {}
+
+  struct Boredom {
+    static func doNothing() {}
+  }
+
+  enum MyEnum {
+    case first(String)
+  }
+
+  let item: MyEnum? = nil
+  executeClosure(closure: {
+    switch item {
+    case .#^SWITCH_WITH_ASSOC_IN_CLOSURE^#first(_):
+      break
+    }
+  })
+
+// SWITCH_WITH_ASSOC_IN_CLOSURE: Begin completions
+// SWITCH_WITH_ASSOC_IN_CLOSURE-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: first({#String#})[#MyEnum#];
+// SWITCH_WITH_ASSOC_IN_CLOSURE: End completions
+}
+
+func testCompleteInMatchOfAssociatedValueInSwitchCase() {
+  func testSwitchWithAssociatedValueInClosure() {
+  func executeClosure(closure: () -> Void) {}
+
+  struct Boredom {
+    static func doNothing() {}
+  }
+
+  enum MyEnum {
+    case first(Bool, String)
+  }
+
+  let item: MyEnum? = nil
+  let str = "hi"
+  executeClosure(closure: {
+    switch item {
+    case .first(true, #^IN_ASSOC_OF_CASE_IN_CLOSURE^#str):
+      break
+    }
+  })
+
+// IN_ASSOC_OF_CASE_IN_CLOSURE: Begin completions
+// IN_ASSOC_OF_CASE_IN_CLOSURE-DAG: Decl[LocalVar]/Local:               str[#String#]; name=str
+// IN_ASSOC_OF_CASE_IN_CLOSURE: End completions
+}
+
+}

--- a/test/IDE/complete_in_closures.swift
+++ b/test/IDE/complete_in_closures.swift
@@ -104,7 +104,7 @@ struct NestedStructWithClosureMember1 {
 struct StructWithClosureMemberAndLocal {
   var c = {
     var x = 0
-    #^DELAYED_10?check=WITH_GLOBAL_DECLS_AND_LOCAL1;xfail=https://github.com/apple/swift/issues/58273^#
+    #^DELAYED_10?check=WITH_GLOBAL_DECLS_AND_LOCAL1^#
   }
 }
 

--- a/test/IDE/complete_in_result_builder.swift
+++ b/test/IDE/complete_in_result_builder.swift
@@ -329,3 +329,39 @@ func testInStringLiteralInResultBuilder() {
 // IN_STRING_LITERAL_IN_RESULT_BUILDER-DAG: Decl[InstanceVar]/CurrNominal:      bar[#Int#]; name=bar
 // IN_STRING_LITERAL_IN_RESULT_BUILDER: End completions
 }
+
+func testSwitchInResultBuilder() {
+  @resultBuilder
+  enum ReducerBuilder2<Action> {
+    static func buildBlock(_ r: Reduce2<Action>) -> Reduce2<Action> { r }
+    static func buildBlock(_ r0: Reduce2<Action>, _ r1: Reduce2<Action>) -> Reduce2<Action> { r0 }
+    static func buildExpression(_ r: Reduce2<Action>) -> Reduce2<Action> { r }
+  }
+
+  enum Action {
+    case alertDismissed
+  }
+
+  struct Reduce2<Action> {
+    init() {}
+
+    init(_ reduce: (Action) -> Int) {}
+  }
+
+  struct Login2 {
+    @ReducerBuilder2<Action>
+    var body: Reduce2<Action> {
+      Reduce2()
+      Reduce2 { action in
+        switch action {
+        case .#^SWITCH_IN_RESULT_BUILDER^# alertDismissed:
+          return 0
+        }
+      }
+    }
+  }
+// SWITCH_IN_RESULT_BUILDER: Begin completions, 2 items
+// SWITCH_IN_RESULT_BUILDER-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: alertDismissed[#Action#];
+// SWITCH_IN_RESULT_BUILDER-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): Action#})[#(into: inout Hasher) -> Void#];
+// SWITCH_IN_RESULT_BUILDER: End completions
+}

--- a/test/IDE/complete_in_result_builder.swift
+++ b/test/IDE/complete_in_result_builder.swift
@@ -302,3 +302,30 @@ func testCompleteGlobalInResultBuilderIf() {
   // GLOBAL_IN_RESULT_BUILDER_IF-DAG: Decl[Struct]/Local/TypeRelation[Convertible]: MyView[#MyView#]; name=MyView
   // GLOBAL_IN_RESULT_BUILDER_IF: End completions
 }
+
+func testInStringLiteralInResultBuilder() {
+  func buildResult<Content>(@MyResultBuilder content: () -> Content) {}
+
+  @resultBuilder
+  struct MyResultBuilder {
+    static func buildBlock(_ components: String) -> String {
+      components
+    }
+  }
+
+  struct Foo {
+    var bar: Int
+  }
+
+  func withClosure(_ x: () -> Bool) -> String { return "" }
+
+  func test(foo: Foo) {
+    buildResult {
+      "\(withClosure { foo.#^IN_STRING_LITERAL_IN_RESULT_BUILDER^# })"
+    }
+  }
+// IN_STRING_LITERAL_IN_RESULT_BUILDER: Begin completions, 2 items
+// IN_STRING_LITERAL_IN_RESULT_BUILDER-DAG: Keyword[self]/CurrNominal:          self[#Foo#]; name=self
+// IN_STRING_LITERAL_IN_RESULT_BUILDER-DAG: Decl[InstanceVar]/CurrNominal:      bar[#Int#]; name=bar
+// IN_STRING_LITERAL_IN_RESULT_BUILDER: End completions
+}

--- a/test/IDE/complete_in_result_builder.swift
+++ b/test/IDE/complete_in_result_builder.swift
@@ -274,3 +274,31 @@ func testAmbiguousInResultBuilder() {
 // AMBIGUOUS_IN_RESULT_BUILDER: End completions
   }
 }
+
+func testCompleteGlobalInResultBuilderIf() {
+  func buildView(@ViewBuilder2 content: () -> MyView) {}
+
+  @resultBuilder public struct ViewBuilder2 {
+    static func buildBlock() -> MyView { fatalError() }
+    static func buildBlock(_ content: MyView) -> MyView { fatalError() }
+    static func buildIf(_ content: MyView?) -> MyView? { fatalError() }
+    static func buildEither(first: MyView) -> MyView { fatalError() }
+    static func buildEither(second: MyView) -> MyView { fatalError() }
+  }
+
+  struct MyView {}
+
+  func test() {
+    buildView {
+      if true {
+        MyView()
+      } else {
+        #^GLOBAL_IN_RESULT_BUILDER_IF^#
+      }
+    }
+  }
+
+  // GLOBAL_IN_RESULT_BUILDER_IF: Begin completions
+  // GLOBAL_IN_RESULT_BUILDER_IF-DAG: Decl[Struct]/Local/TypeRelation[Convertible]: MyView[#MyView#]; name=MyView
+  // GLOBAL_IN_RESULT_BUILDER_IF: End completions
+}

--- a/test/IDE/complete_skipbody.swift
+++ b/test/IDE/complete_skipbody.swift
@@ -45,8 +45,6 @@ func test(valueOptOpt: MyStruct??) {
     case let x where x < 2:
       let unrelated3 = FORBIDDEN_Struct()
       _ = { xx in
-        let unrelated4 = FORBIDDEN_Struct()
-
         if xx == localFunc(value.#^FUNCTIONBODY^#) {
           let unrelated5 = FORBIDDEN_Struct()
           return 1

--- a/test/IDE/complete_unresolved_members.swift
+++ b/test/IDE/complete_unresolved_members.swift
@@ -732,3 +732,14 @@ func testSameType() {
 // SUGAR_TYPE: End completions
 }
 
+struct DispatchTime {
+  static func now() -> DispatchTime { .init() }
+}
+func +(_ x: DispatchTime, _ y: Double) -> DispatchTime { return x }
+
+let _: DispatchTime = .#^UNRESOLVED_FUNCTION_CALL^#now() + 0.2
+
+// UNRESOLVED_FUNCTION_CALL: Begin completions, 2 items
+// UNRESOLVED_FUNCTION_CALL-DAG: Decl[StaticMethod]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: now()[#DispatchTime#];
+// UNRESOLVED_FUNCTION_CALL-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]: init()[#DispatchTime#];
+// UNRESOLVED_FUNCTION_CALL: End completions

--- a/test/IDE/complete_with_trailing_closure.swift
+++ b/test/IDE/complete_with_trailing_closure.swift
@@ -16,10 +16,20 @@ func sink(receiveValue: (MyArray) -> Void) {
 func foo() {
   sink { items in
     let a = items.#^COMPLETE_WITHOUT_SPACE?check=CHECK^#map{ $0.content }
+  }
+  sink { items in
     let b = items.#^COMPLETE_WITH_SPACE?check=CHECK^# map{ $0.content }
+  }
+  sink { items in
     let c = items.#^COMPLETE_WITH_SPACE_AND_PARENS?check=CHECK^# map({ $0.content })
+  }
+  sink { items in
     let d = items.#^COMPLETE_WITHOUT_SPACE_BUT_PARENS?check=CHECK^#map({ $0.content })
+  }
+  sink { items in
     let e = items.#^COMPLETE_WITHOUT_MAP?check=CHECK^# { $0.content }
+  }
+  sink { items in
     let f = items.#^COMPLETE_WITHOUT_MAP_BUT_PARENS?check=CHECK^# ({ $0.content })
   }
 }


### PR DESCRIPTION
With this change, we are no longer passing `LeaveClosureBodiesUnchecked` for solver-based code completion. The only remaining user of `LeaveClosureBodiesUnchecked` are the legacy AST-based completions which I’m working to migrate to solver-based in the following PRs:
- https://github.com/apple/swift/pull/42156
- https://github.com/apple/swift/pull/42280

After that, we can remove `LeaveClosureBodiesUnchecked`.