### PR TITLE
Fixed release/5.4's update-checkout swift-format.

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -425,7 +425,7 @@
                 "cmake": "v3.16.5",
                 "indexstore-db": "release/5.4",
                 "sourcekit-lsp": "release/5.4",
-                "swift-format": "main",
+                "swift-format": "swift-5.4-branch",
                 "swift-installer-scripts": "main"
             }
         }


### PR DESCRIPTION
It was main but should be swift-5.4-branch.
