### PR TITLE
[move-only] Move the various passes closer to their final positions.

### DIFF
--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -4744,8 +4744,18 @@ public:
         if (F.getModule().getStage() != SILStage::Lowered) {
           // During the lowered stage, a function type might have different
           // signature
-          require(eltArgTy == bbArgTy,
-                  "switch_enum destination bbarg must match case arg type");
+          //
+          // We allow for move only wrapped enums to have trivial payloads that
+          // are not move only wrapped. This occurs since we want to lower
+          // trivial move only wrapped types earlier in the pipeline than
+          // non-trivial types.
+          if (bbArgTy.isTrivial(F)) {
+            require(eltArgTy == bbArgTy.copyingMoveOnlyWrapper(eltArgTy),
+                    "switch_enum destination bbarg must match case arg type");
+          } else {
+            require(eltArgTy == bbArgTy,
+                    "switch_enum destination bbarg must match case arg type");
+          }
         }
         require(!dest->getArguments()[0]->getType().isAddress(),
                 "switch_enum destination bbarg type must not be an address");

--- a/lib/SILOptimizer/Mandatory/MoveOnlyWrappedTypeEliminator.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyWrappedTypeEliminator.cpp
@@ -93,7 +93,7 @@ struct SILMoveOnlyWrappedTypeEliminatorVisitor
       endBorrows.push_back(ebi);
     }
     for (auto *ebi : endBorrows) {
-      ebi->eraseFromParent();
+      eraseFromParent(ebi);
     }
     si->replaceAllUsesWith(si->getDest());
     return eraseFromParent(si);
@@ -183,19 +183,32 @@ struct SILMoveOnlyWrappedTypeEliminatorVisitor
   NO_UPDATE_NEEDED(DestroyAddr)
   NO_UPDATE_NEEDED(DeallocStack)
   NO_UPDATE_NEEDED(Branch)
-  NO_UPDATE_NEEDED(UncheckedAddrCast)
   NO_UPDATE_NEEDED(RefElementAddr)
-  NO_UPDATE_NEEDED(Upcast)
   NO_UPDATE_NEEDED(CheckedCastBranch)
   NO_UPDATE_NEEDED(Object)
   NO_UPDATE_NEEDED(OpenExistentialRef)
   NO_UPDATE_NEEDED(ConvertFunction)
   NO_UPDATE_NEEDED(RefToBridgeObject)
   NO_UPDATE_NEEDED(BridgeObjectToRef)
-  NO_UPDATE_NEEDED(UnconditionalCheckedCast)
   NO_UPDATE_NEEDED(ClassMethod)
 #undef NO_UPDATE_NEEDED
 
+  bool eliminateIdentityCast(SingleValueInstruction *svi) {
+    if (svi->getOperand(0)->getType() != svi->getType())
+      return false;
+    svi->replaceAllUsesWith(svi->getOperand(0));
+    eraseFromParent(svi);
+    return true;
+  }
+
+#define ELIMINATE_POTENTIAL_IDENTITY_CAST(NAME) \
+  bool visit##NAME##Inst(NAME##Inst *cast) { \
+    return eliminateIdentityCast(cast); \
+  }
+  ELIMINATE_POTENTIAL_IDENTITY_CAST(Upcast)
+  ELIMINATE_POTENTIAL_IDENTITY_CAST(UncheckedAddrCast)
+  ELIMINATE_POTENTIAL_IDENTITY_CAST(UnconditionalCheckedCast)
+#undef ELIMINATE_POTENTIAL_IDENTITY_CAST
   // We handle apply sites by just inserting a convert_function that converts
   // the original function type into a function type without move only. This is
   // safe since adding/removing moveonlywrapped types is ABI neutral.

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -140,10 +140,6 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
   P.addMoveKillsCopyableValuesChecker(); // No uses after _move of copyable
                                          //   value.
   P.addTrivialMoveOnlyTypeEliminator();
-  // As a temporary measure, we also eliminate move only for non-trivial types
-  // until we can audit the later part of the pipeline. Eventually, this should
-  // occur before IRGen.
-  P.addMoveOnlyTypeEliminator();
 
   P.addAddressLowering();
 
@@ -221,6 +217,11 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
   
   // Canonical swift requires all non cond_br critical edges to be split.
   P.addSplitNonCondBrCriticalEdges();
+
+  // As a temporary measure, we also eliminate move only for non-trivial types
+  // until we can audit the later part of the pipeline. Eventually, this should
+  // occur before IRGen.
+  P.addMoveOnlyTypeEliminator();
 }
 
 SILPassPipelinePlan


### PR DESCRIPTION
Specifically, I moved the ownership checking passes before mandatory inlining and I moved the non-trivial move only wrapped type lowering to the end of the guaranteed pipeline.