### PR TITLE
[ConstraintSystem] Specify atom and collection literal kinds for type variable attributes.

### DIFF
--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -470,7 +470,11 @@ public:
     return Info.AssociatedCodeCompletionToken;
   }
 
-  LiteralBindingKind getLiteralKind() const;
+  void forEachLiteralRequirement(
+      llvm::function_ref<void(KnownProtocolKind)> callback) const;
+
+  /// Return a literal requirement that has the most impact on the binding score.
+  LiteralBindingKind getLiteralForScore() const;
 
   /// Check if this binding is favored over a disjunction e.g.
   /// if it has only concrete types or would resolve a closure.

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1648,9 +1648,17 @@ void BindingSet::dump(llvm::raw_ostream &out, unsigned indent) const {
     attributes.push_back("subtype_of_existential");
   auto literalKind = getLiteralKind();
   if (literalKind != LiteralBindingKind::None) {
-    auto literalAttrStr = ("[literal: " + getLiteralBindingKind(literalKind)
-                        + "]").str();
-    attributes.push_back(literalAttrStr);
+    std::string literalAttrStr;
+    literalAttrStr.append("[literal: ");
+    if (literalKind == LiteralBindingKind::Atom) {
+      if (auto atomKind = TypeVar->getImpl().getAtomicLiteralKind()) {
+        literalAttrStr.append(getAtomLiteralAsString(*atomKind));
+      }
+    } else {
+      literalAttrStr.append(getLiteralBindingKind(literalKind).str());
+    }
+    literalAttrStr.append("]");
+    attributes.push_back(std::move(literalAttrStr));
   }
   if (!attributes.empty()) {
     out << "[attributes: ";

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1622,6 +1622,22 @@ static std::string getAtomLiteralAsString(ExprKind EK) {
 #undef ENTRY
 }
 
+/// Return string for collection literal kinds (interpolated string, array,
+/// dictionary) for printing in debug output.
+static std::string getCollectionLiteralAsString(KnownProtocolKind KPK) {
+#define ENTRY(Kind, String)                                                    \
+  case KnownProtocolKind::Kind:                                                \
+    return String
+  switch (KPK) {
+    ENTRY(ExpressibleByDictionaryLiteral, "dictionary");
+    ENTRY(ExpressibleByArrayLiteral, "array");
+    ENTRY(ExpressibleByStringInterpolation, "interpolated string");
+  default:
+    return "";
+  }
+#undef ENTRY
+}
+
 void BindingSet::dump(TypeVariableType *typeVar, llvm::raw_ostream &out,
                       unsigned indent) const {
   out.indent(indent);

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1605,6 +1605,23 @@ unsigned BindingSet::getNumViableLiteralBindings() const {
   });
 }
 
+/// Return string for atomic literal kinds (integer, string, & boolean) for
+/// printing in debug output.
+static std::string getAtomLiteralAsString(ExprKind EK) {
+#define ENTRY(Kind, String)                                                    \
+  case ExprKind::Kind:                                                         \
+    return String
+  switch (EK) {
+    ENTRY(IntegerLiteral, "integer");
+    ENTRY(StringLiteral, "string");
+    ENTRY(BooleanLiteral, "boolean");
+    ENTRY(NilLiteral, "nil");
+  default:
+    return "";
+  }
+#undef ENTRY
+}
+
 void BindingSet::dump(TypeVariableType *typeVar, llvm::raw_ostream &out,
                       unsigned indent) const {
   out.indent(indent);


### PR DESCRIPTION
If LiteralBindKind is of type `atom` or `collection`, printing its specific kind is helpful when reading type variables and bindings produced without locators during SolverSteps. This is an addition to apple/swift#59855.

The following:
```
  $T3 [allows bindings to: noescape] [attributes: delayed, [literal: collection]] [involves_type_vars: $T4] [with possible bindings: <empty>] @ locator@0x13c00b790 [InterpolatedStringLiteral@/Users/amritpankaur/test.swift:64:2]
  $T4 [allows bindings to: noescape] [attributes: delayed, [literal: collection]] [with possible bindings: <empty>] @ locator@0x13c00cef8 [Array@/Users/amritpankaur/test.swift:64:1]
  $T5 [allows bindings to: noescape] [attributes: delayed, [literal: atom]] [with possible bindings: <empty>] @ locator@0x13c00d0c8 [IntegerLiteral@/Users/amritpankaur/test.swift:64:12]
  $T7 [allows bindings to: noescape] [attributes: delayed, [literal: float]] [with possible bindings: <empty>] @ locator@0x13c00d2f8 [FloatLiteral@/Users/amritpankaur/test.swift:64:16]
```

will now read as:
```
  $T3 [allows bindings to: noescape] [attributes: delayed, [literal: interpolated string]] [involves_type_vars: $T4] [with possible bindings: <empty>] @ locator@0x13a302590 [InterpolatedStringLiteral@/Users/...]
  $T4 [allows bindings to: noescape] [attributes: delayed, [literal: array]] [with possible bindings: <empty>] @ locator@0x13a3060f8 [Array@/Users/...]
  $T5 [allows bindings to: noescape] [attributes: delayed, [literal: integer]] [with possible bindings: <empty>] @ locator@0x13a3062c8 [IntegerLiteral@/Users/...]
  $T7 [allows bindings to: noescape] [attributes: delayed, [literal: float]] [with possible bindings: <empty>] @ locator@0x13a3064f8 [FloatLiteral@/Users/...]
```
