### PR TITLE
Follow up of #61126

### DIFF
--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -78,7 +78,7 @@ inline bool isForwardingConsume(SILValue value) {
   return canOpcodeForwardOwnedValues(value);
 }
 
-bool hasEscaped(BorrowedValue value);
+bool hasPointerEscape(BorrowedValue value);
 
 /// Find leaf "use points" of \p guaranteedValue that determine its lifetime
 /// requirement. Return true if no PointerEscape use was found.

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -25,7 +25,9 @@
 
 using namespace swift;
 
-bool swift::hasEscaped(BorrowedValue value) {
+bool swift::hasPointerEscape(BorrowedValue value) {
+  assert(value.kind == BorrowedValueKind::BeginBorrow ||
+         value.kind == BorrowedValueKind::LoadBorrow);
   GraphNodeWorklist<Operand *, 8> worklist;
   for (Operand *use : value->getUses()) {
     if (use->getOperandOwnership() != OperandOwnership::NonUse)
@@ -42,7 +44,6 @@ bool swift::hasEscaped(BorrowedValue value) {
 
     case OperandOwnership::ForwardingUnowned:
     case OperandOwnership::PointerEscape:
-    case OperandOwnership::BitwiseEscape:
       return true;
 
     case OperandOwnership::Borrow:
@@ -50,6 +51,7 @@ bool swift::hasEscaped(BorrowedValue value) {
     case OperandOwnership::InstantaneousUse:
     case OperandOwnership::UnownedInstantaneousUse:
     case OperandOwnership::InteriorPointer:
+    case OperandOwnership::BitwiseEscape:
       break;
 
     case OperandOwnership::Reborrow: {

--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -303,7 +303,10 @@ void DCE::markLive() {
         }
         // Populate reborrowDependencies for this borrow
         findReborrowDependencies(borrowInst);
-        if (hasPointerEscape(BorrowedValue(borrowInst))) {
+        // Don't optimize a borrow scope if it is lexical or has a pointer
+        // escape.
+        if (borrowInst->isLexical() ||
+            hasPointerEscape(BorrowedValue(borrowInst))) {
           // Visit all end_borrows and mark them live
           visitTransitiveEndBorrows(borrowInst, [&](EndBorrowInst *endBorrow) {
             markInstructionLive(endBorrow);

--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -303,7 +303,7 @@ void DCE::markLive() {
         }
         // Populate reborrowDependencies for this borrow
         findReborrowDependencies(borrowInst);
-        if (hasEscaped(BorrowedValue(borrowInst))) {
+        if (hasPointerEscape(BorrowedValue(borrowInst))) {
           // Visit all end_borrows and mark them live
           visitTransitiveEndBorrows(borrowInst, [&](EndBorrowInst *endBorrow) {
             markInstructionLive(endBorrow);


### PR DESCRIPTION
- Rename hasEscaped -> hasPointerEscape, and don't consider OperandOwnership::BitwiseEscape as a pointer escape
- Avoid optimizing lexical borrow scopes in DCE