### PR TITLE
Add '@_alwaysEmitConformanceMetadata' protocol attribute

### DIFF
--- a/docs/ReferenceGuides/UnderscoredAttributes.md
+++ b/docs/ReferenceGuides/UnderscoredAttributes.md
@@ -852,3 +852,8 @@ the distributed actor isolation checks. This is used for things like `whenLocal`
 where the actor passed to the closure is known-to-be-local, and similarly a 
 `self` of obtained from an _isolated_ function inside a distributed actor is 
 also guaranteed to be local by construction.
+
+
+## `@_alwaysEmitConformanceMetadata`
+
+Forces conformances of the attributed protocol to always have their Type Metadata get emitted into the binary and prevents it from being optimized away or stripped by the linker.

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -740,6 +740,10 @@ SIMPLE_DECL_ATTR(_moveOnly, MoveOnly,
   UserInaccessible |
   ABIBreakingToAdd | ABIBreakingToRemove | APIBreakingToAdd | APIBreakingToRemove,
   131)
+  
+SIMPLE_DECL_ATTR(_alwaysEmitConformanceMetadata, AlwaysEmitConformanceMetadata,
+  OnProtocol | UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
+  132)
 
 // If you're adding a new underscored attribute here, please document it in
 // docs/ReferenceGuides/UnderscoredAttributes.md.

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -311,6 +311,8 @@ public:
   void visitNonisolatedAttr(NonisolatedAttr *attr);
 
   void visitNoImplicitCopyAttr(NoImplicitCopyAttr *attr);
+  
+  void visitAlwaysEmitConformanceMetadataAttr(AlwaysEmitConformanceMetadataAttr *attr);
 
   void visitUnavailableFromAsyncAttr(UnavailableFromAsyncAttr *attr);
 
@@ -379,6 +381,10 @@ void AttributeChecker::visitNoImplicitCopyAttr(NoImplicitCopyAttr *attr) {
     diagnoseAndRemoveAttr(attr, error);
     return;
   }
+}
+
+void AttributeChecker::visitAlwaysEmitConformanceMetadataAttr(AlwaysEmitConformanceMetadataAttr *attr) {
+  return;
 }
 
 void AttributeChecker::visitTransparentAttr(TransparentAttr *attr) {

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1613,6 +1613,7 @@ namespace  {
 
     UNINTERESTING_ATTR(UnsafeInheritExecutor)
     UNINTERESTING_ATTR(CompilerInitialized)
+    UNINTERESTING_ATTR(AlwaysEmitConformanceMetadata)
 #undef UNINTERESTING_ATTR
 
     void visitAvailableAttr(AvailableAttr *attr) {

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 698; // opaque decl with unavailability conditions
+const uint16_t SWIFTMODULE_VERSION_MINOR = 699; // @_alwaysEmitConformanceMetadata
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/test/ModuleInterface/alwaysEmitConformanceMetadata_attr.swift
+++ b/test/ModuleInterface/alwaysEmitConformanceMetadata_attr.swift
@@ -1,0 +1,18 @@
+// RUN: %empty-directory(%t)
+
+// Ensure the attribute is printed in swiftinterface files
+// RUN: %target-swift-emit-module-interface(%t/Foo.swiftinterface) %s -module-name Foo
+// RUN: %target-swift-typecheck-module-from-interface(%t/Foo.swiftinterface) -module-name Foo
+// RUN: %FileCheck %s < %t/Foo.swiftinterface
+
+// Ensure the attribute is in .swiftmodule files
+// RUN: %target-swift-ide-test -print-module -module-to-print Foo -I %t -source-filename %s -fully-qualified-types -print-access > %t/printed-module.txt
+// RUN: %FileCheck %s < %t/printed-module.txt
+
+@_alwaysEmitConformanceMetadata
+public protocol TestP {
+    static var foo: Int { get }
+}
+
+
+// CHECK: @_alwaysEmitConformanceMetadata public protocol TestP

--- a/test/Parse/alwaysEmitConformanceMetadata_attr.swift
+++ b/test/Parse/alwaysEmitConformanceMetadata_attr.swift
@@ -1,0 +1,6 @@
+// RUN: %target-typecheck-verify-swift -parse -parse-stdlib -verify-syntax-tree
+
+import Swift
+
+@_alwaysEmitConformanceMetadata
+protocol Test {}

--- a/test/Sema/alwaysEmitConformanceMetadata_attr.swift
+++ b/test/Sema/alwaysEmitConformanceMetadata_attr.swift
@@ -1,0 +1,25 @@
+// RUN: %target-typecheck-verify-swift -parse-stdlib -verify-syntax-tree
+
+import Swift
+
+@_alwaysEmitConformanceMetadata
+protocol TestP {
+    static var foo: Int { get }
+}
+
+@_alwaysEmitConformanceMetadata // expected-error {{@_alwaysEmitConformanceMetadata may only be used on 'protocol' declarations}}
+class TestC {}
+
+@_alwaysEmitConformanceMetadata // expected-error {{@_alwaysEmitConformanceMetadata may only be used on 'protocol' declarations}}
+struct TestS {}
+
+@_alwaysEmitConformanceMetadata // expected-error {{@_alwaysEmitConformanceMetadata may only be used on 'protocol' declarations}}
+enum TestE {}
+
+@_alwaysEmitConformanceMetadata // expected-error {{@_alwaysEmitConformanceMetadata may only be used on 'protocol' declarations}}
+extension TestS {}
+
+class TestC2 {
+    @_alwaysEmitConformanceMetadata  // expected-error {{@_alwaysEmitConformanceMetadata may only be used on 'protocol' declarations}}
+    var foo: Int = 11
+}


### PR DESCRIPTION
This attribute will, in the near future, be used to inform IRGen that a nominal type that conforms to such protocol must have its type metadata always emitted into the binary, regardless of whether it is used/public.