### PR TITLE
Some improvements in WalkUtils and use the ValueUseDefWalker in the ReleaseDevirtualizer pass

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/EscapeInfoDumper.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/EscapeInfoDumper.swift
@@ -25,19 +25,19 @@ let escapeInfoDumper = FunctionPass(name: "dump-escape-info", {
   struct Visitor : EscapeInfoVisitor {
     var results: Set<String> =  Set()
     
-    mutating func visitUse(operand: Operand, path: Path, state: State) -> UseResult {
+    mutating func visitUse(operand: Operand, path: EscapePath) -> UseResult {
       if operand.instruction is ReturnInst {
-        results.insert("return[\(path)]")
+        results.insert("return[\(path.projectionPath)]")
         return .ignore
       }
       return .continueWalk
     }
     
-    mutating func visitDef(def: Value, path: Path, state: State) -> DefResult {
+    mutating func visitDef(def: Value, path: EscapePath) -> DefResult {
       guard let arg = def as? FunctionArgument else {
         return .continueWalkUp
       }
-      results.insert("arg\(arg.index)[\(path)]")
+      results.insert("arg\(arg.index)[\(path.projectionPath)]")
       return .walkDown
     }
   }
@@ -96,7 +96,7 @@ let addressEscapeInfoDumper = FunctionPass(name: "dump-addr-escape-info", {
   
   struct Visitor : EscapeInfoVisitor {
     let apply: Instruction
-    mutating func visitUse(operand: Operand, path: Path, state: State) -> UseResult {
+    mutating func visitUse(operand: Operand, path: EscapePath) -> UseResult {
       let user = operand.instruction
       if user == apply {
         return .abort

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/StackPromotion.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/StackPromotion.swift
@@ -201,7 +201,7 @@ private func getDominatingBlockOfAllUsePoints(context: PassContext,
   struct Visitor : EscapeInfoVisitor {
     var dominatingBlock: BasicBlock
     let domTree: DominatorTree
-    mutating func visitUse(operand: Operand, path: Path, state: State) -> UseResult {
+    mutating func visitUse(operand: Operand, path: EscapePath) -> UseResult {
       let defBlock = operand.value.definingBlock
       if defBlock.dominates(dominatingBlock, domTree) {
         dominatingBlock = defBlock
@@ -232,7 +232,7 @@ func computeInnerAndOuterLiferanges(instruction: SingleValueInstruction, in domB
       self.domTree = domTree
     }
     
-    mutating func visitUse(operand: Operand, path: Path, state: State) -> UseResult {
+    mutating func visitUse(operand: Operand, path: EscapePath) -> UseResult {
       let user = operand.instruction
       if innerRange.blockRange.begin.dominates(user.block, domTree) {
         innerRange.insert(user)

--- a/test/SILOptimizer/devirt_release.sil
+++ b/test/SILOptimizer/devirt_release.sil
@@ -11,8 +11,12 @@ import Builtin
 import Swift
 
 class B {
+  @_hasStorage var next: B
 }
 
+struct Str {
+  @_hasStorage var b: B
+}
 
 // CHECK-LABEL: sil @devirtualize_object
 // CHECK: [[A:%[0-9]+]] = alloc_ref
@@ -21,7 +25,7 @@ class B {
 // CHECK: [[D:%[0-9]+]] = function_ref @$s4test1BCfD
 // CHECK-NEXT: apply [[D]]([[A]])
 // CHECK-NEXT: dealloc_stack_ref [[A]]
-// CHECK: return
+// CHECK: } // end sil function 'devirtualize_object'
 sil @devirtualize_object : $@convention(thin) () -> () {
 bb0:
   %1 = alloc_ref [stack] $B
@@ -36,6 +40,7 @@ bb0:
 // CHECK-NEXT: strong_release
 // CHECK-NEXT: dealloc_ref
 // CHECK: return
+// CHECK: } // end sil function 'dont_devirtualize_heap_allocated'
 sil @dont_devirtualize_heap_allocated : $@convention(thin) () -> () {
 bb0:
   %1 = alloc_ref $B
@@ -72,6 +77,7 @@ bb0:
 // CHECK-NEXT: strong_release
 // CHECK-NEXT: dealloc_ref
 // CHECK: return
+// CHECK: } // end sil function 'dont_devirtualize_wrong_release'
 sil @dont_devirtualize_wrong_release : $@convention(thin) (@owned B) -> () {
 bb0(%0 : $B):
   %1 = alloc_ref $B
@@ -88,7 +94,7 @@ bb0(%0 : $B):
 // CHECK: [[F:%[0-9]+]] = function_ref @unknown_func
 // CHECK-NEXT: apply [[F]]()
 // CHECK-NEXT: dealloc_ref
-// CHECK: return
+// CHECK: } // end sil function 'dont_devirtualize_unknown_release'
 sil @dont_devirtualize_unknown_release : $@convention(thin) (@owned B) -> () {
 bb0(%0 : $B):
   %1 = alloc_ref $B
@@ -107,7 +113,7 @@ bb0(%0 : $B):
 // CHECK: [[D:%[0-9]+]] = function_ref @$s4test1BCfD
 // CHECK-NEXT: apply [[D]]([[A]])
 // CHECK-NEXT: dealloc_stack_ref [[A]]
-// CHECK: return
+// CHECK: } // end sil function 'dont_crash_with_missing_release'
 sil @dont_crash_with_missing_release : $@convention(thin) () -> () {
 bb0:
   %1 = alloc_ref [stack] $B
@@ -119,42 +125,93 @@ bb0:
   return %r : $()
 }
 
+// CHECK-LABEL: sil @long_chain_from_alloc_to_release
+// CHECK: set_deallocating
+// CHECK-NOT: release_value
+// CHECK: } // end sil function 'long_chain_from_alloc_to_release'
+sil @long_chain_from_alloc_to_release : $@convention(thin) () -> () {
+bb0:
+  %1 = alloc_ref [stack] $B
+  %2 = struct $Str(%1 : $B)
+  %3 = struct_extract %2 : $Str, #Str.b
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3(%3 : $B)
+
+bb2:
+  br bb3(%3 : $B)
+
+bb3(%a : $B):
+  %s = struct $Str (%a : $B)
+  %i = integer_literal $Builtin.Int64, 0
+  %t = tuple (%s : $Str, %i : $Builtin.Int64)
+  %o = enum $Optional<(Str, Builtin.Int64)>, #Optional.some!enumelt, %t : $(Str, Builtin.Int64)
+  release_value %o : $Optional<(Str, Builtin.Int64)>
+  dealloc_stack_ref %1 : $B
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @dont_devirtualize_double_release
+// CHECK-NOT:     set_deallocating
+// CHECK:         release_value
+// CHECK: } // end sil function 'dont_devirtualize_double_release'
+sil @dont_devirtualize_double_release : $@convention(thin) () -> () {
+bb0:
+  %1 = alloc_ref [stack] $B
+  %t = tuple (%1 : $B, %1 : $B)
+  release_value %t : $(B, B)
+  dealloc_stack_ref %1 : $B
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @dont_devirtualize_release_of_load
+// CHECK-NOT:     set_deallocating
+// CHECK:         strong_release
+// CHECK: } // end sil function 'dont_devirtualize_release_of_load'
+sil @dont_devirtualize_release_of_load : $@convention(thin) () -> () {
+bb0:
+  %1 = alloc_ref [stack] $B
+  %2 = ref_element_addr %1 : $B, #B.next
+  %3 = load %2 : $*B
+  strong_release %3 : $B
+  dealloc_stack_ref %1 : $B
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @dont_devirtualize_release_of_different_allocations
+// CHECK-NOT:     set_deallocating
+// CHECK:         strong_release
+// CHECK: } // end sil function 'dont_devirtualize_release_of_different_allocations'
+sil @dont_devirtualize_release_of_different_allocations : $@convention(thin) () -> () {
+bb0:
+  %1 = alloc_ref [stack] $B
+  %2 = alloc_ref [stack] $B
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3(%1 : $B)
+
+bb2:
+  br bb3(%2 : $B)
+
+bb3(%a : $B):
+  strong_release %a : $B
+  dealloc_stack_ref %2 : $B
+  dealloc_stack_ref %1 : $B
+  %r = tuple ()
+  return %r : $()
+}
+
 
 sil @unknown_func : $@convention(thin) () -> ()
 
-// test.B.__deallocating_deinit
-sil hidden @$s4test1BCfD : $@convention(method) (@owned B) -> () {
-// %0                                             // users: %1, %3
-bb0(%0 : $B):
-  debug_value %0 : $B, let, name "self" // id: %1
-  // function_ref test.B.deinit
-  %2 = function_ref @$s4test1BCfd : $@convention(method) (@guaranteed B) -> @owned Builtin.NativeObject // user: %3
-  %3 = apply %2(%0) : $@convention(method) (@guaranteed B) -> @owned Builtin.NativeObject // user: %4
-  %4 = unchecked_ref_cast %3 : $Builtin.NativeObject to $B // user: %5
-  dealloc_ref %4 : $B                             // id: %5
-  %6 = tuple ()                                   // user: %7
-  return %6 : $()                                 // id: %7
-}
-
-// test.B.deinit
-sil hidden @$s4test1BCfd : $@convention(method) (@guaranteed B) -> @owned Builtin.NativeObject {
-// %0                                             // users: %1, %2
-bb0(%0 : $B):
-  debug_value %0 : $B, let, name "self" // id: %1
-  %2 = unchecked_ref_cast %0 : $B to $Builtin.NativeObject // user: %3
-  return %2 : $Builtin.NativeObject               // id: %3
-}
-
-// test.B.init () -> test.B
-sil hidden @$s4test1BCACycfc : $@convention(method) (@owned B) -> @owned B {
-// %0                                             // users: %1, %2
-bb0(%0 : $B):
-  debug_value %0 : $B, let, name "self" // id: %1
-  return %0 : $B                                  // id: %2
-}
+sil @$s4test1BCfD : $@convention(method) (@owned B) -> ()
 
 sil_vtable B {
-  #B.deinit!deallocator: @$s4test1BCfD	// test.B.__deallocating_deinit
-  #B.init!initializer: @$s4test1BCACycfc	// test.B.init () -> test.B
+  #B.deinit!deallocator: @$s4test1BCfD
 }
 

--- a/test/SILOptimizer/escape_info.sil
+++ b/test/SILOptimizer/escape_info.sil
@@ -1240,3 +1240,24 @@ bb0:
   return %14 : $()
 }
 
+// CHECK-LABEL: Escape information for test_destroyArray:
+// CHECK: global:   %0 = alloc_ref $Y
+// CHECK:  -    :   %1 = alloc_ref $Z
+// CHECK: End function test_destroyArray
+sil @test_destroyArray : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_ref $Y
+  %1 = alloc_ref $Z
+  %2 = ref_element_addr %1 : $Z, #Z.y
+  store %0 to %2 : $*Y
+  %4 = alloc_stack $Z
+  store %1 to %4 : $*Z
+  %6 = metatype $@thick Z.Type
+  %7 = address_to_pointer %4 : $*Z to $Builtin.RawPointer
+  %8 = integer_literal $Builtin.Word, 1
+  %9 = builtin "destroyArray"<Z>(%6 : $@thick Z.Type, %7 : $Builtin.RawPointer, %8 : $Builtin.Word) : $()
+  dealloc_stack %4 : $*Z
+  %11 = tuple ()
+  return %11 : $()
+}
+


### PR DESCRIPTION
Improvements for WalkUtils and EscapeInfo:

* "merge" the `Path` and `State` in WalkUtils into a single `WalkingPath`. This makes it simpler for clients to configure a path and additional state variables. EscapeInfo now defines `EscapePath` which includes the projection path and EscapeInfo's specific state variables.
* Make the `WalkerCache` part of the WalkUtils, so that not all clients have to re-implement it.
* Rename `walkDownResults` -> `walkDownAllResults` and `walkUpOperands` -> `walkUpAllOperands` and make these functions client configurable.

And: use the `ValueUseDefWalker` instead of the manual use-def walking implementation