### PR TITLE
[Sema] Check for function type when validating Sendable attribute applied to typealias

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2846,6 +2846,19 @@ TypeResolver::resolveAttributedType(TypeAttributes &attrs, TypeRepr *repr,
   }
 
   if (hasFunctionAttr && !fnRepr) {
+
+    if (attrs.has(TAK_Sendable)) {
+      // A Sendable closure must be attached to a function type. If the
+      // attribute is attached to a typealias that points to a function type,
+      // then we won't have a FunctionTypeRepr. So just ignore the repr and just
+      // check whether we have a function type. If we don't, the code below will
+      // emit a diagnostic later on.
+      if (ty->is<FunctionType>()) {
+        // Ok, remove the attribute from the set so we don't diagnose.
+        attrs.clearAttribute(TAK_Sendable);
+      }
+    }
+
     const auto diagnoseInvalidAttr = [&](TypeAttrKind kind) {
       if (kind == TAK_escaping) {
         Type optionalObjectType = ty->getOptionalObjectType();

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -113,3 +113,9 @@ class SendableSubclass: NSClass, @unchecked Sendable { }
 func testSubclassing(obj: SendableSubclass) async {
   acceptCV(obj) // okay!
 }
+
+// https://github.com/apple/swift/issues/60488
+typealias VoidFunction = () -> Void
+func testSendableTypealiasClosure1(callback: @Sendable VoidFunction) {} // ok
+func testSendableTypealiasClosure2(callback: @Sendable () -> Void) {} // ok
+func testSendableTypealiasClosure3(callback: @Sendable Void) {} // expected-error {{@Sendable attribute only applies to function types}}


### PR DESCRIPTION
Resolves #60488

A `Sendable` attribute can be applied to function types, but we currently reject it if it is applied to a typealias that points to a function type:

```swift
typealias Callback = () -> Void
func foo(callback: @Sendable Callback) {} // error: @Sendable attribute only applies to function types
func bar(callback: @Sendable () -> Void) {} // no error
```

This is because we don't have a `FunctionTypeRepr` in this case (because of the typealias), but we do have a function type. So ignore the repr and only check for the presence of a function type.