### PR TITLE
sema: diagnose @_spi_available on all platforms

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1637,6 +1637,10 @@ ERROR(originally_definedin_must_not_before_available_version,none,
       "symbols are moved to the current module before they were available in "
       "the OSs", ())
 
+WARNING(spi_preferred_over_spi_available,none,
+        "symbols that are @_spi_available on all platforms should use @_spi "
+        "instead", ())
+
 // Alignment attribute
 ERROR(alignment_not_power_of_two,none,
       "alignment value must be a power of two", ())

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -328,6 +328,7 @@ public:
 
   void visitCompilerInitializedAttr(CompilerInitializedAttr *attr);
 
+  void checkAvailableAttrs(ArrayRef<AvailableAttr *> Attrs);
   void checkBackDeployAttrs(ArrayRef<BackDeployAttr *> Attrs);
 
   void visitKnownToBeLocalAttr(KnownToBeLocalAttr *attr);
@@ -1421,8 +1422,10 @@ void TypeChecker::checkDeclAttributes(Decl *D) {
     TypeChecker::applyAccessNote(VD);
 
   AttributeChecker Checker(D);
-  // We need to check all OriginallyDefinedInAttr and BackDeployAttr relative
-  // to each other, so collect them and check in batch later.
+  // We need to check all availableAttrs, OriginallyDefinedInAttr and
+  // BackDeployAttr relative to each other, so collect them and check in
+  // batch later.
+  llvm::SmallVector<AvailableAttr *, 4> availableAttrs;
   llvm::SmallVector<BackDeployAttr *, 4> backDeployAttrs;
   llvm::SmallVector<OriginallyDefinedInAttr*, 4> ODIAttrs;
   for (auto attr : D->getAttrs()) {
@@ -1436,6 +1439,10 @@ void TypeChecker::checkDeclAttributes(Decl *D) {
       } else if (auto *BD = dyn_cast<BackDeployAttr>(attr)) {
         backDeployAttrs.push_back(BD);
       } else {
+        // check @available attribute both collectively and individually.
+        if (auto *AV = dyn_cast<AvailableAttr>(attr)) {
+          availableAttrs.push_back(AV);
+        }
         // Otherwise, check it.
         Checker.visit(attr);
       }
@@ -1475,6 +1482,7 @@ void TypeChecker::checkDeclAttributes(Decl *D) {
     else
       Checker.diagnoseAndRemoveAttr(attr, diag::invalid_decl_attribute, attr);
   }
+  Checker.checkAvailableAttrs(availableAttrs);
   Checker.checkBackDeployAttrs(backDeployAttrs);
   Checker.checkOriginalDefinedInAttrs(ODIAttrs);
 }
@@ -4000,6 +4008,17 @@ void AttributeChecker::checkOriginalDefinedInAttrs(
       return;
     }
   }
+}
+
+void AttributeChecker::checkAvailableAttrs(ArrayRef<AvailableAttr *> Attrs) {
+  if (Attrs.empty())
+    return;
+  // If all available are spi available, we should use @_spi instead.
+  if (std::all_of(Attrs.begin(), Attrs.end(), [](AvailableAttr *AV) {
+    return AV->IsSPI;
+  })) {
+    diagnose(D->getLoc(), diag::spi_preferred_over_spi_available);
+  };
 }
 
 void AttributeChecker::checkBackDeployAttrs(ArrayRef<BackDeployAttr *> Attrs) {

--- a/test/Sema/spi-available-context.swift
+++ b/test/Sema/spi-available-context.swift
@@ -3,9 +3,11 @@
 // RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx11.9 -library-level api
 
 @_spi_available(macOS 10.4, *)
+@available(iOS 8.0, *)
 public protocol Foo { }
 
 @_spi_available(macOS 10.4, *)
+@available(iOS 8.0, *)
 public class Bar {
     public var foo: Foo?
 }

--- a/test/Sema/spi-available-inline.swift
+++ b/test/Sema/spi-available-inline.swift
@@ -3,9 +3,11 @@
 // RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx11.9 -library-level api
 
 @_spi_available(macOS 10.4, *)
+@available(iOS 8.0, *)
 public class MacOSSPIClass { public init() {} }
 
 @_spi_available(iOS 8.0, *)
+@available(macOS 10.4, *)
 public class iOSSPIClass { public init() {} }
 
 @inlinable public func foo() {

--- a/test/attr/spi_available.swift
+++ b/test/attr/spi_available.swift
@@ -1,10 +1,13 @@
 // RUN: %target-typecheck-verify-swift
 
 @_spi_available(*, deprecated, renamed: "another") // expected-error {{SPI available only supports introducing version on specific platform}}
-public class SPIClass1 {}
+public class SPIClass1 {} // expected-warning {{symbols that are @_spi_available on all platforms should use @_spi instead}}
 
 @_spi_available(*, unavailable) // expected-error {{SPI available only supports introducing version on specific platform}}
-public class SPIClass2 {}
+public class SPIClass2 {} // expected-warning {{symbols that are @_spi_available on all platforms should use @_spi instead}}
 
 @_spi_available(AlienPlatform 5.2, *) // expected-warning {{unrecognized platform name 'AlienPlatform'}}
 public class SPIClass3 {}
+
+@_spi_available(macOS 10.4, *)
+public class SPIClass4 {} // expected-warning {{symbols that are @_spi_available on all platforms should use @_spi instead}}


### PR DESCRIPTION
@_spi_available should only be used when the symbol is publically available in some deployment platforms, otherwise, we should use @_spi.
