### PR TITLE
[cxx-interop] Add base classes as opaque fields when lowering in IRGen.

### DIFF
--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -354,37 +354,6 @@ namespace {
       }
     }
 
-    template <class Fn>
-    void forEachNonEmptyBaseTypeInfo(Fn fn) const {
-      forEachNonEmptyBase([&](clang::QualType, clang::CharUnits,
-                              clang::CharUnits size) {
-        auto &typeInfo = IGM.getOpaqueStorageTypeInfo(Size(size.getQuantity()),
-                                                      Alignment(1));
-        fn(typeInfo);
-      });
-    }
-
-    template <class Fn>
-    void forEachNonEmptyBaseTypeInfoAndBaseAddress(IRGenFunction &IGF,
-                                                   Address addr, Fn fn) const {
-      forEachNonEmptyBase([&](clang::QualType,
-                              clang::CharUnits offset, clang::CharUnits size) {
-        auto &typeInfo = IGM.getOpaqueStorageTypeInfo(Size(size.getQuantity()),
-                                                      Alignment(1));
-
-        Address baseAddr = addr;
-        if (offset.getQuantity() != 0) {
-          auto baseAddrVal =
-              IGF.Builder.CreateBitCast(addr.getAddress(), IGF.IGM.Int8PtrTy);
-          baseAddrVal = IGF.Builder.CreateConstGEP1_64(
-              IGF.IGM.Int8Ty, baseAddrVal, offset.getQuantity());
-          baseAddr = Address(baseAddrVal, Alignment(1));
-        }
-
-        fn(typeInfo, baseAddr);
-      });
-    }
-
   public:
     LoadableClangRecordTypeInfo(ArrayRef<ClangFieldInfo> fields,
                                 unsigned explosionSize, IRGenModule &IGM,
@@ -435,106 +404,6 @@ namespace {
       });
 
       lowering.addTypedData(ClangDecl, offset.asCharUnits());
-    }
-
-    void getSchema(ExplosionSchema &schema) const override {
-      forEachNonEmptyBaseTypeInfo([&](const LoadableTypeInfo &typeInfo) {
-        typeInfo.getSchema(schema);
-      });
-
-      for (auto &field : getFields()) {
-        field.getTypeInfo().getSchema(schema);
-      }
-    }
-
-    void projectFieldFromExplosion(IRGenFunction &IGF, Explosion &in,
-                                   VarDecl *field,
-                                   Explosion &out) const override {
-      auto &fieldInfo = getFieldInfo(field);
-
-      // If the field requires no storage, there's nothing to do.
-      if (fieldInfo.isEmpty())
-        return;
-
-      unsigned baseOffset = 0;
-      if (auto cxxRecord = dyn_cast<clang::CXXRecordDecl>(ClangDecl)) {
-        baseOffset = llvm::count_if(cxxRecord->bases(), [](auto base) {
-          auto baseType = base.getType().getCanonicalType();
-
-          auto baseRecord = cast<clang::RecordType>(baseType)->getDecl();
-          auto baseCxxRecord = cast<clang::CXXRecordDecl>(baseRecord);
-
-          return !baseCxxRecord->isEmpty();
-        });
-      }
-
-      // Otherwise, project from the base.
-      auto fieldRange = fieldInfo.getProjectionRange();
-      auto elements = in.getRange(fieldRange.first + baseOffset,
-                                  fieldRange.second + baseOffset);
-      out.add(elements);
-    }
-
-    void reexplode(IRGenFunction &IGF, Explosion &src,
-                   Explosion &dest) const override {
-      forEachNonEmptyBaseTypeInfo([&](const LoadableTypeInfo &typeInfo) {
-        typeInfo.reexplode(IGF, src, dest);
-      });
-
-      for (auto &field : getFields()) {
-        cast<LoadableTypeInfo>(field.getTypeInfo()).reexplode(IGF, src, dest);
-      }
-    }
-
-    void initialize(IRGenFunction &IGF, Explosion &e, Address addr,
-                    bool isOutlined) const override {
-      forEachNonEmptyBaseTypeInfoAndBaseAddress(
-          IGF, addr, [&](const LoadableTypeInfo &typeInfo, Address baseAddr) {
-            typeInfo.initialize(IGF, e, baseAddr, isOutlined);
-          });
-
-      for (auto &field : getFields()) {
-        if (field.isEmpty())
-          continue;
-
-        Address fieldAddr = field.projectAddress(IGF, addr, None);
-        cast<LoadableTypeInfo>(field.getTypeInfo())
-            .initialize(IGF, e, fieldAddr, isOutlined);
-      }
-    }
-
-    void loadAsTake(IRGenFunction &IGF, Address addr,
-                    Explosion &e) const override {
-      forEachNonEmptyBaseTypeInfoAndBaseAddress(
-          IGF, addr, [&](const LoadableTypeInfo &typeInfo, Address baseAddr) {
-            typeInfo.loadAsTake(IGF, baseAddr, e);
-          });
-
-      for (auto &field : getFields()) {
-        if (field.isEmpty())
-          continue;
-
-        Address fieldAddr = field.projectAddress(IGF, addr, None);
-        cast<LoadableTypeInfo>(field.getTypeInfo())
-            .loadAsTake(IGF, fieldAddr, e);
-      }
-    }
-
-    void loadAsCopy(IRGenFunction &IGF, Address addr,
-                    Explosion &e) const override {
-      forEachNonEmptyBaseTypeInfoAndBaseAddress(
-          IGF, addr, [&](const LoadableTypeInfo &typeInfo, Address baseAddr) {
-            typeInfo.loadAsCopy(IGF, baseAddr, e);
-          });
-
-      for (auto &field : getFields()) {
-        if (field.isEmpty())
-          continue;
-
-        Address fieldAddr = field.projectAddress(IGF, addr, None);
-        cast<LoadableTypeInfo>(field.getTypeInfo())
-            .loadAsCopy(IGF, fieldAddr, e);
-      }
     }
 
     llvm::NoneType getNonFixedOffsets(IRGenFunction &IGF) const {
@@ -1168,6 +1037,7 @@ public:
     if (ClangDecl->isUnion()) {
       collectUnionFields();
     } else {
+      collectBases();
       collectStructFields();
     }
   }
@@ -1193,6 +1063,29 @@ private:
                                    const clang::FieldDecl *clangField) {
     assert(swiftField->hasClangNode());
     return (swiftField->getClangNode().castAsDecl() == clangField);
+  }
+
+  void collectBases() {
+    auto &layout = ClangDecl->getASTContext().getASTRecordLayout(ClangDecl);
+
+    if (auto cxxRecord = dyn_cast<clang::CXXRecordDecl>(ClangDecl)) {
+      for (auto base : cxxRecord->bases()) {
+        if (base.isVirtual())
+          continue;
+
+        auto baseType = base.getType().getCanonicalType();
+
+        auto baseRecord = cast<clang::RecordType>(baseType)->getDecl();
+        auto baseCxxRecord = cast<clang::CXXRecordDecl>(baseRecord);
+
+        if (baseCxxRecord->isEmpty())
+          continue;
+
+        auto offset = layout.getBaseClassOffset(baseCxxRecord);
+        auto size = ClangDecl->getASTContext().getTypeSizeInChars(baseType);
+        addOpaqueField(Size(offset.getQuantity()), Size(size.getQuantity()));
+      }
+    }
   }
 
   void collectStructFields() {

--- a/test/Interop/Cxx/class/inheritance/Inputs/fields.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/fields.h
@@ -16,6 +16,12 @@ struct DerivedFromAll : HasOneField, DerivedWithOneField {
   int f = 6;
 };
 
+struct OneField {
+  int value = 42;
+};
+
+struct DerivedFromOneField : OneField {};
+
 // Non trivial types:
 
 struct __attribute__((swift_attr("import_unsafe"))) NonTrivial {

--- a/test/Interop/Cxx/class/inheritance/fields-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/fields-module-interface.swift
@@ -32,6 +32,16 @@
 // CHECK-NEXT:   var c: Int32
 // CHECK-NEXT: }
 
+// CHECK-NEXT: struct OneField {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   init(value: Int32)
+// CHECK-NEXT:   var value: Int32
+// CHECK-NEXT: }
+// CHECK-NEXT: struct DerivedFromOneField {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   var value: Int32
+// CHECK-NEXT: }
+
 // CHECK-NEXT: struct NonTrivial {
 // CHECK-NEXT:   init()
 // CHECK-NEXT: }

--- a/test/Interop/Cxx/class/inheritance/fields.swift
+++ b/test/Interop/Cxx/class/inheritance/fields.swift
@@ -10,6 +10,12 @@ import Fields
 
 var FieldsTestSuite = TestSuite("Getting and setting fields in base classes")
 
+struct SwiftStructWrapper {
+  let value: DerivedFromOneField
+}
+
+func optionalDerivedFromAll() -> DerivedFromAll? { DerivedFromAll() }
+
 FieldsTestSuite.test("Fields from derived from all") {
   let derived = DerivedFromAll()
   expectEqual(derived.a, 1)
@@ -29,6 +35,23 @@ FieldsTestSuite.test("Fields from derived from all") {
   expectEqual(mutable.d, 44)
   expectEqual(mutable.e, 46)
   expectEqual(mutable.f, 48)
+}
+
+FieldsTestSuite.test("Optional") {
+  let derived = optionalDerivedFromAll()
+  expectEqual(derived!.a, 1)
+  expectEqual(derived!.b, 2)
+  expectEqual(derived!.c, 3)
+  expectEqual(derived!.d, 4)
+  expectEqual(derived!.e, 5)
+  expectEqual(derived!.f, 6)
+}
+
+FieldsTestSuite.test("Struct holding derived from one field") {
+  let derived = DerivedFromOneField()
+  let s = SwiftStructWrapper(value: derived)
+
+  expectEqual(s.value.value, 42)
 }
 
 FieldsTestSuite.test("Fields from derived from non trivial") {


### PR DESCRIPTION
Much of IRGen is built around fields (example: enum packing/unpacking). This is a simpler/less bug-prone way to do it. Fixes rdar://100093641 and rdar://100093806