### PR TITLE
[Dependency Scanning] Do not add underlying Clang module to persistent (global) scanner cache

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -610,6 +610,15 @@ private:
   /// Additional information needed for Clang dependency scanning.
   ClangModuleDependenciesCacheImpl *clangImpl = nullptr;
 
+  /// Name of the main Swift module of this scan
+  StringRef mainModuleName;
+  /// Underlying Clang module is seen differently by the main
+  /// module and by module clients. For this reason, we do not wish subsequent
+  /// scans to be able to re-use this dependency info and therefore we avoid
+  /// adding it to the global cache. The dependency storage is therefore tied
+  /// to this, local, cache.
+  std::unique_ptr<ModuleDependencies> underlyingClangModuleDependency = nullptr;
+
   /// Function that will delete \c clangImpl properly.
   void (*clangImplDeleter)(ClangModuleDependenciesCacheImpl *) = nullptr;
 
@@ -638,7 +647,8 @@ private:
                    Optional<ModuleDependenciesKind> kind) const;
 
 public:
-  ModuleDependenciesCache(GlobalModuleDependenciesCache &globalCache);
+  ModuleDependenciesCache(GlobalModuleDependenciesCache &globalCache,
+                          StringRef mainModuleName);
   ModuleDependenciesCache(const ModuleDependenciesCache &) = delete;
   ModuleDependenciesCache &operator=(const ModuleDependenciesCache &) = delete;
   virtual ~ModuleDependenciesCache() { destroyClangImpl(); }

--- a/lib/DependencyScan/DependencyScanningTool.cpp
+++ b/lib/DependencyScan/DependencyScanningTool.cpp
@@ -73,7 +73,8 @@ DependencyScanningTool::getDependencies(
   auto Instance = std::move(*InstanceOrErr);
 
   // Local scan cache instance, wrapping the shared global cache.
-  ModuleDependenciesCache cache(*SharedCache);
+  ModuleDependenciesCache cache(*SharedCache,
+                                Instance->getMainModule()->getNameStr());
   // Execute the scanning action, retrieving the in-memory result
   auto DependenciesOrErr = performModuleScan(*Instance.get(), cache);
   if (DependenciesOrErr.getError())
@@ -113,7 +114,8 @@ DependencyScanningTool::getDependencies(
   auto Instance = std::move(*InstanceOrErr);
 
   // Local scan cache instance, wrapping the shared global cache.
-  ModuleDependenciesCache cache(*SharedCache);
+  ModuleDependenciesCache cache(*SharedCache,
+                                Instance->getMainModule()->getNameStr());
   auto BatchScanResults = performBatchModuleScan(
       *Instance.get(), cache, VersionedPCMInstanceCacheCache.get(),
       Saver, BatchInput);


### PR DESCRIPTION
When we are building a Swift module which has an underlying Clang module, and which generates an ObjC interface ('-Swift.h'), the mechanism for building the latter involves a VFS redirect of its modulemap to one that does not yet have the generated Swift code, because it must be built before the Swift portion is built because the Swift portion depends on it. This means that the invocation to build this module is different to one used by the clients which depend on this module.

To avoid the subsequent client scans from re-using the partial (VFS-redirected) module, ensure that we do not store dependency info of the underlying Clang module into the global scanner cache. This will cause subsequent client scans to re-scan for this module, and find the fully-resolved modulemap without a VFS redirect.

Resolves rdar://88309064
