### PR TITLE
Add missing compat dependencies to bootstrapping

### DIFF
--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -295,6 +295,8 @@ else()
       set(compatibility_libs
           "swiftCompatibility50-${platform}"
           "swiftCompatibility51-${platform}"
+          "swiftCompatibility56-${platform}"
+          "swiftCompatibilityConcurrency-${platform}"
           "swiftCompatibilityDynamicReplacements-${platform}")
 
       list(APPEND b0_deps ${compatibility_libs})


### PR DESCRIPTION
The bootstrapping stages were missing dependencies on the Concurrency
and Swift 5.6 backdeployment compatibility libraries resulting in
failing builds.