### PR TITLE
Adds sleep(for:) to clock

### DIFF
--- a/stdlib/public/Concurrency/Clock.swift
+++ b/stdlib/public/Concurrency/Clock.swift
@@ -77,6 +77,24 @@ extension Clock {
   }
 }
 
+#if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
+@available(SwiftStdlib 5.7, *)
+extension Clock {
+  /// Suspends for the given duration.
+  ///
+  /// Prefer to use the `sleep(until:tolerance:)` method on `Clock` if you have
+  /// access to an absolute instant.
+  @available(SwiftStdlib 5.7, *)
+  @_alwaysEmitIntoClient
+  public func sleep(
+    for duration: Instant.Duration,
+    tolerance: Instant.Duration? = nil
+  ) async throws {
+    try await sleep(until: now.advanced(by: duration), tolerance: tolerance)
+  }
+}
+#endif
+
 enum _ClockID: Int32 {
   case continuous = 1
   case suspending = 2

--- a/stdlib/public/Concurrency/TaskSleepDuration.swift
+++ b/stdlib/public/Concurrency/TaskSleepDuration.swift
@@ -133,18 +133,18 @@ extension Task where Success == Never, Failure == Never {
   ///
   /// This function doesn't block the underlying thread.
   ///
-  ///       try await Task.sleep(until: .now + .seconds(3), clock: .continuous)
+  ///       try await Task.sleep(until: .now + .seconds(3))
   ///
   @available(SwiftStdlib 5.7, *)
   public static func sleep<C: Clock>(
     until deadline: C.Instant,
     tolerance: C.Instant.Duration? = nil,
-    clock: C
+    clock: C = ContinuousClock()
   ) async throws {
     try await clock.sleep(until: deadline, tolerance: tolerance)
   }
   
-  /// Suspends the current task for the given duration on a continuous clock.
+  /// Suspends the current task for the given duration.
   ///
   /// If the task is cancelled before the time ends, this function throws 
   /// `CancellationError`.
@@ -153,11 +153,14 @@ extension Task where Success == Never, Failure == Never {
   ///
   ///       try await Task.sleep(for: .seconds(3))
   ///
-  /// - Parameter duration: The duration to wait.
   @available(SwiftStdlib 5.7, *)
   @_alwaysEmitIntoClient
-  public static func sleep(for duration: Duration) async throws {
-    try await sleep(until: .now + duration, clock: .continuous)
+  public static func sleep<C: Clock>(
+    for duration: C.Instant.Duration,
+    tolerance: C.Instant.Duration? = nil,
+    clock: C = ContinuousClock()
+  ) async throws {
+    try await clock.sleep(for: duration, tolerance: tolerance)
   }
 }
 #else
@@ -169,13 +172,18 @@ extension Task where Success == Never, Failure == Never {
   public static func sleep<C: Clock>(
     until deadline: C.Instant,
     tolerance: C.Instant.Duration? = nil,
-    clock: C
+    clock: C = ContinuousClock()
   ) async throws {
     fatalError("Unavailable in task-to-thread concurrency model")
   }
   @available(SwiftStdlib 5.7, *)
   @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
-  public static func sleep(for duration: Duration) async throws {
+  @_alwaysEmitIntoClient
+  public static func sleep<C: Clock>(
+    for duration: C.Instant.Duration,
+    tolerance: C.Instant.Duration? = nil,
+    clock: C = ContinuousClock()
+  ) async throws {
     fatalError("Unavailable in task-to-thread concurrency model")
   }
 }


### PR DESCRIPTION
This adds a duration-based `sleep(for:)` method to `Clock` as an alternative to using the instant-based `sleep(until:)` method.

Evolution proposal coming next, and [here's](https://forums.swift.org/t/pitch-clock-sleep-for/60376) a forum discussion.