### PR TITLE
only warn if `@preconcurrency` closure has an isolation mismatch in reference

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -210,6 +210,9 @@ struct ActorReferenceResult {
     /// The declaration is being accessed from outside the actor and
     /// potentially from a different node, so it must be marked 'distributed'.
     Distributed = 1 << 2,
+
+    /// The declaration is being accessed from a @preconcurrency context.
+    Preconcurrency = 1 << 3,
   };
 
   using Options = OptionSet<Flags>;

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -381,3 +381,17 @@ public struct SomeWrapper<T: AuditedNonSendable> {
 }
 
 extension SomeWrapper: Sendable where T: Sendable {}
+
+
+// rdar://96830159
+@MainActor class SendableCompletionHandler {
+  var isolatedThing: [String] = []
+  // expected-note@-1 {{property declared here}}
+
+  func makeCall(slowServer: SlowServer) {
+    slowServer.doSomethingSlow("churn butter") { (_ : Int) in
+      let _ = self.isolatedThing
+      // expected-warning@-1 {{main actor-isolated property 'isolatedThing' can not be referenced from a Sendable closure; this is an error in Swift 6}}
+    }
+  }
+}


### PR DESCRIPTION
Much like how we do for an isolation mismatch for a call within
a closure that is `@preconcurrency`, references should also only
warn about the isolation issue too.

The reason why there is a mismatch is that the completion-handlers
are considered `@Sendable`, which disables the isolation inheriting
behavior of other, non-Sendable closures.

resolves rdar://96830159