### PR TITLE
Issue #59903 - Removing _decodeScalar function that isn't being used

### DIFF
--- a/stdlib/public/core/UnicodeHelpers.swift
+++ b/stdlib/public/core/UnicodeHelpers.swift
@@ -61,27 +61,6 @@ internal func _decodeUTF8(
   return Unicode.Scalar(_unchecked: value)
 }
 
-internal func _decodeScalar(
-  _ utf16: UnsafeBufferPointer<UInt16>, startingAt i: Int
-) -> (Unicode.Scalar, scalarLength: Int) {
-  let high = utf16[_unchecked: i]
-  if i + 1 >= utf16.count {
-    _internalInvariant(!UTF16.isLeadSurrogate(high))
-    _internalInvariant(!UTF16.isTrailSurrogate(high))
-    return (Unicode.Scalar(_unchecked: UInt32(high)), 1)
-  }
-
-  if !UTF16.isLeadSurrogate(high) {
-    _internalInvariant(!UTF16.isTrailSurrogate(high))
-    return (Unicode.Scalar(_unchecked: UInt32(high)), 1)
-  }
-
-  let low = utf16[_unchecked: i+1]
-  _internalInvariant(UTF16.isLeadSurrogate(high))
-  _internalInvariant(UTF16.isTrailSurrogate(low))
-  return (UTF16._decodeSurrogates(high, low), 2)
-}
-
 @inlinable
 internal func _decodeScalar(
   _ utf8: UnsafeBufferPointer<UInt8>, startingAt i: Int


### PR DESCRIPTION
<!-- What's in this pull request? -->
Addressing Issue #59903  - removing what I think is dead code in the _decodeScalar function.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves https://github.com/apple/swift/issues/59903

@hborla and @karwa  - please review! :) 

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
