### PR TITLE
[stdlib] Fix func signature spacing in KeyPath.swift

### DIFF
--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -77,7 +77,7 @@ public class AnyKeyPath: Hashable, _AppendKeyPath {
     }
   }
   
-  public static func ==(a: AnyKeyPath, b: AnyKeyPath) -> Bool {
+  public static func == (a: AnyKeyPath, b: AnyKeyPath) -> Bool {
     // Fast-path identical objects
     if a === b {
       return true
@@ -439,7 +439,7 @@ internal struct ComputedPropertyID: Hashable {
   internal var value: Int
   internal var kind: KeyPathComputedIDKind
 
-  internal static func ==(
+  internal static func == (
     x: ComputedPropertyID, y: ComputedPropertyID
   ) -> Bool {
     return x.value == y.value
@@ -654,7 +654,7 @@ internal enum KeyPathComponent: Hashable {
   /// The keypath wraps a value in an optional.
   case optionalWrap
 
-  internal static func ==(a: KeyPathComponent, b: KeyPathComponent) -> Bool {
+  internal static func == (a: KeyPathComponent, b: KeyPathComponent) -> Bool {
     switch (a, b) {
     case (.struct(offset: let a), .struct(offset: let b)),
          (.class (offset: let a), .class (offset: let b)):


### PR DESCRIPTION
- standardizes spacing of an operator(==) func signature in `KeyPath.swift`
  - (ref.) #3698
  - (ref.) #59868

```diff
- func ==(...
+ func == (...
```