### PR TITLE
value witness table: initializeWithCopy takes in an immutable source …

### DIFF
--- a/include/swift/ABI/ValueWitness.def
+++ b/include/swift/ABI/ValueWitness.def
@@ -122,14 +122,14 @@ FUNCTION_VALUE_WITNESS(destroy,
                        VOID_TYPE,
                        (MUTABLE_VALUE_TYPE, TYPE_TYPE))
 
-///   T *(*initializeWithCopy)(T *dest, T *src, M *self);
+///   T *(*initializeWithCopy)(T *dest, const T *src, M *self);
 ///
 /// Given an invalid object of this type, initialize it as a copy of
 /// the source object.  Returns the dest object.
 FUNCTION_VALUE_WITNESS(initializeWithCopy,
                        InitializeWithCopy,
                        MUTABLE_VALUE_TYPE,
-                       (MUTABLE_VALUE_TYPE, MUTABLE_VALUE_TYPE, TYPE_TYPE))
+                       (MUTABLE_VALUE_TYPE, IMMUTABLE_VALUE_TYPE, TYPE_TYPE))
 
 ///   T *(*assignWithCopy)(T *dest, T *src, M *self);
 ///

--- a/test/Interop/SwiftToCxx/core/swift-impl-defs-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/core/swift-impl-defs-in-cxx.swift
@@ -31,7 +31,7 @@
 // CHECK-EMPTY:
 // CHECK-NEXT: using ValueWitnessInitializeBufferWithCopyOfBufferTy = void * _Nonnull(* __ptrauth_swift_value_witness_function_pointer(55882))(void * _Nonnull, void * _Nonnull, void * _Nonnull) SWIFT_NOEXCEPT_FUNCTION_PTR;
 // CHECK-NEXT: using ValueWitnessDestroyTy = void(* __ptrauth_swift_value_witness_function_pointer(1272))(void * _Nonnull, void * _Nonnull) SWIFT_NOEXCEPT_FUNCTION_PTR;
-// CHECK-NEXT: using ValueWitnessInitializeWithCopyTy = void * _Nonnull(* __ptrauth_swift_value_witness_function_pointer(58298))(void * _Nonnull, void * _Nonnull, void * _Nonnull) SWIFT_NOEXCEPT_FUNCTION_PTR;
+// CHECK-NEXT: using ValueWitnessInitializeWithCopyTy = void * _Nonnull(* __ptrauth_swift_value_witness_function_pointer(58298))(void * _Nonnull, const void * _Nonnull, void * _Nonnull) SWIFT_NOEXCEPT_FUNCTION_PTR;
 // CHECK-NEXT: using ValueWitnessAssignWithCopyTy = void * _Nonnull(* __ptrauth_swift_value_witness_function_pointer(34641))(void * _Nonnull, void * _Nonnull, void * _Nonnull) SWIFT_NOEXCEPT_FUNCTION_PTR;
 // CHECK-NEXT: using ValueWitnessInitializeWithTakeTy = void * _Nonnull(* __ptrauth_swift_value_witness_function_pointer(18648))(void * _Nonnull, void * _Nonnull, void * _Nonnull) SWIFT_NOEXCEPT_FUNCTION_PTR;
 // CHECK-NEXT: using ValueWitnessAssignWithTakeTy = void * _Nonnull(* __ptrauth_swift_value_witness_function_pointer(61402))(void * _Nonnull, void * _Nonnull, void * _Nonnull) SWIFT_NOEXCEPT_FUNCTION_PTR;


### PR DESCRIPTION
…value type
