### PR TITLE
[stdlib] use a primary associated type

### DIFF
--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -711,9 +711,9 @@ extension Unsafe${Mutable}BufferPointer {
   ///     by this function.
   @inlinable
   @_alwaysEmitIntoClient
-  public func initialize<C: Collection>(
-    fromContentsOf source: C
-  ) -> Index where C.Element == Element {
+  public func initialize(
+    fromContentsOf source: some Collection<Element>
+  ) -> Index {
     let count = source.withContiguousStorageIfAvailable {
       guard let sourceAddress = $0.baseAddress, !$0.isEmpty else {
         return 0
@@ -814,9 +814,9 @@ extension Unsafe${Mutable}BufferPointer {
   /// - Returns: An index one past the index of the last element updated.
   @inlinable
   @_alwaysEmitIntoClient
-  public func update<C: Collection>(
-    fromContentsOf source: C
-  ) -> Index where C.Element == Element {
+  public func update(
+    fromContentsOf source: some Collection<Element>
+  ) -> Index {
     let count = source.withContiguousStorageIfAvailable {
       guard let sourceAddress = $0.baseAddress else {
         return 0

--- a/stdlib/public/core/UnsafeBufferPointerSlice.swift
+++ b/stdlib/public/core/UnsafeBufferPointerSlice.swift
@@ -763,9 +763,9 @@ extension Slice {
   ///    initialized by this function.
   @inlinable
   @_alwaysEmitIntoClient
-  public func initialize<C: Collection>(
-    fromContentsOf source: C
-  ) -> Index where Base == UnsafeMutableBufferPointer<C.Element> {
+  public func initialize<Element>(
+    fromContentsOf source: some Collection<Element>
+  ) -> Index where Base == UnsafeMutableBufferPointer<Element> {
     let buffer = Base(rebasing: self)
     let index = buffer.initialize(fromContentsOf: source)
     let distance = buffer.distance(from: buffer.startIndex, to: index)
@@ -833,9 +833,9 @@ extension Slice {
   /// - Returns: An index one past the index of the last element updated.
   @inlinable
   @_alwaysEmitIntoClient
-  public func update<C: Collection>(
-    fromContentsOf source: C
-  ) -> Index where Base == UnsafeMutableBufferPointer<C.Element> {
+  public func update<Element>(
+    fromContentsOf source: some Collection<Element>
+  ) -> Index where Base == UnsafeMutableBufferPointer<Element> {
     let buffer = Base(rebasing: self)
     let index = buffer.update(fromContentsOf: source)
     let distance = buffer.distance(from: buffer.startIndex, to: index)


### PR DESCRIPTION
Express the generic parameter of `UnsafeMutableBufferPointer.initialize(fromContentsOf:)` using `some` notation
(primary associated type).

Follow-up to SE-0370 (https://github.com/apple/swift/pull/41608), where this API was proposed using primary associated type notation.

Addresses rdar://99909349 (https://github.com/apple/swift/issues/61094)