### PR TITLE
[Interop][SwiftToCxx] add support for resilient enum

### DIFF
--- a/include/swift/IRGen/IRABIDetailsProvider.h
+++ b/include/swift/IRGen/IRABIDetailsProvider.h
@@ -105,9 +105,15 @@ public:
   /// access function.
   FunctionABISignature getTypeMetadataAccessFunctionSignature();
 
+  struct EnumElementInfo {
+    unsigned tag;
+    StringRef globalVariableName;
+  };
+
   /// Returns EnumElementDecls (enum cases) in their declaration order with
   /// their tag indices from the given EnumDecl
-  llvm::MapVector<EnumElementDecl *, unsigned> getEnumTagMapping(EnumDecl *ED);
+  llvm::MapVector<EnumElementDecl *, EnumElementInfo>
+  getEnumTagMapping(const EnumDecl *ED);
 
   /// Returns the additional params if they exist after lowering the function.
   SmallVector<ABIAdditionalParam, 1>

--- a/lib/IRGen/IRABIDetailsProvider.cpp
+++ b/lib/IRGen/IRABIDetailsProvider.cpp
@@ -126,14 +126,18 @@ public:
     return {returnTy, {paramTy}};
   }
 
-  llvm::MapVector<EnumElementDecl *, unsigned> getEnumTagMapping(EnumDecl *ED) {
-    llvm::MapVector<EnumElementDecl *, unsigned> elements;
+  llvm::MapVector<EnumElementDecl *, IRABIDetailsProvider::EnumElementInfo>
+  getEnumTagMapping(const EnumDecl *ED) {
+    llvm::MapVector<EnumElementDecl *, IRABIDetailsProvider::EnumElementInfo>
+        elements;
     auto &enumImplStrat =
         getEnumImplStrategy(IGM, ED->getDeclaredType()->getCanonicalType());
 
     for (auto *element : ED->getAllElements()) {
       auto tagIdx = enumImplStrat.getTagIndex(element);
-      elements.insert({element, tagIdx});
+      auto *global = cast<llvm::GlobalVariable>(
+          IGM.getAddrOfEnumCase(element, NotForDefinition).getAddress());
+      elements.insert({element, {tagIdx, global->getName()}});
     }
 
     return elements;
@@ -217,7 +221,7 @@ IRABIDetailsProvider::getTypeMetadataAccessFunctionSignature() {
   return impl->getTypeMetadataAccessFunctionSignature();
 }
 
-llvm::MapVector<EnumElementDecl *, unsigned>
-IRABIDetailsProvider::getEnumTagMapping(EnumDecl *ED) {
+llvm::MapVector<EnumElementDecl *, IRABIDetailsProvider::EnumElementInfo>
+IRABIDetailsProvider::getEnumTagMapping(const EnumDecl *ED) {
   return impl->getEnumTagMapping(ED);
 }

--- a/lib/PrintAsClang/PrintClangValueType.cpp
+++ b/lib/PrintAsClang/PrintClangValueType.cpp
@@ -113,6 +113,22 @@ void ClangValueTypePrinter::printValueTypeDecl(
                            // access type metadata.
                            printer.printCTypeMetadataTypeFunction(
                                typeDecl, typeMetadataFuncName);
+                           // Print out global variables for resilient enum
+                           // cases
+                           if (isa<EnumDecl>(typeDecl) && isOpaqueLayout) {
+                             auto elementTagMapping =
+                                 interopContext.getIrABIDetails()
+                                     .getEnumTagMapping(
+                                         cast<EnumDecl>(typeDecl));
+                             os << "// Tags for resilient enum ";
+                             os << typeDecl->getName().str() << '\n';
+                             os << "extern \"C\" {\n";
+                             for (const auto &pair : elementTagMapping) {
+                               os << "extern int "
+                                  << pair.second.globalVariableName << ";\n";
+                             }
+                             os << "}\n";
+                           }
                          });
 
   auto printEnumVWTableVariable = [&](StringRef metadataName = "metadata",
@@ -265,17 +281,13 @@ void ClangValueTypePrinter::printValueTypeDecl(
         os << "    return result;\n";
         os << "  }\n";
         // Print out helper function for initializeWithTake
-        // TODO: (tongjie) support opaque layout
-        if (!isOpaqueLayout) {
-          os << "  static inline void initializeWithTake(char * _Nonnull "
-                "destStorage, char * _Nonnull srcStorage) {\n";
-          ClangValueTypePrinter::printValueWitnessTableAccessAsVariable(
-              os, typeMetadataFuncName);
-          os << "    vwTable->initializeWithTake(destStorage, srcStorage, "
-                "metadata._0);\n";
-          os << "  }\n";
-        }
-
+        os << "  static inline void initializeWithTake(char * _Nonnull "
+              "destStorage, char * _Nonnull srcStorage) {\n";
+        ClangValueTypePrinter::printValueWitnessTableAccessAsVariable(
+            os, typeMetadataFuncName);
+        os << "    vwTable->initializeWithTake(destStorage, srcStorage, "
+              "metadata._0);\n";
+        os << "  }\n";
         os << "};\n";
       });
 

--- a/test/Interop/SwiftToCxx/enums/resilient-enum-in-cxx-execution.cpp
+++ b/test/Interop/SwiftToCxx/enums/resilient-enum-in-cxx-execution.cpp
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %S/resilient-enum-in-cxx.swift -enable-library-evolution -typecheck -module-name Enums -clang-header-expose-public-decls -emit-clang-header-path %t/enums.h
+
+// RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-enums-execution.o
+
+// RUN: %target-interop-build-swift %S/resilient-enum-in-cxx.swift -enable-library-evolution -o %t/swift-enums-execution -Xlinker %t/swift-enums-execution.o -module-name Enums -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+// RUN: %target-codesign %t/swift-enums-execution
+// RUN: %target-run %t/swift-enums-execution | %FileCheck --check-prefixes=CHECK,OLD_CASE %s
+
+// RUN: %target-interop-build-swift %S/resilient-enum-in-cxx.swift -enable-library-evolution -o %t//swift-enums-execution-new -Xlinker %t/swift-enums-execution.o -module-name Enums -Xfrontend -entry-point-function-name -Xfrontend swiftMain -D NEW_CASE
+// RUN: %target-codesign %t/swift-enums-execution-new
+// RUN: %target-run %t/swift-enums-execution-new | %FileCheck --check-prefixes=CHECK,NEW_CASE %s
+
+// REQUIRES: executable_test
+
+#include <cassert>
+#include <iostream>
+#include "enums.h"
+
+int main() {
+  using namespace Enums;
+  auto f1 = makeFoo(10);
+  auto f2 = makeFoo(-10);
+
+  printFoo(f1);
+  printFoo(f2);
+
+  assert(!f2.inResilientUnknownCase());
+  if (f1.inResilientUnknownCase()) {
+    std::cout << "f1.inResilientUnknownCase()\n";
+    assert(!f1.isA());
+  } else {
+    assert(f1.isA());
+    assert(f1.getA() == 10.0);
+  }
+
+  return 0;
+}
+
+// OLD_CASE: a(10.0)
+// NEW_CASE: b(10)
+// CHECK-NEXT: a(-10.0)
+
+// NEW_CASE: f1.inResilientUnknownCase()

--- a/test/Interop/SwiftToCxx/enums/resilient-enum-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/resilient-enum-in-cxx.swift
@@ -1,0 +1,63 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %s -enable-library-evolution -typecheck -module-name Enums -clang-header-expose-public-decls -emit-clang-header-path %t/enums.h
+// RUN: %FileCheck --check-prefixes=CHECK,OLD_CASE %s < %t/enums.h
+
+// RUN: %target-swift-frontend %s -enable-library-evolution -D NEW_CASE -typecheck -module-name Enums -clang-header-expose-public-decls -emit-clang-header-path %t/enums_new_case.h
+// RUN: %FileCheck --check-prefixes=CHECK,NEW_CASE %s < %t/enums_new_case.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/enums.h -Wno-unused-private-field -Wno-unused-function)
+// RUN: %check-interop-cxx-header-in-clang(%t/enums_new_case.h -Wno-unused-private-field -Wno-unused-function)
+
+public enum Foo {
+    case a(Double)
+#if NEW_CASE
+    case b(Int)
+#endif
+}
+
+public func makeFoo(_ x: Int) -> Foo {
+#if NEW_CASE
+    if x >= 0 {
+        return .b(x)
+    } else {
+        return .a(Double(x))
+    }
+#else
+    return .a(Double(x))
+#endif
+}
+
+public func printFoo(_ x: Foo) {
+    print(x)
+}
+
+// CHECK:         // Tags for resilient enum Foo
+// CHECK-NEXT:    extern "C" {
+// CHECK-NEXT:    extern int $s5Enums3FooO1ayACSdcACmFWC;
+// NEW_CASE-NEXT: extern int $s5Enums3FooO1byACSicACmFWC;
+// CHECK-NEXT:    }
+// CHECK-EMPTY:
+// CHECK-NEXT:    } // namespace _impl
+// CHECK-EMPTY:
+// CHECK-NEXT:    class Foo final {
+// CHECK-NEXT:    public:
+// CHECK:         inline operator cases() const {
+// CHECK-NEXT:      auto tag = _getEnumTag();
+// CHECK-NEXT:      if (tag == _impl::$s5Enums3FooO1ayACSdcACmFWC) return cases::a;
+// NEW_CASE-NEXT:   if (tag == _impl::$s5Enums3FooO1byACSicACmFWC) return cases::b;
+// CHECK-NEXT:      abort();
+// CHECK-NEXT:    }
+// CHECK-NEXT:    inline bool inResilientUnknownCase() const {
+// CHECK-NEXT:      auto tag = _getEnumTag();
+// CHECK-NEXT:      return
+// OLD_CASE-NEXT:     tag != _impl::$s5Enums3FooO1ayACSdcACmFWC;
+// NEW_CASE-NEXT:     tag != _impl::$s5Enums3FooO1ayACSdcACmFWC &&
+// NEW_CASE-NEXT:     tag != _impl::$s5Enums3FooO1byACSicACmFWC;
+// CHECK-NEXT:    }
+// CHECK-NEXT:    inline bool isA() const {
+// CHECK-NEXT:      return _getEnumTag() == _impl::$s5Enums3FooO1ayACSdcACmFWC;
+// CHECK-NEXT:    }
+// NEW_CASE:      inline bool isB() const {
+// NEW_CASE-NEXT:   return _getEnumTag() == _impl::$s5Enums3FooO1byACSicACmFWC;
+// NEW_CASE-NEXT: }

--- a/test/Interop/SwiftToCxx/enums/swift-enum-case-functions.swift
+++ b/test/Interop/SwiftToCxx/enums/swift-enum-case-functions.swift
@@ -162,13 +162,13 @@ public func checkIntDoubleOrBignum(_ x: IntDoubleOrBignum, tag: Int) -> Bool {
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 // CHECK-NEXT: inline bool isSecond() const {
-// CHECK-NEXT:   return *this == cases::second;
+// CHECK-NEXT:   return _getEnumTag() == 0;
 // CHECK-NEXT: }
 // CHECK:      inline bool isFirst() const {
-// CHECK-NEXT:   return *this == cases::first;
+// CHECK-NEXT:   return _getEnumTag() == 1;
 // CHECK-NEXT: }
 // CHECK-NEXT: inline bool isThird() const {
-// CHECK-NEXT:     return *this == cases::third;
+// CHECK-NEXT:   return _getEnumTag() == 2;
 // CHECK-NEXT: }
 // CHECK:      inline int _getEnumTag() const {
 // CHECK-NEXT:   auto metadata = _impl::$s5Enums12BoolWithCaseOMa(0);
@@ -193,13 +193,13 @@ public func checkIntDoubleOrBignum(_ x: IntDoubleOrBignum, tag: Int) -> Bool {
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 // CHECK-NEXT: inline bool isOne() const {
-// CHECK-NEXT:   return *this == cases::one;
+// CHECK-NEXT:   return _getEnumTag() == 0;
 // CHECK-NEXT: }
 // CHECK:      inline bool isTwo() const {
-// CHECK-NEXT:   return *this == cases::two;
+// CHECK-NEXT:   return _getEnumTag() == 1;
 // CHECK-NEXT: }
 // CHECK:      inline bool isThree() const {
-// CHECK-NEXT:   return *this == cases::three;
+// CHECK-NEXT:   return _getEnumTag() == 2;
 // CHECK-NEXT: }
 // CHECK:      inline int _getEnumTag() const {
 // CHECK-NEXT:   auto metadata = _impl::$s5Enums9CLikeEnumOMa(0);
@@ -222,7 +222,7 @@ public func checkIntDoubleOrBignum(_ x: IntDoubleOrBignum, tag: Int) -> Bool {
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 // CHECK-NEXT: inline bool isOne() const {
-// CHECK-NEXT:   return *this == cases::one;
+// CHECK-NEXT:   return _getEnumTag() == 0;
 // CHECK-NEXT: }
 // CHECK:      inline int _getEnumTag() const {
 // CHECK-NEXT:   auto metadata = _impl::$s5Enums8DataCaseOMa(0);
@@ -247,13 +247,13 @@ public func checkIntDoubleOrBignum(_ x: IntDoubleOrBignum, tag: Int) -> Bool {
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 // CHECK-NEXT: inline bool isInt() const {
-// CHECK-NEXT:   return *this == cases::Int;
+// CHECK-NEXT:   return _getEnumTag() == 0;
 // CHECK-NEXT: }
 // CHECK:      inline bool isDouble() const {
-// CHECK-NEXT:   return *this == cases::Double;
+// CHECK-NEXT:   return _getEnumTag() == 1;
 // CHECK-NEXT: }
 // CHECK:      inline bool isBignum() const {
-// CHECK-NEXT:   return *this == cases::Bignum;
+// CHECK-NEXT:   return _getEnumTag() == 2;
 // CHECK-NEXT: }
 // CHECK:      inline int _getEnumTag() const {
 // CHECK-NEXT:   auto metadata = _impl::$s5Enums17IntDoubleOrBignumOMa(0);
@@ -278,13 +278,13 @@ public func checkIntDoubleOrBignum(_ x: IntDoubleOrBignum, tag: Int) -> Bool {
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 // CHECK-NEXT: inline bool isInt() const {
-// CHECK-NEXT:   return *this == cases::Int;
+// CHECK-NEXT:   return _getEnumTag() == 0;
 // CHECK-NEXT: }
 // CHECK:      inline bool isNegInfinity() const {
-// CHECK-NEXT:   return *this == cases::NegInfinity;
+// CHECK-NEXT:   return _getEnumTag() == 1;
 // CHECK-NEXT: }
 // CHECK:      inline bool isPosInfinity() const {
-// CHECK-NEXT:   return *this == cases::PosInfinity;
+// CHECK-NEXT:   return _getEnumTag() == 2;
 // CHECK-NEXT: }
 // CHECK:      inline int _getEnumTag() const {
 // CHECK-NEXT:   auto metadata = _impl::$s5Enums13IntOrInfinityOMa(0);
@@ -310,16 +310,16 @@ public func checkIntDoubleOrBignum(_ x: IntDoubleOrBignum, tag: Int) -> Bool {
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 // CHECK-NEXT: inline bool isSecond() const {
-// CHECK-NEXT:     return *this == cases::second;
+// CHECK-NEXT:   return _getEnumTag() == 0;
 // CHECK-NEXT: }
 // CHECK:      inline bool isThird() const {
-// CHECK-NEXT:     return *this == cases::third;
+// CHECK-NEXT:   return _getEnumTag() == 1;
 // CHECK-NEXT: }
 // CHECK:      inline bool isFirst() const {
-// CHECK-NEXT:     return *this == cases::first;
+// CHECK-NEXT:   return _getEnumTag() == 2;
 // CHECK-NEXT: }
 // CHECK-NEXT: inline bool isFourth() const {
-// CHECK-NEXT:     return *this == cases::fourth;
+// CHECK-NEXT:   return _getEnumTag() == 3;
 // CHECK-NEXT: }
 // CHECK:      inline int _getEnumTag() const {
 // CHECK-NEXT:   auto metadata = _impl::$s5Enums20MultipleBoolWithCaseOMa(0);


### PR DESCRIPTION
Changes:

- Update `IRABIDetailsProvider::getEnumTagMapping` so that it will also return the global variable name for the enum tag
- Update `operator cases` in the printed header: supporting resilient enum
- Update `bool isXyz()` in the printed header: these functions will compare with the tag constants (non-resilient) or tag global variables (resilient) directly
- Add `bool inResilientUnknownCase()` in the printed header for resilient enum, allowing checking if the enum is in an unknown case
- Add tag global variables for resilient enum in the `_impl` namespace of printed header
- Update tests accordingly

@hyp Could you please review this pull request? Thanks.