### PR TITLE
[interop][SwiftToCxx] reimplement function lowering to correctly dist…

### DIFF
--- a/include/swift/IRGen/IRABIDetailsProvider.h
+++ b/include/swift/IRGen/IRABIDetailsProvider.h
@@ -62,7 +62,7 @@ public:
   public:
     enum class ABIParameterRole {
       /// The Swift error parameter.
-      Error
+      None
     };
 
     inline ABIParameterRole getRole() const { return role; }
@@ -182,6 +182,9 @@ public:
     /// Represents a context parameter passed to the call.
     class ContextParameter {};
 
+    /// Represents an out error parameter passed indirectly to the call.
+    class ErrorResultValue {};
+
     /// Returns lowered direct result details, or \c None if direct result is
     /// void.
     llvm::Optional<DirectResultType> getDirectResultType() const;
@@ -204,7 +207,8 @@ public:
             genericRequirementVisitor,
         llvm::function_ref<void(const MetadataSourceParameter &)>
             metadataSourceVisitor,
-        llvm::function_ref<void(const ContextParameter &)> contextParamVisitor);
+        llvm::function_ref<void(const ContextParameter &)> contextParamVisitor,
+        llvm::function_ref<void(const ErrorResultValue &)> errorResultVisitor);
 
     /// FIXME: make private.
     SmallVector<ABIAdditionalParam, 1> additionalParams;

--- a/include/swift/IRGen/IRABIDetailsProvider.h
+++ b/include/swift/IRGen/IRABIDetailsProvider.h
@@ -43,6 +43,146 @@ class TypeInfo;
 
 } // namespace irgen
 
+/// Describes the lowered Swift function signature.
+class LoweredFunctionSignature {
+public:
+  class DirectResultType {
+  public:
+    /// Enumerates all of the members of the underlying record in terms of
+    /// their primitive types that needs to be stored in a Clang/LLVM record
+    /// when this type is passed or returned directly to/from swiftcc
+    /// function.
+    ///
+    /// Returns true if an error occurred when a particular member can't be
+    /// represented with an AST type.
+    bool enumerateRecordMembers(
+        llvm::function_ref<void(clang::CharUnits, clang::CharUnits, Type)>
+            callback) const;
+
+  private:
+    DirectResultType(IRABIDetailsProviderImpl &owner,
+                     const irgen::TypeInfo &typeDetails);
+    IRABIDetailsProviderImpl &owner;
+    const irgen::TypeInfo &typeDetails;
+    friend class LoweredFunctionSignature;
+  };
+
+  /// Represents a result value returned indirectly out of a function.
+  class IndirectResultValue {
+  public:
+    /// Returns true if this indirect result type uses the `sret` LLVM
+    /// attribute.
+    inline bool hasSRet() const { return hasSRet_; }
+
+  private:
+    inline IndirectResultValue(bool hasSRet_) : hasSRet_(hasSRet_) {}
+    bool hasSRet_;
+    friend class LoweredFunctionSignature;
+  };
+
+  /// Represents a parameter passed directly to the function.
+  class DirectParameter {
+  public:
+    /// Enumerates all of the members of the underlying record in terms of
+    /// their primitive types that needs to be stored in a Clang/LLVM record
+    /// when this type is passed or returned directly to/from swiftcc
+    /// function.
+    ///
+    /// Returns true if an error occurred when a particular member can't be
+    /// represented with an AST type.
+    bool enumerateRecordMembers(
+        llvm::function_ref<void(clang::CharUnits, clang::CharUnits, Type)>
+            callback) const;
+
+    inline const ParamDecl &getParamDecl() const { return paramDecl; }
+
+  private:
+    DirectParameter(IRABIDetailsProviderImpl &owner,
+                    const irgen::TypeInfo &typeDetails,
+                    const ParamDecl &paramDecl);
+    IRABIDetailsProviderImpl &owner;
+    const irgen::TypeInfo &typeDetails;
+    const ParamDecl &paramDecl;
+    friend class LoweredFunctionSignature;
+  };
+
+  /// Represents a parameter passed indirectly to the function.
+  class IndirectParameter {
+  public:
+    inline const ParamDecl &getParamDecl() const { return paramDecl; }
+
+  private:
+    IndirectParameter(const ParamDecl &paramDecl);
+    const ParamDecl &paramDecl;
+    friend class LoweredFunctionSignature;
+  };
+
+  /// Represents a generic requirement paremeter that must be passed to the
+  /// function.
+  class GenericRequirementParameter {
+  public:
+    inline GenericRequirement getRequirement() const { return requirement; }
+
+  private:
+    GenericRequirementParameter(const GenericRequirement &requirement);
+    GenericRequirement requirement;
+    friend class LoweredFunctionSignature;
+  };
+
+  /// Represents a parameter which is a Swift type pointer sourced from a
+  /// valid metadata source, like the type of another argument.
+  class MetadataSourceParameter {
+  public:
+    inline CanType getType() const { return type; }
+
+  private:
+    MetadataSourceParameter(const CanType &type);
+    CanType type;
+    friend class LoweredFunctionSignature;
+  };
+
+  /// Represents a context parameter passed to the call.
+  class ContextParameter {};
+
+  /// Represents an out error parameter passed indirectly to the call.
+  class ErrorResultValue {};
+
+  /// Returns lowered direct result details, or \c None if direct result is
+  /// void.
+  llvm::Optional<DirectResultType> getDirectResultType() const;
+
+  /// Returns the number of indirect result values in this function signature.
+  size_t getNumIndirectResultValues() const;
+
+  /// Traverse the entire parameter list of the function signature.
+  ///
+  /// The parameter list can include actual Swift function parameters, result
+  /// values returned indirectly, and additional values, like generic
+  /// requirements for polymorphic calls and the error parameter as well.
+  void visitParameterList(
+      llvm::function_ref<void(const IndirectResultValue &)>
+          indirectResultVisitor,
+      llvm::function_ref<void(const DirectParameter &)> directParamVisitor,
+      llvm::function_ref<void(const IndirectParameter &)> indirectParamVisitor,
+      llvm::function_ref<void(const GenericRequirementParameter &)>
+          genericRequirementVisitor,
+      llvm::function_ref<void(const MetadataSourceParameter &)>
+          metadataSourceVisitor,
+      llvm::function_ref<void(const ContextParameter &)> contextParamVisitor,
+      llvm::function_ref<void(const ErrorResultValue &)> errorResultVisitor)
+      const;
+
+private:
+  LoweredFunctionSignature(
+      const AbstractFunctionDecl *FD, IRABIDetailsProviderImpl &owner,
+      const irgen::SignatureExpansionABIDetails &abiDetails);
+  const AbstractFunctionDecl *FD;
+  IRABIDetailsProviderImpl &owner;
+  const irgen::SignatureExpansionABIDetails &abiDetails;
+  SmallVector<CanType, 1> metadataSourceTypes;
+  friend class IRABIDetailsProviderImpl;
+};
+
 /// Provides access to the IRGen-based queries that can be performed on
 /// declarations to get their various ABI details.
 class IRABIDetailsProvider {
@@ -57,204 +197,15 @@ public:
     SizeType alignment;
   };
 
-  /// Information about any ABI additional parameters.
-  class ABIAdditionalParam {
-  public:
-    enum class ABIParameterRole {
-      /// The Swift error parameter.
-      None
-    };
-
-    inline ABIParameterRole getRole() const { return role; }
-
-  private:
-    inline ABIAdditionalParam(
-        ABIParameterRole role,
-        llvm::Optional<GenericRequirement> genericRequirement, CanType canType)
-        : role(role), genericRequirement(genericRequirement), canType(canType) {
-    }
-
-    ABIParameterRole role;
-    llvm::Optional<GenericRequirement> genericRequirement;
-    CanType canType;
-
-    friend class IRABIDetailsProviderImpl;
-  };
-
-  /// Describes the lowered Swift function signature.
-  class LoweredFunctionSignature {
-  public:
-    class DirectResultType {
-    public:
-      /// Enumerates all of the members of the underlying record in terms of
-      /// their primitive types that needs to be stored in a Clang/LLVM record
-      /// when this type is passed or returned directly to/from swiftcc
-      /// function.
-      ///
-      /// Returns true if an error occurred when a particular member can't be
-      /// represented with an AST type.
-      bool enumerateRecordMembers(
-          llvm::function_ref<void(clang::CharUnits, clang::CharUnits, Type)>
-              callback) const;
-
-    private:
-      DirectResultType(IRABIDetailsProviderImpl &owner,
-                       const irgen::TypeInfo &typeDetails);
-      IRABIDetailsProviderImpl &owner;
-      const irgen::TypeInfo &typeDetails;
-      friend class LoweredFunctionSignature;
-    };
-
-    /// Represents a result value returned indirectly out of a function.
-    class IndirectResultValue {
-    public:
-      /// Returns true if this indirect result type uses the `sret` LLVM
-      /// attribute.
-      inline bool hasSRet() const { return hasSRet_; }
-
-    private:
-      inline IndirectResultValue(bool hasSRet_) : hasSRet_(hasSRet_) {}
-      bool hasSRet_;
-      friend class LoweredFunctionSignature;
-    };
-
-    /// Represents a parameter passed directly to the function.
-    class DirectParameter {
-    public:
-      /// Enumerates all of the members of the underlying record in terms of
-      /// their primitive types that needs to be stored in a Clang/LLVM record
-      /// when this type is passed or returned directly to/from swiftcc
-      /// function.
-      ///
-      /// Returns true if an error occurred when a particular member can't be
-      /// represented with an AST type.
-      bool enumerateRecordMembers(
-          llvm::function_ref<void(clang::CharUnits, clang::CharUnits, Type)>
-              callback) const;
-
-      inline const ParamDecl &getParamDecl() const { return paramDecl; }
-
-    private:
-      DirectParameter(IRABIDetailsProviderImpl &owner,
-                      const irgen::TypeInfo &typeDetails,
-                      const ParamDecl &paramDecl);
-      IRABIDetailsProviderImpl &owner;
-      const irgen::TypeInfo &typeDetails;
-      const ParamDecl &paramDecl;
-      friend class LoweredFunctionSignature;
-    };
-
-    /// Represents a parameter passed indirectly to the function.
-    class IndirectParameter {
-    public:
-      inline const ParamDecl &getParamDecl() const { return paramDecl; }
-
-    private:
-      IndirectParameter(const ParamDecl &paramDecl);
-      const ParamDecl &paramDecl;
-      friend class LoweredFunctionSignature;
-    };
-
-    /// Represents a generic requirement paremeter that must be passed to the
-    /// function.
-    class GenericRequirementParameter {
-    public:
-      inline GenericRequirement getRequirement() const { return requirement; }
-
-    private:
-      GenericRequirementParameter(const GenericRequirement &requirement);
-      GenericRequirement requirement;
-      friend class LoweredFunctionSignature;
-    };
-
-    /// Represents a parameter which is a Swift type pointer sourced from a
-    /// valid metadata source, like the type of another argument.
-    class MetadataSourceParameter {
-    public:
-      inline CanType getType() const { return type; }
-
-    private:
-      MetadataSourceParameter(const CanType &type);
-      CanType type;
-      friend class LoweredFunctionSignature;
-    };
-
-    /// Represents a context parameter passed to the call.
-    class ContextParameter {};
-
-    /// Represents an out error parameter passed indirectly to the call.
-    class ErrorResultValue {};
-
-    /// Returns lowered direct result details, or \c None if direct result is
-    /// void.
-    llvm::Optional<DirectResultType> getDirectResultType() const;
-
-    /// Returns the number of indirect result values in this function signature.
-    size_t getNumIndirectResultValues() const;
-
-    /// Traverse the entire parameter list of the function signature.
-    ///
-    /// The parameter list can include actual Swift function parameters, result
-    /// values returned indirectly, and additional values, like generic
-    /// requirements for polymorphic calls and the error parameter as well.
-    void visitParameterList(
-        llvm::function_ref<void(const IndirectResultValue &)>
-            indirectResultVisitor,
-        llvm::function_ref<void(const DirectParameter &)> directParamVisitor,
-        llvm::function_ref<void(const IndirectParameter &)>
-            indirectParamVisitor,
-        llvm::function_ref<void(const GenericRequirementParameter &)>
-            genericRequirementVisitor,
-        llvm::function_ref<void(const MetadataSourceParameter &)>
-            metadataSourceVisitor,
-        llvm::function_ref<void(const ContextParameter &)> contextParamVisitor,
-        llvm::function_ref<void(const ErrorResultValue &)> errorResultVisitor);
-
-    /// FIXME: make private.
-    SmallVector<ABIAdditionalParam, 1> additionalParams;
-
-  private:
-    LoweredFunctionSignature(
-        const AbstractFunctionDecl *FD, IRABIDetailsProviderImpl &owner,
-        const irgen::SignatureExpansionABIDetails &abiDetails);
-    const AbstractFunctionDecl *FD;
-    IRABIDetailsProviderImpl &owner;
-    const irgen::SignatureExpansionABIDetails &abiDetails;
-    SmallVector<CanType, 1> metadataSourceTypes;
-    friend class IRABIDetailsProviderImpl;
-  };
-
   /// Returns the function signature lowered to its C / LLVM - like
   /// representation, or \c None if such representation could not be computed.
   llvm::Optional<LoweredFunctionSignature>
   getFunctionLoweredSignature(AbstractFunctionDecl *fd);
 
-  /// Returns the additional params if they exist after lowering the function.
-  SmallVector<ABIAdditionalParam, 1>
-  getFunctionABIAdditionalParams(AbstractFunctionDecl *fd);
-
   /// Returns the size and alignment for the given type, or \c None if the type
   /// is not a fixed layout type.
   llvm::Optional<SizeAndAlignment>
   getTypeSizeAlignment(const NominalTypeDecl *TD);
-
-  /// Returns true if the given type should be passed indirectly into a swiftcc
-  /// function.
-  bool shouldPassIndirectly(Type t);
-
-  /// Returns true if the given type should be returned indirectly from a
-  /// swiftcc function.
-  bool shouldReturnIndirectly(Type t);
-
-  /// Enumerates all of the members of the underlying record in terms of their
-  /// primitive types that needs to be stored in a Clang/LLVM record when this
-  /// type is passed or returned directly to/from swiftcc function.
-  ///
-  /// Returns true if an error occurred when a particular member can't be
-  /// represented with an AST type.
-  bool enumerateDirectPassingRecordMembers(
-      Type t, llvm::function_ref<void(clang::CharUnits, clang::CharUnits, Type)>
-                  callback);
 
   /// An representation of a single type, or a C struct with multiple members
   /// with specified types. The C struct is expected to be passed via swiftcc

--- a/include/swift/IRGen/IRABIDetailsProvider.h
+++ b/include/swift/IRGen/IRABIDetailsProvider.h
@@ -123,14 +123,15 @@ public:
       friend class LoweredFunctionSignature;
     };
 
-    class IndirectResultType {
+    /// Represents a result value returned indirectly out of a function.
+    class IndirectResultValue {
     public:
       /// Returns true if this indirect result type uses the `sret` LLVM
       /// attribute.
       inline bool hasSRet() const { return hasSRet_; }
 
     private:
-      inline IndirectResultType(bool hasSRet_) : hasSRet_(hasSRet_) {}
+      inline IndirectResultValue(bool hasSRet_) : hasSRet_(hasSRet_) {}
       bool hasSRet_;
       friend class LoweredFunctionSignature;
     };
@@ -177,10 +178,7 @@ public:
     llvm::Optional<DirectResultType> getDirectResultType() const;
 
     /// Returns the number of indirect result values in this function signature.
-    size_t getNumIndirectResults() const;
-
-    /// Returns lowered indirect result details.
-    llvm::SmallVector<IndirectResultType, 1> getIndirectResultTypes() const;
+    size_t getNumIndirectResultValues() const;
 
     /// Traverse the entire parameter list of the function signature.
     ///
@@ -188,6 +186,8 @@ public:
     /// values returned indirectly, and additional values, like generic
     /// requirements for polymorphic calls and the error parameter as well.
     void visitParameterList(
+        llvm::function_ref<void(const IndirectResultValue &)>
+            indirectResultVisitor,
         llvm::function_ref<void(const DirectParameter &)> directParamVisitor,
         llvm::function_ref<void(const IndirectParameter &)>
             indirectParamVisitor);

--- a/include/swift/IRGen/IRABIDetailsProvider.h
+++ b/include/swift/IRGen/IRABIDetailsProvider.h
@@ -61,8 +61,6 @@ public:
   class ABIAdditionalParam {
   public:
     enum class ABIParameterRole {
-      /// A parameter that corresponds to the 'self' parameter.
-      Self,
       /// The Swift error parameter.
       Error
     };
@@ -181,6 +179,9 @@ public:
       friend class LoweredFunctionSignature;
     };
 
+    /// Represents a context parameter passed to the call.
+    class ContextParameter {};
+
     /// Returns lowered direct result details, or \c None if direct result is
     /// void.
     llvm::Optional<DirectResultType> getDirectResultType() const;
@@ -202,7 +203,8 @@ public:
         llvm::function_ref<void(const GenericRequirementParameter &)>
             genericRequirementVisitor,
         llvm::function_ref<void(const MetadataSourceParameter &)>
-            metadataSourceVisitor);
+            metadataSourceVisitor,
+        llvm::function_ref<void(const ContextParameter &)> contextParamVisitor);
 
     /// FIXME: make private.
     SmallVector<ABIAdditionalParam, 1> additionalParams;

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -1723,6 +1723,8 @@ void SignatureExpansion::expandParameters(
         IGM.getStorageType(getSILFuncConventions().getSILType(
             FnType->getErrorResult(), IGM.getMaximalTypeExpansionContext()));
     ParamIRTypes.push_back(errorType->getPointerTo());
+    if (recordedABIDetails)
+      recordedABIDetails->hasErrorResult = true;
   }
 
   // Witness methods have some extra parameter types.

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -1679,6 +1679,8 @@ void SignatureExpansion::expandParameters(
     if (claimSelf())
       IGM.addSwiftSelfAttributes(Attrs, curLength);
     expand(FnType->getSelfParameter());
+    if (recordedABIDetails)
+      recordedABIDetails->hasTrailingSelfParam = true;
     assert(ParamIRTypes.size() == curLength + 1 &&
            "adding 'self' added unexpected number of parameters");
   } else {
@@ -1706,6 +1708,8 @@ void SignatureExpansion::expandParameters(
       if (claimSelf())
         IGM.addSwiftSelfAttributes(Attrs, ParamIRTypes.size());
       ParamIRTypes.push_back(IGM.RefCountedPtrTy);
+      if (recordedABIDetails)
+        recordedABIDetails->hasContextParam = true;
     }
   }
 

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -1986,6 +1986,7 @@ SignatureExpansionABIDetails Signature::getUncachedABIDetails(
   SignatureExpansion expansion(IGM, formalType, kind);
   SignatureExpansionABIDetails result;
   expansion.expandFunctionType(&result);
+  result.numParamIRTypesInSignature = expansion.ParamIRTypes.size();
   return result;
 }
 

--- a/lib/IRGen/IRABIDetailsProvider.cpp
+++ b/lib/IRGen/IRABIDetailsProvider.cpp
@@ -188,6 +188,35 @@ public:
             result.metadataSourceTypes.push_back(canType);
           });
     }
+    // Verify that the signature param count matches the IR param count.
+    size_t signatureParamCount = 0;
+    result.visitParameterList(
+        [&](const IRABIDetailsProvider::LoweredFunctionSignature::
+                IndirectResultValue &indirectResult) { ++signatureParamCount; },
+        [&](const IRABIDetailsProvider::LoweredFunctionSignature::
+                DirectParameter &param) {
+          param.enumerateRecordMembers([&](clang::CharUnits, clang::CharUnits,
+                                           Type) { ++signatureParamCount; });
+        },
+        [&](const IRABIDetailsProvider::LoweredFunctionSignature::
+                IndirectParameter &param) { ++signatureParamCount; },
+        [&](const IRABIDetailsProvider::LoweredFunctionSignature::
+                GenericRequirementParameter &genericRequirementParam) {
+          ++signatureParamCount;
+        },
+        [&](const IRABIDetailsProvider::LoweredFunctionSignature::
+                MetadataSourceParameter &metadataSrcParam) {
+          ++signatureParamCount;
+        },
+        [&](const IRABIDetailsProvider::LoweredFunctionSignature::
+                ContextParameter &) { ++signatureParamCount; },
+        [&](const IRABIDetailsProvider::LoweredFunctionSignature::
+                ErrorResultValue &) { ++signatureParamCount; });
+    // Return nothing if we were unable to represent the exact signature
+    // parameters.
+    if (signatureParamCount != abiDetails->numParamIRTypesInSignature)
+      return None;
+
     return result;
   }
 

--- a/lib/IRGen/IRABIDetailsProvider.cpp
+++ b/lib/IRGen/IRABIDetailsProvider.cpp
@@ -127,6 +127,7 @@ public:
   llvm::Optional<LoweredFunctionSignature>
   getFunctionLoweredSignature(AbstractFunctionDecl *fd) {
     auto function = SILFunction::getFunction(SILDeclRef(fd), *silMod);
+    IGM.lowerSILFunction(function);
     auto silFuncType = function->getLoweredFunctionType();
     // FIXME: Async function support.
     if (silFuncType->isAsync())

--- a/lib/IRGen/IRABIDetailsProvider.cpp
+++ b/lib/IRGen/IRABIDetailsProvider.cpp
@@ -301,23 +301,19 @@ IRABIDetailsProvider::LoweredFunctionSignature::getDirectResultType() const {
 }
 
 size_t
-IRABIDetailsProvider::LoweredFunctionSignature::getNumIndirectResults() const {
+IRABIDetailsProvider::LoweredFunctionSignature::getNumIndirectResultValues()
+    const {
   return abiDetails.indirectResults.size();
 }
 
-llvm::SmallVector<
-    IRABIDetailsProvider::LoweredFunctionSignature::IndirectResultType, 1>
-IRABIDetailsProvider::LoweredFunctionSignature::getIndirectResultTypes() const {
-  llvm::SmallVector<IndirectResultType, 1> result;
-  for (const auto &r : abiDetails.indirectResults)
-    result.push_back(IndirectResultType(r.hasSRet));
-  return result;
-}
-
 void IRABIDetailsProvider::LoweredFunctionSignature::visitParameterList(
+    llvm::function_ref<void(const IndirectResultValue &)> indirectResultVisitor,
     llvm::function_ref<void(const DirectParameter &)> directParamVisitor,
     llvm::function_ref<void(const IndirectParameter &)> indirectParamVisitor) {
-  // FIXME: Traverse indirect result values.
+  // Indirect result values come before parameters.
+  llvm::SmallVector<IndirectResultValue, 1> result;
+  for (const auto &r : abiDetails.indirectResults)
+    indirectResultVisitor(IndirectResultValue(r.hasSRet));
 
   // Traverse ABI parameters, mapping them back to the AST parameters.
   llvm::SmallVector<const ParamDecl *, 8> silParamMapping;

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1762,6 +1762,11 @@ public:
   /// Emit a resilient class stub.
   llvm::Constant *emitObjCResilientClassStub(ClassDecl *D, bool isPublic);
 
+  /// Runs additional lowering logic on the given SIL function to ensure that
+  /// the SIL function is correctly lowered even if the lowering passes do not
+  /// run on the SIL module that owns this function.
+  void lowerSILFunction(SILFunction *f);
+
 private:
   llvm::Constant *
   getAddrOfSharedContextDescriptor(LinkEntity entity,

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -2909,6 +2909,17 @@ void LoadableByAddress::updateLoweredTypes(SILFunction *F) {
   F->rewriteLoweredTypeUnsafe(newFuncTy);
 }
 
+void IRGenModule::lowerSILFunction(SILFunction *f) {
+  CanSILFunctionType funcType = f->getLoweredFunctionType();
+  GenericEnvironment *genEnv = getSubstGenericEnvironment(f);
+  if (!genEnv && funcType->getSubstGenericSignature()) {
+    genEnv = getSubstGenericEnvironment(funcType);
+  }
+  LargeSILTypeMapper MapperCache;
+  auto newFuncTy = MapperCache.getNewSILFunctionType(genEnv, funcType, *this);
+  f->rewriteLoweredTypeUnsafe(newFuncTy);
+}
+
 bool LoadableByAddress::shouldTransformGlobal(SILGlobalVariable *global) {
   SILInstruction *init = global->getStaticInitializerValue();
   if (!init)

--- a/lib/IRGen/Signature.h
+++ b/lib/IRGen/Signature.h
@@ -161,6 +161,8 @@ public:
   bool hasTrailingSelfParam = false;
   /// True if a context parameter passed to the call.
   bool hasContextParam = false;
+  /// True if an error result value indirect parameter is passed to the call.
+  bool hasErrorResult = false;
 };
 
 /// A signature represents something which can actually be called.

--- a/lib/IRGen/Signature.h
+++ b/lib/IRGen/Signature.h
@@ -157,6 +157,10 @@ public:
   /// Type sources added to the signature during expansion.
   llvm::SmallVector<PolymorphicSignatureExpandedTypeSource, 2>
       polymorphicSignatureExpandedTypeSources;
+  /// True if a trailing self parameter is passed to the call.
+  bool hasTrailingSelfParam = false;
+  /// True if a context parameter passed to the call.
+  bool hasContextParam = false;
 };
 
 /// A signature represents something which can actually be called.

--- a/lib/IRGen/Signature.h
+++ b/lib/IRGen/Signature.h
@@ -163,6 +163,8 @@ public:
   bool hasContextParam = false;
   /// True if an error result value indirect parameter is passed to the call.
   bool hasErrorResult = false;
+  /// The number of LLVM IR parameters in the LLVM IR function signature.
+  size_t numParamIRTypesInSignature = 0;
 };
 
 /// A signature represents something which can actually be called.

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -898,12 +898,14 @@ private:
           owningPrinter.interopContext, owningPrinter);
       if (auto *accessor = dyn_cast<AccessorDecl>(AFD)) {
         declPrinter.printCxxPropertyAccessorMethod(
-            typeDeclContext, accessor, funcABI->getSymbolName(), resultTy,
-            /*isDefinition=*/false, funcABI->additionalParams);
+            typeDeclContext, accessor, funcABI->getSignature(),
+            funcABI->getSymbolName(), resultTy,
+            /*isDefinition=*/false);
       } else {
-        declPrinter.printCxxMethod(
-            typeDeclContext, AFD, funcABI->getSymbolName(), resultTy,
-            /*isDefinition=*/false, funcABI->additionalParams);
+        declPrinter.printCxxMethod(typeDeclContext, AFD,
+                                   funcABI->getSignature(),
+                                   funcABI->getSymbolName(), resultTy,
+                                   /*isDefinition=*/false);
       }
 
       DeclAndTypeClangFunctionPrinter defPrinter(
@@ -914,12 +916,13 @@ private:
       if (auto *accessor = dyn_cast<AccessorDecl>(AFD)) {
 
         defPrinter.printCxxPropertyAccessorMethod(
-            typeDeclContext, accessor, funcABI->getSymbolName(), resultTy,
-            /*isDefinition=*/true, funcABI->additionalParams);
+            typeDeclContext, accessor, funcABI->getSignature(),
+            funcABI->getSymbolName(), resultTy,
+            /*isDefinition=*/true);
       } else {
-        defPrinter.printCxxMethod(
-            typeDeclContext, AFD, funcABI->getSymbolName(), resultTy,
-            /*isDefinition=*/true, funcABI->additionalParams);
+        defPrinter.printCxxMethod(typeDeclContext, AFD, funcABI->getSignature(),
+                                  funcABI->getSymbolName(), resultTy,
+                                  /*isDefinition=*/true);
       }
 
       // FIXME: SWIFT_WARN_UNUSED_RESULT
@@ -1199,8 +1202,10 @@ private:
     os << ";\n";
   }
 
-  struct FuncionSwiftABIInformation {
-    FuncionSwiftABIInformation(AbstractFunctionDecl *FD) {
+  struct FunctionSwiftABIInformation {
+    FunctionSwiftABIInformation(AbstractFunctionDecl *FD,
+                                LoweredFunctionSignature signature)
+        : signature(signature) {
       isCDecl = FD->getAttrs().hasAttribute<CDeclAttr>();
       if (!isCDecl) {
         auto mangledName = SILDeclRef(FD).mangle();
@@ -1216,26 +1221,16 @@ private:
 
     bool useMangledSymbolName() const { return !isCDecl; }
 
-    SmallVector<DeclAndTypeClangFunctionPrinter::AdditionalParam, 2>
-        additionalParams;
+    const LoweredFunctionSignature &getSignature() const { return signature; }
 
   private:
     bool isCDecl;
     StringRef symbolName;
+    LoweredFunctionSignature signature;
   };
 
-  // Converts the array of ABIAdditionalParam into an array of AdditionalParam
-  void convertABIAdditionalParams(
-      AbstractFunctionDecl *FD,
-      llvm::SmallVector<IRABIDetailsProvider::ABIAdditionalParam, 1> ABIparams,
-      llvm::SmallVector<DeclAndTypeClangFunctionPrinter::AdditionalParam, 2>
-          &params,
-      Optional<NominalTypeDecl *> selfTypeDeclContext = None) {
-    // FIXME: remove.
-  }
-
   // Print out the extern C Swift ABI function signature.
-  Optional<FuncionSwiftABIInformation>
+  Optional<FunctionSwiftABIInformation>
   printSwiftABIFunctionSignatureAsCxxFunction(
       AbstractFunctionDecl *FD, Optional<FunctionType *> givenFuncType = None,
       Optional<NominalTypeDecl *> selfTypeDeclContext = None) {
@@ -1259,23 +1254,22 @@ private:
     std::string cRepresentationString;
     llvm::raw_string_ostream cRepresentationOS(cRepresentationString);
 
-    FuncionSwiftABIInformation funcABI(FD);
+    auto signature = owningPrinter.interopContext.getIrABIDetails()
+                         .getFunctionLoweredSignature(FD);
+    // FIXME: Add a note saying that this func is unsupported.
+    if (!signature)
+      return None;
+    FunctionSwiftABIInformation funcABI(FD, *signature);
 
     cRepresentationOS << "SWIFT_EXTERN ";
 
     DeclAndTypeClangFunctionPrinter funcPrinter(
         cRepresentationOS, owningPrinter.prologueOS, owningPrinter.typeMapping,
         owningPrinter.interopContext, owningPrinter);
-    auto ABIparams = owningPrinter.interopContext.getIrABIDetails()
-                         .getFunctionABIAdditionalParams(FD);
-    if (!ABIparams.empty())
-      convertABIAdditionalParams(FD, ABIparams, funcABI.additionalParams,
-                                 /*selfContext=*/selfTypeDeclContext);
 
     auto representation = funcPrinter.printFunctionSignature(
-        FD, funcABI.getSymbolName(), resultTy,
-        DeclAndTypeClangFunctionPrinter::FunctionSignatureKind::CFunctionProto,
-        funcABI.additionalParams);
+        FD, funcABI.getSignature(), funcABI.getSymbolName(), resultTy,
+        DeclAndTypeClangFunctionPrinter::FunctionSignatureKind::CFunctionProto);
     if (representation.isUnsupported()) {
       // FIXME: Emit remark about unemitted declaration.
       return None;
@@ -1304,7 +1298,7 @@ private:
   // Print out the C++ inline function thunk that
   // represents the Swift function in C++.
   void printAbstractFunctionAsCxxFunctionThunk(
-      FuncDecl *FD, const FuncionSwiftABIInformation &funcABI) {
+      FuncDecl *FD, const FunctionSwiftABIInformation &funcABI) {
     assert(outputLang == OutputLanguageMode::Cxx);
     printDocumentationComment(FD);
 
@@ -1322,9 +1316,10 @@ private:
     DeclAndTypeClangFunctionPrinter::FunctionSignatureModifiers modifiers;
     modifiers.isInline = true;
     auto result = funcPrinter.printFunctionSignature(
-        FD, cxx_translation::getNameForCxx(FD), resultTy,
+        FD, funcABI.getSignature(), cxx_translation::getNameForCxx(FD),
+        resultTy,
         DeclAndTypeClangFunctionPrinter::FunctionSignatureKind::CxxInlineThunk,
-        {}, modifiers);
+        modifiers);
     assert(
         !result.isUnsupported()); // The C signature should be unsupported too.
     // FIXME: Support throwing exceptions for Swift errors.
@@ -1333,10 +1328,10 @@ private:
     printFunctionClangAttributes(FD, funcTy);
     printAvailability(FD);
     os << " {\n";
-    funcPrinter.printCxxThunkBody(FD, funcABI.getSymbolName(),
-                                  FD->getModuleContext(), resultTy,
-                                  FD->getParameters(), funcABI.additionalParams,
-                                  funcTy->isThrowing(), funcTy);
+    funcPrinter.printCxxThunkBody(
+        FD, funcABI.getSignature(), funcABI.getSymbolName(),
+        FD->getModuleContext(), resultTy, FD->getParameters(),
+        funcTy->isThrowing(), funcTy);
     os << "}\n";
   }
 

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1231,16 +1231,7 @@ private:
       llvm::SmallVector<DeclAndTypeClangFunctionPrinter::AdditionalParam, 2>
           &params,
       Optional<NominalTypeDecl *> selfTypeDeclContext = None) {
-    for (auto param : ABIparams) {
-      using Role = IRABIDetailsProvider::ABIAdditionalParam::ABIParameterRole;
-      switch (param.getRole()) {
-      case Role::Error:
-        params.push_back(
-            {DeclAndTypeClangFunctionPrinter::AdditionalParam::Role::Error,
-             FD->getASTContext().getOpaquePointerType()});
-        break;
-      }
-    }
+    // FIXME: remove.
   }
 
   // Print out the extern C Swift ABI function signature.

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1234,15 +1234,6 @@ private:
     for (auto param : ABIparams) {
       using Role = IRABIDetailsProvider::ABIAdditionalParam::ABIParameterRole;
       switch (param.getRole()) {
-      case Role::Self:
-        params.push_back(
-            {DeclAndTypeClangFunctionPrinter::AdditionalParam::Role::Self,
-             selfTypeDeclContext
-                 ? (*selfTypeDeclContext)->getDeclaredInterfaceType()
-                 : FD->getASTContext().getOpaquePointerType(),
-             /*isIndirect=*/
-             isa<FuncDecl>(FD) ? cast<FuncDecl>(FD)->isMutating() : false});
-        break;
       case Role::Error:
         params.push_back(
             {DeclAndTypeClangFunctionPrinter::AdditionalParam::Role::Error,

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1234,18 +1234,6 @@ private:
     for (auto param : ABIparams) {
       using Role = IRABIDetailsProvider::ABIAdditionalParam::ABIParameterRole;
       switch (param.getRole()) {
-      case Role::GenericRequirement:
-        params.push_back({DeclAndTypeClangFunctionPrinter::AdditionalParam::
-                              Role::GenericRequirement,
-                          FD->getASTContext().getOpaquePointerType(),
-                          /*isIndirect=*/false, param.getGenericRequirement()});
-        break;
-      case Role::GenericTypeMetadataSource:
-        params.push_back({DeclAndTypeClangFunctionPrinter::AdditionalParam::
-                              Role::GenericTypeMetadata,
-                          param.getMetadataSourceType(), /*isIndirect=*/false,
-                          None});
-        break;
       case Role::Self:
         params.push_back(
             {DeclAndTypeClangFunctionPrinter::AdditionalParam::Role::Self,

--- a/lib/PrintAsClang/PrintClangFunction.h
+++ b/lib/PrintAsClang/PrintClangFunction.h
@@ -79,7 +79,7 @@ public:
 
   /// Information about any additional parameters.
   struct AdditionalParam {
-    enum class Role { Self, Error };
+    enum class Role { Error };
 
     Role role;
     Type type;

--- a/lib/PrintAsClang/PrintClangFunction.h
+++ b/lib/PrintAsClang/PrintClangFunction.h
@@ -32,6 +32,7 @@ class AnyFunctionType;
 class FuncDecl;
 class ModuleDecl;
 class NominalTypeDecl;
+class LoweredFunctionSignature;
 class ParamDecl;
 class ParameterList;
 class PrimitiveTypeMapping;
@@ -77,17 +78,6 @@ public:
     CxxInlineThunk
   };
 
-  /// Information about any additional parameters.
-  struct AdditionalParam {
-    enum class Role { Error };
-
-    Role role;
-    Type type;
-    // Should self be passed indirectly?
-    bool isIndirect = false;
-    llvm::Optional<GenericRequirement> genericRequirement = None;
-  };
-
   /// Optional modifiers that can be applied to function signature.
   struct FunctionSignatureModifiers {
     /// Additional qualifier to add before the function's name.
@@ -104,34 +94,34 @@ public:
   ///
   /// \return value describing in which Clang language mode the function is
   /// supported, if any.
-  ClangRepresentation
-  printFunctionSignature(const AbstractFunctionDecl *FD, StringRef name,
-                         Type resultTy, FunctionSignatureKind kind,
-                         ArrayRef<AdditionalParam> additionalParams = {},
-                         FunctionSignatureModifiers modifiers = {});
+  ClangRepresentation printFunctionSignature(
+      const AbstractFunctionDecl *FD, const LoweredFunctionSignature &signature,
+      StringRef name, Type resultTy, FunctionSignatureKind kind,
+      FunctionSignatureModifiers modifiers = {});
 
   /// Print the body of the inline C++ function thunk that calls the underlying
   /// Swift function.
   void printCxxThunkBody(const AbstractFunctionDecl *FD,
+                         const LoweredFunctionSignature &signature,
                          StringRef swiftSymbolName,
                          const ModuleDecl *moduleContext, Type resultTy,
-                         const ParameterList *params,
-                         ArrayRef<AdditionalParam> additionalParams = {},
-                         bool hasThrows = false,
+                         const ParameterList *params, bool hasThrows = false,
                          const AnyFunctionType *funcType = nullptr);
 
   /// Print the Swift method as C++ method declaration/definition, including
   /// constructors.
   void printCxxMethod(const NominalTypeDecl *typeDeclContext,
-                      const AbstractFunctionDecl *FD, StringRef swiftSymbolName,
-                      Type resultTy, bool isDefinition,
-                      ArrayRef<AdditionalParam> additionalParams);
+                      const AbstractFunctionDecl *FD,
+                      const LoweredFunctionSignature &signature,
+                      StringRef swiftSymbolName, Type resultTy,
+                      bool isDefinition);
 
   /// Print the C++ getter/setter method signature.
-  void printCxxPropertyAccessorMethod(
-      const NominalTypeDecl *typeDeclContext, const AccessorDecl *accessor,
-      StringRef swiftSymbolName, Type resultTy, bool isDefinition,
-      ArrayRef<AdditionalParam> additionalParams);
+  void printCxxPropertyAccessorMethod(const NominalTypeDecl *typeDeclContext,
+                                      const AccessorDecl *accessor,
+                                      const LoweredFunctionSignature &signature,
+                                      StringRef swiftSymbolName, Type resultTy,
+                                      bool isDefinition);
 
   /// Print Swift type as C/C++ type, as the return type of a C/C++ function.
   ClangRepresentation

--- a/lib/PrintAsClang/PrintClangFunction.h
+++ b/lib/PrintAsClang/PrintClangFunction.h
@@ -79,7 +79,7 @@ public:
 
   /// Information about any additional parameters.
   struct AdditionalParam {
-    enum class Role { GenericRequirement, GenericTypeMetadata, Self, Error };
+    enum class Role { Self, Error };
 
     Role role;
     Type type;

--- a/lib/PrintAsClang/PrintClangFunction.h
+++ b/lib/PrintAsClang/PrintClangFunction.h
@@ -110,13 +110,10 @@ public:
                          ArrayRef<AdditionalParam> additionalParams = {},
                          FunctionSignatureModifiers modifiers = {});
 
-  /// Print the use of the C++ function thunk parameter as it's passed to the C
-  /// function declaration.
-  void printCxxToCFunctionParameterUse(const ParamDecl *param, StringRef name);
-
   /// Print the body of the inline C++ function thunk that calls the underlying
   /// Swift function.
-  void printCxxThunkBody(StringRef swiftSymbolName,
+  void printCxxThunkBody(const AbstractFunctionDecl *FD,
+                         StringRef swiftSymbolName,
                          const ModuleDecl *moduleContext, Type resultTy,
                          const ParameterList *params,
                          ArrayRef<AdditionalParam> additionalParams = {},
@@ -153,10 +150,11 @@ public:
                               raw_ostream &outOfLineOS);
 
 private:
-  void printCxxToCFunctionParameterUse(
-      Type type, StringRef name, const ModuleDecl *moduleContext, bool isInOut,
-      bool isIndirect = false,
-      llvm::Optional<AdditionalParam::Role> paramRole = None);
+  void printCxxToCFunctionParameterUse(Type type, StringRef name,
+                                       const ModuleDecl *moduleContext,
+                                       bool isInOut, bool isIndirect,
+                                       std::string directTypeEncoding,
+                                       bool isSelf);
 
   // Print out the full type specifier that refers to the
   // _impl::_impl_<typename> C++ class for the given Swift type.

--- a/lib/PrintAsClang/PrintClangValueType.h
+++ b/lib/PrintAsClang/PrintClangValueType.h
@@ -33,10 +33,8 @@ class SwiftToClangInteropContext;
 class ClangValueTypePrinter {
 public:
   ClangValueTypePrinter(raw_ostream &os, raw_ostream &cPrologueOS,
-                        PrimitiveTypeMapping &typeMapping,
                         SwiftToClangInteropContext &interopContext)
-      : os(os), cPrologueOS(cPrologueOS), typeMapping(typeMapping),
-        interopContext(interopContext) {}
+      : os(os), cPrologueOS(cPrologueOS), interopContext(interopContext) {}
 
   /// Print the C++ class definition that
   /// corresponds to the given structure or enum declaration.
@@ -46,9 +44,8 @@ public:
   /// Print the use of a C++ struct/enum parameter value as it's passed to the
   /// underlying C function that represents the native Swift function.
   void printParameterCxxToCUseScaffold(
-      bool isIndirect, const NominalTypeDecl *type, ArrayRef<Type> genericArgs,
       const ModuleDecl *moduleContext, llvm::function_ref<void()> typePrinter,
-      llvm::function_ref<void()> cxxParamPrinter, bool isInOut, bool isSelf);
+      llvm::function_ref<void()> cxxParamPrinter, bool isSelf);
 
   enum class TypeUseKind {
     // The name of the C++ class that corresponds to the Swift value type (with
@@ -65,29 +62,14 @@ public:
                                 TypeUseKind typeUse,
                                 const ModuleDecl *moduleContext);
 
-  /// Prints out the C stub name used to pass/return value directly for the
-  /// given value type.
-  ///
-  /// If the C stub isn't declared yet in the emitted header, that declaration
-  /// will be emitted by this function.
-  void printCStubType(Type type, const NominalTypeDecl *typeDecl,
-                      ArrayRef<Type> genericArgs);
-
   /// Print the supporting code  that's required to indirectly return a C++
   /// class that represents a Swift value type as it's being indirectly passed
   /// from the C function that represents the native Swift function.
-  void printValueTypeIndirectReturnScaffold(
-      const NominalTypeDecl *typeDecl, const ModuleDecl *moduleContext,
-      llvm::function_ref<void()> typePrinter,
-      llvm::function_ref<void(StringRef)> bodyPrinter);
-
-  /// Print the supporting code  that's required to directly return a C++ class
-  /// that represents a Swift value type as it's being returned from the C
-  /// function that represents the native Swift function.
-  void printValueTypeDirectReturnScaffold(
-      const NominalTypeDecl *typeDecl, ArrayRef<Type> genericArgs,
-      const ModuleDecl *moduleContext, llvm::function_ref<void()> typePrinter,
-      llvm::function_ref<void()> bodyPrinter);
+  void
+  printValueTypeReturnScaffold(const NominalTypeDecl *typeDecl,
+                               const ModuleDecl *moduleContext,
+                               llvm::function_ref<void()> typePrinter,
+                               llvm::function_ref<void(StringRef)> bodyPrinter);
 
   /// Print out the C++ type name of the implementation class that provides
   /// hidden access to the private class APIs.
@@ -118,7 +100,6 @@ public:
 private:
   raw_ostream &os;
   raw_ostream &cPrologueOS;
-  PrimitiveTypeMapping &typeMapping;
   SwiftToClangInteropContext &interopContext;
 };
 

--- a/test/Interop/SwiftToC/structs/small-structs-64-bit-pass-return-direct-in-c.swift
+++ b/test/Interop/SwiftToC/structs/small-structs-64-bit-pass-return-direct-in-c.swift
@@ -60,64 +60,78 @@ public func printStructI8AndU32AndI16(_ x: StructI8AndU32AndI16) {
     print("StructI8AndU32AndI16.x = \(x.x), y = \(x.y), z = \(x.z)")
 }
 
-// CHECK:      struct swift_interop_stub_Structs_StructTwoI32 {
+// CHECK:      struct swift_interop_returnStub_Structs_uint64_t_0_8 {
 // CHECK-NEXT:  uint64_t _1;
 // CHECK-NEXT: };
 
-// CHECK:      static inline void swift_interop_returnDirect_Structs_StructTwoI32(char * _Nonnull result, struct swift_interop_stub_Structs_StructTwoI32 value) __attribute__((always_inline)) {
+// CHECK:      static inline void swift_interop_returnDirect_Structs_uint64_t_0_8(char * _Nonnull result, struct swift_interop_returnStub_Structs_uint64_t_0_8 value) __attribute__((always_inline)) {
 // CHECK-NEXT:  memcpy(result + 0, &value._1, 8);
 // CHECK-NEXT: }
 
-// CHECK:      static inline struct swift_interop_stub_Structs_StructTwoI32 swift_interop_passDirect_Structs_StructTwoI32(const char * _Nonnull value) __attribute__((always_inline)) {
-// CHECK-NEXT:  struct swift_interop_stub_Structs_StructTwoI32 result;
+// CHECK:      struct swift_interop_passStub_Structs_uint64_t_0_8 {
+// CHECK-NEXT:  uint64_t _1;
+// CHECK-NEXT: };
+
+// CHECK:      static inline struct swift_interop_passStub_Structs_uint64_t_0_8 swift_interop_passDirect_Structs_uint64_t_0_8(const char * _Nonnull value) __attribute__((always_inline)) {
+// CHECK-NEXT:  struct swift_interop_passStub_Structs_uint64_t_0_8 result;
 // CHECK-NEXT:  memcpy(&result._1, value + 0, 8);
 // CHECK-NEXT:  return result;
 // CHECK-NEXT: }
 
-// CHECK:      SWIFT_EXTERN struct swift_interop_stub_Structs_StructTwoI32 $s7Structs23passThroughStructTwoI32yAA0deF0Vs5Int32V_AdFtF(int32_t i, struct swift_interop_stub_Structs_StructTwoI32 x, int32_t j) SWIFT_NOEXCEPT SWIFT_CALL;
+// CHECK:      SWIFT_EXTERN struct swift_interop_returnStub_Structs_uint64_t_0_8 $s7Structs23passThroughStructTwoI32yAA0deF0Vs5Int32V_AdFtF(int32_t i, struct swift_interop_passStub_Structs_uint64_t_0_8 x, int32_t j) SWIFT_NOEXCEPT SWIFT_CALL;
 
-// CHECK:      struct swift_interop_stub_Structs_StructI8AndU32AndI16 {
+// CHECK:      struct swift_interop_passStub_Structs_uint64_t_0_8_uint16_t_8_10 {
 // CHECK-NEXT:  uint64_t _1;
 // CHECK-NEXT:  uint16_t _2;
 // CHECK-NEXT: };
 
-// CHECK:      static inline void swift_interop_returnDirect_Structs_StructI8AndU32AndI16(char * _Nonnull result, struct swift_interop_stub_Structs_StructI8AndU32AndI16 value) __attribute__((always_inline)) {
-// CHECK-NEXT:  memcpy(result + 0, &value._1, 8);
-// CHECK-NEXT:  memcpy(result + 8, &value._2, 2);
-// CHECK-NEXT: }
-
-// CHECK:      static inline struct swift_interop_stub_Structs_StructI8AndU32AndI16 swift_interop_passDirect_Structs_StructI8AndU32AndI16(const char * _Nonnull value) __attribute__((always_inline)) {
-// CHECK-NEXT:  struct swift_interop_stub_Structs_StructI8AndU32AndI16 result;
+// CHECK:      static inline struct swift_interop_passStub_Structs_uint64_t_0_8_uint16_t_8_10 swift_interop_passDirect_Structs_uint64_t_0_8_uint16_t_8_10(const char * _Nonnull value) __attribute__((always_inline)) {
+// CHECK-NEXT:  struct swift_interop_passStub_Structs_uint64_t_0_8_uint16_t_8_10 result;
 // CHECK-NEXT:  memcpy(&result._1, value + 0, 8);
 // CHECK-NEXT:  memcpy(&result._2, value + 8, 2);
 // CHECK-NEXT:  return result;
 // CHECK-NEXT: }
 
-// CHECK:      SWIFT_EXTERN void $s7Structs019printStructI8AndU32E3I16yyAA0cdefeG0VF(struct swift_interop_stub_Structs_StructI8AndU32AndI16 x) SWIFT_NOEXCEPT SWIFT_CALL;
+// CHECK:      SWIFT_EXTERN void $s7Structs019printStructI8AndU32E3I16yyAA0cdefeG0VF(struct swift_interop_passStub_Structs_uint64_t_0_8_uint16_t_8_10 x) SWIFT_NOEXCEPT SWIFT_CALL;
 
-// CHECK:      struct swift_interop_stub_Structs_StructOneI16AndOneStruct {
+// CHECK:      struct swift_interop_passStub_Structs_uint64_t_0_8_uint32_t_8_12 {
 // CHECK-NEXT:  uint64_t _1;
 // CHECK-NEXT:  uint32_t _2;
 // CHECK-NEXT: };
 
-// CHECK:      static inline void swift_interop_returnDirect_Structs_StructOneI16AndOneStruct(char * _Nonnull result, struct swift_interop_stub_Structs_StructOneI16AndOneStruct value) __attribute__((always_inline)) {
-// CHECK-NEXT:  memcpy(result + 0, &value._1, 8);
-// CHECK-NEXT:  memcpy(result + 8, &value._2, 4);
-// CHECK-NEXT: }
-
-// CHECK:      static inline struct swift_interop_stub_Structs_StructOneI16AndOneStruct swift_interop_passDirect_Structs_StructOneI16AndOneStruct(const char * _Nonnull value) __attribute__((always_inline)) {
-// CHECK-NEXT:  struct swift_interop_stub_Structs_StructOneI16AndOneStruct result;
+// CHECK:      static inline struct swift_interop_passStub_Structs_uint64_t_0_8_uint32_t_8_12 swift_interop_passDirect_Structs_uint64_t_0_8_uint32_t_8_12(const char * _Nonnull value) __attribute__((always_inline)) {
+// CHECK-NEXT:  struct swift_interop_passStub_Structs_uint64_t_0_8_uint32_t_8_12 result;
 // CHECK-NEXT:  memcpy(&result._1, value + 0, 8);
 // CHECK-NEXT:  memcpy(&result._2, value + 8, 4);
 // CHECK-NEXT:  return result;
 // CHECK-NEXT: }
 
-// CHECK:      SWIFT_EXTERN void $s7Structs011printStructc20TwoI32_and_OneI16AndgC0yyAA0cdE0V_AA0cghigC0VtF(struct swift_interop_stub_Structs_StructTwoI32 y, struct swift_interop_stub_Structs_StructOneI16AndOneStruct x) SWIFT_NOEXCEPT SWIFT_CALL;
+// CHECK:      SWIFT_EXTERN void $s7Structs011printStructc20TwoI32_and_OneI16AndgC0yyAA0cdE0V_AA0cghigC0VtF(struct swift_interop_passStub_Structs_uint64_t_0_8 y, struct swift_interop_passStub_Structs_uint64_t_0_8_uint32_t_8_12 x) SWIFT_NOEXCEPT SWIFT_CALL;
 
-// CHECK:      SWIFT_EXTERN void $s7Structs17printStructTwoI32yyAA0cdE0VF(struct swift_interop_stub_Structs_StructTwoI32 x) SWIFT_NOEXCEPT SWIFT_CALL;
+// CHECK:      SWIFT_EXTERN void $s7Structs17printStructTwoI32yyAA0cdE0VF(struct swift_interop_passStub_Structs_uint64_t_0_8 x) SWIFT_NOEXCEPT SWIFT_CALL;
 
-// CHECK:      SWIFT_EXTERN struct swift_interop_stub_Structs_StructI8AndU32AndI16 $s7Structs023returnNewStructI8AndU32F3I16AA0defgfH0VyF(void) SWIFT_NOEXCEPT SWIFT_CALL;
+// CHECK: struct swift_interop_returnStub_Structs_uint64_t_0_8_uint16_t_8_10 {
+// CHECK-NEXT:   uint64_t _1;
+// CHECK-NEXT:   uint16_t _2;
+// CHECK-NEXT: };
+// CHECK-EMPTY:
+// CHECK-NEXT: static inline void swift_interop_returnDirect_Structs_uint64_t_0_8_uint16_t_8_10(char * _Nonnull result, struct swift_interop_returnStub_Structs_uint64_t_0_8_uint16_t_8_10 value) __attribute__((always_inline)) {
+// CHECK-NEXT:   memcpy(result + 0, &value._1, 8);
+// CHECK-NEXT:   memcpy(result + 8, &value._2, 2);
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK:      SWIFT_EXTERN struct swift_interop_returnStub_Structs_uint64_t_0_8_uint16_t_8_10 $s7Structs023returnNewStructI8AndU32F3I16AA0defgfH0VyF(void) SWIFT_NOEXCEPT SWIFT_CALL;
 
-// CHECK:      SWIFT_EXTERN struct swift_interop_stub_Structs_StructOneI16AndOneStruct $s7Structs024returnNewStructOneI16AndeD0AA0defgeD0VyF(void) SWIFT_NOEXCEPT SWIFT_CALL;
+// CHECK: struct swift_interop_returnStub_Structs_uint64_t_0_8_uint32_t_8_12 {
+// CHECK-NEXT:   uint64_t _1;
+// CHECK-NEXT:   uint32_t _2;
+// CHECK-NEXT: };
 
-// CHECK:      SWIFT_EXTERN struct swift_interop_stub_Structs_StructTwoI32 $s7Structs21returnNewStructTwoI32yAA0deF0Vs5Int32VF(int32_t x) SWIFT_NOEXCEPT SWIFT_CALL;
+// CHECK: static inline void swift_interop_returnDirect_Structs_uint64_t_0_8_uint32_t_8_12(char * _Nonnull result, struct swift_interop_returnStub_Structs_uint64_t_0_8_uint32_t_8_12 value) __attribute__((always_inline)) {
+// CHECK-NEXT:   memcpy(result + 0, &value._1, 8);
+// CHECK-NEXT:   memcpy(result + 8, &value._2, 4);
+// CHECK-NEXT: }
+
+// CHECK:      SWIFT_EXTERN struct swift_interop_returnStub_Structs_uint64_t_0_8_uint32_t_8_12 $s7Structs024returnNewStructOneI16AndeD0AA0defgeD0VyF(void) SWIFT_NOEXCEPT SWIFT_CALL;
+
+// CHECK:      SWIFT_EXTERN struct swift_interop_returnStub_Structs_uint64_t_0_8 $s7Structs21returnNewStructTwoI32yAA0deF0Vs5Int32VF(int32_t x) SWIFT_NOEXCEPT SWIFT_CALL;

--- a/test/Interop/SwiftToC/structs/small-structs-pass-return-direct-in-c-execution.c
+++ b/test/Interop/SwiftToC/structs/small-structs-pass-return-direct-in-c-execution.c
@@ -12,81 +12,78 @@
 
 // REQUIRES: executable_test
 
+// FIXME: can we also make a generic test?
+// REQUIRES: PTRSIZE=64
+
 #include <assert.h>
 #include "structs.h"
 
 int main() {
   // printStructOneI64(returnNewStructOneI64())
-  struct Structs_StructOneI64 structOneI64;
-  swift_interop_returnDirect_Structs_StructOneI64(&structOneI64, $s7Structs21returnNewStructOneI64AA0deF0VyF());
-  $s7Structs17printStructOneI64yyAA0cdE0VF(swift_interop_passDirect_Structs_StructOneI64(&structOneI64));
+  struct swift_interop_returnStub_Structs_uint64_t_0_8 structOneI64;
+  swift_interop_returnDirect_Structs_uint64_t_0_8(&structOneI64, $s7Structs21returnNewStructOneI64AA0deF0VyF());
+  $s7Structs17printStructOneI64yyAA0cdE0VF(swift_interop_passDirect_Structs_uint64_t_0_8(&structOneI64));
 // CHECK:      StructOneI64.x = 42
-
   // printStructOneI64(passThroughStructOneI64(...))
-  struct Structs_StructOneI64 structOneI64_copy;
-  swift_interop_returnDirect_Structs_StructOneI64(&structOneI64_copy,
-    $s7Structs23passThroughStructOneI64yAA0deF0VADF(
-      swift_interop_passDirect_Structs_StructOneI64(&structOneI64)));
-  $s7Structs17printStructOneI64yyAA0cdE0VF(swift_interop_passDirect_Structs_StructOneI64(&structOneI64_copy));
+  struct swift_interop_returnStub_Structs_uint64_t_0_8 structOneI64_copy;
+  swift_interop_returnDirect_Structs_uint64_t_0_8(&structOneI64_copy,
+    $s7Structs23passThroughStructOneI64yAA0deF0VADF(swift_interop_passDirect_Structs_uint64_t_0_8(&structOneI64)));
+  $s7Structs17printStructOneI64yyAA0cdE0VF(swift_interop_passDirect_Structs_uint64_t_0_8(&structOneI64_copy));
 // CHECK-NEXT: StructOneI64.x = 42
-  $s7Structs17printStructOneI64yyAA0cdE0VF(swift_interop_passDirect_Structs_StructOneI64(&structOneI64));
+  $s7Structs17printStructOneI64yyAA0cdE0VF(swift_interop_passDirect_Structs_uint64_t_0_8(&structOneI64));
 // CHECK-NEXT: StructOneI64.x = 42
-
   // printStructTwoI32(returnNewStructTwoI32(11))
-  struct Structs_StructTwoI32 structTwoI32;
-  swift_interop_returnDirect_Structs_StructTwoI32(&structTwoI32,
+  struct swift_interop_returnStub_Structs_uint64_t_0_8 structTwoI32;
+  swift_interop_returnDirect_Structs_uint64_t_0_8(&structTwoI32,
                                                   $s7Structs21returnNewStructTwoI32yAA0deF0Vs5Int32VF(11));
-  $s7Structs17printStructTwoI32yyAA0cdE0VF(swift_interop_passDirect_Structs_StructTwoI32(&structTwoI32));
+  $s7Structs17printStructTwoI32yyAA0cdE0VF(swift_interop_passDirect_Structs_uint64_t_0_8(&structTwoI32));
 // CHECK-NEXT: StructTwoI32.x = 11, y = 22
-
   // printStructTwoI32(passThroughStructTwoI32(4, ..., 6))
-  struct Structs_StructTwoI32 structTwoI32_copy;
-  swift_interop_returnDirect_Structs_StructTwoI32(&structTwoI32_copy,
-    $s7Structs23passThroughStructTwoI32yAA0deF0Vs5Int32V_AdFtF(4, swift_interop_passDirect_Structs_StructTwoI32(&structTwoI32), 6));
-  $s7Structs17printStructTwoI32yyAA0cdE0VF(swift_interop_passDirect_Structs_StructTwoI32(&structTwoI32_copy));
+  struct swift_interop_returnStub_Structs_uint64_t_0_8 structTwoI32_copy;
+  swift_interop_returnDirect_Structs_uint64_t_0_8(&structTwoI32_copy,
+    $s7Structs23passThroughStructTwoI32yAA0deF0Vs5Int32V_AdFtF(4, swift_interop_passDirect_Structs_uint64_t_0_8(&structTwoI32), 6));
+  $s7Structs17printStructTwoI32yyAA0cdE0VF(swift_interop_passDirect_Structs_uint64_t_0_8(&structTwoI32_copy));
 // CHECK-NEXT: StructTwoI32.x = 15, y = 28
-
   // printStructStructTwoI32_and_OneI16AndOneStruct(... , returnNewStructOneI16AndOneStruct());
-  struct Structs_StructOneI16AndOneStruct structOneI16AndOneStruct;
-  swift_interop_returnDirect_Structs_StructOneI16AndOneStruct(&structOneI16AndOneStruct,
+  struct swift_interop_returnStub_Structs_uint64_t_0_8_uint32_t_8_12 structOneI16AndOneStruct;
+  swift_interop_returnDirect_Structs_uint64_t_0_8_uint32_t_8_12(&structOneI16AndOneStruct,
     $s7Structs024returnNewStructOneI16AndeD0AA0defgeD0VyF());
   $s7Structs011printStructc20TwoI32_and_OneI16AndgC0yyAA0cdE0V_AA0cghigC0VtF(
-    swift_interop_passDirect_Structs_StructTwoI32(&structTwoI32),
-    swift_interop_passDirect_Structs_StructOneI16AndOneStruct(&structOneI16AndOneStruct));
+    swift_interop_passDirect_Structs_uint64_t_0_8(&structTwoI32),
+    swift_interop_passDirect_Structs_uint64_t_0_8_uint32_t_8_12(&structOneI16AndOneStruct));
 // CHECK-NEXT: StructTwoI32.x = 11, y = 22
 // CHECK-NEXT: StructOneI16AndOneStruct.x = 255, y.x = 5, y.y = 72
-
   // let x = returnNewStructU16AndPointer(...)
   // getStructU16AndPointer_x(x)
   // getStructU16AndPointer_y(y)
   char c = 'A';
-  struct Structs_StructU16AndPointer structU16AndPointer;
-  swift_interop_returnDirect_Structs_StructU16AndPointer(&structU16AndPointer,
+  struct swift_interop_returnStub_Structs_uint8_t_0_1_void_ptr_8_16 structU16AndPointer;
+  swift_interop_returnDirect_Structs_uint8_t_0_1_void_ptr_8_16(&structU16AndPointer,
     $s7Structs28returnNewStructU16AndPointeryAA0defG0VSvF(&c));
   assert($s7Structs24getStructU16AndPointer_xys5UInt8VAA0cdeF0VF(
-    swift_interop_passDirect_Structs_StructU16AndPointer(&structU16AndPointer)) == 55);
+    swift_interop_passDirect_Structs_uint8_t_0_1_void_ptr_8_16(&structU16AndPointer)) == 55);
   assert($s7Structs24getStructU16AndPointer_yySvAA0cdeF0VF(
-    swift_interop_passDirect_Structs_StructU16AndPointer(&structU16AndPointer)) == &c);
+    swift_interop_passDirect_Structs_uint8_t_0_1_void_ptr_8_16(&structU16AndPointer)) == &c);
 
   // let x = returnNewStructDoubleAndFloat()
   // getStructDoubleAndFloat_x(x)
   // getStructDoubleAndFloat_y(x)
   double doubleValue = 1.25;
   float floatValue = -5.0f;
-  struct Structs_StructDoubleAndFloat structDoubleAndFloat;
-  swift_interop_returnDirect_Structs_StructDoubleAndFloat(&structDoubleAndFloat,
+  struct swift_interop_returnStub_Structs_double_0_8_float_8_12 structDoubleAndFloat;
+  swift_interop_returnDirect_Structs_double_0_8_float_8_12(&structDoubleAndFloat,
     $s7Structs29returnNewStructDoubleAndFloatyAA0defG0VSf_SdtF(floatValue, doubleValue));
   assert($s7Structs25getStructDoubleAndFloat_xySdAA0cdeF0VF(
-    swift_interop_passDirect_Structs_StructDoubleAndFloat(&structDoubleAndFloat)) == doubleValue);
+    swift_interop_passDirect_Structs_double_0_8_float_8_12(&structDoubleAndFloat)) == doubleValue);
   assert($s7Structs25getStructDoubleAndFloat_yySfAA0cdeF0VF(
-    swift_interop_passDirect_Structs_StructDoubleAndFloat(&structDoubleAndFloat)) == floatValue);
+    swift_interop_passDirect_Structs_double_0_8_float_8_12(&structDoubleAndFloat)) == floatValue);
 
   // printStructI8AndU32AndI16(returnNewStructI8AndU32AndI16())
-  struct Structs_StructI8AndU32AndI16 structI8AndU32AndI16;
-  swift_interop_returnDirect_Structs_StructI8AndU32AndI16(&structI8AndU32AndI16,
+  struct swift_interop_returnStub_Structs_uint64_t_0_8_uint16_t_8_10 structI8AndU32AndI16;
+  swift_interop_returnDirect_Structs_uint64_t_0_8_uint16_t_8_10(&structI8AndU32AndI16,
     $s7Structs023returnNewStructI8AndU32F3I16AA0defgfH0VyF());
   $s7Structs019printStructI8AndU32E3I16yyAA0cdefeG0VF(
-    swift_interop_passDirect_Structs_StructI8AndU32AndI16(&structI8AndU32AndI16));
+    swift_interop_passDirect_Structs_uint64_t_0_8_uint16_t_8_10(&structI8AndU32AndI16));
 // CHECK-NEXT: StructI8AndU32AndI16.x = -100, y = 123456, z = -3456
   return 0;
 }

--- a/test/Interop/SwiftToC/structs/small-structs-pass-return-direct-in-c.swift
+++ b/test/Interop/SwiftToC/structs/small-structs-pass-return-direct-in-c.swift
@@ -54,68 +54,82 @@ public func getStructDoubleAndFloat_x(_ x: StructDoubleAndFloat) -> Double { ret
 
 public func getStructDoubleAndFloat_y(_ x: StructDoubleAndFloat) -> Float { return x.y }
 
-// CHECK:      struct swift_interop_stub_Structs_StructDoubleAndFloat {
+// CHECK:      struct swift_interop_passStub_Structs_double_0_8_float_8_12 {
 // CHECK-NEXT:  double _1;
 // CHECK-NEXT:  float _2;
 // CHECK-NEXT: };
 
-// CHECK:      static inline void swift_interop_returnDirect_Structs_StructDoubleAndFloat(char * _Nonnull result, struct swift_interop_stub_Structs_StructDoubleAndFloat value) __attribute__((always_inline)) {
-// CHECK-NEXT:  memcpy(result + 0, &value._1, 8);
-// CHECK-NEXT:  memcpy(result + 8, &value._2, 4);
-// CHECK-NEXT: }
-
-// CHECK:      static inline struct swift_interop_stub_Structs_StructDoubleAndFloat swift_interop_passDirect_Structs_StructDoubleAndFloat(const char * _Nonnull value) __attribute__((always_inline)) {
-// CHECK-NEXT:  struct swift_interop_stub_Structs_StructDoubleAndFloat result;
+// CHECK:      static inline struct swift_interop_passStub_Structs_double_0_8_float_8_12 swift_interop_passDirect_Structs_double_0_8_float_8_12(const char * _Nonnull value) __attribute__((always_inline)) {
+// CHECK-NEXT:  struct swift_interop_passStub_Structs_double_0_8_float_8_12 result;
 // CHECK-NEXT:  memcpy(&result._1, value + 0, 8);
 // CHECK-NEXT:  memcpy(&result._2, value + 8, 4);
 // CHECK-NEXT:  return result;
 // CHECK-NEXT: }
 
-// CHECK:      SWIFT_EXTERN double $s7Structs25getStructDoubleAndFloat_xySdAA0cdeF0VF(struct swift_interop_stub_Structs_StructDoubleAndFloat x) SWIFT_NOEXCEPT SWIFT_CALL;
+// CHECK:      SWIFT_EXTERN double $s7Structs25getStructDoubleAndFloat_xySdAA0cdeF0VF(struct swift_interop_passStub_Structs_double_0_8_float_8_12 x) SWIFT_NOEXCEPT SWIFT_CALL;
 
-// CHECK:      SWIFT_EXTERN float $s7Structs25getStructDoubleAndFloat_yySfAA0cdeF0VF(struct swift_interop_stub_Structs_StructDoubleAndFloat x) SWIFT_NOEXCEPT SWIFT_CALL;
+// CHECK:      SWIFT_EXTERN float $s7Structs25getStructDoubleAndFloat_yySfAA0cdeF0VF(struct swift_interop_passStub_Structs_double_0_8_float_8_12 x) SWIFT_NOEXCEPT SWIFT_CALL;
 
-// CHECK:      struct swift_interop_stub_Structs_StructU16AndPointer {
+// CHECK:      struct swift_interop_passStub_Structs_[[StructU16AndPointer:uint8_t_0_1_void_ptr_[0-9_]+]] {
 // CHECK-NEXT:  uint8_t _1;
-// CHECK-NEXT:  void * _Null_unspecified _2;
+// CHECK-NEXT:  void * _Nullable _2;
 // CHECK-NEXT: };
 
-// CHECK:      static inline void swift_interop_returnDirect_Structs_StructU16AndPointer(char * _Nonnull result, struct swift_interop_stub_Structs_StructU16AndPointer value) __attribute__((always_inline)) {
-// CHECK-NEXT:  memcpy(result + 0, &value._1, 1);
-// CHECK-NEXT:  memcpy(result + [[PTRSIZE:[48]]], &value._2, [[PTRSIZE]]);
-// CHECK-NEXT: }
-
-// CHECK:      static inline struct swift_interop_stub_Structs_StructU16AndPointer swift_interop_passDirect_Structs_StructU16AndPointer(const char * _Nonnull value) __attribute__((always_inline)) {
-// CHECK-NEXT:  struct swift_interop_stub_Structs_StructU16AndPointer result;
+// CHECK:      static inline struct swift_interop_passStub_Structs_[[StructU16AndPointer]] swift_interop_passDirect_Structs_[[StructU16AndPointer]](const char * _Nonnull value) __attribute__((always_inline)) {
+// CHECK-NEXT:  struct swift_interop_passStub_Structs_[[StructU16AndPointer]] result;
 // CHECK-NEXT:  memcpy(&result._1, value + 0, 1);
-// CHECK-NEXT:  memcpy(&result._2, value + [[PTRSIZE]], [[PTRSIZE]]);
+// CHECK-NEXT:  memcpy(&result._2, value + [[PTRSIZE:[48]]], [[PTRSIZE]]);
 // CHECK-NEXT:  return result;
 // CHECK-NEXT: }
 
-// CHECK:      SWIFT_EXTERN uint8_t $s7Structs24getStructU16AndPointer_xys5UInt8VAA0cdeF0VF(struct swift_interop_stub_Structs_StructU16AndPointer x) SWIFT_NOEXCEPT SWIFT_CALL;
+// CHECK:      SWIFT_EXTERN uint8_t $s7Structs24getStructU16AndPointer_xys5UInt8VAA0cdeF0VF(struct swift_interop_passStub_Structs_[[StructU16AndPointer]] x) SWIFT_NOEXCEPT SWIFT_CALL;
 
-// CHECK:      SWIFT_EXTERN void * _Nonnull $s7Structs24getStructU16AndPointer_yySvAA0cdeF0VF(struct swift_interop_stub_Structs_StructU16AndPointer x) SWIFT_NOEXCEPT SWIFT_CALL;
+// CHECK:      SWIFT_EXTERN void * _Nonnull $s7Structs24getStructU16AndPointer_yySvAA0cdeF0VF(struct swift_interop_passStub_Structs_[[StructU16AndPointer]] x) SWIFT_NOEXCEPT SWIFT_CALL;
 
-// CHECK:      struct swift_interop_stub_Structs_StructOneI64 {
+// CHECK:      struct swift_interop_returnStub_Structs_uint64_t_0_8 {
 // CHECK-NEXT:  uint64_t _1;
 // CHECK-NEXT: };
 
-// CHECK:      static inline void swift_interop_returnDirect_Structs_StructOneI64(char * _Nonnull result, struct swift_interop_stub_Structs_StructOneI64 value) __attribute__((always_inline)) {
+// CHECK:      static inline void swift_interop_returnDirect_Structs_uint64_t_0_8(char * _Nonnull result, struct swift_interop_returnStub_Structs_uint64_t_0_8 value) __attribute__((always_inline)) {
 // CHECK-NEXT:  memcpy(result + 0, &value._1, 8);
 // CHECK-NEXT: }
 
-// CHECK:      static inline struct swift_interop_stub_Structs_StructOneI64 swift_interop_passDirect_Structs_StructOneI64(const char * _Nonnull value) __attribute__((always_inline)) {
-// CHECK-NEXT:  struct swift_interop_stub_Structs_StructOneI64 result;
+// CHECK:      struct swift_interop_passStub_Structs_uint64_t_0_8 {
+// CHECK-NEXT:  uint64_t _1;
+// CHECK-NEXT: };
+
+// CHECK:      static inline struct swift_interop_passStub_Structs_uint64_t_0_8 swift_interop_passDirect_Structs_uint64_t_0_8(const char * _Nonnull value) __attribute__((always_inline)) {
+// CHECK-NEXT:  struct swift_interop_passStub_Structs_uint64_t_0_8 result;
 // CHECK-NEXT:  memcpy(&result._1, value + 0, 8);
 // CHECK-NEXT:  return result;
 // CHECK-NEXT: }
 
-// CHECK:      SWIFT_EXTERN struct swift_interop_stub_Structs_StructOneI64 $s7Structs23passThroughStructOneI64yAA0deF0VADF(struct swift_interop_stub_Structs_StructOneI64 x) SWIFT_NOEXCEPT SWIFT_CALL;
+// CHECK:      SWIFT_EXTERN struct swift_interop_returnStub_Structs_uint64_t_0_8 $s7Structs23passThroughStructOneI64yAA0deF0VADF(struct swift_interop_passStub_Structs_uint64_t_0_8 x) SWIFT_NOEXCEPT SWIFT_CALL;
 
-// CHECK:      SWIFT_EXTERN void $s7Structs17printStructOneI64yyAA0cdE0VF(struct swift_interop_stub_Structs_StructOneI64 x) SWIFT_NOEXCEPT SWIFT_CALL;
+// CHECK:      SWIFT_EXTERN void $s7Structs17printStructOneI64yyAA0cdE0VF(struct swift_interop_passStub_Structs_uint64_t_0_8 x) SWIFT_NOEXCEPT SWIFT_CALL;
 
-// CHECK:      SWIFT_EXTERN struct swift_interop_stub_Structs_StructDoubleAndFloat $s7Structs29returnNewStructDoubleAndFloatyAA0defG0VSf_SdtF(float y, double x) SWIFT_NOEXCEPT SWIFT_CALL;
+// CHECK: struct swift_interop_returnStub_Structs_double_0_8_float_8_12 {
+// CHECK-NEXT:   double _1;
+// CHECK-NEXT:  float _2;
+// CHECK-NEXT: };
 
-// CHECK:      SWIFT_EXTERN struct swift_interop_stub_Structs_StructOneI64 $s7Structs21returnNewStructOneI64AA0deF0VyF(void) SWIFT_NOEXCEPT SWIFT_CALL;
+// CHECK: static inline void swift_interop_returnDirect_Structs_double_0_8_float_8_12(char * _Nonnull result, struct swift_interop_returnStub_Structs_double_0_8_float_8_12 value) __attribute__((always_inline)) {
+// CHECK-NEXT:   memcpy(result + 0, &value._1, 8);
+// CHECK-NEXT:   memcpy(result + 8, &value._2, 4);
+// CHECK-NEXT: }
 
-// CHECK:      SWIFT_EXTERN struct swift_interop_stub_Structs_StructU16AndPointer $s7Structs28returnNewStructU16AndPointeryAA0defG0VSvF(void * _Nonnull x) SWIFT_NOEXCEPT SWIFT_CALL;
+// CHECK:      SWIFT_EXTERN struct swift_interop_returnStub_Structs_double_0_8_float_8_12 $s7Structs29returnNewStructDoubleAndFloatyAA0defG0VSf_SdtF(float y, double x) SWIFT_NOEXCEPT SWIFT_CALL;
+
+// CHECK:      SWIFT_EXTERN struct swift_interop_returnStub_Structs_uint64_t_0_8 $s7Structs21returnNewStructOneI64AA0deF0VyF(void) SWIFT_NOEXCEPT SWIFT_CALL;
+
+// CHECK: struct swift_interop_returnStub_Structs_[[StructU16AndPointer]] {
+// CHECK-NEXT:   uint8_t _1;
+// CHECK-NEXT:   void * _Nullable _2;
+// CHECK-NEXT: };
+
+// CHECK:      static inline void swift_interop_returnDirect_Structs_[[StructU16AndPointer]](char * _Nonnull result, struct swift_interop_returnStub_Structs_[[StructU16AndPointer]] value) __attribute__((always_inline)) {
+// CHECK-NEXT:  memcpy(result + 0, &value._1, 1);
+// CHECK-NEXT:  memcpy(result + [[PTRSIZE]], &value._2, [[PTRSIZE]]);
+// CHECK-NEXT: }
+
+// CHECK:      SWIFT_EXTERN struct swift_interop_returnStub_Structs_[[StructU16AndPointer]] $s7Structs28returnNewStructU16AndPointeryAA0defG0VSvF(void * _Nonnull x) SWIFT_NOEXCEPT SWIFT_CALL;

--- a/test/Interop/SwiftToCxx/cross-module-refs/imported-enum-refs-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/cross-module-refs/imported-enum-refs-in-cxx.swift
@@ -30,12 +30,12 @@ public func inoutLargeEnum(_ s: inout LargeEnum) {
 // CHECK-NEXT: }
 
 // CHECK: inline Enums::LargeEnum UsesEnumsLargeEnum::passThroughStructSeveralI64(const Enums::LargeEnum& y) const {
-// CHECK-NEXT: return Enums::_impl::_impl_LargeEnum::returnNewValue([&](void * _Nonnull result) {
+// CHECK-NEXT: return Enums::_impl::_impl_LargeEnum::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:   _impl::$s9UsesEnums0aB9LargeEnumV27passThroughStructSeveralI64y0B00cD0OAGF(result, Enums::_impl::_impl_LargeEnum::getOpaquePointer(y), _getOpaquePointer());
 // CHECK-NEXT: });
 // CHECK-NEXT: }
 // CHECK-NEXT: inline Enums::LargeEnum UsesEnumsLargeEnum::getX() const {
-// CHECK-NEXT: return Enums::_impl::_impl_LargeEnum::returnNewValue([&](void * _Nonnull result) {
+// CHECK-NEXT: return Enums::_impl::_impl_LargeEnum::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:   _impl::$s9UsesEnums0aB9LargeEnumV1x0B00cD0Ovg(result, _getOpaquePointer());
 // CHECK-NEXT: });
 // CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/cross-module-refs/imported-struct-refs-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/cross-module-refs/imported-struct-refs-in-cxx.swift
@@ -43,25 +43,25 @@ public func passThroughStructSmallDirect(_ x: SmallStructDirectPassing) -> Small
 
 
 // CHECK:      inline Structs::StructSeveralI64 passThroughStructSeveralI64(const Structs::StructSeveralI64& x) noexcept SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:  return Structs::_impl::_impl_StructSeveralI64::returnNewValue([&](void * _Nonnull result) {
+// CHECK-NEXT:  return Structs::_impl::_impl_StructSeveralI64::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:    _impl::$s11UsesStructs27passThroughStructSeveralI64y0B00efG0VAEF(result, Structs::_impl::_impl_StructSeveralI64::getOpaquePointer(x));
 // CHECK-NEXT:  });
 // CHECK-NEXT: }
 
 // CHECK:      inline Structs::SmallStructDirectPassing passThroughStructSmallDirect(const Structs::SmallStructDirectPassing& x) noexcept SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return Structs::_impl::_impl_SmallStructDirectPassing::returnNewValue([&](char * _Nonnull result) {
-// CHECK-NEXT:    _impl::swift_interop_returnDirect_Structs_SmallStructDirectPassing(result, _impl::$s11UsesStructs28passThroughStructSmallDirecty0B00feG7PassingVAEF(_impl::swift_interop_passDirect_Structs_SmallStructDirectPassing(Structs::_impl::_impl_SmallStructDirectPassing::getOpaquePointer(x))));
+// CHECK-NEXT:    _impl::swift_interop_returnDirect_UsesStructs_uint32_t_0_4(result, _impl::$s11UsesStructs28passThroughStructSmallDirecty0B00feG7PassingVAEF(_impl::swift_interop_passDirect_UsesStructs_uint32_t_0_4(Structs::_impl::_impl_SmallStructDirectPassing::getOpaquePointer(x))));
 // CHECK-NEXT:  });
 // CHECK-NEXT: }
 
 // CHECK: inline Structs::StructSeveralI64 UsesStructsStruct::passThroughStructSeveralI64(const Structs::StructSeveralI64& y) const {
-// CHECK-NEXT: return Structs::_impl::_impl_StructSeveralI64::returnNewValue([&](void * _Nonnull result) {
+// CHECK-NEXT: return Structs::_impl::_impl_StructSeveralI64::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:   _impl::$s11UsesStructs0aB6StructV011passThroughC10SeveralI64y0B00cfG0VAGF(result, Structs::_impl::_impl_StructSeveralI64::getOpaquePointer(y), _getOpaquePointer());
 // CHECK-NEXT: });
 // CHECK-NEXT: }
 
 // CHECK: inline Structs::StructSeveralI64 UsesStructsStruct::getX() const {
-// CHECK-NEXT: return Structs::_impl::_impl_StructSeveralI64::returnNewValue([&](void * _Nonnull result) {
+// CHECK-NEXT: return Structs::_impl::_impl_StructSeveralI64::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:   _impl::$s11UsesStructs0aB6StructV1x0B00C10SeveralI64Vvg(result, _getOpaquePointer());
 // CHECK-NEXT: });
 // CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/enums/large-enums-pass-return-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/large-enums-pass-return-in-cxx.swift
@@ -46,13 +46,13 @@ public func inoutLarge(_ en: inout Large, _ x: Int) {
 // CHECK-NEXT: }
 
 // CHECK:      inline Large makeLarge(swift::Int x) noexcept SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::_impl_Large::returnNewValue([&](void * _Nonnull result) {
+// CHECK-NEXT:   return _impl::_impl_Large::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:     _impl::$s5Enums9makeLargeyAA0C0OSiF(result, x);
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
 // CHECK:      inline Large passThroughLarge(const Large& en) noexcept SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::_impl_Large::returnNewValue([&](void * _Nonnull result) {
+// CHECK-NEXT:   return _impl::_impl_Large::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:     _impl::$s5Enums16passThroughLargeyAA0D0OADF(result, _impl::_impl_Large::getOpaquePointer(en));
 // CHECK-NEXT:   });
 // CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/enums/small-enums-generated-stub-64bit.swift
+++ b/test/Interop/SwiftToCxx/enums/small-enums-generated-stub-64bit.swift
@@ -15,18 +15,23 @@ public func passThroughSmall(_ en: Small) -> Small {
     return en
 }
 
-// CHECK:      struct swift_interop_stub_Enums_Small {
+// CHECK:      struct swift_interop_returnStub_Enums_uint64_t_0_8_uint8_t_8_9 {
 // CHECK-NEXT:   uint64_t _1;
 // CHECK-NEXT:   uint8_t _2;
 // CHECK-NEXT: };
 
-// CHECK:      static inline void swift_interop_returnDirect_Enums_Small(char * _Nonnull result, struct swift_interop_stub_Enums_Small value) __attribute__((always_inline)) {
+// CHECK:      static inline void swift_interop_returnDirect_Enums_uint64_t_0_8_uint8_t_8_9(char * _Nonnull result, struct swift_interop_returnStub_Enums_uint64_t_0_8_uint8_t_8_9 value) __attribute__((always_inline)) {
 // CHECK-NEXT:   memcpy(result + 0, &value._1, 8);
 // CHECK-NEXT:   memcpy(result + 8, &value._2, 1);
 // CHECK-NEXT: }
 
-// CHECK:      static inline struct swift_interop_stub_Enums_Small swift_interop_passDirect_Enums_Small(const char * _Nonnull value) __attribute__((always_inline)) {
-// CHECK-NEXT:   struct swift_interop_stub_Enums_Small result;
+// CHECK:      struct swift_interop_passStub_Enums_uint64_t_0_8_uint8_t_8_9 {
+// CHECK-NEXT:   uint64_t _1;
+// CHECK-NEXT:   uint8_t _2;
+// CHECK-NEXT: };
+
+// CHECK:      static inline struct swift_interop_passStub_Enums_uint64_t_0_8_uint8_t_8_9 swift_interop_passDirect_Enums_uint64_t_0_8_uint8_t_8_9(const char * _Nonnull value) __attribute__((always_inline)) {
+// CHECK-NEXT:   struct swift_interop_passStub_Enums_uint64_t_0_8_uint8_t_8_9 result;
 // CHECK-NEXT:   memcpy(&result._1, value + 0, 8);
 // CHECK-NEXT:   memcpy(&result._2, value + 8, 1);
 // CHECK-NEXT:   return result;

--- a/test/Interop/SwiftToCxx/enums/small-enums-pass-return-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/small-enums-pass-return-in-cxx.swift
@@ -64,32 +64,37 @@ public func inoutSmall(_ en: inout Small, _ x: Int) {
     }
 }
 
-// CHECK: SWIFT_EXTERN void $s5Enums10inoutSmallyyAA0C0Oz_SitF(char * _Nonnull en, ptrdiff_t x) SWIFT_NOEXCEPT SWIFT_CALL; // inoutSmall(_:_:)
-// CHECK: SWIFT_EXTERN void $s5Enums9inoutTinyyyAA0C0Oz_SitF(char * _Nonnull en, ptrdiff_t x) SWIFT_NOEXCEPT SWIFT_CALL; // inoutTiny(_:_:)
+// CHECK: SWIFT_EXTERN void $s5Enums10inoutSmallyyAA0C0Oz_SitF(void * _Nonnull en, ptrdiff_t x) SWIFT_NOEXCEPT SWIFT_CALL; // inoutSmall(_:_:)
+// CHECK: SWIFT_EXTERN void $s5Enums9inoutTinyyyAA0C0Oz_SitF(void * _Nonnull en, ptrdiff_t x) SWIFT_NOEXCEPT SWIFT_CALL; // inoutTiny(_:_:)
 
 // The check for generated stub is currently moved to small-enums-generated-stub-64bit.swift
 
-// CHECK: SWIFT_EXTERN struct swift_interop_stub_Enums_Small $s5Enums9makeSmallyAA0C0OSiF(ptrdiff_t x) SWIFT_NOEXCEPT SWIFT_CALL; // makeSmall(_:)
+// CHECK: SWIFT_EXTERN struct swift_interop_returnStub_Enums_[[Small:[0-9a-z_]+]] $s5Enums9makeSmallyAA0C0OSiF(ptrdiff_t x) SWIFT_NOEXCEPT SWIFT_CALL; // makeSmall(_:)
 
-// CHECK:      struct swift_interop_stub_Enums_Tiny {
+// CHECK:      struct swift_interop_returnStub_Enums_uint8_t_0_1 {
 // CHECK-NEXT:   uint8_t _1;
 // CHECK-NEXT: };
 
-// CHECK:      static inline void swift_interop_returnDirect_Enums_Tiny(char * _Nonnull result, struct swift_interop_stub_Enums_Tiny value) __attribute__((always_inline)) {
+// CHECK:      static inline void swift_interop_returnDirect_Enums_uint8_t_0_1(char * _Nonnull result, struct swift_interop_returnStub_Enums_uint8_t_0_1 value) __attribute__((always_inline)) {
 // CHECK-NEXT:   memcpy(result + 0, &value._1, 1);
 // CHECK-NEXT: }
 
-// CHECK:      static inline struct swift_interop_stub_Enums_Tiny swift_interop_passDirect_Enums_Tiny(const char * _Nonnull value) __attribute__((always_inline)) {
-// CHECK-NEXT:   struct swift_interop_stub_Enums_Tiny result;
-// CHECK-NEXT:   memcpy(&result._1, value + 0, 1);
-// CHECK-NEXT:   return result;
+// CHECK: SWIFT_EXTERN struct swift_interop_returnStub_Enums_uint8_t_0_1 $s5Enums8makeTinyyAA0C0OSiF(ptrdiff_t x) SWIFT_NOEXCEPT SWIFT_CALL; // makeTiny(_:)
+// CHECK: SWIFT_EXTERN struct swift_interop_returnStub_Enums_[[Small]] $s5Enums16passThroughSmallyAA0D0OADF(struct swift_interop_passStub_Enums_[[Small]] en) SWIFT_NOEXCEPT SWIFT_CALL; // passThroughSmall(_:)
+
+// CHECK: struct swift_interop_passStub_Enums_uint8_t_0_1 {
+// CHECK-NEXT: uint8_t _1;
+// CHECK-NEXT: };
+
+// CHECK: static inline struct swift_interop_passStub_Enums_uint8_t_0_1 swift_interop_passDirect_Enums_uint8_t_0_1(const char * _Nonnull value) __attribute__((always_inline)) {
+// CHECK-NEXT: struct swift_interop_passStub_Enums_uint8_t_0_1 result;
+// CHECK-NEXT: memcpy(&result._1, value + 0, 1);
+// CHECK-NEXT: return result;
 // CHECK-NEXT: }
 
-// CHECK: SWIFT_EXTERN struct swift_interop_stub_Enums_Tiny $s5Enums8makeTinyyAA0C0OSiF(ptrdiff_t x) SWIFT_NOEXCEPT SWIFT_CALL; // makeTiny(_:)
-// CHECK: SWIFT_EXTERN struct swift_interop_stub_Enums_Small $s5Enums16passThroughSmallyAA0D0OADF(struct swift_interop_stub_Enums_Small en) SWIFT_NOEXCEPT SWIFT_CALL; // passThroughSmall(_:)
-// CHECK: SWIFT_EXTERN struct swift_interop_stub_Enums_Tiny $s5Enums15passThroughTinyyAA0D0OADF(struct swift_interop_stub_Enums_Tiny en) SWIFT_NOEXCEPT SWIFT_CALL; // passThroughTiny(_:)
-// CHECK: SWIFT_EXTERN void $s5Enums10printSmallyyAA0C0OF(struct swift_interop_stub_Enums_Small en) SWIFT_NOEXCEPT SWIFT_CALL; // printSmall(_:)
-// CHECK: SWIFT_EXTERN void $s5Enums9printTinyyyAA0C0OF(struct swift_interop_stub_Enums_Tiny en) SWIFT_NOEXCEPT SWIFT_CALL; // printTiny(_:)
+// CHECK: SWIFT_EXTERN struct swift_interop_returnStub_Enums_uint8_t_0_1 $s5Enums15passThroughTinyyAA0D0OADF(struct swift_interop_passStub_Enums_uint8_t_0_1 en) SWIFT_NOEXCEPT SWIFT_CALL; // passThroughTiny(_:)
+// CHECK: SWIFT_EXTERN void $s5Enums10printSmallyyAA0C0OF(struct swift_interop_passStub_Enums_[[Small]] en) SWIFT_NOEXCEPT SWIFT_CALL; // printSmall(_:)
+// CHECK: SWIFT_EXTERN void $s5Enums9printTinyyyAA0C0OF(struct swift_interop_passStub_Enums_uint8_t_0_1 en) SWIFT_NOEXCEPT SWIFT_CALL; // printTiny(_:)
 // CHECK: class Small final {
 // CHECK: class Tiny final {
 
@@ -103,32 +108,32 @@ public func inoutSmall(_ en: inout Small, _ x: Int) {
 
 // CHECK:      inline Small makeSmall(swift::Int x) noexcept SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::_impl_Small::returnNewValue([&](char * _Nonnull result) {
-// CHECK-NEXT:     _impl::swift_interop_returnDirect_Enums_Small(result, _impl::$s5Enums9makeSmallyAA0C0OSiF(x));
+// CHECK-NEXT:     _impl::swift_interop_returnDirect_Enums_[[Small]](result, _impl::$s5Enums9makeSmallyAA0C0OSiF(x));
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
 // CHECK:      inline Tiny makeTiny(swift::Int x) noexcept SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::_impl_Tiny::returnNewValue([&](char * _Nonnull result) {
-// CHECK-NEXT:     _impl::swift_interop_returnDirect_Enums_Tiny(result, _impl::$s5Enums8makeTinyyAA0C0OSiF(x));
+// CHECK-NEXT:     _impl::swift_interop_returnDirect_Enums_uint8_t_0_1(result, _impl::$s5Enums8makeTinyyAA0C0OSiF(x));
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
 // CHECK:      inline Small passThroughSmall(const Small& en) noexcept SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::_impl_Small::returnNewValue([&](char * _Nonnull result) {
-// CHECK-NEXT:     _impl::swift_interop_returnDirect_Enums_Small(result, _impl::$s5Enums16passThroughSmallyAA0D0OADF(_impl::swift_interop_passDirect_Enums_Small(_impl::_impl_Small::getOpaquePointer(en))));
+// CHECK-NEXT:     _impl::swift_interop_returnDirect_Enums_[[Small]](result, _impl::$s5Enums16passThroughSmallyAA0D0OADF(_impl::swift_interop_passDirect_Enums_[[Small]](_impl::_impl_Small::getOpaquePointer(en))));
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
 // CHECK:      inline Tiny passThroughTiny(const Tiny& en) noexcept SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::_impl_Tiny::returnNewValue([&](char * _Nonnull result) {
-// CHECK-NEXT:     _impl::swift_interop_returnDirect_Enums_Tiny(result, _impl::$s5Enums15passThroughTinyyAA0D0OADF(_impl::swift_interop_passDirect_Enums_Tiny(_impl::_impl_Tiny::getOpaquePointer(en))));
+// CHECK-NEXT:     _impl::swift_interop_returnDirect_Enums_uint8_t_0_1(result, _impl::$s5Enums15passThroughTinyyAA0D0OADF(_impl::swift_interop_passDirect_Enums_uint8_t_0_1(_impl::_impl_Tiny::getOpaquePointer(en))));
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
 // CHECK:      inline void printSmall(const Small& en) noexcept {
-// CHECK-NEXT:   return _impl::$s5Enums10printSmallyyAA0C0OF(_impl::swift_interop_passDirect_Enums_Small(_impl::_impl_Small::getOpaquePointer(en)));
+// CHECK-NEXT:   return _impl::$s5Enums10printSmallyyAA0C0OF(_impl::swift_interop_passDirect_Enums_[[Small]](_impl::_impl_Small::getOpaquePointer(en)));
 // CHECK-NEXT: }
 
 // CHECK:      inline void printTiny(const Tiny& en) noexcept {
-// CHECK-NEXT:   return _impl::$s5Enums9printTinyyyAA0C0OF(_impl::swift_interop_passDirect_Enums_Tiny(_impl::_impl_Tiny::getOpaquePointer(en)));
+// CHECK-NEXT:   return _impl::$s5Enums9printTinyyyAA0C0OF(_impl::swift_interop_passDirect_Enums_uint8_t_0_1(_impl::_impl_Tiny::getOpaquePointer(en)));
 // CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/functions/swift-functions-errors.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-functions-errors.swift
@@ -8,8 +8,8 @@
 
 // CHECK-LABEL: namespace _impl {
 
-// CHECK: SWIFT_EXTERN void $s9Functions18emptyThrowFunctionyyKF(SWIFT_CONTEXT const void * _Nonnull _self, SWIFT_ERROR_RESULT void * _Nullable * _Nullable _error) SWIFT_CALL; // emptyThrowFunction()
-// CHECK: SWIFT_EXTERN void $s9Functions13throwFunctionyyKF(SWIFT_CONTEXT const void * _Nonnull _self, SWIFT_ERROR_RESULT void * _Nullable * _Nullable _error) SWIFT_CALL; // throwFunction()
+// CHECK: SWIFT_EXTERN void $s9Functions18emptyThrowFunctionyyKF(SWIFT_CONTEXT void * _Nonnull _ctx, SWIFT_ERROR_RESULT void * _Nullable * _Nullable _error) SWIFT_CALL; // emptyThrowFunction()
+// CHECK: SWIFT_EXTERN void $s9Functions13throwFunctionyyKF(SWIFT_CONTEXT void * _Nonnull _ctx, SWIFT_ERROR_RESULT void * _Nullable * _Nullable _error) SWIFT_CALL; // throwFunction()
 
 // CHECK: }
 
@@ -22,8 +22,8 @@ public func emptyThrowFunction() throws { print("passEmptyThrowFunction") }
 
 // CHECK: inline void emptyThrowFunction() {
 // CHECK: void* opaqueError = nullptr;
-// CHECK: void* self = nullptr;
-// CHECK: _impl::$s9Functions18emptyThrowFunctionyyKF(self, &opaqueError);
+// CHECK: void* _ctx = nullptr;
+// CHECK: _impl::$s9Functions18emptyThrowFunctionyyKF(_ctx, &opaqueError);
 // CHECK: if (opaqueError != nullptr)
 // CHECK: throw (swift::Error(opaqueError))
 // CHECK: }
@@ -42,8 +42,8 @@ public func testDestroyedError() throws { throw DestroyedError() }
 
 // CHECK: inline void testDestroyedError() {
 // CHECK: void* opaqueError = nullptr;
-// CHECK: void* self = nullptr;
-// CHECK: _impl::$s9Functions18testDestroyedErroryyKF(self, &opaqueError);
+// CHECK: void* _ctx = nullptr;
+// CHECK: _impl::$s9Functions18testDestroyedErroryyKF(_ctx, &opaqueError);
 // CHECK: if (opaqueError != nullptr)
 // CHECK: throw (swift::Error(opaqueError))
 // CHECK: }
@@ -55,8 +55,8 @@ public func throwFunction() throws {
 
 // CHECK: inline void throwFunction() {
 // CHECK: void* opaqueError = nullptr;
-// CHECK: void* self = nullptr;
-// CHECK: _impl::$s9Functions13throwFunctionyyKF(self, &opaqueError);
+// CHECK: void* _ctx = nullptr;
+// CHECK: _impl::$s9Functions13throwFunctionyyKF(_ctx, &opaqueError);
 // CHECK: if (opaqueError != nullptr)
 // CHECK: throw (swift::Error(opaqueError))
 // CHECK: }
@@ -69,8 +69,8 @@ public func throwFunctionWithReturn() throws -> Int {
 
 // CHECK: inline swift::Int throwFunctionWithReturn() SWIFT_WARN_UNUSED_RESULT {
 // CHECK: void* opaqueError = nullptr;
-// CHECK: void* self = nullptr;
-// CHECK: auto returnValue = _impl::$s9Functions23throwFunctionWithReturnSiyKF(self, &opaqueError);
+// CHECK: void* _ctx = nullptr;
+// CHECK: auto returnValue = _impl::$s9Functions23throwFunctionWithReturnSiyKF(_ctx, &opaqueError);
 // CHECK: if (opaqueError != nullptr)
 // CHECK: throw (swift::Error(opaqueError))
 // CHECK: return returnValue;

--- a/test/Interop/SwiftToCxx/functions/swift-functions-errors.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-functions-errors.swift
@@ -8,8 +8,8 @@
 
 // CHECK-LABEL: namespace _impl {
 
-// CHECK: SWIFT_EXTERN void $s9Functions18emptyThrowFunctionyyKF(SWIFT_CONTEXT void * _Nonnull _self, SWIFT_ERROR_RESULT void * _Nullable * _Nullable _error) SWIFT_CALL; // emptyThrowFunction()
-// CHECK: SWIFT_EXTERN void $s9Functions13throwFunctionyyKF(SWIFT_CONTEXT void * _Nonnull _self, SWIFT_ERROR_RESULT void * _Nullable * _Nullable _error) SWIFT_CALL; // throwFunction()
+// CHECK: SWIFT_EXTERN void $s9Functions18emptyThrowFunctionyyKF(SWIFT_CONTEXT const void * _Nonnull _self, SWIFT_ERROR_RESULT void * _Nullable * _Nullable _error) SWIFT_CALL; // emptyThrowFunction()
+// CHECK: SWIFT_EXTERN void $s9Functions13throwFunctionyyKF(SWIFT_CONTEXT const void * _Nonnull _self, SWIFT_ERROR_RESULT void * _Nullable * _Nullable _error) SWIFT_CALL; // throwFunction()
 
 // CHECK: }
 

--- a/test/Interop/SwiftToCxx/generics/generic-function-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-function-in-cxx.swift
@@ -97,7 +97,7 @@ public func createTestSmallStruct(_ x: UInt32) -> TestSmallStruct {
     return TestSmallStruct(x1: x)
 }
 
-// CHECK: SWIFT_EXTERN void $s9Functions15TestSmallStructV24genericMethodPassThroughyxxlF(SWIFT_INDIRECT_RESULT void * _Nonnull, const void * _Nonnull x, struct swift_interop_stub_Functions_TestSmallStruct _self, void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // genericMethodPassThrough(_:)
+// CHECK: SWIFT_EXTERN void $s9Functions15TestSmallStructV24genericMethodPassThroughyxxlF(SWIFT_INDIRECT_RESULT void * _Nonnull, const void * _Nonnull x, struct swift_interop_passStub_Functions_uint32_t_0_4 _self, void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // genericMethodPassThrough(_:)
 // CHECK-NEXT: SWIFT_EXTERN void $s9Functions15TestSmallStructV20genericMethodMutTakeyyxlF(const void * _Nonnull x, void * _Nonnull , SWIFT_CONTEXT void * _Nonnull _self) SWIFT_NOEXCEPT SWIFT_CALL; // genericMethodMutTake(_:)
 
 // CHECK: SWIFT_EXTERN void $s9Functions20genericPrintFunctionyyxlF(const void * _Nonnull x, void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // genericPrintFunction(_:)
@@ -168,15 +168,15 @@ public func createTestSmallStruct(_ x: UInt32) -> TestSmallStruct {
 // CHECK-NEXT: inline T_0_0 TestSmallStruct::genericMethodPassThrough(const T_0_0& x) const {
 // CHECK-NEXT:   if constexpr (std::is_base_of<::swift::_impl::RefCountedClass, T_0_0>::value) {
 // CHECK-NEXT:   void *returnValue;
-// CHECK-NEXT:   _impl::$s9Functions15TestSmallStructV24genericMethodPassThroughyxxlF(reinterpret_cast<void *>(&returnValue), swift::_impl::getOpaquePointer(x), _impl::swift_interop_passDirect_Functions_TestSmallStruct(_getOpaquePointer()), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata());
+// CHECK-NEXT:   _impl::$s9Functions15TestSmallStructV24genericMethodPassThroughyxxlF(reinterpret_cast<void *>(&returnValue), swift::_impl::getOpaquePointer(x), _impl::swift_interop_passDirect_Functions_uint32_t_0_4(_getOpaquePointer()), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata());
 // CHECK-NEXT:   return ::swift::_impl::implClassFor<T_0_0>::type::makeRetained(returnValue);
 // CHECK-NEXT:   } else if constexpr (::swift::_impl::isValueType<T_0_0>) {
 // CHECK-NEXT:   return ::swift::_impl::implClassFor<T_0_0>::type::returnNewValue([&](void * _Nonnull returnValue) {
-// CHECK-NEXT: _impl::$s9Functions15TestSmallStructV24genericMethodPassThroughyxxlF(returnValue, swift::_impl::getOpaquePointer(x), _impl::swift_interop_passDirect_Functions_TestSmallStruct(_getOpaquePointer()), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata());
+// CHECK-NEXT: _impl::$s9Functions15TestSmallStructV24genericMethodPassThroughyxxlF(returnValue, swift::_impl::getOpaquePointer(x), _impl::swift_interop_passDirect_Functions_uint32_t_0_4(_getOpaquePointer()), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata());
 // CHECK-NEXT:   });
 // CHECK-NEXT:   } else {
 // CHECK-NEXT:   T_0_0 returnValue;
-// CHECK-NEXT: _impl::$s9Functions15TestSmallStructV24genericMethodPassThroughyxxlF(reinterpret_cast<void *>(&returnValue), swift::_impl::getOpaquePointer(x), _impl::swift_interop_passDirect_Functions_TestSmallStruct(_getOpaquePointer()), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata());
+// CHECK-NEXT: _impl::$s9Functions15TestSmallStructV24genericMethodPassThroughyxxlF(reinterpret_cast<void *>(&returnValue), swift::_impl::getOpaquePointer(x), _impl::swift_interop_passDirect_Functions_uint32_t_0_4(_getOpaquePointer()), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata());
 // CHECK-NEXT:   return returnValue;
 // CHECK-NEXT:   }
 // CHECK-NEXT:   }

--- a/test/Interop/SwiftToCxx/generics/generic-struct-execution-known-layout-direct.cpp
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-execution-known-layout-direct.cpp
@@ -1,0 +1,55 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %S/generic-struct-in-cxx.swift -D KNOWN_LAYOUT -typecheck -module-name Generics -clang-header-expose-public-decls -emit-clang-header-path %t/generics.h
+
+// RUN: %target-interop-build-clangxx -std=gnu++20 -c %s -I %t -o %t/swift-generics-execution.o
+// RUN: %target-interop-build-swift %S/generic-struct-in-cxx.swift -D KNOWN_LAYOUT -o %t/swift-generics-execution -Xlinker %t/swift-generics-execution.o -module-name Generics -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+
+// RUN: %target-codesign %t/swift-generics-execution
+// RUN: %target-run %t/swift-generics-execution | %FileCheck %s
+
+// REQUIRES: executable_test
+
+#include <cstdint>
+#include "generic-struct-execution.cpp"
+
+// CHECK: GenericPair<Int32, Int32>(x_: ClassWithT(11), y_: ClassWithT(42))
+// CHECK-NEXT: GenericPair<Int32, Int32>(x_: ClassWithT(11), y_: ClassWithT(42))
+// CHECK-NEXT: GenericPair<Int32, Int32>(x_: ClassWithT(11), y_: ClassWithT(-995))
+// CHECK-NEXT: GenericPair<Int32, Int32>(x_: ClassWithT(255), y_: ClassWithT(42))
+// CHECK-NEXT: GenericPair<T, T2>::testme::255,42;
+// CHECK-NEXT: GenericPair<T, T2>::testme::-995,11;
+// CHECK-NEXT: GenericPair<Int32, Int32>(x_: ClassWithT(-995), y_: ClassWithT(11))
+// CHECK-NEXT: GenericPair<Int32, Int32>(x_: ClassWithT(11), y_: ClassWithT(-995))
+// CHECK-NEXT: GenericPair<Int32, Int32>(x_: ClassWithT(-995), y_: ClassWithT(561))
+// CHECK-NEXT: GenericPair<T, T2>::computeVar::get
+// CHECK-NEXT: GenericPair<T, T2>::computeVar::set
+// CHECK-NEXT: GenericPair<T, T2>::computeVar::get
+// CHECK-NEXT: GenericPair<Int32, Int32>(x_: ClassWithT(-123456), y_: ClassWithT(561))
+// CHECK-NEXT: GenericPair<T, T2>::genericMethod<T>::2.25,4221;
+// CHECK-NEXT: GenericPair<UInt16, UInt16>(x_: ClassWithT(10000), y_: ClassWithT(65255))
+// CHECK-NEXT: CONCRETE pair of UInt16: 10000 65255 ;
+// CHECK-NEXT: CONCRETE pair of UInt16: 10000 65255 ;
+// CHECK-NEXT: CONCRETE pair of UInt16: 10000 918 ;
+// CHECK-NEXT: GenericPair<UInt16, UInt16>(x_: ClassWithT(10000), y_: ClassWithT(918))
+// CHECK-NEXT: CONCRETE pair of UInt16: 77 65255 ;
+// CHECK-NEXT: GenericPair<T, T2>::testme::77,65255;
+// CHECK-NEXT: GenericPair<T, T2>::testme::918,10000;
+// CHECK-NEXT: CONCRETE pair of UInt16: 10000 918 ;
+// CHECK-NEXT: GenericPair<T, T2>::init::11,44,234242;
+// CHECK-NEXT: GenericPair<Int32, Int32>(x_: ClassWithT(11), y_: ClassWithT(44))
+// CHECK-NEXT: GenericPair<T, T2>::testme::11,44;
+// CHECK-NEXT: GenericPair<T, T2>::init::0,3425,-987;
+// CHECK-NEXT: CONCRETE pair of UInt16: 0 3425 ;
+// CHECK-NEXT: GenericPair<T, T2>::testme::0,3425;
+// CHECK-NEXT: GenericPair<T, T2>::genericMethod<T>::PairOfUInt64(x: 719610, y: 205891),4221;
+// CHECK-NEXT: EOF
+
+#if UINTPTR_MAX == 0xFFFFFFFFFFFFFFFFu
+using stubType = Generics::_impl::swift_interop_passStub_Generics_void_ptr_0_8_void_ptr_8_16;
+#elif UINTPTR_MAX == 0xFFFFFFFF
+using stubType = Generics::_impl::swift_interop_passStub_Generics_void_ptr_0_4_void_ptr_4_8;
+#endif
+
+// verify that we're using direct stub type in the test.
+static_assert(sizeof(stubType) == sizeof(void *) * 2);

--- a/test/Interop/SwiftToCxx/generics/generic-struct-execution-known-layout-indirect.cpp
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-execution-known-layout-indirect.cpp
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %S/generic-struct-in-cxx.swift -D KNOWN_LAYOUT -D INDIRECT_KNOWN_LAYOUT -typecheck -module-name Generics -clang-header-expose-public-decls -emit-clang-header-path %t/generics.h
+
+// RUN: %target-interop-build-clangxx -std=gnu++20 -c %s -I %t -o %t/swift-generics-execution.o
+// RUN: %target-interop-build-swift %S/generic-struct-in-cxx.swift -D KNOWN_LAYOUT -D INDIRECT_KNOWN_LAYOUT -o %t/swift-generics-execution -Xlinker %t/swift-generics-execution.o -module-name Generics -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+
+// RUN: %target-codesign %t/swift-generics-execution
+// RUN: %target-run %t/swift-generics-execution | %FileCheck %s
+
+// REQUIRES: executable_test
+
+#include "generic-struct-execution.cpp"
+
+// CHECK: GenericPair<Int32, Int32>(x_: ClassWithT(11), y_: ClassWithT(42), val1: 0, val2: 0, val3: 0, val4: 0)
+// CHECK-NEXT: GenericPair<Int32, Int32>(x_: ClassWithT(11), y_: ClassWithT(42), val1: 0, val2: 0, val3: 0, val4: 0)
+// CHECK-NEXT: GenericPair<Int32, Int32>(x_: ClassWithT(11), y_: ClassWithT(-995), val1: 0, val2: 0, val3: 0, val4: 0)
+// CHECK-NEXT: GenericPair<Int32, Int32>(x_: ClassWithT(255), y_: ClassWithT(42), val1: 0, val2: 0, val3: 0, val4: 0)
+// CHECK-NEXT: GenericPair<T, T2>::testme::255,42;
+// CHECK-NEXT: GenericPair<T, T2>::testme::-995,11;
+// CHECK-NEXT: GenericPair<Int32, Int32>(x_: ClassWithT(-995), y_: ClassWithT(11), val1: 0, val2: 0, val3: 0, val4: 0)
+// CHECK-NEXT: GenericPair<Int32, Int32>(x_: ClassWithT(11), y_: ClassWithT(-995), val1: 0, val2: 0, val3: 0, val4: 0)
+// CHECK-NEXT: GenericPair<Int32, Int32>(x_: ClassWithT(-995), y_: ClassWithT(561), val1: 0, val2: 0, val3: 0, val4: 0)
+// CHECK-NEXT: GenericPair<T, T2>::computeVar::get
+// CHECK-NEXT: GenericPair<T, T2>::computeVar::set
+// CHECK-NEXT: GenericPair<T, T2>::computeVar::get
+// CHECK-NEXT: GenericPair<Int32, Int32>(x_: ClassWithT(-123456), y_: ClassWithT(561), val1: 0, val2: 0, val3: 0, val4: 0)
+// CHECK-NEXT: GenericPair<T, T2>::genericMethod<T>::2.25,4221;
+// CHECK-NEXT: GenericPair<UInt16, UInt16>(x_: ClassWithT(10000), y_: ClassWithT(65255), val1: 0, val2: 0, val3: 0, val4: 0)
+// CHECK-NEXT: CONCRETE pair of UInt16: 10000 65255 ;
+// CHECK-NEXT: CONCRETE pair of UInt16: 10000 65255 ;
+// CHECK-NEXT: CONCRETE pair of UInt16: 10000 918 ;
+// CHECK-NEXT: GenericPair<UInt16, UInt16>(x_: ClassWithT(10000), y_: ClassWithT(918), val1: 0, val2: 0, val3: 0, val4: 0)
+// CHECK-NEXT: CONCRETE pair of UInt16: 77 65255 ;
+// CHECK-NEXT: GenericPair<T, T2>::testme::77,65255;
+// CHECK-NEXT: GenericPair<T, T2>::testme::918,10000;
+// CHECK-NEXT: CONCRETE pair of UInt16: 10000 918 ;
+// CHECK-NEXT: GenericPair<T, T2>::init::11,44,234242;
+// CHECK-NEXT: GenericPair<Int32, Int32>(x_: ClassWithT(11), y_: ClassWithT(44), val1: 0, val2: 0, val3: 0, val4: 0)
+// CHECK-NEXT: GenericPair<T, T2>::testme::11,44;
+// CHECK-NEXT: GenericPair<T, T2>::init::0,3425,-987;
+// CHECK-NEXT: CONCRETE pair of UInt16: 0 3425 ;
+// CHECK-NEXT: GenericPair<T, T2>::testme::0,3425;
+// CHECK-NEXT: GenericPair<T, T2>::genericMethod<T>::PairOfUInt64(x: 719610, y: 205891),4221;
+// CHECK-NEXT: EOF

--- a/test/Interop/SwiftToCxx/generics/generic-struct-execution.cpp
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-execution.cpp
@@ -10,8 +10,9 @@
 
 // REQUIRES: executable_test
 
-#include <cassert>
 #include "generics.h"
+#include <cassert>
+#include <cstdio>
 
 int main() {
   using namespace Generics;
@@ -56,28 +57,28 @@ int main() {
   }
 
   {
-    auto x = makeConcretePair(100000, 0x1fee7);
+    auto x = makeConcretePair(10000, 0xfee7);
     takeGenericPair(x);
-    // CHECK-NEXT: GenericPair<UInt32, UInt32>(x: 100000, y: 130791)
+    // CHECK-NEXT: GenericPair<UInt16, UInt16>(x: 10000, y: 65255)
     takeConcretePair(x);
-    // CHECK-NEXT: CONCRETE pair of UInt32: 100000 130791 ;
+    // CHECK-NEXT: CONCRETE pair of UInt16: 10000 65255 ;
     auto xprime = passThroughConcretePair(x, 918);
     takeConcretePair(x);
     takeConcretePair(xprime);
     takeGenericPair(xprime);
-    // CHECK-NEXT: CONCRETE pair of UInt32: 100000 130791 ;
-    // CHECK-NEXT: CONCRETE pair of UInt32: 100000 918 ;
-    // CHECK-NEXT: GenericPair<UInt32, UInt32>(x: 100000, y: 918)
+    // CHECK-NEXT: CONCRETE pair of UInt16: 10000 65255 ;
+    // CHECK-NEXT: CONCRETE pair of UInt16: 10000 918 ;
+    // CHECK-NEXT: GenericPair<UInt16, UInt16>(x: 10000, y: 918)
     inoutConcretePair(77, x);
     takeConcretePair(x);
-    // CHECK-NEXT: CONCRETE pair of UInt32: 77 130791 ;
+    // CHECK-NEXT: CONCRETE pair of UInt16: 77 65255 ;
     x.method();
-    // CHECK-NEXT: GenericPair<T, T2>::testme::77,130791;
+    // CHECK-NEXT: GenericPair<T, T2>::testme::77,65255;
     x.mutatingMethod(xprime);
     x.method();
-    // CHECK-NEXT: GenericPair<T, T2>::testme::918,100000;
+    // CHECK-NEXT: GenericPair<T, T2>::testme::918,10000;
     takeConcretePair(xprime);
-    // CHECK-NEXT: CONCRETE pair of UInt32: 100000 918 ;
+    // CHECK-NEXT: CONCRETE pair of UInt16: 10000 918 ;
   }
 
   {
@@ -88,12 +89,12 @@ int main() {
     // CHECK-NEXT: GenericPair<T, T2>::init::11,44,234242;
     // CHECK-NEXT: GenericPair<Int32, Int32>(x: 11, y: 44)
     // CHECK-NEXT: GenericPair<T, T2>::testme::11,44;
-    auto y = GenericPair<uint32_t, uint32_t>::init(0, -987, 3425);
+    auto y = GenericPair<uint16_t, uint16_t>::init(0, -987, 3425);
     takeConcretePair(y);
     y.method();
     assert(y.getY() == 3425);
     // CHECK-NEXT: GenericPair<T, T2>::init::0,3425,-987;
-    // CHECK-NEXT: CONCRETE pair of UInt32: 0 3425 ;
+    // CHECK-NEXT: CONCRETE pair of UInt16: 0 3425 ;
     // CHECK-NEXT: GenericPair<T, T2>::testme::0,3425;
     auto val = PairOfUInt64::init(0xafafa, 0x32443);
     auto valprime = x.genericMethod(val, 4221);
@@ -101,5 +102,7 @@ int main() {
     assert(valprime.getY() == val.getY());
     // CHECK-NEXT: GenericPair<T, T2>::genericMethod<T>::PairOfUInt64(x: 719610, y: 205891),4221;
   }
+  puts("EOF\n");
+  // CHECK-NEXT: EOF
   return 0;
 }

--- a/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
@@ -56,6 +56,9 @@ public struct GenericPair<T, T2> {
             y_ = ClassWithT<T2>(newValue)
         }
     }
+    #if INDIRECT_KNOWN_LAYOUT
+    let val1, val2, val3, val4: Int
+    #endif
     #else
     var x: T
     public var y: T2
@@ -65,6 +68,12 @@ public struct GenericPair<T, T2> {
 #if KNOWN_LAYOUT
         self.x_ = ClassWithT<T>(x)
         self.y_ = ClassWithT<T2>(y)
+#if INDIRECT_KNOWN_LAYOUT
+        val1 = 0
+        val2 = 0
+        val3 = 0
+        val4 = 0
+#endif
 #else
         self.x = x
         self.y = y
@@ -75,6 +84,12 @@ public struct GenericPair<T, T2> {
 #if KNOWN_LAYOUT
         self.x_ = ClassWithT<T>(x)
         self.y_ = ClassWithT<T2>(y)
+#if INDIRECT_KNOWN_LAYOUT
+        val1 = 0
+        val2 = 0
+        val3 = 0
+        val4 = 0
+#endif
 #else
         self.x = x
         self.y = y

--- a/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
@@ -26,19 +26,59 @@ public struct PairOfUInt64 {
     }
 }
 
+class ClassWithT<T>: CustomStringConvertible {
+    var val: T
+
+    init(_ x: T) {
+        val = x
+    }
+    var description: String {
+      return "ClassWithT(\(val))"
+    }
+}
+
 @frozen
 public struct GenericPair<T, T2> {
+    #if KNOWN_LAYOUT
+    var x_: ClassWithT<T>
+    var y_: ClassWithT<T2>
+    var x: T {
+        get {
+            return x_.val
+        } set {
+            x_ = ClassWithT<T>(newValue)
+        }
+    }
+    public var y: T2 {
+        get {
+            return y_.val
+        } set {
+            y_ = ClassWithT<T2>(newValue)
+        }
+    }
+    #else
     var x: T
     public var y: T2
+    #endif
 
     init(x: T, y: T2) {
+#if KNOWN_LAYOUT
+        self.x_ = ClassWithT<T>(x)
+        self.y_ = ClassWithT<T2>(y)
+#else
         self.x = x
         self.y = y
+#endif
     }
 
     public init(_ x: T, _ i: Int, _ y: T2) {
+#if KNOWN_LAYOUT
+        self.x_ = ClassWithT<T>(x)
+        self.y_ = ClassWithT<T2>(y)
+#else
         self.x = x
         self.y = y
+#endif
         print("GenericPair<T, T2>::init::\(x),\(y),\(i);")
     }
 
@@ -76,25 +116,25 @@ public func makeGenericPair<T, T1>(_ x: T, _ y: T1) -> GenericPair<T, T1> {
     return GenericPair<T, T1>(x: x, y: y);
 }
 
-public func makeConcretePair(_ x: UInt32, _ y: UInt32) -> GenericPair<UInt32, UInt32> {
-    return GenericPair<UInt32, UInt32>(x: x, y: y)
+public func makeConcretePair(_ x: UInt16, _ y: UInt16) -> GenericPair<UInt16, UInt16> {
+    return GenericPair<UInt16, UInt16>(x: x, y: y)
 }
 
 public func takeGenericPair<T, T1>(_ x: GenericPair<T, T1>) {
     print(x)
 }
 
-public func takeConcretePair(_ x: GenericPair<UInt32, UInt32>) {
-    print("CONCRETE pair of UInt32: ", x.x, x.y, ";")
+public func takeConcretePair(_ x: GenericPair<UInt16, UInt16>) {
+    print("CONCRETE pair of UInt16: ", x.x, x.y, ";")
 }
 
 public func passThroughGenericPair<T1, T>(_ x: GenericPair<T1, T>, _ y: T)  -> GenericPair<T1, T> {
     return GenericPair<T1, T>(x: x.x, y: y)
 }
 
-public typealias ConcreteUint32Pair = GenericPair<UInt32, UInt32>
+public typealias ConcreteUint32Pair = GenericPair<UInt16, UInt16>
 
-public func passThroughConcretePair(_ x: ConcreteUint32Pair, y: UInt32) -> ConcreteUint32Pair {
+public func passThroughConcretePair(_ x: ConcreteUint32Pair, y: UInt16) -> ConcreteUint32Pair {
     return ConcreteUint32Pair(x: x.x, y: y)
 }
 
@@ -102,7 +142,7 @@ public func inoutGenericPair<T1, T>(_ x: inout GenericPair<T1, T>, _ y: T1) {
     x.x = y
 }
 
-public func inoutConcretePair(_ x: UInt32, _ y: inout GenericPair<UInt32, UInt32>) {
+public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16>) {
     y.x = x
 }
 
@@ -116,28 +156,33 @@ public func inoutConcretePair(_ x: UInt32, _ y: inout GenericPair<UInt32, UInt32
 // CHECK-NEXT: SWIFT_EXTERN void $s8Generics11GenericPairV11computedVarxvg(SWIFT_INDIRECT_RESULT void * _Nonnull, void * _Nonnull , SWIFT_CONTEXT const void * _Nonnull _self) SWIFT_NOEXCEPT SWIFT_CALL; // _
 // CHECK-NEXT: SWIFT_EXTERN void $s8Generics11GenericPairV11computedVarxvs(const void * _Nonnull newValue, void * _Nonnull , SWIFT_CONTEXT void * _Nonnull _self) SWIFT_NOEXCEPT SWIFT_CALL; // _
 
-// CHECK: SWIFT_EXTERN void $s8Generics17inoutConcretePairyys6UInt32V_AA07GenericD0VyA2DGztF(uint32_t x, char * _Nonnull y) SWIFT_NOEXCEPT SWIFT_CALL; // inoutConcretePair(_:_:)
+// CHECK: SWIFT_EXTERN void $s8Generics17inoutConcretePairyys6UInt16V_AA07GenericD0VyA2DGztF(uint16_t x, void * _Nonnull y) SWIFT_NOEXCEPT SWIFT_CALL; // inoutConcretePair(_:_:)
 // CHECK-NEXT: SWIFT_EXTERN void $s8Generics16inoutGenericPairyyAA0cD0Vyxq_Gz_xtr0_lF(void * _Nonnull x, const void * _Nonnull y, void * _Nonnull , void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // inoutGenericPair(_:_:)
 // CHECK-NEXT: // Stub struct to be used to pass/return values to/from Swift functions.
-// CHECK-NEXT: struct swift_interop_stub_Generics_GenericPair_s6UInt32V_s6UInt32V {
-// CHECK-NEXT:   uint64_t _1;
+// CHECK-NEXT: struct swift_interop_returnStub_Generics_uint32_t_0_4 {
+// CHECK-NEXT:   uint32_t _1;
 // CHECK-NEXT: };
 // CHECK-EMPTY:
-// CHECK-NEXT: static inline void swift_interop_returnDirect_Generics_GenericPair_s6UInt32V_s6UInt32V(char * _Nonnull result, struct swift_interop_stub_Generics_GenericPair_s6UInt32V_s6UInt32V value) __attribute__((always_inline)) {
-// CHECK-NEXT:   memcpy(result + 0, &value._1, 8);
+// CHECK-NEXT: static inline void swift_interop_returnDirect_Generics_uint32_t_0_4(char * _Nonnull result, struct swift_interop_returnStub_Generics_uint32_t_0_4 value) __attribute__((always_inline)) {
+// CHECK-NEXT:   memcpy(result + 0, &value._1, 4);
 // CHECK-NEXT: }
 // CHECK-EMPTY:
-// CHECK-NEXT: static inline struct swift_interop_stub_Generics_GenericPair_s6UInt32V_s6UInt32V swift_interop_passDirect_Generics_GenericPair_s6UInt32V_s6UInt32V(const char * _Nonnull value) __attribute__((always_inline)) {
-// CHECK-NEXT:   struct swift_interop_stub_Generics_GenericPair_s6UInt32V_s6UInt32V result;
-// CHECK-NEXT:   memcpy(&result._1, value + 0, 8);
+// CHECK-NEXT: SWIFT_EXTERN struct swift_interop_returnStub_Generics_uint32_t_0_4 $s8Generics16makeConcretePairyAA07GenericD0Vys6UInt16VAFGAF_AFtF(uint16_t x, uint16_t y) SWIFT_NOEXCEPT SWIFT_CALL; // makeConcretePair(_:_:)
+// CHECK-NEXT: SWIFT_EXTERN void $s8Generics15makeGenericPairyAA0cD0Vyxq_Gx_q_tr0_lF(SWIFT_INDIRECT_RESULT void * _Nonnull, const void * _Nonnull x, const void * _Nonnull y, void * _Nonnull , void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // makeGenericPair(_:_:)
+// CHECK-NEXT: // Stub struct to be used to pass/return values to/from Swift functions.
+// CHECK-NEXT: struct swift_interop_passStub_Generics_uint32_t_0_4 {
+// CHECK-NEXT:   uint32_t _1;
+// CHECK-NEXT: };
+// CHECK-EMPTY:
+// CHECK-NEXT: static inline struct swift_interop_passStub_Generics_uint32_t_0_4 swift_interop_passDirect_Generics_uint32_t_0_4(const char * _Nonnull value) __attribute__((always_inline)) {
+// CHECK-NEXT:   struct swift_interop_passStub_Generics_uint32_t_0_4 result;
+// CHECK-NEXT:   memcpy(&result._1, value + 0, 4);
 // CHECK-NEXT:   return result;
 // CHECK-NEXT: }
 // CHECK-EMPTY:
-// CHECK-NEXT: SWIFT_EXTERN struct swift_interop_stub_Generics_GenericPair_s6UInt32V_s6UInt32V $s8Generics16makeConcretePairyAA07GenericD0Vys6UInt32VAFGAF_AFtF(uint32_t x, uint32_t y) SWIFT_NOEXCEPT SWIFT_CALL; // makeConcretePair(_:_:)
-// CHECK-NEXT: SWIFT_EXTERN void $s8Generics15makeGenericPairyAA0cD0Vyxq_Gx_q_tr0_lF(SWIFT_INDIRECT_RESULT void * _Nonnull, const void * _Nonnull x, const void * _Nonnull y, void * _Nonnull , void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // makeGenericPair(_:_:)
-// CHECK-NEXT: SWIFT_EXTERN struct swift_interop_stub_Generics_GenericPair_s6UInt32V_s6UInt32V $s8Generics23passThroughConcretePair_1yAA07GenericE0Vys6UInt32VAGGAH_AGtF(struct swift_interop_stub_Generics_GenericPair_s6UInt32V_s6UInt32V x, uint32_t y) SWIFT_NOEXCEPT SWIFT_CALL; // passThroughConcretePair(_:y:)
+// CHECK-NEXT: SWIFT_EXTERN struct swift_interop_returnStub_Generics_uint32_t_0_4 $s8Generics23passThroughConcretePair_1yAA07GenericE0Vys6UInt16VAGGAH_AGtF(struct swift_interop_passStub_Generics_uint32_t_0_4 x, uint16_t y) SWIFT_NOEXCEPT SWIFT_CALL; // passThroughConcretePair(_:y:)
 // CHECK-NEXT: SWIFT_EXTERN void $s8Generics22passThroughGenericPairyAA0dE0Vyxq_GAE_q_tr0_lF(SWIFT_INDIRECT_RESULT void * _Nonnull, const void * _Nonnull x, const void * _Nonnull y, void * _Nonnull , void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // passThroughGenericPair(_:_:)
-// CHECK-NEXT: SWIFT_EXTERN void $s8Generics16takeConcretePairyyAA07GenericD0Vys6UInt32VAFGF(struct swift_interop_stub_Generics_GenericPair_s6UInt32V_s6UInt32V x) SWIFT_NOEXCEPT SWIFT_CALL; // takeConcretePair(_:)
+// CHECK-NEXT: SWIFT_EXTERN void $s8Generics16takeConcretePairyyAA07GenericD0Vys6UInt16VAFGF(struct swift_interop_passStub_Generics_uint32_t_0_4 x) SWIFT_NOEXCEPT SWIFT_CALL; // takeConcretePair(_:)
 // CHECK-NEXT: SWIFT_EXTERN void $s8Generics15takeGenericPairyyAA0cD0Vyxq_Gr0_lF(const void * _Nonnull x, void * _Nonnull , void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // takeGenericPair(_:)
 
 // CHECK: template<class T_0_0, class T_0_1>
@@ -191,8 +236,8 @@ public func inoutConcretePair(_ x: UInt32, _ y: inout GenericPair<UInt32, UInt32
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: class GenericPair;
 // CHECK-EMPTY:
-// CHECK-NEXT: inline void inoutConcretePair(uint32_t x, GenericPair<uint32_t, uint32_t>& y) noexcept {
-// CHECK-NEXT:   return _impl::$s8Generics17inoutConcretePairyys6UInt32V_AA07GenericD0VyA2DGztF(x, _impl::_impl_GenericPair<uint32_t, uint32_t>::getOpaquePointer(y));
+// CHECK-NEXT: inline void inoutConcretePair(uint16_t x, GenericPair<uint16_t, uint16_t>& y) noexcept {
+// CHECK-NEXT:   return _impl::$s8Generics17inoutConcretePairyys6UInt16V_AA07GenericD0VyA2DGztF(x, _impl::_impl_GenericPair<uint16_t, uint16_t>::getOpaquePointer(y));
 // CHECK-NEXT: }
 
 // CHECK: template<class T_0_0, class T_0_1>
@@ -204,27 +249,27 @@ public func inoutConcretePair(_ x: UInt32, _ y: inout GenericPair<UInt32, UInt32
 // CHECK: template<class T_0_0, class T_0_1>
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: inline GenericPair<T_0_0, T_0_1> makeGenericPair(const T_0_0& x, const T_0_1& y) noexcept SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::_impl_GenericPair<T_0_0, T_0_1>::returnNewValue([&](void * _Nonnull result) {
+// CHECK-NEXT:   return _impl::_impl_GenericPair<T_0_0, T_0_1>::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:     _impl::$s8Generics15makeGenericPairyAA0cD0Vyxq_Gx_q_tr0_lF(result, swift::_impl::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata());
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
-// CHECK: inline GenericPair<uint32_t, uint32_t> passThroughConcretePair(const GenericPair<uint32_t, uint32_t>& x, uint32_t y) noexcept SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:  return _impl::_impl_GenericPair<uint32_t, uint32_t>::returnNewValue([&](char * _Nonnull result) {
-// CHECK-NEXT:     _impl::swift_interop_returnDirect_Generics_GenericPair_s6UInt32V_s6UInt32V(result, _impl::$s8Generics23passThroughConcretePair_1yAA07GenericE0Vys6UInt32VAGGAH_AGtF(_impl::swift_interop_passDirect_Generics_GenericPair_s6UInt32V_s6UInt32V(_impl::_impl_GenericPair<uint32_t, uint32_t>::getOpaquePointer(x)), y));
+// CHECK: inline GenericPair<uint16_t, uint16_t> passThroughConcretePair(const GenericPair<uint16_t, uint16_t>& x, uint16_t y) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT:  return _impl::_impl_GenericPair<uint16_t, uint16_t>::returnNewValue([&](char * _Nonnull result) {
+// CHECK-NEXT:     _impl::swift_interop_returnDirect_Generics_uint32_t_0_4(result, _impl::$s8Generics23passThroughConcretePair_1yAA07GenericE0Vys6UInt16VAGGAH_AGtF(_impl::swift_interop_passDirect_Generics_uint32_t_0_4(_impl::_impl_GenericPair<uint16_t, uint16_t>::getOpaquePointer(x)), y));
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
 // CHECK: template<class T_0_0, class T_0_1>
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: inline GenericPair<T_0_0, T_0_1> passThroughGenericPair(const GenericPair<T_0_0, T_0_1>& x, const T_0_1& y) noexcept SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::_impl_GenericPair<T_0_0, T_0_1>::returnNewValue([&](void * _Nonnull result) {
+// CHECK-NEXT:   return _impl::_impl_GenericPair<T_0_0, T_0_1>::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:     _impl::$s8Generics22passThroughGenericPairyAA0dE0Vyxq_GAE_q_tr0_lF(result, _impl::_impl_GenericPair<T_0_0, T_0_1>::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata());
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
-// CHECK: inline void takeConcretePair(const GenericPair<uint32_t, uint32_t>& x) noexcept {
-// CHECK-NEXT:  return _impl::$s8Generics16takeConcretePairyyAA07GenericD0Vys6UInt32VAFGF(_impl::swift_interop_passDirect_Generics_GenericPair_s6UInt32V_s6UInt32V(_impl::_impl_GenericPair<uint32_t, uint32_t>::getOpaquePointer(x)));
+// CHECK: inline void takeConcretePair(const GenericPair<uint16_t, uint16_t>& x) noexcept {
+// CHECK-NEXT:  return _impl::$s8Generics16takeConcretePairyyAA07GenericD0Vys6UInt16VAFGF(_impl::swift_interop_passDirect_Generics_uint32_t_0_4(_impl::_impl_GenericPair<uint16_t, uint16_t>::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
 // CHECK: template<class T_0_0, class T_0_1>
@@ -258,7 +303,7 @@ public func inoutConcretePair(_ x: UInt32, _ y: inout GenericPair<UInt32, UInt32
 // CHECK-NEXT: template<class T_0_0, class T_0_1>
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: inline GenericPair<T_0_0, T_0_1> GenericPair<T_0_0, T_0_1>::init(const T_0_0& x, swift::Int i, const T_0_1& y) {
-// CHECK-NEXT: return _impl::_impl_GenericPair<T_0_0, T_0_1>::returnNewValue([&](void * _Nonnull result) {
+// CHECK-NEXT: return _impl::_impl_GenericPair<T_0_0, T_0_1>::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:   _impl::$s8Generics11GenericPairVyACyxq_Gx_Siq_tcfC(result, swift::_impl::getOpaquePointer(x), i, swift::_impl::getOpaquePointer(y), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata());
 // CHECK-NEXT: });
 // CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/generics/generic-struct-known-layout-direct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-known-layout-direct-in-cxx.swift
@@ -1,0 +1,125 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %S/generic-struct-in-cxx.swift -D KNOWN_LAYOUT -typecheck -module-name Generics -clang-header-expose-public-decls -emit-clang-header-path %t/generics.h
+// RUN: %FileCheck %s < %t/generics.h
+// RUN: %check-generic-interop-cxx-header-in-clang(%t/generics.h -Wno-reserved-identifier)
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %S/generic-struct-in-cxx.swift -D KNOWN_LAYOUT -enable-library-evolution -typecheck -module-name Generics -clang-header-expose-public-decls -emit-clang-header-path %t/generics.h
+// RUN: %FileCheck %s < %t/generics.h
+// RUN: %check-generic-interop-cxx-header-in-clang(%t/generics.h -Wno-reserved-identifier)
+
+// CHECK: // Stub struct to be used to pass/return values to/from Swift functions.
+// CHECK-NEXT: struct swift_interop_passStub_Generics_[[PTRPTRENC:void_ptr_[0-9]_[0-9]_void_ptr_[0-9]_[0-9]+]] {
+// CHECK-NEXT:  void * _Nullable _1;
+// CHECK-NEXT:  void * _Nullable _2;
+// CHECK-NEXT: };
+// CHECK-EMPTY:
+// CHECK-NEXT: static inline struct swift_interop_passStub_Generics_[[PTRPTRENC]] swift_interop_passDirect_Generics_[[PTRPTRENC]](const char * _Nonnull value) __attribute__((always_inline)) {
+// CHECK-NEXT:  struct swift_interop_passStub_Generics_[[PTRPTRENC]] result;
+// CHECK-NEXT:  memcpy(&result._1, value
+// CHECK-NEXT:  memcpy(&result._2, value
+// CHECK-NEXT:  return result;
+// CHECK-NEXT:}
+// CHECK-EMPTY:
+// CHECK-NEXT: SWIFT_EXTERN void $s8Generics11GenericPairV1yq_vg(SWIFT_INDIRECT_RESULT void * _Nonnull, struct swift_interop_passStub_Generics_[[PTRPTRENC]] _self, void * _Nonnull , void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // _
+// CHECK-NEXT: SWIFT_EXTERN void $s8Generics11GenericPairV1yq_vs(const void * _Nonnull newValue, void * _Nonnull , SWIFT_CONTEXT void * _Nonnull _self) SWIFT_NOEXCEPT SWIFT_CALL; // _
+// CHECK-NEXT: // Stub struct to be used to pass/return values to/from Swift functions.
+// CHECK-NEXT: struct swift_interop_returnStub_Generics_[[PTRPTRENC]] {
+// CHECK-NEXT:   void * _Nullable _1;
+// CHECK-NEXT:   void * _Nullable _2;
+// CHECK-NEXT: };
+// CHECK-EMPTY:
+// CHECK-NEXT: static inline void swift_interop_returnDirect_Generics_[[PTRPTRENC]](char * _Nonnull result, struct swift_interop_returnStub_Generics_[[PTRPTRENC]] value) __attribute__((always_inline)) {
+// CHECK-NEXT:   memcpy(result
+// CHECK-NEXT:   memcpy(result
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK-NEXT: SWIFT_EXTERN struct swift_interop_returnStub_Generics_[[PTRPTRENC]] $s8Generics11GenericPairVyACyxq_Gx_Siq_tcfC(const void * _Nonnull x, ptrdiff_t i, const void * _Nonnull y, void * _Nonnull , void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // init(_:_:_:)
+// CHECK-NEXT: SWIFT_EXTERN void $s8Generics11GenericPairV6methodyyF(struct swift_interop_passStub_Generics_[[PTRPTRENC]] _self, void * _Nonnull , void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // method()
+// CHECK-NEXT: SWIFT_EXTERN void $s8Generics11GenericPairV14mutatingMethodyyACyq_xGF(struct swift_interop_passStub_Generics_[[PTRPTRENC]] other, void * _Nonnull , SWIFT_CONTEXT void * _Nonnull _self) SWIFT_NOEXCEPT SWIFT_CALL; // mutatingMethod(_:)
+// CHECK-NEXT: SWIFT_EXTERN void $s8Generics11GenericPairV13genericMethodyqd__qd___q_tlF(SWIFT_INDIRECT_RESULT void * _Nonnull, const void * _Nonnull x, const void * _Nonnull y, struct swift_interop_passStub_Generics_[[PTRPTRENC]] _self, void * _Nonnull , void * _Nonnull , void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // genericMethod(_:_:)
+// CHECK-NEXT: SWIFT_EXTERN ptrdiff_t $s8Generics11GenericPairV12computedPropSivg(struct swift_interop_passStub_Generics_[[PTRPTRENC]] _self, void * _Nonnull , void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // _
+// CHECK-NEXT: SWIFT_EXTERN void $s8Generics11GenericPairV11computedVarxvg(SWIFT_INDIRECT_RESULT void * _Nonnull, struct swift_interop_passStub_Generics_[[PTRPTRENC]] _self, void * _Nonnull , void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // _
+// CHECK-NEXT: SWIFT_EXTERN void $s8Generics11GenericPairV11computedVarxvs(const void * _Nonnull newValue, void * _Nonnull , SWIFT_CONTEXT void * _Nonnull _self) SWIFT_NOEXCEPT SWIFT_CALL; // _
+// CHECK-NEXT: // Stub struct to be used to pass/return values to/from Swift functions.
+// CHECK-NEXT: struct swift_interop_passStub_Generics_uint64_t_0_8_uint64_t_8_16 {
+// CHECK-NEXT:   uint64_t _1;
+// CHECK-NEXT:   uint64_t _2;
+// CHECK-NEXT: };
+// CHECK-EMPTY:
+// CHECK-NEXT: static inline struct swift_interop_passStub_Generics_uint64_t_0_8_uint64_t_8_16 swift_interop_passDirect_Generics_uint64_t_0_8_uint64_t_8_16(const char * _Nonnull value) __attribute__((always_inline)) {
+// CHECK: }
+// CHECK-EMPTY:
+// CHECK-NEXT: SWIFT_EXTERN uint64_t $s8Generics12PairOfUInt64V1xs0D0Vvg(struct swift_interop_passStub_Generics_uint64_t_0_8_uint64_t_8_16 _self) SWIFT_NOEXCEPT SWIFT_CALL; // _
+// CHECK-NEXT: SWIFT_EXTERN uint64_t $s8Generics12PairOfUInt64V1ys0D0Vvg(struct swift_interop_passStub_Generics_uint64_t_0_8_uint64_t_8_16 _self) SWIFT_NOEXCEPT SWIFT_CALL; // _
+// CHECK-NEXT: // Stub struct to be used to pass/return values to/from Swift functions.
+// CHECK-NEXT: struct swift_interop_returnStub_Generics_uint64_t_0_8_uint64_t_8_16 {
+// CHECK-NEXT:   uint64_t _1;
+// CHECK-NEXT:   uint64_t _2;
+// CHECK-NEXT: };
+// CHECK-EMPTY:
+// CHECK-NEXT: static inline void swift_interop_returnDirect_Generics_uint64_t_0_8_uint64_t_8_16(char * _Nonnull result, struct swift_interop_returnStub_Generics_uint64_t_0_8_uint64_t_8_16 value) __attribute__((always_inline)) {
+// CHECK: }
+
+// CHECK: SWIFT_EXTERN void $s8Generics17inoutConcretePairyys6UInt16V_AA07GenericD0VyA2DGztF(uint16_t x, void * _Nonnull y) SWIFT_NOEXCEPT SWIFT_CALL; // inoutConcretePair(_:_:)
+// CHECK-NEXT: SWIFT_EXTERN void $s8Generics16inoutGenericPairyyAA0cD0Vyxq_Gz_xtr0_lF(void * _Nonnull x, const void * _Nonnull y, void * _Nonnull , void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // inoutGenericPair(_:_:)
+// CHECK-NEXT: SWIFT_EXTERN struct swift_interop_returnStub_Generics_[[PTRPTRENC]] $s8Generics16makeConcretePairyAA07GenericD0Vys6UInt16VAFGAF_AFtF(uint16_t x, uint16_t y) SWIFT_NOEXCEPT SWIFT_CALL; // makeConcretePair(_:_:)
+// CHECK-NEXT: SWIFT_EXTERN struct swift_interop_returnStub_Generics_[[PTRPTRENC]] $s8Generics15makeGenericPairyAA0cD0Vyxq_Gx_q_tr0_lF(const void * _Nonnull x, const void * _Nonnull y, void * _Nonnull , void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // makeGenericPair(_:_:)
+// CHECK-NEXT: SWIFT_EXTERN struct swift_interop_returnStub_Generics_[[PTRPTRENC]] $s8Generics23passThroughConcretePair_1yAA07GenericE0Vys6UInt16VAGGAH_AGtF(struct swift_interop_passStub_Generics_[[PTRPTRENC]] x, uint16_t y) SWIFT_NOEXCEPT SWIFT_CALL; // passThroughConcretePair(_:y:)
+// CHECK-NEXT: SWIFT_EXTERN struct swift_interop_returnStub_Generics_[[PTRPTRENC]] $s8Generics22passThroughGenericPairyAA0dE0Vyxq_GAE_q_tr0_lF(struct swift_interop_passStub_Generics_[[PTRPTRENC]] x, const void * _Nonnull y, void * _Nonnull , void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // passThroughGenericPair(_:_:)
+// CHECK-NEXT: SWIFT_EXTERN void $s8Generics16takeConcretePairyyAA07GenericD0Vys6UInt16VAFGF(struct swift_interop_passStub_Generics_[[PTRPTRENC]] x) SWIFT_NOEXCEPT SWIFT_CALL; // takeConcretePair(_:)
+// CHECK-NEXT: SWIFT_EXTERN void $s8Generics15takeGenericPairyyAA0cD0Vyxq_Gr0_lF(struct swift_interop_passStub_Generics_[[PTRPTRENC]] x, void * _Nonnull , void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // takeGenericPair(_:)
+
+
+// CHECK: template<class T_0_0, class T_0_1>
+// CHECK: template<class T_0_0, class T_0_1>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
+// CHECK-NEXT: class GenericPair final {
+
+// CHECK: swift::_impl::OpaqueStorage _storage;
+// CHECK-NEXT: friend class _impl::_impl_GenericPair<T_0_0, T_0_1>;
+// CHECK-NEXT: }
+
+// CHECK: inline void inoutConcretePair(uint16_t x, GenericPair<uint16_t, uint16_t>& y) noexcept {
+// CHECK-NEXT: return _impl::$s8Generics17inoutConcretePairyys6UInt16V_AA07GenericD0VyA2DGztF(x, _impl::_impl_GenericPair<uint16_t, uint16_t>::getOpaquePointer(y));
+
+
+// CHECK: inline void inoutGenericPair(GenericPair<T_0_0, T_0_1>& x, const T_0_0& y) noexcept {
+// CHECK-NEXT:   return _impl::$s8Generics16inoutGenericPairyyAA0cD0Vyxq_Gz_xtr0_lF(_impl::_impl_GenericPair<T_0_0, T_0_1>::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata());
+
+
+// CHECK: inline GenericPair<uint16_t, uint16_t> makeConcretePair(uint16_t x, uint16_t y) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT:  return _impl::_impl_GenericPair<uint16_t, uint16_t>::returnNewValue([&](char * _Nonnull result) {
+// CHECK-NEXT:    _impl::swift_interop_returnDirect_Generics_[[PTRPTRENC]](result, _impl::$s8Generics16makeConcretePairyAA07GenericD0Vys6UInt16VAFGAF_AFtF(x, y));
+
+// CHECK: inline GenericPair<T_0_0, T_0_1> makeGenericPair(const T_0_0& x, const T_0_1& y) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT:  return _impl::_impl_GenericPair<T_0_0, T_0_1>::returnNewValue([&](char * _Nonnull result) {
+// CHECK-NEXT:    _impl::swift_interop_returnDirect_Generics_[[PTRPTRENC]](result, _impl::$s8Generics15makeGenericPairyAA0cD0Vyxq_Gx_q_tr0_lF(swift::_impl::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata()));
+
+// CHECK: inline GenericPair<uint16_t, uint16_t> passThroughConcretePair(const GenericPair<uint16_t, uint16_t>& x, uint16_t y) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT:  return _impl::_impl_GenericPair<uint16_t, uint16_t>::returnNewValue([&](char * _Nonnull result) {
+// CHECK-NEXT:    _impl::swift_interop_returnDirect_Generics_[[PTRPTRENC]](result, _impl::$s8Generics23passThroughConcretePair_1yAA07GenericE0Vys6UInt16VAGGAH_AGtF(_impl::swift_interop_passDirect_Generics_[[PTRPTRENC]](_impl::_impl_GenericPair<uint16_t, uint16_t>::getOpaquePointer(x)), y));
+
+// CHECK: inline GenericPair<T_0_0, T_0_1> passThroughGenericPair(const GenericPair<T_0_0, T_0_1>& x, const T_0_1& y) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT:  return _impl::_impl_GenericPair<T_0_0, T_0_1>::returnNewValue([&](char * _Nonnull result) {
+// CHECK-NEXT:    _impl::swift_interop_returnDirect_Generics_[[PTRPTRENC]](result, _impl::$s8Generics22passThroughGenericPairyAA0dE0Vyxq_GAE_q_tr0_lF(_impl::swift_interop_passDirect_Generics_[[PTRPTRENC]](_impl::_impl_GenericPair<T_0_0, T_0_1>::getOpaquePointer(x)), swift::_impl::getOpaquePointer(y), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata()));
+
+// CHECK: inline void takeConcretePair(const GenericPair<uint16_t, uint16_t>& x) noexcept {
+// CHECK-NEXT:  return _impl::$s8Generics16takeConcretePairyyAA07GenericD0Vys6UInt16VAFGF(_impl::swift_interop_passDirect_Generics_[[PTRPTRENC]](_impl::_impl_GenericPair<uint16_t, uint16_t>::getOpaquePointer(x)));
+
+
+// CHECK:  inline void takeGenericPair(const GenericPair<T_0_0, T_0_1>& x) noexcept {
+// CHECK-NEXT:  return _impl::$s8Generics15takeGenericPairyyAA0cD0Vyxq_Gr0_lF(_impl::swift_interop_passDirect_Generics_[[PTRPTRENC]](_impl::_impl_GenericPair<T_0_0, T_0_1>::getOpaquePointer(x)), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata());
+
+// CHECK: inline T_0_1 GenericPair<T_0_0, T_0_1>::getY() const {
+// CHECK: _impl::$s8Generics11GenericPairV1yq_vg(reinterpret_cast<void *>(&returnValue), _impl::swift_interop_passDirect_Generics_[[PTRPTRENC]](_getOpaquePointer()), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata());
+
+// CHECK: inline void GenericPair<T_0_0, T_0_1>::setY(const T_0_1& newValue) {
+// CHECK-NEXT: return _impl::$s8Generics11GenericPairV1yq_vs(swift::_impl::getOpaquePointer(newValue), swift::TypeMetadataTrait<GenericPair<T_0_0, T_0_1>>::getTypeMetadata(), _getOpaquePointer());
+
+// CHECK: inline GenericPair<T_0_0, T_0_1> GenericPair<T_0_0, T_0_1>::init(const T_0_0& x, swift::Int i, const T_0_1& y)
+// CHECK-NEXT: return _impl::_impl_GenericPair<T_0_0, T_0_1>::returnNewValue([&](char * _Nonnull result) {
+// CHECK-NEXT: _impl::swift_interop_returnDirect_Generics_[[PTRPTRENC]](result, _impl::$s8Generics11GenericPairVyACyxq_Gx_Siq_tcfC(swift::_impl::getOpaquePointer(x), i, swift::_impl::getOpaquePointer(y), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata()));
+
+// CHECK: inline T_1_0 GenericPair<T_0_0, T_0_1>::genericMethod(const T_1_0& x, const T_0_1& y) const {
+// CHECK: _impl::$s8Generics11GenericPairV13genericMethodyqd__qd___q_tlF(reinterpret_cast<void *>(&returnValue), swift::_impl::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), _impl::swift_interop_passDirect_Generics_[[PTRPTRENC]](_getOpaquePointer()), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata(), swift::TypeMetadataTrait<T_1_0>::getTypeMetadata());

--- a/test/Interop/SwiftToCxx/generics/generic-struct-known-layout-indirect-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-known-layout-indirect-in-cxx.swift
@@ -1,0 +1,22 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %S/generic-struct-in-cxx.swift  -D KNOWN_LAYOUT -D INDIRECT_KNOWN_LAYOUT -typecheck -module-name Generics -clang-header-expose-public-decls -emit-clang-header-path %t/generics.h
+// RUN: %FileCheck %s < %t/generics.h
+// RUN: %check-generic-interop-cxx-header-in-clang(%t/generics.h -Wno-reserved-identifier)
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %S/generic-struct-in-cxx.swift -D KNOWN_LAYOUT -D INDIRECT_KNOWN_LAYOUT -enable-library-evolution -typecheck -module-name Generics -clang-header-expose-public-decls -emit-clang-header-path %t/generics.h
+// RUN: %FileCheck %s < %t/generics.h
+// RUN: %check-generic-interop-cxx-header-in-clang(%t/generics.h -Wno-reserved-identifier)
+
+// CHECK: SWIFT_EXTERN void $s8Generics11GenericPairV1yq_vg(SWIFT_INDIRECT_RESULT void * _Nonnull, void * _Nonnull , SWIFT_CONTEXT const void * _Nonnull _self) SWIFT_NOEXCEPT SWIFT_CALL; // _
+// CHECK-NEXT: SWIFT_EXTERN void $s8Generics11GenericPairV1yq_vs(const void * _Nonnull newValue, void * _Nonnull , SWIFT_CONTEXT void * _Nonnull _self) SWIFT_NOEXCEPT SWIFT_CALL; // _
+// CHECK-NEXT: SWIFT_EXTERN void $s8Generics11GenericPairVyACyxq_Gx_Siq_tcfC(SWIFT_INDIRECT_RESULT void * _Nonnull, const void * _Nonnull x, ptrdiff_t i, const void * _Nonnull y, void * _Nonnull , void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // init(_:_:_:)
+// CHECK-NEXT: SWIFT_EXTERN void $s8Generics11GenericPairV6methodyyF(void * _Nonnull , SWIFT_CONTEXT const void * _Nonnull _self) SWIFT_NOEXCEPT SWIFT_CALL; // method()
+// CHECK-NEXT: SWIFT_EXTERN void $s8Generics11GenericPairV14mutatingMethodyyACyq_xGF(const void * _Nonnull other, void * _Nonnull , SWIFT_CONTEXT void * _Nonnull _self) SWIFT_NOEXCEPT SWIFT_CALL; // mutatingMethod(_:)
+// CHECK-NEXT: SWIFT_EXTERN void $s8Generics11GenericPairV13genericMethodyqd__qd___q_tlF(SWIFT_INDIRECT_RESULT void * _Nonnull, const void * _Nonnull x, const void * _Nonnull y, void * _Nonnull , void * _Nonnull , SWIFT_CONTEXT const void * _Nonnull _self) SWIFT_NOEXCEPT SWIFT_CALL; // genericMethod(_:_:)
+
+
+// CHECK: SWIFT_EXTERN void $s8Generics17inoutConcretePairyys6UInt16V_AA07GenericD0VyA2DGztF(uint16_t x, void * _Nonnull y) SWIFT_NOEXCEPT SWIFT_CALL; // inoutConcretePair(_:_:)
+// CHECK-NEXT: SWIFT_EXTERN void $s8Generics16inoutGenericPairyyAA0cD0Vyxq_Gz_xtr0_lF(void * _Nonnull x, const void * _Nonnull y, void * _Nonnull , void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // inoutGenericPair(_:_:)
+// CHECK-NEXT: SWIFT_EXTERN void $s8Generics16makeConcretePairyAA07GenericD0Vys6UInt16VAFGAF_AFtF(SWIFT_INDIRECT_RESULT void * _Nonnull, uint16_t x, uint16_t y) SWIFT_NOEXCEPT SWIFT_CALL; // makeConcretePair(_:_:)
+// CHECK-NEXT: SWIFT_EXTERN void $s8Generics15makeGenericPairyAA0cD0Vyxq_Gx_q_tr0_lF(SWIFT_INDIRECT_RESULT void * _Nonnull, const void * _Nonnull x, const void * _Nonnull y, void * _Nonnull , void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // makeGenericPair(_:_:)

--- a/test/Interop/SwiftToCxx/generics/resilient-generic-struct-execution-known-layout-direct.cpp
+++ b/test/Interop/SwiftToCxx/generics/resilient-generic-struct-execution-known-layout-direct.cpp
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %S/generic-struct-in-cxx.swift -D KNOWN_LAYOUT -typecheck -enable-library-evolution -module-name Generics -clang-header-expose-public-decls -emit-clang-header-path %t/generics.h
+
+// RUN: %target-interop-build-clangxx -std=gnu++20 -c %s -I %t -o %t/swift-generics-execution.o
+// RUN: %target-interop-build-swift %S/generic-struct-in-cxx.swift -D KNOWN_LAYOUT -o %t/swift-generics-execution -Xlinker %t/swift-generics-execution.o -enable-library-evolution -module-name Generics -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+
+// RUN: %target-codesign %t/swift-generics-execution
+// RUN: %target-run %t/swift-generics-execution | %FileCheck %S/generic-struct-execution-known-layout-direct.cpp
+
+// REQUIRES: executable_test
+
+#include "generic-struct-execution-known-layout-direct.cpp"

--- a/test/Interop/SwiftToCxx/generics/resilient-generic-struct-execution-known-layout-indirect.cpp
+++ b/test/Interop/SwiftToCxx/generics/resilient-generic-struct-execution-known-layout-indirect.cpp
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %S/generic-struct-in-cxx.swift -D KNOWN_LAYOUT -D INDIRECT_KNOWN_LAYOUT -typecheck -enable-library-evolution -module-name Generics -clang-header-expose-public-decls -emit-clang-header-path %t/generics.h
+
+// RUN: %target-interop-build-clangxx -std=gnu++20 -c %s -I %t -o %t/swift-generics-execution.o
+// RUN: %target-interop-build-swift %S/generic-struct-in-cxx.swift -D KNOWN_LAYOUT -D INDIRECT_KNOWN_LAYOUT -o %t/swift-generics-execution -Xlinker %t/swift-generics-execution.o -enable-library-evolution -module-name Generics -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+
+// RUN: %target-codesign %t/swift-generics-execution
+// RUN: %target-run %t/swift-generics-execution | %FileCheck %S/generic-struct-execution-known-layout-indirect.cpp
+
+// REQUIRES: executable_test
+
+#include "generic-struct-execution-known-layout-indirect.cpp"

--- a/test/Interop/SwiftToCxx/initializers/init-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/initializers/init-in-cxx.swift
@@ -5,14 +5,14 @@
 // RUN: %check-interop-cxx-header-in-clang(%t/inits.h -Wno-unused-function)
 
 
-// CHECK:      SWIFT_EXTERN struct swift_interop_stub_Init_FirstSmallStruct $s4Init16FirstSmallStructVACycfC(void) SWIFT_NOEXCEPT SWIFT_CALL; // init()
-// CHECK-NEXT: SWIFT_EXTERN struct swift_interop_stub_Init_FirstSmallStruct $s4Init16FirstSmallStructVyACSicfC(ptrdiff_t x) SWIFT_NOEXCEPT SWIFT_CALL; // init(_:)
+// CHECK:      SWIFT_EXTERN struct swift_interop_returnStub_Init_uint32_t_0_4 $s4Init16FirstSmallStructVACycfC(void) SWIFT_NOEXCEPT SWIFT_CALL; // init()
+// CHECK-NEXT: SWIFT_EXTERN struct swift_interop_returnStub_Init_uint32_t_0_4 $s4Init16FirstSmallStructVyACSicfC(ptrdiff_t x) SWIFT_NOEXCEPT SWIFT_CALL; // init(_:)
 
 // CHECK:      SWIFT_EXTERN void $s4Init11LargeStructVACycfC(SWIFT_INDIRECT_RESULT void * _Nonnull) SWIFT_NOEXCEPT SWIFT_CALL; // init()
-// CHECK-NEXT: SWIFT_EXTERN void $s4Init11LargeStructV1x1yACSi_AA010FirstSmallC0VtcfC(SWIFT_INDIRECT_RESULT void * _Nonnull, ptrdiff_t x, struct swift_interop_stub_Init_FirstSmallStruct y) SWIFT_NOEXCEPT SWIFT_CALL; // init(x:y:)
+// CHECK-NEXT: SWIFT_EXTERN void $s4Init11LargeStructV1x1yACSi_AA010FirstSmallC0VtcfC(SWIFT_INDIRECT_RESULT void * _Nonnull, ptrdiff_t x, struct swift_interop_passStub_Init_uint32_t_0_4 y) SWIFT_NOEXCEPT SWIFT_CALL; // init(x:y:)
 
-// CHECK:      SWIFT_EXTERN struct swift_interop_stub_Init_StructWithRefCountStoredProp $s4Init28StructWithRefCountStoredPropVACycfC(void) SWIFT_NOEXCEPT SWIFT_CALL; // init()
-// CHECK-NEXT: SWIFT_EXTERN struct swift_interop_stub_Init_StructWithRefCountStoredProp $s4Init28StructWithRefCountStoredPropV1xACSi_tcfC(ptrdiff_t x) SWIFT_NOEXCEPT SWIFT_CALL; // init(x:)
+// CHECK:      SWIFT_EXTERN struct swift_interop_returnStub_Init_[[PTRENC:void_ptr_0_[0-9]]] $s4Init28StructWithRefCountStoredPropVACycfC(void) SWIFT_NOEXCEPT SWIFT_CALL; // init()
+// CHECK-NEXT: SWIFT_EXTERN struct swift_interop_returnStub_Init_[[PTRENC]] $s4Init28StructWithRefCountStoredPropV1xACSi_tcfC(ptrdiff_t x) SWIFT_NOEXCEPT SWIFT_CALL; // init(x:)
 
 public struct FirstSmallStruct {
     public let x: UInt32
@@ -95,37 +95,37 @@ public struct StructWithRefCountStoredProp {
 
 
 // CHECK:      inline uint32_t FirstSmallStruct::getX() const {
-// CHECK-NEXT: return _impl::$s4Init16FirstSmallStructV1xs6UInt32Vvg(_impl::swift_interop_passDirect_Init_FirstSmallStruct(_getOpaquePointer()));
+// CHECK-NEXT: return _impl::$s4Init16FirstSmallStructV1xs6UInt32Vvg(_impl::swift_interop_passDirect_Init_uint32_t_0_4(_getOpaquePointer()));
 // CHECK-NEXT: }
 // CHECK-NEXT: inline FirstSmallStruct FirstSmallStruct::init() {
 // CHECK-NEXT: return _impl::_impl_FirstSmallStruct::returnNewValue([&](char * _Nonnull result) {
-// CHECK-NEXT:   _impl::swift_interop_returnDirect_Init_FirstSmallStruct(result, _impl::$s4Init16FirstSmallStructVACycfC());
+// CHECK-NEXT:   _impl::swift_interop_returnDirect_Init_uint32_t_0_4(result, _impl::$s4Init16FirstSmallStructVACycfC());
 // CHECK-NEXT: });
 // CHECK-NEXT: }
 // CHECK-NEXT: inline FirstSmallStruct FirstSmallStruct::init(swift::Int x) {
 // CHECK-NEXT: return _impl::_impl_FirstSmallStruct::returnNewValue([&](char * _Nonnull result) {
-// CHECK-NEXT:   _impl::swift_interop_returnDirect_Init_FirstSmallStruct(result, _impl::$s4Init16FirstSmallStructVyACSicfC(x));
+// CHECK-NEXT:   _impl::swift_interop_returnDirect_Init_uint32_t_0_4(result, _impl::$s4Init16FirstSmallStructVyACSicfC(x));
 // CHECK-NEXT: });
 // CHECK-NEXT: }
 
 // CHECK:      inline LargeStruct LargeStruct::init() {
-// CHECK-NEXT: return _impl::_impl_LargeStruct::returnNewValue([&](void * _Nonnull result) {
+// CHECK-NEXT: return _impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:   _impl::$s4Init11LargeStructVACycfC(result);
 // CHECK-NEXT: });
 // CHECK-NEXT: }
 // CHECK-NEXT: inline LargeStruct LargeStruct::init(swift::Int x, const FirstSmallStruct& y) {
-// CHECK-NEXT: return _impl::_impl_LargeStruct::returnNewValue([&](void * _Nonnull result) {
-// CHECK-NEXT:   _impl::$s4Init11LargeStructV1x1yACSi_AA010FirstSmallC0VtcfC(result, x, _impl::swift_interop_passDirect_Init_FirstSmallStruct(_impl::_impl_FirstSmallStruct::getOpaquePointer(y)));
+// CHECK-NEXT: return _impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) {
+// CHECK-NEXT:   _impl::$s4Init11LargeStructV1x1yACSi_AA010FirstSmallC0VtcfC(result, x, _impl::swift_interop_passDirect_Init_uint32_t_0_4(_impl::_impl_FirstSmallStruct::getOpaquePointer(y)));
 // CHECK-NEXT: });
 // CHECK-NEXT: }
 
 // CHECK:      inline StructWithRefCountStoredProp StructWithRefCountStoredProp::init() {
 // CHECK-NEXT: return _impl::_impl_StructWithRefCountStoredProp::returnNewValue([&](char * _Nonnull result) {
-// CHECK-NEXT:   _impl::swift_interop_returnDirect_Init_StructWithRefCountStoredProp(result, _impl::$s4Init28StructWithRefCountStoredPropVACycfC());
+// CHECK-NEXT:   _impl::swift_interop_returnDirect_Init_[[PTRENC]](result, _impl::$s4Init28StructWithRefCountStoredPropVACycfC());
 // CHECK-NEXT: });
 // CHECK-NEXT: }
 // CHECK-NEXT: inline StructWithRefCountStoredProp StructWithRefCountStoredProp::init(swift::Int x) {
 // CHECK-NEXT: return _impl::_impl_StructWithRefCountStoredProp::returnNewValue([&](char * _Nonnull result) {
-// CHECK-NEXT:   _impl::swift_interop_returnDirect_Init_StructWithRefCountStoredProp(result, _impl::$s4Init28StructWithRefCountStoredPropV1xACSi_tcfC(x));
+// CHECK-NEXT:   _impl::swift_interop_returnDirect_Init_[[PTRENC]](result, _impl::$s4Init28StructWithRefCountStoredPropV1xACSi_tcfC(x));
 // CHECK-NEXT: });
 // CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/methods/method-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/methods/method-in-cxx.swift
@@ -119,7 +119,7 @@ public func createPassStructInClassMethod() -> PassStructInClassMethod {
 // CHECK-NEXT: }
 
 // CHECK:      inline LargeStruct LargeStruct::doubled() const {
-// CHECK-NEXT: return _impl::_impl_LargeStruct::returnNewValue([&](void * _Nonnull result) {
+// CHECK-NEXT: return _impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:   _impl::$s7Methods11LargeStructV7doubledACyF(result, _getOpaquePointer());
 // CHECK-NEXT: });
 // CHECK-NEXT: }
@@ -127,18 +127,18 @@ public func createPassStructInClassMethod() -> PassStructInClassMethod {
 // CHECK-NEXT: return _impl::$s7Methods11LargeStructV4dumpyyF(_getOpaquePointer());
 // CHECK-NEXT: }
 // CHECK-NEXT: inline LargeStruct LargeStruct::scaled(swift::Int x, swift::Int y) const {
-// CHECK-NEXT: return _impl::_impl_LargeStruct::returnNewValue([&](void * _Nonnull result) {
+// CHECK-NEXT: return _impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:   _impl::$s7Methods11LargeStructV6scaledyACSi_SitF(result, x, y, _getOpaquePointer());
 // CHECK-NEXT: });
 // CHECK-NEXT: }
 // CHECK-NEXT: inline LargeStruct LargeStruct::added(const LargeStruct& x) const {
-// CHECK-NEXT: return _impl::_impl_LargeStruct::returnNewValue([&](void * _Nonnull result) {
+// CHECK-NEXT: return _impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:   _impl::$s7Methods11LargeStructV5addedyA2CF(result, _impl::_impl_LargeStruct::getOpaquePointer(x), _getOpaquePointer());
 // CHECK-NEXT: });
 // CHECK-NEXT: }
 
 // CHECK: inline LargeStruct PassStructInClassMethod::retStruct(swift::Int x) {
-// CHECK-NEXT: return _impl::_impl_LargeStruct::returnNewValue([&](void * _Nonnull result) {
+// CHECK-NEXT: return _impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:   _impl::$s7Methods23PassStructInClassMethodC03retC0yAA05LargeC0VSiF(result, x, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT: });
 // CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/methods/mutating-method-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/methods/mutating-method-in-cxx.swift
@@ -52,8 +52,8 @@ public struct SmallStruct {
 // CHECK: SWIFT_EXTERN void $s7Methods11LargeStructV6doubleyyF(SWIFT_CONTEXT void * _Nonnull _self) SWIFT_NOEXCEPT SWIFT_CALL; // double()
 // CHECK: SWIFT_EXTERN void $s7Methods11LargeStructV5scaleyACSi_SitF(SWIFT_INDIRECT_RESULT void * _Nonnull, ptrdiff_t x, ptrdiff_t y, SWIFT_CONTEXT void * _Nonnull _self) SWIFT_NOEXCEPT SWIFT_CALL; // scale(_:_:)
 
-// CHECK: SWIFT_EXTERN void $s7Methods11SmallStructV4dumpyyF(struct swift_interop_stub_Methods_SmallStruct _self) SWIFT_NOEXCEPT SWIFT_CALL; // dump()
-// CHECK: SWIFT_EXTERN struct swift_interop_stub_Methods_SmallStruct $s7Methods11SmallStructV5scaleyACSfF(float y, SWIFT_CONTEXT void * _Nonnull _self) SWIFT_NOEXCEPT SWIFT_CALL; // scale(_:)
+// CHECK: SWIFT_EXTERN void $s7Methods11SmallStructV4dumpyyF(struct swift_interop_passStub_Methods_float_0_4 _self) SWIFT_NOEXCEPT SWIFT_CALL; // dump()
+// CHECK: SWIFT_EXTERN struct swift_interop_returnStub_Methods_float_0_4 $s7Methods11SmallStructV5scaleyACSfF(float y, SWIFT_CONTEXT void * _Nonnull _self) SWIFT_NOEXCEPT SWIFT_CALL; // scale(_:)
 // CHECK: SWIFT_EXTERN void $s7Methods11SmallStructV6invertyyF(SWIFT_CONTEXT void * _Nonnull _self) SWIFT_NOEXCEPT SWIFT_CALL; // invert()
 
 // CHECK: class LargeStruct final {
@@ -86,17 +86,17 @@ public func createSmallStruct(x: Float) -> SmallStruct {
 // CHECK-NEXT:   return _impl::$s7Methods11LargeStructV6doubleyyF(_getOpaquePointer());
 // CHECK-NEXT:   }
 // CHECK-NEXT:   inline LargeStruct LargeStruct::scale(swift::Int x, swift::Int y) {
-// CHECK-NEXT:   return _impl::_impl_LargeStruct::returnNewValue([&](void * _Nonnull result) {
+// CHECK-NEXT:   return _impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:     _impl::$s7Methods11LargeStructV5scaleyACSi_SitF(result, x, y, _getOpaquePointer());
 // CHECK-NEXT:   });
 // CHECK-NEXT:   }
 
 // CHECK:        inline void SmallStruct::dump() const {
-// CHECK-NEXT:   return _impl::$s7Methods11SmallStructV4dumpyyF(_impl::swift_interop_passDirect_Methods_SmallStruct(_getOpaquePointer()));
+// CHECK-NEXT:   return _impl::$s7Methods11SmallStructV4dumpyyF(_impl::swift_interop_passDirect_Methods_float_0_4(_getOpaquePointer()));
 // CHECK-NEXT:   }
 // CHECK-NEXT:   inline SmallStruct SmallStruct::scale(float y) {
 // CHECK-NEXT:   return _impl::_impl_SmallStruct::returnNewValue([&](char * _Nonnull result) {
-// CHECK-NEXT:     _impl::swift_interop_returnDirect_Methods_SmallStruct(result, _impl::$s7Methods11SmallStructV5scaleyACSfF(y, _getOpaquePointer()));
+// CHECK-NEXT:     _impl::swift_interop_returnDirect_Methods_float_0_4(result, _impl::$s7Methods11SmallStructV5scaleyACSfF(y, _getOpaquePointer()));
 // CHECK-NEXT:   });
 // CHECK-NEXT:   }
 // CHECK-NEXT:   inline void SmallStruct::invert() {

--- a/test/Interop/SwiftToCxx/properties/getter-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/properties/getter-in-cxx.swift
@@ -122,7 +122,7 @@ public func createStructWithRefCountStoredProp() -> StructWithRefCountStoredProp
 }
 
 // CHECK: inline uint32_t FirstSmallStruct::getX() const {
-// CHECK-NEXT: return _impl::$s10Properties16FirstSmallStructV1xs6UInt32Vvg(_impl::swift_interop_passDirect_Properties_FirstSmallStruct(_getOpaquePointer()));
+// CHECK-NEXT: return _impl::$s10Properties16FirstSmallStructV1xs6UInt32Vvg(_impl::swift_interop_passDirect_Properties_uint32_t_0_4(_getOpaquePointer()));
 // CHECK-NEXT: }
 
 // CHECK:      inline swift::Int LargeStruct::getX1() const {
@@ -144,13 +144,13 @@ public func createStructWithRefCountStoredProp() -> StructWithRefCountStoredProp
 // CHECK-NEXT: return _impl::$s10Properties11LargeStructV2x6Sivg(_getOpaquePointer());
 // CHECK-NEXT: }
 // CHECK-NEXT: inline LargeStruct LargeStruct::getAnotherLargeStruct() const {
-// CHECK-NEXT: return _impl::_impl_LargeStruct::returnNewValue([&](void * _Nonnull result) {
+// CHECK-NEXT: return _impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:   _impl::$s10Properties11LargeStructV07anotherbC0ACvg(result, _getOpaquePointer());
 // CHECK-NEXT: });
 // CHECK-NEXT: }
 // CHECK-NEXT: inline FirstSmallStruct LargeStruct::getFirstSmallStruct() const {
 // CHECK-NEXT: return _impl::_impl_FirstSmallStruct::returnNewValue([&](char * _Nonnull result) {
-// CHECK-NEXT:   _impl::swift_interop_returnDirect_Properties_FirstSmallStruct(result, _impl::$s10Properties11LargeStructV010firstSmallC0AA05FirsteC0Vvg(_getOpaquePointer()));
+// CHECK-NEXT:   _impl::swift_interop_returnDirect_Properties_uint32_t_0_4(result, _impl::$s10Properties11LargeStructV010firstSmallC0AA05FirsteC0Vvg(_getOpaquePointer()));
 // CHECK-NEXT: });
 // CHECK-NEXT: }
 
@@ -162,23 +162,23 @@ public func createStructWithRefCountStoredProp() -> StructWithRefCountStoredProp
 // CHECK-NEXT: }
 // CHECK-NEXT: inline FirstSmallStruct PropertiesInClass::getSmallStruct() {
 // CHECK-NEXT: return _impl::_impl_FirstSmallStruct::returnNewValue([&](char * _Nonnull result) {
-// CHECK-NEXT:   _impl::swift_interop_returnDirect_Properties_FirstSmallStruct(result, _impl::$s10Properties0A7InClassC11smallStructAA010FirstSmallE0Vvg(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this)));
+// CHECK-NEXT:   _impl::swift_interop_returnDirect_Properties_uint32_t_0_4(result, _impl::$s10Properties0A7InClassC11smallStructAA010FirstSmallE0Vvg(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this)));
 // CHECK-NEXT: });
 // CHECK-NEXT: }
 
 // CHECK:      inline uint32_t SmallStructWithGetters::getStoredInt() const {
-// CHECK-NEXT: return _impl::$s10Properties22SmallStructWithGettersV9storedInts6UInt32Vvg(_impl::swift_interop_passDirect_Properties_SmallStructWithGetters(_getOpaquePointer()));
+// CHECK-NEXT: return _impl::$s10Properties22SmallStructWithGettersV9storedInts6UInt32Vvg(_impl::swift_interop_passDirect_Properties_uint32_t_0_4(_getOpaquePointer()));
 // CHECK-NEXT: }
 // CHECK-NEXT: inline swift::Int SmallStructWithGetters::getComputedInt() const {
-// CHECK-NEXT: return _impl::$s10Properties22SmallStructWithGettersV11computedIntSivg(_impl::swift_interop_passDirect_Properties_SmallStructWithGetters(_getOpaquePointer()));
+// CHECK-NEXT: return _impl::$s10Properties22SmallStructWithGettersV11computedIntSivg(_impl::swift_interop_passDirect_Properties_uint32_t_0_4(_getOpaquePointer()));
 // CHECK-NEXT: }
 // CHECK-NEXT: inline LargeStruct SmallStructWithGetters::getLargeStruct() const {
-// CHECK-NEXT: return _impl::_impl_LargeStruct::returnNewValue([&](void * _Nonnull result) {
-// CHECK-NEXT:   _impl::$s10Properties22SmallStructWithGettersV05largeC0AA05LargeC0Vvg(result, _impl::swift_interop_passDirect_Properties_SmallStructWithGetters(_getOpaquePointer()));
+// CHECK-NEXT: return _impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) {
+// CHECK-NEXT:   _impl::$s10Properties22SmallStructWithGettersV05largeC0AA05LargeC0Vvg(result, _impl::swift_interop_passDirect_Properties_uint32_t_0_4(_getOpaquePointer()));
 // CHECK-NEXT: });
 // CHECK-NEXT: }
 // CHECK-NEXT: inline SmallStructWithGetters SmallStructWithGetters::getSmallStruct() const {
 // CHECK-NEXT: return _impl::_impl_SmallStructWithGetters::returnNewValue([&](char * _Nonnull result) {
-// CHECK-NEXT:   _impl::swift_interop_returnDirect_Properties_SmallStructWithGetters(result, _impl::$s10Properties22SmallStructWithGettersV05smallC0ACvg(_impl::swift_interop_passDirect_Properties_SmallStructWithGetters(_getOpaquePointer())));
+// CHECK-NEXT:   _impl::swift_interop_returnDirect_Properties_uint32_t_0_4(result, _impl::$s10Properties22SmallStructWithGettersV05smallC0ACvg(_impl::swift_interop_passDirect_Properties_uint32_t_0_4(_getOpaquePointer())));
 // CHECK-NEXT: });
 // CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/properties/setter-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/properties/setter-in-cxx.swift
@@ -115,7 +115,7 @@ public func createFirstSmallStruct(_ x: UInt32) -> FirstSmallStruct {
 }
 
 // CHECK: inline uint32_t FirstSmallStruct::getX() const {
-// CHECK-NEXT: return _impl::$s10Properties16FirstSmallStructV1xs6UInt32Vvg(_impl::swift_interop_passDirect_Properties_FirstSmallStruct(_getOpaquePointer()));
+// CHECK-NEXT: return _impl::$s10Properties16FirstSmallStructV1xs6UInt32Vvg(_impl::swift_interop_passDirect_Properties_uint32_t_0_4(_getOpaquePointer()));
 // CHECK-NEXT: }
 // CHECK-NEXT: inline void FirstSmallStruct::setX(uint32_t value) {
 // CHECK-NEXT: return _impl::$s10Properties16FirstSmallStructV1xs6UInt32Vvs(value, _getOpaquePointer());
@@ -129,7 +129,7 @@ public func createFirstSmallStruct(_ x: UInt32) -> FirstSmallStruct {
 // CHECK-NEXT:   }
 
 // CHECK:        inline LargeStruct LargeStructWithProps::getStoredLargeStruct() const {
-// CHECK-NEXT:    return _impl::_impl_LargeStruct::returnNewValue([&](void * _Nonnull result) {
+// CHECK-NEXT:    return _impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:     _impl::$s10Properties20LargeStructWithPropsV06storedbC0AA0bC0Vvg(result, _getOpaquePointer());
 // CHECK-NEXT:   });
 // CHECK-NEXT:   }
@@ -138,11 +138,11 @@ public func createFirstSmallStruct(_ x: UInt32) -> FirstSmallStruct {
 // CHECK-NEXT:   }
 // CHECK-NEXT:   inline FirstSmallStruct LargeStructWithProps::getStoredSmallStruct() const {
 // CHECK-NEXT:   return _impl::_impl_FirstSmallStruct::returnNewValue([&](char * _Nonnull result) {
-// CHECK-NEXT:     _impl::swift_interop_returnDirect_Properties_FirstSmallStruct(result, _impl::$s10Properties20LargeStructWithPropsV011storedSmallC0AA05FirstgC0Vvg(_getOpaquePointer()));
+// CHECK-NEXT:     _impl::swift_interop_returnDirect_Properties_uint32_t_0_4(result, _impl::$s10Properties20LargeStructWithPropsV011storedSmallC0AA05FirstgC0Vvg(_getOpaquePointer()));
 // CHECK-NEXT:   });
 // CHECK-NEXT:   }
 // CHECK-NEXT:   inline void LargeStructWithProps::setStoredSmallStruct(const FirstSmallStruct& value) {
-// CHECK-NEXT:   return _impl::$s10Properties20LargeStructWithPropsV011storedSmallC0AA05FirstgC0Vvs(_impl::swift_interop_passDirect_Properties_FirstSmallStruct(_impl::_impl_FirstSmallStruct::getOpaquePointer(value)), _getOpaquePointer());
+// CHECK-NEXT:   return _impl::$s10Properties20LargeStructWithPropsV011storedSmallC0AA05FirstgC0Vvs(_impl::swift_interop_passDirect_Properties_uint32_t_0_4(_impl::_impl_FirstSmallStruct::getOpaquePointer(value)), _getOpaquePointer());
 // CHECK-NEXT:   }
 
 // CHECK: inline int32_t PropertiesInClass::getStoredInt() {
@@ -159,20 +159,20 @@ public func createFirstSmallStruct(_ x: UInt32) -> FirstSmallStruct {
 // CHECK-NEXT: }
 
 // CHECK:        inline uint32_t SmallStructWithProps::getStoredInt() const {
-// CHECK-NEXT:  return _impl::$s10Properties20SmallStructWithPropsV9storedInts6UInt32Vvg(_impl::swift_interop_passDirect_Properties_SmallStructWithProps(_getOpaquePointer()));
+// CHECK-NEXT:  return _impl::$s10Properties20SmallStructWithPropsV9storedInts6UInt32Vvg(_impl::swift_interop_passDirect_Properties_uint32_t_0_4(_getOpaquePointer()));
 // CHECK-NEXT:  }
 // CHECK-NEXT:  inline void SmallStructWithProps::setStoredInt(uint32_t value) {
 // CHECK-NEXT:  return _impl::$s10Properties20SmallStructWithPropsV9storedInts6UInt32Vvs(value, _getOpaquePointer());
 // CHECK-NEXT:  }
 // CHECK-NEXT:  inline swift::Int SmallStructWithProps::getComputedInt() const {
-// CHECK-NEXT:  return _impl::$s10Properties20SmallStructWithPropsV11computedIntSivg(_impl::swift_interop_passDirect_Properties_SmallStructWithProps(_getOpaquePointer()));
+// CHECK-NEXT:  return _impl::$s10Properties20SmallStructWithPropsV11computedIntSivg(_impl::swift_interop_passDirect_Properties_uint32_t_0_4(_getOpaquePointer()));
 // CHECK-NEXT:  }
 // CHECK-NEXT:  inline void SmallStructWithProps::setComputedInt(swift::Int newValue) {
 // CHECK-NEXT:  return _impl::$s10Properties20SmallStructWithPropsV11computedIntSivs(newValue, _getOpaquePointer());
 // CHECK-NEXT:  }
 // CHECK-NEXT:  inline LargeStructWithProps SmallStructWithProps::getLargeStructWithProps() const {
-// CHECK-NEXT:  return _impl::_impl_LargeStructWithProps::returnNewValue([&](void * _Nonnull result) {
-// CHECK-NEXT:    _impl::$s10Properties20SmallStructWithPropsV05largecdE0AA05LargecdE0Vvg(result, _impl::swift_interop_passDirect_Properties_SmallStructWithProps(_getOpaquePointer()));
+// CHECK-NEXT:  return _impl::_impl_LargeStructWithProps::returnNewValue([&](char * _Nonnull result) {
+// CHECK-NEXT:    _impl::$s10Properties20SmallStructWithPropsV05largecdE0AA05LargecdE0Vvg(result, _impl::swift_interop_passDirect_Properties_uint32_t_0_4(_getOpaquePointer()));
 // CHECK-NEXT:  });
 // CHECK-NEXT:  }
 // CHECK-NEXT:  inline void SmallStructWithProps::setLargeStructWithProps(const LargeStructWithProps& newValue) {

--- a/test/Interop/SwiftToCxx/structs/large-structs-pass-return-indirect-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/large-structs-pass-return-indirect-in-cxx.swift
@@ -37,7 +37,7 @@ public func inoutStructSeveralI64(_ s: inout StructSeveralI64) {
 
 
 // CHECK: inline StructSeveralI64 passThroughStructSeveralI64(int64_t i, const StructSeveralI64& x, float j) noexcept SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:  return _impl::_impl_StructSeveralI64::returnNewValue([&](void * _Nonnull result) {
+// CHECK-NEXT:  return _impl::_impl_StructSeveralI64::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:    _impl::$s7Structs27passThroughStructSeveralI641i_1jAA0deF0Vs5Int64V_AFSftF(result, i, _impl::_impl_StructSeveralI64::getOpaquePointer(x), j);
 // CHECK-NEXT:  });
 // CHECK-NEXT: }
@@ -49,7 +49,7 @@ public func inoutStructSeveralI64(_ s: inout StructSeveralI64) {
 
 
 // CHECK: inline StructSeveralI64 returnNewStructSeveralI64(int64_t i) noexcept SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:  return _impl::_impl_StructSeveralI64::returnNewValue([&](void * _Nonnull result) {
+// CHECK-NEXT:  return _impl::_impl_StructSeveralI64::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:    _impl::$s7Structs25returnNewStructSeveralI641iAA0deF0Vs5Int64V_tF(result, i);
 // CHECK-NEXT:  });
 // CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/structs/resilient-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/resilient-struct-in-cxx.swift
@@ -194,13 +194,13 @@ public func mutateSmall(_ x: inout FirstSmallStruct) {
 }
 
 // CHECK:      inline LargeStruct createLargeStruct(swift::Int x) noexcept SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::_impl_LargeStruct::returnNewValue([&](void * _Nonnull result) {
+// CHECK-NEXT:   return _impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:     _impl::$s7Structs17createLargeStructyAA0cD0VSiF(result, x);
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
 // CHECK:      inline StructWithRefCountStoredProp createStructWithRefCountStoredProp() noexcept SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:   return _impl::_impl_StructWithRefCountStoredProp::returnNewValue([&](void * _Nonnull result) {
+// CHECK-NEXT:   return _impl::_impl_StructWithRefCountStoredProp::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:     _impl::$s7Structs34createStructWithRefCountStoredPropAA0cdefgH0VyF(result);
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
@@ -230,7 +230,7 @@ public func mutateSmall(_ x: inout FirstSmallStruct) {
 // CHECK-NEXT: return _impl::$s7Structs11LargeStructV2x1Sivg(_getOpaquePointer());
 // CHECK-NEXT: }
 // CHECK-NEXT: inline FirstSmallStruct LargeStruct::getFirstSmallStruct() const {
-// CHECK-NEXT: return _impl::_impl_FirstSmallStruct::returnNewValue([&](void * _Nonnull result) {
+// CHECK-NEXT: return _impl::_impl_FirstSmallStruct::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:   _impl::$s7Structs11LargeStructV010firstSmallC0AA05FirsteC0Vvg(result, _getOpaquePointer());
 // CHECK-NEXT: });
 // CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/structs/small-structs-pass-return-direct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/small-structs-pass-return-direct-in-cxx.swift
@@ -31,8 +31,8 @@ public struct StructDoubleAndFloat {
     var y: Float
 }
 
-// CHECK: SWIFT_EXTERN void $s7Structs25inoutStructDoubleAndFloatyyAA0cdeF0VzF(char * _Nonnull s) SWIFT_NOEXCEPT SWIFT_CALL; // inoutStructDoubleAndFloat(_:)
-// CHECK: SWIFT_EXTERN void $s7Structs020inoutStructOneI16AnddC0yyAA0cdefdC0Vz_AA0C6TwoI32VtF(char * _Nonnull s, struct swift_interop_stub_Structs_StructTwoI32 s2) SWIFT_NOEXCEPT SWIFT_CALL; // inoutStructOneI16AndOneStruct(_:_:)
+// CHECK: SWIFT_EXTERN void $s7Structs25inoutStructDoubleAndFloatyyAA0cdeF0VzF(void * _Nonnull s) SWIFT_NOEXCEPT SWIFT_CALL; // inoutStructDoubleAndFloat(_:)
+// CHECK: SWIFT_EXTERN void $s7Structs020inoutStructOneI16AnddC0yyAA0cdefdC0Vz_AA0C6TwoI32VtF(void * _Nonnull s, struct swift_interop_passStub_Structs_[[StructTwoI32:[0-9a-z_]+]] s2) SWIFT_NOEXCEPT SWIFT_CALL; // inoutStructOneI16AndOneStruct(_:_:)
 
 // CHECK: class StructDoubleAndFloat final {
 
@@ -113,22 +113,22 @@ public func inoutStructDoubleAndFloat(_ s: inout StructDoubleAndFloat) {
 }
 
 // CHECK: inline double getStructDoubleAndFloat_x(const StructDoubleAndFloat& x) noexcept SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:  return _impl::$s7Structs25getStructDoubleAndFloat_xySdAA0cdeF0VF(_impl::swift_interop_passDirect_Structs_StructDoubleAndFloat(_impl::_impl_StructDoubleAndFloat::getOpaquePointer(x)));
+// CHECK-NEXT:  return _impl::$s7Structs25getStructDoubleAndFloat_xySdAA0cdeF0VF(_impl::swift_interop_passDirect_Structs_double_0_8_float_8_12(_impl::_impl_StructDoubleAndFloat::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
 
 // CHECK: inline float getStructDoubleAndFloat_y(const StructDoubleAndFloat& x) noexcept SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:  return _impl::$s7Structs25getStructDoubleAndFloat_yySfAA0cdeF0VF(_impl::swift_interop_passDirect_Structs_StructDoubleAndFloat(_impl::_impl_StructDoubleAndFloat::getOpaquePointer(x)));
+// CHECK-NEXT:  return _impl::$s7Structs25getStructDoubleAndFloat_yySfAA0cdeF0VF(_impl::swift_interop_passDirect_Structs_double_0_8_float_8_12(_impl::_impl_StructDoubleAndFloat::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
 
 // CHECK: inline uint8_t getStructU16AndPointer_x(const StructU16AndPointer& x) noexcept SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:  return _impl::$s7Structs24getStructU16AndPointer_xys5UInt8VAA0cdeF0VF(_impl::swift_interop_passDirect_Structs_StructU16AndPointer(_impl::_impl_StructU16AndPointer::getOpaquePointer(x)));
+// CHECK-NEXT:  return _impl::$s7Structs24getStructU16AndPointer_xys5UInt8VAA0cdeF0VF(_impl::swift_interop_passDirect_Structs_[[StructU16AndPointer:[0-9a-z_]+]](_impl::_impl_StructU16AndPointer::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
 
 // CHECK: inline void * _Nonnull getStructU16AndPointer_y(const StructU16AndPointer& x) noexcept SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT:  return _impl::$s7Structs24getStructU16AndPointer_yySvAA0cdeF0VF(_impl::swift_interop_passDirect_Structs_StructU16AndPointer(_impl::_impl_StructU16AndPointer::getOpaquePointer(x)));
+// CHECK-NEXT:  return _impl::$s7Structs24getStructU16AndPointer_yySvAA0cdeF0VF(_impl::swift_interop_passDirect_Structs_[[StructU16AndPointer]](_impl::_impl_StructU16AndPointer::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
 
@@ -138,69 +138,69 @@ public func inoutStructDoubleAndFloat(_ s: inout StructDoubleAndFloat) {
 
 
 // CHECK:      inline void inoutStructOneI16AndOneStruct(StructOneI16AndOneStruct& s, const StructTwoI32& s2) noexcept {
-// CHECK-NEXT:   return _impl::$s7Structs020inoutStructOneI16AnddC0yyAA0cdefdC0Vz_AA0C6TwoI32VtF(_impl::_impl_StructOneI16AndOneStruct::getOpaquePointer(s), _impl::swift_interop_passDirect_Structs_StructTwoI32(_impl::_impl_StructTwoI32::getOpaquePointer(s2)));
+// CHECK-NEXT:   return _impl::$s7Structs020inoutStructOneI16AnddC0yyAA0cdefdC0Vz_AA0C6TwoI32VtF(_impl::_impl_StructOneI16AndOneStruct::getOpaquePointer(s), _impl::swift_interop_passDirect_Structs_[[StructTwoI32]](_impl::_impl_StructTwoI32::getOpaquePointer(s2)));
 // CHECK-NEXT: }
 
 
 // CHECK: inline StructOneI64 passThroughStructOneI64(const StructOneI64& x) noexcept SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return _impl::_impl_StructOneI64::returnNewValue([&](char * _Nonnull result) {
-// CHECK-NEXT:    _impl::swift_interop_returnDirect_Structs_StructOneI64(result, _impl::$s7Structs23passThroughStructOneI64yAA0deF0VADF(_impl::swift_interop_passDirect_Structs_StructOneI64(_impl::_impl_StructOneI64::getOpaquePointer(x))));
+// CHECK-NEXT:    _impl::swift_interop_returnDirect_Structs_uint64_t_0_8(result, _impl::$s7Structs23passThroughStructOneI64yAA0deF0VADF(_impl::swift_interop_passDirect_Structs_uint64_t_0_8(_impl::_impl_StructOneI64::getOpaquePointer(x))));
 // CHECK-NEXT:  });
 // CHECK-NEXT: }
 
 
 // CHECK: inline StructTwoI32 passThroughStructTwoI32(int32_t i, const StructTwoI32& x, int32_t j) noexcept SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return _impl::_impl_StructTwoI32::returnNewValue([&](char * _Nonnull result) {
-// CHECK-NEXT:    _impl::swift_interop_returnDirect_Structs_StructTwoI32(result, _impl::$s7Structs23passThroughStructTwoI32yAA0deF0Vs5Int32V_AdFtF(i, _impl::swift_interop_passDirect_Structs_StructTwoI32(_impl::_impl_StructTwoI32::getOpaquePointer(x)), j));
+// CHECK-NEXT:    _impl::swift_interop_returnDirect_Structs_[[StructTwoI32]](result, _impl::$s7Structs23passThroughStructTwoI32yAA0deF0Vs5Int32V_AdFtF(i, _impl::swift_interop_passDirect_Structs_[[StructTwoI32]](_impl::_impl_StructTwoI32::getOpaquePointer(x)), j));
 // CHECK-NEXT:  });
 // CHECK-NEXT: }
 
 
 // CHECK: inline void printStructOneI64(const StructOneI64& x) noexcept {
-// CHECK-NEXT:  return _impl::$s7Structs17printStructOneI64yyAA0cdE0VF(_impl::swift_interop_passDirect_Structs_StructOneI64(_impl::_impl_StructOneI64::getOpaquePointer(x)));
+// CHECK-NEXT:  return _impl::$s7Structs17printStructOneI64yyAA0cdE0VF(_impl::swift_interop_passDirect_Structs_uint64_t_0_8(_impl::_impl_StructOneI64::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
 
 // CHECK: inline void printStructStructTwoI32_and_OneI16AndOneStruct(const StructTwoI32& y, const StructOneI16AndOneStruct& x) noexcept {
-// CHECK-NEXT:  return _impl::$s7Structs011printStructc20TwoI32_and_OneI16AndgC0yyAA0cdE0V_AA0cghigC0VtF(_impl::swift_interop_passDirect_Structs_StructTwoI32(_impl::_impl_StructTwoI32::getOpaquePointer(y)), _impl::swift_interop_passDirect_Structs_StructOneI16AndOneStruct(_impl::_impl_StructOneI16AndOneStruct::getOpaquePointer(x)));
+// CHECK-NEXT:  return _impl::$s7Structs011printStructc20TwoI32_and_OneI16AndgC0yyAA0cdE0V_AA0cghigC0VtF(_impl::swift_interop_passDirect_Structs_[[StructTwoI32]](_impl::_impl_StructTwoI32::getOpaquePointer(y)), _impl::swift_interop_passDirect_Structs_[[StructOneI16AndOneStruct:[0-9a-z_]+]](_impl::_impl_StructOneI16AndOneStruct::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
 
 // CHECK: inline void printStructTwoI32(const StructTwoI32& x) noexcept {
-// CHECK-NEXT:  return _impl::$s7Structs17printStructTwoI32yyAA0cdE0VF(_impl::swift_interop_passDirect_Structs_StructTwoI32(_impl::_impl_StructTwoI32::getOpaquePointer(x)));
+// CHECK-NEXT:  return _impl::$s7Structs17printStructTwoI32yyAA0cdE0VF(_impl::swift_interop_passDirect_Structs_[[StructTwoI32]](_impl::_impl_StructTwoI32::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
 
 // CHECK: inline StructDoubleAndFloat returnNewStructDoubleAndFloat(float y, double x) noexcept SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return _impl::_impl_StructDoubleAndFloat::returnNewValue([&](char * _Nonnull result) {
-// CHECK-NEXT:    _impl::swift_interop_returnDirect_Structs_StructDoubleAndFloat(result, _impl::$s7Structs29returnNewStructDoubleAndFloatyAA0defG0VSf_SdtF(y, x));
+// CHECK-NEXT:    _impl::swift_interop_returnDirect_Structs_double_0_8_float_8_12(result, _impl::$s7Structs29returnNewStructDoubleAndFloatyAA0defG0VSf_SdtF(y, x));
 // CHECK-NEXT:  });
 // CHECK-NEXT: }
 
 
 // CHECK: inline StructOneI16AndOneStruct returnNewStructOneI16AndOneStruct() noexcept SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return _impl::_impl_StructOneI16AndOneStruct::returnNewValue([&](char * _Nonnull result) {
-// CHECK-NEXT:    _impl::swift_interop_returnDirect_Structs_StructOneI16AndOneStruct(result, _impl::$s7Structs024returnNewStructOneI16AndeD0AA0defgeD0VyF());
+// CHECK-NEXT:    _impl::swift_interop_returnDirect_Structs_[[StructOneI16AndOneStruct]](result, _impl::$s7Structs024returnNewStructOneI16AndeD0AA0defgeD0VyF());
 // CHECK-NEXT:  });
 // CHECK-NEXT: }
 
 
 // CHECK: inline StructOneI64 returnNewStructOneI64() noexcept SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return _impl::_impl_StructOneI64::returnNewValue([&](char * _Nonnull result) {
-// CHECK-NEXT:    _impl::swift_interop_returnDirect_Structs_StructOneI64(result, _impl::$s7Structs21returnNewStructOneI64AA0deF0VyF());
+// CHECK-NEXT:    _impl::swift_interop_returnDirect_Structs_uint64_t_0_8(result, _impl::$s7Structs21returnNewStructOneI64AA0deF0VyF());
 // CHECK-NEXT:  });
 // CHECK-NEXT: }
 
 
 // CHECK: inline StructTwoI32 returnNewStructTwoI32(int32_t x) noexcept SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return _impl::_impl_StructTwoI32::returnNewValue([&](char * _Nonnull result) {
-// CHECK-NEXT:    _impl::swift_interop_returnDirect_Structs_StructTwoI32(result, _impl::$s7Structs21returnNewStructTwoI32yAA0deF0Vs5Int32VF(x));
+// CHECK-NEXT:    _impl::swift_interop_returnDirect_Structs_[[StructTwoI32]](result, _impl::$s7Structs21returnNewStructTwoI32yAA0deF0Vs5Int32VF(x));
 // CHECK-NEXT:  });
 // CHECK-NEXT: }
 
 
 // CHECK: inline StructU16AndPointer returnNewStructU16AndPointer(void * _Nonnull x) noexcept SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return _impl::_impl_StructU16AndPointer::returnNewValue([&](char * _Nonnull result) {
-// CHECK-NEXT:    _impl::swift_interop_returnDirect_Structs_StructU16AndPointer(result, _impl::$s7Structs28returnNewStructU16AndPointeryAA0defG0VSvF(x));
+// CHECK-NEXT:    _impl::swift_interop_returnDirect_Structs_[[StructU16AndPointer]](result, _impl::$s7Structs28returnNewStructU16AndPointeryAA0defG0VSvF(x));
 // CHECK-NEXT:  });
 // CHECK-NEXT: }


### PR DESCRIPTION
…inguish between direct/indirect return values and parameters

This is required to pass and return a generic type with known layout, like `Array<T>` correctly. This also fixes a bunch of other soundness holes, and sets us up for future handling of multiple return values and lambdas.