### PR TITLE
[SourceKit] Fix typo in SwiftSourceDocInfo.cpp

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -1286,7 +1286,7 @@ static bool passNameInfoForDecl(ResolvedCursorInfo CursorInfo,
   auto *VD = CursorInfo.ValueD;
 
   // If the given name is not a function name, and the cursor points to
-  // a contructor call, we use the type declaration instead of the init
+  // a constructor call, we use the type declaration instead of the init
   // declaration to translate the name.
   if (Info.ArgNames.empty() && !Info.IsZeroArgSelector) {
     if (auto *TD = CursorInfo.CtorTyRef) {


### PR DESCRIPTION
contructor -> constructor
