### PR TITLE
Self parameters can be @_noImplicitCopy or @_eagerMove.

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -698,7 +698,7 @@ SIMPLE_DECL_ATTR(_noImplicitCopy, NoImplicitCopy,
   UserInaccessible |
   ABIStableToAdd | ABIBreakingToRemove |
   APIStableToAdd | APIBreakingToRemove |
-  OnParam | OnVar,
+  OnFunc | OnParam | OnVar,
   122)
 
 SIMPLE_DECL_ATTR(_noLocks, NoLocks,

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -666,7 +666,7 @@ SIMPLE_DECL_ATTR(_eagerMove, EagerMove,
   UserInaccessible |
   ABIStableToAdd | ABIStableToRemove |
   APIStableToAdd | APIStableToRemove |
-  OnParam | OnVar | OnNominalType,
+  OnFunc | OnParam | OnVar | OnNominalType,
   117)
 
 CONTEXTUAL_SIMPLE_DECL_ATTR(distributed, DistributedActor,
@@ -679,7 +679,7 @@ SIMPLE_DECL_ATTR(_lexical, Lexical,
   UserInaccessible |
   ABIStableToAdd | ABIStableToRemove |
   APIStableToAdd | APIStableToRemove |
-  OnParam | OnVar | OnNominalType,
+  OnFunc | OnParam | OnVar | OnNominalType,
   119)
 
 SIMPLE_DECL_ATTR(_assemblyVision, EmitAssemblyVisionRemarks,

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -986,6 +986,15 @@ public:
   /// Check if this is a declaration defined at the top level of the Swift module
   bool isStdlibDecl() const;
 
+  LifetimeAnnotation getLifetimeAnnotation() const {
+    auto &attrs = getAttrs();
+    if (attrs.hasAttribute<EagerMoveAttr>())
+      return LifetimeAnnotation::EagerMove;
+    if (attrs.hasAttribute<LexicalAttr>())
+      return LifetimeAnnotation::Lexical;
+    return LifetimeAnnotation::None;
+  }
+
   bool isNoImplicitCopy() const {
     return getAttrs().hasAttribute<NoImplicitCopyAttr>();
   }
@@ -2718,15 +2727,6 @@ public:
   /// 'func foo(Int) -> () -> Self?'.
   GenericParameterReferenceInfo findExistentialSelfReferences(
       Type baseTy, bool treatNonResultCovariantSelfAsInvariant) const;
-
-  LifetimeAnnotation getLifetimeAnnotation() const {
-    auto &attrs = getAttrs();
-    if (attrs.hasAttribute<EagerMoveAttr>())
-      return LifetimeAnnotation::EagerMove;
-    if (attrs.hasAttribute<LexicalAttr>())
-      return LifetimeAnnotation::Lexical;
-    return LifetimeAnnotation::None;
-  }
 };
 
 /// This is a common base class for declarations which declare a type.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -986,6 +986,10 @@ public:
   /// Check if this is a declaration defined at the top level of the Swift module
   bool isStdlibDecl() const;
 
+  bool isNoImplicitCopy() const {
+    return getAttrs().hasAttribute<NoImplicitCopyAttr>();
+  }
+
   AvailabilityContext getAvailabilityForLinkage() const;
 
   /// Whether this declaration or one of its outer contexts has the
@@ -5781,10 +5785,6 @@ public:
 
   void setDefaultArgumentKind(ArgumentAttrs K) {
     setDefaultArgumentKind(K.argumentKind);
-  }
-
-  bool isNoImplicitCopy() const {
-    return getAttrs().hasAttribute<NoImplicitCopyAttr>();
   }
 
   /// Whether this parameter has a default argument expression available.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3209,6 +3209,8 @@ ERROR(reasync_without_async_parameter,none,
 ERROR(inherits_executor_without_async,none,
       "non-async functions cannot inherit an executor", ())
 
+ERROR(lifetime_invalid_global_scope,none, "%0 is only valid on methods",
+      (DeclAttribute))
 ERROR(eagermove_and_lexical_combined,none,
       "@_eagerMove and @_lexical attributes are alternate styles of lifetimes "
       "and can't be combined", ())

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -979,7 +979,7 @@ namespace {
         break;
       }
 
-      if (P->getAttrs().hasAttribute<NoImplicitCopyAttr>())
+      if (P->isNoImplicitCopy())
         OS << " noImplicitCopy";
 
       if (P->getDefaultArgumentKind() != DefaultArgumentKind::None) {

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -450,7 +450,7 @@ public:
   LetValueInitialization(VarDecl *vd, SILGenFunction &SGF) : vd(vd) {
     const TypeLowering *lowering = nullptr;
     if (SGF.getASTContext().LangOpts.Features.count(Feature::MoveOnly) &&
-        vd->getAttrs().hasAttribute<NoImplicitCopyAttr>()) {
+        vd->isNoImplicitCopy()) {
       lowering = &SGF.getTypeLowering(
           SILMoveOnlyWrappedType::get(vd->getType()->getCanonicalType()));
     } else {
@@ -487,8 +487,7 @@ public:
     // Make sure that we have a non-address only type when binding a
     // @_noImplicitCopy let.
     if (SGF.getASTContext().LangOpts.Features.count(Feature::MoveOnly) &&
-        lowering->isAddressOnly() &&
-        vd->getAttrs().hasAttribute<NoImplicitCopyAttr>()) {
+        lowering->isAddressOnly() && vd->isNoImplicitCopy()) {
       auto d = diag::noimplicitcopy_used_on_generic_or_existential;
       diagnose(SGF.getASTContext(), vd->getLoc(), d);
     }
@@ -569,8 +568,7 @@ public:
       // ... and we don't have a no implicit copy trivial type, just return
       // value.
       if (!SGF.getASTContext().LangOpts.Features.count(Feature::MoveOnly) ||
-          !vd->getAttrs().hasAttribute<NoImplicitCopyAttr>() ||
-          !value->getType().isTrivial(SGF.F))
+          !vd->isNoImplicitCopy() || !value->getType().isTrivial(SGF.F))
         return value;
 
       // Otherwise, we have a no implicit copy trivial type, so wrap it in the
@@ -626,7 +624,7 @@ public:
 
     // Otherwise, if we do not have a no implicit copy variable, just follow
     // the "normal path": perform a lexical borrow if the lifetime is lexical.
-    if (!vd->getAttrs().hasAttribute<NoImplicitCopyAttr>()) {
+    if (!vd->isNoImplicitCopy()) {
       if (SGF.F.getLifetime(vd, value->getType()).isLexical())
         return SGF.B.createBeginBorrow(PrologueLoc, value, /*isLexical*/ true);
       else

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -355,8 +355,19 @@ struct ArgumentInitHelper {
     SILLocation loc(pd);
     loc.markAsPrologue();
 
-    ManagedValue argrv = makeArgument(ty, pd->isInOut(), pd->isNoImplicitCopy(),
-                                      pd->getLifetimeAnnotation(), parent, loc);
+    LifetimeAnnotation lifetimeAnnotation = LifetimeAnnotation::None;
+    bool isNoImplicitCopy = false;
+    if (pd->isSelfParameter()) {
+      if (auto *afd = dyn_cast<AbstractFunctionDecl>(pd->getDeclContext())) {
+        lifetimeAnnotation = afd->getLifetimeAnnotation();
+      }
+    } else {
+      lifetimeAnnotation = pd->getLifetimeAnnotation();
+      isNoImplicitCopy = pd->isNoImplicitCopy();
+    }
+
+    ManagedValue argrv = makeArgument(ty, pd->isInOut(), isNoImplicitCopy,
+                                      lifetimeAnnotation, parent, loc);
 
     if (pd->isInOut()) {
       assert(argrv.getType().isAddress() && "expected inout to be address");

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -360,6 +360,7 @@ struct ArgumentInitHelper {
     if (pd->isSelfParameter()) {
       if (auto *afd = dyn_cast<AbstractFunctionDecl>(pd->getDeclContext())) {
         lifetimeAnnotation = afd->getLifetimeAnnotation();
+        isNoImplicitCopy = afd->isNoImplicitCopy();
       }
     } else {
       lifetimeAnnotation = pd->getLifetimeAnnotation();

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -343,6 +343,19 @@ void AttributeChecker::visitNoImplicitCopyAttr(NoImplicitCopyAttr *attr) {
     return;
   }
 
+  if (auto *funcDecl = dyn_cast<FuncDecl>(D)) {
+    if (visitLifetimeAttr(attr))
+      return;
+
+    // We only handle non-lvalue arguments today.
+    if (funcDecl->isMutating()) {
+      auto error = diag::noimplicitcopy_attr_valid_only_on_local_let_params;
+      diagnoseAndRemoveAttr(attr, error);
+      return;
+    }
+    return;
+  }
+
   auto *dc = D->getDeclContext();
 
   // If we have a param decl that is marked as no implicit copy, change our

--- a/test/SILGen/lexical_lifetime.swift
+++ b/test/SILGen/lexical_lifetime.swift
@@ -129,6 +129,24 @@ func lexical_borrow_arg_trivial(_ trivial: Trivial) {
   use_generic(trivial)
 }
 
+extension C {
+// CHECK-LABEL: sil hidden [ossa] @lexical_method_attr : $@convention(method) (@owned C) -> () {
+// CHECK:       {{bb[0-9]+}}({{%[^,]+}} : @_lexical @owned $C):
+// CHECK-LABEL: } // end sil function 'lexical_method_attr'
+  @_silgen_name("lexical_method_attr")
+  @_lexical
+  __consuming
+  func lexical_method_attr() {}
+
+// CHECK-LABEL: sil hidden [ossa] @eagermove_method_attr : $@convention(method) (@owned C) -> () {
+// CHECK:       {{bb[0-9]+}}({{%[^,]+}} : @_eagerMove @owned $C):
+// CHECK-LABEL: } // end sil function 'eagermove_method_attr'
+  @_silgen_name("eagermove_method_attr")
+  @_eagerMove
+  __consuming
+  func eagermove_method_attr() {}
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Test                                                                       }}
 ////////////////////////////////////////////////////////////////////////////////

--- a/test/SILGen/noimplicitcopy_attr.swift
+++ b/test/SILGen/noimplicitcopy_attr.swift
@@ -18,3 +18,13 @@ public func arguments(@_noImplicitCopy _ x: Klass) {
 public func argumentsOwned(@_noImplicitCopy _ x: __owned Klass) {
     x.doSomething()
 }
+
+extension Klass {
+// CHECK-LABEL: sil hidden [ossa] @noimplicitcopy_method_attr : $@convention(method) (@owned Klass) -> () {
+// CHECK:       {{bb[0-9]+}}({{%[^,]+}} : @noImplicitCopy @owned $Klass):
+// CHECK-LABEL: } // end sil function 'noimplicitcopy_method_attr'
+  @_silgen_name("noimplicitcopy_method_attr")
+  @_noImplicitCopy
+  __consuming
+  func noimplicitcopy_method_attr() {}
+}

--- a/test/attr/lexical.swift
+++ b/test/attr/lexical.swift
@@ -15,6 +15,20 @@ func bar(@_lexical _ s: S) {} // okay
 
 func baz(@_eagerMove _ c: C) {} // okay
 
+@_eagerMove // expected-error {{@_eagerMove is only valid on methods}}
+func bazzoo(_ c: C) {}
+
+@_lexical // expected-error {{@_lexical is only valid on methods}}
+func bazzoozoo(_ c: C) {}
+
+extension C {
+  @_eagerMove
+  func pazzoo() {}
+
+  @_lexical
+  func pazzoozoo() {}
+}
+
 struct S2 {
   @_eagerMove let c: C // okay
   @_lexical let e: E // okay

--- a/test/attr/noimplicitcopy.swift
+++ b/test/attr/noimplicitcopy.swift
@@ -1,0 +1,7 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-move-only
+
+struct S {
+  func bar(@_noImplicitCopy s: S) {} // okay
+  @_noImplicitCopy func foo(s: S) {} // okay
+  @_noImplicitCopy mutating func nopers() {} // expected-error {{'@_noImplicitCopy' attribute can only be applied to local lets and params}}
+}


### PR DESCRIPTION
Expand the support for annotating parameters `@_noImplicitCopy` and `@_eagerMove` to include the implicit `self` parameter of methods.  Spell this as an annotation on the method itself.

