### PR TITLE
RequirementMachine: Fix a request cycle [5.7]

### DIFF
--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -987,7 +987,12 @@ TypeAliasRequirementsRequest::evaluate(Evaluator &evaluator,
         // to the associated type would have to be conditional, which we cannot
         // model.
         if (auto ext = dyn_cast<ExtensionDecl>(type->getDeclContext())) {
-          if (ext->isConstrainedExtension()) continue;
+          // FIXME: isConstrainedExtension() can cause request cycles because it
+          // computes a generic signature. getTrailingWhereClause() should be good
+          // enough for protocol extensions, which cannot specify constraints in
+          // any other way right now (eg, via requirement inference or by
+          // extending a bound generic type).
+          if (ext->getTrailingWhereClause()) continue;
         }
 
         // We found something.

--- a/test/Generics/protocol_typealias_cycle_6.swift
+++ b/test/Generics/protocol_typealias_cycle_6.swift
@@ -1,0 +1,12 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P {
+  associatedtype A
+  associatedtype B
+}
+
+protocol Q: P {}
+
+extension Q where A == Int {
+  typealias B = Int
+}


### PR DESCRIPTION
    RequirementSignatureRequest
    => TypeAliasRequirementsRequest
       => isConstrainedExtension()
          => GenericSignatureRequest
             => RequirementSignatureRequest

Instead, use getTrailingWhereClause() as an approximation of
isConstrainedExtension().

Fixes rdar://problem/97236936.
