### PR TITLE
[Explicit Modules] On an explicit interface build, early exit if expected output is up-to-date.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -979,6 +979,10 @@ REMARK(cross_import_added,none,
 REMARK(module_loaded,none,
        "loaded module at %0",
        (StringRef))
+       
+REMARK(explicit_interface_build_skipped,none,
+       "Skipped rebuilding module at %0 - up-to-date",
+       (StringRef))
 
 WARNING(cannot_find_project_version,none,
         "cannot find user version number for %0 module '%1'; version number ignored", (StringRef, StringRef))

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -215,6 +215,9 @@ namespace swift {
 
     /// Emit a remark after loading a module.
     bool EnableModuleLoadingRemarks = false;
+    
+    /// Emit a remark on early exit in explicit interface build
+    bool EnableSkipExplicitInterfaceModuleBuildRemarks = false;
 
     ///
     /// Support for alternate usage modes

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -340,6 +340,10 @@ def remark_loading_module : Flag<["-"], "Rmodule-loading">,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Emit a remark and file path of each loaded module">;
 
+def remark_skip_explicit_interface_build : Flag<["-"], "Rskip-explicit-interface-build">,
+  Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
+  HelpText<"Emit a remark if an explicit module interface invocation has an early exit because the expected output is up-to-date">;
+
 def emit_tbd : Flag<["-"], "emit-tbd">,
   HelpText<"Emit a TBD file">,
   Flags<[FrontendOption, NoInteractiveOption, SupplementaryOutput]>;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -797,6 +797,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   Opts.EnableModuleLoadingRemarks = Args.hasArg(OPT_remark_loading_module);
 
+  Opts.EnableSkipExplicitInterfaceModuleBuildRemarks = Args.hasArg(OPT_remark_skip_explicit_interface_build);
+  
   llvm::Triple Target = Opts.Target;
   StringRef TargetArg;
   std::string TargetArgScratch;

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1345,6 +1345,21 @@ bool ModuleInterfaceLoader::buildExplicitSwiftModuleFromSwiftInterface(
     ArrayRef<std::string> CompiledCandidates,
     DependencyTracker *tracker) {
   
+  // First, check if the expected output already exists and possibly up-to-date w.r.t.
+  // all of the dependencies it was built with. If so, early exit.
+  UpToDateModuleCheker checker(Instance.getASTContext(),
+                               RequireOSSAModules_t(Instance.getSILOptions()));
+  ModuleRebuildInfo rebuildInfo;
+  SmallVector<FileDependency, 3> allDeps;
+  std::unique_ptr<llvm::MemoryBuffer> moduleBuffer;
+  if (checker.swiftModuleIsUpToDate(outputPath, rebuildInfo, allDeps, moduleBuffer)) {
+    if (Instance.getASTContext().LangOpts.EnableSkipExplicitInterfaceModuleBuildRemarks) {
+      Instance.getDiags().diagnose(SourceLoc(),
+                                   diag::explicit_interface_build_skipped, outputPath);
+    }
+    return false;
+  }
+  
   // Read out the compiler version.
   llvm::BumpPtrAllocator alloc;
   llvm::StringSaver ArgSaver(alloc);

--- a/test/ModuleInterface/repeated-explicit-interface-build-nop.swiftinterface
+++ b/test/ModuleInterface/repeated-explicit-interface-build-nop.swiftinterface
@@ -1,0 +1,14 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -parse-stdlib
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -compile-module-from-interface -module-name ExplicitModule -explicit-interface-module-build -o %/t/ExplicitModule.swiftmodule %s
+
+// RUN: %target-swift-frontend -compile-module-from-interface -module-name ExplicitModule -explicit-interface-module-build -o %/t/ExplicitModule.swiftmodule %s -Rskip-explicit-interface-build 2>&1 | %FileCheck %s
+
+import Swift
+extension Int {
+  public static var fortytwo: Int = 42
+}
+
+// CHECK: <unknown>:0: remark: Skipped rebuilding module at {{.*}}ExplicitModule.swiftmodule - up-to-date


### PR DESCRIPTION
This PR contains two changes: 
- Refactor the portions of `ModuleInterfaceLoaderImpl` that check if a given binary Swift module is up-to-date by verifying all of its serialized files dependency timestamps into a separate implementation helper class - `UpToDateModuleChecker`, so that it can be used by other clients.
- Adopt `UpToDateModuleChecker` in the explicit interface build code-path to early exit when the `.swiftinterface` -> `.swiftmodule` build action is not needed because the expected output is already up-to-date.
    - Add a remark emitted when `-Rskip-explicit-interface-build` is specified and the above early exit is taken.