### PR TITLE
[SourceKit] Register await as a contextual keyword

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -413,6 +413,7 @@ ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
       diagnose(Tok.getLoc(), diag::expected_await_not_async)
         .fixItReplace(Tok.getLoc(), "await");
     }
+    Tok.setKind(tok::contextual_keyword);
     SourceLoc awaitLoc = consumeToken();
     ParserResult<Expr> sub =
       parseExprSequenceElement(diag::expected_expr_after_await, isExprBasic);

--- a/test/SourceKit/SyntaxMapData/await.swift
+++ b/test/SourceKit/SyntaxMapData/await.swift
@@ -1,0 +1,7 @@
+// RUN: %sourcekitd-test -req=syntax-map %s > %t.response
+// RUN: %diff -u %s.response %t.response
+
+func foo() async {}
+func test() async {
+  await foo()
+}

--- a/test/SourceKit/SyntaxMapData/await.swift.response
+++ b/test/SourceKit/SyntaxMapData/await.swift.response
@@ -1,0 +1,57 @@
+{
+  key.offset: 0,
+  key.length: 156,
+  key.diagnostic_stage: source.diagnostic.stage.swift.parse,
+  key.syntaxmap: [
+    {
+      key.kind: source.lang.swift.syntaxtype.comment,
+      key.offset: 0,
+      key.length: 58
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.comment,
+      key.offset: 58,
+      key.length: 41
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 100,
+      key.length: 4
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 105,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 111,
+      key.length: 5
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 120,
+      key.length: 4
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 125,
+      key.length: 4
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 132,
+      key.length: 5
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 142,
+      key.length: 5
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 148,
+      key.length: 3
+    }
+  ]
+}

--- a/utils/gyb_syntax_support/ExprNodes.py
+++ b/utils/gyb_syntax_support/ExprNodes.py
@@ -49,8 +49,7 @@ EXPR_NODES = [
     # await foo()
     Node('AwaitExpr', kind='Expr',
          children=[
-             Child('AwaitKeyword', kind='IdentifierToken',
-                   classification='Keyword',
+             Child('AwaitKeyword', kind='ContextualKeywordToken',
                    text_choices=['await']),
              Child('Expression', kind='Expr'),
          ]),


### PR DESCRIPTION
`await` in an expresssion should be marked as a contextual keyword, not as an identifier

Resolves apple/sourcekit-lsp#591
