### PR TITLE
[CSGen] Allow `_` pattern to be a hole

### DIFF
--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -298,9 +298,9 @@ enum class FixKind : uint8_t {
   /// Ignore `ErrorExpr` or `ErrorType` during pre-check.
   IgnoreInvalidASTNode,
 
-  /// Ignore a named pattern whose type we couldn't infer. This issue should
-  /// already have been diagnosed elsewhere.
-  IgnoreInvalidNamedPattern,
+  /// Ignore a named or `_` pattern whose type we couldn't infer.
+  /// This issue should already have been diagnosed elsewhere.
+  IgnoreUnresolvedPatternVar,
 
   /// Resolve type of `nil` by providing a contextual type.
   SpecifyContextualTypeForNil,
@@ -2746,10 +2746,10 @@ public:
   }
 };
 
-class IgnoreInvalidNamedPattern final : public ConstraintFix {
-  IgnoreInvalidNamedPattern(ConstraintSystem &cs, NamedPattern *pattern,
-                            ConstraintLocator *locator)
-      : ConstraintFix(cs, FixKind::IgnoreInvalidNamedPattern, locator) {}
+class IgnoreUnresolvedPatternVar final : public ConstraintFix {
+  IgnoreUnresolvedPatternVar(ConstraintSystem &cs, Pattern *pattern,
+                             ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::IgnoreUnresolvedPatternVar, locator) {}
 
 public:
   std::string getName() const override {
@@ -2762,12 +2762,11 @@ public:
     return diagnose(*commonFixes.front().first);
   }
 
-  static IgnoreInvalidNamedPattern *create(ConstraintSystem &cs,
-                                           NamedPattern *pattern,
-                                           ConstraintLocator *locator);
+  static IgnoreUnresolvedPatternVar *
+  create(ConstraintSystem &cs, Pattern *pattern, ConstraintLocator *locator);
 
   static bool classof(ConstraintFix *fix) {
-    return fix->getKind() == FixKind::IgnoreInvalidNamedPattern;
+    return fix->getKind() == FixKind::IgnoreUnresolvedPatternVar;
   }
 };
 

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -2287,6 +2287,10 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
+    return diagnose(*commonFixes.front().first);
+  }
+
   static UseRawValue *create(ConstraintSystem &cs, Type rawReprType,
                              Type expectedType, ConstraintLocator *locator);
 

--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -1076,6 +1076,39 @@ public:
   }
 };
 
+class LocatorPathElt::PatternDecl : public StoredIntegerElement<1> {
+public:
+  PatternDecl(ConstraintLocator::PathElementKind kind)
+      : StoredIntegerElement(kind, /*placeholder=*/0) {
+    assert(classof(this) && "classof needs updating");
+  }
+
+  static bool classof(const LocatorPathElt *elt) {
+    return elt->getKind() == ConstraintLocator::NamedPatternDecl ||
+           elt->getKind() == ConstraintLocator::AnyPatternDecl;
+  }
+};
+
+class LocatorPathElt::NamedPatternDecl final
+    : public LocatorPathElt::PatternDecl {
+public:
+  NamedPatternDecl() : PatternDecl(ConstraintLocator::NamedPatternDecl) {}
+
+  static bool classof(const LocatorPathElt *elt) {
+    return elt->getKind() == ConstraintLocator::NamedPatternDecl;
+  }
+};
+
+class LocatorPathElt::AnyPatternDecl final
+    : public LocatorPathElt::PatternDecl {
+public:
+  AnyPatternDecl() : PatternDecl(ConstraintLocator::AnyPatternDecl) {}
+
+  static bool classof(const LocatorPathElt *elt) {
+    return elt->getKind() == ConstraintLocator::AnyPatternDecl;
+  }
+};
+
 namespace details {
   template <typename CustomPathElement>
   class PathElement {

--- a/include/swift/Sema/ConstraintLocatorPathElts.def
+++ b/include/swift/Sema/ConstraintLocatorPathElts.def
@@ -239,8 +239,12 @@ CUSTOM_LOCATOR_PATH_ELT(SyntacticElement)
 /// The element of the pattern binding declaration.
 CUSTOM_LOCATOR_PATH_ELT(PatternBindingElement)
 
-/// The variable declared by a named pattern.
-SIMPLE_LOCATOR_PATH_ELT(NamedPatternDecl)
+/// A declaration introduced by a pattern: name (i.e. `x`) or `_`
+ABSTRACT_LOCATOR_PATH_ELT(PatternDecl)
+  /// The variable declared by a named pattern.
+  CUSTOM_LOCATOR_PATH_ELT(NamedPatternDecl)
+  /// The anonymous variable declared by a `_` pattern.
+  CUSTOM_LOCATOR_PATH_ELT(AnyPatternDecl)
 
 #undef LOCATOR_PATH_ELT
 #undef CUSTOM_LOCATOR_PATH_ELT

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -758,7 +758,7 @@ protected:
     // If needed, generate constraints for everything in the case statement.
     if (cs) {
       auto locator = cs->getConstraintLocator(
-          subjectExpr, LocatorPathElt::ContextualType(CTP_Initialization));
+          subjectExpr, LocatorPathElt::ContextualType(CTP_CaseStmt));
       Type subjectType = cs->getType(subjectExpr);
 
       if (cs->generateConstraints(caseStmt, dc, subjectType, locator)) {

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -115,7 +115,7 @@ bool BindingSet::isDelayed() const {
     // allows us to produce more specific errors because the type variable in
     // the expression that introduced the placeholder might be diagnosable using
     // fixForHole.
-    if (locator->isLastElement<LocatorPathElt::NamedPatternDecl>()) {
+    if (locator->isLastElement<LocatorPathElt::PatternDecl>()) {
       return true;
     }
 
@@ -2061,16 +2061,16 @@ TypeVariableBinding::fixForHole(ConstraintSystem &cs) const {
     return std::make_pair(fix, /*impact=*/(unsigned)10);
   }
 
-  if (auto pattern = getAsPattern<NamedPattern>(dstLocator->getAnchor())) {
+  if (auto pattern = getAsPattern(dstLocator->getAnchor())) {
     if (dstLocator->getPath().size() == 1 &&
-        dstLocator->isLastElement<LocatorPathElt::NamedPatternDecl>()) {
+        dstLocator->isLastElement<LocatorPathElt::PatternDecl>()) {
       // Not being able to infer the type of a variable in a pattern binding
       // decl is more dramatic than anything that could happen inside the
       // expression because we want to preferrably point the diagnostic to a
       // part of the expression that caused us to be unable to infer the
       // variable's type.
       ConstraintFix *fix =
-          IgnoreInvalidNamedPattern::create(cs, pattern, dstLocator);
+          IgnoreUnresolvedPatternVar::create(cs, pattern, dstLocator);
       return std::make_pair(fix, /*impact=*/(unsigned)100);
     }
   }

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2004,18 +2004,18 @@ IgnoreResultBuilderWithReturnStmts::create(ConstraintSystem &cs, Type builderTy,
       IgnoreResultBuilderWithReturnStmts(cs, builderTy, locator);
 }
 
-bool IgnoreInvalidNamedPattern::diagnose(const Solution &solution,
-                                         bool asNote) const {
+bool IgnoreUnresolvedPatternVar::diagnose(const Solution &solution,
+                                          bool asNote) const {
   // Not being able to infer the type of a pattern should already have been
   // diagnosed on the pattern's initializer or as a structural issue of the AST.
   return true;
 }
 
-IgnoreInvalidNamedPattern *
-IgnoreInvalidNamedPattern::create(ConstraintSystem &cs, NamedPattern *pattern,
-                                  ConstraintLocator *locator) {
+IgnoreUnresolvedPatternVar *
+IgnoreUnresolvedPatternVar::create(ConstraintSystem &cs, Pattern *pattern,
+                                   ConstraintLocator *locator) {
   return new (cs.getAllocator())
-      IgnoreInvalidNamedPattern(cs, pattern, locator);
+      IgnoreUnresolvedPatternVar(cs, pattern, locator);
 }
 
 bool SpecifyBaseTypeForOptionalUnresolvedMember::diagnose(

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2286,11 +2286,18 @@ namespace {
         return setType(type);
       }
       case PatternKind::Any: {
-        return setType(
-            externalPatternType
-                ? externalPatternType
-                : CS.createTypeVariable(CS.getConstraintLocator(locator),
-                                        TVO_CanBindToNoEscape));
+        Type type;
+
+        // Always prefer a contextual type when it's available.
+        if (externalPatternType) {
+          type = externalPatternType;
+        } else {
+          type = CS.createTypeVariable(
+              CS.getConstraintLocator(pattern,
+                                      ConstraintLocator::AnyPatternDecl),
+              TVO_CanBindToNoEscape | TVO_CanBindToHole);
+        }
+        return setType(type);
       }
 
       case PatternKind::Named: {

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2265,9 +2265,11 @@ namespace {
               ->getUnderlyingType();
         }
 
-        auto underlyingType =
-            getTypeForPattern(paren->getSubPattern(), locator,
-                              externalPatternType, bindPatternVarsOneWay);
+        auto *subPattern = paren->getSubPattern();
+        auto underlyingType = getTypeForPattern(
+            subPattern,
+            locator.withPathElement(LocatorPathElt::PatternMatch(subPattern)),
+            externalPatternType, bindPatternVarsOneWay);
 
         if (!underlyingType)
           return Type();
@@ -2694,7 +2696,9 @@ namespace {
           // and we're matching the type of that subpattern to the parameter
           // types.
           Type subPatternType = getTypeForPattern(
-              subPattern, locator, Type(), bindPatternVarsOneWay);
+              subPattern,
+              locator.withPathElement(LocatorPathElt::PatternMatch(subPattern)),
+              Type(), bindPatternVarsOneWay);
 
           if (!subPatternType)
             return Type();

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -7328,7 +7328,11 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
             TypeChecker::conformsToProtocol(rawValue, protocol,
                                             DC->getParentModule())) {
           auto *fix = UseRawValue::create(*this, type, protocolTy, loc);
-          return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
+          // Since this is a conformance requirement failure (where the
+          // source is most likely an argument), let's increase its impact
+          // to disambiguate vs. conversion failure of the same kind.
+          return recordFix(fix, /*impact=*/2) ? SolutionKind::Error
+                                              : SolutionKind::Solved;
         }
       }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -12938,7 +12938,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::IgnoreInvalidASTNode: {
     return recordFix(fix, 10) ? SolutionKind::Error : SolutionKind::Solved;
   }
-  case FixKind::IgnoreInvalidNamedPattern: {
+  case FixKind::IgnoreUnresolvedPatternVar: {
     return recordFix(fix, 100) ? SolutionKind::Error : SolutionKind::Solved;
   }
 

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -98,6 +98,7 @@ unsigned LocatorPathElt::getNewSummaryFlags() const {
   case ConstraintLocator::PackElement:
   case ConstraintLocator::PatternBindingElement:
   case ConstraintLocator::NamedPatternDecl:
+  case ConstraintLocator::AnyPatternDecl:
     return 0;
 
   case ConstraintLocator::FunctionArgument:
@@ -445,6 +446,11 @@ void LocatorPathElt::dump(raw_ostream &out) const {
 
   case ConstraintLocator::NamedPatternDecl: {
     out << "named pattern decl";
+    break;
+  }
+
+  case ConstraintLocator::AnyPatternDecl: {
+    out << "'_' pattern decl";
     break;
   }
   }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5277,6 +5277,15 @@ void constraints::simplifyLocator(ASTNode &anchor,
       break;
     }
 
+    case ConstraintLocator::AnyPatternDecl: {
+      // This element is just a marker for `_` pattern since it doesn't
+      // have a declaration. We need to make sure that it only appaears
+      // when anchored on `AnyPattern`.
+      assert(getAsPattern<AnyPattern>(anchor));
+      path = path.slice(1);
+      break;
+    }
+
     case ConstraintLocator::ImplicitConversion:
       break;
 

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -486,6 +486,7 @@ func rdar63510989() {
   }
 
   func test(e: E) {
+    if case .single(_) = e {} // Ok
     if case .single(_ as Value) = e {} // Ok
     if case .single(let v as Value) = e {} // Ok
     // expected-warning@-1 {{immutable value 'v' was never used; consider replacing with '_' or removing it}}

--- a/test/Sema/enum_raw_representable.swift
+++ b/test/Sema/enum_raw_representable.swift
@@ -146,10 +146,10 @@ rdar32431165_2(42, E_32431165.bar)
 // or constructing raw representable type from second, both ways are valid.
 do {
   E_32431165.bar == "bar"
-  // expected-error@-1 {{binary operator '==' cannot be applied to operands of type 'E_32431165' and 'String'}} expected-note@-1 {{partially matching parameter lists: (String, String)}}
+  // expected-error@-1 {{cannot convert value of type 'E_32431165' to expected argument type 'String'}} {{17-17=.rawValue}}
 
   "bar" == E_32431165.bar
-  // expected-error@-1 {{binary operator '==' cannot be applied to operands of type 'String' and 'E_32431165'}} expected-note@-1 {{partially matching parameter lists: (String, String)}}
+  // expected-error@-1 {{cannot convert value of type 'E_32431165' to expected argument type 'String'}} {{26-26=.rawValue}}
 }
 
 func rdar32431165_overloaded() -> Int { 42 }     // expected-note {{'rdar32431165_overloaded()' produces 'Int', not the expected contextual result type 'E_32431165'}}


### PR DESCRIPTION
In cases like `case .test(_)` it might not be possible to
establish a type of `_` and hole cannot be propagated to
it from context if condition of switch is incorrect, so
`_` just like a named pattern should be allowed to become
a hole.

Resolves: rdar://96997534

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
