### PR TITLE
[AST] Introduce `Argument::implicitInOut`

### DIFF
--- a/include/swift/AST/ArgumentList.h
+++ b/include/swift/AST/ArgumentList.h
@@ -51,6 +51,9 @@ public:
     return Argument(SourceLoc(), Identifier(), expr);
   }
 
+  /// Make an implicit unlabeled 'inout' argument.
+  static Argument implicitInOut(ASTContext &ctx, Expr *expr);
+
   SourceLoc getStartLoc() const { return getSourceRange().Start; }
   SourceLoc getEndLoc() const { return getSourceRange().End; }
   SourceRange getSourceRange() const;

--- a/include/swift/AST/ArgumentList.h
+++ b/include/swift/AST/ArgumentList.h
@@ -68,6 +68,11 @@ public:
   /// The argument label written in the call.
   Identifier getLabel() const { return Label; }
 
+  /// Whether the argument has a non-empty label. Note that this returns `false`
+  /// for an explicitly specified empty label e.g `_: {}` for a trailing
+  /// closure.
+  bool hasLabel() const { return !Label.empty(); }
+
   /// Set a new argument label.
   ///
   /// Note this is marked \c & to prevent its use on an rvalue Argument vended

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -4736,8 +4736,13 @@ class DotSyntaxCallExpr : public SelfApplyExpr {
   }
 
 public:
+  /// Create a new method reference to \p fnExpr on the base value \p baseArg.
+  /// 
+  /// If this is for a 'mutating' method, \p baseArg should be created using
+  /// \c Argument::implicitInOut. Otherwise, \p Argument::unlabeled should be
+  /// used. \p baseArg must not be labeled.
   static DotSyntaxCallExpr *create(ASTContext &ctx, Expr *fnExpr,
-                                   SourceLoc dotLoc, Expr *baseExpr,
+                                   SourceLoc dotLoc, Argument baseArg,
                                    Type ty = Type());
 
   SourceLoc getDotLoc() const { return DotLoc; }

--- a/lib/AST/ArgumentList.cpp
+++ b/lib/AST/ArgumentList.cpp
@@ -35,6 +35,19 @@ SourceRange Argument::getSourceRange() const {
   return SourceRange(labelLoc, exprEndLoc);
 }
 
+Argument Argument::implicitInOut(ASTContext &ctx, Expr *expr) {
+  assert(!isa<InOutExpr>(expr) && "Cannot nest InOutExpr");
+
+  // Eventually this will set an 'inout' bit on Argument, but for now,
+  // synthesize in the InOutExpr.
+  Type objectTy;
+  if (auto subTy = expr->getType())
+    objectTy = subTy->castTo<LValueType>()->getObjectType();
+
+  return Argument::unlabeled(
+      new (ctx) InOutExpr(SourceLoc(), expr, objectTy, /*isImplicit*/ true));
+}
+
 bool Argument::isInOut() const {
   return ArgExpr->isSemanticallyInOutExpr();
 }

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1571,9 +1571,10 @@ BinaryExpr *BinaryExpr::create(ASTContext &ctx, Expr *lhs, Expr *fn, Expr *rhs,
 }
 
 DotSyntaxCallExpr *DotSyntaxCallExpr::create(ASTContext &ctx, Expr *fnExpr,
-                                             SourceLoc dotLoc, Expr *baseExpr,
+                                             SourceLoc dotLoc, Argument baseArg,
                                              Type ty) {
-  auto *argList = ArgumentList::forImplicitUnlabeled(ctx, {baseExpr});
+  assert(!baseArg.hasLabel());
+  auto *argList = ArgumentList::forImplicitUnlabeled(ctx, {baseArg.getExpr()});
   return new (ctx) DotSyntaxCallExpr(fnExpr, dotLoc, argList, ty);
 }
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4444,29 +4444,23 @@ DeclRefExpr *getInteropStaticCastDeclRefExpr(ASTContext &ctx,
 // %2 = __swift_interopStaticCast<UnsafeMutablePointer<Base>?>(%1)
 // %3 = %2!
 // return %3.pointee
-MemberRefExpr *getInOutSelfInteropStaticCast(FuncDecl *funcDecl,
-                                             NominalTypeDecl *baseStruct,
-                                             NominalTypeDecl *derivedStruct) {
+MemberRefExpr *getSelfInteropStaticCast(FuncDecl *funcDecl,
+                                        NominalTypeDecl *baseStruct,
+                                        NominalTypeDecl *derivedStruct) {
   auto &ctx = funcDecl->getASTContext();
 
-  auto inoutSelf = [&ctx](FuncDecl *funcDecl) {
-    auto inoutSelfDecl = funcDecl->getImplicitSelfDecl();
+  auto mutableSelf = [&ctx](FuncDecl *funcDecl) {
+    auto selfDecl = funcDecl->getImplicitSelfDecl();
 
-    auto inoutSelfRef =
-        new (ctx) DeclRefExpr(inoutSelfDecl, DeclNameLoc(), /*implicit*/ true);
-    inoutSelfRef->setType(LValueType::get(inoutSelfDecl->getInterfaceType()));
+    auto selfRef =
+        new (ctx) DeclRefExpr(selfDecl, DeclNameLoc(), /*implicit*/ true);
+    selfRef->setType(LValueType::get(selfDecl->getInterfaceType()));
 
-    auto inoutSelf = new (ctx) InOutExpr(
-        SourceLoc(), inoutSelfRef,
-        funcDecl->mapTypeIntoContext(inoutSelfDecl->getValueInterfaceType()),
-        /*implicit*/ true);
-    inoutSelf->setType(InOutType::get(inoutSelfDecl->getInterfaceType()));
-
-    return inoutSelf;
+    return selfRef;
   }(funcDecl);
 
   auto createCallToBuiltin = [&](Identifier name, ArrayRef<Type> substTypes,
-                                 Expr *arg) {
+                                 Argument arg) {
     auto builtinFn = cast<FuncDecl>(getBuiltinValueDecl(ctx, name));
     auto substMap =
         SubstitutionMap::get(builtinFn->getGenericSignature(), substTypes,
@@ -4479,22 +4473,23 @@ MemberRefExpr *getInOutSelfInteropStaticCast(FuncDecl *funcDecl,
     if (auto genericFnType = dyn_cast<GenericFunctionType>(fnType.getPointer()))
       fnType = genericFnType->substGenericArgs(substMap);
     builtinFnRefExpr->setType(fnType);
-    auto *argList = ArgumentList::forImplicitUnlabeled(ctx, {arg});
+    auto *argList = ArgumentList::createImplicit(ctx, {arg});
     auto callExpr = CallExpr::create(ctx, builtinFnRefExpr, argList, /*implicit*/ true);
     callExpr->setThrows(false);
     return callExpr;
   };
 
-  auto rawSelfPointer =
-      createCallToBuiltin(ctx.getIdentifier("addressof"),
-                          {derivedStruct->getSelfInterfaceType()}, inoutSelf);
+  auto rawSelfPointer = createCallToBuiltin(
+      ctx.getIdentifier("addressof"), {derivedStruct->getSelfInterfaceType()},
+      Argument::implicitInOut(ctx, mutableSelf));
   rawSelfPointer->setType(ctx.TheRawPointerType);
 
   auto derivedPtrType = derivedStruct->getSelfInterfaceType()->wrapInPointer(
       PTK_UnsafeMutablePointer);
-  auto selfPointer = createCallToBuiltin(
-      ctx.getIdentifier("reinterpretCast"),
-      {ctx.TheRawPointerType, derivedPtrType}, rawSelfPointer);
+  auto selfPointer =
+      createCallToBuiltin(ctx.getIdentifier("reinterpretCast"),
+                          {ctx.TheRawPointerType, derivedPtrType},
+                          Argument::unlabeled(rawSelfPointer));
   selfPointer->setType(derivedPtrType);
 
   auto staticCastRefExpr = getInteropStaticCastDeclRefExpr(
@@ -4554,14 +4549,11 @@ synthesizeBaseClassMethodBody(AbstractFunctionDecl *afd, void *context) {
     forwardingParams.push_back(paramRefExpr);
   }
 
-  Expr *casted = nullptr;
-  if (funcDecl->isMutating()) {
-    auto pointeeMemberRefExpr =
-        getInOutSelfInteropStaticCast(funcDecl, baseStruct, derivedStruct);
-    casted = new (ctx) InOutExpr(SourceLoc(), pointeeMemberRefExpr, baseType,
-                                 /*implicit*/ true);
-    casted->setType(InOutType::get(baseType));
-  } else {
+  Argument casted = [&]() {
+    if (funcDecl->isMutating()) {
+      return Argument::implicitInOut(
+          ctx, getSelfInteropStaticCast(funcDecl, baseStruct, derivedStruct));
+    }
     auto *selfDecl = funcDecl->getImplicitSelfDecl();
     auto selfExpr = new (ctx) DeclRefExpr(selfDecl, DeclNameLoc(),
                                           /*implicit*/ true);
@@ -4575,8 +4567,8 @@ synthesizeBaseClassMethodBody(AbstractFunctionDecl *afd, void *context) {
     auto castedCall = CallExpr::createImplicit(ctx, staticCastRefExpr, argList);
     castedCall->setType(baseType);
     castedCall->setThrows(false);
-    casted = castedCall;
-  }
+    return Argument::unlabeled(castedCall);
+  }();
 
   auto *baseMemberExpr =
       new (ctx) DeclRefExpr(ConcreteDeclRef(baseMember), DeclNameLoc(),
@@ -4680,7 +4672,7 @@ synthesizeBaseClassFieldSetterBody(AbstractFunctionDecl *afd, void *context) {
       cast<NominalTypeDecl>(setterDecl->getDeclContext()->getAsDecl());
 
   auto *pointeePropertyRefExpr =
-      getInOutSelfInteropStaticCast(setterDecl, baseStruct, derivedStruct);
+      getSelfInteropStaticCast(setterDecl, baseStruct, derivedStruct);
 
   Expr *storedRef = nullptr;
   if (auto subscript = dyn_cast<SubscriptDecl>(baseClassVar)) {
@@ -5378,7 +5370,7 @@ static ValueDecl *rewriteIntegerTypes(SubstitutionMap subst, ValueDecl *oldDecl,
   return newDecl;
 }
 
-static Expr *createSelfExpr(FuncDecl *fnDecl) {
+static Argument createSelfArg(FuncDecl *fnDecl) {
   ASTContext &ctx = fnDecl->getASTContext();
 
   auto selfDecl = fnDecl->getImplicitSelfDecl();
@@ -5387,16 +5379,10 @@ static Expr *createSelfExpr(FuncDecl *fnDecl) {
 
   if (!fnDecl->isMutating()) {
     selfRefExpr->setType(selfDecl->getInterfaceType());
-    return selfRefExpr;
+    return Argument::unlabeled(selfRefExpr);
   }
   selfRefExpr->setType(LValueType::get(selfDecl->getInterfaceType()));
-
-  auto inoutSelfExpr = new (ctx) InOutExpr(
-      SourceLoc(), selfRefExpr,
-      fnDecl->mapTypeIntoContext(selfDecl->getValueInterfaceType()),
-      /*isImplicit*/ true);
-  inoutSelfExpr->setType(InOutType::get(selfDecl->getInterfaceType()));
-  return inoutSelfExpr;
+  return Argument::implicitInOut(ctx, selfRefExpr);
 }
 
 // Synthesize a thunk body for the function created in
@@ -5449,8 +5435,9 @@ synthesizeDependentTypeThunkParamForwarding(AbstractFunctionDecl *afd, void *con
   specializedFuncDeclRef->setType(specializedFuncDecl->getInterfaceType());
 
   if (specializedFuncDecl->isInstanceMember()) {
-    auto selfExpr = createSelfExpr(thunkDecl);
-    auto *memberCall = DotSyntaxCallExpr::create(ctx, specializedFuncDeclRef, SourceLoc(), selfExpr);
+    auto selfArg = createSelfArg(thunkDecl);
+    auto *memberCall = DotSyntaxCallExpr::create(ctx, specializedFuncDeclRef,
+                                                 SourceLoc(), selfArg);
     memberCall->setThrows(false);
     auto resultType = specializedFuncDecl->getInterfaceType()->getAs<FunctionType>()->getResult();
     specializedFuncDeclRef = memberCall;
@@ -5459,7 +5446,9 @@ synthesizeDependentTypeThunkParamForwarding(AbstractFunctionDecl *afd, void *con
     auto resultType = specializedFuncDecl->getInterfaceType()->getAs<FunctionType>()->getResult();
     auto selfType = cast<NominalTypeDecl>(thunkDecl->getDeclContext()->getAsDecl())->getDeclaredInterfaceType();
     auto selfTypeExpr = TypeExpr::createImplicit(selfType, ctx);
-    auto *memberCall = DotSyntaxCallExpr::create(ctx, specializedFuncDeclRef, SourceLoc(), selfTypeExpr);
+    auto *memberCall =
+        DotSyntaxCallExpr::create(ctx, specializedFuncDeclRef, SourceLoc(),
+                                  Argument::unlabeled(selfTypeExpr));
     memberCall->setThrows(false);
     specializedFuncDeclRef = memberCall;
     specializedFuncDeclRef->setType(resultType);
@@ -5576,8 +5565,9 @@ synthesizeForwardingThunkBody(AbstractFunctionDecl *afd, void *context) {
   specializedFuncDeclRef->setType(specializedFuncDecl->getInterfaceType());
 
   if (specializedFuncDecl->isInstanceMember()) {
-    auto selfExpr = createSelfExpr(thunkDecl);
-    auto *memberCall = DotSyntaxCallExpr::create(ctx, specializedFuncDeclRef, SourceLoc(), selfExpr);
+    auto selfArg = createSelfArg(thunkDecl);
+    auto *memberCall = DotSyntaxCallExpr::create(ctx, specializedFuncDeclRef,
+                                                 SourceLoc(), selfArg);
     memberCall->setThrows(false);
     auto resultType = specializedFuncDecl->getInterfaceType()->getAs<FunctionType>()->getResult();
     specializedFuncDeclRef = memberCall;
@@ -5586,7 +5576,9 @@ synthesizeForwardingThunkBody(AbstractFunctionDecl *afd, void *context) {
     auto resultType = specializedFuncDecl->getInterfaceType()->getAs<FunctionType>()->getResult();
     auto selfType = cast<NominalTypeDecl>(thunkDecl->getDeclContext()->getAsDecl())->getDeclaredInterfaceType();
     auto selfTypeExpr = TypeExpr::createImplicit(selfType, ctx);
-    auto *memberCall = DotSyntaxCallExpr::create(ctx, specializedFuncDeclRef, SourceLoc(), selfTypeExpr);
+    auto *memberCall =
+        DotSyntaxCallExpr::create(ctx, specializedFuncDeclRef, SourceLoc(),
+                                  Argument::unlabeled(selfTypeExpr));
     memberCall->setThrows(false);
     specializedFuncDeclRef = memberCall;
     specializedFuncDeclRef->setType(resultType);

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5457,8 +5457,9 @@ Decl *SwiftDeclConverter::importEnumCaseAlias(
                                             /*implicit*/ true);
     constantRef->setType(enumElt->getInterfaceType());
 
-    auto instantiate = DotSyntaxCallExpr::create(Impl.SwiftContext, constantRef,
-                                                 SourceLoc(), typeRef);
+    auto instantiate =
+        DotSyntaxCallExpr::create(Impl.SwiftContext, constantRef, SourceLoc(),
+                                  Argument::unlabeled(typeRef));
     instantiate->setType(importedEnumTy);
     instantiate->setThrows(false);
 

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -22,7 +22,7 @@
 using namespace swift;
 using namespace importer;
 
-static Expr *createSelfExpr(AccessorDecl *accessorDecl) {
+static Argument createSelfArg(AccessorDecl *accessorDecl) {
   ASTContext &ctx = accessorDecl->getASTContext();
 
   auto selfDecl = accessorDecl->getImplicitSelfDecl();
@@ -31,20 +31,14 @@ static Expr *createSelfExpr(AccessorDecl *accessorDecl) {
 
   if (!accessorDecl->isMutating()) {
     selfRefExpr->setType(selfDecl->getInterfaceType());
-    return selfRefExpr;
+    return Argument::unlabeled(selfRefExpr);
   }
   selfRefExpr->setType(LValueType::get(selfDecl->getInterfaceType()));
-
-  auto inoutSelfExpr = new (ctx) InOutExpr(
-      SourceLoc(), selfRefExpr,
-      accessorDecl->mapTypeIntoContext(selfDecl->getValueInterfaceType()),
-      /*isImplicit*/ true);
-  inoutSelfExpr->setType(InOutType::get(selfDecl->getInterfaceType()));
-  return inoutSelfExpr;
+  return Argument::implicitInOut(ctx, selfRefExpr);
 }
 
 static CallExpr *createAccessorImplCallExpr(FuncDecl *accessorImpl,
-                                            Expr *selfExpr,
+                                            Argument selfArg,
                                             DeclRefExpr *keyRefExpr = nullptr) {
   ASTContext &ctx = accessorImpl->getASTContext();
 
@@ -54,7 +48,7 @@ static CallExpr *createAccessorImplCallExpr(FuncDecl *accessorImpl,
   accessorImplExpr->setType(accessorImpl->getInterfaceType());
 
   auto accessorImplDotCallExpr =
-      DotSyntaxCallExpr::create(ctx, accessorImplExpr, SourceLoc(), selfExpr);
+      DotSyntaxCallExpr::create(ctx, accessorImplExpr, SourceLoc(), selfArg);
   accessorImplDotCallExpr->setType(accessorImpl->getMethodInterfaceType());
   accessorImplDotCallExpr->setThrows(false);
 
@@ -352,8 +346,8 @@ synthesizeConstantGetterBody(AbstractFunctionDecl *afd, void *voidContext) {
 
     // (Self) -> ...
     initTy = initTy->castTo<FunctionType>()->getResult();
-    auto initRef =
-        DotSyntaxCallExpr::create(ctx, declRef, SourceLoc(), typeRef, initTy);
+    auto initRef = DotSyntaxCallExpr::create(
+        ctx, declRef, SourceLoc(), Argument::unlabeled(typeRef), initTy);
     initRef->setThrows(false);
 
     // (rawValue: T) -> ...
@@ -878,11 +872,6 @@ synthesizeUnionFieldSetterBody(AbstractFunctionDecl *afd, void *context) {
   auto inoutSelfRef = new (ctx) DeclRefExpr(inoutSelfDecl, DeclNameLoc(),
                                             /*implicit*/ true);
   inoutSelfRef->setType(LValueType::get(inoutSelfDecl->getInterfaceType()));
-  auto inoutSelf = new (ctx) InOutExpr(
-      SourceLoc(), inoutSelfRef,
-      setterDecl->mapTypeIntoContext(inoutSelfDecl->getValueInterfaceType()),
-      /*implicit*/ true);
-  inoutSelf->setType(InOutType::get(inoutSelfDecl->getInterfaceType()));
 
   auto newValueDecl = setterDecl->getParameters()->get(0);
 
@@ -905,7 +894,8 @@ synthesizeUnionFieldSetterBody(AbstractFunctionDecl *afd, void *context) {
                              ParameterTypeFlags().withInOut(true)),
       ctx.TheRawPointerType, addressOfInfo));
 
-  auto *selfPtrArgs = ArgumentList::forImplicitUnlabeled(ctx, {inoutSelf});
+  auto *selfPtrArgs = ArgumentList::createImplicit(
+      ctx, {Argument::implicitInOut(ctx, inoutSelfRef)});
   auto selfPointer =
       CallExpr::createImplicit(ctx, addressofFnRefExpr, selfPtrArgs);
   selfPointer->setType(ctx.TheRawPointerType);
@@ -1512,7 +1502,7 @@ synthesizeUnwrappingGetterBody(AbstractFunctionDecl *afd, void *context) {
 
   ASTContext &ctx = getterDecl->getASTContext();
 
-  Expr *selfExpr = createSelfExpr(getterDecl);
+  auto selfArg = createSelfArg(getterDecl);
   DeclRefExpr *keyRefExpr = getterDecl->getParameters()->size() == 0
                                 ? nullptr
                                 : createParamRefExpr(getterDecl, 0);
@@ -1520,7 +1510,7 @@ synthesizeUnwrappingGetterBody(AbstractFunctionDecl *afd, void *context) {
   Type elementTy = getterDecl->getResultInterfaceType();
 
   auto *getterImplCallExpr =
-      createAccessorImplCallExpr(getterImpl, selfExpr, keyRefExpr);
+      createAccessorImplCallExpr(getterImpl, selfArg, keyRefExpr);
 
   // This default handles C++'s operator[] that returns a value type.
   Expr *propertyExpr = getterImplCallExpr;
@@ -1562,14 +1552,14 @@ synthesizeSubscriptSetterBody(AbstractFunctionDecl *afd, void *context) {
 
   ASTContext &ctx = setterDecl->getASTContext();
 
-  Expr *selfExpr = createSelfExpr(setterDecl);
+  auto selfArg = createSelfArg(setterDecl);
   DeclRefExpr *valueParamRefExpr = createParamRefExpr(setterDecl, 0);
   DeclRefExpr *keyParamRefExpr = createParamRefExpr(setterDecl, 1);
 
   Type elementTy = valueParamRefExpr->getDecl()->getInterfaceType();
 
   auto *setterImplCallExpr =
-      createAccessorImplCallExpr(setterImpl, selfExpr, keyParamRefExpr);
+      createAccessorImplCallExpr(setterImpl, selfArg, keyParamRefExpr);
 
   VarDecl *pointeePropertyDecl =
       ctx.getPointerPointeePropertyDecl(PTK_UnsafeMutablePointer);
@@ -1756,19 +1746,14 @@ synthesizeSuccessorFuncBody(AbstractFunctionDecl *afd, void *context) {
                                                  /*implicit*/ true);
   copyRefLValueExpr->setType(LValueType::get(copyDecl->getInterfaceType()));
 
-  auto inoutCopyExpr = new (ctx) InOutExpr(
-      SourceLoc(), copyRefLValueExpr,
-      successorDecl->mapTypeIntoContext(copyDecl->getValueInterfaceType()),
-      /*isImplicit*/ true);
-  inoutCopyExpr->setType(InOutType::get(copyDecl->getInterfaceType()));
-
   // Copy `self` to `__copy`.
   auto copyAssignExpr = new (ctx) AssignExpr(copyRefLValueExpr, SourceLoc(),
                                              selfRefExpr, /*implicit*/ true);
   copyAssignExpr->setType(emptyTupleTy);
 
   // Call `operator++`.
-  auto incrementExpr = createAccessorImplCallExpr(incrementImpl, inoutCopyExpr);
+  auto incrementExpr = createAccessorImplCallExpr(
+      incrementImpl, Argument::implicitInOut(ctx, copyRefLValueExpr));
 
   auto copyRefRValueExpr = new (ctx) DeclRefExpr(copyDecl, DeclNameLoc(),
                                                  /*implicit*/ true);
@@ -1845,19 +1830,17 @@ synthesizeOperatorMethodBody(AbstractFunctionDecl *afd, void *context) {
 
   // Lhs parameter
   auto baseParam = funcDecl->getParameters()->front();
+  auto baseParamTy = baseParam->getType();
+  auto baseIsInOut = baseParam->isInOut();
+
   Expr *baseExpr =
       new (ctx) DeclRefExpr(baseParam, DeclNameLoc(), /*implicit*/ true);
-  baseExpr->setType(baseParam->getType());
-  if (baseParam->isInOut()) {
-    baseExpr->setType(LValueType::get(baseParam->getType()));
+  baseExpr->setType(baseIsInOut ? LValueType::get(baseParamTy) : baseParamTy);
 
-    baseExpr = new (ctx) InOutExpr(SourceLoc(), baseExpr, baseParam->getType(),
-                                   /*isImplicit*/ true);
-    baseExpr->setType(InOutType::get(baseParam->getType()));
-  }
-
+  auto baseArg = baseIsInOut ? Argument::implicitInOut(ctx, baseExpr)
+                             : Argument::unlabeled(baseExpr);
   auto dotCallExpr =
-      DotSyntaxCallExpr::create(ctx, methodExpr, SourceLoc(), baseExpr);
+      DotSyntaxCallExpr::create(ctx, methodExpr, SourceLoc(), baseArg);
   dotCallExpr->setType(methodDecl->getMethodInterfaceType());
   dotCallExpr->setThrows(false);
 
@@ -1951,9 +1934,9 @@ synthesizeComputedGetterFromCXXMethod(AbstractFunctionDecl *afd,
   auto accessor = cast<AccessorDecl>(afd);
   auto method = static_cast<FuncDecl *>(context);
 
-  Expr *selfExpr = createSelfExpr(accessor);
+  auto selfArg = createSelfArg(accessor);
 
-  auto *getterImplCallExpr = createAccessorImplCallExpr(method, selfExpr);
+  auto *getterImplCallExpr = createAccessorImplCallExpr(method, selfArg);
   auto returnStmt =
       new (method->getASTContext()) ReturnStmt(SourceLoc(), getterImplCallExpr);
   auto body = BraceStmt::create(method->getASTContext(), SourceLoc(),
@@ -1968,11 +1951,11 @@ synthesizeComputedSetterFromCXXMethod(AbstractFunctionDecl *afd,
   auto setterDecl = cast<AccessorDecl>(afd);
   auto setterImpl = static_cast<FuncDecl *>(context);
 
-  Expr *selfExpr = createSelfExpr(setterDecl);
+  auto selfArg = createSelfArg(setterDecl);
   DeclRefExpr *valueParamRefExpr = createParamRefExpr(setterDecl, 0);
 
   auto *getterImplCallExpr =
-      createAccessorImplCallExpr(setterImpl, selfExpr, valueParamRefExpr);
+      createAccessorImplCallExpr(setterImpl, selfArg, valueParamRefExpr);
 
   auto body = BraceStmt::create(setterImpl->getASTContext(), SourceLoc(),
                                 {getterImplCallExpr}, SourceLoc());

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -587,8 +587,9 @@ namespace {
                                                    ctx);
                     cs.setType(base, MetatypeType::get(baseTy));
 
-                    refExpr = DotSyntaxCallExpr::create(ctx, declRefExpr,
-                                                        SourceLoc(), base);
+                    refExpr =
+                        DotSyntaxCallExpr::create(ctx, declRefExpr, SourceLoc(),
+                                                  Argument::unlabeled(base));
                     auto refType = adjustedFullType->castTo<FunctionType>()->getResult();
                     cs.setType(refExpr, refType);
                   } else {
@@ -1121,7 +1122,8 @@ namespace {
                                           fnTy->getExtInfo()));
         cs.cacheType(fnExpr);
 
-        fnExpr = DotSyntaxCallExpr::create(ctx, fnExpr, SourceLoc(), baseExpr);
+        fnExpr = DotSyntaxCallExpr::create(ctx, fnExpr, SourceLoc(),
+                                           Argument::unlabeled(baseExpr));
       }
       fnExpr->setType(newCalleeFnTy);
       cs.cacheType(fnExpr);
@@ -1833,7 +1835,7 @@ namespace {
         assert((!baseIsInstance || member->isInstanceMember()) &&
                "can't call a static method on an instance");
         ref = forceUnwrapIfExpected(ref, memberLocator);
-        apply = DotSyntaxCallExpr::create(context, ref, dotLoc, base);
+        apply = DotSyntaxCallExpr::create(context, ref, dotLoc, Argument::unlabeled(base));
         if (Implicit) {
           apply->setImplicit();
         }
@@ -3125,7 +3127,8 @@ namespace {
                                                base, nameLoc, ctorLocator,
                                                implicit);
       auto *call =
-          DotSyntaxCallExpr::create(cs.getASTContext(), ctorRef, dotLoc, base);
+          DotSyntaxCallExpr::create(cs.getASTContext(), ctorRef, dotLoc,
+                                    Argument::unlabeled(base));
 
       return finishApply(call, cs.getType(expr), locator, ctorLocator);
     }

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -96,6 +96,15 @@ Expr *swift::buildSelfReference(VarDecl *selfDecl,
   llvm_unreachable("bad self access kind");
 }
 
+Argument swift::buildSelfArgument(VarDecl *selfDecl,
+                                  SelfAccessorKind selfAccessorKind,
+                                  bool isMutable) {
+  auto &ctx = selfDecl->getASTContext();
+  auto *selfRef = buildSelfReference(selfDecl, selfAccessorKind, isMutable);
+  return isMutable ? Argument::implicitInOut(ctx, selfRef)
+                   : Argument::unlabeled(selfRef);
+}
+
 /// Build an argument list that forwards references to the specified parameter
 /// list.
 ArgumentList *swift::buildForwardingArgumentList(ArrayRef<ParamDecl *> params,
@@ -540,8 +549,8 @@ synthesizeDesignatedInitOverride(AbstractFunctionDecl *fn, void *context) {
 
   // Reference to super.init.
   auto *selfDecl = ctor->getImplicitSelfDecl();
-  auto *superRef = buildSelfReference(selfDecl, SelfAccessorKind::Super,
-                                      /*isLValue=*/false);
+  auto superArg = buildSelfArgument(selfDecl, SelfAccessorKind::Super,
+                                    /*isMutable*/ false);
 
   SubstitutionMap subs;
   if (auto *genericEnv = fn->getGenericEnvironment())
@@ -558,7 +567,7 @@ synthesizeDesignatedInitOverride(AbstractFunctionDecl *fn, void *context) {
   if (auto *funcTy = type->getAs<FunctionType>())
     type = funcTy->getResult();
   auto *superclassCtorRefExpr =
-      DotSyntaxCallExpr::create(ctx, ctorRefExpr, SourceLoc(), superRef, type);
+      DotSyntaxCallExpr::create(ctx, ctorRefExpr, SourceLoc(), superArg, type);
   superclassCtorRefExpr->setThrows(false);
 
   auto *bodyParams = ctor->getParameters();

--- a/lib/Sema/CodeSynthesis.h
+++ b/lib/Sema/CodeSynthesis.h
@@ -28,6 +28,7 @@ namespace swift {
 
 class AbstractFunctionDecl;
 class AbstractStorageDecl;
+class Argument;
 class ArgumentList;
 class ASTContext;
 class ClassDecl;
@@ -61,6 +62,18 @@ enum class SelfAccessorKind {
 /// super, this can be a superclass type to upcast to.
 Expr *buildSelfReference(VarDecl *selfDecl, SelfAccessorKind selfAccessorKind,
                          bool isLValue, Type convertTy = Type());
+
+/// Builds a reference to the \c self decl in a function, for use as an argument
+/// to a function.
+///
+/// \param selfDecl The self decl to reference.
+/// \param selfAccessorKind The kind of access being performed.
+/// \param isMutable Whether the resulting argument is for a mutable self
+/// argument. Such an argument is passed 'inout'.
+/// \param convertTy The type of the resulting argument. For a reference to
+/// super, this can be a superclass type to upcast to.
+Argument buildSelfArgument(VarDecl *selfDecl, SelfAccessorKind selfAccessorKind,
+                           bool isMutable);
 
 /// Build an argument list that forwards references to the specified parameter
 /// list.

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -897,8 +897,8 @@ deriveBodyEncodable_encode(AbstractFunctionDecl *encodeDecl, void *) {
     auto *method = UnresolvedDeclRefExpr::createImplicit(C, C.Id_superEncoder);
 
     // container.superEncoder()
-    auto *superEncoderRef =
-        DotSyntaxCallExpr::create(C, containerExpr, SourceLoc(), method);
+    auto *superEncoderRef = DotSyntaxCallExpr::create(
+        C, method, SourceLoc(), Argument::unlabeled(containerExpr));
 
     // encode(to:) expr
     auto *encodeDeclRef = new (C) DeclRefExpr(ConcreteDeclRef(encodeDecl),
@@ -909,8 +909,8 @@ deriveBodyEncodable_encode(AbstractFunctionDecl *encodeDecl, void *) {
                                           SourceLoc(), /*Implicit=*/true);
 
     // super.encode(to:)
-    auto *encodeCall =
-        DotSyntaxCallExpr::create(C, superRef, SourceLoc(), encodeDeclRef);
+    auto *encodeCall = DotSyntaxCallExpr::create(C, encodeDeclRef, SourceLoc(),
+                                                 Argument::unlabeled(superRef));
 
     // super.encode(to: container.superEncoder())
     auto *args = ArgumentList::forImplicitSingle(C, C.Id_to, superEncoderRef);

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -129,8 +129,8 @@ deriveBodyEquatable_enum_noAssociatedValues_eq(AbstractFunctionDecl *eqDecl,
                                     AccessSemantics::Ordinary, fnType);
 
     fnType = fnType->getResult()->castTo<FunctionType>();
-    auto *callExpr =
-        DotSyntaxCallExpr::create(C, ref, SourceLoc(), base, fnType);
+    auto *callExpr = DotSyntaxCallExpr::create(
+        C, ref, SourceLoc(), Argument::unlabeled(base), fnType);
     callExpr->setImplicit();
     callExpr->setThrows(false);
     cmpFuncExpr = callExpr;

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -984,13 +984,6 @@ static Expr *buildStorageReference(AccessorDecl *accessor,
   // Build self
   Expr *selfDRE = buildSelfReference(selfDecl, selfAccessKind, isBaseLValue,
                                      /*convertTy*/ selfTypeForAccess);
-  if (isBaseLValue)
-    selfTypeForAccess = LValueType::get(selfTypeForAccess);
-
-  if (!selfDRE->getType()->isEqual(selfTypeForAccess)) {
-    assert(selfAccessKind == SelfAccessorKind::Super);
-    selfDRE = new (ctx) DerivedToBaseExpr(selfDRE, selfTypeForAccess);
-  }
 
   // Build self.member or equivalent
 

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -1163,7 +1163,8 @@ static Expr *synthesizeCopyWithZoneCall(Expr *Val, VarDecl *VD,
   // Drop the self type
   copyMethodType = copyMethodType->getResult()->castTo<FunctionType>();
 
-  auto DSCE = DotSyntaxCallExpr::create(Ctx, DRE, SourceLoc(), Val);
+  auto DSCE = DotSyntaxCallExpr::create(Ctx, DRE, SourceLoc(),
+                                        Argument::unlabeled(Val));
   DSCE->setImplicit();
   DSCE->setType(copyMethodType);
   DSCE->setThrows(false);
@@ -1647,10 +1648,9 @@ synthesizeObservedSetterBody(AccessorDecl *Set, TargetImpl target,
     }
 
     if (SelfDecl) {
-      auto *SelfDRE =
-          buildSelfReference(SelfDecl, SelfAccessorKind::Peer, IsSelfLValue);
-      SelfDRE = maybeWrapInOutExpr(SelfDRE, Ctx);
-      auto *DSCE = DotSyntaxCallExpr::create(Ctx, Callee, SourceLoc(), SelfDRE);
+      auto SelfArg = buildSelfArgument(SelfDecl, SelfAccessorKind::Peer,
+                                       /*isMutable*/ IsSelfLValue);
+      auto *DSCE = DotSyntaxCallExpr::create(Ctx, Callee, SourceLoc(), SelfArg);
 
       if (auto funcType = type->getAs<FunctionType>())
         type = funcType->getResult();
@@ -1829,10 +1829,10 @@ synthesizeModifyCoroutineBodyWithSimpleDidSet(AccessorDecl *accessor,
     Callee->setType(type);
 
     if (SelfDecl) {
-      auto *SelfDRE = buildSelfReference(SelfDecl, SelfAccessorKind::Peer,
-                                         storage->isSetterMutating());
-      SelfDRE = maybeWrapInOutExpr(SelfDRE, ctx);
-      auto *DSCE = DotSyntaxCallExpr::create(ctx, Callee, SourceLoc(), SelfDRE);
+      auto SelfArg =
+          buildSelfArgument(SelfDecl, SelfAccessorKind::Peer,
+                            /*isMutable*/ storage->isSetterMutating());
+      auto *DSCE = DotSyntaxCallExpr::create(ctx, Callee, SourceLoc(), SelfArg);
 
       if (auto funcType = type->getAs<FunctionType>())
         type = funcType->getResult();


### PR DESCRIPTION
The first step on a long road towards removing InOutExpr/InOutType. Introduce `Argument::implicitInOut`, and use it to factor out `InOutExpr` creation for a bunch of code synthesis logic. This will eventually become `Argument::inout` and will just store the expression along with an "is inout" bit.