### PR TITLE
[Glibc] Refer to UUID headers from the modulemap using relative paths

### DIFF
--- a/stdlib/public/Platform/glibc.modulemap.gyb
+++ b/stdlib/public/Platform/glibc.modulemap.gyb
@@ -51,7 +51,7 @@ module SwiftGlibc [system] {
 
 % if CMAKE_SDK != "WASI" and CMAKE_SDK != "ANDROID":
 module CUUID [system] {
-  header "${GLIBC_INCLUDE_PATH}/uuid/uuid.h"
+  header "uuid/uuid.h"
   link "uuid"
   export *
 }


### PR DESCRIPTION
This improves portability of the Swift toolchains by removing a usage of absolute path to Glibc.

The Glibc modulemap is now injected into the Glibc include path using LLVM VFS, so it can reference Glibc headers using relative paths. This already works for other Glibc headers (e.g. `assert.h`)