### PR TITLE
introduce a `@_documentation(...)` attribute to influence SymbolGraphGen

### DIFF
--- a/docs/ReferenceGuides/UnderscoredAttributes.md
+++ b/docs/ReferenceGuides/UnderscoredAttributes.md
@@ -121,6 +121,27 @@ extension Text {
 }
 ```
 
+## `@_documentation(metadata: ...)`
+
+Adds "documentation metadata" to the symbol. The identifier in the attribute is
+added to the symbol graph in the `"metadata"` field of the symbol. This can be
+used to add an arbitrary grouping or other indicator to symbols for use in
+documentation.
+
+## `@_documentation(visibility: ...)`
+
+Forces the symbol to be treated as the given access level when checking
+visibility. This can be used to, for example, force a symbol with an underscored
+name to appear in `public` symbol graphs, or treat an otherwise-`public` symbol
+as being `internal` or `private` for the purposes of documentation, to hide it
+from `public` docs.
+
+This can also be applied to `@_exported import` statements to only include the
+imported symbols in symbol graphs with the given minimum access level. For
+example, applying `@_documentation(visibility: internal)` to an `@_exported
+import` statement will hide the imported symbols from `public` symbol graphs and
+documentation, but show them on `internal` symbol graphs and documentation.
+
 ## `@_dynamicReplacement(for: targetFunc(label:))`
 
 Marks a function as the dynamic replacement for another `dynamic` function.

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -773,6 +773,11 @@ SIMPLE_DECL_ATTR(_spiOnly, SPIOnly,
   ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   135)
 
+DECL_ATTR(_documentation, Documentation,
+  OnAnyDecl | UserInaccessible |
+  APIBreakingToAdd | APIStableToRemove | ABIStableToAdd | ABIStableToRemove,
+  136)
+
 // If you're adding a new underscored attribute here, please document it in
 // docs/ReferenceGuides/UnderscoredAttributes.md.
 

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -2244,9 +2244,8 @@ public:
   }
 };
 
-/// The `@_documentation(...)` attribute, used to note a "category" for a
-/// symbol to be associated with, with special cases for forcing a symbol to be
-/// hidden or visible.
+/// The `@_documentation(...)` attribute, used to override a symbol's visibility
+/// in symbol graphs, and/or adding arbitrary metadata to it.
 class DocumentationAttr: public DeclAttribute {
 public:
   DocumentationAttr(SourceLoc AtLoc, SourceRange Range,

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -2244,6 +2244,28 @@ public:
   }
 };
 
+/// The `@_documentation(...)` attribute, used to note a "category" for a
+/// symbol to be associated with, with special cases for forcing a symbol to be
+/// hidden or visible.
+class DocumentationAttr: public DeclAttribute {
+public:
+  DocumentationAttr(SourceLoc AtLoc, SourceRange Range,
+                    StringRef Metadata, Optional<AccessLevel> Visibility,
+                    bool Implicit)
+  : DeclAttribute(DAK_Documentation, AtLoc, Range, Implicit),
+    Metadata(Metadata), Visibility(Visibility) {}
+
+  DocumentationAttr(StringRef Metadata, Optional<AccessLevel> Visibility, bool Implicit)
+  : DocumentationAttr(SourceLoc(), SourceRange(), Metadata, Visibility, Implicit) {}
+
+  const StringRef Metadata;
+  const Optional<AccessLevel> Visibility;
+
+  static bool classof(const DeclAttribute *DA) {
+    return DA->getKind() == DAK_Documentation;
+  }
+};
+
 /// Attributes that may be applied to declarations.
 class DeclAttributes {
   /// Linked list of declaration attributes.

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1763,6 +1763,27 @@ WARNING(warn_attr_unsafe_removed,none,
         "'%0' attribute has been removed in favor of @preconcurrency",
         (StringRef))
 
+// _documentation
+ERROR(documentation_attr_expected_argument,none,
+      "@_documentation attribute expected 'visibility' or 'metadata' argument",
+      ())
+ERROR(documentation_attr_unknown_argument,none,
+      "unknown argument '%0', expected 'visibility' or 'metadata'",
+      (StringRef))
+ERROR(documentation_attr_expected_access_level,none,
+      "@_documentation attribute's 'visibility' argument expected an access level",
+      ())
+ERROR(documentation_attr_unknown_access_level,none,
+      "unknown visibility '%0', expected an access level keyword",
+      (StringRef))
+ERROR(documentation_attr_duplicate_visibility,none,
+      "cannot give more than one visibility to the same item", ())
+ERROR(documentation_attr_metadata_expected_identifier,none,
+      "@_documentation attribute's 'metadata' argument expected a plain identifier",
+      ())
+ERROR(documentation_attr_duplicate_metadata,none,
+      "cannot give more than one metadata argument to the same item", ())
+
 //------------------------------------------------------------------------------
 // MARK: Generics parsing diagnostics
 //------------------------------------------------------------------------------

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1778,8 +1778,9 @@ ERROR(documentation_attr_unknown_access_level,none,
       (StringRef))
 ERROR(documentation_attr_duplicate_visibility,none,
       "cannot give more than one visibility to the same item", ())
-ERROR(documentation_attr_metadata_expected_identifier,none,
-      "@_documentation attribute's 'metadata' argument expected a plain identifier",
+ERROR(documentation_attr_metadata_expected_text,none,
+      "@_documentation attribute's 'metadata' argument expected an identifier or "
+      "quoted string",
       ())
 ERROR(documentation_attr_duplicate_metadata,none,
       "cannot give more than one metadata argument to the same item", ())

--- a/include/swift/AST/Import.h
+++ b/include/swift/AST/Import.h
@@ -19,6 +19,7 @@
 #ifndef SWIFT_IMPORT_H
 #define SWIFT_IMPORT_H
 
+#include "swift/AST/AttrKind.h"
 #include "swift/AST/Identifier.h"
 #include "swift/Basic/Located.h"
 #include "swift/Basic/OptionSet.h"
@@ -579,13 +580,18 @@ struct AttributedImport {
   /// is the source range covering the annotation.
   SourceRange preconcurrencyRange;
 
+  /// If the import declaration has a `@_documentation(visibility: <access>)`
+  /// attribute, this is the given access level.
+  Optional<AccessLevel> docVisibility;
+
   AttributedImport(ModuleInfo module, SourceLoc importLoc = SourceLoc(),
                    ImportOptions options = ImportOptions(),
                    StringRef filename = {}, ArrayRef<Identifier> spiGroups = {},
-                   SourceRange preconcurrencyRange = {})
+                   SourceRange preconcurrencyRange = {},
+                   Optional<AccessLevel> docVisibility = None)
       : module(module), importLoc(importLoc), options(options),
         sourceFileArg(filename), spiGroups(spiGroups),
-        preconcurrencyRange(preconcurrencyRange) {
+        preconcurrencyRange(preconcurrencyRange), docVisibility(docVisibility) {
     assert(!(options.contains(ImportFlags::Exported) &&
              options.contains(ImportFlags::ImplementationOnly)) ||
            options.contains(ImportFlags::Reserved));
@@ -595,14 +601,15 @@ struct AttributedImport {
   AttributedImport(ModuleInfo module, AttributedImport<OtherModuleInfo> other)
     : AttributedImport(module, other.importLoc, other.options,
                        other.sourceFileArg, other.spiGroups,
-                       other.preconcurrencyRange) { }
+                       other.preconcurrencyRange, other.docVisibility) { }
 
   friend bool operator==(const AttributedImport<ModuleInfo> &lhs,
                          const AttributedImport<ModuleInfo> &rhs) {
     return lhs.module == rhs.module &&
            lhs.options.toRaw() == rhs.options.toRaw() &&
            lhs.sourceFileArg == rhs.sourceFileArg &&
-           lhs.spiGroups == rhs.spiGroups;
+           lhs.spiGroups == rhs.spiGroups &&
+           lhs.docVisibility == rhs.docVisibility;
   }
 
   AttributedImport<ImportedModule> getLoaded(ModuleDecl *loadedModule) const {
@@ -754,14 +761,14 @@ struct DenseMapInfo<swift::AttributedImport<ModuleInfo>> {
                             SourceLocDMI::getEmptyKey(),
                             ImportOptionsDMI::getEmptyKey(),
                             StringRefDMI::getEmptyKey(),
-                            {});
+                            {}, {}, None);
   }
   static inline AttributedImport getTombstoneKey() {
     return AttributedImport(ModuleInfoDMI::getTombstoneKey(),
                             SourceLocDMI::getEmptyKey(),
                             ImportOptionsDMI::getTombstoneKey(),
                             StringRefDMI::getTombstoneKey(),
-                            {});
+                            {}, {}, None);
   }
   static inline unsigned getHashValue(const AttributedImport &import) {
     return detail::combineHashValue(
@@ -775,7 +782,8 @@ struct DenseMapInfo<swift::AttributedImport<ModuleInfo>> {
     return ModuleInfoDMI::isEqual(a.module, b.module) &&
            ImportOptionsDMI::isEqual(a.options, b.options) &&
            StringRefDMI::isEqual(a.sourceFileArg, b.sourceFileArg) &&
-           a.spiGroups == b.spiGroups;
+           a.spiGroups == b.spiGroups &&
+           a.docVisibility == b.docVisibility;
   }
 };
 }

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -959,7 +959,8 @@ inline SourceLoc extractNearestSourceLoc(const ModuleDecl *mod) {
 /// Collects modules that this module imports via `@_exported import`.
 void collectParsedExportedImports(const ModuleDecl *M,
                                   SmallPtrSetImpl<ModuleDecl *> &Imports,
-                                  llvm::SmallDenseMap<ModuleDecl *, SmallPtrSet<Decl *, 4>, 4> &QualifiedImports);
+                                  llvm::SmallDenseMap<ModuleDecl *, SmallPtrSet<Decl *, 4>, 4> &QualifiedImports,
+                                  llvm::function_ref<bool(AttributedImport<ImportedModule>)> includeImport = nullptr);
 
 } // end namespace swift
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1145,6 +1145,14 @@ public:
   bool parseBackDeployAttribute(DeclAttributes &Attributes, StringRef AttrName,
                                 SourceLoc AtLoc, SourceLoc Loc);
 
+  /// Parse the @_documentation attribute.
+  ParserResult<DocumentationAttr> parseDocumentationAttribute(SourceLoc AtLoc,
+                                                              SourceLoc Loc);
+
+  /// Parse a single argument from a @_documentation attribute.
+  bool parseDocumentationAttributeArgument(Optional<StringRef> &Metadata,
+                                           Optional<AccessLevel> &Visibility);
+
   /// Parse a specific attribute.
   ParserStatus parseDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
                                   PatternBindingInitializer *&initContext,

--- a/include/swift/SymbolGraphGen/DocumentationCategory.h
+++ b/include/swift/SymbolGraphGen/DocumentationCategory.h
@@ -1,0 +1,48 @@
+//===--- DocumentationCategory.h - Accessors for @_documentation ----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SYMBOLGRAPHGEN_DOCUMENTATIONCATEGORY_H
+#define SWIFT_SYMBOLGRAPHGEN_DOCUMENTATIONCATEGORY_H
+
+#include "swift/AST/Decl.h"
+
+#include "llvm/Support/Compiler.h"
+
+namespace swift {
+namespace symbolgraphgen {
+
+LLVM_ATTRIBUTE_USED
+static StringRef documentationMetadataForDecl(const Decl *D) {
+  if (!D) return {};
+
+  if (const auto *DC = D->getAttrs().getAttribute<DocumentationAttr>()) {
+    return DC->Metadata;
+  }
+
+  return {};
+}
+
+LLVM_ATTRIBUTE_USED
+static Optional<AccessLevel> documentationVisibilityForDecl(const Decl *D) {
+  if (!D) return None;
+
+  if (const auto *DC = D->getAttrs().getAttribute<DocumentationAttr>()) {
+    return DC->Visibility;
+  }
+
+  return None;
+}
+
+} // namespace symbolgraphgen
+} // namespace swift
+
+#endif // SWIFT_SYMBOLGRAPHGEN_DOCUMENTATIONCATEGORY_H

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1450,6 +1450,8 @@ StringRef DeclAttribute::getAttrName() const {
     return "_backDeploy";
   case DAK_Expose:
     return "_expose";
+  case DAK_Documentation:
+    return "_documentation";
   }
   llvm_unreachable("bad DeclAttrKind");
 }

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -794,12 +794,14 @@ bool ModuleDecl::shouldCollectDisplayDecls() const {
 
 void swift::collectParsedExportedImports(const ModuleDecl *M,
                                          SmallPtrSetImpl<ModuleDecl *> &Imports,
-                                         llvm::SmallDenseMap<ModuleDecl *, SmallPtrSet<Decl *, 4>, 4> &QualifiedImports) {
+                                         llvm::SmallDenseMap<ModuleDecl *, SmallPtrSet<Decl *, 4>, 4> &QualifiedImports,
+                                         llvm::function_ref<bool(AttributedImport<ImportedModule>)> includeImport) {
   for (const FileUnit *file : M->getFiles()) {
     if (const SourceFile *source = dyn_cast<SourceFile>(file)) {
       if (source->hasImports()) {
         for (auto import : source->getImports()) {
           if (import.options.contains(ImportFlags::Exported) &&
+              (!includeImport || includeImport(import)) &&
               import.module.importedModule->shouldCollectDisplayDecls()) {
             auto *TheModule = import.module.importedModule;
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1985,18 +1985,22 @@ bool Parser::parseDocumentationAttributeArgument(Optional<StringRef> &Metadata,
     consumeToken();
     Visibility = ParsedVisibility;
   } else if (ArgumentName == "metadata") {
-    if (Tok.isNot(tok::identifier)) {
-      diagnose(Tok.getLoc(), diag::documentation_attr_metadata_expected_identifier);
+    if (!Tok.isAny(tok::identifier, tok::string_literal)) {
+      diagnose(Tok.getLoc(), diag::documentation_attr_metadata_expected_text);
       return false;
     }
     auto ArgumentValue = Tok.getText();
+    if (ArgumentValue.front() == '\"' && ArgumentValue.back() == '\"') {
+      // String literals get saved with surrounding quotes. Trim them off if they're present.
+      ArgumentValue = ArgumentValue.slice(1, ArgumentValue.size() - 1);
+    }
 
     if (Metadata) {
       diagnose(Tok.getLoc(), diag::documentation_attr_duplicate_metadata);
       return false;
     }
 
-    consumeToken(tok::identifier);
+    consumeToken();
     Metadata = ArgumentValue;
   } else {
     llvm_unreachable("unimplemented @_documentation attr argument");

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1930,6 +1930,119 @@ bool Parser::parseBackDeployAttribute(DeclAttributes &Attributes,
   return true;
 }
 
+static bool isKnownDocumentationAttributeArgument(StringRef ArgumentName) {
+  return llvm::StringSwitch<bool>(ArgumentName)
+    .Case("visibility", true)
+    .Case("metadata", true)
+    .Default(false);
+}
+
+bool Parser::parseDocumentationAttributeArgument(Optional<StringRef> &Metadata,
+                                                 Optional<AccessLevel> &Visibility) {
+  if (Tok.isNot(tok::identifier)) {
+    diagnose(Tok.getLoc(), diag::documentation_attr_expected_argument);
+    return false;
+  }
+
+  auto ArgumentName = Tok.getText();
+
+  if (!isKnownDocumentationAttributeArgument(ArgumentName)) {
+    diagnose(Tok.getLoc(), diag::documentation_attr_unknown_argument, ArgumentName);
+    return false;
+  }
+
+  consumeToken(tok::identifier);
+  if (!consumeIf(tok::colon)) {
+    diagnose(Tok.getLoc(), diag::expected_colon_after_label, ArgumentName);
+    return false;
+  }
+
+  if (ArgumentName == "visibility") {
+    if (!Tok.isAny(tok::kw_public, tok::kw_internal, tok::kw_private, tok::kw_fileprivate, tok::identifier)) {
+      diagnose(Tok.getLoc(), diag::documentation_attr_expected_access_level);
+      return false;
+    }
+    auto ArgumentValue = Tok.getText();
+    Optional<AccessLevel> ParsedVisibility =
+      llvm::StringSwitch<Optional<AccessLevel>>(ArgumentValue)
+        .Case("open", AccessLevel::Open)
+        .Case("public", AccessLevel::Public)
+        .Case("internal", AccessLevel::Internal)
+        .Case("private", AccessLevel::Private)
+        .Case("fileprivate", AccessLevel::FilePrivate)
+        .Default(None);
+
+    if (!ParsedVisibility) {
+      diagnose(Tok.getLoc(), diag::documentation_attr_unknown_access_level, ArgumentValue);
+      return false;
+    }
+
+    if (Visibility) {
+      diagnose(Tok.getLoc(), diag::documentation_attr_duplicate_visibility);
+      return false;
+    }
+
+    consumeToken();
+    Visibility = ParsedVisibility;
+  } else if (ArgumentName == "metadata") {
+    if (Tok.isNot(tok::identifier)) {
+      diagnose(Tok.getLoc(), diag::documentation_attr_metadata_expected_identifier);
+      return false;
+    }
+    auto ArgumentValue = Tok.getText();
+
+    if (Metadata) {
+      diagnose(Tok.getLoc(), diag::documentation_attr_duplicate_metadata);
+      return false;
+    }
+
+    consumeToken(tok::identifier);
+    Metadata = ArgumentValue;
+  } else {
+    llvm_unreachable("unimplemented @_documentation attr argument");
+  }
+
+  return true;
+}
+
+ParserResult<DocumentationAttr>
+Parser::parseDocumentationAttribute(SourceLoc AtLoc, SourceLoc Loc) {
+  StringRef AttrName = "_documentation";
+  bool declModifier = DeclAttribute::isDeclModifier(DAK_Documentation);
+  Optional<AccessLevel> Visibility = None;
+  Optional<StringRef> Metadata = None;
+
+  if (!consumeIf(tok::l_paren)) {
+    diagnose(Loc, diag::attr_expected_lparen, AttrName,
+             declModifier);
+    return makeParserError();
+  }
+
+  while (Tok.isNot(tok::r_paren)) {
+    if (!parseDocumentationAttributeArgument(Metadata, Visibility))
+      return makeParserError();
+
+    if (Tok.is(tok::comma)) {
+      consumeToken();
+    } else if (Tok.isNot(tok::r_paren)) {
+      diagnose(Tok, diag::expected_separator, ",");
+      return makeParserError();
+    }
+  }
+
+  auto range = SourceRange(Loc, Tok.getRange().getStart());
+
+  if (!consumeIf(tok::r_paren)) {
+    diagnose(Loc, diag::attr_expected_rparen, AttrName,
+             declModifier);
+    return makeParserError();
+  }
+
+  StringRef FinalMetadata = Metadata.getValueOr("");
+
+  return makeParserResult(new (Context) DocumentationAttr(Loc, range, FinalMetadata, Visibility, false));
+}
+
 /// Processes a parsed option name by attempting to match it to a list of
 /// alternative name/value pairs provided by a chain of \c when() calls, ending
 /// in either \c whenOmitted() if omitting the option is allowed, or
@@ -2999,6 +3112,14 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
   }
   case DAK_BackDeploy: {
     if (!parseBackDeployAttribute(Attributes, AttrName, AtLoc, Loc))
+      return false;
+    break;
+  }
+  case DAK_Documentation: {
+    auto Attr = parseDocumentationAttribute(AtLoc, Loc);
+    if (Attr.isNonNull())
+      Attributes.add(Attr.get());
+    else
       return false;
     break;
   }

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -28,6 +28,7 @@
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/Parse/Parser.h"
 #include "swift/Subsystems.h"
+#include "swift/SymbolGraphGen/DocumentationCategory.h"
 #include "clang/Basic/Module.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/TinyPtrVector.h"
@@ -560,6 +561,8 @@ UnboundImport::UnboundImport(ImportDecl *ID)
 
   if (auto attr = ID->getAttrs().getAttribute<WeakLinkedAttr>())
     import.options |= ImportFlags::WeakLinked;
+
+  import.docVisibility = swift::symbolgraphgen::documentationVisibilityForDecl(ID);
 }
 
 bool UnboundImport::checkNotTautological(const SourceFile &SF) {
@@ -1032,6 +1035,14 @@ UnboundImport::UnboundImport(
   if (declaringOptions.contains(ImportFlags::ImplementationOnly) ||
       bystandingOptions.contains(ImportFlags::ImplementationOnly))
     import.options |= ImportFlags::ImplementationOnly;
+
+  // If either have a `@_documentation(visibility: <access>)` attribute, the
+  // cross-import has the more restrictive of the two.
+  if (declaringImport.docVisibility || bystandingImport.docVisibility) {
+    auto declaringAccess = declaringImport.docVisibility.getValueOr(AccessLevel::Public);
+    auto bystandingAccess = bystandingImport.docVisibility.getValueOr(AccessLevel::Public);
+    import.docVisibility = std::min(declaringAccess, bystandingAccess);
+  }
 }
 
 void ImportResolver::crossImport(ModuleDecl *M, UnboundImport &I) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -157,6 +157,7 @@ public:
   IGNORED_ATTR(Isolated)
   IGNORED_ATTR(Preconcurrency)
   IGNORED_ATTR(BackDeploy)
+  IGNORED_ATTR(Documentation)
 #undef IGNORED_ATTR
 
   void visitAlignmentAttr(AlignmentAttr *attr) {

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1491,6 +1491,7 @@ namespace  {
     UNINTERESTING_ATTR(Borrowed)
     UNINTERESTING_ATTR(CDecl)
     UNINTERESTING_ATTR(Consuming)
+    UNINTERESTING_ATTR(Documentation)
     UNINTERESTING_ATTR(Dynamic)
     UNINTERESTING_ATTR(DynamicCallable)
     UNINTERESTING_ATTR(DynamicMemberLookup)

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5058,6 +5058,21 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
         break;
       }
 
+      case decls_block::Documentation_DECL_ATTR: {
+        bool isImplicit;
+        uint64_t CategoryID;
+        bool hasVisibility;
+        uint8_t visibilityID;
+        serialization::decls_block::DocumentationDeclAttrLayout::readRecord(
+            scratch, isImplicit, CategoryID, hasVisibility, visibilityID);
+        StringRef CategoryText = MF.getIdentifierText(CategoryID);
+        Optional<swift::AccessLevel> realVisibility = None;
+        if (hasVisibility)
+          realVisibility = getActualAccessLevel(visibilityID);
+        Attr = new (ctx) DocumentationAttr(CategoryText, realVisibility, isImplicit);
+        break;
+      }
+
 #define SIMPLE_DECL_ATTR(NAME, CLASS, ...) \
       case decls_block::CLASS##_DECL_ATTR: { \
         bool isImplicit; \

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -2110,6 +2110,14 @@ namespace decls_block {
                                               BCBlob      // declaration name
                                               >;
 
+  using DocumentationDeclAttrLayout = BCRecordLayout<
+    Documentation_DECL_ATTR,
+    BCFixed<1>,         // implicit flag
+    IdentifierIDField,  // metadata text
+    BCFixed<1>,         // has visibility
+    AccessLevelField    // visibility
+  >;
+
 #undef SYNTAX_SUGAR_TYPE_LAYOUT
 #undef TYPE_LAYOUT
 #undef TYPE_LAYOUT_IMPL

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2871,6 +2871,23 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
                                        theAttr->isImplicit(), theAttr->Name);
       return;
     }
+
+    case DAK_Documentation: {
+      auto *theAttr = cast<DocumentationAttr>(DA);
+      auto abbrCode = S.DeclTypeAbbrCodes[DocumentationDeclAttrLayout::Code];
+      auto metadataIDPair = S.addUniquedString(theAttr->Metadata);
+      bool hasVisibility = false;
+      uint8_t visibility = static_cast<uint8_t>(AccessLevel::Private);
+      if (theAttr->Visibility) {
+        hasVisibility = true;
+        visibility = getRawStableAccessLevel(*theAttr->Visibility);
+      }
+
+      DocumentationDeclAttrLayout::emitRecord(
+          S.Out, S.ScratchRecord, abbrCode, theAttr->isImplicit(),
+          metadataIDPair.second, hasVisibility, visibility);
+      return;
+    }
     }
   }
 

--- a/lib/SymbolGraphGen/Symbol.cpp
+++ b/lib/SymbolGraphGen/Symbol.cpp
@@ -19,6 +19,7 @@
 #include "swift/Basic/PrimitiveParsing.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Basic/Unicode.h"
+#include "swift/SymbolGraphGen/DocumentationCategory.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Decl.h"
 #include "clang/Basic/SourceManager.h"
@@ -452,6 +453,12 @@ void Symbol::serializeAccessLevelMixin(llvm::json::OStream &OS) const {
   OS.attribute("accessLevel", getAccessLevelSpelling(VD->getFormalAccess()));
 }
 
+void Symbol::serializeMetadataMixin(llvm::json::OStream &OS) const {
+  StringRef Category = documentationMetadataForDecl(VD);
+  if (!Category.empty())
+    OS.attribute("metadata", Category);
+}
+
 void Symbol::serializeLocationMixin(llvm::json::OStream &OS) const {
   if (ClangNode ClangN = VD->getClangNode()) {
     if (!Graph->Walker.Options.IncludeClangDocs)
@@ -592,6 +599,7 @@ void Symbol::serialize(llvm::json::OStream &OS) const {
     serializeDeclarationFragmentMixin(OS);
     serializeAccessLevelMixin(OS);
     serializeAvailabilityMixin(OS);
+    serializeMetadataMixin(OS);
     serializeLocationMixin(OS);
     serializeSPIMixin(OS);
   });

--- a/lib/SymbolGraphGen/Symbol.h
+++ b/lib/SymbolGraphGen/Symbol.h
@@ -72,6 +72,8 @@ class Symbol {
 
   void serializeAccessLevelMixin(llvm::json::OStream &OS) const;
 
+  void serializeMetadataMixin(llvm::json::OStream &OS) const;
+
   void serializeLocationMixin(llvm::json::OStream &OS) const;
 
   void serializeAvailabilityMixin(llvm::json::OStream &OS) const;

--- a/lib/SymbolGraphGen/SymbolGraphGen.cpp
+++ b/lib/SymbolGraphGen/SymbolGraphGen.cpp
@@ -60,7 +60,11 @@ symbolgraphgen::emitSymbolGraphForModule(ModuleDecl *M,
   
   SmallPtrSet<ModuleDecl *, 4> ExportedImportedModules;
   llvm::SmallDenseMap<ModuleDecl *, SmallPtrSet<Decl *, 4>, 4> QualifiedImports;
-  swift::collectParsedExportedImports(M, ExportedImportedModules, QualifiedImports);
+  auto shouldIncludeImport = [&](AttributedImport<ImportedModule> import) {
+    auto docVisibility = import.docVisibility.getValueOr(AccessLevel::Public);
+    return docVisibility >= Options.MinimumAccessLevel;
+  };
+  swift::collectParsedExportedImports(M, ExportedImportedModules, QualifiedImports, shouldIncludeImport);
 
   if (Options.PrintMessages)
     llvm::errs() << ModuleDecls.size()

--- a/test/SymbolGraph/Module/DocAttrExportedImport.swift
+++ b/test/SymbolGraph/Module/DocAttrExportedImport.swift
@@ -1,0 +1,30 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %S/Inputs/ExportedImport/A.swift -module-name A -emit-module -emit-module-path %t/A.swiftmodule
+// RUN: %target-swift-frontend %S/Inputs/ExportedImport/B.swift -module-name B -emit-module -emit-module-path %t/B.swiftmodule
+
+// RUN: %target-swift-frontend %s -module-name DocAttrExportedImport -emit-module -emit-module-path /dev/null -I %t -emit-symbol-graph -emit-symbol-graph-dir %t/
+// RUN: %FileCheck %s --input-file %t/DocAttrExportedImport.symbols.json --check-prefix PUBLIC
+// RUN: ls %t | %FileCheck %s --check-prefix FILES
+
+// RUN: %target-swift-frontend %s -module-name DocAttrExportedImport -emit-module -emit-module-path /dev/null -I %t -emit-symbol-graph -emit-symbol-graph-dir %t/ -symbol-graph-minimum-access-level internal
+// RUN: %FileCheck %s --input-file %t/DocAttrExportedImport.symbols.json --check-prefix INTERNAL
+// RUN: ls %t | %FileCheck %s --check-prefix FILES
+
+@_documentation(visibility: internal) @_exported import A
+@_documentation(visibility: internal) @_exported import struct B.StructOne
+
+// PUBLIC-NOT: InternalSymbolFromA
+// PUBLIC-NOT: StructTwo
+// PUBLIC-NOT: "precise":"s:1A11SymbolFromAV"
+// PUBLIC-NOT: "precise":"s:1B9StructOneV"
+
+// INTERNAL-NOT: InternalSymbolFromA
+// INTERNAL-NOT: StructTwo
+// INTERNAL-DAG: "precise":"s:1A11SymbolFromAV"
+// INTERNAL-DAG: "precise":"s:1B9StructOneV"
+
+// FIXME: Symbols from `@_exported import` do not get emitted when using swift-symbolgraph-extract
+// This is tracked by https://bugs.swift.org/browse/SR-15921.
+
+// FILES-NOT: DocAttrExportedImport@A.symbols.json
+

--- a/test/SymbolGraph/Symbols/DocumentationAttr.swift
+++ b/test/SymbolGraph/Symbols/DocumentationAttr.swift
@@ -1,0 +1,47 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name DocumentationAttr -emit-module -emit-module-path %t/
+// RUN: %target-swift-symbolgraph-extract -module-name DocumentationAttr -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/DocumentationAttr.symbols.json --check-prefix PUBLIC
+
+// RUN: %target-swift-symbolgraph-extract -module-name DocumentationAttr -I %t -pretty-print -output-dir %t -minimum-access-level internal
+// RUN: %FileCheck %s --input-file %t/DocumentationAttr.symbols.json --check-prefix INTERNAL
+
+// RUN: %target-swift-symbolgraph-extract -module-name DocumentationAttr -I %t -pretty-print -output-dir %t -minimum-access-level private
+// RUN: %FileCheck %s --input-file %t/DocumentationAttr.symbols.json --check-prefix PRIVATE
+
+// This test is a mirror of SkipsPublicUnderscore.swift, but using `@_documentation`
+// instead of underscored names.
+
+public protocol PublicProtocol {}
+
+// PUBLIC-NOT: ShouldntAppear
+// INTERNAL-DAG: ShouldntAppear
+// PRIVATE-DAG: ShouldntAppear
+
+@_documentation(visibility: internal) public struct ShouldntAppear: PublicProtocol {
+    public struct InnerShouldntAppear {}
+}
+
+public class SomeClass {
+    // PUBLIC-NOT: internalVar
+    // INTERNAL-NOT: internalVar
+    // PRIVATE-DAG: internalVar
+    @_documentation(visibility: private) internal var internalVar: String = ""
+}
+
+@_documentation(visibility: internal) public protocol ProtocolShouldntAppear {}
+
+public struct PublicStruct: ProtocolShouldntAppear {
+    @_documentation(visibility: internal) public struct InnerShouldntAppear {}
+}
+
+// The presence of `@_documentation(visibility: public)` should cause SymbolGraphGen to include an
+// underscored enum case.
+
+// PUBLIC-DAG: _ShouldAppear
+
+public enum PublicEnum {
+    case RegularCase
+    case _ShouldntAppear
+    @_documentation(visibility: public) case _ShouldAppear
+}

--- a/test/SymbolGraph/Symbols/DocumentationMetadata.swift
+++ b/test/SymbolGraph/Symbols/DocumentationMetadata.swift
@@ -1,0 +1,8 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name DocumentationMetadata -emit-module -emit-module-path %t/
+// RUN: %target-swift-symbolgraph-extract -module-name DocumentationMetadata -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/DocumentationMetadata.symbols.json
+
+// CHECK: "metadata": "cool_stuff"
+@_documentation(metadata: cool_stuff) public class SomeClass {}
+

--- a/test/SymbolGraph/Symbols/DocumentationMetadata.swift
+++ b/test/SymbolGraph/Symbols/DocumentationMetadata.swift
@@ -3,6 +3,9 @@
 // RUN: %target-swift-symbolgraph-extract -module-name DocumentationMetadata -I %t -pretty-print -output-dir %t
 // RUN: %FileCheck %s --input-file %t/DocumentationMetadata.symbols.json
 
-// CHECK: "metadata": "cool_stuff"
+// CHECK-DAG: "metadata": "cool_stuff"
 @_documentation(metadata: cool_stuff) public class SomeClass {}
+
+// CHECK-DAG: "metadata": "this is a longer string"
+@_documentation(metadata: "this is a longer string") public class OtherClass {}
 


### PR DESCRIPTION
Resolves rdar://79049241

This PR introduces a new attribute, `@_documentation(...)`, that influences how SymbolGraphGen handles the symbol it's attached to. There are two forms of this attribute:

- `@_documentation(visibility: ...)` treats the symbol as the given access level in the symbol graph, allowing you to hide a technically-`public` implementation detail from public documentation, or reveal a symbol with an underscored name that would otherwise be hidden.
- `@_documentation(metadata: ...)` adds an arbitrary identifier to the symbol's `"metadata"` field, which can then be handled by other tooling.

This PR also fixes a pre-existing issue where symbols that were declared `internal` in a re-exported module would be included in the symbol graph if it was being requested with an `internal` access level, and similarly for anything below `public`.