### PR TITLE
[5.7][ConstraintSystem] Before applying the result builder transform to a function body, map the result builder type into context.

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5299,6 +5299,9 @@ public:
 
   /// Apply the given result builder to the closure expression.
   ///
+  /// \note builderType must be a contexutal type - callers should
+  /// open the builder type or map it into context as appropriate.
+  ///
   /// \returns \c None when the result builder cannot be applied at all,
   /// otherwise the result of applying the result builder.
   Optional<TypeMatchResult>

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -287,16 +287,13 @@ static Type inferResultBuilderType(ValueDecl *decl)  {
           continue;
 
         // Substitute Self and associated type witnesses into the
-        // result builder type. Then, map all type parameters from
-        // the conforming type into context. We don't want type
-        // parameters to appear in the result builder type, because
-        // the result builder type will only be used inside the body
-        // of this decl; it's not part of the interface type.
+        // result builder type. Type parameters will be mapped
+        // into context when applying the result builder to the
+        // function body in the constraint system.
         auto subs = SubstitutionMap::getProtocolSubstitutions(
             protocol, dc->getSelfInterfaceType(),
             ProtocolConformanceRef(conformance));
-        Type subResultBuilderType = dc->mapTypeIntoContext(
-            resultBuilderType.subst(subs));
+        Type subResultBuilderType = resultBuilderType.subst(subs);
 
         matches.push_back(
             Match::forConformance(

--- a/test/Constraints/result_builder_generic_infer.swift
+++ b/test/Constraints/result_builder_generic_infer.swift
@@ -41,6 +41,19 @@ struct ArchetypeSubstitution<A>: P {
   var x2: [S] { S() }
 }
 
+// CHECK-LABEL: struct_decl{{.*}}ExplicitGenericAttribute
+struct ExplicitGenericAttribute<T: P> {
+  // CHECK: var_decl{{.*}}x1
+  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature=<T> (substitution T -> T))
+  @Builder<T>
+  var x1: [S] { S() }
+
+  // CHECK: var_decl{{.*}}x2
+  // CHECK: Builder.buildBlock{{.*}}(substitution_map generic_signature=<T> (substitution T -> T.A))
+  @Builder<T.A>
+  var x2: [S] { S() }
+}
+
 // CHECK: struct_decl{{.*}}ConcreteTypeSubstitution
 struct ConcreteTypeSubstitution<Value> {}
 


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/60844

* **Explanation**: Before applying the result builder transform to a function body, map the result builder type into context. This was already done for inferred result builder attributes; now, the constraint system will map the builder type into context for all result builder attributes applied to computed properties/functions. Otherwise, the compiler will crash when writing a generic result builder explicitly on a function body because generic parameters will appear in expression types.
* **Scope**: This only affects generic result builder attributes.
* **Risk**: Low.
* **Testing**: Added a new unit test, passed source compatibility tests on `main`.
* **Reviewer**: @xedin 

Resolves: rdar://99162854