### PR TITLE
[Distributed] more specific errorCodes for dist failures

### DIFF
--- a/stdlib/public/Distributed/DistributedActor.cpp
+++ b/stdlib/public/Distributed/DistributedActor.cpp
@@ -109,8 +109,7 @@ static void swift_distributed_execute_target_resume(
   return resumeInParent(parentCtx, error);
 }
 
-SWIFT_CC(swift)
-SWIFT_EXPORT_FROM(swiftDistributed)
+SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
 SwiftError* swift_distributed_makeDistributedTargetAccessorNotFoundError(
     const char *targetNameStart, size_t targetNameLength);
 

--- a/stdlib/public/Distributed/DistributedActorSystem.swift
+++ b/stdlib/public/Distributed/DistributedActorSystem.swift
@@ -251,7 +251,8 @@ extension DistributedActorSystem {
       let subs = try invocationDecoder.decodeGenericSubstitutions()
       if subs.isEmpty {
         throw ExecuteDistributedTargetError(
-          message: "Cannot call generic method without generic argument substitutions")
+          message: "Cannot call generic method without generic argument substitutions",
+          errorCode: .missingGenericSubstitutions)
       }
 
       substitutionsBuffer = .allocate(capacity: subs.count)
@@ -265,7 +266,8 @@ extension DistributedActorSystem {
                                                                      genericArguments: substitutionsBuffer!)
       if numWitnessTables < 0 {
         throw ExecuteDistributedTargetError(
-          message: "Generic substitutions \(subs) do not satisfy generic requirements of \(target) (\(targetName))")
+          message: "Generic substitutions \(subs) do not satisfy generic requirements of \(target) (\(targetName))",
+          errorCode: .invalidGenericSubstitutions)
       }
     }
 
@@ -279,7 +281,8 @@ extension DistributedActorSystem {
                  Failed to decode distributed invocation target expected parameter count,
                  error code: \(paramCount)
                  mangled name: \(targetName)
-                 """)
+                 """,
+        errorCode: .invalidParameterCount)
     }
 
     // Prepare buffer for the parameter types to be decoded into:
@@ -304,7 +307,8 @@ extension DistributedActorSystem {
                  Failed to decode the expected number of params of distributed invocation target, error code: \(decodedNum)
                  (decoded: \(decodedNum), expected params: \(paramCount)
                  mangled name: \(targetName)
-                 """)
+                 """,
+        errorCode: .invalidParameterCount)
     }
 
     // Copy the types from the buffer into a Swift Array
@@ -325,12 +329,14 @@ extension DistributedActorSystem {
                                                                     genericEnv: genericEnv,
                                                                     genericArguments: substitutionsBuffer) else {
       throw ExecuteDistributedTargetError(
-        message: "Failed to decode distributed target return type")
+        message: "Failed to decode distributed target return type",
+        errorCode: .typeDeserializationFailure)
     }
 
     guard let resultBuffer = _openExistential(returnTypeFromTypeInfo, do: allocateReturnTypeBuffer) else {
       throw ExecuteDistributedTargetError(
-        message: "Failed to allocate buffer for distributed target return type")
+        message: "Failed to allocate buffer for distributed target return type",
+        errorCode: .typeDeserializationFailure)
     }
 
     func destroyReturnTypeBuffer<R>(_: R.Type) {
@@ -576,19 +582,38 @@ public protocol DistributedTargetInvocationResultHandler {
 @available(SwiftStdlib 5.7, *)
 public protocol DistributedActorSystemError: Error {}
 
+/// Error thrown by ``DistributedActorSystem/executeDistributedTarget(on:target:invocationDecoder:handler:)``.
+///
+/// Inspect the ``errorCode`` for details about the underlying reason this error was thrown.
 @available(SwiftStdlib 5.7, *)
 public struct ExecuteDistributedTargetError: DistributedActorSystemError {
   public let errorCode: ErrorCode
   public let message: String
 
   public enum ErrorCode {
-    /// Thrown when unable to resolve the target identifier to a function accessor.
+    /// Unable to resolve the target identifier to a function accessor.
     /// This can happen when the identifier is corrupt, illegal, or wrong in the
     /// sense that the caller and callee do not have the called function recorded
     /// using the same identifier.
     case targetAccessorNotFound
 
-    /// A general issue during the execution of the distributed call target ocurred.
+    /// Call target has different number of parameters than arguments
+    /// provided by the invocation decoder.
+    case invalidParameterCount
+
+    /// Target expects generic environment information, but invocation decoder
+    /// provided no generic substitutions.
+    case missingGenericSubstitutions
+
+    /// Generic substitutions provided by invocation decoder are incompatible
+    /// with target of the call. E.g. the generic requirements on the actual
+    /// target could not be fulfilled by the obtained generic substitutions.
+    case invalidGenericSubstitutions
+
+    // Failed to deserialize type or obtain type information for call.
+    case typeDeserializationFailure
+
+    /// A general issue during the execution of the distributed call target occurred.
     case other
   }
 


### PR DESCRIPTION
Review follow up from https://github.com/apple/swift/pull/60476 and https://github.com/apple/swift/pull/60266

Now this:
- does not export the `swift_distributed_makeDistributedTargetAccessorNotFoundError` anymore 🥳 
- has more precise error values whenever we throw from execute, for easier analysis