### PR TITLE
[SIL] Maintain owned argument lifetimes at inlining.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/WalkUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/WalkUtils.swift
@@ -341,7 +341,7 @@ extension ValueDefUseWalker {
         return unmatchedPath(value: operand, path: path)
       }
     case is InitExistentialRefInst, is OpenExistentialRefInst,
-      is BeginBorrowInst, is CopyValueInst,
+      is BeginBorrowInst, is CopyValueInst, is MoveValueInst,
       is UpcastInst, is UncheckedRefCastInst, is EndCOWMutationInst,
       is RefToBridgeObjectInst, is BridgeObjectToRefInst, is MarkMustCheckInst:
       return walkDownUses(ofValue: (instruction as! SingleValueInstruction), path: path)
@@ -618,7 +618,7 @@ extension ValueUseDefWalker {
         return rootDef(value: mvr, path: path)
       }
     case is InitExistentialRefInst, is OpenExistentialRefInst,
-      is BeginBorrowInst, is CopyValueInst,
+      is BeginBorrowInst, is CopyValueInst, is MoveValueInst,
       is UpcastInst, is UncheckedRefCastInst, is EndCOWMutationInst,
       is RefToBridgeObjectInst, is BridgeObjectToRefInst, is MarkMustCheckInst:
       return walkUp(value: (def as! Instruction).operands[0].value, path: path)

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -609,6 +609,8 @@ final public class ProjectBoxInst : SingleValueInstruction, UnaryInstruction {
 
 final public class CopyValueInst : SingleValueInstruction, UnaryInstruction {}
 
+final public class MoveValueInst : SingleValueInstruction, UnaryInstruction {}
+
 final public class StrongCopyUnownedValueInst : SingleValueInstruction, UnaryInstruction {}
 
 final public class StrongCopyUnmanagedValueInst : SingleValueInstruction, UnaryInstruction  {}

--- a/SwiftCompilerSources/Sources/SIL/Registration.swift
+++ b/SwiftCompilerSources/Sources/SIL/Registration.swift
@@ -123,6 +123,7 @@ public func registerSILClasses() {
   register(BeginBorrowInst.self)
   register(ProjectBoxInst.self)
   register(CopyValueInst.self)
+  register(MoveValueInst.self)
   register(EndCOWMutationInst.self)
   register(ClassifyBridgeObjectInst.self)
   register(PartialApplyInst.self)

--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -2458,6 +2458,12 @@ That the first three have constrained lifetimes is encoded in
 ValueBase::isLexical, which should be checked before changing the lifetime of a
 value.
 
+When a function is inlined into its caller, a lexical borrow scope is added for
+each of its @guaranteed arguments, and a lexical move is added for each of its
+@owned arguments, (unless the values being passed are already lexical
+themselves) ensuring that the lifetimes of the corresponding source-level
+values are not shortened in a way that doesn't respect deinit barriers.
+
 Unlike the other sorts, `alloc_stack [lexical]` isn't a SILValue.  Instead, it
 constrains the lifetime of an addressable variable.  Since the constraint is
 applied to the in-memory representation, no additional lexical SILValue is

--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -2414,27 +2414,49 @@ Variable Lifetimes
 In order for programmer intended lifetimes to be maintained under optimization,
 the lifetimes of SIL values which correspond to named source-level values can
 only be modified in limited ways.  Generally, the behavior is that the lifetime
-of a named source-level value cannot _observably_ end before the end of the
-lexical scope in which that value is defined.  Specifically, code motion may
-not move the ends of these lifetimes across a **deinit barrier**.
+of a named source-level value is anchored to the variable's lexical scope and
+confined by **deinit barriers**.  Specifically, code motion may not move the
+ends of these lifetimes across a deinit barrier.
 
-A few sorts of SIL value have lifetimes that are constrained that way:
+Source level variables (lets, vars, ...) and function arguments will result in
+SIL-level lexical lifetimes if either of the two sets of circumstances apply:
+(1) Inferred lexicality.
+- the type is non-trivial
+- the type is not eager-move
+- the variable or argument is not annotated to be eager-move
+OR
+(2) Explicit lexicality.
+- the type, variable, or argument is annotated `@_lexical`
+
+A type is eager-move by satisfying one of two conditions:
+(1) Inferred: An aggregate is inferred to be eager-move if all of its fields are
+    eager-move.
+(2) Annotated: Any type can be eager-move if it is annotated with an attribute
+    that explicitly specifies it to be: `@_eagerMove`, `@_noImplicitCopy`.
+
+A variable or argument is eager-move by satisfying one of two conditions:
+(1) Inferred: Its type is eager-move.
+(2) Annotated: The variable or argument is annotated with an attribute that
+    specifies it to be: `@_eagerMove`, `@_noImplicitCopy`.
+
+These source-level rules result in a few sorts of SIL value whose destroys must
+not be moved across deinit barriers:
 
 1: `begin_borrow [lexical]`
 2: `move_value [lexical]`
-3: @owned function arguments
+3: function arguments
 4: `alloc_stack [lexical]`
 
-That these three have constrained lifetimes is encoded in ValueBase::isLexical,
-which should be checked before changing the lifetime of a value.
+To translate from the source-level representation of lexicality to the
+SIL-level representation, for source-level variables (vars, lets, ...) SILGen
+generates `begin_borrow [lexical]`, `move_value [lexical]`, `alloc_stack
+[lexical]` .  For function arguments, there is no work to do:
+a `SILFunctionArgument` itself can be lexical
+(`SILFunctionArgument::isLexical`).
 
-The reason that only @owned function arguments are constrained is that a
-@guaranteed function argument is guaranteed by the function's caller to live for
-the full duration of the function already.  Optimization of the function alone
-can't shorten it.  When such a function is inlined into its caller, though, a
-lexical borrow scope is added for each of its @guaranteed arguments, ensuring
-that the lifetime of the corresponding source-level value is not shortened in a
-way that doesn't respect deinit barriers.
+That the first three have constrained lifetimes is encoded in
+ValueBase::isLexical, which should be checked before changing the lifetime of a
+value.
 
 Unlike the other sorts, `alloc_stack [lexical]` isn't a SILValue.  Instead, it
 constrains the lifetime of an addressable variable.  Since the constraint is

--- a/include/swift/SIL/InstructionUtils.h
+++ b/include/swift/SIL/InstructionUtils.h
@@ -88,8 +88,8 @@ SILValue stripBorrow(SILValue V);
 //===----------------------------------------------------------------------===//
 
 /// Return a non-null SingleValueInstruction if the given instruction merely
-/// copies the value of its first operand, possibly changing its type or
-/// ownership state, but otherwise having no effect.
+/// copies or moves the value of its first operand, possibly changing its type
+/// or ownership state, but otherwise having no effect.
 ///
 /// The returned instruction may have additional "incidental" operands;
 /// mark_dependence for example.

--- a/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
@@ -109,7 +109,7 @@
 
 namespace swift {
 
-extern llvm::Statistic NumCopiesEliminated;
+extern llvm::Statistic NumCopiesAndMovesEliminated;
 extern llvm::Statistic NumCopiesGenerated;
 
 /// Insert a copy on this operand. Trace and update stats.

--- a/lib/SIL/IR/SILValue.cpp
+++ b/lib/SIL/IR/SILValue.cpp
@@ -116,11 +116,8 @@ ValueBase::getDefiningInstructionResult() {
 }
 
 bool ValueBase::isLexical() const {
-  if (auto *argument = dyn_cast<SILFunctionArgument>(this)) {
-    // TODO: Recognize guaranteed arguments as lexical too.
-    return argument->getOwnershipKind() == OwnershipKind::Owned &&
-           argument->getLifetime().isLexical();
-  }
+  if (auto *argument = dyn_cast<SILFunctionArgument>(this))
+    return argument->getLifetime().isLexical();
   if (auto *bbi = dyn_cast<BeginBorrowInst>(this))
     return bbi->isLexical();
   if (auto *mvi = dyn_cast<MoveValueInst>(this))

--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -256,6 +256,7 @@ SingleValueInstruction *swift::getSingleValueCopyOrCast(SILInstruction *I) {
   case SILInstructionKind::BeginBorrowInst:
   case SILInstructionKind::BeginAccessInst:
   case SILInstructionKind::MarkDependenceInst:
+  case SILInstructionKind::MoveValueInst:
     return cast<SingleValueInstruction>(I);
   }
 }

--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -31,6 +31,7 @@ SILValue swift::lookThroughOwnershipInsts(SILValue v) {
     switch (v->getKind()) {
     default:
       return v;
+    case ValueKind::MoveValueInst:
     case ValueKind::CopyValueInst:
     case ValueKind::BeginBorrowInst:
       v = cast<SingleValueInstruction>(v)->getOperand(0);

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -2409,16 +2409,25 @@ void swift::visitTransitiveEndBorrows(
 ///
 /// A begin_borrow [lexical] is nested if the borrowed value's lifetime is
 /// guaranteed by another lexical scope.  That happens if:
-/// - the value is a guaranteed argument to the function
-/// - the value is itself a begin_borrow [lexical]
+/// - the non-guaranteed borrowee's value is lexical
+/// - the guaranteed borrowee's value's reference roots are lexical
+///   - for example, the borrowee is itself a begin_borrow [lexical]
 bool swift::isNestedLexicalBeginBorrow(BeginBorrowInst *bbi) {
   assert(bbi->isLexical());
   auto value = bbi->getOperand();
-  if (auto *outerBBI = dyn_cast<BeginBorrowInst>(value)) {
-    return outerBBI->isLexical();
+  if (value->getOwnershipKind() != OwnershipKind::Guaranteed) {
+    return value->isLexical();
   }
-  if (auto *arg = dyn_cast<SILFunctionArgument>(value)) {
-    return arg->getOwnershipKind() == OwnershipKind::Guaranteed;
-  }
-  return false;
+  SmallVector<SILValue, 8> roots;
+  findGuaranteedReferenceRoots(value, /*lookThroughNestedBorrows=*/false,
+                               roots);
+  return llvm::all_of(roots, [](auto root) {
+    if (auto *outerBBI = dyn_cast<BeginBorrowInst>(root)) {
+      return outerBBI->isLexical();
+    }
+    if (auto *arg = dyn_cast<SILFunctionArgument>(root)) {
+      return arg->getOwnershipKind() == OwnershipKind::Guaranteed;
+    }
+    return false;
+  });
 }

--- a/lib/SIL/Utils/Projection.cpp
+++ b/lib/SIL/Utils/Projection.cpp
@@ -387,7 +387,7 @@ Optional<ProjectionPath> ProjectionPath::getProjectionPath(SILValue Start,
     // TODO: migrate users to getProjectionPath to the AccessPath utility to
     // avoid this hack.
     if (!isa<EndCOWMutationInst>(Iter) && !isa<BeginAccessInst>(Iter) &&
-        !isa<BeginBorrowInst>(Iter)) {
+        !isa<BeginBorrowInst>(Iter) && !isa<MoveValueInst>(Iter)) {
       Projection AP(Iter);
       if (!AP.isValid())
         break;

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -303,15 +303,8 @@ struct ArgumentInitHelper {
     // form.
     if (!isNoImplicitCopy) {
       if (!value->getType().isMoveOnly()) {
-        // Follow the "normal path": perform a lexical borrow if the lifetime is
-        // lexical.
-        if (value->getOwnershipKind() == OwnershipKind::Owned) {
-          if (lifetime.isLexical()) {
-            value = SILValue(
-                SGF.B.createBeginBorrow(loc, value, /*isLexical*/ true));
-            SGF.Cleanups.pushCleanup<EndBorrowCleanup>(value);
-          }
-        }
+        // Follow the normal path.  The value's lifetime will be enforced based
+        // on its ownership.
         return value;
       }
 

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -67,13 +67,6 @@ static void diagnose(ASTContext &Context, SourceLoc loc, Diag<T...> diag,
   Context.Diags.diagnose(loc, diag, std::forward<U>(args)...);
 }
 
-static SILValue stripCopiesAndBorrows(SILValue v) {
-  while (isa<CopyValueInst>(v) || isa<BeginBorrowInst>(v)) {
-    v = cast<SingleValueInstruction>(v)->getOperand(0);
-  }
-  return v;
-}
-
 /// Fixup reference counts after inlining a function call (which is a no-op
 /// unless the function is a thick function).
 ///
@@ -388,7 +381,7 @@ static void cleanupCalleeValue(SILValue calleeValue,
   if (auto loadedValue = cleanupLoadedCalleeValue(calleeValue))
     calleeValue = loadedValue;
 
-  calleeValue = stripCopiesAndBorrows(calleeValue);
+  calleeValue = lookThroughOwnershipInsts(calleeValue);
 
   // Inline constructor
   auto calleeSource = ([&]() -> SILValue {
@@ -398,12 +391,12 @@ static void cleanupCalleeValue(SILValue calleeValue,
     // will delete any uses of the closure, including a
     // convert_escape_to_noescape conversion.
     if (auto *cfi = dyn_cast<ConvertFunctionInst>(calleeValue))
-      return stripCopiesAndBorrows(cfi->getOperand());
+      return lookThroughOwnershipInsts(cfi->getOperand());
 
     if (auto *cvt = dyn_cast<ConvertEscapeToNoEscapeInst>(calleeValue))
-      return stripCopiesAndBorrows(cvt->getOperand());
+      return lookThroughOwnershipInsts(cvt->getOperand());
 
-    return stripCopiesAndBorrows(calleeValue);
+    return lookThroughOwnershipInsts(calleeValue);
   })();
 
   if (auto *pai = dyn_cast<PartialApplyInst>(calleeSource)) {
@@ -419,7 +412,7 @@ static void cleanupCalleeValue(SILValue calleeValue,
   }
   invalidatedStackNesting = true;
 
-  calleeValue = stripCopiesAndBorrows(calleeValue);
+  calleeValue = lookThroughOwnershipInsts(calleeValue);
 
   // Handle function_ref -> convert_function -> partial_apply/thin_to_thick.
   if (auto *cfi = dyn_cast<ConvertFunctionInst>(calleeValue)) {
@@ -599,7 +592,7 @@ static SILValue getLoadedCalleeValue(LoadInst *li) {
 // a cast.
 static SILValue stripFunctionConversions(SILValue CalleeValue) {
   // Skip any copies that we see.
-  CalleeValue = stripCopiesAndBorrows(CalleeValue);
+  CalleeValue = lookThroughOwnershipInsts(CalleeValue);
 
   // We can also allow a thin @escape to noescape conversion as such:
   // %1 = function_ref @thin_closure_impl : $@convention(thin) () -> ()
@@ -626,7 +619,7 @@ static SILValue stripFunctionConversions(SILValue CalleeValue) {
     if (FromCalleeTy != EscapingCalleeTy)
       return CalleeValue;
 
-    return stripCopiesAndBorrows(ConvertFn->getOperand());
+    return lookThroughOwnershipInsts(ConvertFn->getOperand());
   }
 
   // Ignore mark_dependence users. A partial_apply [stack] uses them to mark
@@ -642,7 +635,7 @@ static SILValue stripFunctionConversions(SILValue CalleeValue) {
 
   auto *CFI = dyn_cast<ConvertEscapeToNoEscapeInst>(CalleeValue);
   if (!CFI)
-    return stripCopiesAndBorrows(CalleeValue);
+    return lookThroughOwnershipInsts(CalleeValue);
 
   // TODO: Handle argument conversion. All the code in this file needs to be
   // cleaned up and generalized. The argument conversion handling in
@@ -658,9 +651,9 @@ static SILValue stripFunctionConversions(SILValue CalleeValue) {
   auto EscapingCalleeTy =
     ToCalleeTy->getWithExtInfo(ToCalleeTy->getExtInfo().withNoEscape(false));
   if (FromCalleeTy != EscapingCalleeTy)
-    return stripCopiesAndBorrows(CalleeValue);
+    return lookThroughOwnershipInsts(CalleeValue);
 
-  return stripCopiesAndBorrows(CFI->getOperand());
+  return lookThroughOwnershipInsts(CFI->getOperand());
 }
 
 /// Returns the callee SILFunction called at a call site, in the case
@@ -687,7 +680,7 @@ getCalleeFunction(SILFunction *F, FullApplySite AI, bool &IsThick,
 
   // Then grab a first approximation of our apply by stripping off all copy
   // operations.
-  SILValue CalleeValue = stripCopiesAndBorrows(AI.getCallee());
+  SILValue CalleeValue = lookThroughOwnershipInsts(AI.getCallee());
 
   // If after stripping off copy_values, we have a load then see if we the
   // function we want to inline has a simple available value through a simple
@@ -696,7 +689,7 @@ getCalleeFunction(SILFunction *F, FullApplySite AI, bool &IsThick,
     CalleeValue = getLoadedCalleeValue(li);
     if (!CalleeValue)
       return nullptr;
-    CalleeValue = stripCopiesAndBorrows(CalleeValue);
+    CalleeValue = lookThroughOwnershipInsts(CalleeValue);
   }
 
   // Look through a escape to @noescape conversion.
@@ -709,11 +702,11 @@ getCalleeFunction(SILFunction *F, FullApplySite AI, bool &IsThick,
     // Collect the applied arguments and their convention.
     collectPartiallyAppliedArguments(PAI, CapturedArgConventions, FullArgs);
 
-    CalleeValue = stripCopiesAndBorrows(PAI->getCallee());
+    CalleeValue = lookThroughOwnershipInsts(PAI->getCallee());
     IsThick = true;
     PartialApply = PAI;
   } else if (auto *TTTFI = dyn_cast<ThinToThickFunctionInst>(CalleeValue)) {
-    CalleeValue = stripCopiesAndBorrows(TTTFI->getOperand());
+    CalleeValue = lookThroughOwnershipInsts(TTTFI->getOperand());
     IsThick = true;
   }
 

--- a/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
+++ b/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
@@ -135,6 +135,10 @@ struct OwnershipModelEliminatorVisitor
   bool visitExplicitCopyValueInst(ExplicitCopyValueInst *cvi);
   bool visitDestroyValueInst(DestroyValueInst *dvi);
   bool visitLoadBorrowInst(LoadBorrowInst *lbi);
+  bool visitMoveValueInst(MoveValueInst *mvi) {
+    eraseInstructionAndRAUW(mvi, mvi->getOperand());
+    return true;
+  }
   bool visitBeginBorrowInst(BeginBorrowInst *bbi) {
     eraseInstructionAndRAUW(bbi, bbi->getOperand());
     return true;

--- a/lib/SILOptimizer/Transforms/ObjectOutliner.cpp
+++ b/lib/SILOptimizer/Transforms/ObjectOutliner.cpp
@@ -252,6 +252,11 @@ bool ObjectOutliner::getObjectInitVals(SILValue Val,
       if (!getObjectInitVals(UC, MemberStores, TailStores, NumTailTupleElements,
                              toIgnore))
         return false;
+    } else if (auto *mvi = dyn_cast<MoveValueInst>(User)) {
+      // move_value is transparent.
+      if (!getObjectInitVals(mvi, MemberStores, TailStores,
+                             NumTailTupleElements, toIgnore))
+        return false;
     } else if (auto *REA = dyn_cast<RefElementAddrInst>(User)) {
       // The address of a stored property.
       for (Operand *ElemAddrUse : REA->getUses()) {
@@ -315,6 +320,9 @@ static EndCOWMutationInst *getEndCOWMutation(SILValue object) {
     if (auto *upCast = dyn_cast<UpcastInst>(user)) {
       // Look through upcast instructions.
       if (EndCOWMutationInst *ecm = getEndCOWMutation(upCast))
+        return ecm;
+    } else if (auto *mvi = dyn_cast<MoveValueInst>(user)) {
+      if (auto *ecm = getEndCOWMutation(mvi))
         return ecm;
     } else if (auto *ecm = dyn_cast<EndCOWMutationInst>(use->getUser())) {
       return ecm;

--- a/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
+++ b/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
@@ -394,6 +394,23 @@ struct CanonicalizeOSSALifetimeTest : UnitTest {
 };
 
 // Arguments:
+// - SILValue: value to canonicalize
+// Dumps:
+// - function after value canonicalization
+struct CanonicalizeBorrowScopeTest : UnitTest {
+  CanonicalizeBorrowScopeTest(UnitTestRunner *pass) : UnitTest(pass) {}
+  void invoke(Arguments &arguments) override {
+    auto value = arguments.takeValue();
+    auto borrowedValue = BorrowedValue(value);
+    assert(borrowedValue && "specified value isn't a BorrowedValue!?");
+    InstructionDeleter deleter;
+    CanonicalizeBorrowScope canonicalizer(deleter);
+    canonicalizer.canonicalizeBorrowScope(borrowedValue);
+    getFunction()->dump();
+  }
+};
+
+// Arguments:
 // - instruction
 // Dumps:
 // - instruction
@@ -616,6 +633,8 @@ void UnitTestRunner::withTest(StringRef name, Doit doit) {
 
     // Alphabetical mapping from string to unit test subclass.
     ADD_UNIT_TEST_SUBCLASS("canonicalize-ossa-lifetime", CanonicalizeOSSALifetimeTest)
+    ADD_UNIT_TEST_SUBCLASS("canonicalize-borrow-scope",
+                           CanonicalizeBorrowScopeTest)
     ADD_UNIT_TEST_SUBCLASS("dump-function", DumpFunction)
     ADD_UNIT_TEST_SUBCLASS("find-borrow-introducers", FindBorrowIntroducers)
     ADD_UNIT_TEST_SUBCLASS("find-enclosing-defs", FindEnclosingDefsTest)

--- a/lib/SILOptimizer/Utils/CanonicalizeBorrowScope.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeBorrowScope.cpp
@@ -44,16 +44,24 @@ static bool hasValueOwnership(SILValue value) {
          value->getOwnershipKind() == OwnershipKind::Owned;
 }
 
-/// Delete a chain of unused copies leading to \p v.
-static void deleteCopyChain(SILValue v, InstructionDeleter &deleter) {
-  while (auto *copy = dyn_cast<CopyValueInst>(v)) {
-    if (!onlyHaveDebugUses(copy))
+static SingleValueInstruction *asCopyOrMove(SILValue v) {
+  if (auto *copy = dyn_cast<CopyValueInst>(v))
+    return copy;
+  if (auto *move = dyn_cast<MoveValueInst>(v))
+    return move;
+  return nullptr;
+}
+
+/// Delete a chain of unused copies and moves leading to \p v.
+static void deleteCopyAndMoveChain(SILValue v, InstructionDeleter &deleter) {
+  while (auto *inst = asCopyOrMove(v)) {
+    if (!onlyHaveDebugUses(inst))
       break;
 
-    v = copy->getOperand();
-    LLVM_DEBUG(llvm::dbgs() << "  Deleting " << *copy);
-    ++NumCopiesEliminated;
-    deleter.forceDelete(copy);
+    v = inst->getOperand(CopyLikeInstruction::Src);
+    LLVM_DEBUG(llvm::dbgs() << "  Deleting " << *inst);
+    ++NumCopiesAndMovesEliminated;
+    deleter.forceDelete(inst);
   }
 }
 
@@ -182,11 +190,12 @@ bool CanonicalizeBorrowScope::computeBorrowLiveness() {
 /// equivalent to the logic in visitBorrowScopeUses that recurses through
 /// copies. The use-def and def-use logic must be consistent.
 SILValue CanonicalizeBorrowScope::findDefInBorrowScope(SILValue value) {
-  while (auto *copy = dyn_cast<CopyValueInst>(value)) {
-    if (isPersistentCopy(copy))
+  while (auto *inst = asCopyOrMove(value)) {
+    auto *copy = dyn_cast<CopyValueInst>(inst);
+    if (copy && isPersistentCopy(copy))
       return copy;
 
-    value = copy->getOperand();
+    value = inst->getOperand(0);
   }
   return value;
 }
@@ -224,8 +233,9 @@ bool CanonicalizeBorrowScope::visitBorrowScopeUses(SILValue innerValue,
     // Gather the uses before updating any of them.
     // 'value' may be deleted in this loop after rewriting its last use.
     // 'use' may become invalid after processing its user.
+
     SmallVector<Operand *, 4> uses(value->getUses());
-    for (Operand *use : uses) {
+    for (auto *use : uses) {
       auto *user = use->getUser();
       // Incidental uses, such as debug_value may be deleted before they can be
       // processed. Their user will now be nullptr. This means that value
@@ -233,10 +243,15 @@ bool CanonicalizeBorrowScope::visitBorrowScopeUses(SILValue innerValue,
       if (!user)
         break;
 
-      // Recurse through copies.
+      // Recurse through copies and moves.
       if (auto *copy = dyn_cast<CopyValueInst>(user)) {
         if (!isPersistentCopy(copy)) {
           defUseWorklist.insert(copy);
+          continue;
+        }
+      } else if (auto *move = dyn_cast<MoveValueInst>(user)) {
+        if (!move->isLexical() || innerValue->isLexical()) {
+          defUseWorklist.insert(move);
           continue;
         }
       }
@@ -433,7 +448,7 @@ public:
     // destroys are never needed within a borrow scope.
     if (isa<DestroyValueInst>(user)) {
       scope.getDeleter().forceDelete(user);
-      deleteCopyChain(value, scope.getDeleter());
+      deleteCopyAndMoveChain(value, scope.getDeleter());
       return true;
     }
     SILValue def = scope.findDefInBorrowScope(value);
@@ -447,12 +462,12 @@ public:
         use->set(def);
         copyLiveUse(use, scope.getCallbacks());
       }
-      deleteCopyChain(value, scope.getDeleter());
+      deleteCopyAndMoveChain(value, scope.getDeleter());
       return true;
     }
     // Non-consuming use.
     use->set(def);
-    deleteCopyChain(value, scope.getDeleter());
+    deleteCopyAndMoveChain(value, scope.getDeleter());
     return true;
   }
 
@@ -474,7 +489,7 @@ public:
     use->set(scope.findDefInBorrowScope(value));
     ForwardingOperand(use).setForwardingOwnershipKind(
         OwnershipKind::Guaranteed);
-    deleteCopyChain(value, scope.getDeleter());
+    deleteCopyAndMoveChain(value, scope.getDeleter());
     return true;
   }
 };
@@ -593,7 +608,7 @@ public:
       ForwardingOperand(use).setForwardingOwnershipKind(
           OwnershipKind::Guaranteed);
     }
-    deleteCopyChain(innerValue, scope.getDeleter());
+    deleteCopyAndMoveChain(innerValue, scope.getDeleter());
     return true;
   }
 
@@ -644,7 +659,7 @@ protected:
 
     use->set(outerValue);
 
-    deleteCopyChain(innerValue, scope.getDeleter());
+    deleteCopyAndMoveChain(innerValue, scope.getDeleter());
 
     recordOuterUse(use);
   };

--- a/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
@@ -78,9 +78,9 @@
 using namespace swift;
 using llvm::SmallSetVector;
 
-llvm::Statistic swift::NumCopiesEliminated = {
-    DEBUG_TYPE, "NumCopiesEliminated",
-    "number of copy_value instructions removed"};
+llvm::Statistic swift::NumCopiesAndMovesEliminated = {
+    DEBUG_TYPE, "NumCopiesAndMovesEliminated",
+    "number of copy_value and move_value instructions removed"};
 
 llvm::Statistic swift::NumCopiesGenerated = {
     DEBUG_TYPE, "NumCopiesGenerated",
@@ -970,7 +970,7 @@ void CanonicalizeOSSALifetime::rewriteCopies() {
       } else {
         if (instsToDelete.insert(srcCopy)) {
           LLVM_DEBUG(llvm::dbgs() << "  Removing " << *srcCopy);
-          ++NumCopiesEliminated;
+          ++NumCopiesAndMovesEliminated;
         }
       }
     }

--- a/lib/SILOptimizer/Utils/ConstExpr.cpp
+++ b/lib/SILOptimizer/Utils/ConstExpr.cpp
@@ -488,9 +488,10 @@ SymbolicValue ConstExprFunctionState::computeConstantValue(SILValue value) {
   if (auto *bai = dyn_cast<BeginAccessInst>(value))
     return getConstantValue(bai->getOperand());
 
-  // Look through copy_value and begin_borrow since the interpreter doesn't
-  // model these memory management instructions.
-  if (isa<CopyValueInst>(value) || isa<BeginBorrowInst>(value))
+  // Look through copy_value, begin_borrow, and move_value since the
+  // interpreter doesn't model these memory management instructions.
+  if (isa<CopyValueInst>(value) || isa<BeginBorrowInst>(value) ||
+      isa<MoveValueInst>(value))
     return getConstantValue(cast<SingleValueInstruction>(value)->getOperand(0));
 
   // Builtin.RawPointer and addresses have the same representation.

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -305,8 +305,7 @@ public:
   void cloneInline(ArrayRef<SILValue> AppliedArgs);
 
 protected:
-  SILValue borrowFunctionArgument(SILValue callArg, FullApplySite AI,
-                                  unsigned index);
+  SILValue borrowFunctionArgument(SILValue callArg, unsigned index);
 
   void visitDebugValueInst(DebugValueInst *Inst);
   void visitHopToExecutorInst(HopToExecutorInst *Inst);
@@ -486,7 +485,7 @@ void SILInlineCloner::cloneInline(ArrayRef<SILValue> AppliedArgs) {
       } else {
         // Insert begin/end borrow for guaranteed arguments.
         if (paramInfo.isGuaranteed()) {
-          if (SILValue newValue = borrowFunctionArgument(callArg, Apply, idx)) {
+          if (SILValue newValue = borrowFunctionArgument(callArg, idx)) {
             callArg = newValue;
             borrowedArgs[idx] = true;
           }
@@ -631,34 +630,77 @@ void SILInlineCloner::postFixUp(SILFunction *calleeFunction) {
   deleter.forceDelete(Apply.getInstruction());
 }
 
-SILValue SILInlineCloner::borrowFunctionArgument(SILValue callArg,
-                                                 FullApplySite AI,
-                                                 unsigned index) {
-  auto &mod = Apply.getFunction()->getModule();
-  auto enableLexicalLifetimes =
-      mod.getASTContext().SILOpts.supportsLexicalLifetimes(mod);
-  auto argOwnershipRequiresBorrow = [&]() {
-    auto kind = callArg->getOwnershipKind();
-    if (enableLexicalLifetimes) {
-      // At this point, we know that the function argument is @guaranteed.
-      // If the value passed as that parameter has ownership, always add a
-      // lexical borrow scope to ensure that the value stays alive for the
-      // duration of the inlined callee.
-      return kind != OwnershipKind::None;
-    }
-    return kind == OwnershipKind::Owned;
-  };
-  if (!AI.getFunction()->hasOwnership() || !argOwnershipRequiresBorrow()) {
-    return SILValue();
+namespace {
+
+enum class Scope : uint8_t {
+  None,
+  Bare,
+  Lexical,
+};
+Scope scopeForArgument(Scope nonlexicalScope, SILValue callArg, unsigned index,
+                       SILFunction *caller, SILFunction *callee) {
+  if (!caller->hasOwnership()) {
+    // The function isn't in OSSA.  Borrows/moves are not meaningful.
+    return Scope::None;
   }
 
-  SILFunctionArgument *argument = cast<SILFunctionArgument>(
-      getCalleeFunction()->getEntryBlock()->getArgument(index));
+  auto &mod = caller->getModule();
+  auto enableLexicalLifetimes =
+      mod.getASTContext().SILOpts.supportsLexicalLifetimes(mod);
+  SILFunctionArgument *argument =
+      cast<SILFunctionArgument>(callee->getEntryBlock()->getArgument(index));
+  if (!enableLexicalLifetimes) {
+    // Lexical lifetimes are disabled.  Use the non-lexical scope:
+    // - for borrows, do an ownership conversion.
+    return nonlexicalScope;
+  }
+  if (!argument->getLifetime().isLexical()) {
+    // The same applies if lexical lifetimes are enabled but the function
+    // argument is not lexical.  There is no lexical lifetime to maintain.  Use
+    // the non-lexical scope.
+    return nonlexicalScope;
+  }
+  // Lexical lifetimes are enabled and the function argument is lexical.
+  // During inlining, we need to ensure that the lifetime is maintained.
+  if (callArg->isLexical()) {
+    // The caller's value is already lexical.  It will maintain the lifetime of
+    // the argument.  Just do an ownership conversion if needed.
+    return nonlexicalScope;
+  }
+  // Lexical lifetimes are enabled, the function argument's lifetime is
+  // lexical, but the caller's value is not lexical.  Extra care is required to
+  // maintain the function argument's lifetime.  We need to add a lexical
+  // scope.
+  return Scope::Lexical;
+}
 
-  SILBuilderWithScope beginBuilder(AI.getInstruction(), getBuilder());
-  auto isLexical =
-      enableLexicalLifetimes && argument->getLifetime().isLexical();
-  return beginBuilder.createBeginBorrow(AI.getLoc(), callArg, isLexical);
+} // anonymous namespace
+
+SILValue SILInlineCloner::borrowFunctionArgument(SILValue callArg,
+                                                 unsigned index) {
+  // The "minimal" borrow scope:  Guaranteed values are valid operands to some
+  // instructions that owned values are not.  If the caller's value is owned,
+  // it must be converted (via a "bare" begin_borrow) to a guaranteed value so
+  // that it can be used in place of the original guaranteed value in the
+  // instructions that are being inlined.
+  auto scopeForOwnership = callArg->getOwnershipKind() == OwnershipKind::Owned
+                               ? Scope::Bare
+                               : Scope::None;
+  auto scope = scopeForArgument(scopeForOwnership, callArg, index,
+                                Apply.getFunction(), getCalleeFunction());
+  bool isLexical;
+  switch (scope) {
+  case Scope::None:
+    return SILValue();
+  case Scope::Bare:
+    isLexical = false;
+    break;
+  case Scope::Lexical:
+    isLexical = true;
+    break;
+  }
+  SILBuilderWithScope beginBuilder(Apply.getInstruction(), getBuilder());
+  return beginBuilder.createBeginBorrow(Apply.getLoc(), callArg, isLexical);
 }
 
 void SILInlineCloner::visitDebugValueInst(DebugValueInst *Inst) {

--- a/test/SILGen/async_builtins.swift
+++ b/test/SILGen/async_builtins.swift
@@ -117,8 +117,8 @@ public func usesWithUnsafeContinuationCaptures(fn: (Builtin.RawUnsafeContinuatio
 public func resumeNonThrowingContinuation(_ cont: Builtin.RawUnsafeContinuation,
                                           _ value: __owned String) {
   // CHECK: bb0(%0 : $Builtin.RawUnsafeContinuation, %1 : @owned $String):
-  // CHECK:      [[BORROW:%.*]] = begin_borrow [lexical] %1 : $String
-  // CHECK-NEXT: debug_value
+  // CHECK:      debug_value
+  // CHECK:      [[BORROW:%.*]] = begin_borrow %1 : $String
   // CHECK-NEXT: [[COPY:%.*]] = copy_value [[BORROW]] : $String
   // CHECK-NEXT: builtin "resumeNonThrowingContinuationReturning"<String>(%0 : $Builtin.RawUnsafeContinuation, [[COPY]] : $String)
   // CHECK-NEXT: end_borrow [[BORROW]] : $String
@@ -130,8 +130,8 @@ public func resumeNonThrowingContinuation(_ cont: Builtin.RawUnsafeContinuation,
 public func resumeThrowingContinuation(_ cont: Builtin.RawUnsafeContinuation,
                                        _ value: __owned String) {
   // CHECK: bb0(%0 : $Builtin.RawUnsafeContinuation, %1 : @owned $String):
-  // CHECK:      [[BORROW:%.*]] = begin_borrow [lexical] %1 : $String
-  // CHECK-NEXT: debug_value
+  // CHECK:      debug_value
+  // CHECK:      [[BORROW:%.*]] = begin_borrow %1 : $String
   // CHECK-NEXT: [[COPY:%.*]] = copy_value [[BORROW]] : $String
   // CHECK-NEXT: builtin "resumeThrowingContinuationReturning"<String>(%0 : $Builtin.RawUnsafeContinuation, [[COPY]] : $String)
   // CHECK-NEXT: end_borrow [[BORROW]] : $String
@@ -143,8 +143,8 @@ public func resumeThrowingContinuation(_ cont: Builtin.RawUnsafeContinuation,
 public func resumeThrowingContinuationThrowing(_ cont: Builtin.RawUnsafeContinuation,
                                                _ error: __owned Error) {
   // CHECK: bb0(%0 : $Builtin.RawUnsafeContinuation, %1 : @owned $any Error):
-  // CHECK:      [[BORROW:%.*]] = begin_borrow [lexical] %1 : $any Error
-  // CHECK-NEXT: debug_value
+  // CHECK:      debug_value
+  // CHECK:      [[BORROW:%.*]] = begin_borrow %1 : $any Error
   // CHECK-NEXT: [[COPY:%.*]] = copy_value [[BORROW]] : $any Error
   // CHECK-NEXT: builtin "resumeThrowingContinuationThrowing"(%0 : $Builtin.RawUnsafeContinuation, [[COPY]] : $any Error)
   // CHECK-NEXT: end_borrow [[BORROW]] : $any Error

--- a/test/SILGen/builtins.swift
+++ b/test/SILGen/builtins.swift
@@ -365,7 +365,7 @@ func projectTailElems<T>(h: Header, ty: T.Type) -> Builtin.RawPointer {
 // CHECK-LABEL: sil hidden [ossa] @$s8builtins21projectTailElemsOwned{{[_0-9a-zA-Z]*}}F
 func projectTailElemsOwned<T>(h: __owned Header, ty: T.Type) -> Builtin.RawPointer {
   // CHECK: bb0([[ARG1:%.*]] : @owned $Header
-  // CHECK:   [[BORROWED_ARG1:%.*]] = begin_borrow [lexical] [[ARG1]]
+  // CHECK:   [[BORROWED_ARG1:%.*]] = begin_borrow [[ARG1]]
   // CHECK:   [[TA:%.*]] = ref_tail_addr [[BORROWED_ARG1]] : $Header
   //   -- Once we have passed the address through a2p, we no longer provide any guarantees.
   //   -- We still need to make sure that the a2p itself is in the borrow site though.

--- a/test/SILGen/foreign_errors.swift
+++ b/test/SILGen/foreign_errors.swift
@@ -190,10 +190,10 @@ class VeryErrorProne : ErrorProne {
 // CHECK:      [[MARKED_BOX:%.*]] = mark_uninitialized [derivedself] [[BOX]]
 // CHECK:      [[LIFETIME:%.*]] = begin_borrow [lexical] [[MARKED_BOX]]
 // CHECK:      [[PB:%.*]] = project_box [[LIFETIME]]
-// CHECK:      [[BORROWED_ARG1:%.*]] = begin_borrow [lexical] [[ARG1]]
 // CHECK:      store [[ARG2]] to [init] [[PB]]
 // CHECK:      [[T0:%.*]] = load [take] [[PB]]
 // CHECK-NEXT: [[T1:%.*]] = upcast [[T0]] : $VeryErrorProne to $ErrorProne
+// CHECK:      [[BORROWED_ARG1:%.*]] = begin_borrow [[ARG1]]
 // CHECK:      [[ARG1_COPY:%.*]] = copy_value [[BORROWED_ARG1]]
 // CHECK-NOT:  [[BOX]]{{^[0-9]}}
 // CHECK-NOT:  [[PB]]{{^[0-9]}}

--- a/test/SILGen/function_conversion_objc.swift
+++ b/test/SILGen/function_conversion_objc.swift
@@ -59,7 +59,7 @@ func funcToBlock(_ x: @escaping () -> ()) -> @convention(block) () -> () {
 // CHECK-LABEL: sil hidden [ossa] @$s24function_conversion_objc11blockToFuncyyycyyXBF : $@convention(thin) (@guaranteed @convention(block) () -> ()) -> @owned @callee_guaranteed () -> ()
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $@convention(block) () -> ()):
 // CHECK:   [[COPIED:%.*]] = copy_block [[ARG]]
-// CHECK:   [[BORROWED_COPIED:%.*]] = begin_borrow [lexical] [[COPIED]]
+// CHECK:   [[BORROWED_COPIED:%.*]] = begin_borrow [[COPIED]]
 // CHECK:   [[COPIED_2:%.*]] = copy_value [[BORROWED_COPIED]]
 // CHECK:   [[THUNK:%.*]] = function_ref @$sIeyB_Ieg_TR
 // CHECK:   [[FUNC:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[COPIED_2]])

--- a/test/SILGen/guaranteed_normal_args.swift
+++ b/test/SILGen/guaranteed_normal_args.swift
@@ -148,7 +148,7 @@ struct StructContainingBridgeObject {
 
   // CHECK-LABEL: sil hidden [ossa] @$ss28StructContainingBridgeObjectV8swiftObjAByXl_tcfC : $@convention(method) (@owned AnyObject, @thin StructContainingBridgeObject.Type) -> @owned StructContainingBridgeObject {
   // CHECK: bb0([[ARG:%.*]] : @owned $AnyObject,
-  // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [lexical] [[ARG]]
+  // CHECK:   [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
   // CHECK:   [[COPIED_ARG:%.*]] = copy_value [[BORROWED_ARG]]
   // CHECK:   [[CASTED_ARG:%.*]] = unchecked_ref_cast [[COPIED_ARG]] : $AnyObject to $Builtin.BridgeObject
   // CHECK:   assign [[CASTED_ARG]] to

--- a/test/SILGen/initializers.swift
+++ b/test/SILGen/initializers.swift
@@ -1296,8 +1296,8 @@ class SubVariadic : SuperVariadic { }
 
 // CHECK-LABEL: sil hidden [ossa] @$s21failable_initializers11SubVariadicC4intsACSid_tcfc
 // CHECK:       bb0(%0 : @owned $Array<Int>, %1 : @owned $SubVariadic):
-// CHECK:         [[T0:%.*]] = begin_borrow [lexical] %0 : $Array<Int>
 // CHECK:         [[SELF_UPCAST:%.*]] = upcast {{.*}} : $SubVariadic to $SuperVariadic
+// CHECK:         [[T0:%.*]] = begin_borrow %0 : $Array<Int>
 // CHECK:         [[T1:%.*]] = copy_value [[T0]] : $Array<Int>
 // CHECK:         [[SUPER_INIT:%.*]] = function_ref @$s21failable_initializers13SuperVariadicC4intsACSid_tcfc
 // CHECK:         apply [[SUPER_INIT]]([[T1]], [[SELF_UPCAST]])

--- a/test/SILGen/lexical_lifetime.swift
+++ b/test/SILGen/lexical_lifetime.swift
@@ -88,8 +88,8 @@ func lexical_borrow_let_class_in_enum() {
 
 // CHECK-LABEL: sil hidden [ossa] @lexical_borrow_arg_owned_class : $@convention(thin) (@owned C) -> () {
 // CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @owned $C):
-// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]] 
-// CHECK:         debug_value [[LIFETIME]] 
+// CHECK:         debug_value [[INSTANCE]]
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [[INSTANCE]] 
 // CHECK:         [[ADDR:%[^,]+]] = alloc_stack $C
 // CHECK:         [[SB:%.*]] = store_borrow [[LIFETIME]] to [[ADDR]] 
 // CHECK:         [[USE_GENERIC:%[^,]+]] = function_ref @use_generic

--- a/test/SILGen/modify_accessor.swift
+++ b/test/SILGen/modify_accessor.swift
@@ -61,9 +61,9 @@ class SetterSynthesisFromModify {
   var modifiable: String {
     get { return stored }
 // CHECK: sil hidden [transparent] [ossa] @$s15modify_accessor25SetterSynthesisFromModifyC10modifiableSSvs
-// CHECK:         [[VALUE_BORROW:%.*]] = begin_borrow [lexical] %0 : $String
+// CHECK:         debug_value
 // CHECK-NEXT:    debug_value
-// CHECK-NEXT:    debug_value
+// CHECK-NEXT:    [[VALUE_BORROW:%.*]] = begin_borrow %0 : $String
 // CHECK-NEXT:    [[VALUE:%.*]] = copy_value [[VALUE_BORROW]] : $String
 // CHECK-NEXT:    // function_ref
 // CHECK-NEXT:    [[MODIFYFN:%.*]] = function_ref @$s15modify_accessor25SetterSynthesisFromModifyC10modifiableSSvM

--- a/test/SILGen/moveonly_deinits.swift
+++ b/test/SILGen/moveonly_deinits.swift
@@ -72,7 +72,8 @@ var value: Bool { false }
 // SILGEN: } // end sil function '$s16moveonly_deinits24testIntPairWithoutDeinityyF'
 
 // SIL-LABEL: sil @$s16moveonly_deinits24testIntPairWithoutDeinityyF : $@convention(thin) () -> () {
-// SIL: [[VALUE:%.*]] = move_value [lexical]
+// SIL: [[CONSTRUCTOR:%[^,]+]] = function_ref @$s16moveonly_deinits20IntPairWithoutDeinitVACycfC
+// SIL: [[VALUE:%.*]] = apply [[CONSTRUCTOR]]
 // SIL: cond_br {{%.*}}, bb1, bb2
 //
 // SIL: bb1:
@@ -113,7 +114,8 @@ public func testIntPairWithoutDeinit() {
 // SILGEN: } // end sil function '$s16moveonly_deinits21testIntPairWithDeinityyF'
 
 // SIL-LABEL: sil @$s16moveonly_deinits21testIntPairWithDeinityyF : $@convention(thin) () -> () {
-// SIL: [[VALUE:%.*]] = move_value [lexical]
+// SIL: [[CONSTRUCTOR:%[^,]+]] = function_ref @$s16moveonly_deinits17IntPairWithDeinitVACycfC
+// SIL: [[VALUE:%.*]] = apply [[CONSTRUCTOR]]
 // SIL: cond_br {{%.*}}, bb1, bb2
 //
 // SIL: bb1:
@@ -155,7 +157,8 @@ public func testIntPairWithDeinit() {
 // SILGEN: } // end sil function '$s16moveonly_deinits26testKlassPairWithoutDeinityyF'
 
 // SIL-LABEL: sil @$s16moveonly_deinits26testKlassPairWithoutDeinityyF : $@convention(thin) () -> () {
-// SIL: [[VALUE:%.*]] = move_value [lexical]
+// SIL: [[CONSTRUCTOR:%[^,]+]] = function_ref @$s16moveonly_deinits22KlassPairWithoutDeinitVACycfC
+// SIL: [[VALUE:%.*]] = apply [[CONSTRUCTOR]]
 // SIL: cond_br {{%.*}}, bb1, bb2
 //
 // SIL: bb1:
@@ -196,7 +199,8 @@ public func testKlassPairWithoutDeinit() {
 // SILGEN: } // end sil function '$s16moveonly_deinits23testKlassPairWithDeinityyF'
 
 // SIL-LABEL: sil @$s16moveonly_deinits23testKlassPairWithDeinityyF : $@convention(thin) () -> () {
-// SIL: [[VALUE:%.*]] = move_value [lexical]
+// SIL: [[CONSTRUCTOR:%[^,]+]] = function_ref @$s16moveonly_deinits19KlassPairWithDeinitVACycfC
+// SIL: [[VALUE:%.*]] = apply [[CONSTRUCTOR]]
 // SIL: cond_br {{%.*}}, bb1, bb2
 //
 // SIL: bb1:
@@ -283,7 +287,7 @@ func consumeKlassEnumPairWithDeinit(_ x: __owned KlassEnumPairWithDeinit) { }
 // SILGEN: } // end sil function '$s16moveonly_deinits28testIntEnumPairWithoutDeinityyF'
 
 // SIL-LABEL: sil @$s16moveonly_deinits28testIntEnumPairWithoutDeinityyF : $@convention(thin) () -> () {
-// SIL: [[VALUE:%.*]] = move_value [lexical]
+// SIL: [[VALUE:%.*]] = enum $IntEnumPairWithoutDeinit
 // SIL: cond_br {{%.*}}, bb1, bb2
 //
 // SIL: bb1:
@@ -324,7 +328,7 @@ public func testIntEnumPairWithoutDeinit() {
 // SILGEN: } // end sil function '$s16moveonly_deinits25testIntEnumPairWithDeinityyF'
 
 // SIL-LABEL: sil @$s16moveonly_deinits25testIntEnumPairWithDeinityyF : $@convention(thin) () -> () {
-// SIL: [[VALUE:%.*]] = move_value [lexical]
+// SIL: [[VALUE:%.*]] = enum $IntEnumPairWithDeinit
 // SIL: cond_br {{%.*}}, bb1, bb2
 //
 // SIL: bb1:
@@ -366,7 +370,7 @@ public func testIntEnumPairWithDeinit() {
 // SILGEN: } // end sil function '$s16moveonly_deinits30testKlassEnumPairWithoutDeinityyF'
 
 // SIL-LABEL: sil @$s16moveonly_deinits30testKlassEnumPairWithoutDeinityyF : $@convention(thin) () -> () {
-// SIL: [[VALUE:%.*]] = move_value [lexical]
+// SIL: [[VALUE:%.*]] = enum $KlassEnumPairWithoutDeinit
 // SIL: cond_br {{%.*}}, bb1, bb2
 //
 // SIL: bb1:
@@ -407,7 +411,7 @@ public func testKlassEnumPairWithoutDeinit() {
 // SILGEN: } // end sil function '$s16moveonly_deinits27testKlassEnumPairWithDeinityyF'
 
 // SIL-LABEL: sil @$s16moveonly_deinits27testKlassEnumPairWithDeinityyF : $@convention(thin) () -> () {
-// SIL: [[VALUE:%.*]] = move_value [lexical]
+// SIL: [[VALUE:%.*]] = enum $KlassEnumPairWithDeinit
 // SIL: cond_br {{%.*}}, bb1, bb2
 //
 // SIL: bb1:

--- a/test/SILGen/newtype.swift
+++ b/test/SILGen/newtype.swift
@@ -10,8 +10,9 @@ import Newtype
 // CHECK-CANONICAL-LABEL: sil hidden @$s7newtype17createErrorDomain{{[_0-9a-zA-Z]*}}F
 // CHECK-CANONICAL: bb0([[STR:%[0-9]+]] : $String)
 func createErrorDomain(str: String) -> ErrorDomain {
+  // CHECK-CANONICAL: [[MOVED_STR:%[^,]+]] = move_value [lexical] [[STR]]
   // CHECK-CANONICAL: [[BRIDGE_FN:%[0-9]+]] = function_ref @{{.*}}_bridgeToObjectiveC
-  // CHECK-CANONICAL-NEXT: [[BRIDGED:%[0-9]+]] = apply [[BRIDGE_FN]]([[STR]])
+  // CHECK-CANONICAL-NEXT: [[BRIDGED:%[0-9]+]] = apply [[BRIDGE_FN]]([[MOVED_STR]])
   // CHECK-CANONICAL: struct $ErrorDomain ([[BRIDGED]] : $NSString)
   return ErrorDomain(rawValue: str)
 }
@@ -22,7 +23,7 @@ func createErrorDomain(str: String) -> ErrorDomain {
 // CHECK-RAW: [[MARKED_SELF_BOX:%[0-9]+]] = mark_uninitialized [rootself] [[SELF_BOX]]
 // CHECK-RAW: [[SELF_BOX_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[MARKED_SELF_BOX]]
 // CHECK-RAW: [[PB_BOX:%[0-9]+]] = project_box [[SELF_BOX_LIFETIME]]
-// CHECK-RAW: [[BORROWED_STR:%.*]] = begin_borrow [lexical] [[STR]]
+// CHECK-RAW: [[BORROWED_STR:%.*]] = begin_borrow [[STR]]
 // CHECK-RAW: [[COPIED_STR:%.*]] = copy_value [[BORROWED_STR]]
 // CHECK-RAW: [[BRIDGE_FN:%[0-9]+]] = function_ref @{{.*}}_bridgeToObjectiveC
 // CHECK-RAW: [[BORROWED_COPIED_STR:%.*]] = begin_borrow [[COPIED_STR]]

--- a/test/SILGen/newtype.swift
+++ b/test/SILGen/newtype.swift
@@ -10,9 +10,8 @@ import Newtype
 // CHECK-CANONICAL-LABEL: sil hidden @$s7newtype17createErrorDomain{{[_0-9a-zA-Z]*}}F
 // CHECK-CANONICAL: bb0([[STR:%[0-9]+]] : $String)
 func createErrorDomain(str: String) -> ErrorDomain {
-  // CHECK-CANONICAL: [[MOVED_STR:%[^,]+]] = move_value [lexical] [[STR]]
   // CHECK-CANONICAL: [[BRIDGE_FN:%[0-9]+]] = function_ref @{{.*}}_bridgeToObjectiveC
-  // CHECK-CANONICAL-NEXT: [[BRIDGED:%[0-9]+]] = apply [[BRIDGE_FN]]([[MOVED_STR]])
+  // CHECK-CANONICAL-NEXT: [[BRIDGED:%[0-9]+]] = apply [[BRIDGE_FN]]([[STR]])
   // CHECK-CANONICAL: struct $ErrorDomain ([[BRIDGED]] : $NSString)
   return ErrorDomain(rawValue: str)
 }

--- a/test/SILGen/objc_access_notes.swift
+++ b/test/SILGen/objc_access_notes.swift
@@ -179,7 +179,7 @@ class Hoozit : Gizmo {
 
   // CHECK-LABEL: sil hidden [ossa] @$s11objc_thunks6HoozitC15typicalPropertySo5GizmoCvs
   // CHECK: bb0([[ARG0:%.*]] : @owned $Gizmo, [[ARG1:%.*]] : @guaranteed $Hoozit):
-  // CHECK:   [[BORROWED_ARG0:%.*]] = begin_borrow [lexical] [[ARG0]]
+  // CHECK:   [[BORROWED_ARG0:%.*]] = begin_borrow [[ARG0]]
   // CHECK:   [[ARG0_COPY:%.*]] = copy_value [[BORROWED_ARG0]]
   // CHECK:   [[ADDR:%.*]] = ref_element_addr [[ARG1]] : {{.*}}, #Hoozit.typicalProperty
   // CHECK:   [[WRITE:%.*]] = begin_access [modify] [dynamic] [[ADDR]] : $*Gizmo
@@ -229,7 +229,7 @@ class Hoozit : Gizmo {
 
   // CHECK-LABEL: sil hidden [ossa] @$s11objc_thunks6HoozitC12copyPropertySo5GizmoCvs
   // CHECK: bb0([[ARG1:%.*]] : @owned $Gizmo, [[SELF:%.*]] : @guaranteed $Hoozit):
-  // CHECK:   [[BORROWED_ARG1:%.*]] = begin_borrow [lexical] [[ARG1]]
+  // CHECK:   [[BORROWED_ARG1:%.*]] = begin_borrow [[ARG1]]
   // CHECK:   [[ARG1_COPY:%.*]] = copy_value [[BORROWED_ARG1]]
   // CHECK:   [[ADDR:%.*]] = ref_element_addr [[SELF]] : {{.*}}, #Hoozit.copyProperty
   // CHECK:   [[WRITE:%.*]] = begin_access [modify] [dynamic] [[ADDR]] : $*Gizmo

--- a/test/SILGen/objc_bridging.swift
+++ b/test/SILGen/objc_bridging.swift
@@ -464,7 +464,7 @@ class Bas : NSObject {
 func applyStringBlock(_ f: @convention(block) (String) -> String, x: String) -> String {
   // CHECK: bb0([[BLOCK:%.*]] : @guaranteed $@convention(block) @noescape (NSString) -> @autoreleased NSString, [[STRING:%.*]] : @guaranteed $String):
   // CHECK:   [[BLOCK_COPY:%.*]] = copy_block [[BLOCK]]
-  // CHECK:   [[BORROWED_BLOCK_COPY:%.*]] = begin_borrow [lexical] [[BLOCK_COPY]]
+  // CHECK:   [[BORROWED_BLOCK_COPY:%.*]] = begin_borrow [[BLOCK_COPY]]
   // CHECK:   [[BLOCK_COPY_COPY:%.*]] = copy_value [[BORROWED_BLOCK_COPY]]
   // CHECK:   [[STRING_COPY:%.*]] = copy_value [[STRING]]
   // CHECK:   [[STRING_TO_NSSTRING:%.*]] = function_ref @$sSS10FoundationE19_bridgeToObjectiveCSo8NSStringCyF

--- a/test/SILGen/objc_bridging_peephole.swift
+++ b/test/SILGen/objc_bridging_peephole.swift
@@ -579,15 +579,15 @@ func testOptionalToNonOptionalBridge() {
 
 // CHECK-LABEL: sil hidden [ossa] @$s22objc_bridging_peephole34testBlockToOptionalAnyObjectBridge5blockyyyXB_tF
 func testBlockToOptionalAnyObjectBridge(block: @escaping @convention(block) () -> ()) {
-  // CHECK:      [[T0:%.*]] = begin_borrow [lexical] {{%.*}} : $@convention(block) () -> ()
-  // CHECK-NEXT: debug_value
+  // CHECK:      debug_value
+  // CHECK-NEXT: [[T0:%.*]] = begin_borrow {{%.*}} : $@convention(block) () -> ()
   // CHECK-NEXT: [[T1:%.*]] = copy_value [[T0]]
   // CHECK-NEXT: [[REF:%.*]] = unchecked_ref_cast [[T1]] : $@convention(block) () -> () to $AnyObject
   // CHECK-NEXT: [[OPTREF:%.*]] = enum $Optional<AnyObject>, #Optional.some!enumelt, [[REF]] : $AnyObject
+  // CHECK-NEXT: end_borrow [[T0]]
   // CHECK-NEXT: // function_ref
   // CHECK-NEXT: [[FN:%.*]] = function_ref @takeNullableId : $@convention(c) (Optional<AnyObject>) -> ()
   // CHECK-NEXT: apply [[FN]]([[OPTREF]])
   // CHECK-NEXT: destroy_value [[OPTREF]]
-  // CHECK-NEXT: end_borrow [[T0]]
   takeNullableId(block as Any)
 }

--- a/test/SILGen/objc_extensions.swift
+++ b/test/SILGen/objc_extensions.swift
@@ -64,7 +64,6 @@ extension Sub {
 
     // First we get the old value.
     // CHECK: bb0([[NEW_VALUE:%.*]] : @owned $Optional<String>, [[SELF:%.*]] : @guaranteed $Sub):
-    // CHECK:   [[BORROWED_NEW_VALUE:%.*]] = begin_borrow [lexical] [[NEW_VALUE]]
     // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
     // CHECK:   [[UPCAST_SELF_COPY:%.*]] = upcast [[SELF_COPY]] : $Sub to $Base
     // CHECK:   [[BORROWED_UPCAST_SELF_COPY:%.*]] = begin_borrow [[UPCAST_SELF_COPY]]
@@ -78,6 +77,7 @@ extension Sub {
     // CHECK:   destroy_value [[UPCAST_SELF_COPY]]
     // CHECK:   [[SELF_COPY:%.*]] = copy_value [[SELF]]
     // CHECK:   [[UPCAST_SELF_COPY:%.*]] = upcast [[SELF_COPY]] : $Sub to $Base
+    // CHECK:   [[BORROWED_NEW_VALUE:%.*]] = begin_borrow [[NEW_VALUE]]
     // CHECK:   [[NEW_VALUE_COPY:%.*]] = copy_value [[BORROWED_NEW_VALUE]]
     // CHECK:   switch_enum [[NEW_VALUE_COPY]] : $Optional<String>, case #Optional.some!enumelt: [[SOME_BB:bb[0-9]+]], case #Optional.none!enumelt: [[NONE_BB:bb[0-9]+]]
     //

--- a/test/SILGen/objc_factory_init.swift
+++ b/test/SILGen/objc_factory_init.swift
@@ -27,8 +27,8 @@ extension Hive {
   // CHECK:   [[MU:%.*]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
   // CHECK:   [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MU]]
   // CHECK:   [[PB_BOX:%.*]] = project_box [[LIFETIME]] : ${ var Hive }, 0
-  // CHECK:   [[BORROWED_QUEEN:%.*]] = begin_borrow [lexical] [[QUEEN]]
   // CHECK:   [[OBJC_META:%[0-9]+]] = thick_to_objc_metatype [[META]] : $@thick Hive.Type to $@objc_metatype Hive.Type
+  // CHECK:   [[BORROWED_QUEEN:%.*]] = begin_borrow [[QUEEN]]
   // CHECK:   [[COPIED_BORROWED_QUEEN:%.*]] = copy_value [[BORROWED_QUEEN]]
   // CHECK:   [[OPT_COPIED_BORROWED_QUEEN:%.*]] = enum $Optional<Bee>, #Optional.some!enumelt, [[COPIED_BORROWED_QUEEN]]
   // CHECK:   [[FACTORY:%[0-9]+]] = objc_method [[OBJC_META]] : $@objc_metatype Hive.Type, #Hive.init!allocator.foreign : (Hive.Type) -> (Bee?) -> Hive?, $@convention(objc_method) (Optional<Bee>, @objc_metatype Hive.Type) -> @autoreleased Optional<Hive>
@@ -49,9 +49,9 @@ extension Hive {
   // CHECK-NEXT:   [[MU:%.*]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
   // CHECK-NEXT:   [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MU]]
   // CHECK-NEXT:   [[PB_BOX:%.*]] = project_box [[LIFETIME]] : ${ var Hive }, 0
-  // CHECK-NEXT:   [[BORROWED_QUEEN:%.*]] = begin_borrow [lexical] [[QUEEN]]
   // CHECK:   [[FOREIGN_ERROR_STACK:%.*]] = alloc_stack [dynamic_lifetime] $Optional<NSError>
   // CHECK:   [[OBJC_META:%[0-9]+]] = thick_to_objc_metatype [[META]] : $@thick Hive.Type to $@objc_metatype Hive.Type
+  // CHECK:   [[BORROWED_QUEEN:%.*]] = begin_borrow [[QUEEN]]
   // CHECK:   [[COPIED_BORROWED_QUEEN:%.*]] = copy_value [[BORROWED_QUEEN]]
   // CHECK:   [[OPT_COPIED_BORROWED_QUEEN:%.*]] = enum $Optional<Bee>, #Optional.some!enumelt, [[COPIED_BORROWED_QUEEN]]
   // CHECK:   [[FACTORY:%[0-9]+]] = objc_method [[OBJC_META]] : $@objc_metatype Hive.Type, #Hive.init!allocator.foreign : (Hive.Type) -> (Bee?) throws -> Hive, $@convention(objc_method) (Optional<Bee>, Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>, @objc_metatype Hive.Type) -> @autoreleased Optional<Hive>

--- a/test/SILGen/objc_ownership_conventions.swift
+++ b/test/SILGen/objc_ownership_conventions.swift
@@ -178,7 +178,7 @@ func test11(_ g: Gizmo) -> AnyClass {
 func applyBlock(_ f: @convention(block) (Gizmo) -> Gizmo, x: Gizmo) -> Gizmo {
   // CHECK:     bb0([[BLOCK:%.*]] : @guaranteed $@convention(block) @noescape (Gizmo) -> @autoreleased Gizmo, [[ARG:%.*]] : @guaranteed $Gizmo):
   // CHECK:       [[BLOCK_COPY:%.*]] = copy_block [[BLOCK]]
-  // CHECK:       [[BORROWED_BLOCK_COPY:%.*]] = begin_borrow [lexical] [[BLOCK_COPY]]
+  // CHECK:       [[BORROWED_BLOCK_COPY:%.*]] = begin_borrow [[BLOCK_COPY]]
   // CHECK:       [[BLOCK_COPY_COPY:%.*]] = copy_value [[BORROWED_BLOCK_COPY]]
   // CHECK:       [[RESULT:%.*]] = apply [[BLOCK_COPY_COPY]]([[ARG]])
   // CHECK:       destroy_value [[BLOCK_COPY_COPY]]

--- a/test/SILGen/objc_properties.swift
+++ b/test/SILGen/objc_properties.swift
@@ -105,7 +105,7 @@ class B : A {
 class TestNSCopying {
   // CHECK-LABEL: sil hidden [transparent] [ossa] @$s15objc_properties13TestNSCopyingC8propertySo8NSStringCvs : $@convention(method) (@owned NSString, @guaranteed TestNSCopying) -> ()
   // CHECK: bb0([[ARG0:%.*]] : @owned $NSString, [[ARG1:%.*]] : @guaranteed $TestNSCopying):
-  // CHECK:   [[BORROWED_ARG0:%.*]] = begin_borrow [lexical] [[ARG0]]
+  // CHECK:   [[BORROWED_ARG0:%.*]] = begin_borrow [[ARG0]]
   // CHECK:   objc_method [[BORROWED_ARG0]] : $NSString, #NSCopying.copy!foreign
   @NSCopying var property : NSString
 

--- a/test/SILGen/objc_thunks.swift
+++ b/test/SILGen/objc_thunks.swift
@@ -163,7 +163,7 @@ class Hoozit : Gizmo {
 
   // CHECK-LABEL: sil hidden [ossa] @$s11objc_thunks6HoozitC15typicalPropertySo5GizmoCvs
   // CHECK: bb0([[ARG0:%.*]] : @owned $Gizmo, [[ARG1:%.*]] : @guaranteed $Hoozit):
-  // CHECK:   [[BORROWED_ARG0:%.*]] = begin_borrow [lexical] [[ARG0]]
+  // CHECK:   [[BORROWED_ARG0:%.*]] = begin_borrow [[ARG0]]
   // CHECK:   [[ARG0_COPY:%.*]] = copy_value [[BORROWED_ARG0]]
   // CHECK:   [[ADDR:%.*]] = ref_element_addr [[ARG1]] : {{.*}}, #Hoozit.typicalProperty
   // CHECK:   [[WRITE:%.*]] = begin_access [modify] [dynamic] [[ADDR]] : $*Gizmo
@@ -211,7 +211,7 @@ class Hoozit : Gizmo {
 
   // CHECK-LABEL: sil hidden [ossa] @$s11objc_thunks6HoozitC12copyPropertySo5GizmoCvs
   // CHECK: bb0([[ARG1:%.*]] : @owned $Gizmo, [[SELF:%.*]] : @guaranteed $Hoozit):
-  // CHECK:   [[BORROWED_ARG1:%.*]] = begin_borrow [lexical] [[ARG1]]
+  // CHECK:   [[BORROWED_ARG1:%.*]] = begin_borrow [[ARG1]]
   // CHECK:   [[ARG1_COPY:%.*]] = copy_value [[BORROWED_ARG1]]
   // CHECK:   [[ADDR:%.*]] = ref_element_addr [[SELF]] : {{.*}}, #Hoozit.copyProperty
   // CHECK:   [[WRITE:%.*]] = begin_access [modify] [dynamic] [[ADDR]] : $*Gizmo

--- a/test/SILGen/property_wrapper_parameter.swift
+++ b/test/SILGen/property_wrapper_parameter.swift
@@ -105,9 +105,9 @@ struct TestStructInit {
   // CHECK-LABEL: sil hidden [ossa] @$s26property_wrapper_parameter14TestStructInitV6number7messageAcA7WrapperVySiG_SStcfC : $@convention(method) (Wrapper<Int>, @owned String, @thin TestStructInit.Type) -> TestStructInit
   init(@Wrapper number: Int, @ImplementationDetail message: String) {
     // CHECK: debug_value %0 : $Wrapper<Int>, let, name "_number"
-    // CHECK: [[STR:%.*]] = begin_borrow [lexical] %1
-    // CHECK: debug_value [[STR]] : $String, let, name "message"
+    // CHECK: debug_value [[STR:%.*]] : $String, let, name "message"
     // CHECK: alloc_stack $ImplementationDetail<String>
+    // CHECK: begin_borrow [[STR]]
     // CHECK" function_ref @$s26property_wrapper_parameter20ImplementationDetailV12wrappedValueACyxGx_tcfC : $@convention(method) <τ_0_0> (@in τ_0_0, @thin ImplementationDetail<τ_0_0>.Type) -> @out ImplementationDetail<τ_0_0>
 
     _ = number
@@ -138,9 +138,9 @@ class TestClassInit {
   // CHECK-LABEL: sil hidden [ossa] @$s26property_wrapper_parameter13TestClassInitC6number7messageAcA7WrapperVySiG_SStcfc : $@convention(method) (Wrapper<Int>, @owned String, @owned TestClassInit) -> @owned TestClassInit
   init(@Wrapper number: Int, @ImplementationDetail message: String) {
     // CHECK: debug_value %0 : $Wrapper<Int>, let, name "_number"
-    // CHECK: [[STR:%.*]] = begin_borrow [lexical] %1
-    // CHECK: debug_value [[STR]] : $String, let, name "message"
+    // CHECK: debug_value [[STR:%.*]] : $String, let, name "message"
     // CHECK: alloc_stack $ImplementationDetail<String>
+    // CHECK: begin_borrow [[STR]]
 
     _ = number
     _ = _number

--- a/test/SILGen/protocol_extensions.swift
+++ b/test/SILGen/protocol_extensions.swift
@@ -704,16 +704,16 @@ extension InitRequirement {
     // CHECK-NEXT: [[UNINIT_SELF:%.*]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
     // CHECK-NEXT: [[SELF_BOX_LIFETIME:%.*]] = begin_borrow [lexical] [[UNINIT_SELF]]
     // CHECK-NEXT: [[SELF_BOX_ADDR:%.*]] = project_box [[SELF_BOX_LIFETIME]]
-    // CHECK-NEXT: [[BORROWED_ARG:%.*]] = begin_borrow [lexical] [[ARG]]
     // CHECK:      [[SELF_BOX:%.*]] = alloc_stack $Self
+    // CHECK-NEXT: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
     // CHECK-NEXT: [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
     // CHECK-NEXT: [[ARG_COPY_CAST:%.*]] = upcast [[ARG_COPY]]
     // CHECK:      [[DELEGATEE:%.*]] = witness_method $Self, #InitRequirement.init!allocator : {{.*}} : $@convention(witness_method: InitRequirement) <τ_0_0 where τ_0_0 : InitRequirement> (@owned C, @thick τ_0_0.Type) -> @out τ_0_0
     // CHECK-NEXT: apply [[DELEGATEE]]<Self>([[SELF_BOX]], [[ARG_COPY_CAST]], [[SELF_TYPE]])
+    // CHECK-NEXT: end_borrow [[BORROWED_ARG]]
     // CHECK-NEXT: copy_addr [take] [[SELF_BOX]] to [[SELF_BOX_ADDR]]
     // CHECK-NEXT: dealloc_stack [[SELF_BOX]]
     // CHECK-NEXT: copy_addr [[SELF_BOX_ADDR]] to [init] [[OUT]]
-    // CHECK-NEXT: end_borrow [[BORROWED_ARG]]
     // CHECK-NEXT: destroy_value [[ARG]]
     // CHECK-NEXT: end_borrow [[SELF_BOX_LIFETIME]]
     // CHECK-NEXT: destroy_value [[UNINIT_SELF]]
@@ -728,15 +728,15 @@ extension InitRequirement {
     // CHECK-NEXT: [[UNINIT_SELF:%.*]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
     // CHECK-NEXT: [[SELF_LIFETIME:%.*]] = begin_borrow [lexical] [[UNINIT_SELF]]
     // CHECK-NEXT: [[SELF_BOX_ADDR:%.*]] = project_box [[SELF_LIFETIME]]
-    // CHECK-NEXT: [[BORROWED_ARG:%.*]] = begin_borrow [lexical] [[ARG]]
     // CHECK:      [[SELF_BOX:%.*]] = alloc_stack $Self
+    // CHECK-NEXT: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
     // CHECK-NEXT: [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
     // CHECK:      [[DELEGATEE:%.*]] = function_ref @$s19protocol_extensions15InitRequirementPAAE1dxAA1DC_tcfC :
     // CHECK-NEXT: apply [[DELEGATEE]]<Self>([[SELF_BOX]], [[ARG_COPY]], [[SELF_TYPE]])
+    // CHECK-NEXT: end_borrow [[BORROWED_ARG]]
     // CHECK-NEXT: copy_addr [take] [[SELF_BOX]] to [[SELF_BOX_ADDR]]
     // CHECK-NEXT: dealloc_stack [[SELF_BOX]]
     // CHECK-NEXT: copy_addr [[SELF_BOX_ADDR]] to [init] [[OUT]]
-    // CHECK-NEXT: end_borrow [[BORROWED_ARG]]
     // CHECK-NEXT: destroy_value [[ARG]]
     // CHECK-NEXT: end_borrow [[SELF_LIFETIME]]
     // CHECK-NEXT: destroy_value [[UNINIT_SELF]]
@@ -751,18 +751,18 @@ extension InitRequirement {
     // CHECK-NEXT: [[UNINIT_SELF:%.*]] = mark_uninitialized [delegatingself] [[SELF_BOX]]
     // CHECK-NEXT: [[SELF_LIFETIME:%.*]] = begin_borrow [lexical] [[UNINIT_SELF]]
     // CHECK-NEXT: [[SELF_BOX_ADDR:%.*]] = project_box [[SELF_LIFETIME]]
-    // CHECK-NEXT: [[BORROWED_ARG:%.*]] = begin_borrow [lexical] [[ARG]]
     // CHECK:      [[SELF_BOX:%.*]] = alloc_stack $Self
     // CHECK-NEXT: [[SELF_TYPE:%.*]] = metatype $@thick Self.Type
+    // CHECK-NEXT: [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
     // CHECK-NEXT: [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
     // CHECK:      [[DELEGATEE:%.*]] = witness_method $Self, #InitRequirement.init!allocator
     // CHECK-NEXT: apply [[DELEGATEE]]<Self>([[SELF_BOX]], [[ARG_COPY]], [[SELF_TYPE]])
+    // CHECK-NEXT: end_borrow [[BORROWED_ARG]]
     // CHECK-NEXT: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[SELF_BOX_ADDR]]
     // CHECK-NEXT: copy_addr [take] [[SELF_BOX]] to [[ACCESS]]
     // CHECK-NEXT: end_access [[ACCESS]]
     // CHECK-NEXT: dealloc_stack [[SELF_BOX]]
     // CHECK-NEXT: copy_addr [[SELF_BOX_ADDR]] to [init] [[OUT]]
-    // CHECK-NEXT: end_borrow [[BORROWED_ARG]]
     // CHECK-NEXT: destroy_value [[ARG]]
     // CHECK-NEXT: end_borrow [[SELF_LIFETIME]]
     // CHECK-NEXT: destroy_value [[UNINIT_SELF]]
@@ -778,7 +778,7 @@ protocol ClassInitRequirement: class {
 extension ClassInitRequirement {
   // CHECK-LABEL: sil hidden [ossa] @$s19protocol_extensions20ClassInitRequirementPAAE{{[_0-9a-zA-Z]*}}fC : $@convention(method) <Self where Self : ClassInitRequirement> (@owned D, @thick Self.Type) -> @owned Self
   // CHECK:       bb0([[ARG:%.*]] : @owned $D, [[SELF_TYPE:%.*]] : $@thick Self.Type):
-  // CHECK:         [[BORROWED_ARG:%.*]] = begin_borrow [lexical] [[ARG]]
+  // CHECK:         [[BORROWED_ARG:%.*]] = begin_borrow [[ARG]]
   // CHECK:         [[ARG_COPY:%.*]] = copy_value [[BORROWED_ARG]]
   // CHECK:         [[ARG_COPY_CAST:%.*]] = upcast [[ARG_COPY]]
   // CHECK:         [[DELEGATEE:%.*]] = witness_method $Self, #ClassInitRequirement.init!allocator : {{.*}} : $@convention(witness_method: ClassInitRequirement) <τ_0_0 where τ_0_0 : ClassInitRequirement> (@owned C, @thick τ_0_0.Type) -> @owned τ_0_0
@@ -805,11 +805,12 @@ func foo(_ t: ObjCInitRequirement.Type, c: OC) -> ObjCInitRequirement {
 extension ObjCInitRequirement {
   // CHECK-LABEL: sil hidden [ossa] @$s19protocol_extensions19ObjCInitRequirementPAAE{{[_0-9a-zA-Z]*}}fC : $@convention(method) <Self where Self : ObjCInitRequirement> (@owned OD, @thick Self.Type) -> @owned Self
   // CHECK:       bb0([[ARG:%.*]] : @owned $OD, [[SELF_TYPE:%.*]] : $@thick Self.Type):
-  // CHECK:         [[BORROWED_ARG_1:%.*]] = begin_borrow [lexical] [[ARG]]
   // CHECK:         [[OBJC_SELF_TYPE:%.*]] = thick_to_objc_metatype [[SELF_TYPE]]
   // CHECK:         [[SELF:%.*]] = alloc_ref_dynamic [objc] [[OBJC_SELF_TYPE]] : $@objc_metatype Self.Type, $Self
+  // CHECK:         [[BORROWED_ARG_1:%.*]] = begin_borrow [[ARG]]
   // CHECK:         [[BORROWED_ARG_1_UPCAST:%.*]] = upcast [[BORROWED_ARG_1]]
-  // CHECK:         [[BORROWED_ARG_2_UPCAST:%.*]] = upcast [[BORROWED_ARG_1]]
+  // CHECK:         [[BORROWED_ARG_2:%.*]] = begin_borrow [[ARG]]
+  // CHECK:         [[BORROWED_ARG_2_UPCAST:%.*]] = upcast [[BORROWED_ARG_2]]
   // CHECK:         [[WITNESS:%.*]] = objc_method [[SELF]] : $Self, #ObjCInitRequirement.init!initializer.foreign : {{.*}}, $@convention(objc_method) <τ_0_0 where τ_0_0 : ObjCInitRequirement> (OC, OC, @owned τ_0_0) -> @owned τ_0_0
   // CHECK:         apply [[WITNESS]]<Self>([[BORROWED_ARG_1_UPCAST]], [[BORROWED_ARG_2_UPCAST]], [[SELF]])
   // CHECK:         end_borrow [[BORROWED_ARG_1]]

--- a/test/SILGen/unowned.swift
+++ b/test/SILGen/unowned.swift
@@ -138,9 +138,9 @@ class TestUnownedMember {
 
 // CHECK-LABEL: sil hidden [ossa] @$s7unowned17TestUnownedMemberC5invalAcA1CC_tcfc :
 // CHECK: bb0([[ARG1:%.*]] : @owned $C, [[SELF_PARAM:%.*]] : @owned $TestUnownedMember):
-// CHECK:   [[BORROWED_ARG1:%.*]] = begin_borrow [lexical] [[ARG1]]
 // CHECK:   [[SELF:%.*]] = mark_uninitialized [rootself] [[SELF_PARAM]] : $TestUnownedMember
 // CHECK:   [[BORROWED_SELF:%.*]] = begin_borrow [[SELF]]
+// CHECK:   [[BORROWED_ARG1:%.*]] = begin_borrow [[ARG1]]
 // CHECK:   [[ARG1_COPY:%.*]] = copy_value [[BORROWED_ARG1]]
 // CHECK:   [[FIELDPTR:%.*]] = ref_element_addr [[BORROWED_SELF]] : $TestUnownedMember, #TestUnownedMember.member
 // CHECK:   [[INVAL:%.*]] = ref_to_unowned [[ARG1_COPY]] : $C to $@sil_unowned C

--- a/test/SILGen/without_actually_escaping_block.swift
+++ b/test/SILGen/without_actually_escaping_block.swift
@@ -11,7 +11,7 @@ typealias Callback = @convention(block) () -> Void
 // CHECK-LABEL: sil {{.*}} @$s25without_actually_escaping9testBlock5blockyyyXB_tF
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $@convention(block) @noescape () -> ()):
 // CHECK:  [[C1:%.*]] = copy_block [[ARG]]
-// CHECK:  [[B1:%.*]] = begin_borrow [lexical] [[C1]]
+// CHECK:  [[B1:%.*]] = begin_borrow [[C1]]
 // CHECK:  [[C2:%.*]] = copy_value [[B1]]
 // CHECK:  [[CVT:%.*]] = convert_function [[C2]] : $@convention(block) @noescape () -> () to [without_actually_escaping] $@convention(block) () -> ()
 // CHECK:  [[FN:%.*]] = function_ref @$s25without_actually_escaping9testBlock5blockyyyXB_tFyyyXBXEfU_

--- a/test/SILOptimizer/arc_crash.swift
+++ b/test/SILOptimizer/arc_crash.swift
@@ -15,6 +15,7 @@ public class Base {
 public class Node : Base {
   var node: Base
 
+  @inline(never)
   init(node: Base) { self.node = node }
 }
 struct Queue {

--- a/test/SILOptimizer/canonicalize_borrow_scope_unit.sil
+++ b/test/SILOptimizer/canonicalize_borrow_scope_unit.sil
@@ -1,0 +1,59 @@
+// RUN: %target-sil-opt -unit-test-runner %s -o /dev/null 2>&1 | %FileCheck %s
+
+import Builtin
+
+typealias AnyObject = Builtin.AnyObject
+
+struct Unmanaged<Instance> where Instance : AnyObject {
+  unowned(unsafe) var _value: @sil_unmanaged Instance
+}
+
+// CHECK-LABEL: begin {{.*}} on copy_and_move_argument: canonicalize-borrow-scope
+// CHECK-LABEL: sil [ossa] @copy_and_move_argument : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK:         [[UNMANAGED:%[^,]+]] = ref_to_unmanaged [[INSTANCE]]
+// CHECK:         [[RETVAL:%[^,]+]] = struct $Unmanaged<Instance> ([[UNMANAGED]] : $@sil_unmanaged Instance) 
+// CHECK:         return [[RETVAL]]
+// CHECK-LABEL: } // end sil function 'copy_and_move_argument'
+// CHECK-LABEL: end {{.*}} on copy_and_move_argument: canonicalize-borrow-scope
+sil [ossa] @copy_and_move_argument : $@convention(thin) <Instance where Instance : AnyObject> (@guaranteed Instance) -> Unmanaged<Instance> {
+bb0(%instance : @guaranteed $Instance):
+  test_specification "canonicalize-borrow-scope @argument"
+  %copy_1 = copy_value %instance : $Instance
+  %copy_2 = copy_value %copy_1 : $Instance
+  %move = move_value %copy_2 : $Instance
+  %copy_3 = copy_value %move : $Instance
+  %copy_4 = copy_value %copy_3 : $Instance
+  %unmanaged = ref_to_unmanaged %copy_4 : $Instance to $@sil_unmanaged Instance
+  destroy_value %copy_4 : $Instance
+  destroy_value %copy_3 : $Instance
+  destroy_value %move : $Instance
+  destroy_value %copy_1 : $Instance
+  %retval = struct $Unmanaged<Instance> (%unmanaged : $@sil_unmanaged Instance)
+  return %retval : $Unmanaged<Instance>
+}
+
+// CHECK-LABEL: begin {{.*}} on copy_and_move_lexical_argument: canonicalize-borrow-scope
+// CHECK-LABEL: sil [ossa] @copy_and_move_lexical_argument : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK:         [[UNMANAGED:%[^,]+]] = ref_to_unmanaged [[INSTANCE]]
+// CHECK:         [[RETVAL:%[^,]+]] = struct $Unmanaged<Instance> ([[UNMANAGED]] : $@sil_unmanaged Instance) 
+// CHECK:         return [[RETVAL]]
+// CHECK-LABEL: } // end sil function 'copy_and_move_lexical_argument'
+// CHECK-LABEL: end {{.*}} on copy_and_move_lexical_argument: canonicalize-borrow-scope
+sil [ossa] @copy_and_move_lexical_argument : $@convention(thin) <Instance where Instance : AnyObject> (@guaranteed Instance) -> Unmanaged<Instance> {
+bb0(%instance : @guaranteed $Instance):
+  test_specification "canonicalize-borrow-scope @argument"
+  %copy_1 = copy_value %instance : $Instance
+  %copy_2 = copy_value %copy_1 : $Instance
+  %move = move_value [lexical] %copy_2 : $Instance
+  %copy_3 = copy_value %move : $Instance
+  %copy_4 = copy_value %copy_3 : $Instance
+  %unmanaged = ref_to_unmanaged %copy_4 : $Instance to $@sil_unmanaged Instance
+  destroy_value %copy_4 : $Instance
+  destroy_value %copy_3 : $Instance
+  destroy_value %move : $Instance
+  destroy_value %copy_1 : $Instance
+  %retval = struct $Unmanaged<Instance> (%unmanaged : $@sil_unmanaged Instance)
+  return %retval : $Unmanaged<Instance>
+}

--- a/test/SILOptimizer/inline_lifetime.sil
+++ b/test/SILOptimizer/inline_lifetime.sil
@@ -327,7 +327,7 @@ entry(%instance : @owned $InferredEagerD2S1):
 
 // CHECK-LABEL: sil [ossa] @caller_owned_callee_guaranteed : $@convention(thin) (@owned C) -> () {
 // CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @owned $C):
-// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [[INSTANCE]]
 // CHECK:         [[RETVAL:%[^,]+]] = tuple ()
 // CHECK:         end_borrow [[LIFETIME]]
 // CHECK:         destroy_value [[INSTANCE]]
@@ -430,7 +430,7 @@ entry(%instance : @owned $InferredEagerD2S1):
 }
 
 // CHECK-LABEL: sil [ossa] @caller_owned_callee_guaranteed_lexical__type_annotation : {{.*}} {
-// CHECK:         begin_borrow [lexical]
+// CHECK:         begin_borrow
 // CHECK-LABEL: } // end sil function 'caller_owned_callee_guaranteed_lexical__type_annotation'
 sil [ossa] @caller_owned_callee_guaranteed_lexical__type_annotation : $@convention(thin) (@owned LexicalS) -> () {
 entry(%instance : @owned $LexicalS):
@@ -441,7 +441,7 @@ entry(%instance : @owned $LexicalS):
 }
 
 // CHECK-LABEL: sil [ossa] @caller_owned_callee_guaranteed_lexical__type_inferred_d1_s1 : {{.*}} {
-// CHECK:         begin_borrow [lexical]
+// CHECK:         begin_borrow
 // CHECK-LABEL: } // end sil function 'caller_owned_callee_guaranteed_lexical__type_inferred_d1_s1'
 sil [ossa] @caller_owned_callee_guaranteed_lexical__type_inferred_d1_s1 : $@convention(thin) (@owned InferredLexicalD1S1) -> () {
 entry(%instance : @owned $InferredLexicalD1S1):
@@ -452,7 +452,7 @@ entry(%instance : @owned $InferredLexicalD1S1):
 }
 
 // CHECK-LABEL: sil [ossa] @caller_owned_callee_guaranteed_lexical__type_inferred_d1_s2 : {{.*}} {
-// CHECK:         begin_borrow [lexical]
+// CHECK:         begin_borrow
 // CHECK-LABEL: } // end sil function 'caller_owned_callee_guaranteed_lexical__type_inferred_d1_s2'
 sil [ossa] @caller_owned_callee_guaranteed_lexical__type_inferred_d1_s2 : $@convention(thin) (@owned InferredLexicalD1S2) -> () {
 entry(%instance : @owned $InferredLexicalD1S2):
@@ -463,7 +463,7 @@ entry(%instance : @owned $InferredLexicalD1S2):
 }
 
 // CHECK-LABEL: sil [ossa] @caller_owned_callee_guaranteed_lexical__type_inferred_d1_s3 : {{.*}} {
-// CHECK:         begin_borrow [lexical]
+// CHECK:         begin_borrow
 // CHECK-LABEL: } // end sil function 'caller_owned_callee_guaranteed_lexical__type_inferred_d1_s3'
 sil [ossa] @caller_owned_callee_guaranteed_lexical__type_inferred_d1_s3 : $@convention(thin) (@owned InferredLexicalD1S3) -> () {
 entry(%instance : @owned $InferredLexicalD1S3):
@@ -474,7 +474,7 @@ entry(%instance : @owned $InferredLexicalD1S3):
 }
 
 // CHECK-LABEL: sil [ossa] @caller_owned_callee_guaranteed_lexical__type_inferred_d1_s4 : {{.*}} {
-// CHECK:         begin_borrow [lexical]
+// CHECK:         begin_borrow
 // CHECK-LABEL: } // end sil function 'caller_owned_callee_guaranteed_lexical__type_inferred_d1_s4'
 sil [ossa] @caller_owned_callee_guaranteed_lexical__type_inferred_d1_s4 : $@convention(thin) (@owned InferredLexicalD1S4) -> () {
 entry(%instance : @owned $InferredLexicalD1S4):
@@ -486,9 +486,9 @@ entry(%instance : @owned $InferredLexicalD1S4):
 
 // CHECK-LABEL: sil [ossa] @caller_guaranteed_callee_guaranteed : $@convention(thin) (@guaranteed C) -> () {
 // CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @guaranteed $C):
-// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
+// CHECK-NOT:     begin_borrow [[INSTANCE]]
 // CHECK:         [[RETVAL:%[^,]+]] = tuple ()
-// CHECK:         end_borrow [[LIFETIME]]
+// CHECK-NOT:     end_borrow
 // CHECK:         return [[RETVAL]]
 // CHECK-LABEL: } // end sil function 'caller_guaranteed_callee_guaranteed'
 sil [ossa] @caller_guaranteed_callee_guaranteed : $@convention(thin) (@guaranteed C) -> () {
@@ -673,7 +673,7 @@ bb0(%instance : @owned $C):
 
 // CHECK-LABEL: sil [ossa] @caller_owned_callee_coro_guaranteed : $@convention(thin) (@owned C) -> () {
 // CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @owned $C):
-// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [[INSTANCE]]
 // CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
 // CHECK:         [[ADDR:%[^,]+]] = alloc_stack $C
 // CHECK:         store [[LIFETIME_OWNED]] to [init] [[ADDR]]
@@ -714,14 +714,14 @@ bb0(%instance : @guaranteed $C):
 
 // CHECK-LABEL: sil [ossa] @caller_guaranteed_callee_coro_guaranteed : $@convention(thin) (@guaranteed C) -> () {
 // CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @guaranteed $C):
-// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
-// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK-NOT:     begin_borrow
+// CHECK:         [[LIFETIME_OWNED:%[^,]+]] = copy_value [[INSTANCE]]
 // CHECK:         [[ADDR:%[^,]+]] = alloc_stack $C
 // CHECK:         store [[LIFETIME_OWNED]] to [init] [[ADDR]]
 // CHECK:         destroy_addr [[ADDR]]
 // CHECK:         dealloc_stack [[ADDR]]
 // CHECK:         [[ORIGINAL_RETVAL:%[^,]+]] = tuple ()
-// CHECK:         end_borrow [[LIFETIME]]
+// CHECK-NOT:     end_borrow
 // CHECK:         [[RETVAL:%[^,]+]] = tuple ()
 // CHECK:         return [[RETVAL]]
 // CHECK:       bb1:
@@ -865,7 +865,7 @@ bb2(%12 : @owned $Error):
 
 // CHECK-LABEL: sil [ossa] @caller_owned_callee_error_guaranteed : $@convention(thin) (@owned C) -> @error any Error {
 // CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @owned $C):
-// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [[INSTANCE]]
 // CHECK:         cond_br undef, [[THROW_BLOCK:bb[^,]+]], [[REGULAR_BLOCK:bb[0-9]+]]
 // CHECK:       [[THROW_BLOCK]]:
 // CHECK:         end_borrow [[LIFETIME]]
@@ -908,14 +908,14 @@ bb2(%12 : @owned $Error):
 
 // CHECK-LABEL: sil [ossa] @caller_guaranteed_callee_error_guaranteed : $@convention(thin) (@guaranteed C) -> @error any Error {
 // CHECK:       {{bb[^,]+}}([[INSTANCE:%[^,]+]] : @guaranteed $C):
-// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
+// CHECK-NOT:     begin_borrow
 // CHECK:         cond_br undef, [[THROW_BLOCK:bb[^,]+]], [[REGULAR_BLOCK:bb[0-9]+]]
 // CHECK:       [[THROW_BLOCK]]:
-// CHECK:         end_borrow [[LIFETIME]]
+// CHECK-NOT:     end_borrow
 // CHECK:         throw undef
 // CHECK:       [[REGULAR_BLOCK]]:
 // CHECK:         [[ORIGINAL_RETVAL:%[^,]+]] = tuple ()
-// CHECK:         end_borrow [[LIFETIME]]
+// CHECK-NOT:     end_borrow
 // CHECK:         [[RETVAL:%[^,]+]] = tuple ()
 // CHECK:         return [[RETVAL]]
 // CHECK-LABEL: } // end sil function 'caller_guaranteed_callee_error_guaranteed'

--- a/test/SILOptimizer/lexical_lifetime_elim.swift
+++ b/test/SILOptimizer/lexical_lifetime_elim.swift
@@ -6,8 +6,13 @@ func takeGuaranteed(_ a: AnyObject) -> AnyObject {
   return a
 }
 
-// CHECK-LABEL: // testLexical(a:)
-// CHECK: [[B:%.*]] = begin_borrow [lexical] %0
+@_silgen_name("getOwned")
+@inline(never)
+func getOwned() -> AnyObject
+
+// CHECK-LABEL: // testLexical()
+// CHECK: [[A:%.*]] = apply %{{.*}}()
+// CHECK: [[B:%.*]] = begin_borrow [lexical] [[A]]
 // CHECK: apply %{{.*}}([[B]])
 // CHECK: apply
 // CHECK: end_borrow [[B]]
@@ -19,8 +24,9 @@ func takeGuaranteed(_ a: AnyObject) -> AnyObject {
 // CHECK-NOT: *** SIL function after {{.*}} (semantic-arc-opts)
 
 // CHECK-LABEL: *** SIL function after {{.*}} (sil-lexical-lifetime-eliminator)
-// CHECK-LABEL: // testLexical(a:)
-// CHECK: [[B:%.*]] = begin_borrow %0
+// CHECK-LABEL: // testLexical()
+// CHECK: [[A:%.*]] = apply %{{.*}}()
+// CHECK: [[B:%.*]] = begin_borrow [[A]]
 // CHECK: apply %{{.*}}([[B]])
 // CHECK: apply
 // CHECK: end_borrow [[B]]
@@ -30,10 +36,12 @@ func takeGuaranteed(_ a: AnyObject) -> AnyObject {
 // that was only needed for a lexical lifetime.
 
 // CHECK-LABEL: *** SIL function after {{.*}} (semantic-arc-opts)
-// CHECK-LABEL: // testLexical(a:)
-// CHECK: apply %{{.*}}(%0)
+// CHECK-LABEL: // testLexical()
+// CHECK: [[A:%.*]] = apply %{{.*}}()
+// CHECK: apply %{{.*}}([[A]])
 // CHECK-LABEL: } // end sil function
-public func testLexical(a: __owned AnyObject) -> AnyObject {
+public func testLexical() -> AnyObject {
+  let a = getOwned()
   // Without lexical lifetimes, the lifetime of 'a' ends in between the two calls:
   return takeGuaranteed(takeGuaranteed(a))
 }

--- a/test/SILOptimizer/mandatory_inlining_ownership.sil
+++ b/test/SILOptimizer/mandatory_inlining_ownership.sil
@@ -28,7 +28,7 @@ bb(%0 : @guaranteed $C):
 
 // CHECK-LABEL: sil [ossa] @callerWithOwned : $@convention(thin) (@owned C) -> Builtin.Int64 {
 // CHECK: bb0(%0 : @owned $C):
-// CHECK:   [[BORROW:%.*]] = begin_borrow [lexical] %0 : $C
+// CHECK:   [[BORROW:%.*]] = begin_borrow %0 : $C
 // CHECK:   [[ADDR:%.*]] = ref_element_addr [[BORROW]] : $C, #C.i
 // CHECK:   [[VAL:%.*]] = load [trivial] [[ADDR]] : $*Builtin.Int64
 // CHECK:   end_borrow [[BORROW]] : $C
@@ -63,7 +63,7 @@ bb2:
 
 // CHECK-LABEL: sil [ossa] @callerWithThrow : $@convention(thin) (@owned C) -> (Builtin.Int64, @error any Error) {
 // CHECK: bb0(%0 : @owned $C):
-// CHECK:   [[BORROW:%.*]] = begin_borrow [lexical] %0 : $C
+// CHECK:   [[BORROW:%.*]] = begin_borrow %0 : $C
 // CHECK:   [[ADDR:%.*]] = ref_element_addr [[BORROW]] : $C, #C.i
 // CHECK:   [[VAL:%.*]] = load [trivial] [[ADDR]] : $*Builtin.Int64
 // CHECK: bb{{.*}}:
@@ -122,8 +122,10 @@ bb0(%0 : @guaranteed $@callee_guaranteed (@owned Builtin.NativeObject) -> @owned
 // CHECK:   [[ARG_COPY_2:%.*]] = copy_value [[ARG_COPY]]
 // CHECK:   [[PAI:%.*]] = partial_apply [[FN]]([[ARG_COPY]])
 // CHECK:   [[ARG_COPY_3:%.*]] = copy_value [[ARG]]
+// CHECK:   [[MOVE_ARG_COPY_3:%[^,]+]] = move_value [lexical] [[ARG_COPY_3]]
+// CHECK:   [[MOVE_ARG_COPY_2:%[^,]+]] = move_value [lexical] [[ARG_COPY_2]]
 // CHECK:   [[FN2:%.*]] = function_ref @nativeobject_plus :
-// CHECK:   [[RESULT:%.*]] = apply [[FN2]]([[ARG_COPY_3]], [[ARG_COPY_2]])
+// CHECK:   [[RESULT:%.*]] = apply [[FN2]]([[MOVE_ARG_COPY_3]], [[MOVE_ARG_COPY_2]])
 // CHECK:   [[PAI_COPY:%.*]] = copy_value [[PAI]]
 // CHECK:   [[OPAQUE_FN:%.*]] = function_ref @partial_apply_user
 // CHECK:   apply [[OPAQUE_FN]]([[PAI_COPY]])
@@ -293,9 +295,10 @@ bb3:
 // CHECK-LABEL: sil [ossa] @term_nonossa_checked_cast_addr_br_takealways_caller : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK-NEXT:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK-NEXT:   [[ARG_MOVE:%[^,]+]] = move_value [lexical] [[ARG_COPY]] : $Builtin.NativeObject
 // CHECK-NEXT:   [[SRC_ADDR:%.*]] = alloc_stack $Builtin.NativeObject
 // CHECK-NEXT:   [[DEST_ADDR:%.*]] = alloc_stack $Klass
-// CHECK-NEXT:   store [[ARG_COPY]] to [init] [[SRC_ADDR]]
+// CHECK-NEXT:   store [[ARG_MOVE]] to [init] [[SRC_ADDR]]
 // CHECK-NEXT:   [[RELOADED_ARG:%.*]] = load [take] [[SRC_ADDR]]
 // CHECK-NEXT:   checked_cast_br [[RELOADED_ARG]] : $Builtin.NativeObject to Klass, [[SUCCESS_BB:bb[0-9]+]], [[FAILURE_BB:bb[0-9]+]]
 //
@@ -368,9 +371,10 @@ bb3:
 // CHECK-LABEL: sil [ossa] @checked_cast_addr_br_takeonsuccess_caller : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK-NEXT:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK-NEXT:   [[ARG_MOVE:%[^,]+]] = move_value [lexical] [[ARG_COPY]] : $Builtin.NativeObject
 // CHECK-NEXT:   [[SRC_ADDR:%.*]] = alloc_stack $Builtin.NativeObject
 // CHECK-NEXT:   [[DEST_ADDR:%.*]] = alloc_stack $Klass
-// CHECK-NEXT:   store [[ARG_COPY]] to [init] [[SRC_ADDR]]
+// CHECK-NEXT:   store [[ARG_MOVE]] to [init] [[SRC_ADDR]]
 // CHECK-NEXT:   [[RELOADED_ARG:%.*]] = load [take] [[SRC_ADDR]]
 // CHECK-NEXT:   checked_cast_br [[RELOADED_ARG]] : $Builtin.NativeObject to Klass, [[SUCCESS_BB:bb[0-9]+]], [[FAILURE_BB:bb[0-9]+]]
 //
@@ -424,9 +428,10 @@ bb3:
 // CHECK-LABEL: sil [ossa] @checked_cast_addr_br_copyonsuccess_caller : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK-NEXT:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK-NEXT:   [[ARG_MOVE:%[^,]+]] = move_value [lexical] [[ARG_COPY]]
 // CHECK-NEXT:   [[SRC_ADDR:%.*]] = alloc_stack $Builtin.NativeObject
 // CHECK-NEXT:   [[DEST_ADDR:%.*]] = alloc_stack $Klass
-// CHECK-NEXT:   store [[ARG_COPY]] to [init] [[SRC_ADDR]]
+// CHECK-NEXT:   store [[ARG_MOVE]] to [init] [[SRC_ADDR]]
 // CHECK-NEXT:   [[RELOADED_ARG:%.*]] = load_borrow [[SRC_ADDR]]
 // CHECK-NEXT:   checked_cast_br [[RELOADED_ARG]] : $Builtin.NativeObject to Klass, [[SUCCESS_BB:bb[0-9]+]], [[FAILURE_BB:bb[0-9]+]]
 //

--- a/test/SILOptimizer/mandatory_inlining_ownership2.sil
+++ b/test/SILOptimizer/mandatory_inlining_ownership2.sil
@@ -510,8 +510,10 @@ bb0(%0 : @owned $@callee_owned (@owned Builtin.NativeObject) -> @owned Builtin.N
 // CHECK:   [[ARG_COPY_2:%.*]] = copy_value [[ARG_COPY]]
 // CHECK:   [[PAI:%.*]] = partial_apply [[FN]]([[ARG_COPY]])
 // CHECK:   [[ARG_COPY_3:%.*]] = copy_value [[ARG]]
+// CHECK:   [[MOVE_ARG_COPY_3:%[^,]+]] = move_value [lexical] [[ARG_COPY_3]]
+// CHECK:   [[MOVE_ARG_COPY_2:%[^,]+]] = move_value [lexical] [[ARG_COPY_2]]
 // CHECK:   [[FN2:%.*]] = function_ref @nativeobject_plus :
-// CHECK:   [[RESULT:%.*]] = apply [[FN2]]([[ARG_COPY_3]], [[ARG_COPY_2]])
+// CHECK:   [[RESULT:%.*]] = apply [[FN2]]([[MOVE_ARG_COPY_3]], [[MOVE_ARG_COPY_2]])
 // CHECK:   [[PAI_COPY:%.*]] = copy_value [[PAI]]
 // CHECK:   [[OPAQUE_FN:%.*]] = function_ref @partial_apply_user
 // CHECK:   apply [[OPAQUE_FN]]([[PAI_COPY]])
@@ -605,14 +607,14 @@ bb0(%0 : @owned ${ var Bool }):
 // CHECK: bb2:
 // Separation marker
 // CHECK:   integer_literal $Builtin.Int32, 3
-// CHECK:   [[ADDR4:%.*]] = project_box [[BOX2_COPY_COPY]]
+// CHECK:   [[BOX2_COPY_COPY_MOVE:%[^,]+]] = move_value [lexical] [[BOX2_COPY_COPY]] : ${ var Bool }  
+// CHECK:   [[ADDR4:%.*]] = project_box [[BOX2_COPY_COPY_MOVE]]
 // CHECK:   {{%.*}} = tuple ()
 // CHECK:   {{%.*}} = load [trivial] [[ADDR4]]
-// CHECK:   destroy_value [[BOX2_COPY_COPY]]
+// CHECK:   destroy_value [[BOX2_COPY_COPY_MOVE]]
 // CHECK:   br [[BB3]](
 //
 // CHECK: [[BB3]](
-// CHECK:   destroy_value [[BOX2_COPY]]
 // CHECK:   destroy_value [[BOX2]]
 // CHECK:   destroy_value [[BOX1]]
 // CHECK:   return {{.*}}
@@ -654,10 +656,11 @@ bb0(%0 : $Bool, %1 : $Bool):
 // CHECK:   integer_literal $Builtin.Int32, 2
 // Marker -
 // CHECK:   integer_literal $Builtin.Int32, 3
-// CHECK:   [[ADDR4:%.*]] = project_box [[BOX2_COPY_COPY]]
+// CHECK:   [[BOX2_COPY_COPY_MOVE:%[^,]+]] = move_value [lexical] [[BOX2_COPY_COPY]] : ${ var Bool }
+// CHECK:   [[ADDR4:%.*]] = project_box [[BOX2_COPY_COPY_MOVE]]
 // CHECK:   {{%.*}} = tuple ()
 // CHECK:   {{%.*}} = load [trivial] [[ADDR4]]
-// CHECK:   destroy_value [[BOX2_COPY_COPY]]
+// CHECK:   destroy_value [[BOX2_COPY_COPY_MOVE]]
 // CHECK:   br [[BB3]](
 //
 // CHECK: [[BB3]](
@@ -725,11 +728,13 @@ bb0(%0 : @owned $CP):
 // CHECK-LABEL: sil [ossa] @_TF2t222outer_open_existentialFT3cp1PS_2CP_3cp2PS0___T_ :
 // CHECK: bb0([[ARG0:%.*]] : @owned $any CP, [[ARG1:%.*]] : @owned $any CP):
 // CHECK:   [[ARG0_COPY:%.*]] = copy_value [[ARG0]]
-// CHECK:   [[ARG0_COPY_COPY:%.*]] = copy_value [[ARG0_COPY]]
+// CHECK:   [[ARG0_COPY_MOVE:%[^,]+]] = move_value [lexical] [[ARG0_COPY]]
+// CHECK:   [[ARG0_COPY_COPY:%.*]] = copy_value [[ARG0_COPY_MOVE]]
 // CHECK:   open_existential_ref [[ARG0_COPY_COPY]] : $any CP to $@opened([[N1:".*"]], any CP) Self
 //
 // CHECK:   [[ARG1_COPY:%.*]] = copy_value [[ARG1]]
-// CHECK:   [[ARG1_COPY_COPY:%.*]] = copy_value [[ARG1_COPY]]
+// CHECK:   [[ARG1_COPY_MOVE:%[^,]+]] = move_value [lexical] [[ARG1_COPY]]
+// CHECK:   [[ARG1_COPY_COPY:%.*]] = copy_value [[ARG1_COPY_MOVE]]
 // CHECK:   open_existential_ref [[ARG1_COPY_COPY]] : $any CP to $@opened([[N1:".*"]], any CP) Self
 // CHECK: } // end sil function '_TF2t222outer_open_existentialFT3cp1PS_2CP_3cp2PS0___T_'
 sil [ossa] @_TF2t222outer_open_existentialFT3cp1PS_2CP_3cp2PS0___T_ : $@convention(thin) (@owned CP, @owned CP) -> () {
@@ -844,12 +849,13 @@ bb0(%0 : @owned $T):
 // CHECK-LABEL: sil hidden [ossa] @protocolTypedParam :
 // CHECK: bb0([[ARG:%.*]] : @owned $any Foo):
 // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
-// CHECK:   [[ARG_COPY_2:%.*]] = copy_value [[ARG_COPY]]
+// CHECK:   [[ARG_COPY_MOVE:%[^,]+]] = move_value [lexical] [[ARG_COPY]] : $any Foo         
+// CHECK:   [[ARG_COPY_2:%.*]] = copy_value [[ARG_COPY_MOVE]]
 // CHECK-NOT: apply
-// CHECK:   [[METHOD:%[a-zA-Z0-9]+]] = objc_method [[ARG_COPY]] : $any Foo, #Foo.foo!foreign : {{.*}}, $@convention(objc_method) <τ_0_0 where τ_0_0 : Foo> (τ_0_0) -> ()
+// CHECK:   [[METHOD:%[a-zA-Z0-9]+]] = objc_method [[ARG_COPY_MOVE]] : $any Foo, #Foo.foo!foreign : {{.*}}, $@convention(objc_method) <τ_0_0 where τ_0_0 : Foo> (τ_0_0) -> ()
 // CHECK:   apply [[METHOD]]<any Foo>([[ARG_COPY_2]]) : $@convention(objc_method) <τ_0_0 where τ_0_0 : Foo> (τ_0_0) -> ()
 // CHECK:   destroy_value [[ARG_COPY_2]]
-// CHECK:   destroy_value [[ARG_COPY]]
+// CHECK:   destroy_value [[ARG_COPY_MOVE]]
 // CHECK:   destroy_value [[ARG]]
 // CHECK: } // end sil function 'protocolTypedParam'
 sil hidden [ossa] @protocolTypedParam : $@convention(thin) (@owned Foo) -> () {
@@ -916,7 +922,8 @@ bb0(%0 : $*U, %1 : $*T, %2 : @owned $@callee_owned (@in T) -> @out U):
 // CHECK-NOT: function_ref @reabstractionThunk
 // CHECK-NOT: partial_apply
 // CHECK-NOT: apply
-// CHECK:   apply [[ARG2_COPY_COPY]](
+// CHECK:   [[ARG2_COPY_COPY_MOVE:%[^,]+]] = move_value [lexical] [[ARG2_COPY_COPY]]
+// CHECK:   apply [[ARG2_COPY_COPY_MOVE]](
 // CHECK: } // end sil function 'applyPartial'
 sil [ossa] @applyPartial : $@convention(thin) <U> (Builtin.Int32, @owned @callee_owned (Builtin.Int32) -> @out U) -> @out U {
 bb0(%0 : $*U, %1 : $Builtin.Int32, %2 : @owned $@callee_owned (Builtin.Int32) -> @out U):
@@ -1046,8 +1053,9 @@ bb0(%0 : @owned $Optional<C>):
 // CHECK: bb0([[ARG:%.*]] : @owned $C):
 // CHECK:   [[F1:%.*]] = function_ref @testMandatoryConvertedHelper : $@convention(thin) (@owned C) -> @owned C
 // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK:   [[ARG_COPY_MOVE:%[^,]+]] = move_value [lexical] [[ARG_COPY]]
 // CHECK:   [[CVT1:%.*]] = convert_function [[F1]] : $@convention(thin) (@owned C) -> @owned C to $@convention(thin) (@owned C) -> (@owned C, @error any Error)
-// CHECK:   try_apply [[CVT1]]([[ARG_COPY]]) : $@convention(thin) (@owned C) -> (@owned C, @error any Error), normal bb1, error bb2
+// CHECK:   try_apply [[CVT1]]([[ARG_COPY_MOVE]]) : $@convention(thin) (@owned C) -> (@owned C, @error any Error), normal bb1, error bb2
 //
 // CHECK: bb1(%{{.*}} : @owned $C):
 // CHECK:   br bb3(%{{.*}} : $C)

--- a/test/SILOptimizer/move_function_kills_copyable_values.swift
+++ b/test/SILOptimizer/move_function_kills_copyable_values.swift
@@ -232,13 +232,13 @@ public func patternMatchSwitchLet2(_ x: __owned (Klass?, Klass?)?) {
 
 public func patternMatchSwitchLet3(_ x: __owned (Klass?, Klass?)?) { // expected-error {{'x' used after being moved}}
     let _ = _move x // expected-note {{move here}}
-    switch x { // expected-note {{use here}}
+    switch x {
     case .some((.some(_), .some(let z))): // expected-error {{'z' used after being moved}}
         let _ = _move z // expected-note {{move here}}
         nonConsumingUse(z) // expected-note {{use here}}
     default:
         break
-    }
+    } // expected-note {{use here}} expected-note {{use here}}
 }
 
 ////////////////
@@ -296,11 +296,11 @@ public func castTest2(_ x: __owned Klass) -> SubKlass1? { // expected-error {{'x
 public func castTestSwitch1(_ x : __owned Klass) { // expected-error {{'x' used after being moved}}
     let _ = _move x // expected-note {{move here}}
     switch x {
-    case let k as SubKlass1: // expected-note {{use here}}
+    case let k as SubKlass1:
         print(k)
     default:
         print("Nope")
-    }
+    } // expected-note {{use here}} expected-note {{use here}}
 }
 
 public func castTestSwitch2(_ x : __owned Klass) { // expected-error {{'x' used after being moved}}
@@ -308,11 +308,11 @@ public func castTestSwitch2(_ x : __owned Klass) { // expected-error {{'x' used 
     switch x {
     case let k as SubKlass1:
         print(k)
-    case let k as SubKlass2: // expected-note {{use here}}
+    case let k as SubKlass2:
         print(k)
     default:
         print("Nope")
-    }
+    } // expected-note {{use here}} expected-note {{use here}} expected-note {{use here}}
 }
 
 public func castTestSwitchInLoop(_ x : __owned Klass) { // expected-error {{'x' used after being moved}}
@@ -320,7 +320,7 @@ public func castTestSwitchInLoop(_ x : __owned Klass) { // expected-error {{'x' 
 
     for _ in 0..<1024 {
         switch x {
-        case let k as SubKlass1: // expected-note {{use here}}
+        case let k as SubKlass1:
             print(k)
         default:
             print("Nope")

--- a/test/SILOptimizer/moveonly_lifetime.swift
+++ b/test/SILOptimizer/moveonly_lifetime.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -Onone -verify -enable-experimental-move-only -enable-experimental-feature MoveOnlyClasses %s | %FileCheck %s
+// RUN: %target-swift-emit-sil -module-name moveonly_lifetime -o /dev/null -Xllvm -sil-print-canonical-module -Onone -verify -enable-experimental-move-only -enable-experimental-feature MoveOnlyClasses %s 2>&1 | %FileCheck %s
 
 @_moveOnly
 class C {}
@@ -19,9 +19,12 @@ func something()
 // non-consuming scope where it appears but not further (which would require a
 // copy).
 //
-// CHECK-LABEL: sil hidden @test_diamond__consume_r__use_l : $@convention(thin) (Bool) -> () {
+// CHECK-LABEL: sil hidden [ossa] @test_diamond__consume_r__use_l : $@convention(thin) (Bool) -> () {
 // CHECK:         [[INSTANCE:%[^,]+]] = move_value [lexical] {{%[^,]+}}
 // CHECK:         cond_br {{%[^,]+}}, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[RIGHT]]:
+// CHECK:         [[TAKE_C:%[^,]+]] = function_ref @takeC
+// CHECK:         apply [[TAKE_C]]([[INSTANCE]])
 // CHECK:       [[LEFT]]:
 // CHECK:         [[BORROW_C:%[^,]+]] = function_ref @borrowC
 // CHECK:         apply [[BORROW_C]]([[INSTANCE]])
@@ -29,9 +32,6 @@ func something()
 // CHECK:         apply [[SOMETHING]]
 // CHECK:         [[DESTROY_C:%[^,]+]] = function_ref @$s17moveonly_lifetime1CCfD
 // CHECK:         apply [[DESTROY_C]]([[INSTANCE]])
-// CHECK:       [[RIGHT]]:
-// CHECK:         [[TAKE_C:%[^,]+]] = function_ref @takeC
-// CHECK:         apply [[TAKE_C]]([[INSTANCE]])
 // CHECK-LABEL: } // end sil function 'test_diamond__consume_r__use_l'
 @_silgen_name("test_diamond__consume_r__use_l")
 func test_diamond(_ condition: Bool) {

--- a/test/SILOptimizer/semantic-arc-opts.sil
+++ b/test/SILOptimizer/semantic-arc-opts.sil
@@ -1529,7 +1529,7 @@ bb3(%7 : @owned $FakeOptional<Builtin.NativeObject>):
 
 // SemanticARCOptVisitor::performGuaranteedCopyValueOptimization should not optimize this case.
 //
-// CHECK-LABEL: sil [ossa] @testDeadInterleavedBorrow : $@convention(c) (@owned FakeOptional<AnyObject>) -> () {
+// CHECK-LABEL: sil [ossa] @testDeadInterleavedBorrow : $@convention(c) () -> () {
 // CHECK: [[B:%.*]] = begin_borrow [lexical] %0 : $FakeOptional<AnyObject>
 // CHECK: copy_value
 // CHECK: switch_enum
@@ -1539,8 +1539,9 @@ bb3(%7 : @owned $FakeOptional<Builtin.NativeObject>):
 // CHECK: end_borrow
 // CHECK: destroy_value [[COPY]] : $AnyObject
 // CHECK-LABEL: } // end sil function 'testDeadInterleavedBorrow'
-sil [ossa] @testDeadInterleavedBorrow : $@convention(c) (@owned FakeOptional<AnyObject>) -> () {
-bb0(%opt : @owned $FakeOptional<AnyObject>):
+sil [ossa] @testDeadInterleavedBorrow : $@convention(c) () -> () {
+bb0:
+    %opt = apply undef() : $@convention(thin) () -> (@owned FakeOptional<AnyObject>)
     %opt_borrow = begin_borrow [lexical] %opt : $FakeOptional<AnyObject>
     %opt_borrow_copy = copy_value %opt_borrow : $FakeOptional<AnyObject>
     switch_enum %opt_borrow_copy : $FakeOptional<AnyObject>, case #FakeOptional.some!enumelt: some, case #FakeOptional.none!enumelt: none
@@ -1567,7 +1568,7 @@ exit:
 
 // SemanticARCOptVisitor::performGuaranteedCopyValueOptimization should not optimize this case.
 //
-// CHECK-LABEL: sil [ossa] @testDeadAndAliveInterleavedBorrow : $@convention(c) (@owned FakeOptional<AnyObject>) -> () {
+// CHECK-LABEL: sil [ossa] @testDeadAndAliveInterleavedBorrow : $@convention(c) () -> () {
 // CHECK: [[B:%.*]] = begin_borrow [lexical] %0 : $FakeOptional<AnyObject>
 // CHECK: copy_value
 // CHECK: switch_enum
@@ -1586,8 +1587,9 @@ exit:
 // CHECK: destroy_value [[COPY]] : $AnyObject
 // CHECK: destroy_value %0 : $FakeOptional<AnyObject>
 // CHECK-LABEL: } // end sil function 'testDeadAndAliveInterleavedBorrow'
-sil [ossa] @testDeadAndAliveInterleavedBorrow : $@convention(c) (@owned FakeOptional<AnyObject>) -> () {
-bb0(%opt : @owned $FakeOptional<AnyObject>):
+sil [ossa] @testDeadAndAliveInterleavedBorrow : $@convention(c) () -> () {
+bb0:
+    %opt = apply undef() : $@convention(thin) () -> (@owned FakeOptional<AnyObject>)
     %opt_borrow = begin_borrow [lexical] %opt : $FakeOptional<AnyObject>
     %opt_borrow_copy = copy_value %opt_borrow : $FakeOptional<AnyObject>
     switch_enum %opt_borrow_copy : $FakeOptional<AnyObject>, case #FakeOptional.some!enumelt: some, case #FakeOptional.none!enumelt: none

--- a/test/SILOptimizer/shrink_borrow_scope.swift
+++ b/test/SILOptimizer/shrink_borrow_scope.swift
@@ -20,15 +20,13 @@ public func eliminate_copy_of_returned_then_consumed_owned_value(arg: __owned An
   // CHECK-LABEL: sil [ossa] @eliminate_copy_of_returned_then_consumed_owned_value : {{.*}} {
   // CHECK:       {{bb[0-9]+}}([[ARG:%[^,]+]] : @owned $AnyObject):
   // retain arg
-  // CHECK:       [[ARG_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[ARG]]
-  // CHECK:       [[ARG_COPY:%[^,]+]] = copy_value [[ARG_LIFETIME]]
+  // CHECK:       [[ARG_COPY:%[^,]+]] = copy_value [[ARG]]
   let x = consumeAndProduce(arg)
   // CHECK:       [[X:%[^,]+]] = apply {{%[^,]+}}([[ARG_COPY]])
   // CHECK:       [[MOVE_X:%[^,]+]] = move_value [lexical] [[X]]
   // no copy of 'x'
   _ = consumeAndProduce(x)
   // CHECK:       [[RESULT:%[^,]+]] = apply {{%[^,]+}}([[MOVE_X]])
-  // CHECK:       end_borrow [[ARG_LIFETIME]]
   // release result
   // release arg
   // CHECK:       destroy_value [[ARG]]

--- a/test/SILOptimizer/sil_combine_protocol_conf.swift
+++ b/test/SILOptimizer/sil_combine_protocol_conf.swift
@@ -248,10 +248,10 @@ public class OtherClass {
 // CHECK: load [[S11]] 
 // CHECK: [[R2:%.*]] = ref_element_addr [[ARG]] : $OtherClass, #OtherClass.arg2
 // CHECK: [[ACC2:%.*]] = begin_access [read] [static] [no_nested_conflict] [[R2]]
-// CHECK: copy_addr [[ACC2]] to [init] [[T1:%[0-9]*]]
-// CHECK: [[O2:%.*]] = open_existential_addr immutable_access [[T1]] : $*any GenericPropProtocol to $*@opened("{{.*}}", any GenericPropProtocol) Self
+// CHECK: [[O2:%.*]] = open_existential_addr immutable_access [[ACC2]] : $*any GenericPropProtocol to $*@opened("{{.*}}", any GenericPropProtocol) Self
+// CHECK: copy_addr [[O2]] to [init] [[T1:%[0-9]*]]
 // CHECK: [[W2:%.*]] = witness_method $@opened("{{.*}}", any GenericPropProtocol) Self, #GenericPropProtocol.val!getter : <Self where Self : GenericPropProtocol> (Self) -> () -> Int, [[O2]] : $*@opened("{{.*}}", any GenericPropProtocol) Self : $@convention(witness_method: GenericPropProtocol) <τ_0_0 where τ_0_0 : GenericPropProtocol> (@in_guaranteed τ_0_0) -> Int
-// CHECK: apply [[W2]]<@opened("{{.*}}", any GenericPropProtocol) Self>([[O2]]) : $@convention(witness_method: GenericPropProtocol) <τ_0_0 where τ_0_0 : GenericPropProtocol> (@in_guaranteed τ_0_0) -> Int
+// CHECK: apply [[W2]]<@opened("{{.*}}", any GenericPropProtocol) Self>([[T1]]) : $@convention(witness_method: GenericPropProtocol) <τ_0_0 where τ_0_0 : GenericPropProtocol> (@in_guaranteed τ_0_0) -> Int
 // CHECK: struct_extract
 // CHECK: integer_literal
 // CHECK: builtin
@@ -271,10 +271,10 @@ public class OtherClass {
 // CHECK: cond_fail
 // CHECK: [[R5:%.*]] = ref_element_addr [[ARG]] : $OtherClass, #OtherClass.arg4
 // CHECK: [[ACC5:%.*]] = begin_access [read] [static] [no_nested_conflict] [[R5]]
-// CHECK: copy_addr [[ACC5]] to [init] [[T2:%[0-9]+]]
-// CHECK: [[O5:%.*]] = open_existential_addr immutable_access [[T2]] : $*any GenericNestedPropProtocol to $*@opened("{{.*}}", any GenericNestedPropProtocol) Self
+// CHECK: [[O5:%.*]] = open_existential_addr immutable_access [[ACC5]] : $*any GenericNestedPropProtocol to $*@opened("{{.*}}", any GenericNestedPropProtocol) Self
+// CHECK: copy_addr [[O5]] to [init] [[T2:%[0-9]+]]
 // CHECK: [[W5:%.*]] = witness_method $@opened("{{.*}}", any GenericNestedPropProtocol) Self, #GenericNestedPropProtocol.val!getter : <Self where Self : GenericNestedPropProtocol> (Self) -> () -> Int, [[O5:%.*]] : $*@opened("{{.*}}", any GenericNestedPropProtocol) Self : $@convention(witness_method: GenericNestedPropProtocol) <τ_0_0 where τ_0_0 : GenericNestedPropProtocol> (@in_guaranteed τ_0_0) -> Int 
-// CHECK: apply [[W5]]<@opened("{{.*}}", any GenericNestedPropProtocol) Self>([[O5]]) : $@convention(witness_method: GenericNestedPropProtocol) <τ_0_0 where τ_0_0 : GenericNestedPropProtocol> (@in_guaranteed τ_0_0) -> Int
+// CHECK: apply [[W5]]<@opened("{{.*}}", any GenericNestedPropProtocol) Self>([[T2]]) : $@convention(witness_method: GenericNestedPropProtocol) <τ_0_0 where τ_0_0 : GenericNestedPropProtocol> (@in_guaranteed τ_0_0) -> Int
 // CHECK: struct_extract
 // CHECK: builtin
 // CHECK: tuple_extract
@@ -341,10 +341,10 @@ public class OtherKlass {
 // CHECK: integer_literal
 // CHECK: [[R1:%.*]] = ref_element_addr [[ARG]] : $OtherKlass, #OtherKlass.arg2
 // CHECK: [[ACC1:%.*]] = begin_access [read] [static] [no_nested_conflict] [[R1]]
-// CHECK: copy_addr [[ACC1]] to [init] [[T1:%[0-9]+]]
-// CHECK: [[O1:%.*]] = open_existential_addr immutable_access [[T1]] : $*any AGenericProtocol to $*@opened("{{.*}}", any AGenericProtocol) Self
+// CHECK: [[O1:%.*]] = open_existential_addr immutable_access [[ACC1]] : $*any AGenericProtocol to $*@opened("{{.*}}", any AGenericProtocol) Self
+// CHECK: copy_addr [[O1]] to [init] [[T1:%[0-9]+]]
 // CHECK: [[W1:%.*]] = witness_method $@opened("{{.*}}", any AGenericProtocol) Self, #AGenericProtocol.val!getter : <Self where Self : AGenericProtocol> (Self) -> () -> Int, [[O1]] : $*@opened("{{.*}}", any AGenericProtocol) Self : $@convention(witness_method: AGenericProtocol) <τ_0_0 where τ_0_0 : AGenericProtocol> (@in_guaranteed τ_0_0) -> Int
-// CHECK: apply [[W1]]<@opened("{{.*}}", any AGenericProtocol) Self>([[O1]]) : $@convention(witness_method: AGenericProtocol) <τ_0_0 where τ_0_0 : AGenericProtocol> (@in_guaranteed τ_0_0) -> Int
+// CHECK: apply [[W1]]<@opened("{{.*}}", any AGenericProtocol) Self>([[T1]]) : $@convention(witness_method: AGenericProtocol) <τ_0_0 where τ_0_0 : AGenericProtocol> (@in_guaranteed τ_0_0) -> Int
 // CHECK: struct_extract
 // CHECK: integer_literal
 // CHECK: builtin

--- a/test/SILOptimizer/type_wrapper_init_transform.swift
+++ b/test/SILOptimizer/type_wrapper_init_transform.swift
@@ -129,7 +129,7 @@ struct TupleFlatteningTest<K: Collection & Hashable, V> {
   // CHECK: [[STORAGE_VAR:%.*]] = alloc_stack $TupleFlatteningTest<K, V>.$Storage
   // CHECK: [[STORAGE_INIT_REF:%.*]] = function_ref @$s4test19TupleFlatteningTestV8$StorageV1a1b1c1dAEyxq__GSi_SS_Si_xttSDyxq_Gq_SgtcfC
   // CHECK: [[LOCAL_STORAGE_ACCESS:%.*]] = begin_access [read] [unsafe] [[LOCAL_STORAGE:%.*]] : $*(a: Int, b: (String, (Int, K)), c: Dictionary<K, V>, d: Optional<V>)
-  // CHECK: [[A_REF:%.*]] = tuple_element_addr %73 : $*(a: Int, b: (String, (Int, K)), c: Dictionary<K, V>, d: Optional<V>), 0
+  // CHECK: [[A_REF:%.*]] = tuple_element_addr {{%[^,]+}} : $*(a: Int, b: (String, (Int, K)), c: Dictionary<K, V>, d: Optional<V>), 0
   // CHECK: [[A:%.*]] = load [trivial] [[A_REF]] : $*Int
   // CHECK: [[B_TUPLE:%.*]] = tuple_element_addr [[LOCAL_STORAGE_ACCESS]] : $*(a: Int, b: (String, (Int, K)), c: Dictionary<K, V>, d: Optional<V>), 1
   // CHECK: [[B_ELT_0_REF:%.*]] = tuple_element_addr [[B_TUPLE]] : $*(String, (Int, K)), 0
@@ -354,7 +354,7 @@ struct TypeWithLetProperties<T> {
   public init(a: T, b: Int? = nil, onSet: (() -> Void)? = nil) {
     // CHECK: [[LOCAL_STORAGE_ACCESS:%.*]] = begin_access [modify] [static] [[LOCAL_STORAGE]] : $*(a: T, b: Int)
     // CHECK-NEXT: [[A_REF:%.*]] = tuple_element_addr [[LOCAL_STORAGE_ACCESS]] : $*(a: T, b: Int), 0
-    // CHECK-NEXT: copy_addr [take] %11 to [init] [[A_REF]] : $*T
+    // CHECK-NEXT: copy_addr [take] {{%[^,]+}} to [init] [[A_REF]] : $*T
     // CHECK-NOT: {{.*}} = assign_by_wrapper {{.*}}
     // CHECK-NEXT: end_access [[LOCAL_STORAGE_ACCESS]]
     self.a = a
@@ -444,7 +444,7 @@ struct TypeWithDefaultedProperties<T> {
   // --> Assignment to `let a`
   // CHECK: [[LOCAL_STORAGE_ACCESS:%.*]] = begin_access [modify] [static] [[LOCAL_STORAGE]] : $*(a: Array<String>, b: Optional<T>, c: Int)
   // CHECK-NEXT: [[A_REF:%.*]] = tuple_element_addr [[LOCAL_STORAGE_ACCESS]] : $*(a: Array<String>, b: Optional<T>, c: Int), 0
-  // CHECK-NEXT: assign [[A_ARG:%.*]] to [init] %18 : $*Array<String>
+  // CHECK-NEXT: assign [[A_ARG:%.*]] to [init] {{%[^,]+}} : $*Array<String>
   // CHECK-NEXT: end_access [[LOCAL_STORAGE_ACCESS]]
   // --> Assignment to `var c`, note that the assignment is done to a wrapped value
   // CHECK: [[C_REF:%.*]] = tuple_element_addr [[LOCAL_STORAGE]] : $*(a: Array<String>, b: Optional<T>, c: Int), 2


### PR DESCRIPTION
Previously, `begin_borrow [lexical]` were created during SILGen for @owned arguments.  Such borrows could be deleted if trivially dead, which was the original reason why @owned arguments were considered lexical and could not have their destroys hoisted.

Those borrows were however important during inlining because they would maintain the lifetime of the owned argument.  Unless of course the borrow scope was trivially dead.  In which case the owned argument's lifetime would not be maintained.  And if the caller's value was non-lexical, destroys of the value could be hoisted over deinit barriers.

Here, during inlining, `move_value [lexical]`s are introduced during inlining whever the caller's value is non-lexical.  This maintains the lifetime of the owned argument even after inlining.

Additionally, took the opportunity to improve the handling of guaranteed function argument lifetimes: (1) during inlining they don't get lexical borrow_scopes when the caller's value is already lexical and (2) they are recongized as lexical.
