### PR TITLE
[cxx-interop] Mark un-specialized class templates as unavailable in Swift.

### DIFF
--- a/SwiftCompilerSources/Sources/AST/DiagnosticEngine.swift
+++ b/SwiftCompilerSources/Sources/AST/DiagnosticEngine.swift
@@ -46,7 +46,7 @@ public struct DiagnosticFixIt {
       let bridgedDiagnosticFixIt = swift.DiagnosticInfo.FixIt(
         swift.CharSourceRange(start.bridged, UInt32(byteLength)),
         bridgedTextRef,
-        llvm.ArrayRef<swift.DiagnosticArgument>())
+        ArrayRefOfDiagnosticArgument())
       fn(bridgedDiagnosticFixIt)
     }
   }

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -45,6 +45,8 @@ void DiagnosticEngine_diagnose(swift::DiagnosticEngine &, swift::SourceLoc loc,
                                swift::CharSourceRange highlight,
                                BridgedArrayRef fixIts);
 
+using ArrayRefOfDiagnosticArgument = llvm::ArrayRef<swift::DiagnosticArgument>;
+
 SWIFT_END_NULLABILITY_ANNOTATIONS
 
 #endif // SWIFT_AST_ASTBRIDGING_H

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3497,6 +3497,13 @@ namespace {
 
       auto structDecl = Impl.createDeclWithClangNode<StructDecl>(
         decl, AccessLevel::Public, loc, name, loc, None, genericParamList, dc);
+
+      auto attr = AvailableAttr::createPlatformAgnostic(
+          Impl.SwiftContext, "Un-specialized class templates are not currently "
+                             "supported. Please use a specialization of this "
+                             "type.");
+      structDecl->getAttrs().add(attr);
+
       return structDecl;
     }
 

--- a/test/Interop/Cxx/namespace/templates-module-interface.swift
+++ b/test/Interop/Cxx/namespace/templates-module-interface.swift
@@ -7,6 +7,7 @@
 // CHECK-NEXT:       init()
 // CHECK-NEXT:       mutating func basicMember() -> UnsafePointer<CChar>!
 // CHECK-NEXT:     }
+// CHECK-NEXT:     @available(*, unavailable, message: "Un-specialized class templates are not currently supported. Please use a specialization of this type.")
 // CHECK-NEXT:     struct ForwardDeclaredClassTemplate<> {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     static func forwardDeclaredFunctionTemplateOutOfLine<T>(_: T) -> UnsafePointer<CChar>!
@@ -14,6 +15,7 @@
 // CHECK-NEXT:       init()
 // CHECK-NEXT:       mutating func basicMember() -> UnsafePointer<CChar>!
 // CHECK-NEXT:     }
+// CHECK-NEXT:     @available(*, unavailable, message: "Un-specialized class templates are not currently supported. Please use a specialization of this type.")
 // CHECK-NEXT:     struct ForwardDeclaredClassTemplateOutOfLine<> {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     typealias BasicClassTemplateChar = TemplatesNS1.TemplatesNS3.__CxxTemplateInstN12TemplatesNS112TemplatesNS318BasicClassTemplateIcEE
@@ -24,10 +26,12 @@
 // CHECK-NEXT:     init()
 // CHECK-NEXT:     mutating func basicMember() -> UnsafePointer<CChar>!
 // CHECK-NEXT:   }
+// CHECK-NEXT:   @available(*, unavailable, message: "Un-specialized class templates are not currently supported. Please use a specialization of this type.")
 // CHECK-NEXT:   struct BasicClassTemplate<> {
 // CHECK-NEXT:   }
 // CHECK-NEXT:   typealias BasicClassTemplateChar = TemplatesNS1.__CxxTemplateInstN12TemplatesNS118BasicClassTemplateIcEE
 // CHECK-NEXT:   static func basicFunctionTemplateDefinedInDefs<T>(_: T) -> UnsafePointer<CChar>!
+// CHECK-NEXT:   @available(*, unavailable, message: "Un-specialized class templates are not currently supported. Please use a specialization of this type.")
 // CHECK-NEXT:   struct BasicClassTemplateDefinedInDefs<> {
 // CHECK-NEXT:   }
 // CHECK-NEXT:   typealias UseTemplate = TemplatesNS4.__CxxTemplateInstN12TemplatesNS417HasSpecializationIcEE
@@ -36,6 +40,7 @@
 // CHECK-NEXT:     struct __CxxTemplateInstN12TemplatesNS112TemplatesNS318BasicClassTemplateIcEE {
 // CHECK-NEXT:       init()
 // CHECK-NEXT:     }
+// CHECK-NEXT:     @available(*, unavailable, message: "Un-specialized class templates are not currently supported. Please use a specialization of this type.")
 // CHECK-NEXT:     struct BasicClassTemplate<> {
 // CHECK-NEXT:     }
 // CHECK-NEXT:   }
@@ -53,6 +58,7 @@
 // CHECK-NEXT:   struct __CxxTemplateInstN12TemplatesNS417HasSpecializationIiEE {
 // CHECK-NEXT:     init()
 // CHECK-NEXT:   }
+// CHECK-NEXT:   @available(*, unavailable, message: "Un-specialized class templates are not currently supported. Please use a specialization of this type.")
 // CHECK-NEXT:   struct HasSpecialization<> {
 // CHECK-NEXT:   }
 // CHECK-NEXT: }

--- a/test/Interop/Cxx/namespace/templates-with-forward-decl-module-interface.swift
+++ b/test/Interop/Cxx/namespace/templates-with-forward-decl-module-interface.swift
@@ -4,6 +4,7 @@
 // CHECK-NEXT:   struct __CxxTemplateInstN3NS115ForwardDeclaredIiEE {
 // CHECK-NEXT:     init()
 // CHECK-NEXT:   }
+// CHECK-NEXT:   @available(*, unavailable, message: "Un-specialized class templates are not currently supported. Please use a specialization of this type.")
 // CHECK-NEXT:   struct ForwardDeclared<T> {
 // CHECK-NEXT:   }
 // CHECK-NEXT:   struct __CxxTemplateInstN3NS14DeclIiEE {
@@ -13,6 +14,7 @@
 // CHECK-NEXT:     var fwd: NS1.__CxxTemplateInstN3NS115ForwardDeclaredIiEE
 // CHECK-NEXT:     static let intValue: NS1.__CxxTemplateInstN3NS14DeclIiEE.MyInt
 // CHECK-NEXT:   }
+// CHECK-NEXT:   @available(*, unavailable, message: "Un-specialized class templates are not currently supported. Please use a specialization of this type.")
 // CHECK-NEXT:   struct Decl<T> {
 // CHECK-NEXT:   }
 // CHECK-NEXT:   typealias di = NS1.__CxxTemplateInstN3NS14DeclIiEE

--- a/test/Interop/Cxx/templates/Inputs/SwiftClassInstantiationModule.swift
+++ b/test/Interop/Cxx/templates/Inputs/SwiftClassInstantiationModule.swift
@@ -1,10 +1,10 @@
 import ClassTemplateForSwiftModule
 
-public func makeWrappedMagicNumber() -> MagicWrapper<IntWrapper> {
+public func makeWrappedMagicNumber() -> MagicWrapperSpec {
   let t = IntWrapper(value: 42)
   return MagicWrapper<IntWrapper>(t: t)
 }
 
-public func readWrappedMagicNumber(_ i: inout MagicWrapper<IntWrapper>) -> CInt {
+public func readWrappedMagicNumber(_ i: inout MagicWrapperSpec) -> CInt {
   return i.getValuePlusArg(13)
 }

--- a/test/Interop/Cxx/templates/Inputs/class-template-for-swift-module.h
+++ b/test/Interop/Cxx/templates/Inputs/class-template-for-swift-module.h
@@ -12,4 +12,6 @@ struct MagicWrapper {
   int getValuePlusArg(int arg) const { return t.getValue() + arg; }
 };
 
+using MagicWrapperSpec = MagicWrapper<IntWrapper>;
+
 #endif // TEST_INTEROP_CXX_TEMPLATES_INPUTS_CLASS_TEMPLATE_FOR_SWIFT_MODULE_H

--- a/test/Interop/Cxx/templates/class-template-instantiation-existing-specialization.swift
+++ b/test/Interop/Cxx/templates/class-template-instantiation-existing-specialization.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xfrontend -disable-availability-checking)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/templates/class-template-instantiation-typechecker-calls-method-with-error.swift
+++ b/test/Interop/Cxx/templates/class-template-instantiation-typechecker-calls-method-with-error.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop 2>&1 | %FileCheck %s
+// RUN: not %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -disable-availability-checking 2>&1 | %FileCheck %s
 
 import ClassTemplateInstantiationErrors
 

--- a/test/Interop/Cxx/templates/class-template-instantiation-typechecker-constructor-calls-method-with-error.swift
+++ b/test/Interop/Cxx/templates/class-template-instantiation-typechecker-constructor-calls-method-with-error.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop 2>&1 | %FileCheck %s
+// RUN: not %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -disable-availability-checking 2>&1 | %FileCheck %s
 
 import ClassTemplateInstantiationErrors
 

--- a/test/Interop/Cxx/templates/class-template-instantiation.swift
+++ b/test/Interop/Cxx/templates/class-template-instantiation.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xfrontend -disable-availability-checking)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/templates/class-template-uninstantiatable-members-irgen.swift
+++ b/test/Interop/Cxx/templates/class-template-uninstantiatable-members-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -disable-availability-checking | %FileCheck %s
 
 import ClassTemplateInstantiationErrors
 

--- a/test/Interop/Cxx/templates/class-template-uninstantiatable-members.swift
+++ b/test/Interop/Cxx/templates/class-template-uninstantiatable-members.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xfrontend -disable-availability-checking)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/templates/define-referenced-inline.swift
+++ b/test/Interop/Cxx/templates/define-referenced-inline.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -fno-exceptions)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -fno-exceptions -Xfrontend -disable-availability-checking)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/templates/dependent-types-silgen.swift
+++ b/test/Interop/Cxx/templates/dependent-types-silgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-silgen %s -I %S/Inputs -enable-experimental-cxx-interop -disable-availability-checking | %FileCheck %s
 
 import DependentTypes
 

--- a/test/Interop/Cxx/templates/dependent-types.swift
+++ b/test/Interop/Cxx/templates/dependent-types.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none -Xfrontend -disable-availability-checking)
 //
 // REQUIRES: executable_test
 //

--- a/test/Interop/Cxx/templates/swift-class-instantiation-module-interface.swift
+++ b/test/Interop/Cxx/templates/swift-class-instantiation-module-interface.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swiftxx-frontend -emit-module -o %t/SwiftClassTemplateModule.swiftmodule %S/Inputs/SwiftClassInstantiationModule.swift -I %S/Inputs -enable-library-evolution -swift-version 5
+// RUN: %target-swiftxx-frontend -emit-module -o %t/SwiftClassTemplateModule.swiftmodule %S/Inputs/SwiftClassInstantiationModule.swift -I %S/Inputs -enable-library-evolution -swift-version 5 -disable-availability-checking
 // RUN: %target-swift-ide-test -print-module -module-to-print=SwiftClassTemplateModule -I %t/ -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx-execution.cpp
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx-execution.cpp
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -parse-as-library %platform-module-dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies  -disable-availability-checking
+// RUN: %target-swift-frontend -parse-as-library %platform-module-dir/Swift.swiftmodule/%module-target-triple.swiftinterface -enable-library-evolution -disable-objc-attr-requires-foundation-module -typecheck -module-name Swift -parse-stdlib -enable-experimental-cxx-interop -emit-clang-header-path %t/Swift.h  -experimental-skip-all-function-bodies
 
-// RUN: %target-swift-frontend -typecheck %t/use-cxx-types.swift -typecheck -module-name UseCxx -emit-clang-header-path %t/UseCxx.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=all-public  -disable-availability-checking
+// RUN: %target-swift-frontend -typecheck %t/use-cxx-types.swift -typecheck -module-name UseCxx -emit-clang-header-path %t/UseCxx.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=all-public
 
 // RUN: %target-interop-build-clangxx -std=c++20 -c %t/use-swift-cxx-types.cpp -I %t -o %t/swift-cxx-execution.o -g
 // RUN: %target-interop-build-swift %t/use-cxx-types.swift -o %t/swift-cxx-execution -Xlinker %t/swift-cxx-execution.o -module-name UseCxx -Xfrontend -entry-point-function-name -Xfrontend swiftMain -I %t -g
@@ -41,8 +41,6 @@ struct NonTrivialTemplate {
     }
 };
 
-using NonTrivialTemplateTrivial = NonTrivialTemplate<Trivial>;
-
 //--- module.modulemap
 module CxxTest {
     header "header.h"
@@ -52,19 +50,19 @@ module CxxTest {
 //--- use-cxx-types.swift
 import CxxTest
 
-public func retNonTrivial(y: CInt) -> NonTrivialTemplateTrivial {
-    return NonTrivialTemplateTrivial(Trivial(42, y))
+public func retNonTrivial(y: CInt) -> NonTrivialTemplate<Trivial> {
+    return NonTrivialTemplate<Trivial>(Trivial(42, y))
 }
 
-public func takeNonTrivial(_ x: NonTrivialTemplateTrivial) {
+public func takeNonTrivial(_ x: NonTrivialTemplate<Trivial>) {
     print(x)
 }
 
-public func passThroughNonTrivial(_ x: NonTrivialTemplateTrivial) -> NonTrivialTemplateTrivial {
+public func passThroughNonTrivial(_ x: NonTrivialTemplate<Trivial>) -> NonTrivialTemplate<Trivial>{
     return x
 }
 
-public func inoutNonTrivial(_ x: inout NonTrivialTemplateTrivial) {
+public func inoutNonTrivial(_ x: inout NonTrivialTemplate<Trivial>) {
     x.x.y *= 2
 }
 
@@ -84,7 +82,6 @@ public func inoutTrivial(_ x: inout Trivial) {
     x.x = x.y + x.x - 11
 }
 
-
 public func takeGeneric<T>(_ x: T) {
     print("GENERIC", x)
 }
@@ -93,10 +90,9 @@ public func retPassThroughGeneric<T>(_ x: T) -> T {
     return x
 }
 
-// This is not working.
-// public func retArrayNonTrivial(_ x: CInt) -> [NonTrivialTemplateTrivial] {
-//     return [NonTrivialTemplateTrivial(Trivial(x, -x))]
-// }
+public func retArrayNonTrivial(_ x: CInt) -> [NonTrivialTemplate<Trivial>] {
+    return [NonTrivialTemplate<Trivial>(Trivial(x, -x))]
+}
 
 //--- use-swift-cxx-types.cpp
 
@@ -117,15 +113,15 @@ int main() {
     assert(x.x == -11);
     assert(x.y == -423421);
     UseCxx::takeTrivial(x);
-//    UseCxx::takeGeneric(x);
-//    auto xPrime = UseCxx::retPassThroughGeneric(x);
-    assert(x.x == -11);
-    assert(x.y == -423421);
-    UseCxx::takeTrivial(x);
+    UseCxx::takeGeneric(x);
+    auto xPrime = UseCxx::retPassThroughGeneric(x);
+    assert(xPrime.x == -11);
+    assert(xPrime.y == -423421);
+    UseCxx::takeTrivial(xPrime);
   }
 // CHECK: Trivial(x: 423421, y: -423421)
 // CHECK-NEXT: Trivial(x: -11, y: -423421)
-// X-CHECK-NEXT: GENERIC Trivial(x: -11, y: -423421)
+// CHECK-NEXT: GENERIC Trivial(x: -11, y: -423421)
 // CHECK-NEXT: Trivial(x: -11, y: -423421)
   {
     auto x = UseCxx::retNonTrivial(-942);
@@ -136,12 +132,12 @@ int main() {
     UseCxx::inoutNonTrivial(x);
     assert(x.x.y == -1884);
     assert(x.x.x == 42);
-//    UseCxx::takeGeneric(x);
+    UseCxx::takeGeneric(x);
     {
-//      auto xPrime = UseCxx::retPassThroughGeneric(x);
-//      assert(x.x.y == -1884);
-//      assert(x.x.x == 42);
-//      UseCxx::takeNonTrivial(x);
+      auto xPrime = UseCxx::retPassThroughGeneric(x);
+      assert(xPrime.x.y == -1884);
+      assert(xPrime.x.x == 42);
+      UseCxx::takeNonTrivial(xPrime);
     }
     puts("secondon non trivial");
   }
@@ -156,32 +152,30 @@ int main() {
 // CHECK-NEXT: ~NonTrivialTemplate
 // CHECK-NEXT: ~NonTrivialTemplate
 // CHECK-NEXT: done non trivial
-// X-CHECK-NEXT: copy NonTrivialTemplate
-// X-CHECK-NEXT: GENERIC __CxxTemplateInst18NonTrivialTemplateI7TrivialE(x: __C.Trivial(x: 42, y: -1884))
-// X-CHECK-NEXT: ~NonTrivialTemplate
-// X-CHECK-NEXT: copy NonTrivialTemplate
-// X-CHECK-NEXT: move NonTrivialTemplate
-// X-CHECK-NEXT: ~NonTrivialTemplate
-// X-CHECK-NEXT: copy NonTrivialTemplate
-// X-CHECK-NEXT: __CxxTemplateInst18NonTrivialTemplateI7TrivialE(x: __C.Trivial(x: 42, y: -1884))
-// X-CHECK-NEXT: ~NonTrivialTemplate
-// X-CHECK-NEXT: ~NonTrivialTemplate
+// CHECK-NEXT: copy NonTrivialTemplate
+// CHECK-NEXT: GENERIC __CxxTemplateInst18NonTrivialTemplateI7TrivialE(x: __C.Trivial(x: 42, y: -1884))
+// CHECK-NEXT: ~NonTrivialTemplate
+// CHECK-NEXT: copy NonTrivialTemplate
+// CHECK-NEXT: move NonTrivialTemplate
+// CHECK-NEXT: ~NonTrivialTemplate
+// CHECK-NEXT: copy NonTrivialTemplate
+// CHECK-NEXT: __CxxTemplateInst18NonTrivialTemplateI7TrivialE(x: __C.Trivial(x: 42, y: -1884))
+// CHECK-NEXT: ~NonTrivialTemplate
+// CHECK-NEXT: ~NonTrivialTemplate
 // CHECK-NEXT: secondon non trivial
 // CHECK-NEXT: ~NonTrivialTemplate
-
-  // Also not working
-//  {
-//    auto arr = UseCxx::retArrayNonTrivial(1234);
-//    auto val = arr[0];
-//    assert(val.x.x == 1234);
-//    assert(val.x.y == -1234);
-//  }
-// X-CHECK-NEXT: create NonTrivialTemplate
-// X-CHECK-NEXT: copy NonTrivialTemplate
-// X-CHECK-NEXT: move NonTrivialTemplate
-// X-CHECK-NEXT: ~NonTrivialTemplate
-// X-CHECK-NEXT: ~NonTrivialTemplate
-// X-CHECK-NEXT: ~NonTrivialTemplate
+  {
+    auto arr = UseCxx::retArrayNonTrivial(1234);
+    auto val = arr[0];
+    assert(val.x.x == 1234);
+    assert(val.x.y == -1234);
+  }
+// CHECK-NEXT: create NonTrivialTemplate
+// CHECK-NEXT: copy NonTrivialTemplate
+// CHECK-NEXT: move NonTrivialTemplate
+// CHECK-NEXT: ~NonTrivialTemplate
+// CHECK-NEXT: ~NonTrivialTemplate
+// CHECK-NEXT: ~NonTrivialTemplate
   puts("EndOfTest");
 // CHECK-NEXT: EndOfTest
   return 0;

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx-execution.cpp
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx-execution.cpp
@@ -1,3 +1,6 @@
+// rdar://101431096
+// XFAIL: *
+
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
@@ -1,3 +1,6 @@
+// rdar://101431096
+// XFAIL: *
+
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
@@ -1,11 +1,11 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -typecheck %t/use-cxx-types.swift -typecheck -module-name UseCxxTy -emit-clang-header-path %t/UseCxxTy.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=all-public
+// RUN: %target-swift-frontend -c %t/use-cxx-types.swift -disable-availability-checking  -module-name UseCxxTy -emit-clang-header-path %t/UseCxxTy.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=all-public
 
 // RUN: %FileCheck %s < %t/UseCxxTy.h
 
-// RUN: %target-swift-frontend -typecheck %t/use-cxx-types.swift -typecheck -module-name UseCxxTy -emit-clang-header-path %t/UseCxxTyExposeOnly.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr
+// RUN: %target-swift-frontend -c %t/use-cxx-types.swift -disable-availability-checking  -module-name UseCxxTy -emit-clang-header-path %t/UseCxxTyExposeOnly.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr
 
 // RUN: %FileCheck %s < %t/UseCxxTyExposeOnly.h
 
@@ -39,6 +39,7 @@ namespace ns {
         ~NonTrivialTemplate() {}
     };
 
+    using NonTrivialTemplateCInt = NonTrivialTemplate<int>;
     using TypeAlias = NonTrivialTemplate<TrivialinNS>;
 
     struct NonTrivialImplicitMove {
@@ -89,13 +90,8 @@ public func retImmortalTemplate() -> ns.ImmortalCInt {
 }
 
 @_expose(Cxx)
-public func retNonTrivial() -> ns.NonTrivialTemplate<CInt> {
+public func retNonTrivial() -> ns.NonTrivialTemplateCInt {
     return ns.NonTrivialTemplate<CInt>()
-}
-
-@_expose(Cxx)
-public func retNonTrivial2() -> ns.NonTrivialTemplate<ns.TrivialinNS> {
-    return ns.NonTrivialTemplate<ns.TrivialinNS>()
 }
 
 @_expose(Cxx)
@@ -122,7 +118,7 @@ public func takeImmortalTemplate(_ x: ns.ImmortalCInt) {
 }
 
 @_expose(Cxx)
-public func takeNonTrivial2(_ x: ns.NonTrivialTemplate<ns.TrivialinNS>) {
+public func takeNonTrivial2(_ x: ns.TypeAlias) {
 }
 
 @_expose(Cxx)
@@ -153,36 +149,6 @@ public func takeTrivialInout(_ x: inout Trivial) {
 // CHECK-NEXT: return _impl::$s8UseCxxTy19retImmortalTemplateSo2nsO02__bf10InstN2ns16eF4IiEEVyF();
 // CHECK-NEXT: }
 
-// CHECK: } // end namespace
-// CHECK-EMPTY:
-// CHECK-NEXT: namespace swift {
-// CHECK-NEXT: namespace _impl {
-// CHECK-EMPTY:
-// CHECK-NEXT: // Type metadata accessor for __CxxTemplateInstN2ns18NonTrivialTemplateIiEE
-// CHECK-NEXT: SWIFT_EXTERN swift::_impl::MetadataResponseTy $sSo2nsO033__CxxTemplateInstN2ns18NonTrivialC4IiEEVMa(swift::_impl::MetadataRequestTy) SWIFT_NOEXCEPT SWIFT_CALL;
-// CHECK-EMPTY:
-// CHECK-EMPTY:
-// CHECK-NEXT: } // namespace _impl
-// CHECK-EMPTY:
-// CHECK-NEXT: #pragma clang diagnostic push
-// CHECK-NEXT: #pragma clang diagnostic ignored "-Wc++17-extensions"
-// CHECK-NEXT: template<>
-// CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<ns::NonTrivialTemplate<int>> = true;
-// CHECK-NEXT: template<>
-// CHECK-NEXT: struct TypeMetadataTrait<ns::NonTrivialTemplate<int>> {
-// CHECK-NEXT:   static inline void * _Nonnull getTypeMetadata() {
-// CHECK-NEXT:     return _impl::$sSo2nsO033__CxxTemplateInstN2ns18NonTrivialC4IiEEVMa(0)._0;
-// CHECK-NEXT:   }
-// CHECK-NEXT: };
-// CHECK-NEXT: namespace _impl{
-// CHECK-NEXT: template<>
-// CHECK-NEXT: static inline const constexpr bool isSwiftBridgedCxxRecord<ns::NonTrivialTemplate<int>> = true;
-// CHECK-NEXT: } // namespace
-// CHECK-NEXT: #pragma clang diagnostic pop
-// CHECK-NEXT: } // namespace swift
-// CHECK-EMPTY:
-// CHECK-NEXT: namespace UseCxxTy {
-
 // CHECK: inline ns::NonTrivialTemplate<int> retNonTrivial() noexcept SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT: alignas(alignof(ns::NonTrivialTemplate<int>)) char storage[sizeof(ns::NonTrivialTemplate<int>)];
 // CHECK-NEXT: auto * _Nonnull storageObjectPtr = reinterpret_cast<ns::NonTrivialTemplate<int> *>(storage);
@@ -197,8 +163,8 @@ public func takeTrivialInout(_ x: inout Trivial) {
 // CHECK-NEXT: namespace swift {
 // CHECK-NEXT: namespace _impl {
 // CHECK-EMPTY:
-// CHECK-NEXT: // Type metadata accessor for __CxxTemplateInstN2ns18NonTrivialTemplateINS_11TrivialinNSEEE
-// CHECK-NEXT: SWIFT_EXTERN swift::_impl::MetadataResponseTy $sSo2nsO033__CxxTemplateInstN2ns18NonTrivialC20INS_11TrivialinNSEEEVMa(swift::_impl::MetadataRequestTy) SWIFT_NOEXCEPT SWIFT_CALL;
+// CHECK-NEXT: // Type metadata accessor for NonTrivialImplicitMove
+// CHECK-NEXT: SWIFT_EXTERN swift::_impl::MetadataResponseTy $sSo2nsO22NonTrivialImplicitMoveVMa(swift::_impl::MetadataRequestTy) SWIFT_NOEXCEPT SWIFT_CALL;
 // CHECK-EMPTY:
 // CHECK-EMPTY:
 // CHECK-NEXT: } // namespace _impl
@@ -206,31 +172,21 @@ public func takeTrivialInout(_ x: inout Trivial) {
 // CHECK-NEXT: #pragma clang diagnostic push
 // CHECK-NEXT: #pragma clang diagnostic ignored "-Wc++17-extensions"
 // CHECK-NEXT: template<>
-// CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<ns::NonTrivialTemplate<ns::TrivialinNS>> = true;
+// CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<ns::NonTrivialImplicitMove> = true;
 // CHECK-NEXT: template<>
-// CHECK-NEXT: struct TypeMetadataTrait<ns::NonTrivialTemplate<ns::TrivialinNS>> {
+// CHECK-NEXT: struct TypeMetadataTrait<ns::NonTrivialImplicitMove> {
 // CHECK-NEXT:   static inline void * _Nonnull getTypeMetadata() {
-// CHECK-NEXT:     return _impl::$sSo2nsO033__CxxTemplateInstN2ns18NonTrivialC20INS_11TrivialinNSEEEVMa(0)._0;
+// CHECK-NEXT:     return _impl::$sSo2nsO22NonTrivialImplicitMoveVMa(0)._0;
 // CHECK-NEXT:   }
 // CHECK-NEXT: };
 // CHECK-NEXT: namespace _impl{
 // CHECK-NEXT: template<>
-// CHECK-NEXT: static inline const constexpr bool isSwiftBridgedCxxRecord<ns::NonTrivialTemplate<ns::TrivialinNS>> = true;
+// CHECK-NEXT: static inline const constexpr bool isSwiftBridgedCxxRecord<ns::NonTrivialImplicitMove> = true;
 // CHECK-NEXT: } // namespace
 // CHECK-NEXT: #pragma clang diagnostic pop
 // CHECK-NEXT: } // namespace swift
-// CHECK-EMPTY:
-// CHECK-NEXT: namespace UseCxxTy {
-// CHECK-EMPTY:
-// CHECK-NEXT: inline ns::NonTrivialTemplate<ns::TrivialinNS> retNonTrivial2() noexcept SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT: alignas(alignof(ns::NonTrivialTemplate<ns::TrivialinNS>)) char storage[sizeof(ns::NonTrivialTemplate<ns::TrivialinNS>)];
-// CHECK-NEXT: auto * _Nonnull storageObjectPtr = reinterpret_cast<ns::NonTrivialTemplate<ns::TrivialinNS> *>(storage);
-// CHECK-NEXT: _impl::$s8UseCxxTy14retNonTrivial2So2nsO02__b18TemplateInstN2ns18e7TrivialH20INS_11TrivialinNSEEEVyF(storage);
-// CHECK-NEXT: ns::NonTrivialTemplate<ns::TrivialinNS> result(static_cast<ns::NonTrivialTemplate<ns::TrivialinNS> &&>(*storageObjectPtr));
-// CHECK-NEXT: storageObjectPtr->~NonTrivialTemplate();
-// CHECK-NEXT: return result;
-// CHECK-NEXT: }
 
+// CHECK: namespace UseCxxTy {
 // CHECK: inline ns::NonTrivialImplicitMove retNonTrivialImplicitMove() noexcept SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT: alignas(alignof(ns::NonTrivialImplicitMove)) char storage[sizeof(ns::NonTrivialImplicitMove)];
 // CHECK-NEXT: auto * _Nonnull storageObjectPtr = reinterpret_cast<ns::NonTrivialImplicitMove *>(storage);


### PR DESCRIPTION
They don't really work, so let's not "support" them yet.