### PR TITLE
[Concurrency] Disable more flow-isolation warnings in deinitializers.

### DIFF
--- a/lib/SILOptimizer/Mandatory/FlowIsolation.cpp
+++ b/lib/SILOptimizer/Mandatory/FlowIsolation.cpp
@@ -422,6 +422,15 @@ void Info::diagnoseAll(AnalysisInfo &info, bool forDeinit,
   if (propertyUses.empty())
     return;
 
+  auto *fn = info.getFunction();
+  auto &ctx = fn->getASTContext();
+
+  // Disable these diagnostics in deinitializers unless complete checking is
+  // enabled.
+  if (forDeinit && ctx.LangOpts.StrictConcurrencyLevel
+        != StrictConcurrency::Complete)
+    return;
+
   // Blame that is valid for the first property use is valid for all uses
   // in this block.
   if (!blame)
@@ -438,7 +447,6 @@ void Info::diagnoseAll(AnalysisInfo &info, bool forDeinit,
     }
   }
 
-  auto *fn = info.getFunction();
   auto &diag = fn->getASTContext().Diags;
 
   SILLocation blameLoc = blame->getDebugLocation().getLocation();

--- a/test/Concurrency/flow_isolation_nonstrict.swift
+++ b/test/Concurrency/flow_isolation_nonstrict.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -strict-concurrency=targeted -swift-version 5 -parse-as-library -emit-sil -verify %s
 
+@_nonSendable
 class NonSendableType {
   var x: Int = 0
   func f() {}
@@ -26,5 +27,16 @@ actor CheckDeinitFromActor {
   deinit {
     ns?.f()
     ns = nil
+  }
+}
+
+@MainActor class X {
+  var ns: NonSendableType = NonSendableType()
+
+  nonisolated func something() { }
+
+  deinit {
+    something()
+    print(ns)
   }
 }


### PR DESCRIPTION
When we disabled flow-isolation warnings for non-complete concurrency
checking, we disabled one of two places where we emit diagnostics.
Disable the other one. Fixes rdar://94707894.
