### PR TITLE
[Sema] TypeWrappers: Disable memberwise synthesis if type has designa…

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1255,10 +1255,14 @@ void TypeChecker::addImplicitConstructors(NominalTypeDecl *decl) {
     return;
 
   if (!shouldAttemptInitializerSynthesis(decl)) {
-    // If declaration is type wrapped, synthesize a
-    // special initializer that would instantiate storage.
-    if (decl->hasTypeWrapper())
-      (void)decl->getTypeWrapperInitializer();
+    if (decl->hasTypeWrapper()) {
+      auto &ctx = decl->getASTContext();
+      // If declaration is type wrapped and there are no
+      // designated initializers, synthesize a special
+      // memberwise initializer that would instantiate `$_storage`.
+      if (!hasUserDefinedDesignatedInit(ctx.evaluator, decl))
+        (void)decl->getTypeWrapperInitializer();
+    }
 
     decl->setAddedImplicitInitializers();
     return;

--- a/test/Interpreter/Inputs/type_wrapper_defs.swift
+++ b/test/Interpreter/Inputs/type_wrapper_defs.swift
@@ -136,3 +136,13 @@ public struct PersonWithUnmanagedTest {
 
   @PropWrapper public var favoredColor: String = "red"
 }
+
+@Wrapper
+public class ClassWithDesignatedInit {
+  public var a: Int
+  @PropWrapperWithoutInit public var b: [Int]
+
+  public init(a: Int, b: [Int] = [1, 2, 3]) {
+    $_storage = .init(memberwise: $Storage(a: 42, _b: PropWrapperWithoutInit(value: b)))
+  }
+}

--- a/test/Interpreter/type_wrappers.swift
+++ b/test/Interpreter/type_wrappers.swift
@@ -381,3 +381,30 @@ do {
   // CHECK: in getter
   // CHECK-NEXT: yellow
 }
+
+do {
+  var test = ClassWithDesignatedInit(a: 42)
+
+  print(test.a)
+  // CHECK: in getter
+  // CHECK-NEXT: 42
+
+  print(test.b)
+  // CHECK: in getter
+  // CHECK-NEXT: [1, 2, 3]
+
+  test.a = 0
+  // CHECK: in setter => 0
+
+  test.b = [42]
+  // CHECK: in getter
+  // CHECK-NEXT: in setter => PropWrapperWithoutInit<Array<Int>>(value: [42])
+
+  print(test.a)
+  // CHECK: in getter
+  // CHECK-NEXT: 0
+
+  print(test.b)
+  // CHECK: in getter
+  // CHECK-NEXT: [42]
+}


### PR DESCRIPTION
…ted init

If type has any user-defined designated initializers, let's not
synthesize a special memberwise initializer.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
