### PR TITLE
Add experimental flag to turn on just opaque type erasure

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -117,6 +117,9 @@ EXPERIMENTAL_FEATURE(AdditiveArithmeticDerivedConformances)
 /// @Sendable.
 EXPERIMENTAL_FEATURE(SendableCompletionHandlers)
 
+/// Enables opaque type erasure without also enabling implict dynamic
+EXPERIMENTAL_FEATURE(OpaqueTypeErasure)
+
 #undef EXPERIMENTAL_FEATURE
 #undef FUTURE_FEATURE
 #undef SUPPRESSIBLE_LANGUAGE_FEATURE

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -614,6 +614,10 @@ def disable_swift3_objc_inference :
 def enable_implicit_dynamic : Flag<["-"], "enable-implicit-dynamic">,
   Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,
   HelpText<"Add 'dynamic' to all declarations">;
+  
+def enable_experimental_opaque_type_erasure : Flag<["-"], "enable-experimental-opaque-type-erasure">,
+  Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,
+  HelpText<"Type-erases opaque types that conform to @_typeEraser protocols">;
 
 def enable_llvm_vfe : Flag<["-"], "enable-llvm-vfe">,
   Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5089,7 +5089,8 @@ public:
   ///
   /// An expression needs type erasure if:
   ///  1. The expression is a return value.
-  ///  2. The enclosing function is dynamic or a dynamic replacement.
+  ///  2. The enclosing function is dynamic, a dynamic replacement, or
+  ///     `-enable-experimental-opaque-type-erasure` is used.
   ///  3. The enclosing function returns an opaque type.
   ///  4. The opaque type conforms to (exactly) one protocol, and the protocol
   ///     has a declared type eraser.

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3041,6 +3041,10 @@ static bool usesFeatureTypeWitnessSystemInference(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureOpaqueTypeErasure(Decl *decl) {
+  return false;
+}
+
 static bool usesFeatureDifferentiableProgramming(Decl *decl) {
   return false;
 }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -657,6 +657,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     Opts.Features.insert(Feature::ForwardModeDifferentiation);
   if (Args.hasArg(OPT_enable_experimental_additive_arithmetic_derivation))
     Opts.Features.insert(Feature::AdditiveArithmeticDerivedConformances);
+  
+  if (Args.hasArg(OPT_enable_experimental_opaque_type_erasure))
+    Opts.Features.insert(Feature::OpaqueTypeErasure);
 
   Opts.EnableAppExtensionRestrictions |= Args.hasArg(OPT_enable_app_extension);
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -6018,7 +6018,8 @@ Expr *ConstraintSystem::buildTypeErasedExpr(Expr *expr, DeclContext *dc,
 
   auto *decl = dyn_cast_or_null<ValueDecl>(dc->getAsDecl());
   if (!decl ||
-      !(decl->isDynamic() || decl->getDynamicallyReplacedDecl()))
+      (!Context.LangOpts.hasFeature(Feature::OpaqueTypeErasure) &&
+       !(decl->isDynamic() || decl->getDynamicallyReplacedDecl())))
     return expr;
 
   auto *opaque = contextualType->getAs<OpaqueTypeArchetypeType>();

--- a/test/Sema/type_eraser_experimental_flag.swift
+++ b/test/Sema/type_eraser_experimental_flag.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend -typecheck -disable-availability-checking -dump-ast -enable-experimental-opaque-type-erasure %s | %FileCheck %s
+
+class AnyP: P {
+  init<T: P>(erasing: T) {}
+}
+
+@_typeEraser(AnyP)
+protocol P {}
+
+struct ConcreteP: P, Hashable {}
+
+// CHECK-LABEL: testTypeErased
+func testTypeErased() -> some P {
+  // CHECK: underlying_to_opaque_expr{{.*}}'some P'
+  // CHECK-NEXT: call_expr implicit type='AnyP'
+  ConcreteP()
+}


### PR DESCRIPTION
This was already enabled as part of `-enable-implicit-dynamic` but this
new flag allows turning on opaque type erasure all by itself whether or not
`dynamic` is added explicitly.
