### PR TITLE
[interop][SwiftToCxx] add support for invoking methods in generic structs & unify function and struct generics

### DIFF
--- a/include/swift/IRGen/IRABIDetailsProvider.h
+++ b/include/swift/IRGen/IRABIDetailsProvider.h
@@ -49,12 +49,45 @@ public:
   };
 
   /// Information about any ABI additional parameters.
-  struct ABIAdditionalParam {
-    enum class ABIParameterRole { GenericRequirementRole, Self, Error };
+  class ABIAdditionalParam {
+  public:
+    enum class ABIParameterRole {
+      /// A parameter that corresponds to a generic requirement that must be
+      /// fullfilled by a call to this function.
+      GenericRequirement,
+      /// A parameter that corresponds to a Swift type pointer sourced from a
+      /// valid metadata source, like the type of another argument.
+      GenericTypeMetadataSource,
+      /// A parameter that corresponds to the 'self' parameter.
+      Self,
+      /// The Swift error parameter.
+      Error
+    };
+
+    inline ABIParameterRole getRole() const { return role; }
+
+    inline GenericRequirement getGenericRequirement() {
+      assert(role == ABIParameterRole::GenericRequirement);
+      return *genericRequirement;
+    }
+
+    inline CanType getMetadataSourceType() {
+      assert(role == ABIParameterRole::GenericTypeMetadataSource);
+      return canType;
+    }
+
+  private:
+    inline ABIAdditionalParam(
+        ABIParameterRole role,
+        llvm::Optional<GenericRequirement> genericRequirement, CanType canType)
+        : role(role), genericRequirement(genericRequirement), canType(canType) {
+    }
 
     ABIParameterRole role;
     llvm::Optional<GenericRequirement> genericRequirement;
-    TypeDecl *type;
+    CanType canType;
+
+    friend class IRABIDetailsProviderImpl;
   };
 
   /// Returns the size and alignment for the given type, or \c None if the type

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -397,7 +397,8 @@ namespace {
     unsigned AsyncResumeFunctionSwiftSelfIdx = 0;
     FunctionPointerKind FnKind;
     bool ShouldComputeABIDetails;
-    SmallVector<GenericRequirement, 4> GenericRequirements;
+    SmallVector<PolymorphicSignatureExpandedTypeSource, 4>
+        polymorphicSignatureTypeSources;
 
     SignatureExpansion(IRGenModule &IGM, CanSILFunctionType fnType,
                        FunctionPointerKind fnKind,
@@ -1631,9 +1632,9 @@ void SignatureExpansion::expandParameters() {
   // Next, the generic signature.
   if (hasPolymorphicParameters(FnType) &&
       !FnKind.shouldSuppressPolymorphicArguments())
-    expandPolymorphicSignature(IGM, FnType, ParamIRTypes,
-                               ShouldComputeABIDetails ? &GenericRequirements
-                                                       : nullptr);
+    expandPolymorphicSignature(
+        IGM, FnType, ParamIRTypes,
+        ShouldComputeABIDetails ? &polymorphicSignatureTypeSources : nullptr);
 
   // Certain special functions are passed the continuation directly.
   if (FnKind.shouldPassContinuationDirectly()) {
@@ -1931,8 +1932,8 @@ Signature SignatureExpansion::getSignature() {
     result.ExtraDataKind = ExtraData::kindForMember<void>();
   }
   if (ShouldComputeABIDetails)
-    result.ABIDetails =
-        SignatureExpansionABIDetails{std::move(GenericRequirements)};
+    result.ABIDetails = SignatureExpansionABIDetails{
+        std::move(polymorphicSignatureTypeSources)};
   return result;
 }
 

--- a/lib/IRGen/GenProto.h
+++ b/lib/IRGen/GenProto.h
@@ -21,6 +21,7 @@
 
 #include "Fulfillment.h"
 #include "GenericRequirement.h"
+#include "MetadataSource.h"
 
 namespace llvm {
   class Type;
@@ -178,90 +179,6 @@ namespace irgen {
   llvm::Value *emitWitnessTableRef(IRGenFunction &IGF,
                                    CanType srcType,
                                    ProtocolConformanceRef conformance);
-
-  class MetadataSource {
-  public:
-    enum class Kind {
-      /// Metadata is derived from a source class pointer.
-      ClassPointer,
-
-      /// Metadata is derived from a type metadata pointer.
-      Metadata,
-
-      /// Metadata is derived from the origin type parameter.
-      GenericLValueMetadata,
-
-      /// Metadata is obtained directly from the from a Self metadata
-      /// parameter passed via the WitnessMethod convention.
-      SelfMetadata,
-
-      /// Metadata is derived from the Self witness table parameter
-      /// passed via the WitnessMethod convention.
-      SelfWitnessTable,
-
-      /// Metadata is obtained directly from the FixedType indicated. Used with
-      /// Objective-C generics, where the actual argument is erased at runtime
-      /// and its existential bound is used instead.
-      ErasedTypeMetadata,
-    };
-
-    static bool requiresSourceIndex(Kind kind) {
-      return (kind == Kind::ClassPointer ||
-              kind == Kind::Metadata ||
-              kind == Kind::GenericLValueMetadata);
-    }
-
-    static bool requiresFixedType(Kind kind) {
-      return (kind == Kind::ErasedTypeMetadata);
-    }
-
-    enum : unsigned { InvalidSourceIndex = ~0U };
-
-  private:
-    /// The kind of source this is.
-    Kind TheKind;
-
-    /// For ClassPointer, Metadata, and GenericLValueMetadata, the source index;
-    /// for ErasedTypeMetadata, the type; for others, Index should be set to
-    /// InvalidSourceIndex.
-    union {
-      unsigned Index;
-      CanType FixedType;
-    };
-
-  public:
-    CanType Type;
-
-    MetadataSource(Kind kind, CanType type)
-      : TheKind(kind), Index(InvalidSourceIndex), Type(type)
-    {
-      assert(!requiresSourceIndex(kind) && !requiresFixedType(kind));
-    }
-
-
-    MetadataSource(Kind kind, CanType type, unsigned index)
-      : TheKind(kind), Index(index), Type(type) {
-      assert(requiresSourceIndex(kind));
-      assert(index != InvalidSourceIndex);
-    }
-
-    MetadataSource(Kind kind, CanType type, CanType fixedType)
-      : TheKind(kind), FixedType(fixedType), Type(type) {
-      assert(requiresFixedType(kind));
-    }
-
-    Kind getKind() const { return TheKind; }
-
-    unsigned getParamIndex() const {
-      assert(requiresSourceIndex(getKind()));
-      return Index;
-    }
-
-    CanType getFixedType() const {
-      assert(requiresFixedType(getKind()));
-      return FixedType;
-    }
-  };
 
   using GenericParamFulfillmentCallback =
     llvm::function_ref<void(CanType genericParamType,

--- a/lib/IRGen/GenProto.h
+++ b/lib/IRGen/GenProto.h
@@ -49,6 +49,7 @@ namespace irgen {
   class MetadataPath;
   class MetadataResponse;
   class NativeCCEntryPointArgumentEmission;
+  class PolymorphicSignatureExpandedTypeSource;
   class ProtocolInfo;
   class TypeInfo;
 
@@ -103,7 +104,8 @@ namespace irgen {
   void expandPolymorphicSignature(
       IRGenModule &IGM, CanSILFunctionType type,
       SmallVectorImpl<llvm::Type *> &types,
-      SmallVectorImpl<GenericRequirement> *outReqs = nullptr);
+      SmallVectorImpl<PolymorphicSignatureExpandedTypeSource> *outReqs =
+          nullptr);
 
   /// Return the number of trailing arguments necessary for calling a
   /// witness method.

--- a/lib/IRGen/MetadataSource.h
+++ b/lib/IRGen/MetadataSource.h
@@ -1,0 +1,108 @@
+//===--- MetadataSource.h - structure for the source of metadata *- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_IRGEN_METADATA_SOURCE_H
+#define SWIFT_IRGEN_METADATA_SOURCE_H
+
+#include "swift/AST/Types.h"
+
+namespace swift {
+namespace irgen {
+
+class MetadataSource {
+public:
+  enum class Kind {
+    /// Metadata is derived from a source class pointer.
+    ClassPointer,
+
+    /// Metadata is derived from a type metadata pointer.
+    Metadata,
+
+    /// Metadata is derived from the origin type parameter.
+    GenericLValueMetadata,
+
+    /// Metadata is obtained directly from the from a Self metadata
+    /// parameter passed via the WitnessMethod convention.
+    SelfMetadata,
+
+    /// Metadata is derived from the Self witness table parameter
+    /// passed via the WitnessMethod convention.
+    SelfWitnessTable,
+
+    /// Metadata is obtained directly from the FixedType indicated. Used with
+    /// Objective-C generics, where the actual argument is erased at runtime
+    /// and its existential bound is used instead.
+    ErasedTypeMetadata,
+  };
+
+  static bool requiresSourceIndex(Kind kind) {
+    return (kind == Kind::ClassPointer ||
+            kind == Kind::Metadata ||
+            kind == Kind::GenericLValueMetadata);
+  }
+
+  static bool requiresFixedType(Kind kind) {
+    return (kind == Kind::ErasedTypeMetadata);
+  }
+
+  enum : unsigned { InvalidSourceIndex = ~0U };
+
+private:
+  /// The kind of source this is.
+  Kind TheKind;
+
+  /// For ClassPointer, Metadata, and GenericLValueMetadata, the source index;
+  /// for ErasedTypeMetadata, the type; for others, Index should be set to
+  /// InvalidSourceIndex.
+  union {
+    unsigned Index;
+    CanType FixedType;
+  };
+
+public:
+  CanType Type;
+
+  MetadataSource(Kind kind, CanType type)
+    : TheKind(kind), Index(InvalidSourceIndex), Type(type)
+  {
+    assert(!requiresSourceIndex(kind) && !requiresFixedType(kind));
+  }
+
+
+  MetadataSource(Kind kind, CanType type, unsigned index)
+    : TheKind(kind), Index(index), Type(type) {
+    assert(requiresSourceIndex(kind));
+    assert(index != InvalidSourceIndex);
+  }
+
+  MetadataSource(Kind kind, CanType type, CanType fixedType)
+    : TheKind(kind), FixedType(fixedType), Type(type) {
+    assert(requiresFixedType(kind));
+  }
+
+  Kind getKind() const { return TheKind; }
+
+  unsigned getParamIndex() const {
+    assert(requiresSourceIndex(getKind()));
+    return Index;
+  }
+
+  CanType getFixedType() const {
+    assert(requiresFixedType(getKind()));
+    return FixedType;
+  }
+};
+
+} // end namespace irgen
+} // end namespace swift
+
+#endif

--- a/lib/PrintAsClang/ClangSyntaxPrinter.cpp
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.cpp
@@ -70,6 +70,33 @@ void ClangSyntaxPrinter::printModuleNamespaceQualifiersIfNeeded(
   os << "::";
 }
 
+bool ClangSyntaxPrinter::printNominalTypeOutsideMemberDeclTemplateSpecifiers(
+    const NominalTypeDecl *typeDecl) {
+  // FIXME: Full qualifiers for nested types?
+  if (!typeDecl->isGeneric())
+    return true;
+  printGenericSignature(
+      typeDecl->getGenericSignature().getCanonicalSignature());
+  return false;
+}
+
+void ClangSyntaxPrinter::printNominalTypeReference(
+    const NominalTypeDecl *typeDecl, const ModuleDecl *moduleContext) {
+  printModuleNamespaceQualifiersIfNeeded(typeDecl->getModuleContext(),
+                                         moduleContext);
+  // FIXME: Full qualifiers for nested types?
+  ClangSyntaxPrinter(os).printBaseName(typeDecl);
+  if (typeDecl->isGeneric())
+    printGenericSignatureParams(
+        typeDecl->getGenericSignature().getCanonicalSignature());
+}
+
+void ClangSyntaxPrinter::printNominalTypeQualifier(
+    const NominalTypeDecl *typeDecl, const ModuleDecl *moduleContext) {
+  printNominalTypeReference(typeDecl, moduleContext);
+  os << "::";
+}
+
 /// Print a C++ namespace declaration with the give name and body.
 void ClangSyntaxPrinter::printNamespace(
     llvm::function_ref<void(raw_ostream &OS)> namePrinter,

--- a/lib/PrintAsClang/ClangSyntaxPrinter.cpp
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.cpp
@@ -256,9 +256,9 @@ void ClangSyntaxPrinter::printGenericRequirementInstantiantion(
   assert(!requirement.Protocol && "protocol requirements not supported yet!");
   auto *gtpt = requirement.TypeParameter->getAs<GenericTypeParamType>();
   assert(gtpt && "unexpected generic param type");
-  os << "swift::getTypeMetadata<";
+  os << "swift::TypeMetadataTrait<";
   printGenericTypeParamTypeName(gtpt);
-  os << ">()";
+  os << ">::getTypeMetadata()";
 }
 
 void ClangSyntaxPrinter::printGenericRequirementsInstantiantions(

--- a/lib/PrintAsClang/ClangSyntaxPrinter.h
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.h
@@ -65,6 +65,43 @@ public:
   printModuleNamespaceQualifiersIfNeeded(const ModuleDecl *referencedModule,
                                          const ModuleDecl *currentContext);
 
+  /// Print out additional C++ `template` and `requires` clauses that
+  /// are required to emit a member definition outside  a C++ class that is
+  /// generated for the given Swift type declaration.
+  ///
+  /// \returns true if nothing was printed.
+  ///
+  /// Examples:
+  ///    1) For Swift's `String` type, it will print nothing.
+  ///    2) For Swift's `Array<T>` type, it will print `template<class
+  ///    T_0_0>\nrequires swift::isUsableInGenericContext<T_0_0>\n`
+  bool printNominalTypeOutsideMemberDeclTemplateSpecifiers(
+      const NominalTypeDecl *typeDecl);
+
+  /// Print out the C++ class access qualifier for the given Swift  type
+  /// declaration.
+  ///
+  /// Examples:
+  ///    1) For Swift's `String` type, it will print `String
+  ///    2) For Swift's `Array<T>` type, it will print `Array<T_0_0>
+  ///    3) For Swift's `Array<T>.Index` type, it will print
+  ///    `Array<T_0_0>::Index` 4) For Swift's `String` type in another module,
+  ///    it will print `Swift::String`
+  void printNominalTypeReference(const NominalTypeDecl *typeDecl,
+                                 const ModuleDecl *moduleContext);
+
+  /// Print out the C++ class access qualifier for the given Swift  type
+  /// declaration.
+  ///
+  /// Examples:
+  ///    1) For Swift's `String` type, it will print `String::`.
+  ///    2) For Swift's `Array<T>` type, it will print `Array<T_0_0>::`
+  ///    3) For Swift's `Array<T>.Index` type, it will print
+  ///    `Array<T_0_0>::Index::` 4) For Swift's `String` type in another module,
+  ///    it will print `Swift::String::`
+  void printNominalTypeQualifier(const NominalTypeDecl *typeDecl,
+                                 const ModuleDecl *moduleContext);
+
   /// Print a C++ namespace declaration with the give name and body.
   void
   printNamespace(llvm::function_ref<void(raw_ostream &OS)> namePrinter,

--- a/lib/PrintAsClang/PrintClangClassType.cpp
+++ b/lib/PrintAsClang/PrintClangClassType.cpp
@@ -94,8 +94,8 @@ void ClangClassTypePrinter::printClassTypeDecl(
         os << "};\n";
       });
 
-  ClangValueTypePrinter::printTypeGenericTraits(os, typeDecl,
-                                                typeMetadataFuncName);
+  ClangValueTypePrinter::printTypeGenericTraits(
+      os, typeDecl, typeMetadataFuncName, /*genericRequirements=*/{});
 }
 
 void ClangClassTypePrinter::printClassTypeReturnScaffold(

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -650,9 +650,9 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
           assert(!genericRequirement.Protocol);
           if (auto *gtpt = genericRequirement.TypeParameter
                                ->getAs<GenericTypeParamType>()) {
-            os << "swift::getTypeMetadata<";
+            os << "swift::TypeMetadataTrait<";
             ClangSyntaxPrinter(os).printGenericTypeParamTypeName(gtpt);
-            os << ">()";
+            os << ">::getTypeMetadata()";
             return;
           }
           os << "ERROR";

--- a/lib/PrintAsClang/PrintClangFunction.h
+++ b/lib/PrintAsClang/PrintClangFunction.h
@@ -79,7 +79,7 @@ public:
 
   /// Information about any additional parameters.
   struct AdditionalParam {
-    enum class Role { GenericRequirement, Self, Error };
+    enum class Role { GenericRequirement, GenericTypeMetadata, Self, Error };
 
     Role role;
     Type type;

--- a/lib/PrintAsClang/PrintClangValueType.cpp
+++ b/lib/PrintAsClang/PrintClangValueType.cpp
@@ -559,17 +559,17 @@ void ClangValueTypePrinter::printTypeGenericTraits(
   os << "::";
   printer.printBaseName(typeDecl);
   os << "> = true;\n";
-  os << "template<>\n";
-  os << "inline void * _Nonnull getTypeMetadata<";
+  os << "template<>\nstruct TypeMetadataTrait<";
   printer.printBaseName(typeDecl->getModuleContext());
   os << "::";
   printer.printBaseName(typeDecl);
-  os << ">() {\n";
-  os << "  return ";
+  os << "> {\n";
+  os << "  static inline void * _Nonnull getTypeMetadata() {\n";
+  os << "    return ";
   printer.printBaseName(typeDecl->getModuleContext());
   os << "::" << cxx_synthesis::getCxxImplNamespaceName()
      << "::" << typeMetadataFuncName << "(0)._0;\n";
-  os << "}\n";
+  os << "  }\n};\n";
 
   os << "namespace " << cxx_synthesis::getCxxImplNamespaceName() << "{\n";
 

--- a/lib/PrintAsClang/PrintClangValueType.cpp
+++ b/lib/PrintAsClang/PrintClangValueType.cpp
@@ -391,10 +391,8 @@ void ClangValueTypePrinter::printValueTypeDecl(
   if (!isOpaqueLayout)
     printCValueTypeStorageStruct(cPrologueOS, typeDecl, *typeSizeAlign);
 
-  // FIXME: Type traits for generic structs.
-  if (genericSignature)
-    return;
-  printTypeGenericTraits(os, typeDecl, typeMetadataFuncName);
+  printTypeGenericTraits(os, typeDecl, typeMetadataFuncName,
+                         typeMetadataFuncGenericParams);
 }
 
 /// Print out the C stub struct that's used to pass/return a value type directly
@@ -545,7 +543,8 @@ void ClangValueTypePrinter::printValueTypeDirectReturnScaffold(
 
 void ClangValueTypePrinter::printTypeGenericTraits(
     raw_ostream &os, const NominalTypeDecl *typeDecl,
-    StringRef typeMetadataFuncName) {
+    StringRef typeMetadataFuncName,
+    ArrayRef<GenericRequirement> typeMetadataFuncRequirements) {
   ClangSyntaxPrinter printer(os);
   // FIXME: avoid popping out of the module's namespace here.
   os << "} // end namespace \n\n";
@@ -553,27 +552,34 @@ void ClangValueTypePrinter::printTypeGenericTraits(
 
   os << "#pragma clang diagnostic push\n";
   os << "#pragma clang diagnostic ignored \"-Wc++17-extensions\"\n";
-  os << "template<>\n";
-  os << "static inline const constexpr bool isUsableInGenericContext<";
-  printer.printBaseName(typeDecl->getModuleContext());
-  os << "::";
-  printer.printBaseName(typeDecl);
-  os << "> = true;\n";
-  os << "template<>\nstruct TypeMetadataTrait<";
-  printer.printBaseName(typeDecl->getModuleContext());
-  os << "::";
-  printer.printBaseName(typeDecl);
+  if (typeMetadataFuncRequirements.empty()) {
+    // FIXME: generic type support.
+    os << "template<>\n";
+    os << "static inline const constexpr bool isUsableInGenericContext<";
+    printer.printBaseName(typeDecl->getModuleContext());
+    os << "::";
+    printer.printBaseName(typeDecl);
+    os << "> = true;\n";
+  }
+  if (printer.printNominalTypeOutsideMemberDeclTemplateSpecifiers(typeDecl))
+    os << "template<>\n";
+  os << "struct TypeMetadataTrait<";
+  printer.printNominalTypeReference(typeDecl,
+                                    /*moduleContext=*/nullptr);
   os << "> {\n";
   os << "  static inline void * _Nonnull getTypeMetadata() {\n";
   os << "    return ";
   printer.printBaseName(typeDecl->getModuleContext());
-  os << "::" << cxx_synthesis::getCxxImplNamespaceName()
-     << "::" << typeMetadataFuncName << "(0)._0;\n";
+  os << "::" << cxx_synthesis::getCxxImplNamespaceName() << "::";
+  ClangSyntaxPrinter(os).printSwiftTypeMetadataAccessFunctionCall(
+      typeMetadataFuncName, typeMetadataFuncRequirements);
+  os << "._0;\n";
   os << "  }\n};\n";
 
   os << "namespace " << cxx_synthesis::getCxxImplNamespaceName() << "{\n";
 
-  if (!isa<ClassDecl>(typeDecl)) {
+  if (!isa<ClassDecl>(typeDecl) && typeMetadataFuncRequirements.empty()) {
+    // FIXME: generic support.
     os << "template<>\n";
     os << "static inline const constexpr bool isValueType<";
     printer.printBaseName(typeDecl->getModuleContext());
@@ -590,20 +596,23 @@ void ClangValueTypePrinter::printTypeGenericTraits(
     }
   }
 
-        os << "template<>\n";
-        os << "struct implClassFor<";
-        printer.printBaseName(typeDecl->getModuleContext());
-        os << "::";
-        printer.printBaseName(typeDecl);
-        os << "> { using type = ";
-        printer.printBaseName(typeDecl->getModuleContext());
-        os << "::" << cxx_synthesis::getCxxImplNamespaceName() << "::";
-        printCxxImplClassName(os, typeDecl);
-        os << "; };\n";
-        os << "} // namespace\n";
-        os << "#pragma clang diagnostic pop\n";
-        os << "} // namespace swift\n";
-        os << "\nnamespace ";
-        printer.printBaseName(typeDecl->getModuleContext());
-        os << " {\n";
+  // FIXME: generic support.
+  if (typeMetadataFuncRequirements.empty()) {
+    os << "template<>\n";
+    os << "struct implClassFor<";
+    printer.printBaseName(typeDecl->getModuleContext());
+    os << "::";
+    printer.printBaseName(typeDecl);
+    os << "> { using type = ";
+    printer.printBaseName(typeDecl->getModuleContext());
+    os << "::" << cxx_synthesis::getCxxImplNamespaceName() << "::";
+    printCxxImplClassName(os, typeDecl);
+    os << "; };\n";
+  }
+  os << "} // namespace\n";
+  os << "#pragma clang diagnostic pop\n";
+  os << "} // namespace swift\n";
+  os << "\nnamespace ";
+  printer.printBaseName(typeDecl->getModuleContext());
+  os << " {\n";
 }

--- a/lib/PrintAsClang/PrintClangValueType.h
+++ b/lib/PrintAsClang/PrintClangValueType.h
@@ -108,9 +108,10 @@ public:
       StringRef metadataVarName = "metadata",
       StringRef vwTableVarName = "vwTable");
 
-  static void printTypeGenericTraits(raw_ostream &os,
-                                     const NominalTypeDecl *typeDecl,
-                                     StringRef typeMetadataFuncName);
+  static void printTypeGenericTraits(
+      raw_ostream &os, const NominalTypeDecl *typeDecl,
+      StringRef typeMetadataFuncName,
+      ArrayRef<GenericRequirement> typeMetadataFuncRequirements);
 
   static void forwardDeclType(raw_ostream &os, const NominalTypeDecl *typeDecl);
 

--- a/lib/PrintAsClang/PrintSwiftToClangCoreScaffold.cpp
+++ b/lib/PrintAsClang/PrintSwiftToClangCoreScaffold.cpp
@@ -214,11 +214,11 @@ void printPrimitiveGenericTypeTraits(raw_ostream &os, ASTContext &astContext,
     os << "static inline const constexpr bool isUsableInGenericContext<"
        << typeInfo.name << "> = true;\n\n";
 
-    os << "template<>\ninline void * _Nonnull getTypeMetadata<";
-    os << typeInfo.name << ">() {\n";
-    os << "  return &" << cxx_synthesis::getCxxImplNamespaceName()
-       << "::" << typeMetadataVarName << ";\n";
-    os << "}\n\n";
+    os << "template<>\nstruct TypeMetadataTrait<" << typeInfo.name << "> {\n"
+       << "  static inline void * _Nonnull getTypeMetadata() {\n"
+       << "    return &" << cxx_synthesis::getCxxImplNamespaceName()
+       << "::" << typeMetadataVarName << ";\n"
+       << "  }\n};\n\n";
   }
 }
 

--- a/stdlib/public/SwiftShims/_SwiftCxxInteroperability.h
+++ b/stdlib/public/SwiftShims/_SwiftCxxInteroperability.h
@@ -140,8 +140,10 @@ using UInt = size_t;
 template <class T>
 static inline const constexpr bool isUsableInGenericContext = false;
 
-/// Returns the type metadat for the given Swift type T.
-template <class T> inline void *_Nonnull getTypeMetadata();
+/// Returns the type metadata for the given Swift type T.
+template <class T> struct TypeMetadataTrait {
+  static inline void *_Nonnull getTypeMetadata();
+};
 
 namespace _impl {
 

--- a/test/Interop/SwiftToCxx/class/swift-class-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/class/swift-class-in-cxx.swift
@@ -66,9 +66,11 @@ public final class ClassWithIntField {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<Class::ClassWithIntField> = true;
 // CHECK-NEXT: template<>
-// CHECK-NEXT: inline void * _Nonnull getTypeMetadata<Class::ClassWithIntField>() {
-// CHECK-NEXT:   return Class::_impl::$s5Class0A12WithIntFieldCMa(0)._0;
-// CHECK-NEXT: }
+// CHECK-NEXT: struct TypeMetadataTrait<Class::ClassWithIntField> {
+// CHECK-NEXT:   inline void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:     return Class::_impl::$s5Class0A12WithIntFieldCMa(0)._0;
+// CHECK-NEXT:   }
+// CHECK-NEXT: };
 // CHECK-NEXT: namespace _impl{
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct implClassFor<Class::ClassWithIntField> { using type = Class::_impl::_impl_ClassWithIntField; };

--- a/test/Interop/SwiftToCxx/core/swift-impl-defs-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/core/swift-impl-defs-in-cxx.swift
@@ -119,97 +119,121 @@
 // CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<bool> = true;
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
-// CHECK-NEXT: inline void * _Nonnull getTypeMetadata<bool>() {
-// CHECK-NEXT:   return &_impl::$sSbN;
-// CHECK-NEXT: }
+// CHECK-NEXT: struct TypeMetadataTrait<bool> {
+// CHECK-NEXT:   static inline void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:     return &_impl::$sSbN;
+// CHECK-NEXT:   }
+// CHECK-NEXT: };
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<int8_t> = true;
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
-// CHECK-NEXT: inline void * _Nonnull getTypeMetadata<int8_t>() {
-// CHECK-NEXT:   return &_impl::$ss4Int8VN;
-// CHECK-NEXT: }
+// CHECK-NEXT: struct TypeMetadataTrait<int8_t> {
+// CHECK-NEXT:   static inline void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:     return &_impl::$ss4Int8VN;
+// CHECK-NEXT:   }
+// CHECK-NEXT: };
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<uint8_t> = true;
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
-// CHECK-NEXT: inline void * _Nonnull getTypeMetadata<uint8_t>() {
-// CHECK-NEXT:   return &_impl::$ss5UInt8VN;
-// CHECK-NEXT: }
+// CHECK-NEXT: struct TypeMetadataTrait<uint8_t> {
+// CHECK-NEXT:   static inline void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:     return &_impl::$ss5UInt8VN;
+// CHECK-NEXT:   }
+// CHECK-NEXT: };
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<int16_t> = true;
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
-// CHECK-NEXT: inline void * _Nonnull getTypeMetadata<int16_t>() {
-// CHECK-NEXT:   return &_impl::$ss5Int16VN;
-// CHECK-NEXT: }
+// CHECK-NEXT: struct TypeMetadataTrait<int16_t> {
+// CHECK-NEXT:   static inline void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:     return &_impl::$ss5Int16VN;
+// CHECK-NEXT:   }
+// CHECK-NEXT: };
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<uint16_t> = true;
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
-// CHECK-NEXT: inline void * _Nonnull getTypeMetadata<uint16_t>() {
-// CHECK-NEXT:   return &_impl::$ss6UInt16VN;
-// CHECK-NEXT: }
+// CHECK-NEXT: struct TypeMetadataTrait<uint16_t> {
+// CHECK-NEXT:   static inline void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:     return &_impl::$ss6UInt16VN;
+// CHECK-NEXT:   }
+// CHECK-NEXT: };
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<int32_t> = true;
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
-// CHECK-NEXT: inline void * _Nonnull getTypeMetadata<int32_t>() {
-// CHECK-NEXT:   return &_impl::$ss5Int32VN;
-// CHECK-NEXT: }
+// CHECK-NEXT: struct TypeMetadataTrait<int32_t> {
+// CHECK-NEXT:   static inline void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:     return &_impl::$ss5Int32VN;
+// CHECK-NEXT:   }
+// CHECK-NEXT: };
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<uint32_t> = true;
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
-// CHECK-NEXT: inline void * _Nonnull getTypeMetadata<uint32_t>() {
-// CHECK-NEXT:   return &_impl::$ss6UInt32VN;
-// CHECK-NEXT: }
+// CHECK-NEXT: struct TypeMetadataTrait<uint32_t> {
+// CHECK-NEXT:   static inline void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:     return &_impl::$ss6UInt32VN;
+// CHECK-NEXT:   }
+// CHECK-NEXT: };
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<int64_t> = true;
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
-// CHECK-NEXT: inline void * _Nonnull getTypeMetadata<int64_t>() {
-// CHECK-NEXT:   return &_impl::$ss5Int64VN;
-// CHECK-NEXT: }
+// CHECK-NEXT: struct TypeMetadataTrait<int64_t> {
+// CHECK-NEXT:   static inline void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:     return &_impl::$ss5Int64VN;
+// CHECK-NEXT:   }
+// CHECK-NEXT: };
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<uint64_t> = true;
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
-// CHECK-NEXT: inline void * _Nonnull getTypeMetadata<uint64_t>() {
-// CHECK-NEXT:   return &_impl::$ss6UInt64VN;
-// CHECK-NEXT: }
+// CHECK-NEXT: struct TypeMetadataTrait<uint64_t> {
+// CHECK-NEXT:   static inline void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:     return &_impl::$ss6UInt64VN;
+// CHECK-NEXT:   }
+// CHECK-NEXT: };
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<float> = true;
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
-// CHECK-NEXT: inline void * _Nonnull getTypeMetadata<float>() {
-// CHECK-NEXT:   return &_impl::$sSfN;
-// CHECK-NEXT: }
+// CHECK-NEXT: struct TypeMetadataTrait<float> {
+// CHECK-NEXT:   static inline void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:     return &_impl::$sSfN;
+// CHECK-NEXT:   }
+// CHECK-NEXT: };
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<double> = true;
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
-// CHECK-NEXT: inline void * _Nonnull getTypeMetadata<double>() {
-// CHECK-NEXT:   return &_impl::$sSdN;
-// CHECK-NEXT: }
+// CHECK-NEXT: struct TypeMetadataTrait<double> {
+// CHECK-NEXT:   static inline void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:     return &_impl::$sSdN;
+// CHECK-NEXT:   }
+// CHECK-NEXT: };
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
 // CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<void *> = true;
 // CHECK-EMPTY:
 // CHECK-NEXT: template<>
-// CHECK-NEXT: inline void * _Nonnull getTypeMetadata<void *>() {
-// CHECK-NEXT:   return &_impl::$ss13OpaquePointerVN;
-// CHECK-NEXT: }
+// CHECK-NEXT: struct TypeMetadataTrait<void *> {
+// CHECK-NEXT:   static inline void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:     return &_impl::$ss13OpaquePointerVN;
+// CHECK-NEXT:   }
+// CHECK-NEXT: };
 // CHECK-EMPTY:
 // CHECK-NEXT: #endif
 // CHECK-EMPTY:

--- a/test/Interop/SwiftToCxx/generics/generic-function-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-function-in-cxx.swift
@@ -110,78 +110,78 @@ public func createTestSmallStruct(_ x: UInt32) -> TestSmallStruct {
 
 // Skip templates in impl classes.
 // CHECK: _impl_TestSmallStruct
-// CHECK:      template<class T>
-// CHECK-NEXT: requires swift::isUsableInGenericContext<T>
-// CHECK-NEXT: inline T genericMethodPassThrough(const T & x) const;
-// CHECK-NEXT: template<class T>
-// CHECK-NEXT: requires swift::isUsableInGenericContext<T>
-// CHECK-NEXT: inline void genericMethodMutTake(const T & x);
+// CHECK:      template<class T_0_0>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
+// CHECK-NEXT: inline T_0_0 genericMethodPassThrough(const T_0_0& x) const;
+// CHECK-NEXT: template<class T_0_0>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
+// CHECK-NEXT: inline void genericMethodMutTake(const T_0_0& x);
 // CHECK:      template<class T>
 // CHECK-NEXT: returnNewValue
 
-// CHECK:      template<class T>
-// CHECK-NEXT: requires swift::isUsableInGenericContext<T>
-// CHECK-NEXT: inline void genericPrintFunction(const T & x) noexcept {
-// CHECK-NEXT:   return _impl::$s9Functions20genericPrintFunctionyyxlF(swift::_impl::getOpaquePointer(x), swift::getTypeMetadata<T>());
+// CHECK:      template<class T_0_0>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
+// CHECK-NEXT: inline void genericPrintFunction(const T_0_0& x) noexcept {
+// CHECK-NEXT:   return _impl::$s9Functions20genericPrintFunctionyyxlF(swift::_impl::getOpaquePointer(x), swift::getTypeMetadata<T_0_0>());
 // CHECK-NEXT: }
 
 
-// CHECK:      template<class T1, class T2>
-// CHECK-NEXT: requires swift::isUsableInGenericContext<T1> && swift::isUsableInGenericContext<T2>
-// CHECK-NEXT: inline void genericPrintFunctionMultiGeneric(swift::Int x, const T1 & t1, const T1 & t1p, swift::Int y, const T2 & t2) noexcept {
-// CHECK-NEXT:   return _impl::$s9Functions32genericPrintFunctionMultiGenericyySi_xxSiq_tr0_lF(x, swift::_impl::getOpaquePointer(t1), swift::_impl::getOpaquePointer(t1p), y, swift::_impl::getOpaquePointer(t2), swift::getTypeMetadata<T1>(), swift::getTypeMetadata<T2>());
+// CHECK:      template<class T_0_0, class T_0_1>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
+// CHECK-NEXT: inline void genericPrintFunctionMultiGeneric(swift::Int x, const T_0_0& t1, const T_0_0& t1p, swift::Int y, const T_0_1& t2) noexcept {
+// CHECK-NEXT:   return _impl::$s9Functions32genericPrintFunctionMultiGenericyySi_xxSiq_tr0_lF(x, swift::_impl::getOpaquePointer(t1), swift::_impl::getOpaquePointer(t1p), y, swift::_impl::getOpaquePointer(t2), swift::getTypeMetadata<T_0_0>(), swift::getTypeMetadata<T_0_1>());
 // CHECK-NEXT: }
 
 
-// CHECK:      template<class T>
-// CHECK-NEXT: requires swift::isUsableInGenericContext<T>
-// CHECK-NEXT: inline void genericPrintFunctionTwoArg(const T & x, swift::Int y) noexcept {
-// CHECK-NEXT:   return _impl::$s9Functions26genericPrintFunctionTwoArgyyx_SitlF(swift::_impl::getOpaquePointer(x), y, swift::getTypeMetadata<T>());
+// CHECK:      template<class T_0_0>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
+// CHECK-NEXT: inline void genericPrintFunctionTwoArg(const T_0_0& x, swift::Int y) noexcept {
+// CHECK-NEXT:   return _impl::$s9Functions26genericPrintFunctionTwoArgyyx_SitlF(swift::_impl::getOpaquePointer(x), y, swift::getTypeMetadata<T_0_0>());
 // CHECK-NEXT: }
 
-// CHECK:      template<class T>
-// CHECK-NEXT: requires swift::isUsableInGenericContext<T>
-// CHECK-NEXT: inline T genericRet(const T & x) noexcept SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:    if constexpr (std::is_base_of<::swift::_impl::RefCountedClass, T>::value) {
+// CHECK:      template<class T_0_0>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
+// CHECK-NEXT: inline T_0_0 genericRet(const T_0_0& x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT:    if constexpr (std::is_base_of<::swift::_impl::RefCountedClass, T_0_0>::value) {
 // CHECK-NEXT:    void *returnValue;
-// CHECK-NEXT:    _impl::$s9Functions10genericRetyxxlF(reinterpret_cast<void *>(&returnValue), swift::_impl::getOpaquePointer(x), swift::getTypeMetadata<T>());
-// CHECK-NEXT:    return ::swift::_impl::implClassFor<T>::type::makeRetained(returnValue);
-// CHECK-NEXT:    } else if constexpr (::swift::_impl::isValueType<T>) {
-// CHECK-NEXT:    return ::swift::_impl::implClassFor<T>::type::returnNewValue([&](void * _Nonnull returnValue) {
-// CHECK-NEXT:    _impl::$s9Functions10genericRetyxxlF(returnValue, swift::_impl::getOpaquePointer(x), swift::getTypeMetadata<T>());
+// CHECK-NEXT:    _impl::$s9Functions10genericRetyxxlF(reinterpret_cast<void *>(&returnValue), swift::_impl::getOpaquePointer(x), swift::getTypeMetadata<T_0_0>());
+// CHECK-NEXT:    return ::swift::_impl::implClassFor<T_0_0>::type::makeRetained(returnValue);
+// CHECK-NEXT:    } else if constexpr (::swift::_impl::isValueType<T_0_0>) {
+// CHECK-NEXT:    return ::swift::_impl::implClassFor<T_0_0>::type::returnNewValue([&](void * _Nonnull returnValue) {
+// CHECK-NEXT:    _impl::$s9Functions10genericRetyxxlF(returnValue, swift::_impl::getOpaquePointer(x), swift::getTypeMetadata<T_0_0>());
 // CHECK-NEXT:    });
 // CHECK-NEXT:    } else {
-// CHECK-NEXT:    T returnValue;
-// CHECK-NEXT:    _impl::$s9Functions10genericRetyxxlF(reinterpret_cast<void *>(&returnValue), swift::_impl::getOpaquePointer(x), swift::getTypeMetadata<T>());
+// CHECK-NEXT:    T_0_0 returnValue;
+// CHECK-NEXT:    _impl::$s9Functions10genericRetyxxlF(reinterpret_cast<void *>(&returnValue), swift::_impl::getOpaquePointer(x), swift::getTypeMetadata<T_0_0>());
 // CHECK-NEXT:    return returnValue;
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
 
-// CHECK:      template<class T>
-// CHECK-NEXT: requires swift::isUsableInGenericContext<T>
-// CHECK-NEXT: inline void genericSwap(T & x, T & y) noexcept {
-// CHECK-NEXT:   return _impl::$s9Functions11genericSwapyyxz_xztlF(swift::_impl::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::getTypeMetadata<T>());
+// CHECK:      template<class T_0_0>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
+// CHECK-NEXT: inline void genericSwap(T_0_0& x, T_0_0& y) noexcept {
+// CHECK-NEXT:   return _impl::$s9Functions11genericSwapyyxz_xztlF(swift::_impl::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::getTypeMetadata<T_0_0>());
 // CHECK-NEXT: }
 
-// CHECK:      template<class T>
-// CHECK-NEXT: requires swift::isUsableInGenericContext<T>
-// CHECK-NEXT: inline T TestSmallStruct::genericMethodPassThrough(const T & x) const {
-// CHECK-NEXT:   if constexpr (std::is_base_of<::swift::_impl::RefCountedClass, T>::value) {
+// CHECK:      template<class T_0_0>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
+// CHECK-NEXT: inline T_0_0 TestSmallStruct::genericMethodPassThrough(const T_0_0& x) const {
+// CHECK-NEXT:   if constexpr (std::is_base_of<::swift::_impl::RefCountedClass, T_0_0>::value) {
 // CHECK-NEXT:   void *returnValue;
-// CHECK-NEXT:   _impl::$s9Functions15TestSmallStructV24genericMethodPassThroughyxxlF(reinterpret_cast<void *>(&returnValue), swift::_impl::getOpaquePointer(x), _impl::swift_interop_passDirect_Functions_TestSmallStruct(_getOpaquePointer()), swift::getTypeMetadata<T>());
-// CHECK-NEXT:   return ::swift::_impl::implClassFor<T>::type::makeRetained(returnValue);
-// CHECK-NEXT:   } else if constexpr (::swift::_impl::isValueType<T>) {
-// CHECK-NEXT:   return ::swift::_impl::implClassFor<T>::type::returnNewValue([&](void * _Nonnull returnValue) {
-// CHECK-NEXT: _impl::$s9Functions15TestSmallStructV24genericMethodPassThroughyxxlF(returnValue, swift::_impl::getOpaquePointer(x), _impl::swift_interop_passDirect_Functions_TestSmallStruct(_getOpaquePointer()), swift::getTypeMetadata<T>());
+// CHECK-NEXT:   _impl::$s9Functions15TestSmallStructV24genericMethodPassThroughyxxlF(reinterpret_cast<void *>(&returnValue), swift::_impl::getOpaquePointer(x), _impl::swift_interop_passDirect_Functions_TestSmallStruct(_getOpaquePointer()), swift::getTypeMetadata<T_0_0>());
+// CHECK-NEXT:   return ::swift::_impl::implClassFor<T_0_0>::type::makeRetained(returnValue);
+// CHECK-NEXT:   } else if constexpr (::swift::_impl::isValueType<T_0_0>) {
+// CHECK-NEXT:   return ::swift::_impl::implClassFor<T_0_0>::type::returnNewValue([&](void * _Nonnull returnValue) {
+// CHECK-NEXT: _impl::$s9Functions15TestSmallStructV24genericMethodPassThroughyxxlF(returnValue, swift::_impl::getOpaquePointer(x), _impl::swift_interop_passDirect_Functions_TestSmallStruct(_getOpaquePointer()), swift::getTypeMetadata<T_0_0>());
 // CHECK-NEXT:   });
 // CHECK-NEXT:   } else {
-// CHECK-NEXT:   T returnValue;
-// CHECK-NEXT: _impl::$s9Functions15TestSmallStructV24genericMethodPassThroughyxxlF(reinterpret_cast<void *>(&returnValue), swift::_impl::getOpaquePointer(x), _impl::swift_interop_passDirect_Functions_TestSmallStruct(_getOpaquePointer()), swift::getTypeMetadata<T>());
+// CHECK-NEXT:   T_0_0 returnValue;
+// CHECK-NEXT: _impl::$s9Functions15TestSmallStructV24genericMethodPassThroughyxxlF(reinterpret_cast<void *>(&returnValue), swift::_impl::getOpaquePointer(x), _impl::swift_interop_passDirect_Functions_TestSmallStruct(_getOpaquePointer()), swift::getTypeMetadata<T_0_0>());
 // CHECK-NEXT:   return returnValue;
 // CHECK-NEXT:   }
 // CHECK-NEXT:   }
-// CHECK-NEXT:   template<class T>
-// CHECK-NEXT: requires swift::isUsableInGenericContext<T>
-// CHECK-NEXT: inline void TestSmallStruct::genericMethodMutTake(const T & x) {
-// CHECK-NEXT:   return _impl::$s9Functions15TestSmallStructV20genericMethodMutTakeyyxlF(swift::_impl::getOpaquePointer(x), swift::getTypeMetadata<T>(), _getOpaquePointer());
+// CHECK-NEXT:   template<class T_0_0>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
+// CHECK-NEXT: inline void TestSmallStruct::genericMethodMutTake(const T_0_0& x) {
+// CHECK-NEXT:   return _impl::$s9Functions15TestSmallStructV20genericMethodMutTakeyyxlF(swift::_impl::getOpaquePointer(x), swift::getTypeMetadata<T_0_0>(), _getOpaquePointer());
 // CHECK-NEXT:   }

--- a/test/Interop/SwiftToCxx/generics/generic-function-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-function-in-cxx.swift
@@ -122,21 +122,21 @@ public func createTestSmallStruct(_ x: UInt32) -> TestSmallStruct {
 // CHECK:      template<class T_0_0>
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
 // CHECK-NEXT: inline void genericPrintFunction(const T_0_0& x) noexcept {
-// CHECK-NEXT:   return _impl::$s9Functions20genericPrintFunctionyyxlF(swift::_impl::getOpaquePointer(x), swift::getTypeMetadata<T_0_0>());
+// CHECK-NEXT:   return _impl::$s9Functions20genericPrintFunctionyyxlF(swift::_impl::getOpaquePointer(x), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata());
 // CHECK-NEXT: }
 
 
 // CHECK:      template<class T_0_0, class T_0_1>
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: inline void genericPrintFunctionMultiGeneric(swift::Int x, const T_0_0& t1, const T_0_0& t1p, swift::Int y, const T_0_1& t2) noexcept {
-// CHECK-NEXT:   return _impl::$s9Functions32genericPrintFunctionMultiGenericyySi_xxSiq_tr0_lF(x, swift::_impl::getOpaquePointer(t1), swift::_impl::getOpaquePointer(t1p), y, swift::_impl::getOpaquePointer(t2), swift::getTypeMetadata<T_0_0>(), swift::getTypeMetadata<T_0_1>());
+// CHECK-NEXT:   return _impl::$s9Functions32genericPrintFunctionMultiGenericyySi_xxSiq_tr0_lF(x, swift::_impl::getOpaquePointer(t1), swift::_impl::getOpaquePointer(t1p), y, swift::_impl::getOpaquePointer(t2), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata());
 // CHECK-NEXT: }
 
 
 // CHECK:      template<class T_0_0>
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
 // CHECK-NEXT: inline void genericPrintFunctionTwoArg(const T_0_0& x, swift::Int y) noexcept {
-// CHECK-NEXT:   return _impl::$s9Functions26genericPrintFunctionTwoArgyyx_SitlF(swift::_impl::getOpaquePointer(x), y, swift::getTypeMetadata<T_0_0>());
+// CHECK-NEXT:   return _impl::$s9Functions26genericPrintFunctionTwoArgyyx_SitlF(swift::_impl::getOpaquePointer(x), y, swift::TypeMetadataTrait<T_0_0>::getTypeMetadata());
 // CHECK-NEXT: }
 
 // CHECK:      template<class T_0_0>
@@ -144,15 +144,15 @@ public func createTestSmallStruct(_ x: UInt32) -> TestSmallStruct {
 // CHECK-NEXT: inline T_0_0 genericRet(const T_0_0& x) noexcept SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:    if constexpr (std::is_base_of<::swift::_impl::RefCountedClass, T_0_0>::value) {
 // CHECK-NEXT:    void *returnValue;
-// CHECK-NEXT:    _impl::$s9Functions10genericRetyxxlF(reinterpret_cast<void *>(&returnValue), swift::_impl::getOpaquePointer(x), swift::getTypeMetadata<T_0_0>());
+// CHECK-NEXT:    _impl::$s9Functions10genericRetyxxlF(reinterpret_cast<void *>(&returnValue), swift::_impl::getOpaquePointer(x), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata());
 // CHECK-NEXT:    return ::swift::_impl::implClassFor<T_0_0>::type::makeRetained(returnValue);
 // CHECK-NEXT:    } else if constexpr (::swift::_impl::isValueType<T_0_0>) {
 // CHECK-NEXT:    return ::swift::_impl::implClassFor<T_0_0>::type::returnNewValue([&](void * _Nonnull returnValue) {
-// CHECK-NEXT:    _impl::$s9Functions10genericRetyxxlF(returnValue, swift::_impl::getOpaquePointer(x), swift::getTypeMetadata<T_0_0>());
+// CHECK-NEXT:    _impl::$s9Functions10genericRetyxxlF(returnValue, swift::_impl::getOpaquePointer(x), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata());
 // CHECK-NEXT:    });
 // CHECK-NEXT:    } else {
 // CHECK-NEXT:    T_0_0 returnValue;
-// CHECK-NEXT:    _impl::$s9Functions10genericRetyxxlF(reinterpret_cast<void *>(&returnValue), swift::_impl::getOpaquePointer(x), swift::getTypeMetadata<T_0_0>());
+// CHECK-NEXT:    _impl::$s9Functions10genericRetyxxlF(reinterpret_cast<void *>(&returnValue), swift::_impl::getOpaquePointer(x), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata());
 // CHECK-NEXT:    return returnValue;
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
@@ -160,7 +160,7 @@ public func createTestSmallStruct(_ x: UInt32) -> TestSmallStruct {
 // CHECK:      template<class T_0_0>
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
 // CHECK-NEXT: inline void genericSwap(T_0_0& x, T_0_0& y) noexcept {
-// CHECK-NEXT:   return _impl::$s9Functions11genericSwapyyxz_xztlF(swift::_impl::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::getTypeMetadata<T_0_0>());
+// CHECK-NEXT:   return _impl::$s9Functions11genericSwapyyxz_xztlF(swift::_impl::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata());
 // CHECK-NEXT: }
 
 // CHECK:      template<class T_0_0>
@@ -168,20 +168,20 @@ public func createTestSmallStruct(_ x: UInt32) -> TestSmallStruct {
 // CHECK-NEXT: inline T_0_0 TestSmallStruct::genericMethodPassThrough(const T_0_0& x) const {
 // CHECK-NEXT:   if constexpr (std::is_base_of<::swift::_impl::RefCountedClass, T_0_0>::value) {
 // CHECK-NEXT:   void *returnValue;
-// CHECK-NEXT:   _impl::$s9Functions15TestSmallStructV24genericMethodPassThroughyxxlF(reinterpret_cast<void *>(&returnValue), swift::_impl::getOpaquePointer(x), _impl::swift_interop_passDirect_Functions_TestSmallStruct(_getOpaquePointer()), swift::getTypeMetadata<T_0_0>());
+// CHECK-NEXT:   _impl::$s9Functions15TestSmallStructV24genericMethodPassThroughyxxlF(reinterpret_cast<void *>(&returnValue), swift::_impl::getOpaquePointer(x), _impl::swift_interop_passDirect_Functions_TestSmallStruct(_getOpaquePointer()), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata());
 // CHECK-NEXT:   return ::swift::_impl::implClassFor<T_0_0>::type::makeRetained(returnValue);
 // CHECK-NEXT:   } else if constexpr (::swift::_impl::isValueType<T_0_0>) {
 // CHECK-NEXT:   return ::swift::_impl::implClassFor<T_0_0>::type::returnNewValue([&](void * _Nonnull returnValue) {
-// CHECK-NEXT: _impl::$s9Functions15TestSmallStructV24genericMethodPassThroughyxxlF(returnValue, swift::_impl::getOpaquePointer(x), _impl::swift_interop_passDirect_Functions_TestSmallStruct(_getOpaquePointer()), swift::getTypeMetadata<T_0_0>());
+// CHECK-NEXT: _impl::$s9Functions15TestSmallStructV24genericMethodPassThroughyxxlF(returnValue, swift::_impl::getOpaquePointer(x), _impl::swift_interop_passDirect_Functions_TestSmallStruct(_getOpaquePointer()), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata());
 // CHECK-NEXT:   });
 // CHECK-NEXT:   } else {
 // CHECK-NEXT:   T_0_0 returnValue;
-// CHECK-NEXT: _impl::$s9Functions15TestSmallStructV24genericMethodPassThroughyxxlF(reinterpret_cast<void *>(&returnValue), swift::_impl::getOpaquePointer(x), _impl::swift_interop_passDirect_Functions_TestSmallStruct(_getOpaquePointer()), swift::getTypeMetadata<T_0_0>());
+// CHECK-NEXT: _impl::$s9Functions15TestSmallStructV24genericMethodPassThroughyxxlF(reinterpret_cast<void *>(&returnValue), swift::_impl::getOpaquePointer(x), _impl::swift_interop_passDirect_Functions_TestSmallStruct(_getOpaquePointer()), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata());
 // CHECK-NEXT:   return returnValue;
 // CHECK-NEXT:   }
 // CHECK-NEXT:   }
 // CHECK-NEXT:   template<class T_0_0>
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
 // CHECK-NEXT: inline void TestSmallStruct::genericMethodMutTake(const T_0_0& x) {
-// CHECK-NEXT:   return _impl::$s9Functions15TestSmallStructV20genericMethodMutTakeyyxlF(swift::_impl::getOpaquePointer(x), swift::getTypeMetadata<T_0_0>(), _getOpaquePointer());
+// CHECK-NEXT:   return _impl::$s9Functions15TestSmallStructV20genericMethodMutTakeyyxlF(swift::_impl::getOpaquePointer(x), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), _getOpaquePointer());
 // CHECK-NEXT:   }

--- a/test/Interop/SwiftToCxx/generics/generic-struct-execution.cpp
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-execution.cpp
@@ -28,6 +28,15 @@ int main() {
     inoutGenericPair(x, 0xFF);
     takeGenericPair(x);
     // CHECK-NEXT: GenericPair<Int32, Int32>(x: 255, y: 42)
+    x.method();
+    // CHECK-NEXT: GenericPair<T, T2>::testme::255,42;
+    x.mutatingMethod(xprime);
+    x.method();
+    // CHECK-NEXT: GenericPair<T, T2>::testme::-995,11;
+    takeGenericPair(x);
+    takeGenericPair(xprime);
+    // CHECK-NEXT: GenericPair<Int32, Int32>(x: -995, y: 11)
+    // CHECK-NEXT: GenericPair<Int32, Int32>(x: 11, y: -995)
   }
 
   {
@@ -46,6 +55,13 @@ int main() {
     inoutConcretePair(77, x);
     takeConcretePair(x);
     // CHECK-NEXT: CONCRETE pair of UInt32: 77 130791 ;
+    x.method();
+    // CHECK-NEXT: GenericPair<T, T2>::testme::77,130791;
+    x.mutatingMethod(xprime);
+    x.method();
+    // CHECK-NEXT: GenericPair<T, T2>::testme::918,100000;
+    takeConcretePair(xprime);
+    // CHECK-NEXT: CONCRETE pair of UInt32: 100000 918 ;
   }
   return 0;
 }

--- a/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
@@ -116,17 +116,17 @@ public func inoutConcretePair(_ x: UInt32, _ y: inout GenericPair<UInt32, UInt32
 // CHECK-NEXT:   return _impl::$s8Generics17inoutConcretePairyys6UInt32V_AA07GenericD0VyA2DGztF(x, _impl::_impl_GenericPair<uint32_t, uint32_t>::getOpaquePointer(y));
 // CHECK-NEXT: }
 
-// CHECK: template<class T1, class T>
-// CHECK-NEXT: requires swift::isUsableInGenericContext<T1> && swift::isUsableInGenericContext<T>
-// CHECK-NEXT: inline void inoutGenericPair(GenericPair<T1, T>& x, const T1 & y) noexcept {
-// CHECK-NEXT:   return _impl::$s8Generics16inoutGenericPairyyAA0cD0Vyxq_Gz_xtr0_lF(_impl::_impl_GenericPair<T1, T>::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::getTypeMetadata<T1>(), swift::getTypeMetadata<T>());
+// CHECK: template<class T_0_0, class T_0_1>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
+// CHECK-NEXT: inline void inoutGenericPair(GenericPair<T_0_0, T_0_1>& x, const T_0_0& y) noexcept {
+// CHECK-NEXT:   return _impl::$s8Generics16inoutGenericPairyyAA0cD0Vyxq_Gz_xtr0_lF(_impl::_impl_GenericPair<T_0_0, T_0_1>::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::getTypeMetadata<T_0_0>(), swift::getTypeMetadata<T_0_1>());
 // CHECK-NEXT: }
 
-// CHECK: template<class T, class T1>
-// CHECK-NEXT: requires swift::isUsableInGenericContext<T> && swift::isUsableInGenericContext<T1>
-// CHECK-NEXT: inline GenericPair<T, T1> makeGenericPair(const T & x, const T1 & y) noexcept SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::_impl_GenericPair<T, T1>::returnNewValue([&](void * _Nonnull result) {
-// CHECK-NEXT:     _impl::$s8Generics15makeGenericPairyAA0cD0Vyxq_Gx_q_tr0_lF(result, swift::_impl::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::getTypeMetadata<T>(), swift::getTypeMetadata<T1>());
+// CHECK: template<class T_0_0, class T_0_1>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
+// CHECK-NEXT: inline GenericPair<T_0_0, T_0_1> makeGenericPair(const T_0_0& x, const T_0_1& y) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT:   return _impl::_impl_GenericPair<T_0_0, T_0_1>::returnNewValue([&](void * _Nonnull result) {
+// CHECK-NEXT:     _impl::$s8Generics15makeGenericPairyAA0cD0Vyxq_Gx_q_tr0_lF(result, swift::_impl::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::getTypeMetadata<T_0_0>(), swift::getTypeMetadata<T_0_1>());
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
@@ -136,11 +136,11 @@ public func inoutConcretePair(_ x: UInt32, _ y: inout GenericPair<UInt32, UInt32
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
-// CHECK: template<class T1, class T>
-// CHECK-NEXT: requires swift::isUsableInGenericContext<T1> && swift::isUsableInGenericContext<T>
-// CHECK-NEXT: inline GenericPair<T1, T> passThroughGenericPair(const GenericPair<T1, T>& x, const T & y) noexcept SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::_impl_GenericPair<T1, T>::returnNewValue([&](void * _Nonnull result) {
-// CHECK-NEXT:     _impl::$s8Generics22passThroughGenericPairyAA0dE0Vyxq_GAE_q_tr0_lF(result, _impl::_impl_GenericPair<T1, T>::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::getTypeMetadata<T1>(), swift::getTypeMetadata<T>());
+// CHECK: template<class T_0_0, class T_0_1>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
+// CHECK-NEXT: inline GenericPair<T_0_0, T_0_1> passThroughGenericPair(const GenericPair<T_0_0, T_0_1>& x, const T_0_1& y) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT:   return _impl::_impl_GenericPair<T_0_0, T_0_1>::returnNewValue([&](void * _Nonnull result) {
+// CHECK-NEXT:     _impl::$s8Generics22passThroughGenericPairyAA0dE0Vyxq_GAE_q_tr0_lF(result, _impl::_impl_GenericPair<T_0_0, T_0_1>::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::getTypeMetadata<T_0_0>(), swift::getTypeMetadata<T_0_1>());
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
@@ -148,8 +148,8 @@ public func inoutConcretePair(_ x: UInt32, _ y: inout GenericPair<UInt32, UInt32
 // CHECK-NEXT:  return _impl::$s8Generics16takeConcretePairyyAA07GenericD0Vys6UInt32VAFGF(_impl::swift_interop_passDirect_Generics_GenericPair_s6UInt32V_s6UInt32V(_impl::_impl_GenericPair<uint32_t, uint32_t>::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
-// CHECK: template<class T, class T1>
-// CHECK-NEXT: requires swift::isUsableInGenericContext<T> && swift::isUsableInGenericContext<T1>
-// CHECK-NEXT: inline void takeGenericPair(const GenericPair<T, T1>& x) noexcept {
-// CHECK-NEXT:  return _impl::$s8Generics15takeGenericPairyyAA0cD0Vyxq_Gr0_lF(_impl::_impl_GenericPair<T, T1>::getOpaquePointer(x), swift::getTypeMetadata<T>(), swift::getTypeMetadata<T1>());
+// CHECK: template<class T_0_0, class T_0_1>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
+// CHECK-NEXT: inline void takeGenericPair(const GenericPair<T_0_0, T_0_1>& x) noexcept {
+// CHECK-NEXT:  return _impl::$s8Generics15takeGenericPairyyAA0cD0Vyxq_Gr0_lF(_impl::_impl_GenericPair<T_0_0, T_0_1>::getOpaquePointer(x), swift::getTypeMetadata<T_0_0>(), swift::getTypeMetadata<T_0_1>());
 // CHECK-NEXT:}

--- a/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
@@ -16,6 +16,16 @@
 public struct GenericPair<T, T2> {
     var x: T
     var y: T2
+
+    public func method() {
+        let copyOfSelf = self
+        print("GenericPair<T, T2>::testme::\(x),\(copyOfSelf.y);")
+    }
+
+    public mutating func mutatingMethod(_ other: GenericPair<T2, T>) {
+        x = other.y
+        y = other.x
+    }
 }
 
 public func makeGenericPair<T, T1>(_ x: T, _ y: T1) -> GenericPair<T, T1> {
@@ -52,7 +62,9 @@ public func inoutConcretePair(_ x: UInt32, _ y: inout GenericPair<UInt32, UInt32
     y.x = x
 }
 
-// CHECK: SWIFT_EXTERN void $s8Generics17inoutConcretePairyys6UInt32V_AA07GenericD0VyA2DGztF(uint32_t x, char * _Nonnull y) SWIFT_NOEXCEPT SWIFT_CALL; // inoutConcretePair(_:_:)
+// CHECK: SWIFT_EXTERN void $s8Generics11GenericPairV6methodyyF(void * _Nonnull , SWIFT_CONTEXT const void * _Nonnull _self) SWIFT_NOEXCEPT SWIFT_CALL; // method()
+// CHECK-NEXT: SWIFT_EXTERN void $s8Generics11GenericPairV14mutatingMethodyyACyq_xGF(const void * _Nonnull other, void * _Nonnull , SWIFT_CONTEXT void * _Nonnull _self) SWIFT_NOEXCEPT SWIFT_CALL; // mutatingMethod(_:)
+// CHECK-NEXT: SWIFT_EXTERN void $s8Generics17inoutConcretePairyys6UInt32V_AA07GenericD0VyA2DGztF(uint32_t x, char * _Nonnull y) SWIFT_NOEXCEPT SWIFT_CALL; // inoutConcretePair(_:_:)
 // CHECK-NEXT: SWIFT_EXTERN void $s8Generics16inoutGenericPairyyAA0cD0Vyxq_Gz_xtr0_lF(void * _Nonnull x, const void * _Nonnull y, void * _Nonnull , void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // inoutGenericPair(_:_:)
 // CHECK-NEXT: // Stub struct to be used to pass/return values to/from Swift functions.
 // CHECK-NEXT: struct swift_interop_stub_Generics_GenericPair_s6UInt32V_s6UInt32V {
@@ -108,6 +120,21 @@ public func inoutConcretePair(_ x: UInt32, _ y: inout GenericPair<UInt32, UInt32
 // CHECK-NEXT:   return result;
 // CHECK-NEXT: }
 
+// CHECK: namespace swift {
+// CHECK-NEXT: #pragma clang diagnostic push
+// CHECK-NEXT: #pragma clang diagnostic ignored "-Wc++17-extensions"
+// CHECK-NEXT: template<class T_0_0, class T_0_1>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
+// CHECK-NEXT: struct TypeMetadataTrait<Generics::GenericPair<T_0_0, T_0_1>> {
+// CHECK-NEXT:   static inline void * _Nonnull getTypeMetadata() {
+// CHECK-NEXT:     return Generics::_impl::$s8Generics11GenericPairVMa(0, swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata())._0;
+// CHECK-NEXT:   }
+// CHECK-NEXT: };
+// CHECK-NEXT: namespace _impl{
+// CHECK-NEXT: } // namespace
+// CHECK-NEXT: #pragma clang diagnostic pop
+// CHECK-NEXT: } // namespace swift
+
 // CHECK: template<class T_0_0, class T_0_1>
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: class GenericPair;
@@ -153,3 +180,14 @@ public func inoutConcretePair(_ x: UInt32, _ y: inout GenericPair<UInt32, UInt32
 // CHECK-NEXT: inline void takeGenericPair(const GenericPair<T_0_0, T_0_1>& x) noexcept {
 // CHECK-NEXT:  return _impl::$s8Generics15takeGenericPairyyAA0cD0Vyxq_Gr0_lF(_impl::_impl_GenericPair<T_0_0, T_0_1>::getOpaquePointer(x), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata());
 // CHECK-NEXT:}
+
+// CHECK: template<class T_0_0, class T_0_1>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
+// CHECK-NEXT: inline void GenericPair<T_0_0, T_0_1>::method() const {
+// CHECK-NEXT: return _impl::$s8Generics11GenericPairV6methodyyF(swift::TypeMetadataTrait<GenericPair<T_0_0, T_0_1>>::getTypeMetadata(), _getOpaquePointer());
+// CHECK-NEXT: }
+// CHECK-NEXT: template<class T_0_0, class T_0_1>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
+// CHECK-NEXT: inline void GenericPair<T_0_0, T_0_1>::mutatingMethod(const GenericPair<T_0_1, T_0_0>& other) {
+// CHECK-NEXT: return _impl::$s8Generics11GenericPairV14mutatingMethodyyACyq_xGF(_impl::_impl_GenericPair<T_0_1, T_0_0>::getOpaquePointer(other), swift::TypeMetadataTrait<GenericPair<T_0_0, T_0_1>>::getTypeMetadata(), _getOpaquePointer());
+// CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
@@ -89,7 +89,7 @@ public func inoutConcretePair(_ x: UInt32, _ y: inout GenericPair<UInt32, UInt32
 // CHECK-NEXT: class GenericPair final {
 // CHECK-NEXT: public:
 // CHECK-NEXT:   inline ~GenericPair() {
-// CHECK-NEXT:     auto metadata = _impl::$s8Generics11GenericPairVMa(0, swift::getTypeMetadata<T_0_0>(), swift::getTypeMetadata<T_0_1>());
+// CHECK-NEXT:     auto metadata = _impl::$s8Generics11GenericPairVMa(0, swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata());
 
 // CHECK: swift::_impl::OpaqueStorage _storage;
 // CHECK-NEXT: friend class _impl::_impl_GenericPair<T_0_0, T_0_1>;
@@ -119,14 +119,14 @@ public func inoutConcretePair(_ x: UInt32, _ y: inout GenericPair<UInt32, UInt32
 // CHECK: template<class T_0_0, class T_0_1>
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: inline void inoutGenericPair(GenericPair<T_0_0, T_0_1>& x, const T_0_0& y) noexcept {
-// CHECK-NEXT:   return _impl::$s8Generics16inoutGenericPairyyAA0cD0Vyxq_Gz_xtr0_lF(_impl::_impl_GenericPair<T_0_0, T_0_1>::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::getTypeMetadata<T_0_0>(), swift::getTypeMetadata<T_0_1>());
+// CHECK-NEXT:   return _impl::$s8Generics16inoutGenericPairyyAA0cD0Vyxq_Gz_xtr0_lF(_impl::_impl_GenericPair<T_0_0, T_0_1>::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata());
 // CHECK-NEXT: }
 
 // CHECK: template<class T_0_0, class T_0_1>
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: inline GenericPair<T_0_0, T_0_1> makeGenericPair(const T_0_0& x, const T_0_1& y) noexcept SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::_impl_GenericPair<T_0_0, T_0_1>::returnNewValue([&](void * _Nonnull result) {
-// CHECK-NEXT:     _impl::$s8Generics15makeGenericPairyAA0cD0Vyxq_Gx_q_tr0_lF(result, swift::_impl::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::getTypeMetadata<T_0_0>(), swift::getTypeMetadata<T_0_1>());
+// CHECK-NEXT:     _impl::$s8Generics15makeGenericPairyAA0cD0Vyxq_Gx_q_tr0_lF(result, swift::_impl::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata());
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
@@ -140,7 +140,7 @@ public func inoutConcretePair(_ x: UInt32, _ y: inout GenericPair<UInt32, UInt32
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: inline GenericPair<T_0_0, T_0_1> passThroughGenericPair(const GenericPair<T_0_0, T_0_1>& x, const T_0_1& y) noexcept SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::_impl_GenericPair<T_0_0, T_0_1>::returnNewValue([&](void * _Nonnull result) {
-// CHECK-NEXT:     _impl::$s8Generics22passThroughGenericPairyAA0dE0Vyxq_GAE_q_tr0_lF(result, _impl::_impl_GenericPair<T_0_0, T_0_1>::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::getTypeMetadata<T_0_0>(), swift::getTypeMetadata<T_0_1>());
+// CHECK-NEXT:     _impl::$s8Generics22passThroughGenericPairyAA0dE0Vyxq_GAE_q_tr0_lF(result, _impl::_impl_GenericPair<T_0_0, T_0_1>::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata());
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
@@ -151,5 +151,5 @@ public func inoutConcretePair(_ x: UInt32, _ y: inout GenericPair<UInt32, UInt32
 // CHECK: template<class T_0_0, class T_0_1>
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: inline void takeGenericPair(const GenericPair<T_0_0, T_0_1>& x) noexcept {
-// CHECK-NEXT:  return _impl::$s8Generics15takeGenericPairyyAA0cD0Vyxq_Gr0_lF(_impl::_impl_GenericPair<T_0_0, T_0_1>::getOpaquePointer(x), swift::getTypeMetadata<T_0_0>(), swift::getTypeMetadata<T_0_1>());
+// CHECK-NEXT:  return _impl::$s8Generics15takeGenericPairyyAA0cD0Vyxq_Gr0_lF(_impl::_impl_GenericPair<T_0_0, T_0_1>::getOpaquePointer(x), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata());
 // CHECK-NEXT:}

--- a/test/Interop/SwiftToCxx/structs/resilient-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/resilient-struct-in-cxx.swift
@@ -73,9 +73,11 @@ public struct FirstSmallStruct {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<Structs::FirstSmallStruct> = true;
 // CHECK-NEXT: template<>
-// CHECK-NEXT: inline void * _Nonnull getTypeMetadata<Structs::FirstSmallStruct>() {
+// CHECK-NEXT: struct TypeMetadataTrait<Structs::FirstSmallStruct> {
+// CHECK-NEXT: inline void * _Nonnull getTypeMetadata() {
 // CHECK-NEXT:   return Structs::_impl::$s7Structs16FirstSmallStructVMa(0)._0;
 // CHECK-NEXT: }
+// CHECK-NEXT: };
 // CHECK-NEXT: namespace _impl{
 // CHECK-NEXT: template<>
 // CHECK-NEXT: static inline const constexpr bool isValueType<Structs::FirstSmallStruct> = true;

--- a/test/Interop/SwiftToCxx/structs/swift-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/swift-struct-in-cxx.swift
@@ -70,9 +70,11 @@
 // CHECK-NEXT: template<>
 // CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<Structs::StructWithIntField> = true;
 // CHECK-NEXT: template<>
-// CHECK-NEXT: inline void * _Nonnull getTypeMetadata<Structs::StructWithIntField>() {
+// CHECK-NEXT: struct TypeMetadataTrait<Structs::StructWithIntField>
+// CHECK-NEXT: inline void * _Nonnull getTypeMetadata() {
 // CHECK-NEXT:   return Structs::_impl::$s7Structs18StructWithIntFieldVMa(0)._0;
 // CHECK-NEXT: }
+// CHECK-NEXT: };
 // CHECK-NEXT: namespace _impl{
 // CHECK-NEXT: template<>
 // CHECK-NEXT: static inline const constexpr bool isValueType<Structs::StructWithIntField> = true;


### PR DESCRIPTION
This adds support for calling methods in generic structs from C++.
Some prerequisite patches:
- unifying the generic model between functions and structs in C++
- Using a struct type traits for type metadata accessor to allow partial specializations for type metadata accessor for generic structs.

Properties, initializers and more testing to be added in future patches