### PR TITLE
[Constraint solver] Improve fix behaviors for better concurrency-related recovery and overloading

### DIFF
--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -25,6 +25,7 @@
 #include "swift/AST/Types.h"
 #include "swift/Basic/Debug.h"
 #include "swift/Sema/ConstraintLocator.h"
+#include "swift/Sema/FixBehavior.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/TrailingObjects.h"
@@ -410,13 +411,12 @@ class ConstraintFix {
   ConstraintLocator *Locator;
 
   /// The behavior limit to apply to the diagnostics emitted.
-  DiagnosticBehavior behaviorLimit;
+  FixBehavior fixBehavior;
 
 public:
   ConstraintFix(ConstraintSystem &cs, FixKind kind, ConstraintLocator *locator,
-                DiagnosticBehavior behaviorLimit =
-                    DiagnosticBehavior::Unspecified)
-      : CS(cs), Kind(kind), Locator(locator), behaviorLimit(behaviorLimit) {}
+                FixBehavior fixBehavior = FixBehavior::Error)
+      : CS(cs), Kind(kind), Locator(locator), fixBehavior(fixBehavior) {}
 
   virtual ~ConstraintFix();
 
@@ -427,14 +427,36 @@ public:
 
   FixKind getKind() const { return Kind; }
 
-  bool isWarning() const {
-    return behaviorLimit == DiagnosticBehavior::Warning ||
-           behaviorLimit == DiagnosticBehavior::Ignore;
+  /// Whether it is still possible to "apply" a solution containing this kind
+  /// of fix to get a usable AST.
+  bool canApplySolution() const {
+    switch (fixBehavior) {
+    case FixBehavior::AlwaysWarning:
+    case FixBehavior::DowngradeToWarning:
+    case FixBehavior::Suppress:
+      return true;
+
+    case FixBehavior::Error:
+      return false;
+    }
+  }
+
+  /// Whether this kind of fix affects the solution score.
+  bool affectsSolutionScore() const {
+    switch (fixBehavior) {
+    case FixBehavior::AlwaysWarning:
+    case FixBehavior::DowngradeToWarning:
+    case FixBehavior::Suppress:
+      return false;
+
+    case FixBehavior::Error:
+      return true;
+    }
   }
 
   /// The diagnostic behavior limit that will be applied to any emitted
   /// diagnostics.
-  DiagnosticBehavior diagBehaviorLimit() const { return behaviorLimit; }
+  FixBehavior diagfixBehavior() const { return fixBehavior; }
 
   virtual std::string getName() const = 0;
 
@@ -680,16 +702,15 @@ class ContextualMismatch : public ConstraintFix {
 
   ContextualMismatch(ConstraintSystem &cs, Type lhs, Type rhs,
                      ConstraintLocator *locator,
-                     DiagnosticBehavior behaviorLimit)
-      : ConstraintFix(cs, FixKind::ContextualMismatch, locator, behaviorLimit),
+                     FixBehavior fixBehavior)
+      : ConstraintFix(cs, FixKind::ContextualMismatch, locator, fixBehavior),
         LHS(lhs), RHS(rhs) {}
 
 protected:
   ContextualMismatch(ConstraintSystem &cs, FixKind kind, Type lhs, Type rhs,
                      ConstraintLocator *locator,
-                     DiagnosticBehavior behaviorLimit =
-                         DiagnosticBehavior::Unspecified)
-      : ConstraintFix(cs, kind, locator, behaviorLimit), LHS(lhs), RHS(rhs) {}
+                     FixBehavior fixBehavior = FixBehavior::Error)
+      : ConstraintFix(cs, kind, locator, fixBehavior), LHS(lhs), RHS(rhs) {}
 
 public:
   std::string getName() const override { return "fix contextual mismatch"; }
@@ -777,9 +798,9 @@ public:
 class MarkGlobalActorFunction final : public ContextualMismatch {
   MarkGlobalActorFunction(ConstraintSystem &cs, Type lhs, Type rhs,
                           ConstraintLocator *locator,
-                          DiagnosticBehavior behaviorLimit)
+                          FixBehavior fixBehavior)
       : ContextualMismatch(cs, FixKind::MarkGlobalActorFunction, lhs, rhs,
-                           locator, behaviorLimit) {
+                           locator, fixBehavior) {
   }
 
 public:
@@ -789,7 +810,7 @@ public:
 
   static MarkGlobalActorFunction *create(ConstraintSystem &cs, Type lhs,
                                          Type rhs, ConstraintLocator *locator,
-                                         DiagnosticBehavior behaviorLimit);
+                                         FixBehavior fixBehavior);
 
   static bool classof(ConstraintFix *fix) {
     return fix->getKind() == FixKind::MarkGlobalActorFunction;
@@ -825,9 +846,9 @@ public:
 class AddSendableAttribute final : public ContextualMismatch {
   AddSendableAttribute(ConstraintSystem &cs, FunctionType *fromType,
                        FunctionType *toType, ConstraintLocator *locator,
-                       DiagnosticBehavior behaviorLimit)
+                       FixBehavior fixBehavior)
       : ContextualMismatch(cs, FixKind::AddSendableAttribute, fromType, toType,
-                           locator, behaviorLimit) {
+                           locator, fixBehavior) {
     assert(fromType->isSendable() != toType->isSendable());
   }
 
@@ -840,7 +861,7 @@ public:
                                       FunctionType *fromType,
                                       FunctionType *toType,
                                       ConstraintLocator *locator,
-                                      DiagnosticBehavior behaviorLimit);
+                                      FixBehavior fixBehavior);
 
   static bool classof(ConstraintFix *fix) {
     return fix->getKind() == FixKind::AddSendableAttribute;
@@ -1403,11 +1424,14 @@ public:
 };
 
 class AllowInvalidPartialApplication final : public ConstraintFix {
+  bool isWarning;
+
   AllowInvalidPartialApplication(bool isWarning, ConstraintSystem &cs,
                                  ConstraintLocator *locator)
       : ConstraintFix(cs, FixKind::AllowInvalidPartialApplication, locator,
-                      isWarning ? DiagnosticBehavior::Warning
-                                : DiagnosticBehavior::Unspecified) {}
+                      isWarning ? FixBehavior::AlwaysWarning
+                                : FixBehavior::Error),
+        isWarning(isWarning) {}
 
 public:
   std::string getName() const override {
@@ -2141,10 +2165,9 @@ protected:
 
   AllowArgumentMismatch(ConstraintSystem &cs, FixKind kind, Type argType,
                         Type paramType, ConstraintLocator *locator,
-                        DiagnosticBehavior behaviorLimit =
-                            DiagnosticBehavior::Unspecified)
+                        FixBehavior fixBehavior = FixBehavior::Error)
       : ContextualMismatch(
-            cs, kind, argType, paramType, locator, behaviorLimit) {}
+            cs, kind, argType, paramType, locator, fixBehavior) {}
 
 public:
   std::string getName() const override {
@@ -2292,9 +2315,9 @@ class TreatEphemeralAsNonEphemeral final : public AllowArgumentMismatch {
   TreatEphemeralAsNonEphemeral(ConstraintSystem &cs, ConstraintLocator *locator,
                                Type srcType, Type dstType,
                                ConversionRestrictionKind conversionKind,
-                               DiagnosticBehavior behaviorLimit)
+                               FixBehavior fixBehavior)
       : AllowArgumentMismatch(cs, FixKind::TreatEphemeralAsNonEphemeral,
-                              srcType, dstType, locator, behaviorLimit),
+                              srcType, dstType, locator, fixBehavior),
         ConversionKind(conversionKind) {}
 
 public:
@@ -2458,7 +2481,7 @@ class AllowCoercionToForceCast final : public ContextualMismatch {
   AllowCoercionToForceCast(ConstraintSystem &cs, Type fromType, Type toType,
                            ConstraintLocator *locator)
       : ContextualMismatch(cs, FixKind::AllowCoercionToForceCast, fromType,
-                           toType, locator, DiagnosticBehavior::Warning) {}
+                           toType, locator, FixBehavior::AlwaysWarning) {}
 
 public:
   std::string getName() const override {
@@ -2572,7 +2595,7 @@ class SpecifyLabelToAssociateTrailingClosure final : public ConstraintFix {
   SpecifyLabelToAssociateTrailingClosure(ConstraintSystem &cs,
                                          ConstraintLocator *locator)
       : ConstraintFix(cs, FixKind::SpecifyLabelToAssociateTrailingClosure,
-                      locator, DiagnosticBehavior::Warning) {}
+                      locator, FixBehavior::AlwaysWarning) {}
 
 public:
   std::string getName() const override {
@@ -2742,7 +2765,7 @@ class SpecifyBaseTypeForOptionalUnresolvedMember final : public ConstraintFix {
                                              DeclNameRef memberName,
                                              ConstraintLocator *locator)
       : ConstraintFix(cs, FixKind::SpecifyBaseTypeForOptionalUnresolvedMember,
-                      locator, DiagnosticBehavior::Warning),
+                      locator, FixBehavior::AlwaysWarning),
         MemberName(memberName) {}
   DeclNameRef MemberName;
 
@@ -2773,7 +2796,7 @@ protected:
                                        CheckedCastKind kind,
                                        ConstraintLocator *locator)
       : ContextualMismatch(cs, fixKind, fromType, toType, locator,
-                           DiagnosticBehavior::Warning),
+                           FixBehavior::AlwaysWarning),
         CastKind(kind) {}
   CheckedCastKind CastKind;
 };
@@ -2932,7 +2955,7 @@ class AllowTupleLabelMismatch final : public ContextualMismatch {
   AllowTupleLabelMismatch(ConstraintSystem &cs, Type fromType, Type toType,
                           ConstraintLocator *locator)
       : ContextualMismatch(cs, FixKind::AllowTupleLabelMismatch, fromType,
-                           toType, locator, DiagnosticBehavior::Warning) {}
+                           toType, locator, FixBehavior::AlwaysWarning) {}
 
 public:
   std::string getName() const override { return "allow tuple label mismatch"; }

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -46,6 +46,7 @@ class ConstraintSystem;
 class ConstraintLocator;
 class ConstraintLocatorBuilder;
 enum class ConversionRestrictionKind;
+enum ScoreKind: unsigned int;
 class Solution;
 struct MemberLookupResult;
 
@@ -441,18 +442,9 @@ public:
     }
   }
 
-  /// Whether this kind of fix affects the solution score.
-  bool affectsSolutionScore() const {
-    switch (fixBehavior) {
-    case FixBehavior::AlwaysWarning:
-    case FixBehavior::DowngradeToWarning:
-    case FixBehavior::Suppress:
-      return false;
-
-    case FixBehavior::Error:
-      return true;
-    }
-  }
+  /// Whether this kind of fix affects the solution score, and which score
+  /// it affects.
+  Optional<ScoreKind> affectsSolutionScore() const;
 
   /// The diagnostic behavior limit that will be applied to any emitted
   /// diagnostics.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -819,7 +819,7 @@ public:
 
 /// Describes an aspect of a solution that affects its overall score, i.e., a
 /// user-defined conversions.
-enum ScoreKind {
+enum ScoreKind: unsigned int {
   // These values are used as indices into a Score value.
 
   /// A fix needs to be applied to the source.

--- a/include/swift/Sema/FixBehavior.h
+++ b/include/swift/Sema/FixBehavior.h
@@ -1,0 +1,41 @@
+//===--- FixBehavior.h - Constraint Fix Behavior --------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provides information about how a constraint fix should behavior.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SEMA_FIXBEHAVIOR_H
+#define SWIFT_SEMA_FIXBEHAVIOR_H
+
+namespace swift {
+namespace constraints {
+
+/// Describes the behavior of the diagnostic corresponding to a given fix.
+enum class FixBehavior {
+  /// The diagnostic is an error, and should prevent constraint application.
+  Error,
+  /// The diagnostic is always a warning, which should not prevent constraint
+  /// application.
+  AlwaysWarning,
+  /// The diagnostic should be downgraded to a warning, and not prevent
+  /// constraint application.
+  DowngradeToWarning,
+  /// The diagnostic should be suppressed, and not prevent constraint
+  /// application.
+  Suppress
+};
+
+}
+}
+
+#endif // SWIFT_SEMA_FIXBEHAVIOR_H

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -9132,16 +9132,23 @@ Optional<SolutionApplicationTarget> ConstraintSystem::applySolution(
     Solution &solution, SolutionApplicationTarget target) {
   // If any fixes needed to be applied to arrive at this solution, resolve
   // them to specific expressions.
+  unsigned numResolvableFixes = 0;
   if (!solution.Fixes.empty()) {
     if (shouldSuppressDiagnostics())
       return None;
 
     bool diagnosedErrorsViaFixes = applySolutionFixes(solution);
+    bool canApplySolution = true;
+    for (const auto fix : solution.Fixes) {
+      if (!fix->canApplySolution())
+        canApplySolution = false;
+      if (fix->affectsSolutionScore() == SK_Fix && fix->canApplySolution())
+        ++numResolvableFixes;
+    }
+
     // If all of the available fixes would result in a warning,
     // we can go ahead and apply this solution to AST.
-    if (!llvm::all_of(solution.Fixes, [](const ConstraintFix *fix) {
-          return fix->canApplySolution();
-        })) {
+    if (!canApplySolution) {
       // If we already diagnosed any errors via fixes, that's it.
       if (diagnosedErrorsViaFixes)
         return None;
@@ -9158,7 +9165,7 @@ Optional<SolutionApplicationTarget> ConstraintSystem::applySolution(
   // produce a fallback diagnostic to highlight the problem.
   {
     const auto &score = solution.getFixedScore();
-    if (score.Data[SK_Fix] > 0 || score.Data[SK_Hole] > 0) {
+    if (score.Data[SK_Fix] > numResolvableFixes || score.Data[SK_Hole] > 0) {
       maybeProduceFallbackDiagnostic(target);
       return None;
     }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8480,7 +8480,7 @@ bool ConstraintSystem::applySolutionFixes(const Solution &solution) {
 
         auto diagnosed =
             primaryFix->coalesceAndDiagnose(solution, secondaryFixes);
-        if (primaryFix->isWarning()) {
+        if (primaryFix->canApplySolution()) {
           assert(diagnosed && "warnings should always be diagnosed");
           (void)diagnosed;
         } else {
@@ -9140,7 +9140,7 @@ Optional<SolutionApplicationTarget> ConstraintSystem::applySolution(
     // If all of the available fixes would result in a warning,
     // we can go ahead and apply this solution to AST.
     if (!llvm::all_of(solution.Fixes, [](const ConstraintFix *fix) {
-          return fix->isWarning();
+          return fix->canApplySolution();
         })) {
       // If we already diagnosed any errors via fixes, that's it.
       if (diagnosedErrorsViaFixes)

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -103,6 +103,22 @@ template <typename... ArgTypes>
 InFlightDiagnostic
 FailureDiagnostic::emitDiagnosticAt(ArgTypes &&... Args) const {
   auto &DE = getASTContext().Diags;
+  DiagnosticBehavior behaviorLimit;
+  switch (fixBehavior) {
+  case FixBehavior::Error:
+  case FixBehavior::AlwaysWarning:
+    behaviorLimit = DiagnosticBehavior::Unspecified;
+    break;
+
+  case FixBehavior::DowngradeToWarning:
+    behaviorLimit = DiagnosticBehavior::Warning;
+    break;
+
+  case FixBehavior::Suppress:
+    behaviorLimit = DiagnosticBehavior::Ignore;
+    break;
+  }
+
   return std::move(DE.diagnose(std::forward<ArgTypes>(Args)...)
                      .limitBehavior(behaviorLimit));
 }

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -27,6 +27,7 @@
 #include "swift/AST/Types.h"
 #include "swift/Basic/SourceLoc.h"
 #include "swift/Sema/ConstraintSystem.h"
+#include "swift/Sema/FixBehavior.h"
 #include "swift/Sema/OverloadChoice.h"
 #include "llvm/ADT/ArrayRef.h"
 #include <tuple>
@@ -42,19 +43,17 @@ class FunctionArgApplyInfo;
 class FailureDiagnostic {
   const Solution &S;
   ConstraintLocator *Locator;
-  DiagnosticBehavior behaviorLimit;
+  FixBehavior fixBehavior;
 
 public:
   FailureDiagnostic(const Solution &solution, ConstraintLocator *locator,
-                    DiagnosticBehavior behaviorLimit =
-                        DiagnosticBehavior::Unspecified)
-      : S(solution), Locator(locator), behaviorLimit(behaviorLimit) {}
+                    FixBehavior fixBehavior = FixBehavior::Error)
+      : S(solution), Locator(locator), fixBehavior(fixBehavior) {}
 
   FailureDiagnostic(const Solution &solution, ASTNode anchor,
-                    DiagnosticBehavior behaviorLimit =
-                        DiagnosticBehavior::Unspecified)
+                    FixBehavior fixBehavior = FixBehavior::Error)
       : FailureDiagnostic(solution, solution.getConstraintLocator(anchor),
-                          behaviorLimit) { }
+                          fixBehavior) { }
 
   virtual ~FailureDiagnostic();
 
@@ -608,8 +607,7 @@ class ContextualFailure : public FailureDiagnostic {
 public:
   ContextualFailure(const Solution &solution, Type lhs, Type rhs,
                     ConstraintLocator *locator,
-                    DiagnosticBehavior behaviorLimit =
-                        DiagnosticBehavior::Unspecified)
+                    FixBehavior fixBehavior = FixBehavior::Error)
       : ContextualFailure(
             solution,
             locator->isForContextualType()
@@ -617,13 +615,12 @@ public:
                       .getPurpose()
                 : solution.getConstraintSystem().getContextualTypePurpose(
                       locator->getAnchor()),
-            lhs, rhs, locator, behaviorLimit) {}
+            lhs, rhs, locator, fixBehavior) {}
 
   ContextualFailure(const Solution &solution, ContextualTypePurpose purpose,
                     Type lhs, Type rhs, ConstraintLocator *locator,
-                    DiagnosticBehavior behaviorLimit =
-                        DiagnosticBehavior::Unspecified)
-      : FailureDiagnostic(solution, locator, behaviorLimit), CTP(purpose),
+                    FixBehavior fixBehavior = FixBehavior::Error)
+      : FailureDiagnostic(solution, locator, fixBehavior), CTP(purpose),
         RawFromType(lhs), RawToType(rhs) {
     assert(lhs && "Expected a valid 'from' type");
     assert(rhs && "Expected a valid 'to' type");
@@ -764,9 +761,9 @@ public:
   AttributedFuncToTypeConversionFailure(const Solution &solution, Type fromType,
                                         Type toType, ConstraintLocator *locator,
                                         AttributeKind attributeKind,
-                                        DiagnosticBehavior behaviorLimit =
-                                            DiagnosticBehavior::Unspecified)
-      : ContextualFailure(solution, fromType, toType, locator, behaviorLimit),
+                                        FixBehavior fixBehavior =
+                                            FixBehavior::Error)
+      : ContextualFailure(solution, fromType, toType, locator, fixBehavior),
         attributeKind(attributeKind) {}
 
   bool diagnoseAsError() override;
@@ -790,8 +787,8 @@ class DroppedGlobalActorFunctionAttr final : public ContextualFailure {
 public:
   DroppedGlobalActorFunctionAttr(const Solution &solution, Type fromType,
                                  Type toType, ConstraintLocator *locator,
-                                 DiagnosticBehavior behaviorLimit)
-    : ContextualFailure(solution, fromType, toType, locator, behaviorLimit) { }
+                                 FixBehavior fixBehavior)
+    : ContextualFailure(solution, fromType, toType, locator, fixBehavior) { }
 
   bool diagnoseAsError() override;
 };
@@ -1961,9 +1958,9 @@ class ArgumentMismatchFailure : public ContextualFailure {
 public:
   ArgumentMismatchFailure(const Solution &solution, Type argType,
                           Type paramType, ConstraintLocator *locator,
-                          DiagnosticBehavior behaviorLimit =
-                              DiagnosticBehavior::Unspecified)
-      : ContextualFailure(solution, argType, paramType, locator, behaviorLimit),
+                          FixBehavior fixBehavior =
+                              FixBehavior::Error)
+      : ContextualFailure(solution, argType, paramType, locator, fixBehavior),
         Info(*getFunctionArgApplyInfo(getLocator())) {}
 
   bool diagnoseAsError() override;
@@ -2142,9 +2139,9 @@ public:
                                 ConstraintLocator *locator, Type fromType,
                                 Type toType,
                                 ConversionRestrictionKind conversionKind,
-                                DiagnosticBehavior behaviorLimit)
+                                FixBehavior fixBehavior)
       : ArgumentMismatchFailure(
-            solution, fromType, toType, locator, behaviorLimit),
+            solution, fromType, toType, locator, fixBehavior),
         ConversionKind(conversionKind) {
   }
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -37,6 +37,20 @@ using namespace constraints;
 
 ConstraintFix::~ConstraintFix() {}
 
+Optional<ScoreKind> ConstraintFix::affectsSolutionScore() const {
+  switch (fixBehavior) {
+  case FixBehavior::AlwaysWarning:
+    return None;
+
+  case FixBehavior::Error:
+    return SK_Fix;
+
+  case FixBehavior::DowngradeToWarning:
+  case FixBehavior::Suppress:
+    return SK_DisfavoredOverload;
+  }
+}
+
 ASTNode ConstraintFix::getAnchor() const { return getLocator()->getAnchor(); }
 
 void ConstraintFix::print(llvm::raw_ostream &Out) const {

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -227,27 +227,27 @@ MarkExplicitlyEscaping::create(ConstraintSystem &cs, Type lhs, Type rhs,
 bool MarkGlobalActorFunction::diagnose(const Solution &solution,
                                        bool asNote) const {
   DroppedGlobalActorFunctionAttr failure(
-      solution, getFromType(), getToType(), getLocator(), diagBehaviorLimit());
+      solution, getFromType(), getToType(), getLocator(), diagfixBehavior());
   return failure.diagnose(asNote);
 }
 
 MarkGlobalActorFunction *
 MarkGlobalActorFunction::create(ConstraintSystem &cs, Type lhs, Type rhs,
                                 ConstraintLocator *locator,
-                                DiagnosticBehavior behaviorLimit) {
+                                FixBehavior fixBehavior) {
   if (locator->isLastElement<LocatorPathElt::ApplyArgToParam>())
     locator = cs.getConstraintLocator(
         locator, LocatorPathElt::ArgumentAttribute::forGlobalActor());
 
   return new (cs.getAllocator()) MarkGlobalActorFunction(
-      cs, lhs, rhs, locator, behaviorLimit);
+      cs, lhs, rhs, locator, fixBehavior);
 }
 
 bool AddSendableAttribute::diagnose(const Solution &solution,
                                       bool asNote) const {
   AttributedFuncToTypeConversionFailure failure(
       solution, getFromType(), getToType(), getLocator(),
-      AttributedFuncToTypeConversionFailure::Concurrent, diagBehaviorLimit());
+      AttributedFuncToTypeConversionFailure::Concurrent, diagfixBehavior());
   return failure.diagnose(asNote);
 }
 
@@ -256,13 +256,13 @@ AddSendableAttribute::create(ConstraintSystem &cs,
                              FunctionType *fromType,
                              FunctionType *toType,
                              ConstraintLocator *locator,
-                             DiagnosticBehavior behaviorLimit) {
+                             FixBehavior fixBehavior) {
   if (locator->isLastElement<LocatorPathElt::ApplyArgToParam>())
     locator = cs.getConstraintLocator(
         locator, LocatorPathElt::ArgumentAttribute::forConcurrent());
 
   return new (cs.getAllocator()) AddSendableAttribute(
-      cs, fromType, toType, locator, behaviorLimit);
+      cs, fromType, toType, locator, fixBehavior);
 }
 bool RelabelArguments::diagnose(const Solution &solution, bool asNote) const {
   LabelingFailure failure(solution, getLocator(), getLabels());
@@ -431,7 +431,7 @@ ContextualMismatch *ContextualMismatch::create(ConstraintSystem &cs, Type lhs,
                                                Type rhs,
                                                ConstraintLocator *locator) {
   return new (cs.getAllocator()) ContextualMismatch(
-      cs, lhs, rhs, locator, DiagnosticBehavior::Unspecified);
+      cs, lhs, rhs, locator, FixBehavior::Error);
 }
 
 bool AllowWrappedValueMismatch::diagnose(const Solution &solution, bool asError) const {
@@ -837,7 +837,7 @@ AllowTypeOrInstanceMember::create(ConstraintSystem &cs, Type baseType,
 
 bool AllowInvalidPartialApplication::diagnose(const Solution &solution,
                                               bool asNote) const {
-  PartialApplicationFailure failure(isWarning(), solution, getLocator());
+  PartialApplicationFailure failure(isWarning, solution, getLocator());
   return failure.diagnose(asNote);
 }
 
@@ -1192,7 +1192,7 @@ NotCompileTimeConst::NotCompileTimeConst(ConstraintSystem &cs, Type paramTy,
                                          ConstraintLocator *locator):
   ContextualMismatch(cs, FixKind::NotCompileTimeConst, paramTy,
                      cs.getASTContext().TheEmptyTupleType, locator,
-                     DiagnosticBehavior::Warning) {}
+                     FixBehavior::AlwaysWarning) {}
 
 NotCompileTimeConst *
 NotCompileTimeConst::create(ConstraintSystem &cs, Type paramTy,
@@ -1623,7 +1623,7 @@ bool TreatEphemeralAsNonEphemeral::diagnose(const Solution &solution,
                                             bool asNote) const {
   NonEphemeralConversionFailure failure(solution, getLocator(), getFromType(),
                                         getToType(), ConversionKind,
-                                        diagBehaviorLimit());
+                                        diagfixBehavior());
   return failure.diagnose(asNote);
 }
 
@@ -1633,8 +1633,8 @@ TreatEphemeralAsNonEphemeral *TreatEphemeralAsNonEphemeral::create(
     bool downgradeToWarning) {
   return new (cs.getAllocator()) TreatEphemeralAsNonEphemeral(
       cs, locator, srcType, dstType, conversionKind,
-      downgradeToWarning ? DiagnosticBehavior::Warning
-                         : DiagnosticBehavior::Unspecified);
+      downgradeToWarning ? FixBehavior::DowngradeToWarning
+                         : FixBehavior::Error);
 }
 
 std::string TreatEphemeralAsNonEphemeral::getName() const {

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -46,8 +46,10 @@ Optional<ScoreKind> ConstraintFix::affectsSolutionScore() const {
     return SK_Fix;
 
   case FixBehavior::DowngradeToWarning:
-  case FixBehavior::Suppress:
     return SK_DisfavoredOverload;
+
+  case FixBehavior::Suppress:
+    return None;
   }
 }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -12701,8 +12701,8 @@ bool ConstraintSystem::recordFix(ConstraintFix *fix, unsigned impact) {
   // Record the fix.
 
   // If this should affect the solution score, do so.
-  if (fix->affectsSolutionScore())
-    increaseScore(SK_Fix, impact);
+  if (auto scoreKind = fix->affectsSolutionScore())
+    increaseScore(*scoreKind, impact);
 
   // If we've made the current solution worse than the best solution we've seen
   // already, stop now.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2717,7 +2717,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
   }
 
   /// The behavior limit to apply to a concurrency check.
-  auto getConcurrencyDiagnosticBehavior = [&](bool forSendable) {
+  auto getConcurrencyFixBehavior = [&](bool forSendable) {
     // We can only handle the downgrade for conversions.
     switch (kind) {
     case ConstraintKind::Conversion:
@@ -2725,20 +2725,20 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
       break;
 
     default:
-      return DiagnosticBehavior::Unspecified;
+      return FixBehavior::Error;
     }
 
     // For a @preconcurrency callee outside of a strict concurrency context,
     // ignore.
     if (hasPreconcurrencyCallee(this, locator) &&
         !contextRequiresStrictConcurrencyChecking(DC, GetClosureType{*this}))
-      return DiagnosticBehavior::Ignore;
+      return FixBehavior::Suppress;
 
     // Otherwise, warn until Swift 6.
     if (!getASTContext().LangOpts.isSwiftVersionAtLeast(6))
-      return DiagnosticBehavior::Warning;
+      return FixBehavior::DowngradeToWarning;
 
-    return DiagnosticBehavior::Unspecified;
+    return FixBehavior::Error;
   };
 
   // A @Sendable function can be a subtype of a non-@Sendable function.
@@ -2750,7 +2750,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
 
       auto *fix = AddSendableAttribute::create(
           *this, func1, func2, getConstraintLocator(locator),
-          getConcurrencyDiagnosticBehavior(true));
+          getConcurrencyFixBehavior(true));
       if (recordFix(fix))
         return getTypeMatchFailure(locator);
     }
@@ -2785,7 +2785,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
 
       auto *fix = MarkGlobalActorFunction::create(
           *this, func1, func2, getConstraintLocator(locator),
-          getConcurrencyDiagnosticBehavior(false));
+          getConcurrencyFixBehavior(false));
 
       if (recordFix(fix))
         return getTypeMatchFailure(locator);
@@ -12700,9 +12700,8 @@ bool ConstraintSystem::recordFix(ConstraintFix *fix, unsigned impact) {
 
   // Record the fix.
 
-  // If this is just a warning, it shouldn't affect the solver. Otherwise,
-  // increase the score.
-  if (!fix->isWarning())
+  // If this should affect the solution score, do so.
+  if (fix->affectsSolutionScore())
     increaseScore(SK_Fix, impact);
 
   // If we've made the current solution worse than the best solution we've seen
@@ -12723,10 +12722,10 @@ bool ConstraintSystem::recordFix(ConstraintFix *fix, unsigned impact) {
   // its sub-expressions.
   llvm::SmallDenseSet<ASTNode> anchors;
   for (const auto *fix : Fixes) {
-    // Warning fixes shouldn't be considered because even if
-    // such fix is recorded at that anchor this should not
+    // Fixes that don't affect the score shouldn't be considered because even
+    // if such a fix is recorded at that anchor this should not
     // have any affect in the recording of any other fix.
-    if (fix->isWarning())
+    if (!fix->affectsSolutionScore())
       continue;
 
     anchors.insert(fix->getAnchor());

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4606,7 +4606,7 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
   // let's diagnose this as regular ambiguity.
   if (llvm::all_of(solutions, [](const Solution &solution) {
         return llvm::all_of(solution.Fixes, [](const ConstraintFix *fix) {
-          return fix->isWarning();
+          return fix->canApplySolution();
         });
       })) {
     return diagnoseAmbiguity(solutions);
@@ -4624,9 +4624,11 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
   llvm::SmallSetVector<FixInContext, 4> fixes;
   for (auto &solution : solutions) {
     for (auto *fix : solution.Fixes) {
+      // If the fix doesn't affect the solution score, it is not the
+      // source of ambiguity or failures.
       // Ignore warnings in favor of actual error fixes,
       // because they are not the source of ambiguity/failures.
-      if (fix->isWarning())
+      if (!fix->affectsSolutionScore())
         continue;
 
       fixes.insert({&solution, fix});

--- a/test/Concurrency/preconcurrency_overload.swift
+++ b/test/Concurrency/preconcurrency_overload.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+// REQUIRES: concurrency
+
+// https://github.com/apple/swift/issues/59909
+struct Future<T> { }
+
+extension Future {
+  @preconcurrency
+  func flatMap<NewValue>(_ callback: @escaping @Sendable (T) -> Future<NewValue>) -> Future<NewValue> { // #1
+    fatalError()
+  }
+}
+
+extension Future {
+  @available(*, deprecated, message: "")
+  func flatMap<NewValue>(file: StaticString = #file, line: UInt = #line, _ callback: @escaping (T) -> Future<NewValue>) -> Future<NewValue> { // #2
+    return self.flatMap(callback)
+  }
+}

--- a/test/Concurrency/preconcurrency_overload.swift
+++ b/test/Concurrency/preconcurrency_overload.swift
@@ -9,11 +9,22 @@ extension Future {
   func flatMap<NewValue>(_ callback: @escaping @Sendable (T) -> Future<NewValue>) -> Future<NewValue> { // #1
     fatalError()
   }
+
+  @preconcurrency
+  public func flatMapErrorThrowing(_ callback: @escaping @Sendable (Error) throws -> T) -> Future<T> {
+    fatalError("")
+  }
 }
 
 extension Future {
   @available(*, deprecated, message: "")
   func flatMap<NewValue>(file: StaticString = #file, line: UInt = #line, _ callback: @escaping (T) -> Future<NewValue>) -> Future<NewValue> { // #2
     return self.flatMap(callback)
+  }
+
+  @inlinable
+  @available(*, deprecated, message: "Please don't pass file:line:, there's no point.")
+  public func flatMapErrorThrowing(file: StaticString = #file, line: UInt = #line, _ callback: @escaping (Error) throws -> T) -> Future<T> {
+    return self.flatMapErrorThrowing(callback)
   }
 }


### PR DESCRIPTION
Improve the modeling of fix behaviors in the constraint solver rather than abusing `DiagnosticBehavior` for this purpose. Clearly call out the various cases (error, always-warning, downgrade-to-warning, ignore) and separate the predicates for "prevents solution application" and "should impact the score."

With that refactoring in place, tune the behavior for recoverable concurrency fixes to (1) apply even when we aren't allowing fixes (i.e., along the fast path), which improves solver performance overall when dealing with concurrency issues like a missing `@Sendable`, and (2) classify recoverable errors as "disfavored overloads" so that are more desirable than outright errors, which addresses the overloading problem from https://github.com/apple/swift/issues/59909.