### PR TITLE
[stdlib] add overflow checks for pointer arithmetic

### DIFF
--- a/stdlib/public/core/Pointer.swift
+++ b/stdlib/public/core/Pointer.swift
@@ -286,8 +286,13 @@ extension _Pointer /*: Strideable*/ {
   ///   `Pointee` type.
   @_transparent
   public func advanced(by n: Int) -> Self {
-    return Self(Builtin.gep_Word(
-      self._rawValue, n._builtinWordValue, Pointee.self))
+    _debugPrecondition(
+      n == 0 ||
+      (n > 0 ? (self < Self(bitPattern: -n*MemoryLayout<Pointee>.stride)!)
+             : (Self(bitPattern: -n*MemoryLayout<Pointee>.stride)! < self) ),
+      "Overflow in pointer arithmetic"
+    )
+    return Self(Builtin.gep_Word(_rawValue, n._builtinWordValue, Pointee.self))
   }
 }
 

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -482,7 +482,12 @@ extension UnsafeRawPointer: Strideable {
   // custom version for raw pointers
   @_transparent
   public func advanced(by n: Int) -> UnsafeRawPointer {
-    return UnsafeRawPointer(Builtin.gepRaw_Word(_rawValue, n._builtinWordValue))
+    _debugPrecondition(
+      n == 0 ||
+      (n > 0 ? (self < Self(bitPattern: -n)!) : (Self(bitPattern: -n)! < self)),
+      "Overflow in pointer arithmetic"
+    )
+    return .init(Builtin.gepRaw_Word(_rawValue, n._builtinWordValue))
   }
 }
 
@@ -1339,7 +1344,12 @@ extension UnsafeMutableRawPointer: Strideable {
   // custom version for raw pointers
   @_transparent
   public func advanced(by n: Int) -> UnsafeMutableRawPointer {
-    return UnsafeMutableRawPointer(Builtin.gepRaw_Word(_rawValue, n._builtinWordValue))
+    _debugPrecondition(
+      n == 0 ||
+      (n > 0 ? (self < Self(bitPattern: -n)!) : (Self(bitPattern: -n)! < self)),
+      "Overflow in pointer arithmetic"
+    )
+    return .init(Builtin.gepRaw_Word(_rawValue, n._builtinWordValue))
   }
 }
 


### PR DESCRIPTION
Pointer arithmetic uses operations that can overflow. This adds debug-mode overflow checks to the various pointer arithmetic functions.
(todo: add tests)

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.
(todo: find or write a bug for this.)
