### PR TITLE
[5.7] SILGen: Fix potential use-after-free in `@_backDeploy` coroutines

### DIFF
--- a/lib/SILGen/SILGenBackDeploy.cpp
+++ b/lib/SILGen/SILGenBackDeploy.cpp
@@ -108,15 +108,16 @@ static void emitBackDeployForwardApplyAndReturnOrThrow(
       rawResults.push_back(result);
 
     auto token = rawResults.pop_back_val();
-    SGF.B.createEndApply(loc, token);
     SGF.B.createYield(loc, rawResults, resumeBB, unwindBB);
 
     // Emit resume block.
     SGF.B.emitBlock(resumeBB);
+    SGF.B.createEndApply(loc, token);
     SGF.B.createBranch(loc, SGF.ReturnDest.getBlock());
 
     // Emit unwind block.
     SGF.B.emitBlock(unwindBB);
+    SGF.B.createEndApply(loc, token);
     SGF.B.createBranch(loc, SGF.CoroutineUnwindDest.getBlock());
     return;
   }

--- a/test/SILGen/back_deploy_attribute_accessor_coroutine.swift
+++ b/test/SILGen/back_deploy_attribute_accessor_coroutine.swift
@@ -32,25 +32,27 @@ public struct TopLevelStruct {
   // CHECK: [[UNAVAIL_BB]]:
   // CHECK:   [[FALLBACKFN:%.*]] = function_ref @$s11back_deploy14TopLevelStructV8propertyACvrTwB : $@yield_once @convention(method) (TopLevelStruct) -> @yields TopLevelStruct
   // CHECK:   ([[YIELD_RES:%.*]], [[YIELD_TOK:%.*]]) = begin_apply [[FALLBACKFN]]([[BB0_ARG]]) : $@yield_once @convention(method) (TopLevelStruct) -> @yields TopLevelStruct
-  // CHECK:   end_apply [[YIELD_TOK]]
   // CHECK:   yield [[YIELD_RES]] : $TopLevelStruct, resume [[UNAVAIL_RESUME_BB:bb[0-9]+]], unwind [[UNAVAIL_UNWIND_BB:bb[0-9]+]]
   //
   // CHECK: [[UNAVAIL_UNWIND_BB]]:
+  // CHECK:   end_apply [[YIELD_TOK]]
   // CHECK:   br [[UNWIND_BB:bb[0-9]+]]
   //
   // CHECK: [[UNAVAIL_RESUME_BB]]:
+  // CHECK:   end_apply [[YIELD_TOK]]
   // CHECK:   br [[RETURN_BB:bb[0-9]+]]
   //
   // CHECK: [[AVAIL_BB]]:
   // CHECK:   [[ORIGFN:%.*]] = function_ref @$s11back_deploy14TopLevelStructV8propertyACvr : $@yield_once @convention(method) (TopLevelStruct) -> @yields TopLevelStruct
   // CHECK:   ([[YIELD_RES:%.*]], [[YIELD_TOK:%.*]]) = begin_apply [[ORIGFN]]([[BB0_ARG]]) : $@yield_once @convention(method) (TopLevelStruct) -> @yields TopLevelStruct
-  // CHECK:   end_apply [[YIELD_TOK]]
   // CHECK:   yield [[YIELD_RES]] : $TopLevelStruct, resume [[AVAIL_RESUME_BB:bb[0-9]+]], unwind [[UAVAIL_UNWIND_BB:bb[0-9]+]]
   //
   // CHECK: [[UAVAIL_UNWIND_BB]]:
+  // CHECK:   end_apply [[YIELD_TOK]]
   // CHECK:   br [[UNWIND_BB]]
   //
   // CHECK: [[AVAIL_RESUME_BB]]:
+  // CHECK:   end_apply [[YIELD_TOK]]
   // CHECK:   br [[RETURN_BB]]
   //
   // CHECK: [[RETURN_BB]]:


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/60021

The SIL verifier has identified an issue with the SIL generated for property accessors structured like this:

```
public struct S {
  @available(macOS, introduced: 12.0)
  @_backDeploy(before: macOS 13.0)
  public var x: String {
    _read {
      yield "x"
    }
  }
}
```

The emitted SIL is invalid because the value `%9` is used after `end_apply` may have ended the lifetime of the value:

```
bb1:
  %8 = function_ref @$s4test1SV1xSSvrTwB : $@yield_once @convention(method) (S) -> @yields @guaranteed String9
  (%9, %10) = begin_apply %8(%0) : $@yield_once @convention(method) (S) -> @yields @guaranteed String
  end_apply %10
  yield %9 : $String, resume bb3, unwind bb2
```

The fix is to move the `end_apply` to the resume and unwind blocks, after the value has been yielded to the caller.

Resolves rdar://96879247
