### PR TITLE
[Dependency Scanner] Diagnose failure to find a module

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -989,7 +989,8 @@ public:
       bool isUnderlyingClangModule,
       ModuleDependenciesCache &cache,
       InterfaceSubContextDelegate &delegate,
-      bool cacheOnly = false);
+      bool cacheOnly = false,
+      llvm::Optional<std::pair<std::string, swift::ModuleDependenciesKind>> dependencyOf = None);
 
   /// Retrieve the module dependencies for the Swift module with the given name.
   Optional<ModuleDependencies> getSwiftModuleDependencies(

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1641,6 +1641,14 @@ ERROR(originally_definedin_must_not_before_available_version,none,
 ERROR(alignment_not_power_of_two,none,
       "alignment value must be a power of two", ())
 
+// Dependency Scanning
+ERROR(dependency_scan_module_not_found, none, "Unable to find module dependency: '%0'", (StringRef))
+NOTE(dependency_as_imported_by_main_module,none,
+     "a dependency of main module '%0'", (StringRef))
+NOTE(dependency_as_imported_by, none,
+     "a dependency of %select{Swift|Clang}2 module '%0': '%1'", (StringRef, StringRef, bool))
+ERROR(clang_dependency_scan_error, none, "Clang dependency scanner failure: %0", (StringRef))
+
 // Enum annotations
 ERROR(indirect_case_without_payload,none,
       "enum case %0 without associated value cannot be 'indirect'", (Identifier))

--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -606,6 +606,9 @@ private:
   /// `clangModuleDependencies` for Clang dependencies accimulated during
   /// the current scanning action.
   ModuleDependenciesKindRefMap ModuleDependenciesMap;
+  
+  /// Name of the module under scan
+  StringRef mainScanModuleName;
 
   /// Discovered Clang modules are only cached locally.
   llvm::StringMap<ModuleDependenciesVector> clangModuleDependencies;
@@ -640,7 +643,8 @@ private:
                    Optional<ModuleDependenciesKind> kind) const;
 
 public:
-  ModuleDependenciesCache(GlobalModuleDependenciesCache &globalCache);
+  ModuleDependenciesCache(GlobalModuleDependenciesCache &globalCache,
+                          StringRef mainScanModuleName);
   ModuleDependenciesCache(const ModuleDependenciesCache &) = delete;
   ModuleDependenciesCache &operator=(const ModuleDependenciesCache &) = delete;
   virtual ~ModuleDependenciesCache() { destroyClangImpl(); }
@@ -694,6 +698,10 @@ public:
 
   const std::vector<ModuleDependencyID> &getAllSourceModules() const {
     return globalCache.getAllSourceModules();
+  }
+  
+  StringRef getMainModuleName() const {
+    return mainScanModuleName;
   }
 };
 

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -531,8 +531,9 @@ ModuleDependenciesCache::getDependencyReferencesMap(
 }
 
 ModuleDependenciesCache::ModuleDependenciesCache(
-    GlobalModuleDependenciesCache &globalCache)
-    : globalCache(globalCache) {
+    GlobalModuleDependenciesCache &globalCache,
+    StringRef mainScanModuleName)
+    : globalCache(globalCache), mainScanModuleName(mainScanModuleName) {
   for (auto kind = ModuleDependenciesKind::FirstKind;
        kind != ModuleDependenciesKind::LastKind; ++kind) {
     ModuleDependenciesMap.insert(

--- a/lib/DependencyScan/DependencyScanningTool.cpp
+++ b/lib/DependencyScan/DependencyScanningTool.cpp
@@ -73,7 +73,8 @@ DependencyScanningTool::getDependencies(
   auto Instance = std::move(*InstanceOrErr);
 
   // Local scan cache instance, wrapping the shared global cache.
-  ModuleDependenciesCache cache(*SharedCache);
+  ModuleDependenciesCache cache(*SharedCache,
+                                Instance->getMainModule()->getNameStr());
   // Execute the scanning action, retrieving the in-memory result
   auto DependenciesOrErr = performModuleScan(*Instance.get(), cache);
   if (DependenciesOrErr.getError())
@@ -113,7 +114,8 @@ DependencyScanningTool::getDependencies(
   auto Instance = std::move(*InstanceOrErr);
 
   // Local scan cache instance, wrapping the shared global cache.
-  ModuleDependenciesCache cache(*SharedCache);
+  ModuleDependenciesCache cache(*SharedCache,
+                                Instance->getMainModule()->getNameStr());
   auto BatchScanResults = performBatchModuleScan(
       *Instance.get(), cache, VersionedPCMInstanceCacheCache.get(),
       Saver, BatchInput);

--- a/test/ScanDependencies/Inputs/Swift/P.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/P.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name P
+import Y
+public func funcP() { }

--- a/test/ScanDependencies/Inputs/Swift/Y.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/Y.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name Y
+import Z
+public func funcY() { }

--- a/test/ScanDependencies/Inputs/Swift/Z.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/Z.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name Z
+import missing_module
+public func funcZ() { }

--- a/test/ScanDependencies/error_path.swift
+++ b/test/ScanDependencies/error_path.swift
@@ -1,0 +1,14 @@
+// expected-error@-1 {{Unable to find module dependency: 'missing_module'}}
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/clang-module-cache
+// REQUIRES: objc_interop
+
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 2>&1 | %FileCheck %s
+
+import P
+
+// CHECK: <unknown>:0: error: Unable to find module dependency: 'missing_module'
+// CHECK: <unknown>:0: note: a dependency of Swift module 'Z': '{{.*}}/Inputs/Swift/Z.swiftinterface'
+// CHECK: <unknown>:0: note: a dependency of Swift module 'Y': '{{.*}}/Inputs/Swift/Y.swiftinterface'
+// CHECK: <unknown>:0: note: a dependency of Swift module 'P': '{{.*}}/Inputs/Swift/P.swiftinterface'
+// CHECK: <unknown>:0: note: a dependency of main module 'deps'


### PR DESCRIPTION
And produce a dependency path from the missing dependency to the main module being scanned.
For example, if the scanned module `deps` depends on module `X`, which depends on module `Y`, which depends on module `Z`, which depends on module `missing_module` where the scanner fails to located the `missing_module` module, we can expect the following diagnostics:

```
<unknown>:0: error: Unable to find module dependency: 'missing_module'
<unknown>:0: note: a dependency of Swift module 'Z': '{{.*}}/Z.swiftinterface'
<unknown>:0: note: a dependency of Swift module 'Y': '{{.*}}/Y.swiftinterface'
<unknown>:0: note: a dependency of Swift module 'X': '{{.*}}/X.swiftinterface'
<unknown>:0: note: a dependency of main module 'deps'
```