### PR TITLE
[ConstraintSystem] Fix spacing issues with printing attributes.

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1686,7 +1686,12 @@ void BindingSet::dump(llvm::raw_ostream &out, unsigned indent) const {
   
   auto literalKind = getLiteralForScore();
   if (literalKind != LiteralBindingKind::None) {
-    out << ", [literal: ";
+    if (!attributes.empty()) {
+      out << ", ";
+    } else {
+      out << "[attributes: ";
+    }
+    out << "[literal: ";
     switch (literalKind) {
     case LiteralBindingKind::Atom: {
       if (auto atomKind = TypeVar->getImpl().getAtomicLiteralKind()) {
@@ -1708,9 +1713,14 @@ void BindingSet::dump(llvm::raw_ostream &out, unsigned indent) const {
         out << getLiteralBindingKind(literalKind).str();
       break;
     }
-    out << "]";
+    if (attributes.empty()) {
+      out << "]] ";
+    } else {
+      out << "]";
+    }
   }
-  out << "] ";
+  if (!attributes.empty())
+    out << "] ";
 
   if (involvesTypeVariables()) {
     out << "[involves_type_vars: ";


### PR DESCRIPTION
Type variables with only a literal kind attribute and no other attributes may print with incorrect spacing and `[]` styling, like so: 

```
$T2 [allows bindings to: noescape] ] [with possible bindings: (subtypes of) String]
$T7 [allows bindings to: noescape] , [literal: interpolated string]] [with possible bindings: (subtypes of) Any]
```

Corrected, the attributes will print:

```
$T2 [allows bindings to: noescape] [with possible bindings: (subtypes of) String]
$T7 [allows bindings to: noescape] [attributes: [literal: interpolated string]] [with possible bindings: (subtypes of) Any]
```

This is an edit to apple/swift#60205