### PR TITLE
[5.7][Swift Static Mirror] Avoid downcasting to 32-bit value when reading out TypeRef address of a same-type requirement

### DIFF
--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -1598,7 +1598,7 @@ private:
     // is an offset to a TypeRef string, read it.
     auto readRequirementTypeRefAddress =
         [&](uintptr_t offsetFromOpaqueDescBase,
-            uintptr_t requirementAddress) -> uint32_t {
+            uintptr_t requirementAddress) -> uintptr_t {
       std::string typeRefString = "";
       auto fieldOffsetOffset = requirementAddress + offsetFromOpaqueDescBase -
                                (uintptr_t)opaqueTypeDescriptor;


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/60041
-------------------------------------------------
• Explanation: This change fixes a small bug in computation of an address of a TypeRef pointed to by a same-type requirement on an Opaque Type Descriptor. The code mistakenly, silently, downcast the value to a 32-bit value when it should not have. 
• Scope of Issue: *Some* opaque associated type same-type requirements may fail to get extracted by the tooling from binary files, when their adjusted address in the binary is > a 32-bit value.
• Origination: Recently introduced bug in new code
• Risk: Minimal. The change also only affects libStaticMirror tooling code-paths without affecting compilation.

-------------------------------------------------
Resolves rdar://97017422