### PR TITLE
[cxx-interop] Emit `-enable-experimental-cxx-interop` flag into the module interface

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -614,7 +614,7 @@ def enable_experimental_concise_pound_file : Flag<["-"],
 
 def enable_experimental_cxx_interop :
   Flag<["-"], "enable-experimental-cxx-interop">,
-  Flags<[FrontendOption, HelpHidden]>,
+  Flags<[FrontendOption, HelpHidden, ModuleInterfaceOption]>,
   HelpText<"Enable experimental C++ interop code generation and config directives">;
 
 def experimental_cxx_stdlib :

--- a/test/Interop/Cxx/modules/Inputs/module.modulemap
+++ b/test/Interop/Cxx/modules/Inputs/module.modulemap
@@ -1,4 +1,4 @@
-module Namespace {
+module Namespaces {
   header "namespace.h"
   requires cplusplus
 }

--- a/test/Interop/Cxx/modules/Inputs/namespace-extension-lib.swift
+++ b/test/Interop/Cxx/modules/Inputs/namespace-extension-lib.swift
@@ -1,4 +1,4 @@
-import Namespace
+import Namespaces
 
 extension Namespace.Parent {
   public static func test() -> Int { 42 }

--- a/test/Interop/Cxx/modules/emit-module-interface.swift
+++ b/test/Interop/Cxx/modules/emit-module-interface.swift
@@ -1,0 +1,9 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-emit-module-interface(%t/UsesCxxStruct.swiftinterface) %s -I %S/Inputs -enable-library-evolution -swift-version 5 -enable-experimental-cxx-interop %S/Inputs/namespace-extension-lib.swift
+// RUN: %target-swift-typecheck-module-from-interface(%t/UsesCxxStruct.swiftinterface) -I %S/Inputs
+// RUN: %FileCheck --input-file=%t/UsesCxxStruct.swiftinterface %s
+// CHECK: -enable-experimental-cxx-interop
+
+import Namespaces
+
+var x: Namespace.Parent? = nil

--- a/test/Interop/Cxx/modules/use-namespace-extension-lib.swift
+++ b/test/Interop/Cxx/modules/use-namespace-extension-lib.swift
@@ -9,7 +9,7 @@
 // XFAIL: OS=windows-msvc
 
 import StdlibUnittest
-import Namespace
+import Namespaces
 import NamespaceExtensionLib
 
 var NamespacesTestSuite = TestSuite("Extension in library on namespace")


### PR DESCRIPTION
This makes sure that when Swift is generating a `.swiftinterface` file for a Swift module with a dependency on C++ module, `-enable-experimental-cxx-interop` is emitted under `// swift-module-flags:`.

The module interface might refer to C++ symbols which are not available in Swift without C++ interop enabled. This caused a build error for Swift LLVM bindings during `verify-module-interface` stage: Swift tried to import the module interface and couldn't find C++ stdlib headers because C++ interop was disabled.
```
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "Support/ConvertUTF.h"
        ^
/Volumes/Projects/swift/llvm-project/llvm/include/llvm/Support/ConvertUTF.h:92:10: error: 'cstddef' file not found
#include <cstddef>
         ^
Sources/LLVM/LLVM_Utils.swiftinterface:4:19: error: could not build Objective-C module 'LLVM_Utils'
@_exported import LLVM_Utils
                  ^
Sources/LLVM/LLVM_Utils.swiftinterface:1:1: error: failed to verify module interface of 'LLVM_Utils' due to the errors above; the textual interface may be broken by project issues or a compiler bug
// swift-interface-format-version: 1.0
^
<unknown>:0: error: verify-module-interface command failed with exit code 1 (use -v to see invocation)
```