### PR TITLE
Downgrade "reference to captured var" to warn in preconcurrency code.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2632,10 +2632,15 @@ namespace {
         }
 
         // Otherwise, we have concurrent access. Complain.
+        bool preconcurrencyContext =
+            getActorIsolationOfContext(
+              const_cast<DeclContext *>(getDeclContext())).preconcurrency();
+
         ctx.Diags.diagnose(
             loc, diag::concurrent_access_of_local_capture,
             parent.dyn_cast<LoadExpr *>(),
-            var->getDescriptiveKind(), var->getName());
+            var->getDescriptiveKind(), var->getName())
+          .warnUntilSwiftVersionIf(preconcurrencyContext, 6);
         return true;
       }
 

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -114,7 +114,7 @@ func testSendable(fn: () -> Void) {
 func testSendableInAsync() async {
   var x = 17
   doSomethingConcurrentlyButUnsafe {
-    x = 42 // expected-error{{mutation of captured var 'x' in concurrently-executing code}}
+    x = 42 // expected-warning{{mutation of captured var 'x' in concurrently-executing code}}
   }
   print(x)
 }

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -174,7 +174,7 @@ func testConcurrency() {
 func testUnsafeSendableNothing() {
   var x = 5
   acceptUnsafeSendable {
-    x = 17 // expected-error{{mutation of captured var 'x' in concurrently-executing code}}
+    x = 17 // expected-warning{{mutation of captured var 'x' in concurrently-executing code}}
   }
   print(x)
 }
@@ -182,7 +182,7 @@ func testUnsafeSendableNothing() {
 func testUnsafeSendableInAsync() async {
   var x = 5
   acceptUnsafeSendable {
-    x = 17 // expected-error{{mutation of captured var 'x' in concurrently-executing code}}
+    x = 17 // expected-warning{{mutation of captured var 'x' in concurrently-executing code}}
   }
   print(x)
 }


### PR DESCRIPTION
Fixes rdar://97228088.
