### PR TITLE
[Sema] Report conflicting uses of `@_spiOnly` with other import modifiers

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -965,8 +965,10 @@ ERROR(module_not_compiled_for_private_import,none,
       "module %0 was not compiled for private import", (Identifier))
 
 ERROR(import_restriction_conflict,none,
-      "module %0 cannot be both %1 and %2",
-      (Identifier, StringRef, StringRef))
+      "module %0 cannot be both "
+      "%select{implementation-only|SPI only|exported}1 and "
+      "%select{implementation-only|SPI only|exported}2 ",
+      (Identifier, unsigned, unsigned))
 
 WARNING(module_not_compiled_with_library_evolution,none,
         "module %0 was not compiled with library evolution support; "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -964,8 +964,9 @@ ERROR(module_not_testable,Fatal,
 ERROR(module_not_compiled_for_private_import,none,
       "module %0 was not compiled for private import", (Identifier))
 
-ERROR(import_implementation_cannot_be_exported,none,
-      "module %0 cannot be both exported and implementation-only", (Identifier))
+ERROR(import_restriction_conflict,none,
+      "module %0 cannot be both %1 and %2",
+      (Identifier, StringRef, StringRef))
 
 WARNING(module_not_compiled_with_library_evolution,none,
         "module %0 was not compiled with library evolution support; "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2983,6 +2983,13 @@ WARNING(warn_implementation_only_conflict,none,
         (Identifier))
 NOTE(implementation_only_conflict_here,none,
      "imported as implementation-only here", ())
+
+ERROR(spi_only_import_conflict,none,
+      "%0 inconsistently imported for SPI only",
+      (Identifier))
+NOTE(spi_only_import_conflict_here,none,
+     "imported for SPI only here", ())
+
 ERROR(error_public_import_of_private_module,none,
         "private module %0 is imported publicly from the public module %1",
         (Identifier, Identifier))

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3289,6 +3289,25 @@ public:
   bool isCached() const { return true; }
 };
 
+/// Check that if one import in a file uses \c @_spiOnly, all imports from the
+/// same file are consistently using \c @_spiOnly.
+class CheckInconsistentSPIOnlyImportsRequest
+    : public SimpleRequest<CheckInconsistentSPIOnlyImportsRequest,
+                           evaluator::SideEffect(SourceFile *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  evaluator::SideEffect evaluate(Evaluator &evaluator, SourceFile *mod) const;
+
+public:
+  // Cached.
+  bool isCached() const { return true; }
+};
+
 /// Checks to see if any of the imports in a module use \c @_weakLinked
 /// in one file and not in another.
 ///

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -33,6 +33,8 @@ SWIFT_REQUEST(TypeChecker, CallerSideDefaultArgExprRequest,
               Expr *(DefaultArgumentExpr *), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, CheckInconsistentImplementationOnlyImportsRequest,
               evaluator::SideEffect(ModuleDecl *), Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, CheckInconsistentSPIOnlyImportsRequest,
+              evaluator::SideEffect(SourceFile *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, CheckInconsistentWeakLinkedImportsRequest,
               evaluator::SideEffect(ModuleDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, CheckRedeclarationRequest,

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -337,6 +337,11 @@ TypeCheckSourceFileRequest::evaluate(Evaluator &eval, SourceFile *SF) const {
 
   evaluateOrDefault(
       Ctx.evaluator,
+      CheckInconsistentSPIOnlyImportsRequest{SF},
+      {});
+
+  evaluateOrDefault(
+      Ctx.evaluator,
       CheckInconsistentWeakLinkedImportsRequest{SF->getParentModule()}, {});
 
   // Perform various AST transforms we've been asked to perform.

--- a/test/SPI/spi-only-import-conflicting.swift
+++ b/test/SPI/spi-only-import-conflicting.swift
@@ -1,0 +1,79 @@
+/// Test duplicate and conflicting imports from the same file.
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// Generate dependencies.
+// RUN: %target-swift-frontend -emit-module %t/Lib.swift \
+// RUN:   -module-name Lib -emit-module-path %t/Lib.swiftmodule \
+// RUN:   -swift-version 5 -enable-library-evolution
+
+/// Build clients.
+// RUN: %target-swift-frontend -typecheck %t/SPIOnly_Default.swift -I %t -verify \
+// RUN:   -experimental-spi-only-imports -verify
+// RUN: %target-swift-frontend -typecheck %t/Default_SPIOnly.swift -I %t -verify \
+// RUN:   -experimental-spi-only-imports -verify
+// RUN: %target-swift-frontend -typecheck %t/SPIOnly_Exported.swift -I %t -verify \
+// RUN:   -experimental-spi-only-imports -verify
+// RUN: %target-swift-frontend -typecheck %t/Exported_SPIOnly.swift -I %t -verify \
+// RUN:   -experimental-spi-only-imports -verify
+// RUN: %target-swift-frontend -typecheck %t/SPIOnly_IOI.swift -I %t -verify \
+// RUN:   -experimental-spi-only-imports -verify
+// RUN: %target-swift-frontend -typecheck %t/SPIOnly_IOI_Exported_Default.swift -I %t -verify \
+// RUN:   -experimental-spi-only-imports -verify
+// RUN: %target-swift-frontend -typecheck -primary-file %t/SPIOnly_Default_FileA.swift \
+// RUN:   %t/SPIOnly_Default_FileB.swift -I %t -verify \
+// RUN:   -experimental-spi-only-imports -verify
+// RUN: %target-swift-frontend -typecheck -primary-file %t/IOI_Default_FileA.swift \
+// RUN:   %t/IOI_Default_FileB.swift -I %t -verify \
+// RUN:   -experimental-spi-only-imports -verify
+
+//--- Lib.swift
+// Empty source file for import.
+
+//--- SPIOnly_Default.swift
+@_spiOnly import Lib // expected-note {{imported for SPI only here}}
+import Lib // expected-error {{'Lib' inconsistently imported for SPI only}}
+
+//--- Default_SPIOnly.swift
+import Lib // expected-error {{'Lib' inconsistently imported for SPI only}}
+@_spiOnly import Lib // expected-note {{imported for SPI only here}}
+
+//--- SPIOnly_Exported.swift
+@_spiOnly import Lib // expected-note {{imported for SPI only here}}
+@_exported import Lib // expected-error {{'Lib' inconsistently imported for SPI only}}
+
+//--- Exported_SPIOnly.swift
+@_exported import Lib // expected-error {{'Lib' inconsistently imported for SPI only}}
+@_spiOnly import Lib // expected-note {{imported for SPI only here}}
+
+//--- SPIOnly_IOI.swift
+@_spiOnly import Lib // expected-note {{imported for SPI only here}}
+// expected-warning @-1 {{'Lib' inconsistently imported as implementation-only}}
+@_implementationOnly import Lib // expected-error {{'Lib' inconsistently imported for SPI only}}
+// expected-note @-1 {{imported as implementation-only here}}
+
+/// Many confliciting imports lead to many diagnostics.
+//--- SPIOnly_IOI_Exported_Default.swift
+@_spiOnly import Lib // expected-note 3 {{imported for SPI only here}}
+// expected-warning @-1 {{'Lib' inconsistently imported as implementation-only}}
+@_implementationOnly import Lib // expected-error {{'Lib' inconsistently imported for SPI only}}
+// expected-note @-1 3 {{imported as implementation-only here}}
+@_exported import Lib // expected-error {{'Lib' inconsistently imported for SPI only}}
+// expected-warning @-1 {{'Lib' inconsistently imported as implementation-only}}
+import Lib // expected-error {{'Lib' inconsistently imported for SPI only}}
+// expected-warning @-1 {{'Lib' inconsistently imported as implementation-only}}
+
+/// Different SPI only imports in different files of the same module are accepted.
+//--- SPIOnly_Default_FileA.swift
+@_spiOnly import Lib
+
+//--- SPIOnly_Default_FileB.swift
+import Lib
+
+/// Different IOI in different files of the same module are still rejected.
+//--- IOI_Default_FileA.swift
+@_implementationOnly import Lib // expected-note {{imported as implementation-only here}}
+
+//--- IOI_Default_FileB.swift
+import Lib // expected-warning {{'Lib' inconsistently imported as implementation-only}}


### PR DESCRIPTION
Check that an `@_spiOnly` attribute isn't used with `@_implementationOnly` or `@_exported` on the same import statement or in the same source file. This check is partially integrated with the existing check for `@_implementationOnly` consistency. This could be integrated further once we have a per-file implementation-only import alternative, for now the differences between `@_implementationOnly` and `@_spiOnly` makes it a bit messy.

For clarification, here's what we check:

- (updated) Raise an error if incompatible import modifiers are used on the same import statement. Only one or none of the following can be used at a time: `@_spiOnly`, `@_implementationOnly` and `@_exported`.
- (new) Raise an error on inconsistent `@_spiOnly` imports of the same target within one source file.
- (old, for reference) Report as a warning inconsistent `@_implementationOnly` imports of the same target within a module.

Follows the integration with API checks from #61023. This should complete the main feature, but of course, further tweaks will likely be needed.