### PR TITLE
Clean up calculation of override substitutions

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -1344,6 +1344,12 @@ public:
   GenericSignature getOverrideGenericSignature(const ValueDecl *base,
                                                const ValueDecl *derived);
 
+  GenericSignature
+  getOverrideGenericSignature(const NominalTypeDecl *baseNominal,
+                              const NominalTypeDecl *derivedNominal,
+                              GenericSignature baseGenericSig,
+                              const GenericParamList *derivedParams);
+
   enum class OverrideGenericSignatureReqCheck {
     /// Base method's generic requirements are satisfied by derived method
     BaseReqSatisfiedByDerived,

--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -205,10 +205,10 @@ public:
   /// Variant of the above for when we have the generic signatures but not
   /// the decls for 'derived' and 'base'.
   static SubstitutionMap
-  getOverrideSubstitutions(const ClassDecl *baseClass,
-                           const ClassDecl *derivedClass,
+  getOverrideSubstitutions(const NominalTypeDecl *baseNominal,
+                           const NominalTypeDecl *derivedNominal,
                            GenericSignature baseSig,
-                           GenericParamList *derivedParams);
+                           const GenericParamList *derivedParams);
 
   /// Combine two substitution maps as follows.
   ///
@@ -310,6 +310,39 @@ public:
   ProtocolConformanceRef operator()(CanType dependentType,
                                     Type conformingReplacementType,
                                     ProtocolDecl *conformedProtocol) const;
+};
+
+struct OverrideSubsInfo {
+  ASTContext &Ctx;
+  unsigned BaseDepth;
+  unsigned OrigDepth;
+  SubstitutionMap BaseSubMap;
+  const GenericParamList *DerivedParams;
+
+  OverrideSubsInfo(const NominalTypeDecl *baseNominal,
+                   const NominalTypeDecl *derivedNominal,
+                   GenericSignature baseSig,
+                   const GenericParamList *derivedParams);
+};
+
+struct QueryOverrideSubs {
+  OverrideSubsInfo info;
+
+  explicit QueryOverrideSubs(const OverrideSubsInfo &info)
+    : info(info) {}
+
+  Type operator()(SubstitutableType *type) const;
+};
+
+struct LookUpConformanceInOverrideSubs {
+  OverrideSubsInfo info;
+
+  explicit LookUpConformanceInOverrideSubs(const OverrideSubsInfo &info)
+    : info(info) {}
+
+  ProtocolConformanceRef operator()(CanType type,
+                                    Type substType,
+                                    ProtocolDecl *proto) const;
 };
 
 } // end namespace swift

--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -33,6 +33,7 @@ namespace llvm {
 namespace swift {
 
 class GenericEnvironment;
+class GenericParamList;
 class SubstitutableType;
 typedef CanTypeWrapper<GenericTypeParamType> CanGenericTypeParamType;
 
@@ -207,7 +208,7 @@ public:
   getOverrideSubstitutions(const ClassDecl *baseClass,
                            const ClassDecl *derivedClass,
                            GenericSignature baseSig,
-                           GenericSignature derivedSig);
+                           GenericParamList *derivedParams);
 
   /// Combine two substitution maps as follows.
   ///

--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -199,8 +199,7 @@ public:
   /// written in terms of the generic signature of 'baseDecl'.
   static SubstitutionMap
   getOverrideSubstitutions(const ValueDecl *baseDecl,
-                           const ValueDecl *derivedDecl,
-                           Optional<SubstitutionMap> derivedSubs);
+                           const ValueDecl *derivedDecl);
 
   /// Variant of the above for when we have the generic signatures but not
   /// the decls for 'derived' and 'base'.
@@ -208,8 +207,7 @@ public:
   getOverrideSubstitutions(const ClassDecl *baseClass,
                            const ClassDecl *derivedClass,
                            GenericSignature baseSig,
-                           GenericSignature derivedSig,
-                           Optional<SubstitutionMap> derivedSubs);
+                           GenericSignature derivedSig);
 
   /// Combine two substitution maps as follows.
   ///

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -5328,11 +5328,6 @@ ASTContext::getOverrideGenericSignature(const NominalTypeDecl *baseNominal,
       addedRequirements.push_back(reqt);
     }
   } else {
-    const auto derivedSuperclass = cast<ClassDecl>(derivedNominal)
-        ->getSuperclass();
-    if (derivedSuperclass.isNull())
-      return nullptr;
-
     unsigned derivedDepth = 0;
     unsigned baseDepth = 0;
     if (derivedNominalSig)
@@ -5340,8 +5335,9 @@ ASTContext::getOverrideGenericSignature(const NominalTypeDecl *baseNominal,
     if (const auto baseNominalSig = baseNominal->getGenericSignature())
       baseDepth = baseNominalSig.getGenericParams().back()->getDepth() + 1;
 
-    const auto subMap = derivedSuperclass->getContextSubstitutionMap(
-        derivedNominal->getModuleContext(), baseNominal);
+    const auto subMap = derivedNominal->getDeclaredInterfaceType()
+        ->getContextSubstitutionMap(derivedNominal->getModuleContext(),
+                                    baseNominal);
 
     auto substFn = [&](SubstitutableType *type) -> Type {
       auto *gp = cast<GenericTypeParamType>(type);

--- a/lib/AST/ConcreteDeclRef.cpp
+++ b/lib/AST/ConcreteDeclRef.cpp
@@ -36,11 +36,9 @@ ConcreteDeclRef ConcreteDeclRef::getOverriddenDecl() const {
 
   SubstitutionMap subs;
   if (baseSig) {
-    Optional<SubstitutionMap> derivedSubMap;
+    subs = SubstitutionMap::getOverrideSubstitutions(baseDecl, derivedDecl);
     if (derivedSig)
-      derivedSubMap = getSubstitutions();
-    subs = SubstitutionMap::getOverrideSubstitutions(baseDecl, derivedDecl,
-                                                     derivedSubMap);
+      subs = subs.subst(getSubstitutions());
   }
   return ConcreteDeclRef(baseDecl, subs);
 }

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -638,6 +638,9 @@ SubstitutionMap::combineSubstitutionMaps(SubstitutionMap firstSubMap,
       // Some combination of storing substitution maps in BoundGenericTypes
       // as well as for method overrides would solve this, but for now, just
       // punt to module lookup.
+      if (substType->isTypeParameter())
+        return ProtocolConformanceRef(proto);
+
       return proto->getParentModule()->lookupConformance(substType, proto);
     });
 }

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -539,6 +539,7 @@ SubstitutionMap::getOverrideSubstitutions(const ClassDecl *baseClass,
     auto derivedClassTy = derivedClass->getDeclaredInterfaceType();
     baseSubMap = derivedClassTy->getContextSubstitutionMap(
         baseClass->getParentModule(), baseClass);
+    assert(!baseSubMap.hasArchetypes());
   }
 
   unsigned origDepth = 0;

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4835,8 +4835,10 @@ TypeBase::getContextSubstitutions(const DeclContext *dc,
 
   // Find the superclass type with the context matching that of the member.
   auto *ownerNominal = dc->getSelfNominalTypeDecl();
-  if (auto *ownerClass = dyn_cast<ClassDecl>(ownerNominal))
-    baseTy = baseTy->getSuperclassForDecl(ownerClass);
+  if (auto *ownerClass = dyn_cast<ClassDecl>(ownerNominal)) {
+    baseTy = baseTy->getSuperclassForDecl(ownerClass,
+                                      /*usesArchetypes=*/genericEnv != nullptr);
+  }
 
   // Gather all of the substitutions for all levels of generic arguments.
   auto params = genericSig.getGenericParams();

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4428,10 +4428,12 @@ operator()(CanType dependentType, Type conformingReplacementType,
 ProtocolConformanceRef LookUpConformanceInSubstitutionMap::
 operator()(CanType dependentType, Type conformingReplacementType,
            ProtocolDecl *conformedProtocol) const {
-  // Lookup conformances for opened existential.
-  if (conformingReplacementType->isOpenedExistential()) {
+  // Lookup conformances for archetypes that conform concretely
+  // via a superclass.
+  if (auto archetypeType = conformingReplacementType->getAs<ArchetypeType>()) {
     return conformedProtocol->getModuleContext()->lookupConformance(
-        conformingReplacementType, conformedProtocol);
+        conformingReplacementType, conformedProtocol,
+        /*allowMissing=*/true);
   }
   return Subs.lookupConformance(dependentType, conformedProtocol);
 }

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4989,7 +4989,7 @@ Type TypeBase::adjustSuperclassMemberDeclType(const ValueDecl *baseDecl,
                                               const ValueDecl *derivedDecl,
                                               Type memberType) {
   auto subs = SubstitutionMap::getOverrideSubstitutions(
-      baseDecl, derivedDecl, /*derivedSubs=*/None);
+      baseDecl, derivedDecl);
 
   if (auto *genericMemberType = memberType->getAs<GenericFunctionType>()) {
     memberType = FunctionType::get(genericMemberType->getParams(),

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3665,8 +3665,8 @@ SILGenModule::emitKeyPathComponentForDecl(SILLocation loc,
     // to reference the overridden declaration instead.
     if (baseDecl != externalDecl) {
       externalSubs = SubstitutionMap::getOverrideSubstitutions(baseDecl,
-                                                               externalDecl,
-                                                               externalSubs);
+                                                               externalDecl)
+          .subst(externalSubs);
       externalDecl = baseDecl;
     }
   }

--- a/lib/SILGen/SILGenLazyConformance.cpp
+++ b/lib/SILGen/SILGenLazyConformance.cpp
@@ -21,6 +21,12 @@ using namespace swift;
 using namespace swift::Lowering;
 
 void SILGenModule::useConformance(ProtocolConformanceRef conformanceRef) {
+  // If the conformance is invalid, crash deterministically even in noassert
+  // builds.
+  if (conformanceRef.isInvalid()) {
+    llvm::report_fatal_error("Invalid conformance in type-checked AST");
+  }
+
   // We don't need to emit dependent conformances.
   if (conformanceRef.isAbstract())
     return;

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -4224,7 +4224,7 @@ SILGenFunction::emitVTableThunk(SILDeclRef base,
                                   SILType::getPrimitiveObjectType(derivedFTy),
                                   subs, args, derivedYields);
     auto overrideSubs = SubstitutionMap::getOverrideSubstitutions(
-        base.getDecl(), derived.getDecl(), /*derivedSubs=*/subs);
+        base.getDecl(), derived.getDecl()).subst(subs);
 
     YieldInfo derivedYieldInfo(SGM, derived, derivedFTy, subs);
     YieldInfo baseYieldInfo(SGM, base, thunkTy, overrideSubs);

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -645,6 +645,8 @@ createDesignatedInitOverride(ClassDecl *classDecl,
   auto genericSig = ctx.getOverrideGenericSignature(
       superclassDecl, classDecl, superclassCtorSig, genericParams);
 
+  assert(!subMap.hasArchetypes());
+
   if (superclassCtorSig) {
     auto *genericEnv = genericSig.getGenericEnvironment();
 

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -434,7 +434,7 @@ computeDesignatedInitOverrideSignature(ASTContext &ctx,
                                        ClassDecl *classDecl,
                                        Type superclassTy,
                                        ConstructorDecl *superclassCtor) {
-  auto *superclassDecl = superclassTy->getAnyNominal();
+  auto *superclassDecl = superclassTy->getClassOrBoundGenericClass();
 
   auto classSig = classDecl->getGenericSignature();
   auto superclassCtorSig = superclassCtor->getGenericSignature();
@@ -515,11 +515,6 @@ computeDesignatedInitOverrideSignature(ASTContext &ctx,
     return ProtocolConformanceRef(proto);
   };
 
-  // Now form the substitution map that will be used to remap parameter
-  // types.
-  auto subMap = SubstitutionMap::get(superclassCtorSig,
-                                     substFn, lookupConformanceFn);
-
   SmallVector<Requirement, 2> requirements;
 
   // If the base initializer's generic signature is different
@@ -539,6 +534,11 @@ computeDesignatedInitOverrideSignature(ASTContext &ctx,
                                        std::move(newParamTypes),
                                        std::move(requirements));
   }
+
+  // Now form the substitution map that will be used to remap parameter
+  // types.
+  auto subMap = SubstitutionMap::getOverrideSubstitutions(
+      superclassDecl, classDecl, superclassCtorSig, genericParams);
 
   return DesignatedInitOverrideInfo{genericSig, genericParams, subMap};
 }

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -639,7 +639,8 @@ synthesizeDesignatedInitOverride(AbstractFunctionDecl *fn, void *context) {
   SubstitutionMap subs;
   if (auto *genericEnv = fn->getGenericEnvironment())
     subs = genericEnv->getForwardingSubstitutionMap();
-  subs = SubstitutionMap::getOverrideSubstitutions(superclassCtor, fn, subs);
+  subs = SubstitutionMap::getOverrideSubstitutions(superclassCtor, fn)
+      .subst(subs);
   ConcreteDeclRef ctorRef(superclassCtor, subs);
 
   auto type = superclassCtor->getInitializerInterfaceType().subst(subs);

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1510,24 +1510,6 @@ bool swift::hasLetStoredPropertyWithInitialValue(NominalTypeDecl *nominal) {
   });
 }
 
-void swift::addFixedLayoutAttr(NominalTypeDecl *nominal) {
-  auto &C = nominal->getASTContext();
-  // If nominal already has `@_fixed_layout`, return.
-  if (nominal->getAttrs().hasAttribute<FixedLayoutAttr>())
-    return;
-  auto access = nominal->getEffectiveAccess();
-  // If nominal does not have at least internal access, return.
-  if (access < AccessLevel::Internal)
-    return;
-  // If nominal is internal, it should have the `@usableFromInline` attribute.
-  if (access == AccessLevel::Internal &&
-      !nominal->getAttrs().hasAttribute<UsableFromInlineAttr>()) {
-    nominal->getAttrs().add(new (C) UsableFromInlineAttr(/*Implicit*/ true));
-  }
-  // Add `@_fixed_layout` to the nominal.
-  nominal->getAttrs().add(new (C) FixedLayoutAttr(/*Implicit*/ true));
-}
-
 void swift::addNonIsolatedToSynthesized(
     NominalTypeDecl *nominal, ValueDecl *value) {
   if (!getActorIsolation(nominal).isActorIsolated())

--- a/lib/Sema/CodeSynthesis.h
+++ b/lib/Sema/CodeSynthesis.h
@@ -74,9 +74,6 @@ ValueDecl *getProtocolRequirement(ProtocolDecl *protocol, Identifier name);
 // with an initial value.
 bool hasLetStoredPropertyWithInitialValue(NominalTypeDecl *nominal);
 
-/// Add `@_fixed_layout` attribute to the nominal type, if possible.
-void addFixedLayoutAttr(NominalTypeDecl *nominal);
-
 /// Add 'nonisolated' to the synthesized declaration when needed.
 void addNonIsolatedToSynthesized(NominalTypeDecl *nominal, ValueDecl *value);
 

--- a/lib/Sema/DerivedConformanceDistributedActor.cpp
+++ b/lib/Sema/DerivedConformanceDistributedActor.cpp
@@ -236,7 +236,7 @@ static FuncDecl* createLocalFunc_doInvokeOnReturn(
     auto requirement =
         Requirement(RequirementKind::Conformance,
                     resultGenericParamDecl->getDeclaredInterfaceType(),
-                    p->getInterfaceType()->getMetatypeInstanceType());
+                    p->getDeclaredInterfaceType());
     requirements.push_back(requirement);
   }
   GenericSignature doInvokeGenSig =

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -620,8 +620,7 @@ static bool parameterTypesMatch(const ValueDecl *derivedDecl,
   if (baseParams->size() != derivedParams->size())
     return false;
 
-  auto subs = SubstitutionMap::getOverrideSubstitutions(baseDecl, derivedDecl,
-                                                        /*derivedSubs=*/None);
+  auto subs = SubstitutionMap::getOverrideSubstitutions(baseDecl, derivedDecl);
 
   for (auto i : indices(baseParams->getArray())) {
     auto *baseParam = baseParams->get(i);

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -843,7 +843,7 @@ GetDistributedActorArgumentDecodingMethodRequest::evaluate(Evaluator &evaluator,
   auto *decoder = ctx.getDistributedActorInvocationDecoder(actor);
   assert(decoder);
 
-  auto decoderTy = decoder->getInterfaceType()->getMetatypeInstanceType();
+  auto decoderTy = decoder->getDeclaredInterfaceType();
 
   auto members = TypeChecker::lookupMember(actor->getDeclContext(), decoderTy,
                                            DeclNameRef(ctx.Id_decodeNextArgument));

--- a/test/SILGen/vtable_generic_signature.swift
+++ b/test/SILGen/vtable_generic_signature.swift
@@ -3,9 +3,11 @@
 
 protocol P {}
 protocol Q : P {}
+class C : P {}
 
 class ConcreteBase {
   func f<U : Q>(_: U) {}
+  func g<U : C>(_: U) {}
 }
 
 class ConcreteDerivedFromConcreteBase : ConcreteBase {
@@ -37,6 +39,10 @@ func call<T, U : P>(_ t: T, _ u: U) {
   GenericDerivedFromGenericBase<T>().f(u)
 }
 
+class ConcreteDerived: ConcreteBase {
+  override func g<U : P>(_: U) {}
+}
+
 // All the vtable thunks should traffic in <U where U : Q>, because that's
 // what the base method declares.
 
@@ -47,12 +53,14 @@ func call<T, U : P>(_ t: T, _ u: U) {
 
 // CHECK-LABEL: sil_vtable ConcreteBase {
 // CHECK-NEXT:   #ConcreteBase.f: <U where U : Q> (ConcreteBase) -> (U) -> () : @$s24vtable_generic_signature12ConcreteBaseC1fyyxAA1QRzlF
+// CHECK-NEXT:   #ConcreteBase.g: <U where U : C> (ConcreteBase) -> (U) -> () : @$s24vtable_generic_signature12ConcreteBaseC1gyyxAA1CCRbzlF
 // CHECK-NEXT:   #ConcreteBase.init!allocator: (ConcreteBase.Type) -> () -> ConcreteBase : @$s24vtable_generic_signature12ConcreteBaseCACycfC
 // CHECK-NEXT:   #ConcreteBase.deinit!deallocator: @$s24vtable_generic_signature12ConcreteBaseCfD
 // CHECK-NEXT: }
 
 // CHECK-LABEL: sil_vtable ConcreteDerivedFromConcreteBase {
 // CHECK-NEXT:   #ConcreteBase.f: <U where U : Q> (ConcreteBase) -> (U) -> () : @$s24vtable_generic_signature019ConcreteDerivedFromD4BaseC1fyyxAA1PRzlFAA0dG0CADyyxAA1QRzlFTV [override]
+// CHECK-NEXT:   #ConcreteBase.g: <U where U : C> (ConcreteBase) -> (U) -> () : @$s24vtable_generic_signature12ConcreteBaseC1gyyxAA1CCRbzlF
 // CHECK-NEXT:   #ConcreteBase.init!allocator: (ConcreteBase.Type) -> () -> ConcreteBase : @$s24vtable_generic_signature019ConcreteDerivedFromD4BaseCACycfC [override]
 // CHECK-NEXT:   #ConcreteDerivedFromConcreteBase.f: <U where U : P> (ConcreteDerivedFromConcreteBase) -> (U) -> () : @$s24vtable_generic_signature019ConcreteDerivedFromD4BaseC1fyyxAA1PRzlF
 // CHECK-NEXT:   #ConcreteDerivedFromConcreteBase.deinit!deallocator: @$s24vtable_generic_signature019ConcreteDerivedFromD4BaseCfD
@@ -60,6 +68,7 @@ func call<T, U : P>(_ t: T, _ u: U) {
 
 // CHECK-LABEL: sil_vtable GenericDerivedFromConcreteBase {
 // CHECK-NEXT:   #ConcreteBase.f: <U where U : Q> (ConcreteBase) -> (U) -> () : @$s24vtable_generic_signature30GenericDerivedFromConcreteBaseC1fyyqd__AA1PRd__lFAA0gH0CADyyxAA1QRzlFTV [override]
+// CHECK-NEXT:   #ConcreteBase.g: <U where U : C> (ConcreteBase) -> (U) -> () : @$s24vtable_generic_signature12ConcreteBaseC1gyyxAA1CCRbzlF
 // CHECK-NEXT:   #ConcreteBase.init!allocator: (ConcreteBase.Type) -> () -> ConcreteBase : @$s24vtable_generic_signature30GenericDerivedFromConcreteBaseCACyxGycfC [override]
 // CHECK-NEXT:   #GenericDerivedFromConcreteBase.f: <T><U where U : P> (GenericDerivedFromConcreteBase<T>) -> (U) -> () : @$s24vtable_generic_signature30GenericDerivedFromConcreteBaseC1fyyqd__AA1PRd__lF
 // CHECK-NEXT:   #GenericDerivedFromConcreteBase.deinit!deallocator: @$s24vtable_generic_signature30GenericDerivedFromConcreteBaseCfD
@@ -83,4 +92,12 @@ func call<T, U : P>(_ t: T, _ u: U) {
 // CHECK-NEXT:   #GenericBase.init!allocator: <T> (GenericBase<T>.Type) -> () -> GenericBase<T> : @$s24vtable_generic_signature018GenericDerivedFromD4BaseCACyxGycfC [override]
 // CHECK-NEXT:   #GenericDerivedFromGenericBase.f: <T><U where U : P> (GenericDerivedFromGenericBase<T>) -> (U) -> () : @$s24vtable_generic_signature018GenericDerivedFromD4BaseC1fyyqd__AA1PRd__lF
 // CHECK-NEXT:   #GenericDerivedFromGenericBase.deinit!deallocator: @$s24vtable_generic_signature018GenericDerivedFromD4BaseCfD
+// CHECK-NEXT: }
+
+// CHECK-LABEL: sil_vtable ConcreteDerived {
+// CHECK-NEXT:   #ConcreteBase.f: <U where U : Q> (ConcreteBase) -> (U) -> () : @$s24vtable_generic_signature12ConcreteBaseC1fyyxAA1QRzlF [inherited]
+// CHECK-NEXT:   #ConcreteBase.g: <U where U : C> (ConcreteBase) -> (U) -> () : @$s24vtable_generic_signature15ConcreteDerivedC1gyyxAA1PRzlFAA0D4BaseCADyyxAA1CCRbzlFTV [override]
+// CHECK-NEXT:   #ConcreteBase.init!allocator: (ConcreteBase.Type) -> () -> ConcreteBase : @$s24vtable_generic_signature15ConcreteDerivedCACycfC [override]
+// CHECK-NEXT:   #ConcreteDerived.g: <U where U : P> (ConcreteDerived) -> (U) -> () : @$s24vtable_generic_signature15ConcreteDerivedC1gyyxAA1PRzlF
+// CHECK-NEXT:   #ConcreteDerived.deinit!deallocator: @$s24vtable_generic_signature15ConcreteDerivedCfD  // ConcreteDerived.__deallocating_deinit
 // CHECK-NEXT: }


### PR DESCRIPTION
- getOverrideGenericSignature() duplicated logic from getOverrideSubstitutions().
- configureDesignatedInitOverrideSignature() duplicated logic from both getOverrideGenericSignature() and getOverrideSubstitutions().