### PR TITLE
[interop] pass and return C++ value types to/from Swift in C++

### DIFF
--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -27,6 +27,9 @@
 #include "swift/AST/TypeVisitor.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/IRGen/IRABIDetailsProvider.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/DeclTemplate.h"
+#include "clang/AST/NestedNameSpecifier.h"
 #include "llvm/ADT/STLExtras.h"
 
 using namespace swift;
@@ -88,6 +91,74 @@ struct CFunctionSignatureTypePrinterModifierDelegate {
   Optional<llvm::function_ref<ClangValueTypePrinter::TypeUseKind(
       ClangValueTypePrinter::TypeUseKind)>>
       mapValueTypeUseKind = None;
+};
+
+class ClangTypeHandler {
+public:
+  ClangTypeHandler(const clang::Decl *typeDecl) : typeDecl(typeDecl) {}
+
+  bool isRepresentable() const {
+    // We can only return trivial types, or
+    // types that can be moved or copied.
+    if (auto *record = dyn_cast<clang::CXXRecordDecl>(typeDecl)) {
+      return record->isTrivial() || record->hasMoveConstructor() ||
+             record->hasCopyConstructorWithConstParam();
+    }
+    return false;
+  }
+
+  void printTypeName(raw_ostream &os) const {
+    auto &clangCtx = typeDecl->getASTContext();
+    clang::PrintingPolicy pp(clangCtx.getLangOpts());
+    const auto *NS = clang::NestedNameSpecifier::getRequiredQualification(
+        clangCtx, clangCtx.getTranslationUnitDecl(),
+        typeDecl->getLexicalDeclContext());
+    if (NS)
+      NS->print(os, pp);
+    assert(cast<clang::NamedDecl>(typeDecl)->getDeclName().isIdentifier());
+    os << cast<clang::NamedDecl>(typeDecl)->getName();
+    if (auto *ctd =
+            dyn_cast<clang::ClassTemplateSpecializationDecl>(typeDecl)) {
+      if (ctd->getTemplateArgs().size()) {
+        os << '<';
+        llvm::interleaveComma(ctd->getTemplateArgs().asArray(), os,
+                              [&](const clang::TemplateArgument &arg) {
+                                arg.print(pp, os, /*IncludeType=*/true);
+                              });
+        os << '>';
+      }
+    }
+  }
+
+  void printReturnScaffold(raw_ostream &os,
+                           llvm::function_ref<void(StringRef)> bodyOfReturn) {
+    std::string fullQualifiedType;
+    std::string typeName;
+    {
+      llvm::raw_string_ostream typeNameOS(fullQualifiedType);
+      printTypeName(typeNameOS);
+      llvm::raw_string_ostream unqualTypeNameOS(typeName);
+      unqualTypeNameOS << cast<clang::NamedDecl>(typeDecl)->getName();
+    }
+    os << "alignas(alignof(" << fullQualifiedType << ")) char storage[sizeof("
+       << fullQualifiedType << ")];\n";
+    os << "auto * _Nonnull storageObjectPtr = reinterpret_cast<"
+       << fullQualifiedType << " *>(storage);\n";
+    bodyOfReturn("storage");
+    os << ";\n";
+    auto *cxxRecord = cast<clang::CXXRecordDecl>(typeDecl);
+    if (cxxRecord->isTrivial()) {
+      // Trivial object can be just copied and not destroyed.
+      os << "return *storageObjectPtr;\n";
+      return;
+    }
+    os << fullQualifiedType << " result(std::move(*storageObjectPtr));\n";
+    os << "storageObjectPtr->~" << typeName << "();\n";
+    os << "return result;\n";
+  }
+
+private:
+  const clang::Decl *typeDecl;
 };
 
 // Prints types in the C function signature that corresponds to the
@@ -234,6 +305,14 @@ public:
     // Only C++ mode supports struct types.
     if (languageMode != OutputLanguageMode::Cxx)
       return ClangRepresentation::unsupported;
+
+    if (decl->hasClangNode()) {
+      ClangTypeHandler handler(decl->getClangDecl());
+      if (!handler.isRepresentable())
+        return ClangRepresentation::unsupported;
+      handler.printTypeName(os);
+      return ClangRepresentation::representable;
+    }
 
     // FIXME: Handle optional structures.
     if (typeUseKind == FunctionSignatureTypeUse::ParamType) {
@@ -938,24 +1017,31 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
       return;
     }
     if (auto *decl = resultTy->getNominalOrBoundGenericNominal()) {
+      auto valueTypeReturnThunker = [&](StringRef resultPointerName) {
+        if (auto directResultType = signature.getDirectResultType()) {
+          std::string typeEncoding =
+              encodeTypeInfo(*directResultType, moduleContext, typeMapping);
+          os << cxx_synthesis::getCxxImplNamespaceName()
+             << "::swift_interop_returnDirect_" << typeEncoding << '('
+             << resultPointerName << ", ";
+          printCallToCFunc(None);
+          os << ')';
+        } else {
+          printCallToCFunc(/*firstParam=*/resultPointerName);
+        }
+      };
+      if (decl->hasClangNode()) {
+        ClangTypeHandler handler(decl->getClangDecl());
+        assert(handler.isRepresentable());
+        handler.printReturnScaffold(os, valueTypeReturnThunker);
+        return;
+      }
       ClangValueTypePrinter valueTypePrinter(os, cPrologueOS, interopContext);
 
       valueTypePrinter.printValueTypeReturnScaffold(
           decl, moduleContext,
           [&]() { printTypeImplTypeSpecifier(resultTy, moduleContext); },
-          [&](StringRef resultPointerName) {
-            if (auto directResultType = signature.getDirectResultType()) {
-              std::string typeEncoding =
-                  encodeTypeInfo(*directResultType, moduleContext, typeMapping);
-              os << cxx_synthesis::getCxxImplNamespaceName()
-                 << "::swift_interop_returnDirect_" << typeEncoding << '('
-                 << resultPointerName << ", ";
-              printCallToCFunc(None);
-              os << ')';
-            } else {
-              printCallToCFunc(/*firstParam=*/resultPointerName);
-            }
-          });
+          valueTypeReturnThunker);
       return;
     }
   }

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx-execution.cpp
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx-execution.cpp
@@ -1,0 +1,79 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -typecheck %t/use-cxx-types.swift -typecheck -module-name UseCxx -emit-clang-header-path %t/UseCxx.h -I %t -enable-experimental-cxx-interop -clang-header-expose-public-decls
+
+// RUN: %target-interop-build-clangxx -c %t/use-swift-cxx-types.cpp -I %t -o %t/swift-cxx-execution.o -g
+// RUN: %target-interop-build-swift %t/use-cxx-types.swift -o %t/swift-cxx-execution -Xlinker %t/swift-cxx-execution.o -module-name UseCxx -Xfrontend -entry-point-function-name -Xfrontend swiftMain -I %t -g
+
+// RUN: %target-codesign %t/swift-cxx-execution
+// RUN: %target-run %t/swift-cxx-execution | %FileCheck %s
+
+// REQUIRES: executable_test
+
+//--- header.h
+
+extern "C" void puts(const char *);
+
+struct Trivial {
+    int x, y;
+
+    inline Trivial(int x, int y) : x(x), y(y) {}
+};
+
+template<class T>
+struct NonTrivialTemplate {
+    T x;
+
+    inline NonTrivialTemplate(T x) : x(x) {
+        puts("create NonTrivialTemplate");
+    }
+    inline NonTrivialTemplate(const NonTrivialTemplate<T> &) = default;
+    inline NonTrivialTemplate(NonTrivialTemplate<T> &&other) : x(static_cast<T &&>(other.x)) {
+        puts("move NonTrivialTemplate");
+    }
+    inline ~NonTrivialTemplate() {
+        puts("~NonTrivialTemplate");
+    }
+};
+
+//--- module.modulemap
+module CxxTest {
+    header "header.h"
+    requires cplusplus
+}
+
+//--- use-cxx-types.swift
+import CxxTest
+
+public func retNonTrivial(y: CInt) -> NonTrivialTemplate<Trivial> {
+    return NonTrivialTemplate<Trivial>(Trivial(42, y))
+}
+
+public func retTrivial(_ x: CInt) -> Trivial {
+    return Trivial(x, -x)
+}
+
+//--- use-swift-cxx-types.cpp
+
+#include "header.h"
+#include "UseCxx.h"
+#include <assert.h>
+
+int main() {
+  {
+    auto x = UseCxx::retTrivial(423421);
+    assert(x.x == 423421);
+    assert(x.y == -423421);
+  }
+  {
+    auto x = UseCxx::retNonTrivial(-942);
+    assert(x.x.y == -942);
+    assert(x.x.x == 42);
+  }
+// CHECK: create NonTrivialTemplate
+// CHECK-NEXT: move NonTrivialTemplate
+// CHECK-NEXT: ~NonTrivialTemplate
+// CHECK-NEXT: ~NonTrivialTemplate
+  return 0;
+}

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx-execution.cpp
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx-execution.cpp
@@ -28,7 +28,9 @@ struct NonTrivialTemplate {
     inline NonTrivialTemplate(T x) : x(x) {
         puts("create NonTrivialTemplate");
     }
-    inline NonTrivialTemplate(const NonTrivialTemplate<T> &) = default;
+    inline NonTrivialTemplate(const NonTrivialTemplate<T> &other) : x(other.x) {
+        puts("copy NonTrivialTemplate");
+    }
     inline NonTrivialTemplate(NonTrivialTemplate<T> &&other) : x(static_cast<T &&>(other.x)) {
         puts("move NonTrivialTemplate");
     }
@@ -50,8 +52,32 @@ public func retNonTrivial(y: CInt) -> NonTrivialTemplate<Trivial> {
     return NonTrivialTemplate<Trivial>(Trivial(42, y))
 }
 
+public func takeNonTrivial(_ x: NonTrivialTemplate<Trivial>) {
+    print(x)
+}
+
+public func passThroughNonTrivial(_ x: NonTrivialTemplate<Trivial>) -> NonTrivialTemplate<Trivial>{
+    return x
+}
+
+public func inoutNonTrivial(_ x: inout NonTrivialTemplate<Trivial>) {
+    x.x.y *= 2
+}
+
 public func retTrivial(_ x: CInt) -> Trivial {
     return Trivial(x, -x)
+}
+
+public func takeTrivial(_ x: Trivial) {
+    print(x)
+}
+
+public func passThroughTrivial(_ x: Trivial) -> Trivial {
+    return x
+}
+
+public func inoutTrivial(_ x: inout Trivial) {
+    x.x = x.y + x.x - 11
 }
 
 //--- use-swift-cxx-types.cpp
@@ -65,15 +91,37 @@ int main() {
     auto x = UseCxx::retTrivial(423421);
     assert(x.x == 423421);
     assert(x.y == -423421);
+    UseCxx::takeTrivial(UseCxx::passThroughTrivial(x));
+    assert(x.x == 423421);
+    assert(x.y == -423421);
+    UseCxx::inoutTrivial(x);
+    assert(x.x == -11);
+    assert(x.y == -423421);
+    UseCxx::takeTrivial(x);
   }
+// CHECK: Trivial(x: 423421, y: -423421)
+// CHECK-NEXT: Trivial(x: -11, y: -423421)
   {
     auto x = UseCxx::retNonTrivial(-942);
     assert(x.x.y == -942);
     assert(x.x.x == 42);
+    UseCxx::takeNonTrivial(UseCxx::passThroughNonTrivial(x));
+    puts("done non trivial");
+    UseCxx::inoutNonTrivial(x);
+    assert(x.x.y == -1884);
+    assert(x.x.x == 42);
   }
-// CHECK: create NonTrivialTemplate
+// CHECK-NEXT: create NonTrivialTemplate
 // CHECK-NEXT: move NonTrivialTemplate
 // CHECK-NEXT: ~NonTrivialTemplate
+// CHECK-NEXT: copy NonTrivialTemplate
+// CHECK-NEXT: move NonTrivialTemplate
+// CHECK-NEXT: ~NonTrivialTemplate
+// CHECK-NEXT: copy NonTrivialTemplate
+// CHECK-NEXT: __CxxTemplateInst18NonTrivialTemplateI7TrivialE(x: __C.Trivial(x: 42, y: -942))
+// CHECK-NEXT: ~NonTrivialTemplate
+// CHECK-NEXT: ~NonTrivialTemplate
+// CHECK-NEXT: done non trivial
 // CHECK-NEXT: ~NonTrivialTemplate
   return 0;
 }

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
@@ -1,0 +1,122 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -typecheck %t/use-cxx-types.swift -typecheck -module-name UseCxxTy -emit-clang-header-path %t/UseCxxTy.h -I %t -enable-experimental-cxx-interop -clang-header-expose-public-decls
+
+// RUN: %FileCheck %s < %t/UseCxxTy.h
+
+// FIXME: remove once https://github.com/apple/swift/pull/60971 lands.
+// RUN: echo "#include \"header.h\"" > %t/full-cxx-swift-cxx-bridging.h
+// RUN: cat %t/UseCxxTy.h >> %t/full-cxx-swift-cxx-bridging.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/full-cxx-swift-cxx-bridging.h -Wno-reserved-identifier)
+
+// FIXME: test in C++ with modules (but libc++ modularization is preventing this)
+
+//--- header.h
+
+struct Trivial {
+    short x, y;
+};
+
+namespace ns {
+
+    struct TrivialinNS {
+        short x, y;
+    };
+
+    template<class T>
+    struct NonTrivialTemplate {
+        T x;
+
+        NonTrivialTemplate();
+        NonTrivialTemplate(const NonTrivialTemplate<T> &) = default;
+        NonTrivialTemplate(NonTrivialTemplate<T> &&) = default;
+        ~NonTrivialTemplate() {}
+    };
+
+    using TypeAlias = NonTrivialTemplate<TrivialinNS>;
+
+    struct NonTrivialImplicitMove {
+        NonTrivialTemplate<int> member;
+    };
+}
+
+//--- module.modulemap
+module CxxTest {
+    header "header.h"
+    requires cplusplus
+}
+
+//--- use-cxx-types.swift
+import CxxTest
+
+public func retNonTrivial() -> ns.NonTrivialTemplate<CInt> {
+    return ns.NonTrivialTemplate<CInt>()
+}
+
+public func retNonTrivial2() -> ns.NonTrivialTemplate<ns.TrivialinNS> {
+    return ns.NonTrivialTemplate<ns.TrivialinNS>()
+}
+
+public func retNonTrivialImplicitMove() -> ns.NonTrivialImplicitMove {
+    return ns.NonTrivialImplicitMove()
+}
+
+public func retNonTrivialTypeAlias() -> ns.TypeAlias {
+    return ns.TypeAlias()
+}
+
+public func retTrivial() -> Trivial {
+    return Trivial()
+}
+
+// CHECK: #if __has_feature(objc_modules)
+// CHECK: #if __has_feature(objc_modules)
+// CHECK-NEXT: #if __has_warning("-Watimport-in-framework-header")
+// CHECK-NEXT: #pragma clang diagnostic ignored "-Watimport-in-framework-header"
+// CHECK-NEXT:#endif
+// CHECK-NEXT: #pragma clang module import CxxTest;
+// CHECK-NEXT: #endif
+
+
+// CHECK: SWIFT_EXTERN void $s8UseCxxTy13retNonTrivialSo2nsO02__b18TemplateInstN2ns18efH4IiEEVyF(SWIFT_INDIRECT_RESULT void * _Nonnull) SWIFT_NOEXCEPT SWIFT_CALL; // retNonTrivial()
+// CHECK: SWIFT_EXTERN struct swift_interop_returnStub_UseCxxTy_uint32_t_0_4 $s8UseCxxTy10retTrivialSo0E0VyF(void) SWIFT_NOEXCEPT SWIFT_CALL; // retTrivial()
+
+// CHECK: inline ns::NonTrivialTemplate<int> retNonTrivial() noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT: alignas(alignof(ns::NonTrivialTemplate<int>)) char storage[sizeof(ns::NonTrivialTemplate<int>)];
+// CHECK-NEXT: auto * _Nonnull storageObjectPtr = reinterpret_cast<ns::NonTrivialTemplate<int> *>(storage);
+// CHECK-NEXT: _impl::$s8UseCxxTy13retNonTrivialSo2nsO02__b18TemplateInstN2ns18efH4IiEEVyF(storage);
+// CHECK-NEXT: ns::NonTrivialTemplate<int> result(std::move(*storageObjectPtr));
+// CHECK-NEXT: storageObjectPtr->~NonTrivialTemplate();
+// CHECK-NEXT: return result;
+// CHECK-NEXT: }
+// CHECK-EMPTY:
+// CHECK-EMPTY:
+// CHECK: inline ns::NonTrivialTemplate<ns::TrivialinNS> retNonTrivial2() noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT: alignas(alignof(ns::NonTrivialTemplate<ns::TrivialinNS>)) char storage[sizeof(ns::NonTrivialTemplate<ns::TrivialinNS>)];
+// CHECK-NEXT: auto * _Nonnull storageObjectPtr = reinterpret_cast<ns::NonTrivialTemplate<ns::TrivialinNS> *>(storage);
+// CHECK-NEXT: _impl::$s8UseCxxTy14retNonTrivial2So2nsO02__b18TemplateInstN2ns18e7TrivialH20INS_11TrivialinNSEEEVyF(storage);
+// CHECK-NEXT: ns::NonTrivialTemplate<ns::TrivialinNS> result(std::move(*storageObjectPtr));
+// CHECK-NEXT: storageObjectPtr->~NonTrivialTemplate();
+// CHECK-NEXT: return result;
+// CHECK-NEXT: }
+
+// CHECK: inline ns::NonTrivialImplicitMove retNonTrivialImplicitMove() noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT: alignas(alignof(ns::NonTrivialImplicitMove)) char storage[sizeof(ns::NonTrivialImplicitMove)];
+// CHECK-NEXT: auto * _Nonnull storageObjectPtr = reinterpret_cast<ns::NonTrivialImplicitMove *>(storage);
+// CHECK-NEXT: _impl::$s8UseCxxTy25retNonTrivialImplicitMoveSo2nsO0efgH0VyF(storage);
+// CHECK-NEXT: ns::NonTrivialImplicitMove result(std::move(*storageObjectPtr));
+// CHECK-NEXT: storageObjectPtr->~NonTrivialImplicitMove();
+// CHECK-NEXT: return result;
+// CHECK-NEXT: }
+
+// CHECK: ns::NonTrivialTemplate<ns::TrivialinNS> retNonTrivialTypeAlias() noexcept SWIFT_WARN_UNUSED_RESULT {
+
+// CHECK: inline Trivial retTrivial() noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT: alignas(alignof(Trivial)) char storage[sizeof(Trivial)];
+// CHECK-NEXT: auto * _Nonnull storageObjectPtr = reinterpret_cast<Trivial *>(storage);
+// CHECK-NEXT: _impl::swift_interop_returnDirect_UseCxxTy_uint32_t_0_4(storage, _impl::$s8UseCxxTy10retTrivialSo0E0VyF());
+// CHECK-NEXT: return *storageObjectPtr;
+// CHECK-NEXT: }
+

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
@@ -71,6 +71,15 @@ public func retTrivial() -> Trivial {
     return Trivial()
 }
 
+public func takeNonTrivial2(_ x: ns.NonTrivialTemplate<ns.TrivialinNS>) {
+}
+
+public func takeTrivial(_ x: Trivial) {
+}
+
+public func takeTrivialInout(_ x: inout Trivial) {
+}
+
 // CHECK: #if __has_feature(objc_modules)
 // CHECK: #if __has_feature(objc_modules)
 // CHECK-NEXT: #if __has_warning("-Watimport-in-framework-header")
@@ -120,3 +129,14 @@ public func retTrivial() -> Trivial {
 // CHECK-NEXT: return *storageObjectPtr;
 // CHECK-NEXT: }
 
+// CHECK: inline void takeNonTrivial2(const ns::NonTrivialTemplate<ns::TrivialinNS>& x) noexcept {
+// CHECK-NEXT:   return _impl::$s8UseCxxTy15takeNonTrivial2yySo2nsO02__b18TemplateInstN2ns18e7TrivialH20INS_11TrivialinNSEEEVF(swift::_impl::getOpaquePointer(x));
+// CHECK-NEXT: }
+
+// CHECK: inline void takeTrivial(const Trivial& x) noexcept {
+// CHECK-NEXT:   return _impl::$s8UseCxxTy11takeTrivialyySo0E0VF(_impl::swift_interop_passDirect_UseCxxTy_uint32_t_0_4(reinterpret_cast<const char *>(swift::_impl::getOpaquePointer(x))));
+// CHECK-NEXT: }
+
+// CHECK: inline void takeTrivialInout(Trivial& x) noexcept {
+// CHECK-NEXT:   return _impl::$s8UseCxxTy16takeTrivialInoutyySo0E0VzF(swift::_impl::getOpaquePointer(x));
+// CHECK-NEXT: }

--- a/test/Interop/CxxToSwiftToCxx/lit.local.cfg
+++ b/test/Interop/CxxToSwiftToCxx/lit.local.cfg
@@ -1,0 +1,1 @@
+config.suffixes = ['.swift', '.cpp', '.mm']

--- a/test/PrintAsCxx/empty.swift
+++ b/test/PrintAsCxx/empty.swift
@@ -90,12 +90,13 @@
 // CHECK:       # define SWIFT_ERROR_RESULT __attribute__((swift_error_result))
 
 // CHECK-LABEL: #if defined(__OBJC__)
-// CHECK-NEXT:  #if __has_feature(modules)
+// CHECK-NEXT:  #if __has_feature(objc_modules)
 
 // CHECK-LABEL: #if defined(__OBJC__)
 // CHECK-NEXT:  #endif
 // CHECK-NEXT:  #if defined(__cplusplus)
-// CHECK-NEXT:  #ifndef SWIFT_PRINTED_CORE
+// CHECK-NEXT:  #if __has_feature(objc_modules)
+// CHECK:       #ifndef SWIFT_PRINTED_CORE
 // CHECK:       } // namespace swift
 // CHECK-EMPTY:
 // CHECK-NEXT:  #endif

--- a/test/PrintAsObjC/empty.swift
+++ b/test/PrintAsObjC/empty.swift
@@ -34,7 +34,7 @@
 // CHECK: # define SWIFT_EXTENSION(M)
 // CHECK: # define OBJC_DESIGNATED_INITIALIZER
 
-// CHECK-LABEL: #if __has_feature(modules)
+// CHECK-LABEL: #if __has_feature(objc_modules)
 // CHECK-NEXT: #if __has_warning
 // CHECK-NEXT: #pragma clang diagnostic
 // CHECK-NEXT: #endif

--- a/test/PrintAsObjC/mixed-framework-fwd.swift
+++ b/test/PrintAsObjC/mixed-framework-fwd.swift
@@ -17,7 +17,7 @@
 
 // REQUIRES: objc_interop
 
-// CHECK-LABEL: #if __has_feature(modules)
+// CHECK-LABEL: #if __has_feature(objc_modules)
 // CHECK-NEXT: #if __has_warning
 // CHECK-NEXT: #pragma clang diagnostic
 // CHECK-NEXT: #endif

--- a/test/PrintAsObjC/mixed-framework.swift
+++ b/test/PrintAsObjC/mixed-framework.swift
@@ -12,7 +12,7 @@
 
 // CHECK: #pragma clang diagnostic push
 
-// CHECK-LABEL: #if __has_feature(modules)
+// CHECK-LABEL: #if __has_feature(objc_modules)
 // CHECK-NEXT: #if __has_warning("-Watimport-in-framework-header")
 // CHECK-NEXT: #pragma clang diagnostic ignored "-Watimport-in-framework-header"
 // CHECK-NEXT: #endif


### PR DESCRIPTION
This is done by moving-non trivial C++ records when returning them from Swift.
Also, we need to use `objc_modules` feature for printing dependencies in the generated header, as in C++20 mode `modules` is always enabled.