### PR TITLE
[ConstraintSystem] NFC: Fix a warning by switching from `dumpContext`…

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -6131,7 +6131,7 @@ void SolutionApplicationTargetsKey::dump(raw_ostream &OS) const {
 
   case Kind::functionRef:
     OS << "<function>\n";
-    storage.functionRef->dumpContext();
+    storage.functionRef->printContext(OS);
     return;
   }
   llvm_unreachable("invalid statement kind");


### PR DESCRIPTION
… to `printContext`

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
