### PR TITLE
[cxx-interop] Fix issue where multiple records in a module containing the same meth…

### DIFF
--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -615,10 +615,10 @@ public:
 
   /// Keep track of cxx function names, params etc in order to
   /// allow for de-duping functions that differ strictly on "constness".
-  llvm::DenseMap<llvm::StringRef,
+  llvm::DenseMap<const clang::DeclContext *, llvm::DenseMap<llvm::StringRef,
                  std::pair<
                      llvm::DenseSet<clang::FunctionDecl *>,
-                     llvm::DenseSet<clang::FunctionDecl *>>>
+                     llvm::DenseSet<clang::FunctionDecl *>>>>
       cxxMethods;
 
   // Cache for already-specialized function templates and any thunks they may

--- a/test/Interop/Cxx/class/method/Inputs/ambiguous_methods.h
+++ b/test/Interop/Cxx/class/method/Inputs/ambiguous_methods.h
@@ -41,4 +41,10 @@ private:
   int mutableMethodsCalledCount = 0;
 };
 
+struct HasAmbiguousMethods2 {
+  int increment(int a) const {
+    return a + 1;
+  }
+};
+
 #endif // TEST_INTEROP_CXX_CLASS_AMBIGUOUS_METHOD_METHODS_H

--- a/test/Interop/Cxx/class/method/ambiguous-methods-module-interface.swift
+++ b/test/Interop/Cxx/class/method/ambiguous-methods-module-interface.swift
@@ -11,3 +11,7 @@
 
 // CHECK: func numberOfMutableMethodsCalled() -> Int32
 // CHECK: mutating func numberOfMutableMethodsCalledMutating() -> Int32
+
+// CHECK: struct HasAmbiguousMethods2
+// CHECK: func increment(_ a: Int32) -> Int32
+// CHECK-NOT: mutating func incrementMutating(_ a: Int32) -> Int32

--- a/test/Interop/Cxx/ergonomics/implicit-computed-properties-module-interface.swift
+++ b/test/Interop/Cxx/ergonomics/implicit-computed-properties-module-interface.swift
@@ -3,8 +3,8 @@
 // CHECK:      struct VoidGetter {
 // CHECK-NOT:     var
 // CHECK-NEXT:    init()
-// CHECK-NEXT:    mutating func getXMutating()
-// CHECK-NEXT:    mutating func setXMutating(_: Int32)
+// CHECK-NEXT:    mutating func getX()
+// CHECK-NEXT:    mutating func setX(_: Int32)
 // CHECK-NEXT: }
 
 // CHECK:      struct VoidSetterNoName {
@@ -16,13 +16,13 @@
 // CHECK:      struct IllegalIntReturnSetter {
 // CHECK-NOT:     var
 // CHECK-NEXT:    init()
-// CHECK-NEXT:    mutating func setXMutating(_: Int32) -> Int32
+// CHECK-NEXT:    mutating func setX(_: Int32) -> Int32
 // CHECK-NEXT: }
 
 // CHECK:      struct TwoParameterSetter {
 // CHECK-NOT:     var
 // CHECK-NEXT:    init()
-// CHECK-NEXT:    mutating func setXMutating(_: Int32, _: Int32)
+// CHECK-NEXT:    mutating func setX(_: Int32, _: Int32)
 // CHECK-NEXT: }
 
 // CHECK:      struct NoNameSetter {
@@ -88,7 +88,7 @@
 
 // CHECK:      struct NotypeSetter {
 // CHECK-NEXT:    init()
-// CHECK-NEXT:    mutating func setXMutating()
+// CHECK-NEXT:    mutating func setX()
 // CHECK-NEXT: }
 
 // CHECK:      struct IntGetterSetter {
@@ -96,7 +96,7 @@
 // CHECK-NEXT:    init(val: Int32)
 // CHECK-NEXT:    var x: Int32
 // CHECK-NEXT:    func getX() -> Int32
-// CHECK-NEXT:    mutating func setXMutating(_ v: Int32)
+// CHECK-NEXT:    mutating func setX(_ v: Int32)
 // CHECK-NEXT:    var val: Int32
 // CHECK-NEXT: }
 
@@ -120,7 +120,7 @@
 // CHECK:      struct GetterHasArg {
 // CHECK-NEXT:    init()
 // CHECK-NEXT:    func getX(_ v: Int32) -> Int32
-// CHECK-NEXT:    mutating func setXMutating(_ v: Int32)
+// CHECK-NEXT:    mutating func setX(_ v: Int32)
 // CHECK-NEXT: }
 
 // CHECK:      struct GetterSetterIsUpper {
@@ -172,8 +172,8 @@
 // CHECK-NEXT:    init()
 // CHECK-NEXT:    init(val: Int32)
 // CHECK-NEXT:    var x: Int32 { mutating get set }
-// CHECK-NEXT:    mutating func getXMutating() -> Int32
-// CHECK-NEXT:    mutating func setXMutating(_ v: Int32)
+// CHECK-NEXT:    mutating func getX() -> Int32
+// CHECK-NEXT:    mutating func setX(_ v: Int32)
 // CHECK-NEXT:    var val: Int32
 // CHECK-NEXT: }
 
@@ -191,7 +191,7 @@
 // CHECK-NEXT:    init()
 // CHECK-NEXT:    var x: Int32
 // CHECK-NEXT:    func getX() -> Int32
-// CHECK-NEXT:    mutating func setXMutating(_ a: Int32, _ b: Int32)
+// CHECK-NEXT:    mutating func setX(_ a: Int32, _ b: Int32)
 // CHECK-NEXT: }
 
 // CHECK:      struct NonTrivial {
@@ -204,16 +204,16 @@
 // CHECK-NEXT:    init()
 // CHECK-NEXT:    init(value: Int32)
 // CHECK-NEXT:    var x: UnsafeMutablePointer<Int32>? { mutating get set }
-// CHECK-NEXT:    mutating func getXMutating() -> UnsafeMutablePointer<Int32>!
-// CHECK-NEXT:    mutating func setXMutating(_ v: UnsafeMutablePointer<Int32>!)
+// CHECK-NEXT:    mutating func getX() -> UnsafeMutablePointer<Int32>!
+// CHECK-NEXT:    mutating func setX(_ v: UnsafeMutablePointer<Int32>!)
 // CHECK-NEXT:    var value: Int32
 // CHECK-NEXT: }
 
 // CHECK:      struct RefGetterSetter {
 // CHECK-NEXT:    init()
 // CHECK-NEXT:    init(value: Int32)
-// CHECK-NEXT:    mutating func getXMutating() -> UnsafePointer<Int32>
-// CHECK-NEXT:    mutating func setXMutating(_ v: Int32)
+// CHECK-NEXT:    mutating func getX() -> UnsafePointer<Int32>
+// CHECK-NEXT:    mutating func setX(_ v: Int32)
 // CHECK-NEXT:    var value: Int32
 // CHECK-NEXT: }
 
@@ -221,16 +221,16 @@
 // CHECK-NEXT:    init()
 // CHECK-NEXT:    init(value: NonTrivial)
 // CHECK-NEXT:    var x: NonTrivial { mutating get set }
-// CHECK-NEXT:    mutating func getXMutating() -> NonTrivial
-// CHECK-NEXT:    mutating func setXMutating(_ v: NonTrivial)
+// CHECK-NEXT:    mutating func getX() -> NonTrivial
+// CHECK-NEXT:    mutating func setX(_ v: NonTrivial)
 // CHECK-NEXT:    var value: NonTrivial
 // CHECK-NEXT: }
 
 // CHECK:      struct DifferentTypes {
 // CHECK-NEXT:    init()
 // CHECK-NEXT:    init(value: NonTrivial)
-// CHECK-NEXT:    mutating func getXMutating() -> NonTrivial
-// CHECK-NEXT:    mutating func setXMutating(_ v: Int32)
+// CHECK-NEXT:    mutating func getX() -> NonTrivial
+// CHECK-NEXT:    mutating func setX(_ v: Int32)
 // CHECK-NEXT:    var value: NonTrivial
 // CHECK-NEXT: }
 


### PR DESCRIPTION
If 2 records in the same module had the same method name but methods differed in constness the logic that mutates the mutable one into `FooMutating` would still get called. 