### PR TITLE
[cherry-pick][5.7] Presets: Build a release stdlib on the lldb sanitizer bot.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -539,12 +539,6 @@ lldb-use-system-debugserver
 release-debuginfo
 assertions
 
-# We need to build an unoptimized swift benchmark driver for stepper testing.
-# Ditto for the swift stdlib. (LLDB doesn't support stepping through optimized
-# swift code yet.)
-extra-cmake-options=-DSWIFT_BENCHMARK_UNOPTIMIZED_DRIVER:BOOL=1
-debug-swift-stdlib
-
 # Disable non-x86 building/testing.
 skip-build-ios
 skip-test-ios


### PR DESCRIPTION
The reason for building a debug stdlib was the stepper test, but that
test proved unreliable and is disabled.

(cherry picked from commit 5ed0affbaebadf9193658b017462fda29cd6efc9)