### PR TITLE
[cxx-interop] Add `@available` attribute to decls in Cxx module

### DIFF
--- a/stdlib/public/Cxx/CxxConvertibleToCollection.swift
+++ b/stdlib/public/Cxx/CxxConvertibleToCollection.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// A C++ type that can be converted to a Swift collection.
+@available(SwiftStdlib 5.8, *)
 public protocol CxxConvertibleToCollection {
   associatedtype RawIterator: UnsafeCxxInputIterator
 
@@ -21,6 +22,7 @@ public protocol CxxConvertibleToCollection {
   mutating func __endUnsafe() -> RawIterator
 }
 
+@available(SwiftStdlib 5.8, *)
 @inlinable @inline(__always)
 internal func forEachElement<C: CxxConvertibleToCollection>(
   of c: C,
@@ -45,6 +47,7 @@ extension Array {
   ///
   /// - Complexity: O(*n*), where *n* is the number of elements in the C++
   ///   collection.
+  @available(SwiftStdlib 5.8, *)
   public init<C: CxxConvertibleToCollection>(_ c: C)
     where C.RawIterator.Pointee == Element {
 
@@ -61,6 +64,7 @@ extension Set {
   ///
   /// - Complexity: O(*n*), where *n* is the number of elements in the C++
   ///   collection.
+  @available(SwiftStdlib 5.8, *)
   public init<C: CxxConvertibleToCollection>(_ c: C)
     where C.RawIterator.Pointee == Element {
 

--- a/stdlib/public/Cxx/CxxRandomAccessCollection.swift
+++ b/stdlib/public/Cxx/CxxRandomAccessCollection.swift
@@ -17,6 +17,7 @@
 /// protocol and should not generally be used directly.
 ///
 /// - SeeAlso: https://en.cppreference.com/w/cpp/named_req/RandomAccessIterator
+@available(SwiftStdlib 5.8, *)
 public protocol UnsafeCxxRandomAccessIterator: UnsafeCxxInputIterator {
   associatedtype Distance: BinaryInteger
 
@@ -24,10 +25,13 @@ public protocol UnsafeCxxRandomAccessIterator: UnsafeCxxInputIterator {
   static func +=(lhs: inout Self, rhs: Distance)
 }
 
+@available(SwiftStdlib 5.8, *)
 extension UnsafePointer: UnsafeCxxRandomAccessIterator {}
 
+@available(SwiftStdlib 5.8, *)
 extension UnsafeMutablePointer: UnsafeCxxRandomAccessIterator {}
 
+@available(SwiftStdlib 5.8, *)
 public protocol CxxRandomAccessCollection: CxxSequence, RandomAccessCollection {
   override associatedtype RawIterator: UnsafeCxxRandomAccessIterator
   override associatedtype Iterator = CxxIterator<Self>
@@ -43,6 +47,7 @@ public protocol CxxRandomAccessCollection: CxxSequence, RandomAccessCollection {
   func __endUnsafe() -> RawIterator
 }
 
+@available(SwiftStdlib 5.8, *)
 extension CxxRandomAccessCollection {
   @inlinable
   public var startIndex: Int {

--- a/stdlib/public/Cxx/CxxSequence.swift
+++ b/stdlib/public/Cxx/CxxSequence.swift
@@ -17,6 +17,7 @@
 /// not generally be used directly.
 ///
 /// - SeeAlso: https://en.cppreference.com/w/cpp/named_req/InputIterator
+@available(SwiftStdlib 5.8, *)
 public protocol UnsafeCxxInputIterator: Equatable {
   associatedtype Pointee
 
@@ -33,10 +34,13 @@ public protocol UnsafeCxxInputIterator: Equatable {
   func successor() -> Self
 }
 
+@available(SwiftStdlib 5.8, *)
 extension UnsafePointer: UnsafeCxxInputIterator {}
 
+@available(SwiftStdlib 5.8, *)
 extension UnsafeMutablePointer: UnsafeCxxInputIterator {}
 
+@available(SwiftStdlib 5.8, *)
 extension Optional: UnsafeCxxInputIterator where Wrapped: UnsafeCxxInputIterator {
   public typealias Pointee = Wrapped.Pointee
 
@@ -63,6 +67,7 @@ extension Optional: UnsafeCxxInputIterator where Wrapped: UnsafeCxxInputIterator
 /// This requires the C++ sequence type to define const methods `begin()` and
 /// `end()` which return input iterators into the C++ sequence. The iterator
 /// types must conform to `UnsafeCxxInputIterator`.
+@available(SwiftStdlib 5.8, *)
 public protocol CxxSequence: Sequence {
   associatedtype RawIterator: UnsafeCxxInputIterator
   override associatedtype Element = RawIterator.Pointee
@@ -82,6 +87,7 @@ public protocol CxxSequence: Sequence {
 
 /// Prevents a C++ sequence from being copied or moved implicitly. Makes sure
 /// that raw C++ iterators pointing into the sequence are not invalidated.
+@available(SwiftStdlib 5.8, *)
 @usableFromInline
 internal final class CxxSequenceBox<T> where T: CxxSequence {
   @usableFromInline
@@ -93,6 +99,7 @@ internal final class CxxSequenceBox<T> where T: CxxSequence {
   }
 }
 
+@available(SwiftStdlib 5.8, *)
 @frozen
 public struct CxxIterator<T>: IteratorProtocol where T: CxxSequence {
   public typealias Element = T.RawIterator.Pointee
@@ -122,6 +129,7 @@ public struct CxxIterator<T>: IteratorProtocol where T: CxxSequence {
   }
 }
 
+@available(SwiftStdlib 5.8, *)
 extension CxxSequence {
   @inlinable
   public func makeIterator() -> CxxIterator<Self> {


### PR DESCRIPTION
Until we have a back-deployment story for the `Cxx` module, let's explicitly provide availability attributes to prevent users from accidentally using the new symbols in a back-deployed app.