### PR TITLE
[cxx-interop] Do not synthesize `successor()` for immortal types

### DIFF
--- a/test/Interop/Cxx/operators/Inputs/member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/member-inline.h
@@ -85,6 +85,18 @@ struct HasPreIncrementOperatorWithVoidReturnType {
   void operator++() { ++value; }
 };
 
+struct __attribute__((swift_attr("import_reference"),
+                      swift_attr("retain:immortal"),
+                      swift_attr("release:immortal"))) ImmortalCounter {
+  int value = 0;
+
+  ImmortalCounter &operator++() {
+    value++;
+    return *this;
+  }
+};
+static ImmortalCounter myCounter;
+
 struct HasDeletedOperator {
   void operator!=(HasDeletedOperator) const = delete;
 };

--- a/test/Interop/Cxx/operators/member-inline-typechecker.swift
+++ b/test/Interop/Cxx/operators/member-inline-typechecker.swift
@@ -49,3 +49,5 @@ let anotherReturnTypeResult: HasPreIncrementOperatorWithAnotherReturnType = anot
 
 let voidReturnType = HasPreIncrementOperatorWithVoidReturnType()
 let voidReturnTypeResult: HasPreIncrementOperatorWithVoidReturnType = voidReturnType.successor()
+
+let immortalIncrement = myCounter.successor() // expected-error {{value of type 'ImmortalCounter' has no member 'successor'}}


### PR DESCRIPTION
Our current implementation of `func successor() -> MyType` relies on the ability to create a new instance of the type. For immortal foreign reference types, this wouldn't be reasonable to do.

rdar://100050151
