### PR TITLE
Sema: Diagnose declarations that are annotated to be more available than their unavailable enclosing scope

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5696,13 +5696,21 @@ ERROR(availability_decl_more_than_enclosing, none,
       "%0 cannot be more available than enclosing scope",
       (DescriptiveDeclKind))
 
+WARNING(availability_decl_more_than_unavailable_enclosing, none,
+        "%0 cannot be more available than unavailable enclosing scope",
+        (DescriptiveDeclKind))
+
 NOTE(availability_implicit_decl_here, none,
      "%0 implicitly declared here with availability of %1 %2 or newer",
      (DescriptiveDeclKind, StringRef, llvm::VersionTuple))
 
-NOTE(availability_decl_more_than_enclosing_enclosing_here, none,
+NOTE(availability_decl_more_than_enclosing_here, none,
      "enclosing scope requires availability of %0 %1 or newer",
      (StringRef, llvm::VersionTuple))
+
+NOTE(availability_decl_more_than_unavailable_enclosing_here, none,
+     "enclosing scope has been explicitly marked unavailable here",
+     ())
 
 ERROR(availability_decl_only_version_newer, none,
       "%0 is only available in %1 %2 or newer",

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -1725,10 +1725,12 @@ struct HasUnavailableExtension {
 
 @available(OSX, unavailable)
 extension HasUnavailableExtension {
+    // expected-note@-1 {{enclosing scope has been explicitly marked unavailable here}}
+
   public func inheritsUnavailable() { }
       // expected-note@-1 {{'inheritsUnavailable()' has been explicitly marked unavailable here}}
 
-  @available(OSX 10.9, *)
+  @available(OSX 10.9, *) // expected-warning {{instance method cannot be more available than unavailable enclosing scope}}
   public func moreAvailableButStillUnavailable() { }
       // expected-note@-1 {{'moreAvailableButStillUnavailable()' has been explicitly marked unavailable here}}
 }

--- a/test/attr/attr_availability_transitive_osx.swift
+++ b/test/attr/attr_availability_transitive_osx.swift
@@ -105,6 +105,7 @@ extension Outer {
 }
 
 @available(OSX, unavailable)
+// expected-note@+1 {{enclosing scope has been explicitly marked unavailable here}}
 extension Outer {
   // expected-note@+1 {{'outer_osx_init_osx' has been explicitly marked unavailable here}}
   static var outer_osx_init_osx = osx() // OK
@@ -123,7 +124,7 @@ extension Outer {
   }
   
   // This @available should be ignored; inherited unavailability takes precedence
-  @available(OSX 999, *)
+  @available(OSX 999, *) // expected-warning {{instance method cannot be more available than unavailable enclosing scope}}
   // expected-note@+1 {{'osx_more_available_but_still_unavailable_call_osx()' has been explicitly marked unavailable here}}
   func osx_more_available_but_still_unavailable_call_osx() {
     osx() // OK


### PR DESCRIPTION
Example:
```
public struct S { }

@available(macOS, unavailable)
extension S { // note: enclosing scope has been explicitly marked unavailable here
  @available(macOS 11.0, *) // warning: warning: instance method cannot be more available than unavailable enclosing scope
  public func foo() { }
}
```

Resolves rdar://92552186