### PR TITLE
[Sema] TypeWrappers: Set `$_storage` access level to `internal`

### DIFF
--- a/lib/Sema/TypeCheckTypeWrapper.cpp
+++ b/lib/Sema/TypeCheckTypeWrapper.cpp
@@ -195,7 +195,7 @@ GetTypeWrapperProperty::evaluate(Evaluator &evaluator,
       /*genericArgs=*/{storage->getInterfaceType()->getMetatypeInstanceType()});
 
   return injectProperty(parent, ctx.Id_TypeWrapperProperty, propertyTy,
-                        VarDecl::Introducer::Var, AccessLevel::Private);
+                        VarDecl::Introducer::Var, AccessLevel::Internal);
 }
 
 VarDecl *GetTypeWrapperStorageForProperty::evaluate(Evaluator &evaluator,


### PR DESCRIPTION
Otherwise it cannot be used as a protocol requirement witness.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
