### PR TITLE
[Test] Reenable "failed to demangle" portion of associated_type_demangle_private.swift.

### DIFF
--- a/test/Runtime/associated_type_demangle_private.swift
+++ b/test/Runtime/associated_type_demangle_private.swift
@@ -104,8 +104,7 @@ AssociatedTypeDemangleTests.test("nested private generic types in associated typ
   if #available(SwiftStdlib 5.1, *) {}
   // Bug is still present in Swift 5.0 runtime.
   else {
-    // FIXME: rdar://problem/51959305
-    // expectCrashLater(withMessage: "failed to demangle witness for associated type 'Second' in conformance")
+    expectCrashLater(withMessage: "failed to demangle witness for associated type 'Second' in conformance")
     return
   }
 


### PR DESCRIPTION
This test was disabled a while ago but the problem seems to have been fixed sometime since then.

rdar://51959305