### PR TITLE
[SILPrinter] print target branch debug names in SIL dumps

### DIFF
--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -894,6 +894,7 @@ public:
     llvm::SmallVector<SILValue, 8> values;
     llvm::copy(inst->getResults(), std::back_inserter(values));
     printUserList(values, inst);
+    printBranchTargets(inst);
   }
 
   void printUserList(ArrayRef<SILValue> values, SILNodePointer node) {
@@ -935,6 +936,21 @@ public:
     llvm::interleave(
         UserIDs.begin(), UserIDs.end(), [&](ID id) { *this << id; },
         [&] { *this << ", "; });
+  }
+
+  void printBranchTargets(const SILInstruction *inst) {
+    if (auto condBr = dyn_cast<CondBranchInst>(inst)) {
+      if (condBr->getTrueBB()->getDebugName().hasValue()) {
+        *this << ", true->" << condBr->getTrueBB()->getDebugName().getValue();
+      }
+      if (condBr->getFalseBB()->getDebugName().hasValue()) {
+        *this << ", false->" << condBr->getFalseBB()->getDebugName().getValue();
+      }
+    } else if (auto br = dyn_cast<BranchInst>(inst)) {
+      if (br->getDestBB()->getDebugName().hasValue()) {
+        *this << ", dest->" << br->getDestBB()->getDebugName().getValue();
+      }
+    }
   }
 
   void printConformances(ArrayRef<ProtocolConformanceRef> conformances) {

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -950,6 +950,16 @@ public:
       if (br->getDestBB()->getDebugName().hasValue()) {
         *this << ", dest->" << br->getDestBB()->getDebugName().getValue();
       }
+    } else if (auto termInst = dyn_cast<TermInst>(inst)) {
+      // Otherwise, we just print the successors in order without pretty printing
+      for (unsigned i = 0, numSuccessors = termInst->getSuccessors().size();
+           i != numSuccessors; ++i) {
+        auto &successor = termInst->getSuccessors()[i];
+        if (successor.getBB()->getDebugName().hasValue()) {
+          *this << ", #" << i
+                << "->" << successor.getBB()->getDebugName().getValue();
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Improve SIL dumps to include the debug names of target branches, if they have names:

```
  cond_br %5, bb3, bb1                            // id: %6, true->remoteActorDeinitBB, false->deinitBodyBB

// deinitBodyBB
bb1:                                              // Preds: bb0
// remoteActorDeinitBB
bb3:                                              // Preds: bb0
```

```
// remoteActorFinishDeinitBB
bb2:                                              // Preds: bb1 bb3

...

  br bb2                                          // id: %28, dest->remoteActorFinishDeinitBB
```

Example:
![Screen Shot 2022-07-14 at 17 38 07](https://user-images.githubusercontent.com/120979/178940311-15e1eccb-6a08-4e0e-a8b6-25a3dd788928.png)
