### PR TITLE
Preliminary Linux-OpenBSD cross-compile support.

### DIFF
--- a/cmake/modules/SwiftConfigureSDK.cmake
+++ b/cmake/modules/SwiftConfigureSDK.cmake
@@ -405,7 +405,7 @@ macro(configure_sdk_unix name architectures)
 
         set(SWIFT_SDK_OPENBSD_ARCH_amd64_TRIPLE "amd64-unknown-openbsd${openbsd_system_version}")
 
-	if(NOT CMAKE_SYSROOT STREQUAL "")
+	if(CMAKE_SYSROOT)
 	  set(SWIFT_SDK_OPENBSD_ARCH_${arch}_PATH "${CMAKE_SYSROOT}${SWIFT_SDK_OPENBSD_ARCH_${arch}_PATH}" CACHE INTERNAL "sysroot path" FORCE)
 	  set(SWIFT_SDK_OPENBSD_ARCH_${arch}_LIBC_INCLUDE_DIRECTORY "${CMAKE_SYSROOT}${SWIFT_SDK_OPENBSD_ARCH_${arch}_LIBC_INCLUDE_DIRECTORY}" CACHE INTERNAL "sysroot libc path" FORCE)
 	endif()

--- a/cmake/modules/SwiftConfigureSDK.cmake
+++ b/cmake/modules/SwiftConfigureSDK.cmake
@@ -404,6 +404,11 @@ macro(configure_sdk_unix name architectures)
         message(STATUS "OpenBSD Version: ${openbsd_system_version}")
 
         set(SWIFT_SDK_OPENBSD_ARCH_amd64_TRIPLE "amd64-unknown-openbsd${openbsd_system_version}")
+
+	if(NOT CMAKE_SYSROOT STREQUAL "")
+	  set(SWIFT_SDK_OPENBSD_ARCH_${arch}_PATH "${CMAKE_SYSROOT}${SWIFT_SDK_OPENBSD_ARCH_${arch}_PATH}" CACHE INTERNAL "sysroot path" FORCE)
+	  set(SWIFT_SDK_OPENBSD_ARCH_${arch}_LIBC_INCLUDE_DIRECTORY "${CMAKE_SYSROOT}${SWIFT_SDK_OPENBSD_ARCH_${arch}_LIBC_INCLUDE_DIRECTORY}" CACHE INTERNAL "sysroot libc path" FORCE)
+	endif()
       elseif("${prefix}" STREQUAL "CYGWIN")
         if(NOT arch STREQUAL x86_64)
           message(FATAL_ERROR "unsupported arch for cygwin: ${arch}")

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1082,7 +1082,7 @@ function false_true() {
 CROSS_COMPILE_HOSTS=($CROSS_COMPILE_HOSTS)
 for t in "${CROSS_COMPILE_HOSTS[@]}"; do
     case ${t} in
-        macosx* | iphone* | appletv* | watch* | linux-armv5 | linux-armv6 | linux-armv7 | android-* )
+        macosx* | iphone* | appletv* | watch* | linux-armv5 | linux-armv6 | linux-armv7 | android-* | openbsd-* )
             ;;
         *)
             echo "Unknown host to cross-compile for: ${t}"
@@ -1605,6 +1605,13 @@ for host in "${ALL_HOSTS[@]}"; do
                 -DCMAKE_BUILD_WITH_INSTALL_RPATH="1"
             )
         fi
+
+        if [[ "${host}" == "openbsd-"* && "${OPENBSD_USE_TOOLCHAIN_FILE}" != "" ]]; then
+            llvm_cmake_options=(
+                "${llvm_cmake_options[@]}"
+                -DCMAKE_TOOLCHAIN_FILE="${OPENBSD_USE_TOOLCHAIN_FILE}"
+            )
+        fi
     fi
 
     llvm_cmake_options=(
@@ -1884,6 +1891,13 @@ for host in "${ALL_HOSTS[@]}"; do
                         -DSWIFT_ANDROID_NDK_PATH:STRING="${ANDROID_NDK}"
                         -DSWIFT_ANDROID_DEPLOY_DEVICE_PATH:STRING="${ANDROID_DEPLOY_DEVICE_PATH}"
                         -DSWIFT_SDK_ANDROID_ARCHITECTURES:STRING="${ANDROID_ARCH}"
+                    )
+                fi
+
+                if [[ $(is_cross_tools_host ${host}) && "${host}" == "openbsd-"* && "${OPENBSD_USE_TOOLCHAIN_FILE}" != "" ]]; then
+                    cmake_options=(
+                        "${cmake_options[@]}"
+                        -DCMAKE_TOOLCHAIN_FILE="${OPENBSD_USE_TOOLCHAIN_FILE}"
                     )
                 fi
 

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1606,7 +1606,7 @@ for host in "${ALL_HOSTS[@]}"; do
             )
         fi
 
-        if [[ "${host}" == "openbsd-"* && "${OPENBSD_USE_TOOLCHAIN_FILE}" != "" ]]; then
+        if [[ "${host}" == "openbsd-"* && -n "${OPENBSD_USE_TOOLCHAIN_FILE}" ]]; then
             llvm_cmake_options=(
                 "${llvm_cmake_options[@]}"
                 -DCMAKE_TOOLCHAIN_FILE="${OPENBSD_USE_TOOLCHAIN_FILE}"
@@ -1894,7 +1894,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     )
                 fi
 
-                if [[ $(is_cross_tools_host ${host}) && "${host}" == "openbsd-"* && "${OPENBSD_USE_TOOLCHAIN_FILE}" != "" ]]; then
+                if [[ $(is_cross_tools_host ${host}) && "${host}" == "openbsd-"* && -n "${OPENBSD_USE_TOOLCHAIN_FILE}" ]]; then
                     cmake_options=(
                         "${cmake_options[@]}"
                         -DCMAKE_TOOLCHAIN_FILE="${OPENBSD_USE_TOOLCHAIN_FILE}"

--- a/utils/swift_build_support/swift_build_support/products/cmark.py
+++ b/utils/swift_build_support/swift_build_support/products/cmark.py
@@ -69,6 +69,10 @@ class CMark(cmake_product.CMakeProduct):
         elif platform == "linux":
             toolchain_file = self.generate_linux_toolchain_file(platform, arch)
             self.cmake_options.define('CMAKE_TOOLCHAIN_FILE:PATH', toolchain_file)
+        elif platform == "openbsd":
+            toolchain_file = self.get_openbsd_toolchain_file()
+            if toolchain_file:
+                self.cmake_options.define('CMAKE_TOOLCHAIN_FILE:PATH', toolchain_file)
 
         self.build_with_cmake(["all"], self.args.cmark_build_variant, [])
 

--- a/utils/swift_build_support/swift_build_support/products/product.py
+++ b/utils/swift_build_support/swift_build_support/products/product.py
@@ -366,6 +366,9 @@ class Product(object):
 
         return toolchain_file
 
+    def get_openbsd_toolchain_file(self):
+        return os.getenv('OPENBSD_USE_TOOLCHAIN_FILE')
+
     def common_cross_c_flags(self, platform, arch):
         cross_flags = []
 

--- a/utils/swift_build_support/swift_build_support/targets.py
+++ b/utils/swift_build_support/swift_build_support/targets.py
@@ -205,6 +205,14 @@ class AndroidPlatform(Platform):
         return config_file
 
 
+class OpenBSDPlatform(Platform):
+    def cmake_options(self, args):
+        toolchain_file = os.getenv('OPENBSD_USE_TOOLCHAIN_FILE')
+        if not toolchain_file:
+            return ''
+        return f'-DCMAKE_TOOLCHAIN_FILE="${toolchain_file}"'
+
+
 class Target(object):
     """
     Abstract representation of a target Swift can run on.
@@ -265,7 +273,7 @@ class StdlibDeploymentTarget(object):
 
     FreeBSD = Platform("freebsd", archs=["x86_64"])
 
-    OpenBSD = Platform("openbsd", archs=["amd64"])
+    OpenBSD = OpenBSDPlatform("openbsd", archs=["amd64"])
 
     Cygwin = Platform("cygwin", archs=["x86_64"])
 


### PR DESCRIPTION
With a properly prepared sysroot and toolchain file, these changes permit
cross-compilation of Swift as well as LLVM, CMark, and Dispatch (picking,
as usual, apple/swift-corelibs-libdispatch#556) from a Linux host
generating OpenBSD binaries.

The toolchain file must be specified as an environment variable to
`build-script` and discussion on how to properly set up the sysroot and
toolchain file will be handled later.
