### PR TITLE
Make Initializer Clause of Optional Pattern Binding Optional

### DIFF
--- a/utils/gyb_syntax_support/StmtNodes.py
+++ b/utils/gyb_syntax_support/StmtNodes.py
@@ -236,7 +236,8 @@ STMT_NODES = [
              Child('Pattern', kind='Pattern'),
              Child('TypeAnnotation', kind='TypeAnnotation',
                    is_optional=True),
-             Child('Initializer', kind='InitializerClause'),
+             Child('Initializer', kind='InitializerClause',
+                   is_optional=True),
          ]),
 
     # unavailability-condition -> '#unavailable' '(' availability-spec ')'


### PR DESCRIPTION
Make Initializer Clause of Optional Pattern Binding Optional

See [SE-0345](https://github.com/apple/swift-evolution/blob/main/proposals/0345-if-let-shorthand.md)
"'if let' shorthand for shadowing an existing optional variable"