### PR TITLE
[ConstraintSystem] Before applying the result builder transform to a function body, map the result builder type into context.

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5528,6 +5528,9 @@ public:
 
   /// Apply the given result builder to the closure expression.
   ///
+  /// \note builderType must be a contexutal type - callers should
+  /// open the builder type or map it into context as appropriate.
+  ///
   /// \returns \c None when the result builder cannot be applied at all,
   /// otherwise the result of applying the result builder.
   Optional<TypeMatchResult>

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -2335,6 +2335,12 @@ Optional<BraceStmt *> TypeChecker::applyResultBuilderBodyTransform(
     log << '\n';
   }
 
+  // Map type parameters into context. We don't want type
+  // parameters to appear in the result builder type, because
+  // the result builder type will only be used inside the body
+  // of this decl; it's not part of the interface type.
+  builderType = func->mapTypeIntoContext(builderType);
+
   if (auto result = cs.matchResultBuilder(
           func, builderType, resultContextType, resultConstraintKind,
           cs.getConstraintLocator(func->getBody()))) {
@@ -2425,6 +2431,7 @@ ConstraintSystem::matchResultBuilder(AnyFunctionRef fn, Type builderType,
   auto builder = builderType->getAnyNominal();
   assert(builder && "Bad result builder type");
   assert(builder->getAttrs().hasAttribute<ResultBuilderAttr>());
+  assert(!builderType->hasTypeParameter());
 
   if (InvalidResultBuilderBodies.count(fn)) {
     (void)recordFix(IgnoreInvalidResultBuilderBody::create(

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -287,16 +287,13 @@ static Type inferResultBuilderType(ValueDecl *decl)  {
           continue;
 
         // Substitute Self and associated type witnesses into the
-        // result builder type. Then, map all type parameters from
-        // the conforming type into context. We don't want type
-        // parameters to appear in the result builder type, because
-        // the result builder type will only be used inside the body
-        // of this decl; it's not part of the interface type.
+        // result builder type. Type parameters will be mapped
+        // into context when applying the result builder to the
+        // function body in the constraint system.
         auto subs = SubstitutionMap::getProtocolSubstitutions(
             protocol, dc->getSelfInterfaceType(),
             ProtocolConformanceRef(conformance));
-        Type subResultBuilderType = dc->mapTypeIntoContext(
-            resultBuilderType.subst(subs));
+        Type subResultBuilderType = resultBuilderType.subst(subs);
 
         matches.push_back(
             Match::forConformance(

--- a/test/Constraints/result_builder_generic_infer.swift
+++ b/test/Constraints/result_builder_generic_infer.swift
@@ -41,6 +41,19 @@ struct ArchetypeSubstitution<A>: P {
   var x2: [S] { S() }
 }
 
+// CHECK-LABEL: struct_decl{{.*}}ExplicitGenericAttribute
+struct ExplicitGenericAttribute<T: P> {
+  // CHECK: var_decl{{.*}}x1
+  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature=<T> (substitution T -> T))
+  @Builder<T>
+  var x1: [S] { S() }
+
+  // CHECK: var_decl{{.*}}x2
+  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature=<T> (substitution T -> T.A))
+  @Builder<T.A>
+  var x2: [S] { S() }
+}
+
 // CHECK: struct_decl{{.*}}ConcreteTypeSubstitution
 struct ConcreteTypeSubstitution<Value> {}
 


### PR DESCRIPTION
This was already done for inferred result builder attributes; now, the constraint system will map the builder type into context for all result builder attributes applied to computed properties/functions.

Resolves: rdar://99162854