### PR TITLE
Renamed _noEagerMove attribute.

### DIFF
--- a/docs/ReferenceGuides/UnderscoredAttributes.md
+++ b/docs/ReferenceGuides/UnderscoredAttributes.md
@@ -159,7 +159,7 @@ that releases of the value may be hoisted without respect to deinit barriers.
 
 When applied to a type, indicates that all values which are _statically_
 instances of that type are themselves `@_eagerMove` as above, unless overridden
-with `@_lexical`.
+with `@_noEagerMove`.
 
 Aggregates all of whose fields are `@_eagerMove` or trivial are inferred to be
 `@_eagerMove`.
@@ -534,7 +534,7 @@ initializers from its superclass. This implies that all designated initializers
 overridden. This attribute is often printed alongside
 `@_hasMissingDesignatedInitializers` in this case.
 
-## `@_lexical`
+## `@_noEagerMove`
 
 When applied to a value, indicates that the value's lifetime is lexical, that
 releases of the value may not be hoisted over deinit barriers.  
@@ -544,7 +544,7 @@ This is the default behavior, unless the value's type is annotated
 annotation.
 
 When applied to a type, indicates that all values which are instances of that
-type are themselves `@_lexical` as above.
+type are themselves `@_noEagerMove` as above.
 
 This is the default behavior, unless the type annotated is an aggregate that
 consists entirely of `@_eagerMove` or trivial values, in which case the

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -676,7 +676,7 @@ CONTEXTUAL_SIMPLE_DECL_ATTR(distributed, DistributedActor,
   APIBreakingToAdd | APIBreakingToRemove,
   118)
 
-SIMPLE_DECL_ATTR(_lexical, Lexical,
+SIMPLE_DECL_ATTR(_noEagerMove, NoEagerMove,
   UserInaccessible |
   ABIStableToAdd | ABIStableToRemove |
   APIStableToAdd | APIStableToRemove |

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -990,7 +990,7 @@ public:
     auto &attrs = getAttrs();
     if (attrs.hasAttribute<EagerMoveAttr>())
       return LifetimeAnnotation::EagerMove;
-    if (attrs.hasAttribute<LexicalAttr>())
+    if (attrs.hasAttribute<NoEagerMoveAttr>())
       return LifetimeAnnotation::Lexical;
     return LifetimeAnnotation::None;
   }

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -516,7 +516,7 @@ ERROR(silfunc_and_silarg_have_incompatible_sil_value_ownership,none,
       "Function type specifies: '@%0'. SIL argument specifies: '@%1'.",
       (StringRef, StringRef))
 ERROR(sil_arg_both_lexical_and_eagerMove,none,
-      "Function argument is annotated both @_eagerMove and @_lexical, "
+      "Function argument is annotated both @_eagerMove and @_noEagerMove, "
       "but these are incompatible alternatives", ())
 ERROR(expected_sil_colon,none,
       "expected ':' before %0", (StringRef))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3240,7 +3240,7 @@ ERROR(inherits_executor_without_async,none,
 ERROR(lifetime_invalid_global_scope,none, "%0 is only valid on methods",
       (DeclAttribute))
 ERROR(eagermove_and_lexical_combined,none,
-      "@_eagerMove and @_lexical attributes are alternate styles of lifetimes "
+      "@_eagerMove and @_noEagerMove attributes are alternate styles of lifetimes "
       "and can't be combined", ())
 
 ERROR(autoclosure_function_type,none,

--- a/include/swift/AST/LifetimeAnnotation.h
+++ b/include/swift/AST/LifetimeAnnotation.h
@@ -29,7 +29,7 @@ namespace swift {
 ///
 /// 1) None: No annotation has been applied.
 /// 2) EagerMove: The @_eagerMove attribute has been applied.
-/// 3) Lexical: The @_lexical attribute has been applied.
+/// 3) NoEagerMove: The @_noEagerMove attribute has been applied.
 struct LifetimeAnnotation {
   enum Case : uint8_t {
     None,

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -272,7 +272,7 @@ struct ArgumentInitHelper {
     // Look for the following annotations on the function argument:
     // - @noImplicitCopy
     // - @_eagerMove
-    // - @_lexical
+    // - @_noEagerMove
     auto isNoImplicitCopy = pd->isNoImplicitCopy();
     auto lifetime = SGF.F.getLifetime(pd, value->getType());
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -324,7 +324,7 @@ public:
 
   bool visitLifetimeAttr(DeclAttribute *attr);
   void visitEagerMoveAttr(EagerMoveAttr *attr);
-  void visitLexicalAttr(LexicalAttr *attr);
+  void visitNoEagerMoveAttr(NoEagerMoveAttr *attr);
 
   void visitCompilerInitializedAttr(CompilerInitializedAttr *attr);
 
@@ -6519,10 +6519,10 @@ void AttributeChecker::visitEagerMoveAttr(EagerMoveAttr *attr) {
     return;
 }
 
-void AttributeChecker::visitLexicalAttr(LexicalAttr *attr) {
+void AttributeChecker::visitNoEagerMoveAttr(NoEagerMoveAttr *attr) {
   if (visitLifetimeAttr(attr))
     return;
-  // @_lexical and @_eagerMove are opposites and can't be combined.
+  // @_noEagerMove and @_eagerMove are opposites and can't be combined.
   if (D->getAttrs().hasAttribute<EagerMoveAttr>()) {
     diagnoseAndRemoveAttr(attr, diag::eagermove_and_lexical_combined);
     return;

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1620,7 +1620,7 @@ namespace  {
     UNINTERESTING_ATTR(AlwaysEmitConformanceMetadata)
 
     UNINTERESTING_ATTR(EagerMove)
-    UNINTERESTING_ATTR(Lexical)
+    UNINTERESTING_ATTR(NoEagerMove)
 #undef UNINTERESTING_ATTR
 
     void visitAvailableAttr(AvailableAttr *attr) {

--- a/test/SILGen/lexical_lifetime.swift
+++ b/test/SILGen/lexical_lifetime.swift
@@ -134,7 +134,7 @@ extension C {
 // CHECK:       {{bb[0-9]+}}({{%[^,]+}} : @_lexical @owned $C):
 // CHECK-LABEL: } // end sil function 'lexical_method_attr'
   @_silgen_name("lexical_method_attr")
-  @_lexical
+  @_noEagerMove
   __consuming
   func lexical_method_attr() {}
 

--- a/test/SILOptimizer/inline_lifetime.sil
+++ b/test/SILOptimizer/inline_lifetime.sil
@@ -34,7 +34,7 @@ struct InferredEagerD2S1 {
   var i4: InferredEagerD1S4
 }
 
-@_lexical
+@_noEagerMove
 struct LexicalS {
   var i: InferredEagerD2S1
 }
@@ -47,11 +47,11 @@ struct InferredLexicalD1S1 {
 }
 
 struct InferredLexicalD1S2 {
-  @_lexical var i: InferredEagerD2S1
+  @_noEagerMove var i: InferredEagerD2S1
 }
 
 struct InferredLexicalD1S3 {
-  @_lexical var i: InferredEagerD2S1
+  @_noEagerMove var i: InferredEagerD2S1
   var j: InferredEagerD2S1
 }
 

--- a/test/attr/lexical.swift
+++ b/test/attr/lexical.swift
@@ -9,35 +9,35 @@ enum E {}
 @_eagerMove // expected-error {{'@_eagerMove' attribute cannot be applied to this declaration}}
 typealias EagerTuple = (C, C)
 
-func foo(@_lexical @_eagerMove _ e: E) {} // expected-error {{@_eagerMove and @_lexical attributes are alternate styles of lifetimes and can't be combined}}
+func foo(@_noEagerMove @_eagerMove _ e: E) {} // expected-error {{@_eagerMove and @_noEagerMove attributes are alternate styles of lifetimes and can't be combined}}
 
-func bar(@_lexical _ s: S) {} // okay
+func bar(@_noEagerMove _ s: S) {} // okay
 
 func baz(@_eagerMove _ c: C) {} // okay
 
 @_eagerMove // expected-error {{@_eagerMove is only valid on methods}}
 func bazzoo(_ c: C) {}
 
-@_lexical // expected-error {{@_lexical is only valid on methods}}
+@_noEagerMove // expected-error {{@_noEagerMove is only valid on methods}}
 func bazzoozoo(_ c: C) {}
 
 extension C {
   @_eagerMove
   func pazzoo() {}
 
-  @_lexical
+  @_noEagerMove
   func pazzoozoo() {}
 }
 
 struct S2 {
   @_eagerMove let c: C // okay
-  @_lexical let e: E // okay
+  @_noEagerMove let e: E // okay
 }
 
 func foo() {
-  @_lexical let s1 = S()
+  @_noEagerMove let s1 = S()
   @_eagerMove var s2 = S()
-  @_lexical @_eagerMove let s3 = S() // expected-error {{@_eagerMove and @_lexical attributes are alternate styles of lifetimes and can't be combined}}
+  @_noEagerMove @_eagerMove let s3 = S() // expected-error {{@_eagerMove and @_noEagerMove attributes are alternate styles of lifetimes and can't be combined}}
   _ = s1
   s2 = S()
   _ = s2


### PR DESCRIPTION
Avoid introducing extra terminology via an underscored attribute.

rdar://99723104
