### PR TITLE
[Serialization] Filter internal decls before full deserialization when appropriate

### DIFF
--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -208,7 +208,15 @@ public:
   ///
   /// This does a simple local lookup, not recursively looking through imports.
   /// The order of the results is not guaranteed to be meaningful.
-  virtual void getTopLevelDecls(SmallVectorImpl<Decl*> &results) const {}
+  ///
+  /// \param results Vector collecting the top-level decls.
+  ///
+  /// \p minAccessLevel If set, allow implementations to avoid collecting decls
+  /// that are more private than the given access level. This is applied in
+  /// deserialization \c ModuleFile to limit deserialization work. Other
+  /// implementations may still return decls under that access level.
+  virtual void getTopLevelDecls(SmallVectorImpl<Decl*> &results,
+                                Optional<AccessLevel> minAccessLevel = None) const {}
 
   virtual void
   getExportedPrespecializations(SmallVectorImpl<Decl *> &results) const {}

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -736,7 +736,8 @@ public:
   ///
   /// This does a simple local lookup, not recursively looking through imports.
   /// The order of the results is not guaranteed to be meaningful.
-  void getTopLevelDecls(SmallVectorImpl<Decl*> &Results) const;
+  void getTopLevelDecls(SmallVectorImpl<Decl*> &Results,
+                        Optional<AccessLevel> minAccessLevel = None) const;
 
   void getExportedPrespecializations(SmallVectorImpl<Decl *> &results) const;
 

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -429,7 +429,9 @@ protected:
       TinyPtrVector<PrecedenceGroupDecl *> &results) const override;
 
 public:
-  virtual void getTopLevelDecls(SmallVectorImpl<Decl*> &results) const override;
+  virtual void
+  getTopLevelDecls(SmallVectorImpl<Decl*> &results,
+                   Optional<AccessLevel> minAccessLevel = None) const override;
 
   virtual void
   getOperatorDecls(SmallVectorImpl<OperatorDecl *> &results) const override;

--- a/include/swift/AST/SynthesizedFileUnit.h
+++ b/include/swift/AST/SynthesizedFileUnit.h
@@ -52,7 +52,8 @@ public:
 
   Identifier getDiscriminatorForPrivateValue(const ValueDecl *D) const override;
 
-  void getTopLevelDecls(SmallVectorImpl<Decl*> &results) const override;
+  void getTopLevelDecls(SmallVectorImpl<Decl*> &results,
+                        Optional<AccessLevel> minAccessLevel = None) const override;
 
   ArrayRef<Decl *> getTopLevelDecls() const {
     return TopLevelDecls;

--- a/include/swift/ClangImporter/ClangModule.h
+++ b/include/swift/ClangImporter/ClangModule.h
@@ -89,7 +89,9 @@ public:
 
   virtual bool shouldCollectDisplayDecls() const override;
 
-  virtual void getTopLevelDecls(SmallVectorImpl<Decl*> &results) const override;
+  virtual void
+  getTopLevelDecls(SmallVectorImpl<Decl*> &results,
+                   Optional<AccessLevel> minAccessLevel = None) const override;
 
   virtual void getDisplayDecls(SmallVectorImpl<Decl*> &results, bool recursive = false) const override;
 

--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -172,7 +172,7 @@ namespace swift {
   /// \c ModuleDecl::getDisplayDecls() would only return if previous
   /// work happened to have synthesized them.
   void
-  getTopLevelDeclsForDisplay(ModuleDecl *M, SmallVectorImpl<Decl*> &Results, bool Recursive = false);
+  getTopLevelDeclsForDisplay(ModuleDecl *M, SmallVectorImpl<Decl*> &Results, bool recursive = false);
 
   struct ExtensionInfo {
     // The extension with the declarations to apply.

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -412,7 +412,9 @@ public:
 
   void collectAllGroups(SmallVectorImpl<StringRef> &Names) const override;
 
-  virtual void getTopLevelDecls(SmallVectorImpl<Decl*> &results) const override;
+  virtual void
+  getTopLevelDecls(SmallVectorImpl<Decl*> &results,
+                   Optional<AccessLevel> minAccessLevel = None) const override;
 
   virtual void getExportedPrespecializations(
       SmallVectorImpl<Decl *> &results) const override;

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -830,8 +830,9 @@ void ModuleDecl::getLocalTypeDecls(SmallVectorImpl<TypeDecl*> &Results) const {
   FORWARD(getLocalTypeDecls, (Results));
 }
 
-void ModuleDecl::getTopLevelDecls(SmallVectorImpl<Decl*> &Results) const {
-  FORWARD(getTopLevelDecls, (Results));
+void ModuleDecl::getTopLevelDecls(SmallVectorImpl<Decl*> &Results,
+                                  Optional<AccessLevel> minAccessLevel) const {
+  FORWARD(getTopLevelDecls, (Results, minAccessLevel));
 }
 
 void ModuleDecl::dumpDisplayDecls() const {
@@ -863,7 +864,8 @@ void ModuleDecl::getTopLevelDeclsWhereAttributesMatch(
   FORWARD(getTopLevelDeclsWhereAttributesMatch, (Results, matchAttributes));
 }
 
-void SourceFile::getTopLevelDecls(SmallVectorImpl<Decl*> &Results) const {
+void SourceFile::getTopLevelDecls(SmallVectorImpl<Decl*> &Results,
+                                  Optional<AccessLevel> minAccessLevel) const {
   auto decls = getTopLevelDecls();
   Results.append(decls.begin(), decls.end());
 }
@@ -3300,7 +3302,7 @@ void SynthesizedFileUnit::lookupObjCMethods(
 }
 
 void SynthesizedFileUnit::getTopLevelDecls(
-    SmallVectorImpl<swift::Decl *> &results) const {
+    SmallVectorImpl<swift::Decl *> &results, Optional<AccessLevel> minAccessLevel) const {
   results.append(TopLevelDecls.begin(), TopLevelDecls.end());
 }
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3126,7 +3126,8 @@ public:
 // FIXME: should submodules still be crawled for the symbol graph? (SR-15753)
 bool ClangModuleUnit::shouldCollectDisplayDecls() const { return isTopLevel(); }
 
-void ClangModuleUnit::getTopLevelDecls(SmallVectorImpl<Decl*> &results) const {
+void ClangModuleUnit::getTopLevelDecls(SmallVectorImpl<Decl*> &results,
+                                       Optional<AccessLevel> minAccessLevel) const {
   VectorDeclPtrConsumer consumer(results);
   FilteringDeclaredDeclConsumer filterConsumer(consumer, this);
   DarwinLegacyFilterDeclConsumer darwinFilterConsumer(filterConsumer,

--- a/lib/ClangImporter/DWARFImporter.cpp
+++ b/lib/ClangImporter/DWARFImporter.cpp
@@ -61,7 +61,8 @@ public:
       SmallVectorImpl<AbstractFunctionDecl *> &results) const override {}
 
   virtual void
-  getTopLevelDecls(SmallVectorImpl<Decl *> &results) const override {}
+  getTopLevelDecls(SmallVectorImpl<Decl *> &results,
+                   Optional<AccessLevel> minAccessLevel = None) const override {}
 
   virtual void
   getDisplayDecls(SmallVectorImpl<Decl *> &results, bool recursive = false) const override {}

--- a/lib/Serialization/DeserializationErrors.h
+++ b/lib/Serialization/DeserializationErrors.h
@@ -445,6 +445,36 @@ public:
   }
 };
 
+// Decl was not deserialized because its access level was below the filter.
+//
+// \sa getDeclChecked
+class DeclAccessLevelTooLow : public llvm::ErrorInfo<DeclAccessLevelTooLow> {
+  friend ErrorInfo;
+  static const char ID;
+  void anchor() override;
+
+  swift::AccessLevel declAccessLevel;
+  swift::AccessLevel minAccessLevel;
+
+public:
+  DeclAccessLevelTooLow(swift::AccessLevel declAccessLevel,
+                        swift::AccessLevel minAccessLevel) {
+    this->declAccessLevel = declAccessLevel;
+    this->minAccessLevel = minAccessLevel;
+  }
+
+  void log(raw_ostream &OS) const override {
+    OS << "Access level too low: deserialized '" <<
+          getAccessLevelSpelling(declAccessLevel) <<
+          "', expected greater or equal to '" <<
+          getAccessLevelSpelling(minAccessLevel) << "'";
+  }
+
+  std::error_code convertToErrorCode() const override {
+    return llvm::inconvertibleErrorCode();
+  }
+};
+
 LLVM_NODISCARD
 static inline std::unique_ptr<llvm::ErrorInfoBase>
 takeErrorInfo(llvm::Error error) {

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -830,10 +830,15 @@ public:
   /// determine if it should be fully deserialized and returned. If the
   /// attributes fail the check, the decl is not deserialized and
   /// \c DeclAttributesDidNotMatch is returned.
+  ///
+  /// \param minAccessLevel If set, skip deserializing decls under the given
+  /// access level when possible. On a skipped decl, this returns
+  /// \c DeclAccessLevelTooLow.
   llvm::Expected<Decl *>
   getDeclChecked(
     serialization::DeclID DID,
-    llvm::function_ref<bool(DeclAttributes)> matchAttributes = nullptr);
+    llvm::function_ref<bool(DeclAttributes)> matchAttributes = nullptr,
+    Optional<AccessLevel> minAccessLevel = None);
 
   /// Returns the decl context with the given ID, deserializing it if needed.
   DeclContext *getDeclContext(serialization::DeclContextID DID);

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -679,9 +679,13 @@ public:
   /// \param matchAttributes Optional check on the attributes of a decl to
   /// filter which decls to fully deserialize. Only decls with accepted
   /// attributes are deserialized and added to Results.
+  ///
+  /// \p minAccessLevel If set, skip deserializing decls that are
+  /// more private than the given access level.
   void getTopLevelDecls(
          SmallVectorImpl<Decl*> &Results,
-         llvm::function_ref<bool(DeclAttributes)> matchAttributes = nullptr);
+         llvm::function_ref<bool(DeclAttributes)> matchAttributes = nullptr,
+         Optional<AccessLevel> minAccessLevel = None);
 
   void getExportedPrespecializations(SmallVectorImpl<Decl *> &results);
 

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1525,8 +1525,8 @@ SerializedASTFile::getGroupNameByUSR(StringRef USR) const {
 }
 
 void
-SerializedASTFile::getTopLevelDecls(SmallVectorImpl<Decl*> &results) const {
-  File.getTopLevelDecls(results);
+SerializedASTFile::getTopLevelDecls(SmallVectorImpl<Decl*> &results, Optional<AccessLevel> minAccessLevel) const {
+  File.getTopLevelDecls(results, /*matchAttributes*/ nullptr, minAccessLevel);
 }
 
 void SerializedASTFile::getExportedPrespecializations(


### PR DESCRIPTION
Introduce an API to limit which decls to deserialize according to their access level. The filter is applied early, after reading the binary data and before reconstructing the decl. This logic can prevent deserialization failures on reading non-public decls when they're not actually desired.

The current version checks for the simple access level, it doesn't take into account `@usableFromInline` and similar. As such it could be useful to documentation tools, or it would have to be improved to support ABI public decls.

This version applies that filtering only to indexing that already ignores non-public decls after deserializing them.