### PR TITLE
Reduce semantic dependencies in contextRequiresStrictConcurrencyChecking

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3115,6 +3115,23 @@ swift::determineClosureActorIsolation(AbstractClosureExpr *closure) {
   return checker.determineClosureIsolation(closure);
 }
 
+/// Determine whethere there is an explicit isolation attribute
+/// of any kind.
+static bool hasExplicitIsolationAttribute(const Decl *decl) {
+  if (auto nonisolatedAttr =
+      decl->getAttrs().getAttribute<NonisolatedAttr>()) {
+    if (!nonisolatedAttr->isImplicit())
+      return true;
+  }
+
+  if (auto globalActorAttr = decl->getGlobalActorAttr()) {
+    if (!globalActorAttr->first->isImplicit())
+      return true;
+  }
+
+  return false;
+}
+
 /// Determine actor isolation solely from attributes.
 ///
 /// \returns the actor isolation determined from attributes alone (with no
@@ -4085,8 +4102,7 @@ bool swift::contextRequiresStrictConcurrencyChecking(
     } else if (auto decl = dc->getAsDecl()) {
       // If any isolation attributes are present, we're using concurrency
       // features.
-      if (getIsolationFromAttributes(
-              decl, /*shouldDiagnose=*/false, /*onlyExplicit=*/true))
+      if (hasExplicitIsolationAttribute(decl))
         return true;
 
       if (auto func = dyn_cast<AbstractFunctionDecl>(decl)) {
@@ -4097,9 +4113,7 @@ bool swift::contextRequiresStrictConcurrencyChecking(
         // If we're in an accessor declaration, also check the storage
         // declaration.
         if (auto accessor = dyn_cast<AccessorDecl>(decl)) {
-          if (getIsolationFromAttributes(
-                  accessor->getStorage(), /*shouldDiagnose=*/false,
-                  /*onlyExplicit=*/true))
+          if (hasExplicitIsolationAttribute(accessor->getStorage()))
             return true;
         }
       }


### PR DESCRIPTION
We don't need fully-checked isolation as computed from attributes to
determine whether we're in a concurrency context. Use a cheaper predicate,
which can also avoid spurious cycles.

Fixes rdar://99013488.
