### PR TITLE
[stdlib] add overflow checks for some pointer arithmetic

### DIFF
--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -371,6 +371,11 @@ public struct UnsafePointer<Pointee>: _Pointer {
     to property: KeyPath<Pointee, Property>
   ) -> UnsafePointer<Property>? {
     guard let o = property._storedInlineOffset else { return nil }
+    _internalInvariant(o >= 0)
+    _debugPrecondition(
+      o == 0 || UnsafeRawPointer(self) < UnsafeRawPointer(bitPattern: 0 &- o)!,
+      "Overflow in pointer arithmetic"
+    )
     return .init(Builtin.gepRaw_Word(_rawValue, o._builtinWordValue))
   }
 
@@ -1088,6 +1093,11 @@ public struct UnsafeMutablePointer<Pointee>: _Pointer {
     to property: KeyPath<Pointee, Property>
   ) -> UnsafePointer<Property>? {
     guard let o = property._storedInlineOffset else { return nil }
+    _internalInvariant(o >= 0)
+    _debugPrecondition(
+      o == 0 || UnsafeRawPointer(self) < UnsafeRawPointer(bitPattern: 0 &- o)!,
+      "Overflow in pointer arithmetic"
+    )
     return .init(Builtin.gepRaw_Word(_rawValue, o._builtinWordValue))
   }
 
@@ -1105,6 +1115,11 @@ public struct UnsafeMutablePointer<Pointee>: _Pointer {
     to property: WritableKeyPath<Pointee, Property>
   ) -> UnsafeMutablePointer<Property>? {
     guard let o = property._storedInlineOffset else { return nil }
+    _internalInvariant(o >= 0)
+    _debugPrecondition(
+      o == 0 || UnsafeRawPointer(self) < UnsafeRawPointer(bitPattern: 0 &- o)!,
+      "Overflow in pointer arithmetic"
+    )
     return .init(Builtin.gepRaw_Word(_rawValue, o._builtinWordValue))
   }
 

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -499,6 +499,7 @@ extension UnsafeRawPointer {
   public func alignedUp<T>(for type: T.Type) -> Self {
     let mask = UInt(Builtin.alignof(T.self)) &- 1
     let bits = (UInt(Builtin.ptrtoint_Word(_rawValue)) &+ mask) & ~mask
+    _debugPrecondition(bits != 0, "Overflow in pointer arithmetic")
     return .init(Builtin.inttoptr_Word(bits._builtinWordValue))
   }
 
@@ -515,6 +516,7 @@ extension UnsafeRawPointer {
   public func alignedDown<T>(for type: T.Type) -> Self {
     let mask = UInt(Builtin.alignof(T.self)) &- 1
     let bits = UInt(Builtin.ptrtoint_Word(_rawValue)) & ~mask
+    _debugPrecondition(bits != 0, "Overflow in pointer arithmetic")
     return .init(Builtin.inttoptr_Word(bits._builtinWordValue))
   }
 
@@ -536,6 +538,7 @@ extension UnsafeRawPointer {
       "alignment must be a whole power of 2."
     )
     let bits = (UInt(Builtin.ptrtoint_Word(_rawValue)) &+ mask) & ~mask
+    _debugPrecondition(bits != 0, "Overflow in pointer arithmetic")
     return .init(Builtin.inttoptr_Word(bits._builtinWordValue))
   }
 
@@ -557,6 +560,7 @@ extension UnsafeRawPointer {
       "alignment must be a whole power of 2."
     )
     let bits = UInt(Builtin.ptrtoint_Word(_rawValue)) & ~mask
+    _debugPrecondition(bits != 0, "Overflow in pointer arithmetic")
     return .init(Builtin.inttoptr_Word(bits._builtinWordValue))
   }
 }
@@ -1351,6 +1355,7 @@ extension UnsafeMutableRawPointer {
   public func alignedUp<T>(for type: T.Type) -> Self {
     let mask = UInt(Builtin.alignof(T.self)) &- 1
     let bits = (UInt(Builtin.ptrtoint_Word(_rawValue)) &+ mask) & ~mask
+    _debugPrecondition(bits != 0, "Overflow in pointer arithmetic")
     return .init(Builtin.inttoptr_Word(bits._builtinWordValue))
   }
 
@@ -1367,6 +1372,7 @@ extension UnsafeMutableRawPointer {
   public func alignedDown<T>(for type: T.Type) -> Self {
     let mask = UInt(Builtin.alignof(T.self)) &- 1
     let bits = UInt(Builtin.ptrtoint_Word(_rawValue)) & ~mask
+    _debugPrecondition(bits != 0, "Overflow in pointer arithmetic")
     return .init(Builtin.inttoptr_Word(bits._builtinWordValue))
   }
 
@@ -1388,6 +1394,7 @@ extension UnsafeMutableRawPointer {
       "alignment must be a whole power of 2."
     )
     let bits = (UInt(Builtin.ptrtoint_Word(_rawValue)) &+ mask) & ~mask
+    _debugPrecondition(bits != 0, "Overflow in pointer arithmetic")
     return .init(Builtin.inttoptr_Word(bits._builtinWordValue))
   }
 
@@ -1409,6 +1416,7 @@ extension UnsafeMutableRawPointer {
       "alignment must be a whole power of 2."
     )
     let bits = UInt(Builtin.ptrtoint_Word(_rawValue)) & ~mask
+    _debugPrecondition(bits != 0, "Overflow in pointer arithmetic")
     return .init(Builtin.inttoptr_Word(bits._builtinWordValue))
   }
 }

--- a/test/stdlib/UnsafePointer.swift.gyb
+++ b/test/stdlib/UnsafePointer.swift.gyb
@@ -537,6 +537,28 @@ ${SelfName}TestSuite.test("pointer(to:)") {
 % end
 }
 
+${SelfName}TestSuite.test("pointer(to:).overflow") {
+  struct Example {
+    var a = false
+    var b = 0
+    var c: String { "\(a),\(b)" }
+    var d = 0.0
+  }
+  let o = MemoryLayout<Example>.offset(of: \.b)!
+  let p = UnsafePointer<Example>(bitPattern: -o)
+  expectNotNil(p)
+  guard let p else { fatalError() }
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  let intPointer = p.pointer(to: \.b)
+  expectNil(intPointer) // nil because of overflow
+  let stringPointer = p.pointer(to: \.c)
+  expectNil(stringPointer) // nil because c is a computed property
+  let doublePointer = p.pointer(to: \.d)
+  expectNotNil(doublePointer)
+}
+
 % end
 
 runAllTests()

--- a/validation-test/stdlib/UnsafeRawPointerInternal.swift
+++ b/validation-test/stdlib/UnsafeRawPointerInternal.swift
@@ -58,4 +58,76 @@ UnsafeRawPointerTestSuite.test("load.unaligned.largeAlignment.mutablePointer")
   }
 }
 
+UnsafeRawPointerTestSuite.test("alignedUp.for.overflow") {
+  let p = UnsafeRawPointer(bitPattern: 1-MemoryLayout<Int>.stride)!
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  let up = p.alignedUp(for: Int.self)
+  expectEqual(Int(bitPattern: up), 0)
+}
+
+UnsafeRawPointerTestSuite.test("alignedUp.toMultiple.overflow") {
+  let p = UnsafeRawPointer(bitPattern: -7)!
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  let up = p.alignedUp(toMultipleOf: 8)
+  expectEqual(Int(bitPattern: up), 0)
+}
+
+UnsafeRawPointerTestSuite.test("alignedUp.for.overflow") {
+  let p = UnsafeRawPointer(bitPattern: MemoryLayout<Int64>.stride-1)!
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  let up = p.alignedDown(for: Int64.self)
+  expectEqual(Int(bitPattern: up), 0)
+}
+
+UnsafeRawPointerTestSuite.test("alignedUp.toMultiple.overflow") {
+  let p = UnsafeRawPointer(bitPattern: 13)!
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  let up = p.alignedDown(toMultipleOf: 16)
+  expectEqual(Int(bitPattern: up), 0)
+}
+
+UnsafeRawPointerTestSuite.test("alignedUp.for.overflow.mutable") {
+  let p = UnsafeMutableRawPointer(bitPattern: 1-MemoryLayout<Int>.stride)!
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  let up = p.alignedUp(for: Int.self)
+  expectEqual(Int(bitPattern: up), 0)
+}
+
+UnsafeRawPointerTestSuite.test("alignedUp.toMultiple.overflow.mutable") {
+  let p = UnsafeMutableRawPointer(bitPattern: -7)!
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  let up = p.alignedUp(toMultipleOf: 8)
+  expectEqual(Int(bitPattern: up), 0)
+}
+
+UnsafeRawPointerTestSuite.test("alignedUp.for.overflow.mutable") {
+  let p = UnsafeMutableRawPointer(bitPattern: MemoryLayout<Int64>.stride-1)!
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  let up = p.alignedDown(for: Int64.self)
+  expectEqual(Int(bitPattern: up), 0)
+}
+
+UnsafeRawPointerTestSuite.test("alignedUp.toMultiple.overflow.mutable") {
+  let p = UnsafeMutableRawPointer(bitPattern: 13)!
+  if _isDebugAssertConfiguration() {
+    expectCrashLater()
+  }
+  let up = p.alignedDown(toMultipleOf: 16)
+  expectEqual(Int(bitPattern: up), 0)
+}
+
 runAllTests()


### PR DESCRIPTION
- Pointer arithmetic uses operations that can overflow.
- This adds overflow checks added for recent additions to pointer arithmetic (rounding and property pointers).
- The basic `advanced(by:)` functions will be dealt with separately.
