### PR TITLE
RequirementMachine: Redo concrete contraction after splitting concrete equivalence classes

### DIFF
--- a/lib/AST/RequirementMachine/Debug.h
+++ b/lib/AST/RequirementMachine/Debug.h
@@ -78,6 +78,10 @@ enum class DebugFlags : unsigned {
 
   /// Print conflicting rules.
   ConflictingRules = (1<<18),
+
+  /// Print debug output from concrete equivalence class splitting during
+  /// minimization.
+  SplitConcreteEquivalenceClass = (1<<19),
 };
 
 using DebugOptions = OptionSet<DebugFlags>;

--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -155,6 +155,9 @@ static void splitConcreteEquivalenceClasses(
     TypeArrayView<GenericTypeParamType> genericParams,
     SmallVectorImpl<StructuralRequirement> &splitRequirements,
     unsigned &attempt) {
+  bool debug = machine->getDebugOptions().contains(
+      DebugFlags::SplitConcreteEquivalenceClass);
+
   unsigned maxAttempts =
       ctx.LangOpts.RequirementMachineMaxSplitConcreteEquivClassAttempts;
 
@@ -172,6 +175,10 @@ static void splitConcreteEquivalenceClasses(
 
   splitRequirements.clear();
 
+  if (debug) {
+    llvm::dbgs() << "\n# Splitting concrete equivalence classes:\n";
+  }
+
   for (auto req : requirements) {
     if (shouldSplitConcreteEquivalenceClass(req, proto, machine)) {
       auto concreteType = machine->getConcreteType(
@@ -183,10 +190,24 @@ static void splitConcreteEquivalenceClasses(
                             req.getSecondType(), concreteType);
       splitRequirements.push_back({firstReq, SourceLoc(), /*inferred=*/false});
       splitRequirements.push_back({secondReq, SourceLoc(), /*inferred=*/false});
+
+      if (debug) {
+        llvm::dbgs() << "- First split: ";
+        firstReq.dump(llvm::dbgs());
+        llvm::dbgs() << "\n- Second split: ";
+        secondReq.dump(llvm::dbgs());
+        llvm::dbgs() << "\n";
+      }
       continue;
     }
 
     splitRequirements.push_back({req, SourceLoc(), /*inferred=*/false});
+
+    if (debug) {
+      llvm::dbgs() << "- Not split: ";
+      req.dump(llvm::dbgs());
+      llvm::dbgs() << "\n";
+    }
   }
 }
 

--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -320,20 +320,6 @@ RequirementSignatureRequest::evaluate(Evaluator &evaluator,
       requirements.push_back(req);
     for (auto req : proto->getTypeAliasRequirements())
       requirements.push_back({req, SourceLoc(), /*inferred=*/false});
-
-    // Preprocess requirements to eliminate conformances on type parameters
-    // which are made concrete.
-    if (ctx.LangOpts.EnableRequirementMachineConcreteContraction) {
-      SmallVector<StructuralRequirement, 4> contractedRequirements;
-
-      bool debug = rewriteCtx.getDebugOptions()
-                             .contains(DebugFlags::ConcreteContraction);
-
-      if (performConcreteContraction(requirements, contractedRequirements,
-                                     errors, debug)) {
-        std::swap(contractedRequirements, requirements);
-      }
-    }
   }
 
   if (rewriteCtx.getDebugOptions().contains(DebugFlags::Timers)) {
@@ -356,6 +342,24 @@ RequirementSignatureRequest::evaluate(Evaluator &evaluator,
 
   unsigned attempt = 0;
   for (;;) {
+    for (const auto *proto : component) {
+      auto &requirements = protos[proto];
+
+      // Preprocess requirements to eliminate conformances on type parameters
+      // which are made concrete.
+      if (ctx.LangOpts.EnableRequirementMachineConcreteContraction) {
+        SmallVector<StructuralRequirement, 4> contractedRequirements;
+
+        bool debug = rewriteCtx.getDebugOptions()
+                               .contains(DebugFlags::ConcreteContraction);
+
+        if (performConcreteContraction(requirements, contractedRequirements,
+                                       errors, debug)) {
+          std::swap(contractedRequirements, requirements);
+        }
+      }
+    }
+
     // Heap-allocate the requirement machine to save stack space.
     std::unique_ptr<RequirementMachine> machine(new RequirementMachine(
         rewriteCtx));
@@ -660,20 +664,20 @@ AbstractGenericSignatureRequest::evaluate(
     llvm::dbgs() << "\n";
   }
 
-  // Preprocess requirements to eliminate conformances on generic parameters
-  // which are made concrete.
-  if (ctx.LangOpts.EnableRequirementMachineConcreteContraction) {
-    SmallVector<StructuralRequirement, 4> contractedRequirements;
-    bool debug = rewriteCtx.getDebugOptions()
-                           .contains(DebugFlags::ConcreteContraction);
-    if (performConcreteContraction(requirements, contractedRequirements,
-                                   errors, debug)) {
-      std::swap(contractedRequirements, requirements);
-    }
-  }
-
   unsigned attempt = 0;
   for (;;) {
+    // Preprocess requirements to eliminate conformances on generic parameters
+    // which are made concrete.
+    if (ctx.LangOpts.EnableRequirementMachineConcreteContraction) {
+      SmallVector<StructuralRequirement, 4> contractedRequirements;
+      bool debug = rewriteCtx.getDebugOptions()
+                             .contains(DebugFlags::ConcreteContraction);
+      if (performConcreteContraction(requirements, contractedRequirements,
+                                     errors, debug)) {
+        std::swap(contractedRequirements, requirements);
+      }
+    }
+
     // Heap-allocate the requirement machine to save stack space.
     std::unique_ptr<RequirementMachine> machine(new RequirementMachine(
         rewriteCtx));
@@ -855,20 +859,20 @@ InferredGenericSignatureRequest::evaluate(
     llvm::dbgs() << "\n";
   }
 
-  // Preprocess requirements to eliminate conformances on generic parameters
-  // which are made concrete.
-  if (ctx.LangOpts.EnableRequirementMachineConcreteContraction) {
-    SmallVector<StructuralRequirement, 4> contractedRequirements;
-    bool debug = rewriteCtx.getDebugOptions()
-                           .contains(DebugFlags::ConcreteContraction);
-    if (performConcreteContraction(requirements, contractedRequirements,
-                                   errors, debug)) {
-      std::swap(contractedRequirements, requirements);
-    }
-  }
-
   unsigned attempt = 0;
   for (;;) {
+    // Preprocess requirements to eliminate conformances on generic parameters
+    // which are made concrete.
+    if (ctx.LangOpts.EnableRequirementMachineConcreteContraction) {
+      SmallVector<StructuralRequirement, 4> contractedRequirements;
+      bool debug = rewriteCtx.getDebugOptions()
+                             .contains(DebugFlags::ConcreteContraction);
+      if (performConcreteContraction(requirements, contractedRequirements,
+                                     errors, debug)) {
+        std::swap(contractedRequirements, requirements);
+      }
+    }
+
     // Heap-allocate the requirement machine to save stack space.
     std::unique_ptr<RequirementMachine> machine(new RequirementMachine(
         rewriteCtx));

--- a/lib/AST/RequirementMachine/RewriteContext.cpp
+++ b/lib/AST/RequirementMachine/RewriteContext.cpp
@@ -179,6 +179,7 @@ static DebugOptions parseDebugFlags(StringRef debugFlags) {
       .Case("propagate-requirement-ids", DebugFlags::PropagateRequirementIDs)
       .Case("timers", DebugFlags::Timers)
       .Case("conflicting-rules", DebugFlags::ConflictingRules)
+      .Case("split-concrete-equiv-class", DebugFlags::SplitConcreteEquivalenceClass)
       .Default(None);
     if (!flag) {
       llvm::errs() << "Unknown debug flag in -debug-requirement-machine "

--- a/test/Generics/issue-61192.swift
+++ b/test/Generics/issue-61192.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -typecheck -verify %s -debug-generic-signatures -warn-redundant-requirements 2>&1 | %FileCheck %s
+
+struct C {}
+
+protocol P {
+  associatedtype A
+}
+
+struct G<A>: P {}
+
+struct Body<T: P> where T.A == C {
+  // CHECK-LABEL: .init(_:)@
+  // CHECK-NEXT: <T, U where T == G<C>, U : P, U.[P]A == C>
+  init<U: P>(_: U) where T == G<T.A>, U.A == T.A {}
+}


### PR DESCRIPTION
This fixes an edge case where we start with the following requirements:

    - U : P
    - T : P
    - T.[P]A == C
    - T == G<T.[P]A>
    - U.[P]A == T.[P]A

and end up with the following set of minimal rules (where the type witness for [P]A in the conformance G<C> : P is C):

    - U.[P] => U
    - U.[P:A] => T.[P:A]
    - T.[concrete: G<C>] => T
    - T.[concrete: G<C> : P] => T

Since U.[P]A and T.[P]A are concrete, we split the abstract same-type requirement into two requirements, and re-run minimization:

    - U : P
    - T.[P]A == C
    - U.[P]A == C
    - T == G<C>

The concrete conformance rule T.[concrete: G<C> : P] => T does not correspond to a requirement, so it was simply dropped, and the above rules violate post-contraction invariants; T.[P]A is not a valid type parameter because there is no conformance requirement T : P in the minimized signature.

We can fix this by re-running concrete contraction after splitting concrete equivalence classes. After contraction, the above requirements turn into

    - U : P
    - C == C
    - U.[P]A == C
    - T == G<C>

Which correctly minimizes to

    - U : P
    - U.[P]A == C
    - T == G<C>

Both concrete contraction and concrete equivalence class splitting are hacks, and we should think of a way to directly express the transformations they perform with the rewrite system.

Fixes https://github.com/apple/swift/issues/61192.