### PR TITLE
[ConstraintSystem] Add literal default types to type variable binding printing

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -636,8 +636,6 @@ void BindingSet::determineLiteralCoverage() {
   if (Literals.empty())
     return;
 
-  SmallVector<PotentialBinding, 4> adjustedBindings;
-
   bool allowsNil = canBeNil();
 
   for (auto &entry : Literals) {
@@ -648,7 +646,6 @@ void BindingSet::determineLiteralCoverage() {
 
     for (auto binding = Bindings.begin(); binding != Bindings.end();
          ++binding) {
-
       bool isCovered = false;
       Type adjustedTy;
 

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1710,7 +1710,7 @@ void BindingSet::dump(llvm::raw_ostream &out, unsigned indent) const {
     }
     case LiteralBindingKind::Float:
     case LiteralBindingKind::None:
-        out << getLiteralBindingKind(literalKind).str();
+      out << getLiteralBindingKind(literalKind).str();
       break;
     }
     if (attributes.empty()) {
@@ -1755,8 +1755,20 @@ void BindingSet::dump(llvm::raw_ostream &out, unsigned indent) const {
 
   out << "[with possible bindings: ";
   interleave(Bindings, printBinding, [&]() { out << "; "; });
-  if (Bindings.empty())
+  if (!Literals.empty()) {
+    std::vector<std::string> defaultLiterals;
+    for (const auto &literal : Literals) {
+      if (literal.second.viableAsBinding()) {
+        auto defaultWithType = "(default type of literal) " +
+                               literal.second.getDefaultType().getString(PO);
+        defaultLiterals.push_back(defaultWithType);
+      }
+    }
+    interleave(defaultLiterals, out, ", ");
+  }
+  if (Bindings.empty() && Literals.empty()) {
     out << "<empty>";
+  }
   out << "]";
 
   if (!Defaults.empty()) {


### PR DESCRIPTION
This adds inferred bindings from literal conformances to type variable binding printing. Previously, bindings printed <empty> when no direct binding was found and omitted potential bindings found via inference. 
```
($T2 [attributes: delayed, [literal: integer]] [with possible bindings: <empty>])
($T3 [attributes: delayed, [literal: string]] [with possible bindings: <empty>])
($T4 [attributes: delayed] [with possible bindings: (subtypes of) Int])
```
will now print as: 
```
($T2 [attributes: delayed, [literal: integer]] [with possible bindings: (default literal type of) Int])
($T3 [attributes: delayed, [literal: string]] [with possible bindings: (default literal type of) String])
($T4 [attributes: delayed] [with possible bindings: (subtypes of) Int])
```
This is an addition to apple/swift#59855.

