### PR TITLE
[AST] Introduce explicit actions for ASTWalker

### DIFF
--- a/include/swift/AST/TypeDeclFinder.h
+++ b/include/swift/AST/TypeDeclFinder.h
@@ -66,7 +66,8 @@ class TypeReprIdentFinder : public ASTWalker {
   /// The function to call when a ComponentIdentTypeRepr is seen.
   llvm::function_ref<bool(const ComponentIdentTypeRepr *)> Callback;
 
-  bool walkToTypeReprPost(TypeRepr *TR) override;
+  PostWalkAction walkToTypeReprPost(TypeRepr *TR) override;
+
 public:
   explicit TypeReprIdentFinder(
       llvm::function_ref<bool(const ComponentIdentTypeRepr *)> callback)

--- a/include/swift/IDE/SourceEntityWalker.h
+++ b/include/swift/IDE/SourceEntityWalker.h
@@ -54,6 +54,7 @@ namespace swift {
 /// call will *not* receive a \c walkTo*Post call.
 /// If \c walkTo*Post returns \c true, the traversal continues.
 class SourceEntityWalker {
+  // TODO: Switch to using explicit ASTWalker actions.
 public:
   /// Walks the provided source file.
   /// \returns true if traversal was aborted, false otherwise.

--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -284,18 +284,18 @@ class NameMatcher: public ASTWalker {
   bool handleCustomAttrs(Decl *D);
   ArgumentList *getApplicableArgsFor(Expr* E);
 
-  std::pair<bool, Expr*> walkToExprPre(Expr *E) override;
-  Expr* walkToExprPost(Expr *E) override;
-  bool walkToDeclPre(Decl *D) override;
-  bool walkToDeclPost(Decl *D) override;
-  std::pair<bool, Stmt*> walkToStmtPre(Stmt *S) override;
-  Stmt* walkToStmtPost(Stmt *S) override;
-  bool walkToTypeReprPre(TypeRepr *T) override;
-  bool walkToTypeReprPost(TypeRepr *T) override;
-  std::pair<bool, Pattern*> walkToPatternPre(Pattern *P) override;
+  PreWalkResult<Expr *> walkToExprPre(Expr *E) override;
+  PostWalkResult<Expr *> walkToExprPost(Expr *E) override;
+  PreWalkAction walkToDeclPre(Decl *D) override;
+  PostWalkAction walkToDeclPost(Decl *D) override;
+  PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override;
+  PostWalkResult<Stmt *> walkToStmtPost(Stmt *S) override;
+  PreWalkAction walkToTypeReprPre(TypeRepr *T) override;
+  PostWalkAction walkToTypeReprPost(TypeRepr *T) override;
+  PreWalkResult<Pattern *> walkToPatternPre(Pattern *P) override;
   bool shouldWalkIntoGenericParams() override { return true; }
 
-  std::pair<bool, ArgumentList *>
+  PreWalkResult<ArgumentList *>
   walkToArgumentListPre(ArgumentList *ArgList) override;
 
   // FIXME: Remove this

--- a/include/swift/Sema/CompletionContextFinder.h
+++ b/include/swift/Sema/CompletionContextFinder.h
@@ -64,9 +64,9 @@ public:
     InitialDC->walkContext(*this);
   }
 
-  std::pair<bool, Expr *> walkToExprPre(Expr *E) override;
+  PreWalkResult<Expr *> walkToExprPre(Expr *E) override;
 
-  Expr *walkToExprPost(Expr *E) override;
+  PostWalkResult<Expr *> walkToExprPost(Expr *E) override;
 
   /// Check whether code completion expression is located inside of a
   /// multi-statement closure.

--- a/lib/APIDigester/ModuleAnalyzerNodes.cpp
+++ b/lib/APIDigester/ModuleAnalyzerNodes.cpp
@@ -2387,16 +2387,17 @@ class ConstExtractor: public ASTWalker {
     }
     return false;
   }
-  std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+  PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
     if (E->isSemanticallyConstExpr()) {
       record(E, E);
-      return { false, E };
+      return Action::SkipChildren(E);
     }
     if (handleSimpleReference(E)) {
-      return { false, E };
+      return Action::SkipChildren(E);
     }
-    return { true, E };
+    return Action::Continue(E);
   }
+
 public:
   ConstExtractor(SDKContext &SCtx, ASTContext &Ctx): SCtx(SCtx),
     SM(Ctx.SourceMgr) {}

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -108,33 +108,39 @@ public:
       ClosureFinder(ScopeCreator &scopeCreator, ASTScopeImpl *parent)
           : scopeCreator(scopeCreator), parent(parent) {}
 
-      std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+      PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
         if (auto *closure = dyn_cast<ClosureExpr>(E)) {
           scopeCreator
               .constructExpandAndInsert<ClosureParametersScope>(
                   parent, closure);
-          return {false, E};
+          return Action::SkipChildren(E);
         }
         if (auto *capture = dyn_cast<CaptureListExpr>(E)) {
           scopeCreator
               .constructExpandAndInsert<CaptureListScope>(
                   parent, capture);
-          return {false, E};
+          return Action::SkipChildren(E);
         }
-        return {true, E};
+        return Action::Continue(E);
       }
-      std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
+      PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
         if (isa<BraceStmt>(S)) { // closures hidden in here
-          return {true, S};
+          return Action::Continue(S);
         }
-        return {false, S};
+        return Action::SkipChildren(S);
       }
-      std::pair<bool, Pattern *> walkToPatternPre(Pattern *P) override {
-        return {false, P};
+      PreWalkResult<Pattern *> walkToPatternPre(Pattern *P) override {
+        return Action::SkipChildren(P);
       }
-      bool walkToDeclPre(Decl *D) override { return false; }
-      bool walkToTypeReprPre(TypeRepr *T) override { return false; }
-      bool walkToParameterListPre(ParameterList *PL) override { return false; }
+      PreWalkAction walkToDeclPre(Decl *D) override {
+        return Action::SkipChildren();
+      }
+      PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
+        return Action::SkipChildren();
+      }
+      PreWalkAction walkToParameterListPre(ParameterList *PL) override {
+        return Action::SkipChildren();
+      }
     };
 
     expr->walk(ClosureFinder(*this, parent));

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1237,53 +1237,97 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
 
 #define TYPEREPR(Id, Parent) bool visit##Id##TypeRepr(Id##TypeRepr *T);
 #include "swift/AST/TypeReprNodes.def"
-  
-  bool visitParameterList(ParameterList *PL) {
-    if (!Walker.walkToParameterListPre(PL))
-      return false;
-    
-    for (auto P : *PL) {
-      // Walk each parameter's decl and typeloc and default value.
-      if (doIt(P))
-        return true;
-    }
 
-    return Walker.walkToParameterListPost(PL);
+  using Action = ASTWalker::Action;
+
+  using PreWalkAction = ASTWalker::PreWalkAction;
+  using PostWalkAction = ASTWalker::PostWalkAction;
+
+  template <typename T>
+  using PreWalkResult = ASTWalker::PreWalkResult<T>;
+
+  template <typename T>
+  using PostWalkResult = ASTWalker::PostWalkResult<T>;
+
+  bool traverse(PreWalkAction Pre, llvm::function_ref<bool(void)> VisitChildren,
+                llvm::function_ref<PostWalkAction(void)> WalkPost) {
+    switch (Pre.Action) {
+    case PreWalkAction::Stop:
+      return true;
+    case PreWalkAction::SkipChildren:
+      return false;
+    case PreWalkAction::Continue:
+      break;
+    }
+    if (VisitChildren())
+      return true;
+    switch (WalkPost().Action) {
+    case PostWalkAction::Stop:
+      return true;
+    case PostWalkAction::Continue:
+      return false;
+    }
+    llvm_unreachable("Unhandled case in switch!");
   }
-  
+
+  template <typename T>
+  T *traverse(PreWalkResult<T *> Pre,
+              llvm::function_ref<T *(T *)> VisitChildren,
+              llvm::function_ref<PostWalkResult<T *>(T *)> WalkPost) {
+    switch (Pre.Action.Action) {
+    case PreWalkAction::Stop:
+      return nullptr;
+    case PreWalkAction::SkipChildren:
+      assert(*Pre.Value && "Use Action::Stop instead of returning nullptr");
+      return *Pre.Value;
+    case PreWalkAction::Continue:
+      break;
+    }
+    assert(*Pre.Value && "Use Action::Stop instead of returning nullptr");
+    auto Value = VisitChildren(*Pre.Value);
+    if (!Value)
+      return nullptr;
+
+    auto Post = WalkPost(Value);
+    switch (Post.Action.Action) {
+    case PostWalkAction::Stop:
+      return nullptr;
+    case PostWalkAction::Continue:
+      assert(*Post.Value && "Use Action::Stop instead of returning nullptr");
+      return *Post.Value;
+    }
+    llvm_unreachable("Unhandled case in switch!");
+  }
+
+  bool visitParameterList(ParameterList *PL) {
+    return traverse(
+        Walker.walkToParameterListPre(PL),
+        [&]() {
+          for (auto P : *PL) {
+            // Walk each parameter's decl and typeloc and default value.
+            if (doIt(P))
+              return true;
+          }
+          return false;
+        },
+        [&]() { return Walker.walkToParameterListPost(PL); });
+  }
+
 public:
   Traversal(ASTWalker &walker) : Walker(walker) {}
 
   Expr *doIt(Expr *E) {
-    // Do the pre-order visitation.  If it returns false, we just
-    // skip entering subnodes of this tree.
-    auto Pre = Walker.walkToExprPre(E);
-    if (!Pre.first || !Pre.second)
-      return Pre.second;
-
-    // Otherwise, visit the children.
-    E = visit(Pre.second);
-
-    // If we didn't bail out, do post-order visitation.
-    if (E) E = Walker.walkToExprPost(E);
-
-    return E;
+    return traverse<Expr>(
+        Walker.walkToExprPre(E),
+        [&](Expr *E) { return visit(E); },
+        [&](Expr *E) { return Walker.walkToExprPost(E); });
   }
 
   Stmt *doIt(Stmt *S) {
-    // Do the pre-order visitation.  If it returns false, we just
-    // skip entering subnodes of this tree.
-    auto Pre = Walker.walkToStmtPre(S);
-    if (!Pre.first || !Pre.second)
-      return Pre.second;
-
-    // Otherwise, visit the children.
-    S = visit(S);
-
-    // If we didn't bail out, do post-order visitation.
-    if (S) S = Walker.walkToStmtPost(S);
-
-    return S;
+    return traverse<Stmt>(
+        Walker.walkToStmtPre(S),
+        [&](Stmt *S) { return visit(S); },
+        [&](Stmt *S) { return Walker.walkToStmtPost(S); });
   }
   
   bool shouldSkip(Decl *D) {
@@ -1310,31 +1354,17 @@ public:
     if (shouldSkip(D))
       return false;
 
-    // Do the pre-order visitation.  If it returns false, we just
-    // skip entering subnodes of this tree.
-    if (!Walker.walkToDeclPre(D))
-      return false;
-
-    if (visit(D))
-      return true;
-
-    return !Walker.walkToDeclPost(D);
+    return traverse(
+        Walker.walkToDeclPre(D),
+        [&]() { return visit(D); },
+        [&]() { return Walker.walkToDeclPost(D); });
   }
   
   Pattern *doIt(Pattern *P) {
-    // Do the pre-order visitation.  If it returns false, we just
-    // skip entering subnodes of this tree.
-    auto Pre = Walker.walkToPatternPre(P);
-    if (!Pre.first || !Pre.second)
-      return Pre.second;
-
-    // Otherwise, visit the children.
-    P = visit(P);
-
-    // If we didn't bail out, do post-order visitation.
-    if (P) P = Walker.walkToPatternPost(P);
-
-    return P;
+    return traverse<Pattern>(
+        Walker.walkToPatternPre(P),
+        [&](Pattern *P) { return visit(P); },
+        [&](Pattern *P) { return Walker.walkToPatternPost(P); });
   }
 
   bool doIt(const StmtCondition &C) {
@@ -1369,17 +1399,10 @@ public:
 
   /// Returns true on failure.
   bool doIt(TypeRepr *T) {
-    // Do the pre-order visitation.  If it returns false, we just
-    // skip entering subnodes of this tree.
-    if (!Walker.walkToTypeReprPre(T))
-      return false;
-
-    // Otherwise, visit the children.
-    if (visit(T))
-      return true;
-
-    // If we didn't bail out, do post-order visitation.
-    return !Walker.walkToTypeReprPost(T);
+    return traverse(
+        Walker.walkToTypeReprPre(T),
+        [&]() { return visit(T); },
+        [&]() { return Walker.walkToTypeReprPost(T); });
   }
   
   bool doIt(RequirementRepr &Req) {
@@ -1416,18 +1439,22 @@ public:
     return false;
   }
 
-  ArgumentList *doIt(ArgumentList *ArgList) {
-    bool WalkChildren;
-    std::tie(WalkChildren, ArgList) = Walker.walkToArgumentListPre(ArgList);
-    if (!WalkChildren || !ArgList)
-      return ArgList;
-
+  ArgumentList *visit(ArgumentList *ArgList) {
     for (auto Idx : indices(*ArgList)) {
       auto *E = doIt(ArgList->getExpr(Idx));
       if (!E) return nullptr;
       ArgList->setExpr(Idx, E);
     }
-    return Walker.walkToArgumentListPost(ArgList);
+    return ArgList;
+  }
+
+  ArgumentList *doIt(ArgumentList *ArgList) {
+    return traverse<ArgumentList>(
+        Walker.walkToArgumentListPre(ArgList),
+        [&](ArgumentList *ArgList) { return visit(ArgList); },
+        [&](ArgumentList *ArgList) {
+          return Walker.walkToArgumentListPost(ArgList);
+        });
   }
 };
 

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -484,25 +484,35 @@ forEachImmediateChildExpr(llvm::function_ref<Expr *(Expr *)> callback) {
     ChildWalker(llvm::function_ref<Expr *(Expr *)> callback, Expr *ThisNode)
       : callback(callback), ThisNode(ThisNode) {}
     
-    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+    PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       // When looking at the current node, of course we want to enter it.  We
       // also don't want to enumerate it.
       if (E == ThisNode)
-        return { true, E };
+        return Action::Continue(E);
 
       // Otherwise we must be a child of our expression, enumerate it!
-      return { false, callback(E) };
+      E = callback(E);
+      if (!E)
+        return Action::Stop();
+
+      // We're only interested in the immediate children, so don't walk any
+      // further.
+      return Action::SkipChildren(E);
     }
     
-    std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
-      return { false, S };
+    PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
+      return Action::SkipChildren(S);
     }
 
-    std::pair<bool, Pattern*> walkToPatternPre(Pattern *P) override {
-      return { false, P };
+    PreWalkResult<Pattern *> walkToPatternPre(Pattern *P) override {
+      return Action::SkipChildren(P);
     }
-    bool walkToDeclPre(Decl *D) override { return false; }
-    bool walkToTypeReprPre(TypeRepr *T) override { return false; }
+    PreWalkAction walkToDeclPre(Decl *D) override {
+      return Action::SkipChildren();
+    }
+    PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
+      return Action::SkipChildren();
+    }
   };
   
   this->walk(ChildWalker(callback, this));
@@ -518,20 +528,28 @@ void Expr::forEachChildExpr(llvm::function_ref<Expr *(Expr *)> callback) {
     ChildWalker(llvm::function_ref<Expr *(Expr *)> callback)
     : callback(callback) {}
 
-    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+    PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       // Enumerate the node!
-      return { true, callback(E) };
+      E = callback(E);
+      if (!E)
+        return Action::Stop();
+
+      return Action::Continue(E);
     }
 
-    std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
-      return { false, S };
+    PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
+      return Action::SkipChildren(S);
     }
 
-    std::pair<bool, Pattern*> walkToPatternPre(Pattern *P) override {
-      return { false, P };
+    PreWalkResult<Pattern *> walkToPatternPre(Pattern *P) override {
+      return Action::SkipChildren(P);
     }
-    bool walkToDeclPre(Decl *D) override { return false; }
-    bool walkToTypeReprPre(TypeRepr *T) override { return false; }
+    PreWalkAction walkToDeclPre(Decl *D) override {
+      return Action::SkipChildren();
+    }
+    PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
+      return Action::SkipChildren();
+    }
   };
 
   this->walk(ChildWalker(callback));
@@ -823,11 +841,11 @@ llvm::DenseMap<Expr *, Expr *> Expr::getParentMap() {
     explicit RecordingTraversal(llvm::DenseMap<Expr *, Expr *> &parentMap)
       : ParentMap(parentMap) { }
 
-    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+    PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       if (auto parent = Parent.getAsExpr())
         ParentMap[E] = parent;
 
-      return { true, E };
+      return Action::Continue(E);
     }
   };
 

--- a/lib/AST/InlinableText.cpp
+++ b/lib/AST/InlinableText.cpp
@@ -49,7 +49,7 @@ class IsFeatureCheck : public ASTWalker {
 public:
   bool foundFeature = false;
 
-  std::pair<bool, Expr *> walkToExprPre(Expr *expr) override {
+  PreWalkResult<Expr *> walkToExprPre(Expr *expr) override {
     if (auto unresolved = dyn_cast<UnresolvedDeclRefExpr>(expr)) {
       if (unresolved->getName().getBaseName().userFacingName().startswith("$"))
         foundFeature = true;
@@ -64,7 +64,7 @@ public:
       }
     }
 
-    return { !foundFeature, expr };
+    return Action::SkipChildrenIf(foundFeature, expr);
   }
 };
 
@@ -122,9 +122,10 @@ struct ExtractInactiveRanges : public ASTWalker {
     ranges.push_back(charRange);
   }
 
-  bool walkToDeclPre(Decl *d) override {
+  PreWalkAction walkToDeclPre(Decl *d) override {
     auto icd = dyn_cast<IfConfigDecl>(d);
-    if (!icd) return true;
+    if (!icd)
+      return Action::Continue();
 
     auto start = Lexer::getLocForStartOfLine(sourceMgr, icd->getStartLoc());
     auto end = Lexer::getLocForEndOfLine(sourceMgr, icd->getEndLoc());
@@ -134,13 +135,13 @@ struct ExtractInactiveRanges : public ASTWalker {
     // If there's no active clause, add the entire #if...#endif block.
     if (!clause) {
       addRange(start, end);
-      return false;
+      return Action::SkipChildren();
     }
 
     // If the clause is checking for a particular feature with $ or a compiler
     // version, keep the whole thing.
     if (anyClauseIsFeatureCheck(icd->getClauses())) {
-      return false;
+      return Action::SkipChildren();
     }
 
     // Ignore range from beginning of '#if', '#elseif', or '#else' to the
@@ -163,7 +164,7 @@ struct ExtractInactiveRanges : public ASTWalker {
       if (elt.isDecl(DeclKind::IfConfig))
         elt.get<Decl *>()->walk(*this);
 
-    return false;
+    return Action::SkipChildren();
   }
 
   /// Gets the ignored ranges in source order.

--- a/lib/AST/Pattern.cpp
+++ b/lib/AST/Pattern.cpp
@@ -166,30 +166,36 @@ namespace {
     
     WalkToVarDecls(const std::function<void(VarDecl*)> &fn)
     : fn(fn) {}
-    
-    Pattern *walkToPatternPost(Pattern *P) override {
+
+    PostWalkResult<Pattern *> walkToPatternPost(Pattern *P) override {
       // Handle vars.
       if (auto *Named = dyn_cast<NamedPattern>(P))
         fn(Named->getDecl());
-      return P;
+      return Action::Continue(P);
     }
 
     // Only walk into an expression insofar as it doesn't open a new scope -
     // that is, don't walk into a closure body.
-    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+    PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       if (isa<ClosureExpr>(E)) {
-        return { false, E };
+        return Action::SkipChildren(E);
       }
-      return { true, E };
+      return Action::Continue(E);
     }
 
     // Don't walk into anything else.
-    std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
-      return { false, S };
+    PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
+      return Action::SkipChildren(S);
     }
-    bool walkToTypeReprPre(TypeRepr *T) override { return false; }
-    bool walkToParameterListPre(ParameterList *PL) override { return false; }
-    bool walkToDeclPre(Decl *D) override { return false; }
+    PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
+      return Action::SkipChildren();
+    }
+    PreWalkAction walkToParameterListPre(ParameterList *PL) override {
+      return Action::SkipChildren();
+    }
+    PreWalkAction walkToDeclPre(Decl *D) override {
+      return Action::SkipChildren();
+    }
   };
 } // end anonymous namespace
 

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -192,41 +192,41 @@ ASTNode BraceStmt::findAsyncNode() {
   class FindInnerAsync : public ASTWalker {
     ASTNode AsyncNode;
 
-    std::pair<bool, Expr *> walkToExprPre(Expr *expr) override {
+    PreWalkResult<Expr *> walkToExprPre(Expr *expr) override {
       // If we've found an 'await', record it and terminate the traversal.
       if (isa<AwaitExpr>(expr)) {
         AsyncNode = expr;
-        return {false, nullptr};
+        return Action::Stop();
       }
 
       // Do not recurse into other closures.
       if (isa<ClosureExpr>(expr))
-        return {false, expr};
+        return Action::SkipChildren(expr);
 
-      return {true, expr};
+      return Action::Continue(expr);
     }
 
-    bool walkToDeclPre(Decl *decl) override {
+    PreWalkAction walkToDeclPre(Decl *decl) override {
       // Do not walk into function or type declarations.
       if (auto *patternBinding = dyn_cast<PatternBindingDecl>(decl)) {
         if (patternBinding->isAsyncLet())
           AsyncNode = patternBinding;
 
-        return true;
+        return Action::Continue();
       }
 
-      return false;
+      return Action::SkipChildren();
     }
 
-    std::pair<bool, Stmt *> walkToStmtPre(Stmt *stmt) override {
+    PreWalkResult<Stmt *> walkToStmtPre(Stmt *stmt) override {
       if (auto forEach = dyn_cast<ForEachStmt>(stmt)) {
         if (forEach->getAwaitLoc().isValid()) {
           AsyncNode = forEach;
-          return {false, nullptr};
+          return Action::Stop();
         }
       }
 
-      return {true, stmt};
+      return Action::Continue(stmt);
     }
 
   public:

--- a/lib/AST/TypeDeclFinder.cpp
+++ b/lib/AST/TypeDeclFinder.cpp
@@ -49,9 +49,10 @@ SimpleTypeDeclFinder::visitTypeAliasType(TypeAliasType *ty) {
   return Callback(ty->getDecl());
 }
 
-bool TypeReprIdentFinder::walkToTypeReprPost(TypeRepr *TR) {
+ASTWalker::PostWalkAction
+TypeReprIdentFinder::walkToTypeReprPost(TypeRepr *TR) {
   auto CITR = dyn_cast<ComponentIdentTypeRepr>(TR);
   if (!CITR || !CITR->getBoundDecl())
-    return true;
-  return Callback(CITR);
+    return Action::Continue();
+  return Action::StopIf(!Callback(CITR));
 }

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -83,10 +83,12 @@ bool TypeRepr::findIf(llvm::function_ref<bool(TypeRepr *)> pred) {
     explicit Walker(llvm::function_ref<bool(TypeRepr *)> pred)
         : Pred(pred), FoundIt(false) {}
 
-    bool walkToTypeReprPre(TypeRepr *ty) override {
-      // Returning false skips any child nodes. If we "found it", we can bail by
-      // returning false repeatedly back up the type tree.
-      return !(FoundIt || (FoundIt = Pred(ty)));
+    PreWalkAction walkToTypeReprPre(TypeRepr *ty) override {
+      if (Pred(ty)) {
+        FoundIt = true;
+        return Action::Stop();
+      }
+      return Action::Continue();
     }
   };
 
@@ -119,14 +121,14 @@ CollectedOpaqueReprs TypeRepr::collectOpaqueReturnTypeReprs() {
   public:
     explicit Walker(CollectedOpaqueReprs &reprs) : Reprs(reprs) {}
 
-    bool walkToTypeReprPre(TypeRepr *repr) override {
+    PreWalkAction walkToTypeReprPre(TypeRepr *repr) override {
       // Don't allow variadic opaque parameter or return types.
       if (isa<PackExpansionTypeRepr>(repr))
-        return false;
+        return Action::SkipChildren();
 
       if (auto opaqueRepr = dyn_cast<OpaqueReturnTypeRepr>(repr))
         Reprs.push_back(opaqueRepr);
-      return true;
+      return Action::Continue();
     }
   };
 

--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -43,13 +43,13 @@ public:
       std::vector<NominalTypeDecl *> &ConformanceDecls)
       : Protocols(Protocols), ConformanceTypeDecls(ConformanceDecls) {}
 
-  bool walkToDeclPre(Decl *D) override {
+  PreWalkAction walkToDeclPre(Decl *D) override {
     if (auto *NTD = llvm::dyn_cast<NominalTypeDecl>(D))
       if (!isa<ProtocolDecl>(NTD))
         for (auto &Protocol : NTD->getAllProtocols())
           if (Protocols.count(Protocol->getName().str().str()) != 0)
             ConformanceTypeDecls.push_back(NTD);
-    return true;
+    return Action::Continue();
   }
 };
 

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -187,19 +187,19 @@ bool swift::ide::canDeclContextHandleAsync(const DeclContext *DC) {
 
       AsyncClosureChecker(const ClosureExpr *Target) : Target(Target) {}
 
-      std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+      PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
         if (E == Target)
-          return {false, E};
+          return Action::SkipChildren(E);
 
         if (auto conversionExpr = dyn_cast<FunctionConversionExpr>(E)) {
           if (conversionExpr->getSubExpr() == Target) {
             if (conversionExpr->getType()->is<AnyFunctionType>() &&
                 conversionExpr->getType()->castTo<AnyFunctionType>()->isAsync())
               Result = true;
-            return {false, E};
+            return Action::SkipChildren(E);
           }
         }
-        return {true, E};
+        return Action::Continue(E);
       }
     } checker(closure);
     closure->getParent()->walkContext(checker);
@@ -3180,9 +3180,9 @@ void CompletionLookup::getStmtLabelCompletions(SourceLoc Loc, bool isContinue) {
     LabelFinder(SourceManager &SM, SourceLoc TargetLoc, bool IsContinue)
         : SM(SM), TargetLoc(TargetLoc), IsContinue(IsContinue) {}
 
-    std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
+    PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
       if (SM.isBeforeInBuffer(S->getEndLoc(), TargetLoc))
-        return {false, S};
+        return Action::SkipChildren(S);
 
       if (LabeledStmt *LS = dyn_cast<LabeledStmt>(S)) {
         if (LS->getLabelInfo()) {
@@ -3194,15 +3194,17 @@ void CompletionLookup::getStmtLabelCompletions(SourceLoc Loc, bool isContinue) {
         }
       }
 
-      return {true, S};
+      return Action::Continue(S);
     }
 
-    Stmt *walkToStmtPost(Stmt *S) override { return nullptr; }
+    PostWalkResult<Stmt *> walkToStmtPost(Stmt *S) override {
+      return Action::Stop();
+    }
 
-    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+    PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       if (SM.isBeforeInBuffer(E->getEndLoc(), TargetLoc))
-        return {false, E};
-      return {true, E};
+        return Action::SkipChildren(E);
+      return Action::Continue(E);
     }
   } Finder(CurrDeclContext->getASTContext().SourceMgr, Loc, isContinue);
   const_cast<DeclContext *>(CurrDeclContext)->walkContext(Finder);

--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -475,14 +475,14 @@ private:
     return true;
   }
 
-  bool walkToDeclPre(Decl *D) override {
-    bool Continue = true, Stop = false;
-
+  PreWalkAction walkToDeclPre(Decl *D) override {
+    // TODO: Can we use Action::Stop instead of Action::SkipChildren in this
+    // function?
     if (!walkCustomAttributes(D))
-      return Stop;
+      return Action::SkipChildren();
 
     if (D->isImplicit())
-      return Continue;
+      return Action::Continue();
 
     // Walk into inactive config regions.
     if (auto *ICD = dyn_cast<IfConfigDecl>(D)) {
@@ -490,7 +490,7 @@ private:
         for (auto Member : Clause.Elements)
           Member.walk(*this);
       }
-      return false;
+      return Action::SkipChildren();
     }
 
     SourceLoc ContextLoc = D->getStartLoc();
@@ -504,44 +504,42 @@ private:
       if (SafeToAskForGenerics) {
         if (auto *GP = GC->getParsedGenericParams()) {
           if (!handleAngles(GP->getLAngleLoc(), GP->getRAngleLoc(), ContextLoc))
-            return Stop;
+            return Action::SkipChildren();
         }
       }
     }
 
     if (auto *NTD = dyn_cast<NominalTypeDecl>(D)) {
       if (!handleBraces(NTD->getBraces(), ContextLoc))
-        return Stop;
+        return Action::SkipChildren();
     } else if (auto *ED = dyn_cast<ExtensionDecl>(D)) {
       if (!handleBraces(ED->getBraces(), ContextLoc))
-        return Stop;
+        return Action::SkipChildren();
     } else if (auto *VD = dyn_cast<VarDecl>(D)) {
       if (!handleBraces(VD->getBracesRange(), VD->getNameLoc()))
-        return Stop;
+        return Action::SkipChildren();
     } else if (isa<AbstractFunctionDecl>(D) || isa<SubscriptDecl>(D)) {
       if (isa<SubscriptDecl>(D)) {
         if (!handleBraces(cast<SubscriptDecl>(D)->getBracesRange(), ContextLoc))
-          return Stop;
+          return Action::SkipChildren();
       }
       auto *PL = getParameterList(cast<ValueDecl>(D));
       if (!handleParens(PL->getLParenLoc(), PL->getRParenLoc(), ContextLoc))
-        return Stop;
+        return Action::SkipChildren();
     } else if (auto *PGD = dyn_cast<PrecedenceGroupDecl>(D)) {
       SourceRange Braces(PGD->getLBraceLoc(), PGD->getRBraceLoc());
       if (!handleBraces(Braces, ContextLoc))
-        return Stop;
+        return Action::SkipChildren();
     } else if (auto *PDD = dyn_cast<PoundDiagnosticDecl>(D)) {
       // TODO: add paren locations to PoundDiagnosticDecl
     }
 
-    return Continue;
+    return Action::Continue();
   }
 
-  std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
-    std::pair<bool, Stmt*> Continue = {true, S}, Stop = {false, nullptr};
-
+  PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
     if (S->isImplicit())
-      return Continue;
+      return Action::Continue(S);
 
     if (auto *LCS = dyn_cast<LabeledConditionalStmt>(S)) {
       for (auto &Elem: LCS->getCond()) {
@@ -549,7 +547,7 @@ private:
           PoundAvailableInfo *PA = Elem.getAvailability();
           if (!handleParens(PA->getLParenLoc(), PA->getRParenLoc(),
                             PA->getStartLoc()))
-            return Stop;
+            return Action::Stop();
         }
       }
     }
@@ -557,58 +555,56 @@ private:
     SourceLoc ContextLoc = S->getStartLoc();
     if (auto *BS = dyn_cast<BraceStmt>(S)) {
       if (!handleBraceStmt(BS, ContextLoc))
-        return Stop;
+        return Action::Stop();
     } else if (auto *IS = dyn_cast<IfStmt>(S)) {
       if (!handleBraceStmt(IS->getThenStmt(), IS->getIfLoc()))
-        return Stop;
+        return Action::Stop();
     } else if (auto *GS = dyn_cast<GuardStmt>(S)) {
       if (!handleBraceStmt(GS->getBody(), GS->getGuardLoc()))
-        return Stop;
+        return Action::Stop();
     } else if (auto *FS = dyn_cast<ForEachStmt>(S)) {
       if (!handleBraceStmt(FS->getBody(), FS->getForLoc()))
-        return Stop;
+        return Action::Stop();
     } else if (auto *SS = dyn_cast<SwitchStmt>(S)) {
       SourceRange Braces(SS->getLBraceLoc(), SS->getRBraceLoc());
       if (!handleBraces(Braces, SS->getSwitchLoc()))
-        return Stop;
+        return Action::Stop();
     } else if (auto *DS = dyn_cast<DoStmt>(S)) {
       if (!handleBraceStmt(DS->getBody(), DS->getDoLoc()))
-        return Stop;
+        return Action::Stop();
     } else if (auto *DCS = dyn_cast<DoCatchStmt>(S)) {
       if (!handleBraceStmt(DCS->getBody(), DCS->getDoLoc()))
-        return Stop;
+        return Action::Stop();
     } else if (isa<CaseStmt>(S) &&
                cast<CaseStmt>(S)->getParentKind() == CaseParentKind::DoCatch) {
       auto CS = cast<CaseStmt>(S);
       if (!handleBraceStmt(CS->getBody(), CS->getLoc()))
-        return Stop;
+        return Action::Stop();
     } else if (auto *RWS = dyn_cast<RepeatWhileStmt>(S)) {
       if (!handleBraceStmt(RWS->getBody(), RWS->getRepeatLoc()))
-        return Stop;
+        return Action::Stop();
     } else if (auto *WS = dyn_cast<WhileStmt>(S)) {
       if (!handleBraceStmt(WS->getBody(), WS->getWhileLoc()))
-        return Stop;
+        return Action::Stop();
     } else if (auto *PAS = dyn_cast<PoundAssertStmt>(S)) {
       // TODO: add paren locations to PoundAssertStmt
     }
 
-    return Continue;
+    return Action::Continue(S);
   }
 
-  std::pair<bool, Expr*> walkToExprPre(Expr *E) override {
-    std::pair<bool, Expr*> Stop = {false, nullptr}, Continue = {true, E};
-
+  PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
     // Walk through error expressions.
     if (auto *EE = dyn_cast<ErrorExpr>(E)) {
       if (auto *OE = EE->getOriginalExpr()) {
         llvm::SaveAndRestore<ASTWalker::ParentTy>(Parent, EE);
         OE->walk(*this);
       }
-      return Continue;
+      return Action::Continue(E);
     }
 
     if (E->isImplicit())
-      return Continue;
+      return Action::Continue(E);
 
     SourceLoc ContextLoc = E->getStartLoc();
     if (auto *PE = dyn_cast<ParenExpr>(E)) {
@@ -617,33 +613,33 @@ private:
       SourceLoc R = getLocIfKind(SM, PE->getRParenLoc(),
                                  {tok::r_paren, tok::r_square});
       if (L.isValid() && !handleRange(L, R, ContextLoc))
-        return Stop;
+        return Action::Stop();
     } else if (auto *TE = dyn_cast<TupleExpr>(E)) {
       SourceLoc L = getLocIfKind(SM, TE->getLParenLoc(),
                                  {tok::l_paren, tok::l_square});
       SourceLoc R = getLocIfKind(SM, TE->getRParenLoc(),
                                  {tok::r_paren, tok::r_square});
       if (L.isValid() && !handleRange(L, R, ContextLoc))
-        return Stop;
+        return Action::Stop();
     } else if (auto *CE = dyn_cast<CollectionExpr>(E)) {
       if (!handleSquares(CE->getLBracketLoc(), CE->getRBracketLoc(),
                          ContextLoc))
-        return Stop;
+        return Action::Stop();
     } else if (auto *CE = dyn_cast<ClosureExpr>(E)) {
       if (!handleBraceStmt(CE->getBody(), ContextLoc))
-        return Stop;
+        return Action::Stop();
       SourceRange Capture = CE->getBracketRange();
       if (!handleSquares(Capture.Start, Capture.End, Capture.Start))
-        return Stop;
+        return Action::Stop();
       if (auto *PL = CE->getParameters()) {
         if (!handleParens(PL->getLParenLoc(), PL->getRParenLoc(),
                           PL->getStartLoc()))
-          return Stop;
+          return Action::Stop();
       }
     } else if (auto *USE = dyn_cast<UnresolvedSpecializeExpr>(E)) {
       SourceLoc ContextLoc = getContextLocForArgs(SM, E);
       if (!handleAngles(USE->getLAngleLoc(), USE->getRAngleLoc(), ContextLoc))
-        return Stop;
+        return Action::Stop();
     } else if (isa<CallExpr>(E) || isa<SubscriptExpr>(E)) {
       SourceLoc ContextLoc = getContextLocForArgs(SM, E);
       auto *Args = E->getArgs();
@@ -653,17 +649,17 @@ private:
 
       if (isa<SubscriptExpr>(E)) {
         if (!handleSquares(lParenLoc, rParenLoc, ContextLoc))
-          return Stop;
+          return Action::Stop();
       } else {
         if (!handleParens(lParenLoc, rParenLoc, ContextLoc))
-          return Stop;
+          return Action::Stop();
       }
 
       if (Args->hasAnyTrailingClosures()) {
         if (auto *unaryArg = Args->getUnaryExpr()) {
           if (auto CE = findTrailingClosureFromArgument(unaryArg)) {
             if (!handleBraceStmt(CE->getBody(), ContextLoc))
-              return Stop;
+              return Action::Stop();
           }
         } else {
           handleImplicitRange(Args->getOriginalArgs()->getTrailingSourceRange(),
@@ -671,41 +667,38 @@ private:
         }
       }
     }
-    return Continue;
+    return Action::Continue(E);
   }
 
-  std::pair<bool, Pattern*> walkToPatternPre(Pattern *P) override {
-    std::pair<bool, Pattern*> Continue = {true, P}, Stop = {false, nullptr};
-
+  PreWalkResult<Pattern *> walkToPatternPre(Pattern *P) override {
     if (P->isImplicit())
-      return Continue;
+      return Action::Continue(P);
 
     if (isa<TuplePattern>(P) || isa<ParenPattern>(P)) {
       if (!handleParens(P->getStartLoc(), P->getEndLoc(), P->getStartLoc()))
-        return Stop;
+        return Action::Stop();
     }
 
-    return Continue;
+    return Action::Continue(P);
   }
 
-  bool walkToTypeReprPre(TypeRepr *T) override {
-    bool Continue = true, Stop = false;
-
+  PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
+    // TODO: Can we use Action::Stop instead of Action::SkipChildren in this
+    // function?
     if (auto *TT = dyn_cast<TupleTypeRepr>(T)) {
       SourceRange Parens = TT->getParens();
       if (!handleParens(Parens.Start, Parens.End, Parens.Start))
-        return Stop;
+        return Action::SkipChildren();
     } else if (isa<ArrayTypeRepr>(T) || isa<DictionaryTypeRepr>(T)) {
       if (!handleSquares(T->getStartLoc(), T->getEndLoc(), T->getStartLoc()))
-        return Stop;
+        return Action::SkipChildren();
     } else if (auto *GI = dyn_cast<GenericIdentTypeRepr>(T)) {
       SourceLoc ContextLoc = GI->getNameLoc().getBaseNameLoc();
       SourceRange Brackets = GI->getAngleBrackets();
       if (!handleAngles(Brackets.Start, Brackets.End, ContextLoc))
-        return Stop;
+        return Action::SkipChildren();
     }
-
-    return Continue;
+    return Action::Continue();
   }
 
   bool shouldWalkIntoGenericParams() override { return true; }
@@ -1362,9 +1355,9 @@ private:
     return true;
   }
 
-  bool walkToDeclPre(Decl *D) override {
+  PreWalkAction walkToDeclPre(Decl *D) override {
     if (!walkCustomAttributes(D))
-      return false;
+      return Action::SkipChildren();
 
     auto Action = HandlePre(D, D->isImplicit());
     if (Action.shouldGenerateIndentContext()) {
@@ -1404,22 +1397,22 @@ private:
             Member.walk(*this);
         }
       }
-      return false;
+      return Action::SkipChildren();
     }
 
-    return Action.shouldVisitChildren();
+    return Action::VisitChildrenIf(Action.shouldVisitChildren());
   }
 
-  std::pair<bool, Stmt*> walkToStmtPre(Stmt *S) override {
+  PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
     auto Action = HandlePre(S, S->isImplicit());
     if (Action.shouldGenerateIndentContext()) {
       if (auto IndentCtx = getIndentContextFrom(S, Action.Trailing))
         InnermostCtx = IndentCtx;
     }
-    return {Action.shouldVisitChildren(), S};
+    return Action::VisitChildrenIf(Action.shouldVisitChildren(), S);
   }
 
-  std::pair<bool, ArgumentList *>
+  PreWalkResult<ArgumentList *>
   walkToArgumentListPre(ArgumentList *Args) override {
     SourceLoc ContextLoc;
     if (auto *E = Parent.getAsExpr()) {
@@ -1435,10 +1428,10 @@ private:
       if (auto Ctx = getIndentContextFrom(Args, Action.Trailing, ContextLoc))
         InnermostCtx = Ctx;
     }
-    return {Action.shouldVisitChildren(), Args};
+    return Action::VisitChildrenIf(Action.shouldVisitChildren(), Args);
   }
 
-  std::pair<bool, Expr*> walkToExprPre(Expr *E) override {
+  PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
     if (E->getKind() == ExprKind::StringLiteral &&
         SM.isBeforeInBuffer(E->getStartLoc(), TargetLocation) &&
         SM.isBeforeInBuffer(TargetLocation,
@@ -1493,7 +1486,7 @@ private:
           StringLiteralRange =
               Lexer::getCharSourceRangeFromSourceRange(SM, E->getSourceRange());
 
-        return {false, E};
+        return Action::SkipChildren(E);
       }
     }
 
@@ -1504,44 +1497,48 @@ private:
           llvm::SaveAndRestore<ASTWalker::ParentTy>(Parent, EE);
           OE->walk(*this);
         }
-        return {false, E};
+        return Action::SkipChildren(E);
       }
     }
 
-    return {Action.shouldVisitChildren(), E};
+    return Action::VisitChildrenIf(Action.shouldVisitChildren(), E);
   }
 
-  std::pair<bool, Pattern *> walkToPatternPre(Pattern *P) override {
+  PreWalkResult<Pattern *> walkToPatternPre(Pattern *P) override {
     auto Action = HandlePre(P, P->isImplicit());
     if (Action.shouldGenerateIndentContext()) {
       if (auto IndentCtx = getIndentContextFrom(P, Action.Trailing))
         InnermostCtx = IndentCtx;
     }
-    return {Action.shouldVisitChildren(), P};
+    return Action::VisitChildrenIf(Action.shouldVisitChildren(), P);
   }
 
-  bool walkToTypeReprPre(TypeRepr *T) override {
+  PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
     auto Action = HandlePre(T, false);
     if (Action.shouldGenerateIndentContext()) {
       if (auto IndentCtx = getIndentContextFrom(T, Action.Trailing))
         InnermostCtx = IndentCtx;
     }
-    return Action.shouldVisitChildren();
+    return Action::VisitChildrenIf(Action.shouldVisitChildren());
   }
 
-  bool walkToDeclPost(Decl *D) override { return HandlePost(D); }
-  bool walkToTypeReprPost(TypeRepr *T) override { return HandlePost(T); }
-
-  Stmt* walkToStmtPost(Stmt *S) override {
-    return HandlePost(S)? S : nullptr;
+  PostWalkAction walkToDeclPost(Decl *D) override {
+    return HandlePost(D).Action;
+  }
+  PostWalkAction walkToTypeReprPost(TypeRepr *T) override {
+    return HandlePost(T).Action;
   }
 
-  Expr *walkToExprPost(Expr *E) override {
-    return HandlePost(E) ? E : nullptr;
+  PostWalkResult<Stmt *> walkToStmtPost(Stmt *S) override {
+    return HandlePost(S);
   }
 
-  Pattern * walkToPatternPost(Pattern *P) override {
-    return HandlePost(P) ? P : nullptr;
+  PostWalkResult<Expr *> walkToExprPost(Expr *E) override {
+    return HandlePost(E);
+  }
+
+  PostWalkResult<Pattern *> walkToPatternPost(Pattern *P) override {
+    return HandlePost(P);
   }
 
   bool shouldWalkIntoGenericParams() override { return true; }
@@ -1575,8 +1572,11 @@ private:
   }
 
   template <typename T>
-  bool HandlePost(T* Node) {
-    return !SM.isBeforeInBuffer(TargetLocation, Node->getStartLoc());
+  PostWalkResult<T *> HandlePost(T *Node) {
+    if (SM.isBeforeInBuffer(TargetLocation, Node->getStartLoc()))
+      return Action::Stop();
+
+    return Action::Continue(Node);
   }
 
   void scanTokensUntil(SourceLoc Loc) {

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -274,10 +274,14 @@ std::pair<bool, Stmt *> SemaAnnotator::walkToStmtPre(Stmt *S) {
       // Since 'DeferStmt::getTempDecl()' is marked as implicit, we manually
       // walk into the body.
       if (auto *FD = DeferS->getTempDecl()) {
-        auto *RetS = FD->getBody()->walk(*this);
+        auto *Body = FD->getBody();
+        if (!Body)
+          return Action::Stop();
+
+        auto *RetS = Body->walk(*this);
         if (!RetS)
           return { false, nullptr };
-        assert(RetS == FD->getBody());
+        assert(RetS == Body);
       }
       bool Continue = SEWalker.walkToStmtPost(DeferS);
       if (!Continue)

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -44,6 +44,8 @@ public:
   explicit SemaAnnotator(SourceEntityWalker &SEWalker)
     : SEWalker(SEWalker) { }
 
+  // TODO: Can we bail using Action::Stop instead of setting and checking
+  // this flag?
   bool isDone() const { return Cancelled; }
 
 private:
@@ -59,24 +61,24 @@ private:
     return false;
   }
 
-  bool walkToDeclPre(Decl *D) override;
-  bool walkToDeclPreProper(Decl *D);
-  std::pair<bool, Expr *> walkToExprPre(Expr *E) override;
-  bool walkToTypeReprPre(TypeRepr *T) override;
+  PreWalkAction walkToDeclPre(Decl *D) override;
+  PreWalkAction walkToDeclPreProper(Decl *D);
+  PreWalkResult<Expr *> walkToExprPre(Expr *E) override;
+  PreWalkAction walkToTypeReprPre(TypeRepr *T) override;
 
-  bool walkToDeclPost(Decl *D) override;
-  bool walkToDeclPostProper(Decl *D);
-  Expr *walkToExprPost(Expr *E) override;
-  bool walkToTypeReprPost(TypeRepr *T) override;
+  PostWalkAction walkToDeclPost(Decl *D) override;
+  PostWalkAction walkToDeclPostProper(Decl *D);
+  PostWalkResult<Expr *> walkToExprPost(Expr *E) override;
+  PostWalkAction walkToTypeReprPost(TypeRepr *T) override;
 
-  std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override;
-  Stmt *walkToStmtPost(Stmt *S) override;
+  PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override;
+  PostWalkResult<Stmt *> walkToStmtPost(Stmt *S) override;
 
-  std::pair<bool, ArgumentList *>
+  PreWalkResult<ArgumentList *>
   walkToArgumentListPre(ArgumentList *ArgList) override;
 
-  std::pair<bool, Pattern *> walkToPatternPre(Pattern *P) override;
-  Pattern *walkToPatternPost(Pattern *P) override;
+  PreWalkResult<Pattern *> walkToPatternPre(Pattern *P) override;
+  PostWalkResult<Pattern *> walkToPatternPost(Pattern *P) override;
 
   bool handleImports(ImportDecl *Import);
   bool handleCustomAttributes(Decl *D);
@@ -113,22 +115,22 @@ private:
 
 } // end anonymous namespace
 
-bool SemaAnnotator::walkToDeclPre(Decl *D) {
+ASTWalker::PreWalkAction SemaAnnotator::walkToDeclPre(Decl *D) {
   if (isDone())
-    return false;
+    return Action::SkipChildren();
 
   if (shouldIgnore(D)) {
     // If we return true here, the children will still be visited, but we won't
     // call walkToDeclPre on SEWalker. The corresponding walkToDeclPost call
     // on SEWalker will be prevented by the check for shouldIgnore in
     // walkToDeclPost in SemaAnnotator.
-    return isa<PatternBindingDecl>(D);
+    return Action::VisitChildrenIf(isa<PatternBindingDecl>(D));
   }
 
   SEWalker.beginBalancedASTOrderDeclVisit(D);
-  bool Continue = walkToDeclPreProper(D);
+  auto Result = walkToDeclPreProper(D);
 
-  if (!Continue) {
+  if (Result.Action != PreWalkAction::Continue) {
     // To satisfy the contract of balanced calls to
     // begin/endBalancedASTOrderDeclVisit, we must call
     // endBalancedASTOrderDeclVisit here if walkToDeclPost isn't going to be
@@ -136,13 +138,13 @@ bool SemaAnnotator::walkToDeclPre(Decl *D) {
     SEWalker.endBalancedASTOrderDeclVisit(D);
   }
 
-  return Continue;
+  return Result;
 }
 
-bool SemaAnnotator::walkToDeclPreProper(Decl *D) {
+ASTWalker::PreWalkAction SemaAnnotator::walkToDeclPreProper(Decl *D) {
   if (!handleCustomAttributes(D)) {
     Cancelled = true;
-    return false;
+    return Action::SkipChildren();
   }
 
   SourceLoc Loc = D->getLoc();
@@ -178,7 +180,7 @@ bool SemaAnnotator::walkToDeclPreProper(Decl *D) {
     if (isa<AbstractFunctionDecl>(VD) || isa<SubscriptDecl>(VD)) {
       auto ParamList = getParameterList(VD);
       if (!ReportParamList(ParamList))
-        return false;
+        return Action::SkipChildren();
     }
 
     if (auto proto = dyn_cast<ProtocolDecl>(VD)) {
@@ -205,7 +207,7 @@ bool SemaAnnotator::walkToDeclPreProper(Decl *D) {
     IsExtension = true;
   } else if (auto Import = dyn_cast<ImportDecl>(D)) {
     if (!handleImports(Import))
-      return false;
+      return Action::SkipChildren();
 
   } else if (auto OpD = dyn_cast<OperatorDecl>(D)) {
     Loc = OpD->getLoc();
@@ -224,7 +226,7 @@ bool SemaAnnotator::walkToDeclPreProper(Decl *D) {
           Member.walk(*this);
         }
       }
-      return false;
+      return Action::SkipChildren();
     }
   }
 
@@ -236,21 +238,21 @@ bool SemaAnnotator::walkToDeclPreProper(Decl *D) {
   if (IsExtension && ShouldVisitChildren) {
     ExtDecls.push_back(static_cast<ExtensionDecl*>(D));
   }
-  return ShouldVisitChildren;
+  return Action::VisitChildrenIf(ShouldVisitChildren);
 }
 
-bool SemaAnnotator::walkToDeclPost(Decl *D) {
-  bool Continue = walkToDeclPostProper(D);
+ASTWalker::PostWalkAction SemaAnnotator::walkToDeclPost(Decl *D) {
+  auto Action = walkToDeclPostProper(D);
   SEWalker.endBalancedASTOrderDeclVisit(D);
-  return Continue;
+  return Action;
 }
 
-bool SemaAnnotator::walkToDeclPostProper(Decl *D) {
+ASTWalker::PostWalkAction SemaAnnotator::walkToDeclPostProper(Decl *D) {
   if (isDone())
-    return false;
+    return Action::Stop();
 
   if (shouldIgnore(D))
-    return true;
+    return Action::Continue();
 
   if (isa<ExtensionDecl>(D)) {
     assert(ExtDecls.back() == D);
@@ -258,15 +260,16 @@ bool SemaAnnotator::walkToDeclPostProper(Decl *D) {
   }
 
   bool Continue = SEWalker.walkToDeclPost(D);
-  if (!Continue)
+  if (!Continue) {
     Cancelled = true;
-  return Continue;
+    return Action::Stop();
+  }
+  return Action::Continue();
 }
 
-std::pair<bool, Stmt *> SemaAnnotator::walkToStmtPre(Stmt *S) {
-  if (isDone()) {
-    return { false, nullptr };
-  }
+ASTWalker::PreWalkResult<Stmt *> SemaAnnotator::walkToStmtPre(Stmt *S) {
+  if (isDone())
+    return Action::Stop();
 
   bool TraverseChildren = SEWalker.walkToStmtPre(S);
   if (TraverseChildren) {
@@ -280,28 +283,31 @@ std::pair<bool, Stmt *> SemaAnnotator::walkToStmtPre(Stmt *S) {
 
         auto *RetS = Body->walk(*this);
         if (!RetS)
-          return { false, nullptr };
+          return Action::Stop();
         assert(RetS == Body);
       }
       bool Continue = SEWalker.walkToStmtPost(DeferS);
-      if (!Continue)
+      if (!Continue) {
         Cancelled = true;
+        return Action::Stop();
+      }
       // Already walked children.
-      return { false, Continue ? DeferS : nullptr };
+      return Action::SkipChildren(DeferS);
     }
   }
-  return { TraverseChildren, S };
+  return Action::VisitChildrenIf(TraverseChildren, S);
 }
 
-Stmt *SemaAnnotator::walkToStmtPost(Stmt *S) {
-  if (isDone()) {
-    return nullptr;
-  }
+ASTWalker::PostWalkResult<Stmt *> SemaAnnotator::walkToStmtPost(Stmt *S) {
+  if (isDone())
+    return Action::Stop();
 
   bool Continue = SEWalker.walkToStmtPost(S);
-  if (!Continue)
+  if (!Continue) {
     Cancelled = true;
-  return Continue ? S : nullptr;
+    return Action::Stop();
+  }
+  return Action::Continue(S);
 }
 
 static SemaReferenceKind getReferenceKind(Expr *Parent, Expr *E) {
@@ -312,41 +318,40 @@ static SemaReferenceKind getReferenceKind(Expr *Parent, Expr *E) {
   return SemaReferenceKind::DeclRef;
 }
 
-std::pair<bool, ArgumentList *>
+ASTWalker::PreWalkResult<ArgumentList *>
 SemaAnnotator::walkToArgumentListPre(ArgumentList *ArgList) {
-  auto doStopTraversal = [&]() -> std::pair<bool, ArgumentList *> {
+  auto doStopTraversal = [&]() {
     Cancelled = true;
-    return {false, nullptr};
+    return Action::Stop();
   };
 
   // Don't consider the argument labels for an implicit ArgumentList.
   if (ArgList->isImplicit())
-    return {true, ArgList};
+    return Action::Continue(ArgList);
 
   // FIXME: What about SubscriptExpr and KeyPathExpr arg labels? (SR-15063)
   if (auto CallE = dyn_cast_or_null<CallExpr>(Parent.getAsExpr())) {
     if (!passCallArgNames(CallE->getFn(), ArgList))
       return doStopTraversal();
   }
-  return {true, ArgList};
+  return Action::Continue(ArgList);
 }
 
-std::pair<bool, Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
+ASTWalker::PreWalkResult<Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
   assert(E);
 
-  if (isDone()) {
-    return { false, nullptr };
-  }
+  if (isDone())
+    return Action::Stop();
 
   if (ExprsToSkip.count(E) != 0) {
     // We are skipping the expression. Call neither walkToExprPr nor
     // walkToExprPost on it
-    return { false, E };
+    return Action::SkipChildren(E);
   }
 
-  auto doStopTraversal = [&]() -> std::pair<bool, Expr *> {
+  auto doStopTraversal = [&]() {
     Cancelled = true;
-    return { false, nullptr };
+    return Action::Stop();
   };
 
   // Skip the synthesized curry thunks and just walk over the unwrapped
@@ -355,24 +360,29 @@ std::pair<bool, Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
     if (auto *SubExpr = ACE->getUnwrappedCurryThunkExpr()) {
       if (!SubExpr->walk(*this))
         return doStopTraversal();
-      return { false, E };
+      return Action::SkipChildren(E);
     }
   }
 
   if (!SEWalker.walkToExprPre(E)) {
-    return { false, E };
+    return Action::SkipChildren(E);
   }
 
-  auto doSkipChildren = [&]() -> std::pair<bool, Expr *> {
+  auto doSkipChildren = [&]() -> PreWalkResult<Expr *> {
     // If we decide to skip the children after having issued the call to
     // walkToExprPre, we need to simulate a corresponding call to walkToExprPost
     // which will not be issued by the ASTWalker if we return false in the first
     // component.
-    if (!walkToExprPost(E)) {
-      // walkToExprPost has cancelled the traversal. Stop.
-      return { false, nullptr };
+    // TODO: We should consider changing Action::SkipChildren to still call
+    // walkToExprPost, which would eliminate the need for this.
+    auto postWalkResult = walkToExprPost(E);
+    switch (postWalkResult.Action.Action) {
+    case PostWalkAction::Stop:
+      return Action::Stop();
+    case PostWalkAction::Continue:
+      return Action::SkipChildren(*postWalkResult.Value);
     }
-    return { false, E };
+    llvm_unreachable("Unhandled case in switch!");
   };
 
   if (auto *CtorRefE = dyn_cast<ConstructorRefCallExpr>(E))
@@ -385,8 +395,9 @@ std::pair<bool, Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
     if (DRE->isImplicit() && FD && FD->isCallAsFunctionMethod()) {
       ReferenceMetaData data(SemaReferenceKind::DeclMemberRef, OpAccess);
       if (!passCallAsFunctionReference(FD, DRE->getLoc(), data))
-        return {false, nullptr};
-      return {true, E};
+        return Action::Stop();
+
+      return Action::Continue(E);
     }
   }
 
@@ -395,7 +406,7 @@ std::pair<bool, Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
       !isa<CollectionUpcastConversionExpr>(E) && !isa<OpaqueValueExpr>(E) &&
       !isa<SubscriptExpr>(E) && !isa<KeyPathExpr>(E) && !isa<LiteralExpr>(E) &&
       !isa<CollectionExpr>(E) && E->isImplicit())
-    return {true, E};
+    return Action::Continue(E);
 
   if (auto LE = dyn_cast<LiteralExpr>(E)) {
     if (LE->getInitializer() &&
@@ -405,7 +416,7 @@ std::pair<bool, Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
                                          /*isImplicit=*/true))) {
       return doStopTraversal();
     }
-    return {true, E};
+    return Action::Continue(E);
   } else if (auto CE = dyn_cast<CollectionExpr>(E)) {
     if (CE->getInitializer() &&
         !passReference(CE->getInitializer().getDecl(), CE->getType(), {},
@@ -414,7 +425,7 @@ std::pair<bool, Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
                                          /*isImplicit=*/true))) {
       return doStopTraversal();
     }
-    return {true, E};
+    return Action::Continue(E);
   } else if (auto *DRE = dyn_cast<DeclRefExpr>(E)) {
     if (auto *module = dyn_cast<ModuleDecl>(DRE->getDecl())) {
       if (!passReference(ModuleEntity(module),
@@ -618,13 +629,12 @@ std::pair<bool, Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
     return doSkipChildren();
   }
 
-  return { true, E };
+  return Action::Continue(E);
 }
 
-Expr *SemaAnnotator::walkToExprPost(Expr *E) {
-  if (isDone()) {
-    return nullptr;
-  }
+ASTWalker::PostWalkResult<Expr *> SemaAnnotator::walkToExprPost(Expr *E) {
+  if (isDone())
+    return Action::Stop();
 
   if (isa<ConstructorRefCallExpr>(E)) {
     assert(CtorRefs.back() == E);
@@ -632,85 +642,95 @@ Expr *SemaAnnotator::walkToExprPost(Expr *E) {
   }
 
   bool Continue = SEWalker.walkToExprPost(E);
-  if (!Continue)
+  if (!Continue) {
     Cancelled = true;
-  return Continue ? E : nullptr;
+    return Action::Stop();
+  }
+  return Action::Continue(E);
 }
 
-bool SemaAnnotator::walkToTypeReprPre(TypeRepr *T) {
+ASTWalker::PreWalkAction SemaAnnotator::walkToTypeReprPre(TypeRepr *T) {
   if (isDone())
-    return false;
+    return Action::Stop();
 
   bool Continue = SEWalker.walkToTypeReprPre(T);
   if (!Continue) {
     Cancelled = true;
-    return false;
+    return Action::Stop();
   }
 
   if (auto IdT = dyn_cast<ComponentIdentTypeRepr>(T)) {
     if (ValueDecl *VD = IdT->getBoundDecl()) {
       if (auto *ModD = dyn_cast<ModuleDecl>(VD)) {
         auto ident = IdT->getNameRef().getBaseIdentifier();
-        return passReference(ModD, { ident, IdT->getLoc() });
+        auto VisitChildren = passReference(ModD, {ident, IdT->getLoc()});
+        return Action::VisitChildrenIf(VisitChildren);
       }
-
-      return passReference(VD, Type(), IdT->getNameLoc(),
-                           ReferenceMetaData(SemaReferenceKind::TypeRef, None));
+      auto VisitChildren =
+          passReference(VD, Type(), IdT->getNameLoc(),
+                        ReferenceMetaData(SemaReferenceKind::TypeRef, None));
+      return Action::VisitChildrenIf(VisitChildren);
     }
   }
 
-  return true;
+  return Action::Continue();
 }
 
-bool SemaAnnotator::walkToTypeReprPost(TypeRepr *T) {
-  if (isDone()) {
-    return false;
-  }
+ASTWalker::PostWalkAction SemaAnnotator::walkToTypeReprPost(TypeRepr *T) {
+  if (isDone())
+    return Action::Stop();
 
   bool Continue = SEWalker.walkToTypeReprPost(T);
-  if (!Continue)
+  if (!Continue) {
     Cancelled = true;
-  return Continue;
+    return Action::Stop();
+  }
+  return Action::Continue();
 }
 
-std::pair<bool, Pattern *> SemaAnnotator::walkToPatternPre(Pattern *P) {
-  if (isDone()) {
-    return { false, nullptr };
-  }
+ASTWalker::PreWalkResult<Pattern *>
+SemaAnnotator::walkToPatternPre(Pattern *P) {
+  if (isDone())
+    return Action::Stop();
 
   if (!SEWalker.walkToPatternPre(P))
-    return { false, P };
+    return Action::SkipChildren(P);
 
   if (P->isImplicit())
-    return { true, P };
+    return Action::Continue(P);
 
   if (auto *EP = dyn_cast<EnumElementPattern>(P)) {
     auto *Element = EP->getElementDecl();
     if (!Element)
-      return { true, P };
+      return Action::Continue(P);
     Type T = EP->hasType() ? EP->getType() : Type();
-    return { passReference(Element, T, DeclNameLoc(EP->getLoc()),
-                ReferenceMetaData(SemaReferenceKind::EnumElementRef, None)), P };
+    auto Continue = passReference(
+        Element, T, DeclNameLoc(EP->getLoc()),
+        ReferenceMetaData(SemaReferenceKind::EnumElementRef, None));
+    return Action::VisitChildrenIf(Continue, P);
   }
 
   auto *TP = dyn_cast<TypedPattern>(P);
   if (!TP || !TP->isPropagatedType())
-    return { true, P };
+    return Action::Continue(P);
 
   // If the typed pattern was propagated from somewhere, just walk the
   // subpattern.  The type will be walked as a part of another TypedPattern.
   TP->getSubPattern()->walk(*this);
-  return { false, P };
+  return Action::SkipChildren(P);
 }
 
-Pattern *SemaAnnotator::walkToPatternPost(Pattern *P) {
+ASTWalker::PostWalkResult<Pattern *>
+SemaAnnotator::walkToPatternPost(Pattern *P) {
   if (isDone())
-     return nullptr;
+    return Action::Stop();
 
   bool Continue = SEWalker.walkToPatternPost(P);
-  if (!Continue)
+  if (!Continue) {
     Cancelled = true;
-  return Continue ? P : nullptr;
+    return Action::Stop();
+  }
+  return Action::Continue(P);
 }
 
 bool SemaAnnotator::handleCustomAttributes(Decl *D) {

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -196,7 +196,7 @@ bool NameMatcher::handleCustomAttrs(Decl *D) {
   return !isDone();
 }
 
-bool NameMatcher::walkToDeclPre(Decl *D) {
+ASTWalker::PreWalkAction NameMatcher::walkToDeclPre(Decl *D) {
   // Handle occurrences in any preceding doc comments
   RawComment R = D->getRawComment(/*SerializedOK=*/false);
   if (!R.isEmpty()) {
@@ -209,13 +209,13 @@ bool NameMatcher::walkToDeclPre(Decl *D) {
   // FIXME: Even implicit Decls should have proper ranges if they include any
   // non-implicit children (fix implicit Decls created for lazy vars).
   if (D->isImplicit())
-    return !isDone();
+    return Action::SkipChildrenIf(isDone());
 
   if (shouldSkip(D->getSourceRangeIncludingAttrs()))
-    return false;
-  
+    return Action::SkipChildren();
+
   if (!handleCustomAttrs(D))
-    return false;
+    return Action::SkipChildren();
 
   if (auto *ICD = dyn_cast<IfConfigDecl>(D)) {
     for (auto Clause : ICD->getClauses()) {
@@ -231,7 +231,7 @@ bool NameMatcher::walkToDeclPre(Decl *D) {
         --InactiveConfigRegionNestings;
       }
     }
-    return false;
+    return Action::SkipChildren();
   } else if (AbstractFunctionDecl *AFD = dyn_cast<AbstractFunctionDecl>(D)) {
     std::vector<CharSourceRange> LabelRanges;
     if (AFD->getNameLoc() == nextLoc()) {
@@ -261,25 +261,28 @@ bool NameMatcher::walkToDeclPre(Decl *D) {
              isa<PrecedenceGroupDecl>(D)) {
     tryResolve(ASTWalker::ParentTy(D), D->getLoc());
   }
-  return !isDone();
+  // TODO: Can this use Action::StopIf?
+  return Action::SkipChildrenIf(isDone());
 }
 
-bool NameMatcher::walkToDeclPost(Decl *D) {
-  return !isDone();
+ASTWalker::PostWalkAction NameMatcher::walkToDeclPost(Decl *D) {
+  return Action::StopIf(isDone());
 }
 
-std::pair<bool, Stmt *> NameMatcher::walkToStmtPre(Stmt *S) {
+ASTWalker::PreWalkResult<Stmt *> NameMatcher::walkToStmtPre(Stmt *S) {
   // FIXME: Even implicit Stmts should have proper ranges that include any
   // non-implicit Stmts (fix Stmts created for lazy vars).
-  if (!S->isImplicit() && shouldSkip(S->getSourceRange()))
-    return std::make_pair(false, isDone()? nullptr : S);
-  return std::make_pair(true, S);
+  if (!S->isImplicit() && shouldSkip(S->getSourceRange())) {
+    if (isDone())
+      return Action::Stop();
+
+    return Action::SkipChildren(S);
+  }
+  return Action::Continue(S);
 }
 
-Stmt *NameMatcher::walkToStmtPost(Stmt *S) {
-  if (isDone())
-    return nullptr;
-  return S;
+ASTWalker::PostWalkResult<Stmt *> NameMatcher::walkToStmtPost(Stmt *S) {
+  return Action::StopIf(isDone(), S);
 }
 
 ArgumentList *NameMatcher::getApplicableArgsFor(Expr *E) {
@@ -308,7 +311,7 @@ static Expr *extractNameExpr(Expr *Fn) {
   return nullptr;
 }
 
-std::pair<bool, ArgumentList *>
+ASTWalker::PreWalkResult<ArgumentList *>
 NameMatcher::walkToArgumentListPre(ArgumentList *ArgList) {
   if (!ArgList->isImplicit()) {
     auto Labels = getCallArgLabelRanges(getSourceMgr(), ArgList,
@@ -317,7 +320,7 @@ NameMatcher::walkToArgumentListPre(ArgumentList *ArgList) {
              Labels.first, Labels.second);
   }
   if (isDone())
-    return {false, ArgList};
+    return Action::SkipChildren(ArgList);
 
   // Handle arg label locations (the index reports property occurrences on them
   // for memberwise inits).
@@ -327,21 +330,31 @@ NameMatcher::walkToArgumentListPre(ArgumentList *ArgList) {
     if (!Name.empty()) {
       tryResolve(Parent, Arg.getLabelLoc());
       if (isDone())
-        return {false, ArgList};
+        return Action::SkipChildren(ArgList);
     }
     if (!E->walk(*this))
-      return {false, ArgList};
+      return Action::SkipChildren(ArgList);
   }
-  // We already visited the children.
-  if (!walkToArgumentListPost(ArgList))
-    return {false, nullptr};
-  return {false, ArgList};
+  // TODO: We should consider changing Action::SkipChildren to still call
+  // walkToArgumentListPost, which would eliminate the need for this.
+  auto postWalkResult = walkToArgumentListPost(ArgList);
+  switch (postWalkResult.Action.Action) {
+  case PostWalkAction::Stop:
+    return Action::Stop();
+  case PostWalkAction::Continue:
+    // We already visited the children.
+    return Action::SkipChildren(*postWalkResult.Value);
+  }
+  llvm_unreachable("Unhandled case in switch!");
 }
 
-std::pair<bool, Expr*> NameMatcher::walkToExprPre(Expr *E) {
-  if (shouldSkip(E))
-    return std::make_pair(false, isDone()? nullptr : E);
+ASTWalker::PreWalkResult<Expr *> NameMatcher::walkToExprPre(Expr *E) {
+  if (shouldSkip(E)) {
+    if (isDone())
+      return Action::Stop();
 
+    return Action::SkipChildren(E);
+  }
   if (isa<ObjCSelectorExpr>(E)) {
       ++SelectorNestings;
   }
@@ -388,16 +401,23 @@ std::pair<bool, Expr*> NameMatcher::walkToExprPre(Expr *E) {
         BinaryExpr *BinE = cast<BinaryExpr>(E);
         // Visit in source order.
         if (!BinE->getLHS()->walk(*this))
-          return {false, nullptr};
+          return Action::Stop();
         if (!BinE->getFn()->walk(*this))
-          return {false, nullptr};
+          return Action::Stop();
         if (!BinE->getRHS()->walk(*this))
-          return {false, nullptr};
+          return Action::Stop();
 
-        // We already visited the children.
-        if (!walkToExprPost(E))
-          return {false, nullptr};
-        return {false, E};
+        // TODO: We should consider changing Action::SkipChildren to still call
+        // walkToArgumentListPost, which would eliminate the need for this.
+        auto postWalkResult = walkToExprPost(E);
+        switch (postWalkResult.Action.Action) {
+        case PostWalkAction::Stop:
+          return Action::Stop();
+        case PostWalkAction::Continue:
+          // We already visited the children.
+          return Action::SkipChildren(*postWalkResult.Value);
+        }
+        llvm_unreachable("Unhandled case in switch!");
       }
       case ExprKind::KeyPath: {
         KeyPathExpr *KP = cast<KeyPathExpr>(E);
@@ -434,12 +454,12 @@ std::pair<bool, Expr*> NameMatcher::walkToExprPre(Expr *E) {
         break;
     }
   }
-  return std::make_pair(!isDone(), isDone()? nullptr : E);
+  return Action::StopIf(isDone(), E);
 }
 
-Expr *NameMatcher::walkToExprPost(Expr *E) {
+ASTWalker::PostWalkResult<Expr *> NameMatcher::walkToExprPost(Expr *E) {
   if (isDone())
-    return nullptr;
+    return Action::Stop();
 
   if (!E->isImplicit()) {
     // Try to resolve against the below kinds *after* their children have been
@@ -469,12 +489,12 @@ Expr *NameMatcher::walkToExprPost(Expr *E) {
     --SelectorNestings;
   }
 
-  return E;
+  return Action::Continue(E);
 }
 
-bool NameMatcher::walkToTypeReprPre(TypeRepr *T) {
+ASTWalker::PreWalkAction NameMatcher::walkToTypeReprPre(TypeRepr *T) {
   if (isDone() || shouldSkip(T->getSourceRange()))
-    return false;
+    return Action::SkipChildren();
 
   if (isa<ComponentIdentTypeRepr>(T)) {
     // If we're walking a CustomAttr's type we may have an associated call
@@ -489,19 +509,19 @@ bool NameMatcher::walkToTypeReprPre(TypeRepr *T) {
       tryResolve(ASTWalker::ParentTy(T), T->getLoc());
     }
   }
-  return !isDone();
+  return Action::SkipChildrenIf(isDone());
 }
 
-bool NameMatcher::walkToTypeReprPost(TypeRepr *T) {
-  return !isDone();
+ASTWalker::PostWalkAction NameMatcher::walkToTypeReprPost(TypeRepr *T) {
+  return Action::StopIf(isDone());
 }
 
-std::pair<bool, Pattern*> NameMatcher::walkToPatternPre(Pattern *P) {
+ASTWalker::PreWalkResult<Pattern *> NameMatcher::walkToPatternPre(Pattern *P) {
   if (isDone() || shouldSkip(P->getSourceRange()))
-    return std::make_pair(false, P);
+    return Action::SkipChildren(P);
 
   tryResolve(ASTWalker::ParentTy(P), P->getStartLoc());
-  return std::make_pair(!isDone(), P);
+  return Action::SkipChildrenIf(isDone(), P);
 }
 
 bool NameMatcher::checkComments() {

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -854,9 +854,11 @@ std::pair<bool, Stmt *> ModelASTWalker::walkToStmtPre(Stmt *S) {
     // Since 'DeferStmt::getTempDecl()' is marked as implicit, we manually walk
     // into the body.
     if (auto *FD = DeferS->getTempDecl()) {
-      auto *RetS = FD->getBody()->walk(*this);
-      assert(RetS == FD->getBody());
-      (void)RetS;
+      if (auto *Body = FD->getBody()) {
+        auto *RetS = Body->walk(*this);
+        assert(RetS == Body);
+        (void)RetS;
+      }
       walkToStmtPost(DeferS);
     }
     // Already walked children.

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -396,17 +396,18 @@ public:
 
   void visitSourceFile(SourceFile &SrcFile, ArrayRef<SyntaxNode> Tokens);
 
-  std::pair<bool, ArgumentList *>
+  PreWalkResult<ArgumentList *>
   walkToArgumentListPre(ArgumentList *ArgList) override;
-  ArgumentList *walkToArgumentListPost(ArgumentList *ArgList) override;
+  PostWalkResult<ArgumentList *>
+  walkToArgumentListPost(ArgumentList *ArgList) override;
 
-  std::pair<bool, Expr *> walkToExprPre(Expr *E) override;
-  Expr *walkToExprPost(Expr *E) override;
-  std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override;
-  Stmt *walkToStmtPost(Stmt *S) override;
-  bool walkToDeclPre(Decl *D) override;
-  bool walkToDeclPost(Decl *D) override;
-  bool walkToTypeReprPre(TypeRepr *T) override;
+  PreWalkResult<Expr *> walkToExprPre(Expr *E) override;
+  PostWalkResult<Expr *> walkToExprPost(Expr *E) override;
+  PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override;
+  PostWalkResult<Stmt *> walkToStmtPost(Stmt *S) override;
+  PreWalkAction walkToDeclPre(Decl *D) override;
+  PostWalkAction walkToDeclPost(Decl *D) override;
+  PreWalkAction walkToTypeReprPre(TypeRepr *T) override;
   bool shouldWalkIntoGenericParams() override { return true; }
 
 private:
@@ -538,11 +539,11 @@ static bool shouldTreatAsSingleToken(const SyntaxStructureNode &Node,
              SM.getLineAndColumnInBuffer(Node.Range.getEnd()).first;
 }
 
-std::pair<bool, ArgumentList *>
+ASTWalker::PreWalkResult<ArgumentList *>
 ModelASTWalker::walkToArgumentListPre(ArgumentList *ArgList) {
   Expr *ParentExpr = Parent.getAsExpr();
   if (!ParentExpr)
-    return {true, ArgList};
+    return Action::Continue(ArgList);
 
   ParentArgsTy Mapping;
   Mapping.Parent = ParentExpr;
@@ -552,21 +553,22 @@ ModelASTWalker::walkToArgumentListPre(ArgumentList *ArgList) {
     (void)res;
   }
   ParentArgs.push_back(std::move(Mapping));
-  return {true, ArgList};
+  return Action::Continue(ArgList);
 }
 
-ArgumentList *ModelASTWalker::walkToArgumentListPost(ArgumentList *ArgList) {
+ASTWalker::PostWalkResult<ArgumentList *>
+ModelASTWalker::walkToArgumentListPost(ArgumentList *ArgList) {
   if (Expr *ParentExpr = Parent.getAsExpr()) {
     assert(ParentExpr == ParentArgs.back().Parent &&
            "Unmatched walkToArgumentList(Pre|Post)");
     ParentArgs.pop_back();
   }
-  return ArgList;
+  return Action::Continue(ArgList);
 }
 
-std::pair<bool, Expr *> ModelASTWalker::walkToExprPre(Expr *E) {
+ASTWalker::PreWalkResult<Expr *> ModelASTWalker::walkToExprPre(Expr *E) {
   if (isVisitedBefore(E))
-    return {false, E};
+    return Action::SkipChildren(E);
 
   auto addCallArgExpr = [&](const Argument &Arg) {
     auto *Elem = Arg.getExpr();
@@ -601,7 +603,7 @@ std::pair<bool, Expr *> ModelASTWalker::walkToExprPre(Expr *E) {
   }
 
   if (E->isImplicit())
-    return { true, E };
+    return Action::Continue(E);
 
   auto addExprElem = [&](const Expr *Elem, SyntaxStructureNode &SN) {
     if (isa<ErrorExpr>(Elem))
@@ -706,7 +708,17 @@ std::pair<bool, Expr *> ModelASTWalker::walkToExprPre(Expr *E) {
       llvm::SaveAndRestore<ASTWalker::ParentTy> SetParent(Parent, E);
       subExpr->walk(*this);
     }
-    return { false, walkToExprPost(SE) };
+    // TODO: We should consider changing Action::SkipChildren to still call
+    // walkToExprPost, which would eliminate the need for this.
+    auto postWalkResult = walkToExprPost(SE);
+    switch (postWalkResult.Action.Action) {
+    case PostWalkAction::Stop:
+      return Action::Stop();
+    case PostWalkAction::Continue:
+      // We already visited the children.
+      return Action::SkipChildren(*postWalkResult.Value);
+    }
+    llvm_unreachable("Unhandled case in switch!");
   } else if (auto *ISL = dyn_cast<InterpolatedStringLiteralExpr>(E)) {
     // Don't visit the child expressions directly. Instead visit the arguments
     // of each appendStringLiteral/appendInterpolation CallExpr so we don't
@@ -718,23 +730,33 @@ std::pair<bool, Expr *> ModelASTWalker::walkToExprPre(Expr *E) {
           arg.getExpr()->walk(*this);
       }
     });
-    return { false, walkToExprPost(E) };
+    // TODO: We should consider changing Action::SkipChildren to still call
+    // walkToExprPost, which would eliminate the need for this.
+    auto postWalkResult = walkToExprPost(E);
+    switch (postWalkResult.Action.Action) {
+    case PostWalkAction::Stop:
+      return Action::Stop();
+    case PostWalkAction::Continue:
+      // We already visited the children.
+      return Action::SkipChildren(*postWalkResult.Value);
+    }
+    llvm_unreachable("Unhandled case in switch!");
   }
 
-  return { true, E };
+  return Action::Continue(E);
 }
 
-Expr *ModelASTWalker::walkToExprPost(Expr *E) {
+ASTWalker::PostWalkResult<Expr *> ModelASTWalker::walkToExprPost(Expr *E) {
   while (!SubStructureStack.empty() &&
       SubStructureStack.back().ASTNode.getAsExpr() == E)
     popStructureNode();
 
-  return E;
+  return Action::Continue(E);
 }
 
-std::pair<bool, Stmt *> ModelASTWalker::walkToStmtPre(Stmt *S) {
+ASTWalker::PreWalkResult<Stmt *> ModelASTWalker::walkToStmtPre(Stmt *S) {
   if (isVisitedBefore(S)) {
-    return {false, S};
+    return Action::SkipChildren(S);
   }
   auto addExprElem = [&](SyntaxStructureElementKind K, const Expr *Elem,
                          SyntaxStructureNode &SN) {
@@ -862,25 +884,25 @@ std::pair<bool, Stmt *> ModelASTWalker::walkToStmtPre(Stmt *S) {
       walkToStmtPost(DeferS);
     }
     // Already walked children.
-    return { false, DeferS };
+    return Action::SkipChildren(DeferS);
   }
 
-  return { true, S };
+  return Action::Continue(S);
 }
 
-Stmt *ModelASTWalker::walkToStmtPost(Stmt *S) {
+ASTWalker::PostWalkResult<Stmt *> ModelASTWalker::walkToStmtPost(Stmt *S) {
   while (!SubStructureStack.empty() &&
       SubStructureStack.back().ASTNode.getAsStmt() == S)
     popStructureNode();
 
-  return S;
+  return Action::Continue(S);
 }
 
-bool ModelASTWalker::walkToDeclPre(Decl *D) {
+ASTWalker::PreWalkAction ModelASTWalker::walkToDeclPre(Decl *D) {
   if (isVisitedBefore(D))
-    return false;
+    return Action::SkipChildren();
   if (D->isImplicit())
-    return false;
+    return Action::SkipChildren();
 
   // The attributes of EnumElementDecls and VarDecls are handled when visiting
   // their parent EnumCaseDecl/PatternBindingDecl (which the attributes are
@@ -888,7 +910,7 @@ bool ModelASTWalker::walkToDeclPre(Decl *D) {
   if (!isa<EnumElementDecl>(D) &&
       !(isa<VarDecl>(D) && cast<VarDecl>(D)->getParentPatternBinding())) {
     if (!handleAttrs(D->getAttrs()))
-      return false;
+      return Action::SkipChildren();
   }
 
   if (isa<AccessorDecl>(D)) {
@@ -985,7 +1007,7 @@ bool ModelASTWalker::walkToDeclPre(Decl *D) {
       });
       if (Contained) {
         if (!handleAttrs(Contained->getAttrs()))
-          return false;
+          return Action::SkipChildren();
         break;
       }
     }
@@ -1032,7 +1054,7 @@ bool ModelASTWalker::walkToDeclPre(Decl *D) {
   } else if (auto *ConfigD = dyn_cast<IfConfigDecl>(D)) {
     for (auto &Clause : ConfigD->getClauses()) {
       if (Clause.Cond && !annotateIfConfigConditionIdentifiers(Clause.Cond))
-        return false;
+        return Action::SkipChildren();
 
       InactiveClauseRAII inactiveClauseRAII(inInactiveClause, !Clause.isActive);
       for (auto &Element : Clause.Elements) {
@@ -1057,7 +1079,7 @@ bool ModelASTWalker::walkToDeclPre(Decl *D) {
     // attach to enum element decls while syntactically locate before enum case decl.
     if (!EnumCaseD->getElements().empty()) {
       if (!handleAttrs(EnumCaseD->getElements().front()->getAttrs()))
-        return false;
+        return Action::SkipChildren();
     }
     if (pushStructureNode(SN, D)) {
       // FIXME: ASTWalker walks enum elements as members of the enum decl, not
@@ -1140,34 +1162,34 @@ bool ModelASTWalker::walkToDeclPre(Decl *D) {
     pushStructureNode(SN, GenericParamD);
   }
 
-  return true;
+  return Action::Continue();
 }
 
-bool ModelASTWalker::walkToDeclPost(swift::Decl *D) {
+ASTWalker::PostWalkAction ModelASTWalker::walkToDeclPost(swift::Decl *D) {
   while (!SubStructureStack.empty() &&
       SubStructureStack.back().ASTNode.getAsDecl() == D)
     popStructureNode();
 
-  return true;
+  return Action::Continue();
 }
 
-bool ModelASTWalker::walkToTypeReprPre(TypeRepr *T) {
+ASTWalker::PreWalkAction ModelASTWalker::walkToTypeReprPre(TypeRepr *T) {
   if (auto AttrT = dyn_cast<AttributedTypeRepr>(T)) {
     if (!handleAttrs(AttrT->getAttrs()))
-      return false;
+      return Action::SkipChildren();
 
   } else if (auto IdT = dyn_cast<ComponentIdentTypeRepr>(T)) {
     if (!passTokenNodesUntil(IdT->getStartLoc(),
                              ExcludeNodeAtLocation).shouldContinue)
-      return false;
+      return Action::SkipChildren();
     if (TokenNodes.empty() ||
         TokenNodes.front().Range.getStart() != IdT->getStartLoc())
-      return false;
+      return Action::SkipChildren();
     if (!passNode({SyntaxNodeKind::TypeId, TokenNodes.front().Range}))
-      return false;
+      return Action::SkipChildren();
     TokenNodes = TokenNodes.slice(1);
   }
-  return true;
+  return Action::Continue();
 }
 
 namespace {
@@ -1178,18 +1200,18 @@ class IdRefWalker : public ASTWalker {
 public:
   IdRefWalker(const FnTy &Fn) : Fn(Fn) {}
 
-  std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+  PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
     if (auto DRE = dyn_cast<UnresolvedDeclRefExpr>(E)) {
       if (!DRE->hasName())
-        return { true, E };
+        return Action::Continue(E);
       if (DRE->getRefKind() != DeclRefKind::Ordinary)
-        return { true, E };
+        return Action::Continue(E);
       if (!Fn(CharSourceRange(
               DRE->getSourceRange().Start,
               DRE->getName().getBaseName().userFacingName().size())))
-        return { false, nullptr };
+        return Action::Stop();
     }
-    return { true, E };
+    return Action::Continue(E);
   }
 };
 } // end anonymous namespace

--- a/lib/IRGen/TypeLayoutDumper.cpp
+++ b/lib/IRGen/TypeLayoutDumper.cpp
@@ -51,11 +51,11 @@ public:
   NominalTypeWalker(std::vector<NominalTypeDecl *> &Results)
     : Results(Results) {}
 
-  bool walkToDeclPre(Decl *D) override {
+  PreWalkAction walkToDeclPre(Decl *D) override {
     if (auto *NTD = dyn_cast<NominalTypeDecl>(D))
       Results.push_back(NTD);
 
-    return true;
+    return Action::Continue();
   }
 };
 

--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -1390,7 +1390,7 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
       }
       return false;
     }
-    std::pair<bool, Stmt*> walkToStmtPre(Stmt *S) override {
+    PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
       if (auto *BS = dyn_cast<BraceStmt>(S)) {
         for(auto Ele: BS->getElements()) {
           if (Ele.is<Expr*>() && isSuperExpr(Ele.get<Expr*>())) {
@@ -1399,7 +1399,7 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
 	}
       }
       // We only handle top-level expressions, so avoid visiting further.
-      return {false, S};
+      return Action::SkipChildren(S);
     }
   };
 

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -2616,23 +2616,29 @@ struct FallthroughFinder : ASTWalker {
 
   // We walk through statements.  If we find a fallthrough, then we got what
   // we came for.
-  std::pair<bool, Stmt *> walkToStmtPre(Stmt *s) override {
+  PreWalkResult<Stmt *> walkToStmtPre(Stmt *s) override {
     if (auto *f = dyn_cast<FallthroughStmt>(s)) {
       result = f;
     }
 
-    return {true, s};
+    return Action::Continue(s);
   }
 
   // Expressions, patterns and decls cannot contain fallthrough statements, so
   // there is no reason to walk into them.
-  std::pair<bool, Expr *> walkToExprPre(Expr *e) override { return {false, e}; }
-  std::pair<bool, Pattern *> walkToPatternPre(Pattern *p) override {
-    return {false, p};
+  PreWalkResult<Expr *> walkToExprPre(Expr *e) override {
+    return Action::SkipChildren(e);
+  }
+  PreWalkResult<Pattern *> walkToPatternPre(Pattern *p) override {
+    return Action::SkipChildren(p);
   }
 
-  bool walkToDeclPre(Decl *d) override { return false; }
-  bool walkToTypeReprPre(TypeRepr *t) override { return false; }
+  PreWalkAction walkToDeclPre(Decl *d) override {
+    return Action::SkipChildren();
+  }
+  PreWalkAction walkToTypeReprPre(TypeRepr *t) override {
+    return Action::SkipChildren();
+  }
 
   static FallthroughStmt *findFallthrough(Stmt *s) {
     FallthroughFinder finder;

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -538,14 +538,14 @@ ParserResult<TypeRepr> Parser::parseTypeScalar(
     // Forget any generic parameters we saw in the type.
     class EraseTypeParamWalker : public ASTWalker {
     public:
-      bool walkToTypeReprPre(TypeRepr *T) override {
+      PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
         if (auto ident = dyn_cast<ComponentIdentTypeRepr>(T)) {
           if (auto decl = ident->getBoundDecl()) {
             if (auto genericParam = dyn_cast<GenericTypeParamDecl>(decl))
               ident->overwriteNameRef(genericParam->createNameRef());
           }
         }
-        return true;
+        return Action::Continue();
       }
 
     } walker;

--- a/lib/SIL/IR/SILProfiler.cpp
+++ b/lib/SIL/IR/SILProfiler.cpp
@@ -178,11 +178,13 @@ namespace {
 ///
 /// Apply \p Func if the function can be visited.
 template <typename F>
-bool visitFunctionDecl(ASTWalker &Walker, AbstractFunctionDecl *AFD, F Func) {
-  bool continueWalk = Walker.Parent.isNull();
-  if (continueWalk)
+ASTWalker::PreWalkAction
+visitFunctionDecl(ASTWalker &Walker, AbstractFunctionDecl *AFD, F Func) {
+  if (Walker.Parent.isNull()) {
     Func();
-  return continueWalk;
+    return ASTWalker::Action::Continue();
+  }
+  return ASTWalker::Action::SkipChildren();
 }
 
 /// Whether to skip visitation of an expression. Children of skipped exprs
@@ -231,19 +233,19 @@ struct MapRegionCounters : public ASTWalker {
     ++NextCounter;
   }
 
-  bool walkToDeclPre(Decl *D) override {
+  PreWalkAction walkToDeclPre(Decl *D) override {
     if (isUnmapped(D))
-      return shouldWalkUnmappedDecl(D);
+      return Action::VisitChildrenIf(shouldWalkUnmappedDecl(D));
 
     if (auto *AFD = dyn_cast<AbstractFunctionDecl>(D)) {
       return visitFunctionDecl(*this, AFD, [&] { mapRegion(AFD->getBody()); });
     } else if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(D)) {
       mapRegion(TLCD->getBody());
     }
-    return true;
+    return Action::Continue();
   }
 
-  std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
+  PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
     if (auto *IS = dyn_cast<IfStmt>(S)) {
       mapRegion(IS->getThenStmt());
     } else if (auto *US = dyn_cast<GuardStmt>(S)) {
@@ -257,17 +259,17 @@ struct MapRegionCounters : public ASTWalker {
     } else if (auto *CS = dyn_cast<CaseStmt>(S)) {
       mapRegion(getProfilerStmtForCase(CS));
     }
-    return {true, S};
+    return Action::Continue(S);
   }
 
-  std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+  PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
     if (skipExpr(E))
-      return {true, E};
+      return Action::Continue(E);
 
     // Profiling for closures should be handled separately. Do not visit
     // closure expressions twice.
     if (isa<AbstractClosureExpr>(E) && !Parent.isNull())
-      return {false, E};
+      return Action::SkipChildren(E);
 
     // If AST visitation begins with an expression, the counter map must be
     // empty. Set up a counter for the root.
@@ -283,7 +285,7 @@ struct MapRegionCounters : public ASTWalker {
     if (isa<LazyInitializerExpr>(E))
       mapRegion(E);
 
-    return {true, E};
+    return Action::Continue(E);
   }
 };
 
@@ -578,9 +580,9 @@ struct PGOMapping : public ASTWalker {
     LoadedCounterMap[Node] = count;
   }
 
-  bool walkToDeclPre(Decl *D) override {
+  PreWalkAction walkToDeclPre(Decl *D) override {
     if (isUnmapped(D))
-      return shouldWalkUnmappedDecl(D);
+      return Action::VisitChildrenIf(shouldWalkUnmappedDecl(D));
     if (auto *AFD = dyn_cast<AbstractFunctionDecl>(D)) {
       return visitFunctionDecl(*this, AFD, [&] {
         setKnownExecutionCount(AFD->getBody());
@@ -589,7 +591,7 @@ struct PGOMapping : public ASTWalker {
     if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(D))
       setKnownExecutionCount(TLCD->getBody());
 
-    return true;
+    return Action::Continue();
   }
 
   LazyInitializerWalking getLazyInitializerWalkingBehavior() override {
@@ -598,7 +600,7 @@ struct PGOMapping : public ASTWalker {
     return LazyInitializerWalking::InAccessor;
   }
 
-  std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
+  PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
     unsigned parent = getParentCounter();
     auto parentCount = LoadedCounts.Counts[parent];
     if (auto *IS = dyn_cast<IfStmt>(S)) {
@@ -643,17 +645,17 @@ struct PGOMapping : public ASTWalker {
     } else if (auto *CS = dyn_cast<CaseStmt>(S)) {
       setKnownExecutionCount(getProfilerStmtForCase(CS));
     }
-    return {true, S};
+    return Action::Continue(S);
   }
 
-  std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+  PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
     if (skipExpr(E))
-      return {true, E};
+      return Action::Continue(E);
 
     // Profiling for closures should be handled separately. Do not visit
     // closure expressions twice.
     if (isa<AbstractClosureExpr>(E) && !Parent.isNull())
-      return {false, E};
+      return Action::SkipChildren(E);
 
     unsigned parent = getParentCounter();
 
@@ -682,7 +684,7 @@ struct PGOMapping : public ASTWalker {
     if (isa<LazyInitializerExpr>(E))
       setKnownExecutionCount(E);
 
-    return {true, E};
+    return Action::Continue(E);
   }
 };
 
@@ -949,9 +951,9 @@ public:
                                   Builder.getExpressions());
   }
 
-  bool walkToDeclPre(Decl *D) override {
+  PreWalkAction walkToDeclPre(Decl *D) override {
     if (isUnmapped(D))
-      return shouldWalkUnmappedDecl(D);
+      return Action::VisitChildrenIf(shouldWalkUnmappedDecl(D));
 
     if (auto *AFD = dyn_cast<AbstractFunctionDecl>(D)) {
       return visitFunctionDecl(*this, AFD, [&] {
@@ -961,18 +963,18 @@ public:
       assignCounter(TLCD->getBody());
       ImplicitTopLevelBody = TLCD->getBody();
     }
-    return true;
+    return Action::Continue();
   }
 
-  bool walkToDeclPost(Decl *D) override {
+  PostWalkAction walkToDeclPost(Decl *D) override {
     if (isa<TopLevelCodeDecl>(D))
       ImplicitTopLevelBody = nullptr;
-    return true;
+    return Action::Continue();
   }
 
-  std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
+  PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
     if (S->isImplicit() && S != ImplicitTopLevelBody)
-      return {true, S};
+      return Action::Continue(S);
 
     // If we're in an 'incomplete' region, update it to include this node. This
     // ensures we only create the region if needed.
@@ -1060,12 +1062,12 @@ public:
       assignCounter(DCS, CounterExpr::Ref(getCurrentCounter()));
       DoCatchStack.push_back(DCS);
     }
-    return {true, S};
+    return Action::Continue(S);
   }
 
-  Stmt *walkToStmtPost(Stmt *S) override {
+  PostWalkResult<Stmt *> walkToStmtPost(Stmt *S) override {
     if (S->isImplicit() && S != ImplicitTopLevelBody)
-      return S;
+      return Action::Continue(S);
 
     if (isa<BraceStmt>(S)) {
       if (hasCounter(S)) {
@@ -1141,17 +1143,17 @@ public:
 
       terminateRegion(S);
     }
-    return S;
+    return Action::Continue(S);
   }
 
-  std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+  PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
     if (skipExpr(E))
-      return {true, E};
+      return Action::Continue(E);
 
     // Profiling for closures should be handled separately. Do not visit
     // closure expressions twice.
     if (isa<AbstractClosureExpr>(E) && !Parent.isNull())
-      return {false, E};
+      return Action::SkipChildren(E);
 
     // If we're in an 'incomplete' region, update it to include this node. This
     // ensures we only create the region if needed.
@@ -1182,14 +1184,14 @@ public:
 
     if (hasCounter(E) && !Parent.isNull())
       pushRegion(E);
-    return {true, E};
+    return Action::Continue(E);
   }
 
-  Expr *walkToExprPost(Expr *E) override {
+  PostWalkResult<Expr *> walkToExprPost(Expr *E) override {
     if (hasCounter(E))
       popRegions(E);
 
-    return E;
+    return Action::Continue(E);
   }
 };
 

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -1318,7 +1318,7 @@ void SILParser::bindSILGenericParams(TypeRepr *TyR) {
   public:
     HandleSILGenericParamsWalker(SourceFile *SF) : SF(SF) {}
 
-    bool walkToTypeReprPre(TypeRepr *T) override {
+    PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
       if (auto fnType = dyn_cast<FunctionTypeRepr>(T)) {
         if (auto *genericParams = fnType->getGenericParams()) {
           auto sig = handleSILGenericParams(genericParams, SF);
@@ -1338,7 +1338,7 @@ void SILParser::bindSILGenericParams(TypeRepr *TyR) {
         }
       }
 
-      return true;
+      return Action::Continue();
     }
   };
 

--- a/lib/SILOptimizer/Analysis/ProtocolConformanceAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ProtocolConformanceAnalysis.cpp
@@ -34,7 +34,7 @@ public:
                     &ProtocolConformanceCache)
       : ProtocolConformanceCache(ProtocolConformanceCache) {}
 
-  bool walkToDeclPre(Decl *D) override {
+  PreWalkAction walkToDeclPre(Decl *D) override {
     /// (1) Walk over all NominalTypeDecls to determine conformances.
     if (auto *NTD = dyn_cast<NominalTypeDecl>(D)) {
       if (!isa<ProtocolDecl>(NTD)) {
@@ -60,7 +60,7 @@ public:
         }
       }
     }
-    return true;
+    return Action::Continue();
   }
 };
 } // end anonymous namespace

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -2695,9 +2695,9 @@ public:
     return ResultBuilderBodyPreCheck::Okay;
   }
 
-  std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+  PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
     if (SkipPrecheck)
-      return std::make_pair(false, E);
+      return Action::SkipChildren(E);
 
     // Pre-check the expression.  If this fails, abort the walk immediately.
     // Otherwise, replace the expression with the result of pre-checking.
@@ -2721,21 +2721,24 @@ public:
       if (SuppressDiagnostics)
         transaction.abort();
 
-      return std::make_pair(false, HasError ? nullptr : E);
+      if (HasError)
+        return Action::Stop();
+
+      return Action::SkipChildren(E);
     }
   }
 
-  std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
+  PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
     // If we see a return statement, note it..
     if (auto returnStmt = dyn_cast<ReturnStmt>(S)) {
       if (!returnStmt->isImplicit()) {
         ReturnStmts.push_back(returnStmt);
-        return std::make_pair(false, S);
+        return Action::SkipChildren(S);
       }
     }
 
     // Otherwise, recurse into the statement normally.
-    return std::make_pair(true, S);
+    return Action::Continue(S);
   }
 
   /// Check whether given expression (including single-statement
@@ -2762,8 +2765,8 @@ public:
   }
 
   /// Ignore patterns.
-  std::pair<bool, Pattern*> walkToPatternPre(Pattern *pat) override {
-    return { false, pat };
+  PreWalkResult<Pattern *> walkToPatternPre(Pattern *pat) override {
+    return Action::SkipChildren(pat);
   }
 };
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8215,7 +8215,7 @@ namespace {
     explicit SetExprTypes(const Solution &solution)
         : solution(solution) {}
 
-    Expr *walkToExprPost(Expr *expr) override {
+    PostWalkResult<Expr *> walkToExprPost(Expr *expr) override {
       auto &cs = solution.getConstraintSystem();
       auto exprType = cs.getType(expr);
       exprType = solution.simplifyType(exprType);
@@ -8241,16 +8241,18 @@ namespace {
         }
       }
 
-      return expr;
+      return Action::Continue(expr);
     }
 
     /// Ignore statements.
-    std::pair<bool, Stmt *> walkToStmtPre(Stmt *stmt) override {
-      return { false, stmt };
+    PreWalkResult<Stmt *> walkToStmtPre(Stmt *stmt) override {
+      return Action::SkipChildren(stmt);
     }
 
     /// Ignore declarations.
-    bool walkToDeclPre(Decl *decl) override { return false; }
+    PreWalkAction walkToDeclPre(Decl *decl) override {
+      return Action::SkipChildren();
+    }
   };
 
   class ExprWalker : public ASTWalker {
@@ -8332,16 +8334,16 @@ namespace {
       return hadError;
     }
 
-    std::pair<bool, Expr *> walkToExprPre(Expr *expr) override {
+    PreWalkResult<Expr *> walkToExprPre(Expr *expr) override {
       // For closures, update the parameter types and check the body.
       if (auto closure = dyn_cast<ClosureExpr>(expr)) {
         rewriteFunction(closure);
 
         if (AnyFunctionRef(closure).hasExternalPropertyWrapperParameters()) {
-          return { false, rewriteClosure(closure) };
+          return Action::SkipChildren(rewriteClosure(closure));
         }
 
-        return { false, closure };
+        return Action::SkipChildren(closure);
       }
 
       if (auto tap = dyn_cast_or_null<TapExpr>(expr)) {
@@ -8358,20 +8360,26 @@ namespace {
       }
 
       Rewriter.walkToExprPre(expr);
-      return { true, expr };
+      return Action::Continue(expr);
     }
 
-    Expr *walkToExprPost(Expr *expr) override {
-      return Rewriter.walkToExprPost(expr);
+    PostWalkResult<Expr *> walkToExprPost(Expr *expr) override {
+      auto *result = Rewriter.walkToExprPost(expr);
+      if (!result)
+        return Action::Stop();
+
+      return Action::Continue(result);
     }
 
     /// Ignore statements.
-    std::pair<bool, Stmt *> walkToStmtPre(Stmt *stmt) override {
-      return { false, stmt };
+    PreWalkResult<Stmt *> walkToStmtPre(Stmt *stmt) override {
+      return Action::SkipChildren(stmt);
     }
 
     /// Ignore declarations.
-    bool walkToDeclPre(Decl *decl) override { return false; }
+    PreWalkAction walkToDeclPre(Decl *decl) override {
+      return Action::SkipChildren();
+    }
 
     /// Rewrite the target, producing a new target.
     Optional<SolutionApplicationTarget>

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1595,7 +1595,8 @@ bool MissingOptionalUnwrapFailure::diagnoseAsError() {
       AbstractFunctionDecl *AFD = nullptr;
       if ((AFD = dyn_cast<AbstractFunctionDecl>(varDecl->getDeclContext()))) {
         auto checker = VarDeclMultipleReferencesChecker(getDC(), varDecl);
-        AFD->getBody()->walk(checker);
+        if (auto *body = AFD->getBody())
+          body->walk(checker);
         singleUse = checker.referencesCount() == 1;
       }
 

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -905,7 +905,7 @@ void ConstraintSystem::shrink(Expr *expr) {
     ExprCollector(Expr *expr, ConstraintSystem &cs, DomainMap &domains)
         : PrimaryExpr(expr), CS(cs), Domains(domains) {}
 
-    std::pair<bool, Expr *> walkToExprPre(Expr *expr) override {
+    PreWalkResult<Expr *> walkToExprPre(Expr *expr) override {
       // A dictionary expression is just a set of tuples; try to solve ones
       // that have overload sets.
       if (auto collectionExpr = dyn_cast<CollectionExpr>(expr)) {
@@ -913,27 +913,27 @@ void ConstraintSystem::shrink(Expr *expr) {
                             CS.getContextualType(expr, /*forConstraint=*/false),
                             CS.getContextualTypePurpose(expr));
         // Don't try to walk into the dictionary.
-        return {false, expr};
+        return Action::SkipChildren(expr);
       }
 
       // Let's not attempt to type-check closures or expressions
       // which constrain closures, because they require special handling
       // when dealing with context and parameters declarations.
       if (isa<ClosureExpr>(expr)) {
-        return {false, expr};
+        return Action::SkipChildren(expr);
       }
 
       // Similar to 'ClosureExpr', 'TapExpr' has a 'VarDecl' the type of which
       // is determined by type checking the parent interpolated string literal.
       if (isa<TapExpr>(expr)) {
-        return {false, expr};
+        return Action::SkipChildren(expr);
       }
 
       if (auto coerceExpr = dyn_cast<CoerceExpr>(expr)) {
         if (coerceExpr->isLiteralInit())
           ApplyExprs.push_back({coerceExpr, 1});
         visitCoerceExpr(coerceExpr);
-        return {false, expr};
+        return Action::SkipChildren(expr);
       }
 
       if (auto OSR = dyn_cast<OverloadSetRefExpr>(expr)) {
@@ -948,7 +948,7 @@ void ConstraintSystem::shrink(Expr *expr) {
             {applyExpr, isa<OverloadSetRefExpr>(func) || isa<TypeExpr>(func)});
       }
 
-      return { true, expr };
+      return Action::Continue(expr);
     }
 
     /// Determine whether this is an arithmetic expression comprised entirely
@@ -969,7 +969,7 @@ void ConstraintSystem::shrink(Expr *expr) {
       return isa<IntegerLiteralExpr>(expr) || isa<FloatLiteralExpr>(expr);
     }
 
-    Expr *walkToExprPost(Expr *expr) override {
+    PostWalkResult<Expr *> walkToExprPost(Expr *expr) override {
       auto isSrcOfPrimaryAssignment = [&](Expr *expr) -> bool {
         if (auto *AE = dyn_cast<AssignExpr>(PrimaryExpr))
           return expr == AE->getSrc();
@@ -981,7 +981,7 @@ void ConstraintSystem::shrink(Expr *expr) {
         // to be solved, let's not record it, because it's going to be
         // solved regardless.
         if (Candidates.empty())
-          return expr;
+          return Action::Continue(expr);
 
         auto contextualType = CS.getContextualType(expr,
                                                    /*forConstraint=*/false);
@@ -989,7 +989,7 @@ void ConstraintSystem::shrink(Expr *expr) {
         if (!contextualType.isNull()) {
           Candidates.push_back(Candidate(CS, PrimaryExpr, contextualType,
                                          CS.getContextualTypePurpose(expr)));
-          return expr;
+          return Action::Continue(expr);
         }
 
         // Or it's a function application or assignment with other candidates
@@ -999,12 +999,12 @@ void ConstraintSystem::shrink(Expr *expr) {
         // destination type.
         if (isa<ApplyExpr>(expr) || isa<AssignExpr>(expr)) {
           Candidates.push_back(Candidate(CS, PrimaryExpr));
-          return expr;
+          return Action::Continue(expr);
         }
       }
 
       if (!isa<ApplyExpr>(expr))
-        return expr;
+        return Action::Continue(expr);
 
       unsigned numOverloadSets = 0;
       // Let's count how many overload sets do we have.
@@ -1030,7 +1030,7 @@ void ConstraintSystem::shrink(Expr *expr) {
       if (numOverloadSets > 1 && !isArithmeticExprOfLiterals(expr))
         Candidates.push_back(Candidate(CS, expr));
 
-      return expr;
+      return Action::Continue(expr);
     }
 
   private:

--- a/lib/Sema/ConstantnessSemaDiagnostics.cpp
+++ b/lib/Sema/ConstantnessSemaDiagnostics.cpp
@@ -342,7 +342,7 @@ void swift::diagnoseConstantArgumentRequirement(
     // Descend until we find a call expressions. Note that the input expression
     // could be an assign expression or another expression that contains the
     // call.
-    std::pair<bool, Expr *> walkToExprPre(Expr *expr) override {
+    PreWalkResult<Expr *> walkToExprPre(Expr *expr) override {
       // Handle closure expressions separately as we may need to
       // manually descend into the body.
       if (auto *closureExpr = dyn_cast<ClosureExpr>(expr)) {
@@ -357,20 +357,20 @@ void swift::diagnoseConstantArgumentRequirement(
       // interpolated expressions if we are inside of a closure.
       if (!expr || isa<ErrorExpr>(expr) || !expr->getType() ||
           (isa<InterpolatedStringLiteralExpr>(expr) && !insideClosure))
-        return {false, expr};
+        return Action::SkipChildren(expr);
       if (auto *callExpr = dyn_cast<CallExpr>(expr)) {
         diagnoseConstantArgumentRequirementOfCall(callExpr, DC->getASTContext());
       }
-      return {true, expr};
+      return Action::Continue(expr);
     }
-    
-    std::pair<bool, Expr *> walkToClosureExprPre(ClosureExpr *closure) {
+
+    PreWalkResult<Expr *> walkToClosureExprPre(ClosureExpr *closure) {
       DC = closure;
       insideClosure = true;
-      return {true, closure};
+      return Action::Continue(closure);
     }
-    
-    Expr *walkToExprPost(Expr *expr) override {
+
+    PostWalkResult<Expr *> walkToExprPost(Expr *expr) override {
       if (auto *closureExpr = dyn_cast<ClosureExpr>(expr)) {
         // Reset the DeclContext to the outer scope if we descended
         // into a closure expr and check whether or not we are still
@@ -378,7 +378,7 @@ void swift::diagnoseConstantArgumentRequirement(
         DC = closureExpr->getParent();
         insideClosure = isa<ClosureExpr>(DC);
       }
-      return expr;
+      return Action::Continue(expr);
     }
   };
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -657,37 +657,38 @@ static void extendDepthMap(
     // should actually do this, as it doesn't reflect the true expression depth,
     // but it's needed to preserve compatibility with the behavior from when
     // TupleExpr and ParenExpr were used to represent argument lists.
-    std::pair<bool, ArgumentList *>
+    PreWalkResult<ArgumentList *>
     walkToArgumentListPre(ArgumentList *ArgList) override {
       ++Depth;
-      return {true, ArgList};
+      return Action::Continue(ArgList);
     }
-    ArgumentList *walkToArgumentListPost(ArgumentList *ArgList) override {
+    PostWalkResult<ArgumentList *>
+    walkToArgumentListPost(ArgumentList *ArgList) override {
       --Depth;
-      return ArgList;
+      return Action::Continue(ArgList);
     }
 
-    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+    PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       DepthMap[E] = {Depth, Parent.getAsExpr()};
       ++Depth;
 
       if (auto CE = dyn_cast<ClosureExpr>(E))
         Closures.push_back(CE);
 
-      return { true, E };
+      return Action::Continue(E);
     }
 
-    Expr *walkToExprPost(Expr *E) override {
+    PostWalkResult<Expr *> walkToExprPost(Expr *E) override {
       if (auto CE = dyn_cast<ClosureExpr>(E)) {
         assert(Closures.back() == CE);
         Closures.pop_back();
       }
 
       --Depth;
-      return E;
+      return Action::Continue(E);
     }
 
-    std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
+    PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
       if (auto RS = dyn_cast<ReturnStmt>(S)) {
         // For return statements, treat the parent of the return expression
         // as the closure itself.
@@ -695,11 +696,11 @@ static void extendDepthMap(
           llvm::SaveAndRestore<ParentTy> SavedParent(Parent, Closures.back());
           auto E = RS->getResult();
           E->walk(*this);
-          return { false, S };
+          return Action::SkipChildren(S);
         }
       }
 
-      return { true, S };
+      return Action::Continue(S);
     }
   };
 
@@ -2856,31 +2857,28 @@ FunctionType::ExtInfo ClosureEffectsRequest::evaluate(
     DeclContext *DC;
     bool FoundThrow = false;
 
-    std::pair<bool, Expr *> walkToExprPre(Expr *expr) override {
+    PreWalkResult<Expr *> walkToExprPre(Expr *expr) override {
       // If we've found a 'try', record it and terminate the traversal.
       if (isa<TryExpr>(expr)) {
         FoundThrow = true;
-        return { false, nullptr };
+        return Action::Stop();
       }
 
       // Don't walk into a 'try!' or 'try?'.
       if (isa<ForceTryExpr>(expr) || isa<OptionalTryExpr>(expr)) {
-        return { false, expr };
+        return Action::SkipChildren(expr);
       }
 
       // Do not recurse into other closures.
       if (isa<ClosureExpr>(expr))
-        return { false, expr };
+        return Action::SkipChildren(expr);
 
-      return { true, expr };
+      return Action::Continue(expr);
     }
 
-    bool walkToDeclPre(Decl *decl) override {
+    PreWalkAction walkToDeclPre(Decl *decl) override {
       // Do not walk into function or type declarations.
-      if (!isa<PatternBindingDecl>(decl))
-        return false;
-
-      return true;
+      return Action::VisitChildrenIf(isa<PatternBindingDecl>(decl));
     }
 
     bool isSyntacticallyExhaustive(DoCatchStmt *stmt) {
@@ -2966,11 +2964,11 @@ FunctionType::ExtInfo ClosureEffectsRequest::evaluate(
       return LabelItem.isSyntacticallyExhaustive();
     }
 
-    std::pair<bool, Stmt *> walkToStmtPre(Stmt *stmt) override {
+    PreWalkResult<Stmt *> walkToStmtPre(Stmt *stmt) override {
       // If we've found a 'throw', record it and terminate the traversal.
       if (isa<ThrowStmt>(stmt)) {
         FoundThrow = true;
-        return { false, nullptr };
+        return Action::Stop();
       }
 
       // Handle do/catch differently.
@@ -2979,27 +2977,27 @@ FunctionType::ExtInfo ClosureEffectsRequest::evaluate(
         // if the catch isn't syntactically exhaustive.
         if (!isSyntacticallyExhaustive(doCatch)) {
           if (!doCatch->getBody()->walk(*this))
-            return { false, nullptr };
+            return Action::Stop();
         }
 
         // Walk into all the catch clauses.
         for (auto catchClause : doCatch->getCatches()) {
           if (!catchClause->walk(*this))
-            return { false, nullptr };
+            return Action::Stop();
         }
 
         // We've already walked all the children we care about.
-        return { false, stmt };
+        return Action::SkipChildren(stmt);
       }
 
       if (auto forEach = dyn_cast<ForEachStmt>(stmt)) {
         if (forEach->getTryLoc().isValid()) {
           FoundThrow = true;
-          return { false, nullptr };
+          return Action::Stop();
         }
       }
 
-      return { true, stmt };
+      return Action::Continue(stmt);
     }
 
   public:
@@ -4834,10 +4832,10 @@ static void extendPreorderIndexMap(
     explicit RecordingTraversal(llvm::DenseMap<Expr *, unsigned> &indexMap)
       : IndexMap(indexMap) { }
 
-    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+    PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       IndexMap[E] = Index;
       ++Index;
-      return { true, E };
+      return Action::Continue(E);
     }
   };
 

--- a/lib/Sema/DebuggerTestingTransform.cpp
+++ b/lib/Sema/DebuggerTestingTransform.cpp
@@ -42,17 +42,17 @@ class DiscriminatorFinder : public ASTWalker {
   unsigned NextDiscriminator = 0;
 
 public:
-  Expr *walkToExprPost(Expr *E) override {
+  PostWalkResult<Expr *> walkToExprPost(Expr *E) override {
     auto *ACE = dyn_cast<AbstractClosureExpr>(E);
     if (!ACE)
-      return E;
+      return Action::Continue(E);
 
     unsigned Discriminator = ACE->getDiscriminator();
     assert(Discriminator != AbstractClosureExpr::InvalidDiscriminator &&
            "Existing closures should have valid discriminators");
     if (Discriminator >= NextDiscriminator)
       NextDiscriminator = Discriminator + 1;
-    return E;
+    return Action::Continue(E);
   }
 
   // Get the next available closure discriminator.
@@ -78,31 +78,32 @@ public:
         DebuggerTestingCheckExpectName(
             Ctx.getIdentifier("_debuggerTestingCheckExpect")) {}
 
-  bool walkToDeclPre(Decl *D) override {
+  PreWalkAction walkToDeclPre(Decl *D) override {
     pushLocalDeclContext(D);
 
     // Skip implicit decls, because the debugger isn't used to step through
     // these.
     if (D->isImplicit())
-      return false;
+      return Action::SkipChildren();
 
     // Whitelist the kinds of decls to transform.
     // TODO: Expand the set of decls visited here.
     if (auto *FD = dyn_cast<AbstractFunctionDecl>(D))
-      return FD->getBody();
+      return Action::VisitChildrenIf(FD->getBody());
     if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(D))
-      return TLCD->getBody();
+      return Action::VisitChildrenIf(TLCD->getBody());
     if (isa<NominalTypeDecl>(D))
-      return true;
-    return false;
+      return Action::Continue();
+
+    return Action::SkipChildren();
   }
 
-  bool walkToDeclPost(Decl *D) override {
+  PostWalkAction walkToDeclPost(Decl *D) override {
     popLocalDeclContext(D);
-    return true;
+    return Action::Continue();
   }
 
-  std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+  PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
     pushLocalDeclContext(E);
 
     // Whitelist the kinds of exprs to transform.
@@ -110,12 +111,12 @@ public:
     if (auto *AE = dyn_cast<AssignExpr>(E))
       return insertCheckExpect(AE, AE->getDest());
 
-    return {true, E};
+    return Action::Continue(E);
   }
 
-  Expr *walkToExprPost(Expr *E) override {
+  PostWalkResult<Expr *> walkToExprPost(Expr *E) override {
     popLocalDeclContext(E);
-    return E;
+    return Action::Continue(E);
   }
 
 private:
@@ -167,10 +168,10 @@ private:
   /// The return value contains 1) a flag indicating whether or not to
   /// recursively transform the children of the transformed expression, and 2)
   /// the transformed expression itself.
-  std::pair<bool, Expr *> insertCheckExpect(Expr *OriginalExpr, Expr *DstExpr) {
+  PreWalkResult<Expr *> insertCheckExpect(Expr *OriginalExpr, Expr *DstExpr) {
     auto *DstRef = extractDeclOrMemberRef(DstExpr);
     if (!DstRef)
-      return {true, OriginalExpr};
+      return Action::Continue(OriginalExpr);
 
     ValueDecl *DstDecl;
     if (auto *DRE = dyn_cast<DeclRefExpr>(DstRef))
@@ -180,14 +181,14 @@ private:
       DstDecl = MRE->getMember().getDecl();
     }
     if (!DstDecl->hasName())
-      return {true, OriginalExpr};
+      return Action::Continue(OriginalExpr);
 
     // Don't capture variables which aren't default-initialized.
     if (auto *VD = dyn_cast<VarDecl>(DstDecl))
       if (!VD->isParentInitialized() &&
           !(isa<ParamDecl>(VD) &&
             cast<ParamDecl>(VD)->isInOut()))
-        return {true, OriginalExpr};
+        return Action::Continue(OriginalExpr);
 
     // Rewrite the original expression into this:
     // call
@@ -295,7 +296,7 @@ private:
     // ensures that the type checker can infer <noescape> for captured values.
     TypeChecker::computeCaptures(Closure);
 
-    return {false, FinalExpr};
+    return Action::SkipChildren(FinalExpr);
   }
 };
 

--- a/lib/Sema/InstrumenterSupport.cpp
+++ b/lib/Sema/InstrumenterSupport.cpp
@@ -54,21 +54,21 @@ class ErrorFinder : public ASTWalker {
 
 public:
   ErrorFinder() {}
-  std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+  PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
     if (isa<ErrorExpr>(E) || !E->getType() || E->getType()->hasError()) {
       error = true;
-      return {false, E};
+      return Action::SkipChildren(E);
     }
-    return {true, E};
+    return Action::Continue(E);
   }
-  bool walkToDeclPre(Decl *D) override {
+  PreWalkAction walkToDeclPre(Decl *D) override {
     if (auto *VD = dyn_cast<ValueDecl>(D)) {
       if (!VD->hasInterfaceType() || VD->getInterfaceType()->hasError()) {
         error = true;
-        return false;
+        return Action::SkipChildren();
       }
     }
-    return true;
+    return Action::Continue();
   }
   bool hadError() { return error; }
 };

--- a/lib/Sema/InstrumenterSupport.h
+++ b/lib/Sema/InstrumenterSupport.h
@@ -61,15 +61,15 @@ protected:
 
   public:
     ClosureFinder(InstrumenterBase &Inst) : I(Inst) {}
-    std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
+    PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
       if (isa<BraceStmt>(S)) {
-        return {false, S}; // don't walk into brace statements; we
+        return Action::SkipChildren(S); // don't walk into brace statements; we
                            // need to respect nesting!
       } else {
-        return {true, S};
+        return Action::Continue(S);
       }
     }
-    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+    PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       if (auto *CE = dyn_cast<ClosureExpr>(E)) {
         BraceStmt *B = CE->getBody();
         if (B) {
@@ -79,7 +79,7 @@ protected:
           // be more than a single expression!
         }
       }
-      return {true, E};
+      return Action::Continue(E);
     }
   };
 

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -54,10 +54,9 @@ static Expr *isImplicitPromotionToOptional(Expr *E) {
   return nullptr;
 }
 
-bool BaseDiagnosticWalker::walkToDeclPre(Decl *D) {
-  return isa<ClosureExpr>(D->getDeclContext())
-             ? shouldWalkIntoDeclInClosureContext(D)
-             : false;
+ASTWalker::PreWalkAction BaseDiagnosticWalker::walkToDeclPre(Decl *D) {
+  return Action::VisitChildrenIf(isa<ClosureExpr>(D->getDeclContext()) &&
+                                 shouldWalkIntoDeclInClosureContext(D));
 }
 
 bool BaseDiagnosticWalker::shouldWalkIntoDeclInClosureContext(Decl *D) {
@@ -121,20 +120,22 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
           HasReachedSemanticsProvidingExpr(false),
           Ctx(DC->getASTContext()), DC(DC) {}
 
-    std::pair<bool, Pattern*> walkToPatternPre(Pattern *P) override {
-      return { false, P };
+    PreWalkResult<Pattern *> walkToPatternPre(Pattern *P) override {
+      return Action::SkipChildren(P);
     }
 
-    bool walkToTypeReprPre(TypeRepr *T) override { return true; }
+    PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
+      return Action::Continue();
+    }
 
     bool shouldWalkCaptureInitializerExpressions() override { return true; }
 
     bool shouldWalkIntoTapExpression() override { return false; }
 
-    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+    PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       if (isa<OpenExistentialExpr>(E)) {
         // Don't increase ExprNestingDepth.
-        return { true, E };
+        return Action::Continue(E);
       }
 
       if (auto collection = dyn_cast<CollectionExpr>(E)) {
@@ -358,16 +359,16 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
 
       ++ExprNestingDepth;
 
-      return { true, E };
+      return Action::Continue(E);
     }
 
-    Expr *walkToExprPost(Expr *E) override {
+    PostWalkResult<Expr *> walkToExprPost(Expr *E) override {
       if (isa<OpenExistentialExpr>(E))
-        return E;
+        return Action::Continue(E);
 
       assert(ExprNestingDepth != 0);
       --ExprNestingDepth;
-      return E;
+      return Action::Continue(E);
     }
 
     /// Visit each component of the keypath and emit a diagnostic if they
@@ -1422,7 +1423,7 @@ static void diagRecursivePropertyAccess(const Expr *E, const DeclContext *DC) {
 
     bool shouldWalkIntoTapExpression() override { return false; }
 
-    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+    PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       Expr *subExpr;
       bool isStore = false;
 
@@ -1431,7 +1432,7 @@ static void diagRecursivePropertyAccess(const Expr *E, const DeclContext *DC) {
         
         // If we couldn't flatten this expression, don't explode.
         if (!subExpr)
-          return { true, E };
+          return Action::Continue(E);
 
         isStore = true;
       } else if (auto *IOE = dyn_cast<InOutExpr>(E)) {
@@ -1517,7 +1518,7 @@ static void diagRecursivePropertyAccess(const Expr *E, const DeclContext *DC) {
 
       }
 
-      return { true, E };
+      return Action::Continue(E);
     }
   };
 
@@ -1618,7 +1619,7 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
 
     bool shouldWalkIntoTapExpression() override { return false; }
 
-    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+    PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       if (auto *CE = dyn_cast<AbstractClosureExpr>(E)) {
         // If this is a potentially-escaping closure expression, start looking
         // for references to self if we aren't already.
@@ -1628,7 +1629,7 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
 
       // If we aren't in a closure, no diagnostics will be produced.
       if (Closures.size() == 0)
-        return { true, E };
+        return Action::Continue(E);
 
       auto &Diags = Ctx.Diags;
       
@@ -1670,7 +1671,7 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
 
       if (memberLoc.isValid()) {
         emitFixIts(Diags, memberLoc, ACE);
-        return { false, E };
+        return Action::SkipChildren(E);
       }
       
       // Catch any other implicit uses of self with a generic diagnostic.
@@ -1678,10 +1679,10 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
         Diags.diagnose(E->getLoc(), diag::implicit_use_of_self_in_closure)
              .warnUntilSwiftVersionIf(shouldOnlyWarn(E), 6);
 
-      return { true, E };
+      return Action::Continue(E);
     }
     
-    Expr *walkToExprPost(Expr *E) override {
+    PostWalkResult<Expr *> walkToExprPost(Expr *E) override {
       if (auto *CE = dyn_cast<AbstractClosureExpr>(E)) {
         if (isClosureRequiringSelfQualification(CE)) {
           assert(Closures.size() > 0);
@@ -1689,7 +1690,7 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
         }
       }
       
-      return E;
+      return Action::Continue(E);
     }
 
     /// Emit any fix-its for this error.
@@ -2520,10 +2521,10 @@ public:
   
   // We generally walk into declarations, other than types and nested functions.
   // FIXME: peek into capture lists of nested functions.
-  bool walkToDeclPre(Decl *D) override {
+  PreWalkAction walkToDeclPre(Decl *D) override {
     if (isa<TypeDecl>(D))
-      return false;
-      
+      return Action::SkipChildren();
+
     // The body of #if clauses are not walked into, we need custom processing
     // for them.
     if (auto *ICD = dyn_cast<IfConfigDecl>(D))
@@ -2549,7 +2550,7 @@ public:
     // references the variable, but we don't want to consider it as a real
     // "use".
     if (isa<AccessorDecl>(D) && D->isImplicit())
-      return false;
+      return Action::SkipChildren();
 
     if (auto *afd = dyn_cast<AbstractFunctionDecl>(D)) {
       // If this AFD is a setter, track the parameter and the getter for
@@ -2565,12 +2566,12 @@ public:
       }
 
       if (afd->isBodyTypeChecked())
-        return true;
+        return Action::Continue();
 
       // Don't walk into a body that has not yet been type checked. This should
       // only occur for top-level code.
       VarDecls.clear();
-      return false;
+      return Action::SkipChildren();
     }
 
     if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(D)) {
@@ -2606,17 +2607,17 @@ public:
     // Note that we ignore the initialization behavior of PatternBindingDecls,
     // but we do want to walk into them, because we want to see any uses or
     // other things going on in the initializer expressions.
-    return true;
+    return Action::Continue();
   }
 
   /// The heavy lifting happens when visiting expressions.
-  std::pair<bool, Expr *> walkToExprPre(Expr *E) override;
+  PreWalkResult<Expr *> walkToExprPre(Expr *E) override;
 
   /// handle #if directives.
   void handleIfConfig(IfConfigDecl *ICD);
 
   /// Custom handling for statements.
-  std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
+  PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
     // Keep track of an association between vardecls and the StmtCondition that
     // they are bound in for IfStmt, GuardStmt, WhileStmt, etc.
     if (auto LCS = dyn_cast<LabeledConditionalStmt>(S)) {
@@ -2658,7 +2659,7 @@ public:
       }
     }
 
-    return { true, S };
+    return Action::Continue(S);
   }
 };
   
@@ -2914,7 +2915,7 @@ public:
         conditionalSubstitutions);
   }
 
-  std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+  PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
     if (auto underlyingToOpaque = dyn_cast<UnderlyingToOpaqueExpr>(E)) {
       auto subMap = underlyingToOpaque->substitutions;
 
@@ -2926,30 +2927,30 @@ public:
 
       if (isSelfReferencing(candidate)) {
         HasInvalidReturn = true;
-        return {false, nullptr};
+        return Action::Stop();
       }
 
       if (subMap.hasDynamicSelf()) {
         Ctx.Diags.diagnose(E->getLoc(),
                            diag::opaque_type_cannot_contain_dynamic_self);
         HasInvalidReturn = true;
-        return {false, nullptr};
+        return Action::Stop();
       }
 
       Candidates.push_back({CurrentAvailability, candidate});
-      return {false, E};
+      return Action::SkipChildren(E);
     }
 
-    return {true, E};
+    return Action::Continue(E);
   }
 
-  std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
+  PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
     if (auto *If = dyn_cast<IfStmt>(S)) {
       if (Parent.getAsStmt() != Body) {
         // If this is not a top-level `if`, let's drop
         // contextual information that has been set previously.
         CurrentAvailability = nullptr;
-        return {true, S};
+        return Action::Continue(S);
       }
 
       // If this is `if #(un)available` statement with no other dynamic
@@ -2988,7 +2989,7 @@ public:
           Else->walk(*this);
         }
 
-        return {false, S};
+        return Action::SkipChildren(S);
       }
     }
 
@@ -3002,12 +3003,12 @@ public:
       }
     }
 
-    return {true, S};
+    return Action::Continue(S);
   }
 
   // Don't descend into nested decls.
-  bool walkToDeclPre(Decl *D) override {
-    return false;
+  PreWalkAction walkToDeclPre(Decl *D) override {
+    return Action::SkipChildren();
   }
 };
 
@@ -3052,9 +3053,9 @@ public:
     }
   }
 
-  std::pair<bool, Expr *> walkToExprPre(Expr *E) override { return {true, E}; }
+  PreWalkResult<Expr *> walkToExprPre(Expr *E) override { return Action::Continue(E); }
 
-  std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
+  PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
     if (auto *RS = dyn_cast<ReturnStmt>(S)) {
       if (RS->hasResult()) {
         auto resultTy = RS->getResult()->getType();
@@ -3063,11 +3064,13 @@ public:
       }
     }
 
-    return {true, S};
+    return Action::Continue(S);
   }
 
   // Don't descend into nested decls.
-  bool walkToDeclPre(Decl *D) override { return false; }
+  PreWalkAction walkToDeclPre(Decl *D) override {
+    return Action::SkipChildren();
+  }
 };
 
 } // end anonymous namespace
@@ -3480,7 +3483,7 @@ void VarDeclUsageChecker::markStoredOrInOutExpr(Expr *E, unsigned Flags) {
 }
 
 /// The heavy lifting happens when visiting expressions.
-std::pair<bool, Expr *> VarDeclUsageChecker::walkToExprPre(Expr *E) {
+ASTWalker::PreWalkResult<Expr *> VarDeclUsageChecker::walkToExprPre(Expr *E) {
   STATISTIC(VarDeclUsageCheckerExprVisits,
             "# of times VarDeclUsageChecker::walkToExprPre is called");
   ++VarDeclUsageCheckerExprVisits;
@@ -3489,7 +3492,7 @@ std::pair<bool, Expr *> VarDeclUsageChecker::walkToExprPre(Expr *E) {
   // should replace them with ErrorExpr.
   if (E == nullptr || !E->getType() || E->getType()->hasError()) {
     sawError = true;
-    return { false, E };
+    return Action::SkipChildren(E);
   }
 
   assert(AllExprsSeen.insert(E).second && "duplicate traversal");
@@ -3510,13 +3513,13 @@ std::pair<bool, Expr *> VarDeclUsageChecker::walkToExprPre(Expr *E) {
     if (auto VD = dyn_cast<VarDecl>(MRE->getMember().getDecl())) {
       AssociatedGetterRefExpr.insert(std::make_pair(VD, MRE));
       markBaseOfStorageUse(MRE->getBase(), MRE->getMember(), RK_Read);
-      return { false, E };
+      return Action::SkipChildren(E);
     }
   }
   if (auto SE = dyn_cast<SubscriptExpr>(E)) {
     SE->getArgs()->walk(*this);
     markBaseOfStorageUse(SE->getBase(), SE->getDecl(), RK_Read);
-    return { false, E };
+    return Action::SkipChildren(E);
   }
 
   // If this is an AssignExpr, see if we're mutating something that we know
@@ -3526,14 +3529,14 @@ std::pair<bool, Expr *> VarDeclUsageChecker::walkToExprPre(Expr *E) {
     
     // Don't walk into the LHS of the assignment, only the RHS.
     assign->getSrc()->walk(*this);
-    return { false, E };
+    return Action::SkipChildren(E);
   }
   
   // '&x' is a read and write of 'x'.
   if (auto *io = dyn_cast<InOutExpr>(E)) {
     markStoredOrInOutExpr(io->getSubExpr(), RK_Read|RK_Written);
     // Don't bother walking into this.
-    return { false, E };
+    return Action::SkipChildren(E);
   }
   
   // If we see an OpenExistentialExpr, remember the mapping for its OpaqueValue
@@ -3541,21 +3544,21 @@ std::pair<bool, Expr *> VarDeclUsageChecker::walkToExprPre(Expr *E) {
   if (auto *oee = dyn_cast<OpenExistentialExpr>(E)) {
     OpaqueValueMap[oee->getOpaqueValue()] = oee->getExistentialValue();
     oee->getSubExpr()->walk(*this);
-    return { false, E };
+    return Action::SkipChildren(E);
   }
 
   // Visit bindings.
   if (auto ove = dyn_cast<OpaqueValueExpr>(E)) {
     if (auto mapping = OpaqueValueMap.lookup(ove))
       mapping->walk(*this);
-    return { false, E };
+    return Action::SkipChildren(E);
   }
   
   // If we saw an ErrorExpr, take note of this.
   if (isa<ErrorExpr>(E))
     sawError = true;
   
-  return { true, E };
+  return Action::Continue(E);
 }
 
 /// handle #if directives.  All of the active clauses are already walked by the
@@ -3569,7 +3572,7 @@ void VarDeclUsageChecker::handleIfConfig(IfConfigDecl *ICD) {
     ConservativeDeclMarker(VarDeclUsageChecker &VDUC)
       : VDUC(VDUC), SF(VDUC.DC->getParentSourceFile()) {}
 
-    Expr *walkToExprPost(Expr *E) override {
+    PostWalkResult<Expr *> walkToExprPost(Expr *E) override {
       // If we see a bound reference to a decl in an inactive #if block, then
       // conservatively mark it read and written.  This will silence "variable
       // unused" and "could be marked let" warnings for it.
@@ -3585,7 +3588,7 @@ void VarDeclUsageChecker::handleIfConfig(IfConfigDecl *ICD) {
             VDUC.addMark(varDecl, RK_Read|RK_Written);
         }
       }
-      return E;
+      return Action::Continue(E);
     }
   };
 
@@ -3801,14 +3804,14 @@ static void checkStmtConditionTrailingClosure(ASTContext &ctx, const Expr *E) {
 
     bool shouldWalkIntoTapExpression() override { return false; }
 
-    std::pair<bool, ArgumentList *>
+    PreWalkResult<ArgumentList *>
     walkToArgumentListPre(ArgumentList *args) override {
       // Don't walk into an explicit argument list, as trailing closures that
       // appear in child arguments are fine.
-      return {args->isImplicit(), args};
+      return Action::VisitChildrenIf(args->isImplicit(), args);
     }
 
-    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+    PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       switch (E->getKind()) {
       case ExprKind::Paren:
       case ExprKind::Tuple:
@@ -3818,14 +3821,14 @@ static void checkStmtConditionTrailingClosure(ASTContext &ctx, const Expr *E) {
       case ExprKind::Closure:
         // If a trailing closure appears as a child of one of these types of
         // expression, don't diagnose it as there is no ambiguity.
-        return {E->isImplicit(), E};
+        return Action::VisitChildrenIf(E->isImplicit(), E);
       case ExprKind::Call:
         diagnoseIt(cast<CallExpr>(E));
         break;
       default:
         break;
       }
-      return {true, E};
+      return Action::Continue(E);
     }
   };
 
@@ -3927,7 +3930,7 @@ public:
 
   bool shouldWalkIntoTapExpression() override { return false; }
 
-  std::pair<bool, Expr *> walkToExprPre(Expr *expr) override {
+  PreWalkResult<Expr *> walkToExprPre(Expr *expr) override {
     auto *stringLiteral = dyn_cast<StringLiteralExpr>(expr);
     bool fromStringLiteral = false;
     bool hadParens = false;
@@ -3935,7 +3938,7 @@ public:
       // Is this a string literal that has type 'Selector'.
       if (!stringLiteral->getType() ||
           !stringLiteral->getType()->isEqual(SelectorTy))
-        return { true, expr };
+        return Action::Continue(expr);
 
       fromStringLiteral = true;
 
@@ -3943,11 +3946,11 @@ public:
     } else {
       // Is this an initialization of 'Selector'?
       auto call = dyn_cast<CallExpr>(expr);
-      if (!call) return { true, expr };
+      if (!call) return Action::Continue(expr);
 
       // That produce Selectors.
       if (!call->getType() || !call->getType()->isEqual(SelectorTy))
-        return { true, expr };
+        return Action::Continue(expr);
 
       // Via a constructor.
       ConstructorDecl *ctor = nullptr;
@@ -3959,27 +3962,27 @@ public:
           ctor = otherCtorRef->getDecl();
       }
 
-      if (!ctor) return { true, expr };
+      if (!ctor) return Action::Continue(expr);
 
       // Make sure the constructor is within Selector.
       auto ctorContextType = ctor->getDeclContext()
           ->getSelfNominalTypeDecl()
           ->getDeclaredType();
       if (!ctorContextType || !ctorContextType->isEqual(SelectorTy))
-        return { true, expr };
+        return Action::Continue(expr);
 
       auto argNames = ctor->getName().getArgumentNames();
-      if (argNames.size() != 1) return { true, expr };
+      if (argNames.size() != 1) return Action::Continue(expr);
 
       // Is this the init(stringLiteral:) initializer or init(_:) initializer?
       if (argNames[0] == Ctx.Id_stringLiteral)
         fromStringLiteral = true;
       else if (!argNames[0].empty())
-        return { true, expr };
+        return Action::Continue(expr);
 
       auto *arg = call->getArgs()->getUnaryExpr();
       if (!arg)
-        return { true, expr };
+        return Action::Continue(expr);
 
       // Track whether we had parentheses around the string literal.
       if (auto paren = dyn_cast<ParenExpr>(arg)) {
@@ -3989,7 +3992,7 @@ public:
 
       // Check whether we have a string literal.
       stringLiteral = dyn_cast<StringLiteralExpr>(arg);
-      if (!stringLiteral) return { true, expr };
+      if (!stringLiteral) return Action::Continue(expr);
     }
 
     /// Retrieve the parent expression that coerces to Selector, if
@@ -4035,7 +4038,7 @@ public:
                                      diag::selector_literal_invalid);
       diag.highlight(stringLiteral->getSourceRange());
       addSelectorConstruction(diag);
-      return { true, expr };
+      return Action::Continue(expr);
     }
 
     // Look for methods with this selector.
@@ -4047,7 +4050,7 @@ public:
       // If this was Selector(("selector-name")), suppress, the
       // diagnostic.
       if (!fromStringLiteral && hadParens)
-        return { true, expr };
+        return Action::Continue(expr);
 
       {
         auto diag = Ctx.Diags.diagnose(stringLiteral->getLoc(),
@@ -4066,7 +4069,7 @@ public:
           .fixItInsertAfter(stringLiteral->getEndLoc(), ")");
       }
 
-      return { true, expr };
+      return Action::Continue(expr);
     }
 
     // Find the "best" method that has this selector, so we can report
@@ -4205,7 +4208,7 @@ public:
                         ? diag::selector_literal_deprecated_suggest
                         : diag::selector_construction_suggest)
           .fixItReplace(replacementRange, replacement);
-      return { true, expr };
+      return Action::Continue(expr);
     }
 
     // If we couldn't pick a method to use for #selector, just wrap
@@ -4214,10 +4217,10 @@ public:
       auto diag = Ctx.Diags.diagnose(stringLiteral->getLoc(),
                                      diag::selector_literal_deprecated);
       addSelectorConstruction(diag);
-      return { true, expr };
+      return Action::Continue(expr);
     }
 
-    return { true, expr };
+    return Action::Continue(expr);
   }
 
 };
@@ -4656,12 +4659,12 @@ static void diagnoseUnintendedOptionalBehavior(const Expr *E,
 
     bool shouldWalkIntoTapExpression() override { return false; }
 
-    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+    PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       if (!E || isa<ErrorExpr>(E) || !E->getType())
-        return { false, E };
+        return Action::SkipChildren(E);
 
       if (IgnoredExprs.count(E))
-        return { true, E };
+        return Action::Continue(E);
 
       if (auto *literal = dyn_cast<InterpolatedStringLiteralExpr>(E)) {
         visitInterpolatedStringLiteralExpr(literal);
@@ -4675,7 +4678,7 @@ static void diagnoseUnintendedOptionalBehavior(const Expr *E,
       } else {
         visitPossibleOptionalToAnyExpr(E, { E->getType(), nullptr });
       }
-      return { true, E };
+      return Action::Continue(E);
     }
 
   public:
@@ -4733,16 +4736,16 @@ static void diagnoseDeprecatedWritableKeyPath(const Expr *E,
 
     bool shouldWalkIntoTapExpression() override { return false; }
 
-    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+    PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       if (!E || isa<ErrorExpr>(E) || !E->getType())
-        return {false, E};
+        return Action::SkipChildren(E);
 
       if (auto *KPAE = dyn_cast<KeyPathApplicationExpr>(E)) {
         visitKeyPathApplicationExpr(KPAE);
-        return {true, E};
+        return Action::Continue(E);
       }
 
-      return {true, E};
+      return Action::Continue(E);
     }
 
   public:
@@ -4793,16 +4796,16 @@ static void maybeDiagnoseCallToKeyValueObserveMethod(const Expr *E,
           .highlight(lastComponent.getLoc());
     }
 
-    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+    PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       if (!E || isa<ErrorExpr>(E) || !E->getType())
-        return {false, E};
+        return Action::SkipChildren(E);
 
       if (auto *CE = dyn_cast<CallExpr>(E)) {
         maybeDiagnoseCallExpr(CE);
-        return {false, E};
+        return Action::SkipChildren(E);
       }
 
-      return {true, E};
+      return Action::Continue(E);
     }
   };
 
@@ -4840,16 +4843,16 @@ static void diagnoseExplicitUseOfLazyVariableStorage(const Expr *E,
       }
     }
 
-    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+    PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       if (!E || isa<ErrorExpr>(E) || !E->getType())
-        return {false, E};
+        return Action::SkipChildren(E);
 
       if (auto *MRE = dyn_cast<MemberRefExpr>(E)) {
         tryDiagnoseExplicitLazyStorageVariableUse(MRE);
-        return {false, E};
+        return Action::SkipChildren(E);
       }
 
-      return {true, E};
+      return Action::Continue(E);
     }
   };
 
@@ -4969,16 +4972,16 @@ static void diagnoseComparisonWithNaN(const Expr *E, const DeclContext *DC) {
       }
     }
 
-    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+    PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       if (!E || isa<ErrorExpr>(E) || !E->getType())
-        return {false, E};
+        return Action::SkipChildren(E);
 
       if (auto *BE = dyn_cast<BinaryExpr>(E)) {
         tryDiagnoseComparisonWithNaN(BE);
-        return {false, E};
+        return Action::SkipChildren(E);
       }
 
-      return {true, E};
+      return Action::Continue(E);
     }
   };
 
@@ -5004,34 +5007,34 @@ static void diagUnqualifiedAccessToMethodNamedSelf(const Expr *E,
 
     bool shouldWalkIntoTapExpression() override { return false; }
 
-    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+    PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       if (!E || isa<ErrorExpr>(E) || !E->getType())
-        return {false, E};
+        return Action::SkipChildren(E);
 
       auto *DRE = dyn_cast<DeclRefExpr>(E);
       // If this is not an explicit 'self' reference, let's keep searching.
       if (!DRE || DRE->isImplicit())
-        return {true, E};
+        return Action::Continue(E);
 
       // If this not 'self' or it's not a function reference, it's unrelated.
       if (!(DRE->getDecl()->getBaseName() == Ctx.Id_self &&
             DRE->getType()->is<AnyFunctionType>()))
-        return {true, E};
+        return Action::Continue(E);
 
       auto typeContext = DC->getInnermostTypeContext();
       // Use of 'self' in enums is not confusable.
       if (!typeContext || typeContext->getSelfEnumDecl())
-        return {true, E};
+        return Action::Continue(E);
 
       // self(...) is not easily confusable.
       if (auto *parentExpr = Parent.getAsExpr()) {
         if (isa<CallExpr>(parentExpr))
-          return {true, E};
+          return Action::Continue(E);
 
         // Explicit call to a static method 'self' of some type is not
         // confusable.
         if (isa<DotSyntaxCallExpr>(parentExpr) && !parentExpr->isImplicit())
-          return {true, E};
+          return Action::Continue(E);
       }
 
       auto baseType = typeContext->getDeclaredInterfaceType();
@@ -5045,7 +5048,7 @@ static void diagUnqualifiedAccessToMethodNamedSelf(const Expr *E,
                     baseTypeString)
           .fixItInsert(E->getLoc(), diag::insert_type_qualification, baseType);
 
-      return {true, E};
+      return Action::Continue(E);
     }
   };
 
@@ -5161,16 +5164,16 @@ diagnoseDictionaryLiteralDuplicateKeyEntries(const Expr *E,
 
     bool shouldWalkIntoTapExpression() override { return false; }
 
-    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+    PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       const auto *DLE = dyn_cast_or_null<DictionaryExpr>(E);
       if (!DLE)
-        return {true, E};
+        return Action::Continue(E);
 
       auto type = DLE->getType();
       // For other types conforming with `ExpressibleByDictionaryLiteral`
       // protocol, duplicated keys may be allowed.
       if (!(type && type->isDictionary())) {
-        return {true, E};
+        return Action::Continue(E);
       }
 
       using LiteralKey = std::pair<std::string, ExprKind>;
@@ -5197,7 +5200,7 @@ diagnoseDictionaryLiteralDuplicateKeyEntries(const Expr *E,
 
       // All keys are unique.
       if (groupedLiteralKeys.size() == DLE->getNumElements()) {
-        return {true, E};
+        return Action::Continue(E);
       }
 
       auto &DE = Ctx.Diags;
@@ -5233,7 +5236,7 @@ diagnoseDictionaryLiteralDuplicateKeyEntries(const Expr *E,
           emitNoteWithFixit(duplicated);
         }
       }
-      return {true, E};
+      return Action::Continue(E);
     }
   };
 

--- a/lib/Sema/MiscDiagnostics.h
+++ b/lib/Sema/MiscDiagnostics.h
@@ -126,7 +126,7 @@ bool diagnoseUnhandledThrowsInAsyncContext(DeclContext *dc,
                                            ForEachStmt *forEach);
 
 class BaseDiagnosticWalker : public ASTWalker {
-  bool walkToDeclPre(Decl *D) override;
+  PreWalkAction walkToDeclPre(Decl *D) override;
 
   bool shouldWalkIntoSeparatelyCheckedClosure(ClosureExpr *expr) override {
     return false;

--- a/lib/Sema/PCMacro.cpp
+++ b/lib/Sema/PCMacro.cpp
@@ -674,14 +674,14 @@ void swift::performPCMacro(SourceFile &SF) {
   public:
     ExpressionFinder() = default;
 
-    bool walkToDeclPre(Decl *D) override {
+    PreWalkAction walkToDeclPre(Decl *D) override {
       ASTContext &ctx = D->getASTContext();
       if (auto *FD = dyn_cast<AbstractFunctionDecl>(D)) {
         if (!FD->isImplicit()) {
           if (FD->getBody()) {
             Instrumenter I(ctx, FD, TmpNameIndex);
             I.transformDecl(FD);
-            return false;
+            return Action::SkipChildren();
           }
         }
       } else if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(D)) {
@@ -694,11 +694,11 @@ void swift::performPCMacro(SourceFile &SF) {
               TypeChecker::checkTopLevelEffects(TLCD);
               TypeChecker::contextualizeTopLevelCode(TLCD);
             }
-            return false;
+            return Action::SkipChildren();
           }
         }
       }
-      return true;
+      return Action::Continue();
     }
   };
 

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -861,7 +861,7 @@ void swift::performPlaygroundTransform(SourceFile &SF, bool HighPerformance) {
     // FIXME: Remove this
     bool shouldWalkAccessorsTheOldWay() override { return true; }
 
-    bool walkToDeclPre(Decl *D) override {
+    PreWalkAction walkToDeclPre(Decl *D) override {
       if (auto *FD = dyn_cast<AbstractFunctionDecl>(D)) {
         if (!FD->isImplicit()) {
           if (BraceStmt *Body = FD->getBody()) {
@@ -871,7 +871,7 @@ void swift::performPlaygroundTransform(SourceFile &SF, bool HighPerformance) {
               FD->setBody(NewBody, AbstractFunctionDecl::BodyKind::TypeChecked);
               TypeChecker::checkFunctionEffects(FD);
             }
-            return false;
+            return Action::SkipChildren();
           }
         }
       } else if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(D)) {
@@ -883,11 +883,11 @@ void swift::performPlaygroundTransform(SourceFile &SF, bool HighPerformance) {
               TLCD->setBody(NewBody);
               TypeChecker::checkTopLevelEffects(TLCD);
             }
-            return false;
+            return Action::SkipChildren();
           }
         }
       }
-      return true;
+      return Action::Continue();
     }
   };
 

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -993,12 +993,12 @@ namespace {
       public:
         StrangeInterpolationRewriter(ASTContext &Ctx) : Context(Ctx) {}
 
-        virtual bool walkToDeclPre(Decl *D) override {
+        virtual PreWalkAction walkToDeclPre(Decl *D) override {
           // We don't want to look inside decls.
-          return false;
+          return Action::SkipChildren();
         }
 
-        virtual std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+        virtual PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
           // One InterpolatedStringLiteralExpr should never be nested inside
           // another except as a child of a CallExpr, and we don't recurse into
           // the children of CallExprs.
@@ -1007,7 +1007,7 @@ namespace {
 
           // We only care about CallExprs.
           if (!isa<CallExpr>(E))
-            return { true, E };
+            return Action::Continue(E);
 
           auto *call = cast<CallExpr>(E);
           auto *args = call->getArgs();
@@ -1038,7 +1038,7 @@ namespace {
                   if (arg.isInOut()) {
                     Context.Diags.diagnose(arg.getExpr()->getStartLoc(),
                                            diag::extraneous_address_of);
-                    return {false, nullptr};
+                    return Action::Stop();
                   }
                 }
 
@@ -1087,7 +1087,7 @@ namespace {
           // There is never a CallExpr between an InterpolatedStringLiteralExpr
           // and an un-typechecked appendInterpolation(...) call, so whether we
           // changed E or not, we don't need to recurse any deeper.
-          return { false, E };
+          return Action::SkipChildren(E);
         }
       };
 
@@ -1153,7 +1153,7 @@ namespace {
       return methodSelf;
     }
 
-    std::pair<bool, Expr *> walkToExprPre(Expr *expr) override {
+    PreWalkResult<Expr *> walkToExprPre(Expr *expr) override {
       // FIXME(diagnostics): `InOutType` could appear here as a result
       // of successful re-typecheck of the one of the sub-expressions e.g.
       // `let _: Int = { (s: inout S) in s.bar() }`. On the first
@@ -1180,15 +1180,17 @@ namespace {
 
       // Local function used to finish up processing before returning. Every
       // return site should call through here.
-      auto finish = [&](bool recursive, Expr *expr) {
+      auto finish = [&](bool recursive, Expr *expr) -> PreWalkResult<Expr *> {
+        if (!expr)
+          return Action::Stop();
+
         // If we're going to recurse, record this expression on the stack.
         if (recursive) {
           if (isa<SequenceExpr>(expr))
             SequenceExprDepth++;
           ExprStack.push_back(expr);
         }
-
-        return std::make_pair(recursive, expr);
+        return Action::VisitChildrenIf(recursive, expr);
       };
 
       // Resolve 'super' references.
@@ -1284,7 +1286,7 @@ namespace {
       return finish(true, expr);
     }
 
-    Expr *walkToExprPost(Expr *expr) override {
+    PostWalkResult<Expr *> walkToExprPost(Expr *expr) override {
       // Remove this expression from the stack.
       assert(ExprStack.back() == expr);
       ExprStack.pop_back();
@@ -1297,13 +1299,17 @@ namespace {
       if (auto *seqExpr = dyn_cast<SequenceExpr>(expr)) {
         auto result = TypeChecker::foldSequence(seqExpr, DC);
         SequenceExprDepth--;
-        return result->walk(*this);
+        result = result->walk(*this);
+        if (!result)
+          return Action::Stop();
+
+        return Action::Continue(result);
       }
 
       // Type check the type parameters in an UnresolvedSpecializeExpr.
       if (auto *us = dyn_cast<UnresolvedSpecializeExpr>(expr)) {
         if (auto *typeExpr = simplifyUnresolvedSpecializeExpr(us))
-          return typeExpr;
+          return Action::Continue(typeExpr);
       }
       
       // If we're about to step out of a ClosureExpr, restore the DeclContext.
@@ -1379,7 +1385,7 @@ namespace {
         expr = new (ctx)
             RebindSelfInConstructorExpr(expr, UnresolvedCtorSelf);
         UnresolvedCtorRebindTarget = nullptr;
-        return expr;
+        return Action::Continue(expr);
       }
 
       // Double check if there are any BindOptionalExpr remaining in the
@@ -1395,7 +1401,7 @@ namespace {
           return hasBindOptional ? nullptr : expr;
         });
 
-        return hasBindOptional ? OEE : OEE->getSubExpr();
+        return Action::Continue(hasBindOptional ? OEE : OEE->getSubExpr());
       }
 
       // Check if there are any BindOptionalExpr in the tree which
@@ -1407,13 +1413,13 @@ namespace {
       if (auto BOE = dyn_cast<BindOptionalExpr>(expr)) {
         if (auto DAE = dyn_cast<DiscardAssignmentExpr>(BOE->getSubExpr()))
           if (CorrectDiscardAssignmentExprs.count(DAE))
-            return DAE;
+            return Action::Continue(DAE);
       }
 
       // If this is a sugared type that needs to be folded into a single
       // TypeExpr, do it.
       if (auto *simplified = simplifyTypeExpr(expr))
-        return simplified;
+        return Action::Continue(simplified);
 
       // Diagnose a '_' that isn't on the immediate LHS of an assignment. We
       // skip diagnostics if we've explicitly marked the expression as valid,
@@ -1424,42 +1430,49 @@ namespace {
             SequenceExprDepth == 0) {
           ctx.Diags.diagnose(expr->getLoc(),
                              diag::discard_expr_outside_of_assignment);
-          return nullptr;
+          return Action::Stop();
         }
       }
 
       if (auto KPE = dyn_cast<KeyPathExpr>(expr)) {
         resolveKeyPathExpr(KPE);
-        return KPE;
+        return Action::Continue(KPE);
       }
 
       if (auto *result = simplifyTypeConstructionWithLiteralArg(expr)) {
-        return isa<ErrorExpr>(result) ? nullptr : result;
+        if (isa<ErrorExpr>(result))
+           return Action::Stop();
+
+        return Action::Continue(result);
       }
 
       // If we find an unresolved member chain, wrap it in an
       // UnresolvedMemberChainResultExpr (unless this has already been done).
       auto *parent = Parent.getAsExpr();
-      if (isMemberChainTail(expr, parent))
-        if (auto *UME = TypeChecker::getUnresolvedMemberChainBase(expr))
-          if (!parent || !isa<UnresolvedMemberChainResultExpr>(parent))
-            return new (ctx) UnresolvedMemberChainResultExpr(expr, UME);
-
-      return expr;
+      if (isMemberChainTail(expr, parent)) {
+        if (auto *UME = TypeChecker::getUnresolvedMemberChainBase(expr)) {
+          if (!parent || !isa<UnresolvedMemberChainResultExpr>(parent)) {
+            auto *chain = new (ctx) UnresolvedMemberChainResultExpr(expr, UME);
+            return Action::Continue(chain);
+          }
+        }
+      }
+      return Action::Continue(expr);
     }
 
-    std::pair<bool, Stmt *> walkToStmtPre(Stmt *stmt) override {
-      return { true, stmt };
+    PreWalkResult<Stmt *> walkToStmtPre(Stmt *stmt) override {
+      return Action::Continue(stmt);
     }
 
-    bool walkToDeclPre(Decl *D) override { return isa<PatternBindingDecl>(D); }
+    PreWalkAction walkToDeclPre(Decl *D) override {
+      return Action::VisitChildrenIf(isa<PatternBindingDecl>(D));
+    }
 
-    std::pair<bool, Pattern *> walkToPatternPre(Pattern *pattern) override {
+    PreWalkResult<Pattern *> walkToPatternPre(Pattern *pattern) override {
       // Constraint generation is responsible for pattern verification and
       // type-checking in the body of the closure, so there is no need to
       // walk into patterns.
-      bool walkIntoPatterns = !isa<ClosureExpr>(DC);
-      return {walkIntoPatterns, pattern};
+      return Action::SkipChildrenIf(isa<ClosureExpr>(DC), pattern);
     }
   };
 } // end anonymous namespace

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -142,7 +142,7 @@ class TypeAccessScopeDiagnoser : private ASTWalker {
 
   bool walkToTypeReprPost(TypeRepr *T) override {
     // Exit early if we've already found a problem type.
-    return offendingType != nullptr;
+    return offendingType == nullptr;
   }
 
   explicit TypeAccessScopeDiagnoser(AccessScope accessScope,

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -119,30 +119,21 @@ class TypeAccessScopeDiagnoser : private ASTWalker {
   bool treatUsableFromInlineAsPublic;
   const ComponentIdentTypeRepr *offendingType = nullptr;
 
-  bool walkToTypeReprPre(TypeRepr *TR) override {
-    // Exit early if we've already found a problem type.
-    if (offendingType)
-      return false;
-
+  PreWalkAction walkToTypeReprPre(TypeRepr *TR) override {
     auto CITR = dyn_cast<ComponentIdentTypeRepr>(TR);
     if (!CITR)
-      return true;
+      return Action::Continue();
 
     const ValueDecl *VD = CITR->getBoundDecl();
     if (!VD)
-      return true;
+      return Action::Continue();
 
     if (VD->getFormalAccessScope(useDC, treatUsableFromInlineAsPublic)
         != accessScope)
-      return true;
+      return Action::Continue();
 
     offendingType = CITR;
-    return false;
-  }
-
-  bool walkToTypeReprPost(TypeRepr *T) override {
-    // Exit early if we've already found a problem type.
-    return offendingType == nullptr;
+    return Action::Stop();
   }
 
   explicit TypeAccessScopeDiagnoser(AccessScope accessScope,

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -470,7 +470,7 @@ public:
   }
 
 private:
-  bool walkToDeclPre(Decl *D) override {
+  PreWalkAction walkToDeclPre(Decl *D) override {
     PrettyStackTraceDecl trace(stackTraceAction(), D);
 
     // Adds in a parent TRC for decls which are syntactically nested but are not
@@ -490,10 +490,10 @@ private:
 
     // Create TRCs that cover only the body of the declaration.
     buildContextsForBodyOfDecl(D);
-    return true;
+    return Action::Continue();
   }
 
-  bool walkToDeclPost(Decl *D) override {
+  PostWalkAction walkToDeclPost(Decl *D) override {
     while (ContextStack.back().ScopeNode.getAsDecl() == D) {
       ContextStack.pop_back();
     }
@@ -503,7 +503,7 @@ private:
       DeclBodyContextStack.pop_back();
     }
 
-    return true;
+    return Action::Continue();
   }
 
   TypeRefinementContext *getEffectiveParentContextForDecl(Decl *D) {
@@ -778,32 +778,32 @@ private:
     }
   }
 
-  std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
+  PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
     PrettyStackTraceStmt trace(Context, stackTraceAction(), S);
 
     if (consumeDeclBodyContextIfNecessary(S)) {
-      return std::make_pair(true, S);
+      return Action::Continue(S);
     }
 
     if (auto *IS = dyn_cast<IfStmt>(S)) {
       buildIfStmtRefinementContext(IS);
-      return std::make_pair(false, S);
+      return Action::SkipChildren(S);
     }
 
     if (auto *RS = dyn_cast<GuardStmt>(S)) {
       buildGuardStmtRefinementContext(RS);
-      return std::make_pair(false, S);
+      return Action::SkipChildren(S);
     }
 
     if (auto *WS = dyn_cast<WhileStmt>(S)) {
       buildWhileStmtRefinementContext(WS);
-      return std::make_pair(false, S);
+      return Action::SkipChildren(S);
     }
 
-    return std::make_pair(true, S);
+    return Action::Continue(S);
   }
 
-  Stmt *walkToStmtPost(Stmt *S) override {
+  PostWalkResult<Stmt *> walkToStmtPost(Stmt *S) override {
     // If we have multiple guard statements in the same block
     // then we may have multiple refinement contexts to pop
     // after walking that block.
@@ -812,7 +812,7 @@ private:
       ContextStack.pop_back();
     }
 
-    return S;
+    return Action::Continue(S);
   }
 
   /// Consumes the top TRC from \p DeclBodyContextStack and pushes it onto the
@@ -1199,12 +1199,12 @@ private:
     return AvailabilityContext(VersionRange::allGTE(Version));
   }
 
-  Expr *walkToExprPost(Expr *E) override {
+  PostWalkResult<Expr *> walkToExprPost(Expr *E) override {
     if (ContextStack.back().ScopeNode.getAsExpr() == E) {
       ContextStack.pop_back();
     }
 
-    return E;
+    return Action::Continue(E);
   }
 };
   
@@ -1414,84 +1414,82 @@ public:
   /// the predicate.
   Optional<ASTNode> getInnermostMatchingNode() { return InnermostMatchingNode; }
 
-  std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
-    return std::make_pair(walkToRangePre(E->getSourceRange()), E);
+  PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
+    return getPreWalkActionFor(E);
   }
 
-  std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
-    return std::make_pair(walkToRangePre(S->getSourceRange()), S);
+  PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
+    return getPreWalkActionFor(S);
   }
 
-  bool walkToDeclPre(Decl *D) override {
-    return walkToRangePre(D->getSourceRange());
+  PreWalkAction walkToDeclPre(Decl *D) override {
+    return getPreWalkActionFor(D).Action;
   }
 
-  std::pair<bool, Pattern *> walkToPatternPre(Pattern *P) override {
-    return std::make_pair(walkToRangePre(P->getSourceRange()), P);
+  PreWalkResult<Pattern *> walkToPatternPre(Pattern *P) override {
+    return getPreWalkActionFor(P);
   }
 
-  bool walkToTypeReprPre(TypeRepr *T) override {
-    return walkToRangePre(T->getSourceRange());
+  PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
+    return getPreWalkActionFor(T).Action;
   }
 
-  /// Returns true if the walker should traverse an AST node with
-  /// source range Range.
-  bool walkToRangePre(SourceRange Range) {
+  /// Retrieve the pre-walk action for a given node, which determines whether
+  /// or not it should be walked into.
+  template <typename T>
+  PreWalkResult<T> getPreWalkActionFor(T Node) {
     // When walking down the tree, we traverse until we have found a node
     // inside the target range. Once we have found such a node, there is no
     // need to traverse any deeper.
     if (FoundTarget)
-      return false;
+      return Action::SkipChildren(Node);
 
     // If we haven't found our target yet and the node we are pre-visiting
     // doesn't have a valid range, we still have to traverse it because its
     // subtrees may have valid ranges.
+    auto Range = Node->getSourceRange();
     if (Range.isInvalid())
-      return true;
+      return Action::Continue(Node);
 
     // We have found our target if the range of the node we are visiting
     // is contained in the range we are looking for.
     FoundTarget = SM.rangeContains(TargetRange, Range);
 
     if (FoundTarget)
-      return false;
+      return Action::SkipChildren(Node);
 
     // Search the subtree if the target range is inside its range.
-    return SM.rangeContains(Range, TargetRange);
+    if (!SM.rangeContains(Range, TargetRange))
+      return Action::SkipChildren(Node);
+
+    return Action::Continue(Node);
   }
 
-  Expr *walkToExprPost(Expr *E) override {
-    if (walkToNodePost(E)) {
-      return E;
-    }
-
-    return nullptr;
+  PostWalkResult<Expr *> walkToExprPost(Expr *E) override {
+    return walkToNodePost(E);
   }
 
-  Stmt *walkToStmtPost(Stmt *S) override {
-    if (walkToNodePost(S)) {
-      return S;
-    }
-
-    return nullptr;
+  PostWalkResult<Stmt *> walkToStmtPost(Stmt *S) override {
+    return walkToNodePost(S);
   }
 
-  bool walkToDeclPost(Decl *D) override {
-    return walkToNodePost(D);
+  PostWalkAction walkToDeclPost(Decl *D) override {
+    return walkToNodePost(D).Action;
   }
 
   /// Once we have found the target node, look for the innermost ancestor
   /// matching our criteria on the way back up the spine of the tree.
-  bool walkToNodePost(ASTNode Node) {
+  template <typename T>
+  PostWalkResult<T> walkToNodePost(T Node) {
     if (!InnermostMatchingNode.hasValue() && Predicate(Node, Parent)) {
-      assert(Node.getSourceRange().isInvalid() ||
-             SM.rangeContains(Node.getSourceRange(), TargetRange));
+      assert(Node->getSourceRange().isInvalid() ||
+             SM.rangeContains(Node->getSourceRange(), TargetRange));
 
       InnermostMatchingNode = Node;
-      return false;
+      return Action::Stop();
     }
 
-    return true;
+    return Action::Continue(Node);
   }
 };
 
@@ -3221,15 +3219,14 @@ public:
 
   bool shouldWalkIntoTapExpression() override { return false; }
 
-  std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+  PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
     auto *DC = Where.getDeclContext();
 
     ExprStack.push_back(E);
 
-    auto visitChildren = [&]() { return std::make_pair(true, E); };
     auto skipChildren = [&]() {
       ExprStack.pop_back();
-      return std::make_pair(false, E);
+      return Action::SkipChildren(E);
     };
 
     if (auto DR = dyn_cast<DeclRefExpr>(E)) {
@@ -3321,17 +3318,17 @@ public:
       }
     }
 
-    return visitChildren();
+    return Action::Continue(E);
   }
 
-  Expr *walkToExprPost(Expr *E) override {
+  PostWalkResult<Expr *> walkToExprPost(Expr *E) override {
     assert(ExprStack.back() == E);
     ExprStack.pop_back();
 
-    return E;
+    return Action::Continue(E);
   }
 
-  std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
+  PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
 
     // We end up here when checking the output of the result builder transform,
     // which includes closures that are not "separately typechecked" and yet
@@ -3339,7 +3336,7 @@ public:
     // since these availability for these statements is not diagnosed from
     // typeCheckStmt() as usual.
     diagnoseStmtAvailability(S, Where.getDeclContext(), /*walkRecursively=*/true);
-    return std::make_pair(false, S);
+    return Action::SkipChildren(S);
   }
 
   bool diagnoseDeclRefAvailability(ConcreteDeclRef declRef, SourceRange R,
@@ -3900,32 +3897,32 @@ public:
   explicit StmtAvailabilityWalker(DeclContext *dc, bool walkRecursively)
     : DC(dc), WalkRecursively(walkRecursively) {}
 
-  std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
+  PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
     if (!WalkRecursively && isa<BraceStmt>(S))
-      return std::make_pair(false, S);
+      return Action::SkipChildren(S);
 
-    return std::make_pair(true, S);
+    return Action::Continue(S);
   }
 
-  std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+  PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
     if (WalkRecursively)
       diagnoseExprAvailability(E, DC);
-    return std::make_pair(false, E);
+    return Action::SkipChildren(E);
   }
 
-  bool walkToTypeReprPre(TypeRepr *T) override {
+  PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
     auto where = ExportContext::forFunctionBody(DC, T->getStartLoc());
     diagnoseTypeReprAvailability(T, where);
-    return false;
+    return Action::SkipChildren();
   }
 
-  std::pair<bool, Pattern *> walkToPatternPre(Pattern *P) override {
+  PreWalkResult<Pattern *> walkToPatternPre(Pattern *P) override {
     if (auto *IP = dyn_cast<IsPattern>(P)) {
       auto where = ExportContext::forFunctionBody(DC, P->getLoc());
       diagnoseTypeAvailability(IP->getCastType(), P->getLoc(), where);
     }
 
-    return std::make_pair(true, P);
+    return Action::Continue(P);
   }
 };
 }
@@ -3975,7 +3972,7 @@ public:
                              DeclAvailabilityFlags flags)
       : where(where), flags(flags) {}
 
-  bool walkToTypeReprPre(TypeRepr *T) override {
+  PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
     if (auto *ITR = dyn_cast<IdentTypeRepr>(T)) {
       if (auto *CTR = dyn_cast<CompoundIdentTypeRepr>(ITR)) {
         for (auto *comp : CTR->getComponents()) {
@@ -3997,10 +3994,10 @@ public:
 
       // We've already visited all the children above, so we don't
       // need to recurse.
-      return false;
+      return Action::SkipChildren();
     }
 
-    return true;
+    return Action::Continue();
   }
 };
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3073,7 +3073,8 @@ bool ActorIsolationChecker::mayExecuteConcurrentlyWith(
 
 void swift::checkTopLevelActorIsolation(TopLevelCodeDecl *decl) {
   ActorIsolationChecker checker(decl);
-  decl->getBody()->walk(checker);
+  if (auto *body = decl->getBody())
+    body->walk(checker);
 }
 
 void swift::checkFunctionActorIsolation(AbstractFunctionDecl *decl) {

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -271,20 +271,20 @@ class FunctionSyntacticDiagnosticWalker : public ASTWalker {
 public:
   FunctionSyntacticDiagnosticWalker(DeclContext *dc) { dcStack.push_back(dc); }
 
-  std::pair<bool, Expr *> walkToExprPre(Expr *expr) override {
+  PreWalkResult<Expr *> walkToExprPre(Expr *expr) override {
     performSyntacticExprDiagnostics(expr, dcStack.back(), /*isExprStmt=*/false);
 
     if (auto closure = dyn_cast<ClosureExpr>(expr)) {
       if (closure->isSeparatelyTypeChecked()) {
         dcStack.push_back(closure);
-        return {true, expr};
+        return Action::Continue(expr);
       }
     }
 
-    return {false, expr};
+    return Action::SkipChildren(expr);
   }
 
-  Expr *walkToExprPost(Expr *expr) override {
+  PostWalkResult<Expr *> walkToExprPost(Expr *expr) override {
     if (auto closure = dyn_cast<ClosureExpr>(expr)) {
       if (closure->isSeparatelyTypeChecked()) {
         assert(dcStack.back() == closure);
@@ -292,20 +292,23 @@ public:
       }
     }
 
-    return expr;
+    return Action::Continue(expr);
   }
 
-  std::pair<bool, Stmt *> walkToStmtPre(Stmt *stmt) override {
+  PreWalkResult<Stmt *> walkToStmtPre(Stmt *stmt) override {
     performStmtDiagnostics(stmt, dcStack.back());
-    return {true, stmt};
+    return Action::Continue(stmt);
   }
 
-  std::pair<bool, Pattern *> walkToPatternPre(Pattern *pattern) override {
-    return {false, pattern};
+  PreWalkResult<Pattern *> walkToPatternPre(Pattern *pattern) override {
+    return Action::SkipChildren(pattern);
   }
-
-  bool walkToTypeReprPre(TypeRepr *typeRepr) override { return false; }
-  bool walkToParameterListPre(ParameterList *params) override { return false; }
+  PreWalkAction walkToTypeReprPre(TypeRepr *typeRepr) override {
+    return Action::SkipChildren();
+  }
+  PreWalkAction walkToParameterListPre(ParameterList *params) override {
+    return Action::SkipChildren();
+  }
 };
 } // end anonymous namespace
 
@@ -1108,27 +1111,27 @@ TypeChecker::addImplicitLoadExpr(ASTContext &Context, Expr *expr,
     LoadAdder(ASTContext &ctx, GetTypeFn getType, SetTypeFn setType)
         : Ctx(ctx), getType(getType), setType(setType) {}
 
-    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+    PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       if (isa<ParenExpr>(E) || isa<ForceValueExpr>(E))
-        return { true, E };
+        return Action::Continue(E);
 
       // Since load expression is created by walker,
       // it's safe to stop as soon as it encounters first one
       // because it would be the one it just created.
       if (isa<LoadExpr>(E))
-        return { false, nullptr };
+        return Action::Stop();
 
-      return { false, createLoadExpr(E) };
+      return Action::SkipChildren(createLoadExpr(E));
     }
 
-    Expr *walkToExprPost(Expr *E) override {
+    PostWalkResult<Expr *> walkToExprPost(Expr *E) override {
       if (auto *FVE = dyn_cast<ForceValueExpr>(E))
         setType(E, getType(FVE->getSubExpr())->getOptionalObjectType());
 
       if (auto *PE = dyn_cast<ParenExpr>(E))
         setType(E, ParenType::get(Ctx, getType(PE->getSubExpr())));
 
-      return E;
+      return Action::Continue(E);
     }
 
   private:
@@ -2250,19 +2253,27 @@ void ConstraintSystem::forEachExpr(
                 llvm::function_ref<Expr *(Expr *)> callback)
         : CS(CS), callback(callback) {}
 
-    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+    PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
+      auto *NewE = callback(E);
+      if (!NewE)
+        return Action::Stop();
+
       if (auto closure = dyn_cast<ClosureExpr>(E)) {
         if (!CS.participatesInInference(closure))
-          return { false, callback(E) };
+          return Action::SkipChildren(NewE);
       }
-      return { true, callback(E) };
+      return Action::Continue(NewE);
     }
 
-    std::pair<bool, Pattern*> walkToPatternPre(Pattern *P) override {
-      return { false, P };
+    PreWalkResult<Pattern *> walkToPatternPre(Pattern *P) override {
+      return Action::SkipChildren(P);
     }
-    bool walkToDeclPre(Decl *D) override { return false; }
-    bool walkToTypeReprPre(TypeRepr *T) override { return false; }
+    PreWalkAction walkToDeclPre(Decl *D) override {
+      return Action::SkipChildren();
+    }
+    PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
+      return Action::SkipChildren();
+    }
   };
 
   expr->walk(ChildWalker(*this, callback));

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -582,7 +582,8 @@ BodyInitKindRequest::evaluate(Evaluator &evaluator,
 
   auto &ctx = decl->getASTContext();
   FindReferenceToInitializer finder(decl, ctx);
-  decl->getBody()->walk(finder);
+  if (auto *body = decl->getBody())
+    body->walk(finder);
 
   // get the kind out of the finder.
   auto Kind = finder.Kind;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -498,20 +498,20 @@ BodyInitKindRequest::evaluate(Evaluator &evaluator,
                                ASTContext &ctx)
         : Decl(decl), ctx(ctx) { }
 
-    bool walkToDeclPre(class Decl *D) override {
+    PreWalkAction walkToDeclPre(class Decl *D) override {
       // Don't walk into further nominal decls.
-      return !isa<NominalTypeDecl>(D);
+      return Action::SkipChildrenIf(isa<NominalTypeDecl>(D));
     }
     
-    std::pair<bool, Expr*> walkToExprPre(Expr *E) override {
+    PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       // Don't walk into closures.
       if (isa<ClosureExpr>(E))
-        return { false, E };
+        return Action::SkipChildren(E);
       
       // Look for calls of a constructor on self or super.
       auto apply = dyn_cast<ApplyExpr>(E);
       if (!apply)
-        return { true, E };
+        return Action::Continue(E);
 
       auto *argList = apply->getArgs();
       auto Callee = apply->getSemanticFn();
@@ -525,12 +525,12 @@ BodyInitKindRequest::evaluate(Evaluator &evaluator,
         arg = CRE->getBase();
       } else if (auto *dotExpr = dyn_cast<UnresolvedDotExpr>(Callee)) {
         if (dotExpr->getName().getBaseName() != DeclBaseName::createConstructor())
-          return { true, E };
+          return Action::Continue(E);
 
         arg = dotExpr->getBase();
       } else {
         // Not a constructor call.
-        return { true, E };
+        return Action::Continue(E);
       }
 
       // Look for a base of 'self' or 'super'.
@@ -559,13 +559,13 @@ BodyInitKindRequest::evaluate(Evaluator &evaluator,
       }
       
       if (myKind == BodyInitKind::None)
-        return { true, E };
+        return Action::Continue(E);
 
       if (Kind == BodyInitKind::None) {
         Kind = myKind;
 
         InitExpr = apply;
-        return { true, E };
+        return Action::Continue(E);
       }
 
       // If the kind changed, complain.
@@ -576,7 +576,7 @@ BodyInitKindRequest::evaluate(Evaluator &evaluator,
                            Kind == BodyInitKind::Chained);
       }
 
-      return { true, E };
+      return Action::Continue(E);
     }
   };
 

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -2906,8 +2906,10 @@ void TypeChecker::checkTopLevelEffects(TopLevelCodeDecl *code) {
   if (ctx.LangOpts.EnableThrowWithoutTry)
     checker.setTopLevelThrowWithoutTry();
 
-  code->getBody()->walk(checker);
-  code->getBody()->walk(LocalFunctionEffectsChecker());
+  if (auto *body = code->getBody()) {
+    body->walk(checker);
+    body->walk(LocalFunctionEffectsChecker());
+  }
 }
 
 void TypeChecker::checkFunctionEffects(AbstractFunctionDecl *fn) {

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -399,7 +399,7 @@ template <class Impl>
 class EffectsHandlingWalker : public ASTWalker {
   Impl &asImpl() { return *static_cast<Impl*>(this); }
 public:
-  bool walkToDeclPre(Decl *D) override {
+  PreWalkAction walkToDeclPre(Decl *D) override {
     ShouldRecurse_t recurse = ShouldRecurse;
     // Skip the implementations of all local declarations... except
     // PBD.  We should really just have a PatternBindingStmt.
@@ -411,10 +411,10 @@ public:
     } else {
       recurse = ShouldNotRecurse;
     }
-    return bool(recurse);
+    return Action::VisitChildrenIf(bool(recurse));
   }
 
-  std::pair<bool, Expr*> walkToExprPre(Expr *E) override {
+  PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
     visitExprPre(E);
     ShouldRecurse_t recurse = ShouldRecurse;
     if (isa<ErrorExpr>(E)) {
@@ -444,13 +444,13 @@ public:
     // type checking. If an unchecked expression is still around, the code was
     // invalid.
 #define UNCHECKED_EXPR(KIND, BASE) \
-    else if (isa<KIND##Expr>(E)) return {false, nullptr};
+    else if (isa<KIND##Expr>(E)) return Action::Stop();
 #include "swift/AST/ExprNodes.def"
 
-    return {bool(recurse), E};
+    return Action::VisitChildrenIf(bool(recurse), E);
   }
 
-  std::pair<bool, Stmt*> walkToStmtPre(Stmt *S) override {
+  PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
     ShouldRecurse_t recurse = ShouldRecurse;
     if (auto doCatch = dyn_cast<DoCatchStmt>(S)) {
       recurse = asImpl().checkDoCatch(doCatch);
@@ -459,7 +459,10 @@ public:
     } else if (auto forEach = dyn_cast<ForEachStmt>(S)) {
       recurse = asImpl().checkForEach(forEach);
     }
-    return {bool(recurse), S};
+    if (!recurse)
+      return Action::SkipChildren(S);
+
+    return Action::Continue(S);
   }
 
   ShouldRecurse_t checkDoCatch(DoCatchStmt *S) {
@@ -2572,17 +2575,17 @@ private:
       CheckEffectsCoverage &CEC;
       ConservativeThrowChecker(CheckEffectsCoverage &CEC) : CEC(CEC) {}
       
-      Expr *walkToExprPost(Expr *E) override {
+      PostWalkResult<Expr *> walkToExprPost(Expr *E) override {
         if (isa<TryExpr>(E))
           CEC.Flags.set(ContextFlags::HasAnyThrowSite);
-        return E;
+        return Action::Continue(E);
       }
       
-      Stmt *walkToStmtPost(Stmt *S) override {
+      PostWalkResult<Stmt *> walkToStmtPost(Stmt *S) override {
         if (isa<ThrowStmt>(S))
           CEC.Flags.set(ContextFlags::HasAnyThrowSite);
 
-        return S;
+        return Action::Continue(S);
       }
     };
 
@@ -2884,15 +2887,15 @@ private:
 
 // Find nested functions and perform effects checking on them.
 struct LocalFunctionEffectsChecker : ASTWalker {
-  bool walkToDeclPre(Decl *D) override {
+  PreWalkAction walkToDeclPre(Decl *D) override {
     if (auto func = dyn_cast<AbstractFunctionDecl>(D)) {
       if (func->getDeclContext()->isLocalContext())
         TypeChecker::checkFunctionEffects(func);
 
-      return false;
+      return Action::SkipChildren();
     }
 
-    return true;
+    return Action::Continue();
   }
 };
 

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -234,14 +234,14 @@ namespace {
     UnresolvedPatternFinder(bool &HadUnresolvedPattern)
       : HadUnresolvedPattern(HadUnresolvedPattern) {}
     
-    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+    PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       // If we find an UnresolvedPatternExpr, return true.
       if (isa<UnresolvedPatternExpr>(E)) {
         HadUnresolvedPattern = true;
-        return { false, E };
+        return Action::SkipChildren(E);
       }
       
-      return { true, E };
+      return Action::Continue(E);
     }
     
     static bool hasAny(Expr *E) {

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -205,7 +205,8 @@ void TypeChecker::contextualizeTopLevelCode(TopLevelCodeDecl *TLCD) {
   auto &Context = TLCD->DeclContext::getASTContext();
   unsigned nextDiscriminator = Context.NextAutoClosureDiscriminator;
   ContextualizeClosures CC(TLCD, nextDiscriminator);
-  TLCD->getBody()->walk(CC);
+  if (auto *body = TLCD->getBody())
+    body->walk(CC);
   assert(nextDiscriminator == Context.NextAutoClosureDiscriminator &&
          "reentrant/concurrent invocation of contextualizeTopLevelCode?");
   Context.NextAutoClosureDiscriminator = CC.NextDiscriminator;

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -69,7 +69,7 @@ namespace {
                           unsigned nextDiscriminator = 0)
       : ParentDC(parent), NextDiscriminator(nextDiscriminator) {}
 
-    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+    PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       // Autoclosures need to be numbered and potentially reparented.
       // Reparenting is required with:
       //   - nested autoclosures, because the inner autoclosure will be
@@ -81,7 +81,7 @@ namespace {
         // underlying issue. -Joe
         if (CE->getParent() == ParentDC
             && CE->getDiscriminator() != AutoClosureExpr::InvalidDiscriminator)
-          return { false, E };
+          return Action::SkipChildren(E);
         
         assert(CE->getDiscriminator() == AutoClosureExpr::InvalidDiscriminator);
         CE->setDiscriminator(NextDiscriminator++);
@@ -95,7 +95,7 @@ namespace {
         ParentDC = oldParentDC;
 
         TypeChecker::computeCaptures(CE);
-        return { false, E };
+        return Action::SkipChildren(E);
       } 
 
       // Capture lists need to be reparented to enclosing autoclosures.
@@ -119,7 +119,7 @@ namespace {
           CE->getBody()->walk(ContextualizeClosures(CE));
 
         TypeChecker::computeCaptures(CE);
-        return { false, E };
+        return Action::SkipChildren(E);
       }
 
       // Caller-side default arguments need their @autoclosures checked.
@@ -127,14 +127,14 @@ namespace {
         if (DAE->isCallerSide() && DAE->getParamDecl()->isAutoClosure())
           DAE->getCallerSideDefaultExpr()->walk(*this);
 
-      return { true, E };
+      return Action::Continue(E);
     }
 
     /// We don't want to recurse into most local declarations.
-    bool walkToDeclPre(Decl *D) override {
+    PreWalkAction walkToDeclPre(Decl *D) override {
       // But we do want to walk into the initializers of local
       // variables.
-      return isa<PatternBindingDecl>(D);
+      return Action::VisitChildrenIf(isa<PatternBindingDecl>(D));
     }
   };
 
@@ -1765,15 +1765,14 @@ static void checkClassConstructorBody(ClassDecl *classDecl,
   public:
     ApplyExpr *Found = nullptr;
 
-    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+    PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       if (auto apply = dyn_cast<ApplyExpr>(E)) {
         if (isa<OtherConstructorDeclRefExpr>(apply->getSemanticFn())) {
           Found = apply;
-          return { false, E };
+          return Action::Stop();
         }
       }
-
-      return { Found == nullptr, E };
+      return Action::Continue(E);
     }
   };
 
@@ -1868,13 +1867,13 @@ bool TypeCheckASTNodeAtLocRequest::evaluate(
     }
     DeclContext *getDeclContext() const { return DC; }
 
-    std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
+    PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
       if (auto *brace = dyn_cast<BraceStmt>(S)) {
         auto braceCharRange = Lexer::getCharSourceRangeFromSourceRange(
             SM, brace->getSourceRange());
         // Unless this brace contains the loc, there's nothing to do.
         if (!braceCharRange.contains(Loc))
-          return {false, S};
+          return Action::SkipChildren(S);
 
         // Reset the node found in a parent context.
         if (!brace->isImplicit())
@@ -1902,40 +1901,40 @@ bool TypeCheckASTNodeAtLocRequest::evaluate(
           break;
         }
         // Already walked into.
-        return {false, nullptr};
+        return Action::Stop();
       }
 
-      return {true, S};
+      return Action::Continue(S);
     }
 
-    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+    PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       if (SM.isBeforeInBuffer(Loc, E->getStartLoc()))
-        return {false, E};
+        return Action::SkipChildren(E);
 
       SourceLoc endLoc = Lexer::getLocForEndOfToken(SM, E->getEndLoc());
       if (SM.isBeforeInBuffer(endLoc, Loc))
-        return {false, E};
+        return Action::SkipChildren(E);
 
       // Don't walk into 'TapExpr'. They should be type checked with parent
       // 'InterpolatedStringLiteralExpr'.
       if (isa<TapExpr>(E))
-        return {false, E};
+        return Action::SkipChildren(E);
 
       if (auto closure = dyn_cast<ClosureExpr>(E)) {
         // NOTE: When a client wants to type check a closure signature, it
         // requests with closure's 'getLoc()' location.
         if (Loc == closure->getLoc())
-          return {false, E};
+          return Action::SkipChildren(E);
 
         DC = closure;
       }
-      return {true, E};
+      return Action::Continue(E);
     }
 
-    bool walkToDeclPre(Decl *D) override {
+    PreWalkAction walkToDeclPre(Decl *D) override {
       if (auto *newDC = dyn_cast<DeclContext>(D))
         DC = newDC;
-      return true;
+      return Action::Continue();
     }
 
   } finder(ctx.SourceMgr, Loc);

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -3584,7 +3584,8 @@ bool SimpleDidSetRequest::evaluate(Evaluator &evaluator,
   // If we find a reference to the implicit 'oldValue' parameter, then it is
   // not a "simple" didSet because we need to fetch it.
   auto walker = OldValueFinder(param);
-  decl->getTypecheckedBody()->walk(walker);
+  if (auto *body = decl->getTypecheckedBody())
+    body->walk(walker);
   auto hasOldValueRef = walker.didFindOldValueRef();
   if (!hasOldValueRef) {
     // If the body does not refer to implicit 'oldValue', it means we can

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4561,55 +4561,55 @@ public:
   ExistentialTypeVisitor(ASTContext &ctx, bool checkStatements)
     : Ctx(ctx), checkStatements(checkStatements), hitTopStmt(false) { }
 
-  bool walkToTypeReprPre(TypeRepr *T) override {
+  PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
     reprStack.push_back(T);
 
     if (T->isInvalid())
-      return false;
+      return Action::SkipChildren();
     if (auto compound = dyn_cast<CompoundIdentTypeRepr>(T)) {
       // Only visit the last component to check, because nested typealiases in
       // existentials are okay.
       visit(compound->getComponentRange().back());
-      return false;
+      return Action::SkipChildren();
     }
     // Arbitrary protocol constraints are OK on opaque types.
     if (isa<OpaqueReturnTypeRepr>(T))
-      return false;
+      return Action::SkipChildren();
 
     // Arbitrary protocol constraints are okay for 'any' types.
     if (isa<ExistentialTypeRepr>(T))
-      return false;
+      return Action::SkipChildren();
 
     visit(T);
-    return true;
+    return Action::Continue();
   }
 
-  bool walkToTypeReprPost(TypeRepr *T) override {
+  PostWalkAction walkToTypeReprPost(TypeRepr *T) override {
     reprStack.pop_back();
-    return true;
+    return Action::Continue();
   }
 
-  std::pair<bool, Stmt*> walkToStmtPre(Stmt *S) override {
+  PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
     if (checkStatements && !hitTopStmt) {
       hitTopStmt = true;
-      return { true, S };
+      return Action::Continue(S);
     }
 
-    return { false, S };
+    return Action::SkipChildren(S);
   }
 
-  bool walkToDeclPre(Decl *D) override {
-    return !checkStatements;
+  PreWalkAction walkToDeclPre(Decl *D) override {
+    return Action::SkipChildrenIf(checkStatements);
   }
 
-  std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+  PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
     ++exprCount;
-    return {true, E};
+    return Action::Continue(E);
   }
 
-  Expr * walkToExprPost(Expr *E) override {
+  PostWalkResult<Expr *> walkToExprPost(Expr *E) override {
     --exprCount;
-    return E;
+    return Action::Continue(E);
   }
 
   void visitTypeRepr(TypeRepr *T) {

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -386,7 +386,7 @@ void swift::loadDerivativeConfigurations(SourceFile &SF) {
   public:
     DerivativeFinder() {}
 
-    bool walkToDeclPre(Decl *D) override {
+    PreWalkAction walkToDeclPre(Decl *D) override {
       if (auto *afd = dyn_cast<AbstractFunctionDecl>(D)) {
         for (auto *derAttr : afd->getAttrs().getAttributes<DerivativeAttr>()) {
           // Resolve derivative function configurations from `@derivative`
@@ -395,7 +395,7 @@ void swift::loadDerivativeConfigurations(SourceFile &SF) {
         }
       }
 
-      return true;
+      return Action::Continue();
     }
   };
 
@@ -462,7 +462,7 @@ namespace {
                             GenericParamList *params)
         : dc(dc), params(params) {}
 
-    bool walkToTypeReprPre(TypeRepr *T) override {
+    PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
       if (auto *ident = dyn_cast<IdentTypeRepr>(T)) {
         auto firstComponent = ident->getComponentRange().front();
         auto name = firstComponent->getNameRef().getBaseIdentifier();
@@ -470,7 +470,7 @@ namespace {
           firstComponent->setValue(paramDecl, dc);
       }
 
-      return true;
+      return Action::Continue();
     }
   };
 }

--- a/test/Sema/accessibility_typealias.swift
+++ b/test/Sema/accessibility_typealias.swift
@@ -27,7 +27,7 @@ public final class ReplayableGenerator<S: Sequence> : IteratorProtocol {
 }
 
 struct Generic<T> {
-  fileprivate typealias Dependent = T
+  fileprivate typealias Dependent = T // expected-note 2{{type declared here}}
 }
 
 var x: Generic<Int>.Dependent = 3 // expected-error {{variable must be declared private or fileprivate because its type uses a fileprivate type}}

--- a/test/Sema/availability_compound.swift
+++ b/test/Sema/availability_compound.swift
@@ -6,6 +6,7 @@ public struct PublicStruct {
   public struct Inner {}
   @available(*, unavailable)
   internal struct Obsolete {} // expected-note * {{marked unavailable here}}
+  // expected-note@-1 3{{type declared here}}
 }
 
 @available(*, unavailable, renamed: "PublicStruct")

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1541,15 +1541,15 @@ private:
     : PlaceholderLoc(PlaceholderLoc), Found(Found) {
     }
 
-    std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+    PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       if (isa<EditorPlaceholderExpr>(E) && E->getStartLoc() == PlaceholderLoc) {
         Found = cast<EditorPlaceholderExpr>(E);
-        return { false, nullptr };
+        return Action::Stop();
       }
-      return { true, E };
+      return Action::Continue(E);
     }
 
-    bool walkToDeclPre(Decl *D) override {
+    PreWalkAction walkToDeclPre(Decl *D) override {
       if (auto *ICD = dyn_cast<IfConfigDecl>(D)) {
         // The base walker assumes the content of active IfConfigDecl clauses
         // has been injected into the parent context and will be walked there.
@@ -1560,9 +1560,9 @@ private:
             Elem.walk(*this);
           }
         }
-        return false;
+        return Action::SkipChildren();
       }
-      return true;
+      return Action::Continue();
     }
   };
 
@@ -1574,7 +1574,7 @@ private:
     explicit ClosureTypeWalker(SourceManager &SM, ClosureInfo &Info) : SM(SM),
       Info(Info) { }
 
-    bool walkToTypeReprPre(TypeRepr *T) override {
+    PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
       if (auto *FTR = dyn_cast<FunctionTypeRepr>(T)) {
         FoundFunctionTypeRepr = true;
         for (auto &ArgElt : FTR->getArgsTypeRepr()->getElements()) {
@@ -1595,14 +1595,8 @@ private:
           Info.ReturnTypeRange = CharSourceRange(SM, RTR->getStartLoc(), SRE);
         }
       }
-      return !FoundFunctionTypeRepr;
+      return Action::StopIf(FoundFunctionTypeRepr);
     }
-
-    bool walkToTypeReprPost(TypeRepr *T) override {
-      // If we just visited the FunctionTypeRepr, end traversal.
-      return !FoundFunctionTypeRepr;
-    }
-
   };
 
   bool containClosure(Expr *E) {

--- a/tools/swift-ast-script/ASTScriptEvaluator.cpp
+++ b/tools/swift-ast-script/ASTScriptEvaluator.cpp
@@ -37,9 +37,9 @@ public:
   ASTScriptWalker(const ASTScript &script, ProtocolDecl *viewProtocol)
     : Script(script), ViewProtocol(viewProtocol) {}
 
-  bool walkToDeclPre(Decl *D) override {
+  PreWalkAction walkToDeclPre(Decl *D) override {
     visit(D);
-    return true;
+    return Action::Continue();
   }
 
   void visit(const Decl *D) {

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -3217,7 +3217,7 @@ public:
   ASTTypePrinter(SourceManager &SM, const PrintOptions &Options)
       : OS(llvm::outs()), SM(SM), Options(Options) {}
 
-  bool walkToDeclPre(Decl *D) override {
+  PreWalkAction walkToDeclPre(Decl *D) override {
     if (auto *VD = dyn_cast<ValueDecl>(D)) {
       OS.indent(IndentLevel * 2);
       OS << Decl::getKindName(VD->getKind()) << "Decl '''"
@@ -3226,15 +3226,15 @@ public:
       OS << "\n";
     }
     IndentLevel++;
-    return true;
+    return Action::Continue();
   }
 
-  bool walkToDeclPost(Decl *D) override {
+  PostWalkAction walkToDeclPost(Decl *D) override {
     IndentLevel--;
-    return true;
+    return Action::Continue();
   }
 
-  std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
+  PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
     StringRef SourceCode{ "<unknown>" };
     unsigned Line = ~0U;
 
@@ -3257,12 +3257,12 @@ public:
     E->getType().print(OS, Options);
     OS << "\n";
     IndentLevel++;
-    return { true, E };
+    return Action::Continue(E);
   }
 
-  Expr *walkToExprPost(Expr *E) override {
+  PostWalkResult<Expr *> walkToExprPost(Expr *E) override {
     IndentLevel--;
-    return E;
+    return Action::Continue(E);
   }
 };
 } // unnamed namespace
@@ -3300,16 +3300,16 @@ class ASTDocCommentDumper : public ASTWalker {
 public:
   ASTDocCommentDumper() : OS(llvm::outs()) {}
 
-  bool walkToDeclPre(Decl *D) override {
+  PreWalkAction walkToDeclPre(Decl *D) override {
     if (D->isImplicit())
-      return true;
+      return Action::Continue();
 
     swift::markup::MarkupContext MC;
     auto DC = getSingleDocComment(MC, D);
     if (DC)
       swift::markup::dump(DC->getDocument(), OS);
 
-    return true;
+    return Action::Continue();
   }
 };
 } // end anonymous namespace
@@ -3454,9 +3454,9 @@ public:
     }
   }
 
-  bool walkToDeclPre(Decl *D) override {
+  PreWalkAction walkToDeclPre(Decl *D) override {
     if (D->isImplicit())
-      return true;
+      return Action::Continue();
 
     if (auto *VD = dyn_cast<ValueDecl>(D)) {
       SourceLoc Loc = D->getLoc(/*SerializedOK=*/true);
@@ -3491,7 +3491,7 @@ public:
       printDocComment(D);
       OS << "\n";
     }
-    return true;
+    return Action::Continue();
   }
 };
 } // unnamed namespace


### PR DESCRIPTION
Replace the use of bool and pointer returns for `walkToXXXPre`/`walkToXXXPost`, and instead use explicit actions such as `Action::Continue(E)`, `Action::SkipChildren(E)`, and `Action::Stop()`. There are also conditional variants, e.g `Action::SkipChildrenIf`, `Action::VisitChildrenIf`, and `Action::StopIf`.

There is still more work that can be done here, in particular:

- SourceEntityWalker still needs to be migrated.
- Some uses of `return false` in pre-visitation methods can likely now be replaced by `Action::Stop`.
- We still use bool and pointer returns internally within the ASTWalker traversal, which could likely be improved.

But I'm leaving those as future work for now as this patch is already large enough.