### PR TITLE
[interop][SwiftToCxx] initial generic struct support

### DIFF
--- a/include/swift/IRGen/IRABIDetailsProvider.h
+++ b/include/swift/IRGen/IRABIDetailsProvider.h
@@ -105,6 +105,12 @@ public:
   /// access function.
   FunctionABISignature getTypeMetadataAccessFunctionSignature();
 
+  /// Returns additional generic requirement parameters that are required to
+  /// call the type metadata access function for the given type.
+  SmallVector<GenericRequirement, 2>
+  getTypeMetadataAccessFunctionGenericRequirementParameters(
+      NominalTypeDecl *nominal);
+
   struct EnumElementInfo {
     unsigned tag;
     StringRef globalVariableName;

--- a/lib/IRGen/IRABIDetailsProvider.cpp
+++ b/lib/IRGen/IRABIDetailsProvider.cpp
@@ -15,6 +15,7 @@
 #include "FixedTypeInfo.h"
 #include "GenEnum.h"
 #include "GenType.h"
+#include "GenericRequirement.h"
 #include "IRGen.h"
 #include "IRGenModule.h"
 #include "NativeConventionSchema.h"
@@ -126,6 +127,16 @@ public:
     return {returnTy, {paramTy}};
   }
 
+  SmallVector<GenericRequirement, 2>
+  getTypeMetadataAccessFunctionGenericRequirementParameters(
+      NominalTypeDecl *nominal) {
+    GenericTypeRequirements requirements(IGM, nominal);
+    SmallVector<GenericRequirement, 2> result;
+    for (const auto &req : requirements.getRequirements())
+      result.push_back(req);
+    return result;
+  }
+
   llvm::MapVector<EnumElementDecl *, IRABIDetailsProvider::EnumElementInfo>
   getEnumTagMapping(const EnumDecl *ED) {
     llvm::MapVector<EnumElementDecl *, IRABIDetailsProvider::EnumElementInfo>
@@ -219,6 +230,13 @@ bool IRABIDetailsProvider::enumerateDirectPassingRecordMembers(
 IRABIDetailsProvider::FunctionABISignature
 IRABIDetailsProvider::getTypeMetadataAccessFunctionSignature() {
   return impl->getTypeMetadataAccessFunctionSignature();
+}
+
+SmallVector<GenericRequirement, 2>
+IRABIDetailsProvider::getTypeMetadataAccessFunctionGenericRequirementParameters(
+    NominalTypeDecl *nominal) {
+  return impl->getTypeMetadataAccessFunctionGenericRequirementParameters(
+      nominal);
 }
 
 llvm::MapVector<EnumElementDecl *, IRABIDetailsProvider::EnumElementInfo>

--- a/lib/PrintAsClang/ClangSyntaxPrinter.cpp
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.cpp
@@ -191,6 +191,11 @@ void ClangSyntaxPrinter::printValueWitnessTableAccessSequenceFromTypeMetadata(
 void ClangSyntaxPrinter::printCTypeMetadataTypeFunction(
     const NominalTypeDecl *typeDecl, StringRef typeMetadataFuncName,
     llvm::ArrayRef<GenericRequirement> genericRequirements) {
+  // FIXME: Support generic requirements > 3.
+  if (!genericRequirements.empty())
+    os << "static_assert(" << genericRequirements.size()
+       << " <= " << NumDirectGenericTypeMetadataAccessFunctionArgs
+       << ", \"unsupported generic requirement list for metadata func\");\n";
   os << "// Type metadata accessor for " << typeDecl->getNameStr() << "\n";
   os << "SWIFT_EXTERN ";
   printSwiftImplQualifier();

--- a/lib/PrintAsClang/ClangSyntaxPrinter.cpp
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.cpp
@@ -265,3 +265,11 @@ void ClangSyntaxPrinter::printGenericRequirementsInstantiantions(
                           printGenericRequirementInstantiantion(requirement);
                         });
 }
+
+void ClangSyntaxPrinter::printPrimaryCxxTypeName(
+    const NominalTypeDecl *type, const ModuleDecl *moduleContext) {
+  printModuleNamespaceQualifiersIfNeeded(type->getModuleContext(),
+                                         moduleContext);
+  // FIXME: Print class qualifiers for nested class references.
+  printBaseName(type);
+}

--- a/lib/PrintAsClang/ClangSyntaxPrinter.cpp
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.cpp
@@ -159,8 +159,10 @@ void ClangSyntaxPrinter::printNullability(
 }
 
 void ClangSyntaxPrinter::printSwiftTypeMetadataAccessFunctionCall(
-    StringRef name) {
-  os << name << "(0)";
+    StringRef name, ArrayRef<GenericRequirement> requirements) {
+  os << name << "(0";
+  printGenericRequirementsInstantiantions(requirements, LeadingTrivia::Comma);
+  os << ')';
 }
 
 void ClangSyntaxPrinter::printValueWitnessTableAccessSequenceFromTypeMetadata(
@@ -187,12 +189,79 @@ void ClangSyntaxPrinter::printValueWitnessTableAccessSequenceFromTypeMetadata(
 }
 
 void ClangSyntaxPrinter::printCTypeMetadataTypeFunction(
-    const NominalTypeDecl *typeDecl, StringRef typeMetadataFuncName) {
+    const NominalTypeDecl *typeDecl, StringRef typeMetadataFuncName,
+    llvm::ArrayRef<GenericRequirement> genericRequirements) {
   os << "// Type metadata accessor for " << typeDecl->getNameStr() << "\n";
   os << "SWIFT_EXTERN ";
   printSwiftImplQualifier();
   os << "MetadataResponseTy " << typeMetadataFuncName << '(';
   printSwiftImplQualifier();
-  os << "MetadataRequestTy)";
+  os << "MetadataRequestTy";
+  if (!genericRequirements.empty())
+    os << ", ";
+  llvm::interleaveComma(genericRequirements, os,
+                        [&](const GenericRequirement &) {
+                          // FIXME: Print parameter name.
+                          os << "void * _Nonnull";
+                        });
+  os << ')';
   os << " SWIFT_NOEXCEPT SWIFT_CALL;\n\n";
+}
+
+void ClangSyntaxPrinter::printGenericTypeParamTypeName(
+    const GenericTypeParamType *gtpt) {
+  os << "T_" << gtpt->getDepth() << '_' << gtpt->getIndex();
+}
+
+void ClangSyntaxPrinter::printGenericSignature(
+    const CanGenericSignature &signature) {
+  os << "template<";
+  llvm::interleaveComma(
+      signature.getGenericParams(), os,
+      [&](const CanTypeWrapper<GenericTypeParamType> &genericParamType) {
+        os << "class ";
+        printGenericTypeParamTypeName(genericParamType);
+      });
+  os << ">\n";
+  os << "requires ";
+  llvm::interleave(
+      signature.getGenericParams(), os,
+      [&](const CanTypeWrapper<GenericTypeParamType> &genericParamType) {
+        os << "swift::isUsableInGenericContext<";
+        printGenericTypeParamTypeName(genericParamType);
+        os << ">";
+      },
+      " && ");
+  os << "\n";
+}
+
+void ClangSyntaxPrinter::printGenericSignatureParams(
+    const CanGenericSignature &signature) {
+  os << '<';
+  llvm::interleaveComma(
+      signature.getGenericParams(), os,
+      [&](const CanTypeWrapper<GenericTypeParamType> &genericParamType) {
+        printGenericTypeParamTypeName(genericParamType);
+      });
+  os << '>';
+}
+
+void ClangSyntaxPrinter::printGenericRequirementInstantiantion(
+    const GenericRequirement &requirement) {
+  assert(!requirement.Protocol && "protocol requirements not supported yet!");
+  auto *gtpt = requirement.TypeParameter->getAs<GenericTypeParamType>();
+  assert(gtpt && "unexpected generic param type");
+  os << "swift::getTypeMetadata<";
+  printGenericTypeParamTypeName(gtpt);
+  os << ">()";
+}
+
+void ClangSyntaxPrinter::printGenericRequirementsInstantiantions(
+    ArrayRef<GenericRequirement> requirements, LeadingTrivia leadingTrivia) {
+  if (leadingTrivia == LeadingTrivia::Comma && !requirements.empty())
+    os << ", ";
+  llvm::interleaveComma(requirements, os,
+                        [&](const GenericRequirement &requirement) {
+                          printGenericRequirementInstantiantion(requirement);
+                        });
 }

--- a/lib/PrintAsClang/ClangSyntaxPrinter.h
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.h
@@ -139,6 +139,11 @@ public:
       ArrayRef<GenericRequirement> requirements,
       LeadingTrivia leadingTrivia = LeadingTrivia::None);
 
+  // Print the C++ type name that corresponds to the primary user facing C++
+  // class for the given nominal type.
+  void printPrimaryCxxTypeName(const NominalTypeDecl *type,
+                               const ModuleDecl *moduleContext);
+
 protected:
   raw_ostream &os;
 };

--- a/lib/PrintAsClang/ClangSyntaxPrinter.h
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_PRINTASCLANG_CLANGSYNTAXPRINTER_H
 #define SWIFT_PRINTASCLANG_CLANGSYNTAXPRINTER_H
 
+#include "swift/AST/GenericRequirement.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "llvm/ADT/StringRef.h"
@@ -20,6 +21,8 @@
 
 namespace swift {
 
+class CanGenericSignature;
+class GenericTypeParamType;
 class ModuleDecl;
 class NominalTypeDecl;
 
@@ -41,6 +44,8 @@ StringRef getCxxOpaqueStorageClassName();
 
 class ClangSyntaxPrinter {
 public:
+  enum class LeadingTrivia { None, Comma };
+
   ClangSyntaxPrinter(raw_ostream &os) : os(os) {}
 
   /// Print a given identifier. If the identifer conflicts with a keyword, add a
@@ -98,7 +103,8 @@ public:
   static bool isClangKeyword(Identifier name);
 
   /// Print the call expression to the Swift type metadata access function.
-  void printSwiftTypeMetadataAccessFunctionCall(StringRef name);
+  void printSwiftTypeMetadataAccessFunctionCall(
+      StringRef name, ArrayRef<GenericRequirement> requirements);
 
   /// Print the set of statements to access the value witness table pointer
   /// ('vwTable') from the given type metadata variable.
@@ -106,8 +112,32 @@ public:
       StringRef metadataVariable, StringRef vwTableVariable, int indent);
 
   /// Print the metadata accessor function for the given type declaration.
-  void printCTypeMetadataTypeFunction(const NominalTypeDecl *typeDecl,
-                                      StringRef typeMetadataFuncName);
+  void printCTypeMetadataTypeFunction(
+      const NominalTypeDecl *typeDecl, StringRef typeMetadataFuncName,
+      llvm::ArrayRef<GenericRequirement> genericRequirements);
+
+  /// Print the name of the generic type param type in C++.
+  void printGenericTypeParamTypeName(const GenericTypeParamType *gtpt);
+
+  /// Print the Swift generic signature as C++ template declaration alongside
+  /// its requirements.
+  void printGenericSignature(const CanGenericSignature &signature);
+
+  /// Print the C++ template parameters that should be passed for a given
+  /// generic signature.
+  void printGenericSignatureParams(const CanGenericSignature &signature);
+
+  /// Print the call to the C++ type traits that computes the underlying type /
+  /// witness table pointer value that are passed to Swift for the given generic
+  /// requirement.
+  void
+  printGenericRequirementInstantiantion(const GenericRequirement &requirement);
+
+  /// Print the list of calls to C++ type traits that compute the generic
+  /// pointer values to pass to Swift.
+  void printGenericRequirementsInstantiantions(
+      ArrayRef<GenericRequirement> requirements,
+      LeadingTrivia leadingTrivia = LeadingTrivia::None);
 
 protected:
   raw_ostream &os;

--- a/lib/PrintAsClang/PrintClangClassType.cpp
+++ b/lib/PrintAsClang/PrintClangClassType.cpp
@@ -37,7 +37,7 @@ void ClangClassTypePrinter::printClassTypeDecl(
                            // Print out special functions, like functions that
                            // access type metadata.
                            printer.printCTypeMetadataTypeFunction(
-                               typeDecl, typeMetadataFuncName);
+                               typeDecl, typeMetadataFuncName, {});
                          });
 
   std::string baseClassName;

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -237,8 +237,9 @@ public:
     if (typeUseKind == FunctionSignatureTypeUse::ParamType) {
       if (languageMode != OutputLanguageMode::Cxx && !genericArgs.empty()) {
         // FIXME: what about concrete generic type.
-        // FIXME: inout.
-        os << "const void * _Nonnull";
+        if (!isInOutParam)
+          os << "const ";
+        os << "void * _Nonnull";
         return ClangRepresentation::representable;
       }
       if (languageMode != OutputLanguageMode::Cxx &&

--- a/lib/PrintAsClang/PrintClangFunction.h
+++ b/lib/PrintAsClang/PrintClangFunction.h
@@ -158,6 +158,10 @@ private:
       bool isIndirect = false,
       llvm::Optional<AdditionalParam::Role> paramRole = None);
 
+  // Print out the full type specifier that refers to the
+  // _impl::_impl_<typename> C++ class for the given Swift type.
+  void printTypeImplTypeSpecifier(Type type, const ModuleDecl *moduleContext);
+
   bool hasKnownOptionalNullableCxxMapping(Type type);
 
   raw_ostream &os;

--- a/lib/PrintAsClang/PrintClangValueType.cpp
+++ b/lib/PrintAsClang/PrintClangValueType.cpp
@@ -15,6 +15,7 @@
 #include "OutputLanguageMode.h"
 #include "PrimitiveTypeMapping.h"
 #include "SwiftToClangInteropContext.h"
+#include "swift/AST/ASTMangler.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/Type.h"
@@ -27,11 +28,22 @@
 using namespace swift;
 
 /// Print out the C type name of a struct/enum declaration.
-static void printCTypeName(raw_ostream &os, const NominalTypeDecl *type) {
+static void printCTypeName(raw_ostream &os, const NominalTypeDecl *type,
+                           ArrayRef<Type> genericArgs = {}) {
   ClangSyntaxPrinter printer(os);
   printer.printModuleNameCPrefix(*type->getParentModule());
   // FIXME: add nested type qualifiers to fully disambiguate the name.
   printer.printBaseName(type);
+  if (!genericArgs.empty()) {
+    os << '_';
+    llvm::interleave(
+        genericArgs, os,
+        [&](Type t) {
+          swift::Mangle::ASTMangler mangler;
+          os << mangler.mangleTypeWithoutPrefix(t);
+        },
+        "_");
+  }
 }
 
 /// Print out the C++ type name of a struct/enum declaration.
@@ -385,29 +397,19 @@ void ClangValueTypePrinter::printValueTypeDecl(
   printTypeGenericTraits(os, typeDecl, typeMetadataFuncName);
 }
 
-/// Print the name of the C stub struct for passing/returning a value type
-/// directly to/from swiftcc function.
-static void printStubCTypeName(raw_ostream &os, const NominalTypeDecl *type) {
-  os << "swift_interop_stub_";
-  printCTypeName(os, type);
-}
-
 /// Print out the C stub struct that's used to pass/return a value type directly
 /// to/from swiftcc function.
 static void
-printCStructStubForDirectPassing(raw_ostream &os, const NominalTypeDecl *SD,
+printCStructStubForDirectPassing(raw_ostream &os, StringRef stubName, Type type,
                                  PrimitiveTypeMapping &typeMapping,
                                  SwiftToClangInteropContext &interopContext) {
   // Print out a C stub for this value type.
   os << "// Stub struct to be used to pass/return values to/from Swift "
         "functions.\n";
-  os << "struct ";
-  printStubCTypeName(os, SD);
-  os << " {\n";
+  os << "struct " << stubName << " {\n";
   llvm::SmallVector<std::pair<clang::CharUnits, clang::CharUnits>, 8> fields;
   interopContext.getIrABIDetails().enumerateDirectPassingRecordMembers(
-      SD->getDeclaredType(),
-      [&](clang::CharUnits offset, clang::CharUnits end, Type t) {
+      type, [&](clang::CharUnits offset, clang::CharUnits end, Type t) {
         auto info =
             typeMapping.getKnownCTypeInfo(t->getNominalOrBoundGenericNominal());
         if (!info)
@@ -419,13 +421,12 @@ printCStructStubForDirectPassing(raw_ostream &os, const NominalTypeDecl *SD,
         fields.push_back(std::make_pair(offset, end));
       });
   os << "};\n\n";
+  auto minimalStubName = stubName;
+  minimalStubName.consume_front("swift_interop_stub_");
 
   // Emit a stub that returns a value directly from swiftcc function.
-  os << "static inline void swift_interop_returnDirect_";
-  printCTypeName(os, SD);
-  os << "(char * _Nonnull result, struct ";
-  printStubCTypeName(os, SD);
-  os << " value";
+  os << "static inline void swift_interop_returnDirect_" << minimalStubName;
+  os << "(char * _Nonnull result, struct " << stubName << " value";
   os << ") __attribute__((always_inline)) {\n";
   for (size_t i = 0; i < fields.size(); ++i) {
     os << "  memcpy(result + " << fields[i].first.getQuantity() << ", "
@@ -435,14 +436,10 @@ printCStructStubForDirectPassing(raw_ostream &os, const NominalTypeDecl *SD,
   os << "}\n\n";
 
   // Emit a stub that is used to pass value type directly to swiftcc function.
-  os << "static inline struct ";
-  printStubCTypeName(os, SD);
-  os << " swift_interop_passDirect_";
-  printCTypeName(os, SD);
+  os << "static inline struct " << stubName << " swift_interop_passDirect_"
+     << minimalStubName;
   os << "(const char * _Nonnull value) __attribute__((always_inline)) {\n";
-  os << "  struct ";
-  printStubCTypeName(os, SD);
-  os << " result;\n";
+  os << "  struct " << stubName << " result;\n";
   for (size_t i = 0; i < fields.size(); ++i) {
     os << "  memcpy(&result._" << (i + 1) << ", value + "
        << fields[i].first.getQuantity() << ", "
@@ -450,38 +447,6 @@ printCStructStubForDirectPassing(raw_ostream &os, const NominalTypeDecl *SD,
   }
   os << "  return result;\n";
   os << "}\n\n";
-}
-
-void ClangValueTypePrinter::printCStubTypeName(const NominalTypeDecl *type) {
-  printStubCTypeName(os, type);
-  // Ensure the stub is declared in the header.
-  interopContext.runIfStubForDeclNotEmitted(type, [&]() {
-    printCStructStubForDirectPassing(cPrologueOS, type, typeMapping,
-                                     interopContext);
-  });
-}
-
-void ClangValueTypePrinter::printValueTypeParameterType(
-    const NominalTypeDecl *type, OutputLanguageMode outputLang,
-    const ModuleDecl *moduleContext, bool isInOutParam) {
-  assert(isa<StructDecl>(type) || isa<EnumDecl>(type));
-  if (outputLang != OutputLanguageMode::Cxx) {
-    if (!isInOutParam) {
-      // C functions only take stub values directly as parameters.
-      os << "struct ";
-      printCStubTypeName(type);
-    } else {
-      // Directly pass the pointer (from getOpaquePointer) to C interface
-      // when in inout mode
-      os << "char * _Nonnull";
-    }
-    return;
-  }
-  if (!isInOutParam) {
-    os << "const ";
-  }
-  printCxxTypeName(os, type, moduleContext);
-  os << '&';
 }
 
 void ClangValueTypePrinter::printParameterCxxToCUseScaffold(
@@ -514,6 +479,7 @@ void ClangValueTypePrinter::printValueTypeReturnType(
     const NominalTypeDecl *type, OutputLanguageMode outputLang,
     TypeUseKind typeUse, const ModuleDecl *moduleContext) {
   assert(isa<StructDecl>(type) || isa<EnumDecl>(type));
+  assert(outputLang == OutputLanguageMode::Cxx);
   // FIXME: make a type use.
   if (outputLang == OutputLanguageMode::Cxx) {
     if (typeUse == TypeUseKind::CxxTypeName)
@@ -525,10 +491,25 @@ void ClangValueTypePrinter::printValueTypeReturnType(
       os << cxx_synthesis::getCxxImplNamespaceName() << "::";
       printCxxImplClassName(os, type);
     }
-  } else {
-    os << "struct ";
-    printCStubTypeName(type);
   }
+}
+
+void ClangValueTypePrinter::printCStubType(Type type,
+                                           const NominalTypeDecl *typeDecl,
+                                           ArrayRef<Type> genericArgs) {
+  os << "struct ";
+  std::string stubName;
+  {
+    llvm::raw_string_ostream stubNameOS(stubName);
+    stubNameOS << "swift_interop_stub_";
+    printCTypeName(stubNameOS, typeDecl, genericArgs);
+  }
+  os << stubName;
+  // Ensure the stub is declared in the header.
+  interopContext.runIfStubForDeclNotEmitted(stubName, [&]() {
+    printCStructStubForDirectPassing(cPrologueOS, stubName, type, typeMapping,
+                                     interopContext);
+  });
 }
 
 void ClangValueTypePrinter::printValueTypeIndirectReturnScaffold(
@@ -545,19 +526,17 @@ void ClangValueTypePrinter::printValueTypeIndirectReturnScaffold(
 }
 
 void ClangValueTypePrinter::printValueTypeDirectReturnScaffold(
-    const NominalTypeDecl *type, const ModuleDecl *moduleContext,
+    const NominalTypeDecl *type, ArrayRef<Type> genericArgs,
+    const ModuleDecl *moduleContext, llvm::function_ref<void()> typePrinter,
     llvm::function_ref<void()> bodyPrinter) {
   assert(isa<StructDecl>(type) || isa<EnumDecl>(type));
   os << "  return ";
-  ClangSyntaxPrinter(os).printModuleNamespaceQualifiersIfNeeded(
-      type->getModuleContext(), moduleContext);
-  os << cxx_synthesis::getCxxImplNamespaceName() << "::";
-  printCxxImplClassName(os, type);
+  typePrinter();
   os << "::returnNewValue([&](char * _Nonnull result) {\n";
   os << "    ";
   os << cxx_synthesis::getCxxImplNamespaceName() << "::"
      << "swift_interop_returnDirect_";
-  printCTypeName(os, type);
+  printCTypeName(os, type, genericArgs);
   os << "(result, ";
   bodyPrinter();
   os << ");\n";

--- a/lib/PrintAsClang/PrintClangValueType.cpp
+++ b/lib/PrintAsClang/PrintClangValueType.cpp
@@ -29,7 +29,7 @@ using namespace swift;
 
 /// Print out the C type name of a struct/enum declaration.
 static void printCTypeName(raw_ostream &os, const NominalTypeDecl *type,
-                           ArrayRef<Type> genericArgs = {}) {
+                           ArrayRef<Type> genericArgs) {
   ClangSyntaxPrinter printer(os);
   printer.printModuleNameCPrefix(*type->getParentModule());
   // FIXME: add nested type qualifiers to fully disambiguate the name.
@@ -85,7 +85,7 @@ static void
 printCValueTypeStorageStruct(raw_ostream &os, const NominalTypeDecl *typeDecl,
                              IRABIDetailsProvider::SizeAndAlignment layout) {
   os << "struct ";
-  printCTypeName(os, typeDecl);
+  printCTypeName(os, typeDecl, /*genericArgs=*/{});
   os << " {\n";
   os << "  _Alignas(" << layout.alignment << ") ";
   os << "char _storage[" << layout.size << "];\n";
@@ -450,7 +450,7 @@ printCStructStubForDirectPassing(raw_ostream &os, StringRef stubName, Type type,
 }
 
 void ClangValueTypePrinter::printParameterCxxToCUseScaffold(
-    bool isIndirect, const NominalTypeDecl *type,
+    bool isIndirect, const NominalTypeDecl *type, ArrayRef<Type> genericArgs,
     const ModuleDecl *moduleContext, llvm::function_ref<void()> typePrinter,
     llvm::function_ref<void()> cxxParamPrinter, bool isInOut, bool isSelf) {
   // A Swift value type is passed to its underlying Swift function
@@ -458,7 +458,7 @@ void ClangValueTypePrinter::printParameterCxxToCUseScaffold(
   if (!isIndirect && !isInOut) {
     os << cxx_synthesis::getCxxImplNamespaceName() << "::"
        << "swift_interop_passDirect_";
-    printCTypeName(os, type);
+    printCTypeName(os, type, genericArgs);
     os << '(';
   }
   if (isSelf) {

--- a/lib/PrintAsClang/PrintClangValueType.h
+++ b/lib/PrintAsClang/PrintClangValueType.h
@@ -51,11 +51,10 @@ public:
 
   /// Print the use of a C++ struct/enum parameter value as it's passed to the
   /// underlying C function that represents the native Swift function.
-  void
-  printParameterCxxToCUseScaffold(bool isIndirect, const NominalTypeDecl *type,
-                                  const ModuleDecl *moduleContext,
-                                  llvm::function_ref<void()> cxxParamPrinter,
-                                  bool isInOut, bool isSelf);
+  void printParameterCxxToCUseScaffold(
+      bool isIndirect, const NominalTypeDecl *type,
+      const ModuleDecl *moduleContext, llvm::function_ref<void()> typePrinter,
+      llvm::function_ref<void()> cxxParamPrinter, bool isInOut, bool isSelf);
 
   enum class TypeUseKind {
     // The name of the C++ class that corresponds to the Swift value type (with

--- a/lib/PrintAsClang/PrintClangValueType.h
+++ b/lib/PrintAsClang/PrintClangValueType.h
@@ -46,7 +46,7 @@ public:
   /// Print the use of a C++ struct/enum parameter value as it's passed to the
   /// underlying C function that represents the native Swift function.
   void printParameterCxxToCUseScaffold(
-      bool isIndirect, const NominalTypeDecl *type,
+      bool isIndirect, const NominalTypeDecl *type, ArrayRef<Type> genericArgs,
       const ModuleDecl *moduleContext, llvm::function_ref<void()> typePrinter,
       llvm::function_ref<void()> cxxParamPrinter, bool isInOut, bool isSelf);
 

--- a/lib/PrintAsClang/PrintClangValueType.h
+++ b/lib/PrintAsClang/PrintClangValueType.h
@@ -43,12 +43,6 @@ public:
   void printValueTypeDecl(const NominalTypeDecl *typeDecl,
                           llvm::function_ref<void(void)> bodyPrinter);
 
-  /// Print the pararameter type that referes to a Swift struct type in C/C++.
-  void printValueTypeParameterType(const NominalTypeDecl *type,
-                                   OutputLanguageMode outputLang,
-                                   const ModuleDecl *moduleContext,
-                                   bool isInOutParam);
-
   /// Print the use of a C++ struct/enum parameter value as it's passed to the
   /// underlying C function that represents the native Swift function.
   void printParameterCxxToCUseScaffold(
@@ -71,6 +65,14 @@ public:
                                 TypeUseKind typeUse,
                                 const ModuleDecl *moduleContext);
 
+  /// Prints out the C stub name used to pass/return value directly for the
+  /// given value type.
+  ///
+  /// If the C stub isn't declared yet in the emitted header, that declaration
+  /// will be emitted by this function.
+  void printCStubType(Type type, const NominalTypeDecl *typeDecl,
+                      ArrayRef<Type> genericArgs);
+
   /// Print the supporting code  that's required to indirectly return a C++
   /// class that represents a Swift value type as it's being indirectly passed
   /// from the C function that represents the native Swift function.
@@ -82,10 +84,10 @@ public:
   /// Print the supporting code  that's required to directly return a C++ class
   /// that represents a Swift value type as it's being returned from the C
   /// function that represents the native Swift function.
-  void
-  printValueTypeDirectReturnScaffold(const NominalTypeDecl *typeDecl,
-                                     const ModuleDecl *moduleContext,
-                                     llvm::function_ref<void()> bodyPrinter);
+  void printValueTypeDirectReturnScaffold(
+      const NominalTypeDecl *typeDecl, ArrayRef<Type> genericArgs,
+      const ModuleDecl *moduleContext, llvm::function_ref<void()> typePrinter,
+      llvm::function_ref<void()> bodyPrinter);
 
   /// Print out the C++ type name of the implementation class that provides
   /// hidden access to the private class APIs.
@@ -113,13 +115,6 @@ public:
   static void forwardDeclType(raw_ostream &os, const NominalTypeDecl *typeDecl);
 
 private:
-  /// Prints out the C stub name used to pass/return value directly for the
-  /// given value type.
-  ///
-  /// If the C stub isn't declared yet in the emitted header, that declaration
-  /// will be emitted by this function.
-  void printCStubTypeName(const NominalTypeDecl *type);
-
   raw_ostream &os;
   raw_ostream &cPrologueOS;
   PrimitiveTypeMapping &typeMapping;

--- a/lib/PrintAsClang/PrintClangValueType.h
+++ b/lib/PrintAsClang/PrintClangValueType.h
@@ -57,9 +57,19 @@ public:
                                   llvm::function_ref<void()> cxxParamPrinter,
                                   bool isInOut, bool isSelf);
 
+  enum class TypeUseKind {
+    // The name of the C++ class that corresponds to the Swift value type (with
+    // any qualifiers).
+    CxxTypeName,
+    // The name of the C++ _impl class that corresponds to the Swift value type
+    // (with any qualifiers).
+    CxxImplTypeName
+  };
+
   /// Print the return type that refers to a Swift struct type in C/C++.
   void printValueTypeReturnType(const NominalTypeDecl *typeDecl,
                                 OutputLanguageMode outputLang,
+                                TypeUseKind typeUse,
                                 const ModuleDecl *moduleContext);
 
   /// Print the supporting code  that's required to indirectly return a C++
@@ -67,6 +77,7 @@ public:
   /// from the C function that represents the native Swift function.
   void printValueTypeIndirectReturnScaffold(
       const NominalTypeDecl *typeDecl, const ModuleDecl *moduleContext,
+      llvm::function_ref<void()> typePrinter,
       llvm::function_ref<void(StringRef)> bodyPrinter);
 
   /// Print the supporting code  that's required to directly return a C++ class

--- a/lib/PrintAsClang/PrintClangValueType.h
+++ b/lib/PrintAsClang/PrintClangValueType.h
@@ -14,6 +14,7 @@
 #define SWIFT_PRINTASCLANG_PRINTCLANGVALUETYPE_H
 
 #include "OutputLanguageMode.h"
+#include "swift/AST/GenericRequirement.h"
 #include "swift/AST/Type.h"
 #include "swift/Basic/LLVM.h"
 #include "llvm/ADT/STLExtras.h"
@@ -82,15 +83,16 @@ public:
                                     const NominalTypeDecl *type);
 
   /// Print a variable that can be used to access type's metadata function
-  static void printMetadataAccessAsVariable(raw_ostream &os,
-                                            StringRef metadataFuncName,
-                                            int indent = 4,
-                                            StringRef varName = "metadata");
+  static void printMetadataAccessAsVariable(
+      raw_ostream &os, StringRef metadataFuncName,
+      ArrayRef<GenericRequirement> genericRequirements, int indent = 4,
+      StringRef varName = "metadata");
 
   /// Print a variable that can be used to access type's metadata function and
   /// value witness table
   static void printValueWitnessTableAccessAsVariable(
-      raw_ostream &os, StringRef metadataFuncName, int indent = 4,
+      raw_ostream &os, StringRef metadataFuncName,
+      ArrayRef<GenericRequirement> genericRequirements, int indent = 4,
       StringRef metadataVarName = "metadata",
       StringRef vwTableVarName = "vwTable");
 

--- a/lib/PrintAsClang/SwiftToClangInteropContext.cpp
+++ b/lib/PrintAsClang/SwiftToClangInteropContext.cpp
@@ -28,8 +28,8 @@ IRABIDetailsProvider &SwiftToClangInteropContext::getIrABIDetails() {
 }
 
 void SwiftToClangInteropContext::runIfStubForDeclNotEmitted(
-    const Decl *d, llvm::function_ref<void(void)> function) {
-  auto result = emittedStubs.insert(d);
+    StringRef stubName, llvm::function_ref<void(void)> function) {
+  auto result = emittedStubs.insert(stubName);
   if (result.second)
     function();
 }

--- a/lib/PrintAsClang/SwiftToClangInteropContext.h
+++ b/lib/PrintAsClang/SwiftToClangInteropContext.h
@@ -13,8 +13,8 @@
 #ifndef SWIFT_PRINTASCLANG_SWIFTTOCLANGINTEROPCONTEXT_H
 #define SWIFT_PRINTASCLANG_SWIFTTOCLANGINTEROPCONTEXT_H
 
-#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringSet.h"
 #include <memory>
 
 namespace swift {
@@ -36,15 +36,15 @@ public:
   IRABIDetailsProvider &getIrABIDetails();
 
   // Runs the given function if we haven't emitted some context-specific stub
-  // for the given declaration yet.
-  void runIfStubForDeclNotEmitted(const Decl *d,
+  // for the given concrete stub name.
+  void runIfStubForDeclNotEmitted(llvm::StringRef stubName,
                                   llvm::function_ref<void(void)> function);
 
 private:
   ModuleDecl &mod;
   const IRGenOptions &irGenOpts;
   std::unique_ptr<IRABIDetailsProvider> irABIDetails;
-  llvm::DenseSet<const Decl *> emittedStubs;
+  llvm::StringSet<> emittedStubs;
 };
 
 } // end namespace swift

--- a/test/Interop/SwiftToCxx/functions/PrintAsCxx/function_with_array.swift
+++ b/test/Interop/SwiftToCxx/functions/PrintAsCxx/function_with_array.swift
@@ -5,5 +5,5 @@
 // CHECK: namespace function_with_array
 // FIXME: we don't actually emit a declaration for this, but for now at least
 // check that we don't crash.
-// CHECK-NOT: void f
+// CHECK: void f(const Swift::Array<swift::Int>&
 public func f(_: [Int]) { }

--- a/test/Interop/SwiftToCxx/generics/generic-struct-execution.cpp
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-execution.cpp
@@ -13,8 +13,6 @@
 #include <cassert>
 #include "generics.h"
 
-extern "C" void puts(const char *);
-
 int main() {
   using namespace Generics;
 

--- a/test/Interop/SwiftToCxx/generics/generic-struct-execution.cpp
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-execution.cpp
@@ -19,7 +19,7 @@ int main() {
   using namespace Generics;
 
   auto x = makeGenericPair<int, int>(11, 42);
-  puts("no\n");
-// CHECK: no
+  takeGenericPair(x);
+// CHECK: GenericPair<Int32, Int32>(x: 11, y: 42)
   return 0;
 }

--- a/test/Interop/SwiftToCxx/generics/generic-struct-execution.cpp
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-execution.cpp
@@ -34,6 +34,18 @@ int main() {
     auto x = makeConcretePair(100000, 0x1fee7);
     takeGenericPair(x);
     // CHECK-NEXT: GenericPair<UInt32, UInt32>(x: 100000, y: 130791)
+    takeConcretePair(x);
+    // CHECK-NEXT: CONCRETE pair of UInt32: 100000 130791 ;
+    auto xprime = passThroughConcretePair(x, 918);
+    takeConcretePair(x);
+    takeConcretePair(xprime);
+    takeGenericPair(xprime);
+    // CHECK-NEXT: CONCRETE pair of UInt32: 100000 130791 ;
+    // CHECK-NEXT: CONCRETE pair of UInt32: 100000 918 ;
+    // CHECK-NEXT: GenericPair<UInt32, UInt32>(x: 100000, y: 918)
+    inoutConcretePair(77, x);
+    takeConcretePair(x);
+    // CHECK-NEXT: CONCRETE pair of UInt32: 77 130791 ;
   }
   return 0;
 }

--- a/test/Interop/SwiftToCxx/generics/generic-struct-execution.cpp
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-execution.cpp
@@ -24,5 +24,8 @@ int main() {
   takeGenericPair(xprime);
 // CHECK-NEXT: GenericPair<Int32, Int32>(x: 11, y: 42)
 // CHECK-NEXT: GenericPair<Int32, Int32>(x: 11, y: -995)
+  inoutGenericPair(x, 0xFF);
+  takeGenericPair(x);
+// CHECK-NEXT: GenericPair<Int32, Int32>(x: 255, y: 42)
   return 0;
 }

--- a/test/Interop/SwiftToCxx/generics/generic-struct-execution.cpp
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-execution.cpp
@@ -1,0 +1,27 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %S/generic-struct-in-cxx.swift -typecheck -module-name Generics -clang-header-expose-public-decls -emit-clang-header-path %t/generics.h
+
+// RUN: %target-interop-build-clangxx -std=gnu++20 -c %s -I %t -o %t/swift-generics-execution.o
+// RUN: %target-interop-build-swift %S/generic-struct-in-cxx.swift -o %t/swift-generics-execution -Xlinker %t/swift-generics-execution.o -module-name Generics -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+
+// RUN: %target-codesign %t/swift-generics-execution
+// RUN: %target-run %t/swift-generics-execution | %FileCheck %s
+
+// REQUIRES: executable_test
+
+#include <cassert>
+#include "generics.h"
+
+extern "C" void puts(const char *);
+
+int main() {
+  using namespace Generics;
+
+  auto x = _impl::_impl_GenericPair<int, int>::returnNewValue([] (void *p) {
+    // nada.
+  });
+  puts("no\n");
+// CHECK: no
+  return 0;
+}

--- a/test/Interop/SwiftToCxx/generics/generic-struct-execution.cpp
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-execution.cpp
@@ -16,16 +16,24 @@
 int main() {
   using namespace Generics;
 
-  auto x = makeGenericPair<int, int>(11, 42);
-  takeGenericPair(x);
-// CHECK: GenericPair<Int32, Int32>(x: 11, y: 42)
-  auto xprime = passThroughGenericPair(x, -995);
-  takeGenericPair(x);
-  takeGenericPair(xprime);
-// CHECK-NEXT: GenericPair<Int32, Int32>(x: 11, y: 42)
-// CHECK-NEXT: GenericPair<Int32, Int32>(x: 11, y: -995)
-  inoutGenericPair(x, 0xFF);
-  takeGenericPair(x);
-// CHECK-NEXT: GenericPair<Int32, Int32>(x: 255, y: 42)
+  {
+    auto x = makeGenericPair<int, int>(11, 42);
+    takeGenericPair(x);
+    // CHECK: GenericPair<Int32, Int32>(x: 11, y: 42)
+    auto xprime = passThroughGenericPair(x, -995);
+    takeGenericPair(x);
+    takeGenericPair(xprime);
+    // CHECK-NEXT: GenericPair<Int32, Int32>(x: 11, y: 42)
+    // CHECK-NEXT: GenericPair<Int32, Int32>(x: 11, y: -995)
+    inoutGenericPair(x, 0xFF);
+    takeGenericPair(x);
+    // CHECK-NEXT: GenericPair<Int32, Int32>(x: 255, y: 42)
+  }
+
+  {
+    auto x = makeConcretePair(100000, 0x1fee7);
+    takeGenericPair(x);
+    // CHECK-NEXT: GenericPair<UInt32, UInt32>(x: 100000, y: 130791)
+  }
   return 0;
 }

--- a/test/Interop/SwiftToCxx/generics/generic-struct-execution.cpp
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-execution.cpp
@@ -18,9 +18,7 @@ extern "C" void puts(const char *);
 int main() {
   using namespace Generics;
 
-  auto x = _impl::_impl_GenericPair<int, int>::returnNewValue([] (void *p) {
-    // nada.
-  });
+  auto x = makeGenericPair<int, int>(11, 42);
   puts("no\n");
 // CHECK: no
   return 0;

--- a/test/Interop/SwiftToCxx/generics/generic-struct-execution.cpp
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-execution.cpp
@@ -19,5 +19,10 @@ int main() {
   auto x = makeGenericPair<int, int>(11, 42);
   takeGenericPair(x);
 // CHECK: GenericPair<Int32, Int32>(x: 11, y: 42)
+  auto xprime = passThroughGenericPair(x, -995);
+  takeGenericPair(x);
+  takeGenericPair(xprime);
+// CHECK-NEXT: GenericPair<Int32, Int32>(x: 11, y: 42)
+// CHECK-NEXT: GenericPair<Int32, Int32>(x: 11, y: -995)
   return 0;
 }

--- a/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
@@ -18,6 +18,10 @@ public func makeGenericPair<T, T1>(_ x: T, _ y: T1) -> GenericPair<T, T1> {
     return GenericPair<T, T1>(x: x, y: y);
 }
 
+public func takeGenericPair<T, T1>(_ x: GenericPair<T, T1>) {
+    print(x)
+}
+
 // CHECK: template<class T_0_0, class T_0_1>
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: class _impl_GenericPair;
@@ -60,3 +64,9 @@ public func makeGenericPair<T, T1>(_ x: T, _ y: T1) -> GenericPair<T, T1> {
 // CHECK-NEXT:     _impl::$s8Generics15makeGenericPairyAA0cD0Vyxq_Gx_q_tr0_lF(result, swift::_impl::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::getTypeMetadata<T>(), swift::getTypeMetadata<T1>());
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
+
+// CHECK: template<class T, class T1>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T> && swift::isUsableInGenericContext<T1>
+// CHECK-NEXT: inline void takeGenericPair(const GenericPair<T, T1>& x) noexcept {
+// CHECK-NEXT:  return _impl::$s8Generics15takeGenericPairyyAA0cD0Vyxq_Gr0_lF(_impl::_impl_GenericPair<T, T1>::getOpaquePointer(x), swift::getTypeMetadata<T>(), swift::getTypeMetadata<T1>());
+// CHECK-NEXT:}

--- a/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
@@ -13,8 +13,8 @@
 // RUN: %check-generic-interop-cxx-header-in-clang(%t/generics.h)
 
 public struct GenericPair<T, T2> {
-    let x: T
-    let y: T2
+    var x: T
+    var y: T2
 }
 
 public func makeGenericPair<T, T1>(_ x: T, _ y: T1) -> GenericPair<T, T1> {
@@ -28,6 +28,15 @@ public func takeGenericPair<T, T1>(_ x: GenericPair<T, T1>) {
 public func passThroughGenericPair<T1, T>(_ x: GenericPair<T1, T>, _ y: T)  -> GenericPair<T1, T> {
     return GenericPair<T1, T>(x: x.x, y: y)
 }
+
+public func inoutGenericPair<T1, T>(_ x: inout GenericPair<T1, T>, _ y: T1) {
+    x.x = y
+}
+
+// CHECK: SWIFT_EXTERN void $s8Generics16inoutGenericPairyyAA0cD0Vyxq_Gz_xtr0_lF(void * _Nonnull x, const void * _Nonnull y, void * _Nonnull , void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // inoutGenericPair(_:_:)
+// CHECK-NEXT: SWIFT_EXTERN void $s8Generics15makeGenericPairyAA0cD0Vyxq_Gx_q_tr0_lF(SWIFT_INDIRECT_RESULT void * _Nonnull, const void * _Nonnull x, const void * _Nonnull y, void * _Nonnull , void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // makeGenericPair(_:_:)
+// CHECK-NEXT: SWIFT_EXTERN void $s8Generics22passThroughGenericPairyAA0dE0Vyxq_GAE_q_tr0_lF(SWIFT_INDIRECT_RESULT void * _Nonnull, const void * _Nonnull x, const void * _Nonnull y, void * _Nonnull , void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // passThroughGenericPair(_:_:)
+// CHECK-NEXT: SWIFT_EXTERN void $s8Generics15takeGenericPairyyAA0cD0Vyxq_Gr0_lF(const void * _Nonnull x, void * _Nonnull , void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // takeGenericPair(_:)
 
 // CHECK: template<class T_0_0, class T_0_1>
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
@@ -65,7 +74,13 @@ public func passThroughGenericPair<T1, T>(_ x: GenericPair<T1, T>, _ y: T)  -> G
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: class GenericPair;
 // CHECK-EMPTY:
-// CHECK-NEXT: template<class T, class T1>
+// CHECK-NEXT: template<class T1, class T>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T1> && swift::isUsableInGenericContext<T>
+// CHECK-NEXT: inline void inoutGenericPair(GenericPair<T1, T>& x, const T1 & y) noexcept {
+// CHECK-NEXT:   return _impl::$s8Generics16inoutGenericPairyyAA0cD0Vyxq_Gz_xtr0_lF(_impl::_impl_GenericPair<T1, T>::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::getTypeMetadata<T1>(), swift::getTypeMetadata<T>());
+// CHECK-NEXT: }
+
+// CHECK: template<class T, class T1>
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T> && swift::isUsableInGenericContext<T1>
 // CHECK-NEXT: inline GenericPair<T, T1> makeGenericPair(const T & x, const T1 & y) noexcept SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::_impl_GenericPair<T, T1>::returnNewValue([&](void * _Nonnull result) {

--- a/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
@@ -29,6 +29,7 @@ public func takeGenericPair<T, T1>(_ x: GenericPair<T, T1>) {
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: class _impl_GenericPair;
 // CHECK-EMPTY:
+// CHECK-NEXT: static_assert(2 <= 3, "unsupported generic requirement list for metadata func"); 
 // CHECK-NEXT: // Type metadata accessor for GenericPair
 // CHECK-NEXT: SWIFT_EXTERN swift::_impl::MetadataResponseTy $s8Generics11GenericPairVMa(swift::_impl::MetadataRequestTy, void * _Nonnull, void * _Nonnull) SWIFT_NOEXCEPT SWIFT_CALL;
 

--- a/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
@@ -1,17 +1,18 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -typecheck -module-name Generics -clang-header-expose-public-decls -emit-clang-header-path %t/generics.h
 // RUN: %FileCheck %s < %t/generics.h
-// RUN: %check-generic-interop-cxx-header-in-clang(%t/generics.h)
+// RUN: %check-generic-interop-cxx-header-in-clang(%t/generics.h -Wno-unused-function)
 
 // Check that an instantiation compiles too.
 // RUN: echo "constexpr int x = sizeof(Generics::GenericPair<int, int>);" >> %t/generics.h
-// RUN: %check-generic-interop-cxx-header-in-clang(%t/generics.h)
+// RUN: %check-generic-interop-cxx-header-in-clang(%t/generics.h -Wno-unused-function)
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -enable-library-evolution -typecheck -module-name Generics -clang-header-expose-public-decls -emit-clang-header-path %t/generics.h
 // RUN: %FileCheck %s < %t/generics.h
-// RUN: %check-generic-interop-cxx-header-in-clang(%t/generics.h)
+// RUN: %check-generic-interop-cxx-header-in-clang(%t/generics.h -Wno-unused-function)
 
+@frozen
 public struct GenericPair<T, T2> {
     var x: T
     var y: T2
@@ -19,6 +20,10 @@ public struct GenericPair<T, T2> {
 
 public func makeGenericPair<T, T1>(_ x: T, _ y: T1) -> GenericPair<T, T1> {
     return GenericPair<T, T1>(x: x, y: y);
+}
+
+public func makeConcretePair(_ x: UInt32, _ y: UInt32) -> GenericPair<UInt32, UInt32> {
+    return GenericPair<UInt32, UInt32>(x: x, y: y)
 }
 
 public func takeGenericPair<T, T1>(_ x: GenericPair<T, T1>) {
@@ -34,6 +39,22 @@ public func inoutGenericPair<T1, T>(_ x: inout GenericPair<T1, T>, _ y: T1) {
 }
 
 // CHECK: SWIFT_EXTERN void $s8Generics16inoutGenericPairyyAA0cD0Vyxq_Gz_xtr0_lF(void * _Nonnull x, const void * _Nonnull y, void * _Nonnull , void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // inoutGenericPair(_:_:)
+// CHECK-NEXT: // Stub struct to be used to pass/return values to/from Swift functions.
+// CHECK-NEXT: struct swift_interop_stub_Generics_GenericPair_s6UInt32V_s6UInt32V {
+// CHECK-NEXT:   uint64_t _1;
+// CHECK-NEXT: };
+// CHECK-EMPTY:
+// CHECK-NEXT: static inline void swift_interop_returnDirect_Generics_GenericPair_s6UInt32V_s6UInt32V(char * _Nonnull result, struct swift_interop_stub_Generics_GenericPair_s6UInt32V_s6UInt32V value) __attribute__((always_inline)) {
+// CHECK-NEXT:   memcpy(result + 0, &value._1, 8);
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK-NEXT: static inline struct swift_interop_stub_Generics_GenericPair_s6UInt32V_s6UInt32V swift_interop_passDirect_Generics_GenericPair_s6UInt32V_s6UInt32V(const char * _Nonnull value) __attribute__((always_inline)) {
+// CHECK-NEXT:   struct swift_interop_stub_Generics_GenericPair_s6UInt32V_s6UInt32V result;
+// CHECK-NEXT:   memcpy(&result._1, value + 0, 8);
+// CHECK-NEXT:   return result;
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK-NEXT: SWIFT_EXTERN struct swift_interop_stub_Generics_GenericPair_s6UInt32V_s6UInt32V $s8Generics16makeConcretePairyAA07GenericD0Vys6UInt32VAFGAF_AFtF(uint32_t x, uint32_t y) SWIFT_NOEXCEPT SWIFT_CALL; // makeConcretePair(_:_:)
 // CHECK-NEXT: SWIFT_EXTERN void $s8Generics15makeGenericPairyAA0cD0Vyxq_Gx_q_tr0_lF(SWIFT_INDIRECT_RESULT void * _Nonnull, const void * _Nonnull x, const void * _Nonnull y, void * _Nonnull , void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // makeGenericPair(_:_:)
 // CHECK-NEXT: SWIFT_EXTERN void $s8Generics22passThroughGenericPairyAA0dE0Vyxq_GAE_q_tr0_lF(SWIFT_INDIRECT_RESULT void * _Nonnull, const void * _Nonnull x, const void * _Nonnull y, void * _Nonnull , void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // passThroughGenericPair(_:_:)
 // CHECK-NEXT: SWIFT_EXTERN void $s8Generics15takeGenericPairyyAA0cD0Vyxq_Gr0_lF(const void * _Nonnull x, void * _Nonnull , void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // takeGenericPair(_:)

--- a/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
@@ -30,15 +30,30 @@ public func takeGenericPair<T, T1>(_ x: GenericPair<T, T1>) {
     print(x)
 }
 
+public func takeConcretePair(_ x: GenericPair<UInt32, UInt32>) {
+    print("CONCRETE pair of UInt32: ", x.x, x.y, ";")
+}
+
 public func passThroughGenericPair<T1, T>(_ x: GenericPair<T1, T>, _ y: T)  -> GenericPair<T1, T> {
     return GenericPair<T1, T>(x: x.x, y: y)
+}
+
+public typealias ConcreteUint32Pair = GenericPair<UInt32, UInt32>
+
+public func passThroughConcretePair(_ x: ConcreteUint32Pair, y: UInt32) -> ConcreteUint32Pair {
+    return ConcreteUint32Pair(x: x.x, y: y)
 }
 
 public func inoutGenericPair<T1, T>(_ x: inout GenericPair<T1, T>, _ y: T1) {
     x.x = y
 }
 
-// CHECK: SWIFT_EXTERN void $s8Generics16inoutGenericPairyyAA0cD0Vyxq_Gz_xtr0_lF(void * _Nonnull x, const void * _Nonnull y, void * _Nonnull , void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // inoutGenericPair(_:_:)
+public func inoutConcretePair(_ x: UInt32, _ y: inout GenericPair<UInt32, UInt32>) {
+    y.x = x
+}
+
+// CHECK: SWIFT_EXTERN void $s8Generics17inoutConcretePairyys6UInt32V_AA07GenericD0VyA2DGztF(uint32_t x, char * _Nonnull y) SWIFT_NOEXCEPT SWIFT_CALL; // inoutConcretePair(_:_:)
+// CHECK-NEXT: SWIFT_EXTERN void $s8Generics16inoutGenericPairyyAA0cD0Vyxq_Gz_xtr0_lF(void * _Nonnull x, const void * _Nonnull y, void * _Nonnull , void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // inoutGenericPair(_:_:)
 // CHECK-NEXT: // Stub struct to be used to pass/return values to/from Swift functions.
 // CHECK-NEXT: struct swift_interop_stub_Generics_GenericPair_s6UInt32V_s6UInt32V {
 // CHECK-NEXT:   uint64_t _1;
@@ -56,7 +71,9 @@ public func inoutGenericPair<T1, T>(_ x: inout GenericPair<T1, T>, _ y: T1) {
 // CHECK-EMPTY:
 // CHECK-NEXT: SWIFT_EXTERN struct swift_interop_stub_Generics_GenericPair_s6UInt32V_s6UInt32V $s8Generics16makeConcretePairyAA07GenericD0Vys6UInt32VAFGAF_AFtF(uint32_t x, uint32_t y) SWIFT_NOEXCEPT SWIFT_CALL; // makeConcretePair(_:_:)
 // CHECK-NEXT: SWIFT_EXTERN void $s8Generics15makeGenericPairyAA0cD0Vyxq_Gx_q_tr0_lF(SWIFT_INDIRECT_RESULT void * _Nonnull, const void * _Nonnull x, const void * _Nonnull y, void * _Nonnull , void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // makeGenericPair(_:_:)
+// CHECK-NEXT: SWIFT_EXTERN struct swift_interop_stub_Generics_GenericPair_s6UInt32V_s6UInt32V $s8Generics23passThroughConcretePair_1yAA07GenericE0Vys6UInt32VAGGAH_AGtF(struct swift_interop_stub_Generics_GenericPair_s6UInt32V_s6UInt32V x, uint32_t y) SWIFT_NOEXCEPT SWIFT_CALL; // passThroughConcretePair(_:y:)
 // CHECK-NEXT: SWIFT_EXTERN void $s8Generics22passThroughGenericPairyAA0dE0Vyxq_GAE_q_tr0_lF(SWIFT_INDIRECT_RESULT void * _Nonnull, const void * _Nonnull x, const void * _Nonnull y, void * _Nonnull , void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // passThroughGenericPair(_:_:)
+// CHECK-NEXT: SWIFT_EXTERN void $s8Generics16takeConcretePairyyAA07GenericD0Vys6UInt32VAFGF(struct swift_interop_stub_Generics_GenericPair_s6UInt32V_s6UInt32V x) SWIFT_NOEXCEPT SWIFT_CALL; // takeConcretePair(_:)
 // CHECK-NEXT: SWIFT_EXTERN void $s8Generics15takeGenericPairyyAA0cD0Vyxq_Gr0_lF(const void * _Nonnull x, void * _Nonnull , void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // takeGenericPair(_:)
 
 // CHECK: template<class T_0_0, class T_0_1>
@@ -95,7 +112,11 @@ public func inoutGenericPair<T1, T>(_ x: inout GenericPair<T1, T>, _ y: T1) {
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: class GenericPair;
 // CHECK-EMPTY:
-// CHECK-NEXT: template<class T1, class T>
+// CHECK-NEXT: inline void inoutConcretePair(uint32_t x, GenericPair<uint32_t, uint32_t>& y) noexcept {
+// CHECK-NEXT:   return _impl::$s8Generics17inoutConcretePairyys6UInt32V_AA07GenericD0VyA2DGztF(x, _impl::_impl_GenericPair<uint32_t, uint32_t>::getOpaquePointer(y));
+// CHECK-NEXT: }
+
+// CHECK: template<class T1, class T>
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T1> && swift::isUsableInGenericContext<T>
 // CHECK-NEXT: inline void inoutGenericPair(GenericPair<T1, T>& x, const T1 & y) noexcept {
 // CHECK-NEXT:   return _impl::$s8Generics16inoutGenericPairyyAA0cD0Vyxq_Gz_xtr0_lF(_impl::_impl_GenericPair<T1, T>::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::getTypeMetadata<T1>(), swift::getTypeMetadata<T>());
@@ -109,12 +130,22 @@ public func inoutGenericPair<T1, T>(_ x: inout GenericPair<T1, T>, _ y: T1) {
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
+// CHECK: inline GenericPair<uint32_t, uint32_t> passThroughConcretePair(const GenericPair<uint32_t, uint32_t>& x, uint32_t y) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT:  return _impl::_impl_GenericPair<uint32_t, uint32_t>::returnNewValue([&](char * _Nonnull result) {
+// CHECK-NEXT:     _impl::swift_interop_returnDirect_Generics_GenericPair_s6UInt32V_s6UInt32V(result, _impl::$s8Generics23passThroughConcretePair_1yAA07GenericE0Vys6UInt32VAGGAH_AGtF(_impl::swift_interop_passDirect_Generics_GenericPair_s6UInt32V_s6UInt32V(_impl::_impl_GenericPair<uint32_t, uint32_t>::getOpaquePointer(x)), y));
+// CHECK-NEXT:   });
+// CHECK-NEXT: }
+
 // CHECK: template<class T1, class T>
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T1> && swift::isUsableInGenericContext<T>
 // CHECK-NEXT: inline GenericPair<T1, T> passThroughGenericPair(const GenericPair<T1, T>& x, const T & y) noexcept SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::_impl_GenericPair<T1, T>::returnNewValue([&](void * _Nonnull result) {
 // CHECK-NEXT:     _impl::$s8Generics22passThroughGenericPairyAA0dE0Vyxq_GAE_q_tr0_lF(result, _impl::_impl_GenericPair<T1, T>::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::getTypeMetadata<T1>(), swift::getTypeMetadata<T>());
 // CHECK-NEXT:   });
+// CHECK-NEXT: }
+
+// CHECK: inline void takeConcretePair(const GenericPair<uint32_t, uint32_t>& x) noexcept {
+// CHECK-NEXT:  return _impl::$s8Generics16takeConcretePairyyAA07GenericD0Vys6UInt32VAFGF(_impl::swift_interop_passDirect_Generics_GenericPair_s6UInt32V_s6UInt32V(_impl::_impl_GenericPair<uint32_t, uint32_t>::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
 // CHECK: template<class T, class T1>

--- a/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
@@ -1,0 +1,46 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -module-name Generics -clang-header-expose-public-decls -emit-clang-header-path %t/generics.h
+// RUN: %FileCheck %s < %t/generics.h
+// RUN: %check-generic-interop-cxx-header-in-clang(%t/generics.h)
+
+// Check that an instantiation compiles too.
+// RUN: echo "constexpr int x = sizeof(Generics::GenericPair<int, int>);" >> %t/generics.h
+// RUN: %check-generic-interop-cxx-header-in-clang(%t/generics.h)
+
+// FIXME: evolution on.
+
+public struct GenericPair<T, T2> {
+    let x: T
+    let y: T2
+}
+
+// CHECK: template<class T_0_0, class T_0_1>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
+// CHECK-NEXT: class _impl_GenericPair;
+// CHECK-EMPTY:
+// CHECK-NEXT: // Type metadata accessor for GenericPair
+// CHECK-NEXT: SWIFT_EXTERN swift::_impl::MetadataResponseTy $s8Generics11GenericPairVMa(swift::_impl::MetadataRequestTy, void * _Nonnull, void * _Nonnull) SWIFT_NOEXCEPT SWIFT_CALL;
+
+// CHECK: template<class T_0_0, class T_0_1>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
+// CHECK-NEXT: class GenericPair final {
+// CHECK-NEXT: public:
+// CHECK-NEXT:   inline ~GenericPair() {
+// CHECK-NEXT:     auto metadata = _impl::$s8Generics11GenericPairVMa(0, swift::getTypeMetadata<T_0_0>(), swift::getTypeMetadata<T_0_1>());
+
+// CHECK: swift::_impl::OpaqueStorage _storage;
+// CHECK-NEXT: friend class _impl::_impl_GenericPair<T_0_0, T_0_1>;
+// CHECK-NEXT: }
+
+// CHECK: template<class T_0_0, class T_0_1>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
+// CHECK-NEXT: class _impl_GenericPair {
+// CHECK-NEXT: public:
+// CHECK-NEXT:   static inline char * _Nonnull getOpaquePointer(GenericPair<T_0_0, T_0_1> &object) { return object._getOpaquePointer(); }
+// CHECK-NEXT:   static inline const char * _Nonnull getOpaquePointer(const GenericPair<T_0_0, T_0_1> &object) { return object._getOpaquePointer(); }
+// CHECK-NEXT: template<class T>
+// CHECK-NEXT: static inline GenericPair<T_0_0, T_0_1> returnNewValue(T callable) {
+// CHECK-NEXT:   auto result = GenericPair<T_0_0, T_0_1>::_make();
+// CHECK-NEXT:   callable(result._getOpaquePointer());
+// CHECK-NEXT:   return result;
+// CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
@@ -25,11 +25,15 @@ public func takeGenericPair<T, T1>(_ x: GenericPair<T, T1>) {
     print(x)
 }
 
+public func passThroughGenericPair<T1, T>(_ x: GenericPair<T1, T>, _ y: T)  -> GenericPair<T1, T> {
+    return GenericPair<T1, T>(x: x.x, y: y)
+}
+
 // CHECK: template<class T_0_0, class T_0_1>
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: class _impl_GenericPair;
 // CHECK-EMPTY:
-// CHECK-NEXT: static_assert(2 <= 3, "unsupported generic requirement list for metadata func"); 
+// CHECK-NEXT: static_assert(2 <= 3, "unsupported generic requirement list for metadata func");
 // CHECK-NEXT: // Type metadata accessor for GenericPair
 // CHECK-NEXT: SWIFT_EXTERN swift::_impl::MetadataResponseTy $s8Generics11GenericPairVMa(swift::_impl::MetadataRequestTy, void * _Nonnull, void * _Nonnull) SWIFT_NOEXCEPT SWIFT_CALL;
 
@@ -66,6 +70,14 @@ public func takeGenericPair<T, T1>(_ x: GenericPair<T, T1>) {
 // CHECK-NEXT: inline GenericPair<T, T1> makeGenericPair(const T & x, const T1 & y) noexcept SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::_impl_GenericPair<T, T1>::returnNewValue([&](void * _Nonnull result) {
 // CHECK-NEXT:     _impl::$s8Generics15makeGenericPairyAA0cD0Vyxq_Gx_q_tr0_lF(result, swift::_impl::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::getTypeMetadata<T>(), swift::getTypeMetadata<T1>());
+// CHECK-NEXT:   });
+// CHECK-NEXT: }
+
+// CHECK: template<class T1, class T>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T1> && swift::isUsableInGenericContext<T>
+// CHECK-NEXT: inline GenericPair<T1, T> passThroughGenericPair(const GenericPair<T1, T>& x, const T & y) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT:   return _impl::_impl_GenericPair<T1, T>::returnNewValue([&](void * _Nonnull result) {
+// CHECK-NEXT:     _impl::$s8Generics22passThroughGenericPairyAA0dE0Vyxq_GAE_q_tr0_lF(result, _impl::_impl_GenericPair<T1, T>::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::getTypeMetadata<T1>(), swift::getTypeMetadata<T>());
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 

--- a/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
@@ -14,6 +14,10 @@ public struct GenericPair<T, T2> {
     let y: T2
 }
 
+public func makeGenericPair<T, T1>(_ x: T, _ y: T1) -> GenericPair<T, T1> {
+    return GenericPair<T, T1>(x: x, y: y);
+}
+
 // CHECK: template<class T_0_0, class T_0_1>
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: class _impl_GenericPair;
@@ -43,4 +47,16 @@ public struct GenericPair<T, T2> {
 // CHECK-NEXT:   auto result = GenericPair<T_0_0, T_0_1>::_make();
 // CHECK-NEXT:   callable(result._getOpaquePointer());
 // CHECK-NEXT:   return result;
+// CHECK-NEXT: }
+
+// CHECK: template<class T_0_0, class T_0_1>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
+// CHECK-NEXT: class GenericPair;
+// CHECK-EMPTY:
+// CHECK-NEXT: template<class T, class T1>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T> && swift::isUsableInGenericContext<T1>
+// CHECK-NEXT: inline GenericPair<T, T1> makeGenericPair(const T & x, const T1 & y) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT:   return _impl::_impl_GenericPair<T, T1>::returnNewValue([&](void * _Nonnull result) {
+// CHECK-NEXT:     _impl::$s8Generics15makeGenericPairyAA0cD0Vyxq_Gx_q_tr0_lF(result, swift::_impl::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::getTypeMetadata<T>(), swift::getTypeMetadata<T1>());
+// CHECK-NEXT:   });
 // CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
@@ -7,7 +7,10 @@
 // RUN: echo "constexpr int x = sizeof(Generics::GenericPair<int, int>);" >> %t/generics.h
 // RUN: %check-generic-interop-cxx-header-in-clang(%t/generics.h)
 
-// FIXME: evolution on.
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -enable-library-evolution -typecheck -module-name Generics -clang-header-expose-public-decls -emit-clang-header-path %t/generics.h
+// RUN: %FileCheck %s < %t/generics.h
+// RUN: %check-generic-interop-cxx-header-in-clang(%t/generics.h)
 
 public struct GenericPair<T, T2> {
     let x: T

--- a/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
@@ -1,16 +1,16 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -typecheck -module-name Generics -clang-header-expose-public-decls -emit-clang-header-path %t/generics.h
 // RUN: %FileCheck %s < %t/generics.h
-// RUN: %check-generic-interop-cxx-header-in-clang(%t/generics.h -Wno-unused-function)
+// RUN: %check-generic-interop-cxx-header-in-clang(%t/generics.h)
 
 // Check that an instantiation compiles too.
 // RUN: echo "constexpr int x = sizeof(Generics::GenericPair<int, int>);" >> %t/generics.h
-// RUN: %check-generic-interop-cxx-header-in-clang(%t/generics.h -Wno-unused-function)
+// RUN: %check-generic-interop-cxx-header-in-clang(%t/generics.h)
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -enable-library-evolution -typecheck -module-name Generics -clang-header-expose-public-decls -emit-clang-header-path %t/generics.h
 // RUN: %FileCheck %s < %t/generics.h
-// RUN: %check-generic-interop-cxx-header-in-clang(%t/generics.h -Wno-unused-function)
+// RUN: %check-generic-interop-cxx-header-in-clang(%t/generics.h)
 
 @frozen
 public struct GenericPair<T, T2> {

--- a/test/Interop/SwiftToCxx/generics/resilient-generic-struct-execution.cpp
+++ b/test/Interop/SwiftToCxx/generics/resilient-generic-struct-execution.cpp
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %S/generic-struct-in-cxx.swift -typecheck -enable-library-evolution -module-name Generics -clang-header-expose-public-decls -emit-clang-header-path %t/generics.h
+
+// RUN: %target-interop-build-clangxx -std=gnu++20 -c %s -I %t -o %t/swift-generics-execution.o
+// RUN: %target-interop-build-swift %S/generic-struct-in-cxx.swift -o %t/swift-generics-execution -Xlinker %t/swift-generics-execution.o -enable-library-evolution -module-name Generics -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+
+// RUN: %target-codesign %t/swift-generics-execution
+// RUN: %target-run %t/swift-generics-execution | %FileCheck %S/generic-struct-execution.cpp
+
+// REQUIRES: executable_test
+
+#include "generic-struct-execution.cpp"


### PR DESCRIPTION
Initial patch only adds support for passing and returning direct generic values , without supporting concrete instantiations, or using them in generic context, or even methods on them. More to come.
