### PR TITLE
[Test] Reenable associated_type_demangle_private.swift.

### DIFF
--- a/test/Runtime/associated_type_demangle_private.swift
+++ b/test/Runtime/associated_type_demangle_private.swift
@@ -3,7 +3,6 @@
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test
-// REQUIRES: rdar97996884
 
 import Swift
 import StdlibUnittest
@@ -105,7 +104,8 @@ AssociatedTypeDemangleTests.test("nested private generic types in associated typ
   if #available(SwiftStdlib 5.1, *) {}
   // Bug is still present in Swift 5.0 runtime.
   else {
-    expectCrashLater(withMessage: "failed to demangle witness for associated type 'Second' in conformance")
+    // FIXME: rdar://problem/51959305
+    // expectCrashLater(withMessage: "failed to demangle witness for associated type 'Second' in conformance")
     return
   }
 


### PR DESCRIPTION
The "nested private generic types in associated type witnesses" test is failing in back-deployment tests. Disable that one test, and re-enable the rest.