### PR TITLE
Ignore SIL Files in Swift Syntax Parser Validation

### DIFF
--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -196,7 +196,8 @@ SourceFileParsingResult ParseSourceFileRequest::evaluate(Evaluator &evaluator,
 #ifdef SWIFT_SWIFT_PARSER
   if ((ctx.LangOpts.hasFeature(Feature::ParserRoundTrip) ||
        ctx.LangOpts.hasFeature(Feature::ParserValidation)) &&
-      ctx.SourceMgr.getCodeCompletionBufferID() != bufferID) {
+      ctx.SourceMgr.getCodeCompletionBufferID() != bufferID &&
+      SF->Kind != SourceFileKind::SIL) {
     auto bufferRange = ctx.SourceMgr.getRangeForBuffer(*bufferID);
     unsigned int flags = 0;
 


### PR DESCRIPTION
Validating these files creates a load of false positive error cases since the new Swift parser doesn't handle SIL. Disable validating these files.