### PR TITLE
sema: consider decl context with @_spi_available as an SPI export context

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -180,7 +180,8 @@ static void forEachOuterDecl(DeclContext *DC, Fn fn) {
 static void computeExportContextBits(ASTContext &Ctx, Decl *D,
                                      bool *spi, bool *implicit, bool *deprecated,
                                      Optional<PlatformKind> *unavailablePlatformKind) {
-  if (D->isSPI())
+  if (D->isSPI() ||
+      D->isAvailableAsSPI())
     *spi = true;
 
   // Defer bodies are desugared to an implicit closure expression. We need to

--- a/test/Sema/spi-available-context.swift
+++ b/test/Sema/spi-available-context.swift
@@ -1,0 +1,11 @@
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx11.9 -library-level api
+
+@_spi_available(macOS 10.4, *)
+public protocol Foo { }
+
+@_spi_available(macOS 10.4, *)
+public class Bar {
+    public var foo: Foo?
+}


### PR DESCRIPTION
This allows chained invocations of multiple @_spi_available decls.

rdar://97636996
