### PR TITLE
Add option to run new llvm pass manager in IRGen

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -237,6 +237,9 @@ public:
   /// well-formed?
   unsigned Verify : 1;
 
+  /// Should we use the legacy pass manager.
+  unsigned LegacyPassManager : 1;
+
   OptimizationMode OptMode;
 
   /// Which sanitizer is turned on.
@@ -443,7 +446,7 @@ public:
   IRGenOptions()
       : DWARFVersion(2),
         OutputKind(IRGenOutputKind::LLVMAssemblyAfterOptimization),
-        Verify(true), OptMode(OptimizationMode::NotSet),
+        Verify(true), LegacyPassManager(1), OptMode(OptimizationMode::NotSet),
         Sanitizers(OptionSet<SanitizerKind>()),
         SanitizersWithRecoveryInstrumentation(OptionSet<SanitizerKind>()),
         SanitizeAddressUseODRIndicator(false),

--- a/include/swift/LLVMPasses/Passes.h
+++ b/include/swift/LLVMPasses/Passes.h
@@ -31,6 +31,11 @@ namespace swift {
     bool invalidate(llvm::Function &,
                     const llvm::PreservedAnalyses &) { return false; }
 
+    bool invalidate(llvm::Function &, const llvm::PreservedAnalyses &,
+                    llvm::FunctionAnalysisManager::Invalidator &) {
+      return false;
+    }
+
     using AAResultBase::getModRefInfo;
     llvm::ModRefInfo getModRefInfo(const llvm::CallBase *Call,
                                    const llvm::MemoryLocation &Loc) {
@@ -57,27 +62,34 @@ namespace swift {
     void getAnalysisUsage(llvm::AnalysisUsage &AU) const override;
   };
 
-  class SwiftRCIdentity : public llvm::ImmutablePass {
+  class SwiftAA : public llvm::AnalysisInfoMixin<SwiftAA> {
+    friend llvm::AnalysisInfoMixin<SwiftAA>;
+
+    static llvm::AnalysisKey Key;
+
   public:
-    static char ID; // Class identification, replacement for typeinfo
-    SwiftRCIdentity() : ImmutablePass(ID) {}
+    using Result = SwiftAAResult;
+
+    SwiftAAResult run(llvm::Function &F, llvm::FunctionAnalysisManager &AM);
+  };
+
+  class SwiftRCIdentity {
+  public:
+    SwiftRCIdentity() {}
 
     /// Returns the root of the RC-equivalent value for the given V.
     llvm::Value *getSwiftRCIdentityRoot(llvm::Value *V);
+
   private:
     enum { MaxRecursionDepth = 16 };
-    bool doInitialization(llvm::Module &M) override;
 
-    void getAnalysisUsage(llvm::AnalysisUsage &AU) const override {
-      AU.setPreservesAll();
-    }
     llvm::Value *stripPointerCasts(llvm::Value *Val);
     llvm::Value *stripReferenceForwarding(llvm::Value *Val);
   };
 
   class SwiftARCOpt : public llvm::FunctionPass {
     /// Swift RC Identity analysis.
-    SwiftRCIdentity *RC;
+    SwiftRCIdentity RC;
     virtual void getAnalysisUsage(llvm::AnalysisUsage &AU) const override;
     virtual bool runOnFunction(llvm::Function &F) override;
   public:
@@ -85,14 +97,29 @@ namespace swift {
     SwiftARCOpt();
   };
 
+  struct SwiftARCOptPass : public llvm::PassInfoMixin<SwiftARCOptPass> {
+    SwiftRCIdentity RC;
+
+    llvm::PreservedAnalyses run(llvm::Function &F,
+                                llvm::FunctionAnalysisManager &AM);
+  };
+
   class SwiftARCContract : public llvm::FunctionPass {
     /// Swift RC Identity analysis.
-    SwiftRCIdentity *RC;
+    SwiftRCIdentity RC;
     virtual void getAnalysisUsage(llvm::AnalysisUsage &AU) const override;
     virtual bool runOnFunction(llvm::Function &F) override;
   public:
     static char ID;
     SwiftARCContract() : llvm::FunctionPass(ID) {}
+  };
+
+  struct SwiftARCContractPass
+      : public llvm::PassInfoMixin<SwiftARCContractPass> {
+    SwiftRCIdentity RC;
+
+    llvm::PreservedAnalyses run(llvm::Function &F,
+                                llvm::FunctionAnalysisManager &AM);
   };
 
   class InlineTreePrinter : public llvm::ModulePass {
@@ -101,6 +128,30 @@ namespace swift {
   public:
     static char ID;
     InlineTreePrinter() : llvm::ModulePass(ID) {}
+  };
+
+  class SwiftMergeFunctionsPass
+      : public llvm::PassInfoMixin<SwiftMergeFunctionsPass> {
+    bool ptrAuthEnabled = false;
+    unsigned ptrAuthKey = 0;
+
+  public:
+    SwiftMergeFunctionsPass(bool ptrAuthEnabled, unsigned ptrAuthKey)
+        : ptrAuthEnabled(ptrAuthEnabled), ptrAuthKey(ptrAuthKey) {}
+    llvm::PreservedAnalyses run(llvm::Module &M,
+                                llvm::ModuleAnalysisManager &AM);
+  };
+
+  struct SwiftDbgAddrBlockSplitterPass
+      : public llvm::PassInfoMixin<SwiftDbgAddrBlockSplitterPass> {
+    llvm::PreservedAnalyses run(llvm::Function &F,
+                                llvm::FunctionAnalysisManager &AM);
+  };
+
+  struct InlineTreePrinterPass
+      : public llvm::PassInfoMixin<InlineTreePrinterPass> {
+    llvm::PreservedAnalyses run(llvm::Module &M,
+                                llvm::ModuleAnalysisManager &AM);
   };
 } // end namespace swift
 

--- a/include/swift/LLVMPasses/PassesFwd.h
+++ b/include/swift/LLVMPasses/PassesFwd.h
@@ -20,11 +20,10 @@ namespace llvm {
   class PassRegistry;
 
   void initializeSwiftAAWrapperPassPass(PassRegistry &);
-  void initializeSwiftRCIdentityPass(PassRegistry &);
   void initializeSwiftARCOptPass(PassRegistry &);
   void initializeSwiftARCContractPass(PassRegistry &);
   void initializeInlineTreePrinterPass(PassRegistry &);
-  void initializeSwiftMergeFunctionsPass(PassRegistry &);
+  void initializeLegacySwiftMergeFunctionsPass(PassRegistry &);
   void initializeSwiftDbgAddrBlockSplitterPass(PassRegistry &);
 }
 
@@ -32,11 +31,10 @@ namespace swift {
   llvm::FunctionPass *createSwiftARCOptPass();
   llvm::FunctionPass *createSwiftARCContractPass();
   llvm::ModulePass *createInlineTreePrinterPass();
-  llvm::ModulePass *createSwiftMergeFunctionsPass(bool ptrAuthEnabled,
-                                                  unsigned ptrAuthKey);
+  llvm::ModulePass *createLegacySwiftMergeFunctionsPass(bool ptrAuthEnabled,
+                                                        unsigned ptrAuthKey);
   llvm::FunctionPass *createSwiftDbgAddrBlockSplitter();
   llvm::ImmutablePass *createSwiftAAWrapperPass();
-  llvm::ImmutablePass *createSwiftRCIdentityPass();
 } // end namespace swift
 
 #endif

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -1072,4 +1072,8 @@ def concurrency_model :
 def concurrency_model_EQ :
     Joined<["-"], "concurrency-model=">,
     Alias<concurrency_model>;
+
+def enable_new_llvm_pass_manager :
+  Flag<["-"], "enable-new-llvm-pass-manager">,
+  HelpText<"Enable new llvm pass manager">;
 } // end let Flags = [FrontendOption, NoDriverOption, HelpHidden]

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2365,6 +2365,9 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
       Opts.SwiftAsyncFramePointer = SwiftAsyncFramePointerKind::Never;
   }
 
+  if (Args.hasArg(OPT_enable_new_llvm_pass_manager))
+    Opts.LegacyPassManager = false;
+
   return false;
 }
 

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -290,7 +290,7 @@ performOptimizationsUsingLegacyPassManger(const IRGenOptions &Opts,
         if (Builder.OptLevel > 0) {
           const PointerAuthSchema &schema = Opts.PointerAuth.FunctionPointers;
           unsigned key = (schema.isEnabled() ? schema.getKey() : 0);
-          PM.add(createSwiftMergeFunctionsPass(schema.isEnabled(), key));
+          PM.add(createLegacySwiftMergeFunctionsPass(schema.isEnabled(), key));
         }
       });
   }

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -14,7 +14,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#define DEBUG_TYPE "irgen"
+#include "../Serialization/ModuleFormat.h"
 #include "IRGenModule.h"
 #include "swift/ABI/MetadataValues.h"
 #include "swift/AST/DiagnosticsIRGen.h"
@@ -44,7 +44,6 @@
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/Subsystems.h"
 #include "swift/TBDGen/TBDGen.h"
-#include "../Serialization/ModuleFormat.h"
 #include "clang/Basic/TargetInfo.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "llvm/ADT/StringSet.h"
@@ -59,12 +58,15 @@
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/Module.h"
+#include "llvm/IR/PassManager.h"
 #include "llvm/IR/ValueSymbolTable.h"
 #include "llvm/IR/Verifier.h"
 #include "llvm/Linker/Linker.h"
 #include "llvm/MC/SubtargetFeature.h"
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Object/ObjectFile.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Passes/StandardInstrumentations.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -79,6 +81,7 @@
 #include "llvm/Transforms/IPO/PassManagerBuilder.h"
 #include "llvm/Transforms/Instrumentation.h"
 #include "llvm/Transforms/Instrumentation/AddressSanitizer.h"
+#include "llvm/Transforms/Instrumentation/InstrProfiling.h"
 #include "llvm/Transforms/Instrumentation/SanitizerCoverage.h"
 #include "llvm/Transforms/Instrumentation/ThreadSanitizer.h"
 #include "llvm/Transforms/ObjCARC.h"
@@ -92,6 +95,8 @@
 using namespace swift;
 using namespace irgen;
 using namespace llvm;
+
+#define DEBUG_TYPE "irgen"
 
 static cl::opt<bool> DisableObjCARCContract(
     "disable-objc-arc-contract", cl::Hidden,
@@ -216,6 +221,22 @@ void setModuleFlags(IRGenModule &IGM) {
   }
 }
 
+static void align(llvm::Module *Module) {
+  // For performance benchmarking: Align the module to the page size by
+  // aligning the first function of the module.
+    unsigned pageSize =
+#if HAVE_UNISTD_H
+      sysconf(_SC_PAGESIZE));
+#else
+      4096; // Use a default value
+#endif
+    for (auto I = Module->begin(), E = Module->end(); I != E; ++I) {
+      if (!I->isDeclaration()) {
+        I->setAlignment(llvm::MaybeAlign(pageSize));
+        break;
+      }
+    }
+}
 static void
 performOptimizationsUsingLegacyPassManger(const IRGenOptions &Opts,
                                           llvm::Module *Module,
@@ -373,27 +394,197 @@ performOptimizationsUsingLegacyPassManger(const IRGenOptions &Opts,
   ModulePasses.run(*Module);
 
   if (AlignModuleToPageSize) {
-    // For performance benchmarking: Align the module to the page size by
-    // aligning the first function of the module.
-    unsigned pageSize =
-#if HAVE_UNISTD_H
-      sysconf(_SC_PAGESIZE));
-#else
-      4096; // Use a default value
-#endif
-    for (auto I = Module->begin(), E = Module->end(); I != E; ++I) {
-      if (!I->isDeclaration()) {
-        I->setAlignment(llvm::MaybeAlign(pageSize));
-        break;
-      }
-    }
+    align(Module);
   }
 }
 
 static void
 performOptimizationsUsingNewPassManger(const IRGenOptions &Opts,
                                        llvm::Module *Module,
-                                       llvm::TargetMachine *TargetMachine) {}
+                                       llvm::TargetMachine *TargetMachine) {
+  Optional<PGOOptions> PGOOpt;
+
+  PipelineTuningOptions PTO;
+
+  bool RunSwiftMergeFunctions = true;
+  // LLVM MergeFunctions and SwiftMergeFunctions don't understand that the
+  // string in the metadata on calls in @llvm.type.checked.load intrinsics is
+  // semantically meaningful, and mis-compile (mis-merge) unrelated functions.
+  if (Opts.VirtualFunctionElimination || Opts.WitnessMethodElimination) {
+    RunSwiftMergeFunctions = false;
+  }
+
+  bool RunSwiftSpecificLLVMOptzns =
+      !Opts.DisableSwiftSpecificLLVMOptzns && !Opts.DisableLLVMOptzns;
+
+  PTO.CallGraphProfile = false;
+
+  llvm::OptimizationLevel level = llvm::OptimizationLevel::O0;
+  if (Opts.shouldOptimize() && !Opts.DisableLLVMOptzns) {
+    // For historical reasons, loop interleaving is set to mirror setting for
+    // loop unrolling.
+    PTO.LoopInterleaving = true;
+    PTO.LoopVectorization = true;
+    PTO.SLPVectorization = true;
+    PTO.MergeFunctions = RunSwiftMergeFunctions;
+    level = llvm::OptimizationLevel::Os;
+  } else {
+    level = llvm::OptimizationLevel::O0;
+  }
+
+  LoopAnalysisManager LAM;
+  FunctionAnalysisManager FAM;
+  CGSCCAnalysisManager CGAM;
+  ModuleAnalysisManager MAM;
+
+  bool DebugPassStructure = false;
+  PassInstrumentationCallbacks PIC;
+  PrintPassOptions PrintPassOpts;
+  PrintPassOpts.Indent = DebugPassStructure;
+  PrintPassOpts.SkipAnalyses = DebugPassStructure;
+  StandardInstrumentations SI(DebugPassStructure, /*VerifyEach*/ false,
+                              PrintPassOpts);
+  SI.registerCallbacks(PIC, &FAM);
+
+  PassBuilder PB(TargetMachine, PTO, PGOOpt, &PIC);
+
+  // Register the AA manager first so that our version is the one used.
+  FAM.registerPass([&] {
+    auto AA = PB.buildDefaultAAPipeline();
+    if (RunSwiftSpecificLLVMOptzns)
+      AA.registerFunctionAnalysis<SwiftAA>();
+    return AA;
+  });
+  FAM.registerPass([&] { return SwiftAA(); });
+
+  // Register all the basic analyses with the managers.
+  PB.registerModuleAnalyses(MAM);
+  PB.registerCGSCCAnalyses(CGAM);
+  PB.registerFunctionAnalyses(FAM);
+  PB.registerLoopAnalyses(LAM);
+  PB.crossRegisterProxies(LAM, FAM, CGAM, MAM);
+  ModulePassManager MPM;
+
+  if (RunSwiftSpecificLLVMOptzns) {
+    PB.registerScalarOptimizerLateEPCallback(
+        [](FunctionPassManager &FPM, OptimizationLevel Level) {
+          if (Level != OptimizationLevel::O0)
+            FPM.addPass(SwiftARCOptPass());
+        });
+    PB.registerOptimizerLastEPCallback([](ModulePassManager &MPM,
+                                          OptimizationLevel Level) {
+      if (Level != OptimizationLevel::O0)
+        MPM.addPass(createModuleToFunctionPassAdaptor(SwiftARCContractPass()));
+    });
+  }
+
+  // PassBuilder adds coroutine passes per default.
+  //
+
+  if (Opts.Sanitizers & SanitizerKind::Address) {
+    PB.registerOptimizerLastEPCallback([&](ModulePassManager &MPM,
+                                           OptimizationLevel Level) {
+      auto Recover = bool(Opts.SanitizersWithRecoveryInstrumentation &
+                          SanitizerKind::Address);
+      bool UseAfterScope = false;
+      bool ModuleUseAfterScope = true;
+      bool UseOdrIndicator = Opts.SanitizeAddressUseODRIndicator;
+      llvm::AsanDtorKind DestructorKind = llvm::AsanDtorKind::Global;
+      llvm::AsanDetectStackUseAfterReturnMode UseAfterReturn =
+          llvm::AsanDetectStackUseAfterReturnMode::Runtime;
+      MPM.addPass(
+          RequireAnalysisPass<ASanGlobalsMetadataAnalysis, llvm::Module>());
+      MPM.addPass(ModuleAddressSanitizerPass(false, Recover,
+                                             ModuleUseAfterScope,
+                                             UseOdrIndicator, DestructorKind));
+      MPM.addPass(createModuleToFunctionPassAdaptor(AddressSanitizerPass(
+          {false, Recover, UseAfterScope, UseAfterReturn})));
+    });
+  }
+
+  if (Opts.Sanitizers & SanitizerKind::Thread) {
+    PB.registerOptimizerLastEPCallback(
+        [&](ModulePassManager &MPM, OptimizationLevel Level) {
+          MPM.addPass(ModuleThreadSanitizerPass());
+          MPM.addPass(createModuleToFunctionPassAdaptor(ThreadSanitizerPass()));
+        });
+  }
+
+  if (Opts.SanitizeCoverage.CoverageType !=
+      llvm::SanitizerCoverageOptions::SCK_None) {
+    PB.registerOptimizerLastEPCallback([&](ModulePassManager &MPM,
+                                           OptimizationLevel Level) {
+      std::vector<std::string> allowlistFiles;
+      std::vector<std::string> ignorelistFiles;
+      MPM.addPass(ModuleSanitizerCoveragePass(Opts.SanitizeCoverage,
+                                              allowlistFiles, ignorelistFiles));
+    });
+  }
+  if (RunSwiftSpecificLLVMOptzns && RunSwiftMergeFunctions) {
+    PB.registerOptimizerLastEPCallback(
+        [&](ModulePassManager &MPM, OptimizationLevel Level) {
+          if (Level != OptimizationLevel::O0) {
+            const PointerAuthSchema &schema = Opts.PointerAuth.FunctionPointers;
+            unsigned key = (schema.isEnabled() ? schema.getKey() : 0);
+            MPM.addPass(SwiftMergeFunctionsPass(schema.isEnabled(), key));
+          }
+        });
+  }
+  if (RunSwiftSpecificLLVMOptzns) {
+    PB.registerOptimizerLastEPCallback([&](ModulePassManager &MPM,
+                                           OptimizationLevel Level) {
+      MPM.addPass(
+          createModuleToFunctionPassAdaptor(SwiftDbgAddrBlockSplitterPass()));
+    });
+  }
+
+  if (Opts.GenerateProfile) {
+    InstrProfOptions options;
+    options.Atomic = bool(Opts.Sanitizers & SanitizerKind::Thread);
+    PB.registerPipelineStartEPCallback(
+        [options](ModulePassManager &MPM, OptimizationLevel level) {
+          MPM.addPass(InstrProfiling(options, false));
+        });
+  }
+
+  if (!Opts.shouldOptimize() || Opts.DisableLLVMOptzns) {
+    MPM = PB.buildO0DefaultPipeline(level, false);
+  } else {
+    MPM = PB.buildPerModuleDefaultPipeline(level);
+  }
+
+  // Make sure we do ARC contraction under optimization.  We don't
+  // rely on any other LLVM ARC transformations, but we do need ARC
+  // contraction to add the objc_retainAutoreleasedReturnValue
+  // assembly markers and remove clang.arc.used.
+  if (Opts.shouldOptimize() && !DisableObjCARCContract &&
+      !Opts.DisableLLVMOptzns)
+    MPM.addPass(createModuleToFunctionPassAdaptor(ObjCARCContractPass()));
+
+  if (Opts.Verify) {
+    // Run verification before we run the pipeline.
+    ModulePassManager VerifyPM;
+    VerifyPM.addPass(VerifierPass());
+    VerifyPM.run(*Module, MAM);
+    // PB.registerPipelineStartEPCallback(
+    //       [](ModulePassManager &MPM, OptimizationLevel Level) {
+    //         MPM.addPass(VerifierPass());
+    //       });
+
+    // Run verification after we ran the pipeline;
+    MPM.addPass(VerifierPass());
+  }
+
+  if (Opts.PrintInlineTree)
+    MPM.addPass(InlineTreePrinterPass());
+
+  if (!Opts.DisableLLVMOptzns)
+    MPM.run(*Module, MAM);
+
+  if (AlignModuleToPageSize) {
+    align(Module);
+  }
+}
 
 void swift::performLLVMOptimizations(const IRGenOptions &Opts,
                                      llvm::Module *Module,

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -216,9 +216,10 @@ void setModuleFlags(IRGenModule &IGM) {
   }
 }
 
-void swift::performLLVMOptimizations(const IRGenOptions &Opts,
-                                     llvm::Module *Module,
-                                     llvm::TargetMachine *TargetMachine) {
+static void
+performOptimizationsUsingLegacyPassManger(const IRGenOptions &Opts,
+                                          llvm::Module *Module,
+                                          llvm::TargetMachine *TargetMachine) {
   // Set up a pipeline.
   PassManagerBuilderWrapper PMBuilder(Opts);
 
@@ -387,6 +388,20 @@ void swift::performLLVMOptimizations(const IRGenOptions &Opts,
       }
     }
   }
+}
+
+static void
+performOptimizationsUsingNewPassManger(const IRGenOptions &Opts,
+                                       llvm::Module *Module,
+                                       llvm::TargetMachine *TargetMachine) {}
+
+void swift::performLLVMOptimizations(const IRGenOptions &Opts,
+                                     llvm::Module *Module,
+                                     llvm::TargetMachine *TargetMachine) {
+  if (Opts.LegacyPassManager)
+    performOptimizationsUsingLegacyPassManger(Opts, Module, TargetMachine);
+  else
+    performOptimizationsUsingNewPassManger(Opts, Module, TargetMachine);
 }
 
 /// Computes the MD5 hash of the llvm \p Module including the compiler version

--- a/lib/LLVMPasses/DbgAddrBlockSplitter.cpp
+++ b/lib/LLVMPasses/DbgAddrBlockSplitter.cpp
@@ -36,7 +36,7 @@ struct SwiftDbgAddrBlockSplitter : FunctionPass {
 
 } // namespace
 
-bool SwiftDbgAddrBlockSplitter::runOnFunction(Function &fn) {
+static bool split(Function &fn) {
   SmallVector<Instruction *, 32> breakBlockPoints;
 
   // If we are in the first block,
@@ -65,6 +65,10 @@ bool SwiftDbgAddrBlockSplitter::runOnFunction(Function &fn) {
   return madeChange;
 }
 
+bool SwiftDbgAddrBlockSplitter::runOnFunction(Function &fn) {
+  return split(fn);
+}
+
 char SwiftDbgAddrBlockSplitter::ID = 0;
 INITIALIZE_PASS_BEGIN(SwiftDbgAddrBlockSplitter,
                       "swift-dbg-addr-block-splitter",
@@ -78,4 +82,13 @@ llvm::FunctionPass *swift::createSwiftDbgAddrBlockSplitter() {
   initializeSwiftDbgAddrBlockSplitterPass(
       *llvm::PassRegistry::getPassRegistry());
   return new SwiftDbgAddrBlockSplitter();
+}
+
+llvm::PreservedAnalyses
+swift::SwiftDbgAddrBlockSplitterPass::run(llvm::Function &F,
+                                          llvm::FunctionAnalysisManager &AM) {
+  bool changed = split(F);
+  if (!changed)
+    return PreservedAnalyses::all();
+  return PreservedAnalyses::none();
 }

--- a/lib/LLVMPasses/LLVMInlineTree.cpp
+++ b/lib/LLVMPasses/LLVMInlineTree.cpp
@@ -370,3 +370,12 @@ bool InlineTreePrinter::runOnModule(Module &M) {
   Tree.print(outs());
   return false;
 }
+
+llvm::PreservedAnalyses
+swift::InlineTreePrinterPass::run(llvm::Module &M,
+                                  llvm::ModuleAnalysisManager &AM) {
+  InlineTree Tree;
+  Tree.build(&M);
+  Tree.print(outs());
+  return llvm::PreservedAnalyses::all();
+}

--- a/lib/LLVMPasses/LLVMSwiftAA.cpp
+++ b/lib/LLVMPasses/LLVMSwiftAA.cpp
@@ -75,6 +75,13 @@ void SwiftAAWrapperPass::getAnalysisUsage(AnalysisUsage &AU) const {
   AU.addRequired<TargetLibraryInfoWrapperPass>();
 }
 
+AnalysisKey SwiftAA::Key;
+
+SwiftAAResult SwiftAA::run(llvm::Function &F,
+                           llvm::FunctionAnalysisManager &AM) {
+  return SwiftAAResult();
+}
+
 //===----------------------------------------------------------------------===//
 //                           Top Level Entry Point
 //===----------------------------------------------------------------------===//

--- a/lib/LLVMPasses/LLVMSwiftRCIdentity.cpp
+++ b/lib/LLVMPasses/LLVMSwiftRCIdentity.cpp
@@ -17,15 +17,6 @@
 using namespace llvm;
 using swift::SwiftRCIdentity;
 
-// Register this pass...
-char SwiftRCIdentity::ID = 0;
-INITIALIZE_PASS(SwiftRCIdentity, "swift-rc-identity",
-               "Swift RC Identity Analysis", false, true)
-
-bool SwiftRCIdentity::doInitialization(Module &M) {
-  return true;
-}
-
 llvm::Value *
 SwiftRCIdentity::stripPointerCasts(llvm::Value *Val) {
   return Val->stripPointerCasts();
@@ -86,9 +77,4 @@ SwiftRCIdentity::getSwiftRCIdentityRoot(llvm::Value *Val) {
       return OldVal;
   } while (true);
   return Val;
-}
-
-llvm::ImmutablePass *swift::createSwiftRCIdentityPass() {
-  initializeSwiftRCIdentityPass(*PassRegistry::getPassRegistry());
-  return new SwiftRCIdentity();
 }

--- a/test/IRGen/runtime_calling_conventions.swift
+++ b/test/IRGen/runtime_calling_conventions.swift
@@ -11,7 +11,7 @@ public class C {
 // Check that runtime functions use a proper calling convention.
 // CHECK-NOT: call void {{.*}} @swift_release
 
-// OPT-CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swiftcc void @"$s27runtime_calling_conventions3fooyyAA1CCF"(%T27runtime_calling_conventions1CC* nocapture %0)
+// OPT-CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swiftcc void @"$s{{(27|28)}}runtime_calling_conventions3fooyyAA1CCF"(%T27runtime_calling_conventions1CC* nocapture{{.*}} %0)
 // Check that runtime functions use a proper calling convention.
 // OPT-CHECK-NOT: tail call void @swift_release
 

--- a/test/SILOptimizer/devirt_witness_method_empty_conformance.swift
+++ b/test/SILOptimizer/devirt_witness_method_empty_conformance.swift
@@ -76,7 +76,7 @@ extension ApplyRegStruct {
         from space: PublicEnum, transform: RegStruct
     ) {
         transform.funcInStructAndProtAndExt(.case2, space: space) {
-// CHECK-LABEL: define hidden swiftcc void @"$sSa39devirt_witness_method_empty_conformanceAA12PublicStructVRszlE14applyTransformyyF"(%TSa* nocapture swiftself dereferenceable
+// CHECK-LABEL: define hidden swiftcc void @"$sSa39devirt_witness_method_empty_conformanceAA12PublicStructVRszlE14applyTransformyyF"(%TSa* nocapture {{.*}}swiftself dereferenceable
 // CHECK-NEXT: entry
 // CHECK-NEXT: ret void
             applyTransform()

--- a/test/SILOptimizer/opt_mode.swift
+++ b/test/SILOptimizer/opt_mode.swift
@@ -47,5 +47,5 @@ func test_ospeed(_ a: A) -> Int {
 }
 
 
-// CHECK-IR: attributes [[SIZE_ATTR]] = { minsize optsize "
-// CHECK-IR: attributes [[NOSIZE_ATTR]] = { "
+// CHECK-IR-DAG: attributes [[SIZE_ATTR]] = { minsize optsize "
+// CHECK-IR-DAG: attributes [[NOSIZE_ATTR]] = { "

--- a/tools/swift-llvm-opt/LLVMOpt.cpp
+++ b/tools/swift-llvm-opt/LLVMOpt.cpp
@@ -81,6 +81,11 @@ static llvm::cl::list<const llvm::PassInfo *, bool, llvm::PassNameParser>
     PassList(llvm::cl::desc("Optimizations available:"));
 
 static llvm::cl::opt<bool>
+    UseLegacyPassManager("legacy-pass-manager",
+                         llvm::cl::desc("Use the legacy llvm pass manager"),
+                         llvm::cl::init(true));
+
+static llvm::cl::opt<bool>
     Optimized("O", llvm::cl::desc("Optimization level O. Similar to swift -O"));
 
 // TODO: I wanted to call this 'verify', but some other pass is using this
@@ -309,6 +314,7 @@ int main(int argc, char **argv) {
   if (Optimized) {
     IRGenOptions Opts;
     Opts.OptMode = OptimizationMode::ForSpeed;
+    Opts.LegacyPassManager = UseLegacyPassManager;
 
     // Then perform the optimizations.
     performLLVMOptimizations(Opts, M.get(), TM.get());

--- a/tools/swift-llvm-opt/LLVMOpt.cpp
+++ b/tools/swift-llvm-opt/LLVMOpt.cpp
@@ -242,11 +242,10 @@ int main(int argc, char **argv) {
 
   // Register Swift Only Passes.
   initializeSwiftAAWrapperPassPass(Registry);
-  initializeSwiftRCIdentityPass(Registry);
   initializeSwiftARCOptPass(Registry);
   initializeSwiftARCContractPass(Registry);
   initializeInlineTreePrinterPass(Registry);
-  initializeSwiftMergeFunctionsPass(Registry);
+  initializeLegacySwiftMergeFunctionsPass(Registry);
 
   llvm::cl::ParseCommandLineOptions(argc, argv, "Swift LLVM optimizer\n");
 


### PR DESCRIPTION
Adds the frontend option `-enable-new-llvm-pass-manager` and implementation to use LLVM's 'new' pass manager in IRGen.

For now, the legacy pass manager remains the default.