### PR TITLE
[5.7][ASTPrinter] Don't desugar typealiases in existential types.

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -156,7 +156,6 @@ PrintOptions PrintOptions::printSwiftInterfaceFile(ModuleDecl *ModuleToPrint,
       PrintOptions::FunctionRepresentationMode::Full;
   result.AlwaysTryPrintParameterLabels = true;
   result.PrintSPIs = printSPIs;
-  result.DesugarExistentialConstraint = true;
 
   // We should print __consuming, __owned, etc for the module interface file.
   result.SkipUnderscoredKeywords = false;

--- a/test/ModuleInterface/existential-any.swift
+++ b/test/ModuleInterface/existential-any.swift
@@ -44,5 +44,10 @@ public protocol ProtocolTypealias {
   typealias A = P
 }
 
-// CHECK: public func dependentExistential<T>(value: (T) -> main.P) where T : main.ProtocolTypealias
+// CHECK: public func dependentExistential<T>(value: (T) -> T.A) where T : main.ProtocolTypealias
 public func dependentExistential<T: ProtocolTypealias>(value: (T) -> T.A) {}
+
+public typealias Composition = ProtocolTypealias & P
+
+// CHECK: public func optionalComposition(value: main.Composition?)
+public func optionalComposition(value: Composition?) {}


### PR DESCRIPTION
This effectively reverts https://github.com/apple/swift/pull/59077, which only exhibits the correct behavior when the `any` keyword is also printed. Without the `any` keyword, existential types aren't correctly parenthesized.

Resolves: rdar://96845685