### PR TITLE
[Sema] Check exportability of @_spiOnly imported decls

### DIFF
--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -344,6 +344,12 @@ code for the target that is not the build machine:
   swiftinterface to the given path and passing additional default flags
   appropriate for resilient frameworks.
 
+* ``%target-swift-emit-module-interfaces(`` *swift interface path*,
+  *swift private interface path* ``)`` *other arguments*:
+  run ``swift-frontend`` for the target, emitting both swiftinterfaces
+  to the given paths and passing additional default flags appropriate for
+  resilient frameworks.
+
 * ``%target-swift-typecheck-module-from-interface(`` *swift interface path*
   ``)`` *other arguments*: run ``swift-frontend`` for the target, verifying
   the swiftinterface at the given path and passing additional default flags

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2931,6 +2931,7 @@ ERROR(decl_from_hidden_module,none,
       "%select{%3 has been imported as implementation-only|"
       "it is an SPI imported from %3|"
       "it is SPI|"
+      "%3 was imported for SPI only|"
       "%3 was not imported by this file}4",
       (DescriptiveDeclKind, DeclName, unsigned, Identifier, unsigned))
 WARNING(decl_from_hidden_module_warn,none,
@@ -2939,7 +2940,7 @@ WARNING(decl_from_hidden_module_warn,none,
       "in an extension with public or '@usableFromInline' members|"
       "in an extension with conditional conformances}2; "
       "%select{%3 has been imported as implementation-only|"
-      "<<ERROR>>|<<ERROR>>|"
+      "<<ERROR>>|<<ERROR>>|<<ERROR>>|"
       "%3 was not imported by this file}4",
       (DescriptiveDeclKind, DeclName, unsigned, Identifier, unsigned))
 ERROR(typealias_desugars_to_type_from_hidden_module,none,
@@ -2951,6 +2952,7 @@ ERROR(typealias_desugars_to_type_from_hidden_module,none,
       "because %select{%4 has been imported as implementation-only|"
       "it is an SPI imported from %4|"
       "<<ERROR>>|"
+      "%4 was imported for SPI only|"
       "%4 was not imported by this file}5",
       (DeclName, StringRef, StringRef, unsigned, Identifier, unsigned))
 ERROR(conformance_from_implementation_only_module,none,
@@ -2961,6 +2963,7 @@ ERROR(conformance_from_implementation_only_module,none,
       "%select{%3 has been imported as implementation-only|"
       "the conformance is declared as SPI in %3|"
       "the conformance is declared as SPI|"
+      "%3 was imported for SPI only|"
       "%3 was not imported by this file}4",
       (Type, Identifier, unsigned, Identifier, unsigned))
 NOTE(assoc_conformance_from_implementation_only_module,none,
@@ -5860,12 +5863,13 @@ ERROR(inlinable_decl_ref_from_hidden_module,
       "because %select{%3 was imported implementation-only|"
       "it is an SPI imported from %3|"
       "it is SPI|"
+      "%3 was imported for SPI only|"
       "%3 was not imported by this file}4",
       (DescriptiveDeclKind, DeclName, unsigned, Identifier, unsigned))
 
 WARNING(inlinable_decl_ref_from_hidden_module_warn,
       none, "%0 %1 cannot be used in " FRAGILE_FUNC_KIND "2 "
-      "because %select{<<ERROR>>|<<ERROR>>|<<ERROR>>|"
+      "because %select{<<ERROR>>|<<ERROR>>|<<ERROR>>|<<ERROR>>|"
       "%3 was not imported by this file}4"
       "; this is an error in Swift 6",
       (DescriptiveDeclKind, DeclName, unsigned, Identifier, unsigned))
@@ -5875,6 +5879,7 @@ ERROR(inlinable_typealias_desugars_to_type_from_hidden_module,
       "because %select{%4 has been imported as implementation-only|"
       "it is an SPI imported from %4|"
       "<<ERROR>>|"
+      "%4 was imported for SPI only|"
       "%4 was not imported by this file}5",
       (DeclName, StringRef, StringRef, unsigned, Identifier, unsigned))
 

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -26,12 +26,20 @@ namespace swift {
 class PersistentParserState;
 
 /// Kind of import affecting how a decl can be reexported.
+///
+/// This is sorted in order of priority in case the same module is imported
+/// differently. e.g. a normal import (None) offers more visibility than
+/// an @_spiOnly import, which offers more visibility than an
+/// @_implementationOnly import. The logic of \c getRestrictedImportKind relies
+/// on the order of this enum.
+///
 /// This is a subset of \c DisallowedOriginKind.
 ///
 /// \sa getRestrictedImportKind
 enum class RestrictedImportKind {
-  ImplementationOnly,
   Implicit,
+  ImplementationOnly,
+  SPIOnly,
   None // No restriction, i.e. the module is imported publicly.
 };
 

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -1548,7 +1548,9 @@ swift::getDisallowedOriginKind(const Decl *decl,
   if (howImported != RestrictedImportKind::None) {
     // Temporarily downgrade implementation-only exportability in SPI to
     // a warning.
-    if (where.isSPI())
+    if (where.isSPI() &&
+        where.getFragileFunctionKind().kind == FragileFunctionKind::None &&
+        !SF->getASTContext().LangOpts.EnableSPIOnlyImports)
       downgradeToWarning = DowngradeToWarning::Yes;
 
     if (where.isSPI() && howImported == RestrictedImportKind::SPIOnly)

--- a/lib/Sema/TypeCheckAccess.h
+++ b/lib/Sema/TypeCheckAccess.h
@@ -44,6 +44,7 @@ enum class DisallowedOriginKind : uint8_t {
   ImplementationOnly,
   SPIImported,
   SPILocal,
+  SPIOnly,
   ImplicitlyImported,
   None
 };

--- a/test/SPI/report-ioi-in-spi.swift
+++ b/test/SPI/report-ioi-in-spi.swift
@@ -1,0 +1,60 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module %t/Lib.swift -I %t \
+// RUN:   -module-name Lib -emit-module-path %t/Lib.swiftmodule \
+// RUN:   -swift-version 5
+
+/// Use of IOI types in SPI signatures is an error with -experimental-spi-only-imports
+// RUN: %target-swift-frontend -emit-module %t/ClientSPIOnlyMode.swift -I %t \
+// RUN:   -swift-version 5 -verify \
+// RUN:   -experimental-spi-only-imports
+
+/// Use of IOI types in SPI signatures is a warning without -experimental-spi-only-imports
+// RUN: %target-swift-frontend -emit-module %t/ClientDefaultMode.swift -I %t \
+// RUN:   -swift-version 5 -verify
+
+/// This is a warning in swiftinterfaces
+// R UN: %target-swift-typecheck-module-from-interface(%t/Client.private.swiftinterface) \
+// R UN:   -I %t -module-name Client
+
+//--- Lib.swift
+
+public struct IOIStruct {
+    public init() {}
+}
+
+//--- ClientSPIOnlyMode.swift
+
+@_implementationOnly import Lib
+
+@_spi(X) public func spiClient(s: IOIStruct) -> IOIStruct { // expected-error 2 {{cannot use struct 'IOIStruct' here; 'Lib' has been imported as implementation-only}}
+    return IOIStruct()
+}
+
+@_spi(X) @inlinable public func inlinableClient(s: IOIStruct) -> IOIStruct { // expected-error 2 {{struct 'IOIStruct' cannot be used in an '@inlinable' function because 'Lib' was imported implementation-only}}
+    return IOIStruct() // expected-error {{struct 'IOIStruct' cannot be used in an '@inlinable' function because 'Lib' was imported implementation-only}}
+    // expected-error @-1 {{initializer 'init()' cannot be used in an '@inlinable' function because 'Lib' was imported implementation-only}}
+}
+
+//--- ClientDefaultMode.swift
+
+@_implementationOnly import Lib
+
+@_spi(X) public func spiClient(s: IOIStruct) -> IOIStruct { // expected-warning 2 {{cannot use struct 'IOIStruct' here; 'Lib' has been imported as implementation-only}}
+    return IOIStruct()
+}
+
+@_spi(X) @inlinable public func inlinableClient(s: IOIStruct) -> IOIStruct { // expected-error 2 {{struct 'IOIStruct' cannot be used in an '@inlinable' function because 'Lib' was imported implementation-only}}
+    return IOIStruct() // expected-error {{struct 'IOIStruct' cannot be used in an '@inlinable' function because 'Lib' was imported implementation-only}}
+    // expected-error @-1 {{initializer 'init()' cannot be used in an '@inlinable' function because 'Lib' was imported implementation-only}}
+}
+
+//--- Client.private.swiftinterface
+
+// swift-interface-format-version: 1.0
+// swift-compiler-version: Swift version 5.8-dev effective-4.1.50
+// swift-module-flags: -swift-version 4 -module-name Client
+@_implementationOnly import Lib
+
+@_spi(X) public func spiClient() -> IOIStruct { fatalError() }

--- a/test/SPI/spi-only-and-library-level.swift
+++ b/test/SPI/spi-only-and-library-level.swift
@@ -1,0 +1,42 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module %t/Lib.swift -I %t \
+// RUN:   -module-name Lib -emit-module-path %t/Lib.swiftmodule \
+// RUN:   -swift-version 5
+// RUN: %target-swift-frontend -emit-module %t/APILib.swift -I %t \
+// RUN:   -swift-version 5 -verify \
+// RUN:   -experimental-spi-only-imports \
+// RUN:   -library-level api
+// RUN: %target-swift-frontend -emit-module %t/SPILib.swift -I %t \
+// RUN:   -swift-version 5 -verify \
+// RUN:   -experimental-spi-only-imports \
+// RUN:   -library-level spi
+// RUN: %target-swift-frontend -emit-module %t/OtherLib.swift -I %t \
+// RUN:   -swift-version 5 -verify \
+// RUN:   -experimental-spi-only-imports
+
+//--- Lib.swift
+
+public struct LibStruct {}
+
+//--- APILib.swift
+
+@_spiOnly import Lib
+
+public func publicClient() -> LibStruct { fatalError() } // expected-error {{cannot use struct 'LibStruct' here; 'Lib' was imported for SPI only}}
+@_spi(X) public func spiClient() -> LibStruct { fatalError() }
+
+//--- SPILib.swift
+
+@_spiOnly import Lib
+
+public func publicClient() -> LibStruct { fatalError() }
+@_spi(X) public func spiClient() -> LibStruct { fatalError() }
+
+//--- OtherLib.swift
+
+@_spiOnly import Lib
+
+public func publicClient() -> LibStruct { fatalError() } // expected-error {{cannot use struct 'LibStruct' here; 'Lib' was imported for SPI only}}
+@_spi(X) public func spiClient() -> LibStruct { fatalError() }

--- a/test/SPI/spi-only-import-exportability.swift
+++ b/test/SPI/spi-only-import-exportability.swift
@@ -1,0 +1,152 @@
+/// Test @_spiOnly exportability type-checking
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// Generate dependencies.
+// RUN: %target-swift-frontend -emit-module %t/PublicLib.swift \
+// RUN:   -module-name PublicLib -emit-module-path %t/PublicLib.swiftmodule \
+// RUN:   -swift-version 5 -enable-library-evolution
+// RUN: %target-swift-frontend -emit-module %t/SPIOnlyImportedLib.swift \
+// RUN:   -module-name SPIOnlyImportedLib \
+// RUN:   -emit-module-path %t/SPIOnlyImportedLib.swiftmodule \
+// RUN:   -swift-version 5 -enable-library-evolution -I %t
+
+/// Test the client.
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t -verify \
+// RUN:   -experimental-spi-only-imports
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t -verify \
+// RUN:   -experimental-spi-only-imports \
+// RUN:   -enable-library-evolution
+
+/// Generate the swiftinterface of the working code and verify it.
+// RUN: %target-swift-emit-module-interface(%t/Client.swiftinterface) \
+// RUN:   %t/Client.swift -I %t -DSKIP_ERRORS \
+// RUN:   -experimental-spi-only-imports
+// RUN: %target-swift-typecheck-module-from-interface(%t/Client.swiftinterface) -I %t
+
+
+//--- PublicLib.swift
+
+public struct PublicType {
+    public init() {}
+}
+
+public protocol PublicProtocol {}
+public func conformanceUse(_ a: PublicProtocol) {}
+
+@propertyWrapper
+public struct PublicPropertyWrapper<T> {
+  public var wrappedValue: T
+
+  public init(wrappedValue value: T) { self.wrappedValue = value }
+  public init(_ value: T) { self.wrappedValue = value }
+}
+
+//--- SPIOnlyImportedLib.swift
+import PublicLib
+
+public func spiOnlyFunc() -> String { fatalError() }
+
+public protocol SPIOnlyProto {
+}
+
+public struct SPIOnlyStruct {
+    public init() {}
+    public func structMethod() {}
+}
+
+public class SPIOnlyClass<P: PublicProtocol> {
+    public init(p: P) {}
+    public func classMethod() {}
+}
+
+public enum SPIOnlyEnum {
+    case A
+    case B
+    public func enumMethod() {}
+}
+
+extension PublicType {
+    public func spiOnlyExtensionMethod() {}
+}
+
+extension PublicType : PublicProtocol {}
+
+@propertyWrapper
+public struct SPIOnlyPropertyWrapper<T> {
+  public var wrappedValue: T
+
+  public init(wrappedValue value: T) { self.wrappedValue = value }
+  public init(_ value: T) { self.wrappedValue = value }
+}
+
+//--- Client.swift
+
+import PublicLib
+@_spiOnly import SPIOnlyImportedLib
+
+#if !SKIP_ERRORS
+public func publicUser<T: SPIOnlyProto>(_ a: SPIOnlyStruct, t: T) -> SPIOnlyStruct { fatalError() }
+// expected-error @-1 2 {{cannot use struct 'SPIOnlyStruct' here; 'SPIOnlyImportedLib' was imported for SPI only}}
+// expected-error @-2 {{cannot use protocol 'SPIOnlyProto' here; 'SPIOnlyImportedLib' was imported for SPI only}}
+#endif
+
+@_spi(X) public func spiUser(_ a: SPIOnlyStruct) -> SPIOnlyStruct { fatalError() }
+
+internal func internalUser(_ a: SPIOnlyStruct) -> SPIOnlyStruct { fatalError() }
+
+#if !SKIP_ERRORS
+@inlinable
+public func publicInlinableUser() {
+    _ = spiOnlyFunc() // expected-error {{global function 'spiOnlyFunc()' cannot be used in an '@inlinable' function because 'SPIOnlyImportedLib' was imported for SPI only}}
+
+    var x: SPIOnlyStruct // expected-error {{struct 'SPIOnlyStruct' cannot be used in an '@inlinable' function because 'SPIOnlyImportedLib' was imported for SPI only}}
+    x = SPIOnlyStruct() // expected-error {{struct 'SPIOnlyStruct' cannot be used in an '@inlinable' function because 'SPIOnlyImportedLib' was imported for SPI only}}
+    // expected-error @-1 {{initializer 'init()' cannot be used in an '@inlinable' function because 'SPIOnlyImportedLib' was imported for SPI only}}
+    x.structMethod() // expected-error {{instance method 'structMethod()' cannot be used in an '@inlinable' function because 'SPIOnlyImportedLib' was imported for SPI only}}
+
+    var c: SPIOnlyClass<PublicType> // expected-error {{generic class 'SPIOnlyClass' cannot be used in an '@inlinable' function because 'SPIOnlyImportedLib' was imported for SPI only}}
+    c = SPIOnlyClass(p: PublicType()) // expected-error {{generic class 'SPIOnlyClass' cannot be used in an '@inlinable' function because 'SPIOnlyImportedLib' was imported for SPI only}}
+    // expected-error @-1 {{initializer 'init(p:)' cannot be used in an '@inlinable' function because 'SPIOnlyImportedLib' was imported for SPI only}}
+    c.classMethod() // expected-error {{instance method 'classMethod()' cannot be used in an '@inlinable' function because 'SPIOnlyImportedLib' was imported for SPI only}}
+
+    var e: SPIOnlyEnum // expected-error {{enum 'SPIOnlyEnum' cannot be used in an '@inlinable' function because 'SPIOnlyImportedLib' was imported for SPI only}}
+    e = .A // expected-error {{enum case 'A' cannot be used in an '@inlinable' function because 'SPIOnlyImportedLib' was imported for SPI only}}
+    e.enumMethod() // expected-error {{instance method 'enumMethod()' cannot be used in an '@inlinable' function because 'SPIOnlyImportedLib' was imported for SPI only}}
+
+    let p: PublicType = PublicType()
+    p.spiOnlyExtensionMethod() // expected-error {{instance method 'spiOnlyExtensionMethod()' cannot be used in an '@inlinable' function because 'SPIOnlyImportedLib' was imported for SPI only}}
+}
+#endif
+
+@inlinable @_spi(X)
+public func spiInlinableUser() {
+    _ = spiOnlyFunc()
+
+    var x: SPIOnlyStruct
+    x = SPIOnlyStruct()
+    x.structMethod()
+
+    let p: PublicType = PublicType()
+    p.spiOnlyExtensionMethod()
+}
+
+public func implementationDetailsUser() {
+    _ = spiOnlyFunc()
+
+    var x: SPIOnlyStruct
+    x = SPIOnlyStruct()
+    x.structMethod()
+
+    let p: PublicType = PublicType()
+    p.spiOnlyExtensionMethod()
+}
+
+public struct ClientStruct {
+#if !SKIP_ERRORS
+  public var a: SPIOnlyStruct // expected-error {{cannot use struct 'SPIOnlyStruct' here; 'SPIOnlyImportedLib' was imported for SPI only}}
+  @SPIOnlyPropertyWrapper(42) public var aWrapped: Any // expected-error {{cannot use generic struct 'SPIOnlyPropertyWrapper' as property wrapper here; 'SPIOnlyImportedLib' was imported for SPI only}}
+#endif
+  @PublicPropertyWrapper(SPIOnlyStruct()) public var bWrapped: Any
+}

--- a/test/SPI/spi-only-import-exportability.swift
+++ b/test/SPI/spi-only-import-exportability.swift
@@ -20,10 +20,11 @@
 // RUN:   -enable-library-evolution
 
 /// Generate the swiftinterface of the working code and verify it.
-// RUN: %target-swift-emit-module-interface(%t/Client.swiftinterface) \
+// RUN: %target-swift-emit-module-interfaces(%t/Client.swiftinterface, %t/Client.private.swiftinterface) \
 // RUN:   %t/Client.swift -I %t -DSKIP_ERRORS \
 // RUN:   -experimental-spi-only-imports
 // RUN: %target-swift-typecheck-module-from-interface(%t/Client.swiftinterface) -I %t
+// RUN: %target-swift-typecheck-module-from-interface(%t/Client.private.swiftinterface) -I %t
 
 
 //--- PublicLib.swift

--- a/test/Sema/restricted-imports-priorities.swift
+++ b/test/Sema/restricted-imports-priorities.swift
@@ -1,0 +1,74 @@
+/// Test that the least restricting restricted import takes priority in
+/// exportability checks.
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// Generate dependencies.
+// RUN: %target-swift-frontend -emit-module %t/LibA.swift \
+// RUN:   -module-name LibA -emit-module-path %t/LibA.swiftmodule \
+// RUN:   -swift-version 5 -enable-library-evolution
+// RUN: %target-swift-frontend -emit-module %t/LibB.swift \
+// RUN:   -module-name LibB -emit-module-path %t/LibB.swiftmodule \
+// RUN:   -swift-version 5 -enable-library-evolution -I %t
+// RUN: %target-swift-frontend -emit-module %t/LibC.swift \
+// RUN:   -module-name LibC -emit-module-path %t/LibC.swiftmodule \
+// RUN:   -swift-version 5 -enable-library-evolution -I %t
+
+// RUN: %target-swift-frontend -typecheck %t/TwoIOI.swift -I %t -verify \
+// RUN:   -experimental-spi-only-imports -verify
+// RUN: %target-swift-frontend -typecheck %t/SPIOnlyAndIOI1.swift -I %t -verify \
+// RUN:   -experimental-spi-only-imports -verify
+// RUN: %target-swift-frontend -typecheck %t/SPIOnlyAndIOI2.swift -I %t -verify \
+// RUN:   -experimental-spi-only-imports -verify
+// RUN: %target-swift-frontend -typecheck %t/TwoSPIOnly.swift -I %t -verify \
+// RUN:   -experimental-spi-only-imports -verify
+// RUN: %target-swift-frontend -typecheck %t/OneSPIOnly1.swift -I %t -verify \
+// RUN:   -experimental-spi-only-imports -verify
+// RUN: %target-swift-frontend -typecheck %t/OneSPIOnly2.swift -I %t -verify \
+// RUN:   -experimental-spi-only-imports -verify
+
+/// Setup 2 indirect imports of LibA, allowing the same LibA to be imported
+/// via 2 different imports from the same file.
+//--- LibA.swift
+public struct LibAStruct {}
+//--- LibB.swift
+@_exported import LibA
+//--- LibC.swift
+@_exported import LibA
+
+//--- TwoIOI.swift
+@_implementationOnly import LibB
+@_implementationOnly import LibC
+
+public func foo(a: LibAStruct) {} // expected-error {{cannot use struct 'LibAStruct' here; 'LibA' has been imported as implementation-only}}
+
+//--- SPIOnlyAndIOI1.swift
+@_spiOnly import LibB
+@_implementationOnly import LibC
+
+public func foo(a: LibAStruct) {} // expected-error {{cannot use struct 'LibAStruct' here; 'LibA' was imported for SPI only}}
+
+//--- SPIOnlyAndIOI2.swift
+@_implementationOnly import LibB
+@_spiOnly import LibC
+
+public func foo(a: LibAStruct) {} // expected-error {{cannot use struct 'LibAStruct' here; 'LibA' was imported for SPI only}}
+
+//--- TwoSPIOnly.swift
+@_spiOnly import LibB
+@_spiOnly import LibC
+
+public func foo(a: LibAStruct) {} // expected-error {{cannot use struct 'LibAStruct' here; 'LibA' was imported for SPI only}}
+
+//--- OneSPIOnly1.swift
+import LibB
+@_spiOnly import LibC
+
+public func foo(a: LibAStruct) {}
+
+//--- OneSPIOnly2.swift
+import LibB
+@_spiOnly import LibC
+
+public func foo(a: LibAStruct) {}

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2300,6 +2300,8 @@ config.substitutions.append(('%target-pic-opt', config.target_pic_opt))
 config.substitutions.append(('%target-msvc-runtime-opt',
                              config.target_msvc_runtime_opt))
 
+config.substitutions.append(('%target-swift-emit-module-interfaces\(([^)]+),\w*([^)]+)\)',
+                             SubstituteCaptures(r'%target-swift-emit-module-interface(\1) -emit-private-module-interface-path \2')))
 config.substitutions.append(('%target-swift-emit-module-interface\(([^)]+)\)',
                              SubstituteCaptures(r'%target-swift-frontend -swift-version 5 -enable-library-evolution -typecheck -emit-module-interface-path \1')))
 


### PR DESCRIPTION
Extend the exportability checker to ensure that types and decls imported from an `@_spiOnly` import are only used in SPI signatures or implementation details, and not used in API. The check will always pick the less restrictive import between `@_spiOnly`, `@_implementationOnly` and the default import to apply the relevant check.

Plus, fix the leak allowing the use of implementation-only imported types in SPI by reporting it as an error when `-experimental-spi-only-imports` is set. This is the desired behavior when the feature will be completed.

This follows the module interface support for @_spiOnly imports in #60935. Next I'll integrate this feature with recent checks of API breakers (typealias desugaring in the swiftinterface, public use of conformances, and public imports of private modules), and report conflicting imports.