### PR TITLE
[ConstraintSystem] Improve solver step printing in the type inference algorithm debug output

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -590,7 +590,7 @@ public:
 
   /// Print the type variable to the given output stream.
   void print(llvm::raw_ostream &OS);
-  
+
 private:
   StringRef getTypeVariableOptions(TypeVariableOptions TVO) const {
   #define ENTRY(Kind, String) case TypeVariableOptions::Kind: return String

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1657,9 +1657,11 @@ void BindingSet::dump(llvm::raw_ostream &out, unsigned indent) const {
 
   out.indent(indent);
   out << "(";
-  if (auto typeVar = getTypeVariable())
-    out << "$T" << typeVar->getImpl().getID() << " ";
-  
+  if (auto typeVar = getTypeVariable()) {
+    typeVar->print(out, PO);
+    out << " ";
+  }
+
   std::vector<std::string> attributes;
   if (isDirectHole())
     attributes.push_back("hole");
@@ -1722,7 +1724,7 @@ void BindingSet::dump(llvm::raw_ostream &out, unsigned indent) const {
 
   auto numDefaultable = getNumViableDefaultableBindings();
   if (numDefaultable > 0)
-    out << "#defaultable_bindings: " << numDefaultable << " ";
+    out << "[#defaultable_bindings: " << numDefaultable << "] ";
 
   auto printBinding = [&](const PotentialBinding &binding) {
     auto type = binding.BindingType;
@@ -1769,9 +1771,9 @@ void BindingSet::dump(llvm::raw_ostream &out, unsigned indent) const {
                                AllowedBindingKind::Exact, constraint};
       printBinding(binding);
     }
-    out << "] ";
+    out << "]";
   }
-  out << ")\n";
+  out << ")";
 }
 
 // Given a possibly-Optional type, return the direct superclass of the

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4207,6 +4207,7 @@ bool ConstraintSystem::generateConstraints(
       print(log, expr);
       log << "\n";
       print(log);
+      log << "\n";
     }
 
     return false;

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -875,6 +875,10 @@ StepResult ConjunctionStep::resume(bool prevFailed) {
   // attempted to apply information gained from the
   // isolated constraint to the outer context.
   if (Snapshot && Snapshot->isScoped()) {
+    Snapshot.reset();
+    if (CS.isDebugMode())
+      getDebugLogger() << ")\n";
+    
     return done(/*isSuccess=*/!prevFailed);
   }
 

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -352,6 +352,7 @@ StepResult ComponentStep::take(bool prevFailed) {
   auto bestBindings = CS.determineBestBindings([&](const BindingSet &bindings) {
     if (CS.isDebugMode() && bindings.hasViableBindings()) {
       bindings.dump(bos, CS.solverState->getCurrentIndent() + 2);
+      bos << "\n";
     }
   });
 

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -999,9 +999,6 @@ public:
       auto remainingTime = OuterTimeRemaining->second;
       CS.Timer.emplace(anchor, CS, remainingTime);
     }
-    
-    if (CS.isDebugMode())
-      getDebugLogger() << ")\n";
   }
 
   StepResult resume(bool prevFailed) override;

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1466,16 +1466,17 @@ void ConstraintSystem::print(raw_ostream &out) const {
              });
   for (auto tv : typeVariables) {
     out.indent(2);
-    tv->getImpl().print(out);
     auto rep = getRepresentative(tv);
     if (rep == tv) {
       if (auto fixed = getFixedType(tv)) {
+        tv->getImpl().print(out);
         out << " as ";
         Type(fixed).print(out, PO);
       } else {
         const_cast<ConstraintSystem *>(this)->getBindingsFor(tv).dump(out, 1);
       }
     } else {
+      tv->getImpl().print(out);
       out << " equivalent to ";
       Type(rep).print(out, PO);
     }

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1299,9 +1299,9 @@ void Solution::dump(raw_ostream &out) const {
   if (!overloadChoices.empty()) {
     out << "\nOverload choices:";
     for (auto ovl : overloadChoices) {
-      out.indent(2);
       if (ovl.first) {
         out << "\n";
+        out.indent(2);
         ovl.first->dump(sm, out);
       }
 


### PR DESCRIPTION
These changes make minor improvements to solver step printing including indentation and spacing cleanup and refactoring repetitive code. `overload set choice binding` now prints only for disjunction overloads with generics and will print an accompanying list of type variables assigned to the generic parameters involved in that disjunction scope.

For example, the following disjunctions:
```
(attempting disjunction choice $T1 bound to decl Swift.(file).UInt extension.+ : (UInt.Type) -> (UInt, UInt) -> UInt [[locator@0x13a9ff398 [OverloadedDeclRef@/Users/amritpankaur/test.swift:62:3]]];
  (overload set choice binding $T1 := (UInt, UInt) -> UInt)
  (failed constraint (_const $T2, _const $T3) -> $T4 applicable fn $T1 [[locator@0x13aa16390 [Binary@/Users/amritpankaur/test.swift:62:3 -> apply function]]];)
)
(attempting disjunction choice $T1 bound to decl Swift.(file).AdditiveArithmetic.+ : <Self where Self : AdditiveArithmetic> (Self.Type) -> (Self, Self) -> Self [[locator@0x13a9ff398 [OverloadedDeclRef@/Users/amritpankaur/test.swift:62:3]]];
  (overload set choice binding $T1 := ($T7, $T7) -> $T7)
  ...
```
will now print as:
```
(attempting disjunction choice $T1 bound to decl : (UInt.Type) -> (UInt, UInt) -> UInt
  (failed constraint (_const $T2, _const $T3) -> $T4 applicable fn $T1 [[locator@0x13c00b990 [Binary@/... -> apply function]]];)
)
(attempting disjunction choice $T1 bound to decl : <Self where Self : AdditiveArithmetic> (Self.Type) -> (Self, Self) -> Self
  (overload set choice binding $T1 := ($T7, $T7) -> $T7 [Self := $T7])
  ...
```