### PR TITLE
[SymbolGraphGen] emit USRs for primary associated types in DeclarationFragmentPrinter

### DIFF
--- a/lib/SymbolGraphGen/DeclarationFragmentPrinter.cpp
+++ b/lib/SymbolGraphGen/DeclarationFragmentPrinter.cpp
@@ -148,7 +148,7 @@ void DeclarationFragmentPrinter::printTypeRef(Type T, const TypeDecl *RefTo,
       }
     }
 
-    if (T->isTypeParameter()) {
+    if (T->isTypeParameter() && T->getKind() != TypeKind::DependentMember) {
       ShouldLink = false;
     }
   }

--- a/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/PrimaryAssocType.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/PrimaryAssocType.swift
@@ -1,0 +1,36 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name PrimaryAssocType -emit-module -emit-module-path %t/
+// RUN: %target-swift-symbolgraph-extract -module-name PrimaryAssocType -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/PrimaryAssocType.symbols.json
+
+public protocol WithPrimary<Assoc> {
+    associatedtype Assoc
+}
+
+// CHECK-LABEL: "precise": "s:16PrimaryAssocType04WithA0P"
+// CHECK:           "declarationFragments": [
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "kind": "keyword",
+// CHECK-NEXT:          "spelling": "protocol"
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "kind": "text",
+// CHECK-NEXT:          "spelling": " "
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "kind": "identifier",
+// CHECK-NEXT:          "spelling": "WithPrimary"
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "kind": "text",
+// CHECK-NEXT:          "spelling": "<"
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "kind": "typeIdentifier",
+// CHECK-NEXT:          "spelling": "Assoc"
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "kind": "text",
+// CHECK-NEXT:          "spelling": ">"
+// CHECK-NEXT:        }
+// CHECK-NEXT:      ],

--- a/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/PrimaryAssocType.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/PrimaryAssocType.swift
@@ -10,27 +10,28 @@ public protocol WithPrimary<Assoc> {
 // CHECK-LABEL: "precise": "s:16PrimaryAssocType04WithA0P"
 // CHECK:           "declarationFragments": [
 // CHECK-NEXT:        {
-// CHECK-NEXT:          "kind": "keyword",
+// CHECK-NEXT:          "kind": "keyword"
 // CHECK-NEXT:          "spelling": "protocol"
-// CHECK-NEXT:        },
+// CHECK-NEXT:        }
 // CHECK-NEXT:        {
-// CHECK-NEXT:          "kind": "text",
+// CHECK-NEXT:          "kind": "text"
 // CHECK-NEXT:          "spelling": " "
-// CHECK-NEXT:        },
+// CHECK-NEXT:        }
 // CHECK-NEXT:        {
-// CHECK-NEXT:          "kind": "identifier",
+// CHECK-NEXT:          "kind": "identifier"
 // CHECK-NEXT:          "spelling": "WithPrimary"
-// CHECK-NEXT:        },
+// CHECK-NEXT:        }
 // CHECK-NEXT:        {
-// CHECK-NEXT:          "kind": "text",
+// CHECK-NEXT:          "kind": "text"
 // CHECK-NEXT:          "spelling": "<"
-// CHECK-NEXT:        },
+// CHECK-NEXT:        }
 // CHECK-NEXT:        {
-// CHECK-NEXT:          "kind": "typeIdentifier",
+// CHECK-NEXT:          "kind": "typeIdentifier"
 // CHECK-NEXT:          "spelling": "Assoc"
-// CHECK-NEXT:        },
+// CHECK-NEXT:          "preciseIdentifier": "s:16PrimaryAssocType04WithA0P0B0Qa"
+// CHECK-NEXT:        }
 // CHECK-NEXT:        {
-// CHECK-NEXT:          "kind": "text",
+// CHECK-NEXT:          "kind": "text"
 // CHECK-NEXT:          "spelling": ">"
 // CHECK-NEXT:        }
-// CHECK-NEXT:      ],
+// CHECK-NEXT:      ]


### PR DESCRIPTION
This is a follow-up from https://github.com/apple/swift/pull/58973, which adds a SymbolGraph test to match the SourceKit tests added there. It also updates the declaration fragments printer to emit the USR for primary associated types, even though they're being printed as a type parameter.