### PR TITLE
Build indexstore-db and sourcekit-lsp in a unified SwiftPM build

### DIFF
--- a/utils/build_swift/resources/SwiftPM-Unified-Build.xcworkspace/contents.xcworkspacedata
+++ b/utils/build_swift/resources/SwiftPM-Unified-Build.xcworkspace/contents.xcworkspacedata
@@ -1,19 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Workspace
    version = "1.0">
-   <FileRef
-      location = "group:../../../../swift-syntax">
-   </FileRef>
-   <FileRef
-      location = "group:../../../../swift-stress-tester/SourceKitStressTester">
-   </FileRef>
-   <FileRef
-      location = "group:../../../../swift-format">
-   </FileRef>
-   <FileRef
-      location = "group:../../../../swift-stress-tester/SwiftEvolve">
-   </FileRef>
-   <FileRef
-      location = "group:../../../../swift-docc">
-   </FileRef>
+   <FileRef location = "group:../../../../indexstore-db"></FileRef>
+   <FileRef location = "group:../../../../llbuild"></FileRef>
+   <FileRef location = "group:../../../../sourcekit-lsp"></FileRef>
+   <FileRef location = "group:../../../../swift-argument-parser"></FileRef>
+   <FileRef location = "group:../../../../swift-collections"></FileRef>
+   <FileRef location = "group:../../../../swift-crypto"></FileRef>
+   <FileRef location = "group:../../../../swift-docc"></FileRef>
+   <FileRef location = "group:../../../../swift-driver"></FileRef>
+   <FileRef location = "group:../../../../swift-format"></FileRef>
+   <FileRef location = "group:../../../../swift-stress-tester/SourceKitStressTester"></FileRef>
+   <FileRef location = "group:../../../../swift-stress-tester/SwiftEvolve"></FileRef>
+   <FileRef location = "group:../../../../swift-syntax"></FileRef>
+   <FileRef location = "group:../../../../swift-system"></FileRef>
+   <FileRef location = "group:../../../../swift-tools-support-core"></FileRef>
+   <FileRef location = "group:../../../../swiftpm"></FileRef>
+   <FileRef location = "group:../../../../yams"></FileRef>
 </Workspace>

--- a/utils/swift_build_support/swift_build_support/products/indexstoredb.py
+++ b/utils/swift_build_support/swift_build_support/products/indexstoredb.py
@@ -12,6 +12,8 @@
 
 import os
 
+from build_swift.build_swift.constants import MULTIROOT_DATA_FILE_PATH
+
 from . import cmark
 from . import foundation
 from . import libcxx
@@ -40,6 +42,10 @@ class IndexStoreDB(product.Product):
     @classmethod
     def is_before_build_script_impl_product(cls):
         return False
+
+    @classmethod
+    def is_swiftpm_unified_build_product(cls):
+        return True
 
     def should_build(self, host_target):
         return True
@@ -95,6 +101,7 @@ def run_build_script_helper(action, host_target, product, args,
         '--configuration', configuration,
         '--toolchain', toolchain_path,
         '--ninja-bin', product.toolchain.ninja,
+        '--multiroot-data-file', MULTIROOT_DATA_FILE_PATH,
     ]
     if args.verbose_build:
         helper_cmd.append('--verbose')

--- a/utils/swift_build_support/swift_build_support/products/sourcekitlsp.py
+++ b/utils/swift_build_support/swift_build_support/products/sourcekitlsp.py
@@ -37,6 +37,10 @@ class SourceKitLSP(product.Product):
     def is_before_build_script_impl_product(cls):
         return False
 
+    @classmethod
+    def is_swiftpm_unified_build_product(cls):
+        return True
+
     def should_build(self, host_target):
         return True
 


### PR DESCRIPTION
This way we don’t need to build indexstore-db twice (once when building indexstore-db itself and once when building sourcekit-lsp). This reduced the smoke testing time by ~5 minutes.