### PR TITLE
[test] lit: Delay setting up %env- substitutions until we have target_env_prefix fully configured

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1954,12 +1954,6 @@ def configure_remote_run():
         remote_tmp_dir, 'bin', swift_reflection_test_name)
     config.available_features.add('remote_run')
 
-# Different OS's require different prefixes for the environment variables to be
-# propagated to the calling contexts.
-# In order to make tests OS-agnostic, names of environment variables should be
-# prefixed with `%env-`, which is then expanded to the appropriate prefix.
-config.substitutions.append(('%env-', config.target_env_prefix))
-
 config.substitutions.append(("%target-sdk-name", config.target_sdk_name))
 
 simulator_sdks = [
@@ -2285,6 +2279,12 @@ if platform.system() != 'Darwin' or swift_test_mode == 'optimize_none_with_impli
 #
 # When changing substitutions, update docs/Testing.md.
 #
+
+# Different OS's require different prefixes for the environment variables to be
+# propagated to the calling contexts.
+# In order to make tests OS-agnostic, names of environment variables should be
+# prefixed with `%env-`, which is then expanded to the appropriate prefix.
+config.substitutions.append(('%env-', config.target_env_prefix))
 
 config.substitutions.append(('%target-clangxx', '%s -std=c++11' % config.target_clang))
 config.substitutions.append(('%target-swiftxx-frontend', '%s -enable-experimental-cxx-interop' % config.target_swift_frontend))


### PR DESCRIPTION
This resolves variables not properly propagating through `remote-run` invocations during testing.

Currently, when tests are run through `remote-run`, incantations such as

```
// RUN: env %env-SWIFT_DETERMINISTIC_HASHING='' %target-run %t/hash > %t/nondeterministic.log
```

get turned into this:

```
: 'RUN: at line 5';   env SWIFT_DETERMINISTIC_HASHING='' /usr/bin/env REMOTE_RUN_CHILD_DYLD_LIBRARY_PATH='/usr/lib/swift:/tmp/swift-remote-run/stdlib' '<PATH>/swift/utils'/remote-run --input-prefix '<PATH>/swift' --output-prefix <PATH>/stdlib/Output/HashingRandomization.swift.tmp --remote-dir '/tmp/swift-remote-run'<PATH>/stdlib/Output/HashingRandomization.swift.tmp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i <PATH>/ssh_id root@<HOST>:<PORT> <PATH>/stdlib/Output/HashingRandomization.swift.tmp/hash >> <PATH>/stdlib/Output/HashingRandomization.swift.tmp/nondeterministic.log
```

Note how the SWIFT_DETERMINISTIC_HASHING environment variable doesn't get the expected REMOTE_RUN_CHILD_ prefix, so it only affects the `remote-run` process tree, not the remote process which is its intended target.