### PR TITLE
[ConstraintSystem] Adjust locator for implicit conversions between tu…

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -452,6 +452,18 @@ ConstraintLocator *ConstraintSystem::getImplicitValueConversionLocator(
       anchor = ASTNode();
       path.clear();
     }
+
+    // If conversion is for a tuple element, let's drop `TupleType`
+    // components from the path since they carry information for
+    // diagnostics that `ExprRewriter` won't be able to re-construct
+    // during solution application.
+    if (!path.empty() && path.back().is<LocatorPathElt::TupleElement>()) {
+      path.erase(llvm::remove_if(path,
+                                 [](const LocatorPathElt &elt) {
+                                   return elt.is<LocatorPathElt::TupleType>();
+                                 }),
+                 path.end());
+    }
   }
 
   return getConstraintLocator(/*base=*/getConstraintLocator(anchor, path),

--- a/test/Constraints/implicit_double_cgfloat_conversion.swift
+++ b/test/Constraints/implicit_double_cgfloat_conversion.swift
@@ -280,3 +280,8 @@ func assignment_with_leading_dot_syntax() {
     }()
   }
 }
+
+func test_conversion_inside_tuple_elements() -> (a: CGFloat, b: (c: Int, d: CGFloat)) {
+  let x: Double = 0.0
+  return (a: x, b: (c: 42, d: x)) // Ok
+}


### PR DESCRIPTION
…ple elements

Drop `TupleType` element which is only used for diagnostics and
cannot be re-created by `ExprRewriter` during solution application.

Resolves: rdar://97389698


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
