### PR TITLE
[DNM][c++ interop] Showcase SILGen crash when successor() is used

### DIFF
--- a/test/Interop/Cxx/stdlib/Inputs/module.modulemap
+++ b/test/Interop/Cxx/stdlib/Inputs/module.modulemap
@@ -7,3 +7,8 @@ module StdString {
   header "std-string.h"
   requires cplusplus
 }
+
+module Sample {
+  header "sample.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/stdlib/Inputs/sample.h
+++ b/test/Interop/Cxx/stdlib/Inputs/sample.h
@@ -1,0 +1,23 @@
+#ifndef TEST_INTEROP_CXX_STDLIB_INPUTS_STD_SAMPLE_H
+#define TEST_INTEROP_CXX_STDLIB_INPUTS_STD_SAMPLE_H
+
+#include <string>
+
+#define SWIFT_CXX_REF_IMMORTAL                                                 \
+	__attribute__((swift_attr("import_as_ref")))                                 \
+  __attribute__((swift_attr("retain:immortal")))                               \
+	__attribute__((swift_attr("release:immortal")))
+
+
+struct SWIFT_CXX_REF_IMMORTAL Counter {
+public:
+typedef int64_t Value;
+
+void operator+=(Value delta);
+void operator++() { *this += 1; }
+
+private:
+std::string name;
+};
+
+#endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_SAMPLE_H

--- a/test/Interop/Cxx/stdlib/sample.swift
+++ b/test/Interop/Cxx/stdlib/sample.swift
@@ -1,0 +1,29 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
+//
+// REQUIRES: executable_test
+//
+// Enable this everywhere once we have a solution for modularizing libstdc++: rdar://87654514
+// REQUIRES: OS=macosx
+
+import StdlibUnittest
+import std.map
+import Sample
+
+var SampleTestSuite = TestSuite("Sample")
+
+actor X {
+    var counter: Counter
+
+    init(counter: Counter) {
+        self.counter = counter
+    }
+
+    func test() {
+        self.counter = self.counter.successor() // this is ++
+    }
+}
+
+SampleTestSuite.test("test") {
+}
+
+runAllTests()


### PR DESCRIPTION
Showcase SILGen crash when successor() is used.

cc @zoecarver 
rdar://100050151