### PR TITLE
[5.7] [Constraint solver] Track "isolated by preconcurrency" in the solver.

### DIFF
--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -46,6 +46,7 @@ class ConstraintSystem;
 class ConstraintLocator;
 class ConstraintLocatorBuilder;
 enum class ConversionRestrictionKind;
+enum ScoreKind: unsigned int;
 class Solution;
 struct MemberLookupResult;
 
@@ -433,18 +434,9 @@ public:
     }
   }
 
-  /// Whether this kind of fix affects the solution score.
-  bool affectsSolutionScore() const {
-    switch (fixBehavior) {
-    case FixBehavior::AlwaysWarning:
-    case FixBehavior::DowngradeToWarning:
-    case FixBehavior::Suppress:
-      return false;
-
-    case FixBehavior::Error:
-      return true;
-    }
-  }
+  /// Whether this kind of fix affects the solution score, and which score
+  /// it affects.
+  Optional<ScoreKind> affectsSolutionScore() const;
 
   /// The diagnostic behavior limit that will be applied to any emitted
   /// diagnostics.

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -25,6 +25,7 @@
 #include "swift/AST/Types.h"
 #include "swift/Basic/Debug.h"
 #include "swift/Sema/ConstraintLocator.h"
+#include "swift/Sema/FixBehavior.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/TrailingObjects.h"
@@ -402,13 +403,12 @@ class ConstraintFix {
   ConstraintLocator *Locator;
 
   /// The behavior limit to apply to the diagnostics emitted.
-  DiagnosticBehavior behaviorLimit;
+  FixBehavior fixBehavior;
 
 public:
   ConstraintFix(ConstraintSystem &cs, FixKind kind, ConstraintLocator *locator,
-                DiagnosticBehavior behaviorLimit =
-                    DiagnosticBehavior::Unspecified)
-      : CS(cs), Kind(kind), Locator(locator), behaviorLimit(behaviorLimit) {}
+                FixBehavior fixBehavior = FixBehavior::Error)
+      : CS(cs), Kind(kind), Locator(locator), fixBehavior(fixBehavior) {}
 
   virtual ~ConstraintFix();
 
@@ -419,14 +419,36 @@ public:
 
   FixKind getKind() const { return Kind; }
 
-  bool isWarning() const {
-    return behaviorLimit == DiagnosticBehavior::Warning ||
-           behaviorLimit == DiagnosticBehavior::Ignore;
+  /// Whether it is still possible to "apply" a solution containing this kind
+  /// of fix to get a usable AST.
+  bool canApplySolution() const {
+    switch (fixBehavior) {
+    case FixBehavior::AlwaysWarning:
+    case FixBehavior::DowngradeToWarning:
+    case FixBehavior::Suppress:
+      return true;
+
+    case FixBehavior::Error:
+      return false;
+    }
+  }
+
+  /// Whether this kind of fix affects the solution score.
+  bool affectsSolutionScore() const {
+    switch (fixBehavior) {
+    case FixBehavior::AlwaysWarning:
+    case FixBehavior::DowngradeToWarning:
+    case FixBehavior::Suppress:
+      return false;
+
+    case FixBehavior::Error:
+      return true;
+    }
   }
 
   /// The diagnostic behavior limit that will be applied to any emitted
   /// diagnostics.
-  DiagnosticBehavior diagBehaviorLimit() const { return behaviorLimit; }
+  FixBehavior diagfixBehavior() const { return fixBehavior; }
 
   virtual std::string getName() const = 0;
 
@@ -672,16 +694,15 @@ class ContextualMismatch : public ConstraintFix {
 
   ContextualMismatch(ConstraintSystem &cs, Type lhs, Type rhs,
                      ConstraintLocator *locator,
-                     DiagnosticBehavior behaviorLimit)
-      : ConstraintFix(cs, FixKind::ContextualMismatch, locator, behaviorLimit),
+                     FixBehavior fixBehavior)
+      : ConstraintFix(cs, FixKind::ContextualMismatch, locator, fixBehavior),
         LHS(lhs), RHS(rhs) {}
 
 protected:
   ContextualMismatch(ConstraintSystem &cs, FixKind kind, Type lhs, Type rhs,
                      ConstraintLocator *locator,
-                     DiagnosticBehavior behaviorLimit =
-                         DiagnosticBehavior::Unspecified)
-      : ConstraintFix(cs, kind, locator, behaviorLimit), LHS(lhs), RHS(rhs) {}
+                     FixBehavior fixBehavior = FixBehavior::Error)
+      : ConstraintFix(cs, kind, locator, fixBehavior), LHS(lhs), RHS(rhs) {}
 
 public:
   std::string getName() const override { return "fix contextual mismatch"; }
@@ -766,9 +787,9 @@ public:
 class MarkGlobalActorFunction final : public ContextualMismatch {
   MarkGlobalActorFunction(ConstraintSystem &cs, Type lhs, Type rhs,
                           ConstraintLocator *locator,
-                          DiagnosticBehavior behaviorLimit)
+                          FixBehavior fixBehavior)
       : ContextualMismatch(cs, FixKind::MarkGlobalActorFunction, lhs, rhs,
-                           locator, behaviorLimit) {
+                           locator, fixBehavior) {
   }
 
 public:
@@ -778,7 +799,7 @@ public:
 
   static MarkGlobalActorFunction *create(ConstraintSystem &cs, Type lhs,
                                          Type rhs, ConstraintLocator *locator,
-                                         DiagnosticBehavior behaviorLimit);
+                                         FixBehavior fixBehavior);
 
   static bool classof(ConstraintFix *fix) {
     return fix->getKind() == FixKind::MarkGlobalActorFunction;
@@ -814,9 +835,9 @@ public:
 class AddSendableAttribute final : public ContextualMismatch {
   AddSendableAttribute(ConstraintSystem &cs, FunctionType *fromType,
                        FunctionType *toType, ConstraintLocator *locator,
-                       DiagnosticBehavior behaviorLimit)
+                       FixBehavior fixBehavior)
       : ContextualMismatch(cs, FixKind::AddSendableAttribute, fromType, toType,
-                           locator, behaviorLimit) {
+                           locator, fixBehavior) {
     assert(fromType->isSendable() != toType->isSendable());
   }
 
@@ -829,7 +850,7 @@ public:
                                       FunctionType *fromType,
                                       FunctionType *toType,
                                       ConstraintLocator *locator,
-                                      DiagnosticBehavior behaviorLimit);
+                                      FixBehavior fixBehavior);
 
   static bool classof(ConstraintFix *fix) {
     return fix->getKind() == FixKind::AddSendableAttribute;
@@ -1392,11 +1413,14 @@ public:
 };
 
 class AllowInvalidPartialApplication final : public ConstraintFix {
+  bool isWarning;
+
   AllowInvalidPartialApplication(bool isWarning, ConstraintSystem &cs,
                                  ConstraintLocator *locator)
       : ConstraintFix(cs, FixKind::AllowInvalidPartialApplication, locator,
-                      isWarning ? DiagnosticBehavior::Warning
-                                : DiagnosticBehavior::Unspecified) {}
+                      isWarning ? FixBehavior::AlwaysWarning
+                                : FixBehavior::Error),
+        isWarning(isWarning) {}
 
 public:
   std::string getName() const override {
@@ -2130,10 +2154,9 @@ protected:
 
   AllowArgumentMismatch(ConstraintSystem &cs, FixKind kind, Type argType,
                         Type paramType, ConstraintLocator *locator,
-                        DiagnosticBehavior behaviorLimit =
-                            DiagnosticBehavior::Unspecified)
+                        FixBehavior fixBehavior = FixBehavior::Error)
       : ContextualMismatch(
-            cs, kind, argType, paramType, locator, behaviorLimit) {}
+            cs, kind, argType, paramType, locator, fixBehavior) {}
 
 public:
   std::string getName() const override {
@@ -2281,9 +2304,9 @@ class TreatEphemeralAsNonEphemeral final : public AllowArgumentMismatch {
   TreatEphemeralAsNonEphemeral(ConstraintSystem &cs, ConstraintLocator *locator,
                                Type srcType, Type dstType,
                                ConversionRestrictionKind conversionKind,
-                               DiagnosticBehavior behaviorLimit)
+                               FixBehavior fixBehavior)
       : AllowArgumentMismatch(cs, FixKind::TreatEphemeralAsNonEphemeral,
-                              srcType, dstType, locator, behaviorLimit),
+                              srcType, dstType, locator, fixBehavior),
         ConversionKind(conversionKind) {}
 
 public:
@@ -2447,7 +2470,7 @@ class AllowCoercionToForceCast final : public ContextualMismatch {
   AllowCoercionToForceCast(ConstraintSystem &cs, Type fromType, Type toType,
                            ConstraintLocator *locator)
       : ContextualMismatch(cs, FixKind::AllowCoercionToForceCast, fromType,
-                           toType, locator, DiagnosticBehavior::Warning) {}
+                           toType, locator, FixBehavior::AlwaysWarning) {}
 
 public:
   std::string getName() const override {
@@ -2561,7 +2584,7 @@ class SpecifyLabelToAssociateTrailingClosure final : public ConstraintFix {
   SpecifyLabelToAssociateTrailingClosure(ConstraintSystem &cs,
                                          ConstraintLocator *locator)
       : ConstraintFix(cs, FixKind::SpecifyLabelToAssociateTrailingClosure,
-                      locator, DiagnosticBehavior::Warning) {}
+                      locator, FixBehavior::AlwaysWarning) {}
 
 public:
   std::string getName() const override {
@@ -2731,7 +2754,7 @@ class SpecifyBaseTypeForOptionalUnresolvedMember final : public ConstraintFix {
                                              DeclNameRef memberName,
                                              ConstraintLocator *locator)
       : ConstraintFix(cs, FixKind::SpecifyBaseTypeForOptionalUnresolvedMember,
-                      locator, DiagnosticBehavior::Warning),
+                      locator, FixBehavior::AlwaysWarning),
         MemberName(memberName) {}
   DeclNameRef MemberName;
 
@@ -2762,7 +2785,7 @@ protected:
                                        CheckedCastKind kind,
                                        ConstraintLocator *locator)
       : ContextualMismatch(cs, fixKind, fromType, toType, locator,
-                           DiagnosticBehavior::Warning),
+                           FixBehavior::AlwaysWarning),
         CastKind(kind) {}
   CheckedCastKind CastKind;
 };
@@ -2873,7 +2896,7 @@ class AllowTupleLabelMismatch final : public ContextualMismatch {
   AllowTupleLabelMismatch(ConstraintSystem &cs, Type fromType, Type toType,
                           ConstraintLocator *locator)
       : ContextualMismatch(cs, FixKind::AllowTupleLabelMismatch, fromType,
-                           toType, locator, DiagnosticBehavior::Warning) {}
+                           toType, locator, FixBehavior::AlwaysWarning) {}
 
 public:
   std::string getName() const override { return "allow tuple label mismatch"; }

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -775,7 +775,7 @@ public:
 
 /// Describes an aspect of a solution that affects its overall score, i.e., a
 /// user-defined conversions.
-enum ScoreKind {
+enum ScoreKind: unsigned int {
   // These values are used as indices into a Score value.
 
   /// A fix needs to be applied to the source.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1276,6 +1276,10 @@ public:
   /// The set of parameters that have been inferred to be 'isolated'.
   llvm::SmallVector<ParamDecl *, 2> isolatedParams;
 
+  /// The set of closures that have been inferred to be "isolated by
+  /// preconcurrency".
+  llvm::SmallVector<const ClosureExpr *, 2> preconcurrencyClosures;
+
   /// The set of functions that have been transformed by a result builder.
   llvm::MapVector<AnyFunctionRef, AppliedBuilderTransform>
       resultBuilderTransformed;
@@ -2479,6 +2483,13 @@ struct GetClosureType {
   Type operator()(const AbstractClosureExpr *expr) const;
 };
 
+/// Retrieve the closure type from the constraint system.
+struct ClosureIsolatedByPreconcurrency {
+  ConstraintSystem &cs;
+
+  bool operator()(const ClosureExpr *expr) const;
+};
+
 /// Describes the type produced when referencing a declaration.
 struct DeclReferenceType {
   /// The "opened" type, which is the type of the declaration where any
@@ -2533,6 +2544,7 @@ public:
   friend class ConjunctionElement;
   friend class RequirementFailure;
   friend class MissingMemberFailure;
+  friend struct ClosureIsolatedByPreconcurrency;
 
   class SolverScope;
 
@@ -2662,6 +2674,10 @@ private:
 
   /// The set of parameters that have been inferred to be 'isolated'.
   llvm::SmallSetVector<ParamDecl *, 2> isolatedParams;
+
+  /// The set of closures that have been inferred to be "isolated by
+  /// preconcurrency".
+  llvm::SmallSetVector<const ClosureExpr *, 2> preconcurrencyClosures;
 
   /// Maps closure parameters to type variables.
   llvm::DenseMap<const ParamDecl *, TypeVariableType *>
@@ -3232,6 +3248,9 @@ public:
 
     /// The length of \c isolatedParams.
     unsigned numIsolatedParams;
+
+    /// The length of \c PreconcurrencyClosures.
+    unsigned numPreconcurrencyClosures;
 
     /// The length of \c ImplicitValueConversions.
     unsigned numImplicitValueConversions;
@@ -4511,6 +4530,10 @@ public:
       llvm::function_ref<Type(const AbstractClosureExpr *)> getClosureType =
         [](const AbstractClosureExpr *) {
           return Type();
+        },
+      llvm::function_ref<bool(const ClosureExpr *)> isolatedByPreconcurrency =
+        [](const ClosureExpr *closure) {
+          return closure->isIsolatedByPreconcurrency();
         });
 
   /// Given the opened type and a pile of information about a member reference,

--- a/include/swift/Sema/FixBehavior.h
+++ b/include/swift/Sema/FixBehavior.h
@@ -1,0 +1,41 @@
+//===--- FixBehavior.h - Constraint Fix Behavior --------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provides information about how a constraint fix should behavior.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SEMA_FIXBEHAVIOR_H
+#define SWIFT_SEMA_FIXBEHAVIOR_H
+
+namespace swift {
+namespace constraints {
+
+/// Describes the behavior of the diagnostic corresponding to a given fix.
+enum class FixBehavior {
+  /// The diagnostic is an error, and should prevent constraint application.
+  Error,
+  /// The diagnostic is always a warning, which should not prevent constraint
+  /// application.
+  AlwaysWarning,
+  /// The diagnostic should be downgraded to a warning, and not prevent
+  /// constraint application.
+  DowngradeToWarning,
+  /// The diagnostic should be suppressed, and not prevent constraint
+  /// application.
+  Suppress
+};
+
+}
+}
+
+#endif // SWIFT_SEMA_FIXBEHAVIOR_H

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5638,25 +5638,22 @@ static bool hasCurriedSelf(ConstraintSystem &cs, ConcreteDeclRef callee,
 
 /// Apply the contextually Sendable flag to the given expression,
 static void applyContextualClosureFlags(
-      Expr *expr, bool implicitSelfCapture, bool inheritActorContext,
-      bool isolatedByPreconcurrency) {
+      Expr *expr, bool implicitSelfCapture, bool inheritActorContext) {
   if (auto closure = dyn_cast<ClosureExpr>(expr)) {
     closure->setAllowsImplicitSelfCapture(implicitSelfCapture);
     closure->setInheritsActorContext(inheritActorContext);
-    closure->setIsolatedByPreconcurrency(isolatedByPreconcurrency);
     return;
   }
 
   if (auto captureList = dyn_cast<CaptureListExpr>(expr)) {
     applyContextualClosureFlags(
         captureList->getClosureBody(), implicitSelfCapture,
-        inheritActorContext, isolatedByPreconcurrency);
+        inheritActorContext);
   }
 
   if (auto identity = dyn_cast<IdentityExpr>(expr)) {
     applyContextualClosureFlags(
-        identity->getSubExpr(), implicitSelfCapture, inheritActorContext,
-        isolatedByPreconcurrency);
+        identity->getSubExpr(), implicitSelfCapture, inheritActorContext);
   }
 }
 
@@ -5683,8 +5680,6 @@ ArgumentList *ExprRewriter::coerceCallArguments(
   // Determine the parameter bindings.
   ParameterListInfo paramInfo(params, callee.getDecl(), skipCurriedSelf);
 
-  bool preconcurrency = callee && callee.getDecl()->preconcurrency();
-
   // If this application is an init(wrappedValue:) call that needs an injected
   // wrapped value placeholder, the first non-defaulted argument must be
   // wrapped in an OpaqueValueExpr.
@@ -5707,14 +5702,6 @@ ArgumentList *ExprRewriter::coerceCallArguments(
   auto matches = args->matches(params, [&](Expr *E) { return cs.getType(E); });
   if (matches && !shouldInjectWrappedValuePlaceholder &&
       !paramInfo.anyContextualInfo()) {
-    // Propagate preconcurrency to any closure arguments.
-    if (preconcurrency) {
-      for (const auto &arg : *args) {
-        Expr *argExpr = arg.getExpr();
-        applyContextualClosureFlags(argExpr, false, false, preconcurrency);
-      }
-    }
-
     return args;
   }
 
@@ -5865,7 +5852,7 @@ ArgumentList *ExprRewriter::coerceCallArguments(
     bool isImplicitSelfCapture = paramInfo.isImplicitSelfCapture(paramIdx);
     bool inheritsActorContext = paramInfo.inheritsActorContext(paramIdx);
     applyContextualClosureFlags(
-        argExpr, isImplicitSelfCapture, inheritsActorContext, preconcurrency);
+        argExpr, isImplicitSelfCapture, inheritsActorContext);
 
     // If the types exactly match, this is easy.
     auto paramType = param.getOldType();

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8480,7 +8480,7 @@ bool ConstraintSystem::applySolutionFixes(const Solution &solution) {
 
         auto diagnosed =
             primaryFix->coalesceAndDiagnose(solution, secondaryFixes);
-        if (primaryFix->isWarning()) {
+        if (primaryFix->canApplySolution()) {
           assert(diagnosed && "warnings should always be diagnosed");
           (void)diagnosed;
         } else {
@@ -9113,7 +9113,7 @@ Optional<SolutionApplicationTarget> ConstraintSystem::applySolution(
     // If all of the available fixes would result in a warning,
     // we can go ahead and apply this solution to AST.
     if (!llvm::all_of(solution.Fixes, [](const ConstraintFix *fix) {
-          return fix->isWarning();
+          return fix->canApplySolution();
         })) {
       // If we already diagnosed any errors via fixes, that's it.
       if (diagnosedErrorsViaFixes)

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -9105,16 +9105,23 @@ Optional<SolutionApplicationTarget> ConstraintSystem::applySolution(
     Solution &solution, SolutionApplicationTarget target) {
   // If any fixes needed to be applied to arrive at this solution, resolve
   // them to specific expressions.
+  unsigned numResolvableFixes = 0;
   if (!solution.Fixes.empty()) {
     if (shouldSuppressDiagnostics())
       return None;
 
     bool diagnosedErrorsViaFixes = applySolutionFixes(solution);
+    bool canApplySolution = true;
+    for (const auto fix : solution.Fixes) {
+      if (!fix->canApplySolution())
+        canApplySolution = false;
+      if (fix->affectsSolutionScore() == SK_Fix && fix->canApplySolution())
+        ++numResolvableFixes;
+    }
+
     // If all of the available fixes would result in a warning,
     // we can go ahead and apply this solution to AST.
-    if (!llvm::all_of(solution.Fixes, [](const ConstraintFix *fix) {
-          return fix->canApplySolution();
-        })) {
+    if (!canApplySolution) {
       // If we already diagnosed any errors via fixes, that's it.
       if (diagnosedErrorsViaFixes)
         return None;
@@ -9131,7 +9138,7 @@ Optional<SolutionApplicationTarget> ConstraintSystem::applySolution(
   // produce a fallback diagnostic to highlight the problem.
   {
     const auto &score = solution.getFixedScore();
-    if (score.Data[SK_Fix] > 0 || score.Data[SK_Hole] > 0) {
+    if (score.Data[SK_Fix] > numResolvableFixes || score.Data[SK_Hole] > 0) {
       maybeProduceFallbackDiagnostic(target);
       return None;
     }

--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -1656,6 +1656,9 @@ SolutionApplicationToFunctionResult ConstraintSystem::applySolution(
         param->setIsolated(true);
     }
 
+    if (llvm::is_contained(solution.preconcurrencyClosures, closure))
+      closure->setIsolatedByPreconcurrency();
+
     // Coerce the result type, if it was written explicitly.
     if (closure->hasExplicitResultType()) {
       closure->setExplicitResultType(closureFnType->getResult());

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -103,6 +103,22 @@ template <typename... ArgTypes>
 InFlightDiagnostic
 FailureDiagnostic::emitDiagnosticAt(ArgTypes &&... Args) const {
   auto &DE = getASTContext().Diags;
+  DiagnosticBehavior behaviorLimit;
+  switch (fixBehavior) {
+  case FixBehavior::Error:
+  case FixBehavior::AlwaysWarning:
+    behaviorLimit = DiagnosticBehavior::Unspecified;
+    break;
+
+  case FixBehavior::DowngradeToWarning:
+    behaviorLimit = DiagnosticBehavior::Warning;
+    break;
+
+  case FixBehavior::Suppress:
+    behaviorLimit = DiagnosticBehavior::Ignore;
+    break;
+  }
+
   return std::move(DE.diagnose(std::forward<ArgTypes>(Args)...)
                      .limitBehavior(behaviorLimit));
 }

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -27,6 +27,7 @@
 #include "swift/AST/Types.h"
 #include "swift/Basic/SourceLoc.h"
 #include "swift/Sema/ConstraintSystem.h"
+#include "swift/Sema/FixBehavior.h"
 #include "swift/Sema/OverloadChoice.h"
 #include "llvm/ADT/ArrayRef.h"
 #include <tuple>
@@ -42,19 +43,17 @@ class FunctionArgApplyInfo;
 class FailureDiagnostic {
   const Solution &S;
   ConstraintLocator *Locator;
-  DiagnosticBehavior behaviorLimit;
+  FixBehavior fixBehavior;
 
 public:
   FailureDiagnostic(const Solution &solution, ConstraintLocator *locator,
-                    DiagnosticBehavior behaviorLimit =
-                        DiagnosticBehavior::Unspecified)
-      : S(solution), Locator(locator), behaviorLimit(behaviorLimit) {}
+                    FixBehavior fixBehavior = FixBehavior::Error)
+      : S(solution), Locator(locator), fixBehavior(fixBehavior) {}
 
   FailureDiagnostic(const Solution &solution, ASTNode anchor,
-                    DiagnosticBehavior behaviorLimit =
-                        DiagnosticBehavior::Unspecified)
+                    FixBehavior fixBehavior = FixBehavior::Error)
       : FailureDiagnostic(solution, solution.getConstraintLocator(anchor),
-                          behaviorLimit) { }
+                          fixBehavior) { }
 
   virtual ~FailureDiagnostic();
 
@@ -608,8 +607,7 @@ class ContextualFailure : public FailureDiagnostic {
 public:
   ContextualFailure(const Solution &solution, Type lhs, Type rhs,
                     ConstraintLocator *locator,
-                    DiagnosticBehavior behaviorLimit =
-                        DiagnosticBehavior::Unspecified)
+                    FixBehavior fixBehavior = FixBehavior::Error)
       : ContextualFailure(
             solution,
             locator->isForContextualType()
@@ -617,13 +615,12 @@ public:
                       .getPurpose()
                 : solution.getConstraintSystem().getContextualTypePurpose(
                       locator->getAnchor()),
-            lhs, rhs, locator, behaviorLimit) {}
+            lhs, rhs, locator, fixBehavior) {}
 
   ContextualFailure(const Solution &solution, ContextualTypePurpose purpose,
                     Type lhs, Type rhs, ConstraintLocator *locator,
-                    DiagnosticBehavior behaviorLimit =
-                        DiagnosticBehavior::Unspecified)
-      : FailureDiagnostic(solution, locator, behaviorLimit), CTP(purpose),
+                    FixBehavior fixBehavior = FixBehavior::Error)
+      : FailureDiagnostic(solution, locator, fixBehavior), CTP(purpose),
         RawFromType(lhs), RawToType(rhs) {
     assert(lhs && "Expected a valid 'from' type");
     assert(rhs && "Expected a valid 'to' type");
@@ -764,9 +761,9 @@ public:
   AttributedFuncToTypeConversionFailure(const Solution &solution, Type fromType,
                                         Type toType, ConstraintLocator *locator,
                                         AttributeKind attributeKind,
-                                        DiagnosticBehavior behaviorLimit =
-                                            DiagnosticBehavior::Unspecified)
-      : ContextualFailure(solution, fromType, toType, locator, behaviorLimit),
+                                        FixBehavior fixBehavior =
+                                            FixBehavior::Error)
+      : ContextualFailure(solution, fromType, toType, locator, fixBehavior),
         attributeKind(attributeKind) {}
 
   bool diagnoseAsError() override;
@@ -790,8 +787,8 @@ class DroppedGlobalActorFunctionAttr final : public ContextualFailure {
 public:
   DroppedGlobalActorFunctionAttr(const Solution &solution, Type fromType,
                                  Type toType, ConstraintLocator *locator,
-                                 DiagnosticBehavior behaviorLimit)
-    : ContextualFailure(solution, fromType, toType, locator, behaviorLimit) { }
+                                 FixBehavior fixBehavior)
+    : ContextualFailure(solution, fromType, toType, locator, fixBehavior) { }
 
   bool diagnoseAsError() override;
 };
@@ -1961,9 +1958,9 @@ class ArgumentMismatchFailure : public ContextualFailure {
 public:
   ArgumentMismatchFailure(const Solution &solution, Type argType,
                           Type paramType, ConstraintLocator *locator,
-                          DiagnosticBehavior behaviorLimit =
-                              DiagnosticBehavior::Unspecified)
-      : ContextualFailure(solution, argType, paramType, locator, behaviorLimit),
+                          FixBehavior fixBehavior =
+                              FixBehavior::Error)
+      : ContextualFailure(solution, argType, paramType, locator, fixBehavior),
         Info(*getFunctionArgApplyInfo(getLocator())) {}
 
   bool diagnoseAsError() override;
@@ -2142,9 +2139,9 @@ public:
                                 ConstraintLocator *locator, Type fromType,
                                 Type toType,
                                 ConversionRestrictionKind conversionKind,
-                                DiagnosticBehavior behaviorLimit)
+                                FixBehavior fixBehavior)
       : ArgumentMismatchFailure(
-            solution, fromType, toType, locator, behaviorLimit),
+            solution, fromType, toType, locator, fixBehavior),
         ConversionKind(conversionKind) {
   }
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -37,6 +37,20 @@ using namespace constraints;
 
 ConstraintFix::~ConstraintFix() {}
 
+Optional<ScoreKind> ConstraintFix::affectsSolutionScore() const {
+  switch (fixBehavior) {
+  case FixBehavior::AlwaysWarning:
+    return None;
+
+  case FixBehavior::Error:
+    return SK_Fix;
+
+  case FixBehavior::DowngradeToWarning:
+  case FixBehavior::Suppress:
+    return SK_DisfavoredOverload;
+  }
+}
+
 ASTNode ConstraintFix::getAnchor() const { return getLocator()->getAnchor(); }
 
 void ConstraintFix::print(llvm::raw_ostream &Out) const {

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -203,27 +203,27 @@ MarkExplicitlyEscaping::create(ConstraintSystem &cs, Type lhs, Type rhs,
 bool MarkGlobalActorFunction::diagnose(const Solution &solution,
                                        bool asNote) const {
   DroppedGlobalActorFunctionAttr failure(
-      solution, getFromType(), getToType(), getLocator(), diagBehaviorLimit());
+      solution, getFromType(), getToType(), getLocator(), diagfixBehavior());
   return failure.diagnose(asNote);
 }
 
 MarkGlobalActorFunction *
 MarkGlobalActorFunction::create(ConstraintSystem &cs, Type lhs, Type rhs,
                                 ConstraintLocator *locator,
-                                DiagnosticBehavior behaviorLimit) {
+                                FixBehavior fixBehavior) {
   if (locator->isLastElement<LocatorPathElt::ApplyArgToParam>())
     locator = cs.getConstraintLocator(
         locator, LocatorPathElt::ArgumentAttribute::forGlobalActor());
 
   return new (cs.getAllocator()) MarkGlobalActorFunction(
-      cs, lhs, rhs, locator, behaviorLimit);
+      cs, lhs, rhs, locator, fixBehavior);
 }
 
 bool AddSendableAttribute::diagnose(const Solution &solution,
                                       bool asNote) const {
   AttributedFuncToTypeConversionFailure failure(
       solution, getFromType(), getToType(), getLocator(),
-      AttributedFuncToTypeConversionFailure::Concurrent, diagBehaviorLimit());
+      AttributedFuncToTypeConversionFailure::Concurrent, diagfixBehavior());
   return failure.diagnose(asNote);
 }
 
@@ -232,13 +232,13 @@ AddSendableAttribute::create(ConstraintSystem &cs,
                              FunctionType *fromType,
                              FunctionType *toType,
                              ConstraintLocator *locator,
-                             DiagnosticBehavior behaviorLimit) {
+                             FixBehavior fixBehavior) {
   if (locator->isLastElement<LocatorPathElt::ApplyArgToParam>())
     locator = cs.getConstraintLocator(
         locator, LocatorPathElt::ArgumentAttribute::forConcurrent());
 
   return new (cs.getAllocator()) AddSendableAttribute(
-      cs, fromType, toType, locator, behaviorLimit);
+      cs, fromType, toType, locator, fixBehavior);
 }
 bool RelabelArguments::diagnose(const Solution &solution, bool asNote) const {
   LabelingFailure failure(solution, getLocator(), getLabels());
@@ -407,7 +407,7 @@ ContextualMismatch *ContextualMismatch::create(ConstraintSystem &cs, Type lhs,
                                                Type rhs,
                                                ConstraintLocator *locator) {
   return new (cs.getAllocator()) ContextualMismatch(
-      cs, lhs, rhs, locator, DiagnosticBehavior::Unspecified);
+      cs, lhs, rhs, locator, FixBehavior::Error);
 }
 
 bool AllowWrappedValueMismatch::diagnose(const Solution &solution, bool asError) const {
@@ -813,7 +813,7 @@ AllowTypeOrInstanceMember::create(ConstraintSystem &cs, Type baseType,
 
 bool AllowInvalidPartialApplication::diagnose(const Solution &solution,
                                               bool asNote) const {
-  PartialApplicationFailure failure(isWarning(), solution, getLocator());
+  PartialApplicationFailure failure(isWarning, solution, getLocator());
   return failure.diagnose(asNote);
 }
 
@@ -1168,7 +1168,7 @@ NotCompileTimeConst::NotCompileTimeConst(ConstraintSystem &cs, Type paramTy,
                                          ConstraintLocator *locator):
   ContextualMismatch(cs, FixKind::NotCompileTimeConst, paramTy,
                      cs.getASTContext().TheEmptyTupleType, locator,
-                     DiagnosticBehavior::Warning) {}
+                     FixBehavior::AlwaysWarning) {}
 
 NotCompileTimeConst *
 NotCompileTimeConst::create(ConstraintSystem &cs, Type paramTy,
@@ -1599,7 +1599,7 @@ bool TreatEphemeralAsNonEphemeral::diagnose(const Solution &solution,
                                             bool asNote) const {
   NonEphemeralConversionFailure failure(solution, getLocator(), getFromType(),
                                         getToType(), ConversionKind,
-                                        diagBehaviorLimit());
+                                        diagfixBehavior());
   return failure.diagnose(asNote);
 }
 
@@ -1609,8 +1609,8 @@ TreatEphemeralAsNonEphemeral *TreatEphemeralAsNonEphemeral::create(
     bool downgradeToWarning) {
   return new (cs.getAllocator()) TreatEphemeralAsNonEphemeral(
       cs, locator, srcType, dstType, conversionKind,
-      downgradeToWarning ? DiagnosticBehavior::Warning
-                         : DiagnosticBehavior::Unspecified);
+      downgradeToWarning ? FixBehavior::DowngradeToWarning
+                         : FixBehavior::Error);
 }
 
 std::string TreatEphemeralAsNonEphemeral::getName() const {

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -46,8 +46,10 @@ Optional<ScoreKind> ConstraintFix::affectsSolutionScore() const {
     return SK_Fix;
 
   case FixBehavior::DowngradeToWarning:
-  case FixBehavior::Suppress:
     return SK_DisfavoredOverload;
+
+  case FixBehavior::Suppress:
+    return None;
   }
 }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -12706,8 +12706,8 @@ bool ConstraintSystem::recordFix(ConstraintFix *fix, unsigned impact) {
   // Record the fix.
 
   // If this should affect the solution score, do so.
-  if (fix->affectsSolutionScore())
-    increaseScore(SK_Fix, impact);
+  if (auto scoreKind = fix->affectsSolutionScore())
+    increaseScore(*scoreKind, impact);
 
   // If we've made the current solution worse than the best solution we've seen
   // already, stop now.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2738,7 +2738,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
         // For a @preconcurrency callee outside of a strict concurrency
         // context, ignore.
         if (hasPreconcurrencyCallee(this, locator) &&
-            !contextRequiresStrictConcurrencyChecking(DC, GetClosureType{*this}))
+            !contextRequiresStrictConcurrencyChecking(DC, GetClosureType{*this}, ClosureIsolatedByPreconcurrency{*this}))
           return FixBehavior::Suppress;
 
         // Otherwise, warn until Swift 6.
@@ -9840,6 +9840,10 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
   auto *closureLocator = typeVar->getImpl().getLocator();
   auto *closure = castToExpr<ClosureExpr>(closureLocator->getAnchor());
   auto *inferredClosureType = getClosureType(closure);
+
+  // Note if this closure is isolated by preconcurrency.
+  if (hasPreconcurrencyCallee(this, locator))
+    preconcurrencyClosures.insert(closure);
 
   // Let's look through all optionals associated with contextual
   // type to make it possible to infer parameter/result type of

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2719,42 +2719,47 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
   }
 
   /// The behavior limit to apply to a concurrency check.
-  auto getConcurrencyFixBehavior = [&](bool forSendable) {
-    // We can only handle the downgrade for conversions.
-    switch (kind) {
-    case ConstraintKind::Conversion:
-    case ConstraintKind::ArgumentConversion:
-      break;
+  auto getConcurrencyFixBehavior = [&](
+        bool forSendable
+      ) -> Optional<FixBehavior> {
+        // We can only handle the downgrade for conversions.
+        switch (kind) {
+        case ConstraintKind::Conversion:
+        case ConstraintKind::ArgumentConversion:
+          break;
 
-    default:
-      return FixBehavior::Error;
-    }
+        default:
+          if (!shouldAttemptFixes())
+            return None;
 
-    // For a @preconcurrency callee outside of a strict concurrency context,
-    // ignore.
-    if (hasPreconcurrencyCallee(this, locator) &&
-        !contextRequiresStrictConcurrencyChecking(DC, GetClosureType{*this}))
-      return FixBehavior::Suppress;
+          return FixBehavior::Error;
+        }
 
-    // Otherwise, warn until Swift 6.
-    if (!getASTContext().LangOpts.isSwiftVersionAtLeast(6))
-      return FixBehavior::DowngradeToWarning;
+        // For a @preconcurrency callee outside of a strict concurrency
+        // context, ignore.
+        if (hasPreconcurrencyCallee(this, locator) &&
+            !contextRequiresStrictConcurrencyChecking(DC, GetClosureType{*this}))
+          return FixBehavior::Suppress;
 
-    return FixBehavior::Error;
+        // Otherwise, warn until Swift 6.
+        if (!getASTContext().LangOpts.isSwiftVersionAtLeast(6))
+          return FixBehavior::DowngradeToWarning;
+
+        return FixBehavior::Error;
   };
 
   // A @Sendable function can be a subtype of a non-@Sendable function.
   if (func1->isSendable() != func2->isSendable()) {
     // Cannot add '@Sendable'.
     if (func2->isSendable() || kind < ConstraintKind::Subtype) {
-      if (!shouldAttemptFixes())
+      if (auto fixBehavior = getConcurrencyFixBehavior(true)) {
+        auto *fix = AddSendableAttribute::create(
+            *this, func1, func2, getConstraintLocator(locator), *fixBehavior);
+        if (recordFix(fix))
+          return getTypeMatchFailure(locator);
+      } else {
         return getTypeMatchFailure(locator);
-
-      auto *fix = AddSendableAttribute::create(
-          *this, func1, func2, getConstraintLocator(locator),
-          getConcurrencyFixBehavior(true));
-      if (recordFix(fix))
-        return getTypeMatchFailure(locator);
+      }
     }
   }
 
@@ -2782,15 +2787,16 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
         return getTypeMatchFailure(locator);
     } else if (func1->getGlobalActor() && !func2->isAsync()) {
       // Cannot remove a global actor from a synchronous function.
-      if (!shouldAttemptFixes())
-        return getTypeMatchFailure(locator);
+      if (auto fixBehavior = getConcurrencyFixBehavior(false)) {
+        auto *fix = MarkGlobalActorFunction::create(
+            *this, func1, func2, getConstraintLocator(locator),
+            *fixBehavior);
 
-      auto *fix = MarkGlobalActorFunction::create(
-          *this, func1, func2, getConstraintLocator(locator),
-          getConcurrencyFixBehavior(false));
-
-      if (recordFix(fix))
+        if (recordFix(fix))
+          return getTypeMatchFailure(locator);
+      } else {
         return getTypeMatchFailure(locator);
+      }
     } else if (kind < ConstraintKind::Subtype) {
       return getTypeMatchFailure(locator);
     }

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -182,6 +182,8 @@ Solution ConstraintSystem::finalize() {
   solution.solutionApplicationTargets = solutionApplicationTargets;
   solution.caseLabelItems = caseLabelItems;
   solution.isolatedParams.append(isolatedParams.begin(), isolatedParams.end());
+  solution.preconcurrencyClosures.append(preconcurrencyClosures.begin(),
+                                         preconcurrencyClosures.end());
 
   for (const auto &transformed : resultBuilderTransformed) {
     solution.resultBuilderTransformed.insert(transformed);
@@ -293,6 +295,10 @@ void ConstraintSystem::applySolution(const Solution &solution) {
 
   for (auto param : solution.isolatedParams) {
     isolatedParams.insert(param);
+  }
+
+  for (auto closure : solution.preconcurrencyClosures) {
+    preconcurrencyClosures.insert(closure);
   }
 
   for (const auto &transformed : solution.resultBuilderTransformed) {
@@ -535,6 +541,7 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
   numSolutionApplicationTargets = cs.solutionApplicationTargets.size();
   numCaseLabelItems = cs.caseLabelItems.size();
   numIsolatedParams = cs.isolatedParams.size();
+  numPreconcurrencyClosures = cs.preconcurrencyClosures.size();
   numImplicitValueConversions = cs.ImplicitValueConversions.size();
   numArgumentLists = cs.ArgumentLists.size();
   numImplicitCallAsFunctionRoots = cs.ImplicitCallAsFunctionRoots.size();
@@ -645,6 +652,9 @@ ConstraintSystem::SolverScope::~SolverScope() {
 
   // Remove any isolated parameters.
   truncate(cs.isolatedParams, numIsolatedParams);
+
+  // Remove any preconcurrency closures.
+  truncate(cs.preconcurrencyClosures, numPreconcurrencyClosures);
 
   // Remove any implicit value conversions.
   truncate(cs.ImplicitValueConversions, numImplicitValueConversions);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4584,7 +4584,7 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
   // let's diagnose this as regular ambiguity.
   if (llvm::all_of(solutions, [](const Solution &solution) {
         return llvm::all_of(solution.Fixes, [](const ConstraintFix *fix) {
-          return fix->isWarning();
+          return fix->canApplySolution();
         });
       })) {
     return diagnoseAmbiguity(solutions);
@@ -4602,9 +4602,11 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
   llvm::SmallSetVector<FixInContext, 4> fixes;
   for (auto &solution : solutions) {
     for (auto *fix : solution.Fixes) {
+      // If the fix doesn't affect the solution score, it is not the
+      // source of ambiguity or failures.
       // Ignore warnings in favor of actual error fixes,
       // because they are not the source of ambiguity/failures.
-      if (fix->isWarning())
+      if (!fix->affectsSolutionScore())
         continue;
 
       fixes.insert({&solution, fix});

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -102,7 +102,8 @@ void checkOverrideActorIsolation(ValueDecl *value);
 /// code where strict checking has been enabled.
 bool contextRequiresStrictConcurrencyChecking(
     const DeclContext *dc,
-    llvm::function_ref<Type(const AbstractClosureExpr *)> getType);
+    llvm::function_ref<Type(const AbstractClosureExpr *)> getType,
+    llvm::function_ref<bool(const ClosureExpr *)> isolatedByPreconcurrency);
 
 /// Describes a referenced actor variable and whether it is isolated.
 struct ReferencedActor {
@@ -417,7 +418,8 @@ Type getExplicitGlobalActor(ClosureExpr *closure);
 /// Adjust the type of the variable for concurrency.
 Type adjustVarTypeForConcurrency(
     Type type, VarDecl *var, DeclContext *dc,
-    llvm::function_ref<Type(const AbstractClosureExpr *)> getType);
+    llvm::function_ref<Type(const AbstractClosureExpr *)> getType,
+    llvm::function_ref<bool(const ClosureExpr *)> isolatedByPreconcurrency);
 
 /// Adjust the given function type to account for concurrency-specific
 /// attributes whose affect on the type might differ based on context.
@@ -428,6 +430,7 @@ AnyFunctionType *adjustFunctionTypeForConcurrency(
     AnyFunctionType *fnType, ValueDecl *decl, DeclContext *dc,
     unsigned numApplies, bool isMainDispatchQueue,
     llvm::function_ref<Type(const AbstractClosureExpr *)> getType,
+    llvm::function_ref<bool(const ClosureExpr *)> isolatedByPreconcurrency,
     llvm::function_ref<Type(Type)> openType);
 
 /// Determine whether the given name is that of a DispatchQueue operation that

--- a/test/Concurrency/preconcurrency_overload.swift
+++ b/test/Concurrency/preconcurrency_overload.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+// REQUIRES: concurrency
+
+// https://github.com/apple/swift/issues/59909
+struct Future<T> { }
+
+extension Future {
+  @preconcurrency
+  func flatMap<NewValue>(_ callback: @escaping @Sendable (T) -> Future<NewValue>) -> Future<NewValue> { // #1
+    fatalError()
+  }
+}
+
+extension Future {
+  @available(*, deprecated, message: "")
+  func flatMap<NewValue>(file: StaticString = #file, line: UInt = #line, _ callback: @escaping (T) -> Future<NewValue>) -> Future<NewValue> { // #2
+    return self.flatMap(callback)
+  }
+}

--- a/test/Concurrency/preconcurrency_overload.swift
+++ b/test/Concurrency/preconcurrency_overload.swift
@@ -9,11 +9,22 @@ extension Future {
   func flatMap<NewValue>(_ callback: @escaping @Sendable (T) -> Future<NewValue>) -> Future<NewValue> { // #1
     fatalError()
   }
+
+  @preconcurrency
+  public func flatMapErrorThrowing(_ callback: @escaping @Sendable (Error) throws -> T) -> Future<T> {
+    fatalError("")
+  }
 }
 
 extension Future {
   @available(*, deprecated, message: "")
   func flatMap<NewValue>(file: StaticString = #file, line: UInt = #line, _ callback: @escaping (T) -> Future<NewValue>) -> Future<NewValue> { // #2
     return self.flatMap(callback)
+  }
+
+  @inlinable
+  @available(*, deprecated, message: "Please don't pass file:line:, there's no point.")
+  public func flatMapErrorThrowing(file: StaticString = #file, line: UInt = #line, _ callback: @escaping (Error) throws -> T) -> Future<T> {
+    return self.flatMapErrorThrowing(callback)
   }
 }


### PR DESCRIPTION
Rather than only setting the isolated-by-preconcurrency bit during
constraint application, track the closures it will be set for as part
of the constraint system and solution. Then, use that bit when
performing "strict concurrency context" checks and type adjustments,
so we don't treat an inferred-to-by-@Sendable-by-preconcurrency
closure in the solver as if it weren't related to preconcurrency.

Fixes the spurious warning from https://github.com/apple/swift/issues/59910.