### PR TITLE
Allow subtyping conversion to add `@Sendable` in preconcurrency code.

### DIFF
--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -257,6 +257,7 @@ getConcurrencyFixBehavior(
   switch (constraintKind) {
   case ConstraintKind::Conversion:
   case ConstraintKind::ArgumentConversion:
+  case ConstraintKind::Subtype:
     break;
 
   default:

--- a/test/Concurrency/preconcurrency_typealias.swift
+++ b/test/Concurrency/preconcurrency_typealias.swift
@@ -46,3 +46,17 @@ func testAsync() async {
   }
   mutableVariable += 1
 }
+
+// rdar://99518344 - @Sendable in nested positions
+@preconcurrency typealias OtherHandler = @Sendable () -> Void
+@preconcurrency typealias Handler = (@Sendable () -> OtherHandler?)?
+@preconcurrency func f(arg: Int, withFn: Handler?) {}
+
+class C {
+  func test() {
+    f(arg: 5, withFn: { [weak self] () -> OtherHandler? in
+        _ = self
+        return nil
+      })
+  }
+}

--- a/test/attr/attr_concurrent.swift
+++ b/test/attr/attr_concurrent.swift
@@ -2,9 +2,11 @@
 // REQUIRES: concurrency
 
 // Concurrent attribute on a function type.
+// expected-note@+1{{found this candidate}}
 func f(_ fn: @Sendable (Int) -> Int) { }
 
 // Okay to overload @Sendable vs. not concurrent
+// expected-note@+1{{found this candidate}}
 func f(_ fn: (Int) -> Int) { }
 
 // Concurrent attribute with other function attributes.
@@ -24,8 +26,10 @@ func passingConcurrentOrNot(
   _ cfn: @Sendable (Int) -> Int,
   ncfn: (Int) -> Int // expected-note{{parameter 'ncfn' is implicitly non-sendable}}{{9-9=@Sendable }}
 ) {
+  // Ambiguous because preconcurrency code doesn't consider `@Sendable`.
+  f(cfn) // expected-error{{ambiguous use of 'f'}}
+
   // Okay due to overloading
-  f(cfn)
   f(ncfn)
 
   acceptsConcurrent(cfn) // okay


### PR DESCRIPTION
Fixes rdar://99518344.
