### PR TITLE
Rely on macOS deployment target set by compiler-rt for sanitizers

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -735,7 +735,6 @@ function set_build_options_for_host() {
                 -DCOMPILER_RT_ENABLE_IOS:BOOL=FALSE
                 -DCOMPILER_RT_ENABLE_WATCHOS:BOOL=FALSE
                 -DCOMPILER_RT_ENABLE_TVOS:BOOL=FALSE
-                -DSANITIZER_MIN_OSX_VERSION="${cmake_osx_deployment_target}"
                 -DLLVM_ENABLE_MODULES:BOOL="$(true_false ${LLVM_ENABLE_MODULES})"
                 -DCMAKE_OSX_ARCHITECTURES="${architecture}"
             )


### PR DESCRIPTION
Using newer targets can lead to build failures, see

https://github.com/llvm/llvm-project/commit/41c52889b90ded563e1aa56cfa7764e083323b00 https://github.com/llvm/llvm-project/commit/b87fc09dceeff9cb838884961d817c0ab0257176

This has no effect currently, it is meant to support the switch to `LLVM_ENABLE_RUNTIMES` to build compiler-rt -- #58465

Addresses rdar://99140817