### PR TITLE
[cxx-interop] Bump SWIFT_LOOKUP_TABLE_VERSION_MINOR after changes to …

### DIFF
--- a/lib/ClangImporter/SwiftLookupTable.h
+++ b/lib/ClangImporter/SwiftLookupTable.h
@@ -279,7 +279,8 @@ const uint16_t SWIFT_LOOKUP_TABLE_VERSION_MAJOR = 1;
 /// Lookup table minor version number.
 ///
 /// When the format changes IN ANY WAY, this number should be incremented.
-const uint16_t SWIFT_LOOKUP_TABLE_VERSION_MINOR = 17; // Lazy Member Loading Index
+const uint16_t SWIFT_LOOKUP_TABLE_VERSION_MINOR = 18; // Unsafe C++ method renaming.
+
 
 /// A lookup table that maps Swift names to the set of Clang
 /// declarations with that particular name.


### PR DESCRIPTION
…importing unsafe C++ method names.


I don't know how to write a test for this, but hopefully the flakey CI starts passing. 