### PR TITLE
[cxx-interop] Fix foreign reference types with reference counting that live in a namespace.

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6137,7 +6137,9 @@ CustomRefCountingOperationResult CustomRefCountingOperation::evaluate(
     return {CustomRefCountingOperationResult::immortal, nullptr, name};
 
   llvm::SmallVector<ValueDecl *, 1> results;
-  ctx.lookupInModule(swiftDecl->getParentModule(), name, results);
+  auto parentModule = ctx.getClangModuleLoader()->getWrapperForModule(
+      swiftDecl->getClangDecl()->getOwningModule());
+  ctx.lookupInModule(parentModule, name, results);
 
   if (results.size() == 1)
     return {CustomRefCountingOperationResult::foundOperation, results.front(),

--- a/test/Interop/Cxx/foreign-reference/Inputs/reference-counted.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/reference-counted.h
@@ -11,6 +11,8 @@ SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 
 static int finalLocalRefCount = 100;
 
+namespace NS {
+
 struct __attribute__((swift_attr("import_as_ref")))
 __attribute__((swift_attr("retain:LCRetain")))
 __attribute__((swift_attr("release:LCRelease"))) LocalCount {
@@ -21,8 +23,10 @@ __attribute__((swift_attr("release:LCRelease"))) LocalCount {
   }
 };
 
-inline void LCRetain(LocalCount *x) { x->value++; }
-inline void LCRelease(LocalCount *x) {
+}
+
+inline void LCRetain(NS::LocalCount *x) { x->value++; }
+inline void LCRelease(NS::LocalCount *x) {
   x->value--;
   finalLocalRefCount = x->value;
 }

--- a/test/Interop/Cxx/foreign-reference/reference-counted-silgen.swift
+++ b/test/Interop/Cxx/foreign-reference/reference-counted-silgen.swift
@@ -20,12 +20,12 @@ public func testTrivial() {
 }
 
 // CHECK-LABEL: sil [ossa] @$s4main14testNonTrivialyyF : $@convention(thin) () -> ()
-// CHECK:  copy_value %{{[0-9]+}} : $LocalCount
-// CHECK:  copy_value %{{[0-9]+}} : $LocalCount
-// CHECK:  copy_value %{{[0-9]+}} : $LocalCount
+// CHECK:  copy_value %{{[0-9]+}} : $NS.LocalCount
+// CHECK:  copy_value %{{[0-9]+}} : $NS.LocalCount
+// CHECK:  copy_value %{{[0-9]+}} : $NS.LocalCount
 // CHECK: return
 // CHECK-LABEL: end sil function '$s4main14testNonTrivialyyF'
 public func testNonTrivial() {
-    let x = LocalCount.create()
+    let x = NS.LocalCount.create()
     let t = (x, x, x)
 }

--- a/test/Interop/Cxx/foreign-reference/reference-counted.swift
+++ b/test/Interop/Cxx/foreign-reference/reference-counted.swift
@@ -16,7 +16,7 @@ public func blackHole<T>(_ _: T) {  }
 
 @inline(never)
 func localTest() {
-    var x = LocalCount.create()
+    var x = NS.LocalCount.create()
     expectEqual(x.value, 6) // This is 6 because of "var x" "x.value" * 2 and "(x, x, x)".
 
     let t = (x, x, x)


### PR DESCRIPTION
Before this patch we tried to do lookup in the _ObjC module for the retain/release functions. Now we use the clang module that the reference type lives in.
