### PR TITLE
[Emacs] Fix dir-locals.el.

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -11,6 +11,7 @@
           (add-to-list 'load-path
                        (concat this-directory "utils")
                        :append)
+          (defvar swift-project-directory)
           (let ((swift-project-directory this-directory))
             (require 'swift-project-settings)))
         (set (make-local-variable 'swift-project-directory)


### PR DESCRIPTION
dir-locals.el needs to `(defvar swift-project-directory)`, otherwise we get an error from Emacs later on because the `let` has bound it as the wrong kind of variable.
