### PR TITLE
[libSyntax] Allow adding garbage nodes in between any two children of a syntax node

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1688,10 +1688,12 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
       if (SyntaxContext->isEnabled()) {
         ParsedPatternSyntax PatternNode =
             ParsedSyntaxRecorder::makeIdentifierPattern(
-                                    SyntaxContext->popToken(), *SyntaxContext);
+                /*GarbageNodes=*/None,
+                /*Identifier=*/SyntaxContext->popToken(), *SyntaxContext);
         ParsedExprSyntax ExprNode =
-            ParsedSyntaxRecorder::makeUnresolvedPatternExpr(std::move(PatternNode),
-                                                             *SyntaxContext);
+            ParsedSyntaxRecorder::makeUnresolvedPatternExpr(
+                /*GarbageNodes=*/None,
+                /*Pattern=*/std::move(PatternNode), *SyntaxContext);
         SyntaxContext->addSyntax(std::move(ExprNode));
       }
       return makeParserResult(new (Context) UnresolvedPatternExpr(pattern));

--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -817,8 +817,20 @@ ParserResult<IfConfigDecl> Parser::parseIfConfig(
     // clause unless we're doing a parse-only pass.
     if (isElse) {
       isActive = !foundActive && shouldEvaluate;
-      if (SyntaxContext->isEnabled())
+      if (SyntaxContext->isEnabled()) {
+        // Because we use the same libSyntax node for #elseif and #else, we need
+        // to disambiguate whether a postfix expression is the condition of
+        // #elseif or a postfix expression of the #else body.
+        // To do this, push three empty syntax nodes onto the stack.
+        //  - First one for garbage nodes between the #else keyword and the
+        //    condition
+        //  - One for the condition itself (whcih doesn't exist)
+        //  - And finally one for the garbage nodes between the condition and
+        //    the elements
         SyntaxContext->addRawSyntax(ParsedRawSyntaxNode());
+        SyntaxContext->addRawSyntax(ParsedRawSyntaxNode());
+        SyntaxContext->addRawSyntax(ParsedRawSyntaxNode());
+      }
     } else {
       llvm::SaveAndRestore<bool> S(InPoundIfEnvironment, true);
       ParserResult<Expr> Result = parseExprSequence(diag::expected_expr,

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -916,7 +916,10 @@ Parser::parseTypeSimpleOrComposition(Diag<> MessageID, ParseTypeReason reason) {
   if (SyntaxContext->isEnabled()) {
     if (auto synType = SyntaxContext->popIf<ParsedTypeSyntax>()) {
       auto LastNode = ParsedSyntaxRecorder::makeCompositionTypeElement(
-          std::move(*synType), None, *SyntaxContext);
+          /*GarbageNodes=*/None,
+          /*Type=*/std::move(*synType),
+          /*GarbageNodes=*/None,
+          /*Ampersand=*/None, *SyntaxContext);
       SyntaxContext->addSyntax(std::move(LastNode));
     }
   }

--- a/lib/Parse/ParsedSyntaxRecorder.cpp.gyb
+++ b/lib/Parse/ParsedSyntaxRecorder.cpp.gyb
@@ -172,6 +172,23 @@ ParsedTupleTypeElementSyntax
 ParsedSyntaxRecorder::makeTupleTypeElement(ParsedTypeSyntax Type,
                                     llvm::Optional<ParsedTokenSyntax> TrailingComma,
                                     SyntaxParsingContext &SPCtx) {
-  return makeTupleTypeElement(None, None, None, None, std::move(Type), None, None,
-                              std::move(TrailingComma), SPCtx);
+  return makeTupleTypeElement(
+    /*GarbageNodes=*/None,
+    /*InOut=*/None,
+    /*GarbageNodes=*/None,
+    /*Name=*/None,
+    /*GarbageNodes=*/None,
+    /*SecondName=*/None,
+    /*GarbageNodes=*/None,
+    /*Colon=*/None,
+    /*GarbageNodes=*/None,
+    std::move(Type),
+    /*GarbageNodes=*/None,
+    /*Ellipsis=*/None,
+    /*GarbageNodes=*/None,
+    /*Initializer=*/None,
+    /*GarbageNodes=*/None,
+    std::move(TrailingComma),
+    SPCtx
+  );
 }

--- a/lib/Parse/SyntaxParsingContext.cpp
+++ b/lib/Parse/SyntaxParsingContext.cpp
@@ -322,10 +322,10 @@ void SyntaxParsingContext::collectNodesInPlace(SyntaxKind CollectionKind,
 static ParsedRawSyntaxNode finalizeSourceFile(RootContextData &RootData,
                                            MutableArrayRef<ParsedRawSyntaxNode> Parts) {
   ParsedRawSyntaxRecorder &Recorder = RootData.Recorder;
-  ParsedRawSyntaxNode Layout[2];
+  ParsedRawSyntaxNode Layout[4];
 
   assert(!Parts.empty() && Parts.back().isToken(tok::eof));
-  Layout[1] = std::move(Parts.back());
+  Layout[3] = std::move(Parts.back());
   Parts = Parts.drop_back();
 
 
@@ -333,10 +333,10 @@ static ParsedRawSyntaxNode finalizeSourceFile(RootContextData &RootData,
     return node.getKind() == SyntaxKind::CodeBlockItem;
   }) && "all top level element must be 'CodeBlockItem'");
 
-  Layout[0] = Recorder.recordRawSyntax(SyntaxKind::CodeBlockItemList, Parts);
+  Layout[1] = Recorder.recordRawSyntax(SyntaxKind::CodeBlockItemList, Parts);
 
   return Recorder.recordRawSyntax(SyntaxKind::SourceFile,
-                                  llvm::makeMutableArrayRef(Layout, 2));
+                                  llvm::makeMutableArrayRef(Layout, 4));
 }
 
 OpaqueSyntaxNode SyntaxParsingContext::finalizeRoot() {

--- a/lib/Syntax/SyntaxFactory.cpp.gyb
+++ b/lib/Syntax/SyntaxFactory.cpp.gyb
@@ -65,8 +65,8 @@ SyntaxFactory::countChildren(SyntaxKind Kind){
 % for node in SYNTAX_NODES:
 %   if not node.is_syntax_collection():
   case SyntaxKind::${node.syntax_kind}:
-%     child_count = len(node.children)
-%     non_optional_child_count = sum(0 if child.is_optional else 1 for child in node.children)
+%     child_count = len(node.non_garbage_children)
+%     non_optional_child_count = sum(0 if child.is_optional else 1 for child in node.non_garbage_children)
     return {${non_optional_child_count}, ${child_count}};
 %   end
 % end
@@ -243,9 +243,14 @@ SyntaxFactory::makeBlank${node.syntax_kind}() {
 % end
 
 TupleTypeSyntax SyntaxFactory::makeVoidTupleType() {
-  return makeTupleType(makeLeftParenToken({}, {}),
-                       makeBlankTupleTypeElementList(),
-                       makeRightParenToken({}, {}));
+  return makeTupleType(
+    /*GarbageNodes=*/None,
+    /*LeftParen=*/makeLeftParenToken({}, {}),
+    /*GarbageNodes=*/None,
+    /*Elements=*/makeBlankTupleTypeElementList(),
+    /*GarbageNodes=*/None,
+    /*RightParen=*/makeRightParenToken({}, {})
+  );
 }
 
 TupleTypeElementSyntax
@@ -253,29 +258,80 @@ SyntaxFactory::makeTupleTypeElement(llvm::Optional<TokenSyntax> Label,
                                     llvm::Optional<TokenSyntax> Colon,
                                     TypeSyntax Type,
                                     llvm::Optional<TokenSyntax> TrailingComma) {
-  return makeTupleTypeElement(None, Label, None, Colon, Type, None, None,
-                              TrailingComma);
+  return makeTupleTypeElement(
+    /*GarbageNodes=*/None,
+    /*InOut=*/None,
+    /*GarbageNodes=*/None,
+    /*Name=*/Label,
+    /*GarbageNodes=*/None,
+    /*SecondName=*/None,
+    /*GarbageNodes=*/None,
+    /*Colon=*/Colon,
+    /*GarbageNodes=*/None,
+    /*Type=*/Type,
+    /*GarbageNodes=*/None,
+    /*Ellipsis=*/None,
+    /*GarbageNodes=*/None,
+    /*Intitializer=*/None,
+    /*GarbageNodes=*/None,
+    /*TrailingComma=*/TrailingComma
+  );
 }
 
 TupleTypeElementSyntax
 SyntaxFactory::makeTupleTypeElement(TypeSyntax Type,
                                     llvm::Optional<TokenSyntax> TrailingComma) {
-  return makeTupleTypeElement(None, None, None, None, Type, None, None,
-                              TrailingComma);
+  return makeTupleTypeElement(
+    /*GarbageNodes=*/None,
+    /*InOut=*/None,
+    /*GarbageNodes=*/None,
+    /*Name=*/None,
+    /*GarbageNodes=*/None,
+    /*SecondName=*/None,
+    /*GarbageNodes=*/None,
+    /*Colon=*/None,
+    /*GarbageNodes=*/None,
+    /*Type=*/Type,
+    /*GarbageNodes=*/None,
+    /*Ellipsis=*/None,
+    /*GarbageNodes=*/None,
+    /*Initializer=*/None,
+    /*GarbageNodes=*/None,
+    /*TrailingComma=*/TrailingComma
+  );
 }
 
 GenericParameterSyntax
 SyntaxFactory::makeGenericParameter(TokenSyntax Name,
                                     llvm::Optional<TokenSyntax> TrailingComma) {
-  return makeGenericParameter(None, Name, None, None, TrailingComma);
+  return makeGenericParameter(
+    /*GarbageNodes=*/None,
+    /*Attributes=*/None,
+    /*GarbageNodes=*/None,
+    /*Name=*/Name,
+    /*GarbageNodes=*/None,
+    /*Colon=*/None,
+    /*GarbageNodes=*/None,
+    /*InheritedType=*/None,
+    /*GarbageNodes=*/None,
+    /*TrailingComma=*/TrailingComma
+  );
 }
 
 TypeSyntax SyntaxFactory::makeTypeIdentifier(StringRef TypeName,
                                              StringRef LeadingTrivia,
                                              StringRef TrailingTrivia) {
-  auto identifier =
-      makeIdentifier(TypeName, LeadingTrivia, TrailingTrivia);
-  return makeSimpleTypeIdentifier(identifier, None);
+  auto identifier = makeIdentifier(
+    TypeName,
+    LeadingTrivia,
+    TrailingTrivia
+  );
+  return makeSimpleTypeIdentifier(
+    /*GarbageNodes=*/None,
+    /*Name=*/identifier,
+    /*GarbageNodes=*/None,
+    /*GenerigArgumentClause=*/None
+  );
 }
 
 TypeSyntax SyntaxFactory::makeAnyTypeIdentifier(StringRef LeadingTrivia,

--- a/test/Syntax/Inputs/serialize_class_decl.json
+++ b/test/Syntax/Inputs/serialize_class_decl.json
@@ -1,15 +1,19 @@
 {
   "kind": "SourceFile",
   "layout": [
+    null,
     {
       "kind": "CodeBlockItemList",
       "layout": [
         {
           "kind": "CodeBlockItem",
           "layout": [
+            null,
             {
               "kind": "ClassDecl",
               "layout": [
+                null,
+                null,
                 null,
                 {
                   "kind": "ModifierList",
@@ -17,6 +21,7 @@
                     {
                       "kind": "DeclModifier",
                       "layout": [
+                        null,
                         {
                           "tokenKind": {
                             "kind": "contextual_keyword",
@@ -26,6 +31,7 @@
                           "trailingTrivia": " ",
                           "presence": "Present"
                         },
+                        null,
                         null
                       ],
                       "presence": "Present"
@@ -33,6 +39,7 @@
                   ],
                   "presence": "Present"
                 },
+                null,
                 {
                   "tokenKind": {
                     "kind": "kw_class"
@@ -41,6 +48,7 @@
                   "trailingTrivia": " ",
                   "presence": "Present"
                 },
+                null,
                 {
                   "tokenKind": {
                     "kind": "identifier",
@@ -53,9 +61,14 @@
                 null,
                 null,
                 null,
+                null,
+                null,
+                null,
+                null,
                 {
                   "kind": "MemberDeclBlock",
                   "layout": [
+                    null,
                     {
                       "tokenKind": {
                         "kind": "l_brace"
@@ -64,11 +77,13 @@
                       "trailingTrivia": "",
                       "presence": "Present"
                     },
+                    null,
                     {
                       "kind": "MemberDeclList",
                       "layout": [],
                       "presence": "Present"
                     },
+                    null,
                     {
                       "tokenKind": {
                         "kind": "r_brace"
@@ -84,6 +99,8 @@
               "presence": "Present"
             },
             null,
+            null,
+            null,
             null
           ],
           "presence": "Present"
@@ -91,6 +108,7 @@
       ],
       "presence": "Present"
     },
+    null,
     {
       "tokenKind": {
         "kind": "eof",

--- a/test/Syntax/Inputs/serialize_distributed_actor.json
+++ b/test/Syntax/Inputs/serialize_distributed_actor.json
@@ -1,15 +1,19 @@
 {
   "kind": "SourceFile",
   "layout": [
+    null,
     {
       "kind": "CodeBlockItemList",
       "layout": [
         {
           "kind": "CodeBlockItem",
           "layout": [
+            null,
             {
               "kind": "ActorDecl",
               "layout": [
+                null,
+                null,
                 null,
                 {
                   "kind": "ModifierList",
@@ -17,6 +21,7 @@
                     {
                       "kind": "DeclModifier",
                       "layout": [
+                        null,
                         {
                           "tokenKind": {
                             "kind": "contextual_keyword",
@@ -26,6 +31,7 @@
                           "trailingTrivia": " ",
                           "presence": "Present"
                         },
+                        null,
                         null
                       ],
                       "presence": "Present"
@@ -33,6 +39,7 @@
                   ],
                   "presence": "Present"
                 },
+                null,
                 {
                   "tokenKind": {
                     "kind": "contextual_keyword",
@@ -42,6 +49,7 @@
                   "trailingTrivia": " ",
                   "presence": "Present"
                 },
+                null,
                 {
                   "tokenKind": {
                     "kind": "identifier",
@@ -54,9 +62,14 @@
                 null,
                 null,
                 null,
+                null,
+                null,
+                null,
+                null,
                 {
                   "kind": "MemberDeclBlock",
                   "layout": [
+                    null,
                     {
                       "tokenKind": {
                         "kind": "l_brace"
@@ -65,15 +78,19 @@
                       "trailingTrivia": "",
                       "presence": "Present"
                     },
+                    null,
                     {
                       "kind": "MemberDeclList",
                       "layout": [
                         {
                           "kind": "MemberDeclListItem",
                           "layout": [
+                            null,
                             {
                               "kind": "FunctionDecl",
                               "layout": [
+                                null,
+                                null,
                                 null,
                                 {
                                   "kind": "ModifierList",
@@ -81,6 +98,7 @@
                                     {
                                       "kind": "DeclModifier",
                                       "layout": [
+                                        null,
                                         {
                                           "tokenKind": {
                                             "kind": "contextual_keyword",
@@ -90,6 +108,7 @@
                                           "trailingTrivia": " ",
                                           "presence": "Present"
                                         },
+                                        null,
                                         null
                                       ],
                                       "presence": "Present"
@@ -97,6 +116,7 @@
                                   ],
                                   "presence": "Present"
                                 },
+                                null,
                                 {
                                   "tokenKind": {
                                     "kind": "kw_func"
@@ -105,6 +125,7 @@
                                   "trailingTrivia": " ",
                                   "presence": "Present"
                                 },
+                                null,
                                 {
                                   "tokenKind": {
                                     "kind": "identifier",
@@ -115,12 +136,16 @@
                                   "presence": "Present"
                                 },
                                 null,
+                                null,
+                                null,
                                 {
                                   "kind": "FunctionSignature",
                                   "layout": [
+                                    null,
                                     {
                                       "kind": "ParameterClause",
                                       "layout": [
+                                        null,
                                         {
                                           "tokenKind": {
                                             "kind": "l_paren"
@@ -129,12 +154,15 @@
                                           "trailingTrivia": "",
                                           "presence": "Present"
                                         },
+                                        null,
                                         {
                                           "kind": "FunctionParameterList",
                                           "layout": [
                                             {
                                               "kind": "FunctionParameter",
                                               "layout": [
+                                                null,
+                                                null,
                                                 null,
                                                 {
                                                   "tokenKind": {
@@ -146,6 +174,8 @@
                                                   "presence": "Present"
                                                 },
                                                 null,
+                                                null,
+                                                null,
                                                 {
                                                   "tokenKind": {
                                                     "kind": "colon"
@@ -154,9 +184,11 @@
                                                   "trailingTrivia": " ",
                                                   "presence": "Present"
                                                 },
+                                                null,
                                                 {
                                                   "kind": "SimpleTypeIdentifier",
                                                   "layout": [
+                                                    null,
                                                     {
                                                       "tokenKind": {
                                                         "kind": "identifier",
@@ -166,10 +198,14 @@
                                                       "trailingTrivia": "",
                                                       "presence": "Present"
                                                     },
+                                                    null,
                                                     null
                                                   ],
                                                   "presence": "Present"
                                                 },
+                                                null,
+                                                null,
+                                                null,
                                                 null,
                                                 null,
                                                 null
@@ -179,6 +215,7 @@
                                           ],
                                           "presence": "Present"
                                         },
+                                        null,
                                         {
                                           "tokenKind": {
                                             "kind": "r_paren"
@@ -192,9 +229,13 @@
                                     },
                                     null,
                                     null,
+                                    null,
+                                    null,
+                                    null,
                                     {
                                       "kind": "ReturnClause",
                                       "layout": [
+                                        null,
                                         {
                                           "tokenKind": {
                                             "kind": "arrow"
@@ -203,9 +244,11 @@
                                           "trailingTrivia": " ",
                                           "presence": "Present"
                                         },
+                                        null,
                                         {
                                           "kind": "SimpleTypeIdentifier",
                                           "layout": [
+                                            null,
                                             {
                                               "tokenKind": {
                                                 "kind": "identifier",
@@ -215,6 +258,7 @@
                                               "trailingTrivia": " ",
                                               "presence": "Present"
                                             },
+                                            null,
                                             null
                                           ],
                                           "presence": "Present"
@@ -226,9 +270,12 @@
                                   "presence": "Present"
                                 },
                                 null,
+                                null,
+                                null,
                                 {
                                   "kind": "CodeBlock",
                                   "layout": [
+                                    null,
                                     {
                                       "tokenKind": {
                                         "kind": "l_brace"
@@ -237,15 +284,19 @@
                                       "trailingTrivia": "",
                                       "presence": "Present"
                                     },
+                                    null,
                                     {
                                       "kind": "CodeBlockItemList",
                                       "layout": [
                                         {
                                           "kind": "CodeBlockItem",
                                           "layout": [
+                                            null,
                                             {
                                               "kind": "StringLiteralExpr",
                                               "layout": [
+                                                null,
+                                                null,
                                                 null,
                                                 {
                                                   "tokenKind": {
@@ -255,12 +306,14 @@
                                                   "trailingTrivia": "",
                                                   "presence": "Present"
                                                 },
+                                                null,
                                                 {
                                                   "kind": "StringLiteralSegments",
                                                   "layout": [
                                                     {
                                                       "kind": "StringSegment",
                                                       "layout": [
+                                                        null,
                                                         {
                                                           "tokenKind": {
                                                             "kind": "string_segment",
@@ -276,6 +329,7 @@
                                                     {
                                                       "kind": "ExpressionSegment",
                                                       "layout": [
+                                                        null,
                                                         {
                                                           "tokenKind": {
                                                             "kind": "backslash"
@@ -285,6 +339,8 @@
                                                           "presence": "Present"
                                                         },
                                                         null,
+                                                        null,
+                                                        null,
                                                         {
                                                           "tokenKind": {
                                                             "kind": "l_paren"
@@ -293,6 +349,7 @@
                                                           "trailingTrivia": "",
                                                           "presence": "Present"
                                                         },
+                                                        null,
                                                         {
                                                           "kind": "TupleExprElementList",
                                                           "layout": [
@@ -301,9 +358,13 @@
                                                               "layout": [
                                                                 null,
                                                                 null,
+                                                                null,
+                                                                null,
+                                                                null,
                                                                 {
                                                                   "kind": "IdentifierExpr",
                                                                   "layout": [
+                                                                    null,
                                                                     {
                                                                       "tokenKind": {
                                                                         "kind": "identifier",
@@ -313,10 +374,12 @@
                                                                       "trailingTrivia": "",
                                                                       "presence": "Present"
                                                                     },
+                                                                    null,
                                                                     null
                                                                   ],
                                                                   "presence": "Present"
                                                                 },
+                                                                null,
                                                                 null
                                                               ],
                                                               "presence": "Present"
@@ -324,6 +387,7 @@
                                                           ],
                                                           "presence": "Present"
                                                         },
+                                                        null,
                                                         {
                                                           "tokenKind": {
                                                             "kind": "string_interpolation_anchor"
@@ -338,6 +402,7 @@
                                                     {
                                                       "kind": "StringSegment",
                                                       "layout": [
+                                                        null,
                                                         {
                                                           "tokenKind": {
                                                             "kind": "string_segment",
@@ -353,6 +418,7 @@
                                                   ],
                                                   "presence": "Present"
                                                 },
+                                                null,
                                                 {
                                                   "tokenKind": {
                                                     "kind": "string_quote"
@@ -361,10 +427,13 @@
                                                   "trailingTrivia": "",
                                                   "presence": "Present"
                                                 },
+                                                null,
                                                 null
                                               ],
                                               "presence": "Present"
                                             },
+                                            null,
+                                            null,
                                             null,
                                             null
                                           ],
@@ -373,6 +442,7 @@
                                       ],
                                       "presence": "Present"
                                     },
+                                    null,
                                     {
                                       "tokenKind": {
                                         "kind": "r_brace"
@@ -387,6 +457,7 @@
                               ],
                               "presence": "Present"
                             },
+                            null,
                             null
                           ],
                           "presence": "Present"
@@ -394,6 +465,7 @@
                       ],
                       "presence": "Present"
                     },
+                    null,
                     {
                       "tokenKind": {
                         "kind": "r_brace"
@@ -409,6 +481,8 @@
               "presence": "Present"
             },
             null,
+            null,
+            null,
             null
           ],
           "presence": "Present"
@@ -416,6 +490,7 @@
       ],
       "presence": "Present"
     },
+    null,
     {
       "tokenKind": {
         "kind": "eof",

--- a/test/Syntax/Inputs/serialize_main_actor.json
+++ b/test/Syntax/Inputs/serialize_main_actor.json
@@ -1,15 +1,20 @@
 {
   "kind": "SourceFile",
   "layout": [
+    null,
     {
       "kind": "CodeBlockItemList",
       "layout": [
         {
           "kind": "CodeBlockItem",
           "layout": [
+            null,
             {
               "kind": "StructDecl",
               "layout": [
+                null,
+                null,
+                null,
                 null,
                 null,
                 {
@@ -20,6 +25,7 @@
                   "trailingTrivia": " ",
                   "presence": "Present"
                 },
+                null,
                 {
                   "tokenKind": {
                     "kind": "identifier",
@@ -32,9 +38,14 @@
                 null,
                 null,
                 null,
+                null,
+                null,
+                null,
+                null,
                 {
                   "kind": "MemberDeclBlock",
                   "layout": [
+                    null,
                     {
                       "tokenKind": {
                         "kind": "l_brace"
@@ -43,15 +54,20 @@
                       "trailingTrivia": "",
                       "presence": "Present"
                     },
+                    null,
                     {
                       "kind": "MemberDeclList",
                       "layout": [
                         {
                           "kind": "MemberDeclListItem",
                           "layout": [
+                            null,
                             {
                               "kind": "InitializerDecl",
                               "layout": [
+                                null,
+                                null,
+                                null,
                                 null,
                                 null,
                                 {
@@ -64,12 +80,17 @@
                                 },
                                 null,
                                 null,
+                                null,
+                                null,
+                                null,
                                 {
                                   "kind": "FunctionSignature",
                                   "layout": [
+                                    null,
                                     {
                                       "kind": "ParameterClause",
                                       "layout": [
+                                        null,
                                         {
                                           "tokenKind": {
                                             "kind": "l_paren"
@@ -78,12 +99,15 @@
                                           "trailingTrivia": "",
                                           "presence": "Present"
                                         },
+                                        null,
                                         {
                                           "kind": "FunctionParameterList",
                                           "layout": [
                                             {
                                               "kind": "FunctionParameter",
                                               "layout": [
+                                                null,
+                                                null,
                                                 null,
                                                 {
                                                   "tokenKind": {
@@ -93,6 +117,7 @@
                                                   "trailingTrivia": " ",
                                                   "presence": "Present"
                                                 },
+                                                null,
                                                 {
                                                   "tokenKind": {
                                                     "kind": "identifier",
@@ -102,6 +127,7 @@
                                                   "trailingTrivia": "",
                                                   "presence": "Present"
                                                 },
+                                                null,
                                                 {
                                                   "tokenKind": {
                                                     "kind": "colon"
@@ -110,9 +136,12 @@
                                                   "trailingTrivia": " ",
                                                   "presence": "Present"
                                                 },
+                                                null,
                                                 {
                                                   "kind": "AttributedType",
                                                   "layout": [
+                                                    null,
+                                                    null,
                                                     null,
                                                     {
                                                       "kind": "AttributeList",
@@ -120,6 +149,7 @@
                                                         {
                                                           "kind": "CustomAttribute",
                                                           "layout": [
+                                                            null,
                                                             {
                                                               "tokenKind": {
                                                                 "kind": "at_sign"
@@ -128,9 +158,11 @@
                                                               "trailingTrivia": "",
                                                               "presence": "Present"
                                                             },
+                                                            null,
                                                             {
                                                               "kind": "SimpleTypeIdentifier",
                                                               "layout": [
+                                                                null,
                                                                 {
                                                                   "tokenKind": {
                                                                     "kind": "identifier",
@@ -140,10 +172,14 @@
                                                                   "trailingTrivia": " ",
                                                                   "presence": "Present"
                                                                 },
+                                                                null,
                                                                 null
                                                               ],
                                                               "presence": "Present"
                                                             },
+                                                            null,
+                                                            null,
+                                                            null,
                                                             null,
                                                             null,
                                                             null
@@ -153,9 +189,11 @@
                                                       ],
                                                       "presence": "Present"
                                                     },
+                                                    null,
                                                     {
                                                       "kind": "FunctionType",
                                                       "layout": [
+                                                        null,
                                                         {
                                                           "tokenKind": {
                                                             "kind": "l_paren"
@@ -164,11 +202,13 @@
                                                           "trailingTrivia": "",
                                                           "presence": "Present"
                                                         },
+                                                        null,
                                                         {
                                                           "kind": "TupleTypeElementList",
                                                           "layout": [],
                                                           "presence": "Present"
                                                         },
+                                                        null,
                                                         {
                                                           "tokenKind": {
                                                             "kind": "r_paren"
@@ -179,6 +219,9 @@
                                                         },
                                                         null,
                                                         null,
+                                                        null,
+                                                        null,
+                                                        null,
                                                         {
                                                           "tokenKind": {
                                                             "kind": "arrow"
@@ -187,9 +230,11 @@
                                                           "trailingTrivia": " ",
                                                           "presence": "Present"
                                                         },
+                                                        null,
                                                         {
                                                           "kind": "SimpleTypeIdentifier",
                                                           "layout": [
+                                                            null,
                                                             {
                                                               "tokenKind": {
                                                                 "kind": "identifier",
@@ -199,6 +244,7 @@
                                                               "trailingTrivia": "",
                                                               "presence": "Present"
                                                             },
+                                                            null,
                                                             null
                                                           ],
                                                           "presence": "Present"
@@ -211,6 +257,9 @@
                                                 },
                                                 null,
                                                 null,
+                                                null,
+                                                null,
+                                                null,
                                                 null
                                               ],
                                               "presence": "Present"
@@ -218,6 +267,7 @@
                                           ],
                                           "presence": "Present"
                                         },
+                                        null,
                                         {
                                           "tokenKind": {
                                             "kind": "r_paren"
@@ -231,14 +281,20 @@
                                     },
                                     null,
                                     null,
+                                    null,
+                                    null,
+                                    null,
                                     null
                                   ],
                                   "presence": "Present"
                                 },
                                 null,
+                                null,
+                                null,
                                 {
                                   "kind": "CodeBlock",
                                   "layout": [
+                                    null,
                                     {
                                       "tokenKind": {
                                         "kind": "l_brace"
@@ -247,11 +303,13 @@
                                       "trailingTrivia": "",
                                       "presence": "Present"
                                     },
+                                    null,
                                     {
                                       "kind": "CodeBlockItemList",
                                       "layout": [],
                                       "presence": "Present"
                                     },
+                                    null,
                                     {
                                       "tokenKind": {
                                         "kind": "r_brace"
@@ -266,6 +324,7 @@
                               ],
                               "presence": "Present"
                             },
+                            null,
                             null
                           ],
                           "presence": "Present"
@@ -273,6 +332,7 @@
                       ],
                       "presence": "Present"
                     },
+                    null,
                     {
                       "tokenKind": {
                         "kind": "r_brace"
@@ -288,6 +348,8 @@
               "presence": "Present"
             },
             null,
+            null,
+            null,
             null
           ],
           "presence": "Present"
@@ -295,9 +357,13 @@
         {
           "kind": "CodeBlockItem",
           "layout": [
+            null,
             {
               "kind": "StructDecl",
               "layout": [
+                null,
+                null,
+                null,
                 null,
                 null,
                 {
@@ -308,6 +374,7 @@
                   "trailingTrivia": " ",
                   "presence": "Present"
                 },
+                null,
                 {
                   "tokenKind": {
                     "kind": "identifier",
@@ -320,9 +387,14 @@
                 null,
                 null,
                 null,
+                null,
+                null,
+                null,
+                null,
                 {
                   "kind": "MemberDeclBlock",
                   "layout": [
+                    null,
                     {
                       "tokenKind": {
                         "kind": "l_brace"
@@ -331,15 +403,20 @@
                       "trailingTrivia": "",
                       "presence": "Present"
                     },
+                    null,
                     {
                       "kind": "MemberDeclList",
                       "layout": [
                         {
                           "kind": "MemberDeclListItem",
                           "layout": [
+                            null,
                             {
                               "kind": "VariableDecl",
                               "layout": [
+                                null,
+                                null,
+                                null,
                                 null,
                                 null,
                                 {
@@ -350,15 +427,18 @@
                                   "trailingTrivia": " ",
                                   "presence": "Present"
                                 },
+                                null,
                                 {
                                   "kind": "PatternBindingList",
                                   "layout": [
                                     {
                                       "kind": "PatternBinding",
                                       "layout": [
+                                        null,
                                         {
                                           "kind": "IdentifierPattern",
                                           "layout": [
+                                            null,
                                             {
                                               "tokenKind": {
                                                 "kind": "identifier",
@@ -371,9 +451,11 @@
                                           ],
                                           "presence": "Present"
                                         },
+                                        null,
                                         {
                                           "kind": "TypeAnnotation",
                                           "layout": [
+                                            null,
                                             {
                                               "tokenKind": {
                                                 "kind": "colon"
@@ -382,9 +464,11 @@
                                               "trailingTrivia": " ",
                                               "presence": "Present"
                                             },
+                                            null,
                                             {
                                               "kind": "SimpleTypeIdentifier",
                                               "layout": [
+                                                null,
                                                 {
                                                   "tokenKind": {
                                                     "kind": "identifier",
@@ -394,6 +478,7 @@
                                                   "trailingTrivia": " ",
                                                   "presence": "Present"
                                                 },
+                                                null,
                                                 null
                                               ],
                                               "presence": "Present"
@@ -402,9 +487,12 @@
                                           "presence": "Present"
                                         },
                                         null,
+                                        null,
+                                        null,
                                         {
                                           "kind": "CodeBlock",
                                           "layout": [
+                                            null,
                                             {
                                               "tokenKind": {
                                                 "kind": "l_brace"
@@ -413,18 +501,22 @@
                                               "trailingTrivia": "",
                                               "presence": "Present"
                                             },
+                                            null,
                                             {
                                               "kind": "CodeBlockItemList",
                                               "layout": [
                                                 {
                                                   "kind": "CodeBlockItem",
                                                   "layout": [
+                                                    null,
                                                     {
                                                       "kind": "FunctionCallExpr",
                                                       "layout": [
+                                                        null,
                                                         {
                                                           "kind": "IdentifierExpr",
                                                           "layout": [
+                                                            null,
                                                             {
                                                               "tokenKind": {
                                                                 "kind": "identifier",
@@ -434,10 +526,13 @@
                                                               "trailingTrivia": " ",
                                                               "presence": "Present"
                                                             },
+                                                            null,
                                                             null
                                                           ],
                                                           "presence": "Present"
                                                         },
+                                                        null,
+                                                        null,
                                                         null,
                                                         {
                                                           "kind": "TupleExprElementList",
@@ -445,9 +540,12 @@
                                                           "presence": "Present"
                                                         },
                                                         null,
+                                                        null,
+                                                        null,
                                                         {
                                                           "kind": "ClosureExpr",
                                                           "layout": [
+                                                            null,
                                                             {
                                                               "tokenKind": {
                                                                 "kind": "l_brace"
@@ -456,15 +554,18 @@
                                                               "trailingTrivia": " ",
                                                               "presence": "Present"
                                                             },
+                                                            null,
                                                             {
                                                               "kind": "ClosureSignature",
                                                               "layout": [
+                                                                null,
                                                                 {
                                                                   "kind": "AttributeList",
                                                                   "layout": [
                                                                     {
                                                                       "kind": "CustomAttribute",
                                                                       "layout": [
+                                                                        null,
                                                                         {
                                                                           "tokenKind": {
                                                                             "kind": "at_sign"
@@ -473,9 +574,11 @@
                                                                           "trailingTrivia": "",
                                                                           "presence": "Present"
                                                                         },
+                                                                        null,
                                                                         {
                                                                           "kind": "SimpleTypeIdentifier",
                                                                           "layout": [
+                                                                            null,
                                                                             {
                                                                               "tokenKind": {
                                                                                 "kind": "identifier",
@@ -485,10 +588,14 @@
                                                                               "trailingTrivia": " ",
                                                                               "presence": "Present"
                                                                             },
+                                                                            null,
                                                                             null
                                                                           ],
                                                                           "presence": "Present"
                                                                         },
+                                                                        null,
+                                                                        null,
+                                                                        null,
                                                                         null,
                                                                         null,
                                                                         null
@@ -498,6 +605,12 @@
                                                                   ],
                                                                   "presence": "Present"
                                                                 },
+                                                                null,
+                                                                null,
+                                                                null,
+                                                                null,
+                                                                null,
+                                                                null,
                                                                 null,
                                                                 null,
                                                                 null,
@@ -514,18 +627,22 @@
                                                               ],
                                                               "presence": "Present"
                                                             },
+                                                            null,
                                                             {
                                                               "kind": "CodeBlockItemList",
                                                               "layout": [
                                                                 {
                                                                   "kind": "CodeBlockItem",
                                                                   "layout": [
+                                                                    null,
                                                                     {
                                                                       "kind": "FunctionCallExpr",
                                                                       "layout": [
+                                                                        null,
                                                                         {
                                                                           "kind": "IdentifierExpr",
                                                                           "layout": [
+                                                                            null,
                                                                             {
                                                                               "tokenKind": {
                                                                                 "kind": "identifier",
@@ -535,10 +652,12 @@
                                                                               "trailingTrivia": "",
                                                                               "presence": "Present"
                                                                             },
+                                                                            null,
                                                                             null
                                                                           ],
                                                                           "presence": "Present"
                                                                         },
+                                                                        null,
                                                                         {
                                                                           "tokenKind": {
                                                                             "kind": "l_paren"
@@ -547,6 +666,7 @@
                                                                           "trailingTrivia": "",
                                                                           "presence": "Present"
                                                                         },
+                                                                        null,
                                                                         {
                                                                           "kind": "TupleExprElementList",
                                                                           "layout": [
@@ -555,9 +675,14 @@
                                                                               "layout": [
                                                                                 null,
                                                                                 null,
+                                                                                null,
+                                                                                null,
+                                                                                null,
                                                                                 {
                                                                                   "kind": "StringLiteralExpr",
                                                                                   "layout": [
+                                                                                    null,
+                                                                                    null,
                                                                                     null,
                                                                                     {
                                                                                       "tokenKind": {
@@ -567,12 +692,14 @@
                                                                                       "trailingTrivia": "",
                                                                                       "presence": "Present"
                                                                                     },
+                                                                                    null,
                                                                                     {
                                                                                       "kind": "StringLiteralSegments",
                                                                                       "layout": [
                                                                                         {
                                                                                           "kind": "StringSegment",
                                                                                           "layout": [
+                                                                                            null,
                                                                                             {
                                                                                               "tokenKind": {
                                                                                                 "kind": "string_segment",
@@ -588,6 +715,7 @@
                                                                                       ],
                                                                                       "presence": "Present"
                                                                                     },
+                                                                                    null,
                                                                                     {
                                                                                       "tokenKind": {
                                                                                         "kind": "string_quote"
@@ -596,10 +724,12 @@
                                                                                       "trailingTrivia": "",
                                                                                       "presence": "Present"
                                                                                     },
+                                                                                    null,
                                                                                     null
                                                                                   ],
                                                                                   "presence": "Present"
                                                                                 },
+                                                                                null,
                                                                                 null
                                                                               ],
                                                                               "presence": "Present"
@@ -607,6 +737,7 @@
                                                                           ],
                                                                           "presence": "Present"
                                                                         },
+                                                                        null,
                                                                         {
                                                                           "tokenKind": {
                                                                             "kind": "r_paren"
@@ -616,10 +747,14 @@
                                                                           "presence": "Present"
                                                                         },
                                                                         null,
+                                                                        null,
+                                                                        null,
                                                                         null
                                                                       ],
                                                                       "presence": "Present"
                                                                     },
+                                                                    null,
+                                                                    null,
                                                                     null,
                                                                     null
                                                                   ],
@@ -628,6 +763,7 @@
                                                               ],
                                                               "presence": "Present"
                                                             },
+                                                            null,
                                                             {
                                                               "tokenKind": {
                                                                 "kind": "r_brace"
@@ -639,10 +775,13 @@
                                                           ],
                                                           "presence": "Present"
                                                         },
+                                                        null,
                                                         null
                                                       ],
                                                       "presence": "Present"
                                                     },
+                                                    null,
+                                                    null,
                                                     null,
                                                     null
                                                   ],
@@ -651,6 +790,7 @@
                                               ],
                                               "presence": "Present"
                                             },
+                                            null,
                                             {
                                               "tokenKind": {
                                                 "kind": "r_brace"
@@ -662,6 +802,7 @@
                                           ],
                                           "presence": "Present"
                                         },
+                                        null,
                                         null
                                       ],
                                       "presence": "Present"
@@ -672,6 +813,7 @@
                               ],
                               "presence": "Present"
                             },
+                            null,
                             null
                           ],
                           "presence": "Present"
@@ -679,6 +821,7 @@
                       ],
                       "presence": "Present"
                     },
+                    null,
                     {
                       "tokenKind": {
                         "kind": "r_brace"
@@ -694,6 +837,8 @@
               "presence": "Present"
             },
             null,
+            null,
+            null,
             null
           ],
           "presence": "Present"
@@ -701,6 +846,7 @@
       ],
       "presence": "Present"
     },
+    null,
     {
       "tokenKind": {
         "kind": "eof",

--- a/test/Syntax/Inputs/serialize_multiple_decls.json
+++ b/test/Syntax/Inputs/serialize_multiple_decls.json
@@ -1,15 +1,20 @@
 {
   "kind": "SourceFile",
   "layout": [
+    null,
     {
       "kind": "CodeBlockItemList",
       "layout": [
         {
           "kind": "CodeBlockItem",
           "layout": [
+            null,
             {
               "kind": "StructDecl",
               "layout": [
+                null,
+                null,
+                null,
                 null,
                 null,
                 {
@@ -20,6 +25,7 @@
                   "trailingTrivia": " ",
                   "presence": "Present"
                 },
+                null,
                 {
                   "tokenKind": {
                     "kind": "identifier",
@@ -32,9 +38,14 @@
                 null,
                 null,
                 null,
+                null,
+                null,
+                null,
+                null,
                 {
                   "kind": "MemberDeclBlock",
                   "layout": [
+                    null,
                     {
                       "tokenKind": {
                         "kind": "l_brace"
@@ -43,11 +54,13 @@
                       "trailingTrivia": "",
                       "presence": "Present"
                     },
+                    null,
                     {
                       "kind": "MemberDeclList",
                       "layout": [],
                       "presence": "Present"
                     },
+                    null,
                     {
                       "tokenKind": {
                         "kind": "r_brace"
@@ -63,6 +76,8 @@
               "presence": "Present"
             },
             null,
+            null,
+            null,
             null
           ],
           "presence": "Present"
@@ -70,9 +85,13 @@
         {
           "kind": "CodeBlockItem",
           "layout": [
+            null,
             {
               "kind": "StructDecl",
               "layout": [
+                null,
+                null,
+                null,
                 null,
                 null,
                 {
@@ -83,6 +102,7 @@
                   "trailingTrivia": " ",
                   "presence": "Present"
                 },
+                null,
                 {
                   "tokenKind": {
                     "kind": "identifier",
@@ -95,9 +115,14 @@
                 null,
                 null,
                 null,
+                null,
+                null,
+                null,
+                null,
                 {
                   "kind": "MemberDeclBlock",
                   "layout": [
+                    null,
                     {
                       "tokenKind": {
                         "kind": "l_brace"
@@ -106,11 +131,13 @@
                       "trailingTrivia": "",
                       "presence": "Present"
                     },
+                    null,
                     {
                       "kind": "MemberDeclList",
                       "layout": [],
                       "presence": "Present"
                     },
+                    null,
                     {
                       "tokenKind": {
                         "kind": "r_brace"
@@ -126,6 +153,8 @@
               "presence": "Present"
             },
             null,
+            null,
+            null,
             null
           ],
           "presence": "Present"
@@ -133,6 +162,7 @@
       ],
       "presence": "Present"
     },
+    null,
     {
       "tokenKind": {
         "kind": "eof",

--- a/test/Syntax/Inputs/serialize_struct_decl.json
+++ b/test/Syntax/Inputs/serialize_struct_decl.json
@@ -1,15 +1,20 @@
 {
   "kind": "SourceFile",
   "layout": [
+    null,
     {
       "kind": "CodeBlockItemList",
       "layout": [
         {
           "kind": "CodeBlockItem",
           "layout": [
+            null,
             {
               "kind": "StructDecl",
               "layout": [
+                null,
+                null,
+                null,
                 null,
                 null,
                 {
@@ -20,6 +25,7 @@
                   "trailingTrivia": " ",
                   "presence": "Present"
                 },
+                null,
                 {
                   "tokenKind": {
                     "kind": "identifier",
@@ -32,9 +38,14 @@
                 null,
                 null,
                 null,
+                null,
+                null,
+                null,
+                null,
                 {
                   "kind": "MemberDeclBlock",
                   "layout": [
+                    null,
                     {
                       "tokenKind": {
                         "kind": "l_brace"
@@ -43,15 +54,20 @@
                       "trailingTrivia": "",
                       "presence": "Present"
                     },
+                    null,
                     {
                       "kind": "MemberDeclList",
                       "layout": [
                         {
                           "kind": "MemberDeclListItem",
                           "layout": [
+                            null,
                             {
                               "kind": "VariableDecl",
                               "layout": [
+                                null,
+                                null,
+                                null,
                                 null,
                                 null,
                                 {
@@ -62,15 +78,18 @@
                                   "trailingTrivia": "   ",
                                   "presence": "Present"
                                 },
+                                null,
                                 {
                                   "kind": "PatternBindingList",
                                   "layout": [
                                     {
                                       "kind": "PatternBinding",
                                       "layout": [
+                                        null,
                                         {
                                           "kind": "IdentifierPattern",
                                           "layout": [
+                                            null,
                                             {
                                               "tokenKind": {
                                                 "kind": "identifier",
@@ -83,9 +102,11 @@
                                           ],
                                           "presence": "Present"
                                         },
+                                        null,
                                         {
                                           "kind": "TypeAnnotation",
                                           "layout": [
+                                            null,
                                             {
                                               "tokenKind": {
                                                 "kind": "colon"
@@ -94,9 +115,11 @@
                                               "trailingTrivia": " ",
                                               "presence": "Present"
                                             },
+                                            null,
                                             {
                                               "kind": "SimpleTypeIdentifier",
                                               "layout": [
+                                                null,
                                                 {
                                                   "tokenKind": {
                                                     "kind": "identifier",
@@ -106,6 +129,7 @@
                                                   "trailingTrivia": "",
                                                   "presence": "Present"
                                                 },
+                                                null,
                                                 null
                                               ],
                                               "presence": "Present"
@@ -113,6 +137,9 @@
                                           ],
                                           "presence": "Present"
                                         },
+                                        null,
+                                        null,
+                                        null,
                                         null,
                                         null,
                                         null
@@ -125,6 +152,7 @@
                               ],
                               "presence": "Present"
                             },
+                            null,
                             null
                           ],
                           "presence": "Present"
@@ -132,9 +160,13 @@
                         {
                           "kind": "MemberDeclListItem",
                           "layout": [
+                            null,
                             {
                               "kind": "VariableDecl",
                               "layout": [
+                                null,
+                                null,
+                                null,
                                 null,
                                 null,
                                 {
@@ -145,15 +177,18 @@
                                   "trailingTrivia": " ",
                                   "presence": "Present"
                                 },
+                                null,
                                 {
                                   "kind": "PatternBindingList",
                                   "layout": [
                                     {
                                       "kind": "PatternBinding",
                                       "layout": [
+                                        null,
                                         {
                                           "kind": "IdentifierPattern",
                                           "layout": [
+                                            null,
                                             {
                                               "tokenKind": {
                                                 "kind": "identifier",
@@ -166,9 +201,11 @@
                                           ],
                                           "presence": "Present"
                                         },
+                                        null,
                                         {
                                           "kind": "TypeAnnotation",
                                           "layout": [
+                                            null,
                                             {
                                               "tokenKind": {
                                                 "kind": "colon"
@@ -177,9 +214,11 @@
                                               "trailingTrivia": " ",
                                               "presence": "Present"
                                             },
+                                            null,
                                             {
                                               "kind": "SimpleTypeIdentifier",
                                               "layout": [
+                                                null,
                                                 {
                                                   "tokenKind": {
                                                     "kind": "identifier",
@@ -189,9 +228,11 @@
                                                   "trailingTrivia": " ",
                                                   "presence": "Present"
                                                 },
+                                                null,
                                                 {
                                                   "kind": "GenericArgumentClause",
                                                   "layout": [
+                                                    null,
                                                     {
                                                       "tokenKind": {
                                                         "kind": "l_angle"
@@ -200,15 +241,18 @@
                                                       "trailingTrivia": " ",
                                                       "presence": "Present"
                                                     },
+                                                    null,
                                                     {
                                                       "kind": "GenericArgumentList",
                                                       "layout": [
                                                         {
                                                           "kind": "GenericArgument",
                                                           "layout": [
+                                                            null,
                                                             {
                                                               "kind": "SimpleTypeIdentifier",
                                                               "layout": [
+                                                                null,
                                                                 {
                                                                   "tokenKind": {
                                                                     "kind": "identifier",
@@ -218,10 +262,12 @@
                                                                   "trailingTrivia": " ",
                                                                   "presence": "Present"
                                                                 },
+                                                                null,
                                                                 null
                                                               ],
                                                               "presence": "Present"
                                                             },
+                                                            null,
                                                             null
                                                           ],
                                                           "presence": "Present"
@@ -229,6 +275,7 @@
                                                       ],
                                                       "presence": "Present"
                                                     },
+                                                    null,
                                                     {
                                                       "tokenKind": {
                                                         "kind": "r_angle"
@@ -248,6 +295,9 @@
                                         },
                                         null,
                                         null,
+                                        null,
+                                        null,
+                                        null,
                                         null
                                       ],
                                       "presence": "Present"
@@ -258,6 +308,7 @@
                               ],
                               "presence": "Present"
                             },
+                            null,
                             null
                           ],
                           "presence": "Present"
@@ -265,6 +316,7 @@
                       ],
                       "presence": "Present"
                     },
+                    null,
                     {
                       "tokenKind": {
                         "kind": "r_brace"
@@ -280,6 +332,8 @@
               "presence": "Present"
             },
             null,
+            null,
+            null,
             null
           ],
           "presence": "Present"
@@ -287,6 +341,7 @@
       ],
       "presence": "Present"
     },
+    null,
     {
       "tokenKind": {
         "kind": "eof",

--- a/test/Syntax/Parser/tree.swift.result
+++ b/test/Syntax/Parser/tree.swift.result
@@ -1,8 +1,8 @@
-<s118><s163><s92><s13><NULL/><NULL/><t6>// REQUIRES: syntax_parser_lib
+<s118><NULL/><s163><s92><NULL/><s13><NULL/><NULL/><NULL/><NULL/><NULL/><t6>// REQUIRES: syntax_parser_lib
 // RUN: %swift-syntax-parser-test %s -dump-tree > %t.result
 // RUN: diff -u %s.result %t.result
 
-|func| </t6><t105>|test|</t105><NULL/><s110><s108><t88>|(|</t88><s174></s174><t89>|)| </t89></s108><NULL/><NULL/><NULL/></s110><NULL/><s93><t90>|{|</t90><s163><s92><s48><NULL/><t102>
-  |"|</t102><s168><s104><t104>|a|</t104></s104><s105><t100>|\|</t100><NULL/><t88>|(|</t88><s165><s97><NULL/><NULL/><s28><t105>|b|</t105><NULL/></s28><NULL/></s97></s165><t101>|)|</t101></s105><s104><t104>|c|</t104></s104></s168><t102>|"|</t102><NULL/></s48><NULL/><NULL/></s92></s163><t91>
-|}|</t91></s93></s13><NULL/><NULL/></s92></s163><t0>
+|func| </t6><NULL/><t105>|test|</t105><NULL/><NULL/><NULL/><s110><NULL/><s108><NULL/><t88>|(|</t88><NULL/><s174></s174><NULL/><t89>|)| </t89></s108><NULL/><NULL/><NULL/><NULL/><NULL/><NULL/></s110><NULL/><NULL/><NULL/><s93><NULL/><t90>|{|</t90><NULL/><s163><s92><NULL/><s48><NULL/><NULL/><NULL/><t102>
+  |"|</t102><NULL/><s168><s104><NULL/><t104>|a|</t104></s104><s105><NULL/><t100>|\|</t100><NULL/><NULL/><NULL/><t88>|(|</t88><NULL/><s165><s97><NULL/><NULL/><NULL/><NULL/><NULL/><s28><NULL/><t105>|b|</t105><NULL/><NULL/></s28><NULL/><NULL/></s97></s165><NULL/><t101>|)|</t101></s105><s104><NULL/><t104>|c|</t104></s104></s168><NULL/><t102>|"|</t102><NULL/><NULL/></s48><NULL/><NULL/><NULL/><NULL/></s92></s163><NULL/><t91>
+|}|</t91></s93></s13><NULL/><NULL/><NULL/><NULL/></s92></s163><NULL/><t0>
 ||</t0></s118>

--- a/test/Syntax/serialize_tupletype.swift.result
+++ b/test/Syntax/serialize_tupletype.swift.result
@@ -1,15 +1,20 @@
 {
   "kind": "SourceFile",
   "layout": [
+    null,
     {
       "kind": "CodeBlockItemList",
       "layout": [
         {
           "kind": "CodeBlockItem",
           "layout": [
+            null,
             {
               "kind": "TypealiasDecl",
               "layout": [
+                null,
+                null,
+                null,
                 null,
                 null,
                 {
@@ -20,6 +25,7 @@
                   "trailingTrivia": " ",
                   "presence": "Present"
                 },
+                null,
                 {
                   "tokenKind": {
                     "kind": "identifier",
@@ -30,9 +36,12 @@
                   "presence": "Present"
                 },
                 null,
+                null,
+                null,
                 {
                   "kind": "TypeInitializerClause",
                   "layout": [
+                    null,
                     {
                       "tokenKind": {
                         "kind": "equal"
@@ -41,9 +50,11 @@
                       "trailingTrivia": " ",
                       "presence": "Present"
                     },
+                    null,
                     {
                       "kind": "TupleType",
                       "layout": [
+                        null,
                         {
                           "tokenKind": {
                             "kind": "l_paren"
@@ -52,12 +63,15 @@
                           "trailingTrivia": "",
                           "presence": "Present"
                         },
+                        null,
                         {
                           "kind": "TupleTypeElementList",
                           "layout": [
                             {
                               "kind": "TupleTypeElement",
                               "layout": [
+                                null,
+                                null,
                                 null,
                                 {
                                   "tokenKind": {
@@ -67,6 +81,7 @@
                                   "trailingTrivia": " ",
                                   "presence": "Present"
                                 },
+                                null,
                                 {
                                   "tokenKind": {
                                     "kind": "identifier",
@@ -76,6 +91,7 @@
                                   "trailingTrivia": "",
                                   "presence": "Present"
                                 },
+                                null,
                                 {
                                   "tokenKind": {
                                     "kind": "colon"
@@ -84,9 +100,11 @@
                                   "trailingTrivia": " ",
                                   "presence": "Present"
                                 },
+                                null,
                                 {
                                   "kind": "SimpleTypeIdentifier",
                                   "layout": [
+                                    null,
                                     {
                                       "tokenKind": {
                                         "kind": "identifier",
@@ -96,10 +114,14 @@
                                       "trailingTrivia": "",
                                       "presence": "Present"
                                     },
+                                    null,
                                     null
                                   ],
                                   "presence": "Present"
                                 },
+                                null,
+                                null,
+                                null,
                                 null,
                                 null,
                                 {
@@ -117,6 +139,8 @@
                               "kind": "TupleTypeElement",
                               "layout": [
                                 null,
+                                null,
+                                null,
                                 {
                                   "tokenKind": {
                                     "kind": "kw__"
@@ -126,6 +150,8 @@
                                   "presence": "Present"
                                 },
                                 null,
+                                null,
+                                null,
                                 {
                                   "tokenKind": {
                                     "kind": "colon"
@@ -134,9 +160,11 @@
                                   "trailingTrivia": " ",
                                   "presence": "Present"
                                 },
+                                null,
                                 {
                                   "kind": "SimpleTypeIdentifier",
                                   "layout": [
+                                    null,
                                     {
                                       "tokenKind": {
                                         "kind": "identifier",
@@ -146,10 +174,14 @@
                                       "trailingTrivia": "",
                                       "presence": "Present"
                                     },
+                                    null,
                                     null
                                   ],
                                   "presence": "Present"
                                 },
+                                null,
+                                null,
+                                null,
                                 null,
                                 null,
                                 null
@@ -159,6 +191,7 @@
                           ],
                           "presence": "Present"
                         },
+                        null,
                         {
                           "tokenKind": {
                             "kind": "r_paren"
@@ -173,10 +206,13 @@
                   ],
                   "presence": "Present"
                 },
+                null,
                 null
               ],
               "presence": "Present"
             },
+            null,
+            null,
             null,
             null
           ],
@@ -185,6 +221,7 @@
       ],
       "presence": "Present"
     },
+    null,
     {
       "tokenKind": {
         "kind": "eof",

--- a/unittests/Syntax/DeclSyntaxTests.cpp
+++ b/unittests/Syntax/DeclSyntaxTests.cpp
@@ -18,8 +18,11 @@ DeclModifierSyntax getCannedDeclModifier(const RC<SyntaxArena> &Arena) {
   auto LParen = Factory.makeLeftParenToken("", "");
   auto Set = Factory.makeIdentifier("set", "", "");
   auto RParen = Factory.makeRightParenToken("", "");
-  return Factory.makeDeclModifier(
-      Private, Factory.makeDeclModifierDetail(LParen, Set, RParen));
+  auto DeclModifierDetail = Factory.makeDeclModifierDetail(
+      /*GarbageNodes=*/None, LParen, /*GarbageNodes=*/None, Set,
+      /*GarbageNodes=*/None, RParen);
+  return Factory.makeDeclModifier(/*GarbageNodes=*/None, Private,
+                                  /*GarbageNodes=*/None, DeclModifierDetail);
 }
 
 TEST(DeclSyntaxTests, DeclModifierMakeAPIs) {
@@ -46,8 +49,12 @@ TEST(DeclSyntaxTests, DeclModifierGetAPIs) {
   auto LParen = Factory.makeLeftParenToken("", "");
   auto Set = Factory.makeIdentifier("set", "", "");
   auto RParen = Factory.makeRightParenToken("", "");
-  auto Mod = Factory.makeDeclModifier(
-      Private, Factory.makeDeclModifierDetail(LParen, Set, RParen));
+  auto DeclModifierDetail = Factory.makeDeclModifierDetail(
+      /*GarbageNodes=*/None, LParen, /*GarbageNodes=*/None, Set,
+      /*GarbageNodes=*/None, RParen);
+  auto Mod =
+      Factory.makeDeclModifier(/*GarbageNodes=*/None, Private,
+                               /*GarbageNodes=*/None, DeclModifierDetail);
 
   ASSERT_EQ(Private.getRaw(), Mod.getName().getRaw());
   ASSERT_EQ(LParen.getRaw(), Mod.getDetail()->getLeftParen().getRaw());
@@ -67,7 +74,9 @@ TEST(DeclSyntaxTests, DeclModifierWithAPIs) {
   llvm::raw_svector_ostream OS(Scratch);
   Factory.makeBlankDeclModifier()
       .withName(Private)
-      .withDetail(Factory.makeDeclModifierDetail(LParen, Set, RParen))
+      .withDetail(Factory.makeDeclModifierDetail(/*GarbageNodes=*/None, LParen,
+                                                 /*GarbageNodes=*/None, Set,
+                                                 /*GarbageNodes=*/None, RParen))
       .print(OS);
   ASSERT_EQ(OS.str().str(), "private(set)");
 }
@@ -89,8 +98,11 @@ TEST(DeclSyntaxTests, TypealiasMakeAPIs) {
     auto Typealias = Factory.makeTypealiasKeyword("", " ");
     auto Subsequence = Factory.makeIdentifier("MyCollection", "", "");
     auto ElementName = Factory.makeIdentifier("Element", "", "");
-    auto ElementParam =
-        Factory.makeGenericParameter(None, ElementName, None, None, None);
+    auto ElementParam = Factory.makeGenericParameter(
+        /*GarbageNodes=*/None, /*Attributes=*/None, /*GarbageNodes=*/None,
+        /*Name=*/ElementName, /*GarbageNodes=*/None, /*Colon=*/None,
+        /*GarbageNodes=*/None, /*InheritedType=*/None, /*GarbageNodes=*/None,
+        /*TrailingComma=*/None);
     auto LeftAngle = Factory.makeLeftAngleToken("", "");
     auto RightAngle = Factory.makeRightAngleToken("", " ");
     auto GenericParams = GenericParameterClauseSyntaxBuilder(Arena)
@@ -100,7 +112,9 @@ TEST(DeclSyntaxTests, TypealiasMakeAPIs) {
                              .build();
     auto Assignment = Factory.makeEqualToken("", " ");
     auto ElementType = Factory.makeTypeIdentifier("Element", "", "");
-    auto ElementArg = Factory.makeGenericArgument(ElementType, None);
+    auto ElementArg = Factory.makeGenericArgument(
+        /*GarbageNodes=*/None, /*ArgumentType=*/ElementType,
+        /*GarbageNodes=*/None, /*TrailingComma=*/None);
 
     auto GenericArgs =
         GenericArgumentClauseSyntaxBuilder(Arena)
@@ -110,11 +124,21 @@ TEST(DeclSyntaxTests, TypealiasMakeAPIs) {
             .build();
 
     auto Array = Factory.makeIdentifier("Array", "", "");
-    auto Array_Int = Factory.makeSimpleTypeIdentifier(Array, GenericArgs);
-    auto TypeInit = Factory.makeTypeInitializerClause(Assignment, Array_Int);
+    auto Array_Int = Factory.makeSimpleTypeIdentifier(
+        /*GarbageNodes=*/None, /*Name=*/Array, /*GarbageNodes=*/None,
+        /*GenericArgumentClause=*/GenericArgs);
+    auto TypeInit = Factory.makeTypeInitializerClause(
+        /*GarbageNodes=*/None, /*Equal=*/Assignment, /*GarbageNodes=*/None,
+        /*Value=*/Array_Int);
     Factory
-        .makeTypealiasDecl(None, None, Typealias, Subsequence, GenericParams,
-                           TypeInit, None)
+        .makeTypealiasDecl(
+            /*GarbageNodes=*/None, /*Attributes=*/None, /*GarbageNodes=*/None,
+            /*Modifiers=*/None, /*GarbageNodes=*/None,
+            /*TypealiasKeyword=*/Typealias, /*GarbageNodes=*/None,
+            /*Identifier=*/Subsequence, /*GarbageNodes=*/None,
+            /*GenericParameterClause=*/GenericParams, /*GarbageNodes=*/None,
+            /*Initializer=*/TypeInit, /*GarbageNodes=*/None,
+            /*GenericWhereClause=*/None)
         .print(OS);
     ASSERT_EQ(OS.str().str(),
               "typealias MyCollection<Element> = Array<Element>");
@@ -127,8 +151,10 @@ TEST(DeclSyntaxTests, TypealiasWithAPIs) {
   auto Typealias = Factory.makeTypealiasKeyword("", " ");
   auto MyCollection = Factory.makeIdentifier("MyCollection", "", "");
   auto ElementName = Factory.makeIdentifier("Element", "", "");
-  auto ElementParam =
-      Factory.makeGenericParameter(None, ElementName, None, None, None);
+  auto ElementParam = Factory.makeGenericParameter(
+      /*GarbageNodes=*/None, None, /*GarbageNodes=*/None, ElementName,
+      /*GarbageNodes=*/None, None, /*GarbageNodes=*/None, None,
+      /*GarbageNodes=*/None, None);
   auto LeftAngle = Factory.makeLeftAngleToken("", "");
   auto RightAngle = Factory.makeRightAngleToken("", " ");
   auto GenericParams = GenericParameterClauseSyntaxBuilder(Arena)
@@ -139,7 +165,8 @@ TEST(DeclSyntaxTests, TypealiasWithAPIs) {
   auto Equal = Factory.makeEqualToken("", " ");
 
   auto ElementType = Factory.makeTypeIdentifier("Element", "", "");
-  auto ElementArg = Factory.makeGenericArgument(ElementType, None);
+  auto ElementArg = Factory.makeGenericArgument(
+      /*GarbageNodes=*/None, ElementType, /*GarbageNodes=*/None, None);
   auto GenericArgs =
       GenericArgumentClauseSyntaxBuilder(Arena)
           .useLeftAngleBracket(LeftAngle)
@@ -148,8 +175,10 @@ TEST(DeclSyntaxTests, TypealiasWithAPIs) {
           .build();
 
   auto Array = Factory.makeIdentifier("Array", "", "");
-  auto Array_Int = Factory.makeSimpleTypeIdentifier(Array, GenericArgs);
-  auto Type_Init = Factory.makeTypeInitializerClause(Equal, Array_Int);
+  auto Array_Int = Factory.makeSimpleTypeIdentifier(
+      /*GarbageNodes=*/None, Array, /*GarbageNodes=*/None, GenericArgs);
+  auto Type_Init = Factory.makeTypeInitializerClause(
+      /*GarbageNodes=*/None, Equal, /*GarbageNodes=*/None, Array_Int);
   {
     SmallString<1> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
@@ -184,7 +213,8 @@ TEST(DeclSyntaxTests, TypealiasBuilderAPIs) {
   auto Equal = Factory.makeEqualToken("", " ");
 
   auto ElementType = Factory.makeTypeIdentifier("Element", "", "");
-  auto ElementArg = Factory.makeGenericArgument(ElementType, None);
+  auto ElementArg = Factory.makeGenericArgument(
+      /*GarbageNodes=*/None, ElementType, /*GarbageNodes=*/None, None);
 
   auto GenericArgs =
       GenericArgumentClauseSyntaxBuilder(Arena)
@@ -194,8 +224,10 @@ TEST(DeclSyntaxTests, TypealiasBuilderAPIs) {
           .build();
 
   auto Array = Factory.makeIdentifier("Array", "", "");
-  auto Array_Int = Factory.makeSimpleTypeIdentifier(Array, GenericArgs);
-  auto Type_Init = Factory.makeTypeInitializerClause(Equal, Array_Int);
+  auto Array_Int = Factory.makeSimpleTypeIdentifier(
+      /*GarbageNodes=*/None, Array, /*GarbageNodes=*/None, GenericArgs);
+  auto Type_Init = Factory.makeTypeInitializerClause(
+      /*GarbageNodes=*/None, Equal, /*GarbageNodes=*/None, Array_Int);
   TypealiasDeclSyntaxBuilder(Arena)
       .useTypealiasKeyword(Typealias)
       .useIdentifier(MyCollection)
@@ -220,13 +252,19 @@ FunctionParameterSyntax getCannedFunctionParameter(const RC<SyntaxArena> &Arena)
 
   auto Sign = Factory.makePrefixOperator("-", "", "");
   auto OneDigits = Factory.makeIntegerLiteral("1", "", "");
-  auto One = Factory.makePrefixOperatorExpr(
-      Sign, Factory.makeIntegerLiteralExpr(OneDigits));
-  auto DefaultArg = Factory.makeInitializerClause(Equal, One);
+  auto OneLiteral =
+      Factory.makeIntegerLiteralExpr(/*GarbageNodes=*/None, OneDigits);
+  auto One = Factory.makePrefixOperatorExpr(/*GarbageNodes=*/None, Sign,
+                                            /*GarbageNodes=*/None, OneLiteral);
+  auto DefaultArg = Factory.makeInitializerClause(/*GarbageNodes=*/None, Equal,
+                                                  /*GarbageNodes=*/None, One);
   auto Comma = Factory.makeCommaToken("", " ");
 
-  return Factory.makeFunctionParameter(None, ExternalName, LocalName, Colon,
-                                       Int, NoEllipsis, DefaultArg, Comma);
+  return Factory.makeFunctionParameter(
+      /*GarbageNodes=*/None, None, /*GarbageNodes=*/None, ExternalName,
+      /*GarbageNodes=*/None, LocalName, /*GarbageNodes=*/None, Colon,
+      /*GarbageNodes=*/None, Int, /*GarbageNodes=*/None, NoEllipsis,
+      /*GarbageNodes=*/None, DefaultArg, /*GarbageNodes=*/None, Comma);
 }
 
 TEST(DeclSyntaxTests, FunctionParameterMakeAPIs) {
@@ -258,13 +296,19 @@ TEST(DeclSyntaxTests, FunctionParameterGetAPIs) {
 
   auto Sign = Factory.makePrefixOperator("-", "", "");
   auto OneDigits = Factory.makeIntegerLiteral("1", "", "");
-  auto One = Factory.makePrefixOperatorExpr(
-      Sign, Factory.makeIntegerLiteralExpr(OneDigits));
-  auto DefaultArg = Factory.makeInitializerClause(Equal, One);
+  auto OneLiteral =
+      Factory.makeIntegerLiteralExpr(/*GarbageNodes=*/None, OneDigits);
+  auto One = Factory.makePrefixOperatorExpr(/*GarbageNodes=*/None, Sign,
+                                            /*GarbageNodes=*/None, OneLiteral);
+  auto DefaultArg = Factory.makeInitializerClause(/*GarbageNodes=*/None, Equal,
+                                                  /*GarbageNodes=*/None, One);
   auto Comma = Factory.makeCommaToken("", "");
 
   auto Param = Factory.makeFunctionParameter(
-      None, ExternalName, LocalName, Colon, Int, NoEllipsis, DefaultArg, Comma);
+      /*GarbageNodes=*/None, None, /*GarbageNodes=*/None, ExternalName,
+      /*GarbageNodes=*/None, LocalName, /*GarbageNodes=*/None, Colon,
+      /*GarbageNodes=*/None, Int, /*GarbageNodes=*/None, NoEllipsis,
+      /*GarbageNodes=*/None, DefaultArg, /*GarbageNodes=*/None, Comma);
 
   ASSERT_EQ(ExternalName.getRaw(), Param.getFirstName()->getRaw());
   ASSERT_EQ(LocalName.getRaw(), Param.getSecondName()->getRaw());
@@ -302,8 +346,9 @@ TEST(DeclSyntaxTests, FunctionParameterWithAPIs) {
 
   auto NoSign = TokenSyntax::missingToken(tok::oper_prefix, "", Arena);
   auto OneDigits = Factory.makeIntegerLiteral("1", "", "");
-  auto One = Factory.makeIntegerLiteralExpr(OneDigits);
-  auto DefaultArg = Factory.makeInitializerClause(Equal, One);
+  auto One = Factory.makeIntegerLiteralExpr(/*GarbageNodes=*/None, OneDigits);
+  auto DefaultArg = Factory.makeInitializerClause(/*GarbageNodes=*/None, Equal,
+                                                  /*GarbageNodes=*/None, One);
   auto Comma = Factory.makeCommaToken("", "");
 
   {
@@ -390,13 +435,18 @@ FunctionSignatureSyntax getCannedFunctionSignature(const RC<SyntaxArena> &Arena)
                   .appending(Param)
                   .castTo<FunctionParameterListSyntax>();
   auto RParen = Factory.makeRightParenToken("", " ");
-  auto Parameter = Factory.makeParameterClause(LParen, List, RParen);
+  auto Parameter = Factory.makeParameterClause(/*GarbageNodes=*/None, LParen,
+                                               /*GarbageNodes=*/None, List,
+                                               /*GarbageNodes=*/None, RParen);
   auto Throws = Factory.makeThrowsKeyword("", " ");
   auto Arrow = Factory.makeArrowToken("", " ");
   auto Int = Factory.makeTypeIdentifier("Int", "", " ");
-  auto Return = Factory.makeReturnClause(Arrow, Int);
+  auto Return = Factory.makeReturnClause(/*GarbageNodes=*/None, Arrow,
+                                         /*GarbageNodes=*/None, Int);
 
-  return Factory.makeFunctionSignature(Parameter, None, Throws, Return);
+  return Factory.makeFunctionSignature(
+      /*GarbageNodes=*/None, Parameter, /*GarbageNodes=*/None, None,
+      /*GarbageNodes=*/None, Throws, /*GarbageNodes=*/None, Return);
 }
 
 TEST(DeclSyntaxTests, FunctionSignatureMakeAPIs) {
@@ -435,9 +485,14 @@ TEST(DeclSyntaxTests, FunctionSignatureGetAPIs) {
 
   auto Int = Factory.makeTypeIdentifier("Int", "", "");
 
+  auto ParamClause = Factory.makeParameterClause(/*GarbageNodes=*/None, LParen,
+                                                 /*GarbageNodes=*/None, List,
+                                                 /*GarbageNodes=*/None, RParen);
+  auto ReturnClause = Factory.makeReturnClause(/*GarbageNodes=*/None, Arrow,
+                                               /*GarbageNodes=*/None, Int);
   auto Sig = Factory.makeFunctionSignature(
-      Factory.makeParameterClause(LParen, List, RParen), None, Throws,
-      Factory.makeReturnClause(Arrow, Int));
+      /*GarbageNodes=*/None, ParamClause, /*GarbageNodes=*/None, None,
+      /*GarbageNodes=*/None, Throws, /*GarbageNodes=*/None, ReturnClause);
 
   ASSERT_EQ(LParen.getRaw(), Sig.getInput().getLeftParen().getRaw());
 
@@ -485,8 +540,11 @@ TEST(DeclSyntaxTests, FunctionSignatureWithAPIs) {
   auto Arrow = Factory.makeArrowToken("", " ");
   auto Int = Factory.makeTypeIdentifier("Int", "", "");
 
-  auto Parameter = Factory.makeParameterClause(LParen, List, RParen);
-  auto Return = Factory.makeReturnClause(Arrow, Int);
+  auto Parameter = Factory.makeParameterClause(/*GarbageNodes=*/None, LParen,
+                                               /*GarbageNodes=*/None, List,
+                                               /*GarbageNodes=*/None, RParen);
+  auto Return = Factory.makeReturnClause(/*GarbageNodes=*/None, Arrow,
+                                         /*GarbageNodes=*/None, Int);
   SmallString<48> Scratch;
   llvm::raw_svector_ostream OS(Scratch);
   Factory.makeBlankFunctionSignature()
@@ -508,16 +566,20 @@ ModifierListSyntax getCannedModifiers(const RC<SyntaxArena> &Arena) {
   auto NoLParen = TokenSyntax::missingToken(tok::l_paren, "(", Arena);
   auto NoArgument = TokenSyntax::missingToken(tok::identifier, "", Arena);
   auto NoRParen = TokenSyntax::missingToken(tok::r_paren, ")", Arena);
-  auto Public =
-      Factory.makeDeclModifier(
-         PublicID,
-        Factory.makeDeclModifierDetail(NoLParen, NoArgument, NoRParen));
+  auto PublicDeclModifierDetail = Factory.makeDeclModifierDetail(
+      /*GarbageNodes=*/None, NoLParen, /*GarbageNodes=*/None, NoArgument,
+      /*GarbageNodes=*/None, NoRParen);
+  auto Public = Factory.makeDeclModifier(
+      /*GarbageNodes=*/None, PublicID,
+      /*GarbageNodes=*/None, PublicDeclModifierDetail);
 
   auto StaticKW = Factory.makeStaticKeyword("", " ");
+  auto StaticDeclModifierDetail = Factory.makeDeclModifierDetail(
+      /*GarbageNodes=*/None, NoLParen, /*GarbageNodes=*/None, NoArgument,
+      /*GarbageNodes=*/None, NoRParen);
   auto Static =
-      Factory.makeDeclModifier(
-        StaticKW,
-        Factory.makeDeclModifierDetail(NoLParen, NoArgument, NoRParen));
+      Factory.makeDeclModifier(/*GarbageNodes=*/None, StaticKW,
+                               /*GarbageNodes=*/None, StaticDeclModifierDetail);
 
   return Factory.makeBlankModifierList().appending(Public).appending(Static);
 }
@@ -547,17 +609,22 @@ CodeBlockSyntax getCannedBody(const RC<SyntaxArena> &Arena) {
   SyntaxFactory Factory(Arena);
   auto NoSign = TokenSyntax::missingToken(tok::oper_prefix, "-", Arena);
   auto OneDigits = Factory.makeIntegerLiteral("1", "", "");
-  auto One = Factory.makeIntegerLiteralExpr(OneDigits);
+  auto One = Factory.makeIntegerLiteralExpr(/*GarbageNodes=*/None, OneDigits);
   auto ReturnKW = Factory.makeReturnKeyword("\n  ", "");
-  auto Return = Factory.makeReturnStmt(ReturnKW, One);
-  auto ReturnItem = Factory.makeCodeBlockItem(Return, None, None);
+  auto Return = Factory.makeReturnStmt(/*GarbageNodes=*/None, ReturnKW,
+                                       /*GarbageNodes=*/None, One);
+  auto ReturnItem = Factory.makeCodeBlockItem(/*GarbageNodes=*/None, Return,
+                                              /*GarbageNodes=*/None, None,
+                                              /*GarbageNodes=*/None, None);
 
   auto Stmts = Factory.makeCodeBlockItemList({ReturnItem});
 
   auto LBrace = Factory.makeLeftBraceToken("", "");
   auto RBrace = Factory.makeRightBraceToken("\n", "");
 
-  return Factory.makeCodeBlock(LBrace, Stmts, RBrace);
+  return Factory.makeCodeBlock(/*GarbageNodes=*/None, LBrace,
+                               /*GarbageNodes=*/None, Stmts,
+                               /*GarbageNodes=*/None, RBrace);
 }
 
 GenericWhereClauseSyntax getCannedWhereClause(const RC<SyntaxArena> &Arena) {
@@ -566,8 +633,11 @@ GenericWhereClauseSyntax getCannedWhereClause(const RC<SyntaxArena> &Arena) {
   auto T = Factory.makeTypeIdentifier("T", "", " ");
   auto EqualEqual = Factory.makeEqualityOperator("", " ");
   auto Int = Factory.makeTypeIdentifier("Int", "", " ");
-  auto SameType = Factory.makeSameTypeRequirement(T, EqualEqual, Int);
-  auto Req = Factory.makeGenericRequirement(SameType, None);
+  auto SameType = Factory.makeSameTypeRequirement(
+      /*GarbageNodes=*/None, T, /*GarbageNodes=*/None, EqualEqual,
+      /*GarbageNodes=*/None, Int);
+  auto Req = Factory.makeGenericRequirement(/*GarbageNodes=*/None, SameType,
+                                            /*GarbageNodes=*/None, None);
 
   auto Requirements = Factory.makeBlankGenericRequirementList().appending(Req);
 
@@ -587,8 +657,11 @@ FunctionDeclSyntax getCannedFunctionDecl(const RC<SyntaxArena> &Arena) {
   auto Signature = getCannedFunctionSignature(Arena);
   auto Body = getCannedBody(Arena);
 
-  return Factory.makeFunctionDecl(NoAttributes, Modifiers, FuncKW, Foo,
-                                  GenericParams, Signature, GenericWhere, Body);
+  return Factory.makeFunctionDecl(
+      /*GarbageNodes=*/None, NoAttributes, /*GarbageNodes=*/None, Modifiers,
+      /*GarbageNodes=*/None, FuncKW, /*GarbageNodes=*/None, Foo,
+      /*GarbageNodes=*/None, GenericParams, /*GarbageNodes=*/None, Signature,
+      /*GarbageNodes=*/None, GenericWhere, /*GarbageNodes=*/None, Body);
 }
 
 TEST(DeclSyntaxTests, FunctionDeclMakeAPIs) {
@@ -655,8 +728,8 @@ TEST(DeclSyntaxTests, ProtocolMakeAPIs) {
     auto Protocol = Factory.makeProtocolKeyword("", " ");
     auto MyCollection = Factory.makeIdentifier("MyCollection", "", "");
     auto ElementName = Factory.makeIdentifier("Element", "", "");
-    auto ElementParam =
-        Factory.makePrimaryAssociatedType(ElementName, None);
+    auto ElementParam = Factory.makePrimaryAssociatedType(
+        /*GarbageNodes=*/None, ElementName, /*GarbageNodes=*/None, None);
     auto LeftAngle = Factory.makeLeftAngleToken("", "");
     auto RightAngle = Factory.makeRightAngleToken("", " ");
     auto PrimaryAssocs = PrimaryAssociatedTypeClauseSyntaxBuilder(Arena)
@@ -672,7 +745,12 @@ TEST(DeclSyntaxTests, ProtocolMakeAPIs) {
                       .useRightBrace(RightBrace)
                       .build();
     Factory
-        .makeProtocolDecl(None, None, Protocol, MyCollection, PrimaryAssocs, None, None, Members)
+        .makeProtocolDecl(/*GarbageNodes=*/None, None, /*GarbageNodes=*/None,
+                          None, /*GarbageNodes=*/None, Protocol,
+                          /*GarbageNodes=*/None, MyCollection,
+                          /*GarbageNodes=*/None, PrimaryAssocs,
+                          /*GarbageNodes=*/None, None, /*GarbageNodes=*/None,
+                          None, /*GarbageNodes=*/None, Members)
         .print(OS);
     ASSERT_EQ(OS.str().str(),
               "protocol MyCollection<Element> {}");

--- a/unittests/Syntax/ExprSyntaxTests.cpp
+++ b/unittests/Syntax/ExprSyntaxTests.cpp
@@ -14,8 +14,10 @@ TEST(ExprSyntaxTests, IntegerLiteralExprMakeAPIs) {
   {
     auto LiteralToken = Factory.makeIntegerLiteral("100", "", "");
     auto Sign = Factory.makePrefixOperator("-", "", "");
+    auto IntegerLiteral =
+        Factory.makeIntegerLiteralExpr(/*GarbageNodes=*/None, LiteralToken);
     auto Literal = Factory.makePrefixOperatorExpr(
-        Sign, Factory.makeIntegerLiteralExpr(LiteralToken));
+        /*GarbageNodes=*/None, Sign, /*GarbageNodes=*/None, IntegerLiteral);
 
     llvm::SmallString<10> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
@@ -26,7 +28,8 @@ TEST(ExprSyntaxTests, IntegerLiteralExprMakeAPIs) {
   {
     auto LiteralToken = Factory.makeIntegerLiteral("1_000", "", "");
     auto NoSign = TokenSyntax::missingToken(tok::oper_prefix, "", Arena);
-    auto Literal = Factory.makeIntegerLiteralExpr(LiteralToken);
+    auto Literal =
+        Factory.makeIntegerLiteralExpr(/*GarbageNodes=*/None, LiteralToken);
 
     llvm::SmallString<10> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
@@ -34,11 +37,13 @@ TEST(ExprSyntaxTests, IntegerLiteralExprMakeAPIs) {
     ASSERT_EQ(OS.str().str(), "1_000");
   }
   {
+    auto IntLiteral = Factory.makeIntegerLiteral("0", "", "    ");
+    auto IntLiteralExpr =
+        Factory.makeIntegerLiteralExpr(/*GarbageNodes=*/None, IntLiteral);
     auto Literal = Factory.makeBlankPrefixOperatorExpr()
                        .withOperatorToken(TokenSyntax::missingToken(
                            tok::oper_prefix, "", Arena))
-                       .withPostfixExpression(Factory.makeIntegerLiteralExpr(
-                           Factory.makeIntegerLiteral("0", "", "    ")));
+                       .withPostfixExpression(IntLiteralExpr);
 
     llvm::SmallString<10> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
@@ -48,8 +53,10 @@ TEST(ExprSyntaxTests, IntegerLiteralExprMakeAPIs) {
   {
     auto LiteralToken = Factory.makeIntegerLiteral("1_000_000_000_000", "", "");
     auto PlusSign = Factory.makePrefixOperator("+", "", "");
+    auto IntLiteralExpr =
+        Factory.makeIntegerLiteralExpr(/*GarbageNodes=*/None, LiteralToken);
     auto OneThousand = Factory.makePrefixOperatorExpr(
-        PlusSign, Factory.makeIntegerLiteralExpr(LiteralToken));
+        /*GarbageNodes=*/None, PlusSign, /*GarbageNodes=*/None, IntLiteralExpr);
 
     llvm::SmallString<10> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
@@ -66,8 +73,10 @@ TEST(ExprSyntaxTests, SymbolicReferenceExprGetAPIs) {
   {
     auto Array = Factory.makeIdentifier("Array", "", "");
     auto Int = Factory.makeIdentifier("Int", "", "");
-    auto IntType = Factory.makeSimpleTypeIdentifier(Int, None);
-    auto GenericArg = Factory.makeGenericArgument(IntType, None);
+    auto IntType = Factory.makeSimpleTypeIdentifier(
+        /*GarbageNodes=*/None, Int, /*GarbageNodes=*/None, None);
+    auto GenericArg = Factory.makeGenericArgument(
+        /*GarbageNodes=*/None, IntType, /*GarbageNodes=*/None, None);
     GenericArgumentClauseSyntaxBuilder ArgBuilder(Arena);
     ArgBuilder.useLeftAngleBracket(Factory.makeLeftAngleToken("", ""))
         .useRightAngleBracket(Factory.makeRightAngleToken("", ""))
@@ -75,7 +84,8 @@ TEST(ExprSyntaxTests, SymbolicReferenceExprGetAPIs) {
 
     auto GenericArgs = ArgBuilder.build();
 
-    auto Ref = Factory.makeSymbolicReferenceExpr(Array, GenericArgs);
+    auto Ref = Factory.makeSymbolicReferenceExpr(
+        /*GarbageNodes=*/None, Array, /*GarbageNodes=*/None, GenericArgs);
 
     ASSERT_EQ(Ref.getIdentifier().getRaw(), Array.getRaw());
 
@@ -97,8 +107,10 @@ TEST(ExprSyntaxTests, SymbolicReferenceExprMakeAPIs) {
   SyntaxFactory Factory(Arena);
   auto Array = Factory.makeIdentifier("Array", "", "");
   auto Int = Factory.makeIdentifier("Int", "", "");
-  auto IntType = Factory.makeSimpleTypeIdentifier(Int, None);
-  auto GenericArg = Factory.makeGenericArgument(IntType, None);
+  auto IntType = Factory.makeSimpleTypeIdentifier(/*GarbageNodes=*/None, Int,
+                                                  /*GarbageNodes=*/None, None);
+  auto GenericArg = Factory.makeGenericArgument(/*GarbageNodes=*/None, IntType,
+                                                /*GarbageNodes=*/None, None);
   GenericArgumentClauseSyntaxBuilder ArgBuilder(Arena);
   ArgBuilder.useLeftAngleBracket(Factory.makeLeftAngleToken("", ""))
       .useRightAngleBracket(Factory.makeRightAngleToken("", ""))
@@ -118,14 +130,20 @@ TEST(ExprSyntaxTests, SymbolicReferenceExprMakeAPIs) {
     llvm::raw_svector_ostream OS(Scratch);
     auto BlankArgs = Factory.makeBlankGenericArgumentClause();
 
-    Factory.makeSymbolicReferenceExpr(Foo, BlankArgs).print(OS);
+    Factory
+        .makeSymbolicReferenceExpr(/*GarbageNodes=*/None, Foo,
+                                   /*GarbageNodes=*/None, BlankArgs)
+        .print(OS);
     EXPECT_EQ(OS.str().str(), "foo");
   }
 
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    Factory.makeSymbolicReferenceExpr(Array, GenericArgs).print(OS);
+    Factory
+        .makeSymbolicReferenceExpr(/*GarbageNodes=*/None, Array,
+                                   /*GarbageNodes=*/None, GenericArgs)
+        .print(OS);
     ASSERT_EQ(OS.str().str(), "Array<Int>");
   }
 }
@@ -135,8 +153,10 @@ TEST(ExprSyntaxTests, SymbolicReferenceExprWithAPIs) {
   SyntaxFactory Factory(Arena);
   auto Array = Factory.makeIdentifier("Array", "", "");
   auto Int = Factory.makeIdentifier("Int", "", "");
-  auto IntType = Factory.makeSimpleTypeIdentifier(Int, None);
-  auto GenericArg = Factory.makeGenericArgument(IntType, None);
+  auto IntType = Factory.makeSimpleTypeIdentifier(/*GarbageNodes=*/None, Int,
+                                                  /*GarbageNodes=*/None, None);
+  auto GenericArg = Factory.makeGenericArgument(/*GarbageNodes=*/None, IntType,
+                                                /*GarbageNodes=*/None, None);
   GenericArgumentClauseSyntaxBuilder ArgBuilder(Arena);
   ArgBuilder.useLeftAngleBracket(Factory.makeLeftAngleToken("", ""))
       .useRightAngleBracket(Factory.makeRightAngleToken("", ""))
@@ -176,11 +196,14 @@ TEST(ExprSyntaxTests, TupleExprElementGetAPIs) {
   auto X = Factory.makeIdentifier("x", "", "");
   auto Foo = Factory.makeIdentifier("foo", "", "");
   auto Colon = Factory.makeColonToken("", " ");
-  auto SymbolicRef = Factory.makeSymbolicReferenceExpr(Foo, llvm::None);
+  auto SymbolicRef = Factory.makeSymbolicReferenceExpr(
+      /*GarbageNodes=*/None, Foo, /*GarbageNodes=*/None, None);
   auto Comma = Factory.makeCommaToken("", " ");
 
   {
-    auto Arg = Factory.makeTupleExprElement(X, Colon, SymbolicRef, Comma);
+    auto Arg = Factory.makeTupleExprElement(
+        /*GarbageNodes=*/None, X, /*GarbageNodes=*/None, Colon,
+        /*GarbageNodes=*/None, SymbolicRef, /*GarbageNodes=*/None, Comma);
 
     ASSERT_EQ(X.getRaw(), Arg.getLabel()->getRaw());
     ASSERT_EQ(Colon.getRaw(), Arg.getColon()->getRaw());
@@ -203,7 +226,8 @@ TEST(ExprSyntaxTests, TupleExprElementMakeAPIs) {
   auto X = Factory.makeIdentifier("x", "", "");
   auto Foo = Factory.makeIdentifier("foo", "", "");
   auto Colon = Factory.makeColonToken("", " ");
-  auto SymbolicRef = Factory.makeSymbolicReferenceExpr(Foo, llvm::None);
+  auto SymbolicRef = Factory.makeSymbolicReferenceExpr(
+      /*GarbageNodes=*/None, Foo, /*GarbageNodes=*/None, None);
   auto Comma = Factory.makeCommaToken("", " ");
 
   {
@@ -223,7 +247,11 @@ TEST(ExprSyntaxTests, TupleExprElementMakeAPIs) {
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    Factory.makeTupleExprElement(X, Colon, SymbolicRef, Comma).print(OS);
+    Factory
+        .makeTupleExprElement(/*GarbageNodes=*/None, X, /*GarbageNodes=*/None,
+                              Colon, /*GarbageNodes=*/None, SymbolicRef,
+                              /*GarbageNodes=*/None, Comma)
+        .print(OS);
     ASSERT_EQ(OS.str().str(), "x: foo, ");
   }
 }
@@ -234,7 +262,8 @@ TEST(ExprSyntaxTests, TupleExprElementWithAPIs) {
   auto X = Factory.makeIdentifier("x", "", "");
   auto Foo = Factory.makeIdentifier("foo", "", "");
   auto Colon = Factory.makeColonToken("", " ");
-  auto SymbolicRef = Factory.makeSymbolicReferenceExpr(Foo, llvm::None);
+  auto SymbolicRef = Factory.makeSymbolicReferenceExpr(
+      /*GarbageNodes=*/None, Foo, /*GarbageNodes=*/None, None);
   auto Comma = Factory.makeCommaToken("", " ");
 
   {
@@ -260,11 +289,14 @@ TupleExprElementListSyntax getFullArgumentList(const RC<SyntaxArena> &Arena) {
   auto Z = Factory.makeIdentifier("z", "", "");
   auto Foo = Factory.makeIdentifier("foo", "", "");
   auto Colon = Factory.makeColonToken("", " ");
-  auto SymbolicRef = Factory.makeSymbolicReferenceExpr(Foo, llvm::None);
+  auto SymbolicRef = Factory.makeSymbolicReferenceExpr(
+      /*GarbageNodes=*/None, Foo, /*GarbageNodes=*/None, None);
   auto Comma = Factory.makeCommaToken("", " ");
   auto NoComma = TokenSyntax::missingToken(tok::comma, ",", Arena);
 
-  auto Arg = Factory.makeTupleExprElement(X, Colon, SymbolicRef, Comma);
+  auto Arg = Factory.makeTupleExprElement(
+      /*GarbageNodes=*/None, X, /*GarbageNodes=*/None, Colon,
+      /*GarbageNodes=*/None, SymbolicRef, /*GarbageNodes=*/None, Comma);
 
   return Factory.makeBlankTupleExprElementList()
       .appending(Arg)
@@ -280,18 +312,24 @@ getLabellessArgumentList(const RC<SyntaxArena> &Arena) {
   auto OneDigits = Factory.makeIntegerLiteral("1", "", "");
   auto TwoDigits = Factory.makeIntegerLiteral("2", "", "");
   auto ThreeDigits = Factory.makeIntegerLiteral("3", "", "");
-  auto One = Factory.makeIntegerLiteralExpr(OneDigits);
+  auto One = Factory.makeIntegerLiteralExpr(/*GarbageNodes=*/None, OneDigits);
   auto NoLabel = TokenSyntax::missingToken(tok::identifier, "", Arena);
   auto NoColon = TokenSyntax::missingToken(tok::colon, ":", Arena);
   auto Comma = Factory.makeCommaToken("", " ");
   auto NoComma = TokenSyntax::missingToken(tok::comma, ",", Arena);
-  auto Two = Factory.makeIntegerLiteralExpr(TwoDigits);
-  auto Three = Factory.makeIntegerLiteralExpr(ThreeDigits);
+  auto Two = Factory.makeIntegerLiteralExpr(/*GarbageNodes=*/None, TwoDigits);
+  auto Three =
+      Factory.makeIntegerLiteralExpr(/*GarbageNodes=*/None, ThreeDigits);
 
-  auto OneArg = Factory.makeTupleExprElement(NoLabel, NoColon, One, Comma);
-  auto TwoArg = Factory.makeTupleExprElement(NoLabel, NoColon, Two, Comma);
-  auto ThreeArg =
-      Factory.makeTupleExprElement(NoLabel, NoColon, Three, NoComma);
+  auto OneArg = Factory.makeTupleExprElement(
+      /*GarbageNodes=*/None, NoLabel, /*GarbageNodes=*/None, NoColon,
+      /*GarbageNodes=*/None, One, /*GarbageNodes=*/None, Comma);
+  auto TwoArg = Factory.makeTupleExprElement(
+      /*GarbageNodes=*/None, NoLabel, /*GarbageNodes=*/None, NoColon,
+      /*GarbageNodes=*/None, Two, /*GarbageNodes=*/None, Comma);
+  auto ThreeArg = Factory.makeTupleExprElement(
+      /*GarbageNodes=*/None, NoLabel, /*GarbageNodes=*/None, NoColon,
+      /*GarbageNodes=*/None, Three, /*GarbageNodes=*/None, NoComma);
 
   return Factory.makeBlankTupleExprElementList()
       .appending(OneArg)
@@ -309,11 +347,14 @@ TEST(ExprSyntaxTests, TupleExprElementListGetAPIs) {
   auto Z = Factory.makeIdentifier("z", "", "");
   auto Foo = Factory.makeIdentifier("foo", "", "");
   auto Colon = Factory.makeColonToken("", " ");
-  auto SymbolicRef = Factory.makeSymbolicReferenceExpr(Foo, llvm::None);
+  auto SymbolicRef = Factory.makeSymbolicReferenceExpr(
+      /*GarbageNodes=*/None, Foo, /*GarbageNodes=*/None, None);
   auto Comma = Factory.makeCommaToken("", " ");
   auto NoComma = TokenSyntax::missingToken(tok::comma, ",", Arena);
 
-  auto Arg = Factory.makeTupleExprElement(X, Colon, SymbolicRef, Comma);
+  auto Arg = Factory.makeTupleExprElement(
+      /*GarbageNodes=*/None, X, /*GarbageNodes=*/None, Colon,
+      /*GarbageNodes=*/None, SymbolicRef, /*GarbageNodes=*/None, Comma);
 
   auto ArgList = Factory.makeBlankTupleExprElementList()
                      .appending(Arg)
@@ -369,11 +410,14 @@ TEST(ExprSyntaxTests, TupleExprElementListMakeAPIs) {
     auto Z = Factory.makeIdentifier("z", "", "");
     auto Foo = Factory.makeIdentifier("foo", "", "");
     auto Colon = Factory.makeColonToken("", " ");
-    auto SymbolicRef = Factory.makeSymbolicReferenceExpr(Foo, llvm::None);
+    auto SymbolicRef = Factory.makeSymbolicReferenceExpr(
+        /*GarbageNodes=*/None, Foo, /*GarbageNodes=*/None, None);
     auto Comma = Factory.makeCommaToken("", " ");
     auto NoComma = TokenSyntax::missingToken(tok::comma, ",", Arena);
 
-    auto Arg = Factory.makeTupleExprElement(X, Colon, SymbolicRef, Comma);
+    auto Arg = Factory.makeTupleExprElement(
+        /*GarbageNodes=*/None, X, /*GarbageNodes=*/None, Colon,
+        /*GarbageNodes=*/None, SymbolicRef, /*GarbageNodes=*/None, Comma);
 
     std::vector<TupleExprElementSyntax> Args {
       Arg, Arg.withLabel(Y), Arg.withLabel(Z).withTrailingComma(NoComma)
@@ -406,13 +450,17 @@ TEST(ExprSyntaxTests, FunctionCallExprGetAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
   SyntaxFactory Factory(Arena);
   auto Foo = Factory.makeIdentifier("foo", "", "");
-  auto SymbolicRef = Factory.makeSymbolicReferenceExpr(Foo, llvm::None);
+  auto SymbolicRef = Factory.makeSymbolicReferenceExpr(
+      /*GarbageNodes=*/None, Foo, /*GarbageNodes=*/None, None);
   auto LeftParen = Factory.makeLeftParenToken("", "");
   auto ArgList = getFullArgumentList(Arena);
   auto RightParen = Factory.makeRightParenToken("", "");
 
-  auto Call = Factory.makeFunctionCallExpr(SymbolicRef, LeftParen, ArgList,
-                                           RightParen, None, None);
+  auto Call = Factory.makeFunctionCallExpr(
+      /*GarbageNodes=*/None, SymbolicRef, /*GarbageNodes=*/None, LeftParen,
+      /*GarbageNodes=*/None, ArgList,
+      /*GarbageNodes=*/None, RightParen, /*GarbageNodes=*/None, None,
+      /*GarbageNodes=*/None, None);
 
   {
     auto GottenExpression1 = Call.getCalledExpression();
@@ -442,14 +490,18 @@ TEST(ExprSyntaxTests, FunctionCallExprMakeAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
   SyntaxFactory Factory(Arena);
   auto Foo = Factory.makeIdentifier("foo", "", "");
-  auto SymbolicRef = Factory.makeSymbolicReferenceExpr(Foo, llvm::None);
+  auto SymbolicRef = Factory.makeSymbolicReferenceExpr(
+      /*GarbageNodes=*/None, Foo, /*GarbageNodes=*/None, None);
   auto LeftParen = Factory.makeLeftParenToken("", "");
   auto ArgList = getFullArgumentList(Arena);
   auto RightParen = Factory.makeRightParenToken("", "");
 
   {
-    auto Call = Factory.makeFunctionCallExpr(SymbolicRef, LeftParen, ArgList,
-                                             RightParen, None, None);
+    auto Call = Factory.makeFunctionCallExpr(
+        /*GarbageNodes=*/None, SymbolicRef, /*GarbageNodes=*/None, LeftParen,
+        /*GarbageNodes=*/None, ArgList,
+        /*GarbageNodes=*/None, RightParen, /*GarbageNodes=*/None, None,
+        /*GarbageNodes=*/None, None);
     llvm::SmallString<64> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
     Call.print(OS);
@@ -468,7 +520,8 @@ TEST(ExprSyntaxTests, FunctionCallExprWithAPIs) {
   RC<SyntaxArena> Arena = SyntaxArena::make();
   SyntaxFactory Factory(Arena);
   auto Foo = Factory.makeIdentifier("foo", "", "");
-  auto SymbolicRef = Factory.makeSymbolicReferenceExpr(Foo, llvm::None);
+  auto SymbolicRef = Factory.makeSymbolicReferenceExpr(
+      /*GarbageNodes=*/None, Foo, /*GarbageNodes=*/None, None);
   auto LeftParen = Factory.makeLeftParenToken("", "");
   auto ArgList = getFullArgumentList(Arena);
   auto RightParen = Factory.makeRightParenToken("", "");
@@ -524,13 +577,14 @@ TEST(ExprSyntaxTests, FunctionCallExprBuilderAPIs) {
   auto OneDigits = Factory.makeIntegerLiteral("1", "", "");
   auto TwoDigits = Factory.makeIntegerLiteral("2", "", "");
   auto ThreeDigits = Factory.makeIntegerLiteral("3", "", "");
-  auto One = Factory.makeIntegerLiteralExpr(OneDigits);
+  auto One = Factory.makeIntegerLiteralExpr(/*GarbageNodes=*/None, OneDigits);
   auto NoLabel = TokenSyntax::missingToken(tok::identifier, "", Arena);
   auto NoColon = TokenSyntax::missingToken(tok::colon, ":", Arena);
   auto Comma = Factory.makeCommaToken("", " ");
   auto NoComma = TokenSyntax::missingToken(tok::comma, ",", Arena);
   auto Foo = Factory.makeIdentifier("foo", "", "");
-  auto SymbolicRef = Factory.makeSymbolicReferenceExpr(Foo, llvm::None);
+  auto SymbolicRef = Factory.makeSymbolicReferenceExpr(
+      /*GarbageNodes=*/None, Foo, /*GarbageNodes=*/None, None);
 
   {
     llvm::SmallString<64> Scratch;
@@ -540,7 +594,9 @@ TEST(ExprSyntaxTests, FunctionCallExprBuilderAPIs) {
     ASSERT_EQ(OS.str().str(), "foo()");
   }
 
-  auto OneArg = Factory.makeTupleExprElement(NoLabel, NoColon, One, Comma);
+  auto OneArg = Factory.makeTupleExprElement(
+      /*GarbageNodes=*/None, NoLabel, /*GarbageNodes=*/None, NoColon,
+      /*GarbageNodes=*/None, One, /*GarbageNodes=*/None, Comma);
   {
     llvm::SmallString<64> Scratch;
     llvm::raw_svector_ostream OS(Scratch);

--- a/unittests/Syntax/StmtSyntaxTests.cpp
+++ b/unittests/Syntax/StmtSyntaxTests.cpp
@@ -47,7 +47,7 @@ TEST(StmtSyntaxTests, FallthroughStmtMakeAPIs) {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
 
-    Factory.makeFallthroughStmt(FallthroughKW).print(OS);
+    Factory.makeFallthroughStmt(/*GarbageNodes=*/None, FallthroughKW).print(OS);
     ASSERT_EQ(OS.str().str(), "fallthrough");
   }
 
@@ -57,7 +57,8 @@ TEST(StmtSyntaxTests, FallthroughStmtMakeAPIs) {
 
     auto NewFallthroughKW = FallthroughKW.withLeadingTrivia("  ");
 
-    Factory.makeFallthroughStmt(NewFallthroughKW).print(OS);
+    Factory.makeFallthroughStmt(/*GarbageNodes=*/None, NewFallthroughKW)
+        .print(OS);
     ASSERT_EQ(OS.str().str(), "  fallthrough");
   }
 
@@ -68,7 +69,8 @@ TEST(StmtSyntaxTests, FallthroughStmtMakeAPIs) {
     auto NewFallthroughKW =
         FallthroughKW.withLeadingTrivia("  ").withTrailingTrivia("  ");
 
-    Factory.makeFallthroughStmt(NewFallthroughKW).print(OS);
+    Factory.makeFallthroughStmt(/*GarbageNodes=*/None, NewFallthroughKW)
+        .print(OS);
     ASSERT_EQ(OS.str().str(), "  fallthrough  ");
   }
 
@@ -88,7 +90,8 @@ TEST(StmtSyntaxTests, BreakStmtGetAPIs) {
   SyntaxFactory Factory(Arena);
   auto BreakKW = Factory.makeBreakKeyword("", " ");
   auto Label = Factory.makeIdentifier("sometimesYouNeedTo", "", "");
-  auto Break = Factory.makeBreakStmt(BreakKW, Label);
+  auto Break = Factory.makeBreakStmt(/*GarbageNodes=*/None, BreakKW,
+                                     /*GarbageNodes=*/None, Label);
 
   /// These should be directly shared through reference-counting.
   ASSERT_EQ(BreakKW.getRaw(), Break.getBreakKeyword().getRaw());
@@ -140,7 +143,8 @@ TEST(StmtSyntaxTests, BreakStmtMakeAPIs) {
     llvm::raw_svector_ostream OS(Scratch);
     auto BreakKW = Factory.makeBreakKeyword("", " ");
     auto Label = Factory.makeIdentifier("theBuild", "", "");
-    auto Break = Factory.makeBreakStmt(BreakKW, Label);
+    auto Break = Factory.makeBreakStmt(/*GarbageNodes=*/None, BreakKW,
+                                       /*GarbageNodes=*/None, Label);
     Break.print(OS);
     ASSERT_EQ(OS.str().str(), "break theBuild"); // don't you dare
   }
@@ -159,7 +163,8 @@ TEST(StmtSyntaxTests, ContinueStmtGetAPIs) {
   SyntaxFactory Factory(Arena);
   auto ContinueKW = Factory.makeContinueKeyword("", " ");
   auto Label = Factory.makeIdentifier("always", "", "");
-  auto Continue = Factory.makeContinueStmt(ContinueKW, Label);
+  auto Continue = Factory.makeContinueStmt(/*GarbageNodes=*/None, ContinueKW,
+                                           /*GarbageNodes=*/None, Label);
 
   /// These should be directly shared through reference-counting.
   ASSERT_EQ(ContinueKW.getRaw(), Continue.getContinueKeyword().getRaw());
@@ -210,7 +215,8 @@ TEST(StmtSyntaxTests, ContinueStmtMakeAPIs) {
     llvm::raw_svector_ostream OS(Scratch);
     auto ContinueKW = Factory.makeContinueKeyword("", " ");
     auto Label = Factory.makeIdentifier("toLead", "", "");
-    auto Continue = Factory.makeContinueStmt(ContinueKW, Label);
+    auto Continue = Factory.makeContinueStmt(/*GarbageNodes=*/None, ContinueKW,
+                                             /*GarbageNodes=*/None, Label);
     Continue.print(OS);
     ASSERT_EQ(OS.str().str(), "continue toLead"); // by example
   }
@@ -230,8 +236,10 @@ TEST(StmtSyntaxTests, ReturnStmtMakeAPIs) {
   auto ReturnKW = Factory.makeReturnKeyword("", " ");
   auto Minus = Factory.makePrefixOperator("-", "", "");
   auto OneDigits = Factory.makeIntegerLiteral("1", "", "");
+  auto OneLiteral =
+      Factory.makeIntegerLiteralExpr(/*GarbageNodes=*/None, OneDigits);
   auto MinusOne = Factory.makePrefixOperatorExpr(
-      Minus, Factory.makeIntegerLiteralExpr(OneDigits));
+      /*GarbageNodes=*/None, Minus, /*GarbageNodes=*/None, OneLiteral);
 
   {
     llvm::SmallString<48> Scratch;
@@ -243,7 +251,10 @@ TEST(StmtSyntaxTests, ReturnStmtMakeAPIs) {
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    Factory.makeReturnStmt(ReturnKW, MinusOne).print(OS);
+    Factory
+        .makeReturnStmt(/*GarbageNodes=*/None, ReturnKW, /*GarbageNodes=*/None,
+                        MinusOne)
+        .print(OS);
     ASSERT_EQ(OS.str().str(), "return -1");
   }
 }
@@ -254,9 +265,12 @@ TEST(StmtSyntaxTests, ReturnStmtGetAPIs) {
   auto ReturnKW = Factory.makeReturnKeyword("", " ");
   auto Minus = Factory.makePrefixOperator("-", "", "");
   auto OneDigits = Factory.makeIntegerLiteral("1", "", "");
+  auto OneLiteral =
+      Factory.makeIntegerLiteralExpr(/*GarbageNodes=*/None, OneDigits);
   auto MinusOne = Factory.makePrefixOperatorExpr(
-      Minus, Factory.makeIntegerLiteralExpr(OneDigits));
-  auto Return = Factory.makeReturnStmt(ReturnKW, MinusOne);
+      /*GarbageNodes=*/None, Minus, /*GarbageNodes=*/None, OneLiteral);
+  auto Return = Factory.makeReturnStmt(/*GarbageNodes=*/None, ReturnKW,
+                                       /*GarbageNodes=*/None, MinusOne);
 
   ASSERT_EQ(ReturnKW.getRaw(), Return.getReturnKeyword().getRaw());
   auto GottenExpression = Return.getExpression().getValue();
@@ -270,8 +284,10 @@ TEST(StmtSyntaxTests, ReturnStmtWithAPIs) {
   auto ReturnKW = Factory.makeReturnKeyword("", " ");
   auto Minus = Factory.makePrefixOperator("-", "", "");
   auto OneDigits = Factory.makeIntegerLiteral("1", "", "");
+  auto OneLiteral =
+      Factory.makeIntegerLiteralExpr(/*GarbageNodes=*/None, OneDigits);
   auto MinusOne = Factory.makePrefixOperatorExpr(
-      Minus, Factory.makeIntegerLiteralExpr(OneDigits));
+      /*GarbageNodes=*/None, Minus, /*GarbageNodes=*/None, OneLiteral);
 
   {
     llvm::SmallString<48> Scratch;

--- a/unittests/Syntax/SyntaxCollectionTests.cpp
+++ b/unittests/Syntax/SyntaxCollectionTests.cpp
@@ -13,10 +13,13 @@ TupleExprElementSyntax getCannedArgument(const RC<SyntaxArena> &Arena) {
   auto X = Factory.makeIdentifier("x", "", "");
   auto Foo = Factory.makeIdentifier("foo", "", "");
   auto Colon = Factory.makeColonToken("", " ");
-  auto SymbolicRef = Factory.makeSymbolicReferenceExpr(Foo, llvm::None);
+  auto SymbolicRef = Factory.makeSymbolicReferenceExpr(
+      /*GarbageNodes=*/None, Foo, /*GarbageNodes=*/None, None);
   auto Comma = Factory.makeCommaToken("", " ");
 
-  return Factory.makeTupleExprElement(X, Colon, SymbolicRef, Comma);
+  return Factory.makeTupleExprElement(
+      /*GarbageNodes=*/None, X, /*GarbageNodes=*/None, Colon,
+      /*GarbageNodes=*/None, SymbolicRef, /*GarbageNodes=*/None, Comma);
 }
 
 TEST(SyntaxCollectionTests, empty) {

--- a/unittests/Syntax/TypeSyntaxTests.cpp
+++ b/unittests/Syntax/TypeSyntaxTests.cpp
@@ -101,8 +101,11 @@ TEST(TypeSyntaxTests, TypeAttributeMakeAPIs) {
       llvm::raw_svector_ostream OS { Scratch };
       auto cID = Factory.makeIdentifier("c", "", "");
       Factory
-          .makeAttribute(At, conventionID, LeftParen, cID, RightParen,
-                         llvm::None)
+          .makeAttribute(/*GarbageNodes=*/None, At, /*GarbageNodes=*/None,
+                         conventionID, /*GarbageNodes=*/None, LeftParen,
+                         /*GarbageNodes=*/None, cID, /*GarbageNodes=*/None,
+                         RightParen,
+                         /*GarbageNodes=*/None, None)
           .print(OS);
       ASSERT_EQ(OS.str().str(), "@convention(c)");
     }
@@ -112,8 +115,11 @@ TEST(TypeSyntaxTests, TypeAttributeMakeAPIs) {
       llvm::raw_svector_ostream OS { Scratch };
       auto swiftID = Factory.makeIdentifier("swift", "", "");
       Factory
-          .makeAttribute(At, conventionID, LeftParen, swiftID, RightParen,
-                         llvm::None)
+          .makeAttribute(/*GarbageNodes=*/None, At, /*GarbageNodes=*/None,
+                         conventionID, /*GarbageNodes=*/None, LeftParen,
+                         /*GarbageNodes=*/None, swiftID, /*GarbageNodes=*/None,
+                         RightParen,
+                         /*GarbageNodes=*/None, None)
           .print(OS);
       ASSERT_EQ(OS.str().str(), "@convention(swift)");
     }
@@ -123,8 +129,11 @@ TEST(TypeSyntaxTests, TypeAttributeMakeAPIs) {
       llvm::raw_svector_ostream OS { Scratch };
       auto blockID = Factory.makeIdentifier("block", "", "");
       Factory
-          .makeAttribute(At, conventionID, LeftParen, blockID, RightParen,
-                         llvm::None)
+          .makeAttribute(/*GarbageNodes=*/None, At, /*GarbageNodes=*/None,
+                         conventionID, /*GarbageNodes=*/None, LeftParen,
+                         /*GarbageNodes=*/None, blockID, /*GarbageNodes=*/None,
+                         RightParen,
+                         /*GarbageNodes=*/None, None)
           .print(OS);
       ASSERT_EQ(OS.str().str(), "@convention(block)");
     }
@@ -204,11 +213,13 @@ TEST(TypeSyntaxTests, TupleBuilderAPIs) {
     auto Comma = Factory.makeCommaToken("", " ");
     auto NoComma = TokenSyntax::missingToken(tok::comma, ",", Arena);
     auto IntId = Factory.makeIdentifier("Int", "", "");
-    auto IntType = Factory.makeSimpleTypeIdentifier(IntId, None);
+    auto IntType = Factory.makeSimpleTypeIdentifier(
+        /*GarbageNodes=*/None, IntId, /*GarbageNodes=*/None, None);
     auto Int = Factory.makeTupleTypeElement(IntType, NoComma);
     auto IntWithComma = Factory.makeTupleTypeElement(IntType, Comma);
     auto StringId = Factory.makeIdentifier("String", "", "");
-    auto StringType = Factory.makeSimpleTypeIdentifier(StringId, None);
+    auto StringType = Factory.makeSimpleTypeIdentifier(
+        /*GarbageNodes=*/None, StringId, /*GarbageNodes=*/None, None);
     auto String = Factory.makeTupleTypeElement(StringType, Comma);
     Builder.addElement(IntWithComma);
     Builder.addElement(String);
@@ -264,15 +275,18 @@ TEST(TypeSyntaxTests, TupleMakeAPIs) {
     auto Int = Factory.makeTypeIdentifier("Int", "", "");
     auto Bool = Factory.makeTypeIdentifier("Bool", "", "");
     auto Comma = Factory.makeCommaToken("", " ");
+    auto LeftParen = Factory.makeLeftParenToken("", "");
+    auto TupleElementList = Factory.makeTupleTypeElementList(
+        {Factory.makeTupleTypeElement(Int, Comma),
+         Factory.makeTupleTypeElement(Bool, Comma),
+         Factory.makeTupleTypeElement(Int, Comma),
+         Factory.makeTupleTypeElement(Bool, Comma),
+         Factory.makeTupleTypeElement(Int, None)});
+    auto RightParen = Factory.makeRightParenToken("", "");
     auto TupleType =
-        Factory.makeTupleType(Factory.makeLeftParenToken("", ""),
-                              Factory.makeTupleTypeElementList(
-                                  {Factory.makeTupleTypeElement(Int, Comma),
-                                   Factory.makeTupleTypeElement(Bool, Comma),
-                                   Factory.makeTupleTypeElement(Int, Comma),
-                                   Factory.makeTupleTypeElement(Bool, Comma),
-                                   Factory.makeTupleTypeElement(Int, None)}),
-                              Factory.makeRightParenToken("", ""));
+        Factory.makeTupleType(/*GarbageNodes=*/None, LeftParen,
+                              /*GarbageNodes=*/None, TupleElementList,
+                              /*GarbageNodes=*/None, RightParen);
     TupleType.print(OS);
     ASSERT_EQ(OS.str().str(),
               "(Int, Bool, Int, Bool, Int)");
@@ -307,7 +321,8 @@ TEST(TypeSyntaxTests, OptionalTypeMakeAPIs) {
     llvm::raw_svector_ostream OS(Scratch);
     auto Int = Factory.makeTypeIdentifier("Int", "", "");
     auto Question = Factory.makePostfixQuestionMarkToken("", "");
-    auto OptionalInt = Factory.makeOptionalType(Int, Question);
+    auto OptionalInt = Factory.makeOptionalType(
+        /*GarbageNodes=*/None, Int, /*GarbageNodes=*/None, Question);
     OptionalInt.print(OS);
     ASSERT_EQ(OS.str(), "Int?");
   }
@@ -336,7 +351,8 @@ TEST(TypeSyntaxTests, ImplicitlyUnwrappedOptionalTypeMakeAPIs) {
     llvm::raw_svector_ostream OS(Scratch);
     auto Int = Factory.makeTypeIdentifier("Int", "", "");
     auto Bang = Factory.makeExclamationMarkToken("", "");
-    auto IntBang = Factory.makeImplicitlyUnwrappedOptionalType(Int, Bang);
+    auto IntBang = Factory.makeImplicitlyUnwrappedOptionalType(
+        /*GarbageNodes=*/None, Int, /*GarbageNodes=*/None, Bang);
     IntBang.print(OS);
     ASSERT_EQ(OS.str(), "Int!");
   }
@@ -366,7 +382,10 @@ TEST(TypeSyntaxTests, MetatypeTypeMakeAPIs) {
     auto Int = Factory.makeTypeIdentifier("T", "", "");
     auto Dot = Factory.makePeriodToken("", "");
     auto Type = Factory.makeTypeToken("", "");
-    Factory.makeMetatypeType(Int, Dot, Type).print(OS);
+    Factory
+        .makeMetatypeType(/*GarbageNodes=*/None, Int, /*GarbageNodes=*/None,
+                          Dot, /*GarbageNodes=*/None, Type)
+        .print(OS);
     ASSERT_EQ(OS.str(), "T.Type");
   }
 }
@@ -439,7 +458,10 @@ TEST(TypeSyntaxTests, ArrayTypeMakeAPIs) {
     auto LeftSquare = Factory.makeLeftSquareBracketToken("", "");
     auto RightSquare = Factory.makeRightSquareBracketToken("", "");
     auto Void = Factory.makeVoidTupleType();
-    Factory.makeArrayType(LeftSquare, Void, RightSquare).print(OS);
+    Factory
+        .makeArrayType(/*GarbageNodes=*/None, LeftSquare, /*GarbageNodes=*/None,
+                       Void, /*GarbageNodes=*/None, RightSquare)
+        .print(OS);
     ASSERT_EQ(OS.str(), "[()]");
   }
 }
@@ -479,7 +501,11 @@ TEST(TypeSyntaxTests, DictionaryTypeMakeAPIs) {
     auto Key = Factory.makeTypeIdentifier("String", "", " ");
     auto Value = Factory.makeTypeIdentifier("Int", "", "");
     auto Colon = Factory.makeColonToken("", " ");
-    Factory.makeDictionaryType(LeftSquare, Key, Colon, Value, RightSquare)
+    Factory
+        .makeDictionaryType(/*GarbageNodes=*/None, LeftSquare,
+                            /*GarbageNodes=*/None, Key, /*GarbageNodes=*/None,
+                            Colon, /*GarbageNodes=*/None, Value,
+                            /*GarbageNodes=*/None, RightSquare)
         .print(OS);
     ASSERT_EQ(OS.str(), "[String : Int]");
   }
@@ -517,8 +543,11 @@ TEST(TypeSyntaxTests, FunctionTypeMakeAPIs) {
 
     auto TypeList = Factory.makeTupleTypeElementList({xArg, yArg});
     Factory
-        .makeFunctionType(LeftParen, TypeList, RightParen, Async, Throws, Arrow,
-                          Int)
+        .makeFunctionType(
+            /*GarbageNodes=*/None, LeftParen, /*GarbageNodes=*/None, TypeList,
+            /*GarbageNodes=*/None, RightParen, /*GarbageNodes=*/None, Async,
+            /*GarbageNodes=*/None, Throws, /*GarbageNodes=*/None, Arrow,
+            /*GarbageNodes=*/None, Int)
         .print(OS);
     ASSERT_EQ(OS.str().str(), "(x: Int, y: Int) async throws -> Int");
   }
@@ -541,8 +570,11 @@ TEST(TypeSyntaxTests, FunctionTypeMakeAPIs) {
 
     auto TypeList = Factory.makeTupleTypeElementList({xArg, yArg});
     Factory
-        .makeFunctionType(LeftParen, TypeList, RightParen, None, Throws, Arrow,
-                          Int)
+        .makeFunctionType(
+            /*GarbageNodes=*/None, LeftParen, /*GarbageNodes=*/None, TypeList,
+            /*GarbageNodes=*/None, RightParen, /*GarbageNodes=*/None, None,
+            /*GarbageNodes=*/None, Throws, /*GarbageNodes=*/None, Arrow,
+            /*GarbageNodes=*/None, Int)
         .print(OS);
     ASSERT_EQ(OS.str().str(), "(x: Int, y: Int) throws -> Int");
   }
@@ -552,8 +584,11 @@ TEST(TypeSyntaxTests, FunctionTypeMakeAPIs) {
     auto TypeList = Factory.makeTupleTypeElementList(
         {IntArg.withTrailingComma(Comma), IntArg});
     Factory
-        .makeFunctionType(LeftParen, TypeList, RightParen, None, Rethrows,
-                          Arrow, Int)
+        .makeFunctionType(
+            /*GarbageNodes=*/None, LeftParen, /*GarbageNodes=*/None, TypeList,
+            /*GarbageNodes=*/None, RightParen, /*GarbageNodes=*/None, None,
+            /*GarbageNodes=*/None, Rethrows,
+            /*GarbageNodes=*/None, Arrow, /*GarbageNodes=*/None, Int)
         .print(OS);
     ASSERT_EQ(OS.str().str(), "(Int, Int) rethrows -> Int");
   }
@@ -563,11 +598,13 @@ TEST(TypeSyntaxTests, FunctionTypeMakeAPIs) {
     llvm::raw_svector_ostream OS(Scratch);
     auto TypeList = Factory.makeBlankTupleTypeElementList();
     auto Void = Factory.makeVoidTupleType();
+    auto ThrowsTok = TokenSyntax::missingToken(tok::kw_throws, "throws", Arena);
     Factory
         .makeFunctionType(
-            LeftParen, TypeList, RightParen, None,
-            TokenSyntax::missingToken(tok::kw_throws, "throws", Arena), Arrow,
-            Void)
+            /*GarbageNodes=*/None, LeftParen, /*GarbageNodes=*/None, TypeList,
+            /*GarbageNodes=*/None, RightParen, /*GarbageNodes=*/None, None,
+            /*GarbageNodes=*/None, ThrowsTok, /*GarbageNodes=*/None, Arrow,
+            /*GarbageNodes=*/None, Void)
         .print(OS);
     ASSERT_EQ(OS.str().str(), "() -> ()");
   }
@@ -580,8 +617,11 @@ TEST(TypeSyntaxTests, FunctionTypeWithAPIs) {
   auto LeftParen = Factory.makeLeftParenToken("", "");
   auto RightParen = Factory.makeRightParenToken("", " ");
   auto Int = Factory.makeTypeIdentifier("Int", "", "");
-  auto IntArg = Factory.makeTupleTypeElement(None, None, None, None, Int, None,
-                                             None, None);
+  auto IntArg = Factory.makeTupleTypeElement(
+      /*GarbageNodes=*/None, None, /*GarbageNodes=*/None, None,
+      /*GarbageNodes=*/None, None, /*GarbageNodes=*/None, None,
+      /*GarbageNodes=*/None, Int, /*GarbageNodes=*/None, None,
+      /*GarbageNodes=*/None, None, /*GarbageNodes=*/None, None);
   auto Throws = Factory.makeThrowsKeyword("", " ");
   auto Rethrows = Factory.makeRethrowsKeyword("", " ");
   auto Arrow = Factory.makeArrowToken("", " ");
@@ -592,10 +632,16 @@ TEST(TypeSyntaxTests, FunctionTypeWithAPIs) {
     auto x = Factory.makeIdentifier("x", "", "");
     auto y = Factory.makeIdentifier("y", "", "");
     auto Colon = Factory.makeColonToken("", " ");
-    auto xArg = Factory.makeTupleTypeElement(None, x, None, Colon, Int, None,
-                                             None, Comma);
-    auto yArg = Factory.makeTupleTypeElement(None, y, None, Colon, Int, None,
-                                             None, None);
+    auto xArg = Factory.makeTupleTypeElement(
+        /*GarbageNodes=*/None, None, /*GarbageNodes=*/None, x,
+        /*GarbageNodes=*/None, None, /*GarbageNodes=*/None, Colon,
+        /*GarbageNodes=*/None, Int, /*GarbageNodes=*/None, None,
+        /*GarbageNodes=*/None, None, /*GarbageNodes=*/None, Comma);
+    auto yArg = Factory.makeTupleTypeElement(
+        /*GarbageNodes=*/None, None, /*GarbageNodes=*/None, y,
+        /*GarbageNodes=*/None, None, /*GarbageNodes=*/None, Colon,
+        /*GarbageNodes=*/None, Int, /*GarbageNodes=*/None, None,
+        /*GarbageNodes=*/None, None, /*GarbageNodes=*/None, None);
 
     Factory.makeBlankFunctionType()
         .withLeftParen(LeftParen)
@@ -658,10 +704,16 @@ TEST(TypeSyntaxTests, FunctionTypeBuilderAPIs) {
     auto x = Factory.makeIdentifier("x", "", "");
     auto y = Factory.makeIdentifier("y", "", "");
     auto Colon = Factory.makeColonToken("", " ");
-    auto xArg = Factory.makeTupleTypeElement(None, x, None, Colon, Int, None,
-                                             None, Comma);
-    auto yArg = Factory.makeTupleTypeElement(None, y, None, Colon, Int, None,
-                                             None, None);
+    auto xArg = Factory.makeTupleTypeElement(
+        /*GarbageNodes=*/None, None, /*GarbageNodes=*/None, x,
+        /*GarbageNodes=*/None, None, /*GarbageNodes=*/None, Colon,
+        /*GarbageNodes=*/None, Int, /*GarbageNodes=*/None, None,
+        /*GarbageNodes=*/None, None, /*GarbageNodes=*/None, Comma);
+    auto yArg = Factory.makeTupleTypeElement(
+        /*GarbageNodes=*/None, None, /*GarbageNodes=*/None, y,
+        /*GarbageNodes=*/None, None, /*GarbageNodes=*/None, Colon,
+        /*GarbageNodes=*/None, Int, /*GarbageNodes=*/None, None,
+        /*GarbageNodes=*/None, None, /*GarbageNodes=*/None, None);
 
     Builder.useLeftParen(LeftParen)
       .useRightParen(RightParen)
@@ -679,8 +731,12 @@ TEST(TypeSyntaxTests, FunctionTypeBuilderAPIs) {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
     FunctionTypeSyntaxBuilder Builder(Arena);
-    auto IntArg = Factory.makeTupleTypeElement(None, None, None, None, Int,
-                                               None, None, None);
+    auto IntArg = Factory.makeTupleTypeElement(
+        /*GarbageNodes=*/None, None, /*GarbageNodes=*/None, None,
+        /*GarbageNodes=*/None, None, /*GarbageNodes=*/None, None,
+        /*GarbageNodes=*/None, Int,
+        /*GarbageNodes=*/None, None, /*GarbageNodes=*/None, None,
+        /*GarbageNodes=*/None, None);
     Builder.useLeftParen(LeftParen)
       .useRightParen(RightParen)
       .addArgument(IntArg.withTrailingComma(Comma))

--- a/utils/gyb_syntax_support/Child.py
+++ b/utils/gyb_syntax_support/Child.py
@@ -83,3 +83,6 @@ class Child(object):
         if self.token_choices:
             return self.token_choices[0]
         return None
+
+    def is_garbage_nodes(self):
+        return self.syntax_kind == 'GarbageNodes'

--- a/utils/gyb_syntax_support/CommonNodes.py
+++ b/utils/gyb_syntax_support/CommonNodes.py
@@ -57,4 +57,10 @@ COMMON_NODES = [
              Child('RightBrace', kind='RightBraceToken', 
                    requires_leading_newline=True),
          ]),
+
+    Node('GarbageNodes', kind='SyntaxCollection', element='Syntax',
+         description='''
+         A collection of syntax nodes that occurred in the source code but
+         could not be used to form a valid syntax tree.
+         '''),
 ]

--- a/utils/gyb_syntax_support/NodeSerializationCodes.py
+++ b/utils/gyb_syntax_support/NodeSerializationCodes.py
@@ -267,6 +267,7 @@ SYNTAX_NODE_SERIALIZATION_CODES = {
     'MissingStmt': 263,
     'MissingType': 264,
     'MissingPattern': 265,
+    'GarbageNodes' : 266,
 }
 
 


### PR DESCRIPTION
When the source code is invalid, this allows us to represent tokens that could not be used to form a valid syntax tree with more fidelity.

This commit does not start using GarbageNodes yet, it just sets everything up for them.
