### PR TITLE
[cxx-interop] Explicitly require `CxxSequence`'s iterator to be `CxxIterator`

### DIFF
--- a/stdlib/public/Cxx/CxxSequence.swift
+++ b/stdlib/public/Cxx/CxxSequence.swift
@@ -66,6 +66,7 @@ extension Optional: UnsafeCxxInputIterator where Wrapped: UnsafeCxxInputIterator
 public protocol CxxSequence: Sequence {
   associatedtype RawIterator: UnsafeCxxInputIterator
   associatedtype Element = RawIterator.Pointee
+  associatedtype Iterator = CxxIterator<Self>
 
   // `begin()` and `end()` have to be mutating, otherwise calling 
   // `self.sequence.begin()` will copy `self.sequence` into a temporary value,


### PR DESCRIPTION
This is needed for automatic synthesis of conformances to `CxxSequence` protocol.
It also makes typechecker errors easier to understand when they happen.