### PR TITLE
IRGen: Fix shift amount in typelayout lowering of mulipayload enums to bits

### DIFF
--- a/lib/IRGen/TypeLayout.cpp
+++ b/lib/IRGen/TypeLayout.cpp
@@ -2398,7 +2398,7 @@ void EnumTypeLayoutEntry::storeEnumTagMultipayload(IRGenFunction &IGF,
   //   } else {
   //     unsigned numPayloadBits = layout.payloadSize * CHAR_BIT;
   //     whichTag = numPayloads + (whichEmptyCase >> numPayloadBits);
-  //     whichPayloadValue = whichEmptyCase & ((1U << numPayloads) - 1U);
+  //     whichPayloadValue = whichEmptyCase & ((1U << numPayloadBits) - 1U);
   //   }
   //   storeMultiPayloadTag(value, layout, whichTag);
   //   storeMultiPayloadValue(value, layout, whichPayloadValue);
@@ -2444,7 +2444,7 @@ void EnumTypeLayoutEntry::storeEnumTagMultipayload(IRGenFunction &IGF,
     whichTag->addIncoming(tmp2, Builder.GetInsertBlock());
 
     auto tmp3 = Builder.CreateSub(
-        Builder.CreateShl(IGM.getInt32(1), numPayloads), IGM.getInt32(1));
+        Builder.CreateShl(IGM.getInt32(1), numPayloadBits), IGM.getInt32(1));
     auto tmp4 = Builder.CreateAnd(whichEmptyCase, tmp3);
     whichPayloadValue->addIncoming(tmp4, Builder.GetInsertBlock());
     Builder.CreateBr(storeBB);

--- a/test/Interpreter/Inputs/resilient_multipayload_enum.swift
+++ b/test/Interpreter/Inputs/resilient_multipayload_enum.swift
@@ -1,0 +1,9 @@
+public enum ProblematicEnumeration<T> {
+  case zero(T)
+  case one(Bool)
+  case two
+  case three
+  case four
+  case five
+  case six
+}

--- a/test/Interpreter/resilient_multipayload_enum.swift
+++ b/test/Interpreter/resilient_multipayload_enum.swift
@@ -1,0 +1,32 @@
+// Build unoptimized library
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(ResilientEnum)) -enable-library-evolution %S/Inputs/resilient_multipayload_enum.swift -emit-module -emit-module-path %t/ResilientEnum.swiftmodule -module-name ResilientEnum
+// RUN: %target-codesign %t/%target-library-name(ResilientEnum)
+// RUN: %target-build-swift %s -lResilientEnum -I %t -L %t -o %t/main %target-rpath(%t)
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main %t/%target-library-name(ResilientEnum) | %FileCheck %s
+
+// Build optimized library (this exercises a different value witness generation path)
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(ResilientEnum)) -enable-library-evolution %S/Inputs/resilient_multipayload_enum.swift -emit-module -emit-module-path %t/ResilientEnum.swiftmodule -module-name ResilientEnum -O
+// RUN: %target-codesign %t/%target-library-name(ResilientEnum)
+// RUN: %target-build-swift %s -lResilientEnum -I %t -L %t -o %t/main %target-rpath(%t)
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main %t/%target-library-name(ResilientEnum) | %FileCheck %s
+
+import ResilientEnum
+
+@inline(never)
+@_semantics("optimize.sil.specialize.generic.never")
+func dump<T>(_ t: T) {
+    print(t)
+}
+
+@inline(never)
+func doit() {
+  let e = ProblematicEnumeration<Bool>.six
+  // CHECK: six
+  dump(e)
+}
+
+doit()


### PR DESCRIPTION
Transfer the fix in #42131 to the typelayout lowering code. Noticed as part of
investigating the fix for #60590.
