### PR TITLE
Sema: Upgrade resilience diagnostics in Swift 6 for local typealiases to non-public typealiases

### DIFF
--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -84,8 +84,7 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
   }
 
   // Swift 5.0 did not check the underlying types of local typealiases.
-  // FIXME: Conditionalize this once we have a new language mode.
-  if (isa<TypeAliasDecl>(DC))
+  if (isa<TypeAliasDecl>(DC) && !Context.isSwiftVersionAtLeast(6))
     downgradeToWarning = DowngradeToWarning::Yes;
 
   auto diagID = diag::resilience_decl_unavailable;

--- a/test/attr/attr_inlinable_typealias_swift6.swift
+++ b/test/attr/attr_inlinable_typealias_swift6.swift
@@ -1,0 +1,8 @@
+// RUN: %target-typecheck-verify-swift -swift-version 6
+
+internal typealias InternalAlias = Int // expected-note 2 {{type alias 'InternalAlias' is not '@usableFromInline' or public}}
+
+@inlinable public func localTypealiases() {
+  typealias LocalAlias = InternalAlias // expected-error {{type alias 'InternalAlias' is internal and cannot be referenced from an '@inlinable' function}}
+  typealias GenericAlias<T> = (T, InternalAlias) // expected-error {{type alias 'InternalAlias' is internal and cannot be referenced from an '@inlinable' function}}
+}


### PR DESCRIPTION
This addresses a FIXME that was written in anticipation of a Swift 6 language mode becoming available.