### PR TITLE
Sema: Type check #_hasSymbol()

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6577,5 +6577,15 @@ ERROR(type_wrapper_ignored_on_static_properties,none,
 ERROR(type_wrapper_ignored_on_lazy_properties,none,
       "%0 must not be used on lazy properties", (DeclAttribute))
 
+//------------------------------------------------------------------------------
+// MARK: #_hasSymbol
+//------------------------------------------------------------------------------
+
+WARNING(has_symbol_decl_must_be_weak,none,
+        "%0 %1 is not a weakly linked declaration",
+        (DescriptiveDeclKind, DeclName))
+ERROR(has_symbol_invalid_expr,none,
+      "#_hasSymbol condition must refer to a declaration", ())
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6586,6 +6586,8 @@ WARNING(has_symbol_decl_must_be_weak,none,
         (DescriptiveDeclKind, DeclName))
 ERROR(has_symbol_invalid_expr,none,
       "#_hasSymbol condition must refer to a declaration", ())
+ERROR(has_symbol_unsupported_in_closures,none,
+      "#_hasSymbol is not supported in closures", ())
 
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -397,6 +397,7 @@ public:
 ///
 class PoundHasSymbolInfo final : public ASTAllocated<PoundHasSymbolInfo> {
   Expr *SymbolExpr;
+  ConcreteDeclRef ReferencedDecl;
 
   SourceLoc PoundLoc;
   SourceLoc LParenLoc;
@@ -404,8 +405,8 @@ class PoundHasSymbolInfo final : public ASTAllocated<PoundHasSymbolInfo> {
 
   PoundHasSymbolInfo(SourceLoc PoundLoc, SourceLoc LParenLoc, Expr *SymbolExpr,
                      SourceLoc RParenLoc)
-      : SymbolExpr(SymbolExpr), PoundLoc(PoundLoc), LParenLoc(LParenLoc),
-        RParenLoc(RParenLoc){};
+      : SymbolExpr(SymbolExpr), ReferencedDecl(), PoundLoc(PoundLoc),
+        LParenLoc(LParenLoc), RParenLoc(RParenLoc){};
 
 public:
   static PoundHasSymbolInfo *create(ASTContext &Ctx, SourceLoc PoundLoc,
@@ -414,6 +415,9 @@ public:
 
   Expr *getSymbolExpr() const { return SymbolExpr; }
   void setSymbolExpr(Expr *E) { SymbolExpr = E; }
+
+  ConcreteDeclRef getReferencedDecl() { return ReferencedDecl; }
+  void setReferencedDecl(ConcreteDeclRef CDR) { ReferencedDecl = CDR; }
 
   SourceLoc getLParenLoc() const { return LParenLoc; }
   SourceLoc getRParenLoc() const { return RParenLoc; }

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4365,9 +4365,15 @@ bool ConstraintSystem::generateConstraints(StmtCondition condition,
   for (const auto &condElement : condition) {
     switch (condElement.getKind()) {
     case StmtConditionElement::CK_Availability:
-    case StmtConditionElement::CK_HasSymbol:
       // Nothing to do here.
       continue;
+
+    case StmtConditionElement::CK_HasSymbol: {
+      ASTContext &ctx = getASTContext();
+      ctx.Diags.diagnose(condElement.getStartLoc(),
+                         diag::has_symbol_unsupported_in_closures);
+      return true;
+    }
 
     case StmtConditionElement::CK_Boolean: {
       Expr *condExpr = condElement.getBoolean();

--- a/test/Parse/has_symbol.swift
+++ b/test/Parse/has_symbol.swift
@@ -1,7 +1,18 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/Library.swiftmodule -parse-as-library %t/Library.swift -enable-library-evolution
+// RUN: %target-swift-frontend -typecheck -verify %t/Client.swift -I %t
 
-func foo() {}
-func bar() {}
+// UNSUPPORTED: OS=windows-msvc
+
+//--- Library.swift
+
+public func foo() {}
+public func bar() {}
+
+//--- Client.swift
+
+@_weakLinked import Library
 
 if #_hasSymbol(foo) {}
 if #_hasSymbol(foo), #_hasSymbol(bar) {}

--- a/test/Sema/Inputs/has_symbol_helper.swift
+++ b/test/Sema/Inputs/has_symbol_helper.swift
@@ -1,0 +1,69 @@
+public let global: Int = 0
+
+public func noArgFunc() {}
+public func function(with argument: Int) {}
+public func throwingFunc() throws {}
+public func ambiguousFunc() {}
+public func ambiguousFunc() -> Int { return 0 }
+public func genericFunc<T: P>(_ t: T) {}
+
+public protocol P {
+  func requirement()
+  func requirementWithDefaultImpl()
+}
+
+extension P {
+  public func requirementWithDefaultImpl() {}
+}
+
+public struct S {
+  public static var staticMember: Int = 0
+  public static func staticFunc() {}
+
+  public var member: Int
+
+  public init(member: Int) {
+    self.member = member
+  }
+  public func noArgsMethod() {}
+  public func method(with argument: Int) {}
+  public func genericFunc<T: P>(_ t: T) {}
+}
+
+extension S: P {
+  public func requirement() {}
+}
+
+public struct GenericS<T: P> {
+  public var member: T
+
+  public init(member: T) {
+    self.member = member
+  }
+  public func noArgsMethod() {}
+  public func method(with argument: T) {}
+}
+
+public class C {
+  public static var staticMember: Int = 0
+  public class func classFunc() {}
+
+  public var member: Int
+
+  public init(member: Int) {
+    self.member = member
+  }
+  public func noArgsMethod() {}
+  public func method(with argument: Int) {}
+}
+
+extension C: P {
+  public func requirement() {}
+}
+
+public enum E {
+  case basicCase
+  case payloadCase(_: S)
+
+  public func method() {}
+}

--- a/test/Sema/has_symbol.swift
+++ b/test/Sema/has_symbol.swift
@@ -1,0 +1,102 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/has_symbol_helper.swiftmodule -parse-as-library %S/Inputs/has_symbol_helper.swift -enable-library-evolution
+// RUN: %target-typecheck-verify-swift -I %t
+
+// UNSUPPORTED: OS=windows-msvc
+
+@_weakLinked import has_symbol_helper
+
+func testGlobalFunctions() {
+  if #_hasSymbol(noArgFunc) {}
+  if #_hasSymbol(function(with:)) {}
+  if #_hasSymbol(throwingFunc) {}
+  if #_hasSymbol(ambiguousFunc) {} // expected-error {{ambiguous use of 'ambiguousFunc()'}}
+  if #_hasSymbol(ambiguousFunc as () -> Int) {}
+  if #_hasSymbol(genericFunc(_:) as (S) -> Void) {}
+}
+
+func testVars() {
+  if #_hasSymbol(global) {}
+  if #_hasSymbol(global as Int) {}
+}
+
+func testStruct(_ s: S) {
+  if #_hasSymbol(s.member) {}
+  if #_hasSymbol(s.noArgsMethod) {}
+  if #_hasSymbol(s.method(with:)) {}
+  if #_hasSymbol(s.genericFunc(_:)) {} // expected-error {{generic parameter 'T' could not be inferred}}
+  if #_hasSymbol(s.genericFunc(_:) as (S) -> ()) {}
+  if #_hasSymbol(s.requirement) {}
+  if #_hasSymbol(s.requirementWithDefaultImpl) {}
+
+  if #_hasSymbol(S.staticFunc) {}
+  if #_hasSymbol(S.staticMember) {}
+  if #_hasSymbol(S.init(member:)) {}
+}
+
+func testGenericStruct(_ s: GenericS<S>) {
+  if #_hasSymbol(s.member) {}
+  if #_hasSymbol(s.noArgsMethod) {}
+  if #_hasSymbol(s.method(with:)) {}
+}
+
+func testClass(_ c: C) {
+  if #_hasSymbol(c.member) {}
+  if #_hasSymbol(c.noArgsMethod) {}
+  if #_hasSymbol(c.method(with:)) {}
+  if #_hasSymbol(c.requirement) {}
+  if #_hasSymbol(c.requirementWithDefaultImpl) {}
+
+  if #_hasSymbol(C.classFunc) {}
+  if #_hasSymbol(C.staticMember) {}
+  if #_hasSymbol(C.init(member:)) {}
+}
+
+func testEnum(_ e: E) {
+  if #_hasSymbol(E.basicCase) {}
+  if #_hasSymbol(E.payloadCase) {}
+  if #_hasSymbol(E.payloadCase(_:)) {}
+  if #_hasSymbol(e.method) {}
+}
+
+func testMetatypes() {
+  if #_hasSymbol(P.self) {}
+  if #_hasSymbol(S.self) {}
+  if #_hasSymbol(GenericS.self) {} // expected-error {{generic parameter 'T' could not be inferred}} expected-note {{explicitly specify the generic arguments to fix this issue}}
+  if #_hasSymbol(GenericS<S>.self) {}
+  if #_hasSymbol(C.self) {}
+  if #_hasSymbol(E.self) {}
+}
+
+var localGlobal: Int = 0
+
+func localFunc() {}
+
+struct LocalStruct {
+  var member: Int = 0
+}
+
+protocol LocalProtocol {}
+
+enum LocalEnum {
+  case a
+}
+
+func testNotWeakDeclDiagnostics(_ s: LocalStruct) {
+  if #_hasSymbol(localFunc) {} // expected-warning {{global function 'localFunc()' is not a weakly linked declaration}}
+  if #_hasSymbol(localGlobal) {} // expected-warning {{var 'localGlobal' is not a weakly linked declaration}}
+  if #_hasSymbol(s) {} // expected-warning {{parameter 's' is not a weakly linked declaration}}
+  if #_hasSymbol(s.member) {} // expected-warning {{property 'member' is not a weakly linked declaration}}
+  if #_hasSymbol(LocalEnum.a) {} // expected-warning {{enum case 'a' is not a weakly linked declaration}}
+  if #_hasSymbol(LocalStruct.self) {} // expected-warning {{struct 'LocalStruct' is not a weakly linked declaration}}
+  if #_hasSymbol(LocalProtocol.self) {} // expected-warning {{protocol 'LocalProtocol' is not a weakly linked declaration}}
+}
+
+func testInvalidExpressionsDiagnostics() {
+  if #_hasSymbol(noArgFunc()) {} // expected-error {{#_hasSymbol condition must refer to a declaration}}
+  if #_hasSymbol(global - 1) {} // expected-error {{#_hasSymbol condition must refer to a declaration}}
+  if #_hasSymbol(S.staticFunc()) {} // expected-error {{#_hasSymbol condition must refer to a declaration}}
+  if #_hasSymbol(C.classFunc()) {} // expected-error {{#_hasSymbol condition must refer to a declaration}}
+  if #_hasSymbol(1 as Int) {} // expected-error {{#_hasSymbol condition must refer to a declaration}}
+  if #_hasSymbol(1 as S) {} // expected-error {{cannot convert value of type 'Int' to type 'S' in coercion}}
+}


### PR DESCRIPTION
Implement type checking for the `#_hasSymbol` directive. The directive takes an expression which must resolve at compile time to a single concrete declaration. There are a few kinds of expressions which we intend to accept:

- Unapplied functions: `if #_hasSymbol(foo(_:))`
- Member references: `if #_hasSymbol(a.x)`
- `.self` expressions on static metatypes: `if #_hasSymbol(SomeEnum.self)`
- Dot syntax call expressions with unapplied functions: `if #_hasSymbol(SomeType.init(_:)`

Additionally, we diagnose when the concretely referenced declaration is not weak linked since this likely indicates that the programmer misidentified the declaration they wish to check or the build is not configured in a way such that the check will be meaningful.

Resolves rdar://99826340