### PR TITLE
Revert protocol selector conflict changes for 5.7 and add a workaround

### DIFF
--- a/include/swift/AST/ModuleLoader.h
+++ b/include/swift/AST/ModuleLoader.h
@@ -226,11 +226,11 @@ public:
   virtual void loadExtensions(NominalTypeDecl *nominal,
                               unsigned previousGeneration) { }
 
-  /// Load the methods within the given type that produce
+  /// Load the methods within the given class that produce
   /// Objective-C class or instance methods with the given selector.
   ///
-  /// \param typeDecl The type in which we are searching for @objc methods.
-  /// The search only considers this type and its extensions; not any
+  /// \param classDecl The class in which we are searching for @objc methods.
+  /// The search only considers this class and its extensions; not any
   /// superclasses.
   ///
   /// \param selector The selector to search for.
@@ -246,7 +246,7 @@ public:
   /// selector and are instance/class methods as requested. This list will be
   /// extended with any methods found in subsequent generations.
   virtual void loadObjCMethods(
-                 NominalTypeDecl *typeDecl,
+                 ClassDecl *classDecl,
                  ObjCSelector selector,
                  bool isInstanceMethod,
                  unsigned previousGeneration,

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -309,7 +309,7 @@ public:
                               unsigned previousGeneration) override;
 
   virtual void loadObjCMethods(
-                 NominalTypeDecl *typeDecl,
+                 ClassDecl *classDecl,
                  ObjCSelector selector,
                  bool isInstanceMethod,
                  unsigned previousGeneration,

--- a/include/swift/Sema/SourceLoader.h
+++ b/include/swift/Sema/SourceLoader.h
@@ -85,7 +85,7 @@ public:
                               unsigned previousGeneration) override;
 
   virtual void loadObjCMethods(
-                 NominalTypeDecl *typeDecl,
+                 ClassDecl *classDecl,
                  ObjCSelector selector,
                  bool isInstanceMethod,
                  unsigned previousGeneration,

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -190,7 +190,7 @@ public:
                               unsigned previousGeneration) override;
 
   virtual void loadObjCMethods(
-                 NominalTypeDecl *typeDecl,
+                 ClassDecl *classDecl,
                  ObjCSelector selector,
                  bool isInstanceMethod,
                  unsigned previousGeneration,

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1699,16 +1699,6 @@ NominalTypeDecl::lookupDirect(ObjCSelector selector, bool isInstance) {
   return stored.Methods;
 }
 
-/// Is the new method an async alternative of any existing method, or vice
-/// versa?
-static bool isAnAsyncAlternative(AbstractFunctionDecl *newDecl,
-                                 llvm::TinyPtrVector<AbstractFunctionDecl *> &vec) {
-  return llvm::any_of(vec, [&](AbstractFunctionDecl *oldDecl) {
-    return newDecl->getAsyncAlternative(/*isKnownObjC=*/true) == oldDecl
-              || oldDecl->getAsyncAlternative(/*isKnownObjC=*/true) == newDecl;
-  });
-}
-
 void NominalTypeDecl::recordObjCMethod(AbstractFunctionDecl *method,
                                        ObjCSelector selector) {
   if (!ObjCMethodLookup && !createObjCMethodLookup())
@@ -1726,7 +1716,7 @@ void NominalTypeDecl::recordObjCMethod(AbstractFunctionDecl *method,
   if (auto *sf = method->getParentSourceFile()) {
     if (vec.empty()) {
       sf->ObjCMethodList.push_back(method);
-    } else if (!isa<ProtocolDecl>(this) || !isAnAsyncAlternative(method, vec)) {
+    } else {
       // We have a conflict.
       sf->ObjCMethodConflicts.insert({ this, selector, isInstanceMethod });
     }

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1668,7 +1668,7 @@ bool NominalTypeDecl::createObjCMethodLookup() {
   assert(!ObjCMethodLookup && "Already have an Objective-C member table");
 
   // Most types cannot have ObjC methods.
-  if (!(isa<ClassDecl>(this) || isa<ProtocolDecl>(this)))
+  if (!(isa<ClassDecl>(this)))
     return false;
 
   auto &ctx = getASTContext();

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1714,11 +1714,12 @@ void NominalTypeDecl::recordObjCMethod(AbstractFunctionDecl *method,
     return;
 
   if (auto *sf = method->getParentSourceFile()) {
-    if (vec.empty()) {
-      sf->ObjCMethodList.push_back(method);
-    } else {
+    if (vec.size() == 1) {
       // We have a conflict.
-      sf->ObjCMethodConflicts.insert({ this, selector, isInstanceMethod });
+      sf->ObjCMethodConflicts.push_back(std::make_tuple(this, selector,
+                                                        isInstanceMethod));
+    } if (vec.empty()) {
+      sf->ObjCMethodList.push_back(method);
     }
   }
 

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1310,24 +1310,7 @@ class swift::ObjCMethodLookupTable
         : public llvm::DenseMap<std::pair<ObjCSelector, char>,
                                 StoredObjCMethods>,
           public ASTAllocated<ObjCMethodLookupTable>
-{
-  SWIFT_DEBUG_DUMP {
-    llvm::errs() << "ObjCMethodLookupTable:\n";
-    for (auto pair : *this) {
-      auto selector = pair.getFirst().first;
-      auto isInstanceMethod = pair.getFirst().second;
-      auto &methods = pair.getSecond();
-
-      llvm::errs() << "  \"" << (isInstanceMethod ? "-" : "+") << selector
-                   << "\":\n";
-      for (auto method : methods.Methods) {
-        llvm::errs() << "  - \"";
-        method->dumpRef(llvm::errs());
-        llvm::errs() << "\"\n";
-      }
-    }
-  }
-};
+{};
 
 MemberLookupTable::MemberLookupTable(ASTContext &ctx) {
   // Register a cleanup with the ASTContext to call the lookup table

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3435,16 +3435,11 @@ void ClangImporter::loadExtensions(NominalTypeDecl *nominal,
 }
 
 void ClangImporter::loadObjCMethods(
-       NominalTypeDecl *typeDecl,
+       ClassDecl *classDecl,
        ObjCSelector selector,
        bool isInstanceMethod,
        unsigned previousGeneration,
        llvm::TinyPtrVector<AbstractFunctionDecl *> &methods) {
-  // TODO: We don't currently need to load methods from imported ObjC protocols.
-  auto classDecl = dyn_cast<ClassDecl>(typeDecl);
-  if (!classDecl)
-    return;
-
   const auto *objcClass =
       dyn_cast_or_null<clang::ObjCInterfaceDecl>(classDecl->getClangDecl());
   if (!objcClass)

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -2019,31 +2019,12 @@ auto DeclAndTypePrinter::getImpl() -> Implementation {
   return Implementation(os, *this, outputLang);
 }
 
-static bool isAsyncAlternativeOfOtherDecl(const ValueDecl *VD) {
-  auto AFD = dyn_cast<AbstractFunctionDecl>(VD);
-  if (!AFD || !AFD->isAsyncContext() || !AFD->getObjCSelector())
-    return false;
-
-  auto type = AFD->getDeclContext()->getSelfNominalTypeDecl();
-  if (!type)
-    return false;
-  auto others = type->lookupDirect(AFD->getObjCSelector(),
-                                   AFD->isInstanceMember());
-
-  for (auto other : others)
-    if (other->getAsyncAlternative() == AFD)
-      return true;
-
-  return false;
-}
-
 bool DeclAndTypePrinter::shouldInclude(const ValueDecl *VD) {
   return !VD->isInvalid() &&
          (outputLang == OutputLanguageMode::Cxx
               ? cxx_translation::isVisibleToCxx(VD, minRequiredAccess)
               : isVisibleToObjC(VD, minRequiredAccess)) &&
-         !VD->getAttrs().hasAttribute<ImplementationOnlyAttr>() &&
-         !isAsyncAlternativeOfOtherDecl(VD);
+         !VD->getAttrs().hasAttribute<ImplementationOnlyAttr>();
 }
 
 void DeclAndTypePrinter::print(const Decl *D) {

--- a/lib/PrintAsClang/PrintAsClang.cpp
+++ b/lib/PrintAsClang/PrintAsClang.cpp
@@ -80,6 +80,7 @@ static void writePrologue(raw_ostream &out, ASTContext &ctx,
          "# include <swift/objc-prologue.h>\n"
          "#endif\n"
          "\n"
+         "#pragma clang diagnostic ignored \"-Wduplicate-method-match\"\n"
          "#pragma clang diagnostic ignored \"-Wauto-import\"\n";
   emitObjCConditional(out,
                       [&] { out << "#include <Foundation/Foundation.h>\n"; });

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -2269,7 +2269,7 @@ namespace {
       // location within that source file.
       SourceFile *lhsSF = lhs->getDeclContext()->getParentSourceFile();
       SourceFile *rhsSF = rhs->getDeclContext()->getParentSourceFile();
-      if (lhsSF && lhsSF == rhsSF) {
+      if (lhsSF == rhsSF) {
         // If only one location is valid, the valid location comes first.
         if (lhs->getLoc().isValid() != rhs->getLoc().isValid()) {
           return lhs->getLoc().isValid();

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -2463,7 +2463,6 @@ bool swift::diagnoseObjCMethodConflicts(SourceFile &sf) {
   // Diagnose each conflict.
   bool anyConflicts = false;
   for (const auto &conflict : localConflicts) {
-    NominalTypeDecl *tyDecl = std::get<0>(conflict);
     ObjCSelector selector = std::get<1>(conflict);
 
     auto methods = getObjCMethodConflictDecls(conflict);
@@ -2546,9 +2545,6 @@ bool swift::diagnoseObjCMethodConflicts(SourceFile &sf) {
                                      diagInfo.first, diagInfo.second,
                                      origDiagInfo.first, origDiagInfo.second,
                                      selector);
-
-      // Protocols weren't checked for selector conflicts in 5.0.
-      diag.warnUntilSwiftVersionIf(!isa<ClassDecl>(tyDecl), 6);
 
       auto objcAttr = getObjCAttrIfFromAccessNote(conflictingDecl);
       swift::softenIfAccessNote(conflictingDecl, objcAttr, diag);

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -613,7 +613,7 @@ void ModuleFile::loadExtensions(NominalTypeDecl *nominal) {
 }
 
 void ModuleFile::loadObjCMethods(
-       NominalTypeDecl *typeDecl,
+       ClassDecl *classDecl,
        ObjCSelector selector,
        bool isInstanceMethod,
        llvm::TinyPtrVector<AbstractFunctionDecl *> &methods) {
@@ -627,7 +627,7 @@ void ModuleFile::loadObjCMethods(
     return;
   }
 
-  std::string ownerName = Mangle::ASTMangler().mangleNominalType(typeDecl);
+  std::string ownerName = Mangle::ASTMangler().mangleNominalType(classDecl);
   auto results = *known;
   for (const auto &result : results) {
     // If the method is the wrong kind (instance vs. class), skip it.

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -631,7 +631,7 @@ public:
   ///
   /// \param methods The list of @objc methods in this class that have this
   /// selector and are instance/class methods as requested.
-  void loadObjCMethods(NominalTypeDecl *typeDecl,
+  void loadObjCMethods(ClassDecl *classDecl,
                        ObjCSelector selector,
                        bool isInstanceMethod,
                        llvm::TinyPtrVector<AbstractFunctionDecl *> &methods);

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -56,7 +56,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 697; // change local type mangling
+const uint16_t SWIFTMODULE_VERSION_MINOR = 698; // revert selector table changes
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -5533,10 +5533,10 @@ static void collectInterestingNestedDeclarations(
       if (isLocal)
         return;
 
-      if (auto owningType = func->getDeclContext()->getSelfNominalTypeDecl()) {
+      if (auto owningClass = func->getDeclContext()->getSelfClassDecl()) {
         if (func->isObjC()) {
           Mangle::ASTMangler mangler;
-          std::string ownerName = mangler.mangleNominalType(owningType);
+          std::string ownerName = mangler.mangleNominalType(owningClass);
           assert(!ownerName.empty() && "Mangled type came back empty!");
 
           objcMethods[func->getObjCSelector()].push_back(

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1320,7 +1320,7 @@ void SerializedModuleLoaderBase::loadExtensions(NominalTypeDecl *nominal,
 }
 
 void SerializedModuleLoaderBase::loadObjCMethods(
-       NominalTypeDecl *typeDecl,
+       ClassDecl *classDecl,
        ObjCSelector selector,
        bool isInstanceMethod,
        unsigned previousGeneration,
@@ -1328,7 +1328,7 @@ void SerializedModuleLoaderBase::loadObjCMethods(
   for (auto &modulePair : LoadedModuleFiles) {
     if (modulePair.second <= previousGeneration)
       continue;
-    modulePair.first->loadObjCMethods(typeDecl, selector, isInstanceMethod,
+    modulePair.first->loadObjCMethods(classDecl, selector, isInstanceMethod,
                                       methods);
   }
 }

--- a/test/ClangImporter/Inputs/custom-modules/module.map
+++ b/test/ClangImporter/Inputs/custom-modules/module.map
@@ -271,8 +271,3 @@ module CommonName {
   header "CommonName.h"
   export *
 }
-
-module objc_init_redundant {
-  header "objc_init_redundant.h"
-  export *
-}

--- a/test/ClangImporter/Inputs/custom-modules/objc_init_redundant.h
+++ b/test/ClangImporter/Inputs/custom-modules/objc_init_redundant.h
@@ -1,7 +1,0 @@
-#import <Foundation.h>
-
-@interface MyObject : NSObject
-
-- (void)implementedInSwift;
-
-@end

--- a/test/ClangImporter/Inputs/objc_init_redundant_bridging.h
+++ b/test/ClangImporter/Inputs/objc_init_redundant_bridging.h
@@ -1,7 +1,0 @@
-#import <Foundation.h>
-
-@interface MyBridgedObject : NSObject
-
-- (void)implementedInSwift;
-
-@end

--- a/test/ClangImporter/objc_async_conformance.swift
+++ b/test/ClangImporter/objc_async_conformance.swift
@@ -63,33 +63,6 @@ class SelectorOK2 : NSObject, RequiredObserverOnlyCompletion {
   @nonobjc func hello(_ completion : @escaping (Bool) -> Void) -> Void { completion(true) }
 }
 
-// can declare an @objc protocol with both selectors...
-@objc protocol SelectorBothAsyncProto {
-  @objc(helloWithCompletion:)
-  func hello() async -> Bool
-
-  @available(*, renamed: "hello()")
-  @objc(helloWithCompletion:)
-  func hello(completion: @escaping (Bool) -> Void)
-}
-
-// and conform by implementing either one...
-class SelectorBothAsync1: NSObject, SelectorBothAsyncProto {
-  func hello() async -> Bool { true }
-}
-class SelectorBothAsync2: NSObject, SelectorBothAsyncProto {
-  func hello(completion: @escaping (Bool) -> Void) { completion(true) }
-}
-
-// but not without declaring the async alternative.
-@objc protocol BadSelectorBothAsyncProto {
-  @objc(helloWithCompletion:)
-  func hello() async -> Bool // expected-note {{method 'hello()' declared here}}
-
-  @objc(helloWithCompletion:)
-  func hello(completion: @escaping (Bool) -> Void) // expected-warning {{method 'hello(completion:)' with Objective-C selector 'helloWithCompletion:' conflicts with method 'hello()' with the same Objective-C selector; this is an error in Swift 6}}
-}
-
 // additional coverage for situation like C4, where the method names don't
 // clash on the ObjC side, but they do on Swift side, BUT their ObjC selectors
 // differ, so it's OK.

--- a/test/ClangImporter/objc_bridging_custom.swift
+++ b/test/ClangImporter/objc_bridging_custom.swift
@@ -159,9 +159,8 @@ protocol TestProto {
   @objc optional func testUnmigrated(a: NSRuncingMode, b: Refrigerator, c: NSCoding) // expected-note {{here}} {{none}}
   @objc optional func testPartialMigrated(a: NSRuncingMode, b: Refrigerator) // expected-note {{here}} {{none}}
 
-  @objc optional subscript(a a: Refrigerator) -> Refrigerator? { get } // expected-note 2 {{here}} {{none}}
+  @objc optional subscript(a a: Refrigerator) -> Refrigerator? { get } // expected-note {{here}} {{none}}
   @objc optional subscript(generic a: ManufacturerInfo<NSString>) -> ManufacturerInfo<NSString>? { get } // expected-note {{here}} {{none}}
-  // expected-warning@-1 {{subscript getter with Objective-C selector 'objectForKeyedSubscript:' conflicts with previous declaration with the same Objective-C selector; this is an error in Swift 6}}
 
   @objc optional var prop: Refrigerator? { get } // expected-note {{here}} {{none}}
   @objc optional var propGeneric: ManufacturerInfo<NSString>? { get } // expected-note {{here}} {{none}}

--- a/test/ClangImporter/objc_init_redundant.swift
+++ b/test/ClangImporter/objc_init_redundant.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk -I %S/Inputs/custom-modules) -import-underlying-module -import-objc-header %S/Inputs/objc_init_redundant_bridging.h -emit-sil %s -verify
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk -I %S/Inputs/custom-modules) -import-underlying-module -import-objc-header %S/Inputs/objc_init_redundant_bridging.h -emit-sil %s > %t.log 2>&1
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk -I %S/Inputs/custom-modules) -emit-sil %s -verify
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk -I %S/Inputs/custom-modules) -emit-sil %s > %t.log 2>&1
 // RUN: %FileCheck %s < %t.log
 
 // REQUIRES: objc_interop
@@ -19,12 +19,3 @@ extension NSObject {
 // CHECK: ObjectiveC.NSObjectProtocol:{{.*}}note: method 'class()' declared here
 }
 
-// rdar://96470068 - Don't want conflict diagnostics in the same module
-extension MyObject {
-  @objc func implementedInSwift() {}
-}
-
-// ...or the bridging header
-extension MyBridgedObject {
-  @objc func implementedInSwift() {}
-}

--- a/test/Concurrency/Inputs/Delegate.h
+++ b/test/Concurrency/Inputs/Delegate.h
@@ -21,10 +21,4 @@
 -(void)myAsyncMethod:(void (^ _Nullable)(NSError * _Nullable, NSString * _Nullable))completionHandler;
 @end
 
-@interface Delegate (SwiftImpls)
-
-- (void)makeRequestFromSwift:(Request * _Nonnull)request completionHandler:(void (^ _Nullable)(void))handler;
-
-@end
-
 #endif

--- a/test/Concurrency/objc_async_overload.swift
+++ b/test/Concurrency/objc_async_overload.swift
@@ -53,10 +53,3 @@ extension Delegate {
     }
   }
 }
-
-// rdar://95887113 - Implementing an ObjC category method in Swift is not strictly valid, but should be tolerated
-
-extension Delegate {
-  @objc public func makeRequest(fromSwift: Request, completionHandler: (() -> Void)?) {}
-  // expected-warning@-1 {{method 'makeRequest(fromSwift:completionHandler:)' with Objective-C selector 'makeRequestFromSwift:completionHandler:' conflicts with method 'makeRequest(fromSwift:)' with the same Objective-C selector; this is an error in Swift 6}}
-}

--- a/test/Concurrency/objc_async_overload.swift
+++ b/test/Concurrency/objc_async_overload.swift
@@ -58,4 +58,5 @@ extension Delegate {
 
 extension Delegate {
   @objc public func makeRequest(fromSwift: Request, completionHandler: (() -> Void)?) {}
+  // expected-warning@-1 {{method 'makeRequest(fromSwift:completionHandler:)' with Objective-C selector 'makeRequestFromSwift:completionHandler:' conflicts with method 'makeRequest(fromSwift:)' with the same Objective-C selector; this is an error in Swift 6}}
 }

--- a/test/Constraints/common_type_objc.swift
+++ b/test/Constraints/common_type_objc.swift
@@ -6,11 +6,11 @@
 import Foundation
 
 @objc protocol P {
-  func foo(_ i: Int) -> Double // expected-note {{'foo' previously declared here}}
-  func foo(_ d: Double) -> Double // expected-warning {{method 'foo' with Objective-C selector 'foo:' conflicts with previous declaration with the same Objective-C selector; this is an error in Swift 6}}
+  func foo(_ i: Int) -> Double
+  func foo(_ d: Double) -> Double
 
-  @objc optional func opt(_ i: Int) -> Int // expected-note {{'opt' previously declared here}}
-  @objc optional func opt(_ d: Double) -> Int // expected-warning {{method 'opt' with Objective-C selector 'opt:' conflicts with previous declaration with the same Objective-C selector; this is an error in Swift 6}}
+  @objc optional func opt(_ i: Int) -> Int
+  @objc optional func opt(_ d: Double) -> Int
 }
 
 func testOptional(obj: P) {

--- a/test/Constraints/overload_filtering_objc.swift
+++ b/test/Constraints/overload_filtering_objc.swift
@@ -9,8 +9,8 @@
 import Foundation
 
 @objc protocol P {
-  func foo(_ i: Int) -> Int // expected-note {{'foo' previously declared here}}
-  func foo(_ d: Double) -> Int // expected-warning {{method 'foo' with Objective-C selector 'foo:' conflicts with previous declaration with the same Objective-C selector; this is an error in Swift 6}}
+  func foo(_ i: Int) -> Int
+  func foo(_ d: Double) -> Int
 
   @objc optional func opt(_ i: Int) -> Int
   @objc optional func opt(double: Double) -> Int

--- a/test/PrintAsObjC/protocols.swift
+++ b/test/PrintAsObjC/protocols.swift
@@ -28,6 +28,8 @@ import objc_generics
 @objc protocol B : A, Sendable {}
 
 // CHECK-LABEL: @protocol CompletionAndAsync
+// FIXME: We should detect this duplication.
+// CHECK-NEXT: - (void)helloWithCompletion:(void (^ _Nonnull)(BOOL))completionHandler SWIFT_AVAILABILITY
 // CHECK-NEXT: - (void)helloWithCompletion:(void (^ _Nonnull)(BOOL))completion;
 // CHECK-NEXT: @end
 @objc protocol CompletionAndAsync {

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -364,11 +364,9 @@ protocol subject_containerObjCProtocol1 {
 @objc // access-note-move{{subject_containerObjCProtocol2}}
 protocol subject_containerObjCProtocol2 {
   init(a: Int)
-  // expected-note@-1 {{'init' previously declared here}}
 
   @objc // FIXME: Access notes can't distinguish between init(a:) overloads
   init(a: Double)
-  // expected-warning@-1 {{initializer 'init(a:)' with Objective-C selector 'initWithA:' conflicts with previous declaration with the same Objective-C selector; this is an error in Swift 6}}
 
   func func1() -> Int
   @objc // access-note-move{{subject_containerObjCProtocol2.func1_()}}

--- a/test/decl/Inputs/objc_redeclaration_multi_2.swift
+++ b/test/decl/Inputs/objc_redeclaration_multi_2.swift
@@ -5,7 +5,7 @@ extension Redecl1 {
   @objc(init)
   func initialize() { } // expected-error{{method 'initialize()' with Objective-C selector 'init' conflicts with initializer 'init()' with the same Objective-C selector}}
 
-  @objc func method2() { } // expected-note{{method 'method2()' declared here}}
+  @objc func method2() { } // expected-error{{method 'method2()' with Objective-C selector 'method2' conflicts with method 'method2_alias()' with the same Objective-C selector}}
 }
 
 @objc class Redecl2 {

--- a/test/decl/objc_redeclaration.swift
+++ b/test/decl/objc_redeclaration.swift
@@ -26,7 +26,7 @@ extension Redecl1 {
   @objc var method1_var_alias: Int {
     @objc(method1) get { return 5 } // expected-error{{getter for 'method1_var_alias' with Objective-C selector 'method1' conflicts with method 'method1()' with the same Objective-C selector}}
 
-    @objc(method2:) set { } // expected-error{{setter for 'method1_var_alias' with Objective-C selector 'method2:' conflicts with method 'method2' with the same Objective-C selector}}
+    @objc(method2:) set { } // expected-note{{setter for 'method1_var_alias' declared here}}
   }
 
   @objc subscript (i: Int) -> Redecl1 {
@@ -37,7 +37,7 @@ extension Redecl1 {
 
 extension Redecl1 {
   @objc
-  func method2(_ x: Int) { } // expected-note{{method 'method2' declared here}}
+  func method2(_ x: Int) { } // expected-error{{method 'method2' with Objective-C selector 'method2:' conflicts with setter for 'method1_var_alias' with the same Objective-C selector}}
 
   @objc(objectAtIndexedSubscript:)
   func indexed(_ x: Int) { } // expected-error{{method 'indexed' with Objective-C selector 'objectAtIndexedSubscript:' conflicts with subscript getter with the same Objective-C selector}}

--- a/test/decl/objc_redeclaration_multi.swift
+++ b/test/decl/objc_redeclaration_multi.swift
@@ -16,5 +16,5 @@ extension Redecl2 {
 }
 
 extension Redecl1 {
-  @objc(method2) func method2_alias() { } // expected-error{{method 'method2_alias()' with Objective-C selector 'method2' conflicts with method 'method2()' with the same Objective-C selector}}
+  @objc(method2) func method2_alias() { } // expected-note{{method 'method2_alias()' declared here}}
 }

--- a/test/decl/protocol/objc.swift
+++ b/test/decl/protocol/objc.swift
@@ -261,7 +261,7 @@ class C8SubRW2: C8Base {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 @objc protocol P9 {
-  @objc(custom:) func f(_: Any) // expected-warning {{method 'f' with Objective-C selector 'custom:' conflicts with method 'h()' with the same Objective-C selector; this is an error in Swift 6}}
-  @objc(custom:) func g(_: Any) // expected-warning {{method 'g' with Objective-C selector 'custom:' conflicts with method 'h()' with the same Objective-C selector; this is an error in Swift 6}}
-  @objc(custom:) func h() async // expected-note 2 {{method 'h()' declared here}}
+  @objc(custom:) func f(_: Any) // expected-note 2 {{method 'f' declared here}}
+  @objc(custom:) func g(_: Any) // expected-warning {{method 'g' with Objective-C selector 'custom:' conflicts with method 'f' with the same Objective-C selector; this is an error in Swift 6}}
+  @objc(custom:) func h() async // expected-warning {{method 'h()' with Objective-C selector 'custom:' conflicts with method 'f' with the same Objective-C selector; this is an error in Swift 6}}
 }

--- a/test/decl/protocol/objc.swift
+++ b/test/decl/protocol/objc.swift
@@ -258,10 +258,3 @@ class C8SubRW: C8Base {
 class C8SubRW2: C8Base {
   var prop: Int = 0
 }
-
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-@objc protocol P9 {
-  @objc(custom:) func f(_: Any) // expected-note 2 {{method 'f' declared here}}
-  @objc(custom:) func g(_: Any) // expected-warning {{method 'g' with Objective-C selector 'custom:' conflicts with method 'f' with the same Objective-C selector; this is an error in Swift 6}}
-  @objc(custom:) func h() async // expected-warning {{method 'h()' with Objective-C selector 'custom:' conflicts with method 'f' with the same Objective-C selector; this is an error in Swift 6}}
-}


### PR DESCRIPTION
In #41828, I attempted to fix a longstanding bug in the decl checker which caused us to not diagnose protocol requirements with conflicting ObjC selectors. Unfortunately, subsequent testing repeatedly turned up exceptions and refinements, necessitating #59479, #59743, and #60081. The latest round of testing indicates that further refinement is still necessary, but we are running out of time to stabilize this change for 5.7.

This PR reverts all of this work and instead implements a low-risk workaround to make the test case in #59479 produce a generated header that clang will not warn about. In other words, Swift 5.7 will now behave as Swift 5.6 did except that the generated header will suppress an additional clang warning. I am reverting this work only in release/5.7, and will continue refining the new behavior in main.

Fixes rdar://97810819.