### PR TITLE
[SourceKit] Don’t provide incorrect semantic highlighting of `nil` in case statements as enum decl element

### DIFF
--- a/test/SourceKit/Sema/nil_annotation_in_case.swift
+++ b/test/SourceKit/Sema/nil_annotation_in_case.swift
@@ -1,0 +1,31 @@
+func foo(o: Int?) {
+  switch o {
+  case nil:
+    break
+  case .none:
+    break
+  }
+}
+
+
+// RUN: %sourcekitd-test -req=open %s -- %s == -req=print-annotations %s -- %s | %FileCheck %s
+
+// CHECK:      [
+// CHECK-NEXT:   {
+// CHECK-NEXT:     key.kind: source.lang.swift.ref.struct,
+// CHECK-NEXT:     key.offset: 12,
+// CHECK-NEXT:     key.length: 3,
+// CHECK-NEXT:     key.is_system: 1
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     key.kind: source.lang.swift.ref.var.local,
+// CHECK-NEXT:     key.offset: 29,
+// CHECK-NEXT:     key.length: 1
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     key.kind: source.lang.swift.ref.enumelement,
+// CHECK-NEXT:     key.offset: 63,
+// CHECK-NEXT:     key.length: 4,
+// CHECK-NEXT:     key.is_system: 1
+// CHECK-NEXT:   }
+// CHECK-NEXT: ]

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -963,6 +963,15 @@ public:
     if (AvailableAttr::isUnavailable(D))
       return true;
 
+    auto &SM = D->getASTContext().SourceMgr;
+    if (D == D->getASTContext().getOptionalNoneDecl() &&
+        SM.extractText(Range, BufferID) == "nil") {
+      // If a 'nil' literal occurs in a swift-case statement, it gets replaced
+      // by a reference to 'Optional.none' in the AST. We want to continue
+      // highlighting 'nil' as a keyword and not as an enum element.
+      return true;
+    }
+
     if (CtorTyRef)
       D = CtorTyRef;
     annotate(D, /*IsRef=*/true, Range);


### PR DESCRIPTION
If a 'nil' literal occurs in a swift-case statement, it gets replaced by a reference to 'Optional.none' in the AST. We want to continue highlighting 'nil' as a keyword and not as an enum element. Detect this case if 'none' was spelled with 3 characters, which indicates that it was rewritten from 'nil'.

Resolves apple/sourcekit-lsp#599
rdar://97961865
