### PR TITLE
Formalize Labeled Syntax

### DIFF
--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -524,21 +524,23 @@ static ParserResult<Stmt> recoverFromInvalidCase(Parser &P) {
 ParserResult<Stmt> Parser::parseStmt() {
   AssertParserMadeProgressBeforeLeavingScopeRAII apmp(*this);
 
+  // If this is a label on a loop/switch statement, consume it and pass it into
+  // parsing logic below.
+  SyntaxParsingContext LabelContext(SyntaxContext, SyntaxKind::LabeledStmt);
+  LabeledStmtInfo LabelInfo;
+  if (Tok.is(tok::identifier) && peekToken().is(tok::colon)) {
+    LabelInfo.Loc = consumeIdentifier(LabelInfo.Name,
+                                      /*diagnoseDollarPrefix=*/true);
+    consumeToken(tok::colon);
+  } else {
+    LabelContext.setTransparent();
+  }
+
   SyntaxParsingContext LocalContext(SyntaxContext, SyntaxContextKind::Stmt);
 
   // Note that we're parsing a statement.
   StructureMarkerRAII ParsingStmt(*this, Tok.getLoc(),
                                   StructureMarkerKind::Statement);
-  
-  LabeledStmtInfo LabelInfo;
-  
-  // If this is a label on a loop/switch statement, consume it and pass it into
-  // parsing logic below.
-  if (Tok.is(tok::identifier) && peekToken().is(tok::colon)) {
-    LabelInfo.Loc = consumeIdentifier(LabelInfo.Name,
-                                      /*diagnoseDollarPrefix=*/true);
-    consumeToken(tok::colon);
-  }
 
   SourceLoc tryLoc;
   (void)consumeIf(tok::kw_try, tryLoc);

--- a/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
+++ b/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
@@ -345,19 +345,19 @@ func statementTests<FunctionSignature><ParameterClause>() </ParameterClause></Fu
   } </CodeBlock></CatchClause><CatchClause>catch <CatchItem><ExpressionPattern><FunctionCallExpr><MemberAccessExpr>.a</MemberAccessExpr>(<TupleExprElement><UnresolvedPatternExpr><ValueBindingPattern>let <IdentifierPattern>a</IdentifierPattern></ValueBindingPattern></UnresolvedPatternExpr></TupleExprElement>)</FunctionCallExpr></ExpressionPattern>, </CatchItem><CatchItem><ExpressionPattern><FunctionCallExpr><MemberAccessExpr>.b</MemberAccessExpr>(<TupleExprElement><UnresolvedPatternExpr><ValueBindingPattern>let <IdentifierPattern>b</IdentifierPattern></ValueBindingPattern></UnresolvedPatternExpr></TupleExprElement>) </FunctionCallExpr></ExpressionPattern><WhereClause>where <SequenceExpr><IdentifierExpr>b </IdentifierExpr><BinaryOperatorExpr>== </BinaryOperatorExpr><StringLiteralExpr>"<StringSegment></StringSegment>" </StringLiteralExpr></SequenceExpr></WhereClause></CatchItem><CodeBlock>{
   } </CodeBlock></CatchClause><CatchClause>catch <CatchItem></CatchItem><CodeBlock>{
   }</CodeBlock></CatchClause></DoStmt><RepeatWhileStmt>
-  repeat <CodeBlock>{ } </CodeBlock>while <BooleanLiteralExpr>true</BooleanLiteralExpr></RepeatWhileStmt><RepeatWhileStmt>
-  LABEL: repeat <CodeBlock>{ } </CodeBlock>while <BooleanLiteralExpr>false</BooleanLiteralExpr></RepeatWhileStmt><WhileStmt>
-  while <ConditionElement><BooleanLiteralExpr>true </BooleanLiteralExpr></ConditionElement><CodeBlock>{ }</CodeBlock></WhileStmt><WhileStmt>
-  LABEL: while <ConditionElement><BooleanLiteralExpr>true </BooleanLiteralExpr></ConditionElement><CodeBlock>{ }</CodeBlock></WhileStmt><DoStmt>
-  LABEL: do <CodeBlock>{}</CodeBlock></DoStmt><SwitchStmt>
-  LABEL: switch <IdentifierExpr>foo </IdentifierExpr>{<SwitchCase><SwitchCaseLabel>
+  repeat <CodeBlock>{ } </CodeBlock>while <BooleanLiteralExpr>true</BooleanLiteralExpr></RepeatWhileStmt><LabeledStmt>
+  LABEL: <RepeatWhileStmt>repeat <CodeBlock>{ } </CodeBlock>while <BooleanLiteralExpr>false</BooleanLiteralExpr></RepeatWhileStmt></LabeledStmt><WhileStmt>
+  while <ConditionElement><BooleanLiteralExpr>true </BooleanLiteralExpr></ConditionElement><CodeBlock>{ }</CodeBlock></WhileStmt><LabeledStmt>
+  LABEL: <WhileStmt>while <ConditionElement><BooleanLiteralExpr>true </BooleanLiteralExpr></ConditionElement><CodeBlock>{ }</CodeBlock></WhileStmt></LabeledStmt><LabeledStmt>
+  LABEL: <DoStmt>do <CodeBlock>{}</CodeBlock></DoStmt></LabeledStmt><LabeledStmt>
+  LABEL: <SwitchStmt>switch <IdentifierExpr>foo </IdentifierExpr>{<SwitchCase><SwitchCaseLabel>
     case <CaseItem><ExpressionPattern><IntegerLiteralExpr>1</IntegerLiteralExpr></ExpressionPattern></CaseItem>:</SwitchCaseLabel><FallthroughStmt>
       fallthrough</FallthroughStmt></SwitchCase><SwitchCase><SwitchCaseLabel>
     case <CaseItem><ExpressionPattern><IntegerLiteralExpr>2</IntegerLiteralExpr></ExpressionPattern></CaseItem>:</SwitchCaseLabel><BreakStmt>
       break LABEL</BreakStmt></SwitchCase><SwitchCase><SwitchCaseLabel>
     case <CaseItem><ExpressionPattern><IntegerLiteralExpr>3</IntegerLiteralExpr></ExpressionPattern></CaseItem>:</SwitchCaseLabel><BreakStmt>
       break</BreakStmt></SwitchCase>
-  }</SwitchStmt><ForInStmt>
+  }</SwitchStmt></LabeledStmt><ForInStmt>
 
   for <IdentifierPattern>a </IdentifierPattern>in <IdentifierExpr>b </IdentifierExpr><CodeBlock>{<DeferStmt>
     defer <CodeBlock>{ <TupleExpr>() </TupleExpr>}</CodeBlock></DeferStmt><IfStmt>

--- a/utils/gyb_syntax_support/NodeSerializationCodes.py
+++ b/utils/gyb_syntax_support/NodeSerializationCodes.py
@@ -268,6 +268,7 @@ SYNTAX_NODE_SERIALIZATION_CODES = {
     'MissingType': 264,
     'MissingPattern': 265,
     'GarbageNodes' : 266,
+    'LabeledStmt': 267,
 }
 
 

--- a/utils/gyb_syntax_support/PatternNodes.py
+++ b/utils/gyb_syntax_support/PatternNodes.py
@@ -73,7 +73,7 @@ PATTERN_NODES = [
 
     # tuple-pattern-element -> identifier? ':' pattern ','?
     Node('TuplePatternElement', kind='Syntax',
-         traits=['WithTrailingComma', 'Labeled'],
+         traits=['WithTrailingComma'],
          children=[
              Child('LabelName', kind='IdentifierToken',
                    is_optional=True),

--- a/utils/gyb_syntax_support/StmtNodes.py
+++ b/utils/gyb_syntax_support/StmtNodes.py
@@ -2,6 +2,14 @@ from .Child import Child
 from .Node import Node  # noqa: I201
 
 STMT_NODES = [
+    # labeled-stmt -> label ':' stmt
+    Node('LabeledStmt', kind='Stmt',
+         children=[
+             Child('LabelName', kind='IdentifierToken'),
+             Child('LabelColon', kind='ColonToken'),
+             Child('Statement', kind='Stmt'),
+         ]),
+
     # continue-stmt -> 'continue' label? ';'?
     Node('ContinueStmt', kind='Stmt',
          children=[
@@ -12,12 +20,8 @@ STMT_NODES = [
 
     # while-stmt -> label? ':'? 'while' condition-list code-block ';'?
     Node('WhileStmt', kind='Stmt',
-         traits=['WithCodeBlock', 'Labeled'],
+         traits=['WithCodeBlock'],
          children=[
-             Child('LabelName', kind='IdentifierToken',
-                   is_optional=True),
-             Child('LabelColon', kind='ColonToken',
-                   is_optional=True),
              Child('WhileKeyword', kind='WhileToken'),
              Child('Conditions', kind='ConditionElementList',
                    collection_element_name='Condition'),
@@ -46,12 +50,8 @@ STMT_NODES = [
 
     # repeat-while-stmt -> label? ':'? 'repeat' code-block 'while' expr ';'?
     Node('RepeatWhileStmt', kind='Stmt',
-         traits=['WithCodeBlock', 'Labeled'],
+         traits=['WithCodeBlock'],
          children=[
-             Child('LabelName', kind='IdentifierToken',
-                   is_optional=True),
-             Child('LabelColon', kind='ColonToken',
-                   is_optional=True),
              Child('RepeatKeyword', kind='RepeatToken'),
              Child('Body', kind='CodeBlock'),
              Child('WhileKeyword', kind='WhileToken'),
@@ -79,12 +79,8 @@ STMT_NODES = [
     #   'for' 'try'? 'await'? 'case'? pattern 'in' expr 'where'?
     #   expr code-block ';'?
     Node('ForInStmt', kind='Stmt',
-         traits=['WithCodeBlock', 'Labeled'],
+         traits=['WithCodeBlock'],
          children=[
-             Child('LabelName', kind='IdentifierToken',
-                   is_optional=True),
-             Child('LabelColon', kind='ColonToken',
-                   is_optional=True),
              Child('ForKeyword', kind='ForToken'),
              Child('TryKeyword', kind='TryToken', 
                    is_optional=True),
@@ -106,12 +102,8 @@ STMT_NODES = [
     # switch-stmt -> identifier? ':'? 'switch' expr '{'
     #   switch-case-list '}' ';'?
     Node('SwitchStmt', kind='Stmt',
-         traits=['Braced', 'Labeled'],
+         traits=['Braced'],
          children=[
-             Child('LabelName', kind='IdentifierToken',
-                   is_optional=True),
-             Child('LabelColon', kind='ColonToken',
-                   is_optional=True),
              Child('SwitchKeyword', kind='SwitchToken'),
              Child('Expression', kind='Expr'),
              Child('LeftBrace', kind='LeftBraceToken'),
@@ -127,12 +119,8 @@ STMT_NODES = [
 
     # do-stmt -> identifier? ':'? 'do' code-block catch-clause-list ';'?
     Node('DoStmt', kind='Stmt',
-         traits=['WithCodeBlock', 'Labeled'],
+         traits=['WithCodeBlock'],
          children=[
-             Child('LabelName', kind='IdentifierToken',
-                   is_optional=True),
-             Child('LabelColon', kind='ColonToken',
-                   is_optional=True),
              Child('DoKeyword', kind='DoToken'),
              Child('Body', kind='CodeBlock'),
              Child('CatchClauses', kind='CatchClauseList',
@@ -272,12 +260,8 @@ STMT_NODES = [
     # if-stmt -> identifier? ':'? 'if' condition-list code-block
     #   else-clause ';'?
     Node('IfStmt', kind='Stmt',
-         traits=['WithCodeBlock', 'Labeled'],
+         traits=['WithCodeBlock'],
          children=[
-             Child('LabelName', kind='IdentifierToken',
-                   is_optional=True),
-             Child('LabelColon', kind='ColonToken',
-                   is_optional=True),
              Child('IfKeyword', kind='IfToken'),
              Child('Conditions', kind='ConditionElementList',
                    collection_element_name='Condition'),

--- a/utils/gyb_syntax_support/Traits.py
+++ b/utils/gyb_syntax_support/Traits.py
@@ -43,12 +43,6 @@ TRAITS = [
               Child('TrailingComma', kind='CommaToken', is_optional=True),
           ]),
 
-    Trait('Labeled',
-          children=[
-              Child('LabelName', kind='IdentifierToken', is_optional=True),
-              Child('LabelColon', kind='ColonToken', is_optional=True),
-          ]),
-
     Trait('WithStatements',
           children=[
               Child('Statements', kind='CodeBlockItemList'),


### PR DESCRIPTION
This represents labeled statements as an explicit kind of statement and removes the Labeled trait. Any kind of statement is allowed to be labeled in the tree, but we specifically diagnose the syntax elements that aren't allowed to have labels. This homogenizes the way clients deal with statement labels and also makes parser recovery quite a bit easier in the case where we have a label but no actual statement following it.