### PR TITLE
[Gardening] Remove trailing whitespaces in Python scripts. (W291)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -51,9 +51,6 @@ ignore =
     # compliant (https://github.com/psf/black#slices).
     E203,
 
-    # FIXME: We should not have trailing whitespace.
-    W291,
-
     # Line breaks before binary operators are not explicitly disallowed in
     # PEP8, rather it should be consistent throughout the project. The black
     # tool puts them on new lines which is to be considered a best practice

--- a/benchmark/scripts/create_benchmark.py
+++ b/benchmark/scripts/create_benchmark.py
@@ -61,7 +61,7 @@ def create_benchmark_file(name):
 
 
 def add_import_benchmark(name):
-    """Adds an `import` statement to the `main.swift` file for the new 
+    """Adds an `import` statement to the `main.swift` file for the new
     benchmark.
     """
     relative_path = create_relative_path("../utils/main.swift")

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -352,7 +352,7 @@ def create_argument_parser():
            help='enable code coverage analysis in Swift (false, not-merged, '
                 'merged).')
 
-    option('--swift-disable-dead-stripping', toggle_true, 
+    option('--swift-disable-dead-stripping', toggle_true,
            help="Turn off Darwin-specific dead stripping for Swift host tools")
 
     option('--build-subdir', store,

--- a/utils/build_swift/build_swift/presets.py
+++ b/utils/build_swift/build_swift/presets.py
@@ -352,9 +352,9 @@ class PresetParser(object):
     def _interpolate_preset_vars(self, preset, vars):
         interpolated_options = []
         for (name, value) in preset.options:
-            # If the option is a key-value pair, e.g. 
+            # If the option is a key-value pair, e.g.
             # install-destdir=%(install_dir)s
-            # interpolate the value. If it is a raw option, e.g. 
+            # interpolate the value. If it is a raw option, e.g.
             # %(some_flag)s
             # is a raw option without a value, expand the name.
             if value:

--- a/utils/gyb_syntax_support/CommonNodes.py
+++ b/utils/gyb_syntax_support/CommonNodes.py
@@ -59,7 +59,7 @@ COMMON_NODES = [
              Child('LeftBrace', kind='LeftBraceToken'),
              Child('Statements', kind='CodeBlockItemList',
                    collection_element_name='Statement', is_indented=True),
-             Child('RightBrace', kind='RightBraceToken', 
+             Child('RightBrace', kind='RightBraceToken',
                    requires_leading_newline=True),
          ]),
 

--- a/utils/gyb_syntax_support/ExprNodes.py
+++ b/utils/gyb_syntax_support/ExprNodes.py
@@ -446,7 +446,7 @@ EXPR_NODES = [
 
     Node('ClosureSignature', kind='Syntax',
          children=[
-             Child('Attributes', kind='AttributeList', 
+             Child('Attributes', kind='AttributeList',
                    collection_element_name='Attribute', is_optional=True),
              Child('Capture', kind='ClosureCaptureSignature',
                    is_optional=True),
@@ -568,7 +568,7 @@ EXPR_NODES = [
          traits=['Parenthesized'],
          children=[
              Child('Backslash', kind='BackslashToken'),
-             Child('Delimiter', kind='RawStringDelimiterToken', 
+             Child('Delimiter', kind='RawStringDelimiterToken',
                    is_optional=True),
              Child('LeftParen', kind='LeftParenToken',
                    classification='StringInterpolationAnchor',
@@ -581,7 +581,7 @@ EXPR_NODES = [
     # e.g. "abc \(foo()) def"
     Node('StringLiteralExpr', kind='Expr',
          children=[
-             Child('OpenDelimiter', kind='RawStringDelimiterToken', 
+             Child('OpenDelimiter', kind='RawStringDelimiterToken',
                    is_optional=True),
              Child('OpenQuote', kind='Token',
                    token_choices=[
@@ -595,7 +595,7 @@ EXPR_NODES = [
                        'StringQuoteToken',
                        'MultilineStringQuoteToken',
                    ]),
-             Child('CloseDelimiter', kind='RawStringDelimiterToken', 
+             Child('CloseDelimiter', kind='RawStringDelimiterToken',
                    is_optional=True),
          ]),
 

--- a/utils/gyb_syntax_support/Node.py
+++ b/utils/gyb_syntax_support/Node.py
@@ -13,7 +13,7 @@ class Node(object):
 
     def __init__(self, name, description=None, kind=None, traits=None,
                  children=[], element=None, element_name=None,
-                 element_choices=None, omit_when_empty=False, 
+                 element_choices=None, omit_when_empty=False,
                  elements_separated_by_newline=False):
         self.syntax_kind = name
         self.element_name = element_name
@@ -24,7 +24,7 @@ class Node(object):
 
         self.traits = traits or []
         self.children = []
-        # Add implicitly generated UnexpectedNodes children in between any two 
+        # Add implicitly generated UnexpectedNodes children in between any two
         # defined children
         if kind != 'SyntaxCollection':
             for i in range(2 * len(children)):
@@ -35,8 +35,8 @@ class Node(object):
                         name = 'UnexpectedBetween%sAnd%s' % \
                             (children[int(i / 2) - 1].name, children[int(i / 2)].name)
                     self.children.append(Child(
-                        name, 
-                        kind='UnexpectedNodes', 
+                        name,
+                        kind='UnexpectedNodes',
                         collection_element_name=name,
                         is_optional=True
                     ))

--- a/utils/gyb_syntax_support/StmtNodes.py
+++ b/utils/gyb_syntax_support/StmtNodes.py
@@ -75,14 +75,14 @@ STMT_NODES = [
              Child('GuardResult', kind='Expr'),
          ]),
 
-    # for-in-stmt -> label? ':'? 
+    # for-in-stmt -> label? ':'?
     #   'for' 'try'? 'await'? 'case'? pattern 'in' expr 'where'?
     #   expr code-block ';'?
     Node('ForInStmt', kind='Stmt',
          traits=['WithCodeBlock'],
          children=[
              Child('ForKeyword', kind='ForToken'),
-             Child('TryKeyword', kind='TryToken', 
+             Child('TryKeyword', kind='TryToken',
                    is_optional=True),
              Child('AwaitKeyword', kind='IdentifierToken',
                    classification='Keyword',

--- a/utils/gyb_syntax_support/Token.py
+++ b/utils/gyb_syntax_support/Token.py
@@ -232,7 +232,7 @@ SYNTAX_TOKENS = [
                serialization_code=92),
     Punctuator('RightSquareBracket', 'r_square', text=']',
                serialization_code=93),
-    Punctuator('LeftAngle', 'l_angle', text='<', requires_leading_space=True, 
+    Punctuator('LeftAngle', 'l_angle', text='<', requires_leading_space=True,
                requires_trailing_space=True, serialization_code=94),
     Punctuator('RightAngle', 'r_angle', text='>', requires_leading_space=True,
                requires_trailing_space=True, serialization_code=95),
@@ -253,7 +253,7 @@ SYNTAX_TOKENS = [
     Punctuator('Pound', 'pound', text='#', serialization_code=81),
 
     Punctuator('PrefixAmpersand', 'amp_prefix', text='&',
-               requires_leading_space=True, requires_trailing_space=True, 
+               requires_leading_space=True, requires_trailing_space=True,
                serialization_code=96),
     Punctuator('Arrow', 'arrow', text='->', requires_leading_space=True,
                requires_trailing_space=True, serialization_code=78),

--- a/utils/gyb_syntax_support/__init__.py
+++ b/utils/gyb_syntax_support/__init__.py
@@ -129,7 +129,7 @@ def make_missing_swift_child(child):
         elif child.syntax_kind in SYNTAX_BASE_KINDS:
             missing_kind = f"missing{child.syntax_kind}"
         else:
-            missing_kind = child.swift_syntax_kind 
+            missing_kind = child.swift_syntax_kind
         return f'RawSyntax.makeEmptyLayout(kind: SyntaxKind.{missing_kind}, ' + \
             'arena: .default)'
 

--- a/utils/scale-test
+++ b/utils/scale-test
@@ -173,7 +173,7 @@ def run_once_with_primary(args, ast, rng, primary_idx):
         if not args.save_temps:
             shutil.rmtree(d)
 
-    return {k: v for (k, v) in r.items() if args.select in k and 
+    return {k: v for (k, v) in r.items() if args.select in k and
             not (args.exclude_timers and k.startswith('time.'))}
 
 

--- a/utils/swift_build_support/swift_build_support/build_script_invocation.py
+++ b/utils/swift_build_support/swift_build_support/build_script_invocation.py
@@ -636,7 +636,7 @@ class BuildScriptInvocation(object):
         builder.add_product(products.SwiftDocC,
                             is_enabled=self.args.build_swiftdocc)
         builder.add_product(products.SwiftDocCRender,
-                            is_enabled=self.args.install_swiftdocc)                  
+                            is_enabled=self.args.install_swiftdocc)
 
         # Keep SwiftDriver at last.
         # swift-driver's integration with the build scripts is not fully

--- a/utils/swift_build_support/swift_build_support/products/swiftsyntax.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftsyntax.py
@@ -78,7 +78,7 @@ class SwiftSyntax(product.Product):
             self.run_swiftsyntax_build_script(target=host_target,
                                               command='verify-source-code')
 
-        self.run_swiftsyntax_build_script(target=host_target, 
+        self.run_swiftsyntax_build_script(target=host_target,
                                           command='build')
 
     def should_test(self, host_target):
@@ -91,9 +91,9 @@ class SwiftSyntax(product.Product):
         self.run_swiftsyntax_build_script(target=host_target,
                                           command='test',
                                           additional_params=[
-                                              '--filecheck-exec', 
-                                              os.path.join(llvm_build_dir, 
-                                                           'bin', 
+                                              '--filecheck-exec',
+                                              os.path.join(llvm_build_dir,
+                                                           'bin',
                                                            'FileCheck')
                                           ])
 
@@ -101,8 +101,8 @@ class SwiftSyntax(product.Product):
         return self.args.install_swiftsyntax
 
     def install(self, target_name):
-        # SwiftSyntax doesn't produce any products thate should be installed 
-        # into the toolchein. All tools using it link against SwiftSyntax 
+        # SwiftSyntax doesn't produce any products thate should be installed
+        # into the toolchein. All tools using it link against SwiftSyntax
         # statically.
         pass
 

--- a/utils/update_checkout/tests/test_update_worktree.py
+++ b/utils/update_checkout/tests/test_update_worktree.py
@@ -29,8 +29,8 @@ def setup_worktree(workspace_path, local_path, worktree_name):
     for project in os.listdir(local_path):
         local_project_path = os.path.join(local_path, project)
         worktree_project_path = os.path.join(worktree_path, project)
-        call_quietly(['git', 
-                      '-C', local_project_path, 
+        call_quietly(['git',
+                      '-C', local_project_path,
                       'worktree', 'add', worktree_project_path])
 
 
@@ -39,8 +39,8 @@ def teardown_worktree(workspace_path, local_path, worktree_name):
     for project in os.listdir(local_path):
         local_project_path = os.path.join(local_path, project)
         worktree_project_path = os.path.join(worktree_path, project)
-        call_quietly(['git', 
-                      '-C', local_project_path, 
+        call_quietly(['git',
+                      '-C', local_project_path,
                       'worktree', 'remove', worktree_project_path])
 
 

--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -509,7 +509,7 @@ repositories.
         action="append")
     parser.add_argument(
         "--all-repositories",
-        help="""Includes repositories not required for current platform. 
+        help="""Includes repositories not required for current platform.
         This will not override '--skip-repositories'""",
         action='store_true')
     parser.add_argument(


### PR DESCRIPTION
That has been marked as 'FIXME' for three years.
This PR fixes it.

(Last mowing: https://github.com/apple/swift/pull/20829)