### PR TITLE
Tests all cases of `infer-cross-compile-hosts-on-darwin` at once

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -413,17 +413,35 @@ def apply_default_arguments(toolchain, args):
 
     if (args.infer_cross_compile_hosts_on_darwin and
             platform.system() == "Darwin"):
-        args.cross_compile_hosts = _infer_cross_compile_hosts_on_darwin()
+        args.cross_compile_hosts = _infer_cross_compile_hosts_on_darwin(
+            get_running_arch(args.dry_run))
         print("Inferred the following hosts for cross compilations: "
               f"{args.cross_compile_hosts}")
         sys.stdout.flush()
 
 
-def _infer_cross_compile_hosts_on_darwin():
-    if platform.machine() == "x86_64":
+def _infer_cross_compile_hosts_on_darwin(arch_we_are_running_on):
+    if arch_we_are_running_on == "x86_64":
         return ["macosx-arm64"]
     else:
         return ["macosx-x86_64"]
+
+
+def get_running_arch(dry_run):
+    # We can override the detected arch to support
+    # BuildSystem/infer-cross-compile-hosts-on-darwin-macosx.test
+    # Given the narrow scenario, we preferred using
+    # an environment variable instead of a build-script
+    # argument to make this less discoverable on purpose
+    if dry_run:
+        injected_arch = os.environ.get(
+            'ARCH_FOR_BUILDSYSTEM_TESTS',
+            platform.machine())
+        print("DRY RUN: assume build-script is being run on a "
+              f"{injected_arch} machine")
+        return injected_arch
+    else:
+        return platform.machine()
 
 
 # -----------------------------------------------------------------------------

--- a/validation-test/BuildSystem/infer-cross-compile-hosts-on-darwin-macosx.test
+++ b/validation-test/BuildSystem/infer-cross-compile-hosts-on-darwin-macosx.test
@@ -2,9 +2,9 @@
 # REQUIRES: OS=macosx
 
 # RUN: %empty-directory(%t)
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --infer-cross-compile-hosts-on-darwin --cmake %cmake  2>&1 | %FileCheck --check-prefix=INFER-CROSS-COMPILE-HOSTS-ON-DARWIN-%target-cpu %s
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t ARCH_FOR_BUILDSYSTEM_TESTS=x86_64 %swift_src_root/utils/build-script --dry-run --infer-cross-compile-hosts-on-darwin --cmake %cmake  2>&1 | %FileCheck --check-prefix=INFER-CROSS-COMPILE-HOSTS-ON-DARWIN-x86_64 %s
 # RUN: %empty-directory(%t)
-# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --infer-cross-compile-hosts-on-darwin=1 --cmake %cmake  2>&1 | %FileCheck --check-prefix=INFER-CROSS-COMPILE-HOSTS-ON-DARWIN-%target-cpu %s
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t ARCH_FOR_BUILDSYSTEM_TESTS=arm64 %swift_src_root/utils/build-script --dry-run --infer-cross-compile-hosts-on-darwin=1 --cmake %cmake  2>&1 | %FileCheck --check-prefix=INFER-CROSS-COMPILE-HOSTS-ON-DARWIN-arm64 %s
 
 # INFER-CROSS-COMPILE-HOSTS-ON-DARWIN-x86_64: Inferred the following hosts for cross compilations: ['macosx-arm64']
 # INFER-CROSS-COMPILE-HOSTS-ON-DARWIN-arm64: Inferred the following hosts for cross compilations: ['macosx-x86_64']


### PR DESCRIPTION
The current implementation currently requires to have physical machine
for each architecture supported by macOS, which is not desirable.

To allow all cases to be tested on a random Mac machine, allow
to inject an arbitratry current architecture into the inference
of the cross compile hosts by means of an environment variable.

Addresses rdar://99096874