### PR TITLE
[test] IRGen/opaque_result_alwaysInlineIntoClient: Try again

### DIFF
--- a/test/IRGen/opaque_result_alwaysInlineIntoClient.swift
+++ b/test/IRGen/opaque_result_alwaysInlineIntoClient.swift
@@ -1,13 +1,22 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 -parse-as-library -emit-library -emit-module-path %t/AlwaysInlineIntoWithOpaque.swiftmodule -module-name AlwaysInlineIntoWithOpaque %S/Inputs/AlwaysInlineIntoWithOpaque.swift -o %t/%target-library-name(AlwaysInlineIntoWithOpaque)
+// RUN: %target-codesign %t/%target-library-name(AlwaysInlineIntoWithOpaque)
 // RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 -lAlwaysInlineIntoWithOpaque -module-name main -I %t -L %t %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 -parse-as-library -emit-library -emit-module-path %t/AlwaysInlineIntoWithOpaque.swiftmodule -module-name AlwaysInlineIntoWithOpaque %S/Inputs/AlwaysInlineIntoWithOpaqueReplacement.swift -o %t/%target-library-name(AlwaysInlineIntoWithOpaque)
+// RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: OS=macosx && (CPU=x86_64 || CPU=arm64)
 // REQUIRES: executable_test
+
+// This test requires executable tests to be run on the same machine as the
+// compiler, as it links with a dylib that it doesn't arrange to get uploaded
+// to remote executors.
+// (rdar://97995151)
+// UNSUPPORTED: remote_run || device_run
 
 import AlwaysInlineIntoWithOpaque
 


### PR DESCRIPTION
Sigh, the issue #60735 ended up resolving does not actually apply to this test, as it's not an Interpreter test.

- Manually disable remote execution. (This test links its executable with a custom dylib that does not get uploaded to remote executors.)
- For good measure, code sign binaries before executing them. Beyond the actual code signing step, this also prevents dyld 4 problems with DYLD_LIBRARY_PATH on recent macOS releases. (See utils/swift-darwin-postprocess.py.)

rdar://97995151