### PR TITLE
Frontend: Rename -enable-ad-hoc-availability to -weak-link-at-target

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -170,9 +170,9 @@ namespace swift {
     /// Only check the availability of the API, ignore function bodies.
     bool CheckAPIAvailabilityOnly = false;
 
-    /// Causes the compiler to treat declarations available at the current
-    /// runtime OS version as potentially unavailable.
-    bool EnableAdHocAvailability = false;
+    /// Causes the compiler to use weak linkage for symbols belonging to
+    /// declarations introduced at the deployment target.
+    bool WeakLinkAtTarget = false;
 
     /// Should conformance availability violations be diagnosed as errors?
     bool EnableConformanceAvailabilityErrors = false;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -1065,9 +1065,11 @@ def clang_header_expose_public_decls:
   HelpText<"Expose all public declarations in the generated clang header">,
   Flags<[FrontendOption, HelpHidden]>;
   
-def enable_ad_hoc_availability :
-  Flag<["-"], "enable-ad-hoc-availability">,
-  HelpText<"Enable experimental support for ad hoc availability">;
+def weak_link_at_target :
+  Flag<["-"], "weak-link-at-target">,
+  HelpText<"Weakly link symbols for declarations that were introduced at the "
+           "deployment target. Symbols introduced before the deployment "
+           "target are still strongly linked.">;
 
 def concurrency_model :
     Separate<["-"], "concurrency-model">,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1009,7 +1009,7 @@ bool Decl::isWeakImported(ModuleDecl *fromModule) const {
   auto &ctx = fromModule->getASTContext();
   auto deploymentTarget = AvailabilityContext::forDeploymentTarget(ctx);
 
-  if (ctx.LangOpts.EnableAdHocAvailability)
+  if (ctx.LangOpts.WeakLinkAtTarget)
     return !availability.isSupersetOf(deploymentTarget);
 
   return !deploymentTarget.isContainedIn(availability);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -497,8 +497,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
       Args.hasArg(OPT_disable_availability_checking);
   Opts.CheckAPIAvailabilityOnly |=
       Args.hasArg(OPT_check_api_availability_only);
-  Opts.EnableAdHocAvailability |=
-      Args.hasArg(OPT_enable_ad_hoc_availability);
+  Opts.WeakLinkAtTarget |= Args.hasArg(OPT_weak_link_at_target);
 
   if (auto A = Args.getLastArg(OPT_enable_conformance_availability_errors,
                                OPT_disable_conformance_availability_errors)) {

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -480,7 +480,7 @@ bool SILFunction::isWeakImported() const {
   auto deploymentTarget =
       AvailabilityContext::forDeploymentTarget(getASTContext());
 
-  if (getASTContext().LangOpts.EnableAdHocAvailability)
+  if (getASTContext().LangOpts.WeakLinkAtTarget)
     return !Availability.isSupersetOf(deploymentTarget);
 
   return !deploymentTarget.isContainedIn(Availability);

--- a/test/IRGen/weak_import_availability.swift
+++ b/test/IRGen/weak_import_availability.swift
@@ -5,8 +5,8 @@
 // RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir -target %target-cpu-apple-macosx10.50 | %FileCheck %s --check-prefix=CHECK-NEW
 // RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir -target %target-cpu-apple-macosx10.60 | %FileCheck %s --check-prefix=CHECK-NEW
 
-// RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir -target %target-cpu-apple-macosx10.50 -enable-ad-hoc-availability | %FileCheck %s --check-prefix=CHECK-OLD
-// RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir -target %target-cpu-apple-macosx10.60 -enable-ad-hoc-availability | %FileCheck %s --check-prefix=CHECK-NEW
+// RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir -target %target-cpu-apple-macosx10.50 -weak-link-at-target | %FileCheck %s --check-prefix=CHECK-OLD
+// RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir -target %target-cpu-apple-macosx10.60 -weak-link-at-target | %FileCheck %s --check-prefix=CHECK-NEW
 
 // REQUIRES: OS=macosx
 


### PR DESCRIPTION
I am separating the concern of weakly linking symbols that are introduced at the deployment target from the concern of type checking this new type of potential unavailability.

Resolves rdar://97925900
