### PR TITLE
[CS] Improve diagnostics when `buildPartialBlock` is unavailable

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -107,6 +107,33 @@ enum class FreeTypeVariableBinding {
   UnresolvedType
 };
 
+/// Describes whether or not a result builder method is supported.
+struct ResultBuilderOpSupport {
+  enum Classification {
+    Unsupported,
+    Unavailable,
+    Supported
+  };
+  Classification Kind;
+
+  ResultBuilderOpSupport(Classification Kind) : Kind(Kind) {}
+
+  /// Returns whether or not the builder method is supported. If
+  /// \p requireAvailable is true, an unavailable method will be considered
+  /// unsupported.
+  bool isSupported(bool requireAvailable) const {
+    switch (Kind) {
+    case Unsupported:
+      return false;
+    case Unavailable:
+      return !requireAvailable;
+    case Supported:
+      return true;
+    }
+    llvm_unreachable("Unhandled case in switch!");
+  }
+};
+
 namespace constraints {
 
 struct ResultBuilder {
@@ -115,7 +142,9 @@ private:
   /// An implicit variable that represents `Self` type of the result builder.
   VarDecl *BuilderSelf;
   Type BuilderType;
-  llvm::SmallDenseMap<DeclName, bool> SupportedOps;
+
+  /// Cache of supported result builder operations.
+  llvm::SmallDenseMap<DeclName, ResultBuilderOpSupport> SupportedOps;
 
   Identifier BuildOptionalId;
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -172,6 +172,13 @@ public:
 
   bool supportsOptional() { return supports(getBuildOptionalId()); }
 
+  /// Checks whether the `buildPartialBlock` method is supported.
+  bool supportsBuildPartialBlock(bool checkAvailability);
+
+  /// Checks whether the builder can use `buildPartialBlock` to combine
+  /// expressions, instead of `buildBlock`.
+  bool canUseBuildPartialBlock();
+
   Expr *buildCall(SourceLoc loc, Identifier fnName,
                   ArrayRef<Expr *> argExprs,
                   ArrayRef<Identifier> argLabels) const;

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1234,10 +1234,20 @@ UnresolvedMemberExpr *getUnresolvedMemberChainBase(Expr *expr);
 /// Checks whether a result builder type has a well-formed result builder
 /// method with the given name. If provided and non-empty, the argument labels
 /// are verified against any candidates.
+ResultBuilderOpSupport
+checkBuilderOpSupport(Type builderType, DeclContext *dc, Identifier fnName,
+                      ArrayRef<Identifier> argLabels = {},
+                      SmallVectorImpl<ValueDecl *> *allResults = nullptr);
+
+/// Checks whether a result builder type has a well-formed result builder
+/// method with the given name. If provided and non-empty, the argument labels
+/// are verified against any candidates.
+///
+/// This will return \c true even if the builder method is unavailable. Use
+/// \c checkBuilderOpSupport if availability should be checked.
 bool typeSupportsBuilderOp(Type builderType, DeclContext *dc, Identifier fnName,
                            ArrayRef<Identifier> argLabels = {},
-                           SmallVectorImpl<ValueDecl *> *allResults = nullptr,
-                           bool checkAvailability = false);
+                           SmallVectorImpl<ValueDecl *> *allResults = nullptr);
 
 /// Forces all changes specified by the module's access notes file to be
 /// applied to this declaration. It is safe to call this function more than

--- a/test/StringProcessing/Sema/regex_builder_unavailable.swift
+++ b/test/StringProcessing/Sema/regex_builder_unavailable.swift
@@ -1,0 +1,28 @@
+// RUN: %target-typecheck-verify-swift -enable-bare-slash-regex -target %target-cpu-apple-macosx12.0
+
+// REQUIRES: OS=macosx
+
+import RegexBuilder
+
+// rdar://97533700 – Make sure we can emit an availability diagnostic here.
+
+let _ = Regex { // expected-error {{'Regex' is only available in macOS 13.0 or newer}}
+  // expected-error@-1 {{'init(_:)' is only available in macOS 13.0 or newer}}
+  // expected-note@-2 2{{add 'if #available' version check}}
+
+  Capture {} // expected-error {{'Capture' is only available in macOS 13.0 or newer}}
+  // expected-error@-1 {{'init(_:)' is only available in macOS 13.0 or newer}}
+  // expected-note@-2 2{{add 'if #available' version check}}
+}
+
+let _ = Regex { // expected-error {{'Regex' is only available in macOS 13.0 or newer}}
+  // expected-error@-1 {{'init(_:)' is only available in macOS 13.0 or newer}}
+  // expected-error@-2 {{'buildPartialBlock(accumulated:next:)' is only available in macOS 13.0 or newer}}
+  // expected-note@-3 3{{add 'if #available' version check}}
+
+  /abc/ // expected-error {{'Regex' is only available in macOS 13.0 or newer}}
+  // expected-note@-1 {{add 'if #available' version check}}
+
+  /def/ // expected-error {{'Regex' is only available in macOS 13.0 or newer}}
+  // expected-note@-1 {{add 'if #available' version check}}
+}


### PR DESCRIPTION
If `buildBlock` is also unavailable, or the builder itself is unavailable, continue to solve using `buildPartialBlock` to get better diagnostics.

This behavior technically differs from what is specified in [SE-0348](https://apple.github.io/swift-evolution/#?proposal=SE-0348), but only affects the invalid case where no builder methods are available to use.

In particular, this improves diagnostics for RegexComponentBuilder when the deployment target is too low. Previously we would try to solve using `buildBlock` (as `buildPartialBlock` is unavailable), but RegexComponentBuilder only defines `buildBlock` for the empty body case, leading to unhelpful diagnostics that ultimately preferred not to use the result builder at all.

rdar://97533700