### PR TITLE
[cxx-interop] Do not try to import uninstantiatable templates

### DIFF
--- a/test/Interop/Cxx/templates/Inputs/member-templates.h
+++ b/test/Interop/Cxx/templates/Inputs/member-templates.h
@@ -50,4 +50,16 @@ struct HasTemplatedField {
   MyTemplatedStruct<int> x;
 };
 
+template <typename A, typename R = TemplateClassWithMemberTemplates<A>>
+struct HasUninstantiatableTemplateMember {
+  R *pointer; // R cannot be instantiated here, because R is an incomplete type,
+              // so this should be imported as OpaquePointer.
+};
+
+struct HasTemplateInstantiationWithForwardDecl {
+  class NoDefinition;
+
+  HasUninstantiatableTemplateMember<NoDefinition> noDefMember;
+};
+
 #endif // TEST_INTEROP_CXX_TEMPLATES_INPUTS_MEMBER_TEMPLATES_H

--- a/test/Interop/Cxx/templates/member-templates-module-interface.swift
+++ b/test/Interop/Cxx/templates/member-templates-module-interface.swift
@@ -35,3 +35,13 @@
 // CHECK:   init(x: __CxxTemplateInst17MyTemplatedStructIiE)
 // CHECK:   var x: __CxxTemplateInst17MyTemplatedStructIiE
 // CHECK: }
+
+// CHECK: struct __CxxTemplateInst33HasUninstantiatableTemplateMemberIN39HasTemplateInstantiationWithForwardDecl12NoDefinitionE32TemplateClassWithMemberTemplatesIS1_EE {
+// CHECK:   init(pointer: OpaquePointer!)
+// CHECK:   var pointer: OpaquePointer!
+// CHECK: }
+
+// CHECK: struct HasTemplateInstantiationWithForwardDecl {
+// CHECK:   init(noDefMember: __CxxTemplateInst33HasUninstantiatableTemplateMemberIN39HasTemplateInstantiationWithForwardDecl12NoDefinitionE32TemplateClassWithMemberTemplatesIS1_EE)
+// CHECK:   var noDefMember: __CxxTemplateInst33HasUninstantiatableTemplateMemberIN39HasTemplateInstantiationWithForwardDecl12NoDefinitionE32TemplateClassWithMemberTemplatesIS1_EE
+// CHECK: }


### PR DESCRIPTION
Calling `clangSema.isCompleteType` tries to instantiate a template, and if that is impossible, returns `true`. This caused Swift to try to import invalid C++ template instantiations.

This was discovered during C++ interop adoption in SwiftCompilerSources:
Several LLVM headers declare a field with a type `DenseMap<int, ForwardDeclared>` where `ForwardDeclared` is defined in an implementation file (`.cpp`) and is not visible to ClangImporter. That is valid in C++ but caused an error when importing into Swift.