### PR TITLE
[Sema] property wrapper missing wrappedValue check should add fixit to new line

### DIFF
--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -58,7 +58,7 @@ static VarDecl *findValueProperty(ASTContext &ctx, NominalTypeDecl *nominal,
       auto fixitLocation = nominal->getBraces().Start;
       nominal->diagnose(diag::property_wrapper_no_value_property,
                         nominal->getDeclaredType(), name)
-        .fixItInsertAfter(fixitLocation, fixIt);
+        .fixItInsertAfter(fixitLocation, "\n"+fixIt);
     }
 
     return nullptr;

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -58,13 +58,13 @@ struct WrapperAcceptingAutoclosure<T> {
 
 @propertyWrapper
 struct MissingValue<T> { }
-// expected-error@-1{{property wrapper type 'MissingValue' does not contain a non-static property named 'wrappedValue'}} {{educational-notes=property-wrapper-requirements}}{{25-25=var wrappedValue: <#Value#>}}
+// expected-error@-1{{property wrapper type 'MissingValue' does not contain a non-static property named 'wrappedValue'}} {{educational-notes=property-wrapper-requirements}}{{25-25=\nvar wrappedValue: <#Value#>}}
 
 @propertyWrapper
 struct StaticValue {
   static var wrappedValue: Int = 17
 }
-// expected-error@-3{{property wrapper type 'StaticValue' does not contain a non-static property named 'wrappedValue'}}{{21-21=var wrappedValue: <#Value#>}}
+// expected-error@-3{{property wrapper type 'StaticValue' does not contain a non-static property named 'wrappedValue'}}{{21-21=\nvar wrappedValue: <#Value#>}}
 
 
 // expected-error@+1{{'@propertyWrapper' attribute cannot be applied to this declaration}}


### PR DESCRIPTION
Instead of adding the fixit directly after the curly brace, it should be added to a new line 

@propertyWrapper
struct Wrapped<Gift> { 
    var wrappedValue: Value <-- add here instead of the line above 
}

rdar://95208456