### PR TITLE
[cmake] Repair non-stdlib builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1194,7 +1194,7 @@ else()
   # Some tools (e.g. swift-reflection-dump) rely on a host swiftReflection, so
   # ensure we build that when building tools.
   if(SWIFT_INCLUDE_TOOLS)
-    add_subdirectory(stdlib/public/SwiftShims)
+    add_subdirectory(stdlib/public/SwiftShims/swift/shims)
   endif()
 endif()
 


### PR DESCRIPTION
Update the SwiftShims path to reflect the new directory structure (#60218). This fixes non-`SWIFT_BUILD_STDLIB` builds.