### PR TITLE
Disable resilient_multipayload_enum.swift test that fails on older runtimes

### DIFF
--- a/test/Interpreter/resilient_multipayload_enum.swift
+++ b/test/Interpreter/resilient_multipayload_enum.swift
@@ -16,6 +16,9 @@
 
 // REQUIRES: executable_test
 
+// Older runtimes have a bug (fixed by PR#42131) that causes this test to fail.
+// UNSUPPORTED: use_os_stdlib || back_deployment_runtime
+
 import ResilientEnum
 
 @inline(never)


### PR DESCRIPTION

Older runtimes have a bug that was fixed by PR #42131 that this test exercises.

rdar://99099912
