### PR TITLE
disable Interop/Cxx/foreign-reference/reference-counted.swift

### DIFF
--- a/test/Interop/Cxx/foreign-reference/reference-counted.swift
+++ b/test/Interop/Cxx/foreign-reference/reference-counted.swift
@@ -4,6 +4,8 @@
 // TODO: This should work without ObjC interop in the future rdar://97497120
 // REQUIRES: objc_interop
 
+// REQUIRES: rdar97532642
+
 import StdlibUnittest
 import ReferenceCounted
 


### PR DESCRIPTION
It fails on CI.
Caused by https://github.com/apple/swift/pull/59509

rdar://97532642
