### PR TITLE
[Dependency Scan] Remove redundant recombination of arguments in 'initCompilerInstanceForScan' into a string, before being re-parsed.

### DIFF
--- a/lib/DependencyScan/DependencyScanningTool.cpp
+++ b/lib/DependencyScan/DependencyScanningTool.cpp
@@ -160,13 +160,13 @@ DependencyScanningTool::initScannerForAction(
 
 llvm::ErrorOr<std::unique_ptr<CompilerInstance>>
 DependencyScanningTool::initCompilerInstanceForScan(
-    ArrayRef<const char *> Command) {
+    ArrayRef<const char *> CommandArgs) {
   // State unique to an individual scan
   auto Instance = std::make_unique<CompilerInstance>();
   Instance->addDiagnosticConsumer(&PDC);
 
   // Basic error checking on the arguments
-  if (Command.empty()) {
+  if (CommandArgs.empty()) {
     Instance->getDiags().diagnose(SourceLoc(), diag::error_no_frontend_args);
     return std::make_error_code(std::errc::invalid_argument);
   }
@@ -180,16 +180,7 @@ DependencyScanningTool::initCompilerInstanceForScan(
   // We must do so because LLVM options parsing is done using a managed
   // static `GlobalParser`.
   llvm::cl::ResetAllOptionOccurrences();
-
-  // Parse arguments.
-  std::string CommandString;
-  for (const auto *c : Command) {
-    CommandString.append(c);
-    CommandString.append(" ");
-  }
-  SmallVector<const char *, 4> Args;
-  llvm::cl::TokenizeGNUCommandLine(CommandString, Saver, Args);
-  if (Invocation.parseArgs(Args, Instance->getDiags())) {
+  if (Invocation.parseArgs(CommandArgs, Instance->getDiags())) {
     return std::make_error_code(std::errc::invalid_argument);
   }
 

--- a/unittests/DependencyScan/ModuleDeps.cpp
+++ b/unittests/DependencyScan/ModuleDeps.cpp
@@ -157,11 +157,11 @@ export *\n\
   llvm::sys::path::append(StdLibDir, getPlatformNameForTriple(Target));
 
   std::vector<std::string> CommandStrArr = {
-    std::string("'") + TestPathStr + std::string("'"),
-    std::string("-I ") + std::string("'") + SwiftDirPath + std::string("'"),
-    std::string("-I ") + std::string("'") + CHeadersDirPath + std::string("'"),
-    std::string("-I ") + std::string("'") + StdLibDir.str().str() + std::string("'"),
-    std::string("-I ") + std::string("'") + ShimsLibDir.str().str() + std::string("'")
+    TestPathStr,
+    std::string("-I ") + SwiftDirPath,
+    std::string("-I ") + CHeadersDirPath,
+    std::string("-I ") + StdLibDir.str().str(),
+    std::string("-I ") + ShimsLibDir.str().str(),
   };
 
   // On Windows we need to add an extra escape for path separator characters because otherwise


### PR DESCRIPTION
This does not seem to serve a purpose other than corrupting arguments with whitespaces - they get merged into one large string where the whitespace boundary between arguments and whitespaces within arguments are blurred.

Part of rdar://98985453