### PR TITLE
stdlib: fix compilation error when compiling with an old compiler

### DIFF
--- a/stdlib/public/core/StringSwitch.swift
+++ b/stdlib/public/core/StringSwitch.swift
@@ -68,7 +68,11 @@ func _findStringSwitchCaseWithCache(
   string: String,
   cache: inout _OpaqueStringSwitchCache) -> Int {
 
+#if $BuiltinUnprotectedAddressOf
   let ptr = UnsafeMutableRawPointer(Builtin.unprotectedAddressOf(&cache))
+#else
+  let ptr = UnsafeMutableRawPointer(Builtin.addressof(&cache))
+#endif
   let oncePtr = ptr
   let cacheRawPtr = oncePtr + MemoryLayout<Builtin.Word>.stride
   let cachePtr = cacheRawPtr.bindMemory(to: _StringSwitchCache.self, capacity: 1)

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -1095,7 +1095,7 @@ public func _withUnprotectedUnsafeBytes<T, Result>(
 #if $BuiltinUnprotectedAddressOf
   let addr = UnsafeRawPointer(Builtin.unprotectedAddressOfBorrow(value))
 #else
-  let addr = UnsafeRawPointer(Builtin.addressof(value))
+  let addr = UnsafeRawPointer(Builtin.addressOfBorrow(value))
 #endif
   let buffer = UnsafeRawBufferPointer(start: addr, count: MemoryLayout<T>.size)
   return try body(buffer)


### PR DESCRIPTION
Fix wrong/missing check for `$BuiltinUnprotectedAddressOf` around the new "unprotectedAddressOf" builtins.

rdar://99713099
