### PR TITLE
[Sema] Fix dictionary duplicate keys false positives for #line and #column magic literal

### DIFF
--- a/test/Sema/diag_dictionary_keys_duplicated.swift
+++ b/test/Sema/diag_dictionary_keys_duplicated.swift
@@ -209,3 +209,21 @@ let _: [String: String] = [
   "\(a)": "B",
   "\(1)": "C"
 ]
+
+// https://github.com/apple/swift/issues/60873
+let _: [Int: String] = [
+  #line: "A",
+  #line: "B"
+]
+
+let _: [Int: String] = [#line: "A", #line: "B"] // expected-warning{{dictionary literal of type '[Int : String]' has duplicate entries for #line literal key}}
+// expected-note@-1{{duplicate key declared here}} {{25-35=}} {{35-36=}}
+// expected-note@-2{{duplicate key declared here}} {{37-47=}} {{35-36=}}
+
+let _: [Int: String] = [#column: "A", #column: "B"] // OK
+
+let _: [Int: String] = [
+  // expected-note@+1{{duplicate key declared here}} {{3-15=}} {{15-16=}} 
+  #column: "A", // expected-warning{{dictionary literal of type '[Int : String]' has duplicate entries for #column literal key}}
+  #column: "B"  // expected-note{{duplicate key declared here}} {{3-16=}} {{227:15-16=}}
+]


### PR DESCRIPTION
<!-- What's in this pull request? -->
Fix a false positive warning of duplicated key for #column and #line magic literals where they can evaluate to different values in a dictionary literal declaration context depending on source position. So we have to take that value of then into account when checking for duplication. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves https://github.com/apple/swift/issues/60873.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
