### PR TITLE
[5.7.0] Update the scripts to support Python3

### DIFF
--- a/benchmark/scripts/Benchmark_DTrace.in
+++ b/benchmark/scripts/Benchmark_DTrace.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # ===--- Benchmark_DTrace.in ---------------------------------------------===//
 #

--- a/benchmark/scripts/Benchmark_Driver
+++ b/benchmark/scripts/Benchmark_Driver
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # ===--- Benchmark_Driver ------------------------------------------------===//

--- a/benchmark/scripts/Benchmark_GuardMalloc.in
+++ b/benchmark/scripts/Benchmark_GuardMalloc.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # ===--- Benchmark_GuardMalloc.in ----------------------------------------===//
 #

--- a/benchmark/scripts/Benchmark_QuickCheck.in
+++ b/benchmark/scripts/Benchmark_QuickCheck.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # ===--- Benchmark_QuickCheck.in -----------------------------------------===//
 #

--- a/benchmark/scripts/Benchmark_RuntimeLeaksRunner.in
+++ b/benchmark/scripts/Benchmark_RuntimeLeaksRunner.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # ===--- Benchmark_RuntimeLeaksRunner.in ---------------------------------===//
 #

--- a/benchmark/scripts/build_linux.py
+++ b/benchmark/scripts/build_linux.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import os

--- a/benchmark/scripts/build_script_helper.py
+++ b/benchmark/scripts/build_script_helper.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-
-from __future__ import print_function
+#!/usr/bin/env python3
 
 import argparse
 import os

--- a/benchmark/scripts/compare_perf_tests.py
+++ b/benchmark/scripts/compare_perf_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # ===--- compare_perf_tests.py -------------------------------------------===//
@@ -26,8 +26,6 @@ class `TestComparator` analyzes changes betweeen the old and new test results.
 class `ReportFormatter` creates the test comparison report in specified format.
 
 """
-
-from __future__ import print_function
 
 import argparse
 import functools

--- a/benchmark/scripts/create_benchmark.py
+++ b/benchmark/scripts/create_benchmark.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import os

--- a/benchmark/scripts/generate_harness/generate_harness.py
+++ b/benchmark/scripts/generate_harness/generate_harness.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # ===--- generate_harness.py ---------------------------------------------===//
 #
@@ -13,8 +13,6 @@
 # ===---------------------------------------------------------------------===//
 
 # Generate boilerplate, CMakeLists.txt and utils/main.swift from templates.
-
-from __future__ import print_function
 
 import argparse
 import os

--- a/benchmark/scripts/perf_test_driver/perf_test_driver.py
+++ b/benchmark/scripts/perf_test_driver/perf_test_driver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # ===--- perf_test_driver.py ---------------------------------------------===//
 #
@@ -11,8 +11,6 @@
 #  See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 #
 # ===---------------------------------------------------------------------===//
-
-from __future__ import print_function
 
 import functools
 import glob

--- a/benchmark/scripts/run_smoke_bench
+++ b/benchmark/scripts/run_smoke_bench
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # ===--- run_smoke_bench -------------------------------------------------===//
@@ -20,8 +20,6 @@
 # Also reports code size differences.
 #
 # ===---------------------------------------------------------------------===//
-
-from __future__ import print_function
 
 import argparse
 import glob

--- a/benchmark/scripts/test_Benchmark_Driver.py
+++ b/benchmark/scripts/test_Benchmark_Driver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # ===--- test_Benchmark_Driver.py ----------------------------------------===//

--- a/benchmark/scripts/test_compare_perf_tests.py
+++ b/benchmark/scripts/test_compare_perf_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # ===--- test_compare_perf_tests.py --------------------------------------===//

--- a/benchmark/scripts/test_utils.py
+++ b/benchmark/scripts/test_utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # ===--- test_utils.py ---------------------------------------------------===//

--- a/benchmark/utils/convertToJSON.py
+++ b/benchmark/utils/convertToJSON.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # ===--- convertToJSON.py ------------------------------------------------===//
 #
@@ -56,8 +56,6 @@
 #         }
 #     ]
 # }
-
-from __future__ import print_function
 
 import json
 import re

--- a/docs/scripts/ns-html2rst
+++ b/docs/scripts/ns-html2rst
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-from __future__ import print_function
-
+#!/usr/bin/env python3
 import re
 import subprocess
 import sys

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -13,7 +13,6 @@
 import SwiftShims
 
 %{
-from __future__ import division
 from SwiftIntTypes import all_integer_types
 from SwiftFloatingPointTypes import all_floating_point_types
 

--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -14,7 +14,6 @@
 # Utility code for later in this template
 #
 
-from __future__ import division
 from SwiftIntTypes import all_integer_types, int_max_bits, should_define_truncating_bit_pattern_init
 from SwiftFloatingPointTypes import getFtoIBounds
 

--- a/stdlib/public/core/SIMDConcreteOperations.swift.gyb
+++ b/stdlib/public/core/SIMDConcreteOperations.swift.gyb
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 %{
-from __future__ import division
 from SwiftIntTypes import all_integer_types
 word_bits = int(CMAKE_SIZEOF_VOID_P) * 8
 storagescalarCounts = [2,4,8,16,32,64]

--- a/stdlib/public/core/SIMDVectorTypes.swift.gyb
+++ b/stdlib/public/core/SIMDVectorTypes.swift.gyb
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 %{
-from __future__ import division
 from SwiftIntTypes import all_integer_types
 word_bits = int(CMAKE_SIZEOF_VOID_P) * 8
 storagescalarCounts = [2,4,8,16,32,64]

--- a/test/CrossImport/Inputs/rewrite-module-triples.py
+++ b/test/CrossImport/Inputs/rewrite-module-triples.py
@@ -1,10 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Renames files or directories with "module-triple-here" in their names to use
 the indicated module triples instead.
 """
-
-from __future__ import print_function
 
 import os
 import platform

--- a/test/Driver/Dependencies/Inputs/fake-build-for-bitcode.py
+++ b/test/Driver/Dependencies/Inputs/fake-build-for-bitcode.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # fake-build-for-bitcode.py - Fake build with -embed-bitcode -*- python -*-
 #
 # This source file is part of the Swift.org open source project
@@ -15,8 +15,6 @@
 # -emit-bc and -c actions.
 #
 # ----------------------------------------------------------------------------
-
-from __future__ import print_function
 
 import os
 import sys

--- a/test/Driver/Dependencies/Inputs/fake-build-whole-module.py
+++ b/test/Driver/Dependencies/Inputs/fake-build-whole-module.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # fake-build-for-whole-module.py - Optimized fake build -*- python -*-
 #
 # This source file is part of the Swift.org open source project
@@ -14,8 +14,6 @@
 # Emulates the frontend of a -whole-module-optimization compilation.
 #
 # ----------------------------------------------------------------------------
-
-from __future__ import print_function
 
 import os
 import sys

--- a/test/Driver/Dependencies/Inputs/modify-non-primary-files.py
+++ b/test/Driver/Dependencies/Inputs/modify-non-primary-files.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # modify-non-primary-files.py - Fake build while modifying files -*- python -*-
 #
 # This source file is part of the Swift.org open source project
@@ -15,8 +15,6 @@
 # source files during compilation.
 #
 # ----------------------------------------------------------------------------
-
-from __future__ import print_function
 
 import os
 import sys

--- a/test/Driver/Dependencies/Inputs/touch.py
+++ b/test/Driver/Dependencies/Inputs/touch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # touch.py - /bin/touch that writes the LLVM epoch -*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/test/Driver/Dependencies/Inputs/update-dependencies-bad.py
+++ b/test/Driver/Dependencies/Inputs/update-dependencies-bad.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # update-dependencies-bad.py - Fails on bad.swift -*- python -*-
 #
 # This source file is part of the Swift.org open source project
@@ -16,8 +16,6 @@
 # exit-by-SIGKILL
 #
 # ----------------------------------------------------------------------------
-
-from __future__ import print_function
 
 import os
 import shutil

--- a/test/Driver/Dependencies/Inputs/update-dependencies.py
+++ b/test/Driver/Dependencies/Inputs/update-dependencies.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # update-dependencies.py - Fake build for dependency analysis -*- python -*-
 #
 # This source file is part of the Swift.org open source project
@@ -26,8 +26,6 @@
 # If invoked in non-primary-file mode, it only creates the output file.
 #
 # ----------------------------------------------------------------------------
-
-from __future__ import print_function
 
 import os
 import shutil

--- a/test/Driver/Inputs/crash-after-generating-pch.py
+++ b/test/Driver/Inputs/crash-after-generating-pch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # crash.py - Sends SIGKILL to self. -*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/test/Driver/Inputs/crash.py
+++ b/test/Driver/Inputs/crash.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # crash.py - Sends SIGKILL to self. -*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/test/Driver/Inputs/fail.py
+++ b/test/Driver/Inputs/fail.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # fail.py - Just exits with an error code -*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/test/Driver/Inputs/fake-toolchain/clang
+++ b/test/Driver/Inputs/fake-toolchain/clang
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # clang++ - Fake Clang to test finding clang++ in the toolchain path
 #
 # This source file is part of the Swift.org open source project
@@ -10,7 +10,5 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 #
 # ----------------------------------------------------------------------------
-
-from __future__ import print_function
 
 print("Sorry, I'm lazy-clang")

--- a/test/Driver/Inputs/fake-toolchain/ld
+++ b/test/Driver/Inputs/fake-toolchain/ld
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # ld - Fake ld to test finding the Darwin linker in the toolchain path
 #
 # This source file is part of the Swift.org open source project
@@ -10,7 +10,5 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 #
 # ----------------------------------------------------------------------------
-
-from __future__ import print_function
 
 print("Sorry, wrong number!")

--- a/test/Driver/Inputs/filelists/check-filelist-abc.py
+++ b/test/Driver/Inputs/filelists/check-filelist-abc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # check-filelist-abc.py - Fake build to test driver-produced -filelists.
 #
 # This source file is part of the Swift.org open source project
@@ -10,8 +10,6 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 #
 # ----------------------------------------------------------------------------
-
-from __future__ import print_function
 
 import os
 import sys

--- a/test/Driver/Inputs/filelists/fake-ld.py
+++ b/test/Driver/Inputs/filelists/fake-ld.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # fake-ld.py - Fake Darwin linker to test driver-produced -filelists.
 #
 # This source file is part of the Swift.org open source project
@@ -10,8 +10,6 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 #
 # ----------------------------------------------------------------------------
-
-from __future__ import print_function
 
 import sys
 

--- a/test/Incremental/Verifier/gen-output-file-map.py
+++ b/test/Incremental/Verifier/gen-output-file-map.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-
-from __future__ import print_function
+#!/usr/bin/env python3
 
 import argparse
 import io

--- a/test/Inputs/getmtime.py
+++ b/test/Inputs/getmtime.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-
-from __future__ import print_function
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/test/Inputs/symlink.py
+++ b/test/Inputs/symlink.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import subprocess
 import sys

--- a/test/Inputs/timeout.py
+++ b/test/Inputs/timeout.py
@@ -1,4 +1,4 @@
-#!/uar/bin/env python
+#!/uar/bin/env python3
 
 import subprocess
 import sys

--- a/test/Misc/you-should-be-using-LLVM_DEBUG.test-sh
+++ b/test/Misc/you-should-be-using-LLVM_DEBUG.test-sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 # -*- python -*-
 # RUN: %{python} %s '%swift_src_root'
 

--- a/test/ModuleInterface/ModuleCache/Inputs/check-is-new.py
+++ b/test/ModuleInterface/ModuleCache/Inputs/check-is-new.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # check-is-new.py - a more-legible way to read a timestamp test than test(1)
 #

--- a/test/ModuleInterface/ModuleCache/Inputs/check-is-old.py
+++ b/test/ModuleInterface/ModuleCache/Inputs/check-is-old.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # check-is-old.py - a more-legible way to read a timestamp test than test(1)
 #

--- a/test/ModuleInterface/ModuleCache/Inputs/make-old.py
+++ b/test/ModuleInterface/ModuleCache/Inputs/make-old.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # make-old.py - /bin/touch that writes a constant "old" timestamp.
 #

--- a/test/RemoteMirror/Inputs/interop.py
+++ b/test/RemoteMirror/Inputs/interop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Exercise the SwiftRemoteMirrorLegacyInterop API. This works with
 # multiple versions of Swift. It builds Swift code using all versions,
@@ -6,8 +6,6 @@
 # versions' Remote Mirror libraries.
 #
 # Invoke by passing the various Swift build directories as parameters.
-
-from __future__ import print_function
 
 import itertools
 import os

--- a/test/ScanDependencies/Inputs/CommandRunner.py
+++ b/test/ScanDependencies/Inputs/CommandRunner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import subprocess
 import sys

--- a/test/Serialization/Inputs/binary_sub.py
+++ b/test/Serialization/Inputs/binary_sub.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/test/SourceKit/Inputs/sourcekitd_path_sanitize.py
+++ b/test/SourceKit/Inputs/sourcekitd_path_sanitize.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # sourcekitd_path_sanitize.py - Cleans up paths from sourcekitd-test output
 #
 # This source file is part of the Swift.org open source project

--- a/test/attr/Inputs/access-note-gen.py
+++ b/test/attr/Inputs/access-note-gen.py
@@ -1,12 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding=utf8
 
 """
 Convert selected @objc attributes in a source file into access notes, removing
 the originals in the process.
 """
-
-from __future__ import print_function
 
 import io
 import re

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -18,7 +18,6 @@
 #
 # -----------------------------------------------------------------------------
 
-from __future__ import absolute_import
 import os
 import platform
 import re

--- a/test/stdlib/Integers.swift.gyb
+++ b/test/stdlib/Integers.swift.gyb
@@ -20,7 +20,6 @@
 // REQUIRES: OS=macosx
 
 %{
-from __future__ import division
 word_bits = int(WORD_BITS) // 2
 from SwiftIntTypes import all_integer_types
 }%

--- a/test/stdlib/NumericParsing.swift.gyb
+++ b/test/stdlib/NumericParsing.swift.gyb
@@ -17,7 +17,6 @@
 // RUN: %line-directive %t/NumericParsing.swift -- %target-run %t/a.out
 // REQUIRES: executable_test
 %{
-from __future__ import division
 from SwiftIntTypes import all_integer_types
 
 word_bits = int(CMAKE_SIZEOF_VOID_P)

--- a/test/stdlib/SIMDConcreteIntegers.swift.gyb
+++ b/test/stdlib/SIMDConcreteIntegers.swift.gyb
@@ -20,7 +20,6 @@
 import StdlibUnittest
 
 %{
-from __future__ import division
 from SwiftIntTypes import all_integer_types
 word_bits = int(CMAKE_SIZEOF_VOID_P) * 8
 storagescalarCounts = [2,4,8,16,32,64]

--- a/test/stdlib/SIMDConcreteMasks.swift.gyb
+++ b/test/stdlib/SIMDConcreteMasks.swift.gyb
@@ -20,7 +20,6 @@
 import StdlibUnittest
 
 %{
-from __future__ import division
 from SwiftIntTypes import all_integer_types
 word_bits = int(CMAKE_SIZEOF_VOID_P) * 8
 storagescalarCounts = [2,4,8,16,32,64]

--- a/tools/swift-inspect/build_script_helper.py
+++ b/tools/swift-inspect/build_script_helper.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-
-from __future__ import print_function
+#!/usr/bin/env python3
 
 import argparse
 import os

--- a/utils/80+-check
+++ b/utils/80+-check
@@ -1,7 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-
-from __future__ import print_function, unicode_literals
 
 import argparse
 import sys

--- a/utils/PathSanitizingFileCheck
+++ b/utils/PathSanitizingFileCheck
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # utils/PathSanitizingFileCheck -*- python -*-
 #
 # This source file is part of the Swift.org open source project
@@ -8,8 +8,6 @@
 #
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-
-from __future__ import print_function
 
 import argparse
 import io

--- a/utils/analyze_code_size.py
+++ b/utils/analyze_code_size.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import re

--- a/utils/android/adb/commands.py
+++ b/utils/android/adb/commands.py
@@ -15,8 +15,6 @@
 #
 # ----------------------------------------------------------------------------
 
-from __future__ import print_function
-
 import os
 import subprocess
 import tempfile

--- a/utils/android/adb_clean.py
+++ b/utils/android/adb_clean.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # adb_reboot.py - Reboots and cleans an Android device. -*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/utils/android/adb_push_built_products.py
+++ b/utils/android/adb_push_built_products.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # adb_push_build_products.py - Push libraries to Android device -*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/utils/android/adb_push_built_products/main.py
+++ b/utils/android/adb_push_built_products/main.py
@@ -15,8 +15,6 @@
 #
 # ----------------------------------------------------------------------------
 
-from __future__ import print_function
-
 import argparse
 import glob
 import os

--- a/utils/android/adb_test_runner.py
+++ b/utils/android/adb_test_runner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # adb_test_runner.py - Calls adb_test_runner.main -*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/utils/android/adb_test_runner/main.py
+++ b/utils/android/adb_test_runner/main.py
@@ -17,8 +17,6 @@
 #
 # ----------------------------------------------------------------------------
 
-from __future__ import print_function
-
 import os
 import sys
 

--- a/utils/api_checker/sdk-module-lists/infer-imports.py
+++ b/utils/api_checker/sdk-module-lists/infer-imports.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python -u
 
-from __future__ import print_function
-
 import os
 import sys
 

--- a/utils/api_checker/swift-api-checker.py
+++ b/utils/api_checker/swift-api-checker.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import print_function
-
 import argparse
 import os
 import subprocess

--- a/utils/apply-fixit-edits.py
+++ b/utils/apply-fixit-edits.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # utils/apply-fixit-edits.py - Apply edits from .remap files -*- python -*-
 #
 # This source file is part of the Swift.org open source project
@@ -8,8 +8,6 @@
 #
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-
-from __future__ import print_function
 
 import argparse
 import collections

--- a/utils/backtrace-check
+++ b/utils/backtrace-check
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 
 """
@@ -21,8 +21,6 @@ imagine we can just check the format.
 StaticString, StaticString, UInt, flags : UInt32) -> () + 444
 """
 
-
-from __future__ import absolute_import, print_function, unicode_literals
 
 import argparse
 import re

--- a/utils/bug_reducer/bug_reducer/bug_reducer.py
+++ b/utils/bug_reducer/bug_reducer/bug_reducer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 

--- a/utils/bug_reducer/bug_reducer/func_bug_reducer.py
+++ b/utils/bug_reducer/bug_reducer/func_bug_reducer.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import md5
 import os
 import sys

--- a/utils/bug_reducer/bug_reducer/list_reducer.py
+++ b/utils/bug_reducer/bug_reducer/list_reducer.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import random
 
 TESTRESULT_NOFAILURE = "NoFailure"

--- a/utils/bug_reducer/bug_reducer/opt_bug_reducer.py
+++ b/utils/bug_reducer/bug_reducer/opt_bug_reducer.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import json
 import md5
 import subprocess

--- a/utils/bug_reducer/bug_reducer/random_bug_finder.py
+++ b/utils/bug_reducer/bug_reducer/random_bug_finder.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import json
 import random
 import subprocess

--- a/utils/bug_reducer/bug_reducer/swift_tools.py
+++ b/utils/bug_reducer/bug_reducer/swift_tools.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import subprocess
 

--- a/utils/build-script
+++ b/utils/build-script
@@ -14,8 +14,6 @@ The ultimate tool for building Swift.
 """
 
 
-from __future__ import absolute_import, print_function, unicode_literals
-
 import json
 import os
 import platform

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -337,7 +337,7 @@ function with_pushd() {
 }
 
 function quoted_print() {
-    python -c 'import pipes; import sys; print(" ".join(pipes.quote(arg) for arg in sys.argv[1:]))' "$@"
+    python3 -c 'import pipes; import sys; print(" ".join(pipes.quote(arg) for arg in sys.argv[1:]))' "$@"
 }
 
 function toupper() {

--- a/utils/build-tooling-libs
+++ b/utils/build-tooling-libs
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # utils/build-tooling-libs - Helper tool for building the SwiftSyntax paresr
 # and SwiftStaticMirror libraries -*- python -*-
 #
@@ -22,8 +22,6 @@
 #
 # This utility also provides capability to gather profile data and build the parser
 # library with PGO optimization enabled.
-
-from __future__ import print_function
 
 import copy
 import multiprocessing

--- a/utils/build_swift/build_swift/argparse/__init__.py
+++ b/utils/build_swift/build_swift/argparse/__init__.py
@@ -14,8 +14,6 @@ constructing parsers and more argument types. This module exposes a strict
 super-set of the argparse API and is meant to be used as a drop-in replacement.
 """
 
-from __future__ import absolute_import, unicode_literals
-
 from argparse import (ArgumentDefaultsHelpFormatter, ArgumentError,
                       ArgumentTypeError, FileType, HelpFormatter,
                       Namespace, RawDescriptionHelpFormatter,

--- a/utils/build_swift/build_swift/argparse/actions.py
+++ b/utils/build_swift/build_swift/argparse/actions.py
@@ -13,8 +13,6 @@ default actions provided by the standard argparse.
 """
 
 
-from __future__ import absolute_import, unicode_literals
-
 import argparse
 import copy
 

--- a/utils/build_swift/build_swift/argparse/parser.py
+++ b/utils/build_swift/build_swift/argparse/parser.py
@@ -13,9 +13,6 @@ destination actions as well as a new builder DSL for declaratively
 constructing complex parsers.
 """
 
-
-from __future__ import absolute_import, unicode_literals
-
 import argparse
 from contextlib import contextmanager
 

--- a/utils/build_swift/build_swift/argparse/types.py
+++ b/utils/build_swift/build_swift/argparse/types.py
@@ -13,8 +13,6 @@ arguments.
 """
 
 
-from __future__ import absolute_import, unicode_literals
-
 import os.path
 import re
 import shlex

--- a/utils/build_swift/build_swift/cache_utils.py
+++ b/utils/build_swift/build_swift/cache_utils.py
@@ -11,9 +11,6 @@
 Cache related utitlity functions and decorators.
 """
 
-
-from __future__ import absolute_import, unicode_literals
-
 import functools
 
 

--- a/utils/build_swift/build_swift/class_utils.py
+++ b/utils/build_swift/build_swift/class_utils.py
@@ -12,9 +12,6 @@ Class utility functions and decorators.
 """
 
 
-from __future__ import absolute_import, unicode_literals
-
-
 __all__ = [
     'generate_repr',
 ]

--- a/utils/build_swift/build_swift/constants.py
+++ b/utils/build_swift/build_swift/constants.py
@@ -6,11 +6,6 @@
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import os.path
 
 

--- a/utils/build_swift/build_swift/defaults.py
+++ b/utils/build_swift/build_swift/defaults.py
@@ -11,9 +11,6 @@
 Default option value definitions.
 """
 
-
-from __future__ import absolute_import, unicode_literals
-
 import os
 import platform
 

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -6,9 +6,6 @@
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-
-from __future__ import absolute_import, unicode_literals
-
 import multiprocessing
 import os
 

--- a/utils/build_swift/build_swift/migration.py
+++ b/utils/build_swift/build_swift/migration.py
@@ -12,8 +12,6 @@ Temporary module with functionality used to migrate away from build-script-impl.
 """
 
 
-from __future__ import absolute_import, unicode_literals
-
 import itertools
 import subprocess
 

--- a/utils/build_swift/build_swift/presets.py
+++ b/utils/build_swift/build_swift/presets.py
@@ -12,8 +12,6 @@ Swift preset parsing and handling functionality.
 """
 
 
-from __future__ import absolute_import, unicode_literals
-
 import configparser
 import functools
 import io

--- a/utils/build_swift/build_swift/shell.py
+++ b/utils/build_swift/build_swift/shell.py
@@ -206,7 +206,7 @@ def quote(command):
     if isinstance(command, (str,)):
         return _quote(command)
 
-    if isinstance(command, collections.Iterable):
+    if isinstance(command, collections.abc.Iterable):
         return ' '.join([_quote(arg) for arg in _normalize_args(command)])
 
     raise ValueError('Invalid command type: {}'.format(type(command).__name__))

--- a/utils/build_swift/build_swift/shell.py
+++ b/utils/build_swift/build_swift/shell.py
@@ -12,8 +12,6 @@ Shell utilities wrapper module.
 """
 
 
-from __future__ import absolute_import, unicode_literals
-
 import abc
 import collections
 import functools

--- a/utils/build_swift/build_swift/versions.py
+++ b/utils/build_swift/build_swift/versions.py
@@ -12,8 +12,6 @@ Version parsing classes.
 """
 
 
-from __future__ import absolute_import, unicode_literals
-
 import functools
 
 

--- a/utils/build_swift/build_swift/wrappers/__init__.py
+++ b/utils/build_swift/build_swift/wrappers/__init__.py
@@ -6,9 +6,6 @@
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-
-from __future__ import absolute_import, unicode_literals
-
 from . import xcrun as _xcrun
 
 

--- a/utils/build_swift/build_swift/wrappers/xcrun.py
+++ b/utils/build_swift/build_swift/wrappers/xcrun.py
@@ -11,9 +11,6 @@
 Wrapper module around the 'xcrun' command-line utility.
 """
 
-
-from __future__ import absolute_import, unicode_literals
-
 import functools
 import re
 import shlex

--- a/utils/build_swift/run_tests.py
+++ b/utils/build_swift/run_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This source file is part of the Swift.org open source project
 #
@@ -13,8 +13,6 @@
 Utility script used to easily run the build_swift module unit tests.
 """
 
-
-from __future__ import absolute_import, unicode_literals
 
 import argparse
 import os

--- a/utils/build_swift/tests/build_swift/argparse/test_actions.py
+++ b/utils/build_swift/tests/build_swift/argparse/test_actions.py
@@ -7,8 +7,6 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 
-from __future__ import absolute_import, unicode_literals
-
 import unittest
 
 from build_swift.argparse import (

--- a/utils/build_swift/tests/build_swift/argparse/test_parser.py
+++ b/utils/build_swift/tests/build_swift/argparse/test_parser.py
@@ -7,8 +7,6 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 
-from __future__ import absolute_import, unicode_literals
-
 import unittest
 from argparse import _ArgumentGroup, _MutuallyExclusiveGroup
 

--- a/utils/build_swift/tests/build_swift/argparse/test_types.py
+++ b/utils/build_swift/tests/build_swift/argparse/test_types.py
@@ -7,8 +7,6 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 
-from __future__ import absolute_import, unicode_literals
-
 import os.path
 import platform
 import unittest

--- a/utils/build_swift/tests/build_swift/test_cache_utils.py
+++ b/utils/build_swift/tests/build_swift/test_cache_utils.py
@@ -7,8 +7,6 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 
-from __future__ import absolute_import, unicode_literals
-
 import unittest
 
 from build_swift import cache_utils

--- a/utils/build_swift/tests/build_swift/test_constants.py
+++ b/utils/build_swift/tests/build_swift/test_constants.py
@@ -7,9 +7,6 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 import os.path
 import unittest
 

--- a/utils/build_swift/tests/build_swift/test_defaults.py
+++ b/utils/build_swift/tests/build_swift/test_defaults.py
@@ -7,8 +7,6 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 
-from __future__ import absolute_import, unicode_literals
-
 import unittest
 
 from build_swift import defaults

--- a/utils/build_swift/tests/build_swift/test_driver_arguments.py
+++ b/utils/build_swift/tests/build_swift/test_driver_arguments.py
@@ -7,8 +7,6 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 
-from __future__ import absolute_import, unicode_literals
-
 import os
 import platform
 import sys

--- a/utils/build_swift/tests/build_swift/test_migration.py
+++ b/utils/build_swift/tests/build_swift/test_migration.py
@@ -7,8 +7,6 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 
-from __future__ import absolute_import, unicode_literals
-
 import platform
 import unittest
 

--- a/utils/build_swift/tests/build_swift/test_presets.py
+++ b/utils/build_swift/tests/build_swift/test_presets.py
@@ -7,8 +7,6 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 
-from __future__ import unicode_literals
-
 import configparser
 import os
 import unittest

--- a/utils/build_swift/tests/build_swift/test_shell.py
+++ b/utils/build_swift/tests/build_swift/test_shell.py
@@ -65,7 +65,7 @@ class TestHelpers(unittest.TestCase):
 
         result = shell._flatmap(duplicate, [1, 2, 3])
 
-        self.assertIsInstance(result, collections.Iterable)
+        self.assertIsInstance(result, collections.abc.Iterable)
         self.assertEqual(list(result), [1, 1, 2, 2, 3, 3])
 
     # -------------------------------------------------------------------------

--- a/utils/build_swift/tests/build_swift/test_shell.py
+++ b/utils/build_swift/tests/build_swift/test_shell.py
@@ -7,8 +7,6 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 
-from __future__ import absolute_import, unicode_literals
-
 import builtins
 import collections
 import sys

--- a/utils/build_swift/tests/build_swift/test_versions.py
+++ b/utils/build_swift/tests/build_swift/test_versions.py
@@ -7,8 +7,6 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 
-from __future__ import absolute_import, unicode_literals
-
 import unittest
 
 from build_swift.versions import Version

--- a/utils/build_swift/tests/build_swift/wrappers/test_xcrun.py
+++ b/utils/build_swift/tests/build_swift/wrappers/test_xcrun.py
@@ -7,8 +7,6 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 
-from __future__ import absolute_import, unicode_literals
-
 import os.path
 import unittest
 

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -7,8 +7,6 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 
-from __future__ import absolute_import, unicode_literals
-
 import multiprocessing
 
 from build_swift import argparse

--- a/utils/build_swift/tests/utils.py
+++ b/utils/build_swift/tests/utils.py
@@ -7,8 +7,6 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 
-from __future__ import absolute_import, unicode_literals
-
 import functools
 import os
 import platform

--- a/utils/check_freestanding_dependencies.py
+++ b/utils/check_freestanding_dependencies.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This source file is part of the Swift.org open source project
 #

--- a/utils/check_freestanding_size.py
+++ b/utils/check_freestanding_size.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This source file is part of the Swift.org open source project
 #

--- a/utils/chex.py
+++ b/utils/chex.py
@@ -1,10 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Check HEX -- a stupid filter that allows hexadecimal literals to be checked
 # for in LLVM IR FileCheck tests. It works by replacing occurrences of
 # strings matching the regex /< (i[0-9]+) \s+ (0x[0-9A-Fa-f]+) >/x with the
 # decimal literal equivalent that would really appear in printed LLVM IR.
-
-from __future__ import print_function
 
 import re
 import sys

--- a/utils/cmpcodesize/cmpcodesize.py
+++ b/utils/cmpcodesize/cmpcodesize.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # cmpcodesize.py - Compare sizes of built products -*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/utils/cmpcodesize/cmpcodesize/compare.py
+++ b/utils/cmpcodesize/cmpcodesize/compare.py
@@ -8,8 +8,6 @@
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-from __future__ import print_function
-
 import collections
 import os
 import re

--- a/utils/cmpcodesize/cmpcodesize/main.py
+++ b/utils/cmpcodesize/cmpcodesize/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # cmpcodesize/main.py - Command-line entry point for cmpcodesize -*- python -*-
 #
 # This source file is part of the Swift.org open source project
@@ -8,8 +8,6 @@
 #
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-
-from __future__ import print_function
 
 import argparse
 import collections

--- a/utils/coverage/coverage-build-db
+++ b/utils/coverage/coverage-build-db
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # utils/coverage/coverage-build-db - Build sqlite3 database from profdata
 #
 # This source file is part of the Swift.org open source project

--- a/utils/coverage/coverage-generate-data
+++ b/utils/coverage/coverage-generate-data
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # utils/coverage/coverage-generate-data - Generate, parse test run profdata
 #
 # This source file is part of the Swift.org open source project

--- a/utils/coverage/coverage-query-db
+++ b/utils/coverage/coverage-query-db
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # utils/coverage/coverage-query-db - Find covering tests using coverage
 # database
 #

--- a/utils/coverage/coverage-touch-tests
+++ b/utils/coverage/coverage-touch-tests
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # utils/coverage/coverage-touch-tests - Touch tests covering git changes
 #
 # This source file is part of the Swift.org open source project
@@ -8,8 +8,6 @@
 #
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-
-from __future__ import print_function
 
 import argparse
 import logging

--- a/utils/create-filecheck-test.py
+++ b/utils/create-filecheck-test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # The following script takes as input a SIL fragment and changes all
 # SSA variables into FileCheck variables. This significantly reduces

--- a/utils/dev-scripts/blockifyasm
+++ b/utils/dev-scripts/blockifyasm
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # blockifyasm ----- Split disassembly into basic blocks ---------*- python -*-
 #
 # This source file is part of the Swift.org open source project
@@ -21,8 +21,6 @@
 # $ blockifyasm < file.s | viewcfg
 #
 # ----------------------------------------------------------------------------
-
-from __future__ import print_function
 
 import re
 import sys

--- a/utils/dev-scripts/csvcolumn_to_scurve.py
+++ b/utils/dev-scripts/csvcolumn_to_scurve.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This is a simple script that reads in a csv file, selects a column, and then
 # forms an "s-curve" graph of that column.

--- a/utils/dev-scripts/scurve_printer.py
+++ b/utils/dev-scripts/scurve_printer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This is a simple script that takes in an scurve file produced by
 # csvcolumn_to_scurve and produces a png graph of the scurve.

--- a/utils/dev-scripts/split-cmdline
+++ b/utils/dev-scripts/split-cmdline
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # split-cmdline - Split swift compiler command lines ------------*- python -*-
 #
 # This source file is part of the Swift.org open source project
@@ -35,8 +35,6 @@
 # :'<,'>!split-cmdline
 #
 # ----------------------------------------------------------------------------
-
-from __future__ import print_function
 
 import os
 import re

--- a/utils/generate_confusables.py
+++ b/utils/generate_confusables.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 # utils/update_confusables.py - Utility to update definitions of unicode
 # confusables

--- a/utils/gyb.py
+++ b/utils/gyb.py
@@ -2,8 +2,6 @@
 # GYB: Generate Your Boilerplate (improved names welcome; at least
 # this one's short).  See -h output for instructions
 
-from __future__ import print_function
-
 import io
 import os
 import re

--- a/utils/gyb_syntax_support/Node.py
+++ b/utils/gyb_syntax_support/Node.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import sys  # noqa: I201
 
 from .kinds import SYNTAX_BASE_KINDS, kind_to_type, lowercase_first_word

--- a/utils/gyb_syntax_support/Traits.py
+++ b/utils/gyb_syntax_support/Traits.py
@@ -1,4 +1,4 @@
-from Child import Child
+from .Child import Child
 
 
 class Trait(object):

--- a/utils/incrparse/incr_transfer_round_trip.py
+++ b/utils/incrparse/incr_transfer_round_trip.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-
-from __future__ import print_function
+#!/usr/bin/env python3
 
 import argparse
 import os

--- a/utils/incrparse/test_util.py
+++ b/utils/incrparse/test_util.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-
-from __future__ import print_function
+#!/usr/bin/env python3
 
 import argparse
 import io

--- a/utils/incrparse/validate_parse.py
+++ b/utils/incrparse/validate_parse.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-
-from __future__ import print_function
+#!/usr/bin/env python3
 
 import argparse
 import difflib

--- a/utils/jobstats/__init__.py
+++ b/utils/jobstats/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # ==-- jobstats - support for reading the contents of stats dirs --==#
 #

--- a/utils/jobstats/jobstats.py
+++ b/utils/jobstats/jobstats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # ==-- jobstats - support for reading the contents of stats dirs --==#
 #

--- a/utils/line-directive
+++ b/utils/line-directive
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # line-directive.py - Transform line numbers in error messages -*- python -*-
 #
 # This source file is part of the Swift.org open source project
@@ -10,8 +10,6 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 #
 # ----------------------------------------------------------------------------
-from __future__ import print_function
-
 import bisect
 import io
 import os

--- a/utils/lldb/lldbCheckExpect.py
+++ b/utils/lldb/lldbCheckExpect.py
@@ -21,7 +21,6 @@ this, e.g:
       Expected value  : 98
       Actual value    : ...
 '''
-from __future__ import print_function
 
 
 def unwrap(s):

--- a/utils/lldb/lldbToolBox.py
+++ b/utils/lldb/lldbToolBox.py
@@ -6,8 +6,6 @@ Load into LLDB with 'command script import /path/to/lldbToolBox.py'
 This will also import LLVM data formatters as well, assuming that llvm is next
 to the swift checkout.
 """
-from __future__ import print_function
-
 import argparse
 import os
 import shlex

--- a/utils/optimizer_counters_to_sql.py
+++ b/utils/optimizer_counters_to_sql.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # optimizer_counters_to_sql.py - Store CSV counters into SQLite  -*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/utils/pass-pipeline/scripts/pipeline_generator.py
+++ b/utils/pass-pipeline/scripts/pipeline_generator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import json

--- a/utils/pass-pipeline/scripts/pipelines_build_script.py
+++ b/utils/pass-pipeline/scripts/pipelines_build_script.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import os

--- a/utils/process-stats-dir.py
+++ b/utils/process-stats-dir.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # ==-- process-stats-dir - summarize one or more Swift -stats-output-dirs --==#
 #

--- a/utils/protocol_graph.py
+++ b/utils/protocol_graph.py
@@ -23,8 +23,6 @@
 #
 # ===---------------------------------------------------------------------===//
 
-from __future__ import print_function
-
 import cgi
 import os
 import re

--- a/utils/pygments/swift.py
+++ b/utils/pygments/swift.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import re
 

--- a/utils/python_lint.py
+++ b/utils/python_lint.py
@@ -16,8 +16,6 @@ sources.
 """
 
 
-from __future__ import absolute_import, print_function, unicode_literals
-
 import os
 import subprocess
 import sys

--- a/utils/recursive-lipo
+++ b/utils/recursive-lipo
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-
-from __future__ import print_function
+#!/usr/bin/env python3
 
 import argparse
 import filecmp

--- a/utils/refactor-check-compiles.py
+++ b/utils/refactor-check-compiles.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-from __future__ import print_function
-
+#!/usr/bin/env python3
 import argparse
 import os
 import subprocess

--- a/utils/remote-run
+++ b/utils/remote-run
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # remote-run - Runs a command on another machine, for testing -----*- python -*-
 #
 # This source file is part of the Swift.org open source project
@@ -10,8 +10,6 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 #
 # ----------------------------------------------------------------------------
-
-from __future__ import print_function
 
 import argparse
 import os

--- a/utils/resolve-crashes.py
+++ b/utils/resolve-crashes.py
@@ -1,10 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # A small utility to take the output of a Swift validation test run
 # where some compiler crashers have been fixed, and move them into the
 # "fixed" testsuite, removing the "--crash" in the process.
-
-from __future__ import print_function
 
 import os
 import re

--- a/utils/round-trip-syntax-test
+++ b/utils/round-trip-syntax-test
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-
-from __future__ import print_function, unicode_literals
+#!/usr/bin/env python3
 
 import argparse
 import difflib

--- a/utils/rth
+++ b/utils/rth
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # utils/rth - Resilience test helper
 #
 # This source file is part of the Swift.org open source project
@@ -8,8 +8,6 @@
 #
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-
-from __future__ import print_function
 
 import argparse
 import glob

--- a/utils/run-test
+++ b/utils/run-test
@@ -9,8 +9,6 @@
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-from __future__ import print_function
-
 import multiprocessing
 import os
 import shutil

--- a/utils/rusage.py
+++ b/utils/rusage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # utils/rusage.py - Utility to measure resource usage -*- python -*-
 #
 # This source file is part of the Swift.org open source project

--- a/utils/scale-test
+++ b/utils/scale-test
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # -*- python -*-
 #
@@ -11,8 +11,6 @@
 # not-terribly-convincing estimate, try increasing --begin and --end to larger
 # values.
 #
-
-from __future__ import print_function
 
 import argparse
 import functools

--- a/utils/sil-opt-verify-all-modules.py
+++ b/utils/sil-opt-verify-all-modules.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # utils/sil-opt-verify-all-modules.py - Verifies Swift modules -*- python -*-
 #
 # This source file is part of the Swift.org open source project
@@ -8,8 +8,6 @@
 #
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-
-from __future__ import print_function
 
 import argparse
 import glob

--- a/utils/split_file.py
+++ b/utils/split_file.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This source file is part of the Swift.org open source project
 #

--- a/utils/submit-benchmark-results
+++ b/utils/submit-benchmark-results
@@ -1,8 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Utility script for submitting benchmark results to an LNT server."""
-
-from __future__ import print_function
 
 import datetime
 import errno

--- a/utils/swift-api-dump.py
+++ b/utils/swift-api-dump.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This tool dumps imported Swift APIs to help validate changes in the
 # projection of (Objective-)C APIs into Swift, which is a function of the
@@ -20,8 +20,6 @@
 #  /path/to/bin/dir/swift-api-dump.py -swift-version 4.2 -o output-dir \
 #      -s macosx iphoneos watchos appletvos
 #
-
-from __future__ import print_function
 
 import argparse
 import multiprocessing

--- a/utils/swift-bench.py
+++ b/utils/swift-bench.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # ===--- swift-bench.py ------------------------------*- coding: utf-8 -*-===//
 #
 # This source file is part of the Swift.org open source project
@@ -31,8 +31,6 @@
 #
 # Ideas for the harness improvement and development are welcomed here:
 # rdar://problem/18072938
-
-from __future__ import print_function
 
 import argparse
 import math

--- a/utils/swift-rpathize.py
+++ b/utils/swift-rpathize.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # On Darwin, dynamic libraries have an install name.  At link time, the
 # linker can work with a dylib anywhere in the filesystem, but it will

--- a/utils/swift_build_sdk_interfaces.py
+++ b/utils/swift_build_sdk_interfaces.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-
-from __future__ import print_function
+#!/usr/bin/env python3
 
 import argparse
 import errno

--- a/utils/swift_build_support/run_tests.py
+++ b/utils/swift_build_support/run_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This source file is part of the Swift.org open source project
 #
@@ -13,8 +13,6 @@
 Small script used to easily run the swift_build_support module unit tests.
 """
 
-
-from __future__ import absolute_import, unicode_literals
 
 import os
 import sys

--- a/utils/swift_build_support/swift_build_support/cmake.py
+++ b/utils/swift_build_support/swift_build_support/cmake.py
@@ -15,8 +15,6 @@
 # ----------------------------------------------------------------------------
 
 
-from __future__ import absolute_import, unicode_literals
-
 import os
 import platform
 import re

--- a/utils/swift_build_support/swift_build_support/shell.py
+++ b/utils/swift_build_support/swift_build_support/shell.py
@@ -13,8 +13,6 @@ Centralized command line and file system interface for the build script.
 """
 # ----------------------------------------------------------------------------
 
-from __future__ import print_function
-
 import os
 import pipes
 import platform

--- a/utils/swift_build_support/swift_build_support/toolchain.py
+++ b/utils/swift_build_support/swift_build_support/toolchain.py
@@ -14,8 +14,6 @@ Represent toolchain - the versioned executables.
 """
 # ----------------------------------------------------------------------------
 
-from __future__ import absolute_import
-
 import os
 import platform
 

--- a/utils/swift_build_support/swift_build_support/utils.py
+++ b/utils/swift_build_support/swift_build_support/utils.py
@@ -10,8 +10,6 @@
 #
 # ===---------------------------------------------------------------------===#
 
-from __future__ import absolute_import, print_function, unicode_literals
-
 import sys
 
 

--- a/utils/swift_build_support/tests/mock-distcc
+++ b/utils/swift_build_support/tests/mock-distcc
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # mock-distcc - discc mock used from tests ----------------------*- python -*-
 #
 # This source file is part of the Swift.org open source project
@@ -8,8 +8,6 @@
 #
 # See https://swift.org/LICENSE.txt for license information
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-
-from __future__ import print_function
 
 import sys
 

--- a/utils/swift_build_support/tests/test_build_graph.py
+++ b/utils/swift_build_support/tests/test_build_graph.py
@@ -9,8 +9,6 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 
-from __future__ import absolute_import, unicode_literals
-
 import unittest
 
 from swift_build_support import build_graph

--- a/utils/swift_build_support/tests/test_cmake.py
+++ b/utils/swift_build_support/tests/test_cmake.py
@@ -9,8 +9,6 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 
-from __future__ import absolute_import, unicode_literals
-
 import os
 import platform
 import unittest

--- a/utils/symbolicate-linux-fatal
+++ b/utils/symbolicate-linux-fatal
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # symbolicate-linux-fatal - Symbolicate Linux stack traces -*- python -*-
 #
 # This source file is part of the Swift.org open source project
@@ -21,8 +21,6 @@
 # * search symbols by name for the not <unavailable> ones
 #
 # ----------------------------------------------------------------------------
-
-from __future__ import print_function
 
 import argparse
 import datetime

--- a/utils/type-layout-fuzzer.py
+++ b/utils/type-layout-fuzzer.py
@@ -1,11 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This script outputs a Swift source with randomly-generated type definitions,
 # which can be used for ABI or layout algorithm fuzzing.
 
 # TODO: generate types with generics, existentials, compositions
-
-from __future__ import print_function
 
 import random
 import sys

--- a/utils/viewcfg
+++ b/utils/viewcfg
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # viewcfg - A script for viewing the CFG of SIL and LLVM IR -*- python -*-
 #
 # This source file is part of the Swift.org open source project
@@ -25,8 +25,6 @@
 # with the Graphviz app.
 #
 # ----------------------------------------------------------------------------
-
-from __future__ import print_function
 
 import argparse
 import re

--- a/utils/vim/swift-indent.py
+++ b/utils/vim/swift-indent.py
@@ -27,8 +27,6 @@
 # It operates on the current, potentially unsaved buffer and does not create or
 # save any files.  To revert a indenting, just undo.
 
-from __future__ import print_function
-
 import difflib
 import platform
 import subprocess

--- a/validation-test/ParseableInterface/verify_all_overlays.py
+++ b/validation-test/ParseableInterface/verify_all_overlays.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Note that this test should still "pass" when no swiftinterfaces have been
 # generated.
@@ -17,8 +17,6 @@
 # Expected failures by platform
 # -----------------------------
 # (none)
-
-from __future__ import print_function
 
 import os
 import subprocess

--- a/validation-test/SIL/verify_all_overlays.py
+++ b/validation-test/SIL/verify_all_overlays.py
@@ -8,8 +8,6 @@
 # REQUIRES: nonexecutable_test
 
 
-from __future__ import print_function
-
 import os
 import subprocess
 import sys

--- a/validation-test/stdlib/FixedPoint.swift.gyb
+++ b/validation-test/stdlib/FixedPoint.swift.gyb
@@ -13,7 +13,6 @@ var FixedPoint = TestSuite("FixedPoint")
 
 %{
 
-from __future__ import division
 import gyb
 from SwiftIntTypes import all_integer_types
 

--- a/validation-test/stdlib/UnicodeTrieGenerator.gyb
+++ b/validation-test/stdlib/UnicodeTrieGenerator.gyb
@@ -2,8 +2,6 @@
 
 # RUN: %empty-directory(%t) && %gyb %s | %FileCheck %s
 
-from __future__ import print_function
-
 from GYBUnicodeDataUtils import *
 
 def test_trie_generation(property_table, configure_generator=None):


### PR DESCRIPTION
**Explanation**: Support Ubuntu 22.04 for Swift 5.7
**Resolves**: Ubuntu 22.04 requires Python 3, and we are missing few changes from main branch.
**Risk**: Low
**Testing**: Verify with CI testing
**GitHub Issue**: https://github.com/apple/swift/issues/60465