### PR TITLE
[build-script] Handle SystemExit containing string error messages

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -181,6 +181,19 @@ def tar(source, destination):
     # raise.
     shell.call(args + [source], stderr=shell.DEVNULL)
 
+# \param[in] exception SystemExit object
+#
+# Read the error code/error message stored
+# in SystemExit.code and exit the application.
+def handle_system_exit_exception(exception):
+    sys_err = e.code
+    exit_code = 1
+    if isinstance(sys_err, str):
+        print(sys_err)
+    elif isinstance(sys_err, int):
+        exit_code = sys_err
+    
+    os._exit(exit_code)
 
 # -----------------------------------------------------------------------------
 # Argument Validation
@@ -719,7 +732,7 @@ if __name__ == "__main__":
     try:
         exit_code = main()
     except SystemExit as e:
-        os._exit(e.code)
+        handle_system_exit_exception(e)
     except KeyboardInterrupt:
         sys.exit(1)
     finally:


### PR DESCRIPTION
Sometimes we set `SystemExit.code` to a string. In such cases
the build-script would throw another exception when handling
`SystemExit` because `os._exit` expects an integer input:
```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File
"/Users/ec2-user/jenkins/workspace/oss-lldb-asan-macos/swift/utils/build-script",
line 722, in <module>
    os._exit(e.code)
TypeError: an integer is required (got type str)
```

Looks like we're setting `SystemExit.code` to a string error message
sometimes.
```

This patch handles such cases by checking the type of `SystemExit.code` before
calling `os._exit`
