### PR TITLE
Fix source to use template <typename T, unsigned N> class SmallVector

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1355,7 +1355,7 @@ protected:
         }
       } else {
         auto *elseBraceStmt = cast<BraceStmt>(elseStmt);
-        SmallVector<ASTNode> elseBody;
+        SmallVector<ASTNode, 4> elseBody;
 
         std::tie(elseVar, unsupported) = transform(elseBraceStmt, elseBody);
         if (unsupported) {


### PR DESCRIPTION
The SmallVector version with default template does not compile with older compiler versions
