### PR TITLE
SR-12802: Disambiguate functions with lvalue and rvalue reference parameters in the same overload set

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2301,8 +2301,11 @@ ClangImporter::Implementation::importParameterType(
     }
 
     paramTy = refType->getPointeeType();
-    if (!paramTy.isConstQualified())
+    if ((isa<clang::LValueReferenceType>(paramTy) &&
+        !paramTy.isConstQualified()) &&
+        !isa<clang::RValueReferenceType>(paramTy)) {
       isInOut = true;
+    }
   }
 
   // Special case for NSDictionary's subscript.

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1328,9 +1328,12 @@ static bool isClangTypeMoreIndirectThanSubstType(TypeConverter &TC,
   // Pass C++ const reference types indirectly. Right now there's no way to
   // express immutable borrowed params, so we have to have this hack.
   // Eventually, we should just express these correctly: rdar://89647503
-  if (clangTy->isReferenceType() &&
-      clangTy->getPointeeType().isConstQualified())
-    return true;
+  if (clangTy->isReferenceType()) {
+    if (clangTy->getPointeeType().isConstQualified() ||
+        clangTy->isRValueReferenceType()) {
+      return true;
+    }
+  }
 
   return false;
 }

--- a/test/Interop/Cxx/class/method/ambiguous-methods-module-interface.swift
+++ b/test/Interop/Cxx/class/method/ambiguous-methods-module-interface.swift
@@ -3,11 +3,11 @@
 // CHECK: func increment(_ a: Int32) -> Int32
 // CHECK: mutating func incrementMutating(_ a: Int32) -> Int32
 
-// CHECK: mutating func incrementMutating(_ a: Int32, _ b: Int32, _ c: inout Int32)
-// CHECK: func increment(_ a: Int32, _ b: Int32, _ c: inout Int32)
+// CHECK: mutating func incrementMutating(_ a: Int32, _ b: Int32, _ c: Int32)
+// CHECK: func increment(_ a: Int32, _ b: Int32, _ c: Int32)
 
-// CHECK: mutating func incrementMutating(_ a: inout Int32, _ b: Int32)
-// CHECK: func increment(_ a: inout Int32, _ b: Int32)
+// CHECK: mutating func incrementMutating(_ a: Int32, _ b: Int32)
+// CHECK: func increment(_ a: Int32, _ b: Int32)
 
 // CHECK: func numberOfMutableMethodsCalled() -> Int32
 // CHECK: mutating func numberOfMutableMethodsCalledMutating() -> Int32

--- a/test/Interop/Cxx/class/method/ambiguous-methods.swift
+++ b/test/Interop/Cxx/class/method/ambiguous-methods.swift
@@ -59,11 +59,11 @@ CxxAmbiguousMethodTestSuite.test("Out Param Increment: (Int, Int, inout Int) -> 
   expectEqual(0, instance.numberOfMutableMethodsCalled())
 
   // Non mutable version should NOT change count
-  instance.increment(0, 1, &out);
+  instance.increment(0, 1, out);
   expectEqual(1, out)
   expectEqual(0, instance.numberOfMutableMethodsCalled())
 
-  instance.incrementMutating(5, 2, &out);
+  instance.incrementMutating(5, 2, out);
   expectEqual(7, out)
   expectEqual(1, instance.numberOfMutableMethodsCalled())
 }
@@ -76,11 +76,11 @@ CxxAmbiguousMethodTestSuite.test("Inout Param Increment: (inout Int, Int) -> Voi
   expectEqual(0, instance.numberOfMutableMethodsCalled())
 
   // Non mutable version should NOT change count
-  instance.increment(&inoutVal, 1);
+  instance.increment(inoutVal, 1);
   expectEqual(1, inoutVal)
   expectEqual(0, instance.numberOfMutableMethodsCalled())
 
-  instance.incrementMutating(&inoutVal, 2);
+  instance.incrementMutating(inoutVal, 2);
   expectEqual(3, inoutVal)
   expectEqual(1, instance.numberOfMutableMethodsCalled())
 }

--- a/test/Interop/Cxx/reference/reference-irgen.swift
+++ b/test/Interop/Cxx/reference/reference-irgen.swift
@@ -32,7 +32,7 @@ public func getConstCxxRvalueRef() -> UnsafePointer<CInt> {
 
 public func setCxxRef() {
   var val: CInt = 21
-  setStaticIntRef(&val)
+  setStaticIntRef(val)
 }
 
 // CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main9setCxxRefyyF"()
@@ -48,7 +48,7 @@ public func setCxxConstRef() {
 
 public func setCxxRvalueRef() {
   var val: CInt = 21
-  setStaticIntRvalueRef(&val)
+  setStaticIntRvalueRef(val)
 }
 
 // CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main15setCxxRvalueRefyyF"()

--- a/test/Interop/Cxx/reference/reference-module-interface.swift
+++ b/test/Interop/Cxx/reference/reference-module-interface.swift
@@ -6,8 +6,8 @@
 // CHECK: func getConstStaticIntRef() -> UnsafePointer<Int32>
 // CHECK: func getConstStaticIntRvalueRef() -> UnsafePointer<Int32>
 // CHECK: func setStaticInt(_: Int32)
-// CHECK: func setStaticIntRef(_: inout Int32)
-// CHECK: func setStaticIntRvalueRef(_: inout Int32)
+// CHECK: func setStaticIntRef(_: Int32)
+// CHECK: func setStaticIntRvalueRef(_: Int32)
 // CHECK: func setConstStaticIntRef(_: Int32)
 // CHECK: func setConstStaticIntRvalueRef(_: Int32)
 // CHECK: func getFuncRef() -> @convention(c) () -> Int32

--- a/test/Interop/Cxx/reference/reference-silgen.swift
+++ b/test/Interop/Cxx/reference/reference-silgen.swift
@@ -36,12 +36,12 @@ func getConstCxxRvalueRef() -> UnsafePointer<CInt> {
 
 func setCxxRef() {
   var val: CInt = 21
-  setStaticIntRef(&val)
+  setStaticIntRef(val)
 }
 
 // CHECK: sil hidden @$s4main9setCxxRefyyF : $@convention(thin) () -> ()
-// CHECK: [[REF:%.*]] = function_ref @{{_Z15setStaticIntRefRi|\?setStaticIntRef@@YAXAEAH@Z}} : $@convention(c) (@inout Int32) -> ()
-// CHECK: apply [[REF]](%{{[0-9]+}}) : $@convention(c) (@inout Int32) -> ()
+// CHECK: [[REF:%.*]] = function_ref @{{_Z15setStaticIntRefRi|\?setStaticIntRef@@YAXAEAH@Z}} : $@convention(c) (Int32) -> ()
+// CHECK: apply [[REF]](%{{[0-9]+}}) : $@convention(c) (Int32) -> ()
 
 func setCxxConstRef() {
   let val: CInt = 21
@@ -54,12 +54,12 @@ func setCxxConstRef() {
 
 func setCxxRvalueRef() {
   var val: CInt = 21
-  setStaticIntRvalueRef(&val)
+  setStaticIntRvalueRef(val)
 }
 
 // CHECK: sil hidden @$s4main15setCxxRvalueRefyyF : $@convention(thin) () -> ()
-// CHECK: [[REF:%.*]] = function_ref @{{_Z21setStaticIntRvalueRefOi|\?setStaticIntRvalueRef@@YAX\$\$QEAH@Z}} : $@convention(c) (@inout Int32) -> ()
-// CHECK: apply [[REF]](%{{[0-9]+}}) : $@convention(c) (@inout Int32) -> ()
+// CHECK: [[REF:%.*]] = function_ref @{{_Z21setStaticIntRvalueRefOi|\?setStaticIntRvalueRef@@YAX\$\$QEAH@Z}} : $@convention(c) (@in Int32) -> ()
+// CHECK: apply [[REF]](%{{[0-9]+}}) : $@convention(c) (@in Int32) -> ()
 
 func setCxxConstRvalueRef() {
   let val: CInt = 21

--- a/test/Interop/Cxx/reference/reference.swift
+++ b/test/Interop/Cxx/reference/reference.swift
@@ -40,7 +40,7 @@ ReferenceTestSuite.test("write-rvalue-reference") {
 ReferenceTestSuite.test("pass-lvalue-reference") {
   expectNotEqual(21, getStaticInt())
   var val: CInt = 21
-  setStaticIntRef(&val)
+  setStaticIntRef(val)
   expectEqual(21, getStaticInt())
 }
 
@@ -54,7 +54,7 @@ ReferenceTestSuite.test("pass-const-lvalue-reference") {
 ReferenceTestSuite.test("pass-rvalue-reference") {
   expectNotEqual(52, getStaticInt())
   var val: CInt = 52
-  setStaticIntRvalueRef(&val)
+  setStaticIntRvalueRef(val)
   expectEqual(52, getStaticInt())
 }
 

--- a/test/Interop/Cxx/stdlib/use-std-vector.swift
+++ b/test/Interop/Cxx/stdlib/use-std-vector.swift
@@ -24,18 +24,16 @@ StdVectorTestSuite.test("init") {
 
 StdVectorTestSuite.test("push back") {
     var v = Vector()
-    var _42: CInt = 42
-    v.push_back(&_42)
+    v.push_back(42)
     expectEqual(v.size(), 1)
     expectFalse(v.empty())
     expectEqual(v[0], 42)
 }
 
 func fill(vector v: inout Vector) {
-    var _1: CInt = 1, _2: CInt = 2, _3: CInt = 3
-    v.push_back(&_1)
-    v.push_back(&_2)
-    v.push_back(&_3)
+    v.push_back(1)
+    v.push_back(2)
+    v.push_back(3)
 }
 
 // TODO: in some configurations the stdlib emits a "initializeWithCopy" where the arguments

--- a/test/Interop/Cxx/templates/dependent-types.swift
+++ b/test/Interop/Cxx/templates/dependent-types.swift
@@ -89,7 +89,6 @@ DependentTypesTestSuite.test("Complex different dependent return type inferrd.")
   expectEqual(m.getValue(), 42)
 }
 
-// TODO: Currently still failing: Could not cast value of type '__C.__CxxTemplateInst1MIlE' to 'Swift.Int'
 DependentTypesTestSuite.test("Complex different dependent argument and return type") {
   let m = complexDifferentDependentArgAndRet(42, T: Int.self, U: Int.self) as! Int
   expectEqual(m, 42)


### PR DESCRIPTION
This patch is to start the work on fixing the way we import C++ method overload imports that use rvalue references, by passing by value, however this may not be the best approach. I have updated the tests that use the `push_back` but this is causing a crash. 

Related to https://github.com/apple/swift/issues/55247

@zoecarver @hyp 