### PR TITLE
[Sema] Require explicit availability on public modules (Landing again after we held it back)

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -729,7 +729,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
                      diagLevel);
     }
   } else if (Args.getLastArg(OPT_require_explicit_availability,
-                             OPT_require_explicit_availability_target)) {
+                             OPT_require_explicit_availability_target) ||
+             Opts.LibraryLevel == LibraryLevel::API) {
     Opts.RequireExplicitAvailability = DiagnosticBehavior::Warning;
   }
 

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -483,7 +483,8 @@ function(_compile_swift_files
   # The standard library and overlays are built resiliently when SWIFT_STDLIB_STABLE_ABI=On.
   if(SWIFTFILE_IS_STDLIB AND SWIFT_STDLIB_STABLE_ABI)
     list(APPEND swift_flags "-enable-library-evolution")
-    list(APPEND swift_flags "-Xfrontend" "-library-level"  "-Xfrontend" "api")
+    list(APPEND swift_flags "-library-level" "api")
+    list(APPEND swift_flags "-Xfrontend" "-require-explicit-availability=ignore")
   endif()
 
   if("${SWIFT_SDK_${SWIFTFILE_SDK}_THREADING_PACKAGE}" STREQUAL "none")

--- a/test/ClangImporter/availability_spi_as_unavailable.swift
+++ b/test/ClangImporter/availability_spi_as_unavailable.swift
@@ -13,7 +13,7 @@ public let c: SPIInterface1 // expected-error{{cannot use class 'SPIInterface1' 
 public let d: SPIInterface2 // expected-error{{cannot use class 'SPIInterface2' here; it is an SPI imported from 'SPIContainer'}}
 
 @inlinable
-public func inlinableUsingSPI() {
+public func inlinableUsingSPI() { // expected-warning{{public declarations should have an availability attribute with an introduction version}}
   SharedInterface.foo() // expected-error{{class method 'foo()' cannot be used in an '@inlinable' function because it is an SPI imported from 'SPIContainer'}}
 }
 

--- a/test/ClangImporter/availability_spi_as_unavailable_bridging_header.swift
+++ b/test/ClangImporter/availability_spi_as_unavailable_bridging_header.swift
@@ -9,6 +9,6 @@ public let c: SPIInterface1 // expected-error{{cannot use class 'SPIInterface1' 
 public let d: SPIInterface2 // expected-error{{cannot use class 'SPIInterface2' here; it is an SPI imported from '__ObjC'}}
 
 @inlinable
-public func inlinableUsingSPI() {
+public func inlinableUsingSPI() { // expected-warning{{public declarations should have an availability attribute with an introduction version}}
   SharedInterface.foo() // expected-error{{class method 'foo()' cannot be used in an '@inlinable' function because it is an SPI imported from '__ObjC'}}
 }

--- a/test/SPI/spi-only-and-library-level.swift
+++ b/test/SPI/spi-only-and-library-level.swift
@@ -25,6 +25,7 @@ public struct LibStruct {}
 @_spiOnly import Lib
 
 public func publicClient() -> LibStruct { fatalError() } // expected-error {{cannot use struct 'LibStruct' here; 'Lib' was imported for SPI only}}
+// expected-warning @-1 {{public declarations should have an availability attribute with an introduction version}}
 @_spi(X) public func spiClient() -> LibStruct { fatalError() }
 
 //--- SPILib.swift

--- a/test/Sema/spi-available-inline.swift
+++ b/test/Sema/spi-available-inline.swift
@@ -10,7 +10,7 @@ public class MacOSSPIClass { public init() {} }
 @available(macOS 10.4, *)
 public class iOSSPIClass { public init() {} }
 
-@inlinable public func foo() {
+@inlinable public func foo() { // expected-warning{{public declarations should have an availability attribute with an introduction version}}
 	_ = MacOSSPIClass() // expected-error {{class 'MacOSSPIClass' cannot be used in an '@inlinable' function because it is SPI}}
 	_ = iOSSPIClass()
 }

--- a/test/attr/attr_inlinable_available.swift
+++ b/test/attr/attr_inlinable_available.swift
@@ -14,7 +14,7 @@
 
 
 // Check that `-library-level api` implies `-target-min-inlining-version min`
-// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-library-evolution -module-name Test -target %target-next-stable-abi-triple -library-level api
+// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-library-evolution -module-name Test -target %target-next-stable-abi-triple -library-level api -require-explicit-availability=ignore
 
 
 // Check that these rules are only applied when requested and that at least some
@@ -24,7 +24,7 @@
 
 // Check that -target-min-inlining-version overrides -library-level, allowing
 // library owners to disable this behavior for API libraries if needed.
-// RUN: not %target-typecheck-verify-swift -swift-version 5 -enable-library-evolution -module-name Test -target %target-next-stable-abi-triple -target-min-inlining-version target -library-level api 2>&1 | %FileCheck --check-prefix NON_MIN %s
+// RUN: not %target-typecheck-verify-swift -swift-version 5 -enable-library-evolution -module-name Test -target %target-next-stable-abi-triple -target-min-inlining-version target -library-level api -require-explicit-availability=ignore 2>&1 | %FileCheck --check-prefix NON_MIN %s
 
 
 // Check that we respect -target-min-inlining-version by cranking it up high

--- a/test/attr/require_explicit_availability.swift
+++ b/test/attr/require_explicit_availability.swift
@@ -10,6 +10,17 @@
 // RUN:   -target %target-cpu-apple-macosx10.10 -require-explicit-availability=warn \
 // RUN:   -require-explicit-availability-target "macOS 10.10"
 
+/// Using -library-level api defaults to enabling warnings, without fixits.
+// RUN: sed -e "s/}} {{.*/}}/" < %s > %t/NoFixits.swift
+// RUN: %target-swift-frontend -typecheck -parse-as-library -verify %t/NoFixits.swift \
+// RUN:   -target %target-cpu-apple-macosx10.10 -library-level api
+
+/// Explicitly disable the diagnostic.
+// RUN: sed -e 's/xpected-warning/not-something-expected/' < %s > %t/None.swift
+// RUN: %target-swift-frontend -typecheck -parse-as-library -verify %t/None.swift \
+// RUN:   -target %target-cpu-apple-macosx10.10 -require-explicit-availability=ignore \
+// RUN:   -require-explicit-availability-target "macOS 10.10" -library-level api
+
 /// Upgrade the diagnostic to an error.
 // RUN: sed -e "s/xpected-warning/xpected-error/" < %s > %t/Errors.swift
 // RUN: %target-swift-frontend -typecheck -parse-as-library -verify %t/Errors.swift \


### PR DESCRIPTION
Enabling require explicit availability by default for modules with an API library level was introduced by #61105 and reverted in #61161. We can land this again once the latest OSS toolchain supports the flag `-require-explicit-availability=ignore`.

rdar://99929744