### PR TITLE
[Frontend] add -emit-ast and -emit-parse as aliases for the -dump-* flags

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1061,8 +1061,12 @@ def typecheck : Flag<["-"], "typecheck">,
 def dump_parse : Flag<["-"], "dump-parse">,
   HelpText<"Parse input file(s) and dump AST(s)">, ModeOpt,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
+def emit_parse : Flag<["-"], "emit-parse">, Alias<dump_parse>,
+  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
 def dump_ast : Flag<["-"], "dump-ast">,
   HelpText<"Parse and type-check input file(s) and dump AST(s)">, ModeOpt,
+  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
+def emit_ast : Flag<["-"], "emit-ast">, Alias<dump_ast>,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
 def dump_scope_maps : Separate<["-"], "dump-scope-maps">,
   HelpText<"Parse and type-check input file(s) and dump the scope map(s)">,

--- a/test/Frontend/ast-dump.swift
+++ b/test/Frontend/ast-dump.swift
@@ -3,9 +3,9 @@
 // RUN: echo 'public func b() { }' >%t/b.swift
 // RUN: echo 'public func main() {a(); b()}' >%t/main.swift
 
-// Test printing to stdout
+// Test printing to stdout (using either -dump-ast or -emit-ast)
 // RUN: %target-swift-frontend -dump-ast -primary-file %t/a.swift %t/b.swift %t/main.swift -module-name main -o - 2>%t/a.swift.stderr | %FileCheck -check-prefix A-AST %s
-// RUN: %target-swift-frontend -dump-ast %t/a.swift -primary-file %t/b.swift %t/main.swift -module-name main -o - 2>%t/b.swift.stderr | %FileCheck -check-prefix B-AST %s
+// RUN: %target-swift-frontend -emit-ast %t/a.swift -primary-file %t/b.swift %t/main.swift -module-name main -o - 2>%t/b.swift.stderr | %FileCheck -check-prefix B-AST %s
 // RUN: %target-swift-frontend -dump-ast %t/a.swift %t/b.swift -primary-file %t/main.swift -module-name main -o - 2>%t/main.swift.stderr | %FileCheck -check-prefix MAIN-AST %s
 
 // Test printing to files

--- a/test/Frontend/dump-parse-syntactically-valid.swift
+++ b/test/Frontend/dump-parse-syntactically-valid.swift
@@ -1,4 +1,7 @@
+// RUN: %target-swift-frontend -emit-parse %s
 // RUN: %target-swift-frontend -dump-parse %s
+
+// Also makes sure -emit-parse and -dump-parse are both valid.
 
 // Make sure we don't do any Sema and don't crash.
 extension X {


### PR DESCRIPTION
This is mainly to improve usability for Swift compiler developers.

resolves rdar://99357128