### PR TITLE
vcruntime: adjust module definition further

### DIFF
--- a/stdlib/public/Platform/vcruntime.modulemap
+++ b/stdlib/public/Platform/vcruntime.modulemap
@@ -652,4 +652,24 @@ module std [system] {
     header "version"
     export *
   }
+
+  explicit module xmemory {
+    header "xmemory"
+    export *
+  }
+
+  explicit module xtr1common {
+    header "xtr1common"
+    export *
+  }
+
+  explicit module xstring {
+    header "xstring"
+    export *
+  }
+
+  explicit module xtree {
+    header "xtree"
+    export *
+  }
 }


### PR DESCRIPTION
Add some of the x* headers to the c++ module.  These are included
multiply and so we create private modules for them rather than
associate them with a different module which could cause issues
in practice due to intra-module dependencies.