### PR TITLE
[CSDiagnostics] Optional closure diagnostic improvement

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1166,6 +1166,8 @@ NOTE(unwrap_iuo_initializer,none,
 NOTE(unwrap_with_guard,none,
      "short-circuit using 'guard' to exit this function early "
      "if the optional value contains 'nil'", ())
+NOTE(perform_optional_chain_on_closure, none,
+     "use optional chaining to call this closure", ())
 ERROR(optional_base_not_unwrapped,none,
       "value of optional type %0 must be unwrapped to refer to member %1 of "
       "wrapped base type %2", (Type, DeclNameRef, Type))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1166,8 +1166,9 @@ NOTE(unwrap_iuo_initializer,none,
 NOTE(unwrap_with_guard,none,
      "short-circuit using 'guard' to exit this function early "
      "if the optional value contains 'nil'", ())
-NOTE(perform_optional_chain_on_closure, none,
-     "use optional chaining to call this closure", ())
+NOTE(perform_optional_chain_on_function_type, none,
+     "use optional chaining to call this value of function type when optional "
+     "is non-'nil'", ())
 ERROR(optional_base_not_unwrapped,none,
       "value of optional type %0 must be unwrapped to refer to member %1 of "
       "wrapped base type %2", (Type, DeclNameRef, Type))

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -1262,6 +1262,9 @@ public:
   /// types.
   Type lookThroughAllOptionalTypes(SmallVectorImpl<Type> &optionals);
 
+  /// Return the number of optionals this type is wrapped with.
+  unsigned int getOptionalityDepth();
+
   /// Remove concurrency-related types and constraints from the given
   /// type
   ///

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -881,6 +881,12 @@ Type TypeBase::lookThroughAllOptionalTypes(SmallVectorImpl<Type> &optionals){
   return type;
 }
 
+unsigned int TypeBase::getOptionalityDepth() {
+  SmallVector<Type> types;
+  lookThroughAllOptionalTypes(types);
+  return types.size();
+}
+
 Type TypeBase::stripConcurrency(bool recurse, bool dropGlobalActor) {
   // Look through optionals.
   if (Type optionalObject = getOptionalObjectType()) {

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -4169,26 +4169,16 @@ RValue RValueEmitter::visitRebindSelfInConstructorExpr(
   auto *otherCtor = E->getCalledConstructor(isChaining)->getDecl();
   assert(otherCtor);
 
-  auto getOptionalityDepth = [](Type ty) {
-    unsigned level = 0;
-    Type objTy = ty->getOptionalObjectType();
-    while (objTy) {
-      ++level;
-      objTy = objTy->getOptionalObjectType();
-    }
-
-    return level;
-  };
-
   // The optionality depth of the 'new self' value. This can be '2' if the ctor
   // we are delegating/chaining to is both throwing and failable, or more if
   // 'self' is optional.
-  auto srcOptionalityDepth = getOptionalityDepth(E->getSubExpr()->getType());
+  auto srcOptionalityDepth = E->getSubExpr()->getType()->getOptionalityDepth();
 
   // The optionality depth of the result type of the enclosing initializer in
   // this context.
-  const auto destOptionalityDepth = getOptionalityDepth(
-      ctorDecl->mapTypeIntoContext(ctorDecl->getResultInterfaceType()));
+  const auto destOptionalityDepth =
+      ctorDecl->mapTypeIntoContext(ctorDecl->getResultInterfaceType())
+          ->getOptionalityDepth();
 
   // The subexpression consumes the current 'self' binding.
   assert(SGF.SelfInitDelegationState == SILGenFunction::NormalSelf

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1555,21 +1555,15 @@ bool MissingOptionalUnwrapFailure::diagnoseAsError() {
   // If this is a closure, suggest using optional chaining to
   // call it.
   if (unwrappedType->lookThroughAllOptionalTypes()->is<FunctionType>()) {
-    DeclRefExpr *declRefExpr = nullptr;
-    auto tryCastToDeclRef = [](Expr *expr) -> DeclRefExpr * {
-      if (auto dre = dyn_cast<DeclRefExpr>(expr)) {
-        return dre;
-      }
-      return nullptr;
-    };
-    if (auto drf = dyn_cast<DeclRefExpr>(unwrappedExpr)) {
-      declRefExpr = drf;
+    bool isDeclRefExpr = false;
+    if (isa<DeclRefExpr>(unwrappedExpr)) {
+      isDeclRefExpr = true;
     } else if (auto fve = dyn_cast<ForceValueExpr>(unwrappedExpr)) {
-      declRefExpr = tryCastToDeclRef(fve->getSubExpr());
+      isDeclRefExpr = isa<DeclRefExpr>(fve->getSubExpr());
     } else if (auto boe = dyn_cast<BindOptionalExpr>(unwrappedExpr)) {
-      declRefExpr = tryCastToDeclRef(boe->getSubExpr());
+      isDeclRefExpr = isa<DeclRefExpr>(boe->getSubExpr());
     }
-    if (declRefExpr) {
+    if (isDeclRefExpr) {
       auto depth = baseType->getOptionalityDepth();
       auto diag = emitDiagnosticAt(unwrappedExpr->getLoc(),
                                    diag::perform_optional_chain_on_closure);

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1552,7 +1552,7 @@ bool MissingOptionalUnwrapFailure::diagnoseAsError() {
   emitDiagnosticAt(unwrappedExpr->getLoc(), diag::optional_not_unwrapped,
                    baseType, unwrappedType);
 
-  // If this is a closure, suggest using optional chaining to
+  // If this is a function type, suggest using optional chaining to
   // call it.
   if (unwrappedType->lookThroughAllOptionalTypes()->is<FunctionType>()) {
     bool isDeclRefExpr = false;
@@ -1566,7 +1566,7 @@ bool MissingOptionalUnwrapFailure::diagnoseAsError() {
     if (isDeclRefExpr) {
       auto depth = baseType->getOptionalityDepth();
       auto diag = emitDiagnosticAt(unwrappedExpr->getLoc(),
-                                   diag::perform_optional_chain_on_closure);
+                                   diag::perform_optional_chain_on_function_type);
       auto fixItString = std::string(depth, '?');
       diag.fixItInsertAfter(unwrappedExpr->getEndLoc(), fixItString);
     }

--- a/test/ClangImporter/cfuncs_parse.swift
+++ b/test/ClangImporter/cfuncs_parse.swift
@@ -24,8 +24,9 @@ func test_cfunc2(_ i: Int) {
 func test_cfunc3_a() {
   let b = cfunc3( { (a : Double, b : Double) -> Double in a + b } )
   _ = b(1.5, 2.5) as Double // expected-error{{value of optional type 'double_bin_op_block?' (aka 'Optional<(Double, Double) -> Double>') must be unwrapped to a value of type 'double_bin_op_block' (aka '(Double, Double) -> Double')}}
-  // expected-note@-1{{coalesce}}
-  // expected-note@-2{{force-unwrap}}
+  // expected-note@-1{{use optional chaining to call this value of function type when optional is non-'nil'}}
+  // expected-note@-2{{coalesce}}
+  // expected-note@-3{{force-unwrap}}
   _ = b!(1.5, 2.5) as Double
   _ = b as Double// expected-error{{cannot convert value of type 'double_bin_op_block?' (aka 'Optional<(Double, Double) -> Double>') to type 'Double' in coercion}}
 }
@@ -33,8 +34,9 @@ func test_cfunc3_a() {
 func test_cfunc3_b() {
   let b = cfunc3( { a, b in a + b } )
   _ = b(1.5, 2.5) as Double // expected-error{{value of optional type 'double_bin_op_block?' (aka 'Optional<(Double, Double) -> Double>') must be unwrapped to a value of type 'double_bin_op_block' (aka '(Double, Double) -> Double')}}
-  // expected-note@-1{{coalesce}}
-  // expected-note@-2{{force-unwrap}}
+  // expected-note@-1{{use optional chaining to call this value of function type when optional is non-'nil'}}
+  // expected-note@-2{{coalesce}}
+  // expected-note@-3{{force-unwrap}}
   _ = b!(1.5, 2.5) as Double
   _ = b as Double// expected-error{{cannot convert value of type 'double_bin_op_block?' (aka 'Optional<(Double, Double) -> Double>') to type 'Double' in coercion}}
 }
@@ -42,8 +44,9 @@ func test_cfunc3_b() {
 func test_cfunc3_c() {
   let b = cfunc3({ $0 + $1 })
   _ = b(1.5, 2.5) as Double // expected-error{{value of optional type 'double_bin_op_block?' (aka 'Optional<(Double, Double) -> Double>') must be unwrapped to a value of type 'double_bin_op_block' (aka '(Double, Double) -> Double')}}
-  // expected-note@-1{{coalesce}}
-  // expected-note@-2{{force-unwrap}}
+  // expected-note@-1{{use optional chaining to call this value of function type when optional is non-'nil'}}
+  // expected-note@-2{{coalesce}}
+  // expected-note@-3{{force-unwrap}}
   _ = b!(1.5, 2.5) as Double
   _ = b as Double// expected-error{{cannot convert value of type 'double_bin_op_block?' (aka 'Optional<(Double, Double) -> Double>') to type 'Double' in coercion}}
 }

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -512,3 +512,30 @@ func rdar85166519() {
 
 // https://github.com/apple/swift/issues/58539
 if let x = nil {} // expected-error{{'nil' requires a contextual type}}
+
+// https://github.com/apple/swift/issues/56699
+let singleOptionalClosure: (() -> Void)? = nil
+let doubleOptionalClosure: (() -> Void)?? = nil
+singleOptionalClosure()
+// expected-error@-1 {{value of optional type}}
+// expected-note@-2 {{use optional chaining to call this closure}} {{22-22=?}}
+// expected-note@-3 {{coalesce}}
+// expected-note@-4 {{force-unwrap}}
+
+doubleOptionalClosure()
+// expected-error@-1 {{value of optional type}}
+// expected-note@-2 {{use optional chaining to call this closure}} {{22-22=??}}
+// expected-note@-3 {{coalesce}}
+// expected-note@-4 {{force-unwrap}}
+
+doubleOptionalClosure?()
+// expected-error@-1 {{value of optional type}}
+// expected-note@-2 {{use optional chaining to call this closure}} {{23-23=?}}
+// expected-note@-3 {{coalesce}}
+// expected-note@-4 {{force-unwrap}}
+
+doubleOptionalClosure!()
+// expected-error@-1 {{value of optional type}}
+// expected-note@-2 {{use optional chaining to call this closure}} {{23-23=?}}
+// expected-note@-3 {{coalesce}}
+// expected-note@-4 {{force-unwrap}}

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -518,24 +518,40 @@ let singleOptionalClosure: (() -> Void)? = nil
 let doubleOptionalClosure: (() -> Void)?? = nil
 singleOptionalClosure()
 // expected-error@-1 {{value of optional type}}
-// expected-note@-2 {{use optional chaining to call this closure}} {{22-22=?}}
+// expected-note@-2 {{use optional chaining to call this value of function type when optional is non-'nil'}} {{22-22=?}}
 // expected-note@-3 {{coalesce}}
 // expected-note@-4 {{force-unwrap}}
 
 doubleOptionalClosure()
 // expected-error@-1 {{value of optional type}}
-// expected-note@-2 {{use optional chaining to call this closure}} {{22-22=??}}
+// expected-note@-2 {{use optional chaining to call this value of function type when optional is non-'nil'}} {{22-22=??}}
 // expected-note@-3 {{coalesce}}
 // expected-note@-4 {{force-unwrap}}
 
 doubleOptionalClosure?()
 // expected-error@-1 {{value of optional type}}
-// expected-note@-2 {{use optional chaining to call this closure}} {{23-23=?}}
+// expected-note@-2 {{use optional chaining to call this value of function type when optional is non-'nil'}} {{23-23=?}}
 // expected-note@-3 {{coalesce}}
 // expected-note@-4 {{force-unwrap}}
 
 doubleOptionalClosure!()
 // expected-error@-1 {{value of optional type}}
-// expected-note@-2 {{use optional chaining to call this closure}} {{23-23=?}}
+// expected-note@-2 {{use optional chaining to call this value of function type when optional is non-'nil'}} {{23-23=?}}
 // expected-note@-3 {{coalesce}}
 // expected-note@-4 {{force-unwrap}}
+
+struct FunctionContainer {
+  func test() {}
+}
+
+func testFunctionContainerMethodCall(container: FunctionContainer?) {
+  let fn = container?.test
+   // expected-note@-1 {{short-circuit}}
+   // expected-note@-2 {{coalesce}}
+   // expected-note@-3 {{force-unwrap}}
+  fn()
+  // expected-error@-1 {{value of optional type}}
+  // expected-note@-2 {{use optional chaining to call this value of function type when optional is non-'nil'}} {{5-5=?}}
+  // expected-note@-3 {{coalesce}}
+  // expected-note@-4 {{force-unwrap}}
+}


### PR DESCRIPTION
Resolves https://github.com/apple/swift/issues/56699

Add a new diagnostic note to suggest using optional chaining to unwrap a closure when trying to call it. Right now, we provide two notes - (1) to coalesce using `??` (2) to force unwrap using `!`. But usually, what you really want to do here is to use `?` to optional chain and only call the method if it's not `nil`.

For example:

```swift
let closure: (() -> Void)? = nil
closure() // should suggest changing to closure?()
```