### PR TITLE
Ban constructing normal conformances where the conforming type is a protocol

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2314,10 +2314,12 @@ void PrintAST::printMembersOfDecl(Decl *D, bool needComma,
         AddMembers(Ext);
     }
     if (Options.PrintExtensionFromConformingProtocols) {
-      for (auto Conf : NTD->getAllConformances()) {
-        for (auto Ext : Conf->getProtocol()->getExtensions()) {
-          if (Options.printExtensionContentAsMembers(Ext))
-            AddMembers(Ext);
+      if (!isa<ProtocolDecl>(NTD)) {
+        for (auto Conf : NTD->getAllConformances()) {
+          for (auto Ext : Conf->getProtocol()->getExtensions()) {
+            if (Options.printExtensionContentAsMembers(Ext))
+              AddMembers(Ext);
+          }
         }
       }
     }

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -875,7 +875,7 @@ ConformanceLookupTable::getConformance(NominalTypeDecl *nominal,
         ctx.getInheritedConformance(type, inheritedConformance.getConcrete());
   } else {
     // Create or find the normal conformance.
-    Type conformingType = conformingDC->getDeclaredInterfaceType();
+    Type conformingType = conformingDC->getSelfInterfaceType();
     SourceLoc conformanceLoc
       = conformingNominal == conformingDC
           ? conformingNominal->getLoc()

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -620,20 +620,14 @@ ConformanceLookupTable::Ordering ConformanceLookupTable::compareConformances(
     // If the explicit protocol for the left-hand side is implied by
     // the explicit protocol for the right-hand side, the left-hand
     // side supersedes the right-hand side.
-    for (auto rhsProtocol : rhsExplicitProtocol->getAllProtocols()) {
-      if (rhsProtocol == lhsExplicitProtocol) {
-        return Ordering::Before;
-      }
-    }
+    if (rhsExplicitProtocol->inheritsFrom(lhsExplicitProtocol))
+      return Ordering::Before;
 
     // If the explicit protocol for the right-hand side is implied by
     // the explicit protocol for the left-hand side, the right-hand
     // side supersedes the left-hand side.
-    for (auto lhsProtocol : lhsExplicitProtocol->getAllProtocols()) {
-      if (lhsProtocol == rhsExplicitProtocol) {
-        return Ordering::After;
-      }
-    }
+    if (lhsExplicitProtocol->inheritsFrom(rhsExplicitProtocol))
+      return Ordering::After;
   }
 
   // Prefer the least conditional implier, which we approximate by seeing if one

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -874,13 +874,18 @@ ConformanceLookupTable::getConformance(NominalTypeDecl *nominal,
     entry->Conformance =
         ctx.getInheritedConformance(type, inheritedConformance.getConcrete());
   } else {
-    // Create or find the normal conformance.
+    // Protocols don't have conformance lookup tables. Self-conformance is
+    // handled directly in lookupConformance().
+    assert(!isa<ProtocolDecl>(conformingNominal));
+    assert(!isa<ProtocolDecl>(conformingDC->getSelfNominalTypeDecl()));
     Type conformingType = conformingDC->getSelfInterfaceType();
+
     SourceLoc conformanceLoc
       = conformingNominal == conformingDC
           ? conformingNominal->getLoc()
           : cast<ExtensionDecl>(conformingDC)->getLoc();
 
+    // Create or find the normal conformance.
     auto normalConf =
         ctx.getConformance(conformingType, protocol, conformanceLoc,
                            conformingDC, ProtocolConformanceState::Incomplete,

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -3121,10 +3121,17 @@ static bool checkForDynamicAttribute(Evaluator &eval, NominalTypeDecl *decl) {
     return evaluateOrDefault(eval, Req{decl}, false);
   };
 
-  // Check the protocols the type conforms to.
-  for (auto *proto : decl->getAllProtocols()) {
-    if (hasAttribute(proto))
-      return true;
+  if (auto *proto = dyn_cast<ProtocolDecl>(decl)) {
+    // Check inherited protocols of a protocol.
+    for (auto *otherProto : proto->getInheritedProtocols())
+      if (hasAttribute(otherProto))
+        return true;
+  } else {
+    // Check the protocols the type conforms to.
+    for (auto *otherProto : decl->getAllProtocols()) {
+      if (hasAttribute(otherProto))
+        return true;
+    }
   }
 
   // Check the superclass if present.

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -1224,6 +1224,9 @@ ProtocolConformance::getInheritedConformance(ProtocolDecl *protocol) const {
 
 #pragma mark Protocol conformance lookup
 void NominalTypeDecl::prepareConformanceTable() const {
+  assert(!isa<ProtocolDecl>(this) &&
+         "Protocols don't have a conformance table");
+
   if (ConformanceTable)
     return;
 
@@ -1292,6 +1295,10 @@ void NominalTypeDecl::prepareConformanceTable() const {
 bool NominalTypeDecl::lookupConformance(
        ProtocolDecl *protocol,
        SmallVectorImpl<ProtocolConformance *> &conformances) const {
+  assert(!isa<ProtocolDecl>(this) &&
+         "Self-conformances are only found by the higher-level "
+         "ModuleDecl::lookupConformance() entry point");
+
   prepareConformanceTable();
   return ConformanceTable->lookupConformance(
            const_cast<NominalTypeDecl *>(this),
@@ -1301,6 +1308,10 @@ bool NominalTypeDecl::lookupConformance(
 
 SmallVector<ProtocolDecl *, 2>
 NominalTypeDecl::getAllProtocols(bool sorted) const {
+  assert(!isa<ProtocolDecl>(this) &&
+         "For inherited protocols, use ProtocolDecl::inheritsFrom() or "
+         "ProtocolDecl::getInheritedProtocols()");
+
   prepareConformanceTable();
   SmallVector<ProtocolDecl *, 2> result;
   ConformanceTable->getAllProtocols(const_cast<NominalTypeDecl *>(this), result,

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -6598,8 +6598,8 @@ void SwiftDeclConverter::importObjCProtocols(
     SmallVectorImpl<InheritedEntry> &inheritedTypes) {
   SmallVector<ProtocolDecl *, 4> protocols;
   llvm::SmallPtrSet<ProtocolDecl *, 4> knownProtocols;
-  if (auto nominal = dyn_cast<NominalTypeDecl>(decl)) {
-    nominal->getImplicitProtocols(protocols);
+  if (auto classDecl = dyn_cast<ClassDecl>(decl)) {
+    classDecl->getImplicitProtocols(protocols);
     knownProtocols.insert(protocols.begin(), protocols.end());
   }
 

--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -26,24 +26,27 @@
 #include <sstream>
 #include <string>
 
+using namespace swift;
+
 namespace {
 /// A helper class to collect all nominal type declarations that conform to
 /// specific protocols provided as input.
-class NominalTypeConformanceCollector : public swift::ASTWalker {
+class NominalTypeConformanceCollector : public ASTWalker {
   const std::unordered_set<std::string> &Protocols;
-  std::vector<swift::NominalTypeDecl *> &ConformanceTypeDecls;
+  std::vector<NominalTypeDecl *> &ConformanceTypeDecls;
 
 public:
   NominalTypeConformanceCollector(
       const std::unordered_set<std::string> &Protocols,
-      std::vector<swift::NominalTypeDecl *> &ConformanceDecls)
+      std::vector<NominalTypeDecl *> &ConformanceDecls)
       : Protocols(Protocols), ConformanceTypeDecls(ConformanceDecls) {}
 
-  bool walkToDeclPre(swift::Decl *D) override {
-    if (auto *NTD = llvm::dyn_cast<swift::NominalTypeDecl>(D))
-      for (auto &Protocol : NTD->getAllProtocols())
-        if (Protocols.count(Protocol->getName().str().str()) != 0)
-          ConformanceTypeDecls.push_back(NTD);
+  bool walkToDeclPre(Decl *D) override {
+    if (auto *NTD = llvm::dyn_cast<NominalTypeDecl>(D))
+      if (!isa<ProtocolDecl>(NTD))
+        for (auto &Protocol : NTD->getAllProtocols())
+          if (Protocols.count(Protocol->getName().str().str()) != 0)
+            ConformanceTypeDecls.push_back(NTD);
     return true;
   }
 };

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -2483,7 +2483,7 @@ void CompletionLookup::addTypeRelationFromProtocol(
 
   // The literal can produce any type that conforms to its ExpressibleBy
   // protocol. Figure out as which type we want to show it in code completion.
-  auto *P = Ctx.getProtocol(protocolForLiteralKind(kind));
+  auto *PD = Ctx.getProtocol(protocolForLiteralKind(kind));
   for (auto T : expectedTypeContext.getPossibleTypes()) {
     if (!T)
       continue;
@@ -2497,9 +2497,8 @@ void CompletionLookup::addTypeRelationFromProtocol(
     }
 
     // Check for conformance to the literal protocol.
-    if (auto *NTD = T->getAnyNominal()) {
-      SmallVector<ProtocolConformance *, 2> conformances;
-      if (NTD->lookupConformance(P, conformances)) {
+    if (T->getAnyNominal()) {
+      if (CurrModule->lookupConformance(T, PD)) {
         literalType = T;
         break;
       }

--- a/lib/IDE/CompletionOverrideLookup.cpp
+++ b/lib/IDE/CompletionOverrideLookup.cpp
@@ -411,6 +411,9 @@ void CompletionOverrideLookup::addAssociatedTypes(NominalTypeDecl *NTD) {
        hasOverride || hasOverridabilityModifier || hasStaticOrClass))
     return;
 
+  if (isa<ProtocolDecl>(NTD))
+    return;
+
   for (auto Conformance : NTD->getAllConformances()) {
     auto Proto = Conformance->getProtocol();
     if (!Proto->isAccessibleFrom(CurrDeclContext))

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1742,6 +1742,9 @@ public:
     if (nominal->hasClangNode())
       return nullptr;
 
+    if (isa<ProtocolDecl>(nominal))
+      return nullptr;
+
     auto &ctx = nominal->getASTContext();
 
     // Dig out the ObjectiveCBridgeable protocol.

--- a/lib/SILOptimizer/Analysis/ProtocolConformanceAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ProtocolConformanceAnalysis.cpp
@@ -37,10 +37,12 @@ public:
   bool walkToDeclPre(Decl *D) override {
     /// (1) Walk over all NominalTypeDecls to determine conformances.
     if (auto *NTD = dyn_cast<NominalTypeDecl>(D)) {
-      auto Protocols = NTD->getAllProtocols();
-      for (auto &Protocol : Protocols) {
-        if (Protocol->getEffectiveAccess() <= AccessLevel::Internal) {
-          ProtocolConformanceCache[Protocol].push_back(NTD);
+      if (!isa<ProtocolDecl>(NTD)) {
+        auto Protocols = NTD->getAllProtocols();
+        for (auto &Protocol : Protocols) {
+          if (Protocol->getEffectiveAccess() <= AccessLevel::Internal) {
+            ProtocolConformanceCache[Protocol].push_back(NTD);
+          }
         }
       }
     }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -8093,16 +8093,12 @@ allFromConditionalConformances(DeclContext *DC, Type baseTy,
     }
 
     if (auto *protocol = candidateDC->getSelfProtocolDecl()) {
-      SmallVector<ProtocolConformance *, 4> conformances;
-      if (!NTD->lookupConformance(protocol, conformances))
+      auto conformance = DC->getParentModule()->lookupConformance(
+          baseTy, protocol);
+      if (!conformance.isConcrete())
         return false;
 
-      // This is opportunistic, there should be a way to narrow the
-      // list down to a particular declaration member comes from.
-      return llvm::any_of(
-          conformances, [](const ProtocolConformance *conformance) {
-            return !conformance->getConditionalRequirements().empty();
-          });
+      return !conformance.getConcrete()->getConditionalRequirements().empty();
     }
 
     return false;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -6947,15 +6947,10 @@ bool TypeVarBindingProducer::requiresOptionalAdjustment(
     // produce an optional of that type as a potential binding. We
     // overwrite the binding in place because the non-optional type
     // will fail to type-check against the nil-literal conformance.
-    bool conformsToExprByNilLiteral = false;
-    if (auto *nominalBindingDecl = type->getAnyNominal()) {
-      SmallVector<ProtocolConformance *, 2> conformances;
-      conformsToExprByNilLiteral = nominalBindingDecl->lookupConformance(
-          CS.getASTContext().getProtocol(
-              KnownProtocolKind::ExpressibleByNilLiteral),
-          conformances);
-    }
-    return !conformsToExprByNilLiteral;
+    auto *proto = CS.getASTContext().getProtocol(
+         KnownProtocolKind::ExpressibleByNilLiteral);
+
+    return !proto->getParentModule()->lookupConformance(type, proto);
   } else if (binding.isDefaultableBinding() && binding.BindingType->isAny()) {
     return true;
   }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3306,14 +3306,22 @@ void AttributeChecker::visitImplementsAttr(ImplementsAttr *attr) {
     // Check that the decl we're decorating is a member of a type that actually
     // conforms to the specified protocol.
     NominalTypeDecl *NTD = DC->getSelfNominalTypeDecl();
-    SmallVector<ProtocolConformance *, 2> conformances;
-    if (!NTD->lookupConformance(PD, conformances)) {
-      diagnose(attr->getLocation(),
-               diag::implements_attr_protocol_not_conformed_to,
-               NTD->getName(), PD->getName())
-        .highlight(attr->getProtocolTypeRepr()->getSourceRange());
+    if (auto *OtherPD = dyn_cast<ProtocolDecl>(NTD)) {
+      if (!OtherPD->inheritsFrom(PD)) {
+        diagnose(attr->getLocation(),
+                 diag::implements_attr_protocol_not_conformed_to,
+                 NTD->getName(), PD->getName())
+          .highlight(attr->getProtocolTypeRepr()->getSourceRange());
+      }
+    } else {
+      SmallVector<ProtocolConformance *, 2> conformances;
+      if (!NTD->lookupConformance(PD, conformances)) {
+        diagnose(attr->getLocation(),
+                 diag::implements_attr_protocol_not_conformed_to,
+                 NTD->getName(), PD->getName())
+          .highlight(attr->getProtocolTypeRepr()->getSourceRange());
+      }
     }
-
   } else {
     diagnose(attr->getLocation(), diag::implements_attr_non_protocol_type)
       .highlight(attr->getProtocolTypeRepr()->getSourceRange());

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -6762,7 +6762,9 @@ swift::findWitnessedObjCRequirements(const ValueDecl *witness,
 
   auto dc = witness->getDeclContext();
   auto nominal = dc->getSelfNominalTypeDecl();
+
   if (!nominal) return result;
+  if (isa<ProtocolDecl>(nominal)) return result;
 
   DeclName name = witness->getName();
   Optional<AccessorKind> accessorKind;

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -229,8 +229,7 @@ static void tryDiagnoseUnnecessaryCastOverOptionSet(ASTContext &Ctx,
   auto optionSetType = dyn_cast_or_null<ProtocolDecl>(Ctx.getOptionSetDecl());
   if (!optionSetType)
     return;
-  SmallVector<ProtocolConformance *, 4> conformances;
-  if (!(optionSetType && NTD->lookupConformance(optionSetType, conformances)))
+  if (!module->lookupConformance(ResultType, optionSetType))
     return;
 
   auto *CE = dyn_cast<CallExpr>(E);

--- a/test/api-digester/Outputs/cake-abi.json
+++ b/test/api-digester/Outputs/cake-abi.json
@@ -102,17 +102,17 @@
         "conformances": [
           {
             "kind": "Conformance",
-            "name": "P2",
-            "printedName": "P2",
-            "usr": "s:4cake2P2P",
-            "mangledName": "$s4cake2P2P"
-          },
-          {
-            "kind": "Conformance",
             "name": "P1",
             "printedName": "P1",
             "usr": "s:4cake2P1P",
             "mangledName": "$s4cake2P1P"
+          },
+          {
+            "kind": "Conformance",
+            "name": "P2",
+            "printedName": "P2",
+            "usr": "s:4cake2P2P",
+            "mangledName": "$s4cake2P2P"
           }
         ]
       },

--- a/test/api-digester/Outputs/cake.json
+++ b/test/api-digester/Outputs/cake.json
@@ -100,17 +100,17 @@
         "conformances": [
           {
             "kind": "Conformance",
-            "name": "P2",
-            "printedName": "P2",
-            "usr": "s:4cake2P2P",
-            "mangledName": "$s4cake2P2P"
-          },
-          {
-            "kind": "Conformance",
             "name": "P1",
             "printedName": "P1",
             "usr": "s:4cake2P1P",
             "mangledName": "$s4cake2P1P"
+          },
+          {
+            "kind": "Conformance",
+            "name": "P2",
+            "printedName": "P2",
+            "usr": "s:4cake2P2P",
+            "mangledName": "$s4cake2P2P"
           }
         ]
       },


### PR DESCRIPTION
While ModuleDecl::lookupConformance() never returned a NormalProtocolConformance when given a protocol type, the conformance lookup table operations were more than happy to construct one directly if called on a protocol as the nominal type declaration. This could even trigger conformance checking, which would fail in odd ways when trying to derive type witnesses for example.

This represents wasted work and potential crashes from constructing a representation of something we never intended to exist.

One consequence is that the API digester and symbol graph model protocol inheritance as "conformances" in their schemas, which feels wrong, but I maintained the exact behavior by adding a bit of extra boilerplate at various call sites.