### PR TITLE
🍒[5.7][IRGen/Distributed] Adjust protocol requirement and witness table to handle distributed thunks

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -913,6 +913,10 @@ namespace {
         if (entry.getFunction().isAutoDiffDerivativeFunction())
           declRef = declRef.asAutoDiffDerivativeFunction(
               entry.getFunction().getAutoDiffDerivativeFunctionIdentifier());
+        if (entry.getFunction().isDistributedThunk()) {
+          flags = flags.withIsAsync(true);
+          declRef = declRef.asDistributed();
+        }
         addDiscriminator(flags, schema, declRef);
       }
 

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_through_generic.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_through_generic.swift
@@ -7,9 +7,6 @@
 // REQUIRES: concurrency
 // REQUIRES: distributed
 
-// FIXME: rdar://96520492 Test fails on specific config: Tools Opt+Assert, Stdlib Opt+DebInfo+Assert, iOS_arm64e
-// UNSUPPORTED: CPU=arm64e
-
 // rdar://76038845
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_through_generic_and_inner.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_through_generic_and_inner.swift
@@ -11,9 +11,6 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-// FIXME: rdar://96520224 Test fails on specific config: Tools Opt+Assert, Stdlib Opt+DebInfo+Assert, iOS_arm64e
-// UNSUPPORTED: CPU=arm64e
-
 // FIXME(distributed): Distributed actors currently have some issues on windows, isRemote always returns false. rdar://82593574
 // UNSUPPORTED: OS=windows-msvc
 


### PR DESCRIPTION
**Description:** Pointer authentication would fail on arm64e for distributed method witnesses where the requirement. This PR makes the necessary changes for the verification to look at the right discriminators.

- Determine whether protocol requirement is async using SILDeclRef

This is necessary because SILDeclRef of the distributed thunk witness is anchored
on the requirement declaration which might not be async, but the witness itself is
always async throws.

- Mark protocol requirement descriptor for distributed thunk as async

Fixes a bug where descriptor for protocol requirement associated with
distributed thunk wasn't marked as async that results in ptrauth failures
because discriminator would be misaligned between requirement and witness.


**Risk:** Low, only fixes pointer auth for distributed protocol requirements and actors
**Review by:** @DougGregor @tkremenek 
**Testing:** PR Testing, validated on arm64e 
**Original PR:**  https://github.com/apple/swift/pull/60184
**Radar:** rdar://97228310 rdar://96520492 