### PR TITLE
SIL: Don't eagerly erase instructions in builder peepholes.

### DIFF
--- a/lib/SIL/IR/SILBuilder.cpp
+++ b/lib/SIL/IR/SILBuilder.cpp
@@ -480,16 +480,12 @@ SILBuilder::emitDestroyValue(SILLocation Loc, SILValue Operand) {
 
 SILValue SILBuilder::emitThickToObjCMetatype(SILLocation Loc, SILValue Op,
                                              SILType Ty) {
-  // If the operand is an otherwise-unused 'metatype' instruction in the
-  // same basic block, zap it and create a 'metatype' instruction that
-  // directly produces an Objective-C metatype.
+  // If the operand is a 'metatype' instruction accessing a known static type's
+  // metadata, create a 'metatype' instruction that
+  // directly produces the Objective-C class object representation instead.
   if (auto metatypeInst = dyn_cast<MetatypeInst>(Op)) {
-    if (metatypeInst->use_empty() &&
-        metatypeInst->getParent() == getInsertionBB()) {
-      auto origLoc = metatypeInst->getLoc();
-      metatypeInst->eraseFromParent();
-      return createMetatype(origLoc, Ty);
-    }
+    auto origLoc = metatypeInst->getLoc();
+    return createMetatype(origLoc, Ty);
   }
 
   // Just create the thick_to_objc_metatype instruction.
@@ -498,16 +494,12 @@ SILValue SILBuilder::emitThickToObjCMetatype(SILLocation Loc, SILValue Op,
 
 SILValue SILBuilder::emitObjCToThickMetatype(SILLocation Loc, SILValue Op,
                                              SILType Ty) {
-  // If the operand is an otherwise-unused 'metatype' instruction in the
-  // same basic block, zap it and create a 'metatype' instruction that
-  // directly produces a thick metatype.
+  // If the operand is a 'metatype' instruction accessing a known static type's
+  // metadata, create a 'metatype' instruction that directly produces the
+  // Swift metatype representation instead.
   if (auto metatypeInst = dyn_cast<MetatypeInst>(Op)) {
-    if (metatypeInst->use_empty() &&
-        metatypeInst->getParent() == getInsertionBB()) {
-      auto origLoc = metatypeInst->getLoc();
-      metatypeInst->eraseFromParent();
-      return createMetatype(origLoc, Ty);
-    }
+    auto origLoc = metatypeInst->getLoc();
+    return createMetatype(origLoc, Ty);
   }
 
   // Just create the objc_to_thick_metatype instruction.

--- a/test/SILGen/use_thick_metatype_after_objc.swift
+++ b/test/SILGen/use_thick_metatype_after_objc.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen -enable-implicit-dynamic -verify %s
+// rdar://98418860
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+@propertyWrapper
+struct ExamplePropertyWrapper {
+    var wrappedValue: Bool = false
+}
+
+@objcMembers
+class ExampleClass {
+    @ExamplePropertyWrapper
+    static var exampleProperty: Bool
+}
+
+class ExampleCallingClass {
+    func exampleSegfaultingCall() {
+        ExampleClass.exampleProperty.toggle()
+    }
+}


### PR DESCRIPTION
Even if the operand doesn't currently have any uses after the peephole, the
caller may intend to use the operand for other purposes. If the operand is
really unused in the end, then dead code elimination ought to clean it up.
Fixes rdar://98418860.