### PR TITLE
IRGen/SIL: Fix IR linkage computation for inlined function references from modules imported `@_weakLinked`

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -685,9 +685,8 @@ public:
   // Is \p spiGroup accessible as an explicitly imported SPI from this module?
   bool isImportedAsSPI(Identifier spiGroup, const ModuleDecl *fromModule) const;
 
-  /// Is \p targetDecl from a module that is imported as \c @_weakLinked from
-  /// this module?
-  bool isImportedAsWeakLinked(const Decl *targetDecl) const;
+  /// Is \p module imported as \c @_weakLinked from this module?
+  bool isImportedAsWeakLinked(const ModuleDecl *module) const;
 
   /// \sa getImportedModules
   enum class ImportFilterKind {

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -19,6 +19,7 @@
 
 #include "swift/AST/ASTNode.h"
 #include "swift/AST/Availability.h"
+#include "swift/AST/Module.h"
 #include "swift/AST/ResilienceExpansion.h"
 #include "swift/Basic/ProfileCounter.h"
 #include "swift/Basic/SwiftObjectHeader.h"
@@ -63,11 +64,6 @@ enum IsExactSelfClass_t {
 enum IsDistributed_t {
   IsNotDistributed,
   IsDistributed,
-};
-enum IsWeakImported_t {
-  IsNotWeakImported,
-  IsWeakImportedByModule,
-  IsAlwaysWeakImported,
 };
 
 enum class PerformanceConstraints : uint8_t {
@@ -222,6 +218,10 @@ private:
   /// The AST decl context of the function.
   DeclContext *DeclCtxt = nullptr;
 
+  /// The module that defines this function. This member should only be set as
+  /// a fallback when a \c DeclCtxt is unavailable.
+  ModuleDecl *ParentModule = nullptr;
+
   /// The profiler for instrumentation based profiling, or null if profiling is
   /// disabled.
   SILProfiler *Profiler = nullptr;
@@ -322,8 +322,9 @@ private:
   /// would indicate.
   unsigned HasCReferences : 1;
 
-  /// Whether cross-module references to this function should use weak linking.
-  unsigned IsWeakImported : 2;
+  /// Whether cross-module references to this function should always use weak
+  /// linking.
+  unsigned IsAlwaysWeakImported : 1;
 
   /// Whether the implementation can be dynamically replaced.
   unsigned IsDynamicReplaceable : 1;
@@ -801,19 +802,11 @@ public:
 
   /// Returns whether this function's symbol must always be weakly referenced
   /// across module boundaries.
-  bool isAlwaysWeakImported() const {
-    return IsWeakImported == IsWeakImported_t::IsAlwaysWeakImported;
-  }
+  bool isAlwaysWeakImported() const { return IsAlwaysWeakImported; }
 
-  /// Returns whether this function's symbol was referenced by a module that
-  /// imports the defining module \c @_weakLinked.
-  bool isWeakImportedByModule() const {
-    return IsWeakImported == IsWeakImported_t::IsWeakImportedByModule;
-  }
+  void setIsAlwaysWeakImported(bool value) { IsAlwaysWeakImported = value; }
 
-  void setIsWeakImported(IsWeakImported_t value) { IsWeakImported = value; }
-
-  bool isWeakImported() const;
+  bool isWeakImported(ModuleDecl *module) const;
 
   /// Returns whether this function implementation can be dynamically replaced.
   IsDynamicallyReplaceable_t isDynamicallyReplaceable() const {
@@ -958,6 +951,18 @@ public:
   void setDebugScope(const SILDebugScope *DS) {
     DebugScope = DS;
     DeclCtxt = (DS ? DebugScope->Loc.getAsDeclContext() : nullptr);
+  }
+
+  /// Returns the module that defines this function.
+  ModuleDecl *getParentModule() const {
+    return DeclCtxt ? DeclCtxt->getParentModule() : ParentModule;
+  }
+
+  /// Sets \c ParentModule as fallback if \c DeclCtxt is not available to
+  /// provide the parent module.
+  void setParentModule(ModuleDecl *module) {
+    assert(!DeclCtxt && "already have a DeclCtxt");
+    ParentModule = module;
   }
 
   /// Initialize the debug scope for debug info on SIL level

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1002,7 +1002,7 @@ bool Decl::isWeakImported(ModuleDecl *fromModule) const {
   if (isAlwaysWeakImported())
     return true;
 
-  if (fromModule->isImportedAsWeakLinked(this))
+  if (fromModule->isImportedAsWeakLinked(this->getModuleContext()))
     return true;
 
   auto availability = getAvailabilityForLinkage();

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2663,10 +2663,9 @@ bool ModuleDecl::isImportedAsSPI(Identifier spiGroup,
   return importedSPIGroups.count(spiGroup);
 }
 
-bool ModuleDecl::isImportedAsWeakLinked(const Decl *targetDecl) const {
-  const auto *declaringModule = targetDecl->getModuleContext();
+bool ModuleDecl::isImportedAsWeakLinked(const ModuleDecl *module) const {
   for (auto file : getFiles()) {
-    if (file->importsModuleAsWeakLinked(declaringModule))
+    if (file->importsModuleAsWeakLinked(module))
       return true;
   }
   return false;

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2520,7 +2520,8 @@ Address IRGenModule::getAddrOfSILGlobalVariable(SILGlobalVariable *var,
     // FIXME: We should be able to set the linkage unconditionally here but
     //        some fixes are needed for Cxx interop.
     if (auto globalVar = dyn_cast<llvm::GlobalVariable>(addr)) {
-      if (getSwiftModule()->isImportedAsWeakLinked(var->getDecl()))
+      auto varModule = var->getDecl()->getModuleContext();
+      if (getSwiftModule()->isImportedAsWeakLinked(varModule))
         globalVar->setLinkage(link.getLinkage());
     }
 
@@ -3275,13 +3276,16 @@ llvm::Function *IRGenModule::getAddrOfSILFunction(
     fn = dyn_cast<llvm::Function>(clangAddr->stripPointerCasts());
 
     if (fn) {
-      // Override the linkage computed by Clang if the decl is from another
-      // module that imported @_weakLinked.
-      //
-      // FIXME: We should be able to set the linkage unconditionally here but
-      //        some fixes are needed for Cxx interop.
-      if (!forDefinition && f->isWeakImportedByModule())
-        fn->setLinkage(link.getLinkage());
+      if (!forDefinition) {
+        // Override the linkage computed by Clang if the decl is from another
+        // module that imported @_weakLinked.
+        //
+        // FIXME: We should be able to set the linkage unconditionally here but
+        //        some fixes are needed for Cxx interop.
+        if (auto *DC = f->getDeclContext())
+          if (getSwiftModule()->isImportedAsWeakLinked(DC->getParentModule()))
+            fn->setLinkage(link.getLinkage());
+      }
 
       // If we have a function, move it to the appropriate position.
       if (hasOrderNumber) {

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3282,8 +3282,8 @@ llvm::Function *IRGenModule::getAddrOfSILFunction(
         //
         // FIXME: We should be able to set the linkage unconditionally here but
         //        some fixes are needed for Cxx interop.
-        if (auto *DC = f->getDeclContext())
-          if (getSwiftModule()->isImportedAsWeakLinked(DC->getParentModule()))
+        if (auto *parentModule = f->getParentModule())
+          if (getSwiftModule()->isImportedAsWeakLinked(parentModule))
             fn->setLinkage(link.getLinkage());
       }
 

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -1177,7 +1177,7 @@ bool LinkEntity::isWeakImported(ModuleDecl *module) const {
   case Kind::DynamicallyReplaceableFunctionVariable:
   case Kind::SILFunction:
   case Kind::DistributedAccessor: {
-    return getSILFunction()->isWeakImported();
+    return getSILFunction()->isWeakImported(module);
   }
 
   case Kind::AssociatedConformanceDescriptor:

--- a/lib/SIL/IR/Linker.cpp
+++ b/lib/SIL/IR/Linker.cpp
@@ -16,10 +16,7 @@
 /// deserializing functions, vtables and witness tables.
 ///
 /// The behavior of the linker is controlled by a LinkMode value. The LinkMode
-/// has three possible values:
-///
-/// - LinkNone: The linker does not deserialize anything. This is only used for
-///   debugging and testing purposes, and never during normal operation.
+/// has two possible values:
 ///
 /// - LinkNormal: The linker deserializes bodies for declarations that must be
 ///   emitted into the client because they do not have definitions available

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -182,7 +182,7 @@ void SILFunction::init(
   this->InlineStrategy = inlineStrategy;
   this->Linkage = unsigned(Linkage);
   this->HasCReferences = false;
-  this->IsWeakImported = false;
+  this->IsAlwaysWeakImported = false;
   this->IsDynamicReplaceable = isDynamic;
   this->ExactSelfClass = isExactSelfClass;
   this->IsDistributed = isDistributed;
@@ -260,7 +260,7 @@ void SILFunction::createSnapshot(int id) {
   newSnapshot->perfConstraints = perfConstraints;
   newSnapshot->GlobalInitFlag = GlobalInitFlag;
   newSnapshot->HasCReferences = HasCReferences;
-  newSnapshot->IsWeakImported = IsWeakImported;
+  newSnapshot->IsAlwaysWeakImported = IsAlwaysWeakImported;
   newSnapshot->HasOwnership = HasOwnership;
   newSnapshot->IsWithoutActuallyEscapingThunk = IsWithoutActuallyEscapingThunk;
   newSnapshot->OptMode = OptMode;
@@ -452,9 +452,10 @@ bool SILFunction::isTypeABIAccessible(SILType type) const {
   return getModule().isTypeABIAccessible(type, TypeExpansionContext(*this));
 }
 
-bool SILFunction::isWeakImported() const {
-  if (isWeakImportedByModule())
-    return true;
+bool SILFunction::isWeakImported(ModuleDecl *module) const {
+  if (auto *parent = getParentModule())
+    if (module->isImportedAsWeakLinked(parent))
+      return true;
 
   // For imported functions check the Clang declaration.
   if (ClangNodeOwner)

--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -312,14 +312,7 @@ SILFunction *SILFunctionBuilder::getOrCreateFunction(
       F->setClangNodeOwner(decl);
 
     F->setAvailabilityForLinkage(decl->getAvailabilityForLinkage());
-
-    if (decl->isAlwaysWeakImported()) {
-      F->setIsWeakImported(IsWeakImported_t::IsAlwaysWeakImported);
-    } else if (decl->isWeakImported(mod.getSwiftModule())) {
-      F->setIsWeakImported(IsWeakImported_t::IsWeakImportedByModule);
-    } else {
-      F->setIsWeakImported(IsWeakImported_t::IsNotWeakImported);
-    }
+    F->setIsAlwaysWeakImported(decl->isAlwaysWeakImported());
 
     if (auto *accessor = dyn_cast<AccessorDecl>(decl)) {
       auto *storage = accessor->getStorage();

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -6514,9 +6514,7 @@ bool SILParserState::parseDeclSIL(Parser &P) {
     if (!objCReplacementFor.empty())
       FunctionState.F->setObjCReplacement(objCReplacementFor);
     FunctionState.F->setSpecialPurpose(specialPurpose);
-    FunctionState.F->setIsWeakImported(
-        isWeakImported ? IsWeakImported_t::IsAlwaysWeakImported
-                       : IsWeakImported_t::IsNotWeakImported);
+    FunctionState.F->setIsAlwaysWeakImported(isWeakImported);
     FunctionState.F->setAvailabilityForLinkage(availability);
     FunctionState.F->setWithoutActuallyEscapingThunk(
       isWithoutActuallyEscapingThunk);

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -519,6 +519,7 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
   (void)kind;
 
   DeclID clangNodeOwnerID;
+  ModuleID parentModuleID;
   TypeID funcTyID;
   IdentifierID replacedFunctionID;
   IdentifierID usedAdHocWitnessFunctionID;
@@ -538,7 +539,7 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
       hasQualifiedOwnership, isWeakImported, LIST_VER_TUPLE_PIECES(available),
       isDynamic, isExactSelfClass, isDistributed, funcTyID,
       replacedFunctionID, usedAdHocWitnessFunctionID,
-      genericSigID, clangNodeOwnerID, SemanticsIDs);
+      genericSigID, clangNodeOwnerID, parentModuleID, SemanticsIDs);
 
   if (funcTyID == 0) {
     MF->fatal("SILFunction typeID is 0");
@@ -661,9 +662,7 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
     fn->setEffectsKind(EffectsKind(effect));
     fn->setOptimizationMode(OptimizationMode(optimizationMode));
     fn->setPerfConstraints((PerformanceConstraints)perfConstr);
-    fn->setIsWeakImported(isWeakImported
-                              ? IsWeakImported_t::IsAlwaysWeakImported
-                              : IsWeakImported_t::IsNotWeakImported);
+    fn->setIsAlwaysWeakImported(isWeakImported);
     fn->setClassSubclassScope(SubclassScope(subclassScope));
     fn->setHasCReferences(bool(hasCReferences));
 
@@ -705,11 +704,15 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
     fn->setWasDeserializedCanonical();
 
   fn->setBare(IsBare);
-  const SILDebugScope *DS = fn->getDebugScope();
-  if (!DS) {
-    DS = new (SILMod) SILDebugScope(loc, fn);
+  if (!fn->getDebugScope()) {
+    const SILDebugScope *DS = new (SILMod) SILDebugScope(loc, fn);
     fn->setDebugScope(DS);
   }
+
+  // If we don't already have a DeclContext to use to find a parent module,
+  // attempt to deserialize a parent module reference directly.
+  if (!fn->getDeclContext() && parentModuleID)
+    fn->setParentModule(MF->getModule(parentModuleID));
 
   // Read and instantiate the specialize attributes.
   bool shouldAddSpecAttrs = fn->getSpecializeAttrs().empty();
@@ -3014,6 +3017,7 @@ bool SILDeserializer::hasSILFunction(StringRef Name,
   // TODO: If this results in any noticeable performance problems, Cache the
   // linkage to avoid re-reading it from the bitcode each time?
   DeclID clangOwnerID;
+  ModuleID parentModuleID;
   TypeID funcTyID;
   IdentifierID replacedFunctionID;
   IdentifierID usedAdHocWitnessFunctionID;
@@ -3033,7 +3037,7 @@ bool SILDeserializer::hasSILFunction(StringRef Name,
       hasQualifiedOwnership, isWeakImported, LIST_VER_TUPLE_PIECES(available),
       isDynamic, isExactSelfClass, isDistributed, funcTyID,
       replacedFunctionID, usedAdHocWitnessFunctionID,
-      genericSigID, clangOwnerID, SemanticsIDs);
+      genericSigID, clangOwnerID, parentModuleID, SemanticsIDs);
   auto linkage = fromStableSILLinkage(rawLinkage);
   if (!linkage) {
     LLVM_DEBUG(llvm::dbgs() << "invalid linkage code " << rawLinkage

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 701; // opened archetype serialization
+const uint16_t SWIFTMODULE_VERSION_MINOR = 702; // SILFunction DeclCtxt
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -287,6 +287,7 @@ namespace sil_block {
                      DeclIDField,  // SILFunction name or 0 (used ad-hoc requirement witness function)
                      GenericSignatureIDField,
                      DeclIDField, // ClangNode owner
+                     ModuleIDField, // Parent ModuleDecl *
                      BCArray<IdentifierIDField> // Semantics Attribute
                      // followed by specialize and argument effects attributes
                      // followed by generic param list, if any

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -459,6 +459,10 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
   if (F.hasClangNode())
     clangNodeOwnerID = S.addDeclRef(F.getClangNodeOwner());
 
+  ModuleID parentModuleID;
+  if (auto *parentModule = F.getParentModule())
+    parentModuleID = S.addModuleRef(parentModule);
+
   IdentifierID replacedFunctionID = 0;
   if (auto *fun = F.getDynamicallyReplacedFunction()) {
     addReferencedSILFunction(fun, true);
@@ -505,7 +509,7 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
       (unsigned)F.isExactSelfClass(),
       (unsigned)F.isDistributed(),
       FnID, replacedFunctionID, usedAdHocWitnessFunctionID,
-      genericSigID, clangNodeOwnerID, SemanticsIDs);
+      genericSigID, clangNodeOwnerID, parentModuleID, SemanticsIDs);
 
   F.visitArgEffects(
     [&](int effectIdx, bool isDerived, SILFunction::ArgEffectKind) {

--- a/test/IRGen/weaklinked_import.swift
+++ b/test/IRGen/weaklinked_import.swift
@@ -159,10 +159,7 @@ protocol RefinesP: BaseP {}
 extension S: RefinesP {}
 
 func testInlining() {
-  // FIXME: usableFromInlineFn() should be extern_weak but isn't because
-  //        inlining doesn't respect @_weakLinked import yet.
-
   // CHECK-DAG: define linkonce_odr hidden {{.+}} @"$s24weaklinked_import_helper22alwaysEmitIntoClientFnyyF"()
-  // CHECK-DAG: declare swiftcc {{.+}} @"$s24weaklinked_import_helper18usableFromInlineFnyyF"
+  // CHECK-DAG: declare extern_weak {{.+}} @"$s24weaklinked_import_helper18usableFromInlineFnyyF"
   alwaysEmitIntoClientFn()
 }

--- a/test/IRGen/weaklinked_import_inlining.swift
+++ b/test/IRGen/weaklinked_import_inlining.swift
@@ -1,0 +1,39 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/weaklinked_import_helper.swiftmodule -parse-as-library %S/Inputs/weaklinked_import_helper.swift -enable-library-evolution
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/Intermediate.swiftmodule -parse-as-library %t/Intermediate.swift -I %t -enable-library-evolution
+//
+// RUN: %target-swift-frontend -primary-file %t/Client.swift -I %t -emit-ir | %FileCheck %s
+
+// UNSUPPORTED: OS=windows-msvc
+
+//--- Intermediate.swift
+
+import weaklinked_import_helper
+
+public func hasDefaultArgument(_ s: S = S()) { }
+
+@_alwaysEmitIntoClient
+public func aeicFuncCallingFn() {
+  fn()
+}
+
+//--- Client.swift
+
+import Intermediate
+@_weakLinked import weaklinked_import_helper
+
+// Symbols from `weaklinked_import_helper` should have weak linkage even
+// when the references to them are inlined from `Intermediate`, which imported
+// `weaklinked_import_helper` without `@_weakLinked`.
+
+func testDefaultArguments() {
+  // CHECK: declare extern_weak {{.+}} @"$s24weaklinked_import_helper1SVMa"
+  hasDefaultArgument()
+}
+
+func testAlwaysEmitIntoClient() {
+  // CHECK-DAG: declare extern_weak {{.+}} @"$s24weaklinked_import_helper2fnyyF"()
+  aeicFuncCallingFn()
+}

--- a/test/IRGen/weaklinked_import_inlining_clang.swift
+++ b/test/IRGen/weaklinked_import_inlining_clang.swift
@@ -1,0 +1,56 @@
+// RUN: %empty-directory(%t)
+// RUN: %build-irgen-test-overlays
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-module -emit-module-path %t/Intermediate.swiftmodule -parse-as-library %t/Intermediate.swift -enable-library-evolution
+//
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %t/Client.swift -emit-ir | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+//--- Intermediate.swift
+
+import Foundation
+
+public func hasDefaultArgument(_ n: NSNotification = NSNotification()) { }
+
+@_alwaysEmitIntoClient
+public func aeicFuncUsingWeakVar() {
+  _ = weak_variable
+}
+
+@_alwaysEmitIntoClient
+public func aeicFuncUsingStrongVar() {
+  _ = strong_variable
+}
+
+@_alwaysEmitIntoClient
+public func aeicFuncCallingAlwaysAvailableFunc() {
+  always_available_function()
+}
+
+
+//--- Client.swift
+
+import Intermediate
+@_weakLinked import Foundation
+
+// Symbols from `Foundation` should have weak linkage even when the references
+// to them are inlined from `Intermediate`, which imported `Foundation` without
+// `@_weakLinked`.
+
+func testDefaultArguments() {
+  // CHECK-DAG: @"OBJC_CLASS_$_NSNotification" = extern_weak global %objc_class
+  hasDefaultArgument()
+}
+
+func testAlwaysEmitIntoClient() {
+  // CHECK-DAG: @weak_variable = extern_weak global
+  aeicFuncUsingWeakVar()
+  
+  // CHECK-DAG: @strong_variable = extern_weak global
+  aeicFuncUsingStrongVar()
+  
+  // CHECK-DAG: declare extern_weak void @always_available_function()
+  aeicFuncCallingAlwaysAvailableFunc()
+}

--- a/test/IRGen/weaklinked_import_transitive.swift
+++ b/test/IRGen/weaklinked_import_transitive.swift
@@ -12,8 +12,9 @@
 import intermediate
 import weaklinked_import_helper
 
-// Symbols from weaklinked_import_helper should be strong, despite intermediate
-// importining the module @_weakLinked.
+// The `@_weakLinked` attribute on the import of `weaklinked_import_helper` in
+// the module `intermediate` should not apply transitively to the import from
+// this module.
 
 // CHECK-DAG: declare swiftcc {{.+}} @"$s24weaklinked_import_helper2fnyyF"()
 fn()


### PR DESCRIPTION
Include the parent `ModuleDecl` when serializing a `SILFunction` so that it is available on deserialized functions even though the full `DeclContext` is not present. With the parent module always available we can reliably compute whether the `SILFunction` comes from a module that was imported `@_weakLinked`.

Originally, I attempted to serialize the full `DeclContext`. That didn't work out because deserialization would then fail for certain accessors functions, usually the getter for a synthesized `rawValue` property on enums imported from clang modules. Since nothing in this change actually depends on having the full `DeclContext` I abandoned that approach, but this is a bit of an unfortunate compromise that could be revisited if the deserialization issue can be solved.
    
Resolves rdar://98521248