### PR TITLE
Pass the early SwiftSyntax build directory down to build-script-impl.

### DIFF
--- a/utils/swift_build_support/swift_build_support/build_script_invocation.py
+++ b/utils/swift_build_support/swift_build_support/build_script_invocation.py
@@ -253,10 +253,11 @@ class BuildScriptInvocation(object):
 
         if args.build_early_swiftsyntax:
             early_swiftsyntax_build_dir = os.path.join(
-               self.workspace.build_root, '%s-%s' % ('earlyswiftsyntax',
-                                                     self.args.host_target))
+                self.workspace.build_root,
+                '%s-%s' % ('earlyswiftsyntax', self.args.host_target))
             args.extra_cmake_options.append(
-              '-DSWIFT_PATH_TO_EARLYSWIFTSYNTAX_BUILD_DIR:PATH={}'.format(early_swiftsyntax_build_dir))
+                '-DSWIFT_PATH_TO_EARLYSWIFTSYNTAX_BUILD_DIR:PATH={}'
+                .format(early_swiftsyntax_build_dir))
 
         # Then add subproject install flags that either skip building them /or/
         # if we are going to build them and install_all is set, we also install

--- a/utils/swift_build_support/swift_build_support/build_script_invocation.py
+++ b/utils/swift_build_support/swift_build_support/build_script_invocation.py
@@ -251,6 +251,13 @@ class BuildScriptInvocation(object):
         args.extra_cmake_options.append(
             '-DSWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE:PATH={}'.format(swift_syntax_src))
 
+        if args.build_early_swiftsyntax:
+            early_swiftsyntax_build_dir = os.path.join(
+               self.workspace.build_root, '%s-%s' % ('earlyswiftsyntax',
+                                                     self.args.host_target))
+            args.extra_cmake_options.append(
+              '-DSWIFT_PATH_TO_EARLYSWIFTSYNTAX_BUILD_DIR:PATH={}'.format(early_swiftsyntax_build_dir))
+
         # Then add subproject install flags that either skip building them /or/
         # if we are going to build them and install_all is set, we also install
         # them.


### PR DESCRIPTION
This gives LLDB's CMake build access to the build directory.