### PR TITLE
[Interop][SwiftToCxx] Update current enum implementation for new enum design

### DIFF
--- a/docs/CppInteroperability/UserGuide-CallingSwiftFromC++.md
+++ b/docs/CppInteroperability/UserGuide-CallingSwiftFromC++.md
@@ -595,7 +595,7 @@ enum value will abort the program.
 A resilient Swift enumeration value could represent a case that's unknown to the client.
 Swift forces the client to check if the value is `@uknown default` when switching over
 the enumeration to account for that. C++ follows a similar principle,
-by exposing an `unknown_default` case that can then be matched in a switch.
+by exposing an `unknownDefault` case that can then be matched in a switch.
 
 For example, given the following resilient enumeration:
 
@@ -620,14 +620,14 @@ void test(const DateFormatStyle &style) {
   case DateFormatStyle::full:
     ...
     break;
-  case DateFormatStyle::unknown_default: // just like Swift's @unknown default
+  case DateFormatStyle::unknownDefault: // just like Swift's @unknown default
     // Some case value added in a future version of enum.
     break;
   }
 }
 ```
 
-The `unknown_default` case value is not a constructible case and you will get a compiler error if you try to construct it in C++.
+The `unknownDefault` case value is not a constructible case and you will get a compiler error if you try to construct it in C++.
 
 ## Using Swift Class Types
 

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -414,94 +414,55 @@ private:
         return p1.second.tag < p2.second.tag;
       });
 
-      if (elementTagMapping.empty()) {
-        os << "\n";
-        return;
-      }
-
-      os << "  enum class cases {\n";
-      for (const auto &pair : elementTagMapping) {
-        os << "    ";
+      os << '\n';
+      os << "  enum class cases {";
+      llvm::interleave(elementTagMapping, os, [&](const auto &pair){
+        os << "\n    ";
         syntaxPrinter.printIdentifier(pair.first->getNameStr());
-        os << ",\n";
-      }
-      os << "  };\n"; // enum class cases' closing bracket
-
-      // Printing operator cases()
-      os << "  inline operator cases() const {\n";
+      }, ",");
+      // TODO: allow custom name for this special case
+      auto resilientUnknownDefaultCaseName = "unknownDefault";
       if (ED->isResilient()) {
-        os << "    auto tag = _getEnumTag();\n";
-        for (const auto &pair : elementTagMapping) {
-          os << "    if (tag == " << cxx_synthesis::getCxxImplNamespaceName();
-          os << "::" << pair.second.globalVariableName << ") return cases::";
-          syntaxPrinter.printIdentifier(pair.first->getNameStr());
-          os << ";\n";
-        }
-        // TODO: change to Swift's fatalError when it's available in C++
-        os << "    abort();\n";
-      } else { // non-resilient enum
-        os << "    switch (_getEnumTag()) {\n";
-        for (const auto &pair : elementTagMapping) {
-          os << "      case " << pair.second.tag << ": return cases::";
-          syntaxPrinter.printIdentifier(pair.first->getNameStr());
-          os << ";\n";
-        }
-        // TODO: change to Swift's fatalError when it's available in C++
-        os << "      default: abort();\n";
-        os << "    }\n"; // switch's closing bracket
+        os << ",\n    " << resilientUnknownDefaultCaseName;
       }
-      os << "  }\n";   // operator cases()'s closing bracket
-
-      if (ED->isResilient()) {
-        os << "  inline bool inResilientUnknownCase() const {\n";
-        os << "    auto tag = _getEnumTag();\n";
-        os << "    return";
-        llvm::interleave(
-            elementTagMapping, os,
-            [&](const auto &pair) {
-              os << "\n      tag != " << cxx_synthesis::getCxxImplNamespaceName()
-                 << "::" << pair.second.globalVariableName;
-            },
-            " &&");
-        os << ";\n";
-        os << "  }\n";
-      }
-
-      // Printing case-related functions
+      os << "\n  };\n\n"; // enum class cases' closing bracket
+      
+      // Printing struct, is, and get functions for each case
       DeclAndTypeClangFunctionPrinter clangFuncPrinter(
           os, owningPrinter.prologueOS, owningPrinter.typeMapping,
           owningPrinter.interopContext);
-
-      for (const auto &pair : elementTagMapping) {
+      
+      auto printIsFunction = [&](StringRef caseName, EnumDecl *ED) {
         os << "  inline bool is";
-        auto name = pair.first->getNameStr().str();
+        std::string name;
+        llvm::raw_string_ostream nameStream(name);
+        ClangSyntaxPrinter(nameStream).printIdentifier(caseName);
         name[0] = std::toupper(name[0]);
         os << name << "() const {\n";
-        os << "    return _getEnumTag() == ";
-        if (ED->isResilient()) {
-          os << cxx_synthesis::getCxxImplNamespaceName()
-             << "::" << pair.second.globalVariableName;
-        } else {
-          os << pair.second.tag;
-        }
-        os << ";\n  }\n";
-
-        if (!pair.first->hasAssociatedValues()) {
-          continue;
-        }
-
-        auto associatedValueList = pair.first->getParameterList();
+        os << "    return *this == ";
+        syntaxPrinter.printBaseName(ED);
+        os << "::";
+        syntaxPrinter.printIdentifier(caseName);
+        os << ";\n";
+        os << "  }\n";
+      };
+      
+      auto printGetFunction = [&](EnumElementDecl *elementDecl) {
+        auto associatedValueList = elementDecl->getParameterList();
         // TODO: add tuple type support
         if (associatedValueList->size() > 1) {
-          continue;
+          return;
         }
         auto firstType = associatedValueList->front()->getType();
         auto firstTypeDecl = firstType->getNominalOrBoundGenericNominal();
         OptionalTypeKind optKind;
         std::tie(firstType, optKind) =
             getObjectTypeAndOptionality(firstTypeDecl, firstType);
-
-        // FIXME: (tongjie) may have to forward declare return type
+        
+        auto name = elementDecl->getNameStr().str();
+        name[0] = std::toupper(name[0]);
+        
+        // FIXME: may have to forward declare return type
         os << "  inline ";
         clangFuncPrinter.printClangFunctionReturnType(
             firstType, optKind, firstTypeDecl->getModuleContext(),
@@ -509,12 +470,12 @@ private:
         os << " get" << name << "() const {\n";
         os << "    if (!is" << name << "()) abort();\n";
         os << "    alignas(";
-        syntaxPrinter.printBaseName(ED);
+        syntaxPrinter.printBaseName(elementDecl->getParentEnum());
         os << ") unsigned char buffer[sizeof(";
-        syntaxPrinter.printBaseName(ED);
+        syntaxPrinter.printBaseName(elementDecl->getParentEnum());
         os << ")];\n";
         os << "    auto *thisCopy = new(buffer) ";
-        syntaxPrinter.printBaseName(ED);
+        syntaxPrinter.printBaseName(elementDecl->getParentEnum());
         os << "(*this);\n";
         os << "    char * _Nonnull payloadFromDestruction = "
               "thisCopy->_destructiveProjectEnumData();\n";
@@ -531,7 +492,7 @@ private:
         } else {
           os << "    return ";
           syntaxPrinter.printModuleNamespaceQualifiersIfNeeded(
-              firstTypeDecl->getModuleContext(), ED->getModuleContext());
+              firstTypeDecl->getModuleContext(), elementDecl->getParentEnum()->getModuleContext());
           os << cxx_synthesis::getCxxImplNamespaceName();
           os << "::";
           ClangValueTypePrinter::printCxxImplClassName(os, firstTypeDecl);
@@ -542,8 +503,77 @@ private:
           os << "::initializeWithTake(result, payloadFromDestruction);\n";
           os << "    });\n";
         }
-        os << "  }\n";
+        os << "  }\n";  // closing bracket of get function
+      };
+      
+      auto printStruct = [&](StringRef caseName, EnumElementDecl *elementDecl) {
+        os << "  static struct {  // impl struct for case " << caseName << '\n';
+        os << "    inline constexpr operator cases() const {\n";
+        os << "      return cases::";
+        syntaxPrinter.printIdentifier(caseName);
+        os << ";\n";
+        os << "    }\n";
+        if (elementDecl != nullptr) {
+          os << "    inline ";
+          syntaxPrinter.printBaseName(elementDecl->getParentEnum());
+          os << " operator()(";
+          // TODO: implement parameter for associated value
+          os << ") const {\n";
+          // TODO: print _make for now; need to implement actual code making an enum
+          os << "      return ";
+          syntaxPrinter.printBaseName(elementDecl->getParentEnum());
+          os << "::_make();\n";
+          os << "    }\n";
+        }
+        os << "  } ";
+        syntaxPrinter.printIdentifier(caseName);
+        os << ";\n";
+      };
+
+      for (const auto &pair : elementTagMapping) {
+        // Printing struct
+        printStruct(pair.first->getNameStr(), pair.first);
+        // Printing `is` function
+        printIsFunction(pair.first->getNameStr(), ED);
+        if (pair.first->hasAssociatedValues()) {
+          // Printing `get` function
+          printGetFunction(pair.first);
+        }
+        os << '\n';
       }
+      
+      if (ED->isResilient()) {
+        // Printing struct for unknownDefault
+        printStruct(resilientUnknownDefaultCaseName, /* elementDecl */ nullptr);
+        // Printing isUnknownDefault
+        printIsFunction(resilientUnknownDefaultCaseName, ED);
+        os << '\n';
+      }
+      os << '\n';
+      
+      // Printing operator cases()
+      os << "  inline operator cases() const {\n";
+      if (ED->isResilient()) {
+        os << "    auto tag = _getEnumTag();\n";
+        for (const auto &pair : elementTagMapping) {
+          os << "    if (tag == " << cxx_synthesis::getCxxImplNamespaceName();
+          os << "::" << pair.second.globalVariableName << ") return cases::";
+          syntaxPrinter.printIdentifier(pair.first->getNameStr());
+          os << ";\n";
+        }
+        os << "    return cases::" << resilientUnknownDefaultCaseName << ";\n";
+      } else { // non-resilient enum
+        os << "    switch (_getEnumTag()) {\n";
+        for (const auto &pair : elementTagMapping) {
+          os << "      case " << pair.second.tag << ": return cases::";
+          syntaxPrinter.printIdentifier(pair.first->getNameStr());
+          os << ";\n";
+        }
+        // TODO: change to Swift's fatalError when it's available in C++
+        os << "      default: abort();\n";
+        os << "    }\n"; // switch's closing bracket
+      }
+      os << "  }\n";   // operator cases()'s closing bracket
       os << "\n";
     });
     os << outOfLineDefinitions;

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -416,22 +416,25 @@ private:
 
       os << '\n';
       os << "  enum class cases {";
-      llvm::interleave(elementTagMapping, os, [&](const auto &pair){
-        os << "\n    ";
-        syntaxPrinter.printIdentifier(pair.first->getNameStr());
-      }, ",");
+      llvm::interleave(
+          elementTagMapping, os,
+          [&](const auto &pair) {
+            os << "\n    ";
+            syntaxPrinter.printIdentifier(pair.first->getNameStr());
+          },
+          ",");
       // TODO: allow custom name for this special case
       auto resilientUnknownDefaultCaseName = "unknownDefault";
       if (ED->isResilient()) {
         os << ",\n    " << resilientUnknownDefaultCaseName;
       }
       os << "\n  };\n\n"; // enum class cases' closing bracket
-      
+
       // Printing struct, is, and get functions for each case
       DeclAndTypeClangFunctionPrinter clangFuncPrinter(
           os, owningPrinter.prologueOS, owningPrinter.typeMapping,
           owningPrinter.interopContext);
-      
+
       auto printIsFunction = [&](StringRef caseName, EnumDecl *ED) {
         os << "  inline bool is";
         std::string name;
@@ -446,7 +449,7 @@ private:
         os << ";\n";
         os << "  }\n";
       };
-      
+
       auto printGetFunction = [&](EnumElementDecl *elementDecl) {
         auto associatedValueList = elementDecl->getParameterList();
         // TODO: add tuple type support
@@ -458,10 +461,10 @@ private:
         OptionalTypeKind optKind;
         std::tie(firstType, optKind) =
             getObjectTypeAndOptionality(firstTypeDecl, firstType);
-        
+
         auto name = elementDecl->getNameStr().str();
         name[0] = std::toupper(name[0]);
-        
+
         // FIXME: may have to forward declare return type
         os << "  inline ";
         clangFuncPrinter.printClangFunctionReturnType(
@@ -492,7 +495,8 @@ private:
         } else {
           os << "    return ";
           syntaxPrinter.printModuleNamespaceQualifiersIfNeeded(
-              firstTypeDecl->getModuleContext(), elementDecl->getParentEnum()->getModuleContext());
+              firstTypeDecl->getModuleContext(),
+              elementDecl->getParentEnum()->getModuleContext());
           os << cxx_synthesis::getCxxImplNamespaceName();
           os << "::";
           ClangValueTypePrinter::printCxxImplClassName(os, firstTypeDecl);
@@ -503,9 +507,9 @@ private:
           os << "::initializeWithTake(result, payloadFromDestruction);\n";
           os << "    });\n";
         }
-        os << "  }\n";  // closing bracket of get function
+        os << "  }\n"; // closing bracket of get function
       };
-      
+
       auto printStruct = [&](StringRef caseName, EnumElementDecl *elementDecl) {
         os << "  static struct {  // impl struct for case " << caseName << '\n';
         os << "    inline constexpr operator cases() const {\n";
@@ -519,7 +523,7 @@ private:
           os << " operator()(";
           // TODO: implement parameter for associated value
           os << ") const {\n";
-          // TODO: print _make for now; need to implement actual code making an enum
+          // TODO: print _make for now; need to print actual code making an enum
           os << "      return ";
           syntaxPrinter.printBaseName(elementDecl->getParentEnum());
           os << "::_make();\n";
@@ -541,7 +545,7 @@ private:
         }
         os << '\n';
       }
-      
+
       if (ED->isResilient()) {
         // Printing struct for unknownDefault
         printStruct(resilientUnknownDefaultCaseName, /* elementDecl */ nullptr);
@@ -550,7 +554,7 @@ private:
         os << '\n';
       }
       os << '\n';
-      
+
       // Printing operator cases()
       os << "  inline operator cases() const {\n";
       if (ED->isResilient()) {
@@ -573,7 +577,7 @@ private:
         os << "      default: abort();\n";
         os << "    }\n"; // switch's closing bracket
       }
-      os << "  }\n";   // operator cases()'s closing bracket
+      os << "  }\n"; // operator cases()'s closing bracket
       os << "\n";
     });
     os << outOfLineDefinitions;

--- a/lib/PrintAsClang/PrintClangValueType.cpp
+++ b/lib/PrintAsClang/PrintClangValueType.cpp
@@ -257,8 +257,9 @@ void ClangValueTypePrinter::printValueTypeDecl(
   os << "};\n";
   // Print the definition of enum static struct data memebers
   if (isa<EnumDecl>(typeDecl)) {
-    auto tagMapping = interopContext.getIrABIDetails().getEnumTagMapping(cast<EnumDecl>(typeDecl));
-    for (const auto& pair : tagMapping) {
+    auto tagMapping = interopContext.getIrABIDetails().getEnumTagMapping(
+        cast<EnumDecl>(typeDecl));
+    for (const auto &pair : tagMapping) {
       os << "decltype(";
       printer.printBaseName(typeDecl);
       os << "::";

--- a/lib/PrintAsClang/PrintClangValueType.cpp
+++ b/lib/PrintAsClang/PrintClangValueType.cpp
@@ -254,7 +254,35 @@ void ClangValueTypePrinter::printValueTypeDecl(
   os << "  friend class " << cxx_synthesis::getCxxImplNamespaceName() << "::";
   printCxxImplClassName(os, typeDecl);
   os << ";\n";
-  os << "};\n\n";
+  os << "};\n";
+  // Print the definition of enum static struct data memebers
+  if (isa<EnumDecl>(typeDecl)) {
+    auto tagMapping = interopContext.getIrABIDetails().getEnumTagMapping(cast<EnumDecl>(typeDecl));
+    for (const auto& pair : tagMapping) {
+      os << "decltype(";
+      printer.printBaseName(typeDecl);
+      os << "::";
+      printer.printIdentifier(pair.first->getNameStr());
+      os << ") ";
+      printer.printBaseName(typeDecl);
+      os << "::";
+      printer.printIdentifier(pair.first->getNameStr());
+      os << ";\n";
+    }
+    if (isOpaqueLayout) {
+      os << "decltype(";
+      printer.printBaseName(typeDecl);
+      // TODO: allow custom name for this special case
+      os << "::";
+      printer.printIdentifier("unknownDefault");
+      os << ") ";
+      printer.printBaseName(typeDecl);
+      os << "::";
+      printer.printIdentifier("unknownDefault");
+      os << ";\n";
+    }
+  }
+  os << '\n';
 
   const auto *moduleContext = typeDecl->getModuleContext();
   // Print out the "hidden" _impl class.

--- a/test/Interop/SwiftToCxx/enums/resilient-enum-in-cxx-execution.cpp
+++ b/test/Interop/SwiftToCxx/enums/resilient-enum-in-cxx-execution.cpp
@@ -18,22 +18,37 @@
 #include <iostream>
 #include "enums.h"
 
+using namespace Enums;
+
+void useFooInSwitch(const Foo& f) {
+  switch (f) {
+    case Foo::a:
+      std::cout << "Foo::a\n";
+      break;;
+    case Foo::unknownDefault:
+      std::cout << "Foo::unknownDefault\n";
+      break;
+  }
+}
+
 int main() {
-  using namespace Enums;
   auto f1 = makeFoo(10);
   auto f2 = makeFoo(-10);
 
   printFoo(f1);
   printFoo(f2);
 
-  assert(!f2.inResilientUnknownCase());
-  if (f1.inResilientUnknownCase()) {
+  assert(!f2.isUnknownDefault());
+  if (f1.isUnknownDefault()) {
     std::cout << "f1.inResilientUnknownCase()\n";
     assert(!f1.isA());
   } else {
     assert(f1.isA());
     assert(f1.getA() == 10.0);
   }
+
+  useFooInSwitch(f1);
+  useFooInSwitch(f2);
 
   return 0;
 }
@@ -43,3 +58,7 @@ int main() {
 // CHECK-NEXT: a(-10.0)
 
 // NEW_CASE: f1.inResilientUnknownCase()
+
+// NEW_CASE: Foo::unknownDefault
+// OLD_CASE: Foo::a
+// CHECK-NEXT: Foo::a

--- a/test/Interop/SwiftToCxx/enums/resilient-enum-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/resilient-enum-in-cxx.swift
@@ -42,22 +42,22 @@ public func printFoo(_ x: Foo) {
 // CHECK-EMPTY:
 // CHECK-NEXT:    class Foo final {
 // CHECK-NEXT:    public:
+// CHECK:         enum class cases {
+// CHECK-NEXT:      a,
+// NEW_CASE-NEXT:   b,
+// CHECK-NEXT:      unknownDefault
+// CHECK-NEXT:    }
+// CHECK:         static struct {  // impl struct for case unknownDefault
+// CHECK-NEXT:      constexpr operator cases() const {
+// CHECK-NEXT:        return cases::unknownDefault;
+// CHECK-NEXT:      }
+// CHECK-NEXT:    } unknownDefault;
+// CHECK-NEXT:    inline bool isUnknownDefault() const {
+// CHECK-NEXT:      return *this == Foo::unknownDefault;
+// CHECK-NEXT:    }
 // CHECK:         inline operator cases() const {
 // CHECK-NEXT:      auto tag = _getEnumTag();
 // CHECK-NEXT:      if (tag == _impl::$s5Enums3FooO1ayACSdcACmFWC) return cases::a;
 // NEW_CASE-NEXT:   if (tag == _impl::$s5Enums3FooO1byACSicACmFWC) return cases::b;
-// CHECK-NEXT:      abort();
+// CHECK-NEXT:      return cases::unknownDefault;
 // CHECK-NEXT:    }
-// CHECK-NEXT:    inline bool inResilientUnknownCase() const {
-// CHECK-NEXT:      auto tag = _getEnumTag();
-// CHECK-NEXT:      return
-// OLD_CASE-NEXT:     tag != _impl::$s5Enums3FooO1ayACSdcACmFWC;
-// NEW_CASE-NEXT:     tag != _impl::$s5Enums3FooO1ayACSdcACmFWC &&
-// NEW_CASE-NEXT:     tag != _impl::$s5Enums3FooO1byACSicACmFWC;
-// CHECK-NEXT:    }
-// CHECK-NEXT:    inline bool isA() const {
-// CHECK-NEXT:      return _getEnumTag() == _impl::$s5Enums3FooO1ayACSdcACmFWC;
-// CHECK-NEXT:    }
-// NEW_CASE:      inline bool isB() const {
-// NEW_CASE-NEXT:   return _getEnumTag() == _impl::$s5Enums3FooO1byACSicACmFWC;
-// NEW_CASE-NEXT: }

--- a/test/Interop/SwiftToCxx/enums/swift-enum-case-functions.swift
+++ b/test/Interop/SwiftToCxx/enums/swift-enum-case-functions.swift
@@ -207,6 +207,7 @@ public func checkIntDoubleOrBignum(_ x: IntDoubleOrBignum, tag: Int) -> Bool {
 // CHECK-NEXT:     default: abort();
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
+// CHECK:      private:
 // CHECK:      inline int _getEnumTag() const {
 // CHECK-NEXT:   auto metadata = _impl::$s5Enums12BoolWithCaseOMa(0);
 // CHECK-NEXT:   auto *vwTableAddr = reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1;
@@ -218,6 +219,10 @@ public func checkIntDoubleOrBignum(_ x: IntDoubleOrBignum, tag: Int) -> Bool {
 // CHECK-NEXT:   const auto *enumVWTable = reinterpret_cast<swift::_impl::EnumValueWitnessTable *>(vwTable);
 // CHECK-NEXT:   return enumVWTable->getEnumTag(_getOpaquePointer(), metadata._0);
 // CHECK-NEXT: }
+// CHECK:      };
+// CHECK-NEXT: decltype(BoolWithCase::first) BoolWithCase::first;
+// CHECK-NEXT: decltype(BoolWithCase::second) BoolWithCase::second;
+// CHECK-NEXT: decltype(BoolWithCase::third) BoolWithCase::third;
 
 // CHECK: class CLikeEnum final {
 
@@ -277,6 +282,10 @@ public func checkIntDoubleOrBignum(_ x: IntDoubleOrBignum, tag: Int) -> Bool {
 // CHECK-NEXT:   const auto *enumVWTable = reinterpret_cast<swift::_impl::EnumValueWitnessTable *>(vwTable);
 // CHECK-NEXT:   return enumVWTable->getEnumTag(_getOpaquePointer(), metadata._0);
 // CHECK-NEXT: }
+// CHECK:      };
+// CHECK-NEXT: decltype(CLikeEnum::one) CLikeEnum::one;
+// CHECK-NEXT: decltype(CLikeEnum::two) CLikeEnum::two;
+// CHECK-NEXT: decltype(CLikeEnum::three) CLikeEnum::three;
 
 // CHECK: class DataCase final {
 
@@ -319,6 +328,8 @@ public func checkIntDoubleOrBignum(_ x: IntDoubleOrBignum, tag: Int) -> Bool {
 // CHECK-NEXT:   const auto *enumVWTable = reinterpret_cast<swift::_impl::EnumValueWitnessTable *>(vwTable);
 // CHECK-NEXT:   return enumVWTable->getEnumTag(_getOpaquePointer(), metadata._0);
 // CHECK-NEXT: }
+// CHECK:      };
+// CHECK-NEXT: decltype(DataCase::one) DataCase::one;
 
 // CHECK: class IntDoubleOrBignum final {
 
@@ -402,6 +413,10 @@ public func checkIntDoubleOrBignum(_ x: IntDoubleOrBignum, tag: Int) -> Bool {
 // CHECK-NEXT:   const auto *enumVWTable = reinterpret_cast<swift::_impl::EnumValueWitnessTable *>(vwTable);
 // CHECK-NEXT:   return enumVWTable->getEnumTag(_getOpaquePointer(), metadata._0);
 // CHECK-NEXT: }
+// CHECK:      };
+// CHECK-NEXT: decltype(IntDoubleOrBignum::Int) IntDoubleOrBignum::Int;
+// CHECK-NEXT: decltype(IntDoubleOrBignum::Double) IntDoubleOrBignum::Double;
+// CHECK-NEXT: decltype(IntDoubleOrBignum::Bignum) IntDoubleOrBignum::Bignum;
 
 // CHECK: class IntOrInfinity final {
 
@@ -470,6 +485,10 @@ public func checkIntDoubleOrBignum(_ x: IntDoubleOrBignum, tag: Int) -> Bool {
 // CHECK-NEXT:   const auto *enumVWTable = reinterpret_cast<swift::_impl::EnumValueWitnessTable *>(vwTable);
 // CHECK-NEXT:   return enumVWTable->getEnumTag(_getOpaquePointer(), metadata._0);
 // CHECK-NEXT: }
+// CHECK:      };
+// CHECK-NEXT: decltype(IntOrInfinity::NegInfinity) IntOrInfinity::NegInfinity;
+// CHECK-NEXT: decltype(IntOrInfinity::Int) IntOrInfinity::Int;
+// CHECK-NEXT: decltype(IntOrInfinity::PosInfinity) IntOrInfinity::PosInfinity;
 
 // CHECK: class MultipleBoolWithCase final {
 
@@ -560,3 +579,8 @@ public func checkIntDoubleOrBignum(_ x: IntDoubleOrBignum, tag: Int) -> Bool {
 // CHECK-NEXT:   const auto *enumVWTable = reinterpret_cast<swift::_impl::EnumValueWitnessTable *>(vwTable);
 // CHECK-NEXT:   return enumVWTable->getEnumTag(_getOpaquePointer(), metadata._0);
 // CHECK-NEXT: }
+// CHECK:      };
+// CHECK-NEXT: decltype(MultipleBoolWithCase::first) MultipleBoolWithCase::first;
+// CHECK-NEXT: decltype(MultipleBoolWithCase::second) MultipleBoolWithCase::second;
+// CHECK-NEXT: decltype(MultipleBoolWithCase::third) MultipleBoolWithCase::third;
+// CHECK-NEXT: decltype(MultipleBoolWithCase::fourth) MultipleBoolWithCase::fourth;

--- a/test/Interop/SwiftToCxx/enums/swift-enum-case-functions.swift
+++ b/test/Interop/SwiftToCxx/enums/swift-enum-case-functions.swift
@@ -4,7 +4,7 @@
 
 // RUN: %check-interop-cxx-header-in-clang(%t/enums.h -Wno-unused-private-field -Wno-unused-function)
 
-// test case-related member functions: operator cases() and isXYZ predicates
+// test case-related member functions and structs
 
 public enum DataCase { case one(_ x: Int) }
 
@@ -153,22 +153,59 @@ public func checkIntDoubleOrBignum(_ x: IntDoubleOrBignum, tag: Int) -> Bool {
 
 // CHECK: class BoolWithCase final {
 
-// CHECK:      inline operator cases() const {
+// CHECK:      static struct {  // impl struct for case second
+// CHECK-NEXT:   inline constexpr operator cases() const {
+// CHECK-NEXT:     return cases::second;
+// CHECK-NEXT:   }
+// CHECK-NEXT:   inline BoolWithCase operator()() const {
+// CHECK-NEXT:     return BoolWithCase::_make();
+// CHECK-NEXT:   }
+// CHECK-NEXT: } second;
+// CHECK-NEXT: inline bool isSecond() const {
+// CHECK-NEXT:   return *this == BoolWithCase::second;
+// CHECK-NEXT: }
+// CHECK-NEXT: inline bool getSecond() const {
+// CHECK-NEXT:   if (!isSecond()) abort();
+// CHECK-NEXT:   alignas(BoolWithCase) unsigned char buffer[sizeof(BoolWithCase)];
+// CHECK-NEXT:   auto *thisCopy = new(buffer) BoolWithCase(*this);
+// CHECK-NEXT:   char * _Nonnull payloadFromDestruction = thisCopy->_destructiveProjectEnumData();
+// CHECK-NEXT:   bool result;
+// CHECK-NEXT:   memcpy(&result, payloadFromDestruction, sizeof(result));
+// CHECK-NEXT:   return result;
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK-NEXT: static struct {  // impl struct for case first
+// CHECK-NEXT:   inline constexpr operator cases() const {
+// CHECK-NEXT:     return cases::first;
+// CHECK-NEXT:   }
+// CHECK-NEXT:   inline BoolWithCase operator()() const {
+// CHECK-NEXT:     return BoolWithCase::_make();
+// CHECK-NEXT:   }
+// CHECK-NEXT: } first;
+// CHECK-NEXT: inline bool isFirst() const {
+// CHECK-NEXT:   return *this == BoolWithCase::first;
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK-NEXT: static struct {  // impl struct for case third
+// CHECK-NEXT:   inline constexpr operator cases() const {
+// CHECK-NEXT:     return cases::third;
+// CHECK-NEXT:   }
+// CHECK-NEXT:   inline BoolWithCase operator()() const {
+// CHECK-NEXT:     return BoolWithCase::_make();
+// CHECK-NEXT:   }
+// CHECK-NEXT: } third;
+// CHECK-NEXT: inline bool isThird() const {
+// CHECK-NEXT:   return *this == BoolWithCase::third;
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK-EMPTY:
+// CHECK-NEXT: inline operator cases() const {
 // CHECK-NEXT:   switch (_getEnumTag()) {
 // CHECK-NEXT:     case 0: return cases::second;
 // CHECK-NEXT:     case 1: return cases::first;
 // CHECK-NEXT:     case 2: return cases::third;
 // CHECK-NEXT:     default: abort();
 // CHECK-NEXT:   }
-// CHECK-NEXT: }
-// CHECK-NEXT: inline bool isSecond() const {
-// CHECK-NEXT:   return _getEnumTag() == 0;
-// CHECK-NEXT: }
-// CHECK:      inline bool isFirst() const {
-// CHECK-NEXT:   return _getEnumTag() == 1;
-// CHECK-NEXT: }
-// CHECK-NEXT: inline bool isThird() const {
-// CHECK-NEXT:   return _getEnumTag() == 2;
 // CHECK-NEXT: }
 // CHECK:      inline int _getEnumTag() const {
 // CHECK-NEXT:   auto metadata = _impl::$s5Enums12BoolWithCaseOMa(0);
@@ -184,22 +221,50 @@ public func checkIntDoubleOrBignum(_ x: IntDoubleOrBignum, tag: Int) -> Bool {
 
 // CHECK: class CLikeEnum final {
 
-// CHECK:      inline operator cases() const {
+// CHECK:      static struct {  // impl struct for case one
+// CHECK-NEXT:   inline constexpr operator cases() const {
+// CHECK-NEXT:     return cases::one;
+// CHECK-NEXT:   }
+// CHECK-NEXT:   inline CLikeEnum operator()() const {
+// CHECK-NEXT:     return CLikeEnum::_make();
+// CHECK-NEXT:   }
+// CHECK-NEXT: } one;
+// CHECK-NEXT: inline bool isOne() const {
+// CHECK-NEXT:   return *this == CLikeEnum::one;
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK-NEXT: static struct {  // impl struct for case two
+// CHECK-NEXT:   inline constexpr operator cases() const {
+// CHECK-NEXT:     return cases::two;
+// CHECK-NEXT:   }
+// CHECK-NEXT:   inline CLikeEnum operator()() const {
+// CHECK-NEXT:     return CLikeEnum::_make();
+// CHECK-NEXT:   }
+// CHECK-NEXT: } two;
+// CHECK-NEXT: inline bool isTwo() const {
+// CHECK-NEXT:   return *this == CLikeEnum::two;
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK-NEXT: static struct {  // impl struct for case three
+// CHECK-NEXT:   inline constexpr operator cases() const {
+// CHECK-NEXT:     return cases::three;
+// CHECK-NEXT:   }
+// CHECK-NEXT:   inline CLikeEnum operator()() const {
+// CHECK-NEXT:     return CLikeEnum::_make();
+// CHECK-NEXT:   }
+// CHECK-NEXT: } three;
+// CHECK-NEXT: inline bool isThree() const {
+// CHECK-NEXT:   return *this == CLikeEnum::three;
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK-EMPTY:
+// CHECK-NEXT: inline operator cases() const {
 // CHECK-NEXT:   switch (_getEnumTag()) {
 // CHECK-NEXT:     case 0: return cases::one;
 // CHECK-NEXT:     case 1: return cases::two;
 // CHECK-NEXT:     case 2: return cases::three;
 // CHECK-NEXT:     default: abort();
 // CHECK-NEXT:   }
-// CHECK-NEXT: }
-// CHECK-NEXT: inline bool isOne() const {
-// CHECK-NEXT:   return _getEnumTag() == 0;
-// CHECK-NEXT: }
-// CHECK:      inline bool isTwo() const {
-// CHECK-NEXT:   return _getEnumTag() == 1;
-// CHECK-NEXT: }
-// CHECK:      inline bool isThree() const {
-// CHECK-NEXT:   return _getEnumTag() == 2;
 // CHECK-NEXT: }
 // CHECK:      inline int _getEnumTag() const {
 // CHECK-NEXT:   auto metadata = _impl::$s5Enums9CLikeEnumOMa(0);
@@ -215,14 +280,33 @@ public func checkIntDoubleOrBignum(_ x: IntDoubleOrBignum, tag: Int) -> Bool {
 
 // CHECK: class DataCase final {
 
-// CHECK:      inline operator cases() const {
+// CHECK:      static struct {  // impl struct for case one
+// CHECK-NEXT:   inline constexpr operator cases() const {
+// CHECK-NEXT:     return cases::one;
+// CHECK-NEXT:   }
+// CHECK-NEXT:   inline DataCase operator()() const {
+// CHECK-NEXT:     return DataCase::_make();
+// CHECK-NEXT:   }
+// CHECK-NEXT: } one;
+// CHECK-NEXT: inline bool isOne() const {
+// CHECK-NEXT:   return *this == DataCase::one;
+// CHECK-NEXT: }
+// CHECK-NEXT: inline swift::Int getOne() const {
+// CHECK-NEXT:   if (!isOne()) abort();
+// CHECK-NEXT:   alignas(DataCase) unsigned char buffer[sizeof(DataCase)];
+// CHECK-NEXT:   auto *thisCopy = new(buffer) DataCase(*this);
+// CHECK-NEXT:   char * _Nonnull payloadFromDestruction = thisCopy->_destructiveProjectEnumData();
+// CHECK-NEXT:   swift::Int result;
+// CHECK-NEXT:   memcpy(&result, payloadFromDestruction, sizeof(result));
+// CHECK-NEXT:   return result;
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK-EMPTY:
+// CHECK-NEXT: inline operator cases() const {
 // CHECK-NEXT:   switch (_getEnumTag()) {
 // CHECK-NEXT:     case 0: return cases::one;
 // CHECK-NEXT:     default: abort();
 // CHECK-NEXT:   }
-// CHECK-NEXT: }
-// CHECK-NEXT: inline bool isOne() const {
-// CHECK-NEXT:   return _getEnumTag() == 0;
 // CHECK-NEXT: }
 // CHECK:      inline int _getEnumTag() const {
 // CHECK-NEXT:   auto metadata = _impl::$s5Enums8DataCaseOMa(0);
@@ -238,22 +322,74 @@ public func checkIntDoubleOrBignum(_ x: IntDoubleOrBignum, tag: Int) -> Bool {
 
 // CHECK: class IntDoubleOrBignum final {
 
-// CHECK:      inline operator cases() const {
+// CHECK:      enum class cases {
+// CHECK-NEXT:   Int,
+// CHECK-NEXT:   Double,
+// CHECK-NEXT:   Bignum
+// CHECK-NEXT: };
+// CHECK-EMPTY:
+// CHECK-NEXT: static struct {  // impl struct for case Int
+// CHECK-NEXT:   inline constexpr operator cases() const {
+// CHECK-NEXT:     return cases::Int;
+// CHECK-NEXT:   }
+// CHECK-NEXT:   inline IntDoubleOrBignum operator()() const {
+// CHECK-NEXT:     return IntDoubleOrBignum::_make();
+// CHECK-NEXT:   }
+// CHECK-NEXT: } Int;
+// CHECK-NEXT: inline bool isInt() const {
+// CHECK-NEXT:   return *this == IntDoubleOrBignum::Int;
+// CHECK-NEXT: }
+// CHECK-NEXT: inline swift::Int getInt() const {
+// CHECK-NEXT:   if (!isInt()) abort();
+// CHECK-NEXT:   alignas(IntDoubleOrBignum) unsigned char buffer[sizeof(IntDoubleOrBignum)];
+// CHECK-NEXT:   auto *thisCopy = new(buffer) IntDoubleOrBignum(*this);
+// CHECK-NEXT:   char * _Nonnull payloadFromDestruction = thisCopy->_destructiveProjectEnumData();
+// CHECK-NEXT:   swift::Int result;
+// CHECK-NEXT:   memcpy(&result, payloadFromDestruction, sizeof(result));
+// CHECK-NEXT:   return result;
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK-NEXT: static struct {  // impl struct for case Double
+// CHECK-NEXT:   inline constexpr operator cases() const {
+// CHECK-NEXT:     return cases::Double;
+// CHECK-NEXT:   }
+// CHECK-NEXT:   inline IntDoubleOrBignum operator()() const {
+// CHECK-NEXT:     return IntDoubleOrBignum::_make();
+// CHECK-NEXT:   }
+// CHECK-NEXT: } Double;
+// CHECK-NEXT: inline bool isDouble() const {
+// CHECK-NEXT:   return *this == IntDoubleOrBignum::Double;
+// CHECK-NEXT: }
+// CHECK-NEXT: inline double getDouble() const {
+// CHECK-NEXT:   if (!isDouble()) abort();
+// CHECK-NEXT:   alignas(IntDoubleOrBignum) unsigned char buffer[sizeof(IntDoubleOrBignum)];
+// CHECK-NEXT:   auto *thisCopy = new(buffer) IntDoubleOrBignum(*this);
+// CHECK-NEXT:   char * _Nonnull payloadFromDestruction = thisCopy->_destructiveProjectEnumData();
+// CHECK-NEXT:   double result;
+// CHECK-NEXT:   memcpy(&result, payloadFromDestruction, sizeof(result));
+// CHECK-NEXT:   return result;
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK-NEXT: static struct {  // impl struct for case Bignum
+// CHECK-NEXT:   inline constexpr operator cases() const {
+// CHECK-NEXT:     return cases::Bignum;
+// CHECK-NEXT:   }
+// CHECK-NEXT:   inline IntDoubleOrBignum operator()() const {
+// CHECK-NEXT:     return IntDoubleOrBignum::_make();
+// CHECK-NEXT:   }
+// CHECK-NEXT: } Bignum;
+// CHECK-NEXT: inline bool isBignum() const {
+// CHECK-NEXT:   return *this == IntDoubleOrBignum::Bignum;
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK-EMPTY:
+// CHECK-NEXT: inline operator cases() const {
 // CHECK-NEXT:   switch (_getEnumTag()) {
 // CHECK-NEXT:     case 0: return cases::Int;
 // CHECK-NEXT:     case 1: return cases::Double;
 // CHECK-NEXT:     case 2: return cases::Bignum;
 // CHECK-NEXT:     default: abort();
 // CHECK-NEXT:   }
-// CHECK-NEXT: }
-// CHECK-NEXT: inline bool isInt() const {
-// CHECK-NEXT:   return _getEnumTag() == 0;
-// CHECK-NEXT: }
-// CHECK:      inline bool isDouble() const {
-// CHECK-NEXT:   return _getEnumTag() == 1;
-// CHECK-NEXT: }
-// CHECK:      inline bool isBignum() const {
-// CHECK-NEXT:   return _getEnumTag() == 2;
 // CHECK-NEXT: }
 // CHECK:      inline int _getEnumTag() const {
 // CHECK-NEXT:   auto metadata = _impl::$s5Enums17IntDoubleOrBignumOMa(0);
@@ -269,23 +405,60 @@ public func checkIntDoubleOrBignum(_ x: IntDoubleOrBignum, tag: Int) -> Bool {
 
 // CHECK: class IntOrInfinity final {
 
-// CHECK:      inline operator cases() const {
+// CHECK:      static struct {  // impl struct for case Int
+// CHECK-NEXT:   inline constexpr operator cases() const {
+// CHECK-NEXT:     return cases::Int;
+// CHECK-NEXT:   }
+// CHECK-NEXT:   inline IntOrInfinity operator()() const {
+// CHECK-NEXT:     return IntOrInfinity::_make();
+// CHECK-NEXT:   }
+// CHECK-NEXT: } Int;
+// CHECK-NEXT: inline bool isInt() const {
+// CHECK-NEXT:   return *this == IntOrInfinity::Int;
+// CHECK-NEXT: }
+// CHECK-NEXT: inline swift::Int getInt() const {
+// CHECK-NEXT:   if (!isInt()) abort();
+// CHECK-NEXT:   alignas(IntOrInfinity) unsigned char buffer[sizeof(IntOrInfinity)];
+// CHECK-NEXT:   auto *thisCopy = new(buffer) IntOrInfinity(*this);
+// CHECK-NEXT:   char * _Nonnull payloadFromDestruction = thisCopy->_destructiveProjectEnumData();
+// CHECK-NEXT:   swift::Int result;
+// CHECK-NEXT:   memcpy(&result, payloadFromDestruction, sizeof(result));
+// CHECK-NEXT:   return result;
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK-NEXT: static struct {  // impl struct for case NegInfinity
+// CHECK-NEXT:   inline constexpr operator cases() const {
+// CHECK-NEXT:     return cases::NegInfinity;
+// CHECK-NEXT:   }
+// CHECK-NEXT:   inline IntOrInfinity operator()() const {
+// CHECK-NEXT:     return IntOrInfinity::_make();
+// CHECK-NEXT:   }
+// CHECK-NEXT: } NegInfinity;
+// CHECK-NEXT: inline bool isNegInfinity() const {
+// CHECK-NEXT:   return *this == IntOrInfinity::NegInfinity;
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK-NEXT: static struct {  // impl struct for case PosInfinity
+// CHECK-NEXT:   inline constexpr operator cases() const {
+// CHECK-NEXT:     return cases::PosInfinity;
+// CHECK-NEXT:   }
+// CHECK-NEXT:   inline IntOrInfinity operator()() const {
+// CHECK-NEXT:     return IntOrInfinity::_make();
+// CHECK-NEXT:   }
+// CHECK-NEXT: } PosInfinity;
+// CHECK-NEXT: inline bool isPosInfinity() const {
+// CHECK-NEXT:   return *this == IntOrInfinity::PosInfinity;
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK-EMPTY:
+// CHECK-NEXT: inline operator cases() const {
 // CHECK-NEXT:   switch (_getEnumTag()) {
 // CHECK-NEXT:     case 0: return cases::Int;
 // CHECK-NEXT:     case 1: return cases::NegInfinity;
 // CHECK-NEXT:     case 2: return cases::PosInfinity;
 // CHECK-NEXT:     default: abort();
 // CHECK-NEXT:   }
-// CHECK-NEXT: }
-// CHECK-NEXT: inline bool isInt() const {
-// CHECK-NEXT:   return _getEnumTag() == 0;
-// CHECK-NEXT: }
-// CHECK:      inline bool isNegInfinity() const {
-// CHECK-NEXT:   return _getEnumTag() == 1;
-// CHECK-NEXT: }
-// CHECK:      inline bool isPosInfinity() const {
-// CHECK-NEXT:   return _getEnumTag() == 2;
-// CHECK-NEXT: }
+// CHECK-NEXT: } 
 // CHECK:      inline int _getEnumTag() const {
 // CHECK-NEXT:   auto metadata = _impl::$s5Enums13IntOrInfinityOMa(0);
 // CHECK-NEXT:   auto *vwTableAddr = reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1;
@@ -300,26 +473,81 @@ public func checkIntDoubleOrBignum(_ x: IntDoubleOrBignum, tag: Int) -> Bool {
 
 // CHECK: class MultipleBoolWithCase final {
 
-// CHECK:      inline operator cases() const {
-// CHECK-NEXT:     switch (_getEnumTag()) {
+// CHECK:      static struct {  // impl struct for case second
+// CHECK-NEXT:   inline constexpr operator cases() const {
+// CHECK-NEXT:     return cases::second;
+// CHECK-NEXT:   }
+// CHECK-NEXT:   inline MultipleBoolWithCase operator()() const {
+// CHECK-NEXT:     return MultipleBoolWithCase::_make();
+// CHECK-NEXT:   }
+// CHECK-NEXT: } second;
+// CHECK-NEXT: inline bool isSecond() const {
+// CHECK-NEXT:   return *this == MultipleBoolWithCase::second;
+// CHECK-NEXT: }
+// CHECK-NEXT: inline bool getSecond() const {
+// CHECK-NEXT:   if (!isSecond()) abort();
+// CHECK-NEXT:   alignas(MultipleBoolWithCase) unsigned char buffer[sizeof(MultipleBoolWithCase)];
+// CHECK-NEXT:   auto *thisCopy = new(buffer) MultipleBoolWithCase(*this);
+// CHECK-NEXT:   char * _Nonnull payloadFromDestruction = thisCopy->_destructiveProjectEnumData();
+// CHECK-NEXT:   bool result;
+// CHECK-NEXT:   memcpy(&result, payloadFromDestruction, sizeof(result));
+// CHECK-NEXT:   return result;
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK-NEXT: static struct {  // impl struct for case third
+// CHECK-NEXT:   inline constexpr operator cases() const {
+// CHECK-NEXT:     return cases::third;
+// CHECK-NEXT:   }
+// CHECK-NEXT:   inline MultipleBoolWithCase operator()() const {
+// CHECK-NEXT:     return MultipleBoolWithCase::_make();
+// CHECK-NEXT:   }
+// CHECK-NEXT: } third;
+// CHECK-NEXT: inline bool isThird() const {
+// CHECK-NEXT:   return *this == MultipleBoolWithCase::third;
+// CHECK-NEXT: }
+// CHECK-NEXT: inline bool getThird() const {
+// CHECK-NEXT:   if (!isThird()) abort();
+// CHECK-NEXT:   alignas(MultipleBoolWithCase) unsigned char buffer[sizeof(MultipleBoolWithCase)];
+// CHECK-NEXT:   auto *thisCopy = new(buffer) MultipleBoolWithCase(*this);
+// CHECK-NEXT:   char * _Nonnull payloadFromDestruction = thisCopy->_destructiveProjectEnumData();
+// CHECK-NEXT:   bool result;
+// CHECK-NEXT:   memcpy(&result, payloadFromDestruction, sizeof(result));
+// CHECK-NEXT:   return result;
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK-NEXT: static struct {  // impl struct for case first
+// CHECK-NEXT:   inline constexpr operator cases() const {
+// CHECK-NEXT:     return cases::first;
+// CHECK-NEXT:   }
+// CHECK-NEXT:   inline MultipleBoolWithCase operator()() const {
+// CHECK-NEXT:     return MultipleBoolWithCase::_make();
+// CHECK-NEXT:   }
+// CHECK-NEXT: } first;
+// CHECK-NEXT: inline bool isFirst() const {
+// CHECK-NEXT:   return *this == MultipleBoolWithCase::first;
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK-NEXT: static struct {  // impl struct for case fourth
+// CHECK-NEXT:   inline constexpr operator cases() const {
+// CHECK-NEXT:     return cases::fourth;
+// CHECK-NEXT:   }
+// CHECK-NEXT:   inline MultipleBoolWithCase operator()() const {
+// CHECK-NEXT:     return MultipleBoolWithCase::_make();
+// CHECK-NEXT:   }
+// CHECK-NEXT: } fourth;
+// CHECK-NEXT: inline bool isFourth() const {
+// CHECK-NEXT:   return *this == MultipleBoolWithCase::fourth;
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK-EMPTY:
+// CHECK-NEXT: inline operator cases() const {
+// CHECK-NEXT:   switch (_getEnumTag()) {
 // CHECK-NEXT:     case 0: return cases::second;
 // CHECK-NEXT:     case 1: return cases::third;
 // CHECK-NEXT:     case 2: return cases::first;
 // CHECK-NEXT:     case 3: return cases::fourth;
 // CHECK-NEXT:     default: abort();
-// CHECK-NEXT:     }
-// CHECK-NEXT: }
-// CHECK-NEXT: inline bool isSecond() const {
-// CHECK-NEXT:   return _getEnumTag() == 0;
-// CHECK-NEXT: }
-// CHECK:      inline bool isThird() const {
-// CHECK-NEXT:   return _getEnumTag() == 1;
-// CHECK-NEXT: }
-// CHECK:      inline bool isFirst() const {
-// CHECK-NEXT:   return _getEnumTag() == 2;
-// CHECK-NEXT: }
-// CHECK-NEXT: inline bool isFourth() const {
-// CHECK-NEXT:   return _getEnumTag() == 3;
+// CHECK-NEXT:   }
 // CHECK-NEXT: }
 // CHECK:      inline int _getEnumTag() const {
 // CHECK-NEXT:   auto metadata = _impl::$s5Enums20MultipleBoolWithCaseOMa(0);


### PR DESCRIPTION
Implement the new enum design described in #60524.

All existing features are updated for the new design. The class constructor and `operator ()` in case structs will be implemented in future.

@hyp Could you please review this PR? Thanks.