### PR TITLE
New parser build cleanups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -872,8 +872,14 @@ endif()
 
 # When we have the early SwiftSyntax build, we can include its parser.
 if(SWIFT_PATH_TO_EARLYSWIFTSYNTAX_BUILD_DIR)
-  set(SWIFT_SWIFT_PARSER TRUE)
-  include(${SWIFT_PATH_TO_EARLYSWIFTSYNTAX_BUILD_DIR}/cmake/SwiftSyntaxTargets.cmake)
+  set(SWIFT_PATH_TO_EARLYSWIFTSYNTAX_TARGETS
+    ${SWIFT_PATH_TO_EARLYSWIFTSYNTAX_BUILD_DIR}/cmake/SwiftSyntaxTargets.cmake)
+  if(NOT EXISTS "${SWIFT_PATH_TO_EARLYSWIFTSYNTAX_TARGETS}")
+    message(STATUS "Skipping Swift Swift parser integration due to missing early SwiftSyntax")
+  else()
+    set(SWIFT_SWIFT_PARSER TRUE)
+    include(${SWIFT_PATH_TO_EARLYSWIFTSYNTAX_TARGETS})
+  endif()
 endif()
 
 

--- a/cmake/modules/AddSwiftUnittests.cmake
+++ b/cmake/modules/AddSwiftUnittests.cmake
@@ -81,6 +81,7 @@ function(add_swift_unittest test_dirname)
 
   if (SWIFT_SWIFT_PARSER)
     _add_swift_runtime_link_flags(${test_dirname} "../../lib" "")
+    set_property(TARGET ${test_dirname} PROPERTY BUILD_WITH_INSTALL_RPATH OFF)
   endif()
 endfunction()
 


### PR DESCRIPTION
Two cleanups to the build that includes the new parser:
* [Unit tests] Use the rpaths determined for unit tests
* [CMake] Disable the new Swift Swift parser if we can't find its targets file