### PR TITLE
[SourceKit] Fix a crash because the API for retrieving intherited protocols of a ProtocolDecl changed

### DIFF
--- a/test/SourceKit/CursorInfo/rdar_99096663.swift
+++ b/test/SourceKit/CursorInfo/rdar_99096663.swift
@@ -1,0 +1,4 @@
+// This should not crash
+// RUN: %sourcekitd-test -req=cursor -cursor-action -pos=4:11 %s -- %s 
+
+extension RandomAccessCollection 


### PR DESCRIPTION
apple/swift#60716 changed `NominalTypeDecl::getAllProtocols` to no longer work on `ProtocolDecl`. Add a new wrapper to Refactoring.cpp that dispatches to either `getInheritedProtocols` or `getAllProtocols` depending on whether the type is a protocol or not.

rdar://99096663
