### PR TITLE
[static-stdlib] Explicit autolink for RegexParser in StringProcessing

### DIFF
--- a/stdlib/public/StringProcessing/CMakeLists.txt
+++ b/stdlib/public/StringProcessing/CMakeLists.txt
@@ -14,6 +14,13 @@ set(swift_string_processing_link_libraries
   swiftCore
   swift_RegexParser)
 
+set(swift_string_processing_compile_flags)
+if(SWIFT_BUILD_STATIC_STDLIB)
+  # Explicitly autolink swift_RegexParser because it's imported with @_implementationOnly
+  list(APPEND swift_string_processing_compile_flags
+    "-Xfrontend" "-public-autolink-library" "-Xfrontend" "swift_RegexParser")
+endif()
+
 file(GLOB_RECURSE _STRING_PROCESSING_SOURCES
   "${EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR}/Sources/_StringProcessing/*.swift"
   "${EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR}/Sources/_CUnicode/*.h"
@@ -40,6 +47,7 @@ add_swift_target_library(swift_StringProcessing ${SWIFT_STDLIB_LIBRARY_BUILD_TYP
   C_COMPILE_FLAGS
     -Dswift_StringProcessing_EXPORTS
   SWIFT_COMPILE_FLAGS
+    ${swift_string_processing_compile_flags}
     ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
 


### PR DESCRIPTION


<!-- What's in this pull request? -->
_RegexParser is used only in StringProcessing and it's imported with
@_implementationOnly.
Modules imported with @_implementationOnly are not autolinked, so build
system let the importer module how to link it. When building a shared
library, _RegexParser is already linked into StringProcessing. But when
building a static library, it's not. So we need to add autolink entry
explicitly.

Without this patch, compilation of source using regex feature with `-static-stdlib`  would fail with the following error:

```
$ echo '_ = try Regex("x")' | swiftc - -static-stdlib
error: link command failed with exit code 1 (use -v to see invocation)
/usr/lib/swift_static/linux/libswift_StringProcessing.a(_StringProcessing.o):_StringProcessing.o:function $s17_StringProcessing5RegexV5MatchV6outputxvg: error: undefined reference to '$s12_RegexParser16TypeConstructionO5tuple2ofypxn_tSKRzyp7ElementRtzlFZ'
/usr/lib/swift_static/linux/libswift_StringProcessing.a(_StringProcessing.o):_StringProcessing.o:function $s17_StringProcessing8CompilerC11ByteCodeGenV8emitNode33_39AB0CA4F16DF29C6C8E2960922072B7LLyAA8TypedIntVyAA14_ValueRegisterOGSgAA7DSLTreeV0H0OKF: error: undefined reference to '$s12_RegexParser3ASTV14QuantificationV6AmountOMa'
/usr/lib/swift_static/linux/libswift_StringProcessing.a(_StringProcessing.o):_StringProcessing.o:function $s17_StringProcessing8CompilerC11ByteCodeGenV8emitNode33_39AB0CA4F16DF29C6C8E2960922072B7LLyAA8TypedIntVyAA14_ValueRegisterOGSgAA7DSLTreeV0H0OKF: error: undefined reference to '$s12_RegexParser3ASTV5GroupV4KindOMa'
/usr/lib/swift_static/linux/libswift_StringProcessing.a(_StringProcessing.o):_StringProcessing.o:function $s17_StringProcessing8CompilerC11ByteCodeGenV8emitNode33_39AB0CA4F16DF29C6C8E2960922072B7LLyAA8TypedIntVyAA14_ValueRegisterOGSgAA7DSLTreeV0H0OKF: error: undefined reference to '$s12_RegexParser11CaptureListVMa'
/usr/lib/swift_static/linux/libswift_StringProcessing.a(_StringProcessing.o):_StringProcessing.o:function $s17_StringProcessing8CompilerC11ByteCodeGenV8emitNode33_39AB0CA4F16DF29C6C8E2960922072B7LLyAA8TypedIntVyAA14_ValueRegisterOGSgAA7DSLTreeV0H0OKF: error: undefined reference to '$s12_RegexParser11UnsupportedVMa'
/usr/lib/swift_static/linux/libswift_StringProcessing.a(_StringProcessing.o):_StringProcessing.o:function $s17_StringProcessing8CompilerC11ByteCodeGenV8emitNode33_39AB0CA4F16DF29C6C8E2960922072B7LLyAA8TypedIntVyAA14_ValueRegisterOGSgAA7DSLTreeV0H0OKF: error: undefined reference to '$s12_RegexParser11UnsupportedVMa'
...
```
