### PR TITLE
[ConstraintSystem] Update score labels

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1108,15 +1108,14 @@ struct Score {
     bool hasNonDefault = false;
     for (unsigned int i = 0; i < NumScoreKinds; ++i) {
       if (Data[i] != 0) {
-        out << " [";
+        out << " [component: ";
         out << getNameFor(ScoreKind(i));
-        out << "(s) = ";
+        out << "(s), value: ";
         out << std::to_string(Data[i]);
         out << "]";
         hasNonDefault = true;
       }
     }
-
     if (!hasNonDefault) {
       out << " <default ";
       out << *this;

--- a/test/Constraints/one_way_solve.swift
+++ b/test/Constraints/one_way_solve.swift
@@ -38,9 +38,9 @@ func testTernaryOneWayOverload(b: Bool) {
 
   // CHECK: solving component #1
   // CHECK: (attempting type variable $T11 := Int8 
-  // CHECK: (found solution: [non-default literal(s) = 2] [use of overloaded unapplied function(s) = 2])
+  // CHECK: (found solution: [component: non-default literal(s), value: 2] [component: use of overloaded unapplied function(s), value: 2]) 
 
-  // CHECK: (composed solution: [non-default literal(s) = 2] [use of overloaded unapplied function(s) = 2])
-  // CHECK-NOT: (composed solution: [non-default literal(s) = 2] [use of overloaded unapplied function(s) = 2])
+  // CHECK: (composed solution: [component: non-default literal(s), value: 2] [component: use of overloaded unapplied function(s), value: 2])
+  // CHECK-NOT: (composed solution: [component: non-default literal(s), value: 2] [component: use of overloaded unapplied function(s), value: 2])
   let _: Int8 = b ? Builtin.one_way(int8Or16(17)) : Builtin.one_way(int8Or16(42))
 }


### PR DESCRIPTION
`found solutions` and `scores` will print with`component` and `value` labels, like so:
```
(found solution: [component: non-default literal(s), value: 1])

```

This updates apple/swift#60387.