### PR TITLE
[cxx-interop] Enable a test on Windows

### DIFF
--- a/test/Interop/Cxx/stdlib/overlay/custom-sequence-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-sequence-typechecker.swift
@@ -1,6 +1,4 @@
 // RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop
-//
-// REQUIRES: OS=macosx || OS=linux-gnu
 
 import CustomSequence
 import Cxx


### PR DESCRIPTION
The `Cxx` module is present on all platforms, so we can enable at least the typechecker test unconditionally.