### PR TITLE
[cxx-interop] Fix ASAN error

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2006,7 +2006,7 @@ ModuleDecl *ClangImporter::Implementation::loadModule(
   if (path.front().Item == ctx.Id_CxxStdlib) {
     ImportPath::Builder adjustedPath(ctx.getIdentifier("std"), importLoc);
     adjustedPath.append(path.getSubmodulePath());
-    path = adjustedPath.get().getModulePath(ImportKind::Module);
+    path = adjustedPath.copyTo(ctx).getModulePath(ImportKind::Module);
   }
 
   if (!DisableSourceImport)


### PR DESCRIPTION
e3c58386 introduced an ASAN error:
```
ERROR: AddressSanitizer: stack-use-after-scope on address ...
in swift::ClangImporter::Implementation::loadModuleClang ...
SUMMARY: AddressSanitizer: stack-use-after-scope ClangImporter.cpp:1903 in swift::ClangImporter::Implementation::loadModuleClang
```

rdar://99986478