### PR TITLE
Support property wrappers in top-level code

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5433,6 +5433,9 @@ public:
     Bits.VarDecl.IsLazyStorageProperty = IsLazyStorage;
   }
 
+  bool isPropertyWrapperBackingProperty() const { return Bits.VarDecl.IsPropertyWrapperBackingProperty; }
+  void setPropertyWrapperBackingProperty(bool b) { Bits.VarDecl.IsPropertyWrapperBackingProperty = b; }
+
   /// True if this is a top-level global variable from the main source file.
   bool isTopLevelGlobal() const { return Bits.VarDecl.IsTopLevelGlobal; }
   void setTopLevelGlobal(bool b) { Bits.VarDecl.IsTopLevelGlobal = b; }

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6073,9 +6073,6 @@ ERROR(invalid_implicit_property_wrapper,none,
 ERROR(property_wrapper_mutating_get_composed_to_get_only,none,
       "property wrapper %0 with a mutating getter cannot be composed inside "
       "get-only property wrapper %1", (TypeLoc, TypeLoc))
-
-ERROR(property_wrapper_top_level,none,
-      "property wrappers are not yet supported in top-level code", ())
 ERROR(property_wrapper_let, none,
       "property wrapper can only be applied to a 'var'",
       ())

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2214,7 +2214,7 @@ public:
     // local variables with initializers.
     bool hasInit = expression.propertyWrapper.hasInitialWrappedValue;
     if (wrappedVar->isStatic() ||
-        (hasInit && wrappedVar->getDeclContext()->isLocalContext()))
+        (hasInit && wrappedVar->getDeclContext()->isLocalContext()) || (hasInit && wrappedVar->isTopLevelGlobal()))
       return false;
 
     return expression.propertyWrapper.innermostWrappedValueInit == apply;

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -376,11 +376,8 @@ SILLinkage SILDeclRef::getLinkage(ForDefinition_t forDefinition) const {
     if (isSerialized())
       return maybeAddExternal(SILLinkage::PublicNonABI);
 
-    d = cast<NominalTypeDecl>(d->getDeclContext());
+    limit = Limit::NeverPublic;
 
-    // FIXME: This should always be true.
-    if (d->getModuleContext()->isResilient())
-      limit = Limit::NeverPublic;
   }
 
   // The global addressor is never public for resilient globals.

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1772,24 +1772,20 @@ void SILGenModule::visitPatternBindingDecl(PatternBindingDecl *pd) {
 void SILGenModule::visitVarDecl(VarDecl *vd) {
     // We handle emitting the variable storage when we see the pattern binding.
 
-    // Avoid request evaluator overhead in the common case where there's
-    // no wrapper.
-    /*if (vd->getAttrs().hasAttribute<CustomAttr>()) {
-      // Emit the property wrapper backing initializer if necessary.
-      auto initInfo = vd->getPropertyWrapperInitializerInfo();
-      if (initInfo.hasInitFromWrappedValue())
-        emitPropertyWrapperBackingInitializer(vd);
-    }*/
-
     // Emit lazy and property wrapper backing storage.
     vd->visitAuxiliaryDecls([&](VarDecl *var) {
-        if (auto *patternBinding = var->getParentPatternBinding())
-          TopLevelSGF->visitPatternBindingDecl(patternBinding);
+        if (auto *patternBinding = var->getParentPatternBinding()){
+            if (TopLevelSGF){
+            TopLevelSGF->visitPatternBindingDecl(patternBinding);
+            } else {
+                //Call SGM::visitPatternBindingDecl if not in script mode
+                visitPatternBindingDecl(patternBinding);
+            }
+        }
         TopLevelSGF->visit(var);
 
         if (var->hasStorage())
           addGlobalVariable(var);
-
     });
 
   if (vd->hasStorage())

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1997,14 +1997,11 @@ void SILGenModule::visitTopLevelCodeDecl(TopLevelCodeDecl *td) {
       return;
     }
 
-    auto *decl = td->getDeclContext();
-    auto *vard = dyn_cast<VarDecl>(td);
-
     if (auto *S = ESD.dyn_cast<Stmt*>()) {
       TopLevelSGF->emitStmt(S);
     } else if (auto *E = ESD.dyn_cast<Expr*>()) {
       TopLevelSGF->emitIgnoredExpr(E);
-    }else {
+    } else {
         TopLevelSGF->visit(ESD.get<Decl*>());
     }
   }
@@ -2200,8 +2197,6 @@ public:
     for (auto *D : sf->getTopLevelDecls()) {
       FrontendStatsTracer StatsTracer(SGM.getASTContext().Stats,
                                       "SILgen-decl", D);
-      if(isa<TopLevelCodeDecl>(D))
-          bool top = true;
       SGM.visit(D);
     }
 

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1770,6 +1770,28 @@ void SILGenModule::visitPatternBindingDecl(PatternBindingDecl *pd) {
 }
 
 void SILGenModule::visitVarDecl(VarDecl *vd) {
+    // We handle emitting the variable storage when we see the pattern binding.
+
+    // Avoid request evaluator overhead in the common case where there's
+    // no wrapper.
+    /*if (vd->getAttrs().hasAttribute<CustomAttr>()) {
+      // Emit the property wrapper backing initializer if necessary.
+      auto initInfo = vd->getPropertyWrapperInitializerInfo();
+      if (initInfo.hasInitFromWrappedValue())
+        emitPropertyWrapperBackingInitializer(vd);
+    }*/
+
+    // Emit lazy and property wrapper backing storage.
+    vd->visitAuxiliaryDecls([&](VarDecl *var) {
+        if (auto *patternBinding = var->getParentPatternBinding())
+          TopLevelSGF->visitPatternBindingDecl(patternBinding);
+        TopLevelSGF->visit(var);
+
+        if (var->hasStorage())
+          addGlobalVariable(var);
+
+    });
+
   if (vd->hasStorage())
     addGlobalVariable(vd);
 
@@ -1975,12 +1997,15 @@ void SILGenModule::visitTopLevelCodeDecl(TopLevelCodeDecl *td) {
       return;
     }
 
+    auto *decl = td->getDeclContext();
+    auto *vard = dyn_cast<VarDecl>(td);
+
     if (auto *S = ESD.dyn_cast<Stmt*>()) {
       TopLevelSGF->emitStmt(S);
     } else if (auto *E = ESD.dyn_cast<Expr*>()) {
       TopLevelSGF->emitIgnoredExpr(E);
-    } else {
-      TopLevelSGF->visit(ESD.get<Decl*>());
+    }else {
+        TopLevelSGF->visit(ESD.get<Decl*>());
     }
   }
 }
@@ -2175,6 +2200,8 @@ public:
     for (auto *D : sf->getTopLevelDecls()) {
       FrontendStatsTracer StatsTracer(SGM.getASTContext().Stats,
                                       "SILgen-decl", D);
+      if(isa<TopLevelCodeDecl>(D))
+          bool top = true;
       SGM.visit(D);
     }
 

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1776,16 +1776,27 @@ void SILGenModule::visitVarDecl(VarDecl *vd) {
     vd->visitAuxiliaryDecls([&](VarDecl *var) {
         if (auto *patternBinding = var->getParentPatternBinding()){
             if (TopLevelSGF){
-            TopLevelSGF->visitPatternBindingDecl(patternBinding);
+                TopLevelSGF->visitPatternBindingDecl(patternBinding);
+                TopLevelSGF->visit(var);
+
             } else {
                 //Call SGM::visitPatternBindingDecl if not in script mode
                 visitPatternBindingDecl(patternBinding);
+                visit(var);
             }
         }
-        TopLevelSGF->visit(var);
 
         if (var->hasStorage())
           addGlobalVariable(var);
+
+        var->visitEmittedAccessors([&](AccessorDecl *accessor){
+          emitFunction(accessor);
+        });
+
+        /*auto *asd = dyn_cast<AbstractStorageDecl>(var);
+        asd->visitEmittedAccessors([&](AccessorDecl *accessor) {
+          visitFuncDecl(accessor);
+        });*/
     });
 
   if (vd->hasStorage())

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1321,7 +1321,7 @@ void SILGenFunction::emitPatternBinding(PatternBindingDecl *PBD,
     FullExpr Scope(Cleanups, CleanupLocation(Init));
 
     auto *var = PBD->getSingleVar();
-    if (var && var->getDeclContext()->isLocalContext()) {
+    if (var && (var->getDeclContext()->isLocalContext() || var->getDeclContext()->isModuleScopeContext())) {
       if (auto *orig = var->getOriginalWrappedProperty()) {
         auto initInfo = orig->getPropertyWrapperInitializerInfo();
         if (auto *placeholder = initInfo.getWrappedValuePlaceholder()) {

--- a/lib/SILGen/SILGenGlobalVariable.cpp
+++ b/lib/SILGen/SILGenGlobalVariable.cpp
@@ -71,7 +71,7 @@ SILGenFunction::emitGlobalVariableRef(SILLocation loc, VarDecl *var,
                                       Optional<ActorIsolation> actorIso) {
   assert(!VarLocs.count(var));
 
-  if (var->isLazilyInitializedGlobal()) {
+  if (var->isLazilyInitializedGlobal() && !var->hasStorageOrWrapsStorage()) {
     // Call the global accessor to get the variable's address.
     SILFunction *accessorFn = SGM.getFunction(
                             SILDeclRef(var, SILDeclRef::Kind::GlobalAccessor),

--- a/lib/SILGen/SILGenGlobalVariable.cpp
+++ b/lib/SILGen/SILGenGlobalVariable.cpp
@@ -71,7 +71,7 @@ SILGenFunction::emitGlobalVariableRef(SILLocation loc, VarDecl *var,
                                       Optional<ActorIsolation> actorIso) {
   assert(!VarLocs.count(var));
 
-  if (var->isLazilyInitializedGlobal() && !var->hasStorageOrWrapsStorage()) {
+  if (var->isLazilyInitializedGlobal() && !var->isPropertyWrapperBackingProperty()) {
     // Call the global accessor to get the variable's address.
     SILFunction *accessorFn = SGM.getFunction(
                             SILDeclRef(var, SILDeclRef::Kind::GlobalAccessor),

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1385,7 +1385,7 @@ namespace {
 
         // Assignment to a wrapped property can only be re-written to initialization for
         // members of `self` in an initializer, and for local or global variables.
-        if (!(isAssignmentToSelfParamInInit || VD->getDeclContext()->isLocalContext() || VD->isTopLevelGlobal() || VD->getDeclContext()->isModuleScopeContext()))
+        if (!(isAssignmentToSelfParamInInit || VD->getDeclContext()->isLocalContext() || VD->getDeclContext()->isModuleScopeContext()))
           return false;
 
         // If this var isn't in a type context, assignment will always use the setter

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1384,8 +1384,8 @@ namespace {
             !(cast<ConstructorDecl>(fnDecl)->isConvenienceInit());
 
         // Assignment to a wrapped property can only be re-written to initialization for
-        // members of `self` in an initializer, and for local variables.
-        if (!(isAssignmentToSelfParamInInit || VD->getDeclContext()->isLocalContext()))
+        // members of `self` in an initializer, and for local or global variables.
+        if (!(isAssignmentToSelfParamInInit || VD->getDeclContext()->isLocalContext() || VD->isTopLevelGlobal() || VD->getDeclContext()->isModuleScopeContext()))
           return false;
 
         // If this var isn't in a type context, assignment will always use the setter
@@ -1501,6 +1501,7 @@ namespace {
         if (!BaseFormalType) {
           proj = SGF.maybeEmitValueOfLocalVarDecl(
               backingVar, AccessKind::Write);
+
         } else if (BaseFormalType->mayHaveSuperclass()) {
           RefElementComponent REC(backingVar, LValueOptions(), varStorageType,
                                   typeData, /*actorIsolation=*/None);

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -581,8 +581,6 @@ PropertyWrapperBackingPropertyTypeRequest::evaluate(
   if (var->hasImplicitPropertyWrapper())
     return var->getInterfaceType();
 
-  if(var->isTopLevelGlobal())
-      bool toplevel = true;
   // The constraint system will infer closure parameter types
   if (isa<ParamDecl>(var) && isa<ClosureExpr>(var->getDeclContext()))
     return var->getPropertyWrapperBackingProperty()->getInterfaceType();

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -458,12 +458,6 @@ AttachedPropertyWrappersRequest::evaluate(Evaluator &evaluator,
     // Check various restrictions on which properties can have wrappers
     // attached to them.
 
-    // Nor does top-level code.
-    if (var->getDeclContext()->isModuleScopeContext()) {
-      ctx.Diags.diagnose(attr->getLocation(), diag::property_wrapper_top_level);
-      continue;
-    }
-
 //    // If the property wrapper requested an `_enclosingInstance: Never`
 //    // it must be declared as static. TODO: or global once we allow wrappers on top-level code
 //    auto wrappedInfo = var->getPropertyWrapperTypeInfo();
@@ -587,6 +581,8 @@ PropertyWrapperBackingPropertyTypeRequest::evaluate(
   if (var->hasImplicitPropertyWrapper())
     return var->getInterfaceType();
 
+  if(var->isTopLevelGlobal())
+      bool toplevel = true;
   // The constraint system will infer closure parameter types
   if (isa<ParamDecl>(var) && isa<ClosureExpr>(var->getDeclContext()))
     return var->getPropertyWrapperBackingProperty()->getInterfaceType();

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2911,6 +2911,7 @@ PropertyWrapperAuxiliaryVariablesRequest::evaluate(Evaluator &evaluator,
                                    name, dc);
     backingVar->setImplicit();
     backingVar->setOriginalWrappedProperty(var);
+    backingVar->setPropertyWrapperBackingProperty(true);
 
     // The backing storage is 'private'.
     backingVar->overwriteAccess(AccessLevel::Private);

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2955,7 +2955,6 @@ PropertyWrapperInitializerInfoRequest::evaluate(Evaluator &evaluator,
   Type storageType = dc->mapTypeIntoContext(wrapperType);
   Expr *initializer = nullptr;
   PropertyWrapperValuePlaceholderExpr *wrappedValue = nullptr;
-//creates pattern bingind decl for property wrapper
   auto createPBD = [&](VarDecl *singleVar) -> PatternBindingDecl * {
     Pattern *pattern = NamedPattern::createImplicit(ctx, singleVar);
     pattern->setType(singleVar->getType());

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2955,7 +2955,7 @@ PropertyWrapperInitializerInfoRequest::evaluate(Evaluator &evaluator,
   Type storageType = dc->mapTypeIntoContext(wrapperType);
   Expr *initializer = nullptr;
   PropertyWrapperValuePlaceholderExpr *wrappedValue = nullptr;
-
+//creates pattern bingind decl for property wrapper
   auto createPBD = [&](VarDecl *singleVar) -> PatternBindingDecl * {
     Pattern *pattern = NamedPattern::createImplicit(ctx, singleVar);
     pattern->setType(singleVar->getType());

--- a/test/decl/var/property_wrappers_top_level.swift
+++ b/test/decl/var/property_wrappers_top_level.swift
@@ -8,7 +8,6 @@ struct Wrapper<T> {
   }
 }
 
-// expected-error@+1{{property wrappers are not yet supported in top-level code}}
 @Wrapper var value: Int = 17
 
 func f() { }


### PR DESCRIPTION
```
@propertyWrapper struct Capitalized {
    var wrappedValue: String {
        didSet { wrappedValue = wrappedValue.uppercased() }
    }

    init(wrappedValue: String) {
        self.wrappedValue = wrappedValue.uppercased()
    }
}

@Capitalized var user = "tim cook"
print(user)
```


rdar://53481137


