### PR TITLE
[cxx-interop] Conform `std::string` to `ExpressibleByStringLiteral`

### DIFF
--- a/stdlib/public/Cxx/std/String.swift
+++ b/stdlib/public/Cxx/std/String.swift
@@ -19,6 +19,12 @@ extension std.string {
   }
 }
 
+extension std.string: ExpressibleByStringLiteral {
+  public init(stringLiteral value: String) {
+    self.init(value)
+  }
+}
+
 extension String {
   public init(cxxString: std.string) {
     self.init(cString: cxxString.__c_strUnsafe())

--- a/test/Interop/Cxx/stdlib/overlay/std-string-overlay.swift
+++ b/test/Interop/Cxx/stdlib/overlay/std-string-overlay.swift
@@ -16,6 +16,9 @@ StdStringOverlayTestSuite.test("std::string <=> Swift.String") {
   let cxx2 = std.string("something123")
   let swift2 = String(cxxString: cxx2)
   expectEqual(swift2, "something123")
+
+  let cxx3: std.string = "literal"
+  expectEqual(cxx3.size(), 7)
 }
 
 extension std.string.const_iterator: UnsafeCxxInputIterator {


### PR DESCRIPTION
This allows `std::string` to be constructed implicitly from a String literal, which is convenient e.g. when calling C++ APIs that take `std::string` as a parameter.