### PR TITLE
Add CustomDebugDescription conformance to AnyKeyPath

### DIFF
--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -649,6 +649,11 @@ ManglingErrorOr<const char *> mangleNodeAsObjcCString(NodePointer node,
 std::string nodeToString(NodePointer Root,
                          const DemangleOptions &Options = DemangleOptions());
 
+/// Transforms a mangled key path accessor thunk helper
+/// into the identfier/subscript that would be used to invoke it in swift code.
+std::string keyPathSourceString(const char *MangledName,
+                                size_t MangledNameLength);
+
 /// A class for printing to a std::string.
 class DemanglerPrinter {
 public:

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -3255,7 +3255,7 @@ std::string Demangle::keyPathSourceString(const char *MangledName,
       case Node::Kind::Subscript: {
         std::string subscriptText = "subscript(";
         std::vector<std::string> argumentTypeNames;
-        // Multiple arguments case
+        // Multiple arguments case
         NodePointer argList = matchSequenceOfKinds(
             child, {
                        std::make_pair(Node::Kind::Type, 2),

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -14,13 +14,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "swift/AST/Ownership.h"
 #include "swift/Basic/STLExtras.h"
 #include "swift/Demangling/Demangle.h"
-#include "swift/AST/Ownership.h"
 #include "swift/Strings.h"
 #include <cassert>
 #include <cstdio>
 #include <cstdlib>
+#include <vector>
 
 using namespace swift;
 using namespace Demangle;
@@ -3209,6 +3210,146 @@ void NodePrinter::printEntityType(NodePointer Entity, NodePointer type,
   } else {
     print(type, depth + 1);
   }
+}
+
+NodePointer
+matchSequenceOfKinds(NodePointer start,
+                     std::vector<std::tuple<Node::Kind, size_t>> pattern) {
+  if (start != nullptr) {
+    NodePointer current = start;
+    size_t idx = 0;
+    while (idx < pattern.size()) {
+      std::tuple<Node::Kind, size_t> next = pattern[idx];
+      idx += 1;
+      NodePointer nextChild = current->getChild(std::get<1>(next));
+      if (nextChild != nullptr && nextChild->getKind() == std::get<0>(next)) {
+        current = nextChild;
+      } else {
+        return nullptr;
+      }
+    }
+    if (idx == pattern.size()) {
+      return current;
+    } else {
+      return nullptr;
+    }
+  } else {
+    return nullptr;
+  }
+}
+
+std::string Demangle::keyPathSourceString(const char *MangledName,
+                                          size_t MangledNameLength) {
+  std::string invalid = "";
+  std::string unlabelledArg = "_: ";
+  Context ctx;
+  NodePointer root =
+      ctx.demangleSymbolAsNode(StringRef(MangledName, MangledNameLength));
+  if (!root)
+    return invalid;
+  if (root->getNumChildren() >= 1) {
+    NodePointer firstChild = root->getChild(0);
+    if (firstChild->getKind() == Node::Kind::KeyPathGetterThunkHelper) {
+      NodePointer child = firstChild->getChild(0);
+      switch (child->getKind()) {
+      case Node::Kind::Subscript: {
+        std::string subscriptText = "subscript(";
+        std::vector<std::string> argumentTypeNames;
+        // Multiple arguments case
+        NodePointer argList = matchSequenceOfKinds(
+            child, {
+                       std::make_pair(Node::Kind::Type, 2),
+                       std::make_pair(Node::Kind::FunctionType, 0),
+                       std::make_pair(Node::Kind::ArgumentTuple, 0),
+                       std::make_pair(Node::Kind::Type, 0),
+                       std::make_pair(Node::Kind::Tuple, 0),
+                   });
+        if (argList != nullptr) {
+          size_t numArgumentTypes = argList->getNumChildren();
+          size_t idx = 0;
+          while (idx < numArgumentTypes) {
+            NodePointer argumentType = argList->getChild(idx);
+            idx += 1;
+            if (argumentType->getKind() == Node::Kind::TupleElement) {
+              argumentType =
+                  argumentType->getChild(0)->getChild(0)->getChild(1);
+              if (argumentType->getKind() == Node::Kind::Identifier) {
+                argumentTypeNames.push_back(
+                    std::string(argumentType->getText()));
+                continue;
+              }
+            }
+            argumentTypeNames.push_back("<Unknown>");
+          }
+        } else {
+          // Case where there is a single argument
+          argList = matchSequenceOfKinds(
+              child, {
+                         std::make_pair(Node::Kind::Type, 2),
+                         std::make_pair(Node::Kind::FunctionType, 0),
+                         std::make_pair(Node::Kind::ArgumentTuple, 0),
+                         std::make_pair(Node::Kind::Type, 0),
+                     });
+          if (argList != nullptr) {
+            argumentTypeNames.push_back(
+                std::string(argList->getChild(0)->getChild(1)->getText()));
+          }
+        }
+        child = child->getChild(1);
+        size_t idx = 0;
+        // There is an argument label:
+        if (child != nullptr) {
+          if (child->getKind() == Node::Kind::LabelList) {
+            size_t numChildren = child->getNumChildren();
+            if (numChildren == 0) {
+              subscriptText += unlabelledArg + argumentTypeNames[0];
+            } else {
+              while (idx < numChildren) {
+                Node *argChild = child->getChild(idx);
+                idx += 1;
+                if (argChild->getKind() == Node::Kind::Identifier) {
+                  subscriptText += std::string(argChild->getText()) + ": " +
+                                   argumentTypeNames[idx - 1];
+                  if (idx != numChildren) {
+                    subscriptText += ", ";
+                  }
+                } else if (argChild->getKind() ==
+                               Node::Kind::FirstElementMarker ||
+                           argChild->getKind() == Node::Kind::VariadicMarker) {
+                  subscriptText += unlabelledArg + argumentTypeNames[idx - 1];
+                }
+              }
+            }
+          }
+        } else {
+          subscriptText += unlabelledArg + argumentTypeNames[0];
+        }
+        return subscriptText + ")";
+      }
+      case Node::Kind::Variable: {
+        child = child->getChild(1);
+        if (child == nullptr) {
+          return invalid;
+        }
+        if (child->getKind() == Node::Kind::PrivateDeclName) {
+          child = child->getChild(1);
+          if (child == nullptr) {
+            return invalid;
+          }
+          if (child->getKind() == Node::Kind::Identifier) {
+            return std::string(child->getText());
+          }
+        } else if (child->getKind() == Node::Kind::Identifier) {
+          return std::string(child->getText());
+        }
+        break;
+      }
+      default:
+        return invalid;
+      }
+    }
+  }
+  return invalid;
 }
 
 std::string Demangle::nodeToString(NodePointer root,

--- a/stdlib/public/runtime/ReflectionMirror.cpp
+++ b/stdlib/public/runtime/ReflectionMirror.cpp
@@ -1118,6 +1118,17 @@ const char *swift_OpaqueSummary(const Metadata *T) {
   }
 }
 
+#include <dlfcn.h>
+
+SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
+const char *swift_keypath_dladdr(void *address) {
+    Dl_info dlinfo;
+    if (dladdr(address, &dlinfo) == 0) {
+      return 0;
+    }
+    return dlinfo.dli_sname;
+}
+
 #if SWIFT_OBJC_INTEROP
 // func _getQuickLookObject<T>(_: T) -> AnyObject?
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API

--- a/stdlib/public/runtime/ReflectionMirror.cpp
+++ b/stdlib/public/runtime/ReflectionMirror.cpp
@@ -12,20 +12,21 @@
 
 #ifdef SWIFT_ENABLE_REFLECTION
 
-#include "swift/Basic/Lazy.h"
-#include "swift/Runtime/Reflection.h"
-#include "swift/Runtime/Casting.h"
-#include "swift/Runtime/Config.h"
-#include "swift/Runtime/HeapObject.h"
-#include "swift/Runtime/Metadata.h"
-#include "swift/Runtime/Enum.h"
-#include "swift/Basic/Unreachable.h"
-#include "swift/Demangling/Demangle.h"
-#include "swift/Runtime/Debug.h"
-#include "swift/Runtime/Portability.h"
+#include "../SwiftShims/Reflection.h"
+#include "ImageInspection.h"
 #include "Private.h"
 #include "WeakReference.h"
-#include "../SwiftShims/Reflection.h"
+#include "swift/Basic/Lazy.h"
+#include "swift/Basic/Unreachable.h"
+#include "swift/Demangling/Demangle.h"
+#include "swift/Runtime/Casting.h"
+#include "swift/Runtime/Config.h"
+#include "swift/Runtime/Debug.h"
+#include "swift/Runtime/Enum.h"
+#include "swift/Runtime/HeapObject.h"
+#include "swift/Runtime/Metadata.h"
+#include "swift/Runtime/Portability.h"
+#include "swift/Runtime/Reflection.h"
 #include <cassert>
 #include <cinttypes>
 #include <cstdio>
@@ -1118,17 +1119,6 @@ const char *swift_OpaqueSummary(const Metadata *T) {
   }
 }
 
-#include <dlfcn.h>
-
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
-const char *swift_keypath_dladdr(void *address) {
-    Dl_info dlinfo;
-    if (dladdr(address, &dlinfo) == 0) {
-      return 0;
-    }
-    return dlinfo.dli_sname;
-}
-
 #if SWIFT_OBJC_INTEROP
 // func _getQuickLookObject<T>(_: T) -> AnyObject?
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
@@ -1136,5 +1126,27 @@ id swift_reflectionMirror_quickLookObject(OpaqueValue *value, const Metadata *T)
   return call(value, T, nullptr, [](ReflectionMirrorImpl *impl) { return impl->quickLookObject(); });
 }
 #endif
+
+SWIFT_CC(swift)
+SWIFT_RUNTIME_STDLIB_INTERNAL const char *swift_keyPath_dladdr(void *address) {
+  SymbolInfo info;
+  if (lookupSymbol(address, &info) == 0) {
+    return 0;
+  } else {
+    return info.symbolName.get();
+  }
+}
+
+SWIFT_CC(swift)
+SWIFT_RUNTIME_STDLIB_INTERNAL const
+    char *swift_keyPathSourceString(char *name) {
+  size_t length = strlen(name);
+  std::string mangledName = keyPathSourceString(name, length);
+  if (mangledName == "") {
+    return 0;
+  } else {
+    return strdup(mangledName.c_str());
+  }
+}
 
 #endif  // SWIFT_ENABLE_REFLECTION

--- a/test/Interpreter/keypath.swift
+++ b/test/Interpreter/keypath.swift
@@ -6,7 +6,37 @@ class MyLabel {
 }
 
 class Controller {
+  
   fileprivate let label = MyLabel()
+  fileprivate var secondLabel: MyLabel? = MyLabel()
+  public var thirdLabel: MyLabel? = MyLabel()
+  
+  subscript(string: String) -> String {
+    get {
+      ""
+    }
+    set {
+      
+    }
+  }
+  
+  subscript(int int: Int, str str: String, otherInt: Int) -> Int {
+    get {
+      0
+    }
+    set {
+      
+    }
+  }
+  
+  subscript() -> Int {
+    0
+  }
+  
+}
+
+struct S {
+  var a: Int
 }
 
 struct Container<V> {
@@ -43,6 +73,20 @@ public func generic_class_constrained_keypath<U, V>(_ c: V) where V : GenericCon
   print(c[keyPath: kp].text)
 }
 
-// CHECK: Swift.KeyPath<main.GenericController<Swift.Int>, main.MyLabel>
+// CHECK: GenericController<Int>.label
 // CHECK: label
 generic_class_constrained_keypath(GenericController(5))
+
+// CHECK: {{\\Controller\.secondLabel!\.text|\\Controller\.<computed 0x.* \(Optional<MyLabel>\)>!\.<computed 0x.* \(String\)>}}
+print(\Controller.secondLabel!.text)
+
+// CHECK: {{\\Controller\.subscript\(_: String\)|\\Controller\.<computed 0x.* \(String\)>}}
+print(\Controller["abc"])
+// CHECK: \S.a
+print(\S.a)
+// CHECK: {{\\Controller\.subscript\(int: Int, str: String, _: Int\)|\\Controller\.<computed 0x.* \(Int\)>}}
+print(\Controller[int: 0, str: "", 0])
+// CHECK: {{\\Controller\.thirdLabel|\\Controller\.<computed 0x.* \(Optional<MyLabel>\)>}}
+print(\Controller.thirdLabel)
+// CHECK: {{\\Controller\.subscript\(\)|\\Controller\.<computed 0x.* \(Int\)>}}
+print(\Controller.[])

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -57,6 +57,11 @@ Func MutableCollection.moveSubranges(_:to:) has been removed
 Func MutableCollection.removeSubranges(_:) has been removed
 Func RangeReplaceableCollection.removeSubranges(_:) has been removed
 Struct AnyHashable has added a conformance to an existing protocol _HasCustomAnyHashableRepresentation
+Class AnyKeyPath has added a conformance to an existing protocol CustomDebugStringConvertible
+Class KeyPath has added a conformance to an existing protocol CustomDebugStringConvertible
+Class PartialKeyPath has added a conformance to an existing protocol CustomDebugStringConvertible
+Class ReferenceWritableKeyPath has added a conformance to an existing protocol CustomDebugStringConvertible
+Class WritableKeyPath has added a conformance to an existing protocol CustomDebugStringConvertible
 Struct DiscontiguousSlice has been removed
 Struct RangeSet has been removed
 Subscript Collection.subscript(_:) has been removed

--- a/test/stdlib/symbol-visibility-linux.test-sh
+++ b/test/stdlib/symbol-visibility-linux.test-sh
@@ -35,6 +35,8 @@
 // RUN:             -e  _ZNKSt8functionIFNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEmmEEclEmm \
 // RUN:             -e  _ZSt9call_onceIRFvPvEJDnEEvRSt9once_flagOT_DpOT0_ \
 // RUN:             -e _ZNKSt8functionIFSsmmEEclEmm \
+// RUN:             -e _ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE17_M_realloc_insertIJS5_EEEvN9__gnu_cxx17__normal_iteratorIPS5_S7_EEDpOT_ \
+// RUN:             -e _ZStplIcSt11char_traitsIcESaIcEENSt7__cxx1112basic_stringIT_T0_T1_EERKS8_SA_ \
 // RUN:   > %t/swiftCore-all.txt
 // RUN: %llvm-nm --defined-only --extern-only --no-weak %platform-dylib-dir/%target-library-name(swiftCore) > %t/swiftCore-no-weak.txt
 // RUN: diff -u %t/swiftCore-all.txt %t/swiftCore-no-weak.txt
@@ -62,6 +64,8 @@
 // RUN:             -e  _ZNKSt8functionIFNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEmmEEclEmm \
 // RUN:             -e  _ZSt9call_onceIRFvPvEJDnEEvRSt9once_flagOT_DpOT0_ \
 // RUN:             -e _ZNKSt8functionIFSsmmEEclEmm \
+// RUN:             -e _ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE17_M_realloc_insertIJS5_EEEvN9__gnu_cxx17__normal_iteratorIPS5_S7_EEDpOT_ \
+// RUN:             -e _ZStplIcSt11char_traitsIcESaIcEENSt7__cxx1112basic_stringIT_T0_T1_EERKS8_SA_ \
 // RUN:   > %t/swiftRemoteMirror-all.txt
 // RUN: %llvm-nm --defined-only --extern-only --no-weak %platform-dylib-dir/%target-library-name(swiftRemoteMirror) > %t/swiftRemoteMirror-no-weak.txt
 // RUN: diff -u %t/swiftRemoteMirror-all.txt %t/swiftRemoteMirror-no-weak.txt


### PR DESCRIPTION
Implementation of [this pitch](https://forums.swift.org/t/pitch-add-customdebugdescription-conformance-to-anykeypath/58705), adds a conformance to `CustomDebugDescription` to `AnyKeyPath`. This will need an SE before it's merged. 

I haven't modified api-digester yet, which I think I need to do...? I intended to see what the CI says first. 