### PR TITLE
[5.7] Canonicalize the conforming type of BuiltinConformances.

### DIFF
--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -1608,8 +1608,22 @@ bool ProtocolConformance::isCanonical() const {
 
   switch (getKind()) {
   case ProtocolConformanceKind::Self:
-  case ProtocolConformanceKind::Normal:
+  case ProtocolConformanceKind::Normal: {
+    return true;
+  }
   case ProtocolConformanceKind::Builtin: {
+    // Check that the generic signature of the conformance is canonical.
+    auto builtinConformance = cast<BuiltinProtocolConformance>(this);
+    if (builtinConformance->getGenericSignature()
+        && !builtinConformance->getGenericSignature()->isCanonical()) {
+      return false;
+    }
+    // Check that the satisfied conditional requirements are canonical.
+    for (auto &requirement : builtinConformance->getConditionalRequirements()) {
+      if (!requirement.isCanonical()) {
+        return false;
+      }
+    }
     return true;
   }
   case ProtocolConformanceKind::Inherited: {
@@ -1638,10 +1652,24 @@ ProtocolConformance *ProtocolConformance::getCanonicalConformance() {
 
   switch (getKind()) {
   case ProtocolConformanceKind::Self:
-  case ProtocolConformanceKind::Normal:
-  case ProtocolConformanceKind::Builtin: {
+  case ProtocolConformanceKind::Normal: {
     // Root conformances are always canonical by construction.
     return this;
+  }
+  case ProtocolConformanceKind::Builtin: {
+    // Canonicalize the subject type of the builtin conformance.
+    auto &Ctx = getType()->getASTContext();
+    auto builtinConformance = cast<BuiltinProtocolConformance>(this);
+    SmallVector<Requirement, 4> canonicalRequirements;
+    for (auto &reqt : builtinConformance->getConditionalRequirements()) {
+      canonicalRequirements.push_back(reqt.getCanonical());
+    }
+    return Ctx.getBuiltinConformance(
+      builtinConformance->getType()->getCanonicalType(),
+      builtinConformance->getProtocol(),
+      builtinConformance->getGenericSignature().getCanonicalSignature(),
+      canonicalRequirements,
+      builtinConformance->getBuiltinConformanceKind());
   }
 
   case ProtocolConformanceKind::Inherited: {

--- a/test/SILGen/opaque_type_sendable_requirement_canonicalization.swift
+++ b/test/SILGen/opaque_type_sendable_requirement_canonicalization.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-emit-silgen -disable-availability-checking -verify %s
+
+// rdar://94877954
+
+// `dynamic` prevents SILGen from lowering away
+// the opaque return type of `foo`
+dynamic func foo<T: Sendable>(f: () -> T) -> some Sendable {
+    if #available(macOS 11.0, *) {
+        return f()
+    } else {
+        return ()
+    }
+}
+
+func bar() {
+    let x: Void = ()
+    let y: () = ()
+    var a = foo { x }
+    a = foo { y }
+    _ = a
+}


### PR DESCRIPTION
Explanation: An inconsistency in the internal representation of tuple `Sendable` conformances could cause the compiler to crash when handling opaque return types from SwiftUI's `WindowGroup.backgroundTask` modifier.

Scope: Fixes a compiler crash on valid SwiftUI code.

Issue: rdar://94877954.

Risk: Low. Fixes a logic error by canonicalizing protocol conformance representations that were not canonical.

Testing: Project from bug report, Swift CI

Reviewed by: @slavapestov 