### PR TITLE
[test] IRGen/opaque_result_alwaysInlineIntoClient: disable on non-local test configs

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1953,6 +1953,9 @@ def configure_remote_run():
     config.target_swift_reflection_test = os.path.join(
         remote_tmp_dir, 'bin', swift_reflection_test_name)
     config.available_features.add('remote_run')
+    # Interpreter runs require local execution.
+    config.available_features.discard('swift_interpreter')
+
 
 config.substitutions.append(("%target-sdk-name", config.target_sdk_name))
 


### PR DESCRIPTION
This silences a CI blocker issue.

rdar://97995151