### PR TITLE
[Options] Move CXX interop back to a driver option

### DIFF
--- a/docs/CppInteroperability/GettingStartedWithC++Interop.md
+++ b/docs/CppInteroperability/GettingStartedWithC++Interop.md
@@ -34,12 +34,12 @@ module Cxx {
 Add the C++ module to the include path and enable C++ interop:
 - Navigate to your project directory 
 - In `Project` navigate to `Build Settings` -> `Swift Compiler`
-- Under `Custom Flags` -> `Other Swift Flags` add`-Xfrontend -enable-experimental-cxx-interop`
+- Under `Custom Flags` -> `Other Swift Flags` add`-enable-experimental-cxx-interop`
 - Under `Search Paths` -> `Import Paths` add your search path to the C++ module (i.e, `./ProjectName/Cxx`). Repeat this step in `Other Swift Flags` 
 
 ```
 //Add to Other Swift Flags and Import Paths respectively
--Xfrontend -enable-experimental-cxx-interop 
+-enable-experimental-cxx-interop
 -I./ProjectName/Cxx
 ```
 
@@ -118,7 +118,7 @@ let package = Package(
             sources: [ "main.swift" ],
             swiftSettings: [.unsafeFlags([
                 "-I", "Sources/Cxx",
-                "-Xfrontend", "-enable-experimental-cxx-interop",
+                "-enable-experimental-cxx-interop",
             ])]
         ),
     ]
@@ -151,7 +151,7 @@ After creating your project follow the steps [Creating a Module to contain your 
 - Create a `CMakeLists.txt` file and configure for your project
 - In`add_library` invoke `cxx-support` with the path to the C++ implementation file
 - Add the `target_include_directories` with `cxx-support` and path to the C++ Module `${CMAKE_SOURCE_DIR}/Sources/Cxx`
-- Add the `add_executable` to the specific files/directory you would like to generate source, with`SHELL:-Xfrontend -enable-experimental-cxx-interop`.
+- Add the `add_executable` to the specific files/directory you would like to generate source, with`SHELL:-enable-experimental-cxx-interop`.
 - In the example below we will be following the file structure used in [Creating a Swift Package](#Creating-a-Swift-Package) 
 
 ```
@@ -176,7 +176,7 @@ target_include_directories(cxx-support PUBLIC
 
 add_executable(CxxInterop ./Sources/CxxInterop/main.swift)
 target_compile_options(CxxInterop PRIVATE
-  "SHELL:-Xfrontend -enable-experimental-cxx-interop"
+  "SHELL:-enable-experimental-cxx-interop"
 target_link_libraries(CxxInterop PRIVATE cxx-support)
 
 ```

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -282,10 +282,6 @@ def enable_experimental_concurrency :
   Flag<["-"], "enable-experimental-concurrency">,
   HelpText<"Enable experimental concurrency model">;
 
-def enable_experimental_cxx_interop :
-  Flag<["-"], "enable-experimental-cxx-interop">,
-  HelpText<"Enable C++ interop code generation and config directives">;
-
 def enable_lexical_borrow_scopes :
   Joined<["-"], "enable-lexical-borrow-scopes=">,
   HelpText<"Whether to emit lexical borrow scopes (default: true)">,

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -612,8 +612,14 @@ def enable_experimental_concise_pound_file : Flag<["-"],
   Flags<[FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Enable experimental concise '#file' identifier">;
 
+def enable_experimental_cxx_interop :
+  Flag<["-"], "enable-experimental-cxx-interop">,
+  Flags<[FrontendOption, HelpHidden]>,
+  HelpText<"Enable experimental C++ interop code generation and config directives">;
+
 def experimental_cxx_stdlib :
   Separate<["-"], "experimental-cxx-stdlib">,
+  Flags<[HelpHidden]>,
   HelpText<"C++ standard library to use; forwarded to Clang's -stdlib flag">;
 
 def experimental_emit_module_separately:

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -189,9 +189,6 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   }
 
   // Add flags for C++ interop.
-  if (inputArgs.hasArg(options::OPT_enable_experimental_cxx_interop)) {
-    arguments.push_back("-enable-experimental-cxx-interop");
-  }
   if (const Arg *arg =
           inputArgs.getLastArg(options::OPT_experimental_cxx_stdlib)) {
     arguments.push_back("-Xcc");
@@ -302,6 +299,7 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_access_notes_path);
   inputArgs.AddLastArg(arguments, options::OPT_library_level);
   inputArgs.AddLastArg(arguments, options::OPT_enable_bare_slash_regex);
+  inputArgs.AddLastArg(arguments, options::OPT_enable_experimental_cxx_interop);
 
   // Pass on any build config options
   inputArgs.AddAllArgs(arguments, options::OPT_D);


### PR DESCRIPTION
This flag is required in the driver to eg. choose `clang` vs `clang++`
for the linker. Move it back to a driver option and hide both it and the
stdlib flag from help.