### PR TITLE
[5.7🍒][Build] Update scripts to use dyld_info

### DIFF
--- a/utils/swift-darwin-postprocess.py
+++ b/utils/swift-darwin-postprocess.py
@@ -31,9 +31,17 @@ def main(arguments):
 # with runpath-relative loads of system libraries on some dyld versions.
 # (rdar://78851265)
 def unrpathize(filename):
-    dylibsOutput = subprocess.check_output(
-        ['xcrun', 'dyldinfo', '-dylibs', filename],
-        universal_newlines=True)
+    dylibsOutput = None
+    try:
+        # `dyldinfo` has been replaced with `dyld_info`, so we try it first
+        # before falling back to `dyldinfo`
+        dylibsOutput = subprocess.check_output(
+            ['xcrun', 'dyld_info', '-dependents', filename],
+            universal_newlines=True)
+    except subprocess.CalledProcessError:
+        dylibsOutput = subprocess.check_output(
+            ['xcrun', 'dyldinfo', '-dylibs', filename],
+            universal_newlines=True)
 
     # Do not rewrite @rpath-relative load commands for these libraries:
     # they are test support libraries that are never installed under

--- a/utils/swift-rpathize.py
+++ b/utils/swift-rpathize.py
@@ -54,9 +54,18 @@ def main(arguments):
 
 
 def rpathize(filename):
-    dylibsOutput = subprocess.check_output(
-        ['xcrun', 'dyldinfo', '-dylibs', filename],
-        universal_newlines=True)
+    dylibsOutput = None
+
+    try:
+        # `dyldinfo` has been replaced with `dyld_info`, so we try it first
+        # before falling back to `dyldinfo`
+        dylibsOutput = subprocess.check_output(
+            ['xcrun', 'dyld_info', '-dependents', filename],
+            universal_newlines=True)
+    except subprocess.CalledProcessError:
+        dylibsOutput = subprocess.check_output(
+            ['xcrun', 'dyldinfo', '-dylibs', filename],
+            universal_newlines=True)
 
     # The output from dyldinfo -dylibs is a line of header followed by one
     # install name per line, indented with spaces.


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/60532 to fix the `dyldinfo` vs `dyld_info` difference in Xcode 13 vs 14.