### PR TITLE
[NFC] Emit descriptive string constant names

### DIFF
--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -601,3 +601,36 @@ actually unblocks PR testing by running the smoke test build preset locally.
 To enable the lldb test allowlist, add `-G swiftpr` to the
 `LLDB_TEST_CATEGORIES` variable in `utils/build-script-impl`. Disable it by
 removing that option.
+
+#### String constants in IR tests
+
+IRGen often needs to create private constants containing the NUL-terminated
+contents of strings, such as for string literals in user code or names in type
+metadata. When it does, IRGen names them in a specific format: they will
+have the prefix `.str.`, followed by the size in bytes (excluding terminator),
+followed by a `.`, followed by the contents of the string (excluding
+terminator). For example:
+
+```
+@.str.5.Hello             ; A constant containing "Hello\0"
+@".str.11.Hello World"    ; A constant containing "Hello World\0"
+@".str.7.Hello!\0A"       ; A constant containing "Hello!\n\0"
+@".str.4.\F0\9F\8F\8E"    ; A constant containing "🏎️\0"
+@.str.0.                  ; A constant containing "\0"
+```
+
+When writing IRGen tests, you can assume that names in this format have the
+expected contents, so you don't need to capture the constant's name and then
+check that it's referred to correctly at the use site.
+
+Note that this name format treats NUL characters (\00) specially. All string
+constants generated in this manner are NUL-terminated, so the terminator is not
+included in the count *or* the content. To work around LLVM IR limitations, NUL
+characters elsewhere in the content are replaced with `_` and a `.nul<index>`
+suffix is appended to the name, in order from lowest to highest index:
+
+```
+@.str.1._.nul0            ; A constant containing "\0\0"
+@.str.2.__.nul0.nul1      ; A constant containing "\0\0\0"
+@".str.6.nul: _.nul5"     ; A constant containing "nul: \0\0"
+```

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -5410,9 +5410,20 @@ llvm::Constant *IRGenModule::getAddrOfGlobalString(StringRef data,
     return entry.second;
   }
 
+  SmallString<64> name;
+  (llvm::Twine(".str.") + llvm::Twine(data.size()) + "." + data).toVector(name);
+  
+  // \0 is not allowed in variable names. Rewrite any \0s into _s and append
+  // information about their original locations so the name remains unique.
+  for (size_t i = name.find('\0');
+       i != StringRef::npos;
+       i = name.find('\0', i)) {
+    name[i] = '_';
+    (llvm::Twine(".nul") + llvm::Twine(i)).toVector(name);
+  }
+  
   entry = createStringConstant(data, willBeRelativelyAddressed,
-                               /*sectionName*/ "",
-                               ".str" /* match how Clang creates strings */);
+                               /*sectionName*/ "", name);
   return entry.second;
 }
 

--- a/test/IRGen/anonymous_context_descriptors.sil
+++ b/test/IRGen/anonymous_context_descriptors.sil
@@ -1,5 +1,7 @@
-// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s
-// RUN: %target-swift-frontend -emit-ir -enable-anonymous-context-mangled-names %s | %FileCheck %s -check-prefix CHECK-MANGLED
+// RUN: %target-swift-frontend -emit-ir %s > %t.ir
+// %FileCheck --input-file %t.ir %s
+// RUN: %target-swift-frontend -emit-ir -enable-anonymous-context-mangled-names %s > %t.anon.ir
+// RUN: %FileCheck --input-file %t.anon.ir %s -check-prefix CHECK-MANGLED
 
 import Builtin
 import Swift
@@ -12,7 +14,7 @@ class Blah<T: P> {
 
 // Mangled name of the anonymous descriptor
 // CHECK-NOT: private constant [84 x i8] c"$s29anonymous_context_descriptors4BlahC5Inner33_4F495173994818481DD703D65EB08308LLV\00"
-// CHECK-MANGLED: [[INNER_MANGLED:@.str.[0-9]+]] = private constant [84 x i8] c"$s29anonymous_context_descriptors4BlahC5Inner33_4F495173994818481DD703D65EB08308LLV\00"
+// CHECK-MANGLED: @".str.83.$s29anonymous_context_descriptors4BlahC5Inner33_4F495173994818481DD703D65EB08308LLV" = private constant [84 x i8] c"$s29anonymous_context_descriptors4BlahC5Inner33_4F495173994818481DD703D65EB08308LLV\00"
 
 // Anonymous descriptor
 // CHECK: @"$s29anonymous_context_descriptors4BlahC5Inner33{{.*}}MXX" =
@@ -36,4 +38,4 @@ class Blah<T: P> {
 // CHECK-MANGLED-SAME: i16 4, i16 0
 
 // # mangled name
-// CHECK-MANGLED-SAME: [[INNER_MANGLED]]
+// CHECK-MANGLED-SAME: @".str.83.$s29anonymous_context_descriptors4BlahC5Inner33_4F495173994818481DD703D65EB08308LLV"

--- a/test/IRGen/builtins_objc.swift
+++ b/test/IRGen/builtins_objc.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend -parse-stdlib -primary-file %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -parse-stdlib -primary-file %s -emit-ir > %t.ir
+// RUN: %FileCheck %s --input-file=%t.ir
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
@@ -6,9 +7,6 @@
 import Swift
 import Foundation
 import CoreGraphics
-
-// CHECK: [[INT32:@.str.[0-9]+]] = {{.*}} c"i\00"
-// CHECK: [[OBJECT:@.str.[0-9]+]] = {{.*}} c"@\00"
 
 @objc enum ObjCEnum: Int32 { case X }
 @objc class ObjCClass: NSObject {}
@@ -18,21 +16,21 @@ class NonObjCClass {}
 func use(_: Builtin.RawPointer)
 
 func getObjCTypeEncoding<T>(_: T) {
-  // CHECK: call swiftcc void @use({{.* i8]\*}} [[INT32]],
+  // CHECK: call swiftcc void @use({{.* i8]\*}} @.str.1.i,
   use(Builtin.getObjCTypeEncoding(Int32.self))
-  // CHECK: call swiftcc void @use({{.* i8]\*}} [[INT32]]
+  // CHECK: call swiftcc void @use({{.* i8]\*}} @.str.1.i
   use(Builtin.getObjCTypeEncoding(ObjCEnum.self))
-  // CHECK: call swiftcc void @use({{.* i8]\*}} [[CGRECT:@.str.[0-9]+]],
+  // CHECK: call swiftcc void @use({{.* i8]\*}} [[CGRECT:@".str.[0-9]+.\{CGRect=[^"]*"]],
   use(Builtin.getObjCTypeEncoding(CGRect.self))
-  // CHECK: call swiftcc void @use({{.* i8]\*}} [[NSRANGE:@.str.[0-9]+]],
+  // CHECK: call swiftcc void @use({{.* i8]\*}} [[NSRANGE:@".str.[0-9]+.\{_NSRange=[^"]*"]],
   use(Builtin.getObjCTypeEncoding(NSRange.self))
-  // CHECK: call swiftcc void @use({{.* i8]\*}} [[OBJECT]]
+  // CHECK: call swiftcc void @use({{.* i8]\*}} @".str.1.@"
   use(Builtin.getObjCTypeEncoding(AnyObject.self))
-  // CHECK: call swiftcc void @use({{.* i8]\*}} [[OBJECT]]
+  // CHECK: call swiftcc void @use({{.* i8]\*}} @".str.1.@"
   use(Builtin.getObjCTypeEncoding(NSObject.self))
-  // CHECK: call swiftcc void @use({{.* i8]\*}} [[OBJECT]]
+  // CHECK: call swiftcc void @use({{.* i8]\*}} @".str.1.@"
   use(Builtin.getObjCTypeEncoding(ObjCClass.self))
-  // CHECK: call swiftcc void @use({{.* i8]\*}} [[OBJECT]]
+  // CHECK: call swiftcc void @use({{.* i8]\*}} @".str.1.@"
   use(Builtin.getObjCTypeEncoding(NonObjCClass.self))
 }
 

--- a/test/IRGen/closure.swift
+++ b/test/IRGen/closure.swift
@@ -4,8 +4,8 @@
 
 // REQUIRES: PTRSIZE=64
 
-// CHECK-DAG: [[FILENAME:@.str]] = {{.*}} c"{{.*}}closure.swift\00"
-// OPT: [[FILENAME:@.str]] = {{.*}} [1 x i8] zeroinitializer
+// CHECK-DAG: [[FILENAME:@"\.str\..*closure\.swift"]] = {{.*}} c"{{.*}}closure.swift\00"
+// OPT: [[FILENAME:@\.str\.0\.]] = {{.*}} [1 x i8] zeroinitializer
 
 // -- partial_apply context metadata
 

--- a/test/IRGen/expressions.swift
+++ b/test/IRGen/expressions.swift
@@ -5,17 +5,15 @@
 import Swift
 
 
-// CHECK: private unnamed_addr constant [22 x i8] c"this is just a\0A\0A test\00"
-
 // CHECK: define hidden [[stringLayout:[^@]*]] @"$s11expressions17TestStringLiteralSSyF"() {{.*}} {
-// CHECK: call [[stringLayout]] @{{.*}}_builtinStringLiteral{{.*}}(i8* getelementptr inbounds ([22 x i8], [22 x i8]* @.str, i64 0, i64 0), i64 21, i1 true)
+// CHECK: call [[stringLayout]] @{{.*}}_builtinStringLiteral{{.*}}(i8* getelementptr inbounds ([22 x i8], [22 x i8]* @".str.21.this is just a\0A\0A test", i64 0, i64 0), i64 21, i1 true)
 
 func TestStringLiteral() -> String {
   return "this is just a\n\u{0a} test"
 }
 
 // CHECK: define hidden [[stringLayout]] @"$s11expressions18TestStringLiteral2SSyF"() {{.*}} {
-// CHECK: call [[stringLayout]] @{{.*}}_builtinStringLiteral{{.*}}(i8* getelementptr inbounds ([20 x i8], [20 x i8]* @.str.1, i64 0, i64 0), i64 19, i1 false)
+// CHECK: call [[stringLayout]] @{{.*}}_builtinStringLiteral{{.*}}(i8* getelementptr inbounds ([20 x i8], [20 x i8]* @".str.19.non-ASCII string \C2\B5", i64 0, i64 0), i64 19, i1 false)
 func TestStringLiteral2() -> String {
   return "non-ASCII string \u{00B5}"
 }

--- a/test/IRGen/objc_attr_NSManaged.sil
+++ b/test/IRGen/objc_attr_NSManaged.sil
@@ -19,10 +19,8 @@ sil_vtable X {}
 // The getter/setter should not show up in the Objective-C metadata.
 // CHECK: @_INSTANCE_METHODS__TtC19objc_attr_NSManaged10SwiftGizmo = internal constant { i32, i32, [2 x { i8*, i8*, i8* }] } { i32 24, i32 2, {{.*}} @"\01L_selector_data(initWithBellsOn:)", {{.*}} @"\01L_selector_data(init)",
 
-// CHECK: [[X:@.str.[0-9]+]] = private unnamed_addr constant [2 x i8] c"x\00"
-
 // The property 'x' should show up in the Objective-C metadata.
-// CHECK: @_PROPERTIES__TtC19objc_attr_NSManaged10SwiftGizmo = internal constant { {{.*}}i32, i32, [1 x { i8*, i8* }] } { i32 16, i32 1, [1 x { i8*, i8* }] [{ i8*, i8* } { i8* getelementptr inbounds ([2 x i8], [2 x i8]* [[X]], i64 0, i64 0),
+// CHECK: @_PROPERTIES__TtC19objc_attr_NSManaged10SwiftGizmo = internal constant { {{.*}}i32, i32, [1 x { i8*, i8* }] } { i32 16, i32 1, [1 x { i8*, i8* }] [{ i8*, i8* } { i8* getelementptr inbounds ([2 x i8], [2 x i8]* @.str.1.x, i64 0, i64 0),
 
 // The getter/setter should not show up in the Swift metadata.
 // CHECK: @"$s19objc_attr_NSManaged10SwiftGizmoCMf" = internal global <{ {{.*}} }> <{ void (%T19objc_attr_NSManaged10SwiftGizmoC*)* {{.*}}@"$s19objc_attr_NSManaged10SwiftGizmoCfD{{(\.ptrauth)?}}"{{.*}}, i8**{{.*}} @"$sBOWV{{(.ptrauth)?(.)?[0-9]?}}"{{.*}}, {{.*}} @"OBJC_METACLASS_$__TtC19objc_attr_NSManaged10SwiftGizmo{{(.ptrauth)?}}"{{.*}}, %objc_class*{{.*}} @"OBJC_CLASS_$_Gizmo{{(.ptrauth)?}}"{{.*}}, %swift.opaque* @_objc_empty_cache, %swift.opaque* null,{{.*}}@_DATA__TtC19objc_attr_NSManaged10SwiftGizmo{{.*}}i64 {{1|2}}){{.*}}, i32 {{1|0}}, i32 0, i32 8, i16 7, i16 0, i32 96, i32 16, {{.*}}* @"$s19objc_attr_NSManaged10SwiftGizmoCMn{{(\.ptrauth)?}}"{{.*}}, i8* null }>

--- a/test/IRGen/objc_bridge.swift
+++ b/test/IRGen/objc_bridge.swift
@@ -7,101 +7,97 @@
 
 import Foundation
 
-// CHECK: [[GETTER_SIGNATURE:@.*]] = private unnamed_addr constant [8 x i8] c"@16@0:8\00"
-// CHECK: [[SETTER_SIGNATURE:@.*]] = private unnamed_addr constant [11 x i8] c"v24@0:8@16\00"
-// CHECK: [[DEALLOC_SIGNATURE:@.*]] = private unnamed_addr constant [8 x i8] c"v16@0:8\00"
-
 // CHECK: @_INSTANCE_METHODS__TtC11objc_bridge3Bas = internal constant { i32, i32, [17 x { i8*, i8*, i8* }] } {
 // CHECK:   i32 24,
 // CHECK:   i32 17,
 // CHECK:   [17 x { i8*, i8*, i8* }] [
 // CHECK:     { i8*, i8*, i8* } {
 // CHECK:       i8* getelementptr inbounds ([12 x i8], [12 x i8]* @"\01L_selector_data(strRealProp)", i64 0, i64 0),
-// CHECK:       i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[GETTER_SIGNATURE]], i64 0, i64 0),
+// CHECK:       i8* getelementptr inbounds ([8 x i8], [8 x i8]* @".str.7.@16@0:8", i64 0, i64 0),
 // CHECK-noptrauth: i8* bitcast ([[OPAQUE:.*]]* ([[OPAQUE:.*]]*, i8*)* @"$s11objc_bridge3BasC11strRealPropSSvgTo" to i8*)
 // CHECK-ptrauth:   i8* bitcast ({ i8*, i32, i64, i64 }* @"$s11objc_bridge3BasC11strRealPropSSvgTo.ptrauth" to i8*)
 // CHECK:     },
 // CHECK:     { i8*, i8*, i8* } {
 // CHECK:       i8* getelementptr inbounds ([16 x i8], [16 x i8]* @"\01L_selector_data(setStrRealProp:)", i64 0, i64 0),
-// CHECK:       i8* getelementptr inbounds ([11 x i8], [11 x i8]* [[SETTER_SIGNATURE]], i64 0, i64 0),
+// CHECK:       i8* getelementptr inbounds ([11 x i8], [11 x i8]* @".str.10.v24@0:8@16", i64 0, i64 0),
 // CHECK-noptrauth: i8* bitcast (void ([[OPAQUE:.*]]*, i8*, [[OPAQUE:.*]]*)* @"$s11objc_bridge3BasC11strRealPropSSvsTo" to i8*)
 // CHECK-ptrauth:   i8* bitcast ({ i8*, i32, i64, i64 }* @"$s11objc_bridge3BasC11strRealPropSSvsTo.ptrauth" to i8*)
 // CHECK:     },
 // CHECK:     { i8*, i8*, i8* } {
 // CHECK:       i8* getelementptr inbounds ([12 x i8], [12 x i8]* @"\01L_selector_data(strFakeProp)", i64 0, i64 0),
-// CHECK:       i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[GETTER_SIGNATURE]], i64 0, i64 0),
+// CHECK:       i8* getelementptr inbounds ([8 x i8], [8 x i8]* @".str.7.@16@0:8", i64 0, i64 0),
 // CHECK-noptrauth: i8* bitcast ([[OPAQUE:.*]]* ([[OPAQUE:.*]]*, i8*)* @"$s11objc_bridge3BasC11strFakePropSSvgTo" to i8*)
 // CHECK-ptrauth:   i8* bitcast ({ i8*, i32, i64, i64 }* @"$s11objc_bridge3BasC11strFakePropSSvgTo.ptrauth" to i8*)
 // CHECK:     },
 // CHECK:     { i8*, i8*, i8* } {
 // CHECK:       i8* getelementptr inbounds ([16 x i8], [16 x i8]* @"\01L_selector_data(setStrFakeProp:)", i64 0, i64 0),
-// CHECK:       i8* getelementptr inbounds ([11 x i8], [11 x i8]* [[SETTER_SIGNATURE]], i64 0, i64 0),
+// CHECK:       i8* getelementptr inbounds ([11 x i8], [11 x i8]* @".str.10.v24@0:8@16", i64 0, i64 0),
 // CHECK-noptrauth: i8* bitcast (void ([[OPAQUE:.*]]*, i8*, [[OPAQUE:.*]]*)* @"$s11objc_bridge3BasC11strFakePropSSvsTo" to i8*)
 // CHECK-ptrauth:   i8* bitcast ({ i8*, i32, i64, i64 }* @"$s11objc_bridge3BasC11strFakePropSSvsTo.ptrauth" to i8*)
 // CHECK:     },
 // CHECK:     { i8*, i8*, i8* } {
 // CHECK:       i8* getelementptr inbounds ([14 x i8], [14 x i8]* @"\01L_selector_data(nsstrRealProp)", i64 0, i64 0),
-// CHECK:       i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[GETTER_SIGNATURE]], i64 0, i64 0),
+// CHECK:       i8* getelementptr inbounds ([8 x i8], [8 x i8]* @".str.7.@16@0:8", i64 0, i64 0),
 // CHECK-noptrauth: i8* bitcast ([[OPAQUE:.*]]* ([[OPAQUE:.*]]*, i8*)* @"$s11objc_bridge3BasC13nsstrRealPropSo8NSStringCvgTo" to i8*)
 // CHECK-ptrauth:   i8* bitcast ({ i8*, i32, i64, i64 }* @"$s11objc_bridge3BasC13nsstrRealPropSo8NSStringCvgTo.ptrauth" to i8*)
 // CHECK:     },
 // CHECK:     { i8*, i8*, i8* } {
 // CHECK:       i8* getelementptr inbounds ([18 x i8], [18 x i8]* @"\01L_selector_data(setNsstrRealProp:)", i64 0, i64 0),
-// CHECK:       i8* getelementptr inbounds ([11 x i8], [11 x i8]* [[SETTER_SIGNATURE]], i64 0, i64 0),
+// CHECK:       i8* getelementptr inbounds ([11 x i8], [11 x i8]* @".str.10.v24@0:8@16", i64 0, i64 0),
 // CHECK-noptrauth: i8* bitcast (void ([[OPAQUE:.*]]*, i8*, [[OPAQUE:.*]]*)* @"$s11objc_bridge3BasC13nsstrRealPropSo8NSStringCvsTo" to i8*)
 // CHECK-ptrauth:   i8* bitcast ({ i8*, i32, i64, i64 }* @"$s11objc_bridge3BasC13nsstrRealPropSo8NSStringCvsTo.ptrauth" to i8*)
 // CHECK:     },
 // CHECK:     { i8*, i8*, i8* } {
 // CHECK:       i8* getelementptr inbounds ([14 x i8], [14 x i8]* @"\01L_selector_data(nsstrFakeProp)", i64 0, i64 0),
-// CHECK:       i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[GETTER_SIGNATURE]], i64 0, i64 0),
+// CHECK:       i8* getelementptr inbounds ([8 x i8], [8 x i8]* @".str.7.@16@0:8", i64 0, i64 0),
 // CHECK-noptrauth: i8* bitcast ([[OPAQUE:.*]]* ([[OPAQUE:.*]]*, i8*)* @"$s11objc_bridge3BasC13nsstrFakePropSo8NSStringCvgTo" to i8*)
 // CHECK-ptrauth:   i8* bitcast ({ i8*, i32, i64, i64 }* @"$s11objc_bridge3BasC13nsstrFakePropSo8NSStringCvgTo.ptrauth" to i8*)
 // CHECK:     },
 // CHECK:     { i8*, i8*, i8* } {
 // CHECK:       i8* getelementptr inbounds ([18 x i8], [18 x i8]* @"\01L_selector_data(setNsstrFakeProp:)", i64 0, i64 0),
-// CHECK:       i8* getelementptr inbounds ([11 x i8], [11 x i8]* [[SETTER_SIGNATURE]], i64 0, i64 0),
+// CHECK:       i8* getelementptr inbounds ([11 x i8], [11 x i8]* @".str.10.v24@0:8@16", i64 0, i64 0),
 // CHECK-noptrauth: i8* bitcast (void ([[OPAQUE:.*]]*, i8*, [[OPAQUE:.*]]*)* @"$s11objc_bridge3BasC13nsstrFakePropSo8NSStringCvsTo" to i8*)
 // CHECK-ptrauth:   i8* bitcast ({ i8*, i32, i64, i64 }* @"$s11objc_bridge3BasC13nsstrFakePropSo8NSStringCvsTo.ptrauth" to i8*)
 // CHECK:     },
 // CHECK:     { i8*, i8*, i8* } {
 // CHECK:       i8* getelementptr inbounds ([10 x i8], [10 x i8]* @"\01L_selector_data(strResult)", i64 0, i64 0),
-// CHECK:       i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[GETTER_SIGNATURE]], i64 0, i64 0),
+// CHECK:       i8* getelementptr inbounds ([8 x i8], [8 x i8]* @".str.7.@16@0:8", i64 0, i64 0),
 // CHECK-noptrauth: i8* bitcast ([[OPAQUE:.*]]* ([[OPAQUE:.*]]*, i8*)* @"$s11objc_bridge3BasC9strResultSSyFTo" to i8*)
 // CHECK-ptrauth:   i8* bitcast ({ i8*, i32, i64, i64 }* @"$s11objc_bridge3BasC9strResultSSyFTo.ptrauth" to i8*)
 // CHECK:     },
 // CHECK:     { i8*, i8*, i8* } {
 // CHECK:       i8* getelementptr inbounds ([{{[0-9]*}} x i8], [{{[0-9]*}} x i8]* @"\01L_selector_data(strArgWithS:)", i64 0, i64 0),
-// CHECK:       i8* getelementptr inbounds ([11 x i8], [11 x i8]* [[SETTER_SIGNATURE]], i64 0, i64 0),
+// CHECK:       i8* getelementptr inbounds ([11 x i8], [11 x i8]* @".str.10.v24@0:8@16", i64 0, i64 0),
 // CHECK-noptrauth: i8* bitcast (void ([[OPAQUE:.*]]*, i8*, [[OPAQUE:.*]]*)* @"$s11objc_bridge3BasC6strArg1sySS_tFTo" to i8*)
 // CHECK-ptrauth:   i8* bitcast ({ i8*, i32, i64, i64 }* @"$s11objc_bridge3BasC6strArg1sySS_tFTo.ptrauth" to i8*)
 // CHECK:     },
 // CHECK:     { i8*, i8*, i8* } {
 // CHECK:       i8* getelementptr inbounds ([12 x i8], [12 x i8]* @"\01L_selector_data(nsstrResult)", i64 0, i64 0),
-// CHECK:       i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[GETTER_SIGNATURE]], i64 0, i64 0),
+// CHECK:       i8* getelementptr inbounds ([8 x i8], [8 x i8]* @".str.7.@16@0:8", i64 0, i64 0),
 // CHECK-noptrauth: i8* bitcast ([[OPAQUE:.*]]* ([[OPAQUE:.*]]*, i8*)* @"$s11objc_bridge3BasC11nsstrResultSo8NSStringCyFTo" to i8*)
 // CHECK-ptrauth:   i8* bitcast ({ i8*, i32, i64, i64 }* @"$s11objc_bridge3BasC11nsstrResultSo8NSStringCyFTo.ptrauth" to i8*)
 // CHECK:     },
 // CHECK:     { i8*, i8*, i8* } {
 // CHECK:       i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* @"\01L_selector_data(nsstrArgWithS:)", i64 0, i64 0),
-// CHECK:       i8* getelementptr inbounds ([11 x i8], [11 x i8]* [[SETTER_SIGNATURE]], i64 0, i64 0),
+// CHECK:       i8* getelementptr inbounds ([11 x i8], [11 x i8]* @".str.10.v24@0:8@16", i64 0, i64 0),
 // CHECK-noptrauth: i8* bitcast (void ([[OPAQUE:.*]]*, i8*, [[OPAQUE:.*]]*)* @"$s11objc_bridge3BasC8nsstrArg1sySo8NSStringC_tFTo" to i8*)
 // CHECK-ptrauth:   i8* bitcast ({ i8*, i32, i64, i64 }* @"$s11objc_bridge3BasC8nsstrArg1sySo8NSStringC_tFTo.ptrauth" to i8*)
 // CHECK:     },
 // CHECK:     { i8*, i8*, i8* } { 
 // CHECK:       i8* getelementptr inbounds ([5 x i8], [5 x i8]* @"\01L_selector_data(init)", i64 0, i64 0), 
-// CHECK:       i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[GETTER_SIGNATURE]], i64 0, i64 0),
+// CHECK:       i8* getelementptr inbounds ([8 x i8], [8 x i8]* @".str.7.@16@0:8", i64 0, i64 0),
 // CHECK-noptrauth: i8* bitcast ([[OPAQUE:.*]]* ([[OPAQUE:.*]]*, i8*)* @"$s11objc_bridge3BasCACycfcTo" to i8*)
 // CHECK-ptrauth:   i8* bitcast ({ i8*, i32, i64, i64 }* @"$s11objc_bridge3BasCACycfcTo.ptrauth" to i8*)
 // CHECK:     },
 // CHECK:     { i8*, i8*, i8* } { 
 // CHECK:       i8* getelementptr inbounds ([8 x i8], [8 x i8]* @"\01L_selector_data(dealloc)", i64 0, i64 0), 
-// CHECK:       i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[DEALLOC_SIGNATURE]], i64 0, i64 0),
+// CHECK:       i8* getelementptr inbounds ([8 x i8], [8 x i8]* @".str.7.v16@0:8", i64 0, i64 0),
 // CHECK-noptrauth: i8* bitcast (void ([[OPAQUE:.*]]*, i8*)* @"$s11objc_bridge3BasCfDTo" to i8*)
 // CHECK-ptrauth:   i8* bitcast ({ i8*, i32, i64, i64 }* @"$s11objc_bridge3BasCfDTo.ptrauth" to i8*)
 // CHECK:     },
 // CHECK:     { i8*, i8*, i8* } {
 // CHECK:       i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"\01L_selector_data(acceptSet:)", i64 0, i64 0),
-// CHECK:       i8* getelementptr inbounds ([11 x i8], [11 x i8]* @.str.{{[0-9]+}}, i64 0, i64 0),
+// CHECK:       i8* getelementptr inbounds ([11 x i8], [11 x i8]* @".str.10.v24@0:8@16", i64 0, i64 0),
 // CHECK-noptrauth: i8* bitcast (void (%3*, i8*, %4*)* @"$s11objc_bridge3BasC9acceptSetyyShyACGFTo" to i8*)
 // CHECK-ptrauth:   i8* bitcast ({ i8*, i32, i64, i64 }* @"$s11objc_bridge3BasC9acceptSetyyShyACGFTo.ptrauth" to i8*)
 // CHECK:     }

--- a/test/IRGen/objc_bridged_generic_conformance.swift
+++ b/test/IRGen/objc_bridged_generic_conformance.swift
@@ -2,9 +2,7 @@
 
 // CHECK-NOT: _TMnCSo
 
-// CHECK: @"$sSo6ThingyCyxG32objc_bridged_generic_conformance1PADMc" = hidden constant %swift.protocol_conformance_descriptor {{.*}} @.str
-
-// CHECK: @.str = private constant [7 x i8] c"Thingy\00"
+// CHECK: @"$sSo6ThingyCyxG32objc_bridged_generic_conformance1PADMc" = hidden constant %swift.protocol_conformance_descriptor {{.*}} @.str.6.Thingy
 
 // CHECK-NOT: _TMnCSo
 

--- a/test/IRGen/objc_protocols.swift
+++ b/test/IRGen/objc_protocols.swift
@@ -1,7 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -emit-module -o %t %S/Inputs/objc_protocols_Bas.swift
-// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir -disable-objc-attr-requires-foundation-module | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) -primary-file %s -emit-ir -disable-objc-attr-requires-foundation-module > %t/out.ir
+// RUN: %FileCheck --input-file=%t/out.ir %s
 
 // REQUIRES: PTRSIZE=64
 // REQUIRES: objc_interop
@@ -28,9 +29,9 @@ class Foo : NSRuncing, NSFunging, Ansible {
 // CHECK: @_INSTANCE_METHODS__TtC14objc_protocols3Foo = internal constant { i32, i32, [3 x { i8*, i8*, i8* }] } {
 // CHECK:   i32 24, i32 3,
 // CHECK:   [3 x { i8*, i8*, i8* }] [
-// CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([6 x i8], [6 x i8]* @"\01L_selector_data(runce)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[ENC:@.str.[0-9]+]], i64 0, i64 0), i8* bitcast ({{.*}}* @"$s14objc_protocols3FooC5runceyyFTo{{(\.ptrauth)?}}" to i8*) },
-// CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([6 x i8], [6 x i8]* @"\01L_selector_data(funge)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[ENC]], i64 0, i64 0), i8* bitcast ({{.*}}* @"$s14objc_protocols3FooC5fungeyyFTo{{(\.ptrauth)?}}" to i8*) },
-// CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"\01L_selector_data(foo)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[ENC]], i64 0, i64 0), i8* bitcast ({{.*}}* @"$s14objc_protocols3FooC3fooyyFTo{{(\.ptrauth)?}}" to i8*)
+// CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([6 x i8], [6 x i8]* @"\01L_selector_data(runce)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* @".str.7.v16@0:8", i64 0, i64 0), i8* bitcast ({{.*}}* @"$s14objc_protocols3FooC5runceyyFTo{{(\.ptrauth)?}}" to i8*) },
+// CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([6 x i8], [6 x i8]* @"\01L_selector_data(funge)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* @".str.7.v16@0:8", i64 0, i64 0), i8* bitcast ({{.*}}* @"$s14objc_protocols3FooC5fungeyyFTo{{(\.ptrauth)?}}" to i8*) },
+// CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"\01L_selector_data(foo)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* @".str.7.v16@0:8", i64 0, i64 0), i8* bitcast ({{.*}}* @"$s14objc_protocols3FooC3fooyyFTo{{(\.ptrauth)?}}" to i8*)
 // CHECK:   }]
 // CHECK: }, section "__DATA, {{.*}}", align 8
 
@@ -53,9 +54,9 @@ extension Bar : NSRuncing, NSFunging {
 // CHECK: @"_CATEGORY_INSTANCE_METHODS__TtC14objc_protocols3Bar_$_objc_protocols" = internal constant { i32, i32, [3 x { i8*, i8*, i8* }] } {
 // CHECK:   i32 24, i32 3,
 // CHECK:   [3 x { i8*, i8*, i8* }] [
-// CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([6 x i8], [6 x i8]* @"\01L_selector_data(runce)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[ENC]], i64 0, i64 0), i8* bitcast ({{.*}}* @"$s14objc_protocols3BarC5runceyyFTo{{(\.ptrauth)?}}" to i8*) },
-// CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([6 x i8], [6 x i8]* @"\01L_selector_data(funge)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[ENC]], i64 0, i64 0), i8* bitcast ({{.*}}* @"$s14objc_protocols3BarC5fungeyyFTo{{(\.ptrauth)?}}" to i8*) },
-// CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"\01L_selector_data(foo)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[ENC]], i64 0, i64 0), i8* bitcast ({{.*}}* @"$s14objc_protocols3BarC3fooyyFTo{{(\.ptrauth)?}}" to i8*) }
+// CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([6 x i8], [6 x i8]* @"\01L_selector_data(runce)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* @".str.7.v16@0:8", i64 0, i64 0), i8* bitcast ({{.*}}* @"$s14objc_protocols3BarC5runceyyFTo{{(\.ptrauth)?}}" to i8*) },
+// CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([6 x i8], [6 x i8]* @"\01L_selector_data(funge)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* @".str.7.v16@0:8", i64 0, i64 0), i8* bitcast ({{.*}}* @"$s14objc_protocols3BarC5fungeyyFTo{{(\.ptrauth)?}}" to i8*) },
+// CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"\01L_selector_data(foo)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* @".str.7.v16@0:8", i64 0, i64 0), i8* bitcast ({{.*}}* @"$s14objc_protocols3BarC3fooyyFTo{{(\.ptrauth)?}}" to i8*) }
 // CHECK:   ]
 // CHECK: }, section "__DATA, {{.*}}", align 8
 
@@ -69,7 +70,7 @@ extension Bas : NSRuncing {
 // CHECK: @"_CATEGORY_INSTANCE_METHODS__TtC18objc_protocols_Bas3Bas_$_objc_protocols" = internal constant { i32, i32, [1 x { i8*, i8*, i8* }] } {
 // CHECK:   i32 24, i32 1,
 // CHECK:   [1 x { i8*, i8*, i8* }] [
-// CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"\01L_selector_data(foo)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[ENC]], i64 0, i64 0), i8* bitcast ({{.*}}* @"$s18objc_protocols_Bas0C0C0a1_B0E3fooyyFTo{{(\.ptrauth)?}}" to i8*) }
+// CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"\01L_selector_data(foo)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* @".str.7.v16@0:8", i64 0, i64 0), i8* bitcast ({{.*}}* @"$s18objc_protocols_Bas0C0C0a1_B0E3fooyyFTo{{(\.ptrauth)?}}" to i8*) }
 // CHECK:   ]
 // CHECK: }, section "__DATA, {{.*}}", align 8
 
@@ -89,9 +90,9 @@ class Zim : Frungible {
 // CHECK: @_INSTANCE_METHODS__TtC14objc_protocols3Zim = internal constant { i32, i32, [3 x { i8*, i8*, i8* }] } {
 // CHECK:   i32 24, i32 3,
 // CHECK:   [3 x { i8*, i8*, i8* }] [
-// CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([6 x i8], [6 x i8]* @"\01L_selector_data(runce)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[ENC]], i64 0, i64 0), i8* bitcast ({{.*}}* @"$s14objc_protocols3ZimC5runceyyFTo{{(\.ptrauth)?}}" to i8*) },
-// CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([6 x i8], [6 x i8]* @"\01L_selector_data(funge)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[ENC]], i64 0, i64 0), i8* bitcast ({{.*}}* @"$s14objc_protocols3ZimC5fungeyyFTo{{(\.ptrauth)?}}" to i8*) },
-// CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"\01L_selector_data(foo)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[ENC]], i64 0, i64 0), i8* bitcast ({{.*}}* @"$s14objc_protocols3ZimC3fooyyFTo{{(\.ptrauth)?}}" to i8*) }
+// CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([6 x i8], [6 x i8]* @"\01L_selector_data(runce)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* @".str.7.v16@0:8", i64 0, i64 0), i8* bitcast ({{.*}}* @"$s14objc_protocols3ZimC5runceyyFTo{{(\.ptrauth)?}}" to i8*) },
+// CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([6 x i8], [6 x i8]* @"\01L_selector_data(funge)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* @".str.7.v16@0:8", i64 0, i64 0), i8* bitcast ({{.*}}* @"$s14objc_protocols3ZimC5fungeyyFTo{{(\.ptrauth)?}}" to i8*) },
+// CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"\01L_selector_data(foo)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* @".str.7.v16@0:8", i64 0, i64 0), i8* bitcast ({{.*}}* @"$s14objc_protocols3ZimC3fooyyFTo{{(\.ptrauth)?}}" to i8*) }
 // CHECK:   ]
 // CHECK: }, section "__DATA, {{.*}}", align 8
 
@@ -109,8 +110,8 @@ extension Zang : Frungible {
 // CHECK: @"_CATEGORY_INSTANCE_METHODS__TtC18objc_protocols_Bas4Zang_$_objc_protocols" = internal constant { i32, i32, [2 x { i8*, i8*, i8* }] } {
 // CHECK:   i32 24, i32 2,
 // CHECK:   [2 x { i8*, i8*, i8* }] [
-// CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([6 x i8], [6 x i8]* @"\01L_selector_data(runce)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[ENC]], i64 0, i64 0), i8* bitcast ({{.*}}* @"$s18objc_protocols_Bas4ZangC0a1_B0E5runceyyFTo{{(\.ptrauth)?}}" to i8*) },
-// CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"\01L_selector_data(foo)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[ENC]], i64 0, i64 0), i8* bitcast ({{.*}}* @"$s18objc_protocols_Bas4ZangC0a1_B0E3fooyyFTo{{(\.ptrauth)?}}" to i8*) }
+// CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([6 x i8], [6 x i8]* @"\01L_selector_data(runce)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* @".str.7.v16@0:8", i64 0, i64 0), i8* bitcast ({{.*}}* @"$s18objc_protocols_Bas4ZangC0a1_B0E5runceyyFTo{{(\.ptrauth)?}}" to i8*) },
+// CHECK:     { i8*, i8*, i8* } { i8* getelementptr inbounds ([4 x i8], [4 x i8]* @"\01L_selector_data(foo)", i64 0, i64 0), i8* getelementptr inbounds ([8 x i8], [8 x i8]* @".str.7.v16@0:8", i64 0, i64 0), i8* bitcast ({{.*}}* @"$s18objc_protocols_Bas4ZangC0a1_B0E3fooyyFTo{{(\.ptrauth)?}}" to i8*) }
 // CHECK:   ]
 // CHECK: }, section "__DATA, {{.*}}", align 8
 

--- a/test/IRGen/objc_runtime_visible_conformance.swift
+++ b/test/IRGen/objc_runtime_visible_conformance.swift
@@ -10,8 +10,8 @@ extension A : YourProtocol {}
 
 // CHECK-LABEL: @"$sSo1AC32objc_runtime_visible_conformance10MyProtocolACMc"
 // CHECK-SAME:    @"$s32objc_runtime_visible_conformance10MyProtocolMp"
-// CHECK-SAME:    @.str
+// CHECK-SAME:    @.str.21.MyRuntimeVisibleClass
 // CHECK-SAME:    @"$sSo1AC32objc_runtime_visible_conformance10MyProtocolACWP"
 //   DirectObjCClassName
 // CHECK-SAME:    i32 16
-// CHECK:       @.str = private constant [22 x i8] c"MyRuntimeVisibleClass\00"
+// CHECK:       @.str.21.MyRuntimeVisibleClass = private constant [22 x i8] c"MyRuntimeVisibleClass\00"

--- a/test/IRGen/objc_subclass.swift
+++ b/test/IRGen/objc_subclass.swift
@@ -22,14 +22,12 @@
 
 // CHECK: @"OBJC_METACLASS_$__TtC13objc_subclass10SwiftGizmo" = hidden global [[OBJC_CLASS]] { [[OBJC_CLASS]]* @"OBJC_METACLASS_$_NSObject", [[OBJC_CLASS]]* @"OBJC_METACLASS_$_Gizmo", [[OPAQUE]]* @_objc_empty_cache, [[OPAQUE]]* null, [[LLVM_PTRSIZE_INT]] ptrtoint ({{.*}} @_METACLASS_DATA__TtC13objc_subclass10SwiftGizmo to [[LLVM_PTRSIZE_INT]]) }
 
-// CHECK: [[STRING_SWIFTGIZMO:@.*]] = private unnamed_addr constant [32 x i8] c"_TtC13objc_subclass10SwiftGizmo\00"
-
 // CHECK-32: @_METACLASS_DATA__TtC13objc_subclass10SwiftGizmo = internal constant { {{.*}}* } {
 // CHECK-32:   i32 129,
 // CHECK-32:   i32 20,
 // CHECK-32:   i32 20,
 // CHECK-32:   i8* null,
-// CHECK-32:   i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* [[STRING_SWIFTGIZMO]], i32 0, i32 0),
+// CHECK-32:   i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* @.str.31._TtC13objc_subclass10SwiftGizmo, i32 0, i32 0),
 // CHECK-32:   i8* null,
 // CHECK-32:   i8* null,
 // CHECK-32:   i8* null,
@@ -43,7 +41,7 @@
 // CHECK-64:   i32 40,
 // CHECK-64:   i32 0,
 // CHECK-64:   i8* null,
-// CHECK-64:   i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* [[STRING_SWIFTGIZMO]], i64 0, i64 0),
+// CHECK-64:   i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* @.str.31._TtC13objc_subclass10SwiftGizmo, i64 0, i64 0),
 // CHECK-64:   i8* null,
 // CHECK-64:   i8* null,
 // CHECK-64:   i8* null,
@@ -51,63 +49,52 @@
 // CHECK-64:   i8* null
 // CHECK-64: }, section "__DATA, {{.*}}", align 8
 
-// CHECK-32: [[METHOD_TYPE_ENCODING1:@.*]] = private unnamed_addr constant [7 x i8] c"l8@0:4\00"
-// CHECK-64: [[METHOD_TYPE_ENCODING1:@.*]] = private unnamed_addr constant [8 x i8] c"q16@0:8\00"
-// CHECK-32: [[METHOD_TYPE_ENCODING2:@.*]] = private unnamed_addr constant [10 x i8] c"v12@0:4l8\00"
-// CHECK-64: [[METHOD_TYPE_ENCODING2:@.*]] = private unnamed_addr constant [11 x i8] c"v24@0:8q16\00"
-// CHECK-32: [[GETTER_ENCODING:@.*]] = private unnamed_addr constant [7 x i8] c"@8@0:4\00"
-// CHECK-64: [[GETTER_ENCODING:@.*]] = private unnamed_addr constant [8 x i8] c"@16@0:8\00"
-// CHECK-32: [[INIT_ENCODING:@.*]] = private unnamed_addr constant [13 x i8] c"@16@0:4l8@12\00"
-// CHECK-64: [[INIT_ENCODING:@.*]] = private unnamed_addr constant [14 x i8] c"@32@0:8q16@24\00"
-// CHECK-32: [[DEALLOC_ENCODING:@.*]] = private unnamed_addr constant [7 x i8] c"v8@0:4\00"
-// CHECK-64: [[DEALLOC_ENCODING:@.*]] = private unnamed_addr constant [8 x i8] c"v16@0:8\00"
-
 // CHECK-32: @_INSTANCE_METHODS__TtC13objc_subclass10SwiftGizmo = internal constant { {{.*}}] } {
 // CHECK-32:   i32 12,
 // CHECK-32:   i32 11,
 // CHECK-32:   [11 x { i8*, i8*, i8* }] [{ i8*, i8*, i8* } {
 // CHECK-32:     i8* getelementptr inbounds ([2 x i8], [2 x i8]* @"\01L_selector_data(x)", i32 0, i32 0),
-// CHECK-32:     i8* getelementptr inbounds ([7 x i8], [7 x i8]* [[METHOD_TYPE_ENCODING1]], i32 0, i32 0),
+// CHECK-32:     i8* getelementptr inbounds ([7 x i8], [7 x i8]* @".str.6.l8@0:4", i32 0, i32 0),
 // CHECK-32:     i8* bitcast {{.*}}* @"$s13objc_subclass10SwiftGizmoC1xSivgTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-32:   }, { i8*, i8*, i8* } {
 // CHECK-32:     i8* getelementptr inbounds ([6 x i8], [6 x i8]* @"\01L_selector_data(setX:)", i32 0, i32 0),
-// CHECK-32:     i8* getelementptr inbounds ([10 x i8], [10 x i8]* [[METHOD_TYPE_ENCODING2]], i32 0, i32 0),
+// CHECK-32:     i8* getelementptr inbounds ([10 x i8], [10 x i8]* @".str.9.v12@0:4l8", i32 0, i32 0),
 // CHECK-32:     i8* bitcast {{.*}}* @"$s13objc_subclass10SwiftGizmoC1xSivsTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-32:   }, { i8*, i8*, i8* } {
 // CHECK-32:     i8* getelementptr inbounds ([5 x i8], [5 x i8]* @"\01L_selector_data(getX)", i32 0, i32 0),
-// CHECK-32:     i8* getelementptr inbounds ([7 x i8], [7 x i8]* [[METHOD_TYPE_ENCODING1]], i32 0, i32 0),
+// CHECK-32:     i8* getelementptr inbounds ([7 x i8], [7 x i8]* @".str.6.l8@0:4", i32 0, i32 0),
 // CHECK-32:     i8* bitcast {{.*}}* @"$s13objc_subclass10SwiftGizmoC4getXSiyFTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-32:   }, { i8*, i8*, i8* } {
 // CHECK-32:     i8* getelementptr inbounds ([10 x i8], [10 x i8]* @"\01L_selector_data(duplicate)", i32 0, i32 0),
-// CHECK-32:     i8* getelementptr inbounds ([7 x i8], [7 x i8]* [[GETTER_ENCODING]], i32 0, i32 0),
+// CHECK-32:     i8* getelementptr inbounds ([7 x i8], [7 x i8]* @".str.6.@8@0:4", i32 0, i32 0),
 // CHECK-32:     i8* bitcast ({{.*}}* @"$s13objc_subclass10SwiftGizmoC9duplicateSo0D0CyFTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-32:   }, { i8*, i8*, i8* } {
 // CHECK-32:     i8* getelementptr inbounds ([5 x i8], [5 x i8]* @"\01L_selector_data(init)", i32 0, i32 0),
-// CHECK-32:     i8* getelementptr inbounds ([7 x i8], [7 x i8]* [[GETTER_ENCODING]], i32 0, i32 0),
+// CHECK-32:     i8* getelementptr inbounds ([7 x i8], [7 x i8]* @".str.6.@8@0:4", i32 0, i32 0),
 // CHECK-32:     i8* bitcast ({{.*}}* @"$s13objc_subclass10SwiftGizmoCACycfcTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-32:   }, { i8*, i8*, i8* } {
 // CHECK-32:     i8* getelementptr inbounds ([20 x i8], [20 x i8]* @"\01L_selector_data(initWithInt:string:)", i32 0, i32 0),
-// CHECK-32:     i8* getelementptr inbounds ([13 x i8], [13 x i8]* [[INIT_ENCODING]], i32 0, i32 0),
+// CHECK-32:     i8* getelementptr inbounds ([13 x i8], [13 x i8]* @".str.12.@16@0:4l8@12", i32 0, i32 0),
 // CHECK-32:     i8* bitcast ({{.*}}* @"$s13objc_subclass10SwiftGizmoC3int6stringACSi_SStcfcTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-32:   }, { i8*, i8*, i8* } {
 // CHECK-32:     i8* getelementptr inbounds ([8 x i8], [8 x i8]* @"\01L_selector_data(dealloc)", i32 0, i32 0),
-// CHECK-32:     i8* getelementptr inbounds ([7 x i8], [7 x i8]* [[DEALLOC_ENCODING]], i32 0, i32 0),
+// CHECK-32:     i8* getelementptr inbounds ([7 x i8], [7 x i8]* @".str.6.v8@0:4", i32 0, i32 0),
 // CHECK-32:     i8* bitcast {{.*}}* @"$s13objc_subclass10SwiftGizmoCfDTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-32:   }, { i8*, i8*, i8* } {
 // CHECK-32:     i8* getelementptr inbounds ([10 x i8], [10 x i8]* @"\01L_selector_data(isEnabled)", i32 0, i32 0),
-// CHECK-32:     i8* getelementptr inbounds ([7 x i8], [7 x i8]* {{@.str.[0-9]+}}, i32 0, i32 0),
+// CHECK-32:     i8* getelementptr inbounds ([7 x i8], [7 x i8]* {{@".str.[^"]+"}}, i32 0, i32 0),
 // CHECK-32:     i8* bitcast ({{.*}}* @"$s13objc_subclass10SwiftGizmoC7enabledSbvgTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-32:   }, { i8*, i8*, i8* } {
 // CHECK-32:     i8* getelementptr inbounds ([14 x i8], [14 x i8]* @"\01L_selector_data(setIsEnabled:)", i32 0, i32 0),
-// CHECK-32:     i8* getelementptr inbounds ([10 x i8], [10 x i8]* {{@.str.[0-9]+}}, i32 0, i32 0),
+// CHECK-32:     i8* getelementptr inbounds ([10 x i8], [10 x i8]* {{@".str.[^"]+"}}, i32 0, i32 0),
 // CHECK-32:     i8* bitcast ({{.*}}* @"$s13objc_subclass10SwiftGizmoC7enabledSbvsTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-32:   }, { i8*, i8*, i8* } {
 // CHECK-32:     i8* getelementptr inbounds ([17 x i8], [17 x i8]* @"\01L_selector_data(initWithBellsOn:)", i32 0, i32 0),
-// CHECK-32:     i8* getelementptr inbounds ([10 x i8], [10 x i8]* {{@.str.[0-9]+}}, i32 0, i32 0),
+// CHECK-32:     i8* getelementptr inbounds ([10 x i8], [10 x i8]* {{@".str.[^"]+"}}, i32 0, i32 0),
 // CHECK-32:     i8* bitcast ({{.*}}* @"$s13objc_subclass10SwiftGizmoC7bellsOnACSgSi_tcfcTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-32:   }, { i8*, i8*, i8* } {
 // CHECK-32:     i8* getelementptr inbounds ([15 x i8], [15 x i8]* @"\01L_selector_data(.cxx_construct)", i32 0, i32 0),
-// CHECK-32:     i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* {{@.str.[0-9]+}}, i32 0, i32 0),
+// CHECK-32:     i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* {{@".str.[^"]+"}}, i32 0, i32 0),
 // CHECK-32:     i8* bitcast ({{.*}}* @"$s13objc_subclass10SwiftGizmoCfeTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-32:   }]
 // CHECK-32: }, section "__DATA, {{.*}}", align 4
@@ -117,60 +104,57 @@
 // CHECK-64:   i32 11,
 // CHECK-64:   [11 x { i8*, i8*, i8* }] [{
 // CHECK-64:      i8* getelementptr inbounds ([2 x i8], [2 x i8]* @"\01L_selector_data(x)", i64 0, i64 0),
-// CHECK-64:      i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[METHOD_TYPE_ENCODING1]], i64 0, i64 0)
+// CHECK-64:      i8* getelementptr inbounds ([8 x i8], [8 x i8]* @".str.7.q16@0:8", i64 0, i64 0)
 // CHECK-64:      i8* bitcast ({{.*}}* @"$s13objc_subclass10SwiftGizmoC1xSivgTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-64:   }, {
 // CHECK-64:      i8* getelementptr inbounds ([6 x i8], [6 x i8]* @"\01L_selector_data(setX:)", i64 0, i64 0),
-// CHECK-64:      i8* getelementptr inbounds ([11 x i8], [11 x i8]* [[METHOD_TYPE_ENCODING2]], i64 0, i64 0)
+// CHECK-64:      i8* getelementptr inbounds ([11 x i8], [11 x i8]* @".str.10.v24@0:8q16", i64 0, i64 0)
 // CHECK-64:      i8* bitcast ({{.*}}* @"$s13objc_subclass10SwiftGizmoC1xSivsTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-64:   }, {
 // CHECK-64:      i8* getelementptr inbounds ([5 x i8], [5 x i8]* @"\01L_selector_data(getX)", i64 0, i64 0),
-// CHECK-64:      i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[METHOD_TYPE_ENCODING1]], i64 0, i64 0)
+// CHECK-64:      i8* getelementptr inbounds ([8 x i8], [8 x i8]* @".str.7.q16@0:8", i64 0, i64 0)
 // CHECK-64:      i8* bitcast ({{.*}}* @"$s13objc_subclass10SwiftGizmoC4getXSiyFTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-64:   }, {
 // CHECK-64:     i8* getelementptr inbounds ([10 x i8], [10 x i8]* @"\01L_selector_data(duplicate)", i64 0, i64 0),
-// CHECK-64:     i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[GETTER_ENCODING]], i64 0, i64 0),
+// CHECK-64:     i8* getelementptr inbounds ([8 x i8], [8 x i8]* @".str.7.@16@0:8", i64 0, i64 0),
 // CHECK-64:     i8* bitcast ({{.*}}* @"$s13objc_subclass10SwiftGizmoC9duplicateSo0D0CyFTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-64:   }, {
 // CHECK-64:     i8* getelementptr inbounds ([5 x i8], [5 x i8]* @"\01L_selector_data(init)", i64 0, i64 0),
-// CHECK-64:     i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[GETTER_ENCODING]], i64 0, i64 0),
+// CHECK-64:     i8* getelementptr inbounds ([8 x i8], [8 x i8]* @".str.7.@16@0:8", i64 0, i64 0),
 // CHECK-64:     i8* bitcast ({{.*}}* @"$s13objc_subclass10SwiftGizmoCACycfcTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-64:   }, {
 // CHECK-64:     i8* getelementptr inbounds ([20 x i8], [20 x i8]* @"\01L_selector_data(initWithInt:string:)", i64 0, i64 0),
-// CHECK-64:     i8* getelementptr inbounds ([14 x i8], [14 x i8]* [[INIT_ENCODING]], i64 0, i64 0),
+// CHECK-64:     i8* getelementptr inbounds ([14 x i8], [14 x i8]* @".str.13.@32@0:8q16@24", i64 0, i64 0),
 // CHECK-64:     i8* bitcast ({{.*}}* @"$s13objc_subclass10SwiftGizmoC3int6stringACSi_SStcfcTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-64:   }, {
 // CHECK-64:     i8* getelementptr inbounds ([8 x i8], [8 x i8]* @"\01L_selector_data(dealloc)", i64 0, i64 0),
-// CHECK-64:     i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[DEALLOC_ENCODING]], i64 0, i64 0),
+// CHECK-64:     i8* getelementptr inbounds ([8 x i8], [8 x i8]* @".str.7.v16@0:8", i64 0, i64 0),
 // CHECK-64:     i8* bitcast ({{.*}}* @"$s13objc_subclass10SwiftGizmoCfDTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-64:   }, {
 // CHECK-64:     i8* getelementptr inbounds ([10 x i8], [10 x i8]* @"\01L_selector_data(isEnabled)", i64 0, i64 0),
-// CHECK-64:     i8* getelementptr inbounds ([8 x i8], [8 x i8]* {{@.str.[0-9]+}}, i64 0, i64 0),
+// CHECK-64:     i8* getelementptr inbounds ([8 x i8], [8 x i8]* @".str.7.{{[Bc]}}16@0:8", i64 0, i64 0),
 // CHECK-64:     i8* bitcast ({{.*}}* @"$s13objc_subclass10SwiftGizmoC7enabledSbvgTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-64:   }, {
 // CHECK-64:     i8* getelementptr inbounds ([14 x i8], [14 x i8]* @"\01L_selector_data(setIsEnabled:)", i64 0, i64 0),
-// CHECK-64:     i8* getelementptr inbounds ([11 x i8], [11 x i8]* {{@.str.[0-9]+}}, i64 0, i64 0),
+// CHECK-64:     i8* getelementptr inbounds ([11 x i8], [11 x i8]* @".str.10.v20@0:8{{[Bc]}}16", i64 0, i64 0),
 // CHECK-64:     i8* bitcast ({{.*}}* @"$s13objc_subclass10SwiftGizmoC7enabledSbvsTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-64:   }, {
 // CHECK-64:     i8* getelementptr inbounds ([17 x i8], [17 x i8]* @"\01L_selector_data(initWithBellsOn:)", i64 0, i64 0),
-// CHECK-64:     i8* getelementptr inbounds ([11 x i8], [11 x i8]* {{@.str.[0-9]+}}, i64 0, i64 0),
+// CHECK-64:     i8* getelementptr inbounds ([11 x i8], [11 x i8]* @".str.10.@24@0:8q16", i64 0, i64 0),
 // CHECK-64:     i8* bitcast ({{.*}}* @"$s13objc_subclass10SwiftGizmoC7bellsOnACSgSi_tcfcTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-64:   }, {
 // CHECK-64:     i8* getelementptr inbounds ([15 x i8], [15 x i8]* @"\01L_selector_data(.cxx_construct)", i64 0, i64 0),
-// CHECK-64:     i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* {{@.str.[0-9]+}}, i64 0, i64 0),
+// CHECK-64:     i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* @".str.7.v16@0:8", i64 0, i64 0),
 // CHECK-64:     i8* bitcast ({{.*}}* @"$s13objc_subclass10SwiftGizmoCfeTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-64:   }]
 // CHECK-64: }, section "__DATA, {{.*}}", align 8
-
-// CHECK: [[STRING_X:@.*]] = private unnamed_addr constant [2 x i8] c"x\00"
-// CHECK-64: [[STRING_EMPTY:@.*]] = private unnamed_addr constant [1 x i8] zeroinitializer
 
 // CHECK-32: @_IVARS__TtC13objc_subclass10SwiftGizmo = internal constant { {{.*}}] } {
 // CHECK-32:   i32 20,
 // CHECK-32:   i32 1,
 // CHECK-32:   [1 x { i32*, i8*, i8*, i32, i32 }] [{ i32*, i8*, i8*, i32, i32 } {
 // CHECK-32:     i32* @"$s13objc_subclass10SwiftGizmoC1xSivpWvd",
-// CHECK-32:     i8* getelementptr inbounds ([2 x i8], [2 x i8]* [[STRING_X]], i32 0, i32 0),
+// CHECK-32:     i8* getelementptr inbounds ([2 x i8], [2 x i8]* @.str.1.x, i32 0, i32 0),
 // CHECK-32:     i8* getelementptr inbounds ([1 x i8], [1 x i8]* {{.*}}, i32 0, i32 0),
 // CHECK-32:     i32 2,
 // CHECK-32:     i32 4 }]
@@ -181,8 +165,8 @@
 // CHECK-64:   i32 1,
 // CHECK-64:   [1 x { i64*, i8*, i8*, i32, i32 }] [{ i64*, i8*, i8*, i32, i32 } {
 // CHECK-64:     i64* @"$s13objc_subclass10SwiftGizmoC1xSivpWvd",
-// CHECK-64:     i8* getelementptr inbounds ([2 x i8], [2 x i8]* [[STRING_X]], i64 0, i64 0),
-// CHECK-64:     i8* getelementptr inbounds ([1 x i8], [1 x i8]* [[STRING_EMPTY]], i64 0, i64 0),
+// CHECK-64:     i8* getelementptr inbounds ([2 x i8], [2 x i8]* @.str.1.x, i64 0, i64 0),
+// CHECK-64:     i8* getelementptr inbounds ([1 x i8], [1 x i8]* @.str.0., i64 0, i64 0),
 // CHECK-64:     i32 3,
 // CHECK-64:     i32 8 }]
 // CHECK-64: }, section "__DATA, {{.*}}", align 8
@@ -192,7 +176,7 @@
 // CHECK-32:   i32 4,
 // CHECK-32:   i32 8,
 // CHECK-32:   i8* null,
-// CHECK-32:   i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* [[STRING_SWIFTGIZMO]], i32 0, i32 0),
+// CHECK-32:   i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* @.str.31._TtC13objc_subclass10SwiftGizmo, i32 0, i32 0),
 // CHECK-32:   @_INSTANCE_METHODS__TtC13objc_subclass10SwiftGizmo,
 // CHECK-32:   i8* null,
 // CHECK-32:   @_IVARS__TtC13objc_subclass10SwiftGizmo,
@@ -206,7 +190,7 @@
 // CHECK-64:    i32 16,
 // CHECK-64:    i32 0,
 // CHECK-64:    i8* null,
-// CHECK-64:    i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* [[STRING_SWIFTGIZMO]], i64 0, i64 0),
+// CHECK-64:    i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* @.str.31._TtC13objc_subclass10SwiftGizmo, i64 0, i64 0),
 // CHECK-64:    @_INSTANCE_METHODS__TtC13objc_subclass10SwiftGizmo,
 // CHECK-64:    i8* null,
 // CHECK-64:    @_IVARS__TtC13objc_subclass10SwiftGizmo,
@@ -227,7 +211,7 @@
 // CHECK-32:   [5 x { i8*, i8*, i8* }] [
 // CHECK-32:     {
 // CHECK-32:       i8* getelementptr inbounds ([3 x i8], [3 x i8]* @"\01L_selector_data(sg)", i32 0, i32 0),
-// CHECK-32:       i8* getelementptr inbounds ([7 x i8], [7 x i8]* [[GETTER_ENCODING]], i32 0, i32 0),
+// CHECK-32:       i8* getelementptr inbounds ([7 x i8], [7 x i8]* @".str.6.@8@0:4", i32 0, i32 0),
 // CHECK-32:       i8* bitcast ({{.*}}* @"$s13objc_subclass11SwiftGizmo2C2sgAA0C5GizmoCvgTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-32:     }, {
 // CHECK-32:       i8* getelementptr inbounds ([7 x i8], [7 x i8]* @"\01L_selector_data(setSg:)", i32 0, i32 0),
@@ -235,15 +219,15 @@
 // CHECK-32:       i8* bitcast ({{.*}}* @"$s13objc_subclass11SwiftGizmo2C2sgAA0C5GizmoCvsTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-32:     }, {
 // CHECK-32:       i8* getelementptr inbounds ([5 x i8], [5 x i8]* @"\01L_selector_data(init)", i32 0, i32 0),
-// CHECK-32:       i8* getelementptr inbounds ([7 x i8], [7 x i8]* [[GETTER_ENCODING]], i32 0, i32 0),
+// CHECK-32:       i8* getelementptr inbounds ([7 x i8], [7 x i8]* @".str.6.@8@0:4", i32 0, i32 0),
 // CHECK-32:       i8* bitcast ({{.*}}* @"$s13objc_subclass11SwiftGizmo2CACycfcTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-32:     }, {
 // CHECK-32:       i8* getelementptr inbounds ([17 x i8], [17 x i8]* @"\01L_selector_data(initWithBellsOn:)", i32 0, i32 0),
-// CHECK-32:       i8* getelementptr inbounds ([10 x i8], [10 x i8]* {{@.str.[0-9]+}}, i32 0, i32 0),
+// CHECK-32:       i8* getelementptr inbounds ([10 x i8], [10 x i8]* {{@".str.[^"]+"}}, i32 0, i32 0),
 // CHECK-32:       i8* bitcast ({{.*}}* @"$s13objc_subclass11SwiftGizmo2C7bellsOnACSgSi_tcfcTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-32:     }, {
 // CHECK-32:       i8* getelementptr inbounds ([14 x i8], [14 x i8]* @"\01L_selector_data(.cxx_destruct)", i32 0, i32 0),
-// CHECK-32:       i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* {{@.str.[0-9]+}}, i32 0, i32 0),
+// CHECK-32:       i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* {{@".str.[^"]+"}}, i32 0, i32 0),
 // CHECK-32:       i8* bitcast ({{.*}}* @"$s13objc_subclass11SwiftGizmo2CfETo{{(\.ptrauth)?}}" to i8*)
 // CHECK-32:     }
 // CHECK-32:   ]
@@ -255,7 +239,7 @@
 // CHECK-64:   [5 x { i8*, i8*, i8* }] [
 // CHECK-64:     {
 // CHECK-64:       i8* getelementptr inbounds ([3 x i8], [3 x i8]* @"\01L_selector_data(sg)", i64 0, i64 0),
-// CHECK-64:       i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[GETTER_ENCODING]], i64 0, i64 0),
+// CHECK-64:       i8* getelementptr inbounds ([8 x i8], [8 x i8]* @".str.7.@16@0:8", i64 0, i64 0),
 // CHECK-64:       i8* bitcast ({{.*}}* @"$s13objc_subclass11SwiftGizmo2C2sgAA0C5GizmoCvgTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-64:     }, {
 // CHECK-64:       i8* getelementptr inbounds ([7 x i8], [7 x i8]* @"\01L_selector_data(setSg:)", i64 0, i64 0),
@@ -263,15 +247,15 @@
 // CHECK-64:       i8* bitcast ({{.*}}* @"$s13objc_subclass11SwiftGizmo2C2sgAA0C5GizmoCvsTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-64:     }, {
 // CHECK-64:       i8* getelementptr inbounds ([5 x i8], [5 x i8]* @"\01L_selector_data(init)", i64 0, i64 0),
-// CHECK-64:       i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[GETTER_ENCODING]], i64 0, i64 0),
+// CHECK-64:       i8* getelementptr inbounds ([8 x i8], [8 x i8]* @".str.7.@16@0:8", i64 0, i64 0),
 // CHECK-64:       i8* bitcast ({{.*}}* @"$s13objc_subclass11SwiftGizmo2CACycfcTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-64:     }, {
 // CHECK-64:       i8* getelementptr inbounds ([17 x i8], [17 x i8]* @"\01L_selector_data(initWithBellsOn:)", i64 0, i64 0),
-// CHECK-64:       i8* getelementptr inbounds ([11 x i8], [11 x i8]* {{@.str.[0-9]+}}, i64 0, i64 0),
+// CHECK-64:       i8* getelementptr inbounds ([11 x i8], [11 x i8]* @".str.10.@24@0:8q16", i64 0, i64 0),
 // CHECK-64:       i8* bitcast ({{.*}}* @"$s13objc_subclass11SwiftGizmo2C7bellsOnACSgSi_tcfcTo{{(\.ptrauth)?}}" to i8*)
 // CHECK-64:     }, {
 // CHECK-64:       i8* getelementptr inbounds ([14 x i8], [14 x i8]* @"\01L_selector_data(.cxx_destruct)", i64 0, i64 0),
-// CHECK-64:       i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* {{@.str.[0-9]+}}, i64 0, i64 0)
+// CHECK-64:       i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* @".str.7.v16@0:8", i64 0, i64 0)
 // CHECK-64:       i8* bitcast ({{.*}}* @"$s13objc_subclass11SwiftGizmo2CfETo{{(\.ptrauth)?}}" to i8*)
 // CHECK-64:     }
 // CHECK-64: ] }

--- a/test/IRGen/objc_subscripts.swift
+++ b/test/IRGen/objc_subscripts.swift
@@ -2,11 +2,6 @@
 
 // REQUIRES: PTRSIZE=64
 
-// CHECK: [[INDEXED_GETTER_ENCODING:@.+]] = private unnamed_addr constant [11 x i8] c"@24@0:8q16\00"
-// CHECK: [[INDEXED_SETTER_ENCODING:@.+]] = private unnamed_addr constant [14 x i8] c"v32@0:8@16q24\00"
-// CHECK: [[KEYED_GETTER_ENCODING:@.+]] = private unnamed_addr constant [11 x i8] c"q24@0:8@16\00"
-// CHECK: [[KEYED_SETTER_ENCODING:@.+]] = private unnamed_addr constant [14 x i8] c"v32@0:8q16@24\00"
-
 // CHECK: @_INSTANCE_METHODS__TtC15objc_subscripts10SomeObject = 
 // CHECK:   internal constant { i32, i32, [5 x { i8*, i8*, i8* }] } 
 // CHECK:   { i32 24, i32 5, [5 x { i8*, i8*, i8* }] 
@@ -14,35 +9,35 @@
 // CHECK:       { i8*, i8*, i8* } 
 // CHECK:         { 
 // CHECK:           i8* getelementptr inbounds ([26 x i8], [26 x i8]* @"\01L_selector_data(objectAtIndexedSubscript:)", i64 0, i64 0), 
-// CHECK:           i8* getelementptr inbounds ([11 x i8], [11 x i8]* [[INDEXED_GETTER_ENCODING]], i64 0, i64 0), 
+// CHECK:           i8* getelementptr inbounds ([11 x i8], [11 x i8]* @".str.10.@24@0:8q16", i64 0, i64 0),
 // CHECK-noptrauth: i8* bitcast ([[OPAQUE0:%.*]]* ([[OPAQUE1:%.*]]*, i8*, i64)* @"$s15objc_subscripts10SomeObjectCyACSicigTo" to i8*)
 // CHECK-ptrauth:   i8* bitcast ({ i8*, i32, i64, i64 }* @"$s15objc_subscripts10SomeObjectCyACSicigTo.ptrauth" to i8*)
 // CHECK:         }, 
 // CHECK:       { i8*, i8*, i8* } 
 // CHECK:         { 
 // CHECK:           i8* getelementptr inbounds ([30 x i8], [30 x i8]* @"\01L_selector_data(setObject:atIndexedSubscript:)", i64 0, i64 0), 
-// CHECK:           i8* getelementptr inbounds ([14 x i8], [14 x i8]* [[INDEXED_SETTER_ENCODING]], i64 0, i64 0), 
+// CHECK:           i8* getelementptr inbounds ([14 x i8], [14 x i8]* @".str.13.v32@0:8@16q24", i64 0, i64 0),
 // CHECK-noptrauth: i8* bitcast (void ([[OPAQUE2:%.*]]*, i8*, [[OPAQUE3:%.*]]*, i64)* @"$s15objc_subscripts10SomeObjectCyACSicisTo" to i8*)
 // CHECK-ptrauth:   i8* bitcast ({ i8*, i32, i64, i64 }* @"$s15objc_subscripts10SomeObjectCyACSicisTo.ptrauth" to i8*)
 // CHECK:         },
 // CHECK:       { i8*, i8*, i8* } 
 // CHECK:         { 
 // CHECK:           i8* getelementptr inbounds ([25 x i8], [25 x i8]* @"\01L_selector_data(objectForKeyedSubscript:)", i64 0, i64 0), 
-// CHECK:           i8* getelementptr inbounds ([11 x i8], [11 x i8]* [[KEYED_GETTER_ENCODING]], i64 0, i64 0), 
+// CHECK:           i8* getelementptr inbounds ([11 x i8], [11 x i8]* @".str.10.q24@0:8@16", i64 0, i64 0),
 // CHECK-noptrauth: i8* bitcast (i64 ([[OPAQUE4:%.*]]*, i8*, [[OPAQUE5:%.*]]*)* @"$s15objc_subscripts10SomeObjectCySiACcigTo" to i8*)
 // CHECK-ptrauth:   i8* bitcast ({ i8*, i32, i64, i64 }* @"$s15objc_subscripts10SomeObjectCySiACcigTo.ptrauth" to i8*)
 // CHECK:         }, 
 // CHECK:       { i8*, i8*, i8* } 
 // CHECK:         { 
 // CHECK:           i8* getelementptr inbounds ([29 x i8], [29 x i8]* @"\01L_selector_data(setObject:forKeyedSubscript:)", i64 0, i64 0), 
-// CHECK:           i8* getelementptr inbounds ([14 x i8], [14 x i8]* [[KEYED_SETTER_ENCODING]], i64 0, i64 0), 
+// CHECK:           i8* getelementptr inbounds ([14 x i8], [14 x i8]* @".str.13.v32@0:8q16@24", i64 0, i64 0),
 // CHECK-noptrauth: i8* bitcast (void ([[OPAQUE6:%.*]]*, i8*, i64, [[OPAQUE7:%.*]]*)* @"$s15objc_subscripts10SomeObjectCySiACcisTo" to i8*)
 // CHECK-ptrauth:   i8* bitcast ({ i8*, i32, i64, i64 }* @"$s15objc_subscripts10SomeObjectCySiACcisTo.ptrauth" to i8*)
 // CHECK:         },
 // CHECK:       { i8*, i8*, i8* } 
 // CHECK:         {
 // CHECK:           i8* getelementptr inbounds ([5 x i8], [5 x i8]* @"\01L_selector_data(init)", i64 0, i64 0),
-// CHECK:           i8* getelementptr inbounds ([8 x i8], [8 x i8]* @.str.{{[0-9]+}}, i64 0, i64 0),
+// CHECK:           i8* getelementptr inbounds ([8 x i8], [8 x i8]* @".str.7.@16@0:8", i64 0, i64 0),
 // CHECK-noptrauth: i8* bitcast ([[OPAQUE8:%.*]]* ([[OPAQUE9:%.*]]*, i8*)* @"$s15objc_subscripts10SomeObjectCACycfcTo" to i8*)
 // CHECK-ptrauth:   i8* bitcast ({ i8*, i32, i64, i64 }* @"$s15objc_subscripts10SomeObjectCACycfcTo.ptrauth" to i8*)
 // CHECK:         }

--- a/test/IRGen/protocol_conformance_records_objc.swift
+++ b/test/IRGen/protocol_conformance_records_objc.swift
@@ -30,7 +30,7 @@ extension NSRect: Runcible {
 // -- protocol descriptor
 // CHECK-SAME:           [[RUNCIBLE]]
 // -- class name reference
-// CHECK-SAME:           @.str
+// CHECK-SAME:           @.str.5.Gizmo
 // -- witness table
 // CHECK-SAME:           @"$sSo5GizmoC33protocol_conformance_records_objc8RuncibleACWP"
 // -- flags
@@ -39,8 +39,6 @@ extension NSRect: Runcible {
 extension Gizmo: Runcible {
   public func runce() {}
 }
-
-// CHECK: @.str = private constant [6 x i8] c"Gizmo\00"
 
 // CHECK-LABEL: @"$sSo6NSRectV33protocol_conformance_records_objc8RuncibleACHc" = private constant
 // CHECK-LABEL: @"$sSo5GizmoC33protocol_conformance_records_objc8RuncibleACHc" = private constant

--- a/test/IRGen/related_entity.sil
+++ b/test/IRGen/related_entity.sil
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/chex.py < %s > %t/checkfile
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-ir -o - -primary-file %s -import-objc-header %S/Inputs/error_domains.h | %FileCheck %t/checkfile --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-ir -o - -primary-file %s -import-objc-header %S/Inputs/error_domains.h > %t/out.ir
+// RUN: %FileCheck --input-file=%t/out.ir %t/checkfile --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize -DINT=i%target-ptrsize
 
 sil_stage canonical
 
@@ -13,41 +14,35 @@ sil @use_metatypes : $@convention(thin) () -> () {
 bb0:
   %take = function_ref @take_metatype : $@convention(thin) <T> (@thick T.Type) -> ()
 
-// CHECK:         [[NestedTypedefErrorCode_NAME:@.str.[0-9]+]] = private constant [29 x i8] c"Code\00NNestedTypedefError\00St\00\00"
 // CHECK:         @"$sSo18NestedTypedefErroraMn" = linkonce_odr hidden constant
 // CHECK-SAME:    <i32 0x0006_0012>
 // CHECK-SAME:    @"$sSoMXM"
-// CHECK-SAME:    [29 x i8]* [[NestedTypedefErrorCode_NAME]]
+// CHECK-SAME:    [29 x i8]* @.str.28.Code_NNestedTypedefError_St_.nul12.nul32.nul35
 
-// CHECK:         [[NestedTagError_NAME:@.str.[0-9]+]] = private constant [29 x i8] c"TagError\00NNestedTagError\00Re\00\00"
 // CHECK:         @"$sSC14NestedTagErrorLeVMn" = linkonce_odr hidden constant
 // CHECK-SAME:    <i32 0x0006_0011>
 // CHECK-SAME:    @"$sSCMXM"
-// CHECK-SAME:    [29 x i8]* [[NestedTagError_NAME]]
+// CHECK-SAME:    [29 x i8]* @.str.28.TagError_NNestedTagError_Re_.nul16.nul32.nul35
 
-// CHECK:         [[TypedefError2Code_NAME:@.str.[0-9]+]] = private constant [24 x i8] c"Code\00NTypedefError2\00St\00\00"
 // CHECK:         @"$sSo13TypedefError2aMn" = linkonce_odr hidden constant
 // CHECK-SAME:    <i32 0x0006_0012>
 // CHECK-SAME:    @"$sSoMXM"
-// CHECK-SAME:    [24 x i8]* [[TypedefError2Code_NAME]]
+// CHECK-SAME:    [24 x i8]* @.str.23.Code_NTypedefError2_St_.nul12.nul27.nul30
 
-// CHECK:         [[TypedefError1_NAME:@.str.[0-9]+]] = private constant [18 x i8] c"TypedefError1\00RE\00\00"
 // CHECK:         @"$sSC13TypedefError1LEVMn" = linkonce_odr hidden constant
 // CHECK-SAME:    <i32 0x0006_0011>
 // CHECK-SAME:    @"$sSCMXM"
-// CHECK-SAME:    [18 x i8]* [[TypedefError1_NAME]]
+// CHECK-SAME:    [18 x i8]* @.str.17.TypedefError1_RE_.nul21.nul24
 
-// CHECK:         [[TagError2_NAME:@.str.[0-9]+]] = private constant [17 x i8] c"Code\00NTagError2\00\00"
 // CHECK:         @"$sSo9TagError2VMn" = linkonce_odr hidden constant
 // CHECK-SAME:    <i32 0x0006_0012>
 // CHECK-SAME:    @"$sSoMXM"
-// CHECK-SAME:    [17 x i8]* [[TagError2_NAME]]
+// CHECK-SAME:    [17 x i8]* @.str.16.Code_NTagError2_.nul12.nul23
 
-// CHECK:         [[TagError1_NAME:@.str.[0-9]+]] = private constant [14 x i8] c"TagError1\00Re\00\00"
 // CHECK:         @"$sSC9TagError1LeVMn" = linkonce_odr hidden constant
 // CHECK-SAME:    <i32 0x0006_0011>
 // CHECK-SAME:    @"$sSCMXM"
-// CHECK-SAME:    [14 x i8]* [[TagError1_NAME]]
+// CHECK-SAME:    [14 x i8]* @.str.13.TagError1_Re_.nul17.nul20
 
   %0 = metatype $@thick TagError1.Type
   apply %take<TagError1>(%0) : $@convention(thin) <T> (@thick T.Type) -> ()

--- a/test/IRGen/static_initializer.sil
+++ b/test/IRGen/static_initializer.sil
@@ -123,7 +123,7 @@ sil_global [let] @string_with_offset : $MyString = {
   %9 = value_to_bridge_object %8 : $Builtin.Int64
   %initval = struct $MyString (%9 : $Builtin.BridgeObject)
 }
-// CHECK: @string_with_offset = {{.*global .*}} <{ %swift.bridge* inttoptr (i64 add (i64 ptrtoint ([23 x i8]* @.str to i64), i64 9223372036854775776) to %swift.bridge*) }>, align 8
+// CHECK: @string_with_offset = {{.*global .*}} <{ %swift.bridge* inttoptr (i64 add (i64 ptrtoint ([23 x i8]* @.str.22.abc123asd3sdj3basfasdf to i64), i64 9223372036854775776) to %swift.bridge*) }>, align 8
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i8* @_TF2cha1xSi() {{.*}} {
 // CHECK-NEXT: entry:

--- a/test/IRGen/string_global_name.swift
+++ b/test/IRGen/string_global_name.swift
@@ -1,0 +1,26 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir > %t.ir
+// RUN: %FileCheck %s --input-file=%t.ir
+
+// This test checks that `@.str` string constants have names accurately
+// reflecting their contents. Other tests rely on this behavior so they can
+// simply test the names of constants and assume that their values match.
+
+func strings() {
+  // String literal containing only identifier-safe characters.
+  blackHole("01234567890123456789")
+  // CHECK-DAG: @.str.20.01234567890123456789 = private unnamed_addr constant [21 x i8] c"01234567890123456789\00"
+
+  // String literal containing spaces and punctuation.
+  blackHole("Hello, world! Padding past 16.")
+  // CHECK-DAG: @".str.30.Hello, world! Padding past 16." = private unnamed_addr constant [31 x i8] c"Hello, world! Padding past 16.\00"
+  
+  // String literal containing non-ASCII characters.
+  blackHole("🏳️‍⚧️👩‍❤️‍💋‍👩🥹")
+  // CHECK-DAG:  @".str.47.\F0\9F\8F\B3\EF\B8\8F\E2\80\8D\E2\9A\A7\EF\B8\8F\F0\9F\91\A9\E2\80\8D\E2\9D\A4\EF\B8\8F\E2\80\8D\F0\9F\92\8B\E2\80\8D\F0\9F\91\A9\F0\9F\A5\B9" = private unnamed_addr constant [48 x i8] c"\F0\9F\8F\B3\EF\B8\8F\E2\80\8D\E2\9A\A7\EF\B8\8F\F0\9F\91\A9\E2\80\8D\E2\9D\A4\EF\B8\8F\E2\80\8D\F0\9F\92\8B\E2\80\8D\F0\9F\91\A9\F0\9F\A5\B9\00"
+
+  // String literal containing nul characters. These require special encoding.
+  blackHole("\01\02\03\04\05\06\07\08")
+  // CHECK-DAG: @.str.16._1_2_3_4_5_6_7_8.nul8.nul10.nul12.nul14.nul16.nul18.nul20.nul22 = private unnamed_addr constant [17 x i8] c"\001\002\003\004\005\006\007\008\00"
+}
+
+@inline(never) func blackHole(_: String) {}

--- a/test/SILOptimizer/character_literals.swift
+++ b/test/SILOptimizer/character_literals.swift
@@ -43,7 +43,7 @@ public func singleNonAsciiChar() -> Character {
 //
 // CHECK-LABEL: define {{.*}}singleNonSmolChar
 // CHECK-NEXT: entry:
-// CHECK:   ret { i64, %swift.bridge* } { i64 1152921504606847001, %swift.bridge* {{.*}}@.str{{.*}}i64 -9223372036854775808
+// CHECK:   ret { i64, %swift.bridge* } { i64 1152921504606847001, %swift.bridge* {{.*}}@".str.25.\F0\9F\91\A9\E2\80\8D\F0\9F\91\A9\E2\80\8D\F0\9F\91\A6\E2\80\8D\F0\9F\91\A6" {{.*}}i64 -9223372036854775808
 public func singleNonSmolChar() -> Character {
   return "👩‍👩‍👦‍👦"
 }


### PR DESCRIPTION
This PR modifies `getAddrOfGlobalString()` to generate constants whose names reflect their actual contents. Rather than having generic names like `@.str`, `@.str.1`, etc., they now have names like `@".str.11.Hello World"`. This means that when you're FileChecking IR, you can hardcode the expected constant name at the use site and assume that it has the desired contents, rather than matching the constant declaration, capturing the name, and using the captured name in a separate line matching the use site.

This PR includes a description of this format in docs/Testing.md and a new test ensuring that the compiler correctly generates the desired format, but because these string constants are private anyway, it should have no effect on the code size or other behavior of linked binaries.