### PR TITLE
[Sema] Downgrade the redundant conformance error to a warning for conformances originally stated in CoreGraphics.

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -6563,7 +6563,8 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
     if (existingModule != dc->getParentModule() &&
         (existingModule->getName() ==
            extendedNominal->getParentModule()->getName() ||
-         existingModule == diag.Protocol->getParentModule())) {
+         existingModule == diag.Protocol->getParentModule() ||
+         existingModule->getName().is("CoreGraphics"))) {
       // Warn about the conformance.
       auto diagID = differentlyConditional
                         ? diag::redundant_conformance_adhoc_conditional

--- a/test/ClangImporter/import-cgfloat-api.swift
+++ b/test/ClangImporter/import-cgfloat-api.swift
@@ -17,3 +17,6 @@ func test() -> UnsafeMutablePointer<CGFloat>? {
     return CGColorGetComponents(color)
 }
 
+// Allow redundant conformances on CoreFoundation
+// types where the conformance is in CoreGraphics.
+extension CGFloat: CustomStringConvertible {}

--- a/test/Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
@@ -52,3 +52,9 @@ public extension Double {
   }
 }
 #endif
+
+import CoreFoundation
+
+extension CGFloat: CustomStringConvertible {
+  public var description: String { "" }
+}

--- a/test/PrintAsObjC/bridged-known-types-cf-cgfloat.swift
+++ b/test/PrintAsObjC/bridged-known-types-cf-cgfloat.swift
@@ -10,7 +10,7 @@
 // RUN: %target-swift-frontend -typecheck %s -parse-as-library -emit-objc-header-path %t/swift.h
 // RUN: %FileCheck %s < %t/swift.h
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -DCGFLOAT_IN_COREFOUNDATION -emit-module -o %t %clang-importer-sdk-path/swift-modules/CoreFoundation.swift
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource) -DCGFLOAT_IN_COREFOUNDATION -emit-module -o %t %clang-importer-sdk-path/swift-modules/CoreGraphics.swift
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -DCGFLOAT_IN_COREFOUNDATION -emit-module -o %t %clang-importer-sdk-path/swift-modules/CoreGraphics.swift
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift
 
 // REQUIRES: objc_interop


### PR DESCRIPTION
Now that [CoreFoundation is allowed to declare `CGFloat`](https://github.com/apple/swift/pull/40001) and friends, we need to adjust the redundant conformance heuristic to allow redundant conformances when the existing conformance is in CoreGraphics.

Resolves: rdar://95376632