### PR TITLE
[ConstraintSystem] Fix missing binding type vars in type inference debug output

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1765,7 +1765,7 @@ void BindingSet::dump(llvm::raw_ostream &out, unsigned indent) const {
         out << "(default type of literal) ";
         break;
       }
-      BindingType.print(out);
+      BindingType.print(out, PO);
     }
   };
 


### PR DESCRIPTION
This fixes the missing type vars in bindings printing. So,

`($T7 [involves_type_vars: $T2] [with possible bindings: (subtypes of) () -> _] [defaults: () -> _])`

should print as:

`($T7 [involves_type_vars: $T2] [with possible bindings: (subtypes of) () -> $T2] [defaults: () -> $T8])`