### PR TITLE
[Interop] [SwiftToCxx] Implementing a naive exception to be thrown in C++ if an Error is thrown in Swift 

### DIFF
--- a/lib/PrintAsClang/PrintSwiftToClangCoreScaffold.cpp
+++ b/lib/PrintAsClang/PrintSwiftToClangCoreScaffold.cpp
@@ -210,6 +210,27 @@ static void printSwiftResilientStorageClass(raw_ostream &os) {
   os << "};\n";
 }
 
+void printCxxNaiveException(raw_ostream &os) {
+  os << "\n";
+  os << "/// Naive exception class that should be thrown\n";
+  os << "class NaiveException {\n";
+  os << "public:\n";
+  os << "  inline NaiveException(const char * _Nonnull msg) noexcept : "
+     << "msg_(msg) { }\n";
+  os << "  inline NaiveException(NaiveException&& other) noexcept : "
+        "msg_(other.msg_) { other.msg_ = nullptr; }\n";
+  os << "  inline ~NaiveException() noexcept { }\n";
+  os << "  void operator =(NaiveException&& other) noexcept { auto temp = msg_;"
+     << " msg_ = other.msg_; other.msg_ = temp; }\n";
+  os << "  void operator =(const NaiveException&) noexcept = delete;";
+  os << "\n";
+  os << "  inline const char * _Nonnull getMessage() const noexcept { "
+     << "return(msg_); }\n";
+  os << "private:\n";
+  os << "  const char * _Nonnull msg_;\n";
+  os << "};\n";
+}
+
 void swift::printSwiftToClangCoreScaffold(SwiftToClangInteropContext &ctx,
                                           PrimitiveTypeMapping &typeMapping,
                                           raw_ostream &os) {
@@ -226,6 +247,7 @@ void swift::printSwiftToClangCoreScaffold(SwiftToClangInteropContext &ctx,
           printOpaqueAllocFee(os);
           os << "\n";
           printSwiftResilientStorageClass(os);
+          printCxxNaiveException(os);
         });
   });
 }

--- a/test/Interop/SwiftToCxx/core/swift-impl-defs-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/core/swift-impl-defs-in-cxx.swift
@@ -106,6 +106,19 @@
 // CHECK-NEXT:   char * _Nullable storage;
 // CHECK-NEXT: };
 // CHECK-EMPTY:
+// CHECK-NEXT: /// Naive exception class that should be thrown
+// CHECK-NEXT: class NaiveException {
+// CHECK-NEXT: public:
+// CHECK-NEXT: inline NaiveException(const char * _Nonnull msg) noexcept : msg_(msg) { }
+// CHECK-NEXT: inline NaiveException(NaiveException&& other) noexcept : msg_(other.msg_) { other.msg_ = nullptr; }
+// CHECK-NEXT: inline ~NaiveException() noexcept { }
+// CHECK-NEXT: void operator =(NaiveException&& other) noexcept { auto temp = msg_; msg_ = other.msg_; other.msg_ = temp; }
+// CHECK-NEXT: void operator =(const NaiveException&) noexcept = delete;
+// CHECK-NEXT: inline const char * _Nonnull getMessage() const noexcept { return(msg_); }
+// CHECK-NEXT: private:
+// CHECK-NEXT: const char * _Nonnull msg_;
+// CHECK-NEXT: };
+// CHECK-EMPTY:
 // CHECK-NEXT: } // namespace _impl
 // CHECK-EMPTY:
 // CHECK-EMPTY:

--- a/test/Interop/SwiftToCxx/functions/swift-functions-errors-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/swift-functions-errors-execution.cpp
@@ -11,16 +11,35 @@
 // REQUIRES: executable_test
 
 #include <cassert>
+#include <iostream>
 #include "functions.h"
 
 int main() {
   static_assert(!noexcept(Functions::emptyThrowFunction()), "noexcept function");
   static_assert(!noexcept(Functions::throwFunction()), "noexcept function");
+  static_assert(!noexcept(Functions::throwFunctionWithReturn()), "noexcept function");
 
-  Functions::emptyThrowFunction();
-  Functions::throwFunction();
+  try {
+    Functions::emptyThrowFunction();
+  } catch (swift::_impl::NaiveException& e) {
+    std::cout << e.getMessage() << "\n";
+  }
+  try {
+    Functions::throwFunction();
+  } catch (swift::_impl::NaiveException& e) {
+    std::cout << e.getMessage() << "\n";
+  }
+  try {
+    Functions::throwFunctionWithReturn();
+  } catch (swift::_impl::NaiveException& e) {
+    std::cout << e.getMessage() << "\n";
+  }
+
   return 0;
 }
 
 // CHECK: passEmptyThrowFunction
 // CHECK-NEXT: passThrowFunction
+// CHECK-NEXT: Exception
+// CHECK-NEXT: passThrowFunctionWithReturn
+// CHECK-NEXT: Exception

--- a/test/Interop/SwiftToCxx/functions/swift-functions-errors-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/swift-functions-errors-execution.cpp
@@ -11,7 +11,7 @@
 // REQUIRES: executable_test
 
 #include <cassert>
-#include <iostream>
+#include <cstdio>
 #include "functions.h"
 
 int main() {
@@ -22,17 +22,17 @@ int main() {
   try {
     Functions::emptyThrowFunction();
   } catch (swift::_impl::NaiveException& e) {
-    std::cout << e.getMessage() << "\n";
+    printf("%s\n", e.getMessage());
   }
   try {
     Functions::throwFunction();
   } catch (swift::_impl::NaiveException& e) {
-    std::cout << e.getMessage() << "\n";
+    printf("%s\n", e.getMessage());
   }
   try {
     Functions::throwFunctionWithReturn();
   } catch (swift::_impl::NaiveException& e) {
-    std::cout << e.getMessage() << "\n";
+    printf("%s\n", e.getMessage());
   }
 
   return 0;

--- a/test/Interop/SwiftToCxx/functions/swift-functions-errors.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-functions-errors.swift
@@ -23,7 +23,9 @@ public func emptyThrowFunction() throws { print("passEmptyThrowFunction") }
 // CHECK: inline void emptyThrowFunction() {
 // CHECK: void* opaqueError = nullptr;
 // CHECK: void* self = nullptr;
-// CHECK: return _impl::$s9Functions18emptyThrowFunctionyyKF(self, &opaqueError);
+// CHECK: _impl::$s9Functions18emptyThrowFunctionyyKF(self, &opaqueError);
+// CHECK: if (opaqueError != nullptr)
+// CHECK: throw (swift::_impl::NaiveException("Exception"));
 // CHECK: }
 
 public func throwFunction() throws {
@@ -34,5 +36,22 @@ public func throwFunction() throws {
 // CHECK: inline void throwFunction() {
 // CHECK: void* opaqueError = nullptr;
 // CHECK: void* self = nullptr;
-// CHECK: return _impl::$s9Functions13throwFunctionyyKF(self, &opaqueError);
+// CHECK: _impl::$s9Functions13throwFunctionyyKF(self, &opaqueError);
+// CHECK: if (opaqueError != nullptr)
+// CHECK: throw (swift::_impl::NaiveException("Exception"));
+// CHECK: }
+
+public func throwFunctionWithReturn() throws -> Int {
+    print("passThrowFunctionWithReturn")
+    throw NaiveErrors.returnError
+    return 0
+}
+
+// CHECK: inline swift::Int throwFunctionWithReturn() SWIFT_WARN_UNUSED_RESULT {
+// CHECK: void* opaqueError = nullptr;
+// CHECK: void* self = nullptr;
+// CHECK: auto returnValue = _impl::$s9Functions23throwFunctionWithReturnSiyKF(self, &opaqueError);
+// CHECK: if (opaqueError != nullptr)
+// CHECK: throw (swift::_impl::NaiveException("Exception"));
+// CHECK: return returnValue;
 // CHECK: }


### PR DESCRIPTION
This PR aims to extend Swift Error Handling by allowing C++ programs to know that a Swift function throws an Error.
The idea is to create a general naive `Exception` class that should be thrown if the `%swift.error**` internal parameter isn't null after the function execution.

Ex.:
```C++
inline void throwFunction() {
  void* opaqueError = nullptr;
  void* self = nullptr;
  _impl::$s9Functions13throwFunctionyyKF(self, &opaqueError);
  if (opaqueError != nullptr)
    throw (swift::_impl::NaiveException("Exception"));
}
```

Since we must test this condition before returning the function value (if the function isn't void), this value is assigned to a variable that is returned after the if-statement if its condition is False.

As the tests that verify this implementation only had void functions, a new function returning a `Swift::Int` was provided to assure that this modification works as expected.