### PR TITLE
[5.7.0] Disable match-module-cache-with-compiler.swift test on Linux

### DIFF
--- a/test/SourceKit/Misc/match-module-cache-with-compiler.swift
+++ b/test/SourceKit/Misc/match-module-cache-with-compiler.swift
@@ -2,6 +2,10 @@
 // NOTE: Do not change this test without a review from @akyrtzi
 
 // REQUIRES: shell
+
+// https://github.com/apple/swift/issues/58786
+// UNSUPPORTED: OS=linux-gnu
+
 // RUN: %empty-directory(%t)
 
 // RUN: COMPILER_ARGS=( \


### PR DESCRIPTION
Cherry-picks https://github.com/apple/swift/pull/58818 to release/5.7.0.

---

* **Explanation**: SourceKit/Misc/match-module-cache-with-compiler.swift started failing since we started supporting Ubuntu 22.04 in release/5.7.0. The test failure is because in CI builds, the `clang` compiler odes not live next to the `swiftc` compiler but in the `llvm-linux-aarch64` build directory (see https://github.com/apple/swift/pull/58852 for more explanation), so it only manifests in CI and should not be an issue in released toolchains. So, just disable the test on release/5.7.
* **Scope**: Just disables a test
* **Issue**: rdar://98818484
* **Risk**: Zero (just disables a test and the failure should not be happening with released toolchains)