### PR TITLE
Replace SWIFT_SWIFT_PARSER_ROUNDTRIP with an experimental feature. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -870,18 +870,8 @@ endif()
 
 # When we have the early SwiftSyntax build, we can include its parser.
 if(SWIFT_PATH_TO_EARLYSWIFTSYNTAX_BUILD_DIR)
-  # An option that specifies how the SwiftSyntax-based Swift parser is
-  # integrated.
-  option(SWIFT_SWIFT_PARSER_MODE [=[
-How to use the SwiftSyntax-based Swift parser. Possible values are
-    OFF:           do not use this parser at all
-    ROUNDTRIP:     ensure that the SwiftSyntax-based Swift parser round-trips
-]=] OFF)
-
-  if(SWIFT_SWIFT_PARSER_MODE)
-    set(SWIFT_SWIFT_PARSER TRUE)
-    include(${SWIFT_PATH_TO_EARLYSWIFTSYNTAX_BUILD_DIR}/cmake/SwiftSyntaxTargets.cmake)
-  endif()
+  set(SWIFT_SWIFT_PARSER TRUE)
+  include(${SWIFT_PATH_TO_EARLYSWIFTSYNTAX_BUILD_DIR}/cmake/SwiftSyntaxTargets.cmake)
 endif()
 
 
@@ -1091,7 +1081,7 @@ if(SWIFT_INCLUDE_TOOLS)
   message(STATUS "  Assertions:     ${LLVM_ENABLE_ASSERTIONS}")
   message(STATUS "  LTO:            ${SWIFT_TOOLS_ENABLE_LTO}")
   message(STATUS "  Bootstrapping:  ${BOOTSTRAPPING_MODE}")
-  message(STATUS "  Swift parser:   ${SWIFT_SWIFT_PARSER_MODE}")
+  message(STATUS "  Swift parser:   ${SWIFT_SWIFT_PARSER}")
   message(STATUS "")
 else()
   message(STATUS "Not building host Swift tools")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -755,7 +755,7 @@ elseif(BOOTSTRAPPING_MODE MATCHES "BOOTSTRAPPING.*")
   else()
     set(BOOTSTRAPPING_MODE "HOSTTOOLS")
   endif()
-elseif(BOOTSTRAPPING_MODE STREQUAL "HOSTTOOLS")
+elseif(BOOTSTRAPPING_MODE STREQUAL "HOSTTOOLS" OR SWIFT_SWIFT_PARSER)
   # We are building using a pre-installed host toolchain but not bootstrapping
   # the Swift modules. This happens when building using 'build-tooling-libs'
   # where we haven't built a new Swift compiler. Use the Swift compiler from the
@@ -1091,6 +1091,7 @@ if(SWIFT_INCLUDE_TOOLS)
   message(STATUS "  Assertions:     ${LLVM_ENABLE_ASSERTIONS}")
   message(STATUS "  LTO:            ${SWIFT_TOOLS_ENABLE_LTO}")
   message(STATUS "  Bootstrapping:  ${BOOTSTRAPPING_MODE}")
+  message(STATUS "  Swift parser:   ${SWIFT_SWIFT_PARSER_MODE}")
   message(STATUS "")
 else()
   message(STATUS "Not building host Swift tools")

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -435,7 +435,13 @@ endfunction()
 
 function(_add_swift_runtime_link_flags target relpath_to_lib_dir bootstrapping)
   if(NOT BOOTSTRAPPING_MODE)
-    return()
+    if (SWIFT_SWIFT_PARSER)
+      set(ASRLF_BOOTSTRAPPING_MODE "HOSTTOOLS")
+    else()
+      return()
+    endif()
+  else()
+    set(ASRLF_BOOTSTRAPPING_MODE ${BOOTSTRAPPING_MODE})
   endif()
 
   # RPATH where Swift runtime can be found.
@@ -448,7 +454,7 @@ function(_add_swift_runtime_link_flags target relpath_to_lib_dir bootstrapping)
     # If we found a swift compiler and are going to use swift code in swift
     # host side tools but link with clang, add the appropriate -L paths so we
     # find all of the necessary swift libraries on Darwin.
-    if(BOOTSTRAPPING_MODE STREQUAL "HOSTTOOLS")
+    if(ASRLF_BOOTSTRAPPING_MODE STREQUAL "HOSTTOOLS")
       # Add in the toolchain directory so we can grab compatibility libraries
       get_filename_component(TOOLCHAIN_BIN_DIR ${SWIFT_EXEC_FOR_SWIFT_MODULES} DIRECTORY)
       get_filename_component(TOOLCHAIN_LIB_DIR "${TOOLCHAIN_BIN_DIR}/../lib/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}" ABSOLUTE)
@@ -460,7 +466,7 @@ function(_add_swift_runtime_link_flags target relpath_to_lib_dir bootstrapping)
       # Include the abi stable system stdlib in our rpath.
       set(swift_runtime_rpath "/usr/lib/swift")
 
-    elseif(BOOTSTRAPPING_MODE STREQUAL "CROSSCOMPILE-WITH-HOSTLIBS")
+    elseif(ASRLF_BOOTSTRAPPING_MODE STREQUAL "CROSSCOMPILE-WITH-HOSTLIBS")
 
       # Intentionally don't add the lib dir of the cross-compiled compiler, so that
       # the stdlib is not picked up from there, but from the SDK.
@@ -478,7 +484,7 @@ function(_add_swift_runtime_link_flags target relpath_to_lib_dir bootstrapping)
       # Include the abi stable system stdlib in our rpath.
       set(swift_runtime_rpath "/usr/lib/swift")
 
-    elseif(BOOTSTRAPPING_MODE STREQUAL "BOOTSTRAPPING-WITH-HOSTLIBS")
+    elseif(ASRLF_BOOTSTRAPPING_MODE STREQUAL "BOOTSTRAPPING-WITH-HOSTLIBS")
       # Add the SDK directory for the host platform.
       target_link_directories(${target} PRIVATE "${sdk_dir}")
 
@@ -489,7 +495,7 @@ function(_add_swift_runtime_link_flags target relpath_to_lib_dir bootstrapping)
       # Include the abi stable system stdlib in our rpath.
       set(swift_runtime_rpath "/usr/lib/swift")
 
-    elseif(BOOTSTRAPPING_MODE STREQUAL "BOOTSTRAPPING")
+    elseif(ASRLF_BOOTSTRAPPING_MODE STREQUAL "BOOTSTRAPPING")
       # At build time link against the built swift libraries from the
       # previous bootstrapping stage.
       get_bootstrapping_swift_lib_dir(bs_lib_dir "${bootstrapping}")
@@ -503,7 +509,7 @@ function(_add_swift_runtime_link_flags target relpath_to_lib_dir bootstrapping)
       # bootstrapping stage.
       set(swift_runtime_rpath "@loader_path/${relpath_to_lib_dir}/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}")
     else()
-      message(FATAL_ERROR "Unknown BOOTSTRAPPING_MODE '${BOOTSTRAPPING_MODE}'")
+      message(FATAL_ERROR "Unknown BOOTSTRAPPING_MODE '${ASRLF_BOOTSTRAPPING_MODE}'")
     endif()
 
     # Workaround to make lldb happy: we have to explicitly add all swift compiler modules
@@ -524,7 +530,7 @@ function(_add_swift_runtime_link_flags target relpath_to_lib_dir bootstrapping)
 
   elseif(SWIFT_HOST_VARIANT_SDK MATCHES "LINUX|ANDROID|OPENBSD")
     set(swiftrt "swiftImageRegistrationObject${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_OBJECT_FORMAT}-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH}")
-    if(${BOOTSTRAPPING_MODE} MATCHES "HOSTTOOLS|CROSSCOMPILE")
+    if(${ASRLF_BOOTSTRAPPING_MODE} MATCHES "HOSTTOOLS|CROSSCOMPILE")
       # At build time and run time, link against the swift libraries in the
       # installed host toolchain.
       get_filename_component(swift_bin_dir ${SWIFT_EXEC_FOR_SWIFT_MODULES} DIRECTORY)
@@ -535,13 +541,13 @@ function(_add_swift_runtime_link_flags target relpath_to_lib_dir bootstrapping)
       target_link_libraries(${target} PRIVATE "swiftCore")
 
       target_link_directories(${target} PRIVATE ${host_lib_dir})
-      if(BOOTSTRAPPING_MODE STREQUAL "HOSTTOOLS")
+      if(ASRLF_BOOTSTRAPPING_MODE STREQUAL "HOSTTOOLS")
         set(swift_runtime_rpath "${host_lib_dir}")
       else()
         set(swift_runtime_rpath "$ORIGIN/${relpath_to_lib_dir}/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}")
       endif()
 
-    elseif(BOOTSTRAPPING_MODE STREQUAL "BOOTSTRAPPING")
+    elseif(ASRLF_BOOTSTRAPPING_MODE STREQUAL "BOOTSTRAPPING")
       # At build time link against the built swift libraries from the
       # previous bootstrapping stage.
       if (NOT "${bootstrapping}" STREQUAL "0")
@@ -555,10 +561,10 @@ function(_add_swift_runtime_link_flags target relpath_to_lib_dir bootstrapping)
       # bootstrapping stage.
       set(swift_runtime_rpath "$ORIGIN/${relpath_to_lib_dir}/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}")
 
-    elseif(BOOTSTRAPPING_MODE STREQUAL "BOOTSTRAPPING-WITH-HOSTLIBS")
+    elseif(ASRLF_BOOTSTRAPPING_MODE STREQUAL "BOOTSTRAPPING-WITH-HOSTLIBS")
       message(FATAL_ERROR "BOOTSTRAPPING_MODE 'BOOTSTRAPPING-WITH-HOSTLIBS' not supported on Linux")
     else()
-      message(FATAL_ERROR "Unknown BOOTSTRAPPING_MODE '${BOOTSTRAPPING_MODE}'")
+      message(FATAL_ERROR "Unknown BOOTSTRAPPING_MODE '${ASRLF_BOOTSTRAPPING_MODE}'")
     endif()
   endif()
 

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -126,6 +126,9 @@ EXPERIMENTAL_FEATURE(OpaqueTypeErasure)
 /// wrapped type.
 EXPERIMENTAL_FEATURE(TypeWrappers)
 
+/// Whether to perform round-trip testing of the Swift Swift parser.
+EXPERIMENTAL_FEATURE(ParserRoundTrip)
+
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE
 #undef SUPPRESSIBLE_LANGUAGE_FEATURE

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -529,6 +529,8 @@ namespace swift {
       return ActiveConcurrencyModel == ConcurrencyModel::TaskToThread;
     }
 
+    LangOptions();
+
     /// Sets the target we are building for and updates platform conditions
     /// to match.
     ///

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2935,6 +2935,10 @@ static bool usesFeatureTypeWrappers(Decl *decl) {
   return decl->getAttrs().hasAttribute<TypeWrapperAttr>();
 }
 
+static bool usesFeatureParserRoundTrip(Decl *decl) {
+  return false;
+}
+
 static void suppressingFeatureSpecializeAttributeWithAvailability(
                                         PrintOptions &options,
                                         llvm::function_ref<void()> action) {

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -29,6 +29,10 @@
 
 using namespace swift;
 
+LangOptions::LangOptions() {
+  // Note: Introduce default-on language options here.
+}
+
 struct SupportedConditionalValue {
   StringRef value;
 

--- a/lib/Parse/CMakeLists.txt
+++ b/lib/Parse/CMakeLists.txt
@@ -59,7 +59,7 @@ if (SWIFT_SWIFT_PARSER)
 
   target_compile_definitions(swiftParse
     PRIVATE
-    SWIFT_SWIFT_PARSER_ROUNDTRIP
+    SWIFT_SWIFT_PARSER
   )
 endif()
 

--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -26,7 +26,7 @@
 #include "swift/Syntax/SyntaxNodes.h"
 #include "swift/SyntaxParse/SyntaxTreeCreator.h"
 
-#ifdef SWIFT_SWIFT_PARSER_ROUNDTRIP
+#ifdef SWIFT_SWIFT_PARSER
 #include "SwiftParserCompilerSupport.h"
 #endif
 
@@ -193,8 +193,9 @@ SourceFileParsingResult ParseSourceFileRequest::evaluate(Evaluator &evaluator,
   if (auto tokens = parser.takeTokenReceiver()->finalize())
     tokensRef = ctx.AllocateCopy(*tokens);
 
-#ifdef SWIFT_SWIFT_PARSER_ROUNDTRIP
-  if (ctx.SourceMgr.getCodeCompletionBufferID() != bufferID) {
+#ifdef SWIFT_SWIFT_PARSER
+  if (ctx.LangOpts.hasFeature(Feature::ParserRoundTrip) &&
+      ctx.SourceMgr.getCodeCompletionBufferID() != bufferID) {
     auto bufferRange = ctx.SourceMgr.getRangeForBuffer(*bufferID);
     unsigned int flags = SPCC_RoundTrip;
 

--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -20,6 +20,16 @@ endfunction()
 
 function(add_sourcekitd_swifrt_linking target path HAS_SWIFT_MODULES)
   set(RPATH_LIST)
+
+  # If we are linking in the Swift Swift parser, we at least need host tools
+  # to do it.
+  set(ASKD_BOOTSTRAPPING_MODE ${BOOTSTRAPPING_MODE})
+  if (NOT ASKD_BOOTSTRAPPING_MODE)
+    if (SWIFT_SWIFT_PARSER)
+      set(ASKD_BOOTSTRAPPING_MODE HOSTTOOLS)
+    endif()
+  endif()
+
   if(${SWIFT_HOST_VARIANT_SDK} IN_LIST SWIFT_DARWIN_PLATFORMS)
 
     # Lists of rpaths that we are going to add to our executables.
@@ -31,9 +41,9 @@ function(add_sourcekitd_swifrt_linking target path HAS_SWIFT_MODULES)
     # If we found a swift compiler and are going to use swift code in swift
     # host side tools but link with clang, add the appropriate -L paths so we
     # find all of the necessary swift libraries on Darwin.
-    if (HAS_SWIFT_MODULES AND BOOTSTRAPPING_MODE)
+    if (HAS_SWIFT_MODULES AND ASKD_BOOTSTRAPPING_MODE)
 
-      if(BOOTSTRAPPING_MODE STREQUAL "HOSTTOOLS")
+      if(ASKD_BOOTSTRAPPING_MODE STREQUAL "HOSTTOOLS")
         # Add in the toolchain directory so we can grab compatibility libraries
         get_filename_component(TOOLCHAIN_BIN_DIR ${SWIFT_EXEC_FOR_SWIFT_MODULES} DIRECTORY)
         get_filename_component(TOOLCHAIN_LIB_DIR "${TOOLCHAIN_BIN_DIR}/../lib/swift/macosx" ABSOLUTE)
@@ -45,7 +55,7 @@ function(add_sourcekitd_swifrt_linking target path HAS_SWIFT_MODULES)
         # Include the abi stable system stdlib in our rpath.
         list(APPEND RPATH_LIST "/usr/lib/swift")
 
-      elseif(BOOTSTRAPPING_MODE STREQUAL "CROSSCOMPILE-WITH-HOSTLIBS")
+      elseif(ASKD_BOOTSTRAPPING_MODE STREQUAL "CROSSCOMPILE-WITH-HOSTLIBS")
 
         # Intentinally don't add the lib dir of the cross-compiled compiler, so that
         # the stdlib is not picked up from there, but from the SDK.
@@ -59,7 +69,7 @@ function(add_sourcekitd_swifrt_linking target path HAS_SWIFT_MODULES)
         # Include the abi stable system stdlib in our rpath.
         list(APPEND RPATH_LIST "/usr/lib/swift")
 
-      elseif(BOOTSTRAPPING_MODE STREQUAL "BOOTSTRAPPING-WITH-HOSTLIBS")
+      elseif(ASKD_BOOTSTRAPPING_MODE STREQUAL "BOOTSTRAPPING-WITH-HOSTLIBS")
         # Add the SDK directory for the host platform.
         target_link_directories(${target} PRIVATE "${sdk_dir}")
 
@@ -70,7 +80,7 @@ function(add_sourcekitd_swifrt_linking target path HAS_SWIFT_MODULES)
         # Include the abi stable system stdlib in our rpath.
         list(APPEND RPATH_LIST "/usr/lib/swift")
 
-      elseif(BOOTSTRAPPING_MODE STREQUAL "BOOTSTRAPPING")
+      elseif(ASKD_BOOTSTRAPPING_MODE STREQUAL "BOOTSTRAPPING")
         # At build time link against the built swift libraries from the
         # previous bootstrapping stage.
         get_bootstrapping_swift_lib_dir(bs_lib_dir "")
@@ -85,7 +95,7 @@ function(add_sourcekitd_swifrt_linking target path HAS_SWIFT_MODULES)
         file(RELATIVE_PATH relative_rtlib_path "${path}" "${SWIFTLIB_DIR}/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}")
         list(APPEND RPATH_LIST "@loader_path/${relative_rtlib_path}")
       else()
-        message(FATAL_ERROR "Unknown BOOTSTRAPPING_MODE '${BOOTSTRAPPING_MODE}'")
+        message(FATAL_ERROR "Unknown ASKD_BOOTSTRAPPING_MODE '${ASKD_BOOTSTRAPPING_MODE}'")
       endif()
 
       # Workaround to make lldb happy: we have to explicitly add all swift compiler modules
@@ -104,11 +114,11 @@ function(add_sourcekitd_swifrt_linking target path HAS_SWIFT_MODULES)
       set_property(TARGET ${target} APPEND_STRING PROPERTY
                    LINK_FLAGS " -lobjc ")
 
-    endif() # HAS_SWIFT_MODULES AND BOOTSTRAPPING_MODE
+    endif() # HAS_SWIFT_MODULES AND ASKD_BOOTSTRAPPING_MODE
 
-  elseif(SWIFT_HOST_VARIANT_SDK MATCHES "LINUX|ANDROID|OPENBSD" AND HAS_SWIFT_MODULES AND BOOTSTRAPPING_MODE)
+  elseif(SWIFT_HOST_VARIANT_SDK MATCHES "LINUX|ANDROID|OPENBSD" AND HAS_SWIFT_MODULES AND ASKD_BOOTSTRAPPING_MODE)
     set(swiftrt "swiftImageRegistrationObject${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_OBJECT_FORMAT}-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH}")
-    if(${BOOTSTRAPPING_MODE} MATCHES "HOSTTOOLS|CROSSCOMPILE")
+    if(${ASKD_BOOTSTRAPPING_MODE} MATCHES "HOSTTOOLS|CROSSCOMPILE")
       # At build time and and run time, link against the swift libraries in the
       # installed host toolchain.
       get_filename_component(swift_bin_dir ${SWIFT_EXEC_FOR_SWIFT_MODULES} DIRECTORY)
@@ -119,14 +129,14 @@ function(add_sourcekitd_swifrt_linking target path HAS_SWIFT_MODULES)
       target_link_libraries(${target} PRIVATE "swiftCore")
 
       target_link_directories(${target} PRIVATE ${host_lib_dir})
-      if(BOOTSTRAPPING_MODE STREQUAL "HOSTTOOLS")
+      if(ASKD_BOOTSTRAPPING_MODE STREQUAL "HOSTTOOLS")
         list(APPEND RPATH_LIST "${host_lib_dir}")
       else()
         file(RELATIVE_PATH relative_rtlib_path "${path}" "${SWIFTLIB_DIR}/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}")
         list(APPEND RPATH_LIST "$ORIGIN/${relative_rtlib_path}")
       endif()
 
-    elseif(BOOTSTRAPPING_MODE STREQUAL "BOOTSTRAPPING")
+    elseif(ASKD_BOOTSTRAPPING_MODE STREQUAL "BOOTSTRAPPING")
       get_bootstrapping_swift_lib_dir(bs_lib_dir "")
       target_link_directories(${target} PRIVATE ${bs_lib_dir})
       target_link_libraries(${target} PRIVATE ${swiftrt})
@@ -137,10 +147,10 @@ function(add_sourcekitd_swifrt_linking target path HAS_SWIFT_MODULES)
       file(RELATIVE_PATH relative_rtlib_path "${path}" "${SWIFTLIB_DIR}/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}")
       list(APPEND RPATH_LIST "$ORIGIN/${relative_rtlib_path}")
 
-    elseif(BOOTSTRAPPING_MODE STREQUAL "BOOTSTRAPPING-WITH-HOSTLIBS")
-      message(FATAL_ERROR "BOOTSTRAPPING_MODE 'BOOTSTRAPPING-WITH-HOSTLIBS' not supported on Linux")
+    elseif(ASKD_BOOTSTRAPPING_MODE STREQUAL "BOOTSTRAPPING-WITH-HOSTLIBS")
+      message(FATAL_ERROR "ASKD_BOOTSTRAPPING_MODE 'BOOTSTRAPPING-WITH-HOSTLIBS' not supported on Linux")
     else()
-      message(FATAL_ERROR "Unknown BOOTSTRAPPING_MODE '${BOOTSTRAPPING_MODE}'")
+      message(FATAL_ERROR "Unknown ASKD_BOOTSTRAPPING_MODE '${ASKD_BOOTSTRAPPING_MODE}'")
     endif()
   endif()
   set(RPATH_LIST ${RPATH_LIST} PARENT_SCOPE)


### PR DESCRIPTION
Remove the CMake configuration option `SWIFT_SWIFT_PARSER_ROUNDTRIP`.
Instead, whenever the "early" SwiftSyntax module is built, link the
Swift Swift parser into the compiler and related tools.

Introduce a new experimental feature `ParserRoundTrip` that can be
enabled to perform round-trip testing.