### PR TITLE
[libSyntax] Small improvements

### DIFF
--- a/lib/Parse/ParsedSyntaxBuilders.cpp.gyb
+++ b/lib/Parse/ParsedSyntaxBuilders.cpp.gyb
@@ -85,6 +85,7 @@ void Parsed${node.name}Builder::finishLayout(bool deferred) {
 % if node.children:
 %   for (idx, child) in enumerate(node.children):
 %     child_elt = None
+%     child_elt_name = child.name + 'Member'
 %     child_node = NODE_MAP.get(child.syntax_kind)
 %     if child_node and child_node.is_syntax_collection():
 %       child_elt = child_node.collection_element_name

--- a/utils/gyb_syntax_support/Classification.py
+++ b/utils/gyb_syntax_support/Classification.py
@@ -1,4 +1,4 @@
-from .Node import error
+from .Utils import error
 from .kinds import lowercase_first_word  # noqa: I201
 
 

--- a/utils/gyb_syntax_support/Node.py
+++ b/utils/gyb_syntax_support/Node.py
@@ -1,11 +1,5 @@
-import sys  # noqa: I201
-
+from .Utils import error
 from .kinds import SYNTAX_BASE_KINDS, kind_to_type, lowercase_first_word
-
-
-def error(msg):
-    print('error: ' + msg, file=sys.stderr)
-    sys.exit(-1)
 
 
 class Node(object):

--- a/utils/gyb_syntax_support/NodeSerializationCodes.py
+++ b/utils/gyb_syntax_support/NodeSerializationCodes.py
@@ -1,4 +1,4 @@
-from .Node import error
+from .Utils import error
 
 
 SYNTAX_NODE_SERIALIZATION_CODES = {

--- a/utils/gyb_syntax_support/Token.py
+++ b/utils/gyb_syntax_support/Token.py
@@ -1,5 +1,5 @@
 from .Classification import classification_by_name
-from .Node import error  # noqa: I201
+from .Utils import error  # noqa: I201
 from .kinds import lowercase_first_word  # noqa: I201
 
 

--- a/utils/gyb_syntax_support/Trivia.py
+++ b/utils/gyb_syntax_support/Trivia.py
@@ -1,4 +1,4 @@
-from .Node import error
+from .Utils import error
 from .kinds import lowercase_first_word  # noqa: I201
 
 

--- a/utils/gyb_syntax_support/Utils.py
+++ b/utils/gyb_syntax_support/Utils.py
@@ -1,0 +1,6 @@
+import sys
+
+
+def error(msg):
+    print('error: ' + msg, file=sys.stderr)
+    sys.exit(-1)


### PR DESCRIPTION
- Move error function to standalone `Utils.py` because that function really doesn’t belong in `Node.py`
- In ParsedSyntaxBuilders `child_elt_name` was inferred from the last iteration of the loop above, which was incorrect.