### PR TITLE
Link all compatibility libraries when cross compiling and bootstrapping

### DIFF
--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -301,12 +301,13 @@ else()
       endif()
     endif()
     if(SWIFT_HOST_VARIANT_SDK IN_LIST SWIFT_DARWIN_PLATFORMS AND SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT)
-      set(platform ${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR})
-      set(compatibility_libs
-          "swiftCompatibility50-${platform}"
-          "swiftCompatibility51-${platform}"
-          "swiftCompatibilityDynamicReplacements-${platform}")
-
+      # We cannot specify directly HostCompatibilityLibs
+      # because ultimately is used to specify a dependency for a
+      # custom target and, unlike `target_link_libraries`, such dependency
+      # would be lost at the generation of the build system.
+      get_property(compatibility_libs
+        TARGET HostCompatibilityLibs
+        PROPERTY INTERFACE_LINK_LIBRARIES)
       list(APPEND b0_deps ${compatibility_libs})
       list(APPEND b1_deps ${compatibility_libs})
     endif()

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -465,9 +465,7 @@ function(_add_swift_runtime_link_flags target relpath_to_lib_dir bootstrapping)
       # the stdlib is not picked up from there, but from the SDK.
       # This requires to explicitly add all the needed compatibility libraries. We
       # can take them from the current build.
-      set(vsuffix "-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH}")
-      set(conctarget "swiftCompatibilityConcurrency${vsuffix}")
-      target_link_libraries(${target} PUBLIC ${conctarget})
+      target_link_libraries(${target} PUBLIC HostCompatibilityLibs)
 
       # Add the SDK directory for the host platform.
       target_link_directories(${target} PRIVATE "${sdk_dir}")

--- a/stdlib/toolchain/CMakeLists.txt
+++ b/stdlib/toolchain/CMakeLists.txt
@@ -53,4 +53,16 @@ if(SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT)
   add_subdirectory(CompatibilityDynamicReplacements)
   add_subdirectory(CompatibilityConcurrency)
   add_subdirectory(CompatibilityThreading)
+
+  # This is a convenience target to have the list
+  # of all the compatibility libraries needed to build
+  # host tools in a single place
+  add_library(HostCompatibilityLibs INTERFACE)
+  set(vsuffix "-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH}")
+  target_link_libraries(HostCompatibilityLibs INTERFACE
+    swiftCompatibilityConcurrency${vsuffix}
+    swiftCompatibilityDynamicReplacements${vsuffix}
+    swiftCompatibility50${vsuffix}
+    swiftCompatibility51${vsuffix})
+  set_property(GLOBAL APPEND PROPERTY SWIFT_BUILDTREE_EXPORTS HostCompatibilityLibs)
 endif()

--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -51,9 +51,7 @@ function(add_sourcekitd_swifrt_linking target path HAS_SWIFT_MODULES)
         # the stdlib is not picked up from there, but from the SDK.
         # This requires to explicitly add all the needed compatibility libraries. We
         # can take them from the current build.
-        set(vsuffix "-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH}")
-        set(conctarget "swiftCompatibilityConcurrency${vsuffix}")
-        target_link_libraries(${target} PUBLIC ${conctarget})
+        target_link_libraries(${target} PUBLIC HostCompatibilityLibs)
 
         # Add the SDK directory for the host platform.
         target_link_directories(${target} PRIVATE "${sdk_dir}")


### PR DESCRIPTION
Refactor the logic so to have a single target to reference the
compatibility libraries for the host, and use that when needed.

The main driver for this change is supporting the cross-compilation of
x86-64 on Apple Silicon.

Supports rdar://90307965