### PR TITLE
[5.7][CodeComplete] Show global completions from modules that are imported as `@_spi`

### DIFF
--- a/include/swift/IDE/CodeCompletionCache.h
+++ b/include/swift/IDE/CodeCompletionCache.h
@@ -45,6 +45,8 @@ public:
     bool ResultsHaveLeadingDot;
     bool ForTestableLookup;
     bool ForPrivateImportLookup;
+    /// Must be sorted alphabetically for stable identity.
+    llvm::SmallVector<std::string, 2> SpiGroups;
     bool AddInitsInToplevel;
     bool AddCallWithNoDefaultArgs;
     bool Annotated;
@@ -56,6 +58,7 @@ public:
              LHS.ResultsHaveLeadingDot == RHS.ResultsHaveLeadingDot &&
              LHS.ForTestableLookup == RHS.ForTestableLookup &&
              LHS.ForPrivateImportLookup == RHS.ForPrivateImportLookup &&
+             LHS.SpiGroups == RHS.SpiGroups &&
              LHS.AddInitsInToplevel == RHS.AddInitsInToplevel &&
              LHS.AddCallWithNoDefaultArgs == RHS.AddCallWithNoDefaultArgs &&
              LHS.Annotated == RHS.Annotated;
@@ -125,16 +128,35 @@ template<>
 struct DenseMapInfo<swift::ide::CodeCompletionCache::Key> {
   using KeyTy = swift::ide::CodeCompletionCache::Key;
   static inline KeyTy getEmptyKey() {
-    return KeyTy{"", "", {}, false, false, false, false, false, false};
+    return KeyTy{/*ModuleFilename=*/"",
+                 /*ModuleName=*/"",
+                 /*AccessPath=*/{},
+                 /*ResultsHaveLeadingDot=*/false,
+                 /*ForTestableLookup=*/false,
+                 /*ForPrivateImportLookup=*/false,
+                 /*SpiGroups=*/{},
+                 /*AddInitsInToplevel=*/false,
+                 /*AddCallWithNoDefaultArgs=*/false,
+                 /*Annotated=*/false};
   }
   static inline KeyTy getTombstoneKey() {
-    return KeyTy{"", "", {}, true, false, false, false, false, false};
+    return KeyTy{/*ModuleFilename=*/"",
+                 /*ModuleName=*/"",
+                 /*AccessPath=*/{},
+                 /*ResultsHaveLeadingDot=*/true,
+                 /*ForTestableLookup=*/false,
+                 /*ForPrivateImportLookup=*/false,
+                 /*SpiGroups=*/{},
+                 /*AddInitsInToplevel=*/false,
+                 /*AddCallWithNoDefaultArgs=*/false,
+                 /*Annotated=*/false};
   }
   static unsigned getHashValue(const KeyTy &Val) {
     return llvm::hash_combine(
         Val.ModuleFilename, Val.ModuleName,
         llvm::hash_combine_range(Val.AccessPath.begin(), Val.AccessPath.end()),
         Val.ResultsHaveLeadingDot, Val.ForTestableLookup,
+        llvm::hash_combine_range(Val.SpiGroups.begin(), Val.SpiGroups.end()),
         Val.ForPrivateImportLookup, Val.AddInitsInToplevel,
         Val.AddCallWithNoDefaultArgs, Val.Annotated);
   }

--- a/lib/IDE/CodeCompletionCache.cpp
+++ b/lib/IDE/CodeCompletionCache.cpp
@@ -475,6 +475,12 @@ static std::string getName(StringRef cacheDirectory,
       << (K.AddInitsInToplevel ? "-inits" : "")
       << (K.AddCallWithNoDefaultArgs ? "-nodefaults" : "")
       << (K.Annotated ? "-annotated" : "");
+  if (K.SpiGroups.size() > 0) {
+    OSS << "-spi";
+    for (auto SpiGroup : K.SpiGroups) {
+      OSS << "-" << SpiGroup;
+    }
+  }
 
   // name[-access-path-components]
   for (StringRef component : K.AccessPath)
@@ -539,9 +545,16 @@ OnDiskCodeCompletionCache::getFromFile(StringRef filename) {
     return None;
 
   // Make up a key for readCachedModule.
-  CodeCompletionCache::Key K{filename.str(), "<module-name>", {},
-                             false,          false,           false,
-                             false,          false,           false};
+  CodeCompletionCache::Key K{/*ModuleFilename=*/filename.str(),
+                             /*ModuleName=*/"<module-name>",
+                             /*AccessPath=*/{},
+                             /*ResultsHaveLeadingDot=*/false,
+                             /*ForTestableLookup=*/false,
+                             /*ForPrivateImportLookup=*/false,
+                             /*SpiGroups=*/{},
+                             /*AddInitsInToplevel=*/false,
+                             /*AddCallWithNoDefaultArgs=*/false,
+                             /*Annotated=*/false};
 
   // Read the cached results.
   auto V = CodeCompletionCache::createValue();

--- a/test/IDE/complete_from_swift_module_spi.swift
+++ b/test/IDE/complete_from_swift_module_spi.swift
@@ -1,0 +1,61 @@
+// RUN: %empty-directory(%t/split)
+// RUN: %empty-directory(%t/build)
+// RUN: %{python} %utils/split_file.py -o %t/split %s
+
+// RUN: %target-swift-frontend -emit-module -o %t/build %t/split/pck.swift
+
+// First SPI completion then completion in file without SPI import
+// RUN: %empty-directory(%t/cc-cache)
+// RUN: %target-swift-ide-test -code-completion -completion-cache-path %t/cc-cache -source-filename %t/split/with-spi-import.swift -I %t/build -code-completion-token=COMPLETE | %FileCheck %s --check-prefix=WITH_SPI
+// RUN: %target-swift-ide-test -code-completion -completion-cache-path %t/cc-cache -source-filename %t/split/with-different-spi-import.swift -I %t/build -code-completion-token=COMPLETE | %FileCheck %s --check-prefix=WITHOUT_SPI
+// RUN: %target-swift-ide-test -code-completion -completion-cache-path %t/cc-cache -source-filename %t/split/with-normal-import.swift -I %t/build -code-completion-token=COMPLETE | %FileCheck %s --check-prefix=WITHOUT_SPI
+
+// First completion in file without SPI import, then with SPI import
+// RUN: %empty-directory(%t/cc-cache)
+// RUN: %target-swift-ide-test -code-completion -completion-cache-path %t/cc-cache -source-filename %t/split/with-normal-import.swift -I %t/build -code-completion-token=COMPLETE | %FileCheck %s --check-prefix=WITHOUT_SPI
+// RUN: %target-swift-ide-test -code-completion -completion-cache-path %t/cc-cache -source-filename %t/split/with-different-spi-import.swift -I %t/build -code-completion-token=COMPLETE | %FileCheck %s --check-prefix=WITHOUT_SPI
+// RUN: %target-swift-ide-test -code-completion -completion-cache-path %t/cc-cache -source-filename %t/split/with-spi-import.swift -I %t/build -code-completion-token=COMPLETE | %FileCheck %s --check-prefix=WITH_SPI
+
+// WITH_SPI: Begin completions
+// WITH_SPI-DAG: Decl[FreeFunction]/OtherModule[pck]: apiFunc()[#Void#]; name=apiFunc()
+// WITH_SPI-DAG: Decl[FreeFunction]/OtherModule[pck]: spiFunc()[#Void#]; name=spiFunc()
+// WITH_SPI: End completions
+
+// WITHOUT_SPI: Begin completions
+// WITHOUT_SPI-NOT: spiFunc
+// WITHOUT_SPI-DAG: Decl[FreeFunction]/OtherModule[pck]: apiFunc()[#Void#]; name=apiFunc()
+// WITHOUT_SPI-NOT: spiFunc
+// WITHOUT_SPI: End completions
+
+
+// BEGIN pck.swift
+
+public func apiFunc() {}
+
+@_spi(MySPI)
+public func spiFunc() {}
+
+// BEGIN with-spi-import.swift
+
+@_spi(MySPI) import pck
+
+func test() {
+  #^COMPLETE^#
+}
+
+// BEGIN with-different-spi-import.swift
+
+@_spi(OtherSPI) import pck
+
+func test() {
+  #^COMPLETE^#
+}
+
+
+// BEGIN with-normal-import.swift
+
+import pck
+
+func test() {
+  #^COMPLETE^#
+}


### PR DESCRIPTION
* **Explanation**: If a module is imported as `@_spi`, we didn’t receive any global completions from it. In particular, this meant that we weren’t getting good global code completion result in the [tests for the new SwiftParser](https://github.com/apple/swift-syntax/tree/main/Tests/SwiftParserTest), which uses `@_spi` quite extensively.
* **Scope**: Global completions from modules that are imported as `@_spi`
* **Risk**: I can’t think of any risk this might pose
* **Testing**: Added a regression tests
* **Issue**: rdar://99027179
* **Reviewer**: @rintaro on https://github.com/apple/swift/pull/60721