### PR TITLE
Allow declaration recovery to consume attributes.

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -695,7 +695,7 @@ public:
                      tok::pound_else, tok::pound_elseif,
                      tok::code_complete) &&
            !isStartOfStmt() &&
-           !isStartOfSwiftDecl(/*allowPoundIfAttributes=*/false)) {
+           !isStartOfSwiftDecl(/*allowPoundIfAttributes=*/true)) {
       skipSingle();
     }
   }

--- a/validation-test/compiler_crashers_2_fixed/0213-issue60702.swift
+++ b/validation-test/compiler_crashers_2_fixed/0213-issue60702.swift
@@ -1,0 +1,5 @@
+// RUN: not %target-swift-frontend -parse %s
+@
+#if true
+    print("x")
+#endif


### PR DESCRIPTION
Fixes https://github.com/apple/swift/issues/60702 / rdar://98967894
