### PR TITLE
IRGen: Add method lists of generic class patterns to their own section

### DIFF
--- a/lib/IRGen/GenClass.h
+++ b/lib/IRGen/GenClass.h
@@ -78,6 +78,11 @@ namespace irgen {
     HasUpdateCallback = true
   };
 
+  enum ForGenericPattern_t : bool {
+    IsNotForGenericPattern = false,
+    IsForGenericPattern = true
+  };
+
   /// Creates a layout for the class \p classType with allocated tail elements
   /// \p tailTypes.
   ///

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -974,6 +974,10 @@ void IRGenModule::addObjCClassStub(llvm::Constant *classPtr) {
   ObjCClassStubs.push_back(classPtr);
 }
 
+void IRGenModule::addGenericObjCMethodList(llvm::Constant *methodList) {
+  ObjCMethodLists.push_back(methodList);
+}
+
 void IRGenModule::addRuntimeResolvableType(GenericTypeDecl *type) {
   // Collect the nominal type records we emit into a special section.
   RuntimeResolvableTypes.push_back(type);
@@ -1067,6 +1071,12 @@ void IRGenModule::SetCStringLiteralSection(llvm::GlobalVariable *GV,
 
 void IRGenModule::emitGlobalLists() {
   if (ObjCInterop) {
+    emitGlobalList(
+        *this, ObjCMethodLists, "objc_method_list",
+        GetObjCSectionName("__objc_methlist", "regular,no_dead_strip"),
+        llvm::GlobalValue::InternalLinkage, Int8PtrTy, /*isConstant*/ false,
+        /*asContiguousArray*/ false);
+
     // Objective-C class references go in a variable with a meaningless
     // name but a magic section.
     emitGlobalList(

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1080,6 +1080,7 @@ public:
   void addUsedGlobal(llvm::GlobalValue *global);
   void addCompilerUsedGlobal(llvm::GlobalValue *global);
   void addObjCClass(llvm::Constant *addr, bool nonlazy);
+  void addGenericObjCMethodList(llvm::Constant *addr);
   void addObjCClassStub(llvm::Constant *addr);
   void addProtocolConformance(ConformanceDescription &&conformance);
   void addAccessibleFunction(SILFunction *func);
@@ -1197,6 +1198,8 @@ private:
   /// Metadata nodes for autolinking info.
   SmallVector<LinkLibrary, 32> AutolinkEntries;
 
+  /// List of Objective-C method lists of generic classes.
+  SmallVector<llvm::WeakTrackingVH, 4> ObjCMethodLists;
   /// List of Objective-C classes, bitcast to i8*.
   SmallVector<llvm::WeakTrackingVH, 4> ObjCClasses;
   /// List of Objective-C classes that require nonlazy realization, bitcast to


### PR DESCRIPTION
Put the method lists in generic class patterns in a section __objc_methodlist such that they are discoverable by the linker.
The linker can then make them relative like it can for regular objective c class metadata

rdar://66634459