### PR TITLE
[ConstraintSystem] Improve connected components printing in the type inference algorithm debug output

### DIFF
--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -546,8 +546,6 @@ public:
   }
 
   void dump(llvm::raw_ostream &out, unsigned indent) const;
-  void dump(TypeVariableType *typeVar, llvm::raw_ostream &out,
-            unsigned indent = 0) const LLVM_ATTRIBUTE_USED;
 
 private:
   void addBinding(PotentialBinding binding);

--- a/include/swift/Sema/ConstraintGraph.h
+++ b/include/swift/Sema/ConstraintGraph.h
@@ -387,6 +387,7 @@ public:
   /// Print the graph.
   void print(ArrayRef<TypeVariableType *> typeVars, llvm::raw_ostream &out);
   void dump(llvm::raw_ostream &out);
+  void dumpActiveScopeChanges(llvm::raw_ostream &out, unsigned indent = 0);
 
   // FIXME: Potentially side-effectful.
   SWIFT_DEBUG_HELPER(void dump());

--- a/include/swift/Sema/ConstraintGraph.h
+++ b/include/swift/Sema/ConstraintGraph.h
@@ -458,6 +458,7 @@ private:
   /// Each change can be undone (once, and in reverse order) by calling the
   /// undo() method.
   class Change {
+  public:
     /// The kind of change.
     ChangeKind Kind;
 
@@ -482,7 +483,6 @@ private:
       } Binding;
     };
 
-  public:
     Change() : Kind(ChangeKind::AddedTypeVariable), TypeVar(nullptr) { }
 
     /// Create a change that added a type variable.

--- a/include/swift/Sema/ConstraintGraphScope.h
+++ b/include/swift/Sema/ConstraintGraphScope.h
@@ -50,6 +50,11 @@ class ConstraintGraphScope {
 public:
   explicit ConstraintGraphScope(ConstraintGraph &CG);
   ~ConstraintGraphScope();
+  
+  /// Get number of changes recorded at the start of the current active scope.
+  unsigned getStartIdx() {
+    return NumChanges;
+  }
 };
 
 } // end namespace constraints

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5557,7 +5557,10 @@ public:
       Type wrapperType, Type paramType, ParamDecl *param, Identifier argLabel,
       ConstraintKind matchKind, ConstraintLocatorBuilder locator);
 
-  Optional<BindingSet> determineBestBindings();
+  /// Determine whether given type variable with its set of bindings is viable
+  /// to be attempted on the next step of the solver.
+  Optional<BindingSet> determineBestBindings(
+      llvm::function_ref<void(const BindingSet &)> onCandidate);
 
   /// Get bindings for the given type variable based on current
   /// state of the constraint system.

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -805,7 +805,7 @@ Optional<BindingSet> ConstraintSystem::determineBestBindings() {
       continue;
 
     if (isDebugMode()) {
-      bindings.dump(typeVar, llvm::errs(), solverState->getCurrentIndent());
+      bindings.dump(llvm::errs(), solverState->getCurrentIndent());
     }
 
     // If these are the first bindings, or they are better than what
@@ -1652,21 +1652,15 @@ static std::string getCollectionLiteralAsString(KnownProtocolKind KPK) {
 #undef ENTRY
 }
 
-void BindingSet::dump(TypeVariableType *typeVar, llvm::raw_ostream &out,
-                      unsigned indent) const {
-  out.indent(indent);
-  out << "(";
-  if (typeVar)
-    out << "$T" << typeVar->getImpl().getID();
-  dump(out, 1);
-  out << ")\n";
-}
-
 void BindingSet::dump(llvm::raw_ostream &out, unsigned indent) const {
   PrintOptions PO;
   PO.PrintTypesForDebugging = true;
 
   out.indent(indent);
+  out << "(";
+  if (auto typeVar = getTypeVariable())
+    out << "$T" << typeVar->getImpl().getID() << " ";
+  
   std::vector<std::string> attributes;
   if (isDirectHole())
     attributes.push_back("hole");
@@ -1778,6 +1772,7 @@ void BindingSet::dump(llvm::raw_ostream &out, unsigned indent) const {
     }
     out << "] ";
   }
+  out << ")\n";
 }
 
 // Given a possibly-Optional type, return the direct superclass of the

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -742,7 +742,8 @@ BindingSet::BindingScore BindingSet::formBindingScore(const BindingSet &b) {
                          -numNonDefaultableBindings);
 }
 
-Optional<BindingSet> ConstraintSystem::determineBestBindings() {
+Optional<BindingSet> ConstraintSystem::determineBestBindings(
+    llvm::function_ref<void(const BindingSet &)> onCandidate) {
   // Look for potential type variable bindings.
   Optional<BindingSet> bestBindings;
   llvm::SmallDenseMap<TypeVariableType *, BindingSet> cache;
@@ -804,9 +805,7 @@ Optional<BindingSet> ConstraintSystem::determineBestBindings() {
     if (!bindings || !isViable)
       continue;
 
-    if (isDebugMode()) {
-      bindings.dump(llvm::errs(), solverState->getCurrentIndent());
-    }
+    onCandidate(bindings);
 
     // If these are the first bindings, or they are better than what
     // we saw before, use them instead.

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -486,23 +486,6 @@ StepResult ComponentStep::finalize(bool isSuccess) {
 
 void TypeVariableStep::setup() {
   ++CS.solverState->NumTypeVariablesBound;
-  if (CS.isDebugMode()) {
-    PrintOptions PO;
-    PO.PrintTypesForDebugging = true;
-    auto &log = getDebugLogger();
-
-    auto initialBindings = Producer.getCurrentBindings();
-    log << "Initial bindings: ";
-    interleave(
-        initialBindings.begin(), initialBindings.end(),
-        [&](const Binding &binding) {
-          log << TypeVar->getString(PO)
-              << " := " << binding.BindingType->getString(PO);
-        },
-        [&log] { log << ", "; });
-
-    log << '\n';
-  }
 }
 
 bool TypeVariableStep::attempt(const TypeVariableBinding &choice) {

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -346,8 +346,31 @@ StepResult ComponentStep::take(bool prevFailed) {
 
   /// Try to figure out what this step is going to be,
   /// after the scope has been established.
-  auto *disjunction = CS.selectDisjunction();
   auto bestBindings = CS.determineBestBindings();
+  auto *disjunction = CS.selectDisjunction();
+  auto *conjunction = CS.selectConjunction();
+
+  if (CS.isDebugMode()) {
+    PrintOptions PO;
+    PO.PrintTypesForDebugging = true;
+
+    if (disjunction) {
+      auto &log = getDebugLogger();
+      log.indent(2);
+      log << "Disjunction(s) = [";
+      auto constraints = disjunction->getNestedConstraints();
+      log << constraints[0]->getFirstType()->getString(PO);
+      log << "])\n";
+    }
+    if (conjunction) {
+      auto &log = getDebugLogger();
+      log.indent(2);
+      log << "Conjunction(s) = [";
+      auto constraints = conjunction->getNestedConstraints();
+      log << constraints[0]->getFirstType()->getString(PO);
+      log << "])\n";
+    }
+  }
 
   if (CS.shouldAttemptFixes()) {
     if ((bestBindings &&

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -466,11 +466,29 @@ private:
     // to preliminary modify constraint system or log anything.
     if (IsSingle)
       return;
-
-    if (CS.isDebugMode())
-      getDebugLogger() << "(solving component #" << Index << '\n';
-
+    
+    if (CS.isDebugMode()) {
+      auto &log = getDebugLogger();
+      log << "(solving component #" << Index << '\n';
+    }
+    
     ComponentScope = std::make_unique<Scope>(*this);
+    
+    if (CS.isDebugMode()) {
+      auto &log = getDebugLogger();
+      log << "Type variables in scope = "
+          << "[";
+      auto typeVars = CS.getTypeVariables();
+      PrintOptions PO;
+      PO.PrintTypesForDebugging = true;
+      interleave(typeVars, [&](TypeVariableType *typeVar) {
+                   Type(typeVar).print(log, PO);
+                 },
+                 [&] {
+                   log << ", ";
+                 });
+      log << "]" << '\n';
+    }
 
     // If this component has orphaned constraint attached,
     // let's return it to the graph.

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -545,6 +545,13 @@ public:
         auto scope = std::make_unique<Scope>(CS);
         if (attempt(*choice)) {
           ActiveChoice.emplace(std::move(scope), *choice);
+
+          if (CS.isDebugMode()) {
+            auto &log = llvm::errs();
+            auto &CG = CS.getConstraintGraph();
+            CG.dumpActiveScopeChanges(log, CS.solverState->getCurrentIndent());
+          }
+          
           return suspend(std::make_unique<SplitterStep>(CS, Solutions));
         }
       }

--- a/test/Constraints/one_way_solve.swift
+++ b/test/Constraints/one_way_solve.swift
@@ -28,16 +28,16 @@ func testTernaryOneWayOverload(b: Bool) {
   // CHECK: 0: $T2 $T3 $T4
 
   // CHECK: solving component #1
-  // CHECK: Initial bindings: $T11 := Int8, $T11 := Int16
+  // CHECK: (attempting type variable $T11 := Int8
 
   // CHECK: solving component #1
-  // CHECK: Initial bindings: $T11 := Int8, $T11 := Int16
+  // CHECK: (attempting type variable $T11 := Int8
 
   // CHECK: solving component #1
-  // CHECK: Initial bindings: $T11 := Int8, $T11 := Int16
+  // CHECK: (attempting type variable $T11 := Int8
 
   // CHECK: solving component #1
-  // CHECK: Initial bindings: $T11 := Int8
+  // CHECK: (attempting type variable $T11 := Int8 
   // CHECK: (found solution: [non-default literal(s) = 2] [use of overloaded unapplied function(s) = 2])
 
   // CHECK: (composed solution: [non-default literal(s) = 2] [use of overloaded unapplied function(s) = 2])


### PR DESCRIPTION
The connected components will explicitly state the type variables currently in scope, their initial possible bindings, and the next type variable eligible for evaluation. Additionally, any new type variables, constraints or equivalence classes found, added, and removed as a result of the solver step attempt will be listed under a new section called `Changes`

For each component under evaluation, an `Current Bindings` section will present the initial type variable bindings and disjunctions/conjunctions. 

For example:

```
---Connected components---
  0: $T1 $T2 $T3 $T4
  1: $T5
    (solving component #1
      ($T5 bindings={(subtypes of) Int})
      Initial bindings: $T5 := Int
      (attempting type variable $T5 := Int
       ...
```
will now print as:

```
---Connected components---
  0: $T1 $T2 $T3 $T4
  1: $T5
    (solving component #1
      Type variables in scope = [$T5]
      (Current Binding: 
        ($T5 [with possible bindings: (subtypes of) Int])
      )
      (attempting type variable $T5 := Int
       ...
```

When a new type variable, equivalence class or constraint is removed or added during a solving attempt, a `Changes` section will present these updated type variables and constraints. For example:
```
 (attempting disjunction choice $T1 bound to decl Swift.(file).AdditiveArithmetic.+ : <Self where Self : AdditiveArithmetic> (Self.Type) -> (Self, Self) -> Self [[locator@0x13e0a0b98 [OverloadedDeclRef@/...]]];
          ...
          ($T2 [with possible bindings: (subtypes of) Int])
          ($T3 [attributes: [literal: string]] [with possible bindings: (subtypes of) Int])
          Initial bindings: $T2 := Int
          (attempting type variable $T2 := Int
         ... 
```

will now print the following `Changes`:
```
  (attempting disjunction choice $T1 bound to decl Swift.(file).AdditiveArithmetic.+ : <Self where Self : AdditiveArithmetic> (Self.Type) -> (Self, Self) -> Self [[locator@0x13b903798 [OverloadedDeclRef@/...]]];
          ...
          (Changes:
            (New Bound Type: 
              > $T1 := ($T7, $T7) -> $T7
              > $T7 := Int
            )
            (New Type Variable: 
              > $T7
            )
            (Added Constraint: 
              > $T2 transitive conformance to AdditiveArithmetic [[locator@0x13b933158 [OverloadedDeclRef@/... -> opened generic -> type parameter requirement #0 (conformance)]]];
              > $T2 operator arg conv $T7 [[locator@0x13b905e80 [Binary@/... -> apply argument -> comparing call argument #0 to parameter #0]]];
              > $T3 transitive conformance to AdditiveArithmetic [[locator@0x13b933158 [OverloadedDeclRef@/... -> opened generic -> type parameter requirement #0 (conformance)]]];
              > $T3 operator arg conv $T7 [[locator@0x13b905f20 [Binary@/... -> apply argument -> comparing call argument #1 to parameter #1]]];
            )
            (Removed Constraint: 
              > (_const $T2, _const $T3) -> $T4 applicable fn $T1 [[locator@0x13b905990 [Binary@/... -> apply function]]];
            )
          )
          (Current Bindings: 
            ($T2 [with possible bindings: (subtypes of) Int])
            ($T3 [attributes: [literal: string]] [with possible bindings: (subtypes of) Int])
          )
          (attempting type variable $T2 := Int
          ... 
```