### PR TITLE
stdlib: Sprinkle an __always inline onto Range.index(after:)

### DIFF
--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -229,6 +229,7 @@ where Bound: Strideable, Bound.Stride: SignedInteger
   public var endIndex: Index { return upperBound }
 
   @inlinable
+  @inline(__always)
   public func index(after i: Index) -> Index {
     _failEarlyRangeCheck(i, bounds: startIndex..<endIndex)
 


### PR DESCRIPTION
After moving to the new llvm pass pipeline this function no longer gets
inlined. Leading to 150% regressions in ObjectiveCBridge benchmarks.

rdar://98533158
