### PR TITLE
[test] Fix availability incantation in attr_availability_rename_toplevel

### DIFF
--- a/test/attr/attr_availability_async_rename_toplevel.swift
+++ b/test/attr/attr_availability_async_rename_toplevel.swift
@@ -2,7 +2,7 @@
 
 // RUN: %target-typecheck-verify-swift
 
-if #available(macOS 12.0, *) {
+if #available(SwiftStdlib 5.5, *) {
   @available(*, renamed: "process(data:)")
   func process(data: [Int], completion: @escaping ([Int]) -> Void) { completion(data) }
   // expected-note@+1{{'process(data:)' declared here}}


### PR DESCRIPTION
This fixes a recently introduced iOS simulator failure that is blocking PR testing.

rdar://98991162