### PR TITLE
Drop the Identifier List from Designated Type Parsing

### DIFF
--- a/test/Parse/operator_decl_designated_types.swift
+++ b/test/Parse/operator_decl_designated_types.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-operator-designated-types -verify-syntax-tree
+// RUN: %target-typecheck-verify-swift -enable-operator-designated-types
 
 precedencegroup LowPrecedence {
   associativity: right


### PR DESCRIPTION
This was never the correct way to model this because it drops the commas in the list. Instead just take the optional trailing identifier element if we have one.
