### PR TITLE
[cxx-interop][SwiftCompilerSources] Use `swift::DiagnosticArgument` instead of `BridgedDiagnosticArgument`

### DIFF
--- a/SwiftCompilerSources/Sources/AST/DiagnosticEngine.swift
+++ b/SwiftCompilerSources/Sources/AST/DiagnosticEngine.swift
@@ -16,26 +16,17 @@ import Basic
 
 public typealias DiagID = BridgedDiagID
 
-extension BridgedDiagnosticArgument {
-  init(stringRef val: BridgedStringRef) {
-    self.init(kind: .stringRef, value: .init(stringRefValue: val))
-  }
-  init(int val: Int) {
-    self.init(kind: .int, value: .init(intValue: val))
-  }
-}
-
 public protocol DiagnosticArgument {
-  func _withBridgedDiagnosticArgument(_ fn: (BridgedDiagnosticArgument) -> Void)
+  func _withBridgedDiagnosticArgument(_ fn: (swift.DiagnosticArgument) -> Void)
 }
 extension String: DiagnosticArgument {
-  public func _withBridgedDiagnosticArgument(_ fn: (BridgedDiagnosticArgument) -> Void) {
-    withBridgedStringRef { fn(BridgedDiagnosticArgument(stringRef: $0)) }
+  public func _withBridgedDiagnosticArgument(_ fn: (swift.DiagnosticArgument) -> Void) {
+    withBridgedStringRef { fn(swift.DiagnosticArgument(llvm.StringRef($0))) }
   }
 }
 extension Int: DiagnosticArgument {
-  public func _withBridgedDiagnosticArgument(_ fn: (BridgedDiagnosticArgument) -> Void) {
-    fn(BridgedDiagnosticArgument(int: self))
+  public func _withBridgedDiagnosticArgument(_ fn: (swift.DiagnosticArgument) -> Void) {
+    fn(swift.DiagnosticArgument(Int32(self)))
   }
 }
 
@@ -82,7 +73,7 @@ public struct DiagnosticEngine {
 
     let bridgedSourceLoc: swift.SourceLoc = position.bridged
     let bridgedHighlightRange: swift.CharSourceRange = highlight.bridged
-    var bridgedArgs: [BridgedDiagnosticArgument] = []
+    var bridgedArgs: [swift.DiagnosticArgument] = []
     var bridgedFixIts: [swift.DiagnosticInfo.FixIt] = []
 
     // Build a higher-order function to wrap every 'withBridgedXXX { ... }'

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -15,6 +15,7 @@
 
 #include "swift/Basic/BasicBridging.h"
 #include "swift/Basic/Compiler.h"
+#include "swift/AST/DiagnosticEngine.h"
 #include <stdbool.h>
 #include <stddef.h>
 
@@ -37,19 +38,6 @@ typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedDiagID : uint32_t {
 #define DIAG(KIND, ID, Options, Text, Signature) BridgedDiagID_##ID,
 #include "swift/AST/DiagnosticsAll.def"
 } BridgedDiagID;
-
-typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedDiagnosticArgumentKind {
-  BridgedDiagnosticArgumentKind_StringRef,
-  BridgedDiagnosticArgumentKind_Int,
-} BridgedDiagnosticArgumentKind;
-
-typedef struct {
-  BridgedDiagnosticArgumentKind kind;
-  union {
-    BridgedStringRef stringRefValue;
-    SwiftInt intValue;
-  } value;
-} BridgedDiagnosticArgument;
 
 typedef struct {
   void * _Nonnull object;

--- a/lib/AST/ASTBridging.cpp
+++ b/lib/AST/ASTBridging.cpp
@@ -23,33 +23,20 @@ DiagnosticEngine *getDiagnosticEngine(const BridgedDiagnosticEngine &bridged) {
   return static_cast<DiagnosticEngine *>(bridged.object);
 }
 
-/// BridgedDiagnosticArgument -> DiagnosticArgument
-DiagnosticArgument
-getDiagnosticArgument(const BridgedDiagnosticArgument &bridged) {
-  switch (bridged.kind) {
-  case BridgedDiagnosticArgumentKind_StringRef:
-    return {getStringRef(bridged.value.stringRefValue)};
-  case BridgedDiagnosticArgumentKind_Int:
-    return {(int)bridged.value.intValue};
-  }
-  llvm_unreachable("unhandled enum value");
-}
-
 } // namespace
 
 void DiagnosticEngine_diagnose(
     BridgedDiagnosticEngine bridgedEngine, SourceLoc loc,
     BridgedDiagID bridgedDiagID,
-    BridgedArrayRef /*BridgedDiagnosticArgument*/ bridgedArguments,
+    BridgedArrayRef /*DiagnosticArgument*/ bridgedArguments,
     CharSourceRange highlight,
     BridgedArrayRef /*DiagnosticInfo::FixIt*/ bridgedFixIts) {
   auto *D = getDiagnosticEngine(bridgedEngine);
 
   auto diagID = static_cast<DiagID>(bridgedDiagID);
   SmallVector<DiagnosticArgument, 2> arguments;
-  for (auto bridgedArg :
-       getArrayRef<BridgedDiagnosticArgument>(bridgedArguments)) {
-    arguments.push_back(getDiagnosticArgument(bridgedArg));
+  for (auto arg : getArrayRef<DiagnosticArgument>(bridgedArguments)) {
+    arguments.push_back(arg);
   }
   auto inflight = D->diagnose(loc, diagID, arguments);
 
@@ -59,9 +46,9 @@ void DiagnosticEngine_diagnose(
   }
 
   // Add fix-its.
-  for (auto bridgedFixIt : getArrayRef<DiagnosticInfo::FixIt>(bridgedFixIts)) {
-    auto range = bridgedFixIt.getRange();
-    auto text = bridgedFixIt.getText();
+  for (auto fixIt : getArrayRef<DiagnosticInfo::FixIt>(bridgedFixIts)) {
+    auto range = fixIt.getRange();
+    auto text = fixIt.getText();
     inflight.fixItReplaceChars(range.getStart(), range.getEnd(), text);
   }
 }


### PR DESCRIPTION
This also removes `BridgedDiagnosticArgumentKind` in favor of `swift::DiagnosticArgumentKind`, bringing us one step closer to bridging the entire diagnostic engine via C++ interop.

rdar://83361087