### PR TITLE
CrossModuleOptimization: public global variables must not be serialized if they reference private functions/closures

### DIFF
--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -2557,6 +2557,10 @@ void SILSerializer::writeSILGlobalVar(const SILGlobalVariable &g) {
                                  (unsigned)g.isLet(),
                                  TyID, dID);
 
+  // Don't emit the initializer instructions if not marked as "serialized".
+  if (!g.isSerialized())
+    return;
+
   ValueIDs.clear();
   InstID = 0;
   unsigned ValueID = 2;

--- a/test/SILOptimizer/Inputs/cross-module/default-module.swift
+++ b/test/SILOptimizer/Inputs/cross-module/default-module.swift
@@ -27,3 +27,8 @@ public func moduleKlassMember() -> Int {
   return k.i
 }
 
+public struct ModuleStruct {
+  public static var publicFunctionPointer: (Int) -> (Int) = incrementByThree
+  public static var privateFunctionPointer: (Int) -> (Int) = { $0 }
+}
+

--- a/test/SILOptimizer/default-cmo.swift
+++ b/test/SILOptimizer/default-cmo.swift
@@ -11,6 +11,19 @@
 import Module
 import ModuleTBD
 
+// CHECK-LABEL: sil_global public_external [serialized] @$s6Module0A6StructV21publicFunctionPointeryS2icvpZ : $@callee_guaranteed (Int) -> Int = {
+// CHECK:        %0 = function_ref @$s6Module16incrementByThreeyS2iF
+
+// CHECK-LABEL: sil_global public_external @$s6Module0A6StructV22privateFunctionPointeryS2icvpZ : $@callee_guaranteed (Int) -> Int{{$}}
+
+public func callPublicFunctionPointer(_ x: Int) -> Int {
+  return Module.ModuleStruct.publicFunctionPointer(x)
+}
+
+public func callPrivateFunctionPointer(_ x: Int) -> Int {
+  return Module.ModuleStruct.privateFunctionPointer(x)
+}
+
 // CHECK-LABEL: sil @$s4Main11doIncrementyS2iF
 // CHECK-NOT:     function_ref 
 // CHECK-NOT:     apply 
@@ -73,3 +86,4 @@ public func getModuleKlassMember() -> Int {
 public func getModuleKlassMemberTBD() -> Int {
   return ModuleTBD.moduleKlassMember()
 }
+


### PR DESCRIPTION
For example:
```
public static var privateFunctionPointer: (Int) -> (Int) = { $0 }
```

Fixes a verifier crash and/or undefined symbol error

rdar://99493254
