### PR TITLE
[5.7🍒] Fix crash when emitting force-unwrap-and-call expression for optional ObjC methods

### DIFF
--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -393,3 +393,11 @@ extension SomeWrapper: Sendable where T: Sendable {}
     }
   }
 }
+
+// rdar://97646309 -- lookup and direct call of an optional global-actor constrained method would crash in SILGen
+@available(SwiftStdlib 5.5, *)
+extension CoffeeDelegate  {
+    @MainActor func test() async -> (NSObject?, NSObject, NSObject) {
+        return await self.icedMochaServiceGenerateMocha!(NSObject())
+    }
+}

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -319,4 +319,12 @@ SENDABLE id StructWithSendableContentsGetSendableComputed(struct StructWithSenda
 + (void)getAsCustomer:(void(^_Nonnull)(NSObject *device))completion;
 @end
 
+
+// rdar://97646309
+UI_ACTOR
+@protocol CoffeeDelegate <NSObject>
+@optional
+- (void)icedMochaService:(NSObject *)mochaService generateMochaWithCompletion:(void (^)(NSObject *_Nullable ingredient1, NSObject *ingredient2, NSObject *ingredient3))completionHandler;
+@end
+
 #pragma clang assume_nonnull end


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/60399

Resolves rdar://97646309