### PR TITLE
[Diagnostics] Update existential type error message for clarity

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4799,7 +4799,7 @@ ERROR(unchecked_not_existential,none,
       "'unchecked' attribute cannot apply to non-protocol type %0", (Type))
 
 ERROR(redundant_any_in_existential,none,
-       "redundant 'any' has no effect on existential type %0",
+       "redundant 'any' in type %0",
        (Type))
 ERROR(any_not_existential,none,
        "'any' has no effect on %select{concrete type|type parameter}0 %1",

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4325,8 +4325,6 @@ Type ExistentialType::get(Type constraint) {
   if (constraint->is<ExistentialMetatypeType>())
     return constraint;
 
-  assert(constraint->isConstraintType());
-
   bool printWithAny = true;
   if (constraint->isEqual(C.TheAnyType) || constraint->isAnyObject())
     printWithAny = false;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4237,7 +4237,8 @@ TypeResolver::resolveExistentialType(ExistentialTypeRepr *repr,
     // Diagnose redundant `any` on an already existential type e.g. any (any P)
     // with a fix-it to remove first any.
     if (constraintType->is<ExistentialType>()) {
-      diagnose(repr->getLoc(), diag::redundant_any_in_existential, constraintType)
+      diagnose(repr->getLoc(), diag::redundant_any_in_existential,
+               ExistentialType::get(constraintType))
           .fixItRemove(repr->getAnyLoc());
       return constraintType;
     }

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -334,12 +334,12 @@ func testEnumAssociatedValue() {
 
 // https://github.com/apple/swift/issues/58920
 typealias Iterator = any IteratorProtocol
-var example: any Iterator = 5 // expected-error{{redundant 'any' has no effect on existential type 'Iterator' (aka 'any IteratorProtocol')}} {{14-18=}} 
+var example: any Iterator = 5 // expected-error{{redundant 'any' in type 'any Iterator' (aka 'any any IteratorProtocol')}} {{14-18=}}
 // expected-error@-1{{value of type 'Int' does not conform to specified type 'IteratorProtocol'}}
-var example1: any (any IteratorProtocol) = 5 // expected-error{{redundant 'any' has no effect on existential type 'any IteratorProtocol'}} {{15-19=}}
+var example1: any (any IteratorProtocol) = 5 // expected-error{{redundant 'any' in type 'any (any IteratorProtocol)'}} {{15-19=}}
 // expected-error@-1{{value of type 'Int' does not conform to specified type 'IteratorProtocol'}}
 
 protocol PP {}
 struct A : PP {}
 let _: any PP = A() // Ok
-let _: any (any PP) = A() // expected-error{{redundant 'any' has no effect on existential type 'any PP'}} {{8-12=}}
+let _: any (any PP) = A() // expected-error{{redundant 'any' in type 'any (any PP)'}} {{8-12=}}

--- a/test/type/explicit_existential_swift6.swift
+++ b/test/type/explicit_existential_swift6.swift
@@ -360,12 +360,12 @@ func testEnumAssociatedValue() {
 
 // https://github.com/apple/swift/issues/58920
 typealias Iterator = any IteratorProtocol
-var example: any Iterator = 5 // expected-error{{redundant 'any' has no effect on existential type 'Iterator' (aka 'any IteratorProtocol')}} {{14-18=}} 
+var example: any Iterator = 5 // expected-error{{redundant 'any' in type 'any Iterator' (aka 'any any IteratorProtocol')}} {{14-18=}} 
 // expected-error@-1{{value of type 'Int' does not conform to specified type 'IteratorProtocol'}}
-var example1: any (any IteratorProtocol) = 5 // expected-error{{redundant 'any' has no effect on existential type 'any IteratorProtocol'}} {{15-19=}}
+var example1: any (any IteratorProtocol) = 5 // expected-error{{redundant 'any' in type 'any (any IteratorProtocol)'}} {{15-19=}}
 // expected-error@-1{{value of type 'Int' does not conform to specified type 'IteratorProtocol'}}
 
 protocol PP {}
 struct A : PP {}
 let _: any PP = A() // Ok
-let _: any (any PP) = A() // expected-error{{redundant 'any' has no effect on existential type 'any PP'}} {{8-12=}}
+let _: any (any PP) = A() // expected-error{{redundant 'any' in type 'any (any PP)'}} {{8-12=}}


### PR DESCRIPTION
Updating the `redundant_any_in_existential` error message by making it more explicit that the issue is the redundant `any` keyword.

Note: This is my first pull request as part of the Swift Mentorship.
@hborla I guess it's ready for review :)