### PR TITLE
IRGen: Only use clang type based task continuation function pointer descriminator schema if descrimination is requested

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -2732,8 +2732,9 @@ public:
     if (auto schema = IGF.IGM.getOptions().PointerAuth.FunctionPointers) {
       // Use the Clang type for TaskContinuationFunction*
       // to make this work with type diversity.
-      schema =
-          IGF.IGM.getOptions().PointerAuth.ClangTypeTaskContinuationFunction;
+      if (schema.hasOtherDiscrimination())
+        schema =
+            IGF.IGM.getOptions().PointerAuth.ClangTypeTaskContinuationFunction;
       auto authInfo =
           PointerAuthInfo::emit(IGF, schema, nullptr, PointerAuthEntity());
       signedResumeFn = emitPointerAuthSign(IGF, signedResumeFn, authInfo);

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -2471,7 +2471,8 @@ llvm::Function *IRGenFunction::createAsyncSuspendFn() {
   if (auto schema = IGM.getOptions().PointerAuth.FunctionPointers) {
     // Use the Clang type for TaskContinuationFunction*
     // to make this work with type diversity.
-    schema = IGM.getOptions().PointerAuth.ClangTypeTaskContinuationFunction;
+    if (schema.hasOtherDiscrimination())
+      schema = IGM.getOptions().PointerAuth.ClangTypeTaskContinuationFunction;
     auto authInfo = PointerAuthInfo::emit(suspendIGF, schema, nullptr,
                                           PointerAuthEntity());
     resumeFunction = emitPointerAuthSign(suspendIGF, resumeFunction, authInfo);


### PR DESCRIPTION

rdar://99142574
