### PR TITLE
[cxx-interop][SwiftCompilerSources] Add dependency on Swift LLVM Bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -770,6 +770,16 @@ if(BOOTSTRAPPING_MODE MATCHES "HOSTTOOLS|.*-WITH-HOSTLIBS")
   endif()
 endif()
 
+set(SWIFT_PATH_TO_LLVM_BINDINGS_SOURCE "${SWIFT_SOURCE_DIR}/../swift-llvm-bindings")
+if(NOT EXISTS "${SWIFT_PATH_TO_LLVM_BINDINGS_SOURCE}")
+  if(NOT BOOTSTRAPPING_MODE STREQUAL "OFF")
+    message(SEND_ERROR
+        "Building SwiftCompilerSources requires Swift LLVM Bindings. "
+        "Please specify SWIFT_PATH_TO_LLVM_BINDINGS_SOURCE.")
+  endif()
+endif()
+set(SWIFT_LLVM_BINDINGS_MODULES LLVM_Utils)
+
 # This setting causes all CMakeLists.txt to automatically have
 # ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CURRENT_SOURCE_DIR} as an
 # include_directories path. This is done for developer

--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -9,6 +9,12 @@
 # Following function are needed as a workaround until it's possible to compile
 # swift code with cmake's builtin swift support.
 
+if(SWIFT_HOST_VARIANT_SDK IN_LIST SWIFT_DARWIN_PLATFORMS)
+  set(host_deployment_version "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_DEPLOYMENT_VERSION}")
+endif()
+get_versioned_target_triple(host_target ${SWIFT_HOST_VARIANT_SDK}
+    ${SWIFT_HOST_VARIANT_ARCH} "${host_deployment_version}")
+
 # Add a swift compiler module
 #
 # Creates a target to compile a swift module.
@@ -96,7 +102,6 @@ function(add_swift_compiler_modules_library name)
   set(sdk_option "")
 
   if(SWIFT_HOST_VARIANT_SDK IN_LIST SWIFT_DARWIN_PLATFORMS)
-    set(deployment_version "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_DEPLOYMENT_VERSION}")
     set(sdk_path "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_ARCH_${SWIFT_HOST_VARIANT_ARCH}_PATH}")
     set(sdk_option "-sdk" "${sdk_path}")
     if(${BOOTSTRAPPING_MODE} STREQUAL "CROSSCOMPILE-WITH-HOSTLIBS")
@@ -123,8 +128,6 @@ function(add_swift_compiler_modules_library name)
     get_filename_component(swift_exec_bin_dir ${ALS_SWIFT_EXEC} DIRECTORY)
     set(sdk_option ${sdk_option} "-resource-dir" "${swift_exec_bin_dir}/../lib/swift")
   endif()
-  get_versioned_target_triple(target ${SWIFT_HOST_VARIANT_SDK}
-      ${SWIFT_HOST_VARIANT_ARCH} "${deployment_version}")
 
   set(all_obj_files)
   set(all_module_targets)
@@ -168,7 +171,7 @@ function(add_swift_compiler_modules_library name)
         importedHeaderDependencies
       COMMAND ${ALS_SWIFT_EXEC} "-c" "-o" ${module_obj_file}
               ${sdk_option}
-              "-target" ${target}
+              "-target" ${host_target}
               "-module-name" ${module} "-emit-module"
               "-emit-module-path" "${build_dir}/${module}.swiftmodule"
               "-parse-as-library" ${sources}
@@ -201,6 +204,7 @@ function(add_swift_compiler_modules_library name)
   endif()
   add_library(${name} STATIC ${all_obj_files})
   add_dependencies(${name} ${all_module_targets})
+  target_link_directories(${name} PUBLIC ${build_dir}/swift-llvm-bindings/lib)
   set_target_properties(${name} PROPERTIES LINKER_LANGUAGE CXX)
   set_property(GLOBAL APPEND PROPERTY SWIFT_BUILDTREE_EXPORTS ${name})
 
@@ -209,6 +213,7 @@ function(add_swift_compiler_modules_library name)
   endif()
   add_library("${name}_SwiftSyntax" STATIC ${syntaxparse_obj_files})
   add_dependencies("${name}_SwiftSyntax" ${syntaxparse_module_targets})
+  target_link_directories("${name}_SwiftSyntax" PUBLIC ${build_dir}/swift-llvm-bindings/lib)
   set_target_properties("${name}_SwiftSyntax" PROPERTIES LINKER_LANGUAGE CXX)
   set_property(GLOBAL APPEND PROPERTY SWIFT_BUILDTREE_EXPORTS "${name}_SwiftSyntax")
 
@@ -227,6 +232,8 @@ else()
   # Note: "Swift" is not added intentionally here, because it would break
   # the bootstrapping build in case no swift toolchain is installed on the host.
   project(SwiftInTheCompiler LANGUAGES C CXX)
+
+  include(ExternalProject)
 
   add_subdirectory(Sources)
 
@@ -258,6 +265,33 @@ else()
   add_library(importedHeaderDependencies "${CMAKE_CURRENT_BINARY_DIR}/HeaderDependencies.cpp")
   target_include_directories(importedHeaderDependencies PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../include/swift")
 
+  message(STATUS "Using Swift LLVM Bindings (${SWIFT_PATH_TO_LLVM_BINDINGS_SOURCE})")
+  set(bindings_cmake_args
+      -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+      # Tell CMake to not try to compile a sample Swift program with this
+      # compiler. Doing that will sometimes fail because the bootstrapped
+      # compiler might not have backdeployment libraries present.
+      -DCMAKE_Swift_COMPILER_WORKS=YES
+      -DCMAKE_Swift_COMPILER_TARGET=${host_target}
+      # Tell CMake to use the same C and C++ compilers as used for building
+      # Swift itself. This is especially important on Linux where the default
+      # compiler is usually gcc.
+      -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+      -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+      -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
+      -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+      -DCMAKE_EXE_LINKER_FLAGS=${CMAKE_EXE_LINKER_FLAGS}
+      -DCMAKE_SHARED_LINKER_FLAGS=${CMAKE_SHARED_LINKER_FLAGS}
+      -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}
+      -DCMAKE_LINKER=${CMAKE_LINKER}
+      -DCMAKE_MT=${CMAKE_MT}
+      -DCMAKE_RANLIB=${CMAKE_RANLIB}
+      -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
+      # Make sure `find_package(LLVM)` discovers the correct LLVM checkout.
+      -DLLVM_DIR=${LLVM_DIR}
+      -DClang_DIR=${Clang_DIR}
+      )
+
   if(${BOOTSTRAPPING_MODE} MATCHES "HOSTTOOLS|CROSSCOMPILE")
 
     if (NOT SWIFT_EXEC_FOR_SWIFT_MODULES)
@@ -277,8 +311,20 @@ else()
       endif()
     endif()
 
+    get_bootstrapping_path(bindings_build_dir ${CMAKE_CURRENT_BINARY_DIR} "")
+    ExternalProject_Add(swift-llvm-bindings
+        SOURCE_DIR ${SWIFT_PATH_TO_LLVM_BINDINGS_SOURCE}
+        CMAKE_ARGS
+        ${bindings_cmake_args}
+        -DCMAKE_Swift_COMPILER=${CMAKE_Swift_COMPILER}
+        -DCMAKE_INSTALL_PREFIX=${bindings_build_dir}/../
+        -DCMAKE_Swift_MODULE_DIRECTORY=${bindings_build_dir}
+        STEP_TARGETS configure build install
+        BUILD_ALWAYS YES)
+
     add_swift_compiler_modules_library(swiftCompilerModules
-      SWIFT_EXEC "${SWIFT_EXEC_FOR_SWIFT_MODULES}")
+      SWIFT_EXEC "${SWIFT_EXEC_FOR_SWIFT_MODULES}"
+      DEPENDS swift-llvm-bindings-install)
 
   elseif(${BOOTSTRAPPING_MODE} MATCHES "BOOTSTRAPPING.*")
 
@@ -315,16 +361,43 @@ else()
 
     # Bootstrapping - stage 1, using the compiler from level 0
 
+    get_bootstrapping_path(build_dir0 ${CMAKE_CURRENT_BINARY_DIR} "1")
+    ExternalProject_Add(swift-llvm-bindings-bootstrapping0
+        SOURCE_DIR ${SWIFT_PATH_TO_LLVM_BINDINGS_SOURCE}
+        CMAKE_ARGS
+        ${bindings_cmake_args}
+        -DCMAKE_Swift_COMPILER=$<TARGET_FILE_DIR:swift-frontend-bootstrapping0>/swiftc${CMAKE_EXECUTABLE_SUFFIX}
+        -DCMAKE_INSTALL_PREFIX=${build_dir0}/swift-llvm-bindings
+        -DCMAKE_Swift_MODULE_DIRECTORY=${build_dir0}
+        STEP_TARGETS configure build install
+        BUILD_ALWAYS YES)
+    add_dependencies(swift-llvm-bindings-bootstrapping0-configure ${b0_deps})
+
     add_swift_compiler_modules_library(swiftCompilerModules-bootstrapping1
       SWIFT_EXEC $<TARGET_FILE_DIR:swift-frontend-bootstrapping0>/swiftc${CMAKE_EXECUTABLE_SUFFIX}
-      DEPENDS ${b0_deps}
+      DEPENDS ${b0_deps} swift-llvm-bindings-bootstrapping0-install
       BOOTSTRAPPING 1)
 
     # The final build, using the compiler from stage 1
 
+    get_bootstrapping_path(build_dir1 ${CMAKE_CURRENT_BINARY_DIR} "")
+    ExternalProject_Add(swift-llvm-bindings-bootstrapping1
+        SOURCE_DIR ${SWIFT_PATH_TO_LLVM_BINDINGS_SOURCE}
+        CMAKE_ARGS
+        ${bindings_cmake_args}
+        -DCMAKE_Swift_COMPILER=$<TARGET_FILE_DIR:swift-frontend-bootstrapping1>/swiftc${CMAKE_EXECUTABLE_SUFFIX}
+        -DCMAKE_INSTALL_PREFIX=${build_dir1}/swift-llvm-bindings
+        -DCMAKE_Swift_MODULE_DIRECTORY=${build_dir1}
+        STEP_TARGETS configure build install
+        BUILD_ALWAYS YES)
+    add_dependencies(swift-llvm-bindings-bootstrapping1-configure ${b1_deps})
+    foreach(module ${SWIFT_LLVM_BINDINGS_MODULES})
+      set_property(GLOBAL PROPERTY ${module}_module_file "${build_dir1}/${module}.swiftmodule")
+    endforeach()
+
     add_swift_compiler_modules_library(swiftCompilerModules
         SWIFT_EXEC $<TARGET_FILE_DIR:swift-frontend-bootstrapping1>/swiftc${CMAKE_EXECUTABLE_SUFFIX}
-        DEPENDS ${b1_deps})
+        DEPENDS ${b1_deps} swift-llvm-bindings-bootstrapping1-install)
 
     if(BOOTSTRAPPING_MODE STREQUAL "BOOTSTRAPPING-WITH-HOSTLIBS")
       file(GLOB module_dirs "${CMAKE_BINARY_DIR}/bootstrapping*/lib/swift/macosx/*.swiftmodule")

--- a/SwiftCompilerSources/Sources/AST/DiagnosticEngine.swift
+++ b/SwiftCompilerSources/Sources/AST/DiagnosticEngine.swift
@@ -21,7 +21,7 @@ public protocol DiagnosticArgument {
 }
 extension String: DiagnosticArgument {
   public func _withBridgedDiagnosticArgument(_ fn: (swift.DiagnosticArgument) -> Void) {
-    _withStringRef { fn(swift.DiagnosticArgument($0)) }
+    withStringRef { fn(swift.DiagnosticArgument($0)) }
   }
 }
 extension Int: DiagnosticArgument {
@@ -42,7 +42,7 @@ public struct DiagnosticFixIt {
   }
 
   func withBridgedDiagnosticFixIt(_ fn: (swift.DiagnosticInfo.FixIt) -> Void) {
-    text._withStringRef { bridgedTextRef in
+    text.withStringRef { bridgedTextRef in
       let bridgedDiagnosticFixIt = swift.DiagnosticInfo.FixIt(
         swift.CharSourceRange(start.bridged, UInt32(byteLength)),
         bridgedTextRef,

--- a/SwiftCompilerSources/Sources/Basic/Utils.swift
+++ b/SwiftCompilerSources/Sources/Basic/Utils.swift
@@ -50,15 +50,6 @@ extension llvm.StringRef {
 }
 
 extension String {
-  /// Underscored to avoid name collision with Swift LLVM Bindings.
-  /// To be replaced with a bindings call once bindings are a dependency.
-  public func _withStringRef<T>(_ c: (llvm.StringRef) -> T) -> T {
-    var str = self
-    return str.withUTF8 { buffer in
-      return c(llvm.StringRef(buffer.baseAddress, buffer.count))
-    }
-  }
-
   /// Underscored to avoid name collision with the std overlay.
   /// To be replaced with an overlay call once the CI uses SDKs built with Swift 5.8.
   public init(_cxxString s: std.string) {

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
@@ -24,7 +24,7 @@ public func initializeSwiftModules() {
 private func registerPass(
       _ pass: ModulePass,
       _ runFn: @escaping (@convention(c) (BridgedPassContext) -> ())) {
-  pass.name._withStringRef { nameStr in
+  pass.name.withStringRef { nameStr in
     SILPassManager_registerModulePass(nameStr, runFn)
   }
 }
@@ -32,7 +32,7 @@ private func registerPass(
 private func registerPass(
       _ pass: FunctionPass,
       _ runFn: @escaping (@convention(c) (BridgedFunctionPassCtxt) -> ())) {
-  pass.name._withStringRef { nameStr in
+  pass.name.withStringRef { nameStr in
     SILPassManager_registerFunctionPass(nameStr, runFn)
   }
 }
@@ -40,7 +40,7 @@ private func registerPass(
 private func registerPass<InstType: Instruction>(
       _ pass: InstructionPass<InstType>,
       _ runFn: @escaping (@convention(c) (BridgedInstructionPassCtxt) -> ())) {
-  pass.name._withStringRef { nameStr in
+  pass.name.withStringRef { nameStr in
     SILCombine_registerInstructionPass(nameStr, runFn)
   }
 }

--- a/SwiftCompilerSources/Sources/SIL/Builder.swift
+++ b/SwiftCompilerSources/Sources/SIL/Builder.swift
@@ -61,7 +61,7 @@ public struct Builder {
       operandType: Type, resultType: Type, arguments: [Value]) -> BuiltinInst {
     notifyInstructionsChanged()
     return arguments.withBridgedValues { valuesRef in
-      return name._withStringRef { nameStr in
+      return name.withStringRef { nameStr in
         let bi = SILBuilder_createBuiltinBinaryFunction(
           bridged, nameStr, operandType.bridged, resultType.bridged, valuesRef)
         return bi.getAs(BuiltinInst.self)
@@ -71,7 +71,7 @@ public struct Builder {
 
   public func createCondFail(condition: Value, message: String) -> CondFailInst {
     notifyInstructionsChanged()
-    return message._withStringRef { messageStr in
+    return message.withStringRef { messageStr in
       let cf = SILBuilder_createCondFail(bridged, condition.bridged, messageStr)
       return cf.getAs(CondFailInst.self)
     }

--- a/SwiftCompilerSources/Sources/SIL/Function.swift
+++ b/SwiftCompilerSources/Sources/SIL/Function.swift
@@ -130,7 +130,7 @@ final public class Function : CustomStringConvertible, HasShortDescription, Hash
       // writeFn
       { (f: BridgedFunction, os: BridgedOStream, idx: Int) in
         let s = f.function.effects.argumentEffects[idx].description
-        s._withStringRef { OStream_write(os, $0) }
+        s.withStringRef { OStream_write(os, $0) }
       },
       // parseFn:
       { (f: BridgedFunction, str: llvm.StringRef, fromSIL: Int, isDerived: Int, paramNames: BridgedArrayRef) -> BridgedParsingError in

--- a/SwiftCompilerSources/Sources/SIL/Registration.swift
+++ b/SwiftCompilerSources/Sources/SIL/Registration.swift
@@ -14,7 +14,7 @@ import Basic
 import SILBridging
 
 private func register<T: AnyObject>(_ cl: T.Type) {
-  String(describing: cl)._withStringRef { nameStr in
+  String(describing: cl).withStringRef { nameStr in
     let metatype = unsafeBitCast(cl, to: SwiftMetatype.self)
     registerBridgedClass(nameStr, metatype)
   }

--- a/SwiftCompilerSources/Sources/SIL/Type.swift
+++ b/SwiftCompilerSources/Sources/SIL/Type.swift
@@ -44,7 +44,7 @@ public struct Type : CustomStringConvertible, CustomReflectable {
   }
 
   public func getIndexOfEnumCase(withName name: String) -> Int? {
-    let idx = name._withStringRef {
+    let idx = name.withStringRef {
       SILType_getCaseIdxOfEnumType(bridged, $0)
     }
     return idx >= 0 ? idx : nil
@@ -75,7 +75,7 @@ public struct NominalFieldsArray : RandomAccessCollection, FormattedLikeArray {
   }
 
   public func getIndexOfField(withName name: String) -> Int? {
-    let idx = name._withStringRef {
+    let idx = name.withStringRef {
       SILType_getFieldIdxOfNominalType(type.bridged, $0)
     }
     return idx >= 0 ? idx : nil

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -510,6 +510,10 @@ function(_add_swift_runtime_link_flags target relpath_to_lib_dir bootstrapping)
       get_target_property(module_file "SwiftModule${module}" "module_file")
       string(APPEND swift_ast_path_flags ",-add_ast_path,${module_file}")
     endforeach()
+    foreach(module ${SWIFT_LLVM_BINDINGS_MODULES})
+      get_property(module_file GLOBAL PROPERTY "${module}_module_file")
+      string(APPEND swift_ast_path_flags ",-add_ast_path,${module_file}")
+    endforeach()
 
     set_property(TARGET ${target} APPEND_STRING PROPERTY
                  LINK_FLAGS ${swift_ast_path_flags})

--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -96,6 +96,10 @@ function(add_sourcekitd_swifrt_linking target path HAS_SWIFT_MODULES)
         get_target_property(module_file "SwiftModule${module}" "module_file")
         string(APPEND swift_ast_path_flags ",-add_ast_path,${module_file}")
       endforeach()
+      foreach(module ${SWIFT_LLVM_BINDINGS_MODULES})
+        get_property(module_file GLOBAL PROPERTY "${module}_module_file")
+        string(APPEND swift_ast_path_flags ",-add_ast_path,${module_file}")
+      endforeach()
 
       set_property(TARGET ${target} APPEND_STRING PROPERTY
                    LINK_FLAGS " ${swift_ast_path_flags} ")

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -21,6 +21,10 @@ if(${BOOTSTRAPPING_MODE} MATCHES "BOOTSTRAPPING.*")
     SOURCE "swift-frontend${CMAKE_EXECUTABLE_SUFFIX}"
     DESTINATION "swiftc${CMAKE_EXECUTABLE_SUFFIX}"
     WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bootstrapping0/${CMAKE_CFG_INTDIR}/bin")
+  swift_create_post_build_symlink(swift-frontend-bootstrapping0
+    SOURCE "swift-frontend${CMAKE_EXECUTABLE_SUFFIX}"
+    DESTINATION "swift-autolink-extract${CMAKE_EXECUTABLE_SUFFIX}"
+    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bootstrapping0/${CMAKE_CFG_INTDIR}/bin")
 
   # Bootstrapping - level 1
 
@@ -34,11 +38,16 @@ if(${BOOTSTRAPPING_MODE} MATCHES "BOOTSTRAPPING.*")
   target_link_libraries(swift-frontend-bootstrapping1
                         PRIVATE
                           swiftDriverTool
+                          ${SWIFT_LLVM_BINDINGS_MODULES}
                           swiftCompilerModules-bootstrapping1)
 
   swift_create_post_build_symlink(swift-frontend-bootstrapping1
     SOURCE "swift-frontend${CMAKE_EXECUTABLE_SUFFIX}"
     DESTINATION "swiftc${CMAKE_EXECUTABLE_SUFFIX}"
+    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bootstrapping1/${CMAKE_CFG_INTDIR}/bin")
+  swift_create_post_build_symlink(swift-frontend-bootstrapping1
+    SOURCE "swift-frontend${CMAKE_EXECUTABLE_SUFFIX}"
+    DESTINATION "swift-autolink-extract${CMAKE_EXECUTABLE_SUFFIX}"
     WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bootstrapping1/${CMAKE_CFG_INTDIR}/bin")
 endif()
 

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2334,6 +2334,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DCMAKE_BUILD_TYPE:STRING="${LLDB_BUILD_TYPE}"
                     -DLLDB_SWIFTC:PATH=${SWIFTC_BIN}
                     -DLLDB_SWIFT_LIBS:PATH="$(build_directory ${LOCAL_HOST} swift)/lib/swift"
+                    -DLLDB_SWIFT_LLVM_BINDINGS_LIBS:PATH="${swift_build_dir}/SwiftCompilerSources/swift-llvm-bindings/lib"
                     -DCMAKE_INSTALL_PREFIX:PATH="$(get_host_install_prefix ${host})"
                     -DLLDB_FRAMEWORK_INSTALL_DIR="$(get_host_install_prefix ${host})../System/Library/PrivateFrameworks"
                     -DLLVM_DIR:PATH=${llvm_build_dir}/lib/cmake/llvm


### PR DESCRIPTION
SwiftCompilerSources need to use certain LLVM & Clang APIs, and Swift LLVM Bindings make those APIs more convenient to use from Swift.