### PR TITLE
Second attempt to fix IRGen/objc_object_getClass.swift

### DIFF
--- a/test/IRGen/objc_object_getClass.swift
+++ b/test/IRGen/objc_object_getClass.swift
@@ -18,5 +18,5 @@ func test(_ o: ObjCSubclass) {
   o.field = 10
 }
 
-// CHECK-DAG: declare i8* @object_getClass(i8*)
+// CHECK-DAG: declare i8* @object_getClass(i8*{{.*}})
 // CHECK-DAG: call %objc_class* bitcast (i8* (i8*)* @object_getClass to %objc_class* (%objc_object*)*)(%objc_object* %{{.*}})


### PR DESCRIPTION
There can be a `noundef` parameter attribute on object_getClass'
declaration.

rdar://98722116