### PR TITLE
[Test] Fix protocol_conformance_collision.swift.

### DIFF
--- a/test/Runtime/protocol_conformance_collision.swift
+++ b/test/Runtime/protocol_conformance_collision.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -o %t/newSDK %target-link-sdk-future-version
+// RUN: %target-build-swift %s -o %t/newSDK %target-link-sdk-2021-version
 // RUN: %target-codesign %t/newSDK
 // RUN: %target-run %t/newSDK newSDK
 // RUN: %target-build-swift %s -o %t/oldSDK %target-link-sdk-2020-version

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1338,6 +1338,15 @@ if run_vendor == 'apple':
         'watchos': '7.0'
     }
     sdk_2020_version = SDK_2020_VERSION.get(run_os, '')
+    SDK_2021_VERSION = {
+        'macosx': '12.0',
+        'ios': '15.0',
+        'maccatalyst': '15.0',
+        'tvos': '15.0',
+        'watchos': '8.0',
+        'xros': '1.0'
+    }
+    sdk_2021_version = SDK_2021_VERSION.get(run_os, '')
     linker_os = {
         'iphoneos': 'ios',
         'appletvos': 'tvos',
@@ -1351,6 +1360,9 @@ if run_vendor == 'apple':
     config.target_link_sdk_2020_version = (
       "-Xlinker -platform_version -Xlinker %s -Xlinker %s -Xlinker %s" %
       (linker_os, sdk_2020_version, sdk_2020_version))
+    config.target_link_sdk_2021_version = (
+      "-Xlinker -platform_version -Xlinker %s -Xlinker %s -Xlinker %s" %
+      (linker_os, sdk_2021_version, sdk_2021_version))
     config.target_link_sdk_future_version = (
       "-Xlinker -platform_version -Xlinker %s -Xlinker %s -Xlinker %s" %
       (linker_os, target_future_version, target_future_version))
@@ -2472,6 +2484,9 @@ if hasattr(config, 'otool_classic'):
 if hasattr(config, 'target_link_sdk_2020_version'):
     config.substitutions.append(('%target-link-sdk-2020-version',
                                  config.target_link_sdk_2020_version))
+if hasattr(config, 'target_link_sdk_2021_version'):
+    config.substitutions.append(('%target-link-sdk-2021-version',
+                                 config.target_link_sdk_2021_version))
 if hasattr(config, 'target_link_sdk_future_version'):
     config.substitutions.append(('%target-link-sdk-future-version',
                                  config.target_link_sdk_future_version))


### PR DESCRIPTION
Use 2021 OS versions instead of far-future OS versions. We have versions with the fix now, so we don't need the far-future versions. Using them breaks things when building against a newer SDK and running on an older OS, because the system assumes stuff on the newer OS is available when it isn't.