### PR TITLE
[Interop][SwiftToCxx] Initial support for getting associated values from enum

### DIFF
--- a/lib/PrintAsClang/ClangSyntaxPrinter.cpp
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.cpp
@@ -147,13 +147,15 @@ void ClangSyntaxPrinter::printSwiftTypeMetadataAccessFunctionCall(
 }
 
 void ClangSyntaxPrinter::printValueWitnessTableAccessSequenceFromTypeMetadata(
-    StringRef metadataVariable) {
-  os << "    auto *vwTableAddr = ";
+    StringRef metadataVariable, StringRef vwTableVariable, int indent) {
+  os << std::string(indent, ' ');
+  os << "auto *vwTableAddr = ";
   os << "reinterpret_cast<";
   printSwiftImplQualifier();
   os << "ValueWitnessTable **>(" << metadataVariable << "._0) - 1;\n";
   os << "#ifdef __arm64e__\n";
-  os << "    auto *vwTable = ";
+  os << std::string(indent, ' ');
+  os << "auto *" << vwTableVariable << " = ";
   os << "reinterpret_cast<";
   printSwiftImplQualifier();
   os << "ValueWitnessTable *>(ptrauth_auth_data(";
@@ -162,6 +164,7 @@ void ClangSyntaxPrinter::printValueWitnessTableAccessSequenceFromTypeMetadata(
   os << "ptrauth_blend_discriminator(vwTableAddr, "
      << SpecialPointerAuthDiscriminators::ValueWitnessTable << ")));\n";
   os << "#else\n";
-  os << "    auto *vwTable = *vwTableAddr;\n";
+  os << std::string(indent, ' ');
+  os << "auto *" << vwTableVariable << " = *vwTableAddr;\n";
   os << "#endif\n";
 }

--- a/lib/PrintAsClang/ClangSyntaxPrinter.h
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.h
@@ -93,7 +93,7 @@ public:
   /// Print the set of statements to access the value witness table pointer
   /// ('vwTable') from the given type metadata variable.
   void printValueWitnessTableAccessSequenceFromTypeMetadata(
-      StringRef metadataVariable);
+      StringRef metadataVariable, StringRef vwTableVariable, int indent);
 
 protected:
   raw_ostream &os;

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -388,11 +388,13 @@ private:
   }
 
   void visitEnumDeclCxx(EnumDecl *ED) {
+    assert(owningPrinter.outputLang == OutputLanguageMode::Cxx);
+
     // FIXME: Print enum's availability
-    ClangValueTypePrinter printer(os, owningPrinter.prologueOS,
-                                  owningPrinter.typeMapping,
-                                  owningPrinter.interopContext);
-    printer.printValueTypeDecl(ED, /*bodyPrinter=*/[&]() {
+    ClangValueTypePrinter valueTypePrinter(os, owningPrinter.prologueOS,
+                                           owningPrinter.typeMapping,
+                                           owningPrinter.interopContext);
+    valueTypePrinter.printValueTypeDecl(ED, /*bodyPrinter=*/[&]() {
       ClangSyntaxPrinter syntaxPrinter(os);
       auto elementTagMapping =
           owningPrinter.interopContext.getIrABIDetails().getEnumTagMapping(ED);
@@ -418,6 +420,7 @@ private:
       os << "  inline operator cases() const {\n";
       os << "    switch (_getEnumTag()) {\n";
       for (const auto &pair : elementTagMapping) {
+        // TODO: have to use global variable for resilient enum
         os << "      case " << pair.second << ": return cases::";
         syntaxPrinter.printIdentifier(pair.first->getNameStr());
         os << ";\n";
@@ -427,7 +430,11 @@ private:
       os << "    }\n"; // switch's closing bracket
       os << "  }\n";   // operator cases()'s closing bracket
 
-      // Printing predicates
+      // Printing case-related functions
+      DeclAndTypeClangFunctionPrinter clangFuncPrinter(
+          os, owningPrinter.prologueOS, owningPrinter.typeMapping,
+          owningPrinter.interopContext);
+
       for (const auto &pair : elementTagMapping) {
         os << "  inline bool is";
         auto name = pair.first->getNameStr().str();
@@ -436,6 +443,54 @@ private:
         os << "    return *this == cases::";
         syntaxPrinter.printIdentifier(pair.first->getNameStr());
         os << ";\n  }\n";
+
+        if (!pair.first->hasAssociatedValues()) {
+          continue;
+        }
+
+        auto associatedValueList = pair.first->getParameterList();
+        // TODO: add tuple type support
+        if (associatedValueList->size() > 1) {
+          continue;
+        }
+        auto firstType = associatedValueList->front()->getType();
+        auto firstTypeDecl = firstType->getNominalOrBoundGenericNominal();
+        OptionalTypeKind optKind;
+        std::tie(firstType, optKind) =
+            getObjectTypeAndOptionality(firstTypeDecl, firstType);
+
+        // FIXME: (tongjie) may have to forward declare return type
+        os << "  inline ";
+        clangFuncPrinter.printClangFunctionReturnType(
+            firstType, optKind, firstTypeDecl->getModuleContext(),
+            owningPrinter.outputLang);
+        os << " get" << name << "() const {\n";
+        os << "    if (!is" << name << "()) abort();\n";
+        os << "    auto thisCopy = *this;\n";
+        os << "    char * _Nonnull payloadFromDestruction = "
+              "thisCopy._destructiveProjectEnumData();\n";
+        if (auto knownCxxType =
+                owningPrinter.typeMapping.getKnownCxxTypeInfo(firstTypeDecl)) {
+          os << "    ";
+          clangFuncPrinter.printClangFunctionReturnType(
+              firstType, optKind, firstTypeDecl->getModuleContext(),
+              owningPrinter.outputLang);
+          os << " result;\n";
+          os << "    "
+                "memcpy(&result, payloadFromDestruction, sizeof(result));\n";
+          os << "    return result;\n";
+        } else {
+          os << "    return " << cxx_synthesis::getCxxImplNamespaceName();
+          os << "::";
+          ClangValueTypePrinter::printCxxImplClassName(os, firstTypeDecl);
+          os << "::returnNewValue([&](char * _Nonnull result) {\n";
+          os << "      " << cxx_synthesis::getCxxImplNamespaceName();
+          os << "::";
+          ClangValueTypePrinter::printCxxImplClassName(os, firstTypeDecl);
+          os << "::initializeWithTake(result, payloadFromDestruction);\n";
+          os << "    });\n";
+        }
+        os << "  }\n";
       }
       os << "\n";
     });

--- a/lib/PrintAsClang/PrintAsClang.cpp
+++ b/lib/PrintAsClang/PrintAsClang.cpp
@@ -102,7 +102,8 @@ static void writePrologue(raw_ostream &out, ASTContext &ctx,
         out << "#include <cstdint>\n"
                "#include <cstddef>\n"
                "#include <cstdbool>\n"
-               "#include <cstring>\n";
+               "#include <cstring>\n"
+               "#include <new>\n";
         out << "#include <stdlib.h>\n";
         out << "#if defined(_WIN32)\n#include <malloc.h>\n#endif\n";
       },

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -194,6 +194,17 @@ private:
 
 } // end namespace
 
+void DeclAndTypeClangFunctionPrinter::printClangFunctionReturnType(
+    Type ty, OptionalTypeKind optKind, ModuleDecl *moduleContext,
+    OutputLanguageMode outputLang) {
+  CFunctionSignatureTypePrinter typePrinter(
+      os, cPrologueOS, typeMapping, outputLang, interopContext,
+      CFunctionSignatureTypePrinterModifierDelegate(), moduleContext,
+      FunctionSignatureTypeUse::ReturnType);
+  // Param for indirect return cannot be marked as inout
+  typePrinter.visit(ty, optKind, /*isInOutParam=*/false);
+}
+
 void DeclAndTypeClangFunctionPrinter::printFunctionSignature(
     const AbstractFunctionDecl *FD, StringRef name, Type resultTy,
     FunctionSignatureKind kind, ArrayRef<AdditionalParam> additionalParams,
@@ -231,12 +242,7 @@ void DeclAndTypeClangFunctionPrinter::printFunctionSignature(
     Type objTy;
     std::tie(objTy, retKind) =
         DeclAndTypePrinter::getObjectTypeAndOptionality(FD, resultTy);
-    CFunctionSignatureTypePrinter typePrinter(
-        os, cPrologueOS, typeMapping, outputLang, interopContext,
-        CFunctionSignatureTypePrinterModifierDelegate(), emittedModule,
-        FunctionSignatureTypeUse::ReturnType);
-    // Param for indirect return cannot be marked as inout
-    typePrinter.visit(objTy, retKind, /*isInOutParam=*/false);
+    printClangFunctionReturnType(objTy, retKind, emittedModule, outputLang);
   } else {
     os << "void";
   }

--- a/lib/PrintAsClang/PrintClangFunction.h
+++ b/lib/PrintAsClang/PrintClangFunction.h
@@ -13,8 +13,10 @@
 #ifndef SWIFT_PRINTASCLANG_PRINTCLANGFUNCTION_H
 #define SWIFT_PRINTASCLANG_PRINTCLANGFUNCTION_H
 
+#include "OutputLanguageMode.h"
 #include "swift/AST/Type.h"
 #include "swift/Basic/LLVM.h"
+#include "swift/ClangImporter/ClangImporter.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/StringRef.h"
@@ -99,6 +101,11 @@ public:
                                       const AccessorDecl *accessor,
                                       StringRef swiftSymbolName, Type resultTy,
                                       bool isDefinition);
+
+  /// Print Swift type as C/C++ type, as the return type of a C/C++ function.
+  void printClangFunctionReturnType(Type ty, OptionalTypeKind optKind,
+                                    ModuleDecl *moduleContext,
+                                    OutputLanguageMode outputLang);
 
 private:
   void printCxxToCFunctionParameterUse(

--- a/lib/PrintAsClang/PrintClangValueType.cpp
+++ b/lib/PrintAsClang/PrintClangValueType.cpp
@@ -65,7 +65,8 @@ void ClangValueTypePrinter::printValueWitnessTableAccessAsVariable(
     StringRef metadataVarName, StringRef vwTableVarName) {
   ClangSyntaxPrinter printer(os);
   printMetadataAccessAsVariable(os, metadataFuncName, indent, metadataVarName);
-  printer.printValueWitnessTableAccessSequenceFromTypeMetadata("metadata");
+  printer.printValueWitnessTableAccessSequenceFromTypeMetadata(
+      metadataVarName, vwTableVarName, indent);
 }
 
 static void

--- a/lib/PrintAsClang/PrintClangValueType.cpp
+++ b/lib/PrintAsClang/PrintClangValueType.cpp
@@ -44,12 +44,28 @@ static void printCxxTypeName(raw_ostream &os, const NominalTypeDecl *type,
   printer.printBaseName(type);
 }
 
-/// Print out the C++ type name of the implementation class that provides hidden
-/// access to the private class APIs.
-static void printCxxImplClassName(raw_ostream &os,
-                                  const NominalTypeDecl *type) {
+void ClangValueTypePrinter::printCxxImplClassName(raw_ostream &os,
+                                                  const NominalTypeDecl *type) {
   os << "_impl_";
   ClangSyntaxPrinter(os).printBaseName(type);
+}
+
+void ClangValueTypePrinter::printMetadataAccessAsVariable(
+    raw_ostream &os, StringRef metadataFuncName, int indent,
+    StringRef varName) {
+  ClangSyntaxPrinter printer(os);
+  os << std::string(indent, ' ') << "auto " << varName << " = "
+     << cxx_synthesis::getCxxImplNamespaceName() << "::";
+  printer.printSwiftTypeMetadataAccessFunctionCall(metadataFuncName);
+  os << ";\n";
+}
+
+void ClangValueTypePrinter::printValueWitnessTableAccessAsVariable(
+    raw_ostream &os, StringRef metadataFuncName, int indent,
+    StringRef metadataVarName, StringRef vwTableVarName) {
+  ClangSyntaxPrinter printer(os);
+  printMetadataAccessAsVariable(os, metadataFuncName, indent, metadataVarName);
+  printer.printValueWitnessTableAccessSequenceFromTypeMetadata("metadata");
 }
 
 static void
@@ -111,6 +127,18 @@ void ClangValueTypePrinter::printValueTypeDecl(
                                                           typeMetadataFuncName);
                          });
 
+  auto printEnumVWTableVariable = [&](StringRef metadataName = "metadata",
+                                      StringRef vwTableName = "vwTable",
+                                      StringRef enumVWTableName =
+                                          "enumVWTable") {
+    ClangValueTypePrinter::printValueWitnessTableAccessAsVariable(
+        os, typeMetadataFuncName);
+    os << "    const auto *" << enumVWTableName << " = reinterpret_cast<";
+    ClangSyntaxPrinter(os).printSwiftImplQualifier();
+    os << "EnumValueWitnessTable";
+    os << " *>(" << vwTableName << ");\n";
+  };
+
   // Print out the C++ class itself.
   os << "class ";
   ClangSyntaxPrinter(os).printBaseName(typeDecl);
@@ -121,11 +149,8 @@ void ClangValueTypePrinter::printValueTypeDecl(
   os << "  inline ~";
   printer.printBaseName(typeDecl);
   os << "() {\n";
-  os << "    auto metadata = " << cxx_synthesis::getCxxImplNamespaceName()
-     << "::";
-  printer.printSwiftTypeMetadataAccessFunctionCall(typeMetadataFuncName);
-  os << ";\n";
-  printer.printValueWitnessTableAccessSequenceFromTypeMetadata("metadata");
+  ClangValueTypePrinter::printValueWitnessTableAccessAsVariable(
+      os, typeMetadataFuncName);
   os << "    vwTable->destroy(_getOpaquePointer(), metadata._0);\n";
   os << "  }\n";
 
@@ -134,11 +159,8 @@ void ClangValueTypePrinter::printValueTypeDecl(
   os << "(const ";
   printer.printBaseName(typeDecl);
   os << " &other) {\n";
-  os << "    auto metadata = " << cxx_synthesis::getCxxImplNamespaceName()
-     << "::";
-  printer.printSwiftTypeMetadataAccessFunctionCall(typeMetadataFuncName);
-  os << ";\n";
-  printer.printValueWitnessTableAccessSequenceFromTypeMetadata("metadata");
+  ClangValueTypePrinter::printValueWitnessTableAccessAsVariable(
+      os, typeMetadataFuncName);
   if (isOpaqueLayout) {
     os << "    _storage = ";
     printer.printSwiftImplQualifier();
@@ -176,11 +198,8 @@ void ClangValueTypePrinter::printValueTypeDecl(
   os << " _make() {";
   if (isOpaqueLayout) {
     os << "\n";
-    os << "    auto metadata = " << cxx_synthesis::getCxxImplNamespaceName()
-       << "::";
-    printer.printSwiftTypeMetadataAccessFunctionCall(typeMetadataFuncName);
-    os << ";\n";
-    printer.printValueWitnessTableAccessSequenceFromTypeMetadata("metadata");
+    ClangValueTypePrinter::printValueWitnessTableAccessAsVariable(
+        os, typeMetadataFuncName);
     os << "    return ";
     printer.printBaseName(typeDecl);
     os << "(vwTable);\n  }\n";
@@ -200,19 +219,17 @@ void ClangValueTypePrinter::printValueTypeDecl(
     os << ".getOpaquePointer()";
   os << "; }\n";
   os << "\n";
-  // Print out helper function for getting enum tag for enum type
+  // Print out helper function for enums
   if (isa<EnumDecl>(typeDecl)) {
+    os << "  inline char * _Nonnull _destructiveProjectEnumData() {\n";
+    printEnumVWTableVariable();
+    os << "    enumVWTable->destructiveProjectEnumData(_getOpaquePointer(), "
+          "metadata._0);\n";
+    os << "    return _getOpaquePointer();\n";
+    os << "  }\n";
     // FIXME: (tongjie) return type should be unsigned
     os << "  inline int _getEnumTag() const {\n";
-    os << "    auto metadata = " << cxx_synthesis::getCxxImplNamespaceName()
-       << "::";
-    printer.printSwiftTypeMetadataAccessFunctionCall(typeMetadataFuncName);
-    os << ";\n";
-    printer.printValueWitnessTableAccessSequenceFromTypeMetadata("metadata");
-    os << "    const auto *enumVWTable = reinterpret_cast<";
-    ClangSyntaxPrinter(os).printSwiftImplQualifier();
-    os << "EnumValueWitnessTable";
-    os << " *>(vwTable);\n";
+    printEnumVWTableVariable();
     os << "    return enumVWTable->getEnumTag(_getOpaquePointer(), "
           "metadata._0);\n";
     os << "  }\n";
@@ -259,6 +276,17 @@ void ClangValueTypePrinter::printValueTypeDecl(
         os << "    callable(result._getOpaquePointer());\n";
         os << "    return result;\n";
         os << "  }\n";
+        // Print out helper function for initializeWithTake
+        // TODO: (tongjie) support opaque layout
+        if (!isOpaqueLayout) {
+          os << "  static inline void initializeWithTake(char * _Nonnull "
+                "destStorage, char * _Nonnull srcStorage) {\n";
+          ClangValueTypePrinter::printValueWitnessTableAccessAsVariable(
+              os, typeMetadataFuncName);
+          os << "    vwTable->initializeWithTake(destStorage, srcStorage, "
+                "metadata._0);\n";
+          os << "  }\n";
+        }
 
         os << "};\n";
       });

--- a/lib/PrintAsClang/PrintClangValueType.h
+++ b/lib/PrintAsClang/PrintClangValueType.h
@@ -76,6 +76,24 @@ public:
                                      const ModuleDecl *moduleContext,
                                      llvm::function_ref<void()> bodyPrinter);
 
+  /// Print out the C++ type name of the implementation class that provides
+  /// hidden access to the private class APIs.
+  static void printCxxImplClassName(raw_ostream &os,
+                                    const NominalTypeDecl *type);
+
+  /// Print a variable that can be used to access type's metadata function
+  static void printMetadataAccessAsVariable(raw_ostream &os,
+                                            StringRef metadataFuncName,
+                                            int indent = 4,
+                                            StringRef varName = "metadata");
+
+  /// Print a variable that can be used to access type's metadata function and
+  /// value witness table
+  static void printValueWitnessTableAccessAsVariable(
+      raw_ostream &os, StringRef metadataFuncName, int indent = 4,
+      StringRef metadataVarName = "metadata",
+      StringRef vwTableVarName = "vwTable");
+
 private:
   /// Prints out the C stub name used to pass/return value directly for the
   /// given value type.

--- a/test/Interop/SwiftToCxx/enums/swift-enum-case-functions-execution.cpp
+++ b/test/Interop/SwiftToCxx/enums/swift-enum-case-functions-execution.cpp
@@ -37,19 +37,19 @@ void cxxCheckEnum(const CLikeEnum &e) {
     }
 }
 
-void cxxCheckEnum(const CharOrSectionMarker &e) {
+void cxxCheckEnum(const BoolWithCase &e) {
     switch (e) {
-        case CharOrSectionMarker::cases::Paragraph:
-            assert(checkCharOrSectionMarker(e, 1));
-            assert(e.isParagraph());
+        case BoolWithCase::cases::first:
+            assert(checkBoolWithCase(e, 1));
+            assert(e.isFirst());
             break;
-        case CharOrSectionMarker::cases::Char:
-            assert(checkCharOrSectionMarker(e, 2));
-            assert(e.isChar());
+        case BoolWithCase::cases::second:
+            assert(checkBoolWithCase(e, 2));
+            assert(e.isSecond());
             break;
-        case CharOrSectionMarker::cases::Chapter:
-            assert(checkCharOrSectionMarker(e, 3));
-            assert(e.isChapter());
+        case BoolWithCase::cases::third:
+            assert(checkBoolWithCase(e, 3));
+            assert(e.isThird());
             break;
     }
 }
@@ -71,31 +71,23 @@ void cxxCheckEnum(const IntOrInfinity &e) {
     }
 }
 
-void cxxCheckEnum(const TerminalChar &e) {
+void cxxCheckEnum(const MultipleBoolWithCase &e) {
     switch (e) {
-        case TerminalChar::cases::Plain:
-            assert(checkTerminalChar(e, 1));
-            assert(e.isPlain());
+        case MultipleBoolWithCase::cases::first:
+            assert(checkMultipleBoolWithCase(e, 1));
+            assert(e.isFirst());
             break;
-        case TerminalChar::cases::Bold:
-            assert(checkTerminalChar(e, 2));
-            assert(e.isBold());
+        case MultipleBoolWithCase::cases::second:
+            assert(checkMultipleBoolWithCase(e, 2));
+            assert(e.isSecond());
             break;
-        case TerminalChar::cases::Underline:
-            assert(checkTerminalChar(e, 3));
-            assert(e.isUnderline());
+        case MultipleBoolWithCase::cases::third:
+            assert(checkMultipleBoolWithCase(e, 3));
+            assert(e.isThird());
             break;
-        case TerminalChar::cases::Blink:
-            assert(checkTerminalChar(e, 4));
-            assert(e.isBlink());
-            break;
-        case TerminalChar::cases::Empty:
-            assert(checkTerminalChar(e, 5));
-            assert(e.isEmpty());
-            break;
-        case TerminalChar::cases::Cursor:
-            assert(checkTerminalChar(e, 6));
-            assert(e.isCursor());
+        case MultipleBoolWithCase::cases::fourth:
+            assert(checkMultipleBoolWithCase(e, 4));
+            assert(e.isFourth());
             break;
     }
 }
@@ -134,9 +126,9 @@ int main() {
     }
 
     {
-        auto e1 = makeCharOrSectionMarker(1);
-        auto e2 = makeCharOrSectionMarker(2);
-        auto e3 = makeCharOrSectionMarker(3);
+        auto e1 = makeBoolWithCase(1);
+        auto e2 = makeBoolWithCase(2);
+        auto e3 = makeBoolWithCase(3);
 
         cxxCheckEnum(e1);
         cxxCheckEnum(e2);
@@ -154,19 +146,15 @@ int main() {
     }
 
     {
-        auto e1 = makeTerminalChar(1);
-        auto e2 = makeTerminalChar(2);
-        auto e3 = makeTerminalChar(3);
-        auto e4 = makeTerminalChar(4);
-        auto e5 = makeTerminalChar(5);
-        auto e6 = makeTerminalChar(6);
+        auto e1 = makeMultipleBoolWithCase(1);
+        auto e2 = makeMultipleBoolWithCase(2);
+        auto e3 = makeMultipleBoolWithCase(3);
+        auto e4 = makeMultipleBoolWithCase(4);
 
         cxxCheckEnum(e1);
         cxxCheckEnum(e2);
         cxxCheckEnum(e3);
         cxxCheckEnum(e4);
-        cxxCheckEnum(e5);
-        cxxCheckEnum(e6);
     }
 
     {

--- a/test/Interop/SwiftToCxx/enums/swift-enum-case-functions.swift
+++ b/test/Interop/SwiftToCxx/enums/swift-enum-case-functions.swift
@@ -34,30 +34,30 @@ public func checkCLikeEnum(_ x: CLikeEnum, tag: Int) -> Bool {
     }
 }
 
-public enum CharOrSectionMarker {
-    case Paragraph
-    case Char(Unicode.Scalar)
-    case Chapter
+public enum BoolWithCase {
+    case first
+    case second(Bool)
+    case third
 }
 
-public func makeCharOrSectionMarker(_ tag: Int) -> CharOrSectionMarker {
+public func makeBoolWithCase(_ tag: Int) -> BoolWithCase {
     switch tag {
     case 1:
-        return .Paragraph
+        return .first
     case 2:
-        return .Char("🍎")
+        return .second(true)
     default:
-        return .Chapter
+        return .third
     }
 }
 
-public func checkCharOrSectionMarker(_ x: CharOrSectionMarker, tag: Int) -> Bool {
+public func checkBoolWithCase(_ x: BoolWithCase, tag: Int) -> Bool {
     switch x {
-    case .Paragraph:
+    case .first:
         return tag == 1
-    case .Char:
+    case .second:
         return tag == 2
-    case .Chapter:
+    case .third:
         return ![1, 2].contains(tag)
     }
 }
@@ -90,55 +90,43 @@ public func checkIntOrInfinity(_ x: IntOrInfinity, tag: Int) -> Bool {
     }
 }
 
-public enum TerminalChar {
-    case Cursor
-    case Plain(Unicode.Scalar)
-    case Bold(Unicode.Scalar)
-    case Underline(Unicode.Scalar)
-    case Blink(Unicode.Scalar)
-    case Empty
+public enum MultipleBoolWithCase {
+    case first
+    case second(Bool)
+    case third(Bool)
+    case fourth
 }
 
-public func makeTerminalChar(_ tag: Int) -> TerminalChar {
+public func makeMultipleBoolWithCase(_ tag: Int) -> MultipleBoolWithCase {
     switch tag {
     case 1:
-        return .Plain("P")
+        return .first
     case 2:
-        return .Bold("B")
+        return .second(true)
     case 3:
-        return .Underline("U")
-    case 4:
-        return .Blink("L")
-    case 5:
-        return .Empty
+        return .third(false)
     default:
-        return .Cursor
+        return .fourth
     }
 }
 
-public func checkTerminalChar(_ x: TerminalChar, tag: Int) -> Bool {
+public func checkMultipleBoolWithCase(_ x: MultipleBoolWithCase, tag: Int) -> Bool {
     switch x {
-    case .Plain:
+    case .first:
         return tag == 1
-    case .Bold:
+    case .second:
         return tag == 2
-    case .Underline:
+    case .third:
         return tag == 3
-    case .Blink:
-        return tag == 4
-    case .Empty:
-        return tag == 5
-    case .Cursor:
-        return ![1, 2, 3, 4, 5].contains(tag)
+    case .fourth:
+        return ![1, 2, 3].contains(tag)
     }
 }
-
-public class Bignum {}
 
 public enum IntDoubleOrBignum {
     case Int(Int)
     case Double(Double)
-    case Bignum(Bignum)
+    case Bignum
 }
 
 public func makeIntDoubleOrBignum(_ tag: Int) -> IntDoubleOrBignum {
@@ -148,7 +136,7 @@ public func makeIntDoubleOrBignum(_ tag: Int) -> IntDoubleOrBignum {
     case 2:
         return .Double(3.14)
     default:
-        return .Bignum(Bignum())
+        return .Bignum
     }
 }
 
@@ -163,6 +151,37 @@ public func checkIntDoubleOrBignum(_ x: IntDoubleOrBignum, tag: Int) -> Bool {
     }
 }
 
+// CHECK: class BoolWithCase final {
+
+// CHECK:      inline operator cases() const {
+// CHECK-NEXT:   switch (_getEnumTag()) {
+// CHECK-NEXT:     case 0: return cases::second;
+// CHECK-NEXT:     case 1: return cases::first;
+// CHECK-NEXT:     case 2: return cases::third;
+// CHECK-NEXT:     default: abort();
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+// CHECK-NEXT: inline bool isSecond() const {
+// CHECK-NEXT:   return *this == cases::second;
+// CHECK-NEXT: }
+// CHECK:      inline bool isFirst() const {
+// CHECK-NEXT:   return *this == cases::first;
+// CHECK-NEXT: }
+// CHECK-NEXT: inline bool isThird() const {
+// CHECK-NEXT:     return *this == cases::third;
+// CHECK-NEXT: }
+// CHECK:      inline int _getEnumTag() const {
+// CHECK-NEXT:   auto metadata = _impl::$s5Enums12BoolWithCaseOMa(0);
+// CHECK-NEXT:   auto *vwTableAddr = reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1;
+// CHECK-NEXT: #ifdef __arm64e__
+// CHECK-NEXT:   auto *vwTable = reinterpret_cast<swift::_impl::ValueWitnessTable *>(ptrauth_auth_data(reinterpret_cast<void *>(*vwTableAddr), ptrauth_key_process_independent_data, ptrauth_blend_discriminator(vwTableAddr, 11839)));
+// CHECK-NEXT: #else
+// CHECK-NEXT:   auto *vwTable = *vwTableAddr;
+// CHECK-NEXT: #endif
+// CHECK-NEXT:   const auto *enumVWTable = reinterpret_cast<swift::_impl::EnumValueWitnessTable *>(vwTable);
+// CHECK-NEXT:   return enumVWTable->getEnumTag(_getOpaquePointer(), metadata._0);
+// CHECK-NEXT: }
+
 // CHECK: class CLikeEnum final {
 
 // CHECK:      inline operator cases() const {
@@ -176,45 +195,14 @@ public func checkIntDoubleOrBignum(_ x: IntDoubleOrBignum, tag: Int) -> Bool {
 // CHECK-NEXT: inline bool isOne() const {
 // CHECK-NEXT:   return *this == cases::one;
 // CHECK-NEXT: }
-// CHECK-NEXT: inline bool isTwo() const {
+// CHECK:      inline bool isTwo() const {
 // CHECK-NEXT:   return *this == cases::two;
 // CHECK-NEXT: }
-// CHECK-NEXT: inline bool isThree() const {
+// CHECK:      inline bool isThree() const {
 // CHECK-NEXT:   return *this == cases::three;
 // CHECK-NEXT: }
 // CHECK:      inline int _getEnumTag() const {
 // CHECK-NEXT:   auto metadata = _impl::$s5Enums9CLikeEnumOMa(0);
-// CHECK-NEXT:   auto *vwTableAddr = reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1;
-// CHECK-NEXT: #ifdef __arm64e__
-// CHECK-NEXT:   auto *vwTable = reinterpret_cast<swift::_impl::ValueWitnessTable *>(ptrauth_auth_data(reinterpret_cast<void *>(*vwTableAddr), ptrauth_key_process_independent_data, ptrauth_blend_discriminator(vwTableAddr, 11839)));
-// CHECK-NEXT: #else
-// CHECK-NEXT:   auto *vwTable = *vwTableAddr;
-// CHECK-NEXT: #endif
-// CHECK-NEXT:   const auto *enumVWTable = reinterpret_cast<swift::_impl::EnumValueWitnessTable *>(vwTable);
-// CHECK-NEXT:   return enumVWTable->getEnumTag(_getOpaquePointer(), metadata._0);
-// CHECK-NEXT: }
-
-// CHECK: class CharOrSectionMarker final {
-
-// CHECK:      inline operator cases() const {
-// CHECK-NEXT:   switch (_getEnumTag()) {
-// CHECK-NEXT:     case 0: return cases::Char;
-// CHECK-NEXT:     case 1: return cases::Paragraph;
-// CHECK-NEXT:     case 2: return cases::Chapter;
-// CHECK-NEXT:     default: abort();
-// CHECK-NEXT:   }
-// CHECK-NEXT: }
-// CHECK-NEXT: inline bool isChar() const {
-// CHECK-NEXT:   return *this == cases::Char;
-// CHECK-NEXT: }
-// CHECK-NEXT: inline bool isParagraph() const {
-// CHECK-NEXT:   return *this == cases::Paragraph;
-// CHECK-NEXT: }
-// CHECK-NEXT: inline bool isChapter() const {
-// CHECK-NEXT:   return *this == cases::Chapter;
-// CHECK-NEXT: }
-// CHECK:      inline int _getEnumTag() const {
-// CHECK-NEXT:   auto metadata = _impl::$s5Enums19CharOrSectionMarkerOMa(0);
 // CHECK-NEXT:   auto *vwTableAddr = reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1;
 // CHECK-NEXT: #ifdef __arm64e__
 // CHECK-NEXT:   auto *vwTable = reinterpret_cast<swift::_impl::ValueWitnessTable *>(ptrauth_auth_data(reinterpret_cast<void *>(*vwTableAddr), ptrauth_key_process_independent_data, ptrauth_blend_discriminator(vwTableAddr, 11839)));
@@ -261,10 +249,10 @@ public func checkIntDoubleOrBignum(_ x: IntDoubleOrBignum, tag: Int) -> Bool {
 // CHECK-NEXT: inline bool isInt() const {
 // CHECK-NEXT:   return *this == cases::Int;
 // CHECK-NEXT: }
-// CHECK-NEXT: inline bool isDouble() const {
+// CHECK:      inline bool isDouble() const {
 // CHECK-NEXT:   return *this == cases::Double;
 // CHECK-NEXT: }
-// CHECK-NEXT: inline bool isBignum() const {
+// CHECK:      inline bool isBignum() const {
 // CHECK-NEXT:   return *this == cases::Bignum;
 // CHECK-NEXT: }
 // CHECK:      inline int _getEnumTag() const {
@@ -292,10 +280,10 @@ public func checkIntDoubleOrBignum(_ x: IntDoubleOrBignum, tag: Int) -> Bool {
 // CHECK-NEXT: inline bool isInt() const {
 // CHECK-NEXT:   return *this == cases::Int;
 // CHECK-NEXT: }
-// CHECK-NEXT: inline bool isNegInfinity() const {
+// CHECK:      inline bool isNegInfinity() const {
 // CHECK-NEXT:   return *this == cases::NegInfinity;
 // CHECK-NEXT: }
-// CHECK-NEXT: inline bool isPosInfinity() const {
+// CHECK:      inline bool isPosInfinity() const {
 // CHECK-NEXT:   return *this == cases::PosInfinity;
 // CHECK-NEXT: }
 // CHECK:      inline int _getEnumTag() const {
@@ -310,39 +298,31 @@ public func checkIntDoubleOrBignum(_ x: IntDoubleOrBignum, tag: Int) -> Bool {
 // CHECK-NEXT:   return enumVWTable->getEnumTag(_getOpaquePointer(), metadata._0);
 // CHECK-NEXT: }
 
-// CHECK: class TerminalChar final {
+// CHECK: class MultipleBoolWithCase final {
 
 // CHECK:      inline operator cases() const {
-// CHECK-NEXT:   switch (_getEnumTag()) {
-// CHECK-NEXT:     case 0: return cases::Plain;
-// CHECK-NEXT:     case 1: return cases::Bold;
-// CHECK-NEXT:     case 2: return cases::Underline;
-// CHECK-NEXT:     case 3: return cases::Blink;
-// CHECK-NEXT:     case 4: return cases::Cursor;
-// CHECK-NEXT:     case 5: return cases::Empty;
+// CHECK-NEXT:     switch (_getEnumTag()) {
+// CHECK-NEXT:     case 0: return cases::second;
+// CHECK-NEXT:     case 1: return cases::third;
+// CHECK-NEXT:     case 2: return cases::first;
+// CHECK-NEXT:     case 3: return cases::fourth;
 // CHECK-NEXT:     default: abort();
-// CHECK-NEXT:   }
+// CHECK-NEXT:     }
 // CHECK-NEXT: }
-// CHECK-NEXT: inline bool isPlain() const {
-// CHECK-NEXT:   return *this == cases::Plain;
+// CHECK-NEXT: inline bool isSecond() const {
+// CHECK-NEXT:     return *this == cases::second;
 // CHECK-NEXT: }
-// CHECK-NEXT: inline bool isBold() const {
-// CHECK-NEXT:   return *this == cases::Bold;
+// CHECK:      inline bool isThird() const {
+// CHECK-NEXT:     return *this == cases::third;
 // CHECK-NEXT: }
-// CHECK-NEXT: inline bool isUnderline() const {
-// CHECK-NEXT:   return *this == cases::Underline;
+// CHECK:      inline bool isFirst() const {
+// CHECK-NEXT:     return *this == cases::first;
 // CHECK-NEXT: }
-// CHECK-NEXT: inline bool isBlink() const {
-// CHECK-NEXT:   return *this == cases::Blink;
-// CHECK-NEXT: }
-// CHECK-NEXT: inline bool isCursor() const {
-// CHECK-NEXT:   return *this == cases::Cursor;
-// CHECK-NEXT: }
-// CHECK-NEXT: inline bool isEmpty() const {
-// CHECK-NEXT:   return *this == cases::Empty;
+// CHECK-NEXT: inline bool isFourth() const {
+// CHECK-NEXT:     return *this == cases::fourth;
 // CHECK-NEXT: }
 // CHECK:      inline int _getEnumTag() const {
-// CHECK-NEXT:   auto metadata = _impl::$s5Enums12TerminalCharOMa(0);
+// CHECK-NEXT:   auto metadata = _impl::$s5Enums20MultipleBoolWithCaseOMa(0);
 // CHECK-NEXT:   auto *vwTableAddr = reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1;
 // CHECK-NEXT: #ifdef __arm64e__
 // CHECK-NEXT:   auto *vwTable = reinterpret_cast<swift::_impl::ValueWitnessTable *>(ptrauth_auth_data(reinterpret_cast<void *>(*vwTableAddr), ptrauth_key_process_independent_data, ptrauth_blend_discriminator(vwTableAddr, 11839)));

--- a/test/Interop/SwiftToCxx/enums/swift-enum-extract-payload-execution.cpp
+++ b/test/Interop/SwiftToCxx/enums/swift-enum-extract-payload-execution.cpp
@@ -1,0 +1,59 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %S/swift-enum-extract-payload.swift -typecheck -module-name Enums -clang-header-expose-public-decls -emit-clang-header-path %t/enums.h
+
+// RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-enums-execution.o
+// RUN: %target-interop-build-swift %S/swift-enum-extract-payload.swift -o %t/swift-enums-execution -Xlinker %t/swift-enums-execution.o -module-name Enums -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+
+// RUN: %target-codesign %t/swift-enums-execution
+// RUN: %target-run %t/swift-enums-execution
+
+// REQUIRES: executable_test
+// UNSUPPORTED: CPU=arm64e
+
+#include <cassert>
+#include "enums.h"
+
+using namespace Enums;
+
+int main() {
+  {
+    auto xyz = makeXyz(1);
+    assert(xyz.isFirst());
+    assert(checkFoo(Foo::init(1234), xyz.getFirst()));
+    assert(1234 == xyz.getFirst().getX());
+  }
+  {
+    auto xyz = makeXyz(2);
+    assert(xyz.isSecond());
+    assert(checkUvw(makeUvw(2), xyz.getSecond()));
+    assert(xyz.getSecond().isTwo());
+  }
+  {
+    auto xyz = makeXyz(3);
+    assert(xyz.isThird());
+    assert(checkBar(Bar::init(1.1, 2.2, 3.3, 4.4, 5.5, 6.6), xyz.getThird()));
+    assert(1.1 == xyz.getThird().getX1());
+    assert(2.2 == xyz.getThird().getX2());
+    assert(3.3 == xyz.getThird().getX3());
+    assert(4.4 == xyz.getThird().getX4());
+    assert(5.5 == xyz.getThird().getX5());
+    assert(6.6 == xyz.getThird().getX6());
+  }
+  {
+    auto e = makePrimitivePayload(1);
+    assert(e.isX());
+    assert(e.getX() == 9999);
+  }
+  {
+    auto e = makePrimitivePayload(2);
+    assert(e.isY());
+    assert(e.getY() == 3.14);
+  }
+  {
+    auto e = makePrimitivePayload(3);
+    assert(e.isZ());
+    assert(e.getZ());
+  }
+  return 0;
+}

--- a/test/Interop/SwiftToCxx/enums/swift-enum-extract-payload.swift
+++ b/test/Interop/SwiftToCxx/enums/swift-enum-extract-payload.swift
@@ -1,0 +1,178 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -module-name Enums -clang-header-expose-public-decls -emit-clang-header-path %t/enums.h
+// RUN: %FileCheck %s < %t/enums.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/enums.h -Wno-unused-private-field -Wno-unused-function)
+
+public enum PrimitivePayload {
+    case x(Int64)
+    case y(Double)
+    case z(Bool)
+}
+
+public func makePrimitivePayload(_ x: Int) -> PrimitivePayload {
+    switch x {
+    case 1:
+        return .x(9999)
+    case 2:
+        return .y(3.14)
+    default:
+        return .z(true)
+    }
+}
+
+public enum Uvw {
+    case one, two ,three
+}
+
+public enum Xyz {
+    case first(Foo)
+    case second(Uvw)
+    case third(Bar)
+}
+
+public struct Foo {
+    public var x: Int64
+    public init(x: Int64) {
+        self.x = x
+    }
+}
+
+public struct Bar {
+    public var x1, x2, x3, x4, x5, x6: Double
+    public init(x1: Double, x2: Double, x3: Double, x4: Double, x5: Double, x6: Double) {
+        self.x1 = x1
+        self.x2 = x2
+        self.x3 = x3
+        self.x4 = x4
+        self.x5 = x5
+        self.x6 = x6
+    }
+}
+
+public func checkFoo(_ lhs: Foo, _ rhs: Foo) -> Bool {
+    return lhs.x == rhs.x
+}
+
+public func checkBar(_ lhs: Bar, _ rhs: Bar) -> Bool {
+    return lhs.x1 == rhs.x1 && lhs.x2 == rhs.x2 && lhs.x3 == rhs.x3 && lhs.x4 == rhs.x4 && lhs.x5 == rhs.x5 && lhs.x6 == rhs.x6
+}
+
+public func checkUvw(_ lhs: Uvw, _ rhs: Uvw) -> Bool {
+    return lhs == rhs
+}
+
+public func makeXyz(_ x: Int) -> Xyz {
+    switch x {
+    case 1:
+        return .first(Foo(x: 1234))
+    case 2:
+        return .second(.two)
+    default:
+        return .third(Bar(x1: 1.1, x2: 2.2, x3: 3.3, x4: 4.4, x5: 5.5, x6: 6.6))
+    }
+}
+
+public func makeUvw(_ x: Int) -> Uvw {
+    switch x {
+    case 1:
+        return .one
+    case 2:
+        return .two
+    default:
+        return .three
+    }
+}
+
+// CHECK: class _impl_Bar {
+// CHECK:      static inline void initializeWithTake(char * _Nonnull destStorage, char * _Nonnull srcStorage) {
+// CHECK-NEXT:   auto metadata = _impl::$s5Enums3BarVMa(0);
+// CHECK-NEXT:   auto *vwTable = *(reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1);
+// CHECK-NEXT:   vwTable->initializeWithTake(destStorage, srcStorage, metadata._0);
+// CHECK-NEXT: }
+
+// CHECK: class _impl_Foo {
+// CHECK:      static inline void initializeWithTake(char * _Nonnull destStorage, char * _Nonnull srcStorage) {
+// CHECK-NEXT:   auto metadata = _impl::$s5Enums3FooVMa(0);
+// CHECK-NEXT:   auto *vwTable = *(reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1);
+// CHECK-NEXT:   vwTable->initializeWithTake(destStorage, srcStorage, metadata._0);
+// CHECK-NEXT: }
+
+// CHECK: class PrimitivePayload final {
+// CHECK:      inline int64_t getX() const {
+// CHECK-NEXT:   if (!isX()) abort();
+// CHECK-NEXT:   auto thisCopy = *this;
+// CHECK-NEXT:   char * _Nonnull payloadFromDestruction = thisCopy._destructiveProjectEnumData();
+// CHECK-NEXT:   int64_t result;
+// CHECK-NEXT:   memcpy(&result, payloadFromDestruction, sizeof(result));
+// CHECK-NEXT:   return result;
+// CHECK-NEXT: }
+// CHECK:      inline double getY() const {
+// CHECK-NEXT:   if (!isY()) abort();
+// CHECK-NEXT:   auto thisCopy = *this;
+// CHECK-NEXT:   char * _Nonnull payloadFromDestruction = thisCopy._destructiveProjectEnumData();
+// CHECK-NEXT:   double result;
+// CHECK-NEXT:   memcpy(&result, payloadFromDestruction, sizeof(result));
+// CHECK-NEXT:   return result;
+// CHECK-NEXT: }
+// CHECK:      inline bool getZ() const {
+// CHECK-NEXT:   if (!isZ()) abort();
+// CHECK-NEXT:   auto thisCopy = *this;
+// CHECK-NEXT:   char * _Nonnull payloadFromDestruction = thisCopy._destructiveProjectEnumData();
+// CHECK-NEXT:   bool result;
+// CHECK-NEXT:   memcpy(&result, payloadFromDestruction, sizeof(result));
+// CHECK-NEXT:   return result;
+// CHECK-NEXT: }
+// CHECK: private:
+// CHECK:      inline char * _Nonnull _destructiveProjectEnumData() {
+// CHECK-NEXT:   auto metadata = _impl::$s5Enums16PrimitivePayloadOMa(0);
+// CHECK-NEXT:   auto *vwTable = *(reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1);
+// CHECK-NEXT:   const auto *enumVWTable = reinterpret_cast<swift::_impl::EnumValueWitnessTable *>(vwTable);
+// CHECK-NEXT:   enumVWTable->destructiveProjectEnumData(_getOpaquePointer(), metadata._0);
+// CHECK-NEXT:   return _getOpaquePointer();
+// CHECK-NEXT: }
+// CHECK: class _impl_PrimitivePayload {
+// CHECK:      static inline void initializeWithTake(char * _Nonnull destStorage, char * _Nonnull srcStorage) {
+// CHECK-NEXT:   auto metadata = _impl::$s5Enums16PrimitivePayloadOMa(0);
+// CHECK-NEXT:   auto *vwTable = *(reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1);
+// CHECK-NEXT:   vwTable->initializeWithTake(destStorage, srcStorage, metadata._0);
+// CHECK-NEXT: }
+
+// CHECK: class _impl_Uvw {
+// CHECK:      static inline void initializeWithTake(char * _Nonnull destStorage, char * _Nonnull srcStorage) {
+// CHECK-NEXT:   auto metadata = _impl::$s5Enums3UvwOMa(0);
+// CHECK-NEXT:   auto *vwTable = *(reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1);
+// CHECK-NEXT:   vwTable->initializeWithTake(destStorage, srcStorage, metadata._0);
+// CHECK-NEXT: }
+
+// CHECK: class Xyz final {
+// CHECK:      inline Foo getFirst() const {
+// CHECK-NEXT:   if (!isFirst()) abort();
+// CHECK-NEXT:   auto thisCopy = *this;
+// CHECK-NEXT:   char * _Nonnull payloadFromDestruction = thisCopy._destructiveProjectEnumData();
+// CHECK-NEXT:   return _impl::_impl_Foo::returnNewValue([&](char * _Nonnull result) {
+// CHECK-NEXT:     _impl::_impl_Foo::initializeWithTake(result, payloadFromDestruction);
+// CHECK-NEXT:   });
+// CHECK-NEXT: }
+// CHECK:      inline Bar getThird() const {
+// CHECK-NEXT:   if (!isThird()) abort();
+// CHECK-NEXT:   auto thisCopy = *this;
+// CHECK-NEXT:   char * _Nonnull payloadFromDestruction = thisCopy._destructiveProjectEnumData();
+// CHECK-NEXT:   return _impl::_impl_Bar::returnNewValue([&](char * _Nonnull result) {
+// CHECK-NEXT:     _impl::_impl_Bar::initializeWithTake(result, payloadFromDestruction);
+// CHECK-NEXT:   });
+// CHECK-NEXT: }
+// CHECK: private:
+// CHECK:      inline char * _Nonnull _destructiveProjectEnumData() {
+// CHECK-NEXT:   auto metadata = _impl::$s5Enums3XyzOMa(0);
+// CHECK-NEXT:   auto *vwTable = *(reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1);
+// CHECK-NEXT:   const auto *enumVWTable = reinterpret_cast<swift::_impl::EnumValueWitnessTable *>(vwTable);
+// CHECK-NEXT:   enumVWTable->destructiveProjectEnumData(_getOpaquePointer(), metadata._0);
+// CHECK-NEXT:   return _getOpaquePointer();
+// CHECK-NEXT: }
+// CHECK: class _impl_Xyz {
+// CHECK:      static inline void initializeWithTake(char * _Nonnull destStorage, char * _Nonnull srcStorage) {
+// CHECK-NEXT:   auto metadata = _impl::$s5Enums3XyzOMa(0);
+// CHECK-NEXT:   auto *vwTable = *(reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1);
+// CHECK-NEXT:   vwTable->initializeWithTake(destStorage, srcStorage, metadata._0);
+// CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/enums/swift-enum-extract-payload.swift
+++ b/test/Interop/SwiftToCxx/enums/swift-enum-extract-payload.swift
@@ -87,14 +87,24 @@ public func makeUvw(_ x: Int) -> Uvw {
 // CHECK: class _impl_Bar {
 // CHECK:      static inline void initializeWithTake(char * _Nonnull destStorage, char * _Nonnull srcStorage) {
 // CHECK-NEXT:   auto metadata = _impl::$s5Enums3BarVMa(0);
-// CHECK-NEXT:   auto *vwTable = *(reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1);
+// CHECK-NEXT:   auto *vwTableAddr = reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1;
+// CHECK-NEXT: #ifdef __arm64e__
+// CHECK-NEXT:   auto *vwTable = reinterpret_cast<swift::_impl::ValueWitnessTable *>(ptrauth_auth_data(reinterpret_cast<void *>(*vwTableAddr), ptrauth_key_process_independent_data, ptrauth_blend_discriminator(vwTableAddr, 11839)));
+// CHECK-NEXT: #else
+// CHECK-NEXT:   auto *vwTable = *vwTableAddr;
+// CHECK-NEXT: #endif
 // CHECK-NEXT:   vwTable->initializeWithTake(destStorage, srcStorage, metadata._0);
 // CHECK-NEXT: }
 
 // CHECK: class _impl_Foo {
 // CHECK:      static inline void initializeWithTake(char * _Nonnull destStorage, char * _Nonnull srcStorage) {
 // CHECK-NEXT:   auto metadata = _impl::$s5Enums3FooVMa(0);
-// CHECK-NEXT:   auto *vwTable = *(reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1);
+// CHECK-NEXT:   auto *vwTableAddr = reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1;
+// CHECK-NEXT: #ifdef __arm64e__
+// CHECK-NEXT:   auto *vwTable = reinterpret_cast<swift::_impl::ValueWitnessTable *>(ptrauth_auth_data(reinterpret_cast<void *>(*vwTableAddr), ptrauth_key_process_independent_data, ptrauth_blend_discriminator(vwTableAddr, 11839)));
+// CHECK-NEXT: #else
+// CHECK-NEXT:   auto *vwTable = *vwTableAddr;
+// CHECK-NEXT: #endif
 // CHECK-NEXT:   vwTable->initializeWithTake(destStorage, srcStorage, metadata._0);
 // CHECK-NEXT: }
 
@@ -126,7 +136,12 @@ public func makeUvw(_ x: Int) -> Uvw {
 // CHECK: private:
 // CHECK:      inline char * _Nonnull _destructiveProjectEnumData() {
 // CHECK-NEXT:   auto metadata = _impl::$s5Enums16PrimitivePayloadOMa(0);
-// CHECK-NEXT:   auto *vwTable = *(reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1);
+// CHECK-NEXT:   auto *vwTableAddr = reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1;
+// CHECK-NEXT: #ifdef __arm64e__
+// CHECK-NEXT:   auto *vwTable = reinterpret_cast<swift::_impl::ValueWitnessTable *>(ptrauth_auth_data(reinterpret_cast<void *>(*vwTableAddr), ptrauth_key_process_independent_data, ptrauth_blend_discriminator(vwTableAddr, 11839)));
+// CHECK-NEXT: #else
+// CHECK-NEXT:   auto *vwTable = *vwTableAddr;
+// CHECK-NEXT: #endif
 // CHECK-NEXT:   const auto *enumVWTable = reinterpret_cast<swift::_impl::EnumValueWitnessTable *>(vwTable);
 // CHECK-NEXT:   enumVWTable->destructiveProjectEnumData(_getOpaquePointer(), metadata._0);
 // CHECK-NEXT:   return _getOpaquePointer();
@@ -134,14 +149,24 @@ public func makeUvw(_ x: Int) -> Uvw {
 // CHECK: class _impl_PrimitivePayload {
 // CHECK:      static inline void initializeWithTake(char * _Nonnull destStorage, char * _Nonnull srcStorage) {
 // CHECK-NEXT:   auto metadata = _impl::$s5Enums16PrimitivePayloadOMa(0);
-// CHECK-NEXT:   auto *vwTable = *(reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1);
+// CHECK-NEXT:   auto *vwTableAddr = reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1;
+// CHECK-NEXT: #ifdef __arm64e__
+// CHECK-NEXT:   auto *vwTable = reinterpret_cast<swift::_impl::ValueWitnessTable *>(ptrauth_auth_data(reinterpret_cast<void *>(*vwTableAddr), ptrauth_key_process_independent_data, ptrauth_blend_discriminator(vwTableAddr, 11839)));
+// CHECK-NEXT: #else
+// CHECK-NEXT:   auto *vwTable = *vwTableAddr;
+// CHECK-NEXT: #endif
 // CHECK-NEXT:   vwTable->initializeWithTake(destStorage, srcStorage, metadata._0);
 // CHECK-NEXT: }
 
 // CHECK: class _impl_Uvw {
 // CHECK:      static inline void initializeWithTake(char * _Nonnull destStorage, char * _Nonnull srcStorage) {
 // CHECK-NEXT:   auto metadata = _impl::$s5Enums3UvwOMa(0);
-// CHECK-NEXT:   auto *vwTable = *(reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1);
+// CHECK-NEXT:   auto *vwTableAddr = reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1;
+// CHECK-NEXT: #ifdef __arm64e__
+// CHECK-NEXT:   auto *vwTable = reinterpret_cast<swift::_impl::ValueWitnessTable *>(ptrauth_auth_data(reinterpret_cast<void *>(*vwTableAddr), ptrauth_key_process_independent_data, ptrauth_blend_discriminator(vwTableAddr, 11839)));
+// CHECK-NEXT: #else
+// CHECK-NEXT:   auto *vwTable = *vwTableAddr;
+// CHECK-NEXT: #endif
 // CHECK-NEXT:   vwTable->initializeWithTake(destStorage, srcStorage, metadata._0);
 // CHECK-NEXT: }
 
@@ -165,7 +190,12 @@ public func makeUvw(_ x: Int) -> Uvw {
 // CHECK: private:
 // CHECK:      inline char * _Nonnull _destructiveProjectEnumData() {
 // CHECK-NEXT:   auto metadata = _impl::$s5Enums3XyzOMa(0);
-// CHECK-NEXT:   auto *vwTable = *(reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1);
+// CHECK-NEXT:   auto *vwTableAddr = reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1;
+// CHECK-NEXT: #ifdef __arm64e__
+// CHECK-NEXT:   auto *vwTable = reinterpret_cast<swift::_impl::ValueWitnessTable *>(ptrauth_auth_data(reinterpret_cast<void *>(*vwTableAddr), ptrauth_key_process_independent_data, ptrauth_blend_discriminator(vwTableAddr, 11839)));
+// CHECK-NEXT: #else
+// CHECK-NEXT:   auto *vwTable = *vwTableAddr;
+// CHECK-NEXT: #endif
 // CHECK-NEXT:   const auto *enumVWTable = reinterpret_cast<swift::_impl::EnumValueWitnessTable *>(vwTable);
 // CHECK-NEXT:   enumVWTable->destructiveProjectEnumData(_getOpaquePointer(), metadata._0);
 // CHECK-NEXT:   return _getOpaquePointer();
@@ -173,6 +203,11 @@ public func makeUvw(_ x: Int) -> Uvw {
 // CHECK: class _impl_Xyz {
 // CHECK:      static inline void initializeWithTake(char * _Nonnull destStorage, char * _Nonnull srcStorage) {
 // CHECK-NEXT:   auto metadata = _impl::$s5Enums3XyzOMa(0);
-// CHECK-NEXT:   auto *vwTable = *(reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1);
+// CHECK-NEXT:   auto *vwTableAddr = reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1;
+// CHECK-NEXT: #ifdef __arm64e__
+// CHECK-NEXT:   auto *vwTable = reinterpret_cast<swift::_impl::ValueWitnessTable *>(ptrauth_auth_data(reinterpret_cast<void *>(*vwTableAddr), ptrauth_key_process_independent_data, ptrauth_blend_discriminator(vwTableAddr, 11839)));
+// CHECK-NEXT: #else
+// CHECK-NEXT:   auto *vwTable = *vwTableAddr;
+// CHECK-NEXT: #endif
 // CHECK-NEXT:   vwTable->initializeWithTake(destStorage, srcStorage, metadata._0);
 // CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/enums/swift-enum-extract-payload.swift
+++ b/test/Interop/SwiftToCxx/enums/swift-enum-extract-payload.swift
@@ -111,24 +111,27 @@ public func makeUvw(_ x: Int) -> Uvw {
 // CHECK: class PrimitivePayload final {
 // CHECK:      inline int64_t getX() const {
 // CHECK-NEXT:   if (!isX()) abort();
-// CHECK-NEXT:   auto thisCopy = *this;
-// CHECK-NEXT:   char * _Nonnull payloadFromDestruction = thisCopy._destructiveProjectEnumData();
+// CHECK-NEXT:   alignas(PrimitivePayload) unsigned char buffer[sizeof(PrimitivePayload)];
+// CHECK-NEXT:   auto *thisCopy = new(buffer) PrimitivePayload(*this);
+// CHECK-NEXT:   char * _Nonnull payloadFromDestruction = thisCopy->_destructiveProjectEnumData();
 // CHECK-NEXT:   int64_t result;
 // CHECK-NEXT:   memcpy(&result, payloadFromDestruction, sizeof(result));
 // CHECK-NEXT:   return result;
 // CHECK-NEXT: }
 // CHECK:      inline double getY() const {
 // CHECK-NEXT:   if (!isY()) abort();
-// CHECK-NEXT:   auto thisCopy = *this;
-// CHECK-NEXT:   char * _Nonnull payloadFromDestruction = thisCopy._destructiveProjectEnumData();
+// CHECK-NEXT:   alignas(PrimitivePayload) unsigned char buffer[sizeof(PrimitivePayload)];
+// CHECK-NEXT:   auto *thisCopy = new(buffer) PrimitivePayload(*this);
+// CHECK-NEXT:   char * _Nonnull payloadFromDestruction = thisCopy->_destructiveProjectEnumData();
 // CHECK-NEXT:   double result;
 // CHECK-NEXT:   memcpy(&result, payloadFromDestruction, sizeof(result));
 // CHECK-NEXT:   return result;
 // CHECK-NEXT: }
 // CHECK:      inline bool getZ() const {
 // CHECK-NEXT:   if (!isZ()) abort();
-// CHECK-NEXT:   auto thisCopy = *this;
-// CHECK-NEXT:   char * _Nonnull payloadFromDestruction = thisCopy._destructiveProjectEnumData();
+// CHECK-NEXT:   alignas(PrimitivePayload) unsigned char buffer[sizeof(PrimitivePayload)];
+// CHECK-NEXT:   auto *thisCopy = new(buffer) PrimitivePayload(*this);
+// CHECK-NEXT:   char * _Nonnull payloadFromDestruction = thisCopy->_destructiveProjectEnumData();
 // CHECK-NEXT:   bool result;
 // CHECK-NEXT:   memcpy(&result, payloadFromDestruction, sizeof(result));
 // CHECK-NEXT:   return result;
@@ -173,16 +176,18 @@ public func makeUvw(_ x: Int) -> Uvw {
 // CHECK: class Xyz final {
 // CHECK:      inline Foo getFirst() const {
 // CHECK-NEXT:   if (!isFirst()) abort();
-// CHECK-NEXT:   auto thisCopy = *this;
-// CHECK-NEXT:   char * _Nonnull payloadFromDestruction = thisCopy._destructiveProjectEnumData();
+// CHECK-NEXT:   alignas(Xyz) unsigned char buffer[sizeof(Xyz)];
+// CHECK-NEXT:   auto *thisCopy = new(buffer) Xyz(*this);
+// CHECK-NEXT:   char * _Nonnull payloadFromDestruction = thisCopy->_destructiveProjectEnumData();
 // CHECK-NEXT:   return _impl::_impl_Foo::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:     _impl::_impl_Foo::initializeWithTake(result, payloadFromDestruction);
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 // CHECK:      inline Bar getThird() const {
 // CHECK-NEXT:   if (!isThird()) abort();
-// CHECK-NEXT:   auto thisCopy = *this;
-// CHECK-NEXT:   char * _Nonnull payloadFromDestruction = thisCopy._destructiveProjectEnumData();
+// CHECK-NEXT:   alignas(Xyz) unsigned char buffer[sizeof(Xyz)];
+// CHECK-NEXT:   auto *thisCopy = new(buffer) Xyz(*this);
+// CHECK-NEXT:   char * _Nonnull payloadFromDestruction = thisCopy->_destructiveProjectEnumData();
 // CHECK-NEXT:   return _impl::_impl_Bar::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:     _impl::_impl_Bar::initializeWithTake(result, payloadFromDestruction);
 // CHECK-NEXT:   });

--- a/test/Interop/SwiftToCxx/structs/swift-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/swift-struct-in-cxx.swift
@@ -48,6 +48,11 @@
 // CHECK-NEXT:   callable(result._getOpaquePointer());
 // CHECK-NEXT:   return result;
 // CHECK-NEXT:  }
+// CHECK-NEXT: static inline void initializeWithTake(char * _Nonnull destStorage, char * _Nonnull srcStorage) {
+// CHECK-NEXT:   auto metadata = _impl::$s7Structs18StructWithIntFieldVMa(0);
+// CHECK-NEXT:   auto *vwTable = *(reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1);
+// CHECK-NEXT:   vwTable->initializeWithTake(destStorage, srcStorage, metadata._0);
+// CHECK-NEXT: }
 // CHECK-NEXT: };
 // CHECK-EMPTY:
 // CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/structs/swift-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/swift-struct-in-cxx.swift
@@ -50,7 +50,12 @@
 // CHECK-NEXT:  }
 // CHECK-NEXT: static inline void initializeWithTake(char * _Nonnull destStorage, char * _Nonnull srcStorage) {
 // CHECK-NEXT:   auto metadata = _impl::$s7Structs18StructWithIntFieldVMa(0);
-// CHECK-NEXT:   auto *vwTable = *(reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1);
+// CHECK-NEXT:   auto *vwTableAddr = reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1;
+// CHECK-NEXT: #ifdef __arm64e__
+// CHECK-NEXT:   auto *vwTable = reinterpret_cast<swift::_impl::ValueWitnessTable *>(ptrauth_auth_data(reinterpret_cast<void *>(*vwTableAddr), ptrauth_key_process_independent_data, ptrauth_blend_discriminator(vwTableAddr, 11839)));
+// CHECK-NEXT: #else
+// CHECK-NEXT:   auto *vwTable = *vwTableAddr;
+// CHECK-NEXT: #endif
 // CHECK-NEXT:   vwTable->initializeWithTake(destStorage, srcStorage, metadata._0);
 // CHECK-NEXT: }
 // CHECK-NEXT: };

--- a/test/Interop/lit.local.cfg
+++ b/test/Interop/lit.local.cfg
@@ -29,9 +29,9 @@ config.substitutions.insert(0, ('%target-interop-build-clangxx', '%target-clangx
 
 # Test parsing of the generated C++ header in different C++ language modes.
 config.substitutions.insert(0, ('%check-interop-cxx-header-in-clang\(([^)]+)\)',
-                             SubstituteCaptures(r'%check-cxx-header-in-clang -std=c++14 -Wno-padded -Wno-c11-extensions \1 && '
-                                                r'%check-cxx-header-in-clang -std=c++17 -Wno-padded -Wno-c11-extensions \1 && '
-                                                r'%check-cxx-header-in-clang -std=c++20 -Wno-padded -Wno-c11-extensions \1')))
+                             SubstituteCaptures(r'%check-cxx-header-in-clang -std=c++14 -Wno-padded -Wno-c11-extensions -D_LIBCPP_CSTDLIB \1 && '
+                                                r'%check-cxx-header-in-clang -std=c++17 -Wno-padded -Wno-c11-extensions -D_LIBCPP_CSTDLIB \1 && '
+                                                r'%check-cxx-header-in-clang -std=c++20 -Wno-padded -Wno-c11-extensions -D_LIBCPP_CSTDLIB \1')))
 
 # Test parsing of the generated C header in different C language modes.
 config.substitutions.insert(0, ('%check-interop-c-header-in-clang\(([^)]+)\)',

--- a/test/Interop/lit.local.cfg
+++ b/test/Interop/lit.local.cfg
@@ -25,7 +25,7 @@ config.substitutions.insert(0, ('%target-interop-build-swift',
 config.substitutions.insert(0, ('%target-interop-build-clang',  '%target-clang -x c -Werror=implicit-function-declaration ' + clang_opt))
 
 # Build C++ files with matching link settings, if required by the target.
-config.substitutions.insert(0, ('%target-interop-build-clangxx', '%target-clangxx ' + clang_opt))
+config.substitutions.insert(0, ('%target-interop-build-clangxx', '%target-clangxx --std=gnu++14 ' + clang_opt))
 
 # Test parsing of the generated C++ header in different C++ language modes.
 config.substitutions.insert(0, ('%check-interop-cxx-header-in-clang\(([^)]+)\)',

--- a/test/PrintAsCxx/empty.swift
+++ b/test/PrintAsCxx/empty.swift
@@ -29,6 +29,7 @@
 // CHECK-NEXT:  #include <cstddef>
 // CHECK-NEXT:  #include <cstdbool>
 // CHECK-NEXT:  #include <cstring>
+// CHECK-NEXT:  #include <new>
 // CHECK-NEXT:  #include <stdlib.h>
 // CHECK-NEXT:  #if defined(_WIN32)
 // CHECK-NEXT:  #include <malloc.h>

--- a/test/PrintAsObjC/empty.swift
+++ b/test/PrintAsObjC/empty.swift
@@ -4,8 +4,8 @@
 
 // RUN: %check-in-clang -std=c99 %t/empty.h
 // RUN: %check-in-clang -std=c11 %t/empty.h
-// RUN: %check-cxx-header-in-clang -x objective-c++-header -std=c++11 %t/empty.h
-// RUN: %check-cxx-header-in-clang -x objective-c++-header -std=c++14 %t/empty.h
+// RUN: %check-cxx-header-in-clang -x objective-c++-header -std=c++11 -D_LIBCPP_CSTDLIB %t/empty.h
+// RUN: %check-cxx-header-in-clang -x objective-c++-header -std=c++14 -D_LIBCPP_CSTDLIB %t/empty.h
 
 // RUN: %check-in-clang -std=c99 -fno-modules -Qunused-arguments %t/empty.h
 // RUN: not %check-in-clang -I %S/Inputs/clang-headers %t/empty.h 2>&1 | %FileCheck %s --check-prefix=CUSTOM-OBJC-PROLOGUE


### PR DESCRIPTION
<!-- What's in this pull request? -->
This pull request adds initial support for getting associated values in struct/enum/primitive types from enums.

This pull request also rewrites some previous enum test cases because they use types from standard library or reference type, which cannot be test easily.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!-- Resolves SR-NNNN. -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
