### PR TITLE
[5.7.0][incrParse] Encode Unicode characters in command output if stdout doesn't support Unicode

### DIFF
--- a/utils/incrparse/test_util.py
+++ b/utils/incrparse/test_util.py
@@ -23,7 +23,12 @@ def escapeCmdArg(arg):
 def run_command(cmd):
     if sys.version_info[0] < 3:
         cmd = list(map(lambda s: s.encode('utf-8'), cmd))
-    print(' '.join([escapeCmdArg(arg) for arg in cmd]))
+    cmdStr = ' '.join([escapeCmdArg(arg) for arg in cmd])
+    if not sys.stdout.encoding.lower().startswith('utf'):
+        # stdout doesn't support Unicode characters, encode them into an escape
+        # sequence
+        cmdStr = cmdStr.encode('utf-8')
+    print(cmdStr)
     if sys.version_info[0] < 3 or platform.system() == 'Windows':
         return subprocess.check_output(cmd, stderr=subprocess.STDOUT)
     else:


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/42525 to `release/5.7.0`.

---

* **Explanation**: Since we switched release/5.7.0 to use Python 3, the incrParse/simple.swift test started failing on Ubuntu 18.04. We need to adjust that test case for Python 3.
* **Scope**: Test-only change
* **Risk**: Zero (only changes a test)
* **Issue**: rdar://98781907
* **Reviewer**: @rintaro on https://github.com/apple/swift/pull/42525