### PR TITLE
[test] move test to a file requiring the full standard library

### DIFF
--- a/test/stdlib/UnsafeRawPointer.swift
+++ b/test/stdlib/UnsafeRawPointer.swift
@@ -114,35 +114,6 @@ UnsafeMutableRawPointerExtraTestSuite.test("load.unaligned")
   expectEqual(result, 0xffff_0000)
 }
 
-UnsafeMutableRawPointerExtraTestSuite.test("load.unaligned.SIMD")
-.skip(.custom({
-  if #available(SwiftStdlib 5.7, *) { return false }
-  return true
-}, reason: "Requires Swift 5.7's stdlib"))
-.code {
-  guard #available(SwiftStdlib 5.7, *) else { return }
-  var bytes: [UInt8] = Array(0..<64)
-  var offset = 3
-  let vector16 = bytes.withUnsafeBytes { buffer -> SIMD16<UInt8> in
-    let aligned = buffer.baseAddress!.alignedUp(for: SIMD16<UInt8>.self)
-    offset += buffer.baseAddress!.distance(to: aligned)
-    return buffer.loadUnaligned(fromByteOffset: offset, as: SIMD16<UInt8>.self)
-  }
-  expectEqual(Int(vector16[0]), offset)
-  var lastIndex = vector16.indices.last!
-  expectEqual(Int(vector16[lastIndex]), offset+lastIndex)
-
-  offset = 11
-  let vector32 = bytes.withUnsafeMutableBytes { buffer -> SIMD32<UInt8> in
-    let aligned = buffer.baseAddress!.alignedUp(for: SIMD32<UInt8>.self)
-    offset += buffer.baseAddress!.distance(to: aligned)
-    return buffer.loadUnaligned(fromByteOffset: offset, as: SIMD32<UInt8>.self)
-  }
-  expectEqual(Int(vector32[0]), offset)
-  lastIndex = vector32.indices.last!
-  expectEqual(Int(vector32[lastIndex]), offset+lastIndex)
-}
-
 UnsafeMutableRawPointerExtraTestSuite.test("load.invalid")
 .skip(.custom({ !_isDebugAssertConfiguration() },
               reason: "This tests a debug precondition.."))

--- a/validation-test/stdlib/UnsafeRawPointerInternal.swift
+++ b/validation-test/stdlib/UnsafeRawPointerInternal.swift
@@ -1,0 +1,42 @@
+// RUN: %target-build-swift %s -parse-stdlib -Xfrontend -disable-access-control -o %t.out
+// RUN: %target-codesign %t.out
+// RUN: %target-run %t.out
+// REQUIRES: executable_test
+// UNSUPPORTED: freestanding
+
+import Swift
+import StdlibUnittest
+
+var UnsafeRawPointerTestSuite =
+  TestSuite("UnsafeRawPointerTestSuite")
+
+UnsafeRawPointerTestSuite.test("load.unaligned.SIMD")
+.skip(.custom({
+  if #available(SwiftStdlib 5.7, *) { return false }
+  return true
+}, reason: "Requires Swift 5.7's stdlib"))
+.code {
+  guard #available(SwiftStdlib 5.7, *) else { return }
+  var bytes: [UInt8] = Array(0..<64)
+  var offset = 3
+  let vector16 = bytes.withUnsafeBytes { buffer -> SIMD16<UInt8> in
+    let aligned = buffer.baseAddress!.alignedUp(for: SIMD16<UInt8>.self)
+    offset += buffer.baseAddress!.distance(to: aligned)
+    return buffer.loadUnaligned(fromByteOffset: offset, as: SIMD16<UInt8>.self)
+  }
+  expectEqual(Int(vector16[0]), offset)
+  var lastIndex = vector16.indices.last!
+  expectEqual(Int(vector16[lastIndex]), offset+lastIndex)
+
+  offset = 11
+  let vector32 = bytes.withUnsafeMutableBytes { buffer -> SIMD32<UInt8> in
+    let aligned = buffer.baseAddress!.alignedUp(for: SIMD32<UInt8>.self)
+    offset += buffer.baseAddress!.distance(to: aligned)
+    return buffer.loadUnaligned(fromByteOffset: offset, as: SIMD32<UInt8>.self)
+  }
+  expectEqual(Int(vector32[0]), offset)
+  lastIndex = vector32.indices.last!
+  expectEqual(Int(vector32[lastIndex]), offset+lastIndex)
+}
+
+runAllTests()


### PR DESCRIPTION
- SIMD types are not available in the minimal stdlib
- This test was failing on the "OSS - Swift Build Standard Library with Toolchain (minimal) - macOS" CI bot.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://97029576.
