### PR TITLE
[cxx-interop] Fix circular reference errors during conformance synthesis

### DIFF
--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -11,11 +11,35 @@
 //===----------------------------------------------------------------------===//
 
 #include "ClangDerivedConformances.h"
-#include "swift/AST/NameLookup.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/PrettyStackTrace.h"
+#include "swift/AST/ProtocolConformance.h"
+#include "swift/ClangImporter/ClangImporterRequests.h"
 
 using namespace swift;
+
+/// Alternative to `NominalTypeDecl::lookupDirect`.
+/// This function does not attempt to load extensions of the nominal decl.
+static TinyPtrVector<ValueDecl *>
+lookupDirectWithoutExtensions(NominalTypeDecl *decl, Identifier id) {
+  // First see if there is a Clang decl with the given name.
+  TinyPtrVector<ValueDecl *> result = evaluateOrDefault(
+      decl->getASTContext().evaluator, ClangRecordMemberLookup({decl, id}), {});
+
+  // Check if there are any synthesized Swift members that match the name.
+  for (auto member : decl->getMembers()) {
+    if (auto namedMember = dyn_cast<ValueDecl>(member)) {
+      if (namedMember->hasName() && !namedMember->getName().isSpecial() &&
+          namedMember->getName().getBaseIdentifier().is(id.str()) &&
+          // Make sure we don't add duplicate entries, as that would wrongly
+          // imply that lookup is ambiguous.
+          !llvm::is_contained(result, namedMember)) {
+        result.push_back(namedMember);
+      }
+    }
+  }
+  return result;
+}
 
 static clang::TypeDecl *
 getIteratorCategoryDecl(const clang::CXXRecordDecl *clangDecl) {
@@ -55,7 +79,7 @@ static ValueDecl *getEqualEqualOperator(NominalTypeDecl *decl) {
   };
 
   // First look for `func ==` declared as a member.
-  auto memberResults = decl->lookupDirect(id);
+  auto memberResults = lookupDirectWithoutExtensions(decl, id);
   for (const auto &member : memberResults) {
     if (isValid(member))
       return member;
@@ -131,7 +155,7 @@ void swift::conformToCxxIteratorIfNeeded(
 
   // Check if present: `var pointee: Pointee { get }`
   auto pointeeId = ctx.getIdentifier("pointee");
-  auto pointees = decl->lookupDirect(pointeeId);
+  auto pointees = lookupDirectWithoutExtensions(decl, pointeeId);
   if (pointees.size() != 1)
     return;
   auto pointee = dyn_cast<VarDecl>(pointees.front());
@@ -140,7 +164,7 @@ void swift::conformToCxxIteratorIfNeeded(
 
   // Check if present: `func successor() -> Self`
   auto successorId = ctx.getIdentifier("successor");
-  auto successors = decl->lookupDirect(successorId);
+  auto successors = lookupDirectWithoutExtensions(decl, successorId);
   if (successors.size() != 1)
     return;
   auto successor = dyn_cast<FuncDecl>(successors.front());

--- a/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
@@ -5,8 +5,8 @@
 // CHECK: struct ConstIterator : UnsafeCxxInputIterator {
 // CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> ConstIterator
-// CHECK:   typealias Pointee = Int32
 // CHECK:   static func == (lhs: ConstIterator, other: ConstIterator) -> Bool
+// CHECK:   typealias Pointee = Int32
 // CHECK: }
 
 // CHECK: struct ConstIteratorOutOfLineEq : UnsafeCxxInputIterator {
@@ -18,36 +18,36 @@
 // CHECK: struct MinimalIterator : UnsafeCxxInputIterator {
 // CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> MinimalIterator
-// CHECK:   typealias Pointee = Int32
 // CHECK:   static func == (lhs: MinimalIterator, other: MinimalIterator) -> Bool
+// CHECK:   typealias Pointee = Int32
 // CHECK: }
 
 // CHECK: struct ForwardIterator : UnsafeCxxInputIterator {
 // CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> ForwardIterator
-// CHECK:   typealias Pointee = Int32
 // CHECK:   static func == (lhs: ForwardIterator, other: ForwardIterator) -> Bool
+// CHECK:   typealias Pointee = Int32
 // CHECK: }
 
 // CHECK: struct HasCustomIteratorTag : UnsafeCxxInputIterator {
 // CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> HasCustomIteratorTag
-// CHECK:   typealias Pointee = Int32
 // CHECK:   static func == (lhs: HasCustomIteratorTag, other: HasCustomIteratorTag) -> Bool
+// CHECK:   typealias Pointee = Int32
 // CHECK: }
 
 // CHECK: struct HasCustomIteratorTagInline : UnsafeCxxInputIterator {
 // CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> HasCustomIteratorTagInline
-// CHECK:   typealias Pointee = Int32
 // CHECK:   static func == (lhs: HasCustomIteratorTagInline, other: HasCustomIteratorTagInline) -> Bool
+// CHECK:   typealias Pointee = Int32
 // CHECK: }
 
 // CHECK: struct HasTypedefIteratorTag : UnsafeCxxInputIterator {
 // CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> HasTypedefIteratorTag
-// CHECK:   typealias Pointee = Int32
 // CHECK:   static func == (lhs: HasTypedefIteratorTag, other: HasTypedefIteratorTag) -> Bool
+// CHECK:   typealias Pointee = Int32
 // CHECK: }
 
 // CHECK-NOT: struct HasNoIteratorCategory : UnsafeCxxInputIterator


### PR DESCRIPTION
These errors were sometimes produced when synthesizing conformance to `UnsafeCxxInputIterator`:
```
<unknown>:0: error: circular reference
<unknown>:0: note: through reference here
<unknown>:0: note: through reference here
```

This happened because `NominalTypeDecl::lookupDirect` attempts to deserialize Swift extensions of the type, which might belong to the module which has a dependency to the module that is currently being imported, which leads to deserialization errors.

This change makes sure we don't call `NominalTypeDecl::lookupDirect` when synthesizing conformances for C++ types.