### PR TITLE
[5.7][CSSimplify] Failure to bind type variable to invalid dependent membe…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3856,6 +3856,13 @@ ConstraintSystem::matchTypesBindTypeVar(
       // let's ignore this mismatch and mark affected type variable as a hole
       // because something else has to be fixed already for this to happen.
       if (type->is<DependentMemberType>() && !type->hasTypeVariable()) {
+        // Since the binding couldn't be performed, the type variable is a
+        // hole regardless whether it would be bound later to some other
+        // type or not. If this is not reflected in constraint system
+        // it would let the solver to form a _valid_ solution as if the
+        // constraint between the type variable and the unresolved dependent
+        // member type never existed.
+        increaseScore(SK_Hole);
         recordPotentialHole(typeVar);
         return getTypeMatchSuccess();
       }

--- a/validation-test/Sema/type_checker_crashers_fixed/issue60649.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/issue60649.swift
@@ -1,0 +1,26 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P {}
+
+protocol Key {
+  associatedtype A: P
+  // expected-note@-1 {{unable to infer associated type 'A' for protocol 'Key'}}
+  static var value: A { get }
+}
+
+struct Values {
+  subscript<K: Key>(type: K.Type) -> K.A {
+    fatalError()
+  }
+}
+
+enum MyKey: Key { // expected-error {{type 'MyKey' does not conform to protocol 'Key'}}
+  static let value = 1
+  // expected-note@-1 {{candidate would match and infer 'A' = 'Int' if 'Int' conformed to 'P'}}
+}
+
+extension Values {
+  var myValue: Int {
+    get { self[MyKey.self] }
+  }
+}


### PR DESCRIPTION
…r makes it a hole

Cherry-pick of https://github.com/apple/swift/pull/60654

---

If the failure is not reflected in constraint system it would let
the solver to form a _valid_ solution as if the constraint between
the type variable and the unresolved dependent member type never
existed.

Resolves: https://github.com/apple/swift/issues/60649
(cherry picked from commit 4d039686fd6f8d28b2a32d164f7b61cac8e3fd36)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
