### PR TITLE
cross-module-optimization: be more conservative when emitting a TBD file, part 2

### DIFF
--- a/test/SILOptimizer/Inputs/cross-module/default-module.swift
+++ b/test/SILOptimizer/Inputs/cross-module/default-module.swift
@@ -8,3 +8,22 @@ public func incrementByThree(_ x: Int) -> Int {
 public func incrementByThreeWithCall(_ x: Int) -> Int {
   return incrementByOneNoCMO(x) + 2
 }
+
+public func submoduleKlassMember() -> Int {
+  let k = SubmoduleKlass()
+  return k.i
+}
+
+public final class ModuleKlass {
+  public var i: Int
+
+  public init() {
+    i = 27
+  }
+}
+
+public func moduleKlassMember() -> Int {
+  let k = ModuleKlass()
+  return k.i
+}
+

--- a/test/SILOptimizer/Inputs/cross-module/default-submodule.swift
+++ b/test/SILOptimizer/Inputs/cross-module/default-submodule.swift
@@ -8,3 +8,11 @@ public func incrementByOneNoCMO(_ x: Int) -> Int {
   return x + 1
 }
 
+public final class SubmoduleKlass {
+  public var i: Int
+
+  public init() {
+    i = 27
+  }
+}
+

--- a/test/SILOptimizer/default-cmo.swift
+++ b/test/SILOptimizer/default-cmo.swift
@@ -41,3 +41,35 @@ public func doIncrementTBDWithCall(_ x: Int) -> Int {
   return ModuleTBD.incrementByThreeWithCall(x)
 }
 
+// CHECK-LABEL: sil @$s4Main23getSubmoduleKlassMemberSiyF
+// CHECK-NOT:     function_ref 
+// CHECK-NOT:     apply 
+// CHECK:       } // end sil function '$s4Main23getSubmoduleKlassMemberSiyF'
+public func getSubmoduleKlassMember() -> Int {
+  return Module.submoduleKlassMember()
+}
+
+// CHECK-LABEL: sil @$s4Main26getSubmoduleKlassMemberTBDSiyF
+// CHECK:         [[F:%[0-9]+]] = function_ref @$s9ModuleTBD20submoduleKlassMemberSiyF
+// CHECK:         [[I:%[0-9]+]] = apply [[F]]
+// CHECK:         return [[I]]
+// CHECK:       } // end sil function '$s4Main26getSubmoduleKlassMemberTBDSiyF'
+public func getSubmoduleKlassMemberTBD() -> Int {
+  return ModuleTBD.submoduleKlassMember()
+}
+
+// CHECK-LABEL: sil @$s4Main20getModuleKlassMemberSiyF
+// CHECK-NOT:     function_ref 
+// CHECK-NOT:     apply 
+// CHECK:       } // end sil function '$s4Main20getModuleKlassMemberSiyF'
+public func getModuleKlassMember() -> Int {
+  return Module.moduleKlassMember()
+}
+
+// CHECK-LABEL: sil @$s4Main23getModuleKlassMemberTBDSiyF
+// CHECK-NOT:     function_ref 
+// CHECK-NOT:     apply 
+// CHECK:       } // end sil function '$s4Main23getModuleKlassMemberTBDSiyF'
+public func getModuleKlassMemberTBD() -> Int {
+  return ModuleTBD.moduleKlassMember()
+}


### PR DESCRIPTION
This is a follow-up of https://github.com/apple/swift/pull/41642.
We need to be more conservative about types as for functions, because types can also "produce" symbols, like direct field offsets, etc.

rdar://96953318
