### PR TITLE
[Serialization] Suggest a solution path for modified swiftmodules causing deserialization failures

### DIFF
--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -564,6 +564,8 @@ void ModuleFileSharedCore::fatal(llvm::Error error) const {
   llvm::raw_svector_ostream out(errorStr);
 
   out << "*** DESERIALIZATION FAILURE ***\n";
+  out << "*** If any module named here was modified in the SDK, please delete the ***\n";
+  out << "*** new swiftmodule files from the SDK and keep only swiftinterfaces.   ***\n";
   outputDiagnosticInfo(out);
   out << "\n";
   if (error) {

--- a/test/Serialization/Recovery/crash-recovery.swift
+++ b/test/Serialization/Recovery/crash-recovery.swift
@@ -17,5 +17,7 @@ public class Sub: Base {
 // CHECK-CRASH-4_2: Compiling with effective version 4.2
 // CHECK-CRASH: While loading members for 'Sub' (in module 'Lib')
 // CHECK-CRASH-LABEL: *** DESERIALIZATION FAILURE ***
+// CHECK-CRASH-LABEL: *** If any module named here was modified in the SDK, please delete the ***
+// CHECK-CRASH-LABEL: *** new swiftmodule files from the SDK and keep only swiftinterfaces.   ***
 // CHECK-CRASH: module 'Lib' with full misc version {{.*}}4.1.50
 // CHECK-CRASH: could not find 'disappearingMethod()' in parent class

--- a/test/Serialization/Recovery/crash-xref.swift
+++ b/test/Serialization/Recovery/crash-xref.swift
@@ -23,6 +23,8 @@
 
 // RUN: cat %t/normal_stderr | %FileCheck %s -check-prefixes=NORMALFAILURE
 // NORMALFAILURE-LABEL: *** DESERIALIZATION FAILURE ***
+// NORMALFAILURE-LABEL: *** If any module named here was modified in the SDK, please delete the ***
+// NORMALFAILURE-LABEL: *** new swiftmodule files from the SDK and keep only swiftinterfaces.   ***
 // NORMALFAILURE-NEXT: module 'Client' with full misc version {{.*}}'
 // NORMALFAILURE-NEXT: Could not deserialize type for 'foo()'
 // NORMALFAILURE-NEXT: Caused by: top-level value not found
@@ -33,6 +35,8 @@
 
 // RUN: cat %t/error_stderr | %FileCheck %s -check-prefixes=ALLOWFAILURE
 // ALLOWFAILURE-LABEL: *** DESERIALIZATION FAILURE ***
+// ALLOWFAILURE-LABEL: *** If any module named here was modified in the SDK, please delete the ***
+// ALLOWFAILURE-LABEL: *** new swiftmodule files from the SDK and keep only swiftinterfaces.   ***
 // ALLOWFAILURE-NEXT: module 'Client' with full misc version {{.*}}' (built with -experimental-allow-module-with-compiler-errors)
 // ALLOWFAILURE-NEXT: Could not deserialize type for 'foo()'
 // ALLOWFAILURE-NEXT: Caused by: top-level value not found


### PR DESCRIPTION
A large portion of deserialization failures at this points are caused by roots installed over the SDK. Let's extend the error message with a solution for such a case.

rdar://86280699