### PR TITLE
Cleanup after recent refactoring for fix behaviors

### DIFF
--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -3025,8 +3025,10 @@ class AddExplicitExistentialCoercion final : public ConstraintFix {
   Type ErasedResultType;
 
   AddExplicitExistentialCoercion(ConstraintSystem &cs, Type erasedResultTy,
-                                 ConstraintLocator *locator)
-      : ConstraintFix(cs, FixKind::AddExplicitExistentialCoercion, locator),
+                                 ConstraintLocator *locator,
+                                 FixBehavior fixBehavior)
+      : ConstraintFix(cs, FixKind::AddExplicitExistentialCoercion, locator,
+                      fixBehavior),
         ErasedResultType(erasedResultTy) {}
 
 public:

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -411,10 +411,10 @@ class ConstraintFix {
   FixKind Kind;
   ConstraintLocator *Locator;
 
-  /// The behavior limit to apply to the diagnostics emitted.
-  FixBehavior fixBehavior;
-
 public:
+  /// The behavior limit to apply to the diagnostics emitted.
+  const FixBehavior fixBehavior;
+
   ConstraintFix(ConstraintSystem &cs, FixKind kind, ConstraintLocator *locator,
                 FixBehavior fixBehavior = FixBehavior::Error)
       : CS(cs), Kind(kind), Locator(locator), fixBehavior(fixBehavior) {}
@@ -444,10 +444,6 @@ public:
 
   /// Determine the impact of this fix on the solution score, if any.
   Optional<ScoreKind> impact() const;
-
-  /// The diagnostic behavior limit that will be applied to any emitted
-  /// diagnostics.
-  FixBehavior diagfixBehavior() const { return fixBehavior; }
 
   virtual std::string getName() const = 0;
 

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -442,9 +442,8 @@ public:
     }
   }
 
-  /// Whether this kind of fix affects the solution score, and which score
-  /// it affects.
-  Optional<ScoreKind> affectsSolutionScore() const;
+  /// Determine the impact of this fix on the solution score, if any.
+  Optional<ScoreKind> impact() const;
 
   /// The diagnostic behavior limit that will be applied to any emitted
   /// diagnostics.

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -428,17 +428,17 @@ public:
 
   FixKind getKind() const { return Kind; }
 
-  /// Whether it is still possible to "apply" a solution containing this kind
-  /// of fix to get a usable AST.
-  bool canApplySolution() const {
+  /// Whether this fix fatal for the constraint solver, meaning that it cannot
+  /// produce a usable type-checked AST.
+  bool isFatal() const {
     switch (fixBehavior) {
     case FixBehavior::AlwaysWarning:
     case FixBehavior::DowngradeToWarning:
     case FixBehavior::Suppress:
-      return true;
+      return false;
 
     case FixBehavior::Error:
-      return false;
+      return true;
     }
   }
 

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -799,6 +799,16 @@ public:
                                          Type rhs, ConstraintLocator *locator,
                                          FixBehavior fixBehavior);
 
+  /// Try to apply this fix to the given types.
+  ///
+  /// \returns \c true if the fix cannot be applied and the solver must fail,
+  /// or \c false if the fix has been applied and the solver can continue.
+  static bool attempt(ConstraintSystem &cs,
+                      ConstraintKind constraintKind,
+                      FunctionType *fromType,
+                      FunctionType *toType,
+                      ConstraintLocatorBuilder locator);
+
   static bool classof(ConstraintFix *fix) {
     return fix->getKind() == FixKind::MarkGlobalActorFunction;
   }
@@ -849,6 +859,16 @@ public:
                                       FunctionType *toType,
                                       ConstraintLocator *locator,
                                       FixBehavior fixBehavior);
+
+  /// Try to apply this fix to the given types.
+  ///
+  /// \returns \c true if the fix cannot be applied and the solver must fail,
+  /// or \c false if the fix has been applied and the solver can continue.
+  static bool attempt(ConstraintSystem &cs,
+                      ConstraintKind constraintKind,
+                      FunctionType *fromType,
+                      FunctionType *toType,
+                      ConstraintLocatorBuilder locator);
 
   static bool classof(ConstraintFix *fix) {
     return fix->getKind() == FixKind::AddSendableAttribute;

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3820,6 +3820,10 @@ public:
         });
   }
 
+  /// Determine whether the callee for the given locator is marked as
+  /// `@preconcurrency`.
+  bool hasPreconcurrencyCallee(ConstraintLocatorBuilder locator);
+
   /// Determine whether the given declaration is unavailable from the
   /// current context.
   bool isDeclUnavailable(const Decl *D,

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -9129,7 +9129,7 @@ Optional<SolutionApplicationTarget> ConstraintSystem::applySolution(
     for (const auto fix : solution.Fixes) {
       if (fix->isFatal())
         canApplySolution = false;
-      if (fix->affectsSolutionScore() == SK_Fix && !fix->isFatal())
+      if (fix->impact() == SK_Fix && !fix->isFatal())
         ++numResolvableFixes;
     }
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8467,7 +8467,7 @@ bool ConstraintSystem::applySolutionFixes(const Solution &solution) {
 
         auto diagnosed =
             primaryFix->coalesceAndDiagnose(solution, secondaryFixes);
-        if (primaryFix->canApplySolution()) {
+        if (!primaryFix->isFatal()) {
           assert(diagnosed && "warnings should always be diagnosed");
           (void)diagnosed;
         } else {
@@ -9127,9 +9127,9 @@ Optional<SolutionApplicationTarget> ConstraintSystem::applySolution(
     bool diagnosedErrorsViaFixes = applySolutionFixes(solution);
     bool canApplySolution = true;
     for (const auto fix : solution.Fixes) {
-      if (!fix->canApplySolution())
+      if (fix->isFatal())
         canApplySolution = false;
-      if (fix->affectsSolutionScore() == SK_Fix && fix->canApplySolution())
+      if (fix->affectsSolutionScore() == SK_Fix && !fix->isFatal())
         ++numResolvableFixes;
     }
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2749,8 +2749,9 @@ class MissingExplicitExistentialCoercion final : public FailureDiagnostic {
 public:
   MissingExplicitExistentialCoercion(const Solution &solution,
                                      Type erasedResultTy,
-                                     ConstraintLocator *locator)
-      : FailureDiagnostic(solution, locator),
+                                     ConstraintLocator *locator,
+                                     FixBehavior fixBehavior)
+      : FailureDiagnostic(solution, locator, fixBehavior),
         ErasedResultType(resolveType(erasedResultTy)) {}
 
   SourceRange getSourceRange() const override {

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -243,7 +243,7 @@ MarkExplicitlyEscaping::create(ConstraintSystem &cs, Type lhs, Type rhs,
 bool MarkGlobalActorFunction::diagnose(const Solution &solution,
                                        bool asNote) const {
   DroppedGlobalActorFunctionAttr failure(
-      solution, getFromType(), getToType(), getLocator(), diagfixBehavior());
+      solution, getFromType(), getToType(), getLocator(), fixBehavior);
   return failure.diagnose(asNote);
 }
 
@@ -263,7 +263,7 @@ bool AddSendableAttribute::diagnose(const Solution &solution,
                                       bool asNote) const {
   AttributedFuncToTypeConversionFailure failure(
       solution, getFromType(), getToType(), getLocator(),
-      AttributedFuncToTypeConversionFailure::Concurrent, diagfixBehavior());
+      AttributedFuncToTypeConversionFailure::Concurrent, fixBehavior);
   return failure.diagnose(asNote);
 }
 
@@ -1639,7 +1639,7 @@ bool TreatEphemeralAsNonEphemeral::diagnose(const Solution &solution,
                                             bool asNote) const {
   NonEphemeralConversionFailure failure(solution, getLocator(), getFromType(),
                                         getToType(), ConversionKind,
-                                        diagfixBehavior());
+                                        fixBehavior);
   return failure.diagnose(asNote);
 }
 
@@ -2233,7 +2233,7 @@ IgnoreDefaultExprTypeMismatch::create(ConstraintSystem &cs, Type argType,
 bool AddExplicitExistentialCoercion::diagnose(const Solution &solution,
                                               bool asNote) const {
   MissingExplicitExistentialCoercion failure(solution, ErasedResultType,
-                                             getLocator(), diagfixBehavior());
+                                             getLocator(), fixBehavior);
   return failure.diagnose(asNote);
 }
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -37,7 +37,7 @@ using namespace constraints;
 
 ConstraintFix::~ConstraintFix() {}
 
-Optional<ScoreKind> ConstraintFix::affectsSolutionScore() const {
+Optional<ScoreKind> ConstraintFix::impact() const {
   switch (fixBehavior) {
   case FixBehavior::AlwaysWarning:
     return None;

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2233,7 +2233,7 @@ IgnoreDefaultExprTypeMismatch::create(ConstraintSystem &cs, Type argType,
 bool AddExplicitExistentialCoercion::diagnose(const Solution &solution,
                                               bool asNote) const {
   MissingExplicitExistentialCoercion failure(solution, ErasedResultType,
-                                             getLocator());
+                                             getLocator(), diagfixBehavior());
   return failure.diagnose(asNote);
 }
 
@@ -2465,8 +2465,9 @@ bool AddExplicitExistentialCoercion::isRequired(
 AddExplicitExistentialCoercion *
 AddExplicitExistentialCoercion::create(ConstraintSystem &cs, Type resultTy,
                                        ConstraintLocator *locator) {
+  FixBehavior fixBehavior = FixBehavior::Error;
   return new (cs.getAllocator())
-      AddExplicitExistentialCoercion(cs, resultTy, locator);
+      AddExplicitExistentialCoercion(cs, resultTy, locator, fixBehavior);
 }
 
 bool RenameConflictingPatternVariables::diagnose(const Solution &solution,

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -12711,8 +12711,8 @@ bool ConstraintSystem::recordFix(ConstraintFix *fix, unsigned impact) {
   // Record the fix.
 
   // If this should affect the solution score, do so.
-  if (auto scoreKind = fix->affectsSolutionScore())
-    increaseScore(*scoreKind, impact);
+  if (auto impactScoreKind = fix->impact())
+    increaseScore(*impactScoreKind, impact);
 
   // If we've made the current solution worse than the best solution we've seen
   // already, stop now.
@@ -12735,7 +12735,7 @@ bool ConstraintSystem::recordFix(ConstraintFix *fix, unsigned impact) {
     // Fixes that don't affect the score shouldn't be considered because even
     // if such a fix is recorded at that anchor this should not
     // have any affect in the recording of any other fix.
-    if (!fix->affectsSolutionScore())
+    if (!fix->impact())
       continue;
 
     anchors.insert(fix->getAnchor());

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4616,7 +4616,7 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
   // let's diagnose this as regular ambiguity.
   if (llvm::all_of(solutions, [](const Solution &solution) {
         return llvm::all_of(solution.Fixes, [](const ConstraintFix *fix) {
-          return fix->canApplySolution();
+          return !fix->isFatal();
         });
       })) {
     return diagnoseAmbiguity(solutions);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4638,7 +4638,7 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
       // source of ambiguity or failures.
       // Ignore warnings in favor of actual error fixes,
       // because they are not the source of ambiguity/failures.
-      if (!fix->affectsSolutionScore())
+      if (!fix->impact())
         continue;
 
       fixes.insert({&solution, fix});


### PR DESCRIPTION
Address commentary from https://github.com/apple/swift/pull/59958:
* Rename a few `ConstraintFix` functions to make them more understandable
* Sink logic for when to add a fix for concurrency-related issues down into `attempt` functions on the fixes