### PR TITLE
[Sema] Do not attempt openning same generic argument twice while checking default parameter

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -548,6 +548,10 @@ Type TypeChecker::typeCheckParameterDefault(Expr *&defaultValue,
     assert(!type->is<UnboundGenericType>());
 
     if (auto *GP = type->getAs<GenericTypeParamType>()) {
+      auto openedVar = genericParameters.find(getCanonicalGenericParamTy(GP));
+      if (openedVar != genericParameters.end()) {
+        return openedVar->second;
+      }
       return cs.openGenericParameter(DC->getParent(), GP, genericParameters,
                                      locator);
     }

--- a/test/Constraints/type_inference_from_default_exprs.swift
+++ b/test/Constraints/type_inference_from_default_exprs.swift
@@ -233,3 +233,20 @@ class BaseStorage<T> : Storage, StorageType {
 
 final class CustomStorage<T>: BaseStorage<T> { // Ok - no crash typechecking inherited init
 }
+
+// https://github.com/apple/swift/issues/61061
+
+struct S61061<T> where T:Hashable { // expected-note{{'T' declared as parameter to type 'S'}}
+  init(x:[[T: T]] = [:]) {} // expected-error{{default argument value of type '[AnyHashable : Any]' cannot be converted to type '[[T : T]]'}}
+  // expected-error@-1{{generic parameter 'T' could not be inferred}}
+}
+
+struct S61061_1<T> where T:Hashable { // expected-note{{'T' declared as parameter to type 'S1'}}
+  init(x:[(T, T)] = [:]) {} // expected-error{{default argument value of type '[AnyHashable : Any]' cannot be converted to type '[(T, T)]'}}
+  // expected-error@-1{{generic parameter 'T' could not be inferred}}
+}
+
+// TODO(diagnostics): Should produce a conflicting types inferred for generic argument 'T'
+struct S61061_1<T> where T:Hashable {
+  init(x:[(T, T)] = [(1, "")]) {} // expected-error{{type of expression is ambiguous without more context}}
+}

--- a/test/Constraints/type_inference_from_default_exprs.swift
+++ b/test/Constraints/type_inference_from_default_exprs.swift
@@ -236,17 +236,17 @@ final class CustomStorage<T>: BaseStorage<T> { // Ok - no crash typechecking inh
 
 // https://github.com/apple/swift/issues/61061
 
-struct S61061<T> where T:Hashable { // expected-note{{'T' declared as parameter to type 'S'}}
+struct S61061<T> where T:Hashable { // expected-note{{'T' declared as parameter to type 'S61061'}}
   init(x:[[T: T]] = [:]) {} // expected-error{{default argument value of type '[AnyHashable : Any]' cannot be converted to type '[[T : T]]'}}
   // expected-error@-1{{generic parameter 'T' could not be inferred}}
 }
 
-struct S61061_1<T> where T:Hashable { // expected-note{{'T' declared as parameter to type 'S1'}}
+struct S61061_1<T> where T:Hashable { // expected-note{{'T' declared as parameter to type 'S61061_1'}}
   init(x:[(T, T)] = [:]) {} // expected-error{{default argument value of type '[AnyHashable : Any]' cannot be converted to type '[(T, T)]'}}
   // expected-error@-1{{generic parameter 'T' could not be inferred}}
 }
 
 // TODO(diagnostics): Should produce a conflicting types inferred for generic argument 'T'
-struct S61061_1<T> where T:Hashable {
+struct S61061_2<T> where T:Hashable {
   init(x:[(T, T)] = [(1, "")]) {} // expected-error{{type of expression is ambiguous without more context}}
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
Use the already opened type variable for same generic argument instead of attempting to open it twice. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves https://github.com/apple/swift/issues/61061

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
