### PR TITLE
[Freestanding] Disable child task priority spec.

### DIFF
--- a/stdlib/public/Concurrency/SourceCompatibilityShims.swift
+++ b/stdlib/public/Concurrency/SourceCompatibilityShims.swift
@@ -285,6 +285,7 @@ extension Task where Failure == Never {
   }
 }
 
+#if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
 @available(SwiftStdlib 5.1, *)
 extension TaskGroup {
   @available(*, deprecated, renamed: "addTask(priority:operation:)")
@@ -334,7 +335,94 @@ extension TaskGroup {
     addTaskUnlessCancelled(priority: priority, operation: operation)
   }
 }
+#else
+@available(SwiftStdlib 5.1, *)
+extension TaskGroup {
+  @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model", renamed: "addTaskUnlessCancelled(operation:)")
+  public mutating func add(
+      priority: TaskPriority? = nil,
+      operation: __owned @Sendable @escaping () async -> ChildTaskResult
+  ) async -> Bool {
+    fatalError("Unavailable in task-to-thread concurrency model")
+  }
 
+  @available(*, deprecated, renamed: "addTaskUnlessCancelled(operation:)")
+  @_alwaysEmitIntoClient
+  public mutating func add(
+      operation: __owned @Sendable @escaping () async -> ChildTaskResult
+  ) async -> Bool {
+    return self.addTaskUnlessCancelled {
+      await operation()
+    }
+  }
+
+  @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model", renamed: "addTask(operation:)")
+  public mutating func spawn(
+    priority: TaskPriority? = nil,
+    operation: __owned @Sendable @escaping () async -> ChildTaskResult
+  ) {
+    fatalError("Unavailable in task-to-thread concurrency model")
+  }
+
+  @available(*, deprecated, renamed: "addTask(operation:)")
+  @_alwaysEmitIntoClient
+  public mutating func spawn(
+    operation: __owned @Sendable @escaping () async -> ChildTaskResult
+  ) {
+    addTask(operation: operation)
+  }
+
+  @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model", renamed: "addTaskUnlessCancelled(operation:)")
+  public mutating func spawnUnlessCancelled(
+    priority: TaskPriority? = nil,
+    operation: __owned @Sendable @escaping () async -> ChildTaskResult
+  ) -> Bool {
+    fatalError("Unavailable in task-to-thread concurrency model")
+  }
+
+  @available(*, deprecated, renamed: "addTaskUnlessCancelled(operation:)")
+  @_alwaysEmitIntoClient
+  public mutating func spawnUnlessCancelled(
+    operation: __owned @Sendable @escaping () async -> ChildTaskResult
+  ) -> Bool {
+    addTaskUnlessCancelled(operation: operation)
+  }
+
+  @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model", renamed: "addTask(operation:)")
+  public mutating func async(
+    priority: TaskPriority? = nil,
+    operation: __owned @Sendable @escaping () async -> ChildTaskResult
+  ) {
+    fatalError("Unavailable in task-to-thread concurrency model")
+  }
+
+  @available(*, deprecated, renamed: "addTask(operation:)")
+  @_alwaysEmitIntoClient
+  public mutating func async(
+    operation: __owned @Sendable @escaping () async -> ChildTaskResult
+  ) {
+    addTask(operation: operation)
+  }
+
+  @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model", renamed: "addTaskUnlessCancelled(operation:)")
+  public mutating func asyncUnlessCancelled(
+    priority: TaskPriority? = nil,
+    operation: __owned @Sendable @escaping () async -> ChildTaskResult
+  ) -> Bool {
+    fatalError("Unavailable in task-to-thread concurrency model")
+  }
+
+  @available(*, deprecated, renamed: "addTaskUnlessCancelled(operation:)")
+  @_alwaysEmitIntoClient
+  public mutating func asyncUnlessCancelled(
+    operation: __owned @Sendable @escaping () async -> ChildTaskResult
+  ) -> Bool {
+    addTaskUnlessCancelled(operation: operation)
+  }
+}
+#endif
+
+#if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
 @available(SwiftStdlib 5.1, *)
 extension ThrowingTaskGroup {
   @available(*, deprecated, renamed: "addTask(priority:operation:)")
@@ -384,6 +472,92 @@ extension ThrowingTaskGroup {
     addTaskUnlessCancelled(priority: priority, operation: operation)
   }
 }
+#else
+@available(SwiftStdlib 5.1, *)
+extension ThrowingTaskGroup {
+  @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model", renamed: "addTaskUnlessCancelled(operation:)")
+  public mutating func add(
+    priority: TaskPriority? = nil,
+    operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
+  ) async -> Bool {
+    fatalError("Unavailable in task-to-thread concurrency model")
+  }
+
+  @available(*, deprecated, renamed: "addTaskUnlessCancelled(operation:)")
+  @_alwaysEmitIntoClient
+  public mutating func add(
+    operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
+  ) async -> Bool {
+    return self.addTaskUnlessCancelled {
+      try await operation()
+    }
+  }
+
+  @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model", renamed: "addTask(operation:)")
+  public mutating func spawn(
+    priority: TaskPriority? = nil,
+    operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
+  ) {
+    fatalError("Unavailable in task-to-thread concurrency model")
+  }
+
+  @available(*, deprecated, renamed: "addTask(operation:)")
+  @_alwaysEmitIntoClient
+  public mutating func spawn(
+    operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
+  ) {
+    addTask(operation: operation)
+  }
+
+  @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model", renamed: "addTaskUnlessCancelled(operation:)")
+  public mutating func spawnUnlessCancelled(
+    priority: TaskPriority? = nil,
+    operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
+  ) -> Bool {
+    fatalError("Unavailable in task-to-thread concurrency model")
+  }
+
+  @available(*, deprecated, renamed: "addTaskUnlessCancelled(operation:)")
+  @_alwaysEmitIntoClient
+  public mutating func spawnUnlessCancelled(
+    operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
+  ) -> Bool {
+    addTaskUnlessCancelled(operation: operation)
+  }
+
+  @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model", renamed: "addTask(operation:)")
+  public mutating func async(
+    priority: TaskPriority? = nil,
+    operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
+  ) {
+    fatalError("Unavailable in task-to-thread concurrency model")
+  }
+
+  @available(*, deprecated, renamed: "addTask(operation:)")
+  @_alwaysEmitIntoClient
+  public mutating func async(
+    operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
+  ) {
+    addTask(operation: operation)
+  }
+
+  @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model", renamed: "addTaskUnlessCancelled(operation:)")
+  public mutating func asyncUnlessCancelled(
+    priority: TaskPriority? = nil,
+    operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
+  ) -> Bool {
+    fatalError("Unavailable in task-to-thread concurrency model")
+  }
+
+  @available(*, deprecated, renamed: "addTaskUnlessCancelled(operation:)")
+  @_alwaysEmitIntoClient
+  public mutating func asyncUnlessCancelled(
+    operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
+  ) -> Bool {
+    addTaskUnlessCancelled(operation: operation)
+  }
+}
+#endif
 
 @available(SwiftStdlib 5.1, *)
 @available(*, deprecated, message: "please use UnsafeContinuation<..., Error>")

--- a/test/stdlib/freestanding_diags_stdlib.swift
+++ b/test/stdlib/freestanding_diags_stdlib.swift
@@ -11,6 +11,7 @@ func chowMein() async {
 @MainActor // expected-error{{not permitted within task-to-thread concurrency model}}
 class ChowMein {}
 
+@available(SwiftStdlib 5.1, *)
 func foo() async {
   Task<Void, Never> {} // expected-error{{Unavailable in task-to-thread concurrency model}}
   Task<Void, Error> {} // expected-error{{Unavailable in task-to-thread concurrency model}}
@@ -31,6 +32,50 @@ func foo() async {
     _ = error
   }
   _ = CheckedContinuation<Int, Never>.self // expected-error{{Unavailable in task-to-thread concurrency model}}
+  func withTaskGroup(_ tg: inout TaskGroup<Int>) async throws {
+    tg.addTask(priority: .low) { return 1 } // expected-error{{Unavailable in task-to-thread concurrency model}}
+    tg.addTask { return 1 } // ok
+    _ = tg.addTaskUnlessCancelled(priority: .low) { return 1 } // expected-error{{Unavailable in task-to-thread concurrency model}}
+    _ = tg.addTaskUnlessCancelled { return 1 } // ok
+
+    _ = await tg.add(priority: .low) { return 1 } // expected-error{{Unavailable in task-to-thread concurrency model}}
+    _ = await tg.add { return 1 } // expected-warning{{'add(operation:)' is deprecated: renamed to 'addTaskUnlessCancelled(operation:)'}}
+                                  // expected-note@-1{{use 'addTaskUnlessCancelled(operation:)' instead}}
+    tg.spawn(priority: .low) { return 1 } // expected-error{{Unavailable in task-to-thread concurrency model}}
+    tg.spawn { return 1 } // expected-warning{{'spawn(operation:)' is deprecated: renamed to 'addTask(operation:)'}}
+                          // expected-note@-1{{use 'addTask(operation:)' instead}}
+    _ = tg.spawnUnlessCancelled(priority: .low) { return 1 } // expected-error{{Unavailable in task-to-thread concurrency model}}
+    _ = tg.spawnUnlessCancelled { return 1 } // expected-warning{{'spawnUnlessCancelled(operation:)' is deprecated: renamed to 'addTaskUnlessCancelled(operation:)'}}
+                                             // expected-note@-1{{use 'addTaskUnlessCancelled(operation:)' instead}}
+    tg.async(priority: .low) { return 1 } // expected-error{{Unavailable in task-to-thread concurrency model}}
+    tg.async { return 1 } // expected-warning{{'async(operation:)' is deprecated: renamed to 'addTask(operation:)'}}
+                          // expected-note@-1{{use 'addTask(operation:)' instead}}
+    _ = tg.asyncUnlessCancelled(priority: .low) { return 1 } // expected-error{{Unavailable in task-to-thread concurrency model}}
+    _ = tg.asyncUnlessCancelled { return 1 } // expected-warning{{'asyncUnlessCancelled(operation:)' is deprecated: renamed to 'addTaskUnlessCancelled(operation:)'}}
+                                             // expected-note@-1{{use 'addTaskUnlessCancelled(operation:)' instead}}
+  }
+  func withThrowingTaskGroup(_ tg: inout ThrowingTaskGroup<Int, Error>) async throws {
+    tg.addTask(priority: .low) { return 1 } // expected-error{{Unavailable in task-to-thread concurrency model}}
+    tg.addTask { return 1 } // ok
+    _ = tg.addTaskUnlessCancelled(priority: .low) { return 1 } // expected-error{{Unavailable in task-to-thread concurrency model}}
+    _ = tg.addTaskUnlessCancelled { return 1 } // ok
+
+    _ = await tg.add(priority: .low) { return 1 } // expected-error{{Unavailable in task-to-thread concurrency model}}
+    _ = await tg.add { return 1 } // expected-warning{{'add(operation:)' is deprecated: renamed to 'addTaskUnlessCancelled(operation:)'}}
+                                  // expected-note@-1{{use 'addTaskUnlessCancelled(operation:)' instead}}
+    tg.spawn(priority: .low) { return 1 } // expected-error{{Unavailable in task-to-thread concurrency model}}
+    tg.spawn { return 1 } // expected-warning{{'spawn(operation:)' is deprecated: renamed to 'addTask(operation:)'}}
+                          // expected-note@-1{{use 'addTask(operation:)' instead}}
+    _ = tg.spawnUnlessCancelled(priority: .low) { return 1 } // expected-error{{Unavailable in task-to-thread concurrency model}}
+    _ = tg.spawnUnlessCancelled { return 1 } // expected-warning{{'spawnUnlessCancelled(operation:)' is deprecated: renamed to 'addTaskUnlessCancelled(operation:)'}}
+                                             // expected-note@-1{{use 'addTaskUnlessCancelled(operation:)' instead}}
+    tg.async(priority: .low) { return 1 } // expected-error{{Unavailable in task-to-thread concurrency model}}
+    tg.async { return 1 } // expected-warning{{'async(operation:)' is deprecated: renamed to 'addTask(operation:)'}}
+                          // expected-note@-1{{use 'addTask(operation:)' instead}}
+    _ = tg.asyncUnlessCancelled(priority: .low) { return 1 } // expected-error{{Unavailable in task-to-thread concurrency model}}
+    _ = tg.asyncUnlessCancelled { return 1 } // expected-warning{{'asyncUnlessCancelled(operation:)' is deprecated: renamed to 'addTaskUnlessCancelled(operation:)'}}
+                                             // expected-note@-1{{use 'addTaskUnlessCancelled(operation:)' instead}}
+  }
 }
 
 func foo2(


### PR DESCRIPTION
Under the task-to-thread model, specifying a priority doesn't make sense.

Here, variations of addTask and addTaskUnlessCancelled are introduced which do not take a priority.  Additionally, the original functions are made unavailable.
