### PR TITLE
[DI] Add a way to find value of self in initializer context

### DIFF
--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
@@ -169,6 +169,25 @@ SILInstruction *DIMemoryObjectInfo::getFunctionEntryPoint() const {
   return &*getFunction().begin()->begin();
 }
 
+static SingleValueInstruction *
+getUninitializedValue(MarkUninitializedInst *MemoryInst) {
+  SILValue inst = MemoryInst;
+  if (auto *bbi = MemoryInst->getSingleUserOfType<BeginBorrowInst>()) {
+    inst = bbi;
+  }
+
+  if (SingleValueInstruction *svi =
+          inst->getSingleUserOfType<ProjectBoxInst>()) {
+    return svi;
+  }
+
+  return MemoryInst;
+}
+
+SingleValueInstruction *DIMemoryObjectInfo::getUninitializedValue() const {
+  return ::getUninitializedValue(MemoryInst);
+}
+
 /// Given a symbolic element number, return the type of the element.
 static SILType getElementTypeRec(TypeExpansionContext context,
                                  SILModule &Module, SILType T, unsigned EltNo,
@@ -476,6 +495,31 @@ bool DIMemoryObjectInfo::isElementLetProperty(unsigned Element) const {
   // Otherwise, we miscounted elements?
   assert(Element == 0 && "Element count problem");
   return false;
+}
+
+SingleValueInstruction *DIMemoryObjectInfo::findUninitializedSelfValue() const {
+  // If the object is 'self', return its uninitialized value.
+  if (isAnyInitSelf())
+    return getUninitializedValue();
+
+  // Otherwise we need to scan entry block to find mark_uninitialized
+  // instruction that belongs to `self`.
+
+  auto *BB = getFunction().getEntryBlock();
+  if (!BB)
+    return nullptr;
+
+  for (auto &I : *BB) {
+    SILInstruction *Inst = &I;
+    if (auto *MUI = dyn_cast<MarkUninitializedInst>(Inst)) {
+      // If instruction is not a local variable, it could only
+      // be some kind of `self` (root, delegating, derived etc.)
+      // see \c MarkUninitializedInst::Kind for more details.
+      if (!MUI->isVar())
+        return ::getUninitializedValue(MUI);
+    }
+  }
+  return nullptr;
 }
 
 ConstructorDecl *DIMemoryObjectInfo::getActorInitSelf() const {

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.h
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.h
@@ -100,19 +100,7 @@ public:
   /// alloc_stack, this always just returns the actual mark_uninitialized
   /// instruction. For alloc_box though it returns the project_box associated
   /// with the memory info.
-  SingleValueInstruction *getUninitializedValue() const {
-    if (IsBox) {
-      SILValue inst = MemoryInst;
-      if (auto *bbi = MemoryInst->getSingleUserOfType<BeginBorrowInst>()) {
-        inst = bbi;
-      }
-      // TODO: consider just storing the ProjectBoxInst in this case.
-      SingleValueInstruction *svi = inst->getSingleUserOfType<ProjectBoxInst>();
-      assert(svi);
-      return svi;
-    }
-    return MemoryInst;
-  }
+  SingleValueInstruction *getUninitializedValue() const;
 
   /// Return the number of elements, without the extra "super.init" tracker in
   /// initializers of derived classes.
@@ -129,6 +117,10 @@ public:
 
   /// Return true if this is 'self' in any kind of initializer.
   bool isAnyInitSelf() const { return !MemoryInst->isVar(); }
+
+  /// Return uninitialized value of 'self' if current memory object
+  /// is located in an initializer (of any kind).
+  SingleValueInstruction *findUninitializedSelfValue() const;
 
   /// True if the memory object is the 'self' argument of a struct initializer.
   bool isStructInitSelf() const {


### PR DESCRIPTION
This is staging for type wrappers that need to inject `self.$storage = ...` call to user-defined initializers, to be able to do that logic needs to be able to find `self` that is being constructed.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
