### PR TITLE
Unbreak delta reporting in benchmarks

### DIFF
--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -665,8 +665,7 @@ final class TestRunner {
           (c.logMemory ? [r.meta?.maxRSS].compactMap { $0 } : []) +
           (c.logMeta ? r.meta.map {
             [$0.pages, $0.ics, $0.yields] } ?? [] : [])
-        return values.map {
-          (c.delta && $0 == 0) ? "" : String($0) } // drop 0s in deltas
+        return values.map { String($0) }
       }
       let benchmarkStats = (
         [index, t.name] + (results.map(values) ?? ["Unsupported"])


### PR DESCRIPTION
`build-script -B` has been broken for me for a while.  I finally tracked it down to this bit of code.

The logic here was apparently intended to omit literal zeros from deltas to save a few bytes, but it instead drops all zeros from all columns. Remove the condition that drops zeros in order to avoid confusing the many scripts that consume this data.

**Alternatives Considered**

I'm probably going to entirely drop the delta form in an upcoming PR, so I didn't think it was worthwhile to do something more complex, such as:

* Fixing this logic to only omit zeros from actual delta columns

* Rewriting all the client scripts to treat any empty column as zero