### PR TITLE
Add hooks for emitting lifetimes.

### DIFF
--- a/docs/ReferenceGuides/UnderscoredAttributes.md
+++ b/docs/ReferenceGuides/UnderscoredAttributes.md
@@ -131,6 +131,23 @@ library), instead of at an arbitrary point in time.
 For more details, see the forum post on
 [dynamic method replacement](https://forums.swift.org/t/dynamic-method-replacement/16619).
 
+## `@_eagerMove`
+
+When applied to a value, indicates that the value's lifetime is _not_ lexical,
+that releases of the value may be hoisted without respect to deinit barriers.
+
+When applied to a type, indicates that all values which are _statically_
+instances of that type are themselves `@_eagerMove` as above, unless overridden
+with `@_lexical`.
+
+Aggregates all of whose fields are `@_eagerMove` or trivial are inferred to be
+`@_eagerMove`.
+
+Note that a value of an `@_eagerMove` type that is passed to a generic API (to a
+parameter not annotated `@_eagerMove` will, in that generic function's context,
+not be statically an instance of the `@_eagerMove` type.  As a result it will
+have a lexical lifetime in that function.
+
 ## `@_effects(effectname)`
 
 Tells the compiler that the implementation of the defined function is limited
@@ -473,12 +490,28 @@ initializers from its superclass. This implies that all designated initializers
 overridden. This attribute is often printed alongside
 `@_hasMissingDesignatedInitializers` in this case.
 
+## `@_lexical`
+
+When applied to a value, indicates that the value's lifetime is lexical, that
+releases of the value may not be hoisted over deinit barriers.  
+
+This is the default behavior, unless the value's type is annotated
+`@_eagerMove`, in which case this attribute overrides that type-level
+annotation.
+
+When applied to a type, indicates that all values which are instances of that
+type are themselves `@_lexical` as above.
+
+This is the default behavior, unless the type annotated is an aggregate that
+consists entirely of `@_eagerMove` or trivial values, in which case the
+attribute overrides the inferred type-level annotation.
+
 ## `@_marker`
 
 Indicates that a protocol is a marker protocol. Marker protocols represent some
 meaningful property at compile-time but have no runtime representation.
 
-For more details, see [SE-0302](https://github.com/apple/swift-evolution/blob/main/proposals/0302-concurrent-value-and-concurrent-closures.md#marker-protocols), which introduces marker protocols.
+For more details, see [](https://github.com/apple/swift-evolution/blob/main/proposals/0302-concurrent-value-and-concurrent-closures.md#marker-protocols), which introduces marker protocols.
 At the moment, the language only has one marker protocol: `Sendable`.
 
 Fun fact: Rust has a very similar concept called

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -662,7 +662,12 @@ SIMPLE_DECL_ATTR(_inheritActorContext, InheritActorContext,
   ABIStableToAdd | ABIStableToRemove | APIBreakingToAdd | APIBreakingToRemove,
   116)
 
-// 117 was 'spawn' and is now unused
+SIMPLE_DECL_ATTR(_eagerMove, EagerMove,
+  UserInaccessible |
+  ABIStableToAdd | ABIStableToRemove |
+  APIStableToAdd | APIStableToRemove |
+  OnParam | OnVar | OnNominalType,
+  117)
 
 CONTEXTUAL_SIMPLE_DECL_ATTR(distributed, DistributedActor,
   DeclModifier | OnClass | OnFunc | OnAccessor | OnVar |
@@ -670,7 +675,12 @@ CONTEXTUAL_SIMPLE_DECL_ATTR(distributed, DistributedActor,
   APIBreakingToAdd | APIBreakingToRemove,
   118)
 
-// 119 is unused
+SIMPLE_DECL_ATTR(_lexical, Lexical,
+  UserInaccessible |
+  ABIStableToAdd | ABIStableToRemove |
+  APIStableToAdd | APIStableToRemove |
+  OnParam | OnVar | OnNominalType,
+  119)
 
 SIMPLE_DECL_ATTR(_assemblyVision, EmitAssemblyVisionRemarks,
   OnFunc | UserInaccessible | NotSerialized | OnNominalType |

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -29,6 +29,7 @@
 #include "swift/AST/GenericParamKey.h"
 #include "swift/AST/IfConfigClause.h"
 #include "swift/AST/LayoutConstraint.h"
+#include "swift/AST/LifetimeAnnotation.h"
 #include "swift/AST/ReferenceCounting.h"
 #include "swift/AST/RequirementSignature.h"
 #include "swift/AST/StorageImpl.h"
@@ -2713,6 +2714,15 @@ public:
   /// 'func foo(Int) -> () -> Self?'.
   GenericParameterReferenceInfo findExistentialSelfReferences(
       Type baseTy, bool treatNonResultCovariantSelfAsInvariant) const;
+
+  LifetimeAnnotation getLifetimeAnnotation() const {
+    auto &attrs = getAttrs();
+    if (attrs.hasAttribute<EagerMoveAttr>())
+      return LifetimeAnnotation::EagerMove;
+    if (attrs.hasAttribute<LexicalAttr>())
+      return LifetimeAnnotation::Lexical;
+    return LifetimeAnnotation::None;
+  }
 };
 
 /// This is a common base class for declarations which declare a type.

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -517,6 +517,9 @@ ERROR(silfunc_and_silarg_have_incompatible_sil_value_ownership,none,
       "SILFunction and SILArgument have mismatching ValueOwnershipKinds. "
       "Function type specifies: '@%0'. SIL argument specifies: '@%1'.",
       (StringRef, StringRef))
+ERROR(sil_arg_both_lexical_and_eagerMove,none,
+      "Function argument is annotated both @_eagerMove and @_lexical, "
+      "but these are incompatible alternatives", ())
 ERROR(expected_sil_colon,none,
       "expected ':' before %0", (StringRef))
 ERROR(expected_sil_tuple_index,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3207,6 +3207,10 @@ ERROR(reasync_without_async_parameter,none,
 ERROR(inherits_executor_without_async,none,
       "non-async functions cannot inherit an executor", ())
 
+ERROR(eagermove_and_lexical_combined,none,
+      "@_eagerMove and @_lexical attributes are alternate styles of lifetimes "
+      "and can't be combined", ())
+
 ERROR(autoclosure_function_type,none,
       "@autoclosure attribute only applies to function types",
       ())

--- a/include/swift/AST/LifetimeAnnotation.h
+++ b/include/swift/AST/LifetimeAnnotation.h
@@ -1,0 +1,49 @@
+//===--- LifetimeAnnotation.h - Lifetime-affecting attributes ---*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Defines a simple type-safe wrapper around the annotations that affect value
+// lifetimes.  Used for both Decls and SILFunctionArguments.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_LIFETIMEANNOTATION_H
+#define SWIFT_AST_LIFETIMEANNOTATION_H
+
+#include <cstdint>
+
+namespace swift {
+
+/// The annotation on a value (or type) explicitly indicating the lifetime that
+/// it (or its instances) should have.
+///
+/// A LifetimeAnnotation is one of the following three values:
+///
+/// 1) None: No annotation has been applied.
+/// 2) EagerMove: The @_eagerMove attribute has been applied.
+/// 3) Lexical: The @_lexical attribute has been applied.
+struct LifetimeAnnotation {
+  enum Case : uint8_t {
+    None,
+    EagerMove,
+    Lexical,
+  } value;
+
+  LifetimeAnnotation(Case newValue) : value(newValue) {}
+
+  operator Case() const { return value; }
+
+  bool isSome() { return value != None; }
+};
+
+} // namespace swift
+
+#endif

--- a/include/swift/SIL/Lifetime.h
+++ b/include/swift/SIL/Lifetime.h
@@ -1,0 +1,71 @@
+//===---- Lifetime.h - How long a value should be kept alive ----*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Defines a simple type-safe wrapper type to indicate the kind of lifetime that
+// a value has--whether it is tied to a lexical scope or not.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/LifetimeAnnotation.h"
+
+#ifndef SWIFT_SIL_LIFETIME_H
+#define SWIFT_SIL_LIFETIME_H
+
+namespace swift {
+
+/// How long a value (such as instances of a type) should be kept alive--how
+/// aggressively its destroys may be hoisted.
+///
+/// By default, types have lifetimes inferred from their structure, see
+/// TypeLowering::RecursiveProperties::isLexical.  It can be overridden both on
+/// the type level and the value level via attributes.
+struct Lifetime {
+  enum Storage : uint8_t {
+    /// No lifetime.  Applicable to values which aren't destroyed.
+    None,
+    /// A lifetime independent from the lexical scope of the value: its
+    /// releases are hoisted without respect to deinit barriers.
+    EagerMove,
+    /// A lifetime tied to the lexical scope of the value: its releases are
+    /// not hoisted over deinit barriers.
+    Lexical,
+  } value;
+
+  Lifetime(decltype(value) newValue) : value(newValue) {}
+
+  operator Storage() const { return value; }
+
+  bool isLexical() { return value == Lifetime::Lexical; }
+
+  bool isEagerMove() { return value == Lifetime::EagerMove; }
+
+  /// Given a lifetime for a type and the lifetime annotation on a value of that
+  /// type, the lifetime appropriate for that value.
+  ///
+  /// Value annotations override a type's lifetime, so the result is just the
+  /// lifetime indicated by the annotation, if there is one; otherwise its the
+  /// lifetime from the type.
+  Lifetime getLifetimeForAnnotatedValue(LifetimeAnnotation annotation) const {
+    switch (annotation) {
+    case LifetimeAnnotation::None:
+      return *this;
+    case LifetimeAnnotation::EagerMove:
+      return Lifetime::EagerMove;
+    case LifetimeAnnotation::Lexical:
+      return Lifetime::Lexical;
+    }
+  }
+};
+
+} // end swift namespace
+
+#endif

--- a/include/swift/SIL/SILArgument.h
+++ b/include/swift/SIL/SILArgument.h
@@ -113,8 +113,6 @@ public:
            node->getKind() <= SILNodeKind::Last_SILArgument;
   }
 
-  bool isNoImplicitCopy() const;
-
   unsigned getIndex() const;
 
   /// Return non-null if \p value is a phi.
@@ -406,12 +404,6 @@ inline SILPhiArgument *SILArgument::isTerminatorResult(SILValue value) {
       return arg;
   }
   return nullptr;
-}
-
-inline bool SILArgument::isNoImplicitCopy() const {
-  if (auto *fArg = dyn_cast<SILFunctionArgument>(this))
-    return fArg->isNoImplicitCopy();
-  return false;
 }
 
 inline bool SILArgument::isTerminatorResult() const {

--- a/include/swift/SIL/SILArgument.h
+++ b/include/swift/SIL/SILArgument.h
@@ -13,10 +13,12 @@
 #ifndef SWIFT_SIL_SILARGUMENT_H
 #define SWIFT_SIL_SILARGUMENT_H
 
+#include "swift/AST/LifetimeAnnotation.h"
 #include "swift/Basic/Compiler.h"
+#include "swift/SIL/Lifetime.h"
 #include "swift/SIL/SILArgumentConvention.h"
-#include "swift/SIL/SILValue.h"
 #include "swift/SIL/SILFunctionConventions.h"
+#include "swift/SIL/SILValue.h"
 
 namespace swift {
 
@@ -327,14 +329,17 @@ class SILFunctionArgument : public SILArgument {
   friend class SILBasicBlock;
 
   bool noImplicitCopy = false;
+  LifetimeAnnotation lifetimeAnnotation = LifetimeAnnotation::None;
 
-  SILFunctionArgument(SILBasicBlock *parentBlock, SILType type,
-                      ValueOwnershipKind ownershipKind,
-                      const ValueDecl *decl = nullptr,
-                      bool isNoImplicitCopy = false)
+  SILFunctionArgument(
+      SILBasicBlock *parentBlock, SILType type,
+      ValueOwnershipKind ownershipKind, const ValueDecl *decl = nullptr,
+      bool isNoImplicitCopy = false,
+      LifetimeAnnotation lifetimeAnnotation = LifetimeAnnotation::None)
       : SILArgument(ValueKind::SILFunctionArgument, parentBlock, type,
                     ownershipKind, decl),
-        noImplicitCopy(isNoImplicitCopy) {}
+        noImplicitCopy(isNoImplicitCopy),
+        lifetimeAnnotation(lifetimeAnnotation) {}
   // A special constructor, only intended for use in
   // SILBasicBlock::replaceFunctionArg.
   explicit SILFunctionArgument(SILType type, ValueOwnershipKind ownershipKind,
@@ -346,6 +351,20 @@ public:
   bool isNoImplicitCopy() const { return noImplicitCopy; }
 
   void setNoImplicitCopy(bool newValue) { noImplicitCopy = newValue; }
+
+  LifetimeAnnotation getLifetimeAnnotation() const {
+    return lifetimeAnnotation;
+  }
+
+  void setLifetimeAnnotation(LifetimeAnnotation newValue) {
+    lifetimeAnnotation = newValue;
+  }
+
+  Lifetime getLifetime() const {
+    return getType()
+        .getLifetime(*getFunction())
+        .getLifetimeForAnnotatedValue(getLifetimeAnnotation());
+  }
 
   bool isIndirectResult() const;
 

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -1346,6 +1346,13 @@ public:
   // Miscellaneous
   //===--------------------------------------------------------------------===//
 
+  /// A value's lifetime, determined by looking at annotations on its decl and
+  /// the default lifetime for the type.
+  Lifetime getLifetime(VarDecl *decl, SILType ty) {
+    return ty.getLifetime(*this).getLifetimeForAnnotatedValue(
+        decl->getLifetimeAnnotation());
+  }
+
   /// verify - Run the IR verifier to make sure that the SILFunction follows
   /// invariants.
   void verify(bool SingleFunction = true) const;

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -753,6 +753,25 @@ public:
   void dump() const;
   void print(raw_ostream &OS,
              const PrintOptions &PO = PrintOptions::printSIL()) const;
+
+#ifndef NDEBUG
+  /// Visit the distinct types of the fields out of which a type is aggregated.
+  ///
+  /// As we walk into the field types, if an aggregate is encountered, it may
+  /// still be a leaf.  It is a leaf if the \p isLeafAggregate predicate
+  /// returns true.
+  ///
+  /// Returns false if the leaves cannot be visited or if any invocation of the
+  /// visitor returns false.
+  ///
+  /// NOTE: This function is meant for use in verification.  For real use-cases,
+  ///       recursive walks of type leaves should be done via
+  ///       TypeLowering::RecursiveProperties.
+  bool visitAggregateLeaves(
+      Lowering::TypeConverter &TC, TypeExpansionContext context,
+      std::function<bool(SILType, SILType, VarDecl *)> isLeafAggregate,
+      std::function<bool(SILType, SILType, VarDecl *)> visit) const;
+#endif
 };
 
 // Statically prevent SILTypes from being directly cast to a type

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -20,9 +20,10 @@
 
 #include "swift/AST/SILLayout.h"
 #include "swift/AST/Types.h"
+#include "swift/SIL/Lifetime.h"
+#include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/PointerIntPair.h"
 #include "llvm/Support/ErrorHandling.h"
-#include "llvm/ADT/Hashing.h"
 
 namespace swift {
 
@@ -350,6 +351,15 @@ public:
   bool hasReferenceSemantics() const {
     return getASTType().hasReferenceSemantics();
   }
+
+  /// The lifetime of values of this type (which are not otherwise annotated).
+  ///
+  /// Trivial types are ::None.
+  /// Non-trivial types are ::Lexical by default.
+  /// Non-trivial types which are annotated @_eagerMove are ::EagerMove.
+  /// Aggregates which consist entirely of ::EagerMove fields are ::EagerMove.
+  /// All other types are ::Lexical.
+  Lifetime getLifetime(const SILFunction &F) const;
 
   /// Returns true if the referenced type is any sort of class-reference type,
   /// meaning anything with reference semantics that is not a function type.

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -232,6 +232,13 @@ public:
     return value.getPointer()->isVoid();
   }
 
+  /// Whether the type is an enum, struct, or tuple.
+  bool isAggregate() {
+    return is<TupleType>() || is<StructType>() ||
+           is<BoundGenericStructType>() || is<EnumType>() ||
+           is<BoundGenericEnumType>();
+  }
+
   /// Retrieve the ClassDecl for a type that maps to a Swift class or
   /// bound generic class type.
   ClassDecl *getClassOrBoundGenericClass() const {

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -1245,6 +1245,12 @@ private:
                                CanType result,
                                Bridgeability bridging,
                                bool suppressOptional);
+#ifndef NDEBUG
+  /// Check the result of
+  /// getTypeLowering(AbstractionPattern,Type,TypeExpansionContext).
+  void verifyLowering(const TypeLowering &, AbstractionPattern origType,
+                      Type origSubstType, TypeExpansionContext forExpansion);
+#endif
 };
 
 } // namespace Lowering

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -690,6 +690,16 @@ namespace {
         OS << attr->getReplacedFunctionName();
         OS << "\")";
       }
+      switch (VD->getLifetimeAnnotation()) {
+      case LifetimeAnnotation::EagerMove:
+        OS << " _eagerMove";
+        break;
+      case LifetimeAnnotation::Lexical:
+        OS << " _lexical";
+        break;
+      case LifetimeAnnotation::None:
+        break;
+      }
     }
 
     void printCommon(NominalTypeDecl *NTD, const char *Name,
@@ -957,6 +967,17 @@ namespace {
 
       if (P->getAttrs().hasAttribute<NonEphemeralAttr>())
         OS << " nonEphemeral";
+
+      switch (P->getLifetimeAnnotation()) {
+      case LifetimeAnnotation::EagerMove:
+        OS << " _eagerMove";
+        break;
+      case LifetimeAnnotation::Lexical:
+        OS << " _lexical";
+        break;
+      case LifetimeAnnotation::None:
+        break;
+      }
 
       if (P->getAttrs().hasAttribute<NoImplicitCopyAttr>())
         OS << " noImplicitCopy";

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -161,6 +161,15 @@ bool SILType::isNoReturnFunction(SILModule &M,
   return false;
 }
 
+Lifetime SILType::getLifetime(const SILFunction &F) const {
+  auto contextType = hasTypeParameter() ? F.mapTypeIntoContext(*this) : *this;
+  const auto &lowering = F.getTypeLowering(contextType);
+  auto properties = lowering.getRecursiveProperties();
+  if (properties.isTrivial())
+    return Lifetime::None;
+  return properties.isLexical() ? Lifetime::Lexical : Lifetime::EagerMove;
+}
+
 std::string SILType::getMangledName() const {
   Mangle::ASTMangler mangler;
   return mangler.mangleTypeWithoutPrefix(getRawASTType());

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -22,6 +22,7 @@
 #include "swift/SIL/SILFunctionConventions.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SIL/TypeLowering.h"
+#include <tuple>
 
 using namespace swift;
 using namespace swift::Lowering;
@@ -941,3 +942,66 @@ bool SILType::isMoveOnly() const {
       return true;
   return isMoveOnlyWrapped();
 }
+
+#ifndef NDEBUG
+bool SILType::visitAggregateLeaves(
+    Lowering::TypeConverter &TC, TypeExpansionContext context,
+    std::function<bool(SILType, SILType, VarDecl *)> isLeaf,
+    std::function<bool(SILType, SILType, VarDecl *)> visit) const {
+
+  llvm::SmallSet<std::tuple<SILType::ValueType, SILType::ValueType, VarDecl *>,
+                 16>
+      visited;
+  llvm::SmallVector<
+      std::tuple<SILType::ValueType, SILType::ValueType, VarDecl *>, 16>
+      worklist;
+  auto insertIntoWorklist = [&visited, &worklist](SILType parent, SILType type,
+                                                  VarDecl *decl) -> bool {
+    if (!visited.insert({parent.value, type.value, decl}).second) {
+      return false;
+    }
+    worklist.push_back({parent.value, type.value, decl});
+    return true;
+  };
+  auto popFromWorklist =
+      [&worklist]() -> std::tuple<SILType, SILType, VarDecl *> {
+    SILType::ValueType parentOpaqueType;
+    SILType::ValueType opaqueType;
+    VarDecl *decl;
+    std::tie(parentOpaqueType, opaqueType, decl) = worklist.pop_back_val();
+    return {parentOpaqueType, opaqueType, decl};
+  };
+  insertIntoWorklist(SILType(), *this, nullptr);
+  while (!worklist.empty()) {
+    SILType parent;
+    SILType ty;
+    VarDecl *decl;
+    std::tie(parent, ty, decl) = popFromWorklist();
+    if (ty.isAggregate() && !isLeaf(parent, ty, decl)) {
+      if (auto tupleTy = ty.getAs<TupleType>()) {
+        for (unsigned index = 0, num = tupleTy->getNumElements(); index < num;
+             ++index) {
+          insertIntoWorklist(ty, ty.getTupleElementType(index), nullptr);
+        }
+      } else if (auto *decl = ty.getStructOrBoundGenericStruct()) {
+        for (auto *field : decl->getStoredProperties()) {
+          insertIntoWorklist(ty, ty.getFieldType(field, TC, context), field);
+        }
+      } else if (auto *decl = ty.getEnumOrBoundGenericEnum()) {
+        for (auto *field : decl->getStoredProperties()) {
+          insertIntoWorklist(ty, ty.getFieldType(field, TC, context), field);
+        }
+      } else {
+        llvm_unreachable("unknown aggregate kind!");
+      }
+      continue;
+    }
+
+    // This type is a leaf.  Visit it.
+    auto success = visit(parent, ty, decl);
+    if (!success)
+      return false;
+  }
+  return true;
+}
+#endif

--- a/lib/SIL/IR/SILValue.cpp
+++ b/lib/SIL/IR/SILValue.cpp
@@ -106,8 +106,11 @@ ValueBase::getDefiningInstructionResult() {
 }
 
 bool ValueBase::isLexical() const {
-  if (auto *argument = dyn_cast<SILFunctionArgument>(this))
-    return argument->getOwnershipKind() == OwnershipKind::Owned;
+  if (auto *argument = dyn_cast<SILFunctionArgument>(this)) {
+    // TODO: Recognize guaranteed arguments as lexical too.
+    return argument->getOwnershipKind() == OwnershipKind::Owned &&
+           argument->getLifetime().isLexical();
+  }
   if (auto *bbi = dyn_cast<BeginBorrowInst>(this))
     return bbi->isLexical();
   if (auto *mvi = dyn_cast<MoveValueInst>(this))

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2420,8 +2420,104 @@ TypeConverter::getTypeLowering(AbstractionPattern origType,
     removeNullEntry(key.getKeyForMinimalExpansion());
 #endif
   }
+
+#ifndef NDEBUG
+  verifyLowering(*lowering, origType, origSubstType, forExpansion);
+#endif
+
   return *lowering;
 }
+
+#ifndef NDEBUG
+void TypeConverter::verifyLowering(const TypeLowering &lowering,
+                                   AbstractionPattern origType,
+                                   Type origSubstType,
+                                   TypeExpansionContext forExpansion) {
+  // Non-trivial lowerings should always be lexical unless all non-trivial
+  // fields are eager move.
+  if (!lowering.isTrivial() && !lowering.isLexical()) {
+    auto getLifetimeAnnotation = [](SILType ty) -> LifetimeAnnotation {
+      NominalTypeDecl *nominal;
+      if (!(nominal = ty.getASTType().getAnyNominal()))
+        return LifetimeAnnotation::None;
+      return nominal->getLifetimeAnnotation();
+    };
+    auto loweredType = lowering.getLoweredType();
+    bool hasNoNontrivialLexicalLeaf = loweredType.visitAggregateLeaves(
+        *this, forExpansion,
+        /*isLeaf=*/
+        [&](auto parent, auto ty, auto *fieldDecl) -> bool {
+          // The field's type is an aggregate.  Treat it as a leaf if it
+          // has a lifetime annotation.
+
+          // If we don't have a field decl, it's either a field of a tuple
+          // or the top-level type.  Either way, there's no var decl on
+          // which to look for an attribute.
+          //
+          // It's a leaf if the type has a lifetime annotation.
+          if (!fieldDecl)
+            return getLifetimeAnnotation(ty).isSome();
+
+          // It's a field of a struct or an enum.  It's a leaf if the type
+          // or the var decl has a lifetime annotation.
+          return fieldDecl->getLifetimeAnnotation().isSome() ||
+                 getLifetimeAnnotation(ty);
+        },
+        /*visit=*/
+        [&](auto parent, auto ty, auto *fieldDecl) -> bool {
+          // Look at each leaf: if it is non-trivial, verify that it is
+          // attributed @_eagerMove.
+
+          // If the leaf is the whole type, verify that it is annotated
+          // @_eagerMove.
+          if (ty == loweredType)
+            return getLifetimeAnnotation(ty) == LifetimeAnnotation::EagerMove;
+
+          // Get ty's lowering.
+          CanGenericSignature sig;
+          if (fieldDecl) {
+            AbstractionPattern origFieldTy = getAbstractionPattern(fieldDecl);
+            CanType substFieldTy;
+            if (fieldDecl->hasClangNode()) {
+              substFieldTy = origFieldTy.getType();
+            } else {
+              substFieldTy = parent.getASTType()
+                                 ->getTypeOfMember(&M, fieldDecl)
+                                 ->getCanonicalType();
+            }
+            sig = getAbstractionPattern(fieldDecl).getGenericSignatureOrNull();
+          } else {
+            sig = CanGenericSignature();
+          }
+          auto &tyLowering = getTypeLowering(ty, forExpansion, sig);
+
+          // Leaves which are trivial aren't of interest.
+          if (tyLowering.isTrivial())
+            return true;
+
+          // We're visiting a non-trival leaf of a type whose lowering is
+          // not lexical.  The leaf must be annotated @_eagerMove.
+          // Otherwise, the whole type would be lexical.
+
+          if (!fieldDecl) {
+            // The field is non-trivial and the whole type is non-lexical.
+            // If there's no field decl which might be annotated
+            // @_eagerMove, we have a problem.
+            return false;
+          }
+
+          // The field is non-trivial and the whole type is non-lexical.
+          // That's fine as long as the field or its type is annotated
+          // @_eagerMove.
+          return fieldDecl->getLifetimeAnnotation() ==
+                     LifetimeAnnotation::EagerMove ||
+                 getLifetimeAnnotation(ty) == LifetimeAnnotation::EagerMove;
+        });
+    assert(hasNoNontrivialLexicalLeaf &&
+           "Found non-trivial lexical leaf in non-trivial non-lexical type?!");
+  }
+}
+#endif
 
 CanType
 TypeConverter::computeLoweredRValueType(TypeExpansionContext forExpansion,

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -232,6 +232,21 @@ namespace {
       return props;
     }
 
+    RecursiveProperties applyLifetimeAnnotation(LifetimeAnnotation annotation,
+                                                RecursiveProperties props) {
+      switch (annotation) {
+      case LifetimeAnnotation::None:
+        break;
+      case LifetimeAnnotation::Lexical:
+        props.setLexical(IsLexical);
+        break;
+      case LifetimeAnnotation::EagerMove:
+        props.setLexical(IsNotLexical);
+        break;
+      }
+      return props;
+    }
+
     RecursiveProperties
     getTrivialRecursiveProperties(IsTypeExpansionSensitive_t isSensitive) {
       return mergeIsTypeExpansionSensitive(isSensitive,
@@ -267,8 +282,6 @@ namespace {
     IMPL(BuiltinBridgeObject, Reference)
     IMPL(BuiltinVector, Trivial)
     IMPL(SILToken, Trivial)
-    IMPL(Class, Reference)
-    IMPL(BoundGenericClass, Reference)
     IMPL(AnyMetatype, Trivial)
     IMPL(Module, Trivial)
 
@@ -288,7 +301,9 @@ namespace {
                                          IsTypeExpansionSensitive_t isSensitive) {
       return asImpl().handleAddressOnly(type, {IsNotTrivial, IsFixedABI,
                                                IsAddressOnly, IsNotResilient,
-                                               isSensitive});
+                                               isSensitive,
+                                               DoesNotHaveRawPointer,
+                                               IsLexical});
     }
 
     RetTy visitBuiltinDefaultActorStorageType(
@@ -297,7 +312,9 @@ namespace {
                                          IsTypeExpansionSensitive_t isSensitive) {
       return asImpl().handleAddressOnly(type, {IsNotTrivial, IsFixedABI,
                                                IsAddressOnly, IsNotResilient,
-                                               isSensitive});
+                                               isSensitive,
+                                               DoesNotHaveRawPointer,
+                                               IsLexical});
     }
 
     RetTy visitAnyFunctionType(CanAnyFunctionType type,
@@ -479,7 +496,9 @@ namespace {
                                                IsFixedABI, \
                                                IsAddressOnly, \
                                                IsNotResilient, \
-                                               isSensitive}); \
+                                               isSensitive, \
+                                               DoesNotHaveRawPointer, \
+                                               IsLexical}); \
     }
 #define ALWAYS_LOADABLE_CHECKED_REF_STORAGE(Name, ...) \
     RetTy visit##Name##StorageType(Can##Name##StorageType type, \
@@ -502,7 +521,9 @@ namespace {
                                                IsFixedABI, \
                                                IsAddressOnly, \
                                                IsNotResilient, \
-                                               isSensitive}); \
+                                               isSensitive, \
+                                               DoesNotHaveRawPointer, \
+                                               IsLexical}); \
     } \
     RetTy visit##Name##StorageType(Can##Name##StorageType type, \
                                    AbstractionPattern origType, \
@@ -579,7 +600,9 @@ namespace {
                                                  IsFixedABI,
                                                  IsAddressOnly,
                                                  IsNotResilient,
-                                                 isSensitive});
+                                                 isSensitive,
+                                                 DoesNotHaveRawPointer,
+                                                 IsLexical});
       // Class-constrained and boxed existentials are refcounted.
       case ExistentialRepresentation::Class:
       case ExistentialRepresentation::Boxed:
@@ -606,6 +629,20 @@ namespace {
                                          AbstractionPattern origType,
                                          IsTypeExpansionSensitive_t isSensitive) {
       return visitExistentialType(type, origType, isSensitive);
+    }
+
+    // Classes depend on their attributes.
+    RetTy visitClassType(CanClassType type, AbstractionPattern origType,
+                         IsTypeExpansionSensitive_t isSensitive) {
+      return asImpl().visitAnyClassType(type, origType, type->getDecl(),
+                                        isSensitive);
+    }
+
+    RetTy visitBoundGenericClassType(CanBoundGenericClassType type,
+                                     AbstractionPattern origType,
+                                     IsTypeExpansionSensitive_t isSensitive) {
+      return asImpl().visitAnyClassType(type, origType, type->getDecl(),
+                                        isSensitive);
     }
 
     // Enums depend on their enumerators.
@@ -671,7 +708,9 @@ namespace {
                                                IsFixedABI,
                                                IsAddressOnly,
                                                IsNotResilient,
-                                               isSensitive});
+                                               isSensitive,
+                                               DoesNotHaveRawPointer,
+                                               IsLexical});
     }
 
     RetTy visitSILBoxType(CanSILBoxType type,
@@ -721,6 +760,14 @@ namespace {
 
     RecursiveProperties handle(CanType type, RecursiveProperties properties) {
       return properties;
+    }
+
+    RecursiveProperties
+    visitAnyClassType(CanType type, AbstractionPattern origType, ClassDecl *D,
+                      IsTypeExpansionSensitive_t isSensitive) {
+      // Consult the type lowering.
+      auto &lowering = TC.getTypeLowering(origType, type, Expansion);
+      return handleClassificationFromLowering(type, lowering, isSensitive);
     }
 
     RecursiveProperties visitAnyEnumType(CanType type,
@@ -1743,7 +1790,8 @@ namespace {
                                   IsTypeExpansionSensitive_t isSensitive)
       : AddressOnlyTypeLowering(type,
                                 {IsNotTrivial, IsFixedABI,
-                                 IsAddressOnly, IsNotResilient, isSensitive},
+                                 IsAddressOnly, IsNotResilient, isSensitive,
+                                 DoesNotHaveRawPointer, IsLexical},
                                 forExpansion) {}
 
     void emitCopyInto(SILBuilder &B, SILLocation loc,
@@ -2019,6 +2067,18 @@ namespace {
       return false;
     }
 
+    TypeLowering *visitAnyClassType(CanType classType,
+                                    AbstractionPattern origType, ClassDecl *C,
+                                    IsTypeExpansionSensitive_t isSensitive) {
+      RecursiveProperties properties =
+          getReferenceRecursiveProperties(isSensitive);
+
+      if (C->getLifetimeAnnotation() == LifetimeAnnotation::EagerMove)
+        properties.setLexical(IsNotLexical);
+
+      return handleReference(classType, properties);
+    }
+
     TypeLowering *visitAnyStructType(CanType structType,
                                      AbstractionPattern origType,
                                      StructDecl *D,
@@ -2061,7 +2121,13 @@ namespace {
         
         properties.addSubobject(classifyType(origFieldType, substFieldType,
                                              TC, Expansion));
+        properties =
+            applyLifetimeAnnotation(field->getLifetimeAnnotation(), properties);
       }
+
+      // Type-level annotations override inferred behavior.
+      properties =
+          applyLifetimeAnnotation(D->getLifetimeAnnotation(), properties);
 
       return handleAggregateByProperties<LoadableStructTypeLowering>(structType,
                                                                     properties);
@@ -2119,7 +2185,13 @@ namespace {
                                  ->getReducedType(D->getGenericSignature()));
         properties.addSubobject(classifyType(origEltType, substEltType,
                                              TC, Expansion));
+        properties =
+            applyLifetimeAnnotation(elt->getLifetimeAnnotation(), properties);
       }
+
+      // Type-level annotations override inferred behavior.
+      properties =
+          applyLifetimeAnnotation(D->getLifetimeAnnotation(), properties);
 
       return handleAggregateByProperties<LoadableEnumTypeLowering>(enumType,
                                                                    properties);

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -310,19 +310,19 @@ namespace swift {
       return parseASTType(result, genericSig, genericParams);
     }
 
-    bool parseIsNoImplicitCopy() {
+    Optional<StringRef> parseOptionalAttribute(ArrayRef<StringRef> expected) {
       // We parse here @ <identifier>.
       if (P.Tok.getKind() != tok::at_sign)
-        return false;
+        return llvm::None;
 
-      // Make sure our text is no implicit copy.
-      if (P.peekToken().getText() != "noImplicitCopy")
-        return false;
+      auto name = P.peekToken().getText();
+      if (!is_contained(expected, name))
+        return llvm::None;
 
       // Ok, we can do this.
       P.consumeToken(tok::at_sign);
       P.consumeToken(tok::identifier);
-      return true;
+      return name;
     }
 
     bool parseSILOwnership(ValueOwnershipKind &OwnershipKind) {
@@ -6369,7 +6369,31 @@ bool SILParser::parseSILBasicBlock(SILBuilder &B) {
             P.parseToken(tok::colon, diag::expected_sil_colon_value_ref))
           return true;
 
-        bool foundNoImplicitCopy = parseIsNoImplicitCopy();
+        bool foundNoImplicitCopy = false;
+        bool foundLexical = false;
+        bool foundEagerMove = false;
+        while (auto attributeName = parseOptionalAttribute(
+                   {"noImplicitCopy", "_lexical", "_eagerMove"})) {
+          if (*attributeName == "noImplicitCopy")
+            foundNoImplicitCopy = true;
+          else if (*attributeName == "_lexical")
+            foundLexical = true;
+          else if (*attributeName == "_eagerMove")
+            foundEagerMove = true;
+          else {
+            llvm_unreachable("Unexpected attribute!");
+          }
+        }
+
+        LifetimeAnnotation lifetime = LifetimeAnnotation::None;
+        if (foundEagerMove && foundLexical) {
+          P.diagnose(NameLoc, diag::sil_arg_both_lexical_and_eagerMove);
+          return true;
+        } else if (foundEagerMove) {
+          lifetime = LifetimeAnnotation::EagerMove;
+        } else if (foundLexical) {
+          lifetime = LifetimeAnnotation::Lexical;
+        }
 
         // If SILOwnership is enabled and we are not assuming that we are
         // parsing unqualified SIL, look for printed value ownership kinds.
@@ -6384,6 +6408,7 @@ bool SILParser::parseSILBasicBlock(SILBuilder &B) {
         if (IsEntry) {
           auto *fArg = BB->createFunctionArgument(Ty);
           fArg->setNoImplicitCopy(foundNoImplicitCopy);
+          fArg->setLifetimeAnnotation(lifetime);
           Arg = fArg;
 
           // Today, we construct the ownership kind straight from the function

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -1415,6 +1415,10 @@ void swift::visitProductLeafAccessPathNodes(
         visitor(AccessPath::PathNode(node), silType);
         continue;
       }
+      if (decl->isCxxNonTrivial()) {
+        visitor(AccessPath::PathNode(node), silType);
+        continue;
+      }
       unsigned index = 0;
       for (auto *field : decl->getStoredProperties()) {
         auto *fieldNode = node->getChild(index);

--- a/lib/SILGen/ResultPlan.cpp
+++ b/lib/SILGen/ResultPlan.cpp
@@ -68,9 +68,10 @@ public:
     assert(box && "buffer never emitted before activating cleanup?!");
     auto theBox = box;
     if (SGF.getASTContext().SILOpts.supportsLexicalLifetimes(SGF.getModule())) {
-      auto *bbi = cast<BeginBorrowInst>(theBox);
-      SGF.B.createEndBorrow(loc, bbi);
-      theBox = bbi->getOperand();
+      if (auto *bbi = cast<BeginBorrowInst>(theBox)) {
+        SGF.B.createEndBorrow(loc, bbi);
+        theBox = bbi->getOperand();
+      }
     }
     SGF.B.createDeallocBox(loc, theBox);
   }

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3656,9 +3656,10 @@ public:
   void emit(SILGenFunction &SGF, CleanupLocation l, ForUnwind_t forUnwind) override {
     auto theBox = box;
     if (SGF.getASTContext().SILOpts.supportsLexicalLifetimes(SGF.getModule())) {
-      auto *bbi = cast<BeginBorrowInst>(theBox);
-      SGF.B.createEndBorrow(l, bbi);
-      theBox = bbi->getOperand();
+      if (auto *bbi = cast<BeginBorrowInst>(theBox)) {
+        SGF.B.createEndBorrow(l, bbi);
+        theBox = bbi->getOperand();
+      }
     }
     SGF.B.createDeallocBox(l, theBox);
   }

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -433,16 +433,17 @@ ManagedValue SILGenBuilder::createLoadCopy(SILLocation loc, ManagedValue v,
   return SGF.emitManagedRValueWithCleanup(result, lowering);
 }
 
-static ManagedValue createInputFunctionArgument(SILGenBuilder &B, SILType type,
-                                                SILLocation loc,
-                                                ValueDecl *decl = nullptr,
-                                                bool isNoImplicitCopy = false) {
+static ManagedValue createInputFunctionArgument(
+    SILGenBuilder &B, SILType type, SILLocation loc, ValueDecl *decl = nullptr,
+    bool isNoImplicitCopy = false,
+    LifetimeAnnotation lifetimeAnnotation = LifetimeAnnotation::None) {
   auto &SGF = B.getSILGenFunction();
   SILFunction &F = B.getFunction();
   assert((F.isBare() || decl) &&
          "Function arguments of non-bare functions must have a decl");
   auto *arg = F.begin()->createFunctionArgument(type, decl);
   arg->setNoImplicitCopy(isNoImplicitCopy);
+  arg->setLifetimeAnnotation(lifetimeAnnotation);
   switch (arg->getArgumentConvention()) {
   case SILArgumentConvention::Indirect_In_Guaranteed:
   case SILArgumentConvention::Direct_Guaranteed:
@@ -476,11 +477,11 @@ static ManagedValue createInputFunctionArgument(SILGenBuilder &B, SILType type,
   llvm_unreachable("bad parameter convention");
 }
 
-ManagedValue SILGenBuilder::createInputFunctionArgument(SILType type,
-                                                        ValueDecl *decl,
-                                                        bool isNoImplicitCopy) {
+ManagedValue SILGenBuilder::createInputFunctionArgument(
+    SILType type, ValueDecl *decl, bool isNoImplicitCopy,
+    LifetimeAnnotation lifetimeAnnotation) {
   return ::createInputFunctionArgument(*this, type, SILLocation(decl), decl,
-                                       isNoImplicitCopy);
+                                       isNoImplicitCopy, lifetimeAnnotation);
 }
 
 ManagedValue

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -226,8 +226,9 @@ public:
 
   /// Create a SILArgument for an input parameter. Asserts if used to create a
   /// function argument for an out parameter.
-  ManagedValue createInputFunctionArgument(SILType type, ValueDecl *decl,
-                                           bool isNoImplicitCopy = false);
+  ManagedValue createInputFunctionArgument(
+      SILType type, ValueDecl *decl, bool isNoImplicitCopy = false,
+      LifetimeAnnotation lifetimeAnnotation = LifetimeAnnotation::None);
 
   /// Create a SILArgument for an input parameter. Uses \p loc to create any
   /// copies necessary. Asserts if used to create a function argument for an out

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -299,9 +299,10 @@ public:
             ForUnwind_t forUnwind) override {
     auto box = Box;
     if (SGF.getASTContext().SILOpts.supportsLexicalLifetimes(SGF.getModule())) {
-      auto *bbi = cast<BeginBorrowInst>(box);
-      SGF.B.createEndBorrow(l, bbi);
-      box = bbi->getOperand();
+      if (auto *bbi = dyn_cast<BeginBorrowInst>(box)) {
+        SGF.B.createEndBorrow(l, bbi);
+        box = bbi->getOperand();
+      }
     }
     SGF.B.createDeallocBox(l, box);
   }
@@ -367,7 +368,11 @@ public:
       Box = SGF.B.createMarkUninitialized(decl, Box, kind.getValue());
 
     if (SGF.getASTContext().SILOpts.supportsLexicalLifetimes(SGF.getModule())) {
-      Box = SGF.B.createBeginBorrow(decl, Box, /*isLexical=*/true);
+      auto loweredType = SGF.getTypeLowering(decl->getType()).getLoweredType();
+      auto lifetime = SGF.F.getLifetime(decl, loweredType);
+      if (lifetime.isLexical()) {
+        Box = SGF.B.createBeginBorrow(decl, Box, /*isLexical=*/true);
+      }
     }
 
     Addr = SGF.B.createProjectBox(decl, Box, 0);
@@ -489,11 +494,13 @@ public:
     }
 
     if (needsTemporaryBuffer) {
-      bool isLexical =
+      bool lexicalLifetimesEnabled =
           SGF.getASTContext().SILOpts.supportsLexicalLifetimes(SGF.getModule());
+      auto lifetime = SGF.F.getLifetime(vd, lowering->getLoweredType());
+      auto isLexical = lexicalLifetimesEnabled && lifetime.isLexical();
       address =
           SGF.emitTemporaryAllocation(vd, lowering->getLoweredType(),
-                                      false /*hasDynamicLifetime*/, isLexical);
+                                      /*hasDynamicLifetime=*/false, isLexical);
       if (isUninitialized)
         address = SGF.B.createMarkUninitializedVar(vd, address);
       DestroyCleanup = SGF.enterDormantTemporaryCleanup(address, *lowering);
@@ -575,9 +582,14 @@ public:
           PrologueLoc, value, MarkMustCheckInst::CheckKind::NoImplicitCopy);
     }
 
-    // Then if we don't have move only, just perform a lexical borrow.
-    if (!SGF.getASTContext().LangOpts.Features.count(Feature::MoveOnly))
-      return SGF.B.createBeginBorrow(PrologueLoc, value, /*isLexical*/ true);
+    // Then if we don't have move only, just perform a lexical borrow if the
+    // lifetime is lexical.
+    if (!SGF.getASTContext().LangOpts.Features.count(Feature::MoveOnly)) {
+      if (SGF.F.getLifetime(vd, value->getType()).isLexical())
+        return SGF.B.createBeginBorrow(PrologueLoc, value, /*isLexical*/ true);
+      else
+        return value;
+    }
 
     // Otherwise, we need to perform some additional processing. First, if we
     // have an owned moveonly value that had a cleanup, then create a move_value
@@ -612,10 +624,14 @@ public:
           PrologueLoc, value, MarkMustCheckInst::CheckKind::NoImplicitCopy);
     }
 
-    // Otherwise, if we do not have a no implicit copy variable, just do a
-    // borrow lexical. This is the "normal path".
-    if (!vd->getAttrs().hasAttribute<NoImplicitCopyAttr>())
-      return SGF.B.createBeginBorrow(PrologueLoc, value, /*isLexical*/ true);
+    // Otherwise, if we do not have a no implicit copy variable, just follow
+    // the "normal path": perform a lexical borrow if the lifetime is lexical.
+    if (!vd->getAttrs().hasAttribute<NoImplicitCopyAttr>()) {
+      if (SGF.F.getLifetime(vd, value->getType()).isLexical())
+        return SGF.B.createBeginBorrow(PrologueLoc, value, /*isLexical*/ true);
+      else
+        return value;
+    }
 
     // If we have a no implicit copy lexical, emit the instruction stream so
     // that the move checker knows to check this variable.
@@ -1830,10 +1846,13 @@ void SILGenFunction::destroyLocalVariable(SILLocation silLoc, VarDecl *vd) {
       return;
     }
 
-    auto *bbi = cast<BeginBorrowInst>(loc.box);
-    B.createEndBorrow(silLoc, bbi);
-    B.emitDestroyValueOperation(silLoc, bbi->getOperand());
+    if (auto *bbi = dyn_cast<BeginBorrowInst>(loc.box)) {
+      B.createEndBorrow(silLoc, bbi);
+      B.emitDestroyValueOperation(silLoc, bbi->getOperand());
+      return;
+    }
 
+    B.emitDestroyValueOperation(silLoc, loc.box);
     return;
   }
 
@@ -1852,6 +1871,11 @@ void SILGenFunction::destroyLocalVariable(SILLocation silLoc, VarDecl *vd) {
   }
 
   if (Val->getOwnershipKind() == OwnershipKind::None) {
+    return;
+  }
+
+  if (!F.getLifetime(vd, Val->getType()).isLexical()) {
+    B.emitDestroyValueOperation(silLoc, Val);
     return;
   }
 

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -264,9 +264,9 @@ struct ArgumentInitHelper {
     if (!SGF.getASTContext().SILOpts.supportsLexicalLifetimes(SGF.getModule()))
       return value;
 
-    bool isNoImplicitCopy = false;
-    if (auto *arg = dyn_cast<SILFunctionArgument>(value))
-      isNoImplicitCopy = arg->isNoImplicitCopy();
+    // Look for the following annotations on the function argument:
+    // - @noImplicitCopy
+    auto isNoImplicitCopy = pd->isNoImplicitCopy();
 
     // If we have a no implicit copy argument and the argument is trivial,
     // we need to use copyable to move only to convert it to its move only

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -58,12 +58,15 @@ public:
   CanSILFunctionType fnTy;
   ArrayRef<SILParameterInfo> &parameters;
   bool isNoImplicitCopy;
+  LifetimeAnnotation lifetimeAnnotation;
 
   EmitBBArguments(SILGenFunction &sgf, SILBasicBlock *parent, SILLocation l,
                   CanSILFunctionType fnTy,
-                  ArrayRef<SILParameterInfo> &parameters, bool isNoImplicitCopy)
+                  ArrayRef<SILParameterInfo> &parameters, bool isNoImplicitCopy,
+                  LifetimeAnnotation lifetimeAnnotation)
       : SGF(sgf), parent(parent), loc(l), fnTy(fnTy), parameters(parameters),
-        isNoImplicitCopy(isNoImplicitCopy) {}
+        isNoImplicitCopy(isNoImplicitCopy),
+        lifetimeAnnotation(lifetimeAnnotation) {}
 
   ManagedValue visitType(CanType t, AbstractionPattern orig) {
     return visitType(t, orig, /*isInOut=*/false);
@@ -90,7 +93,8 @@ public:
     auto paramType =
         SGF.F.mapTypeIntoContext(SGF.getSILType(parameterInfo, fnTy));
     ManagedValue mv = SGF.B.createInputFunctionArgument(
-        paramType, loc.getAsASTNode<ValueDecl>(), isNoImplicitCopy);
+        paramType, loc.getAsASTNode<ValueDecl>(), isNoImplicitCopy,
+        lifetimeAnnotation);
 
     // This is a hack to deal with the fact that Self.Type comes in as a static
     // metatype, but we have to downcast it to a dynamic Self metatype to get
@@ -239,13 +243,14 @@ struct ArgumentInitHelper {
   unsigned getNumArgs() const { return ArgNo; }
 
   ManagedValue makeArgument(Type ty, bool isInOut, bool isNoImplicitCopy,
-                            SILBasicBlock *parent, SILLocation l) {
+                            LifetimeAnnotation lifetime, SILBasicBlock *parent,
+                            SILLocation l) {
     assert(ty && "no type?!");
 
     // Create an RValue by emitting destructured arguments into a basic block.
     CanType canTy = ty->getCanonicalType();
     EmitBBArguments argEmitter(SGF, parent, l, f.getLoweredFunctionType(),
-                               parameters, isNoImplicitCopy);
+                               parameters, isNoImplicitCopy, lifetime);
 
     // Note: inouts of tuples are not exploded, so we bypass visit().
     AbstractionPattern origTy = OrigFnType
@@ -266,17 +271,24 @@ struct ArgumentInitHelper {
 
     // Look for the following annotations on the function argument:
     // - @noImplicitCopy
+    // - @_eagerMove
+    // - @_lexical
     auto isNoImplicitCopy = pd->isNoImplicitCopy();
+    auto lifetime = SGF.F.getLifetime(pd, value->getType());
 
     // If we have a no implicit copy argument and the argument is trivial,
     // we need to use copyable to move only to convert it to its move only
     // form.
     if (!isNoImplicitCopy) {
       if (!value->getType().isMoveOnly()) {
+        // Follow the "normal path": perform a lexical borrow if the lifetime is
+        // lexical.
         if (value->getOwnershipKind() == OwnershipKind::Owned) {
-          value =
-              SILValue(SGF.B.createBeginBorrow(loc, value, /*isLexical*/ true));
-          SGF.Cleanups.pushCleanup<EndBorrowCleanup>(value);
+          if (lifetime.isLexical()) {
+            value = SILValue(
+                SGF.B.createBeginBorrow(loc, value, /*isLexical*/ true));
+            SGF.Cleanups.pushCleanup<EndBorrowCleanup>(value);
+          }
         }
         return value;
       }
@@ -343,8 +355,8 @@ struct ArgumentInitHelper {
     SILLocation loc(pd);
     loc.markAsPrologue();
 
-    ManagedValue argrv =
-        makeArgument(ty, pd->isInOut(), pd->isNoImplicitCopy(), parent, loc);
+    ManagedValue argrv = makeArgument(ty, pd->isInOut(), pd->isNoImplicitCopy(),
+                                      pd->getLifetimeAnnotation(), parent, loc);
 
     if (pd->isInOut()) {
       assert(argrv.getType().isAddress() && "expected inout to be address");
@@ -362,7 +374,10 @@ struct ArgumentInitHelper {
     } else {
       if (auto *allocStack = dyn_cast<AllocStackInst>(value)) {
         allocStack->setArgNo(ArgNo);
-        allocStack->setIsLexical();
+        if (SGF.getASTContext().SILOpts.supportsLexicalLifetimes(
+                SGF.getModule()) &&
+            SGF.F.getLifetime(pd, value->getType()).isLexical())
+          allocStack->setIsLexical();
       } else {
         SGF.B.createDebugValueAddr(loc, value, varinfo);
       }
@@ -397,8 +412,9 @@ struct ArgumentInitHelper {
     Scope discardScope(SGF.Cleanups, CleanupLocation(PD));
 
     // Manage the parameter.
-    auto argrv = makeArgument(type, PD->isInOut(), PD->isNoImplicitCopy(),
-                              &*f.begin(), paramLoc);
+    auto argrv =
+        makeArgument(type, PD->isInOut(), PD->isNoImplicitCopy(),
+                     PD->getLifetimeAnnotation(), &*f.begin(), paramLoc);
 
     // Emit debug information for the argument.
     SILLocation loc(PD);

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -301,7 +301,7 @@ struct ArgumentInitHelper {
 
     if (value->getType().isTrivial(SGF.F)) {
       value = SGF.B.createOwnedCopyableToMoveOnlyWrapperValue(loc, value);
-      value = SGF.B.createMoveValue(loc, value, true /*is lexical*/);
+      value = SGF.B.createMoveValue(loc, value, /*isLexical=*/true);
 
       // If our argument was owned, we use no implicit copy. Otherwise, we
       // use no copy.

--- a/lib/SILGen/Scope.cpp
+++ b/lib/SILGen/Scope.cpp
@@ -57,6 +57,8 @@ static void lifetimeExtendAddressOnlyRValueSubValues(
            "addresses must be address only.");
     auto boxTy = SILBoxType::get(v->getType().getASTType());
     SILValue box = SGF.B.createAllocBox(loc, boxTy);
+    // TODO: Should these boxes that extend lifetimes for rvalue subobjects ever
+    //       be lexical?
     if (SGF.getASTContext().SILOpts.supportsLexicalLifetimes(SGF.getModule())) {
       box = SGF.B.createBeginBorrow(loc, box, /*isLexical=*/true);
     }

--- a/lib/SILGen/Scope.cpp
+++ b/lib/SILGen/Scope.cpp
@@ -60,7 +60,10 @@ static void lifetimeExtendAddressOnlyRValueSubValues(
     // TODO: Should these boxes that extend lifetimes for rvalue subobjects ever
     //       be lexical?
     if (SGF.getASTContext().SILOpts.supportsLexicalLifetimes(SGF.getModule())) {
-      box = SGF.B.createBeginBorrow(loc, box, /*isLexical=*/true);
+      if (v->getType().getLifetime(SGF.F).isLexical()) {
+        box = SGF.B.createBeginBorrow(loc, box,
+                                      /*isLexical=*/true);
+      }
     }
     SILValue addr = SGF.B.createProjectBox(loc, box, 0);
     SGF.B.createCopyAddr(loc, v, addr, IsTake, IsInitialization);

--- a/lib/SILOptimizer/SemanticARC/CopyValueOpts.cpp
+++ b/lib/SILOptimizer/SemanticARC/CopyValueOpts.cpp
@@ -172,7 +172,7 @@ bool SemanticARCOptVisitor::performGuaranteedCopyValueOptimization(
   // destroy_values. Check if:
   //
   // 1. All of our destroys are joint post-dominated by our end borrow scope
-  //    set. If they do not, then the copy_value is lifetime extending the
+  //    set. If they are not, then the copy_value is lifetime extending the
   //    guaranteed value, we can not eliminate it.
   //
   // 2. If all of our destroy_values are dead end. In such a case, the linear

--- a/lib/SILOptimizer/SemanticARC/CopyValueOpts.cpp
+++ b/lib/SILOptimizer/SemanticARC/CopyValueOpts.cpp
@@ -187,7 +187,6 @@ bool SemanticARCOptVisitor::performGuaranteedCopyValueOptimization(
   // scope, regardless of whether the end of the scope is inside a dead-end
   // block.
   {
-    SmallVector<Operand *, 8> scratchSpace;
     if (llvm::any_of(borrowScopeIntroducers, [&](BorrowedValue borrowScope) {
           return !borrowScope.areUsesWithinTransitiveScope(
               lr.getAllConsumingUses(), nullptr);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -318,6 +318,9 @@ public:
 
   void visitUnsafeInheritExecutorAttr(UnsafeInheritExecutorAttr *attr);
 
+  void visitEagerMoveAttr(EagerMoveAttr *attr);
+  void visitLexicalAttr(LexicalAttr *attr);
+
   void visitCompilerInitializedAttr(CompilerInitializedAttr *attr);
 
   void checkBackDeployAttrs(ArrayRef<BackDeployAttr *> Attrs);
@@ -6214,6 +6217,16 @@ void AttributeChecker::visitUnsafeInheritExecutorAttr(
   auto fn = cast<FuncDecl>(D);
   if (!fn->isAsyncContext()) {
     diagnose(attr->getLocation(), diag::inherits_executor_without_async);
+  }
+}
+
+void AttributeChecker::visitEagerMoveAttr(EagerMoveAttr *attr) {}
+
+void AttributeChecker::visitLexicalAttr(LexicalAttr *attr) {
+  // @_lexical and @_eagerMove are opposites and can't be combined.
+  if (D->getAttrs().hasAttribute<EagerMoveAttr>()) {
+    diagnoseAndRemoveAttr(attr, diag::eagermove_and_lexical_combined);
+    return;
   }
 }
 

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1614,6 +1614,9 @@ namespace  {
     UNINTERESTING_ATTR(UnsafeInheritExecutor)
     UNINTERESTING_ATTR(CompilerInitialized)
     UNINTERESTING_ATTR(AlwaysEmitConformanceMetadata)
+
+    UNINTERESTING_ATTR(EagerMove)
+    UNINTERESTING_ATTR(Lexical)
 #undef UNINTERESTING_ATTR
 
     void visitAvailableAttr(AvailableAttr *attr) {

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -946,6 +946,8 @@ SILBasicBlock *SILDeserializer::readSILBasicBlock(SILFunction *Fn,
       auto *fArg = CurrentBB->createFunctionArgument(SILArgTy);
       bool isNoImplicitCopy = (Args[I + 1] >> 16) & 0x1;
       fArg->setNoImplicitCopy(isNoImplicitCopy);
+      auto lifetime = (LifetimeAnnotation::Case)((Args[I + 1] >> 17) & 0x3);
+      fArg->setLifetimeAnnotation(lifetime);
       Arg = fArg;
     } else {
       auto OwnershipKind = ValueOwnershipKind((Args[I + 1] >> 8) & 0xF);

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 703; // remove builtin unsafe guaran
+const uint16_t SWIFTMODULE_VERSION_MINOR = 704; // _eagerMove/_lexical function argument attributes
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -624,7 +624,9 @@ void SILSerializer::writeSILBasicBlock(const SILBasicBlock &BB) {
     unsigned packedMetadata = 0;
     packedMetadata |= unsigned(SA->getType().getCategory());  // 8 bits
     packedMetadata |= unsigned(SA->getOwnershipKind()) << 8;  // 8 bits
-    packedMetadata |= unsigned(SA->isNoImplicitCopy()) << 16; // 1 bit
+    if (auto *SFA = dyn_cast<SILFunctionArgument>(SA)) {
+      packedMetadata |= unsigned(SFA->isNoImplicitCopy()) << 16; // 1 bit
+    }
     // Used: 17 bits. Free: 15.
     //
     // TODO: We should be able to shrink the packed metadata of the first two.

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -626,8 +626,9 @@ void SILSerializer::writeSILBasicBlock(const SILBasicBlock &BB) {
     packedMetadata |= unsigned(SA->getOwnershipKind()) << 8;  // 8 bits
     if (auto *SFA = dyn_cast<SILFunctionArgument>(SA)) {
       packedMetadata |= unsigned(SFA->isNoImplicitCopy()) << 16; // 1 bit
+      packedMetadata |= unsigned(SFA->getLifetimeAnnotation()) << 17; // 2 bits
     }
-    // Used: 17 bits. Free: 15.
+    // Used: 19 bits. Free: 13.
     //
     // TODO: We should be able to shrink the packed metadata of the first two.
     Args.push_back(packedMetadata);

--- a/test/AutoDiff/SILOptimizer/activity_analysis.swift
+++ b/test/AutoDiff/SILOptimizer/activity_analysis.swift
@@ -18,7 +18,7 @@ func testNoDerivativeStructProjection(_ s: HasNoDerivativeProperty) -> Float {
 
 // CHECK-LABEL: [AD] Activity info for ${{.*}}testNoDerivativeStructProjection{{.*}} at parameter indices (0) and result indices (0):
 // CHECK: [ACTIVE] %0 = argument of bb0 : $HasNoDerivativeProperty
-// CHECK: [ACTIVE]   %2 = alloc_stack [lexical] $HasNoDerivativeProperty, var, name "tmp"
+// CHECK: [ACTIVE]   %2 = alloc_stack $HasNoDerivativeProperty, var, name "tmp"
 // CHECK: [ACTIVE]   %4 = begin_access [read] [static] %2 : $*HasNoDerivativeProperty
 // CHECK: [ACTIVE]   %5 = struct_element_addr %4 : $*HasNoDerivativeProperty, #HasNoDerivativeProperty.x
 // CHECK: [VARIED]   %6 = load [trivial] %5 : $*Float
@@ -76,7 +76,7 @@ func TF_781(_ x: Float, _ y: Float) -> Float {
 // CHECK-LABEL: [AD] Activity info for ${{.*}}TF_781{{.*}} at parameter indices (0) and result indices (0)
 // CHECK: [ACTIVE] %0 = argument of bb0 : $Float
 // CHECK: [USEFUL] %1 = argument of bb0 : $Float
-// CHECK: [ACTIVE]   %4 = alloc_stack [lexical] $Float, var, name "result"
+// CHECK: [ACTIVE]   %4 = alloc_stack $Float, var, name "result"
 // CHECK: [ACTIVE]   %19 = begin_access [read] [static] %4 : $*Float
 // CHECK: [ACTIVE]   %20 = load [trivial] %19 : $*Float
 // CHECK: [ACTIVE]   %23 = apply %22(%20, %0, %18) : $@convention(method) (Float, Float, @thin Float.Type) -> Float
@@ -103,9 +103,9 @@ func TF_954(_ x: Float) -> Float {
 // CHECK-LABEL: [AD] Activity info for ${{.*}}TF_954{{.*}} at parameter indices (0) and result indices (0)
 // CHECK: bb0:
 // CHECK: [ACTIVE] %0 = argument of bb0 : $Float
-// CHECK: [ACTIVE]   %2 = alloc_stack [lexical] $Float, var, name "outer"
+// CHECK: [ACTIVE]   %2 = alloc_stack $Float, var, name "outer"
 // CHECK: bb1:
-// CHECK: [ACTIVE]   %10 = alloc_stack [lexical] $Float, var, name "inner"
+// CHECK: [ACTIVE]   %10 = alloc_stack $Float, var, name "inner"
 // CHECK: [ACTIVE]   %11 = begin_access [read] [static] %2 : $*Float
 // CHECK: [USEFUL]   %14 = metatype $@thin Float.Type
 // CHECK: [ACTIVE]   %15 = begin_access [read] [static] %10 : $*Float
@@ -286,7 +286,7 @@ func testArrayUninitializedIntrinsicAddress(_ x: Float, _ y: Float) -> [Float] {
 // CHECK-LABEL: [AD] Activity info for ${{.*}}testArrayUninitializedIntrinsicAddress{{.*}} at parameter indices (0, 1) and result indices (0)
 // CHECK: [ACTIVE] %0 = argument of bb0 : $Float
 // CHECK: [ACTIVE] %1 = argument of bb0 : $Float
-// CHECK: [ACTIVE]   %4 = alloc_stack [lexical] $Float, var, name "result"
+// CHECK: [ACTIVE]   %4 = alloc_stack $Float, var, name "result"
 // CHECK: [ACTIVE]   %7 = begin_access [read] [static] %4 : $*Float
 // CHECK: [ACTIVE]   %8 = load [trivial] %7 : $*Float
 // CHECK: [NONE]   // function_ref static Float.* infix(_:_:)
@@ -440,7 +440,7 @@ func activeInoutArgMutatingMethod(_ x: Mut) -> Mut {
 
 // CHECK-LABEL: [AD] Activity info for ${{.*}}28activeInoutArgMutatingMethodyAA3MutVADF at parameter indices (0) and result indices (0)
 // CHECK: [ACTIVE] %0 = argument of bb0 : $Mut
-// CHECK: [ACTIVE]   %2 = alloc_stack [lexical] $Mut, var, name "result"
+// CHECK: [ACTIVE]   %2 = alloc_stack $Mut, var, name "result"
 // CHECK: [ACTIVE]   %4 = begin_access [read] [static] %2 : $*Mut
 // CHECK: [ACTIVE]   %5 = load [trivial] %4 : $*Mut
 // CHECK: [ACTIVE]   %7 = begin_access [modify] [static] %2 : $*Mut
@@ -459,7 +459,7 @@ func activeInoutArgMutatingMethodVar(_ nonactive: inout Mut, _ x: Mut) {
 // CHECK_LABEL: [AD] Activity info for ${{.*}}31activeInoutArgMutatingMethodVaryyAA3MutVz_ADtF at (parameters=(1) results=(0))
 // CHECK: [ACTIVE] %0 = argument of bb0 : $*Mut
 // CHECK: [ACTIVE] %1 = argument of bb0 : $Mut
-// CHECK: [ACTIVE]   %4 = alloc_stack [lexical] $Mut, var, name "result"
+// CHECK: [ACTIVE]   %4 = alloc_stack $Mut, var, name "result"
 // CHECK: [ACTIVE]   %5 = begin_access [read] [static] %0 : $*Mut
 // CHECK: [ACTIVE]   %8 = begin_access [modify] [static] %4 : $*Mut
 // CHECK: [NONE]   // function_ref Mut.mutatingMethod(_:)
@@ -480,7 +480,7 @@ func activeInoutArgMutatingMethodTuple(_ nonactive: inout Mut, _ x: Mut) {
 // CHECK-LABEL: [AD] Activity info for ${{.*}}33activeInoutArgMutatingMethodTupleyyAA3MutVz_ADtF at parameter indices (1) and result indices (0)
 // CHECK: [ACTIVE] %0 = argument of bb0 : $*Mut
 // CHECK: [ACTIVE] %1 = argument of bb0 : $Mut
-// CHECK: [ACTIVE]   %4 = alloc_stack [lexical] $(Mut, Mut), var, name "result"
+// CHECK: [ACTIVE]   %4 = alloc_stack $(Mut, Mut), var, name "result"
 // CHECK: [ACTIVE]   %5 = tuple_element_addr %4 : $*(Mut, Mut), 0
 // CHECK: [ACTIVE]   %6 = tuple_element_addr %4 : $*(Mut, Mut), 1
 // CHECK: [ACTIVE]   %7 = begin_access [read] [static] %0 : $*Mut
@@ -507,7 +507,7 @@ func activeInoutArg(_ x: Float) -> Float {
 
 // CHECK-LABEL: [AD] Activity info for ${{.*}}activeInoutArg{{.*}} at parameter indices (0) and result indices (0)
 // CHECK: [ACTIVE] %0 = argument of bb0 : $Float
-// CHECK: [ACTIVE]   %2 = alloc_stack [lexical] $Float, var, name "result"
+// CHECK: [ACTIVE]   %2 = alloc_stack $Float, var, name "result"
 // CHECK: [ACTIVE]   %5 = begin_access [modify] [static] %2 : $*Float
 // CHECK: [NONE]   // function_ref static Float.+= infix(_:_:)
 // CHECK: [NONE]   %7 = apply %6(%5, %0, %4) : $@convention(method) (@inout Float, Float, @thin Float.Type) -> ()
@@ -523,7 +523,7 @@ func activeInoutArgNonactiveInitialResult(_ x: Float) -> Float {
 
 // CHECK-LABEL: [AD] Activity info for ${{.*}}activeInoutArgNonactiveInitialResult{{.*}} at parameter indices (0) and result indices (0)
 // CHECK: [ACTIVE] %0 = argument of bb0 : $Float
-// CHECK: [ACTIVE]   %2 = alloc_stack [lexical] $Float, var, name "result"
+// CHECK: [ACTIVE]   %2 = alloc_stack $Float, var, name "result"
 // CHECK: [NONE]   // function_ref Float.init(_builtinIntegerLiteral:)
 // CHECK: [USEFUL]   %6 = apply %5(%3, %4) : $@convention(method) (Builtin.IntLiteral, @thin Float.Type) -> Float
 // CHECK: [USEFUL]   %8 = metatype $@thin Float.Type
@@ -584,7 +584,7 @@ func testAccessorCoroutines(_ x: HasCoroutineAccessors) -> HasCoroutineAccessors
 
 // CHECK-LABEL: [AD] Activity info for ${{.*}}testAccessorCoroutines{{.*}} at parameter indices (0) and result indices (0)
 // CHECK: [ACTIVE] %0 = argument of bb0 : $HasCoroutineAccessors
-// CHECK: [ACTIVE]   %2 = alloc_stack [lexical] $HasCoroutineAccessors, var, name "x"
+// CHECK: [ACTIVE]   %2 = alloc_stack $HasCoroutineAccessors, var, name "x"
 // CHECK: [ACTIVE]   %4 = begin_access [read] [static] %2 : $*HasCoroutineAccessors
 // CHECK: [ACTIVE]   %5 = load [trivial] %4 : $*HasCoroutineAccessors
 // CHECK: [NONE]   // function_ref HasCoroutineAccessors.computed.read
@@ -754,7 +754,7 @@ func testActiveOptional(_ x: Float) -> Float {
 // CHECK-LABEL: [AD] Activity info for ${{.*}}testActiveOptional{{.*}} at parameter indices (0) and result indices (0)
 // CHECK: bb0:
 // CHECK: [ACTIVE] %0 = argument of bb0 : $Float
-// CHECK: [ACTIVE]   %2 = alloc_stack [lexical] $Optional<Float>, var, name "maybe"
+// CHECK: [ACTIVE]   %2 = alloc_stack $Optional<Float>, var, name "maybe"
 // CHECK: [USEFUL]   %3 = integer_literal $Builtin.IntLiteral, 10
 // CHECK: [USEFUL]   %4 = metatype $@thin Float.Type
 // CHECK: [NONE]   // function_ref Float.init(_builtinIntegerLiteral:)

--- a/test/DebugInfo/debug_value_addr.swift
+++ b/test/DebugInfo/debug_value_addr.swift
@@ -28,7 +28,7 @@ func use<T>(_ t : T) {}
 // CHECK-SIL: sil hidden @$s16debug_value_addr11GenericSelfV1xACyxGx_tcfC : $@convention(method) <T> (@in T, @thin GenericSelf<T>.Type) -> GenericSelf<T> {
 // CHECK-SIL: bb0(%0 : $*T, %1 : $@thin GenericSelf<T>.Type):
 //
-// CHECK-SIL-NEXT:  alloc_stack [lexical] $GenericSelf<T>, var, name "self", implicit, loc {{.*}}
+// CHECK-SIL-NEXT:  alloc_stack $GenericSelf<T>, var, name "self", implicit, loc {{.*}}
 // CHECK-SIL-NEXT:  debug_value %0 : $*T, let, name "x", argno 1, expr op_deref, loc {{.*}}
 struct GenericSelf<T> {
   init(x: T) {

--- a/test/Interop/Cxx/class/type-classification-non-trivial-silgen.swift
+++ b/test/Interop/Cxx/class/type-classification-non-trivial-silgen.swift
@@ -5,7 +5,7 @@ import TypeClassification
 // Make sure that "StructWithDestructor" is marked as non-trivial by checking for a
 // "destroy_addr".
 // CHECK-LABEL: sil [ossa] @$s4main24testStructWithDestructoryyF
-// CHECK: [[AS:%.*]] = alloc_stack [lexical] $StructWithDestructor
+// CHECK: [[AS:%.*]] = alloc_stack $StructWithDestructor
 // CHECK: [[FN:%.*]] = function_ref @{{_ZN20StructWithDestructorC1Ev|\?\?0StructWithDestructor@@QEAA@XZ}} : $@convention(c) () -> @out StructWithDestructor
 // CHECK: apply [[FN]]([[AS]]) : $@convention(c) () -> @out StructWithDestructor
 // CHECK: destroy_addr [[AS]]
@@ -20,7 +20,7 @@ public func testStructWithDestructor() {
 // Make sure that "HasMemberWithDestructor" is marked as non-trivial by checking
 // for a "destroy_addr".
 // CHECK-LABEL: sil [ossa] @$s4main33testStructWithSubobjectDestructoryyF : $@convention(thin) () -> ()
-// CHECK: [[AS:%.*]] = alloc_stack [lexical] $StructWithSubobjectDestructor
+// CHECK: [[AS:%.*]] = alloc_stack $StructWithSubobjectDestructor
 // CHECK: [[FN:%.*]] = function_ref @{{_ZN29StructWithSubobjectDestructorC1Ev|\?\?0StructWithSubobjectDestructor@@QEAA@XZ}} : $@convention(c) () -> @out StructWithSubobjectDestructor
 // CHECK: apply [[FN]]([[AS]]) : $@convention(c) () -> @out StructWithSubobjectDestructor
 // CHECK: destroy_addr [[AS]]
@@ -32,7 +32,7 @@ public func testStructWithSubobjectDestructor() {
 }
 
 // CHECK-LABEL: sil [ossa] @$s4main37testStructWithCopyConstructorAndValueSbyF
-// CHECK: [[AS:%.*]] = alloc_stack [lexical] $StructWithCopyConstructorAndValue
+// CHECK: [[AS:%.*]] = alloc_stack $StructWithCopyConstructorAndValue
 // CHECK: [[FN:%.*]] = function_ref @{{_ZN33StructWithCopyConstructorAndValueC1Ei|\?\?0StructWithCopyConstructorAndValue@@QEAA@H@Z}} : $@convention(c) (Int32) -> @out StructWithCopyConstructorAndValue
 // CHECK: apply [[FN]]([[AS]], %{{.*}}) : $@convention(c) (Int32) -> @out StructWithCopyConstructorAndValue
 // CHECK: [[OBJ_VAL_ADDR:%.*]] = struct_element_addr [[AS]] : $*StructWithCopyConstructorAndValue, #StructWithCopyConstructorAndValue.value
@@ -53,10 +53,10 @@ public func testStructWithCopyConstructorAndValue() -> Bool {
 }
 
 // CHECK-LABEL: sil [ossa] @$s4main46testStructWithSubobjectCopyConstructorAndValueSbyF : $@convention(thin) () -> Bool
-// CHECK: [[MEMBER_0:%.*]] = alloc_stack [lexical] $StructWithCopyConstructorAndValue
+// CHECK: [[MEMBER_0:%.*]] = alloc_stack $StructWithCopyConstructorAndValue
 // CHECK: [[MAKE_MEMBER_FN:%.*]] = function_ref @{{_ZN33StructWithCopyConstructorAndValueC1Ei|\?\?0StructWithCopyConstructorAndValue@@QEAA@H@Z}} : $@convention(c) (Int32) -> @out StructWithCopyConstructorAndValue
 // CHECK: apply [[MAKE_MEMBER_FN]]([[MEMBER_0]], %{{.*}}) : $@convention(c) (Int32) -> @out StructWithCopyConstructorAndValue
-// CHECK: [[AS:%.*]] = alloc_stack [lexical] $StructWithSubobjectCopyConstructorAndValue
+// CHECK: [[AS:%.*]] = alloc_stack $StructWithSubobjectCopyConstructorAndValue
 // CHECK: [[META:%.*]] = metatype $@thin StructWithSubobjectCopyConstructorAndValue.Type
 // CHECK: [[MEMBER_1:%.*]] = alloc_stack $StructWithCopyConstructorAndValue
 // CHECK: copy_addr %0 to [initialization] [[MEMBER_1]] : $*StructWithCopyConstructorAndValue
@@ -87,10 +87,10 @@ public func testStructWithSubobjectCopyConstructorAndValue() -> Bool {
 
 // testStructWithCopyConstructorAndSubobjectCopyConstructorAndValue()
 // CHECK-LABEL: sil [ossa] @$s4main041testStructWithCopyConstructorAndSubobjectefG5ValueSbyF : $@convention(thin) () -> Bool
-// CHECK: [[MEMBER_0:%.*]] = alloc_stack [lexical] $StructWithCopyConstructorAndValue
+// CHECK: [[MEMBER_0:%.*]] = alloc_stack $StructWithCopyConstructorAndValue
 // CHECK: [[CREATE_MEMBER_FN:%.*]] = function_ref @{{_ZN33StructWithCopyConstructorAndValueC1Ei|\?\?0StructWithCopyConstructorAndValue@@QEAA@H@Z}} : $@convention(c) (Int32) -> @out StructWithCopyConstructorAndValue
 // CHECK: apply [[CREATE_MEMBER_FN]]([[MEMBER_0]], %{{.*}}) : $@convention(c) (Int32) -> @out StructWithCopyConstructorAndValue
-// CHECK: [[AS:%.*]] = alloc_stack [lexical] $StructWithCopyConstructorAndSubobjectCopyConstructorAndValue
+// CHECK: [[AS:%.*]] = alloc_stack $StructWithCopyConstructorAndSubobjectCopyConstructorAndValue
 // CHECK: [[MEMBER_1:%.*]] = alloc_stack $StructWithCopyConstructorAndValue
 // CHECK: copy_addr [[MEMBER_0]] to [initialization] [[MEMBER_1]] : $*StructWithCopyConstructorAndValue
 // CHECK: [[FN:%.*]] = function_ref @{{_ZN60StructWithCopyConstructorAndSubobjectCopyConstructorAndValueC1E33StructWithCopyConstructorAndValue|\?\?0StructWithCopyConstructorAndSubobjectCopyConstructorAndValue@@QEAA@UStructWithCopyConstructorAndValue@@@Z}} : $@convention(c) (@in StructWithCopyConstructorAndValue) -> @out StructWithCopyConstructorAndSubobjectCopyConstructorAndValue

--- a/test/SIL/Parser/function_argument_lifetime_annotation.sil
+++ b/test/SIL/Parser/function_argument_lifetime_annotation.sil
@@ -1,0 +1,46 @@
+// RUN: %target-sil-opt -enable-objc-interop -enable-lexical-lifetimes=true -enable-sil-verify-all=true %s | %target-sil-opt -enable-objc-interop -enable-lexical-lifetimes=true -enable-sil-verify-all=true | %FileCheck %s
+
+sil_stage canonical
+
+class C {}
+
+// CHECK-LABEL: sil [ossa] @one_arg_eager_move : {{.*}} {
+// CHECK:       {{bb[0-9]+}}({{%[^,]+}} : @_eagerMove @owned $C):
+// CHECK-LABEL: } // end sil function 'one_arg_eager_move'
+sil [ossa] @one_arg_eager_move : $@convention(thin) (@owned C) -> () {
+bb0(%instance : @_eagerMove @owned $C):
+  destroy_value %instance : $C
+  %retval = tuple()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @one_arg_eager_move_and_no_implicit_copy : {{.*}} {
+// CHECK:       {{bb[0-9]+}}({{%[^,]+}} : @noImplicitCopy @_eagerMove @owned $C):
+// CHECK-LABEL: } // end sil function 'one_arg_eager_move_and_no_implicit_copy'
+sil [ossa] @one_arg_eager_move_and_no_implicit_copy : $(@owned C) -> () {
+bb0(%instance : @noImplicitCopy @_eagerMove @owned $C):
+  destroy_value %instance : $C
+  %retval = tuple()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @one_arg_lexical : {{.*}} {
+// CHECK:       {{bb[0-9]+}}({{%[^,]+}} : @_lexical @owned $C):
+// CHECK-LABEL: } // end sil function 'one_arg_lexical'
+sil [ossa] @one_arg_lexical : $@convention(thin) (@owned C) -> () {
+bb0(%instance : @_lexical @owned $C):
+  destroy_value %instance : $C
+  %retval = tuple()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @one_arg_lexical_and_no_implicit_copy : {{.*}} {
+// CHECK:       {{bb[0-9]+}}({{%[^,]+}} : @noImplicitCopy @_lexical @owned $C):
+// CHECK-LABEL: } // end sil function 'one_arg_lexical_and_no_implicit_copy'
+sil [ossa] @one_arg_lexical_and_no_implicit_copy : $@convention(thin) (@owned C) -> () {
+bb0(%instance : @noImplicitCopy @_lexical @owned $C):
+  destroy_value %instance : $C
+  %retval = tuple()
+  return %retval : $()
+}
+

--- a/test/SIL/Serialization/function_argument_lifetime_annotation.sil
+++ b/test/SIL/Serialization/function_argument_lifetime_annotation.sil
@@ -1,0 +1,30 @@
+// First parse this and then emit a *.sib. Then read in the *.sib, then recreate
+
+// RUN: %empty-directory(%t)
+// RUN: %target-sil-opt %s -emit-sib -o %t/tmp.sib -module-name eager_move
+// RUN: %target-sil-opt %t/tmp.sib -module-name eager_move | %FileCheck %s
+
+sil_stage canonical
+
+class C {}
+
+// CHECK-LABEL: sil [serialized] [ossa] @one_arg_eager_move : {{.*}} {
+// CHECK: bb0(%0 : @_eagerMove @owned $C):
+// CHECK: } // end sil function 'one_arg_eager_move'
+sil [serialized] [ossa] @one_arg_eager_move : $@convention(thin) (@owned C) -> () {
+bb0(%instance : @_eagerMove @owned $C):
+  destroy_value %instance : $C
+  %retval = tuple()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil [serialized] [ossa] @one_arg_lexical : {{.*}} {
+// CHECK: bb0(%0 : @_lexical @owned $C):
+// CHECK: } // end sil function 'one_arg_lexical'
+sil [serialized] [ossa] @one_arg_lexical : $@convention(thin) (@owned C) -> () {
+bb0(%instance : @_lexical @owned $C):
+  destroy_value %instance : $C
+  %retval = tuple()
+  return %retval : $()
+}
+

--- a/test/SILGen/copy_lvalue_peepholes.swift
+++ b/test/SILGen/copy_lvalue_peepholes.swift
@@ -9,11 +9,9 @@ func getInt() -> Int { return zero }
 
 // CHECK-LABEL: sil hidden [ossa] @$s21copy_lvalue_peepholes014init_var_from_B0{{[_0-9a-zA-Z]*}}F
 // CHECK:   [[X:%.*]] = alloc_box ${ var Builtin.Int64 }
-// CHECK:   [[XLIFETIME:%[^,]+]] = begin_borrow [lexical] [[X]]
-// CHECK:   [[PBX:%.*]] = project_box [[XLIFETIME]]
+// CHECK:   [[PBX:%.*]] = project_box [[X]]
 // CHECK:   [[Y:%.*]] = alloc_box ${ var Builtin.Int64 }
-// CHECK:   [[YLIFETIME:%[^,]+]] = begin_borrow [lexical] [[Y]]
-// CHECK:   [[PBY:%.*]] = project_box [[YLIFETIME]]
+// CHECK:   [[PBY:%.*]] = project_box [[Y]]
 // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBX]]
 // CHECK:   copy_addr [[READ]] to [initialization] [[PBY]] : $*Builtin.Int64
 func init_var_from_lvalue(x: Int) {
@@ -40,8 +38,7 @@ func init_var_from_computed_lvalue() {
 
 // CHECK-LABEL: sil hidden [ossa] @$s21copy_lvalue_peepholes021assign_computed_from_B0{{[_0-9a-zA-Z]*}}F
 // CHECK:   [[Y:%.*]] = alloc_box
-// CHECK:   [[YLIFETIME:%[^,]+]] = begin_borrow [lexical] [[Y]]
-// CHECK:   [[PBY:%.*]] = project_box [[YLIFETIME]]
+// CHECK:   [[PBY:%.*]] = project_box [[Y]]
 // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBY]]
 // CHECK:   [[Y_VAL:%.*]] = load [trivial] [[READ]]
 // CHECK:   [[SETTER:%.*]] = function_ref @$s21copy_lvalue_peepholes8computedBi64_vs

--- a/test/SILGen/decls.swift
+++ b/test/SILGen/decls.swift
@@ -33,34 +33,27 @@ func tuple_patterns() {
   var (a, b) : (Int, Float)
   // CHECK: [[ABOX:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK: [[AADDR:%[0-9]+]] = mark_uninitialized [var] [[ABOX]]
-  // CHECK: [[A_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[AADDR]]
-  // CHECK: [[PBA:%.*]] = project_box [[A_LIFETIME]]
+  // CHECK: [[PBA:%.*]] = project_box [[AADDR]]
   // CHECK: [[BBOX:%[0-9]+]] = alloc_box ${ var Float }
   // CHECK: [[BADDR:%[0-9]+]] = mark_uninitialized [var] [[BBOX]]
-  // CHECK: [[B_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[BADDR]]
-  // CHECK: [[PBB:%.*]] = project_box [[B_LIFETIME]]
+  // CHECK: [[PBB:%.*]] = project_box [[BADDR]]
 
   var (c, d) = (a, b)
   // CHECK: [[CADDR:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[C_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[CADDR]]
-  // CHECK: [[PBC:%.*]] = project_box [[C_LIFETIME]]
+  // CHECK: [[PBC:%.*]] = project_box [[CADDR]]
   // CHECK: [[DADDR:%[0-9]+]] = alloc_box ${ var Float }
-  // CHECK: [[D_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[DADDR]]
-  // CHECK: [[PBD:%.*]] = project_box [[D_LIFETIME]]
+  // CHECK: [[PBD:%.*]] = project_box [[DADDR]]
   // CHECK: [[READA:%.*]] = begin_access [read] [unknown] [[PBA]] : $*Int
   // CHECK: copy_addr [[READA]] to [initialization] [[PBC]]
   // CHECK: [[READB:%.*]] = begin_access [read] [unknown] [[PBB]] : $*Float
   // CHECK: copy_addr [[READB]] to [initialization] [[PBD]]
   // CHECK: [[EADDR:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[E_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[EADDR]]
-  // CHECK: [[PBE:%.*]] = project_box [[E_LIFETIME]]
+  // CHECK: [[PBE:%.*]] = project_box [[EADDR]]
   // CHECK: [[FADDR:%[0-9]+]] = alloc_box ${ var Float }
-  // CHECK: [[F_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[FADDR]]
-  // CHECK: [[PBF:%.*]] = project_box [[F_LIFETIME]]
+  // CHECK: [[PBF:%.*]] = project_box [[FADDR]]
   // CHECK: [[GADDR:%[0-9]+]] = alloc_box ${ var () }
   // CHECK: [[HADDR:%[0-9]+]] = alloc_box ${ var Double }
-  // CHECK: [[H_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[HADDR]]
-  // CHECK: [[PBH:%.*]] = project_box [[H_LIFETIME]]
+  // CHECK: [[PBH:%.*]] = project_box [[HADDR]]
   // CHECK: [[EFGH:%[0-9]+]] = apply
   // CHECK: ([[E:%[0-9]+]], [[F:%[0-9]+]], [[H:%[0-9]+]]) = destructure_tuple
   // CHECK: store [[E]] to [trivial] [[PBE]]
@@ -69,8 +62,7 @@ func tuple_patterns() {
   var (e,f,g,h) : (Int, Float, (), Double) = MRV()
 
   // CHECK: [[IADDR:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[I_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[IADDR]]
-  // CHECK: [[PBI:%.*]] = project_box [[I_LIFETIME]]
+  // CHECK: [[PBI:%.*]] = project_box [[IADDR]]
   // CHECK-NOT: alloc_box ${ var Float }
   // CHECK: [[READA:%.*]] = begin_access [read] [unknown] [[PBA]] : $*Int
   // CHECK: copy_addr [[READA]] to [initialization] [[PBI]]
@@ -80,11 +72,9 @@ func tuple_patterns() {
   var (i,_) = (a, b)
 
   // CHECK: [[JADDR:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[J_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[JADDR]]
-  // CHECK: [[PBJ:%.*]] = project_box [[J_LIFETIME]]
+  // CHECK: [[PBJ:%.*]] = project_box [[JADDR]]
   // CHECK-NOT: alloc_box ${ var Float }
   // CHECK: [[KADDR:%[0-9]+]] = alloc_box ${ var () }
-  // CHECK: [[K_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[KADDR]]
   // CHECK-NOT: alloc_box ${ var Double }
   // CHECK: [[J_K_:%[0-9]+]] = apply
   // CHECK: ([[J:%[0-9]+]], [[K:%[0-9]+]], {{%[0-9]+}}) = destructure_tuple
@@ -95,12 +85,10 @@ func tuple_patterns() {
 // CHECK-LABEL: sil hidden [ossa] @$s5decls16simple_arguments{{[_0-9a-zA-Z]*}}F
 // CHECK: bb0(%0 : $Int, %1 : $Int):
 // CHECK: [[X:%[0-9]+]] = alloc_box ${ var Int }
-// CHECK: [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[X]]
-// CHECK-NEXT: [[PBX:%.*]] = project_box [[X_LIFETIME]]
+// CHECK-NEXT: [[PBX:%.*]] = project_box [[X]]
 // CHECK-NEXT: store %0 to [trivial] [[PBX]]
 // CHECK-NEXT: [[Y:%[0-9]+]] = alloc_box ${ var Int }
-// CHECK-NEXT: [[Y_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[Y]]
-// CHECK-NEXT: [[PBY:%[0-9]+]] = project_box [[Y_LIFETIME]]
+// CHECK-NEXT: [[PBY:%[0-9]+]] = project_box [[Y]]
 // CHECK-NEXT: store %1 to [trivial] [[PBY]]
 func simple_arguments(x: Int, y: Int) -> Int {
   var x = x
@@ -118,8 +106,7 @@ func tuple_argument(x: (Int, Float, ())) {
 // CHECK-LABEL: sil hidden [ossa] @$s5decls14inout_argument{{[_0-9a-zA-Z]*}}F
 // CHECK: bb0(%0 : $*Int, %1 : $Int):
 // CHECK: [[X_LOCAL:%[0-9]+]] = alloc_box ${ var Int }
-// CHECK: [[X_LOCAL_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[X_LOCAL]]
-// CHECK: [[PBX:%.*]] = project_box [[X_LOCAL_LIFETIME]]
+// CHECK: [[PBX:%.*]] = project_box [[X_LOCAL]]
 func inout_argument(x: inout Int, y: Int) {
   var y = y
   x = y
@@ -143,8 +130,7 @@ func store_to_global(x: Int) {
   var x = x
   global = x
   // CHECK: [[XADDR:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[XADDR]]
-  // CHECK: [[PBX:%.*]] = project_box [[X_LIFETIME]]
+  // CHECK: [[PBX:%.*]] = project_box [[XADDR]]
   // CHECK: [[ACCESSOR:%[0-9]+]] = function_ref @$s5decls6globalSivau
   // CHECK: [[PTR:%[0-9]+]] = apply [[ACCESSOR]]()
   // CHECK: [[ADDR:%[0-9]+]] = pointer_to_address [[PTR]]

--- a/test/SILGen/default_constructor.swift
+++ b/test/SILGen/default_constructor.swift
@@ -30,8 +30,7 @@ struct D {
 // CHECK-LABEL: sil hidden [ossa] @$s19default_constructor1DV{{[_0-9a-zA-Z]*}}fC : $@convention(method) (@thin D.Type) -> D
 // CHECK: [[THISBOX:%[0-9]+]] = alloc_box ${ var D }
 // CHECK: [[THIS:%[0-9]+]] = mark_uninit
-// CHECK: [[THISLIFE:%[^,]+]] = begin_borrow [lexical] [[THIS]]
-// CHECK: [[PB_THIS:%.*]] = project_box [[THISLIFE]]
+// CHECK: [[PB_THIS:%.*]] = project_box [[THIS]]
 // CHECK: [[IADDR:%[0-9]+]] = struct_element_addr [[PB_THIS]] : $*D, #D.i
 // CHECK: [[JADDR:%[0-9]+]] = struct_element_addr [[PB_THIS]] : $*D, #D.j
 // CHECK: [[INIT:%[0-9]+]] = function_ref @$s19default_constructor1DV1iSivpfi

--- a/test/SILGen/dynamic_lookup.swift
+++ b/test/SILGen/dynamic_lookup.swift
@@ -175,8 +175,7 @@ func opt_to_property(_ obj: AnyObject) {
   // CHECK:   [[OBJ_COPY:%.*]] = copy_value [[OBJ]]
   // CHECK:   store [[OBJ_COPY]] to [init] [[PBOBJ]] : $*AnyObject
   // CHECK:   [[INT_BOX:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK:   [[INT_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INT_BOX]]
-  // CHECK:   project_box [[INT_LIFETIME]]
+  // CHECK:   project_box [[INT_BOX]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBOBJ]]
   // CHECK:   [[OBJ:%[0-9]+]] = load [copy] [[READ]] : $*AnyObject
   // CHECK:   [[RAWOBJ_SELF:%[0-9]+]] = open_existential_ref [[OBJ]] : $AnyObject
@@ -206,8 +205,7 @@ func opt_to_property(_ obj: AnyObject) {
   // GUARANTEED:   [[OBJ_COPY:%.*]] = copy_value [[OBJ]]
   // GUARANTEED:   store [[OBJ_COPY]] to [init] [[PBOBJ]] : $*AnyObject
   // GUARANTEED:   [[INT_BOX:%[0-9]+]] = alloc_box ${ var Int }
-  // GUARANTEED:   [[INT_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INT_BOX]]
-  // GUARANTEED:   project_box [[INT_LIFETIME]]
+  // GUARANTEED:   project_box [[INT_BOX]]
   // GUARANTEED:   [[READ:%.*]] = begin_access [read] [unknown] [[PBOBJ]]
   // GUARANTEED:   [[OBJ:%[0-9]+]] = load [copy] [[READ]] : $*AnyObject
   // GUARANTEED:   [[RAWOBJ_SELF:%[0-9]+]] = open_existential_ref [[OBJ]] : $AnyObject
@@ -237,8 +235,7 @@ func direct_to_subscript(_ obj: AnyObject, i: Int) {
   // CHECK:   [[OBJ_COPY:%.*]] = copy_value [[OBJ]]
   // CHECK:   store [[OBJ_COPY]] to [init] [[PBOBJ]] : $*AnyObject
   // CHECK:   [[I_BOX:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK:   [[I_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[I_BOX]]
-  // CHECK:   [[PBI:%.*]] = project_box [[I_LIFETIME]]
+  // CHECK:   [[PBI:%.*]] = project_box [[I_BOX]]
   // CHECK:   store [[I]] to [trivial] [[PBI]] : $*Int
   // CHECK:   alloc_box ${ var Int }
   // CHECK:   project_box
@@ -273,8 +270,7 @@ func direct_to_subscript(_ obj: AnyObject, i: Int) {
   // GUARANTEED:   [[OBJ_COPY:%.*]] = copy_value [[OBJ]]
   // GUARANTEED:   store [[OBJ_COPY]] to [init] [[PBOBJ]] : $*AnyObject
   // GUARANTEED:   [[I_BOX:%[0-9]+]] = alloc_box ${ var Int }
-  // GUARANTEED:   [[I_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[I_BOX]]
-  // GUARANTEED:   [[PBI:%.*]] = project_box [[I_LIFETIME]]
+  // GUARANTEED:   [[PBI:%.*]] = project_box [[I_BOX]]
   // GUARANTEED:   store [[I]] to [trivial] [[PBI]] : $*Int
   // GUARANTEED:   alloc_box ${ var Int }
   // GUARANTEED:   project_box
@@ -309,8 +305,7 @@ func opt_to_subscript(_ obj: AnyObject, i: Int) {
   // CHECK:   [[OBJ_COPY:%.*]] = copy_value [[OBJ]]
   // CHECK:   store [[OBJ_COPY]] to [init] [[PBOBJ]] : $*AnyObject
   // CHECK:   [[I_BOX:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK:   [[I_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[I_BOX]]
-  // CHECK:   [[PBI:%.*]] = project_box [[I_LIFETIME]]
+  // CHECK:   [[PBI:%.*]] = project_box [[I_BOX]]
   // CHECK:   store [[I]] to [trivial] [[PBI]] : $*Int
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBOBJ]]
   // CHECK:   [[OBJ:%[0-9]+]] = load [copy] [[READ]] : $*AnyObject

--- a/test/SILGen/enum_resilience.swift
+++ b/test/SILGen/enum_resilience.swift
@@ -119,8 +119,7 @@ public enum MyResilientEnum {
   // CHECK-LABEL: sil hidden [ossa] @$s15enum_resilience15MyResilientEnumOACycfC : $@convention(method) (@thin MyResilientEnum.Type) -> @out MyResilientEnum
   // CHECK:       [[SELF_BOX:%.*]] = alloc_box ${ var MyResilientEnum }, var, name "self"
   // CHECK:       [[SELF_TMP:%.*]] = mark_uninitialized [delegatingself] [[SELF_BOX]] : ${ var MyResilientEnum }
-  // CHECK:       [[SELF_LIFETIME:%.*]] = begin_borrow [lexical] [[SELF_TMP]]
-  // CHECK:       [[SELF_ADDR:%.*]] = project_box [[SELF_LIFETIME]] : ${ var MyResilientEnum }, 0
+  // CHECK:       [[SELF_ADDR:%.*]] = project_box [[SELF_TMP]] : ${ var MyResilientEnum }, 0
   // CHECK:       [[NEW_SELF:%.*]] = enum $MyResilientEnum, #MyResilientEnum.loki!enumelt
   // CHECK:       [[ACCESS:%.*]] = begin_access [modify] [unknown] [[SELF_ADDR]] : $*MyResilientEnum
   // CHECK:       assign [[NEW_SELF]] to [[ACCESS]] : $*MyResilientEnum

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -980,12 +980,10 @@ func testOptionalTryNeverFails() {
 // CHECK-LABEL: sil hidden [ossa] @$s6errors28testOptionalTryNeverFailsVaryyF
 // CHECK: bb0:
 // CHECK-NEXT:   [[BOX:%.+]] = alloc_box ${ var Optional<()> }
-// CHECK-NEXT:   [[LIFETIME:%.+]] = begin_borrow [lexical] [[BOX]]
-// CHECK-NEXT:   [[PB:%.*]] = project_box [[LIFETIME]]
+// CHECK-NEXT:   [[PB:%.*]] = project_box [[BOX]]
 // CHECK-NEXT:   [[VALUE:%.+]] = tuple ()
 // CHECK-NEXT:   [[ENUM:%.+]] = enum $Optional<()>, #Optional.some!enumelt, [[VALUE]]
 // CHECK-NEXT:   store [[ENUM]] to [trivial] [[PB]] :
-// CHECK-NEXT:   end_borrow [[LIFETIME]]
 // CHECK-NEXT:   destroy_value [[BOX]] : ${ var Optional<()> }
 // CHECK-NEXT:   [[VOID:%.+]] = tuple ()
 // CHECK-NEXT:   return [[VOID]] : $()

--- a/test/SILGen/existential_metatypes.swift
+++ b/test/SILGen/existential_metatypes.swift
@@ -65,8 +65,7 @@ func existentialMetatypeUpcast2(_ x: (P & Q).Type) -> P.Type {
 // CHECK-LABEL: sil hidden [ossa] @$s21existential_metatypes0A19MetatypeVarPropertyAA5ValueVyF : $@convention(thin) () -> Value
 func existentialMetatypeVarProperty() -> Value {
   // CHECK:      [[BOX:%.*]] = alloc_box ${ var @thick any P.Type }
-  // CHECK:      [[BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[BOX]]
-  // CHECK:      [[ADDR:%.*]] = project_box [[BOX_LIFETIME]] : ${ var @thick any P.Type }, 0
+  // CHECK:      [[ADDR:%.*]] = project_box [[BOX]] : ${ var @thick any P.Type }, 0
   // CHECK:      [[T0:%.*]] = metatype $@thick S.Type
   // CHECK:      [[T1:%.*]] = init_existential_metatype [[T0]]
   // CHECK:      store [[T1]] to [trivial] [[ADDR]] :

--- a/test/SILGen/expressions.swift
+++ b/test/SILGen/expressions.swift
@@ -392,8 +392,7 @@ func tuple() -> (Int, Float) { return (1, 1.0) }
 func tuple_element(_ x: (Int, Float)) {
   var x = x
   // CHECK: [[XADDR:%.*]] = alloc_box ${ var (Int, Float) }
-  // CHECK: [[XLIFETIME:%.*]] = begin_borrow [lexical] [[XADDR]]
-  // CHECK: [[PB:%.*]] = project_box [[XLIFETIME]]
+  // CHECK: [[PB:%.*]] = project_box [[XADDR]]
 
   int(x.0)
   // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[PB]]
@@ -428,20 +427,15 @@ func if_expr(_ a: Bool, b: Bool, x: Int, y: Int, z: Int) -> Int {
   var z = z
   // CHECK: bb0({{.*}}):
   // CHECK: [[AB:%[0-9]+]] = alloc_box ${ var Bool }
-  // CHECK: [[AL:%[0-9]+]] = begin_borrow [lexical] [[AB]]
-  // CHECK: [[PBA:%.*]] = project_box [[AL]]
+  // CHECK: [[PBA:%.*]] = project_box [[AB]]
   // CHECK: [[BB:%[0-9]+]] = alloc_box ${ var Bool }
-  // CHECK: [[BL:%[0-9]+]] = begin_borrow [lexical] [[BB]]
-  // CHECK: [[PBB:%.*]] = project_box [[BL]]
+  // CHECK: [[PBB:%.*]] = project_box [[BB]]
   // CHECK: [[XB:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[XL:%[0-9]+]] = begin_borrow [lexical] [[XB]]
-  // CHECK: [[PBX:%.*]] = project_box [[XL]]
+  // CHECK: [[PBX:%.*]] = project_box [[XB]]
   // CHECK: [[YB:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[YL:%[0-9]+]] = begin_borrow [lexical] [[YB]]
-  // CHECK: [[PBY:%.*]] = project_box [[YL]]
+  // CHECK: [[PBY:%.*]] = project_box [[YB]]
   // CHECK: [[ZB:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[ZL:%[0-9]+]] = begin_borrow [lexical] [[ZB]]
-  // CHECK: [[PBZ:%.*]] = project_box [[ZL]]
+  // CHECK: [[PBZ:%.*]] = project_box [[ZB]]
 
   return a
     ? x

--- a/test/SILGen/functions.swift
+++ b/test/SILGen/functions.swift
@@ -103,14 +103,11 @@ func calls(_ i:Int, j:Int, k:Int) {
   var k = k
   // CHECK: bb0(%0 : $Builtin.Int64, %1 : $Builtin.Int64, %2 : $Builtin.Int64):
   // CHECK: [[IBOX:%[0-9]+]] = alloc_box ${ var Builtin.Int64 }
-  // CHECK: [[ILIFETIME:%[^,]+]] = begin_borrow [lexical] [[IBOX]]
-  // CHECK: [[IADDR:%.*]] = project_box [[ILIFETIME]]
+  // CHECK: [[IADDR:%.*]] = project_box [[IBOX]]
   // CHECK: [[JBOX:%[0-9]+]] = alloc_box ${ var Builtin.Int64 }
-  // CHECK: [[JLIFETIME:%[^,]+]] = begin_borrow [lexical] [[JBOX]]
-  // CHECK: [[JADDR:%.*]] = project_box [[JLIFETIME]]
+  // CHECK: [[JADDR:%.*]] = project_box [[JBOX]]
   // CHECK: [[KBOX:%[0-9]+]] = alloc_box ${ var Builtin.Int64 }
-  // CHECK: [[KLIFETIME:%[^,]+]] = begin_borrow [lexical] [[KBOX]]
-  // CHECK: [[KADDR:%.*]] = project_box [[KLIFETIME]]
+  // CHECK: [[KADDR:%.*]] = project_box [[KBOX]]
 
   // CHECK: [[READI:%.*]] = begin_access [read] [unknown] [[IADDR]]
   // CHECK: [[I:%[0-9]+]] = load [trivial] [[READI]]

--- a/test/SILGen/guaranteed_closure_context.swift
+++ b/test/SILGen/guaranteed_closure_context.swift
@@ -11,7 +11,6 @@ struct S {}
 // CHECK-LABEL: sil hidden [ossa] @$s26guaranteed_closure_context0A9_capturesyyF
 func guaranteed_captures() {
   // CHECK: [[MUTABLE_TRIVIAL_BOX:%.*]] = alloc_box ${ var S }
-  // CHECK: [[MUTABLE_TRIVIAL_BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MUTABLE_TRIVIAL_BOX]]
   var mutableTrivial = S()
   // CHECK: [[MUTABLE_RETAINABLE_BOX:%.*]] = alloc_box ${ var C }
   // CHECK: [[MUTABLE_RETAINABLE_BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MUTABLE_RETAINABLE_BOX]]
@@ -33,23 +32,24 @@ func guaranteed_captures() {
          immutableTrivial, immutableRetainable, immutableAddressOnly))
   }
 
-  // CHECK-NOT: copy_value [[MUTABLE_TRIVIAL_BOX_LIFETIME]]
+  // CHECK-NOT: copy_value [[MUTABLE_TRIVIAL_BOX]]
   // CHECK-NOT: copy_value [[MUTABLE_RETAINABLE_BOX_LIFETIME]]
   // CHECK-NOT: copy_value [[MUTABLE_ADDRESS_ONLY_BOX_LIFETIME]]
   // CHECK-NOT: copy_value [[IMMUTABLE_RETAINABLE]]
 
+  // CHECK: [[MUTABLE_TRIVIAL_BOX_BORROW:%[^,]+]] = begin_borrow [[MUTABLE_TRIVIAL_BOX]]
   // CHECK: [[FN:%.*]] = function_ref [[FN_NAME:@\$s26guaranteed_closure_context0A9_capturesyyF17captureEverythingL_yyF]]
-  // CHECK: apply [[FN]]([[MUTABLE_TRIVIAL_BOX_LIFETIME]], [[MUTABLE_RETAINABLE_BOX_LIFETIME]], [[MUTABLE_ADDRESS_ONLY_BOX_LIFETIME]], [[IMMUTABLE_TRIVIAL]], [[B_IMMUTABLE_RETAINABLE]], [[IMMUTABLE_ADDRESS_ONLY]])
+  // CHECK: apply [[FN]]([[MUTABLE_TRIVIAL_BOX_BORROW]], [[MUTABLE_RETAINABLE_BOX_LIFETIME]], [[MUTABLE_ADDRESS_ONLY_BOX_LIFETIME]], [[IMMUTABLE_TRIVIAL]], [[B_IMMUTABLE_RETAINABLE]], [[IMMUTABLE_ADDRESS_ONLY]])
   captureEverything()
 
-  // CHECK-NOT: copy_value [[MUTABLE_TRIVIAL_BOX_LIFETIME]]
+  // CHECK-NOT: copy_value [[MUTABLE_TRIVIAL_BOX]]
   // CHECK-NOT: copy_value [[MUTABLE_RETAINABLE_BOX_LIFETIME]]
   // CHECK-NOT: copy_value [[MUTABLE_ADDRESS_ONLY_BOX_LIFETIME]]
   // CHECK-NOT: copy_value [[IMMUTABLE_RETAINABLE]]
 
   // -- partial_apply still takes ownership of its arguments.
   // CHECK: [[FN:%.*]] = function_ref [[FN_NAME]]
-  // CHECK: [[MUTABLE_TRIVIAL_BOX_COPY:%.*]] = copy_value [[MUTABLE_TRIVIAL_BOX_LIFETIME]]
+  // CHECK: [[MUTABLE_TRIVIAL_BOX_COPY:%.*]] = copy_value [[MUTABLE_TRIVIAL_BOX]]
   // CHECK: [[MUTABLE_RETAINABLE_BOX_COPY:%.*]] = copy_value [[MUTABLE_RETAINABLE_BOX_LIFETIME]]
   // CHECK: [[MUTABLE_ADDRESS_ONLY_BOX_COPY:%.*]] = copy_value [[MUTABLE_ADDRESS_ONLY_BOX_LIFETIME]]
   // CHECK: [[IMMUTABLE_RETAINABLE_COPY:%.*]] = copy_value [[B_IMMUTABLE_RETAINABLE]]
@@ -58,7 +58,7 @@ func guaranteed_captures() {
   // CHECK: [[CONVERT:%.*]] = convert_escape_to_noescape [not_guaranteed] [[CLOSURE]]
   // CHECK: apply {{.*}}[[CONVERT]]
 
-  // CHECK-NOT: copy_value [[MUTABLE_TRIVIAL_BOX_LIFETIME]]
+  // CHECK-NOT: copy_value [[MUTABLE_TRIVIAL_BOX]]
   // CHECK-NOT: copy_value [[MUTABLE_RETAINABLE_BOX_LIFETIME]]
   // CHECK-NOT: copy_value [[MUTABLE_ADDRESS_ONLY_BOX_LIFETIME]]
   // CHECK-NOT: copy_value [[IMMUTABLE_RETAINABLE]]

--- a/test/SILGen/init_delegation_optional.swift
+++ b/test/SILGen/init_delegation_optional.swift
@@ -365,8 +365,7 @@ extension Optional where Wrapped == Optional<Bool> {
     // CHECK: bb0([[SELF_META:%[0-9]+]] : $@thin Optional<Optional<Bool>>.Type):
     // CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var Optional<Optional<Bool>> }, var
     // CHECK-NEXT: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-    // CHECK-NEXT: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
-    // CHECK-NEXT: [[PB:%[0-9]+]] = project_box [[SELF_LIFETIME]]
+    // CHECK-NEXT: [[PB:%[0-9]+]] = project_box [[MARKED_SELF_BOX]]
     // CHECK: [[RESULT_ADDR:%[0-9]+]] = alloc_stack $Optional<Optional<Bool>>
     // CHECK: [[DELEG_INIT:%[0-9]+]] = function_ref @$sSq24init_delegation_optionalE12nonFailable1xSgyt_tcfC
     // CHECK-NEXT: apply [[DELEG_INIT]]<Bool?>([[RESULT_ADDR]], [[SELF_META]])
@@ -375,7 +374,6 @@ extension Optional where Wrapped == Optional<Bool> {
     // CHECK-NEXT: dealloc_stack [[RESULT_ADDR]]
     // CHECK-NEXT: [[RESULT:%[0-9]+]] = load [trivial] [[PB]]
     // CHECK-NEXT: [[INJECT_INTO_OPT:%[0-9]+]] = enum $Optional<Optional<Optional<Bool>>>, #Optional.some!enumelt, [[RESULT]]
-    // CHECK-NEXT: end_borrow [[SELF_LIFETIME]]
     // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
     // CHECK-NEXT: br bb2([[INJECT_INTO_OPT]] : $Optional<Optional<Optional<Bool>>>)
     //
@@ -393,8 +391,7 @@ extension Optional where Wrapped == Optional<Bool> {
     // CHECK: bb0([[SELF_META:%[0-9]+]] : $@thin Optional<Optional<Bool>>.Type):
     // CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var Optional<Optional<Bool>> }, var
     // CHECK-NEXT: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-    // CHECK-NEXT: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
-    // CHECK-NEXT: [[PB:%[0-9]+]] = project_box [[SELF_LIFETIME]]
+    // CHECK-NEXT: [[PB:%[0-9]+]] = project_box [[MARKED_SELF_BOX]]
     // CHECK: [[DELEG_INIT:%[0-9]+]] = function_ref @$sSq24init_delegation_optionalSbSgRszlE13SpecFailable1ABSgSgyt_tcfC
     // CHECK-NEXT: [[OPT_RESULT:%[0-9]+]] = apply [[DELEG_INIT]]([[SELF_META]])
     // CHECK: [[SELECT:%[0-9]+]] = select_enum [[OPT_RESULT]]
@@ -408,12 +405,10 @@ extension Optional where Wrapped == Optional<Bool> {
     // CHECK-NEXT: assign [[RESULT]] to [[PB]]
     // CHECK-NEXT: [[RESULT:%[0-9]+]] = load [trivial] [[PB]]
     // CHECK-NEXT: [[INJECT_INTO_OPT:%[0-9]+]] = enum $Optional<Optional<Optional<Bool>>>, #Optional.some!enumelt, [[RESULT]]
-    // CHECK-NEXT: end_borrow [[SELF_LIFETIME]]
     // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
     // CHECK-NEXT: br bb4([[INJECT_INTO_OPT]] : $Optional<Optional<Optional<Bool>>>)
     //
     // CHECK: bb3:
-    // CHECK-NEXT: end_borrow [[SELF_LIFETIME]]
     // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
     // CHECK-NEXT: [[NIL:%[0-9]+]] = enum $Optional<Optional<Optional<Bool>>>, #Optional.none!enumelt
     // CHECK-NEXT: br bb4([[NIL]] : $Optional<Optional<Optional<Bool>>>)
@@ -433,8 +428,7 @@ extension Optional where Wrapped == Optional<Bool> {
     // CHECK: bb0([[SELF_META:%[0-9]+]] : $@thin Optional<Optional<Bool>>.Type):
     // CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var Optional<Optional<Bool>> }, var
     // CHECK-NEXT: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-    // CHECK-NEXT: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
-    // CHECK-NEXT: [[PB:%[0-9]+]] = project_box [[SELF_LIFETIME]]
+    // CHECK-NEXT: [[PB:%[0-9]+]] = project_box [[MARKED_SELF_BOX]]
     // CHECK: [[DELEG_INIT:%[0-9]+]] = function_ref @$sSq24init_delegation_optionalSbSgRszlE21SpecFailableAndThrowsABSgSgyt_tKcfC
     // CHECK-NEXT: try_apply [[DELEG_INIT]]([[SELF_META]]) : {{.*}}, normal [[SUCC_BB:bb[0-9]+]], error [[ERROR_BB:bb[0-9]+]]
     //
@@ -464,12 +458,10 @@ extension Optional where Wrapped == Optional<Bool> {
     // CHECK-NEXT: assign [[RESULT]] to [[PB]]
     // CHECK-NEXT: [[RESULT:%[0-9]+]] = load [trivial] [[PB]]
     // CHECK-NEXT: [[INJECT_INTO_OPT:%[0-9]+]] = enum $Optional<Optional<Optional<Bool>>>, #Optional.some!enumelt, [[RESULT]]
-    // CHECK-NEXT: end_borrow [[SELF_LIFETIME]]
     // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
     // CHECK-NEXT: br bb9([[INJECT_INTO_OPT]] : $Optional<Optional<Optional<Bool>>>)
     //
     // CHECK: bb8:
-    // CHECK-NEXT: end_borrow [[SELF_LIFETIME]]
     // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
     // CHECK-NEXT: [[NIL:%[0-9]+]] = enum $Optional<Optional<Optional<Bool>>>, #Optional.none!enumelt
     // CHECK-NEXT: br bb9([[NIL]] : $Optional<Optional<Optional<Bool>>>)

--- a/test/SILGen/init_ref_delegation.swift
+++ b/test/SILGen/init_ref_delegation.swift
@@ -9,8 +9,7 @@ struct S {
     // CHECK: bb0([[SELF_META:%[0-9]+]] : $@thin S.Type):
     // CHECK-NEXT:   [[SELF_BOX:%[0-9]+]] = alloc_box ${ var S }
     // CHECK-NEXT:   [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-    // CHECK-NEXT:   [[SELF_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
-    // CHECK-NEXT:   [[PB:%.*]] = project_box [[SELF_LIFETIME]]
+    // CHECK-NEXT:   [[PB:%.*]] = project_box [[MARKED_SELF_BOX]]
     
     // CHECK-NEXT:   [[X_META:%[0-9]+]] = metatype $@thin X.Type
     // CHECK:   [[X_CTOR:%[0-9]+]] = function_ref @$s19init_ref_delegation1XV{{[_0-9a-zA-Z]*}}fC : $@convention(method) (@thin X.Type) -> X
@@ -20,7 +19,6 @@ struct S {
     self.init(x: X())
     // CHECK-NEXT:   assign [[REPLACEMENT_SELF]] to [[PB]] : $*S
     // CHECK-NEXT:   [[SELF_BOX1:%[0-9]+]] = load [trivial] [[PB]] : $*S
-    // CHECK-NEXT:   end_borrow [[SELF_LIFETIME]]
     // CHECK-NEXT:   destroy_value [[MARKED_SELF_BOX]] : ${ var S }
     // CHECK-NEXT:   return [[SELF_BOX1]] : $S
   }
@@ -38,8 +36,7 @@ enum E {
     // CHECK: bb0([[E_META:%[0-9]+]] : $@thin E.Type):
     // CHECK:   [[E_BOX:%[0-9]+]] = alloc_box ${ var E }
     // CHECK:   [[MARKED_E_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[E_BOX]]
-    // CHECK:   [[E_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MARKED_E_BOX]]
-    // CHECK:   [[PB:%.*]] = project_box [[E_LIFETIME]]
+    // CHECK:   [[PB:%.*]] = project_box [[MARKED_E_BOX]]
 
     // CHECK:   [[X_META:%[0-9]+]] = metatype $@thin X.Type
     // CHECK:   [[E_DELEG_INIT:%[0-9]+]] = function_ref @$s19init_ref_delegation1XV{{[_0-9a-zA-Z]*}}fC : $@convention(method) (@thin X.Type) -> X
@@ -49,7 +46,6 @@ enum E {
     // CHECK:   assign [[S:%[0-9]+]] to [[PB]] : $*E
     // CHECK:   [[E_BOX1:%[0-9]+]] = load [trivial] [[PB]] : $*E
     self.init(x: X())
-    // CHECK:   end_borrow [[E_LIFETIME]]
     // CHECK:   destroy_value [[MARKED_E_BOX]] : ${ var E }
     // CHECK:   return [[E_BOX1:%[0-9]+]] : $E
   }
@@ -64,8 +60,7 @@ struct S2 {
     // CHECK: bb0([[S2_META:%[0-9]+]] : $@thin S2.Type):
     // CHECK:   [[SELF_BOX:%[0-9]+]] = alloc_box ${ var S2 }
     // CHECK:   [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
-    // CHECK:   [[SELF_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
-    // CHECK:   [[PB:%.*]] = project_box [[SELF_LIFETIME]]
+    // CHECK:   [[PB:%.*]] = project_box [[MARKED_SELF_BOX]]
 
     // CHECK:   [[X_META:%[0-9]+]] = metatype $@thin X.Type
     // CHECK:   [[X_INIT:%[0-9]+]] = function_ref @$s19init_ref_delegation1XV{{[_0-9a-zA-Z]*}}fC : $@convention(method) (@thin X.Type) -> X
@@ -78,7 +73,6 @@ struct S2 {
     // CHECK:   assign [[SELF_BOX1]] to [[PB]] : $*S2
     // CHECK:   [[SELF_BOX4:%[0-9]+]] = load [trivial] [[PB]] : $*S2
     self.init(t: X())
-    // CHECK:   end_borrow [[SELF_LIFETIME]]
     // CHECK:   destroy_value [[MARKED_SELF_BOX]] : ${ var S2 }
     // CHECK:   return [[SELF_BOX4]] : $S2
   }

--- a/test/SILGen/let_decls.swift
+++ b/test/SILGen/let_decls.swift
@@ -233,8 +233,7 @@ struct WeirdPropertyTest {
 func test_weird_property(_ v : WeirdPropertyTest, i : Int) -> Int {
   var v = v
   // CHECK: [[VBOX:%[0-9]+]] = alloc_box ${ var WeirdPropertyTest }
-  // CHECK: [[VLIFETIME:%[^,]+]] = begin_borrow [lexical] [[VBOX]]
-  // CHECK: [[PB:%.*]] = project_box [[VLIFETIME]]
+  // CHECK: [[PB:%.*]] = project_box [[VBOX]]
   // CHECK: store %0 to [trivial] [[PB]]
 
   // The setter isn't mutating, so we need to load the box.
@@ -466,13 +465,11 @@ struct LetPropertyStruct {
 // CHECK-LABEL: sil hidden [ossa] @{{.*}}testLetPropertyAccessOnLValueBase
 // CHECK: bb0(%0 : $LetPropertyStruct):
 // CHECK:  [[ABOX:%[0-9]+]] = alloc_box ${ var LetPropertyStruct }
-// CHECK:  [[ALIFETIME:%[^,]+]] = begin_borrow [lexical] [[ABOX]]
-// CHECK:  [[A:%[0-9]+]] = project_box [[ALIFETIME]]
+// CHECK:  [[A:%[0-9]+]] = project_box [[ABOX]]
 // CHECK:   store %0 to [trivial] [[A]] : $*LetPropertyStruct
 // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[A]]
 // CHECK:   [[STRUCT:%[0-9]+]] = load [trivial] [[READ]] : $*LetPropertyStruct
 // CHECK:   [[PROP:%[0-9]+]] = struct_extract [[STRUCT]] : $LetPropertyStruct, #LetPropertyStruct.lp
-// CHECK:   end_borrow [[ALIFETIME]]
 // CHECK:   destroy_value [[ABOX]] : ${ var LetPropertyStruct }
 // CHECK:   return [[PROP]] : $Int
 func testLetPropertyAccessOnLValueBase(_ a : LetPropertyStruct) -> Int {

--- a/test/SILGen/lifetime.swift
+++ b/test/SILGen/lifetime.swift
@@ -18,8 +18,6 @@ func local_valtype() {
     var b: Val
     // CHECK: [[B:%[0-9]+]] = alloc_box ${ var Val }
     // CHECK: [[MARKED_B:%.*]] = mark_uninitialized [var] [[B]]
-    // CHECK: [[MARKED_B_LIFETIME:%.*]] = begin_borrow [lexical] [[MARKED_B]]
-    // CHECK: end_borrow [[MARKED_B_LIFETIME]]
     // CHECK: destroy_value [[MARKED_B]]
     // CHECK: return
 }
@@ -37,7 +35,6 @@ func local_valtype_branch(_ a: Bool) {
     var x:Int
     // CHECK: [[X:%[0-9]+]] = alloc_box ${ var Int }
     // CHECK: [[MARKED_X:%.*]] = mark_uninitialized [var] [[X]]
-    // CHECK: [[MARKED_X_LIFETIME:%.*]] = begin_borrow [lexical] [[MARKED_B]]
 
     if a { return }
     // CHECK: cond_br
@@ -62,12 +59,10 @@ func local_valtype_branch(_ a: Bool) {
         var y:Int
         // CHECK: [[Y:%[0-9]+]] = alloc_box ${ var Int }
         // CHECK: [[MARKED_Y:%.*]] = mark_uninitialized [var] [[Y]]
-        // CHECK: [[MARKED_Y_LIFETIME:%.*]] = begin_borrow [lexical] [[MARKED_Y]]
 
         if a { break }
         // CHECK: cond_br
         // CHECK: {{bb.*:}}
-        // CHECK: end_borrow [[MARKED_Y_LIFETIME]]
         // CHECK: destroy_value [[MARKED_Y]]
         // CHECK-NOT: destroy_value [[MARKED_X]]
         // CHECK-NOT: destroy_value [[A]]
@@ -84,7 +79,6 @@ func local_valtype_branch(_ a: Bool) {
             var z:Int
             // CHECK: [[Z:%[0-9]+]] = alloc_box ${ var Int }
             // CHECK: [[MARKED_Z:%.*]] = mark_uninitialized [var] [[Z]]
-            // CHECK: [[MARKED_Z_LIFETIME:%.*]] = begin_borrow [lexical] [[MARKED_Z]]
 
             if a { break }
             // CHECK: cond_br
@@ -361,12 +355,10 @@ func logical_lvalue_lifetime(_ r: RefWithProp, _ i: Int, _ v: Val) {
   // CHECK: [[R_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[RADDR]]
   // CHECK: [[PR:%[0-9]+]] = project_box [[R_LIFETIME]]
   // CHECK: [[IADDR:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[I_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[IADDR]]
-  // CHECK: [[PI:%[0-9]+]] = project_box [[I_LIFETIME]]
+  // CHECK: [[PI:%[0-9]+]] = project_box [[IADDR]]
   // CHECK: store %1 to [trivial] [[PI]]
   // CHECK: [[VADDR:%[0-9]+]] = alloc_box ${ var Val }
-  // CHECK: [[V_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[VADDR]]
-  // CHECK: [[PV:%[0-9]+]] = project_box [[V_LIFETIME]]
+  // CHECK: [[PV:%[0-9]+]] = project_box [[VADDR]]
 
   // -- Reference types need to be copy_valued as property method args.
   r.int_prop = i
@@ -480,8 +472,7 @@ class Foo<T> {
 
     // -- Then we create a box that we will use to perform a copy_addr into #Foo.x a bit later.
     // CHECK:   [[CHIADDR:%[0-9]+]] = alloc_box ${ var Int }, var, name "chi"
-    // CHECK:   [[CHI_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[CHIADDR]]
-    // CHECK:   [[PCHI:%[0-9]+]] = project_box [[CHI_LIFETIME]]
+    // CHECK:   [[PCHI:%[0-9]+]] = project_box [[CHIADDR]]
     // CHECK:   store [[CHI]] to [trivial] [[PCHI]]
 
     // -- Then we initialize #Foo.z
@@ -666,8 +657,7 @@ struct Bar {
     // CHECK: bb0([[METATYPE:%[0-9]+]] : $@thin Bar.Type):
     // CHECK: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var Bar }
     // CHECK: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [rootself] [[SELF_BOX]]
-    // CHECK: [[SELF_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
-    // CHECK: [[PB_BOX:%.*]] = project_box [[SELF_LIFETIME]]
+    // CHECK: [[PB_BOX:%.*]] = project_box [[MARKED_SELF_BOX]]
 
     x = bar()
     // CHECK:   [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB_BOX]]
@@ -732,12 +722,10 @@ class D : B {
     // CHECK: [[PB_BOX:%[0-9]+]] = project_box [[SELF_LIFETIME]]
     // CHECK: store [[SELF]] to [init] [[PB_BOX]]
     // CHECK: [[XADDR:%[0-9]+]] = alloc_box ${ var Int }
-    // CHECK: [[XLIFETIME:%[0-9]+]] = begin_borrow [lexical] [[XADDR]]
-    // CHECK: [[PX:%[0-9]+]] = project_box [[XLIFETIME]]
+    // CHECK: [[PX:%[0-9]+]] = project_box [[XADDR]]
     // CHECK: store [[X]] to [trivial] [[PX]]
     // CHECK: [[YADDR:%[0-9]+]] = alloc_box ${ var Int }
-    // CHECK: [[Y_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[YADDR]]
-    // CHECK: [[PY:%[0-9]+]] = project_box [[Y_LIFETIME]]
+    // CHECK: [[PY:%[0-9]+]] = project_box [[YADDR]]
     // CHECK: store [[Y]] to [trivial] [[PY]]
 
     super.init(y: y)

--- a/test/SILGen/metatype_abstraction.swift
+++ b/test/SILGen/metatype_abstraction.swift
@@ -57,8 +57,7 @@ func genericMetatypeFromGenericMetatype<T>(_ x: GenericMetatype<T>)-> T.Type {
 }
 // CHECK-LABEL: sil hidden [ossa] @$ss026dynamicMetatypeFromGenericB0ys1CCms0dB0VyACGF
 // CHECK:         [[XBOX:%[0-9]+]] = alloc_box ${ var GenericMetatype<C> }
-// CHECK:         [[XBOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[XBOX]]
-// CHECK:         [[PX:%[0-9]+]] = project_box [[XBOX_LIFETIME]]
+// CHECK:         [[PX:%[0-9]+]] = project_box [[XBOX]]
 // CHECK:         [[READ:%.*]] = begin_access [read] [unknown] [[PX]] : $*GenericMetatype<C>
 // CHECK:         [[ADDR:%.*]] = struct_element_addr [[READ]] : $*GenericMetatype<C>, #GenericMetatype.value
 // CHECK:         [[META:%.*]] = load [trivial] [[ADDR]] : $*@thick C.Type
@@ -95,8 +94,7 @@ func dynamicMetatypeToGeneric(_ x: C.Type) {
 }
 // CHECK-LABEL: sil hidden [ossa] @$ss024dynamicMetatypeToGenericB0yys1CCmF
 // CHECK:         [[XBOX:%[0-9]+]] = alloc_box ${ var @thick C.Type }
-// CHECK:         [[XBOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[XBOX]]
-// CHECK:         [[PX:%[0-9]+]] = project_box [[XBOX_LIFETIME]]
+// CHECK:         [[PX:%[0-9]+]] = project_box [[XBOX]]
 // CHECK:         [[READ:%.*]] = begin_access [read] [unknown] [[PX]] : $*@thick C.Type
 // CHECK:         [[META:%.*]] = load [trivial] [[READ]] : $*@thick C.Type
 // CHECK:         apply {{%.*}}<C>([[META]]) : $@convention(thin) <τ_0_0> (@thick τ_0_0.Type) -> ()

--- a/test/SILGen/noimplicitcopy.swift
+++ b/test/SILGen/noimplicitcopy.swift
@@ -91,8 +91,7 @@ func printIntArg(@_noImplicitCopy _ x: Int) {
 // CHECK: apply [[FUNC]]([[VALUE]])
 //
 // CHECK: [[Y_BOX:%.*]] = alloc_box ${ var Int }
-// CHECK: [[Y_BOX_BORROWED:%.*]] = begin_borrow [lexical] [[Y_BOX]]
-// CHECK: [[Y_BOX_PROJECT:%.*]] = project_box [[Y_BOX_BORROWED]]
+// CHECK: [[Y_BOX_PROJECT:%.*]] = project_box [[Y_BOX]]
 // CHECK: [[Y_BOX_PROJECT_ACCESS:%.*]] = begin_access [read] [unknown] [[Y_BOX_PROJECT]]
 // CHECK: [[Y_VALUE:%.*]] = load [trivial] [[Y_BOX_PROJECT_ACCESS]]
 // CHECK: [[FUNC:%.*]] = function_ref @$s14noimplicitcopy11printIntArgyySiF : $@convention(thin) (Int) -> ()
@@ -141,8 +140,7 @@ func printIntOwnedArg(@_noImplicitCopy _ x: __owned Int) {
 // CHECK: apply [[FUNC]]([[VALUE]])
 //
 // CHECK: [[Y_BOX:%.*]] = alloc_box ${ var Int }
-// CHECK: [[Y_BOX_BORROWED:%.*]] = begin_borrow [lexical] [[Y_BOX]]
-// CHECK: [[Y_BOX_PROJECT:%.*]] = project_box [[Y_BOX_BORROWED]]
+// CHECK: [[Y_BOX_PROJECT:%.*]] = project_box [[Y_BOX]]
 // CHECK: [[Y_BOX_PROJECT_ACCESS:%.*]] = begin_access [read] [unknown] [[Y_BOX_PROJECT]]
 // CHECK: [[Y_VALUE:%.*]] = load [trivial] [[Y_BOX_PROJECT_ACCESS]]
 // CHECK: [[FUNC:%.*]] = function_ref @$s14noimplicitcopy16printIntOwnedArgyySinF : $@convention(thin) (Int) -> ()
@@ -191,8 +189,7 @@ func printIntArgThrows(@_noImplicitCopy _ x: Int) throws {
 // CHECK: try_apply [[FUNC]]([[VALUE]])
 //
 // CHECK: [[Y_BOX:%.*]] = alloc_box ${ var Int }
-// CHECK: [[Y_BOX_BORROWED:%.*]] = begin_borrow [lexical] [[Y_BOX]]
-// CHECK: [[Y_BOX_PROJECT:%.*]] = project_box [[Y_BOX_BORROWED]]
+// CHECK: [[Y_BOX_PROJECT:%.*]] = project_box [[Y_BOX]]
 // CHECK: [[Y_BOX_PROJECT_ACCESS:%.*]] = begin_access [read] [unknown] [[Y_BOX_PROJECT]]
 // CHECK: [[Y_VALUE:%.*]] = load [trivial] [[Y_BOX_PROJECT_ACCESS]]
 // CHECK: [[FUNC:%.*]] = function_ref @$s14noimplicitcopy17printIntArgThrowsyySiKF : $@convention(thin) (Int) -> @error any Error
@@ -232,8 +229,7 @@ func printIntOwnedArgThrows(@_noImplicitCopy _ x: __owned Int) throws {
 // CHECK: try_apply [[FUNC]]([[VALUE]])
 //
 // CHECK: [[Y_BOX:%.*]] = alloc_box ${ var Int }
-// CHECK: [[Y_BOX_BORROWED:%.*]] = begin_borrow [lexical] [[Y_BOX]]
-// CHECK: [[Y_BOX_PROJECT:%.*]] = project_box [[Y_BOX_BORROWED]]
+// CHECK: [[Y_BOX_PROJECT:%.*]] = project_box [[Y_BOX]]
 // CHECK: [[Y_BOX_PROJECT_ACCESS:%.*]] = begin_access [read] [unknown] [[Y_BOX_PROJECT]]
 // CHECK: [[Y_VALUE:%.*]] = load [trivial] [[Y_BOX_PROJECT_ACCESS]]
 // CHECK: [[FUNC:%.*]] = function_ref @$s14noimplicitcopy22printIntOwnedArgThrowsyySinKF : $@convention(thin) (Int) -> @error any Error

--- a/test/SILGen/observers.swift
+++ b/test/SILGen/observers.swift
@@ -18,8 +18,7 @@ public struct DidSetWillSetTests {
 
     // CHECK: bb0(%0 : $Int, %1 : $@thin DidSetWillSetTests.Type):
     // CHECK:        [[SELF:%.*]] = mark_uninitialized [rootself]
-    // CHECK:        [[SELF_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[SELF]]
-    // CHECK:        [[PB_SELF:%.*]] = project_box [[SELF_LIFETIME]]
+    // CHECK:        [[PB_SELF:%.*]] = project_box [[SELF]]
     // CHECK:        [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB_SELF]]
     // CHECK:        [[P1:%.*]] = struct_element_addr [[WRITE]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
     // CHECK-NEXT:   assign %0 to [[P1]]
@@ -318,8 +317,7 @@ func local_observing_property(_ arg: Int) {
   // Alloc and initialize the property to the argument value.
   // CHECK: bb0([[ARG:%[0-9]+]] : $Int)
   // CHECK: [[BOX:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[BOX]]
-  // CHECK: [[PB:%.*]] = project_box [[LIFETIME]]
+  // CHECK: [[PB:%.*]] = project_box [[BOX]]
   // CHECK: store [[ARG]] to [trivial] [[PB]]
 }
 

--- a/test/SILGen/optional-cast.swift
+++ b/test/SILGen/optional-cast.swift
@@ -201,10 +201,8 @@ public struct TestAddressOnlyStruct<T> {
 // CHECK: bb0(%0 : $Optional<Int>):
 // CHECK-NEXT: debug_value %0 : $Optional<Int>, let, name "a"
 // CHECK-NEXT: [[X:%.*]] = alloc_box ${ var Optional<Int> }, var, name "x"
-// CHECK-NEXT: [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[X]]
-// CHECK-NEXT: [[PB:%.*]] = project_box [[X_LIFETIME]]
+// CHECK-NEXT: [[PB:%.*]] = project_box [[X]]
 // CHECK-NEXT: store %0 to [trivial] [[PB]] : $*Optional<Int>
-// CHECK-NEXT: end_borrow [[X_LIFETIME]]
 // CHECK-NEXT: destroy_value [[X]] : ${ var Optional<Int> }
 func testContextualInitOfNonAddrOnlyType(_ a : Int?) {
   var x: Int! = a

--- a/test/SILGen/pointer_conversion.swift
+++ b/test/SILGen/pointer_conversion.swift
@@ -174,8 +174,7 @@ func stringToPointer(_ s: String) {
 func inoutToPointer() {
   var int = 0
   // CHECK: [[INT:%.*]] = alloc_box ${ var Int }
-  // CHECK: [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INT]]
-  // CHECK: [[PB:%.*]] = project_box [[LIFETIME]]
+  // CHECK: [[PB:%.*]] = project_box [[INT]]
   takesMutablePointer(&int)
   // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB]]
   // CHECK: [[POINTER:%.*]] = address_to_pointer [[WRITE]]

--- a/test/SILGen/properties.swift
+++ b/test/SILGen/properties.swift
@@ -13,8 +13,7 @@ func physical_tuple_lvalue(_ c: Int) {
   var x : (Int, Int)
   // CHECK: [[BOX:%[0-9]+]] = alloc_box ${ var (Int, Int) }
   // CHECK: [[MARKED_BOX:%[0-9]+]] = mark_uninitialized [var] [[BOX]]
-  // CHECK: [[LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_BOX]]
-  // CHECK: [[XADDR:%.*]] = project_box [[LIFETIME]]
+  // CHECK: [[XADDR:%.*]] = project_box [[MARKED_BOX]]
   x.1 = c
   // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[XADDR]]
   // CHECK: [[X_1:%[0-9]+]] = tuple_element_addr [[WRITE]] : {{.*}}, 1
@@ -344,8 +343,7 @@ func inout_arg(_ x: inout Int) {}
 func physical_inout(_ x: Int) {
   var x = x
   // CHECK: [[XADDR:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[XADDR]]
-  // CHECK: [[PB:%.*]] = project_box [[LIFETIME]]
+  // CHECK: [[PB:%.*]] = project_box [[XADDR]]
   inout_arg(&x)
   // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB]]
   // CHECK: [[INOUT_ARG:%[0-9]+]] = function_ref @$s10properties9inout_arg{{[_0-9a-zA-Z]*}}F
@@ -781,8 +779,7 @@ struct MutatingGetterStruct {
 
   // CHECK-LABEL: sil hidden [ossa] @$s10properties20MutatingGetterStructV4test
   // CHECK: [[X:%.*]] = alloc_box ${ var MutatingGetterStruct }, var, name "x"
-  // CHECK: [[LIFETIME:%.*]] = begin_borrow [lexical] [[X]]
-  // CHECK-NEXT: [[PB:%.*]] = project_box [[LIFETIME]]
+  // CHECK-NEXT: [[PB:%.*]] = project_box [[X]]
   // CHECK: store {{.*}} to [trivial] [[PB]] : $*MutatingGetterStruct
   // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB]]
   // CHECK: apply {{%.*}}([[WRITE]]) : $@convention(method) (@inout MutatingGetterStruct) -> Int

--- a/test/SILGen/properties_swift4.swift
+++ b/test/SILGen/properties_swift4.swift
@@ -33,8 +33,7 @@ struct DidSetWillSetTests: ForceAccessors {
       var unrelatedValue = DidSetWillSetTests.defaultValue
 
       // CHECK: [[BOX:%.*]] = alloc_box ${ var DidSetWillSetTests }, var, name "unrelatedValue"
-      // CHECK: [[BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[BOX]]
-      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX_LIFETIME]] : ${ var DidSetWillSetTests }, 0
+      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX]] : ${ var DidSetWillSetTests }, 0
       // CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thin DidSetWillSetTests.Type
       // CHECK-NEXT: // function_ref static properties.DidSetWillSetTests.defaultValue.getter : properties.DidSetWillSetTests
       // CHECK-NEXT: [[DEFAULTVALUE_FN:%.*]] = function_ref @$s10properties{{[_0-9a-zA-Z]*}}vgZ : $@convention(method) (@thin DidSetWillSetTests.Type) -> DidSetWillSetTests
@@ -76,8 +75,7 @@ struct DidSetWillSetTests: ForceAccessors {
       var unrelatedValue = DidSetWillSetTests.defaultValue
 
       // CHECK: [[BOX:%.*]] = alloc_box ${ var DidSetWillSetTests }, var, name "unrelatedValue"
-      // CHECK: [[BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[BOX]]
-      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX_LIFETIME]] : ${ var DidSetWillSetTests }, 0
+      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX]] : ${ var DidSetWillSetTests }, 0
       // CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thin DidSetWillSetTests.Type
       // CHECK-NEXT: // function_ref static properties.DidSetWillSetTests.defaultValue.getter : properties.DidSetWillSetTests
       // CHECK-NEXT: [[DEFAULTVALUE_FN:%.*]] = function_ref @$s10properties{{[_0-9a-zA-Z]*}}vgZ : $@convention(method) (@thin DidSetWillSetTests.Type) -> DidSetWillSetTests
@@ -104,8 +102,7 @@ struct DidSetWillSetTests: ForceAccessors {
       var other = self
 
       // CHECK: [[BOX:%.*]] = alloc_box ${ var DidSetWillSetTests }, var, name "other"
-      // CHECK: [[BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[BOX]]
-      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX_LIFETIME]] : ${ var DidSetWillSetTests }, 0
+      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX]] : ${ var DidSetWillSetTests }, 0
       // CHECK-NEXT: [[READ_SELF:%.*]] = begin_access [read] [unknown] %0 : $*DidSetWillSetTests
       // CHECK-NEXT: copy_addr [[READ_SELF]] to [initialization] [[BOXADDR]] : $*DidSetWillSetTests
       // CHECK-NEXT: end_access [[READ_SELF]] : $*DidSetWillSetTests

--- a/test/SILGen/properties_swift5.swift
+++ b/test/SILGen/properties_swift5.swift
@@ -33,8 +33,7 @@ struct DidSetWillSetTests: ForceAccessors {
       var unrelatedValue = DidSetWillSetTests.defaultValue
 
       // CHECK: [[BOX:%.*]] = alloc_box ${ var DidSetWillSetTests }, var, name "unrelatedValue"
-      // CHECK: [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[BOX]]
-      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[LIFETIME]] : ${ var DidSetWillSetTests }, 0
+      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX]] : ${ var DidSetWillSetTests }, 0
       // CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thin DidSetWillSetTests.Type
       // CHECK-NEXT: // function_ref static properties.DidSetWillSetTests.defaultValue.getter : properties.DidSetWillSetTests
       // CHECK-NEXT: [[DEFAULTVALUE_FN:%.*]] = function_ref @$s10properties{{[_0-9a-zA-Z]*}}vgZ : $@convention(method) (@thin DidSetWillSetTests.Type) -> DidSetWillSetTests
@@ -78,8 +77,7 @@ struct DidSetWillSetTests: ForceAccessors {
       var unrelatedValue = DidSetWillSetTests.defaultValue
 
       // CHECK: [[BOX:%.*]] = alloc_box ${ var DidSetWillSetTests }, var, name "unrelatedValue"
-      // CHECK: [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[BOX]]
-      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[LIFETIME]] : ${ var DidSetWillSetTests }, 0
+      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX]] : ${ var DidSetWillSetTests }, 0
       // CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thin DidSetWillSetTests.Type
       // CHECK-NEXT: // function_ref static properties.DidSetWillSetTests.defaultValue.getter : properties.DidSetWillSetTests
       // CHECK-NEXT: [[DEFAULTVALUE_FN:%.*]] = function_ref @$s10properties{{[_0-9a-zA-Z]*}}vgZ : $@convention(method) (@thin DidSetWillSetTests.Type) -> DidSetWillSetTests
@@ -108,8 +106,7 @@ struct DidSetWillSetTests: ForceAccessors {
       var other = self
 
       // CHECK: [[BOX:%.*]] = alloc_box ${ var DidSetWillSetTests }, var, name "other"
-      // CHECK: [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[BOX]]
-      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[LIFETIME]] : ${ var DidSetWillSetTests }, 0
+      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX]] : ${ var DidSetWillSetTests }, 0
       // CHECK-NEXT: [[READ_SELF:%.*]] = begin_access [read] [unknown] %0 : $*DidSetWillSetTests
       // CHECK-NEXT: copy_addr [[READ_SELF]] to [initialization] [[BOXADDR]] : $*DidSetWillSetTests
       // CHECK-NEXT: end_access [[READ_SELF]] : $*DidSetWillSetTests

--- a/test/SILGen/property_wrapper_local.swift
+++ b/test/SILGen/property_wrapper_local.swift
@@ -17,14 +17,13 @@ func testLocalWrapper() {
   @Wrapper var value: Int
   // CHECK: [[A:%.*]] = alloc_box ${ var Wrapper<Int> }, var, name "_value"
   // CHECK: [[W:%.*]] = mark_uninitialized [var] [[A]] : ${ var Wrapper<Int> }
-  // CHECK: [[L:%[^,]+]] = begin_borrow [lexical] [[W]]
-  // CHECK: [[P:%.*]] = project_box [[L]] : ${ var Wrapper<Int> }
+  // CHECK: [[P:%.*]] = project_box [[W]] : ${ var Wrapper<Int> }
 
   value = 10
   // CHECK: [[I:%.*]] = function_ref @$s22property_wrapper_local16testLocalWrapperyyF5valueL_SivpfP : $@convention(thin) (Int) -> Wrapper<Int>
   // CHECK: [[IPA:%.*]] = partial_apply [callee_guaranteed] [[I]]() : $@convention(thin) (Int) -> Wrapper<Int>
   // CHECK: [[S:%.*]] = function_ref @$s22property_wrapper_local16testLocalWrapperyyF5valueL_Sivs : $@convention(thin) (Int, @guaranteed { var Wrapper<Int> }) -> ()
-  // CHECK-NEXT: [[C:%.*]] = copy_value [[L]] : ${ var Wrapper<Int> }
+  // CHECK-NEXT: [[C:%.*]] = copy_value [[W]] : ${ var Wrapper<Int> }
   // CHECK-NOT: mark_function_escape
   // CHECK-NEXT: [[SPA:%.*]] = partial_apply [callee_guaranteed] [[S]]([[C]]) : $@convention(thin) (Int, @guaranteed { var Wrapper<Int> }) -> ()
   // CHECK-NEXT: assign_by_wrapper {{%.*}} : $Int to [[P]] : $*Wrapper<Int>, init [[IPA]] : $@callee_guaranteed (Int) -> Wrapper<Int>, set [[SPA]] : $@callee_guaranteed (Int) -> ()

--- a/test/SILGen/property_wrappers.swift
+++ b/test/SILGen/property_wrappers.swift
@@ -972,14 +972,12 @@ struct SR_15940_C {
 // CHECK: bb0(%0 : $SR_15940_C):
 // CHECK-NEXT:  debug_value %0 : $SR_15940_C, let, name "self", argno 1, implicit
 // CHECK-NEXT:  [[BOX:%.*]] = alloc_box ${ var SR_15940Foo }, var, name "_b"
-// CHECK-NEXT:  [[LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]] : ${ var SR_15940Foo }
-// CHECK-NEXT:  [[BOXADDR:%.*]] = project_box [[LIFETIME]] : ${ var SR_15940Foo }, 0
+// CHECK-NEXT:  [[BOXADDR:%.*]] = project_box [[BOX]] : ${ var SR_15940Foo }, 0
 // CHECK-NEXT:  [[METATYPE:%.*]] = metatype $@thin SR_15940Foo.Type
 // CHECK-NEXT:  // function_ref SR_15940Foo.init()
 // CHECK-NEXT:  [[DEFAULTVALUE_FN:%.*]] = function_ref @$s17property_wrappers11SR_15940FooVACycfC : $@convention(method) (@thin SR_15940Foo.Type) -> SR_15940Foo
 // CHECK-NEXT:  [[DEFAULTRESULT:%.*]] = apply [[DEFAULTVALUE_FN]]([[METATYPE]]) : $@convention(method) (@thin SR_15940Foo.Type) -> SR_15940Foo
 // CHECK-NEXT:  store [[DEFAULTRESULT]] to [trivial] [[BOXADDR]] : $*SR_15940Foo
-// CHECK-NEXT:  end_borrow [[LIFETIME]] : ${ var SR_15940Foo }
 // CHECK-NEXT:  destroy_value [[BOX]] : ${ var SR_15940Foo }
 // CHECK-NEXT:  [[TUPLE:%.*]] = tuple ()
 // CHECK-NEXT:  return [[TUPLE]] : $()

--- a/test/SILGen/protocol_optional.swift
+++ b/test/SILGen/protocol_optional.swift
@@ -103,8 +103,7 @@ func optionalPropertyGeneric<T : P1>(t t : T) {
   // CHECK:   [[T_COPY:%.*]] = copy_value [[T]]
   // CHECK:   store [[T_COPY]] to [init] [[PT]] : $*T
   // CHECK:   [[OPT_BOX:%[0-9]+]] = alloc_box ${ var Optional<Int> }
-  // CHECK:   [[OPT_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[OPT_BOX]]
-  // CHECK:   project_box [[OPT_LIFETIME]]
+  // CHECK:   project_box [[OPT_BOX]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PT]] : $*T
   // CHECK:   [[T:%[0-9]+]] = load [copy] [[READ]] : $*T
   // CHECK:   alloc_stack $Optional<Int>
@@ -123,8 +122,7 @@ func optionalSubscriptGeneric<T : P1>(t t : T) {
   // CHECK:   [[T_COPY:%.*]] = copy_value [[T]]
   // CHECK:   store [[T_COPY]] to [init] [[PT]] : $*T
   // CHECK:   [[OPT_BOX:%[0-9]+]] = alloc_box ${ var Optional<Int> }
-  // CHECK:   [[OPT_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[OPT_BOX]]
-  // CHECK:   project_box [[OPT_LIFETIME]]
+  // CHECK:   project_box [[OPT_BOX]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PT]] : $*T
   // CHECK:   [[T:%[0-9]+]] = load [copy] [[READ]] : $*T
   // CHECK:   [[FIVELIT:%[0-9]+]] = integer_literal $Builtin.IntLiteral, 5

--- a/test/SILGen/statements.swift
+++ b/test/SILGen/statements.swift
@@ -526,12 +526,10 @@ func defer_mutable(_ x: Int) {
   var x = x
   // expected-warning@-1 {{variable 'x' was never mutated; consider changing to 'let' constant}}
   // CHECK: [[BOX:%.*]] = alloc_box ${ var Int }
-  // CHECK: [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[BOX]]
-  // CHECK-NEXT: project_box [[LIFETIME]]
-  // CHECK-NOT: [[LIFETIME]]
+  // CHECK-NEXT: project_box [[BOX]]
+  // CHECK-NOT: [[BOX]]
   // CHECK: function_ref @$s10statements13defer_mutableyySiF6$deferL_yyF : $@convention(thin) (@inout_aliasable Int) -> ()
-  // CHECK-NOT: [[LIFETIME]]
-  // CHECK: end_borrow [[LIFETIME]]
+  // CHECK-NOT: [[BOX]]
   // CHECK: destroy_value [[BOX]]
   defer { _ = x } // expected-warning {{'defer' statement at end of scope always executes immediately}}{{3-8=do}}
 }

--- a/test/SILGen/switch_fallthrough.swift
+++ b/test/SILGen/switch_fallthrough.swift
@@ -139,11 +139,9 @@ func test5() {
   case (var n, foo()):
     // Check that the var is boxed and unboxed and the final value is the one that falls through into the next case
     // CHECK:   [[BOX:%.*]] = alloc_box ${ var Int }, var, name "n"
-    // CHECK:   [[BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[BOX]]
-    // CHECK:   [[N_BOX:%.*]] = project_box [[BOX_LIFETIME]] : ${ var Int }, 0
+    // CHECK:   [[N_BOX:%.*]] = project_box [[BOX]] : ${ var Int }, 0
     // CHECK:   function_ref @$s18switch_fallthrough1ayyF
     // CHECK:   [[N:%.*]] = load [trivial] [[N_BOX]] : $*Int
-    // CHECK:   end_borrow [[BOX_LIFETIME]]
     // CHECK:   destroy_value [[BOX]] : ${ var Int }
     // CHECK:   br [[CASE2:bb[0-9]+]]([[N]] : $Int)
     a()

--- a/test/SILGen/switch_var.swift
+++ b/test/SILGen/switch_var.swift
@@ -47,14 +47,12 @@ func test_var_1() {
   // CHECK:   function_ref @$s10switch_var3fooSiyF
   switch foo() {
   // CHECK:   [[XADDR:%.*]] = alloc_box ${ var Int }
-  // CHECK:   [[XLIFETIME:%.+]] = begin_borrow [lexical] [[XADDR]]
-  // CHECK:   [[X:%.*]] = project_box [[XLIFETIME]]
+  // CHECK:   [[X:%.*]] = project_box [[XADDR]]
   // CHECK-NOT: br bb
   case var x:
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[X]]
   // CHECK:   load [trivial] [[READ]]
   // CHECK:   function_ref @$s10switch_var1a1xySi_tF
-  // CHECK:   end_borrow [[XLIFETIME]]
   // CHECK:   destroy_value [[XADDR]]
     a(x: x)
   }
@@ -67,8 +65,7 @@ func test_var_2() {
   // CHECK:   function_ref @$s10switch_var3fooSiyF
   switch foo() {
   // CHECK:   [[XADDR:%.*]] = alloc_box ${ var Int }
-  // CHECK:   [[XLIFETIME:%.*]] = begin_borrow [lexical] [[XADDR]]
-  // CHECK:   [[X:%.*]] = project_box [[XLIFETIME]]
+  // CHECK:   [[X:%.*]] = project_box [[XADDR]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[X]]
   // CHECK:   load [trivial] [[READ]]
   // CHECK:   function_ref @$s10switch_var6runced1xSbSi_tF
@@ -79,14 +76,12 @@ func test_var_2() {
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[X]]
   // CHECK:   load [trivial] [[READ]]
   // CHECK:   function_ref @$s10switch_var1a1xySi_tF
-  // CHECK:   end_borrow [[XLIFETIME]]
   // CHECK:   destroy_value [[XADDR]]
   // CHECK:   br [[CONT:bb[0-9]+]]
     a(x: x)
   // CHECK: [[NO_CASE1]]:
   // CHECK:   [[YADDR:%.*]] = alloc_box ${ var Int }
-  // CHECK:   [[YLIFETIME:%[^,]+]] = begin_borrow [lexical] [[YADDR]]
-  // CHECK:   [[Y:%.*]] = project_box [[YLIFETIME]]
+  // CHECK:   [[Y:%.*]] = project_box [[YADDR]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[Y]]
   // CHECK:   load [trivial] [[READ]]
   // CHECK:   function_ref @$s10switch_var6funged1xSbSi_tF
@@ -96,19 +91,16 @@ func test_var_2() {
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[Y]]
   // CHECK:   load [trivial] [[READ]]
   // CHECK:   function_ref @$s10switch_var1b1xySi_tF
-  // CHECK:   end_borrow [[YLIFETIME]]
   // CHECK:   destroy_value [[YADDR]]
   // CHECK:   br [[CONT]]
     b(x: y)
   case var z:
   // CHECK: [[NO_CASE2]]:
   // CHECK:   [[ZADDR:%.*]] = alloc_box ${ var Int }
-  // CHECK:   [[ZLIFETIME:%[^,]+]] = begin_borrow [lexical] [[ZADDR]]
-  // CHECK:   [[Z:%.*]] = project_box [[ZLIFETIME]]
+  // CHECK:   [[Z:%.*]] = project_box [[ZADDR]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[Z]]
   // CHECK:   load [trivial] [[READ]]
   // CHECK:   function_ref @$s10switch_var1c1xySi_tF
-  // CHECK:   end_borrow [[ZLIFETIME]]
   // CHECK:   destroy_value [[ZADDR]]
   // CHECK:   br [[CONT]]
     c(x: z)
@@ -124,8 +116,7 @@ func test_var_3() {
   // CHECK:   function_ref @$s10switch_var3barSiyF
   switch (foo(), bar()) {
   // CHECK:   [[XADDR:%.*]] = alloc_box ${ var (Int, Int) }
-  // CHECK:   [[XLIFETIME:%[^,]+]] = begin_borrow [lexical] [[XADDR]]
-  // CHECK:   [[X:%.*]] = project_box [[XLIFETIME]]
+  // CHECK:   [[X:%.*]] = project_box [[XADDR]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[X]]
   // CHECK:   tuple_element_addr [[READ]] : {{.*}}, 0
   // CHECK:   function_ref @$s10switch_var6runced1xSbSi_tF
@@ -135,18 +126,15 @@ func test_var_3() {
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[X]]
   // CHECK:   load [trivial] [[READ]]
   // CHECK:   function_ref @$s10switch_var2aa1xySi_Sit_tF
-  // CHECK:   end_borrow [[XLIFETIME]]
   // CHECK:   destroy_value [[XADDR]]
   // CHECK:   br [[CONT:bb[0-9]+]]
     aa(x: x)
 
   // CHECK: [[NO_CASE1]]:
   // CHECK:   [[YADDR:%.*]] = alloc_box ${ var Int }
-  // CHECK:   [[YLIFETIME:%[^,]+]] = begin_borrow [lexical] [[YADDR]]
-  // CHECK:   [[Y:%.*]] = project_box [[YLIFETIME]]
+  // CHECK:   [[Y:%.*]] = project_box [[YADDR]]
   // CHECK:   [[ZADDR:%.*]] = alloc_box ${ var Int }
-  // CHECK:   [[ZLIFETIME:%[^,]+]] = begin_borrow [lexical] [[ZADDR]]
-  // CHECK:   [[Z:%.*]] = project_box [[ZLIFETIME]]
+  // CHECK:   [[Z:%.*]] = project_box [[ZADDR]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[Y]]
   // CHECK:   load [trivial] [[READ]]
   // CHECK:   function_ref @$s10switch_var6funged1xSbSi_tF
@@ -159,17 +147,14 @@ func test_var_3() {
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[Z]]
   // CHECK:   load [trivial] [[READ]]
   // CHECK:   function_ref @$s10switch_var1b1xySi_tF
-  // CHECK:   end_borrow [[ZLIFETIME]]
   // CHECK:   destroy_value [[ZADDR]]
-  // CHECK:   end_borrow [[YLIFETIME]]
   // CHECK:   destroy_value [[YADDR]]
   // CHECK:   br [[CONT]]
     a(x: y)
     b(x: z)
   // CHECK: [[NO_CASE2]]:
   // CHECK:   [[WADDR:%.*]] = alloc_box ${ var (Int, Int) }
-  // CHECK:   [[WLIFETIME:%[^,]+]] = begin_borrow [lexical] [[WADDR]]
-  // CHECK:   [[W:%.*]] = project_box [[WLIFETIME]]
+  // CHECK:   [[W:%.*]] = project_box [[WADDR]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[W]]
   // CHECK:   tuple_element_addr [[READ]] : {{.*}}, 0
   // CHECK:   function_ref @$s10switch_var5ansed1xSbSi_tF
@@ -182,16 +167,13 @@ func test_var_3() {
   // CHECK:   br [[CONT]]
     bb(x: w)
   // CHECK: [[NO_CASE3]]:
-  // CHECK:   end_borrow [[WLIFETIME]]
   // CHECK:   destroy_value [[WADDR]]
   case var v:
   // CHECK:   [[VADDR:%.*]] = alloc_box ${ var (Int, Int) } 
-  // CHECK:   [[VLIFETIME:%[^,]+]] = begin_borrow [lexical] [[VADDR]]
-  // CHECK:   [[V:%.*]] = project_box [[VLIFETIME]]
+  // CHECK:   [[V:%.*]] = project_box [[VADDR]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[V]]
   // CHECK:   load [trivial] [[READ]]
   // CHECK:   function_ref @$s10switch_var2cc1xySi_Sit_tF
-  // CHECK:   end_borrow [[VLIFETIME]]
   // CHECK:   destroy_value [[VADDR]]
   // CHECK:   br [[CONT]]
     cc(x: v)
@@ -222,8 +204,7 @@ func test_var_4(p p: P) {
   // CHECK: [[IS_X]]:
   // CHECK:   [[T0:%.*]] = load [trivial] [[TMP]] : $*X
   // CHECK:   [[XADDR:%.*]] = alloc_box ${ var Int }
-  // CHECK:   [[XLIFETIME:%.+]] = begin_borrow [lexical] [[XADDR]]
-  // CHECK:   [[X:%.*]] = project_box [[XLIFETIME]]
+  // CHECK:   [[X:%.*]] = project_box [[XADDR]]
   // CHECK:   store [[PAIR_1]] to [trivial] [[X]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[X]]
   // CHECK:   load [trivial] [[READ]]
@@ -232,7 +213,6 @@ func test_var_4(p p: P) {
   case (is X, var x) where runced(x: x):
   // CHECK: [[CASE1]]:
   // CHECK:   function_ref @$s10switch_var1a1xySi_tF
-  // CHECK:   end_borrow [[XLIFETIME]]
   // CHECK:   destroy_value [[XADDR]]
   // CHECK:   dealloc_stack [[TMP]]
   // CHECK:   destroy_addr [[PAIR_0]] : $*any P
@@ -255,8 +235,7 @@ func test_var_4(p p: P) {
   // CHECK: [[IS_Y]]:
   // CHECK:   [[T0:%.*]] = load [trivial] [[TMP]] : $*Y
   // CHECK:   [[YADDR:%.*]] = alloc_box ${ var Int }
-  // CHECK:   [[YLIFETIME:%.+]] = begin_borrow [lexical] [[YADDR]]
-  // CHECK:   [[Y:%.*]] = project_box [[YLIFETIME]]
+  // CHECK:   [[Y:%.*]] = project_box [[YADDR]]
   // CHECK:   store [[PAIR_1]] to [trivial] [[Y]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[Y]]
   // CHECK:   load [trivial] [[READ]]
@@ -268,7 +247,6 @@ func test_var_4(p p: P) {
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[Y]]
   // CHECK:   load [trivial] [[READ]]
   // CHECK:   function_ref @$s10switch_var1b1xySi_tF
-  // CHECK:   end_borrow [[YLIFETIME]]
   // CHECK:   destroy_value [[YADDR]]
   // CHECK:   dealloc_stack [[TMP]]
   // CHECK:   destroy_addr [[PAIR_0]] : $*any P
@@ -277,7 +255,6 @@ func test_var_4(p p: P) {
     b(x: y)
 
   // CHECK: [[NO_CASE2]]:
-  // CHECK:   end_borrow [[YLIFETIME]]
   // CHECK:   destroy_value [[YADDR]]
   // CHECK:   dealloc_stack [[TMP]]
   // CHECK:   br [[NEXT:bb[0-9]+]]
@@ -312,12 +289,10 @@ func test_var_4(p p: P) {
   case (_, var w):
   // CHECK:   [[PAIR_0:%.*]] = tuple_element_addr [[PAIR]] : $*(any P, Int), 0
   // CHECK:   [[WADDR:%.*]] = alloc_box ${ var Int }
-  // CHECK:   [[WLIFETIME:%.+]] = begin_borrow [lexical] [[WADDR]]
-  // CHECK:   [[W:%.*]] = project_box [[WLIFETIME]]
+  // CHECK:   [[W:%.*]] = project_box [[WADDR]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[W]]
   // CHECK:   load [trivial] [[READ]]
   // CHECK:   function_ref @$s10switch_var1d1xySi_tF
-  // CHECK:   end_borrow [[WLIFETIME]]
   // CHECK:   destroy_value [[WADDR]]
   // CHECK-NEXT:   destroy_addr [[PAIR_0]] : $*any P
   // CHECK-NEXT:   dealloc_stack [[PAIR]]
@@ -334,8 +309,7 @@ func test_var_5() {
   // CHECK:   function_ref @$s10switch_var3barSiyF
   switch (foo(), bar()) {
   // CHECK:   [[XADDR:%.*]] = alloc_box ${ var (Int, Int) }
-  // CHECK:   [[XLIFETIME:%.*]] = begin_borrow [lexical] [[XADDR]]
-  // CHECK:   [[X:%.*]] = project_box [[XLIFETIME]]
+  // CHECK:   [[X:%.*]] = project_box [[XADDR]]
   // CHECK:   cond_br {{%.*}}, [[CASE1:bb[0-9]+]], [[NO_CASE1:bb[0-9]+]]
   case var x where runced(x: x.0):
   // CHECK: [[CASE1]]:
@@ -343,24 +317,18 @@ func test_var_5() {
     a()
   // CHECK: [[NO_CASE1]]:
   // CHECK:   [[YADDR:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK:   [[YLIFETIME:%[^,]+]] = begin_borrow [lexical] [[YADDR]]
-  // CHECK:   [[Y:%[0-9]+]] = project_box [[YLIFETIME]]
+  // CHECK:   [[Y:%[0-9]+]] = project_box [[YADDR]]
   // CHECK:   [[ZADDR:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK:   [[ZLIFETIME:%[^,]+]] = begin_borrow [lexical] [[ZADDR]]
-  // CHECK:   [[Z:%[0-9]+]] = project_box [[ZLIFETIME]]
+  // CHECK:   [[Z:%[0-9]+]] = project_box [[ZADDR]]
   // CHECK:   cond_br {{%.*}}, [[CASE2:bb[0-9]+]], [[NO_CASE2:bb[0-9]+]]
   case (var y, var z) where funged(x: y):
   // CHECK: [[CASE2]]:
-  // CHECK:   end_borrow [[ZLIFETIME]]
   // CHECK:   destroy_value [[ZADDR]]
-  // CHECK:   end_borrow [[YLIFETIME]]
   // CHECK:   destroy_value [[YADDR]]
   // CHECK:   br [[CONT]]
     b()
   // CHECK: [[NO_CASE2]]:
-  // CHECK:   end_borrow [[ZLIFETIME]]
   // CHECK:   destroy_value [[ZADDR]]
-  // CHECK:   end_borrow [[YLIFETIME]]
   // CHECK:   destroy_value [[YADDR]]
   // CHECK:   cond_br {{%.*}}, [[CASE3:bb[0-9]+]], [[NO_CASE3:bb[0-9]+]]
   case (_, _) where runced():
@@ -381,49 +349,39 @@ func test_var_return() {
   switch (foo(), bar()) {
   case var x where runced():
     // CHECK: [[XADDR:%[0-9]+]] = alloc_box ${ var (Int, Int) }
-    // CHECK: [[XLIFETIME:%[^,]+]] = begin_borrow [lexical] [[XADDR]]
-    // CHECK: [[X:%[0-9]+]] = project_box [[XLIFETIME]]
+    // CHECK: [[X:%[0-9]+]] = project_box [[XADDR]]
     // CHECK: function_ref @$s10switch_var1ayyF
-    // CHECK: end_borrow [[XLIFETIME]]
     // CHECK: destroy_value [[XADDR]]
     // CHECK: br [[EPILOG:bb[0-9]+]]
     a()
     return
   // CHECK: [[YADDR:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[YLIFETIME:%[^,]+]] = begin_borrow [lexical] [[YADDR]]
-  // CHECK: [[Y:%[0-9]+]] = project_box [[YLIFETIME]]
+  // CHECK: [[Y:%[0-9]+]] = project_box [[YADDR]]
   // CHECK: [[ZADDR:%[0-9]+]] = alloc_box ${ var Int }
-  // CHECK: [[ZLIFETIME:%[^,]+]] = begin_borrow [lexical] [[ZADDR]]
-  // CHECK: [[Z:%[0-9]+]] = project_box [[ZLIFETIME]]
+  // CHECK: [[Z:%[0-9]+]] = project_box [[ZADDR]]
   case (var y, var z) where funged():
     // CHECK: function_ref @$s10switch_var1byyF
-    // CHECK: end_borrow [[ZLIFETIME]]
     // CHECK: destroy_value [[ZADDR]]
-    // CHECK: end_borrow [[YLIFETIME]]
     // CHECK: destroy_value [[YADDR]]
     // CHECK: br [[EPILOG]]
     b()
     return
   case var w where ansed():
     // CHECK: [[WADDR:%[0-9]+]] = alloc_box ${ var (Int, Int) }
-    // CHECK: [[WLIFETIME:%[^,]+]] = begin_borrow [lexical] [[WADDR]]
-    // CHECK: [[W:%[0-9]+]] = project_box [[WLIFETIME]]
+    // CHECK: [[W:%[0-9]+]] = project_box [[WADDR]]
     // CHECK: function_ref @$s10switch_var1cyyF
     // CHECK-NOT: destroy_value [[ZADDR]]
     // CHECK-NOT: destroy_value [[YADDR]]
-    // CHECK: end_borrow [[WLIFETIME]]
     // CHECK: destroy_value [[WADDR]]
     // CHECK: br [[EPILOG]]
     c()
     return
   case var v:
     // CHECK: [[VADDR:%[0-9]+]] = alloc_box ${ var (Int, Int) }
-    // CHECK: [[VLIFETIME:%[^,]+]] = begin_borrow [lexical] [[VADDR]]
-    // CHECK: [[V:%[0-9]+]] = project_box [[VLIFETIME]]
+    // CHECK: [[V:%[0-9]+]] = project_box [[VADDR]]
     // CHECK: function_ref @$s10switch_var1dyyF
     // CHECK-NOT: destroy_value [[ZADDR]]
     // CHECK-NOT: destroy_value [[YADDR]]
-    // CHECK: end_borrow [[VLIFETIME]]
     // CHECK: destroy_value [[VADDR]]
     // CHECK: br [[EPILOG]]
     d()

--- a/test/SILGen/tuples.swift
+++ b/test/SILGen/tuples.swift
@@ -28,8 +28,7 @@ func testShuffleOpaque() {
   // CHECK: [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[X]]
   // CHECK-NEXT: [[PBX:%.*]] = project_box [[X_LIFETIME]]
   // CHECK: [[Y:%.*]] = alloc_box ${ var Int }
-  // CHECK: [[Y_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[Y]]
-  // CHECK-NEXT: [[PBY:%.*]] = project_box [[Y_LIFETIME]]
+  // CHECK-NEXT: [[PBY:%.*]] = project_box [[Y]]
   // CHECK-NEXT: [[TMP:%.*]] = alloc_stack $any P
 
   // CHECK:      [[T0:%.*]] = function_ref @$s6tuples7make_xySi1x_AA1P_p1ytyF
@@ -73,8 +72,7 @@ func testShuffleTuple() {
   // CHECK: [[X_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[X]]
   // CHECK-NEXT: [[PBX:%.*]] = project_box [[X_LIFETIME]]
   // CHECK: [[Y:%.*]] = alloc_box ${ var Int }
-  // CHECK: [[Y_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[Y]]
-  // CHECK-NEXT: [[PBY:%.*]] = project_box [[Y_LIFETIME]]
+  // CHECK-NEXT: [[PBY:%.*]] = project_box [[Y]]
   // CHECK-NEXT: // function_ref
   // CHECK-NEXT: [[T0:%.*]] = function_ref @$s6tuples8make_intSiyF
   // CHECK-NEXT: [[T1:%.*]] = apply [[T0]]()

--- a/test/SILGen/types.swift
+++ b/test/SILGen/types.swift
@@ -28,8 +28,7 @@ struct S {
     // CHECK: bb0([[X:%[0-9]+]] : $Int, [[THIS:%[0-9]+]] : $*S):
     member = x
     // CHECK: [[XBOX:%[0-9]+]] = alloc_box ${ var Int }
-    // CHECK: [[XLIFETIME:%[^,]+]] = begin_borrow [lexical] [[XBOX]]
-    // CHECK: [[XADDR:%[0-9]+]] = project_box [[XLIFETIME]]
+    // CHECK: [[XADDR:%[0-9]+]] = project_box [[XBOX]]
     // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[XADDR]] : $*Int
     // CHECK: [[X:%.*]] = load [trivial] [[READ]] : $*Int
     // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[THIS]] : $*S

--- a/test/SILGen/unsafevalue.swift
+++ b/test/SILGen/unsafevalue.swift
@@ -29,8 +29,7 @@ public struct UnsafeValue<Element: AnyObject> {
   // CHECK: bb0([[INPUT_ELEMENT:%.*]] : @guaranteed $Element,
   // CHECK:   [[BOX:%.*]] = alloc_box
   // CHECK:   [[UNINIT_BOX:%.*]] = mark_uninitialized [rootself] [[BOX]]
-  // CHECK:   [[UNINIT_BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[UNINIT_BOX]]
-  // CHECK:   [[PROJECT_UNINIT_BOX:%.*]] = project_box [[UNINIT_BOX_LIFETIME]]
+  // CHECK:   [[PROJECT_UNINIT_BOX:%.*]] = project_box [[UNINIT_BOX]]
   // CHECK:   [[COPY_INPUT_ELEMENT:%.*]] = copy_value [[INPUT_ELEMENT]]
   // CHECK:   [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJECT_UNINIT_BOX]]
   // CHECK:   [[STRUCT_ACCESS:%.*]] = struct_element_addr [[ACCESS]]
@@ -39,7 +38,6 @@ public struct UnsafeValue<Element: AnyObject> {
   // CHECK:   destroy_value [[COPY_INPUT_ELEMENT]]
   // CHECK:   end_access [[ACCESS]]
   // CHECK:   [[RESULT:%.*]] = load [trivial] [[PROJECT_UNINIT_BOX]]
-  // CHECK:   end_borrow [[UNINIT_BOX_LIFETIME]]
   // CHECK:   destroy_value [[UNINIT_BOX]]
   // CHECK:   return [[RESULT]]
   // CHECK: } // end sil function '$s11unsafevalue11UnsafeValueV14unsafelyAssignACyxGxh_tcfC'
@@ -72,8 +70,7 @@ public struct UnsafeValue<Element: AnyObject> {
   // CHECK-LABEL: sil [transparent] [serialized] [ossa] @$s11unsafevalue11UnsafeValueV20withGuaranteeingBase4base_qd_0_qd___qd_0_xXEtr0_lF :
   // CHECK: bb0([[RESULT:%.*]] : $*Result, [[BASE:%.*]] : $*Base, [[CLOSURE:%.*]] : $@noescape @callee_guaranteed {{.*}}, [[UNSAFE_VALUE:%.*]] : $UnsafeValue<Element>):
   // CHECK:  [[COPY_BOX:%.*]] = alloc_box
-  // CHECK:  [[COPY_BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[COPY_BOX]]
-  // CHECK:  [[COPY_PROJ:%.*]] = project_box [[COPY_BOX_LIFETIME]]
+  // CHECK:  [[COPY_PROJ:%.*]] = project_box [[COPY_BOX]]
   // CHECK:  store [[UNSAFE_VALUE]] to [trivial] [[COPY_PROJ]]
   // CHECK:  [[VALUE_ADDR:%.*]] = begin_access [read] [unknown] [[COPY_PROJ]]
   // CHECK:  [[STR_VALUE_ADDR:%.*]] = struct_element_addr [[VALUE_ADDR]]
@@ -84,7 +81,6 @@ public struct UnsafeValue<Element: AnyObject> {
   // CHECK:  end_access [[VALUE_ADDR]]
   // CHECK:  apply [[CLOSURE]]([[RESULT]], [[GUARANTEED_REF_DEP_ON_BASE]])
   // CHECK:  end_borrow [[GUARANTEED_REF]]
-  // CHECK:  end_borrow [[COPY_BOX_LIFETIME]]
   // CHECK:  destroy_value [[COPY_BOX]]
   // CHECK: } // end sil function '$s11unsafevalue11UnsafeValueV20withGuaranteeingBase4base_qd_0_qd___qd_0_xXEtr0_lF'
   //

--- a/test/SILOptimizer/access_marker_verify.swift
+++ b/test/SILOptimizer/access_marker_verify.swift
@@ -53,15 +53,13 @@ struct StructOfInt {
 // CHECK: bb0(%0 : $@thin StructOfInt.Type):
 // CHECK:   [[BOX:%.*]] = alloc_box ${ var StructOfInt }, var, name "self"
 // CHECK:   [[UNINIT:%.*]] = mark_uninitialized [rootself] [[BOX]] : ${ var StructOfInt }
-// CHECK:   [[UNINIT_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[UNINIT]]
-// CHECK:   [[PROJ:%.*]] = project_box [[UNINIT_LIFETIME]] : ${ var StructOfInt }, 0
+// CHECK:   [[PROJ:%.*]] = project_box [[UNINIT]] : ${ var StructOfInt }, 0
 // CHECK:   [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJ]] : $*StructOfInt
 // CHECK:   [[ADR:%.*]] = struct_element_addr [[ACCESS]] : $*StructOfInt, #StructOfInt.i
 // CHECK:   assign %{{.*}} to [[ADR]] : $*Int
 // CHECK:   end_access [[ACCESS]] : $*StructOfInt
 // CHECK-NOT: begin_access
 // CHECK:   [[VAL:%.*]] = load [trivial] [[PROJ]] : $*StructOfInt
-// CHECK:   end_borrow [[UNINIT_LIFETIME]]
 // CHECK:   destroy_value [[UNINIT]] : ${ var StructOfInt }
 // CHECK:   return [[VAL]] : $StructOfInt
 // CHECK-LABEL: } // end sil function '$s20access_marker_verify11StructOfIntVACycfC'
@@ -222,12 +220,11 @@ func testCaptureLocal() -> ()->() {
 // CHECK-LABEL: sil hidden [ossa] @$s20access_marker_verify16testCaptureLocalyycyF : $@convention(thin) () -> @owned @callee_guaranteed () -> () {
 // CHECK: bb0:
 // CHECK:   [[BOX:%.*]] = alloc_box ${ var Int }, var, name "x"
-// CHECK:   [[LIFETIME:%.*]] = begin_borrow [lexical] [[BOX]]
-// CHECK:   [[PROJ:%.*]] = project_box [[LIFETIME]]
+// CHECK:   [[PROJ:%.*]] = project_box [[BOX]]
 // CHECK:   [[ACCESS:%.*]] = begin_access [modify] [unsafe] [[PROJ]] : $*Int
 // CHECK:   store %{{.*}} to [trivial] [[ACCESS]]
 // CHECK:   end_access
-// CHECK:   [[CAPTURE:%.*]] = copy_value [[LIFETIME]] : ${ var Int }
+// CHECK:   [[CAPTURE:%.*]] = copy_value [[BOX]] : ${ var Int }
 // CHECK:   partial_apply [callee_guaranteed] %{{.*}}([[CAPTURE]]) : $@convention(thin) (@guaranteed { var Int }) -> ()
 // CHECK:   begin_access [read] [unknown] [[PROJ]]
 // CHECK:   [[VAL:%.*]] = load [trivial]
@@ -296,7 +293,7 @@ func testCopyS(_ arg: StructOfInt) -> StructOfInt {
 }
 // CHECK-LABEL: sil hidden [ossa] @$s20access_marker_verify9testCopySyAA11StructOfIntVADF : $@convention(thin) (StructOfInt) -> StructOfInt {
 // CHECK: bb0(%0 : $StructOfInt):
-// CHECK:   alloc_stack [lexical] $StructOfInt, let, name "lhs"
+// CHECK:   alloc_stack $StructOfInt, let, name "lhs"
 // CHECK:   [[UNINIT:%.*]] = mark_uninitialized [var]
 // CHECK-NOT: begin_access
 // CHECK:   assign %0 to [[UNINIT]] : $*StructOfInt

--- a/test/SILOptimizer/capturepromotion-wrong-lexicalscope.swift
+++ b/test/SILOptimizer/capturepromotion-wrong-lexicalscope.swift
@@ -4,28 +4,27 @@
 
 // CHECK: sil hidden [ossa] @$s4null19captureStackPromoteSiycyF : $@convention(thin) () -> @owned @callee_guaranteed () -> Int {
 // CHECK: bb0:
-// CHECK:   [[BOX:%[^,]+]] = alloc_box ${ var Int }, var, name "x", loc {{.*}}:33:7, scope 3
-// CHECK:   [[BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[BOX]]
-// CHECK:   [[BOX_ADDR:%[^,]+]] = project_box [[BOX_LIFETIME]] : ${ var Int }, 0, loc {{.*}}:33:7, scope 3
-// CHECK:   [[ONE:%[^,]+]] = integer_literal $Builtin.IntLiteral, 1, loc {{.*}}:33:11, scope 3
-// CHECK:   [[THIN_INT_TYPE:%[^,]+]] = metatype $@thin Int.Type, loc {{.*}}:33:11, scope 3
-// CHECK:   [[INTEGER_LITERAL:%[^,]+]] = function_ref @$sSi22_builtinIntegerLiteralSiBI_tcfC : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int, loc {{.*}}:33:11, scope 3
-// CHECK:   [[ONE_INT:%[^,]+]] = apply [[INTEGER_LITERAL]]([[ONE]], [[THIN_INT_TYPE]]) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int, loc {{.*}}:33:11, scope 3
-// CHECK:   store [[ONE_INT]] to [trivial] [[BOX_ADDR]] : $*Int, loc {{.*}}:33:11, scope 3
-// CHECK:   [[BOX_COPY:%[^,]+]] = copy_value [[BOX_LIFETIME]] : ${ var Int }, loc {{.*}}:34:11, scope 3
-// CHECK:   [[BOX_COPY_ADDR:%[^,]+]] = project_box [[BOX_COPY]] : ${ var Int }, 0, loc {{.*}}:34:11, scope 3
-// CHECK:   mark_function_escape [[BOX_ADDR]] : $*Int, loc {{.*}}:34:11, scope 3
-// CHECK:   [[SPECIALIZED_F:%[^,]+]] = function_ref @$s4null19captureStackPromoteSiycyFSiycfU_Tf2i_n : $@convention(thin) (Int) -> Int, loc {{.*}}:34:11, scope 3
-// CHECK:   [[REGISTER_11:%[^,]+]] = load [trivial] [[BOX_COPY_ADDR]] : $*Int, loc {{.*}}:34:11, scope 3
-// CHECK:   destroy_value [[BOX_COPY]] : ${ var Int }, loc {{.*}}:34:11, scope 3
-// CHECK:   [[CLOSURE:%[^,]+]] = partial_apply [callee_guaranteed] [[SPECIALIZED_F]]([[REGISTER_11]]) : $@convention(thin) (Int) -> Int, loc {{.*}}:34:11, scope 3
+// CHECK:   [[BOX:%[^,]+]] = alloc_box ${ var Int }, var, name "x", loc {{.*}}:32:7, scope 3
+// CHECK:   [[BOX_ADDR:%[^,]+]] = project_box [[BOX]] : ${ var Int }, 0, loc {{.*}}:32:7, scope 3
+// CHECK:   [[ONE:%[^,]+]] = integer_literal $Builtin.IntLiteral, 1, loc {{.*}}:32:11, scope 3
+// CHECK:   [[THIN_INT_TYPE:%[^,]+]] = metatype $@thin Int.Type, loc {{.*}}:32:11, scope 3
+// CHECK:   [[INTEGER_LITERAL:%[^,]+]] = function_ref @$sSi22_builtinIntegerLiteralSiBI_tcfC : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int, loc {{.*}}:32:11, scope 3
+// CHECK:   [[ONE_INT:%[^,]+]] = apply [[INTEGER_LITERAL]]([[ONE]], [[THIN_INT_TYPE]]) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int, loc {{.*}}:32:11, scope 3
+// CHECK:   store [[ONE_INT]] to [trivial] [[BOX_ADDR]] : $*Int, loc {{.*}}:32:11, scope 3
+// CHECK:   [[BOX_COPY:%[^,]+]] = copy_value [[BOX]] : ${ var Int }, loc {{.*}}:33:11, scope 3
+// CHECK:   [[BOX_COPY_ADDR:%[^,]+]] = project_box [[BOX_COPY]] : ${ var Int }, 0, loc {{.*}}:33:11, scope 3
+// CHECK:   mark_function_escape [[BOX_ADDR]] : $*Int, loc {{.*}}:33:11, scope 3
+// CHECK:   [[SPECIALIZED_F:%[^,]+]] = function_ref @$s4null19captureStackPromoteSiycyFSiycfU_Tf2i_n : $@convention(thin) (Int) -> Int, loc {{.*}}:33:11, scope 3
+// CHECK:   [[REGISTER_11:%[^,]+]] = load [trivial] [[BOX_COPY_ADDR]] : $*Int, loc {{.*}}:33:11, scope 3
+// CHECK:   destroy_value [[BOX_COPY]] : ${ var Int }, loc {{.*}}:33:11, scope 3
+// CHECK:   [[CLOSURE:%[^,]+]] = partial_apply [callee_guaranteed] [[SPECIALIZED_F]]([[REGISTER_11]]) : $@convention(thin) (Int) -> Int, loc {{.*}}:33:11, scope 3
 // CHECK:   [[BORROW:%.*]] = begin_borrow [lexical] [[CLOSURE]]
-// CHECK:   debug_value [[BORROW]] : $@callee_guaranteed () -> Int, let, name "f", loc {{.*}}:34:7, scope 3
-// CHECK:   [[CLOSURE_COPY:%[^,]+]] = copy_value [[BORROW]] : $@callee_guaranteed () -> Int, loc {{.*}}:35:10, scope 3
+// CHECK:   debug_value [[BORROW]] : $@callee_guaranteed () -> Int, let, name "f", loc {{.*}}:33:7, scope 3
+// CHECK:   [[CLOSURE_COPY:%[^,]+]] = copy_value [[BORROW]] : $@callee_guaranteed () -> Int, loc {{.*}}:34:10, scope 3
 // There used to be an end_borrow here. We leave an emptyline here to preserve line numbers.
-// CHECK:   destroy_value [[CLOSURE]] : $@callee_guaranteed () -> Int, loc {{.*}}:36:1, scope 3
-// CHECK:   destroy_value [[BOX]] : ${ var Int }, loc {{.*}}:36:1, scope 3
-// CHECK:   return [[CLOSURE_COPY]] : $@callee_guaranteed () -> Int, loc {{.*}}:35:3, scope 3
+// CHECK:   destroy_value [[CLOSURE]] : $@callee_guaranteed () -> Int, loc {{.*}}:35:1, scope 3
+// CHECK:   destroy_value [[BOX]] : ${ var Int }, loc {{.*}}:35:1, scope 3
+// CHECK:   return [[CLOSURE_COPY]] : $@callee_guaranteed () -> Int, loc {{.*}}:34:3, scope 3
 // CHECK: }
 
 

--- a/test/SILOptimizer/inline_lifetime.sil
+++ b/test/SILOptimizer/inline_lifetime.sil
@@ -4,6 +4,62 @@ import Swift
 
 class C {}
 
+@_eagerMove
+class EagerC {}
+
+struct InferredEagerD1S1 {
+  var c1: EagerC
+  var c2: EagerC
+}
+
+struct InferredEagerD1S2 {
+  @_eagerMove var c1: C
+  var c2: EagerC
+}
+
+struct InferredEagerD1S3 {
+  @_eagerMove var c1: C
+  @_eagerMove let c2: C
+}
+
+struct InferredEagerD1S4 {
+  @_eagerMove var c1: (one: C, two: C)
+  @_eagerMove let c2: C
+}
+
+struct InferredEagerD2S1 {
+  var i1: InferredEagerD1S1
+  var i2: InferredEagerD1S2
+  var i3: InferredEagerD1S3
+  var i4: InferredEagerD1S4
+}
+
+@_lexical
+struct LexicalS {
+  var i: InferredEagerD2S1
+}
+
+struct InferredLexicalD1S1 {
+  var c1: C
+  var c2: C
+  var c3: C
+  var c4: C
+}
+
+struct InferredLexicalD1S2 {
+  @_lexical var i: InferredEagerD2S1
+}
+
+struct InferredLexicalD1S3 {
+  @_lexical var i: InferredEagerD2S1
+  var j: InferredEagerD2S1
+}
+
+struct InferredLexicalD1S4 {
+  var i: C
+  var j: InferredEagerD2S1
+}
+
 struct S {}
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -19,8 +75,142 @@ entry(%instance : @owned $C):
     return %retval : $()
 }
 
+sil [ossa] [always_inline] @callee_owned_eager_move : $@convention(thin) (@owned C) -> () {
+entry(%instance : @_eagerMove @owned $C):
+    destroy_value %instance : $C
+    %retval = tuple ()
+    return %retval : $()
+}
+
+sil [ossa] [always_inline] @callee_owned_eager_move__type_annotation : $@convention(thin) (@owned EagerC) -> () {
+entry(%instance : @owned $EagerC):
+    destroy_value %instance : $EagerC
+    %retval = tuple ()
+    return %retval : $()
+}
+
+sil [ossa] [always_inline] @callee_owned_eager_move__type_inferred_d1_s1 : $@convention(thin) (@owned InferredEagerD1S1) -> () {
+entry(%instance : @owned $InferredEagerD1S1):
+    destroy_value %instance : $InferredEagerD1S1
+    %retval = tuple ()
+    return %retval : $()
+}
+
+sil [ossa] [always_inline] @callee_owned_eager_move__type_inferred_d1_s2 : $@convention(thin) (@owned InferredEagerD1S2) -> () {
+entry(%instance : @owned $InferredEagerD1S2):
+    destroy_value %instance : $InferredEagerD1S2
+    %retval = tuple ()
+    return %retval : $()
+}
+
+sil [ossa] [always_inline] @callee_owned_eager_move__type_inferred_d1_s3 : $@convention(thin) (@owned InferredEagerD1S3) -> () {
+entry(%instance : @owned $InferredEagerD1S3):
+    destroy_value %instance : $InferredEagerD1S3
+    %retval = tuple ()
+    return %retval : $()
+}
+
+sil [ossa] [always_inline] @callee_owned_eager_move__type_inferred_d1_s4 : $@convention(thin) (@owned InferredEagerD1S4) -> () {
+entry(%instance : @owned $InferredEagerD1S4):
+    destroy_value %instance : $InferredEagerD1S4
+    %retval = tuple ()
+    return %retval : $()
+}
+
+sil [ossa] [always_inline] @callee_owned_eager_move__type_inferred_d2_s1 : $@convention(thin) (@owned InferredEagerD2S1) -> () {
+entry(%instance : @owned $InferredEagerD2S1):
+    destroy_value %instance : $InferredEagerD2S1
+    %retval = tuple ()
+    return %retval : $()
+}
+
+sil [ossa] [always_inline] @callee_owned_lexical : $@convention(thin) (@owned InferredEagerD2S1) -> () {
+entry(%instance : @_lexical @owned $InferredEagerD2S1):
+    destroy_value %instance : $InferredEagerD2S1
+    %retval = tuple ()
+    return %retval : $()
+}
+
 sil [ossa] [always_inline] @callee_guaranteed : $@convention(thin) (@guaranteed C) -> () {
 entry(%instance : @guaranteed $C):
+    %retval = tuple ()
+    return %retval : $()
+}
+
+sil [ossa] [always_inline] @callee_guaranteed_eager_move : $@convention(thin) (@guaranteed C) -> () {
+entry(%instance : @_eagerMove @guaranteed $C):
+    %retval = tuple ()
+    return %retval : $()
+}
+
+sil [ossa] [always_inline] @callee_guaranteed_eager_move__type_annotation : $@convention(thin) (@guaranteed EagerC) -> () {
+entry(%instance : @guaranteed $EagerC):
+    %retval = tuple ()
+    return %retval : $()
+}
+
+sil [ossa] [always_inline] @callee_guaranteed_eager_move__type_inferred_d1_s1 : $@convention(thin) (@guaranteed InferredEagerD1S1) -> () {
+entry(%instance : @guaranteed $InferredEagerD1S1):
+    %retval = tuple ()
+    return %retval : $()
+}
+
+sil [ossa] [always_inline] @callee_guaranteed_eager_move__type_inferred_d1_s2 : $@convention(thin) (@guaranteed InferredEagerD1S2) -> () {
+entry(%instance : @guaranteed $InferredEagerD1S2):
+    %retval = tuple ()
+    return %retval : $()
+}
+
+sil [ossa] [always_inline] @callee_guaranteed_eager_move__type_inferred_d1_s3 : $@convention(thin) (@guaranteed InferredEagerD1S3) -> () {
+entry(%instance : @guaranteed $InferredEagerD1S3):
+    %retval = tuple ()
+    return %retval : $()
+}
+
+sil [ossa] [always_inline] @callee_guaranteed_eager_move__type_inferred_d1_s4 : $@convention(thin) (@guaranteed InferredEagerD1S4) -> () {
+entry(%instance : @guaranteed $InferredEagerD1S4):
+    %retval = tuple ()
+    return %retval : $()
+}
+
+sil [ossa] [always_inline] @callee_guaranteed_eager_move__type_inferred_d2_s1 : $@convention(thin) (@guaranteed InferredEagerD2S1) -> () {
+entry(%instance : @guaranteed $InferredEagerD2S1):
+    %retval = tuple ()
+    return %retval : $()
+}
+
+sil [ossa] [always_inline] @callee_guaranteed_lexical : $@convention(thin) (@guaranteed InferredEagerD2S1) -> () {
+entry(%instance : @_lexical @guaranteed $InferredEagerD2S1):
+    %retval = tuple ()
+    return %retval : $()
+}
+
+sil [ossa] [always_inline] @callee_guaranteed_lexical__type_annotation : $@convention(thin) (@guaranteed LexicalS) -> () {
+entry(%instance : @guaranteed $LexicalS):
+    %retval = tuple ()
+    return %retval : $()
+}
+
+sil [ossa] [always_inline] @callee_guaranteed_lexical__type_inferred_d1_s1 : $@convention(thin) (@guaranteed InferredLexicalD1S1) -> () {
+entry(%instance : @guaranteed $InferredLexicalD1S1):
+    %retval = tuple ()
+    return %retval : $()
+}
+
+sil [ossa] [always_inline] @callee_guaranteed_lexical__type_inferred_d1_s2 : $@convention(thin) (@guaranteed InferredLexicalD1S2) -> () {
+entry(%instance : @guaranteed $InferredLexicalD1S2):
+    %retval = tuple ()
+    return %retval : $()
+}
+
+sil [ossa] [always_inline] @callee_guaranteed_lexical__type_inferred_d1_s3 : $@convention(thin) (@guaranteed InferredLexicalD1S3) -> () {
+entry(%instance : @guaranteed $InferredLexicalD1S3):
+    %retval = tuple ()
+    return %retval : $()
+}
+
+sil [ossa] [always_inline] @callee_guaranteed_lexical__type_inferred_d1_s4 : $@convention(thin) (@guaranteed InferredLexicalD1S4) -> () {
+entry(%instance : @guaranteed $InferredLexicalD1S4):
     %retval = tuple ()
     return %retval : $()
 }
@@ -55,6 +245,86 @@ entry(%instance : @owned $C):
     return %result : $()
 }
 
+// CHECK-LABEL: sil [ossa] @caller_owned_callee_owned_eager_move : $@convention(thin) (@owned C) -> () {
+// CHECK-NOT:     begin_borrow [lexical]
+// CHECK-LABEL: } // end sil function 'caller_owned_callee_owned_eager_move'
+sil [ossa] @caller_owned_callee_owned_eager_move : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+    %callee_owned = function_ref @callee_owned_eager_move : $@convention(thin) (@owned C) -> ()
+    %result = apply %callee_owned(%instance) : $@convention(thin) (@owned C) -> ()
+    return %result : $()
+}
+
+// CHECK-LABEL: sil [ossa] @caller_owned_callee_owned_eager_move__type_annotation : {{.*}} {
+// CHECK-NOT:     begin_borrow [lexical]
+// CHECK-LABEL: } // end sil function 'caller_owned_callee_owned_eager_move__type_annotation'
+sil [ossa] @caller_owned_callee_owned_eager_move__type_annotation : $@convention(thin) (@owned EagerC) -> () {
+entry(%instance : @owned $EagerC):
+    %callee_owned = function_ref @callee_owned_eager_move__type_annotation : $@convention(thin) (@owned EagerC) -> ()
+    %result = apply %callee_owned(%instance) : $@convention(thin) (@owned EagerC) -> ()
+    return %result : $()
+}
+
+// CHECK-LABEL: sil [ossa] @caller_owned_callee_owned_eager_move__type_inferred_d1_s1 : {{.*}} {
+// CHECK-NOT:     begin_borrow [lexical]
+// CHECK-LABEL: } // end sil function 'caller_owned_callee_owned_eager_move__type_inferred_d1_s1'
+sil [ossa] @caller_owned_callee_owned_eager_move__type_inferred_d1_s1 : $@convention(thin) (@owned InferredEagerD1S1) -> () {
+entry(%instance : @owned $InferredEagerD1S1):
+    %callee_owned = function_ref @callee_owned_eager_move__type_inferred_d1_s1 : $@convention(thin) (@owned InferredEagerD1S1) -> ()
+    %result = apply %callee_owned(%instance) : $@convention(thin) (@owned InferredEagerD1S1) -> ()
+    return %result : $()
+}
+
+// CHECK-LABEL: sil [ossa] @caller_owned_callee_owned_eager_move__type_inferred_d1_s2 : {{.*}} {
+// CHECK-NOT:     begin_borrow [lexical]
+// CHECK-LABEL: } // end sil function 'caller_owned_callee_owned_eager_move__type_inferred_d1_s2'
+sil [ossa] @caller_owned_callee_owned_eager_move__type_inferred_d1_s2 : $@convention(thin) (@owned InferredEagerD1S2) -> () {
+entry(%instance : @owned $InferredEagerD1S2):
+    %callee_owned = function_ref @callee_owned_eager_move__type_inferred_d1_s2 : $@convention(thin) (@owned InferredEagerD1S2) -> ()
+    %result = apply %callee_owned(%instance) : $@convention(thin) (@owned InferredEagerD1S2) -> ()
+    return %result : $()
+}
+
+// CHECK-LABEL: sil [ossa] @caller_owned_callee_owned_eager_move__type_inferred_d1_s3 : {{.*}} {
+// CHECK-NOT:     begin_borrow [lexical]
+// CHECK-LABEL: } // end sil function 'caller_owned_callee_owned_eager_move__type_inferred_d1_s3'
+sil [ossa] @caller_owned_callee_owned_eager_move__type_inferred_d1_s3 : $@convention(thin) (@owned InferredEagerD1S3) -> () {
+entry(%instance : @owned $InferredEagerD1S3):
+    %callee_owned = function_ref @callee_owned_eager_move__type_inferred_d1_s3 : $@convention(thin) (@owned InferredEagerD1S3) -> ()
+    %result = apply %callee_owned(%instance) : $@convention(thin) (@owned InferredEagerD1S3) -> ()
+    return %result : $()
+}
+
+// CHECK-LABEL: sil [ossa] @caller_owned_callee_owned_eager_move__type_inferred_d1_s4 : {{.*}} {
+// CHECK-NOT:     begin_borrow [lexical]
+// CHECK-LABEL: } // end sil function 'caller_owned_callee_owned_eager_move__type_inferred_d1_s4'
+sil [ossa] @caller_owned_callee_owned_eager_move__type_inferred_d1_s4 : $@convention(thin) (@owned InferredEagerD1S4) -> () {
+entry(%instance : @owned $InferredEagerD1S4):
+    %callee_owned = function_ref @callee_owned_eager_move__type_inferred_d1_s4 : $@convention(thin) (@owned InferredEagerD1S4) -> ()
+    %result = apply %callee_owned(%instance) : $@convention(thin) (@owned InferredEagerD1S4) -> ()
+    return %result : $()
+}
+
+// CHECK-LABEL: sil [ossa] @caller_owned_callee_owned_eager_move__type_inferred_d2_s1 : {{.*}} {
+// CHECK-NOT:     begin_borrow [lexical]
+// CHECK-LABEL: } // end sil function 'caller_owned_callee_owned_eager_move__type_inferred_d2_s1'
+sil [ossa] @caller_owned_callee_owned_eager_move__type_inferred_d2_s1 : $@convention(thin) (@owned InferredEagerD2S1) -> () {
+entry(%instance : @owned $InferredEagerD2S1):
+    %callee_owned = function_ref @callee_owned_eager_move__type_inferred_d2_s1 : $@convention(thin) (@owned InferredEagerD2S1) -> ()
+    %result = apply %callee_owned(%instance) : $@convention(thin) (@owned InferredEagerD2S1) -> ()
+    return %result : $()
+}
+
+// CHECK-LABEL: sil [ossa] @caller_owned_callee_owned_lexical : {{.*}} {
+// CHECK-NOT:     begin_borrow [lexical]
+// CHECK-LABEL: } // end sil function 'caller_owned_callee_owned_lexical'
+sil [ossa] @caller_owned_callee_owned_lexical : $@convention(thin) (@owned InferredEagerD2S1) -> () {
+entry(%instance : @owned $InferredEagerD2S1):
+    %callee_owned = function_ref @callee_owned_lexical : $@convention(thin) (@owned InferredEagerD2S1) -> ()
+    %result = apply %callee_owned(%instance) : $@convention(thin) (@owned InferredEagerD2S1) -> ()
+    return %result : $()
+}
+
 // CHECK-LABEL: sil [ossa] @caller_owned_callee_guaranteed : $@convention(thin) (@owned C) -> () {
 // CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @owned $C):
 // CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
@@ -68,6 +338,149 @@ entry(%instance : @owned $C):
     %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
     %result = apply %callee_guaranteed(%instance) : $@convention(thin) (@guaranteed C) -> ()
     destroy_value %instance : $C
+    return %result : $()
+}
+
+// CHECK-LABEL: sil [ossa] @caller_owned_callee_guaranteed_eager_move : $@convention(thin) (@owned C) -> () {
+// CHECK-NOT:     begin_borrow [lexical]
+// CHECK-LABEL: } // end sil function 'caller_owned_callee_guaranteed_eager_move'
+sil [ossa] @caller_owned_callee_guaranteed_eager_move : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+    %callee_guaranteed = function_ref @callee_guaranteed_eager_move : $@convention(thin) (@guaranteed C) -> ()
+    %result = apply %callee_guaranteed(%instance) : $@convention(thin) (@guaranteed C) -> ()
+    destroy_value %instance : $C
+    return %result : $()
+}
+
+// CHECK-LABEL: sil [ossa] @caller_owned_callee_guaranteed_eager_move__type_annotation : $@convention(thin) (@owned EagerC) -> () {
+// CHECK-NOT:     begin_borrow [lexical]
+// CHECK-LABEL: } // end sil function 'caller_owned_callee_guaranteed_eager_move__type_annotation'
+sil [ossa] @caller_owned_callee_guaranteed_eager_move__type_annotation : $@convention(thin) (@owned EagerC) -> () {
+entry(%instance : @owned $EagerC):
+    %callee_guaranteed = function_ref @callee_guaranteed_eager_move__type_annotation : $@convention(thin) (@guaranteed EagerC) -> ()
+    %result = apply %callee_guaranteed(%instance) : $@convention(thin) (@guaranteed EagerC) -> ()
+    destroy_value %instance : $EagerC
+    return %result : $()
+}
+
+// CHECK-LABEL: sil [ossa] @caller_owned_callee_guaranteed_eager_move__type_inferred_d1_s1 : $@convention(thin) (@owned InferredEagerD1S1) -> () {
+// CHECK-NOT:     begin_borrow [lexical]
+// CHECK-LABEL: } // end sil function 'caller_owned_callee_guaranteed_eager_move__type_inferred_d1_s1'
+sil [ossa] @caller_owned_callee_guaranteed_eager_move__type_inferred_d1_s1 : $@convention(thin) (@owned InferredEagerD1S1) -> () {
+entry(%instance : @owned $InferredEagerD1S1):
+    %callee_guaranteed = function_ref @callee_guaranteed_eager_move__type_inferred_d1_s1 : $@convention(thin) (@guaranteed InferredEagerD1S1) -> ()
+    %result = apply %callee_guaranteed(%instance) : $@convention(thin) (@guaranteed InferredEagerD1S1) -> ()
+    destroy_value %instance : $InferredEagerD1S1
+    return %result : $()
+}
+
+// CHECK-LABEL: sil [ossa] @caller_owned_callee_guaranteed_eager_move__type_inferred_d1_s2 : $@convention(thin) (@owned InferredEagerD1S2) -> () {
+// CHECK-NOT:     begin_borrow [lexical]
+// CHECK-LABEL: } // end sil function 'caller_owned_callee_guaranteed_eager_move__type_inferred_d1_s2'
+sil [ossa] @caller_owned_callee_guaranteed_eager_move__type_inferred_d1_s2 : $@convention(thin) (@owned InferredEagerD1S2) -> () {
+entry(%instance : @owned $InferredEagerD1S2):
+    %callee_guaranteed = function_ref @callee_guaranteed_eager_move__type_inferred_d1_s2 : $@convention(thin) (@guaranteed InferredEagerD1S2) -> ()
+    %result = apply %callee_guaranteed(%instance) : $@convention(thin) (@guaranteed InferredEagerD1S2) -> ()
+    destroy_value %instance : $InferredEagerD1S2
+    return %result : $()
+}
+
+// CHECK-LABEL: sil [ossa] @caller_owned_callee_guaranteed_eager_move__type_inferred_d1_s3 : $@convention(thin) (@owned InferredEagerD1S3) -> () {
+// CHECK-NOT:     begin_borrow [lexical]
+// CHECK-LABEL: } // end sil function 'caller_owned_callee_guaranteed_eager_move__type_inferred_d1_s3'
+sil [ossa] @caller_owned_callee_guaranteed_eager_move__type_inferred_d1_s3 : $@convention(thin) (@owned InferredEagerD1S3) -> () {
+entry(%instance : @owned $InferredEagerD1S3):
+    %callee_guaranteed = function_ref @callee_guaranteed_eager_move__type_inferred_d1_s3 : $@convention(thin) (@guaranteed InferredEagerD1S3) -> ()
+    %result = apply %callee_guaranteed(%instance) : $@convention(thin) (@guaranteed InferredEagerD1S3) -> ()
+    destroy_value %instance : $InferredEagerD1S3
+    return %result : $()
+}
+
+// CHECK-LABEL: sil [ossa] @caller_owned_callee_guaranteed_eager_move__type_inferred_d1_s4 : $@convention(thin) (@owned InferredEagerD1S4) -> () {
+// CHECK-NOT:     begin_borrow [lexical]
+// CHECK-LABEL: } // end sil function 'caller_owned_callee_guaranteed_eager_move__type_inferred_d1_s4'
+sil [ossa] @caller_owned_callee_guaranteed_eager_move__type_inferred_d1_s4 : $@convention(thin) (@owned InferredEagerD1S4) -> () {
+entry(%instance : @owned $InferredEagerD1S4):
+    %callee_guaranteed = function_ref @callee_guaranteed_eager_move__type_inferred_d1_s4 : $@convention(thin) (@guaranteed InferredEagerD1S4) -> ()
+    %result = apply %callee_guaranteed(%instance) : $@convention(thin) (@guaranteed InferredEagerD1S4) -> ()
+    destroy_value %instance : $InferredEagerD1S4
+    return %result : $()
+}
+
+// CHECK-LABEL: sil [ossa] @caller_owned_callee_guaranteed_eager_move__type_inferred_d2_s1 : $@convention(thin) (@owned InferredEagerD2S1) -> () {
+// CHECK-NOT:     begin_borrow [lexical]
+// CHECK-LABEL: } // end sil function 'caller_owned_callee_guaranteed_eager_move__type_inferred_d2_s1'
+sil [ossa] @caller_owned_callee_guaranteed_eager_move__type_inferred_d2_s1 : $@convention(thin) (@owned InferredEagerD2S1) -> () {
+entry(%instance : @owned $InferredEagerD2S1):
+    %callee_guaranteed = function_ref @callee_guaranteed_eager_move__type_inferred_d2_s1 : $@convention(thin) (@guaranteed InferredEagerD2S1) -> ()
+    %result = apply %callee_guaranteed(%instance) : $@convention(thin) (@guaranteed InferredEagerD2S1) -> ()
+    destroy_value %instance : $InferredEagerD2S1
+    return %result : $()
+}
+
+// CHECK-LABEL: sil [ossa] @caller_owned_callee_guaranteed_lexical : {{.*}} {
+// CHECK:         begin_borrow [lexical]
+// CHECK-LABEL: } // end sil function 'caller_owned_callee_guaranteed_lexical'
+sil [ossa] @caller_owned_callee_guaranteed_lexical : $@convention(thin) (@owned InferredEagerD2S1) -> () {
+entry(%instance : @owned $InferredEagerD2S1):
+    %callee_guaranteed = function_ref @callee_guaranteed_lexical : $@convention(thin) (@guaranteed InferredEagerD2S1) -> ()
+    %result = apply %callee_guaranteed(%instance) : $@convention(thin) (@guaranteed InferredEagerD2S1) -> ()
+    destroy_value %instance : $InferredEagerD2S1
+    return %result : $()
+}
+
+// CHECK-LABEL: sil [ossa] @caller_owned_callee_guaranteed_lexical__type_annotation : {{.*}} {
+// CHECK:         begin_borrow [lexical]
+// CHECK-LABEL: } // end sil function 'caller_owned_callee_guaranteed_lexical__type_annotation'
+sil [ossa] @caller_owned_callee_guaranteed_lexical__type_annotation : $@convention(thin) (@owned LexicalS) -> () {
+entry(%instance : @owned $LexicalS):
+    %callee_guaranteed = function_ref @callee_guaranteed_lexical__type_annotation : $@convention(thin) (@guaranteed LexicalS) -> ()
+    %result = apply %callee_guaranteed(%instance) : $@convention(thin) (@guaranteed LexicalS) -> ()
+    destroy_value %instance : $LexicalS
+    return %result : $()
+}
+
+// CHECK-LABEL: sil [ossa] @caller_owned_callee_guaranteed_lexical__type_inferred_d1_s1 : {{.*}} {
+// CHECK:         begin_borrow [lexical]
+// CHECK-LABEL: } // end sil function 'caller_owned_callee_guaranteed_lexical__type_inferred_d1_s1'
+sil [ossa] @caller_owned_callee_guaranteed_lexical__type_inferred_d1_s1 : $@convention(thin) (@owned InferredLexicalD1S1) -> () {
+entry(%instance : @owned $InferredLexicalD1S1):
+    %callee_guaranteed = function_ref @callee_guaranteed_lexical__type_inferred_d1_s1 : $@convention(thin) (@guaranteed InferredLexicalD1S1) -> ()
+    %result = apply %callee_guaranteed(%instance) : $@convention(thin) (@guaranteed InferredLexicalD1S1) -> ()
+    destroy_value %instance : $InferredLexicalD1S1
+    return %result : $()
+}
+
+// CHECK-LABEL: sil [ossa] @caller_owned_callee_guaranteed_lexical__type_inferred_d1_s2 : {{.*}} {
+// CHECK:         begin_borrow [lexical]
+// CHECK-LABEL: } // end sil function 'caller_owned_callee_guaranteed_lexical__type_inferred_d1_s2'
+sil [ossa] @caller_owned_callee_guaranteed_lexical__type_inferred_d1_s2 : $@convention(thin) (@owned InferredLexicalD1S2) -> () {
+entry(%instance : @owned $InferredLexicalD1S2):
+    %callee_guaranteed = function_ref @callee_guaranteed_lexical__type_inferred_d1_s2 : $@convention(thin) (@guaranteed InferredLexicalD1S2) -> ()
+    %result = apply %callee_guaranteed(%instance) : $@convention(thin) (@guaranteed InferredLexicalD1S2) -> ()
+    destroy_value %instance : $InferredLexicalD1S2
+    return %result : $()
+}
+
+// CHECK-LABEL: sil [ossa] @caller_owned_callee_guaranteed_lexical__type_inferred_d1_s3 : {{.*}} {
+// CHECK:         begin_borrow [lexical]
+// CHECK-LABEL: } // end sil function 'caller_owned_callee_guaranteed_lexical__type_inferred_d1_s3'
+sil [ossa] @caller_owned_callee_guaranteed_lexical__type_inferred_d1_s3 : $@convention(thin) (@owned InferredLexicalD1S3) -> () {
+entry(%instance : @owned $InferredLexicalD1S3):
+    %callee_guaranteed = function_ref @callee_guaranteed_lexical__type_inferred_d1_s3 : $@convention(thin) (@guaranteed InferredLexicalD1S3) -> ()
+    %result = apply %callee_guaranteed(%instance) : $@convention(thin) (@guaranteed InferredLexicalD1S3) -> ()
+    destroy_value %instance : $InferredLexicalD1S3
+    return %result : $()
+}
+
+// CHECK-LABEL: sil [ossa] @caller_owned_callee_guaranteed_lexical__type_inferred_d1_s4 : {{.*}} {
+// CHECK:         begin_borrow [lexical]
+// CHECK-LABEL: } // end sil function 'caller_owned_callee_guaranteed_lexical__type_inferred_d1_s4'
+sil [ossa] @caller_owned_callee_guaranteed_lexical__type_inferred_d1_s4 : $@convention(thin) (@owned InferredLexicalD1S4) -> () {
+entry(%instance : @owned $InferredLexicalD1S4):
+    %callee_guaranteed = function_ref @callee_guaranteed_lexical__type_inferred_d1_s4 : $@convention(thin) (@guaranteed InferredLexicalD1S4) -> ()
+    %result = apply %callee_guaranteed(%instance) : $@convention(thin) (@guaranteed InferredLexicalD1S4) -> ()
+    destroy_value %instance : $InferredLexicalD1S4
     return %result : $()
 }
 
@@ -85,6 +498,16 @@ entry(%instance : @guaranteed $C):
     return %result : $()
 }
 
+// CHECK-LABEL: sil [ossa] @caller_guaranteed_callee_guaranteed_eager_move : $@convention(thin) (@guaranteed C) -> () {
+// CHECK-NOT:     begin_borrow [lexical]
+// CHECK-LABEL: } // end sil function 'caller_guaranteed_callee_guaranteed_eager_move'
+sil [ossa] @caller_guaranteed_callee_guaranteed_eager_move : $@convention(thin) (@guaranteed C) -> () {
+entry(%instance : @guaranteed $C):
+    %callee_guaranteed = function_ref @callee_guaranteed_eager_move : $@convention(thin) (@guaranteed C) -> ()
+    %result = apply %callee_guaranteed(%instance) : $@convention(thin) (@guaranteed C) -> ()
+    return %result : $()
+}
+
 // CHECK-LABEL: sil [ossa] @caller_guaranteed_callee_owned : $@convention(thin) (@guaranteed C) -> () {
 // CHECK-NOT:     begin_borrow [lexical]
 // CHECK-LABEL: } // end sil function 'caller_guaranteed_callee_owned'
@@ -92,6 +515,17 @@ sil [ossa] @caller_guaranteed_callee_owned : $@convention(thin) (@guaranteed C) 
 entry(%instance : @guaranteed $C):
     %copy = copy_value %instance : $C
     %callee_owned = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
+    %result = apply %callee_owned(%copy) : $@convention(thin) (@owned C) -> ()
+    return %result : $()
+}
+
+// CHECK-LABEL: sil [ossa] @caller_guaranteed_callee_owned_eager_move : $@convention(thin) (@guaranteed C) -> () {
+// CHECK-NOT:     begin_borrow [lexical]
+// CHECK-LABEL: } // end sil function 'caller_guaranteed_callee_owned_eager_move'
+sil [ossa] @caller_guaranteed_callee_owned_eager_move : $@convention(thin) (@guaranteed C) -> () {
+entry(%instance : @guaranteed $C):
+    %copy = copy_value %instance : $C
+    %callee_owned = function_ref @callee_owned_eager_move : $@convention(thin) (@owned C) -> ()
     %result = apply %callee_owned(%copy) : $@convention(thin) (@owned C) -> ()
     return %result : $()
 }

--- a/test/attr/lexical.swift
+++ b/test/attr/lexical.swift
@@ -1,0 +1,31 @@
+// RUN: %target-typecheck-verify-swift
+
+struct S {}
+
+class C {}
+
+enum E {}
+
+@_eagerMove // expected-error {{'@_eagerMove' attribute cannot be applied to this declaration}}
+typealias EagerTuple = (C, C)
+
+func foo(@_lexical @_eagerMove _ e: E) {} // expected-error {{@_eagerMove and @_lexical attributes are alternate styles of lifetimes and can't be combined}}
+
+func bar(@_lexical _ s: S) {} // okay
+
+func baz(@_eagerMove _ c: C) {} // okay
+
+struct S2 {
+  @_eagerMove let c: C // okay
+  @_lexical let e: E // okay
+}
+
+func foo() {
+  @_lexical let s1 = S()
+  @_eagerMove var s2 = S()
+  @_lexical @_eagerMove let s3 = S() // expected-error {{@_eagerMove and @_lexical attributes are alternate styles of lifetimes and can't be combined}}
+  _ = s1
+  s2 = S()
+  _ = s2
+  _ = s3
+}


### PR DESCRIPTION
Add a new underscored attribute `@_eagerMove` (and also `@_lexical`) to indicate that a value or type should have an eager move lifetime (or a lexical lifetime if it would otherwise be eager move).

Update SILGen to only emit lexical borrow scopes for values which are not eager move.

Add these same attributes to `SILFunctionArgument`.  SILGen emits the lexical borrow scopes according to a variable's lifetime, but it doesn't emit lexical borrow scopes for arguments†.  In order for optimizations (CopyPropagation, SSADestroyHoisting, Inlining) to respect the lifetimes of arguments, the annotations those arguments received have to be available.

Updated CopyPropagation (indirectly, by way of `SILValue::isLexical`), SSADestroyHoisting, and SILInliner to respect these annotations.

† Currently lexical borrows are emitted for owned arguments, but that is superfluous and will be removed in an upcoming PR.

rdar://90411492
