### PR TITLE
Fix a potential use-after-free in lazy global emission.

### DIFF
--- a/validation-test/IRGen/98995607.swift.gyb
+++ b/validation-test/IRGen/98995607.swift.gyb
@@ -1,0 +1,21 @@
+// RUN: %target-run-simple-swiftgyb
+
+%for N in range(0, 100):
+
+protocol P${N}<A, B> {
+  associatedtype A
+  associatedtype B
+}
+
+%end
+
+var array : [Any.Type] = [
+%for N in range(0, 100):
+  (any P${N}<Int, Float>).self,
+%end
+%for N in range(0, 100):
+  (any P${N}<Float, String>).self,
+%end
+]
+
+print(array)


### PR DESCRIPTION
Extended existential type shapes can trigger this by introducing more entities (and thus causing GlobalVars to be rehashed) during the lazy-emission callback.

Fixes rdar://98995607