### PR TITLE
[test] Add any_pattern in tuple pattern element extra tests

### DIFF
--- a/test/Constraints/overload.swift
+++ b/test/Constraints/overload.swift
@@ -258,13 +258,6 @@ func rdar79672230() {
   test(&t) // expected-error {{no exact matches in call to local function 'test'}}
 }
 
-// https://github.com/apple/swift/issues/60029
-for (key, values) in oldName { // expected-error{{cannot find 'oldName' in scope}}
-  for (idx, value) in values.enumerated() {
-    print(key, idx, value)
-  }
-}
-
 // rdar://97396399 - crash in swift::DiagnosticEngine::formatDiagnosticText
 func rdar97396399() {
   // Has to be overloaded to make sure that contextual type is not recorded during constraint generation

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -520,3 +520,16 @@ func rdar80797176 () {
   for x: Int in [1, 2] where x.bitWidth == 32 { // Ok
   }
 }
+
+// https://github.com/apple/swift/issues/60029
+for (key, values) in oldName { // expected-error{{cannot find 'oldName' in scope}}
+  for (idx, value) in values.enumerated() {
+    print(key, idx, value)
+  }
+}
+
+// https://github.com/apple/swift/issues/60503
+func f60503() {
+  let (key, _) = settings.enumerate() // expected-error{{cannot find 'settings' in scope}}
+  let (_, _) = settings.enumerate() // expected-error{{cannot find 'settings' in scope}}
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
AnyPattern in tuple pattern element should be able to be hole in the same way as named patterns. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves https://github.com/apple/swift/issues/60503.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
