### PR TITLE
[Sema] Reject `@objc` functions with incompatible property wrapper in…

### DIFF
--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -182,7 +182,7 @@ static void diagnoseTypeNotRepresentableInObjC(const DeclContext *DC,
   }
 
   // Special diagnostic for structs.
-  if (T->is<StructType>()) {
+  if (auto *SD = T->getStructOrBoundGenericStruct()) {
     diags.diagnose(TypeRange.Start, diag::not_objc_swift_struct)
         .highlight(TypeRange)
         .limitBehavior(behavior);
@@ -291,9 +291,16 @@ static void diagnoseFunctionParamNotRepresentable(
           .limitBehavior(behavior));
   }
   SourceRange SR;
-  if (auto typeRepr = P->getTypeRepr())
-    SR = typeRepr->getSourceRange();
-  diagnoseTypeNotRepresentableInObjC(AFD, P->getType(), SR, behavior);
+
+  if (P->hasAttachedPropertyWrapper()) {
+    auto wrapperTy = P->getPropertyWrapperBackingPropertyType();
+    SR = P->getOutermostAttachedPropertyWrapper()->getRange();
+    diagnoseTypeNotRepresentableInObjC(AFD, wrapperTy, SR, behavior);
+  } else {
+    if (auto typeRepr = P->getTypeRepr())
+      SR = typeRepr->getSourceRange();
+    diagnoseTypeNotRepresentableInObjC(AFD, P->getType(), SR, behavior);
+  }
   Reason.describe(AFD);
 }
 
@@ -335,11 +342,17 @@ static bool isParamListRepresentableInObjC(const AbstractFunctionDecl *AFD,
 
     if (param->getType()->hasError())
       return false;
-    
-    if (param->getType()->isRepresentableIn(
+
+    if (param->hasAttachedPropertyWrapper()) {
+      if (param->getPropertyWrapperBackingPropertyType()->isRepresentableIn(
           ForeignLanguage::ObjectiveC,
           const_cast<AbstractFunctionDecl *>(AFD)))
+        continue;
+    } else if (param->getType()->isRepresentableIn(
+          ForeignLanguage::ObjectiveC,
+          const_cast<AbstractFunctionDecl *>(AFD))) {
       continue;
+    }
 
     // Permit '()' when this method overrides a method with a
     // foreign error convention that replaces NSErrorPointer with ()

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -645,9 +645,12 @@ class NewtypeUser {
   @objc func intNewtype(a: MyInt) {}
   @objc func intNewtypeOptional(a: MyInt?) {} // expected-error {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   @objc func intNewtypeArray(a: [MyInt]) {} // expected-error {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  // expected-note@-1 {{Swift structs cannot be represented in Objective-C}}
   @objc func intNewtypeDictionary(a: [MyInt: NSObject]) {} // expected-error {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  // expected-note@-1 {{Swift structs cannot be represented in Objective-C}}
   @objc func cfNewtype(a: CFNewType) {}
   @objc func cfNewtypeArray(a: [CFNewType]) {} // expected-error {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  // expected-note@-1 {{Swift structs cannot be represented in Objective-C}}
 
   typealias MyTuple = (Int, AnyObject?)
   typealias MyNamedTuple = (a: Int, b: AnyObject?)

--- a/test/Sema/objc_property_wrappers.swift
+++ b/test/Sema/objc_property_wrappers.swift
@@ -1,0 +1,97 @@
+// RUN: %target-swift-frontend -typecheck -verify -enable-objc-interop %s
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+class ObjcClassCase {
+    @objc
+    func foo(@WrapperObjcClass _ ref: Int) throws {}
+}
+
+@propertyWrapper @objc
+public class WrapperObjcClass: NSObject {
+    public var wrappedValue: Int
+
+    public init(wrappedValue: Int) {
+        self.wrappedValue = wrappedValue
+    }
+    
+    public init(projectedValue: WrapperObjcClass) {
+        fatalError()
+    }
+
+    public var projectedValue: WrapperObjcClass {
+        fatalError()
+    }
+}
+
+class GenericClassCase {
+    @objc
+    func foo(@WrapperGenericClass _ ref: Int) throws {} // expected-error {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+    // expected-note@-1 {{classes not annotated with @objc cannot be represented in Objective-C}}
+}
+
+@propertyWrapper
+public class WrapperGenericClass<Element> {
+    public var wrappedValue: Element
+
+    public init(wrappedValue: Element) {
+        self.wrappedValue = wrappedValue
+    }
+    
+    public init(projectedValue: WrapperGenericClass<Element>) {
+        fatalError()
+    }
+
+    public var projectedValue: WrapperGenericClass<Element> {
+        fatalError()
+    }
+}
+
+class StructCase {
+    @objc
+    func foo(@WrapperStruct _ ref: Int) throws {} // expected-error {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+    // expected-note@-1 {{Swift structs cannot be represented in Objective-C}}
+}
+
+@propertyWrapper
+public struct WrapperStruct {
+    public var wrappedValue: Int
+
+    public init(wrappedValue: Int) {
+        self.wrappedValue = wrappedValue
+    }
+    
+    public init(projectedValue: WrapperStruct) {
+        fatalError()
+    }
+
+    public var projectedValue: WrapperStruct {
+        fatalError()
+    }
+}
+
+class EnumCase {
+    @objc
+    func foo(@WrapperEnum _ ref: Int) throws {} // expected-error {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+    // expected-note@-1 {{non-'@objc' enums cannot be represented in Objective-C}}
+}
+
+@propertyWrapper
+public enum WrapperEnum {
+    public var wrappedValue: Int {
+    	fatalError()
+    }
+
+    public init(wrappedValue: Int) {
+    }
+    
+    public init(projectedValue: WrapperStruct) {
+        fatalError()
+    }
+
+    public var projectedValue: WrapperStruct {
+        fatalError()
+    }
+}

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -1556,6 +1556,7 @@ class infer_instanceVar1 {
   @objc // bad-access-note-move{{infer_instanceVar1.var_ArrayType3_}}
   var var_ArrayType3_: [PlainStruct]
   // access-note-adjust{{@objc}} expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
 
   var var_ArrayType4: [(AnyObject) -> AnyObject] // no-error
   // CHECK-LABEL: {{^}}  var var_ArrayType4: [(AnyObject) -> AnyObject]
@@ -1563,6 +1564,7 @@ class infer_instanceVar1 {
   @objc // bad-access-note-move{{infer_instanceVar1.var_ArrayType4_}}
   var var_ArrayType4_: [(AnyObject) -> AnyObject]
   // access-note-adjust{{@objc}} expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
 
   var var_ArrayType5: [Protocol_ObjC1]
   // CHECK-LABEL: {{^}}  @objc var var_ArrayType5: [Protocol_ObjC1]
@@ -1582,6 +1584,7 @@ class infer_instanceVar1 {
   @objc // bad-access-note-move{{infer_instanceVar1.var_ArrayType7_}}
   var var_ArrayType7_: [PlainClass]
   // access-note-adjust{{@objc}} expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
 
   var var_ArrayType8: [PlainProtocol]
   // CHECK-LABEL: {{^}}  var var_ArrayType8: [PlainProtocol]
@@ -1589,6 +1592,7 @@ class infer_instanceVar1 {
   @objc // bad-access-note-move{{infer_instanceVar1.var_ArrayType8_}}
   var var_ArrayType8_: [PlainProtocol]
   // access-note-adjust{{@objc}} expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
 
   var var_ArrayType9: [Protocol_ObjC1 & PlainProtocol]
   // CHECK-LABEL: {{^}}  var var_ArrayType9: [PlainProtocol & Protocol_ObjC1]
@@ -1596,6 +1600,7 @@ class infer_instanceVar1 {
   @objc // bad-access-note-move{{infer_instanceVar1.var_ArrayType9_}}
   var var_ArrayType9_: [Protocol_ObjC1 & PlainProtocol]
   // access-note-adjust{{@objc}} expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
 
   var var_ArrayType10: [Protocol_ObjC1 & Protocol_ObjC2]
   // CHECK-LABEL: {{^}}  @objc var var_ArrayType10: [Protocol_ObjC1 & Protocol_ObjC2]
@@ -1616,6 +1621,7 @@ class infer_instanceVar1 {
   @objc // bad-access-note-move{{infer_instanceVar1.var_ArrayType13_}}
   var var_ArrayType13_: [Any?]
   // access-note-adjust{{@objc}} expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
 
   var var_ArrayType15: [AnyObject?]
   // CHECK-LABEL: {{^}}  var var_ArrayType15: [AnyObject?]
@@ -1623,6 +1629,7 @@ class infer_instanceVar1 {
   @objc // bad-access-note-move{{infer_instanceVar1.var_ArrayType15_}}
   var var_ArrayType15_: [AnyObject?]
   // access-note-adjust{{@objc}} expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
 
   var var_ArrayType16: [[@convention(block) (AnyObject) -> AnyObject]] // no-error
   // CHECK-LABEL: {{^}}  @objc var var_ArrayType16: {{\[}}[@convention(block) (AnyObject) -> AnyObject]]
@@ -1636,6 +1643,7 @@ class infer_instanceVar1 {
   @objc // bad-access-note-move{{infer_instanceVar1.var_ArrayType17_}}
   var var_ArrayType17_: [[(AnyObject) -> AnyObject]]
   // access-note-adjust{{@objc}} expected-error @-1{{property cannot be marked @objc because its type cannot be represented in Objective-C}}
+  // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
 }
 
 @objc // access-note-move{{ObjCBase}}
@@ -2649,6 +2657,7 @@ protocol issue51538_P {
   func throwingMethod1() throws -> Unmanaged<CFArray> // Ok
   func throwingMethod2() throws -> Unmanaged<issue51538_C> // expected-error {{method cannot be a member of an @objc protocol because its result type cannot be represented in Objective-C}}
   // expected-note@-1 {{inferring '@objc' because the declaration is a member of an '@objc' protocol}}
+  // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
 }
 
 // https://github.com/apple/swift/issues/55246

--- a/test/attr/attr_objc_any.swift
+++ b/test/attr/attr_objc_any.swift
@@ -13,6 +13,7 @@ class Foo: NSObject {
   @objc func method(x: Any) -> Any { return x }
 
   @objc func indirectAny(x: UnsafePointer<Any>) {} // expected-error{{type of the parameter cannot be represented in Objective-C}}
+  // expected-note@-1 {{Swift structs cannot be represented in Objective-C}}
 
   @objc func throwingMethod(x: Any) throws -> Any { return x }
 

--- a/test/attr/attr_objc_swift4.swift
+++ b/test/attr/attr_objc_swift4.swift
@@ -26,11 +26,9 @@ struct PlainStruct { }
 class BadInSwift4 {
   @IBInspectable var badIBInspectable: PlainStruct?
   // expected-error@-1{{property cannot be marked @IBInspectable because its type cannot be represented in Objective-C}}
-  // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
 
   @GKInspectable var badGKInspectable: PlainStruct?
   // expected-error@-1{{property cannot be marked @GKInspectable because its type cannot be represented in Objective-C}}
-  // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
 }
 
 // CHECK-LABEL: class InitsInheritObjCAttrBase

--- a/test/attr/attr_objc_swift4.swift
+++ b/test/attr/attr_objc_swift4.swift
@@ -26,9 +26,11 @@ struct PlainStruct { }
 class BadInSwift4 {
   @IBInspectable var badIBInspectable: PlainStruct?
   // expected-error@-1{{property cannot be marked @IBInspectable because its type cannot be represented in Objective-C}}
+  // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
 
   @GKInspectable var badGKInspectable: PlainStruct?
   // expected-error@-1{{property cannot be marked @GKInspectable because its type cannot be represented in Objective-C}}
+  // expected-note@-2 {{Swift structs cannot be represented in Objective-C}}
 }
 
 // CHECK-LABEL: class InitsInheritObjCAttrBase


### PR DESCRIPTION
… params

rdar://99443365

When genrating `@objc` functions, the parameters were not checked for property wrapper and instead only the wrapped type was checked for compatibility. Added checks and diagnostics for incompatible property wrappers.

