### PR TITLE
[cxx-interop][SwiftCompilerSources] Use `DiagnosticInfo::FixIt` instead of `BridgedDiagnosticFixIt`

### DIFF
--- a/SwiftCompilerSources/Sources/AST/DiagnosticEngine.swift
+++ b/SwiftCompilerSources/Sources/AST/DiagnosticEngine.swift
@@ -50,12 +50,12 @@ public struct DiagnosticFixIt {
     self.text = text
   }
 
-  func withBridgedDiagnosticFixIt(_ fn: (BridgedDiagnosticFixIt) -> Void) {
+  func withBridgedDiagnosticFixIt(_ fn: (swift.DiagnosticInfo.FixIt) -> Void) {
     text.withBridgedStringRef { bridgedTextRef in
-      let bridgedDiagnosticFixIt = BridgedDiagnosticFixIt(
-        start: start.bridged,
-        byteLength: byteLength,
-        text: bridgedTextRef)
+      let bridgedDiagnosticFixIt = swift.DiagnosticInfo.FixIt(
+        swift.CharSourceRange(start.bridged, UInt32(byteLength)),
+        llvm.StringRef(bridgedTextRef),
+        llvm.ArrayRef<swift.DiagnosticArgument>())
       fn(bridgedDiagnosticFixIt)
     }
   }
@@ -83,7 +83,7 @@ public struct DiagnosticEngine {
     let bridgedSourceLoc: swift.SourceLoc = position.bridged
     let bridgedHighlightRange: swift.CharSourceRange = highlight.bridged
     var bridgedArgs: [BridgedDiagnosticArgument] = []
-    var bridgedFixIts: [BridgedDiagnosticFixIt] = []
+    var bridgedFixIts: [swift.DiagnosticInfo.FixIt] = []
 
     // Build a higher-order function to wrap every 'withBridgedXXX { ... }'
     // calls, so we don't escape anything from the closure. 'bridgedArgs' and

--- a/SwiftCompilerSources/Sources/Basic/Utils.swift
+++ b/SwiftCompilerSources/Sources/Basic/Utils.swift
@@ -48,6 +48,12 @@ extension BridgedStringRef {
   }
 }
 
+extension llvm.StringRef {
+  public init(_ bridged: BridgedStringRef) {
+    self.init(bridged.data, bridged.length)
+  }
+}
+
 extension String {
   public func withBridgedStringRef<T>(_ c: (BridgedStringRef) -> T) -> T {
     var str = self

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -52,12 +52,6 @@ typedef struct {
 } BridgedDiagnosticArgument;
 
 typedef struct {
-  swift::SourceLoc start;
-  SwiftInt byteLength;
-  BridgedStringRef text;
-} BridgedDiagnosticFixIt;
-
-typedef struct {
   void * _Nonnull object;
 } BridgedDiagnosticEngine;
 

--- a/include/swift/module.modulemap
+++ b/include/swift/module.modulemap
@@ -6,6 +6,9 @@ module BasicBridging {
 
 module ASTBridging {
   header "AST/ASTBridging.h"
+  header "AST/DiagnosticEngine.h"
+  header "AST/DiagnosticConsumer.h"
+  requires cplusplus
   export *
 }
 

--- a/lib/AST/ASTBridging.cpp
+++ b/lib/AST/ASTBridging.cpp
@@ -42,7 +42,7 @@ void DiagnosticEngine_diagnose(
     BridgedDiagID bridgedDiagID,
     BridgedArrayRef /*BridgedDiagnosticArgument*/ bridgedArguments,
     CharSourceRange highlight,
-    BridgedArrayRef /*BridgedDiagnosticFixIt*/ bridgedFixIts) {
+    BridgedArrayRef /*DiagnosticInfo::FixIt*/ bridgedFixIts) {
   auto *D = getDiagnosticEngine(bridgedEngine);
 
   auto diagID = static_cast<DiagID>(bridgedDiagID);
@@ -59,10 +59,9 @@ void DiagnosticEngine_diagnose(
   }
 
   // Add fix-its.
-  for (auto bridgedFixIt : getArrayRef<BridgedDiagnosticFixIt>(bridgedFixIts)) {
-    auto range = CharSourceRange(bridgedFixIt.start,
-                                 bridgedFixIt.byteLength);
-    auto text = getStringRef(bridgedFixIt.text);
+  for (auto bridgedFixIt : getArrayRef<DiagnosticInfo::FixIt>(bridgedFixIts)) {
+    auto range = bridgedFixIt.getRange();
+    auto text = bridgedFixIt.getText();
     inflight.fixItReplaceChars(range.getStart(), range.getEnd(), text);
   }
 }


### PR DESCRIPTION
This removes some of the bridging code and replaces it with C++ calls.

rdar://83361087