### PR TITLE
[5.7] [Sema] Diagnose 'nonisolated' attribute on wrapped properties

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4792,7 +4792,7 @@ ERROR(nonisolated_actor_sync_init,none,
       "'nonisolated' on an actor's synchronous initializer is invalid",
       ())
 ERROR(nonisolated_wrapped_property,none,
-      "'nonisolated' is not supported on wrapped properties",
+      "'nonisolated' is not supported on properties with property wrappers",
       ())
 
 ERROR(actor_instance_property_wrapper,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4791,6 +4791,9 @@ ERROR(nonisolated_local_var,none,
 ERROR(nonisolated_actor_sync_init,none,
       "'nonisolated' on an actor's synchronous initializer is invalid",
       ())
+ERROR(nonisolated_wrapped_property,none,
+      "'nonisolated' is not supported on wrapped properties",
+      ())
 
 ERROR(actor_instance_property_wrapper,none,
       "%0 property in property wrapper type %1 cannot be isolated to "

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5862,6 +5862,16 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
       }
     }
 
+    // We do not support 'nonisolated' on wrapped properties, because
+    // the backing property is a 'var' and so we cannot mark it as
+    // 'nonisolated'. In the future, we could support it by allowing
+    // users to mark the backing property as a 'let' and then it could
+    // also be marked as 'nonisolated'.
+    if (var->hasAttachedPropertyWrapper()) {
+      diagnoseAndRemoveAttr(attr, diag::nonisolated_wrapped_property);
+      return;
+    }
+
     // nonisolated can not be applied to local properties.
     if (dc->isLocalContext()) {
       diagnoseAndRemoveAttr(attr, diag::nonisolated_local_var);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5862,11 +5862,9 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
       }
     }
 
-    // We do not support 'nonisolated' on wrapped properties, because
-    // the backing property is a 'var' and so we cannot mark it as
-    // 'nonisolated'. In the future, we could support it by allowing
-    // users to mark the backing property as a 'let' and then it could
-    // also be marked as 'nonisolated'.
+    // Using 'nonisolated' with wrapped properties is unsupported, because
+    // backing storage is a stored 'var' that is part of the internal state
+    // of the actor which could only be accessed in actor's isolation context.
     if (var->hasAttachedPropertyWrapper()) {
       diagnoseAndRemoveAttr(attr, diag::nonisolated_wrapped_property);
       return;

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -465,7 +465,7 @@ struct SimplePropertyWrapper {
 @MainActor
 class WrappedContainsNonisolatedAttr {
   @SimplePropertyWrapper nonisolated var value 
-  // expected-error@-1 {{'nonisolated' is not supported on wrapped properties}}
+  // expected-error@-1 {{'nonisolated' is not supported on properties with property wrappers}}
   // expected-note@-2 2{{property declared here}}
 
   nonisolated func test() {

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -456,6 +456,23 @@ func testInferredFromWrapper(x: InferredFromPropertyWrapper) { // expected-note{
   _ = x.test() // expected-error{{call to global actor 'SomeGlobalActor'-isolated instance method 'test()' in a synchronous nonisolated context}}
 }
 
+@propertyWrapper 
+struct SimplePropertyWrapper {
+  var wrappedValue: Int { .zero }
+  var projectedValue: Int { .max }
+}
+
+@MainActor
+class WrappedContainsNonisolatedAttr {
+  @SimplePropertyWrapper nonisolated var value 
+  // expected-error@-1 {{'nonisolated' is not supported on wrapped properties}}
+  // expected-note@-2 2{{property declared here}}
+
+  nonisolated func test() {
+    _ = value // expected-error {{main actor-isolated property 'value' can not be referenced from a non-isolated context}}
+    _ = $value // expected-error {{main actor-isolated property '$value' can not be referenced from a non-isolated context}}
+  }
+}
 
 
 // ----------------------------------------------------------------------


### PR DESCRIPTION
**Description:** Diagnose use of `nonisolated` on wrapped properties, because we currently do not support it. This is because the backing property is a stored `var` and so cannot be marked as `nonisolated` at the moment.

**Risk:** Low, adding a new diagnostic to disallow execution of code that is not safe
**Review by:** @xedin, @hborla 
**Testing:** PR Testing
**Original PR:** https://github.com/apple/swift/pull/60475