### PR TITLE
Add link between swiftBasic and swiftAST

### DIFF
--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -98,6 +98,10 @@ target_link_libraries(swiftBasic PUBLIC
 target_link_libraries(swiftBasic PRIVATE
   ${UUID_LIBRARIES})
 
+# This is because swiftBasic uses InFlightDiagnostic::flush, which is defined
+# in swiftAST. This is a cyclic link dependency and it should be removed.
+target_link_libraries(swiftBasic PUBLIC swiftAST)
+
 message(STATUS "Swift version: ${SWIFT_VERSION}")
 message(STATUS "Swift vendor: ${SWIFT_VENDOR}")
 


### PR DESCRIPTION
swiftBasic uses `InFlightDiagnostic::flush`, which is defined in swiftAST. The build graph did not contain that link edge, so it failed to link on Windows. No idea how it's working on macOS ¯\_(ツ)_/¯.