### PR TITLE
Fix some job security in the witness representation

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -35,7 +35,6 @@
 #include "swift/AST/TypeAlignments.h"
 #include "swift/AST/TypeWalker.h"
 #include "swift/AST/Types.h"
-#include "swift/AST/Witness.h"
 #include "swift/Basic/ArrayRefView.h"
 #include "swift/Basic/Compiler.h"
 #include "swift/Basic/Debug.h"
@@ -105,6 +104,7 @@ namespace swift {
   class ValueDecl;
   class VarDecl;
   class OpaqueReturnTypeRepr;
+  class Witness;
 
   namespace ast_scope {
   class AbstractPatternEntryScope;

--- a/include/swift/AST/RequirementEnvironment.h
+++ b/include/swift/AST/RequirementEnvironment.h
@@ -72,15 +72,14 @@ class RequirementEnvironment {
   /// The witness thunk emitted by SILGen uses the synthetic signature.
   /// Therefore one invariant we preserve is that the witness thunk is
   /// ABI compatible with the requirement's function type.
-  GenericSignature syntheticSignature = GenericSignature();
-  GenericEnvironment *syntheticEnvironment = nullptr;
+  GenericSignature syntheticSig = GenericSignature();
 
   /// The generic signature of the protocol requirement member.
   GenericSignature reqSig = GenericSignature();
 
   /// A substitution map mapping the requirement signature to the
   /// generic parameters of the synthetic signature.
-  SubstitutionMap reqToSyntheticEnvMap;
+  SubstitutionMap reqToSyntheticSigMap;
 
 public:
   /// Create a new environment for matching the given requirement within a
@@ -102,20 +101,20 @@ public:
                          ClassDecl *covariantSelf,
                          ProtocolConformance *conformance);
 
-  /// Retrieve the synthetic generic environment.
-  GenericEnvironment *getSyntheticEnvironment() const {
-    return syntheticEnvironment;
-  }
-
   /// Retrieve the generic signature of the requirement.
   GenericSignature getRequirementSignature() const {
     return reqSig;
   }
 
+  /// Retrieve the generic signature of the witness thunk.
+  GenericSignature getSyntheticSignature() const {
+    return syntheticSig;
+  }
+
   /// Retrieve the substitution map that maps the interface types of the
-  /// requirement to the interface types of the synthetic environment.
+  /// requirement to the interface types of the synthetic signature.
   SubstitutionMap getRequirementToSyntheticMap() const {
-    return reqToSyntheticEnvMap;
+    return reqToSyntheticSigMap;
   }
 };
 

--- a/include/swift/AST/RequirementEnvironment.h
+++ b/include/swift/AST/RequirementEnvironment.h
@@ -35,7 +35,7 @@ namespace swift {
 /// environment are the type parameters of the conformance context
 /// (\c conformanceDC) with another (deeper) level of type parameters for
 /// generic requirements. See the \c Witness class for more information about
-/// this synthetic environment.
+/// the witness thunk signature.
 class RequirementEnvironment {
   /// A generic signature that combines the generic parameters of the
   /// concrete conforming type with the generic parameters of the
@@ -52,7 +52,7 @@ class RequirementEnvironment {
   /// <Self : P, T>
   /// <A, B, T>
   ///
-  /// The synthetic signature in this case is just the witness signature.
+  /// The witness thunk signature in this case is just the witness signature.
   ///
   /// It may be that the witness is more generic than the requirement,
   /// for example:
@@ -65,21 +65,21 @@ class RequirementEnvironment {
   /// <Self : P>
   /// <A, B, T>
   ///
-  /// The synthetic signature is just:
+  /// The witness thunk signature is just:
   ///
   /// <A, B>
   ///
-  /// The witness thunk emitted by SILGen uses the synthetic signature.
+  /// The witness thunk emitted by SILGen uses the witness thunk signature.
   /// Therefore one invariant we preserve is that the witness thunk is
   /// ABI compatible with the requirement's function type.
-  GenericSignature syntheticSig = GenericSignature();
+  GenericSignature witnessThunkSig = GenericSignature();
 
   /// The generic signature of the protocol requirement member.
   GenericSignature reqSig = GenericSignature();
 
   /// A substitution map mapping the requirement signature to the
-  /// generic parameters of the synthetic signature.
-  SubstitutionMap reqToSyntheticSigMap;
+  /// generic parameters of the witness thunk signature.
+  SubstitutionMap reqToWitnessThunkSigMap;
 
 public:
   /// Create a new environment for matching the given requirement within a
@@ -107,14 +107,14 @@ public:
   }
 
   /// Retrieve the generic signature of the witness thunk.
-  GenericSignature getSyntheticSignature() const {
-    return syntheticSig;
+  GenericSignature getWitnessThunkSignature() const {
+    return witnessThunkSig;
   }
 
   /// Retrieve the substitution map that maps the interface types of the
-  /// requirement to the interface types of the synthetic signature.
-  SubstitutionMap getRequirementToSyntheticMap() const {
-    return reqToSyntheticSigMap;
+  /// requirement to the interface types of the witness thunk signature.
+  SubstitutionMap getRequirementToWitnessThunkSubs() const {
+    return reqToWitnessThunkSigMap;
   }
 };
 

--- a/include/swift/AST/Witness.h
+++ b/include/swift/AST/Witness.h
@@ -72,7 +72,7 @@ class ValueDecl;
 /// The witness for \c R.foo(x:) is \c X<U, V>.foo(x:), but the generic
 /// functions that describe the generic requirement in \c R and the generic
 /// method in \c X have very different signatures. To handle this case, the
-/// \c Witness class produces a "synthetic" environment that pulls together
+/// \c Witness class produces a witness thunk signature that pulls together
 /// all of the information needed to map from the requirement to the witness.
 /// It is a generic environment that combines the constraints of the
 /// requirement with the constraints from the context of the protocol
@@ -81,19 +81,19 @@ class ValueDecl;
 /// environment are those of the context of the protocol conformance (\c U
 /// and \c V, in the example above) and the innermost generic parameters are
 /// those of the generic requirement (\c T, in the example above). The
-/// \c Witness class contains this synthetic environment (both its generic
+/// \c Witness class contains this witness thunk signature (both its generic
 /// signature and a generic environment providing archetypes), a substitution
 /// map that allows one to map the interface types of the requirement into
-/// the interface types of the synthetic domain, and the set of substitutions
-/// required to use the witness from the synthetic domain (e.g., how one would
+/// the interface types of the witness thunk domain, and the set of substitutions
+/// required to use the witness from the witness thunk domain (e.g., how one would
 /// call the witness from the witness thunk).
 class Witness {
   struct StoredWitness {
     /// The witness declaration, along with the substitutions needed to use
-    /// the witness declaration from the synthetic environment.
+    /// the witness declaration from the witness thunk signature.
     ConcreteDeclRef declRef;
-    GenericSignature syntheticSig;
-    SubstitutionMap reqToSyntheticSigSubs;
+    GenericSignature witnessThunkSig;
+    SubstitutionMap reqToWitnessThunkSigSubs;
     /// The derivative generic signature, when the requirement is a derivative
     /// function.
     GenericSignature derivativeGenSig;
@@ -124,7 +124,7 @@ public:
 
   /// Create a witness for the given requirement.
   ///
-  /// Deserialized witnesses do not have a synthetic environment.
+  /// Deserialized witnesses do not have a witness thunk signature.
   static Witness forDeserialized(ValueDecl *decl,
                                  SubstitutionMap substitutions,
                                  Optional<ActorIsolation> enterIsolation) {
@@ -139,12 +139,12 @@ public:
   /// \param decl The declaration for the witness.
   ///
   /// \param substitutions The substitutions required to use the witness from
-  /// the synthetic environment.
+  /// the witness thunk signature.
   ///
-  /// \param syntheticSig The synthetic signature.
+  /// \param witnessThunkSig The witness thunk signature.
   ///
-  /// \param reqToSyntheticSigSubs The mapping from the interface types of the
-  /// requirement into the interface types of the synthetic signature.
+  /// \param reqToWitnessThunkSigSubs The mapping from the interface types of the
+  /// requirement into the interface types of the witness thunk signature.
   ///
   /// \param derivativeGenSig The derivative generic signature, when the
   /// requirement is a derivative function.
@@ -153,13 +153,13 @@ public:
   /// need to hop to before calling the witness.
   Witness(ValueDecl *decl,
           SubstitutionMap substitutions,
-          GenericSignature syntheticSig,
-          SubstitutionMap reqToSyntheticSigSubs,
+          GenericSignature witnessThunkSig,
+          SubstitutionMap reqToWitnessThunkSigSubs,
           GenericSignature derivativeGenSig,
           Optional<ActorIsolation> enterIsolation);
 
   /// Retrieve the witness declaration reference, which includes the
-  /// substitutions needed to use the witness from the synthetic environment
+  /// substitutions needed to use the witness from the witness thunk signature
   /// (if any).
   ConcreteDeclRef getDeclRef() const {
     if (auto stored = storage.dyn_cast<StoredWitness *>())
@@ -175,26 +175,23 @@ public:
   explicit operator bool() const { return !storage.isNull(); }
 
   /// Retrieve the substitutions required to use this witness from the
-  /// synthetic environment.
-  ///
-  /// The substitutions are substitutions for the witness, providing interface
-  /// types from the synthetic environment.
+  /// witness thunk signature.
   SubstitutionMap getSubstitutions() const {
     return getDeclRef().getSubstitutions();
   }
 
-  /// Retrieve the synthetic generic signature.
-  GenericSignature getSyntheticSignature() const {
+  /// Retrieve the witness thunk generic signature.
+  GenericSignature getWitnessThunkSignature() const {
     if (auto *storedWitness = storage.dyn_cast<StoredWitness *>())
-      return storedWitness->syntheticSig;
+      return storedWitness->witnessThunkSig;
     return nullptr;
   }
 
   /// Retrieve the substitution map that maps the interface types of the
-  /// requirement to the interface types of the synthetic signature.
-  SubstitutionMap getRequirementToSyntheticSubs() const {
+  /// requirement to the interface types of the witness thunk signature.
+  SubstitutionMap getRequirementToWitnessThunkSubs() const {
     if (auto *storedWitness = storage.dyn_cast<StoredWitness *>())
-      return storedWitness->reqToSyntheticSigSubs;
+      return storedWitness->reqToWitnessThunkSigSubs;
     return {};
   }
 

--- a/include/swift/AST/Witness.h
+++ b/include/swift/AST/Witness.h
@@ -92,8 +92,8 @@ class Witness {
     /// The witness declaration, along with the substitutions needed to use
     /// the witness declaration from the synthetic environment.
     ConcreteDeclRef declRef;
-    GenericEnvironment *syntheticEnvironment;
-    SubstitutionMap reqToSyntheticEnvSubs;
+    GenericSignature syntheticSig;
+    SubstitutionMap reqToSyntheticSigSubs;
     /// The derivative generic signature, when the requirement is a derivative
     /// function.
     GenericSignature derivativeGenSig;
@@ -141,10 +141,10 @@ public:
   /// \param substitutions The substitutions required to use the witness from
   /// the synthetic environment.
   ///
-  /// \param syntheticEnv The synthetic environment.
+  /// \param syntheticSig The synthetic signature.
   ///
-  /// \param reqToSyntheticEnvSubs The mapping from the interface types of the
-  /// requirement into the interface types of the synthetic environment.
+  /// \param reqToSyntheticSigSubs The mapping from the interface types of the
+  /// requirement into the interface types of the synthetic signature.
   ///
   /// \param derivativeGenSig The derivative generic signature, when the
   /// requirement is a derivative function.
@@ -153,8 +153,8 @@ public:
   /// need to hop to before calling the witness.
   Witness(ValueDecl *decl,
           SubstitutionMap substitutions,
-          GenericEnvironment *syntheticEnv,
-          SubstitutionMap reqToSyntheticEnvSubs,
+          GenericSignature syntheticSig,
+          SubstitutionMap reqToSyntheticSigSubs,
           GenericSignature derivativeGenSig,
           Optional<ActorIsolation> enterIsolation);
 
@@ -183,18 +183,18 @@ public:
     return getDeclRef().getSubstitutions();
   }
 
-  /// Retrieve the synthetic generic environment.
-  GenericEnvironment *getSyntheticEnvironment() const {
+  /// Retrieve the synthetic generic signature.
+  GenericSignature getSyntheticSignature() const {
     if (auto *storedWitness = storage.dyn_cast<StoredWitness *>())
-      return storedWitness->syntheticEnvironment;
+      return storedWitness->syntheticSig;
     return nullptr;
   }
 
   /// Retrieve the substitution map that maps the interface types of the
-  /// requirement to the interface types of the synthetic environment.
+  /// requirement to the interface types of the synthetic signature.
   SubstitutionMap getRequirementToSyntheticSubs() const {
     if (auto *storedWitness = storage.dyn_cast<StoredWitness *>())
-      return storedWitness->reqToSyntheticEnvSubs;
+      return storedWitness->reqToSyntheticSigSubs;
     return {};
   }
 

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2716,21 +2716,6 @@ public:
             abort();
           }
 
-          // Check the witness substitutions.
-          const auto &witness = normal->getWitnessUncached(req);
-
-          if (auto *genericEnv = witness.getSyntheticEnvironment())
-            Generics.push_back(genericEnv->getGenericSignature());
-
-          verifyChecked(witness.getRequirementToSyntheticSubs());
-          verifyChecked(witness.getSubstitutions());
-
-          if (auto *genericEnv = witness.getSyntheticEnvironment()) {
-            assert(Generics.back().get<GenericSignature>().getPointer()
-                   == genericEnv->getGenericSignature().getPointer());
-            Generics.pop_back();
-          }
-
           continue;
         }
       }

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -42,12 +42,12 @@ STATISTIC(NumConformanceLookupTables, "# of conformance lookup tables built");
 using namespace swift;
 
 Witness::Witness(ValueDecl *decl, SubstitutionMap substitutions,
-                 GenericEnvironment *syntheticEnv,
-                 SubstitutionMap reqToSynthesizedEnvSubs,
+                 GenericSignature syntheticSig,
+                 SubstitutionMap reqToSyntheticSigSubs,
                  GenericSignature derivativeGenSig,
                  Optional<ActorIsolation> enterIsolation) {
-  if (!syntheticEnv && substitutions.empty() &&
-      reqToSynthesizedEnvSubs.empty() && !enterIsolation) {
+  if (!syntheticSig && substitutions.empty() &&
+      reqToSyntheticSigSubs.empty() && !enterIsolation) {
     storage = decl;
     return;
   }
@@ -55,15 +55,15 @@ Witness::Witness(ValueDecl *decl, SubstitutionMap substitutions,
   auto &ctx = decl->getASTContext();
   auto declRef = ConcreteDeclRef(decl, substitutions);
   auto storedMem = ctx.Allocate(sizeof(StoredWitness), alignof(StoredWitness));
-  auto stored = new (storedMem) StoredWitness{declRef, syntheticEnv,
-                                              reqToSynthesizedEnvSubs,
+  auto stored = new (storedMem) StoredWitness{declRef, syntheticSig,
+                                              reqToSyntheticSigSubs,
                                               derivativeGenSig, enterIsolation};
 
   storage = stored;
 }
 
 Witness Witness::withEnterIsolation(ActorIsolation enterIsolation) const {
-  return Witness(getDecl(), getSubstitutions(), getSyntheticEnvironment(),
+  return Witness(getDecl(), getSubstitutions(), getSyntheticSignature(),
                  getRequirementToSyntheticSubs(),
                  getDerivativeGenericSignature(), enterIsolation);
 }

--- a/lib/AST/RequirementEnvironment.cpp
+++ b/lib/AST/RequirementEnvironment.cpp
@@ -44,7 +44,7 @@ RequirementEnvironment::RequirementEnvironment(
   auto conformanceSig = conformanceDC->getGenericSignatureOfContext();
 
   // This is a substitution function from the generic parameters of the
-  // conforming type to the synthetic environment.
+  // conforming type to the witness thunk environment.
   //
   // For structs, enums and protocols, this is a 1:1 mapping; for classes,
   // we increase the depth of each generic parameter by 1 so that we can
@@ -53,7 +53,7 @@ RequirementEnvironment::RequirementEnvironment(
   // This is a raw function rather than a substitution map because we need to
   // keep generic parameters as generic, even if the conformanceSig (the best
   // way to create the substitution map) equates them to concrete types.
-  auto conformanceToSyntheticTypeFn = [&](SubstitutableType *type) {
+  auto conformanceToWitnessThunkTypeFn = [&](SubstitutableType *type) {
     auto *genericParam = cast<GenericTypeParamType>(type);
     if (covariantSelf) {
       return GenericTypeParamType::get(genericParam->isTypeSequence(),
@@ -65,14 +65,14 @@ RequirementEnvironment::RequirementEnvironment(
                                      genericParam->getDepth(),
                                      genericParam->getIndex(), ctx);
   };
-  auto conformanceToSyntheticConformanceFn =
+  auto conformanceToWitnessThunkConformanceFn =
       MakeAbstractConformanceForGenericType();
 
   auto substConcreteType = concreteType.subst(
-      conformanceToSyntheticTypeFn, conformanceToSyntheticConformanceFn);
+      conformanceToWitnessThunkTypeFn, conformanceToWitnessThunkConformanceFn);
 
   // Calculate the depth at which the requirement's generic parameters
-  // appear in the synthetic signature.
+  // appear in the witness thunk signature.
   unsigned depth = 0;
   if (covariantSelf) {
     ++depth;
@@ -88,7 +88,7 @@ RequirementEnvironment::RequirementEnvironment(
   auto selfType = cast<GenericTypeParamType>(
       proto->getSelfInterfaceType()->getCanonicalType());
 
-  reqToSyntheticSigMap = SubstitutionMap::get(reqSig,
+  reqToWitnessThunkSigMap = SubstitutionMap::get(reqSig,
     [selfType, substConcreteType, depth, covariantSelf, &ctx]
     (SubstitutableType *type) -> Type {
       // If the conforming type is a class, the protocol 'Self' maps to
@@ -136,12 +136,13 @@ RequirementEnvironment::RequirementEnvironment(
       return ProtocolConformanceRef(proto);
     });
 
-  // If the requirement itself is non-generic, the synthetic signature
+  // If the requirement itself is non-generic, the witness thunk signature
   // is that of the conformance context.
   if (!covariantSelf &&
       reqSig.getGenericParams().size() == 1 &&
       reqSig.getRequirements().size() == 1) {
-    syntheticSig = conformanceDC->getGenericSignatureOfContext().getCanonicalSignature();
+    witnessThunkSig = conformanceDC->getGenericSignatureOfContext()
+        .getCanonicalSignature();
     return;
   }
 
@@ -161,8 +162,8 @@ RequirementEnvironment::RequirementEnvironment(
   // Now, add all generic parameters from the conforming type.
   if (conformanceSig) {
     for (auto param : conformanceSig.getGenericParams()) {
-      auto substParam = Type(param).subst(conformanceToSyntheticTypeFn,
-                                          conformanceToSyntheticConformanceFn);
+      auto substParam = Type(param).subst(conformanceToWitnessThunkTypeFn,
+                                          conformanceToWitnessThunkConformanceFn);
       genericParamTypes.push_back(substParam->castTo<GenericTypeParamType>());
     }
   }
@@ -178,8 +179,8 @@ RequirementEnvironment::RequirementEnvironment(
 
   if (conformanceSig) {
     for (auto &rawReq : conformanceSig.getRequirements()) {
-      if (auto req = rawReq.subst(conformanceToSyntheticTypeFn,
-                                  conformanceToSyntheticConformanceFn))
+      if (auto req = rawReq.subst(conformanceToWitnessThunkTypeFn,
+                                  conformanceToWitnessThunkConformanceFn))
         requirements.push_back(*req);
     }
   }
@@ -204,12 +205,11 @@ RequirementEnvironment::RequirementEnvironment(
   // Next, add each of the requirements (mapped from the requirement's
   // interface types into the abstract type parameters).
   for (auto &rawReq : reqSig.getRequirements()) {
-    if (auto req = rawReq.subst(reqToSyntheticSigMap))
+    if (auto req = rawReq.subst(reqToWitnessThunkSigMap))
       requirements.push_back(*req);
   }
 
-  // Produce the generic signature and environment.
-  syntheticSig = buildGenericSignature(ctx, GenericSignature(),
-                                       std::move(genericParamTypes),
-                                       std::move(requirements));
+  witnessThunkSig = buildGenericSignature(ctx, GenericSignature(),
+                                          std::move(genericParamTypes),
+                                          std::move(requirements));
 }

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -723,11 +723,11 @@ SILFunction *SILGenModule::emitProtocolWitness(
 
   // Mapping from the requirement's generic signature to the witness
   // thunk's generic signature.
-  auto reqtSubMap = witness.getRequirementToSyntheticSubs();
+  auto reqtSubMap = witness.getRequirementToWitnessThunkSubs();
 
   // The generic environment for the witness thunk.
-  auto *genericEnv = witness.getSyntheticSignature().getGenericEnvironment();
-  auto genericSig = witness.getSyntheticSignature().getCanonicalSignature();
+  auto *genericEnv = witness.getWitnessThunkSignature().getGenericEnvironment();
+  auto genericSig = witness.getWitnessThunkSignature().getCanonicalSignature();
 
   // The type of the witness thunk.
   auto reqtSubstTy = cast<AnyFunctionType>(

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -726,10 +726,8 @@ SILFunction *SILGenModule::emitProtocolWitness(
   auto reqtSubMap = witness.getRequirementToSyntheticSubs();
 
   // The generic environment for the witness thunk.
-  auto *genericEnv = witness.getSyntheticEnvironment();
-  CanGenericSignature genericSig;
-  if (genericEnv)
-    genericSig = genericEnv->getGenericSignature().getCanonicalSignature();
+  auto *genericEnv = witness.getSyntheticSignature().getGenericEnvironment();
+  auto genericSig = witness.getSyntheticSignature().getCanonicalSignature();
 
   // The type of the witness thunk.
   auto reqtSubstTy = cast<AnyFunctionType>(

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -100,8 +100,8 @@ struct swift::RequirementCheck {
 
 swift::Witness RequirementMatch::getWitness(ASTContext &ctx) const {
   return swift::Witness(this->Witness, WitnessSubstitutions,
-                        ReqEnv->getSyntheticSignature(),
-                        ReqEnv->getRequirementToSyntheticMap(),
+                        ReqEnv->getWitnessThunkSignature(),
+                        ReqEnv->getRequirementToWitnessThunkSubs(),
                         DerivativeGenSig, None);
 }
 
@@ -950,7 +950,7 @@ static Optional<RequirementMatch> findMissingGenericRequirementForSolutionFix(
       if (auto assocType = env->mapTypeIntoContext(type))
         return missingRequirementMatch(assocType);
 
-  auto reqSubMap = reqEnvironment.getRequirementToSyntheticMap();
+  auto reqSubMap = reqEnvironment.getRequirementToWitnessThunkSubs();
   auto proto = conformance->getProtocol();
   Type selfTy = proto->getSelfInterfaceType().subst(reqSubMap);
   if (type->isEqual(selfTy)) {
@@ -1077,9 +1077,9 @@ swift::matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
     // the required type and the witness type.
     cs.emplace(dc, ConstraintSystemFlags::AllowFixes);
 
-    auto syntheticSig = reqEnvironment.getSyntheticSignature();
+    auto syntheticSig = reqEnvironment.getWitnessThunkSignature();
     auto *syntheticEnv = syntheticSig.getGenericEnvironment();
-    auto reqSubMap = reqEnvironment.getRequirementToSyntheticMap();
+    auto reqSubMap = reqEnvironment.getRequirementToWitnessThunkSubs();
 
     Type selfTy = proto->getSelfInterfaceType().subst(reqSubMap);
     if (syntheticEnv)

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -99,9 +99,9 @@ struct swift::RequirementCheck {
 };
 
 swift::Witness RequirementMatch::getWitness(ASTContext &ctx) const {
-  auto syntheticEnv = ReqEnv->getSyntheticEnvironment();
   return swift::Witness(this->Witness, WitnessSubstitutions,
-                        syntheticEnv, ReqEnv->getRequirementToSyntheticMap(),
+                        ReqEnv->getSyntheticSignature(),
+                        ReqEnv->getRequirementToSyntheticMap(),
                         DerivativeGenSig, None);
 }
 
@@ -1077,12 +1077,13 @@ swift::matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
     // the required type and the witness type.
     cs.emplace(dc, ConstraintSystemFlags::AllowFixes);
 
-    auto reqGenericEnv = reqEnvironment.getSyntheticEnvironment();
+    auto syntheticSig = reqEnvironment.getSyntheticSignature();
+    auto *syntheticEnv = syntheticSig.getGenericEnvironment();
     auto reqSubMap = reqEnvironment.getRequirementToSyntheticMap();
 
     Type selfTy = proto->getSelfInterfaceType().subst(reqSubMap);
-    if (reqGenericEnv)
-      selfTy = reqGenericEnv->mapTypeIntoContext(selfTy);
+    if (syntheticEnv)
+      selfTy = syntheticEnv->mapTypeIntoContext(selfTy);
 
     // Open up the type of the requirement.
     reqLocator = cs->getConstraintLocator(
@@ -1106,8 +1107,8 @@ swift::matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
       if (replacedInReq->hasError())
         continue;
 
-      if (reqGenericEnv) {
-        replacedInReq = reqGenericEnv->mapTypeIntoContext(replacedInReq);
+      if (syntheticEnv) {
+        replacedInReq = syntheticEnv->mapTypeIntoContext(replacedInReq);
       }
 
       cs->addConstraint(ConstraintKind::Bind, replacement.second, replacedInReq,


### PR DESCRIPTION
The naming here was unnecessarily obscure:

- We can store a GenericSignature instead of a GenericEnvironment, since primary generic environments map 1:1 signatures and it's easy enough to get one when we need it.
- Rename "synthetic signature/environment" to "witness thunk signature" throughout since "synthetic" doesn't mean anything, where as "witness thunk" does, since this is in fact the generic signature of the witness thunk emitted by SILGen.