### PR TITLE
[build] Ignore .git in ninja copy

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/ninja.py
+++ b/utils/swift_build_support/swift_build_support/products/ninja.py
@@ -77,7 +77,7 @@ class NinjaBuilder(product.ProductBuilder):
         # Ninja can only be built in-tree.  Copy the source tree to the build
         # directory.
         shell.rmtree(self.build_dir)
-        shell.copytree(self.source_dir, self.build_dir)
+        shell.copytree(self.source_dir, self.build_dir, ignore_pattern=".git")
         with shell.pushd(self.build_dir):
             shell.call([sys.executable, 'configure.py', '--bootstrap'],
                        env=env)

--- a/utils/swift_build_support/swift_build_support/shell.py
+++ b/utils/swift_build_support/swift_build_support/shell.py
@@ -183,13 +183,14 @@ def rmtree(path, dry_run=None, echo=True):
         shutil.rmtree(path)
 
 
-def copytree(src, dest, dry_run=None, echo=True):
+def copytree(src, dest, dry_run=None, ignore_pattern=None, echo=True):
     dry_run = _coerce_dry_run(dry_run)
     if dry_run or echo:
         _echo_command(dry_run, ['cp', '-r', src, dest])
     if dry_run:
         return
-    shutil.copytree(src, dest)
+    ignore = shutil.ignore_patterns(ignore_pattern) if ignore_pattern else None
+    shutil.copytree(src, dest, ignore=ignore)
 
 
 def symlink(source, dest, dry_run=None, echo=True):


### PR DESCRIPTION
As part of the build the entire ninja source dir is copied to the build
dir and then built. When using git's fsmonitor feature the .git
directory contains a socket which causes the copytree to fail. With this
change .git is ignored entirely instead. Error:

```
Traceback (most recent call last):
  ...
  File "/Users/ksmiley/dev/oss-swift/swift/utils/swift_build_support/swift_build_support/build_script_invocation.py", line 69, in build_ninja
    ninja_build.build()
  File "/Users/ksmiley/dev/oss-swift/swift/utils/swift_build_support/swift_build_support/products/ninja.py", line 80, in build
    shell.copytree(self.source_dir, self.build_dir)
  File "/Users/ksmiley/dev/oss-swift/swift/utils/swift_build_support/swift_build_support/shell.py", line 193, in copytree
    shutil.copytree(src, dest)
  File "/Users/ksmiley/.pyenv/versions/3.10.2/lib/python3.10/shutil.py", line 556, in copytree
    return _copytree(entries=entries, src=src, dst=dst, symlinks=symlinks,
  File "/Users/ksmiley/.pyenv/versions/3.10.2/lib/python3.10/shutil.py", line 512, in _copytree
    raise Error(errors)
shutil.Error: [('/Users/ksmiley/dev/oss-swift/ninja/.git/fsmonitor--daemon.ipc', '/Users/ksmiley/dev/oss-swift/build/buildbot_osx/ninja-build/.git/fsmonitor--daemon.ipc', "[Errno 102] Operation not supported on socket: '/Users/ksmiley/dev/oss-swift/ninja/.git/fsmonitor--daemon.ipc'")]
```