### PR TITLE
[SymbolGraphGen] don't use null types when determining extension access level

### DIFF
--- a/lib/SymbolGraphGen/Symbol.cpp
+++ b/lib/SymbolGraphGen/Symbol.cpp
@@ -801,9 +801,11 @@ AccessLevel Symbol::getEffectiveAccessLevel(const ExtensionDecl *ED) {
 
   AccessLevel maxInheritedAL = AccessLevel::Private;
   for (auto Inherited : ED->getInherited()) {
-    if (const auto *Proto = dyn_cast_or_null<ProtocolDecl>(
-            Inherited.getType()->getAnyNominal())) {
-      maxInheritedAL = std::max(maxInheritedAL, Proto->getFormalAccess());
+    if (const auto Type = Inherited.getType()) {
+      if (const auto *Proto = dyn_cast_or_null<ProtocolDecl>(
+              Type->getAnyNominal())) {
+        maxInheritedAL = std::max(maxInheritedAL, Proto->getFormalAccess());
+      }
     }
   }
 

--- a/test/SourceKit/CursorInfo/cursor_symbol_graph_extensions.swift
+++ b/test/SourceKit/CursorInfo/cursor_symbol_graph_extensions.swift
@@ -1,0 +1,13 @@
+// RUN: %sourcekitd-test -req=cursor -pos=9:28 -req-opts=retrieve_symbol_graph=1 %s -- %s
+
+extension ResourceRecordType {
+    public var debugDescription: String {
+        public struct HostRecord<IPType: IP> {
+        }
+        extension HostRecord: Hashable {
+            public struct StartOfAuthorityRecord {
+                public var a
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes rdar://100169094, fixes #61201

This PR fixes a crash in SourceKit when calculating nested expressions, by double-checking whether a type actually exists before finding its NominalTypeDecl.