### PR TITLE
[Serialization] Output precedence higher/lowerThan relations when valid

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3388,20 +3388,27 @@ public:
 
     SmallVector<DeclID, 8> relations;
     for (auto &rel : group->getHigherThan()) {
-      assert(rel.Group && "Undiagnosed invalid precedence group!");
-      relations.push_back(S.addDeclRef(rel.Group));
+      if (rel.Group) {
+        relations.push_back(S.addDeclRef(rel.Group));
+      } else if (!S.allowCompilerErrors()) {
+        assert(rel.Group && "Undiagnosed invalid precedence group!");
+      }
     }
+
+    size_t numHigher = relations.size();
     for (auto &rel : group->getLowerThan()) {
-      assert(rel.Group && "Undiagnosed invalid precedence group!");
-      relations.push_back(S.addDeclRef(rel.Group));
+      if (rel.Group) {
+        relations.push_back(S.addDeclRef(rel.Group));
+      } else if (!S.allowCompilerErrors()) {
+        assert(rel.Group && "Undiagnosed invalid precedence group!");
+      }
     }
 
     unsigned abbrCode = S.DeclTypeAbbrCodes[PrecedenceGroupLayout::Code];
     PrecedenceGroupLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
                                       nameID, contextID.getOpaqueValue(),
                                       associativity, group->isAssignment(),
-                                      group->getHigherThan().size(),
-                                      relations);
+                                      numHigher, relations);
   }
 
   void visitInfixOperatorDecl(const InfixOperatorDecl *op) {

--- a/test/Serialization/AllowErrors/invalid-precedencegroup.swift
+++ b/test/Serialization/AllowErrors/invalid-precedencegroup.swift
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -verify -emit-module -experimental-allow-module-with-compiler-errors %s -o %t/error.swiftmodule
+// RUN: %target-swift-frontend -module-name error -emit-module -experimental-allow-module-with-compiler-errors %t/error.swiftmodule -o %t/error2.swiftmodule 2>&1 | %FileCheck %s
+
+// CHECK: allowing deserialization of invalid declaration
+
+precedencegroup SomePrecedence {
+  associativity: right
+  higherThan: MissingType // expected-error {{unknown precedence group 'MissingType'}}
+}
+
+infix operator <>: SomePrecedence


### PR DESCRIPTION
When allowing errors, do not output higher/lowerThan relations for
invalid precedencegroup declarations.

Resolves rdar://97362356.