### PR TITLE
Parse: Offer a fix-it when platform is specified with the wrong case in availability attributes and queries

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1513,7 +1513,10 @@ ERROR(attr_availability_multiple_kinds ,none,
 WARNING(attr_availability_invalid_duplicate,none,
         "'%0' argument has already been specified", (StringRef))
 WARNING(attr_availability_unknown_platform,none,
-      "unknown platform '%0' for attribute '%1'", (StringRef, StringRef))
+       "unknown platform '%0' for attribute '%1'", (StringRef, StringRef))
+WARNING(attr_availability_suggest_platform,none,
+       "unknown platform '%0' for attribute '%1'; did you mean '%2'?",
+       (StringRef, StringRef, StringRef))
 ERROR(attr_availability_expected_platform,none,
       "expected platform in '%0' attribute", (StringRef))
 ERROR(attr_availability_invalid_renamed,none,
@@ -1897,6 +1900,10 @@ ERROR(avail_query_expected_rparen,PointsToFirstBadToken,
 
 WARNING(avail_query_unrecognized_platform_name,
         PointsToFirstBadToken, "unrecognized platform name %0", (Identifier))
+WARNING(avail_query_suggest_platform_name,
+        PointsToFirstBadToken, "unrecognized platform name %0;"
+        " did you mean '%1'?",
+        (Identifier, StringRef))
 
 ERROR(avail_query_disallowed_operator, PointsToFirstBadToken,
       "'%0' cannot be used in an availability condition", (StringRef))

--- a/include/swift/AST/PlatformKind.h
+++ b/include/swift/AST/PlatformKind.h
@@ -41,6 +41,10 @@ StringRef platformString(PlatformKind platform);
 /// or None if such a platform kind does not exist.
 Optional<PlatformKind> platformFromString(StringRef Name);
 
+/// Returns a valid platform string if the candidate string would be a valid
+/// platform string if its case were adjusted (e.g. "macos" -> "macOS").
+Optional<StringRef> caseCorrectedPlatformString(StringRef candidate);
+
 /// Returns a human-readable version of the platform name as a string, suitable
 /// for emission in diagnostics (e.g., "macOS").
 StringRef prettyPlatformString(PlatformKind platform);

--- a/lib/AST/PlatformKind.cpp
+++ b/lib/AST/PlatformKind.cpp
@@ -58,6 +58,15 @@ Optional<PlatformKind> swift::platformFromString(StringRef Name) {
       .Default(Optional<PlatformKind>());
 }
 
+Optional<StringRef> swift::caseCorrectedPlatformString(StringRef candidate) {
+#define AVAILABILITY_PLATFORM(X, PrettyName)                                   \
+  if (candidate.compare_insensitive(#X) == 0) {                                \
+    return StringRef(#X);                                                      \
+  }
+#include "swift/AST/PlatformKinds.def"
+  return None;
+}
+
 static bool isApplicationExtensionPlatform(PlatformKind Platform) {
   switch (Platform) {
   case PlatformKind::macOSApplicationExtension:

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3952,8 +3952,15 @@ Parser::parsePlatformVersionConstraintSpec() {
       platformFromString(PlatformIdentifier.str());
 
   if (!Platform.hasValue() || Platform.getValue() == PlatformKind::none) {
-    diagnose(Tok, diag::avail_query_unrecognized_platform_name,
-             PlatformIdentifier);
+    if (auto CorrectedPlatform =
+            caseCorrectedPlatformString(PlatformIdentifier.str())) {
+      diagnose(PlatformLoc, diag::avail_query_suggest_platform_name,
+               PlatformIdentifier, *CorrectedPlatform)
+          .fixItReplace(PlatformLoc, *CorrectedPlatform);
+    } else {
+      diagnose(PlatformLoc, diag::avail_query_unrecognized_platform_name,
+               PlatformIdentifier);
+    }
     Platform = PlatformKind::none;
   }
 

--- a/test/Parse/availability_query.swift
+++ b/test/Parse/availability_query.swift
@@ -46,6 +46,9 @@ if #available(iDishwasherOS 10.51) { // expected-warning {{unrecognized platform
 if #available(iDishwasherOS 10.51, *) { // expected-warning {{unrecognized platform name 'iDishwasherOS'}}
 }
 
+if #available(macos 10.51, *) { // expected-warning {{unrecognized platform name 'macos'; did you mean 'macOS'?}} {{15-20=macOS}}
+}
+
 if #available(OSX 10.51, OSX 10.52, *) {  // expected-error {{version for 'macOS' already specified}}
 }
 

--- a/test/Parse/availability_query_unavailability.swift
+++ b/test/Parse/availability_query_unavailability.swift
@@ -43,6 +43,9 @@ if #unavailable(iDishwasherOS 10.51) { // expected-warning {{unrecognized platfo
 if #unavailable(iDishwasherOS 10.51) { // expected-warning {{unrecognized platform name 'iDishwasherOS'}}
 }
 
+if #unavailable(macos 10.51) { // expected-warning {{unrecognized platform name 'macos'; did you mean 'macOS'?}} {{17-22=macOS}}
+}
+
 if #unavailable(OSX 10.51, OSX 10.52) {  // expected-error {{version for 'macOS' already specified}}
 }
 

--- a/test/Sema/availability_define_parsing.swift
+++ b/test/Sema/availability_define_parsing.swift
@@ -4,6 +4,7 @@
 // RUN:   -define-availability "_justAName" \
 // RUN:   -define-availability "_brokenPlatforms:spaceOS 10.11" \
 // RUN:   -define-availability "_refuseWildcard:iOS 13.0, *, macOS 11.0" \
+// RUN:   -define-availability "_incorrectCase:ios 13.0, macos 11.0" \
 // RUN:   -define-availability "_duplicateVersion 1.0:iOS 13.0" \
 // RUN:   -define-availability "_duplicateVersion 1.0:iOS 13.0" \
 // RUN:   2>&1 | %FileCheck %s
@@ -21,11 +22,17 @@ public func brokenPlatforms() {}
 // CHECK: -define-availability argument:1:11: error: expected ':' after '_justAName' in availability macro definition
 // CHECK-NEXT: _justAName
 
-// CHECK: -define-availability argument:1:31: warning: unrecognized platform name 'spaceOS'
+// CHECK: -define-availability argument:1:18: warning: unrecognized platform name 'spaceOS'
 // CHECK-NEXT: _brokenPlatforms:spaceOS 10.11
 
 // CHECK: -define-availability argument:1:27: error: future platforms identified by '*' cannot be used in an availability macro
 // CHECK-NEXT: _refuseWildcard
+
+// CHECK: -define-availability argument:1:16: warning: unrecognized platform name 'ios'; did you mean 'iOS'?
+// CHECK-NEXT: _incorrectCase
+
+// CHECK: -define-availability argument:1:26: warning: unrecognized platform name 'macos'; did you mean 'macOS'?
+// CHECK-NEXT: _incorrectCase
 
 // CHECK: duplicate definition of availability macro '_duplicateVersion' for version '1.0'
 // CHECK-NEXT: _duplicateVersion

--- a/test/Sema/diag_originally_definedin.swift
+++ b/test/Sema/diag_originally_definedin.swift
@@ -27,6 +27,11 @@ public func macroVersioned() {}
 public func macroUnknown() {}
 
 @available(macOS 10.9, *)
+@_originallyDefinedIn(module: "original", macos 10.13) // expected-warning {{unknown platform 'macos' for attribute '@_originallyDefinedIn'; did you mean 'macOS'?}} {{43-48=macOS}}
+// expected-error@-1 {{expected at least one platform version in '@_originallyDefinedIn' attribute}}
+public func incorrectPlatformCase() {}
+
+@available(macOS 10.9, *)
 @_originallyDefinedIn(module: "original", swift 5.1) // expected-warning {{unknown platform 'swift' for attribute '@_originallyDefinedIn'}}
 // expected-error@-1 {{expected at least one platform version in '@_originallyDefinedIn' attribute}}
 public func swiftVersionMacro() {}

--- a/test/attr/attr_availability.swift
+++ b/test/attr/attr_availability.swift
@@ -20,6 +20,9 @@ func noKind() {}
 @available(badPlatform, unavailable) // expected-warning {{unknown platform 'badPlatform' for attribute 'available'}}
 func unavailable_bad_platform() {}
 
+@available(macos, unavailable) // expected-warning {{unknown platform 'macos' for attribute 'available'; did you mean 'macOS'?}} {{12-17=macOS}}
+func incorrect_platform_case() {}
+
 // Handle unknown platform.
 @available(HAL9000, unavailable) // expected-warning {{unknown platform 'HAL9000'}}
 func availabilityUnknownPlatform() {}
@@ -223,6 +226,12 @@ func shortFormWithUnrecognizedPlatform() {
 // expected-warning@-1 {{unrecognized platform name 'iDishwasherOS'}}
 // expected-warning@-2 {{unrecognized platform name 'iRefrigeratorOS'}}
 func shortFormWithTwoUnrecognizedPlatforms() {
+}
+
+@available(ios 8.0, macos 10.12, *)
+// expected-warning@-1 {{unrecognized platform name 'ios'; did you mean 'iOS'?}}
+// expected-warning@-2 {{unrecognized platform name 'macos'; did you mean 'macOS'?}}
+func shortFormWithTwoPlatformsIncorrectCase() {
 }
 
 // Make sure that even after the parser hits an unrecognized

--- a/test/attr/attr_backDeploy.swift
+++ b/test/attr/attr_backDeploy.swift
@@ -253,6 +253,10 @@ public func transparentFunc() {}
 
 // MARK: - Attribute parsing
 
+@available(macOS 11.0, iOS 14.0, *)
+@_backDeploy(before: macos 12.0, iOS 15.0) // expected-warning {{unknown platform 'macos' for attribute '@_backDeploy'; did you mean 'macOS'?}} {{22-27=macOS}}
+public func incorrectPlatformCaseFunc() {}
+
 @available(macOS 11.0, *)
 @_backDeploy(before: macOS 12.0, unknownOS 1.0) // expected-warning {{unknown platform 'unknownOS' for attribute '@_backDeploy'}}
 public func unknownOSFunc() {}

--- a/test/attr/spi_available.swift
+++ b/test/attr/spi_available.swift
@@ -11,3 +11,6 @@ public class SPIClass3 {}
 
 @_spi_available(macOS 10.4, *)
 public class SPIClass4 {} // expected-warning {{symbols that are @_spi_available on all platforms should use @_spi instead}}
+
+@_spi_available(macos 10.15, *) // expected-warning {{unrecognized platform name 'macos'; did you mean 'macOS'?}} {{17-22=macOS}}
+public class SPIClass5 {}


### PR DESCRIPTION
Example:
```
availability.swift:23:12: warning: unknown platform 'macos' for attribute 'available'; did you mean 'macOS'?
@available(macos, unavailable)
           ^~~~~
           macOS
```

Resolves rdar://100195680