### PR TITLE
[Sema] Intro the @_spiOnly attribute on import statements

### DIFF
--- a/docs/ReferenceGuides/UnderscoredAttributes.md
+++ b/docs/ReferenceGuides/UnderscoredAttributes.md
@@ -451,6 +451,13 @@ This prevents types from that module being exposed in API
 (types of public functions, constraints in public extension etc.)
 and ABI (usage in `@inlinable` code).
 
+## `@_spiOnly`
+
+Marks an import to be used in SPI and implementation details only.
+The import statement will be printed in the private swiftinterface only and
+skipped in the public swiftinterface. Any use of imported types and decls in API
+will be diagnosed.
+
 ## `@_implements(ProtocolName, Requirement)`
 
 An attribute that indicates that a function with one name satisfies

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -768,6 +768,11 @@ SIMPLE_DECL_ATTR(typeWrapper, TypeWrapper,
   ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   134)
 
+SIMPLE_DECL_ATTR(_spiOnly, SPIOnly,
+  OnImport | UserInaccessible |
+  ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
+  135)
+
 // If you're adding a new underscored attribute here, please document it in
 // docs/ReferenceGuides/UnderscoredAttributes.md.
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1902,6 +1902,9 @@ WARNING(spi_attribute_on_import_of_public_module,none,
         "'@_spi' import of %0 will not include any SPI symbols; "
         "%0 was built from the public interface at %1",
         (DeclName, StringRef))
+ERROR(spi_only_imports_not_enabled, none,
+      "'@_spiOnly' requires setting the frontend flag '-experimental-spi-only-imports'",
+      ())
 
 // Opaque return types
 ERROR(opaque_type_invalid_constraint,none,

--- a/include/swift/AST/Import.h
+++ b/include/swift/AST/Import.h
@@ -88,7 +88,11 @@ enum class ImportFlags {
   WeakLinked = 0x40,
 
   /// Used for DenseMap.
-  Reserved = 0x80
+  Reserved = 0x80,
+
+  /// The imported module can only be referenced from SPI decls, or
+  /// implementation details.
+  SPIOnly = 0x100
 };
 
 /// \see ImportFlags

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -696,11 +696,13 @@ public:
     Default = 1 << 1,
     /// Include imports declared with `@_implementationOnly`.
     ImplementationOnly = 1 << 2,
-    /// Include imports of SPIs declared with `@_spi`
+    /// Include imports of SPIs declared with `@_spi`.
     SPIAccessControl = 1 << 3,
+    /// Include imports declared with `@_spiOnly`.
+    SPIOnly = 1 << 4,
     /// Include imports shadowed by a cross-import overlay. Unshadowed imports
     /// are included whether or not this flag is specified.
-    ShadowedByCrossImportOverlay = 1 << 4
+    ShadowedByCrossImportOverlay = 1 << 5
   };
   /// \sa getImportedModules
   using ImportFilter = OptionSet<ImportFilterKind>;

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -456,6 +456,9 @@ namespace swift {
     // FrontendOptions.
     bool AllowModuleWithCompilerErrors = false;
 
+    /// Enable using @_spiOnly on import decls.
+    bool EnableSPIOnlyImports = false;
+
     /// A helper enum to represent whether or not we customized the default
     /// ASTVerifier behavior via a frontend flag. By default, we do not
     /// customize.

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -317,10 +317,6 @@ def enable_resilience : Flag<["-"], "enable-resilience">,
 def enable_experimental_async_top_level :
   Flag<["-"], "enable-experimental-async-top-level">,
   HelpText<"Enable experimental concurrency in top-level code">;
-
-def experimental_spi_only_imports :
-  Flag<["-"], "experimental-spi-only-imports">,
-  HelpText<"Enable use of @_spiOnly imports">;
 }
 
 // HIDDEN FLAGS
@@ -1114,4 +1110,8 @@ def enable_emit_generic_class_ro_t_list :
   Flag<["-"], "enable-emit-generic-class-ro_t-list">,
   HelpText<"Enable emission of a section with references to class_ro_t of "
            "generic class patterns">;
+
+def experimental_spi_only_imports :
+  Flag<["-"], "experimental-spi-only-imports">,
+  HelpText<"Enable use of @_spiOnly imports">;
 } // end let Flags = [FrontendOption, NoDriverOption, HelpHidden]

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -317,6 +317,10 @@ def enable_resilience : Flag<["-"], "enable-resilience">,
 def enable_experimental_async_top_level :
   Flag<["-"], "enable-experimental-async-top-level">,
   HelpText<"Enable experimental concurrency in top-level code">;
+
+def experimental_spi_only_imports :
+  Flag<["-"], "experimental-spi-only-imports">,
+  HelpText<"Enable use of @_spiOnly imports">;
 }
 
 // HIDDEN FLAGS

--- a/lib/AST/ImportCache.cpp
+++ b/lib/AST/ImportCache.cpp
@@ -195,6 +195,7 @@ ImportSet &ImportCache::getImportSet(const DeclContext *dc) {
     file->getImportedModules(imports,
                              {ModuleDecl::ImportFilterKind::Default,
                               ModuleDecl::ImportFilterKind::ImplementationOnly,
+                              ModuleDecl::ImportFilterKind::SPIOnly,
                               ModuleDecl::ImportFilterKind::SPIAccessControl});
   }
 
@@ -279,6 +280,7 @@ ImportCache::getAllAccessPathsNotShadowedBy(const ModuleDecl *mod,
     file->getImportedModules(stack,
                              {ModuleDecl::ImportFilterKind::Default,
                               ModuleDecl::ImportFilterKind::ImplementationOnly,
+                              ModuleDecl::ImportFilterKind::SPIOnly,
                               ModuleDecl::ImportFilterKind::SPIAccessControl});
   }
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1596,6 +1596,8 @@ SourceFile::getImportedModules(SmallVectorImpl<ImportedModule> &modules,
       requiredFilter |= ModuleDecl::ImportFilterKind::Exported;
     else if (desc.options.contains(ImportFlags::ImplementationOnly))
       requiredFilter |= ModuleDecl::ImportFilterKind::ImplementationOnly;
+    else if (desc.options.contains(ImportFlags::SPIOnly))
+      requiredFilter |= ModuleDecl::ImportFilterKind::SPIOnly;
     else if (desc.options.contains(ImportFlags::SPIAccessControl))
       requiredFilter |= ModuleDecl::ImportFilterKind::SPIAccessControl;
     else
@@ -1904,6 +1906,7 @@ SourceFile::collectLinkLibraries(ModuleDecl::LinkLibraryCallback callback) const
 
   ModuleDecl::ImportFilter topLevelFilter = filter;
   topLevelFilter |= ModuleDecl::ImportFilterKind::ImplementationOnly;
+  topLevelFilter |= ModuleDecl::ImportFilterKind::SPIOnly;
   topLevel->getImportedModules(stack, topLevelFilter);
 
   // Make sure the top-level module is first; we want pre-order-ish traversal.
@@ -2600,6 +2603,7 @@ canBeUsedForCrossModuleOptimization(DeclContext *ctxt) const {
   // @_implementationOnly or @_spi.
   ModuleDecl::ImportFilter filter = {
     ModuleDecl::ImportFilterKind::ImplementationOnly,
+    ModuleDecl::ImportFilterKind::SPIOnly,
     ModuleDecl::ImportFilterKind::SPIAccessControl
   };
   SmallVector<ImportedModule, 4> results;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -721,6 +721,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     }
   }
 
+  Opts.EnableSPIOnlyImports = Args.hasArg(OPT_experimental_spi_only_imports);
+
   if (Opts.EnableSwift3ObjCInference) {
     if (const Arg *A = Args.getLastArg(
                                    OPT_warn_swift3_objc_inference_minimal,

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -536,6 +536,9 @@ UnboundImport::UnboundImport(ImportDecl *ID)
   if (ID->getAttrs().hasAttribute<ImplementationOnlyAttr>())
     import.options |= ImportFlags::ImplementationOnly;
 
+  if (ID->getAttrs().hasAttribute<SPIOnlyAttr>())
+    import.options |= ImportFlags::SPIOnly;
+
   if (auto *privateImportAttr =
           ID->getAttrs().getAttribute<PrivateImportAttr>()) {
     import.options |= ImportFlags::PrivateImport;

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -296,6 +296,7 @@ public:
   void visitResultBuilderAttr(ResultBuilderAttr *attr);
 
   void visitImplementationOnlyAttr(ImplementationOnlyAttr *attr);
+  void visitSPIOnlyAttr(SPIOnlyAttr *attr);
   void visitNonEphemeralAttr(NonEphemeralAttr *attr);
   void checkOriginalDefinedInAttrs(ArrayRef<OriginallyDefinedInAttr *> Attrs);
 
@@ -3906,6 +3907,10 @@ AttributeChecker::visitImplementationOnlyAttr(ImplementationOnlyAttr *attr) {
   // FIXME: When compiling without library evolution enabled, this should also
   // check whether VD or any of its accessors need a new vtable entry, even if
   // it won't necessarily be able to say why.
+}
+
+void
+AttributeChecker::visitSPIOnlyAttr(SPIOnlyAttr *attr) {
 }
 
 void AttributeChecker::visitTypeSequenceAttr(TypeSequenceAttr *attr) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3911,6 +3911,9 @@ AttributeChecker::visitImplementationOnlyAttr(ImplementationOnlyAttr *attr) {
 
 void
 AttributeChecker::visitSPIOnlyAttr(SPIOnlyAttr *attr) {
+  if (!Ctx.LangOpts.EnableSPIOnlyImports) {
+    diagnoseAndRemoveAttr(attr, diag::spi_only_imports_not_enabled);
+  }
 }
 
 void AttributeChecker::visitTypeSequenceAttr(TypeSequenceAttr *attr) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3911,7 +3911,9 @@ AttributeChecker::visitImplementationOnlyAttr(ImplementationOnlyAttr *attr) {
 
 void
 AttributeChecker::visitSPIOnlyAttr(SPIOnlyAttr *attr) {
-  if (!Ctx.LangOpts.EnableSPIOnlyImports) {
+  auto *SF = D->getDeclContext()->getParentSourceFile();
+  if (!Ctx.LangOpts.EnableSPIOnlyImports &&
+      SF->Kind != SourceFileKind::Interface) {
     diagnoseAndRemoveAttr(attr, diag::spi_only_imports_not_enabled);
   }
 }

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1582,6 +1582,7 @@ namespace  {
     UNINTERESTING_ATTR(Frozen)
     UNINTERESTING_ATTR(HasInitialValue)
     UNINTERESTING_ATTR(ImplementationOnly)
+    UNINTERESTING_ATTR(SPIOnly)
     UNINTERESTING_ATTR(Custom)
     UNINTERESTING_ATTR(PropertyWrapper)
     UNINTERESTING_ATTR(TypeWrapper)

--- a/test/SPI/spi_only_import_flag_check.swift
+++ b/test/SPI/spi_only_import_flag_check.swift
@@ -16,7 +16,19 @@
 // RUN:   -module-name Client -emit-module-path %t/Client.swiftmodule \
 // RUN:   -experimental-spi-only-imports
 
+/// Attribute is accepted without the flag when in a swiftinterface.
+// RUN: %target-swift-typecheck-module-from-interface(%t/Client.private.swiftinterface) \
+// RUN:   -I %t -module-name Client
+
 //--- Empty.swift
 //--- Client.swift
 
 @_spiOnly import Empty // expected-error {{'@_spiOnly' requires setting the frontend flag '-experimental-spi-only-imports'}}
+
+//--- Client.private.swiftinterface
+
+// swift-interface-format-version: 1.0
+// swift-compiler-version: Swift version 5.8-dev effective-4.1.50
+// swift-module-flags: -swift-version 4 -module-name Client
+import Swift
+@_spiOnly import Empty

--- a/test/SPI/spi_only_import_flag_check.swift
+++ b/test/SPI/spi_only_import_flag_check.swift
@@ -1,0 +1,22 @@
+/// Test requiring the flag -experimental-spi-only-imports to use @_spiOnly.
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// Build dummy dependency.
+// RUN: %target-swift-frontend -emit-module %t/Empty.swift \
+// RUN:   -module-name Empty -emit-module-path %t/Empty.swiftmodule
+
+/// Attribute is rejected without the flag.
+// RUN: %target-swift-frontend -emit-module %t/Client.swift -I %t \
+// RUN:   -module-name Client -emit-module-path %t/Client.swiftmodule -verify
+
+/// Attribute is accepted with the flag.
+// RUN: %target-swift-frontend -emit-module %t/Client.swift -I %t \
+// RUN:   -module-name Client -emit-module-path %t/Client.swiftmodule \
+// RUN:   -experimental-spi-only-imports
+
+//--- Empty.swift
+//--- Client.swift
+
+@_spiOnly import Empty // expected-error {{'@_spiOnly' requires setting the frontend flag '-experimental-spi-only-imports'}}


### PR DESCRIPTION
Prepare the scene for the @_spiOnly attribute on import statements. This modifier will effectively import the target only in the private swiftinterface and swiftmodule, the import will be absent from the public swiftinterface. Type-checking will ensure that imported types are only used in SPI and implementation details, uses in API will be diagnosed.

This PR introduces the attribute, the import filters and the flag required to enable the feature. Next I'll add swiftinterface printing support, exportability diagnostics, and integration with adjacent SDK sanity checks.