### PR TITLE
[5.7][CSDiagnostics] Verify that member is in collection context

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3885,16 +3885,13 @@ bool MissingMemberFailure::diagnoseInLiteralCollectionContext() const {
   if (!parentExpr)
     return false;
 
-  auto parentType = getType(parentExpr);
-
-  if (!parentType->isKnownStdlibCollectionType() && !parentType->is<TupleType>())
-    return false;
-
-  if (isa<TupleExpr>(parentExpr)) {
+  // This could happen if collection is a dictionary literal i.e.
+  // ["a": .test] - the element is a tuple - ("a", .test).
+  if (isExpr<TupleExpr>(parentExpr))
     parentExpr = findParentExpr(parentExpr);
-    if (!parentExpr)
-      return false;
-  }
+
+  if (!isExpr<CollectionExpr>(parentExpr))
+    return false;
 
   if (auto *defaultableVar =
           getRawType(parentExpr)->getAs<TypeVariableType>()) {

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -515,3 +515,23 @@ func test_conflicting_pattern_vars() {
     }
   }
 }
+
+// rdar://91452726 - crash in MissingMemberFailure::diagnoseInLiteralCollectionContext
+struct Test {
+  struct ID {
+  }
+
+  enum E : Hashable, Equatable {
+  case id
+  }
+
+  var arr: [(ID, E)]
+
+  func test() {
+    _ = arr.map { v in
+      switch v {
+      case .id: return true // expected-error {{value of tuple type '(Test.ID, Test.E)' has no member 'id'}}
+      }
+    }
+  }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/60607

---

`MissingMemberFailure::diagnoseInLiteralCollectionContext`
should verify that a parent (or parent of a parent) expression
is indeed a collection expression instead of checking types.

Resolves: rdar://91452726
(cherry picked from commit 3ebc541fd59a7ba947f84ea72a7223bea1a38acc)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
