### PR TITLE
[SILSSAUpdater] Clone `string_literal` arguments to `int_instrprof_increment`

### DIFF
--- a/include/swift/SILOptimizer/Utils/SILSSAUpdater.h
+++ b/include/swift/SILOptimizer/Utils/SILSSAUpdater.h
@@ -101,6 +101,11 @@ public:
   /// merging val_1 and val_2.
   SILValue getValueInMiddleOfBlock(SILBasicBlock *block);
 
+  /// Attempts to rewrite a use by directly cloning it, returning \c true if the
+  /// instruction was cloned, \c false if the instruction requires a general
+  /// rewrite.
+  bool tryRewriteUseByCloning(Operand &use);
+
   void rewriteUse(Operand &operand);
 
   void *allocate(unsigned size, unsigned align) const;

--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -416,14 +416,7 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
     // Extract the PGO function name.
     auto *NameGEP = cast<llvm::User>(args.claimNext());
     auto *NameGV = dyn_cast<llvm::GlobalVariable>(NameGEP->stripPointerCasts());
-
-    // TODO: The SIL optimizer may rewrite the name argument in a way that
-    // makes it impossible to lower. Until that issue is fixed, defensively
-    // refuse to lower ill-formed intrinsics (rdar://39146527).
-    if (!NameGV) {
-      (void)args.claimAll();
-      return;
-    }
+    assert(NameGV && "Need a literal function name for instrprof_increment");
 
     auto *NameC = NameGV->getInitializer();
     StringRef Name = cast<llvm::ConstantDataArray>(NameC)->getRawDataValues();

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1815,6 +1815,11 @@ public:
       require(!isa<SILArgument>(BI->getArguments()[1]),
               "llvm.invariant.end parameter #2 must be an integer literal");
       break;
+    case llvm::Intrinsic::instrprof_increment:
+      const auto &Name = BI->getArguments()[0];
+      require(isa<StringLiteralInst>(Name),
+              "name argument of profiling intrinsic must be a string literal");
+      break;
     }
   }
 

--- a/test/Profiler/instrprof_symtab_valid.sil
+++ b/test/Profiler/instrprof_symtab_valid.sil
@@ -11,14 +11,14 @@ import SwiftShims
 // main
 sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
-  %2 = string_literal utf8 "<stdin>:__tlcd_line:1:1" // user: %6
+  %2 = string_literal utf8 "xxxxx" // user: %6
   %3 = integer_literal $Builtin.Int64, 0          // user: %6
   %4 = integer_literal $Builtin.Int32, 2          // user: %6
   %5 = integer_literal $Builtin.Int32, 0          // user: %6
 
   // Pass an invalid SIL value to the int_instrprof_increment intrinsic
   // to force IRGen to drop it.
-  %6 = builtin "int_instrprof_increment"(%3 : $Builtin.Int64, %3 : $Builtin.Int64, %4 : $Builtin.Int32, %5 : $Builtin.Int32) : $()
+  %6 = builtin "int_instrprof_increment"(%2 : $Builtin.RawPointer, %3 : $Builtin.Int64, %4 : $Builtin.Int32, %5 : $Builtin.Int32) : $()
 
   return %0 : $Int32                             // id: %33
 } // end sil function 'main'

--- a/test/Profiler/rdar39146527.sil
+++ b/test/Profiler/rdar39146527.sil
@@ -1,0 +1,95 @@
+// RUN: %target-swift-frontend -emit-sil -O -sil-verify-all %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -O -sil-verify-all -profile-generate %s
+
+import Builtin
+import Swift
+
+enum Name {
+  case short(Character, allowingJoined: Bool)
+  case longWithSingleDash(String)
+  case long(String)
+}
+
+sil @bar : $@convention(thin) () -> @owned String
+sil @baz : $@convention(thin) (Builtin.Int64) -> @owned Name
+
+// rdar://39146527 – Ensure when thread jumping from bb4 to bb7 that we preserve
+// the literal string argument to int_instrprof_increment in bb8.
+
+sil @foo : $@convention(thin) (Name, String, Builtin.Int64, Builtin.Int64) -> String {
+bb0(%0 : $Name, %1 : $String, %2 : $Builtin.Int64, %3 : $Builtin.Int64):
+  %4 = integer_literal $Builtin.Int64, 0
+  %5 = integer_literal $Builtin.Int32, 0
+  %6 = integer_literal $Builtin.Int32, 1
+  %7 = integer_literal $Builtin.Int32, 2
+  %8 = integer_literal $Builtin.Int32, 3
+  %9 = string_literal utf8 "$s4Test4NameO4caseAC4CaseOvg"
+  %10 = integer_literal $Builtin.Int32, 4
+  br bb2(%2 : $Builtin.Int64)
+
+bb1:
+  %12 = string_literal utf8 "xxxx.swift:$sSK4TestAA4NameO7ElementRtzrlE09preferredC0ACSgvgAGyKXEfu_"
+  %13 = builtin "int_instrprof_increment"(%12 : $Builtin.RawPointer, %4 : $Builtin.Int64, %6 : $Builtin.Int32, %5 : $Builtin.Int32) : $()
+
+  %14 = function_ref @bar : $@convention(thin) () -> @owned String
+  %15 = apply %14() : $@convention(thin) () -> @owned String
+  br bb11(%15 : $String)
+
+bb2(%17 : $Builtin.Int64):
+  %18 = function_ref @baz : $@convention(thin) (Builtin.Int64) -> @owned Name
+  %19 = apply %18(%17) : $@convention(thin) (Builtin.Int64) -> @owned Name
+  switch_enum %19 : $Name, case #Name.short!enumelt: bb3, case #Name.longWithSingleDash!enumelt: bb4, case #Name.long!enumelt: bb5
+
+bb3(%21 : $(Character, allowingJoined: Bool)):
+  release_value %19 : $Name
+  %23 = builtin "int_instrprof_increment"(%9 : $Builtin.RawPointer, %4 : $Builtin.Int64, %10 : $Builtin.Int32, %6 : $Builtin.Int32) : $()
+  %24 = builtin "cmp_eq_Int64"(%3 : $Builtin.Int64, %2 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %24, bb1, bb6
+
+bb4(%26 : $String):
+  %27 = builtin "int_instrprof_increment"(%9 : $Builtin.RawPointer, %4 : $Builtin.Int64, %10 : $Builtin.Int32, %7 : $Builtin.Int32) : $()
+  br bb7(%19 : $Name)
+
+bb5(%29 : $String):
+  %30 = builtin "int_instrprof_increment"(%9 : $Builtin.RawPointer, %4 : $Builtin.Int64, %10 : $Builtin.Int32, %8 : $Builtin.Int32) : $()
+  br bb7(%0 : $Name)
+
+bb6:
+  br bb2(%3 : $Builtin.Int64)
+
+bb7(%33 : $Name):
+  // CHECK:      [[STR:%[0-9]+]] = string_literal utf8 "$s4Test4NameO11valueStringSSvg"
+  // CHECK-NEXT: builtin "int_instrprof_increment"([[STR]] : $Builtin.RawPointer
+  %34 = string_literal utf8 "$s4Test4NameO11valueStringSSvg"
+  %35 = builtin "int_instrprof_increment"(%34 : $Builtin.RawPointer, %4 : $Builtin.Int64, %10 : $Builtin.Int32, %5 : $Builtin.Int32) : $()
+  switch_enum %33 : $Name, case #Name.long!enumelt: bb8, case #Name.short!enumelt: bb9, case #Name.longWithSingleDash!enumelt: bb10
+
+bb8(%37 : $String):
+  // CHECK:      [[STR:%[0-9]+]] = string_literal utf8 "$s4Test4NameO11valueStringSSvg"
+  // CHECK-NEXT: builtin "int_instrprof_increment"([[STR]] : $Builtin.RawPointer
+  // CHECK:      [[STR:%[0-9]+]] = string_literal utf8 "$s4Test4NameO11valueStringSSvg"
+  // CHECK-NEXT: builtin "int_instrprof_increment"([[STR]] : $Builtin.RawPointer
+  %38 = builtin "int_instrprof_increment"(%34 : $Builtin.RawPointer, %4 : $Builtin.Int64, %10 : $Builtin.Int32, %6 : $Builtin.Int32) : $()
+  br bb11(%37 : $String)
+
+bb9(%40 : $(Character, allowingJoined: Bool)):
+  %41 = tuple_extract %40 : $(Character, allowingJoined: Bool), 0
+  %42 = struct_extract %41 : $Character, #Character._str
+  %43 = struct_extract %42 : $String, #String._guts
+  %44 = struct_extract %43 : $_StringGuts, #_StringGuts._object
+  %45 = struct_extract %44 : $_StringObject, #_StringObject._object
+  strong_retain %45 : $Builtin.BridgeObject
+  %47 = move_value [lexical] %41 : $Character
+  %48 = builtin "int_instrprof_increment"(%34 : $Builtin.RawPointer, %4 : $Builtin.Int64, %10 : $Builtin.Int32, %7 : $Builtin.Int32) : $()
+  %49 = struct_extract %47 : $Character, #Character._str
+  release_value %33 : $Name
+  br bb11(%49 : $String)
+
+bb10(%52 : $String):
+  %53 = builtin "int_instrprof_increment"(%34 : $Builtin.RawPointer, %4 : $Builtin.Int64, %10 : $Builtin.Int32, %8 : $Builtin.Int32) : $()
+  br bb11(%52 : $String)
+
+bb11(%55 : $String):
+  release_value %1 : $String
+  return %55 : $String
+}


### PR DESCRIPTION
Previously we could let these arguments become phi nodes when performing jump threading. This would break IRGen, as the string value must be statically known. Update SILSSAUpdater to ensure they are instead rewritten by cloning, ensuring they remain statically known.

rdar://39146527