### PR TITLE
[Swift Static Mirror] Avoid downcasting to 32-bit value when reading out TypeRef address of a same-type requirement

### DIFF
--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -1690,7 +1690,7 @@ private:
     // is an offset to a TypeRef string, read it.
     auto readRequirementTypeRefAddress =
         [&](uintptr_t offsetFromOpaqueDescBase,
-            uintptr_t requirementAddress) -> uint32_t {
+            uintptr_t requirementAddress) -> uintptr_t {
       std::string typeRefString = "";
       auto fieldOffsetOffset = requirementAddress + offsetFromOpaqueDescBase -
                                (uintptr_t)opaqueTypeDescriptor;


### PR DESCRIPTION
This change fixes a small bug in computation of an address of a TypeRef pointed to by a same-type requirement on an Opaque Type Descriptor. The code mistakenly, silently, downcast the value to a 32-bit value when it should not have.