### PR TITLE
[syntax] Add has_value() and value() to OptionalStorage

### DIFF
--- a/include/swift/Syntax/AbsoluteRawSyntax.h
+++ b/include/swift/Syntax/AbsoluteRawSyntax.h
@@ -395,9 +395,18 @@ public:
 
   void reset() { Storage = AbsoluteRawSyntax(nullptr); }
 
+  bool has_value() const { return !Storage.isNull(); }
   bool hasValue() const { return !Storage.isNull(); }
 
+  AbsoluteRawSyntax &value() & {
+    assert(hasValue());
+    return Storage;
+  }
   AbsoluteRawSyntax &getValue() & {
+    assert(hasValue());
+    return Storage;
+  }
+  AbsoluteRawSyntax const &value() const & {
     assert(hasValue());
     return Storage;
   }
@@ -406,6 +415,10 @@ public:
     return Storage;
   }
 #if LLVM_HAS_RVALUE_REFERENCE_THIS
+  AbsoluteRawSyntax &&value() &&noexcept {
+    assert(hasValue());
+    return std::move(Storage);
+  }
   AbsoluteRawSyntax &&getValue() &&noexcept {
     assert(hasValue());
     return std::move(Storage);

--- a/include/swift/Syntax/SyntaxData.h
+++ b/include/swift/Syntax/SyntaxData.h
@@ -414,9 +414,18 @@ public:
 
   void reset() { Storage = SyntaxDataRef(AbsoluteRawSyntax(nullptr), nullptr); }
 
+  bool has_value() const { return !Storage.getAbsoluteRaw().isNull(); }
   bool hasValue() const { return !Storage.getAbsoluteRaw().isNull(); }
 
+  SyntaxDataRef &value() & {
+    assert(hasValue());
+    return Storage;
+  }
   SyntaxDataRef &getValue() & {
+    assert(hasValue());
+    return Storage;
+  }
+  SyntaxDataRef const &value() const & {
     assert(hasValue());
     return Storage;
   }
@@ -425,6 +434,10 @@ public:
     return Storage;
   }
 #if LLVM_HAS_RVALUE_REFERENCE_THIS
+  SyntaxDataRef &&value() &&noexcept {
+    assert(hasValue());
+    return std::move(Storage);
+  }
   SyntaxDataRef &&getValue() &&noexcept {
     assert(hasValue());
     return std::move(Storage);


### PR DESCRIPTION
This matches an upstream change to Optional to use the newer spellings. While stable/20220421 branch has not deprecated/removed the old spellings, the implementation of Optional itself will adopt the new spellings. We can remove or deprecated the old versions in the next llvm rebranch.