### PR TITLE
Swift Optimizer: add `AccessUtils`

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/AccessDumper.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/AccessDumper.swift
@@ -1,0 +1,68 @@
+//===--- AccessDumper.swift - Dump access information  --------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SIL
+
+/// Dumps access information for memory accesses (`load` and `store`)
+/// instructions.
+///
+/// This pass is used for testing `AccessUtils`.
+let accessDumper = FunctionPass(name: "dump-access", {
+  (function: Function, context: PassContext) in
+  print("Accesses for \(function.name)")
+
+  var apw = AccessPathWalker()
+  var arw = AccessStoragePathVisitor()
+  for block in function.blocks {
+    for instr in block.instructions {
+      switch instr {
+      case let st as StoreInst:
+        printAccessInfo(st.destinationOperand.value, &apw, &arw, context)
+      case let load as LoadInst:
+        printAccessInfo(load.operand, &apw, &arw, context)
+      default:
+        break
+      }
+    }
+  }
+
+  print("End accesses for \(function.name)")
+})
+
+private struct AccessStoragePathVisitor : AccessStoragePathWalker {
+  var walkUpCache = WalkerCache<Path>()
+  mutating func visit(access: AccessStoragePath) {
+    print("    Storage: \(access.storage)")
+    print("    Path: \"\(access.path)\"")
+  }
+}
+
+private func printAccessInfo(_ value: Value, _ apw: inout AccessPathWalker, _ aspw: inout AccessStoragePathVisitor,
+                             _ ctx: PassContext) {
+  print("Value: \(value)")
+  let (ap, scope) = apw.getAccessPathWithScope(of: value)
+  if let scope = scope {
+    switch scope {
+    case let .scope(ba):
+      print("  Scope: \(ba)")
+    case .base(_):
+      print("  Scope: base")
+    }
+  }
+
+  if let ap = ap {
+    print("  Base: \(ap.base)")
+    print("  Path: \"\(ap.projectionPath)\"")
+
+    aspw.getAccessStorage(for: ap)
+  }
+}

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CMakeLists.txt
@@ -8,6 +8,7 @@
 
 swift_compiler_sources(Optimizer
   AssumeSingleThreaded.swift
+  AccessDumper.swift
   ComputeEffects.swift
   EscapeInfoDumper.swift
   ObjCBridgingOptimization.swift

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
@@ -42,6 +42,7 @@ private func registerSwiftPasses() {
   registerPass(mergeCondFailsPass, { mergeCondFailsPass.run($0) })
   registerPass(escapeInfoDumper, { escapeInfoDumper.run($0) })
   registerPass(addressEscapeInfoDumper, { addressEscapeInfoDumper.run($0) })
+  registerPass(accessDumper, { accessDumper.run($0) })
   registerPass(computeEffects, { computeEffects.run($0) })
   registerPass(objCBridgingOptimization, { objCBridgingOptimization.run($0) })
   registerPass(stackPromotion, { stackPromotion.run($0) })

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/AccessUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/AccessUtils.swift
@@ -1,0 +1,514 @@
+//===--- AccessUtils.swift - Utilities for analyzing memory accesses ------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+// This file provides a set of utilities for analyzing memory accesses.
+// It defines the following concepts
+// - `AccessBase`: represents the base address of a memory access.
+// - `AccessPath`: a pair of an `AccessBase` and `SmallProjectionPath` with the
+//   the path describing the specific address (in terms of projections) of the
+//   access.
+// - `AccessStoragePath`: identifies the reference (or a value which contains a
+//   reference) an address originates from.
+//
+// The snippet below shows the relationship between the access concepts.
+// ```
+// %ref = struct_extract %value, #f1                                         AccessStoragePath
+// %base = ref_element_addr %ref, #f2         AccessBase       AccessPath            |
+// %scope = begin_access %base                AccessScope          |                 |
+// %t = tuple_element_addr %scope, 0                               |                 |
+// %s = struct_element_addr %t, #f3                                v                 v
+// %l = load %s                               the access
+// ```
+//===----------------------------------------------------------------------===//
+import SIL
+
+/// "AccessBase describes the base address of a memory access (e.g. of a `load` or `store``).
+/// The access address is either the base address directly or an address
+/// projection of it.
+/// The following snippets show examples of memory accesses and their respective bases.
+///
+/// ```
+/// %base1 = ref_element_addr %ref, #Obj.field
+/// %base2 = alloc_stack $S
+/// %base3 = global_addr @gaddr
+/// %addr1 = struct_element_addr %base1
+/// %access1 = store %v1 to [trivial] %addr1   // accessed address is offset from base
+/// %access2 = store %v2 to [trivial] %base2   // accessed address is base itself
+/// ```
+///
+/// The base address is never inside an access scope.
+struct AccessBase : CustomStringConvertible {
+
+  public enum Kind {
+    case box
+    case stack
+    case global
+    case `class`
+    case tail
+    case argument
+    case yield
+    case pointer
+
+    var isObject: Bool { self == .class || self == .tail }
+  }
+
+  let baseAddress: Value
+  let kind: Kind
+
+  init?(baseAddress: Value) {
+    switch baseAddress {
+    case is RefElementAddrInst   : kind = .class
+    case is RefTailAddrInst      : kind = .tail
+    case is ProjectBoxInst       : kind = .box
+    case is AllocStackInst       : kind = .stack
+    case is FunctionArgument     : kind = .argument
+    case is GlobalAddrInst       : kind = .global
+    default:
+      if baseAddress.definingInstruction is BeginApplyInst &&
+         baseAddress.type.isAddress {
+        kind = .yield
+      } else {
+        return nil
+      }
+    }
+
+    self.baseAddress = baseAddress
+  }
+
+  init(baseAddress: Value, kind: Kind) {
+    self.baseAddress = baseAddress
+    self.kind = kind
+  }
+
+  var description: String {
+    "\(kind) - \(baseAddress)"
+  }
+
+  /// Returns `true` if this is an access to a class instance
+  var isObjectAccess: Bool {
+    return kind == .class || kind == .tail
+  }
+
+  /// Returns a value of reference type if this is a reference projection (class, box, tail)
+  var reference: Value? {
+    switch baseAddress {
+    case let rea as RefElementAddrInst:
+      return rea.operand
+    case let pb as ProjectBoxInst:
+      return pb.operand
+    case let rta as RefTailAddrInst:
+      return rta.operand
+    default:
+      return nil
+    }
+  }
+
+  /// Returns `true` if the baseAddress is of an immutable property/global variable
+  var isLet: Bool {
+    switch baseAddress {
+    case let rea as RefElementAddrInst:
+      return rea.fieldIsLet
+    case let ga as GlobalAddrInst:
+      return ga.global.isLet
+    default:
+      return false
+    }
+  }
+
+  /// Returns `true` if the address is immediately produced by a stack or box allocation
+  var isLocal: Bool {
+    switch kind {
+    case .box:
+      // The operand of the projection can be an argument, in which
+      // case it wouldn't be local
+      return (baseAddress as! ProjectBoxInst).operand is AllocBoxInst
+    case .class:
+      let op = (baseAddress as! RefElementAddrInst).operand
+      return op is AllocRefInst || op is AllocRefDynamicInst
+    case .stack:
+      return true
+    default:
+      return false
+    }
+  }
+
+  /// Returns `true` if we can reliably compare this `AccessBase`
+  /// with another `AccessBase` for equality.
+  /// When comparing two uniquely identified access bases and they are not equal,
+  /// it follows that the accessed memory addresses do not alias.
+  /// This is e.g. not the case for class references: two different references
+  /// may still point to the same object.
+  var isUniquelyIdentified: Bool {
+    switch kind {
+    case .box:
+      // The operand `%op` in `%baseAddress = project_box %op` can
+      // be `alloc_box` or an argument. Only if it's a fresh allocation it is
+      // uniquelyIdentified, otherwise it is aliasable, as all the other references.
+      return (baseAddress as! ProjectBoxInst).operand is AllocBoxInst
+    case .stack, .global:
+      return true
+    case .argument:
+      // An argument address that is non-aliasable
+      return (baseAddress as! FunctionArgument).isExclusiveIndirectParameter
+    case .class:
+      let op = (baseAddress as! RefElementAddrInst).operand
+      return op is AllocRefInst || op is AllocRefDynamicInst
+    case .tail, .yield, .pointer:
+      // References (.class and .tail) may alias, and so do pointers and
+      // yield results
+      return false
+    }
+  }
+
+  /// Returns `true` if the two access bases do not alias
+  func isDistinct(from other: AccessBase) -> Bool {
+    switch (baseAddress, other.baseAddress) {
+    case is (AllocStackInst, AllocStackInst):
+      return baseAddress != other.baseAddress
+    case let (this as ProjectBoxInst, that as ProjectBoxInst)
+        where this.operand is AllocBoxInst && that.operand is AllocBoxInst:
+      return this.operand != that.operand
+    case let (this as GlobalAddrInst, that as GlobalAddrInst):
+      return this.global != that.global
+    case let (this as FunctionArgument, that as FunctionArgument):
+      return (this.isExclusiveIndirectParameter || that.isExclusiveIndirectParameter) && this != that
+    case let (this as RefElementAddrInst, that as RefElementAddrInst):
+      return (this.fieldIndex != that.fieldIndex)
+    default:
+      let selfIsUniquelyIdentified = isUniquelyIdentified
+      let otherIsUniquelyIdentified = other.isUniquelyIdentified
+      if selfIsUniquelyIdentified && otherIsUniquelyIdentified && kind != other.kind { return true }
+      // property: `isUniquelyIdentified` XOR `isObject`
+      if selfIsUniquelyIdentified && other.kind.isObject { return true }
+      if kind.isObject && otherIsUniquelyIdentified { return true }
+      return false
+    }
+  }
+}
+
+/// An `AccessPath` is a pair of a `base: AccessBase` and a `projectionPath: Path`
+/// which denotes the offset of the access from the base in terms of projections.
+struct AccessPath : CustomStringConvertible {
+  let base: AccessBase
+
+  /// address projections only
+  let projectionPath: SmallProjectionPath
+
+  var description: String {
+    "\(projectionPath): \(base)"
+  }
+
+  func isDistinct(from other: AccessPath) -> Bool {
+    return
+      base.isDistinct(from: other.base) ||                            // The base is distinct, in which case we are done. OR
+      (base.baseAddress == other.base.baseAddress &&                  // (The base is the exact same AND
+      !(projectionPath.matches(pattern: other.projectionPath)         //  the projection paths do not overlap)
+        || (other.projectionPath.matches(pattern: projectionPath))))
+  }
+}
+
+/// An `AccessStoragePath` is the reference (or a value which contains a reference)
+/// an address originates from.
+/// In the following example the `storage` is `contains_ref` with `path` `"s0.c0.s0"`
+/// ```
+///   %ref = struct_extract %contains_ref : $S, #S.l
+///   %base = ref_element_addr %ref : $List, #List.x
+///   %addr = struct_element_addr %base : $X, #X.e
+///   store %v to [trivial] %addr : $*Int
+/// ```
+struct AccessStoragePath {
+  let storage: Value
+
+  /// Only valid paths are: `"<sequence of value projections>.<one reference projection>.<sequence of address projections>"`
+  let path: SmallProjectionPath
+}
+
+private func canBeOperandOfIndexAddr(_ value: Value) -> Bool {
+  switch value {
+  case is IndexAddrInst, is RefTailAddrInst, is PointerToAddressInst:
+    return true
+  default:
+    return false
+  }
+}
+
+enum AddressOrPointerArgument {
+  case address(Value)
+  case pointer(FunctionArgument)
+}
+
+extension AddressOrPointerArgument : Equatable {
+  static func ==(lhs: AddressOrPointerArgument, rhs: AddressOrPointerArgument) -> Bool {
+    switch (lhs, rhs) {
+    case let (.address(left), .address(right)):
+      return left == right
+    case let (.pointer(left), .pointer(right)):
+      return left == right
+    default:
+      return false
+    }
+  }
+}
+
+/// Given a `%addr = pointer_to_address %ptr_operand` instruction tries to identify
+/// the address the pointer operand `ptr_operand` originates from, if any exists.
+/// This is useful to identify patterns like
+/// ```
+/// %orig_addr = global_addr @...
+/// %ptr = address_to_pointer %orig_addr
+/// %addr = pointer_to_address %ptr
+/// ```
+/// which might arise when `[global_init]` functions for global addressors are inlined.
+///
+/// Alternatively, if the pointer originates from a ``FunctionArgument``, the argument is returned.
+///
+/// This underlying use-def traversal might cross phi arguments to identify the originating address
+/// to handle diamond-shaped control-flow with common originating
+/// address which might arise due to transformations ([example] (https://github.com/apple/swift/blob/8f9c5339542b17af9033f51ad7a0b95a043cad1b/test/SILOptimizer/access_storage_analysis_ossa.sil#L669-L705)) .
+struct PointerIdentification {
+  private var walker = PointerIdentificationUseDefWalker()
+
+  mutating func getOriginatingAddressOrArgument(_ atp: PointerToAddressInst) -> AddressOrPointerArgument? {
+    walker.start(atp.type)
+    if walker.walkUp(value: atp.operand, path: SmallProjectionPath()) == .abortWalk {
+      return nil
+    }
+    return walker.result
+  }
+
+  private struct PointerIdentificationUseDefWalker : ValueUseDefWalker {
+    private var addrType: Type!
+    private(set) var result: AddressOrPointerArgument?
+
+    mutating func start(_ addrType: Type) {
+      self.addrType = addrType
+      result = nil
+      walkUpCache.clear()
+    }
+
+    mutating func rootDef(value: Value, path: SmallProjectionPath) -> WalkResult {
+      switch value {
+      case let arg as FunctionArgument:
+        if let res = result, res != self.result {
+          self.result = nil
+          return .abortWalk
+        }
+        self.result = .pointer(arg)
+        return .continueWalk
+      case let atp as AddressToPointerInst:
+        if case let .address(result) = result, atp.operand != result {
+          self.result = nil
+          return .abortWalk
+        }
+
+        if addrType == atp.operand.type, path.isEmpty {
+          self.result = .address(atp.operand)
+          return .continueWalk
+        }
+      default:
+        break
+      }
+      self.result = nil
+      return .abortWalk
+    }
+
+    mutating func walkUp(value: Value, path: SmallProjectionPath) -> WalkResult {
+      switch value {
+      case is BlockArgument, is MarkDependenceInst, is CopyValueInst,
+           is StructExtractInst, is TupleExtractInst, is StructInst, is TupleInst,
+           is FunctionArgument, is AddressToPointerInst:
+        return walkUpDefault(value: value, path: path)
+      default:
+        self.result = nil
+        return .abortWalk
+      }
+    }
+
+    var walkUpCache = WalkerCache<Path>()
+  }
+}
+
+/// The `EnclosingScope` of an access is the innermost `begin_access`
+/// instruction that checks for exclusivity of the access.
+/// If there is no `begin_access` instruction found, then the scope is
+/// the base itself.
+///
+/// The access scopes for the snippet below are:
+///   (l1, .base(%addr)), (l2, .scope(%a2)), (l3, .scope(%a3))
+///
+/// ````
+/// %addr = ... : $*Int64
+/// %l1 = load %addr : $*Int64
+/// %a1 = begin_access [read] [dynamic] %addr : $*Int64
+/// %a2 = begin_access [read] [dynamic] %addr : $*Int64
+/// %l2   = load %a2 : $*Int64
+/// end_access %a2 : $*Int64
+/// end_access %a1 : $*Int64
+/// %a3 = begin_access [read] [dynamic] [no_nested_conflict] %addr : $*Int64
+/// %l3 = load %a3 : $*Int64
+/// end_access %a3 : $*Int64
+/// ```
+enum EnclosingScope {
+  case scope(BeginAccessInst)
+  case base(AccessBase)
+}
+
+/// A walker utility that, given an address value, computes the `AccessPath`
+/// of the access (the base address and the address projections to the accessed fields) and
+/// the innermost enclosing scope (`begin_access`).
+struct AccessPathWalker {
+  mutating func getAccessPath(of address: Value) -> AccessPath? {
+    assert(address.type.isAddress, "Expected address")
+    walker.start()
+    if walker.walkUp(address: address, path: Walker.Path()) == .abortWalk {
+      return nil
+    }
+    return walker.result
+  }
+
+  mutating func getAccessPathWithScope(of address: Value) -> (AccessPath?, EnclosingScope?) {
+    let ap = getAccessPath(of: address)
+    return (ap, walker.scope)
+  }
+
+  mutating func getAccessBase(of address: Value) -> AccessBase? {
+    getAccessPath(of: address)?.base
+  }
+
+  mutating func getAccessScope(of address: Value) -> EnclosingScope? {
+    getAccessPathWithScope(of: address).1
+  }
+
+  private var walker = Walker()
+
+  private struct Walker : AddressUseDefWalker {
+    private(set) var result: AccessPath? = nil
+    private var foundBeginAccess: BeginAccessInst? = nil
+    private var pointerId = PointerIdentification()
+
+    var scope: EnclosingScope? {
+      if let ba = foundBeginAccess {
+        return .scope(ba)
+      } else {
+        guard let accessPath = result else { return nil }
+        return .base(accessPath.base)
+      }
+    }
+
+    mutating func start() {
+      result = nil
+      foundBeginAccess = nil
+    }
+
+    struct Path : SmallProjectionWalkingPath {
+      let projectionPath: SmallProjectionPath
+
+      // Tracks whether an `index_addr` instruction was crossed.
+      // It should be (FIXME: check if it's enforced) that operands
+      // of `index_addr` must be `tail_addr` or other `index_addr` results.
+      let indexAddr: Bool
+
+      init(projectionPath: SmallProjectionPath = SmallProjectionPath(), indexAddr: Bool = false) {
+        self.projectionPath = projectionPath
+        self.indexAddr = indexAddr
+      }
+
+      func with(projectionPath: SmallProjectionPath) -> Self {
+        return Self(projectionPath: projectionPath, indexAddr: indexAddr)
+      }
+
+      func with(indexAddr: Bool) -> Self {
+        return Self(projectionPath: projectionPath, indexAddr: indexAddr)
+      }
+
+      func merge(with other: Self) -> Self {
+        return Self(
+          projectionPath: projectionPath.merge(with: other.projectionPath),
+          indexAddr: indexAddr || other.indexAddr
+        )
+      }
+    }
+
+    mutating func rootDef(address: Value, path: Path) -> WalkResult {
+      // Try identifying the address a pointer originates from
+      if let p2ai = address as? PointerToAddressInst {
+        if let addrOrArg = pointerId.getOriginatingAddressOrArgument(p2ai) {
+          switch addrOrArg {
+          case let .address(newAddress):
+            return walkUp(address: newAddress, path: path)
+          case let .pointer(arg):
+            self.result = AccessPath(base: AccessBase(baseAddress: arg, kind: .pointer), projectionPath: path.projectionPath)
+          }
+        } else {
+          self.result = AccessPath(base: AccessBase(baseAddress: p2ai, kind: .pointer), projectionPath: path.projectionPath)
+          return .continueWalk
+        }
+      }
+
+      // If this is a base then we're done
+      if let base = AccessBase(baseAddress: address) {
+        self.result = AccessPath(base: base, projectionPath: path.projectionPath)
+        return .continueWalk
+      }
+
+      // The base is unidentified
+      self.result = nil
+      return .abortWalk
+    }
+
+    mutating func walkUp(address: Value, path: Path) -> WalkResult {
+      if address is IndexAddrInst {
+        // Track that we crossed an `index_addr` during the walk-up
+        return walkUpDefault(address: address, path: path.with(indexAddr: true))
+      } else if path.indexAddr && !canBeOperandOfIndexAddr(address) {
+        // An `index_addr` instruction cannot be derived from an address
+        // projection. Bail out
+        self.result = nil
+        return .abortWalk
+      } else if let ba = address as? BeginAccessInst, foundBeginAccess == nil {
+        foundBeginAccess = ba
+      }
+      return walkUpDefault(address: address, path: path.with(indexAddr: false))
+    }
+  }
+}
+
+/// A ValueUseDef walker that identifies which values a reference might
+/// originate from.
+protocol AccessStoragePathWalker : ValueUseDefWalker where Path == SmallProjectionPath {
+  mutating func visit(access: AccessStoragePath)
+}
+
+extension AccessStoragePathWalker {
+  // Main entry point
+  /// Given an `ap: AccessPath` where the base address is a projection
+  /// from a reference type, returns the set of reference definitions
+  /// that the address of the access may originate from.
+  mutating func getAccessStorage(for accessPath: AccessPath) {
+    walkUpCache.clear()
+    let path = accessPath.projectionPath
+    switch accessPath.base.baseAddress {
+    case let rea as RefElementAddrInst:
+      _ = walkUp(value: rea.operand, path: path.push(.classField, index: rea.fieldIndex))
+    case let pb as ProjectBoxInst:
+      _ = walkUp(value: pb.operand, path: path.push(.classField, index: pb.fieldIndex))
+    case let rta as RefTailAddrInst:
+      _ = walkUp(value: rta.operand, path: path.push(.tailElements, index: 0))
+    default:
+      visit(access: AccessStoragePath(storage: accessPath.base.baseAddress, path: accessPath.projectionPath))
+    }
+  }
+
+  mutating func rootDef(value: Value, path: SmallProjectionPath) -> WalkResult {
+    visit(access: AccessStoragePath(storage: value, path: path))
+    return .continueWalk
+  }
+}

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/CMakeLists.txt
@@ -10,4 +10,5 @@ swift_compiler_sources(Optimizer
   EscapeInfo.swift
   OptUtils.swift
   WalkUtils.swift
+  AccessUtils.swift
 )

--- a/SwiftCompilerSources/Sources/SIL/GlobalVariable.swift
+++ b/SwiftCompilerSources/Sources/SIL/GlobalVariable.swift
@@ -32,6 +32,14 @@ final public class GlobalVariable : CustomStringConvertible, HasShortDescription
   var bridged: BridgedGlobalVar { BridgedGlobalVar(obj: SwiftObject(self)) }
 }
 
+public func ==(_ lhs: GlobalVariable, _ rhs: GlobalVariable) -> Bool {
+  return lhs === rhs
+}
+
+public func !=(_ lhs: GlobalVariable, _ rhs: GlobalVariable) -> Bool {
+  return (lhs !== rhs)
+}
+
 // Bridging utilities
 
 extension BridgedGlobalVar {

--- a/SwiftCompilerSources/Sources/SIL/GlobalVariable.swift
+++ b/SwiftCompilerSources/Sources/SIL/GlobalVariable.swift
@@ -25,6 +25,8 @@ final public class GlobalVariable : CustomStringConvertible, HasShortDescription
 
   public var shortDescription: String { name.string }
 
+  public var isLet: Bool { SILGlobalVariable_isLet(bridged) != 0 }
+
   // TODO: initializer instructions
 
   var bridged: BridgedGlobalVar { BridgedGlobalVar(obj: SwiftObject(self)) }

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -448,6 +448,8 @@ final public class UncheckedTakeEnumDataAddrInst : SingleValueInstruction, Unary
 
 final public class RefElementAddrInst : SingleValueInstruction, UnaryInstruction {
   public var fieldIndex: Int { RefElementAddrInst_fieldIndex(bridged) }
+
+  public var fieldIsLet: Bool { RefElementAddrInst_fieldIsLet(bridged) != 0 }
 }
 
 final public class RefTailAddrInst : SingleValueInstruction, UnaryInstruction {}

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -520,6 +520,20 @@ final public class BeginAccessInst : SingleValueInstruction, UnaryInstruction {
   public var accessKind: AccessKind { BeginAccessInst_getAccessKind(bridged).kind }
 }
 
+public protocol ScopedInstruction {
+  associatedtype EndInstructions
+
+  var endInstructions: EndInstructions { get }
+}
+
+extension BeginAccessInst : ScopedInstruction {
+  public typealias EndInstructions = LazyMapSequence<LazyFilterSequence<LazyMapSequence<UseList, EndAccessInst?>>, EndAccessInst>
+
+  public var endInstructions: EndInstructions {
+    uses.lazy.compactMap({ $0.value.definingInstruction as? EndAccessInst })
+  }
+}
+
 final public class BeginBorrowInst : SingleValueInstruction, UnaryInstruction {}
 
 final public class ProjectBoxInst : SingleValueInstruction, UnaryInstruction {

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -488,7 +488,35 @@ final public class BridgeObjectToRefInst : SingleValueInstruction,
 final public class BridgeObjectToWordInst : SingleValueInstruction,
                                            UnaryInstruction {}
 
-final public class BeginAccessInst : SingleValueInstruction, UnaryInstruction {}
+public enum AccessKind {
+  case initialize
+  case read
+  case modify
+  case deinitialize
+}
+
+extension BridgedAccessKind {
+  var kind: AccessKind {
+    switch self {
+    case AccessKind_Init:
+      return .initialize
+    case AccessKind_Read:
+      return .read
+    case AccessKind_Modify:
+      return .modify
+    case AccessKind_Deinit:
+      return .deinitialize
+    default:
+      fatalError("unsupported access kind")
+    }
+  }
+}
+
+
+// TODO: add support for begin_unpaired_access
+final public class BeginAccessInst : SingleValueInstruction, UnaryInstruction {
+  public var accessKind: AccessKind { BeginAccessInst_getAccessKind(bridged).kind }
+}
 
 final public class BeginBorrowInst : SingleValueInstruction, UnaryInstruction {}
 

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -141,6 +141,13 @@ typedef enum {
 } BridgedMemoryBehavior;
 
 typedef enum {
+  AccessKind_Init,
+  AccessKind_Read,
+  AccessKind_Modify,
+  AccessKind_Deinit
+} BridgedAccessKind;
+
+typedef enum {
   Ownership_Unowned,
   Ownership_Owned,
   Ownership_Guaranteed,
@@ -321,6 +328,7 @@ BridgedBasicBlock BranchInst_getTargetBlock(BridgedInstruction bi);
 SwiftInt SwitchEnumInst_getNumCases(BridgedInstruction se);
 SwiftInt SwitchEnumInst_getCaseIndex(BridgedInstruction se, SwiftInt idx);
 SwiftInt StoreInst_getStoreOwnership(BridgedInstruction store);
+BridgedAccessKind BeginAccessInst_getAccessKind(BridgedInstruction beginAccess);
 SwiftInt CopyAddrInst_isTakeOfSrc(BridgedInstruction copyAddr);
 SwiftInt CopyAddrInst_isInitializationOfDest(BridgedInstruction copyAddr);
 void RefCountingInst_setIsAtomic(BridgedInstruction rc, bool isAtomic);

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -228,6 +228,7 @@ SwiftInt SILFunction_hasSemanticsAttr(BridgedFunction function,
 
 llvm::StringRef SILGlobalVariable_getName(BridgedGlobalVar global);
 std::string SILGlobalVariable_debugDescription(BridgedGlobalVar global);
+SwiftInt SILGlobalVariable_isLet(BridgedGlobalVar global);
 
 OptionalBridgedBasicBlock SILBasicBlock_next(BridgedBasicBlock block);
 OptionalBridgedBasicBlock SILBasicBlock_previous(BridgedBasicBlock block);
@@ -316,6 +317,7 @@ SwiftInt InitEnumDataAddrInst_caseIndex(BridgedInstruction idea);
 SwiftInt UncheckedTakeEnumDataAddrInst_caseIndex(BridgedInstruction utedi);
 SwiftInt InjectEnumAddrInst_caseIndex(BridgedInstruction ieai);
 SwiftInt RefElementAddrInst_fieldIndex(BridgedInstruction reai);
+SwiftInt RefElementAddrInst_fieldIsLet(BridgedInstruction reai);
 SwiftInt PartialApplyInst_numArguments(BridgedInstruction ai);
 SwiftInt ApplyInst_numArguments(BridgedInstruction ai);
 SwiftInt PartialApply_getCalleeArgIndexOfFirstAppliedArg(BridgedInstruction pai);

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -228,6 +228,8 @@ SWIFT_FUNCTION_PASS(EscapeInfoDumper, "dump-escape-info",
      "Dumps escape information")
 SWIFT_FUNCTION_PASS(AddressEscapeInfoDumper, "dump-addr-escape-info",
      "Dumps address escape information")
+SWIFT_FUNCTION_PASS(AccessDumper, "dump-access",
+     "Dump access information")
 SWIFT_FUNCTION_PASS(ComputeEffects, "compute-effects",
      "Computes function effects")
 PASS(FlowIsolation, "flow-isolation",

--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -723,6 +723,20 @@ SwiftInt StoreInst_getStoreOwnership(BridgedInstruction store) {
   return (SwiftInt)castToInst<StoreInst>(store)->getOwnershipQualifier();
 }
 
+BridgedAccessKind BeginAccessInst_getAccessKind(BridgedInstruction beginAccess) {
+  auto kind = castToInst<BeginAccessInst>(beginAccess)->getAccessKind();
+  switch (kind) {
+    case SILAccessKind::Init:
+      return BridgedAccessKind::AccessKind_Init;
+    case SILAccessKind::Read:
+      return BridgedAccessKind::AccessKind_Read;
+    case SILAccessKind::Modify:
+      return BridgedAccessKind::AccessKind_Modify;
+    case SILAccessKind::Deinit:
+      return BridgedAccessKind::AccessKind_Deinit;
+  }
+}
+
 SwiftInt CopyAddrInst_isTakeOfSrc(BridgedInstruction copyAddr) {
   return castToInst<CopyAddrInst>(copyAddr)->isTakeOfSrc() ? 1 : 0;
 }

--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -529,6 +529,10 @@ std::string SILGlobalVariable_debugDescription(BridgedGlobalVar global) {
   return str;
 }
 
+SwiftInt SILGlobalVariable_isLet(BridgedGlobalVar global) {
+  return castToGlobal(global)->isLet();
+}
+
 //===----------------------------------------------------------------------===//
 //                               SILInstruction
 //===----------------------------------------------------------------------===//
@@ -671,6 +675,10 @@ SwiftInt InjectEnumAddrInst_caseIndex(BridgedInstruction ieai) {
 
 SwiftInt RefElementAddrInst_fieldIndex(BridgedInstruction reai) {
   return castToInst<RefElementAddrInst>(reai)->getFieldIndex();
+}
+
+SwiftInt RefElementAddrInst_fieldIsLet(BridgedInstruction reai) {
+  return castToInst<RefElementAddrInst>(reai)->getField()->isLet();
 }
 
 SwiftInt PartialApplyInst_numArguments(BridgedInstruction pai) {

--- a/test/SILOptimizer/accessutils.sil
+++ b/test/SILOptimizer/accessutils.sil
@@ -1,0 +1,324 @@
+// RUN: %target-sil-opt %s -dump-access -o /dev/null | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+class List {
+  var x: Int
+  let next: List
+}
+
+struct S {
+  var l: List
+  var y: Int
+}
+
+struct Ptr {
+  var p: Int64
+}
+
+// CHECK-LABEL: Accesses for readIdentifiedArg
+// CHECK-NEXT: Value: %0 = argument of bb0 : $*Int
+// CHECK-NEXT:   Scope: base
+// CHECK-NEXT:   Base: argument - %0 = argument of bb0 : $*Int
+// CHECK-NEXT:   Path: ""
+// CHECK-NEXT:     Storage: %0 = argument of bb0 : $*Int
+// CHECK-NEXT:     Path: ""
+// CHECK-NEXT: End accesses for readIdentifiedArg
+sil [ossa] @readIdentifiedArg : $@convention(thin) (@in Int) -> Int {
+bb0(%0 : $*Int):
+  %res = load [trivial] %0 : $*Int
+  return %res : $Int
+}
+
+// CHECK-LABEL: Accesses for writeIdentifiedArg
+// CHECK-NEXT: Value: %0 = argument of bb0 : $*Int
+// CHECK-NEXT:   Scope: base
+// CHECK-NEXT:   Base: argument - %0 = argument of bb0 : $*Int
+// CHECK-NEXT:   Path: ""
+// CHECK-NEXT:     Storage: %0 = argument of bb0 : $*Int
+// CHECK-NEXT:     Path: ""
+// CHECK-NEXT: End accesses for writeIdentifiedArg
+sil [ossa] @writeIdentifiedArg : $@convention(thin) (@inout Int) -> () {
+bb0(%0 : $*Int):
+  %2 = integer_literal $Builtin.Int64, 42
+  %3 = struct $Int (%2 : $Builtin.Int64)
+  store %3 to [trivial] %0 : $*Int
+  %5 = tuple ()
+  return %5 : $()
+}
+
+// CHECK-LABEL: Accesses for $writeToHead
+// CHECK-NEXT: Value:   %7 = begin_access [modify] [dynamic] %6 : $*Int
+// CHECK-NEXT:   Scope:   %7 = begin_access [modify] [dynamic] %6 : $*Int
+// CHECK-NEXT:   Base: class -   %6 = ref_element_addr %5 : $List, #List.x
+// CHECK-NEXT:   Path: ""
+// CHECK-NEXT:     Storage: %0 = argument of bb0 : $S
+// CHECK-NEXT:     Path: "s0.c0"
+// CHECK-NEXT: End accesses for $writeToHead
+sil [ossa] @$writeToHead : $@convention(thin) (@guaranteed S) -> () {
+bb0(%0 : @guaranteed $S):
+  debug_value %0 : $S, let, name "s", argno 1
+  %2 = struct_extract %0 : $S, #S.l
+  %3 = integer_literal $Builtin.Int64, 10
+  %4 = struct $Int (%3 : $Builtin.Int64)
+  %5 = begin_borrow [lexical] %2 : $List
+  %6 = ref_element_addr %5 : $List, #List.x
+  %7 = begin_access [modify] [dynamic] %6 : $*Int
+  store %4 to [trivial] %7 : $*Int
+  end_access %7 : $*Int
+  end_borrow %5 : $List
+  %11 = tuple ()
+  return %11 : $()
+}
+
+// CHECK-LABEL: Accesses for storeToArgs
+// CHECK-NEXT: Value:   %6 = begin_access [modify] [dynamic] %5 : $*Int
+// CHECK-NEXT:   Scope:   %6 = begin_access [modify] [dynamic] %5 : $*Int
+// CHECK-NEXT:   Base: class -   %5 = ref_element_addr %0 : $List, #List.x
+// CHECK-NEXT:   Path: ""
+// CHECK-NEXT:     Storage: %0 = argument of bb0 : $List
+// CHECK-NEXT:     Path: "c0"
+// CHECK-NEXT: Value:   %14 = begin_access [modify] [dynamic] %13 : $*Int
+// CHECK-NEXT:   Scope:   %14 = begin_access [modify] [dynamic] %13 : $*Int
+// CHECK-NEXT:   Base: class -   %13 = ref_element_addr %1 : $List, #List.x
+// CHECK-NEXT:   Path: ""
+// CHECK-NEXT:     Storage: %1 = argument of bb0 : $List
+// CHECK-NEXT:     Path: "c0"
+// CHECK-NEXT: End accesses for storeToArgs
+sil [ossa] @storeToArgs : $@convention(thin) (@guaranteed List, @guaranteed List) -> () {
+bb0(%1 : @guaranteed $List, %2 : @guaranteed $List):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %8 = integer_literal $Builtin.Int64, 10
+  %9 = struct $Int (%8 : $Builtin.Int64)
+  %10 = ref_element_addr %1 : $List, #List.x
+  %11 = begin_access [modify] [dynamic] %10 : $*Int
+  store %9 to [trivial] %11 : $*Int
+  end_access %11 : $*Int
+  %14 = tuple ()
+  br bb3
+
+bb2:
+  %16 = integer_literal $Builtin.Int64, 20
+  %17 = struct $Int (%16 : $Builtin.Int64)
+  %18 = ref_element_addr %2 : $List, #List.x
+  %19 = begin_access [modify] [dynamic] %18 : $*Int
+  store %17 to [trivial] %19 : $*Int
+  end_access %19 : $*Int
+  %22 = tuple ()
+  br bb3
+
+bb3:
+  %24 = tuple ()
+  return %24 : $()
+}
+
+// CHECK-LABEL: Accesses for storeMaybeLocalPhi
+// CHECK-NEXT: Value:   %10 = begin_access [modify] [dynamic] %9 : $*Int
+// CHECK-NEXT:   Scope:   %10 = begin_access [modify] [dynamic] %9 : $*Int
+// CHECK-NEXT:   Base: class -   %9 = ref_element_addr %6 : $List, #List.x
+// CHECK-NEXT:   Path: ""
+// CHECK-NEXT:     Storage:   %4 = alloc_ref $List
+// CHECK-NEXT:     Path: "c0"
+// CHECK-NEXT:     Storage: %0 = argument of bb0 : $List
+// CHECK-NEXT:     Path: "c0"
+// CHECK-NEXT: End accesses for storeMaybeLocalPhi
+sil @storeMaybeLocalPhi : $@convention(thin) (@guaranteed List) -> () {
+bb0(%1 : $List):
+  cond_br undef, bb1, bb2
+
+bb1:
+  strong_retain %1 : $List
+  br bb3(%1 : $List)
+
+bb2:
+  %10 = alloc_ref $List
+  br bb3(%10 : $List)
+
+bb3(%12 : $List):
+  %14 = integer_literal $Builtin.Int64, 20
+  %15 = struct $Int (%14 : $Builtin.Int64)
+  %16 = ref_element_addr %12 : $List, #List.x
+  %17 = begin_access [modify] [dynamic] %16 : $*Int
+  store %15 to %17 : $*Int
+  end_access %17 : $*Int
+  %20 = tuple ()
+  strong_release %12 : $List
+  %22 = tuple ()
+  return %22 : $()
+}
+
+
+// CHECK-LABEL: Accesses for testStructPhiCommon
+// CHECK-NEXT: Value:   %8 = pointer_to_address %7 : $Builtin.RawPointer to $*Int64
+// CHECK-NEXT:   Scope: base
+// CHECK-NEXT:   Base: argument - %0 = argument of bb0 : $*Ptr
+// CHECK-NEXT:   Path: "s0"
+// CHECK-NEXT:     Storage: %0 = argument of bb0 : $*Ptr
+// CHECK-NEXT:     Path: "s0"
+// CHECK-NEXT: End accesses for testStructPhiCommon
+sil [ossa] @testStructPhiCommon : $@convention(thin) (@inout Ptr) -> () {
+bb0(%0 : $*Ptr):
+  %2 = struct_element_addr %0 : $*Ptr, #Ptr.p
+  cond_br undef, bb1, bb2
+
+bb1:
+  %3 = address_to_pointer %2 : $*Int64 to $Builtin.RawPointer
+  br bb3(%3 : $Builtin.RawPointer)
+
+bb2:
+  %5 = address_to_pointer %2 : $*Int64 to $Builtin.RawPointer
+  br bb3(%5 : $Builtin.RawPointer)
+
+bb3(%6 : $Builtin.RawPointer) :
+  %7 = pointer_to_address %6 : $Builtin.RawPointer to $*Int64
+  %8 = integer_literal $Builtin.Int64, 2
+  %9 = struct $Int64 (%8 : $Builtin.Int64)
+  store %9 to [trivial] %7 : $*Int64
+  %22 = tuple ()
+  return %22 : $()
+}
+
+// CHECK-LABEL: Accesses for testStructPhiDivergent
+// CHECK-NEXT: Value:   %10 = pointer_to_address %9 : $Builtin.RawPointer to $*Int64 // user: %13
+// CHECK-NEXT:   Scope: base
+// CHECK-NEXT:   Base: pointer - %10 = pointer_to_address %9 : $Builtin.RawPointer to $*Int64 // user: %13
+// CHECK-NEXT:   Path: ""
+// CHECK-NEXT:     Storage: %10 = pointer_to_address %9 : $Builtin.RawPointer to $*Int64 // user: %13
+// CHECK-NEXT:     Path: ""
+// CHECK-NEXT: End accesses for testStructPhiDivergent
+sil [ossa] @testStructPhiDivergent : $@convention(thin) (@inout Ptr) -> () {
+bb0(%0 : $*Ptr):
+  %ptr = alloc_stack $Ptr
+  cond_br undef, bb1, bb2
+
+bb1:
+  %2 = struct_element_addr %ptr : $*Ptr, #Ptr.p
+  %3 = address_to_pointer %2 : $*Int64 to $Builtin.RawPointer
+  br bb3(%3 : $Builtin.RawPointer)
+
+bb2:
+  %4 = struct_element_addr %0 : $*Ptr, #Ptr.p
+  %5 = address_to_pointer %4 : $*Int64 to $Builtin.RawPointer
+  br bb3(%5 : $Builtin.RawPointer)
+
+bb3(%6 : $Builtin.RawPointer) :
+  %7 = pointer_to_address %6 : $Builtin.RawPointer to $*Int64
+  %8 = integer_literal $Builtin.Int64, 2
+  %9 = struct $Int64 (%8 : $Builtin.Int64)
+  store %9 to [trivial] %7 : $*Int64
+  dealloc_stack %ptr : $*Ptr
+  %22 = tuple ()
+  return %22 : $()
+}
+
+
+// CHECK-LABEL: Accesses for readIdentifiedBoxArg
+// CHECK-NEXT: Value:   %2 = begin_access [read] [dynamic] %1 : $*Int
+// CHECK-NEXT:   Scope:   %2 = begin_access [read] [dynamic] %1 : $*Int
+// CHECK-NEXT:   Base: box -   %1 = project_box %0 : ${ var Int }, 0
+// CHECK-NEXT:   Path: ""
+// CHECK-NEXT:     Storage: %0 = argument of bb0 : ${ var Int }
+// CHECK-NEXT:     Path: "c0"
+// CHECK-NEXT: End accesses for readIdentifiedBoxArg
+sil [ossa] @readIdentifiedBoxArg : $@convention(thin) (@guaranteed { var Int }) -> Int {
+bb0(%0 : @guaranteed ${ var Int }):
+  %1 = project_box %0 : ${ var Int }, 0
+  %5 = begin_access [read] [dynamic] %1 : $*Int
+  %6 = load [trivial] %5 : $*Int
+  end_access %5 : $*Int
+  return %6 : $Int
+}
+
+
+class A {
+  var prop0: Int64
+}
+class B : A {
+  var prop1: Int64
+}
+
+// CHECK-LABEL: Accesses for testNonUniquePropertyIndex
+// CHECK-NEXT: Value:   %2 = ref_element_addr %1 : $B, #B.prop1
+// CHECK-NEXT:   Scope: base
+// CHECK-NEXT:   Base: class -   %2 = ref_element_addr %1 : $B, #B.prop1
+// CHECK-NEXT:   Path: ""
+// CHECK-NEXT:     Storage:   %1 = alloc_ref $B
+// CHECK-NEXT:     Path: "c1"
+// CHECK-NEXT: Value:   %5 = ref_element_addr %4 : $A, #A.prop0
+// CHECK-NEXT:   Scope: base
+// CHECK-NEXT:   Base: class -   %5 = ref_element_addr %4 : $A, #A.prop0
+// CHECK-NEXT:   Path: ""
+// CHECK-NEXT:     Storage:   %1 = alloc_ref $B
+// CHECK-NEXT:     Path: "c0"
+// CHECK-NEXT: End accesses for testNonUniquePropertyIndex
+sil @testNonUniquePropertyIndex : $@convention(thin) (Int64) -> () {
+bb0(%0 : $Int64):
+  %1 = alloc_ref $B
+  %2 = ref_element_addr %1 : $B, #B.prop1
+  store %0 to %2 : $*Int64
+  %4 = upcast %1 : $B to $A
+  %5 = ref_element_addr %4 : $A, #A.prop0
+  store %0 to %5 : $*Int64
+  %99 = tuple ()
+  return %99 : $()
+}
+
+struct _MyBridgeStorage {
+  @_hasStorage var rawValue : Builtin.BridgeObject
+}
+
+struct _MyArrayBuffer<T> {
+  @_hasStorage var _storage : _MyBridgeStorage
+}
+
+
+struct MyArray<T> {
+  @_hasStorage var _buffer : _MyArrayBuffer<T>
+}
+
+// CHECK-LABEL: Accesses for testRefTailAndStruct0
+// CHECK-NEXT: Value:   %8 = struct_element_addr %7 : $*Int, #Int._value // user: %9
+// CHECK-NEXT:   Scope: base
+// CHECK-NEXT:   Base: class -   %5 = ref_element_addr [immutable] %4 : $__ContiguousArrayStorageBase, #__ContiguousArrayStorageBase.countAndCapacity
+// CHECK-NEXT:   Path: "s0.s0.s0"
+// CHECK-NEXT:     Storage: %0 = argument of bb0 : $MyArray<String>
+// CHECK-NEXT:     Path: "s0.s0.s0.c0.s0.s0.s0"
+// CHECK-NEXT: Value:   %11 = struct_element_addr %10 : $*String, #String._guts
+// CHECK-NEXT:   Scope: base
+// CHECK-NEXT:   Base: tail -   %10 = ref_tail_addr [immutable] %4 : $__ContiguousArrayStorageBase, $String
+// CHECK-NEXT:   Path: "s0"
+// CHECK-NEXT:     Storage: %0 = argument of bb0 : $MyArray<String>
+// CHECK-NEXT:     Path: "s0.s0.s0.ct.s0"
+// CHECK-NEXT: Value:   %10 = ref_tail_addr [immutable] %4 : $__ContiguousArrayStorageBase, $String
+// CHECK-NEXT:   Scope: base
+// CHECK-NEXT:   Base: tail -   %10 = ref_tail_addr [immutable] %4 : $__ContiguousArrayStorageBase, $String
+// CHECK-NEXT:   Path: ""
+// CHECK-NEXT:     Storage: %0 = argument of bb0 : $MyArray<String>
+// CHECK-NEXT:     Path: "s0.s0.s0.ct"
+// CHECK-NEXT: End accesses for testRefTailAndStruct0
+sil hidden [noinline] @testRefTailAndStruct0 : $@convention(thin) (@owned MyArray<String>) -> () {
+bb0(%0 : $MyArray<String>):
+  %1 = struct_extract %0 : $MyArray<String>, #MyArray._buffer
+  %2 = struct_extract %1 : $_MyArrayBuffer<String>, #_MyArrayBuffer._storage
+  %3 = struct_extract %2 : $_MyBridgeStorage, #_MyBridgeStorage.rawValue
+  %4 = unchecked_ref_cast %3 : $Builtin.BridgeObject to $__ContiguousArrayStorageBase
+  %5 = ref_element_addr [immutable] %4 : $__ContiguousArrayStorageBase, #__ContiguousArrayStorageBase.countAndCapacity
+  %6 = struct_element_addr %5 : $*_ArrayBody, #_ArrayBody._storage
+  %7 = struct_element_addr %6 : $*_SwiftArrayBodyStorage, #_SwiftArrayBodyStorage.count
+  %8 = struct_element_addr %7 : $*Int, #Int._value
+  %9 = load %8 : $*Builtin.Int64
+  %10 = ref_tail_addr [immutable] %4 : $__ContiguousArrayStorageBase, $String
+  %11 = struct_element_addr %10 : $*String, #String._guts
+  %12 = load %11 : $*_StringGuts
+  %13 = load %10 : $*String
+  %14 = tuple ()
+  return %14 : $()
+}


### PR DESCRIPTION
This pr adds a set of utilities and concepts (`AccessBase`, `AccessPath` and `AccessStoragePath`) to identify and analyze formal accesses in SIL.

This allows passes to reason about memory accesses relying solely on these concepts without having to implement ad-hoc traversals. This is similar in spirit to what is presentated [SILMemoryAccess.md](https://github.com/apple/swift/blob/9151db55e740fb53027ac2aedb8c5bf8ee97ea72/docs/SILMemoryAccess.md) and [MemAccessUtils](https://github.com/apple/swift/blob/main/include/swift/SIL/MemAccessUtils.h).