### PR TITLE
[SILGen] Fix typo in SILGenStmt.cpp

### DIFF
--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -126,7 +126,7 @@ void SILGenFunction::eraseBasicBlock(SILBasicBlock *block) {
 void SILGenFunction::mergeCleanupBlocks() {
   for (auto bbPos = F.begin(), bbEnd = F.end(), nextPos = bbPos; bbPos != bbEnd;
        bbPos = nextPos) {
-    // A forward iterator refering to the next unprocessed block in the block
+    // A forward iterator referring to the next unprocessed block in the block
     // list. If blocks are merged and moved, then this will be updated.
     nextPos = std::next(bbPos);
 


### PR DESCRIPTION
refering -> referring

