### PR TITLE
Fix tests IRGen/abitypes.swift and IRGen/objc_object_getClass.swift on watchOS

### DIFF
--- a/test/IRGen/abitypes.swift
+++ b/test/IRGen/abitypes.swift
@@ -569,7 +569,7 @@ class Foo {
 
 // armv7-ios: define internal void @makeOne(%struct.One* noalias sret({{.*}}) align 4 %agg.result, float %f, float %s)
 // armv7s-ios: define internal void @makeOne(%struct.One* noalias sret({{.*}}) align 4 %agg.result, float %f, float %s)
-// armv7k-watchos: define internal %struct.One @makeOne(float %f, float %s)
+// armv7k-watchos: define internal %struct.One @makeOne(float {{.*}}%f, float {{.*}}%s)
 
 // rdar://17631440 - Expand direct arguments that are coerced to aggregates.
 // x86_64-macosx: define{{( protected)?}} swiftcc float @"$s8abitypes13testInlineAggySfSo6MyRectVF"(float %0, float %1, float %2, float %3) {{.*}} {

--- a/test/IRGen/objc_object_getClass.swift
+++ b/test/IRGen/objc_object_getClass.swift
@@ -18,5 +18,5 @@ func test(_ o: ObjCSubclass) {
   o.field = 10
 }
 
-// CHECK: declare i8* @object_getClass(i8*)
-// CHECK: call %objc_class* bitcast (i8* (i8*)* @object_getClass to %objc_class* (%objc_object*)*)(%objc_object* %{{.*}})
+// CHECK-DAG: declare i8* @object_getClass(i8*)
+// CHECK-DAG: call %objc_class* bitcast (i8* (i8*)* @object_getClass to %objc_class* (%objc_object*)*)(%objc_object* %{{.*}})


### PR DESCRIPTION
rdar://98722116
