### PR TITLE
[TBDGen] Fix a deserialization crash in TBDGen

### DIFF
--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -479,6 +479,10 @@ void TBDGenVisitor::addConformances(const IterableDeclContext *IDC) {
   for (auto conformance : IDC->getLocalConformances(
                             ConformanceLookupKind::NonInherited)) {
     auto protocol = conformance->getProtocol();
+    if (Opts.PublicSymbolsOnly &&
+        getDeclLinkage(protocol) != FormalLinkage::PublicUnique)
+      continue;
+
     auto needsWTable =
         Lowering::TypeConverter::protocolRequiresWitnessTable(protocol);
     if (!needsWTable)

--- a/test/TBD/rdar93983322.swift
+++ b/test/TBD/rdar93983322.swift
@@ -1,0 +1,45 @@
+// REQUIRES: OS=macosx
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/Frameworks/MyModule.framework/Modules/MyModule.swiftmodule
+// RUN: mkdir -p %t/ProjectInternal/ProjectInternal.framework/Modules/ProjectInternal.swiftmodule
+// RUN: split-file %s %t
+
+// Build the project internal module
+// RUN: %target-swift-frontend %t/ProjectInternal.swift \
+// RUN:   -emit-module -module-name ProjectInternal \
+// RUN:   -o %t/ProjectInternal/ProjectInternal.framework/Modules/ProjectInternal.swiftmodule/%module-target-triple.swiftmodule \
+// RUN:   -disable-experimental-string-processing
+
+// Build MyModule with search path to the project internal module
+// RUN: %target-swift-frontend %t/MyModule.swift \
+// RUN:   -emit-module -module-name MyModule \
+// RUN:   -o %t/Frameworks/MyModule.framework/Modules/MyModule.swiftmodule/%module-target-triple.swiftmodule \
+// RUN:   -Fsystem %t/ProjectInternal -disable-experimental-string-processing
+
+// Remove the project internal module as it's not available to clients of MyModule
+// RUN: rm -rf %t/ProjectInternal
+
+// Use swift-api-extract to load MyModule without ProjectInternal
+// RUN: %target-swift-api-extract -o - -pretty-print \
+// RUN:   -module-name MyModule -Fsystem %t/Frameworks
+
+//--- ProjectInternal.swift
+public class ProjectInternalClass {}
+
+//--- MyModule.swift
+@_implementationOnly import ProjectInternal
+
+public protocol PublicProtocol {}
+
+extension ProjectInternalClass : PublicProtocol {}
+
+internal protocol InternalProtocol {
+  associatedtype T : PublicProtocol
+  static var v : [T] { get }
+}
+
+public class PublicClass {}
+
+extension PublicClass : InternalProtocol {
+  static let v : [ProjectInternalClass] = []
+}

--- a/test/TBD/rdar93983322.swift
+++ b/test/TBD/rdar93983322.swift
@@ -1,27 +1,26 @@
 // REQUIRES: OS=macosx
 // RUN: %empty-directory(%t)
-// RUN: mkdir -p %t/Frameworks/MyModule.framework/Modules/MyModule.swiftmodule
-// RUN: mkdir -p %t/ProjectInternal/ProjectInternal.framework/Modules/ProjectInternal.swiftmodule
+// RUN: mkdir -p %t/Modules
 // RUN: split-file %s %t
 
 // Build the project internal module
 // RUN: %target-swift-frontend %t/ProjectInternal.swift \
 // RUN:   -emit-module -module-name ProjectInternal \
-// RUN:   -o %t/ProjectInternal/ProjectInternal.framework/Modules/ProjectInternal.swiftmodule/%module-target-triple.swiftmodule \
+// RUN:   -o %t/Modules/ProjectInternal.swiftmodule \
 // RUN:   -disable-experimental-string-processing
 
 // Build MyModule with search path to the project internal module
 // RUN: %target-swift-frontend %t/MyModule.swift \
 // RUN:   -emit-module -module-name MyModule \
-// RUN:   -o %t/Frameworks/MyModule.framework/Modules/MyModule.swiftmodule/%module-target-triple.swiftmodule \
-// RUN:   -Fsystem %t/ProjectInternal -disable-experimental-string-processing
+// RUN:   -o %t/Modules/MyModule.swiftmodule \
+// RUN:   -I %t/Modules -disable-experimental-string-processing
 
 // Remove the project internal module as it's not available to clients of MyModule
-// RUN: rm -rf %t/ProjectInternal
+// RUN: rm %t/Modules/ProjectInternal.swiftmodule
 
 // Use swift-api-extract to load MyModule without ProjectInternal
 // RUN: %target-swift-api-extract -o - -pretty-print \
-// RUN:   -module-name MyModule -Fsystem %t/Frameworks
+// RUN:   -module-name MyModule -I %t/Modules
 
 //--- ProjectInternal.swift
 public class ProjectInternalClass {}


### PR DESCRIPTION
Fix a deserialization failure crash in `TBDGenVisitor`, where an
internal protocol conformance with a project internal symbol witness for
an `associatedtype` triggers a crash inside `addConformances` because
the module containing the project internal symbol is not available.

Fixes rdar://93983322