### PR TITLE
[cxx-interop] Do not crash when diagnosing cycles for C++ operators

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8193,9 +8193,13 @@ ClangImporter::Implementation::importDeclForDeclContext(
   if (!contextDeclsWarnedAbout.insert(contextDecl).second)
     return nullptr;
 
-  auto getDeclName = [](const clang::Decl *D) -> StringRef {
-    if (auto ND = dyn_cast<clang::NamedDecl>(D))
-      return ND->getName();
+  auto getDeclName = [](const clang::Decl *D) -> std::string {
+    if (auto ND = dyn_cast<clang::NamedDecl>(D)) {
+      std::string name;
+      llvm::raw_string_ostream os(name);
+      ND->printName(os);
+      return name;
+    }
     return "<anonymous>";
   };
 


### PR DESCRIPTION
C++ operator functions are `NamedDecl`s, but they don't have a trivial name, and calling `getName` results in an assertion failure.

This was discovered during C++ interop adoption in SwiftCompilerSources.

```
Assertion failed: (Name.isIdentifier() && "Name is not a simple identifier"), function getName, file Decl.h, line 277.
...
swift/llvm-project/clang/include/clang/AST/DependentDiagnostic.h:150:8: importing 'clang::DeclContext::ddiag_iterator::operator=='
```