### PR TITLE
[Concurrency] Apply `@preconcurrency` to typealiases at the point of use

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -286,6 +286,27 @@ static Type getIdentityOpaqueTypeArchetypeType(
   return OpaqueTypeArchetypeType::get(opaqueDecl, interfaceType, subs);
 }
 
+/// Adjust the underlying type of a typealias within the given context to
+/// account for @preconcurrency.
+static Type adjustTypeAliasTypeInContext(
+    Type type, TypeAliasDecl *aliasDecl, DeclContext *fromDC) {
+  if (!aliasDecl->preconcurrency())
+    return type;
+
+  if (contextRequiresStrictConcurrencyChecking(
+          fromDC,
+          [](const AbstractClosureExpr *closure) {
+            return closure->getType();
+          },
+          [](const ClosureExpr *closure) {
+            return closure->isIsolatedByPreconcurrency();
+          }))
+    return type;
+
+  return type->stripConcurrency(
+      /*recurse=*/true, /*dropGlobalActor=*/true);
+}
+
 Type TypeResolution::resolveTypeInContext(TypeDecl *typeDecl,
                                           DeclContext *foundDC,
                                           bool isSpecialized) const {
@@ -306,6 +327,13 @@ Type TypeResolution::resolveTypeInContext(TypeDecl *typeDecl,
 
     return genericParam->getDeclaredInterfaceType();
   }
+
+  /// Call this function before returning the underlying type of a typealias,
+  /// to adjust its type for concurrency.
+  auto adjustAliasType = [&](Type type) -> Type {
+    return adjustTypeAliasTypeInContext(
+        type, cast<TypeAliasDecl>(typeDecl), fromDC);
+  };
 
   if (!isSpecialized) {
     // If we are referring to a type within its own context, and we have either
@@ -342,9 +370,9 @@ Type TypeResolution::resolveTypeInContext(TypeDecl *typeDecl,
               if (ugAliasDecl == aliasDecl) {
                 if (getStage() == TypeResolutionStage::Structural &&
                     aliasDecl->getUnderlyingTypeRepr() != nullptr) {
-                  return aliasDecl->getStructuralType();
+                  return adjustAliasType(aliasDecl->getStructuralType());
                 }
-                return aliasDecl->getDeclaredInterfaceType();
+                return adjustAliasType(aliasDecl->getDeclaredInterfaceType());
               }
 
               extendedType = unboundGeneric->getParent();
@@ -356,9 +384,9 @@ Type TypeResolution::resolveTypeInContext(TypeDecl *typeDecl,
             if (aliasType->getDecl() == aliasDecl) {
               if (getStage() == TypeResolutionStage::Structural &&
                   aliasDecl->getUnderlyingTypeRepr() != nullptr) {
-                return aliasDecl->getStructuralType();
+                return adjustAliasType(aliasDecl->getStructuralType());
               }
-              return aliasDecl->getDeclaredInterfaceType();
+              return adjustAliasType(aliasDecl->getDeclaredInterfaceType());
             }
             extendedType = aliasType->getParent();
             continue;
@@ -381,9 +409,9 @@ Type TypeResolution::resolveTypeInContext(TypeDecl *typeDecl,
       // Otherwise, return the appropriate type.
       if (getStage() == TypeResolutionStage::Structural &&
           aliasDecl->getUnderlyingTypeRepr() != nullptr) {
-        return aliasDecl->getStructuralType();
+        return adjustAliasType(aliasDecl->getStructuralType());
       }
-      return aliasDecl->getDeclaredInterfaceType();
+      return adjustAliasType(aliasDecl->getDeclaredInterfaceType());
     }
 
     // When a nominal type used outside its context, return the unbound
@@ -1590,6 +1618,12 @@ static Type resolveNestedIdentTypeComponent(TypeResolution resolution,
   auto maybeDiagnoseBadMemberType = [&](TypeDecl *member, Type memberType,
                                         AssociatedTypeDecl *inferredAssocType) {
     bool hasUnboundOpener = !!resolution.getUnboundTypeOpener();
+
+    // Type aliases might require adjustment due to @preconcurrency.
+    if (auto aliasDecl = dyn_cast<TypeAliasDecl>(member)) {
+      memberType = adjustTypeAliasTypeInContext(
+          memberType, aliasDecl, resolution.getDeclContext());
+    }
 
     if (options.contains(TypeResolutionFlags::SilenceErrors)) {
       if (TypeChecker::isUnsupportedMemberTypeAccess(parentTy, member,
@@ -4493,6 +4527,7 @@ public:
       }
     } else if (auto *alias = dyn_cast_or_null<TypeAliasDecl>(comp->getBoundDecl())) {
       auto type = Type(alias->getDeclaredInterfaceType()->getDesugaredType());
+
       // If this is a type alias to a constraint type, the type
       // alias name must be prefixed with 'any' to be used as an
       // existential type.

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -67,6 +67,9 @@ enum class TypeResolutionFlags : uint16_t {
   /// Needed to enforce that \c any P<some Q> does not resolve to a
   /// parameterized existential with an opaque type constraint.
   DisallowOpaqueTypes = 1 << 9,
+
+  /// We are in a `@preconcurrency` declaration.
+  Preconcurrency = 1 << 10,
 };
 
 /// Type resolution contexts that require special handling.

--- a/test/Concurrency/preconcurrency_typealias.swift
+++ b/test/Concurrency/preconcurrency_typealias.swift
@@ -1,0 +1,34 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+// REQUIRES: concurrency
+
+@preconcurrency @MainActor func f() { }
+// expected-note@-1 2{{calls to global function 'f()' from outside of its actor context are implicitly asynchronous}}
+
+@preconcurrency typealias FN = @Sendable () -> Void
+
+struct Outer {
+  @preconcurrency typealias FN = @Sendable () -> Void
+}
+
+func test() {
+  var _: Outer.FN = {
+    f()
+  }
+
+  var _: FN = {
+    f()
+    print("Hello")
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+func testAsync() async {
+  var _: Outer.FN = {
+    f() // expected-error{{call to main actor-isolated global function 'f()' in a synchronous nonisolated context}}
+  }
+
+  var _: FN = {
+    f() // expected-error{{call to main actor-isolated global function 'f()' in a synchronous nonisolated context}}
+    print("Hello")
+  }
+}

--- a/test/Concurrency/preconcurrency_typealias.swift
+++ b/test/Concurrency/preconcurrency_typealias.swift
@@ -12,13 +12,6 @@ struct Outer {
 
 @preconcurrency func preconcurrencyFunc(callback: FN) {}
 
-func usage() {
-}
-
-func usageAsync() async {
-}
-
-
 func test() {
   var _: Outer.FN = {
     f()

--- a/test/Concurrency/preconcurrency_typealias.swift
+++ b/test/Concurrency/preconcurrency_typealias.swift
@@ -10,6 +10,15 @@ struct Outer {
   @preconcurrency typealias FN = @Sendable () -> Void
 }
 
+@preconcurrency func preconcurrencyFunc(callback: FN) {}
+
+func usage() {
+}
+
+func usageAsync() async {
+}
+
+
 func test() {
   var _: Outer.FN = {
     f()
@@ -19,6 +28,12 @@ func test() {
     f()
     print("Hello")
   }
+
+  var mutableVariable = 0
+  preconcurrencyFunc {
+    mutableVariable += 1 // no sendable warning
+  }
+  mutableVariable += 1
 }
 
 @available(SwiftStdlib 5.1, *)
@@ -31,4 +46,10 @@ func testAsync() async {
     f() // expected-error{{call to main actor-isolated global function 'f()' in a synchronous nonisolated context}}
     print("Hello")
   }
+
+  var mutableVariable = 0
+  preconcurrencyFunc {
+    mutableVariable += 1 // expected-warning{{mutation of captured var 'mutableVariable' in concurrently-executing code; this is an error in Swift 6}}
+  }
+  mutableVariable += 1
 }


### PR DESCRIPTION
When referencing a `@preconcurrency` typealias from code that does not
require strict concurrency, strip off `@Sendable` and global actor
types. This is consistent with references to functions/properties/etc.
that are `@preconcurrency`.

Fixes https://github.com/apple/swift/issues/60487, https://github.com/apple/swift/issues/60488., rdar://98343624.
