### PR TITLE
Add a note about tail padding to URBP.assumingMemoryBound

### DIFF
--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -894,6 +894,12 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///   That is, `Int(bitPattern: self.baseAddress) % MemoryLayout<T>.alignment`
   ///   must equal zero.
   ///
+  /// - Note: The returned buffer references `self.count / MemoryLayout<T>.stride`
+  ///   instances of `T`. If using this function to obtain a typed pointer to a
+  ///   tuple's elements, be aware that the tuple may not include padding for its
+  ///   final element, hence the returned buffer may include fewer elements
+  ///   than expected.
+  ///
   /// - Parameter to: The type `T` that the memory has already been bound to.
   /// - Returns: A typed pointer to the same memory as this raw pointer.
   @inlinable


### PR DESCRIPTION
<!-- What's in this pull request? -->
Simply dividing the tuple's byte count by the element stride may result in a buffer with one fewer element than expected. 
The current docs do not mention strides at all, so this isn't clear.

See https://forums.swift.org/t/zero-sized-types-vs-tuple-memory-layout/58768

Note that `TailPadding` has a stride of 4, yet a tuple of 2 elements contains 7 bytes. Using integer division (such as this function does) would return a buffer with count 1 from a 2-element tuple.

Anybody who wants a pointer to a tuple's elements should specify the expected count rather than relying on division. For example, https://github.com/karwa/swift-url/pull/165

@glessard @belkadan 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
