### PR TITLE
[Sema] Diagnose 'nonisolated' attribute on wrapped properties

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4788,6 +4788,9 @@ ERROR(nonisolated_local_var,none,
 ERROR(nonisolated_actor_sync_init,none,
       "'nonisolated' on an actor's synchronous initializer is invalid",
       ())
+ERROR(nonisolated_wrapped_property,none,
+      "'nonisolated' is not supported on wrapped properties",
+      ())
 
 ERROR(actor_instance_property_wrapper,none,
       "%0 property in property wrapper type %1 cannot be isolated to "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4789,7 +4789,7 @@ ERROR(nonisolated_actor_sync_init,none,
       "'nonisolated' on an actor's synchronous initializer is invalid",
       ())
 ERROR(nonisolated_wrapped_property,none,
-      "'nonisolated' is not supported on wrapped properties",
+      "'nonisolated' is not supported on properties with property wrappers",
       ())
 
 ERROR(actor_instance_property_wrapper,none,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -6026,11 +6026,9 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
       }
     }
 
-    // We do not support 'nonisolated' on wrapped properties, because
-    // the backing property is a 'var' and so we cannot mark it as
-    // 'nonisolated'. In the future, we could support it by allowing
-    // users to mark the backing property as a 'let' and then it could
-    // also be marked as 'nonisolated'.
+    // Using 'nonisolated' with wrapped properties is unsupported, because
+    // backing storage is a stored 'var' that is part of the internal state
+    // of the actor which could only be accessed in actor's isolation context.
     if (var->hasAttachedPropertyWrapper()) {
       diagnoseAndRemoveAttr(attr, diag::nonisolated_wrapped_property);
       return;

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -6026,6 +6026,16 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
       }
     }
 
+    // We do not support 'nonisolated' on wrapped properties, because
+    // the backing property is a 'var' and so we cannot mark it as
+    // 'nonisolated'. In the future, we could support it by allowing
+    // users to mark the backing property as a 'let' and then it could
+    // also be marked as 'nonisolated'.
+    if (var->hasAttachedPropertyWrapper()) {
+      diagnoseAndRemoveAttr(attr, diag::nonisolated_wrapped_property);
+      return;
+    }
+
     // nonisolated can not be applied to local properties.
     if (dc->isLocalContext()) {
       diagnoseAndRemoveAttr(attr, diag::nonisolated_local_var);

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -466,7 +466,7 @@ struct SimplePropertyWrapper {
 @MainActor
 class WrappedContainsNonisolatedAttr {
   @SimplePropertyWrapper nonisolated var value 
-  // expected-error@-1 {{'nonisolated' is not supported on wrapped properties}}
+  // expected-error@-1 {{'nonisolated' is not supported on properties with property wrappers}}
   // expected-note@-2 2{{property declared here}}
 
   nonisolated func test() {

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -457,6 +457,23 @@ func testInferredFromWrapper(x: InferredFromPropertyWrapper) { // expected-note{
   _ = x.test() // expected-error{{call to global actor 'SomeGlobalActor'-isolated instance method 'test()' in a synchronous nonisolated context}}
 }
 
+@propertyWrapper 
+struct SimplePropertyWrapper {
+  var wrappedValue: Int { .zero }
+  var projectedValue: Int { .max }
+}
+
+@MainActor
+class WrappedContainsNonisolatedAttr {
+  @SimplePropertyWrapper nonisolated var value 
+  // expected-error@-1 {{'nonisolated' is not supported on wrapped properties}}
+  // expected-note@-2 2{{property declared here}}
+
+  nonisolated func test() {
+    _ = value // expected-error {{main actor-isolated property 'value' can not be referenced from a non-isolated context}}
+    _ = $value // expected-error {{main actor-isolated property '$value' can not be referenced from a non-isolated context}}
+  }
+}
 
 
 // ----------------------------------------------------------------------


### PR DESCRIPTION
Follow up to #60421.

Diagnose use of `nonisolated` on wrapped properties, because we currently do not support it. This is because the backing property is a stored `var` and so cannot be marked as `nonisolated` (otherwise you would be able to mutate the state from outside the actor, which is an unsafe operation). We could potentially support it in the future by allowing users to mark the backing property as a stored `let` instead, then it would be safe to add `nonisolated` to the wrapped property.

Resolves https://github.com/apple/swift/issues/59380
Resolves https://github.com/apple/swift/issues/59494