### PR TITLE
tell CTest to print on failure for cmark tests

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/cmake_product.py
+++ b/utils/swift_build_support/swift_build_support/products/cmake_product.py
@@ -85,7 +85,7 @@ class CMakeProduct(product.Product):
                        + build_args + build_targets)
 
     def test_with_cmake(self, executable_target, results_targets,
-                        build_type, build_args):
+                        build_type, build_args, test_env=None):
         assert self.toolchain.cmake is not None
         cmake_build = []
 
@@ -110,6 +110,7 @@ class CMakeProduct(product.Product):
         if executable_target:
             shell.call(cmake_build + target_flag(executable_target))
 
+
         for target in results_targets:
             if target:
                 test_target = target
@@ -117,7 +118,9 @@ class CMakeProduct(product.Product):
                 if test_target.startswith("check-swift") and self.args.test_paths:
                     test_target = test_target + "-custom"
 
-                shell.call(cmake_build + target_flag(test_target))
+                # note that passing variables via test_env won't affect lit tests - lit.cfg will
+                # filter environment variables out!
+                shell.call(cmake_build + target_flag(test_target), env=test_env)
 
                 print("--- %s finished ---" % target)
 

--- a/utils/swift_build_support/swift_build_support/products/cmake_product.py
+++ b/utils/swift_build_support/swift_build_support/products/cmake_product.py
@@ -110,7 +110,6 @@ class CMakeProduct(product.Product):
         if executable_target:
             shell.call(cmake_build + target_flag(executable_target))
 
-
         for target in results_targets:
             if target:
                 test_target = target
@@ -118,8 +117,8 @@ class CMakeProduct(product.Product):
                 if test_target.startswith("check-swift") and self.args.test_paths:
                     test_target = test_target + "-custom"
 
-                # note that passing variables via test_env won't affect lit tests - lit.cfg will
-                # filter environment variables out!
+                # note that passing variables via test_env won't affect lit tests -
+                # lit.cfg will filter environment variables out!
                 shell.call(cmake_build + target_flag(test_target), env=test_env)
 
                 print("--- %s finished ---" % target)

--- a/utils/swift_build_support/swift_build_support/products/cmark.py
+++ b/utils/swift_build_support/swift_build_support/products/cmark.py
@@ -99,13 +99,10 @@ class CMark(cmake_product.CMakeProduct):
             "CTEST_OUTPUT_ON_FAILURE": "ON"
         }
 
-        # The environment is passed with pushenv to avoid giving a general
-        # mechanism for test environments - this is because lit.cfg filters out
-        # environment variables. However, since `test_with_cmake` calls cmake
-        # (and thus ctest) directly, we can pass the environment along like this.
-        with shell.pushenv(test_env):
-            self.test_with_cmake(executable_target, results_targets,
-                                 self.args.cmark_build_variant, [])
+        # see the comment in cmake_product.py if you want to copy this code to pass environment
+        # variables to tests
+        self.test_with_cmake(executable_target, results_targets,
+                             self.args.cmark_build_variant, [], test_env)
 
     def should_install(self, host_target):
         """should_install() -> Bool

--- a/utils/swift_build_support/swift_build_support/products/cmark.py
+++ b/utils/swift_build_support/swift_build_support/products/cmark.py
@@ -12,6 +12,7 @@
 
 from . import cmake_product
 from . import earlyswiftdriver
+from .. import shell
 
 
 class CMark(cmake_product.CMakeProduct):
@@ -94,8 +95,17 @@ class CMark(cmake_product.CMakeProduct):
             # Xcode generator uses "RUN_TESTS" instead of "test".
             results_targets = ['RUN_TESTS']
 
-        self.test_with_cmake(executable_target, results_targets,
-                             self.args.cmark_build_variant, [])
+        test_env = {
+            "CTEST_OUTPUT_ON_FAILURE": "ON"
+        }
+
+        # The environment is passed with pushenv to avoid giving a general
+        # mechanism for test environments - this is because lit.cfg filters out
+        # environment variables. However, since `test_with_cmake` calls cmake
+        # (and thus ctest) directly, we can pass the environment along like this.
+        with shell.pushenv(test_env):
+            self.test_with_cmake(executable_target, results_targets,
+                                 self.args.cmark_build_variant, [])
 
     def should_install(self, host_target):
         """should_install() -> Bool

--- a/utils/swift_build_support/swift_build_support/products/cmark.py
+++ b/utils/swift_build_support/swift_build_support/products/cmark.py
@@ -12,7 +12,6 @@
 
 from . import cmake_product
 from . import earlyswiftdriver
-from .. import shell
 
 
 class CMark(cmake_product.CMakeProduct):
@@ -99,8 +98,8 @@ class CMark(cmake_product.CMakeProduct):
             "CTEST_OUTPUT_ON_FAILURE": "ON"
         }
 
-        # see the comment in cmake_product.py if you want to copy this code to pass environment
-        # variables to tests
+        # see the comment in cmake_product.py if you want to copy this code to pass
+        # environment variables to tests
         self.test_with_cmake(executable_target, results_targets,
                              self.args.cmark_build_variant, [], test_env)
 

--- a/utils/swift_build_support/swift_build_support/shell.py
+++ b/utils/swift_build_support/swift_build_support/shell.py
@@ -162,29 +162,6 @@ def pushd(path, dry_run=None, echo=True):
     if not dry_run:
         os.chdir(old_dir)
 
-@contextmanager
-def pushenv(env, dry_run=None, echo=True):
-    saved_env = {}
-    for name in env.keys():
-        if dry_run or echo:
-            _echo_command(dry_run, ['export', name + '=' + env[name]])
-        if not dry_run:
-            if name in os.environ:
-                saved_env[name] = os.environ[name]
-            os.environ[name] = env[name]
-    yield
-    for name in env.keys():
-        if name in saved_env:
-            if dry_run or echo:
-                _echo_command(dry_run, ['export', name + '=' + saved_env[name]])
-            if not dry_run:
-                os.environ[name] = saved_env[name]
-        else:
-            if dry_run or echo:
-                _echo_command(dry_run, ['unset', name])
-            if not dry_run:
-                del os.environ[name]
-
 
 def makedirs(path, dry_run=None, echo=True):
     dry_run = _coerce_dry_run(dry_run)

--- a/utils/swift_build_support/swift_build_support/shell.py
+++ b/utils/swift_build_support/swift_build_support/shell.py
@@ -162,6 +162,29 @@ def pushd(path, dry_run=None, echo=True):
     if not dry_run:
         os.chdir(old_dir)
 
+@contextmanager
+def pushenv(env, dry_run=None, echo=True):
+    saved_env = {}
+    for name in env.keys():
+        if dry_run or echo:
+            _echo_command(dry_run, ['export', name + '=' + env[name]])
+        if not dry_run:
+            if name in os.environ:
+                saved_env[name] = os.environ[name]
+            os.environ[name] = env[name]
+    yield
+    for name in env.keys():
+        if name in saved_env:
+            if dry_run or echo:
+                _echo_command(dry_run, ['export', name + '=' + saved_env[name]])
+            if not dry_run:
+                os.environ[name] = saved_env[name]
+        else:
+            if dry_run or echo:
+                _echo_command(dry_run, ['unset', name])
+            if not dry_run:
+                del os.environ[name]
+
 
 def makedirs(path, dry_run=None, echo=True):
     dry_run = _coerce_dry_run(dry_run)


### PR DESCRIPTION
So that rdar://96543740 can be more easily investigated, this PR updates the build system to print the test log if a cmark test fails, to make the CI console display what went wrong.