### PR TITLE
[SIL] Fix tuple keypath verifier

### DIFF
--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -418,19 +418,19 @@ void verifyKeyPathComponent(SILModule &M,
     break;
   }
   case KeyPathPatternComponent::Kind::TupleElement: {
-    require(loweredBaseTy.is<TupleType>(),
+    require(baseTy->is<TupleType>(),
             "invalid baseTy, should have been a TupleType");
       
-    auto tupleTy = loweredBaseTy.castTo<TupleType>();
+    auto tupleTy = baseTy->castTo<TupleType>();
     auto eltIdx = component.getTupleIndex();
       
     require(eltIdx < tupleTy->getNumElements(),
             "invalid element index, greater than # of tuple elements");
 
-    auto eltTy = tupleTy.getElementType(eltIdx)
-      .getReferenceStorageReferent();
+    auto eltTy = tupleTy->getElementType(eltIdx)
+      ->getReferenceStorageReferent();
     
-    require(eltTy == componentTy,
+    require(eltTy->isEqual(componentTy),
             "tuple element type should match the type of the component");
 
     break;

--- a/test/SILGen/keypaths.swift
+++ b/test/SILGen/keypaths.swift
@@ -572,6 +572,14 @@ func tuples(_: T) {
   let _: ReferenceWritableKeyPath<T, Int> = \T.c.x.x
   // CHECK: keypath $KeyPath<T, String>, (root $T; stored_property #T.c : $(x: C<Int>, y: C<String>); tuple_element #0 : $C<Int>; stored_property #C.y : $String)
   let _: KeyPath<T, String> = \T.c.x.y
+
+  typealias Thing = (type: Any.Type, fn: () -> ())
+
+  // CHECK: keypath $WritableKeyPath<(type: any Any.Type, fn: () -> ()), any Any.Type>, (root $(type: any Any.Type, fn: () -> ()); tuple_element #0 : $any Any.Type)
+  let _: WritableKeyPath<Thing, Any.Type> = \Thing.type
+
+  // CHECK: keypath $WritableKeyPath<(type: any Any.Type, fn: () -> ()), () -> ()>, (root $(type: any Any.Type, fn: () -> ()); tuple_element #1 : $() -> ())
+  let _: WritableKeyPath<Thing, () -> ()> = \Thing.fn
 }
 
 // CHECK-LABEL: sil hidden [ossa] @{{.*}}tuples_generic


### PR DESCRIPTION
Don't compare a lowered type to an unlowered type because we run into the situation where a `@thick Any.Type != Any.Type` causing something like the following to crash:

```swift
typealias Hello = (a: Int, b: Any.Type)

let x = \Hello.b
```