### PR TITLE
AST: Parse `#_hasSymbol`

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1280,7 +1280,7 @@ ERROR(string_literal_no_atsign,none,
 ERROR(invalid_float_literal_missing_leading_zero,none,
       "'.%0' is not a valid floating point literal; it must be written '0.%0'",
       (StringRef))
-ERROR(availability_query_outside_if_stmt_guard, none,
+ERROR(special_condition_outside_if_stmt_guard, none,
       "%0 may only be used as condition of an 'if', 'guard'"
       " or 'while' statement", (StringRef))
 
@@ -1934,6 +1934,19 @@ ERROR(availability_cannot_be_mixed,none,
 
 ERROR(false_available_is_called_unavailable,none,
       "#available cannot be used as an expression, did you mean to use '#unavailable'?", ())
+
+//------------------------------------------------------------------------------
+// MARK: #_hasSymbol query parsing diagnostics
+//------------------------------------------------------------------------------
+
+ERROR(has_symbol_expected_lparen,PointsToFirstBadToken,
+      "expected '(' in #_hasSymbol directive", ())
+
+ERROR(has_symbol_expected_expr,PointsToFirstBadToken,
+      "expected expression in #_hasSymbol", ())
+
+ERROR(has_symbol_expected_rparen,PointsToFirstBadToken,
+      "expected ')' in #_hasSymbol condition", ())
 
 ERROR(attr_requires_concurrency, none,
       "'%0' %select{attribute|modifier}1 is only valid when experimental "

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -990,12 +990,6 @@ WARNING(parameter_unnamed_warn,none,
 ERROR(parameter_curry_syntax_removed,none,
       "cannot have more than one parameter list", ())
 
-ERROR(availability_cannot_be_mixed,none,
-      "#available and #unavailable cannot be in the same statement", ())
-
-ERROR(false_available_is_called_unavailable,none,
-      "#available cannot be used as an expression, did you mean to use '#unavailable'?", ())
-
 ERROR(initializer_as_typed_pattern,none,
       "unexpected initializer in pattern; did you mean to use '='?", ())
 
@@ -1934,6 +1928,12 @@ ERROR(pound_available_package_description_not_allowed, none,
 
 ERROR(availability_query_repeated_platform, none,
       "version for '%0' already specified", (StringRef))
+
+ERROR(availability_cannot_be_mixed,none,
+      "#available and #unavailable cannot be in the same statement", ())
+
+ERROR(false_available_is_called_unavailable,none,
+      "#available cannot be used as an expression, did you mean to use '#unavailable'?", ())
 
 ERROR(attr_requires_concurrency, none,
       "'%0' %select{attribute|modifier}1 is only valid when experimental "

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -389,6 +389,39 @@ public:
   bool isUnavailability() const { return _isUnavailability; }
 };
 
+/// An expression that guards execution based on whether the symbols for the
+/// declaration identified by the given expression are non-null at run-time, e.g.
+///
+///   if #_hasSymbol(foo(_:)) { foo(42) }
+///
+class PoundHasSymbolInfo final : public ASTAllocated<PoundHasSymbolInfo> {
+  Expr *SymbolExpr;
+
+  SourceLoc PoundLoc;
+  SourceLoc LParenLoc;
+  SourceLoc RParenLoc;
+
+  PoundHasSymbolInfo(SourceLoc PoundLoc, SourceLoc LParenLoc, Expr *SymbolExpr,
+                     SourceLoc RParenLoc)
+      : SymbolExpr(SymbolExpr), PoundLoc(PoundLoc), LParenLoc(LParenLoc),
+        RParenLoc(RParenLoc){};
+
+public:
+  static PoundHasSymbolInfo *create(ASTContext &Ctx, SourceLoc PoundLoc,
+                                    SourceLoc LParenLoc, Expr *SymbolExpr,
+                                    SourceLoc RParenLoc);
+
+  Expr *getSymbolExpr() const { return SymbolExpr; }
+  void setSymbolExpr(Expr *E) { SymbolExpr = E; }
+
+  SourceLoc getLParenLoc() const { return LParenLoc; }
+  SourceLoc getRParenLoc() const { return RParenLoc; }
+  SourceLoc getStartLoc() const { return PoundLoc; }
+  SourceLoc getEndLoc() const { return RParenLoc; }
+  SourceRange getSourceRange() const {
+    return SourceRange(getStartLoc(), getEndLoc());
+  }
+};
 
 /// This represents an entry in an "if" or "while" condition.  Pattern bindings
 /// can bind any number of names in the pattern binding decl, and may have an
@@ -413,20 +446,21 @@ class alignas(1 << PatternAlignInBits) StmtConditionElement {
   /// to this as an 'implicit' pattern.
   Pattern *ThePattern = nullptr;
 
-  /// This is either the boolean condition, the initializer for a pattern
-  /// binding, or the #available information.
-  llvm::PointerUnion<PoundAvailableInfo*, Expr *> CondInitOrAvailable;
+  /// This is either the boolean condition, the #available information, or
+  /// the #_hasSymbol information.
+  llvm::PointerUnion<Expr *, PoundAvailableInfo *, PoundHasSymbolInfo *>
+      Condition;
 
 public:
   StmtConditionElement() {}
-  StmtConditionElement(SourceLoc IntroducerLoc, Pattern *ThePattern,
-                       Expr *Init)
-    : IntroducerLoc(IntroducerLoc), ThePattern(ThePattern),
-      CondInitOrAvailable(Init) {}
-  StmtConditionElement(Expr *cond) : CondInitOrAvailable(cond) {}
+  StmtConditionElement(SourceLoc IntroducerLoc, Pattern *ThePattern, Expr *Init)
+      : IntroducerLoc(IntroducerLoc), ThePattern(ThePattern), Condition(Init) {}
+  StmtConditionElement(Expr *cond) : Condition(cond) {}
 
-  StmtConditionElement(PoundAvailableInfo *Info) : CondInitOrAvailable(Info) {}
-  
+  StmtConditionElement(PoundAvailableInfo *Info) : Condition(Info) {}
+
+  StmtConditionElement(PoundHasSymbolInfo *Info) : Condition(Info) {}
+
   SourceLoc getIntroducerLoc() const { return IntroducerLoc; }
   void setIntroducerLoc(SourceLoc loc) { IntroducerLoc = loc; }
 
@@ -434,26 +468,33 @@ public:
   enum ConditionKind {
     CK_Boolean,
     CK_PatternBinding,
-    CK_Availability
+    CK_Availability,
+    CK_HasSymbol,
   };
 
   ConditionKind getKind() const {
-    if (ThePattern) return CK_PatternBinding;
-    return CondInitOrAvailable.is<Expr*>() ? CK_Boolean : CK_Availability;
+    if (ThePattern)
+      return CK_PatternBinding;
+    if (Condition.is<Expr *>())
+      return CK_Boolean;
+    if (Condition.is<PoundAvailableInfo *>())
+      return CK_Availability;
+    assert(Condition.is<PoundHasSymbolInfo *>());
+    return CK_HasSymbol;
   }
 
   /// Boolean Condition Accessors.
   Expr *getBooleanOrNull() const {
-    return getKind() == CK_Boolean ? CondInitOrAvailable.get<Expr*>() : nullptr;
+    return getKind() == CK_Boolean ? Condition.get<Expr *>() : nullptr;
   }
 
   Expr *getBoolean() const {
     assert(getKind() == CK_Boolean && "Not a condition");
-    return CondInitOrAvailable.get<Expr*>();
+    return Condition.get<Expr *>();
   }
   void setBoolean(Expr *E) {
     assert(getKind() == CK_Boolean && "Not a condition");
-    CondInitOrAvailable = E;
+    Condition = E;
   }
 
   /// Pattern Binding Accessors.
@@ -473,22 +514,33 @@ public:
 
   Expr *getInitializer() const {
     assert(getKind() == CK_PatternBinding && "Not a pattern binding condition");
-    return CondInitOrAvailable.get<Expr*>();
+    return Condition.get<Expr *>();
   }
   void setInitializer(Expr *E) {
     assert(getKind() == CK_PatternBinding && "Not a pattern binding condition");
-    CondInitOrAvailable = E;
+    Condition = E;
   }
   
   // Availability Accessors
   PoundAvailableInfo *getAvailability() const {
     assert(getKind() == CK_Availability && "Not an #available condition");
-    return CondInitOrAvailable.get<PoundAvailableInfo*>();
+    return Condition.get<PoundAvailableInfo *>();
   }
 
   void setAvailability(PoundAvailableInfo *Info) {
     assert(getKind() == CK_Availability && "Not an #available condition");
-    CondInitOrAvailable = Info;
+    Condition = Info;
+  }
+
+  // #_hasSymbol Accessors
+  PoundHasSymbolInfo *getHasSymbolInfo() const {
+    assert(getKind() == CK_HasSymbol && "Not a #_hasSymbol condition");
+    return Condition.get<PoundHasSymbolInfo *>();
+  }
+
+  void setHasSymbolInfo(PoundHasSymbolInfo *Info) {
+    assert(getKind() == CK_HasSymbol && "Not a #_hasSymbol condition");
+    Condition = Info;
   }
 
   SourceLoc getStartLoc() const;

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1839,6 +1839,7 @@ public:
   ParserStatus parseStmtCondition(StmtCondition &Result, Diag<> ID,
                                   StmtKind ParentKind);
   ParserResult<PoundAvailableInfo> parseStmtConditionPoundAvailable();
+  ParserResult<PoundHasSymbolInfo> parseStmtConditionPoundHasSymbol();
   ParserResult<Stmt> parseStmtIf(LabeledStmtInfo LabelInfo,
                                  bool IfWasImplicitlyInserted = false);
   ParserResult<Stmt> parseStmtGuard();

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -1167,6 +1167,7 @@ ASTScopeImpl *LabeledConditionalStmtScope::createNestedConditionalClauseScopes(
   for (auto &sec : stmt->getCond()) {
     switch (sec.getKind()) {
     case StmtConditionElement::CK_Availability:
+    case StmtConditionElement::CK_HasSymbol:
       break;
     case StmtConditionElement::CK_Boolean:
       scopeCreator.addToScopeTree(sec.getBoolean(), insertionPoint);

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1030,7 +1030,9 @@ public:
 
     void checkConditionElement(const StmtConditionElement &elt) {
       switch (elt.getKind()) {
-      case StmtConditionElement::CK_Availability: break;
+      case StmtConditionElement::CK_Availability:
+      case StmtConditionElement::CK_HasSymbol:
+        break;
       case StmtConditionElement::CK_Boolean: {
         auto *E = elt.getBoolean();
         if (shouldVerifyChecked(E))

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1340,7 +1340,9 @@ public:
   bool doIt(const StmtCondition &C) {
     for (auto &elt : C) {
       switch (elt.getKind()) {
-      case StmtConditionElement::CK_Availability: break;
+      case StmtConditionElement::CK_Availability:
+      case StmtConditionElement::CK_HasSymbol:
+        break;
       case StmtConditionElement::CK_Boolean: {
         auto E = elt.getBoolean();
         // Walk an expression condition normally.

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -368,6 +368,8 @@ SourceRange StmtConditionElement::getSourceRange() const {
     return getBoolean()->getSourceRange();
   case StmtConditionElement::CK_Availability:
     return getAvailability()->getSourceRange();
+  case StmtConditionElement::CK_HasSymbol:
+    return getHasSymbolInfo()->getSourceRange();
   case StmtConditionElement::CK_PatternBinding:
     SourceLoc Start;
     if (IntroducerLoc.isValid())
@@ -386,6 +388,15 @@ SourceRange StmtConditionElement::getSourceRange() const {
   llvm_unreachable("Unhandled StmtConditionElement in switch.");
 }
 
+PoundHasSymbolInfo *PoundHasSymbolInfo::create(ASTContext &Ctx,
+                                               SourceLoc PoundLoc,
+                                               SourceLoc LParenLoc,
+                                               Expr *SymbolExpr,
+                                               SourceLoc RParenLoc) {
+  return new (Ctx)
+      PoundHasSymbolInfo(PoundLoc, LParenLoc, SymbolExpr, RParenLoc);
+}
+
 SourceLoc StmtConditionElement::getStartLoc() const {
   switch (getKind()) {
   case StmtConditionElement::CK_Boolean:
@@ -394,6 +405,8 @@ SourceLoc StmtConditionElement::getStartLoc() const {
     return getAvailability()->getStartLoc();
   case StmtConditionElement::CK_PatternBinding:
     return getSourceRange().Start;
+  case StmtConditionElement::CK_HasSymbol:
+    return getHasSymbolInfo()->getStartLoc();
   }
 
   llvm_unreachable("Unhandled StmtConditionElement in switch.");
@@ -407,6 +420,8 @@ SourceLoc StmtConditionElement::getEndLoc() const {
     return getAvailability()->getEndLoc();
   case StmtConditionElement::CK_PatternBinding:
     return getSourceRange().End;
+  case StmtConditionElement::CK_HasSymbol:
+    return getHasSymbolInfo()->getEndLoc();
   }
 
   llvm_unreachable("Unhandled StmtConditionElement in switch.");

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -235,7 +235,8 @@ parse_operator:
       // if we're in a stmt-condition.
       if (Tok.getText() == "&&" &&
           peekToken().isAny(tok::pound_available, tok::pound_unavailable,
-                            tok::kw_let, tok::kw_var, tok::kw_case))
+                            tok::pound__hasSymbol, tok::kw_let, tok::kw_var,
+                            tok::kw_case))
         goto done;
       
       // Parse the operator.
@@ -1829,9 +1830,23 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
   case tok::pound_unavailable: {
     // For better error recovery, parse but reject availability in an expr
     // context.
-    diagnose(Tok.getLoc(), diag::availability_query_outside_if_stmt_guard, 
+    diagnose(Tok.getLoc(), diag::special_condition_outside_if_stmt_guard,
              Tok.getText());
     auto res = parseStmtConditionPoundAvailable();
+    if (res.hasCodeCompletion())
+      return makeParserCodeCompletionStatus();
+    if (res.isParseErrorOrHasCompletion() || res.isNull())
+      return nullptr;
+    return makeParserResult(new (Context)
+                                ErrorExpr(res.get()->getSourceRange()));
+  }
+
+  case tok::pound__hasSymbol: {
+    // For better error recovery, parse but reject #_hasSymbol in an expr
+    // context.
+    diagnose(Tok.getLoc(), diag::special_condition_outside_if_stmt_guard,
+             Tok.getText());
+    auto res = parseStmtConditionPoundHasSymbol();
     if (res.hasCodeCompletion())
       return makeParserCodeCompletionStatus();
     if (res.isParseErrorOrHasCompletion() || res.isNull())

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1483,7 +1483,8 @@ void SILGenFunction::emitStmtCondition(StmtCondition Cond, JumpDest FalseDest,
       booleanTestLoc = expr;
       break;
     }
-    case StmtConditionElement::CK_Availability:
+
+    case StmtConditionElement::CK_Availability: {
       // Check the running OS version to determine whether it is in the range
       // specified by elt.
       PoundAvailableInfo *availability = elt.getAvailability();
@@ -1513,6 +1514,12 @@ void SILGenFunction::emitStmtCondition(StmtCondition Cond, JumpDest FalseDest,
         }
       }
       break;
+    }
+
+    case StmtConditionElement::CK_HasSymbol: {
+      llvm::report_fatal_error("Can't SILGen #_hasSymbol yet!");
+      break;
+    }
     }
 
     // Now that we have a boolean test as a Builtin.i1, emit the branch.

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -48,6 +48,7 @@ const StmtConditionElement *findAvailabilityCondition(StmtCondition stmtCond) {
     switch (cond.getKind()) {
     case StmtConditionElement::CK_Boolean:
     case StmtConditionElement::CK_PatternBinding:
+    case StmtConditionElement::CK_HasSymbol:
       continue;
 
     case StmtConditionElement::CK_Availability:

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8909,6 +8909,7 @@ ExprWalker::rewriteTarget(SolutionApplicationTarget target) {
     for (auto &condElement : *stmtCondition) {
       switch (condElement.getKind()) {
       case StmtConditionElement::CK_Availability:
+      case StmtConditionElement::CK_HasSymbol:
         continue;
 
       case StmtConditionElement::CK_Boolean: {

--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -1919,6 +1919,7 @@ private:
         switch (cond.getKind()) {
         case StmtConditionElement::CK_Boolean:
         case StmtConditionElement::CK_PatternBinding:
+        case StmtConditionElement::CK_HasSymbol:
           continue;
 
         case StmtConditionElement::CK_Availability:

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4342,6 +4342,7 @@ bool ConstraintSystem::generateConstraints(StmtCondition condition,
   for (const auto &condElement : condition) {
     switch (condElement.getKind()) {
     case StmtConditionElement::CK_Availability:
+    case StmtConditionElement::CK_HasSymbol:
       // Nothing to do here.
       continue;
 

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -422,6 +422,8 @@ bool TypeChecker::typeCheckStmtConditionElement(StmtConditionElement &elt,
                                                 bool &isFalsable,
                                                 DeclContext *dc) {
   auto &Context = dc->getASTContext();
+
+  // Typecheck a #available or #unavailable condition.
   if (elt.getKind() == StmtConditionElement::CK_Availability) {
     isFalsable = true;
 
@@ -441,6 +443,20 @@ bool TypeChecker::typeCheckStmtConditionElement(StmtConditionElement &elt,
               break;
             }
     }
+
+    return false;
+  }
+
+  // Typecheck a #_hasSymbol condition.
+  if (elt.getKind() == StmtConditionElement::CK_HasSymbol) {
+    auto Info = elt.getHasSymbolInfo();
+    auto E = Info->getSymbolExpr();
+    if (E) {
+      // FIXME: Implement #_hasSymbol typechecking.
+      (void)TypeChecker::typeCheckExpression(E, dc);
+      Info->setSymbolExpr(E);
+    }
+    isFalsable = true;
 
     return false;
   }

--- a/test/Parse/has_symbol.swift
+++ b/test/Parse/has_symbol.swift
@@ -1,0 +1,36 @@
+// RUN: %target-typecheck-verify-swift
+
+func foo() {}
+func bar() {}
+
+if #_hasSymbol(foo) {}
+if #_hasSymbol(foo), #_hasSymbol(bar) {}
+guard #_hasSymbol(foo) else { fatalError() }
+while #_hasSymbol(foo) {}
+
+if #_hasSymbol(foo) == false {} // expected-error {{expected '{' after 'if' condition}}
+
+_ = #_hasSymbol(foo) {} // expected-error {{#_hasSymbol may only be used as condition of}}
+
+(#_hasSymbol(foo) ? 1 : 0) // expected-error {{#_hasSymbol may only be used as condition of}}
+
+if !#_hasSymbol(foo) {} // expected-error {{#_hasSymbol may only be used as condition of}}
+
+if let _ = Optional(5), !#_hasSymbol(foo) {} {} // expected-error {{#_hasSymbol may only be used as condition of}}
+
+if #_hasSymbol {} // expected-error {{expected '(' in #_hasSymbol directive}}
+
+// expected-error@+3 {{expected ')' in #_hasSymbol condition}}
+// expected-error@+2 {{expected '{' after 'if' condition}}
+// expected-note@+1 {{to match this opening '('}}
+if #_hasSymbol(struct) {} // expected-error {{expected expression in #_hasSymbol}}
+
+// expected-error@+3 {{expected ')' in #_hasSymbol condition}}
+// expected-error@+2 {{expected '{' after 'if' condition}}
+// expected-note@+1 {{to match this opening '('}}
+if #_hasSymbol(foo bar) {}
+
+// expected-error@+2 {{expected ')' in #_hasSymbol condition}}
+// expected-note@+1 {{to match this opening '('}}
+if #_hasSymbol(foo {}
+


### PR DESCRIPTION
Introduce the compiler directive `#_hasSymbol` which will be used to detect directly whether weakly linked symbols are present at runtime. It  is intended for use in combination with `@_weakLinked import` or `-weak-link-at-target`.

```
if #_hasSymbol(foo(_:)) {
  foo(42)
}
```

Parsing only; type checking and SILGen will be coming in later commits.

SwiftSyntax parsing has been implemented in https://github.com/apple/swift-syntax/pull/661.
    
Resolves rdar://99342017
