### PR TITLE
[Sema][Revert] Revert CTP to CTP_ReturnStmt for closure result in return stmt

### DIFF
--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -891,7 +891,7 @@ private:
     }
 
     SolutionApplicationTarget target(resultExpr, context.getAsDeclContext(),
-                                     CTP_ClosureResult, resultType,
+                                     CTP_ReturnStmt, resultType,
                                      /*isDiscarded=*/false);
 
     if (cs.generateConstraints(target, FreeTypeVariableBinding::Disallow)) {
@@ -900,7 +900,7 @@ private:
     }
 
     cs.setContextualType(target.getAsExpr(), TypeLoc::withoutLoc(resultType),
-                         CTP_ClosureResult);
+                         CTP_ReturnStmt);
     cs.setSolutionApplicationTarget(returnStmt, target);
   }
 
@@ -1510,7 +1510,7 @@ private:
     // number of times.
     {
       SolutionApplicationTarget target(resultExpr, context.getAsDeclContext(),
-                                       CTP_ClosureResult, resultType,
+                                       CTP_ReturnStmt, resultType,
                                        /*isDiscarded=*/false);
       cs.setSolutionApplicationTarget(returnStmt, target);
 
@@ -1576,7 +1576,7 @@ private:
 
     SolutionApplicationTarget resultTarget(
         resultExpr, context.getAsDeclContext(),
-        mode == convertToResult ? CTP_ClosureResult : CTP_Unused,
+        mode == convertToResult ? CTP_ReturnStmt : CTP_Unused,
         mode == convertToResult ? resultType : Type(),
         /*isDiscarded=*/false);
     if (auto newResultTarget = rewriteTarget(resultTarget))

--- a/test/Constraints/callAsFunction.swift
+++ b/test/Constraints/callAsFunction.swift
@@ -83,7 +83,7 @@ struct Test {
   var body8: MyLayout {
     MyLayout {
       let x = ""
-      return x // expected-error {{cannot convert value of type 'String' to closure result type 'Int'}}
+      return x // expected-error {{cannot convert return expression of type 'String' to return type 'Int'}}
     } content: {
       EmptyView()
     }

--- a/test/decl/circularity.swift
+++ b/test/decl/circularity.swift
@@ -41,7 +41,7 @@ class Sub: Base {
     var foo = { () -> Int in
         let x = 42
         // FIXME: Bogus diagnostic
-        return foo(1) // expected-error {{cannot convert value of type '()' to closure result type 'Int'}}
+        return foo(1) // expected-error {{cannot convert return expression of type '()' to return type 'Int'}}
     }()
 }
 

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -690,7 +690,7 @@ func testSR13239_ArgsFn() -> Int {
 func testSR13239MultiExpr() -> Int {
   callit {
     print("hello") 
-    return print("hello") // expected-error {{cannot convert value of type '()' to closure result type 'Int'}}
+    return print("hello") // expected-error {{cannot convert return expression of type '()' to return type 'Int'}}
   }
 }
 
@@ -734,19 +734,20 @@ public class TestImplicitCaptureOfExplicitCaptureOfSelfInEscapingClosure {
 }
 
 // https://github.com/apple/swift/issues/59716
+// FIXME: Diagnostic should be tailored for closure result
 ["foo"].map { s in
-    if s == "1" { return } // expected-error{{cannot convert value of type '()' to closure result type 'Bool'}}
+    if s == "1" { return } // expected-error{{cannot convert return expression of type '()' to return type 'Bool'}}
     return s.isEmpty
 }.filter { $0 }
 
 ["foo"].map { s in
-    if s == "1" { return } // expected-error{{cannot convert value of type '()' to closure result type 'Bool'}}
+    if s == "1" { return } // expected-error{{cannot convert return expression of type '()' to return type 'Bool'}}
     if s == "2" { return }
     if s == "3" { return }
     return s.isEmpty
 }.filter { $0 }
 
 ["foo"].map { s in
-    if s == "1" { return () } // expected-error{{cannot convert value of type '()' to closure result type 'Bool'}}
+    if s == "1" { return () } // expected-error{{cannot convert return expression of type '()' to return type 'Bool'}}
     return s.isEmpty
 }.filter { $0 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
The original change breaks opaque result type opening - ConstraintSystem::openOpaqueType only accepts CTP_ReturnStmt for opening. So reverting this part for now and improving diagnostics in a follow-up.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
