### PR TITLE
Revert "[cxx-interop][SwiftCompilerSources] Use C++ enums directly from Swift"

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/DataStructures/FunctionUses.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/DataStructures/FunctionUses.swift
@@ -134,7 +134,7 @@ struct FunctionUses {
 
     for witnessTable in context.witnessTables {
       for entry in witnessTable.entries {
-        if entry.kind == .Method, let f = entry.methodFunction {
+        if entry.kind == .method, let f = entry.methodFunction {
           markUnknown(f)
         }
       }
@@ -142,7 +142,7 @@ struct FunctionUses {
 
     for witnessTable in context.defaultWitnessTables {
       for entry in witnessTable.entries {
-        if entry.kind == .Method, let f = entry.methodFunction {
+        if entry.kind == .method, let f = entry.methodFunction {
           markUnknown(f)
         }
       }

--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/StackProtection.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/StackProtection.swift
@@ -124,7 +124,7 @@ private struct StackProtectionOptimization {
                                 mustFixStackNesting: inout Bool, _ context: PassContext) {
 
     // `withUnsafeTemporaryAllocation(of:capacity:_:)` is compiled to a `builtin "stackAlloc"`.
-    if let bi = instruction as? BuiltinInst, bi.id == .StackAlloc {
+    if let bi = instruction as? BuiltinInst, bi.id == .stackAlloc {
       function.setNeedsStackProtection(context)
       return
     }
@@ -332,7 +332,7 @@ private struct StackProtectionOptimization {
   /// Moves the value of a `beginAccess` to a temporary stack location, if possible.
   private func moveToTemporary(scope beginAccess: BeginAccessInst, mustFixStackNesting: inout Bool,
                                _ context: PassContext) {
-    if beginAccess.accessKind != .Modify {
+    if beginAccess.accessKind != .modify {
       // We can only move from a `modify` access.
       // Also, read-only accesses shouldn't be subject to buffer overflows (because
       // no one should ever write to such a storage).

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
@@ -422,7 +422,7 @@ fileprivate struct EscapeWalker<V: EscapeVisitor> : ValueDefUseWalker,
       return walkDownUses(ofAddress: pta, path: path.with(knownType: nil))
     case let bi as BuiltinInst:
       switch bi.id {
-      case .DestroyArray:
+      case .destroyArray:
         // If it's not the array base pointer operand -> bail. Though, that shouldn't happen
         // because the other operands (metatype, count) shouldn't be visited anyway.
         if operand.index != 1 { return isEscaping }

--- a/SwiftCompilerSources/Sources/SIL/WitnessTable.swift
+++ b/SwiftCompilerSources/Sources/SIL/WitnessTable.swift
@@ -20,14 +20,28 @@ public struct WitnessTable : CustomStringConvertible, CustomReflectable {
   public struct Entry : CustomStringConvertible, CustomReflectable {
     fileprivate let bridged: BridgedWitnessTableEntry
     
-    public typealias Kind = swift.SILWitnessTable.WitnessKind
+    public enum Kind {
+      case invalid
+      case method
+      case associatedType
+      case associatedTypeProtocol
+      case baseProtocol
+    }
     
     public var kind: Kind {
-      return SILWitnessTableEntry_getKind(bridged)
+      switch SILWitnessTableEntry_getKind(bridged) {
+        case SILWitnessTableEntry_Invalid:                return .invalid
+        case SILWitnessTableEntry_Method:                 return .method
+        case SILWitnessTableEntry_AssociatedType:         return .associatedType
+        case SILWitnessTableEntry_AssociatedTypeProtocol: return .associatedTypeProtocol
+        case SILWitnessTableEntry_BaseProtocol:           return .baseProtocol
+        default:
+          fatalError("unknown witness table kind")
+      }
     }
     
     public var methodFunction: Function? {
-      assert(kind == .Method)
+      assert(kind == .method)
       return SILWitnessTableEntry_getMethodFunction(bridged).function
     }
 

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -25,6 +25,13 @@ SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 // Diagnostic Engine
 //===----------------------------------------------------------------------===//
 
+// TODO: Move this to somewhere common header.
+#if __has_attribute(enum_extensibility)
+#define ENUM_EXTENSIBILITY_ATTR(arg) __attribute__((enum_extensibility(arg)))
+#else
+#define ENUM_EXTENSIBILITY_ATTR(arg)
+#endif
+
 // NOTE: This must be the same underlying value as C++ 'swift::DiagID' defined
 // in 'DiagnosticList.cpp'.
 typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedDiagID : uint32_t {

--- a/include/swift/Basic/Compiler.h
+++ b/include/swift/Basic/Compiler.h
@@ -187,10 +187,4 @@
 #define SWIFT_IMPORT_REFERENCE
 #endif
 
-#if __has_attribute(enum_extensibility)
-#define ENUM_EXTENSIBILITY_ATTR(arg) __attribute__((enum_extensibility(arg)))
-#else
-#define ENUM_EXTENSIBILITY_ATTR(arg)
-#endif
-
 #endif // SWIFT_BASIC_COMPILER_H

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -15,11 +15,8 @@
 
 #include "swift/Basic/BasicBridging.h"
 #include "swift/Basic/BridgedSwiftObject.h"
-#include "swift/AST/Builtins.h"
 #include "swift/AST/SubstitutionMap.h"
-#include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILLocation.h"
-#include "swift/SIL/SILWitnessTable.h"
 #include <stdbool.h>
 #include <stddef.h>
 #include <string>
@@ -97,6 +94,14 @@ typedef struct {
   const void * _Nonnull ptr;
 } BridgedWitnessTableEntry;
 
+typedef enum {
+  SILWitnessTableEntry_Invalid,
+  SILWitnessTableEntry_Method,
+  SILWitnessTableEntry_AssociatedType,
+  SILWitnessTableEntry_AssociatedTypeProtocol,
+  SILWitnessTableEntry_BaseProtocol
+} SILWitnessTableEntryKind;
+
 typedef struct {
   SwiftObject obj;
 } BridgedFunction;
@@ -171,6 +176,13 @@ typedef enum {
 } BridgedMemoryBehavior;
 
 typedef enum {
+  AccessKind_Init,
+  AccessKind_Read,
+  AccessKind_Modify,
+  AccessKind_Deinit
+} BridgedAccessKind;
+
+typedef enum {
   Ownership_Unowned,
   Ownership_Owned,
   Ownership_Guaranteed,
@@ -190,6 +202,12 @@ typedef enum {
 } BridgedArgumentConvention;
 
 // AST bridging
+
+typedef enum {
+  UnknownBuiltin = 0,
+#define BUILTIN(Id, Name, Attrs) Id##Builtin,
+#include "swift/AST/Builtins.def"
+} BridgedBuiltinID;
 
 struct BridgedEffectInfo {
   SwiftInt argumentIndex;
@@ -258,7 +276,7 @@ BridgedArrayRef SILWitnessTable_getEntries(BridgedWitnessTable table);
 std::string SILDefaultWitnessTable_debugDescription(BridgedDefaultWitnessTable table);
 BridgedArrayRef SILDefaultWitnessTable_getEntries(BridgedDefaultWitnessTable table);
 std::string SILWitnessTableEntry_debugDescription(BridgedWitnessTableEntry entry);
-swift::SILWitnessTable::WitnessKind SILWitnessTableEntry_getKind(BridgedWitnessTableEntry entry);
+SILWitnessTableEntryKind SILWitnessTableEntry_getKind(BridgedWitnessTableEntry entry);
 OptionalBridgedFunction SILWitnessTableEntry_getMethodFunction(BridgedWitnessTableEntry entry);
 
 OptionalBridgedBasicBlock SILBasicBlock_next(BridgedBasicBlock block);
@@ -334,7 +352,7 @@ BridgedMultiValueResult
 BridgedArrayRef TermInst_getSuccessors(BridgedInstruction term);
 
 llvm::StringRef CondFailInst_getMessage(BridgedInstruction cfi);
-swift::BuiltinValueKind BuiltinInst_getID(BridgedInstruction bi);
+BridgedBuiltinID BuiltinInst_getID(BridgedInstruction bi);
 SwiftInt AddressToPointerInst_needsStackProtection(BridgedInstruction atp);
 SwiftInt IndexAddrInst_needsStackProtection(BridgedInstruction ia);
 BridgedGlobalVar GlobalAccessInst_getGlobal(BridgedInstruction globalInst);
@@ -365,7 +383,7 @@ BridgedBasicBlock BranchInst_getTargetBlock(BridgedInstruction bi);
 SwiftInt SwitchEnumInst_getNumCases(BridgedInstruction se);
 SwiftInt SwitchEnumInst_getCaseIndex(BridgedInstruction se, SwiftInt idx);
 SwiftInt StoreInst_getStoreOwnership(BridgedInstruction store);
-swift::SILAccessKind BeginAccessInst_getAccessKind(BridgedInstruction beginAccess);
+BridgedAccessKind BeginAccessInst_getAccessKind(BridgedInstruction beginAccess);
 SwiftInt CopyAddrInst_isTakeOfSrc(BridgedInstruction copyAddr);
 SwiftInt CopyAddrInst_isInitializationOfDest(BridgedInstruction copyAddr);
 void RefCountingInst_setIsAtomic(BridgedInstruction rc, bool isAtomic);

--- a/include/swift/SIL/SILWitnessTable.h
+++ b/include/swift/SIL/SILWitnessTable.h
@@ -90,7 +90,7 @@ public:
     AssociatedType,
     AssociatedTypeProtocol,
     BaseProtocol
-  } ENUM_EXTENSIBILITY_ATTR(open);
+  };
   
   /// A witness table entry.
   class Entry {

--- a/include/swift/module.modulemap
+++ b/include/swift/module.modulemap
@@ -7,17 +7,10 @@ module BasicBridging {
 }
 
 module ASTBridging {
-  header "AST/AnyFunctionRef.h"
   header "AST/ASTBridging.h"
-  header "AST/Builtins.h"
   header "AST/DiagnosticEngine.h"
   header "AST/DiagnosticConsumer.h"
-  header "AST/ForeignAsyncConvention.h"
-  header "AST/ForeignErrorConvention.h"
   header "AST/SubstitutionMap.h"
-
-  textual header "AST/Builtins.def"
-
   requires cplusplus
   export *
 }

--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -653,9 +653,19 @@ std::string SILWitnessTableEntry_debugDescription(BridgedWitnessTableEntry entry
   return str;
 }
 
-SILWitnessTable::WitnessKind
-SILWitnessTableEntry_getKind(BridgedWitnessTableEntry entry) {
-  return castToWitnessTableEntry(entry)->getKind();
+SILWitnessTableEntryKind SILWitnessTableEntry_getKind(BridgedWitnessTableEntry entry) {
+  switch (castToWitnessTableEntry(entry)->getKind()) {
+    case SILWitnessTable::Invalid:
+      return SILWitnessTableEntry_Invalid;
+    case SILWitnessTable::Method:
+      return SILWitnessTableEntry_Method;
+    case SILWitnessTable::AssociatedType:
+      return SILWitnessTableEntry_AssociatedType;
+    case SILWitnessTable::AssociatedTypeProtocol:
+      return SILWitnessTableEntry_AssociatedTypeProtocol;
+    case SILWitnessTable::BaseProtocol:
+      return SILWitnessTableEntry_BaseProtocol;
+  }
 }
 
 OptionalBridgedFunction SILWitnessTableEntry_getMethodFunction(BridgedWitnessTableEntry entry) {
@@ -741,8 +751,8 @@ llvm::StringRef CondFailInst_getMessage(BridgedInstruction cfi) {
   return castToInst<CondFailInst>(cfi)->getMessage();
 }
 
-BuiltinValueKind BuiltinInst_getID(BridgedInstruction bi) {
-  return castToInst<BuiltinInst>(bi)->getBuiltinInfo().ID;
+BridgedBuiltinID BuiltinInst_getID(BridgedInstruction bi) {
+  return (BridgedBuiltinID)castToInst<BuiltinInst>(bi)->getBuiltinInfo().ID;
 }
 
 SwiftInt AddressToPointerInst_needsStackProtection(BridgedInstruction atp) {
@@ -867,8 +877,18 @@ SwiftInt StoreInst_getStoreOwnership(BridgedInstruction store) {
   return (SwiftInt)castToInst<StoreInst>(store)->getOwnershipQualifier();
 }
 
-SILAccessKind BeginAccessInst_getAccessKind(BridgedInstruction beginAccess) {
-  return castToInst<BeginAccessInst>(beginAccess)->getAccessKind();
+BridgedAccessKind BeginAccessInst_getAccessKind(BridgedInstruction beginAccess) {
+  auto kind = castToInst<BeginAccessInst>(beginAccess)->getAccessKind();
+  switch (kind) {
+    case SILAccessKind::Init:
+      return BridgedAccessKind::AccessKind_Init;
+    case SILAccessKind::Read:
+      return BridgedAccessKind::AccessKind_Read;
+    case SILAccessKind::Modify:
+      return BridgedAccessKind::AccessKind_Modify;
+    case SILAccessKind::Deinit:
+      return BridgedAccessKind::AccessKind_Deinit;
+  }
 }
 
 SwiftInt CopyAddrInst_isTakeOfSrc(BridgedInstruction copyAddr) {


### PR DESCRIPTION
Reverts apple/swift#61153

It breaks the "hosttools" build mode.

rdar://100265664