### PR TITLE
[SourceKit] add qualified types in type requests

### DIFF
--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -264,6 +264,7 @@ namespace swift {
   /// \c VariableTypeInfos will index into the string that backs this
   /// stream.
   void collectVariableType(SourceFile &SF, SourceRange Range,
+                           bool FullyQualified,
                            std::vector<VariableTypeInfo> &VariableTypeInfos,
                            llvm::raw_ostream &OS);
 

--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -231,11 +231,10 @@ namespace swift {
 
   /// Collect type information for every expression in \c SF; all types will
   /// be printed to \c OS.
-  ArrayRef<ExpressionTypeInfo> collectExpressionType(SourceFile &SF,
-    ArrayRef<const char *> ExpectedProtocols,
-    std::vector<ExpressionTypeInfo> &scratch,
-    bool CanonicalType,
-    llvm::raw_ostream &OS);
+  ArrayRef<ExpressionTypeInfo> collectExpressionType(
+      SourceFile &SF, ArrayRef<const char *> ExpectedProtocols,
+      std::vector<ExpressionTypeInfo> &scratch, bool FullyQualified,
+      bool CanonicalType, llvm::raw_ostream &OS);
 
   /// Resolve a list of mangled names to accessible protocol decls from
   /// the decl context.

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -630,6 +630,9 @@ class ExpressionTypeCollector: public SourceEntityWalker {
   // these protocols.
   llvm::MapVector<ProtocolDecl*, StringRef> &InterestedProtocols;
 
+  // Specified by the client whether we should print fully qualified types
+  const bool FullyQualified;
+
   // Specified by the client whether we should canonicalize types before printing
   const bool CanonicalType;
 
@@ -676,16 +679,15 @@ class ExpressionTypeCollector: public SourceEntityWalker {
 
 
 public:
-  ExpressionTypeCollector(SourceFile &SF,
-              llvm::MapVector<ProtocolDecl*, StringRef> &InterestedProtocols,
-                          std::vector<ExpressionTypeInfo> &Results,
-                          bool CanonicalType,
-                          llvm::raw_ostream &OS): Module(*SF.getParentModule()),
-                            SM(SF.getASTContext().SourceMgr),
-                            BufferId(*SF.getBufferID()),
-                            Results(Results), OS(OS),
-                            InterestedProtocols(InterestedProtocols),
-                            CanonicalType(CanonicalType) {}
+  ExpressionTypeCollector(
+      SourceFile &SF,
+      llvm::MapVector<ProtocolDecl *, StringRef> &InterestedProtocols,
+      std::vector<ExpressionTypeInfo> &Results, bool FullyQualified,
+      bool CanonicalType, llvm::raw_ostream &OS)
+      : Module(*SF.getParentModule()), SM(SF.getASTContext().SourceMgr),
+        BufferId(*SF.getBufferID()), Results(Results), OS(OS),
+        InterestedProtocols(InterestedProtocols),
+        FullyQualified(FullyQualified), CanonicalType(CanonicalType) {}
   bool walkToExprPre(Expr *E) override {
     if (E->getSourceRange().isInvalid())
       return true;
@@ -701,10 +703,12 @@ public:
     {
       llvm::raw_svector_ostream OS(Buffer);
       auto Ty = E->getType()->getRValueType();
+      PrintOptions printOptions = PrintOptions();
+      printOptions.FullyQualifiedTypes = FullyQualified;
       if (CanonicalType) {
-        Ty->getCanonicalType()->print(OS);
+        Ty->getCanonicalType()->print(OS, printOptions);
       } else {
-        Ty->reconstituteSugar(true)->print(OS);
+        Ty->reconstituteSugar(true)->print(OS, printOptions);
       }
     }
     auto Ty = getTypeOffsets(Buffer.str());
@@ -729,12 +733,10 @@ ProtocolDecl* swift::resolveProtocolName(DeclContext *dc, StringRef name) {
                            nullptr);
 }
 
-ArrayRef<ExpressionTypeInfo>
-swift::collectExpressionType(SourceFile &SF,
-                             ArrayRef<const char *> ExpectedProtocols,
-                             std::vector<ExpressionTypeInfo> &Scratch,
-                             bool CanonicalType,
-                             llvm::raw_ostream &OS) {
+ArrayRef<ExpressionTypeInfo> swift::collectExpressionType(
+    SourceFile &SF, ArrayRef<const char *> ExpectedProtocols,
+    std::vector<ExpressionTypeInfo> &Scratch, bool FullyQualified,
+    bool CanonicalType, llvm::raw_ostream &OS) {
   llvm::MapVector<ProtocolDecl*, StringRef> InterestedProtocols;
   for (auto Name: ExpectedProtocols) {
     if (auto *pd = resolveProtocolName(&SF, Name)) {
@@ -744,7 +746,7 @@ swift::collectExpressionType(SourceFile &SF,
     }
   }
   ExpressionTypeCollector Walker(SF, InterestedProtocols, Scratch,
-    CanonicalType, OS);
+                                 FullyQualified, CanonicalType, OS);
   Walker.walk(SF);
   return Scratch;
 }

--- a/test/IDE/expr_type_qualified.swift
+++ b/test/IDE/expr_type_qualified.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-ide-test -print-expr-type -fully-qualified-types -source-filename %S/Inputs/ExprType.swift -swift-version 5 | %FileCheck %s -check-prefix=CHECK-SUGAR
+// RUN: %target-swift-ide-test -print-expr-type -fully-qualified-types -source-filename %S/Inputs/ExprType.swift -swift-version 5 -canonicalize-type | %FileCheck %s -check-prefix=CHECK-CANON
+
+// CHECK-SUGAR: func foo() -> Int { return <expr type:"Swift.Int">1</expr> }
+// CHECK-SUGAR: func bar(f: Float) -> Float { return <expr type:"Swift.Float"><expr type:"(Swift.Float) -> Swift.Float">bar</expr>(f: <expr type:"Swift.Float">1</expr>)</expr> }
+// CHECK-SUGAR: func fooP(_ p: P) { <expr type:"()"><expr type:"(swift_ide_test.P) -> ()">fooP</expr>(<expr type:"swift_ide_test.P">p</expr>)</expr> }
+// CHECK-SUGAR: <expr type:"()"><expr type:"Swift.Int">_</expr> = <expr type:"Swift.Int"><expr type:"[swift_ide_test.C]">a</expr>.count</expr></expr>
+// CHECK-SUGAR: <expr type:"()"><expr type:"Swift.String">_</expr> = <expr type:"Swift.String"><expr type:"Swift.Int"><expr type:"(Swift.Int) -> Swift.Int"><expr type:"Swift.Int"><expr type:"Swift.String"><expr type:"[swift_ide_test.C]">a</expr>.description</expr>.count</expr>.<expr type:"(Swift.Int) -> (Swift.Int) -> Swift.Int">advanced</expr></expr>(by: <expr type:"Swift.Int">1</expr>)</expr>.description</expr></expr>
+// CHECK-SUGAR: <expr type:"()"><expr type:"Swift.Int?">_</expr> = <expr type:"Swift.Int?"><expr type:"Swift.Int"><expr type:"(Swift.Int) -> Swift.Int"><expr type:"Swift.Int"><expr type:"swift_ide_test.S"><expr type:"swift_ide_test.S?"><expr type:"[Swift.Int : swift_ide_test.S]">a</expr>[<expr type:"Swift.Int">2</expr>]</expr>?</expr>.val</expr>.<expr type:"(Swift.Int) -> (Swift.Int) -> Swift.Int">advanced</expr></expr>(by: <expr type:"Swift.Int">1</expr>)</expr>.byteSwapped</expr></expr>
+
+
+// CHECK-SUGAR: return <expr type:"swift_ide_test.MyInt"><expr type:"swift_ide_test.MyInt">a</expr> <expr type:"(Swift.Int, Swift.Int) -> Swift.Int">+</expr> <expr type:"swift_ide_test.MyInt">b</expr></expr>
+// CHECK-CANON: return <expr type:"Swift.Int"><expr type:"Swift.Int">a</expr> <expr type:"(Swift.Int, Swift.Int) -> Swift.Int">+</expr> <expr type:"Swift.Int">b</expr></expr>

--- a/test/SourceKit/VariableType/basic.swift
+++ b/test/SourceKit/VariableType/basic.swift
@@ -33,3 +33,16 @@ let `else` = 3
 // CHECK: (15:7, 15:8): (Int) -> Int (explicit type: 1)
 // CHECK: (19:7, 19:12): Int (explicit type: 0)
 // CHECK: (22:5, 22:11): Int (explicit type: 0)
+
+// RUN: %sourcekitd-test -req=collect-var-type -req-opts=fully_qualified=true %s -- %s | %FileCheck %s --check-prefix CHECK-FULLY-QUALIFIED
+// CHECK-FULLY-QUALIFIED: (1:5, 1:6): Swift.Int (explicit type: 1)
+// CHECK-FULLY-QUALIFIED: (2:5, 2:6): Swift.String (explicit type: 0)
+// CHECK-FULLY-QUALIFIED: (4:5, 4:8): [Swift.String] (explicit type: 0)
+// CHECK-FULLY-QUALIFIED: (7:7, 7:8): Swift.String (explicit type: 1)
+// CHECK-FULLY-QUALIFIED: (8:7, 8:8): Swift.String (explicit type: 0)
+// CHECK-FULLY-QUALIFIED: (12:7, 12:8): Swift.Double (explicit type: 0)
+// CHECK-FULLY-QUALIFIED: (13:7, 13:8): [basic.A] (explicit type: 0)
+// CHECK-FULLY-QUALIFIED: (14:7, 14:8): [Swift.Int : Swift.Int] (explicit type: 1)
+// CHECK-FULLY-QUALIFIED: (15:7, 15:8): (Swift.Int) -> Swift.Int (explicit type: 1)
+// CHECK-FULLY-QUALIFIED: (19:7, 19:12): Swift.Int (explicit type: 0)
+// CHECK-FULLY-QUALIFIED: (22:5, 22:11): Swift.Int (explicit type: 0)

--- a/tools/SourceKit/docs/Protocol.md
+++ b/tools/SourceKit/docs/Protocol.md
@@ -751,14 +751,15 @@ type checking and the necessary compiler arguments to help resolve all dependenc
 
 ```
 {
-    <key.request>:            (UID)     <source.request.expression.type>,
-    <key.sourcefile>:         (string)  // Absolute path to the file.
-    <key.compilerargs>:       [string*] // Array of zero or more strings for the compiler arguments,
-                                        // e.g ["-sdk", "/path/to/sdk"]. If key.sourcefile is provided,
-                                        // these must include the path to that file.
-    <key.expectedtypes>:      [string*] // A list of interested protocol USRs.
-                                        // When empty, we report all expressions in the file.
-                                        // When non-empty, we report expressions whose types conform to any of the give protocols.
+    <key.request>:                  (UID)     <source.request.expression.type>,
+    <key.sourcefile>:               (string)  // Absolute path to the file.
+    <key.compilerargs>:             [string*] // Array of zero or more strings for the compiler arguments,
+                                              // e.g ["-sdk", "/path/to/sdk"]. If key.sourcefile is provided,
+                                              // these must include the path to that file.
+    <key.expectedtypes>:            [string*] // A list of interested protocol USRs.
+                                              // When empty, we report all expressions in the file.
+                                              // When non-empty, we report expressions whose types conform to any of the give protocols.
+    [opt] <key.fully_qualified>:    (bool)    // True when fully qualified type should be returned. Defaults to False.
 }
 ```
 

--- a/tools/SourceKit/docs/Protocol.md
+++ b/tools/SourceKit/docs/Protocol.md
@@ -796,13 +796,14 @@ type checking and the necessary compiler arguments to help resolve all dependenc
 
 ```
 {
-    <key.request>:            (UID)     <source.request.variable.type>,
-    <key.sourcefile>:         (string)  // Absolute path to the file.
-    <key.compilerargs>:       [string*] // Array of zero or more strings for the compiler arguments,
-                                        // e.g ["-sdk", "/path/to/sdk"]. If key.sourcefile is provided,
-                                        // these must include the path to that file.
-    [opt] <key.offset>:       (int64)   // Offset of the requested range. Defaults to zero.
-    [opt] <key.length>:       (int64)   // Length of the requested range. Defaults to the entire file.
+    <key.request>:                  (UID)     <source.request.variable.type>,
+    <key.sourcefile>:               (string)  // Absolute path to the file.
+    <key.compilerargs>:             [string*] // Array of zero or more strings for the compiler arguments,
+                                              // e.g ["-sdk", "/path/to/sdk"]. If key.sourcefile is provided,
+                                              // these must include the path to that file.
+    [opt] <key.offset>:             (int64)   // Offset of the requested range. Defaults to zero.
+    [opt] <key.length>:             (int64)   // Length of the requested range. Defaults to the entire file.
+    [opt] <key.fully_qualified>:    (bool)    // True when fully qualified type should be returned. Defaults to False.
 }
 ```
 

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -911,8 +911,8 @@ public:
 
   virtual void collectExpressionTypes(
       StringRef FileName, ArrayRef<const char *> Args,
-      ArrayRef<const char *> ExpectedProtocols, bool CanonicalType,
-      SourceKitCancellationToken CancellationToken,
+      ArrayRef<const char *> ExpectedProtocols, bool FullyQualified,
+      bool CanonicalType, SourceKitCancellationToken CancellationToken,
       std::function<void(const RequestResult<ExpressionTypesInFile> &)>
           Receiver) = 0;
 

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -921,7 +921,7 @@ public:
   /// the entire document are collected.
   virtual void collectVariableTypes(
       StringRef FileName, ArrayRef<const char *> Args,
-      Optional<unsigned> Offset, Optional<unsigned> Length,
+      Optional<unsigned> Offset, Optional<unsigned> Length, bool FullyQualified,
       SourceKitCancellationToken CancellationToken,
       std::function<void(const RequestResult<VariableTypesInFile> &)>
           Receiver) = 0;

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -686,8 +686,8 @@ public:
 
   void collectExpressionTypes(
       StringRef FileName, ArrayRef<const char *> Args,
-      ArrayRef<const char *> ExpectedProtocols, bool CanonicalType,
-      SourceKitCancellationToken CancellationToken,
+      ArrayRef<const char *> ExpectedProtocols, bool FullyQualified,
+      bool CanonicalType, SourceKitCancellationToken CancellationToken,
       std::function<void(const RequestResult<ExpressionTypesInFile> &)>
           Receiver) override;
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -693,7 +693,7 @@ public:
 
   void collectVariableTypes(
       StringRef FileName, ArrayRef<const char *> Args,
-      Optional<unsigned> Offset, Optional<unsigned> Length,
+      Optional<unsigned> Offset, Optional<unsigned> Length, bool FullyQualified,
       SourceKitCancellationToken CancellationToken,
       std::function<void(const RequestResult<VariableTypesInFile> &)> Receiver)
       override;

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -1251,8 +1251,10 @@ static void handleSemanticRequest(
         [](int64_t v) -> unsigned { return v; });
     Optional<unsigned> Length = Req.getOptionalInt64(KeyLength).map(
         [](int64_t v) -> unsigned { return v; });
+    int64_t FullyQualified = false;
+    Req.getInt64(KeyFullyQualified, FullyQualified, /*isOptional=*/true);
     return Lang.collectVariableTypes(
-        *SourceFile, Args, Offset, Length, CancellationToken,
+        *SourceFile, Args, Offset, Length, FullyQualified, CancellationToken,
         [Rec](const RequestResult<VariableTypesInFile> &Result) {
           reportVariableTypeInfo(Result, Rec);
         });

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -1233,10 +1233,13 @@ static void handleSemanticRequest(
     SmallVector<const char *, 8> ExpectedProtocols;
     if (Req.getStringArray(KeyExpectedTypes, ExpectedProtocols, true))
       return Rec(createErrorRequestInvalid("invalid 'key.expectedtypes'"));
+    int64_t FullyQualified = false;
+    Req.getInt64(KeyFullyQualified, FullyQualified, /*isOptional=*/true);
     int64_t CanonicalTy = false;
     Req.getInt64(KeyCanonicalizeType, CanonicalTy, /*isOptional=*/true);
     return Lang.collectExpressionTypes(
-        *SourceFile, Args, ExpectedProtocols, CanonicalTy, CancellationToken,
+        *SourceFile, Args, ExpectedProtocols, FullyQualified, CanonicalTy,
+        CancellationToken,
         [Rec](const RequestResult<ExpressionTypesInFile> &Result) {
           reportExpressionTypeInfo(Result, Rec);
         });

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2596,8 +2596,9 @@ static int doPrintExpressionTypes(const CompilerInvocation &InitInvok,
   for (auto &u: options::UsrFilter)
     Usrs.push_back(u.c_str());
   // Collect all tags of expressions.
-  for (auto R: collectExpressionType(*CI.getPrimarySourceFile(), Usrs, Scratch,
-                                     options::CanonicalizeType, OS)) {
+  for (auto R : collectExpressionType(*CI.getPrimarySourceFile(), Usrs, Scratch,
+                                      options::FullyQualifiedTypes,
+                                      options::CanonicalizeType, OS)) {
     SortedTags.push_back({R.offset,
       (llvm::Twine("<expr type:\"") + TypeBuffer.str().substr(R.typeOffset,
                                                   R.typeLength) + "\">").str()});

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -182,6 +182,7 @@ UID_KEYS = [
     KEY('VariableLength', 'key.variable_length'),
     KEY('VariableType', 'key.variable_type'),
     KEY('VariableTypeExplicit', 'key.variable_type_explicit'),
+    KEY('FullyQualified', 'key.fully_qualified'),
     KEY('CanonicalizeType', 'key.canonicalize_type'),
     KEY('InternalDiagnostic', 'key.internal_diagnostic'),
     KEY('VFSName', 'key.vfs.name'),


### PR DESCRIPTION
This adds the fully qualified type to the response of expression and variable type requests in SourceKit.

The qualified type can be accessed through the `<key.expression_qualified_type>` and `<key.variable_qualified_type>` keys in the response of the expression and variable type requests.