### PR TITLE
[build-script] Omit "Build Script Analyzer" when `SystemExit` is caught.

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -718,6 +718,8 @@ def main():
 if __name__ == "__main__":
     try:
         exit_code = main()
+    except SystemExit as e:
+        os._exit(e.code)
     except KeyboardInterrupt:
         sys.exit(1)
     finally:


### PR DESCRIPTION
The content of ".build_script_log" file may be debris when `SystemExit` is thrown; e.g. `--help` is passed.

Resolves https://github.com/apple/swift/issues/60567


