### PR TITLE
Simplify get async alternative

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6827,7 +6827,7 @@ public:
   bool hasDynamicSelfResult() const;
 
   /// The async function marked as the alternative to this function, if any.
-  AbstractFunctionDecl *getAsyncAlternative(bool isKnownObjC = false) const;
+  AbstractFunctionDecl *getAsyncAlternative() const;
 
   /// If \p asyncAlternative is set, then compare its parameters to this
   /// (presumed synchronous) function's parameters to find the index of the

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3455,8 +3455,7 @@ public:
 
 class RenamedDeclRequest
     : public SimpleRequest<RenamedDeclRequest,
-                           ValueDecl *(const ValueDecl *, const AvailableAttr *,
-                                       bool isKnownObjC),
+                           ValueDecl *(const ValueDecl *, const AvailableAttr *),
                            RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -3465,7 +3464,7 @@ private:
   friend SimpleRequest;
 
   ValueDecl *evaluate(Evaluator &evaluator, const ValueDecl *attached,
-                      const AvailableAttr *attr, bool isKnownObjC) const;
+                      const AvailableAttr *attr) const;
 
 public:
   bool isCached() const { return true; }

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -391,7 +391,7 @@ SWIFT_REQUEST(TypeChecker, GetImplicitSendableRequest,
               ProtocolConformance *(NominalTypeDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, RenamedDeclRequest,
-              ValueDecl *(const ValueDecl *, const AvailableAttr *, bool),
+              ValueDecl *(const ValueDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ClosureEffectsRequest,
               FunctionType::ExtInfo(ClosureExpr *),

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -391,7 +391,7 @@ SWIFT_REQUEST(TypeChecker, GetImplicitSendableRequest,
               ProtocolConformance *(NominalTypeDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, RenamedDeclRequest,
-              ValueDecl *(const ValueDecl *),
+              ValueDecl *(const ValueDecl *, const AvailableAttr *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ClosureEffectsRequest,
               FunctionType::ExtInfo(ClosureExpr *),

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7666,8 +7666,7 @@ bool AbstractFunctionDecl::hasDynamicSelfResult() const {
   return isa<ConstructorDecl>(this);
 }
 
-AbstractFunctionDecl *
-AbstractFunctionDecl::getAsyncAlternative(bool isKnownObjC) const {
+AbstractFunctionDecl *AbstractFunctionDecl::getAsyncAlternative() const {
   // Async functions can't have async alternatives
   if (hasAsync())
     return nullptr;
@@ -7691,8 +7690,7 @@ AbstractFunctionDecl::getAsyncAlternative(bool isKnownObjC) const {
   }
 
   auto *renamedDecl = evaluateOrDefault(
-      getASTContext().evaluator, RenamedDeclRequest{this, avAttr, isKnownObjC},
-      nullptr);
+      getASTContext().evaluator, RenamedDeclRequest{this, avAttr}, nullptr);
   auto *alternative = dyn_cast_or_null<AbstractFunctionDecl>(renamedDecl);
   if (!alternative || !alternative->hasAsync())
     return nullptr;

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1741,15 +1741,6 @@ shouldDiagnoseConflict(NominalTypeDecl *ty, AbstractFunctionDecl *newDecl,
   }))
     return false;
 
-  // If we're looking at protocol requirements, is the new method an async
-  // alternative of any existing method, or vice versa?
-  if (isa<ProtocolDecl>(ty) &&
-      llvm::any_of(vec, [&](AbstractFunctionDecl *oldDecl) {
-    return newDecl->getAsyncAlternative(/*isKnownObjC=*/true) == oldDecl
-              || oldDecl->getAsyncAlternative(/*isKnownObjC=*/true) == newDecl;
-  }))
-    return false;
-
   return true;
 }
 

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1547,8 +1547,7 @@ private:
     assert(!AvAttr->Rename.empty());
 
     auto *renamedDecl = evaluateOrDefault(
-        getASTContext().evaluator, RenamedDeclRequest{D, AvAttr, false},
-        nullptr);
+        getASTContext().evaluator, RenamedDeclRequest{D, AvAttr}, nullptr);
     if (renamedDecl) {
       assert(shouldInclude(renamedDecl) &&
              "ObjC printer logic mismatch with renamed decl");

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -6657,8 +6657,7 @@ static bool parametersMatch(const AbstractFunctionDecl *a,
 
 ValueDecl *RenamedDeclRequest::evaluate(Evaluator &evaluator,
                                         const ValueDecl *attached,
-                                        const AvailableAttr *attr,
-                                        bool isKnownObjC) const {
+                                        const AvailableAttr *attr) const {
   if (!attached || !attr)
     return nullptr;
 
@@ -6689,7 +6688,7 @@ ValueDecl *RenamedDeclRequest::evaluate(Evaluator &evaluator,
   auto minAccess = AccessLevel::Private;
   if (attached->getModuleContext()->isExternallyConsumed())
     minAccess = AccessLevel::Public;
-  bool attachedIsObjcVisible = isKnownObjC ||
+  bool attachedIsObjcVisible =
       objc_translation::isVisibleToObjC(attached, minAccess);
 
   SmallVector<ValueDecl *, 4> lookupResults;

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -2453,7 +2453,7 @@ getObjCMethodConflictDecls(const SourceFile::ObjCMethodConflict &conflict) {
     asyncAlternatives;
   for (auto method : methods) {
     if (isa<ProtocolDecl>(method->getDeclContext())) {
-      if (auto alt = method->getAsyncAlternative(/*isKnownObjC=*/true))
+      if (auto alt = method->getAsyncAlternative())
         asyncAlternatives[method] = alt;
     }
   }

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -2448,11 +2448,26 @@ getObjCMethodConflictDecls(const SourceFile::ObjCMethodConflict &conflict) {
   auto methods = conflict.typeDecl->lookupDirect(conflict.selector,
                                                  conflict.isInstanceMethod);
 
+  // Find async alternatives for each.
+  llvm::SmallDenseMap<AbstractFunctionDecl *, AbstractFunctionDecl *>
+    asyncAlternatives;
+  for (auto method : methods) {
+    if (isa<ProtocolDecl>(method->getDeclContext())) {
+      if (auto alt = method->getAsyncAlternative(/*isKnownObjC=*/true))
+        asyncAlternatives[method] = alt;
+    }
+  }
+
   // Erase any invalid or stub declarations. We don't want to complain about
   // them, because we might already have complained about redeclarations
   // based on Swift matching.
-  llvm::erase_if(methods, [](AbstractFunctionDecl *afd) -> bool {
+  llvm::erase_if(methods,
+                 [&asyncAlternatives](AbstractFunctionDecl *afd) -> bool {
     if (afd->isInvalid())
+      return true;
+
+    // If there is an async alternative, remove this entry.
+    if (asyncAlternatives.count(afd))
       return true;
 
     if (auto ad = dyn_cast<AccessorDecl>(afd))
@@ -2462,6 +2477,7 @@ getObjCMethodConflictDecls(const SourceFile::ObjCMethodConflict &conflict) {
       if (ctor->hasStubImplementation())
         return true;
     }
+
     return false;
   });
 

--- a/test/decl/objc_redeclaration.swift
+++ b/test/decl/objc_redeclaration.swift
@@ -66,5 +66,16 @@ extension MyObject {
     public override convenience init() {} // expected-error{{initializer 'init()' with Objective-C selector 'init' conflicts with implicit initializer 'init()' with the same Objective-C selector}}
 }
 
+// Ensure that we don't have cycles with the "renamed decl" request.
+@available(SwiftStdlib 5.1, *)
+@objc protocol MyProtocolWithAsync {
+  @available(*, renamed: "confirm(thing:)")
+  @objc(confirmThing:completion:)
+  optional func confirm(thing: AnyObject, completion: @escaping (AnyObject) -> Void)
+
+  @objc(confirmThing:completion:)
+  optional func confirm(thing: AnyObject) async -> AnyObject
+}
+
 // FIXME: Remove -verify-ignore-unknown.
 // <unknown>:0: error: unexpected note produced: 'nsstringProperty2' previously declared here


### PR DESCRIPTION
Remove an unnecessary parameter to `RenamedDeclRequest` that unsuccessfully broke cycles.