### PR TITLE
Revert "[5.7🍒][Concurrency] Handle actor isolation for defers in closures"

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1489,7 +1489,6 @@ static FuncDecl *findAnnotatableFunction(DeclContext *dc) {
 }
 
 /// Note when the enclosing context could be put on a global actor.
-// FIXME: This should handle closures too.
 static void noteGlobalActorOnContext(DeclContext *dc, Type globalActor) {
   // If we are in a synchronous function on the global actor,
   // suggest annotating with the global actor itself.
@@ -3756,6 +3755,14 @@ ActorIsolation ActorIsolationRequest::evaluate(
   // If this is a local function, inherit the actor isolation from its
   // context if it global or was captured.
   if (auto func = dyn_cast<FuncDecl>(value)) {
+    // If this is a defer body, inherit unconditionally; we don't
+    // care if the enclosing function captures the isolated parameter.
+    if (func->isDeferBody()) {
+      auto enclosingIsolation =
+                        getActorIsolationOfContext(func->getDeclContext());
+      return inferredIsolation(enclosingIsolation);
+    }
+
     if (func->isLocalCapture() && !func->isSendable()) {
       switch (auto enclosingIsolation =
                   getActorIsolationOfContext(func->getDeclContext())) {

--- a/test/Concurrency/actor_defer.swift
+++ b/test/Concurrency/actor_defer.swift
@@ -5,7 +5,7 @@
 
 func doSomething() {}
 
-// expected-note @+1 6 {{calls to global function 'requiresMainActor()' from outside of its actor context are implicitly asynchronous}}
+// expected-note @+1 4 {{calls to global function 'requiresMainActor()' from outside of its actor context are implicitly asynchronous}}
 @MainActor func requiresMainActor() {}
 
 @MainActor func testNonDefer_positive() {
@@ -66,7 +66,7 @@ func testGlobalActorAsync_negative() async {
 
 @available(SwiftStdlib 5.1, *)
 actor Actor {
-  // expected-note @+1 6 {{mutation of this property is only permitted within the actor}}
+  // expected-note @+1 3 {{mutation of this property is only permitted within the actor}}
   var actorProperty = 0
 
   func testActor_positive() {
@@ -74,13 +74,6 @@ actor Actor {
       actorProperty += 1
     }
     doSomething()
-  }
-
-  func testActor_task_positive() {
-    Task {
-      defer { actorProperty += 1 }
-      doSomething()
-    }
   }
 
 #if NEGATIVES
@@ -91,29 +84,12 @@ actor Actor {
     }
     doSomething()
   }
-
-  nonisolated func testActor_task_negative() {
-    Task {
-      // expected-error @+1 {{actor-isolated property 'actorProperty' can not be mutated from a non-isolated context}}
-      defer { actorProperty += 1 }
-      doSomething()
-    }
-  }
-
   @MainActor func testActor_negative_globalActor() {
     defer {
       // expected-error @+1 {{actor-isolated property 'actorProperty' can not be mutated from the main actor}}
       actorProperty += 1
     }
     doSomething()
-  }
-
-  func testActor_task_negative_globalActor() {
-    Task { @MainActor in
-      // expected-error @+1 {{actor-isolated property 'actorProperty' can not be mutated from the main actor}}
-      defer { actorProperty += 1 }
-      doSomething()
-    }
   }
 #endif
 
@@ -123,13 +99,6 @@ actor Actor {
     }
     doSomething()
   }
-  
-  func testGlobalActor_task_positive() {
-    Task { @MainActor in
-      defer { requiresMainActor() }
-      doSomething()
-    }
-  }
 
 #if NEGATIVES
   func testGlobalActor_negative() {
@@ -138,14 +107,6 @@ actor Actor {
       requiresMainActor()
     }
     doSomething()
-  }
-
-  func testGlobalActor_task_negative() {
-    Task {
-      // expected-error @+1 {{call to main actor-isolated global function 'requiresMainActor()' in a synchronous nonisolated context}}
-      defer { requiresMainActor() }
-      doSomething()
-    }
   }
 #endif
 }
@@ -167,50 +128,5 @@ func testIsolatedActor_negative(actor: Actor) {
     actor.actorProperty += 1
   }
   doSomething()
-}
-#endif
-
-@available(SwiftStdlib 5.1, *)
-func testGlobalActor_inTask_positive() {
-  Task { @MainActor in
-    defer { requiresMainActor() }
-    doSomething()
-  }
-}
-
-#if NEGATIVES
-@available(SwiftStdlib 5.1, *)
-func testGlobalActor_inTask_negative() {
-  Task {
-    // expected-error @+1 {{call to main actor-isolated global function 'requiresMainActor()' in a synchronous nonisolated context}}
-    defer { requiresMainActor() }
-    doSomething()
-  }
-}
-#endif
-
-@available(SwiftStdlib 5.1, *)
-func takeClosureWithIsolatedParam(body: (isolated Actor) -> Void) {}
-
-@available(SwiftStdlib 5.1, *)
-func takeClosureWithNotIsolatedParam(body: (Actor) -> Void) {}
-
-@available(SwiftStdlib 5.1, *)
-func testIsolatedActor_closure_positive() {
-  takeClosureWithIsolatedParam { actor in
-    actor.actorProperty += 1
-    defer { actor.actorProperty += 1 }
-    doSomething()
-  }
-}
-
-#if NEGATIVES
-@available(SwiftStdlib 5.1, *)
-func testIsolatedActor_closure_negative() {
-  takeClosureWithNotIsolatedParam { actor in
-    // expected-error @+1 {{actor-isolated property 'actorProperty' can not be mutated from a non-isolated context}}
-    defer { actor.actorProperty += 1 }
-    doSomething()
-  }
 }
 #endif


### PR DESCRIPTION
Reverts apple/swift#60886

After this change landed, we started seeing random failures in a few distributed actor tests. So its too risky to take on for 5.7 at the moment.

should resolve rdar://99714807