### PR TITLE
Using `--enable-experimental-feature` requires an asserts-enabled compiler

### DIFF
--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -2,6 +2,8 @@
 
 // REQUIRES: objc_interop
 // REQUIRES: concurrency
+// REQUIRES: asserts
+
 import Foundation
 import ObjCConcurrency
 // expected-remark@-1{{add '@preconcurrency' to suppress 'Sendable'-related warnings from module 'ObjCConcurrency'}}

--- a/test/Concurrency/objc_async_overload.swift
+++ b/test/Concurrency/objc_async_overload.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk)  -disable-availability-checking -typecheck -verify -import-objc-header %S/Inputs/Delegate.h -enable-experimental-feature SendableCompletionHandlers %s
 // REQUIRES: concurrency
 // REQUIRES: objc_interop
-
+// REQUIRES: asserts
 
 // overload resolution should pick sync version in a sync context
 func syncContext() {

--- a/test/IDE/print_clang_objc_async.swift
+++ b/test/IDE/print_clang_objc_async.swift
@@ -5,6 +5,7 @@
 
 // REQUIRES: objc_interop
 // REQUIRES: concurrency
+// REQUIRES: asserts
 import _Concurrency
 
 // CHECK-LABEL: class SlowServer : NSObject, ServiceProvider {

--- a/test/IDE/print_clang_objc_effectful_properties.swift
+++ b/test/IDE/print_clang_objc_effectful_properties.swift
@@ -5,6 +5,7 @@
 
 // REQUIRES: concurrency
 // REQUIRES: objc_interop
+// REQUIRES: asserts
 
 // CHECK-LABEL: class EffProps : NSObject {
 // CHECK:       @available(*, renamed: "getter:doggo()")

--- a/test/IDE/print_objc_concurrency_interface.swift
+++ b/test/IDE/print_objc_concurrency_interface.swift
@@ -7,6 +7,7 @@
 
 // REQUIRES: objc_interop
 // REQUIRES: concurrency
+// REQUIRES: asserts
 import _Concurrency
 
 // CHECK-LABEL: class SlowServer : NSObject, ServiceProvider {

--- a/test/IDE/print_omit_needless_words.swift
+++ b/test/IDE/print_omit_needless_words.swift
@@ -3,6 +3,7 @@
 // REQUIRES: objc_interop
 // FIXME: this is failing on simulators
 // REQUIRES: OS=macosx
+// REQUIRES: asserts
 
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift -disable-objc-attr-requires-foundation-module -enable-experimental-feature SendableCompletionHandlers
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift -enable-experimental-feature SendableCompletionHandlers

--- a/test/SourceKit/DocSupport/doc_objc_concurrency.swift
+++ b/test/SourceKit/DocSupport/doc_objc_concurrency.swift
@@ -1,5 +1,6 @@
 // REQUIRES: objc_interop
 // REQUIRES: concurrency
+// REQUIRES: asserts
 
 // RUN: %empty-directory(%t)
 

--- a/test/SourceKit/InterfaceGen/gen_objc_concurrency.swift
+++ b/test/SourceKit/InterfaceGen/gen_objc_concurrency.swift
@@ -1,5 +1,6 @@
 // REQUIRES: objc_interop
 // REQUIRES: concurrency
+// REQUIRES: asserts
 
 // RUN: %empty-directory(%t)
 


### PR DESCRIPTION
Fixes rdar://97281993.
