### PR TITLE
[SILInliner] Handled null access storage base.

### DIFF
--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -462,7 +462,7 @@ void SILInlineCloner::cloneInline(ArrayRef<SILValue> AppliedArgs) {
           continue;
 
         auto storage = AccessStorageWithBase::compute(callArg);
-        if (auto *asi = dyn_cast<AllocStackInst>(storage.base))
+        if (auto *asi = dyn_cast_or_null<AllocStackInst>(storage.base))
           asi->setIsLexical();
       } else {
         // Insert begin/end borrow for guaranteed arguments.


### PR DESCRIPTION
During inlining, lexical-ness of arguments is preserved.  In the case of address arguments that come from alloc_stacks, the alloc_stacks are marked lexical.  The base of the storage which is passed to the address is obtained via AccessStorageWithBase.  In some circumstances, a base is not found.  Handled that case by changing a dyn_cast of the base to a dyn_cast_or_null.

rdar://99087653
