### PR TITLE
[Sema] Handle non-function type parameters for closure arguments in ambiguity diagnositc

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4039,7 +4039,8 @@ static bool diagnoseConflictingGenericArguments(ConstraintSystem &cs,
               return fix->getKind() == FixKind::AllowArgumentTypeMismatch ||
                      fix->getKind() == FixKind::AllowFunctionTypeMismatch ||
                      fix->getKind() == FixKind::AllowTupleTypeMismatch ||
-                     fix->getKind() == FixKind::GenericArgumentsMismatch;
+                     fix->getKind() == FixKind::GenericArgumentsMismatch ||
+                     fix->getKind() == FixKind::InsertCall;
             });
       });
 
@@ -4515,7 +4516,9 @@ static bool diagnoseContextualFunctionCallGenericAmbiguity(
 
     auto argParamMatch = argMatching->second.parameterBindings[i];
     auto param = applyFnType->getParams()[argParamMatch.front()];
-    auto paramFnType = param.getPlainType()->castTo<FunctionType>();
+    auto paramFnType = param.getPlainType()->getAs<FunctionType>();
+    if (!paramFnType)
+      continue;
 
     if (cs.typeVarOccursInType(resultTypeVar, paramFnType->getResult()))
       closureArguments.push_back(closure);

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -751,3 +751,15 @@ public class TestImplicitCaptureOfExplicitCaptureOfSelfInEscapingClosure {
     if s == "1" { return () } // expected-error{{cannot convert return expression of type '()' to return type 'Bool'}}
     return s.isEmpty
 }.filter { $0 }
+
+// https://github.com/apple/swift/issues/60781
+func f60781<T>(_ x: T) -> T { x }
+func f60781<T>(_ x: T, _ y: T) -> T { x }
+
+func test60781() -> Int {
+  f60781({ 1 }) // expected-error{{conflicting arguments to generic parameter 'T' ('Int' vs. '() -> Int')}}
+}
+
+func test60781_MultiArg() -> Int {
+  f60781({ 1 }, { 1 }) // expected-error{{conflicting arguments to generic parameter 'T' ('Int' vs. '() -> Int')}}
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
`diagnoseContextualFunctionCallGenericAmbiguity` assumed that closure argument parameter would be always a function type which is not the case for a generic argument `T` that can be inferred as a closure. So in this we just check for this case and let generic `diagnoseConflictingGenericArguments` handle the diagnostic. 
Also, adding `InsertCall` fix for `diagnoseConflictingGenericArguments`  because it is a tailored mismatch diagnostic for `() -> Int vs. Int`

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves https://github.com/apple/swift/issues/60781

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
