### PR TITLE
Sema: Fix deep equality matching for parameterized protocol types

### DIFF
--- a/include/swift/Sema/ConstraintLocatorPathElts.def
+++ b/include/swift/Sema/ConstraintLocatorPathElts.def
@@ -72,8 +72,11 @@ CUSTOM_LOCATOR_PATH_ELT(ContextualType)
 /// A result of an expression involving dynamic lookup.
 SIMPLE_LOCATOR_PATH_ELT(DynamicLookupResult)
 
-/// The superclass of a protocol existential type.
-SIMPLE_LOCATOR_PATH_ELT(ExistentialSuperclassType)
+/// The superclass of a protocol composition type.
+SIMPLE_LOCATOR_PATH_ELT(ProtocolCompositionSuperclassType)
+
+/// The constraint of an existential type.
+SIMPLE_LOCATOR_PATH_ELT(ExistentialConstraintType)
 
 /// The argument type of a function.
 SIMPLE_LOCATOR_PATH_ELT(FunctionArgument)

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -56,7 +56,8 @@ unsigned LocatorPathElt::getNewSummaryFlags() const {
   case ConstraintLocator::MemberRefBase:
   case ConstraintLocator::UnresolvedMember:
   case ConstraintLocator::ParentType:
-  case ConstraintLocator::ExistentialSuperclassType:
+  case ConstraintLocator::ExistentialConstraintType:
+  case ConstraintLocator::ProtocolCompositionSuperclassType:
   case ConstraintLocator::LValueConversion:
   case ConstraintLocator::DynamicType:
   case ConstraintLocator::SubscriptMember:
@@ -247,8 +248,12 @@ void LocatorPathElt::dump(raw_ostream &out) const {
     out << "parent type";
     break;
 
-  case ConstraintLocator::ExistentialSuperclassType:
-    out << "existential superclass type";
+  case ConstraintLocator::ExistentialConstraintType:
+    out << "existential constraint type";
+    break;
+
+  case ConstraintLocator::ProtocolCompositionSuperclassType:
+    out << "protocol composition superclass type";
     break;
 
   case ConstraintLocator::LValueConversion:

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5227,7 +5227,8 @@ void constraints::simplifyLocator(ASTNode &anchor,
     case ConstraintLocator::PlaceholderType:
     case ConstraintLocator::SequenceElementType:
     case ConstraintLocator::ConstructorMemberType:
-    case ConstraintLocator::ExistentialSuperclassType:
+    case ConstraintLocator::ExistentialConstraintType:
+    case ConstraintLocator::ProtocolCompositionSuperclassType:
       break;
 
     case ConstraintLocator::GenericArgument:

--- a/test/Constraints/parameterized_existentials.swift
+++ b/test/Constraints/parameterized_existentials.swift
@@ -1,0 +1,48 @@
+// RUN: %target-typecheck-verify-swift -disable-availability-checking
+
+protocol P<A> {
+  associatedtype A
+}
+
+func f1(x: any P) -> any P<Int> {
+  // FIXME: Bad diagnostic
+  return x // expected-error {{type of expression is ambiguous without more context}}
+}
+
+func f2(x: any P<Int>) -> any P {
+  return x // okay
+}
+
+func f3(x: any P<Int>) -> any P<String> {
+  // FIXME: Misleading diagnostic
+  return x // expected-error {{cannot convert return expression of type 'String' to return type 'Int'}}
+}
+
+struct G<T> {}
+// expected-note@-1 {{arguments to generic parameter 'T' ('any P<Int>' and 'any P') are expected to be equal}}
+// expected-note@-2 {{arguments to generic parameter 'T' ('any P' and 'any P<Int>') are expected to be equal}}
+// expected-note@-3 {{arguments to generic parameter 'T' ('any P<Int>' and 'any P<String>') are expected to be equal}}
+
+func g1(x: G<any P>) -> G<any P<Int>> {
+  return x // expected-error {{cannot convert return expression of type 'G<any P>' to return type 'G<any P<Int>>'}}
+}
+
+func g2(x: G<any P<Int>>) -> G<any P> {
+  return x // expected-error {{cannot convert return expression of type 'G<any P<Int>>' to return type 'G<any P>'}}
+}
+
+func g3(x: G<any P<Int>>) -> G<any P<String>> {
+  return x // expected-error {{cannot convert return expression of type 'G<any P<Int>>' to return type 'G<any P<String>>'}}
+}
+
+func h1(x: (any P)?) -> (any P<Int>)? {
+  return x // expected-error {{cannot convert return expression of type '(any P)?' to return type '(any P<Int>)?'}}
+}
+
+func h2(x: (any P<Int>)?) -> (any P)? {
+  return x // okay
+}
+
+func h3(x: (any P<Int>)?) -> (any P<String>)? {
+  return x // expected-error {{cannot convert return expression of type '(any P<Int>)?' to return type '(any P<String>)?'}}
+}


### PR DESCRIPTION
We would erroneously consider an equality constraint solved if the two sides were different parameterizations of the same protocol. This triggered a crash in coerceToType().

Fixes rdar://problem/98356057.