### PR TITLE
[5.7][AST] SE-0347: Don't check default expression status in type request

### DIFF
--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1230,10 +1230,7 @@ Optional<Type> DefaultArgumentTypeRequest::getCachedResult() const {
   if (!defaultInfo)
     return None;
 
-  if (!defaultInfo->InitContextAndIsTypeChecked.getInt())
-    return None;
-
-  return defaultInfo->ExprType;
+  return defaultInfo->ExprType ? defaultInfo->ExprType : Optional<Type>();
 }
 
 void DefaultArgumentTypeRequest::cacheResult(Type type) const {

--- a/test/Constraints/type_inference_from_default_exprs.swift
+++ b/test/Constraints/type_inference_from_default_exprs.swift
@@ -1,6 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend-emit-module -emit-module-path %t/InferViaDefaults.swiftmodule -module-name InferViaDefaults %S/Inputs/type_inference_via_defaults_other_module.swift
-// RUN: %target-swift-frontend -module-name main -typecheck -verify -I %t %s %S/Inputs/type_inference_via_defaults_other_module.swift
+// RUN: %target-build-swift -parse-as-library -emit-library -emit-module-path %t/InferViaDefaults.swiftmodule -module-name InferViaDefaults %S/Inputs/type_inference_via_defaults_other_module.swift -o %t/%target-library-name(InferViaDefaults)
+// RUN: %target-swift-frontend -typecheck -verify -lInferViaDefaults -module-name main -I %t -L %t %s
+
+import InferViaDefaults
 
 func testInferFromResult<T>(_: T = 42) -> T { fatalError() } // Ok
 
@@ -136,8 +138,8 @@ func main() {
   testMultiple(a: 0.0, b: "a")  // Ok
 
   // From a different module
-  with_defaults() // Ok
-  with_defaults("") // Ok
+  InferViaDefaults.with_defaults() // Ok
+  InferViaDefaults.with_defaults("") // Ok
 
   _ = S()[] // Ok
   _ = S()[B()] // Ok


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/60109

---

- Explanation:

Fixes a bug in "inference from defaults" feature implementation.
 
Information about whether or not default expression is type-checked
is not going to be available for deserialized declaration and it's
not necessary for type requests anyway.

- Scope: Declarations in frameworks with default argument expressions that could be used to infer types at a call site.

- Main Branch PR: https://github.com/apple/swift/pull/60109

- Resolves: rdar://95990526

- Risk: Very low

- Reviewed By: @hborla 

- Testing:  Added a regression test-case to the suite.

Resolves: rdar://95990526

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
