### PR TITLE
[cxx-interop] A few fixes for how we handle class templates specialization.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2657,7 +2657,7 @@ namespace {
       if (isSpecializationDepthGreaterThan(decl, 8))
         return nullptr;
 
-      if (Impl.templateSpecializationsCount[classTemplate] > 4096) {
+      if (Impl.templateSpecializationsCount[classTemplate] > 1000) {
         std::string name;
         llvm::raw_string_ostream os(name);
         decl->printQualifiedName(os);

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -631,9 +631,10 @@ public:
   llvm::DenseMap<clang::FunctionDecl *, ValueDecl *>
       specializedFunctionTemplates;
 
-  /// Stores qualified names of C++ template specializations that were too deep
-  /// to import into Swift.
-  llvm::StringSet<> tooDeepTemplateSpecializations;
+  /// Stores the number of specializations Swift has seen for a given class
+  /// template.
+  llvm::DenseMap<clang::ClassTemplateDecl *, unsigned>
+      templateSpecializationsCount;
 
   /// Keeps track of the Clang functions that have been turned into
   /// properties.

--- a/stdlib/public/Cxx/std/libstdcxx.modulemap
+++ b/stdlib/public/Cxx/std/libstdcxx.modulemap
@@ -81,5 +81,10 @@ module std {
       requires cplusplus
       export *
     }
+    module stddef_h {
+      header "stddef.h"
+      requires cplusplus
+      export *
+    }
   }
 }


### PR DESCRIPTION
This should mostly be a NFC.

* Don't call `ClassTemplateDecl::specializations` to prevent modularization issues.
* Improve compile time (by not loading as many specializations and lowering the threashold).
* Lazily emit un-imported class template errors.
* Remove isSpecializationDepthGreaterThan hack.
