### PR TITLE
Don't shrink escaped borrow scopes in DCE

### DIFF
--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -78,6 +78,8 @@ inline bool isForwardingConsume(SILValue value) {
   return canOpcodeForwardOwnedValues(value);
 }
 
+bool hasEscaped(BorrowedValue value);
+
 /// Find leaf "use points" of \p guaranteedValue that determine its lifetime
 /// requirement. Return true if no PointerEscape use was found.
 ///

--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -301,8 +301,15 @@ void DCE::markLive() {
           }
           continue;
         }
-        // If not populate reborrowDependencies for this borrow
+        // Populate reborrowDependencies for this borrow
         findReborrowDependencies(borrowInst);
+        if (hasEscaped(BorrowedValue(borrowInst))) {
+          // Visit all end_borrows and mark them live
+          visitTransitiveEndBorrows(borrowInst, [&](EndBorrowInst *endBorrow) {
+            markInstructionLive(endBorrow);
+          });
+          continue;
+        }
         break;
       }
       default:

--- a/test/SILOptimizer/dead_code_elimination_nontrivial_ossa.sil
+++ b/test/SILOptimizer/dead_code_elimination_nontrivial_ossa.sil
@@ -972,3 +972,26 @@ bb0(%0 : $@sil_unmanaged AnyObject):
   %242 = tuple ()
   return %242 : $()
 }
+
+sil @foo : $@convention(thin) () -> ()
+
+// CHECK-LABEL: sil [ossa] @test_escape : {{.*}} {
+// CHECK: br bb1
+// CHECK: end_borrow
+// CHECK-LABEL: } // end sil function 'test_escape'
+sil [ossa] @test_escape : $@convention(thin) () -> () {
+bb0:
+  %13 = function_ref @foo : $@convention(thin) () -> ()
+  %14 = partial_apply [callee_guaranteed] %13() : $@convention(thin) () -> ()
+  %15 = convert_escape_to_noescape %14 : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
+  %17 = begin_borrow %14 : $@callee_guaranteed () -> ()
+  %18 = mark_dependence %15 : $@noescape @callee_guaranteed () -> () on %17 : $@callee_guaranteed () -> ()
+  br bb1(%18 : $@noescape @callee_guaranteed () -> (), %17 : $@callee_guaranteed () -> (), %14 : $@callee_guaranteed () -> ())
+
+bb1(%21 : $@noescape @callee_guaranteed () -> (), %22 : @guaranteed $@callee_guaranteed () -> (), %23 : @owned $@callee_guaranteed () -> ()):
+  %27 = apply %21() : $@noescape @callee_guaranteed () -> ()
+  end_borrow %22 : $@callee_guaranteed () -> ()
+  destroy_value %23 : $@callee_guaranteed () -> ()
+  %28 = tuple ()
+  return %28: $()
+}


### PR DESCRIPTION
Fixes rdar://99128631

If a borrow is escapes, the reborrow dependencies will not track the dependent escaped lifetime. This can lead to use after frees due to lifetime shrinking. This PR fixes this by avoiding DCE'ing an escaped borrow scope.