### PR TITLE
[cxx-interop][SwiftCompilerSources] Explicitly list used headers in the modulemap

### DIFF
--- a/include/swift/module.modulemap
+++ b/include/swift/module.modulemap
@@ -1,6 +1,8 @@
 module BasicBridging {
   header "Basic/BridgedSwiftObject.h"
   header "Basic/BasicBridging.h"
+  header "Basic/SourceLoc.h"
+  requires cplusplus
   export *
 }
 


### PR DESCRIPTION
This might help to solve a flaky CI issue, and it's probably a good idea to do that anyway.