### PR TITLE
[Index] Ignore internal conformances in serialized modules

### DIFF
--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -1158,7 +1158,7 @@ bool IndexSwiftASTWalker::handleWitnesses(Decl *D, SmallVectorImpl<IndexedWitnes
 
     // Ignore self-conformances; they're not interesting to show to users.
     auto normal = dyn_cast<NormalProtocolConformance>(conf->getRootConformance());
-    if (!normal)
+    if (!normal || !shouldIndex(normal->getProtocol(), /*IsRef=*/true))
       continue;
 
     normal->forEachValueWitness([&](ValueDecl *req, Witness witness) {


### PR DESCRIPTION
The index should not output any internal conformances from a serialized
module. Ideally these wouldn't be returned at all, but that can be
addressed in a later patch.

Resolves rdar://95460636.