### PR TITLE
[Sema] Add param indicate diagnose or not in lookupPrecedenceGroupForInfixOperator

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8110,7 +8110,8 @@ bool swift::exprNeedsParensInsideFollowingOperator(
     DeclContext *DC, Expr *expr,
     PrecedenceGroupDecl *followingPG) {
   if (expr->isInfixOperator()) {
-    auto exprPG = TypeChecker::lookupPrecedenceGroupForInfixOperator(DC, expr);
+    auto exprPG = TypeChecker::lookupPrecedenceGroupForInfixOperator(
+        DC, expr, /*diagnose=*/false);
     if (!exprPG) return true;
 
     return DC->getASTContext().associateInfixOperators(exprPG, followingPG)
@@ -8160,8 +8161,8 @@ bool swift::exprNeedsParensOutsideFollowingOperator(
     return false;
 
   if (parent->isInfixOperator()) {
-    auto parentPG = TypeChecker::lookupPrecedenceGroupForInfixOperator(DC,
-                                                                       parent);
+    auto parentPG = TypeChecker::lookupPrecedenceGroupForInfixOperator(
+        DC, parent, /*diagnose=*/false);
     if (!parentPG) return true;
 
     // If the index is 0, this is on the LHS of the parent.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -905,8 +905,8 @@ lookupMemberType(DeclContext *dc, Type type, DeclNameRef name,
 
 /// Given an expression that's known to be an infix operator,
 /// look up its precedence group.
-PrecedenceGroupDecl *lookupPrecedenceGroupForInfixOperator(DeclContext *dc,
-                                                           Expr *op);
+PrecedenceGroupDecl *
+lookupPrecedenceGroupForInfixOperator(DeclContext *dc, Expr *op, bool diagnose);
 
 PrecedenceGroupLookupResult
 lookupPrecedenceGroup(DeclContext *dc, Identifier name, SourceLoc nameLoc);

--- a/test/Constraints/operator.swift
+++ b/test/Constraints/operator.swift
@@ -314,3 +314,16 @@ do {
   let number = 1
   let test = true || number == .First.rawValue // expected-error {{type 'Int' has no member 'First'}}
 }
+
+// https://github.com/apple/swift/issues/60954
+enum I60954 {
+  // expected-error@+1{{operator implementation without matching operator declaration}}
+  func ?= (pattern: I60954?, version: Self) { // expected-error{{operator '?=' declared in type 'I60954' must be 'static'}}
+    // expected-error@+2{{operator is not a known binary operator}}
+    // expected-error@+1{{initializer 'init(_:)' requires that 'I60954' conform to 'StringProtocol'}}
+    pattern ?= .init(version) // expected-error{{value of optional type 'I60954?' must be unwrapped to a value of type 'I60954'}}
+    // expected-note@-1{{coalesce using '??' to provide a default when the optional value contains 'nil'}}
+    // expected-note@-2{{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+  }
+  init?<S>(_ string: S) where S: StringProtocol {} // expected-note{{where 'S' = 'I60954'}}
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
While attempting to emit a fix-it for a diagnostic `exprNeedsParensInsideFollowingOperator` indirectly calls `lookupPrecedenceGroupForInfixOperator` which by default also emits diagnostics which in this case crashes diagnostic engine. So we add the option to call `lookupPrecedenceGroupForInfixOperator` without any diagnostic in cases are not needed.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves: https://github.com/apple/swift/issues/60954
Resolves: rdar://99562101

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
