### PR TITLE
[5.7][ConstraintSystem] Fix result builder discovery in leading-dot syntax calls

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9866,7 +9866,9 @@ static Type getOpenedResultBuilderTypeFor(ConstraintSystem &cs,
   auto *calleeLocator = cs.getCalleeLocator(cs.getConstraintLocator(locator));
   auto selectedOverload = cs.findSelectedOverloadFor(calleeLocator);
   if (!(selectedOverload &&
-        selectedOverload->choice.getKind() == OverloadChoiceKind::Decl))
+        (selectedOverload->choice.getKind() == OverloadChoiceKind::Decl ||
+         selectedOverload->choice.getKind() ==
+             OverloadChoiceKind::DeclViaUnwrappedOptional)))
     return Type();
 
   auto *choice = selectedOverload->choice.getDecl();

--- a/test/Constraints/result_builder.swift
+++ b/test/Constraints/result_builder.swift
@@ -1198,3 +1198,19 @@ func test_callAsFunction_with_resultBuilder() {
 test_callAsFunction_with_resultBuilder()
 // CHECK: (0, "with parens", true)
 // CHECK: (1, "without parens", true)
+
+do {
+  struct S {
+    static func test<T>(@TupleBuilder _ body: (Bool) -> T) -> S {
+      print(body(true))
+      return .init()
+    }
+  }
+
+  let _: S? = .test {
+    42
+    ""
+    [$0]
+  }
+  // CHECK: (42, "", [true])
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/60880

--- 

Leading-dot syntax allows implicitly unwrapping result type to form
a base type of the call, `getOpenedResultBuilderTypeFor` needs to
account for that.

Resolves: https://github.com/apple/swift/issues/60586
(cherry picked from commit 9399451edf911b0ab5a6d5784c49d1fcaa6c4407)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
