### PR TITLE
[5.7][IRGen] Emit opaque type descriptors into client for `@_alwaysEmitI…

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -1121,6 +1121,32 @@ public:
     return false;
   }
 
+  /// Returns true if this function belongs to a declaration that
+  /// has `@_alwaysEmitIntoClient` attribute.
+  bool markedAsAlwaysEmitIntoClient() const {
+    if (!hasLocation())
+      return false;
+
+    auto *V = getLocation().getAsASTNode<ValueDecl>();
+    return V && V->getAttrs().hasAttribute<AlwaysEmitIntoClientAttr>();
+  }
+
+  /// Returns true if this function belongs to a declaration that returns
+  /// an opaque result type with one or more availability conditions that are
+  /// allowed to produce a different underlying type at runtime.
+  bool hasOpaqueResultTypeWithAvailabilityConditions() const {
+    if (!hasLocation())
+      return false;
+
+    if (auto *V = getLocation().getAsASTNode<ValueDecl>()) {
+      auto *opaqueResult = V->getOpaqueResultTypeDecl();
+      return opaqueResult &&
+             opaqueResult->hasConditionallyAvailableSubstitutions();
+    }
+
+    return false;
+  }
+
   //===--------------------------------------------------------------------===//
   // Block List Access
   //===--------------------------------------------------------------------===//

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1442,6 +1442,10 @@ public:
   void emitClassDecl(ClassDecl *D);
   void emitExtension(ExtensionDecl *D);
   void emitOpaqueTypeDecl(OpaqueTypeDecl *D);
+  /// This method does additional checking vs. \c emitOpaqueTypeDecl
+  /// based on the state and flags associated with the module.
+  void maybeEmitOpaqueTypeDecl(OpaqueTypeDecl *D);
+
   void emitSILGlobalVariable(SILGlobalVariable *gv);
   void emitCoverageMapping();
   void emitSILFunction(SILFunction *f);
@@ -1764,7 +1768,6 @@ private:
 
   void emitLazyPrivateDefinitions();
   void addRuntimeResolvableType(GenericTypeDecl *nominal);
-  void maybeEmitOpaqueTypeDecl(OpaqueTypeDecl *opaque);
 
   /// Add all conformances of the given \c IterableDeclContext
   /// LazyWitnessTables.

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2221,18 +2221,15 @@ void IRGenSILFunction::emitSILFunction() {
     IGM.IRGen.addDynamicReplacement(CurSILFn);
 
   if (CurSILFn->getLinkage() == SILLinkage::Shared) {
-    if (auto *V = CurSILFn->getLocation().getAsASTNode<ValueDecl>()) {
-      bool alwaysEmitIntoClient =
-          V->getAttrs().hasAttribute<AlwaysEmitIntoClientAttr>();
+    if (CurSILFn->markedAsAlwaysEmitIntoClient() &&
+        CurSILFn->hasOpaqueResultTypeWithAvailabilityConditions()) {
+      auto *V = CurSILFn->getLocation().castToASTNode<ValueDecl>();
       auto *opaqueResult = V->getOpaqueResultTypeDecl();
       // `@_alwaysEmitIntoClient` declaration with opaque result
       // has to emit opaque type descriptor into client module
       // when it has availability conditions because the underlying
       // type in such cases is unknown until runtime.
-      if (alwaysEmitIntoClient && opaqueResult &&
-          opaqueResult->hasConditionallyAvailableSubstitutions()) {
-        IGM.maybeEmitOpaqueTypeDecl(opaqueResult);
-      }
+      IGM.maybeEmitOpaqueTypeDecl(opaqueResult);
     }
   }
 

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2220,6 +2220,22 @@ void IRGenSILFunction::emitSILFunction() {
   if (CurSILFn->getDynamicallyReplacedFunction())
     IGM.IRGen.addDynamicReplacement(CurSILFn);
 
+  if (CurSILFn->getLinkage() == SILLinkage::Shared) {
+    if (auto *V = CurSILFn->getLocation().getAsASTNode<ValueDecl>()) {
+      bool alwaysEmitIntoClient =
+          V->getAttrs().hasAttribute<AlwaysEmitIntoClientAttr>();
+      auto *opaqueResult = V->getOpaqueResultTypeDecl();
+      // `@_alwaysEmitIntoClient` declaration with opaque result
+      // has to emit opaque type descriptor into client module
+      // when it has availability conditions because the underlying
+      // type in such cases is unknown until runtime.
+      if (alwaysEmitIntoClient && opaqueResult &&
+          opaqueResult->hasConditionallyAvailableSubstitutions()) {
+        IGM.maybeEmitOpaqueTypeDecl(opaqueResult);
+      }
+    }
+  }
+
   auto funcTy = CurSILFn->getLoweredFunctionType();
   bool isAsyncFn = funcTy->isAsync();
   if (isAsyncFn && funcTy->getLanguage() == SILFunctionLanguage::Swift) {

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -704,6 +704,13 @@ SILFunction::isPossiblyUsedExternally() const {
   if (isDistributed() && isThunk())
     return true;
 
+  // Declaration marked as `@_alwaysEmitIntoClient` that
+  // returns opaque result type with availability conditions
+  // has to be kept alive to emit opaque type metadata descriptor.
+  if (markedAsAlwaysEmitIntoClient() &&
+      hasOpaqueResultTypeWithAvailabilityConditions())
+    return true;
+
   return swift::isPossiblyUsedExternally(linkage, getModule().isWholeModule());
 }
 

--- a/test/IRGen/Inputs/AlwaysInlineIntoWithOpaque.swift
+++ b/test/IRGen/Inputs/AlwaysInlineIntoWithOpaque.swift
@@ -1,0 +1,16 @@
+public protocol P {
+}
+
+extension Int : P {
+}
+
+extension Double : P {
+}
+
+@_alwaysEmitIntoClient
+public func testInlineWithOpaque() -> some P {
+  if #available(macOS 9.0, *) {
+    return 1
+  }
+  return 2.0
+}

--- a/test/IRGen/Inputs/AlwaysInlineIntoWithOpaqueReplacement.swift
+++ b/test/IRGen/Inputs/AlwaysInlineIntoWithOpaqueReplacement.swift
@@ -1,0 +1,8 @@
+public protocol P {
+}
+
+extension Int : P {
+}
+
+extension Double : P {
+}

--- a/test/IRGen/opaque_result_alwaysInlineIntoClient.swift
+++ b/test/IRGen/opaque_result_alwaysInlineIntoClient.swift
@@ -1,0 +1,20 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 -parse-as-library -emit-library -emit-module-path %t/AlwaysInlineIntoWithOpaque.swiftmodule -module-name AlwaysInlineIntoWithOpaque %S/Inputs/AlwaysInlineIntoWithOpaque.swift -o %t/%target-library-name(AlwaysInlineIntoWithOpaque)
+// RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 -lAlwaysInlineIntoWithOpaque -module-name main -I %t -L %t %s -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 -parse-as-library -emit-library -emit-module-path %t/AlwaysInlineIntoWithOpaque.swiftmodule -module-name AlwaysInlineIntoWithOpaque %S/Inputs/AlwaysInlineIntoWithOpaqueReplacement.swift -o %t/%target-library-name(AlwaysInlineIntoWithOpaque)
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: OS=macosx && (CPU=x86_64 || CPU=arm64)
+// REQUIRES: executable_test
+
+import AlwaysInlineIntoWithOpaque
+
+public func test() {
+  let p = testInlineWithOpaque()
+  print(p)
+}
+
+test()
+// CHECK: 1


### PR DESCRIPTION
…ntoClient` decls

Cherry-pick of https://github.com/apple/swift/pull/60010
Cherry-pick of https://github.com/apple/swift/pull/60048

--- 

- Explanation:

If opaque result type has availability conditions and is associated with
an `@_alwaysEmitIntoClient` declaration, its metadata descriptor has to
be emitted into a client module because availability blocks in the body of
such inlined declaration are allowed to produce different underlying types
at runtime and cannot be substituted at compile-time.

- Scope: `@_alwaysEmitIntoClient` declarations that return opaque result type with availability conditions being used for back-deployment purposes.

- Main Branch PR: https://github.com/apple/swift/pull/60010, https://github.com/apple/swift/pull/60048

- Resolves: rdar://82791712

- Risk: Very low

- Reviewed By: @aschwaighofer 

- Testing:  Added a regression test-case to the suite.

Resolves: rdar://82791712
(cherry picked from commit 76ab70c3a8602c8b51073737d2e3a13b80bb5dd5)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
