### PR TITLE
[Markup] add support for swift-cmark's inline attributes

### DIFF
--- a/bindings/xml/comment-xml-schema.rng
+++ b/bindings/xml/comment-xml-schema.rng
@@ -959,7 +959,7 @@
           <param name="pattern">.*\S.*</param>
         </data>
       </element>
-      <element name="Attribute">
+      <element name="InlineAttributes">
         <attribute name="attributes"/>
         <!-- Non-empty text content. -->
         <data type="string">

--- a/bindings/xml/comment-xml-schema.rng
+++ b/bindings/xml/comment-xml-schema.rng
@@ -959,6 +959,13 @@
           <param name="pattern">.*\S.*</param>
         </data>
       </element>
+      <element name="Attribute">
+        <attribute name="attributes"/>
+        <!-- Non-empty text content. -->
+        <data type="string">
+          <param name="pattern">.*\S.*</param>
+        </data>
+      </element>
     </choice>
   </define>
 

--- a/include/swift/Markup/AST.h
+++ b/include/swift/Markup/AST.h
@@ -589,6 +589,32 @@ public:
   }
 };
 
+class Attribute final : public InlineContent, private llvm::TrailingObjects<Image, MarkupASTNode *> {
+  friend TrailingObjects;
+
+  size_t NumChildren;
+  StringRef Attributes;
+
+  Attribute(StringRef Attributes, ArrayRef<MarkupASTNode *> Children);
+
+public:
+  static Attribute *create(MarkupContext &MC, StringRef Attributes, ArrayRef<MarkupASTNode *> Children);
+
+  StringRef getAttributes() const { return Attributes; }
+
+  ArrayRef<MarkupASTNode *> getChildren() {
+    return {getTrailingObjects<MarkupASTNode *>(), NumChildren};
+  }
+
+  ArrayRef<const MarkupASTNode *> getChildren() const {
+    return {getTrailingObjects<MarkupASTNode *>(), NumChildren};
+  }
+
+  static bool classof(const MarkupASTNode *N) {
+    return N->getKind() == ASTNodeKind::Attribute;
+  }
+};
+
 #pragma mark Private Extensions
 
 class PrivateExtension : public MarkupASTNode {

--- a/include/swift/Markup/AST.h
+++ b/include/swift/Markup/AST.h
@@ -589,16 +589,20 @@ public:
   }
 };
 
-class Attribute final : public InlineContent, private llvm::TrailingObjects<Image, MarkupASTNode *> {
+class InlineAttributes final : public InlineContent, private llvm::TrailingObjects<Image, MarkupASTNode *> {
   friend TrailingObjects;
+
+  // Note that inline attributes are like links, in that there are child inline nodes that are
+  // collectively styled by the attribute text. The child nodes are the text that should be
+  // displayed.
 
   size_t NumChildren;
   StringRef Attributes;
 
-  Attribute(StringRef Attributes, ArrayRef<MarkupASTNode *> Children);
+  InlineAttributes(StringRef Attributes, ArrayRef<MarkupASTNode *> Children);
 
 public:
-  static Attribute *create(MarkupContext &MC, StringRef Attributes, ArrayRef<MarkupASTNode *> Children);
+  static InlineAttributes *create(MarkupContext &MC, StringRef Attributes, ArrayRef<MarkupASTNode *> Children);
 
   StringRef getAttributes() const { return Attributes; }
 
@@ -611,7 +615,7 @@ public:
   }
 
   static bool classof(const MarkupASTNode *N) {
-    return N->getKind() == ASTNodeKind::Attribute;
+    return N->getKind() == ASTNodeKind::InlineAttributes;
   }
 };
 

--- a/include/swift/Markup/ASTNodes.def
+++ b/include/swift/Markup/ASTNodes.def
@@ -40,8 +40,8 @@ ABSTRACT_MARKUP_AST_NODE(InlineContent, MarkupASTNode)
   MARKUP_AST_NODE(Strong, InlineContent)
   MARKUP_AST_NODE(Link, InlineContent)
   MARKUP_AST_NODE(Image, InlineContent)
-  MARKUP_AST_NODE(Attribute, InlineContent)
-MARKUP_AST_NODE_RANGE(Inline, Text, Attribute)
+  MARKUP_AST_NODE(InlineAttributes, InlineContent)
+MARKUP_AST_NODE_RANGE(Inline, Text, InlineAttributes)
 
 /// Private Markdown Extensions - these should not be implemented in the
 /// underlying cmark parser.

--- a/include/swift/Markup/ASTNodes.def
+++ b/include/swift/Markup/ASTNodes.def
@@ -40,7 +40,8 @@ ABSTRACT_MARKUP_AST_NODE(InlineContent, MarkupASTNode)
   MARKUP_AST_NODE(Strong, InlineContent)
   MARKUP_AST_NODE(Link, InlineContent)
   MARKUP_AST_NODE(Image, InlineContent)
-MARKUP_AST_NODE_RANGE(Inline, Text, Image)
+  MARKUP_AST_NODE(Attribute, InlineContent)
+MARKUP_AST_NODE_RANGE(Inline, Text, Attribute)
 
 /// Private Markdown Extensions - these should not be implemented in the
 /// underlying cmark parser.

--- a/lib/Frontend/PrintingDiagnosticConsumer.cpp
+++ b/lib/Frontend/PrintingDiagnosticConsumer.cpp
@@ -142,6 +142,15 @@ namespace {
         }
       }
 
+      void visitAttribute(const Attribute *A) {
+        print("^[");
+        for (const auto *Child : A->getChildren())
+          visit(Child);
+        print("](");
+        print(A->getAttributes());
+        print(")");
+      }
+
       void visitBlockQuote(const BlockQuote *BQ) {
         indent();
         printNewline();

--- a/lib/Frontend/PrintingDiagnosticConsumer.cpp
+++ b/lib/Frontend/PrintingDiagnosticConsumer.cpp
@@ -142,7 +142,7 @@ namespace {
         }
       }
 
-      void visitAttribute(const Attribute *A) {
+      void visitInlineAttributes(const InlineAttributes *A) {
         print("^[");
         for (const auto *Child : A->getChildren())
           visit(Child);

--- a/lib/IDE/CommentConversion.cpp
+++ b/lib/IDE/CommentConversion.cpp
@@ -72,6 +72,18 @@ struct CommentToXMLConverter {
     llvm_unreachable("Can't print a swift::markup::Document as XML directly");
   }
 
+  void printAttribute(const Attribute *A) {
+    OS << "<Attribute attributes=\"";
+    appendWithXMLEscaping(OS, A->getAttributes());
+    OS << "\">";
+
+    for (const auto *N : A->getChildren()) {
+      printASTNode(N);
+    }
+
+    OS << "</Attribute>";
+  }
+
   void printBlockQuote(const BlockQuote *BQ) {
     for (const auto *N : BQ->getChildren())
       printASTNode(N);
@@ -635,6 +647,12 @@ public:
 
   void visitDocument(const Document *D) {
     for (const auto *Child : D->getChildren())
+      visit(Child);
+  }
+
+  void visitAttribute(const Attribute *A) {
+    // attributed strings don't have an analogue in Doxygen, so just print out the text
+    for (const auto *Child : A->getChildren())
       visit(Child);
   }
 

--- a/lib/IDE/CommentConversion.cpp
+++ b/lib/IDE/CommentConversion.cpp
@@ -72,7 +72,7 @@ struct CommentToXMLConverter {
     llvm_unreachable("Can't print a swift::markup::Document as XML directly");
   }
 
-  void printAttribute(const Attribute *A) {
+  void printInlineAttributes(const InlineAttributes *A) {
     OS << "<Attribute attributes=\"";
     appendWithXMLEscaping(OS, A->getAttributes());
     OS << "\">";
@@ -650,7 +650,7 @@ public:
       visit(Child);
   }
 
-  void visitAttribute(const Attribute *A) {
+  void visitInlineAttributes(const InlineAttributes *A) {
     // attributed strings don't have an analogue in Doxygen, so just print out the text
     for (const auto *Child : A->getChildren())
       visit(Child);

--- a/lib/IDE/CommentConversion.cpp
+++ b/lib/IDE/CommentConversion.cpp
@@ -73,7 +73,7 @@ struct CommentToXMLConverter {
   }
 
   void printInlineAttributes(const InlineAttributes *A) {
-    OS << "<Attribute attributes=\"";
+    OS << "<InlineAttributes attributes=\"";
     appendWithXMLEscaping(OS, A->getAttributes());
     OS << "\">";
 
@@ -81,7 +81,7 @@ struct CommentToXMLConverter {
       printASTNode(N);
     }
 
-    OS << "</Attribute>";
+    OS << "</InlineAttributes>";
   }
 
   void printBlockQuote(const BlockQuote *BQ) {

--- a/lib/Markup/AST.cpp
+++ b/lib/Markup/AST.cpp
@@ -157,14 +157,14 @@ Paragraph *Paragraph::create(MarkupContext &MC,
   return new (Mem) Paragraph(Children);
 }
 
-Attribute::Attribute(StringRef Attributes, ArrayRef<MarkupASTNode *> Children) : InlineContent(ASTNodeKind::Attribute), NumChildren(Children.size()), Attributes(Attributes) {
+InlineAttributes::InlineAttributes(StringRef Attributes, ArrayRef<MarkupASTNode *> Children) : InlineContent(ASTNodeKind::InlineAttributes), NumChildren(Children.size()), Attributes(Attributes) {
   std::uninitialized_copy(Children.begin(), Children.end(), getTrailingObjects<MarkupASTNode *>());
 }
 
-Attribute *Attribute::create(MarkupContext &MC, StringRef Attributes, ArrayRef<MarkupASTNode *> Children) {
-  void *Mem = MC.allocate(totalSizeToAlloc<MarkupASTNode *>(Children.size()), alignof(Attribute));
+InlineAttributes *InlineAttributes::create(MarkupContext &MC, StringRef Attributes, ArrayRef<MarkupASTNode *> Children) {
+  void *Mem = MC.allocate(totalSizeToAlloc<MarkupASTNode *>(Children.size()), alignof(InlineAttributes));
   StringRef AttrsCopy = MC.allocateCopy(Attributes);
-  return new (Mem) Attribute(AttrsCopy, Children);
+  return new (Mem) InlineAttributes(AttrsCopy, Children);
 }
 
 HRule *HRule::create(MarkupContext &MC) {
@@ -418,8 +418,8 @@ void swift::markup::dump(const MarkupASTNode *Node, llvm::raw_ostream &OS,
     dumpChildren(Node->getChildren(), OS, indent + 1);
     break;
   }
-  case swift::markup::ASTNodeKind::Attribute: {
-    auto A = cast<Attribute>(Node);
+  case swift::markup::ASTNodeKind::InlineAttributes: {
+    auto A = cast<InlineAttributes>(Node);
     OS << "Attribute:";
     OS << " Attributes=" << A->getAttributes();
     OS << " Children=" << Node->getChildren().size();

--- a/lib/Markup/Markup.cpp
+++ b/lib/Markup/Markup.cpp
@@ -216,13 +216,13 @@ ParseResult<Link> parseLink(MarkupContext &MC, ParseState State) {
   return { Link::create(MC, Destination, Children), ResultState.next() };
 }
 
-ParseResult<Attribute> parseAttribute(MarkupContext &MC, ParseState State) {
+ParseResult<InlineAttributes> parseAttribute(MarkupContext &MC, ParseState State) {
   assert(cmark_node_get_type(State.Node) == CMARK_NODE_ATTRIBUTE && State.Event == CMARK_EVENT_ENTER);
   std::string Attributes(cmark_node_get_attributes(State.Node));
   SmallVector<MarkupASTNode *, 2> Children;
   auto ResultState = parseChildren(MC, State, Children);
   assert(State.Node == ResultState.Node && ResultState.Event == CMARK_EVENT_EXIT);
-  return { Attribute::create(MC, Attributes, Children), ResultState.next() };
+  return { InlineAttributes::create(MC, Attributes, Children), ResultState.next() };
 }
 
 ParseResult<List> parseList(MarkupContext &MC, ParseState State) {

--- a/lib/Markup/Markup.cpp
+++ b/lib/Markup/Markup.cpp
@@ -137,7 +137,7 @@ ParseResult<Strong> parseStrong(MarkupContext &MC, ParseState State) {
 }
 
 ParseResult<Header> parseHeader(MarkupContext &MC, ParseState State) {
-  assert(cmark_node_get_type(State.Node) == CMARK_NODE_HEADER
+  assert(cmark_node_get_type(State.Node) == CMARK_NODE_HEADING
       && State.Event == CMARK_EVENT_ENTER);
   auto Level = cmark_node_get_header_level(State.Node);
   SmallVector<MarkupASTNode *, 2> Children;
@@ -149,19 +149,19 @@ ParseResult<Header> parseHeader(MarkupContext &MC, ParseState State) {
 }
 
 ParseResult<HRule> parseHRule(MarkupContext &MC, ParseState State) {
-  assert(cmark_node_get_type(State.Node) == CMARK_NODE_HRULE
+  assert(cmark_node_get_type(State.Node) == CMARK_NODE_THEMATIC_BREAK
       && State.Event == CMARK_EVENT_ENTER);
   return { HRule::create(MC), State.next() };
 }
 
 ParseResult<HTML> parseHTML(MarkupContext &MC, ParseState State) {
-  assert(cmark_node_get_type(State.Node) == CMARK_NODE_HTML
+  assert(cmark_node_get_type(State.Node) == CMARK_NODE_HTML_BLOCK
       && State.Event == CMARK_EVENT_ENTER);
   return {HTML::create(MC, getLiteralContent(MC, State.Node)), State.next()};
 }
 
 ParseResult<InlineHTML> parseInlineHTML(MarkupContext &MC, ParseState State) {
-  assert(cmark_node_get_type(State.Node) == CMARK_NODE_INLINE_HTML
+  assert(cmark_node_get_type(State.Node) == CMARK_NODE_HTML_INLINE
       && State.Event == CMARK_EVENT_ENTER);
   return {InlineHTML::create(MC, getLiteralContent(MC, State.Node)),
           State.next()};
@@ -257,20 +257,17 @@ ParseResult<MarkupASTNode> parseElement(MarkupContext &MC, ParseState State) {
   case CMARK_NODE_EMPH: {
     return parseEmphasis(MC, State);
   }
-  case CMARK_NODE_HEADER: {
+  case CMARK_NODE_HEADING: {
     return parseHeader(MC, State);
   }
-  case CMARK_NODE_HRULE: {
-    return parseHRule(MC, State);
-  }
-  case CMARK_NODE_HTML: {
+  case CMARK_NODE_HTML_BLOCK: {
     return parseHTML(MC, State);
+  }
+  case CMARK_NODE_HTML_INLINE: {
+    return parseInlineHTML(MC, State);
   }
   case CMARK_NODE_IMAGE: {
     return parseImage(MC, State);
-  }
-  case CMARK_NODE_INLINE_HTML: {
-    return parseInlineHTML(MC, State);
   }
   case CMARK_NODE_ITEM: {
     return parseItem(MC, State);
@@ -295,6 +292,9 @@ ParseResult<MarkupASTNode> parseElement(MarkupContext &MC, ParseState State) {
   }
   case CMARK_NODE_TEXT: {
     return parseText(MC, State);
+  }
+  case CMARK_NODE_THEMATIC_BREAK: {
+    return parseHRule(MC, State);
   }
   default: {
     llvm_unreachable("Can't parse a Markup node of type 'None'");

--- a/test/Inputs/comment_to_something_conversion.swift
+++ b/test/Inputs/comment_to_something_conversion.swift
@@ -62,6 +62,15 @@ public enum A012_AttachToEntities {
 // CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>c:@M@comment_to_xml@objc(cs)ATXHeaders(im)f0</USR><Declaration>@objc public func f0()</Declaration><CommentParts><Discussion><rawHTML><![CDATA[<h1>]]></rawHTML>LEVEL ONE<rawHTML><![CDATA[</h1>]]></rawHTML><rawHTML><![CDATA[<h2>]]></rawHTML>LEVEL TWO<rawHTML><![CDATA[</h2>]]></rawHTML></Discussion></CommentParts></Function>]
 }
 
+@objc public class Attributes {
+// CHECK: {{.*}}DocCommentAsXML=none
+    /// Here is an attribute:
+    ///
+    /// ^[Attribute text](string: "attributed")
+    @objc public func f0() {}
+    // CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>c:@M@comment_to_xml@objc(cs)Attributes(im)f0</USR><Declaration>@objc public func f0()</Declaration><CommentParts><Abstract><Para>Here is an attribute:</Para></Abstract><Discussion><Para><Attribute attributes="string: &quot;attributed&quot;">Attribute text</Attribute></Para></Discussion></CommentParts></Function>]
+}
+
 @objc public class AutomaticLink {
 // CHECK: {{.*}}DocCommentAsXML=none
   /// And now for a URL.
@@ -196,6 +205,18 @@ public enum A012_AttachToEntities {
    */
   @objc public func f4() {}
 // CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f4()</Name><USR>c:@M@comment_to_xml@objc(cs)EmptyComments(im)f4</USR><Declaration>@objc public func f4()</Declaration><CommentParts><Abstract><Para>Aaa.</Para></Abstract></CommentParts></Function>]
+}
+
+@objc public class Footnotes {
+// CHECK: {{.*}}DocCommentAsXML=none
+    /// Has some footnotes.
+    ///
+    /// Footnotes aren't handled by swiftMarkup yet[^footnote], but they may in the future.
+    ///
+    /// [^footnote]: Footnotes aren't parsed by default in swift-cmark, and swiftMarkup doesn't
+    ///     enable the feature.
+    @objc public func f0() {}
+    // CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>c:@M@comment_to_xml@objc(cs)Footnotes(im)f0</USR><Declaration>@objc public func f0()</Declaration><CommentParts><Abstract><Para>Has some footnotes.</Para></Abstract><Discussion><Para>Footnotes aren’t handled by swiftMarkup yet[^footnote], but they may in the future.</Para><Para>[^footnote]: Footnotes aren’t parsed by default in swift-cmark, and swiftMarkup doesn’t enable the feature.</Para></Discussion></CommentParts></Function>]
 }
 
 @objc public class HasThrowingFunction {

--- a/test/Inputs/comment_to_something_conversion.swift
+++ b/test/Inputs/comment_to_something_conversion.swift
@@ -68,7 +68,7 @@ public enum A012_AttachToEntities {
     ///
     /// ^[Attribute text](string: "attributed")
     @objc public func f0() {}
-    // CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>c:@M@comment_to_xml@objc(cs)Attributes(im)f0</USR><Declaration>@objc public func f0()</Declaration><CommentParts><Abstract><Para>Here is an attribute:</Para></Abstract><Discussion><Para><Attribute attributes="string: &quot;attributed&quot;">Attribute text</Attribute></Para></Discussion></CommentParts></Function>]
+    // CHECK: {{.*}}DocCommentAsXML=[<Function file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>f0()</Name><USR>c:@M@comment_to_xml@objc(cs)Attributes(im)f0</USR><Declaration>@objc public func f0()</Declaration><CommentParts><Abstract><Para>Here is an attribute:</Para></Abstract><Discussion><Para><InlineAttributes attributes="string: &quot;attributed&quot;">Attribute text</InlineAttributes></Para></Discussion></CommentParts></Function>]
 }
 
 @objc public class AutomaticLink {

--- a/test/PrintAsObjC/Inputs/comments-expected-output.h
+++ b/test/PrintAsObjC/Inputs/comments-expected-output.h
@@ -32,6 +32,14 @@ SWIFT_CLASS("_TtC8comments10ATXHeaders")
 @end
 
 
+SWIFT_CLASS("_TtC8comments10Attributes")
+@interface Attributes
+/// Here is an attribute:
+/// Attribute text
+- (void)f0;
+@end
+
+
 SWIFT_CLASS("_TtC8comments13AutomaticLink")
 @interface AutomaticLink
 /// And now for a URL.
@@ -182,6 +190,16 @@ SWIFT_CLASS("_TtC8comments13EmptyComments")
 - (void)f3;
 /// Aaa.
 - (void)f4;
+@end
+
+
+SWIFT_CLASS("_TtC8comments9Footnotes")
+@interface Footnotes
+/// Has some footnotes.
+/// Footnotes aren’t handled by swiftMarkup yet[^footnote], but they may in the future.
+/// [^footnote]: Footnotes aren’t parsed by default in swift-cmark, and swiftMarkup doesn’t
+/// enable the feature.
+- (void)f0;
 @end
 
 


### PR DESCRIPTION
Resolves rdar://96830173

When the swift-cmark branch was changes from `main` to `gfm` in https://github.com/apple/swift/pull/40188, swiftMarkup was not updated to handle the new kinds of nodes that were introduced. This causes the compiler to crash when using swift-cmark's "inline attributes" (or Foundation's attributed strings, which use the same syntax). This PR updates swiftMarkup to handle inline attributes from swift-cmark.