### PR TITLE
[cxx-interop] Do not crash when importing anonymous classes

### DIFF
--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1768,6 +1768,8 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
           const char *kind;
           if (fieldTagDecl->isStruct())
             kind = "struct";
+          else if (fieldTagDecl->isClass())
+            kind = "class";
           else if (fieldTagDecl->isUnion())
             kind = "union";
           else if  (fieldTagDecl->isEnum())

--- a/test/Interop/Cxx/class/Inputs/linked-records.h
+++ b/test/Interop/Cxx/class/Inputs/linked-records.h
@@ -36,4 +36,11 @@ struct F {
   M m2;
 };
 
+struct G {
+  class {
+  public:
+    M m;
+  } cc;
+};
+
 #endif // TEST_INTEROP_CXX_CLASS_INPUTS_LINKED_RECORDS_H

--- a/test/Interop/Cxx/class/linked-records-module-interface.swift
+++ b/test/Interop/Cxx/class/linked-records-module-interface.swift
@@ -41,3 +41,14 @@
 // CHECK:   var m: M
 // CHECK:   var m2: M
 // CHECK: }
+
+// CHECK: struct G {
+// CHECK:   init()
+// CHECK:   init(cc: G.__Unnamed_class_cc)
+// CHECK:   struct __Unnamed_class_cc {
+// CHECK:     init()
+// CHECK:     init(m: M)
+// CHECK:     var m: M
+// CHECK:   }
+// CHECK:   var cc: G.__Unnamed_class_cc
+// CHECK: }


### PR DESCRIPTION
This was discovered during interop adoption in SwiftCompilerSources.
```
/Volumes/Projects/swift/swift/include/swift/SIL/SILNode.h:180:5 
<Spelling=/Volumes/Projects/swift/swift/include/swift/SIL/SILNode.h:171:3>: while adding SwiftName lookup table entries for clang declaration 'swift::SILNode::SharedUInt8Fields::(anonymous)'
```
