### PR TITLE
Define our own `assert` implementation for the swift compiler sources

### DIFF
--- a/SwiftCompilerSources/Sources/Basic/Utils.swift
+++ b/SwiftCompilerSources/Sources/Basic/Utils.swift
@@ -13,6 +13,34 @@
 @_exported import BasicBridging
 import std
 
+/// The assert function to be used in the compiler.
+///
+/// This overrides the standard Swift assert for two reasons:
+/// * We also like to check for assert failures in release builds. Although this could be
+///   achieved with `precondition`, it's easy to forget about it and use `assert` instead.
+/// * We need to see the error message in crashlogs of release builds. This is even not the
+///   case for `precondition`.
+@_transparent
+public func assert(_ condition: Bool, _ message: @autoclosure () -> String,
+                   file: StaticString = #fileID, line: UInt = #line) {
+  if !condition {
+    print("### basic")
+    fatalError(message(), file: file, line: line)
+  }
+}
+
+/// The assert function (without a message) to be used in the compiler.
+///
+/// Unforuntately it's not possible to just add a default argument to `message` in the
+/// other `assert` function. We need to defined this overload.
+@_transparent
+public func assert(_ condition: Bool, file: StaticString = #fileID, line: UInt = #line) {
+  if !condition {
+    fatalError("", file: file, line: line)
+  }
+}
+
+
 //===----------------------------------------------------------------------===//
 //                              StringRef
 //===----------------------------------------------------------------------===//

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ObjCBridgingOptimization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ObjCBridgingOptimization.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Basic
 import SIL
 
 /// Removes redundant ObjectiveC <-> Swift bridging calls.

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/StackPromotion.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/StackPromotion.swift
@@ -125,7 +125,7 @@ func tryPromoteAlloc(_ allocRef: AllocRefInstBase,
   var (innerRange, outerBlockRange) = computeInnerAndOuterLiferanges(instruction: allocRef, in: outerDominatingBlock, domTree: domTree, context: context)
   defer { innerRange.deinitialize(); outerBlockRange.deinitialize() }
   
-  precondition(innerRange.blockRange.isValid, "inner range should be valid because we did a dominance check")
+  assert(innerRange.blockRange.isValid, "inner range should be valid because we did a dominance check")
 
   if !outerBlockRange.isValid {
     // This happens if we fail to find a correct outerDominatingBlock.
@@ -282,7 +282,7 @@ private extension BasicBlockRange {
     }
 
     for lifeBlock in inclusiveRange {
-      precondition(otherRange.inclusiveRangeContains(lifeBlock), "range must be a subset of other range")
+      assert(otherRange.inclusiveRangeContains(lifeBlock), "range must be a subset of other range")
       for succ in lifeBlock.successors {
         if isOnlyInOtherRange(succ) {
           return true

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionPasses/SimplifyBeginCOWMutation.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionPasses/SimplifyBeginCOWMutation.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Basic
 import SIL
 
 /// Simplify begin_cow_mutation instructions.

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/ModulePassContext.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/ModulePassContext.swift
@@ -42,7 +42,7 @@ struct ModulePassContext {
     var endIndex: Int { return Int(bridged.count) }
     
     subscript(_ index: Int) -> VTable {
-      precondition(index >= 0 && index < bridged.count)
+      assert(index >= 0 && index < bridged.count)
       return VTable(bridged: bridged.vTables![index])
     }
   }

--- a/SwiftCompilerSources/Sources/Optimizer/TestPasses/RangeDumper.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/TestPasses/RangeDumper.swift
@@ -29,7 +29,7 @@ let rangeDumper = FunctionPass(name: "dump-ranges", {
     if let sli = inst as? StringLiteralInst {
       switch sli.string {
         case "begin":
-          precondition(begin == nil, "more than one begin instruction")
+          assert(begin == nil, "more than one begin instruction")
           begin = sli
         case "end":
           ends.append(sli)
@@ -62,16 +62,16 @@ let rangeDumper = FunctionPass(name: "dump-ranges", {
   verify(instRange.blockRange, context)
   
   for i in ins {
-    precondition(instRange.contains(i))
-    precondition(instRange.inclusiveRangeContains(i))
+    assert(instRange.contains(i))
+    assert(instRange.inclusiveRangeContains(i))
   }
   for e in ends {
-    precondition(!instRange.contains(e))
-    precondition(instRange.inclusiveRangeContains(e))
+    assert(!instRange.contains(e))
+    assert(instRange.inclusiveRangeContains(e))
   }
   for o in outs {
-    precondition(!instRange.contains(o))
-    precondition(!instRange.inclusiveRangeContains(o))
+    assert(!instRange.contains(o))
+    assert(!instRange.inclusiveRangeContains(o))
   }
 })
 
@@ -89,8 +89,8 @@ private func verify(_ blockRange: BasicBlockRange, _ context: PassContext) {
   }
 
   for b in blockRange.begin.function.blocks {
-    precondition(blockRange.contains(b) == inRange.contains(b))
-    precondition(blockRange.inclusiveRangeContains(b) == inInclusiveRange.contains(b))
+    assert(blockRange.contains(b) == inRange.contains(b))
+    assert(blockRange.inclusiveRangeContains(b) == inInclusiveRange.contains(b))
   }
 }
 

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeInfo.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeInfo.swift
@@ -303,7 +303,7 @@ fileprivate struct EscapeInfoWalker<V: EscapeInfoVisitor> : ValueDefUseWalker,
   }
   
   mutating func start(forAnalyzingAddresses: Bool) {
-    precondition(walkDownCache.isEmpty && walkUpCache.isEmpty)
+    assert(walkDownCache.isEmpty && walkUpCache.isEmpty)
     analyzeAddresses = forAnalyzingAddresses
   }
 

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -44,8 +44,8 @@ extension Value {
   /// in a loop while this value is not in that loop, the value has to be copied for
   /// each loop iteration.
   func makeAvailable(in destBlock: BasicBlock, _ context: PassContext) -> Value {
-    precondition(uses.isEmpty)
-    precondition(ownership == .owned)
+    assert(uses.isEmpty)
+    assert(ownership == .owned)
 
     let beginBlock = definingBlock
     var useToDefRange = BasicBlockRange(begin: beginBlock, context)

--- a/SwiftCompilerSources/Sources/SIL/BasicBlock.swift
+++ b/SwiftCompilerSources/Sources/SIL/BasicBlock.swift
@@ -97,7 +97,7 @@ public struct SuccessorArray : RandomAccessCollection, FormattedLikeArray {
   public var endIndex: Int { return Int(succArray.numElements) }
 
   public subscript(_ index: Int) -> BasicBlock {
-    precondition(index >= 0 && index < endIndex)
+    assert(index >= 0 && index < endIndex)
     let s = BridgedSuccessor(succ: succArray.data! + index &* BridgedSuccessorSize);
     return SILSuccessor_getTargetBlock(s).block
   }

--- a/SwiftCompilerSources/Sources/SIL/Operand.swift
+++ b/SwiftCompilerSources/Sources/SIL/Operand.swift
@@ -54,14 +54,14 @@ public struct OperandArray : RandomAccessCollection, CustomReflectable {
   public var endIndex: Int { return Int(opArray.numElements) }
   
   public subscript(_ index: Int) -> Operand {
-    precondition(index >= 0 && index < endIndex)
+    assert(index >= 0 && index < endIndex)
     return Operand(BridgedOperand(op: opArray.data! + index &* BridgedOperandSize))
   }
   
   public func getIndex(of operand: Operand) -> Int {
     let idx = (operand.bridged.op - UnsafeRawPointer(opArray.data!)) /
                 BridgedOperandSize
-    precondition(self[idx].bridged.op == operand.bridged.op)
+    assert(self[idx].bridged.op == operand.bridged.op)
     return idx
   }
   
@@ -74,8 +74,8 @@ public struct OperandArray : RandomAccessCollection, CustomReflectable {
   ///
   /// Note: this does not return a Slice. The first index of the returnd array is always 0.
   public subscript(bounds: Range<Int>) -> OperandArray {
-    precondition(bounds.lowerBound >= 0)
-    precondition(bounds.upperBound <= endIndex)
+    assert(bounds.lowerBound >= 0)
+    assert(bounds.upperBound <= endIndex)
     return OperandArray(opArray: BridgedArrayRef(
       data: opArray.data! + bounds.lowerBound &* BridgedOperandSize,
       numElements: bounds.upperBound - bounds.lowerBound))

--- a/SwiftCompilerSources/Sources/SIL/SmallProjectionPath.swift
+++ b/SwiftCompilerSources/Sources/SIL/SmallProjectionPath.swift
@@ -541,14 +541,14 @@ extension SmallProjectionPath {
       let p1 = SmallProjectionPath(.structField, index: 3)
                         .push(.classField, index: 12345678)
       let (k2, i2, p2) = p1.pop()
-      precondition(k2 == .classField && i2 == 12345678)
+      assert(k2 == .classField && i2 == 12345678)
       let (k3, i3, p3) = p2.pop()
-      precondition(k3 == .structField && i3 == 3)
-      precondition(p3.isEmpty)
+      assert(k3 == .structField && i3 == 3)
+      assert(p3.isEmpty)
       let (k4, i4, _) = p2.push(.enumCase, index: 876).pop()
-      precondition(k4 == .enumCase && i4 == 876)
+      assert(k4 == .enumCase && i4 == 876)
       let p5 = SmallProjectionPath(.anything)
-      precondition(p5.pop().path.isEmpty)
+      assert(p5.pop().path.isEmpty)
     }
     
     func parsing() {
@@ -581,9 +581,9 @@ extension SmallProjectionPath {
     func testParse(_ pathStr: String, expect: SmallProjectionPath) {
       var parser = StringParser(pathStr)
       let path = try! parser.parseProjectionPathFromSIL()
-      precondition(path == expect)
+      assert(path == expect)
       let str = path.description
-      precondition(str == pathStr)
+      assert(str == pathStr)
     }
    
     func merging() {
@@ -609,9 +609,9 @@ extension SmallProjectionPath {
       let expect = try! expectParser.parseProjectionPathFromSIL()
 
       let result = lhs.merge(with: rhs)
-      precondition(result == expect)
+      assert(result == expect)
       let result2 = rhs.merge(with: lhs)
-      precondition(result2 == expect)
+      assert(result2 == expect)
     }
    
     func matching() {
@@ -643,7 +643,7 @@ extension SmallProjectionPath {
       var rhsParser = StringParser(rhsStr)
       let rhs = try! rhsParser.parseProjectionPathFromSIL()
       let result = lhs.matches(pattern: rhs)
-      precondition(result == expect)
+      assert(result == expect)
     }
 
     func overlapping() {
@@ -673,9 +673,9 @@ extension SmallProjectionPath {
       var rhsParser = StringParser(rhsStr)
       let rhs = try! rhsParser.parseProjectionPathFromSIL()
       let result = lhs.mayOverlap(with: rhs)
-      precondition(result == expect)
+      assert(result == expect)
       let reversedResult = rhs.mayOverlap(with: lhs)
-      precondition(reversedResult == expect)
+      assert(reversedResult == expect)
     }
 
     func predicates() {
@@ -696,7 +696,7 @@ extension SmallProjectionPath {
       var parser = StringParser(pathStr)
       let path = try! parser.parseProjectionPathFromSIL()
       let result = property(path)
-      precondition(result == expect)
+      assert(result == expect)
     }
     
     func path2path() {
@@ -727,9 +727,9 @@ extension SmallProjectionPath {
       if let expect = expect {
         var expectParser = StringParser(expect)
         let expectPath = try! expectParser.parseProjectionPathFromSIL()
-        precondition(result == expectPath)
+        assert(result == expectPath)
       } else {
-        precondition(result == nil)
+        assert(result == nil)
       }
     }
   }

--- a/SwiftCompilerSources/Sources/SIL/Utils.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utils.swift
@@ -12,6 +12,10 @@
 
 import SILBridging
 
+// Need to export "Basic" to make `Basic.assert` available in the Optimizer module.
+// Otherwise The Optimizer would fall back to Swift's assert implementation.
+@_exported import Basic
+
 //===----------------------------------------------------------------------===//
 //                              Lists
 //===----------------------------------------------------------------------===//

--- a/SwiftCompilerSources/Sources/SIL/VTable.swift
+++ b/SwiftCompilerSources/Sources/SIL/VTable.swift
@@ -37,7 +37,7 @@ public struct VTable : CustomStringConvertible, CustomReflectable {
     public var endIndex: Int { return Int(bridgedArray.numElements) }
     
     public subscript(_ index: Int) -> Entry {
-      precondition(index >= 0 && index < endIndex)
+      assert(index >= 0 && index < endIndex)
       return Entry(bridged: BridgedVTableEntry(ptr: bridgedArray.data! + index &* BridgedVTableEntrySize))
     }
   }

--- a/SwiftCompilerSources/Sources/SIL/WitnessTable.swift
+++ b/SwiftCompilerSources/Sources/SIL/WitnessTable.swift
@@ -60,7 +60,7 @@ public struct WitnessTable : CustomStringConvertible, CustomReflectable {
     public var endIndex: Int { return Int(bridged.numElements) }
     
     public subscript(_ index: Int) -> Entry {
-      precondition(index >= 0 && index < endIndex)
+      assert(index >= 0 && index < endIndex)
       return Entry(bridged: BridgedWitnessTableEntry(ptr: bridged.data! + index &* BridgedWitnessTableEntrySize))
     }
   }


### PR DESCRIPTION
For two reasons:
* We also like to check for assert failures in release builds. Although this could be achieved with `precondition`, it's easy to forget about it and use `assert` instead.
* We need to see the error message in crashlogs of release builds. This is even not the case for `precondition`.

Also, consistently use `assert` instead of `precondition`.