### PR TITLE
Turn @Sendable completion handlers into an experimental feature. 

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -113,6 +113,10 @@ EXPERIMENTAL_FEATURE(ForwardModeDifferentiation)
 /// conformances.
 EXPERIMENTAL_FEATURE(AdditiveArithmeticDerivedConformances)
 
+/// Whether Objective-C completion handler parameters are imported as
+/// @Sendable.
+EXPERIMENTAL_FEATURE(SendableCompletionHandlers)
+
 #undef EXPERIMENTAL_FEATURE
 #undef FUTURE_FEATURE
 #undef SUPPRESSIBLE_LANGUAGE_FEATURE

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2976,6 +2976,10 @@ static bool usesFeaturePrimaryAssociatedTypes2(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureSendableCompletionHandlers(Decl *decl) {
+  return false;
+}
+
 static void suppressingFeaturePrimaryAssociatedTypes2(PrintOptions &options,
                                          llvm::function_ref<void()> action) {
   bool originalPrintPrimaryAssociatedTypes = options.PrintPrimaryAssociatedTypes;

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2921,6 +2921,9 @@ ImportedType ClangImporter::Implementation::importMethodParamsAndReturnType(
             asyncInfo->completionHandlerErrorParamIndex();
       }
 
+      bool sendableByDefault = paramIsCompletionHandler &&
+        SwiftContext.LangOpts.hasFeature(Feature::SendableCompletionHandlers);
+
       // If this is the throws error parameter, we don't need to convert any
       // NSError** arguments to the sugared NSErrorPointer typealias form,
       // because all that is done with it is retrieving the canonical
@@ -2933,7 +2936,7 @@ ImportedType ClangImporter::Implementation::importMethodParamsAndReturnType(
           importType(paramTy, importKind, paramAddDiag,
                      allowNSUIntegerAsIntInParam, Bridgeability::Full,
                      getImportTypeAttrs(param, /*isParam=*/true,
-                  /*sendableByDefault=*/paramIsCompletionHandler),
+                                        sendableByDefault),
                      optionalityOfParam,
                      /*resugarNSErrorPointer=*/!paramIsError,
                      completionHandlerErrorParamIndex);

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules %s -verify -verify-additional-file %swift_src_root/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h -strict-concurrency=targeted -parse-as-library
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules %s -verify -verify-additional-file %swift_src_root/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h -strict-concurrency=targeted -parse-as-library -enable-experimental-feature SendableCompletionHandlers
 
 // REQUIRES: objc_interop
 // REQUIRES: concurrency

--- a/test/Concurrency/objc_async_overload.swift
+++ b/test/Concurrency/objc_async_overload.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk)  -disable-availability-checking -typecheck -verify -import-objc-header %S/Inputs/Delegate.h %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk)  -disable-availability-checking -typecheck -verify -import-objc-header %S/Inputs/Delegate.h -enable-experimental-feature SendableCompletionHandlers %s
 // REQUIRES: concurrency
 // REQUIRES: objc_interop
 

--- a/test/IDE/print_clang_objc_async.swift
+++ b/test/IDE/print_clang_objc_async.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -print-implicit-attrs -source-filename %s -module-to-print=ObjCConcurrency -function-definitions=false -enable-experimental-concurrency > %t/ObjCConcurrency.printed.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -print-implicit-attrs -source-filename %s -module-to-print=ObjCConcurrency -function-definitions=false -enable-experimental-concurrency -enable-experimental-feature SendableCompletionHandlers > %t/ObjCConcurrency.printed.txt
 // RUN: %FileCheck -input-file %t/ObjCConcurrency.printed.txt %s
 
 // REQUIRES: objc_interop

--- a/test/IDE/print_clang_objc_effectful_properties.swift
+++ b/test/IDE/print_clang_objc_effectful_properties.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -print-implicit-attrs -source-filename %s -module-to-print=EffectfulProperties -function-definitions=false > %t/EffectfulProperties.printed.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -print-implicit-attrs -source-filename %s -module-to-print=EffectfulProperties -function-definitions=false -enable-experimental-feature SendableCompletionHandlers > %t/EffectfulProperties.printed.txt
 // RUN: %FileCheck -input-file %t/EffectfulProperties.printed.txt %s
 
 // REQUIRES: concurrency

--- a/test/IDE/print_objc_concurrency_interface.swift
+++ b/test/IDE/print_objc_concurrency_interface.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -print-interface -source-filename %s -module-to-print=ObjCConcurrency -function-definitions=false > %t/ObjCConcurrency.printed.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -print-interface -source-filename %s -module-to-print=ObjCConcurrency -function-definitions=false -enable-experimental-feature SendableCompletionHandlers > %t/ObjCConcurrency.printed.txt
 // RUN: %FileCheck -input-file %t/ObjCConcurrency.printed.txt %s
 // RUN: %FileCheck -check-prefix NEGATIVE -input-file %t/ObjCConcurrency.printed.txt %s
 

--- a/test/IDE/print_omit_needless_words.swift
+++ b/test/IDE/print_omit_needless_words.swift
@@ -4,25 +4,25 @@
 // FIXME: this is failing on simulators
 // REQUIRES: OS=macosx
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift -disable-objc-attr-requires-foundation-module -enable-experimental-feature SendableCompletionHandlers
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift -enable-experimental-feature SendableCompletionHandlers
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift -enable-experimental-feature SendableCompletionHandlers
 
-// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -print-module -source-filename %s -module-to-print=ObjectiveC -function-definitions=false -prefer-type-repr=true  > %t.ObjectiveC.txt
+// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -print-module -source-filename %s -module-to-print=ObjectiveC -function-definitions=false -prefer-type-repr=true -enable-experimental-feature SendableCompletionHandlers  > %t.ObjectiveC.txt
 // RUN: %FileCheck %s -check-prefix=CHECK-OBJECTIVEC -strict-whitespace < %t.ObjectiveC.txt
 
-// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -print-module -source-filename %s -module-to-print=Foundation -function-definitions=false -prefer-type-repr=true -skip-unavailable -skip-parameter-names > %t.Foundation.txt
+// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -print-module -source-filename %s -module-to-print=Foundation -function-definitions=false -prefer-type-repr=true -skip-unavailable -skip-parameter-names -enable-experimental-feature SendableCompletionHandlers > %t.Foundation.txt
 // RUN: %FileCheck %s -check-prefix=CHECK-FOUNDATION -strict-whitespace < %t.Foundation.txt
 
-// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t -I %S/../ClangImporter/Inputs/custom-modules) -print-module -source-filename %s -module-to-print=CoreCooling -function-definitions=false -prefer-type-repr=true  -skip-parameter-names > %t.CoreCooling.txt
+// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t -I %S/../ClangImporter/Inputs/custom-modules) -print-module -source-filename %s -module-to-print=CoreCooling -function-definitions=false -prefer-type-repr=true  -skip-parameter-names -enable-experimental-feature SendableCompletionHandlers > %t.CoreCooling.txt
 // RUN: %FileCheck %s -check-prefix=CHECK-CORECOOLING -strict-whitespace < %t.CoreCooling.txt
 
-// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t -I %S/Inputs/custom-modules) -print-module -source-filename %s -module-to-print=OmitNeedlessWords -function-definitions=false -prefer-type-repr=true  -skip-parameter-names > %t.OmitNeedlessWords.txt 2> %t.OmitNeedlessWords.diagnostics.txt
+// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t -I %S/Inputs/custom-modules) -print-module -source-filename %s -module-to-print=OmitNeedlessWords -function-definitions=false -prefer-type-repr=true  -skip-parameter-names -enable-experimental-feature SendableCompletionHandlers > %t.OmitNeedlessWords.txt 2> %t.OmitNeedlessWords.diagnostics.txt
 // RUN: %FileCheck %s -check-prefix=CHECK-OMIT-NEEDLESS-WORDS -strict-whitespace < %t.OmitNeedlessWords.txt
 // RUN: %FileCheck %s -check-prefix=CHECK-OMIT-NEEDLESS-WORDS-DIAGS -strict-whitespace < %t.OmitNeedlessWords.diagnostics.txt
 
 
-// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -print-module -source-filename %s -module-to-print=errors -function-definitions=false -prefer-type-repr=true  -skip-parameter-names > %t.errors.txt
+// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -print-module -source-filename %s -module-to-print=errors -function-definitions=false -prefer-type-repr=true  -skip-parameter-names -enable-experimental-feature SendableCompletionHandlers > %t.errors.txt
 // RUN: %FileCheck %s -check-prefix=CHECK-ERRORS -strict-whitespace < %t.errors.txt
 
 // Note: SEL -> "Selector"

--- a/test/SourceKit/DocSupport/doc_objc_concurrency.swift
+++ b/test/SourceKit/DocSupport/doc_objc_concurrency.swift
@@ -3,7 +3,7 @@
 
 // RUN: %empty-directory(%t)
 
-// RUN: %sourcekitd-test -req=doc-info %S/../Inputs/concurrency/gen_concurrency.swift -- -target %target-triple -I %t -Xfrontend -enable-experimental-concurrency | %FileCheck %s --check-prefix=SWIFT-DOC
+// RUN: %sourcekitd-test -req=doc-info %S/../Inputs/concurrency/gen_concurrency.swift -- -target %target-triple -I %t -Xfrontend -enable-experimental-concurrency -enable-experimental-feature SendableCompletionHandlers | %FileCheck %s --check-prefix=SWIFT-DOC
 
 // Never output @available (even if explicitly written by the user).
 
@@ -12,7 +12,7 @@
 // SWIFT-DOC: key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>operation</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String</ref.struct></decl.var.parameter.type></decl.var.parameter>) <syntaxtype.keyword>async</syntaxtype.keyword> -&gt; <decl.function.returntype><ref.struct usr=\"s:Si\">Int</ref.struct></decl.function.returntype></decl.function.method.instance>"
 
 
-// RUN: %sourcekitd-test -req=doc-info -module ConcurrencyHeader -- -Xfrontend -enable-objc-interop -Xfrontend -enable-experimental-concurrency -I %S/../Inputs/concurrency/ -sdk %clang-importer-sdk | %FileCheck %s --check-prefix=OBJC-DOC
+// RUN: %sourcekitd-test -req=doc-info -module ConcurrencyHeader -- -Xfrontend -enable-objc-interop -Xfrontend -enable-experimental-concurrency -I %S/../Inputs/concurrency/ -sdk %clang-importer-sdk -enable-experimental-feature SendableCompletionHandlers | %FileCheck %s --check-prefix=OBJC-DOC
 
 // Especially if the @available was implicitly added to an imported Clang decl
 // (rdar://76685011).

--- a/test/SourceKit/InterfaceGen/gen_objc_concurrency.swift
+++ b/test/SourceKit/InterfaceGen/gen_objc_concurrency.swift
@@ -3,7 +3,7 @@
 
 // RUN: %empty-directory(%t)
 
-// RUN: %sourcekitd-test -req=interface-gen %S/../Inputs/concurrency/gen_concurrency.swift -- %S/../Inputs/concurrency/gen_concurrency.swift -target %target-triple -I %t | %FileCheck %s --check-prefix=SWIFT-GEN-INTERFACE
+// RUN: %sourcekitd-test -req=interface-gen %S/../Inputs/concurrency/gen_concurrency.swift -- %S/../Inputs/concurrency/gen_concurrency.swift -target %target-triple -I %t -enable-experimental-feature SendableCompletionHandlers | %FileCheck %s --check-prefix=SWIFT-GEN-INTERFACE
 
 // Make sure we print @available when it was explicitly written by the user.
 // SWIFT-GEN-INTERFACE-LABEL: class ClassWithAsyncAndHandler {
@@ -14,7 +14,7 @@
 // SWIFT-GEN-INTERFACE:         @MainActor internal func mainActorMethod()
 
 
-// RUN: %sourcekitd-test -req=interface-gen -using-swift-args -header %S/../Inputs/concurrency/header_concurrency.h -- %s -Xfrontend -enable-objc-interop -import-objc-header %S/../Inputs/concurrency/header_concurrency.h -sdk %clang-importer-sdk | %FileCheck %s --check-prefix=OBJC-GEN-INTERFACE
+// RUN: %sourcekitd-test -req=interface-gen -using-swift-args -header %S/../Inputs/concurrency/header_concurrency.h -- %s -Xfrontend -enable-objc-interop -import-objc-header %S/../Inputs/concurrency/header_concurrency.h -sdk %clang-importer-sdk -enable-experimental-feature SendableCompletionHandlers | %FileCheck %s --check-prefix=OBJC-GEN-INTERFACE
 
 // But don't print @available if it was implicitly added to an imported Clang decl (rdar://76685011).
 // OBJC-GEN-INTERFACE-LABEL: class ClassWithHandlerMethod {

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -827,6 +827,11 @@ static llvm::cl::opt<bool> EnableBareSlashRegexLiterals(
     llvm::cl::init(false));
 
 static llvm::cl::list<std::string>
+  EnableExperimentalFeatures("enable-experimental-feature",
+                             llvm::cl::desc("Enable an experimental feature"),
+                             llvm::cl::cat(Category));
+
+static llvm::cl::list<std::string>
 AccessNotesPath("access-notes-path", llvm::cl::desc("Path to access notes file"),
                 llvm::cl::cat(Category));
 
@@ -4319,6 +4324,12 @@ int main(int argc, char *argv[]) {
   if (options::EnableBareSlashRegexLiterals) {
     InitInvok.getLangOptions().Features.insert(Feature::BareSlashRegexLiterals);
     InitInvok.getLangOptions().EnableExperimentalStringProcessing = true;
+  }
+
+  for (const auto &featureArg : options::EnableExperimentalFeatures) {
+    if (auto feature = getExperimentalFeature(featureArg)) {
+      InitInvok.getLangOptions().Features.insert(*feature);
+    }
   }
 
   if (!options::Triple.empty())


### PR DESCRIPTION
`@Sendable` on completion handlers imported from Objective-C has been
implemented for a while, but has been disabled in production builds
due to a number of problems we've encountered with rolling it out.

Introduce an experimental feature for `@Sendable` completion handlers
so we can iterate on this more before we enable it by default.

Part of rdar://85569247, which will cover re-landing this feature.