### PR TITLE
AST: Rename 'canonical wrt. generic signature' to 'reduced'

### DIFF
--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -213,9 +213,9 @@ public:
   SmallVector<Requirement, 4>
   requirementsNotSatisfiedBy(GenericSignature otherSig) const;
 
-  /// Return the canonical version of the given type under this generic
+  /// Return the reduced version of the given type under this generic
   /// signature.
-  CanType getCanonicalTypeInContext(Type type) const;
+  CanType getReducedType(Type type) const;
 
   /// Check invariants.
   void verify() const;
@@ -383,7 +383,7 @@ public:
   /// generic signature.
   ///
   /// The type parameters must be known to not be concrete within the context.
-  bool areSameTypeParameterInContext(Type type1, Type type2) const;
+  bool areReducedTypeParametersEqual(Type type1, Type type2) const;
 
   /// Determine if \c sig can prove \c requirement, meaning that it can deduce
   /// T: Foo or T == U (etc.) with the information it knows. This includes
@@ -392,11 +392,11 @@ public:
   bool isRequirementSatisfied(
       Requirement requirement, bool allowMissing = false) const;
 
-  bool isCanonicalTypeInContext(Type type) const;
+  bool isReducedType(Type type) const;
 
   /// Determine whether the given type parameter is defined under this generic
   /// signature.
-  bool isValidTypeInContext(Type type) const;
+  bool isValidTypeParameter(Type type) const;
 
   /// Retrieve the conformance access path used to extract the conformance of
   /// interface \c type to the given \c protocol.
@@ -487,9 +487,9 @@ private:
   SmallVector<Requirement, 4>
   requirementsNotSatisfiedBy(GenericSignature otherSig) const;
 
-  /// Return the canonical version of the given type under this generic
+  /// Return the reduced version of the given type under this generic
   /// signature.
-  CanType getCanonicalTypeInContext(Type type) const;
+  CanType getReducedType(Type type) const;
 };
 
 void simple_display(raw_ostream &out, GenericSignature sig);

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -503,9 +503,9 @@ public:
     return const_cast<TypeBase*>(this)->computeCanonicalType();
   }
 
-  /// getCanonicalType - Stronger canonicalization which folds away equivalent
+  /// getReducedType - Stronger canonicalization which folds away equivalent
   /// associated types, or type parameters that have been made concrete.
-  CanType getCanonicalType(GenericSignature sig);
+  CanType getReducedType(GenericSignature sig);
 
   /// Canonical protocol composition types are minimized only to a certain
   /// degree to preserve ABI compatibility. This routine enables performing

--- a/include/swift/SIL/AbstractionPattern.h
+++ b/include/swift/SIL/AbstractionPattern.h
@@ -514,7 +514,7 @@ class AbstractionPattern {
     OrigType = origType;
     GenericSig = CanGenericSignature();
     if (OrigType->hasTypeParameter()) {
-      assert(OrigType == signature.getCanonicalTypeInContext(origType));
+      assert(OrigType == signature.getReducedType(origType));
       GenericSig = signature;
     }
   }

--- a/include/swift/SILOptimizer/Analysis/DifferentiableActivityAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/DifferentiableActivityAnalysis.h
@@ -135,7 +135,7 @@ private:
     auto type = value->getType().getASTType();
     // Remap archetypes in the derivative generic signature, if it exists.
     if (type->hasArchetype()) {
-      type = derivativeGenericSignature.getCanonicalTypeInContext(
+      type = derivativeGenericSignature.getReducedType(
           type->mapTypeOutOfContext());
     }
     // Look up conformance in the current module.

--- a/include/swift/SILOptimizer/Differentiation/LinearMapInfo.h
+++ b/include/swift/SILOptimizer/Differentiation/LinearMapInfo.h
@@ -165,7 +165,7 @@ public:
         derivative->getLoweredFunctionType()->getSubstGenericSignature();
     auto *linMapStruct = getLinearMapStruct(origBB);
     auto linMapStructType =
-        linMapStruct->getDeclaredInterfaceType()->getCanonicalType(
+        linMapStruct->getDeclaredInterfaceType()->getReducedType(
             derivativeGenSig);
     Lowering::AbstractionPattern pattern(derivativeGenSig, linMapStructType);
     return typeConverter.getLoweredType(pattern, linMapStructType,

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3541,7 +3541,7 @@ isGenericFunctionTypeCanonical(GenericSignature sig,
     return false;
 
   for (auto param : params) {
-    if (!sig->isCanonicalTypeInContext(param.getPlainType()))
+    if (!sig->isReducedType(param.getPlainType()))
       return false;
     if (!param.getInternalLabel().empty()) {
       // Canonical types don't have internal labels
@@ -3549,7 +3549,7 @@ isGenericFunctionTypeCanonical(GenericSignature sig,
     }
   }
 
-  return sig->isCanonicalTypeInContext(result);
+  return sig->isReducedType(result);
 }
 
 AnyFunctionType *AnyFunctionType::withExtInfo(ExtInfo info) const {
@@ -3771,7 +3771,7 @@ GenericFunctionType *GenericFunctionType::get(GenericSignature sig,
   }
 
   // We have to construct this generic function type. Determine whether
-  // it's canonical.  Unfortunately, isCanonicalTypeInContext can cause
+  // it's canonical.  Unfortunately, isReducedType() can cause
   // new GenericFunctionTypes to be created and thus invalidate our insertion
   // point.
   bool isCanonical = isGenericFunctionTypeCanonical(sig, params, result);
@@ -3788,7 +3788,7 @@ GenericFunctionType *GenericFunctionType::get(GenericSignature sig,
   if (info.hasValue())
     globalActor = info->getGlobalActor();
 
-  if (globalActor && !sig->isCanonicalTypeInContext(globalActor))
+  if (globalActor && !sig->isReducedType(globalActor))
     isCanonical = false;
 
   size_t allocSize = totalSizeToAlloc<AnyFunctionType::Param, Type>(

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3488,7 +3488,7 @@ void ASTMangler::appendConcreteProtocolConformance(
       auto type = conditionalReq.getFirstType();
       if (type->hasArchetype())
         type = type->mapTypeOutOfContext();
-      CanType canType = type->getCanonicalType(sig);
+      CanType canType = type->getReducedType(sig);
       auto proto = conditionalReq.getProtocolDecl();
       
       ProtocolConformanceRef conformance;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4106,7 +4106,7 @@ findGenericParameterReferences(CanGenericSignature genericSig,
 
   // If the type parameter is beyond the domain of the existential generic
   // signature, ignore it.
-  if (!genericSig->isValidTypeInContext(type)) {
+  if (!genericSig->isValidTypeParameter(type)) {
     return GenericParameterReferenceInfo();
   }
 

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -357,7 +357,7 @@ LayoutConstraint GenericSignatureImpl::getLayoutConstraint(Type type) const {
   return getRequirementMachine()->getLayoutConstraint(type);
 }
 
-bool GenericSignatureImpl::areSameTypeParameterInContext(Type type1,
+bool GenericSignatureImpl::areReducedTypeParametersEqual(Type type1,
                                                          Type type2) const {
   assert(type1->isTypeParameter());
   assert(type2->isTypeParameter());
@@ -365,7 +365,7 @@ bool GenericSignatureImpl::areSameTypeParameterInContext(Type type1,
   if (type1.getPointer() == type2.getPointer())
     return true;
 
-  return getRequirementMachine()->areSameTypeParameterInContext(type1, type2);
+  return getRequirementMachine()->areReducedTypeParametersEqual(type1, type2);
 }
 
 bool GenericSignatureImpl::isRequirementSatisfied(
@@ -431,43 +431,40 @@ SmallVector<Requirement, 4> GenericSignatureImpl::requirementsNotSatisfiedBy(
   return result;
 }
 
-bool GenericSignatureImpl::isCanonicalTypeInContext(Type type) const {
-  // If the type isn't independently canonical, it's certainly not canonical
-  // in this context.
+bool GenericSignatureImpl::isReducedType(Type type) const {
+  // If the type isn't canonical, it's not reduced.
   if (!type->isCanonical())
     return false;
 
-  // All the contextual canonicality rules apply to type parameters, so if the
-  // type doesn't involve any type parameters, it's already canonical.
+  // A fully concrete canonical type is reduced.
   if (!type->hasTypeParameter())
     return true;
 
-  return getRequirementMachine()->isCanonicalTypeInContext(type);
+  return getRequirementMachine()->isReducedType(type);
 }
 
-CanType GenericSignature::getCanonicalTypeInContext(Type type) const {
+CanType GenericSignature::getReducedType(Type type) const {
   // The null generic signature has no requirements so cannot influence the
   // structure of the can type computed here.
   if (isNull()) {
     return type->getCanonicalType();
   }
-  return getPointer()->getCanonicalTypeInContext(type);
+  return getPointer()->getReducedType(type);
 }
 
-CanType GenericSignatureImpl::getCanonicalTypeInContext(Type type) const {
+CanType GenericSignatureImpl::getReducedType(Type type) const {
   type = type->getCanonicalType();
 
-  // All the contextual canonicality rules apply to type parameters, so if the
-  // type doesn't involve any type parameters, it's already canonical.
+  // A fully concrete type is already reduced.
   if (!type->hasTypeParameter())
     return CanType(type);
 
-  return getRequirementMachine()->getCanonicalTypeInContext(
+  return getRequirementMachine()->getReducedType(
       type, { })->getCanonicalType();
 }
 
-bool GenericSignatureImpl::isValidTypeInContext(Type type) const {
-  return getRequirementMachine()->isValidTypeInContext(type);
+bool GenericSignatureImpl::isValidTypeParameter(Type type) const {
+  return getRequirementMachine()->isValidTypeParameter(type);
 }
 
 ArrayRef<CanTypeWrapper<GenericTypeParamType>>
@@ -850,8 +847,8 @@ void GenericSignature::verify(ArrayRef<Requirement> reqts) const {
         abort();
       }
 
-      if (!canSig->isCanonicalTypeInContext(reqt.getFirstType())) {
-        llvm::errs() << "Left-hand side is not canonical: ";
+      if (!canSig->isReducedType(reqt.getFirstType())) {
+        llvm::errs() << "Left-hand side is not reduced: ";
         reqt.dump(llvm::errs());
         llvm::errs() << "\n";
         abort();
@@ -861,8 +858,8 @@ void GenericSignature::verify(ArrayRef<Requirement> reqts) const {
     // Check canonicalization of requirement itself.
     switch (reqt.getKind()) {
     case RequirementKind::Superclass:
-      if (!canSig->isCanonicalTypeInContext(reqt.getSecondType())) {
-        llvm::errs() << "Right-hand side is not canonical: ";
+      if (!canSig->isReducedType(reqt.getSecondType())) {
+        llvm::errs() << "Right-hand side is not reduced: ";
         reqt.dump(llvm::errs());
         llvm::errs() << "\n";
         abort();
@@ -873,9 +870,9 @@ void GenericSignature::verify(ArrayRef<Requirement> reqts) const {
       break;
 
     case RequirementKind::SameType: {
-      auto hasCanonicalOrConcreteParent = [&](Type type) {
+      auto hasReducedOrConcreteParent = [&](Type type) {
         if (auto *dmt = type->getAs<DependentMemberType>()) {
-          return (canSig->isCanonicalTypeInContext(dmt->getBase()) ||
+          return (canSig->isReducedType(dmt->getBase()) ||
                   canSig->isConcreteType(dmt->getBase()));
         }
         return type->is<GenericTypeParamType>();
@@ -884,19 +881,19 @@ void GenericSignature::verify(ArrayRef<Requirement> reqts) const {
       auto firstType = reqt.getFirstType();
       auto secondType = reqt.getSecondType();
 
-      auto canType = canSig->getCanonicalTypeInContext(firstType);
+      auto canType = canSig->getReducedType(firstType);
       auto &component = sameTypeComponents[canType];
 
-      if (!hasCanonicalOrConcreteParent(firstType)) {
-        llvm::errs() << "Left hand side does not have a canonical parent: ";
+      if (!hasReducedOrConcreteParent(firstType)) {
+        llvm::errs() << "Left hand side does not have a reduced parent: ";
         reqt.dump(llvm::errs());
         llvm::errs() << "\n";
         abort();
       }
 
       if (reqt.getSecondType()->isTypeParameter()) {
-        if (!hasCanonicalOrConcreteParent(secondType)) {
-          llvm::errs() << "Right hand side does not have a canonical parent: ";
+        if (!hasReducedOrConcreteParent(secondType)) {
+          llvm::errs() << "Right hand side does not have a reduced parent: ";
           reqt.dump(llvm::errs());
           llvm::errs() << "\n";
           abort();
@@ -920,8 +917,8 @@ void GenericSignature::verify(ArrayRef<Requirement> reqts) const {
 
         component.push_back(secondType);
       } else {
-        if (!canSig->isCanonicalTypeInContext(secondType)) {
-          llvm::errs() << "Right hand side is not canonical: ";
+        if (!canSig->isReducedType(secondType)) {
+          llvm::errs() << "Right hand side is not reduced: ";
           reqt.dump(llvm::errs());
           llvm::errs() << "\n";
           abort();
@@ -1004,9 +1001,9 @@ void GenericSignature::verify(ArrayRef<Requirement> reqts) const {
   // Check same-type components for consistency.
   for (const auto &pair : sameTypeComponents) {
     if (pair.second.front()->isTypeParameter() &&
-        !canSig->isCanonicalTypeInContext(pair.second.front())) {
+        !canSig->isReducedType(pair.second.front())) {
       llvm::errs() << "Abstract same-type requirement involving concrete types\n";
-      llvm::errs() << "Canonical type: " << pair.first << "\n";
+      llvm::errs() << "Reduced type: " << pair.first << "\n";
       llvm::errs() << "Left hand side of first requirement: "
                    << pair.second.front() << "\n";
       abort();

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -18,7 +18,7 @@
 // type parameters expressed by this set of generic requirements. These are
 // called "generic signature queries", and are defined as methods on the
 // GenericSignature class; for example, two of the more common ones are
-// getCanonicalTypeInContext() and requiresProtocol().
+// getReducedType() and requiresProtocol().
 //
 // The terms of the rewrite system describe all possible type parameters that
 // can be written -- the generic parameters themselves, together with all nested

--- a/lib/AST/RequirementMachine/RequirementMachine.h
+++ b/lib/AST/RequirementMachine/RequirementMachine.h
@@ -153,11 +153,11 @@ public:
   Type getConcreteType(Type depType,
                        TypeArrayView<GenericTypeParamType> genericParams,
                        const ProtocolDecl *proto=nullptr) const;
-  bool areSameTypeParameterInContext(Type depType1, Type depType2) const;
-  bool isCanonicalTypeInContext(Type type) const;
-  Type getCanonicalTypeInContext(Type type,
+  bool areReducedTypeParametersEqual(Type depType1, Type depType2) const;
+  bool isReducedType(Type type) const;
+  Type getReducedType(Type type,
                       TypeArrayView<GenericTypeParamType> genericParams) const;
-  bool isValidTypeInContext(Type type) const;
+  bool isValidTypeParameter(Type type) const;
   ConformanceAccessPath getConformanceAccessPath(Type type,
                                                  ProtocolDecl *protocol);
   TypeDecl *lookupNestedType(Type depType, Identifier name) const;

--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -920,14 +920,14 @@ InferredGenericSignatureRequest::evaluate(
 
     if (!allowConcreteGenericParams) {
       for (auto genericParam : result.getInnermostGenericParams()) {
-        auto canonical = result.getCanonicalTypeInContext(genericParam);
+        auto reduced = result.getReducedType(genericParam);
 
-        if (canonical->hasError() || canonical->isEqual(genericParam))
+        if (reduced->hasError() || reduced->isEqual(genericParam))
           continue;
 
-        if (canonical->isTypeParameter()) {
+        if (reduced->isTypeParameter()) {
           ctx.Diags.diagnose(loc, diag::requires_generic_params_made_equal,
-                             genericParam, result->getSugaredType(canonical))
+                             genericParam, result->getSugaredType(reduced))
             .warnUntilSwiftVersion(6);
         } else {
           ctx.Diags.diagnose(loc,

--- a/lib/AST/RequirementMachine/RuleBuilder.cpp
+++ b/lib/AST/RequirementMachine/RuleBuilder.cpp
@@ -104,7 +104,7 @@ void RuleBuilder::initWithProtocolSignatureRequirements(
 
     // If completion failed, we'll have a totally empty requirement signature,
     // but to maintain invariants around what constitutes a valid rewrite term
-    // between getTypeForTerm() and isValidTypeInContext(), we need to add rules
+    // between getTypeForTerm() and isValidTypeParameter(), we need to add rules
     // for inherited protocols.
     if (reqs.getErrors().contains(GenericSignatureErrorFlags::CompletionFailed)) {
       for (auto *inheritedProto : Context.getInheritedProtocols(proto)) {

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -299,9 +299,9 @@ Type SubstitutionMap::lookupSubstitution(CanSubstitutableType type) const {
     return replacementType;
   }
 
-  // The generic parameter may not be canonical. Retrieve the canonical
+  // The generic parameter may not be reduced. Retrieve the reduced
   // type, which will be dependent.
-  CanType canonicalType = genericSig.getCanonicalTypeInContext(genericParam);
+  CanType canonicalType = genericSig.getReducedType(genericParam);
 
   // If nothing changed, we don't have a replacement.
   if (canonicalType == type) return Type();

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1537,7 +1537,7 @@ getCanonicalParams(AnyFunctionType *funcType,
   for (auto param : origParams) {
     // Canonicalize the type and drop the internal label to canonicalize the
     // Param.
-    canParams.emplace_back(param.getPlainType()->getCanonicalType(genericSig),
+    canParams.emplace_back(param.getPlainType()->getReducedType(genericSig),
                            param.getLabel(), param.getParameterFlags(),
                            /*InternalLabel=*/Identifier());
   }
@@ -1673,7 +1673,7 @@ CanType TypeBase::computeCanonicalType() {
     // Transform the parameter and result types.
     SmallVector<AnyFunctionType::Param, 8> canParams;
     getCanonicalParams(funcTy, genericSig, canParams);
-    auto resultTy = funcTy->getResult()->getCanonicalType(genericSig);
+    auto resultTy = funcTy->getResult()->getReducedType(genericSig);
 
     Optional<ASTExtInfo> extInfo = None;
     if (funcTy->hasExtInfo())
@@ -1775,8 +1775,8 @@ CanType TypeBase::computeCanonicalType() {
   return CanonicalType = CanType(Result);
 }
 
-CanType TypeBase::getCanonicalType(GenericSignature sig) {
-  return sig.getCanonicalTypeInContext(this);
+CanType TypeBase::getReducedType(GenericSignature sig) {
+  return sig.getReducedType(this);
 }
 
 CanType TypeBase::getMinimalCanonicalType(const DeclContext *useDC) const {
@@ -2555,9 +2555,9 @@ public:
 
         for (unsigned i : indices(origSubs.getReplacementTypes())) {
           auto origType =
-            origSubs.getReplacementTypes()[i]->getCanonicalType(sig);
+            origSubs.getReplacementTypes()[i]->getReducedType(sig);
           auto substType =
-            substSubs.getReplacementTypes()[i]->getCanonicalType(sig);
+            substSubs.getReplacementTypes()[i]->getReducedType(sig);
 
           auto newType = visit(origType, substType, nullptr, {});
 
@@ -2585,9 +2585,9 @@ public:
         
         for (unsigned i : indices(origSubs.getReplacementTypes())) {
           auto origType =
-            origSubs.getReplacementTypes()[i]->getCanonicalType(sig);
+            origSubs.getReplacementTypes()[i]->getReducedType(sig);
           auto substType =
-            substSubs.getReplacementTypes()[i]->getCanonicalType(sig);
+            substSubs.getReplacementTypes()[i]->getReducedType(sig);
           
           auto newType = visit(origType, substType, nullptr, {});
           
@@ -3570,7 +3570,7 @@ SequenceArchetypeType::SequenceArchetypeType(
 CanType OpaqueTypeArchetypeType::getCanonicalInterfaceType(Type interfaceType) {
   auto sig = Environment->getOpaqueTypeDecl()
       ->getOpaqueInterfaceGenericSignature();
-  CanType canonicalType = interfaceType->getCanonicalType(sig);
+  CanType canonicalType = interfaceType->getReducedType(sig);
   return Environment->maybeApplyOpaqueTypeSubstitutions(canonicalType)
       ->getCanonicalType();
 }
@@ -4001,7 +4001,7 @@ Type ArchetypeType::getNestedTypeByName(Identifier name) {
   Type interfaceType = getInterfaceType();
   Type memberInterfaceType = DependentMemberType::get(interfaceType, name);
   auto genericSig = getGenericEnvironment()->getGenericSignature();
-  if (genericSig->isValidTypeInContext(memberInterfaceType)) {
+  if (genericSig->isValidTypeParameter(memberInterfaceType)) {
     return getGenericEnvironment()->getOrCreateArchetypeFromInterfaceType(
         memberInterfaceType);
   }

--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -437,7 +437,7 @@ withOpaqueTypeGenericArgs(IRGenFunction &IGF,
         opaqueDecl->getGenericSignature().getCanonicalSignature(),
         [&](GenericRequirement reqt) {
           auto ty = reqt.TypeParameter.subst(archetype->getSubstitutions())
-                        ->getCanonicalType(opaqueDecl->getGenericSignature());
+                        ->getReducedType(opaqueDecl->getGenericSignature());
           if (reqt.Protocol) {
             auto ref =
                 ProtocolConformanceRef(reqt.Protocol)

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -1402,7 +1402,7 @@ void IRGenModule::emitSILProperty(SILProperty *prop) {
                        prop->getDecl()->getInnermostDeclContext()
                                       ->getInnermostTypeContext()
                                       ->getSelfInterfaceType()
-                                      ->getCanonicalType(genericSig),
+                                      ->getReducedType(genericSig),
                        {},
                        hasSubscriptIndices);
   

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -2189,7 +2189,7 @@ namespace {
 
         auto *genericParam = O->getOpaqueGenericParams()[opaqueParamIdx];
         auto underlyingType =
-            Type(genericParam).subst(*unique)->getCanonicalType(sig);
+            Type(genericParam).subst(*unique)->getReducedType(sig);
         return IGM
             .getTypeRef(underlyingType, contextSig,
                         MangledTypeRefRole::Metadata)
@@ -2450,7 +2450,7 @@ namespace {
         auto type =
             Type(O->getOpaqueGenericParams()[OpaqueParamIndex])
                 .subst(substitutions)
-                ->getCanonicalType(O->getOpaqueInterfaceGenericSignature());
+                ->getReducedType(O->getOpaqueInterfaceGenericSignature());
 
         type = genericEnv
                    ? genericEnv->mapTypeIntoContext(type)->getCanonicalType()

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -3310,7 +3310,7 @@ GenericTypeRequirements::GenericTypeRequirements(IRGenModule &IGM,
   // Figure out what we're actually still required to pass 
   PolymorphicConvention convention(IGM, fnType);
   convention.enumerateUnfulfilledRequirements([&](GenericRequirement reqt) {
-    assert(generics->isCanonicalTypeInContext(reqt.TypeParameter));
+    assert(generics->isReducedType(reqt.TypeParameter));
     Requirements.push_back(reqt);
   });
 

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -357,7 +357,7 @@ IRGenModule::getTypeRef(CanType type, CanGenericSignature sig,
 std::pair<llvm::Constant *, unsigned>
 IRGenModule::getTypeRef(Type type, GenericSignature genericSig,
                         MangledTypeRefRole role) {
-  return getTypeRef(type->getCanonicalType(genericSig),
+  return getTypeRef(type->getReducedType(genericSig),
                     genericSig.getCanonicalSignature(), role);
 }
 
@@ -554,7 +554,7 @@ protected:
   void addTypeRef(Type type, GenericSignature genericSig,
                   MangledTypeRefRole role =
                       MangledTypeRefRole::Reflection) {
-    addTypeRef(type->getCanonicalType(genericSig),
+    addTypeRef(type->getReducedType(genericSig),
                genericSig.getCanonicalSignature(), role);
   }
 

--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -50,7 +50,7 @@ TypeConverter::getAbstractionPattern(AbstractStorageDecl *decl,
 AbstractionPattern
 TypeConverter::getAbstractionPattern(SubscriptDecl *decl, bool isNonObjC) {
   auto sig = decl->getGenericSignatureOfContext().getCanonicalSignature();
-  auto type = sig.getCanonicalTypeInContext(decl->getElementInterfaceType());
+  auto type = sig.getReducedType(decl->getElementInterfaceType());
   return AbstractionPattern(sig, type);
 }
 
@@ -79,7 +79,7 @@ TypeConverter::getAbstractionPattern(VarDecl *var, bool isNonObjC) {
   auto sig = var->getDeclContext()
                  ->getGenericSignatureOfContext()
                  .getCanonicalSignature();
-  auto swiftType = sig.getCanonicalTypeInContext(var->getInterfaceType());
+  auto swiftType = sig.getReducedType(var->getInterfaceType());
 
   if (isNonObjC)
     return AbstractionPattern(sig, swiftType);
@@ -111,7 +111,7 @@ AbstractionPattern TypeConverter::getAbstractionPattern(EnumElementDecl *decl) {
   auto sig = decl->getParentEnum()
                  ->getGenericSignatureOfContext()
                  .getCanonicalSignature();
-  auto type = sig.getCanonicalTypeInContext(decl->getArgumentInterfaceType());
+  auto type = sig.getReducedType(decl->getArgumentInterfaceType());
 
   return AbstractionPattern(sig, type);
 }
@@ -1231,7 +1231,7 @@ const {
   case Kind::Discard:
     auto memberTy = getType()->getTypeOfMember(member->getModuleContext(),
                                       member, origMemberInterfaceType)
-                             ->getCanonicalType(getGenericSignature());
+                             ->getReducedType(getGenericSignature());
       
     return AbstractionPattern(getGenericSignature(), memberTy);
   }
@@ -1253,7 +1253,7 @@ AbstractionPattern AbstractionPattern::getAutoDiffDerivativeFunctionType(
     assert(derivativeFnTy);
     return AbstractionPattern(
         getGenericSignature(),
-        derivativeFnTy->getCanonicalType(getGenericSignature()));
+        derivativeFnTy->getReducedType(getGenericSignature()));
   }
   case Kind::Opaque:
     return getOpaqueDerivativeFunction();
@@ -1882,10 +1882,10 @@ const {
 
   auto yieldType = visitor.substYieldType;
   if (yieldType)
-    yieldType = yieldType->getCanonicalType(substSig);
+    yieldType = yieldType->getReducedType(substSig);
   
   return std::make_tuple(
-          AbstractionPattern(substSig, substTy->getCanonicalType(substSig)),
+          AbstractionPattern(substSig, substTy->getReducedType(substSig)),
           subMap,
           yieldType
             ? AbstractionPattern(substSig, yieldType)

--- a/lib/SIL/IR/SIL.cpp
+++ b/lib/SIL/IR/SIL.cpp
@@ -353,7 +353,7 @@ bool AbstractStorageDecl::exportsPropertyDescriptor() const {
         return false;
       
       auto indexTy = index->getInterfaceType()
-                        ->getCanonicalType(sub->getGenericSignatureOfContext());
+                        ->getReducedType(sub->getGenericSignatureOfContext());
       
       // TODO: Handle reabstraction and tuple explosion in thunk generation.
       // This wasn't previously a concern because anything that was Hashable

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -485,7 +485,7 @@ static CanSILFunctionType getAutoDiffDifferentialType(
     auto sig = buildDifferentiableGenericSignature(
       originalFnTy->getSubstGenericSignature(), tanType, origTypeOfAbstraction);
 
-    tanType = tanType->getCanonicalType(sig);
+    tanType = tanType->getReducedType(sig);
     AbstractionPattern pattern(sig, tanType);
     auto &tl =
         TC.getTypeLowering(pattern, tanType, TypeExpansionContext::minimal());
@@ -513,7 +513,7 @@ static CanSILFunctionType getAutoDiffDifferentialType(
     auto sig = buildDifferentiableGenericSignature(
       originalFnTy->getSubstGenericSignature(), tanType, origTypeOfAbstraction);
 
-    tanType = tanType->getCanonicalType(sig);
+    tanType = tanType->getReducedType(sig);
     AbstractionPattern pattern(sig, tanType);
     auto &tl =
         TC.getTypeLowering(pattern, tanType, TypeExpansionContext::minimal());
@@ -633,7 +633,7 @@ static CanSILFunctionType getAutoDiffPullbackType(
     auto sig = buildDifferentiableGenericSignature(
       originalFnTy->getSubstGenericSignature(), tanType, origTypeOfAbstraction);
 
-    tanType = tanType->getCanonicalType(sig);
+    tanType = tanType->getReducedType(sig);
     AbstractionPattern pattern(sig, tanType);
     auto &tl =
         TC.getTypeLowering(pattern, tanType, TypeExpansionContext::minimal());
@@ -664,7 +664,7 @@ static CanSILFunctionType getAutoDiffPullbackType(
     auto sig = buildDifferentiableGenericSignature(
       originalFnTy->getSubstGenericSignature(), tanType, origTypeOfAbstraction);
 
-    tanType = tanType->getCanonicalType(sig);
+    tanType = tanType->getReducedType(sig);
     AbstractionPattern pattern(sig, tanType);
     auto &tl =
         TC.getTypeLowering(pattern, tanType, TypeExpansionContext::minimal());
@@ -801,7 +801,7 @@ static SILFunctionType *getConstrainedAutoDiffOriginalFunctionType(
   newParameters.reserve(original->getNumParameters());
   for (auto &param : original->getParameters()) {
     newParameters.push_back(
-        param.getWithInterfaceType(param.getInterfaceType()->getCanonicalType(
+        param.getWithInterfaceType(param.getInterfaceType()->getReducedType(
             constrainedInvocationGenSig)));
   }
 
@@ -809,7 +809,7 @@ static SILFunctionType *getConstrainedAutoDiffOriginalFunctionType(
   newResults.reserve(original->getNumResults());
   for (auto &result : original->getResults()) {
     newResults.push_back(
-        result.getWithInterfaceType(result.getInterfaceType()->getCanonicalType(
+        result.getWithInterfaceType(result.getInterfaceType()->getReducedType(
             constrainedInvocationGenSig)));
   }
   return SILFunctionType::get(
@@ -1680,7 +1680,7 @@ lowerCaptureContextParameters(TypeConverter &TC, SILDeclRef function,
       auto selfMetatype = MetatypeType::get(dynamicSelfInterfaceType,
                                             MetatypeRepresentation::Thick);
 
-      auto canSelfMetatype = selfMetatype->getCanonicalType(origGenericSig);
+      auto canSelfMetatype = selfMetatype->getReducedType(origGenericSig);
       SILParameterInfo param(canSelfMetatype, convention);
       inputs.push_back(param);
 
@@ -1690,7 +1690,7 @@ lowerCaptureContextParameters(TypeConverter &TC, SILDeclRef function,
     if (capture.isOpaqueValue()) {
       OpaqueValueExpr *opaqueValue = capture.getOpaqueValue();
       auto canType = opaqueValue->getType()->mapTypeOutOfContext()
-          ->getCanonicalType(origGenericSig);
+          ->getReducedType(origGenericSig);
       auto &loweredTL =
           TC.getTypeLowering(AbstractionPattern(genericSig, canType),
                              canType, expansion);
@@ -1710,7 +1710,7 @@ lowerCaptureContextParameters(TypeConverter &TC, SILDeclRef function,
 
     auto *VD = capture.getDecl();
     auto type = VD->getInterfaceType();
-    auto canType = type->getCanonicalType(origGenericSig);
+    auto canType = type->getReducedType(origGenericSig);
 
     auto &loweredTL =
         TC.getTypeLowering(AbstractionPattern(genericSig, canType), canType,
@@ -1962,7 +1962,7 @@ static CanSILFunctionType getSILFunctionType(
       valueType = valueType.subst(*reqtSubs);
     }
 
-    coroutineSubstYieldType = valueType->getCanonicalType(genericSig);
+    coroutineSubstYieldType = valueType->getReducedType(genericSig);
   }
 
   bool shouldBuildSubstFunctionType = [&]{
@@ -2645,7 +2645,7 @@ CanSILFunctionType swift::buildSILFunctionThunkType(
   }
 
   auto mapTypeOutOfContext = [&](CanType type) -> CanType {
-    return type->mapTypeOutOfContext()->getCanonicalType(genericSig);
+    return type->mapTypeOutOfContext()->getCanonicalType();
   };
 
   // Map the parameter and expected types out of context to get the interface

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2055,7 +2055,7 @@ namespace {
         // would, we use the substituted field type in order to accurately
         // preserve the properties of the aggregate.
         auto sig = field->getDeclContext()->getGenericSignatureOfContext();
-        auto interfaceTy = field->getInterfaceType()->getCanonicalType(sig);
+        auto interfaceTy = field->getInterfaceType()->getReducedType(sig);
         auto origFieldType = origType.unsafeGetSubstFieldType(field,
                                                               interfaceTy);
         
@@ -2116,7 +2116,7 @@ namespace {
         
         auto origEltType = origType.unsafeGetSubstFieldType(elt,
                               elt->getArgumentInterfaceType()
-                                 ->getCanonicalType(D->getGenericSignature()));
+                                 ->getReducedType(D->getGenericSignature()));
         properties.addSubobject(classifyType(origEltType, substEltType,
                                              TC, Expansion));
       }
@@ -2734,7 +2734,7 @@ static CanAnyFunctionType getDefaultArgGeneratorInterfaceType(
 
   // The result type might be written in terms of type parameters
   // that have been made fully concrete.
-  CanType canResultTy = resultTy->getCanonicalType(
+  CanType canResultTy = resultTy->getReducedType(
                             vd->getInnermostDeclContext()
                               ->getGenericSignatureOfContext());
 
@@ -2812,7 +2812,7 @@ static CanAnyFunctionType getDestructorInterfaceType(DestructorDecl *dd,
                                                      bool isDeallocating,
                                                      bool isForeign) {
   auto classType = dd->getDeclContext()->getDeclaredInterfaceType()
-    ->getCanonicalType(dd->getGenericSignatureOfContext());
+    ->getReducedType(dd->getGenericSignatureOfContext());
 
   assert((!isForeign || isDeallocating)
          && "There are no foreign destroying destructors");
@@ -2848,7 +2848,7 @@ static CanAnyFunctionType getIVarInitDestroyerInterfaceType(ClassDecl *cd,
                                                             bool isObjC,
                                                             bool isDestroyer) {
   auto classType = cd->getDeclaredInterfaceType()
-    ->getCanonicalType(cd->getGenericSignatureOfContext());
+    ->getReducedType(cd->getGenericSignatureOfContext());
 
   auto resultType = (isDestroyer
                      ? TupleType::getEmpty(cd->getASTContext())
@@ -3778,12 +3778,7 @@ TypeConverter::getInterfaceBoxTypeForCapture(ValueDecl *captured,
                                /*captures generics*/ false);
   
   // Instantiate the layout with identity substitutions.
-  auto subMap = SubstitutionMap::get(
-      signature,
-      [&](SubstitutableType *type) -> Type {
-        return signature.getCanonicalTypeInContext(type);
-      },
-      MakeAbstractConformanceForGenericType());
+  auto subMap = signature->getIdentitySubstitutionMap();
 
   auto boxTy = SILBoxType::get(C, layout, subMap);
 #ifndef NDEBUG
@@ -3817,7 +3812,7 @@ TypeConverter::getContextBoxTypeForCapture(ValueDecl *captured,
         ->getGenericSignatureOfContext();
     loweredInterfaceType =
       loweredInterfaceType->mapTypeOutOfContext()
-        ->getCanonicalType(homeSig);
+        ->getReducedType(homeSig);
   }
   
   auto boxType = getInterfaceBoxTypeForCapture(captured,

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -5945,8 +5945,8 @@ void SILProperty::verify(const SILModule &M) const {
   // TODO: base type for global/static descriptors
   auto sig = dc->getGenericSignatureOfContext();
   auto baseTy = dc->getInnermostTypeContext()->getSelfInterfaceType()
-                  ->getCanonicalType(sig);
-  auto leafTy = decl->getValueInterfaceType()->getCanonicalType(sig);
+                  ->getReducedType(sig);
+  auto leafTy = decl->getValueInterfaceType()->getReducedType(sig);
   SubstitutionMap subs;
   if (sig) {
     auto env = dc->getGenericEnvironmentOfContext();

--- a/lib/SILGen/ResultPlan.cpp
+++ b/lib/SILGen/ResultPlan.cpp
@@ -179,7 +179,7 @@ public:
         layoutSubs.getGenericSignature().getCanonicalSignature();
     auto boxLayout =
         SILLayout::get(SGF.getASTContext(), layoutSig,
-                       SILField(layoutTy->getCanonicalType(layoutSig), true),
+                       SILField(layoutTy->getReducedType(layoutSig), true),
                        /*captures generics*/ false);
 
     resultBox = SGF.B.createAllocBox(loc,
@@ -576,8 +576,8 @@ public:
     SILFunction *impl =
         SGF.SGM.getOrCreateForeignAsyncCompletionHandlerImplFunction(
             cast<SILFunctionType>(
-                impFnTy->mapTypeOutOfContext()->getCanonicalType(sig)),
-            continuationTy->mapTypeOutOfContext()->getCanonicalType(sig),
+                impFnTy->mapTypeOutOfContext()->getReducedType(sig)),
+            continuationTy->mapTypeOutOfContext()->getReducedType(sig),
             origFormalType, sig, *calleeTypeInfo.foreign.async,
             calleeTypeInfo.foreign.error);
     auto impRef = SGF.B.createFunctionRef(loc, impl);
@@ -660,7 +660,7 @@ public:
         auto sig = env ? env->getGenericSignature().getCanonicalSignature()
                        : CanGenericSignature();
         auto mappedContinuationTy =
-            continuationBGT->mapTypeOutOfContext()->getCanonicalType(sig);
+            continuationBGT->mapTypeOutOfContext()->getReducedType(sig);
         auto resumeType =
             cast<BoundGenericType>(mappedContinuationTy).getGenericArgs()[0];
         auto continuationTy = continuationBGT->getCanonicalType();

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1902,8 +1902,8 @@ void SILGenModule::tryEmitPropertyDescriptor(AbstractStorageDecl *decl) {
     assert(!decl->isStatic());
     
     baseTy = decl->getDeclContext()->getSelfInterfaceType()
-                 ->getCanonicalType(decl->getInnermostDeclContext()
-                                        ->getGenericSignatureOfContext());
+                 ->getReducedType(decl->getInnermostDeclContext()
+                                      ->getGenericSignatureOfContext());
   } else {
     // TODO: Global variables should eventually be referenceable as
     // key paths from (), viz. baseTy = TupleType::getEmpty(getASTContext());

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -6164,7 +6164,7 @@ ManagedValue SILGenFunction::emitReadAsyncLetBinding(SILLocation loc,
   
   // Load and reabstract the value if needed.
   auto genericSig = F.getLoweredFunctionType()->getInvocationGenericSignature();
-  auto substVarTy = var->getType()->getCanonicalType(genericSig);
+  auto substVarTy = var->getType()->getReducedType(genericSig);
   auto substAbstraction = AbstractionPattern(genericSig, substVarTy);
   return emitLoad(loc, visitor.varAddr, substAbstraction, substVarTy,
                   getTypeLowering(substAbstraction, substVarTy),

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3264,7 +3264,7 @@ getOrCreateKeyPathEqualsAndHash(SILGenModule &SGM,
         = GenericEnvironment::mapConformanceRefIntoContext(genericEnv,
                                                            formalTy,
                                                            hashable);
-      auto formalCanTy = formalTy->getCanonicalType(genericSig);
+      auto formalCanTy = formalTy->getReducedType(genericSig);
       
       // Get the Equatable conformance from the Hashable conformance.
       auto equatable = hashable.getAssociatedConformance(
@@ -3690,8 +3690,7 @@ SILGenModule::emitKeyPathComponentForDecl(SILLocation loc,
           ->getTypeOfMember(SwiftModule, var)
           ->getReferenceStorageReferent()
           ->mapTypeOutOfContext()
-          ->getCanonicalType(
-                      genericEnv ? genericEnv->getGenericSignature() : nullptr);
+          ->getCanonicalType();
 
       // The component type for an @objc optional requirement needs to be
       // wrapped in an optional.

--- a/lib/SILGen/SILGenLazyConformance.cpp
+++ b/lib/SILGen/SILGenLazyConformance.cpp
@@ -334,7 +334,7 @@ void SILGenModule::emitLazyConformancesForType(NominalTypeDecl *NTD) {
     for (auto *EED : ED->getAllElements()) {
       if (EED->hasAssociatedValues()) {
         useConformancesFromType(EED->getArgumentInterfaceType()
-                                   ->getCanonicalType(genericSig));
+                                   ->getReducedType(genericSig));
       }
     }
   }
@@ -342,13 +342,13 @@ void SILGenModule::emitLazyConformancesForType(NominalTypeDecl *NTD) {
   if (isa<StructDecl>(NTD) || isa<ClassDecl>(NTD)) {
     for (auto *VD : NTD->getStoredProperties()) {
       useConformancesFromType(VD->getValueInterfaceType()
-                                ->getCanonicalType(genericSig));
+                                ->getReducedType(genericSig));
     }
   }
 
   if (auto *CD = dyn_cast<ClassDecl>(NTD))
     if (auto superclass = CD->getSuperclass())
-      useConformancesFromType(superclass->getCanonicalType(genericSig));
+      useConformancesFromType(superclass->getReducedType(genericSig));
 
   if (auto *PD = dyn_cast<ProtocolDecl>(NTD)) {
     for (auto reqt : PD->getRequirementSignature().getRequirements()) {

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -458,7 +458,7 @@ static void emitCaptureArguments(SILGenFunction &SGF,
   // Local function to get the captured variable type within the capturing
   // context.
   auto getVarTypeInCaptureContext = [&]() -> Type {
-    auto interfaceType = VD->getInterfaceType()->getCanonicalType(
+    auto interfaceType = VD->getInterfaceType()->getReducedType(
         origGenericSig);
     return SGF.F.mapTypeIntoContext(interfaceType);
   };
@@ -1014,7 +1014,7 @@ uint16_t SILGenFunction::emitBasicProlog(ParameterList *paramList,
                                  Optional<AbstractionPattern> origClosureType) {
   // Create the indirect result parameters.
   auto genericSig = DC->getGenericSignatureOfContext();
-  resultType = resultType->getCanonicalType(genericSig);
+  resultType = resultType->getReducedType(genericSig);
 
   AbstractionPattern origResultType = origClosureType
     ? origClosureType->getFunctionResultType()

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -732,7 +732,7 @@ SILFunction *SILGenModule::emitProtocolWitness(
   // The type of the witness thunk.
   auto reqtSubstTy = cast<AnyFunctionType>(
     reqtOrigTy->substGenericArgs(reqtSubMap)
-      ->getCanonicalType(genericSig));
+      ->getReducedType(genericSig));
 
   // Generic signatures where all parameters are concrete are lowered away
   // at the SILFunctionType level.

--- a/lib/SILOptimizer/Differentiation/JVPCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/JVPCloner.cpp
@@ -145,7 +145,7 @@ private:
   SILType getLoweredType(Type type) {
     auto jvpGenSig = jvp->getLoweredFunctionType()->getSubstGenericSignature();
     Lowering::AbstractionPattern pattern(jvpGenSig,
-                                         type->getCanonicalType(jvpGenSig));
+                                         type->getReducedType(jvpGenSig));
     return jvp->getLoweredType(pattern, type);
   }
 
@@ -352,7 +352,7 @@ private:
   /// Find the tangent space of a given canonical type.
   Optional<TangentSpace> getTangentSpace(CanType type) {
     // Use witness generic signature to remap types.
-    type = witness->getDerivativeGenericSignature().getCanonicalTypeInContext(
+    type = witness->getDerivativeGenericSignature().getReducedType(
         type);
     return type->getAutoDiffTangentSpace(
         LookUpConformanceInModule(getModule().getSwiftModule()));
@@ -1627,12 +1627,12 @@ void JVPCloner::Implementation::prepareForDifferentialGeneration() {
       // Handle formal original result.
       auto origResult = origTy->getResults()[resultIndex];
       origResult = origResult.getWithInterfaceType(
-          origResult.getInterfaceType()->getCanonicalType(witnessCanGenSig));
+          origResult.getInterfaceType()->getReducedType(witnessCanGenSig));
       dfResults.push_back(
           SILResultInfo(origResult.getInterfaceType()
                             ->getAutoDiffTangentSpace(lookupConformance)
                             ->getType()
-                            ->getCanonicalType(witnessCanGenSig),
+                            ->getReducedType(witnessCanGenSig),
                         origResult.getConvention()));
     } else {
       // Handle original `inout` parameter.
@@ -1659,12 +1659,12 @@ void JVPCloner::Implementation::prepareForDifferentialGeneration() {
   for (auto i : config.parameterIndices->getIndices()) {
     auto origParam = origParams[i];
     origParam = origParam.getWithInterfaceType(
-        origParam.getInterfaceType()->getCanonicalType(witnessCanGenSig));
+        origParam.getInterfaceType()->getReducedType(witnessCanGenSig));
     dfParams.push_back(
         SILParameterInfo(origParam.getInterfaceType()
                              ->getAutoDiffTangentSpace(lookupConformance)
                              ->getType()
-                             ->getCanonicalType(witnessCanGenSig),
+                             ->getReducedType(witnessCanGenSig),
                          origParam.getConvention()));
   }
 
@@ -1673,7 +1673,7 @@ void JVPCloner::Implementation::prepareForDifferentialGeneration() {
   auto *origEntry = original->getEntryBlock();
   auto *dfStruct = linearMapInfo->getLinearMapStruct(origEntry);
   auto dfStructType =
-      dfStruct->getDeclaredInterfaceType()->getCanonicalType(witnessCanGenSig);
+      dfStruct->getDeclaredInterfaceType()->getReducedType(witnessCanGenSig);
   dfParams.push_back({dfStructType, ParameterConvention::Direct_Owned});
 
   Mangle::DifferentiationMangler mangler;

--- a/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
@@ -194,7 +194,7 @@ private:
     auto pbGenSig =
         getPullback().getLoweredFunctionType()->getSubstGenericSignature();
     Lowering::AbstractionPattern pattern(pbGenSig,
-                                         type->getCanonicalType(pbGenSig));
+                                         type->getReducedType(pbGenSig));
     return getPullback().getTypeLowering(pattern, type);
   }
 
@@ -202,7 +202,7 @@ private:
   SILType remapType(SILType ty) {
     if (ty.hasArchetype())
       ty = ty.mapTypeOutOfContext();
-    auto remappedType = ty.getASTType()->getCanonicalType(
+    auto remappedType = ty.getASTType()->getReducedType(
         getPullback().getLoweredFunctionType()->getSubstGenericSignature());
     auto remappedSILType =
         SILType::getPrimitiveType(remappedType, ty.getCategory());
@@ -212,7 +212,7 @@ private:
   Optional<TangentSpace> getTangentSpace(CanType type) {
     // Use witness generic signature to remap types.
     type =
-        getWitness()->getDerivativeGenericSignature().getCanonicalTypeInContext(
+        getWitness()->getDerivativeGenericSignature().getReducedType(
             type);
     return type->getAutoDiffTangentSpace(
         LookUpConformanceInModule(getModule().getSwiftModule()));

--- a/lib/SILOptimizer/Differentiation/VJPCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/VJPCloner.cpp
@@ -137,7 +137,7 @@ class VJPCloner::Implementation final
   SILType getLoweredType(Type type) {
     auto vjpGenSig = vjp->getLoweredFunctionType()->getSubstGenericSignature();
     Lowering::AbstractionPattern pattern(vjpGenSig,
-                                         type->getCanonicalType(vjpGenSig));
+                                         type->getReducedType(vjpGenSig));
     return vjp->getLoweredType(pattern, type);
   }
 
@@ -809,7 +809,7 @@ SILFunction *VJPCloner::Implementation::createEmptyPullback() {
   // Given a type, returns its formal SIL parameter info.
   auto getTangentParameterInfoForOriginalResult =
       [&](CanType tanType, ResultConvention origResConv) -> SILParameterInfo {
-    tanType = tanType->getCanonicalType(witnessCanGenSig);
+    tanType = tanType->getReducedType(witnessCanGenSig);
     Lowering::AbstractionPattern pattern(witnessCanGenSig, tanType);
     auto &tl = context.getTypeConverter().getTypeLowering(
         pattern, tanType, TypeExpansionContext::minimal());
@@ -836,7 +836,7 @@ SILFunction *VJPCloner::Implementation::createEmptyPullback() {
   // Given a type, returns its formal SIL result info.
   auto getTangentResultInfoForOriginalParameter =
       [&](CanType tanType, ParameterConvention origParamConv) -> SILResultInfo {
-    tanType = tanType->getCanonicalType(witnessCanGenSig);
+    tanType = tanType->getReducedType(witnessCanGenSig);
     Lowering::AbstractionPattern pattern(witnessCanGenSig, tanType);
     auto &tl = context.getTypeConverter().getTypeLowering(
         pattern, tanType, TypeExpansionContext::minimal());
@@ -886,12 +886,12 @@ SILFunction *VJPCloner::Implementation::createEmptyPullback() {
     if (resultIndex < origTy->getNumResults()) {
       auto origResult = origTy->getResults()[resultIndex];
       origResult = origResult.getWithInterfaceType(
-          origResult.getInterfaceType()->getCanonicalType(witnessCanGenSig));
+          origResult.getInterfaceType()->getReducedType(witnessCanGenSig));
       pbParams.push_back(getTangentParameterInfoForOriginalResult(
           origResult.getInterfaceType()
               ->getAutoDiffTangentSpace(lookupConformance)
               ->getType()
-              ->getCanonicalType(witnessCanGenSig),
+              ->getReducedType(witnessCanGenSig),
           origResult.getConvention()));
       continue;
     }
@@ -911,7 +911,7 @@ SILFunction *VJPCloner::Implementation::createEmptyPullback() {
     }
     auto inoutParam = origParams[paramIndex];
     auto origResult = inoutParam.getWithInterfaceType(
-        inoutParam.getInterfaceType()->getCanonicalType(witnessCanGenSig));
+        inoutParam.getInterfaceType()->getReducedType(witnessCanGenSig));
     auto inoutParamTanConvention =
         config.isWrtParameter(paramIndex)
             ? inoutParam.getConvention()
@@ -920,7 +920,7 @@ SILFunction *VJPCloner::Implementation::createEmptyPullback() {
         origResult.getInterfaceType()
             ->getAutoDiffTangentSpace(lookupConformance)
             ->getType()
-            ->getCanonicalType(witnessCanGenSig),
+            ->getReducedType(witnessCanGenSig),
         inoutParamTanConvention);
     pbParams.push_back(inoutParamTanParam);
   }
@@ -937,7 +937,7 @@ SILFunction *VJPCloner::Implementation::createEmptyPullback() {
     auto *origExit = &*original->findReturnBB();
     auto *pbStruct = pullbackInfo.getLinearMapStruct(origExit);
     auto pbStructType =
-    pbStruct->getDeclaredInterfaceType()->getCanonicalType(witnessCanGenSig);
+    pbStruct->getDeclaredInterfaceType()->getReducedType(witnessCanGenSig);
     pbParams.push_back({pbStructType, ParameterConvention::Direct_Owned});
   }
 
@@ -947,12 +947,12 @@ SILFunction *VJPCloner::Implementation::createEmptyPullback() {
     if (origParam.isIndirectMutating())
       continue;
     origParam = origParam.getWithInterfaceType(
-        origParam.getInterfaceType()->getCanonicalType(witnessCanGenSig));
+        origParam.getInterfaceType()->getReducedType(witnessCanGenSig));
     adjResults.push_back(getTangentResultInfoForOriginalParameter(
         origParam.getInterfaceType()
             ->getAutoDiffTangentSpace(lookupConformance)
             ->getType()
-            ->getCanonicalType(witnessCanGenSig),
+            ->getReducedType(witnessCanGenSig),
         origParam.getConvention()));
   }
 

--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
@@ -345,11 +345,6 @@ ExistentialTransform::createExistentialSpecializedFunctionType() {
                                         std::move(GenericParams),
                                         std::move(Requirements));
 
-  /// Create a lambda for GenericParams.
-  auto getCanonicalType = [&](Type t) -> CanType {
-    return t->getCanonicalType(NewGenericSig);
-  };
-
   /// Original list of parameters
   SmallVector<SILParameterInfo, 4> params;
   params.append(FTy->getParameters().begin(), FTy->getParameters().end());
@@ -362,7 +357,7 @@ ExistentialTransform::createExistentialSpecializedFunctionType() {
     auto iter = ArgToGenericTypeMap.find(Idx);
     if (iter != ArgToGenericTypeMap.end()) {
       auto GenericParam = iter->second;
-      InterfaceParams.push_back(SILParameterInfo(getCanonicalType(GenericParam),
+      InterfaceParams.push_back(SILParameterInfo(GenericParam->getReducedType(NewGenericSig),
                                                  param.getConvention()));
     } else {
       InterfaceParams.push_back(param);

--- a/lib/SILOptimizer/SILCombiner/SILCombinerCastVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerCastVisitors.cpp
@@ -291,7 +291,8 @@ SILCombiner::optimizeAlignment(PointerToAddressInst *ptrAdrInst) {
   if (match(alignOper,
             m_ApplyInst(BuiltinValueKind::Alignof))) {
     CanType formalType = cast<BuiltinInst>(alignOper)->getSubstitutions()
-      .getReplacementTypes()[0]->getCanonicalType(ptrAdrInst->getFunction()->getGenericSignature());
+      .getReplacementTypes()[0]->getReducedType(
+          ptrAdrInst->getFunction()->getGenericSignature());
 
     SILType instanceType = ptrAdrInst->getFunction()->getLoweredType(
       Lowering::AbstractionPattern::getOpaque(), formalType);

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -812,7 +812,7 @@ ReabstractionInfo::createSubstitutedType(SILFunction *OrigF,
 
   // First substitute concrete types into the existing function type.
   CanSILFunctionType FnTy =
-      cast<SILFunctionType>(CanSpecializedGenericSig.getCanonicalTypeInContext(
+      cast<SILFunctionType>(CanSpecializedGenericSig.getReducedType(
           OrigF->getLoweredFunctionType()
               ->substGenericArgs(M, SubstMap, getResilienceExpansion())
               ->getUnsubstitutedType(M)));
@@ -1449,7 +1449,7 @@ void FunctionSignaturePartialSpecializer::
     createGenericParamsForCalleeGenericParams() {
   for (auto GP : CalleeGenericSig.getGenericParams()) {
     auto CanTy = GP->getCanonicalType();
-    auto CanTyInContext = CalleeGenericSig.getCanonicalTypeInContext(CanTy);
+    auto CanTyInContext = CalleeGenericSig.getReducedType(CanTy);
     auto Replacement = CanTyInContext.subst(CalleeInterfaceToCallerArchetypeMap);
     LLVM_DEBUG(llvm::dbgs() << "\n\nChecking callee generic parameter:\n";
                CanTy->dump(llvm::dbgs()));

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1988,7 +1988,7 @@ typeEraseExistentialSelfReferences(
 
       // If the type parameter is beyond the domain of the existential generic
       // signature, ignore it.
-      if (!existentialSig->isValidTypeInContext(t)) {
+      if (!existentialSig->isValidTypeParameter(t)) {
         return Type(t);
       }
 
@@ -6540,7 +6540,7 @@ static bool doesMemberHaveUnfulfillableConstraintsWithExistentialBase(
         return Action::SkipChildren;
       }
 
-      if (!Sig->isValidTypeInContext(ty)) {
+      if (!Sig->isValidTypeParameter(ty)) {
         return Action::SkipChildren;
       }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2517,7 +2517,7 @@ static void checkSpecializeAttrRequirements(SpecializeAttr *attr,
 
   for (auto *paramTy : specializedSig.getGenericParams()) {
     auto canTy = paramTy->getCanonicalType();
-    if (specializedSig->isCanonicalTypeInContext(canTy) &&
+    if (specializedSig->isReducedType(canTy) &&
         (!specializedSig->getLayoutConstraint(canTy) ||
          originalSig->getLayoutConstraint(canTy))) {
       unspecializedParams.push_back(paramTy);
@@ -4547,7 +4547,7 @@ static bool checkFunctionSignature(
                     auto xInstanceTy = x.getOldType()->getMetatypeInstanceType();
                     auto yInstanceTy = y.getOldType()->getMetatypeInstanceType();
                     return xInstanceTy->isEqual(
-                        requiredGenSig.getCanonicalTypeInContext(yInstanceTy));
+                        requiredGenSig.getReducedType(yInstanceTy));
                   }))
     return false;
 
@@ -4555,7 +4555,7 @@ static bool checkFunctionSignature(
   // match exactly.
   auto requiredResultFnTy = dyn_cast<AnyFunctionType>(required.getResult());
   auto candidateResultTy =
-      requiredGenSig.getCanonicalTypeInContext(candidateFnTy.getResult());
+      requiredGenSig.getReducedType(candidateFnTy.getResult());
   if (!requiredResultFnTy) {
     auto requiredResultTupleTy = dyn_cast<TupleType>(required.getResult());
     auto candidateResultTupleTy = dyn_cast<TupleType>(candidateResultTy);

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -151,7 +151,7 @@ bool swift::isOverrideBasedOnType(const ValueDecl *decl, Type declTy,
   auto genericSig =
       decl->getInnermostDeclContext()->getGenericSignatureOfContext();
 
-  auto canDeclTy = declTy->getCanonicalType(genericSig);
+  auto canDeclTy = declTy->getReducedType(genericSig);
 
   auto declIUOAttr = decl->isImplicitlyUnwrappedOptional();
   auto parentDeclIUOAttr = parentDecl->isImplicitlyUnwrappedOptional();
@@ -198,7 +198,7 @@ bool swift::isOverrideBasedOnType(const ValueDecl *decl, Type declTy,
   if (parentDeclTy->hasError())
     return false;
 
-  auto canParentDeclTy = parentDeclTy->getCanonicalType(genericSig);
+  auto canParentDeclTy = parentDeclTy->getReducedType(genericSig);
 
   // If this is a constructor, let's compare only parameter types.
   if (isa<ConstructorDecl>(decl)) {
@@ -1264,7 +1264,7 @@ bool OverrideMatcher::checkOverride(ValueDecl *baseDecl,
     auto parentPropertyTy = getSuperMemberDeclType(baseDecl);
 
     CanType parentPropertyCanTy =
-      parentPropertyTy->getCanonicalType(
+      parentPropertyTy->getReducedType(
         decl->getInnermostDeclContext()->getGenericSignatureOfContext());
     if (!propertyTy->matches(parentPropertyCanTy,
                              TypeMatchFlags::AllowOverride)) {

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -834,7 +834,7 @@ Type AssociatedTypeInference::computeFixedTypeWitness(
       continue;
 
     auto structuralTy = DependentMemberType::get(selfTy, assocType->getName());
-    const auto ty = sig.getCanonicalTypeInContext(structuralTy);
+    const auto ty = sig.getReducedType(structuralTy);
 
     // A dependent member type with an identical base and name indicates that
     // the protocol does not same-type constrain it in any way; move on to
@@ -1286,7 +1286,7 @@ AssociatedTypeDecl *AssociatedTypeInference::inferAbstractTypeWitnesses(
       std::function<Type(Type)> substCurrentTypeWitnesses;
       substCurrentTypeWitnesses = [&](Type ty) -> Type {
         if (auto *gp = ty->getAs<GenericTypeParamType>()) {
-          // FIXME: 'computeFixedTypeWitness' uses 'getCanonicalTypeInContext',
+          // FIXME: 'computeFixedTypeWitness' uses 'getReducedType',
           // so if a generic parameter is canonical here, it's 'Self'.
           if (gp->isCanonical() ||
               isa<ProtocolDecl>(gp->getDecl()->getDeclContext()->getAsDecl())) {

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -235,10 +235,10 @@ bool TypeResolution::areSameType(Type type1, Type type2) const {
       // If both are type parameters, we can use a cheaper check
       // that avoids transforming the type and computing anchors.
       if (type1->isTypeParameter() && type2->isTypeParameter()) {
-        return genericSig->areSameTypeParameterInContext(type1, type2);
+        return genericSig->areReducedTypeParametersEqual(type1, type2);
       }
-      return genericSig.getCanonicalTypeInContext(type1) ==
-             genericSig.getCanonicalTypeInContext(type2);
+      return genericSig.getReducedType(type1) ==
+             genericSig.getReducedType(type2);
     }
   }
 

--- a/test/Generics/member_type_of_superclass_bound.swift
+++ b/test/Generics/member_type_of_superclass_bound.swift
@@ -6,7 +6,7 @@
 //
 // The latter generic signature does not have a conformance requirement T : P,
 // but the superclass bound C<U> of T conforms to P concretely; make sure that
-// the requirement machine's getCanonicalTypeInContext() can handle this.
+// the requirement machine's getReducedType() can handle this.
 public protocol P {
   associatedtype T
 }


### PR DESCRIPTION
We had two notions of canonical types, one is the structural property
where it doesn't contain sugared types, the other one where it does
not contain reducible type parameters with respect to a generic
signature.

Rename the second one to a 'reduced type'.