### PR TITLE
[5.7][Sema] Downgrade the redundant conformance error to a warning for conformances originally stated in CoreGraphics.

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -6504,7 +6504,8 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
     if (existingModule != dc->getParentModule() &&
         (existingModule->getName() ==
            extendedNominal->getParentModule()->getName() ||
-         existingModule == diag.Protocol->getParentModule())) {
+         existingModule == diag.Protocol->getParentModule() ||
+         existingModule->getName().is("CoreGraphics"))) {
       // Warn about the conformance.
       auto diagID = differentlyConditional
                         ? diag::redundant_conformance_adhoc_conditional

--- a/test/ClangImporter/import-cgfloat-api.swift
+++ b/test/ClangImporter/import-cgfloat-api.swift
@@ -17,3 +17,6 @@ func test() -> UnsafeMutablePointer<CGFloat>? {
     return CGColorGetComponents(color)
 }
 
+// Allow redundant conformances on CoreFoundation
+// types where the conformance is in CoreGraphics.
+extension CGFloat: CustomStringConvertible {}

--- a/test/Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
@@ -52,3 +52,9 @@ public extension Double {
   }
 }
 #endif
+
+import CoreFoundation
+
+extension CGFloat: CustomStringConvertible {
+  public var description: String { "" }
+}

--- a/test/PrintAsObjC/bridged-known-types-cf-cgfloat.swift
+++ b/test/PrintAsObjC/bridged-known-types-cf-cgfloat.swift
@@ -10,7 +10,7 @@
 // RUN: %target-swift-frontend -typecheck %s -parse-as-library -emit-objc-header-path %t/swift.h
 // RUN: %FileCheck %s < %t/swift.h
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -DCGFLOAT_IN_COREFOUNDATION -emit-module -o %t %clang-importer-sdk-path/swift-modules/CoreFoundation.swift
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource) -DCGFLOAT_IN_COREFOUNDATION -emit-module -o %t %clang-importer-sdk-path/swift-modules/CoreGraphics.swift
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -DCGFLOAT_IN_COREFOUNDATION -emit-module -o %t %clang-importer-sdk-path/swift-modules/CoreGraphics.swift
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift
 
 // REQUIRES: objc_interop


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/60181 ~~(without the test until I can figure out how to change the fake CoreGraphics module without breaking other tests)~~ fixed the test!

* **Explanation**: In Swift 5.7, [CoreFoundation is allowed to declare `CGFloat`](https://github.com/apple/swift/pull/40001) and other CG types. However, this turned out to be source breaking due to a heuristic that downgrades the redundant conformance error to a warning when the type and the original conformance come from the same module. If CoreFoundation declares `CGFloat` and CoreGraphics defines a conformance on `CGFloat`, restating that conformance now becomes an error instead of a warning. This change always downgrades the error to a warning when the conformance comes from CoreGraphics.
* **Scope**: This only affects redundant conformances that are stated in CoreGraphics.
* **Risk**: Very low.
* **Testing**: Manual.
* **Reviewer**: @salinas-miguel

Resolves: rdar://95376632