### PR TITLE
[AST] Remove defaulted SmallVector use

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -882,7 +882,7 @@ Type TypeBase::lookThroughAllOptionalTypes(SmallVectorImpl<Type> &optionals){
 }
 
 unsigned int TypeBase::getOptionalityDepth() {
-  SmallVector<Type> types;
+  SmallVector<Type, 4> types;
   lookThroughAllOptionalTypes(types);
   return types.size();
 }


### PR DESCRIPTION
There's a bug in the compiler on CentOS 7 which causes the template
arguments not to be merged correctly. Use the non-defaulted form until
CentOS 7 is no longer supported.