### PR TITLE
[Sema] Track implicit tuple expr use for closure empty return to improve diagnostic location

### DIFF
--- a/test/Constraints/callAsFunction.swift
+++ b/test/Constraints/callAsFunction.swift
@@ -83,7 +83,7 @@ struct Test {
   var body8: MyLayout {
     MyLayout {
       let x = ""
-      return x // expected-error {{cannot convert return expression of type 'String' to return type 'Int'}}
+      return x // expected-error {{cannot convert value of type 'String' to closure result type 'Int'}}
     } content: {
       EmptyView()
     }

--- a/test/decl/circularity.swift
+++ b/test/decl/circularity.swift
@@ -41,7 +41,7 @@ class Sub: Base {
     var foo = { () -> Int in
         let x = 42
         // FIXME: Bogus diagnostic
-        return foo(1) // expected-error {{cannot convert return expression of type '()' to return type 'Int'}}
+        return foo(1) // expected-error {{cannot convert value of type '()' to closure result type 'Int'}}
     }()
 }
 

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -690,7 +690,7 @@ func testSR13239_ArgsFn() -> Int {
 func testSR13239MultiExpr() -> Int {
   callit {
     print("hello") 
-    return print("hello") // expected-error {{cannot convert return expression of type '()' to return type 'Int'}}
+    return print("hello") // expected-error {{cannot convert value of type '()' to closure result type 'Int'}}
   }
 }
 
@@ -732,3 +732,21 @@ public class TestImplicitCaptureOfExplicitCaptureOfSelfInEscapingClosure {
         }
     }
 }
+
+// https://github.com/apple/swift/issues/59716
+["foo"].map { s in
+    if s == "1" { return } // expected-error{{cannot convert value of type '()' to closure result type 'Bool'}}
+    return s.isEmpty
+}.filter { $0 }
+
+["foo"].map { s in
+    if s == "1" { return } // expected-error{{cannot convert value of type '()' to closure result type 'Bool'}}
+    if s == "2" { return }
+    if s == "3" { return }
+    return s.isEmpty
+}.filter { $0 }
+
+["foo"].map { s in
+    if s == "1" { return () } // expected-error{{cannot convert value of type '()' to closure result type 'Bool'}}
+    return s.isEmpty
+}.filter { $0 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
The problem here is the anchor expr in which the fix is recorded is an implicit  empty tuple expression which means no valid source location.

This PR track the return statement associated with an implicit tuple expression used to type check empty return as `Void` in closure to be able to produce diagnostics with better source location. Couldn't think in another approach for this, the information is somewhat tracked in `solutionApplicationTargets` but not really accessible and it didn't felt correct to rely on it for this in specific, so this seemed like a simpler way to improve this.  

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Fixes #59716

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
