### PR TITLE
[ConstraintSystem] Extend availability check to cover unavailable extensions

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -6513,7 +6513,7 @@ void ConstraintSystem::diagnoseFailureFor(SolutionApplicationTarget target) {
 bool ConstraintSystem::isDeclUnavailable(const Decl *D,
                                          ConstraintLocator *locator) const {
   // First check whether this declaration is universally unavailable.
-  if (D->getAttrs().isUnavailable(getASTContext()))
+  if (AvailableAttr::isUnavailable(D))
     return true;
 
   return TypeChecker::isDeclarationUnavailable(D, DC, [&] {

--- a/test/Constraints/availability.swift
+++ b/test/Constraints/availability.swift
@@ -43,3 +43,25 @@ func unavailableFunction(_ x: Int) -> Bool { true } // expected-note {{'unavaila
 func f_55700(_ arr: [Int]) {
   for x in arr where unavailableFunction(x) {} // expected-error {{'unavailableFunction' is unavailable}}
 }
+
+// rdar://92364955 - ambiguity with member declared in unavailable extension
+ struct WithUnavailableExt {
+ }
+
+ @available(*, unavailable)
+ extension WithUnavailableExt {
+   static var foo: WithUnavailableExt = WithUnavailableExt()
+ }
+
+ func test_no_ambiguity_with_unavailable_ext() {
+   struct A {
+     static var foo: A = A()
+   }
+
+   struct Test {
+     init(_: A) {}
+     init(_: WithUnavailableExt) {}
+   }
+
+   _ = Test(.foo) // Ok `A.foo` since `foo` from `WithUnavailableExt` is unavailable
+ }


### PR DESCRIPTION
Instead of checking for unavailability attributes directly in the solver, use `AvailableAttr::isUnavailable` which checks the enclosing extension too, if necessary.

Resolves rdar://92364955