### PR TITLE
SIL Optimizer: check for SILUndef before constructing a ValueSet for a value

### DIFF
--- a/include/swift/SIL/NodeBits.h
+++ b/include/swift/SIL/NodeBits.h
@@ -43,6 +43,7 @@ class NodeBitfield : public SILBitfield<NodeBitfield, SILNode> {
   template <class, class> friend class SILBitfield;
 
   NodeBitfield *insertInto(SILFunction *function) {
+    assert(function && "NodeBitField constructed with a null function");
     NodeBitfield *oldParent = function->newestAliveNodeBitfield;
     function->newestAliveNodeBitfield = this;
     return oldParent;

--- a/lib/SILOptimizer/Analysis/ValueTracking.cpp
+++ b/lib/SILOptimizer/Analysis/ValueTracking.cpp
@@ -38,6 +38,10 @@ bool swift::isExclusiveArgument(SILValue V) {
 /// Returns a found local object. If a local object was not found, returns an
 /// empty SILValue.
 static bool isLocalObject(SILValue Obj) {
+  // Check for SILUndef.
+  if (!Obj->getFunction())
+    return false;
+
   // Set of values to be checked for their locality.
   SmallVector<SILValue, 8> WorkList;
   // Set of processed values.


### PR DESCRIPTION
Fixes a crash, because SILUndef's function is null.

rdar://97199428
