### PR TITLE
[Sema] Force considering the `__ObjC` module as imported publicly

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2442,6 +2442,9 @@ RestrictedImportKind SourceFile::getRestrictedImportKind(const ModuleDecl *modul
   auto &imports = getASTContext().getImportCache();
   RestrictedImportKind importKind = RestrictedImportKind::Implicit;
 
+  if (module->getName().str() == CLANG_HEADER_MODULE_NAME)
+    return RestrictedImportKind::None;
+
   // Look at the imports of this source file.
   for (auto &desc : *Imports) {
     // Ignore implementation-only imports.


### PR DESCRIPTION
The C++ interop relies on an implicitly imported `__ObjC` module as origin for namespaces and instantiated templates. However it doesn't always actually add `__ObjC` to the list of imports from the module. Let's special case this module in this type-checking phase until we have a proper fix to unblock testing.