### PR TITLE
[Serialization] Use a more reliable macro to get the compiler tag

### DIFF
--- a/include/swift/Basic/Version.h
+++ b/include/swift/Basic/Version.h
@@ -191,8 +191,11 @@ StringRef getSwiftRevision();
 
 /// Is the running compiler built with a version tag for distribution?
 /// When true, \c Version::getCurrentCompilerVersion returns a valid version
-/// and \c getSwiftRevision returns the version tuple in string format.
+/// and \c getCurrentCompilerTag returns the version tuple in string format.
 bool isCurrentCompilerTagged();
+
+/// Retrieves the distribtion tag of the running compiler, if any.
+StringRef getCurrentCompilerTag();
 
 } // end namespace version
 } // end namespace swift

--- a/lib/Basic/Version.cpp
+++ b/lib/Basic/Version.cpp
@@ -507,5 +507,13 @@ bool isCurrentCompilerTagged() {
 #endif
 }
 
+StringRef getCurrentCompilerTag() {
+#ifdef SWIFT_COMPILER_VERSION
+  return SWIFT_COMPILER_VERSION;
+#else
+  return StringRef();
+#endif
+}
+
 } // end namespace version
 } // end namespace swift

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -359,7 +359,7 @@ static ValidationInfo validateControlBlock(
       StringRef moduleRevision = blobData;
       if (isCompilerTagged) {
         StringRef compilerRevision = forcedDebugRevision ?
-          forcedDebugRevision : version::getSwiftRevision();
+          forcedDebugRevision : version::getCurrentCompilerTag();
         if (moduleRevision != compilerRevision) {
           result.status = Status::RevisionIncompatible;
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1004,7 +1004,7 @@ void Serializer::writeHeader(const SerializationOptions &options) {
     static const char* forcedDebugRevision =
       ::getenv("SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION");
     auto revision = forcedDebugRevision ?
-      forcedDebugRevision : version::getSwiftRevision();
+      forcedDebugRevision : version::getCurrentCompilerTag();
     Revision.emit(ScratchRecord, revision);
 
     IsOSSA.emit(ScratchRecord, options.IsOSSA);


### PR DESCRIPTION
Use only the `SWIFT_COMPILER_VERSION` macro to check for swiftmodules being written by the same compiler that reads it. In practice, it's the macro used for release builds of the compiler.

rdar://96868333