### PR TITLE
[cxx-interop] Allow iterators with out-of-class `operator==`

### DIFF
--- a/test/Interop/Cxx/stdlib/overlay/Inputs/custom-iterator.h
+++ b/test/Interop/Cxx/stdlib/overlay/Inputs/custom-iterator.h
@@ -191,6 +191,19 @@ struct HasNoEqualEqual {
   }
 };
 
+struct HasInvalidEqualEqual {
+  int value;
+  using iterator_category = std::input_iterator_tag;
+  const int &operator*() const { return value; }
+  HasInvalidEqualEqual &operator++() {
+    value++;
+    return *this;
+  }
+  bool operator==(const int &other) const { // wrong type
+    return value == other;
+  }
+};
+
 struct HasNoIncrementOperator {
   int value;
   using iterator_category = std::input_iterator_tag;

--- a/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
@@ -9,8 +9,7 @@
 // CHECK:   static func == (lhs: ConstIterator, other: ConstIterator) -> Bool
 // CHECK: }
 
-// TODO: ConstIteratorOutOfLineEq should also conform to UnsafeCxxInputIterator.
-// CHECK: struct ConstIteratorOutOfLineEq {
+// CHECK: struct ConstIteratorOutOfLineEq : UnsafeCxxInputIterator {
 // CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> ConstIteratorOutOfLineEq
 // CHECK: }
@@ -54,6 +53,7 @@
 // CHECK-NOT: struct HasNoIteratorCategory : UnsafeCxxInputIterator
 // CHECK-NOT: struct HasInvalidIteratorCategory : UnsafeCxxInputIterator
 // CHECK-NOT: struct HasNoEqualEqual : UnsafeCxxInputIterator
+// CHECK-NOT: struct HasInvalidEqualEqual : UnsafeCxxInputIterator
 // CHECK-NOT: struct HasNoIncrementOperator : UnsafeCxxInputIterator
 // CHECK-NOT: struct HasNoPreIncrementOperator : UnsafeCxxInputIterator
 // CHECK-NOT: struct HasNoDereferenceOperator : UnsafeCxxInputIterator

--- a/test/Interop/Cxx/stdlib/overlay/custom-sequence-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-sequence-typechecker.swift
@@ -18,8 +18,7 @@ func checkSimpleSequence() {
 }
 
 // === SimpleSequenceWithOutOfLineEqualEqual ===
-// TODO: synthesize conformance to UnsafeCxxInputIterator.
-//extension SimpleSequenceWithOutOfLineEqualEqual : CxxSequence {}
+extension SimpleSequenceWithOutOfLineEqualEqual : CxxSequence {}
 
 // === SimpleArrayWrapper ===
 // No UnsafeCxxInputIterator conformance required, since the iterators are actually UnsafePointers here.


### PR DESCRIPTION
Previosly we didn't detect `func ==` that was declared out-of-class when synthesizing conformaces to `UnsafeCxxInputIterator`. Now we do.

rdar://96235368