### PR TITLE
IRGen: Use the clang type descriminator for TaskContinuationFunction*

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -1428,6 +1428,9 @@ namespace SpecialPointerAuthDiscriminators {
   /// Swift async context parameter stored in the extended frame info.
   const uint16_t SwiftAsyncContextExtendedFrameEntry = 0xc31a; // = 49946
 
+  // C type TaskContinuationFunction* descriminator.
+  const uint16_t ClangTypeTaskContinuationFunction = 0x2abe; // = 10942
+
   /// Dispatch integration.
   const uint16_t DispatchInvokeFunction = 0xf493; // = 62611
 

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -195,6 +195,9 @@ struct PointerAuthOptions : clang::PointerAuthOptions {
   /// Extended existential type shapes in flight.
   PointerAuthSchema ExtendedExistentialTypeShape;
 
+  // The c type descriminator for TaskContinuationFunction*.
+  PointerAuthSchema ClangTypeTaskContinuationFunction;
+
   /// Non-unique extended existential type shapes in flight.
   PointerAuthSchema NonUniqueExtendedExistentialTypeShape;
 };

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -2730,8 +2730,10 @@ public:
     auto signedResumeFn = currentResumeFn;
     // Sign the task resume function with the C function pointer schema.
     if (auto schema = IGF.IGM.getOptions().PointerAuth.FunctionPointers) {
-      // TODO: use the Clang type for TaskContinuationFunction*
+      // Use the Clang type for TaskContinuationFunction*
       // to make this work with type diversity.
+      schema =
+          IGF.IGM.getOptions().PointerAuth.ClangTypeTaskContinuationFunction;
       auto authInfo =
           PointerAuthInfo::emit(IGF, schema, nullptr, PointerAuthEntity());
       signedResumeFn = emitPointerAuthSign(IGF, signedResumeFn, authInfo);

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -2469,8 +2469,9 @@ llvm::Function *IRGenFunction::createAsyncSuspendFn() {
 
   // Sign the task resume function with the C function pointer schema.
   if (auto schema = IGM.getOptions().PointerAuth.FunctionPointers) {
-    // TODO: use the Clang type for TaskContinuationFunction*
+    // Use the Clang type for TaskContinuationFunction*
     // to make this work with type diversity.
+    schema = IGM.getOptions().PointerAuth.ClangTypeTaskContinuationFunction;
     auto authInfo = PointerAuthInfo::emit(suspendIGF, schema, nullptr,
                                           PointerAuthEntity());
     resumeFunction = emitPointerAuthSign(suspendIGF, resumeFunction, authInfo);

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -994,6 +994,10 @@ static void setPointerAuthOptions(PointerAuthOptions &opts,
                         Discrimination::Constant,
                         SpecialPointerAuthDiscriminators
                           ::NonUniqueExtendedExistentialTypeShape);
+
+  opts.ClangTypeTaskContinuationFunction = PointerAuthSchema(
+      codeKey, /*address*/ false, Discrimination::Constant,
+      SpecialPointerAuthDiscriminators::ClangTypeTaskContinuationFunction);
 }
 
 std::unique_ptr<llvm::TargetMachine>


### PR DESCRIPTION
rdar://98992498