### PR TITLE
Add 'forRequirement' distinction to createTypeAliasType

### DIFF
--- a/include/swift/AST/ASTDemangler.h
+++ b/include/swift/AST/ASTDemangler.h
@@ -89,7 +89,8 @@ public:
 
   Type createNominalType(GenericTypeDecl *decl, Type parent);
 
-  Type createTypeAliasType(GenericTypeDecl *decl, Type parent);
+  Type createTypeAliasType(GenericTypeDecl *decl, Type parent,
+                           bool forRequirement = true);
 
   Type createBoundGenericType(GenericTypeDecl *decl, ArrayRef<Type> args);
   

--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -531,7 +531,7 @@ protected:
         return *error;
 
       if (typeAlias)
-        return Builder.createTypeAliasType(typeDecl, parent);
+        return Builder.createTypeAliasType(typeDecl, parent, forRequirement);
 
       return Builder.createNominalType(typeDecl, parent);
     }

--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -518,7 +518,7 @@ public:
 
   const TypeRef *
   createTypeAliasType(const BuiltTypeDecl &typeRefDecl,
-                      const TypeRef *parent) {
+                      const TypeRef *parent, bool forRequirement = true) {
     // TypeRefs don't contain sugared types
     return nullptr;
   }

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1526,8 +1526,9 @@ public:
     return createBoundGenericType(metadataOrTypeDecl, { }, parent);
   }
 
-  TypeLookupErrorOr<BuiltType> createTypeAliasType(BuiltTypeDecl typeAliasDecl,
-                                                   BuiltType parent) const {
+  TypeLookupErrorOr<BuiltType>
+  createTypeAliasType(BuiltTypeDecl typeAliasDecl, BuiltType parent,
+                      bool forRequirement = true) const {
     // We can't support sugared types here since we have no way to
     // resolve the underlying type of the type alias. However, some
     // CF types are mangled as type aliases.


### PR DESCRIPTION
Type aliases may be referenced as existentials, so allow for creating types which are existentials wrapping a type alias, controlled by the 'forRequirement' flag (similar to how it's done in createProtocolCompositionType).

