### PR TITLE
[ConstraintSystem] Teach partial application check about implicit con…

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2751,6 +2751,13 @@ static std::pair<bool, unsigned>
 isInvalidPartialApplication(ConstraintSystem &cs,
                             const AbstractFunctionDecl *member,
                             ConstraintLocator *locator) {
+  // If this is a compiler synthesized implicit conversion, let's skip
+  // the check because the base of `UDE` is not the base of the injected
+  // initializer.
+  if (locator->isLastElement<LocatorPathElt::ConstructorMember>() &&
+      locator->findFirst<LocatorPathElt::ImplicitConversion>())
+    return {false, 0};
+
   auto *UDE = getAsExpr<UnresolvedDotExpr>(locator->getAnchor());
   if (UDE == nullptr)
     return {false,0};

--- a/test/Constraints/implicit_double_cgfloat_conversion.swift
+++ b/test/Constraints/implicit_double_cgfloat_conversion.swift
@@ -315,3 +315,18 @@ do {
     }
   }
 }
+
+// rdar://99282938
+func test_implicit_conversion_clash_with_partial_application_check() {
+  class C {
+    var duration: CGFloat { 0.3 }
+
+    var use: Double {
+      duration // Ok
+    }
+
+    func transitionDuration() -> TimeInterval {
+      duration // Ok
+    }
+  }
+}


### PR DESCRIPTION
…versions

Implicit conversion used to erase path for contextual type conversions
but it does so no longer, this means that invalid partial application
check needs to know about existence of implicit conversions that are
not reflected in the AST until solution is applied.

Resolves: rdar://99282932

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
