### PR TITLE
[ModuleInterface] Print missing imports in swiftinterface

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5849,6 +5849,10 @@ ERROR(inlinable_typealias_desugars_to_type_from_hidden_module,
       "%4 was not imported by this file}5",
       (DeclName, StringRef, StringRef, unsigned, Identifier, unsigned))
 
+NOTE(missing_import_inserted,
+     none, "The missing import of module %0 will be added implicitly",
+     (Identifier))
+
 ERROR(availability_macro_in_inlinable, none,
       "availability macro cannot be used in " FRAGILE_FUNC_KIND "0",
       (unsigned))

--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -271,6 +271,10 @@ public:
   getImportedModules(SmallVectorImpl<ImportedModule> &imports,
                      ModuleDecl::ImportFilter filter) const {}
 
+  /// Lists modules that are not imported from this file and used in API.
+  virtual void
+  getMissingImportedModules(SmallVectorImpl<ImportedModule> &imports) const {}
+
   /// \see ModuleDecl::getImportedModulesForLookup
   virtual void getImportedModulesForLookup(
       SmallVectorImpl<ImportedModule> &imports) const {

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -713,6 +713,10 @@ public:
   void getImportedModules(SmallVectorImpl<ImportedModule> &imports,
                           ImportFilter filter = ImportFilterKind::Exported) const;
 
+  /// Lists modules that are not imported from a file and used in API.
+  void
+  getMissingImportedModules(SmallVectorImpl<ImportedModule> &imports) const;
+
   /// Looks up which modules are imported by this module, ignoring any that
   /// won't contain top-level decls.
   ///

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -399,6 +399,15 @@ public:
 
   SWIFT_DEBUG_DUMPER(dumpSeparatelyImportedOverlays());
 
+  llvm::SmallDenseSet<ImportedModule> MissingImportedModules;
+
+  void addMissingImportedModule(ImportedModule module) const {
+     const_cast<SourceFile *>(this)->MissingImportedModules.insert(module);
+  }
+
+  void getMissingImportedModules(
+         SmallVectorImpl<ImportedModule> &imports) const override;
+
   void cacheVisibleDecls(SmallVectorImpl<ValueDecl *> &&globals) const;
   const SmallVectorImpl<ValueDecl *> &getCachedVisibleDecls() const;
 

--- a/include/swift/Frontend/ModuleInterfaceSupport.h
+++ b/include/swift/Frontend/ModuleInterfaceSupport.h
@@ -53,6 +53,9 @@ struct ModuleInterfaceOptions {
   /// when PrintSPIs is true.
   bool ExperimentalSPIImports = false;
 
+  /// Print imports that are missing from the source and used in API.
+  bool PrintMissingImports = true;
+
   /// Intentionally print invalid syntax into the file.
   bool DebugPrintInvalidSyntax = false;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -900,6 +900,11 @@ def experimental_spi_imports :
   Flag<["-"], "experimental-spi-imports">,
   HelpText<"Enable experimental support for SPI imports">;
 
+def disable_print_missing_imports_in_module_interface :
+  Flag<["-"], "disable-print-missing-imports-in-module-interface">,
+  HelpText<"Disable adding to the module interface imports used from API and "
+           "missing from the sources">;
+
 // [FIXME: Clang-type-plumbing] Make this a SIL-only option once we start
 // unconditionally emitting non-canonical Clang types in swiftinterfaces.
 def experimental_print_full_convention :

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2547,7 +2547,8 @@ RestrictedImportKind SourceFile::getRestrictedImportKind(const ModuleDecl *modul
     return RestrictedImportKind::None;
 
   if (importKind == RestrictedImportKind::Implicit &&
-      module->getLibraryLevel() == LibraryLevel::API) {
+      (module->getLibraryLevel() == LibraryLevel::API ||
+       getParentModule()->getLibraryLevel() != LibraryLevel::API)) {
     // Hack to fix swiftinterfaces in case of missing imports.
     // We can get rid of this logic when we don't leak the use of non-locally
     // imported things in API.

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1570,6 +1570,11 @@ void ModuleDecl::getImportedModules(SmallVectorImpl<ImportedModule> &modules,
   FORWARD(getImportedModules, (modules, filter));
 }
 
+void ModuleDecl::getMissingImportedModules(
+    SmallVectorImpl<ImportedModule> &imports) const {
+  FORWARD(getMissingImportedModules, (imports));
+}
+
 void
 SourceFile::getImportedModules(SmallVectorImpl<ImportedModule> &modules,
                                ModuleDecl::ImportFilter filter) const {
@@ -1602,6 +1607,12 @@ SourceFile::getImportedModules(SmallVectorImpl<ImportedModule> &modules,
     if (filter.contains(requiredFilter))
       modules.push_back(desc.module);
   }
+}
+
+void SourceFile::getMissingImportedModules(
+    SmallVectorImpl<ImportedModule> &modules) const {
+  for (auto module : MissingImportedModules)
+    modules.push_back(module);
 }
 
 void SourceFile::dumpSeparatelyImportedOverlays() const {
@@ -2534,6 +2545,20 @@ RestrictedImportKind SourceFile::getRestrictedImportKind(const ModuleDecl *modul
   // Now check this file's enclosing module in case there are re-exports.
   if (imports.isImportedBy(module, getParentModule()))
     return RestrictedImportKind::None;
+
+  if (importKind == RestrictedImportKind::Implicit &&
+      module->getLibraryLevel() == LibraryLevel::API) {
+    // Hack to fix swiftinterfaces in case of missing imports.
+    // We can get rid of this logic when we don't leak the use of non-locally
+    // imported things in API.
+    ImportPath::Element pathElement = {module->getName(), SourceLoc()};
+    auto pathArray = getASTContext().AllocateCopy(
+                       llvm::makeArrayRef(pathElement));
+    auto missingImport = ImportedModule(
+                           ImportPath::Access(pathArray),
+                           const_cast<ModuleDecl *>(module));
+    addMissingImportedModule(missingImport);
+  }
 
   return importKind;
 }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -373,6 +373,8 @@ static void ParseModuleInterfaceArgs(ModuleInterfaceOptions &Opts,
     Args.hasArg(OPT_experimental_spi_imports);
   Opts.DebugPrintInvalidSyntax |=
     Args.hasArg(OPT_debug_emit_invalid_swiftinterface_syntax);
+  Opts.PrintMissingImports =
+    !Args.hasArg(OPT_disable_print_missing_imports_in_module_interface);
 
   if (const Arg *A = Args.getLastArg(OPT_library_level)) {
     StringRef contents = A->getValue();

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -219,6 +219,10 @@ static void printImports(raw_ostream &out,
 
   SmallVector<ImportedModule, 8> allImports;
   M->getImportedModules(allImports, allImportFilter);
+
+  if (Opts.PrintMissingImports)
+    M->getMissingImportedModules(allImports);
+
   ImportedModule::removeDuplicates(allImports);
   diagnoseScopedImports(M->getASTContext().Diags, allImports);
 

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -144,6 +144,11 @@ static bool diagnoseTypeAliasDeclRefExportability(SourceLoc loc,
   }
   D->diagnose(diag::kind_declared_here, DescriptiveDeclKind::Type);
 
+  if (originKind == DisallowedOriginKind::ImplicitlyImported &&
+      !ctx.LangOpts.isSwiftVersionAtLeast(6))
+    ctx.Diags.diagnose(loc, diag::missing_import_inserted,
+                       definingModule->getName());
+
   return true;
 }
 
@@ -190,7 +195,13 @@ static bool diagnoseValueDeclRefExportability(SourceLoc loc, const ValueDecl *D,
                        D->getDescriptiveKind(), D->getName(),
                        fragileKind.getSelector(), definingModule->getName(),
                        static_cast<unsigned>(originKind));
+
+    if (originKind == DisallowedOriginKind::ImplicitlyImported &&
+        downgradeToWarning == DowngradeToWarning::Yes)
+      ctx.Diags.diagnose(loc, diag::missing_import_inserted,
+                         definingModule->getName());
   }
+
   return true;
 }
 
@@ -244,5 +255,10 @@ TypeChecker::diagnoseConformanceExportability(SourceLoc loc,
       .warnUntilSwiftVersionIf(useConformanceAvailabilityErrorsOption &&
                                !ctx.LangOpts.EnableConformanceAvailabilityErrors,
                                6);
+
+    if (originKind == DisallowedOriginKind::ImplicitlyImported &&
+        !ctx.LangOpts.isSwiftVersionAtLeast(6))
+      ctx.Diags.diagnose(loc, diag::missing_import_inserted,
+                         M->getName());
   return true;
 }

--- a/test/Sema/implicit-import-in-inlinable-code.swift
+++ b/test/Sema/implicit-import-in-inlinable-code.swift
@@ -53,11 +53,13 @@ import libA
 @inlinable public func bar() {
   let a = ImportedType()
   a.implicitlyImportedMethod() // expected-warning {{instance method 'implicitlyImportedMethod()' cannot be used in an '@inlinable' function because 'libB' was not imported by this file; this is an error in Swift 6}}
+  // expected-note@-1 {{The missing import of module 'libB' will be added implicitly}}
 
   // Expected implicit imports are still fine
   a.localModuleMethod()
 
   conformanceUse(a) // expected-warning {{cannot use conformance of 'ImportedType' to 'SomeProtocol' here; 'libB' was not imported by this file; this is an error in Swift 6}}
+  // expected-note@-1 {{The missing import of module 'libB' will be added implicitly}}
 }
 
 // BEGIN clientFileA-OldCheck.swift
@@ -72,6 +74,7 @@ import libA
   a.localModuleMethod()
 
   conformanceUse(a) // expected-warning {{cannot use conformance of 'ImportedType' to 'SomeProtocol' here; 'libB' was not imported by this file; this is an error in Swift 6}}
+  // expected-note@-1 {{The missing import of module 'libB' will be added implicitly}}
 }
 
 // BEGIN clientFileA-Swift6.swift

--- a/test/Sema/implicit-import-in-inlinable-code.swift
+++ b/test/Sema/implicit-import-in-inlinable-code.swift
@@ -16,6 +16,14 @@
 /// In Swift 6, it's an error.
 // RUN: %target-swift-frontend -emit-module %t/clientFileA-Swift6.swift %t/clientFileB.swift -module-name client -o %t/client.swiftmodule -I %t -verify -swift-version 6
 
+/// The swiftinterface is broken by the missing import without the workaround.
+// RUN: %target-swift-emit-module-interface(%t/ClientBroken.swiftinterface)  %t/clientFileA-Swift5.swift %t/clientFileB.swift -I %t -disable-print-missing-imports-in-module-interface
+// RUN: not %target-swift-typecheck-module-from-interface(%t/ClientBroken.swiftinterface) -I %t
+
+/// The swiftinterface parses fine with the workaround adding the missing imports.
+// RUN: %target-swift-emit-module-interface(%t/ClientFixed.swiftinterface)  %t/clientFileA-Swift5.swift %t/clientFileB.swift -I %t
+// RUN: %target-swift-typecheck-module-from-interface(%t/ClientFixed.swiftinterface) -I %t
+
 // REQUIRES: asserts
 
 // BEGIN empty.swift

--- a/test/Sema/implicit-import-typealias.swift
+++ b/test/Sema/implicit-import-typealias.swift
@@ -11,6 +11,19 @@
 // RUN: %target-swift-frontend -typecheck -verify %t/UsesAliasesImplementationOnlyImport.swift -I %t
 // RUN: %target-swift-frontend -typecheck -verify %t/UsesAliasesWithImport.swift  -I %t
 
+/// The swiftinterface is broken by the missing import without the workaround.
+// RUN: %target-swift-emit-module-interface(%t/UsesAliasesNoImport.swiftinterface) %t/UsesAliasesNoImport.swift -I %t \
+// RUN:   -disable-print-missing-imports-in-module-interface
+// RUN: not %target-swift-typecheck-module-from-interface(%t/UsesAliasesNoImport.swiftinterface) -I %t
+
+/// The swiftinterface parses fine with the workaround adding the missing imports.
+// RUN: %target-swift-emit-module-interface(%t/UsesAliasesNoImportFixed.swiftinterface) %t/UsesAliasesNoImport.swift -I %t
+// RUN: %target-swift-typecheck-module-from-interface(%t/UsesAliasesNoImportFixed.swiftinterface) -I %t
+
+/// The module with an implementation-only import is not affected by the workaround and remains broken.
+// RUN: %target-swift-emit-module-interface(%t/UsesAliasesImplementationOnlyImport.swiftinterface) %t/UsesAliasesImplementationOnlyImport.swift -I %t \
+// RUN:   -disable-print-missing-imports-in-module-interface
+// RUN: not %target-swift-typecheck-module-from-interface(%t/UsesAliasesImplementationOnlyImport.swiftinterface) -I %t
 
 //--- Original.swift
 

--- a/test/Sema/implicit-import-typealias.swift
+++ b/test/Sema/implicit-import-typealias.swift
@@ -60,23 +60,28 @@ public typealias WrapperAlias = Wrapper
 
 import Aliases
 
-// expected-warning@+1 {{'ClazzAlias' aliases 'Original.Clazz' and cannot be used here because 'Original' was not imported by this file; this is an error in Swift 6}}
+// expected-warning@+2 {{'ClazzAlias' aliases 'Original.Clazz' and cannot be used here because 'Original' was not imported by this file; this is an error in Swift 6}}
+// expected-note@+1 {{The missing import of module 'Original' will be added implicitly}}
 public class InheritsFromClazzAlias: ClazzAlias {}
 
 @inlinable public func inlinableFunc() {
-  // expected-warning@+1 {{'StructAlias' aliases 'Original.Struct' and cannot be used in an '@inlinable' function because 'Original' was not imported by this file; this is an error in Swift 6}}
+  // expected-warning@+2 {{'StructAlias' aliases 'Original.Struct' and cannot be used in an '@inlinable' function because 'Original' was not imported by this file; this is an error in Swift 6}}
+  // expected-note@+1 {{The missing import of module 'Original' will be added implicitly}}
   _ = StructAlias.self
 }
 
-// expected-warning@+1 {{'ProtoAlias' aliases 'Original.Proto' and cannot be used here because 'Original' was not imported by this file; this is an error in Swift 6}}
+// expected-warning@+2 {{'ProtoAlias' aliases 'Original.Proto' and cannot be used here because 'Original' was not imported by this file; this is an error in Swift 6}}
+// expected-note@+1 {{The missing import of module 'Original' will be added implicitly}}
 public func takesGeneric<T: ProtoAlias>(_ t: T) {}
 
 public struct HasMembers {
-  // expected-warning@+1 {{'WrapperAlias' aliases 'Original.Wrapper' and cannot be used as property wrapper here because 'Original' was not imported by this file; this is an error in Swift 6}}
+  // expected-warning@+2 {{'WrapperAlias' aliases 'Original.Wrapper' and cannot be used as property wrapper here because 'Original' was not imported by this file; this is an error in Swift 6}}
+ // expected-note@+1 {{The missing import of module 'Original' will be added implicitly}}
   @WrapperAlias public var wrapped: Int
 }
 
-// expected-warning@+1 {{'StructAlias' aliases 'Original.Struct' and cannot be used in an extension with public or '@usableFromInline' members because 'Original' was not imported by this file; this is an error in Swift 6}}
+// expected-warning@+2 {{'StructAlias' aliases 'Original.Struct' and cannot be used in an extension with public or '@usableFromInline' members because 'Original' was not imported by this file; this is an error in Swift 6}}
+// expected-note@+1 {{The missing import of module 'Original' will be added implicitly}}
 extension StructAlias {
   public func someFunc() {}
 }


### PR DESCRIPTION
We already diagnose the use in API of a module that is not imported, let's use that information to print the missing imports in the swiftinterfaces. We can get rid of this hack when we don't leak the use of non-locally imported things in API.