### PR TITLE
Frontend: Enable `-target-min-inlining-version min` for API modules by default

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -47,6 +47,17 @@ swift::CompilerInvocation::CompilerInvocation() {
   setTargetTriple(llvm::sys::getDefaultTargetTriple());
 }
 
+/// Converts a llvm::Triple to a llvm::VersionTuple.
+static llvm::VersionTuple
+getVersionTuple(const llvm::Triple &triple) {
+  unsigned major, minor, patch;
+  if (triple.isMacOSX())
+    triple.getMacOSXVersion(major, minor, patch);
+  else
+    triple.getOSVersion(major, minor, patch);
+  return llvm::VersionTuple(major, minor, patch);
+}
+
 void CompilerInvocation::computeRuntimeResourcePathFromExecutablePath(
     StringRef mainExecutablePath, bool shared,
     llvm::SmallVectorImpl<char> &runtimeResourcePath) {
@@ -865,24 +876,19 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   // First, set up default minimum inlining target versions.
   auto getDefaultMinimumInliningTargetVersion =
       [&](const llvm::Triple &triple) -> llvm::VersionTuple {
-    // FIXME: Re-enable with rdar://91387029
-#if SWIFT_DEFAULT_API_TARGET_MIN_INLINING_VERSION_TO_MIN
+    const auto targetVersion = getVersionTuple(triple);
+    
     // In API modules, default to the version when Swift first became available.
-    if (Opts.LibraryLevel == LibraryLevel::API)
-      if (auto minTriple = minimumAvailableOSVersionForTriple(triple))
-        return *minTriple;
-#endif
+    if (Opts.LibraryLevel == LibraryLevel::API) {
+      if (auto minVersion = minimumAvailableOSVersionForTriple(triple))
+        return *minVersion;
+    }
 
     // In other modules, assume that availability is used less consistently
     // and that library clients will generally raise deployment targets as the
     // library evolves so the min inlining version should be the deployment
     // target by default.
-    unsigned major, minor, patch;
-    if (triple.isMacOSX())
-      triple.getMacOSXVersion(major, minor, patch);
-    else
-      triple.getOSVersion(major, minor, patch);
-    return llvm::VersionTuple(major, minor, patch);
+    return targetVersion;
   };
 
   Opts.MinimumInliningTargetVersion =

--- a/test/attr/attr_inlinable_available.swift
+++ b/test/attr/attr_inlinable_available.swift
@@ -13,9 +13,8 @@
 // RUN: %target-typecheck-verify-swift -swift-version 5 -enable-library-evolution -module-name Test -target %target-next-stable-abi-triple -target-min-inlining-version min
 
 
-// FIXME: Re-enable with rdar://91387029
 // Check that `-library-level api` implies `-target-min-inlining-version min`
-// RUN/: %target-typecheck-verify-swift -swift-version 5 -enable-library-evolution -module-name Test -target %target-next-stable-abi-triple -library-level api
+// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-library-evolution -module-name Test -target %target-next-stable-abi-triple -library-level api
 
 
 // Check that these rules are only applied when requested and that at least some


### PR DESCRIPTION
Resolves rdar://67975153.
