### PR TITLE
Add -e flag for new driver

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -241,6 +241,9 @@ def tools_directory : Separate<["-"], "tools-directory">,
 
 def D : JoinedOrSeparate<["-"], "D">, Flags<[FrontendOption]>,
   HelpText<"Marks a conditional compilation flag as true">;
+  
+def e : JoinedOrSeparate<["-"], "e">, Flags<[NewDriverOnlyOption]>,
+  HelpText<"Executes a line of code provided on the command line">;
 
 def F : JoinedOrSeparate<["-"], "F">,
   Flags<[FrontendOption, ArgumentIsPath, SwiftAPIExtractOption, SwiftSymbolGraphExtractOption, SwiftAPIDigesterOption]>,


### PR DESCRIPTION
Matches apple/swift-driver#1188.


Resolves https://github.com/apple/swift/issues/48430