### PR TITLE
[TypeChecker] Type wrappers (experimental feature)

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -763,6 +763,11 @@ DECL_ATTR(_expose, Expose,
   ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   133)
 
+SIMPLE_DECL_ATTR(typeWrapper, TypeWrapper,
+  OnStruct | OnClass | OnEnum |
+  ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
+  134)
+
 // If you're adding a new underscored attribute here, please document it in
 // docs/ReferenceGuides/UnderscoredAttributes.md.
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3754,6 +3754,12 @@ public:
     return getGlobalActorInstance() != nullptr;
   }
 
+  /// Returns true if this type has a type wrapper custom attribute.
+  bool hasTypeWrapper() const { return bool(getTypeWrapper()); }
+
+  /// Return a type wrapper (if any) associated with this type.
+  NominalTypeDecl *getTypeWrapper() const;
+
   // Implement isa/cast/dyncast/etc.
   static bool classof(const Decl *D) {
     return D->getKind() >= DeclKind::First_NominalTypeDecl &&

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3760,6 +3760,11 @@ public:
   /// Return a type wrapper (if any) associated with this type.
   NominalTypeDecl *getTypeWrapper() const;
 
+  /// If this declaration has a type wrapper return a property that
+  /// is used for all type wrapper related operations (mainly for
+  /// applicable property access routing).
+  VarDecl *getTypeWrapperProperty() const;
+
   /// Get an initializer that could be used to instantiate a
   /// type wrapped type.
   ConstructorDecl *getTypeWrapperInitializer() const;

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3760,6 +3760,10 @@ public:
   /// Return a type wrapper (if any) associated with this type.
   NominalTypeDecl *getTypeWrapper() const;
 
+  /// Get an initializer that could be used to instantiate a
+  /// type wrapped type.
+  ConstructorDecl *getTypeWrapperInitializer() const;
+
   // Implement isa/cast/dyncast/etc.
   static bool classof(const Decl *D) {
     return D->getKind() >= DeclKind::First_NominalTypeDecl &&

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5564,6 +5564,13 @@ public:
   /// all access to it routed through a type wrapper.
   bool isAccessedViaTypeWrapper() const;
 
+  /// For type wrapped properties (see \c isAccessedViaTypeWrapper)
+  /// all access is routed through a type wrapper.
+  ///
+  /// \returns an underlying type wrapper property which is a
+  /// storage endpoint for all access to this property.
+  VarDecl *getUnderlyingTypeWrapperStorage() const;
+
   /// Visit all auxiliary declarations to this VarDecl.
   ///
   /// An auxiliary declaration is a declaration synthesized by the compiler to support

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5555,7 +5555,11 @@ public:
   /// Return true if this property either has storage or has an attached property
   /// wrapper that has storage.
   bool hasStorageOrWrapsStorage() const;
-  
+
+  /// Whether this property belongs to a type wrapped type and has
+  /// all access to it routed through a type wrapper.
+  bool isAccessedViaTypeWrapper() const;
+
   /// Visit all auxiliary declarations to this VarDecl.
   ///
   /// An auxiliary declaration is a declaration synthesized by the compiler to support

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6480,6 +6480,9 @@ ERROR(move_expression_not_passed_lvalue,none,
 // MARK: Type Wrappers
 //------------------------------------------------------------------------------
 
+ERROR(type_wrappers_are_experimental,none,
+      "type wrappers are an experimental feature", ())
+
 ERROR(type_wrapper_attribute_not_allowed_here,none,
       "type wrapper attribute %0 can only be applied to a class, struct",
       (Identifier))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6476,5 +6476,40 @@ ERROR(moveOnly_not_allowed_here,none,
 ERROR(move_expression_not_passed_lvalue,none,
       "'move' can only be applied to lvalues", ())
 
+//------------------------------------------------------------------------------
+// MARK: Type Wrappers
+//------------------------------------------------------------------------------
+
+ERROR(type_wrapper_attribute_not_allowed_here,none,
+      "type wrapper attribute %0 can only be applied to a class, struct",
+      (Identifier))
+
+ERROR(type_wrapper_requires_a_single_generic_param,none,
+      "type wrapper has to declare a single generic parameter "
+      "for underlying storage type", ())
+
+ERROR(type_wrapper_requires_memberwise_init,none,
+      "type wrapper type %0 does not contain a required initializer"
+      " - init(memberwise:)",
+      (DeclName))
+
+ERROR(type_wrapper_requires_subscript,none,
+      "type wrapper type %0 does not contain a required subscript"
+      " - subscript(storedKeyPath:)",
+      (DeclName))
+
+ERROR(type_wrapper_failable_init,none,
+      "type wrapper initializer %0 cannot be failable", (DeclName))
+
+ERROR(type_wrapper_invalid_subscript_param_type, none,
+      "type wrapper subscript expects a key path parameter type (got: %0)",
+      (Type))
+
+ERROR(type_wrapper_type_requirement_not_accessible,none,
+      "%select{private|fileprivate|internal|public|open}0 %1 %2 cannot have "
+      "more restrictive access than its enclosing type wrapper type %3 "
+      "(which is %select{private|fileprivate|internal|public|open}4)",
+      (AccessLevel, DescriptiveDeclKind, DeclName, Type, AccessLevel))
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6488,6 +6488,9 @@ ERROR(type_wrapper_requires_a_single_generic_param,none,
       "type wrapper has to declare a single generic parameter "
       "for underlying storage type", ())
 
+ERROR(cannot_use_multiple_type_wrappers,none,
+      "type %0 cannot use more than one type wrapper", ())
+
 ERROR(type_wrapper_requires_memberwise_init,none,
       "type wrapper type %0 does not contain a required initializer"
       " - init(memberwise:)",

--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -309,6 +309,7 @@ IDENTIFIER_WITH_NAME(builderSelf, "$builderSelf")
 
 // Type wrappers
 IDENTIFIER_WITH_NAME(TypeWrapperStorage, "$Storage")
+IDENTIFIER_WITH_NAME(TypeWrapperProperty, "$_storage")
 
 #undef IDENTIFIER
 #undef IDENTIFIER_

--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -311,6 +311,7 @@ IDENTIFIER_WITH_NAME(builderSelf, "$builderSelf")
 IDENTIFIER_WITH_NAME(TypeWrapperStorage, "$Storage")
 IDENTIFIER_WITH_NAME(TypeWrapperProperty, "$_storage")
 IDENTIFIER(storageKeyPath)
+IDENTIFIER(memberwise)
 
 #undef IDENTIFIER
 #undef IDENTIFIER_

--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -307,6 +307,9 @@ IDENTIFIER(decodeNextArgument)
 IDENTIFIER(SerializationRequirement)
 IDENTIFIER_WITH_NAME(builderSelf, "$builderSelf")
 
+// Type wrappers
+IDENTIFIER_WITH_NAME(TypeWrapperStorage, "$Storage")
+
 #undef IDENTIFIER
 #undef IDENTIFIER_
 #undef IDENTIFIER_WITH_NAME

--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -310,6 +310,7 @@ IDENTIFIER_WITH_NAME(builderSelf, "$builderSelf")
 // Type wrappers
 IDENTIFIER_WITH_NAME(TypeWrapperStorage, "$Storage")
 IDENTIFIER_WITH_NAME(TypeWrapperProperty, "$_storage")
+IDENTIFIER(storageKeyPath)
 
 #undef IDENTIFIER
 #undef IDENTIFIER_

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3605,6 +3605,23 @@ public:
   bool isCached() const { return true; }
 };
 
+/// Synthesize the body of a setter for a stored property that belongs to
+/// a type wrapped type.
+class SynthesizeTypeWrappedPropertySetterBody
+    : public SimpleRequest<SynthesizeTypeWrappedPropertySetterBody,
+                           BraceStmt *(AccessorDecl *), RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  BraceStmt *evaluate(Evaluator &evaluator, AccessorDecl *) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
 void simple_display(llvm::raw_ostream &out, ASTNode node);
 void simple_display(llvm::raw_ostream &out, Type value);
 void simple_display(llvm::raw_ostream &out, const TypeRepr *TyR);

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3571,6 +3571,23 @@ public:
   bool isCached() const { return true; }
 };
 
+/// Given a stored property associated with a type wrapped type,
+/// produce a property that mirrors it in the type wrapper context.
+class GetTypeWrapperStorageForProperty
+    : public SimpleRequest<GetTypeWrapperStorageForProperty,
+                           VarDecl *(VarDecl *), RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  VarDecl *evaluate(Evaluator &evaluator, VarDecl *) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
 void simple_display(llvm::raw_ostream &out, ASTNode node);
 void simple_display(llvm::raw_ostream &out, Type value);
 void simple_display(llvm::raw_ostream &out, const TypeRepr *TyR);

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3639,6 +3639,22 @@ public:
   bool isCached() const { return true; }
 };
 
+class SynthesizeTypeWrapperInitializer
+    : public SimpleRequest<SynthesizeTypeWrapperInitializer,
+                           ConstructorDecl *(NominalTypeDecl *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  ConstructorDecl *evaluate(Evaluator &evaluator, NominalTypeDecl *) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
 void simple_display(llvm::raw_ostream &out, ASTNode node);
 void simple_display(llvm::raw_ostream &out, Type value);
 void simple_display(llvm::raw_ostream &out, const TypeRepr *TyR);

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3655,6 +3655,22 @@ public:
   bool isCached() const { return true; }
 };
 
+class SynthesizeTypeWrapperInitializerBody
+    : public SimpleRequest<SynthesizeTypeWrapperInitializerBody,
+                           BraceStmt *(ConstructorDecl *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  BraceStmt *evaluate(Evaluator &evaluator, ConstructorDecl *) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
 void simple_display(llvm::raw_ostream &out, ASTNode node);
 void simple_display(llvm::raw_ostream &out, Type value);
 void simple_display(llvm::raw_ostream &out, const TypeRepr *TyR);

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3622,6 +3622,23 @@ public:
   bool isCached() const { return true; }
 };
 
+/// Inject or get `$Storage` type which has all of the stored properties
+/// of the given type with a type wrapper.
+class IsPropertyAccessedViaTypeWrapper
+    : public SimpleRequest<IsPropertyAccessedViaTypeWrapper, bool(VarDecl *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  bool evaluate(Evaluator &evaluator, VarDecl *) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
 void simple_display(llvm::raw_ostream &out, ASTNode node);
 void simple_display(llvm::raw_ostream &out, Type value);
 void simple_display(llvm::raw_ostream &out, const TypeRepr *TyR);

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3588,6 +3588,23 @@ public:
   bool isCached() const { return true; }
 };
 
+/// Synthesize the body of a getter for a stored property that belongs to
+/// a type wrapped type.
+class SynthesizeTypeWrappedPropertyGetterBody
+    : public SimpleRequest<SynthesizeTypeWrappedPropertyGetterBody,
+                           BraceStmt *(AccessorDecl *), RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  BraceStmt *evaluate(Evaluator &evaluator, AccessorDecl *) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
 void simple_display(llvm::raw_ostream &out, ASTNode node);
 void simple_display(llvm::raw_ostream &out, Type value);
 void simple_display(llvm::raw_ostream &out, const TypeRepr *TyR);

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3364,6 +3364,10 @@ enum class CustomAttrTypeKind {
   /// unbound generic types.
   PropertyWrapper,
 
+  /// Just like property wrappers, type wrappers are represented
+  /// as custom type attributes and allow unbound generic types.
+  TypeWrapper,
+
   /// Global actors are represented as custom type attributes. They don't
   /// have any particularly interesting semantics.
   GlobalActor,
@@ -3510,6 +3514,23 @@ private:
   friend SimpleRequest;
 
   NominalTypeDecl *evaluate(Evaluator &evaluator, NominalTypeDecl *) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
+/// Return a type of the type wrapper (if any) associated with the given
+/// declaration.
+class GetTypeWrapperType
+    : public SimpleRequest<GetTypeWrapperType, Type(NominalTypeDecl *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  Type evaluate(Evaluator &evaluator, NominalTypeDecl *) const;
 
 public:
   bool isCached() const { return true; }

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3536,6 +3536,24 @@ public:
   bool isCached() const { return true; }
 };
 
+/// Inject or get `$Storage` type which has all of the stored properties
+/// of the given type with a type wrapper.
+class GetTypeWrapperStorage
+    : public SimpleRequest<GetTypeWrapperStorage,
+                           NominalTypeDecl *(NominalTypeDecl *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  NominalTypeDecl *evaluate(Evaluator &evaluator, NominalTypeDecl *) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
 void simple_display(llvm::raw_ostream &out, ASTNode node);
 void simple_display(llvm::raw_ostream &out, Type value);
 void simple_display(llvm::raw_ostream &out, const TypeRepr *TyR);

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3554,6 +3554,23 @@ public:
   bool isCached() const { return true; }
 };
 
+/// Inject or get `$_storage` property which is used to route accesses through
+/// to all stored properties of a type that has a type wrapper.
+class GetTypeWrapperProperty
+    : public SimpleRequest<GetTypeWrapperProperty, VarDecl *(NominalTypeDecl *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  VarDecl *evaluate(Evaluator &evaluator, NominalTypeDecl *) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
 void simple_display(llvm::raw_ostream &out, ASTNode node);
 void simple_display(llvm::raw_ostream &out, Type value);
 void simple_display(llvm::raw_ostream &out, const TypeRepr *TyR);

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3499,6 +3499,22 @@ public:
   bool isCached() const { return true; }
 };
 
+/// Return a type wrapper (if any) associated with the given declaration.
+class GetTypeWrapper
+    : public SimpleRequest<GetTypeWrapper, NominalTypeDecl *(NominalTypeDecl *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  NominalTypeDecl *evaluate(Evaluator &evaluator, NominalTypeDecl *) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
 void simple_display(llvm::raw_ostream &out, ASTNode node);
 void simple_display(llvm::raw_ostream &out, Type value);
 void simple_display(llvm::raw_ostream &out, const TypeRepr *TyR);

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -414,3 +414,6 @@ SWIFT_REQUEST(TypeChecker, GetTypeWrapperProperty,
 SWIFT_REQUEST(TypeChecker, GetTypeWrapperStorageForProperty,
               VarDecl *(VarDecl *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, SynthesizeTypeWrappedPropertyGetterBody,
+              BraceStmt *(AccessorDecl *),
+              Cached, NoLocationInfo)

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -402,3 +402,6 @@ SWIFT_REQUEST(TypeChecker, GetSourceFileAsyncNode,
 SWIFT_REQUEST(TypeChecker, GetTypeWrapper,
               NominalTypeDecl *(NominalTypeDecl *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, GetTypeWrapperType,
+              Type(NominalTypeDecl *),
+              Cached, NoLocationInfo)

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -423,3 +423,6 @@ SWIFT_REQUEST(TypeChecker, SynthesizeTypeWrappedPropertySetterBody,
 SWIFT_REQUEST(TypeChecker, IsPropertyAccessedViaTypeWrapper,
               bool(VarDecl *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, SynthesizeTypeWrapperInitializer,
+              ConstructorDecl *(NominalTypeDecl *),
+              Cached, NoLocationInfo)

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -405,3 +405,6 @@ SWIFT_REQUEST(TypeChecker, GetTypeWrapper,
 SWIFT_REQUEST(TypeChecker, GetTypeWrapperType,
               Type(NominalTypeDecl *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, GetTypeWrapperStorage,
+              NominalTypeDecl *(NominalTypeDecl *),
+              Cached, NoLocationInfo)

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -399,3 +399,6 @@ SWIFT_REQUEST(TypeChecker, ClosureEffectsRequest,
 SWIFT_REQUEST(TypeChecker, GetSourceFileAsyncNode,
               AwaitExpr *(const SourceFile *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, GetTypeWrapper,
+              NominalTypeDecl *(NominalTypeDecl *),
+              Cached, NoLocationInfo)

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -408,3 +408,6 @@ SWIFT_REQUEST(TypeChecker, GetTypeWrapperType,
 SWIFT_REQUEST(TypeChecker, GetTypeWrapperStorage,
               NominalTypeDecl *(NominalTypeDecl *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, GetTypeWrapperProperty,
+              VarDecl *(NominalTypeDecl *),
+              Cached, NoLocationInfo)

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -426,3 +426,6 @@ SWIFT_REQUEST(TypeChecker, IsPropertyAccessedViaTypeWrapper,
 SWIFT_REQUEST(TypeChecker, SynthesizeTypeWrapperInitializer,
               ConstructorDecl *(NominalTypeDecl *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, SynthesizeTypeWrapperInitializerBody,
+              BraceStmt *(ConstructorDecl *),
+              Cached, NoLocationInfo)

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -411,3 +411,6 @@ SWIFT_REQUEST(TypeChecker, GetTypeWrapperStorage,
 SWIFT_REQUEST(TypeChecker, GetTypeWrapperProperty,
               VarDecl *(NominalTypeDecl *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, GetTypeWrapperStorageForProperty,
+              VarDecl *(VarDecl *),
+              Cached, NoLocationInfo)

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -420,3 +420,6 @@ SWIFT_REQUEST(TypeChecker, SynthesizeTypeWrappedPropertyGetterBody,
 SWIFT_REQUEST(TypeChecker, SynthesizeTypeWrappedPropertySetterBody,
               BraceStmt *(AccessorDecl *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, IsPropertyAccessedViaTypeWrapper,
+              bool(VarDecl *),
+              Cached, NoLocationInfo)

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -417,3 +417,6 @@ SWIFT_REQUEST(TypeChecker, GetTypeWrapperStorageForProperty,
 SWIFT_REQUEST(TypeChecker, SynthesizeTypeWrappedPropertyGetterBody,
               BraceStmt *(AccessorDecl *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, SynthesizeTypeWrappedPropertySetterBody,
+              BraceStmt *(AccessorDecl *),
+              Cached, NoLocationInfo)

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -122,6 +122,11 @@ EXPERIMENTAL_FEATURE(SendableCompletionHandlers)
 /// Enables opaque type erasure without also enabling implict dynamic
 EXPERIMENTAL_FEATURE(OpaqueTypeErasure)
 
+/// Whether to enable experimental @typeWrapper feature which allows to
+/// declare a type that controls access to all stored properties of the
+/// wrapped type.
+EXPERIMENTAL_FEATURE(TypeWrappers)
+
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE
 #undef SUPPRESSIBLE_LANGUAGE_FEATURE

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2935,6 +2935,10 @@ static bool usesFeatureSpecializeAttributeWithAvailability(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureTypeWrappers(Decl *decl) {
+  return decl->getAttrs().hasAttribute<TypeWrapperAttr>();
+}
+
 static void suppressingFeatureSpecializeAttributeWithAvailability(
                                         PrintOptions &options,
                                         llvm::function_ref<void()> action) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6733,7 +6733,8 @@ bool VarDecl::hasStorageOrWrapsStorage() const {
 }
 
 void VarDecl::visitAuxiliaryDecls(llvm::function_ref<void(VarDecl *)> visit) const {
-  if (getDeclContext()->isTypeContext() || isImplicit())
+  if (getDeclContext()->isTypeContext() ||
+      (isImplicit() && !isa<ParamDecl>(this)))
     return;
 
   if (getAttrs().hasAttribute<LazyAttr>()) {

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1531,6 +1531,10 @@ void swift::simple_display(llvm::raw_ostream &out, CustomAttrTypeKind value) {
     out << "property-wrapper";
     return;
 
+  case CustomAttrTypeKind::TypeWrapper:
+    out << "type-wrapper";
+    return;
+
   case CustomAttrTypeKind::GlobalActor:
     out << "global-actor";
     return;

--- a/lib/Sema/CMakeLists.txt
+++ b/lib/Sema/CMakeLists.txt
@@ -61,6 +61,7 @@ add_swift_host_library(swiftSema STATIC
   TypeCheckNameLookup.cpp
   TypeCheckPattern.cpp
   TypeCheckPropertyWrapper.cpp
+  TypeCheckTypeWrapper.cpp
   TypeCheckProtocol.cpp
   TypeCheckProtocolInference.cpp
   TypeCheckRegex.cpp

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1113,6 +1113,10 @@ static bool shouldAttemptInitializerSynthesis(const NominalTypeDecl *decl) {
   if (decl->isInvalid())
     return false;
 
+  // Don't attempt if the decl has a type wrapper.
+  if (decl->hasTypeWrapper())
+    return false;
+
   return true;
 }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3587,6 +3587,12 @@ void AttributeChecker::visitPropertyWrapperAttr(PropertyWrapperAttr *attr) {
 }
 
 void AttributeChecker::visitTypeWrapperAttr(TypeWrapperAttr *attr) {
+  if (!Ctx.LangOpts.hasFeature(Feature::TypeWrappers)) {
+    diagnose(attr->getLocation(), diag::type_wrappers_are_experimental);
+    attr->setInvalid();
+    return;
+  }
+
   auto nominal = dyn_cast<NominalTypeDecl>(D);
   if (!nominal)
     return;

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -292,6 +292,7 @@ public:
 
   void visitCustomAttr(CustomAttr *attr);
   void visitPropertyWrapperAttr(PropertyWrapperAttr *attr);
+  void visitTypeWrapperAttr(TypeWrapperAttr *attr);
   void visitResultBuilderAttr(ResultBuilderAttr *attr);
 
   void visitImplementationOnlyAttr(ImplementationOnlyAttr *attr);
@@ -3457,6 +3458,18 @@ void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
     return;
   }
 
+  if (nominal->getAttrs().hasAttribute<TypeWrapperAttr>()) {
+    if (!(isa<ClassDecl>(D) || isa<StructDecl>(D))) {
+      diagnose(attr->getLocation(),
+               diag::type_wrapper_attribute_not_allowed_here,
+               nominal->getName());
+      attr->setInvalid();
+      return;
+    }
+
+    return;
+  }
+
   // If the nominal type is a result builder type, verify that D is a
   // function, storage with an explicit getter, or parameter of function type.
   if (nominal->getAttrs().hasAttribute<ResultBuilderAttr>()) {
@@ -3571,6 +3584,171 @@ void AttributeChecker::visitPropertyWrapperAttr(PropertyWrapperAttr *attr) {
 
   // Force checking of the property wrapper type.
   (void)nominal->getPropertyWrapperTypeInfo();
+}
+
+void AttributeChecker::visitTypeWrapperAttr(TypeWrapperAttr *attr) {
+  auto nominal = dyn_cast<NominalTypeDecl>(D);
+  if (!nominal)
+    return;
+
+  auto &ctx = D->getASTContext();
+
+  auto isLessAccessibleThanType = [&](ValueDecl *decl) {
+    return decl->getFormalAccess() <
+           std::min(nominal->getFormalAccess(), AccessLevel::Public);
+  };
+
+  enum class UnviabilityReason { Failable, InvalidType, Inaccessible };
+
+  auto findMembersOrDiagnose = [&](DeclName memberName,
+                                   SmallVectorImpl<ValueDecl *> &results,
+                                   Diag<DeclName> notFoundDiagnostic) -> bool {
+    nominal->lookupQualified(nominal, DeclNameRef(memberName),
+                             NL_QualifiedDefault, results);
+
+    if (results.empty()) {
+      diagnose(nominal->getLoc(), notFoundDiagnostic, nominal->getName());
+      attr->setInvalid();
+      return true;
+    }
+    return false;
+  };
+
+  // Check whether type marked as @typeWrapper is valid:
+  //
+  // - Has a single generic parameter <Storage>
+  // - Has `init(memberwise: <Storage>)`
+  // - Has at least one `subscript(storedKeyPath: KeyPath<...>)` overload
+
+  // Has a single generic parameter.
+  {
+    auto *genericParams = nominal->getGenericParams();
+    if (!genericParams || genericParams->size() != 1) {
+      diagnose(nominal->getLoc(),
+               diag::type_wrapper_requires_a_single_generic_param);
+      attr->setInvalid();
+      return;
+    }
+  }
+
+  // `init(memberwise:)`
+  {
+    DeclName initName(ctx, DeclBaseName::createConstructor(),
+                      ArrayRef<Identifier>(ctx.getIdentifier("memberwise")));
+
+    SmallVector<ValueDecl *, 2> inits;
+    if (findMembersOrDiagnose(initName, inits,
+                              diag::type_wrapper_requires_memberwise_init))
+      return;
+
+    llvm::SmallDenseMap<ConstructorDecl *, SmallVector<UnviabilityReason, 2>, 2>
+        nonViableInits;
+    for (auto *decl : inits) {
+      auto *init = cast<ConstructorDecl>(decl);
+
+      if (init->isFailable())
+        nonViableInits[init].push_back(UnviabilityReason::Failable);
+
+      if (isLessAccessibleThanType(init))
+        nonViableInits[init].push_back(UnviabilityReason::Inaccessible);
+    }
+
+    // If there are no viable initializers, let's complain.
+    if (inits.size() - nonViableInits.size() == 0) {
+      for (const auto &entry : nonViableInits) {
+        auto *init = entry.first;
+
+        for (auto reason : entry.second) {
+          switch (reason) {
+          case UnviabilityReason::Failable:
+            diagnose(init, diag::type_wrapper_failable_init, init->getName());
+            break;
+
+          case UnviabilityReason::Inaccessible:
+            diagnose(init, diag::type_wrapper_type_requirement_not_accessible,
+                     init->getFormalAccess(), init->getDescriptiveKind(),
+                     init->getName(), nominal->getDeclaredType(),
+                     nominal->getFormalAccess());
+            break;
+
+          case UnviabilityReason::InvalidType:
+            llvm_unreachable("init(memberwise:) type is not checked");
+          }
+        }
+      }
+
+      attr->setInvalid();
+      return;
+    }
+  }
+
+  // subscript(storedKeypath: KeyPath<...>)
+  {
+    DeclName subscriptName(
+        ctx, DeclBaseName::createSubscript(),
+        ArrayRef<Identifier>(ctx.getIdentifier("storageKeyPath")));
+
+    SmallVector<ValueDecl *, 2> subscripts;
+    if (findMembersOrDiagnose(subscriptName, subscripts,
+                              diag::type_wrapper_requires_subscript))
+      return;
+
+    llvm::SmallDenseMap<SubscriptDecl *, SmallVector<UnviabilityReason, 2>, 2>
+        nonViableSubscripts;
+
+    for (auto *decl : subscripts) {
+      auto *subscript = cast<SubscriptDecl>(decl);
+
+      auto *keyPathParam = subscript->getIndices()->get(0);
+
+      if (auto *BGT =
+              keyPathParam->getInterfaceType()->getAs<BoundGenericType>()) {
+        if (!(BGT->isKeyPath() || BGT->isWritableKeyPath() ||
+              BGT->isReferenceWritableKeyPath())) {
+          nonViableSubscripts[subscript].push_back(
+              UnviabilityReason::InvalidType);
+        }
+      } else {
+        nonViableSubscripts[subscript].push_back(
+            UnviabilityReason::InvalidType);
+      }
+
+      if (isLessAccessibleThanType(subscript))
+        nonViableSubscripts[subscript].push_back(
+            UnviabilityReason::Inaccessible);
+    }
+
+    if (subscripts.size() - nonViableSubscripts.size() == 0) {
+      for (const auto &entry : nonViableSubscripts) {
+        auto *subscript = entry.first;
+
+        for (auto reason : entry.second) {
+          switch (reason) {
+          case UnviabilityReason::InvalidType: {
+            auto paramTy = subscript->getIndices()->get(0)->getInterfaceType();
+            diagnose(subscript, diag::type_wrapper_invalid_subscript_param_type,
+                     paramTy);
+            break;
+          }
+
+          case UnviabilityReason::Inaccessible:
+            diagnose(subscript,
+                     diag::type_wrapper_type_requirement_not_accessible,
+                     subscript->getFormalAccess(),
+                     subscript->getDescriptiveKind(), subscript->getName(),
+                     nominal->getDeclaredType(), nominal->getFormalAccess());
+            break;
+
+          case UnviabilityReason::Failable:
+            llvm_unreachable("subscripts cannot be failable");
+          }
+        }
+      }
+
+      attr->setInvalid();
+      return;
+    }
+  }
 }
 
 void AttributeChecker::visitResultBuilderAttr(ResultBuilderAttr *attr) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3634,7 +3634,7 @@ void AttributeChecker::visitTypeWrapperAttr(TypeWrapperAttr *attr) {
   // `init(memberwise:)`
   {
     DeclName initName(ctx, DeclBaseName::createConstructor(),
-                      ArrayRef<Identifier>(ctx.getIdentifier("memberwise")));
+                      ArrayRef<Identifier>(ctx.Id_memberwise));
 
     SmallVector<ValueDecl *, 2> inits;
     if (findMembersOrDiagnose(initName, inits,

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1584,6 +1584,7 @@ namespace  {
     UNINTERESTING_ATTR(ImplementationOnly)
     UNINTERESTING_ATTR(Custom)
     UNINTERESTING_ATTR(PropertyWrapper)
+    UNINTERESTING_ATTR(TypeWrapper)
     UNINTERESTING_ATTR(DisfavoredOverload)
     UNINTERESTING_ATTR(ResultBuilder)
     UNINTERESTING_ATTR(ProjectedValueProperty)

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -103,6 +103,11 @@ static bool hasStoredProperties(NominalTypeDecl *decl) {
 }
 
 static void computeLoweredStoredProperties(NominalTypeDecl *decl) {
+  // If declaration has a type wrapper, make sure that
+  // `$_storage` property is synthesized.
+  if (decl->hasTypeWrapper())
+    (void)decl->getTypeWrapperProperty();
+
   // Just walk over the members of the type, forcing backing storage
   // for lazy properties, property and type wrappers to be synthesized.
   for (auto *member : decl->getMembers()) {

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -3277,6 +3277,8 @@ static void finishStorageImplInfo(AbstractStorageDecl *storage,
       finishNSManagedImplInfo(var, info);
     } else if (var->hasAttachedPropertyWrapper()) {
       finishPropertyWrapperImplInfo(var, info);
+    } else if (var->isAccessedViaTypeWrapper()) {
+      info = StorageImplInfo::getMutableComputed();
     }
   }
 

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2475,6 +2475,12 @@ IsAccessorTransparentRequest::evaluate(Evaluator &evaluator,
 
   switch (accessor->getAccessorKind()) {
   case AccessorKind::Get:
+    // Synthesized getter for a type wrapped variable is never transparent.
+    if (auto var = dyn_cast<VarDecl>(storage)) {
+      if (var->isAccessedViaTypeWrapper())
+        return false;
+    }
+
     break;
 
   case AccessorKind::Set:
@@ -2493,6 +2499,10 @@ IsAccessorTransparentRequest::evaluate(Evaluator &evaluator,
                      PropertyWrapperSynthesizedPropertyKind::Projection)) {
           break;
         }
+
+        // Synthesized setter for a type wrapped variable is never transparent.
+        if (var->isAccessedViaTypeWrapper())
+          return false;
       }
 
       if (auto subscript = dyn_cast<SubscriptDecl>(storage)) {

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -104,7 +104,7 @@ static bool hasStoredProperties(NominalTypeDecl *decl) {
 
 static void computeLoweredStoredProperties(NominalTypeDecl *decl) {
   // Just walk over the members of the type, forcing backing storage
-  // for lazy properties and property wrappers to be synthesized.
+  // for lazy properties, property and type wrappers to be synthesized.
   for (auto *member : decl->getMembers()) {
     auto *var = dyn_cast<VarDecl>(member);
     if (!var || var->isStatic())
@@ -116,6 +116,10 @@ static void computeLoweredStoredProperties(NominalTypeDecl *decl) {
     if (var->hasAttachedPropertyWrapper()) {
       (void) var->getPropertyWrapperAuxiliaryVariables();
       (void) var->getPropertyWrapperInitializerInfo();
+    }
+
+    if (var->isAccessedViaTypeWrapper()) {
+      (void)var->getUnderlyingTypeWrapperStorage();
     }
   }
 

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -923,7 +923,9 @@ static Expr *buildStorageReference(AccessorDecl *accessor,
         underlyingVars.push_back({ wrappedValue, isWrapperRefLValue });
       }
     }
-    semantics = AccessSemantics::DirectToStorage;
+    semantics = backing->isAccessedViaTypeWrapper()
+                    ? AccessSemantics::DirectToImplementation
+                    : AccessSemantics::DirectToStorage;
     selfAccessKind = SelfAccessorKind::Peer;
     break;
   }
@@ -952,7 +954,9 @@ static Expr *buildStorageReference(AccessorDecl *accessor,
         { var->getAttachedPropertyWrapperTypeInfo(0).projectedValueVar,
           isLValue });
     }
-    semantics = AccessSemantics::DirectToStorage;
+    semantics = backing->isAccessedViaTypeWrapper()
+                    ? AccessSemantics::DirectToImplementation
+                    : AccessSemantics::DirectToStorage;
     selfAccessKind = SelfAccessorKind::Peer;
     break;
   }

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2981,7 +2981,8 @@ PropertyWrapperAuxiliaryVariablesRequest::evaluate(Evaluator &evaluator,
 PropertyWrapperInitializerInfo
 PropertyWrapperInitializerInfoRequest::evaluate(Evaluator &evaluator,
                                                 VarDecl *var) const {
-  if (!var->hasAttachedPropertyWrapper() || var->isImplicit())
+  if (!var->hasAttachedPropertyWrapper() ||
+      (var->isImplicit() && !isa<ParamDecl>(var)))
     return PropertyWrapperInitializerInfo();
 
   auto wrapperInfo = var->getAttachedPropertyWrapperTypeInfo(0);

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4706,7 +4706,8 @@ Type CustomAttrTypeRequest::evaluate(Evaluator &eval, CustomAttr *attr,
 
   OpenUnboundGenericTypeFn unboundTyOpener = nullptr;
   // Property delegates allow their type to be an unbound generic.
-  if (typeKind == CustomAttrTypeKind::PropertyWrapper) {
+  if (typeKind == CustomAttrTypeKind::PropertyWrapper ||
+      typeKind == CustomAttrTypeKind::TypeWrapper) {
     unboundTyOpener = [](auto unboundTy) {
       // FIXME: Don't let unbound generic types
       // escape type resolution. For now, just

--- a/lib/Sema/TypeCheckTypeWrapper.cpp
+++ b/lib/Sema/TypeCheckTypeWrapper.cpp
@@ -1,0 +1,62 @@
+//===--- TypeCheckTypeWrapper.cpp - type wrappers -------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements semantic analysis for type wrappers.
+//
+//===----------------------------------------------------------------------===//
+#include "TypeChecker.h"
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/Decl.h"
+#include "swift/AST/NameLookupRequests.h"
+#include "swift/AST/TypeCheckRequests.h"
+#include "swift/Basic/LLVM.h"
+#include "swift/Basic/SourceLoc.h"
+
+using namespace swift;
+
+NominalTypeDecl *NominalTypeDecl::getTypeWrapper() const {
+  auto *mutableSelf = const_cast<NominalTypeDecl *>(this);
+  return evaluateOrDefault(getASTContext().evaluator,
+                           GetTypeWrapper{mutableSelf}, nullptr);
+}
+
+NominalTypeDecl *GetTypeWrapper::evaluate(Evaluator &evaluator,
+                                          NominalTypeDecl *decl) const {
+  auto &ctx = decl->getASTContext();
+
+  // Note that we don't actually care whether there are duplicates,
+  // using the same type wrapper multiple times is still an error.
+  SmallVector<NominalTypeDecl *, 2> typeWrappers;
+
+  for (auto *attr : decl->getAttrs().getAttributes<CustomAttr>()) {
+    auto *mutableAttr = const_cast<CustomAttr *>(attr);
+    auto *nominal = evaluateOrDefault(
+        ctx.evaluator, CustomAttrNominalRequest{mutableAttr, decl}, nullptr);
+
+    if (!nominal)
+      continue;
+
+    auto *typeWrapper = nominal->getAttrs().getAttribute<TypeWrapperAttr>();
+    if (typeWrapper && typeWrapper->isValid())
+      typeWrappers.push_back(nominal);
+  }
+
+  if (typeWrappers.empty())
+    return nullptr;
+
+  if (typeWrappers.size() != 1) {
+    ctx.Diags.diagnose(decl, diag::cannot_use_multiple_type_wrappers);
+    return nullptr;
+  }
+
+  return typeWrappers.front();
+}

--- a/lib/Sema/TypeCheckTypeWrapper.cpp
+++ b/lib/Sema/TypeCheckTypeWrapper.cpp
@@ -128,6 +128,13 @@ Type GetTypeWrapperType::evaluate(Evaluator &evaluator,
   return type;
 }
 
+ConstructorDecl *NominalTypeDecl::getTypeWrapperInitializer() const {
+  auto *mutableSelf = const_cast<NominalTypeDecl *>(this);
+  return evaluateOrDefault(getASTContext().evaluator,
+                           SynthesizeTypeWrapperInitializer{mutableSelf},
+                           nullptr);
+}
+
 NominalTypeDecl *
 GetTypeWrapperStorage::evaluate(Evaluator &evaluator,
                                 NominalTypeDecl *parent) const {

--- a/lib/Sema/TypeCheckTypeWrapper.cpp
+++ b/lib/Sema/TypeCheckTypeWrapper.cpp
@@ -164,7 +164,7 @@ GetTypeWrapperStorage::evaluate(Evaluator &evaluator,
 
   storage->setImplicit();
   storage->setSynthesized();
-  storage->copyFormalAccessFrom(parent, /*sourceIsParentContext=*/true);
+  storage->setAccess(AccessLevel::Internal);
 
   parent->addMember(storage);
 

--- a/lib/Sema/TypeCheckTypeWrapper.cpp
+++ b/lib/Sema/TypeCheckTypeWrapper.cpp
@@ -135,6 +135,12 @@ Type GetTypeWrapperType::evaluate(Evaluator &evaluator,
   return type;
 }
 
+VarDecl *NominalTypeDecl::getTypeWrapperProperty() const {
+  auto *mutableSelf = const_cast<NominalTypeDecl *>(this);
+  return evaluateOrDefault(getASTContext().evaluator,
+                           GetTypeWrapperProperty{mutableSelf}, nullptr);
+}
+
 ConstructorDecl *NominalTypeDecl::getTypeWrapperInitializer() const {
   auto *mutableSelf = const_cast<NominalTypeDecl *>(this);
   return evaluateOrDefault(getASTContext().evaluator,
@@ -222,8 +228,7 @@ static SubscriptExpr *subscriptTypeWrappedProperty(VarDecl *var,
   if (!(parent && parent->hasTypeWrapper()))
     return nullptr;
 
-  auto *typeWrapperVar =
-      evaluateOrDefault(ctx.evaluator, GetTypeWrapperProperty{parent}, nullptr);
+  auto *typeWrapperVar = parent->getTypeWrapperProperty();
   auto *storageVar = var->getUnderlyingTypeWrapperStorage();
 
   assert(typeWrapperVar);

--- a/lib/Sema/TypeCheckTypeWrapper.cpp
+++ b/lib/Sema/TypeCheckTypeWrapper.cpp
@@ -60,6 +60,13 @@ bool VarDecl::isAccessedViaTypeWrapper() const {
                            false);
 }
 
+VarDecl *VarDecl::getUnderlyingTypeWrapperStorage() const {
+  auto *mutableSelf = const_cast<VarDecl *>(this);
+  return evaluateOrDefault(getASTContext().evaluator,
+                           GetTypeWrapperStorageForProperty{mutableSelf},
+                           nullptr);
+}
+
 NominalTypeDecl *NominalTypeDecl::getTypeWrapper() const {
   auto *mutableSelf = const_cast<NominalTypeDecl *>(this);
   return evaluateOrDefault(getASTContext().evaluator,
@@ -217,8 +224,7 @@ static SubscriptExpr *subscriptTypeWrappedProperty(VarDecl *var,
 
   auto *typeWrapperVar =
       evaluateOrDefault(ctx.evaluator, GetTypeWrapperProperty{parent}, nullptr);
-  auto *storageVar = evaluateOrDefault(
-      ctx.evaluator, GetTypeWrapperStorageForProperty{var}, nullptr);
+  auto *storageVar = var->getUnderlyingTypeWrapperStorage();
 
   assert(typeWrapperVar);
   assert(storageVar);

--- a/lib/Sema/TypeCheckTypeWrapper.cpp
+++ b/lib/Sema/TypeCheckTypeWrapper.cpp
@@ -90,3 +90,26 @@ Type GetTypeWrapperType::evaluate(Evaluator &evaluator,
   }
   return type;
 }
+
+NominalTypeDecl *
+GetTypeWrapperStorage::evaluate(Evaluator &evaluator,
+                                NominalTypeDecl *parent) const {
+  if (!parent->hasTypeWrapper())
+    return nullptr;
+
+  auto &ctx = parent->getASTContext();
+
+  auto *storage =
+      new (ctx) StructDecl(/*StructLoc=*/SourceLoc(), ctx.Id_TypeWrapperStorage,
+                           /*NameLoc=*/SourceLoc(),
+                           /*Inheritted=*/{},
+                           /*GenericParams=*/nullptr, parent);
+
+  storage->setImplicit();
+  storage->setSynthesized();
+  storage->copyFormalAccessFrom(parent, /*sourceIsParentContext=*/true);
+
+  parent->addMember(storage);
+
+  return storage;
+}

--- a/lib/Sema/TypeCheckTypeWrapper.cpp
+++ b/lib/Sema/TypeCheckTypeWrapper.cpp
@@ -389,8 +389,18 @@ SynthesizeTypeWrapperInitializerBody::evaluate(Evaluator &evaluator,
   SmallVector<Argument, 4> arguments;
   {
     for (auto *param : *ctor->getParameters()) {
-      arguments.push_back({/*labelLoc=*/SourceLoc(), param->getName(),
-                           new (ctx) DeclRefExpr(param, /*Loc=*/DeclNameLoc(),
+      VarDecl *arg = param;
+
+      // type wrappers wrap only backing storage of a wrapped
+      // property, so in this case we need to pass `_<name>` to
+      // `$Storage` constructor.
+      if (param->hasAttachedPropertyWrapper()) {
+        arg = param->getPropertyWrapperBackingProperty();
+        (void)param->getPropertyWrapperBackingPropertyType();
+      }
+
+      arguments.push_back({/*labelLoc=*/SourceLoc(), arg->getName(),
+                           new (ctx) DeclRefExpr(arg, /*Loc=*/DeclNameLoc(),
                                                  /*Implicit=*/true)});
     }
   }

--- a/lib/Sema/TypeCheckTypeWrapper.cpp
+++ b/lib/Sema/TypeCheckTypeWrapper.cpp
@@ -28,6 +28,7 @@ using namespace swift;
 /// Create a property declaration and inject it into the given type.
 static VarDecl *injectProperty(NominalTypeDecl *parent, Identifier name,
                                Type type, VarDecl::Introducer introducer,
+                               AccessLevel accessLevel,
                                Expr *initializer = nullptr) {
   auto &ctx = parent->getASTContext();
 
@@ -36,7 +37,7 @@ static VarDecl *injectProperty(NominalTypeDecl *parent, Identifier name,
 
   var->setImplicit();
   var->setSynthesized();
-  var->copyFormalAccessFrom(parent, /*sourceIsParentContext=*/true);
+  var->setAccess(accessLevel);
   var->setInterfaceType(type);
 
   Pattern *pattern = NamedPattern::createImplicit(ctx, var);
@@ -193,8 +194,8 @@ GetTypeWrapperProperty::evaluate(Evaluator &evaluator,
       typeWrapper, /*Parent=*/typeWrapperType->getParent(),
       /*genericArgs=*/{storage->getInterfaceType()->getMetatypeInstanceType()});
 
-  return injectProperty(parent, ctx.Id_TypeWrapperProperty,
-                        propertyTy, VarDecl::Introducer::Var);
+  return injectProperty(parent, ctx.Id_TypeWrapperProperty, propertyTy,
+                        VarDecl::Introducer::Var, AccessLevel::Private);
 }
 
 VarDecl *GetTypeWrapperStorageForProperty::evaluate(Evaluator &evaluator,
@@ -215,7 +216,7 @@ VarDecl *GetTypeWrapperStorageForProperty::evaluate(Evaluator &evaluator,
 
   return injectProperty(storage, property->getName(),
                         property->getValueInterfaceType(),
-                        property->getIntroducer());
+                        property->getIntroducer(), AccessLevel::Internal);
 }
 
 /// Given the property create a subscript to reach its type wrapper storage:

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 706; // @_expose attribute
+const uint16_t SWIFTMODULE_VERSION_MINOR = 707; // @typeWrapper attribute
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -117,6 +117,7 @@ actor MyGlobalActor {
 // KEYWORD3-NEXT:             Keyword/None:                       resultBuilder[#Class Attribute#]; name=resultBuilder
 // KEYWORD3-NEXT:             Keyword/None:                       globalActor[#Class Attribute#]; name=globalActor
 // KEYWORD3-NEXT:             Keyword/None:                       preconcurrency[#Class Attribute#]; name=preconcurrency
+// KEYWORD3-NEXT:             Keyword/None:                       typeWrapper[#Class Attribute#]; name=typeWrapper
 // KEYWORD3-NEXT:             End completions
 
 @#^KEYWORD3_2^#IB class C2 {}
@@ -135,6 +136,7 @@ actor MyGlobalActor {
 // KEYWORD4-NEXT:             Keyword/None:                       resultBuilder[#Enum Attribute#]; name=resultBuilder
 // KEYWORD4-NEXT:             Keyword/None:                       globalActor[#Enum Attribute#]; name=globalActor
 // KEYWORD4-NEXT:             Keyword/None:                       preconcurrency[#Enum Attribute#]; name=preconcurrency
+// KEYWORD4-NEXT:             Keyword/None:                       typeWrapper[#Enum Attribute#]; name=typeWrapper
 // KEYWORD4-NEXT:             End completions
 
 
@@ -150,6 +152,7 @@ actor MyGlobalActor {
 // KEYWORD5-NEXT:             Keyword/None:                       resultBuilder[#Struct Attribute#]; name=resultBuilder
 // KEYWORD5-NEXT:             Keyword/None:                       globalActor[#Struct Attribute#]; name=globalActor
 // KEYWORD5-NEXT:             Keyword/None:                       preconcurrency[#Struct Attribute#]; name=preconcurrency
+// KEYWORD5-NEXT:             Keyword/None:                       typeWrapper[#Struct Attribute#]; name=typeWrapper
 // KEYWORD5-NEXT:             End completions
 
 @#^ON_GLOBALVAR^# var globalVar
@@ -305,6 +308,7 @@ struct _S {
 // ON_MEMBER_LAST-DAG: Keyword/None:                       Sendable[#Declaration Attribute#]; name=Sendable
 // ON_MEMBER_LAST-DAG: Keyword/None:                       exclusivity[#Declaration Attribute#]; name=exclusivity
 // ON_MEMBER_LAST-DAG: Keyword/None:                       preconcurrency[#Declaration Attribute#]; name=preconcurrency
+// ON_MEMBER_LAST-DAG: Keyword/None:                       typeWrapper[#Declaration Attribute#]; name=typeWrapper
 // ON_MEMBER_LAST-NOT: Keyword
 // ON_MEMBER_LAST-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // ON_MEMBER_LAST-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyPropertyWrapper[#MyPropertyWrapper#]; name=MyPropertyWrapper
@@ -374,6 +378,7 @@ func dummy2() {}
 // KEYWORD_LAST-DAG: Keyword/None:                       Sendable[#Declaration Attribute#]; name=Sendable
 // KEYWORD_LAST-DAG: Keyword/None:                       exclusivity[#Declaration Attribute#]; name=exclusivity
 // KEYWORD_LAST-DAG: Keyword/None:                       preconcurrency[#Declaration Attribute#]; name=preconcurrency
+// KEYWORD_LAST-DAG: Keyword/None:                       typeWrapper[#Declaration Attribute#]; name=typeWrapper
 // KEYWORD_LAST-NOT: Keyword
 // KEYWORD_LAST-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // KEYWORD_LAST-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyPropertyWrapper[#MyPropertyWrapper#]; name=MyPropertyWrapper

--- a/test/Interpreter/Inputs/type_wrapper_defs.swift
+++ b/test/Interpreter/Inputs/type_wrapper_defs.swift
@@ -121,3 +121,18 @@ public struct ComplexPropWrapperTest {
   @PropWrapper public var a: [String] = ["a"]
   @PropWrapperWithoutInit(value: PropWrapper(wrappedValue: [1, 2, 3])) @PropWrapper public var b: [Int]
 }
+
+@Wrapper
+public struct PersonWithUnmanagedTest {
+  public let name: String
+
+  public lazy var age: Int = {
+    30
+  }()
+
+  public var placeOfBirth: String {
+    get { "Earth" }
+  }
+
+  @PropWrapper public var favoredColor: String = "red"
+}

--- a/test/Interpreter/Inputs/type_wrapper_defs.swift
+++ b/test/Interpreter/Inputs/type_wrapper_defs.swift
@@ -24,3 +24,9 @@ public class Person<T> {
   public var name: String
   public var projects: [T]
 }
+
+@Wrapper
+public struct PersonWithDefaults {
+  public var name: String = "<no name>"
+  public var age: Int = 99
+}

--- a/test/Interpreter/Inputs/type_wrapper_defs.swift
+++ b/test/Interpreter/Inputs/type_wrapper_defs.swift
@@ -19,6 +19,64 @@ public struct Wrapper<S> {
   }
 }
 
+@propertyWrapper
+public struct PropWrapper<Value> {
+  public var value: Value
+
+  public init(wrappedValue: Value) {
+    self.value = wrappedValue
+  }
+
+  public var projectedValue: Self { return self }
+
+  public var wrappedValue: Value {
+    get {
+      self.value
+    }
+    set {
+      self.value = newValue
+    }
+  }
+}
+
+@propertyWrapper
+public struct PropWrapperWithoutInit<Value> {
+  public var value: Value
+
+  public init(value: Value) {
+    self.value = value
+  }
+
+  public var projectedValue: Self { return self }
+
+  public var wrappedValue: Value {
+    get {
+      self.value
+    }
+    set {
+      self.value = newValue
+    }
+  }
+}
+
+@propertyWrapper
+public struct PropWrapperWithoutProjection<Value> {
+  public var value: Value
+
+  public init(wrappedValue: Value) {
+    self.value = wrappedValue
+  }
+
+  public var wrappedValue: Value {
+    get {
+      self.value
+    }
+    set {
+      self.value = newValue
+    }
+  }
+}
+
 @Wrapper
 public class Person<T> {
   public var name: String
@@ -29,4 +87,37 @@ public class Person<T> {
 public struct PersonWithDefaults {
   public var name: String = "<no name>"
   public var age: Int = 99
+}
+
+@Wrapper
+public struct PropWrapperTest {
+  @PropWrapper public var test: Int
+}
+
+@Wrapper
+public struct DefaultedPropWrapperTest {
+  @PropWrapper public var test: Int = 0
+}
+
+@Wrapper
+public struct DefaultedPropWrapperWithArgTest {
+  @PropWrapper(wrappedValue: 3) public var test: Int
+}
+
+@Wrapper
+public struct PropWrapperNoInitTest {
+  @PropWrapperWithoutInit public var a: Int
+  @PropWrapperWithoutInit(value: "b") public var b: String
+}
+
+@Wrapper
+public struct PropWrapperNoProjectionTest {
+  @PropWrapperWithoutProjection public var a: Int = 0
+  @PropWrapperWithoutProjection(wrappedValue: PropWrapper(wrappedValue: "b")) @PropWrapper public var b: String
+}
+
+@Wrapper
+public struct ComplexPropWrapperTest {
+  @PropWrapper public var a: [String] = ["a"]
+  @PropWrapperWithoutInit(value: PropWrapper(wrappedValue: [1, 2, 3])) @PropWrapper public var b: [Int]
 }

--- a/test/Interpreter/Inputs/type_wrapper_defs.swift
+++ b/test/Interpreter/Inputs/type_wrapper_defs.swift
@@ -1,0 +1,26 @@
+@typeWrapper
+public struct Wrapper<S> {
+  var underlying: S
+
+  public init(memberwise: S) {
+    print("Wrapper.init(\(memberwise))")
+    self.underlying = memberwise
+  }
+
+  public subscript<V>(storageKeyPath path: WritableKeyPath<S, V>) -> V {
+    get {
+      print("in getter")
+      return underlying[keyPath: path]
+    }
+    set {
+      print("in setter => \(newValue)")
+      underlying[keyPath: path] = newValue
+    }
+  }
+}
+
+@Wrapper
+public class Person<T> {
+  public var name: String
+  public var projects: [T]
+}

--- a/test/Interpreter/type_wrappers.swift
+++ b/test/Interpreter/type_wrappers.swift
@@ -349,3 +349,29 @@ func testPropertyWrappers() {
 }
 
 testPropertyWrappers()
+
+do {
+  var person = PersonWithUnmanagedTest(name: "Arthur Dent")
+  // CHECK: Wrapper.init($Storage(_favoredColor: type_wrapper_defs.PropWrapper<Swift.String>(value: "red")))
+
+  print(person.name)
+  // CHECK: Arthur Dent
+
+  print(person.age)
+  // CHECK: 30
+
+  print(person.placeOfBirth)
+  // CHECK: Earth
+
+  print(person.favoredColor)
+  // CHECK: in getter
+  // CHECK-NEXT: red
+
+  person.favoredColor = "yellow"
+  // CHECK: in getter
+  // CHECK-NEXT: in setter => PropWrapper<String>(value: "yellow")
+
+  print(person.favoredColor)
+  // CHECK: in getter
+  // CHECK-NEXT: yellow
+}

--- a/test/Interpreter/type_wrappers.swift
+++ b/test/Interpreter/type_wrappers.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -parse-as-library -emit-library -emit-module-path %t/type_wrapper_defs.swiftmodule -module-name type_wrapper_defs %S/Inputs/type_wrapper_defs.swift -o %t/%target-library-name(type_wrapper_defs)
+// RUN: %target-build-swift -enable-experimental-feature TypeWrappers -parse-as-library -emit-library -emit-module-path %t/type_wrapper_defs.swiftmodule -module-name type_wrapper_defs %S/Inputs/type_wrapper_defs.swift -o %t/%target-library-name(type_wrapper_defs)
 // RUN: %target-build-swift -ltype_wrapper_defs -module-name main -I %t -L %t %s -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 

--- a/test/Interpreter/type_wrappers.swift
+++ b/test/Interpreter/type_wrappers.swift
@@ -37,3 +37,48 @@ print(p.name)
 print(p.projects)
 // CHECK: in getter
 // CHECK-NEXT: ["A", "B", "C", "D"]
+
+var pDefaults = PersonWithDefaults()
+// CHECK: Wrapper.init($Storage(name: "<no name>", age: 99))
+
+print(pDefaults.name)
+// CHECK: in getter
+// CHECK: <no name>
+
+print(pDefaults.age)
+// CHECK: in getter
+// CHECK: 99
+
+pDefaults.name = "Actual Name"
+// CHECK-NEXT: in setter => Actual Name
+
+pDefaults.age = 0
+// CHECK-NEXT: in setter => 0
+
+print(pDefaults.name)
+// CHECK: in getter
+// CHECK: Actual Name
+
+print(pDefaults.age)
+// CHECK: in getter
+// CHECK: 0
+
+let pDefaultsAge = PersonWithDefaults(name: "Actual Name")
+
+print(pDefaultsAge.name)
+// CHECK: in getter
+// CHECK: Actual Name
+
+print(pDefaultsAge.age)
+// CHECK: in getter
+// CHECK: 99
+
+let pDefaultsName = PersonWithDefaults(age: 31337)
+
+print(pDefaultsName.name)
+// CHECK: in getter
+// CHECK: <no name>
+
+print(pDefaultsName.age)
+// CHECK: in getter
+// CHECK: 31337

--- a/test/Interpreter/type_wrappers.swift
+++ b/test/Interpreter/type_wrappers.swift
@@ -1,0 +1,39 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -parse-as-library -emit-library -emit-module-path %t/type_wrapper_defs.swiftmodule -module-name type_wrapper_defs %S/Inputs/type_wrapper_defs.swift -o %t/%target-library-name(type_wrapper_defs)
+// RUN: %target-build-swift -ltype_wrapper_defs -module-name main -I %t -L %t %s -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+import type_wrapper_defs
+
+var p: Person<String> = .init(name: "P", projects: ["A", "B"])
+// CHECK: Wrapper.init($Storage(name: "P", projects: ["A", "B"]))
+
+print(p.name)
+// CHECK: in getter
+// CHECK-NEXT: P
+print(p.projects)
+// CHECK: in getter
+// CHECK-NEXT: ["A", "B"]
+
+p.name = "OtherP"
+// CHECK: in setter => OtherP
+p.projects.append("C")
+// CHECK: in getter
+// CHECK-NEXT: in setter => ["A", "B", "C"]
+
+
+func addProjects<T>(p: inout Person<T>, _ newProjects: [T]) {
+  p.projects.append(contentsOf: newProjects)
+}
+
+addProjects(p: &p, ["D"])
+// CHECK: in getter
+// CHECK: in setter => ["A", "B", "C", "D"]
+
+print(p.name)
+// CHECK: in getter
+// CHECK-NEXT: OtherP
+
+print(p.projects)
+// CHECK: in getter
+// CHECK-NEXT: ["A", "B", "C", "D"]

--- a/test/Interpreter/type_wrappers.swift
+++ b/test/Interpreter/type_wrappers.swift
@@ -1,7 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -enable-experimental-feature TypeWrappers -parse-as-library -emit-library -emit-module-path %t/type_wrapper_defs.swiftmodule -module-name type_wrapper_defs %S/Inputs/type_wrapper_defs.swift -o %t/%target-library-name(type_wrapper_defs)
-// RUN: %target-build-swift -ltype_wrapper_defs -module-name main -I %t -L %t %s -o %t/a.out
-// RUN: %target-run %t/a.out | %FileCheck %s
+// RUN: %target-build-swift -ltype_wrapper_defs -module-name main -I %t -L %t %s -o %t/main %target-rpath(%t)
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main %t/%target-library-name(type_wrapper_defs) | %FileCheck %s
+
+// REQUIRES: executable_test
 
 import type_wrapper_defs
 

--- a/test/Interpreter/type_wrappers.swift
+++ b/test/Interpreter/type_wrappers.swift
@@ -82,3 +82,267 @@ print(pDefaultsName.name)
 print(pDefaultsName.age)
 // CHECK: in getter
 // CHECK: 31337
+
+func testPropertyWrappers() {
+  var wrapped1 = PropWrapperTest(test: 42)
+  // CHECK: Wrapper.init($Storage(_test: type_wrapper_defs.PropWrapper<Swift.Int>(value: 42)))
+  do {
+    print(wrapped1.test)
+    // CHECK: in getter
+    // CHECK-NEXT: 42
+
+    wrapped1.test = 0
+    // CHECK: in getter
+    // CHECK-NEXT: in setter => PropWrapper<Int>(value: 0)
+
+    print(wrapped1.test)
+    // CHECK: in getter
+    // CHECK-NEXT: 0
+  }
+
+  var wrapped2 = DefaultedPropWrapperTest()
+  // CHECK: Wrapper.init($Storage(_test: type_wrapper_defs.PropWrapper<Swift.Int>(value: 0)))
+  do {
+    print(wrapped2.test)
+    // CHECK: in getter
+    // CHECK-NEXT: 0
+
+    wrapped2.test = 42
+    // CHECK: in getter
+    // CHECK-NEXT: in setter => PropWrapper<Int>(value: 42)
+
+    print(wrapped2.test)
+    // CHECK: in getter
+    // CHECK-NEXT: 42
+  }
+
+  var wrapped3 = DefaultedPropWrapperTest(test: 1)
+  // CHECK: Wrapper.init($Storage(_test: type_wrapper_defs.PropWrapper<Swift.Int>(value: 1)))
+  do {
+    print(wrapped3.test)
+    // CHECK: in getter
+    // CHECK-NEXT: 1
+
+    wrapped3.test = 31337
+    // CHECK: in getter
+    // CHECK-NEXT: in setter => PropWrapper<Int>(value: 31337)
+
+    print(wrapped3.test)
+    // CHECK: in getter
+    // CHECK-NEXT: 31337
+  }
+
+  var wrapped4 = DefaultedPropWrapperWithArgTest()
+  // CHECK: Wrapper.init($Storage(_test: type_wrapper_defs.PropWrapper<Swift.Int>(value: 3)))
+  do {
+    print(wrapped4.test)
+    // CHECK: in getter
+    // CHECK-NEXT: 3
+
+    wrapped4.test = 0
+    // CHECK: in getter
+    // CHECK-NEXT: in setter => PropWrapper<Int>(value: 0)
+
+    print(wrapped4.test)
+    // CHECK: in getter
+    // CHECK-NEXT: 0
+  }
+
+  var wrapped5 = PropWrapperNoInitTest(a: PropWrapperWithoutInit(value: 1))
+  // CHECK: Wrapper.init($Storage(_a: type_wrapper_defs.PropWrapperWithoutInit<Swift.Int>(value: 1), _b: type_wrapper_defs.PropWrapperWithoutInit<Swift.String>(value: "b")))
+  do {
+    print(wrapped5.a)
+    // CHECK: in getter
+    // CHECK-NEXT: 1
+
+    print(wrapped5.b)
+    // CHECK: in getter
+    // CHECK-NEXT: b
+
+    wrapped5.a = 42
+    // CHECK: in getter
+    // CHECK-NEXT: in setter => PropWrapperWithoutInit<Int>(value: 42)
+
+    wrapped5.b = "not b"
+    // CHECK: in getter
+    // CHECK-NEXT: in setter => PropWrapperWithoutInit<String>(value: "not b")
+
+    print(wrapped5.a)
+    // CHECK: in getter
+    // CHECK-NEXT: 42
+
+    print(wrapped5.b)
+    // CHECK: in getter
+    // CHECK-NEXT: not b
+  }
+
+  var wrapped6 = PropWrapperNoInitTest(a: PropWrapperWithoutInit(value: 1), b: PropWrapperWithoutInit(value: "hello"))
+  // CHECK: Wrapper.init($Storage(_a: type_wrapper_defs.PropWrapperWithoutInit<Swift.Int>(value: 1), _b: type_wrapper_defs.PropWrapperWithoutInit<Swift.String>(value: "hello")))
+  do {
+    print(wrapped6.a)
+    // CHECK: in getter
+    // CHECK-NEXT: 1
+
+    print(wrapped6.b)
+    // CHECK: in getter
+    // CHECK-NEXT: hello
+
+    wrapped6.a = 42
+    // CHECK: in getter
+    // CHECK-NEXT: in setter => PropWrapperWithoutInit<Int>(value: 42)
+
+    wrapped6.b = "b"
+    // CHECK: in getter
+    // CHECK-NEXT: in setter => PropWrapperWithoutInit<String>(value: "b")
+
+    print(wrapped6.a)
+    // CHECK: in getter
+    // CHECK-NEXT: 42
+
+    print(wrapped6.b)
+    // CHECK: in getter
+    // CHECK-NEXT: b
+  }
+
+  var wrapped7 = ComplexPropWrapperTest()
+  // CHECK: Wrapper.init($Storage(_a: type_wrapper_defs.PropWrapper<Swift.Array<Swift.String>>(value: ["a"]), _b: type_wrapper_defs.PropWrapperWithoutInit<type_wrapper_defs.PropWrapper<Swift.Array<Swift.Int>>>(value: type_wrapper_defs.PropWrapper<Swift.Array<Swift.Int>>(value: [1, 2, 3]))))
+  do {
+    print(wrapped7.a)
+    // CHECK: in getter
+    // CHECK-NEXT: ["a"]
+
+    print(wrapped7.b)
+    // CHECK: in getter
+    // CHECK-NEXT: [1, 2, 3]
+
+    wrapped7.a = ["a", "b", "c"]
+    // CHECK: in getter
+    // CHECK-NEXT: in setter => PropWrapper<Array<String>>(value: ["a", "b", "c"])
+
+    print(wrapped7.a)
+    // CHECK: in getter
+    // CHECK-NEXT: ["a", "b", "c"]
+
+    wrapped7.b = [0]
+    // CHECK: in getter
+    // CHECK-NEXT: in setter => PropWrapperWithoutInit<PropWrapper<Array<Int>>>(value: type_wrapper_defs.PropWrapper<Swift.Array<Swift.Int>>(value: [0]))
+
+    print(wrapped7.b)
+    // CHECK: in getter
+    // CHECK-NEXT: [0]
+  }
+
+  var wrapped8 = ComplexPropWrapperTest(a: ["a", "b"])
+  // CHECK: Wrapper.init($Storage(_a: type_wrapper_defs.PropWrapper<Swift.Array<Swift.String>>(value: ["a", "b"]), _b: type_wrapper_defs.PropWrapperWithoutInit<type_wrapper_defs.PropWrapper<Swift.Array<Swift.Int>>>(value: type_wrapper_defs.PropWrapper<Swift.Array<Swift.Int>>(value: [1, 2, 3]))))
+  do {
+    print(wrapped8.a)
+    // CHECK: in getter
+    // CHECK-NEXT: ["a", "b"]
+
+    print(wrapped8.b)
+    // CHECK: in getter
+    // CHECK-NEXT: [1, 2, 3]
+
+    wrapped8.a = ["a", "b", "c"]
+    // CHECK: in getter
+    // CHECK-NEXT: in setter => PropWrapper<Array<String>>(value: ["a", "b", "c"])
+
+    print(wrapped8.a)
+    // CHECK: in getter
+    // CHECK-NEXT: ["a", "b", "c"]
+
+    wrapped8.b = [0]
+    // CHECK: in getter
+    // CHECK-NEXT: in setter => PropWrapperWithoutInit<PropWrapper<Array<Int>>>(value: type_wrapper_defs.PropWrapper<Swift.Array<Swift.Int>>(value: [0]))
+
+    print(wrapped8.b)
+    // CHECK: in getter
+    // CHECK-NEXT: [0]
+  }
+
+  var wrapped9 = ComplexPropWrapperTest(b: PropWrapperWithoutInit(value: PropWrapper(wrappedValue: [0])))
+  // CHECK: Wrapper.init($Storage(_a: type_wrapper_defs.PropWrapper<Swift.Array<Swift.String>>(value: ["a"]), _b: type_wrapper_defs.PropWrapperWithoutInit<type_wrapper_defs.PropWrapper<Swift.Array<Swift.Int>>>(value: type_wrapper_defs.PropWrapper<Swift.Array<Swift.Int>>(value: [0]))))
+  do {
+    print(wrapped9.a)
+    // CHECK: in getter
+    // CHECK-NEXT: ["a"]
+
+    print(wrapped9.b)
+    // CHECK: in getter
+    // CHECK-NEXT: [0]
+
+    wrapped9.a = ["a", "b", "c"]
+    // CHECK: in getter
+    // CHECK-NEXT: in setter => PropWrapper<Array<String>>(value: ["a", "b", "c"])
+
+    print(wrapped9.a)
+    // CHECK: in getter
+    // CHECK-NEXT: ["a", "b", "c"]
+
+    wrapped9.b = [1, 2, 3]
+    // CHECK: in getter
+    // CHECK-NEXT: in setter => PropWrapperWithoutInit<PropWrapper<Array<Int>>>(value: type_wrapper_defs.PropWrapper<Swift.Array<Swift.Int>>(value: [1, 2, 3]))
+
+    print(wrapped9.b)
+    // CHECK: in getter
+    // CHECK-NEXT: [1, 2, 3]
+  }
+
+  var wrapped10 = ComplexPropWrapperTest(a: [], b: PropWrapperWithoutInit(value: PropWrapper(wrappedValue: [0])))
+  // CHECK: Wrapper.init($Storage(_a: type_wrapper_defs.PropWrapper<Swift.Array<Swift.String>>(value: []), _b: type_wrapper_defs.PropWrapperWithoutInit<type_wrapper_defs.PropWrapper<Swift.Array<Swift.Int>>>(value: type_wrapper_defs.PropWrapper<Swift.Array<Swift.Int>>(value: [0]))))
+  do {
+    print(wrapped10.a)
+    // CHECK: in getter
+    // CHECK-NEXT: []
+
+    print(wrapped10.b)
+    // CHECK: in getter
+    // CHECK-NEXT: [0]
+
+    wrapped10.a = ["a", "b", "c"]
+    // CHECK: in getter
+    // CHECK-NEXT: in setter => PropWrapper<Array<String>>(value: ["a", "b", "c"])
+
+    print(wrapped10.a)
+    // CHECK: in getter
+    // CHECK-NEXT: ["a", "b", "c"]
+
+    wrapped10.b = [1, 2, 3]
+    // CHECK: in getter
+    // CHECK-NEXT: in setter => PropWrapperWithoutInit<PropWrapper<Array<Int>>>(value: type_wrapper_defs.PropWrapper<Swift.Array<Swift.Int>>(value: [1, 2, 3]))
+
+    print(wrapped10.b)
+    // CHECK: in getter
+    // CHECK-NEXT: [1, 2, 3]
+  }
+
+  var wrapped11 = PropWrapperNoProjectionTest()
+  // CHECK: Wrapper.init($Storage(_a: type_wrapper_defs.PropWrapperWithoutProjection<Swift.Int>(value: 0), _b: type_wrapper_defs.PropWrapperWithoutProjection<type_wrapper_defs.PropWrapper<Swift.String>>(value: type_wrapper_defs.PropWrapper<Swift.String>(value: "b"))))
+  do {
+    print(wrapped11.a)
+    // CHECK: in getter
+    // CHECK-NEXT: 0
+
+    print(wrapped11.b)
+    // CHECK: in getter
+    // CHECK-NEXT: b
+
+    wrapped11.a = 42
+    // CHECK: in getter
+    // CHECK-NEXT: in setter => PropWrapperWithoutProjection<Int>(value: 42)
+
+    wrapped11.b = "not b"
+    // CHECK: in getter
+    // CHECK-NEXT: in setter => PropWrapperWithoutProjection<PropWrapper<String>>(value: type_wrapper_defs.PropWrapper<Swift.String>(value: "not b"))
+
+    print(wrapped11.a)
+    // CHECK: in getter
+    // CHECK-NEXT: 42
+
+    print(wrapped11.b)
+    // CHECK: in getter
+    // CHECK-NEXT: not b
+  }
+}
+
+testPropertyWrappers()

--- a/test/type/type_wrapper.swift
+++ b/test/type/type_wrapper.swift
@@ -147,3 +147,18 @@ func testLocalWithNestedWrapper() {
   _ = t.test // Ok
   _ = t.computed // Ok
 }
+
+func testTypeWrapperWithDefaults() {
+  @NoopWrapper
+  struct A {
+    var question: String = "Ultimate Question"
+    var answer: Int = 42
+  }
+
+  let a = A()
+  _ = a.question
+  _ = a.answer
+
+  _ = A(question: "")
+  _ = A(answer: 0)
+}

--- a/test/type/type_wrapper.swift
+++ b/test/type/type_wrapper.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature TypeWrappers
 
 @typeWrapper
 struct ConcreteTypeWrapper { // expected-error {{type wrapper has to declare a single generic parameter for underlying storage type}}

--- a/test/type/type_wrapper.swift
+++ b/test/type/type_wrapper.swift
@@ -1,0 +1,84 @@
+// RUN: %target-typecheck-verify-swift
+
+@typeWrapper
+struct ConcreteTypeWrapper { // expected-error {{type wrapper has to declare a single generic parameter for underlying storage type}}
+  init(memberwise: Int) {}
+}
+
+@typeWrapper
+struct EmptyTypeWrapper<S> { // expected-error {{type wrapper type 'EmptyTypeWrapper' does not contain a required initializer - init(memberwise:)}}
+}
+
+@typeWrapper
+struct NoMemberwiseInit<S> {
+  // expected-error@-1 {{type wrapper type 'NoMemberwiseInit' does not contain a required initializer - init(memberwise:)}}
+
+  subscript<V>(storageKeyPath path: KeyPath<S, V>) -> V {
+    get { fatalError() }
+  }
+}
+
+@typeWrapper
+struct FailableInit<S> {
+  init?(memberwise: S) { // expected-error {{type wrapper initializer 'init(memberwise:)' cannot be failable}}
+  }
+
+  subscript<V>(storageKeyPath path: KeyPath<S, V>) -> V {
+    get { fatalError() }
+  }
+}
+
+// Okay because there is a valid `init(memberwise:)` overload.
+@typeWrapper
+struct FailableAndValidInit<S> {
+  init(memberwise: S) {
+  }
+
+  init?(memberwise: S) where S == Int {
+  }
+
+  subscript<V>(storageKeyPath path: KeyPath<S, V>) -> V {
+    get { fatalError() }
+  }
+}
+
+@typeWrapper
+public struct InaccessibleInit<S> {
+  fileprivate init(memberwise: S) {
+    // expected-error@-1 {{fileprivate initializer 'init(memberwise:)' cannot have more restrictive access than its enclosing type wrapper type 'InaccessibleInit' (which is public)}}
+  }
+
+  private init?(memberwise: S) where S: AnyObject {
+    // expected-error@-1 {{private initializer 'init(memberwise:)' cannot have more restrictive access than its enclosing type wrapper type 'InaccessibleInit' (which is public)}}
+    // expected-error@-2 {{type wrapper initializer 'init(memberwise:)' cannot be failable}}
+  }
+
+  subscript<V>(storageKeyPath path: KeyPath<S, V>) -> V {
+    get { fatalError() }
+  }
+}
+
+@typeWrapper
+struct NoSubscripts<S> {
+  // expected-error@-1 {{type wrapper type 'NoSubscripts' does not contain a required subscript - subscript(storedKeyPath:)}}
+  init(memberwise: S) {}
+}
+
+@typeWrapper
+struct InaccessibleOrInvalidSubscripts<S> {
+  init(memberwise: S) {}
+
+  fileprivate subscript<V>(storageKeyPath path: KeyPath<S, V>) -> V {
+    // expected-error@-1 {{fileprivate subscript 'subscript(storageKeyPath:)' cannot have more restrictive access than its enclosing type wrapper type 'InaccessibleOrInvalidSubscripts' (which is internal)}}
+    get { fatalError() }
+  }
+
+  private subscript<V>(storageKeyPath path: KeyPath<S, V>) -> [V] {
+    // expected-error@-1 {{private subscript 'subscript(storageKeyPath:)' cannot have more restrictive access than its enclosing type wrapper type 'InaccessibleOrInvalidSubscripts' (which is internal)}}
+    get { fatalError() }
+  }
+
+  subscript(storageKeyPath path: Int) -> Bool { // expected-error {{type wrapper subscript expects a key path parameter type (got: 'Int')}}
+    get { true }
+  }
+}

--- a/test/type/type_wrapper.swift
+++ b/test/type/type_wrapper.swift
@@ -332,3 +332,49 @@ func propertyWrapperTests() {
     // expected-error@-2 {{cannot convert value of type 'String' to expected argument type 'Float'}}
   }
 }
+
+func testDeclarationsWithUnmanagedProperties() {
+  @NoopWrapper
+  struct WithLet { // expected-note {{'init(name:age:)' declared here}}
+    let name: String
+    var age: Int
+  }
+  _ = WithLet(age: 0) // expected-error {{missing argument for parameter 'name' in call}}
+  _ = WithLet(name: "", age: 0) // Ok
+
+  @NoopWrapper
+  struct WithDefaultedLet {
+    let name: String = "Arthur Dent"
+    var age: Int
+  }
+
+  _ = WithDefaultedLet(age: 32) // Ok
+  _ = WithDefaultedLet(name: "", age: 0) // expected-error {{extra argument 'name' in call}}
+
+  @NoopWrapper
+  struct WithLazy {
+    lazy var name: String = {
+      "Arthur Dent"
+    }()
+
+    var age: Int = 30
+  }
+
+  _ = WithLazy() // Ok
+  _ = WithLazy(name: "") // expected-error {{extra argument 'name' in call}}
+  _ = WithLazy(name: "", age: 0) // expected-error {{extra argument 'name' in call}}
+  _ = WithLazy(age: 0) // Ok
+
+  @NoopWrapper
+  struct OnlyLazyLetAndComputed {
+    let name: String
+    lazy var age: Int = {
+      30
+    }()
+    var planet: String {
+      get { "Earth" }
+    }
+  }
+
+  _ = OnlyLazyLetAndComputed(name: "Arthur Dent") // Ok
+}


### PR DESCRIPTION
Initial implementation of `@typeWrapper` attribute which could be used to declare a type
 to "wrap" other types by routing all their stored property accesses through itself.

The type wrapper is very similar to a property wrapper but there are couple of fundamental 
differences:

- Could only be associated with a class or a struct;
- Disables memberwise and default initializers, produces a special synthesized initializer that covers all the stored properties instead;
- All access to the stored properties is routed through a single instance of a type wrapper;
- A per-instance `$Storage` container allocates storage for all of the wrapped properties;
- Default initialization expressions are moved to the synthesized constructor;
- Access is performed via subscripts that accept key paths to the underlying storage.

Valid type wrapper has to have:

- A single generic parameter (i.e. `Storage`) which would be substituted with storage type;
- `init(memberwise: Storage)` - initializer that accepts a generic parameter of underlying storage;
- `subscript<Value>(storageKeyPath path: {Writable, ReferenceWritable}KeyPath<Storage, Value>) -> Value` -
  a subscript that would be called on every applicable property access.

Here is an example of a valid type wrapper declaration:

```swift
@typeWrapper
struct Wrapper<Storage> {
  var storage: Storage

  init(memberwise: Storage) {
    self.storage = memberwise 
  }

  subscript<Value>(storageKeyPath path: WritableKeyPath<Storage, Value>) -> Value {
    get { storage[keyPath: path] }
    set { storage[keyPath: path] = newValue }
  }
}
```

Now, let's see `Wrapper` in action to appreciate how much boiler place it removes:

```swift
@Wrapper
struct Person {
  var name: String
  var age: Int
}
```

Access to `name` and `age` of a `Person` is going to get routed through `Wrapper` type.

The transformed type looks like this:

```swift
struct Person {
  struct Storage {
    var name: String
    var age: Int
  }

  var _storage: Wrapper<Storage>

  init(name: String, age: Int) {
    self._storage = Wrapper(memberwise: Storage(name: name, age: age))
  }

  var name: String {
    get { _storage[storageKeyPath: \Storage.name] }
    set { _storage[storageKeyPath: \Storage.name] = newValue }
  }

  var age: Int {
    get { _storage[storageKeyPath: \Storage.age] }
    set { _storage[storageKeyPath: \Storage.age] = newValue }
  }
}
```
All of the boilerplate code required to create and maintain 1-1 storage between type and `Storage` and proper initialization is now handled by the compiler.

Open questions:
  - Support for pre-existing user-defined initializers
  - ✅ Support for stored properties with property wrappers

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
