### PR TITLE
[cxx-interop] Mark `operator!` as `prefix func`

### DIFF
--- a/test/Interop/Cxx/operators/member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/member-inline-module-interface.swift
@@ -9,7 +9,7 @@
 // CHECK: }
 
 // CHECK: struct LoadableBoolWrapper {
-// CHECK:   static func ! (lhs: inout LoadableBoolWrapper) -> LoadableBoolWrapper
+// CHECK:   prefix static func ! (lhs: inout LoadableBoolWrapper) -> LoadableBoolWrapper
 // CHECK: }
 
 // CHECK: struct AddressOnlyIntWrapper {

--- a/test/Interop/Cxx/operators/member-inline-silgen.swift
+++ b/test/Interop/Cxx/operators/member-inline-silgen.swift
@@ -16,7 +16,7 @@ public func exclaim(_ wrapper: inout LoadableBoolWrapper) -> LoadableBoolWrapper
 // CHECK: bb0([[SELF:%.*]] : $*LoadableBoolWrapper):
 // CHECK:   [[METATYPE:%.*]] = metatype $@thin LoadableBoolWrapper.Type
 // CHECK:   [[SELFACCESS:%.*]] = begin_access [modify] [static] [[SELF]] : $*LoadableBoolWrapper
-// CHECK:   [[OP:%.*]] = function_ref @$sSo19LoadableBoolWrapperV1noiyA2BzFZ : $@convention(method) (@inout LoadableBoolWrapper, @thin LoadableBoolWrapper.Type) -> LoadableBoolWrapper
+// CHECK:   [[OP:%.*]] = function_ref @$sSo19LoadableBoolWrapperV1nopyA2BzFZ : $@convention(method) (@inout LoadableBoolWrapper, @thin LoadableBoolWrapper.Type) -> LoadableBoolWrapper
 // CHECK:   apply [[OP]]([[SELFACCESS]], [[METATYPE]]) : $@convention(method) (@inout LoadableBoolWrapper, @thin LoadableBoolWrapper.Type) -> LoadableBoolWrapper
 // CHECK:   end_access [[SELFACCESS]]
 


### PR DESCRIPTION
Prefix operators in Swift need to be marked as `prefix func`.

For example, the lack of `prefix` attribute prevents the user from conforming a C++ type that defines `operator!` to a Swift protocol that requires `static prefix func !(obj: Self) -> Self`.
