### PR TITLE
[CSApply] Use fully qualified locator while coercing member chain result

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3466,7 +3466,10 @@ namespace {
       // type.
       auto *subExpr = expr->getSubExpr();
       auto type = simplifyType(cs.getType(expr));
-      subExpr = coerceToType(subExpr, type, cs.getConstraintLocator(subExpr));
+      subExpr = coerceToType(
+          subExpr, type,
+          cs.getConstraintLocator(
+              expr, ConstraintLocator::UnresolvedMemberChainResult));
       cs.setType(subExpr, type);
       return subExpr;
     }

--- a/test/Constraints/implicit_double_cgfloat_conversion.swift
+++ b/test/Constraints/implicit_double_cgfloat_conversion.swift
@@ -262,3 +262,21 @@ func assignments_with_and_without_optionals() {
     copy.prop = (true ? cgf : (false ? v : cgf))
   }
 }
+
+extension CGFloat {
+  static let `default` = 42.0
+}
+
+// rdar://97261826 - crash during constraint application with leading-dot syntax
+func assignment_with_leading_dot_syntax() {
+  class Container {
+    var prop: CGFloat = 0
+  }
+
+  struct Test {
+    let test: Void = {
+      let c = Container()
+      c.prop = .default // Ok (Double -> CGFloat)
+    }()
+  }
+}


### PR DESCRIPTION
Constraint generator records conversion between chain result expression
and contextual type as anchored on an implicit unresolved chain result,
which means that coercion has to do the same in case restrictions
(like Double<->CGFloat conversion) depend on locators to retrieve
information for the solution.

Resolves: rdar://97261826

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
