### PR TITLE
ModuleInterface: Avoid printing protocols inherited from superclasses

### DIFF
--- a/test/ModuleInterface/skip-redundant-conformances.swift
+++ b/test/ModuleInterface/skip-redundant-conformances.swift
@@ -1,10 +1,25 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-emit-module-interface(%t/Foo.swiftinterface) %s -module-name Foo
 // RUN: %target-swift-typecheck-module-from-interface(%t/Foo.swiftinterface) -module-name Foo
+// RUN: %FileCheck %s < %t/Foo.swiftinterface
 
-public protocol ProtocolA : class {}
+// CHECK: public protocol ProtocolA : AnyObject
+public protocol ProtocolA : AnyObject {}
+// CHECK: public protocol ProtocolB : Foo.ProtocolA
 public protocol ProtocolB: ProtocolA {}
+// CHECK-NOT: ProtocolC
 protocol ProtocolC: ProtocolA {}
 
+// CHECK: @_hasMissingDesignatedInitializers public class A : Foo.ProtocolB
 public class A: ProtocolB {}
+// CHECK: @_inheritsConvenienceInitializers @_hasMissingDesignatedInitializers public class B : Foo.A
 public class B: A, ProtocolC {}
+
+// CHECK: @_hasMissingDesignatedInitializers public class C
+public class C {}
+extension C: ProtocolC {}
+// CHECK: @_inheritsConvenienceInitializers @_hasMissingDesignatedInitializers public class D : Foo.C
+public class D: C {}
+
+// CHECK: extension Foo.C : Foo.ProtocolA {}
+// CHECK-NOT: extension Foo.D : Foo.ProtocolA {}


### PR DESCRIPTION
"Extra" protocols from a superclass are already handled when printing the superclass, so we should not accumulate them when recording protocols for a subclass.

Resolves rdar://98523784
