### PR TITLE
[5.7] Add `Task.sleep(for: Duration)`

### DIFF
--- a/stdlib/public/Concurrency/TaskSleepDuration.swift
+++ b/stdlib/public/Concurrency/TaskSleepDuration.swift
@@ -142,4 +142,19 @@ extension Task where Success == Never, Failure == Never {
   ) async throws {
     try await clock.sleep(until: deadline, tolerance: tolerance)
   }
+  
+  /// Suspends the current task for the given duration on a continuous clock.
+  ///
+  /// If the task is cancelled before the time ends, this function throws 
+  /// `CancellationError`.
+  ///
+  /// This function doesn't block the underlying thread.
+  ///
+  ///       try await Task.sleep(for: .seconds(3))
+  ///
+  /// - Parameter duration: The duration to wait.
+  @available(SwiftStdlib 5.7, *)
+  public static func sleep(for duration: Duration) async throws {
+    try await sleep(until: .now + duration, clock: .continuous)
+  }
 }


### PR DESCRIPTION
Cherry-pick apple/swift#59203

> This PR introduces missing functionality from [SE-0329][], namely the `Task.sleep` helper that takes a `Duration`.

[SE-0329]: <https://github.com/apple/swift-evolution/blob/main/proposals/0329-clock-instant-duration.md#task>