### PR TITLE
[AST] Improve calculation of source range for brace and do stmt

### DIFF
--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -168,7 +168,8 @@ public:
   SourceLoc getLBraceLoc() const { return LBLoc; }
   SourceLoc getRBraceLoc() const { return RBLoc; }
 
-  SourceRange getSourceRange() const { return SourceRange(LBLoc, RBLoc); }
+  SourceLoc getStartLoc() const;
+  SourceLoc getEndLoc() const;
 
   bool empty() const { return getNumElements() == 0; }
   unsigned getNumElements() const { return Bits.BraceStmt.NumElements; }
@@ -563,8 +564,8 @@ public:
 
   SourceLoc getDoLoc() const { return DoLoc; }
   
-  SourceLoc getStartLoc() const { return getLabelLocOrKeywordLoc(DoLoc); }
-  SourceLoc getEndLoc() const { return Body->getEndLoc(); }
+  SourceLoc getStartLoc() const;
+  SourceLoc getEndLoc() const;
   
   BraceStmt *getBody() const { return Body; }
   void setBody(BraceStmt *s) { Body = s; }

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -156,6 +156,30 @@ BraceStmt *BraceStmt::create(ASTContext &ctx, SourceLoc lbloc,
   return ::new(Buffer) BraceStmt(lbloc, elts, rbloc, implicit);
 }
 
+SourceLoc BraceStmt::getStartLoc() const {
+  if (LBLoc) {
+    return LBLoc;
+  }
+  for (auto elt : getElements()) {
+    if (auto loc = elt.getStartLoc()) {
+      return loc;
+    }
+  }
+  return SourceLoc();
+}
+
+SourceLoc BraceStmt::getEndLoc() const {
+  if (RBLoc) {
+    return RBLoc;
+  }
+  for (auto elt : llvm::reverse(getElements())) {
+    if (auto loc = elt.getEndLoc()) {
+      return loc;
+    }
+  }
+  return SourceLoc();
+}
+
 ASTNode BraceStmt::findAsyncNode() {
   // TODO: Statements don't track their ASTContext/evaluator, so I am not making
   // this a request. It probably should be a request at some point.
@@ -506,6 +530,17 @@ DoStmt *DoStmt::createImplicit(ASTContext &C, LabeledStmtInfo labelInfo,
   return new (C) DoStmt(labelInfo, /*doLoc=*/SourceLoc(),
                         BraceStmt::createImplicit(C, body),
                         /*implicit=*/true);
+}
+
+SourceLoc DoStmt::getStartLoc() const {
+  if (auto LabelOrDoLoc = getLabelLocOrKeywordLoc(DoLoc)) {
+    return LabelOrDoLoc;
+  }
+  return Body->getStartLoc();
+}
+
+SourceLoc DoStmt::getEndLoc() const {
+  return Body->getEndLoc();
 }
 
 namespace {

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -593,7 +593,7 @@ public:
       }
     }
 
-    if (!TopLevel && !HighPerformance) {
+    if (!TopLevel && !HighPerformance && !BS->isImplicit()) {
       Elements.insert(Elements.begin(), *buildScopeEntry(BS->getSourceRange()));
       Elements.insert(Elements.end(), *buildScopeExit(BS->getSourceRange()));
     }


### PR DESCRIPTION
This allows us to later skip brace and do statements in result builders that are unrelated to the code completion token.