### PR TITLE
[ConstraintSystem] Remove conjunction printing and iterate over all disjunction choices in scope

### DIFF
--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -358,15 +358,11 @@ StepResult ComponentStep::take(bool prevFailed) {
   auto *disjunction = CS.selectDisjunction();
 
   if (CS.isDebugMode()) {
-    PrintOptions PO;
-    PO.PrintTypesForDebugging = true;
-
-    auto &log = getDebugLogger();
     if (!potentialBindings.empty()) {
+      auto &log = getDebugLogger();
       log << "(Potential Binding(s): " << '\n';
       log << potentialBindings;
     }
-    log.indent(CS.solverState->getCurrentIndent());
 
     SmallVector<Constraint *, 4> disjunctions;
     CS.collectDisjunctions(disjunctions);
@@ -392,7 +388,6 @@ StepResult ComponentStep::take(bool prevFailed) {
         log << ")\n";
       }
     }
-    log << ")\n";
   }
 
   if (CS.shouldAttemptFixes()) {

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -356,7 +356,6 @@ StepResult ComponentStep::take(bool prevFailed) {
   });
 
   auto *disjunction = CS.selectDisjunction();
-  auto *conjunction = CS.selectConjunction();
 
   if (CS.isDebugMode()) {
     PrintOptions PO;
@@ -369,19 +368,29 @@ StepResult ComponentStep::take(bool prevFailed) {
     }
     log.indent(CS.solverState->getCurrentIndent());
 
-    if (disjunction) {
+    SmallVector<Constraint *, 4> disjunctions;
+    CS.collectDisjunctions(disjunctions);
+    std::vector<std::string> overloadDisjunctions;
+    for (const auto &disjunction : disjunctions) {
+      PrintOptions PO;
+      PO.PrintTypesForDebugging = true;
+
+      auto constraints = disjunction->getNestedConstraints();
+      if (constraints[0]->getKind() == ConstraintKind::BindOverload)
+        overloadDisjunctions.push_back(
+            constraints[0]->getFirstType()->getString(PO));
+    }
+    if (!overloadDisjunctions.empty()) {
+      auto &log = getDebugLogger();
       log.indent(2);
       log << "Disjunction(s) = [";
-      auto constraints = disjunction->getNestedConstraints();
-      log << constraints[0]->getFirstType()->getString(PO);
-      log << "]";
-    }
-    if (conjunction) {
-      log.indent(2);
-      log << "Conjunction(s) = [";
-      auto constraints = conjunction->getNestedConstraints();
-      log << constraints[0]->getFirstType()->getString(PO);
-      log << "]";
+      interleave(overloadDisjunctions, log, ", ");
+      log << "]\n";
+
+      if (!potentialBindings.empty() || !overloadDisjunctions.empty()) {
+        auto &log = getDebugLogger();
+        log << ")\n";
+      }
     }
     log << ")\n";
   }


### PR DESCRIPTION
This prints all of the inactive disjunction choices in the constraint system for the Component Step instead of just the selected disjunction for the attempt. Additionally, conjunction printing is removed as conjunction constraints do not have type variables to list.

This is an edit to apple/swift#59971.