### PR TITLE
[Sema] Propagate nonisolated attribute from wrapped property to the synthesized projectedValue property

### DIFF
--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2685,6 +2685,13 @@ static VarDecl *synthesizePropertyWrapperProjectionVar(
     var->getAttrs().add(
         new (ctx) ProjectedValuePropertyAttr(name, SourceLoc(), SourceRange(),
                                              /*Implicit=*/true));
+
+  // If the wrapped property has a nonisolated attribute, propagate it to
+  // the synthesized projectedValue as well.
+  if (var->getAttrs().getAttribute<NonisolatedAttr>()) {
+    property->getAttrs().add(new (ctx) NonisolatedAttr(/*Implicit=*/true));
+  }
+
   return property;
 }
 

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -457,7 +457,51 @@ func testInferredFromWrapper(x: InferredFromPropertyWrapper) { // expected-note{
   _ = x.test() // expected-error{{call to global actor 'SomeGlobalActor'-isolated instance method 'test()' in a synchronous nonisolated context}}
 }
 
+// https://github.com/apple/swift/issues/59380
+// https://github.com/apple/swift/issues/59494
 
+// Make sure the nonisolated attribute propagates to the synthesized projectedValue
+// variable as well.
+
+@propertyWrapper 
+struct SimplePropertyWrapper {
+  var wrappedValue: Int { .zero }
+  var projectedValue: Int { .max }
+}
+
+@MainActor
+class HasNonIsolatedProperty {
+  @SimplePropertyWrapper nonisolated var value
+
+  deinit {
+    _ = value
+    _ = $value // Ok
+  }
+}
+
+@propertyWrapper
+struct SimplePropertyWrapper2 {
+  var wrappedValue: Int
+  var projectedValue: SimplePropertyWrapper2 { self }
+}
+
+@MainActor
+class HasNonIsolatedProperty2 {
+  @SimplePropertyWrapper2 nonisolated var value = 0
+  nonisolated init() {}
+}
+
+let hasNonIsolatedProperty2 = HasNonIsolatedProperty2()
+
+Task { @MainActor in
+  hasNonIsolatedProperty2.value = 10
+  _ = hasNonIsolatedProperty2.$value.wrappedValue
+}
+
+Task.detached {
+  hasNonIsolatedProperty2.value = 10
+  _ = hasNonIsolatedProperty2.$value.wrappedValue // Ok
+}
 
 // ----------------------------------------------------------------------
 // Unsafe global actors


### PR DESCRIPTION
Resolves https://github.com/apple/swift/issues/59380
Resolves https://github.com/apple/swift/issues/59494

We were not propagating the `nonisolated` attribute from the wrapped property to the synthesised `projectedValue` variable, thus triggering a `main actor-isolated property '$<name>' can not be referenced from a non-isolated context` error in some contexts when accessing the `projectedValue`. 

```swift
@propertyWrapper 
struct Wrapper {
  var wrappedValue: Int { .zero }
  var projectedValue: Int { .max }
}

@MainActor
class Container {
  @Wrapper nonisolated var value

  deinit {
    _ = value // ok
    _ = $value // error
  }
}
```