### PR TITLE
Sema: Diagnose inconsistent use of `@_weakLinked` import

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2978,6 +2978,13 @@ ERROR(implementation_only_override_import_without_attr,none,
       "override of %0 imported as implementation-only must be declared "
       "'@_implementationOnly'", (DescriptiveDeclKind))
 
+ERROR(import_attr_conflict,none,
+      "%0 inconsistently imported with %1",
+      (Identifier, DeclAttribute))
+NOTE(import_attr_conflict_here,none,
+     "imported with %0 here",
+     (DeclAttribute))
+
 // Derived conformances
 ERROR(cannot_synthesize_init_in_extension_of_nonfinal,none,
       "implementation of %0 for non-final class cannot be automatically "

--- a/include/swift/AST/Import.h
+++ b/include/swift/AST/Import.h
@@ -94,6 +94,8 @@ enum class ImportFlags {
 /// \see ImportFlags
 using ImportOptions = OptionSet<ImportFlags>;
 
+void simple_display(llvm::raw_ostream &out, ImportOptions options);
+
 // MARK: - Import Paths
 
 namespace detail {

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -176,7 +176,7 @@ private:
 
   friend class HasImportsMatchingFlagRequest;
 
-  /// Indicates which import options have a valid caches. Storage for
+  /// Indicates which import options have valid caches. Storage for
   /// \c HasImportsMatchingFlagRequest.
   ImportOptions validCachedImportOptions;
 
@@ -352,9 +352,9 @@ public:
   hasTestableOrPrivateImport(AccessLevel accessLevel, const ValueDecl *ofDecl,
                              ImportQueryKind kind = TestableAndPrivate) const;
 
-  /// Does this source file have any implementation-only imports?
+  /// Does this source file have any imports with \c flag?
   /// If not, we can fast-path module checks.
-  bool hasImplementationOnlyImports() const;
+  bool hasImportsWithFlag(ImportFlags flag) const;
 
   /// Get the most permissive restriction applied to the imports of \p module.
   RestrictedImportKind getRestrictedImportKind(const ModuleDecl *module) const;

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -174,6 +174,16 @@ private:
   ParserStatePtr DelayedParserState =
       ParserStatePtr(/*ptr*/ nullptr, /*deleter*/ nullptr);
 
+  friend class HasImportsMatchingFlagRequest;
+
+  /// Indicates which import options have a valid caches. Storage for
+  /// \c HasImportsMatchingFlagRequest.
+  ImportOptions validCachedImportOptions;
+
+  /// The cached computation of which import flags are present in the file.
+  /// Storage for \c HasImportsMatchingFlagRequest.
+  ImportOptions cachedImportOptions;
+
   friend ASTContext;
 
 public:

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3263,7 +3263,7 @@ private:
 void simple_display(llvm::raw_ostream &out, const TypeResolution *resolution);
 SourceLoc extractNearestSourceLoc(const TypeRepr *repr);
 
-/// Checks to see if any of the imports in a module use `@_implementationOnly`
+/// Checks to see if any of the imports in a module use \c @_implementationOnly
 /// in one file and not in another.
 ///
 /// Like redeclaration checking, but for imports.
@@ -3271,9 +3271,35 @@ SourceLoc extractNearestSourceLoc(const TypeRepr *repr);
 /// This is a request purely to ensure that we don't need to perform the same
 /// checking for each file we resolve imports for.
 /// FIXME: Once import resolution operates at module-level, this checking can
-/// integrated into it.
+/// be integrated into it.
 class CheckInconsistentImplementationOnlyImportsRequest
     : public SimpleRequest<CheckInconsistentImplementationOnlyImportsRequest,
+                           evaluator::SideEffect(ModuleDecl *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  evaluator::SideEffect evaluate(Evaluator &evaluator, ModuleDecl *mod) const;
+
+public:
+  // Cached.
+  bool isCached() const { return true; }
+};
+
+/// Checks to see if any of the imports in a module use \c @_weakLinked
+/// in one file and not in another.
+///
+/// Like redeclaration checking, but for imports.
+///
+/// This is a request purely to ensure that we don't need to perform the same
+/// checking for each file we resolve imports for.
+/// FIXME: Once import resolution operates at module-level, this checking can
+/// be integrated into it.
+class CheckInconsistentWeakLinkedImportsRequest
+    : public SimpleRequest<CheckInconsistentWeakLinkedImportsRequest,
                            evaluator::SideEffect(ModuleDecl *),
                            RequestFlags::Cached> {
 public:

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3202,21 +3202,24 @@ public:
   bool isCached() const { return true; }
 };
 
-/// Checks whether a file performs an implementation-only import.
-class HasImplementationOnlyImportsRequest
-    : public SimpleRequest<HasImplementationOnlyImportsRequest,
-                           bool(SourceFile *), RequestFlags::Cached> {
+/// Checks whether a file contains any import declarations with the given flag.
+class HasImportsMatchingFlagRequest
+    : public SimpleRequest<HasImportsMatchingFlagRequest,
+                           bool(SourceFile *, ImportFlags),
+                           RequestFlags::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
 
 private:
   friend SimpleRequest;
 
-  bool evaluate(Evaluator &evaluator, SourceFile *SF) const;
+  bool evaluate(Evaluator &evaluator, SourceFile *SF, ImportFlags flag) const;
 
 public:
   // Cached.
   bool isCached() const { return true; }
+  Optional<bool> getCachedResult() const;
+  void cacheResult(bool value) const;
 };
 
 /// Get the library level of a module.

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -33,6 +33,8 @@ SWIFT_REQUEST(TypeChecker, CallerSideDefaultArgExprRequest,
               Expr *(DefaultArgumentExpr *), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, CheckInconsistentImplementationOnlyImportsRequest,
               evaluator::SideEffect(ModuleDecl *), Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, CheckInconsistentWeakLinkedImportsRequest,
+              evaluator::SideEffect(ModuleDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, CheckRedeclarationRequest,
               evaluator::SideEffect(ValueDecl *),
               Uncached, NoLocationInfo)

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -169,8 +169,8 @@ SWIFT_REQUEST(TypeChecker, HasCircularInheritedProtocolsRequest,
               bool(ProtocolDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, HasCircularRawValueRequest,
               bool(EnumDecl *), Cached, NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, HasImplementationOnlyImportsRequest,
-              bool(SourceFile *), Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, HasImportsMatchingFlagRequest,
+              bool(SourceFile *, ImportOptions), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ModuleLibraryLevelRequest,
               LibraryLevel(ModuleDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, InferredGenericSignatureRequest,

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2389,19 +2389,66 @@ void SourceFile::setImportUsedPreconcurrency(
   PreconcurrencyImportsUsed.insert(import);
 }
 
-bool HasImplementationOnlyImportsRequest::evaluate(Evaluator &evaluator,
-                                                   SourceFile *SF) const {
-  return llvm::any_of(SF->getImports(),
-                      [](AttributedImport<ImportedModule> desc) {
-    return desc.options.contains(ImportFlags::ImplementationOnly);
-  });
+bool HasImportsMatchingFlagRequest::evaluate(Evaluator &evaluator,
+                                             SourceFile *SF,
+                                             ImportFlags flag) const {
+  for (auto desc : SF->getImports()) {
+    if (desc.options.contains(flag))
+      return true;
+  }
+  return false;
+}
+
+Optional<bool> HasImportsMatchingFlagRequest::getCachedResult() const {
+  SourceFile *sourceFile = std::get<0>(getStorage());
+  ImportFlags flag = std::get<1>(getStorage());
+  if (sourceFile->validCachedImportOptions.contains(flag))
+    return sourceFile->cachedImportOptions.contains(flag);
+
+  return None;
+}
+
+void HasImportsMatchingFlagRequest::cacheResult(bool value) const {
+  SourceFile *sourceFile = std::get<0>(getStorage());
+  ImportFlags flag = std::get<1>(getStorage());
+
+  sourceFile->validCachedImportOptions |= flag;
+  if (value)
+    sourceFile->cachedImportOptions |= flag;
+}
+
+void swift::simple_display(llvm::raw_ostream &out, ImportOptions options) {
+  using Flag = std::pair<ImportFlags, StringRef>;
+  Flag possibleFlags[] = {
+#define FLAG(Name) {ImportFlags::Name, #Name},
+    FLAG(Exported)
+    FLAG(Testable)
+    FLAG(PrivateImport)
+    FLAG(ImplementationOnly)
+    FLAG(SPIAccessControl)
+    FLAG(Preconcurrency)
+    FLAG(WeakLinked)
+    FLAG(Reserved)
+#undef FLAG
+  };
+
+  auto flagsToPrint = llvm::make_filter_range(
+      possibleFlags, [&](Flag flag) { return options & flag.first; });
+
+  out << "{ ";
+  interleave(
+      flagsToPrint, [&](Flag flag) { out << flag.second; },
+      [&] { out << ", "; });
+  out << " }";
 }
 
 bool SourceFile::hasImplementationOnlyImports() const {
   auto &ctx = getASTContext();
   auto *mutableThis = const_cast<SourceFile *>(this);
-  return evaluateOrDefault(
-      ctx.evaluator, HasImplementationOnlyImportsRequest{mutableThis}, false);
+  return evaluateOrDefault(ctx.evaluator,
+                           HasImportsMatchingFlagRequest{
+                               mutableThis, ImportFlags::ImplementationOnly},
+                           false);
 }
 
 bool SourceFile::hasTestableOrPrivateImport(

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2442,13 +2442,11 @@ void swift::simple_display(llvm::raw_ostream &out, ImportOptions options) {
   out << " }";
 }
 
-bool SourceFile::hasImplementationOnlyImports() const {
+bool SourceFile::hasImportsWithFlag(ImportFlags flag) const {
   auto &ctx = getASTContext();
   auto *mutableThis = const_cast<SourceFile *>(this);
-  return evaluateOrDefault(ctx.evaluator,
-                           HasImportsMatchingFlagRequest{
-                               mutableThis, ImportFlags::ImplementationOnly},
-                           false);
+  return evaluateOrDefault(
+      ctx.evaluator, HasImportsMatchingFlagRequest{mutableThis, flag}, false);
 }
 
 bool SourceFile::hasTestableOrPrivateImport(

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1474,6 +1474,12 @@ void swift::simple_display(llvm::raw_ostream &out,
     out << ")";
   }
 
+  if (import.options.contains(ImportFlags::Preconcurrency))
+    out << " preconcurrency";
+
+  if (import.options.contains(ImportFlags::WeakLinked))
+    out << " weak-linked";
+
   out << " ]";
 }
 

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -693,6 +693,16 @@ void UnboundImport::diagnoseInvalidAttr(DeclAttrKind attrKind,
   attr->setInvalid();
 }
 
+/// Returns true if any file in the module contains an import with \c flag.
+static bool moduleHasAnyImportsMatchingFlag(ModuleDecl *mod, ImportFlags flag) {
+  for (const FileUnit *F : mod->getFiles()) {
+    auto *SF = dyn_cast<SourceFile>(F);
+    if (SF && SF->hasImportsWithFlag(flag))
+      return true;
+  }
+  return false;
+}
+
 /// Finds all import declarations for a single module that inconsistently match
 /// \c predicate and passes each pair of inconsistent imports to \c diagnose.
 template <typename Pred, typename Diag>
@@ -747,12 +757,7 @@ static void findInconsistentImports(ModuleDecl *mod, Pred predicate,
 evaluator::SideEffect
 CheckInconsistentImplementationOnlyImportsRequest::evaluate(
     Evaluator &evaluator, ModuleDecl *mod) const {
-  bool hasAnyImplementationOnlyImports =
-      llvm::any_of(mod->getFiles(), [](const FileUnit *F) -> bool {
-        auto *SF = dyn_cast<SourceFile>(F);
-        return SF && SF->hasImplementationOnlyImports();
-      });
-  if (!hasAnyImplementationOnlyImports)
+  if (!moduleHasAnyImportsMatchingFlag(mod, ImportFlags::ImplementationOnly))
     return {};
 
   auto diagnose = [mod](const ImportDecl *normalImport,
@@ -777,6 +782,31 @@ CheckInconsistentImplementationOnlyImportsRequest::evaluate(
 
   auto predicate = [](ImportDecl *decl) {
     return decl->getAttrs().hasAttribute<ImplementationOnlyAttr>();
+  };
+
+  findInconsistentImports(mod, predicate, diagnose);
+  return {};
+}
+
+evaluator::SideEffect
+CheckInconsistentWeakLinkedImportsRequest::evaluate(Evaluator &evaluator,
+                                                    ModuleDecl *mod) const {
+  if (!moduleHasAnyImportsMatchingFlag(mod, ImportFlags::WeakLinked))
+    return {};
+
+  auto diagnose = [mod](const ImportDecl *otherImport,
+                        const ImportDecl *weakLinkedImport) {
+    auto attr = weakLinkedImport->getAttrs().getAttribute<WeakLinkedAttr>();
+    auto &diags = mod->getDiags();
+    diags
+        .diagnose(otherImport, diag::import_attr_conflict,
+                  otherImport->getModule()->getName(), attr)
+        .fixItInsert(otherImport->getStartLoc(), "@_weakLinked ");
+    diags.diagnose(weakLinkedImport, diag::import_attr_conflict_here, attr);
+  };
+
+  auto predicate = [](ImportDecl *decl) {
+    return decl->getAttrs().hasAttribute<WeakLinkedAttr>();
   };
 
   findInconsistentImports(mod, predicate, diagnose);

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -693,6 +693,57 @@ void UnboundImport::diagnoseInvalidAttr(DeclAttrKind attrKind,
   attr->setInvalid();
 }
 
+/// Finds all import declarations for a single module that inconsistently match
+/// \c predicate and passes each pair of inconsistent imports to \c diagnose.
+template <typename Pred, typename Diag>
+static void findInconsistentImports(ModuleDecl *mod, Pred predicate,
+                                    Diag diagnose) {
+  llvm::DenseMap<ModuleDecl *, const ImportDecl *> matchingImports;
+  llvm::DenseMap<ModuleDecl *, std::vector<const ImportDecl *>> otherImports;
+
+  for (const FileUnit *file : mod->getFiles()) {
+    auto *SF = dyn_cast<SourceFile>(file);
+    if (!SF)
+      continue;
+
+    for (auto *topLevelDecl : SF->getTopLevelDecls()) {
+      auto *nextImport = dyn_cast<ImportDecl>(topLevelDecl);
+      if (!nextImport)
+        continue;
+
+      ModuleDecl *module = nextImport->getModule();
+      if (!module)
+        continue;
+
+      if (predicate(nextImport)) {
+        // We found a matching import.
+        bool isNew = matchingImports.insert({module, nextImport}).second;
+        if (!isNew)
+          continue;
+
+        auto seenOtherImportPosition = otherImports.find(module);
+        if (seenOtherImportPosition != otherImports.end()) {
+          for (auto *seenOtherImport : seenOtherImportPosition->getSecond())
+            diagnose(seenOtherImport, nextImport);
+
+          // We're done with these; keep the map small if possible.
+          otherImports.erase(seenOtherImportPosition);
+        }
+        continue;
+      }
+
+      // We saw a non-matching import. Is that in conflict with what we've seen?
+      if (auto *seenMatchingImport = matchingImports.lookup(module)) {
+        diagnose(nextImport, seenMatchingImport);
+        continue;
+      }
+
+      // Otherwise, record it for later.
+      otherImports[module].push_back(nextImport);
+    }
+  }
+}
+
 evaluator::SideEffect
 CheckInconsistentImplementationOnlyImportsRequest::evaluate(
     Evaluator &evaluator, ModuleDecl *mod) const {
@@ -724,53 +775,11 @@ CheckInconsistentImplementationOnlyImportsRequest::evaluate(
                    diag::implementation_only_conflict_here);
   };
 
-  llvm::DenseMap<ModuleDecl *, std::vector<const ImportDecl *>> normalImports;
-  llvm::DenseMap<ModuleDecl *, const ImportDecl *> implementationOnlyImports;
+  auto predicate = [](ImportDecl *decl) {
+    return decl->getAttrs().hasAttribute<ImplementationOnlyAttr>();
+  };
 
-  for (const FileUnit *file : mod->getFiles()) {
-    auto *SF = dyn_cast<SourceFile>(file);
-    if (!SF)
-      continue;
-
-    for (auto *topLevelDecl : SF->getTopLevelDecls()) {
-      auto *nextImport = dyn_cast<ImportDecl>(topLevelDecl);
-      if (!nextImport)
-        continue;
-
-      ModuleDecl *module = nextImport->getModule();
-      if (!module)
-        continue;
-
-      if (nextImport->getAttrs().hasAttribute<ImplementationOnlyAttr>()) {
-        // We saw an implementation-only import.
-        bool isNew =
-            implementationOnlyImports.insert({module, nextImport}).second;
-        if (!isNew)
-          continue;
-
-        auto seenNormalImportPosition = normalImports.find(module);
-        if (seenNormalImportPosition != normalImports.end()) {
-          for (auto *seenNormalImport : seenNormalImportPosition->getSecond())
-            diagnose(seenNormalImport, nextImport);
-
-          // We're done with these; keep the map small if possible.
-          normalImports.erase(seenNormalImportPosition);
-        }
-        continue;
-      }
-
-      // We saw a non-implementation-only import. Is that in conflict with what
-      // we've seen?
-      if (auto *seenImplementationOnlyImport =
-            implementationOnlyImports.lookup(module)) {
-        diagnose(nextImport, seenImplementationOnlyImport);
-        continue;
-      }
-
-      // Otherwise, record it for later.
-      normalImports[module].push_back(nextImport);
-    }
-  }
+  findInconsistentImports(mod, predicate, diagnose);
   return {};
 }
 

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -1516,7 +1516,7 @@ swift::getDisallowedOriginKind(const Decl *decl,
     // just in this case.
     if (howImported == RestrictedImportKind::Implicit &&
         !SF->getASTContext().isSwiftVersionAtLeast(6) &&
-        !SF->hasImplementationOnlyImports()) {
+        !SF->hasImportsWithFlag(ImportFlags::ImplementationOnly)) {
       downgradeToWarning = DowngradeToWarning::Yes;
     }
 

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -329,11 +329,15 @@ TypeCheckSourceFileRequest::evaluate(Evaluator &eval, SourceFile *SF) const {
 
   diagnoseUnnecessaryPreconcurrencyImports(*SF);
 
-  // Check to see if there's any inconsistent @_implementationOnly imports.
+  // Check to see if there are any inconsistent imports.
   evaluateOrDefault(
       Ctx.evaluator,
       CheckInconsistentImplementationOnlyImportsRequest{SF->getParentModule()},
       {});
+
+  evaluateOrDefault(
+      Ctx.evaluator,
+      CheckInconsistentWeakLinkedImportsRequest{SF->getParentModule()}, {});
 
   // Perform various AST transforms we've been asked to perform.
   if (!Ctx.hadError() && Ctx.LangOpts.DebuggerTestingTransform)

--- a/test/decl/import/Inputs/inconsistent-implementation-only/2.swift
+++ b/test/decl/import/Inputs/inconsistent-implementation-only/2.swift
@@ -1,8 +1,0 @@
-import NotSoSecret // expected-warning {{'NotSoSecret' inconsistently imported as implementation-only}}
-@_implementationOnly import NotSoSecret2 // expected-note 2 {{imported as implementation-only here}}
-import NotSoSecret3 // expected-warning {{'NotSoSecret3' inconsistently imported as implementation-only}}
-
-@_implementationOnly import ActuallySecret // no-warning
-import ActuallyOkay // no-warning
-
-@_implementationOnly import Contradictory // expected-note {{imported as implementation-only here}}

--- a/test/decl/import/Inputs/inconsistent-implementation-only/3.swift
+++ b/test/decl/import/Inputs/inconsistent-implementation-only/3.swift
@@ -1,6 +1,0 @@
-@_implementationOnly import NotSoSecret
-import NotSoSecret2 // expected-warning {{'NotSoSecret2' inconsistently imported as implementation-only}}
-@_implementationOnly import NotSoSecret3 // expected-note 2 {{imported as implementation-only here}}
-
-@_implementationOnly import ActuallySecret // no-warning
-import ActuallyOkay // no-warning

--- a/test/decl/import/inconsistent-implementation-only.swift
+++ b/test/decl/import/inconsistent-implementation-only.swift
@@ -1,9 +1,14 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
 // Check that the diagnostics are produced regardless of what primary file we're using.
-// RUN: %target-swift-frontend -typecheck -primary-file %s %S/Inputs/inconsistent-implementation-only/2.swift %S/Inputs/inconsistent-implementation-only/3.swift -I %S/Inputs/inconsistent-implementation-only/ -verify
-// RUN: %target-swift-frontend -typecheck %s -primary-file %S/Inputs/inconsistent-implementation-only/2.swift %S/Inputs/inconsistent-implementation-only/3.swift -I %S/Inputs/inconsistent-implementation-only/ -verify
-// RUN: %target-swift-frontend -typecheck %s %S/Inputs/inconsistent-implementation-only/2.swift -primary-file %S/Inputs/inconsistent-implementation-only/3.swift -I %S/Inputs/inconsistent-implementation-only/ -verify
-// RUN: %target-swift-frontend -typecheck -primary-file %s -primary-file %S/Inputs/inconsistent-implementation-only/2.swift -primary-file %S/Inputs/inconsistent-implementation-only/3.swift -I %S/Inputs/inconsistent-implementation-only/ -verify
-// RUN: %target-swift-frontend -typecheck %s %S/Inputs/inconsistent-implementation-only/2.swift %S/Inputs/inconsistent-implementation-only/3.swift -I %S/Inputs/inconsistent-implementation-only/ -verify
+// RUN: %target-swift-frontend -typecheck -primary-file %t/1.swift %t/2.swift %t/3.swift -I %S/Inputs/inconsistent-implementation-only/ -verify
+// RUN: %target-swift-frontend -typecheck %t/1.swift -primary-file %t/2.swift %t/3.swift -I %S/Inputs/inconsistent-implementation-only/ -verify
+// RUN: %target-swift-frontend -typecheck %t/1.swift %t/2.swift -primary-file %t/3.swift -I %S/Inputs/inconsistent-implementation-only/ -verify
+// RUN: %target-swift-frontend -typecheck -primary-file %t/1.swift -primary-file %t/2.swift -primary-file %t/3.swift -I %S/Inputs/inconsistent-implementation-only/ -verify
+// RUN: %target-swift-frontend -typecheck %t/1.swift %t/2.swift %t/3.swift -I %S/Inputs/inconsistent-implementation-only/ -verify
+
+//--- 1.swift
 
 @_implementationOnly import NotSoSecret // expected-note {{imported as implementation-only here}}
 import NotSoSecret2 // expected-warning {{'NotSoSecret2' inconsistently imported as implementation-only}} {{1-1=@_implementationOnly }}
@@ -13,3 +18,24 @@ import NotSoSecret3 // expected-warning {{'NotSoSecret3' inconsistently imported
 import ActuallyOkay // no-warning
 
 @_exported import Contradictory // expected-warning {{'Contradictory' inconsistently imported as implementation-only}} {{none}}
+
+//--- 2.swift
+
+import NotSoSecret // expected-warning {{'NotSoSecret' inconsistently imported as implementation-only}}
+@_implementationOnly import NotSoSecret2 // expected-note 2 {{imported as implementation-only here}}
+import NotSoSecret3 // expected-warning {{'NotSoSecret3' inconsistently imported as implementation-only}}
+
+@_implementationOnly import ActuallySecret // no-warning
+import ActuallyOkay // no-warning
+
+@_implementationOnly import Contradictory // expected-note {{imported as implementation-only here}}
+
+//--- 3.swift
+
+@_implementationOnly import NotSoSecret
+import NotSoSecret2 // expected-warning {{'NotSoSecret2' inconsistently imported as implementation-only}}
+@_implementationOnly import NotSoSecret3 // expected-note 2 {{imported as implementation-only here}}
+
+@_implementationOnly import ActuallySecret // no-warning
+import ActuallyOkay // no-warning
+

--- a/test/decl/import/inconsistent-weaklinked-import.swift
+++ b/test/decl/import/inconsistent-weaklinked-import.swift
@@ -1,0 +1,42 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// Check that the diagnostics are produced regardless of what primary file we're using.
+// RUN: %target-swift-frontend -typecheck -primary-file %t/1.swift %t/2.swift %t/3.swift -I %S/Inputs/inconsistent-implementation-only/ -verify
+// RUN: %target-swift-frontend -typecheck %t/1.swift -primary-file %t/2.swift %t/3.swift -I %S/Inputs/inconsistent-implementation-only/ -verify
+// RUN: %target-swift-frontend -typecheck %t/1.swift %t/2.swift -primary-file %t/3.swift -I %S/Inputs/inconsistent-implementation-only/ -verify
+// RUN: %target-swift-frontend -typecheck -primary-file %t/1.swift -primary-file %t/2.swift -primary-file %t/3.swift -I %S/Inputs/inconsistent-implementation-only/ -verify
+// RUN: %target-swift-frontend -typecheck %t/1.swift %t/2.swift %t/3.swift -I %S/Inputs/inconsistent-implementation-only/ -verify
+
+// UNSUPPORTED: OS=windows-msvc
+
+//--- 1.swift
+
+@_weakLinked import NotSoSecret // expected-note {{imported with @_weakLinked here}}
+import NotSoSecret2 // expected-error {{'NotSoSecret2' inconsistently imported with @_weakLinked}} {{1-1=@_weakLinked }}
+import NotSoSecret3 // expected-error {{'NotSoSecret3' inconsistently imported with @_weakLinked}} {{1-1=@_weakLinked }}
+
+@_weakLinked import ActuallySecret // no-error
+import ActuallyOkay // no-error
+
+@_exported import Contradictory // expected-error {{'Contradictory' inconsistently imported with @_weakLinked}} {{12-12=@_weakLinked }}
+
+//--- 2.swift
+
+import NotSoSecret // expected-error {{'NotSoSecret' inconsistently imported with @_weakLinked}}
+@_weakLinked import NotSoSecret2 // expected-note 2 {{imported with @_weakLinked here}}
+import NotSoSecret3 // expected-error {{'NotSoSecret3' inconsistently imported with @_weakLinked}}
+
+@_weakLinked import ActuallySecret // no-error
+import ActuallyOkay // no-error
+
+@_weakLinked import Contradictory // expected-note {{imported with @_weakLinked here}}
+
+//--- 3.swift
+
+@_weakLinked import NotSoSecret
+import NotSoSecret2 // expected-error {{'NotSoSecret2' inconsistently imported with @_weakLinked}}
+@_weakLinked import NotSoSecret3 // expected-note 2 {{imported with @_weakLinked here}}
+
+@_weakLinked import ActuallySecret // no-error
+import ActuallyOkay // no-error


### PR DESCRIPTION
Just like for `@_implementationOnly import`, we need to diagnose inconsistency in use of the `@_weakLinked` attribute.

```swift
@_weakLinked import Foo
// ...
import Foo // error: 'Foo' inconsistently imported with @_weakLinked
```

Resolves rdar://98465034