### PR TITLE
Revert "Sema: Simplify AST representation of key path literals as functions."

### DIFF
--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2252,24 +2252,21 @@ OpenedArchetypeType *OpenExistentialExpr::getOpenedArchetype() const {
 
 KeyPathExpr::KeyPathExpr(SourceLoc startLoc, Expr *parsedRoot,
                          Expr *parsedPath, SourceLoc endLoc, bool hasLeadingDot,
-                         bool isObjC, bool isImplicit,
-                         unsigned closureDiscriminator)
+                         bool isObjC, bool isImplicit)
     : Expr(ExprKind::KeyPath, isImplicit), StartLoc(startLoc), EndLoc(endLoc),
       ParsedRoot(parsedRoot), ParsedPath(parsedPath),
-      HasLeadingDot(hasLeadingDot), ClosureDiscriminator(closureDiscriminator) {
+      HasLeadingDot(hasLeadingDot) {
   assert(!(isObjC && (parsedRoot || parsedPath)) &&
          "Obj-C key paths should only have components");
   Bits.KeyPathExpr.IsObjC = isObjC;
 }
 
 KeyPathExpr::KeyPathExpr(SourceLoc backslashLoc, Expr *parsedRoot,
-                         Expr *parsedPath, bool hasLeadingDot, bool isImplicit,
-                         unsigned closureDiscriminator)
+                         Expr *parsedPath, bool hasLeadingDot, bool isImplicit)
     : KeyPathExpr(backslashLoc, parsedRoot, parsedPath,
                   parsedPath ? parsedPath->getEndLoc()
                              : parsedRoot->getEndLoc(),
-                  hasLeadingDot, /*isObjC*/ false, isImplicit,
-                  closureDiscriminator) {
+                  hasLeadingDot, /*isObjC*/ false, isImplicit) {
   assert((parsedRoot || parsedPath) &&
          "Key path must have either root or path");
 }
@@ -2278,8 +2275,7 @@ KeyPathExpr::KeyPathExpr(ASTContext &ctx, SourceLoc startLoc,
                          ArrayRef<Component> components, SourceLoc endLoc,
                          bool isObjC, bool isImplicit)
     : KeyPathExpr(startLoc, /*parsedRoot*/ nullptr, /*parsedPath*/ nullptr,
-                  endLoc, /*hasLeadingDot*/ false, isObjC, isImplicit,
-                  /*closure discriminator*/ AbstractClosureExpr::InvalidDiscriminator) {
+                  endLoc, /*hasLeadingDot*/ false, isObjC, isImplicit) {
   assert(!components.empty());
   Components = ctx.AllocateCopy(components);
 }
@@ -2293,11 +2289,9 @@ KeyPathExpr *KeyPathExpr::createParsedPoundKeyPath(
 
 KeyPathExpr *KeyPathExpr::createParsed(ASTContext &ctx, SourceLoc backslashLoc,
                                        Expr *parsedRoot, Expr *parsedPath,
-                                       bool hasLeadingDot,
-                                       unsigned closureDiscriminator) {
+                                       bool hasLeadingDot) {
   return new (ctx) KeyPathExpr(backslashLoc, parsedRoot, parsedPath,
-                               hasLeadingDot, /*isImplicit*/ false,
-                               closureDiscriminator);
+                               hasLeadingDot, /*isImplicit*/ false);
 }
 
 KeyPathExpr *KeyPathExpr::createImplicit(ASTContext &ctx,
@@ -2313,8 +2307,7 @@ KeyPathExpr *KeyPathExpr::createImplicit(ASTContext &ctx,
                                          Expr *parsedRoot, Expr *parsedPath,
                                          bool hasLeadingDot) {
   return new (ctx) KeyPathExpr(backslashLoc, parsedRoot, parsedPath,
-           hasLeadingDot, /*isImplicit*/ true,
-           /*closureDiscriminator*/ AbstractClosureExpr::InvalidDiscriminator);
+                               hasLeadingDot, /*isImplicit*/ true);
 }
 
 void

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -690,8 +690,7 @@ ParserResult<Expr> Parser::parseExprKeyPath() {
 
   auto *keypath = KeyPathExpr::createParsed(
       Context, backslashLoc, rootResult.getPtrOrNull(),
-      pathResult.getPtrOrNull(), hasLeadingDot,
-      CurLocalContext->claimNextClosureDiscriminator());
+      pathResult.getPtrOrNull(), hasLeadingDot);
   return makeParserResult(parseStatus, keypath);
 }
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1748,11 +1748,6 @@ static bool canPeepholeLiteralClosureConversion(Type literalType,
   
   if (!literalFnType || !convertedFnType)
     return false;
-    
-  // Is it an identity conversion?
-  if (literalFnType->isEqual(convertedFnType)) {
-    return true;
-  }
   
   // Does the conversion only add `throws`?
   if (literalFnType->isEqual(convertedFnType->getWithoutThrowing())) {

--- a/lib/SILOptimizer/IPO/CapturePropagation.cpp
+++ b/lib/SILOptimizer/IPO/CapturePropagation.cpp
@@ -329,22 +329,6 @@ void CapturePropagation::rewritePartialApply(PartialApplyInst *OrigPAI,
   auto *T2TF = Builder.createThinToThickFunction(OrigPAI->getLoc(), FuncRef,
                                                  OrigPAI->getType());
   OrigPAI->replaceAllUsesWith(T2TF);
-  
-  // Bypass any mark_dependence on the captures we specialized away.
-  //
-  // TODO: If we start to specialize away key path literals with operands
-  // (subscripts etc.), then a dependence of the new partial_apply on those
-  // operands may still exist. However, we should still leave the key path
-  // itself out of the dependency chain, and introduce dependencies on those
-  // operands instead, so that the key path object itself can be made dead.
-  for (auto user : T2TF->getUsersOfType<MarkDependenceInst>()) {
-    if (auto depUser = user->getBase()->getSingleUserOfType<PartialApplyInst>()){
-      if (depUser == OrigPAI) {
-        user->replaceAllUsesWith(T2TF);
-      }
-    }
-  }
-  
   // Remove any dealloc_stack users.
   SmallVector<Operand*, 16> Uses(T2TF->getUses());
   for (auto *Use : Uses)

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4971,34 +4971,26 @@ namespace {
       cs.cacheType(E);
 
       // To ensure side effects of the key path expression (mainly indices in
-      // subscripts) are only evaluated once, we use a capture list to evaluate
-      // the key path immediately and capture it in the function value created.
-      // The result looks like:
+      // subscripts) are only evaluated once, we construct an outer closure,
+      // which is immediately evaluated, and an inner closure, which it returns.
+      // The result looks like this:
       //
-      //     return "{ [$kp$ = \(E)] in $0[keyPath: $kp$] }"
+      //     return "{ $kp$ in { $0[keyPath: $kp$] } }( \(E) )"
 
       auto &ctx = cs.getASTContext();
-      auto discriminator = E->getClosureDiscriminator();
+      auto discriminator = AutoClosureExpr::InvalidDiscriminator;
 
-      auto contextInfo = exprType->castTo<AnyFunctionType>()->getExtInfo();
+      // The inner closure.
+      //
+      //     let closure = "{ $0[keyPath: $kp$] }"
+      //
+      // FIXME: Verify ExtInfo state is correct, not working by accident.
       FunctionType::ExtInfo closureInfo;
-      closureInfo = closureInfo.withNoEscape(contextInfo.isNoEscape());
       auto closureTy =
           FunctionType::get({FunctionType::Param(baseTy)}, leafTy, closureInfo);
-
-      ClosureExpr *closure = new (ctx)
-        ClosureExpr(DeclAttributes(),
-                    SourceRange(),
-                    /*captured self*/ nullptr,
-                    /*params*/ nullptr,
-                    SourceLoc(),
-                    SourceLoc(),
-                    SourceLoc(),
-                    SourceLoc(),
-                    /*explicit result type*/ nullptr,
-                    discriminator,
-                    dc);
-
+      auto closure = new (ctx)
+          AutoClosureExpr(/*set body later*/nullptr, leafTy,
+                          discriminator, dc);
       auto param = new (ctx) ParamDecl(
           SourceLoc(),
           /*argument label*/ SourceLoc(), Identifier(),
@@ -5006,37 +4998,26 @@ namespace {
       param->setInterfaceType(baseTy->mapTypeOutOfContext());
       param->setSpecifier(ParamSpecifier::Default);
       param->setImplicit();
-      
-      auto params = ParameterList::create(ctx, SourceLoc(),
-                                          param, SourceLoc());
 
-      closure->setParameterList(params);
-
-      // The capture list.
-      VarDecl *outerParam = new (ctx) VarDecl(/*static*/ false,
-                                          VarDecl::Introducer::Let,
-                                          SourceLoc(),
-                                          ctx.getIdentifier("$kp$"),
-                                          dc);
-      outerParam->setImplicit();
+      // The outer closure.
+      //
+      //    let outerClosure = "{ $kp$ in \(closure) }"
+      //
+      // FIXME: Verify ExtInfo state is correct, not working by accident.
+      FunctionType::ExtInfo outerClosureInfo;
+      auto outerClosureTy = FunctionType::get({FunctionType::Param(keyPathTy)},
+                                              closureTy, outerClosureInfo);
+      auto outerClosure = new (ctx)
+          AutoClosureExpr(/*set body later*/nullptr, closureTy,
+                          discriminator, dc);
+      auto outerParam =
+          new (ctx) ParamDecl(SourceLoc(),
+                              /*argument label*/ SourceLoc(), Identifier(),
+                              /*parameter name*/ SourceLoc(),
+                              ctx.getIdentifier("$kp$"), outerClosure);
       outerParam->setInterfaceType(keyPathTy->mapTypeOutOfContext());
-      
-      NamedPattern *outerParamPat = new (ctx) NamedPattern(outerParam);
-      outerParamPat->setImplicit();
-      outerParamPat->setType(keyPathTy);
-      
-      auto outerParamPBE = PatternBindingEntry(outerParamPat,
-                                               SourceLoc(), E, dc);
-      solution.setExprTypes(E);
-      auto outerParamDecl = PatternBindingDecl::create(ctx, SourceLoc(),
-                                                       {}, SourceLoc(),
-                                                       outerParamPBE,
-                                                       dc);
-      outerParamDecl->setImplicit();
-      auto outerParamCapture = CaptureListEntry(outerParamDecl);
-      auto captureExpr = CaptureListExpr::create(ctx, outerParamCapture,
-                                                 closure);
-      captureExpr->setImplicit();
+      outerParam->setSpecifier(ParamSpecifier::Default);
+      outerParam->setImplicit();
 
       // let paramRef = "$0"
       auto *paramRef = new (ctx)
@@ -5056,21 +5037,26 @@ namespace {
                                  E->getStartLoc(), outerParamRef, E->getEndLoc(),
                                  leafTy, /*implicit=*/true);
       cs.cacheType(application);
-      
-      auto returnStmt = new (ctx) ReturnStmt(SourceLoc(), application);
-      auto bodyStmt = BraceStmt::create(ctx,
-                                SourceLoc(), ASTNode(returnStmt), SourceLoc());
 
       // Finish up the inner closure.
       closure->setParameterList(ParameterList::create(ctx, {param}));
-      closure->setBody(bodyStmt, /*singleExpr*/ true);
+      closure->setBody(application);
       closure->setType(closureTy);
       cs.cacheType(closure);
-      
-      captureExpr->setType(closureTy);
-      cs.cacheType(captureExpr);
-      
-      return coerceToType(captureExpr, exprType, cs.getConstraintLocator(E));
+
+      // Finish up the outer closure.
+      outerClosure->setParameterList(ParameterList::create(ctx, {outerParam}));
+      outerClosure->setBody(closure);
+      outerClosure->setType(outerClosureTy);
+      cs.cacheType(outerClosure);
+
+      // let outerApply = "\( outerClosure )( \(E) )"
+      auto *argList = ArgumentList::forImplicitUnlabeled(ctx, {E});
+      auto outerApply = CallExpr::createImplicit(ctx, outerClosure, argList);
+      outerApply->setType(closureTy);
+      cs.cacheExprTypes(outerApply);
+
+      return coerceToType(outerApply, exprType, cs.getConstraintLocator(E));
     }
 
     void buildKeyPathOptionalForceComponent(


### PR DESCRIPTION
Reverts apple/swift#61213