### PR TITLE
Fix invalid pcm with -no-clang-module-breadcrumbs

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1940,6 +1940,10 @@ ModuleDecl *ClangImporter::Implementation::loadModuleClang(
       }
     }
 
+    auto &codeGenOpts = Instance->getCodeGenOpts();
+    bool preservedDebugTypeExtRefs = codeGenOpts.DebugTypeExtRefs;
+    codeGenOpts.DebugTypeExtRefs = true;
+
     clang::SourceLocation clangImportLoc = getNextIncludeLoc();
 
     clang::ModuleLoadResult result =
@@ -1950,6 +1954,8 @@ ModuleDecl *ClangImporter::Implementation::loadModuleClang(
       // Restore the -index-store-path option.
       clangFEOpts.IndexStorePath = preservedIndexStorePathOption;
     }
+
+    codeGenOpts.DebugTypeExtRefs = preservedDebugTypeExtRefs;
 
     if (result && (visibility == clang::Module::AllVisible)) {
       getClangPreprocessor().makeModuleVisible(result, clangImportLoc);


### PR DESCRIPTION
Implicit modules' hashes encode whether or not `DebugTypeExtRefs` is set
on the clang code gen options (indirectly because it uses this to
determine whether or not to store `DebugPrefixMap`, and even empty
arrays affect the overall hash).

The implicit module for the new `_SwiftConcurrencyShims` module can be
created when emitting info about `@async_Main`, which happens _after_
setting `DebugTypeExtRefs` based on `-no-clang-module-breadcrumbs`. This
results in a PCM that was output in the correct directory, but encoding
a different hash, which leads to:

```
<unknown>:0: error: PCH was compiled with module cache path '.../3AWSV6I4O3H6A', but the path is currently '.../156JXK5XAB8RW'
```

This change saves the current value before calling the clang module
loader, and restores it afterwards.