### PR TITLE
[5.7][CSSimplify] Allow referencing typealias declarations via leading-dot…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -7407,6 +7407,12 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
       }
     }
 
+    if (loc->isLastElement<LocatorPathElt::MemberRefBase>()) {
+      auto *fix = ContextualMismatch::create(*this, protocolTy, type, loc);
+      if (!recordFix(fix))
+        return SolutionKind::Solved;
+    }
+
     // If this is an implicit Hashable conformance check generated for each
     // index argument of the keypath subscript component, we could just treat
     // it as though it conforms.
@@ -9788,7 +9794,7 @@ ConstraintSystem::simplifyUnresolvedMemberChainBaseConstraint(
       return SolutionKind::Solved;
 
     auto *memberRef = findResolvedMemberRef(memberLoc);
-    if (memberRef && memberRef->isStatic()) {
+    if (memberRef && (memberRef->isStatic() || isa<TypeAliasDecl>(memberRef))) {
       return simplifyConformsToConstraint(
           resultTy, baseTy, ConstraintKind::ConformsTo,
           getConstraintLocator(memberLoc, ConstraintLocator::MemberRefBase),


### PR DESCRIPTION
… syntax in generic context

Cherry-pick of https://github.com/apple/swift/pull/60080

---

- Explanation:

Previously only static methods found on protocols were allowed but
it is reasonable to reference a typealias to perform an implicit call
to `.init` on its underlying type.

- Scope: Using leading-dot syntax in generic context  in combination with typealiases.

- Main Branch PR: https://github.com/apple/swift/pull/60080

- Resolves: rdar://88513939

- Risk: Very low

- Reviewed By: @hborla 

- Testing:  Added a regression test-case to the suite.

Resolves: rdar://88513939
(cherry picked from commit 12776182f0e2cd7ef870849ccdefcb39c2cad61a)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
