### PR TITLE
[Sema] Skip adding solutions to completion callback if needed

### DIFF
--- a/include/swift/Sema/CompletionContextFinder.h
+++ b/include/swift/Sema/CompletionContextFinder.h
@@ -91,6 +91,10 @@ public:
     return CompletionNode.dyn_cast<const KeyPathExpr *>() != nullptr;
   }
 
+  bool hasCompletion() const {
+    return !CompletionNode.isNull();
+  }
+
   /// If we are completing in a key path, returns the \c KeyPath that contains
   /// the code completion component.
   const KeyPathExpr *getKeyPathContainingCompletionComponent() const {

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -2361,9 +2361,11 @@ Optional<BraceStmt *> TypeChecker::applyResultBuilderBodyTransform(
     cs.solveForCodeCompletion(solutions);
 
     CompletionContextFinder analyzer(func, func->getDeclContext());
-    filterSolutionsForCodeCompletion(solutions, analyzer);
-    for (const auto &solution : solutions) {
-      cs.getASTContext().CompletionCallback->sawSolution(solution);
+    if (analyzer.hasCompletion()) {
+      filterSolutionsForCodeCompletion(solutions, analyzer);
+      for (const auto &solution : solutions) {
+        cs.getASTContext().CompletionCallback->sawSolution(solution);
+      }
     }
     return nullptr;
   }

--- a/lib/Sema/CompletionContextFinder.cpp
+++ b/lib/Sema/CompletionContextFinder.cpp
@@ -71,7 +71,6 @@ CompletionContextFinder::walkToExprPost(Expr *E) {
 }
 
 size_t CompletionContextFinder::getKeyPathCompletionComponentIndex() const {
-  assert(hasCompletionKeyPathComponent());
   size_t ComponentIndex = 0;
   auto Components = getKeyPathContainingCompletionComponent()->getComponents();
   for (auto &Component : Components) {

--- a/lib/Sema/TypeCheckCodeCompletion.cpp
+++ b/lib/Sema/TypeCheckCodeCompletion.cpp
@@ -518,7 +518,6 @@ static bool hasTypeForCompletion(Solution &solution,
   if (contextAnalyzer.hasCompletionExpr()) {
     return solution.hasType(contextAnalyzer.getCompletionExpr());
   } else {
-    assert(contextAnalyzer.hasCompletionKeyPathComponent());
     return solution.hasType(
         contextAnalyzer.getKeyPathContainingCompletionComponent(),
         contextAnalyzer.getKeyPathCompletionComponentIndex());
@@ -578,8 +577,7 @@ bool TypeChecker::typeCheckForCodeCompletion(
 
   // If there was no completion expr (e.g. if the code completion location was
   // among tokens that were skipped over during parser error recovery) bail.
-  if (!contextAnalyzer.hasCompletionExpr() &&
-      !contextAnalyzer.hasCompletionKeyPathComponent())
+  if (!contextAnalyzer.hasCompletion())
     return false;
 
   // Interpolation components are type-checked separately.


### PR DESCRIPTION
If `CompletionContextFinder` fails to find a `CompletionNode`, skip trying to filter and add solutions to the completion callback. This prevents an assertion/crash in `filterSolutionsForCodeCompletion` which assumes `CompletionNode` is non-null (either an expression or keypath).

Resolves rdar://99966094.