### PR TITLE
[stdlib] _modify: Ensure cleanup is always executed

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -751,8 +751,8 @@ extension Array: RandomAccessCollection, MutableCollection {
       _makeMutableAndUnique() // makes the array native, too
       _checkSubscript_mutating(index)
       let address = _buffer.mutableFirstElementAddress + index
+      defer { _endMutation() }
       yield &address.pointee
-      _endMutation();
     }
   }
 

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -546,8 +546,8 @@ extension ArraySlice: RandomAccessCollection, MutableCollection {
       _makeMutableAndUnique() // makes the array native, too
       _checkSubscript_native(index)
       let address = _buffer.subscriptBaseAddress + index
+      defer { _endMutation() }
       yield &address.pointee
-      _endMutation();
     }
   }
 

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -409,8 +409,8 @@ extension ContiguousArray: RandomAccessCollection, MutableCollection {
       _makeMutableAndUnique()
       _checkSubscript_mutating(index)
       let address = _buffer.mutableFirstElementAddress + index
+      defer { _endMutation() }
       yield &address.pointee
-      _endMutation();
     }
   }
 


### PR DESCRIPTION
Cleanup code in _modify accessors will only run reliably if it is put in a defer statement.

(Statements that follow the `yield` aren’t executed if the yielded-to code throws an error.)
