### PR TITLE
Add a flag to infer appropriate cross compile hosts on Darwin

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1237,7 +1237,7 @@ release-debuginfo
 compiler-vendor=apple
 
 # Cross compile for Apple Silicon
-cross-compile-hosts=macosx-arm64
+infer-cross-compile-hosts-on-darwin
 
 lldb-use-system-debugserver
 lldb-build-type=Release

--- a/utils/build-script
+++ b/utils/build-script
@@ -389,6 +389,21 @@ def apply_default_arguments(toolchain, args):
             '-DSWIFT_DARWIN_MODULE_ARCHS:STRING={}'.format(
                 args.swift_darwin_module_archs))
 
+    if (args.infer_cross_compile_hosts_on_darwin and
+            platform.system() == "Darwin"):
+        args.cross_compile_hosts = _infer_cross_compile_hosts_on_darwin()
+        print("Inferred the following hosts for cross compilations: "
+              f"{args.cross_compile_hosts}")
+        sys.stdout.flush()
+
+
+def _infer_cross_compile_hosts_on_darwin():
+    if platform.machine() == "x86_64":
+        return ["macosx-arm64"]
+    else:
+        return ["macosx-x86_64"]
+
+
 # -----------------------------------------------------------------------------
 # Main (preset)
 

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -580,6 +580,11 @@ def create_argument_parser():
            help='A space separated list of targets to cross-compile host '
                 'Swift tools for. Can be used multiple times.')
 
+    option('--infer-cross-compile-hosts-on-darwin', toggle_true,
+           help="When building on Darwin, automatically populate cross-compile-hosts "
+                "based on the architecture build-script is running on. "
+                "Has precedence over cross-compile-hosts")
+
     option('--cross-compile-deps-path', store_path,
            help='The path to a directory that contains prebuilt cross-compiled '
                 'library dependencies of the corelibs and other Swift repos, '

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -133,6 +133,7 @@ EXPECTED_DEFAULTS = {
     'cross_compile_append_host_target_to_destdir': True,
     'cross_compile_deps_path': None,
     'cross_compile_hosts': [],
+    'infer_cross_compile_hosts_on_darwin': False,
     'darwin_deployment_version_ios':
         defaults.DARWIN_DEPLOYMENT_VERSION_IOS,
     'darwin_deployment_version_osx':
@@ -732,6 +733,7 @@ EXPECTED_OPTIONS = [
     IntOption('--dsymutil-jobs', dest='dsymutil_jobs'),
 
     AppendOption('--cross-compile-hosts'),
+    SetTrueOption('--infer-cross-compile-hosts-on-darwin'),
     AppendOption('--extra-cmake-options'),
     AppendOption('--extra-swift-args'),
     AppendOption('--test-paths'),

--- a/validation-test/BuildSystem/infer-cross-compile-hosts-on-darwin-linux.test
+++ b/validation-test/BuildSystem/infer-cross-compile-hosts-on-darwin-linux.test
@@ -1,0 +1,13 @@
+# REQUIRES: standalone_build
+# REQUIRES: OS=linux-gnu
+
+# RUN: %empty-directory(%t)
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --infer-cross-compile-hosts-on-darwin --cmake %cmake  2>&1 | %FileCheck --check-prefix=NO-INFER-CROSS-COMPILE-HOSTS-ON-DARWIN %s
+# RUN: %empty-directory(%t)
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --infer-cross-compile-hosts-on-darwin=1 --cmake %cmake  2>&1 | %FileCheck --check-prefix=NO-INFER-CROSS-COMPILE-HOSTS-ON-DARWIN %s
+# RUN: %empty-directory(%t)
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --cmake %cmake  2>&1 | %FileCheck --check-prefix=NO-INFER-CROSS-COMPILE-HOSTS-ON-DARWIN %s
+# RUN: %empty-directory(%t)
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --infer-cross-compile-hosts-on-darwin=0 --cmake %cmake  2>&1 | %FileCheck --check-prefix=NO-INFER-CROSS-COMPILE-HOSTS-ON-DARWIN %s
+
+# NO-INFER-CROSS-COMPILE-HOSTS-ON-DARWIN-NOT: Inferred the following hosts for cross compilations:

--- a/validation-test/BuildSystem/infer-cross-compile-hosts-on-darwin-macosx.test
+++ b/validation-test/BuildSystem/infer-cross-compile-hosts-on-darwin-macosx.test
@@ -1,0 +1,18 @@
+# REQUIRES: standalone_build
+# REQUIRES: OS=macosx
+
+# RUN: %empty-directory(%t)
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --infer-cross-compile-hosts-on-darwin --cmake %cmake  2>&1 | %FileCheck --check-prefix=INFER-CROSS-COMPILE-HOSTS-ON-DARWIN-%target-cpu %s
+# RUN: %empty-directory(%t)
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --infer-cross-compile-hosts-on-darwin=1 --cmake %cmake  2>&1 | %FileCheck --check-prefix=INFER-CROSS-COMPILE-HOSTS-ON-DARWIN-%target-cpu %s
+
+# INFER-CROSS-COMPILE-HOSTS-ON-DARWIN-x86_64: Inferred the following hosts for cross compilations: ['macosx-arm64']
+# INFER-CROSS-COMPILE-HOSTS-ON-DARWIN-arm64: Inferred the following hosts for cross compilations: ['macosx-x86_64']
+
+
+# RUN: %empty-directory(%t)
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --cmake %cmake  2>&1 | %FileCheck --check-prefix=NO-INFER-CROSS-COMPILE-HOSTS-ON-DARWIN %s
+# RUN: %empty-directory(%t)
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --infer-cross-compile-hosts-on-darwin=0 --cmake %cmake  2>&1 | %FileCheck --check-prefix=NO-INFER-CROSS-COMPILE-HOSTS-ON-DARWIN %s
+
+# NO-INFER-CROSS-COMPILE-HOSTS-ON-DARWIN-NOT: Inferred the following hosts for cross compilations:


### PR DESCRIPTION
Use that immediately for the macOS package presets.

Addresses rdar://98787335, #60348