### PR TITLE
Mangling: Print metatype representation conditionally

### DIFF
--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -2274,8 +2274,11 @@ NodePointer NodePrinter::print(NodePointer Node, unsigned depth,
     unsigned Idx = 0;
     if (Node->getNumChildren() == 2) {
       NodePointer repr = Node->getChild(Idx);
-      print(repr, depth + 1);
-      Printer << " ";
+      if (repr->getKind() == Node::Kind::MetatypeRepresentation &&
+          !Options.PrintForTypeName) {
+        print(repr, depth + 1);
+        Printer << " ";
+      }
       ++Idx;
     }
     NodePointer type = Node->getChild(Idx)->getChild(0);


### PR DESCRIPTION
When demangling a metatype, do not include `@thick`/`@thin`/etc when `PrintForTypeName` is true. This is useful where the demangled string is viewed by a user expecting a language typename, such as in lldb. For example `Thing.Type` instead of `@thick Thing.Type`.

rdar://98785473