### PR TITLE
[build] Remove verbose-build from toolchain builds

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1241,7 +1241,6 @@ cross-compile-hosts=macosx-arm64
 
 lldb-use-system-debugserver
 lldb-build-type=Release
-verbose-build
 build-ninja
 build-swift-stdlib-unittest-extra
 


### PR DESCRIPTION
This creates a lot of noise in failed builds where the error gets hidden
in long command lines. Folks can pass `-v` manually if they want this
locally