### PR TITLE
[Sema] Require explicit availability on public modules and customizable diagnostics level

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -48,6 +48,11 @@ ERROR(error_unknown_library_level, none,
       "unknown library level '%0', "
       "expected one of 'api', 'spi' or 'other'", (StringRef))
 
+ERROR(error_unknown_require_explicit_availability, none,
+      "unknown argument '%0', passed to -require-explicit-availability, "
+      "expected 'error', 'warn' or 'ignore'",
+      (StringRef))
+
 ERROR(error_unsupported_opt_for_target, none,
       "unsupported option '%0' for target '%1'", (StringRef, StringRef))
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5750,8 +5750,8 @@ NOTE(availability_protocol_requirement_here, none,
      "protocol requirement here", ())
 
 WARNING(public_decl_needs_availability, none,
-        "public declarations should have an availability attribute when building "
-        "with -require-explicit-availability", ())
+        "public declarations should have an availability attribute "
+        "with an introduction version", ())
 
 ERROR(attr_requires_decl_availability_for_platform,none,
       "'%0' requires that %1 have explicit availability for %2",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5749,9 +5749,9 @@ ERROR(availability_protocol_requires_version,
 NOTE(availability_protocol_requirement_here, none,
      "protocol requirement here", ())
 
-WARNING(public_decl_needs_availability, none,
-        "public declarations should have an availability attribute "
-        "with an introduction version", ())
+ERROR(public_decl_needs_availability, none,
+      "public declarations should have an availability attribute "
+      "with an introduction version", ())
 
 ERROR(attr_requires_decl_availability_for_platform,none,
       "'%0' requires that %1 have explicit availability for %2",

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -193,8 +193,9 @@ namespace swift {
     /// Enable 'availability' restrictions for App Extensions.
     bool EnableAppExtensionRestrictions = false;
 
-    /// Require public declarations to declare an introduction OS version.
-    bool RequireExplicitAvailability = false;
+    /// Diagnostic level to report when a public declarations doesn't declare
+    /// an introduction OS version.
+    Optional<DiagnosticBehavior> RequireExplicitAvailability = None;
 
     /// Introduction platform and version to suggest as fix-it
     /// when using RequireExplicitAvailability.

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -411,7 +411,13 @@ def enable_library_evolution : Flag<["-"], "enable-library-evolution">,
 
 def require_explicit_availability : Flag<["-"], "require-explicit-availability">,
   Flags<[FrontendOption, NoInteractiveOption]>,
-  HelpText<"Require explicit availability on public declarations">;
+  HelpText<"Warn on public declarations without an availability attribute">;
+
+def require_explicit_availability_EQ : Joined<["-"], "require-explicit-availability=">,
+  MetaVarName<"<error,warn,ignore>">,
+  Flags<[FrontendOption, NoInteractiveOption]>,
+  HelpText<"Set diagnostic level to report public declarations without an availability attribute">;
+
 def require_explicit_availability_target : Separate<["-"], "require-explicit-availability-target">,
   Flags<[FrontendOption, NoInteractiveOption]>,
   HelpText<"Suggest fix-its adding @available(<target>, *) to public declarations without availability">,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -241,6 +241,7 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_enable_library_evolution);
   inputArgs.AddLastArg(arguments, options::OPT_require_explicit_availability);
   inputArgs.AddLastArg(arguments, options::OPT_require_explicit_availability_target);
+  inputArgs.AddLastArg(arguments, options::OPT_require_explicit_availability_EQ);
   inputArgs.AddLastArg(arguments, options::OPT_require_explicit_sendable);
   inputArgs.AddLastArg(arguments, options::OPT_check_api_availability_only);
   inputArgs.AddLastArg(arguments, options::OPT_enable_testing);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -728,7 +728,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
                      diagLevel);
     }
   } else if (Args.getLastArg(OPT_require_explicit_availability,
-                             OPT_require_explicit_availability_target)) {
+                             OPT_require_explicit_availability_target) ||
+             Opts.LibraryLevel == LibraryLevel::API) {
     Opts.RequireExplicitAvailability = DiagnosticBehavior::Warning;
   }
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -587,13 +587,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   if (Args.getLastArg(OPT_debug_cycles))
     Opts.DebugDumpCycles = true;
 
-  if (Args.getLastArg(OPT_require_explicit_availability, OPT_require_explicit_availability_target)) {
-    Opts.RequireExplicitAvailability = true;
-    if (const Arg *A = Args.getLastArg(OPT_require_explicit_availability_target)) {
-      Opts.RequireExplicitAvailabilityTarget = A->getValue();
-    }
-  }
-
   Opts.RequireExplicitSendable |= Args.hasArg(OPT_require_explicit_sendable);
   for (const Arg *A : Args.filtered(OPT_define_availability)) {
     Opts.AvailabilityMacros.push_back(A->getValue());
@@ -719,6 +712,28 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
           inFlight.limitBehavior(DiagnosticBehavior::Warning);
       }
     }
+  }
+
+  if (const Arg *A = Args.getLastArg(OPT_require_explicit_availability_EQ)) {
+    StringRef diagLevel = A->getValue();
+    if (diagLevel == "warn") {
+      Opts.RequireExplicitAvailability = DiagnosticBehavior::Warning;
+    } else if (diagLevel == "error") {
+      Opts.RequireExplicitAvailability = DiagnosticBehavior::Error;
+    } else if (diagLevel == "ignore") {
+      Opts.RequireExplicitAvailability = None;
+    } else {
+      Diags.diagnose(SourceLoc(),
+                     diag::error_unknown_require_explicit_availability,
+                     diagLevel);
+    }
+  } else if (Args.getLastArg(OPT_require_explicit_availability,
+                             OPT_require_explicit_availability_target)) {
+    Opts.RequireExplicitAvailability = DiagnosticBehavior::Warning;
+  }
+
+  if (const Arg *A = Args.getLastArg(OPT_require_explicit_availability_target)) {
+    Opts.RequireExplicitAvailabilityTarget = A->getValue();
   }
 
   Opts.EnableSPIOnlyImports = Args.hasArg(OPT_experimental_spi_only_imports);

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -4279,7 +4279,8 @@ static bool declNeedsExplicitAvailability(const Decl *decl) {
 void swift::checkExplicitAvailability(Decl *decl) {
   // Skip if the command line option was not set and
   // accessors as we check the pattern binding decl instead.
-  if (!decl->getASTContext().LangOpts.RequireExplicitAvailability ||
+  auto DiagLevel = decl->getASTContext().LangOpts.RequireExplicitAvailability;
+  if (!DiagLevel ||
       isa<AccessorDecl>(decl))
     return;
 
@@ -4323,6 +4324,7 @@ void swift::checkExplicitAvailability(Decl *decl) {
 
   if (declNeedsExplicitAvailability(decl)) {
     auto diag = decl->diagnose(diag::public_decl_needs_availability);
+    diag.limitBehavior(*DiagLevel);
 
     auto suggestPlatform =
       decl->getASTContext().LangOpts.RequireExplicitAvailabilityTarget;

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -483,7 +483,8 @@ function(_compile_swift_files
   # The standard library and overlays are built resiliently when SWIFT_STDLIB_STABLE_ABI=On.
   if(SWIFTFILE_IS_STDLIB AND SWIFT_STDLIB_STABLE_ABI)
     list(APPEND swift_flags "-enable-library-evolution")
-    list(APPEND swift_flags "-Xfrontend" "-library-level"  "-Xfrontend" "api")
+    list(APPEND swift_flags "-library-level" "api")
+    list(APPEND swift_flags "-Xfrontend" "-require-explicit-availability=ignore")
   endif()
 
   if("${SWIFT_SDK_${SWIFTFILE_SDK}_THREADING_PACKAGE}" STREQUAL "none")

--- a/test/ClangImporter/availability_spi_as_unavailable.swift
+++ b/test/ClangImporter/availability_spi_as_unavailable.swift
@@ -13,7 +13,7 @@ public let c: SPIInterface1 // expected-error{{cannot use class 'SPIInterface1' 
 public let d: SPIInterface2 // expected-error{{cannot use class 'SPIInterface2' here; it is an SPI imported from 'SPIContainer'}}
 
 @inlinable
-public func inlinableUsingSPI() {
+public func inlinableUsingSPI() { // expected-warning{{public declarations should have an availability attribute with an introduction version}}
   SharedInterface.foo() // expected-error{{class method 'foo()' cannot be used in an '@inlinable' function because it is an SPI imported from 'SPIContainer'}}
 }
 

--- a/test/ClangImporter/availability_spi_as_unavailable_bridging_header.swift
+++ b/test/ClangImporter/availability_spi_as_unavailable_bridging_header.swift
@@ -9,6 +9,6 @@ public let c: SPIInterface1 // expected-error{{cannot use class 'SPIInterface1' 
 public let d: SPIInterface2 // expected-error{{cannot use class 'SPIInterface2' here; it is an SPI imported from '__ObjC'}}
 
 @inlinable
-public func inlinableUsingSPI() {
+public func inlinableUsingSPI() { // expected-warning{{public declarations should have an availability attribute with an introduction version}}
   SharedInterface.foo() // expected-error{{class method 'foo()' cannot be used in an '@inlinable' function because it is an SPI imported from '__ObjC'}}
 }

--- a/test/SPI/spi-only-and-library-level.swift
+++ b/test/SPI/spi-only-and-library-level.swift
@@ -25,6 +25,7 @@ public struct LibStruct {}
 @_spiOnly import Lib
 
 public func publicClient() -> LibStruct { fatalError() } // expected-error {{cannot use struct 'LibStruct' here; 'Lib' was imported for SPI only}}
+// expected-warning @-1 {{public declarations should have an availability attribute with an introduction version}}
 @_spi(X) public func spiClient() -> LibStruct { fatalError() }
 
 //--- SPILib.swift

--- a/test/Sema/spi-available-inline.swift
+++ b/test/Sema/spi-available-inline.swift
@@ -8,7 +8,7 @@ public class MacOSSPIClass { public init() {} }
 @_spi_available(iOS 8.0, *)
 public class iOSSPIClass { public init() {} }
 
-@inlinable public func foo() {
+@inlinable public func foo() { // expected-warning{{public declarations should have an availability attribute with an introduction version}}
 	_ = MacOSSPIClass() // expected-error {{class 'MacOSSPIClass' cannot be used in an '@inlinable' function because it is SPI}}
 	_ = iOSSPIClass()
 }

--- a/test/attr/attr_inlinable_available.swift
+++ b/test/attr/attr_inlinable_available.swift
@@ -14,7 +14,7 @@
 
 
 // Check that `-library-level api` implies `-target-min-inlining-version min`
-// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-library-evolution -module-name Test -target %target-next-stable-abi-triple -library-level api
+// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-library-evolution -module-name Test -target %target-next-stable-abi-triple -library-level api -require-explicit-availability=ignore
 
 
 // Check that these rules are only applied when requested and that at least some
@@ -24,7 +24,7 @@
 
 // Check that -target-min-inlining-version overrides -library-level, allowing
 // library owners to disable this behavior for API libraries if needed.
-// RUN: not %target-typecheck-verify-swift -swift-version 5 -enable-library-evolution -module-name Test -target %target-next-stable-abi-triple -target-min-inlining-version target -library-level api 2>&1 | %FileCheck --check-prefix NON_MIN %s
+// RUN: not %target-typecheck-verify-swift -swift-version 5 -enable-library-evolution -module-name Test -target %target-next-stable-abi-triple -target-min-inlining-version target -library-level api -require-explicit-availability=ignore 2>&1 | %FileCheck --check-prefix NON_MIN %s
 
 
 // Check that we respect -target-min-inlining-version by cranking it up high

--- a/test/attr/require_explicit_availability.swift
+++ b/test/attr/require_explicit_availability.swift
@@ -3,7 +3,7 @@
 
 // RUN: %swiftc_driver -typecheck -parse-as-library -target %target-cpu-apple-macosx10.10 -Xfrontend -verify -require-explicit-availability -require-explicit-availability-target "macOS 10.10"  %s
 
-public struct S { // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}}
+public struct S { // expected-warning {{public declarations should have an availability attribute with an introduction version}}
   public func method() { }
 }
 
@@ -12,10 +12,10 @@ public struct UnavailableStruct {
   public func okMethod() { }
 }
 
-public func foo() { bar() } // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+public func foo() { bar() } // expected-warning {{public declarations should have an availability attribute with an introduction version}} {{1-1=@available(macOS 10.10, *)\n}}
 
 @usableFromInline
-func bar() { } // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+func bar() { } // expected-warning {{public declarations should have an availability attribute with an introduction version}} {{1-1=@available(macOS 10.10, *)\n}}
 
 @available(macOS 10.1, *)
 public func ok() { }
@@ -24,10 +24,10 @@ public func ok() { }
 public func unavailableOk() { }
 
 @available(macOS, deprecated: 10.10)
-public func missingIntro() { } // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+public func missingIntro() { } // expected-warning {{public declarations should have an availability attribute with an introduction version}} {{1-1=@available(macOS 10.10, *)\n}}
 
 @available(iOS 9.0, *)
-public func missingTargetPlatform() { } // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+public func missingTargetPlatform() { } // expected-warning {{public declarations should have an availability attribute with an introduction version}} {{1-1=@available(macOS 10.10, *)\n}}
 
 func privateFunc() { }
 
@@ -42,23 +42,23 @@ struct SOk {
 precedencegroup MediumPrecedence {}
 infix operator + : MediumPrecedence
 
-public func +(lhs: S, rhs: S) -> S { } // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+public func +(lhs: S, rhs: S) -> S { } // expected-warning {{public declarations should have an availability attribute with an introduction version}} {{1-1=@available(macOS 10.10, *)\n}}
 
-public enum E { } // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+public enum E { } // expected-warning {{public declarations should have an availability attribute with an introduction version}} {{1-1=@available(macOS 10.10, *)\n}}
 
 @available(macOS, unavailable)
 public enum UnavailableEnum {
   case caseOk
 }
 
-public class C { } // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+public class C { } // expected-warning {{public declarations should have an availability attribute with an introduction version}} {{1-1=@available(macOS 10.10, *)\n}}
 
 @available(macOS, unavailable)
 public class UnavailableClass {
   public func okMethod() { }
 }
 
-public protocol P { } // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+public protocol P { } // expected-warning {{public declarations should have an availability attribute with an introduction version}} {{1-1=@available(macOS 10.10, *)\n}}
 
 @available(macOS, unavailable)
 public protocol UnavailableProto {
@@ -67,8 +67,8 @@ public protocol UnavailableProto {
 
 private protocol PrivateProto { }
 
-extension S { // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
-  public func warnForPublicMembers() { } // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{3-3=@available(macOS 10.10, *)\n  }}
+extension S { // expected-warning {{public declarations should have an availability attribute with an introduction version}} {{1-1=@available(macOS 10.10, *)\n}}
+  public func warnForPublicMembers() { } // expected-warning {{public declarations should have an availability attribute with an introduction version}} {{3-3=@available(macOS 10.10, *)\n  }}
 }
 
 @available(macOS 10.1, *)
@@ -89,13 +89,13 @@ extension S {
 // An empty extension should be ok.
 extension S { }
 
-extension S : P { // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+extension S : P { // expected-warning {{public declarations should have an availability attribute with an introduction version}} {{1-1=@available(macOS 10.10, *)\n}}
 }
 
 extension S : PrivateProto {
 }
 
-open class OpenClass { } // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+open class OpenClass { } // expected-warning {{public declarations should have an availability attribute with an introduction version}} {{1-1=@available(macOS 10.10, *)\n}}
 
 private class PrivateClass { }
 
@@ -119,7 +119,7 @@ extension spiStruct {
   public func spiExtensionMethod() {}
 }
 
-public var publicVar = S() // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+public var publicVar = S() // expected-warning {{public declarations should have an availability attribute with an introduction version}} {{1-1=@available(macOS 10.10, *)\n}}
 
 @available(macOS 10.10, *)
 public var publicVarOk = S()
@@ -127,14 +127,14 @@ public var publicVarOk = S()
 @available(macOS, unavailable)
 public var unavailablePublicVarOk = S()
 
-public var (a, b) = (S(), S()) // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+public var (a, b) = (S(), S()) // expected-warning {{public declarations should have an availability attribute with an introduction version}} {{1-1=@available(macOS 10.10, *)\n}}
 
 @available(macOS 10.10, *)
 public var (c, d) = (S(), S())
 
 public var _ = S() // expected-error {{global variable declaration does not bind any variables}}
 
-public var implicitGet: S { // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+public var implicitGet: S { // expected-warning {{public declarations should have an availability attribute with an introduction version}} {{1-1=@available(macOS 10.10, *)\n}}
   return S()
 }
 
@@ -148,19 +148,19 @@ public var unavailableImplicitGetOk: S {
   return S()
 }
 
-public var computed: S { // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+public var computed: S { // expected-warning {{public declarations should have an availability attribute with an introduction version}} {{1-1=@available(macOS 10.10, *)\n}}
   get { return S() }
   set { }
 }
 
-public var computedHalf: S { // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+public var computedHalf: S { // expected-warning {{public declarations should have an availability attribute with an introduction version}} {{1-1=@available(macOS 10.10, *)\n}}
   @available(macOS 10.10, *)
   get { return S() }
   set { }
 }
 
 // FIXME the following warning is not needed.
-public var computedOk: S { // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+public var computedOk: S { // expected-warning {{public declarations should have an availability attribute with an introduction version}} {{1-1=@available(macOS 10.10, *)\n}}
   @available(macOS 10.10, *)
   get { return S() }
 
@@ -174,7 +174,7 @@ public var computedOk1: S {
   set { }
 }
 
-public class SomeClass { // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
+public class SomeClass { // expected-warning {{public declarations should have an availability attribute with an introduction version}} {{1-1=@available(macOS 10.10, *)\n}}
   public init () {}
 
   public subscript(index: String) -> Int {
@@ -183,13 +183,13 @@ public class SomeClass { // expected-warning {{public declarations should have a
   }
 }
 
-extension SomeClass { // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{1-1=@available(macOS 10.10, *)\n}}
-  public convenience init(s : S) {} // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{3-3=@available(macOS 10.10, *)\n  }}
+extension SomeClass { // expected-warning {{public declarations should have an availability attribute with an introduction version}} {{1-1=@available(macOS 10.10, *)\n}}
+  public convenience init(s : S) {} // expected-warning {{public declarations should have an availability attribute with an introduction version}} {{3-3=@available(macOS 10.10, *)\n  }}
 
   @available(macOS 10.10, *)
   public convenience init(s : SomeClass) {}
 
-  public subscript(index: Int) -> Int { // expected-warning {{public declarations should have an availability attribute when building with -require-explicit-availability}} {{3-3=@available(macOS 10.10, *)\n  }}
+  public subscript(index: Int) -> Int { // expected-warning {{public declarations should have an availability attribute with an introduction version}} {{3-3=@available(macOS 10.10, *)\n  }}
     get { return 42; }
     set(newValue) { }
   }
@@ -206,5 +206,5 @@ public struct StructWithImplicitMembers { }
 
 extension StructWithImplicitMembers: Hashable { }
 // expected-note @-1 {{add @available attribute to enclosing extension}}
-// expected-warning @-2 {{public declarations should have an availability attribute when building with -require-explicit-availability}}
+// expected-warning @-2 {{public declarations should have an availability attribute with an introduction version}}
 // expected-error @-3 {{'StructWithImplicitMembers' is only available in macOS 10.15 or newer}}

--- a/test/attr/require_explicit_availability.swift
+++ b/test/attr/require_explicit_availability.swift
@@ -10,6 +10,17 @@
 // RUN:   -target %target-cpu-apple-macosx10.10 -require-explicit-availability=warn \
 // RUN:   -require-explicit-availability-target "macOS 10.10"
 
+/// Using -library-level api defaults to enabling warnings, without fixits.
+// RUN: sed -e "s/}} {{.*/}}/" < %s > %t/NoFixits.swift
+// RUN: %target-swift-frontend -typecheck -parse-as-library -verify %t/NoFixits.swift \
+// RUN:   -target %target-cpu-apple-macosx10.10 -library-level api
+
+/// Explicitly disable the diagnostic.
+// RUN: sed -e 's/xpected-warning/not-something-expected/' < %s > %t/None.swift
+// RUN: %target-swift-frontend -typecheck -parse-as-library -verify %t/None.swift \
+// RUN:   -target %target-cpu-apple-macosx10.10 -require-explicit-availability=ignore \
+// RUN:   -require-explicit-availability-target "macOS 10.10" -library-level api
+
 /// Upgrade the diagnostic to an error.
 // RUN: sed -e "s/xpected-warning/xpected-error/" < %s > %t/Errors.swift
 // RUN: %target-swift-frontend -typecheck -parse-as-library -verify %t/Errors.swift \

--- a/test/attr/require_explicit_availability.swift
+++ b/test/attr/require_explicit_availability.swift
@@ -1,7 +1,25 @@
 // Test the -require-explicit-availability flag
 // REQUIRES: OS=macosx
+// RUN: %empty-directory(%t)
 
-// RUN: %swiftc_driver -typecheck -parse-as-library -target %target-cpu-apple-macosx10.10 -Xfrontend -verify -require-explicit-availability -require-explicit-availability-target "macOS 10.10"  %s
+/// Using the flag directly raises warnings and fixits.
+// RUN: %swiftc_driver -typecheck -parse-as-library -Xfrontend -verify %s \
+// RUN:   -target %target-cpu-apple-macosx10.10 -require-explicit-availability \
+// RUN:   -require-explicit-availability-target "macOS 10.10"
+// RUN: %swiftc_driver -typecheck -parse-as-library -Xfrontend -verify %s \
+// RUN:   -target %target-cpu-apple-macosx10.10 -require-explicit-availability=warn \
+// RUN:   -require-explicit-availability-target "macOS 10.10"
+
+/// Upgrade the diagnostic to an error.
+// RUN: sed -e "s/xpected-warning/xpected-error/" < %s > %t/Errors.swift
+// RUN: %target-swift-frontend -typecheck -parse-as-library -verify %t/Errors.swift \
+// RUN:   -target %target-cpu-apple-macosx10.10 -require-explicit-availability=error \
+// RUN:   -require-explicit-availability-target "macOS 10.10"
+
+/// Error on an invalid argument.
+// RUN: not %target-swift-frontend -typecheck %s -require-explicit-availability=NotIt 2>&1 \
+// RUN:   | %FileCheck %s --check-prefix CHECK-ARG
+// CHECK-ARG: error: unknown argument 'NotIt', passed to -require-explicit-availability, expected 'error', 'warn' or 'ignore'
 
 public struct S { // expected-warning {{public declarations should have an availability attribute with an introduction version}}
   public func method() { }


### PR DESCRIPTION
Extend the require explicit availability logic with two new features:

- Enable the require explicit availability warnings by default for public modules. Public modules are usually inferred automatically and identified with `-library-level api`. rdar://99929744

- Intro the flag `-require-explicit-availability=<error,warn,ignore>` to define a custom diagnostic level. The default is still a warning, and the diagnostic can be promoted to an error or ignored.