### PR TITLE
[stdlib] use a primary associated type for `initialize(fromContentsOf:)`

### DIFF
--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -711,9 +711,9 @@ extension Unsafe${Mutable}BufferPointer {
   ///     by this function.
   @inlinable
   @_alwaysEmitIntoClient
-  public func initialize<C: Collection>(
-    fromContentsOf source: C
-  ) -> Index where C.Element == Element {
+  public func initialize(
+    fromContentsOf source: some Collection<Element>
+  ) -> Index {
     let count = source.withContiguousStorageIfAvailable {
       guard let sourceAddress = $0.baseAddress, !$0.isEmpty else {
         return 0
@@ -814,9 +814,9 @@ extension Unsafe${Mutable}BufferPointer {
   /// - Returns: An index one past the index of the last element updated.
   @inlinable
   @_alwaysEmitIntoClient
-  public func update<C: Collection>(
-    fromContentsOf source: C
-  ) -> Index where C.Element == Element {
+  public func update(
+    fromContentsOf source: some Collection<Element>
+  ) -> Index {
     let count = source.withContiguousStorageIfAvailable {
       guard let sourceAddress = $0.baseAddress else {
         return 0


### PR DESCRIPTION
Express `UnsafeMutableBufferPointer.initialize(fromContentsOf:)` using `some` notation
(primary associated type).

Follow-up to SE-0370 (https://github.com/apple/swift/pull/41608)
