### PR TITLE
ASTMangler: Don't consider @_originallyDefinedIn when mangling local type discriminators [5.7]

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -822,6 +822,11 @@ std::string ASTMangler::mangleLocalTypeDecl(const TypeDecl *type) {
   AllowNamelessEntities = true;
   OptimizeProtocolNames = false;
 
+  // Local types are not ABI anyway. To avoid problems with the ASTDemangler,
+  // don't respect @_originallyDefinedIn here, since we don't respect it
+  // when mangling DWARF types for debug info.
+  RespectOriginallyDefinedIn = false;
+
   if (auto GTD = dyn_cast<GenericTypeDecl>(type)) {
     appendAnyGenericType(GTD);
   } else {

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 696; // `distributed thunk` bit on `AbstractFunctionDecl`
+const uint16_t SWIFTMODULE_VERSION_MINOR = 697; // change local type mangling
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/test/DebugInfo/Inputs/local_type_originally_defined_in_other.swift
+++ b/test/DebugInfo/Inputs/local_type_originally_defined_in_other.swift
@@ -1,0 +1,2 @@
+@available(macOS 10, *)
+@_originallyDefinedIn(module: "Barn", macOS 10.1) public struct Horse {}

--- a/test/DebugInfo/local_type_originally_defined_in.swift
+++ b/test/DebugInfo/local_type_originally_defined_in.swift
@@ -1,0 +1,16 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/local_type_originally_defined_in_other.swiftmodule %S/Inputs/local_type_originally_defined_in_other.swift
+// RUN: %target-swift-frontend -I%t -g -emit-ir %s
+
+import local_type_originally_defined_in_other
+
+public func localTypeAliasTest(horse: Horse) {
+  // The local type mangling for 'A' mentions 'Horse', which must
+  // be mangled using it's current module name, and not the
+  // original module name, for consistency with the debug info
+  // mangling.
+  typealias A = Int
+
+  let info = UnsafeMutablePointer<A>.allocate(capacity: 1)
+  _ = info
+}


### PR DESCRIPTION
Local types are not ABI, and the only time we care about the mangling here is
when we look them up using the DWARF mangling in debug info, which doesn't
respect @_originallyDefinedIn either.

Fixes https://github.com/apple/swift/issues/59773.