### PR TITLE
KeyPath performance improvement: Omit projection across trivially-typed memory.

### DIFF
--- a/benchmark/single-source/KeyPathPerformanceTests.swift
+++ b/benchmark/single-source/KeyPathPerformanceTests.swift
@@ -66,6 +66,12 @@ public let benchmarks = [
     tags: [.validation, .api],
     setUpFunction: setupKeyPathNestedStructs
   ),
+  BenchmarkInfo(
+    name: "KeyPathClassStructs",
+    runFunction: run_KeyPathClassStructs,
+    tags: [.validation, .api],
+    setUpFunction: setupKeyPathNestedStructs
+  ),
 ]
 
 /**
@@ -97,6 +103,7 @@ class FixedSizeArrayHolder {
   var fixedSizeArray100: FixedSizeArray100<ElementType>
   var fixedSizeArray10: FixedSizeArray10<ElementType>
   var mainArrayForNestedStructs: [A]
+  var mainArrayForClassStructs: [D1]
   var arrayForMutatingGetset: [MutatingGetsetNested1]
   var arrayForGet: [GetNested1]
   var arrayForOptionals: [Optional1]
@@ -107,6 +114,7 @@ class FixedSizeArrayHolder {
   var keypathForOptional: KeyPath<Optional1, Int?>
   var keypathForNestedClasses: KeyPath<C1, Int>
   var keypathForNonMutatingGetset: WritableKeyPath<M, Int>
+  var keypathForClassStructs: WritableKeyPath<D1, Int>
 
   // Same order as in KeyPathWritePerformance
   var kp46: WritableKeyPath<FixedSizeArray100<ElementType>, ElementType>
@@ -176,6 +184,7 @@ class FixedSizeArrayHolder {
     fixedSizeArray100 = initializeFixedSizeArray100()
     fixedSizeArray10 = initializeFixedSizeArray10()
     mainArrayForNestedStructs = [A]()
+    mainArrayForClassStructs = [D1]()
     arrayForMutatingGetset = [MutatingGetsetNested1]()
     arrayForGet = [GetNested1]()
     arrayForOptionals = [Optional1]()
@@ -252,6 +261,7 @@ class FixedSizeArrayHolder {
       ._nestedItemStorage?!._nestedItemStorage?!._storage)
     keypathForNestedClasses = identity(\C1.r.r.r.r.a)
     keypathForNonMutatingGetset = identity(\M.n.o.p.q.q)
+    keypathForClassStructs = identity(\D1.b.c.d.e.e)
   }
 }
 
@@ -262,6 +272,10 @@ public func setupKeyPathNestedStructs() {
     let instance = A(a: 0, b: B(b: 0, c: C(c: 0, d: D(d: 0, e: E(e: expectedIntForNestedItems)))))
     holder.mainArrayForNestedStructs.append(instance)
 
+    let classStructInstance = D1(b: D2(b: 0, c: D3(c: 0, d: D4(d: 0,
+      e: D5(e: expectedIntForNestedItems)))))
+    holder.mainArrayForClassStructs.append(classStructInstance)
+      
     var mutatingGetsetInstance = MutatingGetsetNested1()
     mutatingGetsetInstance.nestedItem.nestedItem.nestedItem.nestedItem
       .storage = expectedIntForNestedItems
@@ -330,6 +344,36 @@ struct D {
 }
 
 struct E {
+  var e: Int
+}
+
+// Used for run_KeyPathClassStruct().
+class D1 {
+  var a: Int
+  var b: D2
+  init(b: D2)
+  {
+    a = 0
+    self.b = b
+  }
+}
+
+struct D2 {
+  var b: Int
+  var c: D3
+}
+
+struct D3 {
+  var c: Int
+  var d: D4
+}
+
+struct D4 {
+  var d: Int
+  var e: D5
+}
+
+struct D5 {
   var e: Int
 }
 
@@ -1325,6 +1369,36 @@ public func run_KeyPathNestedStructs(n: Int) {
   }
   check(sum == iterationMultipier * n * expectedIntForNestedItems)
 }
+
+// This measures the performance of keypath reads where a block of
+// trivially-typed memory is preceded by something else (optionals, reference
+// types, etc.)
+@inline(never)
+public func run_KeyPathClassStructs(n: Int) {
+  var sum = 0
+  var index = 0
+  let iterationMultipier = 2000
+
+  let singleHopKeyPath0: WritableKeyPath<D1, D2> = \D1.b
+  let singleHopKeyPath1: WritableKeyPath<D2, D3> = \D2.c
+  let singleHopKeyPath2: WritableKeyPath<D3, D4> = \D3.d
+  let singleHopKeyPath3: WritableKeyPath<D4, D5> = \D4.e
+  let singleHopKeyPath4: WritableKeyPath<D5, Int> = \D5.e
+
+  let appendedKeyPath = identity(singleHopKeyPath0.appending(path: singleHopKeyPath1)
+    .appending(path: singleHopKeyPath2).appending(path: singleHopKeyPath3)
+    .appending(path: singleHopKeyPath4))
+
+  let elementCount = FixedSizeArrayHolder.shared.mainArrayForClassStructs.count
+  for _ in 1 ... iterationMultipier * n {
+    let element = FixedSizeArrayHolder.shared.mainArrayForClassStructs[index]
+    sum += element[keyPath: appendedKeyPath]
+    index = (index + 1) % elementCount
+  }
+  check(sum == iterationMultipier * n * expectedIntForNestedItems)
+}
+
+
 
 // This is meant as a baseline, from a timing perspective,
 // for run_testKeyPathReadPerformance() and run_testKeyPathWritePerformance().

--- a/benchmark/single-source/KeyPathPerformanceTests.swift
+++ b/benchmark/single-source/KeyPathPerformanceTests.swift
@@ -66,12 +66,6 @@ public let benchmarks = [
     tags: [.validation, .api],
     setUpFunction: setupKeyPathNestedStructs
   ),
-  BenchmarkInfo(
-    name: "KeyPathClassStructs",
-    runFunction: run_KeyPathClassStructs,
-    tags: [.validation, .api],
-    setUpFunction: setupKeyPathNestedStructs
-  ),
 ]
 
 /**
@@ -103,7 +97,6 @@ class FixedSizeArrayHolder {
   var fixedSizeArray100: FixedSizeArray100<ElementType>
   var fixedSizeArray10: FixedSizeArray10<ElementType>
   var mainArrayForNestedStructs: [A]
-  var mainArrayForClassStructs: [D1]
   var arrayForMutatingGetset: [MutatingGetsetNested1]
   var arrayForGet: [GetNested1]
   var arrayForOptionals: [Optional1]
@@ -114,7 +107,6 @@ class FixedSizeArrayHolder {
   var keypathForOptional: KeyPath<Optional1, Int?>
   var keypathForNestedClasses: KeyPath<C1, Int>
   var keypathForNonMutatingGetset: WritableKeyPath<M, Int>
-  var keypathForClassStructs: WritableKeyPath<D1, Int>
 
   // Same order as in KeyPathWritePerformance
   var kp46: WritableKeyPath<FixedSizeArray100<ElementType>, ElementType>
@@ -184,7 +176,6 @@ class FixedSizeArrayHolder {
     fixedSizeArray100 = initializeFixedSizeArray100()
     fixedSizeArray10 = initializeFixedSizeArray10()
     mainArrayForNestedStructs = [A]()
-    mainArrayForClassStructs = [D1]()
     arrayForMutatingGetset = [MutatingGetsetNested1]()
     arrayForGet = [GetNested1]()
     arrayForOptionals = [Optional1]()
@@ -261,7 +252,6 @@ class FixedSizeArrayHolder {
       ._nestedItemStorage?!._nestedItemStorage?!._storage)
     keypathForNestedClasses = identity(\C1.r.r.r.r.a)
     keypathForNonMutatingGetset = identity(\M.n.o.p.q.q)
-    keypathForClassStructs = identity(\D1.b.c.d.e.e)
   }
 }
 
@@ -272,10 +262,6 @@ public func setupKeyPathNestedStructs() {
     let instance = A(a: 0, b: B(b: 0, c: C(c: 0, d: D(d: 0, e: E(e: expectedIntForNestedItems)))))
     holder.mainArrayForNestedStructs.append(instance)
 
-    let classStructInstance = D1(b: D2(b: 0, c: D3(c: 0, d: D4(d: 0,
-      e: D5(e: expectedIntForNestedItems)))))
-    holder.mainArrayForClassStructs.append(classStructInstance)
-      
     var mutatingGetsetInstance = MutatingGetsetNested1()
     mutatingGetsetInstance.nestedItem.nestedItem.nestedItem.nestedItem
       .storage = expectedIntForNestedItems
@@ -344,36 +330,6 @@ struct D {
 }
 
 struct E {
-  var e: Int
-}
-
-// Used for run_KeyPathClassStruct().
-class D1 {
-  var a: Int
-  var b: D2
-  init(b: D2)
-  {
-    a = 0
-    self.b = b
-  }
-}
-
-struct D2 {
-  var b: Int
-  var c: D3
-}
-
-struct D3 {
-  var c: Int
-  var d: D4
-}
-
-struct D4 {
-  var d: Int
-  var e: D5
-}
-
-struct D5 {
   var e: Int
 }
 
@@ -1369,36 +1325,6 @@ public func run_KeyPathNestedStructs(n: Int) {
   }
   check(sum == iterationMultipier * n * expectedIntForNestedItems)
 }
-
-// This measures the performance of keypath reads where a block of
-// trivially-typed memory is preceded by something else (optionals, reference
-// types, etc.)
-@inline(never)
-public func run_KeyPathClassStructs(n: Int) {
-  var sum = 0
-  var index = 0
-  let iterationMultipier = 2000
-
-  let singleHopKeyPath0: WritableKeyPath<D1, D2> = \D1.b
-  let singleHopKeyPath1: WritableKeyPath<D2, D3> = \D2.c
-  let singleHopKeyPath2: WritableKeyPath<D3, D4> = \D3.d
-  let singleHopKeyPath3: WritableKeyPath<D4, D5> = \D4.e
-  let singleHopKeyPath4: WritableKeyPath<D5, Int> = \D5.e
-
-  let appendedKeyPath = identity(singleHopKeyPath0.appending(path: singleHopKeyPath1)
-    .appending(path: singleHopKeyPath2).appending(path: singleHopKeyPath3)
-    .appending(path: singleHopKeyPath4))
-
-  let elementCount = FixedSizeArrayHolder.shared.mainArrayForClassStructs.count
-  for _ in 1 ... iterationMultipier * n {
-    let element = FixedSizeArrayHolder.shared.mainArrayForClassStructs[index]
-    sum += element[keyPath: appendedKeyPath]
-    index = (index + 1) % elementCount
-  }
-  check(sum == iterationMultipier * n * expectedIntForNestedItems)
-}
-
-
 
 // This is meant as a baseline, from a timing perspective,
 // for run_testKeyPathReadPerformance() and run_testKeyPathWritePerformance().

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -180,7 +180,7 @@ public class AnyKeyPath: Hashable, _AppendKeyPath {
   // TODO: Find a quicker way to see if this is a tuple.
   internal func isTuple(_ item: Any) -> Bool {
     // Unwraps type information if possible.
-    // Otherwise, everything the Mirror sees would be "Optional<Any.Type>".
+    // Otherwise, everything the Mirror handling "item" sees would be "Optional<Any.Type>".
     func unwrapType<T>(_ any: T) -> Any {
       let mirror = Mirror(reflecting: any)
       guard mirror.displayStyle == .optional, let first = mirror.children.first else {

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -168,7 +168,7 @@ public class AnyKeyPath: Hashable, _AppendKeyPath {
     return try f(KeyPathBuffer(base: base))
   }
 
-  public var isPureStructKeyPath: Bool {
+  internal var isPureStructKeyPath: Bool {
     return _isPureStructKeyPath ?? false
   }
 

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -35,6 +35,8 @@ internal func _abstract(
 /// type.
 @_objcRuntimeName(_TtCs11_AnyKeyPath)
 public class AnyKeyPath: Hashable, _AppendKeyPath {
+  internal var _isPureStructKeyPath: Bool?
+  internal var _pureStructValueOffset: Int = 0
   /// The root type for this key path.
   @inlinable
   public static var rootType: Any.Type {
@@ -150,15 +152,15 @@ public class AnyKeyPath: Hashable, _AppendKeyPath {
   ) -> Self {
     _internalInvariant(bytes > 0 && bytes % 4 == 0,
                  "capacity must be multiple of 4 bytes")
-    let result = Builtin.allocWithTailElems_1(self, (bytes/4)._builtinWordValue,
+    let keypath = Builtin.allocWithTailElems_1(self, (bytes/4)._builtinWordValue,
                                               Int32.self)
-    result._kvcKeyPathStringPtr = nil
-    let base = UnsafeMutableRawPointer(Builtin.projectTailElems(result,
+    keypath._kvcKeyPathStringPtr = nil
+    let base = UnsafeMutableRawPointer(Builtin.projectTailElems(keypath,
                                                                 Int32.self))
     body(UnsafeMutableRawBufferPointer(start: base, count: bytes))
-    return result
+    keypath._computeOffsetForPureStructKeypath()
+    return keypath
   }
-  
   final internal func withBuffer<T>(_ f: (KeyPathBuffer) throws -> T) rethrows -> T {
     defer { _fixLifetime(self) }
     
@@ -166,31 +168,94 @@ public class AnyKeyPath: Hashable, _AppendKeyPath {
     return try f(KeyPathBuffer(base: base))
   }
 
-  @usableFromInline // Exposed as public API by MemoryLayout<Root>.offset(of:)
-  internal var _storedInlineOffset: Int? {
-    return withBuffer {
-      var buffer = $0
+  public var isPureStructKeyPath: Bool {
+    return _isPureStructKeyPath ?? false
+  }
 
-      // The identity key path is effectively a stored keypath of type Self
-      // at offset zero
-      if buffer.data.isEmpty { return 0 }
+  internal func isClass(_ item: Any.Type) -> Bool {
+    // Displays "warning: 'is' test is always true" at compile time, but that's not actually the case.
+    return (item is AnyObject)
+  }
 
-      var offset = 0
-      while true {
-        let (rawComponent, optNextType) = buffer.next()
-        switch rawComponent.header.kind {
-        case .struct:
-          offset += rawComponent._structOrClassOffset
+  // TODO: Find a quicker way to see if this is a tuple.
+  internal func isTuple(_ item: Any) -> Bool {
+    // Unwraps type information if possible.
+    // Otherwise, everything the Mirror sees would be "Optional<Any.Type>".
+    func unwrapType<T>(_ any: T) -> Any {
+      let mirror = Mirror(reflecting: any)
+      guard mirror.displayStyle == .optional, let first = mirror.children.first else {
+        return any
+      }
+      return first.value
+    }
 
-        case .class, .computed, .optionalChain, .optionalForce, .optionalWrap, .external:
-          return .none
+    let mirror = Mirror(reflecting: unwrapType(item))
+    let description = mirror.description
+    let offsetOfFirstBracketForMirrorDescriptionOfTuple = 11
+    let idx = description.index(description.startIndex, offsetBy: offsetOfFirstBracketForMirrorDescriptionOfTuple)
+    if description[idx] == "(" {
+      return true
+    }
+    return false
+  }
+    
+    // If this keypath traverses structs only, it'll have a predictable memory layout.
+    // We can then jump to the value directly in _projectReadOnly().
+    internal func _computeOffsets() -> (offset: Int, isPureStruct: Bool, isTuple: Bool) {
+      _pureStructValueOffset = 0
+      var isPureStruct = true
+      var _isTuple = false
+      defer {
+        _isPureStructKeyPath = isPureStruct
+      }
+      withBuffer {
+        var buffer = $0
+        if buffer.data.isEmpty {
+          if isClass(Self._rootAndValueType.root) {
+            isPureStruct = false
+          }
+        } else {
+          while true {
+            let (rawComponent, optNextType) = buffer.next()
+            if isTuple(optNextType as Any) {
+              isPureStruct = false
+              _isTuple = true
+            }
+            switch rawComponent.header.kind {
+            case .struct:
+              _pureStructValueOffset += rawComponent._structOrClassOffset
+            case .class, .computed, .optionalChain, .optionalForce, .optionalWrap, .external:
+              isPureStruct = false
+            }
+            if optNextType == nil {
+              break
+            }
+          }
         }
+      }
+      return (_pureStructValueOffset, isPureStruct, _isTuple)
+    }
 
-        if optNextType == nil { return .some(offset) }
+    internal func _computeOffsetForPureStructKeypath() {
+      _ = _computeOffsets()
+    }
+
+    // This function was refactored since _computeOffsets() was performing
+    // essentially the same computation.
+    @usableFromInline // Exposed as public API by MemoryLayout<Root>.offset(of:)
+    internal var _storedInlineOffset: Int? {
+      // TODO: Cache this value in a similar manner to _pureStructValueOffset.
+      // The current design assumes keypath read and write operations will be called
+      // much more often than MemoryLayout<Root>.offset(of:).
+      let offsetInformation = _computeOffsets()
+      if offsetInformation.isPureStruct || offsetInformation.isTuple {
+        return .some(offsetInformation.offset)
+      } else {
+        return .none
       }
     }
   }
-}
+
 
 /// A partially type-erased key path, from a concrete root type to any
 /// resulting value type.
@@ -246,6 +311,17 @@ public class KeyPath<Root, Value>: PartialKeyPath<Root> {
   
   @usableFromInline
   internal final func _projectReadOnly(from root: Root) -> Value {
+   
+    //One performance improvement is to skip right to Value
+    //if this keypath traverses through structs only.
+    if isPureStructKeyPath
+    {
+      return withUnsafeBytes(of: root) {
+        let pointer = $0.baseAddress.unsafelyUnwrapped.advanced(by: _pureStructValueOffset)
+        return pointer.assumingMemoryBound(to: Value.self).pointee
+      }
+    }
+      
     // TODO: For perf, we could use a local growable buffer instead of Any
     var curBase: Any = root
     return withBuffer {
@@ -302,6 +378,14 @@ public class WritableKeyPath<Root, Value>: KeyPath<Root, Value> {
   @usableFromInline
   internal func _projectMutableAddress(from base: UnsafePointer<Root>)
       -> (pointer: UnsafeMutablePointer<Value>, owner: AnyObject?) {
+          
+    // Don't declare "p" above this if-statement; it may slow things down.
+    if isPureStructKeyPath
+    {
+      let p = UnsafeRawPointer(base).advanced(by: _pureStructValueOffset)
+      return (pointer: UnsafeMutablePointer(
+        mutating: p.assumingMemoryBound(to: Value.self)), owner: nil)
+    }
     var p = UnsafeRawPointer(base)
     var type: Any.Type = Root.self
     var keepAlive: AnyObject?
@@ -2252,6 +2336,19 @@ extension _AppendKeyPath /* where Self == ReferenceWritableKeyPath<T,U> */ {
   }
 }
 
+/// Updates information pertaining to the types associated with each key path.
+///
+/// Note: Currently we only distinguish between keypaths that traverse only structs to get to the final value,
+/// and all other types. This is done for performance reasons.
+/// Other type information may be handled in the future to improve performance.
+internal func _processAppendingKeyPathType(root: inout AnyKeyPath, leaf: AnyKeyPath) {
+  root._isPureStructKeyPath = root.isPureStructKeyPath && leaf.isPureStructKeyPath
+  if let isPureStruct = root._isPureStructKeyPath, isPureStruct {
+    root._computeOffsetForPureStructKeypath()
+  }
+}
+
+
 @usableFromInline
 internal func _tryToAppendKeyPaths<Result: AnyKeyPath>(
   root: AnyKeyPath,
@@ -2277,7 +2374,13 @@ internal func _tryToAppendKeyPaths<Result: AnyKeyPath>(
     }
     return _openExistential(rootValue, do: open2)
   }
-  return _openExistential(rootRoot, do: open)
+  var returnValue:AnyKeyPath = _openExistential(rootRoot, do: open)
+  _processAppendingKeyPathType(root: &returnValue, leaf: leaf)
+  if let returnValue = returnValue as? Result
+  {
+      return returnValue
+  }
+  return nil
 }
 
 @usableFromInline
@@ -2289,7 +2392,7 @@ internal func _appendingKeyPaths<
   leaf: KeyPath<Value, AppendedValue>
 ) -> Result {
   let resultTy = type(of: root).appendedType(with: type(of: leaf))
-  return root.withBuffer {
+  var returnValue:AnyKeyPath = root.withBuffer {
     var rootBuffer = $0
     return leaf.withBuffer {
       var leafBuffer = $0
@@ -2423,6 +2526,8 @@ internal func _appendingKeyPaths<
       return unsafeDowncast(result, to: Result.self)
     }
   }
+   _processAppendingKeyPathType(root: &returnValue, leaf: leaf)
+   return returnValue as! Result
 }
 
 // The distance in bytes from the address point of a KeyPath object to its

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -162,27 +162,23 @@ public class AnyKeyPath: Hashable, _AppendKeyPath {
 
   func getOffsetFromStorage() -> Int? {
     let maximumOffsetOn32BitArchitecture = 4094
-    guard let storage = _kvcKeyPathStringPtr else {
+    guard _kvcKeyPathStringPtr != nil else {
       return nil
     }
 
-    // TODO: Maybe we can get a pointer's raw bits instead of doing
-    // a distance calculation. Note: offsetBase can't be unwrapped
-    // forcefully if its bitPattern is 0x00. Hence the 0x01.
-    let offsetBase = UnsafePointer<CChar>(bitPattern: 0x01)
     let architectureSize = MemoryLayout<Int>.size
     if architectureSize == 8 {
-      let storageDistance = storage.distance(to: offsetBase!) - 2
-      guard storageDistance >= 0 else {
+      let offset = -Int(bitPattern: _kvcKeyPathStringPtr) - 1
+      guard offset >= 0 else {
         // This happens to be an actual _kvcKeyPathStringPtr, not an offset, if we get here.
         return nil
       }
-      return storageDistance
+      return offset
     }
     else {
-      let storageDistance = offsetBase!.distance(to: storage)
-      if (storageDistance <= maximumOffsetOn32BitArchitecture) {
-        return storageDistance
+      let offset = Int(bitPattern: _kvcKeyPathStringPtr) - 1
+      if (offset <= maximumOffsetOn32BitArchitecture) {
+        return offset
       }
       return nil
     }

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -3688,7 +3688,6 @@ internal struct InstantiateKeyPathBuffer: KeyPathPatternVisitor {
   }
 
   mutating func visitIntermediateComponentType(metadataRef: MetadataReference) {
-    isPureStruct.append(false)
     // Get the metadata for the intermediate type.
     let metadata = _resolveKeyPathMetadataReference(
                      metadataRef,

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -3753,7 +3753,7 @@ internal struct ValidatingInstantiateKeyPathBuffer: KeyPathPatternVisitor {
                                             offset: offset)
     checkSizeConsistency()
     structOffset = instantiateVisitor.structOffset
-    isPureStruct = instantiateVisitor.isPureStruct
+    isPureStruct.append(contentsOf: instantiateVisitor.isPureStruct)
   }
   mutating func visitComputedComponent(mutating: Bool,
                                    idKind: KeyPathComputedIDKind,
@@ -3782,32 +3782,41 @@ internal struct ValidatingInstantiateKeyPathBuffer: KeyPathPatternVisitor {
                                        setter: setter,
                                        arguments: arguments,
                                        externalArgs: externalArgs)
+    // Note: For this function and the ones below, modification of structOffset
+    // is omitted since these types of KeyPaths won't have a pureStruct
+    // offset anyway.
+    isPureStruct.append(contentsOf: instantiateVisitor.isPureStruct)
     checkSizeConsistency()
   }
   mutating func visitOptionalChainComponent() {
     sizeVisitor.visitOptionalChainComponent()
     instantiateVisitor.visitOptionalChainComponent()
+    isPureStruct.append(contentsOf: instantiateVisitor.isPureStruct)
     checkSizeConsistency()
   }
   mutating func visitOptionalWrapComponent() {
     sizeVisitor.visitOptionalWrapComponent()
     instantiateVisitor.visitOptionalWrapComponent()
+    isPureStruct.append(contentsOf: instantiateVisitor.isPureStruct)
     checkSizeConsistency()
   }
   mutating func visitOptionalForceComponent() {
     sizeVisitor.visitOptionalForceComponent()
     instantiateVisitor.visitOptionalForceComponent()
+    isPureStruct.append(contentsOf: instantiateVisitor.isPureStruct)
     checkSizeConsistency()
   }
   mutating func visitIntermediateComponentType(metadataRef: MetadataReference) {
     sizeVisitor.visitIntermediateComponentType(metadataRef: metadataRef)
     instantiateVisitor.visitIntermediateComponentType(metadataRef: metadataRef)
+    isPureStruct.append(contentsOf: instantiateVisitor.isPureStruct)
     checkSizeConsistency()
   }
 
   mutating func finish() {
     sizeVisitor.finish()
     instantiateVisitor.finish()
+    isPureStruct.append(contentsOf: instantiateVisitor.isPureStruct)
     checkSizeConsistency()
   }
 
@@ -3885,14 +3894,6 @@ internal func _instantiateKeyPathBuffer(
     isPureStruct = isPureStruct && value
   }
 
-  // Disable the optimization in the general case of 0 components.
-  // Note that a KeyPath such as \SomeStruct.self would still technically
-  // have a valid offset of 0.
-  // TODO: Add the logic to distinguish pure struct
-  // 0-component KeyPaths (tuples too?) from others.
-  if walker.isPureStruct.count == 0 {
-    isPureStruct = false
-  }
   if isPureStruct {
       offset = walker.structOffset
   }


### PR DESCRIPTION
The main assumption associated with this performance improvement is that any contiguous region of (`KeyPathComponentKind`) `struct`s is trivially-typed, and as such, can be traversed via simple pointer arithmetic.

In the general case, in order to read or write to a value referred to by a KeyPath, a projection is required to be performed from the root to the requested value. During a projection, all intermediate nodes between the root and value are visited. An example of this involves structs within structs containing trivial types only. The premise behind this optimization is to precompute, and use, the offset required to reach the value from the root if only trivially-typed memory is traversed. In the case of a KeyPath `append()` operation, the offset is recomputed, and used only if the appended KeyPath ends up only traversing trivially-typed memory.

Tuples are explicitly excluded from this optimization, for the time being.

Upon construction of a new KeyPath instance, the byte offset from the root to the value is precomputed. Further, a Boolean value is precomputed to determine if only trivially-typed memory is traversed. (The function checks to see if all of the `KeyPathComponentKinds` are structs from the root to the value.)

During a projection involving a read or write operation, we check the aforementioned Boolean value. If it's true, then we use simple pointer arithmetic to skip to the final value and perform the cast to the value's type before returning it.


## Alternative Considered

This alternative can potentially be included in a future PR to improve performance. The currently-proposed performance improvement was found to provide the best speedup with the fewest changes.

###  Avoid overwriting `Any` inside `_projectReadOnly()`.
In order to avoid an implicit `realloc()` of the object associated with the `curBase` of type `Any`, we break the storage up into two pieces. The first piece uses an `AnyObject` to store a reference type, if the current item happens to be one. The second piece uses a buffer that grows to the maximum size of any struct encountered during any projection step. This prevents an explicit `realloc()` during any subsequent projections, at the expense of memory that is only relinquished when the KeyPath goes out of scope. Due to the extra memory requirement of these KeyPaths, one could argue that these deserve their own type, perhaps named `BufferedKeyPath`. Additional layers of projection (via `_openExistential()`) may be needed to carry the requisite type information from the root to the final value with this approach.