### PR TITLE
[Distributed] Add deinit test, checking we dont deinit remote actor

### DIFF
--- a/test/Distributed/Runtime/distributed_actor_deinit_not_called_on_remote.swift
+++ b/test/Distributed/Runtime/distributed_actor_deinit_not_called_on_remote.swift
@@ -1,0 +1,48 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-build-swift -module-name main -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s --color
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// rdar://76038845
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+// FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
+// UNSUPPORTED: windows
+
+import Distributed
+import FakeDistributedActorSystems
+
+typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
+
+distributed actor Greeter {
+  deinit {
+      print("DEINIT \(self.id)")
+  }
+}
+
+func test() async throws {
+  let system = DefaultDistributedActorSystem()
+
+  var local: Greeter? = Greeter(actorSystem: system)
+  var ref: Greeter? = try Greeter.resolve(id: local!.id, using: system)
+  assert(__isRemoteActor(ref!))
+
+  local = nil
+  ref = nil
+
+  print("DONE")
+  // CHECK: DEINIT
+  // CHECK-NEXT: DONE
+
+}
+
+@main struct Main {
+  static func main() async {
+    try! await test()
+  }
+}


### PR DESCRIPTION
Just another test for deinits -- making sure a deinit does not run for a remote distributed actor.

We have already deinit tests but this one is more explicitly about this specific property, rather than the resignID calls.

https://forums.swift.org/t/pitch-distributed-actor-runtime/54045/15