### PR TITLE
[test] fix buffer overflow in 32-bit device testing

### DIFF
--- a/validation-test/stdlib/UnsafeBufferPointerSlices.swift
+++ b/validation-test/stdlib/UnsafeBufferPointerSlices.swift
@@ -598,10 +598,9 @@ UnsafeMutableRawBufferPointerSliceTests.test(
 UnsafeMutableRawBufferPointerSliceTests.test(
   "slice.of.UnsafeMutableRawBufferPointer.loadUnaligned"
 ) {
-  let count = 4
-  let sizeInBytes = count * MemoryLayout<Int>.stride
+  let sizeInBytes = 32
   let b = UnsafeMutableRawBufferPointer.allocate(
-    byteCount: sizeInBytes, alignment: MemoryLayout<Int>.alignment
+    byteCount: sizeInBytes, alignment: 4
   )
   defer {
     b.deallocate()


### PR DESCRIPTION
Fix an indexing error that occurs when running on a 32-bit device.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://99933632