### PR TITLE
[5.7][test] UnicodeScalarProperties: Disable when Unicode data files aren’t available

### DIFF
--- a/validation-test/stdlib/UnicodeScalarProperties.swift
+++ b/validation-test/stdlib/UnicodeScalarProperties.swift
@@ -4,6 +4,11 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: objc_interop
 
+// This test requires access to Unicode data files in the source tree, so
+// it doesn't currently support testing on a remote device. (rdar://98993795)
+// UNSUPPORTED: remote_run
+// UNSUPPORTED: device_run
+
 @_spi(_Unicode)
 import Swift
 


### PR DESCRIPTION
To reenable, the test needs to be configured to upload these files to the remote machine that executes the tests.

(cherry picked from commit ffab0c541f56cd7fd1a79b16a14a2627bb57b82d)

- **Explanation**: This cherry picks a configuration change to a Standard Library test that resolves a CI blocker on the 5.7 branch by partially disabling a particular test that only supports running on the build host. It contains no code changes.

- **Scope**: Stdlib tests

- **Issue**: rdar://99716393

- **Risk**: Minimal

- **Testing**: Device/back deployment CI testing (verified on main after #60713 landed)

- **Reviewer**: @Azoy
