### PR TITLE
[stdlib] fix unaligned loads of large SIMD vectors on x86_64

### DIFF
--- a/stdlib/public/core/StringUTF16View.swift
+++ b/stdlib/public/core/StringUTF16View.swift
@@ -597,11 +597,11 @@ extension String.UTF16View {
     
     while readPtr + MemoryLayout<U>.stride < endPtr {
       //Find the number of continuations (0b10xxxxxx)
-      let sValue = Builtin.loadRaw(readPtr._rawValue) as S
+      let sValue = readPtr.loadUnaligned(as: S.self)
       let continuations = S.zero.replacing(with: S.one, where: sValue .< -65 + 1)
             
       //Find the number of 4 byte code points (0b11110xxx)
-      let uValue = Builtin.loadRaw(readPtr._rawValue) as U
+      let uValue = readPtr.loadUnaligned(as: U.self)
       let fourBytes = S.zero.replacing(
         with: S.one,
         where: unsafeBitCast(

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -244,7 +244,7 @@ public struct UnsafeRawPointer: _Pointer {
   /// - Parameter other: The typed pointer to convert.
   @_transparent
   public init<T>(@_nonEphemeral _ other: UnsafeMutablePointer<T>) {
-   _rawValue = other._rawValue
+    _rawValue = other._rawValue
   }
 
   /// Creates a new raw pointer from the given typed pointer.
@@ -257,8 +257,8 @@ public struct UnsafeRawPointer: _Pointer {
   ///   result is `nil`.
   @_transparent
   public init?<T>(@_nonEphemeral _ other: UnsafeMutablePointer<T>?) {
-   guard let unwrapped = other else { return nil }
-   _rawValue = unwrapped._rawValue
+    guard let unwrapped = other else { return nil }
+    _rawValue = unwrapped._rawValue
   }
 
   /// Deallocates the previously allocated memory block referenced by this pointer.
@@ -429,7 +429,7 @@ public struct UnsafeRawPointer: _Pointer {
                               MemoryLayout<T>.alignment._builtinWordValue)
     return Builtin.loadRaw(alignedPointer)
 #else
-  return Builtin.loadRaw(rawPointer)
+    return Builtin.loadRaw(rawPointer)
 #endif
   }
 

--- a/test/stdlib/UnsafeRawPointer.swift
+++ b/test/stdlib/UnsafeRawPointer.swift
@@ -114,6 +114,35 @@ UnsafeMutableRawPointerExtraTestSuite.test("load.unaligned")
   expectEqual(result, 0xffff_0000)
 }
 
+UnsafeMutableRawPointerExtraTestSuite.test("load.unaligned.SIMD")
+.skip(.custom({
+  if #available(SwiftStdlib 5.7, *) { return false }
+  return true
+}, reason: "Requires Swift 5.7's stdlib"))
+.code {
+  guard #available(SwiftStdlib 5.7, *) else { return }
+  var bytes: [UInt8] = Array(0..<64)
+  var offset = 3
+  let vector16 = bytes.withUnsafeBytes { buffer -> SIMD16<UInt8> in
+    let aligned = buffer.baseAddress!.alignedUp(for: SIMD16<UInt8>.self)
+    offset += buffer.baseAddress!.distance(to: aligned)
+    return buffer.loadUnaligned(fromByteOffset: offset, as: SIMD16<UInt8>.self)
+  }
+  expectEqual(Int(vector16[0]), offset)
+  var lastIndex = vector16.indices.last!
+  expectEqual(Int(vector16[lastIndex]), offset+lastIndex)
+
+  offset = 11
+  let vector32 = bytes.withUnsafeMutableBytes { buffer -> SIMD32<UInt8> in
+    let aligned = buffer.baseAddress!.alignedUp(for: SIMD16<UInt8>.self)
+    offset += buffer.baseAddress!.distance(to: aligned)
+    return buffer.loadUnaligned(fromByteOffset: offset, as: SIMD32<UInt8>.self)
+  }
+  expectEqual(Int(vector32[0]), offset)
+  lastIndex = vector32.indices.last!
+  expectEqual(Int(vector32[lastIndex]), offset+lastIndex)
+}
+
 UnsafeMutableRawPointerExtraTestSuite.test("load.invalid")
 .skip(.custom({ !_isDebugAssertConfiguration() },
               reason: "This tests a debug precondition.."))

--- a/test/stdlib/UnsafeRawPointer.swift
+++ b/test/stdlib/UnsafeRawPointer.swift
@@ -134,7 +134,7 @@ UnsafeMutableRawPointerExtraTestSuite.test("load.unaligned.SIMD")
 
   offset = 11
   let vector32 = bytes.withUnsafeMutableBytes { buffer -> SIMD32<UInt8> in
-    let aligned = buffer.baseAddress!.alignedUp(for: SIMD16<UInt8>.self)
+    let aligned = buffer.baseAddress!.alignedUp(for: SIMD32<UInt8>.self)
     offset += buffer.baseAddress!.distance(to: aligned)
     return buffer.loadUnaligned(fromByteOffset: offset, as: SIMD32<UInt8>.self)
   }


### PR DESCRIPTION
Unaligned loads of SIMD vectors with alignment larger than 8 was failing on Intel platforms. This implements a library-level workaround until a compiler correction can be validated.

Resolves rdar://96841899.
