### PR TITLE
NFC, move GenericRequirement struct out of lib/IRGen to include/AST

### DIFF
--- a/include/swift/AST/GenericRequirement.h
+++ b/include/swift/AST/GenericRequirement.h
@@ -1,0 +1,51 @@
+//===--- GenericRequirement.h - Generic requirement -------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_GENERIC_REQUIREMENT_H
+#define SWIFT_AST_GENERIC_REQUIREMENT_H
+
+#include "swift/AST/Type.h"
+
+namespace swift {
+
+class ProtocolDecl;
+
+/// An abstract generic requirement.
+struct GenericRequirement {
+  CanType TypeParameter;
+  ProtocolDecl *Protocol;
+};
+
+} // end namespace swift
+
+namespace llvm {
+template <> struct DenseMapInfo<swift::GenericRequirement> {
+  using GenericRequirement = swift::GenericRequirement;
+  using CanTypeInfo = llvm::DenseMapInfo<swift::CanType>;
+  static GenericRequirement getEmptyKey() {
+    return {CanTypeInfo::getEmptyKey(), nullptr};
+  }
+  static GenericRequirement getTombstoneKey() {
+    return {CanTypeInfo::getTombstoneKey(), nullptr};
+  }
+  static llvm::hash_code getHashValue(GenericRequirement req) {
+    return hash_combine(CanTypeInfo::getHashValue(req.TypeParameter),
+                        hash_value(req.Protocol));
+  }
+  static bool isEqual(GenericRequirement lhs, GenericRequirement rhs) {
+    return (lhs.TypeParameter == rhs.TypeParameter &&
+            lhs.Protocol == rhs.Protocol);
+  }
+};
+} // end namespace llvm
+
+#endif // SWIFT_AST_GENERIC_REQUIREMENT_H

--- a/lib/IRGen/EntryPointArgumentEmission.h
+++ b/lib/IRGen/EntryPointArgumentEmission.h
@@ -18,12 +18,12 @@ class Value;
 
 namespace swift {
 
+struct GenericRequirement;
 class SILArgument;
 
 namespace irgen {
 
 class Explosion;
-struct GenericRequirement;
 class LoadableTypeInfo;
 class TypeInfo;
 

--- a/lib/IRGen/GenericRequirement.h
+++ b/lib/IRGen/GenericRequirement.h
@@ -19,10 +19,11 @@
 #ifndef SWIFT_IRGEN_GENERICREQUIREMENT_H
 #define SWIFT_IRGEN_GENERICREQUIREMENT_H
 
+#include "swift/AST/GenericRequirement.h"
 #include "swift/AST/Type.h"
-#include "llvm/ADT/SmallVector.h"
-#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/DenseMapInfo.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
 
 namespace llvm {
 class Value;
@@ -40,12 +41,6 @@ namespace irgen {
 class Address;
 class IRGenFunction;
 class IRGenModule;
-
-/// An abstract generic requirement.
-struct GenericRequirement {
-  CanType TypeParameter;
-  ProtocolDecl *Protocol;
-};
 
 using RequirementCallback =
   llvm::function_ref<void(GenericRequirement requirement)>;
@@ -151,26 +146,5 @@ public:
 
 } // end namespace irgen
 } // end namespace swift
-
-namespace llvm {
-  template <> struct DenseMapInfo<swift::irgen::GenericRequirement> {
-    using GenericRequirement = swift::irgen::GenericRequirement;
-    using CanTypeInfo = llvm::DenseMapInfo<swift::CanType>;
-    static GenericRequirement getEmptyKey() {
-      return { CanTypeInfo::getEmptyKey(), nullptr };
-    }
-    static GenericRequirement getTombstoneKey() {
-      return { CanTypeInfo::getTombstoneKey(), nullptr };
-    }
-    static llvm::hash_code getHashValue(GenericRequirement req) {
-      return hash_combine(CanTypeInfo::getHashValue(req.TypeParameter),
-                          hash_value(req.Protocol));
-    }
-    static bool isEqual(GenericRequirement lhs, GenericRequirement rhs) {
-      return (lhs.TypeParameter == rhs.TypeParameter &&
-              lhs.Protocol == rhs.Protocol);
-    }
-  };
-}
 
 #endif

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -93,6 +93,7 @@ namespace swift {
   class BraceStmt;
   class CanType;
   class GeneratedModule;
+  struct GenericRequirement;
   class LinkLibrary;
   class SILFunction;
   class IRGenOptions;
@@ -152,7 +153,6 @@ namespace irgen {
   class Signature;
   class StructMetadataLayout;
   struct SymbolicMangling;
-  struct GenericRequirement;
   class TypeConverter;
   class TypeInfo;
   enum class TypeMetadataAddress;


### PR DESCRIPTION
This will permit the use of GenericRequirement in PrintAsClang.
This will allow the C++ bindings printer to print generic function signatures
correctly, by passing information about emitted GenericRequirement values
for a signature from IRGen using IRGenABIDetailsProvider to PrintAsClang.
