### PR TITLE
[Parse] Fix a crash when there is nothing after the prefix/postfix operator colon

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -8745,8 +8745,10 @@ Parser::parseDeclOperatorImpl(SourceLoc OperatorLoc, Identifier Name,
             .fixItRemove({typesStartLoc, typesEndLoc});
     } else {
       if (isPrefix || isPostfix) {
+        // If we have nothing after the colon, then just remove the colon.
+        auto endLoc = groupLoc.isValid() ? groupLoc : colonLoc;
         diagnose(colonLoc, diag::precedencegroup_not_infix)
-            .fixItRemove({colonLoc, groupLoc});
+            .fixItRemove({colonLoc, endLoc});
       }
       // Nothing to complete here, simply consume the token.
       if (Tok.is(tok::code_complete))

--- a/test/Parse/operator_decl.swift
+++ b/test/Parse/operator_decl.swift
@@ -110,3 +110,8 @@ protocol Proto {}
 infix operator *<*< : F, Proto
 // expected-error@-1 {{consecutive statements on a line must be separated by ';'}}
 // expected-error@-2 {{expected expression}}
+
+// https://github.com/apple/swift/issues/60932
+
+// expected-error@+2 {{expected precedence group name after ':' in operator declaration}}
+postfix operator ++: // expected-error {{only infix operators may declare a precedence}} {{20-21=}}


### PR DESCRIPTION
Resolves https://github.com/apple/swift/issues/60932