### PR TITLE
Correct VFS libc modulemap injection condition.

### DIFF
--- a/lib/ClangImporter/ClangIncludePaths.cpp
+++ b/lib/ClangImporter/ClangIncludePaths.cpp
@@ -171,11 +171,15 @@ createClangArgs(const ASTContext &ctx, clang::driver::Driver &clangDriver) {
   return clangDriverArgs;
 }
 
+static bool shouldInjectGlibcModulemap(const llvm::Triple &triple) {
+  return triple.isOSGlibc() || triple.isOSOpenBSD() || triple.isOSFreeBSD() ||
+         triple.isAndroid();
+}
+
 static SmallVector<std::pair<std::string, std::string>, 2>
 getGlibcFileMapping(ASTContext &ctx) {
   const llvm::Triple &triple = ctx.LangOpts.Target;
-  // We currently only need this when building for Linux.
-  if (!triple.isOSLinux())
+  if (!shouldInjectGlibcModulemap(triple))
     return {};
 
   // Extract the Glibc path from Clang driver.


### PR DESCRIPTION
We should only be skipping VFS libc modulemap injection on Darwin and
Windows. Unfortunately, we cannot use the isOSGlibc Triple method because
LLVM's sense of Glibc (does the platform _actually use_ glibc) differs
from Swift's sense of Glibc (does the platform use libc).

There may be other non-libc platforms that we should skip VFS injection
on but let's correct the conditional for now and other prs should add
those platforms as necessary.
