### PR TITLE
[rebranch] Remove now unused function

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -80,10 +80,6 @@ using llvm::BCBlockRAII;
 
 ASTContext &SerializerBase::getASTContext() const { return M->getASTContext(); }
 
-static StringRef withNullAsEmptyStringRef(const char *data) {
-  return StringRef(data ? data : "");
-}
-
 /// Used for static_assert.
 static constexpr bool declIDFitsIn32Bits() {
   using Int32Info = std::numeric_limits<uint32_t>;


### PR DESCRIPTION
No longer used since 427a689a966343a99b67ae81c7d1f31decfbe16b, where `StringRef` is now just used directly.