### PR TITLE
[5.7] Fix a potential use-after-free in lazy global emission

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3437,9 +3437,9 @@ IRGenModule::getAddrOfLLVMVariable(LinkEntity entity,
     ? overrideDeclType
     : entity.getDefaultDeclarationType(*this);
   
-  auto &entry = GlobalVars[entity];
-  if (entry) {
-    auto existing = cast<llvm::GlobalValue>(entry);
+  auto existingGlobal = GlobalVars[entity];
+  if (existingGlobal) {
+    auto existing = cast<llvm::GlobalValue>(existingGlobal);
 
     // If we're looking to define something, we may need to replace a
     // forward declaration.
@@ -3459,12 +3459,12 @@ IRGenModule::getAddrOfLLVMVariable(LinkEntity entity,
 
       // Fall out to the case below, clearing the name so that
       // createVariable doesn't detect a collision.
-      entry->setName("");
+      existingGlobal->setName("");
 
     // Otherwise, we have a previous declaration or definition which
     // we need to ensure has the right type.
     } else {
-      return getElementBitCast(entry, defaultType);
+      return getElementBitCast(existingGlobal, defaultType);
     }
   }
 
@@ -3508,11 +3508,17 @@ IRGenModule::getAddrOfLLVMVariable(LinkEntity entity,
     lazyInitializer->Create(var);
   }
 
+  if (lazyInitializer) {
+    // Protect against self-references that might've been created during
+    // the lazy emission.
+    existingGlobal = GlobalVars[entity];
+  }
+
   // If we have an existing entry, destroy it, replacing it with the
-  // new variable.
-  if (entry) {
-    auto existing = cast<llvm::GlobalValue>(entry);
-    auto castVar = llvm::ConstantExpr::getBitCast(var, entry->getType());
+  // new variable.  We only really have to do 
+  if (existingGlobal) {
+    auto existing = cast<llvm::GlobalValue>(existingGlobal);
+    auto castVar = llvm::ConstantExpr::getBitCast(var, existing->getType());
     existing->replaceAllUsesWith(castVar);
     existing->eraseFromParent();
   }
@@ -3535,7 +3541,7 @@ IRGenModule::getAddrOfLLVMVariable(LinkEntity entity,
   }
 
   // Cache and return.
-  entry = var;
+  GlobalVars[entity] = var;
   return var;
 }
 

--- a/validation-test/IRGen/98995607.swift.gyb
+++ b/validation-test/IRGen/98995607.swift.gyb
@@ -1,0 +1,21 @@
+// RUN: %target-run-simple-swiftgyb
+
+%for N in range(0, 100):
+
+protocol P${N}<A, B> {
+  associatedtype A
+  associatedtype B
+}
+
+%end
+
+var array : [Any.Type] = [
+%for N in range(0, 100):
+  (any P${N}<Int, Float>).self,
+%end
+%for N in range(0, 100):
+  (any P${N}<Float, String>).self,
+%end
+]
+
+print(array)


### PR DESCRIPTION
Extended existential type shapes can trigger this by introducing more entities (and thus causing GlobalVars to be rehashed) during the lazy-emission callback.

Fixes rdar://98995607. 5.7 version of #60782.