### PR TITLE
Sema: Improved check for failure to bind an extension

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1919,7 +1919,7 @@ NOTE(extension_stored_property_fixit,none,
      "Remove '=' to make %0 a computed property", (Identifier))
 ERROR(extension_nongeneric_trailing_where,none,
       "trailing 'where' clause for extension of non-generic type %0",
-      (Identifier))
+      (Type))
 ERROR(extension_protocol_inheritance,none,
       "extension of protocol %0 cannot have an inheritance clause",
       (Identifier))
@@ -1935,6 +1935,8 @@ ERROR(invalid_nominal_extension,none,
       (Type, Type))
 NOTE(invalid_nominal_extension_rewrite,none,
      "did you mean to extend %0 instead?", (Type))
+ERROR(synthesized_nominal_extension,none,
+      "cannot extend synthesized type %0", (Type))
 
 // Protocols
 ERROR(type_does_not_conform,none,

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2842,6 +2842,11 @@ public:
         verifyConformance(ext, conformance);
       }
 
+      // Make sure extension binding succeeded.
+      if (!ext->hasBeenBound()) {
+        Out << "ExtensionDecl was not bound\n";
+        abort();
+      }
       verifyCheckedBase(ext);
     }
 

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1044,7 +1044,8 @@ namespace {
 /// the given parsed type representation.
 static DirectlyReferencedTypeDecls
 directReferencesForTypeRepr(Evaluator &evaluator, ASTContext &ctx,
-                            TypeRepr *typeRepr, DeclContext *dc);
+                            TypeRepr *typeRepr, DeclContext *dc,
+                            bool allowUsableFromInline=false);
 
 /// Retrieve the set of type declarations that are directly referenced from
 /// the given type.
@@ -2325,7 +2326,8 @@ resolveTypeDeclsToNominal(Evaluator &evaluator,
 static DirectlyReferencedTypeDecls
 directReferencesForUnqualifiedTypeLookup(DeclNameRef name,
                                          SourceLoc loc, DeclContext *dc,
-                                         LookupOuterResults lookupOuter) {
+                                         LookupOuterResults lookupOuter,
+                                         bool allowUsableFromInline=false) {
   // In a protocol or protocol extension, the 'where' clause can refer to
   // associated types without 'Self' qualification:
   //
@@ -2359,6 +2361,9 @@ directReferencesForUnqualifiedTypeLookup(DeclNameRef name,
   if (lookupOuter == LookupOuterResults::Included)
     options |= UnqualifiedLookupFlags::IncludeOuterResults;
 
+  if (allowUsableFromInline)
+    options |= UnqualifiedLookupFlags::IncludeUsableFromInline;
+
   auto &ctx = dc->getASTContext();
   auto descriptor = UnqualifiedLookupDescriptor(name, dc, loc, options);
   auto lookup = evaluateOrDefault(ctx.evaluator,
@@ -2388,7 +2393,8 @@ directReferencesForQualifiedTypeLookup(Evaluator &evaluator,
                                        ASTContext &ctx,
                                        ArrayRef<TypeDecl *> baseTypes,
                                        DeclNameRef name,
-                                       DeclContext *dc) {
+                                       DeclContext *dc,
+                                       bool allowUsableFromInline=false) {
   DirectlyReferencedTypeDecls result;
   auto addResults = [&result](ArrayRef<ValueDecl *> found){
     for (auto decl : found){
@@ -2402,6 +2408,9 @@ directReferencesForQualifiedTypeLookup(Evaluator &evaluator,
     // Look into the base types.
     SmallVector<ValueDecl *, 4> members;
     auto options = NL_RemoveNonVisible | NL_OnlyTypes;
+
+    if (allowUsableFromInline)
+      options |= NL_IncludeUsableFromInline;
 
     // Look through the type declarations we were given, resolving them down
     // to nominal type declarations, module declarations, and
@@ -2433,7 +2442,7 @@ directReferencesForQualifiedTypeLookup(Evaluator &evaluator,
 static DirectlyReferencedTypeDecls
 directReferencesForIdentTypeRepr(Evaluator &evaluator,
                                  ASTContext &ctx, IdentTypeRepr *ident,
-                                 DeclContext *dc) {
+                                 DeclContext *dc, bool allowUsableFromInline) {
   DirectlyReferencedTypeDecls current;
 
   for (const auto &component : ident->getComponentRange()) {
@@ -2449,7 +2458,8 @@ directReferencesForIdentTypeRepr(Evaluator &evaluator,
         directReferencesForUnqualifiedTypeLookup(component->getNameRef(),
                                                  component->getLoc(),
                                                  dc,
-                                                 LookupOuterResults::Excluded);
+                                                 LookupOuterResults::Excluded,
+                                                 allowUsableFromInline);
 
       // If we didn't find anything, fail now.
       if (current.empty())
@@ -2461,7 +2471,8 @@ directReferencesForIdentTypeRepr(Evaluator &evaluator,
     // For subsequent components, perform qualified name lookup.
     current =
         directReferencesForQualifiedTypeLookup(evaluator, ctx, current,
-                                               component->getNameRef(), dc);
+                                               component->getNameRef(), dc,
+                                               allowUsableFromInline);
     if (current.empty())
       return current;
   }
@@ -2472,7 +2483,7 @@ directReferencesForIdentTypeRepr(Evaluator &evaluator,
 static DirectlyReferencedTypeDecls
 directReferencesForTypeRepr(Evaluator &evaluator,
                             ASTContext &ctx, TypeRepr *typeRepr,
-                            DeclContext *dc) {
+                            DeclContext *dc, bool allowUsableFromInline) {
   switch (typeRepr->getKind()) {
   case TypeReprKind::Array:
     return {1, ctx.getArrayDecl()};
@@ -2480,7 +2491,8 @@ directReferencesForTypeRepr(Evaluator &evaluator,
   case TypeReprKind::Attributed: {
     auto attributed = cast<AttributedTypeRepr>(typeRepr);
     return directReferencesForTypeRepr(evaluator, ctx,
-                                       attributed->getTypeRepr(), dc);
+                                       attributed->getTypeRepr(), dc,
+                                       allowUsableFromInline);
   }
 
   case TypeReprKind::Composition: {
@@ -2488,7 +2500,8 @@ directReferencesForTypeRepr(Evaluator &evaluator,
     auto composition = cast<CompositionTypeRepr>(typeRepr);
     for (auto component : composition->getTypes()) {
       auto componentResult =
-          directReferencesForTypeRepr(evaluator, ctx, component, dc);
+          directReferencesForTypeRepr(evaluator, ctx, component, dc,
+                                      allowUsableFromInline);
       result.insert(result.end(),
                     componentResult.begin(),
                     componentResult.end());
@@ -2500,7 +2513,8 @@ directReferencesForTypeRepr(Evaluator &evaluator,
   case TypeReprKind::GenericIdent:
   case TypeReprKind::SimpleIdent:
     return directReferencesForIdentTypeRepr(evaluator, ctx,
-                                            cast<IdentTypeRepr>(typeRepr), dc);
+                                            cast<IdentTypeRepr>(typeRepr), dc,
+                                            allowUsableFromInline);
 
   case TypeReprKind::Dictionary:
     return { 1, ctx.getDictionaryDecl()};
@@ -2509,7 +2523,8 @@ directReferencesForTypeRepr(Evaluator &evaluator,
     auto tupleRepr = cast<TupleTypeRepr>(typeRepr);
     if (tupleRepr->isParenType()) {
       return directReferencesForTypeRepr(evaluator, ctx,
-                                         tupleRepr->getElementType(0), dc);
+                                         tupleRepr->getElementType(0), dc,
+                                         allowUsableFromInline);
     }
     return { };
   }
@@ -2715,7 +2730,8 @@ ExtendedNominalRequest::evaluate(Evaluator &evaluator,
 
   ASTContext &ctx = ext->getASTContext();
   DirectlyReferencedTypeDecls referenced =
-    directReferencesForTypeRepr(evaluator, ctx, typeRepr, ext->getParent());
+    directReferencesForTypeRepr(evaluator, ctx, typeRepr, ext->getParent(),
+                                ext->isInSpecializeExtensionContext());
 
   // Resolve those type declarations to nominal type declarations.
   SmallVector<ModuleDecl *, 2> modulesFound;

--- a/test/AutoDiff/Sema/DerivedConformances/struct_differentiable_member_types.swift
+++ b/test/AutoDiff/Sema/DerivedConformances/struct_differentiable_member_types.swift
@@ -12,4 +12,9 @@ protocol Protocol {
 struct Struct: Differentiable {
   var weight: Float
 }
+
+// Extending a synthesized type doesn't actually work because of circularity issues.
+// It just wasn't diagnosed before.
+
 extension Struct.TangentVector: Protocol {}
+// expected-error@-1 {{non-nominal type 'Struct.TangentVector' cannot be extended}}

--- a/test/decl/ext/extensions.swift
+++ b/test/decl/ext/extensions.swift
@@ -104,6 +104,7 @@ var c = C()
 var x = c.p1
 c.p1 = 1
 
+// Reject extension of nominal type via inferred associated type
 protocol P3 {
   associatedtype Assoc
   func foo() -> Assoc
@@ -113,6 +114,8 @@ struct X3 : P3 {
 }
 
 extension X3.Assoc {
+// expected-error@-1 {{extension of type 'X3.Assoc' (aka 'Int') must be declared as an extension of 'Int'}}
+// expected-note@-2 {{did you mean to extend 'Int' instead?}}
 }
 
 extension X3 {
@@ -331,7 +334,7 @@ extension ImposeClassReq2 {
   }
 }
 
-// Reject extension of nominal type via parameterized typealias
+// Reject extension of nominal type via typealias with dependent underlying type
 
 struct Nest<Egg> { typealias Contents = Egg }
 struct Tree { 


### PR DESCRIPTION
Calling computeExtendedNominal() won't catch the case where the
extended type did not exist at extension binding time but then
appeared later, like an inferred associated type witness for
example.