### PR TITLE
[interop][SwiftToCxx] do not use std::move to move the returned C++ v…

### DIFF
--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -146,7 +146,9 @@ private:
       os << "return *storageObjectPtr;\n";
       return;
     }
-    os << fullQualifiedType << " result(std::move(*storageObjectPtr));\n";
+    // Force a `std::move` on the resulting object.
+    os << fullQualifiedType << " result(static_cast<" << fullQualifiedType
+       << " &&>(*storageObjectPtr));\n";
     os << "storageObjectPtr->~" << typeName << "();\n";
     os << "return result;\n";
   }

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
@@ -126,7 +126,7 @@ public func takeTrivialInout(_ x: inout Trivial) {
 // CHECK-NEXT: alignas(alignof(ns::NonTrivialTemplate<int>)) char storage[sizeof(ns::NonTrivialTemplate<int>)];
 // CHECK-NEXT: auto * _Nonnull storageObjectPtr = reinterpret_cast<ns::NonTrivialTemplate<int> *>(storage);
 // CHECK-NEXT: _impl::$s8UseCxxTy13retNonTrivialSo2nsO02__b18TemplateInstN2ns18efH4IiEEVyF(storage);
-// CHECK-NEXT: ns::NonTrivialTemplate<int> result(std::move(*storageObjectPtr));
+// CHECK-NEXT: ns::NonTrivialTemplate<int> result(static_cast<ns::NonTrivialTemplate<int> &&>(*storageObjectPtr));
 // CHECK-NEXT: storageObjectPtr->~NonTrivialTemplate();
 // CHECK-NEXT: return result;
 // CHECK-NEXT: }
@@ -165,7 +165,7 @@ public func takeTrivialInout(_ x: inout Trivial) {
 // CHECK-NEXT: alignas(alignof(ns::NonTrivialTemplate<ns::TrivialinNS>)) char storage[sizeof(ns::NonTrivialTemplate<ns::TrivialinNS>)];
 // CHECK-NEXT: auto * _Nonnull storageObjectPtr = reinterpret_cast<ns::NonTrivialTemplate<ns::TrivialinNS> *>(storage);
 // CHECK-NEXT: _impl::$s8UseCxxTy14retNonTrivial2So2nsO02__b18TemplateInstN2ns18e7TrivialH20INS_11TrivialinNSEEEVyF(storage);
-// CHECK-NEXT: ns::NonTrivialTemplate<ns::TrivialinNS> result(std::move(*storageObjectPtr));
+// CHECK-NEXT: ns::NonTrivialTemplate<ns::TrivialinNS> result(static_cast<ns::NonTrivialTemplate<ns::TrivialinNS> &&>(*storageObjectPtr));
 // CHECK-NEXT: storageObjectPtr->~NonTrivialTemplate();
 // CHECK-NEXT: return result;
 // CHECK-NEXT: }
@@ -174,7 +174,7 @@ public func takeTrivialInout(_ x: inout Trivial) {
 // CHECK-NEXT: alignas(alignof(ns::NonTrivialImplicitMove)) char storage[sizeof(ns::NonTrivialImplicitMove)];
 // CHECK-NEXT: auto * _Nonnull storageObjectPtr = reinterpret_cast<ns::NonTrivialImplicitMove *>(storage);
 // CHECK-NEXT: _impl::$s8UseCxxTy25retNonTrivialImplicitMoveSo2nsO0efgH0VyF(storage);
-// CHECK-NEXT: ns::NonTrivialImplicitMove result(std::move(*storageObjectPtr));
+// CHECK-NEXT: ns::NonTrivialImplicitMove result(static_cast<ns::NonTrivialImplicitMove &&>(*storageObjectPtr));
 // CHECK-NEXT: storageObjectPtr->~NonTrivialImplicitMove();
 // CHECK-NEXT: return result;
 // CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/generics/generic-function-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-function-in-cxx.swift
@@ -154,7 +154,7 @@ public func createTestSmallStruct(_ x: UInt32) -> TestSmallStruct {
 // CHECK-NEXT:    alignas(alignof(T_0_0)) char storage[sizeof(T_0_0)];
 // CHECK-NEXT:    auto * _Nonnull storageObjectPtr = reinterpret_cast<T_0_0 *>(storage);
 // CHECK-NEXT:    _impl::$s9Functions10genericRetyxxlF(storage, swift::_impl::getOpaquePointer(x), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata());
-// CHECK-NEXT:    T_0_0 result(std::move(*storageObjectPtr));
+// CHECK-NEXT:    T_0_0 result(static_cast<T_0_0 &&>(*storageObjectPtr));
 // CHECK-NEXT:    storageObjectPtr->~T_0_0();
 // CHECK-NEXT:    return result;
 // CHECK-NEXT:    } else {
@@ -185,7 +185,7 @@ public func createTestSmallStruct(_ x: UInt32) -> TestSmallStruct {
 // CHECK-NEXT:    alignas(alignof(T_0_0)) char storage[sizeof(T_0_0)];
 // CHECK-NEXT:    auto * _Nonnull storageObjectPtr = reinterpret_cast<T_0_0 *>(storage);
 // CHECK-NEXT:    _impl::$s9Functions15TestSmallStructV24genericMethodPassThroughyxxlF(storage, swift::_impl::getOpaquePointer(x), _impl::swift_interop_passDirect_Functions_uint32_t_0_4(_getOpaquePointer()), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata())
-// CHECK-NEXT:    T_0_0 result(std::move(*storageObjectPtr));
+// CHECK-NEXT:    T_0_0 result(static_cast<T_0_0 &&>(*storageObjectPtr));
 // CHECK-NEXT:    storageObjectPtr->~T_0_0();
 // CHECK-NEXT:    return result;
 // CHECK-NEXT:   } else {


### PR DESCRIPTION
…alue

move needs <utility>, which is not includable in the test SDK.
