### PR TITLE
SIL: Use the right generic signature for computing SIL function type for coroutine accessors

### DIFF
--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1960,9 +1960,12 @@ static CanSILFunctionType getSILFunctionType(
 
     if (reqtSubs) {
       valueType = valueType.subst(*reqtSubs);
+      coroutineSubstYieldType = valueType->getReducedType(
+          genericSig);
+    } else {
+      coroutineSubstYieldType = valueType->getReducedType(
+          accessor->getGenericSignature());
     }
-
-    coroutineSubstYieldType = valueType->getReducedType(genericSig);
   }
 
   bool shouldBuildSubstFunctionType = [&]{

--- a/test/SILGen/constrained_extensions.swift
+++ b/test/SILGen/constrained_extensions.swift
@@ -227,3 +227,16 @@ func referenceNestedTypes() {
   _ = Array<AnyObject>.NestedClass()
   _ = Array<AnyObject>.DerivedClass()
 }
+
+struct S<T> {
+  struct X {}
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s22constrained_extensions1SVAASiRszlEyAC1XVySi_GSicir : $@yield_once @convention(method) (Int, S<Int>) -> @yields S<Int>.X
+extension S<Int> {
+  subscript(index:Int) -> X {
+    _read {
+      fatalError()
+    }
+  }
+}


### PR DESCRIPTION
The function type's generic signature will have already been dropped at this point if all generic parameters were fully concrete, so use the original generic signature to compute the reduced type of the yield type.

Fixes https://github.com/apple/swift/issues/61040.