### PR TITLE
Add InfixOperatorExpr.

### DIFF
--- a/utils/gyb_syntax_support/ExprNodes.py
+++ b/utils/gyb_syntax_support/ExprNodes.py
@@ -199,6 +199,17 @@ EXPR_NODES = [
              Child('ArrowToken', kind='ArrowToken'),
          ]),
 
+    # An infix binary expression like x + y.
+    # NOTE: This won't come directly out of the parser. Rather, it is the
+    # result of "folding" a SequenceExpr based on knowing the precedence
+    # relationships amongst the different infix operators.
+    Node('InfixOperatorExpr', kind='Expr',
+         children=[
+             Child('LeftOperand', kind='Expr'),
+             Child('OperatorOperand', kind='Expr'),
+             Child('RightOperand', kind='Expr'),
+         ]),
+
     # A floating-point literal
     # 4.0
     # -3.9

--- a/utils/gyb_syntax_support/NodeSerializationCodes.py
+++ b/utils/gyb_syntax_support/NodeSerializationCodes.py
@@ -269,6 +269,7 @@ SYNTAX_NODE_SERIALIZATION_CODES = {
     'MissingPattern': 265,
     'GarbageNodes' : 266,
     'LabeledStmt': 267,
+    'InfixOperatorExpr': 268,
 }
 
 


### PR DESCRIPTION
`InfixOperatorExpr` is used to represent a binary expression (such as `x + y`) once a `SequenceExpr` has been "folded" into a tree by operator-precedence parsing.