### PR TITLE
[5.7] Remove an unnecessary assertion.

### DIFF
--- a/lib/AST/ExistentialGeneralization.cpp
+++ b/lib/AST/ExistentialGeneralization.cpp
@@ -267,10 +267,14 @@ private:
 ExistentialTypeGeneralization
 ExistentialTypeGeneralization::get(Type rawType) {
   assert(rawType->isAnyExistentialType());
-  assert(!rawType->hasTypeParameter());
 
   // Canonicalize.  We need to generalize the canonical shape of the
   // type or else generalization parameters won't match up.
+  //
+  // TODO: in full generality, do we need to do *contextual*
+  // canonicalization in order to avoid introducing non-canonical
+  // parameters?  (That is, do we need a contextual generic
+  // signature if given an interface type?)
   CanType type = rawType->getCanonicalType();
 
   Generalizer generalizer(type->getASTContext());

--- a/test/Interpreter/parameterized_existentials.swift
+++ b/test/Interpreter/parameterized_existentials.swift
@@ -44,5 +44,14 @@ ParameterizedProtocolsTestSuite.test("casting") {
   expectEqual(a.value, b.value)
 }
 
+// rdar://96571508
+struct ErasingHolder<T> {
+  let box: any Holder<T>
+}
+ParameterizedProtocolsTestSuite.test("casting") {
+  let a = ErasingHolder(box: IntHolder(value: 5))
+  expectEqual(a.box.value, 5)
+}
+
 runAllTests()
 


### PR DESCRIPTION
I did check that the code doesn't actually rely on not seeing a type parameter.

Fixes rdar://96571508. 5.7 version of https://github.com/apple/swift/pull/60040.