### PR TITLE
[SourceKit] Add an operator syntax kind

### DIFF
--- a/include/swift/IDE/SyntaxModel.h
+++ b/include/swift/IDE/SyntaxModel.h
@@ -29,6 +29,7 @@ namespace ide {
 enum class SyntaxNodeKind : uint8_t {
   Keyword,
   Identifier,
+  Operator,
   DollarIdent,
   Integer,
   Floating,

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -231,9 +231,20 @@ SyntaxModelContext::SyntaxModelContext(SourceFile &SrcFile)
         break;
 
       case tok::oper_prefix:
-        if (Tok.getText() == "-")
+        if (Tok.getText() == "-" && I != E &&
+            (Tokens[I+1].getKind() == tok::integer_literal ||
+             Tokens[I+1].getKind() == tok::floating_literal)) {
           UnaryMinusLoc = Loc;
-        continue;
+          continue;
+        } else {
+          Kind = SyntaxNodeKind::Operator;
+          break;
+        }
+      case tok::oper_postfix:
+      case tok::oper_binary_spaced:
+      case tok::oper_binary_unspaced:
+        Kind = SyntaxNodeKind::Operator;
+        break;
 
       case tok::comment:
         if (Tok.getText().startswith("///") ||

--- a/test/SourceKit/DocSupport/doc_clang_module.swift.response
+++ b/test/SourceKit/DocSupport/doc_clang_module.swift.response
@@ -460,6 +460,11 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.length: 4
   },
   {
+    key.kind: source.lang.swift.syntaxtype.operator,
+    key.offset: 194,
+    key.length: 2
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.argument,
     key.offset: 198,
     key.length: 1
@@ -616,6 +621,11 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 427,
     key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.operator,
+    key.offset: 432,
+    key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
@@ -796,6 +806,11 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 697,
     key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.operator,
+    key.offset: 702,
+    key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
@@ -1019,6 +1034,11 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.length: 4
   },
   {
+    key.kind: source.lang.swift.syntaxtype.operator,
+    key.offset: 1050,
+    key.length: 2
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.argument,
     key.offset: 1054,
     key.length: 1
@@ -1163,6 +1183,11 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.length: 4
   },
   {
+    key.kind: source.lang.swift.syntaxtype.operator,
+    key.offset: 1321,
+    key.length: 2
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.argument,
     key.offset: 1325,
     key.length: 1
@@ -1301,6 +1326,11 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.usr: "c:@E@FooRuncingOptions",
     key.offset: 1547,
     key.length: 17
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.operator,
+    key.offset: 1565,
+    key.length: 2
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
@@ -4314,6 +4344,11 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.length: 4
   },
   {
+    key.kind: source.lang.swift.syntaxtype.operator,
+    key.offset: 7274,
+    key.length: 2
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.argument,
     key.offset: 7278,
     key.length: 1
@@ -4482,6 +4517,11 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 7542,
     key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.operator,
+    key.offset: 7547,
+    key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,

--- a/test/SourceKit/DocSupport/doc_clang_module.swift.sub.response
+++ b/test/SourceKit/DocSupport/doc_clang_module.swift.sub.response
@@ -156,6 +156,11 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.length: 4
   },
   {
+    key.kind: source.lang.swift.syntaxtype.operator,
+    key.offset: 217,
+    key.length: 2
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.argument,
     key.offset: 221,
     key.length: 1

--- a/test/SourceKit/DocSupport/doc_source_file.swift.response
+++ b/test/SourceKit/DocSupport/doc_source_file.swift.response
@@ -242,6 +242,11 @@
     key.length: 4
   },
   {
+    key.kind: source.lang.swift.syntaxtype.operator,
+    key.offset: 293,
+    key.length: 1
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.parameter,
     key.offset: 295,
     key.length: 1
@@ -1669,6 +1674,11 @@
     key.length: 7
   },
   {
+    key.kind: source.lang.swift.syntaxtype.operator,
+    key.offset: 1943,
+    key.length: 2
+  },
+  {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
@@ -1694,6 +1704,11 @@
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 1980,
     key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.operator,
+    key.offset: 1985,
+    key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,

--- a/test/SourceKit/DocSupport/doc_swift_module.swift.response
+++ b/test/SourceKit/DocSupport/doc_swift_module.swift.response
@@ -706,6 +706,11 @@ func shouldPrintAnyAsKeyword(x x: Any)
     key.length: 4
   },
   {
+    key.kind: source.lang.swift.syntaxtype.operator,
+    key.offset: 755,
+    key.length: 2
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.argument,
     key.offset: 759,
     key.length: 1
@@ -902,6 +907,11 @@ func shouldPrintAnyAsKeyword(x x: Any)
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 1003,
     key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.operator,
+    key.offset: 1008,
+    key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
@@ -1313,6 +1323,11 @@ func shouldPrintAnyAsKeyword(x x: Any)
     key.length: 7
   },
   {
+    key.kind: source.lang.swift.syntaxtype.operator,
+    key.offset: 1608,
+    key.length: 2
+  },
+  {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
@@ -1444,6 +1459,11 @@ func shouldPrintAnyAsKeyword(x x: Any)
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 1813,
     key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.operator,
+    key.offset: 1818,
+    key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
@@ -1804,6 +1824,11 @@ func shouldPrintAnyAsKeyword(x x: Any)
     key.usr: "s:4cake4ProtP7ElementQa",
     key.offset: 2183,
     key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.operator,
+    key.offset: 2191,
+    key.length: 2
   },
   {
     key.kind: source.lang.swift.ref.struct,

--- a/test/SourceKit/DocSupport/doc_system_module_underscored.swift.response
+++ b/test/SourceKit/DocSupport/doc_system_module_underscored.swift.response
@@ -224,6 +224,11 @@ protocol Other1 {
     key.length: 1
   },
   {
+    key.kind: source.lang.swift.syntaxtype.operator,
+    key.offset: 229,
+    key.length: 2
+  },
+  {
     key.kind: source.lang.swift.ref.struct,
     key.name: "String",
     key.usr: "s:SS",

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
@@ -3314,6 +3314,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 10
   },
   {
+    key.kind: source.lang.swift.syntaxtype.operator,
+    key.offset: 6397,
+    key.length: 1
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 6400,
     key.length: 10
@@ -3357,6 +3362,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.syntaxtype.number,
     key.offset: 6480,
     key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.operator,
+    key.offset: 6486,
+    key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
@@ -3437,6 +3447,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 6661,
     key.length: 10
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.operator,
+    key.offset: 6672,
+    key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,

--- a/test/SourceKit/SyntaxMapData/Inputs/syntaxmap.swift
+++ b/test/SourceKit/SyntaxMapData/Inputs/syntaxmap.swift
@@ -48,7 +48,8 @@ func bar() {}
 // mailto:thisisnotmail
 // unknownprotocol://awesomeguy.com
 
-_ = -123
+let a = -123
+let b = -a
 
 func testArgumentLabels(in class: Int, _ case: (_ default: Int) -> Void) -> (in: Int, String) {
   let result: (in: Int, String) = (0, "test")

--- a/test/SourceKit/SyntaxMapData/syntaxmap-edit-chained-comment.swift
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-edit-chained-comment.swift
@@ -24,6 +24,11 @@
 // CHECK-NEXT:     key.length: 6
 // CHECK-NEXT:   },
 // CHECK-NEXT:   {
+// CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.operator,
+// CHECK-NEXT:     key.offset: 14,
+// CHECK-NEXT:     key.length: 1
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
 // CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.comment,
 // CHECK-NEXT:     key.offset: 16,
 // CHECK-NEXT:     key.length: 6
@@ -44,6 +49,16 @@
 // CHECK-NEXT: key.diagnostic_stage: source.diagnostic.stage.swift.parse,
 // CHECK-NEXT: key.syntaxmap: [
 // CHECK-NEXT:   {
+// CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.operator,
+// CHECK-NEXT:     key.offset: 9,
+// CHECK-NEXT:     key.length: 1
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.operator,
+// CHECK-NEXT:     key.offset: 12,
+// CHECK-NEXT:     key.length: 1
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
 // CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.comment,
 // CHECK-NEXT:     key.offset: 13,
 // CHECK-NEXT:     key.length: 6
@@ -61,6 +76,11 @@
 // CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.comment,
 // CHECK-NEXT:     key.offset: 8,
 // CHECK-NEXT:     key.length: 6
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.operator,
+// CHECK-NEXT:     key.offset: 14,
+// CHECK-NEXT:     key.length: 1
 // CHECK-NEXT:   },
 // CHECK-NEXT:   {
 // CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.comment,

--- a/test/SourceKit/SyntaxMapData/syntaxmap-multiple-edits.swift
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-multiple-edits.swift
@@ -114,13 +114,28 @@
 // CHECK-NEXT:     key.length: 1
 // CHECK-NEXT:   },
 // CHECK-NEXT:   {
+// CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.operator,
+// CHECK-NEXT:     key.offset: 135,
+// CHECK-NEXT:     key.length: 1
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
 // CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.identifier,
 // CHECK-NEXT:     key.offset: 136,
 // CHECK-NEXT:     key.length: 1
 // CHECK-NEXT:   },
 // CHECK-NEXT:   {
+// CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.operator,
+// CHECK-NEXT:     key.offset: 138,
+// CHECK-NEXT:     key.length: 1
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
 // CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.identifier,
 // CHECK-NEXT:     key.offset: 140,
+// CHECK-NEXT:     key.length: 1
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.operator,
+// CHECK-NEXT:     key.offset: 141,
 // CHECK-NEXT:     key.length: 1
 // CHECK-NEXT:   },
 // CHECK-NEXT:   {
@@ -209,9 +224,19 @@
 // CHECK-NEXT:     key.length: 2
 // CHECK-NEXT:   },
 // CHECK-NEXT:   {
+// CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.operator,
+// CHECK-NEXT:     key.offset: 56,
+// CHECK-NEXT:     key.length: 1
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
 // CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.number,
 // CHECK-NEXT:     key.offset: 58,
 // CHECK-NEXT:     key.length: 2
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.operator,
+// CHECK-NEXT:     key.offset: 61,
+// CHECK-NEXT:     key.length: 1
 // CHECK-NEXT:   },
 // CHECK-NEXT:   {
 // CHECK-NEXT:     key.kind: source.lang.swift.syntaxtype.number,

--- a/test/SourceKit/SyntaxMapData/syntaxmap-pound-keyword.swift.response
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-pound-keyword.swift.response
@@ -94,6 +94,11 @@
       key.length: 3
     },
     {
+      key.kind: source.lang.swift.syntaxtype.operator,
+      key.offset: 200,
+      key.length: 1
+    },
+    {
       key.kind: source.lang.swift.syntaxtype.buildconfig.keyword,
       key.offset: 207,
       key.length: 3

--- a/test/SourceKit/SyntaxMapData/syntaxmap.swift.response
+++ b/test/SourceKit/SyntaxMapData/syntaxmap.swift.response
@@ -1,6 +1,6 @@
 {
   key.offset: 0,
-  key.length: 1393,
+  key.length: 1408,
   key.diagnostic_stage: source.diagnostic.stage.swift.parse,
   key.syntaxmap: [
     {
@@ -334,6 +334,11 @@
       key.length: 1
     },
     {
+      key.kind: source.lang.swift.syntaxtype.operator,
+      key.offset: 579,
+      key.length: 1
+    },
+    {
       key.kind: source.lang.swift.syntaxtype.identifier,
       key.offset: 581,
       key.length: 1
@@ -426,321 +431,346 @@
     {
       key.kind: source.lang.swift.syntaxtype.keyword,
       key.offset: 850,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 854,
       key.length: 1
     },
     {
       key.kind: source.lang.swift.syntaxtype.number,
-      key.offset: 854,
+      key.offset: 858,
       key.length: 4
     },
     {
       key.kind: source.lang.swift.syntaxtype.keyword,
-      key.offset: 860,
+      key.offset: 863,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 867,
+      key.length: 1
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.operator,
+      key.offset: 871,
+      key.length: 1
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 872,
+      key.length: 1
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 875,
       key.length: 4
     },
     {
       key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 865,
+      key.offset: 880,
       key.length: 18
     },
     {
       key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 884,
+      key.offset: 899,
       key.length: 2
     },
     {
       key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 887,
+      key.offset: 902,
       key.length: 5
     },
     {
       key.kind: source.lang.swift.syntaxtype.typeidentifier,
-      key.offset: 894,
+      key.offset: 909,
       key.length: 3
     },
     {
       key.kind: source.lang.swift.syntaxtype.keyword,
-      key.offset: 899,
+      key.offset: 914,
       key.length: 1
     },
     {
       key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 901,
+      key.offset: 916,
       key.length: 4
     },
     {
       key.kind: source.lang.swift.syntaxtype.keyword,
-      key.offset: 908,
+      key.offset: 923,
       key.length: 1
     },
     {
       key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 910,
+      key.offset: 925,
       key.length: 7
     },
     {
       key.kind: source.lang.swift.syntaxtype.typeidentifier,
-      key.offset: 919,
+      key.offset: 934,
       key.length: 3
     },
     {
       key.kind: source.lang.swift.syntaxtype.typeidentifier,
-      key.offset: 927,
+      key.offset: 942,
       key.length: 4
     },
     {
       key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 937,
+      key.offset: 952,
       key.length: 2
     },
     {
       key.kind: source.lang.swift.syntaxtype.typeidentifier,
-      key.offset: 941,
+      key.offset: 956,
       key.length: 3
     },
     {
       key.kind: source.lang.swift.syntaxtype.typeidentifier,
-      key.offset: 946,
+      key.offset: 961,
       key.length: 6
     },
     {
       key.kind: source.lang.swift.syntaxtype.keyword,
-      key.offset: 958,
+      key.offset: 973,
       key.length: 3
     },
     {
       key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 962,
+      key.offset: 977,
       key.length: 6
     },
     {
       key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 971,
+      key.offset: 986,
       key.length: 2
     },
     {
       key.kind: source.lang.swift.syntaxtype.typeidentifier,
-      key.offset: 975,
+      key.offset: 990,
       key.length: 3
     },
     {
       key.kind: source.lang.swift.syntaxtype.typeidentifier,
-      key.offset: 980,
+      key.offset: 995,
       key.length: 6
     },
     {
       key.kind: source.lang.swift.syntaxtype.number,
-      key.offset: 991,
+      key.offset: 1006,
       key.length: 1
     },
     {
       key.kind: source.lang.swift.syntaxtype.string,
-      key.offset: 994,
+      key.offset: 1009,
       key.length: 6
     },
     {
       key.kind: source.lang.swift.syntaxtype.keyword,
-      key.offset: 1004,
+      key.offset: 1019,
       key.length: 6
     },
     {
       key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 1011,
+      key.offset: 1026,
       key.length: 9
     },
     {
       key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 1023,
+      key.offset: 1038,
       key.length: 6
     },
     {
       key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 1033,
+      key.offset: 1048,
       key.length: 2
     },
     {
       key.kind: source.lang.swift.syntaxtype.number,
-      key.offset: 1037,
+      key.offset: 1052,
       key.length: 1
     },
     {
       key.kind: source.lang.swift.syntaxtype.string,
-      key.offset: 1040,
+      key.offset: 1055,
       key.length: 5
     },
     {
       key.kind: source.lang.swift.syntaxtype.comment,
-      key.offset: 1050,
+      key.offset: 1065,
       key.length: 3
     },
     {
       key.kind: source.lang.swift.syntaxtype.comment.url,
-      key.offset: 1053,
+      key.offset: 1068,
       key.length: 37
     },
     {
       key.kind: source.lang.swift.syntaxtype.comment,
-      key.offset: 1090,
+      key.offset: 1105,
       key.length: 1
     },
     {
       key.kind: source.lang.swift.syntaxtype.keyword,
-      key.offset: 1091,
+      key.offset: 1106,
       key.length: 4
     },
     {
       key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 1096,
+      key.offset: 1111,
       key.length: 8
     },
     {
       key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 1105,
+      key.offset: 1120,
       key.length: 5
     },
     {
       key.kind: source.lang.swift.syntaxtype.typeidentifier,
-      key.offset: 1112,
+      key.offset: 1127,
       key.length: 3
     },
     {
       key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 1118,
+      key.offset: 1133,
       key.length: 10
     },
     {
       key.kind: source.lang.swift.syntaxtype.keyword,
-      key.offset: 1133,
+      key.offset: 1148,
       key.length: 6
     },
     {
       key.kind: source.lang.swift.syntaxtype.typeidentifier,
-      key.offset: 1143,
+      key.offset: 1158,
       key.length: 4
     },
     {
       key.kind: source.lang.swift.syntaxtype.keyword,
-      key.offset: 1149,
+      key.offset: 1164,
       key.length: 8
     },
     {
       key.kind: source.lang.swift.syntaxtype.comment,
-      key.offset: 1162,
+      key.offset: 1177,
       key.length: 3
     },
     {
       key.kind: source.lang.swift.syntaxtype.comment.url,
-      key.offset: 1165,
+      key.offset: 1180,
       key.length: 37
     },
     {
       key.kind: source.lang.swift.syntaxtype.comment,
-      key.offset: 1202,
+      key.offset: 1217,
       key.length: 1
     },
     {
       key.kind: source.lang.swift.syntaxtype.keyword,
-      key.offset: 1203,
+      key.offset: 1218,
       key.length: 4
     },
     {
       key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 1208,
+      key.offset: 1223,
       key.length: 1
     },
     {
       key.kind: source.lang.swift.syntaxtype.keyword,
-      key.offset: 1216,
+      key.offset: 1231,
       key.length: 4
     },
     {
       key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 1221,
+      key.offset: 1236,
       key.length: 11
     },
     {
       key.kind: source.lang.swift.syntaxtype.keyword,
-      key.offset: 1237,
+      key.offset: 1252,
       key.length: 4
-    },
-    {
-      key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 1242,
-      key.length: 14
     },
     {
       key.kind: source.lang.swift.syntaxtype.identifier,
       key.offset: 1257,
+      key.length: 14
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 1272,
       key.length: 6
     },
     {
       key.kind: source.lang.swift.syntaxtype.typeidentifier,
-      key.offset: 1265,
+      key.offset: 1280,
       key.length: 6
     },
     {
       key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 1273,
+      key.offset: 1288,
       key.length: 6
     },
     {
       key.kind: source.lang.swift.syntaxtype.typeidentifier,
-      key.offset: 1281,
+      key.offset: 1296,
       key.length: 3
     },
     {
       key.kind: source.lang.swift.syntaxtype.keyword,
-      key.offset: 1290,
+      key.offset: 1305,
       key.length: 4
     },
     {
       key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 1295,
+      key.offset: 1310,
       key.length: 14
     },
     {
       key.kind: source.lang.swift.syntaxtype.typeidentifier,
-      key.offset: 1310,
+      key.offset: 1325,
       key.length: 6
     },
     {
       key.kind: source.lang.swift.syntaxtype.typeidentifier,
-      key.offset: 1318,
+      key.offset: 1333,
       key.length: 3
     },
     {
       key.kind: source.lang.swift.syntaxtype.keyword,
-      key.offset: 1326,
+      key.offset: 1341,
       key.length: 8
     },
     {
       key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 1335,
+      key.offset: 1350,
       key.length: 13
     },
     {
       key.kind: source.lang.swift.syntaxtype.keyword,
-      key.offset: 1353,
+      key.offset: 1368,
       key.length: 3
     },
     {
       key.kind: source.lang.swift.syntaxtype.identifier,
-      key.offset: 1357,
+      key.offset: 1372,
       key.length: 14
     },
     {
       key.kind: source.lang.swift.syntaxtype.typeidentifier,
-      key.offset: 1373,
+      key.offset: 1388,
       key.length: 3
     },
     {
       key.kind: source.lang.swift.syntaxtype.keyword,
-      key.offset: 1379,
+      key.offset: 1394,
       key.length: 3
     },
     {
       key.kind: source.lang.swift.syntaxtype.keyword,
-      key.offset: 1383,
+      key.offset: 1398,
       key.length: 5
     }
   ]

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -787,6 +787,7 @@ public:
         return true;
       break;
 
+    case SyntaxNodeKind::Operator:
     case SyntaxNodeKind::DollarIdent:
     case SyntaxNodeKind::Integer:
     case SyntaxNodeKind::Floating:

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -452,6 +452,8 @@ UIdent SwiftLangSupport::getUIDForSyntaxNodeKind(SyntaxNodeKind SC) {
   case SyntaxNodeKind::Identifier:
   case SyntaxNodeKind::DollarIdent:
     return KindIdentifier;
+  case SyntaxNodeKind::Operator:
+    return KindOperator;
   case SyntaxNodeKind::Integer:
   case SyntaxNodeKind::Floating:
     return KindNumber;

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1821,6 +1821,7 @@ public:
     case SyntaxNodeKind::Keyword: Id = "kw"; break;
     // Skip identifier.
     case SyntaxNodeKind::Identifier: return;
+    case SyntaxNodeKind::Operator: return;
     case SyntaxNodeKind::DollarIdent: Id = "dollar"; break;
     case SyntaxNodeKind::Integer: Id = "int"; break;
     case SyntaxNodeKind::Floating: Id = "float"; break;
@@ -1852,6 +1853,7 @@ public:
     case SyntaxNodeKind::Keyword: Col = llvm::raw_ostream::MAGENTA; break;
     // Skip identifier.
     case SyntaxNodeKind::Identifier: return;
+    case SyntaxNodeKind::Operator: Col = llvm::raw_ostream::MAGENTA; break;
     case SyntaxNodeKind::DollarIdent: Col = llvm::raw_ostream::MAGENTA; break;
     case SyntaxNodeKind::Integer: Col = llvm::raw_ostream::BLUE; break;
     case SyntaxNodeKind::Floating: Col = llvm::raw_ostream::BLUE; break;

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -408,6 +408,7 @@ UID_KINDS = [
     KIND('NameSwift', 'source.lang.name.kind.swift'),
     KIND('Keyword', 'source.lang.swift.syntaxtype.keyword'),
     KIND('Identifier', 'source.lang.swift.syntaxtype.identifier'),
+    KIND('Operator', 'source.lang.swift.syntaxtype.operator'),
     KIND('TypeIdentifier', 'source.lang.swift.syntaxtype.typeidentifier'),
     KIND('BuildConfigKeyword',
          'source.lang.swift.syntaxtype.buildconfig.keyword'),


### PR DESCRIPTION
This will allow us to do semantic highlighting for operators in SourceKit-LSP.

https://github.com/apple/sourcekit-lsp/issues/595