### PR TITLE
Set stdlib source dir in non stdlib builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1185,6 +1185,7 @@ endif()
 if(SWIFT_BUILD_STDLIB)
   add_subdirectory(stdlib)
 else()
+  set(SWIFT_STDLIB_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/stdlib")
   # Some of the things below depend on the threading library
   add_subdirectory(stdlib/public/Threading)
 


### PR DESCRIPTION
Not all configurations add the stdlib directly, resulting in the `SWIFT_STDLIB_SOURCE_DIR` not getting set. In the case where we jump straight to a directory within the stdlib, skipping the actual stdlib itself, we still need this variable set.

rdar://99644429