### PR TITLE
Fix update-checkout error reporting

### DIFF
--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -130,10 +130,9 @@ def get_branch_for_repo(config, repo_name, scheme_name, scheme_map,
                 shell.run(["git", "fetch", "origin",
                            "pull/{0}/merge:{1}"
                            .format(pr_id, repo_branch), "--tags"], echo=True)
-        except KeyError as e:
+        except KeyError:
             print(f"Failed to look up {repo_name} in scheme", file=sys.stderr)
-            raise e
-            exit(1)
+            raise
     return repo_branch, cross_repo
 
 


### PR DESCRIPTION
In the event of a failure, update-checkout wouldn't always fail very
gracefully. As a result the actual failure wasn't always printed, which
makes it really difficult to figure out what's going on.

In my case, I'm jumping between 5.6 and main branches, so
the `swift-cmark-gfm` is causing update-checkout to hiccup since it's
not in the `main` configuration file scheme for `main`, but is in the
5.6 repository. You wouldn't know that though, since it would complain
about `repo_path` not being in the error message before crashing.

I've gone ahead and done some cleanups, reporting what the problem is at
the point of failure beyond the "key error 'swift-cmark-cfg'.
