### PR TITLE
Implement objc_direct in SIL

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1762,10 +1762,12 @@ public:
         getSILDebugLocation(Loc), Operand, Member, MethodTy));
   }
 
-  ObjCMethodInst *createObjCMethod(SILLocation Loc, SILValue Operand,
-                                   SILDeclRef Member, SILType MethodTy) {
-    return insert(ObjCMethodInst::create(getSILDebugLocation(Loc), Operand,
-                                         Member, MethodTy, &getFunction()));
+  ObjCMethodInst *createObjCMethod(SILLocation Loc, bool Direct,
+                                   SILValue Operand, SILDeclRef Member,
+                                   SILType MethodTy) {
+    return insert(ObjCMethodInst::create(getSILDebugLocation(Loc), Direct,
+                                         Operand, Member, MethodTy,
+                                         &getFunction()));
   }
 
   ObjCSuperMethodInst *createObjCSuperMethod(SILLocation Loc, SILValue Operand,

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -2153,10 +2153,11 @@ template<typename ImplClass>
 void
 SILCloner<ImplClass>::visitObjCMethodInst(ObjCMethodInst *Inst) {
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
-  recordClonedInstruction(
-      Inst, getBuilder().createObjCMethod(
-                getOpLocation(Inst->getLoc()), getOpValue(Inst->getOperand()),
-                Inst->getMember(), getOpType(Inst->getType())));
+  recordClonedInstruction(Inst,
+                          getBuilder().createObjCMethod(
+                              getOpLocation(Inst->getLoc()), Inst->isDirect(),
+                              getOpValue(Inst->getOperand()), Inst->getMember(),
+                              getOpType(Inst->getType())));
 }
 
 template<typename ImplClass>

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -6803,16 +6803,22 @@ class ObjCMethodInst final
           MethodInst>
 {
   friend SILBuilder;
+  USE_SHARED_UINT8;
 
-  ObjCMethodInst(SILDebugLocation DebugLoc, SILValue Operand,
-                 ArrayRef<SILValue> TypeDependentOperands,
-                 SILDeclRef Member, SILType Ty)
-      : UnaryInstructionWithTypeDependentOperandsBase(DebugLoc, Operand,
-                               TypeDependentOperands, Ty, Member) {}
+  ObjCMethodInst(SILDebugLocation DebugLoc, bool Direct, SILValue Operand,
+                 ArrayRef<SILValue> TypeDependentOperands, SILDeclRef Member,
+                 SILType Ty)
+      : UnaryInstructionWithTypeDependentOperandsBase(
+            DebugLoc, Operand, TypeDependentOperands, Ty, Member) {
+    sharedUInt8().ObjCMethodInst.isDirect = Direct;
+  }
 
-  static ObjCMethodInst *
-  create(SILDebugLocation DebugLoc, SILValue Operand,
-         SILDeclRef Member, SILType Ty, SILFunction *F);
+  static ObjCMethodInst *create(SILDebugLocation DebugLoc, bool Direct,
+                                SILValue Operand, SILDeclRef Member, SILType Ty,
+                                SILFunction *F);
+
+public:
+  bool isDirect() const { return sharedUInt8().ObjCMethodInst.isDirect; }
 };
 
 /// ObjCSuperMethodInst - Given the address of a value of class type and a method

--- a/include/swift/SIL/SILNode.h
+++ b/include/swift/SIL/SILNode.h
@@ -199,6 +199,7 @@ protected:
     SHARED_FIELD(EndCOWMutationInst, bool keepUnique);
     SHARED_FIELD(ConvertFunctionInst, bool withoutActuallyEscaping);
     SHARED_FIELD(BeginCOWMutationInst, bool native);
+    SHARED_FIELD(ObjCMethodInst, bool isDirect);
 
     SHARED_FIELD(DebugValueInst, uint8_t
       poisonRefs : 1,

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7560,22 +7560,10 @@ void ClangImporter::Implementation::importAttributes(
     if (method->isDirectMethod() && !AnyUnavailable) {
       assert(isa<AbstractFunctionDecl>(MappedDecl) &&
              "objc_direct declarations are expected to be an AbstractFunctionDecl");
-      if (isa<ConstructorDecl>(MappedDecl)) {
-        // TODO: Teach Swift how to directly call these functions.
-        auto attr = AvailableAttr::createPlatformAgnostic(
-            C,
-            "Swift cannot call Objective-C initializers marked with "
-            "'objc_direct'",
-            /*Rename*/ "",
-            PlatformAgnosticAvailabilityKind::UnavailableInSwift);
-        MappedDecl->getAttrs().add(attr);
-        AnyUnavailable = true;
-      } else {
-        MappedDecl->getAttrs().add(new (C) FinalAttr(/*IsImplicit=*/true));
-        if (auto accessorDecl = dyn_cast<AccessorDecl>(MappedDecl)) {
-          auto attr = new (C) FinalAttr(/*isImplicit=*/true);
-          accessorDecl->getStorage()->getAttrs().add(attr);
-        }
+      MappedDecl->getAttrs().add(new (C) FinalAttr(/*IsImplicit=*/true));
+      if (auto accessorDecl = dyn_cast<AccessorDecl>(MappedDecl)) {
+        auto attr = new (C) FinalAttr(/*isImplicit=*/true);
+        accessorDecl->getStorage()->getAttrs().add(attr);
       }
     }
   }

--- a/lib/IRGen/GenObjC.h
+++ b/lib/IRGen/GenObjC.h
@@ -58,12 +58,16 @@ namespace irgen {
     /// the dynamic type of the object.
     llvm::PointerIntPair<SILType, 1, bool> searchTypeAndSuper;
 
+    bool direct;
+
   public:
-    ObjCMethod(SILDeclRef method, SILType searchType, bool startAtSuper)
-      : method(method), searchTypeAndSuper(searchType, startAtSuper)
-    {}
-    
+    ObjCMethod(SILDeclRef method, bool direct, SILType searchType,
+               bool startAtSuper)
+        : method(method), searchTypeAndSuper(searchType, startAtSuper),
+          direct(direct) {}
+
     SILDeclRef getMethod() const { return method; }
+    bool isDirect() const { return direct; }
     SILType getSearchType() const { return searchTypeAndSuper.getPointer(); }
     bool shouldStartAtSuper() const { return searchTypeAndSuper.getInt(); }
     
@@ -89,8 +93,8 @@ namespace irgen {
                              llvm::Value *selfValue, CalleeInfo &&info);
 
   /// Prepare a callee for an Objective-C method with the `objc_direct` attribute.
-  Callee getObjCDirectMethodCallee(CalleeInfo &&info, const FunctionPointer &fn,
-                                   llvm::Value *selfValue);
+  Callee getObjCDirectMethodCallee(IRGenFunction &IGF, const ObjCMethod &fn,
+                                   llvm::Value *selfValue, CalleeInfo &&info);
 
   /// Emit a partial application of an Objective-C method to its 'self'
   /// argument.

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -1988,9 +1988,9 @@ WitnessMethodInst::create(SILDebugLocation Loc, CanType LookupType,
                                           Ty, TypeDependentOperands);
 }
 
-ObjCMethodInst *
-ObjCMethodInst::create(SILDebugLocation DebugLoc, SILValue Operand,
-                       SILDeclRef Member, SILType Ty, SILFunction *F) {
+ObjCMethodInst *ObjCMethodInst::create(SILDebugLocation DebugLoc, bool Direct,
+                                       SILValue Operand, SILDeclRef Member,
+                                       SILType Ty, SILFunction *F) {
   SILModule &Mod = F->getModule();
   SmallVector<SILValue, 8> TypeDependentOperands;
   collectTypeDependentOperands(TypeDependentOperands, *F, Ty.getASTType());
@@ -1998,9 +1998,8 @@ ObjCMethodInst::create(SILDebugLocation DebugLoc, SILValue Operand,
   unsigned size =
       totalSizeToAlloc<swift::Operand>(1 + TypeDependentOperands.size());
   void *Buffer = Mod.allocateInst(size, alignof(ObjCMethodInst));
-  return ::new (Buffer) ObjCMethodInst(DebugLoc, Operand,
-                                       TypeDependentOperands,
-                                       Member, Ty);
+  return ::new (Buffer) ObjCMethodInst(DebugLoc, Direct, Operand,
+                                       TypeDependentOperands, Member, Ty);
 }
 
 InitExistentialAddrInst *InitExistentialAddrInst::create(

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -2128,6 +2128,8 @@ public:
     *this << AMI->getType();
   }
   void visitObjCMethodInst(ObjCMethodInst *AMI) {
+    if (AMI->isDirect())
+      *this << "[direct] ";
     printMethodInst(AMI, AMI->getOperand());
     *this << " : " << AMI->getMember().getDecl()->getInterfaceType();
     *this << ", ";

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -4821,6 +4821,19 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
       SILType MethodTy;
       SourceLoc TyLoc;
       SmallVector<ValueDecl *, 4> values;
+      bool IsObjC = false;
+      if (P.consumeIf(tok::l_square)) {
+        Identifier Id;
+        parseSILIdentifier(Id, diag::expected_in_attribute_list);
+        StringRef Optional = Id.str();
+        if (Optional == "direct") {
+          IsObjC = true;
+        } else {
+          return true;
+        }
+        P.parseToken(tok::r_square, diag::expected_in_attribute_list);
+      }
+
       if (parseTypedValueRef(Val, B) ||
           P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ","))
         return true;
@@ -4842,7 +4855,7 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
         ResultVal = B.createSuperMethod(InstLoc, Val, Member, MethodTy);
         break;
       case SILInstructionKind::ObjCMethodInst:
-        ResultVal = B.createObjCMethod(InstLoc, Val, Member, MethodTy);
+        ResultVal = B.createObjCMethod(InstLoc, IsObjC, Val, Member, MethodTy);
         break;
       case SILInstructionKind::ObjCSuperMethodInst:
         ResultVal = B.createObjCSuperMethod(InstLoc, Val, Member, MethodTy);

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -2566,6 +2566,12 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     // Format: a type, an operand and a SILDeclRef. Use SILOneTypeValuesLayout:
     // type, Attr, SILDeclRef (DeclID, Kind, uncurryLevel), and an operand.
     unsigned NextValueIndex = 0;
+    bool isObjCDirectMethod = false;
+    if (OpCode == SILInstructionKind::ObjCMethodInst) {
+      unsigned Flags = ListOfValues[NextValueIndex];
+      isObjCDirectMethod = (bool)(Flags & 1);
+      NextValueIndex += 1;
+    }
     SILDeclRef DRef = getSILDeclRef(MF, ListOfValues, NextValueIndex);
     SILType Ty =
         getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn);
@@ -2590,8 +2596,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
       break;
     case SILInstructionKind::ObjCMethodInst:
       ResultInst = Builder.createObjCMethod(
-          Loc, getLocalValue(ListOfValues[NextValueIndex], operandTy), DRef,
-          Ty);
+          Loc, isObjCDirectMethod,
+          getLocalValue(ListOfValues[NextValueIndex], operandTy), DRef, Ty);
       break;
     case SILInstructionKind::ObjCSuperMethodInst:
       ResultInst = Builder.createObjCSuperMethod(

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -2206,6 +2206,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     const ObjCMethodInst *OMI = cast<ObjCMethodInst>(&SI);
     SILType Ty = OMI->getType();
     SmallVector<uint64_t, 9> ListOfValues;
+    ListOfValues.push_back(OMI->isDirect());
     handleMethodInst(OMI, OMI->getOperand(), ListOfValues);
 
     SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord,

--- a/test/ClangImporter/objc_direct.swift
+++ b/test/ClangImporter/objc_direct.swift
@@ -2,8 +2,6 @@
 
 // REQUIRES: objc_interop
 
-let _ = Bar(value: 4)               // expected-error {{'init(value:)' is unavailable in Swift}}
-let _ = Bar.init(value: 5)          // expected-error {{'init(value:)' is unavailable in Swift}}
 var something = Bar() as AnyObject
 
 something.directProperty = 123      // expected-error {{value of type 'AnyObject' has no member 'directProperty'}}

--- a/test/IRGen/objc_direct.swift
+++ b/test/IRGen/objc_direct.swift
@@ -10,7 +10,11 @@ protocol BarProtocol {
 
 extension Bar: BarProtocol {}
 
-let bar = Bar()
+let bar = Bar(value: 0)!
+// CHECK: call swiftcc i64 @"$sSo3BarC5valueABSgs5Int32V_tcfC"
+
+let bar2 = Bar.init(value: 0)!
+// CHECK: call swiftcc i64 @"$sSo3BarC5valueABSgs5Int32V_tcfC"
 
 bar.directProperty = 123
 // CHECK: call void @"\01-[Bar setDirectProperty:]"({{.*}}, i8* undef, i32 {{.*}})
@@ -53,6 +57,10 @@ markUsed(Bar.directClassMethod2())
 markUsed(bar.directProtocolMethod())
 // CHECK: call {{.*}} @"\01-[Bar directProtocolMethod]"({{.*}}, i8* undef)
 
+// CHECK: define {{.*}} swiftcc i64 @"$sSo3BarC5valueABSgs5Int32V_tcfC"
+// CHECK:   call swiftcc i64 @"$sSo3BarC5valueABSgs5Int32V_tcfcTO"
+// CHECK: }
+
 // CHECK-DAG: declare i32 @"\01-[Bar directProperty]"
 // CHECK-DAG: declare void @"\01-[Bar setDirectProperty:]"
 // CHECK-DAG: declare i32 @"\01-[Bar directProperty2]"
@@ -64,3 +72,7 @@ markUsed(bar.directProtocolMethod())
 // CHECK-DAG: declare {{.*}} @"\01+[Bar directClassMethod]"
 // CHECK-DAG: declare {{.*}} @"\01+[Bar directClassMethod2]"
 // CHECK-DAG: declare {{.*}} @"\01-[Bar directProtocolMethod]"
+
+// CHECK: define {{.*}} swiftcc i64 @"$sSo3BarC5valueABSgs5Int32V_tcfcTO"
+// CHECK:   call {{.*}} @"\01-[Bar initWithValue:]"
+// CHECK: }

--- a/test/Inputs/objc_direct.h
+++ b/test/Inputs/objc_direct.h
@@ -1,7 +1,6 @@
 #import <Foundation/Foundation.h>
 
 @interface Bar : NSObject
-+ (instancetype)barWithValue:(int)value __attribute__((objc_direct));
 - (instancetype)initWithValue:(int)value __attribute__((objc_direct));
 @property(direct) int directProperty;
 - (int)objectAtIndexedSubscript:(int)i __attribute__((objc_direct));

--- a/test/Interpreter/Inputs/objc_direct.m
+++ b/test/Interpreter/Inputs/objc_direct.m
@@ -1,6 +1,12 @@
 #import "objc_direct.h"
 
 @implementation Bar
+- (instancetype)initWithValue:(int)value {
+  puts(__FUNCTION__);
+  self = [super init];
+  _directProperty = value;
+  return self;
+}
 - (int)objectAtIndexedSubscript:(int)i {
   return 789;
 }

--- a/test/Interpreter/objc_direct.swift
+++ b/test/Interpreter/objc_direct.swift
@@ -13,7 +13,11 @@ protocol BarProtocol {
 
 extension Bar: BarProtocol {}
 
-let bar = Bar()
+let bar = Bar(value: 22)!
+// CHECK: -[Bar initWithValue:]
+
+let bar2 = Bar.init(value: 33)!
+// CHECK: -[Bar initWithValue:]
 
 bar.directProperty = 123
 print(bar.directProperty)

--- a/test/SILGen/objc_direct.swift
+++ b/test/SILGen/objc_direct.swift
@@ -12,40 +12,53 @@ protocol BarProtocol {
 
 extension Bar: BarProtocol {}
 
-let bar = Bar()
+// CHECK-LABEL: sil [ossa] @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+let bar = Bar(value: 0)!
+// CHECK: function_ref @$sSo3BarC5valueABSgs5Int32V_tcfC
+
+let bar2 = Bar.init(value: 0)!
+// CHECK: function_ref @$sSo3BarC5valueABSgs5Int32V_tcfC
 
 bar.directProperty = 123
-// CHECK: function_ref @[[BYTE01:.]]-[Bar setDirectProperty:]
+// CHECK: objc_method [direct] %{{.*}} : $Bar, #Bar.directProperty!setter.foreign
 
 markUsed(bar.directProperty)
-// CHECK: function_ref @[[BYTE01]]-[Bar directProperty]
+// CHECK: objc_method [direct] %{{.*}} : $Bar, #Bar.directProperty!getter.foreign
 
 bar.directProperty2 = 456
-// CHECK: function_ref @[[BYTE01]]-[Bar setDirectProperty2:]
+// CHECK: objc_method [direct] %{{.*}} : $Bar, #Bar.directProperty2!setter.foreign
 
 markUsed(bar.directProperty2)
-// CHECK: function_ref @[[BYTE01]]-[Bar directProperty2]
+// CHECK: objc_method [direct] %{{.*}} : $Bar, #Bar.directProperty2!getter.foreign
 
 bar[0] = 789
-// CHECK: function_ref @[[BYTE01]]-[Bar setObject:atIndexedSubscript:]
+// CHECK: objc_method [direct] %{{.*}} : $Bar, #Bar.subscript!setter.foreign
 
 markUsed(bar[0])
-// CHECK: function_ref @[[BYTE01]]-[Bar objectAtIndexedSubscript:]
+// CHECK: objc_method [direct] %{{.*}} : $Bar, #Bar.subscript!getter.foreign
 
 markUsed(bar.directMethod())
-// CHECK: function_ref @[[BYTE01]]-[Bar directMethod]
+// CHECK: objc_method [direct] %{{.*}} : $Bar, #Bar.directMethod!foreign
 
 markUsed(bar.directMethod2())
-// CHECK: function_ref @[[BYTE01]]-[Bar directMethod2]
+// CHECK: objc_method [direct] %{{.*}} : $Bar, #Bar.directMethod2!foreign
 
 markUsed(Bar.directClassMethod())
-// CHECK: function_ref @[[BYTE01]]+[Bar directClassMethod]
+// CHECK: objc_method [direct] %{{.*}} : $@objc_metatype Bar.Type, #Bar.directClassMethod!foreign
 
 markUsed(Bar.directClassMethod2())
-// CHECK: function_ref @[[BYTE01]]+[Bar directClassMethod2]
+// CHECK: objc_method [direct] %{{.*}} : $@objc_metatype Bar.Type, #Bar.directClassMethod2!foreign
 
 markUsed(bar.directProtocolMethod())
-// CHECK: function_ref @[[BYTE01]]-[Bar directProtocolMethod]
+// CHECK: objc_method [direct] %{{.*}} : $Bar, #Bar.directProtocolMethod!foreign
+
+// CHECK: } // end sil function 'main'
+
+// CHECK: sil [clang Bar.directProtocolMethod] @[[BYTE01:.]]-[Bar directProtocolMethod] : $@convention(objc_method)
+
+// CHECK: sil shared [serialized] [ossa] @$sSo3BarC5valueABSgs5Int32V_tcfC : $@convention(method) (Int32, @thick Bar.Type) -> @owned Optional<Bar> {
+// CHECK: {{.*}} = function_ref @$sSo3BarC5valueABSgs5Int32V_tcfcTO : $@convention(method)
+// CHECK: } // end sil function '$sSo3BarC5valueABSgs5Int32V_tcfC'
 
 // CHECK-DAG: sil @[[BYTE01]]-[Bar setDirectProperty:] : $@convention(objc_method)
 // CHECK-DAG: sil @[[BYTE01]]-[Bar directProperty] : $@convention(objc_method)
@@ -54,7 +67,10 @@ markUsed(bar.directProtocolMethod())
 // CHECK-DAG: sil @[[BYTE01]]-[Bar objectAtIndexedSubscript:] : $@convention(objc_method)
 // CHECK-DAG: sil @[[BYTE01]]-[Bar setObject:atIndexedSubscript:] : $@convention(objc_method)
 // CHECK-DAG: sil [clang Bar.directMethod] @[[BYTE01]]-[Bar directMethod] : $@convention(objc_method)
-// CHECK-DAG: sil [clang Bar.directProtocolMethod] @[[BYTE01]]-[Bar directProtocolMethod] : $@convention(objc_method)
 // CHECK-DAG: sil [clang Bar.directMethod2] @[[BYTE01]]-[Bar directMethod2] : $@convention(objc_method)
 // CHECK-DAG: sil [clang Bar.directClassMethod] @[[BYTE01]]+[Bar directClassMethod] : $@convention(objc_method)
 // CHECK-DAG: sil [clang Bar.directClassMethod2] @[[BYTE01]]+[Bar directClassMethod2] : $@convention(objc_method)
+
+// CHECK-LABEL: sil{{.*}}@$sSo3BarC5valueABSgs5Int32V_tcfcTO : $@convention(method) (Int32, @owned Bar) -> @owned Optional<Bar> {
+// CHECK: {{.*}} = objc_method [direct] %1 : $Bar, #Bar.init!initializer.foreign
+// CHECK: } // end sil function '$sSo3BarC5valueABSgs5Int32V_tcfcTO'


### PR DESCRIPTION
Implement the objc_direct attribute in Clang as a marker bit on objc_method instructions. This more aggressive form of plumbing is needed so SILGen can properly emit the foreign apply in the allocating init among other concerns. It also makes objc_direct calls directly testable in textual SIL.

Use this to lift the restriction on calling objc_direct initializers from Swift.
