### PR TITLE
Sema: Fix existential opening for arguments to self.init/super.init delegation

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -726,6 +726,8 @@ namespace {
         return inout->getSubExpr();
       } else if (auto force = dyn_cast<ForceValueExpr>(expr)) {
         return force->getSubExpr();
+      } else if (auto rebind = dyn_cast<RebindSelfInConstructorExpr>(expr)) {
+        return rebind->getSubExpr();
       } else {
         return nullptr;
       }
@@ -816,11 +818,6 @@ namespace {
       // we can close this existential, and record it.
       unsigned maxArgCount = member->getNumCurryLevels();
       unsigned depth = ExprStack.size() - getArgCount(maxArgCount);
-
-      // Invalid case -- direct call of a metatype. Has one less argument
-      // application because there's no ".init".
-      if (isa<ApplyExpr>(ExprStack.back()))
-        depth++;
 
       // Create the opaque opened value. If we started with a
       // metatype, it's a metatype.
@@ -3757,7 +3754,12 @@ namespace {
         expr->setSubExpr(newSubExpr);
       }
 
-      return expr;
+      // We might have opened existentials in the argument list of the
+      // constructor call.
+      Expr *result = expr;
+      closeExistentials(result, cs.getConstraintLocator(expr));
+
+      return result;
     }
 
     Expr *visitIfExpr(IfExpr *expr) {

--- a/test/SILGen/opened_existential_in_init_delegation.swift
+++ b/test/SILGen/opened_existential_in_init_delegation.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+protocol P {}
+class C {
+  init(x: some P) {}
+
+  convenience init(y: any P) { self.init(x: y) }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s37opened_existential_in_init_delegation1CC1yAcA1P_p_tcfC : $@convention(method) (@in any P, @thick C.Type) -> @owned C {
+// CHECK: [[OPENED:%.*]] = open_existential_addr immutable_access %0 : $*any P to $*@opened("{{.*}}", any P) Self
+// CHECK: [[COPIED:%.*]] = alloc_stack $@opened("{{.*}}", any P) Self
+// CHECK: copy_addr [[OPENED]] to [initialization] [[COPIED]] : $*@opened("{{.*}}", any P) Self
+// CHECK: [[FN:%.*]] = class_method %1 : $@thick C.Type, #C.init!allocator :  (C.Type) -> (some P) -> C, $@convention(method) <τ_0_0 where τ_0_0 : P> (@in τ_0_0, @thick C.Type) -> @owned C
+// CHECK: apply [[FN]]<@opened("{{.*}}", any P) Self>([[COPIED]], %1) : $@convention(method) <τ_0_0 where τ_0_0 : P> (@in τ_0_0, @thick C.Type) -> @owned C
+// CHECK: dealloc_stack [[COPIED]] : $*@opened("{{.*}}", any P) Self


### PR DESCRIPTION
We would put the OpenExistentialExpr inside the RebindSelfInConstructorExpr, which confused SILGen.

Fixes rdar://problem/98404682.