### PR TITLE
build: remove `sed` usage in build system

### DIFF
--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -230,18 +230,28 @@ else()
 
   add_subdirectory(Sources)
 
-  # This is a hack to get correct dependencies from imported C++ headers:
-  # step 1: generate a dummy source file, which just includes all headers defined in include/swift/module.modulemap
-  add_custom_command(
-    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/HeaderDependencies.cpp"
-    COMMAND
-        "sed"
-        -n -e "/header/!d" -e "s/.*header/#include/" -e "w ${CMAKE_CURRENT_BINARY_DIR}/HeaderDependencies.cpp"
-        "${CMAKE_CURRENT_SOURCE_DIR}/../include/swift/module.modulemap"
-    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/../include/swift/module.modulemap"
-    COMMENT "Generate HeaderDependencies.cpp"
-)
-  
+  # TODO: generate this dynamically through the modulemap; this cannot use `sed`
+  # as that is not available on all paltforms (e.g. Windows).
+  #
+  # step 1: generate a dummy source file, which just includes all headers
+  # defined in include/swift/module.modulemap
+  file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/HeaderDependencies.cpp"
+       "
+#include \"Basic/BridgedSwiftObject.h\"
+#include \"Basic/BasicBridging.h\"
+#include \"Basic/SourceLoc.h\"
+
+#include \"AST/ASTBridging.h\"
+#include \"AST/DiagnosticEngine.h\"
+#include \"AST/DiagnosticConsumer.h\"
+
+#include \"SIL/SILBridging.h\"
+
+#include \"SILOptimizer/OptimizerBridging.h\"
+
+#include \"Parse/RegexParserBridging.h\"
+")
+
   # step 2: build a library containing that source file. This library depends on all the included header files.
   #         The swift modules can now depend on that target.
   #         Note that this library is unused, i.e. not linked to anything.   


### PR DESCRIPTION
`sed` is not available on all platforms, we cannot depend on that to
rewrite the module map.  As a temporary stop gap, write the file
statically and generate it at build time.  Eventually, this could be
replaced with a tool or CMake based text processing to generate the
content.  This repairs part of the build for Windows with bootstrapping.