### PR TITLE
Introduce a new syntax kind to represent missing base nodes

### DIFF
--- a/utils/gyb_syntax_support/CommonNodes.py
+++ b/utils/gyb_syntax_support/CommonNodes.py
@@ -12,6 +12,12 @@ COMMON_NODES = [
     Node('UnknownStmt', kind='Stmt'),
     Node('UnknownType', kind='Type'),
     Node('UnknownPattern', kind='Pattern'),
+    Node('Missing', kind='Syntax'),
+    Node('MissingDecl', kind='Decl'),
+    Node('MissingExpr', kind='Expr'),
+    Node('MissingStmt', kind='Stmt'),
+    Node('MissingType', kind='Type'),
+    Node('MissingPattern', kind='Pattern'),
 
     # code-block-item = (decl | stmt | expr) ';'?
     Node('CodeBlockItem', kind='Syntax', omit_when_empty=True,

--- a/utils/gyb_syntax_support/Node.py
+++ b/utils/gyb_syntax_support/Node.py
@@ -69,12 +69,19 @@ class Node(object):
         """
         return "Unknown" in self.syntax_kind
 
+    def is_missing(self):
+        """
+        Returns `True` if this node is a `Missing` syntax subclass.
+        """
+        return "Missing" in self.syntax_kind
+
     def is_buildable(self):
         """
         Returns `True` if this node should have a builder associated.
         """
         return not self.is_base() and \
             not self.is_unknown() and \
+            not self.is_missing() and \
             not self.is_syntax_collection()
 
     def shall_be_omitted_when_empty(self):

--- a/utils/gyb_syntax_support/NodeSerializationCodes.py
+++ b/utils/gyb_syntax_support/NodeSerializationCodes.py
@@ -261,6 +261,12 @@ SYNTAX_NODE_SERIALIZATION_CODES = {
     'BackDeployAttributeSpecList' : 257,
     'BackDeployVersionList' : 258,
     'BackDeployVersionArgument' : 259,
+    'Missing': 260,
+    'MissingDecl': 261,
+    'MissingExpr': 262,
+    'MissingStmt': 263,
+    'MissingType': 264,
+    'MissingPattern': 265,
 }
 
 

--- a/utils/gyb_syntax_support/__init__.py
+++ b/utils/gyb_syntax_support/__init__.py
@@ -15,12 +15,14 @@ from .PatternNodes import PATTERN_NODES  # noqa: I201
 from .StmtNodes import STMT_NODES  # noqa: I201
 from .Trivia import TRIVIAS  # noqa: I201
 from .TypeNodes import TYPE_NODES  # noqa: I201
+from .kinds import SYNTAX_BASE_KINDS  # noqa: I201
 
 
 # Re-export global constants
 SYNTAX_NODES = COMMON_NODES + EXPR_NODES + DECL_NODES + ATTRIBUTE_NODES + \
     STMT_NODES + GENERIC_NODES + TYPE_NODES + PATTERN_NODES + \
     AVAILABILITY_NODES
+NON_BASE_SYNTAX_NODES = [node for node in SYNTAX_NODES if not node.is_base()]
 SYNTAX_TOKENS = Token.SYNTAX_TOKENS
 SYNTAX_TOKEN_MAP = Token.SYNTAX_TOKEN_MAP
 SYNTAX_CLASSIFICATIONS = Classification.SYNTAX_CLASSIFICATIONS
@@ -121,8 +123,12 @@ def make_missing_swift_child(child):
             tok_kind += '("")'
         return 'RawSyntax.missingToken(TokenKind.%s)' % tok_kind
     else:
-        missing_kind = "unknown" if child.syntax_kind == "Syntax" \
-                       else child.swift_syntax_kind
+        if child.syntax_kind == "Syntax":
+            missing_kind = "unknown"
+        elif child.syntax_kind in SYNTAX_BASE_KINDS:
+            missing_kind = f"missing{child.syntax_kind}"
+        else:
+            missing_kind = child.swift_syntax_kind 
         return 'RawSyntax.missing(SyntaxKind.%s)' % missing_kind
 
 


### PR DESCRIPTION
Companion of https://github.com/apple/swift-syntax/pull/535