### PR TITLE
Break dependency cycle between `@objc` checking and and "renamed" availability

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1741,15 +1741,6 @@ shouldDiagnoseConflict(NominalTypeDecl *ty, AbstractFunctionDecl *newDecl,
   }))
     return false;
 
-  // If we're looking at protocol requirements, is the new method an async
-  // alternative of any existing method, or vice versa?
-  if (isa<ProtocolDecl>(ty) &&
-      llvm::any_of(vec, [&](AbstractFunctionDecl *oldDecl) {
-    return newDecl->getAsyncAlternative(/*isKnownObjC=*/true) == oldDecl
-              || oldDecl->getAsyncAlternative(/*isKnownObjC=*/true) == newDecl;
-  }))
-    return false;
-
   return true;
 }
 

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -2448,11 +2448,26 @@ getObjCMethodConflictDecls(const SourceFile::ObjCMethodConflict &conflict) {
   auto methods = conflict.typeDecl->lookupDirect(conflict.selector,
                                                  conflict.isInstanceMethod);
 
+  // Find async alternatives for each.
+  llvm::SmallDenseMap<AbstractFunctionDecl *, AbstractFunctionDecl *>
+    asyncAlternatives;
+  for (auto method : methods) {
+    if (isa<ProtocolDecl>(method->getDeclContext())) {
+      if (auto alt = method->getAsyncAlternative(/*isKnownObjC=*/true))
+        asyncAlternatives[method] = alt;
+    }
+  }
+
   // Erase any invalid or stub declarations. We don't want to complain about
   // them, because we might already have complained about redeclarations
   // based on Swift matching.
-  llvm::erase_if(methods, [](AbstractFunctionDecl *afd) -> bool {
+  llvm::erase_if(methods,
+                 [&asyncAlternatives](AbstractFunctionDecl *afd) -> bool {
     if (afd->isInvalid())
+      return true;
+
+    // If there is an async alternative, remove this entry.
+    if (asyncAlternatives.count(afd))
       return true;
 
     if (auto ad = dyn_cast<AccessorDecl>(afd))
@@ -2462,6 +2477,7 @@ getObjCMethodConflictDecls(const SourceFile::ObjCMethodConflict &conflict) {
       if (ctor->hasStubImplementation())
         return true;
     }
+
     return false;
   });
 

--- a/test/decl/objc_redeclaration.swift
+++ b/test/decl/objc_redeclaration.swift
@@ -66,5 +66,16 @@ extension MyObject {
     public override convenience init() {} // expected-error{{initializer 'init()' with Objective-C selector 'init' conflicts with implicit initializer 'init()' with the same Objective-C selector}}
 }
 
+// Ensure that we don't have cycles with the "renamed decl" request.
+@available(SwiftStdlib 5.1, *)
+@objc protocol MyProtocolWithAsync {
+  @available(*, renamed: "confirm(thing:)")
+  @objc(confirmThing:completion:)
+  optional func confirm(thing: AnyObject, completion: @escaping (AnyObject) -> Void)
+
+  @objc(confirmThing:completion:)
+  optional func confirm(thing: AnyObject) async -> AnyObject
+}
+
 // FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected note produced: 'nsstringProperty2' previously declared here


### PR DESCRIPTION
The filtering used to allow `@objc` protocols to have both an `async` and a completion-handler version of the same method was dependent on the resolution of the "renamed" declaration (for `@available(..., renamed: "")`), which in tern was dependent on whether the declaration is `@objc`... causing a cycle. Break the cycle by moving the filtering later.

Fixes rdar://99618060.
