### PR TITLE
stdlib: remove the inout-violation check from Array bounds checking

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -386,8 +386,13 @@ extension Array {
     _ index: Int, wasNativeTypeChecked: Bool
   ) -> _DependenceToken {
 #if _runtime(_ObjC)
-    _buffer._checkInoutAndNativeTypeCheckedBounds(
-      index, wasNativeTypeChecked: wasNativeTypeChecked)
+    // There is no need to do bounds checking for the non-native case because
+    // ObjectiveC arrays do bounds checking by their own.
+    // And in the native-non-type-checked case, it's also not needed to do bounds
+    // checking here, because it's done in ArrayBuffer._getElementSlowPath.
+    if _fastPath(wasNativeTypeChecked) {
+      _buffer._native._checkValidSubscript(index)
+    }
 #else
     _buffer._checkValidSubscript(index)
 #endif

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -422,6 +422,9 @@ extension _ArrayBuffer {
   /// wasNative == _isNative in the absence of inout violations.
   /// Because the optimizer can hoist the original check it might have
   /// been invalidated by illegal user code.
+  ///
+  /// This function is obsolete but must stay in the library for backward
+  /// compatibility.
   @inlinable
   internal func _checkInoutAndNativeBounds(_ index: Int, wasNative: Bool) {
     _precondition(
@@ -439,6 +442,9 @@ extension _ArrayBuffer {
   /// wasNativeTypeChecked == _isNativeTypeChecked in the absence of
   /// inout violations.  Because the optimizer can hoist the original
   /// check it might have been invalidated by illegal user code.
+  ///
+  /// This function is obsolete but must stay in the library for backward
+  /// compatibility.
   @inlinable
   internal func _checkInoutAndNativeTypeCheckedBounds(
     _ index: Int, wasNativeTypeChecked: Bool


### PR DESCRIPTION
As we have exclusivity checking since a long time, this "explicit" check for inout violations is not needed anymore.
The `_checkInoutAndNativeTypeCheckedBounds` function must remain in the library for backward compatibility.
The remaining relevant subscript index checking from that function is now simply inlined in into the caller.
