### PR TITLE
[CS] Remove assertion that callee locator has an anchor

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -481,8 +481,6 @@ ConstraintLocator *ConstraintSystem::getCalleeLocator(
     }
   }
 
-  assert(bool(anchor) && "Expected an anchor!");
-
   {
     // If we have a locator for a member found through key path dynamic member
     // lookup, then we need to chop off the elements after the

--- a/validation-test/IDE/crashers_2_fixed/0036-callee-locator-with-null-anchor.swift
+++ b/validation-test/IDE/crashers_2_fixed/0036-callee-locator-with-null-anchor.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-ide-test --code-completion --code-completion-token COMPLETE --source-filename %s | %FileCheck %s
+
+func foo(completionHandler completion: (@Sendable (Bool) -> Void)? = nil) {}
+
+func test() {
+  foo(completionHandler: #^COMPLETE^#nil)
+}
+
+// CHECK: Begin completions
+// CHECK-DAG: Literal[Nil]/None/TypeRelation[Convertible]: nil[#(@Sendable (Bool) -> Void)?#];
+// CHECK: End completions


### PR DESCRIPTION
When computing type relations of code completion items with respect to the context they are used in, we add a `ConstraintKind::Conversion` constraint with an empty constraint locator. 
https://github.com/apple/swift/blob/99ee194482d6f5a26c8e95ae5dca9e47db07ad78/lib/Sema/TypeCheckConstraints.cpp#L1022
This currently crashes in `hasPreconcurrencyCallee`.

To fix this crash, just return `false` in these cases.

This fixes a crash found by the SourceKit stress tester that was introduced by https://github.com/apple/swift/pull/59958.