### PR TITLE
[cxx-interop] Do not synthesize `successor()` for foreign reference types

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2221,21 +2221,10 @@ namespace {
               MD->overwriteAccess(AccessLevel::Private);
             } else if (cxxOperatorKind ==
                        clang::OverloadedOperatorKind::OO_PlusPlus) {
-              // Make sure the type is not an immortal foreign reference type.
+              // Make sure the type is not a foreign reference type.
               // We cannot handle `operator++` for those types, since the
               // current implementation creates a new instance of the type.
-              bool isImmortal = false;
-              if (auto classDecl = dyn_cast<ClassDecl>(result)) {
-                auto retainOperation = evaluateOrDefault(
-                    Impl.SwiftContext.evaluator,
-                    CustomRefCountingOperation(
-                        {classDecl, CustomRefCountingOperationKind::retain}),
-                    {});
-                isImmortal = retainOperation.kind ==
-                             CustomRefCountingOperationResult::immortal;
-              }
-
-              if (cxxMethod->param_empty() && !isImmortal) {
+              if (cxxMethod->param_empty() && !isa<ClassDecl>(result)) {
                 // This is a pre-increment operator. We synthesize a
                 // non-mutating function called `successor() -> Self`.
                 FuncDecl *successorFunc = synthesizer.makeSuccessorFunc(MD);


### PR DESCRIPTION
Follow-up after e58e2497.

Thanks @zoecarver for suggesting this change! https://github.com/apple/swift/pull/61205#discussion_r975851655

rdar://100050151