### PR TITLE
[TypeChecker] NFC: Adjust test-case for rdar://98577451

### DIFF
--- a/validation-test/Sema/type_checker_crashers_fixed/rdar98577451.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar98577451.swift
@@ -1,7 +1,4 @@
-// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.15
-
-// REQUIRES: objc_interop
-// REQUIRES: OS=macosx
+// RUN: %target-typecheck-verify-swift -disable-availability-checking
 
 protocol P {
   associatedtype T


### PR DESCRIPTION
Replace `-target` with `-disable-availability-checking`
and drop `REQUIRES:` lines that limit test to macOS.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
