### PR TITLE
[cxx-interop] NFC: Remove unused source file

### DIFF
--- a/stdlib/public/Cxx/cxxshim/libcxxshim.swift
+++ b/stdlib/public/Cxx/cxxshim/libcxxshim.swift
@@ -1,1 +1,0 @@
-@_exported import CxxShim // Clang module


### PR DESCRIPTION
`libcxxshim.swift` is not referenced from CMakeLists, and is not needed because libcxxshim is a pure C++ module.