### PR TITLE
[Sema] Mark variables as hole while diagnosing a optional payload

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5703,6 +5703,9 @@ bool ConstraintSystem::repairFailures(
   }
 
   case ConstraintLocator::OptionalPayload: {
+    recordAnyTypeVarAsPotentialHole(lhs);
+    recordAnyTypeVarAsPotentialHole(rhs);
+    
     if (repairViaOptionalUnwrap(*this, lhs, rhs, matchKind, conversionsOrFixes,
                                 locator))
       return true;

--- a/test/Constraints/overload.swift
+++ b/test/Constraints/overload.swift
@@ -257,3 +257,10 @@ func rdar79672230() {
   var t: MyType = MyType()
   test(&t) // expected-error {{no exact matches in call to local function 'test'}}
 }
+
+// https://github.com/apple/swift/issues/60029
+for (key, values) in oldName { // expected-error{{cannot find 'oldName' in scope}}
+  for (idx, value) in values.enumerated() {
+    print(key, idx, value)
+  }
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
In this case compiler was not being able to produce a diagnostic when attempting overloads for `enumerated` with a hole variable `values` coming from an invalid decl ref as base. 
So to fix this, let's mark type variables as potential hole when failing on optional payload to handle such cases.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves https://github.com/apple/swift/issues/60029.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
