### PR TITLE
[Test] Disable SILOptimizer/accessutils.sil on armv7k/arm64_32.

### DIFF
--- a/test/SILOptimizer/accessutils.sil
+++ b/test/SILOptimizer/accessutils.sil
@@ -2,6 +2,9 @@
 
 // REQUIRES: swift_in_compiler
 
+// Test is failing when targeting ARMv7k/ARM64_32. rdar://98669547
+// UNSUPPORTED: CPU=armv7k || CPU=arm64_32
+
 sil_stage canonical
 
 import Builtin


### PR DESCRIPTION
The test is failing for armv7k/arm64_32.