### PR TITLE
Cleanup outdated comment

### DIFF
--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -90,8 +90,7 @@ static inline bool isValidPointerForNativeRetain(const void *p) {
 //
 // NOTE: the memcpy and asm("") naming shenanigans are to convince the compiler
 // not to emit a bunch of ptrauth instructions just to perform the comparison.
-// We only want to authenticate the function pointer if we actually call it. We
-// can revert to a straight comparison once rdar://problem/55267009 is fixed.
+// We only want to authenticate the function pointer if we actually call it.
 SWIFT_RETURNS_NONNULL SWIFT_NODISCARD
 static HeapObject *_swift_allocObject_(HeapMetadata const *metadata,
                                        size_t requiredSize,


### PR DESCRIPTION
In the general case, the compiler should add ptrauth instructions even for simple pointer equality checks.  We therefore need to manually avoid these checks; making this workaround permanent.
