### PR TITLE
NFC: Update `@_backDeploy` runtime tests to call a coroutine that yields a non-trivial value

### DIFF
--- a/test/attr/Inputs/BackDeployHelper.swift
+++ b/test/attr/Inputs/BackDeployHelper.swift
@@ -1,3 +1,4 @@
+import Foundation
 
 /// Returns the dsohandle for the dynamic library.
 public func libraryHandle() -> UnsafeRawPointer {
@@ -125,8 +126,8 @@ extension IntArray {
   @available(BackDeploy 1.0, *)
   @_backDeploy(before: BackDeploy 2.0)
   public func print() {
-    // Tests recursive @_backDeploy since `values` is also @_backDeploy
-    testPrint(handle: #dsohandle, values.description)
+    // Tests recursive @_backDeploy since `Array.print()` is also @_backDeploy
+    _values.print()
   }
 
   @available(BackDeploy 1.0, *)
@@ -143,6 +144,12 @@ extension IntArray {
     get { _values[i] }
     _modify { yield &_values[i] }
   }
+  
+  @available(BackDeploy 1.0, *)
+  @_backDeploy(before: BackDeploy 2.0)
+  public var rawValues: [Int] {
+    _read { yield _values }
+  }
 }
 
 extension ReferenceIntArray {
@@ -153,8 +160,8 @@ extension ReferenceIntArray {
   @available(BackDeploy 1.0, *)
   @_backDeploy(before: BackDeploy 2.0)
   public final func print() {
-    // Tests recursive @_backDeploy since `values` is also @_backDeploy
-    testPrint(handle: #dsohandle, values.description)
+    // Tests recursive @_backDeploy since `Array.print()` is also @_backDeploy
+    _values.print()
   }
 
   @available(BackDeploy 1.0, *)
@@ -176,6 +183,20 @@ extension ReferenceIntArray {
   public final subscript(_ i: Int) -> Int {
     get { _values[i] }
     _modify { yield &_values[i] }
+  }
+  
+  @available(BackDeploy 1.0, *)
+  @_backDeploy(before: BackDeploy 2.0)
+  public final var rawValues: [Int] {
+    _read { yield _values }
+  }
+}
+
+extension Array {
+  @available(BackDeploy 1.0, *)
+  @_backDeploy(before: BackDeploy 2.0)
+  public func print() {
+    testPrint(handle: #dsohandle, description)
   }
 }
 

--- a/test/attr/attr_backDeploy_evolution.swift
+++ b/test/attr/attr_backDeploy_evolution.swift
@@ -151,6 +151,10 @@ do {
   // CHECK-ABI: library: [5, 43, 3]
   // CHECK-BD: client: [5, 43, 3]
   array.print()
+  
+  // CHECK-ABI: library: [5, 43, 3]
+  // CHECK-BD: client: [5, 43, 3]
+  print(array.rawValues.print())
 }
 
 do {
@@ -179,4 +183,8 @@ do {
   // CHECK-ABI: library: [7, 40, 1]
   // CHECK-BD: client: [7, 40, 1]
   array.print()
+  
+  // CHECK-ABI: library: [7, 40, 1]
+  // CHECK-BD: client: [7, 40, 1]
+  print(array.rawValues.print())
 }


### PR DESCRIPTION
This is a follow up to #60021 to ensure that a test exists that would cause lifetime verification to fail if the fix regressed.