### PR TITLE
[Profiler] Fix autoclosure property wrapper crash

### DIFF
--- a/lib/SIL/IR/SILProfiler.cpp
+++ b/lib/SIL/IR/SILProfiler.cpp
@@ -51,11 +51,6 @@ static bool isUnmapped(ASTNode N) {
   }
 
   if (auto *E = N.dyn_cast<Expr *>()) {
-    if (isa<LiteralExpr>(E)) {
-      LLVM_DEBUG(llvm::dbgs() << "Skipping ASTNode: literal expr\n");
-      return true;
-    }
-
     if (auto *CE = dyn_cast<AbstractClosureExpr>(E)) {
       // Only map closure expressions with bodies.
       if (!doesClosureHaveBody(CE)) {

--- a/test/Profiler/coverage_var_init.swift
+++ b/test/Profiler/coverage_var_init.swift
@@ -1,6 +1,36 @@
 // RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_var_init %s | %FileCheck %s
 // RUN: %target-swift-frontend -profile-generate -profile-coverage-mapping -emit-ir %s
 
+struct S {
+  // CHECK-LABEL: sil_coverage_map {{.*}} "$s17coverage_var_init1SV1iSivpfi" {{.*}} // variable initialization expression of coverage_var_init.S.i
+  // CHECK-NEXT:  [[@LINE+1]]:11 -> [[@LINE+1]]:12 : 0
+  var i = 0
+
+  // CHECK-LABEL: sil_coverage_map {{.*}} "$s17coverage_var_init1SV1jSivpfi" {{.*}} // variable initialization expression of coverage_var_init.S.j
+  // CHECK-NEXT:  [[@LINE+1]]:11 -> [[@LINE+1]]:16 : 0
+  var j = 1 + 2
+
+  // CHECK-LABEL: sil_coverage_map {{.*}} "$s17coverage_var_init1SV1kSiycvpfi" {{.*}} // variable initialization expression of coverage_var_init.S.k
+  // CHECK-NEXT:  [[@LINE+3]]:11 -> [[@LINE+3]]:20 : 0
+  // CHECK-LABEL: sil_coverage_map {{.*}} "$s17coverage_var_init1SV1kSiycvpfiSiycfU_" {{.*}} // closure #1 () -> Swift.Int in variable initialization expression of coverage_var_init.S.k
+  // CHECK-NEXT: [[@LINE+1]]:11 -> [[@LINE+1]]:20 : 0
+  var k = { 1 + 2 }
+
+  // CHECK-LABEL: sil_coverage_map {{.*}} "$s17coverage_var_init1SV1lSivpfi" {{.*}} // variable initialization expression of coverage_var_init.S.l
+  // CHECK-NEXT:  [[@LINE+1]]:11 -> [[@LINE+1]]:16 : 0
+  var l = #line
+
+  // CHECK-LABEL: sil_coverage_map {{.*}} "$s17coverage_var_init1SV1mSaySiGvpfi" {{.*}} // variable initialization expression of coverage_var_init.S.m
+  // CHECK-NEXT:  [[@LINE+1]]:11 -> [[@LINE+1]]:20 : 0
+  var m = [1, 2, 3]
+
+  // CHECK-LABEL: sil_coverage_map {{.*}} "$s17coverage_var_init1SV1nSSvpfi" {{.*}} // variable initialization expression of coverage_var_init.S.n
+  // CHECK-NEXT:  [[@LINE+3]]:11 -> [[@LINE+3]]:33 : 0
+  // CHECK-NEXT:  [[@LINE+2]]:26 -> [[@LINE+2]]:27 : 1
+  // CHECK-NEXT:  [[@LINE+1]]:30 -> [[@LINE+1]]:31 : (0 - 1)
+  var n = "\(.random() ? 1 : 2)"
+}
+
 final class VarInit {
   // CHECK: sil_coverage_map {{.*}} "$s17coverage_var_init7VarInitC018initializedWrapperE0SivpfP"
   // CHECK-NEXT: [[@LINE+1]]:4 -> [[@LINE+1]]:42 : 0

--- a/test/Profiler/coverage_var_init.swift
+++ b/test/Profiler/coverage_var_init.swift
@@ -36,6 +36,10 @@ final class VarInit {
   // CHECK-NEXT: [[@LINE+1]]:4 -> [[@LINE+1]]:42 : 0
   @Wrapper var initializedWrapperInit = 2
 
+  // CHECK: sil_coverage_map {{.*}} // variable initialization expression of coverage_var_init.VarInit.(_autoclosureWrapperInit
+  // CHECK-NEXT: [[@LINE+1]]:52 -> [[@LINE+1]]:53
+  @AutoClosureWrapper var autoclosureWrapperInit = 3
+
   // CHECK: sil_coverage_map {{.*}} "$s17coverage_var_init7VarInitC04lazydE033_49373CB2DFB47C8DC62FA963604688DFLLSSvgSSyXEfU_"
   // CHECK-NEXT: [[@LINE+1]]:42 -> [[@LINE+3]]:4 : 0
   private lazy var lazyVarInit: String = {
@@ -65,6 +69,14 @@ final class VarInit {
 @propertyWrapper struct Wrapper {
   init(wrappedValue: Int) {}
   var wrappedValue: Int { 1 }
+}
+
+@propertyWrapper
+struct AutoClosureWrapper<T> {
+  var wrappedValue: T
+  init(wrappedValue: @autoclosure () -> T) {
+    self.wrappedValue = wrappedValue()
+  }
 }
 
 VarInit().coverageFunction()


### PR DESCRIPTION
We need to query the top-level expression, not the sub-expression of a potential function conversion.

rdar://99449154
Resolves #60908