### PR TITLE
[5.7][CSSimplify] Don't fix invalid r-value use for misplaced `&`

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4579,8 +4579,18 @@ bool ConstraintSystem::repairFailures(
         if (lhs->isPlaceholder())
           return true;
 
-        conversionsOrFixes.push_back(
-            TreatRValueAsLValue::create(*this, getConstraintLocator(locator)));
+        auto *loc = getConstraintLocator(locator);
+        // If this `inout` is in incorrect position, it should be diagnosed
+        // by other fixes.
+        if (loc->directlyAt<InOutExpr>()) {
+          if (!getArgumentLocator(castToExpr(anchor))) {
+            conversionsOrFixes.push_back(
+                RemoveAddressOf::create(*this, lhs, rhs, loc));
+            return true;
+          }
+        }
+
+        conversionsOrFixes.push_back(TreatRValueAsLValue::create(*this, loc));
         return true;
       }
     }
@@ -4779,10 +4789,14 @@ bool ConstraintSystem::repairFailures(
       if (repairByInsertingExplicitCall(lhs, rhs))
         return true;
 
-      if (isa<InOutExpr>(AE->getSrc())) {
+      if (auto *inoutExpr = dyn_cast<InOutExpr>(AE->getSrc())) {
+        auto *loc = getConstraintLocator(inoutExpr);
+
+        if (hasFixFor(loc, FixKind::RemoveAddressOf))
+          return true;
+
         conversionsOrFixes.push_back(
-            RemoveAddressOf::create(*this, lhs, rhs,
-                                    getConstraintLocator(locator)));
+            RemoveAddressOf::create(*this, lhs, rhs, loc));
         return true;
       }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5510,7 +5510,9 @@ Solution::getFunctionArgApplyInfo(ConstraintLocator *locator) const {
   // to figure out exactly where it was used.
   if (auto *argExpr = getAsExpr<InOutExpr>(locator->getAnchor())) {
     auto *argLoc = getConstraintSystem().getArgumentLocator(argExpr);
-    assert(argLoc && "Incorrect use of `inout` expression");
+    if (!argLoc)
+      return None;
+
     locator = argLoc;
   }
 

--- a/test/Constraints/lvalues.swift
+++ b/test/Constraints/lvalues.swift
@@ -286,3 +286,18 @@ func look_through_parens_when_checking_inout() {
   modifyPoint((&point), 0) // expected-error {{use of extraneous '&}} {{16-17=(}} {{15-16=&}}
   modifyPoint((&point), msg: "") // expected-error {{use of extraneous '&}} {{16-17=(}} {{15-16=&}}
 }
+
+// rdar://96631324 - compiler crash while producing diagnostics
+func test_incorrect_inout_at_assignment_source() {
+  class S {
+    var prop: String = ""
+  }
+
+  func test(s: S) {
+    let str: String = ""
+    let val: Int = 0
+
+    s.prop = &str // expected-error {{use of extraneous '&'}}
+    s.prop = &val // expected-error {{use of extraneous '&'}}
+  }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/60024

---

- Explanation:

When `&` is misplaced it creates r-value -> l-value mismatch
in the code which is just a consequence and shouldn't be diagnosed.

- Scope: Invalid assignments with incorrectly used `&` on the right-hand side.

- Main Branch PR: https://github.com/apple/swift/pull/60024

- Resolves: rdar://96631324

- Risk: Very low

- Reviewed By: @hborla 

- Testing:  Added a regression test-case to the suite.

Resolves: rdar://96631324
(cherry picked from commit ff6112024e24dfb8ada85d7b339ef2d9cd0cad04)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
