### PR TITLE
[ConstraintSystem] Fix indentations of AST in Conjunction Steps.

### DIFF
--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -855,7 +855,8 @@ public:
   /// Print constraint placed on type and constraint properties.
   ///
   /// \c skipLocator skips printing of locators.
-  void print(llvm::raw_ostream &Out, SourceManager *sm, bool skipLocator = false) const;
+  void print(llvm::raw_ostream &Out, SourceManager *sm, unsigned indent = 0,
+             bool skipLocator = false) const;
 
   SWIFT_DEBUG_DUMPER(dump(SourceManager *SM));
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -6107,7 +6107,7 @@ public:
   bool isSymmetricOperator() const;
   bool isUnaryOperator() const;
 
-  void print(llvm::raw_ostream &Out, SourceManager *SM) const {
+  void print(llvm::raw_ostream &Out, SourceManager *SM, unsigned indent = 0) const {
     Out << "disjunction choice ";
     Choice->print(Out, SM);
   }
@@ -6139,9 +6139,9 @@ public:
 
   ConstraintLocator *getLocator() const { return Element->getLocator(); }
 
-  void print(llvm::raw_ostream &Out, SourceManager *SM) const {
+  void print(llvm::raw_ostream &Out, SourceManager *SM, unsigned indent) const {
     Out << "conjunction element ";
-    Element->print(Out, SM);
+    Element->print(Out, SM, indent);
   }
 
 private:
@@ -6176,7 +6176,7 @@ public:
   Optional<std::pair<ConstraintFix *, unsigned>>
   fixForHole(ConstraintSystem &cs) const;
 
-  void print(llvm::raw_ostream &Out, SourceManager *) const {
+  void print(llvm::raw_ostream &Out, SourceManager *, unsigned indent) const {
     PrintOptions PO;
     PO.PrintTypesForDebugging = true;
     Out << "type variable " << TypeVar->getString(PO)

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -843,9 +843,6 @@ StepResult ConjunctionStep::resume(bool prevFailed) {
   // attempted to apply information gained from the
   // isolated constraint to the outer context.
   if (Snapshot && Snapshot->isScoped()) {
-    if (CS.isDebugMode())
-      getDebugLogger() << ")\n";
-
     return done(/*isSuccess=*/!prevFailed);
   }
 

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -973,6 +973,9 @@ public:
       auto remainingTime = OuterTimeRemaining->second;
       CS.Timer.emplace(anchor, CS, remainingTime);
     }
+    
+    if (CS.isDebugMode())
+      getDebugLogger() << ")\n";
   }
 
   StepResult resume(bool prevFailed) override;

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -519,7 +519,7 @@ public:
       if (CS.isDebugMode()) {
         auto &log = getDebugLogger();
         log << "(attempting ";
-        choice->print(log, &CS.getASTContext().SourceMgr);
+        choice->print(log, &CS.getASTContext().SourceMgr, CS.solverState->depth * 2 + 2);
         log << '\n';
       }
 

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -382,9 +382,11 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm, bool skipLocat
       auto *patternBinding = cast<PatternBindingDecl>(element.get<Decl *>());
       Out << "pattern binding element @ ";
       Out << patternBindingElt->getIndex() << " : ";
+      Out << '\n';
       patternBinding->getPattern(patternBindingElt->getIndex())->dump(Out);
     } else {
       Out << "syntactic element ";
+      Out << '\n';
       element.dump(Out);
     }
 

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -322,7 +322,7 @@ Constraint *Constraint::clone(ConstraintSystem &cs) const {
   llvm_unreachable("Unhandled ConstraintKind in switch.");
 }
 
-void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm, bool skipLocator) const {
+void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm, unsigned indent, bool skipLocator) const {
   // Print all type variables as $T0 instead of _ here.
   PrintOptions PO;
   PO.PrintTypesForDebugging = true;
@@ -383,11 +383,11 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm, bool skipLocat
       Out << "pattern binding element @ ";
       Out << patternBindingElt->getIndex() << " : ";
       Out << '\n';
-      patternBinding->getPattern(patternBindingElt->getIndex())->dump(Out);
+      patternBinding->getPattern(patternBindingElt->getIndex())->dump(Out, indent);
     } else {
       Out << "syntactic element ";
       Out << '\n';
-      element.dump(Out);
+      element.dump(Out, indent);
     }
 
     return;


### PR DESCRIPTION
Previously, the AST during Conjunction Step was printed in line and with incorrect indentations. This will now print as: 
```
      (attempting conjunction element syntactic element 
        (if_stmt
          (pattern
            (pattern_let implicit
              (pattern_named 'y'))
            (declref_expr type='<null>' decl=test.(file).top-level code.explicit closure discriminator=0.x@/Users/amritpankaur/test.swift:69:7 function_ref=unapplied))
          (brace_stmt
            (call_expr type='<null>'
              (overloaded_decl_ref_expr type='<null>' name=print number_of_decls=2 function_ref=single)
              (argument_list
                (argument
                  (declref_expr type='<null>' decl=test.(file).top-level code.explicit closure discriminator=0.y@/Users/...:70:10 function_ref=unapplied))))))
```