### PR TITLE
[build-script] Makes build-script to support None and string object SystemExit.code

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -182,6 +182,28 @@ def tar(source, destination):
     shell.call(args + [source], stderr=shell.DEVNULL)
 
 
+def process_system_exit(e: SystemExit) -> int:
+    # According to Python's documents, `SystemExit.code` is the exit status
+    # or error message that is passed to the constructor. (Defaults to None.)
+    #
+    # This means that `SystemExit.code` is either `None`, an `int` object or
+    # a `string` object of error message.
+    if e.code is None:
+        # Fallback to 1 if there is no error code but a `SystemExit`.
+        return 1
+    try:
+        numeric_code = int(e.code)
+        return numeric_code
+    except ValueError:
+        # Fallback to 1 if it is an error message and print that message.
+        print(e)
+        return 1
+    finally:
+        # Fallback to 1 and do nothing, since there is only ValueError as
+        # expected exception.
+        return 1
+
+
 # -----------------------------------------------------------------------------
 # Argument Validation
 
@@ -719,7 +741,8 @@ if __name__ == "__main__":
     try:
         exit_code = main()
     except SystemExit as e:
-        os._exit(e.code)
+        error_code = process_system_exit(e)
+        os._exit(error_code)
     except KeyboardInterrupt:
         sys.exit(1)
     finally:


### PR DESCRIPTION
Makes build-script to support `None` and `string` object `SystemExit.code` when a `SystemExit` is caught.

A `SystemExit`'s error code may be either `None`, an `int` object or a `string` object. This commit takes all these possibles into consideration and prevents Python from throwing when `SystemExit.code` is not an `int` object.

This resolves issue #60684 : https://github.com/apple/swift/issues/60684
