### PR TITLE
Add an experimental feature to do validation of the Swift Swift parser.

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -129,6 +129,10 @@ EXPERIMENTAL_FEATURE(TypeWrappers)
 /// Whether to perform round-trip testing of the Swift Swift parser.
 EXPERIMENTAL_FEATURE(ParserRoundTrip)
 
+/// Whether to perform validation of the parse tree produced by the Swift
+/// Swift parser.
+EXPERIMENTAL_FEATURE(ParserValidation)
+
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE
 #undef SUPPRESSIBLE_LANGUAGE_FEATURE

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2939,6 +2939,10 @@ static bool usesFeatureParserRoundTrip(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureParserValidation(Decl *decl) {
+  return false;
+}
+
 static void suppressingFeatureSpecializeAttributeWithAvailability(
                                         PrintOptions &options,
                                         llvm::function_ref<void()> action) {

--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -194,10 +194,18 @@ SourceFileParsingResult ParseSourceFileRequest::evaluate(Evaluator &evaluator,
     tokensRef = ctx.AllocateCopy(*tokens);
 
 #ifdef SWIFT_SWIFT_PARSER
-  if (ctx.LangOpts.hasFeature(Feature::ParserRoundTrip) &&
+  if ((ctx.LangOpts.hasFeature(Feature::ParserRoundTrip) ||
+       ctx.LangOpts.hasFeature(Feature::ParserValidation)) &&
       ctx.SourceMgr.getCodeCompletionBufferID() != bufferID) {
     auto bufferRange = ctx.SourceMgr.getRangeForBuffer(*bufferID);
-    unsigned int flags = SPCC_RoundTrip;
+    unsigned int flags = 0;
+
+    if (ctx.LangOpts.hasFeature(Feature::ParserRoundTrip))
+      flags |= SPCC_RoundTrip;
+
+    if (!ctx.Diags.hadAnyError() &&
+        ctx.LangOpts.hasFeature(Feature::ParserValidation))
+      flags |= SPCC_ParseDiagnostics;
 
     int roundTripResult =
       swift_parser_consistencyCheck(


### PR DESCRIPTION
Add the experimental feature `ParserValidation`. When enabled, the new Swift Swift parser will be run on each source file. When the C++ Swift parser produces no diagnostics, this will also check that the Swift Swift parser produces no diagnostics. This helps us ensure that we are getting valid parses for well-formed code.

Note that this can be combined with `ParserRoundTrip`.

Depends on https://github.com/apple/swift-syntax/pull/733