### PR TITLE
[Sema] Fix missing operator diagnostic logic

### DIFF
--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -459,6 +459,15 @@ public:
         const_cast<DeclContext *>(this)->getInnermostDeclarationDeclContext();
   }
 
+  /// Returns the topmost context that is a declaration, excluding ModuleDecl.
+  ///
+  /// This may return itself.
+  LLVM_READONLY
+  Decl *getTopmostDeclarationDeclContext();
+  const Decl *getTopmostDeclarationDeclContext() const {
+    return const_cast<DeclContext *>(this)->getTopmostDeclarationDeclContext();
+  }
+
   /// Returns the innermost context that is an AbstractFunctionDecl whose
   /// body has been skipped.
   LLVM_READONLY

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -237,6 +237,16 @@ Decl *DeclContext::getInnermostDeclarationDeclContext() {
   return nullptr;
 }
 
+Decl *DeclContext::getTopmostDeclarationDeclContext() {
+  auto *dc = this;
+  Decl *topmost = nullptr;
+  while (auto *decl = dc->getInnermostDeclarationDeclContext()) {
+    topmost = decl;
+    dc = decl->getDeclContext();
+  }
+  return topmost;
+}
+
 DeclContext *DeclContext::getInnermostSkippedFunctionContext() {
   auto dc = this;
   do {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1942,25 +1942,10 @@ FunctionOperatorRequest::evaluate(Evaluator &evaluator, FuncDecl *FD) const {
   }
 
   if (!op) {
-    SourceLoc insertionLoc;
-    if (isa<SourceFile>(FD->getParent())) {
-      // Parent context is SourceFile, insertion location is start of func
-      // declaration or unary operator
-      if (FD->isUnaryOperator()) {
-        insertionLoc = FD->getAttrs().getStartLoc();
-      } else {
-        insertionLoc = FD->getStartLoc();
-      }
-    } else {
-      // Find the topmost non-file decl context and insert there.
-      for (DeclContext *CurContext = FD->getLocalContext();
-           !isa<SourceFile>(CurContext);
-           CurContext = CurContext->getParent()) {
-        // Skip over non-decl contexts (e.g. closure expressions)
-        if (auto *D = CurContext->getAsDecl())
-            insertionLoc = D->getStartLoc();
-      }
-    }
+    // We want to insert at the start of the top-most declaration, taking
+    // attributes into consideration.
+    auto *insertionDecl = FD->getTopmostDeclarationDeclContext();
+    auto insertionLoc = insertionDecl->getSourceRangeIncludingAttrs().Start;
 
     SmallString<128> insertion;
     {

--- a/test/Serialization/AllowErrors/invalid-operator.swift
+++ b/test/Serialization/AllowErrors/invalid-operator.swift
@@ -1,0 +1,9 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -verify -emit-module -experimental-allow-module-with-compiler-errors %s -o %t/foo.swiftmodule
+// RUN: %target-swift-frontend -verify -emit-module -module-name foo %t/foo.swiftmodule
+
+// rdar://97267326 – Make sure we can handle an operator function without its declaration.
+struct S {
+  static func ^^^ (lhs: S, rhs: S) {} // expected-error {{operator implementation without matching operator declaration}}
+}

--- a/test/decl/func/operator.swift
+++ b/test/decl/func/operator.swift
@@ -33,6 +33,29 @@ extension X {
     }
 }
 
+// #60268: Make sure we insert at the start of the attributes.
+@discardableResult
+internal
+func ^^^ (lhs: Int, rhs: Int) -> Int {} // expected-error {{operator implementation without matching operator declaration}} {{37:1-1=infix operator ^^^ : <# Precedence Group #>\n}}
+
+@discardableResult
+internal
+prefix func ^^^ (rhs: Int) -> Int {} // expected-error {{operator implementation without matching operator declaration}} {{41:1-1=prefix operator ^^^ : <# Precedence Group #>\n}}
+
+@frozen
+public
+struct Z {
+  struct Y {
+    static func ^^^ (lhs: Y, rhs: Y) {} // expected-error {{operator implementation without matching operator declaration}} {{45:1-1=infix operator ^^^ : <# Precedence Group #>\n}}
+  }
+}
+
+_ = {
+  func ^^^ (lhs: Int, rhs: Int) {}
+  // expected-error@-1 {{operator functions can only be declared at global or in type scope}}
+  // expected-error@-2 {{operator implementation without matching operator declaration}} {{53:1-1=infix operator ^^^ : <# Precedence Group #>\n}}
+}
+
 infix operator ++++ : ReallyHighPrecedence
 precedencegroup ReallyHighPrecedence {
   higherThan: BitwiseShiftPrecedence


### PR DESCRIPTION
Introduce a `getTopmostDeclarationDeclContext` utility to ensure we ensure we don't visit a `nullptr` DeclContext for an erroneous module under `-experimental-allow-module-with-compiler-errors`.

Additionally, tweak the insertion location such that we insert at the start of any attributes present.

rdar://97267326
Resolves #60268