### PR TITLE
Fixing Cxx Interop Tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,6 +43,10 @@ function(get_test_dependencies SDK result_var_name)
     list(APPEND deps SwiftUnitTests)
   endif()
 
+  if(SWIFT_BUILD_SDK_OVERLAY OR SWIFT_BUILD_TEST_SUPPORT_MODULES)
+    list(APPEND deps sdk-overlay)
+  endif()
+
   set(deps_binaries)
 
   if (SWIFT_INCLUDE_TOOLS)

--- a/test/Interop/Cxx/class/constructors-copy-irgen.swift
+++ b/test/Interop/Cxx/class/constructors-copy-irgen.swift
@@ -4,6 +4,9 @@
 // RUN: %swift -module-name Swift -target armv7-none-linux-androideabi -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=ITANIUM_ARM
 // RUN: %swift -module-name Swift -target x86_64-unknown-windows-msvc -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=MICROSOFT_X64
 
+// REQUIRES: CODEGENERATOR=X86
+// REQUIRES: CODEGENERATOR=ARM
+
 import Constructors
 import TypeClassification
 

--- a/test/Interop/Cxx/class/constructors-irgen.swift
+++ b/test/Interop/Cxx/class/constructors-irgen.swift
@@ -4,6 +4,9 @@
 // RUN: %swift -module-name Swift -target armv7-unknown-linux-androideabi -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=ITANIUM_ARM
 // RUN: %swift -module-name Swift -target x86_64-unknown-windows-msvc -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=MICROSOFT_X64
 
+// REQUIRES: CODEGENERATOR=X86
+// REQUIRES: CODEGENERATOR=ARM
+
 import Constructors
 import TypeClassification
 


### PR DESCRIPTION
Some of the Cxx interop tests were failing locally due to a missing dependency on the libcxx-modulemap created as part of the sdk-overlay target, and adding generator checks to constructor-copy-irgen and constructor-irgen tests to ensure we have the necessary backends enabled.

rdar://100076403