### PR TITLE
Make IfConfigClause Elements Optional

### DIFF
--- a/utils/gyb_syntax_support/DeclNodes.py
+++ b/utils/gyb_syntax_support/DeclNodes.py
@@ -100,6 +100,7 @@ DECL_NODES = [
              Child('Condition', kind='Expr', classification='BuildConfigId',
                    is_optional=True),
              Child('Elements', kind='Syntax',
+                   is_optional=True,
                    node_choices=[
                        Child('Statements', kind='CodeBlockItemList'),
                        Child('SwitchCases', kind='SwitchCaseList'),


### PR DESCRIPTION
Make IfConfigClause Elements Optional

A #if clause need not actually contain any elements. Consider

```
#if !FEATURE_ENABLED
#else
class Foo {

}
#endif
```