### PR TITLE
[ClangImporter] Update to match new DependencyScanningService API

### DIFF
--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -43,9 +43,9 @@ public:
   DependencyScanningTool tool;
 
   ClangModuleDependenciesCacheImpl()
-      : importHackFileCache(),
-        service(ScanningMode::DependencyDirectivesScan,
-                ScanningOutputFormat::Full, clang::CASOptions(), nullptr),
+      : importHackFileCache(), service(ScanningMode::DependencyDirectivesScan,
+                                       ScanningOutputFormat::Full,
+                                       clang::CASOptions(), nullptr, nullptr),
         tool(service) {}
   ~ClangModuleDependenciesCacheImpl();
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Update ClangImporter to match new DependencyScanningService API from
clang depscan.

llvm-project change: https://github.com/apple/llvm-project/pull/5231

