### PR TITLE
[ConstraintSystem] Edit Type Variable printing. 

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -54,7 +54,9 @@ using namespace constraints;
 #pragma mark Type variable implementation
 
 void TypeVariableType::Implementation::print(llvm::raw_ostream &OS) {
-  getTypeVariable()->print(OS, PrintOptions());
+  PrintOptions PO;
+  PO.PrintTypesForDebugging = true;
+  getTypeVariable()->print(OS, PO);
   
   SmallVector<TypeVariableOptions, 4> bindingOptions;
   if (canBindToLValue())


### PR DESCRIPTION
Add PrintTypesForDebugging to ensure printing Type Variables. Without this, a type variable sometimes prints as an `_`. This is an edit to apple/swift#59855.
