### PR TITLE
[cxx-interop] NFC: fix bad merge

### DIFF
--- a/lib/ClangImporter/ClangIncludePaths.cpp
+++ b/lib/ClangImporter/ClangIncludePaths.cpp
@@ -91,6 +91,12 @@ getLibStdCxxModuleMapPath(SearchPathOptions &opts, const llvm::Triple &triple) {
   return getActualModuleMapPath("libstdcxx.modulemap", opts, triple);
 }
 
+Optional<SmallString<128>>
+swift::getCxxShimModuleMapPath(SearchPathOptions &opts,
+                               const llvm::Triple &triple) {
+  return getActualModuleMapPath("libcxxshim.modulemap", opts, triple);
+}
+
 static llvm::opt::InputArgList
 parseClangDriverArgs(const clang::driver::Driver &clangDriver,
                      const ArrayRef<const char *> args) {

--- a/lib/ClangImporter/ClangIncludePaths.h
+++ b/lib/ClangImporter/ClangIncludePaths.h
@@ -23,6 +23,9 @@ namespace swift {
 SmallVector<std::pair<std::string, std::string>, 2>
 getClangInvocationFileMapping(ASTContext &ctx);
 
+Optional<SmallString<128>> getCxxShimModuleMapPath(SearchPathOptions &opts,
+                                                   const llvm::Triple &triple);
+
 } // namespace swift
 
 #endif // SWIFT_CLANG_INCLUDE_PATHS_H


### PR DESCRIPTION
`getModuleMapFilePath` and related logic was moved to `ClangIncludePaths.cpp` recently, but got resurrected in `ClangImporter.cpp` by accident.
