### PR TITLE
IRGen: Add a list of class_ro_t referenced from generic class metadata patterns to a section __swift_rodatas

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -401,6 +401,9 @@ public:
   /// Internalize symbols (static library) - do not export any public symbols.
   unsigned InternalizeSymbols : 1;
 
+  /// Emit a section with references to class_ro_t* in generic class patterns.
+  unsigned EmitGenericRODatas : 1;
+
   /// Whether to avoid emitting zerofill globals as preallocated type metadata
   /// and protocol conformance caches.
   unsigned NoPreallocatedInstantiationCaches : 1;
@@ -475,7 +478,7 @@ public:
         EnableGlobalISel(false), VirtualFunctionElimination(false),
         WitnessMethodElimination(false), ConditionalRuntimeRecords(false),
         InternalizeAtLink(false), InternalizeSymbols(false),
-        NoPreallocatedInstantiationCaches(false),
+        EmitGenericRODatas(false), NoPreallocatedInstantiationCaches(false),
         DisableReadonlyStaticObjects(false), CmdArgs(),
         SanitizeCoverage(llvm::SanitizerCoverageOptions()),
         TypeInfoFilter(TypeInfoDumpFilter::All) {

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -1083,4 +1083,13 @@ def enable_new_llvm_pass_manager :
 def disable_new_llvm_pass_manager :
   Flag<["-"], "disable-new-llvm-pass-manager">,
   HelpText<"Disable the new llvm pass manager">;
+
+def disable_emit_generic_class_ro_t_list :
+  Flag<["-"], "disable-emit-generic-class-ro_t-list">,
+  HelpText<"Disable emission of a section with references to class_ro_t of "
+           "generic class patterns">;
+def enable_emit_generic_class_ro_t_list :
+  Flag<["-"], "enable-emit-generic-class-ro_t-list">,
+  HelpText<"Enable emission of a section with references to class_ro_t of "
+           "generic class patterns">;
 } // end let Flags = [FrontendOption, NoDriverOption, HelpHidden]

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2398,6 +2398,11 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
       Opts.SwiftAsyncFramePointer = SwiftAsyncFramePointerKind::Never;
   }
 
+  Opts.EmitGenericRODatas =
+      Args.hasFlag(OPT_enable_emit_generic_class_ro_t_list,
+                   OPT_disable_emit_generic_class_ro_t_list,
+                   Opts.EmitGenericRODatas);
+
   Opts.LegacyPassManager =
       Args.hasFlag(OPT_disable_new_llvm_pass_manager,
                    OPT_enable_new_llvm_pass_manager,

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1080,6 +1080,7 @@ public:
 
   void addUsedGlobal(llvm::GlobalValue *global);
   void addCompilerUsedGlobal(llvm::GlobalValue *global);
+  void addGenericROData(llvm::Constant *addr);
   void addObjCClass(llvm::Constant *addr, bool nonlazy);
   void addObjCClassStub(llvm::Constant *addr);
   void addProtocolConformance(ConformanceDescription &&conformance);
@@ -1198,6 +1199,8 @@ private:
   /// Metadata nodes for autolinking info.
   SmallVector<LinkLibrary, 32> AutolinkEntries;
 
+  // List of ro_data_t referenced from generic class patterns.
+  SmallVector<llvm::WeakTrackingVH, 4> GenericRODatas;
   /// List of Objective-C classes, bitcast to i8*.
   SmallVector<llvm::WeakTrackingVH, 4> ObjCClasses;
   /// List of Objective-C classes that require nonlazy realization, bitcast to

--- a/test/IRGen/generic_class_rodata_list.swift
+++ b/test/IRGen/generic_class_rodata_list.swift
@@ -1,0 +1,46 @@
+// RUN: %target-swift-frontend -enable-emit-generic-class-ro_t-list -S %s -o - | %FileCheck %s
+// REQUIRES: objc_interop
+// REQUIRES: CPU=x86_64 || CPU=arm64
+// REQUIRES: OS=macosx
+
+// CHECK: ___unnamed_1:
+// CHECK:         .quad   _OBJC_METACLASS_$__TtCs12_SwiftObject
+// CHECK:         .quad   0
+// CHECK:         .quad   __objc_empty_cache
+// CHECK:         .quad   0
+// CHECK:         .quad   0
+// Start of rodata_t
+// CHECK:         .long   128
+// CHECK:         .long   16
+// CHECK:         .long   16
+// CHECK:         .long   0
+// CHECK:         .quad   0
+// CHECK:         .quad   0
+// CHECK:         .quad   __INSTANCE_METHODS__TtC25generic_class_rodata_list9Something
+// CHECK:         .quad   0
+// CHECK:         .quad   0
+// CHECK:         .quad   0
+// CHECK:         .quad   0
+// Start of rodata_t
+// CHECK:         .long   129
+// CHECK:         .long   40
+// CHECK:         .long   40
+// CHECK:         .long   0
+// CHECK:         .quad   0
+// CHECK:         .quad   0
+// CHECK:         .quad   __CLASS_METHODS__TtC25generic_class_rodata_list9Somethin
+
+// CHECK:        .section        __DATA,__swift_rodatas
+// CHECK:        .p2align        3
+// CHECK:_generic_ro_datas:
+// CHECK:        .quad   ___unnamed_1+40
+// CHECK:        .quad   ___unnamed_1+112
+
+import Foundation
+
+public class Something<T> {
+  @objc
+  public func myMethod() { print("hello") }
+  @objc
+  public static func myStaticMethod() { print("static") }
+}


### PR DESCRIPTION
Put pointers to class_ro_t referenced from generic class patterns in a section __swift_rodatas such that they are discoverable by the linker.
The linker can then make the method lists contained in the class_ro_t relative like it can for objective c class metadata from non-generic swift classes.

rdar://66634459
