### PR TITLE
[CSApply] Attempt value-to-opaque-result abstraction only after canon…

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6850,11 +6850,11 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
   // below is just an approximate check since the above would be expensive to
   // verify and still relies on the type checker ensuing `fromType` is
   // compatible with any opaque archetypes.
-  if (toType->hasOpaqueArchetype() &&
+  if (toType->getCanonicalType()->hasOpaqueArchetype() &&
       cs.getConstraintLocator(locator)->isForContextualType()) {
     // Find the opaque type declaration. We need its generic signature.
     OpaqueTypeDecl *opaqueDecl = nullptr;
-    bool found = toType.findIf([&](Type type) {
+    bool found = toType->getCanonicalType().findIf([&](Type type) {
       if (auto opaqueType = type->getAs<OpaqueTypeArchetypeType>()) {
         opaqueDecl = opaqueType->getDecl();
         return true;

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar98577451.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar98577451.swift
@@ -1,0 +1,21 @@
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.15
+
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+protocol P {
+  associatedtype T
+  func f() -> T
+}
+
+struct S: P {
+  func f() -> some Any { return 3 }
+}
+
+struct G<T> {
+  typealias Foo = (T?, S.T)
+}
+
+func f<T>(t: T) -> G<T>.Foo {
+  return (t, S().f()) // Ok
+}


### PR DESCRIPTION
…icalization

`ExprRewriter::coerceToType` should canonicalize contextual type before
attempting to use it for value abstraction, because sugared type could
have typealias references that hide their underlying opaque result types.

Resolves: rdar://98577451

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
