### PR TITLE
[Build] Determine the early SwiftSyntax build directory in build-script-impl

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -230,6 +230,7 @@ KNOWN_SETTINGS=(
     swift-disable-dead-stripping                  "0"               "turns off Darwin-specific dead stripping for Swift host tools"
     common-swift-flags                            ""                "Flags used for Swift targets other than the stdlib, like the corelibs"
     swift-enable-experimental-string-processing   "1"               "whether to build experimental string processing feature"
+    swift-earlyswiftsyntax                        "0"               "use the early SwiftSyntax"
 
     ## FREESTANDING Stdlib Options
     swift-freestanding-flavor                     ""                "when building the FREESTANDING stdlib, which build style to use (options: apple, linux)"
@@ -850,6 +851,16 @@ function set_build_options_for_host() {
     swift_cmake_options+=(
         -DCOVERAGE_DB="${COVERAGE_DB}"
     )
+
+    if [[ "$(true_false ${SWIFT_EARLYSWIFTSYNTAX})" == "TRUE" ]]; then
+        early_swiftsyntax_build_dir="$(build_directory ${host} earlyswiftsyntax)"
+        swift_cmake_options+=(
+            -DSWIFT_PATH_TO_EARLYSWIFTSYNTAX_BUILD_DIR:PATH="${early_swiftsyntax_build_dir}"
+        )
+        lldb_cmake_options+=(
+            -DSWIFT_PATH_TO_EARLYSWIFTSYNTAX_BUILD_DIR:PATH="${early_swiftsyntax_build_dir}"
+        )
+    fi
 }
 
 function configure_default_options() {
@@ -1233,6 +1244,7 @@ LIBDISPATCH_STATIC_SOURCE_DIR="${WORKSPACE}/swift-corelibs-libdispatch"
 LIBICU_SOURCE_DIR="${WORKSPACE}/icu"
 LIBCXX_SOURCE_DIR="${WORKSPACE}/llvm-project/runtimes"
 EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR="${WORKSPACE}/swift-experimental-string-processing"
+SWIFTSYNTAX_SOURCE_DIR="${WORKSPACE}/swift-syntax"
 LIBXML2_SOURCE_DIR="${WORKSPACE}/libxml2"
 SWIFT_SYNTAX_SOURCE_DIR="${WORKSPACE}/swift-syntax"
 

--- a/utils/swift_build_support/swift_build_support/build_script_invocation.py
+++ b/utils/swift_build_support/swift_build_support/build_script_invocation.py
@@ -252,12 +252,7 @@ class BuildScriptInvocation(object):
             '-DSWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE:PATH={}'.format(swift_syntax_src))
 
         if args.build_early_swiftsyntax:
-            early_swiftsyntax_build_dir = os.path.join(
-                self.workspace.build_root,
-                '%s-%s' % ('earlyswiftsyntax', self.args.host_target))
-            args.extra_cmake_options.append(
-                '-DSWIFT_PATH_TO_EARLYSWIFTSYNTAX_BUILD_DIR:PATH={}'
-                .format(early_swiftsyntax_build_dir))
+            impl_args += ["--swift-earlyswiftsyntax"]
 
         # Then add subproject install flags that either skip building them /or/
         # if we are going to build them and install_all is set, we also install

--- a/utils/swift_build_support/swift_build_support/products/swift.py
+++ b/utils/swift_build_support/swift_build_support/products/swift.py
@@ -10,8 +10,6 @@
 #
 # ----------------------------------------------------------------------------
 
-import os
-
 from . import cmark
 from . import earlyswiftdriver
 from . import libcxx

--- a/utils/swift_build_support/swift_build_support/products/swift.py
+++ b/utils/swift_build_support/swift_build_support/products/swift.py
@@ -57,9 +57,6 @@ class Swift(product.Product):
         # Add experimental distributed flag.
         self.cmake_options.extend(self._enable_experimental_distributed)
 
-        # Add path for the early SwiftSyntax build.
-        self.cmake_options.extend(self._early_swiftsyntax_flags)
-
         # Add static vprintf flag
         self.cmake_options.extend(self._enable_stdlib_static_vprintf)
 
@@ -171,18 +168,6 @@ updated without updating swift.py?")
     def _enable_experimental_distributed(self):
         return [('SWIFT_ENABLE_EXPERIMENTAL_DISTRIBUTED:BOOL',
                  self.args.enable_experimental_distributed)]
-
-    @property
-    def _early_swiftsyntax_flags(self):
-        result = []
-        if self.args.build_early_swiftsyntax:
-            build_root = os.path.dirname(self.build_dir)
-            early_swiftsyntax_build_dir = os.path.join(
-                '..', build_root, '%s-%s' % ('earlyswiftsyntax',
-                                             self.args.host_target))
-            result.append(('SWIFT_PATH_TO_EARLYSWIFTSYNTAX_BUILD_DIR:PATH',
-                           early_swiftsyntax_build_dir))
-        return result
 
     @property
     def _enable_stdlib_static_vprintf(self):


### PR DESCRIPTION
Cross-compilation of the host depends on iteration over all of the host architectures within build-script-impl itself, so the computation of the build directory must occur in build-script-impl. Sink it down there to fix builds for multiple host architectures.

Addresses rdar://100182363, wherein I broke all of the builds involving multiple cross-compiled hosts.