### PR TITLE
Sema: Simplify AST representation of key path literals as functions. [take 2]

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -4047,14 +4047,6 @@ public:
 ///   func f(x : @autoclosure () -> Int)
 ///   f(42)  // AutoclosureExpr convert from Int to ()->Int
 /// \endcode
-///
-///  They are also created when key path expressions are converted to function
-///  type, in which case, a pair of nested implicit closures are formed:
-/// \code
-///   { $kp$ in { $0[keyPath: $kp$] } }( \(E) )
-/// \endcode
-/// This is to ensure side effects of the key path expression (mainly indices in
-/// subscripts) are only evaluated once.
 class AutoClosureExpr : public AbstractClosureExpr {
   BraceStmt *Body;
 
@@ -5397,6 +5389,10 @@ class KeyPathExpr : public Expr {
   /// a contextual root type.
   bool HasLeadingDot = false;
 
+  /// When we parse a key path literal, we claim a closure discriminator for it, since it may be used as
+  /// a closure value in function type context.
+  unsigned ClosureDiscriminator;
+
 public:
   /// A single stored component, which will be one of:
   /// - an unresolved DeclNameRef, which has to be type-checked
@@ -5728,11 +5724,12 @@ private:
 
   KeyPathExpr(SourceLoc startLoc, Expr *parsedRoot, Expr *parsedPath,
               SourceLoc endLoc, bool hasLeadingDot, bool isObjC,
-              bool isImplicit);
+              bool isImplicit, unsigned closureDiscriminator);
 
   /// Create a key path with unresolved root and path expressions.
   KeyPathExpr(SourceLoc backslashLoc, Expr *parsedRoot, Expr *parsedPath,
-              bool hasLeadingDot, bool isImplicit);
+              bool hasLeadingDot, bool isImplicit,
+              unsigned closureDiscriminator);
 
   /// Create a key path with components.
   KeyPathExpr(ASTContext &ctx, SourceLoc startLoc,
@@ -5742,8 +5739,9 @@ private:
 public:
   /// Create a new parsed Swift key path expression.
   static KeyPathExpr *createParsed(ASTContext &ctx, SourceLoc backslashLoc,
-                                   Expr *parsedRoot, Expr *parsedPath,
-                                   bool hasLeadingDot);
+     Expr *parsedRoot, Expr *parsedPath,
+     bool hasLeadingDot,
+     unsigned closureDiscriminator = AbstractClosureExpr::InvalidDiscriminator);
 
   /// Create a new parsed #keyPath expression.
   static KeyPathExpr *createParsedPoundKeyPath(ASTContext &ctx,
@@ -5837,6 +5835,9 @@ public:
 
   /// True if this key path expression has a leading dot.
   bool expectsContextualRoot() const { return HasLeadingDot; }
+
+  /// Return the discriminator to use if this key path becomes a closure.
+  unsigned getClosureDiscriminator() const { return ClosureDiscriminator; }
 
   static bool classof(const Expr *E) {
     return E->getKind() == ExprKind::KeyPath;

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -690,7 +690,8 @@ ParserResult<Expr> Parser::parseExprKeyPath() {
 
   auto *keypath = KeyPathExpr::createParsed(
       Context, backslashLoc, rootResult.getPtrOrNull(),
-      pathResult.getPtrOrNull(), hasLeadingDot);
+      pathResult.getPtrOrNull(), hasLeadingDot,
+      CurLocalContext->claimNextClosureDiscriminator());
   return makeParserResult(parseStatus, keypath);
 }
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1748,6 +1748,11 @@ static bool canPeepholeLiteralClosureConversion(Type literalType,
   
   if (!literalFnType || !convertedFnType)
     return false;
+    
+  // Is it an identity conversion?
+  if (literalFnType->isEqual(convertedFnType)) {
+    return true;
+  }
   
   // Does the conversion only add `throws`?
   if (literalFnType->isEqual(convertedFnType->getWithoutThrowing())) {

--- a/test/SILGen/default_arguments.swift
+++ b/test/SILGen/default_arguments.swift
@@ -460,3 +460,11 @@ struct WeirdUMEInitCase {
 
 let _: WeirdUMEInitCase = .ty()
 let _: WeirdUMEInitCase = .ty(5)
+
+struct KeyPathLiteralAsFunctionDefaultArg {
+    var x: Int
+
+    func doStuff(with prop: (KeyPathLiteralAsFunctionDefaultArg) -> Int = \.x) {}
+}
+
+KeyPathLiteralAsFunctionDefaultArg(x: 1738).doStuff()


### PR DESCRIPTION
Previously, we would turn a key path literal like `\.foo` in function type context into a double-wrapped closure like this:

```
  foo(\.x) // before type checking
  foo({ $kp$ in { $0[$kp$] } }(\.x)) // after type checking
```

in order to preserve the evaluation semantics of the key path literal. This works but leads to some awkward raw SIL generated out of SILGen which misses out on various SILGen peepholes and requires a fair number of passes to clean up. The semantics can still be preserved with a single layer of closure, by using a capture list:

```
  foo({[$kp$ = \.x] in $0[$kp$] }) // after type checking
```

which generates better natural code out of SILGen, and is also (IMO) easier to understand on human inspection.

Changing the AST representation did lead to a change in code generation that interfered with the efficacy of CapturePropagation of key path literals; for key path literals used as nonescaping closures, a mark_dependence of the nonescaping function value on the key path was left behind, leaving the key path object alive. The dependence is severed by the specialization done in the pass, so update the pass to eliminate the dependence.

Compared to the previous patch, this version removes the attempt to have the type-checked function expression carry the noescape-ness of its context, and allows for coerceToType to introduce a function conversion instead, since that FunctionConversionExpr is apparently load-bearing for default argument generators.