### PR TITLE
[ModuleInterface] Print @_spiOnly imports in the private swiftinterface

### DIFF
--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -217,6 +217,26 @@ static void printImports(raw_ostream &out,
     allImportFilter |= ModuleDecl::ImportFilterKind::ImplementationOnly;
   }
 
+  /// Collect @_spiOnly imports that are not imported elsewhere publicly.
+  llvm::SmallSet<ImportedModule, 4, ImportedModule::Order> spiOnlyImportSet;
+  if (Opts.PrintSPIs) {
+    SmallVector<ImportedModule, 4> spiOnlyImports, otherImports;
+    M->getImportedModules(spiOnlyImports,
+                          ModuleDecl::ImportFilterKind::SPIOnly);
+
+    M->getImportedModules(otherImports,
+                          allImportFilter);
+    llvm::SmallSet<ImportedModule, 8, ImportedModule::Order> otherImportsSet;
+    otherImportsSet.insert(otherImports.begin(), otherImports.end());
+
+    // Rule out inconsistent imports.
+    for (auto import: spiOnlyImports)
+      if (otherImportsSet.count(import) == 0)
+        spiOnlyImportSet.insert(import);
+
+    allImportFilter |= ModuleDecl::ImportFilterKind::SPIOnly;
+  }
+
   SmallVector<ImportedModule, 8> allImports;
   M->getImportedModules(allImports, allImportFilter);
 
@@ -231,7 +251,6 @@ static void printImports(raw_ostream &out,
   SmallVector<ImportedModule, 8> publicImports;
   M->getImportedModules(publicImports, ModuleDecl::ImportFilterKind::Exported);
   llvm::SmallSet<ImportedModule, 8, ImportedModule::Order> publicImportSet;
-
   publicImportSet.insert(publicImports.begin(), publicImports.end());
 
   for (auto import : allImports) {
@@ -259,8 +278,18 @@ static void printImports(raw_ostream &out,
     if (publicImportSet.count(import))
       out << "@_exported ";
 
-    // SPI attribute on imports
     if (Opts.PrintSPIs) {
+      // An import visible in the private swiftinterface only.
+      //
+      // In the long term, we want to print this attribute for consistency and
+      // to enforce exportability analysis of generated code.
+      // For now, not printing the attribute allows us to have backwards
+      // compatible swiftinterfaces and we can live without
+      // checking the generate code for a while.
+      if (spiOnlyImportSet.count(import))
+        out << "/*@_spiOnly*/ ";
+
+      // List of imported SPI groups for local use.
       for (auto spiName : spis)
         out << "@_spi(" << spiName << ") ";
     }

--- a/test/SPI/spi_only_import_swiftinterfaces.swift
+++ b/test/SPI/spi_only_import_swiftinterfaces.swift
@@ -1,0 +1,90 @@
+/// Test the swiftinterfaces and @_spiOnly.
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// Generate dependencies
+// RUN: %target-swift-frontend -emit-module %S/Inputs/ioi_helper.swift \
+// RUN:   -module-name A_SPIOnlyImported -emit-module-path %t/A_SPIOnlyImported.swiftmodule
+// RUN: %target-swift-frontend -emit-module %t/Empty.swift \
+// RUN:   -module-name ConstantSPIOnly -emit-module-path %t/ConstantSPIOnly.swiftmodule
+// RUN: %target-swift-frontend -emit-module %t/Empty.swift \
+// RUN:   -module-name InconsistentIOI -emit-module-path %t/InconsistentIOI.swiftmodule
+// RUN: %target-swift-frontend -emit-module %t/Empty.swift \
+// RUN:   -module-name InconsistentPublic -emit-module-path %t/InconsistentPublic.swiftmodule
+// RUN: %target-swift-frontend -emit-module %t/Empty.swift \
+// RUN:   -module-name IOIImported -emit-module-path %t/IOIImported.swiftmodule
+// RUN: %target-swift-frontend -emit-module %t/Empty.swift \
+// RUN:   -module-name SPIImported -emit-module-path %t/SPIImported.swiftmodule
+
+/// Test the generated swiftinterface.
+// RUN: %target-swift-frontend -typecheck %t/FileA.swift %t/FileB.swift \
+// RUN:   -experimental-spi-only-imports \
+// RUN:   -swift-version 5 -enable-library-evolution -module-name Main -I %t \
+// RUN:   -emit-module-interface-path %t/Main.swiftinterface \
+// RUN:   -emit-private-module-interface-path %t/Main.private.swiftinterface
+// RUN: %target-swift-typecheck-module-from-interface(%t/Main.swiftinterface) -I %t
+// RUN: %target-swift-typecheck-module-from-interface(%t/Main.private.swiftinterface) \
+// RUN:   -module-name Main -I %t
+// RUN: %FileCheck -check-prefix=CHECK-PUBLIC %s < %t/Main.swiftinterface
+// RUN: %FileCheck -check-prefix=CHECK-PRIVATE %s < %t/Main.private.swiftinterface
+
+/// Test the case of a library-level=SPI where even the public swiftinterface
+/// also has SPI details.
+// RUN: %target-swift-frontend -typecheck %t/FileA.swift %t/FileB.swift \
+// RUN:   -experimental-spi-only-imports \
+// RUN:   -swift-version 5 -enable-library-evolution -module-name SPIMain -I %t \
+// RUN:   -emit-module-interface-path %t/SPIMain.swiftinterface \
+// RUN:   -emit-private-module-interface-path %t/SPIMain.private.swiftinterface \
+// RUN:   -library-level spi
+// RUN: %target-swift-typecheck-module-from-interface(%t/SPIMain.swiftinterface) -I %t
+// RUN: %target-swift-typecheck-module-from-interface(%t/SPIMain.private.swiftinterface) \
+// RUN:   -module-name SPIMain -I %t
+// RUN: %FileCheck -check-prefix=CHECK-PRIVATE %s < %t/SPIMain.swiftinterface
+// RUN: %FileCheck -check-prefix=CHECK-PRIVATE %s < %t/SPIMain.private.swiftinterface
+
+//--- Empty.swift
+//--- FileA.swift
+
+/// We don't need or want the flag in the swiftinterface
+// CHECK-PUBLIC-NOT: -experimental-spi-only-imports
+// CHECK-PRIVATE-NOT: -experimental-spi-only-imports
+
+@_spiOnly @_spi(SomeSPIGroup) import A_SPIOnlyImported
+// CHECK-PUBLIC-NOT: A_SPIOnlyImported
+// CHECK-PRIVATE: {{^}}/*@_spiOnly*/ @_spi(SomeSPIGroup) import A_SPIOnlyImported
+
+/// This is also imported as SPI only via FileB.swift
+@_spiOnly import ConstantSPIOnly
+// CHECK-PUBLIC-NOT: ConstantSPIOnly
+// CHECK-PRIVATE: {{^}}/*@_spiOnly*/ import ConstantSPIOnly
+
+/// This is also imported as SPI only via FileB.swift
+@_implementationOnly import InconsistentIOI
+// CHECK-PUBLIC-NOT: InconsistentIOI
+// CHECK-PRIVATE: {{^}}/*@_spiOnly*/ import InconsistentIOI
+
+/// This is also imported as SPI only via FileB.swift
+import InconsistentPublic
+// CHECK-PUBLIC: {{^}}import InconsistentPublic
+// CHECK-PRIVATE: {{^}}import InconsistentPublic
+
+@_implementationOnly import IOIImported
+// CHECK-PUBLIC-NOT: IOIImported
+// CHECK-PRIVATE-NOT: IOIImported
+
+@_spi(dummy) import SPIImported
+// CHECK-PUBLIC: {{^}}import SPIImported
+// CHECK-PRIVATE: @_spi{{.*}} import SPIImported
+
+@_spi(X)
+extension IOIPublicStruct {
+  public func foo() {}
+}
+// CHECK-PUBLIC-NOT: A_SPIOnlyImported.IOIPublicStruct
+// CHECK-PRIVATE: @_spi{{.*}} extension A_SPIOnlyImported.IOIPublicStruct
+
+//--- FileB.swift
+@_spiOnly import ConstantSPIOnly
+@_spiOnly import InconsistentPublic
+@_spiOnly import InconsistentIOI


### PR DESCRIPTION
Print imports marked with the `@_spiOnly` attribute in the private swiftinterface only. To preserve backwards compatibility we don't print the attribute itself in the swiftinterface so older compilers will be able to understand this new feature.

We will want to add the flag to the swiftinterface later as it will check the exportability of generated code. In most cases, I would expect the (future) exportability analysis to catch errors in the sources, and the verification of both the public and private swiftinterfaces to catch most issues in generated code.

This follows the basic setup in #60918. Next I'll add exportability diagnostics, and integration with adjacent SDK sanity checks.