### PR TITLE
[Concurrency] Fix a few annotations for the concurrency library

### DIFF
--- a/stdlib/public/BackDeployConcurrency/CheckedContinuation.swift
+++ b/stdlib/public/BackDeployConcurrency/CheckedContinuation.swift
@@ -119,7 +119,7 @@ internal final class CheckedContinuationCanary: @unchecked Sendable {
 /// you can replace one with the other in most circumstances,
 /// without making other changes.
 @available(SwiftStdlib 5.1, *)
-public struct CheckedContinuation<T, E: Error> {
+public struct CheckedContinuation<T, E: Error>: Sendable {
   private let canary: CheckedContinuationCanary
   
   /// Creates a checked continuation from an unsafe continuation.
@@ -185,9 +185,6 @@ public struct CheckedContinuation<T, E: Error> {
     }
   }
 }
-
-@available(SwiftStdlib 5.1, *)
-extension CheckedContinuation: Sendable where T: Sendable { }
 
 @available(SwiftStdlib 5.1, *)
 extension CheckedContinuation {

--- a/stdlib/public/BackDeployConcurrency/PartialAsyncTask.swift
+++ b/stdlib/public/BackDeployConcurrency/PartialAsyncTask.swift
@@ -69,7 +69,7 @@ public struct UnownedJob: Sendable {
 /// without making other changes.
 @available(SwiftStdlib 5.1, *)
 @frozen
-public struct UnsafeContinuation<T, E: Error> {
+public struct UnsafeContinuation<T, E: Error>: Sendable {
   @usableFromInline internal var context: Builtin.RawUnsafeContinuation
 
   @_alwaysEmitIntoClient
@@ -143,9 +143,6 @@ public struct UnsafeContinuation<T, E: Error> {
 #endif
   }
 }
-
-@available(SwiftStdlib 5.1, *)
-extension UnsafeContinuation: Sendable where T: Sendable { }
 
 @available(SwiftStdlib 5.1, *)
 extension UnsafeContinuation {

--- a/stdlib/public/Concurrency/CheckedContinuation.swift
+++ b/stdlib/public/Concurrency/CheckedContinuation.swift
@@ -119,7 +119,7 @@ internal final class CheckedContinuationCanary: @unchecked Sendable {
 /// you can replace one with the other in most circumstances,
 /// without making other changes.
 @available(SwiftStdlib 5.1, *)
-public struct CheckedContinuation<T, E: Error> {
+public struct CheckedContinuation<T, E: Error>: Sendable {
   private let canary: CheckedContinuationCanary
   
   /// Creates a checked continuation from an unsafe continuation.
@@ -185,9 +185,6 @@ public struct CheckedContinuation<T, E: Error> {
     }
   }
 }
-
-@available(SwiftStdlib 5.1, *)
-extension CheckedContinuation: Sendable where T: Sendable { }
 
 @available(SwiftStdlib 5.1, *)
 extension CheckedContinuation {

--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -69,7 +69,7 @@ public struct UnownedJob: Sendable {
 /// without making other changes.
 @available(SwiftStdlib 5.1, *)
 @frozen
-public struct UnsafeContinuation<T, E: Error> {
+public struct UnsafeContinuation<T, E: Error>: Sendable {
   @usableFromInline internal var context: Builtin.RawUnsafeContinuation
 
   @_alwaysEmitIntoClient
@@ -143,9 +143,6 @@ public struct UnsafeContinuation<T, E: Error> {
 #endif
   }
 }
-
-@available(SwiftStdlib 5.1, *)
-extension UnsafeContinuation: Sendable where T: Sendable { }
 
 @available(SwiftStdlib 5.1, *)
 extension UnsafeContinuation {

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -65,6 +65,7 @@ import Swift
 /// use the `withThrowingTaskGroup(of:returning:body:)` method instead.
 @available(SwiftStdlib 5.1, *)
 @_silgen_name("$ss13withTaskGroup2of9returning4bodyq_xm_q_mq_ScGyxGzYaXEtYar0_lF")
+@_unsafeInheritExecutor
 @inlinable
 public func withTaskGroup<ChildTaskResult, GroupResult>(
   of childTaskResultType: ChildTaskResult.Type,
@@ -157,6 +158,7 @@ public func withTaskGroup<ChildTaskResult, GroupResult>(
 /// or to let the group rethrow the error.
 @available(SwiftStdlib 5.1, *)
 @_silgen_name("$ss21withThrowingTaskGroup2of9returning4bodyq_xm_q_mq_Scgyxs5Error_pGzYaKXEtYaKr0_lF")
+@_unsafeInheritExecutor
 @inlinable
 public func withThrowingTaskGroup<ChildTaskResult, GroupResult>(
   of childTaskResultType: ChildTaskResult.Type,

--- a/test/Concurrency/async_tasks.swift
+++ b/test/Concurrency/async_tasks.swift
@@ -89,7 +89,6 @@ func test_unsafeThrowingContinuations() async throws {
 
 // ==== Sendability ------------------------------------------------------------
 class NotSendable { }
-// expected-note@-1{{class 'NotSendable' does not conform to the 'Sendable' protocol}}
 
 @available(SwiftStdlib 5.1, *)
 func test_nonsendableContinuation() async throws {
@@ -99,7 +98,7 @@ func test_nonsendableContinuation() async throws {
 
   let _: NotSendable = try await withUnsafeThrowingContinuation { continuation in
     Task {
-      continuation.resume(returning: NotSendable()) // expected-warning{{capture of 'continuation' with non-sendable type 'UnsafeContinuation<NotSendable, any Error>' in a `@Sendable` closure}}
+      continuation.resume(returning: NotSendable()) // okay
     }
   }
 }

--- a/test/Concurrency/unsafe_inherit_executor_lib.swift
+++ b/test/Concurrency/unsafe_inherit_executor_lib.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -typecheck -verify -disable-availability-checking %s -strict-concurrency=complete
+
+actor A {
+  func g() { }
+  func h() throws { }
+  
+  func f() async throws {
+    await withTaskGroup(of: Int.self, returning: Void.self) { group in
+      g()
+    }
+
+    try await withThrowingTaskGroup(of: Int.self, returning: Void.self) { group in
+      try h()
+    }
+  }
+}


### PR DESCRIPTION
Introduce two fixes for annotations to the concurrency library:
* Apply `@_unsafeInheritExecutor` to `with(Throwing)TaskGroup` (rdar://98461630)
* Make `CheckedContinuation` and `UnsafeContinuation` unconditionally `Sendable` (rdar://98462858)