### PR TITLE
[Parse] Fix variable identifier parsing including code on newline as being part of the identifier itself

### DIFF
--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -1112,7 +1112,8 @@ ParserResult<Pattern> Parser::parsePattern() {
     PatternCtx.setCreateSyntax(SyntaxKind::IdentifierPattern);
     Identifier name;
     SourceLoc loc = consumeIdentifier(name, /*diagnoseDollarPrefix=*/true);
-    if (Tok.isIdentifierOrUnderscore() && !Tok.isContextualDeclKeyword())
+    if (Tok.isIdentifierOrUnderscore() && !Tok.isContextualDeclKeyword() &&
+        !Tok.isAtStartOfLine())
       diagnoseConsecutiveIDs(name.str(), loc,
                              introducer == VarDecl::Introducer::Let
                              ? "constant" : "variable");

--- a/test/Parse/identifiers.swift
+++ b/test/Parse/identifiers.swift
@@ -47,3 +47,16 @@ _ = sil_witness_table // expected-error {{cannot find 'sil_witness_table' in sco
 _ = sil_default_witness_table // expected-error {{cannot find 'sil_default_witness_table' in scope}}
 _ = sil_coverage_map // expected-error {{cannot find 'sil_coverage_map' in scope}}
 _ = sil_scope // expected-error {{cannot find 'sil_scope' in scope}}
+
+// https://github.com/apple/swift/issues/57542
+// Make sure we do not parse the '_' on the newline as being part of the 'variable' identifier on the line before.
+
+@propertyWrapper 
+struct Wrapper {
+  var wrappedValue = 0
+}
+
+func localScope() {
+  @Wrapper var variable
+  _ = 0
+}


### PR DESCRIPTION
Resolves #57542