### PR TITLE
[stdlib] Fix Substring.removeSubrange for entire substring

### DIFF
--- a/stdlib/public/core/StringGutsRangeReplaceable.swift
+++ b/stdlib/public/core/StringGutsRangeReplaceable.swift
@@ -483,9 +483,13 @@ extension _StringGuts {
       let newUTF8Count =
         oldUTF8Count + newUTF8Subrange.count - oldUTF8SubrangeCount
 
-      // Get the character stride in the entire string, not just the substring.
-      // (Characters in a substring may end beyond the bounds of it.)
-      let newStride = _opaqueCharacterStride(startingAt: utf8StartOffset)
+      var newStride = 0
+
+      if !newUTF8Subrange.isEmpty {
+        // Get the character stride in the entire string, not just the substring.
+        // (Characters in a substring may end beyond the bounds of it.)
+        newStride = _opaqueCharacterStride(startingAt: utf8StartOffset)
+      }
 
       startIndex = String.Index(
         encodedOffset: utf8StartOffset,
@@ -522,9 +526,14 @@ extension _StringGuts {
     // needs to look ahead by more than one Unicode scalar.)
     let oldStride = startIndex.characterStride ?? 0
     if oldRange.lowerBound <= oldBounds.lowerBound &+ oldStride {
-      // Get the character stride in the entire string, not just the substring.
-      // (Characters in a substring may end beyond the bounds of it.)
-      let newStride = _opaqueCharacterStride(startingAt: newBounds.lowerBound)
+      var newStride = 0
+
+      if !newBounds.isEmpty {
+        // Get the character stride in the entire string, not just the substring.
+        // (Characters in a substring may end beyond the bounds of it.)
+        newStride = _opaqueCharacterStride(startingAt: newBounds.lowerBound)
+      }
+
       var newStart = String.Index(
         encodedOffset: newBounds.lowerBound,
         characterStride: newStride

--- a/test/stdlib/StringIndex.swift
+++ b/test/stdlib/StringIndex.swift
@@ -1059,3 +1059,28 @@ suite.test("String.replaceSubrange index validation")
     }
   }
 }
+
+suite.test("Substring.removeSubrange entire range") {
+  guard #available(SwiftStdlib 5.7, *) else {
+    // This is a regression found in 5.7+
+    return
+  }
+
+  var a: Substring = "abcdef"
+  let aStart = a.startIndex
+  let aEnd = a.endIndex
+
+  a.removeSubrange(aStart ..< aEnd)
+
+  expectTrue(a.isEmpty)
+
+#if _runtime(_ObjC)
+  var b: Substring = ("å∫ç∂éƒ" as NSString) as Substring
+  let bStart = b.startIndex
+  let bEnd = b.endIndex
+
+  b.removeSubrange(bStart ..< bEnd)
+
+  expectTrue(b.isEmpty)
+#endif
+}


### PR DESCRIPTION
When performing `Substring.removeSubrange`, we may end up in a situation where we need to alter the startIndex of the resulting Substring. Because of this, we added the optimization of caching the startIndex's character stride, but in the case where the Substring is empty, we were attempting to get the character stride of an empty range.

Resolves: rdar://98971061