### PR TITLE
[5.7] SILGen: Function availability for linkage should use @_backDeploy OS version if present

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -2197,6 +2197,9 @@ public:
   /// The earliest platform version that may use the back deployed implementation.
   const llvm::VersionTuple Version;
 
+  /// Returns true if this attribute is active given the current platform.
+  bool isActivePlatform(const ASTContext &ctx) const;
+
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DAK_BackDeploy;
   }

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -836,7 +836,7 @@ public:
   /// Returns the OS version in which the decl became ABI as specified by the
   /// @_backDeploy attribute.
   Optional<llvm::VersionTuple>
-  getBackDeployBeforeOSVersion(PlatformKind Kind) const;
+  getBackDeployBeforeOSVersion(ASTContext &Ctx) const;
 
   /// Returns the starting location of the entire declaration.
   SourceLoc getStartLoc() const { return getSourceRange().Start; }

--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -19,11 +19,12 @@
 #ifndef SWIFT_SIL_SILDeclRef_H
 #define SWIFT_SIL_SILDeclRef_H
 
+#include "swift/AST/Availability.h"
 #include "swift/AST/ClangNode.h"
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/TypeAlignments.h"
-#include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/Support/PrettyStackTrace.h"
 
@@ -529,6 +530,9 @@ struct SILDeclRef {
   /// entry overridden by this method.
   static AbstractFunctionDecl *getOverriddenWitnessTableEntry(
                                                     AbstractFunctionDecl *func);
+
+  /// Returns the availability of the decl for computing linkage.
+  Optional<AvailabilityContext> getAvailabilityForLinkage() const;
 
   /// True if the referenced entity is some kind of thunk.
   bool isThunk() const;

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1683,6 +1683,10 @@ bool AvailableAttr::isActivePlatform(const ASTContext &ctx) const {
   return isPlatformActive(Platform, ctx.LangOpts);
 }
 
+bool BackDeployAttr::isActivePlatform(const ASTContext &ctx) const {
+  return isPlatformActive(Platform, ctx.LangOpts);
+}
+
 AvailableAttr *AvailableAttr::clone(ASTContext &C, bool implicit) const {
   return new (C) AvailableAttr(implicit ? SourceLoc() : AtLoc,
                                implicit ? SourceRange() : getRange(),

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -378,10 +378,10 @@ Decl::getIntroducedOSVersion(PlatformKind Kind) const {
 }
 
 Optional<llvm::VersionTuple>
-Decl::getBackDeployBeforeOSVersion(PlatformKind Kind) const {
+Decl::getBackDeployBeforeOSVersion(ASTContext &Ctx) const {
   for (auto *attr : getAttrs()) {
     if (auto *backDeployAttr = dyn_cast<BackDeployAttr>(attr)) {
-      if (backDeployAttr->Platform == Kind && backDeployAttr->Version) {
+      if (backDeployAttr->isActivePlatform(Ctx) && backDeployAttr->Version) {
         return backDeployAttr->Version;
       }
     }
@@ -389,7 +389,8 @@ Decl::getBackDeployBeforeOSVersion(PlatformKind Kind) const {
 
   // Accessors may inherit `@_backDeploy`.
   if (getKind() == DeclKind::Accessor) {
-    return cast<AccessorDecl>(this)->getStorage()->getBackDeployBeforeOSVersion(Kind);
+    return cast<AccessorDecl>(this)->getStorage()->getBackDeployBeforeOSVersion(
+        Ctx);
   }
 
   return None;
@@ -927,14 +928,20 @@ bool Decl::isStdlibDecl() const {
 }
 
 AvailabilityContext Decl::getAvailabilityForLinkage() const {
+  ASTContext &ctx = getASTContext();
+
+  // When computing availability for linkage, use the "before" version from
+  // the @_backDeploy attribute, if present.
+  if (auto backDeployVersion = getBackDeployBeforeOSVersion(ctx))
+    return AvailabilityContext{VersionRange::allGTE(*backDeployVersion)};
+
   auto containingContext =
       AvailabilityInference::annotatedAvailableRange(this, getASTContext());
   if (containingContext.hasValue()) {
-    // If this entity comes from the concurrency module, adjust it's
+    // If this entity comes from the concurrency module, adjust its
     // availability for linkage purposes up to Swift 5.5, so that we use
     // weak references any time we reference those symbols when back-deploying
     // concurrency.
-    ASTContext &ctx = getASTContext();
     if (getModuleContext()->getName() == ctx.Id_Concurrency) {
       containingContext->intersectWith(ctx.getConcurrencyAvailability());
     }

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -207,6 +207,16 @@ ASTContext &SILDeclRef::getASTContext() const {
   llvm_unreachable("Unhandled case in switch");
 }
 
+Optional<AvailabilityContext> SILDeclRef::getAvailabilityForLinkage() const {
+  // Back deployment thunks and fallbacks don't have availability since they
+  // are non-ABI.
+  // FIXME: Generalize this check to all kinds of non-ABI functions.
+  if (backDeploymentKind != SILDeclRef::BackDeploymentKind::None)
+    return None;
+
+  return getDecl()->getAvailabilityForLinkage();
+}
+
 bool SILDeclRef::isThunk() const {
   return isForeignToNativeThunk() || isNativeToForeignThunk() ||
          isDistributedThunk() || isBackDeploymentThunk();

--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -311,7 +311,9 @@ SILFunction *SILFunctionBuilder::getOrCreateFunction(
     if (constant.isForeign && decl->hasClangNode())
       F->setClangNodeOwner(decl);
 
-    F->setAvailabilityForLinkage(decl->getAvailabilityForLinkage());
+    if (auto availability = constant.getAvailabilityForLinkage())
+      F->setAvailabilityForLinkage(*availability);
+
     F->setAlwaysWeakImported(decl->isAlwaysWeakImported());
 
     if (auto *accessor = dyn_cast<AccessorDecl>(decl)) {

--- a/lib/SILGen/SILGenBackDeploy.cpp
+++ b/lib/SILGen/SILGenBackDeploy.cpp
@@ -52,8 +52,7 @@ static void emitBackDeployIfAvailableCondition(SILGenFunction &SGF,
                                                SILLocation loc,
                                                SILBasicBlock *availableBB,
                                                SILBasicBlock *unavailableBB) {
-  PlatformKind platform = targetPlatform(SGF.SGM.getASTContext().LangOpts);
-  auto version = AFD->getBackDeployBeforeOSVersion(platform);
+  auto version = AFD->getBackDeployBeforeOSVersion(SGF.SGM.getASTContext());
   VersionRange OSVersion = VersionRange::empty();
   if (version.hasValue()) {
     OSVersion = VersionRange::allGTE(*version);

--- a/test/IRGen/weak_import_back_deploy_attr.swift
+++ b/test/IRGen/weak_import_back_deploy_attr.swift
@@ -1,0 +1,22 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/Library.swiftmodule -parse-as-library %t/Library.swift -enable-library-evolution
+
+// RUN: %target-swift-frontend -primary-file %t/Client.swift -I %t -emit-ir -target %target-cpu-apple-macosx10.50 | %FileCheck %t/Client.swift --check-prefix=CHECK-OLD
+// RUN: %target-swift-frontend -primary-file %t/Client.swift -I %t -emit-ir -target %target-cpu-apple-macosx10.60 | %FileCheck %t/Client.swift --check-prefix=CHECK-NEW
+
+// REQUIRES: OS=macosx
+
+//--- Library.swift
+
+@available(macOS 10.50, *)
+@_backDeploy(before: macOS 10.60)
+public func backDeployedFunc() {}
+
+//--- Client.swift
+
+import Library
+
+// CHECK-OLD: declare extern_weak {{.*}} void @"$s7Library16backDeployedFuncyyF"()
+// CHECK-NEW: declare {{.*}} void @"$s7Library16backDeployedFuncyyF"()
+backDeployedFunc()

--- a/test/SILGen/back_deploy_attribute_accessor.swift
+++ b/test/SILGen/back_deploy_attribute_accessor.swift
@@ -8,12 +8,12 @@
 @available(macOS 10.50, *)
 public struct TopLevelStruct {
   // -- Fallback definition for TopLevelStruct.property.getter
-  // CHECK-LABEL: sil non_abi [serialized] [available 10.51] [ossa] @$s11back_deploy14TopLevelStructV8propertyACvgTwB : $@convention(method) (TopLevelStruct) -> TopLevelStruct
+  // CHECK-LABEL: sil non_abi [serialized] [ossa] @$s11back_deploy14TopLevelStructV8propertyACvgTwB : $@convention(method) (TopLevelStruct) -> TopLevelStruct
   // CHECK: bb0([[SELF:%.*]] : $TopLevelStruct):
   // CHECK:   return [[SELF]] : $TopLevelStruct
 
   // -- Back deployment thunk for TopLevelStruct.property.getter
-  // CHECK-LABEL: sil non_abi [serialized] [thunk] [available 10.51] [ossa] @$s11back_deploy14TopLevelStructV8propertyACvgTwb : $@convention(method) (TopLevelStruct) -> TopLevelStruct
+  // CHECK-LABEL: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy14TopLevelStructV8propertyACvgTwb : $@convention(method) (TopLevelStruct) -> TopLevelStruct
   // CHECK: bb0([[BB0_ARG:%.*]] : $TopLevelStruct):
   // CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 10
   // CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 52
@@ -36,7 +36,7 @@ public struct TopLevelStruct {
   // CHECK:   return [[RETURN_BB_ARG]] : $TopLevelStruct
 
   // -- Original definition of TopLevelStruct.property.getter
-  // CHECK-LABEL: sil [available 10.51] [ossa] @$s11back_deploy14TopLevelStructV8propertyACvg : $@convention(method) (TopLevelStruct) -> TopLevelStruct
+  // CHECK-LABEL: sil [available 10.52] [ossa] @$s11back_deploy14TopLevelStructV8propertyACvg : $@convention(method) (TopLevelStruct) -> TopLevelStruct
   @available(macOS 10.51, *)
   @_backDeploy(before: macOS 10.52)
   public var property: TopLevelStruct { self }

--- a/test/SILGen/back_deploy_attribute_accessor_coroutine.swift
+++ b/test/SILGen/back_deploy_attribute_accessor_coroutine.swift
@@ -8,7 +8,7 @@
 @available(macOS 10.50, *)
 public struct TopLevelStruct {
   // -- Fallback definition for TopLevelStruct.property.read
-  // CHECK-LABEL: sil non_abi [serialized] [available 10.51] [ossa] @$s11back_deploy14TopLevelStructV8propertyACvrTwB : $@yield_once @convention(method) (TopLevelStruct) -> @yields TopLevelStruct
+  // CHECK-LABEL: sil non_abi [serialized] [ossa] @$s11back_deploy14TopLevelStructV8propertyACvrTwB : $@yield_once @convention(method) (TopLevelStruct) -> @yields TopLevelStruct
   // CHECK: bb0([[BB0_ARG:%.*]] : $TopLevelStruct):
   // CHECK:   yield [[BB0_ARG]] : $TopLevelStruct, resume [[RESUME_BB:bb[0-9]+]], unwind [[UNWIND_BB:bb[0-9]+]]
   //
@@ -20,7 +20,7 @@ public struct TopLevelStruct {
   // CHECK:   unwind
 
   // -- Back deployment thunk for TopLevelStruct.property.read
-  // CHECK-LABEL: sil non_abi [serialized] [thunk] [available 10.51] [ossa] @$s11back_deploy14TopLevelStructV8propertyACvrTwb : $@yield_once @convention(method) (TopLevelStruct) -> @yields TopLevelStruct
+  // CHECK-LABEL: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy14TopLevelStructV8propertyACvrTwb : $@yield_once @convention(method) (TopLevelStruct) -> @yields TopLevelStruct
   // CHECK: bb0([[BB0_ARG:%.*]] : $TopLevelStruct):
   // CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 10
   // CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 52
@@ -63,7 +63,7 @@ public struct TopLevelStruct {
   // CHECK:   unwind
 
   // -- Original definition of TopLevelStruct.property.read
-  // CHECK-LABEL: sil [available 10.51] [ossa] @$s11back_deploy14TopLevelStructV8propertyACvr : $@yield_once @convention(method) (TopLevelStruct) -> @yields TopLevelStruct
+  // CHECK-LABEL: sil [available 10.52] [ossa] @$s11back_deploy14TopLevelStructV8propertyACvr : $@yield_once @convention(method) (TopLevelStruct) -> @yields TopLevelStruct
   @available(macOS 10.51, *)
   @_backDeploy(before: macOS 10.52)
   public var property: TopLevelStruct {

--- a/test/SILGen/back_deploy_attribute_func.swift
+++ b/test/SILGen/back_deploy_attribute_func.swift
@@ -6,13 +6,13 @@
 // REQUIRES: OS=macosx
 
 // -- Fallback definition of trivialFunc()
-// CHECK-LABEL: sil non_abi [serialized] [available 10.51] [ossa] @$s11back_deploy11trivialFuncyyFTwB : $@convention(thin) () -> ()
+// CHECK-LABEL: sil non_abi [serialized] [ossa] @$s11back_deploy11trivialFuncyyFTwB : $@convention(thin) () -> ()
 // CHECK: bb0:
 // CHECK:   [[RESULT:%.*]] = tuple ()
 // CHECK:   return [[RESULT]] : $()
 
 // -- Back deployment thunk for trivialFunc()
-// CHECK-LABEL: sil non_abi [serialized] [thunk] [available 10.51] [ossa] @$s11back_deploy11trivialFuncyyFTwb : $@convention(thin) () -> ()
+// CHECK-LABEL: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy11trivialFuncyyFTwb : $@convention(thin) () -> ()
 // CHECK: bb0:
 // CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 10
 // CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 52
@@ -36,19 +36,19 @@
 // CHECK:   return [[RESULT]] : $()
 
 // -- Original definition of trivialFunc()
-// CHECK-LABEL: sil [available 10.51] [ossa] @$s11back_deploy11trivialFuncyyF : $@convention(thin) () -> ()
+// CHECK-LABEL: sil [available 10.52] [ossa] @$s11back_deploy11trivialFuncyyF : $@convention(thin) () -> ()
 @available(macOS 10.51, *)
 @_backDeploy(before: macOS 10.52)
 public func trivialFunc() {}
 
 // -- Fallback definition of isNumber(_:)
-// CHECK-LABEL: sil non_abi [serialized] [available 10.51] [ossa] @$s11back_deploy8isNumberySbSiFTwB : $@convention(thin) (Int) -> Bool
+// CHECK-LABEL: sil non_abi [serialized] [ossa] @$s11back_deploy8isNumberySbSiFTwB : $@convention(thin) (Int) -> Bool
 // CHECK: bb0([[ARG_X:%.*]] : $Int):
 // ...
 // CHECK:   return {{%.*}} : $Bool
 
 // -- Back deployment thunk for isNumber(_:)
-// CHECK-LABEL: sil non_abi [serialized] [thunk] [available 10.51] [ossa] @$s11back_deploy8isNumberySbSiFTwb : $@convention(thin) (Int) -> Bool
+// CHECK-LABEL: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy8isNumberySbSiFTwb : $@convention(thin) (Int) -> Bool
 // CHECK: bb0([[ARG_X:%.*]] : $Int):
 // CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 10
 // CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 52
@@ -71,7 +71,7 @@ public func trivialFunc() {}
 // CHECK:   return [[RETURN_BB_ARG]] : $Bool
 
 // -- Original definition of isNumber(_:)
-// CHECK-LABEL: sil [available 10.51] [ossa] @$s11back_deploy8isNumberySbSiF : $@convention(thin) (Int) -> Bool
+// CHECK-LABEL: sil [available 10.52] [ossa] @$s11back_deploy8isNumberySbSiF : $@convention(thin) (Int) -> Bool
 @available(macOS 10.51, *)
 @_backDeploy(before: macOS 10.52)
 public func isNumber(_ x: Int) -> Bool {

--- a/test/SILGen/back_deploy_attribute_generic_func.swift
+++ b/test/SILGen/back_deploy_attribute_generic_func.swift
@@ -6,14 +6,14 @@
 // REQUIRES: OS=macosx
 
 // -- Fallback definition of genericFunc()
-// CHECK-LABEL: sil non_abi [serialized] [available 10.51] [ossa] @$s11back_deploy11genericFuncyxxlFTwB : $@convention(thin) <T> (@in_guaranteed T) -> @out T
+// CHECK-LABEL: sil non_abi [serialized] [ossa] @$s11back_deploy11genericFuncyxxlFTwB : $@convention(thin) <T> (@in_guaranteed T) -> @out T
 // CHECK: bb0([[OUT_ARG:%.*]] : $*T, [[IN_ARG:%.*]] : $*T):
 // CHECK:   copy_addr [[IN_ARG]] to [initialization] [[OUT_ARG]] : $*T
 // CHECK:   [[RESULT:%.*]] = tuple ()
 // CHECK:   return [[RESULT]] : $()
 
 // -- Back deployment thunk for genericFunc()
-// CHECK-LABEL: sil non_abi [serialized] [thunk] [available 10.51] [ossa] @$s11back_deploy11genericFuncyxxlFTwb : $@convention(thin) <T> (@in_guaranteed T) -> @out T
+// CHECK-LABEL: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy11genericFuncyxxlFTwb : $@convention(thin) <T> (@in_guaranteed T) -> @out T
 // CHECK: bb0([[OUT_ARG:%.*]] : $*T, [[IN_ARG:%.*]] : $*T):
 // CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 10
 // CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 52
@@ -37,7 +37,7 @@
 // CHECK:   return [[RESULT]] : $()
 
 // -- Original definition of genericFunc()
-// CHECK-LABEL: sil [available 10.51] [ossa] @$s11back_deploy11genericFuncyxxlF : $@convention(thin) <T> (@in_guaranteed T) -> @out T
+// CHECK-LABEL: sil [available 10.52] [ossa] @$s11back_deploy11genericFuncyxxlF : $@convention(thin) <T> (@in_guaranteed T) -> @out T
 @available(macOS 10.51, *)
 @_backDeploy(before: macOS 10.52)
 public func genericFunc<T>(_ t: T) -> T {

--- a/test/SILGen/back_deploy_attribute_struct_method.swift
+++ b/test/SILGen/back_deploy_attribute_struct_method.swift
@@ -8,13 +8,13 @@
 @available(macOS 10.50, *)
 public struct TopLevelStruct {
   // -- Fallback definition for TopLevelStruct.trivialMethod()
-  // CHECK-LABEL: sil non_abi [serialized] [available 10.51] [ossa] @$s11back_deploy14TopLevelStructV13trivialMethodyyFTwB : $@convention(method) (TopLevelStruct) -> ()
+  // CHECK-LABEL: sil non_abi [serialized] [ossa] @$s11back_deploy14TopLevelStructV13trivialMethodyyFTwB : $@convention(method) (TopLevelStruct) -> ()
   // CHECK: bb0({{%.*}} : $TopLevelStruct):
   // CHECK:   [[RESULT:%.*]] = tuple ()
   // CHECK:   return [[RESULT]] : $()
 
   // -- Back deployment thunk for TopLevelStruct.trivialMethod()
-  // CHECK-LABEL: sil non_abi [serialized] [thunk] [available 10.51] [ossa] @$s11back_deploy14TopLevelStructV13trivialMethodyyFTwb : $@convention(method) (TopLevelStruct) -> ()
+  // CHECK-LABEL: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy14TopLevelStructV13trivialMethodyyFTwb : $@convention(method) (TopLevelStruct) -> ()
   // CHECK: bb0([[BB0_ARG:%.*]] : $TopLevelStruct):
   // CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 10
   // CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 52
@@ -38,7 +38,7 @@ public struct TopLevelStruct {
   // CHECK:   return [[RESULT]] : $()
 
   // -- Original definition of TopLevelStruct.trivialMethod()
-  // CHECK-LABEL: sil [available 10.51] [ossa] @$s11back_deploy14TopLevelStructV13trivialMethodyyF : $@convention(method) (TopLevelStruct) -> ()
+  // CHECK-LABEL: sil [available 10.52] [ossa] @$s11back_deploy14TopLevelStructV13trivialMethodyyF : $@convention(method) (TopLevelStruct) -> ()
   @available(macOS 10.51, *)
   @_backDeploy(before: macOS 10.52)
   public func trivialMethod() {}

--- a/test/SILGen/back_deploy_attribute_throwing_func.swift
+++ b/test/SILGen/back_deploy_attribute_throwing_func.swift
@@ -6,13 +6,13 @@
 // REQUIRES: OS=macosx
 
 // -- Fallback definition of throwingFunc()
-// CHECK-LABEL: sil non_abi [serialized] [available 10.51] [ossa] @$s11back_deploy12throwingFuncyyKFTwB : $@convention(thin) () -> @error Error
+// CHECK-LABEL: sil non_abi [serialized] [ossa] @$s11back_deploy12throwingFuncyyKFTwB : $@convention(thin) () -> @error Error
 // CHECK: bb0:
 // CHECK:   [[RESULT:%.*]] = tuple ()
 // CHECK:   return [[RESULT]] : $()
 
 // -- Back deployment thunk for throwingFunc()
-// CHECK-LABEL: sil non_abi [serialized] [thunk] [available 10.51] [ossa] @$s11back_deploy12throwingFuncyyKFTwb : $@convention(thin) () -> @error Error
+// CHECK-LABEL: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy12throwingFuncyyKFTwb : $@convention(thin) () -> @error Error
 // CHECK: bb0:
 // CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 10
 // CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 52
@@ -49,7 +49,7 @@
 // CHECK:   throw [[RETHROW_BB_ARG]] : $Error
 
 // -- Original definition of throwingFunc()
-// CHECK-LABEL: sil [available 10.51] [ossa] @$s11back_deploy12throwingFuncyyKF : $@convention(thin) () -> @error Error
+// CHECK-LABEL: sil [available 10.52] [ossa] @$s11back_deploy12throwingFuncyyKF : $@convention(thin) () -> @error Error
 @available(macOS 10.51, *)
 @_backDeploy(before: macOS 10.52)
 public func throwingFunc() throws {}

--- a/test/attr/attr_backDeploy_evolution.swift
+++ b/test/attr/attr_backDeploy_evolution.swift
@@ -62,7 +62,7 @@
 
 // ---- (3) Run executable
 // RUN: %target-codesign %t/test_ABI
-// RUN: %target-run %t/test_ABI %t/SDK_ABI/Frameworks/BackDeployHelper.framework/BackDeployHelper | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-ABI %s
+// RUN: %target-run %t/test_ABI | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-ABI %s
 
 // ---- (4) Build famework with BackDeploy 2.0 in the future
 // RUN: mkdir -p %t/SDK_BD/Frameworks/BackDeployHelper.framework/Modules/BackDeployHelper.swiftmodule
@@ -89,9 +89,10 @@
 
 // ---- (6) Run executable
 // RUN: %target-codesign %t/test_BD
-// RUN: %target-run %t/test_BD %t/SDK_BD/Frameworks/BackDeployHelper.framework/BackDeployHelper | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-BD %s
+// RUN: %target-run %t/test_BD | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-BD %s
 
-// ---- (7) Re-build famework with the back deployed APIs stripped
+// ---- (7) Re-build framework with the back deployed APIs stripped
+// RUN: %empty-directory(%t/SDK_BD)
 // RUN: mkdir -p %t/SDK_BD/Frameworks/BackDeployHelper.framework/Modules/BackDeployHelper.swiftmodule
 // RUN: %target-build-swift-dylib(%t/SDK_BD/Frameworks/BackDeployHelper.framework/BackDeployHelper) \
 // RUN:   -emit-module-path %t/SDK_BD/Frameworks/BackDeployHelper.framework/Modules/BackDeployHelper.swiftmodule/%module-target-triple.swiftmodule \
@@ -106,7 +107,7 @@
 
 // ---- (8) Re-run executable
 // RUN: %target-codesign %t/test_BD
-// RUN: %target-run %t/test_BD %t/SDK_BD/Frameworks/BackDeployHelper.framework/BackDeployHelper | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-BD %s
+// RUN: %target-run %t/test_BD | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-BD %s
 
 import BackDeployHelper
 


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/61169.

When computing the availability of a `SILFunction` for linkage the OS version specified in the `@_backDeploy` attribute should be preferred over the version in the `@available` attribute. This ensures that the corresponding symbol is weakly linked when deploying to older OSes than the back deploy "before" version.

Resolves rdar://99962885