### PR TITLE
[CS] Don’t fail constraint generation for ErrorExpr or if type fails to resolve

### DIFF
--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -298,6 +298,10 @@ enum class FixKind : uint8_t {
   /// Ignore `ErrorExpr` or `ErrorType` during pre-check.
   IgnoreInvalidASTNode,
 
+  /// Ignore a named pattern whose type we couldn't infer. This issue should
+  /// already have been diagnosed elsewhere.
+  IgnoreInvalidNamedPattern,
+
   /// Resolve type of `nil` by providing a contextual type.
   SpecifyContextualTypeForNil,
 
@@ -2739,6 +2743,31 @@ public:
 
   static bool classof(ConstraintFix *fix) {
     return fix->getKind() == FixKind::IgnoreInvalidASTNode;
+  }
+};
+
+class IgnoreInvalidNamedPattern final : public ConstraintFix {
+  IgnoreInvalidNamedPattern(ConstraintSystem &cs, NamedPattern *pattern,
+                            ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::IgnoreInvalidNamedPattern, locator) {}
+
+public:
+  std::string getName() const override {
+    return "specify type for pattern match";
+  }
+
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
+    return diagnose(*commonFixes.front().first);
+  }
+
+  static IgnoreInvalidNamedPattern *create(ConstraintSystem &cs,
+                                           NamedPattern *pattern,
+                                           ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::IgnoreInvalidNamedPattern;
   }
 };
 

--- a/include/swift/Sema/ConstraintLocatorPathElts.def
+++ b/include/swift/Sema/ConstraintLocatorPathElts.def
@@ -239,6 +239,9 @@ CUSTOM_LOCATOR_PATH_ELT(SyntacticElement)
 /// The element of the pattern binding declaration.
 CUSTOM_LOCATOR_PATH_ELT(PatternBindingElement)
 
+/// The variable declared by a named pattern.
+SIMPLE_LOCATOR_PATH_ELT(NamedPatternDecl)
+
 #undef LOCATOR_PATH_ELT
 #undef CUSTOM_LOCATOR_PATH_ELT
 #undef SIMPLE_LOCATOR_PATH_ELT

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -640,6 +640,13 @@ T *getAsStmt(ASTNode node) {
   return nullptr;
 }
 
+template <typename T = Pattern>
+T *getAsPattern(ASTNode node) {
+  if (auto *P = node.dyn_cast<Pattern *>())
+    return dyn_cast_or_null<T>(P);
+  return nullptr;
+}
+
 SourceLoc getLoc(ASTNode node);
 SourceRange getSourceRange(ASTNode node);
 

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1989,6 +1989,20 @@ TypeVariableBinding::fixForHole(ConstraintSystem &cs) const {
     return std::make_pair(fix, /*impact=*/(unsigned)10);
   }
 
+  if (auto pattern = getAsPattern<NamedPattern>(dstLocator->getAnchor())) {
+    if (dstLocator->getPath().size() == 1 &&
+        dstLocator->isLastElement<LocatorPathElt::NamedPatternDecl>()) {
+      // Not being able to infer the type of a variable in a pattern binding
+      // decl is more dramatic than anything that could happen inside the
+      // expression because we want to preferrably point the diagnostic to a
+      // part of the expression that caused us to be unable to infer the
+      // variable's type.
+      ConstraintFix *fix =
+          IgnoreInvalidNamedPattern::create(cs, pattern, dstLocator);
+      return std::make_pair(fix, /*impact=*/(unsigned)100);
+    }
+  }
+
   return None;
 }
 

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -109,6 +109,16 @@ bool BindingSet::isDelayed() const {
     if (locator->directlyAt<NilLiteralExpr>())
       return true;
 
+    // When inferring the type of a variable in a pattern, delay its resolution
+    // so that we resolve type variables inside the expression as placeholders
+    // instead of marking the type of the variable itself as a placeholder. This
+    // allows us to produce more specific errors because the type variable in
+    // the expression that introduced the placeholder might be diagnosable using
+    // fixForHole.
+    if (locator->isLastElement<LocatorPathElt::NamedPatternDecl>()) {
+      return true;
+    }
+
     // It's possible that type of member couldn't be determined,
     // and if so it would be beneficial to bind member to a hole
     // early to propagate that information down to arguments,

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2004,6 +2004,20 @@ IgnoreResultBuilderWithReturnStmts::create(ConstraintSystem &cs, Type builderTy,
       IgnoreResultBuilderWithReturnStmts(cs, builderTy, locator);
 }
 
+bool IgnoreInvalidNamedPattern::diagnose(const Solution &solution,
+                                         bool asNote) const {
+  // Not being able to infer the type of a pattern should already have been
+  // diagnosed on the pattern's initializer or as a structural issue of the AST.
+  return true;
+}
+
+IgnoreInvalidNamedPattern *
+IgnoreInvalidNamedPattern::create(ConstraintSystem &cs, NamedPattern *pattern,
+                                  ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      IgnoreInvalidNamedPattern(cs, pattern, locator);
+}
+
 bool SpecifyBaseTypeForOptionalUnresolvedMember::diagnose(
     const Solution &solution, bool asNote) const {
   MemberMissingExplicitBaseTypeFailure failure(solution, MemberName,

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1945,6 +1945,16 @@ IgnoreInvalidResultBuilderBody::create(ConstraintSystem &cs,
   return new (cs.getAllocator()) IgnoreInvalidResultBuilderBody(cs, locator);
 }
 
+bool IgnoreInvalidASTNode::diagnose(const Solution &solution,
+                                    bool asNote) const {
+  return true; // Already diagnosed by the producer of ErrorExpr or ErrorType.
+}
+
+IgnoreInvalidASTNode *IgnoreInvalidASTNode::create(ConstraintSystem &cs,
+                                                   ConstraintLocator *locator) {
+  return new (cs.getAllocator()) IgnoreInvalidASTNode(cs, locator);
+}
+
 bool SpecifyContextualTypeForNil::diagnose(const Solution &solution,
                                            bool asNote) const {
   MissingContextualTypeForNil failure(solution, getLocator());

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2327,9 +2327,10 @@ namespace {
         }
 
         if (!varType) {
-          varType =
-              CS.createTypeVariable(CS.getConstraintLocator(locator),
-                                    TVO_CanBindToNoEscape | TVO_CanBindToHole);
+          varType = CS.createTypeVariable(
+              CS.getConstraintLocator(pattern,
+                                      LocatorPathElt::NamedPatternDecl()),
+              TVO_CanBindToNoEscape | TVO_CanBindToHole);
 
           // If this is either a `weak` declaration or capture e.g.
           // `weak var ...` or `[weak self]`. Let's wrap type variable

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -890,6 +890,11 @@ namespace {
       // that member through the base returns a value convertible to the type
       // of this expression.
       auto baseTy = CS.getType(base);
+      if (isa<ErrorExpr>(base)) {
+        return CS.createTypeVariable(
+            CS.getConstraintLocator(expr, ConstraintLocator::Member),
+            TVO_CanBindToHole);
+      }
       auto tv = CS.createTypeVariable(
                   CS.getConstraintLocator(expr, ConstraintLocator::Member),
                   TVO_CanBindToLValue | TVO_CanBindToNoEscape);
@@ -1068,19 +1073,11 @@ namespace {
     ConstraintSystem &getConstraintSystem() const { return CS; }
 
     virtual Type visitErrorExpr(ErrorExpr *E) {
-      if (!CS.isForCodeCompletion())
-        return nullptr;
+      CS.recordFix(
+          IgnoreInvalidASTNode::create(CS, CS.getConstraintLocator(E)));
 
-      // For code completion, treat error expressions that don't contain
-      // the completion location itself as holes. If an ErrorExpr contains the
-      // code completion location, a fallback typecheck is called on the
-      // ErrorExpr's OriginalExpr (valid sub-expression) if it had one,
-      // independent of the wider expression containing the ErrorExpr, so
-      // there's no point attempting to produce a solution for it.
-      if (CS.containsCodeCompletionLoc(E))
-        return nullptr;
-
-      return PlaceholderType::get(CS.getASTContext(), E);
+      return CS.createTypeVariable(CS.getConstraintLocator(E),
+                                   TVO_CanBindToHole);
     }
 
     virtual Type visitCodeCompletionExpr(CodeCompletionExpr *E) {
@@ -1374,7 +1371,11 @@ namespace {
       const auto result = TypeResolution::resolveContextualType(
           repr, CS.DC, resCtx, genericOpener, placeholderHandler);
       if (result->hasError()) {
-        return Type();
+        CS.recordFix(
+            IgnoreInvalidASTNode::create(CS, CS.getConstraintLocator(locator)));
+
+        return CS.createTypeVariable(CS.getConstraintLocator(repr),
+                                     TVO_CanBindToHole);
       }
       // Diagnose top-level usages of placeholder types.
       if (isa<PlaceholderTypeRepr>(repr->getWithoutParens())) {
@@ -1600,7 +1601,11 @@ namespace {
 
     Type visitUnresolvedSpecializeExpr(UnresolvedSpecializeExpr *expr) {
       auto baseTy = CS.getType(expr->getSubExpr());
-      
+
+      if (baseTy->isTypeVariableOrMember()) {
+        return baseTy;
+      }
+
       // We currently only support explicit specialization of generic types.
       // FIXME: We could support explicit function specialization.
       auto &de = CS.getASTContext().Diags;
@@ -2322,8 +2327,9 @@ namespace {
         }
 
         if (!varType) {
-          varType = CS.createTypeVariable(CS.getConstraintLocator(locator),
-                                          TVO_CanBindToNoEscape);
+          varType =
+              CS.createTypeVariable(CS.getConstraintLocator(locator),
+                                    TVO_CanBindToNoEscape | TVO_CanBindToHole);
 
           // If this is either a `weak` declaration or capture e.g.
           // `weak var ...` or `[weak self]`. Let's wrap type variable

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -12941,6 +12941,9 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::IgnoreInvalidASTNode: {
     return recordFix(fix, 10) ? SolutionKind::Error : SolutionKind::Solved;
   }
+  case FixKind::IgnoreInvalidNamedPattern: {
+    return recordFix(fix, 100) ? SolutionKind::Error : SolutionKind::Solved;
+  }
 
   case FixKind::ExplicitlyConstructRawRepresentable: {
     // Let's increase impact of this fix for binary operators because

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11211,18 +11211,6 @@ ConstraintSystem::simplifyApplicableFnConstraint(
   // following: $T1 -> $T2.
   auto func1 = type1->castTo<FunctionType>();
 
-  // If a type variable representing "function type" is a hole
-  // or it could be bound to some concrete type with a help of
-  // a fix, let's propagate holes to the "input" type. Doing so
-  // provides more information to upcoming argument and result matching.
-  if (shouldAttemptFixes()) {
-    if (auto *typeVar = type2->getAs<TypeVariableType>()) {
-      auto *locator = typeVar->getImpl().getLocator();
-      if (typeVar->isPlaceholder() || hasFixFor(locator))
-        recordAnyTypeVarAsPotentialHole(func1);
-    }
-  }
-
   // Before stripping lvalue-ness and optional types, save the original second
   // type for handling `func callAsFunction` and `@dynamicCallable`
   // applications. This supports the following cases:
@@ -11236,6 +11224,29 @@ ConstraintSystem::simplifyApplicableFnConstraint(
   // Drill down to the concrete type on the right hand side.
   type2 = getFixedTypeRecursive(type2, flags, /*wantRValue=*/true);
   auto desugar2 = type2->getDesugaredType();
+
+  // If a type variable representing "function type" is a hole
+  // or it could be bound to some concrete type with a help of
+  // a fix, let's propagate holes to the "input" type. Doing so
+  // provides more information to upcoming argument and result matching.
+  if (shouldAttemptFixes()) {
+    if (auto *typeVar = type2->getAs<TypeVariableType>()) {
+      auto *locator = typeVar->getImpl().getLocator();
+      if (hasFixFor(locator)) {
+        recordAnyTypeVarAsPotentialHole(func1);
+      }
+    }
+    Type underlyingType = desugar2;
+    while (auto *MT = underlyingType->getAs<AnyMetatypeType>()) {
+      underlyingType = MT->getInstanceType();
+    }
+    underlyingType =
+        getFixedTypeRecursive(underlyingType, flags, /*wantRValue=*/true);
+    if (underlyingType->isPlaceholder()) {
+      recordAnyTypeVarAsPotentialHole(func1);
+      return SolutionKind::Solved;
+    }
+  }
 
   TypeMatchOptions subflags = getDefaultDecompositionOptions(flags);
 
@@ -12926,6 +12937,9 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::NotCompileTimeConst:
   case FixKind::RenameConflictingPatternVariables: {
     return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
+  }
+  case FixKind::IgnoreInvalidASTNode: {
+    return recordFix(fix, 10) ? SolutionKind::Error : SolutionKind::Solved;
   }
 
   case FixKind::ExplicitlyConstructRawRepresentable: {

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -598,6 +598,12 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) const {
       out << '@';
       expr->getLoc().print(out, *sm);
     }
+  } else if (auto *pattern = anchor.dyn_cast<Pattern *>()) {
+    out << Pattern::getKindName(pattern->getKind()) << "Pattern";
+    if (sm) {
+      out << '@';
+      pattern->getLoc().print(out, *sm);
+    }
   }
 
   for (auto elt : getPath()) {

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -97,6 +97,7 @@ unsigned LocatorPathElt::getNewSummaryFlags() const {
   case ConstraintLocator::PackType:
   case ConstraintLocator::PackElement:
   case ConstraintLocator::PatternBindingElement:
+  case ConstraintLocator::NamedPatternDecl:
     return 0;
 
   case ConstraintLocator::FunctionArgument:
@@ -439,6 +440,11 @@ void LocatorPathElt::dump(raw_ostream &out) const {
         elt.castTo<LocatorPathElt::PatternBindingElement>();
     out << "pattern binding element #"
         << llvm::utostr(patternBindingElt.getIndex());
+    break;
+  }
+
+  case ConstraintLocator::NamedPatternDecl: {
+    out << "named pattern decl";
     break;
   }
   }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5256,6 +5256,13 @@ void constraints::simplifyLocator(ASTNode &anchor,
       continue;
     }
 
+    case ConstraintLocator::NamedPatternDecl: {
+      auto pattern = cast<NamedPattern>(anchor.get<Pattern *>());
+      anchor = pattern->getDecl();
+      path = path.slice(1);
+      break;
+    }
+
     case ConstraintLocator::ImplicitConversion:
       break;
 

--- a/test/ClangImporter/MixedSource/can_import_objc_idempotent.swift
+++ b/test/ClangImporter/MixedSource/can_import_objc_idempotent.swift
@@ -30,7 +30,7 @@
   // expected-error@-1 {{cannot find 'CGRect' in scope}}
 
   let (r, s) = square.divided(atDistance: 50, from: .minXEdge)
-  // expected-error@-1 {{type of expression is ambiguous without more context}}
+  // expected-error@-1 {{cannot infer contextual base in reference to member 'minXEdge'}}
 #endif
 
 #if canImport(MixedWithHeader)

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1137,7 +1137,7 @@ func badTypes() {
 // rdar://34357545
 func unresolvedTypeExistential() -> Bool {
   return (Int.self==_{})
-  // expected-error@-1 {{type of expression is ambiguous without more context}}
+  // expected-error@-1 {{could not infer type for placeholder}}
   // expected-error@-2 {{type placeholder not allowed here}}
 }
 

--- a/test/Constraints/overload.swift
+++ b/test/Constraints/overload.swift
@@ -257,3 +257,10 @@ func rdar79672230() {
   var t: MyType = MyType()
   test(&t) // expected-error {{no exact matches in call to local function 'test'}}
 }
+
+// https://github.com/apple/swift/issues/60029
+for (key, values) in oldName { // expected-error{{cannot find 'oldName' in scope}}
+  for (idx, value) in values.enumerated() {
+    print(key, idx, value)
+  }
+}

--- a/test/IDE/complete_repl_identifier_prefix_1.swift
+++ b/test/IDE/complete_repl_identifier_prefix_1.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-ide-test -repl-code-completion -source-filename %s | %FileCheck %s
 
 // CHECK: Begin completions
+// CHECK-NEXT: .self: _
 // CHECK-NEXT: {{^}}true: Bool{{$}}
 // CHECK-NEXT: End completions
 

--- a/test/Parse/confusables.swift
+++ b/test/Parse/confusables.swift
@@ -11,6 +11,7 @@ let number⁚ Int // expected-note {{operator '⁚' (Two Dot Punctuation) looks 
 // expected-error @+1 {{consecutive statements on a line must be separated by ';'}}
 5 ‒ 5 // expected-note {{unicode character '‒' (Figure Dash) looks similar to '-' (Hyphen Minus); did you mean to use '-' (Hyphen Minus)?}} {{3-6=-}}
 
+// expected-error @+3 {{cannot convert value of type '(Bool, _)' to expected condition type 'Bool'}}
 // expected-error @+2 {{cannot find 'ꝸꝸꝸ' in scope}}
 // expected-error @+1 {{expected ',' separator}}
 if (true ꝸꝸꝸ false) {} // expected-note {{identifier 'ꝸꝸꝸ' contains possibly confused characters; did you mean to use '&&&'?}} {{10-19=&&&}}

--- a/test/Parse/invalid.swift
+++ b/test/Parse/invalid.swift
@@ -25,7 +25,10 @@ func runAction() {} // expected-note {{'runAction' declared here}}
 
 // rdar://16601779
 func foo() {
-  runAction(SKAction.sequence() // expected-error {{cannot find 'SKAction' in scope; did you mean 'runAction'?}} {{13-21=runAction}} expected-error {{expected ',' separator}} {{32-32=,}}
+  // expected-error@+3 {{argument passed to call that takes no arguments}}
+  // expected-error@+2 {{cannot find 'SKAction' in scope; did you mean 'runAction'?}} {{13-21=runAction}}
+  // expected-error@+1 {{expected ',' separator}} {{32-32=,}}
+  runAction(SKAction.sequence()
     
     skview!
     // expected-error @-1 {{cannot find 'skview' in scope}}

--- a/test/Parse/matching_patterns.swift
+++ b/test/Parse/matching_patterns.swift
@@ -329,4 +329,4 @@ case (_?)?: break // expected-warning {{case is already handled by previous patt
 let (responseObject: Int?) = op1
 // expected-error @-1 {{expected ',' separator}} {{25-25=,}}
 // expected-error @-2 {{expected pattern}}
-// expected-error @-3 {{type of expression is ambiguous without more context}}
+// expected-error @-3 {{cannot convert value of type 'Int?' to specified type '(responseObject: _)'}}

--- a/test/Parse/subscripting.swift
+++ b/test/Parse/subscripting.swift
@@ -176,6 +176,7 @@ struct A6 {
                                      // expected-note@-2 {{did you mean}}
     get {
       return i + j // expected-error {{cannot find 'j' in scope}}
+                   // expected-error@-1 {{cannot convert return expression of type 'Int' to return type '(Int) -> Int'}}
     }
   }
 }

--- a/test/Parse/switch.swift
+++ b/test/Parse/switch.swift
@@ -338,7 +338,7 @@ func f1(x: String, y: Whichever) {
         break
     case Whichever.alias: // expected-error {{expression pattern of type 'Whichever' cannot match values of type 'String'}}
     // expected-note@-1 {{overloads for '~=' exist}}
-        break
+    // expected-error@-2 {{'case' label in a 'switch' must have at least one executable statement}}
     default:
       break
   }

--- a/test/Sema/editor_placeholders.swift
+++ b/test/Sema/editor_placeholders.swift
@@ -1,8 +1,8 @@
 // RUN: %target-typecheck-verify-swift
 
-func foo(_ x: Int) -> Int {} // expected-note {{found this candidate}}
-func foo(_ x: Float) -> Float {} // expected-note {{found this candidate}}
-func foo<T>(_ t: T) -> T {} // expected-note {{found this candidate}}
+func foo(_ x: Int) -> Int {}
+func foo(_ x: Float) -> Float {}
+func foo<T>(_ t: T) -> T {}
 
 var v = foo(<#T##x: Float##Float#>) // expected-error {{editor placeholder}}
 v = "" // expected-error {{cannot assign value of type 'String' to type 'Float'}}
@@ -11,7 +11,7 @@ if (true) {
   <#code#> // expected-error {{editor placeholder}}
 }
 
-foo(<#T##x: Undeclared##Undeclared#>) // expected-error {{editor placeholder}} expected-error {{cannot find type 'Undeclared' in scope}} expected-error {{ambiguous use of 'foo'}}
+foo(<#T##x: Undeclared##Undeclared#>) // expected-error {{editor placeholder}} expected-error {{cannot find type 'Undeclared' in scope}}
 
 func f(_ n: Int) {}
 let a1 = <#T#> // expected-error{{editor placeholder in source file}}

--- a/test/Sema/placeholder_type.swift
+++ b/test/Sema/placeholder_type.swift
@@ -110,13 +110,13 @@ extension Bar {
 }
 
 // FIXME: We should probably have better diagnostics for these situations--the user probably meant to use implicit member syntax
-let _: Int = _() // expected-error {{type placeholder not allowed here}} expected-error {{type of expression is ambiguous without more context}}
-let _: () -> Int = { _() } // expected-error 2 {{type placeholder not allowed here}} expected-error {{unable to infer closure type in the current context}}
+let _: Int = _() // expected-error {{type placeholder not allowed here}} expected-error {{could not infer type for placeholder}}
+let _: () -> Int = { _() } // expected-error 2 {{type placeholder not allowed here}} expected-error {{could not infer type for placeholder}}
 let _: Int = _.init() // expected-error {{type placeholder not allowed here}} expected-error {{could not infer type for placeholder}}
 let _: () -> Int = { _.init() } // expected-error 2 {{type placeholder not allowed here}} expected-error {{could not infer type for placeholder}}
 
-func returnsInt() -> Int { _() } // expected-error {{type placeholder not allowed here}} expected-error {{type of expression is ambiguous without more context}}
-func returnsIntClosure() -> () -> Int { { _() } } // expected-error 2 {{type placeholder not allowed here}} expected-error {{unable to infer closure type in the current context}}
+func returnsInt() -> Int { _() } // expected-error {{type placeholder not allowed here}} expected-error {{could not infer type for placeholder}}
+func returnsIntClosure() -> () -> Int { { _() } } // expected-error 2 {{type placeholder not allowed here}} expected-error {{could not infer type for placeholder}}
 func returnsInt2() -> Int { _.init() }  // expected-error {{type placeholder not allowed here}} expected-error {{could not infer type for placeholder}}
 func returnsIntClosure2() -> () -> Int { { _.init() } } // expected-error 2 {{type placeholder not allowed here}} expected-error {{could not infer type for placeholder}}
 

--- a/test/Serialization/Recovery/typedefs.swift
+++ b/test/Serialization/Recovery/typedefs.swift
@@ -56,6 +56,7 @@ let _ = wrapped // expected-error {{cannot find 'wrapped' in scope}}
 let _ = unwrapped // okay
 
 _ = usesWrapped(nil) // expected-error {{cannot find 'usesWrapped' in scope}}
+                     // expected-error@-1 {{'nil' requires a contextual type}}
 _ = usesUnwrapped(nil) // expected-error {{'nil' is not compatible with expected argument type 'Int32'}}
 
 let _: WrappedAlias = nil // expected-error {{cannot find type 'WrappedAlias' in scope}}

--- a/test/StringProcessing/Parse/forward-slash-regex.swift
+++ b/test/StringProcessing/Parse/forward-slash-regex.swift
@@ -94,10 +94,11 @@ _ = /x/!.blah
 // expected-error@-2 {{value of type 'Regex<Substring>' has no member 'blah'}}
 
 do {
+  // expected-error@+2 {{cannot find operator '/?' in scope}}
+  // expected-error@+1 {{'/' is not a prefix unary operator}}
   _ = /x /?
     .blah
-  // expected-error@-2 {{cannot find operator '/?' in scope}}
-  // expected-error@-3 {{'/' is not a prefix unary operator}}
+  // expected-error@-1 {{cannot infer contextual base in reference to member 'blah'}}
 }
 _ = /x/? // expected-error {{cannot use optional chaining on non-optional value of type 'Regex<Substring>'}}
   .blah // expected-error {{value of type 'Regex<Substring>' has no member 'blah'}}
@@ -418,6 +419,7 @@ do {
   // expected-error@-1 {{'/' is not a prefix unary operator}}
   // expected-error@-2 {{consecutive statements on a line must be separated by ';'}}
   // expected-error@-3 {{expected expression}}
+  // expected-error@-4 {{cannot call value of non-function type '()'}}
 }
 do {
   _ = /[x])/

--- a/test/decl/func/operator.swift
+++ b/test/decl/func/operator.swift
@@ -428,5 +428,5 @@ func testNonexistentPowerOperatorWithPowFunctionOutOfScope() {
   let x: Double = 3.0
   let y: Double = 3.0
   let z: Double = x**y // expected-error {{cannot find operator '**' in scope}}
-  let w: Double = a(x**2.0) // expected-error {{cannot find operator '**' in scope}}
+  let w: Double = a(x**2.0) // expected-error {{cannot find operator '**' in scope}} expected-error {{cannot convert value of type '()' to specified type 'Double'}}
 }

--- a/test/decl/operator/power_operator_imported.swift
+++ b/test/decl/operator/power_operator_imported.swift
@@ -7,5 +7,5 @@ func testNonexistentPowerOperatorWithPowFunctionInScope() {
   let x: Double = 3.0
   let y: Double = 3.0
   let z: Double = x**y // expected-error {{no operator '**' is defined; did you mean 'pow(_:_:)'?}}
-  let w: Double = a(x**2.0) // expected-error {{no operator '**' is defined; did you mean 'pow(_:_:)'?}}
+  let w: Double = a(x**2.0) // expected-error {{no operator '**' is defined; did you mean 'pow(_:_:)'?}} expected-error {{cannot convert value of type '()' to specified type 'Double'}}
 }

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -475,9 +475,9 @@ var f = { (s: Undeclared) -> Int in 0 } // expected-error {{cannot find type 'Un
 
 // <rdar://problem/21375863> Swift compiler crashes when using closure, declared to return illegal type.
 func r21375863() {
-  var width = 0 // expected-warning {{variable 'width' was never mutated}}
-  var height = 0 // expected-warning {{variable 'height' was never mutated}}
-  var bufs: [[UInt8]] = (0..<4).map { _ -> [asdf] in  // expected-error {{cannot find type 'asdf' in scope}} expected-warning {{variable 'bufs' was never used}}
+  var width = 0
+  var height = 0
+  var bufs: [[UInt8]] = (0..<4).map { _ -> [asdf] in  // expected-error {{cannot find type 'asdf' in scope}}
     [UInt8](repeating: 0, count: width*height)
   }
 }

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -337,10 +337,9 @@ func test_unknown_refs_in_tilde_operator() {
   enum E {
   }
 
-  let _: (E) -> Void = {
+  let _: (E) -> Void = { // expected-error {{unable to infer closure type in the current context}}
     if case .test(unknown) = $0 {
-      // expected-error@-1 {{type 'E' has no member 'test'}}
-      // expected-error@-2 2 {{cannot find 'unknown' in scope}}
+      // expected-error@-1 2 {{cannot find 'unknown' in scope}}
     }
   }
 }

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -263,7 +263,6 @@ func test_lambda2() {
   { () -> protocol<Int> in
     // expected-error @-1 {{'protocol<...>' composition syntax has been removed and is not needed here}} {{11-24=Int}}
     // expected-error @-2 {{non-protocol, non-class type 'Int' cannot be used within a protocol-constrained type}}
-    // expected-warning @-3 {{result of call to closure returning 'Int' is unused}}
     return 1
   }()
 }
@@ -429,7 +428,7 @@ var fl_r: Float = 0x1.0fp // expected-error {{expected a digit in floating point
 var fl_s: Float = 0x1.0fp+ // expected-error {{expected a digit in floating point exponent}}
 var fl_t: Float = 0x1.p // expected-error {{value of type 'Int' has no member 'p'}}
 var fl_u: Float = 0x1.p2 // expected-error {{value of type 'Int' has no member 'p2'}}
-var fl_v: Float = 0x1.p+ // expected-error {{'+' is not a postfix unary operator}}
+var fl_v: Float = 0x1.p+ // expected-error {{'+' is not a postfix unary operator}} expected-error {{value of type 'Int' has no member 'p'}}
 var fl_w: Float = 0x1.p+2 // expected-error {{value of type 'Int' has no member 'p'}}
 
 var if1: Double = 1.0 + 4  // integer literal ok as double.

--- a/test/type/protocol_composition.swift
+++ b/test/type/protocol_composition.swift
@@ -173,6 +173,10 @@ takesP1AndP2([Swift.AnyObject & P1 & P2]())
 takesP1AndP2([AnyObject & protocol_composition.P1 & P2]())
 takesP1AndP2([AnyObject & P1 & protocol_composition.P2]())
 takesP1AndP2([DoesNotExist & P1 & P2]()) // expected-error {{cannot find 'DoesNotExist' in scope}}
+// expected-error@-1 {{binary operator '&' cannot be applied to operands of type 'UInt8' and '(any P2).Type'}}
+// expected-error@-2 {{binary operator '&' cannot be applied to operands of type 'UInt8' and '(any P1).Type'}}
+// expected-note@-3 2 {{overloads for '&' exist with these partially matching parameter lists}}
+// expected-error@-4 {{cannot call value of non-function type '[UInt8]'}}
 takesP1AndP2([Swift.DoesNotExist & P1 & P2]()) // expected-error {{module 'Swift' has no member named 'DoesNotExist'}}
 // expected-error@-1 {{binary operator '&' cannot be applied to operands of type 'UInt8' and '(any P2).Type'}}
 // expected-error@-2 {{binary operator '&' cannot be applied to operands of type 'UInt8' and '(any P1).Type'}}

--- a/validation-test/compiler_crashers_2_fixed/0180-rdar45557325.swift
+++ b/validation-test/compiler_crashers_2_fixed/0180-rdar45557325.swift
@@ -8,5 +8,6 @@ class MyClass: NSObject {
   func f() {
     let url = URL(url) // expected-error{{use of local variable 'url' before its declaration}}
     // expected-note@-1 {{'url' declared here}}
+    // expected-error@-2 {{missing argument label 'string:' in call}}
   }
 }


### PR DESCRIPTION
Instead of failing constraint generation by returning `nullptr` for an `ErrorExpr` or returning a null type when a type fails to be resolved, return a fresh type variable. This allows the constraint solver to continue further and produce more meaningful diagnostics.

Most importantly, it allows us to produce a solution where previously constraint generation for a syntactic element had failed, which is required to type check multi-statement closures in result builders inside the constraint system.

Resolves: https://github.com/apple/swift/issues/60029
Resolves: https://github.com/apple/swift/issues/60485