### PR TITLE
[Build] Ensure that we link in SwiftSyntax and Swift for all executables

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -568,6 +568,21 @@ function(_add_swift_runtime_link_flags target relpath_to_lib_dir bootstrapping)
     endif()
   endif()
 
+  if(SWIFT_SWIFT_PARSER)
+    # Make sure we can find the early SwiftSyntax libraries.
+    target_link_directories(${target} PRIVATE "${SWIFT_PATH_TO_EARLYSWIFTSYNTAX_BUILD_DIR}/lib")
+
+    # For the "end step" of bootstrapping configurations on Darwin, need to be
+    # able to fall back to the SDK directory for libswiftCore et al.
+    if (BOOTSTRAPPING_MODE MATCHES "BOOTSTRAPPING.*")
+      if (bootstrapping STREQUAL "")
+        if(${SWIFT_HOST_VARIANT_SDK} IN_LIST SWIFT_DARWIN_PLATFORMS)
+          target_link_directories(${target} PRIVATE "${sdk_dir}")
+        endif()
+      endif()
+    endif()
+  endif()
+
   set_property(TARGET ${target} PROPERTY BUILD_WITH_INSTALL_RPATH YES)
   set_property(TARGET ${target} APPEND PROPERTY INSTALL_RPATH "${swift_runtime_rpath}")
 endfunction()


### PR DESCRIPTION
Non-asserts builds were failing to link non-compiler tools such as `swift-dependency-tool` due to missing the `SwiftSyntax` and Swift standard library linker paths. Fixes rdar://100276989 / rdar://100232982 