### PR TITLE
[5.7.0][Driver] Work around lld 13+ issue with --gc-sections for ELF by adding -z nostart-stop-gc (#60544)

### DIFF
--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -184,6 +184,17 @@ toolchains::GenericUnix::constructInvocation(const DynamicLinkJobAction &job,
 #else
     Arguments.push_back(context.Args.MakeArgString("-fuse-ld=" + Linker));
 #endif
+    // Starting with lld 13, Swift stopped working with the lld --gc-sections
+    // implementation for ELF, unless -z nostart-stop-gc is also passed to lld:
+    //
+    // https://reviews.llvm.org/D96914
+    if (Linker == "lld" || (Linker.length() > 5 &&
+                            Linker.substr(Linker.length() - 6) == "ld.lld")) {
+      Arguments.push_back("-Xlinker");
+      Arguments.push_back("-z");
+      Arguments.push_back("-Xlinker");
+      Arguments.push_back("nostart-stop-gc");
+    }
   }
 
   // Configure the toolchain.

--- a/test/Driver/link-time-opt.swift
+++ b/test/Driver/link-time-opt.swift
@@ -16,6 +16,7 @@
 // CHECK-SIMPLE-THIN-linux-gnu: clang
 // CHECK-SIMPLE-THIN-linux-gnu-DAG: -flto=thin
 // CHECK-SIMPLE-THIN-linux-gnu-DAG: -fuse-ld=lld
+// CHECK-SIMPLE-THIN-linux-gnu-DAG: -Xlinker -z -Xlinker nostart-stop-gc
 // CHECK-SIMPLE-THIN-linux-gnu-DAG: [[BITCODEFILE]]
 // CHECK-SIMPLE-THIN-linux-gnu-NOT: swift-autolink-extract
 
@@ -37,6 +38,7 @@
 // CHECK-SIMPLE-FULL-linux-gnu: clang
 // CHECK-SIMPLE-FULL-linux-gnu-DAG: -flto=full
 // CHECK-SIMPLE-FULL-linux-gnu-DAG: -fuse-ld=lld
+// CHECK-SIMPLE-FULL-linux-gnu-DAG: -Xlinker -z -Xlinker nostart-stop-gc
 // CHECK-SIMPLE-FULL-linux-gnu-DAG: [[BITCODEFILE]]
 // CHECK-SIMPLE-FULL-linux-gnu-NOT: swift-autolink-extract
 


### PR DESCRIPTION
Cherrypick of #60653, the equivalent was already merged into 5.7 with apple/swift-driver#1158 so best to get this into the C++ Driver in 5.7.0 too to avoid any inconsistency

__Explanation:__ [lld 13 changed how `--gc-sections` works last year](https://reviews.llvm.org/D96914), which was then [flipped on by default](https://reviews.llvm.org/rG6d2d3bd0a61f5fc7fd9f61f48bc30e9ca77cc619), and causes all Swift code on ELF platforms not to link with lld 13 and 14 anymore if stripping is enabled.

__Scope:__ Only affects lld for these ELF platforms

__SR Issue:__ #60406

__Risk:__ low, since it only affects ELF platforms for this one linker and flag

__Testing:__ I [built the last August 2 source snapshot of the 5.7 toolchain for Android AArch64](https://github.com/buttaface/termux-packages/actions/runs/2886129294), where lld 14 is the default linker, with [this patch](https://github.com/buttaface/termux-packages/blob/swift-devel/packages/swift/swift-lld-gc.patch) and it works well.
 
__Reviewer:__ @compnerd