### PR TITLE
[5.7] SIL Optimizer: add the OptimizeHopToExecutor in the late pipeline.

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -767,6 +767,7 @@ static void addLateLoopOptPassPipeline(SILPassPipelinePlan &P) {
 // - don't require IRGen information.
 static void addLastChanceOptPassPipeline(SILPassPipelinePlan &P) {
   // Optimize access markers for improved IRGen after all other optimizations.
+  P.addOptimizeHopToExecutor();
   P.addAccessEnforcementReleaseSinking();
   P.addAccessEnforcementOpts();
   P.addAccessEnforcementWMO();

--- a/test/Concurrency/Runtime/exclusivity_custom_executors.swift
+++ b/test/Concurrency/Runtime/exclusivity_custom_executors.swift
@@ -376,6 +376,7 @@ struct Runner {
 
                 await withExclusiveAccessAsync(to: &global) {
                     @MyMainActorWithAccessInUnownedExecAccessor (x: inout Int) async -> Void in
+                    print("do something to avoid optimizing away to executor switch")
                     debugLog("==> Making sure can push/pop access")
                 }
                 // In order to test that we properly hand off the access, we


### PR DESCRIPTION
This is important to remove redundant `hop_to_executor` instructions after inlining.

rdar://95796233

This is a cherry-pick of https://github.com/apple/swift/pull/60153