### PR TITLE
IRGen: Pass the elementType of pointers through to operations

### DIFF
--- a/include/swift/Runtime/RuntimeFnWrappersGen.h
+++ b/include/swift/Runtime/RuntimeFnWrappersGen.h
@@ -46,5 +46,9 @@ llvm::Constant *getRuntimeFn(llvm::Module &Module, llvm::Constant *&cache,
                              llvm::ArrayRef<llvm::Attribute::AttrKind> attrs,
                              irgen::IRGenModule *IGM = nullptr);
 
+llvm::FunctionType *getRuntimeFnType(llvm::Module &Module,
+                             llvm::ArrayRef<llvm::Type *> retTypes,
+                             llvm::ArrayRef<llvm::Type *> argTypes);
+
 } // namespace swift
 #endif

--- a/lib/IRGen/Address.h
+++ b/lib/IRGen/Address.h
@@ -31,11 +31,22 @@ namespace irgen {
 /// The address of an object in memory.
 class Address {
   llvm::Value *Addr;
+  llvm::Type *ElementType;
   Alignment Align;
 
 public:
   Address() : Addr(nullptr) {}
-  Address(llvm::Value *addr, Alignment align) : Addr(addr), Align(align) {
+
+  Address(llvm::Value *addr, llvm::Type *elementType, Alignment align)
+      : Addr(addr), ElementType(elementType), Align(align) {
+    if (!llvm::cast<llvm::PointerType>(addr->getType())
+             ->isOpaqueOrPointeeTypeMatches(elementType)) {
+      addr->getType()->dump();
+      elementType->dump();
+    }
+    assert(llvm::cast<llvm::PointerType>(addr->getType())
+               ->isOpaqueOrPointeeTypeMatches(elementType) &&
+           "Incorrect pointer element type");
     assert(addr != nullptr && "building an invalid address");
   }
 
@@ -55,6 +66,8 @@ public:
   llvm::PointerType *getType() const {
     return cast<llvm::PointerType>(Addr->getType());
   }
+
+  llvm::Type *getElementType() const { return ElementType; }
 };
 
 /// An address in memory together with the (possibly null) heap

--- a/lib/IRGen/ClassTypeInfo.h
+++ b/lib/IRGen/ClassTypeInfo.h
@@ -28,6 +28,7 @@ namespace irgen {
 /// Layout information for class types.
 class ClassTypeInfo : public HeapTypeInfo<ClassTypeInfo> {
   ClassDecl *TheClass;
+  mutable llvm::StructType *classLayoutType;
 
   // The resilient layout of the class, without making any assumptions
   // that violate resilience boundaries. This is used to allocate
@@ -47,13 +48,16 @@ class ClassTypeInfo : public HeapTypeInfo<ClassTypeInfo> {
 public:
   ClassTypeInfo(llvm::PointerType *irType, Size size, SpareBitVector spareBits,
                 Alignment align, ClassDecl *theClass,
-                ReferenceCounting refcount)
+                ReferenceCounting refcount, llvm::StructType *classLayoutType)
       : HeapTypeInfo(irType, size, std::move(spareBits), align),
-        TheClass(theClass), Refcount(refcount) {}
+        TheClass(theClass), classLayoutType(classLayoutType),
+        Refcount(refcount) {}
 
   ReferenceCounting getReferenceCounting() const { return Refcount; }
 
   ClassDecl *getClass() const { return TheClass; }
+
+  llvm::Type *getClassLayoutType() const { return classLayoutType; }
 
   const ClassLayout &getClassLayout(IRGenModule &IGM, SILType type,
                                     bool forBackwardDeployment) const;

--- a/lib/IRGen/EnumPayload.cpp
+++ b/lib/IRGen/EnumPayload.cpp
@@ -227,8 +227,8 @@ EnumPayload EnumPayload::load(IRGenFunction &IGF, Address address,
     return result;
   
   auto storageTy = getPayloadStorageType(IGF.IGM, result);
-  address = IGF.Builder.CreateBitCast(address, storageTy->getPointerTo());
-  
+  address = IGF.Builder.CreateElementBitCast(address, storageTy);
+
   if (result.PayloadValues.size() == 1) {
     result.PayloadValues.front() = IGF.Builder.CreateLoad(address);
   } else {
@@ -250,8 +250,8 @@ void EnumPayload::store(IRGenFunction &IGF, Address address) const {
     return;
 
   auto storageTy = getPayloadStorageType(IGF.IGM, *this);
-  address = IGF.Builder.CreateBitCast(address, storageTy->getPointerTo());
-  
+  address = IGF.Builder.CreateElementBitCast(address, storageTy);
+
   if (PayloadValues.size() == 1) {
     IGF.Builder.CreateStore(forcePayloadValue(PayloadValues.front()), address);
     return;

--- a/lib/IRGen/ExtraInhabitants.cpp
+++ b/lib/IRGen/ExtraInhabitants.cpp
@@ -106,8 +106,8 @@ llvm::Value *PointerInfo::getExtraInhabitantIndex(IRGenFunction &IGF,
   llvm::BasicBlock *contBB = IGF.createBasicBlock("is-valid-pointer");
   SmallVector<std::pair<llvm::BasicBlock*, llvm::Value*>, 3> phiValues;
   auto invalidIndex = llvm::ConstantInt::getSigned(IGF.IGM.Int32Ty, -1);
-  
-  src = IGF.Builder.CreateBitCast(src, IGF.IGM.SizeTy->getPointerTo());
+
+  src = IGF.Builder.CreateElementBitCast(src, IGF.IGM.SizeTy);
 
   // Check if the inhabitant is below the least valid pointer value.
   llvm::Value *val = IGF.Builder.CreateLoad(src);
@@ -206,7 +206,7 @@ void PointerInfo::storeExtraInhabitant(IRGenFunction &IGF,
                   llvm::ConstantInt::get(IGF.IGM.SizeTy, NumReservedLowBits));
   }
 
-  dest = IGF.Builder.CreateBitCast(dest, IGF.IGM.SizeTy->getPointerTo());
+  dest = IGF.Builder.CreateElementBitCast(dest, IGF.IGM.SizeTy);
   IGF.Builder.CreateStore(index, dest);
 }
 

--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -342,7 +342,7 @@ const TypeInfo *TypeConverter::convertArchetypeType(ArchetypeType *archetype) {
   }
 
   // Otherwise, for now, always use an opaque indirect type.
-  llvm::Type *storageType = IGM.OpaquePtrTy->getPointerElementType();
+  llvm::Type *storageType = IGM.OpaqueTy;
 
   // Opaque result types can be private and from a different module. In this
   // case we can't access their type metadata from another module.
@@ -410,9 +410,9 @@ llvm::Value *irgen::emitDynamicTypeOfOpaqueArchetype(IRGenFunction &IGF,
   llvm::Value *metadata =
     emitArchetypeTypeMetadataRef(IGF, archetype, MetadataState::Complete)
       .getMetadata();
-  return IGF.Builder.CreateCall(IGF.IGM.getGetDynamicTypeFn(),
-                                {addr.getAddress(), metadata,
-                                 llvm::ConstantInt::get(IGF.IGM.Int1Ty, 0)});
+  return IGF.Builder.CreateCall(
+      IGF.IGM.getGetDynamicTypeFunctionPointer(),
+      {addr.getAddress(), metadata, llvm::ConstantInt::get(IGF.IGM.Int1Ty, 0)});
 }
 
 static void
@@ -505,7 +505,7 @@ getAddressOfOpaqueTypeDescriptor(IRGenFunction &IGF,
 MetadataResponse irgen::emitOpaqueTypeMetadataRef(IRGenFunction &IGF,
                                           CanOpaqueTypeArchetypeType archetype,
                                           DynamicMetadataRequest request) {
-  auto accessorFn = IGF.IGM.getGetOpaqueTypeMetadataFn();
+  auto accessorFn = IGF.IGM.getGetOpaqueTypeMetadataFunctionPointer();
   auto opaqueDecl = archetype->getDecl();
   auto genericParam = archetype->getInterfaceType()
       ->castTo<GenericTypeParamType>();
@@ -532,7 +532,7 @@ MetadataResponse irgen::emitOpaqueTypeMetadataRef(IRGenFunction &IGF,
 llvm::Value *irgen::emitOpaqueTypeWitnessTableRef(IRGenFunction &IGF,
                                           CanOpaqueTypeArchetypeType archetype,
                                           ProtocolDecl *protocol) {
-  auto accessorFn = IGF.IGM.getGetOpaqueTypeConformanceFn();
+  auto accessorFn = IGF.IGM.getGetOpaqueTypeConformanceFunctionPointer();
   auto opaqueDecl = archetype->getDecl();
   assert(archetype->isRoot() && "Can only follow from the root");
 

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -19,8 +19,8 @@
 #include "swift/ABI/MetadataValues.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/GenericEnvironment.h"
-#include "swift/Runtime/Config.h"
 #include "swift/IRGen/Linking.h"
+#include "swift/Runtime/Config.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SIL/SILType.h"
 #include "clang/AST/ASTContext.h"
@@ -29,6 +29,7 @@
 #include "clang/CodeGen/CodeGenABITypes.h"
 #include "clang/CodeGen/ModuleBuilder.h"
 #include "llvm/IR/GlobalPtrAuthInfo.h"
+#include "llvm/IR/GlobalValue.h"
 #include "llvm/Support/Compiler.h"
 
 #include "CallEmission.h"
@@ -185,7 +186,7 @@ void IRGenFunction::setupAsync(unsigned asyncContextIndex) {
 }
 
 llvm::Value *IRGenFunction::getAsyncTask() {
-  auto call = Builder.CreateCall(IGM.getGetCurrentTaskFn(), {});
+  auto call = Builder.CreateCall(IGM.getGetCurrentTaskFunctionPointer(), {});
   call->setDoesNotThrow();
   call->setCallingConv(IGM.SwiftCC);
   return call;
@@ -211,9 +212,12 @@ llvm::CallInst *IRGenFunction::emitSuspendAsyncCall(
         Builder.CreateExtractValue(id, asyncContextIndex);
     calleeContext =
         Builder.CreateBitOrPointerCast(calleeContext, IGM.Int8PtrTy);
-    llvm::Constant *projectFn =
-        cast<llvm::Constant>(args[2])->stripPointerCasts();
-    llvm::Value *context = Builder.CreateCall(projectFn, {calleeContext});
+    llvm::Function *projectFn = cast<llvm::Function>(
+        (cast<llvm::Constant>(args[2])->stripPointerCasts()));
+    auto *fnTy = projectFn->getFunctionType();
+
+    llvm::Value *context =
+        Builder.CreateCallWithoutDbgLoc(fnTy, projectFn, {calleeContext});
     storeCurrentAsyncContext(context);
   }
 
@@ -680,9 +684,9 @@ void SignatureExpansion::expandCoroutineResult(bool forContinuation) {
 
     // TODO: should we use some sort of real layout here instead of
     // trusting LLVM's?
-    components.back() =
-      llvm::StructType::get(IGM.getLLVMContext(), overflowTypes)
-        ->getPointerTo();
+    CoroInfo.indirectResultsType =
+        llvm::StructType::get(IGM.getLLVMContext(), overflowTypes);
+    components.back() = CoroInfo.indirectResultsType->getPointerTo();
   }
 
   ResultIRType = components.size() == 1
@@ -1443,9 +1447,12 @@ void SignatureExpansion::expandExternalSignatureTypes() {
         IGM.addSwiftErrorAttributes(Attrs, getCurParamIndex());
         break;
       case clang::ParameterABI::SwiftIndirectResult: {
-        auto *coercedTy = AI.getCoerceToType();
+        auto &param = params[i - clangToSwiftParamOffset];
+        auto paramTy = getSILFuncConventions().getSILType(
+            param, IGM.getMaximalTypeExpansionContext());
+        auto &paramTI = cast<FixedTypeInfo>(IGM.getTypeInfo(paramTy));
         addIndirectResultAttributes(IGM, Attrs, getCurParamIndex(), claimSRet(),
-                                    coercedTy->getPointerElementType());
+                                    paramTI.getStorageType());
         break;
       }
       }
@@ -2084,7 +2091,8 @@ llvm::Value *emitIndirectAsyncFunctionPointer(IRGenFunction &IGF,
   llvm::Value *IntToPtr =
       IGF.Builder.CreateIntToPtr(UntaggedPointer,
                                  AsyncFunctionPointerPtrTy->getPointerTo());
-  llvm::Value *Load = IGF.Builder.CreateLoad(IntToPtr, PointerAlignment);
+  llvm::Value *Load = IGF.Builder.CreateLoad(
+      IntToPtr, AsyncFunctionPointerPtrTy, PointerAlignment);
 
   // (select (icmp eq, (and (ptrtoint %AsyncFunctionPointer), 1), 0),
   //         (%AsyncFunctionPointer),
@@ -2143,11 +2151,12 @@ std::pair<llvm::Value *, llvm::Value *> irgen::getAsyncFunctionAndSize(
     // Otherwise, extract the function pointer from the async FP structure.
     } else {
       llvm::Value *addrPtr = IGF.Builder.CreateStructGEP(
-          getAFPPtr()->getType()->getScalarType()->getPointerElementType(),
-          getAFPPtr(), 0);
+          IGF.IGM.AsyncFunctionPointerTy, getAFPPtr(), 0);
       fn = IGF.emitLoadOfCompactFunctionPointer(
-          Address(addrPtr, IGF.IGM.getPointerAlignment()), /*isFar*/ false,
-          /*expectedType*/ functionPointer.getFunctionType()->getPointerTo());
+          Address(addrPtr, IGF.IGM.RelativeAddressTy,
+                  IGF.IGM.getPointerAlignment()),
+          /*isFar*/ false,
+          /*expectedType*/ functionPointer.getFunctionType());
     }
 
     if (auto authInfo =
@@ -2162,9 +2171,9 @@ std::pair<llvm::Value *, llvm::Value *> irgen::getAsyncFunctionAndSize(
       size = llvm::ConstantInt::get(IGF.IGM.Int32Ty, staticSize->getValue());
     } else {
       auto *sizePtr = IGF.Builder.CreateStructGEP(
-          getAFPPtr()->getType()->getScalarType()->getPointerElementType(),
-          getAFPPtr(), 1);
-      size = IGF.Builder.CreateLoad(sizePtr, IGF.IGM.getPointerAlignment());
+          IGF.IGM.AsyncFunctionPointerTy, getAFPPtr(), 1);
+      size = IGF.Builder.CreateLoad(sizePtr, IGF.IGM.Int32Ty,
+                                    IGF.IGM.getPointerAlignment());
     }
   }
   return {fn, size};
@@ -2290,8 +2299,13 @@ public:
         auto *arg = getCallee().getCXXMethodSelf();
         // We might need to fix the level of indirection for foreign reference types.
         if (selfParam.getInterfaceType().isForeignReferenceType() &&
-            isIndirectFormalParameter(selfParam.getConvention()))
-            arg = IGF.Builder.CreateLoad(arg, IGF.IGM.getPointerAlignment());
+            isIndirectFormalParameter(selfParam.getConvention())) {
+          auto paramTy = fnConv.getSILType(
+              selfParam, IGF.IGM.getMaximalTypeExpansionContext());
+          auto &paramTI = cast<FixedTypeInfo>(IGF.IGM.getTypeInfo(paramTy));
+          arg = IGF.Builder.CreateLoad(arg, paramTI.getStorageType(),
+                                       IGF.IGM.getPointerAlignment());
+        }
 
         adjusted.add(arg);
       }
@@ -2508,10 +2522,15 @@ public:
     PointerAuthInfo codeAuthInfo = CurCallee.getFunctionPointer()
                                        .getAuthInfo()
                                        .getCorrespondingCodeAuthInfo();
-    return FunctionPointer(
-        FunctionPointer::Kind::Function, calleeFunction, codeAuthInfo,
+    auto awaitSig =
         Signature::forAsyncAwait(IGF.IGM, getCallee().getOrigFunctionType(),
-                                 getCallee().getFunctionPointer().getKind()));
+                                 getCallee().getFunctionPointer().getKind());
+    auto awaitEntrySig =
+        Signature::forAsyncEntry(IGF.IGM, getCallee().getOrigFunctionType(),
+                                 getCallee().getFunctionPointer().getKind());
+
+    return FunctionPointer::createForAsyncCall(
+        calleeFunction, codeAuthInfo, awaitSig, awaitEntrySig.getType());
   }
 
   SILType getParameterType(unsigned index) override {
@@ -2826,14 +2845,14 @@ void CallEmission::emitToUnmappedMemory(Address result) {
   SILFunctionConventions FnConv(CurCallee.getSubstFunctionType(),
                                 IGF.getSILModule());
 
-  llvm::Type *storageTy = Args[0]->getType()->getPointerElementType();;
+  llvm::Type *storageTy = result.getElementType();
   if (FnConv.getNumIndirectSILResults() == 1) {
     for (auto indirectResultType : FnConv.getIndirectSILResultTypes(
              IGF.IGM.getMaximalTypeExpansionContext())) {
       bool isFixedSize =
           isa<FixedTypeInfo>(IGF.IGM.getTypeInfo(indirectResultType));
-      storageTy = isFixedSize ? IGF.IGM.getStorageType(indirectResultType)
-                              : IGF.IGM.OpaqueTy;
+      storageTy =
+          isFixedSize ? IGF.IGM.getStorageType(indirectResultType) : storageTy;
     }
   }
   addIndirectResultAttributes(IGF.IGM, CurCallee.getMutableAttributes(), 0,
@@ -2934,22 +2953,21 @@ llvm::CallInst *CallEmission::emitCallSite() {
 }
 
 static llvm::AttributeList
-fixUpTypesInByValAndStructRetAttributes(llvm::FunctionType *fnType,
-                                        llvm::AttributeList attrList) {
+assertTypesInByValAndStructRetAttributes(llvm::FunctionType *fnType,
+                                         llvm::AttributeList attrList) {
   auto &context = fnType->getContext();
-  for (unsigned i = 0; i < fnType->getNumParams(); ++i) {
-    auto paramTy = fnType->getParamType(i);
-    auto attrListIndex = llvm::AttributeList::FirstArgIndex + i;
-    if (attrList.hasParamAttr(i, llvm::Attribute::StructRet) &&
-        paramTy->getPointerElementType() != attrList.getParamStructRetType(i))
-      attrList = attrList.replaceAttributeTypeAtIndex(
-          context, attrListIndex, llvm::Attribute::StructRet,
-          paramTy->getPointerElementType());
-    if (attrList.hasParamAttr(i, llvm::Attribute::ByVal) &&
-        paramTy->getPointerElementType() != attrList.getParamByValType(i))
-      attrList = attrList.replaceAttributeTypeAtIndex(
-          context, attrListIndex, llvm::Attribute::ByVal,
-          paramTy->getPointerElementType());
+  if (context.supportsTypedPointers()) {
+    for (unsigned i = 0; i < fnType->getNumParams(); ++i) {
+      auto paramTy = fnType->getParamType(i);
+      assert(
+          !attrList.hasParamAttr(i, llvm::Attribute::StructRet) ||
+          llvm::cast<llvm::PointerType>(paramTy)->isOpaqueOrPointeeTypeMatches(
+              attrList.getParamStructRetType(i)));
+      assert(
+          !attrList.hasParamAttr(i, llvm::Attribute::ByVal) ||
+          llvm::cast<llvm::PointerType>(paramTy)->isOpaqueOrPointeeTypeMatches(
+              attrList.getParamByValType(i)));
+    }
   }
   return attrList;
 }
@@ -2968,8 +2986,7 @@ llvm::CallInst *IRBuilder::CreateCall(const FunctionPointer &fn,
   }
 
   assert(!isTrapIntrinsic(fn.getRawPointer()) && "Use CreateNonMergeableTrap");
-  auto fnTy = cast<llvm::FunctionType>(
-      fn.getRawPointer()->getType()->getPointerElementType());
+  auto fnTy = cast<llvm::FunctionType>(fn.getFunctionType());
   llvm::CallInst *call =
       IRBuilderBase::CreateCall(fnTy, fn.getRawPointer(), args, bundles);
 
@@ -2980,12 +2997,17 @@ llvm::CallInst *IRBuilder::CreateCall(const FunctionPointer &fn,
     for (unsigned argIndex = 0; argIndex < func->arg_size(); ++argIndex) {
       if (func->hasParamAttribute(argIndex, llvm::Attribute::StructRet)) {
         llvm::AttrBuilder builder(func->getContext());
-        builder.addStructRetAttr(nullptr);
+        builder.addStructRetAttr(func->getParamStructRetType(argIndex));
+        attrs = attrs.addParamAttributes(func->getContext(), argIndex, builder);
+      }
+      if (func->hasParamAttribute(argIndex, llvm::Attribute::ByVal)) {
+        llvm::AttrBuilder builder(func->getContext());
+        builder.addByValAttr(func->getParamByValType(argIndex));
         attrs = attrs.addParamAttributes(func->getContext(), argIndex, builder);
       }
     }
   }
-  call->setAttributes(fixUpTypesInByValAndStructRetAttributes(fnTy, attrs));
+  call->setAttributes(assertTypesInByValAndStructRetAttributes(fnTy, attrs));
   call->setCallingConv(fn.getCallingConv());
   return call;
 }
@@ -3034,8 +3056,8 @@ void CallEmission::emitToMemory(Address addr,
       ->getCanonicalType();
 
   if (origResultType != substResultType) {
-    auto origTy = IGF.IGM.getStoragePointerTypeForLowered(origResultType);
-    origAddr = IGF.Builder.CreateBitCast(origAddr, origTy);
+    auto origTy = IGF.IGM.getStorageTypeForLowered(origResultType);
+    origAddr = IGF.Builder.CreateElementBitCast(origAddr, origTy);
   }
 
   emitToUnmappedMemory(origAddr);
@@ -3082,10 +3104,10 @@ void CallEmission::emitYieldsToExplosion(Explosion &out) {
   if (!rawReturnValues.empty()) {
     // Extract the indirect yield buffer.
     auto indirectPointer = rawReturnValues.claimNext();
-    auto indirectStructTy = cast<llvm::StructType>(
-      indirectPointer->getType()->getPointerElementType());
+    auto indirectStructTy =
+        cast<llvm::StructType>(coroInfo.indirectResultsType);
     auto layout = IGF.IGM.DataLayout.getStructLayout(indirectStructTy);
-    Address indirectBuffer(indirectPointer,
+    Address indirectBuffer(indirectPointer, indirectStructTy,
                            Alignment(layout->getAlignment().value()));
 
     for (auto i : indices(indirectStructTy->elements())) {
@@ -3166,8 +3188,19 @@ void CallEmission::emitToExplosion(Explosion &out, bool isOutlined) {
     if (isNoReturnCFunction) {
       auto fnType = getCallee().getFunctionPointer().getFunctionType();
       assert(fnType->getNumParams() > 0);
-      auto resultTy = fnType->getParamType(0)->getPointerElementType();
+      // The size of the return buffer should not matter since the callee is not
+      // returning but lets try our best to use the right size.
+      llvm::Type *resultTy = IGF.IGM.Int8Ty;
+      auto func = dyn_cast<llvm::Function>(
+          getCallee().getFunctionPointer().getRawPointer());
+      if (func && func->hasParamAttribute(0, llvm::Attribute::StructRet)) {
+        resultTy = func->getParamStructRetType(0);
+      }
       auto temp = IGF.createAlloca(resultTy, Alignment(), "indirect.result");
+      if (IGF.IGM.getLLVMContext().supportsTypedPointers()) {
+        temp = IGF.Builder.CreateElementBitCast(
+            temp, fnType->getParamType(0)->getPointerElementType());
+      }
       emitToMemory(temp, substResultTI, isOutlined);
       return;
     }
@@ -3404,7 +3437,8 @@ static void emitCoerceAndExpand(IRGenFunction &IGF, Explosion &in,
   if (alloca->getAlignment() < coercionTyAlignment.getValue()) {
     alloca->setAlignment(
         llvm::MaybeAlign(coercionTyAlignment.getValue()).valueOrOne());
-    temporary = Address(temporary.getAddress(), coercionTyAlignment);
+    temporary = Address(temporary.getAddress(), temporary.getElementType(),
+                        coercionTyAlignment);
   }
 
   // If we're translating *to* the foreign expansion, do an ordinary
@@ -3493,13 +3527,12 @@ static void emitDirectExternalArgument(IRGenFunction &IGF, SILType argType,
   IGF.Builder.CreateLifetimeStart(temporary, tempSize);
 
   // Store to a temporary.
-  Address tempOfArgTy = IGF.Builder.CreateBitCast(
-      temporary, argTI.getStorageType()->getPointerTo());
+  Address tempOfArgTy =
+      IGF.Builder.CreateElementBitCast(temporary, argTI.getStorageType());
   argTI.initializeFromParams(IGF, in, tempOfArgTy, argType, isOutlined);
 
   // Bitcast the temporary to the expected type.
-  Address coercedAddr =
-      IGF.Builder.CreateBitCast(temporary, coercedTy->getPointerTo());
+  Address coercedAddr = IGF.Builder.CreateElementBitCast(temporary, coercedTy);
 
   if (IsDirectFlattened && isa<llvm::StructType>(coercedTy)) {
     // Project out individual elements if necessary.
@@ -3528,7 +3561,7 @@ namespace {
       : ClangExpandProjection(IGF), Out(out) {}
 
     void visitScalar(llvm::Type *scalarTy, Address addr) {
-      addr = IGF.Builder.CreateBitCast(addr, scalarTy->getPointerTo());
+      addr = IGF.Builder.CreateElementBitCast(addr, scalarTy);
       auto value = IGF.Builder.CreateLoad(addr);
       Out.add(value);
     }
@@ -3545,7 +3578,7 @@ namespace {
     void visitScalar(llvm::Type *scalarTy, Address addr) {
       auto value = In.claimNext();
 
-      addr = IGF.Builder.CreateBitCast(addr, scalarTy->getPointerTo());
+      addr = IGF.Builder.CreateElementBitCast(addr, scalarTy);
       IGF.Builder.CreateStore(value, addr);
     }
   };
@@ -3568,7 +3601,7 @@ emitClangExpandedArgument(IRGenFunction &IGF, Explosion &in, Explosion &out,
   Address temp = ctemp.getAddress();
   swiftTI.initialize(IGF, in, temp, isOutlined);
 
-  Address castTemp = IGF.Builder.CreateBitCast(temp, IGF.IGM.Int8PtrTy);
+  Address castTemp = IGF.Builder.CreateElementBitCast(temp, IGF.IGM.Int8Ty);
   ClangExpandLoadEmitter(IGF, out).visit(clangType, castTemp);
 
   swiftTI.deallocateStack(IGF, ctemp, swiftType);
@@ -3591,7 +3624,7 @@ void irgen::emitClangExpandedParameter(IRGenFunction &IGF,
   auto tempAlloc = swiftTI.allocateStack(IGF, swiftType,
                                          "clang-expand-param.temp");
   Address temp = tempAlloc.getAddress();
-  Address castTemp = IGF.Builder.CreateBitCast(temp, IGF.IGM.Int8PtrTy);
+  Address castTemp = IGF.Builder.CreateElementBitCast(temp, IGF.IGM.Int8Ty);
   ClangExpandStoreEmitter(IGF, in).visit(clangType, castTemp);
 
   // Then load out.
@@ -3664,8 +3697,11 @@ static void externalizeArguments(IRGenFunction &IGF, const Callee &callee,
     // and we can simply use the input directly.
     if (paramType.isForeignReferenceType()) {
       auto *arg = in.claimNext();
-      if (isIndirectFormalParameter(params[i - firstParam].getConvention()))
-        arg = IGF.Builder.CreateLoad(arg, IGF.IGM.getPointerAlignment());
+      if (isIndirectFormalParameter(params[i - firstParam].getConvention())) {
+        auto storageTy = IGF.IGM.getTypeInfo(paramType).getStorageType();
+        arg = IGF.Builder.CreateLoad(arg, storageTy,
+                                     IGF.IGM.getPointerAlignment());
+      }
       out.add(arg);
       continue;
     }
@@ -3711,7 +3747,8 @@ static void externalizeArguments(IRGenFunction &IGF, const Callee &callee,
           auto *AS = cast<llvm::AllocaInst>(addr.getAddress());
           AS->setAlignment(
               llvm::MaybeAlign(ABIAlign.getQuantity()).valueOrOne());
-          addr = Address(addr.getAddress(), Alignment(ABIAlign.getQuantity()));
+          addr = Address(addr.getAddress(), addr.getElementType(),
+                         Alignment(ABIAlign.getQuantity()));
         }
       }
 
@@ -3833,8 +3870,7 @@ static void emitDirectForeignParameter(IRGenFunction &IGF, Explosion &in,
   IGF.Builder.CreateLifetimeStart(temporary, tempSize);
 
   // Write the input parameters into the temporary:
-  Address coercedAddr =
-    IGF.Builder.CreateBitCast(temporary, coercionTy->getPointerTo());
+  Address coercedAddr = IGF.Builder.CreateElementBitCast(temporary, coercionTy);
 
   // Break down a struct expansion if necessary.
   if (auto expansionTy = dyn_cast<llvm::StructType>(coercionTy)) {
@@ -3851,8 +3887,8 @@ static void emitDirectForeignParameter(IRGenFunction &IGF, Explosion &in,
   }
 
   // Pull out the elements.
-  temporary = IGF.Builder.CreateBitCast(temporary,
-                                      paramTI.getStorageType()->getPointerTo());
+  temporary =
+      IGF.Builder.CreateElementBitCast(temporary, paramTI.getStorageType());
   paramTI.loadAsTake(IGF, temporary, out);
 
   // Deallocate the temporary.
@@ -4093,7 +4129,8 @@ void irgen::emitTaskCancel(IRGenFunction &IGF, llvm::Value *task) {
     task = IGF.Builder.CreateBitCast(task, IGF.IGM.SwiftTaskPtrTy);
   }
 
-  auto *call = IGF.Builder.CreateCall(IGF.IGM.getTaskCancelFn(), {task});
+  auto *call =
+      IGF.Builder.CreateCall(IGF.IGM.getTaskCancelFunctionPointer(), {task});
   call->setDoesNotThrow();
   call->setCallingConv(IGF.IGM.SwiftCC);
 }
@@ -4134,11 +4171,8 @@ llvm::Value *irgen::emitTaskCreate(
 
   assert(futureResultType && "no future?!");
   llvm::CallInst *result = IGF.Builder.CreateCall(
-    IGF.IGM.getTaskCreateFn(),
-    {flags,
-     taskOptions,
-     futureResultType,
-     taskFunction, localContextInfo});
+      IGF.IGM.getTaskCreateFunctionPointer(),
+      {flags, taskOptions, futureResultType, taskFunction, localContextInfo});
   result->setDoesNotThrow();
   result->setCallingConv(IGF.IGM.SwiftCC);
 
@@ -4210,9 +4244,7 @@ llvm::Value *irgen::emitYield(IRGenFunction &IGF,
   Optional<Address> indirectBuffer;
   Size indirectBufferSize;
   if (!indirectComponents.empty()) {
-    auto bufferStructTy = cast<llvm::StructType>(
-      resultStructTy->getElementType(resultStructTy->getNumElements() - 1)
-                    ->getPointerElementType());
+    auto bufferStructTy = coroInfo.indirectResultsType;
     auto layout = IGF.IGM.DataLayout.getStructLayout(bufferStructTy);
     indirectBuffer = IGF.createAlloca(
         bufferStructTy, Alignment(layout->getAlignment().value()));
@@ -4326,37 +4358,38 @@ Address IRGenFunction::createErrorResultSlot(SILType errorType, bool isAsync) {
 
 /// Fetch the error result slot.
 Address IRGenFunction::getCalleeErrorResultSlot(SILType errorType) {
-  if (!CalleeErrorResultSlot) {
-    CalleeErrorResultSlot =
-        createErrorResultSlot(errorType, /*isAsync=*/false).getAddress();
+  if (!CalleeErrorResultSlot.isValid()) {
+    CalleeErrorResultSlot = createErrorResultSlot(errorType, /*isAsync=*/false);
   }
-  return Address(CalleeErrorResultSlot, IGM.getPointerAlignment());
+  return CalleeErrorResultSlot;
 }
 
 /// Fetch the error result slot.
 Address IRGenFunction::getAsyncCalleeErrorResultSlot(SILType errorType) {
   assert(isAsync() &&
          "throwing async functions must be called from async functions");
-  if (!AsyncCalleeErrorResultSlot) {
+  if (!AsyncCalleeErrorResultSlot.isValid()) {
     AsyncCalleeErrorResultSlot =
-        createErrorResultSlot(errorType, /*isAsync=*/true).getAddress();
+        createErrorResultSlot(errorType, /*isAsync=*/true);
   }
-  return Address(AsyncCalleeErrorResultSlot, IGM.getPointerAlignment());
+  return AsyncCalleeErrorResultSlot;
 }
 
 /// Fetch the error result slot received from the caller.
 Address IRGenFunction::getCallerErrorResultSlot() {
-  assert(CallerErrorResultSlot && "no error result slot!");
-  assert(isa<llvm::Argument>(CallerErrorResultSlot) && !isAsync() ||
-         isa<llvm::LoadInst>(CallerErrorResultSlot) && isAsync() &&
+  assert(CallerErrorResultSlot.isValid() && "no error result slot!");
+  assert(isa<llvm::Argument>(CallerErrorResultSlot.getAddress()) &&
+             !isAsync() ||
+         isa<llvm::LoadInst>(CallerErrorResultSlot.getAddress()) && isAsync() &&
              "error result slot is local!");
-  return Address(CallerErrorResultSlot, IGM.getPointerAlignment());
+  return CallerErrorResultSlot;
 }
 
 // Set the error result slot.  This should only be done in the prologue.
-void IRGenFunction::setCallerErrorResultSlot(llvm::Value *address) {
-  assert(!CallerErrorResultSlot && "already have a caller error result slot!");
-  assert(isa<llvm::PointerType>(address->getType()));
+void IRGenFunction::setCallerErrorResultSlot(Address address) {
+  assert(!CallerErrorResultSlot.isValid() &&
+         "already have a caller error result slot!");
+  assert(isa<llvm::PointerType>(address.getAddress()->getType()));
   CallerErrorResultSlot = address;
   if (!isAsync()) {
     CalleeErrorResultSlot = address;
@@ -4479,9 +4512,9 @@ llvm::Value* IRGenFunction::coerceValue(llvm::Value *value, llvm::Type *toTy,
   std::tie(address, size) = allocateForCoercion(*this, fromTy, toTy,
                                                 value->getName() + ".coercion");
   Builder.CreateLifetimeStart(address, size);
-  auto orig = Builder.CreateBitCast(address, fromTy->getPointerTo());
+  auto orig = Builder.CreateElementBitCast(address, fromTy);
   Builder.CreateStore(value, orig);
-  auto coerced = Builder.CreateBitCast(address, toTy->getPointerTo());
+  auto coerced = Builder.CreateElementBitCast(address, toTy);
   auto loaded = Builder.CreateLoad(coerced);
   Builder.CreateLifetimeEnd(address, size);
   return loaded;
@@ -4529,7 +4562,8 @@ static void adjustAllocaAlignment(const llvm::DataLayout &DL,
   if (alloca->getAlignment() < layoutAlignment.getValue()) {
     alloca->setAlignment(
         llvm::MaybeAlign(layoutAlignment.getValue()).valueOrOne());
-    allocaAddr = Address(allocaAddr.getAddress(), layoutAlignment);
+    allocaAddr = Address(allocaAddr.getAddress(), allocaAddr.getElementType(),
+                         layoutAlignment);
   }
 }
 
@@ -4700,8 +4734,8 @@ Explosion NativeConventionSchema::mapFromNative(IRGenModule &IGM,
   }
 
   // Reload according to the types schema.
-  Address storageAddr = Builder.CreateBitCast(
-      temporary, loadableTI.getStorageType()->getPointerTo());
+  Address storageAddr =
+      Builder.CreateElementBitCast(temporary, loadableTI.getStorageType());
   loadableTI.loadAsTake(IGF, storageAddr, nonNativeExplosion);
 
   Builder.CreateLifetimeEnd(temporary, tempSize);
@@ -4806,8 +4840,8 @@ Explosion NativeConventionSchema::mapIntoNative(IRGenModule &IGM,
   Builder.CreateLifetimeStart(temporary, tempSize);
 
   // Initialize the memory of the temporary.
-  Address storageAddr = Builder.CreateBitCast(
-      temporary, loadableTI.getStorageType()->getPointerTo());
+  Address storageAddr =
+      Builder.CreateElementBitCast(temporary, loadableTI.getStorageType());
   loadableTI.initialize(IGF, fromNonNative, storageAddr, isOutlined);
 
   // Load the expanded type elements from memory.
@@ -4871,7 +4905,7 @@ Explosion IRGenFunction::coerceValueTo(SILType fromTy, Explosion &from,
   auto addr =
       Address(Builder.CreateBitCast(temporary.getAddressPointer(),
                                     fromTI.getStorageType()->getPointerTo()),
-              temporary.getAlignment());
+              fromTI.getStorageType(), temporary.getAlignment());
   fromTI.initialize(*this, from, addr, false);
 
   toTI.loadAsTake(*this, temporary.getAddress(), result);
@@ -4972,10 +5006,10 @@ Callee irgen::getBlockPointerCallee(IRGenFunction &IGF,
   auto castBlockPtr = IGF.Builder.CreateBitCast(blockPtr, blockPtrTy);
 
   // Extract the invocation pointer for blocks.
-  auto blockStructTy = blockPtrTy->getPointerElementType();
   llvm::Value *invokeFnPtrPtr =
-    IGF.Builder.CreateStructGEP(blockStructTy, castBlockPtr, 3);
-  Address invokeFnPtrAddr(invokeFnPtrPtr, IGF.IGM.getPointerAlignment());
+      IGF.Builder.CreateStructGEP(IGF.IGM.ObjCBlockStructTy, castBlockPtr, 3);
+  Address invokeFnPtrAddr(invokeFnPtrPtr, IGF.IGM.FunctionPtrTy,
+                          IGF.IGM.getPointerAlignment());
   llvm::Value *invokeFnPtr = IGF.Builder.CreateLoad(invokeFnPtrAddr);
 
   auto sig = emitCastOfFunctionPointer(IGF, invokeFnPtr, info.OrigFnType);
@@ -4985,8 +5019,8 @@ Callee irgen::getBlockPointerCallee(IRGenFunction &IGF,
                                         invokeFnPtrAddr.getAddress(),
                                         info.OrigFnType);
 
-  FunctionPointer fn(FunctionPointer::Kind::Function, invokeFnPtr, authInfo,
-                     sig);
+  auto fn = FunctionPointer::createSigned(FunctionPointer::Kind::Function,
+                                          invokeFnPtr, authInfo, sig);
 
   return Callee(std::move(info), fn, blockPtr);
 }
@@ -4998,7 +5032,8 @@ Callee irgen::getSwiftFunctionPointerCallee(
   auto authInfo =
     PointerAuthInfo::forFunctionPointer(IGF.IGM, calleeInfo.OrigFnType);
 
-  FunctionPointer fn(calleeInfo.OrigFnType, fnPtr, authInfo, sig);
+  auto fn = FunctionPointer::createSigned(calleeInfo.OrigFnType, fnPtr,
+                                          authInfo, sig);
   if (castOpaqueToRefcountedContext) {
     assert(dataPtr && dataPtr->getType() == IGF.IGM.OpaquePtrTy &&
            "Expecting trivial closure context");
@@ -5014,7 +5049,8 @@ Callee irgen::getCFunctionPointerCallee(IRGenFunction &IGF,
   auto authInfo =
     PointerAuthInfo::forFunctionPointer(IGF.IGM, calleeInfo.OrigFnType);
 
-  FunctionPointer fn(FunctionPointer::Kind::Function, fnPtr, authInfo, sig);
+  auto fn = FunctionPointer::createSigned(FunctionPointer::Kind::Function,
+                                          fnPtr, authInfo, sig);
 
   return Callee(std::move(calleeInfo), fn);
 }
@@ -5061,12 +5097,13 @@ llvm::Value *FunctionPointer::getPointer(IRGenFunction &IGF) const {
     }
     auto *descriptorPtr =
         IGF.Builder.CreateBitCast(fnPtr, IGF.IGM.AsyncFunctionPointerPtrTy);
-    auto *addrPtr = IGF.Builder.CreateStructGEP(
-        descriptorPtr->getType()->getScalarType()->getPointerElementType(),
-        descriptorPtr, 0);
+    auto *addrPtr = IGF.Builder.CreateStructGEP(IGF.IGM.AsyncFunctionPointerTy,
+                                                descriptorPtr, 0);
     auto *result = IGF.emitLoadOfCompactFunctionPointer(
-        Address(addrPtr, IGF.IGM.getPointerAlignment()), /*isFar*/ false,
-        /*expectedType*/ getFunctionType()->getPointerTo());
+        Address(addrPtr, IGF.IGM.RelativeAddressTy,
+                IGF.IGM.getPointerAlignment()),
+        /*isFar*/ false,
+        /*expectedType*/ getFunctionType());
     if (auto codeAuthInfo = AuthInfo.getCorrespondingCodeAuthInfo()) {
       result = emitPointerAuthSign(IGF, result, codeAuthInfo);
     }
@@ -5138,8 +5175,8 @@ void irgen::emitAsyncReturn(
   }
 
   auto sig = emitCastOfFunctionPointer(IGF, fnVal, fnType, true);
-  FunctionPointer fnPtr(FunctionPointer::Kind::Function, fnVal,
-                        PointerAuthInfo(), sig);
+  auto fnPtr = FunctionPointer::createUnsigned(FunctionPointer::Kind::Function,
+                                               fnVal, sig);
 
   SmallVector<llvm::Value*, 4> Args;
   // Get the current async context.
@@ -5230,40 +5267,41 @@ IRGenFunction::getFunctionPointerForResumeIntrinsic(llvm::Value *resume) {
                                   llvm::Attribute::SwiftAsync);
   auto signature =
       Signature(fnTy, attrs, IGM.SwiftAsyncCC);
-  auto fnPtr = FunctionPointer(
+  auto fnPtr = FunctionPointer::createUnsigned(
       FunctionPointer::Kind::Function,
-      Builder.CreateBitOrPointerCast(resume, fnTy->getPointerTo()),
-      PointerAuthInfo(), signature);
+      Builder.CreateBitOrPointerCast(resume, fnTy->getPointerTo()), signature);
   return fnPtr;
 }
 
 Address irgen::emitAutoDiffCreateLinearMapContext(
     IRGenFunction &IGF, llvm::Value *topLevelSubcontextSize) {
   auto *call = IGF.Builder.CreateCall(
-      IGF.IGM.getAutoDiffCreateLinearMapContextFn(), {topLevelSubcontextSize});
+      IGF.IGM.getAutoDiffCreateLinearMapContextFunctionPointer(),
+      {topLevelSubcontextSize});
   call->setDoesNotThrow();
   call->setCallingConv(IGF.IGM.SwiftCC);
-  return Address(call, IGF.IGM.getPointerAlignment());
+  return Address(call, IGF.IGM.RefCountedStructTy,
+                 IGF.IGM.getPointerAlignment());
 }
 
 Address irgen::emitAutoDiffProjectTopLevelSubcontext(
     IRGenFunction &IGF, Address context) {
   auto *call = IGF.Builder.CreateCall(
-      IGF.IGM.getAutoDiffProjectTopLevelSubcontextFn(),
+      IGF.IGM.getAutoDiffProjectTopLevelSubcontextFunctionPointer(),
       {context.getAddress()});
   call->setDoesNotThrow();
   call->setCallingConv(IGF.IGM.SwiftCC);
-  return Address(call, IGF.IGM.getPointerAlignment());
+  return Address(call, IGF.IGM.Int8Ty, IGF.IGM.getPointerAlignment());
 }
 
 Address irgen::emitAutoDiffAllocateSubcontext(
     IRGenFunction &IGF, Address context, llvm::Value *size) {
   auto *call = IGF.Builder.CreateCall(
-      IGF.IGM.getAutoDiffAllocateSubcontextFn(),
+      IGF.IGM.getAutoDiffAllocateSubcontextFunctionPointer(),
       {context.getAddress(), size});
   call->setDoesNotThrow();
   call->setCallingConv(IGF.IGM.SwiftCC);
-  return Address(call, IGF.IGM.getPointerAlignment());
+  return Address(call, IGF.IGM.Int8Ty, IGF.IGM.getPointerAlignment());
 }
 
 FunctionPointer
@@ -5275,8 +5313,9 @@ irgen::getFunctionPointerForDispatchCall(IRGenModule &IGM,
       IGM.VoidTy, fn.getSignature().getType()->params(), false /*vaargs*/);
   auto signature =
       Signature(fnTy, fn.getSignature().getAttributes(), IGM.SwiftAsyncCC);
-  auto fnPtr = FunctionPointer(FunctionPointer::Kind::Function,
-                               fn.getRawPointer(), fn.getAuthInfo(), signature);
+  auto fnPtr = FunctionPointer::createSigned(FunctionPointer::Kind::Function,
+                                             fn.getRawPointer(),
+                                             fn.getAuthInfo(), signature);
   return fnPtr;
 }
 
@@ -5312,4 +5351,29 @@ void irgen::forwardAsyncCallResult(IRGenFunction &IGF,
     nativeResults = nativeResultsStorage;
   }
   emitAsyncReturn(IGF, layout, fnType, nativeResults);
+}
+
+llvm::FunctionType *FunctionPointer::getFunctionType() const {
+  // Read the function type off the global or else from the Signature.
+  if (auto *constant = dyn_cast<llvm::Constant>(Value)) {
+    auto *gv = dyn_cast<llvm::GlobalValue>(Value);
+    if (!gv) {
+      assert(llvm::cast<llvm::PointerType>(Value->getType())
+                 ->isOpaqueOrPointeeTypeMatches(Sig.getType()));
+      return Sig.getType();
+    }
+    assert(llvm::cast<llvm::PointerType>(Value->getType())
+               ->isOpaqueOrPointeeTypeMatches(gv->getValueType()));
+    return cast<llvm::FunctionType>(gv->getValueType());
+  }
+
+  if (awaitSignature) {
+    assert(llvm::cast<llvm::PointerType>(Value->getType())
+               ->isOpaqueOrPointeeTypeMatches(awaitSignature));
+    return cast<llvm::FunctionType>(awaitSignature);
+  }
+
+  assert(llvm::cast<llvm::PointerType>(Value->getType())
+             ->isOpaqueOrPointeeTypeMatches(Sig.getType()));
+  return Sig.getType();
 }

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -2845,19 +2845,6 @@ void CallEmission::emitToUnmappedMemory(Address result) {
   SILFunctionConventions FnConv(CurCallee.getSubstFunctionType(),
                                 IGF.getSILModule());
 
-  llvm::Type *storageTy = result.getElementType();
-  if (FnConv.getNumIndirectSILResults() == 1) {
-    for (auto indirectResultType : FnConv.getIndirectSILResultTypes(
-             IGF.IGM.getMaximalTypeExpansionContext())) {
-      bool isFixedSize =
-          isa<FixedTypeInfo>(IGF.IGM.getTypeInfo(indirectResultType));
-      storageTy =
-          isFixedSize ? IGF.IGM.getStorageType(indirectResultType) : storageTy;
-    }
-  }
-  addIndirectResultAttributes(IGF.IGM, CurCallee.getMutableAttributes(), 0,
-                              FnConv.getNumIndirectSILResults() <= 1,
-                              storageTy);
 #ifndef NDEBUG
   LastArgWritten = 0; // appease an assert
 #endif

--- a/lib/IRGen/GenCast.cpp
+++ b/lib/IRGen/GenCast.cpp
@@ -68,8 +68,8 @@ llvm::Value *irgen::emitCheckedCast(IRGenFunction &IGF,
   DynamicCastFlags flags = getDynamicCastFlags(consumptionKind, mode);
 
   // Cast both addresses to opaque pointer type.
-  dest = IGF.Builder.CreateBitCast(dest, IGF.IGM.OpaquePtrTy);
-  src = IGF.Builder.CreateBitCast(src, IGF.IGM.OpaquePtrTy);
+  dest = IGF.Builder.CreateElementBitCast(dest, IGF.IGM.OpaqueTy);
+  src = IGF.Builder.CreateElementBitCast(src, IGF.IGM.OpaqueTy);
 
   // Load type metadata for the source's static type and the target type.
   llvm::Value *srcMetadata = IGF.emitTypeMetadataRef(srcType);
@@ -81,7 +81,8 @@ llvm::Value *irgen::emitCheckedCast(IRGenFunction &IGF,
     IGF.IGM.getSize(Size(unsigned(flags)))
   };
 
-  auto call = IGF.Builder.CreateCall(IGF.IGM.getDynamicCastFn(), args);
+  auto call =
+      IGF.Builder.CreateCall(IGF.IGM.getDynamicCastFunctionPointer(), args);
   call->setDoesNotThrow();
 
   return call;
@@ -175,7 +176,7 @@ llvm::Value *irgen::emitClassDowncast(IRGenFunction &IGF, llvm::Value *from,
   // Emit a reference to the metadata and figure out what cast
   // function to use.
   llvm::Value *metadataRef;
-  llvm::Constant *castFn;
+  FunctionPointer castFn;
 
   // If true, the target class is not known at compile time because it is a
   // class-bounded archetype or the dynamic Self type.
@@ -202,10 +203,10 @@ llvm::Value *irgen::emitClassDowncast(IRGenFunction &IGF, llvm::Value *from,
 
     switch (mode) {
     case CheckedCastMode::Unconditional:
-      castFn = IGF.IGM.getDynamicCastClassUnconditionalFn();
+      castFn = IGF.IGM.getDynamicCastClassUnconditionalFunctionPointer();
       break;
     case CheckedCastMode::Conditional:
-      castFn = IGF.IGM.getDynamicCastClassFn();
+      castFn = IGF.IGM.getDynamicCastClassFunctionPointer();
       break;
     }
 
@@ -217,10 +218,10 @@ llvm::Value *irgen::emitClassDowncast(IRGenFunction &IGF, llvm::Value *from,
 
     switch (mode) {
     case CheckedCastMode::Unconditional:
-      castFn = IGF.IGM.getDynamicCastUnknownClassUnconditionalFn();
+      castFn = IGF.IGM.getDynamicCastUnknownClassUnconditionalFunctionPointer();
       break;
     case CheckedCastMode::Conditional:
-      castFn = IGF.IGM.getDynamicCastUnknownClassFn();
+      castFn = IGF.IGM.getDynamicCastUnknownClassFunctionPointer();
       break;
     }
 
@@ -230,10 +231,10 @@ llvm::Value *irgen::emitClassDowncast(IRGenFunction &IGF, llvm::Value *from,
 
     switch (mode) {
     case CheckedCastMode::Unconditional:
-      castFn = IGF.IGM.getDynamicCastObjCClassUnconditionalFn();
+      castFn = IGF.IGM.getDynamicCastObjCClassUnconditionalFunctionPointer();
       break;
     case CheckedCastMode::Conditional:
-      castFn = IGF.IGM.getDynamicCastObjCClassFn();
+      castFn = IGF.IGM.getDynamicCastObjCClassFunctionPointer();
       break;
     }
   }
@@ -242,10 +243,6 @@ llvm::Value *irgen::emitClassDowncast(IRGenFunction &IGF, llvm::Value *from,
     metadataRef = IGF.Builder.CreateBitCast(metadataRef, IGF.IGM.Int8PtrTy);
 
   // Call the (unconditional) dynamic cast.
-  auto cc = IGF.IGM.DefaultCC;
-  if (auto fun = dyn_cast<llvm::Function>(castFn))
-    cc = fun->getCallingConv();
-
   llvm::Value *argsBuf[] = {
     from,
     metadataRef,
@@ -254,10 +251,8 @@ llvm::Value *irgen::emitClassDowncast(IRGenFunction &IGF, llvm::Value *from,
     nullptr,
   };
 
-  auto call
-    = IGF.Builder.CreateCall(castFn,
-                             getDynamicCastArguments(IGF, argsBuf, mode));
-  call->setCallingConv(cc);
+  auto call = IGF.Builder.CreateCall(
+      castFn, getDynamicCastArguments(IGF, argsBuf, mode));
   call->setDoesNotThrow();
 
   llvm::Type *subTy = IGF.getTypeInfoForUnlowered(toType).getStorageType();
@@ -272,7 +267,7 @@ void irgen::emitMetatypeDowncast(IRGenFunction &IGF,
                                  Explosion &ex) {
   // Pick a runtime entry point and target metadata based on what kind of
   // representation we're casting.
-  llvm::Constant *castFn;
+  FunctionPointer castFn;
   llvm::Value *toMetadata;
 
   switch (toMetatype->getRepresentation()) {
@@ -281,10 +276,10 @@ void irgen::emitMetatypeDowncast(IRGenFunction &IGF,
     toMetadata = IGF.emitTypeMetadataRef(toMetatype.getInstanceType());
     switch (mode) {
     case CheckedCastMode::Unconditional:
-      castFn = IGF.IGM.getDynamicCastMetatypeUnconditionalFn();
+      castFn = IGF.IGM.getDynamicCastMetatypeUnconditionalFunctionPointer();
       break;
     case CheckedCastMode::Conditional:
-      castFn = IGF.IGM.getDynamicCastMetatypeFn();
+      castFn = IGF.IGM.getDynamicCastMetatypeFunctionPointer();
       break;
     }
     break;
@@ -299,10 +294,11 @@ void irgen::emitMetatypeDowncast(IRGenFunction &IGF,
                                           MetadataState::Complete);
     switch (mode) {
     case CheckedCastMode::Unconditional:
-      castFn = IGF.IGM.getDynamicCastObjCClassMetatypeUnconditionalFn();
+      castFn =
+          IGF.IGM.getDynamicCastObjCClassMetatypeUnconditionalFunctionPointer();
       break;
     case CheckedCastMode::Conditional:
-      castFn = IGF.IGM.getDynamicCastObjCClassMetatypeFn();
+      castFn = IGF.IGM.getDynamicCastObjCClassMetatypeFunctionPointer();
       break;
     }
     break;
@@ -312,10 +308,6 @@ void irgen::emitMetatypeDowncast(IRGenFunction &IGF,
     llvm_unreachable("not implemented");
   }
 
-  auto cc = IGF.IGM.DefaultCC;
-  if (auto fun = dyn_cast<llvm::Function>(castFn))
-    cc = fun->getCallingConv();
-  
   llvm::Value *argsBuf[] = {
     metatype,
     toMetadata,
@@ -324,9 +316,8 @@ void irgen::emitMetatypeDowncast(IRGenFunction &IGF,
     nullptr,
   };
 
-  auto call = IGF.Builder.CreateCall(castFn,
-                                   getDynamicCastArguments(IGF, argsBuf, mode));
-  call->setCallingConv(cc);
+  auto call = IGF.Builder.CreateCall(
+      castFn, getDynamicCastArguments(IGF, argsBuf, mode));
   call->setDoesNotThrow();
   ex.add(call);
 }
@@ -338,12 +329,9 @@ llvm::Value *irgen::emitReferenceToObjCProtocol(IRGenFunction &IGF,
 
   // Get the address of the global variable the protocol reference gets
   // indirected through.
-  llvm::Constant *protocolRefAddr
-    = IGF.IGM.getAddrOfObjCProtocolRef(proto, NotForDefinition);
-
-  // Load the protocol reference.
-  Address addr(protocolRefAddr, IGF.IGM.getPointerAlignment());
-  return IGF.Builder.CreateLoad(addr);
+  auto protocolRefAddr =
+      IGF.IGM.getAddrOfObjCProtocolRef(proto, NotForDefinition);
+  return IGF.Builder.CreateLoad(protocolRefAddr);
 }
 
 /// Emit a helper function to look up \c numProtocols witness tables given
@@ -360,11 +348,9 @@ llvm::Value *irgen::emitReferenceToObjCProtocol(IRGenFunction &IGF,
 /// The function's output type is (value, witnessTable...)
 ///
 /// The value is NULL if the cast failed.
-static llvm::Constant *
-emitExistentialScalarCastFn(IRGenModule &IGM,
-                            unsigned numProtocols,
-                            CheckedCastMode mode,
-                            bool checkClassConstraint,
+static FunctionPointer
+emitExistentialScalarCastFn(IRGenModule &IGM, unsigned numProtocols,
+                            CheckedCastMode mode, bool checkClassConstraint,
                             bool checkSuperclassConstraint) {
   assert(!checkSuperclassConstraint || checkClassConstraint);
 
@@ -403,76 +389,79 @@ emitExistentialScalarCastFn(IRGenModule &IGM,
   
   llvm::Type *returnTy = llvm::StructType::get(IGM.getLLVMContext(), returnTys);
 
-  return IGM.getOrCreateHelperFunction(name, returnTy, argTys,
-                                       [&](IRGenFunction &IGF) {
-    Explosion args = IGF.collectParameters();
+  auto fn = IGM.getOrCreateHelperFunction(
+      name, returnTy, argTys, [&](IRGenFunction &IGF) {
+        Explosion args = IGF.collectParameters();
 
-    auto value = args.claimNext();
-    auto ref = args.claimNext();
-    auto failBB = IGF.createBasicBlock("fail");
-    auto conformsToProtocol = IGM.getConformsToProtocolFn();
+        auto value = args.claimNext();
+        auto ref = args.claimNext();
+        auto failBB = IGF.createBasicBlock("fail");
+        auto conformsToProtocol = IGM.getConformsToProtocolFunctionPointer();
 
-    Explosion rets;
-    rets.add(value);
+        Explosion rets;
+        rets.add(value);
 
-    // Check the class constraint if necessary.
-    if (checkSuperclassConstraint) {
-      auto superclassMetadata = args.claimNext();
-      auto castFn = IGF.IGM.getDynamicCastMetatypeFn();
-      auto castResult = IGF.Builder.CreateCall(castFn, {ref,
-                                                        superclassMetadata});
+        // Check the class constraint if necessary.
+        if (checkSuperclassConstraint) {
+          auto superclassMetadata = args.claimNext();
+          auto castFn = IGF.IGM.getDynamicCastMetatypeFunctionPointer();
+          auto castResult =
+              IGF.Builder.CreateCall(castFn, {ref, superclassMetadata});
 
-      auto cc = cast<llvm::Function>(castFn)->getCallingConv();
+          // FIXME: Eventually, we may want to throw.
+          castResult->setDoesNotThrow();
 
-      // FIXME: Eventually, we may want to throw.
-      castResult->setCallingConv(cc);
-      castResult->setDoesNotThrow();
+          auto isClass = IGF.Builder.CreateICmpNE(
+              castResult,
+              llvm::ConstantPointerNull::get(IGF.IGM.TypeMetadataPtrTy));
 
-      auto isClass = IGF.Builder.CreateICmpNE(
-          castResult,
-          llvm::ConstantPointerNull::get(IGF.IGM.TypeMetadataPtrTy));
+          auto contBB = IGF.createBasicBlock("cont");
+          IGF.Builder.CreateCondBr(isClass, contBB, failBB);
+          IGF.Builder.emitBlock(contBB);
+        } else if (checkClassConstraint) {
+          auto isClass =
+              IGF.Builder.CreateCall(IGM.getIsClassTypeFunctionPointer(), ref);
+          auto contBB = IGF.createBasicBlock("cont");
+          IGF.Builder.CreateCondBr(isClass, contBB, failBB);
+          IGF.Builder.emitBlock(contBB);
+        }
 
-      auto contBB = IGF.createBasicBlock("cont");
-      IGF.Builder.CreateCondBr(isClass, contBB, failBB);
-      IGF.Builder.emitBlock(contBB);
-    } else if (checkClassConstraint) {
-      auto isClass = IGF.Builder.CreateCall(IGM.getIsClassTypeFn(), ref);
-      auto contBB = IGF.createBasicBlock("cont");
-      IGF.Builder.CreateCondBr(isClass, contBB, failBB);
-      IGF.Builder.emitBlock(contBB);
-    }
+        // Look up each protocol conformance we want.
+        for (unsigned i = 0; i < numProtocols; ++i) {
+          auto proto = args.claimNext();
+          auto witness =
+              IGF.Builder.CreateCall(conformsToProtocol, {ref, proto});
+          auto isNull = IGF.Builder.CreateICmpEQ(
+              witness, llvm::ConstantPointerNull::get(IGM.WitnessTablePtrTy));
+          auto contBB = IGF.createBasicBlock("cont");
+          IGF.Builder.CreateCondBr(isNull, failBB, contBB);
 
-    // Look up each protocol conformance we want.
-    for (unsigned i = 0; i < numProtocols; ++i) {
-      auto proto = args.claimNext();
-      auto witness = IGF.Builder.CreateCall(conformsToProtocol, {ref, proto});
-      auto isNull = IGF.Builder.CreateICmpEQ(witness,
-                       llvm::ConstantPointerNull::get(IGM.WitnessTablePtrTy));
-      auto contBB = IGF.createBasicBlock("cont");
-      IGF.Builder.CreateCondBr(isNull, failBB, contBB);
+          IGF.Builder.emitBlock(contBB);
+          rets.add(witness);
+        }
 
-      IGF.Builder.emitBlock(contBB);
-      rets.add(witness);
-    }
+        // If we succeeded, return the witnesses.
+        IGF.emitScalarReturn(returnTy, rets);
 
-    // If we succeeded, return the witnesses.
-    IGF.emitScalarReturn(returnTy, rets);
-    
-    // If we failed, return nil or trap.
-    IGF.Builder.emitBlock(failBB);
-    switch (mode) {
-    case CheckedCastMode::Conditional: {
-      auto null = llvm::ConstantStruct::getNullValue(returnTy);
-      IGF.Builder.CreateRet(null);
-      break;
-    }
+        // If we failed, return nil or trap.
+        IGF.Builder.emitBlock(failBB);
+        switch (mode) {
+        case CheckedCastMode::Conditional: {
+          auto null = llvm::ConstantStruct::getNullValue(returnTy);
+          IGF.Builder.CreateRet(null);
+          break;
+        }
 
-    case CheckedCastMode::Unconditional: {
-      IGF.emitTrap("type cast failed", /*EmitUnreachable=*/true);
-      break;
-    }
-    }
-  });
+        case CheckedCastMode::Unconditional: {
+          IGF.emitTrap("type cast failed", /*EmitUnreachable=*/true);
+          break;
+        }
+        }
+      });
+  auto fnType = llvm::FunctionType::get(returnTy, argTys, false);
+  auto sig = Signature(fnType, {}, IGM.DefaultCC);
+  return FunctionPointer::forDirect(FunctionPointer::Kind::Function, fn,
+                                    nullptr, sig);
 }
 
 llvm::Value *irgen::emitMetatypeToAnyObjectDowncast(IRGenFunction &IGF,
@@ -512,20 +501,18 @@ llvm::Value *irgen::emitMetatypeToAnyObjectDowncast(IRGenFunction &IGF,
     }
 
     // Ask the runtime whether this is class metadata.
-    llvm::Constant *castFn;
+    FunctionPointer castFn;
     switch (mode) {
     case CheckedCastMode::Conditional:
-      castFn = IGF.IGM.getDynamicCastMetatypeToObjectConditionalFn();
+      castFn =
+          IGF.IGM.getDynamicCastMetatypeToObjectConditionalFunctionPointer();
       break;
     case CheckedCastMode::Unconditional:
-      castFn = IGF.IGM.getDynamicCastMetatypeToObjectUnconditionalFn();
+      castFn =
+          IGF.IGM.getDynamicCastMetatypeToObjectUnconditionalFunctionPointer();
       break;
     }
-    
-    auto cc = IGF.IGM.DefaultCC;
-    if (auto fun = dyn_cast<llvm::Function>(castFn))
-      cc = fun->getCallingConv();
-    
+
     llvm::Value *argsBuf[] = {
       metatypeValue,
       nullptr,
@@ -533,9 +520,8 @@ llvm::Value *irgen::emitMetatypeToAnyObjectDowncast(IRGenFunction &IGF,
       nullptr,
     };
 
-    auto call = IGF.Builder.CreateCall(castFn,
-                                   getDynamicCastArguments(IGF, argsBuf, mode));
-    call->setCallingConv(cc);
+    auto call = IGF.Builder.CreateCall(
+        castFn, getDynamicCastArguments(IGF, argsBuf, mode));
     return call;
   }
   }
@@ -686,17 +672,21 @@ void irgen::emitScalarExistentialDowncast(IRGenFunction &IGF,
     
     // Pick the cast function based on the cast mode and on whether we're
     // casting a Swift metatype or ObjC object.
-    llvm::Constant *castFn;
+    FunctionPointer castFn;
     switch (mode) {
     case CheckedCastMode::Unconditional:
-      castFn = objcObject
-        ? IGF.IGM.getDynamicCastObjCProtocolUnconditionalFn()
-        : IGF.IGM.getDynamicCastTypeToObjCProtocolUnconditionalFn();
+      castFn =
+          objcObject
+              ? IGF.IGM.getDynamicCastObjCProtocolUnconditionalFunctionPointer()
+              : IGF.IGM
+                    .getDynamicCastTypeToObjCProtocolUnconditionalFunctionPointer();
       break;
     case CheckedCastMode::Conditional:
-      castFn = objcObject
-        ? IGF.IGM.getDynamicCastObjCProtocolConditionalFn()
-        : IGF.IGM.getDynamicCastTypeToObjCProtocolConditionalFn();
+      castFn =
+          objcObject
+              ? IGF.IGM.getDynamicCastObjCProtocolConditionalFunctionPointer()
+              : IGF.IGM
+                    .getDynamicCastTypeToObjCProtocolConditionalFunctionPointer();
       break;
     }
     llvm::Value *objcCastObject = objcObject ? objcObject : value;
@@ -706,8 +696,8 @@ void irgen::emitScalarExistentialDowncast(IRGenFunction &IGF,
                                                              objcProtos.size()),
                                         IGF.IGM.getPointerAlignment(),
                                         "objc_protocols");
-    protoRefsBuf = IGF.Builder.CreateBitCast(protoRefsBuf,
-                                             IGF.IGM.Int8PtrPtrTy);
+    protoRefsBuf =
+        IGF.Builder.CreateElementBitCast(protoRefsBuf, IGF.IGM.Int8PtrTy);
 
     for (unsigned index : indices(objcProtos)) {
       Address protoRefSlot = IGF.Builder.CreateConstArrayGEP(
@@ -716,11 +706,6 @@ void irgen::emitScalarExistentialDowncast(IRGenFunction &IGF,
       IGF.Builder.CreateStore(objcProtos[index], protoRefSlot);
       ++index;
     }
-
-    
-    auto cc = IGF.IGM.DefaultCC;
-    if (auto fun = dyn_cast<llvm::Function>(castFn))
-      cc = fun->getCallingConv();
 
     llvm::Value *argsBuf[] = {
       objcCastObject,
@@ -732,9 +717,7 @@ void irgen::emitScalarExistentialDowncast(IRGenFunction &IGF,
     };
 
     auto call = IGF.Builder.CreateCall(
-      castFn,
-      getDynamicCastArguments(IGF, argsBuf, mode));
-    call->setCallingConv(cc);
+        castFn, getDynamicCastArguments(IGF, argsBuf, mode));
     objcCast = call;
     resultValue = IGF.Builder.CreateBitCast(objcCast, resultType);
   }

--- a/lib/IRGen/GenConcurrency.cpp
+++ b/lib/IRGen/GenConcurrency.cpp
@@ -129,8 +129,8 @@ const LoadableTypeInfo &TypeConverter::getExecutorTypeInfo() {
 
 void irgen::emitBuildMainActorExecutorRef(IRGenFunction &IGF,
                                           Explosion &out) {
-  auto call = IGF.Builder.CreateCall(IGF.IGM.getTaskGetMainExecutorFn(),
-                                     {});
+  auto call = IGF.Builder.CreateCall(
+      IGF.IGM.getTaskGetMainExecutorFunctionPointer(), {});
   call->setDoesNotThrow();
   call->setCallingConv(IGF.IGM.SwiftCC);
 
@@ -167,8 +167,8 @@ void irgen::emitBuildOrdinarySerialExecutorRef(IRGenFunction &IGF,
 }
 
 void irgen::emitGetCurrentExecutor(IRGenFunction &IGF, Explosion &out) {
-  auto *call = IGF.Builder.CreateCall(IGF.IGM.getTaskGetCurrentExecutorFn(),
-                                      {});
+  auto *call = IGF.Builder.CreateCall(
+      IGF.IGM.getTaskGetCurrentExecutorFunctionPointer(), {});
   call->setDoesNotThrow();
   call->setCallingConv(IGF.IGM.SwiftCC);
 
@@ -241,23 +241,15 @@ llvm::Value *irgen::emitBuiltinStartAsyncLet(IRGenFunction &IGF,
   llvm::CallInst *call;
   if (localResultBuffer) {
     // This is @_silgen_name("swift_asyncLet_begin")
-    call = IGF.Builder.CreateCall(IGF.IGM.getAsyncLetBeginFn(),
-                                      {alet,
-                                       taskOptions,
-                                       futureResultTypeMetadata,
-                                       taskFunction,
-                                       localContextInfo,
-                                       localResultBuffer
-                                      });
+    call = IGF.Builder.CreateCall(IGF.IGM.getAsyncLetBeginFunctionPointer(),
+                                  {alet, taskOptions, futureResultTypeMetadata,
+                                   taskFunction, localContextInfo,
+                                   localResultBuffer});
   } else {
     // This is @_silgen_name("swift_asyncLet_start")
-    call = IGF.Builder.CreateCall(IGF.IGM.getAsyncLetStartFn(),
-                                      {alet,
-                                       taskOptions,
-                                       futureResultTypeMetadata,
-                                       taskFunction,
-                                       localContextInfo
-                                      });
+    call = IGF.Builder.CreateCall(IGF.IGM.getAsyncLetStartFunctionPointer(),
+                                  {alet, taskOptions, futureResultTypeMetadata,
+                                   taskFunction, localContextInfo});
   }
   call->setDoesNotThrow();
   call->setCallingConv(IGF.IGM.SwiftCC);
@@ -266,8 +258,8 @@ llvm::Value *irgen::emitBuiltinStartAsyncLet(IRGenFunction &IGF,
 }
 
 void irgen::emitEndAsyncLet(IRGenFunction &IGF, llvm::Value *alet) {
-  auto *call = IGF.Builder.CreateCall(IGF.IGM.getEndAsyncLetFn(),
-                                      {alet});
+  auto *call =
+      IGF.Builder.CreateCall(IGF.IGM.getEndAsyncLetFunctionPointer(), {alet});
   call->setDoesNotThrow();
   call->setCallingConv(IGF.IGM.SwiftCC);
 
@@ -286,8 +278,9 @@ llvm::Value *irgen::emitCreateTaskGroup(IRGenFunction &IGF,
   auto resultType = subs.getReplacementTypes()[0]->getCanonicalType();
   auto resultTypeMetadata = IGF.emitAbstractTypeMetadataRef(resultType);
 
-  auto *call = IGF.Builder.CreateCall(IGF.IGM.getTaskGroupInitializeFn(),
-                                      {group, resultTypeMetadata});
+  auto *call =
+      IGF.Builder.CreateCall(IGF.IGM.getTaskGroupInitializeFunctionPointer(),
+                             {group, resultTypeMetadata});
   call->setDoesNotThrow();
   call->setCallingConv(IGF.IGM.SwiftCC);
 
@@ -295,8 +288,8 @@ llvm::Value *irgen::emitCreateTaskGroup(IRGenFunction &IGF,
 }
 
 void irgen::emitDestroyTaskGroup(IRGenFunction &IGF, llvm::Value *group) {
-  auto *call = IGF.Builder.CreateCall(IGF.IGM.getTaskGroupDestroyFn(),
-                                      {group});
+  auto *call = IGF.Builder.CreateCall(
+      IGF.IGM.getTaskGroupDestroyFunctionPointer(), {group});
   call->setDoesNotThrow();
   call->setCallingConv(IGF.IGM.SwiftCC);
 
@@ -325,7 +318,8 @@ llvm::Function *IRGenModule::getAwaitAsyncContinuationFn() {
   auto &Builder = suspendIGF.Builder;
 
   llvm::Value *context = suspendFn->getArg(0);
-  auto *call = Builder.CreateCall(getContinuationAwaitFn(), { context });
+  auto *call =
+      Builder.CreateCall(getContinuationAwaitFunctionPointer(), {context});
   call->setDoesNotThrow();
   call->setCallingConv(SwiftAsyncCC);
   call->setTailCallKind(AsyncTailCallKind);
@@ -343,7 +337,7 @@ void irgen::emitTaskRunInline(IRGenFunction &IGF, SubstitutionMap subs,
   auto resultTypeMetadata = IGF.emitAbstractTypeMetadataRef(resultType);
 
   auto *call = IGF.Builder.CreateCall(
-      IGF.IGM.getTaskRunInlineFn(),
+      IGF.IGM.getTaskRunInlineFunctionPointer(),
       {result, closure, closureContext, resultTypeMetadata});
   call->setDoesNotThrow();
   call->setCallingConv(IGF.IGM.SwiftCC);

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1967,6 +1967,8 @@ void IRGenerator::emitEagerClassInitialization() {
                                 "_swift_eager_class_initialization");
   IGM->Module.getFunctionList().push_back(RegisterFn);
   IRGenFunction RegisterIGF(*IGM, RegisterFn);
+  if (IGM->DebugInfo)
+    IGM->DebugInfo->emitArtificialFunction(RegisterIGF, RegisterIGF.CurFn);
   RegisterFn->setAttributes(IGM->constructInitialAttributes());
   RegisterFn->setCallingConv(IGM->DefaultCC);
 
@@ -2008,6 +2010,8 @@ void IRGenerator::emitObjCActorsNeedingSuperclassSwizzle() {
                                 "_swift_objc_actor_initialization");
   IGM->Module.getFunctionList().push_back(RegisterFn);
   IRGenFunction RegisterIGF(*IGM, RegisterFn);
+  if (IGM->DebugInfo)
+    IGM->DebugInfo->emitArtificialFunction(RegisterIGF, RegisterIGF.CurFn);
   RegisterFn->setAttributes(IGM->constructInitialAttributes());
   RegisterFn->setCallingConv(IGM->DefaultCC);
 

--- a/lib/IRGen/GenDistributed.cpp
+++ b/lib/IRGen/GenDistributed.cpp
@@ -51,7 +51,7 @@ llvm::Value *irgen::emitDistributedActorInitializeRemote(
                                              /*forBackwardDeployment=*/false);
   llvm::Type *destType = classLayout.getType()->getPointerTo();
 
-  auto fn = IGF.IGM.getDistributedActorInitializeRemoteFn();
+  auto fn = IGF.IGM.getDistributedActorInitializeRemoteFunctionPointer();
   actorMetatype =
       IGF.Builder.CreateBitCast(actorMetatype, IGF.IGM.TypeMetadataPtrTy);
 
@@ -490,8 +490,8 @@ void DistributedAccessor::decodeArgument(unsigned argumentIdx,
   case ParameterConvention::Direct_Guaranteed:
   case ParameterConvention::Direct_Unowned: {
     auto paramTy = param.getSILStorageInterfaceType();
-    Address eltPtr = IGF.Builder.CreateBitCast(
-        resultValue.getAddress(), IGM.getStoragePointerType(paramTy));
+    Address eltPtr = IGF.Builder.CreateElementBitCast(
+        resultValue.getAddress(), IGM.getStorageType(paramTy));
 
     cast<LoadableTypeInfo>(paramInfo).loadAsTake(IGF, eltPtr, arguments);
     break;
@@ -509,7 +509,7 @@ void DistributedAccessor::decodeArgument(unsigned argumentIdx,
 void DistributedAccessor::lookupWitnessTables(
     llvm::Value *value, ArrayRef<ProtocolDecl *> protocols,
     Explosion &witnessTables) {
-  auto conformsToProtocol = IGM.getConformsToProtocolFn();
+  auto conformsToProtocol = IGM.getConformsToProtocolFunctionPointer();
 
   for (auto *protocol : protocols) {
     auto *protocolDescriptor = IGM.getAddrOfProtocolDescriptor(protocol);
@@ -728,7 +728,7 @@ void DistributedAccessor::emit() {
     // indirect result (e.g. large struct) it result buffer would be passed
     // as an argument.
     {
-      Address resultAddr(typedResultBuffer,
+      Address resultAddr(typedResultBuffer, directResultTI.getStorageType(),
                          directResultTI.getBestKnownAlignment());
       emission->emitToMemory(resultAddr, cast<LoadableTypeInfo>(directResultTI),
                              /*isOutlined=*/false);
@@ -807,7 +807,9 @@ ArgumentDecoderInfo DistributedAccessor::findArgumentDecoder(
 
     Explosion instance;
 
-    classTI.loadAsTake(IGF, {typedDecoderPtr, classTI.getBestKnownAlignment()},
+    classTI.loadAsTake(IGF,
+                       {typedDecoderPtr, classTI.getStorageType(),
+                        classTI.getBestKnownAlignment()},
                        instance);
 
     decoder = instance.claimNext();

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -1710,6 +1710,8 @@ namespace {
 
       IRGenFunction IGF(IGM, func);
       Explosion src = IGF.collectParameters();
+      if (IGM.DebugInfo)
+        IGM.DebugInfo->emitArtificialFunction(IGF, IGF.CurFn);
 
       EnumPayload payload;
       llvm::Value *extraTag;
@@ -1747,6 +1749,8 @@ namespace {
 
       IRGenFunction IGF(IGM, func);
       Explosion src = IGF.collectParameters();
+      if (IGM.DebugInfo)
+        IGM.DebugInfo->emitArtificialFunction(IGF, IGF.CurFn);
 
       EnumPayload payload;
       llvm::Value *extraTag;
@@ -3532,7 +3536,8 @@ namespace {
 
       IRGenFunction IGF(IGM, func);
       Explosion src = IGF.collectParameters();
-
+      if (IGM.DebugInfo)
+        IGM.DebugInfo->emitArtificialFunction(IGF, IGF.CurFn);
       auto parts = destructureAndTagLoadableEnumFromOutlined(IGF, src);
 
       forNontrivialPayloads(IGF, parts.tag, [&](unsigned tagIndex,
@@ -3561,6 +3566,8 @@ namespace {
       auto func = createOutlineLLVMFunction(IGM, name, PayloadTypesAndTagType);
 
       IRGenFunction IGF(IGM, func);
+      if (IGM.DebugInfo)
+        IGM.DebugInfo->emitArtificialFunction(IGF, IGF.CurFn);
       Explosion src = IGF.collectParameters();
       auto parts = destructureAndTagLoadableEnumFromOutlined(IGF, src);
 

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -707,55 +707,52 @@ namespace {
     StringRef getStructNameSuffix() const { return "." #name "ref"; } \
     REF_STORAGE_HELPER(Name, FixedTypeInfo) \
   };
-#define ALWAYS_LOADABLE_CHECKED_REF_STORAGE(Name, ...) \
-  class Loadable##Name##ClassExistentialTypeInfo final \
-    : public ScalarExistentialTypeInfoBase< \
-                                     Loadable##Name##ClassExistentialTypeInfo, \
-                                     LoadableTypeInfo> { \
-    ReferenceCounting Refcounting; \
-    llvm::Type *ValueType; \
-    bool IsOptional; \
-  public: \
-    Loadable##Name##ClassExistentialTypeInfo( \
-        ArrayRef<const ProtocolDecl *> storedProtocols, \
-        llvm::Type *valueTy, llvm::Type *ty, \
-        const SpareBitVector &spareBits, \
-        Size size, Alignment align, \
-        ReferenceCounting refcounting, \
-        bool isOptional) \
-      : ScalarExistentialTypeInfoBase(storedProtocols, ty, size, \
-                                      spareBits, align, IsNotPOD, IsFixedSize), \
-        Refcounting(refcounting), ValueType(valueTy), IsOptional(isOptional) { \
-      assert(refcounting == ReferenceCounting::Native || \
-             refcounting == ReferenceCounting::Unknown); \
-    } \
-    TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM, \
-                                          SILType T) const override { \
-      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T); \
-    } \
-    llvm::Type *getValueType() const { \
-      return ValueType; \
-    } \
-    Address projectValue(IRGenFunction &IGF, Address addr) const { \
-      Address valueAddr = ScalarExistentialTypeInfoBase::projectValue(IGF, addr); \
-      return IGF.Builder.CreateBitCast(valueAddr, ValueType->getPointerTo()); \
-    } \
-    void emitValueRetain(IRGenFunction &IGF, llvm::Value *value, \
-                         Atomicity atomicity) const { \
-      IGF.emit##Name##Retain(value, Refcounting, atomicity); \
-    } \
-    void emitValueRelease(IRGenFunction &IGF, llvm::Value *value, \
-                          Atomicity atomicity) const { \
-      IGF.emit##Name##Release(value, Refcounting, atomicity); \
-    } \
-    void emitValueFixLifetime(IRGenFunction &IGF, llvm::Value *value) const { \
-      IGF.emitFixLifetime(value); \
-    } \
-    const LoadableTypeInfo & \
-    getValueTypeInfoForExtraInhabitants(IRGenModule &IGM) const { \
-      llvm_unreachable("should have overridden all actual uses of this"); \
-    } \
-    REF_STORAGE_HELPER(Name, LoadableTypeInfo) \
+#define ALWAYS_LOADABLE_CHECKED_REF_STORAGE(Name, ...)                         \
+  class Loadable##Name##ClassExistentialTypeInfo final                         \
+      : public ScalarExistentialTypeInfoBase<                                  \
+            Loadable##Name##ClassExistentialTypeInfo, LoadableTypeInfo> {      \
+    ReferenceCounting Refcounting;                                             \
+    llvm::Type *ValueType;                                                     \
+    bool IsOptional;                                                           \
+                                                                               \
+  public:                                                                      \
+    Loadable##Name##ClassExistentialTypeInfo(                                  \
+        ArrayRef<const ProtocolDecl *> storedProtocols, llvm::Type *valueTy,   \
+        llvm::Type *ty, const SpareBitVector &spareBits, Size size,            \
+        Alignment align, ReferenceCounting refcounting, bool isOptional)       \
+        : ScalarExistentialTypeInfoBase(storedProtocols, ty, size, spareBits,  \
+                                        align, IsNotPOD, IsFixedSize),         \
+          Refcounting(refcounting), ValueType(valueTy),                        \
+          IsOptional(isOptional) {                                             \
+      assert(refcounting == ReferenceCounting::Native ||                       \
+             refcounting == ReferenceCounting::Unknown);                       \
+    }                                                                          \
+    TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,                    \
+                                          SILType T) const override {          \
+      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);             \
+    }                                                                          \
+    llvm::Type *getValueType() const { return ValueType; }                     \
+    Address projectValue(IRGenFunction &IGF, Address addr) const {             \
+      Address valueAddr =                                                      \
+          ScalarExistentialTypeInfoBase::projectValue(IGF, addr);              \
+      return IGF.Builder.CreateElementBitCast(valueAddr, ValueType);           \
+    }                                                                          \
+    void emitValueRetain(IRGenFunction &IGF, llvm::Value *value,               \
+                         Atomicity atomicity) const {                          \
+      IGF.emit##Name##Retain(value, Refcounting, atomicity);                   \
+    }                                                                          \
+    void emitValueRelease(IRGenFunction &IGF, llvm::Value *value,              \
+                          Atomicity atomicity) const {                         \
+      IGF.emit##Name##Release(value, Refcounting, atomicity);                  \
+    }                                                                          \
+    void emitValueFixLifetime(IRGenFunction &IGF, llvm::Value *value) const {  \
+      IGF.emitFixLifetime(value);                                              \
+    }                                                                          \
+    const LoadableTypeInfo &                                                   \
+    getValueTypeInfoForExtraInhabitants(IRGenModule &IGM) const {              \
+      llvm_unreachable("should have overridden all actual uses of this");      \
+    }                                                                          \
+    REF_STORAGE_HELPER(Name, LoadableTypeInfo)                                 \
   };
 #define SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, name, ...) \
   NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, name, "...") \
@@ -799,14 +796,13 @@ namespace {
 #undef REF_STORAGE_HELPER
 } // end anonymous namespace
 
-
-static llvm::Constant *getAssignBoxedOpaqueExistentialBufferFunction(
+static llvm::Function *getAssignBoxedOpaqueExistentialBufferFunction(
     IRGenModule &IGM, OpaqueExistentialLayout existLayout);
 
-static llvm::Constant *getDestroyBoxedOpaqueExistentialBufferFunction(
+static llvm::Function *getDestroyBoxedOpaqueExistentialBufferFunction(
     IRGenModule &IGM, OpaqueExistentialLayout existLayout);
 
-static llvm::Constant *
+static llvm::Function *
 getProjectBoxedOpaqueExistentialFunction(IRGenFunction &IGF,
                                          OpenedExistentialAccess accessKind,
                                          OpaqueExistentialLayout existLayout);
@@ -864,8 +860,8 @@ public:
     auto *type = IGF.IGM.getExistentialPtrTy(getLayout().getNumTables());
     auto *destAddr = IGF.Builder.CreateBitCast(dest.getAddress(), type);
     auto *srcAddr = IGF.Builder.CreateBitCast(src.getAddress(), type);
-    auto call =
-        IGF.Builder.CreateCall(fn, {destAddr, srcAddr});
+    auto call = IGF.Builder.CreateCallWithoutDbgLoc(fn->getFunctionType(), fn,
+                                                    {destAddr, srcAddr});
     call->setCallingConv(IGF.IGM.DefaultCC);
     call->setDoesNotThrow();
     return;
@@ -928,7 +924,8 @@ public:
     auto *addr = IGF.Builder.CreateBitCast(
         buffer.getAddress(),
         IGF.IGM.getExistentialPtrTy(getLayout().getNumTables()));
-    auto call = IGF.Builder.CreateCall(fn, {addr});
+    auto call =
+        IGF.Builder.CreateCallWithoutDbgLoc(fn->getFunctionType(), fn, {addr});
     call->setCallingConv(IGF.IGM.DefaultCC);
     call->setDoesNotThrow();
     return;
@@ -1170,66 +1167,46 @@ public:
                                            atomicity); \
     (void)e.claim(getNumStoredProtocols()); \
   }
-#define NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, name, ...) \
-  NEVER_LOADABLE_CHECKED_REF_STORAGE_HELPER(Name, name) \
-  const TypeInfo * \
-  create##Name##StorageType(TypeConverter &TC, \
-                            bool isOptional) const override { \
-    auto spareBits = BitPatternBuilder(TC.IGM.Triple.isLittleEndian()); \
-    auto ref = TC.IGM.getReferenceStorageSpareBits( \
-                                                   ReferenceOwnership::Name, \
-                                                   Refcounting); \
-    spareBits.append(ref); \
-    for (unsigned i = 0, e = getNumStoredProtocols(); i != e; ++i) { \
-      spareBits.append(TC.IGM.getWitnessTablePtrSpareBits()); \
-    } \
-    auto storageTy = buildReferenceStorageType(TC.IGM, \
-                              TC.IGM.Name##ReferencePtrTy->getPointerElementType()); \
-    return AddressOnly##Name##ClassExistentialTypeInfo::create( \
-                                                 getStoredProtocols(), \
-                                                 storageTy, \
-                                                 spareBits.build(), \
-                                                 getFixedSize(), \
-                                                 getFixedAlignment(), \
-                                                 Refcounting, \
-                                                 isOptional); \
+#define NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, name, ...)                    \
+  NEVER_LOADABLE_CHECKED_REF_STORAGE_HELPER(Name, name)                        \
+  const TypeInfo *create##Name##StorageType(TypeConverter &TC,                 \
+                                            bool isOptional) const override {  \
+    auto spareBits = BitPatternBuilder(TC.IGM.Triple.isLittleEndian());        \
+    auto ref = TC.IGM.getReferenceStorageSpareBits(ReferenceOwnership::Name,   \
+                                                   Refcounting);               \
+    spareBits.append(ref);                                                     \
+    for (unsigned i = 0, e = getNumStoredProtocols(); i != e; ++i) {           \
+      spareBits.append(TC.IGM.getWitnessTablePtrSpareBits());                  \
+    }                                                                          \
+    auto storageTy =                                                           \
+        buildReferenceStorageType(TC.IGM, TC.IGM.Name##ReferenceStructTy);     \
+    return AddressOnly##Name##ClassExistentialTypeInfo::create(                \
+        getStoredProtocols(), storageTy, spareBits.build(), getFixedSize(),    \
+        getFixedAlignment(), Refcounting, isOptional);                         \
   }
-#define SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, name, ...) \
-  NEVER_LOADABLE_CHECKED_REF_STORAGE_HELPER(Name, name) \
-  ALWAYS_LOADABLE_CHECKED_REF_STORAGE_HELPER(Name, name) \
-  const TypeInfo * \
-  create##Name##StorageType(TypeConverter &TC, \
-                            bool isOptional) const override { \
-    auto ref = TC.IGM.getReferenceStorageSpareBits( \
-                                                   ReferenceOwnership::Name, \
-                                                   Refcounting); \
-    auto spareBits = BitPatternBuilder(TC.IGM.Triple.isLittleEndian()); \
-    spareBits.append(ref); \
-    for (unsigned i = 0, e = getNumStoredProtocols(); i != e; ++i) { \
-      spareBits.append(TC.IGM.getWitnessTablePtrSpareBits()); \
-    } \
-    auto storageTy = buildReferenceStorageType(TC.IGM, \
-                              TC.IGM.Name##ReferencePtrTy->getPointerElementType()); \
-    if (TC.IGM.isLoadableReferenceAddressOnly(Refcounting)) { \
-      return AddressOnly##Name##ClassExistentialTypeInfo::create( \
-                                                   getStoredProtocols(), \
-                                                   storageTy, \
-                                                   spareBits.build(), \
-                                                   getFixedSize(), \
-                                                   getFixedAlignment(), \
-                                                   Refcounting, \
-                                                   isOptional); \
-    } else { \
-      return Loadable##Name##ClassExistentialTypeInfo::create( \
-                                                   getStoredProtocols(), \
-                                                   getValueType(), \
-                                                   storageTy, \
-                                                   spareBits.build(), \
-                                                   getFixedSize(), \
-                                                   getFixedAlignment(), \
-                                                   Refcounting, \
-                                                   isOptional); \
-    } \
+#define SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, name, ...)                \
+  NEVER_LOADABLE_CHECKED_REF_STORAGE_HELPER(Name, name)                        \
+  ALWAYS_LOADABLE_CHECKED_REF_STORAGE_HELPER(Name, name)                       \
+  const TypeInfo *create##Name##StorageType(TypeConverter &TC,                 \
+                                            bool isOptional) const override {  \
+    auto ref = TC.IGM.getReferenceStorageSpareBits(ReferenceOwnership::Name,   \
+                                                   Refcounting);               \
+    auto spareBits = BitPatternBuilder(TC.IGM.Triple.isLittleEndian());        \
+    spareBits.append(ref);                                                     \
+    for (unsigned i = 0, e = getNumStoredProtocols(); i != e; ++i) {           \
+      spareBits.append(TC.IGM.getWitnessTablePtrSpareBits());                  \
+    }                                                                          \
+    auto storageTy =                                                           \
+        buildReferenceStorageType(TC.IGM, TC.IGM.Name##ReferenceStructTy);     \
+    if (TC.IGM.isLoadableReferenceAddressOnly(Refcounting)) {                  \
+      return AddressOnly##Name##ClassExistentialTypeInfo::create(              \
+          getStoredProtocols(), storageTy, spareBits.build(), getFixedSize(),  \
+          getFixedAlignment(), Refcounting, isOptional);                       \
+    } else {                                                                   \
+      return Loadable##Name##ClassExistentialTypeInfo::create(                 \
+          getStoredProtocols(), getValueType(), storageTy, spareBits.build(),  \
+          getFixedSize(), getFixedAlignment(), Refcounting, isOptional);       \
+    }                                                                          \
   }
 #define ALWAYS_LOADABLE_CHECKED_REF_STORAGE(Name, name, ...) \
   ALWAYS_LOADABLE_CHECKED_REF_STORAGE_HELPER(Name, name) \
@@ -1426,6 +1403,10 @@ llvm::Type *TypeConverter::getExistentialType(unsigned numWitnessTables) {
 
 llvm::PointerType *IRGenModule::getExistentialPtrTy(unsigned numTables) {
   return Types.getExistentialType(numTables)->getPointerTo();
+}
+
+llvm::Type *IRGenModule::getExistentialType(unsigned numTables) {
+  return Types.getExistentialType(numTables);
 }
 
 static const TypeInfo *createExistentialTypeInfo(IRGenModule &IGM, CanType T) {
@@ -1662,10 +1643,9 @@ ContainedAddress irgen::emitBoxedExistentialProjection(IRGenFunction &IGF,
   Address out = IGF.createAlloca(IGF.IGM.OpenedErrorTripleTy,
                                  IGF.IGM.getPointerAlignment(),
                                  "project_error_out");
-  
-  IGF.Builder.CreateCall(IGF.IGM.getGetErrorValueFn(), {box,
-                         scratch.getAddress(),
-                         out.getAddress()});
+
+  IGF.Builder.CreateCall(IGF.IGM.getGetErrorValueFunctionPointer(),
+                         {box, scratch.getAddress(), out.getAddress()});
   // Load the 'out' values.
   auto &projectedTI = IGF.getTypeInfoForLowered(projectedType);
   auto projectedPtrAddr = IGF.Builder.CreateStructGEP(out, 0, Size(0));
@@ -1721,11 +1701,12 @@ OwnedAddress irgen::emitBoxedExistentialContainerAllocation(IRGenFunction &IGF,
   // Call the runtime to allocate the box.
   // TODO: When there's a store or copy_addr immediately into the box, peephole
   // it into the initializer parameter to allocError.
-  auto result = IGF.Builder.CreateCall(IGF.IGM.getAllocErrorFn(),
-                         {srcMetadata, witness,
-                           llvm::ConstantPointerNull::get(IGF.IGM.OpaquePtrTy),
-                           llvm::ConstantInt::get(IGF.IGM.Int1Ty, 0)});
-  
+  auto result = IGF.Builder.CreateCall(
+      IGF.IGM.getAllocErrorFunctionPointer(),
+      {srcMetadata, witness,
+       llvm::ConstantPointerNull::get(IGF.IGM.OpaquePtrTy),
+       llvm::ConstantInt::get(IGF.IGM.Int1Ty, 0)});
+
   // Extract the box and value address from the result.
   auto box = IGF.Builder.CreateExtractValue(result, 0);
   auto addr = IGF.Builder.CreateExtractValue(result, 1);
@@ -1751,8 +1732,9 @@ void irgen::emitBoxedExistentialContainerDeallocation(IRGenFunction &IGF,
 
   auto box = container.claimNext();
   auto srcMetadata = IGF.emitTypeMetadataRef(valueType);
-  
-  IGF.Builder.CreateCall(IGF.IGM.getDeallocErrorFn(), {box, srcMetadata});
+
+  IGF.Builder.CreateCall(IGF.IGM.getDeallocErrorFunctionPointer(),
+                         {box, srcMetadata});
 }
 
 /// Emit a class existential container from a class instance value
@@ -1887,16 +1869,15 @@ void irgen::emitMetatypeOfOpaqueExistential(IRGenFunction &IGF, Address buffer,
       IGF.IGM.getExistentialPtrTy(existLayout.getNumTables()));
   auto *projectFunc = getProjectBoxedOpaqueExistentialFunction(
       IGF, OpenedExistentialAccess::Immutable, existLayout);
-  auto *addrOfValue =
-      IGF.Builder.CreateCall(projectFunc, {addr, metadata});
+  auto *addrOfValue = IGF.Builder.CreateCallWithoutDbgLoc(
+      projectFunc->getFunctionType(), projectFunc, {addr, metadata});
   addrOfValue->setCallingConv(IGF.IGM.DefaultCC);
   addrOfValue->setDoesNotThrow();
   object = addrOfValue;
 
-  llvm::Value *dynamicType =
-    IGF.Builder.CreateCall(IGF.IGM.getGetDynamicTypeFn(),
-                           {object, metadata,
-                            llvm::ConstantInt::get(IGF.IGM.Int1Ty, 1)});
+  llvm::Value *dynamicType = IGF.Builder.CreateCall(
+      IGF.IGM.getGetDynamicTypeFunctionPointer(),
+      {object, metadata, llvm::ConstantInt::get(IGF.IGM.Int1Ty, 1)});
   out.add(dynamicType);
 
   // Get the witness tables.
@@ -1920,9 +1901,8 @@ void irgen::emitMetatypeOfBoxedExistential(IRGenFunction &IGF, Explosion &value,
                                      IGF.IGM.getPointerAlignment(),
                                      "project_error_out");
 
-  IGF.Builder.CreateCall(IGF.IGM.getGetErrorValueFn(), {box,
-                         scratchAddr.getAddress(),
-                         outAddr.getAddress()});
+  IGF.Builder.CreateCall(IGF.IGM.getGetErrorValueFunctionPointer(),
+                         {box, scratchAddr.getAddress(), outAddr.getAddress()});
 
   auto projectedPtrAddr = IGF.Builder.CreateStructGEP(outAddr, 0, Size(0));
   auto projectedPtr = IGF.Builder.CreateLoad(projectedPtrAddr);
@@ -1931,10 +1911,9 @@ void irgen::emitMetatypeOfBoxedExistential(IRGenFunction &IGF, Explosion &value,
                                                   IGF.IGM.getPointerSize());
   auto metadata = IGF.Builder.CreateLoad(metadataAddr);
 
-  auto dynamicType =
-    IGF.Builder.CreateCall(IGF.IGM.getGetDynamicTypeFn(),
-                           {projectedPtr, metadata,
-                            llvm::ConstantInt::get(IGF.IGM.Int1Ty, 1)});
+  auto dynamicType = IGF.Builder.CreateCall(
+      IGF.IGM.getGetDynamicTypeFunctionPointer(),
+      {projectedPtr, metadata, llvm::ConstantInt::get(IGF.IGM.Int1Ty, 1)});
 
   auto witnessAddr = IGF.Builder.CreateStructGEP(outAddr, 2,
                                                  2 * IGF.IGM.getPointerSize());
@@ -1984,7 +1963,7 @@ void irgen::emitMetatypeOfMetatype(IRGenFunction &IGF, Explosion &value,
   auto tablesAndValue = baseTI.getWitnessTablesAndValue(value);
 
   llvm::Value *dynamicType = IGF.Builder.CreateCall(
-                    IGF.IGM.getGetMetatypeMetadataFn(), tablesAndValue.second);
+      IGF.IGM.getGetMetatypeMetadataFunctionPointer(), tablesAndValue.second);
   out.add(dynamicType);
   out.add(tablesAndValue.first);
 }
@@ -2079,10 +2058,10 @@ irgen::emitExistentialMetatypeProjection(IRGenFunction &IGF,
 static Address castToOpaquePtr(IRGenFunction &IGF, Address addr) {
   return Address(
       IGF.Builder.CreateBitCast(addr.getAddress(), IGF.IGM.OpaquePtrTy),
-      addr.getAlignment());
+      IGF.IGM.OpaqueTy, addr.getAlignment());
 }
 
-static llvm::Constant *getAllocateBoxedOpaqueExistentialBufferFunction(
+static llvm::Function *getAllocateBoxedOpaqueExistentialBufferFunction(
     IRGenModule &IGM, OpaqueExistentialLayout existLayout) {
 
   llvm::Type *argTys[] = {IGM.getExistentialPtrTy(existLayout.getNumTables())};
@@ -2095,10 +2074,13 @@ static llvm::Constant *getAllocateBoxedOpaqueExistentialBufferFunction(
       << "__swift_allocate_boxed_opaque_existential_"
       << existLayout.getNumTables();
 
-  return IGM.getOrCreateHelperFunction(
-      fnName, IGM.OpaquePtrTy, argTys, [&](IRGenFunction &IGF) {
+  return cast<llvm::Function>(IGM.getOrCreateHelperFunction(
+      fnName, IGM.OpaquePtrTy, argTys,
+      [&](IRGenFunction &IGF) {
         auto it = IGF.CurFn->arg_begin();
-        Address existentialContainer(&*(it++), existLayout.getAlignment(IGM));
+        Address existentialContainer(
+            &*(it++), IGF.IGM.getExistentialType(existLayout.getNumTables()),
+            existLayout.getAlignment(IGM));
 
         // Dynamically check whether this type is inline or needs an allocation.
         auto *metadata = existLayout.loadMetadataRef(IGF, existentialContainer);
@@ -2128,11 +2110,12 @@ static llvm::Constant *getAllocateBoxedOpaqueExistentialBufferFunction(
               box,
               Address(IGF.Builder.CreateBitCast(existentialBuffer.getAddress(),
                                                 box->getType()->getPointerTo()),
+                      IGF.IGM.RefCountedPtrTy,
                       existLayout.getAlignment(IGF.IGM)));
           IGF.Builder.CreateRet(addressInBox);
         }
-
-      }, true /*noinline*/);
+      },
+      true /*noinline*/));
 }
 
 Address irgen::emitAllocateBoxedOpaqueExistentialBuffer(
@@ -2170,15 +2153,15 @@ Address irgen::emitAllocateBoxedOpaqueExistentialBuffer(
   auto *existentialAddr = IGF.Builder.CreateBitCast(
       existentialContainer.getAddress(),
       IGF.IGM.getExistentialPtrTy(existLayout.getNumTables()));
-  auto *call =
-      IGF.Builder.CreateCall(allocateFun, {existentialAddr});
+  auto *call = IGF.Builder.CreateCallWithoutDbgLoc(
+      allocateFun->getFunctionType(), allocateFun, {existentialAddr});
   call->setCallingConv(IGF.IGM.DefaultCC);
   call->setDoesNotThrow();
   auto addressOfValue = IGF.Builder.CreateBitCast(call, valuePointerType);
   return valueTI.getAddressForPointer(addressOfValue);
 }
 
-static llvm::Constant *getDeallocateBoxedOpaqueExistentialBufferFunction(
+static llvm::Function *getDeallocateBoxedOpaqueExistentialBufferFunction(
     IRGenModule &IGM, OpaqueExistentialLayout existLayout) {
 
   llvm::Type *argTys[] = {IGM.getExistentialPtrTy(existLayout.getNumTables())};
@@ -2191,11 +2174,14 @@ static llvm::Constant *getDeallocateBoxedOpaqueExistentialBufferFunction(
       << "__swift_deallocate_boxed_opaque_existential_"
       << existLayout.getNumTables();
 
-  return IGM.getOrCreateHelperFunction(
-      fnName, IGM.VoidTy, argTys, [&](IRGenFunction &IGF) {
+  return cast<llvm::Function>(IGM.getOrCreateHelperFunction(
+      fnName, IGM.VoidTy, argTys,
+      [&](IRGenFunction &IGF) {
         auto &Builder = IGF.Builder;
         auto it = IGF.CurFn->arg_begin();
-        Address existentialContainer(&*(it++), existLayout.getAlignment(IGM));
+        Address existentialContainer(
+            &*(it++), IGM.getExistentialType(existLayout.getNumTables()),
+            existLayout.getAlignment(IGM));
 
         // Dynamically check whether this type is inline or needs a
         // deallocation.
@@ -2222,8 +2208,9 @@ static llvm::Constant *getDeallocateBoxedOpaqueExistentialBufferFunction(
             Builder.CreateBitCast(existentialBuffer.getAddress(),
                                   IGM.RefCountedPtrTy->getPointerTo());
         // Load the reference.
-        auto *boxReference = Builder.CreateLoad(
-            boxReferenceAddr, existentialBuffer.getAlignment());
+        auto *boxReference =
+            Builder.CreateLoad(Address(boxReferenceAddr, IGM.RefCountedPtrTy,
+                                       existentialBuffer.getAlignment()));
 
         // Size and alignment requirements of the boxed value.
         auto *size = emitLoadOfSize(IGF, metadata);
@@ -2246,7 +2233,8 @@ static llvm::Constant *getDeallocateBoxedOpaqueExistentialBufferFunction(
             alignmentMask);
         // We are done. Return.
         Builder.CreateRetVoid();
-      }, true /*noinline*/);
+      },
+      true /*noinline*/));
 }
 
 void irgen::emitDeallocateBoxedOpaqueExistentialBuffer(
@@ -2262,13 +2250,14 @@ void irgen::emitDeallocateBoxedOpaqueExistentialBuffer(
   auto *bufferAddr = IGF.Builder.CreateBitCast(
       existentialContainer.getAddress(),
       IGF.IGM.getExistentialPtrTy(existLayout.getNumTables()));
-  auto *call = IGF.Builder.CreateCall(deallocateFun, {bufferAddr});
+  auto *call = IGF.Builder.CreateCallWithoutDbgLoc(
+      deallocateFun->getFunctionType(), deallocateFun, {bufferAddr});
   call->setCallingConv(IGF.IGM.DefaultCC);
   call->setDoesNotThrow();
   return;
 }
 
-static llvm::Constant *
+static llvm::Function *
 getProjectBoxedOpaqueExistentialFunction(IRGenFunction &IGF,
                                          OpenedExistentialAccess accessKind,
                                          OpaqueExistentialLayout existLayout) {
@@ -2287,12 +2276,15 @@ getProjectBoxedOpaqueExistentialFunction(IRGenFunction &IGF,
               : "__swift_mutable_project_boxed_opaque_existential_")
       << existLayout.getNumTables();
 
-  return IGM.getOrCreateHelperFunction(
-      fnName, IGM.OpaquePtrTy, argTys, [&](IRGenFunction &IGF) {
+  return cast<llvm::Function>(IGM.getOrCreateHelperFunction(
+      fnName, IGM.OpaquePtrTy, argTys,
+      [&](IRGenFunction &IGF) {
         auto &Builder = IGF.Builder;
         auto &IGM = IGF.IGM;
         auto it = IGF.CurFn->arg_begin();
-        Address existentialBuffer(&*(it++), existLayout.getAlignment(IGM));
+        Address existentialBuffer(
+            &*(it++), IGM.getExistentialType(existLayout.getNumTables()),
+            existLayout.getAlignment(IGM));
         auto *metadata = &*(it++);
 
         // Dynamically check whether this type is inline or needs a
@@ -2318,8 +2310,9 @@ getProjectBoxedOpaqueExistentialFunction(IRGenFunction &IGF,
               Builder.CreateBitCast(existentialBuffer.getAddress(),
                                     IGM.RefCountedPtrTy->getPointerTo());
           // Load the reference.
-          auto *boxReference = Builder.CreateLoad(
-              boxReferenceAddr, existentialBuffer.getAlignment());
+          auto *boxReference =
+              Builder.CreateLoad(Address(boxReferenceAddr, IGM.RefCountedPtrTy,
+                                         existentialBuffer.getAlignment()));
 
           // Size and alignment requirements of the boxed value.
           auto *alignmentMask = emitAlignMaskFromFlags(IGF, flags);
@@ -2347,7 +2340,8 @@ getProjectBoxedOpaqueExistentialFunction(IRGenFunction &IGF,
             metadata, alignmentMask, box, objectAddr);
 
         IGF.Builder.CreateRet(objectAddr);
-      }, true /*noinline*/);
+      },
+      true /*noinline*/));
 }
 
 Address irgen::emitOpaqueBoxedExistentialProjection(
@@ -2404,12 +2398,12 @@ Address irgen::emitOpaqueBoxedExistentialProjection(
   auto *bufferAddr = IGF.Builder.CreateBitCast(
       base.getAddress(),
       IGF.IGM.getExistentialPtrTy(layout.getNumTables()));
-  auto *addrOfValue =
-      IGF.Builder.CreateCall(projectFunc, {bufferAddr, metadata});
+  auto *addrOfValue = IGF.Builder.CreateCallWithoutDbgLoc(
+      projectFunc->getFunctionType(), projectFunc, {bufferAddr, metadata});
   addrOfValue->setCallingConv(IGF.IGM.DefaultCC);
   addrOfValue->setDoesNotThrow();
 
-  return Address(addrOfValue, Alignment(1));
+  return Address(addrOfValue, IGF.IGM.OpaqueTy, Alignment(1));
 }
 
 static void initBufferWithCopyOfReference(IRGenFunction &IGF,
@@ -2423,15 +2417,15 @@ static void initBufferWithCopyOfReference(IRGenFunction &IGF,
       destBuffer.getAddress(), IGM.RefCountedPtrTy->getPointerTo());
   auto *srcReferenceAddr = Builder.CreateBitCast(
       srcBuffer.getAddress(), IGM.RefCountedPtrTy->getPointerTo());
-  auto *srcReference =
-      Builder.CreateLoad(srcReferenceAddr, srcBuffer.getAlignment());
+  auto *srcReference = Builder.CreateLoad(
+      Address(srcReferenceAddr, IGM.RefCountedPtrTy, srcBuffer.getAlignment()));
   IGF.emitNativeStrongRetain(srcReference, IGF.getDefaultAtomicity());
-  IGF.Builder.CreateStore(
-      srcReference,
-      Address(destReferenceAddr, existLayout.getAlignment(IGF.IGM)));
+  IGF.Builder.CreateStore(srcReference,
+                          Address(destReferenceAddr, IGM.RefCountedPtrTy,
+                                  existLayout.getAlignment(IGF.IGM)));
 }
 
-static llvm::Constant *getAssignBoxedOpaqueExistentialBufferFunction(
+static llvm::Function *getAssignBoxedOpaqueExistentialBufferFunction(
     IRGenModule &IGM, OpaqueExistentialLayout existLayout) {
 
   llvm::Type *argTys[] = {IGM.getExistentialPtrTy(existLayout.getNumTables()),
@@ -2445,11 +2439,13 @@ static llvm::Constant *getAssignBoxedOpaqueExistentialBufferFunction(
       << "__swift_assign_boxed_opaque_existential_"
       << existLayout.getNumTables();
 
-  return IGM.getOrCreateHelperFunction(
-      fnName, IGM.VoidTy, argTys, [&](IRGenFunction &IGF) {
+  return cast<llvm::Function>(IGM.getOrCreateHelperFunction(
+      fnName, IGM.VoidTy, argTys,
+      [&](IRGenFunction &IGF) {
         auto it = IGF.CurFn->arg_begin();
-        Address dest(&*(it++), getFixedBufferAlignment(IGM));
-        Address src(&*(it++), getFixedBufferAlignment(IGM));
+        auto boxTy = IGM.getExistentialType(existLayout.getNumTables());
+        Address dest(&*(it++), boxTy, getFixedBufferAlignment(IGM));
+        Address src(&*(it++), boxTy, getFixedBufferAlignment(IGM));
         auto &Builder = IGF.Builder;
 
         // If doing a self-assignment, we're done.
@@ -2507,16 +2503,18 @@ static llvm::Constant *getAssignBoxedOpaqueExistentialBufferFunction(
             auto *srcReferenceAddr = Builder.CreateBitCast(
                 srcBuffer.getAddress(), IGM.RefCountedPtrTy->getPointerTo());
             // Load the reference.
-            auto *destReference = Builder.CreateLoad(destReferenceAddr,
-                                                     destBuffer.getAlignment());
-            auto *srcReference =
-                Builder.CreateLoad(srcReferenceAddr, srcBuffer.getAlignment());
+            auto *destReference = Builder.CreateLoad(
+                Address(destReferenceAddr, IGM.RefCountedPtrTy,
+                        destBuffer.getAlignment()));
+            auto *srcReference = Builder.CreateLoad(
+                Address(srcReferenceAddr, IGM.RefCountedPtrTy,
+                        srcBuffer.getAlignment()));
             IGF.emitNativeStrongRetain(srcReference, IGF.getDefaultAtomicity());
             IGF.emitNativeStrongRelease(destReference,
                                         IGF.getDefaultAtomicity());
             IGF.Builder.CreateStore(
-                srcReference,
-                Address(destReferenceAddr, existLayout.getAlignment(IGF.IGM)));
+                srcReference, Address(destReferenceAddr, IGM.RefCountedPtrTy,
+                                      existLayout.getAlignment(IGF.IGM)));
             Builder.CreateBr(doneBB);
           }
         }
@@ -2605,8 +2603,9 @@ static llvm::Constant *getAssignBoxedOpaqueExistentialBufferFunction(
             // tmpRef = dest[0]
             auto *destReferenceAddr = Builder.CreateBitCast(
                 destBuffer.getAddress(), IGM.RefCountedPtrTy->getPointerTo());
-            auto *destReference =
-                Builder.CreateLoad(destReferenceAddr, srcBuffer.getAlignment());
+            auto *destReference = Builder.CreateLoad(
+                Address(destReferenceAddr, IGM.RefCountedPtrTy,
+                        srcBuffer.getAlignment()));
             auto *srcInlineBB = IGF.createBasicBlock("dest-outline-src-inline");
             auto *srcOutlineBB =
                 IGF.createBasicBlock("dest-outline-src-outline");
@@ -2647,10 +2646,11 @@ static llvm::Constant *getAssignBoxedOpaqueExistentialBufferFunction(
 
         Builder.emitBlock(doneBB);
         Builder.CreateRetVoid();
-      }, true /*noinline*/);
+      },
+      true /*noinline*/));
 }
 
-static llvm::Constant *getDestroyBoxedOpaqueExistentialBufferFunction(
+static llvm::Function *getDestroyBoxedOpaqueExistentialBufferFunction(
     IRGenModule &IGM, OpaqueExistentialLayout existLayout) {
 
   llvm::Type *argTys[] = {IGM.getExistentialPtrTy(existLayout.getNumTables())};
@@ -2660,11 +2660,14 @@ static llvm::Constant *getDestroyBoxedOpaqueExistentialBufferFunction(
       << "__swift_destroy_boxed_opaque_existential_"
       << existLayout.getNumTables();
 
-  return IGM.getOrCreateHelperFunction(
-      fnName, IGM.VoidTy, argTys, [&](IRGenFunction &IGF) {
+  return cast<llvm::Function>(IGM.getOrCreateHelperFunction(
+      fnName, IGM.VoidTy, argTys,
+      [&](IRGenFunction &IGF) {
         auto &Builder = IGF.Builder;
         auto it = IGF.CurFn->arg_begin();
-        Address existentialContainer(&*(it++), existLayout.getAlignment(IGM));
+        auto boxTy = IGM.getExistentialType(existLayout.getNumTables());
+        Address existentialContainer(&*(it++), boxTy,
+                                     existLayout.getAlignment(IGM));
         auto *metadata = existLayout.loadMetadataRef(IGF, existentialContainer);
         auto buffer =
             existLayout.projectExistentialBuffer(IGF, existentialContainer);
@@ -2681,8 +2684,9 @@ static llvm::Constant *getDestroyBoxedOpaqueExistentialBufferFunction(
           ConditionalDominanceScope domScope(IGF);
           auto *opaquePtrToBuffer =
               Builder.CreateBitCast(buffer.getAddress(), IGM.OpaquePtrTy);
-          emitDestroyCall(IGF, metadata,
-                          Address(opaquePtrToBuffer, buffer.getAlignment()));
+          emitDestroyCall(
+              IGF, metadata,
+              Address(opaquePtrToBuffer, IGM.OpaqueTy, buffer.getAlignment()));
           Builder.CreateRetVoid();
         }
 
@@ -2693,11 +2697,12 @@ static llvm::Constant *getDestroyBoxedOpaqueExistentialBufferFunction(
           // swift_release(buffer[0])
           auto *referenceAddr = Builder.CreateBitCast(
               buffer.getAddress(), IGM.RefCountedPtrTy->getPointerTo());
-          auto *reference =
-              Builder.CreateLoad(referenceAddr, buffer.getAlignment());
+          auto *reference = Builder.CreateLoad(Address(
+              referenceAddr, IGM.RefCountedPtrTy, buffer.getAlignment()));
           IGF.emitNativeStrongRelease(reference, IGF.getDefaultAtomicity());
 
           Builder.CreateRetVoid();
         }
-      }, true /*noinline*/);
+      },
+      true /*noinline*/));
 }

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -815,8 +815,8 @@ public:
           outConv.getSILResultType(IGM.getMaximalTypeExpansionContext()),
           "return.temp");
       resultValueAddr = stackAddr.getAddress();
-      auto resultAddr = subIGF.Builder.CreateBitCast(
-          resultValueAddr, IGM.getStoragePointerType(origConv.getSILResultType(
+      auto resultAddr = subIGF.Builder.CreateElementBitCast(
+          resultValueAddr, IGM.getStorageType(origConv.getSILResultType(
                                IGM.getMaximalTypeExpansionContext())));
       args.add(resultAddr.getAddress());
       useSRet = false;
@@ -1159,7 +1159,7 @@ public:
   llvm::CallInst *createCall(FunctionPointer &fnPtr) override {
     PointerAuthInfo newAuthInfo =
         fnPtr.getAuthInfo().getCorrespondingCodeAuthInfo();
-    auto newFnPtr = FunctionPointer(
+    auto newFnPtr = FunctionPointer::createSigned(
         FunctionPointer::Kind::Function, fnPtr.getPointer(subIGF), newAuthInfo,
         Signature::forAsyncAwait(subIGF.IGM, origType,
                                  FunctionPointerKind::defaultAsync()));
@@ -1658,7 +1658,7 @@ static llvm::Value *emitPartialApplicationForwarder(IRGenModule &IGM,
       if (staticFnPtr->getPointer(subIGF)->getType() != fnTy) {
         auto fnPtr = staticFnPtr->getPointer(subIGF);
         fnPtr = subIGF.Builder.CreateBitCast(fnPtr, fnTy);
-        return FunctionPointer(origType, fnPtr, origSig);
+        return FunctionPointer::createUnsigned(origType, fnPtr, origSig);
       }
       return *staticFnPtr;
     }
@@ -1680,10 +1680,10 @@ static llvm::Value *emitPartialApplicationForwarder(IRGenModule &IGM,
     // It comes out of the context as an i8*. Cast to the function type.
     fnPtr = subIGF.Builder.CreateBitCast(fnPtr, fnTy);
 
-    return FunctionPointer(origType->isAsync()
-                               ? FunctionPointer::Kind::AsyncFunctionPointer
-                               : FunctionPointer::Kind::Function,
-                           fnPtr, authInfo, origSig);
+    return FunctionPointer::createSigned(
+        origType->isAsync() ? FunctionPointer::Kind::AsyncFunctionPointer
+                            : FunctionPointer::Kind::Function,
+        fnPtr, authInfo, origSig);
   }();
 
   if (origType->isAsync())
@@ -1783,7 +1783,8 @@ Optional<StackAddress> irgen::emitFunctionPartialApplication(
   enum HasSingleSwiftRefcountedContext { Maybe, Yes, No, Thunkable }
     hasSingleSwiftRefcountedContext = Maybe;
   Optional<ParameterConvention> singleRefcountedConvention;
-  
+  Optional<llvm::Type *> singleRefCountedType;
+
   SmallVector<const TypeInfo *, 4> argTypeInfos;
   SmallVector<SILType, 4> argValTypes;
   SmallVector<ParameterConvention, 4> argConventions;
@@ -1862,6 +1863,7 @@ Optional<StackAddress> irgen::emitFunctionPartialApplication(
     if (ti.isSingleSwiftRetainablePointer(ResilienceExpansion::Maximal)) {
       hasSingleSwiftRefcountedContext = Yes;
       singleRefcountedConvention = param.getConvention();
+      singleRefCountedType = ti.getStorageType();
     } else {
       hasSingleSwiftRefcountedContext = No;
     }
@@ -1920,6 +1922,7 @@ Optional<StackAddress> irgen::emitFunctionPartialApplication(
       assert(bindings.empty());
       hasSingleSwiftRefcountedContext = Yes;
       singleRefcountedConvention = origType->getCalleeConvention();
+      singleRefCountedType = IGF.IGM.getNativeObjectTypeInfo().getStorageType();
     }
   }
 
@@ -1983,7 +1986,8 @@ Optional<StackAddress> irgen::emitFunctionPartialApplication(
 
     llvm::Value *ctx = args.claimNext();
     if (isIndirectFormalParameter(*singleRefcountedConvention))
-      ctx = IGF.Builder.CreateLoad(ctx, IGF.IGM.getPointerAlignment());
+      ctx = IGF.Builder.CreateLoad(
+          Address(ctx, *singleRefCountedType, IGF.IGM.getPointerAlignment()));
 
     auto expectedClosureTy =
         outType->isNoEscape() ? IGF.IGM.OpaquePtrTy : IGF.IGM.RefCountedPtrTy;
@@ -2021,8 +2025,8 @@ Optional<StackAddress> irgen::emitFunctionPartialApplication(
     if (outType->isNoEscape()) {
       stackAddr = IGF.emitDynamicAlloca(
           IGF.IGM.Int8Ty, layout.isFixedLayout() ? layout.emitSize(IGF.IGM) : offsets.getSize() , Alignment(16));
-      stackAddr = stackAddr->withAddress(IGF.Builder.CreateBitCast(
-          stackAddr->getAddress(), IGF.IGM.OpaquePtrTy));
+      stackAddr = stackAddr->withAddress(IGF.Builder.CreateElementBitCast(
+          stackAddr->getAddress(), IGF.IGM.OpaqueTy));
       data = stackAddr->getAddress().getAddress();
     } else {
         auto descriptor = IGF.IGM.getAddrOfCaptureDescriptor(SILFn, origType,
@@ -2136,9 +2140,11 @@ static llvm::Function *emitBlockCopyHelper(IRGenModule &IGM,
   
   // Copy the captures from the source to the destination.
   Explosion params = IGF.collectParameters();
-  auto dest = Address(params.claimNext(), blockTL.getFixedAlignment());
-  auto src = Address(params.claimNext(), blockTL.getFixedAlignment());
-  
+  auto dest = Address(params.claimNext(), blockTL.getStorageType(),
+                      blockTL.getFixedAlignment());
+  auto src = Address(params.claimNext(), blockTL.getStorageType(),
+                     blockTL.getFixedAlignment());
+
   auto destCapture = blockTL.projectCapture(IGF, dest);
   auto srcCapture = blockTL.projectCapture(IGF, src);
   auto &captureTL = IGM.getTypeInfoForLowered(blockTy->getCaptureType());
@@ -2174,7 +2180,8 @@ static llvm::Function *emitBlockDisposeHelper(IRGenModule &IGM,
   
   // Destroy the captures.
   Explosion params = IGF.collectParameters();
-  auto storage = Address(params.claimNext(), blockTL.getFixedAlignment());
+  auto storage = Address(params.claimNext(), blockTL.getStorageType(),
+                         blockTL.getFixedAlignment());
   auto capture = blockTL.projectCapture(IGF, storage);
   auto &captureTL = IGM.getTypeInfoForLowered(blockTy->getCaptureType());
   captureTL.destroy(IGF, capture, blockTy->getCaptureAddressType(),
@@ -2291,7 +2298,7 @@ void irgen::emitBlockHeader(IRGenFunction &IGF,
 llvm::Value *
 IRGenFunction::emitAsyncResumeProjectContext(llvm::Value *calleeContext) {
   auto addr = Builder.CreateBitOrPointerCast(calleeContext, IGM.Int8PtrPtrTy);
-  Address callerContextAddr(addr, IGM.getPointerAlignment());
+  Address callerContextAddr(addr, IGM.Int8PtrTy, IGM.getPointerAlignment());
   llvm::Value *callerContext = Builder.CreateLoad(callerContextAddr);
   if (auto schema = IGM.getOptions().PointerAuth.AsyncContextParent) {
     auto authInfo =
@@ -2305,7 +2312,7 @@ IRGenFunction::emitAsyncResumeProjectContext(llvm::Value *calleeContext) {
     auto contextLocationInExtendedFrame =
         Address(Builder.CreateIntrinsicCall(
                     llvm::Intrinsic::swift_async_context_addr, {}),
-                IGM.getPointerAlignment());
+                IGM.Int8PtrTy, IGM.getPointerAlignment());
     // On arm64e we need to sign this pointer address discriminated
     // with 0xc31a and process dependent key.
     if (auto schema =
@@ -2389,8 +2396,8 @@ IRGenFunction::createAsyncDispatchFn(const FunctionPointer &fnPtr,
       ((bool)originalAuthInfo)
           ? PointerAuthInfo(fnPtr.getAuthInfo().getKey(), discriminatorArg)
           : originalAuthInfo;
-  auto callee = FunctionPointer(fnPtr.getKind(), fnPtrArg, newAuthInfo,
-                                fnPtr.getSignature());
+  auto callee = FunctionPointer::createSigned(
+      fnPtr.getKind(), fnPtrArg, newAuthInfo, fnPtr.getSignature());
   auto call = Builder.CreateCall(callee, callArgs);
   call->setTailCallKind(IGM.AsyncTailCallKind);
   Builder.CreateRetVoid();
@@ -2479,8 +2486,8 @@ llvm::Function *IRGenFunction::createAsyncSuspendFn() {
   }
 
   auto *suspendCall = Builder.CreateCall(
-      IGM.getTaskSwitchFuncFn(),
-      { context, resumeFunction, targetExecutorFirst, targetExecutorSecond });
+      IGM.getTaskSwitchFuncFunctionPointer(),
+      {context, resumeFunction, targetExecutorFirst, targetExecutorSecond});
   suspendCall->setDoesNotThrow();
   suspendCall->setCallingConv(IGM.SwiftAsyncCC);
   suspendCall->setTailCallKind(IGM.AsyncTailCallKind);

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -30,16 +30,17 @@
 #include "swift/AST/IRGenOptions.h"
 #include "swift/SIL/SILModule.h"
 
+#include "ClassTypeInfo.h"
 #include "ConstantBuilder.h"
 #include "Explosion.h"
 #include "GenClass.h"
 #include "GenPointerAuth.h"
 #include "GenProto.h"
 #include "GenType.h"
+#include "HeapTypeInfo.h"
 #include "IRGenDebugInfo.h"
 #include "IRGenFunction.h"
 #include "IRGenModule.h"
-#include "HeapTypeInfo.h"
 #include "IndirectTypeInfo.h"
 #include "MetadataRequest.h"
 
@@ -128,75 +129,71 @@ namespace {
           getFixedSize().getValueInBits()); \
     } \
   };
-#define ALWAYS_LOADABLE_CHECKED_REF_STORAGE_HELPER(Name, Nativeness) \
-  class Nativeness##Name##ReferenceTypeInfo \
-    : public SingleScalarTypeInfo<Nativeness##Name##ReferenceTypeInfo, \
-                                  LoadableTypeInfo> { \
-    llvm::PointerIntPair<llvm::Type*, 1, bool> ValueTypeAndIsOptional; \
-  public: \
-    Nativeness##Name##ReferenceTypeInfo(llvm::Type *valueType, \
-                                              llvm::Type *type, \
-                                              Size size, Alignment alignment, \
-                                              SpareBitVector &&spareBits, \
-                                              bool isOptional) \
-      : SingleScalarTypeInfo(type, size, std::move(spareBits), \
-                             alignment, IsNotPOD, IsFixedSize), \
-        ValueTypeAndIsOptional(valueType, isOptional) {} \
-    enum { IsScalarPOD = false }; \
+#define ALWAYS_LOADABLE_CHECKED_REF_STORAGE_HELPER(Name, Nativeness)           \
+  class Nativeness##Name##ReferenceTypeInfo                                    \
+      : public SingleScalarTypeInfo<Nativeness##Name##ReferenceTypeInfo,       \
+                                    LoadableTypeInfo> {                        \
+    llvm::PointerIntPair<llvm::Type *, 1, bool> ValueTypeAndIsOptional;        \
+                                                                               \
+  public:                                                                      \
+    Nativeness##Name##ReferenceTypeInfo(llvm::Type *valueType,                 \
+                                        llvm::Type *type, Size size,           \
+                                        Alignment alignment,                   \
+                                        SpareBitVector &&spareBits,            \
+                                        bool isOptional)                       \
+        : SingleScalarTypeInfo(type, size, std::move(spareBits), alignment,    \
+                               IsNotPOD, IsFixedSize),                         \
+          ValueTypeAndIsOptional(valueType, isOptional) {}                     \
+    enum { IsScalarPOD = false };                                              \
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,                    \
                                           SILType T) const override {          \
       return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);             \
-    } \
-    llvm::Type *getScalarType() const { \
-      return ValueTypeAndIsOptional.getPointer(); \
-    } \
-    Address projectScalar(IRGenFunction &IGF, Address addr) const { \
-      return IGF.Builder.CreateBitCast(addr, getScalarType()->getPointerTo()); \
-    } \
-    void emitScalarRetain(IRGenFunction &IGF, llvm::Value *value, \
-                          Atomicity atomicity) const { \
-      IGF.emit##Nativeness##Name##Retain(value, atomicity); \
-    } \
-    void emitScalarRelease(IRGenFunction &IGF, llvm::Value *value, \
-                           Atomicity atomicity) const { \
-      IGF.emit##Nativeness##Name##Release(value, atomicity); \
-    } \
+    }                                                                          \
+    llvm::Type *getScalarType() const {                                        \
+      return ValueTypeAndIsOptional.getPointer();                              \
+    }                                                                          \
+    Address projectScalar(IRGenFunction &IGF, Address addr) const {            \
+      return IGF.Builder.CreateElementBitCast(addr, getScalarType());          \
+    }                                                                          \
+    void emitScalarRetain(IRGenFunction &IGF, llvm::Value *value,              \
+                          Atomicity atomicity) const {                         \
+      IGF.emit##Nativeness##Name##Retain(value, atomicity);                    \
+    }                                                                          \
+    void emitScalarRelease(IRGenFunction &IGF, llvm::Value *value,             \
+                           Atomicity atomicity) const {                        \
+      IGF.emit##Nativeness##Name##Release(value, atomicity);                   \
+    }                                                                          \
     void emitScalarFixLifetime(IRGenFunction &IGF, llvm::Value *value) const { \
-      IGF.emitFixLifetime(value); \
-    } \
-    unsigned getFixedExtraInhabitantCount(IRGenModule &IGM) const override { \
-      auto count = IGM.getReferenceStorageExtraInhabitantCount( \
-                                               ReferenceOwnership::Name, \
-                                               ReferenceCounting::Nativeness); \
-      return count - ValueTypeAndIsOptional.getInt(); \
-    } \
-    APInt getFixedExtraInhabitantValue(IRGenModule &IGM, \
-                                       unsigned bits, \
-                                       unsigned index) const override { \
-      return IGM.getReferenceStorageExtraInhabitantValue(bits, \
-                                      index + ValueTypeAndIsOptional.getInt(), \
-                                      ReferenceOwnership::Name, \
-                                      ReferenceCounting::Nativeness); \
-    } \
-    llvm::Value *getExtraInhabitantIndex(IRGenFunction &IGF, Address src, \
-                                         SILType T, bool isOutlined) \
-    const override {     \
-      return IGF.getReferenceStorageExtraInhabitantIndex(src, \
-                                               ReferenceOwnership::Name, \
-                                               ReferenceCounting::Nativeness); \
-    } \
-    void storeExtraInhabitant(IRGenFunction &IGF, llvm::Value *index, \
-                              Address dest, SILType T, bool isOutlined) \
-    const override { \
-      return IGF.storeReferenceStorageExtraInhabitant(index, dest, \
-                                               ReferenceOwnership::Name, \
-                                               ReferenceCounting::Nativeness); \
-    } \
-    APInt getFixedExtraInhabitantMask(IRGenModule &IGM) const override { \
-      return IGM.getReferenceStorageExtraInhabitantMask( \
-                                               ReferenceOwnership::Name, \
-                                               ReferenceCounting::Nativeness); \
-    } \
+      IGF.emitFixLifetime(value);                                              \
+    }                                                                          \
+    unsigned getFixedExtraInhabitantCount(IRGenModule &IGM) const override {   \
+      auto count = IGM.getReferenceStorageExtraInhabitantCount(                \
+          ReferenceOwnership::Name, ReferenceCounting::Nativeness);            \
+      return count - ValueTypeAndIsOptional.getInt();                          \
+    }                                                                          \
+    APInt getFixedExtraInhabitantValue(IRGenModule &IGM, unsigned bits,        \
+                                       unsigned index) const override {        \
+      return IGM.getReferenceStorageExtraInhabitantValue(                      \
+          bits, index + ValueTypeAndIsOptional.getInt(),                       \
+          ReferenceOwnership::Name, ReferenceCounting::Nativeness);            \
+    }                                                                          \
+    llvm::Value *getExtraInhabitantIndex(IRGenFunction &IGF, Address src,      \
+                                         SILType T,                            \
+                                         bool isOutlined) const override {     \
+      return IGF.getReferenceStorageExtraInhabitantIndex(                      \
+          src, ReferenceOwnership::Name, ReferenceCounting::Nativeness);       \
+    }                                                                          \
+    void storeExtraInhabitant(IRGenFunction &IGF, llvm::Value *index,          \
+                              Address dest, SILType T,                         \
+                              bool isOutlined) const override {                \
+      return IGF.storeReferenceStorageExtraInhabitant(                         \
+          index, dest, ReferenceOwnership::Name,                               \
+          ReferenceCounting::Nativeness);                                      \
+    }                                                                          \
+    APInt getFixedExtraInhabitantMask(IRGenModule &IGM) const override {       \
+      return IGM.getReferenceStorageExtraInhabitantMask(                       \
+          ReferenceOwnership::Name, ReferenceCounting::Nativeness);            \
+    }                                                                          \
   };
 
   // The nativeness of a reference storage type is a policy decision.
@@ -370,7 +367,7 @@ void irgen::emitDeallocateHeapObject(IRGenFunction &IGF,
                                      llvm::Value *alignMask) {
   // FIXME: We should call a fast deallocator for heap objects with
   // known size.
-  IGF.Builder.CreateCall(IGF.IGM.getDeallocObjectFn(),
+  IGF.Builder.CreateCall(IGF.IGM.getDeallocObjectFunctionPointer(),
                          {object, size, alignMask});
 }
 
@@ -378,7 +375,7 @@ void emitDeallocateUninitializedHeapObject(IRGenFunction &IGF,
                                            llvm::Value *object,
                                            llvm::Value *size,
                                            llvm::Value *alignMask) {
-  IGF.Builder.CreateCall(IGF.IGM.getDeallocUninitializedObjectFn(),
+  IGF.Builder.CreateCall(IGF.IGM.getDeallocUninitializedObjectFunctionPointer(),
                          {object, size, alignMask});
 }
 
@@ -388,7 +385,7 @@ void irgen::emitDeallocateClassInstance(IRGenFunction &IGF,
                                         llvm::Value *alignMask) {
   // FIXME: We should call a fast deallocator for heap objects with
   // known size.
-  IGF.Builder.CreateCall(IGF.IGM.getDeallocClassInstanceFn(),
+  IGF.Builder.CreateCall(IGF.IGM.getDeallocClassInstanceFunctionPointer(),
                          {object, size, alignMask});
 }
 
@@ -399,8 +396,9 @@ void irgen::emitDeallocatePartialClassInstance(IRGenFunction &IGF,
                                                llvm::Value *alignMask) {
   // FIXME: We should call a fast deallocator for heap objects with
   // known size.
-  IGF.Builder.CreateCall(IGF.IGM.getDeallocPartialClassInstanceFn(),
-                         {object, metadata, size, alignMask});
+  IGF.Builder.CreateCall(
+      IGF.IGM.getDeallocPartialClassInstanceFunctionPointer(),
+      {object, metadata, size, alignMask});
 }
 
 /// Create the destructor function for a layout.
@@ -516,8 +514,8 @@ static llvm::Constant *buildPrivateMetadata(IRGenModule &IGM,
     llvm::ConstantInt::get(IGM.Int32Ty, 0),
     llvm::ConstantInt::get(IGM.Int32Ty, 2)
   };
-  return llvm::ConstantExpr::getInBoundsGetElementPtr(
-      var->getType()->getPointerElementType(), var, indices);
+  return llvm::ConstantExpr::getInBoundsGetElementPtr(var->getValueType(), var,
+                                                      indices);
 }
 
 llvm::Constant *
@@ -761,18 +759,16 @@ void IRGenFunction::storeReferenceStorageExtraInhabitant(llvm::Value *index,
     switch (style) {                                                           \
     case ReferenceCounting::Native:                                            \
       return new Native##Name##ReferenceTypeInfo(                              \
-          valueType, IGM.Name##ReferencePtrTy->getPointerElementType(),        \
-          IGM.getPointerSize(), IGM.getPointerAlignment(),                     \
-          std::move(spareBits), isOptional);                                   \
+          valueType, IGM.Name##ReferenceStructTy, IGM.getPointerSize(),        \
+          IGM.getPointerAlignment(), std::move(spareBits), isOptional);        \
     case ReferenceCounting::ObjC:                                              \
     case ReferenceCounting::None:                                              \
     case ReferenceCounting::Custom:                                            \
     case ReferenceCounting::Block:                                             \
     case ReferenceCounting::Unknown:                                           \
       return new Unknown##Name##ReferenceTypeInfo(                             \
-          valueType, IGM.Name##ReferencePtrTy->getPointerElementType(),        \
-          IGM.getPointerSize(), IGM.getPointerAlignment(),                     \
-          std::move(spareBits), isOptional);                                   \
+          valueType, IGM.Name##ReferenceStructTy, IGM.getPointerSize(),        \
+          IGM.getPointerAlignment(), std::move(spareBits), isOptional);        \
     case ReferenceCounting::Bridge:                                            \
     case ReferenceCounting::Error:                                             \
       llvm_unreachable("not supported!");                                      \
@@ -825,35 +821,28 @@ static bool doesNotRequireRefCounting(llvm::Value *value) {
   return isa<llvm::ConstantPointerNull>(value);
 }
 
-static llvm::FunctionType *getTypeOfFunction(llvm::Constant *fn) {
-  return cast<llvm::FunctionType>(fn->getType()->getPointerElementType());
-}
-
 /// Emit a unary call to perform a ref-counting operation.
 ///
 /// \param fn - expected signature 'void (T)' or 'T (T)'
 static void emitUnaryRefCountCall(IRGenFunction &IGF,
                                   llvm::Constant *fn,
                                   llvm::Value *value) {
-  auto cc = IGF.IGM.DefaultCC;
-  auto fun = dyn_cast<llvm::Function>(fn);
-  if (fun)
-    cc = fun->getCallingConv();
+  auto fun = cast<llvm::Function>(fn);
+  auto cc = fun->getCallingConv();
 
   // Instead of casting the input, we cast the function type.
   // This tends to produce less IR, but might be evil.
-  auto origFnType = getTypeOfFunction(fn);
-  if (value->getType() != origFnType->getParamType(0)) {
-    auto resultTy = origFnType->getReturnType() == IGF.IGM.VoidTy
+  auto fnType = cast<llvm::FunctionType>(fun->getValueType());
+  if (value->getType() != fnType->getParamType(0)) {
+    auto resultTy = fnType->getReturnType() == IGF.IGM.VoidTy
                         ? IGF.IGM.VoidTy
                         : value->getType();
-    llvm::FunctionType *fnType =
-      llvm::FunctionType::get(resultTy, value->getType(), false);
+    fnType = llvm::FunctionType::get(resultTy, value->getType(), false);
     fn = llvm::ConstantExpr::getBitCast(fn, fnType->getPointerTo());
   }
-  
+
   // Emit the call.
-  llvm::CallInst *call = IGF.Builder.CreateCall(fn, value);
+  llvm::CallInst *call = IGF.Builder.CreateCallWithoutDbgLoc(fnType, fn, value);
   if (fun && fun->hasParamAttribute(0, llvm::Attribute::Returned))
     call->addParamAttr(0, llvm::Attribute::Returned);
   call->setCallingConv(cc);
@@ -870,26 +859,23 @@ static void emitCopyLikeCall(IRGenFunction &IGF,
   assert(dest->getType() == src->getType() &&
          "type mismatch in binary refcounting operation");
 
-  auto cc = IGF.IGM.DefaultCC;
-  auto fun = dyn_cast<llvm::Function>(fn);
-  if (fun)
-    cc = fun->getCallingConv();
+  auto fun = cast<llvm::Function>(fn);
+  auto cc = fun->getCallingConv();
 
   // Instead of casting the inputs, we cast the function type.
   // This tends to produce less IR, but might be evil.
-  auto origFnType = getTypeOfFunction(fn);
-  if (dest->getType() != origFnType->getParamType(0)) {
+  auto fnType = cast<llvm::FunctionType>(fun->getValueType());
+  if (dest->getType() != fnType->getParamType(0)) {
     llvm::Type *paramTypes[] = { dest->getType(), dest->getType() };
-    auto resultTy = origFnType->getReturnType() == IGF.IGM.VoidTy
-                        ? IGF.IGM.VoidTy
-                        : dest->getType();
-    llvm::FunctionType *fnType =
-      llvm::FunctionType::get(resultTy, paramTypes, false);
+    auto resultTy = fnType->getReturnType() == IGF.IGM.VoidTy ? IGF.IGM.VoidTy
+                                                              : dest->getType();
+    fnType = llvm::FunctionType::get(resultTy, paramTypes, false);
     fn = llvm::ConstantExpr::getBitCast(fn, fnType->getPointerTo());
   }
-  
+
   // Emit the call.
-  llvm::CallInst *call = IGF.Builder.CreateCall(fn, {dest, src});
+  llvm::CallInst *call =
+      IGF.Builder.CreateCallWithoutDbgLoc(fnType, fn, {dest, src});
   if (fun && fun->hasParamAttribute(0, llvm::Attribute::Returned))
     call->addParamAttr(0, llvm::Attribute::Returned);
   call->setCallingConv(cc);
@@ -907,22 +893,20 @@ static llvm::Value *emitLoadWeakLikeCall(IRGenFunction &IGF,
           addr->getType() == IGF.IGM.UnownedReferencePtrTy) &&
          "address is not of a weak or unowned reference");
 
-  auto cc = IGF.IGM.DefaultCC;
-  if (auto fun = dyn_cast<llvm::Function>(fn))
-    cc = fun->getCallingConv();
-
+  auto fun = cast<llvm::Function>(fn);
+  auto cc = fun->getCallingConv();
 
   // Instead of casting the output, we cast the function type.
   // This tends to produce less IR, but might be evil.
-  if (resultType != getTypeOfFunction(fn)->getReturnType()) {
+  auto fnType = cast<llvm::FunctionType>(fun->getValueType());
+  if (resultType != fnType->getReturnType()) {
     llvm::Type *paramTypes[] = { addr->getType() };
-    llvm::FunctionType *fnType =
-      llvm::FunctionType::get(resultType, paramTypes, false);
+    fnType = llvm::FunctionType::get(resultType, paramTypes, false);
     fn = llvm::ConstantExpr::getBitCast(fn, fnType->getPointerTo());
   }
 
   // Emit the call.
-  llvm::CallInst *call = IGF.Builder.CreateCall(fn, addr);
+  llvm::CallInst *call = IGF.Builder.CreateCallWithoutDbgLoc(fnType, fn, addr);
   call->setCallingConv(cc);
   call->setDoesNotThrow();
 
@@ -940,26 +924,23 @@ static void emitStoreWeakLikeCall(IRGenFunction &IGF,
           addr->getType() == IGF.IGM.UnownedReferencePtrTy) &&
          "address is not of a weak or unowned reference");
 
-  auto cc = IGF.IGM.DefaultCC;
-  auto fun = dyn_cast<llvm::Function>(fn);
-  if (fun)
-    cc = fun->getCallingConv();
+  auto fun = cast<llvm::Function>(fn);
+  auto cc = fun->getCallingConv();
 
   // Instead of casting the inputs, we cast the function type.
   // This tends to produce less IR, but might be evil.
-  auto origFnType = getTypeOfFunction(fn);
-  if (value->getType() != origFnType->getParamType(1)) {
+  auto fnType = cast<llvm::FunctionType>(fun->getValueType());
+  if (value->getType() != fnType->getParamType(1)) {
     llvm::Type *paramTypes[] = { addr->getType(), value->getType() };
-    auto resultTy = origFnType->getReturnType() == IGF.IGM.VoidTy
-                        ? IGF.IGM.VoidTy
-                        : addr->getType();
-    llvm::FunctionType *fnType =
-      llvm::FunctionType::get(resultTy, paramTypes, false);
+    auto resultTy = fnType->getReturnType() == IGF.IGM.VoidTy ? IGF.IGM.VoidTy
+                                                              : addr->getType();
+    fnType = llvm::FunctionType::get(resultTy, paramTypes, false);
     fn = llvm::ConstantExpr::getBitCast(fn, fnType->getPointerTo());
   }
 
   // Emit the call.
-  llvm::CallInst *call = IGF.Builder.CreateCall(fn, {addr, value});
+  llvm::CallInst *call =
+      IGF.Builder.CreateCallWithoutDbgLoc(fnType, fn, {addr, value});
   if (fun && fun->hasParamAttribute(0, llvm::Attribute::Returned))
     call->addParamAttr(0, llvm::Attribute::Returned);
   call->setCallingConv(cc);
@@ -978,8 +959,9 @@ void IRGenFunction::emitNativeStrongRetain(llvm::Value *value,
 
   // Emit the call.
   llvm::CallInst *call = Builder.CreateCall(
-      (atomicity == Atomicity::Atomic) ? IGM.getNativeStrongRetainFn()
-                                       : IGM.getNativeNonAtomicStrongRetainFn(),
+      (atomicity == Atomicity::Atomic)
+          ? IGM.getNativeStrongRetainFunctionPointer()
+          : IGM.getNativeNonAtomicStrongRetainFunctionPointer(),
       value);
   call->setDoesNotThrow();
   call->addParamAttr(0, llvm::Attribute::Returned);
@@ -1273,28 +1255,26 @@ llvm::Constant *IRGenModule::getFixLifetimeFn() {
   return fixLifetime;
 }
 
-llvm::Constant *IRGenModule::getFixedClassInitializationFn() {
+FunctionPointer IRGenModule::getFixedClassInitializationFn() {
   if (FixedClassInitializationFn)
     return *FixedClassInitializationFn;
   
   // If ObjC interop is disabled, we don't need to do fixed class
   // initialization.
-  llvm::Constant *fn;
-  if (!ObjCInterop) {
-    fn = nullptr;
-  } else {
+  FunctionPointer fn;
+  if (ObjCInterop) {
     // In new enough ObjC runtimes, objc_opt_self provides a direct fast path
     // to realize a class.
     if (getAvailabilityContext()
          .isContainedIn(Context.getSwift51Availability())) {
-      fn = getObjCOptSelfFn();
+      fn = getObjCOptSelfFunctionPointer();
     }
     // Otherwise, the Swift runtime always provides a `get
     else {
-      fn = getGetInitializedObjCClassFn();
+      fn = getGetInitializedObjCClassFunctionPointer();
     }
   }
-  
+
   FixedClassInitializationFn = fn;
   return fn;
 }
@@ -1360,42 +1340,42 @@ void IRGenFunction::emitErrorStrongRelease(llvm::Value *value) {
 
 llvm::Value *IRGenFunction::emitLoadRefcountedPtr(Address addr,
                                                   ReferenceCounting style) {
-  Address src =
-    Builder.CreateBitCast(addr, IGM.getReferenceType(style)->getPointerTo());
+  Address src = Builder.CreateElementBitCast(addr, IGM.getReferenceType(style));
   return Builder.CreateLoad(src);
 }
 
 llvm::Value *IRGenFunction::
 emitIsUniqueCall(llvm::Value *value, SourceLoc loc, bool isNonNull) {
-  llvm::Constant *fn;
+  FunctionPointer fn;
   bool nonObjC = !IGM.getAvailabilityContext().isContainedIn(
       IGM.Context.getObjCIsUniquelyReferencedAvailability());
 
   if (value->getType() == IGM.RefCountedPtrTy) {
     if (isNonNull)
-      fn = IGM.getIsUniquelyReferenced_nonNull_nativeFn();
+      fn = IGM.getIsUniquelyReferenced_nonNull_nativeFunctionPointer();
     else
-      fn = IGM.getIsUniquelyReferenced_nativeFn();
+      fn = IGM.getIsUniquelyReferenced_nativeFunctionPointer();
   } else if (value->getType() == IGM.UnknownRefCountedPtrTy) {
     if (nonObjC) {
       if (isNonNull)
-        fn = IGM.getIsUniquelyReferencedNonObjC_nonNullFn();
+        fn = IGM.getIsUniquelyReferencedNonObjC_nonNullFunctionPointer();
       else
-        fn = IGM.getIsUniquelyReferencedNonObjCFn();
+        fn = IGM.getIsUniquelyReferencedNonObjCFunctionPointer();
     } else {
       if (isNonNull)
-        fn = IGM.getIsUniquelyReferenced_nonNullFn();
+        fn = IGM.getIsUniquelyReferenced_nonNullFunctionPointer();
       else
-        fn = IGM.getIsUniquelyReferencedFn();
+        fn = IGM.getIsUniquelyReferencedFunctionPointer();
     }
   } else if (value->getType() == IGM.BridgeObjectPtrTy) {
     if (!isNonNull)
       unimplemented(loc, "optional bridge ref");
 
     if (nonObjC)
-      fn = IGM.getIsUniquelyReferencedNonObjC_nonNull_bridgeObjectFn();
+      fn =
+          IGM.getIsUniquelyReferencedNonObjC_nonNull_bridgeObjectFunctionPointer();
     else
-      fn = IGM.getIsUniquelyReferenced_nonNull_bridgeObjectFn();
+      fn = IGM.getIsUniquelyReferenced_nonNull_bridgeObjectFunctionPointer();
   } else {
     llvm_unreachable("Unexpected LLVM type for a refcounted pointer.");
   }
@@ -1418,9 +1398,9 @@ llvm::Value *IRGenFunction::emitIsEscapingClosureCall(
   auto filenameLength =
       llvm::ConstantInt::get(IGM.Int32Ty, loc.filename.size());
   auto type = llvm::ConstantInt::get(IGM.Int32Ty, verificationType);
-  llvm::CallInst *call =
-      Builder.CreateCall(IGM.getIsEscapingClosureAtFileLocationFn(),
-                         {value, filename, filenameLength, line, col, type});
+  llvm::CallInst *call = Builder.CreateCall(
+      IGM.getIsEscapingClosureAtFileLocationFunctionPointer(),
+      {value, filename, filenameLength, line, col, type});
   call->setDoesNotThrow();
   return call;
 }
@@ -1562,8 +1542,7 @@ public:
     Address rawAddr = layout.emitCastTo(IGF, box);
     rawAddr = layout.getElement(0).project(IGF, rawAddr, None);
     auto &ti = IGF.getTypeInfo(boxedType);
-    return IGF.Builder.CreateBitCast(rawAddr,
-                                     ti.getStorageType()->getPointerTo());
+    return IGF.Builder.CreateElementBitCast(rawAddr, ti.getStorageType());
   }
 };
 
@@ -1713,6 +1692,7 @@ Address irgen::emitAllocateExistentialBoxInBuffer(
                    Address(IGF.Builder.CreateBitCast(
                                destBuffer.getAddress(),
                                owned.getOwner()->getType()->getPointerTo()),
+                           owned.getOwner()->getType(),
                            destBuffer.getAlignment()),
                    isOutlined);
   return owned.getAddress();
@@ -1827,8 +1807,8 @@ llvm::Value *irgen::emitLoadOfObjCHeapMetadataRef(IRGenFunction &IGF,
   if (IGF.IGM.TargetInfo.hasISAMasking()) {
     object = IGF.Builder.CreateBitCast(object,
                                        IGF.IGM.IntPtrTy->getPointerTo());
-    llvm::Value *metadata =
-      IGF.Builder.CreateLoad(Address(object, IGF.IGM.getPointerAlignment()));
+    llvm::Value *metadata = IGF.Builder.CreateLoad(
+        Address(object, IGF.IGM.IntPtrTy, IGF.IGM.getPointerAlignment()));
     llvm::Value *mask = IGF.Builder.CreateLoad(IGF.IGM.getAddrOfObjCISAMask());
     metadata = IGF.Builder.CreateAnd(metadata, mask);
     metadata = IGF.Builder.CreateIntToPtr(metadata, IGF.IGM.TypeMetadataPtrTy);
@@ -1838,8 +1818,8 @@ llvm::Value *irgen::emitLoadOfObjCHeapMetadataRef(IRGenFunction &IGF,
   } else {
     object = IGF.Builder.CreateBitCast(object,
                                   IGF.IGM.TypeMetadataPtrTy->getPointerTo());
-    llvm::Value *metadata =
-      IGF.Builder.CreateLoad(Address(object, IGF.IGM.getPointerAlignment()));
+    llvm::Value *metadata = IGF.Builder.CreateLoad(Address(
+        object, IGF.IGM.TypeMetadataPtrTy, IGF.IGM.getPointerAlignment()));
     return metadata;
   }
 }
@@ -1852,47 +1832,10 @@ static llvm::Value *emitLoadOfHeapMetadataRef(IRGenFunction &IGF,
                                               bool suppressCast) {
   switch (isaEncoding) {
   case IsaEncoding::Pointer: {
-    // Drill into the object pointer.  Rather than bitcasting, we make
-    // an effort to do something that should explode if we get something
-    // mistyped.
-    llvm::StructType *structTy =
-      cast<llvm::StructType>(
-        cast<llvm::PointerType>(object->getType())->getPointerElementType());
-
-    llvm::Value *slot;
-
-    // We need a bitcast if we're dealing with an opaque class.
-    if (structTy->isOpaque()) {
-      auto metadataPtrPtrTy = IGF.IGM.TypeMetadataPtrTy->getPointerTo();
-      slot = IGF.Builder.CreateBitCast(object, metadataPtrPtrTy);
-
-    // Otherwise, make a GEP.
-    } else {
-      auto zero = llvm::ConstantInt::get(IGF.IGM.Int32Ty, 0);
-
-      SmallVector<llvm::Value*, 4> indexes;
-      indexes.push_back(zero);
-      do {
-        indexes.push_back(zero);
-
-        // Keep drilling down to the first element type.
-        auto eltTy = structTy->getElementType(0);
-        assert(isa<llvm::StructType>(eltTy) || eltTy == IGF.IGM.TypeMetadataPtrTy);
-        structTy = dyn_cast<llvm::StructType>(eltTy);
-      } while (structTy != nullptr);
-
-      slot = IGF.Builder.CreateInBoundsGEP(
-          object->getType()->getScalarType()->getPointerElementType(), object,
-          indexes);
-
-      if (!suppressCast) {
-        slot = IGF.Builder.CreateBitCast(slot,
-                                    IGF.IGM.TypeMetadataPtrTy->getPointerTo());
-      }
-    }
-
-    auto metadata = IGF.Builder.CreateLoad(Address(slot,
-                                               IGF.IGM.getPointerAlignment()));
+    llvm::Value *slot =
+        IGF.Builder.CreateBitCast(object, IGF.IGM.TypeMetadataPtrPtrTy);
+    auto metadata = IGF.Builder.CreateLoad(Address(
+        slot, IGF.IGM.TypeMetadataPtrTy, IGF.IGM.getPointerAlignment()));
     if (IGF.IGM.EnableValueNames && object->hasName())
       metadata->setName(llvm::Twine(object->getName()) + ".metadata");
     return metadata;
@@ -1919,9 +1862,7 @@ llvm::Value *irgen::emitHeapMetadataRefForHeapObject(IRGenFunction &IGF,
   ClassDecl *theClass = objectType.getClassOrBoundGenericClass();
   if (theClass && isKnownNotTaggedPointer(IGF.IGM, theClass)) {
     auto isaEncoding = getIsaEncodingForType(IGF.IGM, objectType, sig);
-    return emitLoadOfHeapMetadataRef(IGF, object,
-                                     isaEncoding,
-                                     suppressCast);
+    return emitLoadOfHeapMetadataRef(IGF, object, isaEncoding, suppressCast);
   }
 
   // OK, ask the runtime for the class pointer of this potentially-ObjC object.
@@ -1965,14 +1906,14 @@ static llvm::Value *emitDynamicTypeOfOpaqueHeapObject(IRGenFunction &IGF,
   
   switch (repr) {
   case MetatypeRepresentation::ObjC:
-    metadata = IGF.Builder.CreateCall(IGF.IGM.getGetObjCClassFromObjectFn(),
-                                      object,
-                                      object->getName() + ".Type");
+    metadata = IGF.Builder.CreateCall(
+        IGF.IGM.getGetObjCClassFromObjectFunctionPointer(), object);
+    metadata->setName(object->getName() + ".Type");
     break;
   case MetatypeRepresentation::Thick:
-    metadata = IGF.Builder.CreateCall(IGF.IGM.getGetObjectTypeFn(),
-                                      object,
-                                      object->getName() + ".Type");
+    metadata = IGF.Builder.CreateCall(IGF.IGM.getGetObjectTypeFunctionPointer(),
+                                      object);
+    metadata->setName(object->getName() + ".Type");
     break;
   case MetatypeRepresentation::Thin:
     llvm_unreachable("class metadata can't be thin");
@@ -1987,9 +1928,9 @@ llvm::Value *irgen::
 emitHeapMetadataRefForUnknownHeapObject(IRGenFunction &IGF,
                                         llvm::Value *object) {
   object = IGF.Builder.CreateBitCast(object, IGF.IGM.ObjCPtrTy);
-  auto metadata = IGF.Builder.CreateCall(IGF.IGM.getGetObjectClassFn(),
-                                         object,
-                                         object->getName() + ".Type");
+  auto metadata = IGF.Builder.CreateCall(
+      IGF.IGM.getGetObjectClassFunctionPointer(), object);
+  metadata->setName(object->getName() + ".Type");
   metadata->setCallingConv(llvm::CallingConv::C);
   metadata->setDoesNotThrow();
   metadata->addFnAttr(llvm::Attribute::ReadOnly);

--- a/lib/IRGen/GenIntegerLiteral.cpp
+++ b/lib/IRGen/GenIntegerLiteral.cpp
@@ -202,12 +202,12 @@ ConstantIntegerLiteralMap::get(IRGenModule &IGM, APInt &&value) {
   return entry;
 }
 
-void irgen::emitIntegerLiteralCheckedTrunc(IRGenFunction &IGF,
-                                           Explosion &in,
+void irgen::emitIntegerLiteralCheckedTrunc(IRGenFunction &IGF, Explosion &in,
+                                           llvm::Type *FromTy,
                                            llvm::IntegerType *resultTy,
                                            bool resultIsSigned,
                                            Explosion &out) {
-  Address data(in.claimNext(), IGF.IGM.getPointerAlignment());
+  Address data(in.claimNext(), FromTy, IGF.IGM.getPointerAlignment());
   auto flags = in.claimNext();
 
   size_t chunkWidth = IGF.IGM.getPointerSize().getValueInBits();
@@ -355,8 +355,8 @@ static llvm::Value *emitIntegerLiteralToFloatCall(IRGenFunction &IGF,
                                                   llvm::Value *flags,
                                                   unsigned bitWidth) {
   assert(bitWidth == 32 || bitWidth == 64);
-  auto fn = bitWidth == 32 ? IGF.IGM.getIntToFloat32Fn()
-                           : IGF.IGM.getIntToFloat64Fn();
+  auto fn = bitWidth == 32 ? IGF.IGM.getIntToFloat32FunctionPointer()
+                           : IGF.IGM.getIntToFloat64FunctionPointer();
   auto call = IGF.Builder.CreateCall(fn, {data, flags});
   call->setCallingConv(IGF.IGM.SwiftCC);
   call->setDoesNotThrow();

--- a/lib/IRGen/GenIntegerLiteral.h
+++ b/lib/IRGen/GenIntegerLiteral.h
@@ -56,11 +56,10 @@ ConstantIntegerLiteral
 emitConstantIntegerLiteral(IRGenModule &IGM, IntegerLiteralInst *ILI);
 
 /// Emit a checked truncation of an IntegerLiteral value.
-void emitIntegerLiteralCheckedTrunc(IRGenFunction &IGF,
-                                    Explosion &in,
+void emitIntegerLiteralCheckedTrunc(IRGenFunction &IGF, Explosion &in,
+                                    llvm::Type *FromTy,
                                     llvm::IntegerType *resultTy,
-                                    bool resultIsSigned,
-                                    Explosion &out);
+                                    bool resultIsSigned, Explosion &out);
 
 /// Emit a sitofp operation on an IntegerLiteral value.
 llvm::Value *emitIntegerLiteralToFP(IRGenFunction &IGF,

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -86,16 +86,15 @@ bindPolymorphicArgumentsFromComponentIndices(IRGenFunction &IGF,
       requirements.size() * IGF.IGM.getPointerSize().getValue());
 
     auto genericArgsOffset = IGF.Builder.CreateSub(size, genericArgsSize);
-    args = IGF.Builder.CreateInBoundsGEP(
-        args->getType()->getScalarType()->getPointerElementType(), args,
-        genericArgsOffset);
+    args =
+        IGF.Builder.CreateInBoundsGEP(IGF.IGM.Int8Ty, args, genericArgsOffset);
   }
-  bindFromGenericRequirementsBuffer(IGF, requirements,
-    Address(args, IGF.IGM.getPointerAlignment()),
-    MetadataState::Complete,
-    [&](CanType t) {
-      return genericEnv->mapTypeIntoContext(t)->getCanonicalType();
-    });
+  bindFromGenericRequirementsBuffer(
+      IGF, requirements,
+      Address(args, IGF.IGM.Int8Ty, IGF.IGM.getPointerAlignment()),
+      MetadataState::Complete, [&](CanType t) {
+        return genericEnv->mapTypeIntoContext(t)->getCanonicalType();
+      });
 }
 
 static llvm::Function *
@@ -130,10 +129,9 @@ getAccessorForComputedComponent(IRGenModule &IGM,
     return IGM.getAddrOfSILFunction(accessor, NotForDefinition);
   }
   auto accessorFn = IGM.getAddrOfSILFunction(accessor, NotForDefinition);
-  
-  auto accessorFnTy = cast<llvm::FunctionType>(
-    accessorFn->getType()->getPointerElementType());;
-  
+
+  auto accessorFnTy = accessorFn->getFunctionType();
+
   // Otherwise, we need a thunk to unmarshal the generic environment from the
   // argument area. It'd be nice to have a good way to represent this
   // directly in SIL, of course...
@@ -184,7 +182,7 @@ getAccessorForComputedComponent(IRGenModule &IGM,
   accessorThunk->setCallingConv(IGM.SwiftCC);
 
   switch (whichAccessor) {
-  case Getter:
+  case Getter: {
     // Original accessor's args should be @in or @out, meaning they won't be
     // captured or aliased.
     accessorThunk->addParamAttr(0, llvm::Attribute::NoCapture);
@@ -192,10 +190,11 @@ getAccessorForComputedComponent(IRGenModule &IGM,
     accessorThunk->addParamAttr(1, llvm::Attribute::NoCapture);
     accessorThunk->addParamAttr(1, llvm::Attribute::NoAlias);
     // Output is sret.
-    accessorThunk->addParamAttr(
-        0, llvm::Attribute::getWithStructRetType(
-               IGM.getLLVMContext(), thunkParams[0]->getPointerElementType()));
+    auto structRetTy = accessorFn->getParamStructRetType(0);
+    accessorThunk->addParamAttr(0, llvm::Attribute::getWithStructRetType(
+                                       IGM.getLLVMContext(), structRetTy));
     break;
+  }
   case Setter:
     // Original accessor's args should be @in or @out, meaning they won't be
     // captured or aliased.
@@ -293,12 +292,12 @@ getLayoutFunctionForComputedComponent(IRGenModule &IGM,
     auto args = parameters.claimNext();
     
     if (genericEnv) {
-      bindFromGenericRequirementsBuffer(IGF, requirements,
-        Address(args, IGF.IGM.getPointerAlignment()),
-        MetadataState::Complete,
-        [&](CanType t) {
-          return genericEnv->mapTypeIntoContext(t)->getCanonicalType();
-        });
+      bindFromGenericRequirementsBuffer(
+          IGF, requirements,
+          Address(args, IGM.Int8Ty, IGF.IGM.getPointerAlignment()),
+          MetadataState::Complete, [&](CanType t) {
+            return genericEnv->mapTypeIntoContext(t)->getCanonicalType();
+          });
     }
     
     // Run through the captured index types to determine the size and alignment
@@ -415,10 +414,8 @@ getWitnessTableForComputedComponent(IRGenModule &IGM,
         } else {
           offset = llvm::ConstantInt::get(IGM.SizeTy, 0);
         }
-        auto elt = IGF.Builder.CreateInBoundsGEP(componentArgsBuf->getType()
-                                                     ->getScalarType()
-                                                     ->getPointerElementType(),
-                                                 componentArgsBuf, offset);
+        auto elt =
+            IGF.Builder.CreateInBoundsGEP(IGM.Int8Ty, componentArgsBuf, offset);
         auto eltAddr = ti.getAddressForPointer(
           IGF.Builder.CreateBitCast(elt, ti.getStorageType()->getPointerTo()));
         ti.destroy(IGF, eltAddr, ty,
@@ -470,12 +467,10 @@ getWitnessTableForComputedComponent(IRGenModule &IGM,
         } else {
           offset = llvm::ConstantInt::get(IGM.SizeTy, 0);
         }
-        auto sourceElt = IGF.Builder.CreateInBoundsGEP(
-            sourceArgsBuf->getType()->getScalarType()->getPointerElementType(),
-            sourceArgsBuf, offset);
-        auto destElt = IGF.Builder.CreateInBoundsGEP(
-            destArgsBuf->getType()->getScalarType()->getPointerElementType(),
-            destArgsBuf, offset);
+        auto sourceElt =
+            IGF.Builder.CreateInBoundsGEP(IGM.Int8Ty, sourceArgsBuf, offset);
+        auto destElt =
+            IGF.Builder.CreateInBoundsGEP(IGM.Int8Ty, destArgsBuf, offset);
         auto sourceEltAddr = ti.getAddressForPointer(
           IGF.Builder.CreateBitCast(sourceElt,
                                     ti.getStorageType()->getPointerTo()));
@@ -496,12 +491,10 @@ getWitnessTableForComputedComponent(IRGenModule &IGM,
         offset = IGF.Builder.CreateAdd(offset, envAlignMask);
         offset = IGF.Builder.CreateAnd(offset, notAlignMask);
 
-        auto sourceEnv = IGF.Builder.CreateInBoundsGEP(
-            sourceArgsBuf->getType()->getScalarType()->getPointerElementType(),
-            sourceArgsBuf, offset);
-        auto destEnv = IGF.Builder.CreateInBoundsGEP(
-            destArgsBuf->getType()->getScalarType()->getPointerElementType(),
-            destArgsBuf, offset);
+        auto sourceEnv =
+            IGF.Builder.CreateInBoundsGEP(IGM.Int8Ty, sourceArgsBuf, offset);
+        auto destEnv =
+            IGF.Builder.CreateInBoundsGEP(IGM.Int8Ty, destArgsBuf, offset);
 
         auto align = IGM.getPointerAlignment().getValue();
         IGF.Builder.CreateMemCpy(destEnv, llvm::MaybeAlign(align), sourceEnv,
@@ -587,12 +580,12 @@ getInitializerForComputedComponent(IRGenModule &IGM,
         IGM.getPointerSize().getValue() * requirements.size());
 
       // Bind the generic environment from the argument buffer.
-      bindFromGenericRequirementsBuffer(IGF, requirements,
-        Address(src, IGF.IGM.getPointerAlignment()),
-        MetadataState::Complete,
-        [&](CanType t) {
-          return genericEnv->mapTypeIntoContext(t)->getCanonicalType();
-        });
+      bindFromGenericRequirementsBuffer(
+          IGF, requirements,
+          Address(src, IGM.Int8Ty, IGF.IGM.getPointerAlignment()),
+          MetadataState::Complete, [&](CanType t) {
+            return genericEnv->mapTypeIntoContext(t)->getCanonicalType();
+          });
 
     } else {
       offset = llvm::ConstantInt::get(IGM.SizeTy, 0);
@@ -614,9 +607,7 @@ getInitializerForComputedComponent(IRGenModule &IGM,
         offset = IGF.Builder.CreateAnd(offset, notAlignMask);
       }
 
-      auto ptr = IGF.Builder.CreateInBoundsGEP(
-          src->getType()->getScalarType()->getPointerElementType(), src,
-          offset);
+      auto ptr = IGF.Builder.CreateInBoundsGEP(IGM.Int8Ty, src, offset);
       auto addr = ti.getAddressForPointer(IGF.Builder.CreateBitCast(
         ptr, ti.getStorageType()->getPointerTo()));
       srcAddresses.push_back(addr);
@@ -645,9 +636,7 @@ getInitializerForComputedComponent(IRGenModule &IGM,
         offset = IGF.Builder.CreateAnd(offset, notAlignMask);
       }
 
-      auto ptr = IGF.Builder.CreateInBoundsGEP(
-          dest->getType()->getScalarType()->getPointerElementType(), dest,
-          offset);
+      auto ptr = IGF.Builder.CreateInBoundsGEP(IGM.Int8Ty, dest, offset);
       auto destAddr = ti.getAddressForPointer(IGF.Builder.CreateBitCast(
         ptr, ti.getStorageType()->getPointerTo()));
       
@@ -676,9 +665,8 @@ getInitializerForComputedComponent(IRGenModule &IGM,
         auto notGenericEnvAlignMask = IGF.Builder.CreateNot(genericEnvAlignMask);
         offset = IGF.Builder.CreateAdd(offset, genericEnvAlignMask);
         offset = IGF.Builder.CreateAnd(offset, notGenericEnvAlignMask);
-        destGenericEnv = IGF.Builder.CreateInBoundsGEP(
-            dest->getType()->getScalarType()->getPointerElementType(), dest,
-            offset);
+        destGenericEnv =
+            IGF.Builder.CreateInBoundsGEP(IGM.Int8Ty, dest, offset);
       }
       
       auto align = IGM.getPointerAlignment().getValue();
@@ -700,8 +688,8 @@ emitMetadataTypeRefForKeyPath(IRGenModule &IGM, CanType type,
   // Mask the bottom bit to tell the key path runtime this is a mangled name
   // rather than a direct reference.
   auto bitConstant = llvm::ConstantInt::get(IGM.IntPtrTy, 1);
-  return llvm::ConstantExpr::getGetElementPtr(
-    constant->getType()->getPointerElementType(), constant, bitConstant);
+  return llvm::ConstantExpr::getGetElementPtr(IGM.Int8Ty, constant,
+                                              bitConstant);
 }
 
 static unsigned getClassFieldIndex(ClassDecl *classDecl, VarDecl *property) {

--- a/lib/IRGen/GenOpaque.cpp
+++ b/lib/IRGen/GenOpaque.cpp
@@ -32,6 +32,7 @@
 #include "Explosion.h"
 #include "FixedTypeInfo.h"
 #include "GenPointerAuth.h"
+#include "IRGenDebugInfo.h"
 #include "IRGenFunction.h"
 #include "IRGenModule.h"
 #include "ProtocolInfo.h"
@@ -255,9 +256,9 @@ static StringRef getValueWitnessLabel(ValueWitness index) {
   llvm_unreachable("bad value witness index");
 }
 
-static llvm::PointerType *
-getOrCreateValueWitnessTablePtrTy(IRGenModule &IGM, llvm::PointerType *&cache,
-                                  StringRef name, bool includeEnumWitnesses) {
+static llvm::StructType *
+getOrCreateValueWitnessTableTy(IRGenModule &IGM, llvm::StructType *&cache,
+                               StringRef name, bool includeEnumWitnesses) {
   if (cache) return cache;
 
   SmallVector<llvm::Type*, 16> types;
@@ -285,26 +286,24 @@ getOrCreateValueWitnessTablePtrTy(IRGenModule &IGM, llvm::PointerType *&cache,
 #undef FUNC
 
   auto structTy = llvm::StructType::create(types, name);
-  auto ptrTy = structTy->getPointerTo();
-  cache = ptrTy;
-  return ptrTy;
+  cache = structTy;
+  return structTy;
 }
 
 llvm::StructType *IRGenModule::getValueWitnessTableTy() {
-  return cast<llvm::StructType>(getValueWitnessTablePtrTy()->getPointerElementType());
+  return getOrCreateValueWitnessTableTy(*this, ValueWitnessTableTy,
+                                        "swift.vwtable", false);
 }
 llvm::PointerType *IRGenModule::getValueWitnessTablePtrTy() {
-  return getOrCreateValueWitnessTablePtrTy(*this, ValueWitnessTablePtrTy,
-                                           "swift.vwtable", false);
+  return getValueWitnessTableTy()->getPointerTo();
 }
 
 llvm::StructType *IRGenModule::getEnumValueWitnessTableTy() {
-  return cast<llvm::StructType>(getEnumValueWitnessTablePtrTy()
-           ->getPointerElementType());
+  return getOrCreateValueWitnessTableTy(*this, EnumValueWitnessTableTy,
+                                        "swift.enum_vwtable", true);
 }
 llvm::PointerType *IRGenModule::getEnumValueWitnessTablePtrTy() {
-  return getOrCreateValueWitnessTablePtrTy(*this, EnumValueWitnessTablePtrTy,
-                                           "swift.enum_vwtable", true);
+  return getEnumValueWitnessTableTy()->getPointerTo();
 }
 
 Address irgen::slotForLoadOfOpaqueWitness(IRGenFunction &IGF,
@@ -315,10 +314,10 @@ Address irgen::slotForLoadOfOpaqueWitness(IRGenFunction &IGF,
   // GEP to the appropriate index, avoiding spurious IR in the trivial case.
   llvm::Value *slot = table;
   if (index.getValue() != 0)
-    slot = IGF.Builder.CreateConstInBoundsGEP1_32(
-        table->getType()->getPointerElementType(), table, index.getValue());
+    slot = IGF.Builder.CreateConstInBoundsGEP1_32(IGF.IGM.WitnessTableTy, table,
+                                                  index.getValue());
 
-  return Address(slot, IGF.IGM.getPointerAlignment());
+  return Address(slot, IGF.IGM.WitnessTableTy, IGF.IGM.getPointerAlignment());
 }
 
 /// Load a specific witness from a known table.  The result is
@@ -341,13 +340,13 @@ llvm::Value *irgen::emitInvariantLoadOfOpaqueWitness(IRGenFunction &IGF,
   assert(table->getType() == IGF.IGM.WitnessTablePtrTy);
 
   // GEP to the appropriate index.
-  llvm::Value *slot = IGF.Builder.CreateInBoundsGEP(
-      table->getType()->getScalarType()->getPointerElementType(), table, index);
+  llvm::Value *slot =
+      IGF.Builder.CreateInBoundsGEP(IGF.IGM.WitnessTableTy, table, index);
 
   if (slotPtr) *slotPtr = slot;
 
-  auto witness =
-    IGF.Builder.CreateLoad(Address(slot, IGF.IGM.getPointerAlignment()));
+  auto witness = IGF.Builder.CreateLoad(
+      Address(slot, IGF.IGM.WitnessTableTy, IGF.IGM.getPointerAlignment()));
   IGF.setInvariantLoad(witness);
   return witness;
 }
@@ -372,8 +371,10 @@ static Address emitAddressOfValueWitnessTableValue(IRGenFunction &IGF,
        ? unsigned(ValueWitness::Flags) * pointerSize + Size(4)
        : unsigned(witness) * pointerSize);
 
-  Address addr = Address(table, IGF.IGM.getPointerAlignment());
-  addr = IGF.Builder.CreateBitCast(addr, IGF.IGM.getValueWitnessTablePtrTy());
+  Address addr =
+      Address(table, IGF.IGM.WitnessTableTy, IGF.IGM.getPointerAlignment());
+  addr =
+      IGF.Builder.CreateElementBitCast(addr, IGF.IGM.getValueWitnessTableTy());
   addr = IGF.Builder.CreateStructGEP(addr, unsigned(witness), offset);
   return addr;
 }
@@ -433,8 +434,8 @@ static FunctionPointer emitLoadOfValueWitnessFunction(IRGenFunction &IGF,
                                     IGF.getOptions().PointerAuth.ValueWitnesses,
                                         slot, index);
 
-  return FunctionPointer(FunctionPointer::Kind::Function, witness, authInfo,
-                         signature);
+  return FunctionPointer::createSigned(FunctionPointer::Kind::Function, witness,
+                                       authInfo, signature);
 }
 
 /// Given a type metadata pointer, load one of the function
@@ -480,8 +481,8 @@ IRGenFunction::emitValueWitnessFunctionRef(SILType type,
       assert(discriminator && "no saved discriminator for value witness fn!");
       authInfo = PointerAuthInfo(schema.getKey(), discriminator);
     }
-    return FunctionPointer(FunctionPointer::Kind::Function, witness, authInfo,
-                           signature);
+    return FunctionPointer::createSigned(FunctionPointer::Kind::Function,
+                                         witness, authInfo, signature);
   }
   
   auto vwtable = emitValueWitnessTableRef(type, &metadataSlot);
@@ -569,16 +570,15 @@ StackAddress IRGenFunction::emitDynamicAlloca(llvm::Type *eltTy,
     auto alignment = llvm::ConstantInt::get(IGM.Int32Ty, align.getValue());
 
     // Allocate memory.  This produces an abstract token.
-    auto allocFn = llvm::Intrinsic::getDeclaration(
-        &IGM.Module, llvm::Intrinsic::coro_alloca_alloc, {IGM.SizeTy});
-    auto allocToken = Builder.CreateCall(allocFn, { byteCount, alignment });
+    auto allocToken =
+        Builder.CreateIntrinsicCall(llvm::Intrinsic::coro_alloca_alloc,
+                                    {IGM.SizeTy}, {byteCount, alignment});
 
     // Get the allocation result.
-    auto getFn = llvm::Intrinsic::getDeclaration(
-        &IGM.Module, llvm::Intrinsic::coro_alloca_get);
-    auto ptr = Builder.CreateCall(getFn, { allocToken });
+    auto ptr = Builder.CreateIntrinsicCall(llvm::Intrinsic::coro_alloca_get,
+                                           {allocToken});
 
-    return {Address(ptr, align), allocToken};
+    return {Address(ptr, IGM.Int8Ty, align), allocToken};
   }
 
   // Otherwise, use a dynamic alloca.
@@ -588,10 +588,8 @@ StackAddress IRGenFunction::emitDynamicAlloca(llvm::Type *eltTy,
   // executed more than once).
   bool isInEntryBlock = (Builder.GetInsertBlock() == &*CurFn->begin());
   if (!isInEntryBlock) {
-    auto *stackSaveFn = llvm::Intrinsic::getDeclaration(
-        &IGM.Module, llvm::Intrinsic::stacksave);
-
-    stackRestorePoint =  Builder.CreateCall(stackSaveFn, {}, "spsave");
+    stackRestorePoint =
+        Builder.CreateIntrinsicCall(llvm::Intrinsic::stacksave, {}, "spsave");
   }
 
   // Emit the dynamic alloca.
@@ -602,7 +600,7 @@ StackAddress IRGenFunction::emitDynamicAlloca(llvm::Type *eltTy,
          getActiveDominancePoint().isUniversal() &&
              "Must be in entry block if we insert dynamic alloca's without "
              "stackrestores");
-  return {Address(alloca, align), stackRestorePoint};
+  return {Address(alloca, eltTy, align), stackRestorePoint};
 }
 
 /// Deallocate dynamic alloca's memory if requested by restoring the stack
@@ -611,7 +609,8 @@ void IRGenFunction::emitDeallocateDynamicAlloca(StackAddress address,
                                                 bool allowTaskDealloc) {
   // Async function use taskDealloc.
   if (allowTaskDealloc && isAsync() && address.getAddress().isValid()) {
-    emitTaskDealloc(Address(address.getExtraInfo(), address.getAlignment()));
+    emitTaskDealloc(
+        Address(address.getExtraInfo(), IGM.Int8Ty, address.getAlignment()));
     return;
   }
   // In coroutines, unconditionally call llvm.coro.alloca.free.
@@ -623,18 +622,14 @@ void IRGenFunction::emitDeallocateDynamicAlloca(StackAddress address,
 
     auto allocToken = address.getExtraInfo();
     assert(allocToken && "dynamic alloca in coroutine without alloc token?");
-    auto freeFn = llvm::Intrinsic::getDeclaration(
-        &IGM.Module, llvm::Intrinsic::coro_alloca_free);
-    Builder.CreateCall(freeFn, allocToken);
+    Builder.CreateIntrinsicCall(llvm::Intrinsic::coro_alloca_free, allocToken);
     return;
   }
   // Otherwise, call llvm.stackrestore if an address was saved.
   auto savedSP = address.getExtraInfo();
   if (savedSP == nullptr)
     return;
-  auto *stackRestoreFn = llvm::Intrinsic::getDeclaration(
-      &IGM.Module, llvm::Intrinsic::stackrestore);
-  Builder.CreateCall(stackRestoreFn, savedSP);
+  Builder.CreateIntrinsicCall(llvm::Intrinsic::stackrestore, savedSP);
 }
 
 /// Emit a call to do an 'initializeArrayWithCopy' operation.
@@ -646,7 +641,7 @@ void irgen::emitInitializeArrayWithCopyCall(IRGenFunction &IGF,
   auto metadata = IGF.emitTypeMetadataRefForLayout(T);
   auto dest = emitCastToOpaquePtr(IGF, destObject);
   auto src = emitCastToOpaquePtr(IGF, srcObject);
-  IGF.Builder.CreateCall(IGF.IGM.getArrayInitWithCopyFn(),
+  IGF.Builder.CreateCall(IGF.IGM.getArrayInitWithCopyFunctionPointer(),
                          {dest, src, count, metadata});
 }
 
@@ -659,7 +654,7 @@ void irgen::emitInitializeArrayWithTakeNoAliasCall(IRGenFunction &IGF,
   auto metadata = IGF.emitTypeMetadataRefForLayout(T);
   auto dest = emitCastToOpaquePtr(IGF, destObject);
   auto src = emitCastToOpaquePtr(IGF, srcObject);
-  IGF.Builder.CreateCall(IGF.IGM.getArrayInitWithTakeNoAliasFn(),
+  IGF.Builder.CreateCall(IGF.IGM.getArrayInitWithTakeNoAliasFunctionPointer(),
                          {dest, src, count, metadata});
 }
 
@@ -672,8 +667,9 @@ void irgen::emitInitializeArrayWithTakeFrontToBackCall(IRGenFunction &IGF,
   auto metadata = IGF.emitTypeMetadataRefForLayout(T);
   auto dest = emitCastToOpaquePtr(IGF, destObject);
   auto src = emitCastToOpaquePtr(IGF, srcObject);
-  IGF.Builder.CreateCall(IGF.IGM.getArrayInitWithTakeFrontToBackFn(),
-                         {dest, src, count, metadata});
+  IGF.Builder.CreateCall(
+      IGF.IGM.getArrayInitWithTakeFrontToBackFunctionPointer(),
+      {dest, src, count, metadata});
 }
 
 /// Emit a call to do an 'initializeArrayWithTakeBackToFront' operation.
@@ -685,8 +681,9 @@ void irgen::emitInitializeArrayWithTakeBackToFrontCall(IRGenFunction &IGF,
   auto metadata = IGF.emitTypeMetadataRefForLayout(T);
   auto dest = emitCastToOpaquePtr(IGF, destObject);
   auto src = emitCastToOpaquePtr(IGF, srcObject);
-  IGF.Builder.CreateCall(IGF.IGM.getArrayInitWithTakeBackToFrontFn(),
-                         {dest, src, count, metadata});
+  IGF.Builder.CreateCall(
+      IGF.IGM.getArrayInitWithTakeBackToFrontFunctionPointer(),
+      {dest, src, count, metadata});
 }
 
 /// Emit a call to do an 'assignWithCopy' operation.
@@ -721,7 +718,7 @@ void irgen::emitAssignArrayWithCopyNoAliasCall(IRGenFunction &IGF, SILType T,
   auto metadata = IGF.emitTypeMetadataRefForLayout(T);
   auto dest = emitCastToOpaquePtr(IGF, destObject);
   auto src = emitCastToOpaquePtr(IGF, srcObject);
-  IGF.Builder.CreateCall(IGF.IGM.getArrayAssignWithCopyNoAliasFn(),
+  IGF.Builder.CreateCall(IGF.IGM.getArrayAssignWithCopyNoAliasFunctionPointer(),
                          {dest, src, count, metadata});
 }
 
@@ -734,8 +731,9 @@ void irgen::emitAssignArrayWithCopyFrontToBackCall(IRGenFunction &IGF,
   auto metadata = IGF.emitTypeMetadataRefForLayout(T);
   auto dest = emitCastToOpaquePtr(IGF, destObject);
   auto src = emitCastToOpaquePtr(IGF, srcObject);
-  IGF.Builder.CreateCall(IGF.IGM.getArrayAssignWithCopyFrontToBackFn(),
-                         {dest, src, count, metadata});
+  IGF.Builder.CreateCall(
+      IGF.IGM.getArrayAssignWithCopyFrontToBackFunctionPointer(),
+      {dest, src, count, metadata});
 }
 
 /// Emit a call to do an 'arrayAssignWithCopyBackToFront' operation.
@@ -747,8 +745,9 @@ void irgen::emitAssignArrayWithCopyBackToFrontCall(IRGenFunction &IGF,
   auto metadata = IGF.emitTypeMetadataRefForLayout(T);
   auto dest = emitCastToOpaquePtr(IGF, destObject);
   auto src = emitCastToOpaquePtr(IGF, srcObject);
-  IGF.Builder.CreateCall(IGF.IGM.getArrayAssignWithCopyBackToFrontFn(),
-                         {dest, src, count, metadata});
+  IGF.Builder.CreateCall(
+      IGF.IGM.getArrayAssignWithCopyBackToFrontFunctionPointer(),
+      {dest, src, count, metadata});
 }
 
 /// Emit a call to do an 'assignWithTake' operation.
@@ -771,7 +770,7 @@ void irgen::emitAssignArrayWithTakeCall(IRGenFunction &IGF, SILType T,
   auto metadata = IGF.emitTypeMetadataRefForLayout(T);
   auto dest = emitCastToOpaquePtr(IGF, destObject);
   auto src = emitCastToOpaquePtr(IGF, srcObject);
-  IGF.Builder.CreateCall(IGF.IGM.getArrayAssignWithTakeFn(),
+  IGF.Builder.CreateCall(IGF.IGM.getArrayAssignWithTakeFunctionPointer(),
                          {dest, src, count, metadata});
 }
 
@@ -786,7 +785,8 @@ void irgen::emitDestroyArrayCall(IRGenFunction &IGF,
 
   auto metadata = IGF.emitTypeMetadataRefForLayout(T);
   auto obj = emitCastToOpaquePtr(IGF, object);
-  IGF.Builder.CreateCall(IGF.IGM.getArrayDestroyFn(), {obj, count, metadata});
+  IGF.Builder.CreateCall(IGF.IGM.getArrayDestroyFunctionPointer(),
+                         {obj, count, metadata});
 }
 
 /// Emit a trampoline to call the getEnumTagSinglePayload witness. API:
@@ -863,8 +863,10 @@ llvm::Value *irgen::emitGetEnumTagSinglePayloadCall(IRGenFunction &IGF,
   }
   auto *metadata = IGF.emitTypeMetadataRefForLayout(T);
   auto *func = getGetEnumTagSinglePayloadTrampolineFn(IGF.IGM);
+  auto *fnType = cast<llvm::Function>(func)->getFunctionType();
   auto dest = emitCastToOpaquePtr(IGF, destObject);
-  auto *result = IGF.Builder.CreateCall(func, {dest, numEmptyCases, metadata});
+  auto *result =
+      IGF.Builder.CreateCall(fnType, func, {dest, numEmptyCases, metadata});
   return result;
 }
 
@@ -882,8 +884,10 @@ void irgen::emitStoreEnumTagSinglePayloadCall(
 
   auto *metadata = IGF.emitTypeMetadataRefForLayout(T);
   auto *func = getStoreEnumTagSinglePayloadTrampolineFn(IGF.IGM);
+  auto *fnType = cast<llvm::Function>(func)->getFunctionType();
   auto dest = emitCastToOpaquePtr(IGF, destObject);
-  IGF.Builder.CreateCall(func, {dest, whichCase, numEmptyCases, metadata});
+  IGF.Builder.CreateCall(fnType, func,
+                         {dest, whichCase, numEmptyCases, metadata});
 }
 
 /// Emit a call to the 'getEnumTag' operation.
@@ -1093,7 +1097,7 @@ static llvm::Constant *getAllocateValueBufferFunction(IRGenModule &IGM) {
       [&](IRGenFunction &IGF) {
         auto it = IGF.CurFn->arg_begin();
         auto *metadata = &*(it++);
-        auto buffer = Address(&*(it++), Alignment(1));
+        auto buffer = Address(&*(it++), IGM.OpaqueTy, Alignment(1));
 
         // Dynamically check whether this type is inline or needs an allocation.
         llvm::Value *isInline, *flags;
@@ -1116,7 +1120,7 @@ static llvm::Constant *getAllocateValueBufferFunction(IRGenModule &IGM) {
               valueAddr, Address(IGF.Builder.CreateBitCast(
                                      buffer.getAddress(),
                                      valueAddr->getType()->getPointerTo()),
-                                 Alignment(1)));
+                                 IGM.Int8PtrTy, Alignment(1)));
           addressOutline =
               IGF.Builder.CreateBitCast(valueAddr, IGM.OpaquePtrTy);
           IGF.Builder.CreateBr(doneBB);
@@ -1136,6 +1140,7 @@ Address irgen::emitAllocateValueInBuffer(IRGenFunction &IGF, SILType type,
   // Handle FixedSize types.
   auto &IGM = IGF.IGM;
   auto storagePtrTy = IGM.getStoragePointerType(type);
+  auto storageTy = IGM.getStorageType(type);
   auto &Builder = IGF.Builder;
   if (auto *fixedTI = dyn_cast<FixedTypeInfo>(&IGF.getTypeInfo(type))) {
     auto packing = fixedTI->getFixedPacking(IGM);
@@ -1143,7 +1148,7 @@ Address irgen::emitAllocateValueInBuffer(IRGenFunction &IGF, SILType type,
     // Inline representation.
     if (packing == FixedPacking::OffsetZero) {
       return Address(Builder.CreateBitCast(buffer.getAddress(), storagePtrTy),
-                     buffer.getAlignment());
+                     storageTy, buffer.getAlignment());
     }
 
     // Outline representation.
@@ -1152,12 +1157,11 @@ Address irgen::emitAllocateValueInBuffer(IRGenFunction &IGF, SILType type,
     auto alignMask = fixedTI->getStaticAlignmentMask(IGM);
     auto valueAddr =
         IGF.emitAllocRawCall(size, alignMask, "outline.ValueBuffer");
-    Builder.CreateStore(
-        valueAddr,
-        Address(Builder.CreateBitCast(buffer.getAddress(),
-                                      valueAddr->getType()->getPointerTo()),
-                buffer.getAlignment()));
-    return Address(Builder.CreateBitCast(valueAddr, storagePtrTy),
+    Builder.CreateStore(valueAddr,
+                        Address(Builder.CreateBitCast(buffer.getAddress(),
+                                                      IGF.IGM.Int8PtrPtrTy),
+                                IGM.Int8PtrTy, buffer.getAlignment()));
+    return Address(Builder.CreateBitCast(valueAddr, storagePtrTy), storageTy,
                    buffer.getAlignment());
   }
 
@@ -1165,15 +1169,16 @@ Address irgen::emitAllocateValueInBuffer(IRGenFunction &IGF, SILType type,
 
   /// Call a function to handle the non-fixed case.
   auto *allocateFun = getAllocateValueBufferFunction(IGF.IGM);
+  auto *fnType = cast<llvm::Function>(allocateFun)->getFunctionType();
   auto *metadata = IGF.emitTypeMetadataRefForLayout(type);
   auto *call = Builder.CreateCall(
-      allocateFun,
+      fnType, allocateFun,
       {metadata, Builder.CreateBitCast(buffer.getAddress(), IGM.OpaquePtrTy)});
   call->setCallingConv(IGF.IGM.DefaultCC);
   call->setDoesNotThrow();
 
   auto addressOfValue = Builder.CreateBitCast(call, storagePtrTy);
-  return Address(addressOfValue, Alignment(1));
+  return Address(addressOfValue, storageTy, Alignment(1));
 }
 
 static llvm::Constant *getProjectValueInBufferFunction(IRGenModule &IGM) {
@@ -1187,7 +1192,7 @@ static llvm::Constant *getProjectValueInBufferFunction(IRGenModule &IGM) {
       [&](IRGenFunction &IGF) {
         auto it = IGF.CurFn->arg_begin();
         auto *metadata = &*(it++);
-        auto buffer = Address(&*(it++), Alignment(1));
+        auto buffer = Address(&*(it++), IGM.OpaqueTy, Alignment(1));
         auto &Builder = IGF.Builder;
 
         // Dynamically check whether this type is inline or needs an allocation.
@@ -1207,7 +1212,7 @@ static llvm::Constant *getProjectValueInBufferFunction(IRGenModule &IGM) {
           addressOutline = Builder.CreateLoad(
               Address(Builder.CreateBitCast(buffer.getAddress(),
                                             IGM.OpaquePtrTy->getPointerTo()),
-                      Alignment(1)));
+                      IGM.OpaquePtrTy, Alignment(1)));
           Builder.CreateBr(doneBB);
         }
 
@@ -1226,6 +1231,7 @@ Address irgen::emitProjectValueInBuffer(IRGenFunction &IGF, SILType type,
   // Handle FixedSize types.
   auto &IGM = IGF.IGM;
   auto storagePtrTy = IGM.getStoragePointerType(type);
+  auto storageTy = IGM.getStorageType(type);
   auto &Builder = IGF.Builder;
   if (auto *fixedTI = dyn_cast<FixedTypeInfo>(&IGF.getTypeInfo(type))) {
     auto packing = fixedTI->getFixedPacking(IGM);
@@ -1233,7 +1239,7 @@ Address irgen::emitProjectValueInBuffer(IRGenFunction &IGF, SILType type,
     // Inline representation.
     if (packing == FixedPacking::OffsetZero) {
       return Address(Builder.CreateBitCast(buffer.getAddress(), storagePtrTy),
-                     buffer.getAlignment());
+                     storageTy, buffer.getAlignment());
     }
 
     // Outline representation.
@@ -1241,22 +1247,23 @@ Address irgen::emitProjectValueInBuffer(IRGenFunction &IGF, SILType type,
     auto valueAddr = Builder.CreateLoad(
         Address(Builder.CreateBitCast(buffer.getAddress(),
                                       storagePtrTy->getPointerTo()),
-                buffer.getAlignment()));
-    return Address(Builder.CreateBitCast(valueAddr, storagePtrTy),
+                storagePtrTy, buffer.getAlignment()));
+    return Address(Builder.CreateBitCast(valueAddr, storagePtrTy), storageTy,
                    buffer.getAlignment());
   }
 
   // Dynamic packing.
   auto *projectFun = getProjectValueInBufferFunction(IGF.IGM);
+  auto *fnType = cast<llvm::Function>(projectFun)->getFunctionType();
   auto *metadata = IGF.emitTypeMetadataRefForLayout(type);
   auto *call = Builder.CreateCall(
-      projectFun,
+      fnType, projectFun,
       {metadata, Builder.CreateBitCast(buffer.getAddress(), IGM.OpaquePtrTy)});
   call->setCallingConv(IGF.IGM.DefaultCC);
   call->setDoesNotThrow();
 
   auto addressOfValue = Builder.CreateBitCast(call, storagePtrTy);
-  return Address(addressOfValue, Alignment(1));
+  return Address(addressOfValue, storageTy, Alignment(1));
 }
 
 llvm::Value *
@@ -1281,7 +1288,7 @@ irgen::emitGetEnumTagSinglePayloadGenericCall(IRGenFunction &IGF,
                                        IGF.IGM.OpaquePtrTy);
 
   auto getEnumTagGenericFn =
-    IGF.IGM.getGetEnumTagSinglePayloadGenericFn();
+      IGF.IGM.getGetEnumTagSinglePayloadGenericFunctionPointer();
   auto call = IGF.Builder.CreateCall(getEnumTagGenericFn,
                                      {ptr,
                                       numExtraCases,
@@ -1313,6 +1320,8 @@ irgen::getOrCreateGetExtraInhabitantTagFunction(IRGenModule &IGM,
   fn->setAttributes(IGM.constructInitialAttributes());
   fn->setCallingConv(IGM.SwiftCC);
   IRGenFunction IGF(IGM, fn);
+  if (IGM.DebugInfo)
+    IGM.DebugInfo->emitArtificialFunction(IGF, fn);
   auto parameters = IGF.collectParameters();
   auto ptr = parameters.claimNext();
   auto xiCount = parameters.claimNext();
@@ -1356,7 +1365,7 @@ irgen::emitStoreEnumTagSinglePayloadGenericCall(IRGenFunction &IGF,
                                        IGF.IGM.OpaquePtrTy);
 
   auto storeEnumTagGenericFn =
-    IGF.IGM.getStoreEnumTagSinglePayloadGenericFn();
+      IGF.IGM.getStoreEnumTagSinglePayloadGenericFunctionPointer();
   auto call = IGF.Builder.CreateCall(storeEnumTagGenericFn,
                                      {ptr,
                                       whichCase,
@@ -1389,6 +1398,8 @@ irgen::getOrCreateStoreExtraInhabitantTagFunction(IRGenModule &IGM,
   fn->setAttributes(IGM.constructInitialAttributes());
   fn->setCallingConv(IGM.SwiftCC);
   IRGenFunction IGF(IGM, fn);
+  if (IGM.DebugInfo)
+    IGM.DebugInfo->emitArtificialFunction(IGF, fn);
   auto parameters = IGF.collectParameters();
   auto ptr = parameters.claimNext();
   auto tag = parameters.claimNext();

--- a/lib/IRGen/GenPointerAuth.cpp
+++ b/lib/IRGen/GenPointerAuth.cpp
@@ -48,9 +48,8 @@ llvm::Value *irgen::emitPointerAuthBlend(IRGenFunction &IGF,
                                          llvm::Value *address,
                                          llvm::Value *other) {
   address = IGF.Builder.CreatePtrToInt(address, IGF.IGM.Int64Ty);
-  auto intrinsic = llvm::Intrinsic::getDeclaration(
-      &IGF.IGM.Module, llvm::Intrinsic::ptrauth_blend);
-  return IGF.Builder.CreateCall(intrinsic, {address, other});
+  return IGF.Builder.CreateIntrinsicCall(llvm::Intrinsic::ptrauth_blend,
+                                         {address, other});
 }
 
 llvm::Value *irgen::emitPointerAuthStrip(IRGenFunction &IGF,
@@ -58,9 +57,8 @@ llvm::Value *irgen::emitPointerAuthStrip(IRGenFunction &IGF,
                                           unsigned Key) {
   auto fnVal = IGF.Builder.CreatePtrToInt(fnPtr, IGF.IGM.Int64Ty);
   auto keyArg = llvm::ConstantInt::get(IGF.IGM.Int32Ty, Key);
-  auto intrinsic = llvm::Intrinsic::getDeclaration(
-      &IGF.IGM.Module, llvm::Intrinsic::ptrauth_strip);
-  auto strippedPtr = IGF.Builder.CreateCall(intrinsic, {fnVal, keyArg});
+  auto strippedPtr = IGF.Builder.CreateIntrinsicCall(
+      llvm::Intrinsic::ptrauth_strip, {fnVal, keyArg});
   return IGF.Builder.CreateIntToPtr(strippedPtr, fnPtr->getType());
 }
 
@@ -69,7 +67,8 @@ FunctionPointer irgen::emitPointerAuthResign(IRGenFunction &IGF,
                                           const PointerAuthInfo &newAuthInfo) {
   llvm::Value *fnPtr = emitPointerAuthResign(IGF, fn.getRawPointer(),
                                              fn.getAuthInfo(), newAuthInfo);
-  return FunctionPointer(fn.getKind(), fnPtr, newAuthInfo, fn.getSignature());
+  return FunctionPointer::createSigned(fn.getKind(), fnPtr, newAuthInfo,
+                                       fn.getSignature());
 }
 
 llvm::Value *irgen::emitPointerAuthResign(IRGenFunction &IGF,
@@ -97,12 +96,11 @@ llvm::Value *irgen::emitPointerAuthResign(IRGenFunction &IGF,
   auto oldPair = getPointerAuthPair(IGF, oldAuthInfo);
   auto newPair = getPointerAuthPair(IGF, newAuthInfo);
 
-  auto intrinsic = llvm::Intrinsic::getDeclaration(
-      &IGF.IGM.Module, llvm::Intrinsic::ptrauth_resign);
   llvm::Value *args[] = {
     fnPtr, oldPair.first, oldPair.second, newPair.first, newPair.second
   };
-  fnPtr = IGF.Builder.CreateCall(intrinsic, args);
+  fnPtr =
+      IGF.Builder.CreateIntrinsicCall(llvm::Intrinsic::ptrauth_resign, args);
   return IGF.Builder.CreateIntToPtr(fnPtr, origTy);
 }
 
@@ -113,12 +111,10 @@ llvm::Value *irgen::emitPointerAuthAuth(IRGenFunction &IGF, llvm::Value *fnPtr,
 
   auto oldPair = getPointerAuthPair(IGF, oldAuthInfo);
 
-  auto intrinsic = llvm::Intrinsic::getDeclaration(
-      &IGF.IGM.Module, llvm::Intrinsic::ptrauth_auth);
   llvm::Value *args[] = {
     fnPtr, oldPair.first, oldPair.second
   };
-  fnPtr = IGF.Builder.CreateCall(intrinsic, args);
+  fnPtr = IGF.Builder.CreateIntrinsicCall(llvm::Intrinsic::ptrauth_auth, args);
   return IGF.Builder.CreateIntToPtr(fnPtr, origTy);
 }
 
@@ -147,12 +143,10 @@ llvm::Value *irgen::emitPointerAuthSign(IRGenFunction &IGF, llvm::Value *fnPtr,
 
   auto newPair = getPointerAuthPair(IGF, newAuthInfo);
 
-  auto intrinsic = llvm::Intrinsic::getDeclaration(
-      &IGF.IGM.Module, llvm::Intrinsic::ptrauth_sign);
   llvm::Value *args[] = {
     fnPtr, newPair.first, newPair.second
   };
-  fnPtr = IGF.Builder.CreateCall(intrinsic, args);
+  fnPtr = IGF.Builder.CreateIntrinsicCall(llvm::Intrinsic::ptrauth_sign, args);
   return IGF.Builder.CreateIntToPtr(fnPtr, origTy);
 }
 

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -264,10 +264,10 @@ getTypeRefByFunction(IRGenModule &IGM,
           ? genericEnv->mapTypeIntoContext(t)->getCanonicalType()
           : t;
 
-        bindFromGenericRequirementsBuffer(IGF, requirements,
-            Address(bindingsBufPtr, IGM.getPointerAlignment()),
-            MetadataState::Complete,
-            [&](CanType t) {
+        bindFromGenericRequirementsBuffer(
+            IGF, requirements,
+            Address(bindingsBufPtr, IGM.Int8Ty, IGM.getPointerAlignment()),
+            MetadataState::Complete, [&](CanType t) {
               return genericEnv
                 ? genericEnv->mapTypeIntoContext(t)->getCanonicalType()
                 : t;
@@ -421,10 +421,10 @@ IRGenModule::emitWitnessTableRefString(CanType type,
           if (type->hasTypeParameter()) {
             auto bindingsBufPtr = IGF.collectParameters().claimNext();
 
-            bindFromGenericRequirementsBuffer(IGF, requirements,
-                Address(bindingsBufPtr, getPointerAlignment()),
-                MetadataState::Complete,
-                [&](CanType t) {
+            bindFromGenericRequirementsBuffer(
+                IGF, requirements,
+                Address(bindingsBufPtr, Int8Ty, getPointerAlignment()),
+                MetadataState::Complete, [&](CanType t) {
                   return genericEnv->mapTypeIntoContext(t)->getCanonicalType();
                 });
 
@@ -513,8 +513,7 @@ llvm::Constant *IRGenModule::getMangledAssociatedConformance(
   // Set the low bit.
   unsigned bit = ProtocolRequirementFlags::AssociatedTypeMangledNameBit;
   auto bitConstant = llvm::ConstantInt::get(IntPtrTy, bit);
-  addr = llvm::ConstantExpr::getGetElementPtr(
-    addr->getType()->getPointerElementType(), addr, bitConstant);
+  addr = llvm::ConstantExpr::getGetElementPtr(Int8Ty, addr, bitConstant);
 
   // Update the entry.
   entry = {var, addr};

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -297,16 +297,13 @@ namespace {
           auto metadataBytes =
             IGF.Builder.CreateBitCast(metadata, IGF.IGM.Int8PtrTy);
           auto fieldOffsetPtr = IGF.Builder.CreateInBoundsGEP(
-              metadataBytes->getType()
-                  ->getScalarType()
-                  ->getPointerElementType(),
-              metadataBytes,
+              IGF.IGM.Int8Ty, metadataBytes,
               IGF.IGM.getSize(scanner.FieldOffset - scanner.AddressPoint));
           fieldOffsetPtr =
             IGF.Builder.CreateBitCast(fieldOffsetPtr,
                                       IGF.IGM.Int32Ty->getPointerTo());
-          llvm::Value *fieldOffset =
-            IGF.Builder.CreateLoad(fieldOffsetPtr, Alignment(4));
+          llvm::Value *fieldOffset = IGF.Builder.CreateLoad(
+              Address(fieldOffsetPtr, IGF.IGM.Int32Ty, Alignment(4)));
           fieldOffset = IGF.Builder.CreateZExtOrBitCast(fieldOffset,
                                                         IGF.IGM.SizeTy);
 
@@ -619,7 +616,7 @@ namespace {
                              IGF.IGM.DataLayout);
       src = IGF.coerceValue(src, callee->getFunctionType()->getParamType(1),
                             IGF.IGM.DataLayout);
-      IGF.Builder.CreateCall(callee, {dest, src});
+      IGF.Builder.CreateCall(callee->getFunctionType(), callee, {dest, src});
     }
 
   public:
@@ -1472,7 +1469,7 @@ namespace {
 
 const TypeInfo *
 TypeConverter::convertResilientStruct(IsABIAccessible_t abiAccessible) {
-  llvm::Type *storageType = IGM.OpaquePtrTy->getPointerElementType();
+  llvm::Type *storageType = IGM.OpaqueTy;
   return new ResilientStructTypeInfo(storageType, abiAccessible);
 }
 

--- a/lib/IRGen/GenTuple.cpp
+++ b/lib/IRGen/GenTuple.cpp
@@ -83,13 +83,12 @@ namespace {
       IGF.IGM.getSize(Size(index)),               //     [index]
       llvm::ConstantInt::get(IGF.IGM.Int32Ty, 1)  //       .Offset
     };
-    auto slot = IGF.Builder.CreateInBoundsGEP(
-        asTuple->getType()->getScalarType()->getPointerElementType(), asTuple,
-        indices);
+    auto slot = IGF.Builder.CreateInBoundsGEP(IGF.IGM.TupleTypeMetadataTy,
+                                              asTuple, indices);
 
-    return IGF.Builder.CreateLoad(slot, IGF.IGM.getPointerAlignment(),
-                                  metadata->getName()
-                                    + "." + Twine(index) + ".offset");
+    return IGF.Builder.CreateLoad(
+        slot, IGF.IGM.Int32Ty, IGF.IGM.getPointerAlignment(),
+        metadata->getName() + "." + Twine(index) + ".offset");
   }
 
   /// Adapter for tuple types.

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -112,13 +112,14 @@ TypeInfo::~TypeInfo() {
 }
 
 Address TypeInfo::getAddressForPointer(llvm::Value *ptr) const {
-  assert(ptr->getType()->getPointerElementType() == StorageType);
-  return Address(ptr, getBestKnownAlignment());
+  assert(cast<llvm::PointerType>(ptr->getType())
+             ->isOpaqueOrPointeeTypeMatches(getStorageType()));
+  return Address(ptr, getStorageType(), getBestKnownAlignment());
 }
 
 Address TypeInfo::getUndefAddress() const {
   return Address(llvm::UndefValue::get(getStorageType()->getPointerTo(0)),
-                 getBestKnownAlignment());
+                 getStorageType(), getBestKnownAlignment());
 }
 
 /// Whether this type is known to be empty.
@@ -321,7 +322,7 @@ FixedTypeInfo::getSpareBitExtraInhabitantIndex(IRGenFunction &IGF,
   
   // Load the value.
   auto payloadTy = llvm::IntegerType::get(C, getFixedSize().getValueInBits());
-  src = IGF.Builder.CreateBitCast(src, payloadTy->getPointerTo());
+  src = IGF.Builder.CreateElementBitCast(src, payloadTy);
   auto val = IGF.Builder.CreateLoad(src);
   
   // If the spare bits are all zero, then we have a valid value and not an
@@ -505,7 +506,7 @@ static llvm::Value *emitLoadBytes(IRGenFunction &IGF, Address from,
         }
         // Generate a load of size bytes and zero-extend it to 32-bits.
         auto *type = B.getIntNTy(s.getValueInBits());
-        Address addr = B.CreateBitCast(from, type->getPointerTo());
+        Address addr = B.CreateElementBitCast(from, type);
         auto *val = B.CreateZExtOrTrunc(B.CreateLoad(addr), B.getInt32Ty());
         phi->addIncoming(val, B.GetInsertBlock());
       },
@@ -557,7 +558,7 @@ static void emitStoreBytes(IRGenFunction &IGF, Address to, llvm::Value *val,
         // Store value truncated to size bytes.
         auto *type = B.getIntNTy(s.getValueInBits());
         auto *trunc = B.CreateZExtOrTrunc(val, type);
-        Address addr = B.CreateBitCast(to, type->getPointerTo());
+        Address addr = B.CreateElementBitCast(to, type);
         B.CreateStore(trunc, addr);
       },
       size,
@@ -667,9 +668,9 @@ llvm::Value *irgen::getFixedTypeEnumTagSinglePayload(
   auto *extraTagBitsAddr =
       Builder.CreateConstInBoundsGEP1_32(IGM.Int8Ty, valueAddr,
           fixedSize.getValue());
-  auto *extraTagBits = emitGetTag(IGF,
-      Address(extraTagBitsAddr, Alignment(1)),
-      numExtraTagBytes);
+  auto *extraTagBits =
+      emitGetTag(IGF, Address(extraTagBitsAddr, IGM.Int8Ty, Alignment(1)),
+                 numExtraTagBytes);
 
   extraTagBitsBB = llvm::BasicBlock::Create(Ctx);
   Builder.CreateCondBr(Builder.CreateICmpEQ(extraTagBits, zero),
@@ -698,14 +699,16 @@ llvm::Value *irgen::getFixedTypeEnumTagSinglePayload(
       auto *caseIndexAddr =
           Builder.CreateBitCast(valueAddr, caseIndexType->getPointerTo());
       caseIndexFromValue = Builder.CreateZExtOrTrunc(
-          Builder.CreateLoad(Address(caseIndexAddr, Alignment(1))),
+          Builder.CreateLoad(
+              Address(caseIndexAddr, caseIndexType, Alignment(1))),
           IGM.Int32Ty);
     } else {
       auto *caseIndexType = llvm::IntegerType::get(Ctx, 32);
       auto *caseIndexAddr =
           Builder.CreateBitCast(valueAddr, caseIndexType->getPointerTo());
       caseIndexFromValue = Builder.CreateZExtOrTrunc(
-          Builder.CreateLoad(Address(caseIndexAddr, Alignment(1))),
+          Builder.CreateLoad(
+              Address(caseIndexAddr, caseIndexType, Alignment(1))),
           IGM.Int32Ty);
     }
   }
@@ -882,16 +885,14 @@ void irgen::storeFixedTypeEnumTagSinglePayload(
     if (fixedSize.getValueInBits() <= llvm::IntegerType::MAX_INT_BITS / 4) {
       // Write the value to the payload as a zero extended integer.
       auto *intType = Builder.getIntNTy(fixedSize.getValueInBits());
-      Builder.CreateStore(
-          Builder.CreateZExtOrTrunc(payloadIndex, intType),
-          Builder.CreateBitCast(valueAddr, intType->getPointerTo()));
+      Builder.CreateStore(Builder.CreateZExtOrTrunc(payloadIndex, intType),
+                          Builder.CreateElementBitCast(valueAddr, intType));
     } else {
       // Write the value to the payload as a zero extended integer.
       Size limit = IGM.getPointerSize();
       auto *intType = Builder.getIntNTy(limit.getValueInBits());
-      Builder.CreateStore(
-          Builder.CreateZExtOrTrunc(payloadIndex, intType),
-          Builder.CreateBitCast(valueAddr, intType->getPointerTo()));
+      Builder.CreateStore(Builder.CreateZExtOrTrunc(payloadIndex, intType),
+                          Builder.CreateElementBitCast(valueAddr, intType));
       // Zero the remainder of the payload.
       auto zeroAddr = Builder.CreateConstByteArrayGEP(valueAddr, limit);
       auto zeroSize = Builder.CreateSub(
@@ -952,8 +953,8 @@ FixedTypeInfo::storeSpareBitExtraInhabitant(IRGenFunction &IGF,
   
   // Combine the values and store to the destination.
   llvm::Value *inhabitant = IGF.Builder.CreateOr(occupied, spare);
-  
-  dest = IGF.Builder.CreateBitCast(dest, payloadTy->getPointerTo());
+
+  dest = IGF.Builder.CreateElementBitCast(dest, payloadTy);
   IGF.Builder.CreateStore(inhabitant, dest);
 }
 
@@ -1092,7 +1093,7 @@ namespace {
                                          SILType T,
                                          bool isOutlined) const override {
       // Copied from BridgeObjectTypeInfo.
-      src = IGF.Builder.CreateBitCast(src, IGF.IGM.IntPtrTy->getPointerTo());
+      src = IGF.Builder.CreateElementBitCast(src, IGF.IGM.IntPtrTy);
       auto val = IGF.Builder.CreateLoad(src);
       auto zero = llvm::ConstantInt::get(IGF.IGM.IntPtrTy, 0);
       auto isNonzero = IGF.Builder.CreateICmpNE(val, zero);
@@ -1106,7 +1107,7 @@ namespace {
                               bool isOutlined) const override {
       // Copied from BridgeObjectTypeInfo.
       // There's only one extra inhabitant, 0.
-      dest = IGF.Builder.CreateBitCast(dest, IGF.IGM.IntPtrTy->getPointerTo());
+      dest = IGF.Builder.CreateElementBitCast(dest, IGF.IGM.IntPtrTy);
       IGF.Builder.CreateStore(llvm::ConstantInt::get(IGF.IGM.IntPtrTy, 0),dest);
     }
   };

--- a/lib/IRGen/GenType.h
+++ b/lib/IRGen/GenType.h
@@ -319,7 +319,7 @@ SILType getSingletonAggregateFieldType(IRGenModule &IGM,
 /// An IRGenFunction interface for generating type layout verifiers.
 class IRGenTypeVerifierFunction : public IRGenFunction {
 private:
-  llvm::Constant *VerifierFn;
+  FunctionPointer VerifierFn;
 
   struct VerifierArgumentBuffers {
     Address runtimeBuf, staticBuf;

--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -241,7 +241,7 @@ static Address emitDefaultProjectBuffer(IRGenFunction &IGF, Address buffer,
     Address boxAddress(
         Builder.CreateBitCast(buffer.getAddress(),
                               IGM.RefCountedPtrTy->getPointerTo()),
-        buffer.getAlignment());
+        IGM.RefCountedPtrTy, buffer.getAlignment());
     auto *boxStart = IGF.Builder.CreateLoad(boxAddress);
     auto *alignmentMask = type.getAlignmentMask(IGF, T);
     auto *heapHeaderSize = llvm::ConstantInt::get(
@@ -257,7 +257,8 @@ static Address emitDefaultProjectBuffer(IRGenFunction &IGF, Address buffer,
   }
 
   case FixedPacking::OffsetZero: {
-    return IGF.Builder.CreateBitCast(buffer, resultTy, "object");
+    return IGF.Builder.CreateElementBitCast(buffer, type.getStorageType(),
+                                            "object");
   }
 
   case FixedPacking::Dynamic:
@@ -281,7 +282,7 @@ static Address emitDefaultAllocateBuffer(IRGenFunction &IGF, Address buffer,
     IGF.Builder.CreateStore(
         box, Address(IGF.Builder.CreateBitCast(buffer.getAddress(),
                                                box->getType()->getPointerTo()),
-                     buffer.getAlignment()));
+                     IGF.IGM.RefCountedPtrTy, buffer.getAlignment()));
 
     llvm::PointerType *resultTy = type.getStorageType()->getPointerTo();
     address = IGF.Builder.CreateBitCast(address, resultTy);
@@ -322,11 +323,12 @@ static Address emitDefaultInitializeBufferWithCopyOfBuffer(
         destBuffer.getAddress(), IGF.IGM.RefCountedPtrTy->getPointerTo());
     auto *srcReferenceAddr = IGF.Builder.CreateBitCast(
         srcBuffer.getAddress(), IGF.IGM.RefCountedPtrTy->getPointerTo());
-    auto *srcReference =
-        IGF.Builder.CreateLoad(srcReferenceAddr, srcBuffer.getAlignment());
+    auto *srcReference = IGF.Builder.CreateLoad(Address(
+        srcReferenceAddr, IGF.IGM.RefCountedPtrTy, srcBuffer.getAlignment()));
     IGF.emitNativeStrongRetain(srcReference, IGF.getDefaultAtomicity());
-    IGF.Builder.CreateStore(
-        srcReference, Address(destReferenceAddr, destBuffer.getAlignment()));
+    IGF.Builder.CreateStore(srcReference,
+                            Address(destReferenceAddr, IGF.IGM.RefCountedPtrTy,
+                                    destBuffer.getAlignment()));
     return emitDefaultProjectBuffer(IGF, destBuffer, T, type, packing);
   }
 }
@@ -377,7 +379,8 @@ static Address getArgAsBuffer(IRGenFunction &IGF,
                               llvm::Function::arg_iterator &it,
                               StringRef name) {
   llvm::Value *arg = getArg(it, name);
-  return Address(arg, getFixedBufferAlignment(IGF.IGM));
+  return Address(arg, IGF.IGM.getFixedBufferTy(),
+                 getFixedBufferAlignment(IGF.IGM));
 }
 
 static CanType getFormalTypeInContext(CanType abstractType, DeclContext *dc) {
@@ -486,7 +489,7 @@ static void buildValueWitnessFunction(IRGenModule &IGM,
     } else {
       type.assignWithCopy(IGF, dest, src, concreteType, true);
     }
-    dest = IGF.Builder.CreateBitCast(dest, IGF.IGM.OpaquePtrTy);
+    dest = IGF.Builder.CreateElementBitCast(dest, IGF.IGM.OpaqueTy);
     IGF.Builder.CreateRet(dest.getAddress());
     return;
   }
@@ -501,7 +504,7 @@ static void buildValueWitnessFunction(IRGenModule &IGM,
     } else {
       type.assignWithTake(IGF, dest, src, concreteType, true);
     }
-    dest = IGF.Builder.CreateBitCast(dest, IGF.IGM.OpaquePtrTy);
+    dest = IGF.Builder.CreateElementBitCast(dest, IGF.IGM.OpaqueTy);
     IGF.Builder.CreateRet(dest.getAddress());
     return;
   }
@@ -531,7 +534,7 @@ static void buildValueWitnessFunction(IRGenModule &IGM,
     } else {
       Address result = emitInitializeBufferWithCopyOfBuffer(
           IGF, dest, src, concreteType, type, packing);
-      result = IGF.Builder.CreateBitCast(result, IGF.IGM.OpaquePtrTy);
+      result = IGF.Builder.CreateElementBitCast(result, IGF.IGM.OpaqueTy);
       objectPtr = result.getAddress();
     }
     IGF.Builder.CreateRet(objectPtr);
@@ -548,7 +551,7 @@ static void buildValueWitnessFunction(IRGenModule &IGM,
     } else {
       type.initializeWithCopy(IGF, dest, src, concreteType, true);
     }
-    dest = IGF.Builder.CreateBitCast(dest, IGF.IGM.OpaquePtrTy);
+    dest = IGF.Builder.CreateElementBitCast(dest, IGF.IGM.OpaqueTy);
     IGF.Builder.CreateRet(dest.getAddress());
     return;
   }
@@ -564,7 +567,7 @@ static void buildValueWitnessFunction(IRGenModule &IGM,
     } else {
       type.initializeWithTake(IGF, dest, src, concreteType, true);
     }
-    dest = IGF.Builder.CreateBitCast(dest, IGF.IGM.OpaquePtrTy);
+    dest = IGF.Builder.CreateElementBitCast(dest, IGF.IGM.OpaqueTy);
     IGF.Builder.CreateRet(dest.getAddress());
     return;
   }
@@ -600,10 +603,11 @@ static void buildValueWitnessFunction(IRGenModule &IGM,
       if (auto *enumTypeLayoutEntry =
               conditionallyGetEnumTypeLayoutEntry(IGM, concreteType)) {
         enumTypeLayoutEntry->destructiveProjectEnumData(
-            IGF, Address(value, type.getBestKnownAlignment()));
+            IGF, Address(value, IGM.OpaqueTy, type.getBestKnownAlignment()));
       } else {
         strategy.destructiveProjectDataForLoad(
-            IGF, concreteType, Address(value, type.getBestKnownAlignment()));
+            IGF, concreteType,
+            Address(value, IGM.OpaqueTy, type.getBestKnownAlignment()));
       }
     }
 
@@ -625,10 +629,13 @@ static void buildValueWitnessFunction(IRGenModule &IGM,
     if (auto *enumTypeLayoutEntry =
             conditionallyGetEnumTypeLayoutEntry(IGM, concreteType)) {
       enumTypeLayoutEntry->destructiveInjectEnumTag(
-          IGF, tag, Address(value, type.getBestKnownAlignment()));
+          IGF, tag,
+          Address(value, type.getStorageType(), type.getBestKnownAlignment()));
     } else {
-      strategy.emitStoreTag(IGF, concreteType,
-                            Address(value, type.getBestKnownAlignment()), tag);
+      strategy.emitStoreTag(
+          IGF, concreteType,
+          Address(value, type.getStorageType(), type.getBestKnownAlignment()),
+          tag);
     }
 
     IGF.Builder.CreateRetVoid();
@@ -646,11 +653,13 @@ static void buildValueWitnessFunction(IRGenModule &IGM,
     if (auto *typeLayoutEntry =
             conditionallyGetTypeLayoutEntry(IGM, concreteType)) {
       auto *idx = typeLayoutEntry->getEnumTagSinglePayload(
-          IGF, numEmptyCases, Address(value, type.getBestKnownAlignment()));
+          IGF, numEmptyCases,
+          Address(value, type.getStorageType(), type.getBestKnownAlignment()));
       IGF.Builder.CreateRet(idx);
     } else {
       llvm::Value *idx = type.getEnumTagSinglePayload(
-          IGF, numEmptyCases, Address(value, type.getBestKnownAlignment()),
+          IGF, numEmptyCases,
+          Address(value, type.getStorageType(), type.getBestKnownAlignment()),
           concreteType, true);
       IGF.Builder.CreateRet(idx);
     }
@@ -671,11 +680,12 @@ static void buildValueWitnessFunction(IRGenModule &IGM,
             conditionallyGetTypeLayoutEntry(IGM, concreteType)) {
       typeLayoutEntry->storeEnumTagSinglePayload(
           IGF, whichCase, numEmptyCases,
-          Address(value, type.getBestKnownAlignment()));
+          Address(value, type.getStorageType(), type.getBestKnownAlignment()));
     } else {
       type.storeEnumTagSinglePayload(
           IGF, whichCase, numEmptyCases,
-          Address(value, type.getBestKnownAlignment()), concreteType, true);
+          Address(value, type.getStorageType(), type.getBestKnownAlignment()),
+          concreteType, true);
     }
     IGF.Builder.CreateRetVoid();
     return;
@@ -712,8 +722,8 @@ static llvm::Constant *getAssignWithCopyStrongFunction(IRGenModule &IGM) {
                                        ptrPtrTy, argTys,
                                        [&](IRGenFunction &IGF) {
     auto it = IGF.CurFn->arg_begin();
-    Address dest(&*(it++), IGM.getPointerAlignment());
-    Address src(&*(it++), IGM.getPointerAlignment());
+    Address dest(&*(it++), IGM.RefCountedPtrTy, IGM.getPointerAlignment());
+    Address src(&*(it++), IGM.RefCountedPtrTy, IGM.getPointerAlignment());
 
     llvm::Value *newValue = IGF.Builder.CreateLoad(src, "new");
     IGF.emitNativeStrongRetain(newValue, IGF.getDefaultAtomicity());
@@ -736,8 +746,8 @@ static llvm::Constant *getAssignWithTakeStrongFunction(IRGenModule &IGM) {
                                        ptrPtrTy, argTys,
                                        [&](IRGenFunction &IGF) {
     auto it = IGF.CurFn->arg_begin();
-    Address dest(&*(it++), IGM.getPointerAlignment());
-    Address src(&*(it++), IGM.getPointerAlignment());
+    Address dest(&*(it++), IGM.RefCountedPtrTy, IGM.getPointerAlignment());
+    Address src(&*(it++), IGM.RefCountedPtrTy, IGM.getPointerAlignment());
 
     llvm::Value *newValue = IGF.Builder.CreateLoad(src, "new");
     llvm::Value *oldValue = IGF.Builder.CreateLoad(dest, "old");
@@ -758,8 +768,8 @@ static llvm::Constant *getInitWithCopyStrongFunction(IRGenModule &IGM) {
                                        ptrPtrTy, argTys,
                                        [&](IRGenFunction &IGF) {
     auto it = IGF.CurFn->arg_begin();
-    Address dest(&*(it++), IGM.getPointerAlignment());
-    Address src(&*(it++), IGM.getPointerAlignment());
+    Address dest(&*(it++), IGM.RefCountedPtrTy, IGM.getPointerAlignment());
+    Address src(&*(it++), IGM.RefCountedPtrTy, IGM.getPointerAlignment());
 
     llvm::Value *newValue = IGF.Builder.CreateLoad(src, "new");
     IGF.emitNativeStrongRetain(newValue, IGF.getDefaultAtomicity());
@@ -773,13 +783,14 @@ static llvm::Constant *getInitWithCopyStrongFunction(IRGenModule &IGM) {
 /// pointer from the first, and calls swift_release on it immediately.
 static llvm::Constant *getDestroyStrongFunction(IRGenModule &IGM) {
   llvm::Type *argTys[] = { IGM.Int8PtrPtrTy, IGM.WitnessTablePtrTy };
-  return IGM.getOrCreateHelperFunction("__swift_destroy_strong",
-                                       IGM.VoidTy, argTys,
-                                       [&](IRGenFunction &IGF) {
-    Address arg(&*IGF.CurFn->arg_begin(), IGM.getPointerAlignment());
-    IGF.emitNativeStrongRelease(IGF.Builder.CreateLoad(arg), IGF.getDefaultAtomicity());
-    IGF.Builder.CreateRetVoid();
-  });
+  return IGM.getOrCreateHelperFunction(
+      "__swift_destroy_strong", IGM.VoidTy, argTys, [&](IRGenFunction &IGF) {
+        Address arg(&*IGF.CurFn->arg_begin(), IGM.Int8PtrTy,
+                    IGM.getPointerAlignment());
+        IGF.emitNativeStrongRelease(IGF.Builder.CreateLoad(arg),
+                                    IGF.getDefaultAtomicity());
+        IGF.Builder.CreateRetVoid();
+      });
 }
 
 /// Return a function which takes two pointer arguments, memcpys
@@ -809,8 +820,8 @@ static llvm::Constant *getMemCpyFunction(IRGenModule &IGM,
   return IGM.getOrCreateHelperFunction(name, IGM.Int8PtrTy, argTys,
                                        [&](IRGenFunction &IGF) {
     auto it = IGF.CurFn->arg_begin();
-    Address dest(&*it++, fixedTI->getFixedAlignment());
-    Address src(&*it++, fixedTI->getFixedAlignment());
+    Address dest(&*it++, IGM.Int8Ty, fixedTI->getFixedAlignment());
+    Address src(&*it++, IGM.Int8Ty, fixedTI->getFixedAlignment());
     IGF.emitMemCpy(dest, src, fixedTI->getFixedSize());
     IGF.Builder.CreateRet(dest.getAddress());
   });
@@ -1369,15 +1380,13 @@ Address TypeInfo::indexArray(IRGenFunction &IGF, Address base,
     if (size->getType() != index->getType())
       size = IGF.Builder.CreateZExtOrTrunc(size, index->getType());
     llvm::Value *distance = IGF.Builder.CreateNSWMul(index, size);
-    destValue = IGF.Builder.CreateInBoundsGEP(
-        byteAddr->getType()->getScalarType()->getPointerElementType(), byteAddr,
-        distance);
+    destValue =
+        IGF.Builder.CreateInBoundsGEP(IGF.IGM.Int8Ty, byteAddr, distance);
     destValue = IGF.Builder.CreateBitCast(destValue, base.getType());
   } else {
     // We don't expose a non-inbounds GEP operation.
-    destValue = IGF.Builder.CreateInBoundsGEP(
-        base.getAddress()->getType()->getScalarType()->getPointerElementType(),
-        base.getAddress(), index);
+    destValue = IGF.Builder.CreateInBoundsGEP(getStorageType(),
+                                              base.getAddress(), index);
     stride = fixedTI->getFixedStride();
   }
   if (auto *IndexConst = dyn_cast<llvm::ConstantInt>(index)) {
@@ -1387,7 +1396,7 @@ Address TypeInfo::indexArray(IRGenFunction &IGF, Address base,
     stride *= IndexConst->getValue().getZExtValue();
   }
   Alignment Align = base.getAlignment().alignmentAtOffset(stride);
-  return Address(destValue, Align);
+  return Address(destValue, getStorageType(), Align);
 }
 
 Address TypeInfo::roundUpToTypeAlignment(IRGenFunction &IGF, Address base,
@@ -1406,8 +1415,8 @@ Address TypeInfo::roundUpToTypeAlignment(IRGenFunction &IGF, Address base,
   Addr = IGF.Builder.CreateNUWAdd(Addr, TyAlignMask);
   llvm::Value *InvertedMask = IGF.Builder.CreateNot(TyAlignMask);
   Addr = IGF.Builder.CreateAnd(Addr, InvertedMask);
-  Addr = IGF.Builder.CreateIntToPtr(Addr, base.getAddress()->getType());
-  return Address(Addr, Align);
+  Addr = IGF.Builder.CreateIntToPtr(Addr, getStorageType()->getPointerTo());
+  return Address(Addr, getStorageType(), Align);
 }
 
 void TypeInfo::destroyArray(IRGenFunction &IGF, Address array,

--- a/lib/IRGen/IRGenFunction.cpp
+++ b/lib/IRGen/IRGenFunction.cpp
@@ -120,9 +120,8 @@ void IRGenFunction::emitMemCpy(Address dest, Address src, llvm::Value *size) {
              std::min(dest.getAlignment(), src.getAlignment()));
 }
 
-static llvm::Value *emitAllocatingCall(IRGenFunction &IGF,
-                                       llvm::Constant *fn,
-                                       ArrayRef<llvm::Value*> args,
+static llvm::Value *emitAllocatingCall(IRGenFunction &IGF, FunctionPointer fn,
+                                       ArrayRef<llvm::Value *> args,
                                        const llvm::Twine &name) {
   auto allocAttrs = IGF.IGM.getAllocAttrs();
   llvm::CallInst *call =
@@ -137,9 +136,8 @@ llvm::Value *IRGenFunction::emitAllocRawCall(llvm::Value *size,
                                              llvm::Value *alignMask,
                                              const llvm::Twine &name) {
   // For now, all we have is swift_slowAlloc.
-  return emitAllocatingCall(*this, IGM.getSlowAllocFn(),
-                            {size, alignMask},
-                            name);
+  return emitAllocatingCall(*this, IGM.getSlowAllocFunctionPointer(),
+                            {size, alignMask}, name);
 }
 
 /// Emit a heap allocation.
@@ -148,15 +146,15 @@ llvm::Value *IRGenFunction::emitAllocObjectCall(llvm::Value *metadata,
                                                 llvm::Value *alignMask,
                                                 const llvm::Twine &name) {
   // For now, all we have is swift_allocObject.
-  return emitAllocatingCall(*this, IGM.getAllocObjectFn(),
-                            { metadata, size, alignMask }, name);
+  return emitAllocatingCall(*this, IGM.getAllocObjectFunctionPointer(),
+                            {metadata, size, alignMask}, name);
 }
 
 llvm::Value *IRGenFunction::emitInitStackObjectCall(llvm::Value *metadata,
                                                     llvm::Value *object,
                                                     const llvm::Twine &name) {
-  llvm::CallInst *call =
-    Builder.CreateCall(IGM.getInitStackObjectFn(), { metadata, object }, name);
+  llvm::CallInst *call = Builder.CreateCall(
+      IGM.getInitStackObjectFunctionPointer(), {metadata, object}, name);
   call->setDoesNotThrow();
   return call;
 }
@@ -164,16 +162,16 @@ llvm::Value *IRGenFunction::emitInitStackObjectCall(llvm::Value *metadata,
 llvm::Value *IRGenFunction::emitInitStaticObjectCall(llvm::Value *metadata,
                                                      llvm::Value *object,
                                                      const llvm::Twine &name) {
-  llvm::CallInst *call =
-    Builder.CreateCall(IGM.getInitStaticObjectFn(), { metadata, object }, name);
+  llvm::CallInst *call = Builder.CreateCall(
+      IGM.getInitStaticObjectFunctionPointer(), {metadata, object}, name);
   call->setDoesNotThrow();
   return call;
 }
 
 llvm::Value *IRGenFunction::emitVerifyEndOfLifetimeCall(llvm::Value *object,
                                                       const llvm::Twine &name) {
-  llvm::CallInst *call =
-    Builder.CreateCall(IGM.getVerifyEndOfLifetimeFn(), { object }, name);
+  llvm::CallInst *call = Builder.CreateCall(
+      IGM.getVerifyEndOfLifetimeFunctionPointer(), {object}, name);
   call->setDoesNotThrow();
   return call;
 }
@@ -182,7 +180,7 @@ void IRGenFunction::emitAllocBoxCall(llvm::Value *typeMetadata,
                                       llvm::Value *&box,
                                       llvm::Value *&valueAddress) {
   llvm::CallInst *call =
-    Builder.CreateCall(IGM.getAllocBoxFn(), typeMetadata);
+      Builder.CreateCall(IGM.getAllocBoxFunctionPointer(), typeMetadata);
   call->addFnAttr(llvm::Attribute::NoUnwind);
 
   box = Builder.CreateExtractValue(call, 0);
@@ -194,8 +192,8 @@ void IRGenFunction::emitMakeBoxUniqueCall(llvm::Value *box,
                                           llvm::Value *alignMask,
                                           llvm::Value *&outBox,
                                           llvm::Value *&outValueAddress) {
-  llvm::CallInst *call = Builder.CreateCall(IGM.getMakeBoxUniqueFn(),
-                                            {box, typeMetadata, alignMask});
+  llvm::CallInst *call = Builder.CreateCall(
+      IGM.getMakeBoxUniqueFunctionPointer(), {box, typeMetadata, alignMask});
   call->addFnAttr(llvm::Attribute::NoUnwind);
 
   outBox = Builder.CreateExtractValue(call, 0);
@@ -206,7 +204,7 @@ void IRGenFunction::emitMakeBoxUniqueCall(llvm::Value *box,
 void IRGenFunction::emitDeallocBoxCall(llvm::Value *box,
                                         llvm::Value *typeMetadata) {
   llvm::CallInst *call =
-    Builder.CreateCall(IGM.getDeallocBoxFn(), box);
+      Builder.CreateCall(IGM.getDeallocBoxFunctionPointer(), box);
   call->setCallingConv(IGM.DefaultCC);
   call->addFnAttr(llvm::Attribute::NoUnwind);
 }
@@ -214,31 +212,24 @@ void IRGenFunction::emitDeallocBoxCall(llvm::Value *box,
 llvm::Value *IRGenFunction::emitProjectBoxCall(llvm::Value *box,
                                                 llvm::Value *typeMetadata) {
   llvm::CallInst *call =
-    Builder.CreateCall(IGM.getProjectBoxFn(), box);
+      Builder.CreateCall(IGM.getProjectBoxFunctionPointer(), box);
   call->setCallingConv(IGM.DefaultCC);
   call->addFnAttr(llvm::Attribute::NoUnwind);
-  call->addFnAttr(llvm::Attribute::ReadNone);
   return call;
 }
 
 llvm::Value *IRGenFunction::emitAllocEmptyBoxCall() {
   llvm::CallInst *call =
-    Builder.CreateCall(IGM.getAllocEmptyBoxFn(), {});
+      Builder.CreateCall(IGM.getAllocEmptyBoxFunctionPointer(), {});
   call->setCallingConv(IGM.DefaultCC);
   call->addFnAttr(llvm::Attribute::NoUnwind);
   return call;
 }
 
-static void emitDeallocatingCall(IRGenFunction &IGF, llvm::Constant *fn,
+static void emitDeallocatingCall(IRGenFunction &IGF, FunctionPointer fn,
                                  std::initializer_list<llvm::Value *> args) {
-  auto cc = IGF.IGM.DefaultCC;
-  if (auto fun = dyn_cast<llvm::Function>(fn))
-    cc = fun->getCallingConv();
-
-
   llvm::CallInst *call =
-    IGF.Builder.CreateCall(fn, makeArrayRef(args.begin(), args.size()));
-  call->setCallingConv(cc);
+      IGF.Builder.CreateCall(fn, makeArrayRef(args.begin(), args.size()));
   call->setDoesNotThrow();
 }
 
@@ -248,12 +239,12 @@ void IRGenFunction::emitDeallocRawCall(llvm::Value *pointer,
                                        llvm::Value *size,
                                        llvm::Value *alignMask) {
   // For now, all we have is swift_slowDealloc.
-  return emitDeallocatingCall(*this, IGM.getSlowDeallocFn(),
+  return emitDeallocatingCall(*this, IGM.getSlowDeallocFunctionPointer(),
                               {pointer, size, alignMask});
 }
 
 void IRGenFunction::emitTSanInoutAccessCall(llvm::Value *address) {
-  llvm::Function *fn = cast<llvm::Function>(IGM.getTSanInoutAccessFn());
+  auto fn = IGM.getTSanInoutAccessFunctionPointer();
 
   llvm::Value *castAddress = Builder.CreateBitCast(address, IGM.Int8PtrTy);
 
@@ -293,7 +284,7 @@ llvm::Value *
 IRGenFunction::emitTargetOSVersionAtLeastCall(llvm::Value *major,
                                               llvm::Value *minor,
                                               llvm::Value *patch) {
-  auto *fn = cast<llvm::Function>(IGM.getPlatformVersionAtLeastFn());
+  auto fn = IGM.getPlatformVersionAtLeastFunctionPointer();
 
   llvm::Value *platformID =
     llvm::ConstantInt::get(IGM.Int32Ty, getBaseMachOPlatformID(IGM.Triple));
@@ -321,7 +312,7 @@ void IRGenFunction::emitStoreOfRelativeIndirectablePointer(llvm::Value *value,
 
 llvm::Value *
 IRGenFunction::emitLoadOfRelativePointer(Address addr, bool isFar,
-                                         llvm::PointerType *expectedType,
+                                         llvm::Type *expectedPointedToType,
                                          const llvm::Twine &name) {
   llvm::Value *value = Builder.CreateLoad(addr);
   assert(value->getType() ==
@@ -332,71 +323,26 @@ IRGenFunction::emitLoadOfRelativePointer(Address addr, bool isFar,
   auto *addrInt = Builder.CreatePtrToInt(addr.getAddress(), IGM.IntPtrTy);
   auto *uncastPointerInt = Builder.CreateAdd(addrInt, value);
   auto *uncastPointer = Builder.CreateIntToPtr(uncastPointerInt, IGM.Int8PtrTy);
-  auto uncastPointerAddress = Address(uncastPointer, IGM.getPointerAlignment());
-  auto pointer = Builder.CreateBitCast(uncastPointerAddress, expectedType);
+  auto uncastPointerAddress =
+      Address(uncastPointer, IGM.Int8Ty, IGM.getPointerAlignment());
+  auto pointer =
+      Builder.CreateElementBitCast(uncastPointerAddress, expectedPointedToType);
   return pointer.getAddress();
 }
 
-llvm::Value *
-IRGenFunction::emitLoadOfCompactFunctionPointer(Address addr, bool isFar,
-                                                 llvm::PointerType *expectedType,
-                                                 const llvm::Twine &name) {
+llvm::Value *IRGenFunction::emitLoadOfCompactFunctionPointer(
+    Address addr, bool isFar, llvm::Type *expectedPointedToType,
+    const llvm::Twine &name) {
   if (IGM.getOptions().CompactAbsoluteFunctionPointer) {
     llvm::Value *value = Builder.CreateLoad(addr);
     auto *uncastPointer = Builder.CreateIntToPtr(value, IGM.Int8PtrTy);
-    auto pointer = Builder.CreateBitCast(Address(uncastPointer, IGM.getPointerAlignment()), expectedType);
+    auto pointer = Builder.CreateElementBitCast(
+        Address(uncastPointer, IGM.Int8Ty, IGM.getPointerAlignment()),
+        expectedPointedToType);
     return pointer.getAddress();
   } else {
-    return emitLoadOfRelativePointer(addr, isFar, expectedType, name);
+    return emitLoadOfRelativePointer(addr, isFar, expectedPointedToType, name);
   }
-}
-
-llvm::Value *
-IRGenFunction::emitLoadOfRelativeIndirectablePointer(Address addr,
-                                                bool isFar,
-                                                llvm::PointerType *expectedType,
-                                                const llvm::Twine &name) {
-  // Load the pointer and turn it back into a pointer.
-  llvm::Value *value = Builder.CreateLoad(addr);
-  assert(value->getType() == (isFar ? IGM.FarRelativeAddressTy
-                                    : IGM.RelativeAddressTy));
-  if (!isFar) {
-    value = Builder.CreateSExt(value, IGM.IntPtrTy);
-  }
-  assert(value->getType() == IGM.IntPtrTy);
-
-  llvm::BasicBlock *origBB = Builder.GetInsertBlock();
-  llvm::Value *directResult = Builder.CreateIntToPtr(value, expectedType);
-
-  // Check whether the low bit is set.
-  llvm::Constant *one = llvm::ConstantInt::get(IGM.IntPtrTy, 1);
-  llvm::BasicBlock *indirectBB = createBasicBlock("relptr.indirect");
-  llvm::BasicBlock *contBB = createBasicBlock("relptr.cont");
-  llvm::Value *isIndirect = Builder.CreateAnd(value, one);
-  isIndirect = Builder.CreateIsNotNull(isIndirect);
-  Builder.CreateCondBr(isIndirect, indirectBB, contBB);
-
-  // In the indirect block, clear the low bit and perform an additional load.
-  llvm::Value *indirectResult; {
-    Builder.emitBlock(indirectBB);
-
-    // Clear the low bit.
-    llvm::Value *ptr = Builder.CreateSub(value, one);
-    ptr = Builder.CreateIntToPtr(ptr, expectedType->getPointerTo());
-
-    // Load.
-    Address indirectAddr(ptr, IGM.getPointerAlignment());
-    indirectResult = Builder.CreateLoad(indirectAddr);
-
-    Builder.CreateBr(contBB);
-  }
-
-  Builder.emitBlock(contBB);
-  auto phi = Builder.CreatePHI(expectedType, 2, name);
-  phi->addIncoming(directResult, origBB);
-  phi->addIncoming(indirectResult, indirectBB);
-
-  return phi;
 }
 
 void IRGenFunction::emitFakeExplosion(const TypeInfo &type,
@@ -470,18 +416,16 @@ Address IRGenFunction::emitAddressAtOffset(llvm::Value *base, Offset offset,
       auto scaledIndex =
         int64_t(byteOffset.getValue()) / int64_t(objectSize.getValue());
       auto indexValue = IGM.getSize(Size(scaledIndex));
-      auto slotPtr = Builder.CreateInBoundsGEP(
-          base->getType()->getScalarType()->getPointerElementType(), base,
-          indexValue);
+      auto slotPtr = Builder.CreateInBoundsGEP(objectTy, base, indexValue);
 
-      return Address(slotPtr, objectAlignment);
+      return Address(slotPtr, objectTy, objectAlignment);
     }
   }
 
   // GEP to the slot.
   auto offsetValue = offset.getAsValue(*this);
   auto slotPtr = emitByteOffsetGEP(base, offsetValue, objectTy);
-  return Address(slotPtr, objectAlignment);
+  return Address(slotPtr, objectTy, objectAlignment);
 }
 
 llvm::CallInst *IRBuilder::CreateNonMergeableTrap(IRGenModule &IGM,
@@ -527,15 +471,15 @@ void IRGenFunction::emitTrap(StringRef failureMessage, bool EmitUnreachable) {
 }
 
 Address IRGenFunction::emitTaskAlloc(llvm::Value *size, Alignment alignment) {
-  auto *call = Builder.CreateCall(IGM.getTaskAllocFn(), {size});
+  auto *call = Builder.CreateCall(IGM.getTaskAllocFunctionPointer(), {size});
   call->setDoesNotThrow();
   call->setCallingConv(IGM.SwiftCC);
-  auto address = Address(call, alignment);
+  auto address = Address(call, IGM.Int8Ty, alignment);
   return address;
 }
 
 void IRGenFunction::emitTaskDealloc(Address address) {
-  auto *call = Builder.CreateCall(IGM.getTaskDeallocFn(),
+  auto *call = Builder.CreateCall(IGM.getTaskDeallocFunctionPointer(),
                                   {address.getAddress()});
   call->setDoesNotThrow();
   call->setCallingConv(IGM.SwiftCC);
@@ -565,7 +509,7 @@ static llvm::Value *emitLoadOfResumeContextFromTask(IRGenFunction &IGF,
   const unsigned taskResumeContextIndex = 8;
   const Size taskResumeContextOffset = (7 * IGF.IGM.getPointerSize()) + Size(8);
 
-  auto addr = Address(task, IGF.IGM.getPointerAlignment());
+  auto addr = Address(task, IGF.IGM.SwiftTaskTy, IGF.IGM.getPointerAlignment());
   auto resumeContextAddr = IGF.Builder.CreateStructGEP(
     addr, taskResumeContextIndex, taskResumeContextOffset);
   llvm::Value *resumeContext = IGF.Builder.CreateLoad(resumeContextAddr);
@@ -582,7 +526,8 @@ static Address emitLoadOfContinuationContext(IRGenFunction &IGF,
                                              llvm::Value *continuation) {
   auto ptr = emitLoadOfResumeContextFromTask(IGF, continuation);
   ptr = IGF.Builder.CreateBitCast(ptr, IGF.IGM.ContinuationAsyncContextPtrTy);
-  return Address(ptr, IGF.IGM.getAsyncContextAlignment());
+  return Address(ptr, IGF.IGM.ContinuationAsyncContextTy,
+                 IGF.IGM.getAsyncContextAlignment());
 }
 
 static Address emitAddrOfContinuationNormalResultPointer(IRGenFunction &IGF,
@@ -685,10 +630,9 @@ void IRGenFunction::emitGetAsyncContinuation(SILType resumeTy,
 
   // Call the swift_continuation_init runtime function to initialize
   // the rest of the continuation and return the task pointer back to us.
-  auto task = Builder.CreateCall(IGM.getContinuationInitFn(), {
-    continuationContext.getAddress(),
-    IGM.getSize(Size(flags.getOpaqueValue()))
-  });
+  auto task = Builder.CreateCall(IGM.getContinuationInitFunctionPointer(),
+                                 {continuationContext.getAddress(),
+                                  IGM.getSize(Size(flags.getOpaqueValue()))});
   task->setCallingConv(IGM.SwiftCC);
 
   // TODO: if we have a better idea of what executor to return to than
@@ -715,6 +659,7 @@ void IRGenFunction::emitAwaitAsyncContinuation(
     llvm::PHINode *&optionalErrorResult, llvm::BasicBlock *&optionalErrorBB) {
   assert(AsyncCoroutineCurrentContinuationContext && "no active continuation");
   Address continuationContext(AsyncCoroutineCurrentContinuationContext,
+                              IGM.ContinuationAsyncContextTy,
                               IGM.getAsyncContextAlignment());
 
   // Call swift_continuation_await to check whether the continuation
@@ -730,11 +675,9 @@ void IRGenFunction::emitAwaitAsyncContinuation(
                               3 * IGM.getPointerSize()).getAddress();
 
     auto pendingV = llvm::ConstantInt::get(
-        contAwaitSyncAddr->getType()->getPointerElementType(),
-        unsigned(ContinuationStatus::Pending));
+        IGM.SizeTy, unsigned(ContinuationStatus::Pending));
     auto awaitedV = llvm::ConstantInt::get(
-        contAwaitSyncAddr->getType()->getPointerElementType(),
-        unsigned(ContinuationStatus::Awaited));
+        IGM.SizeTy, unsigned(ContinuationStatus::Awaited));
     auto results = Builder.CreateAtomicCmpXchg(
         contAwaitSyncAddr, pendingV, awaitedV, llvm::MaybeAlign(),
         llvm::AtomicOrdering::Release /*success ordering*/,
@@ -820,7 +763,7 @@ void IRGenFunction::emitAwaitAsyncContinuation(
     auto resultAddr =
         Address(Builder.CreateBitOrPointerCast(resultAddrVal,
                                                resultStorageTy->getPointerTo()),
-                resumeTI.getFixedAlignment());
+                resultStorageTy, resumeTI.getFixedAlignment());
     resumeTI.loadAsTake(*this, resultAddr, outDirectResult);
   }
 
@@ -847,17 +790,18 @@ void IRGenFunction::emitResumeAsyncContinuationReturning(
   valueTI.initializeWithTake(*this, destAddr, srcAddr, valueTy,
                              /*outlined*/ false);
 
-  auto call = Builder.CreateCall(throwing
-                                   ? IGM.getContinuationThrowingResumeFn()
-                                   : IGM.getContinuationResumeFn(),
-                                 { continuation });
+  auto call = Builder.CreateCall(
+      throwing ? IGM.getContinuationThrowingResumeFunctionPointer()
+               : IGM.getContinuationResumeFunctionPointer(),
+      {continuation});
   call->setCallingConv(IGM.SwiftCC);
 }
 
 void IRGenFunction::emitResumeAsyncContinuationThrowing(
                         llvm::Value *continuation, llvm::Value *error) {
   continuation = Builder.CreateBitCast(continuation, IGM.SwiftTaskPtrTy);
-  auto call = Builder.CreateCall(IGM.getContinuationThrowingResumeWithErrorFn(),
-                                 { continuation, error });
+  auto call = Builder.CreateCall(
+      IGM.getContinuationThrowingResumeWithErrorFunctionPointer(),
+      {continuation, error});
   call->setCallingConv(IGM.SwiftCC);
 }

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -118,7 +118,7 @@ public:
   Address getCallerErrorResultSlot();
 
   /// Set the error result slot for the current function.
-  void setCallerErrorResultSlot(llvm::Value *address);
+  void setCallerErrorResultSlot(Address address);
 
   /// Are we currently emitting a coroutine?
   bool isCoroutine() {
@@ -184,9 +184,9 @@ private:
 
   Address ReturnSlot;
   llvm::BasicBlock *ReturnBB;
-  llvm::Value *CalleeErrorResultSlot = nullptr;
-  llvm::Value *AsyncCalleeErrorResultSlot = nullptr;
-  llvm::Value *CallerErrorResultSlot = nullptr;
+  Address CalleeErrorResultSlot;
+  Address AsyncCalleeErrorResultSlot;
+  Address CallerErrorResultSlot;
   llvm::Value *CoroutineHandle = nullptr;
   llvm::Value *AsyncCoroutineCurrentResume = nullptr;
   llvm::Value *AsyncCoroutineCurrentContinuationContext = nullptr;
@@ -259,16 +259,12 @@ public:
                                               Address addr,
                                               bool isFar);
 
-  llvm::Value *
-  emitLoadOfRelativeIndirectablePointer(Address addr, bool isFar,
-                                        llvm::PointerType *expectedType,
-                                        const llvm::Twine &name = "");
   llvm::Value *emitLoadOfRelativePointer(Address addr, bool isFar,
-                                         llvm::PointerType *expectedType,
+                                         llvm::Type *expectedPointedToType,
                                          const llvm::Twine &name = "");
   llvm::Value *
   emitLoadOfCompactFunctionPointer(Address addr, bool isFar,
-                                   llvm::PointerType *expectedType,
+                                   llvm::Type *expectedPointedToType,
                                    const llvm::Twine &name = "");
 
   llvm::Value *emitAllocObjectCall(llvm::Value *metadata, llvm::Value *size,

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -18,6 +18,7 @@
 #ifndef SWIFT_IRGEN_IRGENMODULE_H
 #define SWIFT_IRGEN_IRGENMODULE_H
 
+#include "Callee.h"
 #include "IRGen.h"
 #include "SwiftTargetInfo.h"
 #include "TypeLayout.h"
@@ -664,7 +665,8 @@ public:
   llvm::StructType *RefCountedStructTy;/// %swift.refcounted = type { ... }
   Size RefCountedStructSize;           /// sizeof(%swift.refcounted)
   llvm::PointerType *RefCountedPtrTy;  /// %swift.refcounted*
-#define CHECKED_REF_STORAGE(Name, ...) \
+#define CHECKED_REF_STORAGE(Name, ...)                                         \
+  llvm::StructType *Name##ReferenceStructTy;                                   \
   llvm::PointerType *Name##ReferencePtrTy; /// %swift. #name _reference*
 #include "swift/AST/ReferenceStorage.def"
   llvm::Constant *RefCountedNull;      /// %swift.refcounted* null
@@ -681,6 +683,7 @@ public:
   llvm::StructType *OffsetPairTy;      /// { iSize, iSize }
   llvm::StructType *FullTypeLayoutTy;  /// %swift.full_type_layout = { ... }
   llvm::StructType *TypeLayoutTy;  /// %swift.type_layout = { ... }
+  llvm::StructType *TupleTypeMetadataTy;     /// %swift.tuple_type
   llvm::PointerType *TupleTypeMetadataPtrTy; /// %swift.tuple_type*
   llvm::StructType *FullHeapMetadataStructTy; /// %swift.full_heapmetadata = type { ... }
   llvm::PointerType *FullHeapMetadataPtrTy;/// %swift.full_heapmetadata*
@@ -760,6 +763,7 @@ public:
   llvm::StructType *AsyncTaskAndContextTy;
   llvm::StructType *ContinuationAsyncContextTy;
   llvm::PointerType *ContinuationAsyncContextPtrTy;
+  llvm::StructType *ClassMetadataBaseOffsetTy;
   llvm::StructType *DifferentiabilityWitnessTy; // { i8*, i8* }
 
   llvm::GlobalVariable *TheTrivialPropertyDescriptor = nullptr;
@@ -869,6 +873,7 @@ public:
 
   llvm::Type *getFixedBufferTy();
   llvm::PointerType *getExistentialPtrTy(unsigned numTables);
+  llvm::Type *getExistentialType(unsigned numTables);
   llvm::Type *getValueWitnessTy(ValueWitness index);
   Signature getValueWitnessSignature(ValueWitness index);
 
@@ -928,8 +933,8 @@ private:
   llvm::FunctionType *AssociatedTypeWitnessTableAccessFunctionTy = nullptr;
   llvm::StructType *GenericWitnessTableCacheTy = nullptr;
   llvm::StructType *IntegerLiteralTy = nullptr;
-  llvm::PointerType *ValueWitnessTablePtrTy = nullptr;
-  llvm::PointerType *EnumValueWitnessTablePtrTy = nullptr;
+  llvm::StructType *ValueWitnessTableTy = nullptr;
+  llvm::StructType *EnumValueWitnessTableTy = nullptr;
 
   llvm::DenseMap<llvm::Type *, SpareBitVector> SpareBitsForTypes;
 
@@ -1065,8 +1070,8 @@ public:
   llvm::Constant *getAddrOfObjCMethodName(StringRef methodName);
   llvm::Constant *getAddrOfObjCProtocolRecord(ProtocolDecl *proto,
                                               ForDefinition_t forDefinition);
-  llvm::Constant *getAddrOfObjCProtocolRef(ProtocolDecl *proto,
-                                           ForDefinition_t forDefinition);
+  Address getAddrOfObjCProtocolRef(ProtocolDecl *proto,
+                                   ForDefinition_t forDefinition);
   llvm::Constant *getAddrOfKeyPathPattern(KeyPathPattern *pattern,
                                           SILLocation diagLoc);
   llvm::Constant *getAddrOfOpaqueTypeDescriptor(OpaqueTypeDecl *opaqueType,
@@ -1388,15 +1393,18 @@ private:
   llvm::DenseMap<Identifier, ClassDecl*> SwiftRootClasses;
   llvm::AttributeList AllocAttrs;
 
-#define FUNCTION_ID(Id)             \
-public:                             \
-  llvm::Constant *get##Id##Fn();    \
-private:                            \
+#define FUNCTION_ID(Id)                                                        \
+public:                                                                        \
+  llvm::Constant *get##Id##Fn();                                               \
+  FunctionPointer get##Id##FunctionPointer();                                  \
+  llvm::FunctionType *get##Id##FnType();                                       \
+                                                                               \
+private:                                                                       \
   llvm::Constant *Id##Fn = nullptr;
 #include "swift/Runtime/RuntimeFunctions.def"
-  
-  Optional<llvm::Constant *> FixedClassInitializationFn;
-  
+
+  Optional<FunctionPointer> FixedClassInitializationFn;
+
   llvm::Constant *FixLifetimeFn = nullptr;
 
   mutable Optional<SpareBitVector> HeapPointerSpareBits;
@@ -1404,8 +1412,8 @@ private:                            \
 //--- Generic ---------------------------------------------------------------
 public:
   llvm::Constant *getFixLifetimeFn();
-  
-  llvm::Constant *getFixedClassInitializationFn();
+
+  FunctionPointer getFixedClassInitializationFn();
   llvm::Function *getAwaitAsyncContinuationFn();
 
   /// The constructor used when generating code.
@@ -1505,12 +1513,13 @@ public:
                                                 ForDefinition_t forDefinition);
   void emitMethodLookupFunction(ClassDecl *classDecl);
 
-  llvm::GlobalValue *defineAlias(LinkEntity entity,
-                                 llvm::Constant *definition);
+  llvm::GlobalValue *defineAlias(LinkEntity entity, llvm::Constant *definition,
+                                 llvm::Type *typeOfDefinitionValue);
 
   llvm::GlobalValue *defineMethodDescriptor(SILDeclRef declRef,
                                             NominalTypeDecl *nominalDecl,
-                                            llvm::Constant *definition);
+                                            llvm::Constant *definition,
+                                            llvm::Type *typeOfDefinitionValue);
   llvm::Constant *getAddrOfMethodDescriptor(SILDeclRef declRef,
                                             ForDefinition_t forDefinition);
   void emitNonoverriddenMethodDescriptor(const SILVTable *VTable,
@@ -1718,15 +1727,13 @@ public:
   ConstantReference
   getAddrOfLLVMVariableOrGOTEquivalent(LinkEntity entity);
 
-  llvm::Constant *
-  emitRelativeReference(ConstantReference target,
-                        llvm::Constant *base,
-                        ArrayRef<unsigned> baseIndices);
+  llvm::Constant *emitRelativeReference(ConstantReference target,
+                                        llvm::GlobalValue *base,
+                                        ArrayRef<unsigned> baseIndices);
 
-  llvm::Constant *
-  emitDirectRelativeReference(llvm::Constant *target,
-                              llvm::Constant *base,
-                              ArrayRef<unsigned> baseIndices);
+  llvm::Constant *emitDirectRelativeReference(llvm::Constant *target,
+                                              llvm::GlobalValue *base,
+                                              ArrayRef<unsigned> baseIndices);
 
   /// Mark a global variable as true-const by putting it in the text section of
   /// the binary.
@@ -1747,7 +1754,7 @@ public:
   getGlobalForDynamicallyReplaceableThunk(LinkEntity &entity, llvm::Type *type,
                                           ForDefinition_t forDefinition);
 
-  llvm::Function *getAddrOfOpaqueTypeDescriptorAccessFunction(
+  FunctionPointer getAddrOfOpaqueTypeDescriptorAccessFunction(
       OpaqueTypeDecl *decl, ForDefinition_t forDefinition, bool implementation);
 
   void createReplaceableProlog(IRGenFunction &IGF, SILFunction *f);

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -1021,13 +1021,8 @@ llvm::Type *LinkEntity::getDefaultDeclarationType(IRGenModule &IGM) const {
     return IGM.Int8Ty;
     
   case Kind::ClassMetadataBaseOffset:
-    // TODO: put a cache variable on IGM
-    return llvm::StructType::get(IGM.getLLVMContext(), {
-      IGM.SizeTy,  // Immediate members offset
-      IGM.Int32Ty, // Negative size in words
-      IGM.Int32Ty  // Positive size in words
-    });
-    
+    return IGM.ClassMetadataBaseOffsetTy;
+
   case Kind::TypeMetadataInstantiationCache:
     // TODO: put a cache variable on IGM
     return llvm::ArrayType::get(IGM.Int8PtrTy,

--- a/lib/IRGen/MetadataLayout.cpp
+++ b/lib/IRGen/MetadataLayout.cpp
@@ -164,10 +164,10 @@ Offset NominalMetadataLayout::emitOffset(IRGenFunction &IGF,
   if (offset.isStatic())
     return Offset(offset.getStaticOffset());
 
-  Address layoutAddr(
-    IGF.IGM.getAddrOfClassMetadataBounds(cast<ClassDecl>(getDecl()),
-                                         NotForDefinition),
-    IGF.IGM.getPointerAlignment());
+  Address layoutAddr(IGF.IGM.getAddrOfClassMetadataBounds(
+                         cast<ClassDecl>(getDecl()), NotForDefinition),
+                     IGF.IGM.ClassMetadataBaseOffsetTy,
+                     IGF.IGM.getPointerAlignment());
 
   auto offsetBaseAddr = IGF.Builder.CreateStructGEP(layoutAddr, 0, Size(0));
 
@@ -515,8 +515,9 @@ Address irgen::emitAddressOfSuperclassRefInClassMetadata(IRGenFunction &IGF,
   // The superclass field in a class type is the first field past the isa.
   unsigned index = 1;
 
-  Address addr(metadata, IGF.IGM.getPointerAlignment());
-  addr = IGF.Builder.CreateElementBitCast(addr, IGF.IGM.TypeMetadataPtrTy);
+  Address addr(
+      IGF.Builder.CreateBitCast(metadata, IGF.IGM.TypeMetadataPtrPtrTy),
+      IGF.IGM.TypeMetadataPtrTy, IGF.IGM.getPointerAlignment());
   return IGF.Builder.CreateConstArrayGEP(addr, index, IGF.IGM.getPointerSize());
 }
 

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -2325,6 +2325,8 @@ MetadataResponse irgen::emitGenericTypeMetadataAccessFunction(
       subIGF.CurFn->setOnlyReadsMemory();
       subIGF.CurFn->setWillReturn();
       subIGF.CurFn->setCallingConv(IGM.SwiftCC);
+      if (IGM.DebugInfo)
+        IGM.DebugInfo->emitArtificialFunction(subIGF, subIGF.CurFn);
       IGM.setHasNoFramePointer(subIGF.CurFn);
 
       auto params = subIGF.collectParameters();
@@ -2913,6 +2915,8 @@ emitMetadataAccessByMangledName(IRGenFunction &IGF, CanType type,
     subIGF.CurFn->setOnlyReadsMemory();
     subIGF.CurFn->setWillReturn();
     IGM.setHasNoFramePointer(subIGF.CurFn);
+    if (IGM.DebugInfo)
+      IGM.DebugInfo->emitArtificialFunction(subIGF, subIGF.CurFn);
 
     auto params = subIGF.collectParameters();
     auto cache = params.claimNext();

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -305,8 +305,7 @@ llvm::Constant *IRGenModule::getAddrOfStringForMetadataRef(
       return addr;
 
     auto bitConstant = llvm::ConstantInt::get(IntPtrTy, 1);
-    return llvm::ConstantExpr::getGetElementPtr(
-      addr->getType()->getPointerElementType(), addr, bitConstant);
+    return llvm::ConstantExpr::getGetElementPtr(Int8Ty, addr, bitConstant);
   };
 
   // Check whether we already have an entry with this name.
@@ -484,8 +483,8 @@ llvm::Value *irgen::emitObjCMetadataRefForMetadata(IRGenFunction &IGF,
   classPtr = IGF.Builder.CreateBitCast(classPtr, IGF.IGM.ObjCClassPtrTy);
   
   // Fetch the metadata for that class.
-  auto call = IGF.Builder.CreateCall(IGF.IGM.getGetObjCClassMetadataFn(),
-                                     classPtr);
+  auto call = IGF.Builder.CreateCall(
+      IGF.IGM.getGetObjCClassMetadataFunctionPointer(), classPtr);
   call->setDoesNotThrow();
   call->setDoesNotAccessMemory();
   return call;
@@ -624,7 +623,8 @@ llvm::Value *irgen::emitObjCHeapMetadataRef(IRGenFunction &IGF,
     SmallString<64> scratch;
     auto className =
         IGF.IGM.getAddrOfGlobalString(theClass->getObjCRuntimeName(scratch));
-    return IGF.Builder.CreateCall(IGF.IGM.getLookUpClassFn(), className);
+    return IGF.Builder.CreateCall(IGF.IGM.getLookUpClassFunctionPointer(),
+                                  className);
   }
 
   assert(!theClass->isForeign());
@@ -660,14 +660,13 @@ static MetadataResponse emitNominalPrespecializedGenericMetadataRef(
     auto cacheVariable =
         IGF.IGM.getAddrOfNoncanonicalSpecializedGenericTypeMetadataCacheVariable(theType);
     auto call = IGF.Builder.CreateCall(
-        IGF.IGM.getGetCanonicalSpecializedMetadataFn(),
+        IGF.IGM.getGetCanonicalSpecializedMetadataFunctionPointer(),
         {request.get(IGF),
          IGF.IGM.getAddrOfTypeMetadata(theType,
                                        TypeMetadataCanonicality::Noncanonical),
          cacheVariable});
     call->setDoesNotThrow();
     call->setCallingConv(IGF.IGM.SwiftCC);
-    call->addFnAttr(llvm::Attribute::ReadNone);
     return MetadataResponse::handle(IGF, request, call);
   }
   }
@@ -1172,8 +1171,7 @@ static llvm::Constant *emitEmptyTupleTypeMetadataRef(IRGenModule &IGM) {
     llvm::ConstantInt::get(IGM.Int32Ty, 1)
   };
   return llvm::ConstantExpr::getInBoundsGetElementPtr(
-        fullMetadata->getType()->getPointerElementType(), fullMetadata,
-        indices);
+      IGM.FullTypeMetadataStructTy, fullMetadata, indices);
 }
 
 using GetElementMetadataFn =
@@ -1214,8 +1212,8 @@ static MetadataResponse emitTupleTypeMetadataRef(IRGenFunction &IGF,
       llvm::ConstantPointerNull::get(IGF.IGM.WitnessTablePtrTy) // proposed
     };
 
-    auto call = IGF.Builder.CreateCall(IGF.IGM.getGetTupleMetadata2Fn(),
-                                       args);
+    auto call = IGF.Builder.CreateCall(
+        IGF.IGM.getGetTupleMetadata2FunctionPointer(), args);
     call->setCallingConv(IGF.IGM.SwiftCC);
     call->setDoesNotThrow();
 
@@ -1234,8 +1232,8 @@ static MetadataResponse emitTupleTypeMetadataRef(IRGenFunction &IGF,
       llvm::ConstantPointerNull::get(IGF.IGM.WitnessTablePtrTy) // proposed
     };
 
-    auto call = IGF.Builder.CreateCall(IGF.IGM.getGetTupleMetadata3Fn(),
-                                       args);
+    auto call = IGF.Builder.CreateCall(
+        IGF.IGM.getGetTupleMetadata3FunctionPointer(), args);
     call->setCallingConv(IGF.IGM.SwiftCC);
     call->setDoesNotThrow();
 
@@ -1277,8 +1275,8 @@ static MetadataResponse emitTupleTypeMetadataRef(IRGenFunction &IGF,
       llvm::ConstantPointerNull::get(IGF.IGM.WitnessTablePtrTy) // proposed
     };
 
-    auto call = IGF.Builder.CreateCall(IGF.IGM.getGetTupleMetadataFn(),
-                                       args);
+    auto call = IGF.Builder.CreateCall(
+        IGF.IGM.getGetTupleMetadataFunctionPointer(), args);
     call->setCallingConv(IGF.IGM.SwiftCC);
     call->setDoesNotThrow();
 
@@ -1304,8 +1302,7 @@ static Address createGenericArgumentsArray(IRGenFunction &IGF,
   for (unsigned i : indices(args)) {
     Address elt = IGF.Builder.CreateStructGEP(argsBuffer, i,
                                               IGF.IGM.getPointerSize() * i);
-    auto *arg =
-      IGF.Builder.CreateBitCast(args[i], elt.getType()->getPointerElementType());
+    auto *arg = IGF.Builder.CreateBitCast(args[i], IGF.IGM.Int8PtrTy);
     IGF.Builder.CreateStore(arg, elt);
   }
 
@@ -1577,7 +1574,7 @@ namespace {
 
       auto constructSimpleCall =
           [&](llvm::SmallVectorImpl<llvm::Value *> &arguments)
-          -> llvm::Constant * {
+          -> FunctionPointer {
         arguments.push_back(flagsVal);
 
         collectParameters([&](unsigned i, llvm::Value *typeRef,
@@ -1592,16 +1589,16 @@ namespace {
 
         switch (params.size()) {
         case 0:
-          return IGF.IGM.getGetFunctionMetadata0Fn();
+          return IGF.IGM.getGetFunctionMetadata0FunctionPointer();
 
         case 1:
-          return IGF.IGM.getGetFunctionMetadata1Fn();
+          return IGF.IGM.getGetFunctionMetadata1FunctionPointer();
 
         case 2:
-          return IGF.IGM.getGetFunctionMetadata2Fn();
+          return IGF.IGM.getGetFunctionMetadata2FunctionPointer();
 
         case 3:
-          return IGF.IGM.getGetFunctionMetadata3Fn();
+          return IGF.IGM.getGetFunctionMetadata3FunctionPointer();
 
         default:
           llvm_unreachable("supports only 1/2/3 parameter functions");
@@ -1616,7 +1613,7 @@ namespace {
         if (!hasParameterFlags && !type->isDifferentiable() &&
             !type->getGlobalActor()) {
           llvm::SmallVector<llvm::Value *, 8> arguments;
-          auto *metadataFn = constructSimpleCall(arguments);
+          auto metadataFn = constructSimpleCall(arguments);
           auto *call = IGF.Builder.CreateCall(metadataFn, arguments);
           call->setDoesNotThrow();
           return setLocal(CanType(type), MetadataResponse::forComplete(call));
@@ -1690,13 +1687,16 @@ namespace {
               IGF.emitAbstractTypeMetadataRef(globalActor->getCanonicalType()));
         }
 
-        auto *getMetadataFn = type->getGlobalActor()
-            ? (IGF.IGM.isConcurrencyAvailable()
-               ? IGF.IGM.getGetFunctionMetadataGlobalActorFn()
-               : IGF.IGM.getGetFunctionMetadataGlobalActorBackDeployFn())
+        auto getMetadataFn =
+            type->getGlobalActor()
+                ? (IGF.IGM.isConcurrencyAvailable()
+                       ? IGF.IGM
+                             .getGetFunctionMetadataGlobalActorFunctionPointer()
+                       : IGF.IGM
+                             .getGetFunctionMetadataGlobalActorBackDeployFunctionPointer())
             : type->isDifferentiable()
-              ? IGF.IGM.getGetFunctionMetadataDifferentiableFn()
-              : IGF.IGM.getGetFunctionMetadataFn();
+                ? IGF.IGM.getGetFunctionMetadataDifferentiableFunctionPointer()
+                : IGF.IGM.getGetFunctionMetadataFunctionPointer();
 
         auto call = IGF.Builder.CreateCall(getMetadataFn, arguments);
         call->setDoesNotThrow();
@@ -1725,7 +1725,7 @@ namespace {
       auto instMetadata =
         IGF.emitAbstractTypeMetadataRef(type.getInstanceType());
 
-      auto fn = IGF.IGM.getGetMetatypeMetadataFn();
+      auto fn = IGF.IGM.getGetMetatypeMetadataFunctionPointer();
       auto call = IGF.Builder.CreateCall(fn, instMetadata);
       call->setDoesNotThrow();
 
@@ -1750,7 +1750,7 @@ namespace {
       auto instMetadata =
         IGF.emitAbstractTypeMetadataRef(type.getExistentialInstanceType());
 
-      auto fn = IGF.IGM.getGetExistentialMetatypeMetadataFn();
+      auto fn = IGF.IGM.getGetExistentialMetatypeMetadataFunctionPointer();
       auto call = IGF.Builder.CreateCall(fn, instMetadata);
       call->setDoesNotThrow();
 
@@ -1797,9 +1797,8 @@ namespace {
         llvm::ConstantInt::get(IGF.IGM.Int32Ty, 1)
       };
       return MetadataResponse::forComplete(
-        llvm::ConstantExpr::getInBoundsGetElementPtr(
-          singletonMetadata->getType()->getPointerElementType(),
-          singletonMetadata, indices));
+          llvm::ConstantExpr::getInBoundsGetElementPtr(
+              IGF.IGM.FullTypeMetadataStructTy, singletonMetadata, indices));
     }
 
     llvm::Value *emitExistentialTypeMetadata(CanExistentialType type) {
@@ -1824,9 +1823,9 @@ namespace {
                                                  "protocols");
       IGF.Builder.CreateLifetimeStart(descriptorArray,
                                    IGF.IGM.getPointerSize() * protocols.size());
-      descriptorArray = IGF.Builder.CreateBitCast(descriptorArray,
-                               IGF.IGM.ProtocolDescriptorRefTy->getPointerTo());
-      
+      descriptorArray = IGF.Builder.CreateElementBitCast(
+          descriptorArray, IGF.IGM.ProtocolDescriptorRefTy);
+
       unsigned index = 0;
       for (auto *protoDecl : protocols) {
         llvm::Value *ref = emitProtocolDescriptorRef(IGF, protoDecl);
@@ -1848,11 +1847,11 @@ namespace {
           CanType(superclass));
       }
 
-      auto call = IGF.Builder.CreateCall(IGF.IGM.getGetExistentialMetadataFn(),
-                                         {classConstraint,
-                                          superclassConstraint,
-                                          IGF.IGM.getSize(Size(protocols.size())),
-                                          descriptorArray.getAddress()});
+      auto call = IGF.Builder.CreateCall(
+          IGF.IGM.getGetExistentialMetadataFunctionPointer(),
+          {classConstraint, superclassConstraint,
+           IGF.IGM.getSize(Size(protocols.size())),
+           descriptorArray.getAddress()});
       call->setDoesNotThrow();
       IGF.Builder.CreateLifetimeEnd(descriptorArray,
                                    IGF.IGM.getPointerSize() * protocols.size());
@@ -1892,10 +1891,12 @@ namespace {
       }
 
       // Call the metadata access function in the runtime.
-      auto call = IGF.Builder.CreateCall(shapeIsUnique
-                    ? IGF.IGM.getGetExtendedExistentialTypeMetadataUniqueFn()
-                    : IGF.IGM.getGetExtendedExistentialTypeMetadataFn(),
-                    {shape, argsPointer});
+      auto call = IGF.Builder.CreateCall(
+          shapeIsUnique
+              ? IGF.IGM
+                    .getGetExtendedExistentialTypeMetadataUniqueFunctionPointer()
+              : IGF.IGM.getGetExtendedExistentialTypeMetadataFunctionPointer(),
+          {shape, argsPointer});
       call->setDoesNotThrow();
 
       // Destroy the generalization arguments array, if we made one.
@@ -2039,12 +2040,11 @@ static bool isLoadFrom(llvm::Value *value, Address address) {
 /// If cacheVariable is null, we perform the direct access every time.
 /// This is used for metadata accessors that come about due to resilience,
 /// where the direct access is completely trivial.
-void irgen::emitCacheAccessFunction(IRGenModule &IGM,
-                                    llvm::Function *accessor,
+void irgen::emitCacheAccessFunction(IRGenModule &IGM, llvm::Function *accessor,
                                     llvm::Constant *cacheVariable,
+                                    llvm::Type *cacheTy,
                                     CacheStrategy cacheStrategy,
-                                    CacheEmitter getValue,
-                                    bool isReadNone) {
+                                    CacheEmitter getValue, bool isReadNone) {
   assert((cacheStrategy == CacheStrategy::None) == (cacheVariable == nullptr));
   accessor->setDoesNotThrow();
   // Don't inline cache functions, since doing so has little impact on
@@ -2096,11 +2096,9 @@ void irgen::emitCacheAccessFunction(IRGenModule &IGM,
   }
 
   llvm::Constant *null =
-    llvm::ConstantPointerNull::get(
-      cast<llvm::PointerType>(
-        cacheVariable->getType()->getPointerElementType()));
+      llvm::ConstantPointerNull::get(cast<llvm::PointerType>(cacheTy));
 
-  Address cache(cacheVariable, IGM.getPointerAlignment());
+  Address cache(cacheVariable, cacheTy, IGM.getPointerAlignment());
 
   // Okay, first thing, check the cache variable.
   //
@@ -2250,7 +2248,8 @@ IRGenFunction::emitGenericTypeMetadataAccessFunctionCall(
     callArgs.append(args.begin(), args.end());
   }
 
-  auto call = Builder.CreateCall(accessFunction, callArgs);
+  auto call = Builder.CreateCall(accessFunction->getFunctionType(),
+                                 accessFunction, callArgs);
   call->setDoesNotThrow();
   call->setCallingConv(IGM.SwiftCC);
   call->addFnAttr(allocatedArgsBuffer
@@ -2293,7 +2292,8 @@ MetadataResponse irgen::emitGenericTypeMetadataAccessFunction(
     // swift_getGenericMetadata's calling convention is already cleverly
     // laid out to minimize the assembly language size of the thunk.
     // The caller passed us an appropriate buffer with the arguments.
-    auto argsBuffer = Address(params.claimNext(), IGM.getPointerAlignment());
+    auto argsBuffer =
+        Address(params.claimNext(), IGM.Int8PtrTy, IGM.getPointerAlignment());
     llvm::Value *arguments =
       IGF.Builder.CreateBitCast(argsBuffer.getAddress(), IGM.Int8PtrTy);
 
@@ -2301,12 +2301,12 @@ MetadataResponse irgen::emitGenericTypeMetadataAccessFunction(
     llvm::CallInst *call;
     if (checkPrespecialized) {
       call = IGF.Builder.CreateCall(
-          IGM.getGetCanonicalPrespecializedGenericMetadataFn(),
+          IGM.getGetCanonicalPrespecializedGenericMetadataFunctionPointer(),
           {request, arguments, descriptor,
            IGM.getAddrOfCanonicalPrespecializedGenericTypeCachingOnceToken(
                nominal)});
     } else {
-      call = IGF.Builder.CreateCall(IGM.getGetGenericMetadataFn(),
+      call = IGF.Builder.CreateCall(IGM.getGetGenericMetadataFunctionPointer(),
                                     {request, arguments, descriptor});
     }
     call->setDoesNotThrow();
@@ -2365,17 +2365,18 @@ MetadataResponse irgen::emitGenericTypeMetadataAccessFunction(
       llvm::Value *result;
       if (checkPrespecialized) {
         result = subIGF.Builder.CreateCall(
-            IGM.getGetCanonicalPrespecializedGenericMetadataFn(),
+            IGM.getGetCanonicalPrespecializedGenericMetadataFunctionPointer(),
             {request, argsAddr, descriptor, token});
       } else {
-        result = subIGF.Builder.CreateCall(IGM.getGetGenericMetadataFn(),
-                                           {request, argsAddr, descriptor});
+        result = subIGF.Builder.CreateCall(
+            IGM.getGetGenericMetadataFunctionPointer(),
+            {request, argsAddr, descriptor});
       }
       subIGF.Builder.CreateRet(result);
     };
-    llvm::Constant *thunkFn;
+    llvm::Function *thunkFn;
     if (checkPrespecialized) {
-      thunkFn = IGM.getOrCreateHelperFunction(
+      thunkFn = cast<llvm::Function>(IGM.getOrCreateHelperFunction(
           "__swift_instantiateCanonicalPrespecializedGenericMetadata",
           IGM.TypeMetadataResponseTy,
           {
@@ -2387,9 +2388,9 @@ MetadataResponse irgen::emitGenericTypeMetadataAccessFunction(
               IGM.OnceTy->getPointerTo()      // token pointer
           },
           generateThunkFn,
-          /*noinline*/ true);
+          /*noinline*/ true));
     } else {
-      thunkFn = IGM.getOrCreateHelperFunction(
+      thunkFn = cast<llvm::Function>(IGM.getOrCreateHelperFunction(
           "__swift_instantiateGenericMetadata", IGM.TypeMetadataResponseTy,
           {
               IGM.SizeTy,                    // request
@@ -2399,7 +2400,7 @@ MetadataResponse irgen::emitGenericTypeMetadataAccessFunction(
               IGM.TypeContextDescriptorPtrTy // type context descriptor
           },
           generateThunkFn,
-          /*noinline*/ true);
+          /*noinline*/ true));
     }
 
     // Call out to the helper.
@@ -2419,9 +2420,10 @@ MetadataResponse irgen::emitGenericTypeMetadataAccessFunction(
           IGM.getAddrOfCanonicalPrespecializedGenericTypeCachingOnceToken(
               nominal);
       call = IGF.Builder.CreateCall(
-          thunkFn, {request, arg0, arg1, arg2, descriptor, token});
+          thunkFn->getFunctionType(), thunkFn,
+          {request, arg0, arg1, arg2, descriptor, token});
     } else {
-      call = IGF.Builder.CreateCall(thunkFn,
+      call = IGF.Builder.CreateCall(thunkFn->getFunctionType(), thunkFn,
                                     {request, arg0, arg1, arg2, descriptor});
     }
     call->setDoesNotAccessMemory();
@@ -2602,6 +2604,7 @@ irgen::createTypeMetadataAccessFunction(IRGenModule &IGM, CanType type,
 
   // Okay, define the accessor.
   llvm::Constant *cacheVariable = nullptr;
+  llvm::Type *cacheTy = nullptr;
 
   // If our preferred access method is to go via an accessor, it means
   // there is some non-trivial computation that needs to be cached.
@@ -2616,12 +2619,14 @@ irgen::createTypeMetadataAccessFunction(IRGenModule &IGM, CanType type,
     // For lazy initialization, the cache variable is just a pointer.
     case CacheStrategy::Lazy:
       cacheVariable = IGM.getAddrOfTypeMetadataLazyCacheVariable(type);
+      cacheTy = IGM.TypeMetadataPtrTy;
       break;
 
     // For in-place initialization, drill down to the first element.
     case CacheStrategy::SingletonInitialization:
       cacheVariable = IGM.getAddrOfTypeMetadataSingletonInitializationCache(
                                           type->getAnyNominal(), ForDefinition);
+      cacheTy = IGM.TypeMetadataPtrTy;
       break;
     }
 
@@ -2629,11 +2634,12 @@ irgen::createTypeMetadataAccessFunction(IRGenModule &IGM, CanType type,
       accessor->addFnAttr(llvm::Attribute::NoInline);
   }
 
-  emitCacheAccessFunction(IGM, accessor, cacheVariable, cacheStrategy,
+  emitCacheAccessFunction(IGM, accessor, cacheVariable, cacheTy, cacheStrategy,
                           [&](IRGenFunction &IGF, Explosion &params) {
-    auto request = DynamicMetadataRequest(params.claimNext());
-    return generator(IGF, request, cacheVariable);
-  });
+                            auto request =
+                                DynamicMetadataRequest(params.claimNext());
+                            return generator(IGF, request, cacheVariable);
+                          });
 
   return accessor;
 }
@@ -2932,7 +2938,8 @@ emitMetadataAccessByMangledName(IRGenFunction &IGF, CanType type,
     // in the current LLVM ARM backend.
     auto cacheWordAddr = subIGF.Builder.CreateBitCast(cache,
                                                  IGM.Int64Ty->getPointerTo());
-    auto load = subIGF.Builder.CreateLoad(cacheWordAddr, Alignment(8));
+    auto load = subIGF.Builder.CreateLoad(
+        Address(cacheWordAddr, IGM.Int64Ty, Alignment(8)));
     // Make this barrier explicit when building for TSan to avoid false positives.
     if (IGM.IRGen.Opts.Sanitizers & SanitizerKind::Thread)
       load->setOrdering(llvm::AtomicOrdering::Acquire);
@@ -2991,7 +2998,7 @@ emitMetadataAccessByMangledName(IRGenFunction &IGF, CanType type,
     llvm::CallInst *call;
     if (request.isStaticallyAbstract()) {
       call = subIGF.Builder.CreateCall(
-          IGM.getGetTypeByMangledNameInContextInMetadataStateFn(),
+          IGM.getGetTypeByMangledNameInContextInMetadataStateFunctionPointer(),
           {llvm::ConstantInt::get(IGM.SizeTy, (size_t)MetadataState::Abstract),
            stringAddr, size,
            // TODO: Use mangled name lookup in generic
@@ -3000,7 +3007,7 @@ emitMetadataAccessByMangledName(IRGenFunction &IGF, CanType type,
            llvm::ConstantPointerNull::get(IGM.Int8PtrPtrTy)});
     } else {
       call = subIGF.Builder.CreateCall(
-          IGM.getGetTypeByMangledNameInContextFn(),
+          IGM.getGetTypeByMangledNameInContextFunctionPointer(),
           {stringAddr, size,
            // TODO: Use mangled name lookup in generic
            // contexts?
@@ -3034,14 +3041,13 @@ emitMetadataAccessByMangledName(IRGenFunction &IGF, CanType type,
                                                IGM.TypeMetadataPtrTy);
     subIGF.Builder.CreateRet(resultAddr);
   };
-  auto instantiationFn =
-    IGM.getOrCreateHelperFunction(instantiationFnName,
-                                  IGF.IGM.TypeMetadataPtrTy,
-                                  cache->getType(),
-                                  generateInstantiationFn,
-                                  /*noinline*/true);
-  
-  auto call = IGF.Builder.CreateCall(instantiationFn, cache);
+  auto instantiationFn = cast<llvm::Function>(IGM.getOrCreateHelperFunction(
+      instantiationFnName, IGF.IGM.TypeMetadataPtrTy, cache->getType(),
+      generateInstantiationFn,
+      /*noinline*/ true));
+
+  auto call = IGF.Builder.CreateCall(instantiationFn->getFunctionType(),
+                                     instantiationFn, cache);
   call->setDoesNotThrow();
   call->setOnlyReadsMemory();
   
@@ -3070,9 +3076,9 @@ emitCallToTypeMetadataAccessFunction(IRGenFunction &IGF, CanType type,
     return emitMetadataAccessByMangledName(IGF, type, request);
   }
 
-  llvm::Constant *accessor =
-    getOrCreateTypeMetadataAccessFunction(IGF.IGM, type);
-  llvm::CallInst *call = IGF.Builder.CreateCall(accessor, { request.get(IGF) });
+  auto *accessor = getOrCreateTypeMetadataAccessFunction(IGF.IGM, type);
+  llvm::CallInst *call = IGF.Builder.CreateCall(accessor->getFunctionType(),
+                                                accessor, {request.get(IGF)});
   call->setCallingConv(IGF.IGM.SwiftCC);
   call->setDoesNotAccessMemory();
   call->setDoesNotThrow();
@@ -3541,8 +3547,9 @@ namespace {
         auto elt1 = visit(type.getElementType(1), request);
 
         // Ignore the offset.
-        auto call = IGF.Builder.CreateCall(IGF.IGM.getGetTupleLayout2Fn(),
-                                           {resultPtr, elt0, elt1});
+        auto call =
+            IGF.Builder.CreateCall(IGF.IGM.getGetTupleLayout2FunctionPointer(),
+                                   {resultPtr, elt0, elt1});
         call->setDoesNotThrow();
 
         break;
@@ -3554,8 +3561,9 @@ namespace {
         auto elt2 = visit(type.getElementType(2), request);
 
         // Ignore the offsets.
-        auto call = IGF.Builder.CreateCall(IGF.IGM.getGetTupleLayout3Fn(),
-                                           {resultPtr, elt0, elt1, elt2});
+        auto call =
+            IGF.Builder.CreateCall(IGF.IGM.getGetTupleLayout3FunctionPointer(),
+                                   {resultPtr, elt0, elt1, elt2});
         call->setDoesNotThrow();
 
         break;
@@ -3590,9 +3598,9 @@ namespace {
         auto flagsValue = IGF.IGM.getSize(Size(flags.getIntValue()));
 
         // Compute the layout.
-        auto call = IGF.Builder.CreateCall(IGF.IGM.getGetTupleLayoutFn(),
-                                           {resultPtr, offsetsPtr, flagsValue,
-                                            eltLayoutsArray.getAddress()});
+        auto call = IGF.Builder.CreateCall(
+            IGF.IGM.getGetTupleLayoutFunctionPointer(),
+            {resultPtr, offsetsPtr, flagsValue, eltLayoutsArray.getAddress()});
         call->setDoesNotThrow();
 
         // We're done with the buffer.
@@ -3634,8 +3642,8 @@ llvm::Value *irgen::emitClassHeapMetadataRefForMetatype(IRGenFunction &IGF,
   metatype = IGF.Builder.CreateBitCast(metatype, IGF.IGM.TypeMetadataPtrTy);
   
   // Fetch the metadata for that class.
-  auto call = IGF.Builder.CreateCall(IGF.IGM.getGetObjCClassFromMetadataFn(),
-                                     metatype);
+  auto call = IGF.Builder.CreateCall(
+      IGF.IGM.getGetObjCClassFromMetadataFunctionPointer(), metatype);
   call->setDoesNotThrow();
   call->setDoesNotAccessMemory();
   return call;
@@ -3756,8 +3764,9 @@ MetadataResponse
 irgen::emitGetTypeMetadataDynamicState(IRGenFunction &IGF,
                                        DynamicMetadataRequest request,
                                        llvm::Value *metadata) {
-  auto call = IGF.Builder.CreateCall(IGF.IGM.getCheckMetadataStateFn(),
-                                     { request.get(IGF), metadata });
+  auto call =
+      IGF.Builder.CreateCall(IGF.IGM.getCheckMetadataStateFunctionPointer(),
+                             {request.get(IGF), metadata});
   call->setCallingConv(IGF.IGM.SwiftCC);
 
   return MetadataResponse::handle(IGF, request, call);

--- a/lib/IRGen/MetadataRequest.h
+++ b/lib/IRGen/MetadataRequest.h
@@ -25,6 +25,7 @@ class Constant;
 class Function;
 class GlobalVariable;
 class PHINode;
+class Type;
 class Value;
 }
 
@@ -624,11 +625,9 @@ using CacheEmitter =
   llvm::function_ref<MetadataResponse(IRGenFunction &IGF, Explosion &params)>;
 
 /// Emit the body of a lazy cache access function.
-void emitCacheAccessFunction(IRGenModule &IGM,
-                             llvm::Function *accessor,
-                             llvm::Constant *cache,
-                             CacheStrategy cacheStrategy,
-                             CacheEmitter getValue,
+void emitCacheAccessFunction(IRGenModule &IGM, llvm::Function *accessor,
+                             llvm::Constant *cache, llvm::Type *cacheTy,
+                             CacheStrategy cacheStrategy, CacheEmitter getValue,
                              bool isReadNone = true);
 MetadataResponse
 emitGenericTypeMetadataAccessFunction(IRGenFunction &IGF, Explosion &params,

--- a/lib/IRGen/Outlining.cpp
+++ b/lib/IRGen/Outlining.cpp
@@ -190,7 +190,8 @@ void OutliningMetadataCollector::emitCallToOutlinedCopy(
       IGF.IGM.getOrCreateOutlinedAssignWithCopyFunction(T, ti, *this);
   }
 
-  llvm::CallInst *call = IGF.Builder.CreateCall(outlinedFn, args);
+  llvm::CallInst *call = IGF.Builder.CreateCall(
+      cast<llvm::Function>(outlinedFn)->getFunctionType(), outlinedFn, args);
   call->setCallingConv(IGF.IGM.DefaultCC);
 }
 
@@ -360,7 +361,8 @@ void OutliningMetadataCollector::emitCallToOutlinedDestroy(
   auto outlinedFn =
     IGF.IGM.getOrCreateOutlinedDestroyFunction(T, ti, *this);
 
-  llvm::CallInst *call = IGF.Builder.CreateCall(outlinedFn, args);
+  llvm::CallInst *call = IGF.Builder.CreateCall(
+      cast<llvm::Function>(outlinedFn)->getFunctionType(), outlinedFn, args);
   call->setCallingConv(IGF.IGM.DefaultCC);
 }
 
@@ -409,7 +411,8 @@ llvm::Constant *IRGenModule::getOrCreateRetainFunction(const TypeInfo &ti,
       funcName, llvmType, argTys,
       [&](IRGenFunction &IGF) {
         auto it = IGF.CurFn->arg_begin();
-        Address addr(&*it++, loadableTI->getFixedAlignment());
+        Address addr(&*it++, loadableTI->getStorageType(),
+                     loadableTI->getFixedAlignment());
         Explosion loaded;
         loadableTI->loadAsTake(IGF, addr, loaded);
         Explosion out;
@@ -436,7 +439,8 @@ IRGenModule::getOrCreateReleaseFunction(const TypeInfo &ti,
       funcName, llvmType, argTys,
       [&](IRGenFunction &IGF) {
         auto it = IGF.CurFn->arg_begin();
-        Address addr(&*it++, loadableTI->getFixedAlignment());
+        Address addr(&*it++, loadableTI->getStorageType(),
+                     loadableTI->getFixedAlignment());
         Explosion loaded;
         loadableTI->loadAsTake(IGF, addr, loaded);
         loadableTI->consume(IGF, loaded, atomicity);

--- a/lib/IRGen/ScalarTypeInfo.h
+++ b/lib/IRGen/ScalarTypeInfo.h
@@ -121,7 +121,7 @@ public:
     auto &IGM = IGF.IGM;
 
     // Store in multiples of bytes to avoid undefined bits.
-    auto storageTy = addr.getAddress()->getType()->getPointerElementType();
+    auto storageTy = addr.getElementType();
     if (storageTy->isIntegerTy() && (storageTy->getIntegerBitWidth() % 8)) {
       auto &Builder = IGF.Builder;
       auto nextByteSize = (storageTy->getIntegerBitWidth() + 7) & ~7UL;
@@ -130,7 +130,7 @@ public:
       auto newAddr =
           Address(Builder.CreatePointerCast(addr.getAddress(),
                                             nextByteSizedIntTy->getPointerTo()),
-                  addr.getAlignment());
+                  nextByteSizedIntTy, addr.getAlignment());
       auto newValue = Builder.CreateZExt(src.claimNext(), nextByteSizedIntTy);
       Builder.CreateStore(newValue, newAddr);
       return;

--- a/lib/IRGen/Signature.h
+++ b/lib/IRGen/Signature.h
@@ -86,6 +86,7 @@ public:
   /// The number of yield components that are returned directly in the
   /// coroutine return value.
   unsigned NumDirectYieldComponents = 0;
+  llvm::StructType *indirectResultsType = nullptr;
 };
 
 namespace {

--- a/lib/IRGen/StructLayout.cpp
+++ b/lib/IRGen/StructLayout.cpp
@@ -78,7 +78,7 @@ StructLayout::StructLayout(IRGenModule &IGM,
     IsKnownPOD = IsPOD;
     IsKnownBitwiseTakable = IsBitwiseTakable;
     IsKnownAlwaysFixedSize = IsFixedSize;
-    Ty = (typeToFill ? typeToFill : IGM.OpaquePtrTy->getPointerElementType());
+    Ty = (typeToFill ? typeToFill : IGM.OpaqueTy);
   } else {
     MinimumAlign = builder.getAlignment();
     MinimumSize = builder.getSize();
@@ -152,7 +152,7 @@ Address StructLayout::emitCastTo(IRGenFunction &IGF,
                                  const llvm::Twine &name) const {
   llvm::Value *addr =
     IGF.Builder.CreateBitCast(ptr, getType()->getPointerTo(), name);
-  return Address(addr, getAlignment());
+  return Address(addr, getType(), getAlignment());
 }
 
 Address ElementLayout::project(IRGenFunction &IGF, Address baseAddr,
@@ -178,9 +178,9 @@ Address ElementLayout::project(IRGenFunction &IGF, Address baseAddr,
   }
 
   case Kind::InitialNonFixedSize:
-    return IGF.Builder.CreateBitCast(baseAddr,
-                                 getType().getStorageType()->getPointerTo(),
-                                 baseAddr.getAddress()->getName() + suffix);
+    return IGF.Builder.CreateElementBitCast(
+        baseAddr, getType().getStorageType(),
+        baseAddr.getAddress()->getName() + suffix);
   }
   llvm_unreachable("bad element layout kind");
 }

--- a/lib/LLVMPasses/ARCEntryPointBuilder.h
+++ b/lib/LLVMPasses/ARCEntryPointBuilder.h
@@ -73,7 +73,7 @@ class ARCEntryPointBuilder {
 
   llvm::CallInst *CreateCall(Constant *Fn, Value *V) {
     CallInst *CI = B.CreateCall(
-        cast<llvm::FunctionType>(Fn->getType()->getPointerElementType()), Fn,
+        cast<llvm::FunctionType>(cast<llvm::Function>(Fn)->getValueType()), Fn,
         V);
     if (auto Fun = llvm::dyn_cast<llvm::Function>(Fn))
       CI->setCallingConv(Fun->getCallingConv());
@@ -82,7 +82,7 @@ class ARCEntryPointBuilder {
 
   llvm::CallInst *CreateCall(Constant *Fn, llvm::ArrayRef<Value *> Args) {
     CallInst *CI = B.CreateCall(
-        cast<llvm::FunctionType>(Fn->getType()->getPointerElementType()), Fn,
+        cast<llvm::FunctionType>(cast<llvm::Function>(Fn)->getValueType()), Fn,
         Args);
     if (auto Fun = llvm::dyn_cast<llvm::Function>(Fn))
       CI->setCallingConv(Fun->getCallingConv());

--- a/test/ClangImporter/objc_ir.swift
+++ b/test/ClangImporter/objc_ir.swift
@@ -129,7 +129,6 @@ class Impl: FooProto, AnotherProto {
 
 // CHECK-LABEL: define hidden swiftcc %swift.type* @"$s7objc_ir27protocolCompositionMetatype1pSo12AnotherProto_So03FooG0pXpAA4ImplC_tF"(%T7objc_ir4ImplC* %0) {{.*}} {
 func protocolCompositionMetatype(p: Impl) -> (FooProto & AnotherProto).Type {
-  // CHECK: = getelementptr inbounds %T7objc_ir4ImplC, %T7objc_ir4ImplC* %0, i32 0, i32 0, i32 0
   // CHECK-NOT: {{retain|release}}
   // CHECK: [[RAW_RESULT:%.+]] = call i8* @processComboType(i8* {{%.+}})
   // CHECK: [[CASTED_RESULT:%.+]] = bitcast i8* [[RAW_RESULT]] to %objc_class*
@@ -142,7 +141,6 @@ func protocolCompositionMetatype(p: Impl) -> (FooProto & AnotherProto).Type {
 
 // CHECK-LABEL: define hidden swiftcc %swift.type* @"$s7objc_ir28protocolCompositionMetatype21pSo12AnotherProto_So03FooG0pXpAA4ImplC_tF"(%T7objc_ir4ImplC* %0) {{.*}} {
 func protocolCompositionMetatype2(p: Impl) -> (FooProto & AnotherProto).Type {
-  // CHECK: = getelementptr inbounds %T7objc_ir4ImplC, %T7objc_ir4ImplC* %0, i32 0, i32 0, i32 0
   // CHECK-NOT: {{retain|release}}
   // CHECK: [[RAW_RESULT:%.+]] = call i8* @processComboType2(i8* {{%.+}})
   // CHECK: [[CASTED_RESULT:%.+]] = bitcast i8* [[RAW_RESULT]] to %objc_class*
@@ -357,7 +355,7 @@ func testBlocksWithGenerics(hba: HasBlockArray) -> Any {
 // CHECK: load i8*, i8** @"\01L_selector(initWithInt:)"
 // CHECK: call [[OPAQUE:%.*]]* bitcast (void ()* @objc_msgSend
 
-// CHECK: attributes [[NOUNWIND]] = { nounwind }
+// CHECK: attributes [[NOUNWIND]] = { nounwind readonly }
 
 // CHECK: ![[SWIFT_NAME_ALIAS_VAR]] = !DILocalVariable(name: "obj", arg: 1, scope: !{{[0-9]+}}, file: !{{[0-9]+}}, line: {{[0-9]+}}, type: ![[SWIFT_NAME_ALIAS_TYPE:[0-9]+]])
 // CHECK: ![[LET_SWIFT_NAME_ALIAS_TYPE:[0-9]+]] = !DIDerivedType(tag: DW_TAG_const_type, baseType: ![[SWIFT_NAME_ALIAS_TYPE:[0-9]+]])

--- a/test/IRGen/associated_types.swift
+++ b/test/IRGen/associated_types.swift
@@ -103,5 +103,5 @@ public struct P0Impl : P0 {
 // CHECK: define{{.*}} swiftcc i8** @"$s16associated_types6P0ImplVAA0C0AA9ErrorTypeAaDP_s0E0PWT"(%swift.type* %P0Impl.ErrorType, %swift.type* %P0Impl, i8** %P0Impl.P0)
 // CHECK:  ret i8** @"$ss5ErrorWS"
 
-// CHECK: attributes [[NOUNWIND_READNONE]] = { nounwind readnone }
+// CHECK: attributes [[NOUNWIND_READNONE]] = { nounwind readnone willreturn }
 

--- a/test/IRGen/bitcast.sil
+++ b/test/IRGen/bitcast.sil
@@ -117,8 +117,8 @@ bb0(%0 : $Int, %1 : $Int):
 }
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @unchecked_ref_cast_addr
-// CHECK-i386: call i1 @swift_dynamicCast(%swift.opaque* %0, %swift.opaque* %{{.*}}, %swift.type* %T, %swift.type* %U, i32 7)
-// CHECK-x86_64: call i1 @swift_dynamicCast(%swift.opaque* %0, %swift.opaque* %{{.*}}, %swift.type* %T, %swift.type* %U, i64 7)
+// CHECK-i386: call zeroext i1 @swift_dynamicCast(%swift.opaque* %0, %swift.opaque* %{{.*}}, %swift.type* %T, %swift.type* %U, i32 7)
+// CHECK-x86_64: call zeroext i1 @swift_dynamicCast(%swift.opaque* %0, %swift.opaque* %{{.*}}, %swift.type* %T, %swift.type* %U, i64 7)
 sil @unchecked_ref_cast_addr : $@convention(thin) <T, U> (@in T) -> @out U {
 bb0(%0 : $*U, %1 : $*T):
   %a = alloc_stack $T

--- a/test/IRGen/builtins.swift
+++ b/test/IRGen/builtins.swift
@@ -637,7 +637,7 @@ func acceptsBuiltinNativeObject(_ ref: inout Builtin.NativeObject?) {}
 // CHECK-NEXT: entry:
 // CHECK:      %[[BITCAST_RC:.+]] = bitcast [[BUILTIN_NATIVE_OBJECT_TY]]* %0 to %swift.refcounted**
 // CHECK:      %[[LD_RC:.+]] = load %swift.refcounted*, %swift.refcounted** %[[BITCAST_RC]]
-// CHECK-NEXT: %[[RET:.+]] = call i1 @swift_isUniquelyReferenced_native(%swift.refcounted* %[[LD_RC]])
+// CHECK-NEXT: %[[RET:.+]] = call zeroext i1 @swift_isUniquelyReferenced_native(%swift.refcounted* %[[LD_RC]])
 // CHECK-NEXT: ret i1 %[[RET]]
 func isUnique(_ ref: inout Builtin.NativeObject?) -> Bool {
   return Builtin.isUnique(&ref)
@@ -647,7 +647,7 @@ func isUnique(_ ref: inout Builtin.NativeObject?) -> Bool {
 // CHECK-LABEL: define hidden {{.*}}i1 @"$s8builtins8isUniqueyBi1_BozF"(%swift.refcounted** nocapture dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-NEXT: entry:
 // CHECK:      %[[LD_RC:.+]] = load %swift.refcounted*, %swift.refcounted** %0
-// CHECK:      %[[RET:.+]] = call i1 @swift_isUniquelyReferenced_nonNull_native(%swift.refcounted* %[[LD_RC]])
+// CHECK:      %[[RET:.+]] = call zeroext i1 @swift_isUniquelyReferenced_nonNull_native(%swift.refcounted* %[[LD_RC]])
 // CHECK-NEXT: ret i1 %[[RET]]
 func isUnique(_ ref: inout Builtin.NativeObject) -> Bool {
   return Builtin.isUnique(&ref)
@@ -662,8 +662,8 @@ func acceptsAnyObject(_ ref: inout Builtin.AnyObject?) {}
 // CHECK:      [[ADDR:%.+]] = getelementptr inbounds [[OPTIONAL_ANYOBJECT_TY]], [[OPTIONAL_ANYOBJECT_TY]]* %0, i32 0, i32 0
 // CHECK-NEXT: [[CASTED:%.+]] = bitcast {{.+}}* [[ADDR]] to [[UNKNOWN_OBJECT:%objc_object|%swift\.refcounted]]**
 // CHECK-NEXT: [[REF:%.+]] = load [[UNKNOWN_OBJECT]]*, [[UNKNOWN_OBJECT]]** [[CASTED]]
-// CHECK-objc-NEXT: [[RESULT:%.+]] = call i1 @swift_isUniquelyReferenced{{(NonObjC)?}}([[UNKNOWN_OBJECT]]* [[REF]])
-// CHECK-native-NEXT: [[RESULT:%.+]] = call i1 @swift_isUniquelyReferenced_native([[UNKNOWN_OBJECT]]* [[REF]])
+// CHECK-objc-NEXT: [[RESULT:%.+]] = call zeroext i1 @swift_isUniquelyReferenced{{(NonObjC)?}}([[UNKNOWN_OBJECT]]* [[REF]])
+// CHECK-native-NEXT: [[RESULT:%.+]] = call zeroext i1 @swift_isUniquelyReferenced_native([[UNKNOWN_OBJECT]]* [[REF]])
 // CHECK-NEXT: ret i1 [[RESULT]]
 func isUnique(_ ref: inout Builtin.AnyObject?) -> Bool {
   return Builtin.isUnique(&ref)
@@ -675,8 +675,8 @@ func isUnique(_ ref: inout Builtin.AnyObject?) -> Bool {
 // CHECK-NEXT: entry:
 // CHECK:      [[ADDR:%.+]] = getelementptr inbounds %AnyObject, %AnyObject* %0, i32 0, i32 0
 // CHECK:      [[REF:%.+]] = load [[UNKNOWN_OBJECT]]*, [[UNKNOWN_OBJECT]]** [[ADDR]]
-// CHECK-objc-NEXT: [[RESULT:%.+]] = call i1 @swift_isUniquelyReferenced{{(NonObjC)?}}_nonNull([[UNKNOWN_OBJECT]]* [[REF]])
-// CHECK-native-NEXT: [[RESULT:%.+]] = call i1 @swift_isUniquelyReferenced_nonNull_native([[UNKNOWN_OBJECT]]* [[REF]])
+// CHECK-objc-NEXT: [[RESULT:%.+]] = call zeroext i1 @swift_isUniquelyReferenced{{(NonObjC)?}}_nonNull([[UNKNOWN_OBJECT]]* [[REF]])
+// CHECK-native-NEXT: [[RESULT:%.+]] = call zeroext i1 @swift_isUniquelyReferenced_nonNull_native([[UNKNOWN_OBJECT]]* [[REF]])
 // CHECK-NEXT: ret i1 [[RESULT]]
 func isUnique(_ ref: inout Builtin.AnyObject) -> Bool {
   return Builtin.isUnique(&ref)
@@ -686,7 +686,7 @@ func isUnique(_ ref: inout Builtin.AnyObject) -> Bool {
 // CHECK-LABEL: define hidden {{.*}}i1 @"$s8builtins8isUniqueyBi1_BbzF"(%swift.bridge** nocapture dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-NEXT: entry:
 // CHECK:      %[[LD:.+]] = load %swift.bridge*, %swift.bridge** %0
-// CHECK:      %[[RET:.+]] = call i1 @swift_isUniquelyReferenced{{(NonObjC)?}}_nonNull_bridgeObject(%swift.bridge* %[[LD]])
+// CHECK:      %[[RET:.+]] = call zeroext i1 @swift_isUniquelyReferenced{{(NonObjC)?}}_nonNull_bridgeObject(%swift.bridge* %[[LD]])
 // CHECK-NEXT: ret i1 %[[RET]]
 func isUnique(_ ref: inout Builtin.BridgeObject) -> Bool {
   return Builtin.isUnique(&ref)
@@ -703,7 +703,7 @@ func assumeTrue(_ x: Builtin.Int1) {
 // CHECK-NEXT: entry:
 // CHECK:      %[[BC:.+]] = bitcast %swift.bridge** %0 to %swift.refcounted**
 // CHECK:      %[[LD:.+]] = load %swift.refcounted*, %swift.refcounted** %[[BC]]
-// CHECK-NEXT: %[[RET:.+]] = call i1 @swift_isUniquelyReferenced_nonNull_native(%swift.refcounted* %[[LD]])
+// CHECK-NEXT: %[[RET:.+]] = call zeroext i1 @swift_isUniquelyReferenced_nonNull_native(%swift.refcounted* %[[LD]])
 // CHECK-NEXT: ret i1 %[[RET]]
 func isUnique_native(_ ref: inout Builtin.BridgeObject) -> Bool {
   return Builtin.isUnique_native(&ref)
@@ -712,7 +712,7 @@ func isUnique_native(_ ref: inout Builtin.BridgeObject) -> Bool {
 // ImplicitlyUnwrappedOptional argument to isUnique.
 // CHECK-LABEL: define hidden {{.*}}i1 @"$s8builtins11isUniqueIUOyBi1_BoSgzF"(%{{.*}}* nocapture dereferenceable({{.*}}) %0) {{.*}} {
 // CHECK-NEXT: entry:
-// CHECK: call i1 @swift_isUniquelyReferenced_native(%swift.refcounted*
+// CHECK: call zeroext i1 @swift_isUniquelyReferenced_native(%swift.refcounted*
 // CHECK: ret i1
 func isUniqueIUO(_ ref: inout Builtin.NativeObject?) -> Bool {
   var iuo : Builtin.NativeObject! = ref

--- a/test/IRGen/casts.sil
+++ b/test/IRGen/casts.sil
@@ -276,7 +276,7 @@ nay:
 // CHECK:   [[V2:%.*]] = icmp ne %T5casts1AC* [[V1]], null
 // CHECK:   br i1 [[V2]], label %[[LBL:.*]], label
 // CHECK:    [[LBL]]:
-// CHECK:   [[V4:%.*]] = getelementptr inbounds %T5casts1AC, %T5casts1AC* [[V1]]
+// CHECK:   [[V4:%.*]] = bitcast %T5casts1AC* [[V1]] to %swift.type**
 // CHECK:    load %swift.type*, %swift.type** [[V4]]
 sil @checked_downcast_optional_class_to_ex : $@convention(thin) (@guaranteed Optional<A>) -> @owned Optional<CP> {
 bb0(%0 : $Optional<A>):
@@ -299,7 +299,7 @@ bb3(%9 : $Optional<CP>):
 sil @checked_metatype_to_object_casts : $@convention(thin) <T> (@thick Any.Type) -> () {
 entry(%e : $@thick Any.Type):
   %a = metatype $@thick NotClass.Type
-  // CHECK: call i1 @swift_dynamicCast({{.*}})
+  // CHECK: call zeroext i1 @swift_dynamicCast({{.*}})
   checked_cast_br %a : $@thick NotClass.Type to AnyObject, a_yea, a_nay
 a_yea(%1 : $AnyObject):
   %b = metatype $@thick A.Type

--- a/test/IRGen/class_bounded_generics.swift
+++ b/test/IRGen/class_bounded_generics.swift
@@ -253,7 +253,7 @@ class SomeSwiftClass {
 
 // T must have a Swift layout, so we can load this metatype with a direct access.
 // CHECK-LABEL: define hidden swiftcc void @"$s22class_bounded_generics0a1_B9_metatype{{[_0-9a-zA-Z]*}}F"
-// CHECK:      [[T0:%.*]] = getelementptr inbounds %T22class_bounded_generics14SomeSwiftClassC, %T22class_bounded_generics14SomeSwiftClassC* {{%.*}}, i32 0, i32 0, i32 0
+// CHECK:      [[T0:%.*]] = bitcast %T22class_bounded_generics14SomeSwiftClassC* {{%.*}}
 // CHECK-NEXT: [[T1:%.*]] = load %swift.type*, %swift.type** [[T0]], align 8
 // CHECK-NEXT: [[T2:%.*]] = bitcast %swift.type* [[T1]] to void (%swift.type*)**
 // CHECK-NEXT: [[T3:%.*]] = getelementptr inbounds void (%swift.type*)*, void (%swift.type*)** [[T2]], i64 10
@@ -299,7 +299,7 @@ func archetype_with_generic_class_constraint<T, U>(t: T) where T : A<U> {
 // CHECK-LABEL: define hidden swiftcc void @"$s22class_bounded_generics029calls_archetype_with_generic_A11_constraint1ayAA1ACyxG_tlF"(%T22class_bounded_generics1AC* %0) {{.*}} {
 // CHECK:      alloca
 // CHECK:      memset
-// CHECK:      [[ISA_ADDR:%.*]] = getelementptr inbounds %T22class_bounded_generics1AC, %T22class_bounded_generics1AC* %0, i32 0, i32 0, i32 0
+// CHECK:      [[ISA_ADDR:%.*]] = bitcast %T22class_bounded_generics1AC* %0
 // CHECK-NEXT: [[ISA:%.*]] = load %swift.type*, %swift.type** [[ISA_ADDR]]
 // CHECK:      [[ISA_PTR:%.*]] = bitcast %swift.type* [[ISA]] to %swift.type**
 // CHECK-NEXT: [[T_ADDR:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[ISA_PTR]], i64 10

--- a/test/IRGen/class_resilience.swift
+++ b/test/IRGen/class_resilience.swift
@@ -336,7 +336,7 @@ public class ClassWithResilientThenEmpty {
 
 // CHECK:      load %swift.type*
 
-// CHECK:      [[ADDR:%.*]] = getelementptr inbounds %T16class_resilience21ResilientGenericChildC, %T16class_resilience21ResilientGenericChildC* %0, i32 0, i32 0, i32 0
+// CHECK:      [[ADDR:%.*]] = bitcast %T16class_resilience21ResilientGenericChildC* %0 to %swift.type**
 // CHECK-NEXT: [[ISA:%.*]] = load %swift.type*, %swift.type** [[ADDR]]
 // CHECK-NEXT: [[BASE:%.*]] = load [[INT]], [[INT]]* getelementptr inbounds ([[BOUNDS]], [[BOUNDS]]* @"$s16class_resilience21ResilientGenericChildCMo", i32 0, i32 0)
 // CHECK-NEXT: [[METADATA_OFFSET:%.*]] = add [[INT]] [[BASE]], {{4|8}}
@@ -557,7 +557,7 @@ public class ClassWithResilientThenEmpty {
 // ResilientChild.field getter dispatch thunk
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i32 @"$s16class_resilience14ResilientChildC5fields5Int32VvgTj"(%T16class_resilience14ResilientChildC* swiftself %0)
-// CHECK:      [[ISA_ADDR:%.*]] = getelementptr inbounds %T16class_resilience14ResilientChildC, %T16class_resilience14ResilientChildC* %0, i32 0, i32 0, i32 0
+// CHECK:      [[ISA_ADDR:%.*]] = bitcast %T16class_resilience14ResilientChildC* %0 to %swift.type**
 // CHECK-NEXT: [[ISA:%.*]] = load %swift.type*, %swift.type** [[ISA_ADDR]]
 // CHECK-NEXT: [[BASE_ADDR:%.*]] = load [[INT]], [[INT]]* getelementptr inbounds ([[BOUNDS]], [[BOUNDS]]* @"$s16class_resilience14ResilientChildCMo", i32 0, i32 0)
 // CHECK-NEXT: [[BASE:%.*]] = add [[INT]] [[BASE_ADDR]], {{4|8}}
@@ -573,7 +573,7 @@ public class ClassWithResilientThenEmpty {
 // ResilientChild.field setter dispatch thunk
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$s16class_resilience14ResilientChildC5fields5Int32VvsTj"(i32 %0, %T16class_resilience14ResilientChildC* swiftself %1)
-// CHECK:      [[ISA_ADDR:%.*]] = getelementptr inbounds %T16class_resilience14ResilientChildC, %T16class_resilience14ResilientChildC* %1, i32 0, i32 0, i32 0
+// CHECK:      [[ISA_ADDR:%.*]] = bitcast %T16class_resilience14ResilientChildC* %1 to %swift.type**
 // CHECK-NEXT: [[ISA:%.*]] = load %swift.type*, %swift.type** [[ISA_ADDR]]
 // CHECK-NEXT: [[BASE:%.*]] = load [[INT]], [[INT]]* getelementptr inbounds ([[BOUNDS]], [[BOUNDS]]* @"$s16class_resilience14ResilientChildCMo", i32 0, i32 0)
 // CHECK-NEXT: [[METADATA_OFFSET:%.*]] = add [[INT]] [[BASE]], {{8|16}}

--- a/test/IRGen/class_update_callback_with_fixed_layout.sil
+++ b/test/IRGen/class_update_callback_with_fixed_layout.sil
@@ -136,7 +136,7 @@ bb0:
 // ... dealloc_ref also does the same thing.
 
 // CHECK-NEXT: [[SELF:%.*]] = bitcast %swift.refcounted* [[ALLOC]] to %T39class_update_callback_with_fixed_layout23ClassWithResilientFieldC*
-// CHECK-NEXT: [[ISA_ADDR:%.*]] = getelementptr inbounds %T39class_update_callback_with_fixed_layout23ClassWithResilientFieldC, %T39class_update_callback_with_fixed_layout23ClassWithResilientFieldC* [[SELF]], i32 0, i32 0, i32 0
+// CHECK-NEXT: [[ISA_ADDR:%.*]] = bitcast %T39class_update_callback_with_fixed_layout23ClassWithResilientFieldC* [[SELF]]
 // CHECK-NEXT: [[META:%.*]] = load %swift.type*, %swift.type** [[ISA_ADDR]], align 8
 // CHECK-NEXT: [[META_ADDR:%.*]] = bitcast %swift.type* [[META]] to i8*
 // CHECK-NEXT: [[SIZE_ADDR:%.*]] = getelementptr inbounds i8, i8* [[META_ADDR]], i32 48

--- a/test/IRGen/class_update_callback_without_fixed_layout.sil
+++ b/test/IRGen/class_update_callback_without_fixed_layout.sil
@@ -138,7 +138,7 @@ bb0:
 // ... dealloc_ref also does the same thing.
 
 // CHECK-NEXT: [[SELF:%.*]] = bitcast %swift.refcounted* [[ALLOC]] to %T42class_update_callback_without_fixed_layout23ClassWithResilientFieldC*
-// CHECK-NEXT: [[ISA_ADDR:%.*]] = getelementptr inbounds %T42class_update_callback_without_fixed_layout23ClassWithResilientFieldC, %T42class_update_callback_without_fixed_layout23ClassWithResilientFieldC* [[SELF]], i32 0, i32 0, i32 0
+// CHECK-NEXT: [[ISA_ADDR:%.*]] = bitcast %T42class_update_callback_without_fixed_layout23ClassWithResilientFieldC* [[SELF]] to %swift.type**
 // CHECK-NEXT: [[META:%.*]] = load %swift.type*, %swift.type** [[ISA_ADDR]]
 // CHECK-NEXT: [[META_ADDR:%.*]] = bitcast %swift.type* [[META]] to i8*
 // CHECK-32-NEXT: [[SIZE_ADDR:%.*]] = getelementptr inbounds i8, i8* [[META_ADDR]], i32 28

--- a/test/IRGen/closure.swift
+++ b/test/IRGen/closure.swift
@@ -67,9 +67,9 @@ func no_capture_descriptor(_ c: C, _ d: C, _ e: C, _ f: C, _ g: C) {
 }
 
 // CHECK-LABEL: define hidden swiftcc { i8*, %swift.refcounted* } @"$s7closure9letEscape1fyycyyXE_tF"(i8* %0, %swift.opaque* %1)
-// CHECK: call i1 @swift_isEscapingClosureAtFileLocation(%swift.refcounted* {{.*}}, i8* getelementptr inbounds ({{.*}} [[FILENAME]]
+// CHECK: call zeroext i1 @swift_isEscapingClosureAtFileLocation(%swift.refcounted* {{.*}}, i8* getelementptr inbounds ({{.*}} [[FILENAME]]
 // OPT-LABEL: define hidden swiftcc { i8*, %swift.refcounted* } @"$s7closure9letEscape1fyycyyXE_tF"(i8* %0, %swift.opaque* %1)
-// OPT: call i1 @swift_isEscapingClosureAtFileLocation(%swift.refcounted* {{.*}}, i8* getelementptr inbounds ({{.*}} [[FILENAME]]
+// OPT: call zeroext i1 @swift_isEscapingClosureAtFileLocation(%swift.refcounted* {{.*}}, i8* getelementptr inbounds ({{.*}} [[FILENAME]]
 func letEscape(f: () -> ()) -> () -> () {
   return withoutActuallyEscaping(f) { return $0 }
 }

--- a/test/IRGen/dynamic_cast.sil
+++ b/test/IRGen/dynamic_cast.sil
@@ -24,7 +24,7 @@ bb0(%0 : $*P):
   // CHECK: [[T1:%.*]] = bitcast [[S]]* [[T0]] to [[OPAQUE:%swift.opaque]]*
   // CHECK: [[T2:%.*]] = bitcast [[P:%.*]]* {{%.*}} to [[OPAQUE]]*
   // CHECK: [[T4:%.*]] = call {{.*}}@"$s12dynamic_cast1P_pMD"
-  // CHECK: call i1 @swift_dynamicCast([[OPAQUE]]* [[T1]], [[OPAQUE]]* [[T2]], %swift.type* [[T4]], %swift.type* {{.*}}, [[INT]] 7)
+  // CHECK: call zeroext i1 @swift_dynamicCast([[OPAQUE]]* [[T1]], [[OPAQUE]]* [[T2]], %swift.type* [[T4]], %swift.type* {{.*}}, [[INT]] 7)
   %1 = alloc_stack $S
   unconditional_checked_cast_addr P in %0 : $*P to S in %1 : $*S
   destroy_addr %1 : $*S
@@ -40,7 +40,7 @@ bb0(%0 : $*P):
   // CHECK: [[T1:%.*]] = bitcast [[S]]* [[T0]] to [[OPAQUE:%swift.opaque]]*
   // CHECK: [[T2:%.*]] = bitcast [[P:%.*]]* {{%.*}} to [[OPAQUE]]*
   // CHECK: [[T4:%.*]] = call {{.*}}@"$s12dynamic_cast1P_pMD"
-  // CHECK: call i1 @swift_dynamicCast([[OPAQUE]]* [[T1]], [[OPAQUE]]* [[T2]], %swift.type* [[T4]], %swift.type* {{.*}}, [[INT]] 7)
+  // CHECK: call zeroext i1 @swift_dynamicCast([[OPAQUE]]* [[T1]], [[OPAQUE]]* [[T2]], %swift.type* [[T4]], %swift.type* {{.*}}, [[INT]] 7)
   %1 = alloc_stack $S
   unconditional_checked_cast_addr P in %0 : $*P to S in %1 : $*S
   destroy_addr %1 : $*S
@@ -56,7 +56,7 @@ bb0(%0 : $*P):
   // CHECK: [[T1:%.*]] = bitcast [[S]]* [[T0]] to [[OPAQUE:%swift.opaque]]*
   // CHECK: [[T2:%.*]] = bitcast [[P:%.*]]* {{%.*}} to [[OPAQUE]]*
   // CHECK: [[T4:%.*]] = call {{.*}}@"$s12dynamic_cast1P_pMD"
-  // CHECK: [[T5:%.*]] = call i1 @swift_dynamicCast([[OPAQUE]]* [[T1]], [[OPAQUE]]* [[T2]], %swift.type* [[T4]], %swift.type* {{.*}}, [[INT]] 6)
+  // CHECK: [[T5:%.*]] = call zeroext i1 @swift_dynamicCast([[OPAQUE]]* [[T1]], [[OPAQUE]]* [[T2]], %swift.type* [[T4]], %swift.type* {{.*}}, [[INT]] 6)
   // CHECK: br i1 [[T5]],
   %1 = alloc_stack $S
   checked_cast_addr_br take_always P in %0 : $*P to S in %1 : $*S, bb1, bb2
@@ -78,7 +78,7 @@ bb0(%0 : $*P):
   // CHECK: [[T1:%.*]] = bitcast [[S]]* [[T0]] to [[OPAQUE:%swift.opaque]]*
   // CHECK: [[T2:%.*]] = bitcast [[P:%.*]]* {{%.*}} to [[OPAQUE]]*
   // CHECK: [[T4:%.*]] = call {{.*}}@"$s12dynamic_cast1P_pMD"
-  // CHECK: [[T5:%.*]] = call i1 @swift_dynamicCast([[OPAQUE]]* [[T1]], [[OPAQUE]]* [[T2]], %swift.type* [[T4]], %swift.type* {{.*}}, [[INT]] 2)
+  // CHECK: [[T5:%.*]] = call zeroext i1 @swift_dynamicCast([[OPAQUE]]* [[T1]], [[OPAQUE]]* [[T2]], %swift.type* [[T4]], %swift.type* {{.*}}, [[INT]] 2)
   // CHECK: br i1 [[T5]],
   %1 = alloc_stack $S
   checked_cast_addr_br take_on_success P in %0 : $*P to S in %1 : $*S, bb1, bb2
@@ -100,7 +100,7 @@ bb0(%0 : $*P):
   // CHECK: [[T1:%.*]] = bitcast [[S]]* [[T0]] to [[OPAQUE:%swift.opaque]]*
   // CHECK: [[T2:%.*]] = bitcast [[P:%.*]]* {{%.*}} to [[OPAQUE]]*
   // CHECK: [[T4:%.*]] = call {{.*}}@"$s12dynamic_cast1P_pMD"
-  // CHECK: [[T5:%.*]] = call i1 @swift_dynamicCast([[OPAQUE]]* [[T1]], [[OPAQUE]]* [[T2]], %swift.type* [[T4]], %swift.type* {{.*}}, [[INT]] 0)
+  // CHECK: [[T5:%.*]] = call zeroext i1 @swift_dynamicCast([[OPAQUE]]* [[T1]], [[OPAQUE]]* [[T2]], %swift.type* [[T4]], %swift.type* {{.*}}, [[INT]] 0)
   // CHECK: br i1 [[T5]],
   %1 = alloc_stack $S
   checked_cast_addr_br copy_on_success P in %0 : $*P to S in %1 : $*S, bb1, bb2

--- a/test/IRGen/dynamic_self_cast.swift
+++ b/test/IRGen/dynamic_self_cast.swift
@@ -15,7 +15,7 @@ public class SelfCasts {
   }
 
   // CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swiftcc %T17dynamic_self_cast9SelfCastsC* @"$s17dynamic_self_cast9SelfCastsC09genericToD0yACXDxlFZ"(%swift.opaque* noalias nocapture %0, %swift.type* %T, %swift.type* swiftself %1)
-  // CHECK: call i1 @swift_dynamicCast(%swift.opaque* {{%.*}}, %swift.opaque* {{%.*}}, %swift.type* %T, %swift.type* %1, {{.*}})
+  // CHECK: call zeroext i1 @swift_dynamicCast(%swift.opaque* {{%.*}}, %swift.opaque* {{%.*}}, %swift.type* %T, %swift.type* %1, {{.*}})
   // CHECK: ret
   public static func genericToSelf<T>(_ s: T) -> Self {
     return s as! Self
@@ -31,7 +31,7 @@ public class SelfCasts {
   }
 
   // CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swiftcc void @"$s17dynamic_self_cast9SelfCastsC011genericFromD0xylFZ"(%swift.opaque* noalias nocapture sret({{.*}}) %0, %swift.type* %T, %swift.type* swiftself %1)
-  // CHECK: call i1 @swift_dynamicCast(%swift.opaque* {{%.*}}, %swift.opaque* {{%.*}}, %swift.type* %1, %swift.type* %T, {{.*}})
+  // CHECK: call zeroext i1 @swift_dynamicCast(%swift.opaque* {{%.*}}, %swift.opaque* {{%.*}}, %swift.type* %1, %swift.type* %T, {{.*}})
   // CHECK: ret
   public static func genericFromSelf<T>() -> T {
     let s = Self()
@@ -39,7 +39,7 @@ public class SelfCasts {
   }
 
   // CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swiftcc %swift.refcounted* @"$s17dynamic_self_cast9SelfCastsC016classGenericFromD0xyRlzClFZ"(%swift.type* %T, %swift.type* swiftself %0)
-  // CHECK: call i1 @swift_dynamicCast(%swift.opaque* {{%.*}}, %swift.opaque* {{%.*}}, %swift.type* %0, %swift.type* %T, {{.*}})
+  // CHECK: call zeroext i1 @swift_dynamicCast(%swift.opaque* {{%.*}}, %swift.opaque* {{%.*}}, %swift.type* %0, %swift.type* %T, {{.*}})
   // CHECK: ret
   public static func classGenericFromSelf<T : AnyObject>() -> T {
     let s = Self()
@@ -56,7 +56,7 @@ public class SelfCasts {
   }
 
   // CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swiftcc {{i32|i64}} @"$s17dynamic_self_cast9SelfCastsC09genericToD11ConditionalyACXDSgxlFZ"(%swift.opaque* noalias nocapture %0, %swift.type* %T, %swift.type* swiftself %1)
-  // CHECK: call i1 @swift_dynamicCast(%swift.opaque* {{%.*}}, %swift.opaque* {{%.*}}, %swift.type* %T, %swift.type* %1, {{.*}})
+  // CHECK: call zeroext i1 @swift_dynamicCast(%swift.opaque* {{%.*}}, %swift.opaque* {{%.*}}, %swift.type* %T, %swift.type* %1, {{.*}})
   // CHECK: ret
   public static func genericToSelfConditional<T>(_ s: T) -> Self? {
     return s as? Self
@@ -72,7 +72,7 @@ public class SelfCasts {
   }
 
   // CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swiftcc void @"$s17dynamic_self_cast9SelfCastsC011genericFromD11ConditionalxSgylFZ"(%swift.opaque* noalias nocapture sret({{.*}}) %0, %swift.type* %T, %swift.type* swiftself %1)
-  // CHECK: call i1 @swift_dynamicCast(%swift.opaque* {{%.*}}, %swift.opaque* {{%.*}}, %swift.type* %1, %swift.type* %T, {{.*}})
+  // CHECK: call zeroext i1 @swift_dynamicCast(%swift.opaque* {{%.*}}, %swift.opaque* {{%.*}}, %swift.type* %1, %swift.type* %T, {{.*}})
   // CHECK: ret
   public static func genericFromSelfConditional<T>() -> T? {
     let s = Self()
@@ -80,7 +80,7 @@ public class SelfCasts {
   }
 
   // CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swiftcc {{i32|i64}} @"$s17dynamic_self_cast9SelfCastsC016classGenericFromD11ConditionalxSgyRlzClFZ"(%swift.type* %T, %swift.type* swiftself %0)
-  // CHECK: call i1 @swift_dynamicCast(%swift.opaque* {{%.*}}, %swift.opaque* {{%.*}}, %swift.type* %0, %swift.type* %T, {{.*}})
+  // CHECK: call zeroext i1 @swift_dynamicCast(%swift.opaque* {{%.*}}, %swift.opaque* {{%.*}}, %swift.type* %0, %swift.type* %T, {{.*}})
   // CHECK: ret
   public static func classGenericFromSelfConditional<T : AnyObject>() -> T? {
     let s = Self()

--- a/test/IRGen/dynamic_self_metadata.swift
+++ b/test/IRGen/dynamic_self_metadata.swift
@@ -38,7 +38,7 @@ class C {
     return id(nil)
   }
   // CHECK-LABEL: define hidden swiftcc i64 @"$s21dynamic_self_metadata1CC0A12SelfArgumentACXDSgyF"(%T21dynamic_self_metadata1CC* swiftself %0)
-  // CHECK: [[GEP1:%.+]] = getelementptr {{.*}} %0
+  // CHECK: [[GEP1:%.+]] = bitcast {{.*}} %0
   // CHECK: [[TYPE1:%.+]] = load {{.*}} [[GEP1]]
   // CHECK: [[T0:%.+]] = call swiftcc %swift.metadata_response @"$sSqMa"(i64 0, %swift.type* [[TYPE1]])
   // CHECK: [[TYPE2:%.+]] = extractvalue %swift.metadata_response [[T0]], 0
@@ -49,7 +49,7 @@ class C {
     return nil
   }
   // CHECK-LABEL: define hidden swiftcc i64 @"$s21dynamic_self_metadata1CC0A18SelfConformingTypeACXDSgyF"(%T21dynamic_self_metadata1CC* swiftself %0)
-  // CHECK: [[SELF_GEP:%.+]] = getelementptr {{.*}} %0
+  // CHECK: [[SELF_GEP:%.+]] = bitcast {{.*}} %0
   // CHECK: [[SELF_TYPE:%.+]] = load {{.*}} [[SELF_GEP]]
   // CHECK: [[METADATA_RESPONSE:%.*]] = call swiftcc %swift.metadata_response @"$s21dynamic_self_metadata1GVMa"(i64 0, %swift.type* [[SELF_TYPE]])
   // CHECK: [[METADATA:%.*]] =  extractvalue %swift.metadata_response [[METADATA_RESPONSE]], 0

--- a/test/IRGen/dynamic_self_metadata_future.swift
+++ b/test/IRGen/dynamic_self_metadata_future.swift
@@ -39,7 +39,7 @@ class C {
     return id(nil)
   }
   // CHECK-LABEL: define hidden swiftcc i64 @"$s28dynamic_self_metadata_future1CC0A12SelfArgumentACXDSgyF"(%T28dynamic_self_metadata_future1CC* swiftself %0)
-  // CHECK: [[GEP1:%.+]] = getelementptr {{.*}} %0
+  // CHECK: [[GEP1:%.+]] = bitcast {{.*}} %0
   // CHECK: [[TYPE1:%.+]] = load {{.*}} [[GEP1]]
   // CHECK: [[T0:%.+]] = call swiftcc %swift.metadata_response @"$sSqMa"(i64 0, %swift.type* [[TYPE1]])
   // CHECK: [[TYPE2:%.+]] = extractvalue %swift.metadata_response [[T0]], 0
@@ -50,7 +50,7 @@ class C {
     return nil
   }
   // CHECK-LABEL: define hidden swiftcc i64 @"$s28dynamic_self_metadata_future1CC0A18SelfConformingTypeACXDSgyF"(%T28dynamic_self_metadata_future1CC* swiftself %0)
-  // CHECK: [[SELF_GEP:%.+]] = getelementptr {{.*}} %0
+  // CHECK: [[SELF_GEP:%.+]] = bitcast {{.*}} %0
   // CHECK: [[SELF_TYPE:%.+]] = load {{.*}} [[SELF_GEP]]
   // CHECK: call i8** @swift_getWitnessTable(
   // CHECK-SAME:   %swift.protocol_conformance_descriptor* bitcast (

--- a/test/IRGen/exact_self_class_metadata_peephole.swift
+++ b/test/IRGen/exact_self_class_metadata_peephole.swift
@@ -68,7 +68,7 @@ final private class FinalPrivateNonfinalSubclass<U>: PrivateNonfinal<U, String, 
   // CHECK-LABEL: define {{.*}}FinalPrivateNonfinalSubclass{{.*}}burts
   @inline(never)
   final func burts() {
-    // CHECK: [[TYPE_GEP:%.*]] = getelementptr {{.*}} %0
+    // CHECK: [[TYPE_GEP:%.*]] = bitcast {{.*}} %0
     // CHECK: [[TYPE:%.*]] = load {{.*}} [[TYPE_GEP]]
     // CHECK: call {{.*}} @useMetadata(%swift.type* [[TYPE]], %swift.type* [[TYPE]])
     useMetadata(FinalPrivateNonfinalSubclass<U>.self)
@@ -90,7 +90,7 @@ final private class PrivateFinal<T, U, V> {
 
   // CHECK-LABEL: define {{.*}}PrivateFinal{{.*}}butts
   func butts() {
-    // CHECK: [[TYPE_GEP:%.*]] = getelementptr {{.*}} %0
+    // CHECK: [[TYPE_GEP:%.*]] = bitcast {{.*}} %0
     // CHECK: [[TYPE:%.*]] = load {{.*}} [[TYPE_GEP]]
     // CHECK: call {{.*}} @useMetadata(%swift.type* [[TYPE]], %swift.type* [[TYPE]])
     useMetadata(PrivateFinal<T, U, V>.self)

--- a/test/IRGen/fixed_layout_class.swift
+++ b/test/IRGen/fixed_layout_class.swift
@@ -37,7 +37,7 @@ public func useGenericRootClassProperty<A>(_ o: GenericOutsideParent<A>) {
 
   // CHECK: [[BASE:%.*]] = load [[INT]], [[INT]]* getelementptr inbounds ({ [[INT]], i32, i32 }, { [[INT]], i32, i32 }* @"$s18fixed_layout_class20GenericOutsideParentCMo", i32 0, i32 0)
 
-  // CHECK: [[METADATA_ADDR:%.*]] = getelementptr inbounds %T18fixed_layout_class20GenericOutsideParentC, %T18fixed_layout_class20GenericOutsideParentC* %0, i32 0, i32 0, i32 0
+  // CHECK: [[METADATA_ADDR:%.*]] = bitcast %T18fixed_layout_class20GenericOutsideParentC* %0 to %swift.type**
   // CHECK: [[METADATA:%.*]] = load %swift.type*, %swift.type** [[METADATA_ADDR]]
 
   // CHECK: [[BASE:%.*]] = load [[INT]], [[INT]]* getelementptr inbounds ({ [[INT]], i32, i32 }, { [[INT]], i32, i32 }* @"$s18fixed_layout_class20GenericOutsideParentCMo", i32 0, i32 0)
@@ -68,7 +68,7 @@ public func useGenericSubclassProperty<A>(_ o: GenericOutsideChild<A>) {
   // CHECK: [[BASE:%.*]] = load [[INT]], [[INT]]* getelementptr inbounds ({ [[INT]], i32, i32 }, { [[INT]], i32, i32 }* @"$s18fixed_layout_class19GenericOutsideChildCMo", i32 0, i32 0)
 
   // CHECK: [[UPCAST:%.*]] = bitcast %T18fixed_layout_class19GenericOutsideChildC* %0 to %T18fixed_layout_class20GenericOutsideParentC*
-  // CHECK: [[METADATA_ADDR:%.*]] = getelementptr inbounds %T18fixed_layout_class20GenericOutsideParentC, %T18fixed_layout_class20GenericOutsideParentC* [[UPCAST]], i32 0, i32 0, i32 0
+  // CHECK: [[METADATA_ADDR:%.*]] = bitcast %T18fixed_layout_class20GenericOutsideParentC* [[UPCAST]] to %swift.type**
   // CHECK: [[METADATA:%.*]] = load %swift.type*, %swift.type** [[METADATA_ADDR]]
 
   // CHECK: [[BASE:%.*]] = load [[INT]], [[INT]]* getelementptr inbounds ({ [[INT]], i32, i32 }, { [[INT]], i32, i32 }* @"$s18fixed_layout_class20GenericOutsideParentCMo", i32 0, i32 0)
@@ -80,7 +80,7 @@ public func useGenericSubclassProperty<A>(_ o: GenericOutsideChild<A>) {
   // CHECK: [[FIELD_OFFSET:%.*]] = load [[INT]], [[INT]]* [[FIELD_OFFSET_PTR]]
   _ = o.property
 
-  // CHECK: [[METADATA_ADDR:%.*]] = getelementptr inbounds %T18fixed_layout_class19GenericOutsideChildC, %T18fixed_layout_class19GenericOutsideChildC* %0, i32 0, i32 0, i32 0
+  // CHECK: [[METADATA_ADDR:%.*]] = bitcast %T18fixed_layout_class19GenericOutsideChildC* %0 to %swift.type**
   // CHECK: [[METADATA:%.*]] = load %swift.type*, %swift.type** [[METADATA_ADDR]]
 
   // CHECK: [[BASE:%.*]] = load [[INT]], [[INT]]* getelementptr inbounds ({ [[INT]], i32, i32 }, { [[INT]], i32, i32 }* @"$s18fixed_layout_class19GenericOutsideChildCMo", i32 0, i32 0)

--- a/test/IRGen/generic_casts.swift
+++ b/test/IRGen/generic_casts.swift
@@ -42,7 +42,7 @@ func allToInt<T>(_ x: T) -> Int {
   // CHECK: [[T_TMP:%.*]] = bitcast i8* [[T_ALLOCA]] to %swift.opaque*
   // CHECK: [[TEMP:%.*]] = call %swift.opaque* {{.*}}(%swift.opaque* noalias [[T_TMP]], %swift.opaque* noalias %0, %swift.type* %T)
   // CHECK: [[T0:%.*]] = bitcast %TSi* [[INT_TEMP]] to %swift.opaque*
-  // CHECK: call i1 @swift_dynamicCast(%swift.opaque* [[T0]], %swift.opaque* [[T_TMP]], %swift.type* %T, %swift.type* @"$sSiN", i64 7)
+  // CHECK: call zeroext i1 @swift_dynamicCast(%swift.opaque* [[T0]], %swift.opaque* [[T_TMP]], %swift.type* %T, %swift.type* @"$sSiN", i64 7)
   // CHECK: [[T0:%.*]] = getelementptr inbounds %TSi, %TSi* [[INT_TEMP]], i32 0, i32 0
   // CHECK: [[INT_RESULT:%.*]] = load i64, i64* [[T0]],
   // CHECK: ret i64 [[INT_RESULT]]
@@ -54,7 +54,7 @@ func intToAll<T>(_ x: Int) -> T {
   // CHECK: [[T0:%.*]] = getelementptr inbounds %TSi, %TSi* [[INT_TEMP]], i32 0, i32 0
   // CHECK: store i64 %1, i64* [[T0]],
   // CHECK: [[T0:%.*]] = bitcast %TSi* [[INT_TEMP]] to %swift.opaque*
-  // CHECK: call i1 @swift_dynamicCast(%swift.opaque* %0, %swift.opaque* [[T0]], %swift.type* @"$sSiN", %swift.type* %T, i64 7)
+  // CHECK: call zeroext i1 @swift_dynamicCast(%swift.opaque* %0, %swift.opaque* [[T0]], %swift.type* @"$sSiN", %swift.type* %T, i64 7)
   return x as! T
 }
 
@@ -98,7 +98,7 @@ func classExistentialToOpaqueArchetype<T>(_ x: ObjCProto1) -> T {
   // CHECK: [[LOCAL:%.*]] = alloca %T13generic_casts10ObjCProto1P
   // CHECK: [[LOCAL_OPAQUE:%.*]] = bitcast %T13generic_casts10ObjCProto1P* [[LOCAL]] to %swift.opaque*
   // CHECK: [[PROTO_TYPE:%.*]] = call {{.*}}@"$s13generic_casts10ObjCProto1_pMD"
-  // CHECK: call i1 @swift_dynamicCast(%swift.opaque* %0, %swift.opaque* [[LOCAL_OPAQUE]], %swift.type* [[PROTO_TYPE]], %swift.type* %T, i64 7)
+  // CHECK: call zeroext i1 @swift_dynamicCast(%swift.opaque* %0, %swift.opaque* [[LOCAL_OPAQUE]], %swift.type* [[PROTO_TYPE]], %swift.type* %T, i64 7)
   return x as! T
 }
 

--- a/test/IRGen/object_type.swift
+++ b/test/IRGen/object_type.swift
@@ -36,7 +36,7 @@ func work() {
 // CHECK-IR: call {{.*}} @swift_getObjectType({{.*}}) #[[M:[0-9]+]]
 // CHECK-IR: declare {{.*}} @swift_getObjectType{{.*}} local_unnamed_addr #[[N:[0-9]+]]
 // CHECK-IR: attributes #[[N]] = { mustprogress nofree nounwind readonly willreturn }
-// CHECK-IR: attributes #[[M]] = { nounwind readonly }
+// CHECK-IR: attributes #[[M]] = { nounwind readonly willreturn }
 
 // CHECK: okay
 work()

--- a/test/IRGen/partial_apply_forwarder.sil
+++ b/test/IRGen/partial_apply_forwarder.sil
@@ -94,7 +94,7 @@ sil hidden_external @takingEmptyAndQ : $@convention(thin) <τ_0_0 where  τ_0_0 
 // CHECK-LABEL: define internal swiftcc void @"$s7takingQTA"(%swift.refcounted* swiftself %0)
 // CHECK: entry:
 // CHECK:   [[WB:%.*]] = bitcast %swift.refcounted* %0 to %T23partial_apply_forwarder7WeakBoxC*
-// CHECK:   [[TYADDR:%.*]] = getelementptr inbounds %T23partial_apply_forwarder7WeakBoxC, %T23partial_apply_forwarder7WeakBoxC* %1, i32 0, i32 0, i32 0
+// CHECK:   [[TYADDR:%.*]] = bitcast %T23partial_apply_forwarder7WeakBoxC* %1
 // CHECK:   [[TY:%.*]] = load %swift.type*, %swift.type** [[TYADDR]]
 // CHECK:   [[GENPARAMSADDR:%.*]] = bitcast %swift.type* [[TY]] to %swift.type**
 // CHECK-objc:   [[PARAMTYADDR:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[GENPARAMSADDR]], {{(i64 10|i32 13)}}
@@ -153,7 +153,7 @@ bb0(%0 : $*τ_0_1, %2: $EmptyType):
 
 // CHECK-LABEL: define internal swiftcc void @"$s7takingQTA.1"(%T23partial_apply_forwarder7WeakBoxC* %0, %swift.refcounted* swiftself %1)
 // CHECK: entry:
-// CHECK:   [[TYADDR:%.*]] = getelementptr inbounds %T23partial_apply_forwarder7WeakBoxC, %T23partial_apply_forwarder7WeakBoxC* %0
+// CHECK:   [[TYADDR:%.*]] = bitcast %T23partial_apply_forwarder7WeakBoxC* %0
 // CHECK:   [[TY:%.*]] = load %swift.type*, %swift.type** [[TYADDR]]
 // CHECK:   [[CAST:%.*]] = bitcast %T23partial_apply_forwarder7WeakBoxC* %0 to %T23partial_apply_forwarder7WeakBoxC.1*
 // CHECK:   [[TYPARAMSADDR:%.*]] = bitcast %swift.type* [[TY]] to %swift.type**
@@ -207,7 +207,7 @@ sil hidden_external @takingQAndS : $@convention(thin) <τ_0_0 where  τ_0_0 : Q>
 // CHECK:   [[WB:%.*]] = load %T23partial_apply_forwarder7WeakBoxC*, %T23partial_apply_forwarder7WeakBoxC** [[WBADDR]]
 // CHECK:   [[WBREF:%.*]] = bitcast %T23partial_apply_forwarder7WeakBoxC* [[WB]] to %swift.refcounted*
 // CHECK:   call %swift.refcounted* @swift_retain(%swift.refcounted* returned [[WBREF]])
-// CHECK:   [[TYADDR:%.*]] = getelementptr inbounds %T23partial_apply_forwarder7WeakBoxC, %T23partial_apply_forwarder7WeakBoxC* [[WB]], i32 0, i32 0, i32 0
+// CHECK:   [[TYADDR:%.*]] = bitcast %T23partial_apply_forwarder7WeakBoxC* [[WB]]
 // CHECK:   [[TY:%.*]] = load %swift.type*, %swift.type** [[TYADDR]]
 // CHECK:   %.asUnsubstituted = bitcast %T23partial_apply_forwarder7WeakBoxC* [[WB]] to %T23partial_apply_forwarder7WeakBoxC.1*
 // CHECK:   call void @swift_release(%swift.refcounted* %0)

--- a/test/IRGen/protocol_with_superclass.sil
+++ b/test/IRGen/protocol_with_superclass.sil
@@ -54,7 +54,7 @@ bb0(%0 : $Concrete, %1 : $SuperProto, %2 : $SuperProto & Concrete, %3 : $ProtoRe
 
   // CHECK-objc:        [[ISA:%.*]] = call %swift.type* @swift_getObjectType(%objc_object* %{{[0-9]+}})
   // CHECK-objc-NEXT:   [[OBJECT:%.*]] = bitcast %objc_object* %{{[0-9]+}} to i8*
-  // CHECK-native:      [[ISA_ADDR:%.*]] = getelementptr inbounds %swift.refcounted, %swift.refcounted* %1, i32 0, i32 0
+  // CHECK-native:      [[ISA_ADDR:%.*]] = bitcast %swift.refcounted* %1
   // CHECK-native-NEXT: [[ISA:%.*]] = load %swift.type*, %swift.type** [[ISA_ADDR]]
   // CHECK-native-NEXT: [[OBJECT:%.*]] = bitcast %swift.refcounted* %1 to i8*
   // CHECK-NEXT:        [[RESULT:%.*]] = call { i8*, i8** } @dynamic_cast_existential_1_unconditional(i8* [[OBJECT]], %swift.type* [[ISA]], {{.*}} @"$s24protocol_with_superclass17ProtoRefinesClassMp"
@@ -67,7 +67,7 @@ bb0(%0 : $Concrete, %1 : $SuperProto, %2 : $SuperProto & Concrete, %3 : $ProtoRe
 
   // CHECK-objc:        [[ISA:%.*]] = call %swift.type* @swift_getObjectType(%objc_object* %{{[0-9]+}})
   // CHECK-objc-NEXT:   [[OBJECT:%.*]] = bitcast %objc_object* %{{[0-9]+}} to i8*
-  // CHECK-native:      [[ISA_ADDR:%.*]] = getelementptr inbounds %swift.refcounted, %swift.refcounted* %1, i32 0, i32 0
+  // CHECK-native:      [[ISA_ADDR:%.*]] = bitcast %swift.refcounted* %1
   // CHECK-native-NEXT: [[ISA:%.*]] = load %swift.type*, %swift.type** [[ISA_ADDR]]
   // CHECK-native-NEXT: [[OBJECT:%.*]] = bitcast %swift.refcounted* %1 to i8*
   // CHECK-NEXT:        [[RESULT:%.*]] = call { i8*, i8** } @dynamic_cast_existential_1_unconditional(i8* [[OBJECT]], %swift.type* [[ISA]], {{.*}} @"$s24protocol_with_superclass8SubProtoMp"

--- a/test/IRGen/protocol_with_superclass_where_clause.sil
+++ b/test/IRGen/protocol_with_superclass_where_clause.sil
@@ -54,7 +54,7 @@ bb0(%0 : $Concrete, %1 : $SuperProto, %2 : $SuperProto & Concrete, %3 : $ProtoRe
 
   // CHECK-objc:        [[ISA:%.*]] = call %swift.type* @swift_getObjectType(%objc_object* %{{[0-9]+}})
   // CHECK-objc-NEXT:   [[OBJECT:%.*]] = bitcast %objc_object* %{{[0-9]+}} to i8*
-  // CHECK-native:      [[ISA_ADDR:%.*]] = getelementptr inbounds %swift.refcounted, %swift.refcounted* %1, i32 0, i32 0
+  // CHECK-native:      [[ISA_ADDR:%.*]] = bitcast %swift.refcounted* %1
   // CHECK-native-NEXT: [[ISA:%.*]] = load %swift.type*, %swift.type** [[ISA_ADDR]]
   // CHECK-native-NEXT: [[OBJECT:%.*]] = bitcast %swift.refcounted* %1 to i8*
   // CHECK-NEXT:        [[RESULT:%.*]] = call { i8*, i8** } @dynamic_cast_existential_1_unconditional(i8* [[OBJECT]], %swift.type* [[ISA]], {{.*}} @"$s24protocol_with_superclass17ProtoRefinesClassMp"
@@ -67,7 +67,7 @@ bb0(%0 : $Concrete, %1 : $SuperProto, %2 : $SuperProto & Concrete, %3 : $ProtoRe
 
   // CHECK-objc:        [[ISA:%.*]] = call %swift.type* @swift_getObjectType(%objc_object* %{{[0-9]+}})
   // CHECK-objc-NEXT:   [[OBJECT:%.*]] = bitcast %objc_object* %{{[0-9]+}} to i8*
-  // CHECK-native:      [[ISA_ADDR:%.*]] = getelementptr inbounds %swift.refcounted, %swift.refcounted* %1, i32 0, i32 0
+  // CHECK-native:      [[ISA_ADDR:%.*]] = bitcast %swift.refcounted* %1
   // CHECK-native-NEXT: [[ISA:%.*]] = load %swift.type*, %swift.type** [[ISA_ADDR]]
   // CHECK-native-NEXT: [[OBJECT:%.*]] = bitcast %swift.refcounted* %1 to i8*
   // CHECK-NEXT:        [[RESULT:%.*]] = call { i8*, i8** } @dynamic_cast_existential_1_unconditional(i8* [[OBJECT]], %swift.type* [[ISA]], {{.*}} @"$s24protocol_with_superclass8SubProtoMp"

--- a/test/IRGen/tail_alloc.sil
+++ b/test/IRGen/tail_alloc.sil
@@ -199,8 +199,7 @@ bb0(%0 : $TestClass, %1 : $@thick T.Type):
 // CHECK-NEXT: [[S3:%[0-9]+]] = ptrtoint %Ts4Int8V* [[S2]] to i64
 // CHECK-NEXT: [[S4:%[0-9]+]] = add nuw i64 [[S3]], 3
 // CHECK-NEXT: [[S5:%[0-9]+]] = and i64 [[S4]], -4
-// CHECK-NEXT: [[S6:%[0-9]+]] = inttoptr i64 [[S5]] to %Ts4Int8V*
-// CHECK-NEXT: [[S7:%[0-9]+]] = bitcast %Ts4Int8V* [[S6]] to %Ts5Int32V*
+// CHECK-NEXT: [[S6:%[0-9]+]] = inttoptr i64 [[S5]] to %Ts5Int32V*
 // CHECK: ret
 sil @project_tail_index_byte_to_int : $@convention(thin) (Builtin.RawPointer, Int32) -> () {
 bb0(%0 : $Builtin.RawPointer, %1 : $Int32):


### PR DESCRIPTION
In preparation for moving to llvm's opaque pointer representation replace getPointerElementType and CreateCall/CreateLoad/Store uses that dependent on the address operand's pointer element type.

This means an `Address` carries the element type and we use `FunctionPointer` in more places or read the function type off the `llvm::Function`.