### PR TITLE
ABI checker: we should also print ABI breakages when diagnostics are serialized

### DIFF
--- a/include/swift/APIDigester/ModuleDiagsConsumer.h
+++ b/include/swift/APIDigester/ModuleDiagsConsumer.h
@@ -44,23 +44,20 @@ public:
 
 class FilteringDiagnosticConsumer: public DiagnosticConsumer {
   bool HasError = false;
-  std::unique_ptr<DiagnosticConsumer> subConsumer;
+  std::vector<std::unique_ptr<DiagnosticConsumer>> subConsumers;
   std::unique_ptr<llvm::StringSet<>> allowedBreakages;
   bool shouldProceed(const DiagnosticInfo &Info);
 public:
-  FilteringDiagnosticConsumer(std::unique_ptr<DiagnosticConsumer> subConsumer,
+  FilteringDiagnosticConsumer(std::vector<std::unique_ptr<DiagnosticConsumer>> subConsumers,
                               std::unique_ptr<llvm::StringSet<>> allowedBreakages):
-    subConsumer(std::move(subConsumer)),
+    subConsumers(std::move(subConsumers)),
     allowedBreakages(std::move(allowedBreakages)) {}
   ~FilteringDiagnosticConsumer() = default;
 
-  bool finishProcessing() override { return subConsumer->finishProcessing(); }
+  void flush() override;
+  void informDriverOfIncompleteBatchModeCompilation() override;
+  bool finishProcessing() override;
   bool hasError() const { return HasError; }
-  void flush() override { subConsumer->flush(); }
-
-  void informDriverOfIncompleteBatchModeCompilation() override {
-    subConsumer->informDriverOfIncompleteBatchModeCompilation();
-  }
 
   void handleDiagnostic(SourceManager &SM,
                         const DiagnosticInfo &Info) override;

--- a/lib/APIDigester/ModuleDiagsConsumer.cpp
+++ b/lib/APIDigester/ModuleDiagsConsumer.cpp
@@ -124,8 +124,27 @@ swift::ide::api::ModuleDifferDiagsConsumer::~ModuleDifferDiagsConsumer() {
   }
 }
 
-bool swift::ide::api::
-FilteringDiagnosticConsumer::shouldProceed(const DiagnosticInfo &Info) {
+void swift::ide::api::FilteringDiagnosticConsumer::flush() {
+  for (auto &consumer: subConsumers) {
+    consumer->flush();
+  }
+}
+
+void swift::ide::api::
+FilteringDiagnosticConsumer::informDriverOfIncompleteBatchModeCompilation() {
+  for (auto &consumer: subConsumers) {
+    consumer->informDriverOfIncompleteBatchModeCompilation();
+  }
+}
+
+bool swift::ide::api::FilteringDiagnosticConsumer::finishProcessing() {
+  for (auto &consumer: subConsumers) {
+    consumer->finishProcessing();
+  }
+  return false;
+}
+
+bool swift::ide::api::FilteringDiagnosticConsumer::shouldProceed(const DiagnosticInfo &Info) {
   if (allowedBreakages->empty()) {
     return true;
   }
@@ -145,6 +164,8 @@ FilteringDiagnosticConsumer::handleDiagnostic(SourceManager &SM,
     if (Info.Kind == DiagnosticKind::Error) {
       HasError = true;
     }
-    subConsumer->handleDiagnostic(SM, Info);
+    for (auto &consumer: subConsumers) {
+      consumer->handleDiagnostic(SM, Info);
+    }
   }
 }

--- a/test/api-digester/serialized-diagnostics.swift
+++ b/test/api-digester/serialized-diagnostics.swift
@@ -3,10 +3,11 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend -disable-objc-attr-requires-foundation-module -emit-module -o %t/color.swiftmodule %S/Inputs/cake_baseline/color.swift -parse-as-library -enable-library-evolution %clang-importer-sdk-nosource -module-name color
-// RUN: %api-digester -diagnose-sdk -serialize-diagnostics-path %t/result.dia -empty-baseline -I %t %clang-importer-sdk-nosource -module color -abi
+// RUN: %api-digester -diagnose-sdk -serialize-diagnostics-path %t/result.dia -empty-baseline -I %t %clang-importer-sdk-nosource -module color -abi 2>&1 | %FileCheck %s -check-prefix CHECK-STDERR
 // RUN: c-index-test -read-diagnostics %t/result.dia 2>&1 | %FileCheck %s -check-prefix CHECK-DIA
 // RUN: %api-digester -diagnose-sdk -serialize-diagnostics-path %t/result.dia -empty-baseline -I %t %clang-importer-sdk-nosource -module color -abi -disable-fail-on-error
 // RUN: c-index-test -read-diagnostics %t/result.dia 2>&1 | %FileCheck %s -check-prefix CHECK-DIA
 
 // Ensure the 'api-digester-breaking-change' category is included in the serialized diagnostics file.
 // CHECK-DIA: warning: ABI breakage: enum Color is a new API without @available attribute [] [api-digester-breaking-change]
+// CHECK-STDERR: warning: ABI breakage: enum Color is a new API without @available attribute


### PR DESCRIPTION
This ensures users can review ABI checker failures from build logs alone.

rdar://98624267