### PR TITLE
Warn on implicit pointer conversion from nontrivial inout values.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -748,5 +748,12 @@ ERROR(sil_movekillscopyablevalue_move_applied_to_unsupported_move, none,
       "_move applied to value that the compiler does not support checking",
       ())
 
+// Implicit inout-to-UnsafeRawPointer conversions
+WARNING(nontrivial_to_rawpointer_conversion,none,
+        "cannot implicitly convert an %select{inout value|array}0 of type %1 "
+        "to expected argument type %2 because %1 may contain an object "
+        "reference. Consider using a 'withUnsafeBytes' API instead.",
+        (bool, Type, Type))
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -749,7 +749,7 @@ ERROR(sil_movekillscopyablevalue_move_applied_to_unsupported_move, none,
       ())
 
 // Implicit inout-to-UnsafeRawPointer conversions
-WARNING(nontrivial_to_rawpointer_conversion,none,
+ERROR(nontrivial_to_rawpointer_conversion,none,
         "cannot implicitly convert an %select{inout value|array}0 of type %1 "
         "to expected argument type %2 because %1 may contain an object "
         "reference. Consider using a 'withUnsafeBytes' API instead.",

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -752,7 +752,7 @@ ERROR(sil_movekillscopyablevalue_move_applied_to_unsupported_move, none,
 ERROR(nontrivial_to_rawpointer_conversion,none,
         "cannot implicitly convert an %select{inout value|array}0 of type %1 "
         "to expected argument type %2 because %1 may contain an object "
-        "reference. Consider using a 'withUnsafeBytes' API instead.",
+        "reference.",
         (bool, Type, Type))
 
 #define UNDEFINE_DIAGNOSTIC_MACROS

--- a/test/SILGen/pointer_conversion.swift
+++ b/test/SILGen/pointer_conversion.swift
@@ -20,6 +20,7 @@ func takesMutableRawPointer(_ x: UnsafeMutableRawPointer) {}
 func takesConstRawPointer(_ x: UnsafeRawPointer) {}
 func takesOptConstRawPointer(_ x: UnsafeRawPointer?, and: Int) {}
 func takesOptOptConstRawPointer(_ x: UnsafeRawPointer??, and: Int) {}
+func takesMutableFunctionPointer(_ x: UnsafeMutablePointer<() -> Void>) {}
 
 // CHECK-LABEL: sil hidden [ossa] @$s18pointer_conversion0A9ToPointeryySpySiG_SPySiGSvtF
 // CHECK: bb0([[MP:%.*]] : $UnsafeMutablePointer<Int>, [[CP:%.*]] : $UnsafePointer<Int>, [[MRP:%.*]] : $UnsafeMutableRawPointer):
@@ -272,7 +273,7 @@ func functionInoutToPointer() {
 
   // CHECK: [[REABSTRACT_BUF:%.*]] = alloc_stack $@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <()>
   // CHECK: address_to_pointer [[REABSTRACT_BUF]]
-  takesMutableVoidPointer(&f)
+  takesMutableFunctionPointer(&f)
 }
 
 // rdar://problem/31781386

--- a/validation-test/stdlib/UnicodeUTFEncoders.swift
+++ b/validation-test/stdlib/UnicodeUTFEncoders.swift
@@ -84,14 +84,17 @@ func nsEncode<CodeUnit>(
     length: 4,
     encoding: String.Encoding.utf32LittleEndian.rawValue)!
 
-  s.getBytes(
-    &buffer,
-    maxLength: buffer.count,
-    usedLength: &used,
-    encoding: encoding.rawValue,
-    options: [],
-    range: NSRange(location: 0, length: s.length),
-    remaining: nil)
+  let count = buffer.count
+  _ = buffer.withUnsafeMutableBytes { bufferBytes in
+    s.getBytes(
+      bufferBytes.baseAddress,
+      maxLength: count,
+      usedLength: &used,
+      encoding: encoding.rawValue,
+      options: [],
+      range: NSRange(location: 0, length: s.length),
+      remaining: nil)
+  }
 }
 
 final class CodecTest<Codec : TestableUnicodeCodec> {


### PR DESCRIPTION
Fixes a usability problem with implicit inout conversion to raw pointers.

For example, supporting this conversion turns out to be bad:

    void read_void(const void *input);

    func foo(data: inout Data) {
        read_void(&data)
    }

People understandably expect Foundation.Data to have the same sort of
implicit conversion as Array. But it does something very wrong
instead.

We could have added an an attribute to Data and other copy-on-write
containers to selectively suppress implicit conversion. But there is
no good reason to allow implicit conversion from any non-trivial
type. It is extremely dangerous, and almost always accidental. Note
that this problem becomes worse now that the compiler views imported
`char *` arguments as raw pointers. For example:

  void read_char(const char *input);

  var object: AnyObject = ...
  read_void(&object1)

This seems like a good time to correct this old Swift 3 behavior.

Plan: Add a warning now. Convert it to an error in Swift 6 language
mode based on feedback.

Fixes rdar://97963116 (It's really easy to accidentally corrupt a Data
object with the & operator)

