### PR TITLE
[Sema] TypeWrappers: Don't try to manage compiler synthesized properties

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -381,8 +381,8 @@ static ConstructorDecl *createImplicitConstructor(NominalTypeDecl *decl,
         continue;
 
       if (!var->isAccessedViaTypeWrapper()) {
-        // $_storage itself.
-        if (var->getName() == ctx.Id_TypeWrapperProperty)
+        // Compiler synthesized properties are not included.
+        if (var->isImplicit())
           continue;
 
         // Computed properties are not included.

--- a/lib/Sema/TypeCheckTypeWrapper.cpp
+++ b/lib/Sema/TypeCheckTypeWrapper.cpp
@@ -312,10 +312,6 @@ bool IsPropertyAccessedViaTypeWrapper::evaluate(Evaluator &evaluator,
   if (!(parent && parent->hasTypeWrapper()))
     return false;
 
-  // Don't attempt to wrap the `$_storage` property.
-  if (property->getName() == property->getASTContext().Id_TypeWrapperProperty)
-    return false;
-
   if (property->isStatic() || property->isLet())
     return false;
 
@@ -345,6 +341,11 @@ bool IsPropertyAccessedViaTypeWrapper::evaluate(Evaluator &evaluator,
           PropertyWrapperSynthesizedPropertyKind::Backing))
       return true;
   }
+
+  // Don't wrap any compiler synthesized properties except to
+  // property wrapper backing storage (checked above).
+  if (property->isImplicit())
+    return false;
 
   // Check whether this is a computed property.
   {

--- a/test/Interpreter/type_wrapper_with_actors.swift
+++ b/test/Interpreter/type_wrapper_with_actors.swift
@@ -14,6 +14,11 @@
 
 // REQUIRES: OS=macosx
 
+// This requires executable tests to be run on the same machine as the compiler,
+// as it links with a dylib that it doesn't arrange to get uploaded to remote executors.
+// (rdar://99051588)
+// UNSUPPORTED: remote_run || device_run
+
 import type_wrapper_defs
 
 @Wrapper

--- a/test/Interpreter/type_wrapper_with_actors.swift
+++ b/test/Interpreter/type_wrapper_with_actors.swift
@@ -1,0 +1,43 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 -enable-experimental-feature TypeWrappers -parse-as-library -emit-library -emit-module-path %t/type_wrapper_defs.swiftmodule -module-name type_wrapper_defs %S/Inputs/type_wrapper_defs.swift -o %t/%target-library-name(type_wrapper_defs)
+// RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 -ltype_wrapper_defs -module-name main -I %t -L %t %s -o %t/main %target-rpath(%t)
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main %t/%target-library-name(type_wrapper_defs) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: asserts
+// REQUIRES: concurrency
+
+// rdar://76038845
+// REQUIRES: concurrency_runtime
+// UNSUPPORTED: back_deployment_runtime
+
+// REQUIRES: OS=macosx
+
+import type_wrapper_defs
+
+@Wrapper
+public actor Actor {
+  public var name: String
+  @PropWrapper public var age: Int? = nil
+
+  public func setAge(_ newAge: Int) async {
+    age = newAge
+  }
+}
+
+let a = Actor(name: "Arhtur Dent")
+await print(a.name)
+// CHECK: in getter
+// CHECK-NEXT: Arhtur Dent
+await print(a.age)
+// CHECK: in getter
+// CHECK-NEXT: nil
+
+await a.setAge(30)
+// CHECK: in getter
+// CHECK-NEXT: in setter => PropWrapper<Optional<Int>>(value: Optional(30))
+
+await print(a.age)
+// CHECK: in getter
+// CHECK-NEXT: 30

--- a/test/Interpreter/type_wrappers.swift
+++ b/test/Interpreter/type_wrappers.swift
@@ -7,6 +7,11 @@
 // REQUIRES: executable_test
 // REQUIRES: asserts
 
+// This requires executable tests to be run on the same machine as the compiler,
+// as it links with a dylib that it doesn't arrange to get uploaded to remote executors.
+// (rdar://99051588)
+// UNSUPPORTED: remote_run || device_run
+
 import type_wrapper_defs
 
 var p: Person<String> = .init(name: "P", projects: ["A", "B"])

--- a/test/type/type_wrapper.swift
+++ b/test/type/type_wrapper.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature TypeWrappers
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature TypeWrappers
 
 // REQUIRES: asserts
 
@@ -379,4 +379,22 @@ func testDeclarationsWithUnmanagedProperties() {
   }
 
   _ = OnlyLazyLetAndComputed(name: "Arthur Dent") // Ok
+}
+
+func testActors() async {
+  @NoopWrapper
+  actor Person {
+    var name: String
+    // expected-note@-1 {{mutation of this property is only permitted within the actor}}
+    var age: Int
+    // expected-note@-1 {{mutation of this property is only permitted within the actor}}
+  }
+
+  let person = Person(name: "Arthur Dent", age: 30)
+
+  _ = await person.name
+  _ = await person.age
+
+  person.name = "NoName" // expected-error {{actor-isolated property 'name' can not be mutated from a non-isolated context}}
+  person.age = 0 // expected-error {{actor-isolated property 'age' can not be mutated from a non-isolated context}}
 }


### PR DESCRIPTION
-  Properties like `unownedExecutor` that are implicitly injected into a type
    should not be managed by a type wrapper.

- Expand tests to cover type wrapper/actor interaction.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
