### PR TITLE
[Dependency Scanner][NFC] Clean up/Gardening on 'ClangModuleDependencyScanner'

### DIFF
--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -137,6 +137,7 @@ if(NOT SWIFT_BUILD_ONLY_SYNTAXPARSERLIB)
     clangFormat
     clangToolingCore
     clangFrontendTool
+    clangDependencyScanning
     clangFrontend
     clangDriver
     clangSerialization

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -225,6 +225,7 @@ void ModuleDependencies::addBridgingModuleDependency(
   }
 }
 
+GlobalModuleDependenciesCache::GlobalModuleDependenciesCache() {}
 GlobalModuleDependenciesCache::TargetSpecificGlobalCacheState *
 GlobalModuleDependenciesCache::getCurrentCache() const {
   assert(CurrentTriple.hasValue() &&
@@ -533,7 +534,17 @@ ModuleDependenciesCache::getDependencyReferencesMap(
 ModuleDependenciesCache::ModuleDependenciesCache(
     GlobalModuleDependenciesCache &globalCache,
     StringRef mainScanModuleName)
-    : globalCache(globalCache), mainScanModuleName(mainScanModuleName) {
+    : globalCache(globalCache),
+      mainScanModuleName(mainScanModuleName),
+      clangScanningService(
+          clang::tooling::dependencies::ScanningMode::DependencyDirectivesScan,
+          clang::tooling::dependencies::ScanningOutputFormat::Full,
+          clang::CASOptions(),
+          /* Cache */ nullptr,
+          /* SharedFS */ nullptr,
+          /* ReuseFileManager */ false,
+          /* OptimizeArgs */ false),
+      clangScanningTool(clangScanningService) {
   for (auto kind = ModuleDependenciesKind::FirstKind;
        kind != ModuleDependenciesKind::LastKind; ++kind) {
     ModuleDependenciesMap.insert(


### PR DESCRIPTION
Move `clangScanningTool` and `clangScanningService` to be parts of `ModuleDependenciesCache` state, getting rid of the `ClangModuleDependenciesCacheImpl`, which is no-longer needed since we moved moved to by-name lookup of Clang modules.

A followup change will be moving `clangScanningService` back into state shared across invocations.