### PR TITLE
Swift AccessUtils: improvements and bug fixes

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/AccessDumper.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/AccessDumper.swift
@@ -10,25 +10,35 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Basic
 import SIL
 
 /// Dumps access information for memory accesses (`load` and `store`)
 /// instructions.
+/// Also verifies that `AccessPath.isDistinct(from:)` is correct. This does not actually
+/// dumps anything, but aborts if the result is wrong.
 ///
 /// This pass is used for testing `AccessUtils`.
 let accessDumper = FunctionPass(name: "dump-access", {
   (function: Function, context: PassContext) in
   print("Accesses for \(function.name)")
 
-  var apw = AccessPathWalker()
-  var arw = AccessStoragePathVisitor()
   for block in function.blocks {
     for instr in block.instructions {
       switch instr {
       case let st as StoreInst:
-        printAccessInfo(st.destinationOperand.value, &apw, &arw, context)
+        printAccessInfo(address: st.destination)
       case let load as LoadInst:
-        printAccessInfo(load.operand, &apw, &arw, context)
+        printAccessInfo(address: load.operand)
+      case let apply as ApplyInst:
+        guard let callee = apply.referencedFunction else {
+          break
+        }
+        if callee.name == "_isDistinct" {
+          checkAliasInfo(forArgumentsOf: apply, expectDistinct: true)
+        } else if callee.name == "_isNotDistinct" {
+          checkAliasInfo(forArgumentsOf: apply, expectDistinct: false)
+        }
       default:
         break
       }
@@ -46,10 +56,11 @@ private struct AccessStoragePathVisitor : AccessStoragePathWalker {
   }
 }
 
-private func printAccessInfo(_ value: Value, _ apw: inout AccessPathWalker, _ aspw: inout AccessStoragePathVisitor,
-                             _ ctx: PassContext) {
-  print("Value: \(value)")
-  let (ap, scope) = apw.getAccessPathWithScope(of: value)
+private func printAccessInfo(address: Value) {
+  print("Value: \(address)")
+
+  var apw = AccessPathWalker()
+  let (ap, scope) = apw.getAccessPathWithScope(of: address)
   if let scope = scope {
     switch scope {
     case let .scope(ba):
@@ -63,6 +74,30 @@ private func printAccessInfo(_ value: Value, _ apw: inout AccessPathWalker, _ as
     print("  Base: \(ap.base)")
     print("  Path: \"\(ap.projectionPath)\"")
 
-    aspw.getAccessStorage(for: ap)
+    var arw = AccessStoragePathVisitor()
+    if !arw.visitAccessStorageRoots(of: ap) {
+      print("   no Storage paths")
+    }
   }
+}
+
+private func checkAliasInfo(forArgumentsOf apply: ApplyInst, expectDistinct: Bool) {
+  let address1 = apply.arguments[0]
+  let address2 = apply.arguments[1]
+  var apw = AccessPathWalker()
+  guard let path1 = apw.getAccessPath(of: address1),
+        let path2 = apw.getAccessPath(of: address2) else {
+    return
+  }
+  if path1.isDistinct(from: path2) != expectDistinct {
+    print("wrong isDistinct result of \(apply)")
+  } else if path2.isDistinct(from: path1) != expectDistinct {
+    print("wrong reverse isDistinct result of \(apply)")
+  } else {
+    return
+  }
+  
+  print("in function")
+  print(apply.function)
+  fatalError()
 }

--- a/SwiftCompilerSources/Sources/SIL/Argument.swift
+++ b/SwiftCompilerSources/Sources/SIL/Argument.swift
@@ -16,7 +16,7 @@ import SILBridging
 /// A basic block argument.
 ///
 /// Maps to both, SILPhiArgument and SILFunctionArgument.
-public class Argument : Value, Equatable {
+public class Argument : Value, Hashable {
   public var definingInstruction: Instruction? { nil }
   public var definingBlock: BasicBlock { block }
 
@@ -32,6 +32,10 @@ public class Argument : Value, Equatable {
   
   public static func ==(lhs: Argument, rhs: Argument) -> Bool {
     lhs === rhs
+  }
+
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(ObjectIdentifier(self))
   }
 }
 

--- a/SwiftCompilerSources/Sources/SIL/GlobalVariable.swift
+++ b/SwiftCompilerSources/Sources/SIL/GlobalVariable.swift
@@ -13,7 +13,7 @@
 import Basic
 import SILBridging
 
-final public class GlobalVariable : CustomStringConvertible, HasShortDescription {
+final public class GlobalVariable : CustomStringConvertible, HasShortDescription, Hashable {
   public var name: StringRef {
     return StringRef(bridged: SILGlobalVariable_getName(bridged))
   }
@@ -29,15 +29,15 @@ final public class GlobalVariable : CustomStringConvertible, HasShortDescription
 
   // TODO: initializer instructions
 
+  public static func ==(lhs: GlobalVariable, rhs: GlobalVariable) -> Bool {
+    lhs === rhs
+  }
+
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(ObjectIdentifier(self))
+  }
+
   var bridged: BridgedGlobalVar { BridgedGlobalVar(obj: SwiftObject(self)) }
-}
-
-public func ==(_ lhs: GlobalVariable, _ rhs: GlobalVariable) -> Bool {
-  return lhs === rhs
-}
-
-public func !=(_ lhs: GlobalVariable, _ rhs: GlobalVariable) -> Bool {
-  return (lhs !== rhs)
 }
 
 // Bridging utilities

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -139,6 +139,10 @@ public class SingleValueInstruction : Instruction, Value {
 
   fileprivate final override var resultCount: Int { 1 }
   fileprivate final override func getResult(index: Int) -> Value { self }
+
+  public static func ==(lhs: SingleValueInstruction, rhs: SingleValueInstruction) -> Bool {
+    lhs === rhs
+  }
 }
 
 public final class MultipleValueInstructionResult : Value {

--- a/SwiftCompilerSources/Sources/SIL/Type.swift
+++ b/SwiftCompilerSources/Sources/SIL/Type.swift
@@ -80,6 +80,10 @@ public struct NominalFieldsArray : RandomAccessCollection, FormattedLikeArray {
     }
     return idx >= 0 ? idx : nil
   }
+
+  public func getNameOfField(withIndex idx: Int) -> StringRef {
+    StringRef(bridged: SILType_getNominalFieldName(type.bridged, idx))
+  }
 }
 
 public struct TupleElementArray : RandomAccessCollection, FormattedLikeArray {

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -274,6 +274,7 @@ BridgedType SILType_getNominalFieldType(BridgedType type, SwiftInt index,
                                         BridgedFunction function);
 SwiftInt SILType_getFieldIdxOfNominalType(BridgedType type,
                                           llvm::StringRef fieldName);
+llvm::StringRef SILType_getNominalFieldName(BridgedType type, SwiftInt index);
 SwiftInt SILType_getCaseIdxOfEnumType(BridgedType type,
                                       llvm::StringRef caseName);
 

--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -461,6 +461,14 @@ BridgedType SILType_getNominalFieldType(BridgedType type, SwiftInt index,
   return {fieldType.getOpaqueValue()};
 }
 
+StringRef SILType_getNominalFieldName(BridgedType type, SwiftInt index) {
+  SILType silType = castToSILType(type);
+
+  NominalTypeDecl *decl = silType.getNominalOrBoundGenericNominal();
+  VarDecl *field = getIndexedField(decl, (unsigned)index);
+  return field->getName().str();
+}
+
 SwiftInt SILType_getFieldIdxOfNominalType(BridgedType type,
                                           StringRef fieldName) {
   SILType ty = castToSILType(type);

--- a/test/SILOptimizer/accessutils.sil
+++ b/test/SILOptimizer/accessutils.sil
@@ -21,6 +21,11 @@ struct S {
   var y: Int64
 }
 
+struct TwoInts {
+  var a: Int64
+  var b: Int64
+}
+
 struct Ptr {
   var p: Int64
 }
@@ -30,8 +35,7 @@ struct Ptr {
 // CHECK-NEXT:   Scope: base
 // CHECK-NEXT:   Base: argument - %0 = argument of bb0 : $*Int64
 // CHECK-NEXT:   Path: ""
-// CHECK-NEXT:     Storage: %0 = argument of bb0 : $*Int64
-// CHECK-NEXT:     Path: ""
+// CHECK-NEXT:     no Storage paths
 // CHECK-NEXT: End accesses for readIdentifiedArg
 sil [ossa] @readIdentifiedArg : $@convention(thin) (@in Int64) -> Int64 {
 bb0(%0 : $*Int64):
@@ -44,8 +48,7 @@ bb0(%0 : $*Int64):
 // CHECK-NEXT:   Scope: base
 // CHECK-NEXT:   Base: argument - %0 = argument of bb0 : $*Int64
 // CHECK-NEXT:   Path: ""
-// CHECK-NEXT:     Storage: %0 = argument of bb0 : $*Int64
-// CHECK-NEXT:     Path: ""
+// CHECK-NEXT:     no Storage paths
 // CHECK-NEXT: End accesses for writeIdentifiedArg
 sil [ossa] @writeIdentifiedArg : $@convention(thin) (@inout Int64) -> () {
 bb0(%0 : $*Int64):
@@ -56,15 +59,15 @@ bb0(%0 : $*Int64):
   return %5 : $()
 }
 
-// CHECK-LABEL: Accesses for $writeToHead
+// CHECK-LABEL: Accesses for writeToHead
 // CHECK-NEXT: Value:   %7 = begin_access [modify] [dynamic] %6 : $*Int64
 // CHECK-NEXT:   Scope:   %7 = begin_access [modify] [dynamic] %6 : $*Int64
 // CHECK-NEXT:   Base: class -   %6 = ref_element_addr %5 : $List, #List.x
 // CHECK-NEXT:   Path: ""
 // CHECK-NEXT:     Storage: %0 = argument of bb0 : $S
 // CHECK-NEXT:     Path: "s0.c0"
-// CHECK-NEXT: End accesses for $writeToHead
-sil [ossa] @$writeToHead : $@convention(thin) (@guaranteed S) -> () {
+// CHECK-NEXT: End accesses for writeToHead
+sil [ossa] @writeToHead : $@convention(thin) (@guaranteed S) -> () {
 bb0(%0 : @guaranteed $S):
   debug_value %0 : $S, let, name "s", argno 1
   %2 = struct_extract %0 : $S, #S.l
@@ -95,32 +98,32 @@ bb0(%0 : @guaranteed $S):
 // CHECK-NEXT:     Path: "c0"
 // CHECK-NEXT: End accesses for storeToArgs
 sil [ossa] @storeToArgs : $@convention(thin) (@guaranteed List, @guaranteed List) -> () {
-bb0(%1 : @guaranteed $List, %2 : @guaranteed $List):
+bb0(%0 : @guaranteed $List, %1 : @guaranteed $List):
   cond_br undef, bb1, bb2
 
 bb1:
-  %8 = integer_literal $Builtin.Int64, 10
-  %9 = struct $Int64 (%8 : $Builtin.Int64)
-  %10 = ref_element_addr %1 : $List, #List.x
-  %11 = begin_access [modify] [dynamic] %10 : $*Int64
-  store %9 to [trivial] %11 : $*Int64
-  end_access %11 : $*Int64
-  %14 = tuple ()
+  %3 = integer_literal $Builtin.Int64, 10
+  %4 = struct $Int64 (%3 : $Builtin.Int64)
+  %5 = ref_element_addr %0 : $List, #List.x
+  %6 = begin_access [modify] [dynamic] %5 : $*Int64
+  store %4 to [trivial] %6 : $*Int64
+  end_access %6 : $*Int64
+  %9 = tuple ()
   br bb3
 
 bb2:
-  %16 = integer_literal $Builtin.Int64, 20
-  %17 = struct $Int64 (%16 : $Builtin.Int64)
-  %18 = ref_element_addr %2 : $List, #List.x
-  %19 = begin_access [modify] [dynamic] %18 : $*Int64
-  store %17 to [trivial] %19 : $*Int64
-  end_access %19 : $*Int64
-  %22 = tuple ()
+  %11 = integer_literal $Builtin.Int64, 20
+  %12 = struct $Int64 (%11 : $Builtin.Int64)
+  %13 = ref_element_addr %1 : $List, #List.x
+  %14 = begin_access [modify] [dynamic] %13 : $*Int64
+  store %12 to [trivial] %14 : $*Int64
+  end_access %14 : $*Int64
+  %17 = tuple ()
   br bb3
 
 bb3:
-  %24 = tuple ()
-  return %24 : $()
+  %19 = tuple ()
+  return %19 : $()
 }
 
 // CHECK-LABEL: Accesses for storeMaybeLocalPhi
@@ -134,28 +137,29 @@ bb3:
 // CHECK-NEXT:     Path: "c0"
 // CHECK-NEXT: End accesses for storeMaybeLocalPhi
 sil @storeMaybeLocalPhi : $@convention(thin) (@guaranteed List) -> () {
-bb0(%1 : $List):
+bb0(%0 : $List):
   cond_br undef, bb1, bb2
 
 bb1:
-  strong_retain %1 : $List
-  br bb3(%1 : $List)
+  strong_retain %0 : $List
+  br bb3(%0 : $List)
 
 bb2:
-  %10 = alloc_ref $List
-  br bb3(%10 : $List)
+  %4 = alloc_ref $List
+  br bb3(%4 : $List)
 
-bb3(%12 : $List):
-  %14 = integer_literal $Builtin.Int64, 20
-  %15 = struct $Int64 (%14 : $Builtin.Int64)
-  %16 = ref_element_addr %12 : $List, #List.x
-  %17 = begin_access [modify] [dynamic] %16 : $*Int64
-  store %15 to %17 : $*Int64
-  end_access %17 : $*Int64
-  %20 = tuple ()
-  strong_release %12 : $List
-  %22 = tuple ()
-  return %22 : $()
+
+bb3(%6 : $List):
+  %7 = integer_literal $Builtin.Int64, 20
+  %8 = struct $Int64 (%7 : $Builtin.Int64)
+  %9 = ref_element_addr %6 : $List, #List.x
+  %10 = begin_access [modify] [dynamic] %9 : $*Int64
+  store %8 to %10 : $*Int64
+  end_access %10 : $*Int64
+  %13 = tuple ()
+  strong_release %6 : $List
+  %15 = tuple ()
+  return %15 : $()
 }
 
 
@@ -164,8 +168,7 @@ bb3(%12 : $List):
 // CHECK-NEXT:   Scope: base
 // CHECK-NEXT:   Base: argument - %0 = argument of bb0 : $*Ptr
 // CHECK-NEXT:   Path: "s0"
-// CHECK-NEXT:     Storage: %0 = argument of bb0 : $*Ptr
-// CHECK-NEXT:     Path: "s0"
+// CHECK-NEXT:     no Storage paths
 // CHECK-NEXT: End accesses for testStructPhiCommon
 sil [ossa] @testStructPhiCommon : $@convention(thin) (@inout Ptr) -> () {
 bb0(%0 : $*Ptr):
@@ -180,13 +183,13 @@ bb2:
   %5 = address_to_pointer %2 : $*Int64 to $Builtin.RawPointer
   br bb3(%5 : $Builtin.RawPointer)
 
-bb3(%6 : $Builtin.RawPointer) :
+bb3(%6 : $Builtin.RawPointer):
   %7 = pointer_to_address %6 : $Builtin.RawPointer to $*Int64
   %8 = integer_literal $Builtin.Int64, 2
   %9 = struct $Int64 (%8 : $Builtin.Int64)
   store %9 to [trivial] %7 : $*Int64
-  %22 = tuple ()
-  return %22 : $()
+  %11 = tuple ()
+  return %11 : $()
 }
 
 // CHECK-LABEL: Accesses for testStructPhiDivergent
@@ -194,34 +197,33 @@ bb3(%6 : $Builtin.RawPointer) :
 // CHECK-NEXT:   Scope: base
 // CHECK-NEXT:   Base: pointer - %10 = pointer_to_address %9 : $Builtin.RawPointer to $*Int64 // user: %13
 // CHECK-NEXT:   Path: ""
-// CHECK-NEXT:     Storage: %10 = pointer_to_address %9 : $Builtin.RawPointer to $*Int64 // user: %13
-// CHECK-NEXT:     Path: ""
+// CHECK-NEXT:     no Storage paths
 // CHECK-NEXT: End accesses for testStructPhiDivergent
 sil [ossa] @testStructPhiDivergent : $@convention(thin) (@inout Ptr) -> () {
 bb0(%0 : $*Ptr):
-  %ptr = alloc_stack $Ptr
+  %1 = alloc_stack $Ptr
   cond_br undef, bb1, bb2
 
 bb1:
-  %2 = struct_element_addr %ptr : $*Ptr, #Ptr.p
-  %3 = address_to_pointer %2 : $*Int64 to $Builtin.RawPointer
-  br bb3(%3 : $Builtin.RawPointer)
+  %3 = struct_element_addr %1 : $*Ptr, #Ptr.p
+  %4 = address_to_pointer %3 : $*Int64 to $Builtin.RawPointer
+  br bb3(%4 : $Builtin.RawPointer)
 
 bb2:
-  %4 = struct_element_addr %0 : $*Ptr, #Ptr.p
-  %5 = address_to_pointer %4 : $*Int64 to $Builtin.RawPointer
-  br bb3(%5 : $Builtin.RawPointer)
+  %6 = struct_element_addr %0 : $*Ptr, #Ptr.p
+  %7 = address_to_pointer %6 : $*Int64 to $Builtin.RawPointer
+  br bb3(%7 : $Builtin.RawPointer)
 
-bb3(%6 : $Builtin.RawPointer) :
-  %7 = pointer_to_address %6 : $Builtin.RawPointer to $*Int64
-  %8 = integer_literal $Builtin.Int64, 2
-  %9 = struct $Int64 (%8 : $Builtin.Int64)
-  store %9 to [trivial] %7 : $*Int64
-  dealloc_stack %ptr : $*Ptr
-  %22 = tuple ()
-  return %22 : $()
+
+bb3(%9 : $Builtin.RawPointer):
+  %10 = pointer_to_address %9 : $Builtin.RawPointer to $*Int64
+  %11 = integer_literal $Builtin.Int64, 2
+  %12 = struct $Int64 (%11 : $Builtin.Int64)
+  store %12 to [trivial] %10 : $*Int64
+  dealloc_stack %1 : $*Ptr
+  %15 = tuple ()
+  return %15 : $()
 }
-
 
 // CHECK-LABEL: Accesses for readIdentifiedBoxArg
 // CHECK-NEXT: Value:   %2 = begin_access [read] [dynamic] %1 : $*Int64
@@ -246,6 +248,7 @@ class A {
 }
 class B : A {
   var prop1: Int64
+  var prop2: Int64
 }
 
 // CHECK-LABEL: Accesses for testNonUniquePropertyIndex
@@ -308,13 +311,13 @@ struct MyArray<T> {
 // CHECK-NEXT:     Path: "s0.s0.s0.c0.s0.s0.s0"
 // CHECK-NEXT: Value:   %11 = struct_element_addr %10 : $*String, #String._guts
 // CHECK-NEXT:   Scope: base
-// CHECK-NEXT:   Base: tail -   %10 = ref_tail_addr [immutable] %4 : $MyContiguousArrayStorageBase, $String
+// CHECK-NEXT:   Base: tail -   %4 = unchecked_ref_cast %3 : $Builtin.BridgeObject to $MyContiguousArrayStorageBase
 // CHECK-NEXT:   Path: "s0"
 // CHECK-NEXT:     Storage: %0 = argument of bb0 : $MyArray<String>
 // CHECK-NEXT:     Path: "s0.s0.s0.ct.s0"
 // CHECK-NEXT: Value:   %10 = ref_tail_addr [immutable] %4 : $MyContiguousArrayStorageBase, $String
 // CHECK-NEXT:   Scope: base
-// CHECK-NEXT:   Base: tail -   %10 = ref_tail_addr [immutable] %4 : $MyContiguousArrayStorageBase, $String
+// CHECK-NEXT:   Base: tail -   %4 = unchecked_ref_cast %3 : $Builtin.BridgeObject to $MyContiguousArrayStorageBase
 // CHECK-NEXT:   Path: ""
 // CHECK-NEXT:     Storage: %0 = argument of bb0 : $MyArray<String>
 // CHECK-NEXT:     Path: "s0.s0.s0.ct"
@@ -336,4 +339,163 @@ bb0(%0 : $MyArray<String>):
   %13 = load %10 : $*String
   %14 = tuple ()
   return %14 : $()
+}
+
+sil_global @global1 : $Int64
+sil_global @global2 : $Int64
+
+sil @coro : $@yield_once @convention(thin) () -> @yields @inout Int64
+
+sil @_isDistinct : $@convention(thin) <T1, T2> (@inout T1, @inout T2) -> ()
+sil @_isNotDistinct : $@convention(thin) <T1, T2> (@inout T1, @inout T2) -> ()
+
+// CHECK-LABEL: Accesses for testAccessBaseAliasing
+// CHECK-NEXT: End accesses for testAccessBaseAliasing
+sil @testAccessBaseAliasing : $@convention(thin) (@inout Int64, @inout_aliasable Int64, @inout_aliasable Int64, Builtin.RawPointer, Builtin.RawPointer, @guaranteed B, @guaranteed B, @guaranteed { var Int64, var Int64 }, @guaranteed { var Int64, var Int64 }) -> () {
+bb0(%inoutArg : $*Int64, %aliasableArg1 : $*Int64, %aliasableArg2 : $*Int64, %3 : $Builtin.RawPointer, %4 : $Builtin.RawPointer, %5 : $B, %6 : $B, %7 : ${ var Int64, var Int64 }, %8 : ${ var Int64, var Int64 }):
+  %pointer1 = pointer_to_address %3 : $Builtin.RawPointer to $*Int64
+  %pointer2 = pointer_to_address %4 : $Builtin.RawPointer to $*Int64
+
+  %stack1 = alloc_stack $Int64
+  %stack2 = alloc_stack $Int64
+
+  %20 = alloc_ref $B
+  %21 = alloc_ref $B
+  %prop1OfClassArg1 = ref_element_addr %5 : $B, #B.prop1
+  %prop1OfClassArg2 = ref_element_addr %6 : $B, #B.prop1
+  %prop2OfClassArg2 = ref_element_addr %6 : $B, #B.prop2
+  %prop1OfLocalClass1 = ref_element_addr %20 : $B, #B.prop1
+  %prop1OfLocalClass2 = ref_element_addr %21 : $B, #B.prop1
+  %prop2OfLocalClass2 = ref_element_addr %21 : $B, #B.prop2
+  %tailOfClassArg1 = ref_tail_addr %5 : $B, $Int64
+  %tailOfClassArg2 = ref_tail_addr %6 : $B, $Int64
+  %tailOfLocalClass1 = ref_tail_addr %20 : $B, $Int64
+  %tailOfLocalClass2 = ref_tail_addr %21 : $B, $Int64
+
+  %30 = alloc_box ${ var Int64, var Int64 }
+  %31 = alloc_box ${ var Int64, var Int64 }
+  %field0OfBoxArg1 = project_box %7 : ${ var Int64, var Int64 }, 0
+  %field0OfBoxArg2 = project_box %8 : ${ var Int64, var Int64 }, 0
+  %field1OfBoxArg2 = project_box %8 : ${ var Int64, var Int64 }, 1
+  %field0OfLocalBox1 = project_box %30 : ${ var Int64, var Int64 }, 0
+  %field0OfLocalBox2 = project_box %31 : ${ var Int64, var Int64 }, 0
+  %field1OfLocalBox2 = project_box %31 : ${ var Int64, var Int64 }, 1
+
+  %global1 = global_addr @global1 : $*Int64
+  %global2 = global_addr @global2 : $*Int64
+
+  %50 = function_ref @coro : $@yield_once @convention(thin) () -> @yields @inout Int64
+  (%yield1, %52) = begin_apply %50() : $@yield_once @convention(thin) () -> @yields @inout Int64
+  end_apply %52
+  (%yield2, %55) = begin_apply %50() : $@yield_once @convention(thin) () -> @yields @inout Int64
+  end_apply %55
+
+  %isDistinct = function_ref @_isDistinct : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %isNotDistinct = function_ref @_isNotDistinct : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+
+  // Function arguments
+  %101 = apply %isDistinct<Int64, Int64>(%inoutArg, %aliasableArg1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %102 = apply %isNotDistinct<Int64, Int64>(%aliasableArg1, %aliasableArg2) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+
+  // Pointers
+  %103 = apply %isNotDistinct<Int64, Int64>(%pointer1, %pointer2) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+
+  // Stack allocations
+  %104 = apply %isNotDistinct<Int64, Int64>(%stack1, %stack1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %105 = apply %isDistinct<Int64, Int64>(%stack1, %stack2) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+
+  // Classes
+  %121 = apply %isNotDistinct<Int64, Int64>(%prop1OfClassArg1, %prop1OfClassArg2) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %122 = apply %isDistinct<Int64, Int64>(%prop1OfClassArg1, %prop2OfClassArg2) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %123 = apply %isNotDistinct<Int64, Int64>(%prop1OfLocalClass1, %prop1OfLocalClass1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %124 = apply %isDistinct<Int64, Int64>(%prop1OfLocalClass1, %prop1OfLocalClass2) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %125 = apply %isDistinct<Int64, Int64>(%prop1OfLocalClass1, %prop2OfLocalClass2) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %126 = apply %isDistinct<Int64, Int64>(%prop1OfLocalClass1, %prop1OfClassArg1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+
+  // Tail elements
+  %127 = apply %isNotDistinct<Int64, Int64>(%tailOfClassArg1, %tailOfClassArg2) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %128 = apply %isDistinct<Int64, Int64>(%tailOfClassArg1, %tailOfLocalClass1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %129 = apply %isDistinct<Int64, Int64>(%tailOfLocalClass1, %tailOfLocalClass2) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %130 = apply %isNotDistinct<Int64, Int64>(%tailOfLocalClass1, %tailOfLocalClass1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+
+  // Boxes
+  %131 = apply %isNotDistinct<Int64, Int64>(%field0OfBoxArg1, %field0OfBoxArg2) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %132 = apply %isDistinct<Int64, Int64>(%field0OfBoxArg1, %field1OfBoxArg2) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %133 = apply %isNotDistinct<Int64, Int64>(%field0OfLocalBox1, %field0OfLocalBox1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %134 = apply %isDistinct<Int64, Int64>(%field0OfLocalBox1, %field0OfLocalBox2) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %135 = apply %isDistinct<Int64, Int64>(%field0OfLocalBox1, %field1OfLocalBox2) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %136 = apply %isDistinct<Int64, Int64>(%field0OfLocalBox1, %field0OfBoxArg1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+
+  // Globals
+  %140 = apply %isNotDistinct<Int64, Int64>(%global1, %global1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %141 = apply %isDistinct<Int64, Int64>(%global1, %global2) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+
+  // Yields
+  %145 = apply %isNotDistinct<Int64, Int64>(%yield1, %yield1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %146 = apply %isNotDistinct<Int64, Int64>(%yield1, %yield2) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+
+  // Function arguments vs others
+  %150 = apply %isNotDistinct<Int64, Int64>(%inoutArg, %pointer1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %151 = apply %isNotDistinct<Int64, Int64>(%aliasableArg1, %pointer1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %152 = apply %isDistinct<Int64, Int64>(%inoutArg, %stack1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %153 = apply %isDistinct<Int64, Int64>(%aliasableArg1, %stack1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %154 = apply %isDistinct<Int64, Int64>(%inoutArg, %prop1OfClassArg1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %155 = apply %isNotDistinct<Int64, Int64>(%aliasableArg1, %prop1OfClassArg1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %156 = apply %isDistinct<Int64, Int64>(%inoutArg, %prop1OfLocalClass1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %157 = apply %isDistinct<Int64, Int64>(%aliasableArg1, %prop1OfLocalClass1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %158 = apply %isDistinct<Int64, Int64>(%inoutArg, %tailOfClassArg1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %159 = apply %isDistinct<Int64, Int64>(%aliasableArg1, %tailOfLocalClass1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %160 = apply %isDistinct<Int64, Int64>(%inoutArg, %field0OfBoxArg1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %161 = apply %isNotDistinct<Int64, Int64>(%aliasableArg1, %field0OfBoxArg1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %162 = apply %isDistinct<Int64, Int64>(%inoutArg, %field0OfLocalBox1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %163 = apply %isDistinct<Int64, Int64>(%aliasableArg1, %field0OfLocalBox1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %164 = apply %isNotDistinct<Int64, Int64>(%inoutArg, %yield1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %165 = apply %isNotDistinct<Int64, Int64>(%aliasableArg1, %yield2) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+
+  // Classes vs others
+  %170 = apply %isNotDistinct<Int64, Int64>(%prop1OfClassArg1, %pointer1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %171 = apply %isNotDistinct<Int64, Int64>(%prop1OfLocalClass1, %pointer1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %172 = apply %isDistinct<Int64, Int64>(%prop1OfClassArg1, %stack1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %173 = apply %isDistinct<Int64, Int64>(%prop1OfClassArg1, %tailOfClassArg2) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %174 = apply %isDistinct<Int64, Int64>(%prop1OfClassArg1, %field0OfBoxArg1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %175 = apply %isDistinct<Int64, Int64>(%prop1OfClassArg1, %global1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %176 = apply %isNotDistinct<Int64, Int64>(%prop1OfClassArg1, %yield1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+
+  // Tail elements vs others
+  %180 = apply %isNotDistinct<Int64, Int64>(%tailOfClassArg1, %pointer1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %181 = apply %isNotDistinct<Int64, Int64>(%tailOfLocalClass1, %pointer1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %182 = apply %isDistinct<Int64, Int64>(%tailOfClassArg1, %stack1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %183 = apply %isDistinct<Int64, Int64>(%tailOfClassArg1, %field0OfBoxArg1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %184 = apply %isDistinct<Int64, Int64>(%tailOfClassArg1, %global1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %185 = apply %isNotDistinct<Int64, Int64>(%tailOfClassArg1, %yield1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+
+  // Yields vs others
+  %190 = apply %isNotDistinct<Int64, Int64>(%yield1, %pointer1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %191 = apply %isNotDistinct<Int64, Int64>(%yield1, %stack1) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+
+  dealloc_stack %stack2 : $*Int64
+  dealloc_stack %stack1 : $*Int64
+  %200 = tuple ()
+  return %200 : $()
+}
+
+// CHECK-LABEL: Accesses for testAccessPathAliasing
+// CHECK-NEXT: End accesses for testAccessPathAliasing
+sil @testAccessPathAliasing : $@convention(thin) (@inout TwoInts) -> () {
+bb0(%twoInts: $*TwoInts):
+  %a = struct_element_addr %twoInts : $*TwoInts, #TwoInts.a
+  %b = struct_element_addr %twoInts : $*TwoInts, #TwoInts.b
+
+  %isDistinct = function_ref @_isDistinct : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %isNotDistinct = function_ref @_isNotDistinct : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+
+  %10 = apply %isNotDistinct<TwoInts, TwoInts>(%twoInts, %twoInts) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %11 = apply %isNotDistinct<TwoInts, Int64>(%twoInts, %a) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %12 = apply %isNotDistinct<Int64, TwoInts>(%b, %twoInts) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+  %13 = apply %isDistinct<Int64, Int64>(%a, %b) : $@convention(thin) <τ_0_0, τ_0_1> (@inout τ_0_0, @inout τ_0_1) -> ()
+
+  // More complex paths are tested in the unit test for `SmallProjectionPath.mayOverlap`.
+
+  %200 = tuple ()
+  return %200 : $()
 }


### PR DESCRIPTION
While I was using the new AccessUtils for a new optimization pass I discovered some areas for improvements.
Changes:

* AccessBase: remove the unhealthy redundancy between `kind` and `baseAddress` types. Now AccessBase is single enum with the relevant base objects/addresses as payloads.

* AccessBase: for `global`, store the `GlobalValue` and not a `global_address` instruction, which is more accurate (because there can be multiple `global_addr`s for a single global variable)

* AccessBase: drop the support for function argument "pointers". The `pointer` is now always a `pointer_to_address` instruction. This also simplifies `PointerIdentification`: either it finds a matching `address_to_pointer` or it bails.

* AccessBase: improve `func isDistinct(from:)`. There are more possibilities to prove that two access bases do not alias.

* AccessBase: replace `var isUniquelyIdentified` with `var hasKnownStorageKind` which is more useful for aliasing checking.

* AccessPath: fix `func isDistinct(from:)`. `SmallProjectionPath.matches` is the wrong way to check if two expression paths may overlap. Instead use the new `SmallProjectionPath.mayOverlap`.

* AccessStoragePathWalker: rename `getAccessStorage` -> `visitAccessStorageRoots` and let it return false if it's not a class/reference AccessBase.

* add tests for `AccessPath.isDistinct(from:)`