### PR TITLE
[SILOpt] Hoist destroys for non-lexical alloc_stacks more aggressively.

### DIFF
--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -13,12 +13,13 @@
 #define DEBUG_TYPE "allocbox-to-stack"
 #include "swift/AST/DiagnosticsSIL.h"
 #include "swift/Basic/BlotMapVector.h"
+#include "swift/Basic/GraphNodeWorklist.h"
 #include "swift/SIL/ApplySite.h"
+#include "swift/SIL/BasicBlockDatastructures.h"
 #include "swift/SIL/Dominance.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILCloner.h"
-#include "swift/SIL/BasicBlockDatastructures.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
@@ -27,6 +28,7 @@
 #include "swift/SILOptimizer/Utils/StackNesting.h"
 #include "swift/SILOptimizer/Utils/ValueLifetime.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallVector.h"
@@ -538,13 +540,35 @@ static bool rewriteAllocBoxAsAllocStack(AllocBoxInst *ABI) {
   SILBuilderWithScope Builder(ABI);
   assert(ABI->getBoxType()->getLayout()->getFields().size() == 1
          && "rewriting multi-field box not implemented");
-  auto &mod = ABI->getFunction()->getModule();
-  bool isLexical = mod.getASTContext().SILOpts.supportsLexicalLifetimes(mod);
-  auto *ASI = Builder.createAllocStack(
-      ABI->getLoc(),
-      getSILBoxFieldType(TypeExpansionContext(*ABI->getFunction()),
-                         ABI->getBoxType(), ABI->getModule().Types, 0),
-      ABI->getVarInfo(), ABI->hasDynamicLifetime(), isLexical);
+  auto ty = getSILBoxFieldType(TypeExpansionContext(*ABI->getFunction()),
+                               ABI->getBoxType(), ABI->getModule().Types, 0);
+  auto isLexical = [&]() -> bool {
+    auto &mod = ABI->getFunction()->getModule();
+    bool lexicalLifetimesEnabled =
+        mod.getASTContext().SILOpts.supportsLexicalLifetimes(mod);
+    if (!lexicalLifetimesEnabled)
+      return false;
+    // Look for lexical borrows of the alloc_box.
+    GraphNodeWorklist<Operand *, 4> worklist;
+    worklist.initializeRange(ABI->getUses());
+    while (auto *use = worklist.pop()) {
+      // See through mark_uninitialized and non-lexical begin_borrow
+      // instructions.  It's verified that lexical begin_borrows of SILBoxType
+      // values originate either from AllocBoxInsts or SILFunctionArguments.
+      if (auto *mui = dyn_cast<MarkUninitializedInst>(use->getUser())) {
+        for (auto *use : mui->getUses())
+          worklist.insert(use);
+      } else if (auto *bbi = dyn_cast<BeginBorrowInst>(use->getUser())) {
+        if (bbi->isLexical())
+          return true;
+        for (auto *use : bbi->getUses())
+          worklist.insert(use);
+      }
+    }
+    return false;
+  };
+  auto *ASI = Builder.createAllocStack(ABI->getLoc(), ty, ABI->getVarInfo(),
+                                       ABI->hasDynamicLifetime(), isLexical());
 
   // Transfer a mark_uninitialized if we have one.
   SILValue StackBox = ASI;

--- a/lib/SILOptimizer/Transforms/SSADestroyHoisting.cpp
+++ b/lib/SILOptimizer/Transforms/SSADestroyHoisting.cpp
@@ -962,7 +962,7 @@ void SSADestroyHoisting::run() {
   }
   // Alloc stacks always enclose their accesses.
   for (auto *asi : asis) {
-    changed |= hoistDestroys(asi, /*ignoreDeinitBarriers=*/false,
+    changed |= hoistDestroys(asi, /*ignoreDeinitBarriers=*/!asi->isLexical(),
                              remainingDestroyAddrs, deleter);
   }
   // Arguments enclose everything.

--- a/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
+++ b/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
@@ -501,11 +501,29 @@ void TempRValueOptPass::tryOptimizeCopyIntoTemp(CopyAddrInst *copyInst) {
   if (!tempObj)
     return;
 
-  // If the storage corresponds to a source-level var, do not optimize here.
-  // Mem2Reg will transform the lexical alloc_stack into a lexical begin_borrow
-  // which will ensure that the value's lifetime isn't observably shortened.
-  if (tempObj->isLexical())
-    return;
+  // If the temporary storage is lexical, it either came from a source-level var
+  // or was marked lexical because it was passed to a function that has been
+  // inlined.
+  // TODO: [begin_borrow_addr] Once we can mark addresses as being borrowed, we
+  //       won't need to mark alloc_stacks lexical during inlining.  At that
+  //       point, the above comment should change, but the implementation
+  //       remains the same.
+  //
+  // In either case, we can eliminate the temporary if the source of the copy is
+  // lexical and it is live for longer than the temporary.
+  if (tempObj->isLexical()) {
+    // TODO: Determine whether the base of the copy_addr's source is lexical and
+    //       its live range contains the range in which the alloc_stack
+    //       contains the value copied into it via the copy_addr.
+    //
+    // For now, only look for guaranteed arguments.
+    auto storage = AccessStorageWithBase::compute(copyInst->getSrc());
+    if (!storage.base)
+      return;
+    if (auto *arg = dyn_cast<SILFunctionArgument>(storage.base))
+      if (arg->getOwnershipKind() != OwnershipKind::Guaranteed)
+        return;
+  }
 
   bool isOSSA = copyInst->getFunction()->hasOwnership();
   
@@ -645,10 +663,20 @@ TempRValueOptPass::tryOptimizeStoreIntoTemp(StoreInst *si) {
     return std::next(si->getIterator());
   }
 
-  // If the storage corresponds to a source-level var, do not optimize here.
-  // Mem2Reg will transform the lexical alloc_stack into a lexical begin_borrow
-  // which will ensure that the value's lifetime isn't observably shortened.
+  // If the temporary storage is lexical, it either came from a source-level var
+  // or was marked lexical because it was passed to a function that has been
+  // inlined.
+  // TODO: [begin_borrow_addr] Once we can mark addresses as being borrowed, we
+  //       won't need to mark alloc_stacks lexical during inlining.  At that
+  //       point, the above comment should change, but the implementation
+  //       remains the same.
+  //
+  // In either case, we can eliminate the temporary if the source of the store
+  // is lexical and it is live for longer than the temporary.
   if (tempObj->isLexical()) {
+    // TODO: Find the lexical root of the source, if any, and allow optimization
+    //       if its live range contains the range in which the alloc_stack
+    //       contains the value stored into it.
     return std::next(si->getIterator());
   }
 

--- a/test/SILGen/copy_operator.swift
+++ b/test/SILGen/copy_operator.swift
@@ -37,7 +37,7 @@ class Klass {}
 // CHECK-SIL-LABEL: sil @$s8moveonly7useCopyyAA5KlassCADF : $@convention(thin) (@guaranteed Klass) -> @owned Klass {
 // CHECK-SIL: bb0([[ARG:%.*]] : $Klass):
 // CHECK-SIL-NEXT: debug_value
-// CHECK-SIL-NEXT: [[INPUT:%.*]] = alloc_stack $Klass
+// CHECK-SIL-NEXT: [[INPUT:%.*]] = alloc_stack [lexical] $Klass
 // CHECK-SIL-NEXT: store [[ARG]] to [[INPUT]]
 // CHECK-SIL-NEXT: [[VALUE:%[0-9][0-9]*]] = load [[INPUT]]{{.*}}
 // CHECK-SIL-NEXT: strong_retain [[VALUE]]
@@ -78,7 +78,7 @@ public func useCopy(_ k: Klass) -> Klass {
 // CHECK-SIL-LABEL: sil @$s8moveonly7useCopyyxxRlzClF : $@convention(thin) <T where T : AnyObject> (@guaranteed T) -> @owned T {
 // CHECK-SIL: bb0([[ARG:%.*]] :
 // CHECK-SIL-NEXT: debug_value
-// CHECK-SIL-NEXT: [[INPUT_TO_BE_ELIMINATED:%.*]] = alloc_stack $T
+// CHECK-SIL-NEXT: [[INPUT_TO_BE_ELIMINATED:%.*]] = alloc_stack [lexical] $T
 // CHECK-SIL-NEXT: store [[ARG]] to [[INPUT]] : $*T
 // CHECK-SIL-NEXT: [[VALUE:%.*]] = load [[INPUT]] : $*T
 // CHECK-SIL-NEXT: strong_retain [[VALUE]]

--- a/test/SILOptimizer/allocbox_to_stack_lifetime.sil
+++ b/test/SILOptimizer/allocbox_to_stack_lifetime.sil
@@ -14,8 +14,13 @@ struct Bool {
 
 protocol Error {}
 
-// CHECK-LABEL: sil [ossa] @simple_promotion
-sil [ossa] @simple_promotion : $@convention(thin) (Int) -> Int {
+// CHECK-LABEL: sil [ossa] @promote_nonlexical
+// CHECK:         alloc_stack $
+// CHECK-NOT:     alloc_box
+// CHECK-NOT:     destroy_value
+// CHECK:         return
+// CHECK-LABEL: } // end sil function 'promote_nonlexical'
+sil [ossa] @promote_nonlexical : $@convention(thin) (Int) -> Int {
 bb0(%0 : $Int):
   %1 = alloc_box ${ var Int }
   %1a = project_box %1 : ${ var Int }, 0
@@ -24,9 +29,24 @@ bb0(%0 : $Int):
   %3 = load [trivial] %1a : $*Int
   destroy_value %1 : ${ var Int }
   return %3 : $Int
-// CHECK: alloc_stack [lexical]
-// CHECK-NOT: alloc_box
-// CHECK-NOT: destroy_value
-// CHECK: return
+}
+
+// CHECK-LABEL: sil [ossa] @promote_lexical
+// CHECK:         alloc_stack [lexical]
+// CHECK-NOT:     alloc_box
+// CHECK-NOT:     destroy_value
+// CHECK:         return
+// CHECK-LABEL: } // end sil function 'promote_lexical'
+sil [ossa] @promote_lexical : $@convention(thin) (Int) -> Int {
+bb0(%0 : $Int):
+  %1 = alloc_box ${ var Int }
+  %b = begin_borrow [lexical] %1 : ${ var Int }
+  %1a = project_box %b : ${ var Int }, 0
+  store %0 to [trivial] %1a : $*Int
+
+  %3 = load [trivial] %1a : $*Int
+  end_borrow %b : ${ var Int }
+  destroy_value %1 : ${ var Int }
+  return %3 : $Int
 }
 

--- a/test/SILOptimizer/hoist_destroy_addr.sil
+++ b/test/SILOptimizer/hoist_destroy_addr.sil
@@ -1,5 +1,5 @@
-// RUN: %target-sil-opt -opt-mode=none  -enable-sil-verify-all %s -ssa-destroy-hoisting | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECKDEB
-// RUN: %target-sil-opt -opt-mode=speed -enable-sil-verify-all %s -ssa-destroy-hoisting | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECKOPT
+// RUN: %target-sil-opt -opt-mode=none  -enable-sil-verify-all %s -ssa-destroy-hoisting | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECKDEB --check-prefix=CHECK-DEB
+// RUN: %target-sil-opt -opt-mode=speed -enable-sil-verify-all %s -ssa-destroy-hoisting | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECKOPT --check-prefix=CHECK-OPT
 //
 // TODO: migrate the remaining tests from destroy_hoisting.sil.
 
@@ -188,9 +188,9 @@ bb0(%0 : $*T):
 // bb2.  Dead debug instructions then need to be deleted before the
 // destroy can be merged back onto bb3.
 //
-// CHECK-LABEL: sil hidden [ossa] @destroyDiamond : $@convention(thin) <T> (@in_guaranteed T, Builtin.Int1) -> () {
+// CHECK-LABEL: sil hidden [ossa] @destroyDiamond_lexical : $@convention(thin) <T> (@in_guaranteed T, Builtin.Int1) -> () {
 // CHECK: bb0(%0 : $*T, %1 : $Builtin.Int1):
-// CHECK:   [[ALLOC:%.*]] = alloc_stack $T, var, name "t"
+// CHECK:   [[ALLOC:%.*]] = alloc_stack [lexical] $T, var, name "t"
 // CHECK-NOT: destroy
 // CHECK:   cond_br %{{.*}}, bb1, bb2
 // CHECK: bb1:
@@ -199,13 +199,60 @@ bb0(%0 : $*T):
 // CHECK:   br bb3
 // CHECK: bb2:
 // CHECKDEB: debug_value [[ALLOC]] : $*T, let, name "t"
-// CHECK-NOT: debug_val [[ALLOC]]
+// CHECK-NOT: debug_value [[ALLOC]]
 // CHECK:   br bb3
 // CHECK: bb3:
 // CHECK:   destroy_addr [[ALLOC]] : $*T
 // CHECK:   return
-// CHECK-LABEL: } // end sil function 'destroyDiamond'
-sil hidden [ossa] @destroyDiamond : $@convention(thin) <T> (@in_guaranteed T, Builtin.Int1) -> () {
+// CHECK-LABEL: } // end sil function 'destroyDiamond_lexical'
+sil hidden [ossa] @destroyDiamond_lexical : $@convention(thin) <T> (@in_guaranteed T, Builtin.Int1) -> () {
+bb0(%0 : $*T, %1 : $Builtin.Int1):
+  debug_value %0 : $*T, let, name "arg", argno 1, expr op_deref
+  debug_value %1 : $Builtin.Int1, let, name "z", argno 2
+  %4 = alloc_stack [lexical] $T, var, name "t"
+  copy_addr %0 to [initialization] %4 : $*T
+  cond_br %1, bb1, bb2
+
+bb1:
+  %8 = function_ref @unknown : $@convention(thin) () -> ()
+  %9 = apply %8() : $@convention(thin) () -> ()
+  br bb3
+
+bb2:
+  debug_value %4 : $*T, let, name "t"
+  br bb3
+
+bb3:
+  destroy_addr %4 : $*T
+  dealloc_stack %4 : $*T
+  %14 = tuple ()
+  return %14 : $()
+}
+
+// In contrast to the lexical variant (destroyDiamond_lexical), the destroy can
+// be hoisted over the unknown apply.  In the debug case, it can't be hoisted
+// over the debug_value.  In the optimized case, it can be hoisted up to the
+// entry block.
+//
+// CHECK-LABEL:   sil hidden [ossa] @destroyDiamond_nonlexical : $@convention(thin) <T> (@in_guaranteed T, Builtin.Int1) -> () {
+// CHECK:         {{bb[0-9]+}}
+// CHECK:           [[ALLOC:%.*]] = alloc_stack
+// CHECK-OPT:       destroy_addr [[ALLOC]]
+// CHECK:           cond_br %{{.*}}, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:         [[LEFT]]:
+// CHECK-DBG:       destroy_addr [[ALLOC]]
+// CHECK:           apply %{{.*}}()
+// CHECK-NOT:       destroy_addr
+// CHECK:           br [[EXIT:bb[0-9]+]]
+// CHECK:         [[RIGHT]]:
+// CHECK-OPT-NOT:   debug_value [[ALLOC]]
+// CHECK-DBG:       debug_value [[ALLOC]]
+// CHECK-DBG:       destroy_addr [[ALLOC]]
+// CHECK:           br [[EXIT]]
+// CHECK:         [[EXIT]]:
+// CHECK:           return
+// CHECK-LABEL:   } // end sil function 'destroyDiamond_nonlexical'
+sil hidden [ossa] @destroyDiamond_nonlexical : $@convention(thin) <T> (@in_guaranteed T, Builtin.Int1) -> () {
 bb0(%0 : $*T, %1 : $Builtin.Int1):
   debug_value %0 : $*T, let, name "arg", argno 1, expr op_deref
   debug_value %1 : $Builtin.Int1, let, name "z", argno 2
@@ -229,8 +276,8 @@ bb3:
   return %14 : $()
 }
 
-// CHECK-LABEL: sil hidden [ossa] @destroyLoop : $@convention(thin) <T> (@in_guaranteed T) -> () {
-// CHECK:   [[ALLOC:%.*]] = alloc_stack $T, var, name "t"
+// CHECK-LABEL: sil hidden [ossa] @destroyLoop_lexical : $@convention(thin) <T> (@in_guaranteed T) -> () {
+// CHECK:   [[ALLOC:%.*]] = alloc_stack [lexical] $T, var, name "t"
 // CHECK:   br bb1
 // CHECK: bb1:
 // CHECK:   apply %{{.*}}() : $@convention(thin) () -> Builtin.Int1
@@ -242,8 +289,45 @@ bb3:
 // CHECKOPT-NOT: debug_value
 // CHECK:   destroy_addr [[ALLOC]] : $*T
 // CHECK:   dealloc_stack [[ALLOC]] : $*T
-// CHECK-LABEL: } // end sil function 'destroyLoop'
-sil hidden [ossa] @destroyLoop : $@convention(thin) <T> (@in_guaranteed T) -> () {
+// CHECK-LABEL: } // end sil function 'destroyLoop_lexical'
+sil hidden [ossa] @destroyLoop_lexical : $@convention(thin) <T> (@in_guaranteed T) -> () {
+bb0(%0 : $*T):
+  %a = alloc_stack [lexical] $T, var, name "t"
+  copy_addr %0 to [initialization] %a : $*T
+  br bb1
+
+bb1:
+  %f = function_ref @f_bool : $@convention(thin) () -> Builtin.Int1
+  %c = apply %f() : $@convention(thin) () -> Builtin.Int1
+  cond_br %c, bb2, bb3
+
+bb2:
+  br bb1
+
+bb3:
+  debug_value %a : $*T, let, name "t"
+  destroy_addr %a : $*T
+  dealloc_stack %a : $*T
+  %16 = tuple ()
+  return %16 : $()
+}
+
+// CHECK-LABEL:   sil hidden [ossa] @destroyLoop_nonlexical : $@convention(thin) <T> (@in_guaranteed T) -> () {
+// CHECK:           [[ALLOC:%.*]] = alloc_stack $T, var, name "t"
+// CHECK-OPT:       destroy_addr [[ALLOC]]
+// CHECK:           br bb1
+// CHECK:         bb1:
+// CHECK:           apply %{{.*}}() : $@convention(thin) () -> Builtin.Int1
+// CHECK-NEXT:      cond_br %{{.*}}, bb2, bb3
+// CHECK:         bb2:
+// CHECK-NEXT:      br bb1
+// CHECK:         bb3:
+// CHECK-DEB:       debug_value [[ALLOC]] : $*T, let, name "t"
+// CHECK-OPT-NOT:   debug_value
+// CHECK-DEB:       destroy_addr [[ALLOC]] : $*T
+// CHECK:           dealloc_stack [[ALLOC]] : $*T
+// CHECK-LABEL:   } // end sil function 'destroyLoop_nonlexical'
+sil hidden [ossa] @destroyLoop_nonlexical : $@convention(thin) <T> (@in_guaranteed T) -> () {
 bb0(%0 : $*T):
   %a = alloc_stack $T, var, name "t"
   copy_addr %0 to [initialization] %a : $*T
@@ -352,11 +436,34 @@ exit:
 // unreachable-at-begin block is added to the worklist but its predecessor
 // isn't discovered.
 //
-// CHECK-LABEL: sil [ossa] @undiscovered_predecessor_of_unreachable_at_begin : {{.*}} {
+// CHECK-LABEL: sil [ossa] @undiscovered_predecessor_of_unreachable_at_begin_lexical : {{.*}} {
 // CHECK:         apply undef
 // CHECK-NEXT:    destroy_addr
-// CHECK-LABEL: } // end sil function 'undiscovered_predecessor_of_unreachable_at_begin'
-sil [ossa] @undiscovered_predecessor_of_unreachable_at_begin : $@convention(thin) (@owned S) -> () {
+// CHECK-LABEL: } // end sil function 'undiscovered_predecessor_of_unreachable_at_begin_lexical'
+sil [ossa] @undiscovered_predecessor_of_unreachable_at_begin_lexical : $@convention(thin) (@owned S) -> () {
+entry(%instance : @owned $S):
+  %addr = alloc_stack [lexical] $S
+  store %instance to [init] %addr : $*S
+  br applier
+
+applier:
+  apply undef() : $@convention(thin) () -> ()
+  br good
+
+good:
+  destroy_addr %addr : $*S
+  dealloc_stack %addr : $*S
+  %retval = tuple ()
+  return %retval : $()
+}
+  
+// In contrast to the lexical case (undiscovered_predecessor_of_unreachable_at_begin_lexical)
+//
+// CHECK-LABEL: sil [ossa] @undiscovered_predecessor_of_unreachable_at_begin_nonlexical : {{.*}} {
+// CHECK:         store
+// CHECK-NEXT:    destroy_addr
+// CHECK-LABEL: } // end sil function 'undiscovered_predecessor_of_unreachable_at_begin_nonlexical'
+sil [ossa] @undiscovered_predecessor_of_unreachable_at_begin_nonlexical : $@convention(thin) (@owned S) -> () {
 entry(%instance : @owned $S):
   %addr = alloc_stack $S
   store %instance to [init] %addr : $*S
@@ -545,10 +652,32 @@ entry(%instance : @owned $S):
 
 // Don't fold when there's a deinit barrier in the way.
 //
-// CHECK-LABEL: sil [ossa] @nofold_scoped_load_barrier : {{.*}} {
+// CHECK-LABEL: sil [ossa] @nofold_scoped_load_barrier_lexical : {{.*}} {
 // CHECK: load [copy]
-// CHECK-LABEL: // end sil function 'nofold_scoped_load_barrier'
-sil [ossa] @nofold_scoped_load_barrier : $@convention(thin) (@owned S) -> (@owned S) {
+// CHECK-LABEL: // end sil function 'nofold_scoped_load_barrier_lexical'
+sil [ossa] @nofold_scoped_load_barrier_lexical : $@convention(thin) (@owned S) -> (@owned S) {
+entry(%instance : @owned $S):
+  %addr = alloc_stack [lexical] $S
+  %store_scope = begin_access [modify] [static] %addr : $*S
+  store %instance to [init] %store_scope : $*S
+  end_access %store_scope : $*S
+  %load_scope = begin_access [read] [static] %addr : $*S
+  %value = load [copy] %load_scope : $*S
+  %unknown = function_ref @unknown : $@convention(thin) () -> ()
+  apply %unknown() : $@convention(thin) () -> ()
+  end_access %load_scope : $*S
+  destroy_addr %addr : $*S
+  dealloc_stack %addr : $*S
+  return %value : $S
+}
+
+// Fold when there's a deinit barrier in the way if the alloc_stack is
+// non-lexical.
+//
+// CHECK-LABEL: sil [ossa] @nofold_scoped_load_barrier_nonlexical : {{.*}} {
+// CHECK: load [take]
+// CHECK-LABEL: // end sil function 'nofold_scoped_load_barrier_nonlexical'
+sil [ossa] @nofold_scoped_load_barrier_nonlexical : $@convention(thin) (@owned S) -> (@owned S) {
 entry(%instance : @owned $S):
   %addr = alloc_stack $S
   %store_scope = begin_access [modify] [static] %addr : $*S
@@ -647,8 +776,8 @@ entry(%instance : @owned $S):
 sil [ossa] @nofold_unrelated_scoped_load_copy : $@convention(thin) (@owned X) -> (@owned X) {
 entry(%instance : @owned $X):
   %copy = copy_value %instance : $X
-  %addr_1 = alloc_stack $X
-  %addr_2 = alloc_stack $X
+  %addr_1 = alloc_stack [lexical] $X
+  %addr_2 = alloc_stack [lexical] $X
   store %instance to [init] %addr_1 : $*X
   store %copy to [init] %addr_2 : $*X
 

--- a/test/SILOptimizer/hoist_destroy_addr_loop.sil
+++ b/test/SILOptimizer/hoist_destroy_addr_loop.sil
@@ -41,12 +41,44 @@ bb4:
  return %23 : $()   
 }
 
-// CHECK-LABEL: sil [ossa] @nohoist_into_unrelated_access_scope_above_loop : {{.*}} {
+// CHECK-LABEL: sil [ossa] @nohoist_into_unrelated_access_scope_above_loop_lexical : {{.*}} {
 // CHECK:       {{bb[0-9]+}}({{%[^,]+}} : @owned $X, [[REGISTER_1:%[^,]+]] : $*X):
 // CHECK:         end_access
 // CHECK-NEXT:    destroy_addr
-// CHECK-LABEL: } // end sil function 'nohoist_into_unrelated_access_scope_above_loop'
-sil [ossa] @nohoist_into_unrelated_access_scope_above_loop : $@convention(thin) (@owned X, @inout X) -> () {
+// CHECK-LABEL: } // end sil function 'nohoist_into_unrelated_access_scope_above_loop_lexical'
+sil [ossa] @nohoist_into_unrelated_access_scope_above_loop_lexical : $@convention(thin) (@owned X, @inout X) -> () {
+bb0(%instance : @owned $X, %second: $*X):
+ %addr = alloc_stack [lexical] $X
+ store %instance to [init] %addr : $*X
+ %scope = begin_access [modify] [static] %second : $*X
+ %1 = function_ref @get_owned_X : $@convention(thin) () -> @owned X 
+ %14 = apply %1() : $@convention(thin) () -> @owned X 
+ destroy_value %14 : $X
+ end_access %scope : $*X
+ br bb1                        
+
+bb1:   
+ br bb2   
+
+bb2:   
+ cond_br undef, bb3, bb4   
+
+bb3:   
+ br bb1   
+
+bb4:   
+ destroy_addr %addr : $*X
+ dealloc_stack %addr : $*X
+ %23 = tuple ()   
+ return %23 : $()   
+}
+
+// CHECK-LABEL: sil [ossa] @nohoist_into_unrelated_access_scope_above_loop_nonlexical : {{.*}} {
+// CHECK:       {{bb[0-9]+}}({{%[^,]+}} : @owned $X, [[REGISTER_1:%[^,]+]] : $*X):
+// CHECK:         destroy_addr
+// CHECK:         begin_access
+// CHECK-LABEL: } // end sil function 'nohoist_into_unrelated_access_scope_above_loop_nonlexical'
+sil [ossa] @nohoist_into_unrelated_access_scope_above_loop_nonlexical : $@convention(thin) (@owned X, @inout X) -> () {
 bb0(%instance : @owned $X, %second: $*X):
  %addr = alloc_stack $X
  store %instance to [init] %addr : $*X

--- a/test/SILOptimizer/inline_lifetime.sil
+++ b/test/SILOptimizer/inline_lifetime.sil
@@ -130,6 +130,20 @@ bb0(%instance : $*T):
   return %retval : $()
 }
 
+// CHECK-LABEL: sil [ossa] @caller_allocstack_callee_inguaranteed : $@convention(thin) <T> () -> () {
+// CHECK:         alloc_stack [lexical]
+// CHECK-LABEL: } // end sil function 'caller_allocstack_callee_inguaranteed'
+sil [ossa] @caller_allocstack_callee_inguaranteed : $@convention(thin) <T> () -> () {
+bb0:
+  %addr = alloc_stack $T
+  apply undef<T>(%addr) : $@convention(thin) <τ_0_0> () -> @out τ_0_0
+  %callee_inguaranteed = function_ref @callee_inguaranteed : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  %retval = apply %callee_inguaranteed<T>(%addr) : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  destroy_addr %addr : $*T
+  dealloc_stack %addr : $*T
+  return %retval : $()
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // begin_apply
 ////////////////////////////////////////////////////////////////////////////////

--- a/test/SILOptimizer/specialize_dynamic_self.swift
+++ b/test/SILOptimizer/specialize_dynamic_self.swift
@@ -11,7 +11,7 @@ extension P {
 
 class C<T> : P {
   // CHECK-LABEL: sil shared [noinline] @$s23specialize_dynamic_self1CC11returnsSelfACyxGXDyFSi_Tg5 : $@convention(method) (@guaranteed C<Int>) -> @owned C<Int>
-  // CHECK: [[RESULT:%.*]] = alloc_stack $C<Int>
+  // CHECK: [[RESULT:%.*]] = alloc_stack [lexical] $C<Int>
   // CHECK: [[FN:%.*]] = function_ref @$s23specialize_dynamic_self1PPAAE7method1yyF : $@convention(method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
   // CHECK: apply [[FN]]<@dynamic_self C<Int>>([[RESULT]]) : $@convention(method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
   // CHECK: return %0 : $C<Int>

--- a/test/SILOptimizer/temp_rvalue_opt_ossa.sil
+++ b/test/SILOptimizer/temp_rvalue_opt_ossa.sil
@@ -19,6 +19,10 @@ class Klass {
   init()
 }
 
+class OtherClass {
+  var klass: Klass
+}
+
 struct Two {
   var a: Klass
   var b: Klass
@@ -1544,3 +1548,35 @@ bb1(%6 : @guaranteed $Klass):
   return %res : $()
 }
 
+// Lexical alloc_stacks can still be eliminated if their sources are guaranteed
+// function arguments (because those are lexical and have a live range that
+// contains the live range of the value stored into the alloc stack).
+// CHECK-LABEL: sil [ossa] @copy_addr__lexical_alloc_stack_temporary__guaranteed_function_arg : {{.*}} {
+// CHECK-NOT:     alloc_stack
+// CHECK-LABEL: } // end sil function 'copy_addr__lexical_alloc_stack_temporary__guaranteed_function_arg'
+sil [ossa] @copy_addr__lexical_alloc_stack_temporary__guaranteed_function_arg : $@convention(thin) (@guaranteed OtherClass) -> () {
+entry(%instance : @guaranteed $OtherClass):
+  %field_ptr = ref_element_addr %instance : $OtherClass, #OtherClass.klass
+  %addr = alloc_stack [lexical] $Klass
+  copy_addr %field_ptr to [initialization] %addr : $*Klass
+  destroy_addr %addr : $*Klass
+  dealloc_stack %addr : $*Klass
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Lexical alloc_stacks can't be eliminated even if their source is a function
+// argument if that function argument is inout.
+// CHECK-LABEL: sil [ossa] @copy_addr__lexical_alloc_stack_temporary__inout_function_arg : {{.*}} {
+// CHECK:         alloc_stack [lexical]
+// CHECK-LABEL: } // end sil function 'copy_addr__lexical_alloc_stack_temporary__inout_function_arg'
+sil [ossa] @copy_addr__lexical_alloc_stack_temporary__inout_function_arg : $@convention(thin) (@inout NonTrivialStruct) -> () {
+entry(%instance : $*NonTrivialStruct):
+  %field_ptr = struct_element_addr %instance : $*NonTrivialStruct, #NonTrivialStruct.val
+  %addr = alloc_stack [lexical] $Klass
+  copy_addr %field_ptr to [initialization] %addr : $*Klass
+  destroy_addr %addr : $*Klass
+  dealloc_stack %addr : $*Klass
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
Previously, when hoisting `destroy_addr`s for `alloc_stack`s, deinit barriers were always considered barriers to hoisting.  Here, that is changed so that hoisting only is barred when the `alloc_stack` whose `destroy_addr` is being hoisted is lexical.

Additionally, more non-lexical `alloc_stack`s are formed: only `alloc_box`es whose lifetimes are protected via a lexical borrow scope get promoted to lexical `alloc_stack`s.  This will become more significant when types and values are annotated `@_eagerMove`.

In order to do this safely, we must ensure that implicit lexical lifetimes are not removed.  Address function arguments with a convention other than Indirect_Inout have implicit lexical lifetimes: e.g. SSADestroyHoisting respects deinit barriers when hoisting the the destroy_addrs of such arguments.  Until we have `begin_borrow_addr`/`end_borrow_addr`, when inlining functions with such arguments, if the address passed to it has an `alloc_stack` as its storage base, mark that `alloc_stack` lexical.
