### PR TITLE
[IRGen] Don't emit coverage maps for synthesized Clang decls

### DIFF
--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -981,6 +981,7 @@ std::pair<FuncDecl *, FuncDecl *> SwiftDeclSynthesizer::makeBitFieldAccessors(
       Ctx, structDecl->getDeclContext(), clang::SourceLocation(),
       clang::SourceLocation(), cGetterName, cGetterType, cGetterTypeInfo,
       clang::SC_Static);
+  cGetterDecl->setImplicit();
   cGetterDecl->setImplicitlyInline();
   assert(!cGetterDecl->isExternallyVisible());
 
@@ -1002,6 +1003,7 @@ std::pair<FuncDecl *, FuncDecl *> SwiftDeclSynthesizer::makeBitFieldAccessors(
       Ctx, structDecl->getDeclContext(), clang::SourceLocation(),
       clang::SourceLocation(), cSetterName, cSetterType, cSetterTypeInfo,
       clang::SC_Static);
+  cSetterDecl->setImplicit();
   cSetterDecl->setImplicitlyInline();
   assert(!cSetterDecl->isExternallyVisible());
 
@@ -1017,6 +1019,7 @@ std::pair<FuncDecl *, FuncDecl *> SwiftDeclSynthesizer::makeBitFieldAccessors(
     auto cGetterSelf = clang::ParmVarDecl::Create(
         Ctx, cGetterDecl, clang::SourceLocation(), clang::SourceLocation(),
         cGetterSelfId, recordType, recordTypeInfo, clang::SC_None, nullptr);
+    cGetterSelf->setImplicit();
     cGetterDecl->setParams(cGetterSelf);
 
     auto cGetterSelfExpr = new (Ctx)
@@ -1040,6 +1043,7 @@ std::pair<FuncDecl *, FuncDecl *> SwiftDeclSynthesizer::makeBitFieldAccessors(
         Ctx, cSetterDecl, clang::SourceLocation(), clang::SourceLocation(),
         /* nameID? */ nullptr, fieldType, fieldTypeInfo, clang::SC_None,
         nullptr);
+    cSetterValue->setImplicit();
     cSetterParams.push_back(cSetterValue);
     auto recordPointerTypeInfo =
         Ctx.getTrivialTypeSourceInfo(recordPointerType);
@@ -1047,6 +1051,7 @@ std::pair<FuncDecl *, FuncDecl *> SwiftDeclSynthesizer::makeBitFieldAccessors(
         Ctx, cSetterDecl, clang::SourceLocation(), clang::SourceLocation(),
         /* nameID? */ nullptr, recordPointerType, recordPointerTypeInfo,
         clang::SC_None, nullptr);
+    cSetterSelf->setImplicit();
     cSetterParams.push_back(cSetterSelf);
     cSetterDecl->setParams(cSetterParams);
 

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -138,6 +138,12 @@ static clang::CodeGenerator *createClangCodeGenerator(ASTContext &Context,
     CGO.TrapFuncName = Opts.TrapFuncName;
   }
 
+  // We don't need to perform coverage mapping for any Clang decls we've
+  // synthesized, as they have no user-written code. This is also needed to
+  // avoid a Clang crash when attempting to emit coverage for decls without
+  // source locations (rdar://100172217).
+  CGO.CoverageMapping = false;
+
   auto &VFS = Importer->getClangInstance().getVirtualFileSystem();
   auto &HSI = Importer->getClangPreprocessor()
                   .getHeaderSearchInfo()

--- a/test/Profiler/Inputs/issue-57483/cmodule.h
+++ b/test/Profiler/Inputs/issue-57483/cmodule.h
@@ -1,0 +1,3 @@
+struct cstruct {
+  int member : 16;
+};

--- a/test/Profiler/Inputs/issue-57483/module.modulemap
+++ b/test/Profiler/Inputs/issue-57483/module.modulemap
@@ -1,0 +1,3 @@
+module CModule {
+  header "cmodule.h"
+}

--- a/test/Profiler/issue-57483.swift
+++ b/test/Profiler/issue-57483.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -emit-ir -profile-generate -profile-coverage-mapping -Xcc -fprofile-instr-generate -Xcc -fcoverage-mapping -I %S/Inputs/issue-57483 %s | %FileCheck %s
+
+// https://github.com/apple/swift/issues/57483 (rdar://82820628)
+// Make sure we don't crash in IRGen attempting to emit the coverage map for the
+// implicit Clang getter for the member bitfield.
+
+// CHECK: define {{.*}} @"$So7cstructV$member$getter"
+
+import CModule
+
+func foo(_ x: UnsafePointer<cstruct>?) {
+  _ = x?.pointee.member
+}
+foo(nil)


### PR DESCRIPTION
We don't need to perform coverage mapping for any Clang decls we've synthesized, as they have no user-written code. This is also needed to avoid a Clang crash when attempting to emit coverage for decls without source locations (rdar://100172217).

rdar://82820628
Resolves #57483