### PR TITLE
Conditional compilation for attributes

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -2626,6 +2626,10 @@ inline SourceLoc extractNearestSourceLoc(const DeclAttribute *attr) {
   return attr->getLocation();
 }
 
+/// Determine whether the given attribute is available, looking up the
+/// attribute by name.
+bool hasAttribute(const LangOptions &langOpts, llvm::StringRef attributeName);
+
 } // end namespace swift
 
 #endif

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -100,6 +100,16 @@ public:
   virtual ~ConsumeTokenReceiver() = default;
 };
 
+/// The role of the elements in a given #if
+enum class IfConfigElementsRole {
+  // Parse normally.
+  Normal,
+  // Parse, but only for syntax. Throw away the results.
+  SyntaxOnly,
+  // Already skipped; no need to parse anything.
+  Skipped
+};
+
 /// The main class used for parsing a source file (.swift or .sil).
 ///
 /// Rather than instantiating a Parser yourself, use one of the parsing APIs
@@ -684,7 +694,8 @@ public:
     while (Tok.isNot(K..., tok::eof, tok::r_brace, tok::pound_endif,
                      tok::pound_else, tok::pound_elseif,
                      tok::code_complete) &&
-           !isStartOfStmt() && !isStartOfSwiftDecl()) {
+           !isStartOfStmt() &&
+           !isStartOfSwiftDecl(/*allowPoundIfAttributes=*/false)) {
       skipSingle();
     }
   }
@@ -945,7 +956,7 @@ public:
   // Decl Parsing
 
   /// Returns true if parser is at the start of a Swift decl or decl-import.
-  bool isStartOfSwiftDecl();
+  bool isStartOfSwiftDecl(bool allowPoundIfAttributes = true);
 
   /// Returns true if the parser is at the start of a SIL decl.
   bool isStartOfSILDecl();
@@ -982,6 +993,7 @@ public:
 
   ParserResult<Decl> parseDecl(ParseDeclOptions Flags,
                                bool IsAtStartOfLineOrPreviousHadSemi,
+                               bool IfConfigsAreDeclAttrs,
                                llvm::function_ref<void(Decl*)> Handler);
 
   std::pair<std::vector<Decl *>, Optional<Fingerprint>>
@@ -1004,11 +1016,28 @@ public:
 
   ParserResult<TypeDecl> parseDeclAssociatedType(ParseDeclOptions Flags,
                                                  DeclAttributes &Attributes);
-  
+
+  /// Parse a #if ... #endif directive.
+  /// Delegate callback function to parse elements in the blocks and record
+  /// them however they wish. The parsing function will be provided with the
+  /// location of the clause token (`#if`, `#else`, etc.), the condition,
+  /// whether this is the active clause, and the role of the elements.
+  template<typename Result>
+  Result parseIfConfigRaw(
+      llvm::function_ref<void(SourceLoc clauseLoc, Expr *condition,
+                              bool isActive, IfConfigElementsRole role)>
+          parseElements,
+      llvm::function_ref<Result(SourceLoc endLoc, bool hadMissingEnd)> finish);
+
   /// Parse a #if ... #endif directive.
   /// Delegate callback function to parse elements in the blocks.
   ParserResult<IfConfigDecl> parseIfConfig(
     llvm::function_ref<void(SmallVectorImpl<ASTNode> &, bool)> parseElements);
+
+  /// Parse an #if ... #endif containing only attributes.
+  ParserStatus parseIfConfigDeclAttributes(
+    DeclAttributes &attributes, bool ifConfigsAreDeclAttrs,
+    PatternBindingInitializer *initContext);
 
   /// Parse a #error or #warning diagnostic.
   ParserResult<PoundDiagnosticDecl> parseDeclPoundDiagnostic();
@@ -1020,8 +1049,26 @@ public:
   void setLocalDiscriminator(ValueDecl *D);
   void setLocalDiscriminatorToParamList(ParameterList *PL);
 
+  /// Skip an `#if` configuration block containing only attributes.
+  ///
+  /// \returns true if the skipping was successful, false otherwise.
+  bool skipIfConfigOfAttributes(bool &sawAnyAttributes);
+
+  /// Determine whether the `#if` at which the parser occurs only contains
+  /// attributes (in all branches), in which case it is treated as part of
+  /// an attribute list.
+  bool ifConfigContainsOnlyAttributes();
+
   /// Parse the optional attributes before a declaration.
-  ParserStatus parseDeclAttributeList(DeclAttributes &Attributes);
+  ParserStatus parseDeclAttributeList(DeclAttributes &Attributes,
+                                      bool IfConfigsAreDeclAttrs = false);
+
+  /// Parse the optional attributes before a declaration.
+  ///
+  /// This is the inner loop, which can be called recursively.
+  ParserStatus parseDeclAttributeList(DeclAttributes &Attributes,
+                                      bool IfConfigsAreDeclAttrs,
+                                      PatternBindingInitializer *initContext);
 
   /// Parse the optional modifiers before a declaration.
   bool parseDeclModifierList(DeclAttributes &Attributes, SourceLoc &StaticLoc,

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -2285,3 +2285,23 @@ void swift::simple_display(llvm::raw_ostream &out, const DeclAttribute *attr) {
   if (attr)
     attr->print(out);
 }
+
+bool swift::hasAttribute(
+    const LangOptions &langOpts, llvm::StringRef attributeName) {
+  DeclAttrKind kind = DeclAttribute::getAttrKindFromString(attributeName);
+  if (kind == DAK_Count)
+    return false;
+
+  if (DeclAttribute::isUserInaccessible(kind))
+    return false;
+  if (DeclAttribute::isDeclModifier(kind))
+    return false;
+  if (DeclAttribute::shouldBeRejectedByParser(kind))
+    return false;
+  if (DeclAttribute::isSilOnly(kind))
+    return false;
+  if (DeclAttribute::isConcurrencyOnly(kind))
+    return false;
+
+  return true;
+}

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4346,8 +4346,8 @@ bool Parser::isStartOfSwiftDecl(bool allowPoundIfAttributes) {
   if (Tok.is(tok::pound_if) && allowPoundIfAttributes) {
     BacktrackingScope backtrack(*this);
     bool sawAnyAttributes = false;
-    return skipIfConfigOfAttributes(sawAnyAttributes) && sawAnyAttributes &&
-        isStartOfSwiftDecl();
+    return skipIfConfigOfAttributes(sawAnyAttributes) &&
+        (Tok.is(tok::eof) || (sawAnyAttributes && isStartOfSwiftDecl()));
   }
 
   // If we have a decl modifying keyword, check if the next token is a valid

--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -346,6 +346,16 @@ public:
       return E;
     }
 
+    if (*KindName == "hasAttribute") {
+      if (!getDeclRefStr(Arg, DeclRefKind::Ordinary)) {
+        D.diagnose(E->getLoc(), diag::unsupported_platform_condition_argument,
+                   "attribute name");
+        return nullptr;
+      }
+
+      return E;
+    }
+
     // ( 'os' | 'arch' | '_endian' | '_runtime' ) '(' identifier ')''
     auto Kind = getPlatformConditionKind(*KindName);
     if (!Kind.hasValue()) {
@@ -574,6 +584,9 @@ public:
     } else if (KindName == "hasFeature") {
       auto featureName = getDeclRefStr(Arg);
       return Ctx.LangOpts.hasFeature(featureName);
+    } else if (KindName == "hasAttribute") {
+      auto attributeName = getDeclRefStr(Arg);
+      return hasAttribute(Ctx.LangOpts, attributeName);
     }
 
     auto Val = getDeclRefStr(Arg);

--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -962,6 +962,10 @@ bool Parser::skipIfConfigOfAttributes(bool &sawAnyAttributes) {
       break;
   }
 
+  // If we ran out of tokens, say we consumed the rest.
+  if (Tok.is(tok::eof))
+    return true;
+
   return Tok.isAtStartOfLine() && consumeIf(tok::pound_endif);
 }
 

--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -744,12 +744,15 @@ static Expr *findAnyLikelySimulatorEnvironmentTest(Expr *Condition) {
 
 /// Parse and populate a #if ... #endif directive.
 /// Delegate callback function to parse elements in the blocks.
-ParserResult<IfConfigDecl> Parser::parseIfConfig(
-    llvm::function_ref<void(SmallVectorImpl<ASTNode> &, bool)> parseElements) {
+template<typename Result>
+Result Parser::parseIfConfigRaw(
+    llvm::function_ref<void(SourceLoc clauseLoc, Expr *condition,
+                            bool isActive, IfConfigElementsRole role)>
+      parseElements,
+    llvm::function_ref<Result(SourceLoc endLoc, bool hadMissingEnd)> finish) {
   assert(Tok.is(tok::pound_if));
   SyntaxParsingContext IfConfigCtx(SyntaxContext, SyntaxKind::IfConfigDecl);
 
-  SmallVector<IfConfigClause, 4> Clauses;
   Parser::StructureMarkerRAII ParsingDecl(
       *this, Tok.getLoc(), Parser::StructureMarkerKind::IfConfig);
 
@@ -808,14 +811,14 @@ ParserResult<IfConfigDecl> Parser::parseIfConfig(
         SyntaxContext->addRawSyntax(ParsedRawSyntaxNode());
     } else {
       llvm::SaveAndRestore<bool> S(InPoundIfEnvironment, true);
-      ParserResult<Expr> Result = parseExprSequence(diag::expected_expr,
+      ParserResult<Expr> result = parseExprSequence(diag::expected_expr,
                                                       /*isBasic*/true,
                                                       /*isForDirective*/true);
-      if (Result.hasCodeCompletion())
+      if (result.hasCodeCompletion())
         return makeParserCodeCompletionStatus();
-      if (Result.isNull())
+      if (result.isNull())
         return makeParserError();
-      Condition = Result.get();
+      Condition = result.get();
       if (validateIfConfigCondition(Condition, Context, Diags)) {
         // Error in the condition;
         isActive = false;
@@ -847,7 +850,6 @@ ParserResult<IfConfigDecl> Parser::parseIfConfig(
     }
 
     // Parse elements
-    SmallVector<ASTNode, 16> Elements;
     llvm::SaveAndRestore<bool> S(InInactiveClauseEnvironment,
                                  InInactiveClauseEnvironment || !isActive);
     // Disable updating the interface hash inside inactive blocks.
@@ -856,21 +858,21 @@ ParserResult<IfConfigDecl> Parser::parseIfConfig(
       T.emplace(CurrentTokenHash, None);
 
     if (isActive || !isVersionCondition) {
-      parseElements(Elements, isActive);
+      parseElements(
+          ClauseLoc, Condition, isActive, IfConfigElementsRole::Normal);
     } else if (SyntaxContext->isEnabled()) {
       // We shouldn't skip code if we are building syntax tree.
       // The parser will keep running and we just discard the AST part.
       DiagnosticSuppression suppression(Context.Diags);
-      SmallVector<ASTNode, 16> droppedElements;
-      parseElements(droppedElements, false);
+      parseElements(
+          ClauseLoc, Condition, isActive, IfConfigElementsRole::SyntaxOnly);
     } else {
       DiagnosticTransaction DT(Diags);
       skipUntilConditionalBlockClose();
       DT.abort();
+      parseElements(
+          ClauseLoc, Condition, isActive, IfConfigElementsRole::Skipped);
     }
-
-    Clauses.emplace_back(ClauseLoc, Condition,
-                         Context.AllocateCopy(Elements), isActive);
 
     if (Tok.isNot(tok::pound_elseif, tok::pound_else))
       break;
@@ -883,8 +885,89 @@ ParserResult<IfConfigDecl> Parser::parseIfConfig(
   SourceLoc EndLoc;
   bool HadMissingEnd = parseEndIfDirective(EndLoc);
 
-  auto *ICD = new (Context) IfConfigDecl(CurDeclContext,
-                                         Context.AllocateCopy(Clauses),
-                                         EndLoc, HadMissingEnd);
-  return makeParserResult(ICD);
+  return finish(EndLoc, HadMissingEnd);
+}
+
+/// Parse and populate a #if ... #endif directive.
+/// Delegate callback function to parse elements in the blocks.
+ParserResult<IfConfigDecl> Parser::parseIfConfig(
+    llvm::function_ref<void(SmallVectorImpl<ASTNode> &, bool)> parseElements) {
+  SmallVector<IfConfigClause, 4> clauses;
+  return parseIfConfigRaw<ParserResult<IfConfigDecl>>(
+      [&](SourceLoc clauseLoc, Expr *condition, bool isActive,
+          IfConfigElementsRole role) {
+        SmallVector<ASTNode, 16> elements;
+        if (role != IfConfigElementsRole::Skipped)
+          parseElements(elements, isActive);
+        if (role == IfConfigElementsRole::SyntaxOnly)
+          elements.clear();
+
+        clauses.emplace_back(
+            clauseLoc, condition, Context.AllocateCopy(elements), isActive);
+      }, [&](SourceLoc endLoc, bool hadMissingEnd) {
+        auto *ICD = new (Context) IfConfigDecl(CurDeclContext,
+                                               Context.AllocateCopy(clauses),
+                                               endLoc, hadMissingEnd);
+        return makeParserResult(ICD);
+      });
+}
+
+ParserStatus Parser::parseIfConfigDeclAttributes(
+    DeclAttributes &attributes, bool ifConfigsAreDeclAttrs,
+    PatternBindingInitializer *initContext) {
+  ParserStatus status = makeParserSuccess();
+  return parseIfConfigRaw<ParserStatus>(
+      [&](SourceLoc clauseLoc, Expr *condition, bool isActive,
+          IfConfigElementsRole role) {
+        if (isActive) {
+          status |= parseDeclAttributeList(
+              attributes, ifConfigsAreDeclAttrs, initContext);
+        } else if (role != IfConfigElementsRole::Skipped) {
+          DeclAttributes skippedAttributes;
+          PatternBindingInitializer *skippedInitContext = nullptr;
+          status |= parseDeclAttributeList(
+              skippedAttributes, ifConfigsAreDeclAttrs, skippedInitContext);
+        }
+      },
+      [&](SourceLoc endLoc, bool hadMissingEnd) {
+        return status;
+      });
+}
+
+bool Parser::skipIfConfigOfAttributes(bool &sawAnyAttributes) {
+  assert(Tok.is(tok::pound_if));
+  while (true) {
+    // #if / #else / #elseif
+    consumeToken();
+
+    // <expression>
+    skipUntilTokenOrEndOfLine(tok::NUM_TOKENS);
+
+    while (true) {
+      if (Tok.is(tok::at_sign)) {
+        sawAnyAttributes = true;
+        skipAnyAttribute();
+        continue;
+      }
+
+      if (Tok.is(tok::pound_if)) {
+        skipIfConfigOfAttributes(sawAnyAttributes);
+        continue;
+      }
+
+      break;
+    }
+
+    if (Tok.isNot(tok::pound_elseif, tok::pound_else))
+      break;
+  }
+
+  return Tok.isAtStartOfLine() && consumeIf(tok::pound_endif);
+}
+
+bool Parser::ifConfigContainsOnlyAttributes() {
+  assert(Tok.is(tok::pound_if));
+  bool sawAnyAttributes = false;
+  BacktrackingScope backtrack(*this);
+  return skipIfConfigOfAttributes(sawAnyAttributes) && sawAnyAttributes;
 }

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -346,7 +346,7 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
 
     // Parse the decl, stmt, or expression.
     PreviousHadSemi = false;
-    if (Tok.is(tok::pound_if)) {
+    if (Tok.is(tok::pound_if) && !isStartOfSwiftDecl()) {
       auto IfConfigResult = parseIfConfig(
         [&](SmallVectorImpl<ASTNode> &Elements, bool IsActive) {
           parseBraceItems(Elements, Kind, IsActive
@@ -389,6 +389,7 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
       ParserResult<Decl> DeclResult = 
           parseDecl(IsTopLevel ? PD_AllowTopLevel : PD_Default,
                     IsAtStartOfLineOrPreviousHadSemi,
+                    /*IfConfigsAreDeclAttrs=*/true,
                     [&](Decl *D) {
                       TmpDecls.push_back(D);
 

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -186,7 +186,9 @@ void Parser::performCodeCompletionSecondPassImpl(
     ContextChange CC(*this, DC);
 
     parseDecl(ParseDeclOptions(info.Flags),
-              /*IsAtStartOfLineOrPreviousHadSemi=*/true, [&](Decl *D) {
+              /*IsAtStartOfLineOrPreviousHadSemi=*/true,
+              /*IfConfigsAreDeclAttrs=*/false,
+              [&](Decl *D) {
                 if (auto *NTD = dyn_cast<NominalTypeDecl>(DC)) {
                   NTD->addMemberPreservingSourceOrder(D);
                 } else if (auto *ED = dyn_cast<ExtensionDecl>(DC)) {
@@ -766,7 +768,7 @@ void Parser::skipUntilDeclRBrace() {
   while (Tok.isNot(tok::eof, tok::r_brace, tok::pound_endif,
                    tok::pound_else, tok::pound_elseif,
                    tok::code_complete) &&
-         !isStartOfSwiftDecl())
+         !isStartOfSwiftDecl(/*allowPoundIfAttributes=*/false))
     skipSingle();
 }
 
@@ -776,7 +778,7 @@ void Parser::skipListUntilDeclRBrace(SourceLoc startLoc, tok T1, tok T2) {
     bool hasDelimiter = Tok.getLoc() == startLoc || consumeIf(tok::comma);
     bool possibleDeclStartsLine = Tok.isAtStartOfLine();
     
-    if (isStartOfSwiftDecl()) {
+    if (isStartOfSwiftDecl(/*allowPoundIfAttributes=*/false)) {
       
       // Could have encountered something like `_ var:` 
       // or `let foo:` or `var:`
@@ -806,7 +808,7 @@ void Parser::skipListUntilDeclRBrace(SourceLoc startLoc, tok T1, tok T2) {
 void Parser::skipUntilDeclRBrace(tok T1, tok T2) {
   while (Tok.isNot(T1, T2, tok::eof, tok::r_brace, tok::pound_endif,
                    tok::pound_else, tok::pound_elseif) &&
-         !isStartOfSwiftDecl()) {
+         !isStartOfSwiftDecl(/*allowPoundIfAttributes=*/false)) {
     skipSingle();
   }
 }

--- a/test/attr/conditional_attribute.swift
+++ b/test/attr/conditional_attribute.swift
@@ -1,0 +1,94 @@
+// RUN: %target-typecheck-verify-swift
+
+#if hasAttribute(foo)
+@foo(this is gibberish)
+#endif
+struct S1 { }
+
+@frozen
+#if hasAttribute(foo)
+@foo
+#endif
+public struct S2 { }
+
+#if hasAttribute(foo)
+@foo
+#endif
+@inlinable
+func f1() { }
+
+#if hasAttribute(foo)
+@foo
+#else
+@available(*, deprecated, message: "nope")
+@frozen
+#endif
+public struct S3 { }
+
+// Nested #if
+#if hasAttribute(foo)
+  @foo
+#elseif hasAttribute(available)
+  @available(*, deprecated, message: "nope")
+#if hasAttribute(frozen)
+@frozen
+#endif
+#endif
+public struct S4 { }
+
+// Nested in a type
+struct Inner {
+#if hasAttribute(foo)
+  @foo(this is gibberish)
+#endif
+  struct S1 { }
+
+  @frozen
+#if hasAttribute(foo)
+  #if hasAttribute(bar)
+  @foo @bar
+  #endif
+#endif
+  public struct S2 { }
+
+#if hasAttribute(foo)
+  @foo
+#endif
+  @inlinable
+  func f1() { }
+
+#if hasAttribute(foo)
+  @foo
+#else
+  @available(*, deprecated, message: "nope")
+  @frozen
+#endif
+  public struct S3 { }
+}
+
+// Nested in a function
+func f2() {
+#if hasAttribute(foo)
+  @foo(this is gibberish)
+#endif
+  struct S1 { }
+
+  @available(*, deprecated)
+#if hasAttribute(foo)
+  @foo
+#endif
+  struct S2 { }
+
+#if hasAttribute(foo)
+  @foo
+#endif
+  @available(*, deprecated)
+  func f1() { }
+
+#if hasAttribute(foo)
+  @foo
+#else
+  @available(*, deprecated, message: "nope")
+#endif
+  struct S3 { }
+}

--- a/test/attr/has_attribute.swift
+++ b/test/attr/has_attribute.swift
@@ -1,0 +1,25 @@
+// RUN: %target-typecheck-verify-swift
+
+#if !hasAttribute(dynamicCallable)
+BOOM
+#endif
+
+#if hasAttribute(fortran)
+BOOM
+#endif
+
+#if hasAttribute(cobol)
+this is unparsed junk // expected-error{{consecutive statements on a line must be separated by}}
+#endif
+
+#if hasAttribute(optional)
+ModifiersAreNotAttributes
+#endif
+
+#if hasAttribute(__raw_doc_comment)
+UserInaccessibleAreNotAttributes
+#endif
+
+#if hasAttribute(17)
+// expected-error@-1{{unexpected platform condition argument: expected attribute name}}
+#endif


### PR DESCRIPTION
Implement the proposal for conditional compilation of attributes, which includes:
* `#if hasAttribute(X)`, for code that will only be compiled with the named attribute is available, and
* The ability to put an `#if` around attributes of a declaration, so one can conditionally attach attributes.