### PR TITLE
AST/IRGen: Accept `@_weakLinked` on import decls to force weak linkage of symbols from a module

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -456,7 +456,8 @@ DECL_ATTR(_clangImporterSynthesizedType, ClangImporterSynthesizedType,
   74)
 SIMPLE_DECL_ATTR(_weakLinked, WeakLinked,
   OnNominalType | OnAssociatedType | OnFunc | OnAccessor | OnVar |
-  OnSubscript | OnConstructor | OnEnumElement | OnExtension | UserInaccessible |
+  OnSubscript | OnConstructor | OnEnumElement | OnExtension | OnImport |
+  UserInaccessible |
   ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   75)
 SIMPLE_DECL_ATTR(frozen, Frozen,

--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -123,6 +123,17 @@ public:
                             const ModuleDecl *importedModule,
                             SmallSetVector<Identifier, 4> &spiGroups) const {};
 
+  /// Checks whether this file imports \c module as \c @_weakLinked.
+  virtual bool importsModuleAsWeakLinked(const ModuleDecl *module) const {
+    // For source files, this should be overridden to inspect the import
+    // declarations in the file. Other kinds of file units, like serialized
+    // modules, can just use this default implementation since the @_weakLinked
+    // attribute is not transitive. If module C is imported @_weakLinked by
+    // module B, that does not imply that module A imports module C @_weakLinked
+    // if it imports module B.
+    return false;
+  }
+
   virtual Optional<Fingerprint>
   loadFingerprint(const IterableDeclContext *IDC) const { return None; }
 

--- a/include/swift/AST/Import.h
+++ b/include/swift/AST/Import.h
@@ -84,6 +84,9 @@ enum class ImportFlags {
   /// concurrency.
   Preconcurrency = 0x20,
 
+  /// The module's symbols are linked weakly.
+  WeakLinked = 0x40,
+
   /// Used for DenseMap.
   Reserved = 0x80
 };

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -686,6 +686,9 @@ public:
   // Is \p spiGroup accessible as an explicitly imported SPI from this module?
   bool isImportedAsSPI(Identifier spiGroup, const ModuleDecl *fromModule) const;
 
+  /// Is \p importedModule imported as \c @_weakLinked from this module?
+  bool importsModuleAsWeakLinked(const ModuleDecl *importedModule) const;
+
   /// \sa getImportedModules
   enum class ImportFilterKind {
     /// Include imports declared with `@_exported`.

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -414,11 +414,10 @@ private:
   /// present overlays as if they were part of their underlying module.
   std::pair<ModuleDecl *, Identifier> getDeclaringModuleAndBystander();
 
+public:
   ///  If this is a traditional (non-cross-import) overlay, get its underlying
   ///  module if one exists.
   ModuleDecl *getUnderlyingModuleIfOverlay() const;
-
-public:
 
   /// Returns true if this module is an underscored cross import overlay
   /// declared by \p other or its underlying clang module, either directly or
@@ -686,8 +685,9 @@ public:
   // Is \p spiGroup accessible as an explicitly imported SPI from this module?
   bool isImportedAsSPI(Identifier spiGroup, const ModuleDecl *fromModule) const;
 
-  /// Is \p importedModule imported as \c @_weakLinked from this module?
-  bool importsModuleAsWeakLinked(const ModuleDecl *importedModule) const;
+  /// Is \p targetDecl from a module that is imported as \c @_weakLinked from
+  /// this module?
+  bool isImportedAsWeakLinked(const Decl *targetDecl) const;
 
   /// \sa getImportedModules
   enum class ImportFilterKind {

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -356,6 +356,9 @@ public:
                 const ModuleDecl *importedModule,
                 llvm::SmallSetVector<Identifier, 4> &spiGroups) const override;
 
+  /// Is \p module imported as \c @_weakLinked by this file?
+  bool importsModuleAsWeakLinked(const ModuleDecl *module) const override;
+
   // Is \p targetDecl accessible as an explicitly imported SPI from this file?
   bool isImportedAsSPI(const ValueDecl *targetDecl) const;
 

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -64,6 +64,11 @@ enum IsDistributed_t {
   IsNotDistributed,
   IsDistributed,
 };
+enum IsWeakImported_t {
+  IsNotWeakImported,
+  IsWeakImportedByModule,
+  IsAlwaysWeakImported,
+};
 
 enum class PerformanceConstraints : uint8_t {
   None = 0,
@@ -317,9 +322,8 @@ private:
   /// would indicate.
   unsigned HasCReferences : 1;
 
-  /// Whether cross-module references to this function should always use
-  /// weak linking.
-  unsigned IsWeakImported : 1;
+  /// Whether cross-module references to this function should use weak linking.
+  unsigned IsWeakImported : 2;
 
   /// Whether the implementation can be dynamically replaced.
   unsigned IsDynamicReplaceable : 1;
@@ -797,11 +801,17 @@ public:
 
   /// Returns whether this function's symbol must always be weakly referenced
   /// across module boundaries.
-  bool isAlwaysWeakImported() const { return IsWeakImported; }
-
-  void setAlwaysWeakImported(bool value) {
-    IsWeakImported = value;
+  bool isAlwaysWeakImported() const {
+    return IsWeakImported == IsWeakImported_t::IsAlwaysWeakImported;
   }
+
+  /// Returns whether this function's symbol was referenced by a module that
+  /// imports the defining module \c @_weakLinked.
+  bool isWeakImportedByModule() const {
+    return IsWeakImported == IsWeakImported_t::IsWeakImportedByModule;
+  }
+
+  void setIsWeakImported(IsWeakImported_t value) { IsWeakImported = value; }
 
   bool isWeakImported() const;
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1002,6 +1002,9 @@ bool Decl::isWeakImported(ModuleDecl *fromModule) const {
   if (isAlwaysWeakImported())
     return true;
 
+  if (fromModule->importsModuleAsWeakLinked(getModuleContext()))
+    return true;
+
   auto availability = getAvailabilityForLinkage();
   if (availability.isAlwaysAvailable())
     return false;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1002,7 +1002,7 @@ bool Decl::isWeakImported(ModuleDecl *fromModule) const {
   if (isAlwaysWeakImported())
     return true;
 
-  if (fromModule->importsModuleAsWeakLinked(getModuleContext()))
+  if (fromModule->isImportedAsWeakLinked(this))
     return true;
 
   auto availability = getAvailabilityForLinkage();

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2574,6 +2574,15 @@ bool SourceFile::isImportedAsSPI(const ValueDecl *targetDecl) const {
   return false;
 }
 
+bool SourceFile::importsModuleAsWeakLinked(const ModuleDecl *module) const {
+  for (auto &import : *Imports) {
+    if (import.options.contains(ImportFlags::WeakLinked) &&
+        module == import.module.importedModule)
+      return true;
+  }
+  return false;
+}
+
 bool ModuleDecl::isImportedAsSPI(const SpecializeAttr *attr,
                                  const ValueDecl *targetDecl) const {
   auto targetModule = targetDecl->getModuleContext();
@@ -2597,6 +2606,15 @@ bool ModuleDecl::isImportedAsSPI(Identifier spiGroup,
   if (importedSPIGroups.empty())
     return false;
   return importedSPIGroups.count(spiGroup);
+}
+
+bool ModuleDecl::importsModuleAsWeakLinked(
+    const ModuleDecl *importedModule) const {
+  for (auto file : getFiles()) {
+    if (file->importsModuleAsWeakLinked(importedModule))
+      return true;
+  }
+  return false;
 }
 
 bool Decl::isSPI() const {

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -462,7 +462,7 @@ bool SILFunction::isWeakImported() const {
   if (!isAvailableExternally())
     return false;
 
-  if (isAlwaysWeakImported())
+  if (isAlwaysWeakImported() || isWeakImportedByModule())
     return true;
 
   if (Availability.isAlwaysAvailable())

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -453,6 +453,9 @@ bool SILFunction::isTypeABIAccessible(SILType type) const {
 }
 
 bool SILFunction::isWeakImported() const {
+  if (isWeakImportedByModule())
+    return true;
+
   // For imported functions check the Clang declaration.
   if (ClangNodeOwner)
     return ClangNodeOwner->getClangDecl()->isWeakImported();
@@ -462,7 +465,7 @@ bool SILFunction::isWeakImported() const {
   if (!isAvailableExternally())
     return false;
 
-  if (isAlwaysWeakImported() || isWeakImportedByModule())
+  if (isAlwaysWeakImported())
     return true;
 
   if (Availability.isAlwaysAvailable())

--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -312,7 +312,14 @@ SILFunction *SILFunctionBuilder::getOrCreateFunction(
       F->setClangNodeOwner(decl);
 
     F->setAvailabilityForLinkage(decl->getAvailabilityForLinkage());
-    F->setAlwaysWeakImported(decl->isAlwaysWeakImported());
+
+    if (decl->isAlwaysWeakImported()) {
+      F->setIsWeakImported(IsWeakImported_t::IsAlwaysWeakImported);
+    } else if (decl->isWeakImported(mod.getSwiftModule())) {
+      F->setIsWeakImported(IsWeakImported_t::IsWeakImportedByModule);
+    } else {
+      F->setIsWeakImported(IsWeakImported_t::IsNotWeakImported);
+    }
 
     if (auto *accessor = dyn_cast<AccessorDecl>(decl)) {
       auto *storage = accessor->getStorage();

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -6483,7 +6483,9 @@ bool SILParserState::parseDeclSIL(Parser &P) {
     if (!objCReplacementFor.empty())
       FunctionState.F->setObjCReplacement(objCReplacementFor);
     FunctionState.F->setSpecialPurpose(specialPurpose);
-    FunctionState.F->setAlwaysWeakImported(isWeakImported);
+    FunctionState.F->setIsWeakImported(
+        isWeakImported ? IsWeakImported_t::IsAlwaysWeakImported
+                       : IsWeakImported_t::IsNotWeakImported);
     FunctionState.F->setAvailabilityForLinkage(availability);
     FunctionState.F->setWithoutActuallyEscapingThunk(
       isWithoutActuallyEscapingThunk);

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -554,6 +554,9 @@ UnboundImport::UnboundImport(ImportDecl *ID)
     import.options |= ImportFlags::Preconcurrency;
     import.preconcurrencyRange = attr->getRangeWithAt();
   }
+
+  if (auto attr = ID->getAttrs().getAttribute<WeakLinkedAttr>())
+    import.options |= ImportFlags::WeakLinked;
 }
 
 bool UnboundImport::checkNotTautological(const SourceFile &SF) {

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -661,7 +661,9 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
     fn->setEffectsKind(EffectsKind(effect));
     fn->setOptimizationMode(OptimizationMode(optimizationMode));
     fn->setPerfConstraints((PerformanceConstraints)perfConstr);
-    fn->setAlwaysWeakImported(isWeakImported);
+    fn->setIsWeakImported(isWeakImported
+                              ? IsWeakImported_t::IsAlwaysWeakImported
+                              : IsWeakImported_t::IsNotWeakImported);
     fn->setClassSubclassScope(SubclassScope(subclassScope));
     fn->setHasCReferences(bool(hasCReferences));
 

--- a/test/IRGen/Inputs/usr/include/BridgeTestFoundation.h
+++ b/test/IRGen/Inputs/usr/include/BridgeTestFoundation.h
@@ -53,10 +53,13 @@ __attribute__((availability(macosx,introduced=10.51)))
 @interface NSUserNotificationAction : NSObject
 @end
 
+void always_available_function();
+
 __attribute__((availability(macosx,introduced=10.51)))
 void future_function_should_be_weak();
 
 extern int weak_variable __attribute__((weak_import));
+extern int strong_variable;
 
 @interface NSError : NSObject
 

--- a/test/IRGen/Inputs/weaklinked_import_helper.swift
+++ b/test/IRGen/Inputs/weaklinked_import_helper.swift
@@ -1,0 +1,82 @@
+public func fn() {}
+
+public var globalStored = 0
+
+public var globalComputed: Int {
+  get { return 1 }
+  set {}
+}
+
+public struct S {
+  public func fn() {}
+
+  public var storedProp = 0
+
+  public var computedProp: Int {
+    get { return 1 }
+    set {}
+  }
+
+  public init() {}
+
+  public subscript(_: Int) -> Int {
+    get { return 1 }
+    set {}
+  }
+}
+
+public enum E {
+  case basic
+  case assoc(Int)
+}
+
+open class C {
+  open func fn() {}
+
+  open var storedProp = 0
+
+  open var computedProp: Int {
+    get { return 1 }
+    set {}
+  }
+
+  public init() {}
+
+  open subscript(_: Int) -> Int {
+    get { return 1 }
+    set {}
+  }
+}
+
+public protocol P {
+  func fn()
+
+  var prop: Int { get set }
+
+  init()
+
+  subscript(_: Int) -> Int { get set }
+}
+
+public struct GenericS<T> {}
+
+public enum GenericE<T> {}
+
+open class GenericC<T> {
+  public init() {}
+}
+
+public protocol OtherProtocol {}
+public struct ConcreteType: OtherProtocol {}
+
+public protocol ProtocolWithAssoc {
+  associatedtype T: OtherProtocol = ConcreteType
+  func f()
+}
+
+extension ProtocolWithAssoc {
+  public func f() {}
+}
+
+public protocol BaseP {}
+extension S: BaseP {}

--- a/test/IRGen/Inputs/weaklinked_import_helper.swift
+++ b/test/IRGen/Inputs/weaklinked_import_helper.swift
@@ -1,5 +1,13 @@
 public func fn() {}
 
+@usableFromInline
+func usableFromInlineFn() {}
+
+@_alwaysEmitIntoClient
+public func alwaysEmitIntoClientFn() {
+  usableFromInlineFn()
+}
+
 public var globalStored = 0
 
 public var globalComputed: Int {

--- a/test/IRGen/weaklinked_import.swift
+++ b/test/IRGen/weaklinked_import.swift
@@ -1,0 +1,157 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/weaklinked_import_helper.swiftmodule -parse-as-library %S/Inputs/weaklinked_import_helper.swift -enable-library-evolution
+//
+// RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir | %FileCheck %s
+
+@_weakLinked import weaklinked_import_helper
+
+// CHECK-DAG: @"$s24weaklinked_import_helper12ConcreteTypeVAA13OtherProtocolAAWP" = extern_weak global i8*
+// CHECK-DAG: @"$s24weaklinked_import_helper12ConcreteTypeVMn" = extern_weak global %swift.type_descriptor
+// CHECK-DAG: @"$s24weaklinked_import_helper17ProtocolWithAssocMp" = extern_weak global %swift.protocol
+// CHECK-DAG: @"$s24weaklinked_import_helper17ProtocolWithAssocP1TAC_AA05OtherD0Tn" = extern_weak global %swift.protocol_requirement
+// CHECK-DAG: @"$s1T24weaklinked_import_helper17ProtocolWithAssocPTl" = extern_weak global %swift.protocol_requirement
+// CHECK-DAG: @"$s24weaklinked_import_helper17ProtocolWithAssocP1fyyFTq" = extern_weak global %swift.method_descriptor
+// CHECK-DAG: declare extern_weak {{.+}} @"$s24weaklinked_import_helper17ProtocolWithAssocPAAE1fyyF"
+struct ConformsToProtocolWithAssoc: ProtocolWithAssoc {}
+
+func testTopLevel() {
+  // CHECK-DAG: declare extern_weak {{.+}} @"$s24weaklinked_import_helper2fnyyF"()
+  fn()
+
+  // CHECK-DAG: declare extern_weak {{.+}} @"$s24weaklinked_import_helper12globalStoredSivg"
+  // CHECK-DAG: declare extern_weak {{.+}} @"$s24weaklinked_import_helper12globalStoredSivs"
+  // CHECK-DAG: declare extern_weak {{.+}} @"$s24weaklinked_import_helper12globalStoredSivM"
+  let x = globalStored
+  globalStored = x
+  globalStored += 1
+
+  // CHECK-DAG: declare extern_weak {{.+}} @"$s24weaklinked_import_helper14globalComputedSivg"
+  // CHECK-DAG: declare extern_weak {{.+}} @"$s24weaklinked_import_helper14globalComputedSivs"
+  // CHECK-DAG: declare extern_weak {{.+}} @"$s24weaklinked_import_helper14globalComputedSivM"
+  let y = globalComputed
+  globalComputed = y
+  globalComputed += 1
+}
+
+func testStruct() {
+  // CHECK-DAG: declare extern_weak {{.+}} @"$s24weaklinked_import_helper1SVMa"
+  _ = MemoryLayout<S>.size
+
+  // CHECK-DAG: declare extern_weak {{.+}} @"$s24weaklinked_import_helper1SVACycfC"
+  var s = S()
+
+  // CHECK-DAG: declare extern_weak {{.+}} @"$s24weaklinked_import_helper1SV2fnyyF"
+  s.fn()
+
+  // CHECK-DAG: declare extern_weak {{.+}} @"$s24weaklinked_import_helper1SV10storedPropSivg"
+  // CHECK-DAG: declare extern_weak {{.+}} @"$s24weaklinked_import_helper1SV10storedPropSivs"
+  // CHECK-DAG: declare extern_weak {{.+}} @"$s24weaklinked_import_helper1SV10storedPropSivM"
+  let x = s.storedProp
+  s.storedProp = x
+  s.storedProp += 1
+
+  // CHECK-DAG: declare extern_weak {{.+}} @"$s24weaklinked_import_helper1SV12computedPropSivg"
+  // CHECK-DAG: declare extern_weak {{.+}} @"$s24weaklinked_import_helper1SV12computedPropSivs"
+  // CHECK-DAG: declare extern_weak {{.+}} @"$s24weaklinked_import_helper1SV12computedPropSivM"
+  let y = s.computedProp
+  s.computedProp = y
+  s.computedProp += 1
+
+  // CHECK-DAG: declare extern_weak {{.+}} @"$s24weaklinked_import_helper1SVyS2icig"
+  // CHECK-DAG: declare extern_weak {{.+}} @"$s24weaklinked_import_helper1SVyS2icis"
+  // CHECK-DAG: declare extern_weak {{.+}} @"$s24weaklinked_import_helper1SVyS2iciM"
+  let z = s[0]
+  s[0] = z
+  s[0] += 1
+}
+
+func testEnum() {
+  // CHECK-DAG: declare extern_weak {{.+}} @"$s24weaklinked_import_helper1EOMa"
+  _ = MemoryLayout<E>.size
+
+  // CHECK-DAG: @"$s24weaklinked_import_helper1EO5basicyA2CmFWC" = extern_weak constant i32
+  _ = E.basic
+
+  // CHECK-DAG: @"$s24weaklinked_import_helper1EO5assocyACSicACmFWC" = extern_weak constant i32
+  _ = E.assoc(0)
+}
+
+func testClass() {
+  // CHECK-DAG: declare extern_weak {{.+}} @"$s24weaklinked_import_helper1CCMa"
+  // CHECK-DAG: declare extern_weak {{.+}} @"$s24weaklinked_import_helper1CCACycfC"
+  let c = C()
+
+  // CHECK-DAG: declare extern_weak {{.+}} @"$s24weaklinked_import_helper1CC2fnyyFTj"
+  c.fn()
+
+  // CHECK-DAG: declare extern_weak swiftcc {{.+}} @"$s24weaklinked_import_helper1CC10storedPropSivgTj"
+  // CHECK-DAG: declare extern_weak swiftcc {{.+}} @"$s24weaklinked_import_helper1CC10storedPropSivsTj"
+  // CHECK-DAG: declare extern_weak swiftcc {{.+}} @"$s24weaklinked_import_helper1CC10storedPropSivMTj"
+  let x = c.storedProp
+  c.storedProp = x
+  c.storedProp += 1
+
+  // CHECK-DAG: declare extern_weak swiftcc {{.+}} @"$s24weaklinked_import_helper1CC12computedPropSivgTj"
+  // CHECK-DAG: declare extern_weak swiftcc {{.+}} @"$s24weaklinked_import_helper1CC12computedPropSivsTj"
+  // CHECK-DAG: declare extern_weak swiftcc {{.+}} @"$s24weaklinked_import_helper1CC12computedPropSivMTj"
+  let y = c.computedProp
+  c.computedProp = y
+  c.computedProp += 1
+
+  // CHECK-DAG: declare extern_weak swiftcc {{.+}} @"$s24weaklinked_import_helper1CCyS2icigTj"
+  // CHECK-DAG: declare extern_weak swiftcc {{.+}} @"$s24weaklinked_import_helper1CCyS2icisTj"
+  // CHECK-DAG: declare extern_weak swiftcc {{.+}} @"$s24weaklinked_import_helper1CCyS2iciMTj"
+  let z = c[0]
+  c[0] = z
+  c[0] += 1
+}
+
+// CHECK-DAG: @"$s24weaklinked_import_helper1CCMn" = extern_weak global %swift.type_descriptor
+// CHECK-DAG: @"$s24weaklinked_import_helper1CCACycfCTq" = extern_weak global %swift.method_descriptor
+// CHECK-DAG: declare extern_weak swiftcc {{.+}} @"$s24weaklinked_import_helper1CCACycfc"
+// CHECK-DAG: declare extern_weak swiftcc {{.+}} @"$s24weaklinked_import_helper1CCfd"
+class Sub: C {}
+
+func testProtocolExistential(_ p: P) {
+  var mutP = p
+
+  // CHECK-DAG: declare extern_weak {{.+}} @"$s24weaklinked_import_helper1PP2fnyyFTj"
+  p.fn()
+
+  // CHECK-DAG: declare extern_weak swiftcc {{.+}} @"$s24weaklinked_import_helper1PP4propSivgTj"
+  // CHECK-DAG: declare extern_weak swiftcc {{.+}} @"$s24weaklinked_import_helper1PP4propSivsTj"
+  // CHECK-DAG: declare extern_weak swiftcc {{.+}} @"$s24weaklinked_import_helper1PP4propSivMTj"
+  let x = p.prop
+  mutP.prop = x
+  mutP.prop += 1
+
+  // CHECK-DAG: declare extern_weak swiftcc {{.+}} @"$s24weaklinked_import_helper1PPyS2icigTj"
+  // CHECK-DAG: declare extern_weak swiftcc {{.+}} @"$s24weaklinked_import_helper1PPyS2icisTj"
+  // CHECK-DAG: declare extern_weak swiftcc {{.+}} @"$s24weaklinked_import_helper1PPyS2iciMTj"
+  let z = p[0]
+  mutP[0] = z
+  mutP[0] += 1
+}
+
+func testProtocolGeneric<Impl: P>(_ type: Impl.Type) {
+  // CHECK-DAG: declare extern_weak {{.+}} @"$s24weaklinked_import_helper1PPxycfCTj"
+  var mutP = type.init()
+
+  mutP.fn()
+
+  let x = mutP.prop
+  mutP.prop = x
+  mutP.prop += 1
+
+  let z = mutP[0]
+  mutP[0] = z
+  mutP[0] += 1
+}
+
+// CHECK-DAG: @"$s24weaklinked_import_helper5BasePMp" = extern_weak global %swift.protocol
+protocol RefinesP: BaseP {}
+
+// CHECK-DAG: @"$s24weaklinked_import_helper1SVAA5BasePAAWP" = extern_weak global i8*
+// CHECK-DAG: @"$s24weaklinked_import_helper1SVMn" = extern_weak global %swift.type_descriptor
+extension S: RefinesP {}

--- a/test/IRGen/weaklinked_import.swift
+++ b/test/IRGen/weaklinked_import.swift
@@ -157,3 +157,12 @@ protocol RefinesP: BaseP {}
 // CHECK-DAG: @"$s24weaklinked_import_helper1SVAA5BasePAAWP" = extern_weak global i8*
 // CHECK-DAG: @"$s24weaklinked_import_helper1SVMn" = extern_weak global %swift.type_descriptor
 extension S: RefinesP {}
+
+func testInlining() {
+  // FIXME: usableFromInlineFn() should be extern_weak but isn't because
+  //        inlining doesn't respect @_weakLinked import yet.
+
+  // CHECK-DAG: define linkonce_odr hidden {{.+}} @"$s24weaklinked_import_helper22alwaysEmitIntoClientFnyyF"()
+  // CHECK-DAG: declare swiftcc {{.+}} @"$s24weaklinked_import_helper18usableFromInlineFnyyF"
+  alwaysEmitIntoClientFn()
+}

--- a/test/IRGen/weaklinked_import.swift
+++ b/test/IRGen/weaklinked_import.swift
@@ -4,6 +4,8 @@
 //
 // RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir | %FileCheck %s
 
+// UNSUPPORTED: OS=windows-msvc
+
 @_weakLinked import weaklinked_import_helper
 
 // CHECK-DAG: @"$s24weaklinked_import_helper12ConcreteTypeVAA13OtherProtocolAAWP" = extern_weak global i8*

--- a/test/IRGen/weaklinked_import_clang.swift
+++ b/test/IRGen/weaklinked_import_clang.swift
@@ -1,0 +1,30 @@
+// RUN: %empty-directory(%t)
+// RUN: %build-irgen-test-overlays
+
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+@_weakLinked import Foundation
+
+func testObjCClass() {
+  // CHECK-DAG: @"OBJC_CLASS_$_NSNotification" = extern_weak global %objc_class
+  _ = NSNotification()
+}
+
+func testGlobalVariables() {
+  // CHECK-DAG: @weak_variable = extern_weak global
+  _ = weak_variable
+
+  // CHECK-DAG: @strong_variable = extern_weak global
+  _ = strong_variable
+}
+
+func testFunctions() {
+  // CHECK-DAG: declare extern_weak void @always_available_function()
+  always_available_function()
+}
+
+// CHECK-DAG: @"OBJC_CLASS_$_NSNumber" = extern_weak global %objc_class
+// CHECK-DAG: @"OBJC_METACLASS_$_NSNumber" = extern_weak global %objc_class
+class CustomNumber: NSNumber {}

--- a/test/IRGen/weaklinked_import_transitive.swift
+++ b/test/IRGen/weaklinked_import_transitive.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)
+//
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/weaklinked_import_helper.swiftmodule -parse-as-library %S/Inputs/weaklinked_import_helper.swift -enable-library-evolution
+//
+// RUN: echo '@_weakLinked import weaklinked_import_helper' > %t/intermediate.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/intermediate.swiftmodule -parse-as-library %t/intermediate.swift -I %t -enable-library-evolution
+//
+// RUN: %target-swift-frontend -primary-file %s -I %t -emit-ir | %FileCheck %s
+
+// UNSUPPORTED: OS=windows-msvc
+
+import intermediate
+import weaklinked_import_helper
+
+// Symbols from weaklinked_import_helper should be strong, despite intermediate
+// importining the module @_weakLinked.
+
+// CHECK-DAG: declare swiftcc {{.+}} @"$s24weaklinked_import_helper2fnyyF"()
+fn()

--- a/test/ModuleInterface/weaklinked-import.swift
+++ b/test/ModuleInterface/weaklinked-import.swift
@@ -1,0 +1,14 @@
+// RUN: %empty-directory(%t)
+//
+// RUN: echo 'public struct S {}' > %t/Other.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/Other.swiftmodule -parse-as-library %t/Other.swift -enable-library-evolution
+//
+// RUN: %target-swift-emit-module-interface(%t/WeakLinksOther.swiftinterface) %s -I %t
+// RUN: %target-swift-typecheck-module-from-interface(%t/WeakLinksOther.swiftinterface) -I %t
+// RUN: %FileCheck %s < %t/WeakLinksOther.swiftinterface
+
+// UNSUPPORTED: OS=windows-msvc
+
+// The @_weakLinked attribute should not be printed in swiftinterfaces.
+// CHECK-NOT: @_weakLinked
+@_weakLinked import Other


### PR DESCRIPTION
The effect of declaring an import `@_weakLinked` is to treat every declaration from the module as if it were declared with `@_weakLinked`. This is useful in environments where entire modules may not be present at runtime. Although it is already possible to instruct the linker to weakly link an entire dylib, a Swift attribute provides a way to declare intent in source code and also opens the door to diagnostics and other compiler behaviors that depend on knowing that all the module's symbols will be weakly linked.

The `@_weakLinked` attribute on imports is not transitive; if module A imports module B which `@_weakLinked` imports module C, it does not follow that A should weakly link symbols from C. Just because B needs to operate on runtimes where C is absent does not mean A needs to also operate on runtimes where C is absent. Therefore the `@_weakLinked` attribute is not serialized in binary modules nor is it printed in swiftinterface files.

Resolves rdar://96098097.