### PR TITLE
[5.7][CSClosure] Fix some aspects of property wrapper handling in closures

### DIFF
--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -498,18 +498,13 @@ private:
       init = TypeChecker::buildDefaultInitializer(patternType);
     }
 
-    if (init) {
-      return SolutionApplicationTarget::forInitialization(
-          init, patternBinding->getDeclContext(), patternType, patternBinding,
-          index,
-          /*bindPatternVarsOneWay=*/false);
-    }
-
-    // If there was no initializer, there could be one from a property
-    // wrapper which has to be pre-checked before use. This is not a
-    // problem in top-level code because pattern bindings go through
-    // `typeCheckExpression` which does pre-check automatically and
-    // result builders do not allow declaring local wrapped variables.
+    // A property wrapper initializer (either user-defined
+    // or a synthesized one) has to be pre-checked before use.
+    //
+    // This is not a problem in top-level code because pattern
+    // bindings go through `typeCheckExpression` which does
+    // pre-check automatically and result builders do not allow
+    // declaring local wrapped variables (yet).
     if (hasPropertyWrapper(pattern)) {
       auto target = SolutionApplicationTarget::forInitialization(
           init, patternBinding->getDeclContext(), patternType, patternBinding,
@@ -522,6 +517,13 @@ private:
         return None;
 
       return target;
+    }
+
+    if (init) {
+      return SolutionApplicationTarget::forInitialization(
+          init, patternBinding->getDeclContext(), patternType, patternBinding,
+          index,
+          /*bindPatternVarsOneWay=*/false);
     }
 
     return SolutionApplicationTarget::forUninitializedVar(patternBinding, index,

--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -109,7 +109,7 @@ public:
           CS.setType(var, computeProjectedValueType(wrappedVar, wrapperType));
         } else {
           // _<name> is the wrapper var
-          CS.setType(var, computeWrappedValueType(wrappedVar, wrapperType));
+          CS.setType(var, wrapperType);
         }
 
         return {true, expr};

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -554,3 +554,44 @@ do {
     }
   }
 }
+
+https://github.com/apple/swift/issues/61024
+do {
+  enum Baz: String {
+  case someCase
+  }
+
+  @propertyWrapper
+  struct Wrapper {
+    var wrappedValue: Int
+    let argument: String
+
+    init(wrappedValue: Int, argument: String) { // expected-note 2 {{'init(wrappedValue:argument:)' declared here}}
+      self.wrappedValue = wrappedValue
+      self.argument = argument
+    }
+  }
+
+  class Foo {
+    let ok: () -> Void = {
+      @Wrapper(argument: Baz.someCase.rawValue) var wrapped1 = 1 // Ok
+      @Wrapper(wrappedValue: 42, argument: Baz.someCase.rawValue) var wrapped2 // Ok
+      @Wrapper(wrappedValue: 42, argument: Baz.someCase.rawValue) var wrapped3: Int // Ok
+    }
+
+    let bad0: () -> Void = {
+      @Wrapper var wrapped: Int
+      // expected-error@-1 {{missing arguments for parameters 'wrappedValue', 'argument' in call}}
+    }
+
+    let bad1: () -> Void = {
+      @Wrapper var wrapped = 0
+      // expected-error@-1 {{missing argument for parameter 'argument' in property wrapper initializer; add 'wrappedValue' and 'argument' arguments in '@Wrapper(...)'}}
+    }
+
+    let bad2: () -> Void = {
+      @Wrapper(wrappedValue: 42, argument: Baz.someCase.rawValue) var wrapped = 0
+      // expected-error@-1 {{extra argument 'wrappedValue' in call}}
+    }
+  }
+}

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -535,3 +535,22 @@ struct Test {
     }
   }
 }
+
+https://github.com/apple/swift/issues/61017
+do {
+  @propertyWrapper
+  struct Wrapper {
+    var wrappedValue: Int
+
+    init(wrappedValue: Int) {
+      self.wrappedValue = wrappedValue
+    }
+  }
+
+  class Test {
+    let bar: () -> Void = {
+      @Wrapper var wrapped = 1
+      let wrapper: Wrapper = _wrapped // Ok
+    }
+  }
+}

--- a/validation-test/Sema/type_checker_crashers_fixed/issue59294.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/issue59294.swift
@@ -74,7 +74,7 @@ class Test {
       if $value.returnValue() > 0 {
         test {
           return $value.returnValue() == $0 &&
-                 _value == $0
+                 _value.wrappedValue == $0
         }
       }
       return false
@@ -84,7 +84,7 @@ class Test {
       @WrapperValue var value = $0
 
       test {
-        if _value != $0 { // Ok
+        if _value.wrappedValue != $0 { // Ok
           $value.printValue()
         }
       }
@@ -99,7 +99,8 @@ class Test {
       if true {
         @OuterWrapper @WrapperValue var value = $0
         if true {
-          let _: Bool = _value == $0
+          let _: OuterWrapper<WrapperValue<Bool>> = _value
+          let _ = _value.wrappedValue.wrappedValue == $0
           let _: OuterWrapper<WrapperValue<Bool>> = $value
           let _: Bool = value
         }


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/61052

---

- Explanation:

Fixes a couple of issues related declaring and using property wrappers in closures which regressed in 5.7.

- Always pre-check `init` targets of wrapped vars

If a variable with attached property wrapper has an initializer
expression it could be modified by implicit wrapper application,
if there is no initializer - one would be synthesized by the
compiler (without arguments). In both cases target has to be
pre-checked before constraints are generated for it.

- Use correct type for implicit wrapper variables

Using `computeWrappedValueType` is incorrect because
that return a type of the wrapped variable and not
the *wrapper* variable (one that starts with `_`).

- Scope: Property wrapper variable references in closures (`_<name>`) and property wrapped variable declarations with extra arguments.

- Main Branch PR: https://github.com/apple/swift/pull/61052

- Resolves: https://github.com/apple/swift/issues/61024, https://github.com/apple/swift/issues/61017

- Risk: Very low

- Reviewed By: @hborla

- Testing:  Added a regression test-case to the suite.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
