### PR TITLE
[pruned-liveness] Implement FieldSensitiveAddressPrunedLiveness.

### DIFF
--- a/include/swift/SIL/PrunedLiveness.h
+++ b/include/swift/SIL/PrunedLiveness.h
@@ -94,7 +94,9 @@
 #ifndef SWIFT_SILOPTIMIZER_UTILS_PRUNEDLIVENESS_H
 #define SWIFT_SILOPTIMIZER_UTILS_PRUNEDLIVENESS_H
 
+#include "swift/AST/TypeExpansionContext.h"
 #include "swift/SIL/SILBasicBlock.h"
+#include "swift/SIL/SILFunction.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/PointerIntPair.h"
 #include "llvm/ADT/SmallVector.h"
@@ -236,6 +238,8 @@ public:
     assert(!discoveredBlocks || discoveredBlocks->empty());
   }
 
+  unsigned getNumBitsToTrack() const { return numBitsToTrack; }
+
   bool empty() const { return liveBlocks.empty(); }
 
   void clear() {
@@ -290,7 +294,6 @@ public:
       return;
     }
 
-    assert(liveBlockIter->second.size() == 1);
     liveBlockIter->second.getLiveness(startBitNo, endBitNo, foundLivenessInfo);
   }
 
@@ -551,6 +554,289 @@ struct PrunedLivenessBoundary {
   /// by DeadEndBlocks.
   void compute(const PrunedLiveness &liveness,
                ArrayRef<SILBasicBlock *> postDomBlocks);
+};
+
+/// Given a type T and a descendent field F in T's type tree, then the
+/// sub-element number of F is the first leaf element of the type tree in its
+/// linearized representation.
+struct SubElementNumber {
+  unsigned number;
+
+  SubElementNumber(unsigned number) : number(number) {}
+
+  /// Given an arbitrary projection \p projectionFromRoot from the \p
+  /// rootAddress, compute the sub element number for that \p SILValue. The sub
+  /// element number of a type T is always the index of its first leaf node
+  /// descendent in the type tree.
+  ///
+  /// DISCUSSION: This works for non-leaf types in the type tree as well as
+  /// normal leaf elements. It is the index of the first leaf element that is a
+  /// sub element of the root SILType that this projection will effect. The rest
+  /// of the elements effected can be found by computing the number of leaf sub
+  /// elements of \p projectionFromRoot's type and adding this to the result of
+  /// this function.
+  ///
+  /// \returns None if we didn't know how to compute sub-element for this
+  /// projection.
+  static Optional<SubElementNumber> compute(SILValue projectionFromRoot,
+                                            SILValue root);
+
+  operator unsigned() const { return number; }
+};
+
+/// Given a type T, this is the number of leaf field types in T's type tree. A
+/// leaf field type is a descendent field of T that does not have any
+/// descendent's itself.
+struct TypeSubElementCount {
+  unsigned number;
+
+  TypeSubElementCount(unsigned number) : number(number) {}
+
+  /// Given a type \p type, compute the total number of leaf sub-elements of \p
+  /// type in the type tree.
+  ///
+  /// Some interesting properties of this computation:
+  ///
+  /// 1. When applied to the root type, this equals the total number of bits of
+  /// liveness that we track.
+  ///
+  /// 2. When applied to a field type F of the type tree for a type T,
+  /// computeNumLeafSubElements(F) when added to F's start sub element number
+  /// will go to the next sibling node in the type tree, walking up the tree and
+  /// attempting to find siblings if no further siblings exist.
+  TypeSubElementCount(SILType type, SILModule &mod,
+                      TypeExpansionContext context);
+
+  TypeSubElementCount(SILValue value)
+      : TypeSubElementCount(value->getType(), *value->getModule(),
+                            TypeExpansionContext(*value->getFunction())) {}
+
+  operator unsigned() const { return number; }
+};
+
+/// A span of leaf elements in the sub-element break down of the linearization
+/// of the type tree of a type T.
+struct TypeTreeLeafTypeRange {
+  SubElementNumber startEltOffset;
+  SubElementNumber endEltOffset;
+
+  /// The leaf type range for the entire type tree.
+  TypeTreeLeafTypeRange(SILValue rootAddress)
+      : startEltOffset(0), endEltOffset(TypeSubElementCount(rootAddress)) {}
+
+  /// The leaf type sub-range of the type tree of \p rootAddress, consisting of
+  /// \p projectedAddress and all of \p projectedAddress's descendent fields in
+  /// the type tree.
+  TypeTreeLeafTypeRange(SILValue projectedAddress, SILValue rootAddress)
+      : startEltOffset(
+            *SubElementNumber::compute(projectedAddress, rootAddress)),
+        endEltOffset(startEltOffset + TypeSubElementCount(projectedAddress)) {}
+
+  /// Is the given leaf type specified by \p singleLeafElementNumber apart of
+  /// our \p range of leaf type values in the our larger type.
+  bool contains(SubElementNumber singleLeafElementNumber) const {
+    return startEltOffset <= singleLeafElementNumber &&
+           singleLeafElementNumber < endEltOffset;
+  }
+
+  /// Returns true if either of this overlaps at all with the given range.
+  bool contains(TypeTreeLeafTypeRange range) const {
+    if (startEltOffset <= range.startEltOffset &&
+        range.startEltOffset < endEltOffset)
+      return true;
+
+    // If our start and end offsets, our extent is only 1 and we know that our
+    // value
+    unsigned rangeLastElt = range.endEltOffset - 1;
+    if (range.startEltOffset == rangeLastElt)
+      return false;
+
+    // Othrwise, see if endEltOffset - 1 is within the range.
+    return startEltOffset <= rangeLastElt && rangeLastElt < endEltOffset;
+  }
+};
+
+/// This is exactly like pruned liveness except that instead of tracking a
+/// single bit of liveness, it tracks multiple bits of liveness for leaf type
+/// tree nodes of an allocation one is calculating pruned liveness for.
+///
+/// DISCUSSION: One can view a type T as a tree with recursively each field F of
+/// the type T being a child of T in the tree. We say recursively since the tree
+/// unfolds for F and its children as well.
+class FieldSensitiveAddressPrunedLiveness {
+  PrunedLiveBlocks liveBlocks;
+
+  struct InterestingUser {
+    TypeTreeLeafTypeRange subEltSpan;
+    bool isConsuming;
+
+    InterestingUser(TypeTreeLeafTypeRange subEltSpan, bool isConsuming)
+        : subEltSpan(subEltSpan), isConsuming(isConsuming) {}
+
+    InterestingUser &operator&=(bool otherValue) {
+      isConsuming &= otherValue;
+      return *this;
+    }
+  };
+
+  /// Map all "interesting" user instructions in this def's live range to a pair
+  /// consisting of the SILValue that it uses and a flag indicating whether they
+  /// must end the lifetime.
+  ///
+  /// Lifetime-ending users are always on the boundary so are always
+  /// interesting.
+  ///
+  /// Non-lifetime-ending uses within a LiveWithin block are interesting because
+  /// they may be the last use in the block.
+  ///
+  /// Non-lifetime-ending within a LiveOut block are uninteresting.
+  llvm::SmallMapVector<SILInstruction *, InterestingUser, 8> users;
+
+  /// The root address of our type tree.
+  SILValue rootAddress;
+
+public:
+  FieldSensitiveAddressPrunedLiveness(
+      SILFunction *fn, SILValue rootValue,
+      SmallVectorImpl<SILBasicBlock *> *discoveredBlocks = nullptr)
+      : liveBlocks(TypeSubElementCount(rootValue), discoveredBlocks),
+        rootAddress(rootValue) {}
+
+  bool empty() const {
+    assert(!liveBlocks.empty() || users.empty());
+    return liveBlocks.empty();
+  }
+
+  void clear() {
+    liveBlocks.clear();
+    users.clear();
+  }
+
+  SILValue getRootAddress() const { return rootAddress; }
+
+  unsigned numLiveBlocks() const { return liveBlocks.numLiveBlocks(); }
+
+  /// If the constructor was provided with a vector to populate, then this
+  /// returns the list of all live blocks with no duplicates.
+  ArrayRef<SILBasicBlock *> getDiscoveredBlocks() const {
+    return liveBlocks.getDiscoveredBlocks();
+  }
+
+  using UserRange =
+      iterator_range<const std::pair<SILInstruction *, InterestingUser> *>;
+  UserRange getAllUsers() const {
+    return llvm::make_range(users.begin(), users.end());
+  }
+
+  using UserBlockRange = TransformRange<
+      UserRange, function_ref<SILBasicBlock *(
+                     const std::pair<SILInstruction *, InterestingUser> &)>>;
+  UserBlockRange getAllUserBlocks() const {
+    function_ref<SILBasicBlock *(
+        const std::pair<SILInstruction *, InterestingUser> &)>
+        op;
+    op = [](const std::pair<SILInstruction *, InterestingUser> &pair)
+        -> SILBasicBlock * { return pair.first->getParent(); };
+    return UserBlockRange(getAllUsers(), op);
+  }
+
+  void initializeDefBlock(SILBasicBlock *defBB, TypeTreeLeafTypeRange span) {
+    liveBlocks.initializeDefBlock(defBB, span.startEltOffset,
+                                  span.endEltOffset);
+  }
+
+  /// For flexibility, \p lifetimeEnding is provided by the
+  /// caller. PrunedLiveness makes no assumptions about the def-use
+  /// relationships that generate liveness. For example, use->isLifetimeEnding()
+  /// cannot distinguish the end of the borrow scope that defines this extended
+  /// live range vs. a nested borrow scope within the extended live range.
+  ///
+  /// Also for flexibility, \p affectedAddress must be a derived projection from
+  /// the base that \p user is affecting.
+  void updateForUse(SILInstruction *user, TypeTreeLeafTypeRange span,
+                    bool lifetimeEnding);
+
+  void getBlockLiveness(
+      SILBasicBlock *bb, TypeTreeLeafTypeRange span,
+      SmallVectorImpl<PrunedLiveBlocks::IsLive> &resultingFoundLiveness) const {
+    liveBlocks.getBlockLiveness(bb, span.startEltOffset, span.endEltOffset,
+                                resultingFoundLiveness);
+  }
+
+  /// Return the liveness for this specific sub-element of our root value.
+  PrunedLiveBlocks::IsLive getBlockLiveness(SILBasicBlock *bb,
+                                            unsigned subElementNumber) const {
+    SmallVector<PrunedLiveBlocks::IsLive, 1> isLive;
+    liveBlocks.getBlockLiveness(bb, subElementNumber, subElementNumber + 1,
+                                isLive);
+    return isLive[0];
+  }
+
+  void getBlockLiveness(
+      SILBasicBlock *bb,
+      SmallVectorImpl<PrunedLiveBlocks::IsLive> &foundLiveness) const {
+    liveBlocks.getBlockLiveness(bb, 0, liveBlocks.getNumBitsToTrack(),
+                                foundLiveness);
+  }
+
+  enum IsInterestingUser { NonUser, NonLifetimeEndingUse, LifetimeEndingUse };
+
+  /// Return a result indicating whether the given user was identified as an
+  /// interesting use of the current def and whether it ends the lifetime.
+  std::pair<IsInterestingUser, Optional<TypeTreeLeafTypeRange>>
+  isInterestingUser(SILInstruction *user) const {
+    auto useIter = users.find(user);
+    if (useIter == users.end())
+      return {NonUser, None};
+    auto isInteresting =
+        useIter->second.isConsuming ? LifetimeEndingUse : NonLifetimeEndingUse;
+    return {isInteresting, useIter->second.subEltSpan};
+  }
+
+  unsigned getNumSubElements() const { return liveBlocks.getNumBitsToTrack(); }
+
+  /// Return true if \p inst occurs before the liveness boundary. Used when the
+  /// client already knows that inst occurs after the start of liveness.
+  void isWithinBoundary(SILInstruction *inst, SmallBitVector &outVector) const;
+};
+
+/// Record the last use points and CFG edges that form the boundary of
+/// FieldSensitiveAddressPrunedLiveness. It does this on a per type tree leaf
+/// node basis.
+struct FieldSensitiveAddressPrunedLivenessBoundary {
+  /// The list of last users and an associated SILValue that is the address that
+  /// is being used. The address can be used to determine the start sub element
+  /// number of the user in the type tree and the end sub element number.
+  ///
+  /// TODO (MG): If we don't eventually need to store the SILValue here (I am
+  /// not sure yet...), just store a tuple with the start/end sub element
+  /// number.
+  SmallVector<std::tuple<SILInstruction *, TypeTreeLeafTypeRange>, 8> lastUsers;
+
+  /// Blocks where the value was live out but had a successor that was dead.
+  SmallVector<SILBasicBlock *, 8> boundaryEdges;
+
+  void clear() {
+    lastUsers.clear();
+    boundaryEdges.clear();
+  }
+
+  /// Compute the boundary from the blocks discovered during liveness analysis.
+  ///
+  /// Precondition: \p liveness.getDiscoveredBlocks() is a valid list of all
+  /// live blocks with no duplicates.
+  ///
+  /// The computed boundary will completely post-dominate, including dead end
+  /// paths. The client should query DeadEndBlocks to ignore those dead end
+  /// paths.
+  void compute(const FieldSensitiveAddressPrunedLiveness &liveness);
+
+private:
+  void
+  findLastUserInBlock(SILBasicBlock *bb,
+                      FieldSensitiveAddressPrunedLivenessBoundary &boundary,
+                      const FieldSensitiveAddressPrunedLiveness &liveness,
+                      unsigned subElementNumber);
 };
 
 } // namespace swift

--- a/lib/SIL/Utils/PrunedLiveness.cpp
+++ b/lib/SIL/Utils/PrunedLiveness.cpp
@@ -371,3 +371,245 @@ void PrunedLivenessBoundary::compute(const PrunedLiveness &liveness,
     }
   }
 }
+
+//===----------------------------------------------------------------------===//
+//                       Field Sensitive PrunedLiveness
+//===----------------------------------------------------------------------===//
+
+// We can only analyze components of structs whose storage is fully accessible
+// from Swift.
+static StructDecl *getFullyReferenceableStruct(SILType ktypeTy) {
+  auto structDecl = ktypeTy.getStructOrBoundGenericStruct();
+  if (!structDecl || structDecl->hasUnreferenceableStorage())
+    return nullptr;
+  return structDecl;
+}
+
+TypeSubElementCount::TypeSubElementCount(SILType type, SILModule &mod,
+                                         TypeExpansionContext context)
+    : number(1) {
+  if (auto tupleType = type.getAs<TupleType>()) {
+    unsigned numElements = 0;
+    for (auto index : indices(tupleType.getElementTypes()))
+      numElements +=
+          TypeSubElementCount(type.getTupleElementType(index), mod, context);
+    number = numElements;
+    return;
+  }
+
+  if (auto *structDecl = getFullyReferenceableStruct(type)) {
+    unsigned numElements = 0;
+    for (auto *fieldDecl : structDecl->getStoredProperties())
+      numElements += TypeSubElementCount(
+          type.getFieldType(fieldDecl, mod, context), mod, context);
+    number = numElements;
+    return;
+  }
+
+  // If this isn't a tuple or struct, it is a single element. This was our
+  // default value, so we can just return.
+}
+
+Optional<SubElementNumber>
+SubElementNumber::compute(SILValue projectionDerivedFromRoot,
+                          SILValue rootAddress) {
+  unsigned finalSubElementNumber = 0;
+  SILModule &mod = *rootAddress->getModule();
+
+  while (1) {
+    // If we got to the root, we're done.
+    if (rootAddress == projectionDerivedFromRoot)
+      return {SubElementNumber(finalSubElementNumber)};
+
+    if (auto *pbi = dyn_cast<ProjectBoxInst>(projectionDerivedFromRoot)) {
+      projectionDerivedFromRoot = pbi->getOperand();
+      continue;
+    }
+
+    if (auto *bai = dyn_cast<BeginAccessInst>(projectionDerivedFromRoot)) {
+      projectionDerivedFromRoot = bai->getSource();
+      continue;
+    }
+
+    if (auto *teai =
+            dyn_cast<TupleElementAddrInst>(projectionDerivedFromRoot)) {
+      SILType tupleType = teai->getOperand()->getType();
+
+      // Keep track of what subelement is being referenced.
+      for (unsigned i : range(teai->getFieldIndex())) {
+        finalSubElementNumber += TypeSubElementCount(
+            tupleType.getTupleElementType(i), mod,
+            TypeExpansionContext(*rootAddress->getFunction()));
+      }
+      projectionDerivedFromRoot = teai->getOperand();
+      continue;
+    }
+
+    if (auto *seai =
+            dyn_cast<StructElementAddrInst>(projectionDerivedFromRoot)) {
+      SILType type = seai->getOperand()->getType();
+
+      // Keep track of what subelement is being referenced.
+      StructDecl *structDecl = seai->getStructDecl();
+      for (auto *fieldDecl : structDecl->getStoredProperties()) {
+        if (fieldDecl == seai->getField())
+          break;
+        auto context = TypeExpansionContext(*rootAddress->getFunction());
+        finalSubElementNumber += TypeSubElementCount(
+            type.getFieldType(fieldDecl, mod, context), mod, context);
+      }
+
+      projectionDerivedFromRoot = seai->getOperand();
+      continue;
+    }
+
+    // This fails when we visit unchecked_take_enum_data_addr. We should just
+    // add support for enums.
+#ifndef NDEBUG
+    if (!isa<InitExistentialAddrInst>(projectionDerivedFromRoot)) {
+      llvm::errs() << "Unknown access path instruction!\n";
+      llvm::errs() << "Value: " << *projectionDerivedFromRoot;
+      llvm_unreachable("standard error");
+    }
+#endif
+    // Cannot promote loads and stores from within an existential projection.
+    return None;
+  }
+}
+
+void FieldSensitiveAddressPrunedLiveness::updateForUse(
+    SILInstruction *user, TypeTreeLeafTypeRange range, bool lifetimeEnding) {
+  SmallVector<PrunedLiveBlocks::IsLive, 8> resultingLiveness;
+  liveBlocks.updateForUse(user, range.startEltOffset, range.endEltOffset,
+                          resultingLiveness);
+
+  // Note that a user may use the current value from multiple operands. If any
+  // of the uses are non-lifetime-ending, then we must consider the user
+  // itself non-lifetime-ending; it cannot be a final destroy point because
+  // the value of the non-lifetime-ending operand must be kept alive until the
+  // end of the user. Consider a call that takes the same value using
+  // different conventions:
+  //
+  //   apply %f(%val, %val) : $(@guaranteed, @owned) -> ()
+  //
+  // This call is not considered the end of %val's lifetime. The @owned
+  // argument must be copied.
+  auto iterAndSuccess =
+      users.insert({user, InterestingUser(range, lifetimeEnding)});
+  if (!iterAndSuccess.second)
+    iterAndSuccess.first->second &= lifetimeEnding;
+}
+
+void FieldSensitiveAddressPrunedLiveness::isWithinBoundary(
+    SILInstruction *inst, SmallBitVector &outVector) const {
+  SILBasicBlock *block = inst->getParent();
+
+  SmallVector<PrunedLiveBlocks::IsLive, 8> fieldLiveness;
+  getBlockLiveness(block, fieldLiveness);
+  outVector.resize(fieldLiveness.size());
+
+  for (auto pair : llvm::enumerate(fieldLiveness)) {
+    auto isLive = pair.value();
+    unsigned subEltNumber = pair.index();
+    switch (isLive) {
+    case PrunedLiveBlocks::Dead:
+      outVector[subEltNumber] = false;
+      continue;
+    case PrunedLiveBlocks::LiveOut:
+      outVector[subEltNumber] = true;
+      continue;
+    case PrunedLiveBlocks::LiveWithin:
+      // The boundary is within this block. This instruction is before the
+      // boundary iff any interesting uses occur after it.
+      bool foundValue = false;
+      for (SILInstruction &it :
+           make_range(std::next(inst->getIterator()), block->end())) {
+        auto interestingUser = isInterestingUser(&it);
+        switch (interestingUser.first) {
+        case FieldSensitiveAddressPrunedLiveness::NonUser:
+          break;
+        case FieldSensitiveAddressPrunedLiveness::NonLifetimeEndingUse:
+        case FieldSensitiveAddressPrunedLiveness::LifetimeEndingUse:
+          // Check the overlap in between the sub element number and
+          // interestingUser.second. If we don't overlap, just break. We aren't
+          // effected by this.
+          //
+          // TODO: Hoist this out! We should only be visited blocks like this
+          // once!
+          if (!interestingUser.second->contains(subEltNumber))
+            break;
+          outVector[subEltNumber] = true;
+          foundValue = true;
+          break;
+        }
+      }
+      if (foundValue)
+        continue;
+      outVector[subEltNumber] = false;
+    }
+  }
+}
+
+// Use \p liveness to find the last use in \p bb and add it to \p
+// boundary.lastUsers.
+void FieldSensitiveAddressPrunedLivenessBoundary::findLastUserInBlock(
+    SILBasicBlock *bb, FieldSensitiveAddressPrunedLivenessBoundary &boundary,
+    const FieldSensitiveAddressPrunedLiveness &liveness,
+    unsigned subElementNumber) {
+  // TODO: We should move this loop into the caller and only visit a block once
+  // for each sub-element of a type.
+  for (auto &inst : llvm::reverse(*bb)) {
+    auto pair = liveness.isInterestingUser(&inst);
+    if (pair.first == FieldSensitiveAddressPrunedLiveness::NonUser)
+      continue;
+
+    // Do an intersection in between the range associated with this address and
+    // the sub-element number we are checking for.
+    auto &range = *pair.second;
+    if (!range.contains(subElementNumber))
+      continue;
+    boundary.lastUsers.push_back({&inst, range});
+    return;
+  }
+  llvm_unreachable("No user in LiveWithin block");
+}
+
+void FieldSensitiveAddressPrunedLivenessBoundary::compute(
+    const FieldSensitiveAddressPrunedLiveness &liveness) {
+  using IsLive = PrunedLiveBlocks::IsLive;
+  SmallVector<IsLive, 8> perSubElementblockLivenessInfo;
+  SmallVector<IsLive, 8> boundaryBlockLiveness;
+
+  for (SILBasicBlock *bb : liveness.getDiscoveredBlocks()) {
+    SWIFT_DEFER { perSubElementblockLivenessInfo.clear(); };
+
+    // Process each block that has not been visited and is not LiveOut.
+    liveness.getBlockLiveness(bb, perSubElementblockLivenessInfo);
+
+    // TODO: We should do this for all sub-element LiveWithin at the same time
+    // so that we can avoid iterating over the block multiple times.
+    for (auto pair : llvm::enumerate(perSubElementblockLivenessInfo)) {
+      switch (pair.value()) {
+      case PrunedLiveBlocks::LiveOut:
+        for (SILBasicBlock *succBB : bb->getSuccessors()) {
+          liveness.getBlockLiveness(succBB, boundaryBlockLiveness);
+          if (llvm::all_of(boundaryBlockLiveness, [](IsLive isDead) {
+                return isDead == PrunedLiveBlocks::Dead;
+              })) {
+            boundaryEdges.push_back(succBB);
+          }
+        }
+        break;
+      case PrunedLiveBlocks::LiveWithin: {
+        // The liveness boundary is inside this block. Find the last user. This
+        // is where we would insert a destroy to end the values lifetime for the
+        // specific subelementnumber
+        findLastUserInBlock(bb, *this, liveness, pair.index());
+        break;
+      }
+      case PrunedLiveBlocks::Dead:
+        break;
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is the same algorithm as pruned liveness but assumes that one is tracking
liveness from an address and uses the same scheme as DI to track liveness as a
bit vector.
