### PR TITLE
[IRGen] Look through opaque types for protocol witness table lazy access function.

### DIFF
--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -765,7 +765,13 @@ SILLinkage LinkEntity::getLinkage(ForDefinition_t forDefinition) const {
 
   case Kind::ProtocolWitnessTableLazyAccessFunction:
   case Kind::ProtocolWitnessTableLazyCacheVariable: {
-    auto *nominal = getType().getAnyNominal();
+    auto ty = getType();
+    ValueDecl *nominal = nullptr;
+    if (auto *otat = ty->getAs<OpaqueTypeArchetypeType>()) {
+      nominal = otat->getDecl();
+    } else {
+      nominal = ty->getAnyNominal();
+    }
     assert(nominal);
     if (getDeclLinkage(nominal) == FormalLinkage::Private ||
         getLinkageAsConformance() == SILLinkage::Private) {

--- a/validation-test/compiler_crashers_fixed/rdar96194366.swift
+++ b/validation-test/compiler_crashers_fixed/rdar96194366.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -target %target-cpu-apple-macosx10.15 -swift-version 5 -c %s
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+import SwiftUI
+
+struct DropDestinationCoordinatorView: NSViewRepresentable {
+	func makeNSView(context: Context) -> some NSView {
+    return NSView()
+	}
+	
+	func updateNSView(_ nsView: NSViewType, context: Context) {
+		print("for view:  \(nsView)")
+	}
+}
+


### PR DESCRIPTION
When determining the linkage of protocol witness table lazy access functions and their cache variables, look through opaque types to find the underlying decls.

rdar://96194366