### PR TITLE
[SILGen] correct missing canonicalization of global actor

### DIFF
--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -823,7 +823,7 @@ void SILGenFunction::emitPrologGlobalActorHop(SILLocation loc,
 }
 
 SILValue SILGenFunction::emitLoadGlobalActorExecutor(Type globalActor) {
-  CanType actorType = CanType(globalActor);
+  CanType actorType = globalActor->getCanonicalType();
   NominalTypeDecl *nominal = actorType->getNominalOrBoundGenericNominal();
   VarDecl *sharedInstanceDecl = nominal->getGlobalActorInstance();
   assert(sharedInstanceDecl && "no shared actor field in global actor");

--- a/test/SILGen/hop_to_executor_async_prop.swift
+++ b/test/SILGen/hop_to_executor_async_prop.swift
@@ -667,7 +667,9 @@ struct Blah {
     }
 }
 
-@MainActor
+typealias FancyActor = MainActor // helps cover rdar://96309577
+
+@FancyActor
 func getTemperature() -> Int { return 0 }
 
 @MainActor


### PR DESCRIPTION
resolves rdar://96309577 / https://github.com/apple/swift/issues/59705