### PR TITLE
[move-keyword] Make sure we error correctly on f(_move y, &y) and f(&y, _move y)

### DIFF
--- a/test/SILOptimizer/move_function_kills_copyable_addresses.sil
+++ b/test/SILOptimizer/move_function_kills_copyable_addresses.sil
@@ -1,0 +1,39 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -o - -sil-move-kills-copyable-addresses-checker -verify %s
+
+// This file is meant for specific SIL patterns that may be hard to produce with
+// the current swift frontend but have reproduced before and we want to make
+// sure keep on working.
+
+sil_stage raw
+
+class Klass {}
+
+sil @useTwice : $@convention(thin) (@guaranteed Klass, @inout Klass) -> ()
+
+sil hidden [ossa] @$s4test3fooyyAA5KlassCnF : $@convention(thin) (@owned Klass) -> () {
+bb0(%0 : @owned $Klass):
+  %1 = begin_borrow [lexical] %0 : $Klass
+  debug_value %1 : $Klass, let, name "k", argno 1
+  %3 = alloc_stack [lexical] $Klass, var, name "k2" // expected-error {{'k2' used after being moved}}
+  %4 = copy_value %1 : $Klass
+  %5 = move_value [allows_diagnostics] %4 : $Klass
+  store %5 to [init] %3 : $*Klass
+  %7 = begin_access [modify] [static] %3 : $*Klass
+  %8 = alloc_stack $Klass
+  mark_unresolved_move_addr %7 to %8 : $*Klass // expected-note {{move here}}
+  %10 = load [copy] %8 : $*Klass
+  destroy_addr %8 : $*Klass
+  end_access %7 : $*Klass
+  %13 = begin_access [modify] [static] %3 : $*Klass
+  %14 = function_ref @useTwice : $@convention(thin) (@guaranteed Klass, @inout Klass) -> ()
+  %15 = apply %14(%10, %13) : $@convention(thin) (@guaranteed Klass, @inout Klass) -> () // expected-note {{use here}}
+  end_access %13 : $*Klass
+  destroy_value %10 : $Klass
+  dealloc_stack %8 : $*Klass
+  destroy_addr %3 : $*Klass
+  dealloc_stack %3 : $*Klass
+  end_borrow %1 : $Klass
+  destroy_value %0 : $Klass
+  %23 = tuple ()
+  return %23 : $()
+}

--- a/test/SILOptimizer/move_function_kills_copyable_addressonly_vars.swift
+++ b/test/SILOptimizer/move_function_kills_copyable_addressonly_vars.swift
@@ -688,3 +688,19 @@ func reinitInPieces1<T : P>(_ k: ProtPair<T>) {
     k2.lhs = selfType.getP()
     k2.rhs = selfType.getP()
 }
+
+////////////////////////
+// InOut and Use Test //
+////////////////////////
+
+func useValueAndInOut<T>(_ x: T, _ y: inout T) {}
+func useValueAndInOut<T>(_ x: inout T, _ y: T) {}
+
+func inoutAndUseTest<T>(_ x: T) {
+    var y = x // expected-error {{'y' used after being moved}}
+              // expected-error @-1 {{'y' used after being moved}}
+    useValueAndInOut(_move y, &y) // expected-note {{use here}}
+                                  // expected-note @-1 {{move here}}
+    useValueAndInOut(&y, _move y) // expected-note {{use here}}
+                                  // expected-note @-1 {{move here}}
+}

--- a/test/SILOptimizer/move_function_kills_copyable_loadable_vars.swift
+++ b/test/SILOptimizer/move_function_kills_copyable_loadable_vars.swift
@@ -729,3 +729,19 @@ func reinitInPieces1(_ k: KlassPair) {
     k2.lhs = Klass()
     k2.rhs = Klass()
 }
+
+////////////////////////
+// InOut and Use Test //
+////////////////////////
+
+func useValueAndInOut(_ x: Klass, _ y: inout Klass) {}
+func useValueAndInOut(_ x: inout Klass, _ y: Klass) {}
+
+func inoutAndUseTest(_ x: Klass) {
+    var y = x // expected-error {{'y' used after being moved}}
+              // expected-error @-1 {{'y' used after being moved}}
+    useValueAndInOut(_move y, &y) // expected-note {{use here}}
+                                  // expected-note @-1 {{move here}}
+    useValueAndInOut(&y, _move y) // expected-note {{use here}}
+                                  // expected-note @-1 {{move here}}
+}


### PR DESCRIPTION
This was actually crashing on the inout use since I at some point changed the
isReinit code to use a more general routine to determine that which was
incorrect. Instead, this is actually trying to recognize reinits that we know
how to change into a non-reinit form (e.x.: store [assign] -> store [init]).
Since the inout use was not handled by the convert reinit to init code, we
crashed.

Now we get the correct behavior since the access to y always occurs /before/ the
formal evaluation of the inout.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves SR-NNNN.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
