### PR TITLE
[Basic] Include SmallVector.h for Clang <= 5

### DIFF
--- a/include/swift/Basic/LLVM.h
+++ b/include/swift/Basic/LLVM.h
@@ -25,6 +25,14 @@
 // None.h includes an enumerator that is desired & cannot be forward declared
 // without a definition of NoneType.
 #include "llvm/ADT/None.h"
+#if defined(__clang_major__) && __clang_major__ < 6
+// Add this header as a workaround to prevent `too few template arguments for
+// class template 'SmallVector'` on the buggy Clang 5 compiler (it doesn't
+// merge template arguments correctly). Remove once the CentOS 7 job is
+// replaced.
+// rdar://98218902
+#include "llvm/ADT/SmallVector.h"
+#endif
 
 // Don't pre-declare certain LLVM types in the runtime, which must
 // not put things in namespace llvm for ODR reasons.

--- a/lib/AST/RequirementMachine/ConcreteContraction.cpp
+++ b/lib/AST/RequirementMachine/ConcreteContraction.cpp
@@ -301,7 +301,7 @@ Optional<Type> ConcreteContraction::substTypeParameterRec(
 
     // An unresolved DependentMemberType stores an identifier. Handle this
     // by performing a name lookup into the base type.
-    SmallVector<TypeDecl *, 2> concreteDecls;
+    SmallVector<TypeDecl *> concreteDecls;
     lookupConcreteNestedType(*substBaseType, memberType->getName(), concreteDecls);
 
     auto *typeDecl = findBestConcreteNestedType(concreteDecls);

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -882,7 +882,7 @@ Type TypeBase::lookThroughAllOptionalTypes(SmallVectorImpl<Type> &optionals){
 }
 
 unsigned int TypeBase::getOptionalityDepth() {
-  SmallVector<Type, 4> types;
+  SmallVector<Type> types;
   lookThroughAllOptionalTypes(types);
   return types.size();
 }

--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -88,7 +88,7 @@ static ValueDecl *getEqualEqualOperator(NominalTypeDecl *decl) {
   // If no member `func ==` was found, look for out-of-class definitions in the
   // same module.
   auto module = decl->getModuleContext();
-  llvm::SmallVector<ValueDecl *> nonMemberResults;
+  SmallVector<ValueDecl *> nonMemberResults;
   module->lookupValue(id, NLKind::UnqualifiedLookup, nonMemberResults);
   for (const auto &nonMember : nonMemberResults) {
     if (isValid(nonMember))

--- a/lib/DriverTool/swift_symbolgraph_extract_main.cpp
+++ b/lib/DriverTool/swift_symbolgraph_extract_main.cpp
@@ -241,7 +241,7 @@ int swift_symbolgraph_extract_main(ArrayRef<const char *> Args,
   // don't need to print these errors.
   CI.removeDiagnosticConsumer(&DiagPrinter);
   
-  SmallVector<ModuleDecl *, 8> Overlays;
+  SmallVector<ModuleDecl *> Overlays;
   M->findDeclaredCrossImportOverlaysTransitive(Overlays);
   for (const auto *OM : Overlays) {
     auto CIM = CI.getASTContext().getModuleByName(OM->getNameStr());

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -777,7 +777,7 @@ public:
 
 #ifdef CHECK_RUNTIME_EFFECT_ANALYSIS
   RuntimeEffect effectOfRuntimeFuncs = RuntimeEffect::NoEffect;
-  llvm::SmallVector<const char *> emittedRuntimeFuncs;
+  SmallVector<const char *> emittedRuntimeFuncs;
 
   void registerRuntimeEffect(ArrayRef<RuntimeEffect> realtime,
                              const char *funcName);
@@ -1263,7 +1263,7 @@ private:
   void emitLazyObjCProtocolDefinitions();
   void emitLazyObjCProtocolDefinition(ProtocolDecl *proto);
 
-  llvm::SmallVector<llvm::MDNode *> UsedConditionals;
+  SmallVector<llvm::MDNode *> UsedConditionals;
   void emitUsedConditionals();
 
   void emitGlobalLists();

--- a/lib/SIL/IR/SILArgument.cpp
+++ b/lib/SIL/IR/SILArgument.cpp
@@ -236,7 +236,7 @@ bool SILPhiArgument::visitTransitiveIncomingPhiOperands(
   worklist.initialize(this);
 
   while (auto *argument = worklist.pop()) {
-    llvm::SmallVector<Operand *> operands;
+    SmallVector<Operand *> operands;
     argument->getIncomingPhiOperands(operands);
 
     for (auto *operand : operands) {

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -919,7 +919,7 @@ void StackAllocationPromoter::fixPhiPredBlock(BlockSetVector &phiBlocks,
 
   LLVM_DEBUG(llvm::dbgs() << "*** Found the definition: " << def.stored);
 
-  llvm::SmallVector<SILValue> vals;
+  SmallVector<SILValue> vals;
   vals.push_back(def.stored);
   if (shouldAddLexicalLifetime(asi)) {
     vals.push_back(def.borrow);
@@ -964,7 +964,7 @@ void StackAllocationPromoter::propagateLiveness(
   // If liveness has not been propagated, go over the incoming operands and mark
   // any operand values that are proactivePhis as live
   livePhis.insert(proactivePhi);
-  SmallVector<SILValue, 4> incomingPhiVals;
+  SmallVector<SILValue> incomingPhiVals;
   proactivePhi->getIncomingPhiValues(incomingPhiVals);
   for (auto &inVal : incomingPhiVals) {
     auto *inPhi = dyn_cast<SILPhiArgument>(inVal);

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1355,7 +1355,7 @@ protected:
         }
       } else {
         auto *elseBraceStmt = cast<BraceStmt>(elseStmt);
-        SmallVector<ASTNode, 4> elseBody;
+        SmallVector<ASTNode> elseBody;
 
         std::tie(elseVar, unsupported) = transform(elseBraceStmt, elseBody);
         if (unsupported) {

--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -40,7 +40,7 @@ Expr *getVoidExpr(ASTContext &ctx, SourceLoc contextLoc = SourceLoc()) {
 /// Find any type variable references inside of an AST node.
 class TypeVariableRefFinder : public ASTWalker {
   /// A stack of all closures the walker encountered so far.
-  SmallVector<DeclContext *, 2> ClosureDCs;
+  SmallVector<DeclContext *> ClosureDCs;
 
   ConstraintSystem &CS;
   ASTNode Parent;

--- a/tools/swift-refactor/swift-refactor.cpp
+++ b/tools/swift-refactor/swift-refactor.cpp
@@ -449,7 +449,7 @@ int main(int argc, char *argv[]) {
     return 1;
   }
 
-  SmallVector<std::unique_ptr<SourceEditConsumer>, 32> Consumers;
+  SmallVector<std::unique_ptr<SourceEditConsumer>> Consumers;
   if (!options::RewrittenOutputFile.empty() ||
       options::DumpIn == options::DumpType::REWRITTEN) {
     Consumers.emplace_back(new SourceEditOutputConsumer(


### PR DESCRIPTION
Clang 5 (possibly earlier) has a bug where it does not merge default
template arguments properly for forwarded declarations. Include
`SmallVector.h` directly in this case. This will slightly increase
compile times, but only for very old compilers and only for files that
don't already include `SmallVector.h` (of which there's currently only
23).
