### PR TITLE
[5.7][SourceKit] Workaround a bug that parameterized protocols without 'any' cannot be mangled

### DIFF
--- a/lib/IDE/CodeCompletionResultType.cpp
+++ b/lib/IDE/CodeCompletionResultType.cpp
@@ -194,6 +194,16 @@ const USRBasedType *USRBasedType::fromType(Type Ty, USRBasedTypeArena &Arena) {
     return USRBasedType::null(Arena);
   }
 
+  // ParameterizedProtocolType should always be wrapped in ExistentialType and
+  // cannot be mangled on its own.
+  // But ParameterizedProtocolType can currently occur in 'typealias'
+  // declarations. rdar://99176683
+  // To avoid crashing in USR generation, simply return a null type until the
+  // underlying issue has been fixed.
+  if (Ty->is<ParameterizedProtocolType>()) {
+    return USRBasedType::null(Arena);
+  }
+
   SmallString<32> USR;
   llvm::raw_svector_ostream OS(USR);
   printTypeUSR(Ty, OS);

--- a/test/IDE/complete_from_module_with_type_alias_to_parameterized_protocol.swift
+++ b/test/IDE/complete_from_module_with_type_alias_to_parameterized_protocol.swift
@@ -1,0 +1,30 @@
+// RUN: %empty-directory(%t/split)
+// RUN: %empty-directory(%t/build)
+// RUN: %{python} %utils/split_file.py -o %t/split %s
+
+// RUN: %target-swift-frontend -emit-module -o %t/build %t/split/pck.swift
+
+// RUN: %target-swift-ide-test -code-completion -source-filename %t/split/test.swift -I %t/build -code-completion-token=COMPLETE | %FileCheck %s
+
+// BEGIN pck.swift
+
+public protocol Foo<Bar> {
+  associatedtype Bar
+}
+
+public typealias Problem = Foo<String>
+
+public protocol EmptyProto {}
+public typealias ConstrainedBar<T: EmptyProto> = Foo<T>
+
+// BEGIN test.swift
+
+import pck
+
+#^COMPLETE^#
+
+// CHECK: Begin completions
+// CHECK-DAG: Decl[Protocol]/OtherModule[pck]/Flair[RareType]: Foo[#Foo#];
+// CHECK-DAG: Decl[TypeAlias]/OtherModule[pck]:   Problem[#Foo<String>#];
+// CHECK-DAG: Decl[TypeAlias]/OtherModule[pck]:   ConstrainedBar[#Foo<T>#];
+// CHECK: End completions

--- a/test/SourceKit/CursorInfo/cursor_from_module_with_type_alias_to_parameterized_protocol.swift
+++ b/test/SourceKit/CursorInfo/cursor_from_module_with_type_alias_to_parameterized_protocol.swift
@@ -1,0 +1,13 @@
+// Testing that these requests don't crash
+
+public protocol Foo<Bar> {
+  associatedtype Bar
+}
+// RUN: %sourcekitd-test -req=cursor -pos=%(line+1):11 %s -- %s
+typealias Problem = Foo<String>
+
+protocol EmptyProto {}
+// RUN: %sourcekitd-test -req=cursor -pos=%(line+1):11 %s -- %s
+typealias ConstrainedBar<T: EmptyProto> = Foo<T>
+// RUN: %sourcekitd-test -req=cursor -pos=%(line+1):11 %s -- %s
+typealias ConstrainedBarMetatype<T: P> = Foo<T>.Type


### PR DESCRIPTION
* **Explanation**: When mangling, parameterized protocols are always expected to be spelled with `any` or `some` keywords. `typealias` declarations can refer to a parameterized protocols without the `any` or `some` keyword. When trying to build the USR for these `typealias`es, SourceKit crashes because it tries to mangle the parameterized protocol without an `any` or `some` keyword. The crash happens if you perform code completion while importing a module that exports such a `typealias` or if you invoke cursor info on such a `typealias`. This PR implements a SourceKit-specific minimal workaround for that problem by not computing USRs for parameterized protocols.
* **Scope**: Very narrow, only affects code completion and cursor info in SourceKit in the above circumstances
* **Risk**: Risk of breaking any currently working behavior is very low.
* **Testing**: Added two new regression tests
* **Issue**:  rdar://98623438
* **Reviewer**: @CodaFi