### PR TITLE
Include assert.h manually in SourceLoc.h.

### DIFF
--- a/include/swift/Basic/SourceLoc.h
+++ b/include/swift/Basic/SourceLoc.h
@@ -23,6 +23,7 @@
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/SMLoc.h"
+#include <assert.h>
 #include <functional>
 
 namespace swift {


### PR DESCRIPTION
On the BSDs when building with bootstrapping and therefore modules enabled,
this will result in a "declaration here is not visible" error. This is
_possibly_ because the assert implementation is not reexported from LLVM,
maybe due to libc differences. Regardless, this fixes the problem and
should be relatively inocuous to unconditionally include.