### PR TITLE
[Sema] Integrate `@_spiOnly` imports logic with recent API checks

### DIFF
--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -255,7 +255,8 @@ TypeChecker::diagnoseConformanceExportability(SourceLoc loc,
                      M->getName(),
                      static_cast<unsigned>(originKind))
       .warnUntilSwiftVersionIf((useConformanceAvailabilityErrorsOption &&
-                                !ctx.LangOpts.EnableConformanceAvailabilityErrors) ||
+                                !ctx.LangOpts.EnableConformanceAvailabilityErrors &&
+                                originKind != DisallowedOriginKind::SPIOnly) ||
                                originKind == DisallowedOriginKind::ImplicitlyImported,
                                6);
 

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -132,7 +132,8 @@ static bool diagnoseTypeAliasDeclRefExportability(SourceLoc loc,
                   TAD->getName(), definingModule->getNameStr(), D->getNameStr(),
                   static_cast<unsigned>(*reason), definingModule->getName(),
                   static_cast<unsigned>(originKind))
-        .warnUntilSwiftVersion(6);
+        .warnUntilSwiftVersionIf(originKind != DisallowedOriginKind::SPIOnly,
+                                 6);
   } else {
     ctx.Diags
         .diagnose(loc,
@@ -140,7 +141,8 @@ static bool diagnoseTypeAliasDeclRefExportability(SourceLoc loc,
                   TAD->getName(), definingModule->getNameStr(), D->getNameStr(),
                   fragileKind.getSelector(), definingModule->getName(),
                   static_cast<unsigned>(originKind))
-        .warnUntilSwiftVersion(6);
+        .warnUntilSwiftVersionIf(originKind != DisallowedOriginKind::SPIOnly,
+                                 6);
   }
   D->diagnose(diag::kind_declared_here, DescriptiveDeclKind::Type);
 

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1848,6 +1848,7 @@ public:
       auto importer = ID->getModuleContext();
       if (target &&
           !ID->getAttrs().hasAttribute<ImplementationOnlyAttr>() &&
+          !ID->getAttrs().hasAttribute<SPIOnlyAttr>() &&
           target->getLibraryLevel() == LibraryLevel::SPI) {
 
         auto &diags = ID->getASTContext().Diags;

--- a/test/SPI/spi-only-import-exportability.swift
+++ b/test/SPI/spi-only-import-exportability.swift
@@ -118,6 +118,7 @@ public func publicInlinableUser() {
 
     let p: PublicType = PublicType()
     p.spiOnlyExtensionMethod() // expected-error {{instance method 'spiOnlyExtensionMethod()' cannot be used in an '@inlinable' function because 'SPIOnlyImportedLib' was imported for SPI only}}
+    conformanceUse(p) // expected-error{{cannot use conformance of 'PublicType' to 'PublicProtocol' here; 'SPIOnlyImportedLib' was imported for SPI only}}
 }
 #endif
 
@@ -131,6 +132,7 @@ public func spiInlinableUser() {
 
     let p: PublicType = PublicType()
     p.spiOnlyExtensionMethod()
+    conformanceUse(p)
 }
 
 public func implementationDetailsUser() {
@@ -142,6 +144,7 @@ public func implementationDetailsUser() {
 
     let p: PublicType = PublicType()
     p.spiOnlyExtensionMethod()
+    conformanceUse(p)
 }
 
 public struct ClientStruct {

--- a/test/Sema/implementation-only-import-suggestion.swift
+++ b/test/Sema/implementation-only-import-suggestion.swift
@@ -54,6 +54,18 @@ import LocalClang // expected-error{{private module 'LocalClang' is imported pub
 @_implementationOnly import FullyPrivateClang
 @_implementationOnly import LocalClang
 
+/// Expect no errors with spi-only imports.
+// RUN: %target-swift-frontend -typecheck -sdk %t/sdk -module-cache-path %t %s \
+// RUN:   -experimental-spi-only-imports \
+// RUN:   -F %t/sdk/System/Library/PrivateFrameworks/ \
+// RUN:   -library-level api -D SPI_ONLY_IMPORTS
+#elseif SPI_ONLY_IMPORTS
+
+@_spiOnly import PrivateSwift
+@_spiOnly import PublicClang_Private
+@_spiOnly import FullyPrivateClang
+@_spiOnly import LocalClang
+
 #endif
 
 /// Test error message on an unknown library level name.

--- a/test/Sema/implicit-import-typealias.swift
+++ b/test/Sema/implicit-import-typealias.swift
@@ -9,6 +9,7 @@
 
 // RUN: %target-swift-frontend -typecheck -verify %t/UsesAliasesNoImport.swift -I %t
 // RUN: %target-swift-frontend -typecheck -verify %t/UsesAliasesImplementationOnlyImport.swift -I %t
+// RUN: %target-swift-frontend -typecheck -verify %t/UsesAliasesSPIOnlyImport.swift -I %t -experimental-spi-only-imports
 // RUN: %target-swift-frontend -typecheck -verify %t/UsesAliasesWithImport.swift  -I %t
 
 /// The swiftinterface is broken by the missing import without the workaround.
@@ -98,6 +99,20 @@ import Aliases
 }
 
 // expected-warning@+1 {{'ProtoAlias' aliases 'Original.Proto' and cannot be used here because 'Original' has been imported as implementation-only; this is an error in Swift 6}}
+public func takesGeneric<T: ProtoAlias>(_ t: T) {}
+
+
+//--- UsesAliasesSPIOnlyImport.swift
+
+import Aliases
+@_spiOnly import Original
+
+@inlinable public func inlinableFunc() {
+  // expected-error@+1 {{'StructAlias' aliases 'Original.Struct' and cannot be used in an '@inlinable' function because 'Original' was imported for SPI only}}
+  _ = StructAlias.self
+}
+
+// expected-error@+1 {{'ProtoAlias' aliases 'Original.Proto' and cannot be used here because 'Original' was imported for SPI only}}
 public func takesGeneric<T: ProtoAlias>(_ t: T) {}
 
 


### PR DESCRIPTION
We recently added checks to prevent SDK breakages and downgraded to warnings until Swift 6. Since `@_spiOnly` is a new feature we can skip the warning step and apply them as errors right away.

1. Public use of a typealiases that desugars to something from an `@_spiOnly` import is reported as an error.
2. Public use of an `@_spiOnly` imported conformance is reported as an error.
3. Accept `@_spiOnly` imports of a private module from a public module.

This follows the exportability check added in #61011. Next I’ll add reports of conflicting imports from the same file, and look into better integration with the SPI library-level.