### PR TITLE
Clock measure functions should inherit the actor they are executed upon

### DIFF
--- a/stdlib/public/Concurrency/Clock.swift
+++ b/stdlib/public/Concurrency/Clock.swift
@@ -51,6 +51,7 @@ extension Clock {
   ///          someWork()
   ///       }
   @available(SwiftStdlib 5.7, *)
+  @_unsafeInheritExecutor
   public func measure(_ work: () throws -> Void) rethrows -> Instant.Duration {
     let start = now
     try work()
@@ -65,6 +66,7 @@ extension Clock {
   ///          await someWork()
   ///       }
   @available(SwiftStdlib 5.7, *)
+  @_unsafeInheritExecutor
   public func measure(
     _ work: () async throws -> Void
   ) async rethrows -> Instant.Duration {


### PR DESCRIPTION
Clock.measure can potentially claim incorrectly that the isolation is violated by the closure to be executed. These methods are directly executing the closure in the same context as the caller so they fall into the same rules as other usage of `@_unsafeInheritExecutor`.