### PR TITLE
[ConstraintSystem] Use witnesses for `makeIterator` and `next` refs in `for-in` context

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -602,6 +602,12 @@ public:
   /// Get AsyncSequence.makeAsyncIterator().
   FuncDecl *getAsyncSequenceMakeAsyncIterator() const;
 
+  /// Get IteratorProtocol.next().
+  FuncDecl *getIteratorNext() const;
+
+  /// Get AsyncIteratorProtocol.next().
+  FuncDecl *getAsyncIteratorNext() const;
+
   /// Check whether the standard library provides all the correct
   /// intrinsic support for Optional<T>.
   ///

--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -137,6 +137,11 @@ enum class ConstraintKind : char {
   /// name, and the type of that member, when referenced as a value, is the
   /// second type.
   UnresolvedValueMember,
+  /// The first type conforms to the protocol in which the member requirement
+  /// resides. Once the conformance is resolved, the value witness will be
+  /// determined, and the type of that witness, when referenced as a value,
+  /// will be bound to the second type.
+  ValueWitness,
   /// The first type can be defaulted to the second (which currently
   /// cannot be dependent).  This is more like a type property than a
   /// relational constraint.
@@ -406,11 +411,18 @@ class Constraint final : public llvm::ilist_node<Constraint>,
       /// The type of the member.
       Type Second;
 
-      /// If non-null, the name of a member of the first type is that
-      /// being related to the second type.
-      ///
-      /// Used for ValueMember an UnresolvedValueMember constraints.
-      DeclNameRef Name;
+      union {
+        /// If non-null, the name of a member of the first type is that
+        /// being related to the second type.
+        ///
+        /// Used for ValueMember an UnresolvedValueMember constraints.
+        DeclNameRef Name;
+
+        /// If non-null, the member being referenced.
+        ///
+        /// Used for ValueWitness constraints.
+        ValueDecl *Ref;
+      } Member;
 
       /// The DC in which the use appears.
       DeclContext *UseDC;
@@ -524,6 +536,12 @@ public:
                                   DeclContext *useDC,
                                   FunctionRefKind functionRefKind,
                                   ConstraintLocator *locator);
+
+  /// Create a new value witness constraint.
+  static Constraint *createValueWitness(
+      ConstraintSystem &cs, ConstraintKind kind, Type first, Type second,
+      ValueDecl *requirement, DeclContext *useDC,
+      FunctionRefKind functionRefKind, ConstraintLocator *locator);
 
   /// Create an overload-binding constraint.
   static Constraint *createBindOverload(ConstraintSystem &cs, Type type, 
@@ -672,6 +690,7 @@ public:
 
     case ConstraintKind::ValueMember:
     case ConstraintKind::UnresolvedValueMember:
+    case ConstraintKind::ValueWitness:
     case ConstraintKind::PropertyWrapper:
       return ConstraintClassification::Member;
 
@@ -711,6 +730,7 @@ public:
 
     case ConstraintKind::ValueMember:
     case ConstraintKind::UnresolvedValueMember:
+    case ConstraintKind::ValueWitness:
       return Member.First;
 
     case ConstraintKind::SyntacticElement:
@@ -732,6 +752,7 @@ public:
 
     case ConstraintKind::ValueMember:
     case ConstraintKind::UnresolvedValueMember:
+    case ConstraintKind::ValueWitness:
       return Member.Second;
 
     default:
@@ -757,13 +778,20 @@ public:
   DeclNameRef getMember() const {
     assert(Kind == ConstraintKind::ValueMember ||
            Kind == ConstraintKind::UnresolvedValueMember);
-    return Member.Name;
+    return Member.Member.Name;
+  }
+
+  /// Retrieve the requirement being referenced by a value witness constraint.
+  ValueDecl *getRequirement() const {
+    assert(Kind == ConstraintKind::ValueWitness);
+    return Member.Member.Ref;
   }
 
   /// Determine the kind of function reference we have for a member reference.
   FunctionRefKind getFunctionRefKind() const {
     if (Kind == ConstraintKind::ValueMember ||
-        Kind == ConstraintKind::UnresolvedValueMember)
+        Kind == ConstraintKind::UnresolvedValueMember ||
+        Kind == ConstraintKind::ValueWitness)
       return static_cast<FunctionRefKind>(TheFunctionRefKind);
 
     // Conservative answer: drop all of the labels.
@@ -823,7 +851,8 @@ public:
   /// Retrieve the DC in which the member was used.
   DeclContext *getMemberUseDC() const {
     assert(Kind == ConstraintKind::ValueMember ||
-           Kind == ConstraintKind::UnresolvedValueMember);
+           Kind == ConstraintKind::UnresolvedValueMember ||
+           Kind == ConstraintKind::ValueWitness);
     return Member.UseDC;
   }
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4354,6 +4354,26 @@ public:
     }
   }
 
+  /// Add a value witness constraint to the constraint system.
+  void addValueWitnessConstraint(
+      Type baseTy, ValueDecl *requirement, Type memberTy, DeclContext *useDC,
+      FunctionRefKind functionRefKind, ConstraintLocatorBuilder locator) {
+    assert(baseTy);
+    assert(memberTy);
+    assert(requirement);
+    assert(useDC);
+    switch (simplifyValueWitnessConstraint(
+        ConstraintKind::ValueWitness, baseTy, requirement, memberTy, useDC,
+        functionRefKind, TMF_GenerateConstraints, locator)) {
+    case SolutionKind::Unsolved:
+      llvm_unreachable("Unsolved result when generating constraints!");
+
+    case SolutionKind::Solved:
+    case SolutionKind::Error:
+      break;
+    }
+  }
+
   /// Add an explicit conversion constraint (e.g., \c 'x as T').
   ///
   /// \param fromType The type of the expression being converted.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -217,6 +217,12 @@ struct ASTContext::Implementation {
   /// The declaration of 'AsyncSequence.makeAsyncIterator()'.
   FuncDecl *MakeAsyncIterator = nullptr;
 
+  /// The declaration of 'IteratorProtocol.next()'.
+  FuncDecl *IteratorNext = nullptr;
+
+  /// The declaration of 'AsyncIteratorProtocol.next()'.
+  FuncDecl *AsyncIteratorNext = nullptr;
+
   /// The declaration of Swift.Optional<T>.Some.
   EnumElementDecl *OptionalSomeDecl = nullptr;
 
@@ -806,6 +812,23 @@ FuncDecl *ASTContext::getPlusFunctionOnString() const {
   return getImpl().PlusFunctionOnString;
 }
 
+static FuncDecl *lookupRequirement(ProtocolDecl *proto,
+                                   Identifier requirement) {
+  for (auto result : proto->lookupDirect(requirement)) {
+    if (result->getDeclContext() != proto)
+      continue;
+
+    if (auto func = dyn_cast<FuncDecl>(result)) {
+      if (func->getParameters()->size() != 0)
+        continue;
+
+      return func;
+    }
+  }
+
+  return nullptr;
+}
+
 FuncDecl *ASTContext::getSequenceMakeIterator() const {
   if (getImpl().MakeIterator) {
     return getImpl().MakeIterator;
@@ -815,17 +838,9 @@ FuncDecl *ASTContext::getSequenceMakeIterator() const {
   if (!proto)
     return nullptr;
 
-  for (auto result : proto->lookupDirect(Id_makeIterator)) {
-    if (result->getDeclContext() != proto)
-      continue;
-
-    if (auto func = dyn_cast<FuncDecl>(result)) {
-      if (func->getParameters()->size() != 0)
-        continue;
-
-      getImpl().MakeIterator = func;
-      return func;
-    }
+  if (auto *func = lookupRequirement(proto, Id_makeIterator)) {
+    getImpl().MakeIterator = func;
+    return func;
   }
 
   return nullptr;
@@ -840,17 +855,43 @@ FuncDecl *ASTContext::getAsyncSequenceMakeAsyncIterator() const {
   if (!proto)
     return nullptr;
 
-  for (auto result : proto->lookupDirect(Id_makeAsyncIterator)) {
-    if (result->getDeclContext() != proto)
-      continue;
+  if (auto *func = lookupRequirement(proto, Id_makeAsyncIterator)) {
+    getImpl().MakeAsyncIterator = func;
+    return func;
+  }
 
-    if (auto func = dyn_cast<FuncDecl>(result)) {
-      if (func->getParameters()->size() != 0)
-        continue;
+  return nullptr;
+}
 
-      getImpl().MakeAsyncIterator = func;
-      return func;
-    }
+FuncDecl *ASTContext::getIteratorNext() const {
+  if (getImpl().IteratorNext) {
+    return getImpl().IteratorNext;
+  }
+
+  auto proto = getProtocol(KnownProtocolKind::IteratorProtocol);
+  if (!proto)
+    return nullptr;
+
+  if (auto *func = lookupRequirement(proto, Id_next)) {
+    getImpl().IteratorNext = func;
+    return func;
+  }
+
+  return nullptr;
+}
+
+FuncDecl *ASTContext::getAsyncIteratorNext() const {
+  if (getImpl().AsyncIteratorNext) {
+    return getImpl().AsyncIteratorNext;
+  }
+
+  auto proto = getProtocol(KnownProtocolKind::AsyncIteratorProtocol);
+  if (!proto)
+    return nullptr;
+
+  if (auto *func = lookupRequirement(proto, Id_next)) {
+    getImpl().AsyncIteratorNext = func;
+    return func;
   }
 
   return nullptr;

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1473,6 +1473,7 @@ void PotentialBindings::infer(Constraint *constraint) {
 
   case ConstraintKind::ValueMember:
   case ConstraintKind::UnresolvedValueMember:
+  case ConstraintKind::ValueWitness:
   case ConstraintKind::PropertyWrapper: {
     // If current type variable represents a member type of some reference,
     // it would be bound once member is resolved either to a actual member

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4057,6 +4057,21 @@ generateForEachStmtConstraints(
           AwaitExpr::createImplicit(ctx, /*awaitLoc=*/SourceLoc(), nextCall);
     }
 
+    // The iterator type must conform to IteratorProtocol.
+    {
+      ProtocolDecl *iteratorProto = TypeChecker::getProtocol(
+          cs.getASTContext(), stmt->getForLoc(),
+          isAsync ? KnownProtocolKind::AsyncIteratorProtocol
+                  : KnownProtocolKind::IteratorProtocol);
+      if (!iteratorProto)
+        return None;
+
+      cs.setContextualType(
+          nextRef->getBase(),
+          TypeLoc::withoutLoc(iteratorProto->getDeclaredInterfaceType()),
+          CTP_ForEachSequence);
+    }
+
     SolutionApplicationTarget nextTarget(nextCall, dc, CTP_Unused,
                                          /*contextualType=*/Type(),
                                          /*isDiscarded=*/false);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9254,6 +9254,40 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
     }
   }
 
+  // Special handling of injected references to `makeIterator` in for-in loops.
+  {
+    auto memberRef = getAsExpr<UnresolvedDotExpr>(locator->getAnchor());
+    if (memberRef && memberRef->isImplicit() &&
+        locator->isLastElement<LocatorPathElt::Member>()) {
+      // Cannot simplify this constraint yet since we don't know whether
+      // the base type is going to be existential or not.
+      if (baseObjTy->isTypeVariableOrMember())
+        return formUnsolved();
+
+      auto *sequenceExpr = memberRef->getBase();
+      // If base type is an existential, member lookup is fine because
+      // it would return a witness.
+      if (!baseObjTy->isExistentialType() &&
+          getContextualTypePurpose(sequenceExpr) == CTP_ForEachSequence) {
+        auto &ctx = getASTContext();
+
+        auto *sequenceProto = cast<ProtocolDecl>(
+            getContextualType(sequenceExpr, /*forConstraint=*/false)
+                ->getAnyNominal());
+        bool isAsync = sequenceProto ==
+                       TypeChecker::getProtocol(
+                           ctx, SourceLoc(), KnownProtocolKind::AsyncSequence);
+
+        auto *makeIterator = isAsync ? ctx.getAsyncSequenceMakeAsyncIterator()
+                                     : ctx.getSequenceMakeIterator();
+
+        return simplifyValueWitnessConstraint(
+            ConstraintKind::ValueWitness, baseTy, makeIterator, memberTy, DC,
+            FunctionRefKind::Compound, flags, locator);
+      }
+    }
+  }
+
   MemberLookupResult result =
       performMemberLookup(kind, member, baseTy, functionRefKind, locator,
                           /*includeInaccessibleMembers*/ shouldAttemptFixes());
@@ -9690,6 +9724,17 @@ ConstraintSystem::simplifyValueWitnessConstraint(
     return SolutionKind::Unsolved;
   };
 
+  auto fail = [&] {
+    // The constraint failed, so mark the member type as a "hole".
+    // We cannot do anything further here.
+    if (!shouldAttemptFixes())
+      return SolutionKind::Error;
+
+    recordAnyTypeVarAsPotentialHole(memberType);
+
+    return SolutionKind::Solved;
+  };
+
   // Resolve the base type, if we can. If we can't resolve the base type,
   // then we can't solve this constraint.
   Type baseObjectType = getFixedTypeRecursive(
@@ -9706,16 +9751,8 @@ ConstraintSystem::simplifyValueWitnessConstraint(
   assert(proto && "Value witness constraint for a non-requirement");
   auto conformance = useDC->getParentModule()->lookupConformance(
       baseObjectType, proto);
-  if (!conformance) {
-    // The conformance failed, so mark the member type as a "hole". We cannot
-    // do anything further here.
-    if (!shouldAttemptFixes())
-      return SolutionKind::Error;
-
-    recordAnyTypeVarAsPotentialHole(memberType);
-
-    return SolutionKind::Solved;
-  }
+  if (!conformance)
+    return fail();
 
   // Reference the requirement.
   Type resolvedBaseType = simplifyType(baseType, flags);
@@ -9725,7 +9762,7 @@ ConstraintSystem::simplifyValueWitnessConstraint(
   auto witness =
       conformance.getWitnessByName(baseObjectType, requirement->getName());
   if (!witness)
-    return SolutionKind::Error;
+    return fail();
 
   auto choice = OverloadChoice(resolvedBaseType, witness.getDecl(), functionRefKind);
   resolveOverload(getConstraintLocator(locator), memberType, choice,

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9254,36 +9254,71 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
     }
   }
 
-  // Special handling of injected references to `makeIterator` in for-in loops.
-  {
-    auto memberRef = getAsExpr<UnresolvedDotExpr>(locator->getAnchor());
+  // Special handling of injected references to `makeIterator` and `next`
+  // in for-in loops.
+  if (auto *expr = getAsExpr(locator->getAnchor())) {
+    // `next()` could be wrapped in `await` expression.
+    auto memberRef =
+        getAsExpr<UnresolvedDotExpr>(expr->getSemanticsProvidingExpr());
+
     if (memberRef && memberRef->isImplicit() &&
         locator->isLastElement<LocatorPathElt::Member>()) {
+      auto &ctx = getASTContext();
+
       // Cannot simplify this constraint yet since we don't know whether
       // the base type is going to be existential or not.
       if (baseObjTy->isTypeVariableOrMember())
         return formUnsolved();
 
-      auto *sequenceExpr = memberRef->getBase();
+      // Check whether the given dot expression is a reference
+      // to the given name with the given set of argument labels
+      // (aka compound name).
+      auto isRefTo = [&](UnresolvedDotExpr *UDE, Identifier name,
+                         ArrayRef<StringRef> labels) {
+        auto refName = UDE->getName().getFullName();
+        return refName.isCompoundName(name, labels);
+      };
+
+      auto *baseExpr = memberRef->getBase();
       // If base type is an existential, member lookup is fine because
       // it would return a witness.
-      if (!baseObjTy->isExistentialType() &&
-          getContextualTypePurpose(sequenceExpr) == CTP_ForEachSequence) {
-        auto &ctx = getASTContext();
+      if (!baseObjTy->isExistentialType()) {
+        // Handle `makeIterator` reference.
+        if (getContextualTypePurpose(baseExpr) == CTP_ForEachSequence &&
+            isRefTo(memberRef, ctx.Id_makeIterator, /*lables=*/{})) {
+          auto *sequenceProto = cast<ProtocolDecl>(
+              getContextualType(baseExpr, /*forConstraint=*/false)
+                  ->getAnyNominal());
+          bool isAsync = sequenceProto == TypeChecker::getProtocol(
+                                              ctx, SourceLoc(),
+                                              KnownProtocolKind::AsyncSequence);
 
-        auto *sequenceProto = cast<ProtocolDecl>(
-            getContextualType(sequenceExpr, /*forConstraint=*/false)
-                ->getAnyNominal());
-        bool isAsync = sequenceProto ==
-                       TypeChecker::getProtocol(
-                           ctx, SourceLoc(), KnownProtocolKind::AsyncSequence);
+          auto *makeIterator = isAsync ? ctx.getAsyncSequenceMakeAsyncIterator()
+                                       : ctx.getSequenceMakeIterator();
 
-        auto *makeIterator = isAsync ? ctx.getAsyncSequenceMakeAsyncIterator()
-                                     : ctx.getSequenceMakeIterator();
+          return simplifyValueWitnessConstraint(
+              ConstraintKind::ValueWitness, baseTy, makeIterator, memberTy, DC,
+              FunctionRefKind::Compound, flags, locator);
+        }
 
-        return simplifyValueWitnessConstraint(
-            ConstraintKind::ValueWitness, baseTy, makeIterator, memberTy, DC,
-            FunctionRefKind::Compound, flags, locator);
+        // Handle `next` reference.
+        if (getContextualTypePurpose(baseExpr) == CTP_ForEachSequence &&
+            isRefTo(memberRef, ctx.Id_next, /*labels=*/{})) {
+          auto *iteratorProto = cast<ProtocolDecl>(
+              getContextualType(baseExpr, /*forConstraint=*/false)
+                  ->getAnyNominal());
+          bool isAsync =
+              iteratorProto ==
+              TypeChecker::getProtocol(
+                  ctx, SourceLoc(), KnownProtocolKind::AsyncIteratorProtocol);
+
+          auto *next =
+              isAsync ? ctx.getAsyncIteratorNext() : ctx.getIteratorNext();
+
+          return simplifyValueWitnessConstraint(
+              ConstraintKind::ValueWitness, baseTy, next, memberTy, DC,
+              FunctionRefKind::Compound, flags, locator);
+        }
       }
     }
   }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9722,7 +9722,12 @@ ConstraintSystem::simplifyValueWitnessConstraint(
   if (resolvedBaseType->isTypeVariableOrMember())
     return formUnsolved();
 
-  auto choice = OverloadChoice(resolvedBaseType, requirement, functionRefKind);
+  auto witness =
+      conformance.getWitnessByName(baseObjectType, requirement->getName());
+  if (!witness)
+    return SolutionKind::Error;
+
+  auto choice = OverloadChoice(resolvedBaseType, witness.getDecl(), functionRefKind);
   resolveOverload(getConstraintLocator(locator), memberType, choice,
                   useDC);
   return SolutionKind::Solved;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2252,6 +2252,7 @@ ConstraintSystem::matchTupleTypes(TupleType *tuple1, TupleType *tuple2,
   case ConstraintKind::SelfObjectOfProtocol:
   case ConstraintKind::UnresolvedValueMember:
   case ConstraintKind::ValueMember:
+  case ConstraintKind::ValueWitness:
   case ConstraintKind::BridgingConversion:
   case ConstraintKind::OneWayEqual:
   case ConstraintKind::OneWayBindParam:
@@ -2415,6 +2416,7 @@ static bool matchFunctionRepresentations(FunctionType::ExtInfo einfo1,
   case ConstraintKind::SelfObjectOfProtocol:
   case ConstraintKind::UnresolvedValueMember:
   case ConstraintKind::ValueMember:
+  case ConstraintKind::ValueWitness:
   case ConstraintKind::OneWayEqual:
   case ConstraintKind::OneWayBindParam:
   case ConstraintKind::DefaultClosureType:
@@ -2827,6 +2829,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
   case ConstraintKind::SelfObjectOfProtocol:
   case ConstraintKind::UnresolvedValueMember:
   case ConstraintKind::ValueMember:
+  case ConstraintKind::ValueWitness:
   case ConstraintKind::BridgingConversion:
   case ConstraintKind::OneWayEqual:
   case ConstraintKind::OneWayBindParam:
@@ -6103,6 +6106,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
     case ConstraintKind::SelfObjectOfProtocol:
     case ConstraintKind::UnresolvedValueMember:
     case ConstraintKind::ValueMember:
+    case ConstraintKind::ValueWitness:
     case ConstraintKind::OneWayEqual:
     case ConstraintKind::OneWayBindParam:
     case ConstraintKind::DefaultClosureType:
@@ -9240,7 +9244,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
         markMemberTypeAsPotentialHole(memberTy);
         return SolutionKind::Solved;
       }
-    } else if (kind == ConstraintKind::ValueMember &&
+    } else if ((kind == ConstraintKind::ValueMember ||
+                kind == ConstraintKind::ValueWitness) &&
                baseObjTy->getMetatypeInstanceType()->isPlaceholder()) {
       // If base type is a "hole" there is no reason to record any
       // more "member not found" fixes for chained member references.
@@ -9660,6 +9665,67 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
     return fixMissingMember(origBaseTy, memberTy, locator);
   }
   return SolutionKind::Error;
+}
+
+ConstraintSystem::SolutionKind
+ConstraintSystem::simplifyValueWitnessConstraint(
+    ConstraintKind kind, Type baseType, ValueDecl *requirement, Type memberType,
+    DeclContext *useDC, FunctionRefKind functionRefKind,
+    TypeMatchOptions flags, ConstraintLocatorBuilder locator) {
+  // We'd need to record original base type because it might be a type
+  // variable representing another missing member.
+  auto origBaseType = baseType;
+
+  auto formUnsolved = [&] {
+    // If requested, generate a constraint.
+    if (flags.contains(TMF_GenerateConstraints)) {
+      auto *witnessConstraint = Constraint::createValueWitness(
+          *this, kind, origBaseType, memberType, requirement, useDC,
+          functionRefKind, getConstraintLocator(locator));
+
+      addUnsolvedConstraint(witnessConstraint);
+      return SolutionKind::Solved;
+    }
+
+    return SolutionKind::Unsolved;
+  };
+
+  // Resolve the base type, if we can. If we can't resolve the base type,
+  // then we can't solve this constraint.
+  Type baseObjectType = getFixedTypeRecursive(
+      baseType, flags, /*wantRValue=*/true);
+  if (baseObjectType->isTypeVariableOrMember()) {
+    return formUnsolved();
+  }
+
+  // Check conformance to the protocol. If it doesn't conform, this constraint
+  // fails. Don't attempt to fix it.
+  // FIXME: Look in the constraint system to see if we've resolved the
+  // conformance already?
+  auto proto = requirement->getDeclContext()->getSelfProtocolDecl();
+  assert(proto && "Value witness constraint for a non-requirement");
+  auto conformance = useDC->getParentModule()->lookupConformance(
+      baseObjectType, proto);
+  if (!conformance) {
+    // The conformance failed, so mark the member type as a "hole". We cannot
+    // do anything further here.
+    if (!shouldAttemptFixes())
+      return SolutionKind::Error;
+
+    recordAnyTypeVarAsPotentialHole(memberType);
+
+    return SolutionKind::Solved;
+  }
+
+  // Reference the requirement.
+  Type resolvedBaseType = simplifyType(baseType, flags);
+  if (resolvedBaseType->isTypeVariableOrMember())
+    return formUnsolved();
+
+  auto choice = OverloadChoice(resolvedBaseType, requirement, functionRefKind);
+  resolveOverload(getConstraintLocator(locator), memberType, choice,
+                  useDC);
+  return SolutionKind::Solved;
 }
 
 ConstraintSystem::SolutionKind ConstraintSystem::simplifyDefaultableConstraint(
@@ -13288,6 +13354,7 @@ ConstraintSystem::addConstraintImpl(ConstraintKind kind, Type first,
 
   case ConstraintKind::ValueMember:
   case ConstraintKind::UnresolvedValueMember:
+  case ConstraintKind::ValueWitness:
   case ConstraintKind::BindOverload:
   case ConstraintKind::Disjunction:
   case ConstraintKind::Conjunction:
@@ -13780,6 +13847,16 @@ ConstraintSystem::simplifyConstraint(const Constraint &constraint) {
                                     constraint.getFunctionRefKind(),
                                     /*outerAlternatives=*/{},
                                     /*flags*/ None, constraint.getLocator());
+
+  case ConstraintKind::ValueWitness:
+    return simplifyValueWitnessConstraint(constraint.getKind(),
+                                          constraint.getFirstType(),
+                                          constraint.getRequirement(),
+                                          constraint.getSecondType(),
+                                          constraint.getMemberUseDC(),
+                                          constraint.getFunctionRefKind(),
+                                          /*flags*/ None,
+                                          constraint.getLocator());
 
   case ConstraintKind::Defaultable:
     return simplifyDefaultableConstraint(constraint.getFirstType(),

--- a/validation-test/Sema/issue-60514.swift
+++ b/validation-test/Sema/issue-60514.swift
@@ -1,0 +1,54 @@
+// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+
+// https://github.com/apple/swift/issues/60514
+// Make sure that `makeIterator` witness is picked over the non-witness.
+
+public protocol VectorSectionReader: Sequence where Element == Result<Item, Error> {
+  associatedtype Item
+  var count: UInt32 { get }
+  mutating func read() throws -> Item
+}
+
+public struct VectorSectionIterator<Reader: VectorSectionReader>: IteratorProtocol {
+  private(set) var reader: Reader
+  private(set) var left: UInt32
+
+  init(reader: Reader, count: UInt32) {
+      self.reader = reader
+      self.left = count
+  }
+
+  private var end: Bool = false
+  public mutating func next() -> Reader.Element? {
+    guard !end else { return nil }
+    guard left != 0 else { return nil }
+    let result = Result(catching: { try reader.read() })
+    left -= 1
+    switch result {
+    case .success: return result
+    case .failure:
+      end = true
+      return result
+    }
+  }
+}
+
+extension VectorSectionReader {
+  __consuming public func makeIterator() -> VectorSectionIterator<Self> {
+    VectorSectionIterator(reader: self, count: count)
+  }
+
+  // CHECK: sil [ossa] @$s4main19VectorSectionReaderPAAE7collectSay4ItemQzGyKF
+  public func collect() throws -> [Item] {
+    var items: [Item] = []
+    items.reserveCapacity(Int(count))
+    for result in self {
+      // CHECK: [[ITERATOR:%.*]] = project_box {{.*}} : $<τ_0_0 where τ_0_0 : VectorSectionReader> { var τ_0_0.Iterator } <Self>, 0
+      // CHECK-NEXT: [[SELF:%.*]] = alloc_stack $Self
+      // CHECK: [[MAKE_ITERATOR_REF:%.*]] = witness_method $Self, #Sequence.makeIterator : <Self where Self : Sequence> (__owned Self) -> () -> Self.Iterator : $@convention(witness_method: Sequence) <τ_0_0 where τ_0_0 : Sequence> (@in τ_0_0) -> @out τ_0_0.Iterator
+      // CHECK-NEXT: apply [[MAKE_ITERATOR_REF]]<Self>([[ITERATOR]], [[SELF]]) : $@convention(witness_method: Sequence) <τ_0_0 where τ_0_0 : Sequence> (@in τ_0_0) -> @out τ_0_0.Iterator
+      try items.append(result.get())
+    }
+    return items
+  }
+}

--- a/validation-test/Sema/issue-60958.swift
+++ b/validation-test/Sema/issue-60958.swift
@@ -1,0 +1,36 @@
+// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+
+// https://github.com/apple/swift/issues/60958
+// Make sure that `makeIterator` witness is picked over the non-witness.
+
+struct S: Sequence {
+  private var _storage: [UInt8] = []
+
+  func makeIterator() -> Array<UInt8>.Iterator {
+    _storage.makeIterator()
+  }
+
+  typealias Element = UInt8
+
+  class Iterator: IteratorProtocol {
+    func next() -> UInt8? { 0 }
+    typealias Element = UInt8
+  }
+
+  func makeIterator() -> Iterator {
+    Iterator()
+  }
+}
+
+extension S {
+  // CHECK: sil hidden [ossa] @$s4main1SV1fyyF
+  func f() {
+    for elt in self {
+      // CHECK: [[ITERATOR_VAR:%.*]] = project_box {{.*}} : ${ var S.Iterator }, 0
+      // CHECK: [[MAKE_ITERATOR_REF:%.*]] = function_ref @$s4main1SV12makeIteratorAC0C0CyF : $@convention(method) (@guaranteed S) -> @owned S.Iterator
+      // CHECK-NEXT: [[ITERATOR:%.*]] = apply [[MAKE_ITERATOR_REF]](%0) : $@convention(method) (@guaranteed S) -> @owned S.Iterator
+      // CHECK-NEXT: store [[ITERATOR]] to [init] [[ITERATOR_VAR]] : $*S.Iterator
+      print(elt)
+    }
+  }
+}


### PR DESCRIPTION
References to `makeIterator` and `next` in `for-in` loop context have to be
treated as references to witnesses of `Sequence#makeIterator` and
`IteratorProtocol#next` requirements. Letting overload resolution decide as-if
loop was written direct use of `makeIterator()` and `while let ... = next()` statement
could lead to problems with retroactive conformances and difference in runtime
behavior. 

For example:

```swift
extension Array where Element == Double {
  func makeIterator() -> Array<Int>.Iterator {
    return [1, 2, 3].makeIterator()
  }
}

for i in [4.0, 5.0, 6.0] {
  print(i)
}
```

`makeIterator` declared in the `Array` extension is not a witness to `Sequence#makeIterator`
and shouldn't be used because that would change runtime behavior.

Resolves: https://github.com/apple/swift/issues/60514
Resolves: https://github.com/apple/swift/issues/60958

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
