### PR TITLE
Use `Action::Stop` in more places

### DIFF
--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -287,11 +287,8 @@ class NameMatcher: public ASTWalker {
   PreWalkResult<Expr *> walkToExprPre(Expr *E) override;
   PostWalkResult<Expr *> walkToExprPost(Expr *E) override;
   PreWalkAction walkToDeclPre(Decl *D) override;
-  PostWalkAction walkToDeclPost(Decl *D) override;
   PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override;
-  PostWalkResult<Stmt *> walkToStmtPost(Stmt *S) override;
   PreWalkAction walkToTypeReprPre(TypeRepr *T) override;
-  PostWalkAction walkToTypeReprPost(TypeRepr *T) override;
   PreWalkResult<Pattern *> walkToPatternPre(Pattern *P) override;
   bool shouldWalkIntoGenericParams() override { return true; }
 

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -94,31 +94,37 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
     }
   };
 
+  LLVM_NODISCARD
   Expr *visit(Expr *E) {
     SetParentRAII SetParent(Walker, E);
     return inherited::visit(E);
   }
 
+  LLVM_NODISCARD
   Stmt *visit(Stmt *S) {
     SetParentRAII SetParent(Walker, S);
     return inherited::visit(S);
   }
-  
+
+  LLVM_NODISCARD
   Pattern *visit(Pattern *P) {
     SetParentRAII SetParent(Walker, P);
     return inherited::visit(P);
   }
 
+  LLVM_NODISCARD
   bool visit(Decl *D) {
     SetParentRAII SetParent(Walker, D);
     return inherited::visit(D);
   }
-  
+
+  LLVM_NODISCARD
   bool visit(TypeRepr *T) {
     SetParentRAII SetParent(Walker, T);
     return inherited::visit(T);
   }
-  
+
+  LLVM_NODISCARD
   bool visit(ParameterList *PL) {
     return inherited::visit(PL);
   }
@@ -127,17 +133,20 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   //                                 Decls
   //===--------------------------------------------------------------------===//
 
+  LLVM_NODISCARD
   bool visitGenericParamListIfNeeded(GenericContext *GC) {
     // Must check this first in case extensions have not been bound yet
     if (Walker.shouldWalkIntoGenericParams()) {
       if (auto *params = GC->getParsedGenericParams()) {
-        doIt(params);
+        if (doIt(params))
+          return true;
       }
       return true;
     }
     return false;
   }
 
+  LLVM_NODISCARD
   bool visitTrailingRequirements(GenericContext *GC) {
     if (const auto Where = GC->getTrailingWhereClause()) {
       for (auto &Req: Where->getRequirements())
@@ -368,7 +377,9 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   bool visitSubscriptDecl(SubscriptDecl *SD) {
     bool WalkGenerics = visitGenericParamListIfNeeded(SD);
 
-    visit(SD->getIndices());
+    if (visit(SD->getIndices()))
+      return true;
+
     if (auto *const TyR = SD->getElementTypeRepr())
       if (doIt(TyR))
         return true;
@@ -399,9 +410,12 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
         // accessor generics are visited from the storage decl
         !isa<AccessorDecl>(AFD) && visitGenericParamListIfNeeded(AFD);
 
-    if (auto *PD = AFD->getImplicitSelfDecl(/*createIfNeeded=*/false))
-      visit(PD);
-    visit(AFD->getParameters());
+    if (auto *PD = AFD->getImplicitSelfDecl(/*createIfNeeded=*/false)) {
+      if (visit(PD))
+        return true;
+    }
+    if (visit(AFD->getParameters()))
+      return true;
 
     if (auto *FD = dyn_cast<FuncDecl>(AFD)) {
       if (!isa<AccessorDecl>(FD))
@@ -436,7 +450,8 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
 
   bool visitEnumElementDecl(EnumElementDecl *ED) {
     if (auto *PL = ED->getParameterList()) {
-      visit(PL);
+      if (visit(PL))
+        return true;
     }
 
     if (auto *rawLiteralExpr = ED->getRawValueUnchecked()) {
@@ -857,7 +872,8 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   }
 
   Expr *visitClosureExpr(ClosureExpr *expr) {
-    visit(expr->getParameters());
+    if (visit(expr->getParameters()))
+      return nullptr;
 
     if (expr->hasExplicitResultType()) {
       if (doIt(expr->getExplicitResultTypeRepr()))
@@ -1249,6 +1265,7 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   template <typename T>
   using PostWalkResult = ASTWalker::PostWalkResult<T>;
 
+  LLVM_NODISCARD
   bool traverse(PreWalkAction Pre, llvm::function_ref<bool(void)> VisitChildren,
                 llvm::function_ref<PostWalkAction(void)> WalkPost) {
     switch (Pre.Action) {
@@ -1271,6 +1288,7 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   }
 
   template <typename T>
+  LLVM_NODISCARD
   T *traverse(PreWalkResult<T *> Pre,
               llvm::function_ref<T *(T *)> VisitChildren,
               llvm::function_ref<PostWalkResult<T *>(T *)> WalkPost) {
@@ -1299,6 +1317,7 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
     llvm_unreachable("Unhandled case in switch!");
   }
 
+  LLVM_NODISCARD
   bool visitParameterList(ParameterList *PL) {
     return traverse(
         Walker.walkToParameterListPre(PL),
@@ -1316,6 +1335,7 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
 public:
   Traversal(ASTWalker &walker) : Walker(walker) {}
 
+  LLVM_NODISCARD
   Expr *doIt(Expr *E) {
     return traverse<Expr>(
         Walker.walkToExprPre(E),
@@ -1323,6 +1343,7 @@ public:
         [&](Expr *E) { return Walker.walkToExprPost(E); });
   }
 
+  LLVM_NODISCARD
   Stmt *doIt(Stmt *S) {
     return traverse<Stmt>(
         Walker.walkToStmtPre(S),
@@ -1350,6 +1371,7 @@ public:
   }
 
   /// Returns true on failure.
+  LLVM_NODISCARD
   bool doIt(Decl *D) {
     if (shouldSkip(D))
       return false;
@@ -1359,7 +1381,8 @@ public:
         [&]() { return visit(D); },
         [&]() { return Walker.walkToDeclPost(D); });
   }
-  
+
+  LLVM_NODISCARD
   Pattern *doIt(Pattern *P) {
     return traverse<Pattern>(
         Walker.walkToPatternPre(P),
@@ -1367,6 +1390,7 @@ public:
         [&](Pattern *P) { return Walker.walkToPatternPost(P); });
   }
 
+  LLVM_NODISCARD
   bool doIt(const StmtCondition &C) {
     for (auto &elt : C) {
       switch (elt.getKind()) {
@@ -1398,13 +1422,15 @@ public:
   }
 
   /// Returns true on failure.
+  LLVM_NODISCARD
   bool doIt(TypeRepr *T) {
     return traverse(
         Walker.walkToTypeReprPre(T),
         [&]() { return visit(T); },
         [&]() { return Walker.walkToTypeReprPost(T); });
   }
-  
+
+  LLVM_NODISCARD
   bool doIt(RequirementRepr &Req) {
     switch (Req.getKind()) {
     case RequirementReprKind::SameType:
@@ -1423,6 +1449,7 @@ public:
     return false;
   }
 
+  LLVM_NODISCARD
   bool doIt(GenericParamList *GPL) {
     // Visit generic params
     for (auto &P : GPL->getParams()) {
@@ -1439,6 +1466,7 @@ public:
     return false;
   }
 
+  LLVM_NODISCARD
   ArgumentList *visit(ArgumentList *ArgList) {
     for (auto Idx : indices(*ArgList)) {
       auto *E = doIt(ArgList->getExpr(Idx));
@@ -1448,6 +1476,7 @@ public:
     return ArgList;
   }
 
+  LLVM_NODISCARD
   ArgumentList *doIt(ArgumentList *ArgList) {
     return traverse<ArgumentList>(
         Walker.walkToArgumentListPre(ArgList),
@@ -2001,12 +2030,12 @@ Pattern *Pattern::walk(ASTWalker &walker) {
 }
 
 TypeRepr *TypeRepr::walk(ASTWalker &walker) {
-  Traversal(walker).doIt(this);
+  (void)Traversal(walker).doIt(this);
   return this;
 }
 
 StmtConditionElement *StmtConditionElement::walk(ASTWalker &walker) {
-  Traversal(walker).doIt(*this);
+  (void)Traversal(walker).doIt(*this);
   return this;
 }
 

--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -476,8 +476,6 @@ private:
   }
 
   PreWalkAction walkToDeclPre(Decl *D) override {
-    // TODO: Can we use Action::Stop instead of Action::SkipChildren in this
-    // function?
     if (!walkCustomAttributes(D))
       return Action::SkipChildren();
 
@@ -504,32 +502,32 @@ private:
       if (SafeToAskForGenerics) {
         if (auto *GP = GC->getParsedGenericParams()) {
           if (!handleAngles(GP->getLAngleLoc(), GP->getRAngleLoc(), ContextLoc))
-            return Action::SkipChildren();
+            return Action::Stop();
         }
       }
     }
 
     if (auto *NTD = dyn_cast<NominalTypeDecl>(D)) {
       if (!handleBraces(NTD->getBraces(), ContextLoc))
-        return Action::SkipChildren();
+        return Action::Stop();
     } else if (auto *ED = dyn_cast<ExtensionDecl>(D)) {
       if (!handleBraces(ED->getBraces(), ContextLoc))
-        return Action::SkipChildren();
+        return Action::Stop();
     } else if (auto *VD = dyn_cast<VarDecl>(D)) {
       if (!handleBraces(VD->getBracesRange(), VD->getNameLoc()))
-        return Action::SkipChildren();
+        return Action::Stop();
     } else if (isa<AbstractFunctionDecl>(D) || isa<SubscriptDecl>(D)) {
       if (isa<SubscriptDecl>(D)) {
         if (!handleBraces(cast<SubscriptDecl>(D)->getBracesRange(), ContextLoc))
-          return Action::SkipChildren();
+          return Action::Stop();
       }
       auto *PL = getParameterList(cast<ValueDecl>(D));
       if (!handleParens(PL->getLParenLoc(), PL->getRParenLoc(), ContextLoc))
-        return Action::SkipChildren();
+        return Action::Stop();
     } else if (auto *PGD = dyn_cast<PrecedenceGroupDecl>(D)) {
       SourceRange Braces(PGD->getLBraceLoc(), PGD->getRBraceLoc());
       if (!handleBraces(Braces, ContextLoc))
-        return Action::SkipChildren();
+        return Action::Stop();
     } else if (auto *PDD = dyn_cast<PoundDiagnosticDecl>(D)) {
       // TODO: add paren locations to PoundDiagnosticDecl
     }
@@ -683,20 +681,18 @@ private:
   }
 
   PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
-    // TODO: Can we use Action::Stop instead of Action::SkipChildren in this
-    // function?
     if (auto *TT = dyn_cast<TupleTypeRepr>(T)) {
       SourceRange Parens = TT->getParens();
       if (!handleParens(Parens.Start, Parens.End, Parens.Start))
-        return Action::SkipChildren();
+        return Action::Stop();
     } else if (isa<ArrayTypeRepr>(T) || isa<DictionaryTypeRepr>(T)) {
       if (!handleSquares(T->getStartLoc(), T->getEndLoc(), T->getStartLoc()))
-        return Action::SkipChildren();
+        return Action::Stop();
     } else if (auto *GI = dyn_cast<GenericIdentTypeRepr>(T)) {
       SourceLoc ContextLoc = GI->getNameLoc().getBaseNameLoc();
       SourceRange Brackets = GI->getAngleBrackets();
       if (!handleAngles(Brackets.Start, Brackets.End, ContextLoc))
-        return Action::SkipChildren();
+        return Action::Stop();
     }
     return Action::Continue();
   }

--- a/lib/Sema/InstrumenterSupport.cpp
+++ b/lib/Sema/InstrumenterSupport.cpp
@@ -55,20 +55,17 @@ class ErrorFinder : public ASTWalker {
 public:
   ErrorFinder() {}
   PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
-    if (isa<ErrorExpr>(E) || !E->getType() || E->getType()->hasError()) {
+    if (isa<ErrorExpr>(E) || !E->getType() || E->getType()->hasError())
       error = true;
-      return Action::SkipChildren(E);
-    }
-    return Action::Continue(E);
+
+    return Action::StopIf(error, E);
   }
   PreWalkAction walkToDeclPre(Decl *D) override {
     if (auto *VD = dyn_cast<ValueDecl>(D)) {
-      if (!VD->hasInterfaceType() || VD->getInterfaceType()->hasError()) {
+      if (!VD->hasInterfaceType() || VD->getInterfaceType()->hasError())
         error = true;
-        return Action::SkipChildren();
-      }
     }
-    return Action::Continue();
+    return Action::StopIf(error);
   }
   bool hadError() { return error; }
 };


### PR DESCRIPTION
This used to be something we couldn't express in certain walker methods. Update various places where we can now use it.