### PR TITLE
[Compile Time Constant Extraction] Emit fully-qualified types and more kinds of literal expressions

### DIFF
--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -103,27 +103,11 @@ extractPropertyInitializationValue(VarDecl *propertyDecl) {
   if (binding) {
     auto originalInit = binding->getOriginalInit(0);
     if (originalInit) {
-      // Integer Literals
-      if (auto integerExpr =
-              dyn_cast_or_null<IntegerLiteralExpr>(originalInit)) {
-        std::string LiteralOutput;
-        llvm::raw_string_ostream OutputStream(LiteralOutput);
-        integerExpr->printConstExprValue(&OutputStream, nullptr);
-        OutputStream.flush();
+      std::string LiteralOutput;
+      llvm::raw_string_ostream OutputStream(LiteralOutput);
+      originalInit->printConstExprValue(&OutputStream, nullptr);
+      if (!LiteralOutput.empty())
         return std::make_shared<RawLiteralValue>(LiteralOutput);
-        // Float Literals
-      } else if (auto floatExpr =
-                     dyn_cast_or_null<FloatLiteralExpr>(originalInit)) {
-        std::string LiteralOutput;
-        llvm::raw_string_ostream OutputStream(LiteralOutput);
-        floatExpr->printConstExprValue(&OutputStream, nullptr);
-        OutputStream.flush();
-        return std::make_shared<RawLiteralValue>(LiteralOutput);
-        // String Literals
-      } else if (auto stringExpr =
-                     dyn_cast_or_null<StringLiteralExpr>(originalInit)) {
-        return std::make_shared<RawLiteralValue>(stringExpr->getValue().str());
-      }
     }
   }
 

--- a/lib/Option/features.json
+++ b/lib/Option/features.json
@@ -23,6 +23,9 @@
     },
     {
       "name": "enable-bare-slash-regex-updated"
+    },
+    {
+      "name": "emit-const-value-sidecar"
     }
   ]
 }

--- a/lib/Option/features.json
+++ b/lib/Option/features.json
@@ -23,6 +23,6 @@
     },
     {
       "name": "enable-bare-slash-regex-updated"
-    }    
+    }
   ]
 }

--- a/test/ConstExtraction/fields.swift
+++ b/test/ConstExtraction/fields.swift
@@ -18,6 +18,41 @@
 // CHECK-NEXT:        "value": "Hello, World"
 // CHECK-NEXT:      },
 // CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "p5",
+// CHECK-NEXT:        "type": "[Int]",
+// CHECK-NEXT:        "isStatic": "false",
+// CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "value": "[1, 2, 3, 4, 5, 6, 7, 8, 9]"
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "p6",
+// CHECK-NEXT:        "type": "Bool",
+// CHECK-NEXT:        "isStatic": "false",
+// CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "value": "false"
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "p7",
+// CHECK-NEXT:        "type": "Bool?",
+// CHECK-NEXT:        "isStatic": "false",
+// CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "value": "nil"
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "p8",
+// CHECK-NEXT:        "type": "(Int, Float)",
+// CHECK-NEXT:        "isStatic": "false",
+// CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "value": "(42, 6.6)"
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "p9",
+// CHECK-NEXT:        "type": "[String : Int]",
+// CHECK-NEXT:        "isStatic": "false",
+// CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "value": "[(\"One\", 1), (\"Two\", 2), (\"Three\", 3)]"
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "p0",
 // CHECK-NEXT:        "type": "Int",
 // CHECK-NEXT:        "isStatic": "true",
@@ -57,6 +92,11 @@ public struct Foo {
     static let p2: Float = 42.2
     var p3: Int {3}
     static var p4: Int {3}
+    let p5: [Int] = [1,2,3,4,5,6,7,8,9]
+    let p6: Bool = false
+    let p7: Bool? = nil
+    let p8: (Int, Float) = (42, 6.6)
+    let p9: [String: Int] = ["One": 1, "Two": 2, "Three": 3]
 }
 
 extension Foo : MyProto {}

--- a/test/ConstExtraction/fields.swift
+++ b/test/ConstExtraction/fields.swift
@@ -7,75 +7,75 @@
 // CHECK: [
 // CHECK-NEXT:
 // CHECK-NEXT:  {
-// CHECK-NEXT:    "typeName": "Foo",
+// CHECK-NEXT:    "typeName": "fields.Foo",
 // CHECK-NEXT:    "kind": "struct",
 // CHECK-NEXT:    "properties": [
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "p1",
-// CHECK-NEXT:        "type": "String",
+// CHECK-NEXT:        "type": "Swift.String",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "value": "Hello, World"
 // CHECK-NEXT:      },
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "p5",
-// CHECK-NEXT:        "type": "[Int]",
+// CHECK-NEXT:        "type": "[Swift.Int]",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "value": "[1, 2, 3, 4, 5, 6, 7, 8, 9]"
 // CHECK-NEXT:      },
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "p6",
-// CHECK-NEXT:        "type": "Bool",
+// CHECK-NEXT:        "type": "Swift.Bool",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "value": "false"
 // CHECK-NEXT:      },
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "p7",
-// CHECK-NEXT:        "type": "Bool?",
+// CHECK-NEXT:        "type": "Swift.Bool?",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "value": "nil"
 // CHECK-NEXT:      },
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "p8",
-// CHECK-NEXT:        "type": "(Int, Float)",
+// CHECK-NEXT:        "type": "(Swift.Int, Swift.Float)",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "value": "(42, 6.6)"
 // CHECK-NEXT:      },
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "p9",
-// CHECK-NEXT:        "type": "[String : Int]",
+// CHECK-NEXT:        "type": "[Swift.String : Swift.Int]",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "value": "[(\"One\", 1), (\"Two\", 2), (\"Three\", 3)]"
 // CHECK-NEXT:      },
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "p0",
-// CHECK-NEXT:        "type": "Int",
+// CHECK-NEXT:        "type": "Swift.Int",
 // CHECK-NEXT:        "isStatic": "true",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "value": "11"
 // CHECK-NEXT:      },
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "p2",
-// CHECK-NEXT:        "type": "Float",
+// CHECK-NEXT:        "type": "Swift.Float",
 // CHECK-NEXT:        "isStatic": "true",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "value": "42.2"
 // CHECK-NEXT:      },
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "p3",
-// CHECK-NEXT:        "type": "Int",
+// CHECK-NEXT:        "type": "Swift.Int",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "value": "Unknown"
 // CHECK-NEXT:      },
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "p4",
-// CHECK-NEXT:        "type": "Int",
+// CHECK-NEXT:        "type": "Swift.Int",
 // CHECK-NEXT:        "isStatic": "true",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "value": "Unknown"


### PR DESCRIPTION
- Add emission of supported Arrays, Dictionaries, Tuples, Booleans, and Optionals thanks to `Expr::printConstExprValue`.
- Print fully-qualified type names
- Add `features.json` entry so that compiler clients/users know this features is supported. 