### PR TITLE
[move-only] Fix a few small issues around mark must check.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/WalkUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/WalkUtils.swift
@@ -294,7 +294,7 @@ extension ValueDefUseWalker {
     case is InitExistentialRefInst, is OpenExistentialRefInst,
       is BeginBorrowInst, is CopyValueInst,
       is UpcastInst, is UncheckedRefCastInst, is EndCOWMutationInst,
-      is RefToBridgeObjectInst, is BridgeObjectToRefInst:
+      is RefToBridgeObjectInst, is BridgeObjectToRefInst, is MarkMustCheckInst:
       return walkDownUses(ofValue: (instruction as! SingleValueInstruction), path: path)
     case let mdi as MarkDependenceInst:
       if operand.index == 0 {
@@ -419,7 +419,7 @@ extension AddressDefUseWalker {
         return unmatchedPath(address: operand, path: path)
       }
     case is InitExistentialAddrInst, is OpenExistentialAddrInst, is BeginAccessInst,
-      is IndexAddrInst:
+         is IndexAddrInst, is MarkMustCheckInst:
       // FIXME: for now `index_addr` is treated as a forwarding instruction since
       // SmallProjectionPath does not track indices.
       // This is ok since `index_addr` is eventually preceeded by a `tail_addr`
@@ -558,7 +558,7 @@ extension ValueUseDefWalker {
     case is InitExistentialRefInst, is OpenExistentialRefInst,
       is BeginBorrowInst, is CopyValueInst,
       is UpcastInst, is UncheckedRefCastInst, is EndCOWMutationInst,
-      is RefToBridgeObjectInst, is BridgeObjectToRefInst:
+      is RefToBridgeObjectInst, is BridgeObjectToRefInst, is MarkMustCheckInst:
       return walkUp(value: (def as! Instruction).operands[0].value, path: path)
     case let arg as BlockArgument:
       if arg.isPhiArgument {
@@ -643,7 +643,8 @@ extension AddressUseDefWalker {
     case is InitEnumDataAddrInst, is UncheckedTakeEnumDataAddrInst:
       return walkUp(address: (def as! UnaryInstruction).operand,
                     path: path.push(.enumCase, index: (def as! EnumInstruction).caseIndex))
-    case is InitExistentialAddrInst, is OpenExistentialAddrInst, is BeginAccessInst, is IndexAddrInst:
+    case is InitExistentialAddrInst, is OpenExistentialAddrInst, is BeginAccessInst, is IndexAddrInst,
+         is MarkMustCheckInst:
       // FIXME: for now `index_addr` is treated as a forwarding instruction since
       // SmallProjectionPath does not track indices.
       // This is ok since `index_addr` is eventually preceeded by a `tail_addr`

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -628,6 +628,8 @@ final public class IsUniqueInst : SingleValueInstruction, UnaryInstruction {}
 
 final public class IsEscapingClosureInst : SingleValueInstruction, UnaryInstruction {}
 
+final public
+class MarkMustCheckInst : SingleValueInstruction, UnaryInstruction {}
 
 //===----------------------------------------------------------------------===//
 //                      single-value allocation instructions

--- a/SwiftCompilerSources/Sources/SIL/Registration.swift
+++ b/SwiftCompilerSources/Sources/SIL/Registration.swift
@@ -66,6 +66,7 @@ public func registerSILClasses() {
   register(BuiltinInst.self)
   register(UpcastInst.self)
   register(UncheckedRefCastInst.self)
+  register(MarkMustCheckInst.self)
   register(RawPointerToRefInst.self)
   register(AddressToPointerInst.self)
   register(PointerToAddressInst.self)

--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -1603,6 +1603,7 @@ inline bool isAccessStorageIdentityCast(SingleValueInstruction *svi) {
 
   // Simply pass-thru the incoming address.
   case SILInstructionKind::MarkUninitializedInst:
+  case SILInstructionKind::MarkMustCheckInst:
   case SILInstructionKind::MarkDependenceInst:
   case SILInstructionKind::CopyValueInst:
     return true;

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -3431,11 +3431,6 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
   }
 
   case SILInstructionKind::MarkMustCheckInst: {
-    if (parseTypedValueRef(Val, B))
-      return true;
-    if (parseSILDebugLocation(InstLoc, B))
-      return true;
-
     StringRef AttrName;
     if (!parseSILOptional(AttrName, *this)) {
       auto diag = diag::sil_markmustcheck_requires_attribute;
@@ -3454,6 +3449,12 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
       P.diagnose(InstLoc.getSourceLoc(), diag, AttrName);
       return true;
     }
+
+    if (parseTypedValueRef(Val, B))
+      return true;
+    if (parseSILDebugLocation(InstLoc, B))
+      return true;
+
     auto *MVI = B.createMarkMustCheckInst(InstLoc, Val, CKind);
     ResultVal = MVI;
     break;

--- a/test/SIL/Parser/basic2_moveonly.sil
+++ b/test/SIL/Parser/basic2_moveonly.sil
@@ -1,0 +1,34 @@
+// RUN: %target-sil-opt -enable-experimental-move-only %s | %target-sil-opt -enable-experimental-move-only | %FileCheck %s
+
+// Once move only is no longer behind a feature flag, merge this into basic2.
+
+sil_stage raw
+
+class Klass {}
+@_moveOnly struct MoveOnlyPair {
+  var lhs: Klass
+  var rhs: Klass
+}
+
+// CHECK-LABEL: sil [ossa] @testMarkMustCheckInst : $@convention(thin) (@guaranteed Klass) -> () {
+// CHECK: mark_must_check [no_implicit_copy] %{{[0-9]+}} : $*MoveOnlyPair
+// CHECK: } // end sil function 'testMarkMustCheckInst'
+sil [ossa] @testMarkMustCheckInst : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass):
+  %1 = alloc_box ${ var MoveOnlyPair }
+  %2 = project_box %1 : ${ var MoveOnlyPair }, 0
+  %3 = mark_must_check [no_implicit_copy] %2 : $*MoveOnlyPair
+  %3c = begin_access [modify] [static] %3 : $*MoveOnlyPair
+  %3a = struct_element_addr %3c : $*MoveOnlyPair, #MoveOnlyPair.lhs
+  %3b = struct_element_addr %3c : $*MoveOnlyPair, #MoveOnlyPair.rhs
+  %0a = copy_value %0 : $Klass
+  %0b = copy_value %0 : $Klass
+  store %0a to [init] %3a : $*Klass
+  store %0b to [init] %3b : $*Klass
+  end_access %3c : $*MoveOnlyPair
+
+  destroy_value %1 : ${ var MoveOnlyPair }
+
+  %9999 = tuple()
+  return %9999 : $()
+}

--- a/test/SIL/Serialization/basic2_moveonly.sil
+++ b/test/SIL/Serialization/basic2_moveonly.sil
@@ -1,0 +1,37 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-sil-opt -enable-experimental-move-only %s -emit-sib -o %t/tmp.sib -module-name basic2
+// RUN: %target-sil-opt -enable-experimental-move-only %t/tmp.sib -o %t/tmp.2.sib -module-name basic2
+// RUN: %target-sil-opt -enable-experimental-move-only %t/tmp.2.sib -module-name basic2 -emit-sorted-sil | %FileCheck %s
+
+// Once move only is no longer behind a feature flag, merge this into basic2.
+
+sil_stage raw
+
+class Klass {}
+@_moveOnly struct MoveOnlyPair {
+  var lhs: Klass
+  var rhs: Klass
+}
+
+// CHECK-LABEL: sil [ossa] @testMarkMustCheckInst : $@convention(thin) (@guaranteed Klass) -> () {
+// CHECK: mark_must_check [no_implicit_copy] %{{[0-9]+}} : $*MoveOnlyPair
+// CHECK: } // end sil function 'testMarkMustCheckInst'
+sil [ossa] @testMarkMustCheckInst : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass):
+  %1 = alloc_box ${ var MoveOnlyPair }
+  %2 = project_box %1 : ${ var MoveOnlyPair }, 0
+  %3 = mark_must_check [no_implicit_copy] %2 : $*MoveOnlyPair
+  %3c = begin_access [modify] [static] %3 : $*MoveOnlyPair
+  %3a = struct_element_addr %3c : $*MoveOnlyPair, #MoveOnlyPair.lhs
+  %3b = struct_element_addr %3c : $*MoveOnlyPair, #MoveOnlyPair.rhs
+  %0a = copy_value %0 : $Klass
+  %0b = copy_value %0 : $Klass
+  store %0a to [init] %3a : $*Klass
+  store %0b to [init] %3b : $*Klass
+  end_access %3c : $*MoveOnlyPair
+
+  destroy_value %1 : ${ var MoveOnlyPair }
+
+  %9999 = tuple()
+  return %9999 : $()
+}

--- a/test/SILOptimizer/accessutils_raw.sil
+++ b/test/SILOptimizer/accessutils_raw.sil
@@ -1,0 +1,55 @@
+// RUN: %target-sil-opt -enable-experimental-move-only %s -dump-access -o /dev/null | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+
+// Test is failing when targeting ARMv7k/ARM64_32. rdar://98669547
+// UNSUPPORTED: CPU=armv7k || CPU=arm64_32
+
+sil_stage raw
+
+import Builtin
+
+class List {
+  var x: Builtin.Int64
+  let next: List
+}
+
+@_moveOnly
+struct MoveOnlyPair {
+  var lhs: List
+  var rhs: List
+}
+
+// CHECK-LABEL: Accesses for testMarkMustCheckInst
+// CHECK-NEXT: Value:   %5 = struct_element_addr %4 : $*MoveOnlyPair, #MoveOnlyPair.lhs
+// CHECK-NEXT:   Scope:   %4 = begin_access [modify] [static] %3 : $*MoveOnlyPair
+// CHECK-NEXT:   Base: box -   %2 = project_box %1 : ${ var MoveOnlyPair }, 0
+// CHECK-NEXT:   Path: "s0"
+// CHECK-NEXT:     Storage:   %1 = alloc_box ${ var MoveOnlyPair }
+// CHECK-NEXT:     Path: "c0.s0"
+// CHECK-NEXT: Value:   %6 = struct_element_addr %4 : $*MoveOnlyPair, #MoveOnlyPair.rhs
+// CHECK-NEXT:   Scope:   %4 = begin_access [modify] [static] %3 : $*MoveOnlyPair
+// CHECK-NEXT:   Base: box -   %2 = project_box %1 : ${ var MoveOnlyPair }, 0
+// CHECK-NEXT:   Path: "s1"
+// CHECK-NEXT:     Storage:   %1 = alloc_box ${ var MoveOnlyPair }
+// CHECK-NEXT:     Path: "c0.s1"
+// CHECK-NEXT: End accesses for testMarkMustCheckInst
+sil [ossa] @testMarkMustCheckInst : $@convention(thin) (@guaranteed List) -> () {
+bb0(%0 : @guaranteed $List):
+  %1 = alloc_box ${ var MoveOnlyPair }
+  %2 = project_box %1 : ${ var MoveOnlyPair }, 0
+  %3 = mark_must_check [no_implicit_copy] %2 : $*MoveOnlyPair
+  %3c = begin_access [modify] [static] %3 : $*MoveOnlyPair
+  %3a = struct_element_addr %3c : $*MoveOnlyPair, #MoveOnlyPair.lhs
+  %3b = struct_element_addr %3c : $*MoveOnlyPair, #MoveOnlyPair.rhs
+  %0a = copy_value %0 : $List
+  %0b = copy_value %0 : $List
+  store %0a to [init] %3a : $*List
+  store %0b to [init] %3b : $*List
+  end_access %3c : $*MoveOnlyPair
+
+  destroy_value %1 : ${ var MoveOnlyPair }
+
+  %9999 = tuple()
+  return %9999 : $()
+}


### PR DESCRIPTION
I fixed the parsing of mark must check and added support for it in access utils as an identity transform. Just splitting off a larger patch.