### PR TITLE
Add leading space for arrow token

### DIFF
--- a/utils/gyb_syntax_support/Token.py
+++ b/utils/gyb_syntax_support/Token.py
@@ -244,9 +244,8 @@ SYNTAX_TOKENS = [
     Punctuator('PrefixAmpersand', 'amp_prefix', text='&',
                requires_leading_space=True, requires_trailing_space=True, 
                serialization_code=96),
-    Punctuator('Arrow', 'arrow', text='->', requires_trailing_space=True,
-               serialization_code=78),
-
+    Punctuator('Arrow', 'arrow', text='->', requires_leading_space=True,
+               requires_trailing_space=True, serialization_code=78),
 
     Punctuator('Backtick', 'backtick', text='`', serialization_code=79),
 


### PR DESCRIPTION
This change is required for https://github.com/apple/swift-syntax/pull/508