### PR TITLE
[ResultBuilder] AST transform: don't try type erasure of result expressions

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -919,8 +919,6 @@ class ResultBuilderTransform
 
   using UnsupportedElt = SkipUnhandledConstructInResultBuilder::UnhandledNode;
 
-  /// The constraint system this transform is associated with.
-  ConstraintSystem &CS;
   /// The result type of this result builder body.
   Type ResultType;
 
@@ -930,8 +928,7 @@ class ResultBuilderTransform
 public:
   ResultBuilderTransform(ConstraintSystem &cs, DeclContext *dc,
                          Type builderType, Type resultTy)
-      : BuilderTransformerBase(&cs, dc, builderType), CS(cs),
-        ResultType(resultTy) {}
+      : BuilderTransformerBase(&cs, dc, builderType), ResultType(resultTy) {}
 
   UnsupportedElt getUnsupportedElement() const { return FirstUnsupported; }
 
@@ -1179,10 +1176,6 @@ protected:
             builder.buildCall(resultLoc, ctx.Id_buildFinalResult,
                               {buildBlockResult}, {Identifier()});
       }
-
-      // Type erase return if the result type requires it.
-      buildBlockResult = CS.buildTypeErasedExpr(buildBlockResult, dc,
-                                                ResultType, CTP_ReturnStmt);
 
       elements.push_back(new (ctx) ReturnStmt(resultLoc, buildBlockResult,
                                               /*Implicit=*/true));

--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -1584,6 +1584,8 @@ private:
   }
 
   ASTNode visitReturnStmt(ReturnStmt *returnStmt) {
+    auto &cs = solution.getConstraintSystem();
+
     if (!returnStmt->hasResult()) {
       // If contextual is not optional, there is nothing to do here.
       if (resultType->isVoid())
@@ -1597,8 +1599,6 @@ private:
 
       assert(resultType->getOptionalObjectType() &&
              resultType->lookThroughAllOptionalTypes()->isVoid());
-
-      auto &cs = solution.getConstraintSystem();
 
       auto target = *cs.getSolutionApplicationTarget(returnStmt);
       returnStmt->setResult(target.getAsExpr());
@@ -1629,13 +1629,24 @@ private:
       mode = convertToResult;
     }
 
-    SolutionApplicationTarget resultTarget(
-        resultExpr, context.getAsDeclContext(),
-        mode == convertToResult ? CTP_ReturnStmt : CTP_Unused,
-        mode == convertToResult ? resultType : Type(),
-        /*isDiscarded=*/false);
-    if (auto newResultTarget = rewriteTarget(resultTarget))
+    Optional<SolutionApplicationTarget> resultTarget;
+    if (auto target = cs.getSolutionApplicationTarget(returnStmt)) {
+      resultTarget = *target;
+    } else {
+      // Single-expression closures have to handle returns in a special
+      // way so the target has to be created for them during solution
+      // application based on the resolved type.
+      assert(isSingleExpression);
+      resultTarget = SolutionApplicationTarget(
+          resultExpr, context.getAsDeclContext(),
+          mode == convertToResult ? CTP_ReturnStmt : CTP_Unused,
+          mode == convertToResult ? resultType : Type(),
+          /*isDiscarded=*/false);
+    }
+
+    if (auto newResultTarget = rewriteTarget(*resultTarget)) {
       resultExpr = newResultTarget->getAsExpr();
+    }
 
     switch (mode) {
     case convertToResult:


### PR DESCRIPTION
- Fix `SyntacticElementSolutionApplication` to use existing `return` expression targets when available;
- Don't do type erase of result expressions during builder transform, it would be done during constraint generation.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
