### PR TITLE
[ConstraintSystem] NFC: Check whether opened type has a binding befor…

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1545,6 +1545,10 @@ public:
   /// Retrieve the fixed score of this solution
   Score &getFixedScore() { return FixedScore; }
 
+  /// Check whether this solution has a fixed binding for the given type
+  /// variable.
+  bool hasFixedType(TypeVariableType *typeVar) const;
+
   /// Retrieve the fixed type for the given type variable.
   Type getFixedType(TypeVariableType *typeVar) const;
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -53,6 +53,11 @@
 using namespace swift;
 using namespace constraints;
 
+bool Solution::hasFixedType(TypeVariableType *typeVar) const {
+  auto knownBinding = typeBindings.find(typeVar);
+  return knownBinding != typeBindings.end();
+}
+
 /// Retrieve the fixed type for the given type variable.
 Type Solution::getFixedType(TypeVariableType *typeVar) const {
   auto knownBinding = typeBindings.find(typeVar);

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1362,10 +1362,19 @@ void Solution::dump(raw_ostream &out) const {
             Type(opened.first).print(out, PO);
             out << ")";
             out << " -> ";
-            out << getFixedType(opened.second);
-            out << " [from ";
-            Type(opened.second).print(out, PO);
-            out << "]";
+            // Let's check whether the type variable has been bound.
+            // This is important when solver is working on result
+            // builder transformed code, because dependent sub-components
+            // would not have parent type variables but `OpenedTypes`
+            // cannot be erased, so we'll just print them as unbound.
+            if (hasFixedType(opened.second)) {
+              out << getFixedType(opened.second);
+              out << " [from ";
+              Type(opened.second).print(out, PO);
+              out << "]";
+            } else {
+              Type(opened.second).print(out, PO);
+            }
           },
           [&]() { out << ", "; });
       out << "\n";


### PR DESCRIPTION
…e printing

In some circumstances opened type might not have a fixed binding.
A good example could be dependent sub-component produced for
result builder transformed code (connected via one-way constraints),
in such a case `OpenedTypes` would have outer generic parameters
but they might not be bound yet, so they have to be printed as
type variables.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
