### PR TITLE
MissingDeclSyntax Can Have Attributes and Modifiers

### DIFF
--- a/utils/gyb_syntax_support/CommonNodes.py
+++ b/utils/gyb_syntax_support/CommonNodes.py
@@ -13,7 +13,12 @@ COMMON_NODES = [
     Node('UnknownType', kind='Type'),
     Node('UnknownPattern', kind='Pattern'),
     Node('Missing', kind='Syntax'),
-    Node('MissingDecl', kind='Decl'),
+    Node('MissingDecl', kind='Decl', children=[
+        Child('Attributes', kind='AttributeList',
+              collection_element_name='Attribute', is_optional=True),
+        Child('Modifiers', kind='ModifierList',
+              collection_element_name='Modifier', is_optional=True),
+    ]),
     Node('MissingExpr', kind='Expr'),
     Node('MissingStmt', kind='Stmt'),
     Node('MissingType', kind='Type'),


### PR DESCRIPTION
Strange as it sounds, we parse

@foo public

in item position as a decl that has a hanging attribute and access
control modifier. We need to be able to stick... something in the
tree here so we don't just drop these tokens on the floor.