### PR TITLE
Remove Modeling for Fully-Generic Primary Associated Type Syntax

### DIFF
--- a/unittests/Syntax/DeclSyntaxTests.cpp
+++ b/unittests/Syntax/DeclSyntaxTests.cpp
@@ -652,7 +652,7 @@ TEST(DeclSyntaxTests, ProtocolMakeAPIs) {
     auto MyCollection = Factory.makeIdentifier("MyCollection", "", "");
     auto ElementName = Factory.makeIdentifier("Element", "", "");
     auto ElementParam =
-        Factory.makePrimaryAssociatedType(None, ElementName, None, None, None, None);
+        Factory.makePrimaryAssociatedType(ElementName, None);
     auto LeftAngle = Factory.makeLeftAngleToken("", "");
     auto RightAngle = Factory.makeRightAngleToken("", " ");
     auto PrimaryAssocs = PrimaryAssociatedTypeClauseSyntaxBuilder(Arena)

--- a/utils/gyb_syntax_support/GenericNodes.py
+++ b/utils/gyb_syntax_support/GenericNodes.py
@@ -67,20 +67,11 @@ GENERIC_NODES = [
     Node('PrimaryAssociatedTypeList', kind='SyntaxCollection',
          element='PrimaryAssociatedType'),
 
-    # primary-associated-type -> type-name
-    #                          | type-name (: type-identifier)? (= type)?
+    # primary-associated-type -> type-name ','?
     Node('PrimaryAssociatedType', kind='Syntax',
          traits=['WithTrailingComma'],
          children=[
-             Child('Attributes', kind='AttributeList',
-                   collection_element_name='Attribute', is_optional=True),
              Child('Name', kind='IdentifierToken'),
-             Child('Colon', kind='ColonToken',
-                   is_optional=True),
-             Child('InheritedType', kind='Type',
-                   is_optional=True),
-             Child('Initializer', kind='TypeInitializerClause',
-                   is_optional=True),
              Child('TrailingComma', kind='CommaToken',
                    is_optional=True),
          ]),


### PR DESCRIPTION
Constraints in these positions were not accepted. Remove the modeling
for them.