### PR TITLE
[Sema] Report exported uses of conformances that are implicitly imported

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2922,7 +2922,8 @@ ERROR(conformance_from_implementation_only_module,none,
       "in an extension with conditional conformances}2; "
       "%select{%3 has been imported as implementation-only|"
       "the conformance is declared as SPI in %3|"
-      "the conformance is declared as SPI}4",
+      "the conformance is declared as SPI|"
+      "%3 was not imported by this file}4",
       (Type, Identifier, unsigned, Identifier, unsigned))
 NOTE(assoc_conformance_from_implementation_only_module,none,
      "in associated type %0 (inferred as %1)", (Type, Type))

--- a/test/Sema/implicit-import-in-inlinable-code.swift
+++ b/test/Sema/implicit-import-in-inlinable-code.swift
@@ -23,12 +23,18 @@ public struct ImportedType {
     public init() {}
 }
 
+// Test exportability of conformance uses
+public protocol SomeProtocol {}
+public func conformanceUse(_ a: SomeProtocol) {}
+
 // BEGIN libB.swift
 import libA
 
 extension ImportedType {
     public func implicitlyImportedMethod() {}
 }
+
+extension ImportedType : SomeProtocol {}
 
 /// Client module
 // BEGIN clientFileA-Swift5.swift
@@ -40,6 +46,8 @@ import libA
 
   // Expected implicit imports are still fine
   a.localModuleMethod()
+
+  conformanceUse(a) // expected-warning {{cannot use conformance of 'ImportedType' to 'SomeProtocol' here; 'libB' was not imported by this file; this is an error in Swift 6}}
 }
 
 // BEGIN clientFileA-OldCheck.swift
@@ -52,6 +60,8 @@ import libA
 
   // Expected implicit imports are still fine
   a.localModuleMethod()
+
+  conformanceUse(a) // expected-warning {{cannot use conformance of 'ImportedType' to 'SomeProtocol' here; 'libB' was not imported by this file; this is an error in Swift 6}}
 }
 
 // BEGIN clientFileA-Swift6.swift
@@ -63,6 +73,8 @@ import libA
 
   // Expected implicit imports are still fine
   a.localModuleMethod()
+
+  conformanceUse(a) // expected-error {{cannot use conformance of 'ImportedType' to 'SomeProtocol' here; 'libB' was not imported by this file}}
 }
 
 // BEGIN clientFileB.swift


### PR DESCRIPTION
Diagnose uses of conformances in API when the conformance declaration isn't imported by the local file. This uses the existing logic checking for conformance availability combined with the implicit import check, we just needed to update the diagnostic select block. Report it as a warning until Swift 6 where it will be an error.

rdar://96437311