### PR TITLE
[Concurrency] Handle actor isolation for defers in closures

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9208,14 +9208,20 @@ ActorIsolation swift::getActorIsolation(ValueDecl *value) {
 }
 
 ActorIsolation swift::getActorIsolationOfContext(DeclContext *dc) {
-  if (auto *vd = dyn_cast_or_null<ValueDecl>(dc->getAsDecl()))
+  auto dcToUse = dc;
+  // Defer bodies share actor isolation of their enclosing context.
+  if (auto FD = dyn_cast<FuncDecl>(dcToUse)) {
+    if (FD->isDeferBody()) {
+      dcToUse = FD->getDeclContext();
+    }
+  }
+  if (auto *vd = dyn_cast_or_null<ValueDecl>(dcToUse->getAsDecl()))
     return getActorIsolation(vd);
 
-  if (auto *var = dc->getNonLocalVarDecl())
-     return getActorIsolation(var);
+  if (auto *var = dcToUse->getNonLocalVarDecl())
+    return getActorIsolation(var);
 
-
-  if (auto *closure = dyn_cast<AbstractClosureExpr>(dc)) {
+  if (auto *closure = dyn_cast<AbstractClosureExpr>(dcToUse)) {
     switch (auto isolation = closure->getActorIsolation()) {
     case ClosureActorIsolation::Independent:
       return ActorIsolation::forIndependent()
@@ -9238,14 +9244,14 @@ ActorIsolation swift::getActorIsolationOfContext(DeclContext *dc) {
     }
   }
 
-  if (auto *tld = dyn_cast<TopLevelCodeDecl>(dc)) {
-    if (dc->isAsyncContext() ||
-        dc->getASTContext().LangOpts.StrictConcurrencyLevel
-            >= StrictConcurrency::Complete) {
-      if (Type mainActor = dc->getASTContext().getMainActorType())
+  if (auto *tld = dyn_cast<TopLevelCodeDecl>(dcToUse)) {
+    if (dcToUse->isAsyncContext() ||
+        dcToUse->getASTContext().LangOpts.StrictConcurrencyLevel >=
+            StrictConcurrency::Complete) {
+      if (Type mainActor = dcToUse->getASTContext().getMainActorType())
         return ActorIsolation::forGlobalActor(
             mainActor,
-            /*unsafe=*/!dc->getASTContext().isSwiftVersionAtLeast(6));
+            /*unsafe=*/!dcToUse->getASTContext().isSwiftVersionAtLeast(6));
     }
   }
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1519,6 +1519,7 @@ static FuncDecl *findAnnotatableFunction(DeclContext *dc) {
 }
 
 /// Note when the enclosing context could be put on a global actor.
+// FIXME: This should handle closures too.
 static void noteGlobalActorOnContext(DeclContext *dc, Type globalActor) {
   // If we are in a synchronous function on the global actor,
   // suggest annotating with the global actor itself.
@@ -3798,14 +3799,6 @@ ActorIsolation ActorIsolationRequest::evaluate(
   // If this is a local function, inherit the actor isolation from its
   // context if it global or was captured.
   if (auto func = dyn_cast<FuncDecl>(value)) {
-    // If this is a defer body, inherit unconditionally; we don't
-    // care if the enclosing function captures the isolated parameter.
-    if (func->isDeferBody()) {
-      auto enclosingIsolation =
-                        getActorIsolationOfContext(func->getDeclContext());
-      return inferredIsolation(enclosingIsolation);
-    }
-
     if (func->isLocalCapture() && !func->isSendable()) {
       switch (auto enclosingIsolation =
                   getActorIsolationOfContext(func->getDeclContext())) {


### PR DESCRIPTION
Resolves #58921
Resolves #57673

`defer` bodies share actor isolation with its parent context, so tweak `getActorIsolationOfContext` to handle `defer` (instead of doing it in a ad-hoc way). This method is called from a bunch of places so IMO it's better to handle it there. This also solves the bug where we were not handling `defer` in closures (but it worked fine in functions) 

(edit by @kavon): also resolves rdar://92408225