### PR TITLE
SILGen: Apply function_conversion peephole to CaptureListExprs.

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1804,7 +1804,7 @@ RValue RValueEmitter::visitFunctionConversionExpr(FunctionConversionExpr *e,
   // TODO: Move this up when we can emit closures directly with C calling
   // convention.
   auto subExpr = e->getSubExpr()->getSemanticsProvidingExpr();
-  if (isa<AbstractClosureExpr>(subExpr)
+  if ((isa<AbstractClosureExpr>(subExpr) || isa<CaptureListExpr>(subExpr))
       && canPeepholeLiteralClosureConversion(subExpr->getType(),
                                              e->getType())) {
     // If we're emitting into a context with a preferred abstraction pattern

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1754,11 +1754,26 @@ static bool canPeepholeLiteralClosureConversion(Type literalType,
     return true;
   }
   
-  // Does the conversion only add `throws`?
-  if (literalFnType->isEqual(convertedFnType->getWithoutThrowing())) {
+  // Are the types equivalent aside from effects (throws) or coeffects
+  // (escaping)? Then we should emit the literal as having the destination type
+  // (co)effects, even if it doesn't exercise them.
+  //
+  // TODO: We could also in principle let `async` through here, but that
+  // interferes with the implementation of `reasync`.
+  auto literalWithoutEffects = literalFnType->getExtInfo().intoBuilder()
+    .withThrows(false)
+    .withNoEscape(false)
+    .build();
+    
+  auto convertedWithoutEffects = convertedFnType->getExtInfo().intoBuilder()
+    .withThrows(false)
+    .withNoEscape(false)
+    .build();
+  if (literalFnType->withExtInfo(literalWithoutEffects)
+        ->isEqual(convertedFnType->withExtInfo(convertedWithoutEffects))) {
     return true;
   }
-  
+
   return false;
 }
 

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -82,6 +82,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#define DEBUG_TYPE "silgen-poly"
 #include "ExecutorBreadcrumb.h"
 #include "Initialization.h"
 #include "LValue.h"
@@ -3054,6 +3055,24 @@ static ManagedValue createThunk(SILGenFunction &SGF,
                                 const TypeLowering &expectedTL) {
   auto substSourceType = fn.getType().castTo<SILFunctionType>();
   auto substExpectedType = expectedTL.getLoweredType().castTo<SILFunctionType>();
+  
+  LLVM_DEBUG(llvm::dbgs() << "=== Generating reabstraction thunk from:\n";
+             substSourceType.dump(llvm::dbgs());
+             llvm::dbgs() << "\n    to:\n";
+             substExpectedType.dump(llvm::dbgs());
+             llvm::dbgs() << "\n    for source location:\n";
+             if (auto d = loc.getAsASTNode<Decl>()) {
+               d->dump(llvm::dbgs());
+             } else if (auto e = loc.getAsASTNode<Expr>()) {
+               e->dump(llvm::dbgs());
+             } else if (auto s = loc.getAsASTNode<Stmt>()) {
+               s->dump(llvm::dbgs());
+             } else if (auto p = loc.getAsASTNode<Pattern>()) {
+               p->dump(llvm::dbgs());
+             } else {
+               loc.dump();
+             }
+             llvm::dbgs() << "\n");
   
   // Apply substitutions in the source and destination types, since the thunk
   // doesn't change because of different function representations.

--- a/test/SILGen/closure_literal_reabstraction.swift
+++ b/test/SILGen/closure_literal_reabstraction.swift
@@ -1,0 +1,26 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+func gen<T, U>(f: (T) throws -> U) {}
+
+struct Butt {
+    var x: Int
+}
+
+// CHECK-LABEL: sil {{.*}} @{{.*}}reabstractCaptureListExprArgument
+// CHECK:         [[CLOSURE_FN:%.*]] = function_ref {{.*}}U_
+// CHECK:         [[CLOSURE:%.*]] = partial_apply {{.*}}[[CLOSURE_FN]]
+// CHECK:         [[CLOSURE_NE:%.*]] = convert_escape_to_noescape {{.*}} [[CLOSURE]]
+// CHECK:         apply {{.*}}<Int, Int>([[CLOSURE_NE]])
+func reabstractCaptureListExprArgument() {
+    gen(f: {[x = 42] y in x + y })
+}
+
+// CHECK-LABEL: sil {{.*}} @{{.*}}reabstractKeyPathFunctionArgument
+// CHECK:         [[CLOSURE_FN:%.*]] = function_ref {{.*}}U_
+// CHECK:         [[KP_ARG:%.*]] = copy_value {{.*}} $KeyPath
+// CHECK:         [[CLOSURE:%.*]] = partial_apply {{.*}}[[CLOSURE_FN]]([[KP_ARG]])
+// CHECK:         [[CLOSURE_NE:%.*]] = convert_escape_to_noescape {{.*}} [[CLOSURE]]
+// CHECK:         apply {{.*}}<Butt, Int>([[CLOSURE_NE]])
+func reabstractKeyPathFunctionArgument() {
+    gen(f: \Butt.x)
+}

--- a/test/SILGen/closure_literal_reabstraction.swift
+++ b/test/SILGen/closure_literal_reabstraction.swift
@@ -24,3 +24,11 @@ func reabstractCaptureListExprArgument() {
 func reabstractKeyPathFunctionArgument() {
     gen(f: \Butt.x)
 }
+
+// CHECK-LABEL: sil {{.*}} @{{.*}}reabstractStaticMemberRef
+// CHECK:         [[CLOSURE_FN:%.*]] = function_ref {{.*}}u_
+// CHECK:         [[CLOSURE:%.*]] = thin_to_thick_function [[CLOSURE_FN]]
+// CHECK:         apply {{.*}}<Int, Butt>([[CLOSURE]])
+func reabstractStaticMemberRef() {
+    gen(f: Butt.init)
+}

--- a/test/SILOptimizer/closure_lifetime_fixup.swift
+++ b/test/SILOptimizer/closure_lifetime_fixup.swift
@@ -95,15 +95,10 @@ public func dontCrash<In, Out>(test: Bool, body: @escaping ((In) -> Out, In) -> 
 }
 
 // CHECK-LABEL: sil @$s22closure_lifetime_fixup28to_stack_of_convert_function1pySvSg_tF
-// CHECK:  [[FN:%.*]] = function_ref @$s22closure_lifetime_fixup28to_stack_of_convert_function1pySvSg_tFSSSvcfu_ : $@convention(thin) (UnsafeMutableRawPointer) -> @owned String
+// CHECK:  [[FN:%.*]] = function_ref @$s22closure_lifetime_fixup28to_stack_of_convert_function1pySvSg_tFSSSvcfu_ :
 // CHECK:  [[PA:%.*]] = thin_to_thick_function [[FN]]
-// CHECK:  [[CVT:%.*]] = convert_function [[PA]]
-// CHECK:  [[CVT2:%.*]] = convert_escape_to_noescape [[CVT]]
-// CHECK:  [[REABSTRACT:%.*]] = function_ref @$sSvSSs5Error_pIgyozo_SvSSsAA_pIegnrzo_TR
-// CHECK:  [[PA2:%.*]] = partial_apply [callee_guaranteed] [on_stack] [[REABSTRACT]]([[CVT2]])
-// CHECK:  [[CF2:%.*]] = convert_function [[PA2]]
 // CHECK:  [[MAP:%.*]] = function_ref @$sSq3mapyqd__Sgqd__xKXEKlF
-// CHECK:  try_apply [[MAP]]<UnsafeMutableRawPointer, String>({{.*}}, [[CF2]], {{.*}})
+// CHECK:  try_apply [[MAP]]<UnsafeMutableRawPointer, String>({{.*}}, [[PA]], {{.*}})
 public func to_stack_of_convert_function(p: UnsafeMutableRawPointer?) {
   _ = p.map(String.init(describing:))
 }


### PR DESCRIPTION
Don't let a capture list suppress the reabstraction peephole when a closure literal appears in a context with a function conversion.