### PR TITLE
[ConstraintSystem] Print constraint simplification in type inference debug output

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4421,7 +4421,7 @@ public:
 
     if (isDebugMode()) {
       auto &log = llvm::errs();
-      log.indent(solverState ? solverState->getCurrentIndent() : 0)
+      log.indent(solverState ? solverState->getCurrentIndent() + 4 : 0)
           << "(failed constraint ";
       constraint->print(log, &getASTContext().SourceMgr);
       log << ")\n";
@@ -4446,7 +4446,7 @@ public:
 
     if (isDebugMode() && getPhase() == ConstraintSystemPhase::Solving) {
       auto &log = llvm::errs();
-      log.indent(solverState->getCurrentIndent() + 2) << "(added constraint: ";
+      log.indent(solverState->getCurrentIndent() + 4) << "(added constraint: ";
       constraint->print(log, &getASTContext().SourceMgr,
                         solverState->getCurrentIndent() + 4);
       log << ")\n";
@@ -4464,7 +4464,7 @@ public:
 
     if (isDebugMode() && getPhase() == ConstraintSystemPhase::Solving) {
       auto &log = llvm::errs();
-      log.indent(solverState->getCurrentIndent() + 2)
+      log.indent(solverState->getCurrentIndent() + 4)
           << "(removed constraint: ";
       constraint->print(log, &getASTContext().SourceMgr,
                         solverState->getCurrentIndent() + 4);

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4447,7 +4447,8 @@ public:
     if (isDebugMode() && getPhase() == ConstraintSystemPhase::Solving) {
       auto &log = llvm::errs();
       log.indent(solverState->getCurrentIndent() + 2) << "(added constraint: ";
-      constraint->print(log, &getASTContext().SourceMgr);
+      constraint->print(log, &getASTContext().SourceMgr,
+                        solverState->getCurrentIndent() + 4);
       log << ")\n";
     }
 
@@ -4465,7 +4466,8 @@ public:
       auto &log = llvm::errs();
       log.indent(solverState->getCurrentIndent() + 2)
           << "(removed constraint: ";
-      constraint->print(log, &getASTContext().SourceMgr);
+      constraint->print(log, &getASTContext().SourceMgr,
+                        solverState->getCurrentIndent() + 4);
       log << ")\n";
     }
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4444,6 +4444,13 @@ public:
     // Add this constraint to the constraint graph.
     CG.addConstraint(constraint);
 
+    if (isDebugMode() && getPhase() == ConstraintSystemPhase::Solving) {
+      auto &log = llvm::errs();
+      log.indent(solverState->getCurrentIndent() + 2) << "(added constraint: ";
+      constraint->print(log, &getASTContext().SourceMgr);
+      log << ")\n";
+    }
+
     // Record this as a newly-generated constraint.
     if (solverState)
       solverState->addGeneratedConstraint(constraint);
@@ -4453,6 +4460,14 @@ public:
   void removeInactiveConstraint(Constraint *constraint) {
     CG.removeConstraint(constraint);
     InactiveConstraints.erase(constraint);
+
+    if (isDebugMode() && getPhase() == ConstraintSystemPhase::Solving) {
+      auto &log = llvm::errs();
+      log.indent(solverState->getCurrentIndent() + 2)
+          << "(removed constraint: ";
+      constraint->print(log, &getASTContext().SourceMgr);
+      log << ")\n";
+    }
 
     if (solverState)
       solverState->retireConstraint(constraint);

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -351,6 +351,14 @@ bool ConstraintSystem::simplify() {
       log << "(considering -> ";
       constraint->print(log, &getASTContext().SourceMgr);
       log << "\n";
+
+      // {Dis, Con}junction are returned unsolved in \c simplifyConstraint() and
+      // handled separately by solver steps.
+      if (constraint->getKind() != ConstraintKind::Disjunction &&
+          constraint->getKind() != ConstraintKind::Conjunction) {
+        log.indent(solverState->getCurrentIndent() + 2)
+            << "(simplification result:\n";
+      }
     }
 
     // Simplify this constraint.
@@ -359,6 +367,7 @@ bool ConstraintSystem::simplify() {
       retireFailedConstraint(constraint);
       if (isDebugMode()) {
         auto &log = llvm::errs();
+        log.indent(solverState->getCurrentIndent() + 2) << ")\n";
         log.indent(solverState->getCurrentIndent() + 2) << "(outcome: error)\n";
       }
       break;
@@ -369,6 +378,7 @@ bool ConstraintSystem::simplify() {
       retireConstraint(constraint);
       if (isDebugMode()) {
         auto &log = llvm::errs();
+        log.indent(solverState->getCurrentIndent() + 2) << ")\n";
         log.indent(solverState->getCurrentIndent() + 2)
             << "(outcome: simplified)\n";
       }
@@ -379,6 +389,7 @@ bool ConstraintSystem::simplify() {
         ++solverState->NumUnsimplifiedConstraints;
       if (isDebugMode()) {
         auto &log = llvm::errs();
+        log.indent(solverState->getCurrentIndent() + 2) << ")\n";
         log.indent(solverState->getCurrentIndent() + 2)
             << "(outcome: unsolved)\n";
       }

--- a/test/Concurrency/async_overload_filtering.swift
+++ b/test/Concurrency/async_overload_filtering.swift
@@ -18,8 +18,9 @@ var a: String? = nil
 
 // CHECK: attempting disjunction choice $T0 bound to decl async_overload_filtering.(file).filter_async(fn2:)
 // CHECK-NEXT: overload set choice binding $T0 := {{.*}}
-// CHECK-NEXT: increasing 'sync-in-asynchronous' score by 1
-// CHECK-NEXT: solution is worse than the best solution
+// CHECK-NEXT: (considering -> ({{.*}}) -> {{.*}} applicable fn {{.*}}
+// CHECK: increasing 'sync-in-asynchronous' score by 1
+// CHECK: solution is worse than the best solution
 filter_async {
   Obj()
 }.op("" + (a ?? "a"))

--- a/test/Constraints/common_type.swift
+++ b/test/Constraints/common_type.swift
@@ -28,9 +28,11 @@ func f(_: Double) -> Y { return Y() }
 
 func testCallCommonType() {
   // CHECK: overload set choice binding $T{{[0-9]+}} := (Int) -> X
-  // CHECK-NEXT: (common result type for $T{{[0-9]+}} is Int)
+  // CHECK: (considering -> $T{{[0-9]+}}[.g: value] == [[G:\$T[0-9]+]]
+  // CHECK: (common result type for [[G]] is Int)
   // CHECK: (overload set choice binding $T{{[0-9]+}} := (Double) -> Y)
-  // CHECK-NEXT: (common result type for $T{{[0-9]+}} is Double)
+  // CHECK: (considering -> $T{{[0-9]+}}[.g: value] == [[F:\$T[0-9]+]]
+  // CHECK: (common result type for [[F]] is Double)
   _ = f(0).g(0)
 }
 

--- a/test/Constraints/one_way_solve.swift
+++ b/test/Constraints/one_way_solve.swift
@@ -7,11 +7,11 @@ func takeDoubleAndBool(_: Double, _: Bool) { }
 
 func testTernaryOneWay(b: Bool, b2: Bool) {
   // CHECK: ---Connected components---
-  // CHECK-NEXT: 3: $T10 depends on 1
-  // CHECK-NEXT: 1: $T5 $T8 $T9 depends on 0, 2
-  // CHECK-NEXT: 2: $T7
-  // CHECK-NEXT: 0: $T4
-  // CHECK-NEXT: 4: $T11 $T13 $T14
+  // CHECK-NEXT: 3: $T{{[0-9]+}} depends on 1
+  // CHECK-NEXT: 1: $T{{[0-9]+}} $T{{[0-9]+}} $T{{[0-9]+}} depends on 0, 2
+  // CHECK-NEXT: 2: $T{{[0-9]+}}
+  // CHECK-NEXT: 0: $T{{[0-9]+}}
+  // CHECK-NEXT: 4: $T{{[0-9]+}} $T{{[0-9]+}} $T{{[0-9]+}}
   takeDoubleAndBool(
     Builtin.one_way(
       b ? Builtin.one_way(3.14159) : Builtin.one_way(2.71828)),
@@ -23,22 +23,25 @@ func int8Or16(_ x: Int16) -> Int16 { return x }
 
 func testTernaryOneWayOverload(b: Bool) {
   // CHECK: ---Connected components---
-  // CHECK: 1: $T5 $T10 $T11 depends on 0, 2
-  // CHECK: 2: $T7 $T8 $T9
-  // CHECK: 0: $T2 $T3 $T4
+  // CHECK: 1: [[A:\$T[0-9]+]] [[B:\$T[0-9]+]] [[C:\$T[0-9]+]] depends on 0, 2
+  // CHECK: 2: $T{{[0-9]+}} $T{{[0-9]+}} $T{{[0-9]+}}
+  // CHECK: 0: $T{{[0-9]+}} $T{{[0-9]+}} $T{{[0-9]+}}
 
   // CHECK: solving component #1
-  // CHECK: (attempting type variable $T11 := Int8
+  // CHECK: (attempting type variable [[C]] := Int8
 
   // CHECK: solving component #1
-  // CHECK: (attempting type variable $T11 := Int8
+  // CHECK: (attempting type variable [[C]] := Int8
 
   // CHECK: solving component #1
-  // CHECK: (attempting type variable $T11 := Int8
+  // CHECK: (attempting type variable [[C]] := Int8
 
   // CHECK: solving component #1
-  // CHECK: (attempting type variable $T11 := Int8 
-  // CHECK: (found solution: [component: non-default literal(s), value: 2] [component: use of overloaded unapplied function(s), value: 2]) 
+  // CHECK: (attempting type variable [[C]] := Int8
+  // CHECK: (considering -> $T{{[0-9]+}} conv [[C]]
+  // CHECK: (considering -> $T{{[0-9]+}} conv [[C]]
+  // CHECK: (considering -> [[C]] conv Int8
+  // CHECK: (found solution: [component: non-default literal(s), value: 2] [component: use of overloaded unapplied function(s), value: 2])
 
   // CHECK: (composed solution: [component: non-default literal(s), value: 2] [component: use of overloaded unapplied function(s), value: 2])
   // CHECK-NOT: (composed solution: [component: non-default literal(s), value: 2] [component: use of overloaded unapplied function(s), value: 2])

--- a/test/Constraints/overload_filtering.swift
+++ b/test/Constraints/overload_filtering.swift
@@ -35,6 +35,10 @@ func testSubscript(x: X, i: Int) {
 func testUnresolvedMember(i: Int) -> X {
   // CHECK: disabled disjunction term {{.*}} bound to decl overload_filtering.(file).X.init(_:)
   // CHECK-NEXT: disabled disjunction term {{.*}} bound to decl overload_filtering.(file).X.init(_:_:_:)
+  // CHECK-NEXT: (removed constraint: disjunction
+  // CHECK-NEXT: > [[A:\$T[0-9]+]] bound to decl overload_filtering
+  // CHECK-NEXT: > [disabled] [[A]] bound to decl overload_filtering
+  // CHECK-NEXT: > [disabled] [[A]] bound to decl overload_filtering
   // CHECK-NEXT: introducing single enabled disjunction term {{.*}} bound to decl overload_filtering.(file).X.init(_:_:)
   return .init(i, i)
 }
@@ -56,6 +60,10 @@ func test_member_filtering() {
   func test(s: S) {
     // CHECK: disabled disjunction term {{.*}} bound to decl overload_filtering.(file).test_member_filtering().S.bar(v:)
     // CHECK-NEXT: disabled disjunction term {{.*}} bound to decl overload_filtering.(file).test_member_filtering().S.bar(a:b:)
+    // CHECK-NEXT: (removed constraint: disjunction
+    // CHECK-NEXT: > [[B:\$T[0-9]+]] bound to decl overload_filtering
+    // CHECK-NEXT: > [disabled] [[B]] bound to decl overload_filtering
+    // CHECK-NEXT: > [disabled] [[B]] bound to decl overload_filtering
     // CHECK-NEXT: introducing single enabled disjunction term {{.*}} bound to decl overload_filtering.(file).test_member_filtering().S.bar
     s.foo(42).bar(42)
   }


### PR DESCRIPTION
The constraint currently being evaluated for the overload, any new constraints added as a result of this evaluation (or removed), and the result of the simplification will be printed out to show the constraint simplification process of the constraint solver.

The following is a constraint simplification attempt for an overload choice of `$T0 := (String, String) -> String)`. The initial constraint is simplified and two new smaller constraints are generated to evaluate the expression for this overload. The initial constraint is then removed and the simplification is shown as `simplified`:
```
(considering -> (_const $T1, _const $T2) -> $T3 applicable fn $T0 [[locator@0x13704a3f0 [Binary@/... -> apply function]]];
  (simplification result: 
    (added Constraint: $T1 operator arg conv String [[locator@0x13704a4c0 [Binary@/... -> apply argument -> comparing call argument #0 to parameter #0]]];)
    (added Constraint: $T2 operator arg conv String [[locator@0x13704a560 [Binary@/... -> apply argument -> comparing call argument #1 to parameter #1]]];)
    (removed Constraint: (_const $T1, _const $T2) -> $T3 applicable fn $T0 [[locator@0x13704a3f0 [Binary@/... -> apply function]]];)
  )
  (outcome: simplified)
)
```

If the constraint simplification attempt fails, it will print the constraints followed by an error result:
```
(considering -> (_const $T2, _const $T3) -> $T4 applicable fn $T1 [[locator@0x13f09b190 [Binary@/... -> apply function]]];
  (simplification result:
    (added constraint: $T2 operator arg conv String [[locator@0x13f09b680 [Binary@/...-> apply argument -> comparing call argument #0 to parameter #0]]];)
    (added constraint: $T3 operator arg conv String [[locator@0x13f09b720 [Binary@/... -> apply argument -> comparing call argument #1 to parameter #1]]];)
    (removed constraint: (_const $T2, _const $T3) -> $T4 applicable fn $T1 [[locator@0x13f09b190 [Binary@/... -> apply function]]];)
    (failed constraint (_const $T2, _const $T3) -> $T4 applicable fn $T1 [[locator@0x13f09b190 [Binary@/... -> apply function]]];)
  )
  (outcome: error)
)
```

If an added constraint is a disjunction kind, its choices will be nested:
```
(considering -> @lvalue Int? operator arg conv $T5 [[locator@0x13e00d360 [Binary@/Users/amritpankaur/test.swift:72:18 -> apply argument -> comparing call argument #1 to parameter #1 -> @autoclosure result]]];
  (simplification result:
    (added constraint: disjunction [[locator@0x13e00d360 [Binary@/Users/amritpankaur/test.swift:72:18 -> apply argument -> comparing call argument #1 to parameter #1 -> @autoclosure result]]]:
    >  [favored]  Int? bind Int?? [deep equality] [[locator@0x13e00d360 [Binary@/Users/amritpankaur/test.swift:72:18 -> apply argument -> comparing call argument #1 to parameter #1 -> @autoclosure result]]];
    >             Int? operator arg conv Int?? [optional-to-optional] [[locator@0x13e00d360 [Binary@/Users/amritpankaur/test.swift:72:18 -> apply argument -> comparing call argument #1 to parameter #1 -> @autoclosure result]]];
    >             Int? operator arg conv Int?? [value-to-optional] [[locator@0x13e00d360 [Binary@/Users/amritpankaur/test.swift:72:18 -> apply argument -> comparing call argument #1 to parameter #1 -> @autoclosure result]]];)
  (removed constraint: @lvalue Int? operator arg conv $T5 [[locator@0x13e00d360 [Binary@/Users/amritpankaur/test.swift:72:18 -> apply argument -> comparing call argument #1 to parameter #1 -> @autoclosure result]]];)
  )
  (outcome: simplified)
)
```

This adds to the solver step `Changes` printed in apple/swift#59971.