### PR TITLE
[Index] Always skip invalid locations outside of modules

### DIFF
--- a/include/swift/Index/IndexSymbol.h
+++ b/include/swift/Index/IndexSymbol.h
@@ -65,7 +65,6 @@ struct IndexSymbol : IndexRelation {
   SmallVector<IndexRelation, 3> Relations;
   unsigned line = 0;
   unsigned column = 0;
-  Optional<unsigned> offset;
 
   IndexSymbol() = default;
 

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -1601,8 +1601,13 @@ bool IndexSwiftASTWalker::reportImplicitConformance(ValueDecl *witness, ValueDec
 bool IndexSwiftASTWalker::initIndexSymbol(ValueDecl *D, SourceLoc Loc,
                                           bool IsRef, IndexSymbol &Info) {
   assert(D);
+
+  if (Loc.isInvalid() && !IsModuleFile)
+    return true;
+
   if (Loc.isValid() && SrcMgr.findBufferContainingLoc(Loc) != BufferID)
     return true;
+
   if (auto *VD = dyn_cast<VarDecl>(D)) {
     // Always base the symbol information on the canonical VarDecl
     D = VD->getCanonicalVarDecl();


### PR DESCRIPTION
There's a number of paths that end up calling into `initIndexSymbol`
that may or may not have checked that the given location is actually
valid. Add an extra check within the method to guarantee we only output
0:0 locations when indexing modules.

Resolves rdar://98645486.