### PR TITLE
[interop][SwiftToCxx] Declare the generic usability type trait before…

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -297,6 +297,8 @@ private:
     if (outputLang == OutputLanguageMode::Cxx) {
       // FIXME: Non objc class.
       // FIXME: Print availability.
+      // FIXME: forward decl should be handled by ModuleWriter.
+      ClangValueTypePrinter::forwardDeclType(os, CD);
       ClangClassTypePrinter(os).printClassTypeDecl(
           CD, [&]() { printMembers(CD->getMembers()); });
       return;

--- a/lib/PrintAsClang/PrintClangValueType.cpp
+++ b/lib/PrintAsClang/PrintClangValueType.cpp
@@ -91,6 +91,7 @@ void ClangValueTypePrinter::forwardDeclType(raw_ostream &os,
   os << "class ";
   ClangSyntaxPrinter(os).printBaseName(typeDecl);
   os << ";\n";
+  printTypePrecedingGenericTraits(os, typeDecl, typeDecl->getModuleContext());
 }
 
 static void addCppExtensionsToStdlibType(const NominalTypeDecl *typeDecl,
@@ -471,6 +472,32 @@ void ClangValueTypePrinter::printClangTypeSwiftGenericTraits(
                          /*typeMetadataFuncRequirements=*/{}, moduleContext);
 }
 
+void ClangValueTypePrinter::printTypePrecedingGenericTraits(
+    raw_ostream &os, const NominalTypeDecl *typeDecl,
+    const ModuleDecl *moduleContext) {
+  assert(!typeDecl->hasClangNode());
+  ClangSyntaxPrinter printer(os);
+  // FIXME: avoid popping out of the module's namespace here.
+  os << "} // end namespace \n\n";
+  os << "namespace swift {\n";
+
+  os << "#pragma clang diagnostic push\n";
+  os << "#pragma clang diagnostic ignored \"-Wc++17-extensions\"\n";
+  if (!typeDecl->isGeneric()) {
+    // FIXME: generic type support.
+    os << "template<>\n";
+    os << "static inline const constexpr bool isUsableInGenericContext<";
+    printer.printNominalTypeReference(typeDecl,
+                                      /*moduleContext=*/nullptr);
+    os << "> = true;\n";
+  }
+  os << "#pragma clang diagnostic pop\n";
+  os << "} // namespace swift\n";
+  os << "\nnamespace ";
+  printer.printBaseName(moduleContext);
+  os << " {\n";
+}
+
 void ClangValueTypePrinter::printTypeGenericTraits(
     raw_ostream &os, const NominalTypeDecl *typeDecl,
     StringRef typeMetadataFuncName,
@@ -492,8 +519,8 @@ void ClangValueTypePrinter::printTypeGenericTraits(
 
   os << "#pragma clang diagnostic push\n";
   os << "#pragma clang diagnostic ignored \"-Wc++17-extensions\"\n";
-  if (typeMetadataFuncRequirements.empty()) {
-    // FIXME: generic type support.
+  if (typeDecl->hasClangNode()) {
+    // FIXME: share the code.
     os << "template<>\n";
     os << "static inline const constexpr bool isUsableInGenericContext<";
     printer.printNominalTypeReference(typeDecl,

--- a/lib/PrintAsClang/PrintClangValueType.h
+++ b/lib/PrintAsClang/PrintClangValueType.h
@@ -96,6 +96,10 @@ public:
       ArrayRef<GenericRequirement> typeMetadataFuncRequirements,
       const ModuleDecl *moduleContext);
 
+  static void printTypePrecedingGenericTraits(raw_ostream &os,
+                                              const NominalTypeDecl *typeDecl,
+                                              const ModuleDecl *moduleContext);
+
   static void forwardDeclType(raw_ostream &os, const NominalTypeDecl *typeDecl);
 
   /// Print out the type traits that allow a C++ type be used a Swift generic

--- a/test/Interop/SwiftToCxx/class/swift-class-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/class/swift-class-in-cxx.swift
@@ -30,7 +30,23 @@ public final class ClassWithIntField {
 
 // CHECK: namespace Class {
 
-// CHECK: namespace _impl {
+// CHECK: class ClassWithIntField;
+// CHECK-NEXT: } // end namespace
+
+// CHECK: namespace
+// CHECK-SAME: swift {
+// CHECK-NEXT: #pragma clang diagnostic push
+// CHECK-NEXT: #pragma clang diagnostic ignored "-Wc++17-extensions"
+// CHECK-NEXT: template<>
+// CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<Class::ClassWithIntField> = true;
+// CHECK-NEXT: #pragma clang diagnostic pop
+// CHECK-NEXT: } // namespace swift
+
+// CHECK: namespace
+// CHECK-SAME: Class {
+
+// CHECK: namespace
+// CHECK-SAME: _impl {
 // CHECK-EMPTY:
 // CHECK-NEXT: class _impl_ClassWithIntField;
 // CHECK-NEXT: // Type metadata accessor for ClassWithIntField
@@ -63,8 +79,6 @@ public final class ClassWithIntField {
 // CHECK-NEXT: namespace swift {
 // CHECK-NEXT: #pragma clang diagnostic push
 // CHECK-NEXT: #pragma clang diagnostic ignored "-Wc++17-extensions"
-// CHECK-NEXT: template<>
-// CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<Class::ClassWithIntField> = true;
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<Class::ClassWithIntField> {
 // CHECK-NEXT:   inline void * _Nonnull getTypeMetadata() {

--- a/test/Interop/SwiftToCxx/enums/zero-sized-enum-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/zero-sized-enum-in-cxx.swift
@@ -6,6 +6,6 @@ public enum EmptyEnum {}
 public enum SingleCaseEnum { case first }
 
 // CHECK: namespace Enums {
-// CHECK-NOT: EmptyEnum
-// CHECK-NOT: SingleCaseEnum
+// CHECK-NOT: class EmptyEnum final {
+// CHECK-NOT: class SingleCaseEnum final {
 // CHECK: } // namespace Enums

--- a/test/Interop/SwiftToCxx/generics/generic-enum-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-enum-in-cxx.swift
@@ -91,6 +91,10 @@ public func inoutConcreteOpt(_ x: inout GenericOpt<UInt16>) {
 
 // CHECK: template<class T_0_0>
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
+// CHECK-NEXT: class GenericOpt;
+
+// CHECK: template<class T_0_0>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
 // CHECK-NEXT: class _impl_GenericOpt;
 
 // CHECK: SWIFT_EXTERN swift::_impl::MetadataResponseTy $s8Generics10GenericOptOMa(swift::_impl::MetadataRequestTy, void * _Nonnull) SWIFT_NOEXCEPT SWIFT_CALL;

--- a/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
@@ -202,6 +202,10 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 
 // CHECK: template<class T_0_0, class T_0_1>
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
+// CHECK-NEXT: class GenericPair;
+
+// CHECK: template<class T_0_0, class T_0_1>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: class _impl_GenericPair;
 // CHECK-EMPTY:
 // CHECK-NEXT: static_assert(2 <= 3, "unsupported generic requirement list for metadata func");
@@ -247,11 +251,7 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT: #pragma clang diagnostic pop
 // CHECK-NEXT: } // namespace swift
 
-// CHECK: template<class T_0_0, class T_0_1>
-// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
-// CHECK-NEXT: class GenericPair;
-// CHECK-EMPTY:
-// CHECK-NEXT: inline void inoutConcretePair(uint16_t x, GenericPair<uint16_t, uint16_t>& y) noexcept {
+// CHECK: inline void inoutConcretePair(uint16_t x, GenericPair<uint16_t, uint16_t>& y) noexcept {
 // CHECK-NEXT:   return _impl::$s8Generics17inoutConcretePairyys6UInt16V_AA07GenericD0VyA2DGztF(x, _impl::_impl_GenericPair<uint16_t, uint16_t>::getOpaquePointer(y));
 // CHECK-NEXT: }
 

--- a/test/Interop/SwiftToCxx/generics/generic-struct-known-layout-direct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-known-layout-direct-in-cxx.swift
@@ -70,6 +70,9 @@
 // CHECK-NEXT: SWIFT_EXTERN void $s8Generics16takeConcretePairyyAA07GenericD0Vys6UInt16VAFGF(struct swift_interop_passStub_Generics_[[PTRPTRENC]] x) SWIFT_NOEXCEPT SWIFT_CALL; // takeConcretePair(_:)
 // CHECK-NEXT: SWIFT_EXTERN void $s8Generics15takeGenericPairyyAA0cD0Vyxq_Gr0_lF(struct swift_interop_passStub_Generics_[[PTRPTRENC]] x, void * _Nonnull , void * _Nonnull ) SWIFT_NOEXCEPT SWIFT_CALL; // takeGenericPair(_:)
 
+// CHECK: template<class T_0_0, class T_0_1>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
+// CHECK-NEXT: class GenericPair;
 
 // CHECK: template<class T_0_0, class T_0_1>
 // CHECK: template<class T_0_0, class T_0_1>

--- a/test/Interop/SwiftToCxx/generics/generic-type-traits-fwd.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-type-traits-fwd.swift
@@ -1,0 +1,50 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -module-name Generics -enable-experimental-cxx-interop -emit-clang-header-path %t/generics.h
+// RUN: %FileCheck %s < %t/generics.h
+// RUN: %check-generic-interop-cxx-header-in-clang(%t/generics.h)
+
+@_expose(Cxx)
+public enum ComesFirstEnum {
+    case A
+    case B
+
+    public func returnsLaterOpt() -> LaterGeneric<ComesFirstEnum> { return LaterGeneric(x: ComesFirstEnum.A) }
+
+    public var first: ComesFirstStruct {
+        return ComesFirstStruct(x: 42)
+    }
+}
+
+@_expose(Cxx)
+public struct ComesFirstStruct {
+    let x: Int
+
+    public func returnsLaterOpt() -> LaterGeneric<ComesFirstStruct> { return LaterGeneric(x: ComesFirstStruct(x: 0)) }
+}
+
+@_expose(Cxx)
+public struct LaterGeneric<T> {
+    let x: T
+}
+
+
+// CHECK: class LaterGeneric;
+
+// CHECK: class ComesFirstStruct;
+// CHECK: static inline const constexpr bool isUsableInGenericContext<Generics::ComesFirstStruct> = true;
+
+// CHECK: class ComesFirstEnum;
+// CHECK: static inline const constexpr bool isUsableInGenericContext<Generics::ComesFirstEnum> = true;
+
+// CHECK: class ComesFirstEnum final {
+// CHECK: LaterGeneric<ComesFirstEnum> returnsLaterOpt() const;
+
+// CHECK: namespace Generics {
+// CHECK-EMPTY:
+// CHECK-NEXT:  namespace _impl {
+// CHECK-EMPTY:
+// CHECK-NEXT:  class _impl_ComesFirstStruct;
+
+// CHECK: class ComesFirstStruct final {
+// CHECK: LaterGeneric<ComesFirstStruct> returnsLaterOpt() const;
+// CHECK: class LaterGeneric final {

--- a/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
@@ -8,8 +8,15 @@
 
 // CHECK: namespace Swift {
 
+// CHECK: template<class T_0_0>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
+// CHECK-NEXT: class Optional;
+
 // CHECK: class String;
 
+// CHECK: template<class T_0_0>
+// CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
+// CHECK-NEXT: class Array;
 // CHECK: template<class T_0_0>
 // CHECK: template<class T_0_0>
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>

--- a/test/Interop/SwiftToCxx/structs/resilient-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/resilient-struct-in-cxx.swift
@@ -27,6 +27,11 @@ public struct FirstSmallStruct {
     }
 }
 
+// CHECK: class FirstSmallStruct;
+
+// CHECK: template<>
+// CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<Structs::FirstSmallStruct> = true;
+
 // CHECK: class FirstSmallStruct final {
 // CHECK-NEXT: public:
 // CHECK: inline FirstSmallStruct(const FirstSmallStruct &other) {
@@ -70,8 +75,6 @@ public struct FirstSmallStruct {
 // CHECK-NEXT: namespace swift {
 // CHECK-NEXT: #pragma clang diagnostic push
 // CHECK-NEXT: #pragma clang diagnostic ignored "-Wc++17-extensions"
-// CHECK-NEXT: template<>
-// CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<Structs::FirstSmallStruct> = true;
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<Structs::FirstSmallStruct> {
 // CHECK-NEXT: inline void * _Nonnull getTypeMetadata() {

--- a/test/Interop/SwiftToCxx/structs/swift-struct-circular-dependent-defs.swift
+++ b/test/Interop/SwiftToCxx/structs/swift-struct-circular-dependent-defs.swift
@@ -25,7 +25,8 @@ public struct B {
 }
 
 // CHECK: class B;
-// CHECK-NEXT: namespace _impl {
+// CHECK: class A;
+// CHECK: namespace _impl {
 // CHECK-EMPTY:
 // CHECK-NEXT: class _impl_A;
 
@@ -33,8 +34,11 @@ public struct B {
 
 // CHECK: B returnsB() const;
 
-// CHECK: class A;
-// CHECK-NEXT: namespace _impl {
+// CHECK: namespace _impl {
+// CHECK-EMPTY:
+// CHECK-NEXT: class _impl_A {
+
+// CHECK: namespace _impl {
 // CHECK-EMPTY:
 // CHECK-NEXT: class _impl_B;
 

--- a/test/Interop/SwiftToCxx/structs/swift-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/swift-struct-in-cxx.swift
@@ -9,6 +9,19 @@
 
 // CHECK: namespace Structs {
 
+// CHECK: class StructWithIntField;
+// CHECK-NEXT: } // end namespace
+
+// CHECK: namespace swift {
+// CHECK-NEXT: #pragma clang diagnostic push
+// CHECK-NEXT: #pragma clang diagnostic ignored "-Wc++17-extensions"
+// CHECK-NEXT: template<>
+// CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<Structs::StructWithIntField> = true;
+// CHECK-NEXT: #pragma clang diagnostic pop
+// CHECK-NEXT: } // namespace swift
+
+// CHECK: namespace Structs {
+
 // CHECK:      namespace _impl {
 // CHECK-EMPTY:
 // CHECK-NEXT: class _impl_StructWithIntField;
@@ -67,8 +80,6 @@
 // CHECK-NEXT: namespace swift {
 // CHECK-NEXT: #pragma clang diagnostic push
 // CHECK-NEXT: #pragma clang diagnostic ignored "-Wc++17-extensions"
-// CHECK-NEXT: template<>
-// CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<Structs::StructWithIntField> = true;
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<Structs::StructWithIntField>
 // CHECK-NEXT: inline void * _Nonnull getTypeMetadata() {

--- a/test/Interop/SwiftToCxx/structs/zero-sized-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/zero-sized-struct-in-cxx.swift
@@ -4,7 +4,7 @@
 
 // CHECK: namespace Structs {
 
-// CHECK-NOT: ZeroSizedStruct
+// CHECK-NOT: class ZeroSizedStruct final {
 
 public struct ZeroSizedStruct {}
 


### PR DESCRIPTION
… the C++ class that represents the Swift type

This allows you to import a method that returns the type of the context in which the method is declared when such type is a generic parameter in another type. This means that it's now possible to bridge the initializer for RawRepresentable enums.
