### PR TITLE
[build] Add swift-autolink-extract to macOS toolchains

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -18,7 +18,7 @@ swift-install-components=back-deployment;compiler;clang-builtin-headers;stdlib;s
 
 [preset: mixin_buildbot_install_components_with_clang]
 
-swift-install-components=back-deployment;compiler;clang-resource-dir-symlink;stdlib;sdk-overlay;parser-lib;static-mirror-lib;toolchain-tools;license;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers
+swift-install-components=autolink-driver;back-deployment;compiler;clang-resource-dir-symlink;stdlib;sdk-overlay;parser-lib;static-mirror-lib;toolchain-tools;license;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers
 llvm-install-components=llvm-cov;llvm-profdata;IndexStore;clang;clang-resource-headers;compiler-rt;clangd;dsymutil;LTO;clang-features-file
 
 [preset: mixin_buildbot_trunk_base]


### PR DESCRIPTION
Including this symlink makes it easier to cross compile for Linux which
requires use of this tool.