### PR TITLE
[Sema] Warn about dictionary literal of dictionary type about duplicated keys

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3768,7 +3768,11 @@ ERROR(should_use_empty_dictionary_literal,none,
 // Dictionary literals
 ERROR(type_is_not_dictionary,none,
       "contextual type %0 cannot be used with dictionary literal", (Type))
-
+WARNING(duplicated_literal_keys_in_dictionary_literal, none,
+        "dictionary literal of type %0 has duplicate entries for %1 literal key%select{ %3|}2",
+        (Type, StringRef, bool, StringRef))
+NOTE(duplicated_key_declared_here, none, 
+     "duplicate key declared here", ())
 
 // Generic specializations
 ERROR(cannot_explicitly_specialize_generic_function,none,

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -617,6 +617,9 @@ public:
   void setInitializer(ConcreteDeclRef initializer) {
     Initializer = initializer;
   }
+
+  /// Get description string for the literal expression.
+  StringRef getLiteralKindDescription() const;
 };
 
 /// BuiltinLiteralExpr - Common base class between all literals

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -993,9 +993,9 @@ StringRef LiteralExpr::getLiteralKindDescription() const {
     return "nil";
   case ExprKind::ObjectLiteral:
     return "object";
-    // Define an unreachable case for all non-literal expressions.
-    // This way, if a new literal is added in the future, the compiler
-    // will warn that a case is missing from this switch.
+  // Define an unreachable case for all non-literal expressions.
+  // This way, if a new literal is added in the future, the compiler
+  // will warn that a case is missing from this switch.
   #define LITERAL_EXPR(Id, Parent)
   #define EXPR(Id, Parent) case ExprKind::Id:
   #include "swift/AST/ExprNodes.def"

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -972,6 +972,38 @@ bool Expr::isValidParentOfTypeExpr(Expr *typeExpr) const {
 // Support methods for Exprs.
 //===----------------------------------------------------------------------===//
 
+StringRef LiteralExpr::getLiteralKindDescription() const {
+  switch (getKind()) {
+  case ExprKind::IntegerLiteral:
+    return "integer";
+  case ExprKind::FloatLiteral:
+    return "floating-point";
+  case ExprKind::BooleanLiteral:
+    return "boolean";
+  case ExprKind::StringLiteral:
+    return "string";
+  case ExprKind::InterpolatedStringLiteral:
+    return "string";
+  case ExprKind::RegexLiteral:
+    return "regular expression";
+  case ExprKind::MagicIdentifierLiteral:
+    return MagicIdentifierLiteralExpr::getKindString(
+        cast<MagicIdentifierLiteralExpr>(this)->getKind());
+  case ExprKind::NilLiteral:
+    return "nil";
+  case ExprKind::ObjectLiteral:
+    return "object";
+    // Define an unreachable case for all non-literal expressions.
+    // This way, if a new literal is added in the future, the compiler
+    // will warn that a case is missing from this switch.
+  #define LITERAL_EXPR(Id, Parent)
+  #define EXPR(Id, Parent) case ExprKind::Id:
+  #include "swift/AST/ExprNodes.def"
+    llvm_unreachable("Not a literal expression");
+  }
+  llvm_unreachable("Unhandled literal");
+}
+
 IntegerLiteralExpr * IntegerLiteralExpr::createFromUnsigned(ASTContext &C, unsigned value) {
   llvm::SmallString<8> Scratch;
   llvm::APInt(sizeof(unsigned)*8, value).toString(Scratch, 10, /*signed*/ false);

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1227,34 +1227,8 @@ static bool isDiscardableType(Type type) {
 }
 
 static void diagnoseIgnoredLiteral(ASTContext &Ctx, LiteralExpr *LE) {
-  const auto getLiteralDescription = [](LiteralExpr *LE) -> StringRef {
-    switch (LE->getKind()) {
-    case ExprKind::IntegerLiteral: return "integer";
-    case ExprKind::FloatLiteral: return "floating-point";
-    case ExprKind::BooleanLiteral: return "boolean";
-    case ExprKind::StringLiteral: return "string";
-    case ExprKind::InterpolatedStringLiteral: return "string";
-    case ExprKind::RegexLiteral: return "regular expression";
-    case ExprKind::MagicIdentifierLiteral:
-      return MagicIdentifierLiteralExpr::getKindString(
-          cast<MagicIdentifierLiteralExpr>(LE)->getKind());
-    case ExprKind::NilLiteral: return "nil";
-    case ExprKind::ObjectLiteral: return "object";
-
-    // Define an unreachable case for all non-literal expressions.
-    // This way, if a new literal is added in the future, the compiler
-    // will warn that a case is missing from this switch.
-#define LITERAL_EXPR(Id, Parent)
-#define EXPR(Id, Parent) case ExprKind::Id:
-#include "swift/AST/ExprNodes.def"
-      llvm_unreachable("Not a literal expression");
-    }
-
-    llvm_unreachable("Unhandled ExprKind in switch.");
-  };
-
   Ctx.Diags.diagnose(LE->getLoc(), diag::expression_unused_literal,
-                     getLiteralDescription(LE))
+                     LE->getLiteralKindDescription())
     .highlight(LE->getSourceRange());
 }
 

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -391,7 +391,7 @@ func rdar60501780() {
   func foo(_: [String: NSObject]) {}
 
   func bar(_ v: String) {
-    foo(["": "", "": v as NSString])
+    foo(["a": "", "b": v as NSString])
   }
 }
 

--- a/test/Sema/diag_dictionary_keys_duplicated.swift
+++ b/test/Sema/diag_dictionary_keys_duplicated.swift
@@ -1,0 +1,211 @@
+// RUN: %target-typecheck-verify-swift
+
+class CustomDict: ExpressibleByDictionaryLiteral {
+  typealias Key = String
+  typealias Value = String
+  
+  required init(dictionaryLiteral elements: (String, String)...) {}
+}
+func fDict(_ d: [String: String]) {}
+func fCustomDict(_ d: CustomDict) {}
+func fDictGeneric<D>(_ d: D) where D: ExpressibleByDictionaryLiteral {}
+
+// Duplicated 
+let _ = [
+  // expected-note@+1{{duplicate key declared here}} {{3-11=}} {{11-12=}}
+  "A": "A", // expected-warning{{dictionary literal of type '[String : String]' has duplicate entries for string literal key 'A'}}
+  "A": "B" // expected-note{{duplicate key declared here}} {{3-12=}} {{16:11-12=}}
+]
+
+let _: [String: String] = [
+  // expected-note@+1{{duplicate key declared here}} {{3-11=}} {{11-12=}}
+  "A": "A", // expected-warning{{dictionary literal of type '[String : String]' has duplicate entries for string literal key 'A'}}
+  "A": "B" // expected-note{{duplicate key declared here}} {{3-12=}} {{22:11-12=}}
+]
+
+let _: [String: String] = [
+  // expected-note@+1{{duplicate key declared here}} {{3-15=}}{{15-16=}}
+  (("A")): "A", // expected-warning{{dictionary literal of type '[String : String]' has duplicate entries for string literal key 'A'}}
+  "A": "B" // expected-note{{duplicate key declared here}} {{3-12=}} {{28:15-16=}}
+]
+
+let _: [String: String] = [
+  // expected-note@+1{{duplicate key declared here}} {{3-11=}} {{11-12=}}
+  "A": "A", // expected-warning{{dictionary literal of type '[String : String]' has duplicate entries for string literal key 'A'}}
+  "B": "B",
+  "C": "C", 
+  "A": "D" // expected-note{{duplicate key declared here}} {{3-12=}} {{36:11-12=}}
+]
+
+// Number literal key
+let _: [Int: String] = [
+  // expected-note@+1{{duplicate key declared here}} {{3-9=}} {{9-10=}}
+  1: "1", // expected-warning{{dictionary literal of type '[Int : String]' has duplicate entries for integer literal key '1'}}
+  2: "2",
+  1: "3" // expected-note{{duplicate key declared here}} {{3-10=}} {{44:9-10=}}
+]
+
+let _: [Double: String] = [
+  // expected-note@+1{{duplicate key declared here}} {{3-12=}} {{12-13=}}
+  1.01: "1", // expected-warning{{dictionary literal of type '[Double : String]' has duplicate entries for floating-point literal key '1.01'}}
+  2: "2",
+  1.01: "3" // expected-note{{duplicate key declared here}} {{3-13=}} {{51:9-10=}}
+]
+
+// Boolean literal
+let _: [Bool: String] = [
+  // expected-note@+1{{duplicate key declared here}} {{3-12=}} {{12-13=}}
+  true: "1", // expected-warning{{dictionary literal of type '[Bool : String]' has duplicate entries for boolean literal key 'true'}}
+  false: "2",
+  true: "3" // expected-note{{duplicate key declared here}} {{3-13=}} {{59:13-14=}}
+]
+
+// nil literal 
+let _: [Int?: String] = [
+  // expected-note@+1{{duplicate key declared here}} {{3-11=}} {{11-12=}}
+  nil: "1", // expected-warning{{dictionary literal of type '[Int? : String]' has duplicate entries for nil literal key}}
+  2: "2",
+  nil: "3" // expected-note{{duplicate key declared here}} {{3-12=}} {{67:9-10=}}
+]
+
+// Nested
+let _: [String: [String: String]] = [
+  // expected-note@+1{{duplicate key declared here}} {{3-11=}} {{11-12=}}
+  "A": [:], // expected-warning{{dictionary literal of type '[String : [String : String]]' has duplicate entries for string literal key 'A'}}
+  "B": [:],
+  "C": [:], 
+  "A": [:] // expected-note{{duplicate key declared here}} {{3-12=}} {{76:11-12=}}
+]
+
+let _: [String: [String: String]] = [
+  // expected-note@+1{{duplicate key declared here}} {{3-11=}} {{11-12=}}
+  "A": [:], // expected-warning{{dictionary literal of type '[String : [String : String]]' has duplicate entries for string literal key 'A'}}
+  "B": [:],
+  "C": [:], 
+  "A": ["a": "", "a": ""] // expected-note{{duplicate key declared here}} {{3-27=}} {{84:11-12=}}
+  // expected-warning@-1{{dictionary literal of type '[String : String]' has duplicate entries for string literal key 'a'}}
+  // expected-note@-2{{duplicate key declared here}} {{9-16=}} {{16-17=}}
+  // expected-note@-3{{duplicate key declared here}} {{18-25=}} {{16-17=}}
+]
+
+// Parent OK, nested duplicated
+let _: [String: [String: String]] = [
+  "A": [:], 
+  "B": [:],
+  "C": [:], 
+  // expected-note@+1{{duplicate key declared here}} {{9-16=}} {{16-17=}}
+  "D": ["a": "", "a": ""] // expected-warning{{dictionary literal of type '[String : String]' has duplicate entries for string literal key 'a'}}
+  // expected-note@-1{{duplicate key declared here}}{{18-25=}} {{18-25=}} {{16-17=}}
+]
+
+// Ok, because custom implementations of ExpressibleByDictionaryLiteral can allow duplicated keys.
+let _: CustomDict = [
+  "A": "A", 
+  "A": "B"
+]
+
+fDict([
+  // expected-note@+1{{duplicate key declared here}} {{3-11=}} {{11-12=}}
+  "A": "A", // expected-warning{{dictionary literal of type '[String : String]' has duplicate entries for string literal key 'A'}}
+  "A": "B" // expected-note{{duplicate key declared here}} {{3-12=}} {{109:11-12=}}
+])
+fCustomDict([
+  "A": "A", 
+  "A": "B"
+])
+fDictGeneric([
+  // expected-note@+1{{duplicate key declared here}} {{3-11=}} {{11-12=}}
+  "A": "A", // expected-warning{{dictionary literal of type '[String : String]' has duplicate entries for string literal key 'A'}}
+  "A": "B" // expected-note{{duplicate key declared here}} {{3-12=}} {{118:11-12=}}
+])
+
+// Magic literals
+let _: [String: String] = [
+  // expected-note@+1{{duplicate key declared here}} {{3-13=}} {{13-14=}}
+  #file: "A", // expected-warning{{dictionary literal of type '[String : String]' has duplicate entries for #file literal key}}
+  #file: "B" // expected-note{{duplicate key declared here}} {{3-14=}} {{125:13-14=}}
+]
+
+
+// OK
+let _ = [
+  "A": "A", 
+  "B": "B"
+]
+let _: [String: String] = [
+  "A": "A", 
+  "B": "B"
+]
+let _: CustomDict = [
+  "A": "A", 
+  "B": "B"
+]
+
+// Number literal key
+let _: [Int: String] = [
+  1: "1",
+  2: "2",
+  3: "3"
+]
+
+let _: [Double: String] = [
+  1.01: "1",
+  2: "2",
+  1.02: "3"
+]
+
+// Boolean literal
+let _: [Bool: String] = [
+  true: "1",
+  false: "2"
+]
+
+// nil literal 
+let _: [Int?: String] = [
+  nil: "1",
+  2: "2"
+]
+
+// Key as the same variable is OK, we only diagnose literals
+let a = "A"
+
+let _: [String: String] = [
+  a: "A",
+  "B": "B",
+  "a": "C", 
+  a: "D"
+]
+
+let _: [String: [String: String]] = [
+  "A": [:],
+  "B": [:],
+  "C": [:], 
+  "D": ["a": "", "b": ""]
+]
+
+fDict([
+  "A": "A", 
+  "B": "B"
+])
+fCustomDict([
+  "A": "A", 
+  "B": "B"
+])
+fDictGeneric([
+  "A": "A", 
+  "B": "B"
+])
+
+func magicFn() {
+  let _: [String: String] = [
+    #file: "A", 
+    #function: "B"
+  ]
+}
+
+// Interpolated literals
+let _: [String: String] = [
+  "\(a)": "A", 
+  "\(a)": "B",
+  "\(1)": "C"
+]


### PR DESCRIPTION
<!-- What's in this pull request? -->
This simply warns about dictionary literal with duplicated keys only when they are inferred as `Dictionary` where we know duplicated keys are not stored, but we cannot diagnose the same for other custom `ExpressibleByDictionaryLiteral` type because rules are unknown.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves https://github.com/apple/swift/issues/43258.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
