### PR TITLE
[5.7] Use `collections.abc.Iterable` instead of `collection.Iterable`

### DIFF
--- a/utils/build_swift/build_swift/shell.py
+++ b/utils/build_swift/build_swift/shell.py
@@ -208,7 +208,7 @@ def quote(command):
     if isinstance(command, (str,)):
         return _quote(command)
 
-    if isinstance(command, collections.Iterable):
+    if isinstance(command, collections.abc.Iterable):
         return ' '.join([_quote(arg) for arg in _normalize_args(command)])
 
     raise ValueError('Invalid command type: {}'.format(type(command).__name__))

--- a/utils/build_swift/tests/build_swift/test_shell.py
+++ b/utils/build_swift/tests/build_swift/test_shell.py
@@ -67,7 +67,7 @@ class TestHelpers(unittest.TestCase):
 
         result = shell._flatmap(duplicate, [1, 2, 3])
 
-        self.assertIsInstance(result, collections.Iterable)
+        self.assertIsInstance(result, collections.abc.Iterable)
         self.assertEqual(list(result), [1, 1, 2, 2, 3, 3])
 
     # -------------------------------------------------------------------------


### PR DESCRIPTION
The latter is no longer present in Python 3.10+.

Addresses #58714

(cherry picked from commit ed696240cf610ae7de3eb2e53c89cff83aa1e6e2)

