### PR TITLE
[Build] Update scripts to use dyld_info

### DIFF
--- a/utils/swift-darwin-postprocess.py
+++ b/utils/swift-darwin-postprocess.py
@@ -38,7 +38,7 @@ def unrpathize(filename):
         dylibsOutput = subprocess.check_output(
             ['xcrun', 'dyld_info', '-dependents', filename],
             universal_newlines=True)
-    except exceptions:
+    except:
         dylibsOutput = subprocess.check_output(
             ['xcrun', 'dyldinfo', '-dylibs', filename],
             universal_newlines=True)

--- a/utils/swift-darwin-postprocess.py
+++ b/utils/swift-darwin-postprocess.py
@@ -38,7 +38,7 @@ def unrpathize(filename):
         dylibsOutput = subprocess.check_output(
             ['xcrun', 'dyld_info', '-dependents', filename],
             universal_newlines=True)
-    except:
+    except subprocess.CalledProcessError:
         dylibsOutput = subprocess.check_output(
             ['xcrun', 'dyldinfo', '-dylibs', filename],
             universal_newlines=True)

--- a/utils/swift-darwin-postprocess.py
+++ b/utils/swift-darwin-postprocess.py
@@ -31,9 +31,17 @@ def main(arguments):
 # with runpath-relative loads of system libraries on some dyld versions.
 # (rdar://78851265)
 def unrpathize(filename):
-    dylibsOutput = subprocess.check_output(
-        ['xcrun', 'dyldinfo', '-dylibs', filename],
-        universal_newlines=True)
+    dylibsOutput = None
+    try:
+        # `dyldinfo` has been replaced with `dyld_info`, so we try it first
+        # before falling back to `dyldinfo`
+        dylibsOutput = subprocess.check_output(
+            ['xcrun', 'dyld_info', '-dependents', filename],
+            universal_newlines=True)
+    except exceptions:
+        dylibsOutput = subprocess.check_output(
+            ['xcrun', 'dyldinfo', '-dylibs', filename],
+            universal_newlines=True)
 
     # Do not rewrite @rpath-relative load commands for these libraries:
     # they are test support libraries that are never installed under

--- a/utils/swift-rpathize.py
+++ b/utils/swift-rpathize.py
@@ -62,7 +62,7 @@ def rpathize(filename):
         dylibsOutput = subprocess.check_output(
             ['xcrun', 'dyld_info', '-dependents', filename],
             universal_newlines=True)
-    except:
+    except subprocess.CalledProcessError:
         dylibsOutput = subprocess.check_output(
             ['xcrun', 'dyldinfo', '-dylibs', filename],
             universal_newlines=True)

--- a/utils/swift-rpathize.py
+++ b/utils/swift-rpathize.py
@@ -54,9 +54,18 @@ def main(arguments):
 
 
 def rpathize(filename):
-    dylibsOutput = subprocess.check_output(
-        ['xcrun', 'dyldinfo', '-dylibs', filename],
-        universal_newlines=True)
+    dylibsOutput = None
+
+    try:
+        # `dyldinfo` has been replaced with `dyld_info`, so we try it first
+        # before falling back to `dyldinfo`
+        dylibsOutput = subprocess.check_output(
+            ['xcrun', 'dyld_info', '-dependents', filename],
+            universal_newlines=True)
+    except exceptions:
+        dylibsOutput = subprocess.check_output(
+            ['xcrun', 'dyldinfo', '-dylibs', filename],
+            universal_newlines=True)
 
     # The output from dyldinfo -dylibs is a line of header followed by one
     # install name per line, indented with spaces.

--- a/utils/swift-rpathize.py
+++ b/utils/swift-rpathize.py
@@ -62,7 +62,7 @@ def rpathize(filename):
         dylibsOutput = subprocess.check_output(
             ['xcrun', 'dyld_info', '-dependents', filename],
             universal_newlines=True)
-    except exceptions:
+    except:
         dylibsOutput = subprocess.check_output(
             ['xcrun', 'dyldinfo', '-dylibs', filename],
             universal_newlines=True)


### PR DESCRIPTION
dyldinfo has been deprecated and will no longer be available on newer Xcode releases. It has been replaced with dyld_info. To stay compatible with older releases, we are still falling back to dyldinfo, if dyld_info is not available.

rdar://98570807