### PR TITLE
[AST/TypeChecker] TypeWrappers: Add @typeWrapperIgnored attribute

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -778,6 +778,11 @@ DECL_ATTR(_documentation, Documentation,
   APIBreakingToAdd | APIStableToRemove | ABIStableToAdd | ABIStableToRemove,
   136)
 
+SIMPLE_DECL_ATTR(typeWrapperIgnored, TypeWrapperIgnored,
+  OnVar |
+  ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
+  137)
+
 // If you're adding a new underscored attribute here, please document it in
 // docs/ReferenceGuides/UnderscoredAttributes.md.
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6560,5 +6560,14 @@ ERROR(type_wrapper_type_requirement_not_accessible,none,
       "(which is %select{private|fileprivate|internal|public|open}4)",
       (AccessLevel, DescriptiveDeclKind, DeclName, Type, AccessLevel))
 
+ERROR(type_wrapper_ignored_on_local_properties,none,
+      "%0 must not be used on local properties", (DeclAttribute))
+ERROR(type_wrapper_ignored_on_computed_properties,none,
+      "%0 must not be used on computed properties", (DeclAttribute))
+ERROR(type_wrapper_ignored_on_static_properties,none,
+      "%0 must not be used on static properties", (DeclAttribute))
+ERROR(type_wrapper_ignored_on_lazy_properties,none,
+      "%0 must not be used on lazy properties", (DeclAttribute))
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -385,8 +385,12 @@ static ConstructorDecl *createImplicitConstructor(NominalTypeDecl *decl,
         if (var->isImplicit())
           continue;
 
-        // Computed properties are not included.
-        if (!var->hasStorage())
+        // Computed properties are not included, except in cases
+        // where property has a property wrapper and `@typeWrapperIgnored`
+        // attribute.
+        if (!var->hasStorage() &&
+            !(var->hasAttachedPropertyWrapper() &&
+              var->getAttrs().hasAttribute<TypeWrapperIgnoredAttr>()))
           continue;
 
         // If this is a memberwise initializeable property include

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -294,6 +294,7 @@ public:
   void visitCustomAttr(CustomAttr *attr);
   void visitPropertyWrapperAttr(PropertyWrapperAttr *attr);
   void visitTypeWrapperAttr(TypeWrapperAttr *attr);
+  void visitTypeWrapperIgnoredAttr(TypeWrapperIgnoredAttr *attr);
   void visitResultBuilderAttr(ResultBuilderAttr *attr);
 
   void visitImplementationOnlyAttr(ImplementationOnlyAttr *attr);
@@ -3791,6 +3792,46 @@ void AttributeChecker::visitTypeWrapperAttr(TypeWrapperAttr *attr) {
       }
 
       attr->setInvalid();
+      return;
+    }
+  }
+}
+
+void AttributeChecker::visitTypeWrapperIgnoredAttr(TypeWrapperIgnoredAttr *attr) {
+  auto *var = cast<VarDecl>(D);
+
+  // @typeWrapperIgnored applies only to properties that type wrapper can manage.
+  if (var->getDeclContext()->isLocalContext()) {
+    diagnoseAndRemoveAttr(attr, diag::type_wrapper_ignored_on_local_properties, attr);
+    return;
+  }
+
+  if (var->isLet()) {
+    diagnoseAndRemoveAttr(attr, diag::attr_only_one_decl_kind, attr, "var");
+    return;
+  }
+
+  if (var->getAttrs().hasAttribute<LazyAttr>()) {
+    diagnoseAndRemoveAttr(attr, diag::type_wrapper_ignored_on_lazy_properties, attr);
+    return;
+  }
+
+  if (var->isStatic()) {
+    diagnoseAndRemoveAttr(attr, diag::type_wrapper_ignored_on_static_properties, attr);
+    return;
+  }
+
+  // computed properties
+  {
+    SmallVector<AccessorKind, 4> accessors{AccessorKind::Get, AccessorKind::Set,
+                                           AccessorKind::Modify,
+                                           AccessorKind::MutableAddress};
+
+    if (llvm::any_of(accessors, [&var](const auto &accessor) {
+          return var->getParsedAccessor(accessor);
+        })) {
+      diagnoseAndRemoveAttr(
+          attr, diag::type_wrapper_ignored_on_computed_properties, attr);
       return;
     }
   }

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1587,6 +1587,7 @@ namespace  {
     UNINTERESTING_ATTR(Custom)
     UNINTERESTING_ATTR(PropertyWrapper)
     UNINTERESTING_ATTR(TypeWrapper)
+    UNINTERESTING_ATTR(TypeWrapperIgnored)
     UNINTERESTING_ATTR(DisfavoredOverload)
     UNINTERESTING_ATTR(ResultBuilder)
     UNINTERESTING_ATTR(ProjectedValueProperty)

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -172,6 +172,7 @@ actor MyGlobalActor {
 // ON_GLOBALVAR-DAG: Keyword/None:                       noDerivative[#Var Attribute#]; name=noDerivative
 // ON_GLOBALVAR-DAG: Keyword/None:                       exclusivity[#Var Attribute#]; name=exclusivity
 // ON_GLOBALVAR-DAG: Keyword/None:                       preconcurrency[#Var Attribute#]; name=preconcurrency
+// ON_GLOBALVAR-DAG: Keyword/None:                       typeWrapperIgnored[#Var Attribute#]; name=typeWrapperIgnored
 // ON_GLOBALVAR-NOT: Keyword
 // ON_GLOBALVAR-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // ON_GLOBALVAR-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyPropertyWrapper[#MyPropertyWrapper#]; name=MyPropertyWrapper
@@ -209,6 +210,7 @@ struct _S {
 // ON_PROPERTY-DAG: Keyword/None:                       noDerivative[#Var Attribute#]; name=noDerivative
 // ON_PROPERTY-DAG: Keyword/None:                       exclusivity[#Var Attribute#]; name=exclusivity
 // ON_PROPERTY-DAG: Keyword/None:                       preconcurrency[#Var Attribute#]; name=preconcurrency
+// ON_PROPERTY-DAG: Keyword/None:                       typeWrapperIgnored[#Var Attribute#]; name=typeWrapperIgnored
 // ON_PROPERTY-NOT: Keyword
 // ON_PROPERTY-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // ON_PROPERTY-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyPropertyWrapper[#MyPropertyWrapper#]; name=MyPropertyWrapper
@@ -309,6 +311,7 @@ struct _S {
 // ON_MEMBER_LAST-DAG: Keyword/None:                       exclusivity[#Declaration Attribute#]; name=exclusivity
 // ON_MEMBER_LAST-DAG: Keyword/None:                       preconcurrency[#Declaration Attribute#]; name=preconcurrency
 // ON_MEMBER_LAST-DAG: Keyword/None:                       typeWrapper[#Declaration Attribute#]; name=typeWrapper
+// ON_MEMBER_LAST-DAG: Keyword/None:                       typeWrapperIgnored[#Declaration Attribute#]; name=typeWrapperIgnored
 // ON_MEMBER_LAST-NOT: Keyword
 // ON_MEMBER_LAST-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // ON_MEMBER_LAST-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyPropertyWrapper[#MyPropertyWrapper#]; name=MyPropertyWrapper
@@ -379,6 +382,7 @@ func dummy2() {}
 // KEYWORD_LAST-DAG: Keyword/None:                       exclusivity[#Declaration Attribute#]; name=exclusivity
 // KEYWORD_LAST-DAG: Keyword/None:                       preconcurrency[#Declaration Attribute#]; name=preconcurrency
 // KEYWORD_LAST-DAG: Keyword/None:                       typeWrapper[#Declaration Attribute#]; name=typeWrapper
+// KEYWORD_LAST-DAG: Keyword/None:                       typeWrapperIgnored[#Declaration Attribute#]; name=typeWrapperIgnored
 // KEYWORD_LAST-NOT: Keyword
 // KEYWORD_LAST-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // KEYWORD_LAST-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyPropertyWrapper[#MyPropertyWrapper#]; name=MyPropertyWrapper

--- a/test/Interpreter/Inputs/type_wrapper_defs.swift
+++ b/test/Interpreter/Inputs/type_wrapper_defs.swift
@@ -146,3 +146,10 @@ public class ClassWithDesignatedInit {
     $_storage = .init(memberwise: $Storage(a: 42, _b: PropWrapperWithoutInit(value: b)))
   }
 }
+
+@Wrapper
+public class PersonWithIgnoredAge {
+  public var name: String
+  @typeWrapperIgnored public var age: Int = 0
+  @typeWrapperIgnored @PropWrapper public var manufacturer: String?
+}

--- a/test/Interpreter/type_wrappers.swift
+++ b/test/Interpreter/type_wrappers.swift
@@ -408,3 +408,44 @@ do {
   // CHECK: in getter
   // CHECK-NEXT: [42]
 }
+
+do {
+  var arthur = PersonWithIgnoredAge(name: "Arthur Dent", age: 30)
+  // CHECK: Wrapper.init($Storage(name: "Arthur Dent"))
+
+  print(arthur.name)
+  // CHECK: in getter
+  // CHECK-NEXT: Arthur Dent
+
+  print(arthur.age)
+  // CHECK-NOT: in getter
+  // CHECK-NEXT: 30
+
+  print(arthur.manufacturer)
+  // CHECK-NOT: in getter
+  // CHECK-NEXT: nil
+
+  arthur.age = 32
+  // CHECK-NOT: in setter
+
+  var marvin = PersonWithIgnoredAge(name: "Marvin The Paranoid Android", manufacturer: "Sirius Cybernetics Corporation")
+  // CHECK: Wrapper.init($Storage(name: "Marvin The Paranoid Android"))
+
+  print(marvin.name)
+  // CHECK: in getter
+  // CHECK-NEXT: Marvin The Paranoid Android
+
+  print(marvin.age)
+  // CHECK-NOT: in getter
+  // CHECK-NEXT: 0
+
+  print(marvin.manufacturer)
+  // CHECK-NOT: in getter
+  // CHECK-NEXT: Sirius Cybernetics Corporation
+
+  marvin.age = 1000
+  // CHECK-NOT: in setter
+
+  marvin.manufacturer = nil
+  // CHECK-NOT: in setter
+}

--- a/test/type/type_wrapper.swift
+++ b/test/type/type_wrapper.swift
@@ -398,3 +398,42 @@ func testActors() async {
   person.name = "NoName" // expected-error {{actor-isolated property 'name' can not be mutated from a non-isolated context}}
   person.age = 0 // expected-error {{actor-isolated property 'age' can not be mutated from a non-isolated context}}
 }
+
+func testIgnoredAttr() {
+  @NoopWrapper
+  struct X {
+    @typeWrapperIgnored static var staticVar: Int = 0 // expected-error {{@typeWrapperIgnored must not be used on static properties}}
+
+    @typeWrapperIgnored lazy var lazyVar: Int = { // expected-error {{@typeWrapperIgnored must not be used on lazy properties}}
+      42
+    }()
+
+    @typeWrapperIgnored var x: Int // Ok
+
+    var y: Int {
+      @typeWrapperIgnored get { // expected-error {{@typeWrapperIgnored may only be used on 'var' declarations}}
+        42
+      }
+
+      @typeWrapperIgnored set { // expected-error {{@typeWrapperIgnored may only be used on 'var' declarations}}
+      }
+    }
+
+    @typeWrapperIgnored var computed: Int { // expected-error {{@typeWrapperIgnored must not be used on computed properties}}
+      get { 42 }
+      set {}
+    }
+
+    @typeWrapperIgnored let z: Int = 0 // expected-error {{@typeWrapperIgnored may only be used on 'var' declarations}}
+
+    func test_param(@typeWrapperIgnored x: Int) {} // expected-error {{@typeWrapperIgnored may only be used on 'var' declarations}}
+
+    func test_local() {
+      @typeWrapperIgnored var x: Int = 42 // expected-error {{@typeWrapperIgnored must not be used on local properties}}
+      // expected-warning@-1 {{variable 'x' was never used; consider replacing with '_' or removing it}}
+
+      @typeWrapperIgnored let y: String // expected-error {{@typeWrapperIgnored must not be used on local properties}}
+      // expected-warning@-1 {{immutable value 'y' was never used; consider replacing with '_' or removing it}}
+    }
+  }
+}


### PR DESCRIPTION
`@typeWrapperIgnored` attribute could be used on stored properties
of a type wrapped type to exclude them from type wrapper transform.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
