### PR TITLE
[SwiftToCxx] Including Cxx representation of Swift's Error

### DIFF
--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -475,7 +475,7 @@ ClangRepresentation DeclAndTypeClangFunctionPrinter::printFunctionSignature(
         }
       } else if (param.role ==  AdditionalParam::Role::Error) {
         os << "SWIFT_ERROR_RESULT ";
-        os << "void ** _error";
+        os << "void * _Nullable * _Nullable _error";
       } else if (param.role == AdditionalParam::Role::GenericRequirement) {
         os << "void * _Nonnull ";
         if (param.genericRequirement->Protocol)

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -695,7 +695,7 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
   // Create the condition and the statement to throw an exception.
   if (hasThrows) {
     os << "  if (opaqueError != nullptr)\n";
-    os << "    throw (swift::_impl::NaiveException(\"Exception\"));\n";
+    os << "    throw (swift::_impl::swift::Error(opaqueError));\n";
   }
 
   // Return the function result value if it doesn't throw.

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -695,7 +695,7 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
   // Create the condition and the statement to throw an exception.
   if (hasThrows) {
     os << "  if (opaqueError != nullptr)\n";
-    os << "    throw (swift::_impl::swift::Error(opaqueError));\n";
+    os << "    throw (swift::Error(opaqueError));\n";
   }
 
   // Return the function result value if it doesn't throw.

--- a/lib/PrintAsClang/PrintSwiftToClangCoreScaffold.cpp
+++ b/lib/PrintAsClang/PrintSwiftToClangCoreScaffold.cpp
@@ -158,7 +158,7 @@ static void printTypeMetadataResponseType(SwiftToClangInteropContext &ctx,
 
 void printCxxNaiveException(raw_ostream &os) {
   os << "/// Naive exception class that should be thrown\n";
-  os << "class NaiveException {\n";
+  os << "class NaiveException : public swift::Error {\n";
   os << "public:\n";
   os << "  inline NaiveException(const char * _Nonnull msg) noexcept : "
      << "msg_(msg) { }\n";

--- a/stdlib/public/SwiftShims/_SwiftCxxInteroperability.h
+++ b/stdlib/public/SwiftShims/_SwiftCxxInteroperability.h
@@ -180,6 +180,7 @@ namespace swift {
 class Error {
 public:
   Error() {}
+  Error(void* _Nonnull swiftError) { opaqueValue = swiftError; }
   ~Error() {
     if (opaqueValue)
       swift_errorRelease(opaqueValue);

--- a/stdlib/public/SwiftShims/_SwiftCxxInteroperability.h
+++ b/stdlib/public/SwiftShims/_SwiftCxxInteroperability.h
@@ -32,10 +32,6 @@ extern "C" void *_Nonnull swift_retain(void *_Nonnull) noexcept;
 
 extern "C" void swift_release(void *_Nonnull) noexcept;
 
-extern "C" void *_Nonnull swift_errorRetain(void *_Nonnull swiftError) noexcept;
-
-extern "C" void swift_errorRelease(void *_Nonnull swiftError) noexcept;
-
 inline void *_Nonnull opaqueAlloc(size_t size, size_t align) noexcept {
 #if defined(_WIN32)
   void *r = _aligned_malloc(size, align);
@@ -176,7 +172,12 @@ template <class T> inline void *_Nonnull getOpaquePointer(T &value) {
   return reinterpret_cast<void *>(&value);
 }
 
-namespace swift {
+} // namespace _impl
+
+extern "C" void *_Nonnull swift_errorRetain(void *_Nonnull swiftError) noexcept;
+
+extern "C" void swift_errorRelease(void *_Nonnull swiftError) noexcept;
+
 class Error {
 public:
   Error() {}
@@ -198,9 +199,6 @@ public:
 private:
   void * _Nonnull opaqueValue = nullptr;
 };
-}
-
-} // namespace _impl
 
 #pragma clang diagnostic pop
 

--- a/test/Interop/SwiftToCxx/core/swift-impl-defs-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/core/swift-impl-defs-in-cxx.swift
@@ -99,7 +99,7 @@
 // CHECK-NEXT: #endif
 // CHECK-EMPTY:
 // CHECK-NEXT: /// Naive exception class that should be thrown
-// CHECK-NEXT: class NaiveException {
+// CHECK-NEXT: class NaiveException : public swift::Error {
 // CHECK-NEXT: public:
 // CHECK-NEXT: inline NaiveException(const char * _Nonnull msg) noexcept : msg_(msg) { }
 // CHECK-NEXT: inline NaiveException(NaiveException&& other) noexcept : msg_(other.msg_) { other.msg_ = nullptr; }

--- a/test/Interop/SwiftToCxx/functions/swift-functions-errors-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/swift-functions-errors-execution.cpp
@@ -21,18 +21,18 @@ int main() {
 
   try {
     Functions::emptyThrowFunction();
-  } catch (swift::_impl::NaiveException& e) {
-    printf("%s\n", e.getMessage());
+  } catch (swift::_impl::swift::Error& e) {
+    printf("Exception\n");
   }
   try {
     Functions::throwFunction();
-  } catch (swift::_impl::NaiveException& e) {
-    printf("%s\n", e.getMessage());
+  } catch (swift::_impl::swift::Error& e) {
+     printf("Exception\n");
   }
   try {
     Functions::throwFunctionWithReturn();
-  } catch (swift::_impl::NaiveException& e) {
-    printf("%s\n", e.getMessage());
+  } catch (swift::_impl::swift::Error& e) {
+     printf("Exception\n");
   }
 
   return 0;

--- a/test/Interop/SwiftToCxx/functions/swift-functions-errors-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/swift-functions-errors-execution.cpp
@@ -21,19 +21,22 @@ int main() {
 
   try {
     Functions::emptyThrowFunction();
-  } catch (swift::_impl::swift::Error& e) {
+  } catch (swift::Error& e) {
     printf("Exception\n");
   }
   try {
     Functions::throwFunction();
-  } catch (swift::_impl::swift::Error& e) {
+  } catch (swift::Error& e) {
      printf("Exception\n");
   }
   try {
     Functions::throwFunctionWithReturn();
-  } catch (swift::_impl::swift::Error& e) {
+  } catch (swift::Error& e) {
      printf("Exception\n");
   }
+  try {
+    Functions::testDestroyedError();
+  } catch(const swift::Error &e) { }
 
   return 0;
 }
@@ -43,3 +46,4 @@ int main() {
 // CHECK-NEXT: Exception
 // CHECK-NEXT: passThrowFunctionWithReturn
 // CHECK-NEXT: Exception
+// CHECK-NEXT: Test destroyed

--- a/test/Interop/SwiftToCxx/functions/swift-functions-errors.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-functions-errors.swift
@@ -8,8 +8,8 @@
 
 // CHECK-LABEL: namespace _impl {
 
-// CHECK: SWIFT_EXTERN void $s9Functions18emptyThrowFunctionyyKF(SWIFT_CONTEXT void * _Nonnull _self, SWIFT_ERROR_RESULT void ** _error) SWIFT_CALL; // emptyThrowFunction()
-// CHECK: SWIFT_EXTERN void $s9Functions13throwFunctionyyKF(SWIFT_CONTEXT void * _Nonnull _self, SWIFT_ERROR_RESULT void ** _error) SWIFT_CALL; // throwFunction()
+// CHECK: SWIFT_EXTERN void $s9Functions18emptyThrowFunctionyyKF(SWIFT_CONTEXT void * _Nonnull _self, SWIFT_ERROR_RESULT void * _Nullable * _Nullable _error) SWIFT_CALL; // emptyThrowFunction()
+// CHECK: SWIFT_EXTERN void $s9Functions13throwFunctionyyKF(SWIFT_CONTEXT void * _Nonnull _self, SWIFT_ERROR_RESULT void * _Nullable * _Nullable _error) SWIFT_CALL; // throwFunction()
 
 // CHECK: }
 

--- a/test/Interop/SwiftToCxx/functions/swift-functions-errors.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-functions-errors.swift
@@ -25,7 +25,7 @@ public func emptyThrowFunction() throws { print("passEmptyThrowFunction") }
 // CHECK: void* self = nullptr;
 // CHECK: _impl::$s9Functions18emptyThrowFunctionyyKF(self, &opaqueError);
 // CHECK: if (opaqueError != nullptr)
-// CHECK: throw (swift::_impl::NaiveException("Exception"));
+// CHECK: throw (swift::_impl::swift::Error(opaqueError))
 // CHECK: }
 
 public func throwFunction() throws {
@@ -38,7 +38,7 @@ public func throwFunction() throws {
 // CHECK: void* self = nullptr;
 // CHECK: _impl::$s9Functions13throwFunctionyyKF(self, &opaqueError);
 // CHECK: if (opaqueError != nullptr)
-// CHECK: throw (swift::_impl::NaiveException("Exception"));
+// CHECK: throw (swift::_impl::swift::Error(opaqueError))
 // CHECK: }
 
 public func throwFunctionWithReturn() throws -> Int {
@@ -52,6 +52,6 @@ public func throwFunctionWithReturn() throws -> Int {
 // CHECK: void* self = nullptr;
 // CHECK: auto returnValue = _impl::$s9Functions23throwFunctionWithReturnSiyKF(self, &opaqueError);
 // CHECK: if (opaqueError != nullptr)
-// CHECK: throw (swift::_impl::NaiveException("Exception"));
+// CHECK: throw (swift::_impl::swift::Error(opaqueError))
 // CHECK: return returnValue;
 // CHECK: }

--- a/test/Interop/SwiftToCxx/functions/swift-functions-errors.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-functions-errors.swift
@@ -25,7 +25,27 @@ public func emptyThrowFunction() throws { print("passEmptyThrowFunction") }
 // CHECK: void* self = nullptr;
 // CHECK: _impl::$s9Functions18emptyThrowFunctionyyKF(self, &opaqueError);
 // CHECK: if (opaqueError != nullptr)
-// CHECK: throw (swift::_impl::swift::Error(opaqueError))
+// CHECK: throw (swift::Error(opaqueError))
+// CHECK: }
+
+class TestDestroyed {
+  deinit {
+    print("Test destroyed")
+  }
+}
+
+public struct DestroyedError : Error {
+  let t = TestDestroyed()
+}
+
+public func testDestroyedError() throws { throw DestroyedError() }
+
+// CHECK: inline void testDestroyedError() {
+// CHECK: void* opaqueError = nullptr;
+// CHECK: void* self = nullptr;
+// CHECK: _impl::$s9Functions18testDestroyedErroryyKF(self, &opaqueError);
+// CHECK: if (opaqueError != nullptr)
+// CHECK: throw (swift::Error(opaqueError))
 // CHECK: }
 
 public func throwFunction() throws {
@@ -38,7 +58,7 @@ public func throwFunction() throws {
 // CHECK: void* self = nullptr;
 // CHECK: _impl::$s9Functions13throwFunctionyyKF(self, &opaqueError);
 // CHECK: if (opaqueError != nullptr)
-// CHECK: throw (swift::_impl::swift::Error(opaqueError))
+// CHECK: throw (swift::Error(opaqueError))
 // CHECK: }
 
 public func throwFunctionWithReturn() throws -> Int {
@@ -52,6 +72,6 @@ public func throwFunctionWithReturn() throws -> Int {
 // CHECK: void* self = nullptr;
 // CHECK: auto returnValue = _impl::$s9Functions23throwFunctionWithReturnSiyKF(self, &opaqueError);
 // CHECK: if (opaqueError != nullptr)
-// CHECK: throw (swift::_impl::swift::Error(opaqueError))
+// CHECK: throw (swift::Error(opaqueError))
 // CHECK: return returnValue;
 // CHECK: }


### PR DESCRIPTION
This PR includes the class `Error` which represents a Swift error that can be extended and a function can throw!