### PR TITLE
[cxx-interop] Fix ASTVerifier error when building SwiftCompilerSources

### DIFF
--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -159,7 +159,7 @@ void swift::conformToCxxIteratorIfNeeded(
   if (pointees.size() != 1)
     return;
   auto pointee = dyn_cast<VarDecl>(pointees.front());
-  if (!pointee || pointee->isGetterMutating())
+  if (!pointee || pointee->isGetterMutating() || pointee->getType()->hasError())
     return;
 
   // Check if present: `func successor() -> Self`


### PR DESCRIPTION
I wasn't able to reproduce this with bootstrapping build, seems to only reproduce with hosttools build.

```
1.	Apple Swift version 5.8-dev (LLVM e7221644321f3bb, Swift 1f5e20be8739ea8)
2.	Compiling with the current language version
3.	While walking into '__CxxTemplateInstN4llvm11SmallVectorINSt3__14pairINS_26BlockFrequencyInfoImplBase9BlockNodeENS_10bfi_detail9BlockMassEEELj4EEE' (in module '__ObjC')
Stack dump without symbol names (ensure you have llvm-symbolizer in your PATH or set the environment var `LLVM_SYMBOLIZER_PATH` to point to it):
0  swift-frontend           0x00000001093a3277 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) + 39
1  swift-frontend           0x00000001093a2485 llvm::sys::RunSignalHandlers() + 85
2  swift-frontend           0x00000001093a38c0 SignalHandler(int) + 288
3  libsystem_platform.dylib 0x00007ff813879dfd _sigtramp + 29
4  libsystem_platform.dylib 0x00007ff7bc166a10 _sigtramp + 18446744072242514992
5  libsystem_c.dylib        0x00007ff8137afd24 abort + 123
6  swift-frontend           0x000000010990e010 (anonymous namespace)::Verifier::verifyChecked(swift::VarDecl*) (.cold.1) + 0
7  swift-frontend           0x00000001052dcfba (anonymous namespace)::Verifier::verifyChecked(swift::ValueDecl*) + 282
8  swift-frontend           0x00000001052d6cf0 (anonymous namespace)::Verifier::walkToDeclPost(swift::Decl*) + 4608
9  swift-frontend           0x00000001052de7f8 (anonymous namespace)::Traversal::doIt(swift::Decl*) + 248
10 swift-frontend           0x00000001052e1b6e (anonymous namespace)::Traversal::visitNominalTypeDecl(swift::NominalTypeDecl*) + 654
11 swift-frontend           0x00000001052de7df (anonymous namespace)::Traversal::doIt(swift::Decl*) + 223
12 swift-frontend           0x00000001052de6eb swift::Decl::walk(swift::ASTWalker&) + 27
13 swift-frontend           0x00000001052cb7aa swift::verify(swift::Decl*) + 218
14 swift-frontend           0x000000010515f149 swift::ClangImporter::verifyAllModules() + 537
15 swift-frontend           0x0000000105229c4a swift::ASTContext::verifyAllLoadedModules() const + 90
16 swift-frontend           0x0000000103f7b6fb performEndOfPipelineActions(swift::CompilerInstance&) + 667
17 swift-frontend           0x0000000103f7643c performCompileStepsPostSILGen(swift::CompilerInstance&, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule> >, llvm::PointerUnion<swift::ModuleDecl*, swift::SourceFile*>, swift::PrimarySpecificPaths const&, int&, swift::FrontendObserver*) + 2764
18 swift-frontend           0x0000000103f757d6 swift::performCompileStepsPostSema(swift::CompilerInstance&, int&, swift::FrontendObserver*) + 2454
19 swift-frontend           0x0000000103f775d1 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 4001
20 swift-frontend           0x0000000103db52f4 swift::mainEntry(int, char const**) + 2932
21 dyld                     0x000000011f5c552e start + 462

```

rdar://100214399