### PR TITLE
[IRGen] Emit opaque type descriptors into client for `@_alwaysEmitI…

### DIFF
--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1450,6 +1450,10 @@ public:
   void emitClassDecl(ClassDecl *D);
   void emitExtension(ExtensionDecl *D);
   void emitOpaqueTypeDecl(OpaqueTypeDecl *D);
+  /// This method does additional checking vs. \c emitOpaqueTypeDecl
+  /// based on the state and flags associated with the module.
+  void maybeEmitOpaqueTypeDecl(OpaqueTypeDecl *D);
+
   void emitSILGlobalVariable(SILGlobalVariable *gv);
   void emitCoverageMapping();
   void emitSILFunction(SILFunction *f);
@@ -1772,7 +1776,6 @@ private:
 
   void emitLazyPrivateDefinitions();
   void addRuntimeResolvableType(GenericTypeDecl *nominal);
-  void maybeEmitOpaqueTypeDecl(OpaqueTypeDecl *opaque);
 
   /// Add all conformances of the given \c IterableDeclContext
   /// LazyWitnessTables.

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2231,6 +2231,22 @@ void IRGenSILFunction::emitSILFunction() {
   if (CurSILFn->getDynamicallyReplacedFunction())
     IGM.IRGen.addDynamicReplacement(CurSILFn);
 
+  if (CurSILFn->getLinkage() == SILLinkage::Shared) {
+    if (auto *V = CurSILFn->getLocation().getAsASTNode<ValueDecl>()) {
+      bool alwaysEmitIntoClient =
+          V->getAttrs().hasAttribute<AlwaysEmitIntoClientAttr>();
+      auto *opaqueResult = V->getOpaqueResultTypeDecl();
+      // `@_alwaysEmitIntoClient` declaration with opaque result
+      // has to emit opaque type descriptor into client module
+      // when it has availability conditions because the underlying
+      // type in such cases is unknown until runtime.
+      if (alwaysEmitIntoClient && opaqueResult &&
+          opaqueResult->hasConditionallyAvailableSubstitutions()) {
+        IGM.maybeEmitOpaqueTypeDecl(opaqueResult);
+      }
+    }
+  }
+
   auto funcTy = CurSILFn->getLoweredFunctionType();
   bool isAsyncFn = funcTy->isAsync();
   if (isAsyncFn && funcTy->getLanguage() == SILFunctionLanguage::Swift) {

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -723,6 +723,23 @@ SILLinkage LinkEntity::getLinkage(ForDefinition_t forDefinition) const {
     return getSILLinkage(getDeclLinkage(getterDecl), forDefinition);
   }
 
+  case Kind::OpaqueTypeDescriptor: {
+    auto *opaqueType = cast<OpaqueTypeDecl>(getDecl());
+
+    // The opaque result type descriptor with availability conditions
+    // has to be emitted into a client module when associated with
+    // `@_alwaysInlineIntoClient` declaration which means it's linkage
+    // has to be "shared".
+    if (opaqueType->hasConditionallyAvailableSubstitutions()) {
+      if (auto *srcDecl = opaqueType->getNamingDecl()) {
+        if (srcDecl->getAttrs().hasAttribute<AlwaysEmitIntoClientAttr>())
+          return SILLinkage::Shared;
+      }
+    }
+
+    return getSILLinkage(getDeclLinkage(opaqueType), forDefinition);
+  }
+
   case Kind::AssociatedConformanceDescriptor:
   case Kind::BaseConformanceDescriptor:
   case Kind::ObjCClass:
@@ -735,7 +752,6 @@ SILLinkage LinkEntity::getLinkage(ForDefinition_t forDefinition) const {
   case Kind::ProtocolDescriptorRecord:
   case Kind::ProtocolRequirementsBaseDescriptor:
   case Kind::MethodLookupFunction:
-  case Kind::OpaqueTypeDescriptor:
   case Kind::OpaqueTypeDescriptorRecord:
   case Kind::OpaqueTypeDescriptorAccessor:
   case Kind::OpaqueTypeDescriptorAccessorImpl:

--- a/test/IRGen/Inputs/AlwaysInlineIntoWithOpaque.swift
+++ b/test/IRGen/Inputs/AlwaysInlineIntoWithOpaque.swift
@@ -1,0 +1,16 @@
+public protocol P {
+}
+
+extension Int : P {
+}
+
+extension Double : P {
+}
+
+@_alwaysEmitIntoClient
+public func testInlineWithOpaque() -> some P {
+  if #available(macOS 9.0, *) {
+    return 1
+  }
+  return 2.0
+}

--- a/test/IRGen/Inputs/AlwaysInlineIntoWithOpaqueReplacement.swift
+++ b/test/IRGen/Inputs/AlwaysInlineIntoWithOpaqueReplacement.swift
@@ -1,0 +1,8 @@
+public protocol P {
+}
+
+extension Int : P {
+}
+
+extension Double : P {
+}

--- a/test/IRGen/opaque_result_alwaysInlineIntoClient.swift
+++ b/test/IRGen/opaque_result_alwaysInlineIntoClient.swift
@@ -1,0 +1,20 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 -parse-as-library -emit-library -emit-module-path %t/AlwaysInlineIntoWithOpaque.swiftmodule -module-name AlwaysInlineIntoWithOpaque %S/Inputs/AlwaysInlineIntoWithOpaque.swift -o %t/%target-library-name(AlwaysInlineIntoWithOpaque)
+// RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 -lAlwaysInlineIntoWithOpaque -module-name main -I %t -L %t %s -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 -parse-as-library -emit-library -emit-module-path %t/AlwaysInlineIntoWithOpaque.swiftmodule -module-name AlwaysInlineIntoWithOpaque %S/Inputs/AlwaysInlineIntoWithOpaqueReplacement.swift -o %t/%target-library-name(AlwaysInlineIntoWithOpaque)
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: OS=macosx && (CPU=x86_64 || CPU=arm64)
+// REQUIRES: executable_test
+
+import AlwaysInlineIntoWithOpaque
+
+public func test() {
+  let p = testInlineWithOpaque()
+  print(p)
+}
+
+test()
+// CHECK: 1


### PR DESCRIPTION
…ntoClient` decls

If opaque result type has availability conditions and is associated with
an `@_alwaysEmitIntoClient` declaration, its metadata descriptor has to
be emitted into a client module because the body of the inlined function
depends on it for the runtime information about the underlying type.

Resolves: rdar://82791712


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
