### PR TITLE
SIL: make argument effects more readable in textual SIL

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/SmallProjectionPath.swift
+++ b/SwiftCompilerSources/Sources/SIL/SmallProjectionPath.swift
@@ -471,7 +471,7 @@ extension StringParser {
 
   mutating func parseProjectionPathFromSIL() throws -> SmallProjectionPath {
     var entries: [(SmallProjectionPath.FieldKind, Int)] = []
-    repeat {
+    while true {
       if consume("**") {
         entries.append((.anything, 0))
       } else if consume("c*") {
@@ -497,12 +497,10 @@ extension StringParser {
         entries.append((.structField, idx))
       } else if let tupleElemIdx = consumeInt() {
         entries.append((.tupleField, tupleElemIdx))
-      } else {
-        try throwError("expected selection path component")
+      } else if !consume(".") {
+        return try createPath(from: entries)
       }
-    } while consume(".")
- 
-    return try createPath(from: entries)
+    }
   }
 
   private func createPath(from entries: [(SmallProjectionPath.FieldKind, Int)]) throws -> SmallProjectionPath {

--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -956,7 +956,7 @@ Functions
   decl ::= sil-function
   sil-function ::= 'sil' sil-linkage? sil-function-attribute+
                      sil-function-name ':' sil-type
-                     '{' sil-basic-block+ '}'
+                     '{' argument-effect* sil-basic-block* '}'
   sil-function-name ::= '@' [A-Za-z_0-9]+
 
 SIL functions are defined with the ``sil`` keyword. SIL function names
@@ -966,6 +966,8 @@ and is usually the mangled name of the originating Swift declaration.
 The ``sil`` syntax declares the function's name and SIL type, and
 defines the body of the function inside braces. The declared type must
 be a function type, which may be generic.
+If there are no `sil-basic-block`s contained in the body, the function
+is an external declaration.
 
 
 Function Attributes
@@ -1096,30 +1098,6 @@ from the command line.
 The specified memory effects of the function.
 ::
 
-  sil-function-attribute ::= '[' 'escapes' escape-list ']'
-  sil-function-attribute ::= '[' 'defined_escapes' escape-list ']'
-  escape-list ::= (escape-list ',')? escape
-  escape ::= '!' arg-selection                 // not-escaping
-  escape ::= arg-selection '=>' arg-selection  // exclusive escaping
-  escape ::= arg-selection '->' arg-selection  // not-exclusive escaping
-  arg-selection ::= arg-or-return ('.' projection-path)?
-  arg-or-return ::= '%' [0-9]+
-  arg-or-return ::= '%r'
-  projection-path ::= (projection-path '.')? path-component
-  path-component ::= 's' [0-9]+        // struct field
-  path-component ::= 'c' [0-9]+        // class field
-  path-component ::= 'ct'              // class tail element
-  path-component ::= 'e' [0-9]+        // enum case
-  path-component ::= [0-9]+            // tuple element
-  path-component ::= 'v**'             // any value fields
-  path-component ::= 'c*'              // any class field
-  path-component ::= '**'              // anything
-
-The escaping effects for function arguments. For details see the documentation
-in ``SwiftCompilerSources/Sources/SIL/Effects.swift``.
-
-::
-
   sil-function-attribute ::= '[_semantics "' [A-Za-z._0-9]+ '"]'
 
 The specified high-level semantics of the function. The optimizer can use this
@@ -1146,6 +1124,34 @@ The clang node owner.
 Specifies the performance constraints for the function, which defines which type
 of runtime functions are allowed to be called from the function.
 
+
+Argument Effects
+````````````````
+
+The effects for function arguments. For details see the documentation
+in ``SwiftCompilerSources/Sources/SIL/Effects.swift``.
+::
+
+  argument-effect ::= '[' argument-name defined-effect? ':' effect (',' effect)*]'
+  argument-name ::= '%' [0-9]+
+  defined-effect ::= '!'    // the effect is defined in the source code and not
+                            // derived by the optimizer
+
+  effect ::= 'noescape' projection-path?
+  effect ::= 'escape' projection-path? '=>' arg-or-return  // exclusive escape
+  effect ::= 'escape' projection-path? '->' arg-or-return  // not-exclusive escape
+  arg-or-return ::= argument-name ('.' projection-path)?
+  arg-or-return ::= '%r' ('.' projection-path)?
+
+  projection-path ::= path-component ('.' path-component)* 
+  path-component ::= 's' [0-9]+        // struct field
+  path-component ::= 'c' [0-9]+        // class field
+  path-component ::= 'ct'              // class tail element
+  path-component ::= 'e' [0-9]+        // enum case
+  path-component ::= [0-9]+            // tuple element
+  path-component ::= 'v**'             // any value fields
+  path-component ::= 'c*'              // any class field
+  path-component ::= '**'              // anything
 
 Basic Blocks
 ~~~~~~~~~~~~

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -217,9 +217,9 @@ typedef enum {
 #include "swift/AST/Builtins.def"
 } BridgedBuiltinID;
 
-enum {
-  EffectsFlagEscape = 0x1,
-  EffectsFlagDerived = 0x2
+struct BridgedEffectInfo {
+  SwiftInt argumentIndex;
+  bool isDerived;
 };
 
 void registerBridgedClass(llvm::StringRef className, SwiftMetatype metatype);
@@ -231,17 +231,17 @@ typedef void (* _Nonnull FunctionWriteFn)(BridgedFunction,
                                           BridgedOStream, SwiftInt);
 typedef BridgedParsingError (*_Nonnull FunctionParseFn)(BridgedFunction,
                                                         llvm::StringRef,
-                                                        SwiftInt, SwiftInt,
+                                                        SwiftInt, SwiftInt, SwiftInt,
                                                         BridgedArrayRef);
 typedef SwiftInt (* _Nonnull FunctionCopyEffectsFn)(BridgedFunction,
                                                     BridgedFunction);
-typedef SwiftInt (* _Nonnull FunctionGetEffectFlagsFn)(BridgedFunction, SwiftInt);
+typedef BridgedEffectInfo (* _Nonnull FunctionGetEffectInfoFn)(BridgedFunction, SwiftInt);
 
 void Function_register(SwiftMetatype metatype,
             FunctionRegisterFn initFn, FunctionRegisterFn destroyFn,
             FunctionWriteFn writeFn, FunctionParseFn parseFn,
             FunctionCopyEffectsFn copyEffectsFn,
-            FunctionGetEffectFlagsFn hasEffectsFn);
+            FunctionGetEffectInfoFn effectInfoFn);
 
 SwiftInt PassContext_continueWithNextSubpassRun(BridgedPassContext passContext,
                                                 OptionalBridgedInstruction inst);

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -1031,18 +1031,16 @@ public:
     EffectsKindAttr = unsigned(E);
   }
   
-  enum class ArgEffectKind {
-    Unknown,
-    Escape
-  };
-  
   std::pair<const char *, int>  parseEffects(StringRef attrs, bool fromSIL,
-                                             bool isDerived,
+                                             int argumentIndex, bool isDerived,
                                              ArrayRef<StringRef> paramNames);
   void writeEffect(llvm::raw_ostream &OS, int effectIdx) const;
+  void writeEffects(llvm::raw_ostream &OS) const {
+    writeEffect(OS, -1);
+  }
   void copyEffects(SILFunction *from);
   bool hasArgumentEffects() const;
-  void visitArgEffects(std::function<void(int, bool, ArgEffectKind)> c) const;
+  void visitArgEffects(std::function<void(int, int, bool)> c) const;
 
   Purpose getSpecialPurpose() const { return specialPurpose; }
 

--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -140,7 +140,7 @@ void SILFunctionBuilder::addFunctionAttributes(
     }
     for (const EffectsAttr *effectsAttr : llvm::reverse(customEffects)) {
       auto error = F->parseEffects(effectsAttr->getCustomString(),
-                            /*fromSIL*/ false, /*isDerived*/ false, paramNames);
+        /*fromSIL*/ false, /*argumentIndex*/ -1, /*isDerived*/ false, paramNames);
       if (error.first) {
         SourceLoc loc = effectsAttr->getCustomStringLocation();
         if (loc.isValid())

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -734,10 +734,13 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
     if (kind == SIL_ARG_EFFECTS_ATTR) {
       IdentifierID effectID;
       unsigned isDerived;
-      SILArgEffectsAttrLayout::readRecord(scratch, effectID, isDerived);
+      unsigned argumentIndex;
+      SILArgEffectsAttrLayout::readRecord(scratch, effectID,
+                                          argumentIndex, isDerived);
       if (shouldAddEffectAttrs) {
         StringRef effectStr = MF->getIdentifierText(effectID);
-        auto error = fn->parseEffects(effectStr, /*fromSIL*/ true, isDerived, {});
+        auto error = fn->parseEffects(effectStr, /*fromSIL*/ true,
+                                      argumentIndex, isDerived, {});
         (void)error;
         assert(!error.first && "effects deserialization error");
       }

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 709; // needsStackProtection instruction flags
+const uint16_t SWIFTMODULE_VERSION_MINOR = 710; // new argument-effects format
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -308,6 +308,7 @@ namespace sil_block {
   using SILArgEffectsAttrLayout =
       BCRecordLayout<SIL_ARG_EFFECTS_ATTR,
                      IdentifierIDField, // argument effects string
+                     BCVBR<8>,          // argumentIndex
                      BCFixed<1>         // isDerived
                      >;
 

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -482,7 +482,7 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
 
   auto resilience = F.getModule().getSwiftModule()->getResilienceStrategy();
   F.visitArgEffects(
-    [&](int effectIdx, bool isDerived, SILFunction::ArgEffectKind) {
+    [&](int effectIdx, int argumentIndex, bool isDerived) {
       if (isDerived && resilience == ResilienceStrategy::Resilient)
         return;
       numAttrs++;
@@ -512,7 +512,7 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
       genericSigID, clangNodeOwnerID, parentModuleID, SemanticsIDs);
 
   F.visitArgEffects(
-    [&](int effectIdx, bool isDerived, SILFunction::ArgEffectKind) {
+    [&](int effectIdx, int argumentIndex, bool isDerived) {
       if (isDerived && resilience == ResilienceStrategy::Resilient)
         return;
 
@@ -524,7 +524,8 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
       unsigned abbrCode = SILAbbrCodes[SILArgEffectsAttrLayout::Code];
 
       SILArgEffectsAttrLayout::emitRecord(
-          Out, ScratchRecord, abbrCode, effectsStrID, (unsigned)isDerived);
+          Out, ScratchRecord, abbrCode,
+          effectsStrID, (unsigned)argumentIndex, (unsigned)isDerived);
     });
 
   if (NoBody)

--- a/test/SILGen/effectsattr.swift
+++ b/test/SILGen/effectsattr.swift
@@ -14,16 +14,23 @@
 //CHECK: [releasenone] [ossa] @func4
 @_effects(releasenone) @_silgen_name("func4") func func4() { }
 
-//CHECK: [defined_escapes !%0.**] [ossa] @func5
+//CHECK-LABEL: sil hidden [ossa] @func5
+//CHECK-NEXT:  [%0!: noescape **]
+//CHECK-NEXT:  {{^[^[]}}
 @_effects(notEscaping t.**) @_silgen_name("func5") func func5<T>(_ t: T) { }
 
-//CHECK: [defined_escapes %1.v**.c* => %0.v**] [ossa] @func6
+//CHECK-LABEL: sil hidden [ossa] @func6
+//CHECK-NEXT:  [%1!: escape v**.c* => %0.v**]
+//CHECK-NEXT:  {{^[^[]}}
 @_effects(escaping t.value**.class* => return.value**) @_silgen_name("func6") func func6<T>(_ t: T) -> T { }
 
 struct Mystr<T> {
   var sf: T
 
-  //CHECK: [defined_escapes !%3.**, %2.v** -> %1.s0.v**] [ossa] @func7
+  //CHECK-LABEL: sil hidden [ossa] @func7
+  //CHECK-NEXT:  [%3!: noescape **]
+  //CHECK-NEXT:  [%2!: escape v** -> %1.s0.v**]
+  //CHECK-NEXT:  {{^[^[]}}
   @_effects(notEscaping self.**)
   @_effects(escaping s.value** -> t.sf.value**)
   @_silgen_name("func7") func func7<T>(_ t: inout Mystr<T>, _ s: T) -> T { }

--- a/test/SILOptimizer/addr_escape_info.sil
+++ b/test/SILOptimizer/addr_escape_info.sil
@@ -36,12 +36,20 @@ sil @indirect_argument : $@convention(thin) (@in Int) -> ()
 sil @indirect_struct_argument : $@convention(thin) (@in Str) -> ()
 sil @direct_argument : $@convention(thin) (Int) -> ()
 sil @class_argument : $@convention(thin) (@guaranteed X) -> ()
-sil [escapes !%0] @non_escaping_class_argument : $@convention(thin) (@guaranteed X) -> ()
-sil [escapes !%0.**] @inout_class_argument : $@convention(thin) (@inout X) -> ()
+sil @non_escaping_class_argument : $@convention(thin) (@guaranteed X) -> () {
+[%0: noescape]
+}
+sil @inout_class_argument : $@convention(thin) (@inout X) -> () {
+[%0: noescape **]
+}
 sil @container_argument : $@convention(thin) (@guaranteed Container) -> ()
 sil @take_closure_as_addr : $@convention(thin) (@in @callee_guaranteed () -> ()) -> ()
-sil [escapes !%0.**] @closure_with_inout : $@convention(thin) (@inout Str) -> ()
-sil [escapes %0 => %r, %0.c*.v** => %r.c*.v**] @initX : $@convention(method) (@owned X) -> @owned X
+sil @closure_with_inout : $@convention(thin) (@inout Str) -> () {
+[%0: noescape **]
+}
+sil @initX : $@convention(method) (@owned X) -> @owned X {
+[%0: escape => %r, escape c*.v** => %r.c*.v**]
+}
 sil @modifyStr : $@convention(method) (@inout Str) -> ()
 
 // CHECK-LABEL: Address escape information for test_simple:

--- a/test/SILOptimizer/cross-module-effects.swift
+++ b/test/SILOptimizer/cross-module-effects.swift
@@ -24,21 +24,49 @@ public final class X {
   public init() { }
 }
 
-// CHECK-FR-MODULE-DAG: sil [escapes !%0.**] [canonical] @$s6Module17noInlineNoEffectsySiAA1XCF :
+// CHECK-FR-MODULE-LABEL: sil [canonical] @$s6Module17noInlineNoEffectsySiAA1XCF :
+// CHECK-FR-MODULE-NEXT:  [%0: noescape **]
+// CHECK-FR-MODULE-NEXT:  {{^[^[]}}
 // CHECK-LE-MODULE-NOT: @$s6Module17noInlineNoEffectsySiAA1XCF
 public func noInlineNoEffects(_ x: X) -> Int {
   return x.i
 }
 
-// CHECK-FR-MODULE-DAG: sil [escapes !%0.**] [canonical] @$s6Module14internalCalleeySiAA1XCF :
-// CHECK-LE-MODULE-DAG: sil [canonical] @$s6Module14internalCalleeySiAA1XCF :
+// CHECK-FR-MODULE-LABEL: sil [serialized] [noinline] [canonical] @$s6Module15inlineNoEffectsySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int {
+// CHECK-FR-MODULE-NEXT:  [%0: noescape **]
+// CHECK-FR-MODULE-NEXT:  {{^[^[]}}
+// CHECK-LE-MODULE-LABEL: sil [serialized] [noinline] [canonical] @$s6Module15inlineNoEffectsySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int {
+// CHECK-LE-MODULE-NEXT:  {{^[^[]}}
+@inlinable
+@inline(never)
+public func inlineNoEffects(_ x: X) -> Int {
+  return internalCallee(x)
+}
+
+// CHECK-FR-MODULE-LABEL: sil [canonical] @$s6Module14internalCalleeySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int {
+// CHECK-FR-MODULE-NEXT:  [%0: noescape **]
+// CHECK-FR-MODULE-NEXT:  {{^[^[]}}
+// CHECK-LE-MODULE-LABEL: sil [canonical] @$s6Module14internalCalleeySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int{{$}}
 @usableFromInline
 func internalCallee(_ x: X) -> Int {
   return x.i
 }
 
-// CHECK-FR-MODULE-DAG: sil [serialized] [noinline] [defined_escapes !%0.**] [canonical] @$s6Module17inlineWithEffectsySiAA1XCF :
-// CHECK-LE-MODULE-DAG: sil [serialized] [noinline] [defined_escapes !%0.**] [canonical] @$s6Module17inlineWithEffectsySiAA1XCF :
+// CHECK-FR-MODULE-LABEL: sil [canonical] @$s6Module19noInlineWithEffectsySiAA1XCF :
+// CHECK-FR-MODULE-NEXT:  [%0!: noescape **]
+// CHECK-FR-MODULE-NEXT:  {{^[^[]}}
+// CHECK-LE-MODULE-NOT: @$s6Module19noInlineWithEffectsySiAA1XCF
+@_effects(notEscaping x.**)
+public func noInlineWithEffects(_ x: X) -> Int {
+  return x.i
+}
+
+// CHECK-FR-MODULE-LABEL: sil [serialized] [noinline] [canonical] @$s6Module17inlineWithEffectsySiAA1XCF :
+// CHECK-FR-MODULE-NEXT:  [%0!: noescape **]
+// CHECK-FR-MODULE-NEXT:  {{^[^[]}}
+// CHECK-LE-MODULE-LABEL: sil [serialized] [noinline] [canonical] @$s6Module17inlineWithEffectsySiAA1XCF :
+// CHECK-LE-MODULE-NEXT:  [%0!: noescape **]
+// CHECK-LE-MODULE-NEXT:  {{^[^[]}}
 @inlinable
 @inline(never)
 @_effects(notEscaping x.**)
@@ -46,23 +74,11 @@ public func inlineWithEffects(_ x: X) -> Int {
   return internalCallee(x)
 }
 
-// CHECK-FR-MODULE-DAG: sil [serialized] [noinline] [escapes !%0.**] [canonical] @$s6Module15inlineNoEffectsySiAA1XCF :
-// CHECK-LE-MODULE-DAG: sil [serialized] [noinline] [canonical] @$s6Module15inlineNoEffectsySiAA1XCF :
-@inlinable
-@inline(never)
-public func inlineNoEffects(_ x: X) -> Int {
-  return internalCallee(x)
-}
-
-// CHECK-FR-MODULE-DAG: sil [defined_escapes !%0.**] [canonical] @$s6Module19noInlineWithEffectsySiAA1XCF :
-// CHECK-LE-MODULE-NOT: @$s6Module19noInlineWithEffectsySiAA1XCF
-@_effects(notEscaping x.**)
-public func noInlineWithEffects(_ x: X) -> Int {
-  return x.i
-}
-
-// CHECK-FR-MODULE-DAG: sil [serialized] [noinline] [escapes !%0.**] [canonical] @$s6Module12simpleInlineySiAA1XCF :
-// CHECK-LE-MODULE-DAG: sil [serialized] [noinline] [canonical] @$s6Module12simpleInlineySiAA1XCF :
+// CHECK-FR-MODULE-LABEL: sil [serialized] [noinline] [canonical] @$s6Module12simpleInlineySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int {
+// CHECK-FR-MODULE-NEXT:  [%0: noescape **]
+// CHECK-FR-MODULE-NEXT:  {{^[^[]}}
+// CHECK-LE-MODULE-LABEL: sil [serialized] [noinline] [canonical] @$s6Module12simpleInlineySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int {
+// CHECK-LE-MODULE-NEXT:  {{^[^[]}}
 @inlinable
 @inline(never)
 public func simpleInline(_ x: X) -> Int {
@@ -75,7 +91,7 @@ import Module
 
 // CHECK-MAIN-LABEL: sil [noinline] @$s4Main7callit1SiyF :
 // CHECK-FR-MAIN:       alloc_ref [stack] $X
-// CHECK-EV-MAIN:       alloc_ref $X
+// CHECK-LE-MAIN:       alloc_ref $X
 // CHECK-MAIN:       } // end sil function '$s4Main7callit1SiyF'
 @inline(never)
 public func callit1() -> Int {
@@ -83,12 +99,14 @@ public func callit1() -> Int {
   return noInlineNoEffects(x)
 }
 
-// CHECK-FR-MAIN: sil [escapes !%0.**] @$s6Module17noInlineNoEffectsySiAA1XCF : 
-// CHECK-EV-MAIN: sil @$s6Module17noInlineNoEffectsySiAA1XCF : 
+// CHECK-FR-MAIN-LABEL: sil @$s6Module17noInlineNoEffectsySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int
+// CHECK-FR-MAIN-NEXT:  [%0: noescape **]
+// CHECK-FR-MAIN-NEXT:  {{^[^[]}}
+// CHECK-LE-MAIN-LABEL: sil @$s6Module17noInlineNoEffectsySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int{{$}}
 
 // CHECK-MAIN-LABEL: sil [noinline] @$s4Main7callit2SiyF :
 // CHECK-FR-MAIN:       alloc_ref [stack] $X
-// CHECK-EV-MAIN:       alloc_ref $X
+// CHECK-LE-MAIN:       alloc_ref $X
 // CHECK-MAIN:       } // end sil function '$s4Main7callit2SiyF'
 @inline(never)
 public func callit2() -> Int {
@@ -96,12 +114,15 @@ public func callit2() -> Int {
   return inlineNoEffects(x)
 }
 
-// CHECK-FR-MAIN: sil public_external [noinline] [escapes !%0.**] @$s6Module15inlineNoEffectsySiAA1XCF :
-// CHECK-EV-MAIN: sil public_external [noinline] @$s6Module15inlineNoEffectsySiAA1XCF :
+// CHECK-FR-MAIN-LABEL: sil public_external [noinline] @$s6Module15inlineNoEffectsySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int {
+// CHECK-FR-MAIN-NEXT:  [%0: noescape **]
+// CHECK-FR-MAIN-NEXT:  {{^[^[]}}
+// CHECK-LE-MAIN-LABEL: sil public_external [noinline] @$s6Module15inlineNoEffectsySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int {
+// CHECK-LE-MAIN-NEXT:  {{^[^[]}}
 
 // CHECK-MAIN-LABEL: sil [noinline] @$s4Main7callit3SiyF :
 // CHECK-FR-MAIN:       alloc_ref [stack] $X
-// CHECK-EV-MAIN:       alloc_ref [stack] $X
+// CHECK-LE-MAIN:       = function_ref @$s6Module1XCACycfc
 // CHECK-MAIN:       } // end sil function '$s4Main7callit3SiyF'
 @inline(never)
 public func callit3() -> Int {
@@ -109,12 +130,13 @@ public func callit3() -> Int {
   return noInlineWithEffects(x)
 }
 
-// CHECK-FR-MAIN: sil [defined_escapes !%0.**] @$s6Module19noInlineWithEffectsySiAA1XCF
-// CHECK-EV-MAIN: sil @$s6Module17noInlineNoEffectsySiAA1XCF : 
+// CHECK-FR-MAIN-LABEL: sil @$s6Module19noInlineWithEffectsySiAA1XCF
+// CHECK-FR-MAIN-NEXT:  [%0!: noescape **]
+// CHECK-FR-MAIN-NEXT:  {{^[^[]}}
 
 // CHECK-MAIN-LABEL: sil [noinline] @$s4Main7callit4SiyF :
 // CHECK-FR-MAIN:       alloc_ref [stack] $X
-// CHECK-EV-MAIN:       alloc_ref [stack] $X
+// CHECK-LE-MAIN:       = function_ref @$s6Module1XCACycfc
 // CHECK-MAIN:       } // end sil function '$s4Main7callit4SiyF'
 @inline(never)
 public func callit4() -> Int {
@@ -122,12 +144,16 @@ public func callit4() -> Int {
   return inlineWithEffects(x)
 }
 
-// CHECK-FR-MAIN: sil public_external [noinline] [defined_escapes !%0.**] @$s6Module17inlineWithEffectsySiAA1XCF :
-// CHECK-EV-MAIN: sil public_external [noinline] @$s6Module17inlineWithEffectsySiAA1XCF :
+// CHECK-FR-MAIN-LABEL: sil public_external [noinline] @$s6Module17inlineWithEffectsySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int {
+// CHECK-FR-MAIN-NEXT:  [%0!: noescape **]
+// CHECK-FR-MAIN-NEXT:  {{^[^[]}}
+// CHECK-LE-MAIN-LABEL: sil public_external [noinline] @$s6Module17inlineWithEffectsySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int {
+// CHECK-LE-MAIN-NEXT:  [%0!: noescape **]
+// CHECK-LE-MAIN-NEXT:  {{^[^[]}}
 
 // CHECK-MAIN-LABEL: sil [noinline] @$s4Main7callit5SiyF :
 // CHECK-FR-MAIN:       alloc_ref [stack] $X
-// CHECK-EV-MAIN:       alloc_ref $X
+// CHECK-LE-MAIN:       alloc_ref $X
 // CHECK-MAIN:       } // end sil function '$s4Main7callit5SiyF'
 @inline(never)
 public func callit5() -> Int {
@@ -135,11 +161,16 @@ public func callit5() -> Int {
   return simpleInline(x)
 }
 
-// CHECK-FR-MAIN: sil public_external [noinline] [escapes !%0.**] @$s6Module12simpleInlineySiAA1XCF :
-// CHECK-EV-MAIN: sil public_external [noinline] @$s6Module12simpleInlineySiAA1XCF :
+// CHECK-FR-MAIN-LABEL: sil public_external [noinline] @$s6Module12simpleInlineySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int {
+// CHECK-FR-MAIN-NEXT:  [%0: noescape **]
+// CHECK-FR-MAIN-NEXT:  {{^[^[]}}
+// CHECK-LE-MAIN-LABEL: sil public_external [noinline] @$s6Module12simpleInlineySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int {
+// CHECK-LE-MAIN-NEXT:  {{^[^[]}}
 
-// CHECK-FR-MAIN: sil [escapes !%0.**] @$s6Module14internalCalleeySiAA1XCF :
-// CHECK-EV-MAIN: sil @$s6Module14internalCalleeySiAA1XCF :
+// CHECK-FR-MAIN-LABEL: sil @$s6Module14internalCalleeySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int {
+// CHECK-FR-MAIN-NEXT:  [%0: noescape **]
+// CHECK-FR-MAIN-NEXT:  {{^[^[]}}
+// CHECK-LE-MAIN-LABEL: sil @$s6Module14internalCalleeySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int{{$}}
 
 #endif
 

--- a/test/SILOptimizer/escape_info.sil
+++ b/test/SILOptimizer/escape_info.sil
@@ -70,19 +70,46 @@ enum E {
   case B(Z)
 }
 
-sil [escapes !%0.**] @not_escaping_argument : $@convention(thin) (@guaranteed Z) -> ()
-sil [ossa] [escapes !%1.**] @not_escaping_second_argument : $@convention(thin) (@owned X, @owned Y) -> ()
-sil [escapes %0 => %r, %0.c*.c*.v** => %r.c*.c*.v**] @exclusive_arg_to_return : $@convention(thin) (@owned Z) -> @owned Z
-sil [escapes %0 => %r, %0.c*.c*.v** -> %r.c*.c*.v**] @nonexclusive_arg_to_return : $@convention(thin) (@owned Z) -> @owned Z
-sil [ossa] [escapes %0 => %r.s0] @arg_to_return : $@convention(thin) (@owned X) -> @owned Str
-sil [escapes %1 => %0.s0, !%0] [ossa] @arg_to_arg : $@convention(thin) (@owned X) -> @out Str
-sil [escapes !%0, %0.c* => %r] [ossa] @content_of_arg_to_return : $@convention(thin) (@owned Z) -> @owned Y
-sil [ossa] [escapes !%0.**] @non_escaping_in_arg : $@convention(thin) (@in Z) -> ()
-sil [escapes %0 -> %r, %0.c*.v** -> %r.c*.v**] @load_from_inout : $@convention(thin) (@inout Y) -> @owned Y
-sil [escapes %0 => %r, %0.c*.v** => %r.c*.v**] @forward_from_inout : $@convention(thin) (@inout Z, @guaranteed Y) -> Z
-sil [escapes %0 -> %r, %0.c*.v** -> %r.c*.v**] @load_and_store_to_inout : $@convention(thin) (@inout Z, @guaranteed Y) -> Z
-sil [escapes %0 => %r, %0.c1.v** => %r.c1.v**] @exclusive2 : $@convention(thin) (@owned Z) -> @owned Z
-sil [escapes %0 -> %r, %0.c1.v** -> %r.c1.v**] @nonexclusive2 : $@convention(thin) (@owned Z) -> @owned Z
+sil @not_escaping_argument : $@convention(thin) (@guaranteed Z) -> () {
+[%0: noescape **]
+}
+sil [ossa] @not_escaping_second_argument : $@convention(thin) (@owned X, @owned Y) -> () {
+[%1: noescape **]
+}
+sil @exclusive_arg_to_return : $@convention(thin) (@owned Z) -> @owned Z {
+[%0: escape => %r, escape c*.c*.v** => %r.c*.c*.v**]
+}
+sil @nonexclusive_arg_to_return : $@convention(thin) (@owned Z) -> @owned Z {
+[%0: escape => %r, escape c*.c*.v** -> %r.c*.c*.v**]
+}
+sil [ossa] @arg_to_return : $@convention(thin) (@owned X) -> @owned Str {
+[%0: escape => %r.s0]
+}
+sil [ossa] @arg_to_arg : $@convention(thin) (@owned X) -> @out Str {
+[%0: noescape]
+[%1: escape => %0.s0]
+}
+sil [ossa] @content_of_arg_to_return : $@convention(thin) (@owned Z) -> @owned Y {
+[%0: noescape, escape c* => %r]
+}
+sil [ossa] @non_escaping_in_arg : $@convention(thin) (@in Z) -> () {
+[%0: noescape **]
+}
+sil @load_from_inout : $@convention(thin) (@inout Y) -> @owned Y {
+[%0: escape -> %r, escape c*.v** -> %r.c*.v**]
+}
+sil @forward_from_inout : $@convention(thin) (@inout Z, @guaranteed Y) -> Z {
+[%0: escape => %r, escape c*.v** => %r.c*.v**]
+}
+sil @load_and_store_to_inout : $@convention(thin) (@inout Z, @guaranteed Y) -> Z {
+[%0: escape -> %r, escape c*.v** -> %r.c*.v**]
+}
+sil @exclusive2 : $@convention(thin) (@owned Z) -> @owned Z {
+[%0: escape => %r, escape c1.v** => %r.c1.v**]
+}
+sil @nonexclusive2 : $@convention(thin) (@owned Z) -> @owned Z {
+[%0: escape -> %r, escape c1.v** -> %r.c1.v**]
+}
 
 // CHECK-LABEL: Escape information for test_simple:
 // CHECK: return[]: %1 = alloc_ref $X
@@ -791,7 +818,9 @@ bb0:
   return %6 : $X
 }
 
-sil [escapes !%0.**] @$s4test1FCfD : $@convention(method) (@owned F) -> ()
+sil @$s4test1FCfD : $@convention(method) (@owned F) -> () {
+[%0: noescape **]
+}
 
 // CHECK-LABEL: Escape information for destructure_struct_walkup:
 // CHECK: arg0[c0]:   %2 = alloc_ref $Y                               // user: %9
@@ -965,11 +994,22 @@ bb0(%0 : @owned $Z):
   return %11 : $()
 }
 
-sil [ossa] [escapes !%1] @closure1 : $@convention(thin) (@guaranteed Y, @guaranteed Y) -> ()
-sil [ossa] [escapes !%0] @closure2 : $@convention(thin) (@guaranteed Y, @guaranteed Y) -> ()
-sil [escapes !%0.**] @closure3 : $@convention(thin) (@guaranteed Z) -> ()
-sil [ossa] [escapes %0 => %1, !%1] @closure4 : $@convention(thin) (@guaranteed X, @guaranteed Y) -> ()
-sil [ossa] [escapes %1 => %0, !%1] @closure5 : $@convention(thin) (@guaranteed Y, @guaranteed X) -> ()
+sil [ossa] @closure1 : $@convention(thin) (@guaranteed Y, @guaranteed Y) -> () {
+[%1: noescape]
+}
+sil [ossa] @closure2 : $@convention(thin) (@guaranteed Y, @guaranteed Y) -> () {
+[%0: noescape]
+}
+sil @closure3 : $@convention(thin) (@guaranteed Z) -> () {
+[%0: noescape **]
+}
+sil [ossa] @closure4 : $@convention(thin) (@guaranteed X, @guaranteed Y) -> () {
+[%0: escape => %1]
+[%1: noescape]
+}
+sil [ossa] @closure5 : $@convention(thin) (@guaranteed Y, @guaranteed X) -> () {
+[%1: escape => %0, noescape]
+}
 
 // CHECK-LABEL: Escape information for callClosure1:
 // CHECK:  -    :   %0 = alloc_ref $Y
@@ -1140,8 +1180,12 @@ bb0(%0 : $Y):
   return %10 : $()
 }
 
-sil [escapes !%0.c1.**] @$s4test1ZCfD : $@convention(method) (@owned Z) -> ()
-sil [escapes !%0.c0.**] @$s4test8DerivedZCfD : $@convention(method) (@owned DerivedZ) -> ()
+sil @$s4test1ZCfD : $@convention(method) (@owned Z) -> () {
+[%0: noescape c1.**]
+}
+sil @$s4test8DerivedZCfD : $@convention(method) (@owned DerivedZ) -> () {
+[%0: noescape c0.**]
+}
 
 // CHECK-LABEL: Escape information for known_type:
 // CHECK: global:   %0 = alloc_ref $Y

--- a/test/SILOptimizer/escape_info_objc.sil
+++ b/test/SILOptimizer/escape_info_objc.sil
@@ -15,11 +15,18 @@ import SwiftShims
 
 class X {}
 
-sil [escapes !%0, !%0.c*.v**] @$ss23_ContiguousArrayStorageCfD : $@convention(method) <Element> (@owned _ContiguousArrayStorage<Element>) -> ()
+sil @$ss23_ContiguousArrayStorageCfD : $@convention(method) <Element> (@owned _ContiguousArrayStorage<Element>) -> () {
+[%0: noescape, noescape c*.v**] 
+}
 
-sil [defined_escapes %0 => %r.0.v**, %0.c*.v** => %r.0.v**.c*.v**, %0.c*.v** => %r.1.v**] @array_adopt_storage_class : $@convention(method) (@owned _ContiguousArrayStorage<X>, Int, @thin Array<X>.Type) -> (@owned Array<X>, UnsafeMutablePointer<X>)
+sil @array_adopt_storage_class : $@convention(method) (@owned _ContiguousArrayStorage<X>, Int, @thin Array<X>.Type) -> (@owned Array<X>, UnsafeMutablePointer<X>) {
+[%0!: escape => %r.0.v**, escape c*.v** => %r.0.v**.c*.v**, escape c*.v** => %r.1.v**] 
+}
 
-sil [escapes %0 => %r.0.s0.**] @array_adopt_storage : $@convention(thin) (@owned _ContiguousArrayStorage<Int>) -> (@owned Array<Int>, UnsafeMutablePointer<Int>)
+sil @array_adopt_storage : $@convention(thin) (@owned _ContiguousArrayStorage<Int>) -> (@owned Array<Int>, UnsafeMutablePointer<Int>) {
+[%0: escape => %r.0.s0.**] 
+}
+
 sil @take_ptr : $@convention(thin) (UnsafeMutablePointer<Int>) -> ()
 
 // CHECK-LABEL: Escape information for call_array_adopt_storage:

--- a/test/SILOptimizer/existential_specializer_indirect_class.sil
+++ b/test/SILOptimizer/existential_specializer_indirect_class.sil
@@ -8,10 +8,9 @@ protocol ClassProtocol: AnyObject { func method() }
 
 class C: ClassProtocol { func method() {} }
 
-// CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] {{.*}}@test_indirect_class_protocol : $@convention(thin) (@in any ClassProtocol) -> ()
+// CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] @test_indirect_class_protocol : $@convention(thin) (@in any ClassProtocol) -> ()
 sil @test_indirect_class_protocol : $@convention(thin) (@in ClassProtocol) -> () {
-// CHECK-NEXT: //
-// CHECK-NEXT: bb0(%0 : $*any ClassProtocol):
+// CHECK: bb0(%0 : $*any ClassProtocol):
 bb0(%0 : $*ClassProtocol):
   // CHECK-NEXT: %1 = load %0
   // CHECK-NEXT: strong_release %1
@@ -41,8 +40,7 @@ bb0(%0 : $*ClassProtocol):
 
 // Check that a specialization of test_indirect_class_protocol is created.
 // CHECK-LABEL: sil shared [signature_optimized_thunk] [always_inline] {{.*}}@$s28test_indirect_class_protocolTf4e_n4main1CC_Tg5 : $@convention(thin) (@owned C) -> ()
-// CHECK-NEXT: //
-// CHECK-NEXT: bb0(%0 : $C):
+// CHECK:      bb0(%0 : $C):
 // CHECK-NEXT: strong_release %0
 // CHECK-NEXT: return undef
 // CHECK-LABEL: end sil function '$s28test_indirect_class_protocolTf4e_n4main1CC_Tg5'

--- a/test/SILOptimizer/function_effects.sil
+++ b/test/SILOptimizer/function_effects.sil
@@ -56,7 +56,11 @@ sil_global @globalY : $Y
 sil [ossa] @unknown_function : $@convention(thin) (@owned X) -> ()
 sil [ossa] @unknown_function_y : $@convention(thin) (@owned Y) -> ()
 
-// CHECK-LABEL: sil [escapes %1.v** => %3.v**, !%2, %2.c*.v** -> %r.v**, !%3] [ossa] @test_basic
+// CHECK-LABEL: sil [ossa] @test_basic
+// CHECK-NEXT:  [%1: escape v** => %3.v**]
+// CHECK-NEXT:  [%2: noescape, escape c*.v** -> %r.v**]
+// CHECK-NEXT:  [%3: noescape]
+// CHECK-NEXT:  {{^[^[]}}
 sil [ossa] @test_basic : $@convention(thin) (@owned X, @guaranteed Str, @guaranteed Z, @inout X) -> @owned Y {
 bb0(%0 : @owned $X, %1 : @guaranteed $Str, %2 : @guaranteed $Z, %3 : $*X):
   // %0 escapes to global
@@ -75,20 +79,28 @@ bb0(%0 : @owned $X, %1 : @guaranteed $Str, %2 : @guaranteed $Z, %3 : $*X):
   return %9 : $Y
 }
 
-// CHECK-LABEL: sil [escapes %0 => %r, %0.c*.v** => %r.c*.v**] @simple_forwarding
+// CHECK-LABEL: sil @simple_forwarding
+// CHECK-NEXT:  [%0: escape => %r, escape c*.v** => %r.c*.v**]
+// CHECK-NEXT:  {{^[^[]}}
 sil @simple_forwarding : $@convention(thin) (@owned Z) -> @owned Z {
 bb0(%0 : $Z):
   return %0 : $Z
 }
 
-// CHECK-LABEL: sil [escapes %0.v** => %r.v**, %0.v**.c*.v** => %r.v**.c*.v**] @forwarding_struct_element
+// CHECK-LABEL: sil @forwarding_struct_element
+// CHECK-NEXT:  [%0: escape v** => %r.v**, escape v**.c*.v** => %r.v**.c*.v**]
+// CHECK-NEXT:  {{^[^[]}}
 sil @forwarding_struct_element : $@convention(thin) (@owned Str) -> @owned X {
 bb0(%0 : $Str):
   %1 = struct_extract %0 : $Str, #Str.a
   return %1 : $X
 }
 
-// CHECK-LABEL: sil [escapes %0 => %r.s1.0, %0.c*.v** => %r.s1.0.c*.v**, %1 => %r.s1.1, %1.c*.v** => %r.s1.1.c*.v**, %2 => %r.s0, %2.c*.v** => %r.s0.c*.v**]  @forwarding_in_struct
+// CHECK-LABEL: sil @forwarding_in_struct
+// CHECK-NEXT:  [%0: escape => %r.s1.0, escape c*.v** => %r.s1.0.c*.v**]
+// CHECK-NEXT:  [%1: escape => %r.s1.1, escape c*.v** => %r.s1.1.c*.v**]
+// CHECK-NEXT:  [%2: escape => %r.s0, escape c*.v** => %r.s0.c*.v**]
+// CHECK-NEXT:  {{^[^[]}}
 sil @forwarding_in_struct : $@convention(thin) (@owned X, @owned X, @owned X) -> @owned Str {
 bb0(%0 : $X, %1 : $X, %2: $X):
   %3 = tuple (%0 : $X, %1 : $X)
@@ -96,7 +108,9 @@ bb0(%0 : $X, %1 : $X, %2: $X):
   return %4 : $Str
 }
 
-// CHECK-LABEL: sil [escapes %0 -> %r.v**, %0.c*.v** -> %r.v**.c*.v**] @forwarding_same_arg_in_struct
+// CHECK-LABEL: sil @forwarding_same_arg_in_struct
+// CHECK-NEXT:  [%0: escape -> %r.v**, escape c*.v** -> %r.v**.c*.v**]
+// CHECK-NEXT:  {{^[^[]}}
 sil @forwarding_same_arg_in_struct : $@convention(thin) (@owned X) -> @owned Str {
 bb0(%0 : $X):
   %1 = tuple (%0 : $X, %0 : $X)
@@ -104,7 +118,9 @@ bb0(%0 : $X):
   return %2 : $Str
 }
 
-// CHECK-LABEL: sil [escapes !%0] [ossa] @test_escaping_content
+// CHECK-LABEL: sil [ossa] @test_escaping_content
+// CHECK-NEXT:  [%0: noescape]
+// CHECK-NEXT:  {{^[^[]}}
 sil [ossa] @test_escaping_content : $@convention(thin) (@guaranteed Z) -> () {
 bb0(%0 : @guaranteed $Z):
   %1 = ref_element_addr %0 : $Z, #Z.y
@@ -115,8 +131,11 @@ bb0(%0 : @guaranteed $Z):
   return %5 : $()
 }
 
-// CHECK-LABEL: sil [escapes !%0.**] @not_escaping_argument
+// CHECK-LABEL: sil @not_escaping_argument
+// CHECK-NEXT:  [%0!: noescape **]
+// CHECK-NEXT:  {{^[^[]}}
 sil @not_escaping_argument : $@convention(thin) (@guaranteed Z) -> () {
+[%0!: noescape **]
 bb0(%0 : $Z):
   %1 = ref_element_addr %0 : $Z, #Z.y
   %2 = global_addr @globalY : $*Y
@@ -126,14 +145,19 @@ bb0(%0 : $Z):
   return %4 : $()
 }
 
-// CHECK-LABEL: sil [escapes %0 -> %r, %0.c*.v** -> %r.c*.v**] @load_from_inout
+// CHECK-LABEL: sil @load_from_inout
+// CHECK-NEXT:  [%0: escape -> %r, escape c*.v** -> %r.c*.v**]
+// CHECK-NEXT:  {{^[^[]}}
 sil @load_from_inout : $@convention(thin) (@inout Y) -> @owned Y {
 bb0(%0 : $*Y):
   %2 = load %0 : $*Y
   return %2 : $Y
 }
 
-// CHECK-LABEL: sil [escapes !%0, %0.c*.v** -> %r.v**, !%1] [ossa] @followstore_implies_non_exclusive
+// CHECK-LABEL: sil [ossa] @followstore_implies_non_exclusive
+// CHECK-NEXT:  [%0: noescape, escape c*.v** -> %r.v**]
+// CHECK-NEXT:  [%1: noescape]
+// CHECK-NEXT:  {{^[^[]}}
 sil [ossa] @followstore_implies_non_exclusive : $@convention(thin) (@guaranteed Z, @owned Y) -> @owned Y {
 bb0(%0 : @guaranteed $Z, %1 : @owned $Y):
   %2 = ref_element_addr %0 : $Z, #Z.y
@@ -142,7 +166,10 @@ bb0(%0 : @guaranteed $Z, %1 : @owned $Y):
   return %3 : $Y
 }
 
-// CHECK-LABEL: sil [escapes !%0, %0.c*.v** -> %r.v**, %1 -> %r] [ossa] @test_not_exclusive_escaping_through_phi
+// CHECK-LABEL: sil [ossa] @test_not_exclusive_escaping_through_phi
+// CHECK-NEXT:  [%0: noescape, escape c*.v** -> %r.v**]
+// CHECK-NEXT:  [%1: escape -> %r]
+// CHECK-NEXT:  {{^[^[]}}
 sil [ossa] @test_not_exclusive_escaping_through_phi : $@convention(thin) (@guaranteed Z, @owned Y) -> @owned Y {
 bb0(%0 : @guaranteed $Z, %1 : @owned $Y):
   cond_br undef, bb1, bb2
@@ -158,7 +185,9 @@ bb3(%7: @owned $Y):
   return %7 : $Y
 }
 
-// CHECK-LABEL: sil [escapes !%0, %0.c*.v** -> %r.v**] [ossa] @test_not_exclusive_through_store
+// CHECK-LABEL: sil [ossa] @test_not_exclusive_through_store
+// CHECK-NEXT:  [%0: noescape, escape c*.v** -> %r.v**]
+// CHECK-NEXT:  {{^[^[]}}
 sil [ossa] @test_not_exclusive_through_store : $@convention(thin) (@guaranteed Z, @owned Y) -> @owned Y {
 bb0(%0 : @guaranteed $Z, %1 : @owned $Y):
   %2 = ref_element_addr %0 : $Z, #Z.y
@@ -167,9 +196,13 @@ bb0(%0 : @guaranteed $Z, %1 : @owned $Y):
   return %3 : $Y
 }
 
-sil [escapes %0.v** => %0.v**] [ossa] @self_arg_callee : $@convention(thin) (@inout Str) -> ()
+sil [ossa] @self_arg_callee : $@convention(thin) (@inout Str) -> () {
+[%0: escape v** => %0.v**] 
+}
 
-// CHECK-LABEL: sil [escapes %0.v** => %0.v**] [ossa] @test_self_arg_escape
+// CHECK-LABEL: sil [ossa] @test_self_arg_escape
+// CHECK-NEXT:  [%0: escape v** => %0.v**]
+// CHECK-NEXT:  {{^[^[]}}
 sil [ossa] @test_self_arg_escape : $@convention(thin) (@inout Str) -> () {
 bb0(%0 : $*Str):
   %1 = function_ref @self_arg_callee : $@convention(thin) (@inout Str) -> ()
@@ -178,7 +211,9 @@ bb0(%0 : $*Str):
   return %3 : $()
 }
 
-// CHECK-LABEL: sil [escapes %0.v** => %0.s1.0.v**] [ossa] @test_self_arg_escape_with_copy
+// CHECK-LABEL: sil [ossa] @test_self_arg_escape_with_copy
+// CHECK-NEXT:  [%0: escape v** => %0.s1.0.v**]
+// CHECK-NEXT:  {{^[^[]}}
 sil [ossa] @test_self_arg_escape_with_copy : $@convention(thin) (@inout Str) -> () {
 bb0(%0 : $*Str):
   %1 = struct_element_addr %0 : $*Str, #Str.a
@@ -189,7 +224,9 @@ bb0(%0 : $*Str):
   return %5 : $()
 }
 
-// CHECK-LABEL: sil [escapes %0.v** => %0.v**] [ossa] @test_self_arg_escape_with_bidirectional_copy
+// CHECK-LABEL: sil [ossa] @test_self_arg_escape_with_bidirectional_copy
+// CHECK-NEXT:  [%0: escape v** => %0.v**]
+// CHECK-NEXT:  {{^[^[]}}
 sil [ossa] @test_self_arg_escape_with_bidirectional_copy : $@convention(thin) (@inout Str) -> () {
 bb0(%0 : $*Str):
   %1 = struct_element_addr %0 : $*Str, #Str.a
@@ -201,7 +238,10 @@ bb0(%0 : $*Str):
   return %5 : $()
 }
 
-// CHECK-LABEL: sil [escapes !%0.**, !%1, %1.c*.v** => %0.v**] [ossa] @test_content_to_arg_addr
+// CHECK-LABEL: sil [ossa] @test_content_to_arg_addr
+// CHECK-NEXT:  [%0: noescape **]
+// CHECK-NEXT:  [%1: noescape, escape c*.v** => %0.v**]
+// CHECK-NEXT:  {{^[^[]}}
 sil [ossa] @test_content_to_arg_addr : $@convention(thin) (@guaranteed Y) -> @out Str {
 bb0(%0 : $*Str, %1 : @guaranteed $Y):
   %2 = ref_element_addr %1 : $Y, #Y.s
@@ -212,21 +252,27 @@ bb0(%0 : $*Str, %1 : @guaranteed $Y):
   return %6 : $()
 }
 
-// CHECK-LABEL: sil [escapes %0.v** => %r.v**, %0.v**.c*.v** => %r.v**.c*.v**] @escaping_pointer
+// CHECK-LABEL: sil @escaping_pointer
+// CHECK-NEXT:  [%0: escape v** => %r.v**, escape v**.c*.v** => %r.v**.c*.v**]
+// CHECK-NEXT:  {{^[^[]}}
 sil @escaping_pointer : $@convention(thin) (PointerAndInt) -> UnsafeMutablePointer<Int> {
 bb0(%0 : $PointerAndInt):
   %1 = struct_extract %0 : $PointerAndInt, #PointerAndInt.p
   return %1 : $UnsafeMutablePointer<Int>
 }
 
-// CHECK-LABEL: sil [escapes !%0.**] @not_escaping_int
+// CHECK-LABEL: sil @not_escaping_int
+// CHECK-NEXT:  [%0: noescape **]
+// CHECK-NEXT:  {{^[^[]}}
 sil @not_escaping_int : $@convention(thin) (PointerAndInt) -> Int {
 bb0(%0 : $PointerAndInt):
   %1 = struct_extract %0 : $PointerAndInt, #PointerAndInt.i
   return %1 : $Int
 }
 
-// CHECK-LABEL: sil [escapes !%0.**] @test_simple_recursion
+// CHECK-LABEL: sil @test_simple_recursion
+// CHECK-NEXT:  [%0: noescape **]
+// CHECK-NEXT:  {{^[^[]}}
 sil @test_simple_recursion : $@convention(thin) (@guaranteed Y) -> () {
 bb0(%0 : $Y):
   cond_br undef, bb1, bb2
@@ -244,7 +290,8 @@ bb3:
   return %5 : $() 
 }
 
-// CHECK-LABEL: sil @test_recursion_with_escaping_param
+// CHECK-LABEL: sil @test_recursion_with_escaping_param : $@convention(thin) (@guaranteed Y, @guaranteed Y) -> Y {
+// CHECK-NEXT:  {{^[^[]}}
 sil @test_recursion_with_escaping_param : $@convention(thin) (@guaranteed Y, @guaranteed Y) -> Y {
 bb0(%0 : $Y, %1 : $Y):
   cond_br undef, bb1, bb2
@@ -261,7 +308,9 @@ bb3(%5 : $Y):
   return %5 : $Y
 }
 
-// CHECK-LABEL: [escapes !%0.**] @inout_class_argument
+// CHECK-LABEL: sil @inout_class_argument
+// CHECK-NEXT:  [%0: noescape **]
+// CHECK-NEXT:  {{^[^[]}}
 sil @inout_class_argument : $@convention(thin) (@inout X) -> () {
 bb0(%0 : $*X):
   %1 = alloc_ref $X
@@ -270,7 +319,9 @@ bb0(%0 : $*X):
   return %3 : $()
 }
 
-// CHECK-LABEL: sil [escapes %0 -> %r, %0.c*.v** -> %r.c*.v**] @load_and_store_to_inout
+// CHECK-LABEL: sil @load_and_store_to_inout
+// CHECK-NEXT:  [%0: escape -> %r, escape c*.v** -> %r.c*.v**]
+// CHECK-NEXT:  {{^[^[]}}
 sil @load_and_store_to_inout : $@convention(thin) (@inout Z, @guaranteed Y) -> Z {
 bb0(%0 : $*Z, %1 : $Y):
   %2 = load %0 : $*Z
@@ -279,7 +330,9 @@ bb0(%0 : $*Z, %1 : $Y):
   return %2 : $Z
 }
 
-// CHECK-LABEL: sil [escapes %0 => %r, %0.c*.v** => %r.c*.v**] @store_to_content
+// CHECK-LABEL: sil @store_to_content
+// CHECK-NEXT:  [%0: escape => %r, escape c*.v** => %r.c*.v**]
+// CHECK-NEXT:  {{^[^[]}}
 sil @store_to_content : $@convention(thin) (@owned Z, @guaranteed Y) -> @owned Z {
 bb0(%0 : $Z, %1 : $Y):
   %2 = ref_element_addr %0 : $Z, #Z.y
@@ -287,14 +340,18 @@ bb0(%0 : $Z, %1 : $Y):
   return %0 : $Z
 }
 
-// CHECK-LABEL: sil [escapes !%1.**] @non_returning_function
+// CHECK-LABEL: sil @non_returning_function
+// CHECK-NEXT:  [%1: noescape **]
+// CHECK-NEXT:  {{^[^[]}}
 sil @non_returning_function : $@convention(thin) (Str, @inout Str) -> () {
 bb0(%0 : $Str, %1 : $*Str):
   store %0 to %1 : $*Str
   unreachable
 }
 
-// CHECK-LABEL: sil [escapes !%0] @followStore_introducing1
+// CHECK-LABEL: sil @followStore_introducing1
+// CHECK-NEXT:  [%0: noescape]
+// CHECK-NEXT:  {{^[^[]}}
 sil @followStore_introducing1 : $@convention(thin) (@guaranteed Z) -> @owned Y {
 bb0(%0 : $Z):
   %1 = ref_element_addr %0 : $Z, #Z.y
@@ -304,7 +361,9 @@ bb0(%0 : $Z):
   return %4 : $Y
 }
 
-// CHECK-LABEL: sil [escapes !%0.**] @followStore_introducing2
+// CHECK-LABEL: sil @followStore_introducing2
+// CHECK-NEXT:  [%0: noescape **]
+// CHECK-NEXT:  {{^[^[]}}
 sil @followStore_introducing2 : $@convention(thin) (@inout Z, @guaranteed Y) -> () {
 bb0(%0 : $*Z, %1 : $Y):
   %2 = load %0 : $*Z

--- a/test/SILOptimizer/function_effects_objc.sil
+++ b/test/SILOptimizer/function_effects_objc.sil
@@ -14,7 +14,9 @@ class Y {
   @_hasStorage var i: Int
 }
 
-// CHECK-LABEL: sil [escapes %0 => %r.0.s0.s0.s0, %0.c*.v** -> %r.**] @array_adopt_storage
+// CHECK-LABEL: sil @array_adopt_storage
+// CHECK-NEXT:  [%0: escape => %r.0.s0.s0.s0, escape c*.v** -> %r.**]
+// CHECK-NEXT:  {{^[^[]}}
 sil @array_adopt_storage : $@convention(thin) (@owned _ContiguousArrayStorage<Y>) -> (@owned Array<Y>, UnsafeMutablePointer<Y>) {
 bb0(%0 : $_ContiguousArrayStorage<Y>):
   %3 = upcast %0 : $_ContiguousArrayStorage<Y> to $__ContiguousArrayStorageBase
@@ -29,7 +31,9 @@ bb0(%0 : $_ContiguousArrayStorage<Y>):
   return %19 : $(Array<Y>, UnsafeMutablePointer<Y>)
 }
 
-// CHECK-LABEL: sil [escapes !%0, !%0.c*.v**] @array_destructor
+// CHECK-LABEL: sil @array_destructor
+// CHECK-NEXT:  [%0: noescape, noescape c*.v**]
+// CHECK-NEXT:  {{^[^[]}}
 sil @array_destructor : $@convention(method) <Element> (@owned _ContiguousArrayStorage<Element>) -> () {
 bb0(%0 : $_ContiguousArrayStorage<Element>):
   %1 = ref_tail_addr %0 : $_ContiguousArrayStorage<Element>, $Element

--- a/test/SILOptimizer/specialize_reabstraction.sil
+++ b/test/SILOptimizer/specialize_reabstraction.sil
@@ -135,16 +135,22 @@ bb0(%0 : $Bool):
   return %rv : $()
 }
 
-// CHECK-LABEL: sil shared [escapes %0 => %r] @$s21arg_escapes_to_return4main1XC_Tg5
-sil [escapes %1 => %0] @arg_escapes_to_return : $@convention(thin) <T> (@in_guaranteed T) -> @out T {
+// CHECK-LABEL: sil shared @$s21arg_escapes_to_return4main1XC_Tg5
+// CHECK-NEXT:  [%0: escape => %r]
+// CHECK-NEXT:  {{^[^[]}}
+sil @arg_escapes_to_return : $@convention(thin) <T> (@in_guaranteed T) -> @out T {
+[%1: escape => %0] 
 bb0(%0 : $*T, %1 : $*T):
   copy_addr %1 to [initialization] %0 : $*T
   %4 = tuple ()
   return %4 : $()
 }
 
-// CHECK-LABEL: sil shared [escapes %1 => %0] @$s015arg_escapes_to_A04main1XC_Tg5
-sil [escapes %1 => %0] @arg_escapes_to_arg : $@convention(thin) <T> (@inout T, @in_guaranteed T) -> () {
+// CHECK-LABEL: sil shared @$s015arg_escapes_to_A04main1XC_Tg5
+// CHECK-NEXT:  [%1: escape => %0]
+// CHECK-NEXT:  {{^[^[]}}
+sil @arg_escapes_to_arg : $@convention(thin) <T> (@inout T, @in_guaranteed T) -> () {
+[%1: escape => %0] 
 bb0(%0 : $*T, %1 : $*T):
   copy_addr %1 to %0 : $*T
   %4 = tuple ()

--- a/test/SILOptimizer/stack_promotion.sil
+++ b/test/SILOptimizer/stack_promotion.sil
@@ -847,8 +847,13 @@ bb0(%0 : $Int):
   return %11 : $Array<Int>
 }
 
-sil [escapes %0.v** => %r.0] [_semantics "array.uninitialized"] @init_array_with_buffer : $@convention(thin) (@owned DummyArrayStorage<Int>, Int32, @thin Array<Int>.Type) -> @owned (Array<Int>, UnsafeMutablePointer<Int>)
-sil [escapes !%2.v**] [_semantics "array.withUnsafeMutableBufferPointer"] @withUnsafeMutableBufferPointer : $@convention(method) (@owned @callee_owned (@inout Int) -> (@out (), @error Error), @inout Array<Int>) -> (@out (), @error Error)
+sil [_semantics "array.uninitialized"] @init_array_with_buffer : $@convention(thin) (@owned DummyArrayStorage<Int>, Int32, @thin Array<Int>.Type) -> @owned (Array<Int>, UnsafeMutablePointer<Int>) {
+[%0: escape v** => %r.0]
+}
+
+sil [_semantics "array.withUnsafeMutableBufferPointer"] @withUnsafeMutableBufferPointer : $@convention(method) (@owned @callee_owned (@inout Int) -> (@out (), @error Error), @inout Array<Int>) -> (@out (), @error Error) {
+[%2: noescape v**]
+}
 
 sil @take_array : $@convention(thin) (@owned Array<Int>) -> () {
 bb0(%0 : $Array<Int>):


### PR DESCRIPTION
So far, argument effects were printed in square brackets before the function name, e.g.
```
sil [escapes !%0.**, !%1, %1.c*.v** => %0.v**] @foo : $@convention(thin) (@guaranteed T) -> @out S {
bb0(%0 : $*S, %1 : @guaranteed $T):
...
```

As we are adding more argument effects, this becomes unreadable.
To make it more readable, print the effects after the opening curly brace, and print a separate line for each argument. E.g.
```
sil @foo : $@convention(thin) (@guaranteed T) -> @out S {
[%0: noescape **]
[%1: noescape, escape c*.v** => %0.v**]
bb0(%0 : $*S, %1 : @guaranteed $T):
...
```