### PR TITLE
IDE: convert `PrimaryFile` path to the native spelling

### DIFF
--- a/lib/IDE/Utils.cpp
+++ b/lib/IDE/Utils.cpp
@@ -199,7 +199,6 @@ static FrontendInputsAndOutputs resolveSymbolicLinksInInputs(
   llvm::SmallString<128> PrimaryFile;
   if (auto err = FileSystem->getRealPath(UnresolvedPrimaryFile, PrimaryFile))
     PrimaryFile = UnresolvedPrimaryFile;
-  llvm::sys::path::native(PrimaryFile);
 
   unsigned primaryCount = 0;
   // FIXME: The frontend should be dealing with symlinks, maybe similar to
@@ -209,7 +208,7 @@ static FrontendInputsAndOutputs resolveSymbolicLinksInInputs(
     llvm::SmallString<128> newFilename;
     if (auto err = FileSystem->getRealPath(input.getFileName(), newFilename))
       newFilename = input.getFileName();
-    llvm::sys::path::native(newFilename);
+    llvm::sys::path::native(newFilename, llvm::sys::path::Style::posix);
     bool newIsPrimary = input.isPrimary() ||
                         (!PrimaryFile.empty() && PrimaryFile == newFilename);
     if (newIsPrimary) {

--- a/lib/IDE/Utils.cpp
+++ b/lib/IDE/Utils.cpp
@@ -199,6 +199,7 @@ static FrontendInputsAndOutputs resolveSymbolicLinksInInputs(
   llvm::SmallString<128> PrimaryFile;
   if (auto err = FileSystem->getRealPath(UnresolvedPrimaryFile, PrimaryFile))
     PrimaryFile = UnresolvedPrimaryFile;
+  llvm::sys::path::native(PrimaryFile);
 
   unsigned primaryCount = 0;
   // FIXME: The frontend should be dealing with symlinks, maybe similar to


### PR DESCRIPTION
Make sure that we use the native file system representation for the path
to the primary input.  This is important for the case where we compare
the input set.  This was identified when running the SourceKit-LSP test
suite on Windows.

Thanks to @ahoppen for the discussion around this!
