### PR TITLE
[5.7] [Sema] Look through FunctionConversionExpr when finding @discardableResult callee

### DIFF
--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1412,6 +1412,8 @@ void TypeChecker::checkIgnoredExpr(Expr *E) {
         fn = FVE->getSubExpr();
       } else if (auto dotSyntaxRef = dyn_cast<DotSyntaxBaseIgnoredExpr>(fn)) {
         fn = dotSyntaxRef->getRHS();
+      } else if (auto fnConvExpr = dyn_cast<FunctionConversionExpr>(fn)) {
+        fn = fnConvExpr->getSubExpr();
       } else {
         break;
       }

--- a/test/Concurrency/attr_discardableResult_async_await.swift
+++ b/test/Concurrency/attr_discardableResult_async_await.swift
@@ -1,0 +1,11 @@
+// RUN: %target-typecheck-verify-swift  -disable-availability-checking
+// REQUIRES: concurrency
+
+// https://github.com/apple/swift/issues/60276
+
+@discardableResult @MainActor
+func mainActorAsyncDiscardable() async -> Int { 0 }
+
+func consumesMainActorAsyncDiscardable() async {
+  await mainActorAsyncDiscardable() // ok
+}


### PR DESCRIPTION
**Description:** When calling a `@discardableResult @MainActor` annotated function, the call to the function is wrapped in an implicit `FunctionConversionExpr`. The code was not looking through this expression to find the callee function and thus was incorrectly triggering a `result of call to function <name> is unused` warning. This warning does not trigger on 5.6, so it is a regression in 5.7.

**Risk:** Low, a tiny change to the logic to look through this implicit expression
**Review by:** @xedin
**Testing:** PR Testing
**Original PR:** https://github.com/apple/swift/pull/60324