### PR TITLE
[cxx-interop][SwiftCompilerSources] Use `llvm::StringRef` instead of `BridgedStringRef`

### DIFF
--- a/SwiftCompilerSources/Sources/AST/DiagnosticEngine.swift
+++ b/SwiftCompilerSources/Sources/AST/DiagnosticEngine.swift
@@ -21,7 +21,7 @@ public protocol DiagnosticArgument {
 }
 extension String: DiagnosticArgument {
   public func _withBridgedDiagnosticArgument(_ fn: (swift.DiagnosticArgument) -> Void) {
-    withBridgedStringRef { fn(swift.DiagnosticArgument(llvm.StringRef($0))) }
+    _withStringRef { fn(swift.DiagnosticArgument($0)) }
   }
 }
 extension Int: DiagnosticArgument {
@@ -42,10 +42,10 @@ public struct DiagnosticFixIt {
   }
 
   func withBridgedDiagnosticFixIt(_ fn: (swift.DiagnosticInfo.FixIt) -> Void) {
-    text.withBridgedStringRef { bridgedTextRef in
+    text._withStringRef { bridgedTextRef in
       let bridgedDiagnosticFixIt = swift.DiagnosticInfo.FixIt(
         swift.CharSourceRange(start.bridged, UInt32(byteLength)),
-        llvm.StringRef(bridgedTextRef),
+        bridgedTextRef,
         llvm.ArrayRef<swift.DiagnosticArgument>())
       fn(bridgedDiagnosticFixIt)
     }

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/PassContext.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/PassContext.swift
@@ -66,7 +66,7 @@ struct PassContext {
 
   func loadFunction(name: StaticString) -> Function? {
     return name.withUTF8Buffer { (nameBuffer: UnsafeBufferPointer<UInt8>) in
-      PassContext_loadFunction(_bridged, BridgedStringRef(data: nameBuffer.baseAddress, length: nameBuffer.count)).function
+      PassContext_loadFunction(_bridged, llvm.StringRef(nameBuffer.baseAddress, nameBuffer.count)).function
     }
   }
 

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
@@ -24,7 +24,7 @@ public func initializeSwiftModules() {
 private func registerPass(
       _ pass: FunctionPass,
       _ runFn: @escaping (@convention(c) (BridgedFunctionPassCtxt) -> ())) {
-  pass.name.withBridgedStringRef { nameStr in
+  pass.name._withStringRef { nameStr in
     SILPassManager_registerFunctionPass(nameStr, runFn)
   }
 }
@@ -32,7 +32,7 @@ private func registerPass(
 private func registerPass<InstType: Instruction>(
       _ pass: InstructionPass<InstType>,
       _ runFn: @escaping (@convention(c) (BridgedInstructionPassCtxt) -> ())) {
-  pass.name.withBridgedStringRef { nameStr in
+  pass.name._withStringRef { nameStr in
     SILCombine_registerInstructionPass(nameStr, runFn)
   }
 }

--- a/SwiftCompilerSources/Sources/SIL/Builder.swift
+++ b/SwiftCompilerSources/Sources/SIL/Builder.swift
@@ -61,7 +61,7 @@ public struct Builder {
       operandType: Type, resultType: Type, arguments: [Value]) -> BuiltinInst {
     notifyInstructionsChanged()
     return arguments.withBridgedValues { valuesRef in
-      return name.withBridgedStringRef { nameStr in
+      return name._withStringRef { nameStr in
         let bi = SILBuilder_createBuiltinBinaryFunction(
           bridged, nameStr, operandType.bridged, resultType.bridged, valuesRef)
         return bi.getAs(BuiltinInst.self)
@@ -71,7 +71,7 @@ public struct Builder {
 
   public func createCondFail(condition: Value, message: String) -> CondFailInst {
     notifyInstructionsChanged()
-    return message.withBridgedStringRef { messageStr in
+    return message._withStringRef { messageStr in
       let cf = SILBuilder_createCondFail(bridged, condition.bridged, messageStr)
       return cf.getAs(CondFailInst.self)
     }

--- a/SwiftCompilerSources/Sources/SIL/Function.swift
+++ b/SwiftCompilerSources/Sources/SIL/Function.swift
@@ -67,7 +67,7 @@ final public class Function : CustomStringConvertible, HasShortDescription {
 
   public func hasSemanticsAttribute(_ attr: StaticString) -> Bool {
     attr.withUTF8Buffer { (buffer: UnsafeBufferPointer<UInt8>) in
-      SILFunction_hasSemanticsAttr(bridged, BridgedStringRef(data: buffer.baseAddress!, length: buffer.count)) != 0
+      SILFunction_hasSemanticsAttr(bridged, llvm.StringRef(buffer.baseAddress!, buffer.count)) != 0
     }
   }
 
@@ -105,18 +105,18 @@ final public class Function : CustomStringConvertible, HasShortDescription {
       // writeFn
       { (f: BridgedFunction, os: BridgedOStream, idx: Int) in
         let s = f.function.effects.argumentEffects[idx].description
-        s.withBridgedStringRef { OStream_write(os, $0) }
+        s._withStringRef { OStream_write(os, $0) }
       },
       // parseFn:
-      { (f: BridgedFunction, str: BridgedStringRef, fromSIL: Int, isDerived: Int, paramNames: BridgedArrayRef) -> BridgedParsingError in
+      { (f: BridgedFunction, str: llvm.StringRef, fromSIL: Int, isDerived: Int, paramNames: BridgedArrayRef) -> BridgedParsingError in
         do {
           var parser = StringParser(str.string)
           let effect: ArgumentEffect
           if fromSIL != 0 {
             effect = try parser.parseEffectFromSIL(for: f.function, isDerived: isDerived != 0)
           } else {
-            let paramToIdx = paramNames.withElements(ofType: BridgedStringRef.self) {
-                (buffer: UnsafeBufferPointer<BridgedStringRef>) -> Dictionary<String, Int> in
+            let paramToIdx = paramNames.withElements(ofType: llvm.StringRef.self) {
+                (buffer: UnsafeBufferPointer<llvm.StringRef>) -> Dictionary<String, Int> in
               let keyValPairs = buffer.enumerated().lazy.map { ($0.1.string, $0.0) }
               return Dictionary(uniqueKeysWithValues: keyValPairs)
             }

--- a/SwiftCompilerSources/Sources/SIL/Registration.swift
+++ b/SwiftCompilerSources/Sources/SIL/Registration.swift
@@ -14,7 +14,7 @@ import Basic
 import SILBridging
 
 private func register<T: AnyObject>(_ cl: T.Type) {
-  String(describing: cl).withBridgedStringRef { nameStr in
+  String(describing: cl)._withStringRef { nameStr in
     let metatype = unsafeBitCast(cl, to: SwiftMetatype.self)
     registerBridgedClass(nameStr, metatype)
   }

--- a/SwiftCompilerSources/Sources/SIL/Type.swift
+++ b/SwiftCompilerSources/Sources/SIL/Type.swift
@@ -44,7 +44,7 @@ public struct Type : CustomStringConvertible, CustomReflectable {
   }
 
   public func getIndexOfEnumCase(withName name: String) -> Int? {
-    let idx = name.withBridgedStringRef {
+    let idx = name._withStringRef {
       SILType_getCaseIdxOfEnumType(bridged, $0)
     }
     return idx >= 0 ? idx : nil
@@ -75,7 +75,7 @@ public struct NominalFieldsArray : RandomAccessCollection, FormattedLikeArray {
   }
 
   public func getIndexOfField(withName name: String) -> Int? {
-    let idx = name.withBridgedStringRef {
+    let idx = name._withStringRef {
       SILType_getFieldIdxOfNominalType(type.bridged, $0)
     }
     return idx >= 0 ? idx : nil

--- a/include/swift/Basic/BasicBridging.h
+++ b/include/swift/Basic/BasicBridging.h
@@ -23,11 +23,6 @@ typedef intptr_t SwiftInt;
 typedef uintptr_t SwiftUInt;
 
 typedef struct {
-  const unsigned char * _Nullable data;
-  size_t length;
-} BridgedStringRef;
-
-typedef struct {
   const void * _Nullable data;
   size_t numElements;
 } BridgedArrayRef;
@@ -36,9 +31,7 @@ typedef struct {
   void * _Nonnull streamAddr;
 } BridgedOStream;
 
-void OStream_write(BridgedOStream os, BridgedStringRef str);
-
-void freeBridgedStringRef(BridgedStringRef str);
+void OStream_write(BridgedOStream os, llvm::StringRef str);
 
 SWIFT_END_NULLABILITY_ANNOTATIONS
 

--- a/include/swift/Basic/BridgingUtils.h
+++ b/include/swift/Basic/BridgingUtils.h
@@ -23,14 +23,6 @@
 
 namespace swift {
 
-inline BridgedStringRef getBridgedStringRef(llvm::StringRef str) {
-  return {(const unsigned char *)str.data(), str.size()};
-}
-
-inline llvm::StringRef getStringRef(BridgedStringRef str) {
-  return llvm::StringRef((const char *)str.data, str.length);
-}
-
 template <typename T>
 inline llvm::ArrayRef<T> getArrayRef(BridgedArrayRef bridged) {
   return {static_cast<const T *>(bridged.data), bridged.numElements};

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -176,15 +176,17 @@ enum {
   EffectsFlagDerived = 0x2
 };
 
-void registerBridgedClass(BridgedStringRef className, SwiftMetatype metatype);
+void registerBridgedClass(llvm::StringRef className, SwiftMetatype metatype);
 
 typedef void (* _Nonnull FunctionRegisterFn)(BridgedFunction f,
                                         void * _Nonnull data,
                                         SwiftInt size);
 typedef void (* _Nonnull FunctionWriteFn)(BridgedFunction,
                                           BridgedOStream, SwiftInt);
-typedef BridgedParsingError (* _Nonnull FunctionParseFn)(BridgedFunction,
-                         BridgedStringRef, SwiftInt, SwiftInt, BridgedArrayRef);
+typedef BridgedParsingError (*_Nonnull FunctionParseFn)(BridgedFunction,
+                                                        llvm::StringRef,
+                                                        SwiftInt, SwiftInt,
+                                                        BridgedArrayRef);
 typedef SwiftInt (* _Nonnull FunctionCopyEffectsFn)(BridgedFunction,
                                                     BridgedFunction);
 typedef SwiftInt (* _Nonnull FunctionGetEffectFlagsFn)(BridgedFunction, SwiftInt);
@@ -203,7 +205,7 @@ BridgedBasicBlock PassContext_splitBlock(BridgedInstruction bridgedInst);
 void PassContext_eraseInstruction(BridgedPassContext passContext,
                                   BridgedInstruction inst);
 
-BridgedStringRef SILFunction_getName(BridgedFunction function);
+llvm::StringRef SILFunction_getName(BridgedFunction function);
 std::string SILFunction_debugDescription(BridgedFunction function);
 SwiftInt SILFunction_hasOwnership(BridgedFunction function);
 OptionalBridgedBasicBlock SILFunction_firstBlock(BridgedFunction function);
@@ -215,9 +217,9 @@ BridgedType SILFunction_getSILArgumentType(BridgedFunction function, SwiftInt id
 BridgedType SILFunction_getSILResultType(BridgedFunction function);
 SwiftInt SILFunction_isSwift51RuntimeAvailable(BridgedFunction function);
 SwiftInt SILFunction_hasSemanticsAttr(BridgedFunction function,
-                                      BridgedStringRef attrName);
+                                      llvm::StringRef attrName);
 
-BridgedStringRef SILGlobalVariable_getName(BridgedGlobalVar global);
+llvm::StringRef SILGlobalVariable_getName(BridgedGlobalVar global);
 std::string SILGlobalVariable_debugDescription(BridgedGlobalVar global);
 
 OptionalBridgedBasicBlock SILBasicBlock_next(BridgedBasicBlock block);
@@ -263,9 +265,9 @@ SwiftInt SILType_getNumNominalFields(BridgedType type);
 BridgedType SILType_getNominalFieldType(BridgedType type, SwiftInt index,
                                         BridgedFunction function);
 SwiftInt SILType_getFieldIdxOfNominalType(BridgedType type,
-                                          BridgedStringRef fieldName);
+                                          llvm::StringRef fieldName);
 SwiftInt SILType_getCaseIdxOfEnumType(BridgedType type,
-                                      BridgedStringRef caseName);
+                                      llvm::StringRef caseName);
 
 BridgedSubstitutionMap SubstitutionMap_getEmpty();
 
@@ -290,11 +292,11 @@ BridgedMultiValueResult
 
 BridgedArrayRef TermInst_getSuccessors(BridgedInstruction term);
 
-BridgedStringRef CondFailInst_getMessage(BridgedInstruction cfi);
+llvm::StringRef CondFailInst_getMessage(BridgedInstruction cfi);
 BridgedBuiltinID BuiltinInst_getID(BridgedInstruction bi);
 BridgedGlobalVar GlobalAccessInst_getGlobal(BridgedInstruction globalInst);
 BridgedFunction FunctionRefInst_getReferencedFunction(BridgedInstruction fri);
-BridgedStringRef StringLiteralInst_getValue(BridgedInstruction sli);
+llvm::StringRef StringLiteralInst_getValue(BridgedInstruction sli);
 SwiftInt TupleExtractInst_fieldIndex(BridgedInstruction tei);
 SwiftInt TupleElementAddrInst_fieldIndex(BridgedInstruction teai);
 SwiftInt StructExtractInst_fieldIndex(BridgedInstruction sei);
@@ -331,11 +333,11 @@ ApplySite_getArgumentConvention(BridgedInstruction inst, SwiftInt calleeArgIdx);
 SwiftInt ApplySite_getNumArguments(BridgedInstruction inst);
 
 BridgedInstruction SILBuilder_createBuiltinBinaryFunction(
-          BridgedBuilder builder, BridgedStringRef name,
+          BridgedBuilder builder, llvm::StringRef name,
           BridgedType operandType, BridgedType resultType,
           BridgedValueArray arguments);
 BridgedInstruction SILBuilder_createCondFail(BridgedBuilder builder,
-          BridgedValue condition, BridgedStringRef message);
+          BridgedValue condition, llvm::StringRef message);
 BridgedInstruction SILBuilder_createIntegerLiteral(BridgedBuilder builder,
           BridgedType type, SwiftInt value);
 BridgedInstruction SILBuilder_createDeallocStackRef(BridgedBuilder builder,

--- a/include/swift/SILOptimizer/OptimizerBridging.h
+++ b/include/swift/SILOptimizer/OptimizerBridging.h
@@ -17,10 +17,6 @@
 
 SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 typedef struct {
   BridgedFunction function;
   BridgedPassContext passContext;
@@ -84,10 +80,10 @@ typedef struct {
 typedef void (* _Nonnull BridgedFunctionPassRunFn)(BridgedFunctionPassCtxt);
 typedef void (* _Nonnull BridgedInstructionPassRunFn)(BridgedInstructionPassCtxt);
 
-void SILPassManager_registerFunctionPass(BridgedStringRef name,
+void SILPassManager_registerFunctionPass(llvm::StringRef name,
                                          BridgedFunctionPassRunFn runFn);
 
-void SILCombine_registerInstructionPass(BridgedStringRef name,
+void SILCombine_registerInstructionPass(llvm::StringRef name,
                                         BridgedInstructionPassRunFn runFn);
 
 BridgedAliasAnalysis PassContext_getAliasAnalysis(BridgedPassContext context);
@@ -161,11 +157,7 @@ PassContext_getContextSubstitutionMap(BridgedPassContext context,
                                       BridgedType bridgedType);
 
 OptionalBridgedFunction
-PassContext_loadFunction(BridgedPassContext context, BridgedStringRef name);
-
-#ifdef __cplusplus
-} // extern "C"
-#endif
+PassContext_loadFunction(BridgedPassContext context, llvm::StringRef name);
 
 SWIFT_END_NULLABILITY_ANNOTATIONS
 

--- a/include/swift/module.modulemap
+++ b/include/swift/module.modulemap
@@ -14,6 +14,7 @@ module ASTBridging {
 
 module SILBridging {
   header "SIL/SILBridging.h"
+  requires cplusplus
   export *
 }
 

--- a/lib/Basic/BasicBridging.cpp
+++ b/lib/Basic/BasicBridging.cpp
@@ -19,7 +19,7 @@ using namespace swift;
 //                            Bridging C functions
 //===----------------------------------------------------------------------===//
 
-void OStream_write(BridgedOStream os, BridgedStringRef str) {
+void OStream_write(BridgedOStream os, StringRef str) {
   static_cast<raw_ostream *>(os.streamAddr)
-      ->write((const char *)(str.data), str.length);
+      ->write(str.data(), str.size());
 }

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -829,12 +829,9 @@ std::pair<const char *, int> SILFunction::
 parseEffects(StringRef attrs, bool fromSIL, bool isDerived,
              ArrayRef<StringRef> paramNames) {
   if (parseFunction) {
-    static_assert(sizeof(BridgedStringRef) == sizeof(StringRef),
-                  "relying on StringRef layout compatibility");
-    BridgedParsingError error =
-      parseFunction({this}, getBridgedStringRef(attrs), (SwiftInt)fromSIL,
-                (SwiftInt) isDerived,
-                {(const unsigned char *)paramNames.data(), paramNames.size()});
+    BridgedParsingError error = parseFunction(
+        {this}, attrs, (SwiftInt)fromSIL, (SwiftInt)isDerived,
+        {(const unsigned char *)paramNames.data(), paramNames.size()});
     return {(const char *)error.message, (int)error.position};
   }
   return {nullptr, 0};

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -1486,9 +1486,8 @@ PassContext_getContextSubstitutionMap(BridgedPassContext context,
 }
 
 OptionalBridgedFunction
-PassContext_loadFunction(BridgedPassContext context, BridgedStringRef name) {
+PassContext_loadFunction(BridgedPassContext context, StringRef name) {
   SILModule *mod = castToPassInvocation(context)->getPassManager()->getModule();
-  SILFunction *f = mod->loadFunction(getStringRef(name),
-                                     SILModule::LinkingMode::LinkNormal);
+  SILFunction *f = mod->loadFunction(name, SILModule::LinkingMode::LinkNormal);
   return {f};
 }

--- a/lib/SILOptimizer/PassManager/Passes.cpp
+++ b/lib/SILOptimizer/PassManager/Passes.cpp
@@ -245,9 +245,9 @@ static void runBridgedFunctionPass(BridgedFunctionPassRunFn &runFunction,
 }
 
 // Called from initializeSwiftModules().
-void SILPassManager_registerFunctionPass(BridgedStringRef name,
+void SILPassManager_registerFunctionPass(llvm::StringRef name,
                                          BridgedFunctionPassRunFn runFn) {
-  bridgedPassRunFunctions[getStringRef(name)] = runFn;
+  bridgedPassRunFunctions[name] = runFn;
   passesRegistered = true;
 }
 

--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -536,9 +536,9 @@ static llvm::StringMap<BridgedInstructionPassRunFn> swiftInstPasses;
 static bool passesRegistered = false;
 
 // Called from initializeSwiftModules().
-void SILCombine_registerInstructionPass(BridgedStringRef name,
+void SILCombine_registerInstructionPass(llvm::StringRef name,
                                         BridgedInstructionPassRunFn runFn) {
-  swiftInstPasses[getStringRef(name)] = runFn;
+  swiftInstPasses[name] = runFn;
   passesRegistered = true;
 }
 


### PR DESCRIPTION
rdar://83361000