### PR TITLE
[Sema] Accept IgnoreCollectionElementContextualMismatch in conflict generic diagnostics

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4088,7 +4088,8 @@ static bool diagnoseConflictingGenericArguments(ConstraintSystem &cs,
                      fix->getKind() == FixKind::AllowFunctionTypeMismatch ||
                      fix->getKind() == FixKind::AllowTupleTypeMismatch ||
                      fix->getKind() == FixKind::GenericArgumentsMismatch ||
-                     fix->getKind() == FixKind::InsertCall;
+                     fix->getKind() == FixKind::InsertCall ||
+                     fix->getKind() == FixKind::IgnoreCollectionElementContextualMismatch;
             });
       });
 

--- a/test/Constraints/type_inference_from_default_exprs.swift
+++ b/test/Constraints/type_inference_from_default_exprs.swift
@@ -246,7 +246,10 @@ struct S61061_1<T> where T:Hashable { // expected-note{{'T' declared as paramete
   // expected-error@-1{{generic parameter 'T' could not be inferred}}
 }
 
-// TODO(diagnostics): Should produce a conflicting types inferred for generic argument 'T'
 struct S61061_2<T> where T:Hashable {
-  init(x:[(T, T)] = [(1, "")]) {} // expected-error{{type of expression is ambiguous without more context}}
+  init(x:[(T, T)] = [(1, "")]) {} // expected-error{{conflicting arguments to generic parameter 'T' ('String' vs. 'Int')}}
+}
+
+struct S61061_3<T> where T:Hashable {
+  init(x:[(T, T)] = [(1, 1)]) {} // OK
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
Follow up to #61061, to improve a diagnostic.


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
