### PR TITLE
Sema: Diagnose global actor attribute access and availability

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4882,6 +4882,11 @@ ERROR(global_actor_non_final_class,none,
       "non-final class %0 cannot be a global actor", (DeclName))
 ERROR(global_actor_top_level_var,none,
       "top-level code variables cannot have a global actor", ())
+ERROR(global_actor_access,none,
+      "%select{private|fileprivate|internal|public|open}0 %1 %2 "
+      "cannot have %select{private|fileprivate|internal|%error|%error}3 "
+      "global actor %4",
+      (AccessLevel, DescriptiveDeclKind, DeclName, AccessLevel, DeclName))
 
 ERROR(actor_isolation_multiple_attr,none,
       "%0 %1 has multiple actor-isolation attributes ('%2' and '%3')",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4887,6 +4887,9 @@ ERROR(global_actor_access,none,
       "cannot have %select{private|fileprivate|internal|%error|%error}3 "
       "global actor %4",
       (AccessLevel, DescriptiveDeclKind, DeclName, AccessLevel, DeclName))
+ERROR(global_actor_not_usable_from_inline,none,
+      "global actor for %0 %1 must be '@usableFromInline' or public",
+      (DescriptiveDeclKind, DeclName))
 
 ERROR(actor_isolation_multiple_attr,none,
       "%0 %1 has multiple actor-isolation attributes ('%2' and '%3')",

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -1677,6 +1677,15 @@ public:
   explicit DeclAvailabilityChecker(ExportContext where)
     : Where(where) {}
 
+  void visit(Decl *D) {
+    DeclVisitor<DeclAvailabilityChecker>::visit(D);
+    
+    if (auto globalActor = D->getGlobalActorAttr()) {
+      auto customAttr = globalActor->first;
+      checkType(customAttr->getType(), customAttr->getTypeRepr(), D);
+    }
+  }
+  
   // Force all kinds to be handled at a lower level.
   void visitDecl(Decl *D) = delete;
   void visitValueDecl(ValueDecl *D) = delete;

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -311,6 +311,7 @@ class BazFrame: NotIsolatedPictureFrame {
   }
 }
 
+@available(SwiftStdlib 5.5, *)
 @SomeGlobalActor
 class BazFrameIso: PictureFrame { // expected-error {{global actor 'SomeGlobalActor'-isolated class 'BazFrameIso' has different actor isolation from main actor-isolated superclass 'PictureFrame'}}
 }
@@ -387,6 +388,7 @@ extension SomeWrapper: Sendable where T: Sendable {}
 
 
 // rdar://96830159
+@available(SwiftStdlib 5.5, *)
 @MainActor class SendableCompletionHandler {
   var isolatedThing: [String] = []
   // expected-note@-1 {{property declared here}}

--- a/test/Concurrency/concurrent_value_inference.swift
+++ b/test/Concurrency/concurrent_value_inference.swift
@@ -91,9 +91,11 @@ actor MyGlobalActor {
   static let shared = MyGlobalActor()
 }
 
+@available(SwiftStdlib 5.1, *)
 @MyGlobalActor
 class C3 { }
 
+@available(SwiftStdlib 5.1, *)
 class C4: C3 { }
 
 // Make Sendable unavailable, but be sure not to diagnose it.
@@ -104,6 +106,7 @@ struct S2 {
 @available(*, unavailable)
 extension S2: Sendable { }
 
+@available(SwiftStdlib 5.1, *)
 func testCV(
   c1: C1, c2: C2, c3: C3, c4: C4, s1: S1, e1: E1, e2: E2,
   gs1: GS1<Int>, gs2: GS2<Int>,

--- a/test/Concurrency/flow_isolation_nonstrict.swift
+++ b/test/Concurrency/flow_isolation_nonstrict.swift
@@ -30,6 +30,7 @@ actor CheckDeinitFromActor {
   }
 }
 
+@available(SwiftStdlib 5.1, *)
 @MainActor class X {
   var ns: NonSendableType = NonSendableType()
 

--- a/test/Concurrency/require-explicit-sendable.swift
+++ b/test/Concurrency/require-explicit-sendable.swift
@@ -101,10 +101,16 @@ struct S11: Sendable {
 @_nonSendable public struct S12 { }
 
 // Don't complain about global-actor-qualified classes or their subclasses.
+@available(SwiftStdlib 5.1, *)
 @MainActor
 open class TestThing {}
+
+@available(SwiftStdlib 5.1, *)
 open class TestSubThing : TestThing {}
 
+@available(SwiftStdlib 5.1, *)
 @MainActor(unsafe)
 open class TestThing2 {}
+
+@available(SwiftStdlib 5.1, *)
 open class TestSubThing2 : TestThing2 {}

--- a/test/Concurrency/sendable_conformance_checking.swift
+++ b/test/Concurrency/sendable_conformance_checking.swift
@@ -159,7 +159,10 @@ final class SubKlass: Klass<[S]> {}
 public struct S {}
 
 // rdar://88700507 - redundant conformance of @MainActor-isolated subclass to 'Sendable'
+@available(SwiftStdlib 5.1, *)
 @MainActor class MainSuper {}
+
+@available(SwiftStdlib 5.1, *)
 class MainSub: MainSuper, @unchecked Sendable {}
 
 class SendableSuper: @unchecked Sendable {}

--- a/test/SILGen/functions_uninhabited_param.swift
+++ b/test/SILGen/functions_uninhabited_param.swift
@@ -25,6 +25,7 @@ enum E {
   static func f(_: E) {}
 }
 
+@available(SwiftStdlib 5.1, *)
 @MainActor
 class Bar {
   var foo: (E) -> Void = { _ in }

--- a/test/SPI/spi_global_actor.swift
+++ b/test/SPI/spi_global_actor.swift
@@ -1,0 +1,20 @@
+// RUN: %target-typecheck-verify-swift
+
+// REQUIRES: concurrency
+
+@available(SwiftStdlib 5.1, *)
+@_spi(Foo)
+@globalActor
+public struct SPIGA { // expected-note {{type declared here}}
+  public actor Actor {}
+  public static let shared = Actor()
+}
+
+@available(SwiftStdlib 5.1, *)
+@SPIGA // expected-error {{cannot use struct 'SPIGA' here; it is SPI}}
+public struct PublicStruct {}
+
+@available(SwiftStdlib 5.1, *)
+@_spi(Foo)
+@SPIGA
+public struct SPIStruct {}

--- a/test/Sema/availability_global_actor.swift
+++ b/test/Sema/availability_global_actor.swift
@@ -1,0 +1,37 @@
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.50
+
+// REQUIRES: concurrency
+// REQUIRES: OS=macosx
+
+actor SomeActor {}
+
+@globalActor struct AlwaysAvailableGA {
+  static let shared = SomeActor()
+}
+
+@available(macOS 10.51, *)
+@globalActor struct Available10_51GA {
+  static let shared = SomeActor()
+}
+
+@available(*, unavailable)
+@globalActor struct UnavailableGA { // expected-note {{'UnavailableGA' has been explicitly marked unavailable here}}
+  static let shared = SomeActor()
+}
+
+@AlwaysAvailableGA
+struct AlwaysAvailableWithAlwaysAvailableGA {}
+
+@Available10_51GA // expected-error {{'Available10_51GA' is only available in macOS 10.51 or newer}}
+struct AlwaysAvailableWithAvailable10_51GA {} // expected-note {{add @available attribute to enclosing struct}}
+
+@available(macOS 10.51, *)
+@Available10_51GA
+struct Always10_51WithAvailable10_51GA {}
+
+@UnavailableGA // expected-error {{'UnavailableGA' is unavailable}}
+struct AlwaysAvailableWithUnavailableGA {}
+
+@available(*, unavailable)
+@UnavailableGA
+struct UnavailableWithUnavailableGA {}

--- a/test/attr/attr_inlinable_global_actor.swift
+++ b/test/attr/attr_inlinable_global_actor.swift
@@ -2,32 +2,61 @@
 
 // REQUIRES: concurrency
 
+@available(SwiftStdlib 5.1, *)
 @globalActor
 private struct PrivateGA { // expected-note 2 {{type declared here}}
   actor Actor {}
   static let shared = Actor()
 }
 
+@available(SwiftStdlib 5.1, *)
 @globalActor
 internal struct InternalGA { // expected-note {{type declared here}}
   actor Actor {}
   static let shared = Actor()
 }
 
-@globalActor @usableFromInline
+@available(SwiftStdlib 5.1, *)
+@globalActor
+@usableFromInline
 internal struct UFIGA {
   @usableFromInline actor Actor {}
   @usableFromInline static let shared = Actor()
 }
 
+@available(SwiftStdlib 5.1, *)
 @globalActor
 public struct PublicGA {
   public actor Actor {}
   public static let shared = Actor()
 }
 
-// expected-error@+1 {{internal struct 'UFIStructPrivateGA' cannot have private global actor 'PrivateGA'}}
+// expected-error@+2 {{internal struct 'UFIStructPrivateGA' cannot have private global actor 'PrivateGA'}}
+@available(SwiftStdlib 5.1, *)
 @PrivateGA @usableFromInline internal struct UFIStructPrivateGA {} // expected-error {{global actor for struct 'UFIStructPrivateGA' must be '@usableFromInline' or public}}
+@available(SwiftStdlib 5.1, *)
 @InternalGA @usableFromInline internal struct UFIStructInternalGA {} // expected-error {{global actor for struct 'UFIStructInternalGA' must be '@usableFromInline' or public}}
+@available(SwiftStdlib 5.1, *)
 @UFIGA @usableFromInline internal struct UFIStructUFIGA {}
+@available(SwiftStdlib 5.1, *)
 @PublicGA @usableFromInline internal struct UFIStructPublicGA {}
+
+@available(SwiftStdlib 5.1, *)
+@inlinable public func testNestedFuncs() {
+  // FIXME: Functions isolated to non-resilient global actors nested in
+  //        inlinable functions should be diagnosed.
+  @PrivateGA func inlineFuncPrivateGA() {}
+  @InternalGA func inlineFuncInternalGA() {}
+  @UFIGA func inlineFuncUFIGA() {}
+  @PublicGA func inlineFuncPublicGA() {}
+}
+
+@available(SwiftStdlib 5.1, *)
+@inlinable public func testNestedClosures() {
+  // FIXME: Closures isolated to non-resilient global actors nested in
+  //        inlinable functions should be diagnosed.
+  _ = { @PrivateGA in }
+  _ = { @InternalGA in }
+  _ = { @UFIGA in }
+  _ = { @PublicGA in }
+}

--- a/test/attr/attr_inlinable_global_actor.swift
+++ b/test/attr/attr_inlinable_global_actor.swift
@@ -1,0 +1,33 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5
+
+// REQUIRES: concurrency
+
+@globalActor
+private struct PrivateGA { // expected-note 2 {{type declared here}}
+  actor Actor {}
+  static let shared = Actor()
+}
+
+@globalActor
+internal struct InternalGA { // expected-note {{type declared here}}
+  actor Actor {}
+  static let shared = Actor()
+}
+
+@globalActor @usableFromInline
+internal struct UFIGA {
+  @usableFromInline actor Actor {}
+  @usableFromInline static let shared = Actor()
+}
+
+@globalActor
+public struct PublicGA {
+  public actor Actor {}
+  public static let shared = Actor()
+}
+
+// expected-error@+1 {{internal struct 'UFIStructPrivateGA' cannot have private global actor 'PrivateGA'}}
+@PrivateGA @usableFromInline internal struct UFIStructPrivateGA {} // expected-error {{global actor for struct 'UFIStructPrivateGA' must be '@usableFromInline' or public}}
+@InternalGA @usableFromInline internal struct UFIStructInternalGA {} // expected-error {{global actor for struct 'UFIStructInternalGA' must be '@usableFromInline' or public}}
+@UFIGA @usableFromInline internal struct UFIStructUFIGA {}
+@PublicGA @usableFromInline internal struct UFIStructPublicGA {}

--- a/test/attr/global_actor.swift
+++ b/test/attr/global_actor.swift
@@ -100,3 +100,38 @@ struct Container {
 extension SomeActor {
   @GA1 nonisolated func conflict1() { } // expected-error 3{{instance method 'conflict1()' has multiple actor-isolation attributes ('nonisolated' and 'GA1')}}
 }
+
+
+// -----------------------------------------------------------------------
+// Access
+// -----------------------------------------------------------------------
+
+@globalActor
+private struct PrivateGA { // expected-note 2 {{type declared here}}
+  actor Actor {}
+  static let shared = Actor()
+}
+
+@globalActor
+internal struct InternalGA { // expected-note 1 {{type declared here}}
+  actor Actor {}
+  static let shared = Actor()
+}
+
+@globalActor
+public struct PublicGA {
+  public actor Actor {}
+  public static let shared = Actor()
+}
+
+@PrivateGA private struct PrivateStructPrivateGA {}
+@InternalGA private struct PrivateStructInternalGA {}
+@PublicGA private struct PrivateStructPublicGA {}
+
+@PrivateGA internal struct InternalStructPrivateGA {} // expected-error {{internal struct 'InternalStructPrivateGA' cannot have private global actor 'PrivateGA'}}
+@InternalGA internal struct InternalStructInternalGA {}
+@PublicGA internal struct InternalStructPublicGA {}
+
+@PrivateGA open class OpenClassPrivateGA {} // expected-error {{open class 'OpenClassPrivateGA' cannot have private global actor 'PrivateGA'}}
+@InternalGA open class OpenClassInternalGA {} // expected-error {{open class 'OpenClassInternalGA' cannot have internal global actor 'InternalGA'}}
+@PublicGA open class OpenClassPublicGA {}


### PR DESCRIPTION
When visiting declarations in the availability and accessibility checkers, check the global actor attribute of the declaration, too. Failing to do so allows module authors to construct broken APIs involving global actors.

Resolves: https://github.com/apple/swift/issues/60420 and rdar://98200658