### PR TITLE
[CMake] Use CMAKE_CURRENT_BINARY_DIR as base for generated C header for SwiftCompilerSources

### DIFF
--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -179,7 +179,7 @@ function(add_swift_compiler_modules_library name)
               # Bridging modules and headers.
               "-Xcc" "-I" "-Xcc" "${SWIFT_SOURCE_DIR}/include"
               # Generated C headers.
-              "-Xcc" "-I" "-Xcc" "${CMAKE_BINARY_DIR}/include"
+              "-Xcc" "-I" "-Xcc" "${CMAKE_CURRENT_BINARY_DIR}/../include"
               # Generated swift modules.
               "-I" "${build_dir}"
       COMMENT "Building swift module ${module}")


### PR DESCRIPTION
When using a unified LLVM + Swift build (using `LLVM_EXTERNAL_PROJECTS=swift`), swift is installed into `build_dir/tools/swift`. Thus, we also need to find the generated headers inside the `tools/swift/include` directory and not at the top-level `build_dir/include` directory.
