### PR TITLE
[Sema] Always warn on uses of an implicitly imported conformances in API until Swift 6

### DIFF
--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -241,8 +241,9 @@ TypeChecker::diagnoseConformanceExportability(SourceLoc loc,
                      static_cast<unsigned>(*reason),
                      M->getName(),
                      static_cast<unsigned>(originKind))
-      .warnUntilSwiftVersionIf(useConformanceAvailabilityErrorsOption &&
-                               !ctx.LangOpts.EnableConformanceAvailabilityErrors,
+      .warnUntilSwiftVersionIf((useConformanceAvailabilityErrorsOption &&
+                                !ctx.LangOpts.EnableConformanceAvailabilityErrors) ||
+                               originKind == DisallowedOriginKind::ImplicitlyImported,
                                6);
   return true;
 }


### PR DESCRIPTION
Until Swift 6, always downgrade to a warning the diagnostic on the use in API of a conformance that wasn't imported by the local source file.

rdar://98851314