### PR TITLE
[SILOpt] Handle reborrows of owned phis in CanonicalizeOSSALifetime.

### DIFF
--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -1217,6 +1217,14 @@ void findTransitiveReborrowBaseValuePairs(
     BorrowingOperand initialScopeOperand, SILValue origBaseValue,
     function_ref<void(SILPhiArgument *, SILValue)> visitReborrowBaseValuePair);
 
+/// Visit the phis in the same block as \p phi which are reborrows of a borrow
+/// of one of the values reaching \p phi.
+///
+/// If the visitor returns false, stops visiting and returns false.  Otherwise,
+/// returns true.
+bool visitAdjacentReborrowsOfPhi(SILPhiArgument *phi,
+                                 function_ref<bool(SILPhiArgument *)> visitor);
+
 /// Given a begin of a borrow scope, visit all end_borrow users of the borrow or
 /// its reborrows.
 void visitTransitiveEndBorrows(

--- a/include/swift/SIL/SILArgument.h
+++ b/include/swift/SIL/SILArgument.h
@@ -273,6 +273,13 @@ public:
   /// If visitor returns false, iteration is stopped and we return false.
   bool visitIncomingPhiOperands(function_ref<bool(Operand *)> visitor) const;
 
+  /// Visit incoming phi operands and the argument into which they are incoming;
+  /// if an operand's value is itself a phi, visit that phi's operands.
+  ///
+  /// Returns false when called on a non-phi and when the visitor returns false.
+  bool visitTransitiveIncomingPhiOperands(
+      function_ref<bool(SILPhiArgument *, Operand *)> visitor);
+
   /// Returns true if we were able to find a single terminator operand value for
   /// each predecessor of this arguments basic block. The found values are
   /// stored in OutArray.

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -1586,6 +1586,223 @@ void swift::findTransitiveReborrowBaseValuePairs(
   }
 }
 
+/// Visit the phis in the same block as \p phi which are reborrows of a borrow
+/// of one of the values reaching \p phi.
+///
+/// If the visitor returns false, stops visiting and returns false.  Otherwise,
+/// returns true.
+///
+///
+/// When an owned value is passed as a phi argument, it is consumed.  So any
+/// open scope borrowing that owned value must be ended no later than in that
+/// branch instruction.  Either such a borrow scope is ended beforehand
+///     %lifetime = begin_borrow %value
+///     ...
+///     end_borrow %lifetime <-- borrow scope ended here
+///     br block(%value)        <-- before consume
+/// or the borrow scope is ended in the same instruction as the owned value is
+/// consumed
+///     %lifetime = begin_borrow %value
+///     ...
+///     end_borrow %lifetime
+///     br block(%value, %lifetime)         <-- borrow scope ended here
+///                                         <-- in same instruction as consume
+/// In particular, the following is invalid
+///         %lifetime = begin_borrow %value
+///         ...
+///         br block(%value)
+///     block(%value_2 : @owned):
+///         end_borrow %lifetime
+///         destroy_value %value_2
+/// because %lifetime was guaranteed by %value but value is consumed at
+/// `br two`.
+///
+/// Similarly, when a guaranteed value is passed as a phi argument, its borrow
+/// scope ends and a new borrow scope is begun.  And so any open nested borrow
+/// of the original outer borrow must be ended no later than in that branch
+/// instruction.
+///
+///
+/// Given an phi argument
+///     block(..., %value : @owned, ...)
+/// this function finds the adjacent reborrow phis
+///     block(..., %lifetime : @guaranteed, ..., %value : @owned, ...)
+///                ^^^^^^^^^^^^^^^^^^^^^^^
+/// one of whose reaching values is a borrow of a reaching value of %value.
+///
+/// Finding these is more complicated than merely looking for guaranteed
+/// operands adjacent to the incoming operands to phi and which are borrows of
+/// the value consumed there.  The reason is that they might not be borrows of
+/// that incoming value _directly_ but rather reborrows of some other reborrow
+/// if the incoming value is itself a phi argument:
+///         %lifetime = begin_borrow %value
+///         br one(%value, %lifetime)
+///     one(%value_1 : @owned, %lifetime_1 : @guaranteed)
+///         br two(%value_1, %lifetime_1)
+///     two(%value_2 : @owned, %lifetime_2 : @guaranteed)
+///         end_borrow %lifetime_2
+///         destroy_value %value_2
+///
+/// When called with %value_2, \p visitor is invoked with both:
+///     two(%value_2 : @owned, %lifetime_2 : @guaranteed)
+///                            ^^^^^^^^^^^^^^^^^^^^^^^^^
+bool swift::visitAdjacentReborrowsOfPhi(
+    SILPhiArgument *phi, function_ref<bool(SILPhiArgument *)> visitor) {
+  assert(phi->isPhi());
+
+  // First, collect all the values that reach \p phi, that is:
+  // - operands to the phi
+  // - operands to phis which are operands to the phi
+  // - and so forth.
+  SmallPtrSet<SILValue, 8> reachingValues;
+  // At the same time, record all the phis in \p phi's phi web: the phis which
+  // are transitively operands to \p phi.  This is the subset of \p
+  // reachingValues that are phis.
+  SmallVector<SILPhiArgument *, 4> phis;
+  phi->visitTransitiveIncomingPhiOperands(
+      [&](auto *phi, auto *operand) -> bool {
+        phis.push_back(phi);
+        reachingValues.insert(phi);
+        reachingValues.insert(operand->get());
+        return true;
+      });
+
+  // Second, find all the guaranteed phis one of whose operands _could_ (by
+  // dint of being adjacent to a phi in the phi web with the appropriate
+  // ownership and type) be a reborrow of a reaching value of \p phi.
+  SmallVector<SILPhiArgument *, 4> candidates;
+  for (auto *phi : phis) {
+    SILBasicBlock *block = phi->getParentBlock();
+    for (auto *uncastAdjacent : block->getArguments()) {
+      auto *adjacent = cast<SILPhiArgument>(uncastAdjacent);
+      if (adjacent == phi)
+        continue;
+      if (adjacent->getType() != phi->getType())
+        continue;
+      if (adjacent->getOwnershipKind() != OwnershipKind::Guaranteed)
+        continue;
+      candidates.push_back(adjacent);
+    }
+  }
+
+  // Finally, look through \p candidates to find those one of whose incoming
+  // operands either
+  // (1) borrow one of reaching values of \p phi
+  // or (2) is itself a guaranteed phi which does so.
+  // Because we may discover a reborrow R1 of type (1) after visiting another
+  // R2 of type (2) which reborrows R1, we need to iterate to a fixed point.
+  //
+  // Record all the phis that we see which are borrows or reborrows of a
+  // reaching value \p so that we can check for case (2) above.
+  //
+  // Visit those phis which are both reborrows of a reaching value AND are in
+  // the same block as \phi.
+  //
+  // For example, given
+  //
+  //         %lifetime = begin_borrow %value
+  //         br one(%value, %lifetime)
+  //     one(%value_1 : @owned, %lifetime_1 : @guaranteed)
+  //         br two(%value_1, %lifetime_1)
+  //     two(%value_2 : @owned, %lifetime_2 : @guaranteed)
+  //         end_borrow %lifetime_2
+  //         destroy_value %value_2
+  //
+  // when visiting the reborrow phis adjacent to %value_2, The following steps
+  // would be taken:
+  //
+  // (1) Look at the first candidate:
+  //   two(%value_2 : @owned, %lifetime_2 : @guaranteed)
+  //                          ^^^^^^^^^^^^^^^^^^^^^^^^^
+  // but see that its one incoming value
+  //   br two(%value_1, %lifetime_1)
+  //                    ^^^^^^^^^^^
+  // although a phi argument itself, is not known (yet!) to be a reborrow phi.
+  // So the first candidate is NOT (yet!) added to reborrowPhis.
+  //
+  // (2) Look at the second candidate:
+  //     one(%value_1 : @owned, %lifetime_1 : @guaranteed)
+  //                            ^^^^^^^^^^^^^^^^^^^^^^^^^
+  // and see that one of its incoming values
+  //   br one(%value, %lifetime)
+  //                  ^^^^^^^^^
+  // is a borrow
+  //   %lifetime = begin_borrow %value
+  // of %value, one of the values reaching %value_2.
+  // So the second candidate IS added to reborrowPhis.
+  // AND changed is set to true, so we will repeat the outer loop.
+  // But this candidate is not adjacent to our phi %value_2, so it is not
+  // visited.
+  //
+  // (4.5) Changed is true: repeat the outer loop.  Set changed to false.
+  //
+  // (3) Look at the first candidate:
+  //   two(%value_2 : @owned, %lifetime_2 : @guaranteed)
+  //                          ^^^^^^^^^^^^^^^^^^^^^^^^^
+  // and see that one of its incoming values
+  //   br two(%value_1, %lifetime_1)
+  //                    ^^^^^^^^^^^
+  // is itself a phi
+  //   one(%value_1 : @owned, %lifetime_1 : @guaranteed)
+  //                          ^^^^^^^^^^^^^^^^^^^^^^^^^
+  // which was added to reborrowPhis in (2).
+  // So the first candidate IS added to reborrowPhis.
+  // AND changed is set to true.
+  // ALSO, see that the first candidate IS adjacent to our phi %value_2, so our
+  // visitor is invoked with the first candidate.
+  //
+  // (4) Look at the second candidate.
+  // See that it is already a member of reborrowPhis.
+  //
+  // (4.5) Changed is true: repeat the outer loop.  Set changed to false.
+  //
+  // (5) Look at the first candidate.
+  // See that it is already a member of reborrowPhis.
+  //
+  // (6) Look at the second candidate.
+  // See that it is already a member of reborrowPhis.
+  //
+  // (6.5) Changed is false: exit the outer loop.
+  bool changed = false;
+  SmallSetVector<SILPhiArgument *, 4> reborrowPhis;
+  do {
+    changed = false;
+    for (auto *candidate : candidates) {
+      if (reborrowPhis.contains(candidate))
+        continue;
+      auto success = candidate->visitIncomingPhiOperands([&](auto *operand) {
+        // If the value being reborrowed is itself a reborrow of a value
+        // reaching \p phi, then visit it.
+        SILPhiArgument *forwarded;
+        if ((forwarded = dyn_cast<SILPhiArgument>(operand->get()))) {
+          if (!reborrowPhis.contains(forwarded))
+            return true;
+          changed = true;
+          reborrowPhis.insert(candidate);
+          if (candidate->getParentBlock() == phi->getParentBlock())
+            return visitor(candidate);
+          return true;
+        }
+        BeginBorrowInst *bbi;
+        if (!(bbi = dyn_cast<BeginBorrowInst>(operand->get())))
+          return true;
+        auto borrowee = bbi->getOperand();
+        if (!reachingValues.contains(borrowee))
+          return true;
+        changed = true;
+        reborrowPhis.insert(candidate);
+        if (candidate->getParentBlock() == phi->getParentBlock())
+          return visitor(candidate);
+        return true;
+      });
+      if (!success)
+        return false;
+    }
+  } while (changed);
+
+  return true;
+}
+
 void swift::visitTransitiveEndBorrows(
     SILValue value,
     function_ref<void(EndBorrowInst *)> visitEndBorrow) {

--- a/test/SILOptimizer/copy_propagation_canonicalize_with_reborrows.sil
+++ b/test/SILOptimizer/copy_propagation_canonicalize_with_reborrows.sil
@@ -196,3 +196,111 @@ exit:
   destroy_value %value : $FakeOptional<X>
   return %retval : $()
 }
+
+// Ensure that an adjacent reborrow phi being reborrowed doesn't get counted as
+// a non-lifetime ending use and extend liveness beyond the instruction where
+// the reborrow occurs.
+// CHECK-LABEL: sil [ossa] @reborrow_adjacent_to_consume_doesnt_extend_lifetime : {{.*}} {
+// CHECK:       bb1([[REBORROW:%[^,]+]] : @guaranteed $X, [[VALUE:%[^,]+]] :
+// CHECK:       {{bb[0-9]+}}:
+// CHECK:         end_borrow [[REBORROW]]
+// CHECK:         destroy_value [[VALUE]]
+// CHECK-LABEL: } // end sil function 'reborrow_adjacent_to_consume_doesnt_extend_lifetime'
+sil [ossa] @reborrow_adjacent_to_consume_doesnt_extend_lifetime : $@convention(thin) (@owned X) -> () {
+bb0(%0 : @owned $X):
+  %1 = begin_borrow %0 : $X
+  br bb1(%1 : $X, %0 : $X)
+
+bb1(%3 : @guaranteed $X, %4 : @owned $X):
+  cond_br undef, bb2, bb10
+
+bb2:
+  br bb3
+
+bb3:
+  br bb4(%3 : $X, %4 : $X)
+
+bb4(%8 : @guaranteed $X, %9 : @owned $X):
+  cond_br undef, bb5, bb8
+
+bb5:
+  br bb6
+
+bb6:
+  br bb7
+
+bb7:
+  %13 = function_ref @getX : $@convention(thin) () -> @owned X
+  %14 = apply %13() : $@convention(thin) () -> @owned X
+  end_borrow %8 : $X
+  destroy_value %9 : $X
+  %17 = begin_borrow %14 : $X
+  br bb4(%17 : $X, %14 : $X)
+
+bb8:
+  br bb9
+
+bb9:
+  br bb1(%8 : $X, %9 : $X)
+
+bb10:
+  // TODO: Remove the copy once it isn't necessary to trigger canonicalization.
+  %bogus = copy_value %4 : $X
+  destroy_value %bogus : $X
+  %23 = tuple ()
+  end_borrow %3 : $X
+  destroy_value %4 : $X
+  return %23 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @nohoist_destroy_over_endborrow_nonadjacent_reborrow : {{.*}} {
+// CHECK:         end_borrow {{%[^,]+}}
+// CHECK:         destroy_value {{%[^,]+}}
+// CHECK-LABEL: } // end sil function 'nohoist_destroy_over_endborrow_nonadjacent_reborrow'
+sil [ossa] @nohoist_destroy_over_endborrow_nonadjacent_reborrow : $@convention(thin) (@owned X) -> () {
+entry(%value_1 : @owned $X):
+  %lifetime_1 = begin_borrow %value_1 : $X
+  br consume_and_reborrow(%lifetime_1 : $X, %value_1 : $X)
+
+consume_and_reborrow(%lifetime_2 : @guaranteed $X, %value_2 : @owned $X):
+  br reborrow_only(%lifetime_2 : $X)
+
+reborrow_only(%lifetime_3 : @guaranteed $X):
+  br exit
+
+exit:
+  %bogus = copy_value %value_2 : $X
+  destroy_value %bogus : $X
+  %retval = tuple ()
+  end_borrow %lifetime_3 : $X
+  destroy_value %value_2 : $X
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @nohoist_destroy_over_endborrow_nonadjacent_reborrow_2 : {{.*}} {
+// CHECK:         end_borrow {{%[^,]+}}
+// CHECK:         destroy_value {{%[^,]+}}
+// CHECK-LABEL: } // end sil function 'nohoist_destroy_over_endborrow_nonadjacent_reborrow_2'
+sil [ossa] @nohoist_destroy_over_endborrow_nonadjacent_reborrow_2 : $@convention(thin) (@owned X) -> () {
+entry(%value_1 : @owned $X):
+  %lifetime_1 = begin_borrow %value_1 : $X
+  br consume_and_reborrow(%lifetime_1 : $X, %value_1 : $X)
+
+consume_and_reborrow(%lifetime_2 : @guaranteed $X, %value_2 : @owned $X):
+  br reborrow_only_1(%lifetime_2 : $X)
+
+reborrow_only_1(%lifetime_3 : @guaranteed $X):
+  br reborrow_only_2(%lifetime_3 : $X)
+
+reborrow_only_2(%lifetime_4 : @guaranteed $X):
+  br exit
+
+exit:
+  %bogus = copy_value %value_2 : $X
+  destroy_value %bogus : $X
+  %retval = tuple ()
+  end_borrow %lifetime_4 : $X
+  destroy_value %value_2 : $X
+  return %retval : $()
+}
+

--- a/test/SILOptimizer/copy_propagation_canonicalize_with_reborrows.sil
+++ b/test/SILOptimizer/copy_propagation_canonicalize_with_reborrows.sil
@@ -1,0 +1,198 @@
+// RUN: %target-sil-opt -copy-propagation -enable-sil-verify-all %s | %FileCheck %s --check-prefixes=CHECK,CHECK-OPT
+
+class X {}
+
+enum FakeOptional<T> {
+    case some(T)
+    case none
+}
+
+sil [ossa] @getX : $@convention(thin) () -> (@owned X)
+sil [ossa] @holdX : $@convention(thin) (@guaranteed X) -> ()
+
+// CHECK-LABEL: sil [ossa] @nohoist_destroy_over_reborrow_endborrow : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[REBORROW:%[^,]+]] : @guaranteed $X, [[VALUE:%[^,]+]] : @owned $X):
+// CHECK:         end_borrow [[REBORROW]]
+// CHECK:         destroy_value [[VALUE]]
+// CHECK-LABEL: } // end sil function 'nohoist_destroy_over_reborrow_endborrow'
+sil [ossa] @nohoist_destroy_over_reborrow_endborrow : $@convention(thin) () -> () {
+entry:
+  %get = function_ref @getX : $@convention(thin) () -> @owned X
+  %value_1 = apply %get() : $@convention(thin) () -> @owned X
+  %lifetime = begin_borrow %value_1 : $X
+  br body(%lifetime : $X, %value_1 : $X)
+
+body(%reborrow : @guaranteed $X, %value_2 : @owned $X):
+  // TODO: The copy is currently needed to trigger canonicalization of the
+  // lifetime.  Remove once it is no longer needed.
+  %copy = copy_value %value_2 : $X
+  destroy_value %copy : $X
+
+  end_borrow %reborrow : $X
+  destroy_value %value_2 : $X
+  br exit
+
+exit:
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @hoist_destroy_over_unrelated_endborrow : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[UNRELATED:%[^,]+]] : @guaranteed $X, [[VALUE:%[^,]+]] : @owned $X):
+// CHECK:         destroy_value [[VALUE]]
+// CHECK:         end_borrow [[UNRELATED]]
+// CHECK-LABEL: } // end sil function 'hoist_destroy_over_unrelated_endborrow'
+sil [ossa] @hoist_destroy_over_unrelated_endborrow : $@convention(thin) (@guaranteed X) -> () {
+entry(%unrelated : @guaranteed $X):
+  %get = function_ref @getX : $@convention(thin) () -> @owned X
+  %value_1 = apply %get() : $@convention(thin) () -> @owned X
+  %borrow_1 = begin_borrow %unrelated : $X
+  br body(%borrow_1 : $X, %value_1 : $X)
+
+body(%borrow_2 : @guaranteed $X, %value_2 : @owned $X):
+  // TODO: The copy is currently needed to trigger canonicalization of the
+  // lifetime.  Remove once it is no longer needed.
+  %copy = copy_value %value_2 : $X
+  destroy_value %copy : $X
+
+  %hold = function_ref @holdX : $@convention(thin) (@guaranteed X) -> ()
+  apply %hold(%borrow_2) : $@convention(thin) (@guaranteed X) -> ()
+  end_borrow %borrow_2 : $X
+  destroy_value %value_2 : $X
+  br exit
+
+exit:
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @nohoist_destroy_over_reborrow_reborrow_endborrow : {{.*}} {
+// CHECK:       {{bb[0-9]+}}({{%[^,]+}} : @guaranteed $X, {{%[^,]+}} : @owned $X):
+// CHECK:       {{bb[0-9]+}}([[REBORROW:%[^,]+]] : @guaranteed $X, [[VALUE:%[^,]+]] : @owned $X):
+// CHECK:         end_borrow [[REBORROW]]
+// CHECK:         destroy_value [[VALUE]]
+// CHECK-LABEL: } // end sil function 'nohoist_destroy_over_reborrow_reborrow_endborrow'
+sil [ossa] @nohoist_destroy_over_reborrow_reborrow_endborrow : $@convention(thin) () -> () {
+entry:
+  %get = function_ref @getX : $@convention(thin) () -> @owned X
+  %value_1 = apply %get() : $@convention(thin) () -> @owned X
+  %lifetime = begin_borrow %value_1 : $X
+  br body1(%lifetime : $X, %value_1 : $X)
+
+body1(%lifetime_2 : @guaranteed $X, %value_2 : @owned $X):
+  br body2(%lifetime_2 : $X, %value_2 : $X)
+
+body2(%lifetime_3 : @guaranteed $X, %value_3 : @owned $X):
+  // TODO: Remove the copy once it isn't necessary to trigger canonicalization.
+  %copy_3 = copy_value %value_3 : $X
+  destroy_value %copy_3 : $X
+
+  end_borrow %lifetime_3 : $X
+  destroy_value %value_3 : $X
+  br exit
+
+exit:
+  %14 = tuple ()
+  return %14 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @hoist_destroy_over_unrelated_reborrow_reborrow_endborrow : {{.*}} {
+// CHECK:       {{bb[0-9]+}}({{%[^,]+}} : @guaranteed $X, {{%[^,]+}} : @owned $X):
+// CHECK:       {{bb[0-9]+}}([[REBORROW:%[^,]+]] : @guaranteed $X, [[VALUE:%[^,]+]] : @owned $X):
+// CHECK:         destroy_value [[VALUE]]
+// CHECK:         end_borrow [[REBORROW]]
+// CHECK-LABEL: } // end sil function 'hoist_destroy_over_unrelated_reborrow_reborrow_endborrow'
+sil [ossa] @hoist_destroy_over_unrelated_reborrow_reborrow_endborrow : $@convention(thin) (@guaranteed X) -> () {
+entry(%unrelated : @guaranteed $X):
+  %get = function_ref @getX : $@convention(thin) () -> @owned X
+  %value_1 = apply %get() : $@convention(thin) () -> @owned X
+  %borrow_1 = begin_borrow %unrelated : $X
+  br body1(%borrow_1 : $X, %value_1 : $X)
+
+body1(%borrow_2 : @guaranteed $X, %value_2 : @owned $X):
+  br body2(%borrow_2 : $X, %value_2 : $X)
+
+body2(%borrow_3 : @guaranteed $X, %value_3 : @owned $X):
+  // TODO: Remove the copy once it isn't necessary to trigger canonicalization.
+  %copy_3 = copy_value %value_3 : $X
+  destroy_value %copy_3 : $X
+
+  %hold = function_ref @holdX : $@convention(thin) (@guaranteed X) -> ()
+  apply %hold(%borrow_3) : $@convention(thin) (@guaranteed X) -> ()
+  end_borrow %borrow_3 : $X
+  destroy_value %value_3 : $X
+  br exit
+
+exit:
+  %14 = tuple ()
+  return %14 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @nohoist_destroy_over_forward_reborrow_endborrow : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[REBORROW:%[^,]+]] : @guaranteed $X, [[VALUE:%[^,]+]] : @owned $X):
+// CHECK:         end_borrow [[REBORROW]]
+// CHECK:         destroy_value [[VALUE]]
+// CHECK-LABEL: } // end sil function 'nohoist_destroy_over_forward_reborrow_endborrow'
+sil [ossa] @nohoist_destroy_over_forward_reborrow_endborrow : $@convention(thin) () -> () {
+entry:
+  %get = function_ref @getX : $@convention(thin) () -> @owned X
+  %value_1 = apply %get() : $@convention(thin) () -> @owned X
+  br body1(%value_1 : $X)
+
+body1(%value_2 : @owned $X):
+  %lifetime_2 = begin_borrow %value_2 : $X
+  br body2(%lifetime_2 : $X, %value_2 : $X)
+
+body2(%lifetime_3 : @guaranteed $X, %value_3 : @owned $X):
+  // TODO: Remove the copy once it isn't necessary to trigger canonicalization.
+  %copy_3 = copy_value %value_3 : $X
+  destroy_value %copy_3 : $X
+
+  end_borrow %lifetime_3 : $X
+  destroy_value %value_3 : $X
+  br exit
+
+exit:
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @nohoist_destroy_over_reborrow_loop : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[REBORROW:%[^,]+]] : @guaranteed $FakeOptional<X>, [[VALUE:%[^,]+]] : @owned $FakeOptional<X>):
+// CHECK:         cond_br undef, [[LOOP:bb[0-9]+]], [[BODY:bb[0-9]+]]
+// CHECK:       [[LOOP]]:
+// CHECK:         end_borrow [[REBORROW]] : $FakeOptional<X>
+// CHECK:         destroy_value [[VALUE]] : $FakeOptional<X>
+// CHECK:       [[BODY]]:
+// CHECK:         end_borrow [[REBORROW]] : $FakeOptional<X>
+// CHECK:         destroy_value [[VALUE]] : $FakeOptional<X>
+// CHECK-LABEL: } // end sil function 'nohoist_destroy_over_reborrow_loop'
+sil [ossa] @nohoist_destroy_over_reborrow_loop : $@convention(thin) () -> () {
+entry:
+  %none1 = enum $FakeOptional<X>, #FakeOptional.none!enumelt
+  %none2 = enum $FakeOptional<X>, #FakeOptional.none!enumelt
+  br head(%none2 : $FakeOptional<X>, %none1 : $FakeOptional<X>)
+
+head(%reborrow : @guaranteed $FakeOptional<X>, %value : @owned $FakeOptional<X>):
+  cond_br undef, body, exit
+
+body:
+  %get = function_ref @getX : $@convention(thin) () -> (@owned X)
+  %value_0 = apply %get() : $@convention(thin) () -> (@owned X)
+  end_borrow %reborrow : $FakeOptional<X>
+
+  // TODO: Remove the copy once it isn't necessary to trigger canonicalization.
+  %bogus = copy_value %value : $FakeOptional<X>
+  destroy_value %bogus : $FakeOptional<X>
+
+  destroy_value %value : $FakeOptional<X>
+  %some_value_0 = enum $FakeOptional<X>, #FakeOptional.some!enumelt, %value_0 : $X
+  %some_borrow_0 = begin_borrow %some_value_0 : $FakeOptional<X>
+  br head(%some_borrow_0 : $FakeOptional<X>, %some_value_0 : $FakeOptional<X>)
+
+exit:
+  %retval = tuple ()
+  end_borrow %reborrow : $FakeOptional<X>
+  destroy_value %value : $FakeOptional<X>
+  return %retval : $()
+}


### PR DESCRIPTION
When canonicalizing lifetime of an owned phi, update liveness for all reborrows any of whose underlying values are transitively borrows of any of the owned phi's underlying values.

rdar://94346482

