### PR TITLE
[IDE] Add result builder code completion for buildPartialBlock

### DIFF
--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -304,6 +304,8 @@ namespace swift {
     BuildArray,
     BuildLimitedAvailability,
     BuildFinalResult,
+    BuildPartialBlockFirst,
+    BuildPartialBlockAccumulated,
   };
 
   /// Try to infer the component type of a result builder from the type

--- a/lib/IDE/CompletionOverrideLookup.cpp
+++ b/lib/IDE/CompletionOverrideLookup.cpp
@@ -462,6 +462,11 @@ StringRef CompletionOverrideLookup::getResultBuilderDocComment(
 
   case ResultBuilderBuildFunction::BuildOptional:
     return "Enables support for `if` statements that do not have an `else`";
+  case ResultBuilderBuildFunction::BuildPartialBlockFirst:
+    return "Builds a partial result component from the first component";
+  case ResultBuilderBuildFunction::BuildPartialBlockAccumulated:
+    return "Builds a partial result component by combining an accumulated "
+           "component and a new component";
   }
 }
 
@@ -514,6 +519,12 @@ void CompletionOverrideLookup::addResultBuilderBuildCompletions(
       ResultBuilderBuildFunction::BuildLimitedAvailability);
   addResultBuilderBuildCompletion(builder, componentType,
                                   ResultBuilderBuildFunction::BuildFinalResult);
+  addResultBuilderBuildCompletion(
+      builder, componentType,
+      ResultBuilderBuildFunction::BuildPartialBlockFirst);
+  addResultBuilderBuildCompletion(
+      builder, componentType,
+      ResultBuilderBuildFunction::BuildPartialBlockAccumulated);
 }
 
 void CompletionOverrideLookup::getOverrideCompletions(SourceLoc Loc) {

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -2930,6 +2930,13 @@ void swift::printResultBuilderBuildFunction(
             << ") -> <#Result#>";
     printedResult = true;
     break;
+  case ResultBuilderBuildFunction::BuildPartialBlockFirst:
+    printer << "buildPartialBlock(first: " << componentTypeString << ")";
+    break;
+  case ResultBuilderBuildFunction::BuildPartialBlockAccumulated:
+    printer << "buildPartialBlock(accumulated: " << componentTypeString
+            << ", next: " << componentTypeString << ")";
+    break;
   }
 
   if (!printedResult)

--- a/test/IDE/complete_result_builder.swift
+++ b/test/IDE/complete_result_builder.swift
@@ -105,7 +105,7 @@ struct AnyBuilder {
   static func #^IN_RESULT_BUILDER_DECL^#
 }
 
-// IN_RESULT_BUILDER_DECL: Begin completions, 8 items
+// IN_RESULT_BUILDER_DECL: Begin completions, 10 items
 // IN_RESULT_BUILDER_DECL: Pattern/CurrNominal:                buildBlock(_ components: Any...) -> Any {|}; name=buildBlock(_ components: Any...) -> Any; comment=Required by every
 // IN_RESULT_BUILDER_DECL: Pattern/CurrNominal:                buildExpression(_ expression: <#Expression#>) -> Any {|}; name=buildExpression(_ expression: <#Expression#>) -> Any; comment=
 // IN_RESULT_BUILDER_DECL: Pattern/CurrNominal:                buildOptional(_ component: Any?) -> Any {|}; name=buildOptional(_ component: Any?) -> Any; comment=
@@ -114,6 +114,8 @@ struct AnyBuilder {
 // IN_RESULT_BUILDER_DECL: Pattern/CurrNominal:                buildArray(_ components: [Any]) -> Any {|}; name=buildArray(_ components: [Any]) -> Any; comment=
 // IN_RESULT_BUILDER_DECL: Pattern/CurrNominal:                buildLimitedAvailability(_ component: Any) -> Any {|}; name=buildLimitedAvailability(_ component: Any) -> Any; comment=
 // IN_RESULT_BUILDER_DECL: Pattern/CurrNominal:                buildFinalResult(_ component: Any) -> <#Result#> {|}; name=buildFinalResult(_ component: Any) -> <#Result#>; comment=
+// IN_RESULT_BUILDER_DECL: Pattern/CurrNominal:                buildPartialBlock(first: Any) -> Any {|}; name=buildPartialBlock(first: Any) -> Any; comment=
+// IN_RESULT_BUILDER_DECL: Pattern/CurrNominal:                buildPartialBlock(accumulated: Any, next: Any) -> Any {|}; name=buildPartialBlock(accumulated: Any, next: Any) -> Any; comment=
 // IN_RESULT_BUILDER_DECL: End completions
 
 // IN_RESULT_BUILDER_DECL_PREFIX: Begin completions
@@ -125,4 +127,6 @@ struct AnyBuilder {
 // IN_RESULT_BUILDER_DECL_PREFIX: Pattern/CurrNominal: static func buildArray(_ components: [Any]) -> Any {|}; name=static func buildArray(_ components: [Any]) -> Any; comment=
 // IN_RESULT_BUILDER_DECL_PREFIX: Pattern/CurrNominal: static func buildLimitedAvailability(_ component: Any) -> Any {|}; name=static func buildLimitedAvailability(_ component: Any) -> Any; comment=
 // IN_RESULT_BUILDER_DECL_PREFIX: Pattern/CurrNominal: static func buildFinalResult(_ component: Any) -> <#Result#> {|}; name=static func buildFinalResult(_ component: Any) -> <#Result#>; comment=
+// IN_RESULT_BUILDER_DECL_PREFIX: Pattern/CurrNominal: static func buildPartialBlock(first: Any) -> Any {|}; name=static func buildPartialBlock(first: Any) -> Any; comment=
+// IN_RESULT_BUILDER_DECL_PREFIX: Pattern/CurrNominal: static func buildPartialBlock(accumulated: Any, next: Any) -> Any {|}; name=static func buildPartialBlock(accumulated: Any, next: Any) -> Any; comment=
 // IN_RESULT_BUILDER_DECL_PREFIX: End completions


### PR DESCRIPTION
Resolves #59885. Adds missing code completion support for `buildPartialBlock`.