### PR TITLE
[Freestanding] Disable checked continuations.

### DIFF
--- a/stdlib/public/Concurrency/CheckedContinuation.swift
+++ b/stdlib/public/Concurrency/CheckedContinuation.swift
@@ -16,6 +16,7 @@ import Swift
 @_silgen_name("swift_continuation_logFailedCheck")
 internal func logFailedCheck(_ message: UnsafeRawPointer)
 
+#if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
 /// Implementation class that holds the `UnsafeContinuation` instance for
 /// a `CheckedContinuation`.
 @available(SwiftStdlib 5.1, *)
@@ -82,7 +83,9 @@ internal final class CheckedContinuationCanary: @unchecked Sendable {
     }
   }
 }
+#endif
 
+#if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
 /// A mechanism to interface
 /// between synchronous and asynchronous code,
 /// logging correctness violations.
@@ -296,4 +299,65 @@ public func withCheckedThrowingContinuation<T>(
     body(CheckedContinuation(continuation: $0, function: function))
   }
 }
+#else
+@available(SwiftStdlib 5.1, *)
+@available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+public struct CheckedContinuation<T, E: Error>: Sendable {
+  @available(SwiftStdlib 5.1, *)
+  @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+  public init(continuation: UnsafeContinuation<T, E>, function: String = #function) {
+    fatalError("Unavailable in task-to-thread concurrency model")
+  }
+  
+  @available(SwiftStdlib 5.1, *)
+  @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+  public func resume(returning value: __owned T) {
+    fatalError("Unavailable in task-to-thread concurrency model")
+  }
+  
+  @available(SwiftStdlib 5.1, *)
+  @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+  public func resume(throwing error: __owned E) {
+    fatalError("Unavailable in task-to-thread concurrency model")
+  }
+}
+@available(SwiftStdlib 5.1, *)
+@available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+extension CheckedContinuation {
+  @available(SwiftStdlib 5.1, *)
+  @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+  public func resume<Er: Error>(with result: Result<T, Er>) where E == Error {
+    fatalError("Unavailable in task-to-thread concurrency model")
+  }
 
+  @available(SwiftStdlib 5.1, *)
+  @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+  public func resume(with result: Result<T, E>) {
+    fatalError("Unavailable in task-to-thread concurrency model")
+  }
+
+  @available(SwiftStdlib 5.1, *)
+  @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+  public func resume() where T == Void {
+    fatalError("Unavailable in task-to-thread concurrency model")
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+@available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+public func withCheckedContinuation<T>(
+    function: String = #function,
+    _ body: (CheckedContinuation<T, Never>) -> Void
+) async -> T {
+  fatalError("Unavailable in task-to-thread concurrency model")
+}
+
+@available(SwiftStdlib 5.1, *)
+@available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
+public func withCheckedThrowingContinuation<T>(
+    function: String = #function,
+    _ body: (CheckedContinuation<T, Error>) -> Void
+) async throws -> T {
+  fatalError("Unavailable in task-to-thread concurrency model")
+}
+#endif

--- a/test/stdlib/freestanding_diags_stdlib.swift
+++ b/test/stdlib/freestanding_diags_stdlib.swift
@@ -24,6 +24,13 @@ func foo() async {
   asyncDetached { () async -> () in } // expected-error{{Unavailable in task-to-thread concurrency model}}
   asyncDetached { () async throws -> () in } // expected-error{{Unavailable in task-to-thread concurrency model}}
   _ = MainActor.self // expected-error{{Unavailable in task-to-thread concurrency model}}
+  let _: Int = await withCheckedContinuation { _ in } // expected-error{{Unavailable in task-to-thread concurrency model}}
+  do {
+  let _: Int = try await withCheckedThrowingContinuation { _ in } // expected-error{{Unavailable in task-to-thread concurrency model}}
+  } catch let error {
+    _ = error
+  }
+  _ = CheckedContinuation<Int, Never>.self // expected-error{{Unavailable in task-to-thread concurrency model}}
 }
 
 func foo2(


### PR DESCRIPTION
In the task-to-thread model, there are no threading mechanisms by which work could be offloaded onto another thread.  As such, callback based asynchronous APIs which are not Swift async do not make sense.

rdar://99047747
