### PR TITLE
emit a message when falling-back to `xcrun dyldinfo`

### DIFF
--- a/utils/swift-darwin-postprocess.py
+++ b/utils/swift-darwin-postprocess.py
@@ -39,6 +39,7 @@ def unrpathize(filename):
             ['xcrun', 'dyld_info', '-dependents', filename],
             universal_newlines=True)
     except subprocess.CalledProcessError:
+        sys.stderr.write("falling back to 'xcrun dyldinfo' ...\n")
         dylibsOutput = subprocess.check_output(
             ['xcrun', 'dyldinfo', '-dylibs', filename],
             universal_newlines=True)

--- a/utils/swift-rpathize.py
+++ b/utils/swift-rpathize.py
@@ -63,6 +63,7 @@ def rpathize(filename):
             ['xcrun', 'dyld_info', '-dependents', filename],
             universal_newlines=True)
     except subprocess.CalledProcessError:
+        sys.stderr.write("falling back to 'xcrun dyldinfo' ...\n")
         dylibsOutput = subprocess.check_output(
             ['xcrun', 'dyldinfo', '-dylibs', filename],
             universal_newlines=True)


### PR DESCRIPTION
We swallow the initial error when running `xcrun dyld_info ...` but the error message upon failure is still emitted in logs. This created some confusion when auditing the logs to determine CI failures. Hopefully this little reminder that the error is OK will help explain it.


resolves rdar://99977956