### PR TITLE
[stdlib] use `_copyContents` after all

### DIFF
--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -729,7 +729,7 @@ extension Unsafe${Mutable}BufferPointer {
       return startIndex.advanced(by: count)
     }
 
-    var (iterator, copied) = source._copySequenceContents(initializing: self)
+    var (iterator, copied) = source._copyContents(initializing: self)
     _precondition(
       iterator.next() == nil,
       "buffer cannot contain every element from source."


### PR DESCRIPTION
- originally had avoided `_copyContents` because all the standard library fast paths were already covered.
- however Swift Collections has piecewise-contiguous collections that rely on `_copyContents` to accelerate copies.

Addresses rdar://99890632