### PR TITLE
[cxx-interop] Fix static extensions on foreign reference types.

### DIFF
--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -659,6 +659,9 @@ bool SILFunction::hasDynamicSelfMetadata() const {
       selfTy = dynamicSelfTy.getSelfType();
   }
 
+  if (selfTy.isForeignReferenceType())
+    return false;
+
   return !!selfTy.getClassOrBoundGenericClass();
 }
 

--- a/test/Interop/Cxx/foreign-reference/pod.swift
+++ b/test/Interop/Cxx/foreign-reference/pod.swift
@@ -7,6 +7,10 @@ import StdlibUnittest
 import CxxShim
 import POD
 
+extension IntPair {
+  static public func swiftMake() -> IntPair { IntPair.create() }
+}
+
 struct StructHoldingPair {
   var pair: IntPair
 };
@@ -47,6 +51,12 @@ PODTestSuite.test("var IntPair") {
 
   x = IntPair.create()
   expectEqual(x.test(), 1)
+}
+
+PODTestSuite.test("static extension") {
+  var x = IntPair.swiftMake()
+  expectEqual(x.test(), 1)
+  expectEqual(x.testMutable(), 1)
 }
 
 PODTestSuite.test("let IntPair") {


### PR DESCRIPTION
Foreign reference types don't have dynamic metadata like other Swift classes.