### PR TITLE
[cxx-interop] Emit LValue type in a base subscript assignment expression

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4692,7 +4692,7 @@ synthesizeBaseClassFieldSetterBody(AbstractFunctionDecl *afd, void *context) {
 
     auto *argList = ArgumentList::forImplicitUnlabeled(ctx, {paramRefExpr});
     storedRef = SubscriptExpr::create(ctx, pointeePropertyRefExpr, argList, subscript);
-    storedRef->setType(subscript->getElementInterfaceType());
+    storedRef->setType(LValueType::get(subscript->getElementInterfaceType()));
   } else {
     // If the base class var has a clang decl, that means it's an access into a
     // stored field. Otherwise, we're looking into another base class, so it's a


### PR DESCRIPTION
This fixes an assertion that tripped when running `member-inline.swift` test with an unrelated patch:
```
type is not an l-value in LHS of assignment: Int32
...
3.	While walking into body of setter for subscript(_:) (in module 'MemberInline')
```