### PR TITLE
[Test] Remove nonexistent library from target-run command.

### DIFF
--- a/validation-test/Runtime/old_runtime_crash_without_fixed_layout.swift
+++ b/validation-test/Runtime/old_runtime_crash_without_fixed_layout.swift
@@ -6,7 +6,7 @@
 // RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -o %t/main %target-rpath(%t) -target %target-stable-abi-triple
 // RUN: %target-codesign %t/main
 
-// RUN: %target-run %t/main %t/%target-library-name(resilient_struct) %t/libresilient_class%{target-shared-library-suffix}
+// RUN: %target-run %t/main %t/%target-library-name(resilient_struct)
 
 
 // REQUIRES: executable_test


### PR DESCRIPTION
This caused tests to fail if they were running remotely, but not locally.

rdar://99627836
