### PR TITLE
Disable SROA debug info for variables with expressions

### DIFF
--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -169,10 +169,11 @@ SILDebugVariable::createFromAllocation(const AllocationInst *AI) {
   // TODO: Support AllocBoxInst
 
   if (!VarInfo)
-    return VarInfo;
+    return {};
 
-  // Copy everything but the DIExpr
-  VarInfo->DIExpr.clear();
+  // TODO: Support variables with expressions.
+  if (VarInfo->DIExpr)
+    return {};
 
   // Coalesce the debug loc attached on AI into VarInfo
   SILType Type = AI->getType();

--- a/lib/SILOptimizer/Transforms/SILSROA.cpp
+++ b/lib/SILOptimizer/Transforms/SILSROA.cpp
@@ -213,9 +213,8 @@ createAllocas(llvm::SmallVector<AllocStackInst *, 4> &NewAllocations) {
       Optional<SILDebugVariable> NewDebugVarInfo =
           SILDebugVariable::createFromAllocation(AI);
       if (NewDebugVarInfo)
-        // TODO: Handle DIExpr that is already attached
-        NewDebugVarInfo->DIExpr = SILDebugInfoExpression::createFragment(VD);
-
+        NewDebugVarInfo->DIExpr.append(
+            SILDebugInfoExpression::createFragment(VD));
       NewAllocations.push_back(B.createAllocStack(
           Loc, Type.getFieldType(VD, M, TypeExpansionContext(B.getFunction())),
           NewDebugVarInfo, AI->hasDynamicLifetime(), AI->isLexical()));

--- a/test/DebugInfo/sil_based_dbg.swift
+++ b/test/DebugInfo/sil_based_dbg.swift
@@ -29,10 +29,13 @@ struct TheStruct {
 }
 // CHECK_DBG_SCOPE-LABEL: sil {{.*}}test_debug_scope
 public func test_debug_scope(val : Int) -> Int {
-    // CHECK_DBG_SCOPE: alloc_stack $Builtin.Int{{[0-9]+}}, var, (name "the_struct",
-    // CHECK_DBG_SCOPE-SAME:                                      loc
+    // TODO: Repeated SROA of the same variable is currently disabled.
+    // CHECK_DBG_SCOPE: alloc_stack $Builtin.Int{{[0-9]+}}, 
+    // CHECK_DBG_SCOPE-NOT:                          var,
+    // DISABLED_DBG_SCOPE-SAME:                      var, (name "the_struct",
+    // DISABLED_DBG_SCOPE-SAME:                      loc
     // The auxiliary debug scope should be removed
-    // CHECK_DBG_SCOPE-NOT:                                       scope {{[0-9]+}})
+    // DISABLED_DBG_SCOPE-NOT:                       scope {{[0-9]+}})
     var the_struct = TheStruct(the_member: 0)
     the_struct.the_member = val + 13
     return the_struct.the_member

--- a/test/DebugInfo/srosroa_mem2reg.sil
+++ b/test/DebugInfo/srosroa_mem2reg.sil
@@ -1,0 +1,55 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -sil-print-debuginfo -sroa %s | %FileCheck --check-prefix=CHECK-SROA %s
+sil_stage canonical
+
+import Builtin
+import Swift
+
+struct MyStruct {
+  @_hasStorage var x: Int64 { get set }
+  @_hasStorage var y: Int64 { get set }
+  init(x: Int64, y: Int64)
+}
+
+struct MyContainer {
+  @_hasStorage var z: MyStruct { get set }
+}
+
+sil_scope 1 { loc "sroa.swift":2:8 parent @MyStructInit : $@convention(method) (Int64, Int64, @thin MyStruct.Type) -> MyStruct }
+
+// MyStruct.init(x:y:)
+sil hidden @MyStructInit : $@convention(method) (Int64, Int64, @thin MyStruct.Type) -> MyStruct {
+bb0(%0 : $Int64, %1 : $Int64, %2 : $@thin MyStruct.Type):
+  %3 = struct $MyStruct (%0 : $Int64, %1 : $Int64), loc "sroa.swift":2:8, scope 1
+  return %3 : $MyStruct, loc "sroa.swift":2:8, scope 1
+} // end sil function 'MyStructInit'
+
+sil_scope 2 { loc "sroa.swift":7:6 parent @foo : $@convention(thin) (Int64, Int64) -> Int64 }
+
+// foo(in_x:in_y:)
+sil hidden @foo : $@convention(thin) (Int64, Int64) -> Int64 {
+bb0(%0 : $Int64, %1 : $Int64):
+  debug_value %0 : $Int64, let, name "in_x", argno 1, loc "sroa.swift":7:10, scope 2
+  debug_value %1 : $Int64, let, name "in_y", argno 2, loc "sroa.swift":7:21, scope 2
+  %4 = alloc_stack $MyStruct, var, name "my_struct", type $*MyContainer, expr op_fragment:#MyContainer.z, loc "sroa.swift":8:9, scope 2
+  // Recursive SROA of already SROA-ed aggregates is not yet supported.
+  // CHECK-SROA:      alloc_stack $Int64
+  // CHECK-SROA-NOT:  var,
+  // CHECK-SROA:      alloc_stack $Int64
+  // CHECK-SROA-NOT:  var,
+  // CHECK-SROA:      metatype
+  %5 = metatype $@thin MyStruct.Type, loc "sroa.swift":8:21, scope 2
+  %6 = integer_literal $Builtin.Int64, 0, loc "sroa.swift":8:33, scope 2
+  %7 = struct $Int64 (%6 : $Builtin.Int64), loc "sroa.swift":8:33, scope 2
+  %8 = integer_literal $Builtin.Int64, 0, loc "sroa.swift":8:39, scope 2
+  %9 = struct $Int64 (%8 : $Builtin.Int64), loc "sroa.swift":8:39, scope 2
+  // function_ref MyStruct.init(x:y:)
+  %10 = function_ref @MyStructInit : $@convention(method) (Int64, Int64, @thin MyStruct.Type) -> MyStruct, loc "sroa.swift":8:21, scope 2
+  %11 = apply %10(%7, %9, %5) : $@convention(method) (Int64, Int64, @thin MyStruct.Type) -> MyStruct, loc "sroa.swift":8:21, scope 2
+  store %11 to %4 : $*MyStruct, loc "sroa.swift":8:21, scope 2
+  %13 = struct_element_addr %4 : $*MyStruct, #MyStruct.x, loc "sroa.swift":9:17, scope 2
+  store %0 to %13 : $*Int64, loc "sroa.swift":9:17, scope 2
+  %15 = struct_element_addr %4 : $*MyStruct, #MyStruct.y, loc "sroa.swift":10:17, scope 2
+  store %1 to %15 : $*Int64, loc "sroa.swift":10:17, scope 2
+  dealloc_stack %4 : $*MyStruct, loc "sroa.swift":8:9, scope 2
+  return %0 : $Int64, loc "sroa.swift":11:5, scope 2
+} // end sil function 'foo'


### PR DESCRIPTION
Currently the SROA just overwrites already-existing expressions on variables. When SROA is recursively run on a data structure this leads to nonsensical expressions such as

  type $*Outer, expr op_fragment:#Inner.x

instead of

  type $*Outer, expr op_fragment:#Outer.inner op_fragment:#Inner.x

The (nonsensical) LLVM IR generated from this violates some assumptions in LLVM for example, if a struct has multiple members of the same type, you can end up with multiple dbg.declare intrinsics claiming to describe the same variable). As a quick fix, this patch detects this situation and drops the debug info. A proper fix shouldn't be too difficult to implement though.

rdar://99874371
