### PR TITLE
[Sema] Look through FunctionConversionExpr when finding @discardableResult callee

### DIFF
--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1412,6 +1412,8 @@ void TypeChecker::checkIgnoredExpr(Expr *E) {
         fn = FVE->getSubExpr();
       } else if (auto dotSyntaxRef = dyn_cast<DotSyntaxBaseIgnoredExpr>(fn)) {
         fn = dotSyntaxRef->getRHS();
+      } else if (auto fnConvExpr = dyn_cast<FunctionConversionExpr>(fn)) {
+        fn = fnConvExpr->getSubExpr();
       } else {
         break;
       }

--- a/test/Concurrency/attr_discardableResult_async_await.swift
+++ b/test/Concurrency/attr_discardableResult_async_await.swift
@@ -1,0 +1,11 @@
+// RUN: %target-typecheck-verify-swift  -disable-availability-checking
+// REQUIRES: concurrency
+
+// https://github.com/apple/swift/issues/60276
+
+@discardableResult @MainActor
+func mainActorAsyncDiscardable() async -> Int { 0 }
+
+func consumesMainActorAsyncDiscardable() async {
+  await mainActorAsyncDiscardable() // ok
+}


### PR DESCRIPTION
Resolves https://github.com/apple/swift/issues/60276


```swift
@discardableResult @MainActor
func a() async -> Int { 5 }

func b() async {
  await a()
}
```

On 5.7. you get a warning:

```
<source>:3:11: warning: result of call to function returning 'Int' is unused
    await a()
          ^~~
```

When using `@MainActor` the call is wrapped in an implicit `FunctionConversionExpr` and we currently do not look through that to find the callee function, so the code falls through and triggers this warning. 

This is a regression in 5.7, as this warning does not appear in 5.6.