### PR TITLE
Enable opening of an existential `var`

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5935,7 +5935,8 @@ ArgumentList *ExprRewriter::coerceCallArguments(
 
     // If the argument is an existential type that has been opened, perform
     // the open operation.
-    if (argType->getInOutObjectType()->isAnyExistentialType() &&
+    if (argType->getRValueType()->getInOutObjectType()
+            ->isAnyExistentialType() &&
         paramType->hasOpenedExistential()) {
       // FIXME: Look for an opened existential and use it. We need to
       // know how far out we need to go to close the existentials. Huh.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1547,6 +1547,10 @@ shouldOpenExistentialCallArgument(
     adjustments |= OpenedExistentialAdjustmentFlags::InOut;
   }
 
+  // The argument may be a "var" instead of a "let".
+  if (auto lv = dyn_cast<LValueType>(argTy->getCanonicalType()))
+    argTy = lv->getObjectType();
+
   // The argument type needs to be an existential type or metatype thereof.
   if (!argTy->isAnyExistentialType())
     return None;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1468,6 +1468,7 @@ namespace {
   enum class OpenedExistentialAdjustmentFlags {
     /// The argument should be made inout after opening.
     InOut = 0x01,
+    LValue = 0x02,
   };
 
   using OpenedExistentialAdjustments =
@@ -1541,15 +1542,17 @@ shouldOpenExistentialCallArgument(
 
   OpenedExistentialAdjustments adjustments;
 
+  // The argument may be a "var" instead of a "let".
+  if (auto lv = argTy->getAs<LValueType>()) {
+    argTy = lv->getObjectType();
+    adjustments |= OpenedExistentialAdjustmentFlags::LValue;
+  }
+
   // If the argument is inout, strip it off and we can add it back.
   if (auto inOutArg = argTy->getAs<InOutType>()) {
     argTy = inOutArg->getObjectType();
     adjustments |= OpenedExistentialAdjustmentFlags::InOut;
   }
-
-  // The argument may be a "var" instead of a "let".
-  if (auto lv = dyn_cast<LValueType>(argTy->getCanonicalType()))
-    argTy = lv->getObjectType();
 
   // The argument type needs to be an existential type or metatype thereof.
   if (!argTy->isAnyExistentialType())
@@ -1947,6 +1950,9 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
         OpenedArchetypeType *opened;
         std::tie(argTy, opened) = cs.openExistentialType(
             existentialType, cs.getConstraintLocator(loc));
+
+        if (adjustments.contains(OpenedExistentialAdjustmentFlags::LValue))
+          argTy = LValueType::get(argTy);
 
         if (adjustments.contains(OpenedExistentialAdjustmentFlags::InOut))
           argTy = InOutType::get(argTy);

--- a/test/Constraints/opened_existentials.swift
+++ b/test/Constraints/opened_existentials.swift
@@ -25,6 +25,10 @@ func testSimpleExistentialOpening(p: any P, pq: any P & Q, c: any Collection) {
   let pa = acceptGeneric(p)
   let _: Int = pa // expected-error{{cannot convert value of type '(any Q)?' to specified type 'Int'}}
 
+  var vp = p
+  let vpa = acceptGeneric(vp)
+  let _: Int = vpa // expected-error{{cannot convert value of type '(any Q)?' to specified type 'Int'}}
+
   let pqa = acceptGeneric(pq)
   let _: Int = pqa  // expected-error{{cannot convert value of type '(any Q)?' to specified type 'Int'}}
 


### PR DESCRIPTION
Perform appropriate lvalue adjustments when opening a `var` of existential type. 

Fixes rdar://95874158. Thank you to @johnno1962 for doing 99% of the work here.