### PR TITLE
[interop][SwiftToCxx] initial generic enum support

### DIFF
--- a/lib/IRGen/IRABIDetailsProvider.cpp
+++ b/lib/IRGen/IRABIDetailsProvider.cpp
@@ -111,8 +111,8 @@ public:
   getEnumTagMapping(const EnumDecl *ED) {
     llvm::MapVector<EnumElementDecl *, IRABIDetailsProvider::EnumElementInfo>
         elements;
-    auto &enumImplStrat =
-        getEnumImplStrategy(IGM, ED->getDeclaredType()->getCanonicalType());
+    auto &enumImplStrat = getEnumImplStrategy(
+        IGM, ED->DeclContext::getDeclaredTypeInContext()->getCanonicalType());
 
     for (auto *element : ED->getAllElements()) {
       auto tagIdx = enumImplStrat.getTagIndex(element);

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -434,12 +434,15 @@ private:
 
       os << "  inline bool is" << name << "() const;\n";
 
+      outOfLineSyntaxPrinter
+          .printNominalTypeOutsideMemberDeclTemplateSpecifiers(ED);
       outOfLineOS << "  inline bool ";
-      outOfLineSyntaxPrinter.printBaseName(ED);
-      outOfLineOS << "::is" << name << "() const {\n";
+      outOfLineSyntaxPrinter.printNominalTypeQualifier(
+          ED, /*moduleContext=*/ED->getModuleContext());
+      outOfLineOS << "is" << name << "() const {\n";
       outOfLineOS << "    return *this == ";
-      outOfLineSyntaxPrinter.printBaseName(ED);
-      outOfLineOS << "::";
+      outOfLineSyntaxPrinter.printNominalTypeQualifier(
+          ED, /*moduleContext=*/ED->getModuleContext());
       outOfLineSyntaxPrinter.printIdentifier(caseName);
       outOfLineOS << ";\n";
       outOfLineOS << "  }\n";
@@ -464,6 +467,8 @@ private:
       ClangSyntaxPrinter(nameOS).printIdentifier(elementDecl->getNameStr());
       name[0] = std::toupper(name[0]);
 
+      if (ED->isGeneric())
+        return;
       clangFuncPrinter.printCustomCxxFunction(
           {paramType},
           [&](auto &types) {
@@ -553,107 +558,115 @@ private:
           neededTypes.push_back(paramType);
         }
 
-        clangFuncPrinter.printCustomCxxFunction(
-            neededTypes,
-            [&](auto &types) {
-              // Printing function name and return type
-              os << "    inline ";
-              syntaxPrinter.printBaseName(elementDecl->getParentEnum());
-              os << " operator()";
+        // FIXME: support generic constructor.
+        if (!ED->isGeneric())
+          clangFuncPrinter.printCustomCxxFunction(
+              neededTypes,
+              [&](auto &types) {
+                // Printing function name and return type
+                os << "    inline ";
+                syntaxPrinter.printBaseName(elementDecl->getParentEnum());
+                os << " operator()";
 
-              outOfLineOS << "  inline ";
-              outOfLineSyntaxPrinter.printBaseName(
-                  elementDecl->getParentEnum());
-              outOfLineOS << ' ';
-              outOfLineSyntaxPrinter.printBaseName(
-                  elementDecl->getParentEnum());
-              outOfLineOS << "::_impl_" << elementDecl->getNameStr()
-                          << "::operator()";
-            },
-            [&](auto &types) {
-              // Printing parameters
-              if (!paramType) {
-                return;
-              }
-              assert(objectTypeDecl != nullptr);
-              if (owningPrinter.typeMapping.getKnownCxxTypeInfo(
-                      objectTypeDecl)) {
-                os << types[paramType] << " val";
-                outOfLineOS << types[paramType] << " val";
-              } else {
-                os << "const " << types[paramType] << " &val";
-                outOfLineOS << "const " << types[paramType] << " &val";
-              }
-            },
-            true,
-            [&](auto &types) {
-              // Printing function body
-              outOfLineOS << "    auto result = ";
-              outOfLineSyntaxPrinter.printBaseName(
-                  elementDecl->getParentEnum());
-              outOfLineOS << "::_make();\n";
-
-              if (paramType) {
+                outOfLineOS << "  inline ";
+                outOfLineSyntaxPrinter.printBaseName(
+                    elementDecl->getParentEnum());
+                outOfLineOS << ' ';
+                outOfLineSyntaxPrinter.printBaseName(
+                    elementDecl->getParentEnum());
+                outOfLineOS << "::_impl_" << elementDecl->getNameStr()
+                            << "::operator()";
+              },
+              [&](auto &types) {
+                // Printing parameters
+                if (!paramType) {
+                  return;
+                }
                 assert(objectTypeDecl != nullptr);
-
                 if (owningPrinter.typeMapping.getKnownCxxTypeInfo(
                         objectTypeDecl)) {
-                  outOfLineOS << "    memcpy(result._getOpaquePointer(), &val, "
-                                 "sizeof(val));\n";
+                  os << types[paramType] << " val";
+                  outOfLineOS << types[paramType] << " val";
                 } else {
-                  outOfLineOS << "    alignas(";
-                  outOfLineSyntaxPrinter.printModuleNamespaceQualifiersIfNeeded(
-                      objectTypeDecl->getModuleContext(),
-                      ED->getModuleContext());
-                  outOfLineSyntaxPrinter.printBaseName(objectTypeDecl);
-                  outOfLineOS << ") unsigned char buffer[sizeof(";
-                  outOfLineSyntaxPrinter.printModuleNamespaceQualifiersIfNeeded(
-                      objectTypeDecl->getModuleContext(),
-                      ED->getModuleContext());
-                  outOfLineSyntaxPrinter.printBaseName(objectTypeDecl);
-                  outOfLineOS << ")];\n";
-                  outOfLineOS << "    auto *valCopy = new(buffer) ";
-                  outOfLineSyntaxPrinter.printModuleNamespaceQualifiersIfNeeded(
-                      objectTypeDecl->getModuleContext(),
-                      ED->getModuleContext());
-                  outOfLineSyntaxPrinter.printBaseName(objectTypeDecl);
-                  outOfLineOS << "(val);\n";
-                  outOfLineOS << "    ";
-                  outOfLineOS << cxx_synthesis::getCxxSwiftNamespaceName()
-                              << "::";
-                  outOfLineOS << cxx_synthesis::getCxxImplNamespaceName();
-                  outOfLineOS << "::implClassFor<";
-                  outOfLineSyntaxPrinter.printModuleNamespaceQualifiersIfNeeded(
-                      objectTypeDecl->getModuleContext(),
-                      ED->getModuleContext());
-                  outOfLineSyntaxPrinter.printBaseName(objectTypeDecl);
-                  outOfLineOS << ">::type::initializeWithTake(result._"
-                                 "getOpaquePointer(), ";
-                  outOfLineOS << cxx_synthesis::getCxxSwiftNamespaceName()
-                              << "::";
-                  outOfLineOS << cxx_synthesis::getCxxImplNamespaceName();
-                  outOfLineOS << "::implClassFor<";
-                  outOfLineSyntaxPrinter.printModuleNamespaceQualifiersIfNeeded(
-                      objectTypeDecl->getModuleContext(),
-                      ED->getModuleContext());
-                  outOfLineSyntaxPrinter.printBaseName(objectTypeDecl);
-                  outOfLineOS << ">::type::getOpaquePointer(*valCopy)";
-                  outOfLineOS << ");\n";
+                  os << "const " << types[paramType] << " &val";
+                  outOfLineOS << "const " << types[paramType] << " &val";
                 }
-              }
+              },
+              true,
+              [&](auto &types) {
+                // Printing function body
+                outOfLineOS << "    auto result = ";
+                outOfLineSyntaxPrinter.printBaseName(
+                    elementDecl->getParentEnum());
+                outOfLineOS << "::_make();\n";
 
-              outOfLineOS << "    result._destructiveInjectEnumTag(";
-              if (ED->isResilient()) {
-                outOfLineOS << cxx_synthesis::getCxxImplNamespaceName()
-                            << "::" << elementInfo->globalVariableName;
-              } else {
-                outOfLineOS << elementInfo->tag;
-              }
-              outOfLineOS << ");\n";
-              outOfLineOS << "    return result;\n";
-              outOfLineOS << "  ";
-            },
-            ED->getModuleContext(), outOfLineOS);
+                if (paramType) {
+                  assert(objectTypeDecl != nullptr);
+
+                  if (owningPrinter.typeMapping.getKnownCxxTypeInfo(
+                          objectTypeDecl)) {
+                    outOfLineOS
+                        << "    memcpy(result._getOpaquePointer(), &val, "
+                           "sizeof(val));\n";
+                  } else {
+                    outOfLineOS << "    alignas(";
+                    outOfLineSyntaxPrinter
+                        .printModuleNamespaceQualifiersIfNeeded(
+                            objectTypeDecl->getModuleContext(),
+                            ED->getModuleContext());
+                    outOfLineSyntaxPrinter.printBaseName(objectTypeDecl);
+                    outOfLineOS << ") unsigned char buffer[sizeof(";
+                    outOfLineSyntaxPrinter
+                        .printModuleNamespaceQualifiersIfNeeded(
+                            objectTypeDecl->getModuleContext(),
+                            ED->getModuleContext());
+                    outOfLineSyntaxPrinter.printBaseName(objectTypeDecl);
+                    outOfLineOS << ")];\n";
+                    outOfLineOS << "    auto *valCopy = new(buffer) ";
+                    outOfLineSyntaxPrinter
+                        .printModuleNamespaceQualifiersIfNeeded(
+                            objectTypeDecl->getModuleContext(),
+                            ED->getModuleContext());
+                    outOfLineSyntaxPrinter.printBaseName(objectTypeDecl);
+                    outOfLineOS << "(val);\n";
+                    outOfLineOS << "    ";
+                    outOfLineOS << cxx_synthesis::getCxxSwiftNamespaceName()
+                                << "::";
+                    outOfLineOS << cxx_synthesis::getCxxImplNamespaceName();
+                    outOfLineOS << "::implClassFor<";
+                    outOfLineSyntaxPrinter
+                        .printModuleNamespaceQualifiersIfNeeded(
+                            objectTypeDecl->getModuleContext(),
+                            ED->getModuleContext());
+                    outOfLineSyntaxPrinter.printBaseName(objectTypeDecl);
+                    outOfLineOS << ">::type::initializeWithTake(result._"
+                                   "getOpaquePointer(), ";
+                    outOfLineOS << cxx_synthesis::getCxxSwiftNamespaceName()
+                                << "::";
+                    outOfLineOS << cxx_synthesis::getCxxImplNamespaceName();
+                    outOfLineOS << "::implClassFor<";
+                    outOfLineSyntaxPrinter
+                        .printModuleNamespaceQualifiersIfNeeded(
+                            objectTypeDecl->getModuleContext(),
+                            ED->getModuleContext());
+                    outOfLineSyntaxPrinter.printBaseName(objectTypeDecl);
+                    outOfLineOS << ">::type::getOpaquePointer(*valCopy)";
+                    outOfLineOS << ");\n";
+                  }
+                }
+
+                outOfLineOS << "    result._destructiveInjectEnumTag(";
+                if (ED->isResilient()) {
+                  outOfLineOS << cxx_synthesis::getCxxImplNamespaceName()
+                              << "::" << elementInfo->globalVariableName;
+                } else {
+                  outOfLineOS << elementInfo->tag;
+                }
+                outOfLineOS << ");\n";
+                outOfLineOS << "    return result;\n";
+                outOfLineOS << "  ";
+              },
+              ED->getModuleContext(), outOfLineOS);
       }
       os << "  } ";
       syntaxPrinter.printIdentifier(caseName);

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -382,6 +382,14 @@ public:
   }
 
   ClangRepresentation
+  visitBoundGenericEnumType(BoundGenericEnumType *BGT,
+                            Optional<OptionalTypeKind> optionalKind,
+                            bool isInOutParam) {
+    return visitValueType(BGT, BGT->getDecl(), optionalKind, isInOutParam,
+                          BGT->getGenericArgs());
+  }
+
+  ClangRepresentation
   visitGenericTypeParamType(GenericTypeParamType *genericTpt,
                             Optional<OptionalTypeKind> optionalKind,
                             bool isInOutParam) {

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -928,26 +928,26 @@ void DeclAndTypeClangFunctionPrinter::printGenericReturnSequence(
   os << "  if constexpr (std::is_base_of<::swift::"
      << cxx_synthesis::getCxxImplNamespaceName() << "::RefCountedClass, "
      << resultTyName << ">::value) {\n";
+  os << "  void *returnValue;\n  ";
   if (!initializeWithTakeFromValue) {
-    os << "  void *returnValue;\n  ";
     invocationPrinter(/*additionalParam=*/StringRef(ros.str()));
+  } else {
+    os << "returnValue = *reinterpret_cast<void **>("
+       << *initializeWithTakeFromValue << ")";
+  }
     os << ";\n";
     os << "  return ::swift::" << cxx_synthesis::getCxxImplNamespaceName()
        << "::implClassFor<" << resultTyName
        << ">::type::makeRetained(returnValue);\n";
-  } else {
-    // FIXME: support taking a class pointer.
-    os << "abort();\n";
-  }
-  os << "  } else if constexpr (::swift::"
-     << cxx_synthesis::getCxxImplNamespaceName() << "::isValueType<"
-     << resultTyName << ">) {\n";
+    os << "  } else if constexpr (::swift::"
+       << cxx_synthesis::getCxxImplNamespaceName() << "::isValueType<"
+       << resultTyName << ">) {\n";
 
-  os << "  return ::swift::" << cxx_synthesis::getCxxImplNamespaceName()
-     << "::implClassFor<" << resultTyName
-     << ">::type::returnNewValue([&](void * _Nonnull returnValue) {\n";
-  if (!initializeWithTakeFromValue) {
-    invocationPrinter(/*additionalParam=*/StringRef("returnValue"));
+    os << "  return ::swift::" << cxx_synthesis::getCxxImplNamespaceName()
+       << "::implClassFor<" << resultTyName
+       << ">::type::returnNewValue([&](void * _Nonnull returnValue) {\n";
+    if (!initializeWithTakeFromValue) {
+      invocationPrinter(/*additionalParam=*/StringRef("returnValue"));
   } else {
     os << "  return ::swift::" << cxx_synthesis::getCxxImplNamespaceName()
        << "::implClassFor<" << resultTyName

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -912,6 +912,72 @@ void DeclAndTypeClangFunctionPrinter::printCxxToCFunctionParameterUse(
   namePrinter();
 }
 
+void DeclAndTypeClangFunctionPrinter::printGenericReturnSequence(
+    raw_ostream &os, const GenericTypeParamType *gtpt,
+    llvm::function_ref<void(StringRef)> invocationPrinter,
+    Optional<StringRef> initializeWithTakeFromValue) {
+  std::string returnAddress;
+  llvm::raw_string_ostream ros(returnAddress);
+  ros << "reinterpret_cast<void *>(&returnValue)";
+  std::string resultTyName;
+  {
+    llvm::raw_string_ostream os(resultTyName);
+    ClangSyntaxPrinter(os).printGenericTypeParamTypeName(gtpt);
+  }
+
+  os << "  if constexpr (std::is_base_of<::swift::"
+     << cxx_synthesis::getCxxImplNamespaceName() << "::RefCountedClass, "
+     << resultTyName << ">::value) {\n";
+  if (!initializeWithTakeFromValue) {
+    os << "  void *returnValue;\n  ";
+    invocationPrinter(/*additionalParam=*/StringRef(ros.str()));
+    os << ";\n";
+    os << "  return ::swift::" << cxx_synthesis::getCxxImplNamespaceName()
+       << "::implClassFor<" << resultTyName
+       << ">::type::makeRetained(returnValue);\n";
+  } else {
+    // FIXME: support taking a class pointer.
+    os << "abort();\n";
+  }
+  os << "  } else if constexpr (::swift::"
+     << cxx_synthesis::getCxxImplNamespaceName() << "::isValueType<"
+     << resultTyName << ">) {\n";
+
+  os << "  return ::swift::" << cxx_synthesis::getCxxImplNamespaceName()
+     << "::implClassFor<" << resultTyName
+     << ">::type::returnNewValue([&](void * _Nonnull returnValue) {\n";
+  if (!initializeWithTakeFromValue) {
+    invocationPrinter(/*additionalParam=*/StringRef("returnValue"));
+  } else {
+    os << "  return ::swift::" << cxx_synthesis::getCxxImplNamespaceName()
+       << "::implClassFor<" << resultTyName
+       << ">::type::initializeWithTake(reinterpret_cast<char * "
+          "_Nonnull>(returnValue), "
+       << *initializeWithTakeFromValue << ")";
+  }
+  os << ";\n  });\n";
+  os << "  } else if constexpr (::swift::"
+     << cxx_synthesis::getCxxImplNamespaceName() << "::isSwiftBridgedCxxRecord<"
+     << resultTyName << ">) {\n";
+  if (!initializeWithTakeFromValue) {
+    ClangTypeHandler::printGenericReturnScaffold(os, resultTyName,
+                                                 invocationPrinter);
+  } else {
+    // FIXME: support taking a C++ record type.
+    os << "abort();\n";
+  }
+  os << "  } else {\n";
+  os << "  " << resultTyName << " returnValue;\n";
+  if (!initializeWithTakeFromValue) {
+    invocationPrinter(/*additionalParam=*/StringRef(ros.str()));
+  } else {
+    os << "memcpy(&returnValue, " << *initializeWithTakeFromValue
+       << ", sizeof(returnValue))";
+  }
+  os << ";\n  return returnValue;\n";
+  os << "  }\n";
+}
+
 void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
     const AbstractFunctionDecl *FD, const LoweredFunctionSignature &signature,
     StringRef swiftSymbolName, const ModuleDecl *moduleContext, Type resultTy,
@@ -1012,42 +1078,7 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
   if (!isKnownCxxType(resultTy, typeMapping) &&
       !hasKnownOptionalNullableCxxMapping(resultTy)) {
     if (const auto *gtpt = resultTy->getAs<GenericTypeParamType>()) {
-      std::string returnAddress;
-      llvm::raw_string_ostream ros(returnAddress);
-      ros << "reinterpret_cast<void *>(&returnValue)";
-      std::string resultTyName;
-      {
-        llvm::raw_string_ostream os(resultTyName);
-        ClangSyntaxPrinter(os).printGenericTypeParamTypeName(gtpt);
-      }
-
-      os << "  if constexpr (std::is_base_of<::swift::"
-         << cxx_synthesis::getCxxImplNamespaceName() << "::RefCountedClass, "
-         << resultTyName << ">::value) {\n";
-      os << "  void *returnValue;\n  ";
-      printCallToCFunc(/*additionalParam=*/StringRef(ros.str()));
-      os << ";\n";
-      os << "  return ::swift::" << cxx_synthesis::getCxxImplNamespaceName()
-         << "::implClassFor<" << resultTyName
-         << ">::type::makeRetained(returnValue);\n";
-      os << "  } else if constexpr (::swift::"
-         << cxx_synthesis::getCxxImplNamespaceName() << "::isValueType<"
-         << resultTyName << ">) {\n";
-      os << "  return ::swift::" << cxx_synthesis::getCxxImplNamespaceName()
-         << "::implClassFor<" << resultTyName
-         << ">::type::returnNewValue([&](void * _Nonnull returnValue) {\n";
-      printCallToCFunc(/*additionalParam=*/StringRef("returnValue"));
-      os << ";\n  });\n";
-      os << "  } else if constexpr (::swift::"
-         << cxx_synthesis::getCxxImplNamespaceName()
-         << "::isSwiftBridgedCxxRecord<" << resultTyName << ">) {\n";
-      ClangTypeHandler::printGenericReturnScaffold(os, resultTyName,
-                                                   printCallToCFunc);
-      os << "  } else {\n";
-      os << "  " << resultTyName << " returnValue;\n";
-      printCallToCFunc(/*additionalParam=*/StringRef(ros.str()));
-      os << ";\n  return returnValue;\n";
-      os << "  }\n";
+      printGenericReturnSequence(os, gtpt, printCallToCFunc);
       return;
     }
     if (auto *classDecl = resultTy->getClassOrBoundGenericClass()) {

--- a/lib/PrintAsClang/PrintClangFunction.h
+++ b/lib/PrintAsClang/PrintClangFunction.h
@@ -30,6 +30,7 @@ class AbstractFunctionDecl;
 class AccessorDecl;
 class AnyFunctionType;
 class FuncDecl;
+class GenericTypeParamType;
 class ModuleDecl;
 class NominalTypeDecl;
 class LoweredFunctionSignature;
@@ -134,6 +135,11 @@ public:
   printClangFunctionReturnType(Type ty, OptionalTypeKind optKind,
                                ModuleDecl *moduleContext,
                                OutputLanguageMode outputLang);
+
+  static void printGenericReturnSequence(
+      raw_ostream &os, const GenericTypeParamType *gtpt,
+      llvm::function_ref<void(StringRef)> invocationPrinter,
+      Optional<StringRef> initializeWithTakeFromValue = llvm::None);
 
   using PrinterTy =
       llvm::function_ref<void(llvm::MapVector<Type, std::string> &)>;

--- a/test/Interop/SwiftToCxx/generics/generic-enum-execution.cpp
+++ b/test/Interop/SwiftToCxx/generics/generic-enum-execution.cpp
@@ -1,0 +1,54 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %S/generic-enum-in-cxx.swift -typecheck -module-name Generics -clang-header-expose-public-decls -emit-clang-header-path %t/generics.h
+
+// RUN: %target-interop-build-clangxx -std=gnu++20 -c %s -I %t -o %t/swift-generics-execution.o
+// RUN: %target-interop-build-swift %S/generic-enum-in-cxx.swift -o %t/swift-generics-execution -Xlinker %t/swift-generics-execution.o -module-name Generics -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+
+// RUN: %target-codesign %t/swift-generics-execution
+// RUN: %target-run %t/swift-generics-execution | %FileCheck %s
+
+// REQUIRES: executable_test
+
+#include "generics.h"
+#include <cassert>
+
+int main() {
+  using namespace Generics;
+
+  {
+    auto x = makeGenericOpt<int>(42);
+    takeGenericOpt(x);
+    // CHECK: some(42)
+    inoutGenericOpt(x, -11);
+    takeGenericOpt(x);
+    // CHECK-NEXT: none
+    inoutGenericOpt(x, -11);
+    takeGenericOpt(x);
+    // CHECK-NEXT: some(-11)
+    x.method();
+    // CHECK-NEXT: GenericOpt<T>::testme::some(-11);
+    assert(x.getComputedProp() == 42);
+    x.reset();
+    assert(x.genericMethod<double>(5.25) == 5.25);
+    // CHECK-NEXT: GenericOpt<T>::genericMethod<T>::none,5.25;
+  }
+  {
+    auto x = makeConcreteOpt(0xFA);
+    takeConcreteOpt(x);
+    // CHECK-NEXT: CONCRETE opt: some(250) ;
+    inoutConcreteOpt(x);
+    takeConcreteOpt(x);
+    // CHECK-NEXT: CONCRETE opt: some(750) ;
+    inoutConcreteOpt(x);
+    takeConcreteOpt(x);
+    // CHECK-NEXT: CONCRETE opt: some(2250) ;
+    x.method();
+    // CHECK-NEXT: GenericOpt<T>::testme::some(2250);
+    assert(x.getComputedProp() == 42);
+    x.reset();
+    assert(x.genericMethod<double>(-1.25) == -1.25);
+    // CHECK-NEXT: GenericOpt<T>::genericMethod<T>::none,-1.25;
+  }
+  return 0;
+}

--- a/test/Interop/SwiftToCxx/generics/generic-enum-execution.cpp
+++ b/test/Interop/SwiftToCxx/generics/generic-enum-execution.cpp
@@ -12,6 +12,7 @@
 
 #include "generics.h"
 #include <cassert>
+#include <cstdio>
 
 int main() {
   using namespace Generics;
@@ -29,7 +30,11 @@ int main() {
     x.method();
     // CHECK-NEXT: GenericOpt<T>::testme::some(-11);
     assert(x.getComputedProp() == 42);
+    assert(x.isSome());
+    auto val = x.getSome();
+    assert(val == -11);
     x.reset();
+    assert(x.isNone());
     assert(x.genericMethod<double>(5.25) == 5.25);
     // CHECK-NEXT: GenericOpt<T>::genericMethod<T>::none,5.25;
   }
@@ -46,9 +51,21 @@ int main() {
     x.method();
     // CHECK-NEXT: GenericOpt<T>::testme::some(2250);
     assert(x.getComputedProp() == 42);
+    assert(x.isSome());
+    auto val = x.getSome();
+    assert(val == 2250);
     x.reset();
+    assert(x.isNone());
     assert(x.genericMethod<double>(-1.25) == -1.25);
     // CHECK-NEXT: GenericOpt<T>::genericMethod<T>::none,-1.25;
   }
+  {
+    auto x   = makeGenericOpt<StructForEnum>(StructForEnum::init());
+    auto val = x.getSome();
+    // CHECK-NEXT: init-TracksDeinit
+    // CHECK-NEXT: destroy-TracksDeinit
+  }
+  puts("EOF");
+  // CHECK-NEXT: EOF
   return 0;
 }

--- a/test/Interop/SwiftToCxx/generics/generic-enum-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-enum-in-cxx.swift
@@ -10,6 +10,24 @@
 
 // FIXME: remove the need for -Wno-reserved-identifier
 
+class TracksDeinit {
+    init() {
+        print("init-TracksDeinit")
+    }
+    deinit {
+        print("destroy-TracksDeinit")
+    }
+}
+
+@frozen
+public struct StructForEnum {
+    let x: TracksDeinit
+
+    public init() {
+        x = TracksDeinit()
+    }
+}
+
 @frozen public enum GenericOpt<T> {
     case none
     case some(T)
@@ -152,6 +170,27 @@ public func inoutConcreteOpt(_ x: inout GenericOpt<UInt16>) {
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
 // CHECK-NEXT:   inline bool GenericOpt<T_0_0>::isSome() const {
 // CHECK-NEXT:     return *this == GenericOpt<T_0_0>::some;
+// CHECK-NEXT:   }
+// CHECK-NEXT:   template<class T_0_0>
+// CHECK-NEXT:   requires swift::isUsableInGenericContext<T_0_0>
+// CHECK-NEXT:     inline T_0_0 GenericOpt<T_0_0>::getSome() const {
+// CHECK-NEXT:       if (!isSome()) abort();
+// CHECK-NEXT:       alignas(GenericOpt) unsigned char buffer[sizeof(GenericOpt)];
+// CHECK-NEXT:       auto *thisCopy = new(buffer) GenericOpt(*this);
+// CHECK-NEXT:       char * _Nonnull payloadFromDestruction = thisCopy->_destructiveProjectEnumData();
+// CHECK-NEXT:     if constexpr (std::is_base_of<::swift::_impl::RefCountedClass, T_0_0>::value) {
+// CHECK-NEXT:   abort();
+// CHECK-NEXT:     } else if constexpr (::swift::_impl::isValueType<T_0_0>) {
+// CHECK-NEXT:     return ::swift::_impl::implClassFor<T_0_0>::type::returnNewValue([&](void * _Nonnull returnValue) {
+// CHECK-NEXT:    return ::swift::_impl::implClassFor<T_0_0>::type::initializeWithTake(reinterpret_cast<char * _Nonnull>(returnValue), payloadFromDestruction);
+// CHECK-NEXT:     });
+// CHECK-NEXT:     } else if constexpr (::swift::_impl::isSwiftBridgedCxxRecord<T_0_0>) {
+// CHECK-NEXT:   abort();
+// CHECK-NEXT:     } else {
+// CHECK-NEXT:     T_0_0 returnValue;
+// CHECK-NEXT:   memcpy(&returnValue, payloadFromDestruction, sizeof(returnValue));
+// CHECK-NEXT:     return returnValue;
+// CHECK-NEXT:     }
 // CHECK-NEXT:   }
 // CHECK-NEXT: template<class T_0_0>
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>

--- a/test/Interop/SwiftToCxx/generics/generic-enum-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-enum-in-cxx.swift
@@ -1,0 +1,182 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -module-name Generics -clang-header-expose-public-decls -emit-clang-header-path %t/generics.h
+// RUN: %FileCheck %s < %t/generics.h
+// RUN: %check-generic-interop-cxx-header-in-clang(%t/generics.h -Wno-reserved-identifier)
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -enable-library-evolution -typecheck -module-name Generics -clang-header-expose-public-decls -emit-clang-header-path %t/generics.h
+// RUN: %FileCheck %s < %t/generics.h
+// RUN: %check-generic-interop-cxx-header-in-clang(%t/generics.h -Wno-reserved-identifier)
+
+// FIXME: remove the need for -Wno-reserved-identifier
+
+@frozen public enum GenericOpt<T> {
+    case none
+    case some(T)
+
+    public func method() {
+        let copyOfSelf = self
+        print("GenericOpt<T>::testme::\(copyOfSelf);")
+    }
+
+    public mutating func reset() {
+        self = .none
+    }
+
+    public func genericMethod<T>(_ x: T) -> T {
+        print("GenericOpt<T>::genericMethod<T>::\(self),\(x);")
+        return x
+    }
+
+    public var computedProp: Int {
+        return 42
+    }
+}
+
+public func makeGenericOpt<T>(_ x: T) -> GenericOpt<T> {
+    return .some(x)
+}
+
+public func makeConcreteOpt(_ x: UInt16) -> GenericOpt<UInt16> {
+    return GenericOpt<UInt16>.some(x)
+}
+
+public func takeGenericOpt<T>(_ x: GenericOpt<T>) {
+    print(x)
+}
+
+public func takeConcreteOpt(_ x: GenericOpt<UInt16>) {
+    print("CONCRETE opt:", x, ";")
+}
+
+public func inoutGenericOpt<T>(_ x: inout GenericOpt<T>, _ y: T) {
+    switch (x) {
+    case .some:
+        x = .none
+    case .none:
+        x = .some(y)
+    }
+}
+
+public func inoutConcreteOpt(_ x: inout GenericOpt<UInt16>) {
+    switch (x) {
+    case .some(let x_):
+        x = .some(x_ * 3)
+    case .none:
+        break
+    }
+}
+
+// CHECK: template<class T_0_0>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
+// CHECK-NEXT: class _impl_GenericOpt;
+
+// CHECK: SWIFT_EXTERN swift::_impl::MetadataResponseTy $s8Generics10GenericOptOMa(swift::_impl::MetadataRequestTy, void * _Nonnull) SWIFT_NOEXCEPT SWIFT_CALL;
+
+// CHECK: template<class T_0_0>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
+// CHECK-NEXT: class GenericOpt final {
+// CHECK-NEXT: public:
+// CHECK-NEXT: inline ~GenericOpt() {
+// CHECK-NEXT:   auto metadata = _impl::$s8Generics10GenericOptOMa(0, swift::TypeMetadataTrait<T_0_0>::getTypeMetadata());
+// CHECK-NEXT:   auto *vwTableAddr = reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1;
+// CHECK-NEXT: #ifdef __arm64e__
+// CHECK-NEXT:   auto *vwTable = reinterpret_cast<swift::_impl::ValueWitnessTable *>(ptrauth_auth_data(reinterpret_cast<void *>(*vwTableAddr), ptrauth_key_process_independent_data, ptrauth_blend_discriminator(vwTableAddr, 11839)));
+// CHECK-NEXT: #else
+// CHECK-NEXT:   auto *vwTable = *vwTableAddr;
+// CHECK-NEXT: #endif
+// CHECK-NEXT:   vwTable->destroy(_getOpaquePointer(), metadata._0);
+// CHECK-NEXT: }
+
+// CHECK: enum class cases {
+// CHECK-NEXT:  some,
+// CHECK-NEXT:  none
+// CHECK-NEXT: };
+
+// CHECK: inline operator cases() const {
+// CHECK-NEXT:   switch (_getEnumTag()) {
+// CHECK-NEXT:     case 0: return cases::some;
+// CHECK-NEXT:     case 1: return cases::none;
+// CHECK-NEXT:     default: abort();
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+
+// CHECK: inline void method() const;
+// CHECK-NEXT: inline void reset();
+// CHECK-NEXT: template<class T_1_0>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_1_0>
+// CHECK-NEXT: inline T_1_0 genericMethod(const T_1_0& x) const;
+// CHECK-NEXT: inline swift::Int getComputedProp() const;
+
+
+// CHECK: inline void inoutConcreteOpt(GenericOpt<uint16_t>& x) noexcept {
+// CHECK-NEXT:   return _impl::$s8Generics16inoutConcreteOptyyAA07GenericD0Oys6UInt16VGzF(_impl::_impl_GenericOpt<uint16_t>::getOpaquePointer(x));
+// CHECK-NEXT: }
+
+
+// CHECK: template<class T_0_0>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
+// CHECK-NEXT: inline void inoutGenericOpt(GenericOpt<T_0_0>& x, const T_0_0& y) noexcept {
+// CHECK-NEXT:   return _impl::$s8Generics15inoutGenericOptyyAA0cD0OyxGz_xtlF(_impl::_impl_GenericOpt<T_0_0>::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata());
+// CHECK-NEXT: }
+
+
+// CHECK: inline GenericOpt<uint16_t> makeConcreteOpt(uint16_t x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT:   return _impl::_impl_GenericOpt<uint16_t>::returnNewValue([&](char * _Nonnull result) {
+// CHECK-NEXT:     _impl::swift_interop_returnDirect_Generics_uint32_t_0_4(result, _impl::$s8Generics15makeConcreteOptyAA07GenericD0Oys6UInt16VGAFF(x));
+// CHECK-NEXT:   });
+// CHECK-NEXT: }
+
+
+// CHECK: template<class T_0_0>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
+// CHECK-NEXT: inline GenericOpt<T_0_0> makeGenericOpt(const T_0_0& x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT:   return _impl::_impl_GenericOpt<T_0_0>::returnNewValue([&](char * _Nonnull result) {
+// CHECK-NEXT:     _impl::$s8Generics14makeGenericOptyAA0cD0OyxGxlF(result, swift::_impl::getOpaquePointer(x), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata());
+// CHECK-NEXT:   });
+// CHECK-NEXT: }
+
+
+// CHECK: inline void takeConcreteOpt(const GenericOpt<uint16_t>& x) noexcept {
+// CHECK-NEXT:   return _impl::$s8Generics15takeConcreteOptyyAA07GenericD0Oys6UInt16VGF(_impl::swift_interop_passDirect_Generics_uint32_t_0_4(_impl::_impl_GenericOpt<uint16_t>::getOpaquePointer(x)));
+// CHECK-NEXT: }
+
+
+// CHECK: template<class T_0_0>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
+// CHECK-NEXT: inline void takeGenericOpt(const GenericOpt<T_0_0>& x) noexcept {
+// CHECK-NEXT:  return _impl::$s8Generics14takeGenericOptyyAA0cD0OyxGlF(_impl::_impl_GenericOpt<T_0_0>::getOpaquePointer(x), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata());
+// CHECK-NEXT: }
+
+// CHECK: template<class T_0_0>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
+// CHECK-NEXT:   inline bool GenericOpt<T_0_0>::isSome() const {
+// CHECK-NEXT:     return *this == GenericOpt<T_0_0>::some;
+// CHECK-NEXT:   }
+// CHECK-NEXT: template<class T_0_0>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
+// CHECK-NEXT:   inline bool GenericOpt<T_0_0>::isNone() const {
+// CHECK-NEXT:     return *this == GenericOpt<T_0_0>::none;
+// CHECK-NEXT:   }
+
+// CHECK: template<class T_0_0>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
+// CHECK-NEXT: inline void GenericOpt<T_0_0>::method() const {
+// CHECK-NEXT: return _impl::$s8Generics10GenericOptO6methodyyF(swift::TypeMetadataTrait<GenericOpt<T_0_0>>::getTypeMetadata(), _getOpaquePointer());
+// CHECK-NEXT: }
+
+// CHECK: template<class T_0_0>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
+// CHECK-NEXT: void GenericOpt<T_0_0>::reset()
+
+// CHECK: template<class T_0_0>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
+// CHECK-NEXT: template<class T_1_0>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_1_0>
+// CHECK-NEXT: inline T_1_0 GenericOpt<T_0_0>::genericMethod(const T_1_0& x) const {
+
+// CHECK: template<class T_0_0>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
+// CHECK-NEXT: inline swift::Int GenericOpt<T_0_0>::getComputedProp() const {
+// CHECK-NEXT: return _impl::$s8Generics10GenericOptO12computedPropSivg(swift::TypeMetadataTrait<GenericOpt<T_0_0>>::getTypeMetadata(), _getOpaquePointer());
+// CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/generics/generic-enum-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-enum-in-cxx.swift
@@ -10,13 +10,17 @@
 
 // FIXME: remove the need for -Wno-reserved-identifier
 
-class TracksDeinit {
+public class TracksDeinit {
     init() {
         print("init-TracksDeinit")
     }
     deinit {
         print("destroy-TracksDeinit")
     }
+}
+
+public func constructTracksDeinit() -> TracksDeinit {
+    return TracksDeinit()
 }
 
 @frozen
@@ -179,7 +183,9 @@ public func inoutConcreteOpt(_ x: inout GenericOpt<UInt16>) {
 // CHECK-NEXT:       auto *thisCopy = new(buffer) GenericOpt(*this);
 // CHECK-NEXT:       char * _Nonnull payloadFromDestruction = thisCopy->_destructiveProjectEnumData();
 // CHECK-NEXT:     if constexpr (std::is_base_of<::swift::_impl::RefCountedClass, T_0_0>::value) {
-// CHECK-NEXT:   abort();
+// CHECK-NEXT:     void *returnValue;
+// CHECK-NEXT:     returnValue = *reinterpret_cast<void **>(payloadFromDestruction);
+// CHECK-NEXT:     return ::swift::_impl::implClassFor<T_0_0>::type::makeRetained(returnValue);
 // CHECK-NEXT:     } else if constexpr (::swift::_impl::isValueType<T_0_0>) {
 // CHECK-NEXT:     return ::swift::_impl::implClassFor<T_0_0>::type::returnNewValue([&](void * _Nonnull returnValue) {
 // CHECK-NEXT:    return ::swift::_impl::implClassFor<T_0_0>::type::initializeWithTake(reinterpret_cast<char * _Nonnull>(returnValue), payloadFromDestruction);


### PR DESCRIPTION
This supports generic enums, including getting a generic associated value. The one thing that's not supported yet is the construction of generic enum values. This will allow `Optional` to be bridged.