### PR TITLE
Sema: Don't allow opaque return types to reference DynamicSelfType [5.7]

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4244,6 +4244,9 @@ NOTE(opaque_type_underlying_type_candidate_here,none,
 ERROR(opaque_type_self_referential_underlying_type,none,
       "function opaque return type was inferred as %0, which defines the "
       "opaque type in terms of itself", (Type))
+ERROR(opaque_type_cannot_contain_dynamic_self,none,
+      "function with opaque return type cannot return "
+      "the covariant 'Self' type of a class", ())
 ERROR(opaque_type_var_no_init,none,
       "property declares an opaque return type, but has no initializer "
       "expression from which to infer an underlying type", ())

--- a/test/type/opaque_return_dynamic_self.swift
+++ b/test/type/opaque_return_dynamic_self.swift
@@ -1,0 +1,36 @@
+// RUN: %target-typecheck-verify-swift -disable-availability-checking
+
+protocol P {
+  init()
+}
+
+extension P {
+  static func opaqueProtocolExtensionFunc() -> some P { return Self() }
+}
+
+class C: P {
+  required init() {}
+
+  static func opaqueFunc1() -> some P {
+    return Self()
+    // expected-error@-1 {{function with opaque return type cannot return the covariant 'Self' type of a class}}
+  }
+
+  static func opaqueFunc2() -> some P {
+    return Self.opaqueProtocolExtensionFunc()
+    // expected-error@-1 {{function with opaque return type cannot return the covariant 'Self' type of a class}}
+  }
+
+  var opaqueProperty: some P {
+    return Self()
+    // expected-error@-1 {{function with opaque return type cannot return the covariant 'Self' type of a class}}
+  }
+
+  subscript() -> some P {
+    return Self()
+    // expected-error@-1 {{function with opaque return type cannot return the covariant 'Self' type of a class}}
+  }
+
+  var opaqueStoredProperty: some P = Self()
+  // expected-error@-1 {{covariant 'Self' type cannot be referenced from a stored property initializer}}
+}


### PR DESCRIPTION
This cannot be represented in the ABI because we expect that the
opaque return type can be instantiated from the generic arguments
of its declaring context. Reconstructing type metadata for the
DynamicSelfType would require opaque return type instantiation
to also take the self *value*.

Fixes #56367 / rdar://72407668