### PR TITLE
Don’t cross-compile sourcekit-lsp and indexstore-db when running tests

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/indexstoredb.py
+++ b/utils/swift_build_support/swift_build_support/products/indexstoredb.py
@@ -111,8 +111,9 @@ def run_build_script_helper(action, host_target, product, args,
     if not clean:
         helper_cmd.append('--no-clean')
 
-    # Pass Cross compile host info
-    if product.has_cross_compile_hosts():
+    # Pass Cross compile host info unless we're testing.
+    # It doesn't make sense to run tests of the cross compile host.
+    if product.has_cross_compile_hosts() and action != 'test':
         if product.is_darwin_host(host_target):
             if len(args.cross_compile_hosts) != 1:
                 raise RuntimeError("Cross-Compiling indexstoredb to multiple " +


### PR DESCRIPTION
Running swift test with `--test-product SourceKitLSPPackageTest` fails when cross-compiling with an error message like the following (rdar://97876450)
```
error: Could not find target named 'SourceKitLSPPackageTests_-6F17C3BE20775DA1_PackageProduct'
```

Since we don’t run the test on the cross-compile host anyway, just disable cross-compilation during testing.