### PR TITLE
tests: diable Interop/Cxx/stdlib/overlay/custom-sequence-typechecker.swift

### DIFF
--- a/test/Interop/Cxx/stdlib/overlay/custom-sequence-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-sequence-typechecker.swift
@@ -1,5 +1,7 @@
 // RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop
 
+// REQUIRES: rdar97532965
+
 import CustomSequence
 import Cxx
 


### PR DESCRIPTION
It fails in CI.
Caused by https://github.com/apple/swift/pull/59509

rdar://97532965