### PR TITLE
[Sema] Don't early exit without looking at conformances in ApplyClassifier

### DIFF
--- a/test/Concurrency/sr15049.swift
+++ b/test/Concurrency/sr15049.swift
@@ -1,43 +1,45 @@
 // RUN: %target-typecheck-verify-swift -disable-availability-checking -strict-concurrency=targeted
 // REQUIRES: concurrency
 
+// FIXME: Those cases should compile, but currently ApplyClassifier doesn't handle throws/no-throws properly.
+
 func testAsyncSequenceTypedPatternSendable<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int, Seq: Sendable {
-   async let result: Int = seq.reduce(0) { $0 + $1 } // OK
+   async let result: Int = seq.reduce(0) { $0 + $1 } // expected-error{{call can throw, but it is executed in a non-throwing autoclosure}} expected-note{{call is to 'rethrows' function, but a conformance has a throwing witness}}
    // expected-warning@-1{{immutable value 'result' was never used; consider replacing with '_' or removing it}}
 }
 
 func testAsyncSequenceTypedPattern1Sendable<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int, Seq: Sendable {
-   async let _: Int = seq.reduce(0) { $0 + $1 } // OK
+   async let _: Int = seq.reduce(0) { $0 + $1 } // expected-error{{call can throw, but it is executed in a non-throwing autoclosure}} expected-note{{call is to 'rethrows' function, but a conformance has a throwing witness}}
 }
 
 func testAsyncSequenceSendable<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int, Seq: Sendable {
-   async let result = seq.reduce(0) { $0 + $1 } // OK
+   async let result = seq.reduce(0) { $0 + $1 } // expected-error{{call can throw, but it is executed in a non-throwing autoclosure}} expected-note{{call is to 'rethrows' function, but a conformance has a throwing witness}}
    // expected-warning@-1{{initialization of immutable value 'result' was never used; consider replacing with assignment to '_' or removing it}}
 }
 
 func testAsyncSequence1Sendable<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int, Seq: Sendable {
-   async let _ = seq.reduce(0) { $0 + $1 } // OK
+   async let _ = seq.reduce(0) { $0 + $1 } // expected-error{{call can throw, but it is executed in a non-throwing autoclosure}} expected-note{{call is to 'rethrows' function, but a conformance has a throwing witness}}
 }
 
 func testAsyncSequenceTypedPattern<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int { // expected-note{{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{54-54=, Sendable}}
-   async let result: Int = seq.reduce(0) { $0 + $1 } // OK
+   async let result: Int = seq.reduce(0) { $0 + $1 } // expected-error{{call can throw, but it is executed in a non-throwing autoclosure}} expected-note{{call is to 'rethrows' function, but a conformance has a throwing witness}}
    // expected-warning@-1{{immutable value 'result' was never used; consider replacing with '_' or removing it}}
    // expected-warning@-2{{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
 }
 
 func testAsyncSequenceTypedPattern1<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int { // expected-note{{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{55-55=, Sendable}}
-   async let _: Int = seq.reduce(0) { $0 + $1 } // OK
+   async let _: Int = seq.reduce(0) { $0 + $1 } // expected-error{{call can throw, but it is executed in a non-throwing autoclosure}} expected-note{{call is to 'rethrows' function, but a conformance has a throwing witness}}
    // expected-warning@-1{{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
 }
 
 func testAsyncSequence<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int { // expected-note{{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{42-42=, Sendable}}
-   async let result = seq.reduce(0) { $0 + $1 } // OK
+   async let result = seq.reduce(0) { $0 + $1 } // expected-error{{call can throw, but it is executed in a non-throwing autoclosure}} expected-note{{call is to 'rethrows' function, but a conformance has a throwing witness}}
    // expected-warning@-1{{initialization of immutable value 'result' was never used; consider replacing with assignment to '_' or removing it}}
    // expected-warning@-2{{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
 }
 
 func testAsyncSequence1<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int { // expected-note{{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{43-43=, Sendable}}
-   async let _ = seq.reduce(0) { $0 + $1 } // OK
+   async let _ = seq.reduce(0) { $0 + $1 } // expected-error{{call can throw, but it is executed in a non-throwing autoclosure}} expected-note{{call is to 'rethrows' function, but a conformance has a throwing witness}}
    // expected-warning@-1{{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
 }
 
@@ -48,4 +50,9 @@ func testAsyncSequence3<Seq>(_ seq: Seq) async throws where Seq: AsyncSequence, 
 
 func testAsyncSequence4<Seq>(_ seq: Seq) async throws where Seq: AsyncSequence, Seq.Element == Int { // expected-note{{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{28-28=: Sendable}}
    async let _ = seq // expected-warning{{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
+}
+
+func search(query: String, entities: [String]) async throws -> [String] {
+  async let r = entities.filter { $0.contains(query) }.map { String($0) }
+  return await r // OK
 }

--- a/test/Concurrency/sr15049.swift
+++ b/test/Concurrency/sr15049.swift
@@ -1,45 +1,43 @@
 // RUN: %target-typecheck-verify-swift -disable-availability-checking -strict-concurrency=targeted
 // REQUIRES: concurrency
 
-// FIXME: Those cases should compile, but currently ApplyClassifier doesn't handle throws/no-throws properly.
-
 func testAsyncSequenceTypedPatternSendable<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int, Seq: Sendable {
-   async let result: Int = seq.reduce(0) { $0 + $1 } // expected-error{{call can throw, but it is executed in a non-throwing autoclosure}} expected-note{{call is to 'rethrows' function, but a conformance has a throwing witness}}
+   async let result: Int = seq.reduce(0) { $0 + $1 } // OK
    // expected-warning@-1{{immutable value 'result' was never used; consider replacing with '_' or removing it}}
 }
 
 func testAsyncSequenceTypedPattern1Sendable<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int, Seq: Sendable {
-   async let _: Int = seq.reduce(0) { $0 + $1 } // expected-error{{call can throw, but it is executed in a non-throwing autoclosure}} expected-note{{call is to 'rethrows' function, but a conformance has a throwing witness}}
+   async let _: Int = seq.reduce(0) { $0 + $1 } // OK
 }
 
 func testAsyncSequenceSendable<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int, Seq: Sendable {
-   async let result = seq.reduce(0) { $0 + $1 } // expected-error{{call can throw, but it is executed in a non-throwing autoclosure}} expected-note{{call is to 'rethrows' function, but a conformance has a throwing witness}}
+   async let result = seq.reduce(0) { $0 + $1 } // OK
    // expected-warning@-1{{initialization of immutable value 'result' was never used; consider replacing with assignment to '_' or removing it}}
 }
 
 func testAsyncSequence1Sendable<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int, Seq: Sendable {
-   async let _ = seq.reduce(0) { $0 + $1 } // expected-error{{call can throw, but it is executed in a non-throwing autoclosure}} expected-note{{call is to 'rethrows' function, but a conformance has a throwing witness}}
+   async let _ = seq.reduce(0) { $0 + $1 } // OK
 }
 
 func testAsyncSequenceTypedPattern<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int { // expected-note{{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{54-54=, Sendable}}
-   async let result: Int = seq.reduce(0) { $0 + $1 } // expected-error{{call can throw, but it is executed in a non-throwing autoclosure}} expected-note{{call is to 'rethrows' function, but a conformance has a throwing witness}}
+   async let result: Int = seq.reduce(0) { $0 + $1 } // OK
    // expected-warning@-1{{immutable value 'result' was never used; consider replacing with '_' or removing it}}
    // expected-warning@-2{{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
 }
 
 func testAsyncSequenceTypedPattern1<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int { // expected-note{{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{55-55=, Sendable}}
-   async let _: Int = seq.reduce(0) { $0 + $1 } // expected-error{{call can throw, but it is executed in a non-throwing autoclosure}} expected-note{{call is to 'rethrows' function, but a conformance has a throwing witness}}
+   async let _: Int = seq.reduce(0) { $0 + $1 } // OK
    // expected-warning@-1{{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
 }
 
 func testAsyncSequence<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int { // expected-note{{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{42-42=, Sendable}}
-   async let result = seq.reduce(0) { $0 + $1 } // expected-error{{call can throw, but it is executed in a non-throwing autoclosure}} expected-note{{call is to 'rethrows' function, but a conformance has a throwing witness}}
+   async let result = seq.reduce(0) { $0 + $1 } // OK
    // expected-warning@-1{{initialization of immutable value 'result' was never used; consider replacing with assignment to '_' or removing it}}
    // expected-warning@-2{{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
 }
 
 func testAsyncSequence1<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int { // expected-note{{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{43-43=, Sendable}}
-   async let _ = seq.reduce(0) { $0 + $1 } // expected-error{{call can throw, but it is executed in a non-throwing autoclosure}} expected-note{{call is to 'rethrows' function, but a conformance has a throwing witness}}
+   async let _ = seq.reduce(0) { $0 + $1 } // OK
    // expected-warning@-1{{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
 }
 
@@ -55,4 +53,12 @@ func testAsyncSequence4<Seq>(_ seq: Seq) async throws where Seq: AsyncSequence, 
 func search(query: String, entities: [String]) async throws -> [String] {
   async let r = entities.filter { $0.contains(query) }.map { String($0) }
   return await r // OK
+}
+
+// https://github.com/apple/swift/issues/60351
+func foo() async {
+    let stream = AsyncStream<Int>{ _ in }
+    async let bar = stream.first { _ in true}
+
+    _ = await bar // OK
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
Previous change to apply classifier caused a regression where previously valid code 
```swift
func search(query: String, entities: [String]) async throws -> [String] {
  async let r = entities.filter { $0.contains(query) }.map { String($0) }
  return await r 
}
```
was now being rejected. 

This reverts the change for now, but we the proper fix should be adjust apply classifier to handle this correctly.

Edit: Conformances were not being taking into account because of early return, so this now continues if there are any conformances that need to be looked at. 

Resolves: https://github.com/apple/swift/issues/60351
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
