### PR TITLE
[NFC] Two Tiny Cleanups

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -231,8 +231,6 @@ ERROR(disallowed_var_multiple_getset,none,
 
 ERROR(disallowed_init,none,
       "initial value is not allowed here", ())
-ERROR(var_init_self_referential,none,
-      "variable used within its own initial value", ())
 
 ERROR(disallowed_enum_element,none,
       "enum 'case' is not allowed outside of an enum", ())

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2062,8 +2062,6 @@ QualifiedLookupRequest::evaluate(Evaluator &eval, const DeclContext *DC,
     if (!wantProtocolMembers && !currentIsProtocol)
       continue;
 
-    SmallVector<ProtocolDecl *, 4> protocols;
-
     if (auto *protoDecl = dyn_cast<ProtocolDecl>(current)) {
       // If we haven't seen a class declaration yet, look into the protocol.
       if (!sawClassDecl) {


### PR DESCRIPTION
- Remove an unused diagnostic format string from when the parser was doing lookup
- Remove an unused vector of protocol decls in qualified lookup.