### PR TITLE
[android] Update to LTS NDK 25b

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -404,8 +404,6 @@ set(SWIFT_ANDROID_API_LEVEL "" CACHE STRING
 
 set(SWIFT_ANDROID_NDK_PATH "" CACHE STRING
   "Path to the directory that contains the Android NDK tools that are executable on the build machine")
-set(SWIFT_ANDROID_NDK_CLANG_VERSION "12.0.9" CACHE STRING
-  "The Clang version to use when building for Android.")
 set(SWIFT_ANDROID_DEPLOY_DEVICE_PATH "" CACHE STRING
   "Path on an Android device where build products will be pushed. These are used when running the test suite against the device")
 

--- a/cmake/caches/Runtime-Android-aarch64.cmake
+++ b/cmake/caches/Runtime-Android-aarch64.cmake
@@ -23,5 +23,3 @@ set(SWIFT_SDK_ANDROID_ARCHITECTURES aarch64 CACHE STRING "")
 
 # NOTE(compnerd) this is lollipop, which seems to still have decent usage.
 set(SWIFT_ANDROID_API_LEVEL 21 CACHE STRING "")
-# NOTE(compnerd) this matches the value from the NDK r24.
-set(SWIFT_ANDROID_NDK_CLANG_VERSION 14.0.1 CACHE STRING "" FORCE)

--- a/cmake/caches/Runtime-Android-armv7.cmake
+++ b/cmake/caches/Runtime-Android-armv7.cmake
@@ -23,6 +23,3 @@ set(SWIFT_SDK_ANDROID_ARCHITECTURES armv7 CACHE STRING "")
 
 # NOTE(compnerd) this is lollipop, which seems to still have decent usage.
 set(SWIFT_ANDROID_API_LEVEL 21 CACHE STRING "")
-# NOTE(compnerd) this matches the value from the NDK r24.
-set(SWIFT_ANDROID_NDK_CLANG_VERSION 14.0.1 CACHE STRING "" FORCE)
-

--- a/docs/Android.md
+++ b/docs/Android.md
@@ -36,7 +36,7 @@ To follow along with this guide, you'll need:
    instructions in the Swift project README.
 2. The latest build of the Swift compiler for your Linux distro, available at
    https://www.swift.org/download/ or sometimes your distro package manager.
-3. The latest version of the Android LTS NDK (r23c at the time of this writing),
+3. The latest version of the Android LTS NDK (r25b at the time of this writing),
    available to download here:
    https://developer.android.com/ndk/downloads
 4. An Android device with remote debugging enabled or the emulator. We require
@@ -54,7 +54,7 @@ and the prebuilt Swift toolchain (add --skip-early-swift-driver if you already
 have a Swift toolchain in your path):
 
 ```
-$ NDK_PATH=path/to/android-ndk-r23c
+$ NDK_PATH=path/to/android-ndk-r25b
 $ SWIFT_PATH=path/to/swift-DEVELOPMENT-SNAPSHOT-2022-05-31-a-ubuntu20.04/usr/bin
 $ git checkout swift-DEVELOPMENT-SNAPSHOT-2022-05-31-a
 $ utils/build-script \
@@ -83,7 +83,7 @@ Then use the standalone Swift stdlib from the previous step to compile a Swift
 source file, targeting Android:
 
 ```
-$ NDK_PATH="path/to/android-ndk-r23c"
+$ NDK_PATH="path/to/android-ndk-r25b"
 $ SWIFT_PATH=path/to/swift-DEVELOPMENT-SNAPSHOT-2022-05-31-a-ubuntu20.04/usr/bin
 $ $SWIFT_PATH/swiftc \                                               # The prebuilt Swift compiler you downloaded
                                                                      # The location of the tools used to build Android binaries
@@ -133,7 +133,7 @@ $ adb push build/Ninja-ReleaseAssert/swift-linux-x86_64/lib/swift/android/libBlo
 In addition, you'll also need to copy the Android NDK's libc++:
 
 ```
-$ adb push /path/to/android-ndk-r23c/sources/cxx-stl/llvm-libc++/libs/arm64-v8a/libc++_shared.so /data/local/tmp
+$ adb push /path/to/android-ndk-r25b/sources/cxx-stl/llvm-libc++/libs/arm64-v8a/libc++_shared.so /data/local/tmp
 ```
 
 Finally, you'll need to copy the `hello` executable you built in the
@@ -176,7 +176,7 @@ $ utils/build-script \
   -R \                               # Build in ReleaseAssert mode.
   -T \                               # Run all tests, including on the Android device (add --host-test to only run Android tests on the Linux host).
   --android \                        # Build for Android.
-  --android-ndk ~/android-ndk-r23c \  # Path to an Android NDK.
+  --android-ndk ~/android-ndk-r25b \  # Path to an Android NDK.
   --android-arch aarch64 \           # Optionally specify Android architecture, alternately armv7
   --android-api-level 21
 ```

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -464,7 +464,8 @@ function(_add_target_variant_link_flags)
     # We need to add the math library, which is linked implicitly by libc++
     list(APPEND result "-lm")
     if(NOT "${SWIFT_ANDROID_NDK_PATH}" STREQUAL "")
-      list(APPEND result "-resource-dir=${SWIFT_SDK_ANDROID_ARCH_${LFLAGS_ARCH}_PATH}/../lib64/clang/${SWIFT_ANDROID_NDK_CLANG_VERSION}")
+      file(GLOB RESOURCE_DIR ${SWIFT_SDK_ANDROID_ARCH_${LFLAGS_ARCH}_PATH}/../lib64/clang/*)
+      list(APPEND result "-resource-dir=${RESOURCE_DIR}")
     endif()
 
     # link against the custom C++ library


### PR DESCRIPTION
Also, remove `SWIFT_ANDROID_NDK_CLANG_VERSION` and just extract the resource directory from the NDK using `file(GLOB)`.

There was never any point in this CMake variable, which [I simply replaced the prior GCC version variable with last year](https://github.com/apple/swift/pull/39921/files#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR294), when the NDK dumped binutils for the LLVM equivalents. However, while that previous GCC version never changed, this clang version changes with every NDK, but there's only ever one clang version per NDK, so it's better to simply extract that.

@compnerd, you suggested extracting this clang version before, please review.

@drodriguez, unlike previous NDK version bumps that required updating the community CI, this should extract the clang version for prior NDKs like 23c just fine, so updating to the latest LTS NDK 25b on the CI should not be necessary with this pull. You can put that off for later.