### PR TITLE
SIL optimizer: ignore `_swift_stdlib_malloc_size` and `_swift_stdlib_has_malloc_size` runtime calls in analysis

### DIFF
--- a/include/swift/SILOptimizer/Analysis/AccessStorageAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/AccessStorageAnalysis.h
@@ -295,10 +295,7 @@ public:
   /// the callee.
   ///
   /// TODO: Summarize ArraySemanticsCall accesses.
-  bool summarizeCall(FullApplySite fullApply) {
-    assert(accessResult.isEmpty() && "expected uninitialized results.");
-    return false;
-  }
+  bool summarizeCall(FullApplySite fullApply);
 
   /// Merge effects directly from \p RHS.
   bool mergeFrom(const FunctionAccessStorage &RHS) {

--- a/lib/SILOptimizer/Analysis/AccessStorageAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AccessStorageAnalysis.cpp
@@ -380,6 +380,19 @@ bool FunctionAccessStorage::summarizeFunction(SILFunction *F) {
   return true;
 }
 
+bool FunctionAccessStorage::summarizeCall(FullApplySite fullApply) {
+  assert(accessResult.isEmpty() && "expected uninitialized results.");
+  
+  if (SILFunction *callee = fullApply.getReferencedFunctionOrNull()) {
+    if (callee->getName() == "_swift_stdlib_malloc_size" ||
+        callee->getName() == "_swift_stdlib_has_malloc_size") {
+      return true;
+    }
+  }
+  
+  return false;
+}
+
 SILAnalysis *swift::createAccessStorageAnalysis(SILModule *) {
   return new AccessStorageAnalysis();
 }

--- a/lib/SILOptimizer/Analysis/SideEffectAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/SideEffectAnalysis.cpp
@@ -498,6 +498,12 @@ bool FunctionSideEffects::summarizeCall(FullApplySite fullApply) {
     // Does the function have any @_effects?
     if (setDefinedEffects(SingleCallee))
       return true;
+      
+    if (SingleCallee->getName() == "_swift_stdlib_malloc_size" ||
+        SingleCallee->getName() == "_swift_stdlib_has_malloc_size") {
+      GlobalEffects.Reads = true;
+      return true;
+    }
   }
   return false;
 }

--- a/test/SILOptimizer/access_enforcement_opts_ossa.sil
+++ b/test/SILOptimizer/access_enforcement_opts_ossa.sil
@@ -1874,3 +1874,23 @@ bb0(%0 : @owned $NonTrivial):
   destroy_value %0 : $NonTrivial
   return undef : $()
 }
+
+sil shared [clang _swift_stdlib_has_malloc_size] @_swift_stdlib_has_malloc_size : $@convention(c) () -> Bool
+sil shared [clang _swift_stdlib_malloc_size] @_swift_stdlib_malloc_size : $@convention(c) (UnsafeRawPointer) -> Int
+
+// CHECK-LABEL: sil [ossa] @ignoreMallocSize :
+// CHECK:         begin_access [read] [dynamic] [no_nested_conflict]
+// CHECK-LABEL: } // end sil function 'ignoreMallocSize'
+sil [ossa] @ignoreMallocSize : $@convention(thin) (UnsafeRawPointer) -> () {
+bb0(%0 : $UnsafeRawPointer):
+  %2 = global_addr @globalX: $*X
+  %3 = begin_access [read] [dynamic] %2 : $*X
+  %4 = function_ref @_swift_stdlib_has_malloc_size : $@convention(c) () -> Bool
+  %5 = apply %4() : $@convention(c) () -> Bool
+  %6 = function_ref @_swift_stdlib_malloc_size : $@convention(c) (UnsafeRawPointer) -> Int
+  %7 = apply %6(%0) : $@convention(c) (UnsafeRawPointer) -> Int
+  end_access %3 : $*X
+  %9 = tuple ()
+  return %9 : $()
+}
+

--- a/test/SILOptimizer/merge_exclusivity.swift
+++ b/test/SILOptimizer/merge_exclusivity.swift
@@ -377,13 +377,13 @@ private struct EscapedTransforme<T>: WriteProt {
 
 // TESTSIL-LABEL: sil [noinline] @$s17merge_exclusivity14run_MergeTest9yySiF : $@convention(thin)
 // TESTSIL: [[REFADDR:%.*]] = ref_element_addr {{.*}} : $StreamClass, #StreamClass.buffer
-// TESTSIL-NEXT: [[B1:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[REFADDR]]
+// TESTSIL-NEXT: [[B1:%.*]] = begin_access [modify] [{{.*}}] [no_nested_conflict] [[REFADDR]]
 // TESTSIL: end_access [[B1]]
-// TESTSIL: [[BCONF:%.*]] = begin_access [modify] [dynamic] [[REFADDR]]
+// TESTSIL: [[BCONF:%.*]] = begin_access [modify] [{{.*}}] [[REFADDR]]
 // TESTSIL: end_access [[BCONF]]
-// TESTSIL: [[BCONF:%.*]] = begin_access [modify] [dynamic] [[REFADDR]]
+// TESTSIL: [[BCONF:%.*]] = begin_access [modify] [{{.*}}] [[REFADDR]]
 // TESTSIL: end_access [[BCONF]]
-// TESTSIL: [[BCONF:%.*]] = begin_access [modify] [dynamic] [[REFADDR]]
+// TESTSIL: [[BCONF:%.*]] = begin_access [modify] [{{.*}}] [[REFADDR]]
 // TESTSIL: end_access [[BCONF]]
 // TESTSIL-LABEL: } // end sil function '$s17merge_exclusivity14run_MergeTest9yySiF'
 @inline(never)

--- a/test/SILOptimizer/redundant_load_elim_ossa.sil
+++ b/test/SILOptimizer/redundant_load_elim_ossa.sil
@@ -5,6 +5,7 @@ sil_stage canonical
 
 import Builtin
 import Swift
+import SwiftShims
 
 ///////////////////////
 // Type Declarations //
@@ -1347,6 +1348,29 @@ bb0(%0 : $*Int):
   return %3 : $()
 }
 // CHECK-LABEL: } // end sil function 'test_rle_in_guaranteed_entry'
+
+sil shared [clang _swift_stdlib_has_malloc_size] @_swift_stdlib_has_malloc_size : $@convention(c) () -> Bool
+sil shared [clang _swift_stdlib_malloc_size] @_swift_stdlib_malloc_size : $@convention(c) (UnsafeRawPointer) -> Int
+
+// CHECK-LABEL: sil [ossa] @ignoreMallocSize :
+// CHECK:         [[VAL:%.*]] = load
+// CHECK:         [[UI:%.*]] = function_ref @use_Int
+// CHECK:         apply [[UI]]([[VAL]])
+// CHECK:         return [[VAL]]
+// CHECK-LABEL: } // end sil function 'ignoreMallocSize'
+sil [ossa] @ignoreMallocSize : $@convention(thin) (@guaranteed AB, UnsafeRawPointer) -> Int {
+bb0(%0 : @guaranteed $AB, %1 : $UnsafeRawPointer):
+  %2 = ref_element_addr %0 : $AB, #AB.value
+  %3 = load [trivial] %2 : $*Int
+  %4 = function_ref @_swift_stdlib_has_malloc_size : $@convention(c) () -> Bool
+  %5 = apply %4() : $@convention(c) () -> Bool
+  %6 = function_ref @_swift_stdlib_malloc_size : $@convention(c) (UnsafeRawPointer) -> Int
+  %7 = apply %6(%1) : $@convention(c) (UnsafeRawPointer) -> Int
+  %8 = load [trivial] %2 : $*Int
+  %9 = function_ref @use_Int : $@convention(thin) (Int) -> ()
+  apply %9(%3) : $@convention(thin) (Int) -> ()
+  return %8 : $Int
+}
 
 // Check that begin_access, end_access, strong_release, set_deallocating, and dealloc_ref don't prevent optimization.
 // CHECK-LABEL: ignore_read_write :


### PR DESCRIPTION
Those runtime calls are used in the Array implementation and prevented optimizations like access-optimization redundant load elimination.

rdar://87853551