### PR TITLE
Revert "[5.7] consider requirements of an underscored protocol to also be underscored (take two)"

### DIFF
--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -574,56 +574,6 @@ SymbolGraph::serializeDeclarationFragments(StringRef Key, Type T,
   T->print(Printer, Options);
 }
 
-namespace {
-
-/// Returns the first satisfied protocol requirement for the given decl.
-const ValueDecl *getProtocolRequirement(const ValueDecl *VD) {
-  auto reqs = VD->getSatisfiedProtocolRequirements();
-
-  if (!reqs.empty())
-    return reqs.front();
-  else
-    return nullptr;
-}
-
-/// Returns the protocol that the given decl is a requirement or conformance of, if any.
-const ProtocolDecl *getSourceProtocol(const Decl *D) {
-  const auto *DC = D->getDeclContext();
-
-  // First check to see whether it's declared directly in the protocol decl
-  if (const auto *P = dyn_cast<ProtocolDecl>(DC))
-    return P;
-
-  // Next look at whether it's an extension on a protocol
-  if (const auto *Extension = dyn_cast<ExtensionDecl>(DC)) {
-    if (const auto *ExtendedProtocol = Extension->getExtendedProtocolDecl()) {
-      return ExtendedProtocol;
-    }
-  }
-
-  // Then check to see whether it's an implementation of a protocol requirement
-  if (const auto *VD = dyn_cast<ValueDecl>(D)) {
-    if (const auto *Requirement = getProtocolRequirement(VD)) {
-      if (const auto *P = dyn_cast<ProtocolDecl>(Requirement->getDeclContext())) {
-        return P;
-      }
-    }
-  }
-
-  // If all those didn't work, there's no protocol to fetch
-  return nullptr;
-}
-
-/// Returns whether the given decl is from a protocol, and that protocol has an underscored name.
-bool isFromUnderscoredProtocol(const Decl *D) {
-  if (const auto *P = getSourceProtocol(D))
-    return P->hasUnderscoredNaming();
-
-  return false;
-}
-
-}
-
 bool SymbolGraph::isImplicitlyPrivate(const Decl *D,
                                       bool IgnoreContext) const {
   // Don't record unconditionally private declarations
@@ -632,7 +582,7 @@ bool SymbolGraph::isImplicitlyPrivate(const Decl *D,
   }
 
   // Don't record effectively internal declarations if specified
-  if (D->hasUnderscoredNaming() || isFromUnderscoredProtocol(D)) {
+  if (D->hasUnderscoredNaming()) {
     // Some implicit decls from Clang with underscored names sneak in, so throw those out
     if (const auto *clangD = D->getClangDecl()) {
       if (clangD->isImplicit())

--- a/test/SymbolGraph/Symbols/SkipsPublicUnderscore.swift
+++ b/test/SymbolGraph/Symbols/SkipsPublicUnderscore.swift
@@ -22,11 +22,8 @@ public class SomeClass {
 
 // PUBLIC-NOT: precise:{{.*}}_ProtocolShouldntAppear
 // PUBLIC-NOT: precise:{{.*}}PublicProtocol
-// PUBLIC-NOT: precise:{{.*}}someHiddenVar
 @_show_in_interface
-public protocol _ProtocolShouldntAppear {
-  static var someHiddenVar: String { get }
-}
+public protocol _ProtocolShouldntAppear {}
 
 // PUBLIC-NOT: _ShouldntAppear
 // INTERNAL-DAG: _ShouldntAppear
@@ -49,18 +46,11 @@ public struct _ShouldntAppear: PublicProtocol, _ProtocolShouldntAppear {
   // INTERNAL-DAG: InnerInnerShouldntAppear
   public struct InnerInnerShouldntAppear {}
   }
-
-  // INTERNAL-DAG: someHiddenVar
-  public static var someHiddenVar: String { "someHiddenVar" }
 }
 
 // A public type's relationship to an "internal" protocol
 // shouldn't cause it to be included.
-public struct ShouldAppear {}
-
-extension ShouldAppear: _ProtocolShouldntAppear {
-  public static var someHiddenVar: String { "someHiddenVar" }
-}
+public struct ShouldAppear: _ProtocolShouldntAppear {}
 
 public struct PublicOuter {
   // Nor should an "internal" type's relationship to a "public" protocol.

--- a/test/SymbolGraph/Symbols/UnderscoredProtocols.swift
+++ b/test/SymbolGraph/Symbols/UnderscoredProtocols.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name UnderscoredProtocols -emit-module -emit-module-path %t/
+// RUN: %target-swift-symbolgraph-extract -module-name UnderscoredProtocols -I %t -pretty-print -output-dir %t
+
+// Make sure that underscored protocols do not appear in public symbol graphs, but their
+// requirements do appear on types which conform to them.
+
+// CHECK-NOT: "precise": "s:20UnderscoredProtocols15_HiddenProtocolP",
+// CHECK:     "precise": "s:20UnderscoredProtocols10SomeStructV8someFuncyyF",
+
+public protocol _HiddenProtocol {
+    func someFunc()
+}
+
+public struct SomeStruct {}
+
+extension SomeStruct: _HiddenProtocol {
+    public func someFunc() {}
+}


### PR DESCRIPTION
Reverts apple/swift#59532

**Explanation**: The change introduced by apple/swift#59532 went against the consensus behind underscored protocols: While the protocol itself should be considered internal, the default implementations of that protocol should not. This PR reverts that implementation to return to the consensus implementation for symbol graphs.

**Scope**: Affects symbol graph generation when the "minimum access level" is set to public (the default).

**Bug**: rdar://97074558

**Risk**: Low. The changes are restricted to SymbolGraphGen, and should not affect normal compilation.

**Testing**: A new list test, `SymbolGraph/Symbols/UnderscoredProtocols.swift`, has been added to ensure that the desired behavior is kept.