### PR TITLE
[Concurrency] Deprecate one of the cancellation handler overloads

### DIFF
--- a/stdlib/public/BackDeployConcurrency/SourceCompatibilityShims.swift
+++ b/stdlib/public/BackDeployConcurrency/SourceCompatibilityShims.swift
@@ -54,6 +54,7 @@ extension TaskPriority {
 
 @available(SwiftStdlib 5.1, *)
 @_alwaysEmitIntoClient
+@available(*, deprecated, renamed: "withTaskCancellationHandler(operation:onCancel:)")
 public func withTaskCancellationHandler<T>(
   handler: @Sendable () -> Void,
   operation: () async throws -> T

--- a/stdlib/public/Concurrency/SourceCompatibilityShims.swift
+++ b/stdlib/public/Concurrency/SourceCompatibilityShims.swift
@@ -54,6 +54,7 @@ extension TaskPriority {
 
 @available(SwiftStdlib 5.1, *)
 @_alwaysEmitIntoClient
+@available(*, deprecated, renamed: "withTaskCancellationHandler(operation:onCancel:)")
 public func withTaskCancellationHandler<T>(
   handler: @Sendable () -> Void,
   operation: () async throws -> T


### PR DESCRIPTION
There are two overloads:

 * https://developer.apple.com/documentation/swift/withtaskcancellationhandler(handler:operation:)
 * https://developer.apple.com/documentation/swift/withtaskcancellationhandler(operation:oncancel:)

Only because during SE review we moved to the latter spelling and kept the prior one for source compat. It was always intended to be deprecated though.

Resolves rdar://98676952
Resolves rdar://98473936