### PR TITLE
[Parse] Do not parse generic arguments of a cast destination if the token is more than a `<`

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1259,6 +1259,9 @@ public:
 
     /// Whether the type is for a closure attribute.
     CustomAttribute,
+
+    /// Whether the type is a destination of a cast.
+    CastDestination,
   };
 
   ParserResult<TypeRepr> parseType();
@@ -1297,8 +1300,9 @@ public:
   ///   positioned at '.f'.
   /// - If there is no base type qualifier (e.g. when parsing just 'f'), returns
   ///   an empty parser error.
-  ParserResult<TypeRepr> parseTypeIdentifier(
-      bool isParsingQualifiedDeclBaseType = false);
+  ParserResult<TypeRepr>
+  parseTypeIdentifier(bool isParsingQualifiedDeclBaseType = false,
+                      ParseTypeReason reason = ParseTypeReason::Unspecified);
   ParserResult<TypeRepr> parseOldStyleProtocolComposition();
   ParserResult<TypeRepr> parseAnyType();
   ParserResult<TypeRepr> parseSILBoxType(GenericParamList *generics,

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -74,7 +74,8 @@ ParserResult<Expr> Parser::parseExprImpl(Diag<> Message,
 ParserResult<Expr> Parser::parseExprIs() {
   SourceLoc isLoc = consumeToken(tok::kw_is);
 
-  ParserResult<TypeRepr> type = parseType(diag::expected_type_after_is);
+  ParserResult<TypeRepr> type =
+      parseType(diag::expected_type_after_is, ParseTypeReason::CastDestination);
   if (type.hasCodeCompletion())
     return makeParserCodeCompletionResult<Expr>();
   if (type.isNull())
@@ -101,7 +102,8 @@ ParserResult<Expr> Parser::parseExprAs() {
     exclaimLoc = consumeToken(tok::exclaim_postfix);
   }
 
-  ParserResult<TypeRepr> type = parseType(diag::expected_type_after_as);
+  ParserResult<TypeRepr> type =
+      parseType(diag::expected_type_after_as, ParseTypeReason::CastDestination);
 
   if (type.hasCodeCompletion())
     return makeParserCodeCompletionResult<Expr>();

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -723,18 +723,13 @@ Parser::parseTypeIdentifier(bool isParsingQualifiedDeclBaseType,
       SourceLoc LAngle, RAngle;
       SmallVector<TypeRepr*, 8> GenericArgs;
       if (startsWithLess(Tok)) {
-<<<<<<< HEAD
+        // Only attempt to parse a generic argument list in a cast destination type if the token text is just "<", because it can be an operator, for example:
+        // "1 as Int16 << 7".
         if (Tok.isAnyOperator() &&
             (Tok.getText().str() == "<" ||
              reason != ParseTypeReason::CastDestination)) {
           auto genericArgsStatus =
               parseGenericArguments(GenericArgs, LAngle, RAngle);
-=======
-        // We only want to parse generic arguments if the token text is just a "<" or we are not parsing a cast destination type, because it can be followed by an operator, for example:
-        // "1 as Int16 << 7".
-        if (Tok.getText().str() == "<" || reason != ParseTypeReason::CastDestination) {
-          auto genericArgsStatus = parseGenericArguments(GenericArgs, LAngle, RAngle);
->>>>>>> 641b132b73c (Remove unnecessary import, add a comment)
           if (genericArgsStatus.isErrorOrHasCompletion())
             return genericArgsStatus;
         }

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -723,11 +723,9 @@ Parser::parseTypeIdentifier(bool isParsingQualifiedDeclBaseType,
       SourceLoc LAngle, RAngle;
       SmallVector<TypeRepr*, 8> GenericArgs;
       if (startsWithLess(Tok)) {
-        // Only attempt to parse a generic argument list in a cast destination type if the token text is just "<", because it can be an operator, for example:
-        // "1 as Int16 << 7".
-        if (Tok.isAnyOperator() &&
-            (Tok.getText().str() == "<" ||
-             reason != ParseTypeReason::CastDestination)) {
+        // Only attempt to parse a generic argument list in a cast destination type if the token text is just "<", because it can be an operator, for example: "1 as Int16 << 7".
+        if (Tok.getText().str() == "<" ||
+             reason != ParseTypeReason::CastDestination) {
           auto genericArgsStatus =
               parseGenericArguments(GenericArgs, LAngle, RAngle);
           if (genericArgsStatus.isErrorOrHasCompletion())

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -16,7 +16,6 @@
 
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/Attr.h"
-#include "swift/AST/DiagnosticSuppression.h"
 #include "swift/AST/GenericParamList.h"
 #include "swift/AST/TypeRepr.h"
 #include "swift/Parse/CodeCompletionCallbacks.h"
@@ -724,11 +723,18 @@ Parser::parseTypeIdentifier(bool isParsingQualifiedDeclBaseType,
       SourceLoc LAngle, RAngle;
       SmallVector<TypeRepr*, 8> GenericArgs;
       if (startsWithLess(Tok)) {
+<<<<<<< HEAD
         if (Tok.isAnyOperator() &&
             (Tok.getText().str() == "<" ||
              reason != ParseTypeReason::CastDestination)) {
           auto genericArgsStatus =
               parseGenericArguments(GenericArgs, LAngle, RAngle);
+=======
+        // We only want to parse generic arguments if the token text is just a "<" or we are not parsing a cast destination type, because it can be followed by an operator, for example:
+        // "1 as Int16 << 7".
+        if (Tok.getText().str() == "<" || reason != ParseTypeReason::CastDestination) {
+          auto genericArgsStatus = parseGenericArguments(GenericArgs, LAngle, RAngle);
+>>>>>>> 641b132b73c (Remove unnecessary import, add a comment)
           if (genericArgsStatus.isErrorOrHasCompletion())
             return genericArgsStatus;
         }

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -723,9 +723,11 @@ Parser::parseTypeIdentifier(bool isParsingQualifiedDeclBaseType,
       SourceLoc LAngle, RAngle;
       SmallVector<TypeRepr*, 8> GenericArgs;
       if (startsWithLess(Tok)) {
-        // Only attempt to parse a generic argument list in a cast destination type if the token text is just "<", because it can be an operator, for example: "1 as Int16 << 7".
+        // Only attempt to parse a generic argument list in a cast destination
+        // type if the token text is just "<", because it can be an operator,
+        // for example: "1 as Int16 << 7".
         if (Tok.getText().str() == "<" ||
-             reason != ParseTypeReason::CastDestination) {
+            reason != ParseTypeReason::CastDestination) {
           auto genericArgsStatus =
               parseGenericArguments(GenericArgs, LAngle, RAngle);
           if (genericArgsStatus.isErrorOrHasCompletion())

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -726,7 +726,7 @@ Parser::parseTypeIdentifier(bool isParsingQualifiedDeclBaseType,
         // Only attempt to parse a generic argument list in a cast destination
         // type if the token text is just "<", because it can be an operator,
         // for example: "1 as Int16 << 7".
-        if (Tok.getText().str() == "<" ||
+        if (Tok.getText().equals("<") ||
             reason != ParseTypeReason::CastDestination) {
           auto genericArgsStatus =
               parseGenericArguments(GenericArgs, LAngle, RAngle);

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -180,7 +180,7 @@ ParserResult<TypeRepr> Parser::parseTypeSimple(
   case tok::kw_Self:
   case tok::kw_Any:
   case tok::identifier: {
-    ty = parseTypeIdentifier(false, reason);
+    ty = parseTypeIdentifier(/*isParsingQualifiedDeclBaseType=*/false, reason);
     break;
   }
   case tok::l_paren:

--- a/test/Parse/generic_disambiguation.swift
+++ b/test/Parse/generic_disambiguation.swift
@@ -79,7 +79,7 @@ A<(B) throws -> D>(x: 0) // expected-warning{{unused}}
 
 do {
   let _ = 1 as Int16 << 7
-  let _ = 1 as? Int16 << 7 // expected-warning{{conditional downcast from literal to 'Int16' always fails; consider using 'as' coercion}} expected-warning{{value of optional type 'Int16?' must be unwrapped to a value of type 'Int16'}} expected-note{{coalesce using '??' to provide a default when the optional value contains 'nil'}} expected-note{{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+  let _ = 1 as? Int16 << 7 // expected-error{{value of optional type 'Int16?' must be unwrapped to a value of type 'Int16'}} expected-warning{{conditional downcast from literal to 'Int16' always fails; consider using 'as' coercion}} expected-note{{coalesce using '??' to provide a default when the optional value contains 'nil'}} expected-note{{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
   let _ = 1 is Int16 << 7 // expected-warning{{conditional downcast from literal to 'Int16' always fails; consider using 'as' coercion}} expected-error{{binary operator '<<' cannot be applied to operands of type 'Bool' and 'Int'}}
   let _ = 1 as! Int16 << 7 // expected-warning{{conditional downcast from literal to 'Int16' always fails; consider using 'as' coercion}}
   let _ = 1 as Int16 < 7 // expected-error{{expected type}}

--- a/test/Parse/generic_disambiguation.swift
+++ b/test/Parse/generic_disambiguation.swift
@@ -82,6 +82,7 @@ do {
   let _ = 1 as? Int16 << 7 // expected-error{{value of optional type 'Int16?' must be unwrapped to a value of type 'Int16'}} expected-warning{{conditional downcast from literal to 'Int16' always fails; consider using 'as' coercion}} expected-note{{coalesce using '??' to provide a default when the optional value contains 'nil'}} expected-note{{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
   let _ = 1 is Int16 << 7 // expected-warning{{conditional downcast from literal to 'Int16' always fails; consider using 'as' coercion}} expected-error{{binary operator '<<' cannot be applied to operands of type 'Bool' and 'Int'}}
   let _ = 1 as! Int16 << 7 // expected-warning{{conditional downcast from literal to 'Int16' always fails; consider using 'as' coercion}}
-  let _ = 1 as Int16 < 7 // expected-error{{expected type}}
   let _ = 1 as Int16 <= 7
+  // FIXME: this should not produce any errors.
+  let _ = 1 as Int16 < 7 // expected-error{{expected type}}
 }

--- a/test/Parse/generic_disambiguation.swift
+++ b/test/Parse/generic_disambiguation.swift
@@ -79,13 +79,19 @@ A<(B) throws -> D>(x: 0) // expected-warning{{unused}}
 
 // https://github.com/apple/swift/issues/43053
 do {
-  1 as! A<B>.F << 2 // expected-warning{{cast from 'Int' to unrelated type 'A<B>.F' always fails}} // expected-error {{referencing operator function '<<' on 'BinaryInteger' requires that 'A<B>.F' conform to 'BinaryInteger'}}
-  1 as! A<B> << 2 // expected-warning{{cast from 'Int' to unrelated type 'A<B>' always fails}} expected-error{{referencing operator function '<<' on 'BinaryInteger' requires that 'A<B>' conform to 'BinaryInteger'}}
+  1 as! A<B>.F << 2 // expected-warning {{cast from 'Int' to unrelated type 'A<B>.F' always fails}}
+  // expected-error@-1 {{referencing operator function '<<' on 'BinaryInteger' requires that 'A<B>.F' conform to 'BinaryInteger'}}
+  1 as! A<B> << 2 // expected-warning {{cast from 'Int' to unrelated type 'A<B>' always fails}}
+  // expected-error@-1 {{referencing operator function '<<' on 'BinaryInteger' requires that 'A<B>' conform to 'BinaryInteger'}}
   let _ = 1 as Int16 << 7
-  let _ = 1 as? Int16 << 7 // expected-error{{value of optional type 'Int16?' must be unwrapped to a value of type 'Int16'}} expected-warning{{conditional downcast from literal to 'Int16' always fails; consider using 'as' coercion}} expected-note{{coalesce using '??' to provide a default when the optional value contains 'nil'}} expected-note{{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
-  let _ = 1 is Int16 << 7 // expected-warning{{conditional downcast from literal to 'Int16' always fails; consider using 'as' coercion}} expected-error{{binary operator '<<' cannot be applied to operands of type 'Bool' and 'Int'}}
-  let _ = 1 as! Int16 << 7 // expected-warning{{conditional downcast from literal to 'Int16' always fails; consider using 'as' coercion}}
+  let _ = 1 as? Int16 << 7 // expected-error {{value of optional type 'Int16?' must be unwrapped to a value of type 'Int16'}}
+  // expected-warning@-1 {{conditional downcast from literal to 'Int16' always fails; consider using 'as' coercion}}
+  // expected-note@-2 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
+  // expected-note@-3 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+  let _ = 1 is Int16 << 7 // expected-warning {{conditional downcast from literal to 'Int16' always fails; consider using 'as' coercion}}
+  // expected-error@-1 {{binary operator '<<' cannot be applied to operands of type 'Bool' and 'Int'}}
+  let _ = 1 as! Int16 << 7 // expected-warning {{conditional downcast from literal to 'Int16' always fails; consider using 'as' coercion}}
   let _ = 1 as Int16 <= 7
   // FIXME: this should not produce any errors.
-  let _ = 1 as Int16 < 7 // expected-error{{expected type}}
+  let _ = 1 as Int16 < 7 // expected-error {{expected type}}
 }

--- a/test/Parse/generic_disambiguation.swift
+++ b/test/Parse/generic_disambiguation.swift
@@ -76,3 +76,12 @@ A<B?>(x: 0) // parses as type // expected-warning{{unused}}
 _ = a < b ? c : d
 
 A<(B) throws -> D>(x: 0) // expected-warning{{unused}}
+
+do {
+  let _ = 1 as Int16 << 7
+  let _ = 1 as? Int16 << 7 // expected-warning{{conditional downcast from literal to 'Int16' always fails; consider using 'as' coercion}} expected-warning{{value of optional type 'Int16?' must be unwrapped to a value of type 'Int16'}} expected-note{{coalesce using '??' to provide a default when the optional value contains 'nil'}} expected-note{{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+  let _ = 1 is Int16 << 7 // expected-warning{{conditional downcast from literal to 'Int16' always fails; consider using 'as' coercion}} expected-error{{binary operator '<<' cannot be applied to operands of type 'Bool' and 'Int'}}
+  let _ = 1 as! Int16 << 7 // expected-warning{{conditional downcast from literal to 'Int16' always fails; consider using 'as' coercion}}
+  let _ = 1 as Int16 < 7 // expected-error{{expected type}}
+  let _ = 1 as Int16 <= 7
+}

--- a/test/Parse/generic_disambiguation.swift
+++ b/test/Parse/generic_disambiguation.swift
@@ -77,7 +77,10 @@ _ = a < b ? c : d
 
 A<(B) throws -> D>(x: 0) // expected-warning{{unused}}
 
+// https://github.com/apple/swift/issues/43053
 do {
+  1 as! A<B>.F << 2 // expected-warning{{cast from 'Int' to unrelated type 'A<B>.F' always fails}} // expected-error {{referencing operator function '<<' on 'BinaryInteger' requires that 'A<B>.F' conform to 'BinaryInteger'}}
+  1 as! A<B> << 2 // expected-warning{{cast from 'Int' to unrelated type 'A<B>' always fails}} expected-error{{referencing operator function '<<' on 'BinaryInteger' requires that 'A<B>' conform to 'BinaryInteger'}}
   let _ = 1 as Int16 << 7
   let _ = 1 as? Int16 << 7 // expected-error{{value of optional type 'Int16?' must be unwrapped to a value of type 'Int16'}} expected-warning{{conditional downcast from literal to 'Int16' always fails; consider using 'as' coercion}} expected-note{{coalesce using '??' to provide a default when the optional value contains 'nil'}} expected-note{{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
   let _ = 1 is Int16 << 7 // expected-warning{{conditional downcast from literal to 'Int16' always fails; consider using 'as' coercion}} expected-error{{binary operator '<<' cannot be applied to operands of type 'Bool' and 'Int'}}


### PR DESCRIPTION
Resolves #43053.