### PR TITLE
ModuleInterface: avoid remarking missing prebuilt module for stdlib by default

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -377,11 +377,6 @@ WARNING(warning_module_shadowing_may_break_module_interface,none,
         /*shadowedModule=*/ModuleDecl *, /*interfaceModule*/ModuleDecl *))
 REMARK(rebuilding_module_from_interface,none,
        "rebuilding module '%0' from interface '%1'", (StringRef, StringRef))
-REMARK(rebuilding_stdlib_from_interface,none,
-       "did not find a prebuilt standard library for target '%0' compatible "
-       "with this Swift compiler; building it may take a few minutes, but it "
-       "should only happen once for this combination of compiler and target",
-       (StringRef))
 NOTE(sdk_version_pbm_version,none,
      "SDK build version is '%0'; prebuilt modules were "
      "built using SDK build version: '%1'", (StringRef, StringRef))

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -981,21 +981,9 @@ class ModuleInterfaceLoaderImpl {
                            diag::rebuilding_module_from_interface, moduleName,
                            interfacePath);
     };
-    // Diagnose only for the standard library; it should be prebuilt in typical
-    // workflows, but if it isn't, building it may take several minutes and a
-    // lot of memory, so users may think the compiler is busy-hung.
-    auto remarkRebuildStdlib = [&]() {
-      if (moduleName != "Swift")
-        return;
-      
-      auto moduleTriple = getTargetSpecificModuleTriple(ctx.LangOpts.Target);
-      rebuildInfo.diagnose(ctx, diags, prebuiltCacheDir, SourceLoc(),
-                           diag::rebuilding_stdlib_from_interface,
-                           moduleTriple.str());
-    };
     auto remarkRebuild = Opts.remarkOnRebuildFromInterface
                        ? llvm::function_ref<void()>(remarkRebuildAll)
-                       : remarkRebuildStdlib;
+                       : nullptr;
 
     bool failed = false;
     std::string backupPath = getBackupPublicModuleInterfacePath();

--- a/test/ModuleInterface/stdlib_rebuild.swift
+++ b/test/ModuleInterface/stdlib_rebuild.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t.mcps)
 
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs/stdlib_rebuild -resource-dir %S/Inputs/stdlib_rebuild -module-cache-path %t.mcps/rebuild-remarks-off) -typecheck %s 2>&1 | %FileCheck -check-prefixes SLOW-DIAG,ALL %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs/stdlib_rebuild -resource-dir %S/Inputs/stdlib_rebuild -module-cache-path %t.mcps/rebuild-remarks-off) -typecheck %s 2>&1 | %FileCheck -check-prefixes ALL %s
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs/stdlib_rebuild -resource-dir %S/Inputs/stdlib_rebuild -module-cache-path %t.mcps/rebuild-remarks-off) -typecheck %s 2>&1 | %FileCheck -check-prefixes ALL --allow-empty %s
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs/stdlib_rebuild -resource-dir %S/Inputs/stdlib_rebuild -module-cache-path %t.mcps/rebuild-remarks-off) -D OTHER_IMPORT -typecheck %s 2>&1 | %FileCheck -check-prefixes ALL --allow-empty %s
 
@@ -16,8 +16,6 @@ import OtherModule
 #endif
 
 func fn(_: Int) {}
-
-// SLOW-DIAG: remark: did not find a prebuilt standard library for target '{{.*}}' compatible with this Swift compiler; building it may take a few minutes, but it should only happen once for this combination of compiler and target
 
 // NORMAL-DIAG-DAG: remark: rebuilding module 'Swift' from interface '{{.*}}'
 // NORMAL-DIAG-DAG: remark: rebuilding module '_Concurrency' from interface '{{.*}}'


### PR DESCRIPTION
Prebuilt modules are only available for certain toolchain and SDK combinations. Therefore,
building modules from interface, even for the stdlib, is expected to happen.

related: rdar://96701615
