### PR TITLE
[cxx-interop] Make `Cxx` Swift library static

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -481,15 +481,25 @@ void IRGenModule::emitSourceFile(SourceFile &SF) {
     this->addLinkLibrary(LinkLibrary("objc", LibraryKind::Library));
 
   // If C++ interop is enabled, add -lc++ on Darwin and -lstdc++ on linux.
+  // Also link with C++ bridging utility module (Cxx) and C++ stdlib overlay
+  // (std) if available.
   if (Context.LangOpts.EnableCXXInterop) {
-    if (Context.LangOpts.Target.isOSDarwin())
+    const llvm::Triple &target = Context.LangOpts.Target;
+    if (target.isOSDarwin())
       this->addLinkLibrary(LinkLibrary("c++", LibraryKind::Library));
-    else if (Context.LangOpts.Target.isOSLinux())
+    else if (target.isOSLinux())
       this->addLinkLibrary(LinkLibrary("stdc++", LibraryKind::Library));
 
     // Do not try to link Cxx with itself.
     if (!getSwiftModule()->getName().is("Cxx"))
       this->addLinkLibrary(LinkLibrary("swiftCxx", LibraryKind::Library));
+
+    // Only link with std on platforms where the overlay is available.
+    // Do not try to link std with itself.
+    if ((target.isOSDarwin() || target.isOSLinux()) &&
+        !getSwiftModule()->getName().is("Cxx") &&
+        !getSwiftModule()->getName().is("std"))
+      this->addLinkLibrary(LinkLibrary("swiftstd", LibraryKind::Library));
   }
 
   // FIXME: It'd be better to have the driver invocation or build system that

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -689,6 +689,7 @@ function(add_swift_target_library_single target name)
         OBJECT_LIBRARY
         SHARED
         STATIC
+        NO_LINK_NAME
         INSTALL_WITH_SHARED)
   set(SWIFTLIB_SINGLE_single_parameter_options
         ARCHITECTURE
@@ -727,6 +728,8 @@ function(add_swift_target_library_single target name)
 
   translate_flag(${SWIFTLIB_SINGLE_STATIC} "STATIC"
                  SWIFTLIB_SINGLE_STATIC_keyword)
+  translate_flag(${SWIFTLIB_SINGLE_NO_LINK_NAME} "NO_LINK_NAME"
+                 SWIFTLIB_SINGLE_NO_LINK_NAME_keyword)
   if(DEFINED SWIFTLIB_SINGLE_BOOTSTRAPPING)
     set(BOOTSTRAPPING_arg "BOOTSTRAPPING" ${SWIFTLIB_SINGLE_BOOTSTRAPPING})
   endif()
@@ -896,6 +899,7 @@ function(add_swift_target_library_single target name)
       ${SWIFTLIB_SINGLE_IS_SDK_OVERLAY_keyword}
       ${embed_bitcode_arg}
       ${SWIFTLIB_SINGLE_STATIC_keyword}
+      ${SWIFTLIB_SINGLE_NO_LINK_NAME_keyword}
       ENABLE_LTO "${SWIFTLIB_SINGLE_ENABLE_LTO}"
       INSTALL_IN_COMPONENT "${install_in_component}"
       MACCATALYST_BUILD_FLAVOR "${SWIFTLIB_SINGLE_MACCATALYST_BUILD_FLAVOR}"
@@ -1124,7 +1128,7 @@ function(add_swift_target_library_single target name)
   # Set compile and link flags for the non-static target.
   # Do these LAST.
   set(target_static)
-  if(SWIFTLIB_SINGLE_IS_STDLIB AND SWIFTLIB_SINGLE_STATIC)
+  if(SWIFTLIB_SINGLE_IS_STDLIB AND SWIFTLIB_SINGLE_STATIC AND NOT SWIFTLIB_SINGLE_INSTALL_WITH_SHARED)
     set(target_static "${target}-static")
 
     # We have already compiled Swift sources.  Link everything into a static
@@ -1643,6 +1647,7 @@ function(add_swift_target_library name)
         OBJECT_LIBRARY
         SHARED
         STATIC
+        NO_LINK_NAME
         INSTALL_WITH_SHARED)
   set(SWIFTLIB_single_parameter_options
         DEPLOYMENT_VERSION_IOS
@@ -2137,6 +2142,7 @@ function(add_swift_target_library name)
         ${name}
         ${SWIFTLIB_SHARED_keyword}
         ${SWIFTLIB_STATIC_keyword}
+        ${SWIFTLIB_NO_LINK_NAME_keyword}
         ${SWIFTLIB_OBJECT_LIBRARY_keyword}
         ${SWIFTLIB_INSTALL_WITH_SHARED_keyword}
         ${SWIFTLIB_SOURCES}
@@ -2405,19 +2411,14 @@ function(add_swift_target_library name)
       # If we built static variants of the library, create a lipo target for
       # them.
       set(lipo_target_static)
-      if (SWIFTLIB_IS_STDLIB AND SWIFTLIB_STATIC)
+      if (SWIFTLIB_IS_STDLIB AND SWIFTLIB_STATIC AND NOT SWIFTLIB_INSTALL_WITH_SHARED)
         set(THIN_INPUT_TARGETS_STATIC)
         foreach(TARGET ${THIN_INPUT_TARGETS})
           list(APPEND THIN_INPUT_TARGETS_STATIC "${TARGET}-static")
         endforeach()
 
-        if(SWIFTLIB_INSTALL_WITH_SHARED)
-          set(install_subdir "swift")
-          set(universal_subdir ${SWIFTLIB_DIR})
-        else()
-          set(install_subdir "swift_static")
-          set(universal_subdir ${SWIFTSTATICLIB_DIR})
-        endif()
+        set(install_subdir "swift_static")
+        set(universal_subdir ${SWIFTSTATICLIB_DIR})
 
         set(lipo_target_static
             "${name}-${library_subdir}-static")

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -49,7 +49,7 @@ function(handle_swift_sources
     dependency_sibgen_target_out_var_name
     sourcesvar externalvar name)
   cmake_parse_arguments(SWIFTSOURCES
-      "IS_MAIN;IS_STDLIB;IS_STDLIB_CORE;IS_SDK_OVERLAY;EMBED_BITCODE;STATIC"
+      "IS_MAIN;IS_STDLIB;IS_STDLIB_CORE;IS_SDK_OVERLAY;EMBED_BITCODE;STATIC;NO_LINK_NAME"
       "SDK;ARCHITECTURE;INSTALL_IN_COMPONENT;MACCATALYST_BUILD_FLAVOR;BOOTSTRAPPING"
       "DEPENDS;COMPILE_FLAGS;MODULE_NAME;ENABLE_LTO"
       ${ARGN})
@@ -63,6 +63,7 @@ function(handle_swift_sources
                  EMBED_BITCODE_arg)
   translate_flag(${SWIFTSOURCES_STATIC} "STATIC"
                  STATIC_arg)
+  translate_flag(${SWIFTSOURCES_NO_LINK_NAME} "NO_LINK_NAME" NO_LINK_NAME_arg)
   if(DEFINED SWIFTSOURCES_BOOTSTRAPPING)
     set(BOOTSTRAPPING_arg "BOOTSTRAPPING" ${SWIFTSOURCES_BOOTSTRAPPING})
   endif()
@@ -95,7 +96,7 @@ function(handle_swift_sources
   endforeach()
 
   set(swift_compile_flags ${SWIFTSOURCES_COMPILE_FLAGS})
-  if (NOT SWIFTSOURCES_IS_MAIN)
+  if (NOT SWIFTSOURCES_IS_MAIN AND NOT SWIFTSOURCES_NO_LINK_NAME)
     list(APPEND swift_compile_flags "-module-link-name" "${name}")
   endif()
 
@@ -364,6 +365,8 @@ endfunction()
 #     [EMBED_BITCODE]                   # Embed LLVM bitcode into the .o files
 #     [STATIC]                          # Also write .swiftmodule etc. to static
 #                                       # resource folder
+#     [NO_LINK_NAME]                    # Do not pass -module-link-name flag.
+#                                       # This disables emission of force load symbol.
 #     )
 function(_compile_swift_files
     dependency_target_out_var_name dependency_module_target_out_var_name
@@ -372,7 +375,7 @@ function(_compile_swift_files
   cmake_parse_arguments(SWIFTFILE
     "IS_MAIN;IS_STDLIB;IS_STDLIB_CORE;IS_SDK_OVERLAY;EMBED_BITCODE;STATIC"
     "OUTPUT;MODULE_NAME;INSTALL_IN_COMPONENT;MACCATALYST_BUILD_FLAVOR;BOOTSTRAPPING"
-    "SOURCES;FLAGS;DEPENDS;SDK;ARCHITECTURE;OPT_FLAGS;MODULE_DIR"
+    "SOURCES;FLAGS;DEPENDS;SDK;ARCHITECTURE;OPT_FLAGS;MODULE_DIR;NO_LINK_NAME"
     ${ARGN})
 
   # Check arguments.

--- a/stdlib/public/Cxx/CMakeLists.txt
+++ b/stdlib/public/Cxx/CMakeLists.txt
@@ -1,4 +1,9 @@
-add_swift_target_library(swiftCxx ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+set(SWIFT_CXX_LIBRARY_KIND STATIC)
+if("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "WINDOWS")
+  set(SWIFT_CXX_LIBRARY_KIND SHARED)
+endif()
+
+add_swift_target_library(swiftCxx ${SWIFT_CXX_LIBRARY_KIND} NO_LINK_NAME IS_STDLIB
     CxxConvertibleToCollection.swift
     CxxRandomAccessCollection.swift
     CxxSequence.swift
@@ -10,7 +15,8 @@ add_swift_target_library(swiftCxx ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_OVE
     -Xcc -nostdinc++
 
     LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
-    INSTALL_IN_COMPONENT sdk-overlay)
+    INSTALL_IN_COMPONENT sdk-overlay
+    INSTALL_WITH_SHARED)
 
 add_subdirectory(std)
 add_subdirectory(cxxshim)

--- a/stdlib/public/Cxx/std/CMakeLists.txt
+++ b/stdlib/public/Cxx/std/CMakeLists.txt
@@ -127,7 +127,7 @@ add_dependencies(sdk-overlay libstdcxx-modulemap)
 #
 # C++ Standard Library Overlay.
 #
-add_swift_target_library(swiftstd ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_OVERLAY
+add_swift_target_library(swiftstd STATIC NO_LINK_NAME IS_STDLIB
     std.swift
     String.swift
 
@@ -148,4 +148,5 @@ add_swift_target_library(swiftstd ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_SDK_OVE
     LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
     TARGET_SDKS ALL_APPLE_PLATFORMS LINUX
     INSTALL_IN_COMPONENT sdk-overlay
+    INSTALL_WITH_SHARED
     DEPENDS libstdcxx-modulemap)

--- a/test/Interop/Cxx/stdlib/overlay/std-string-overlay.swift
+++ b/test/Interop/Cxx/stdlib/overlay/std-string-overlay.swift
@@ -1,4 +1,8 @@
-// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none)
+// FIXME: Cannot use target-run-simple-swift as it causes a runtime crash (https://github.com/apple/swift/issues/52881)
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -I %S/Inputs -o %t/std-string-overlay -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none
+// RUN: %target-codesign %t/std-string-overlay
+// RUN: %target-run %t/std-string-overlay
 //
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx || OS=linux-gnu


### PR DESCRIPTION
Instead of a dynamic `swiftCxx.dylib` library, let's build a static library to simplify backdeployment and reduce potential compatibility difficulties in the future.