### PR TITLE
CallerAnalysis: be more tolerant about missing FunctionInfos

### DIFF
--- a/include/swift/SILOptimizer/Analysis/CallerAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/CallerAnalysis.h
@@ -91,12 +91,7 @@ public:
 
   /// Notify the analysis about a function which will be deleted from the
   /// module.
-  void notifyWillDeleteFunction(SILFunction *f) override {
-    invalidateAllInfo(f);
-    recomputeFunctionList.remove(f);
-    // Now that we have invalidated all references to the function, delete it.
-    funcInfos.erase(f);
-  }
+  void notifyWillDeleteFunction(SILFunction *f) override;
 
   /// Notify the analysis about changed witness or vtables.
   ///
@@ -107,6 +102,9 @@ public:
 
   /// Look up the function info that we have stored for f, recomputing all
   /// invalidating parts of the call graph.
+  ///
+  /// Warning: The returned FunctionInfo is only alive until the next call to
+  /// `getFunctionInfo`.
   const FunctionInfo &getFunctionInfo(SILFunction *f) const;
 
   SWIFT_DEBUG_DUMP;
@@ -146,7 +144,7 @@ private:
   void invalidateKnownCallees(SILFunction *caller, FunctionInfo &callerInfo);
 
   /// Invalidate both the known callees of f and the known callers of f.
-  void invalidateAllInfo(SILFunction *f);
+  void invalidateAllInfo(SILFunction *f, FunctionInfo &fInfo);
 
   /// Helper method that reprocesses all elements of recomputeFunctionList and
   /// then clears the function list.


### PR DESCRIPTION
In theory, the analysis invalidation notifications should assure that every function has a CallerAnalysis::FunctionInfo in `funcInfos`. But it's not unlikely that we are missing some of those notifications. We got some not-reproducible crash reports because of missing function infos in CallerAnalysis. With this change the analysis accepts missing function infos and does the right thing if such an info is missing.

In the long term we should replace CallerAnalysis by FunctionUses, anyway.

rdar://99653954
