### PR TITLE
[Tests][Runtime] Update availability test for demangleTruncate.

### DIFF
--- a/test/stdlib/Runtime.swift.gyb
+++ b/test/stdlib/Runtime.swift.gyb
@@ -378,7 +378,7 @@ Runtime.test("demangleName") {
   expectEqual("Foobar", _stdlib_demangleName("$s13__lldb_expr_46FoobarCD"))
 }
 
-if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) {
+if #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) {
   Runtime.test("demangleTruncate") {
     // Swift.Int requires 10 bytes to be fully demangled.
     let buffer = UnsafeMutableBufferPointer<Int8>.allocate(capacity: 10)


### PR DESCRIPTION
The fix for this issue didn't ship in 10.15, so testing it there just causes a build failure.

rdar://87181765
