### PR TITLE
[5.7] Sema: Allow explicitly available overrides to be as available as their context

### DIFF
--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1714,7 +1714,15 @@ static bool isAvailabilitySafeForOverride(ValueDecl *override,
   AvailabilityContext baseInfo =
     AvailabilityInference::availableRange(base, ctx);
 
-  return baseInfo.isContainedIn(overrideInfo);
+  if (baseInfo.isContainedIn(overrideInfo))
+    return true;
+
+  // Allow overrides that are not as available as the base decl as long as the
+  // override is as available as its context.
+  auto overrideTypeAvailability = AvailabilityInference::inferForType(
+      override->getDeclContext()->getSelfTypeInContext());
+  
+  return overrideTypeAvailability.isContainedIn(overrideInfo);
 }
 
 /// Returns true if a diagnostic about an accessor being less available

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -839,6 +839,26 @@ class SubWithLimitedMemberAvailability : SuperWithAlwaysAvailableMembers {
   }
 }
 
+@available(OSX, introduced: 10.51)
+class SubWithLimitedAvailablility : SuperWithAlwaysAvailableMembers {
+  override func shouldAlwaysBeAvailableMethod() {}
+  
+  override var shouldAlwaysBeAvailableProperty: Int {
+    get { return 10 }
+    set(newVal) {}
+  }
+  
+  override var setterShouldAlwaysBeAvailableProperty: Int {
+    get { return 9 }
+    set(newVal) {}
+  }
+
+  override var getterShouldAlwaysBeAvailableProperty: Int {
+    get { return 9 }
+    set(newVal) {}
+  }
+}
+
 class SuperWithLimitedMemberAvailability {
   @available(OSX, introduced: 10.51)
   func someMethod() {
@@ -876,6 +896,44 @@ class SubWithLargerMemberAvailability : SuperWithLimitedMemberAvailability {
       return 9
       }
     set(newVal) {}
+  }
+}
+
+@available(OSX, introduced: 10.51)
+class SubWithLimitedAvailability : SuperWithLimitedMemberAvailability {
+  override func someMethod() {
+    super.someMethod()
+  }
+  
+  override var someProperty: Int {
+    get { super.someProperty }
+    set(newVal) { super.someProperty = newVal }
+  }
+}
+
+@available(OSX, introduced: 10.52)
+class SubWithMoreLimitedAvailability : SuperWithLimitedMemberAvailability {
+  override func someMethod() {
+    super.someMethod()
+  }
+  
+  override var someProperty: Int {
+    get { super.someProperty }
+    set(newVal) { super.someProperty = newVal }
+  }
+}
+
+@available(OSX, introduced: 10.52)
+class SubWithMoreLimitedAvailabilityAndRedundantMemberAvailability : SuperWithLimitedMemberAvailability {
+  @available(OSX, introduced: 10.52)
+  override func someMethod() {
+    super.someMethod()
+  }
+  
+  @available(OSX, introduced: 10.52)
+  override var someProperty: Int {
+    get { super.someProperty }
+    set(newVal) { super.someProperty = newVal }
   }
 }
 


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/59857

Previously, the following test case produced an erroneous diagnostic:

```
class A {
  init() {}
}

@available(macOS 12, *)
class B: A {
  @available(macOS 12, *)
  override init() { // error: overriding 'init' must be as available as declaration it overrides
    super.init()
  }
}
```

The overridden `init()` constructor is as available as it can possibly be. Removing the explicit `@available` annotation suppressed the diagnostic.

To fix this, we check to see if the override is as available as its self type and accept it if it is.

You may be wondering how this works when the `@available` annotation is removed from `override init()` in the example. It turns out that `AvailabilityInference::availableRange()` returns a result that is based only on the explicit availability of the decl in question without taking the availability of the context into account (except when the context is an extension). So with the explicit annotation gone, both the base `init()` and the override are both considered to be "always" available. This is pretty unintuitive and arguably wrong. However, it seems like a lot of existing code depends on this behavior so I've left it for now.

Resolves rdar://96253347 and rdar://96235590.
