### PR TITLE
[cxx-interop] Don't import constructors of foreign reference types.

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4940,6 +4940,10 @@ TinyPtrVector<ValueDecl *> ClangRecordMemberLookup::evaluate(
     auto named = found.get<clang::NamedDecl *>();
     if (dyn_cast<clang::Decl>(named->getDeclContext()) ==
         recordDecl->getClangDecl()) {
+      // Don't import constructors on foreign reference types.
+      if (isa<clang::CXXConstructorDecl>(named) && isa<ClassDecl>(recordDecl))
+        continue;
+
       if (auto import = clangModuleLoader->importDeclDirectly(named))
         result.push_back(cast<ValueDecl>(import));
     }

--- a/test/Interop/Cxx/foreign-reference/no-ctor-errors.swift
+++ b/test/Interop/Cxx/foreign-reference/no-ctor-errors.swift
@@ -1,0 +1,25 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: not %target-swift-frontend -typecheck -I %t/Inputs  %t/test.swift  -enable-experimental-cxx-interop 2>&1 | %FileCheck %s
+
+//--- Inputs/module.modulemap
+module Test {
+    header "test.h"
+    requires cplusplus
+}
+
+//--- Inputs/test.h
+struct
+    __attribute__((swift_attr("import_reference")))
+    __attribute__((swift_attr("retain:immortal")))
+    __attribute__((swift_attr("release:immortal")))
+HasCtor {
+  HasCtor(int a) {}
+};
+
+//--- test.swift
+
+import Test
+
+// CHECK: error: 'HasCtor' cannot be constructed because it has no accessible initializers
+let x = HasCtor(42)


### PR DESCRIPTION
The logic is here for this in the importer, which means the module interface tests make it appear that the behavior is correct, but lazy member lookup still finds the constructors, so this patch fixes that part.