### PR TITLE
[IRGen] Properly handle empty payloads in getEnumTagMultipayload

### DIFF
--- a/lib/IRGen/TypeLayout.cpp
+++ b/lib/IRGen/TypeLayout.cpp
@@ -2330,11 +2330,11 @@ EnumTypeLayoutEntry::getEnumTagMultipayload(IRGenFunction &IGF,
   auto truncSize = Builder.CreateZExtOrTrunc(maxPayloadSize(IGF), IGM.Int32Ty);
   auto sizeGTE4 = Builder.CreateICmpUGE(truncSize, four);
   auto sizeClampedTo4 = Builder.CreateSelect(sizeGTE4, four, truncSize);
-  auto sizeIsZeroBB = IGF.createBasicBlock("");
   auto sizeGreaterZeroBB = IGF.createBasicBlock("");
   auto zero = IGM.getInt32(0);
   auto sizeGreaterZero = Builder.CreateICmpUGT(sizeClampedTo4, zero);
-  Builder.CreateCondBr(sizeGreaterZero, sizeGreaterZeroBB, sizeIsZeroBB);
+  tagValue->addIncoming(loadedTag, Builder.GetInsertBlock());
+  Builder.CreateCondBr(sizeGreaterZero, sizeGreaterZeroBB, resultBB);
 
   Builder.emitBlock(sizeGreaterZeroBB);
   auto payloadValue = emitLoad1to4Bytes(IGF, enumAddr, sizeClampedTo4);
@@ -2355,10 +2355,6 @@ EnumTypeLayoutEntry::getEnumTagMultipayload(IRGenFunction &IGF,
   auto tmp3 = Builder.CreateOr(payloadValue, tmp2);
   auto result3 = Builder.CreateAdd(tmp3, numPayloads);
   tagValue->addIncoming(result3, Builder.GetInsertBlock());
-  Builder.CreateBr(resultBB);
-
-  Builder.emitBlock(sizeIsZeroBB);
-  tagValue->addIncoming(loadedTag, Builder.GetInsertBlock());
   Builder.CreateBr(resultBB);
 
   Builder.emitBlock(resultBB);

--- a/test/Interpreter/rdar97914498.swift
+++ b/test/Interpreter/rdar97914498.swift
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swiftc_driver -Xfrontend -disable-availability-checking -O -Xllvm -sil-opt-pass-count=0 -Xfrontend -disable-llvm-optzns %s -o %t/out
+// RUN: %target-codesign %t/out
+// RUN: %target-run %t/out
+
+// This is a regression test that ensures that empty payloads in multi
+// payload enums are properly handled.
+
+import Foundation
+
+@inline(never)
+func crash() {
+    let testURL = URL(string: "https://www.google.com")!
+    let r = Resource<()>(url: testURL, method: .get)
+    print(r.url)
+}
+
+enum HTTPMethod<Payload> {
+    case get
+    case post(Payload)
+    case patch(Payload)
+}
+
+struct Resource<Payload> {
+    let url: URL
+    let method: HTTPMethod<Payload>
+}
+
+crash()

--- a/test/Interpreter/rdar97914498.swift
+++ b/test/Interpreter/rdar97914498.swift
@@ -3,6 +3,9 @@
 // RUN: %target-codesign %t/out
 // RUN: %target-run %t/out
 
+// REQUIRES: executable_test
+// REQUIRES: foundation
+
 // This is a regression test that ensures that empty payloads in multi
 // payload enums are properly handled.
 


### PR DESCRIPTION
rdar://97914498

The generated code assumed that payloads would always be at least
1 byte long, ignoring the possibility of empty payloads, causing
runtime crashes when using empty payloads in multi payload enums.