### PR TITLE
Fix and update `getSwiftRuntimeCompatibilityVersionForTarget`

### DIFF
--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -428,12 +428,13 @@ swift::getSwiftRuntimeCompatibilityVersionForTarget(
     } else if (Major == 11) {
       if (Minor <= 2)
         return floorFor64(llvm::VersionTuple(5, 3));
-
       return floorFor64(llvm::VersionTuple(5, 4));
     } else if (Major == 12) {
       if (Minor <= 2)
         return floorFor64(llvm::VersionTuple(5, 5));
       return floorFor64(llvm::VersionTuple(5, 6));
+    } else if (Major == 13) {
+      return floorFor64(llvm::VersionTuple(5, 7));
     }
   } else if (Triple.isiOS()) { // includes tvOS
     llvm::VersionTuple OSVersion = Triple.getiOSVersion();
@@ -472,6 +473,8 @@ swift::getSwiftRuntimeCompatibilityVersionForTarget(
       if (Minor <= 3)
         return floorForArchitecture(llvm::VersionTuple(5, 5));
       return floorForArchitecture(llvm::VersionTuple(5, 6));
+    } else if (Major <= 16) {
+      return floorForArchitecture(llvm::VersionTuple(5, 7));
     }
   } else if (Triple.isWatchOS()) {
     llvm::VersionTuple OSVersion = Triple.getWatchOSVersion();
@@ -501,6 +504,8 @@ swift::getSwiftRuntimeCompatibilityVersionForTarget(
       if (Minor <= 4)
         return floorFor64bits(llvm::VersionTuple(5, 5));
       return floorFor64bits(llvm::VersionTuple(5, 6));
+    } else if (Major <= 9) {
+      return floorFor64bits(llvm::VersionTuple(5, 7));
     }
   }
 

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -431,7 +431,9 @@ swift::getSwiftRuntimeCompatibilityVersionForTarget(
 
       return floorFor64(llvm::VersionTuple(5, 4));
     } else if (Major == 12) {
-      return floorFor64(llvm::VersionTuple(5, 5));
+      if (Minor <= 2)
+        return floorFor64(llvm::VersionTuple(5, 5));
+      return floorFor64(llvm::VersionTuple(5, 6));
     }
   } else if (Triple.isiOS()) { // includes tvOS
     llvm::VersionTuple OSVersion = Triple.getiOSVersion();
@@ -467,7 +469,9 @@ swift::getSwiftRuntimeCompatibilityVersionForTarget(
 
       return floorForArchitecture(llvm::VersionTuple(5, 4));
     } else if (Major <= 15) {
-      return floorForArchitecture(llvm::VersionTuple(5, 5));
+      if (Minor <= 3)
+        return floorForArchitecture(llvm::VersionTuple(5, 5));
+      return floorForArchitecture(llvm::VersionTuple(5, 6));
     }
   } else if (Triple.isWatchOS()) {
     llvm::VersionTuple OSVersion = Triple.getWatchOSVersion();
@@ -494,7 +498,9 @@ swift::getSwiftRuntimeCompatibilityVersionForTarget(
 
       return floorFor64bits(llvm::VersionTuple(5, 4));
     } else if (Major <= 8) {
-      return floorFor64bits(llvm::VersionTuple(5, 5));
+      if (Minor <= 4)
+        return floorFor64bits(llvm::VersionTuple(5, 5));
+      return floorFor64bits(llvm::VersionTuple(5, 6));
     }
   }
 

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -426,7 +426,7 @@ swift::getSwiftRuntimeCompatibilityVersionForTarget(
         }
       }
     } else if (Major == 11) {
-      if (Minor <= 3)
+      if (Minor <= 2)
         return floorFor64(llvm::VersionTuple(5, 3));
 
       return floorFor64(llvm::VersionTuple(5, 4));
@@ -489,7 +489,7 @@ swift::getSwiftRuntimeCompatibilityVersionForTarget(
         return floorFor64bits(llvm::VersionTuple(5, 2));
       }
     } else if (Major <= 7) {
-      if (Minor <= 4)
+      if (Minor <= 3)
         return floorFor64bits(llvm::VersionTuple(5, 3));
 
       return floorFor64bits(llvm::VersionTuple(5, 4));


### PR DESCRIPTION
`getSwiftRuntimeCompatibilityVersionForTarget` did not handle Swift 5.6 or 5.7.
Adding those according to `utils/availability-macros.def`.

Also found discrepancies between this function and the mapped version numbers.

rdar://99881351