### PR TITLE
[stdlib] add explanations to _debugPrecondition calls

### DIFF
--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -742,19 +742,21 @@ extension Unsafe${Mutable}BufferPointer {
       return try body(.init(start: nil, count: 0))
     }
 
+    _debugPrecondition(
+      Int(bitPattern: .init(base)) & (MemoryLayout<T>.alignment-1) == 0,
+      "baseAddress must be a properly aligned pointer for types Element and T"
+    )
+
     let newCount: Int
     if MemoryLayout<T>.stride == MemoryLayout<Element>.stride {
       newCount = count
-      _debugPrecondition(
-        MemoryLayout<T>.alignment == MemoryLayout<Element>.alignment
-      )
     } else {
       newCount = count * MemoryLayout<Element>.stride / MemoryLayout<T>.stride
       _debugPrecondition(
-        Int(bitPattern: .init(base)) & (MemoryLayout<T>.alignment-1) == 0 &&
         MemoryLayout<T>.stride > MemoryLayout<Element>.stride
         ? MemoryLayout<T>.stride % MemoryLayout<Element>.stride == 0
-        : MemoryLayout<Element>.stride % MemoryLayout<T>.stride == 0
+        : MemoryLayout<Element>.stride % MemoryLayout<T>.stride == 0,
+        "Buffer must contain a whole number of Element instances"
       )
     }
     let binding = Builtin.bindMemory(base, newCount._builtinWordValue, T.self)

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -319,7 +319,10 @@ public struct UnsafePointer<Pointee>: _Pointer {
         ( MemoryLayout<Pointee>.stride > MemoryLayout<T>.stride
           ? MemoryLayout<Pointee>.stride % MemoryLayout<T>.stride == 0
           : MemoryLayout<T>.stride % MemoryLayout<Pointee>.stride == 0
-    )))
+        )
+      ),
+      "self must be a properly aligned pointer for types Pointee and T"
+    )
     let binding = Builtin.bindMemory(_rawValue, count._builtinWordValue, T.self)
     defer { Builtin.rebindMemory(_rawValue, binding) }
     return try body(.init(_rawValue))
@@ -1026,7 +1029,10 @@ public struct UnsafeMutablePointer<Pointee>: _Pointer {
         ( MemoryLayout<Pointee>.stride > MemoryLayout<T>.stride
           ? MemoryLayout<Pointee>.stride % MemoryLayout<T>.stride == 0
           : MemoryLayout<T>.stride % MemoryLayout<Pointee>.stride == 0
-    )))
+        )
+      ),
+      "self must be a properly aligned pointer for types Pointee and T"
+    )
     let binding = Builtin.bindMemory(_rawValue, count._builtinWordValue, T.self)
     defer { Builtin.rebindMemory(_rawValue, binding) }
     return try body(.init(_rawValue))

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -868,7 +868,8 @@ extension Unsafe${Mutable}RawBufferPointer {
       return try body(.init(start: nil, count: 0))
     }
     _debugPrecondition(
-      Int(bitPattern: s) & (MemoryLayout<T>.alignment-1) == 0
+      Int(bitPattern: s) & (MemoryLayout<T>.alignment-1) == 0,
+      "baseAddress must be a properly aligned pointer for type T"
     )
     // initializer ensures _end is nil only when _position is nil.
     _internalInvariant(_end != nil)

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -378,7 +378,8 @@ public struct UnsafeRawPointer: _Pointer {
     _ body: (_ pointer: UnsafePointer<T>) throws -> Result
   ) rethrows -> Result {
     _debugPrecondition(
-      Int(bitPattern: self) & (MemoryLayout<T>.alignment-1) == 0
+      Int(bitPattern: self) & (MemoryLayout<T>.alignment-1) == 0,
+      "self must be a properly aligned pointer for type T"
     )
     let binding = Builtin.bindMemory(_rawValue, count._builtinWordValue, T.self)
     defer { Builtin.rebindMemory(_rawValue, binding) }
@@ -934,7 +935,8 @@ public struct UnsafeMutableRawPointer: _Pointer {
     _ body: (_ pointer: UnsafeMutablePointer<T>) throws -> Result
   ) rethrows -> Result {
     _debugPrecondition(
-      Int(bitPattern: self) & (MemoryLayout<T>.alignment-1) == 0
+      Int(bitPattern: self) & (MemoryLayout<T>.alignment-1) == 0,
+      "self must be a properly aligned pointer for type T"
     )
     let binding = Builtin.bindMemory(_rawValue, count._builtinWordValue, T.self)
     defer { Builtin.rebindMemory(_rawValue, binding) }


### PR DESCRIPTION
Add explanatory messages to _debugPrecondition calls in withMemoryRebound.

Resolves rdar://98851696.
