### PR TITLE
[Sema] Don't error on public imports of private modules in a swiftinterface

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2993,8 +2993,8 @@ NOTE(spi_only_import_conflict_here,none,
      "imported for SPI only here", ())
 
 ERROR(error_public_import_of_private_module,none,
-        "private module %0 is imported publicly from the public module %1",
-        (Identifier, Identifier))
+      "private module %0 is imported publicly from the public module %1",
+      (Identifier, Identifier))
 
 ERROR(implementation_only_decl_non_override,none,
       "'@_implementationOnly' can only be used on overrides", ())

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1867,8 +1867,10 @@ public:
 #endif
 
         bool isImportOfUnderlying = importer->getName() == target->getName();
+        auto *SF = ID->getDeclContext()->getParentSourceFile();
         bool treatAsError = enableTreatAsError &&
-                            !isImportOfUnderlying;
+                            !isImportOfUnderlying &&
+                            SF->Kind != SourceFileKind::Interface;
         if (!treatAsError)
           inFlight.limitBehavior(DiagnosticBehavior::Warning);
       }

--- a/test/Sema/implementation-only-import-suggestion.swift
+++ b/test/Sema/implementation-only-import-suggestion.swift
@@ -71,3 +71,21 @@ import LocalClang // expected-error{{private module 'LocalClang' is imported pub
 // RUN: not %target-swift-frontend -typecheck %s -library-level ThatsNotALibraryLevel 2>&1 \
 // RUN:   | %FileCheck %s --check-prefix CHECK-ARG
 // CHECK-ARG: error: unknown library level 'ThatsNotALibraryLevel', expected one of 'api', 'spi' or 'other'
+
+/// Expect no errors in swiftinterfaces.
+// RUN: %target-swift-typecheck-module-from-interface(%t/Client.private.swiftinterface) \
+// RUN: -sdk %t/sdk -module-cache-path %t -F %t/sdk/System/Library/PrivateFrameworks/ \
+// RUN:   -I %t -module-name Client
+
+//--- Client.private.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-compiler-version: Swift version 5.8-dev effective-4.1.50
+// swift-module-flags: -swift-version 4 -module-name Client -library-level api
+
+import PublicSwift
+import PrivateSwift
+import PublicClang
+import PublicClang_Private
+import FullyPrivateClang
+import LocalClang
+@_exported import MainLib


### PR DESCRIPTION
The diagnostic reporting imports of a private module from a public module is an error for debug compilers. Let's downgrade the diagnostic to a warning in swiftinterfaces for any compilers. At the point of building a swiftinterface it should either build or not build depending on the context and SDK used, no need to enforce something beyond the build context.