### PR TITLE
[Sanitizer] Deflake TSan test

### DIFF
--- a/test/Sanitizers/tsan/libdispatch.swift
+++ b/test/Sanitizers/tsan/libdispatch.swift
@@ -49,5 +49,5 @@ for _ in 1...10 {
 
 print("Done!")
 
-// CHECK: ThreadSanitizer: data race
-// CHECK: Done!
+// CHECK-DAG: ThreadSanitizer: data race
+// CHECK-DAG: Done!


### PR DESCRIPTION
This test does:
```
race()
print("Done!")

// CHECK: ThreadSanitizer: data race
// CHECK: Done!
```

We see some recent cases where the output of the test binary on iOS devices was:
```
Done!
==================
WARNING: ThreadSanitizer: data race
…
```

So apparently the TSan report output is not guaranteed to be printed before "Done!".  Maybe this is because we print "Done!" on stdout and the sanitizer report on stderr?

The remaining question is: what changed that we are seeing this issue now, but not previously?

rdar://99713724