### PR TITLE
[C++ Interop] Support C++ parameters in Obj-C++ methods.

### DIFF
--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1371,6 +1371,18 @@ public:
   ///        being imported.
   /// \param allowNSUIntegerAsInt If true, NSUInteger will be import as Int
   ///        in certain contexts. If false, it will always be import as UInt.
+  /// \param isNSDictionarySubscriptGetter If true, the parameter is being
+  ///        imported as part of an NSDictionary subscript getter. If false,
+  ///        the parameter belongs to some other kind of method/function.
+  /// \param paramIsError If true, the parameter being imported is an NSError
+  ///        parameter. If false, the parameter is not an error parameter.
+  /// \param paramIsCompletionHandler If true, the parameter being imported is
+  ///        a completion handler. If false, the parameter is not a completion
+  ///        handler.
+  /// \param completionHandlerErrorParamIndex If it contains a value, the value
+  ///        indicates the index of the completion handler whose error
+  ///        parameter is used to indicate throwing. If None, the function does
+  ///        not have such parameter.
   /// \param genericParams For C++ functions, an array of the generic type
   ///        parameters of the function. For the rest of cases, an empty array
   ///        can be provided.
@@ -1386,7 +1398,10 @@ public:
   /// \returns The imported parameter type on success, or None on failure.
   Optional<swift::Type> importParameterType(
       const clang::ParmVarDecl *param, OptionalTypeKind optionalityOfParam,
-      bool allowNSUIntegerAsInt, ArrayRef<GenericTypeParamDecl *> genericParams,
+      bool allowNSUIntegerAsInt, bool isNSDictionarySubscriptGetter,
+      bool paramIsError, bool paramIsCompletionHandler,
+      Optional<unsigned> completionHandlerErrorParamIndex,
+      ArrayRef<GenericTypeParamDecl *> genericParams,
       llvm::function_ref<void(Diagnostic &&)> addImportDiagnosticFn,
       bool &isInOut, bool &isParamTypeImplicitlyUnwrapped);
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1364,6 +1364,32 @@ public:
       bool allowNSUIntegerAsInt, ArrayRef<Identifier> argNames,
       ArrayRef<GenericTypeParamDecl *> genericParams, Type resultType);
 
+  /// Import a parameter type
+  ///
+  /// \param param The underlaying parameter declaraction.
+  /// \param optionalityOfParam The kind of optionality for the parameter
+  ///        being imported.
+  /// \param allowNSUIntegerAsInt If true, NSUInteger will be import as Int
+  ///        in certain contexts. If false, it will always be import as UInt.
+  /// \param genericParams For C++ functions, an array of the generic type
+  ///        parameters of the function. For the rest of cases, an empty array
+  ///        can be provided.
+  /// \param addImportDiagnosticFn A function that can be called to add import
+  ///        diagnostics to the declaration being imported. This can be any
+  ///        lambda or callable object, but it's designed to be compatible
+  ///        with \c ImportDiagnosticAdder .
+  /// \param[out] isInOut On return, true if the parameter is inout. False,
+  ///             otherwise.
+  /// \param[out] isParamTypeImplicitlyUnwrapped On return, true if the
+  ///             parameter is implicitly unwrapped. False, otherwise.
+  ///
+  /// \returns The imported parameter type on success, or None on failure.
+  Optional<swift::Type> importParameterType(
+      const clang::ParmVarDecl *param, OptionalTypeKind optionalityOfParam,
+      bool allowNSUIntegerAsInt, ArrayRef<GenericTypeParamDecl *> genericParams,
+      llvm::function_ref<void(Diagnostic &&)> addImportDiagnosticFn,
+      bool &isInOut, bool &isParamTypeImplicitlyUnwrapped);
+
   ImportedType importPropertyType(const clang::ObjCPropertyDecl *clangDecl,
                                   bool isFromSystemModule);
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1364,6 +1364,15 @@ public:
       bool allowNSUIntegerAsInt, ArrayRef<Identifier> argNames,
       ArrayRef<GenericTypeParamDecl *> genericParams, Type resultType);
 
+  struct ImportParameterTypeResult {
+    /// The imported parameter Swift type.
+    swift::Type swiftTy;
+    /// If the parameter is or not inout.
+    bool isInOut;
+    /// If the parameter is implicitly unwrapped or not.
+    bool isParamTypeImplicitlyUnwrapped;
+  };
+
   /// Import a parameter type
   ///
   /// \param param The underlaying parameter declaraction.
@@ -1390,20 +1399,15 @@ public:
   ///        diagnostics to the declaration being imported. This can be any
   ///        lambda or callable object, but it's designed to be compatible
   ///        with \c ImportDiagnosticAdder .
-  /// \param[out] isInOut On return, true if the parameter is inout. False,
-  ///             otherwise.
-  /// \param[out] isParamTypeImplicitlyUnwrapped On return, true if the
-  ///             parameter is implicitly unwrapped. False, otherwise.
   ///
-  /// \returns The imported parameter type on success, or None on failure.
-  Optional<swift::Type> importParameterType(
+  /// \returns The imported parameter result on success, or None on failure.
+  Optional<ImportParameterTypeResult> importParameterType(
       const clang::ParmVarDecl *param, OptionalTypeKind optionalityOfParam,
       bool allowNSUIntegerAsInt, bool isNSDictionarySubscriptGetter,
       bool paramIsError, bool paramIsCompletionHandler,
       Optional<unsigned> completionHandlerErrorParamIndex,
       ArrayRef<GenericTypeParamDecl *> genericParams,
-      llvm::function_ref<void(Diagnostic &&)> addImportDiagnosticFn,
-      bool &isInOut, bool &isParamTypeImplicitlyUnwrapped);
+      llvm::function_ref<void(Diagnostic &&)> addImportDiagnosticFn);
 
   ImportedType importPropertyType(const clang::ObjCPropertyDecl *clangDecl,
                                   bool isFromSystemModule);

--- a/test/Interop/Cxx/objc-correctness/Inputs/module.modulemap
+++ b/test/Interop/Cxx/objc-correctness/Inputs/module.modulemap
@@ -2,3 +2,4 @@ module ProtocolNamingConflict [extern_c] {
   header "protocol-naming-conflict.h"
   requires objc
 }
+

--- a/test/Interop/Cxx/reference/Inputs/const-ref-parameter.h
+++ b/test/Interop/Cxx/reference/Inputs/const-ref-parameter.h
@@ -1,0 +1,22 @@
+#import <Foundation/Foundation.h>
+
+struct OptionsStruct {
+  int intOption;
+  float floatOption;
+};
+
+@interface OptionsConsumerObjC : NSObject
+
+- (nonnull instancetype)initWithOptions:(const OptionsStruct &)options;
++ (nonnull instancetype)consumerWithOptions:(const OptionsStruct &)options;
++ (int)doThingWithOptions:(const OptionsStruct &)options;
+- (float)doOtherThingWithOptions:(const OptionsStruct &)options;
+
+@end
+
+struct OptionsConsumerCxx {
+  OptionsConsumerCxx(const OptionsStruct &options);
+  static OptionsConsumerCxx build(const OptionsStruct &options);
+  static int doThing(const OptionsStruct &options);
+  float doOtherThing(const OptionsStruct &options);
+};

--- a/test/Interop/Cxx/reference/Inputs/module.modulemap
+++ b/test/Interop/Cxx/reference/Inputs/module.modulemap
@@ -7,3 +7,9 @@ module Closures {
   header "closures.h"
   requires cplusplus
 }
+
+module ConstRefParameter {
+  header "const-ref-parameter.h"
+  requires objc
+  requires cplusplus
+}

--- a/test/Interop/Cxx/reference/const-ref-parameter.swift
+++ b/test/Interop/Cxx/reference/const-ref-parameter.swift
@@ -1,0 +1,77 @@
+// REQUIRES: objc_interop
+
+import ConstRefParameter
+
+func testFunction() {
+    let a = OptionsStruct(intOption: 1, floatOption: 2.0)
+
+    let objc = OptionsConsumerObjC(options: a)
+    _ = objc.doOtherThing(withOptions: a)
+    _ = OptionsConsumerObjC.consumer(withOptions: a)
+    _ = OptionsConsumerObjC.doThing(withOptions: a)
+
+    var cxx = OptionsConsumerCxx(a)
+    _ = cxx.doOtherThing(a)
+    _ = OptionsConsumerCxx.build(a)
+    _ = OptionsConsumerCxx.doThing(a)
+}
+
+// RUN: %target-swift-ide-test -print-module -module-to-print=ConstRefParameter -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop -enable-objc-interop | %FileCheck -check-prefix=CHECK-IDE-TEST %s
+
+// CHECK-IDE-TEST: class OptionsConsumerObjC
+// CHECK-IDE-TEST: init(options: OptionsStruct)
+// COM: FIXME: should it be consumer(options:)?
+// CHECK-IDE-TEST: class func consumer(withOptions options: OptionsStruct) -> Self
+// COM: FIXME: should it be doThing(options:)?
+// CHECK-IDE-TEST: class func doThing(withOptions options: OptionsStruct) -> Int32
+// COM: FIXME: should it be doOtherThing(options:)?
+// CHECK-IDE-TEST: func doOtherThing(withOptions options: OptionsStruct) -> Float
+
+// CHECK-IDE-TEST: struct OptionsConsumerCxx
+// CHECK-IDE-TEST: init(_ options: OptionsStruct)
+// CHECK-IDE-TEST: static func build(_ options: OptionsStruct) -> OptionsConsumerCxx
+// CHECK-IDE-TEST: static func doThing(_ options: OptionsStruct) -> Int32
+// CHECK-IDE-TEST: mutating func doOtherThing(_ options: OptionsStruct) -> Float
+
+
+// RUN: %target-swift-frontend -c -enable-experimental-cxx-interop -enable-objc-interop -I %S/Inputs %s -emit-silgen -o - | %FileCheck %s
+
+// COM: FIXME: should it be @in_guaranteed OptionsStruct? https://github.com/apple/swift/issues/60601
+// CHECK: [[FN1:%[0-9]+]] = function_ref @$sSo19OptionsConsumerObjCC7optionsABSo0A6StructV_tcfC : $@convention(method) (OptionsStruct, @thick OptionsConsumerObjC.Type) -> @owned OptionsConsumerObjC
+// CHECK-NEXT: apply [[FN1]]
+// CHECK-SAME: : $@convention(method) (OptionsStruct, @thick OptionsConsumerObjC.Type) -> @owned OptionsConsumerObjC
+
+// COM: FIXME: should it be @in_guaranteed OptionStruct? https://github.com/apple/swift/issues/60601
+// CHECK: [[FN2:%[0-9]+]] = objc_method {{%[0-9]+}} : $OptionsConsumerObjC, #OptionsConsumerObjC.doOtherThing!foreign : (OptionsConsumerObjC) -> (OptionsStruct) -> Float, $@convention(objc_method) (@in OptionsStruct, OptionsConsumerObjC) -> Float
+// CHECK-NEXT: apply [[FN2]]
+// CHECK-SAME: : $@convention(objc_method) (@in OptionsStruct, OptionsConsumerObjC) -> Float
+
+// COM: FIXME: should it be @in_guaranteed OptionStruct? https://github.com/apple/swift/issues/60601
+// CHECK: [[FN3:%[0-9]+]] = objc_method {{%[0-9]+}} : $@objc_metatype OptionsConsumerObjC.Type, #OptionsConsumerObjC.consumer!foreign : (OptionsConsumerObjC.Type) -> (OptionsStruct) -> @dynamic_self OptionsConsumerObjC, $@convention(objc_method) (@in OptionsStruct, @objc_metatype OptionsConsumerObjC.Type) -> @autoreleased OptionsConsumerObjC
+// CHECK-NEXT: apply [[FN3]]
+// CHECK-SAME: : $@convention(objc_method) (@in OptionsStruct, @objc_metatype OptionsConsumerObjC.Type) -> @autoreleased OptionsConsumerObjC
+
+// COM: FIXME: should it be @in_guaranteed OptionStruct? https://github.com/apple/swift/issues/60601
+// CHECK: [[FN4:%[0-9]+]] = objc_method {{%[0-9]+}} : $@objc_metatype OptionsConsumerObjC.Type, #OptionsConsumerObjC.doThing!foreign : (OptionsConsumerObjC.Type) -> (OptionsStruct) -> Int32, $@convention(objc_method) (@in OptionsStruct, @objc_metatype OptionsConsumerObjC.Type) -> Int32
+// CHECK-NEXT: apply [[FN4]]
+// CHECK-SAME: : $@convention(objc_method) (@in OptionsStruct, @objc_metatype OptionsConsumerObjC.Type) -> Int32
+
+// COM: FIXME: should it be @in_guaranteed OptionStruct? https://github.com/apple/swift/issues/60601
+// CHECK: [[FN5:%[0-9]+]] = function_ref @_ZN18OptionsConsumerCxxC1ERK13OptionsStruct : $@convention(c) (OptionsStruct) -> @out OptionsConsumerCxx
+// CHECK-NEXT: apply [[FN5]]
+// CHECK-SAME: : $@convention(c) (OptionsStruct) -> @out OptionsConsumerCxx
+
+// COM: FIXME: should it be @in_guaranteed OptionStruct? https://github.com/apple/swift/issues/60601
+// CHECK: [[FN6:%[0-9]+]] = function_ref @_ZN18OptionsConsumerCxx12doOtherThingERK13OptionsStruct : $@convention(cxx_method) (@in OptionsStruct, @inout OptionsConsumerCxx) -> Float
+// CHECK-NEXT: apply [[FN6]]
+// CHECK-SAME: : $@convention(cxx_method) (@in OptionsStruct, @inout OptionsConsumerCxx) -> Float
+
+// COM: FIXME: should it be @in_guaranteed OptionStruct? https://github.com/apple/swift/issues/60601
+// CHECK: [[FN6:%[0-9]+]] = function_ref @_ZN18OptionsConsumerCxx5buildERK13OptionsStruct : $@convention(c) (@in OptionsStruct) -> OptionsConsumerCxx
+// CHECK-NEXT: apply [[FN6]]
+// CHECK-SAME: : $@convention(c) (@in OptionsStruct) -> OptionsConsumerCxx
+
+// COM: FIXME: should it be @in_guaranteed OptionStruct? https://github.com/apple/swift/issues/60601
+// CHECK: [[FN7:%[0-9]+]] = function_ref @_ZN18OptionsConsumerCxx7doThingERK13OptionsStruct : $@convention(c) (@in OptionsStruct) -> Int32
+// CHECK-NEXT: apply [[FN7]]
+// CHECK-SAME: : $@convention(c) (@in OptionsStruct) -> Int32


### PR DESCRIPTION
`importMethodParamsAndReturnType` and `importFunctionParameterList`
share a lot of code but differed in how they treated C++ types.

Extract the common code and merge the differences in code between the
two functions into one single function and use it from both places. At the
end it needs also a small function to account for the slightly different way
Obj-C methods deal with error and completion callbacks.

NOTE: Even if `const T&` parameters are now correctly imported as `T` at
the Swift level, in the case of initializers they are not correctly
imported as `@in T` and a crash will occur when using them.

Relates to #60638

/cc @plotfi @bulbazord 