### PR TITLE
[interop][SwiftToCxx] experimentally expose Swift::String type to C++

### DIFF
--- a/lib/PrintAsClang/ClangSyntaxPrinter.cpp
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.cpp
@@ -98,8 +98,21 @@ void ClangSyntaxPrinter::printExternC(
   os << "#endif\n";
 }
 
+void ClangSyntaxPrinter::printObjCBlock(
+    llvm::function_ref<void(raw_ostream &OS)> bodyPrinter) const {
+  os << "#if defined(__OBJC__)\n";
+  bodyPrinter(os);
+  os << "\n#endif\n";
+}
+
 void ClangSyntaxPrinter::printSwiftImplQualifier() const {
   os << "swift::" << cxx_synthesis::getCxxImplNamespaceName() << "::";
+}
+
+void ClangSyntaxPrinter::printInlineForThunk() const {
+  // FIXME: make a macro and add 'nodebug', and
+  // migrate all other 'inline' uses.
+  os << "inline __attribute__((always_inline)) ";
 }
 
 void ClangSyntaxPrinter::printNullability(

--- a/lib/PrintAsClang/ClangSyntaxPrinter.h
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.h
@@ -70,6 +70,10 @@ public:
   void
   printExternC(llvm::function_ref<void(raw_ostream &OS)> bodyPrinter) const;
 
+  /// Print an #ifdef __OBJC__ block.
+  void
+  printObjCBlock(llvm::function_ref<void(raw_ostream &OS)> bodyPrinter) const;
+
   /// Print the `swift::_impl::` namespace qualifier.
   void printSwiftImplQualifier() const;
 
@@ -79,6 +83,8 @@ public:
     After,
     ContextSensitive,
   };
+
+  void printInlineForThunk() const;
 
   void printNullability(
       Optional<OptionalTypeKind> kind,

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -2397,6 +2397,11 @@ static bool isAsyncAlternativeOfOtherDecl(const ValueDecl *VD) {
 }
 
 static bool hasExposeAttr(const ValueDecl *VD) {
+  if (isa<NominalTypeDecl>(VD) && VD->getModuleContext()->isStdlibModule()) {
+    if (VD == VD->getASTContext().getStringDecl())
+      return true;
+    return false;
+  }
   if (VD->getAttrs().hasAttribute<ExposeAttr>())
     return true;
   if (const auto *NMT = dyn_cast<NominalTypeDecl>(VD->getDeclContext()))

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -426,7 +426,7 @@ private:
       // Printing struct, is, and get functions for each case
       DeclAndTypeClangFunctionPrinter clangFuncPrinter(
           os, owningPrinter.prologueOS, owningPrinter.typeMapping,
-          owningPrinter.interopContext);
+          owningPrinter.interopContext, owningPrinter);
 
       auto printIsFunction = [&](StringRef caseName, EnumDecl *ED) {
         os << "  inline bool is";
@@ -745,9 +745,9 @@ private:
         return;
       owningPrinter.prologueOS << cFuncPrologueOS.str();
 
-      DeclAndTypeClangFunctionPrinter declPrinter(os, owningPrinter.prologueOS,
-                                                  owningPrinter.typeMapping,
-                                                  owningPrinter.interopContext);
+      DeclAndTypeClangFunctionPrinter declPrinter(
+          os, owningPrinter.prologueOS, owningPrinter.typeMapping,
+          owningPrinter.interopContext, owningPrinter);
       if (auto *accessor = dyn_cast<AccessorDecl>(AFD)) {
         declPrinter.printCxxPropertyAccessorMethod(
             typeDeclContext, accessor, funcABI->getSymbolName(), resultTy,
@@ -760,7 +760,8 @@ private:
 
       DeclAndTypeClangFunctionPrinter defPrinter(
           owningPrinter.outOfLineDefinitionsOS, owningPrinter.prologueOS,
-          owningPrinter.typeMapping, owningPrinter.interopContext);
+          owningPrinter.typeMapping, owningPrinter.interopContext,
+          owningPrinter);
 
       if (auto *accessor = dyn_cast<AccessorDecl>(AFD)) {
 
@@ -1131,7 +1132,7 @@ private:
 
     DeclAndTypeClangFunctionPrinter funcPrinter(
         cRepresentationOS, owningPrinter.prologueOS, owningPrinter.typeMapping,
-        owningPrinter.interopContext);
+        owningPrinter.interopContext, owningPrinter);
     auto ABIparams = owningPrinter.interopContext.getIrABIDetails()
                          .getFunctionABIAdditionalParams(FD);
     llvm::SmallVector<DeclAndTypeClangFunctionPrinter::AdditionalParam, 2>
@@ -1191,9 +1192,9 @@ private:
     auto resultTy =
         getForeignResultType(FD, funcTy, asyncConvention, errorConvention);
 
-    DeclAndTypeClangFunctionPrinter funcPrinter(os, owningPrinter.prologueOS,
-                                                owningPrinter.typeMapping,
-                                                owningPrinter.interopContext);
+    DeclAndTypeClangFunctionPrinter funcPrinter(
+        os, owningPrinter.prologueOS, owningPrinter.typeMapping,
+        owningPrinter.interopContext, owningPrinter);
     llvm::SmallVector<DeclAndTypeClangFunctionPrinter::AdditionalParam, 2>
         additionalParams;
     auto ABIparams = owningPrinter.interopContext.getIrABIDetails()
@@ -1202,10 +1203,12 @@ private:
       convertABIAdditionalParams(FD, resultTy, ABIparams, additionalParams);
     DeclAndTypeClangFunctionPrinter::FunctionSignatureModifiers modifiers;
     modifiers.isInline = true;
-    funcPrinter.printFunctionSignature(
+    auto result = funcPrinter.printFunctionSignature(
         FD, cxx_translation::getNameForCxx(FD), resultTy,
         DeclAndTypeClangFunctionPrinter::FunctionSignatureKind::CxxInlineThunk,
         {}, modifiers);
+    assert(
+        !result.isUnsupported()); // The C signature should be unsupported too.
     // FIXME: Support throwing exceptions for Swift errors.
     if (!funcTy->isThrowing())
       os << " noexcept";

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -96,13 +96,14 @@ public:
       PrimitiveTypeMapping &typeMapping, OutputLanguageMode languageMode,
       SwiftToClangInteropContext &interopContext,
       CFunctionSignatureTypePrinterModifierDelegate modifiersDelegate,
-      const ModuleDecl *moduleContext,
+      const ModuleDecl *moduleContext, DeclAndTypePrinter &declPrinter,
       FunctionSignatureTypeUse typeUseKind =
           FunctionSignatureTypeUse::ParamType)
       : ClangSyntaxPrinter(os), cPrologueOS(cPrologueOS),
         typeMapping(typeMapping), interopContext(interopContext),
         languageMode(languageMode), modifiersDelegate(modifiersDelegate),
-        moduleContext(moduleContext), typeUseKind(typeUseKind) {}
+        moduleContext(moduleContext), declPrinter(declPrinter),
+        typeUseKind(typeUseKind) {}
 
   void printInoutTypeModifier() {
     os << (languageMode == swift::OutputLanguageMode::Cxx ? " &"
@@ -197,6 +198,9 @@ public:
     // Handle known type names.
     if (printIfKnownSimpleType(decl, optionalKind, isInOutParam))
       return ClangRepresentation::representable;
+    if (!declPrinter.shouldInclude(decl))
+      return ClangRepresentation::unsupported; // FIXME: propagate why it's not
+                                               // exposed.
     // FIXME: Handle optional structures.
     if (typeUseKind == FunctionSignatureTypeUse::ParamType) {
       if (languageMode != OutputLanguageMode::Cxx &&
@@ -292,6 +296,7 @@ private:
   OutputLanguageMode languageMode;
   CFunctionSignatureTypePrinterModifierDelegate modifiersDelegate;
   const ModuleDecl *moduleContext;
+  DeclAndTypePrinter &declPrinter;
   FunctionSignatureTypeUse typeUseKind;
 };
 
@@ -304,7 +309,7 @@ DeclAndTypeClangFunctionPrinter::printClangFunctionReturnType(
   CFunctionSignatureTypePrinter typePrinter(
       os, cPrologueOS, typeMapping, outputLang, interopContext,
       CFunctionSignatureTypePrinterModifierDelegate(), moduleContext,
-      FunctionSignatureTypeUse::ReturnType);
+      declPrinter, FunctionSignatureTypeUse::ReturnType);
   // Param for indirect return cannot be marked as inout
   return typePrinter.visit(ty, optKind, /*isInOutParam=*/false);
 }
@@ -344,9 +349,9 @@ ClangRepresentation DeclAndTypeClangFunctionPrinter::printFunctionSignature(
       -> ClangRepresentation {
     // FIXME: add support for noescape and PrintMultiPartType,
     // see DeclAndTypePrinter::print.
-    CFunctionSignatureTypePrinter typePrinter(os, cPrologueOS, typeMapping,
-                                              outputLang, interopContext,
-                                              delegate, emittedModule);
+    CFunctionSignatureTypePrinter typePrinter(
+        os, cPrologueOS, typeMapping, outputLang, interopContext, delegate,
+        emittedModule, declPrinter);
     auto result = typePrinter.visit(ty, optionalKind, isInOutParam);
 
     if (!name.empty()) {
@@ -385,6 +390,12 @@ ClangRepresentation DeclAndTypeClangFunctionPrinter::printFunctionSignature(
             .isUnsupported())
       return resultingRepresentation;
   } else {
+    // FIXME: also try to figure out if indirect is representable using a type
+    // visitor?
+    if (const auto *NT = resultTy->getNominalOrBoundGenericNominal()) {
+      if (!declPrinter.shouldInclude(NT))
+        return ClangRepresentation::unsupported;
+    }
     os << "void";
   }
 
@@ -701,9 +712,11 @@ void DeclAndTypeClangFunctionPrinter::printCxxMethod(
       isa<FuncDecl>(FD) ? cast<FuncDecl>(FD)->isMutating() : false;
   modifiers.isConst =
       !isa<ClassDecl>(typeDeclContext) && !isMutating && !isConstructor;
-  printFunctionSignature(
+  auto result = printFunctionSignature(
       FD, isConstructor ? "init" : cxx_translation::getNameForCxx(FD), resultTy,
       FunctionSignatureKind::CxxInlineThunk, {}, modifiers);
+  assert(!result.isUnsupported() && "C signature should be unsupported too");
+
   if (!isDefinition) {
     os << ";\n";
     return;
@@ -763,9 +776,10 @@ void DeclAndTypeClangFunctionPrinter::printCxxPropertyAccessorMethod(
     modifiers.qualifierContext = typeDeclContext;
   modifiers.isInline = true;
   modifiers.isConst = accessor->isGetter() && !isa<ClassDecl>(typeDeclContext);
-  printFunctionSignature(accessor, remapPropertyName(accessor, resultTy),
-                         resultTy, FunctionSignatureKind::CxxInlineThunk, {},
-                         modifiers);
+  auto result = printFunctionSignature(
+      accessor, remapPropertyName(accessor, resultTy), resultTy,
+      FunctionSignatureKind::CxxInlineThunk, {}, modifiers);
+  assert(!result.isUnsupported() && "C signature should be unsupported too!");
   if (!isDefinition) {
     os << ";\n";
     return;

--- a/lib/PrintAsClang/PrintClangFunction.h
+++ b/lib/PrintAsClang/PrintClangFunction.h
@@ -35,6 +35,7 @@ class ParamDecl;
 class ParameterList;
 class PrimitiveTypeMapping;
 class SwiftToClangInteropContext;
+class DeclAndTypePrinter;
 
 struct ClangRepresentation {
   enum Kind { representable, unsupported };
@@ -61,9 +62,10 @@ class DeclAndTypeClangFunctionPrinter {
 public:
   DeclAndTypeClangFunctionPrinter(raw_ostream &os, raw_ostream &cPrologueOS,
                                   PrimitiveTypeMapping &typeMapping,
-                                  SwiftToClangInteropContext &interopContext)
+                                  SwiftToClangInteropContext &interopContext,
+                                  DeclAndTypePrinter &declPrinter)
       : os(os), cPrologueOS(cPrologueOS), typeMapping(typeMapping),
-        interopContext(interopContext) {}
+        interopContext(interopContext), declPrinter(declPrinter) {}
 
   /// What kind of function signature should be emitted for the given Swift
   /// function.
@@ -150,6 +152,7 @@ private:
   raw_ostream &cPrologueOS;
   PrimitiveTypeMapping &typeMapping;
   SwiftToClangInteropContext &interopContext;
+  DeclAndTypePrinter &declPrinter;
 };
 
 } // end namespace swift

--- a/lib/PrintAsClang/PrintClangValueType.cpp
+++ b/lib/PrintAsClang/PrintClangValueType.cpp
@@ -87,6 +87,30 @@ void ClangValueTypePrinter::forwardDeclType(raw_ostream &os,
   os << ";\n";
 }
 
+static void addCppExtensionsToStdlibType(const NominalTypeDecl *typeDecl,
+                                         ClangSyntaxPrinter &printer,
+                                         raw_ostream &cPrologueOS) {
+  if (typeDecl == typeDecl->getASTContext().getStringDecl()) {
+    // Perform String -> NSString conversion using
+    // _bridgeToObjectiveCImpl.
+    // FIXME: This is an extension, we should
+    // just expose the method to C once extensions are
+    // supported.
+    cPrologueOS << "SWIFT_EXTERN void *_Nonnull "
+                   "$sSS23_bridgeToObjectiveCImplyXlyF(swift_interop_stub_"
+                   "Swift_String) SWIFT_NOEXCEPT SWIFT_CALL;\n";
+    printer.printObjCBlock([](raw_ostream &os) {
+      os << "  ";
+      ClangSyntaxPrinter(os).printInlineForThunk();
+      os << "operator NSString * _Nonnull () const noexcept {\n";
+      os << "    return (__bridge_transfer NSString "
+            "*)(_impl::$sSS23_bridgeToObjectiveCImplyXlyF(_impl::swift_interop_"
+            "passDirect_Swift_String(_getOpaquePointer())));\n";
+      os << "  }\n";
+    });
+  }
+}
+
 void ClangValueTypePrinter::printValueTypeDecl(
     const NominalTypeDecl *typeDecl,
     llvm::function_ref<void(void)> bodyPrinter) {
@@ -193,6 +217,8 @@ void ClangValueTypePrinter::printValueTypeDecl(
   os << " &&) = default;\n";
 
   bodyPrinter();
+  if (typeDecl->isStdlibDecl())
+    addCppExtensionsToStdlibType(typeDecl, printer, cPrologueOS);
 
   os << "private:\n";
 

--- a/test/Interop/SwiftToCxx/expose-attr/expose-swift-decls-to-cxx.swift
+++ b/test/Interop/SwiftToCxx/expose-attr/expose-swift-decls-to-cxx.swift
@@ -36,6 +36,10 @@ public struct ExposedStruct {
     public func method() {}
 }
 
+public struct NotExposedStruct {
+    public var x: Int
+}
+
 @_expose(Cxx, "ExposedStruct2")
 public struct ExposedStructRenamed {
     public var y: Int
@@ -48,6 +52,15 @@ public struct ExposedStructRenamed {
 
     @_expose(Cxx, "renamedMethod")
     public func method() {}
+
+    public func getNonExposedStruct() -> NotExposedStruct {
+        return NotExposedStruct(x: 2)
+    }
+    // FIXME: if 'getNonExposedStruct' has explicit @_expose we should error in Sema.
+
+    public func passNonExposedStruct(_ x: NotExposedStruct) {
+    }
+    // FIXME: if 'passNonExposedStruct' has explicit @_expose we should error in Sema.
 }
 
 @_expose(Cxx)
@@ -58,6 +71,14 @@ public final class ExposedClass {
 // CHECK: class ExposedClass final
 // CHECK: class ExposedStruct final {
 // CHECK: class ExposedStruct2 final {
+// CHECK: ExposedStruct2(ExposedStruct2 &&) = default;
+// CHECK-NEXT: swift::Int getY() const;
+// CHECK-NEXT: void setY(swift::Int value);
+// CHECK-NEXT: swift::Int getRenamedProp() const;
+// CHECK-NEXT: void setRenamedProp(swift::Int value);
+// CHECK-NEXT: swift::Int getProp3() const;
+// CHECK-NEXT: void renamedMethod() const;
+// CHECK-NEXT: private:
 
 // CHECK: inline void exposed1() noexcept {
 // CHECK-NEXT:   return _impl::$s6Expose8exposed1yyF();
@@ -83,4 +104,6 @@ public final class ExposedClass {
 // CHECK: void ExposedStruct2::setRenamedProp(swift::Int value) {
 // CHECK: swift::Int ExposedStruct2::getProp3() const {
 // CHECK: void ExposedStruct2::renamedMethod() const {
+
+// CHECK-NOT: NonExposedStruct
 

--- a/test/Interop/SwiftToCxx/lit.local.cfg
+++ b/test/Interop/SwiftToCxx/lit.local.cfg
@@ -1,1 +1,1 @@
-config.suffixes = ['.swift', '.cpp']
+config.suffixes = ['.swift', '.cpp', '.mm']

--- a/test/Interop/SwiftToCxx/stdlib/string/string-to-nsstring.mm
+++ b/test/Interop/SwiftToCxx/stdlib/string/string-to-nsstring.mm
@@ -1,0 +1,68 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -parse-as-library %platform-module-dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies
+
+// RUN: %target-swift-frontend -typecheck %t/create_string.swift -typecheck -module-name StringCreator -enable-experimental-cxx-interop -emit-clang-header-path %t/StringCreator.h
+
+// RUN: %target-interop-build-clangxx -fobjc-arc -c %t/string-to-nsstring.mm -I %t -o %t/swift-stdlib-execution.o
+// RUN: %target-build-swift %t/use_foundation.swift %t/create_string.swift -o %t/swift-stdlib-execution -Xlinker %t/swift-stdlib-execution.o -module-name StringCreator -Xfrontend -entry-point-function-name -Xfrontend swiftMain -lc++
+// RUN: %target-codesign %t/swift-stdlib-execution
+// RUN: %target-run %t/swift-stdlib-execution
+
+// RUN: %target-interop-build-clangxx -fobjc-arc -c %t/string-to-nsstring-one-arc-op.mm -I %t -Xclang -emit-llvm -S -o - -O1 |  %FileCheck --check-prefix=CHECKARC %s
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+//--- use_foundation.swift
+import Foundation
+
+//--- create_string.swift
+@_expose(Cxx)
+public func createString(_ ptr: UnsafePointer<CChar>) -> String {
+    return String(cString: ptr)
+}
+
+//--- string-to-nsstring-one-arc-op.mm
+
+#include "Swift.h"
+
+int main() {
+  using namespace Swift;
+  auto emptyString = String::init();
+  NSString *nsStr = emptyString;
+}
+
+// CHECKARC: %[[VAL:.*]] = call swiftcc i8* @"$sSS23_bridgeToObjectiveCImplyXlyF"
+// CHECKARC: call i8* @llvm.objc.autorelease(i8* %[[VAL]])
+// CHECKARC: @llvm.objc.
+// CHECKARC-SAME: autorelease(i8*)
+// CHECKARC-NOT: @llvm.objc.
+
+//--- string-to-nsstring.mm
+
+#include <cassert>
+#include <string>
+#include "Swift.h"
+#include "StringCreator.h"
+
+int main() {
+  using namespace Swift;
+
+  auto emptyString = String::init();
+
+  {
+    NSString *nsStr = emptyString;
+    assert(std::string(nsStr.UTF8String) == "");
+    assert([nsStr isEqualToString:@""]);
+  }
+
+  auto aStr = StringCreator::createString("hello");
+  {
+    NSString *nsStr = aStr;
+    assert(std::string(nsStr.UTF8String) == "hello");
+    assert([nsStr isEqualToString:@"hello"]);
+  }
+  return 0;
+}

--- a/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
@@ -5,4 +5,15 @@
 // RUN: %check-interop-cxx-header-in-clang(%t/Swift.h -Wno-unused-private-field -Wno-unused-function)
 
 // CHECK: namespace Swift {
+
+// CHECK: class String final {
+// CHECK-NEXT: public:
+// CHECK-NEXT: inline ~String() {
+// CHECK:  }
+// CHECK-NEXT:  inline String(const String &other) {
+// CHECK:  }
+// CHECK-NEXT:  inline String(String &&) = default;
+// CHECK-NEXT:  static inline String init();
+// CHECK-NEXT: private:
+
 // CHECK: } // namespace Swift

--- a/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
@@ -14,6 +14,12 @@
 // CHECK:  }
 // CHECK-NEXT:  inline String(String &&) = default;
 // CHECK-NEXT:  static inline String init();
+// CHECK-NEXT:  #if defined(__OBJC__)
+// CHECK-NEXT:  inline __attribute__((always_inline)) operator NSString * _Nonnull () const noexcept {
+// CHECK-NEXT:    return (__bridge_transfer NSString *)(_impl::$sSS23_bridgeToObjectiveCImplyXlyF(_impl::swift_interop_passDirect_Swift_String(_getOpaquePointer())));
+// CHECK-NEXT:   }
+// CHECK-EMPTY:
+// CHECK-NEXT:  #endif
 // CHECK-NEXT: private:
 
 // CHECK: } // namespace Swift


### PR DESCRIPTION
The only stdlib member that's currently exposed is the default initializer, everything else is in extensions.

However, we also add a new generated `operator NSString *` for casting a Swift `String` value to `NSString *` on the C++ side.