### PR TITLE
[cxx-interop] Fix lookup of member operators

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2234,6 +2234,9 @@ namespace {
 
               // Make the actual member operator private.
               MD->overwriteAccess(AccessLevel::Private);
+
+              // Make sure the synthesized decl can be found by lookupDirect.
+              result->addMemberToLookupTable(opFuncDecl);
             }
 
             if (cxxMethod->getDeclName().isIdentifier()) {

--- a/test/Interop/Cxx/class/Inputs/protocol-conformance.h
+++ b/test/Interop/Cxx/class/Inputs/protocol-conformance.h
@@ -38,4 +38,18 @@ struct ReturnsNonNullValue {
   }
 };
 
+struct HasOperatorExclaim {
+  int value;
+
+  HasOperatorExclaim operator!() const { return {-value}; }
+};
+
+struct HasOperatorEqualEqual {
+  int value;
+  
+  bool operator==(const HasOperatorEqualEqual &other) const {
+    return value == other.value;
+  }
+};
+
 #endif // TEST_INTEROP_CXX_CLASS_INPUTS_PROTOCOL_CONFORMANCE_H

--- a/test/Interop/Cxx/class/protocol-conformance-typechecker.swift
+++ b/test/Interop/Cxx/class/protocol-conformance-typechecker.swift
@@ -26,3 +26,12 @@ protocol HasReturnNonNull {
 }
 
 extension ReturnsNonNullValue: HasReturnNonNull {}
+
+
+protocol Invertable {
+  static prefix func !(obj: Self) -> Self
+}
+
+extension HasOperatorExclaim: Invertable {}
+
+extension HasOperatorEqualEqual: Equatable {}


### PR DESCRIPTION
Calling `StructDecl::lookupDirect` with an operator identifier (e.g. `==`) previously returned no results. This happened because the underlying C++ operator function was added to the lookup table with an underscored name (e.g. `__operatorEqualEqual`), and the synthesized function was not added to the lookup table at all. Lookup should find the synthesized decl, since that is what Swift code will call.

This fixes a typechecker error when trying to conform a C++ struct that defines an operator to a Swift protocol with an operator requirement (e.g. `Equatable`).