### PR TITLE
Parse: Fix parsing of `canImport()` version arguments with more than two components

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1851,11 +1851,20 @@ WARNING(likely_simulator_platform_condition,none,
       "use 'targetEnvironment(simulator)' instead",
       ())
 
-ERROR(canimport_two_parameters, none, "canImport can take only two parameters", ())
-
-ERROR(canimport_label, none, "2nd parameter of canImport should be labeled as _version or _underlyingVersion", ())
-
-ERROR(canimport_version, none, "cannot parse module version: %0", (StringRef))
+ERROR(canimport_two_parameters,none,
+      "canImport can take only two parameters", ())
+ERROR(canimport_label,none,
+      "2nd parameter of canImport should be labeled as "
+      "_version or _underlyingVersion", ())
+ERROR(canimport_invalid_version,none,
+      "cannot parse module version '%0'",
+      (StringRef))
+ERROR(canimport_empty_version,none,
+      "%0 argument cannot be empty",
+      (StringRef))
+WARNING(canimport_version_too_many_components,none,
+        "trailing components of version '%0' are ignored",
+        (StringRef))
 
 //------------------------------------------------------------------------------
 // MARK: Availability query parsing diagnostics

--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -77,6 +77,7 @@ static bool isValidVersion(const version::Version &Version,
 }
 
 static llvm::VersionTuple getCanImportVersion(ArgumentList *args,
+                                              SourceManager &SM,
                                               DiagnosticEngine *D,
                                               bool &underlyingVersion) {
   llvm::VersionTuple result;
@@ -99,16 +100,37 @@ static llvm::VersionTuple getCanImportVersion(ArgumentList *args,
     return result;
   }
   StringRef verText;
-  if (auto *nle = dyn_cast<NumberLiteralExpr>(subE)) {
-    verText = nle->getDigitsText();
-  } else if (auto *sle= dyn_cast<StringLiteralExpr>(subE)) {
+  if (auto *sle = dyn_cast<StringLiteralExpr>(subE)) {
     verText = sle->getValue();
+  } else {
+    // Use the raw text for every non-string-literal expression. Versions with
+    // just two components are parsed as number literals, but versions with more
+    // components are parsed as unresolved dot expressions.
+    verText = extractExprSource(SM, subE);
   }
-  if (verText.empty())
+
+  if (verText.empty()) {
+    if (D) {
+      D->diagnose(subE->getLoc(), diag::canimport_empty_version, label.str());
+    }
     return result;
+  }
+
+  // VersionTuple supports a maximum of 4 components.
+  ssize_t excessComponents = verText.count('.') - 3;
+  if (excessComponents > 0) {
+    do {
+      verText = verText.rsplit('.').first;
+    } while (--excessComponents > 0);
+    if (D) {
+      D->diagnose(subE->getLoc(), diag::canimport_version_too_many_components,
+                  verText);
+    }
+  }
+
   if (result.tryParse(verText)) {
     if (D) {
-      D->diagnose(subE->getLoc(), diag::canimport_version, verText);
+      D->diagnose(subE->getLoc(), diag::canimport_invalid_version, verText);
     }
   }
   return result;
@@ -122,12 +144,8 @@ static Expr *getSingleSubExp(ArgumentList *args, StringRef kindName,
   if (auto *unary = args->getUnlabeledUnaryExpr())
     return unary;
 
+  // canImport() has an optional second parameter.
   if (kindName == "canImport") {
-    bool underlyingVersion;
-    if (D) {
-      // Diagnose canImport syntax
-      (void)getCanImportVersion(args, D, underlyingVersion);
-    }
     return args->getExpr(0);
   }
   return nullptr;
@@ -328,6 +346,13 @@ public:
     }
 
     if (*KindName == "canImport") {
+      if (!E->getArgs()->isUnary()) {
+        bool underlyingVersion;
+        // Diagnose canImport(_:_version:) syntax.
+        (void)getCanImportVersion(E->getArgs(), Ctx.SourceMgr, &D,
+                                  underlyingVersion);
+      }
+
       if (!isModulePath(Arg)) {
         D.diagnose(E->getLoc(), diag::unsupported_platform_condition_argument,
                    "module name");
@@ -566,7 +591,8 @@ public:
       bool underlyingModule = false;
       llvm::VersionTuple version;
       if (!E->getArgs()->isUnlabeledUnary()) {
-        version = getCanImportVersion(E->getArgs(), nullptr, underlyingModule);
+        version = getCanImportVersion(E->getArgs(), Ctx.SourceMgr, nullptr,
+                                      underlyingModule);
       }
       ImportPath::Module::Builder builder(Ctx, Str, /*separator=*/'.',
                                           Arg->getStartLoc());

--- a/test/Parse/ifconfig_expr.swift
+++ b/test/Parse/ifconfig_expr.swift
@@ -134,6 +134,18 @@ func canImportVersioned() {
 #if canImport(A, _version: 2.2)
   let a = 1
 #endif
+  
+#if canImport(A, _version: 2.2.2)
+  let a = 1
+#endif
+  
+#if canImport(A, _version: 2.2.2.2)
+  let a = 1
+#endif
+  
+#if canImport(A, _version: 2.2.2.2.2) // expected-warning {{trailing components of version '2.2.2.2' are ignored}}
+  let a = 1
+#endif
 
 #if canImport(A, _underlyingVersion: 4)
   let a = 1
@@ -142,16 +154,48 @@ func canImportVersioned() {
 #if canImport(A, _underlyingVersion: 2.200)
   let a = 1
 #endif
+  
+#if canImport(A, _underlyingVersion: 2.200.1)
+  let a = 1
+#endif
+  
+#if canImport(A, _underlyingVersion: 2.200.1.3)
+  let a = 1
+#endif
 
 #if canImport(A, unknown: 2.2) // expected-error {{2nd parameter of canImport should be labeled as _version or _underlyingVersion}}
   let a = 1
 #endif
 
+#if canImport(A,) // expected-error {{unexpected ',' separator}}
+  let a = 1
+#endif
+  
 #if canImport(A, 2.2) // expected-error {{2nd parameter of canImport should be labeled as _version or _underlyingVersion}}
   let a = 1
 #endif
 
 #if canImport(A, 2.2, 1.1) // expected-error {{canImport can take only two parameters}}
+  let a = 1
+#endif
+  
+#if canImport(A, _version:) // expected-error {{expected expression in list of expressions}}
+  let a = 1
+#endif
+
+#if canImport(A, _version: "") // expected-error {{_version argument cannot be empty}}
+  let a = 1
+#endif
+  
+#if canImport(A, _version: >=2.2) // expected-error {{cannot parse module version '>=2.2'}}
+  let a = 1
+#endif
+  
+#if canImport(A, _version: 20A301) // expected-error {{'A' is not a valid digit in integer literal}}
+  let a = 1
+#endif
+
+#if canImport(A, _version: "20A301") // expected-error {{cannot parse module version '20A301'}}
   let a = 1
 #endif
 }

--- a/test/Parse/versioned_canimport.swift
+++ b/test/Parse/versioned_canimport.swift
@@ -20,57 +20,131 @@ import Bar
 #endif
 
 func canImportVersioned() {
-#if canImport(Foo, _version: 113.331)
-  let a = 1
+#if canImport(Foo, _version: 0)
+  let majorZero = 1 // expected-warning {{initialization of immutable value 'majorZero' was never used; consider replacing with assignment to '_' or removing it}}
 #endif
 
-#if canImport(Foo, _version: 113.3000)
-  let b = 1
+#if canImport(Foo, _version: 112)
+  let majorSmaller = 1 // expected-warning {{initialization of immutable value 'majorSmaller' was never used; consider replacing with assignment to '_' or removing it}}
+#endif
+  
+#if canImport(Foo, _version: 113)
+  let majorEqual = 1 // expected-warning {{initialization of immutable value 'majorEqual' was never used; consider replacing with assignment to '_' or removing it}}
 #endif
 
 #if canImport(Foo, _version: 114)
-  let c = 1
+  let majorLarger = 1
 #endif
-
-#if canImport(Foo, _version: 4)
-  let d = 1 // expected-warning {{initialization of immutable value 'd' was never used; consider replacing with assignment to '_' or removing it}}
-#endif
-
-#if canImport(Foo, _version: 113.33)
-  let e = 1 // expected-warning {{initialization of immutable value 'e' was never used; consider replacing with assignment to '_' or removing it}}
-#endif
-
-#if canImport(Foo, _underlyingVersion: 113.33)
-  let ee = 1
-#endif
-
+  
 #if canImport(Foo, _version: 113.329)
-  let f = 1 // expected-warning {{initialization of immutable value 'f' was never used; consider replacing with assignment to '_' or removing it}}
+  let minorSmaller = 1 // expected-warning {{initialization of immutable value 'minorSmaller' was never used; consider replacing with assignment to '_' or removing it}}
 #endif
 
 #if canImport(Foo, _version: 113.330)
-  let g = 1 // expected-warning {{initialization of immutable value 'g' was never used; consider replacing with assignment to '_' or removing it}}
+  let minorEqual = 1 // expected-warning {{initialization of immutable value 'minorEqual' was never used; consider replacing with assignment to '_' or removing it}}
+#endif
+
+#if canImport(Foo, _version: 113.331)
+  let minorLarger = 1
+#endif
+  
+#if canImport(Foo, _version: 113.330.0)
+  let patchSmaller = 1 // expected-warning {{initialization of immutable value 'patchSmaller' was never used; consider replacing with assignment to '_' or removing it}}
+#endif
+
+#if canImport(Foo, _version: 113.330.1)
+  let patchEqual = 1 // expected-warning {{initialization of immutable value 'patchEqual' was never used; consider replacing with assignment to '_' or removing it}}
+#endif
+  
+#if canImport(Foo, _version: 113.330.2)
+  let patchLarger = 1
+#endif
+
+#if canImport(Foo, _version: 113.330.1.1)
+  let buildSmaller = 1 // expected-warning {{initialization of immutable value 'buildSmaller' was never used; consider replacing with assignment to '_' or removing it}}
+#endif
+
+#if canImport(Foo, _version: 113.330.1.2)
+  let buildEqual = 1 // expected-warning {{initialization of immutable value 'buildEqual' was never used; consider replacing with assignment to '_' or removing it}}
+#endif
+  
+#if canImport(Foo, _version: 113.330.1.3)
+  let buildLarger = 1
+#endif
+  
+#if canImport(Foo, _version: 113.330.1.2.0) // expected-warning {{trailing components of version '113.330.1.2' are ignored}}
+  let extraComponent = 1 // expected-warning {{initialization of immutable value 'extraComponent' was never used; consider replacing with assignment to '_' or removing it}}
+#endif
+
+#if canImport(Foo, _underlyingVersion: 113.33)
+  // Foo is a Swift module with no underlying clang module.
+  let underlyingMinorSmaller = 1
 #endif
 
 #if canImport(Foo)
-  let h = 1 // expected-warning {{initialization of immutable value 'h' was never used; consider replacing with assignment to '_' or removing it}}
+  let noVersion = 1 // expected-warning {{initialization of immutable value 'noVersion' was never used; consider replacing with assignment to '_' or removing it}}
 #endif
 }
 
 func canImportVersionedString() {
+#if canImport(Foo, _version: "0")
+  let majorZero = 1 // expected-warning {{initialization of immutable value 'majorZero' was never used; consider replacing with assignment to '_' or removing it}}
+#endif
+
+#if canImport(Foo, _version: "112")
+  let majorSmaller = 1 // expected-warning {{initialization of immutable value 'majorSmaller' was never used; consider replacing with assignment to '_' or removing it}}
+#endif
+  
+#if canImport(Foo, _version: "113")
+  let majorEqual = 1 // expected-warning {{initialization of immutable value 'majorEqual' was never used; consider replacing with assignment to '_' or removing it}}
+#endif
+
+#if canImport(Foo, _version: "114")
+  let majorLarger = 1
+#endif
+  
+#if canImport(Foo, _version: "113.329")
+  let minorSmaller = 1 // expected-warning {{initialization of immutable value 'minorSmaller' was never used; consider replacing with assignment to '_' or removing it}}
+#endif
+
+#if canImport(Foo, _version: "113.330")
+  let minorEqual = 1 // expected-warning {{initialization of immutable value 'minorEqual' was never used; consider replacing with assignment to '_' or removing it}}
+#endif
+
 #if canImport(Foo, _version: "113.331")
-  let a = 1
+  let minorLarger = 1
+#endif
+  
+#if canImport(Foo, _version: "113.330.0")
+  let patchSmaller = 1 // expected-warning {{initialization of immutable value 'patchSmaller' was never used; consider replacing with assignment to '_' or removing it}}
 #endif
 
-#if canImport(Foo, _version: "113.3000")
-  let b = 1
+#if canImport(Foo, _version: "113.330.1")
+  let patchEqual = 1 // expected-warning {{initialization of immutable value 'patchEqual' was never used; consider replacing with assignment to '_' or removing it}}
+#endif
+  
+#if canImport(Foo, _version: "113.330.2")
+  let patchLarger = 1
 #endif
 
-#if canImport(Foo, _version: "4")
-  let d = 1 // expected-warning {{initialization of immutable value 'd' was never used; consider replacing with assignment to '_' or removing it}}
+#if canImport(Foo, _version: "113.330.1.1")
+  let buildSmaller = 1 // expected-warning {{initialization of immutable value 'buildSmaller' was never used; consider replacing with assignment to '_' or removing it}}
 #endif
 
-#if canImport(Foo, _version: "113.33")
-  let e = 1 // expected-warning {{initialization of immutable value 'e' was never used; consider replacing with assignment to '_' or removing it}}
+#if canImport(Foo, _version: "113.330.1.2")
+  let buildEqual = 1 // expected-warning {{initialization of immutable value 'buildEqual' was never used; consider replacing with assignment to '_' or removing it}}
+#endif
+  
+#if canImport(Foo, _version: "113.330.1.3")
+  let buildLarger = 1
+#endif
+
+#if canImport(Foo, _version: "113.330.1.2.0") // expected-warning {{trailing components of version '113.330.1.2' are ignored}}
+  let extraComponent = 1 // expected-warning {{initialization of immutable value 'extraComponent' was never used; consider replacing with assignment to '_' or removing it}}
+#endif
+
+#if canImport(Foo, _underlyingVersion: 113.33)
+  // Foo is a Swift module with no underlying clang module.
+  let underlyingMinorSmaller = 1
 #endif
 }


### PR DESCRIPTION
Only string literal and number literal expressions were being handled by `getCanImportVersion()`. Versions like `1.2.3.4` are parsed as unresolved dot expressions and were being ignored entirely, resulting in the version silently parsing as `0`.

Resolves: rdar://97990159
