### PR TITLE
Swift Optimizer: improve ergonomics of EscapeUtils

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeEffects.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeEffects.swift
@@ -46,8 +46,8 @@ let computeEffects = FunctionPass(name: "compute-effects", {
     if argsWithDefinedEffects.contains(arg.index) { continue }
     
     // First check: is the argument (or a projected value of it) escaping at all?
-    if !arg.at(.anything).isEscaping(using: IgnoreRecursiveCallVisitor(),
-                                     startWalkingDown: true, context) {
+    if !arg.at(.anything).isEscapingWhenWalkingDown(using: IgnoreRecursiveCallVisitor(),
+                                                    context) {
       newEffects.push(ArgumentEffect(.notEscaping, argumentIndex: arg.index, pathPattern: SmallProjectionPath(.anything)))
       continue
     }
@@ -131,8 +131,8 @@ func addArgEffects(_ arg: FunctionArgument, argPath ap: SmallProjectionPath,
     }
   }
   
-  guard let result = arg.at(argPath).visit(using: ArgEffectsVisitor(),
-                                           startWalkingDown: true, context) else {
+  guard let result = arg.at(argPath).visitByWalkingDown(using: ArgEffectsVisitor(),
+                                                        context) else {
     return false
   }
   
@@ -253,6 +253,6 @@ func isExclusiveEscapeToArgument(fromArgument: Argument, fromPath: SmallProjecti
   let visitor = IsExclusiveArgumentEscapeVisitor(fromArgument: fromArgument, fromPath: fromPath,
                                                  toArgumentIndex: toArgumentIndex, toPath: toPath)
   let toArg = fromArgument.function.arguments[toArgumentIndex]
-  return !toArg.at(toPath).isEscaping(using: visitor, startWalkingDown: true, context)
+  return !toArg.at(toPath).isEscapingWhenWalkingDown(using: visitor, context)
 }
 

--- a/SwiftCompilerSources/Sources/Optimizer/TestPasses/AccessDumper.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/TestPasses/AccessDumper.swift
@@ -50,9 +50,9 @@ let accessDumper = FunctionPass(name: "dump-access", {
 
 private struct AccessStoragePathVisitor : AccessStoragePathWalker {
   var walkUpCache = WalkerCache<Path>()
-  mutating func visit(access: AccessStoragePath) {
-    print("    Storage: \(access.storage)")
-    print("    Path: \"\(access.path)\"")
+  mutating func visit(accessStoragePath: ProjectedValue) {
+    print("    Storage: \(accessStoragePath.value)")
+    print("    Path: \"\(accessStoragePath.path)\"")
   }
 }
 

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/CMakeLists.txt
@@ -7,7 +7,7 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 swift_compiler_sources(Optimizer
-  EscapeInfo.swift
+  EscapeUtils.swift
   OptUtils.swift
   WalkUtils.swift
   AccessUtils.swift

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
@@ -1,4 +1,4 @@
-//===--- EscapeInfo.swift - Finds escape points of a value ----------------===//
+//===--- EscapeUtils.swift ------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/WalkUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/WalkUtils.swift
@@ -144,8 +144,6 @@ struct WalkerCache<Path : WalkingPath> {
     return cache[value.hashable, default: CacheEntry()].needWalk(path: path)
   }
 
-  var isEmpty: Bool { cache.isEmpty }
-  
   mutating func clear() {
     inlineEntry0 = nil
     inlineEntry1 = nil

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/WalkUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/WalkUtils.swift
@@ -111,12 +111,46 @@ extension SmallProjectionWalkingPath {
 /// A client must provide this cache in a `walkUpCache` or `walkDownCache` property.
 struct WalkerCache<Path : WalkingPath> {
   mutating func needWalk(for value: Value, path: Path) -> Path? {
+  
+    // Handle the first inline entry.
+    guard let e = inlineEntry0 else {
+      inlineEntry0 = (value, path)
+      return path
+    }
+    if e.value == value {
+      let newPath = e.path.merge(with: path)
+      if newPath != e.path {
+        inlineEntry0 = (value, newPath)
+        return newPath
+      }
+      return nil
+    }
+    
+    // Handle the second inline entry.
+    guard let e = inlineEntry1 else {
+      inlineEntry1 = (value, path)
+      return path
+    }
+    if e.value == value {
+      let newPath = e.path.merge(with: path)
+      if newPath != e.path {
+        inlineEntry1 = (value, newPath)
+        return newPath
+      }
+      return nil
+    }
+    
+    // If there are more than two elements, it goes into the `cache` Dictionary.
     return cache[value.hashable, default: CacheEntry()].needWalk(path: path)
   }
 
   var isEmpty: Bool { cache.isEmpty }
   
-  mutating func clear() { cache.removeAll(keepingCapacity: true) }
+  mutating func clear() {
+    inlineEntry0 = nil
+    inlineEntry1 = nil
+    cache.removeAll(keepingCapacity: true)
+  }
 
   private struct CacheEntry {
     var cachedPath: Path?
@@ -135,6 +169,13 @@ struct WalkerCache<Path : WalkingPath> {
     }
   }
 
+  // If there are no more than 2 elements in the cache, we can avoid using the `cache` Dictionary,
+  // which avoids memory allocations.
+  // Fortunately this is the common case by far (about 97% of all walker invocations).
+  private var inlineEntry0: (value: Value, path: Path)?
+  private var inlineEntry1: (value: Value, path: Path)?
+
+  // All elements, which don't fit into the inline entries.
   private var cache = Dictionary<HashableValue, CacheEntry>()
 }
 

--- a/SwiftCompilerSources/Sources/SIL/Value.swift
+++ b/SwiftCompilerSources/Sources/SIL/Value.swift
@@ -118,6 +118,30 @@ public func !=(_ lhs: Value, _ rhs: Value) -> Bool {
   return !(lhs === rhs)
 }
 
+/// A projected value, which is defined by the original value and a projection path.
+///
+/// For example, if the `value` is of type `struct S { var x: Int }` and `path` is `s0`,
+/// then the projected value represents field `x` of the original value.
+/// An empty path means represents the "whole" original value.
+///
+public struct ProjectedValue {
+  public let value: Value
+  public let path: SmallProjectionPath
+}
+
+extension Value {
+  /// Returns a projected value, defined by this value and `path`.
+  public func at(_ path: SmallProjectionPath) -> ProjectedValue {
+    ProjectedValue(value: self, path: path)
+  }
+
+  /// Returns a projected value, defined by this value and path containig a single field of `kind` and `index`.
+  public func at(_ kind: SmallProjectionPath.FieldKind, index: Int = 0) -> ProjectedValue {
+    ProjectedValue(value: self, path: SmallProjectionPath(kind, index: index))
+  }
+}
+
+
 extension BridgedValue {
   public func getAs<T: AnyObject>(_ valueType: T.Type) -> T { obj.getAs(T.self) }
 

--- a/docs/SIL-Utilities.md
+++ b/docs/SIL-Utilities.md
@@ -75,10 +75,15 @@ This consists of four protocols, which can be implemented to walk up or down the
 **Related C++ utilities:** `AccessPath`, `RCIdentityAnalysis`, various def-use/use-def walkers in optimization passes.  
 **Status:** done
 
-#### `EscapeInfo`
+#### Escape Utilities
 Escape analysis, which is used e.g. in stack promotion or alias analysis.
+Escape analysis is usable through the following methods of `ProjectedValue` and `Value`:
+* `isEscaping()`
+* `isAddressEscaping()`
+* `visit()`
+* `visitAddress()`
 
-**Uses:** Walk Utils, `SmallProjectionPath`  
+**Uses:** Walk Utilities, `ProjectedValue`
 **Related C++ utilities:** `EscapeAnalysis`, various def-use walkers in optimization passes.  
 **Status:** done
 
@@ -86,7 +91,7 @@ Escape analysis, which is used e.g. in stack promotion or alias analysis.
 A set of utilities for analyzing memory accesses. It defines the following concepts:
 * `AccessBase`: represents the base address of a memory access.
 * `AccessPath`: a pair of an `AccessBase` and `SmallProjectionPath` with the path describing the specific address (in terms of projections) of the access.
-* `AccessStoragePath`: identifies the reference (or a value which contains a reference) an address originates from.
+* Access storage path (which is of type `ProjectedValue`): identifies the reference - or a value which contains a reference - an address originates from.
 
 **Uses:** Walk utils
 **Related C++ utilities:** `AccessPath`  and other access utilities.

--- a/docs/SIL-Utilities.md
+++ b/docs/SIL-Utilities.md
@@ -40,6 +40,20 @@ To be used for all kind of basic-block work-list algorithms.
 **Related C++ utilities:** `BasicBlockWorklist`
 **Status:** done
 
+## SIL data structures
+
+#### `SmallProjectionPath`
+Describes a path of projections.
+
+**Related C++ utilities:** `AccessPath`, `ProjectionPath`  
+**Status:** done
+
+### `ProjectedValue`
+A projected value is defined by the original value and a projection path.
+
+**Related C++ utilities:** `AccessPath`
+**Status:** done
+
 ## Building SIL
 
 #### `static Builder.insert(after:, insertFunc: (Builder) -> ())`
@@ -59,12 +73,6 @@ This consists of four protocols, which can be implemented to walk up or down the
 
 **Uses:** instruction classifications  
 **Related C++ utilities:** `AccessPath`, `RCIdentityAnalysis`, various def-use/use-def walkers in optimization passes.  
-**Status:** done
-
-#### `SmallProjectionPath`
-Describes a path of projections.
-
-**Related C++ utilities:** `AccessPath`, `ProjectionPath`  
 **Status:** done
 
 #### `EscapeInfo`


### PR DESCRIPTION
Replace the `struct EscapeInfo` with a simpler API, just consisting of methods of `ProjectedValue` and `Value`:
* `isEscaping()`
* `isAddressEscaping()`
* `visit()`
* `visitAddress()`

For details see the commit messages