### PR TITLE
Improve Diagnostics for Over-Constrained Protocol Types

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3762,7 +3762,8 @@ ERROR(protocol_declares_unknown_primary_assoc_type,none,
 ERROR(protocol_declares_duplicate_primary_assoc_type,none,
       "duplicate primary associated type name %0", (Identifier))
 ERROR(protocol_does_not_have_primary_assoc_type,none,
-      "cannot specialize protocol type %0", (Type))
+      "protocol %0 does not have primary associated types that can be "
+      "constrained", (Type))
 ERROR(parameterized_protocol_type_argument_count_mismatch,none,
       "protocol type %0 specialized with %select{too many|too few}3 type arguments "
       "(got %1, but expected %2)",

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -621,8 +621,12 @@ static Type applyGenericArguments(Type type, TypeResolution resolution,
     auto assocTypes = protoDecl->getPrimaryAssociatedTypes();
     if (assocTypes.empty()) {
       diags.diagnose(loc, diag::protocol_does_not_have_primary_assoc_type,
-                     protoType);
-
+                     protoType)
+           .fixItRemove(generic->getAngleBrackets());
+      if (!protoDecl->isImplicit()) {
+        diags.diagnose(protoDecl, diag::decl_declared_here,
+                       protoDecl->getName());
+      }
       return ErrorType::get(ctx);
     }
 

--- a/test/Generics/generic_types.swift
+++ b/test/Generics/generic_types.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift
 
-protocol MyFormattedPrintable {
+protocol MyFormattedPrintable { // expected-note 3 {{declared here}}
   func myFormat() -> String
 }
 
@@ -258,3 +258,10 @@ extension X8 where T == MetatypeTypeResolutionProto {
   static var property2: T.Type { property1 } // ok, still .Protocol
   static func method2() -> T.Type { method1() } // ok, still .Protocol
 }
+
+func bogusProtocolConstraint1(_ : any MyFormattedPrintable<String>) {}
+// expected-error@-1 {{protocol 'MyFormattedPrintable' does not have primary associated types that can be constrained}}{{59-67=}}
+func bogusProtocolConstraint2(_ : some MyFormattedPrintable<String>) {}
+// expected-error@-1 {{protocol 'MyFormattedPrintable' does not have primary associated types that can be constrained}}{{60-68=}}
+func bogusProtocolConstraint3(_ : MyFormattedPrintable<String>) {}
+// expected-error@-1 {{protocol 'MyFormattedPrintable' does not have primary associated types that can be constrained}}{{55-63=}}


### PR DESCRIPTION
Upgrade the diagnostic from one that mentions the restriction to one
that

1) Mentions primary associated types at all
2) Removes the constraints
3) Points at the declaration of the protocol type so the user can fix it