### PR TITLE
[5.7][CSClosure] Add support for projected/wrapper values

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5430,6 +5430,20 @@ public:
   /// is provided first.
   llvm::TinyPtrVector<CustomAttr *> getAttachedPropertyWrappers() const;
 
+  /// Retrieve the outermost property wrapper attribute associated with
+  /// this declaration. For example:
+  ///
+  /// \code
+  /// @A @B @C var <name>: Bool = ...
+  /// \endcode
+  ///
+  /// The outermost attribute in this case is `@A` and it has
+  /// complete wrapper type `A<B<C<Bool>>>`.
+  CustomAttr *getOutermostAttachedPropertyWrapper() const {
+    auto wrappers = getAttachedPropertyWrappers();
+    return wrappers.empty() ? nullptr : wrappers.front();
+  }
+
   /// Whether this property has any attached property wrappers.
   bool hasAttachedPropertyWrapper() const;
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6532,7 +6532,7 @@ bool VarDecl::hasExternalPropertyWrapper() const {
     return true;
 
   // Wrappers with attribute arguments are always implementation-detail.
-  if (getAttachedPropertyWrappers().front()->hasArgs())
+  if (getOutermostAttachedPropertyWrapper()->hasArgs())
     return false;
 
   auto wrapperInfo = getAttachedPropertyWrapperTypeInfo(0);

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8564,8 +8564,8 @@ static Optional<SolutionApplicationTarget> applySolutionToInitialization(
         wrappedVar, initType->mapTypeOutOfContext());
 
     // Record the semantic initializer on the outermost property wrapper.
-    wrappedVar->getAttachedPropertyWrappers().front()
-        ->setSemanticInit(initializer);
+    wrappedVar->getOutermostAttachedPropertyWrapper()->setSemanticInit(
+        initializer);
 
     // If this is a wrapped parameter, we're done.
     if (isa<ParamDecl>(wrappedVar))
@@ -8983,7 +8983,7 @@ ExprWalker::rewriteTarget(SolutionApplicationTarget target) {
     return target;
   } else if (auto *wrappedVar = target.getAsUninitializedWrappedVar()) {
     // Get the outermost wrapper type from the solution
-    auto outermostWrapper = wrappedVar->getAttachedPropertyWrappers().front();
+    auto outermostWrapper = wrappedVar->getOutermostAttachedPropertyWrapper();
     auto backingType = solution.simplifyType(
         solution.getType(outermostWrapper->getTypeExpr()));
 

--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -94,7 +94,7 @@ public:
 
       if (auto *wrappedVar = var->getOriginalWrappedProperty()) {
         auto outermostWrapperAttr =
-            wrappedVar->getAttachedPropertyWrappers().front();
+            wrappedVar->getOutermostAttachedPropertyWrapper();
 
         // If the attribute doesn't have a type it could only mean
         // that the declaration was incorrect.

--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -85,6 +85,34 @@ public:
         }
 
         inferVariables(type);
+        return {true, expr};
+      }
+
+      auto var = dyn_cast<VarDecl>(decl);
+      if (!var)
+        return {true, expr};
+
+      if (auto *wrappedVar = var->getOriginalWrappedProperty()) {
+        auto outermostWrapperAttr =
+            wrappedVar->getAttachedPropertyWrappers().front();
+
+        // If the attribute doesn't have a type it could only mean
+        // that the declaration was incorrect.
+        if (!CS.hasType(outermostWrapperAttr->getTypeExpr()))
+          return {true, expr};
+
+        auto wrapperType =
+            CS.simplifyType(CS.getType(outermostWrapperAttr->getTypeExpr()));
+
+        if (var->getName().hasDollarPrefix()) {
+          // $<name> is the projected value var
+          CS.setType(var, computeProjectedValueType(wrappedVar, wrapperType));
+        } else {
+          // _<name> is the wrapper var
+          CS.setType(var, computeWrappedValueType(wrappedVar, wrapperType));
+        }
+
+        return {true, expr};
       }
     }
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3568,7 +3568,7 @@ bool InvalidProjectedValueArgument::diagnoseAsError() {
   if (!param->hasAttachedPropertyWrapper()) {
     param->diagnose(diag::property_wrapper_param_no_wrapper, param->getName());
   } else if (!param->hasImplicitPropertyWrapper() &&
-             param->getAttachedPropertyWrappers().front()->hasArgs()) {
+             param->getOutermostAttachedPropertyWrapper()->hasArgs()) {
     param->diagnose(diag::property_wrapper_param_attr_arg);
   } else {
     Type backingType;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9989,7 +9989,7 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
         wrappedValueType = createTypeVariable(getConstraintLocator(paramDecl),
                                               TVO_CanBindToHole | TVO_CanBindToLValue);
       } else {
-        auto *wrapperAttr = paramDecl->getAttachedPropertyWrappers().front();
+        auto *wrapperAttr = paramDecl->getOutermostAttachedPropertyWrapper();
         auto wrapperType = paramDecl->getAttachedPropertyWrapperType(0);
         backingType = replaceInferableTypesWithTypeVars(
             wrapperType, getConstraintLocator(wrapperAttr->getTypeRepr()));

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -6327,9 +6327,9 @@ void ConstraintSystem::diagnoseFailureFor(SolutionApplicationTarget target) {
     DE.diagnose(expr->getLoc(), diag::type_of_expression_is_ambiguous)
         .highlight(expr->getSourceRange());
   } else if (auto *wrappedVar = target.getAsUninitializedWrappedVar()) {
-    auto *wrapper = wrappedVar->getAttachedPropertyWrappers().back();
+    auto *outerWrapper = wrappedVar->getOutermostAttachedPropertyWrapper();
     Type propertyType = wrappedVar->getInterfaceType();
-    Type wrapperType = wrapper->getType();
+    Type wrapperType = outerWrapper->getType();
 
     // Emit the property wrapper fallback diagnostic
     wrappedVar->diagnose(diag::property_wrapper_incompatible_property,

--- a/validation-test/Sema/type_checker_crashers_fixed/issue59294.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/issue59294.swift
@@ -1,6 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 
 // https://github.com/apple/swift/issues/59294
+// https://github.com/apple/swift/issues/59295
 
 @propertyWrapper
 struct WrapperValue<Value> {
@@ -25,18 +26,94 @@ struct WrapperValue<Value> {
   func printValue() {
     print(value)
   }
+
+  func returnValue() -> Value {
+    return value
+  }
 }
 
+@propertyWrapper
+struct OuterWrapper<Value> {
+  var value: Value
+  init(wrappedValue: Value) {
+    self.value = wrappedValue
+  }
+
+  var projectedValue: Self {
+    return self
+  }
+
+  var wrappedValue: Value {
+    get {
+      self.value
+    }
+    set {
+      self.value = newValue
+    }
+  }
+}
 
 class Test {
   static func test() {
     return [0, 1, 2].compactMap { _ in // expected-error {{unexpected non-void return value in void function}} expected-note {{did you mean to add a return type?}}
       @WrapperValue var value: Bool? = false
       if value != nil {
+        $value.printValue()
         return false
       }
 
       return value ?? false
+    }
+  }
+  static func testProjectedAndWrapperVars() {
+    func test(_: (Int) -> Bool) {}
+    func test(_: (String) -> Void) {}
+
+    test {
+      @WrapperValue var value = $0
+      if $value.returnValue() > 0 {
+        test {
+          return $value.returnValue() == $0 &&
+                 _value == $0
+        }
+      }
+      return false
+    }
+
+    test {
+      @WrapperValue var value = $0
+
+      test {
+        if _value != $0 { // Ok
+          $value.printValue()
+        }
+      }
+    }
+  }
+
+  static func testNestedWrappers() {
+    func test(_: (Bool) -> Void) {}
+    func test(_: () -> Void) {}
+
+    test {
+      if true {
+        @OuterWrapper @WrapperValue var value = $0
+        if true {
+          let _: Bool = _value == $0
+          let _: OuterWrapper<WrapperValue<Bool>> = $value
+          let _: Bool = value
+        }
+      }
+    }
+  }
+
+  static func invalidVar() {
+    _ = [0, 1, 2].compactMap {
+      @WrapperValue var value: Bool? = $0
+      // expected-error@-1 {{cannot convert value of type 'Int' to specified type 'Bool?'}}
+      if true {
+        $value.printValue()
+      }
     }
   }
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/60384

---

- Explanation:

Fixes a regression introduced in 5.7 where references to projected/wrapper vars,
originating from a property wrapped variable declared in a multi-statement closure,
are going to be rejected by the compiler.

To support referencing projected and/or wrapped var in a closure solver needs to
lookup a type of their originator and based on the wrapper type compute and
assign types to projection and/or wrapper.

- Scope: Use of projection and wrapper variables of a property wrapped variable in a multi-statement closure.

- Main Branch PR: https://github.com/apple/swift/pull/60384

- Resolves: rdar://94506352

- Risk: Very low

- Reviewed By: @hborla 

- Testing:  Added a regression test-case to the suite.

Resolves: https://github.com/apple/swift/issues/59295
Resolves: rdar://94506352

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
