### PR TITLE
[move-keyword] Put the move keyword behind the experimental move only flag for now.

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -368,6 +368,13 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
     }
 
     void checkMoveExpr(MoveExpr *moveExpr) {
+      // Make sure the MoveOnly feature is set. If not, error.
+      if (!Ctx.LangOpts.hasFeature(Feature::MoveOnly)) {
+        auto error =
+          diag::experimental_moveonly_feature_can_only_be_used_when_enabled;
+        Ctx.Diags.diagnose(moveExpr->getLoc(), error);
+      }
+
       if (!isa<DeclRefExpr>(moveExpr->getSubExpr())) {
         Ctx.Diags.diagnose(moveExpr->getLoc(),
                            diag::move_expression_not_passed_lvalue);

--- a/test/DebugInfo/move_function_dbginfo.swift
+++ b/test/DebugInfo/move_function_dbginfo.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -parse-as-library -g -emit-ir -o - %s | %FileCheck %s
-// RUN: %target-swift-frontend -parse-as-library -g -c %s -o %t/out.o
+// RUN: %target-swift-frontend -enable-experimental-move-only -parse-as-library -g -emit-ir -o - %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-experimental-move-only -parse-as-library -g -c %s -o %t/out.o
 // RUN: %llvm-dwarfdump --show-children %t/out.o | %FileCheck -check-prefix=DWARF %s
 
 // This test checks that:

--- a/test/DebugInfo/move_function_dbginfo_async.swift
+++ b/test/DebugInfo/move_function_dbginfo_async.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -parse-as-library -disable-availability-checking -g -emit-sil -o - %s | %FileCheck -check-prefix=SIL %s
-// RUN: %target-swift-frontend -parse-as-library -disable-availability-checking -g -emit-ir -o - %s | %FileCheck %s
-// RUN: %target-swift-frontend -parse-as-library -disable-availability-checking -g -c %s -o %t/out.o
+// RUN: %target-swift-frontend -parse-as-library -enable-experimental-move-only -disable-availability-checking -g -emit-sil -o - %s | %FileCheck -check-prefix=SIL %s
+// RUN: %target-swift-frontend -parse-as-library -enable-experimental-move-only -disable-availability-checking -g -emit-ir -o - %s | %FileCheck %s
+// RUN: %target-swift-frontend -parse-as-library -enable-experimental-move-only -disable-availability-checking -g -c %s -o %t/out.o
 // RUN: %llvm-dwarfdump --show-children %t/out.o | %FileCheck -check-prefix=DWARF %s
 
 // This test checks that:

--- a/test/Parse/move_expr.swift
+++ b/test/Parse/move_expr.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift  -disable-availability-checking
+// RUN: %target-typecheck-verify-swift  -disable-availability-checking -enable-experimental-move-only
 
 var global: Int = 5
 func testGlobal() {

--- a/test/Sema/move_expr.swift
+++ b/test/Sema/move_expr.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift  -disable-availability-checking
+// RUN: %target-typecheck-verify-swift  -disable-availability-checking -enable-experimental-move-only
 
 class Klass {
     var k: Klass? = nil

--- a/test/stdlib/LifetimeManagement.swift
+++ b/test/stdlib/LifetimeManagement.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-move-only)
 
 // REQUIRES: executable_test
 

--- a/test/stdlib/move_function.swift
+++ b/test/stdlib/move_function.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-stdlib-swift(-Xllvm -sil-disable-pass=DestroyHoisting)
+// RUN: %target-run-stdlib-swift(-Xllvm -sil-disable-pass=DestroyHoisting -Xfrontend -enable-experimental-move-only)
 //
 // NOTE ON ABOVE: I am disabling destroy hoisting on this test since we are
 // going to move it out of the mandatory pipeline eventually and it causes the


### PR DESCRIPTION
Originally move when it was in the stdlib as _move was behind a keyword but we
moved it in front to allow for some testing. Now that we are going with a
keyword (which we can't leave in/deprecate) move it behind the move only
experimental flag until this gets through evolution.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
