### PR TITLE
Factor "maybeWrapInExistential" into builders

### DIFF
--- a/include/swift/AST/ASTDemangler.h
+++ b/include/swift/AST/ASTDemangler.h
@@ -193,6 +193,8 @@ public:
                                                     unsigned size,
                                                     unsigned alignment);
 
+  Type maybeWrapInExistential(Type type);
+
 private:
   bool validateParentType(TypeDecl *decl, Type parent);
   CanGenericSignature demangleGenericSignature(

--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -736,8 +736,7 @@ public:
 
   const ProtocolCompositionTypeRef *
   createProtocolCompositionType(llvm::ArrayRef<BuiltProtocolDecl> protocols,
-                                BuiltType superclass, bool isClassBound,
-                                bool forRequirement = true) {
+                                BuiltType superclass, bool isClassBound) {
     std::vector<const TypeRef *> protocolRefs;
     for (const auto &protocol : protocols) {
       if (!protocol)
@@ -832,6 +831,11 @@ public:
       const llvm::SmallVectorImpl<BuiltRequirement> &Requirements) {
     return SILBoxTypeWithLayoutTypeRef::create(*this, Fields, Substitutions,
                                                Requirements);
+  }
+
+  BuiltType maybeWrapInExistential(BuiltType type) {
+    // Nothing to do.
+    return type;
   }
 
   bool isExistential(const TypeRef *) {

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -588,11 +588,7 @@ Type ASTBuilder::createProtocolCompositionType(
   if (superclass && superclass->getClassOrBoundGenericClass())
     members.push_back(superclass);
 
-  Type composition = ProtocolCompositionType::get(Ctx, members, isClassBound);
-  if (forRequirement)
-    return composition;
-
-  return ExistentialType::get(composition);
+  return ProtocolCompositionType::get(Ctx, members, isClassBound);
 }
 
 Type ASTBuilder::createProtocolTypeFromDecl(ProtocolDecl *protocol) {
@@ -1219,4 +1215,10 @@ GenericTypeDecl *ASTBuilder::findForeignTypeDecl(StringRef name,
   }
 
   return consumer.Result;
+}
+
+Type ASTBuilder::maybeWrapInExistential(Type type) {
+  if (type->isConstraintType())
+    return ExistentialType::get(type);
+  return type;
 }

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1644,8 +1644,7 @@ public:
 
   TypeLookupErrorOr<BuiltType>
   createProtocolCompositionType(llvm::ArrayRef<BuiltProtocolDecl> protocols,
-                                BuiltType superclass, bool isClassBound,
-                                bool forRequirement = true) const {
+                                BuiltType superclass, bool isClassBound) const {
     // Determine whether we have a class bound.
     ProtocolClassConstraint classConstraint = ProtocolClassConstraint::Any;
     if (isClassBound || superclass) {
@@ -1838,8 +1837,13 @@ public:
     // Mangled types for building metadata don't contain sugared types
     return BuiltType();
   }
-};
 
+  TypeLookupErrorOr<BuiltType>
+  maybeWrapInExistential(TypeLookupErrorOr<BuiltType> type) {
+    // Nothing to do.
+    return type;
+  }
+};
 }
 
 SWIFT_CC(swift)


### PR DESCRIPTION
When decoding mangled names into types, a type may be optionally wrapped in an existential depending on the context (for example, if a protocol appears in a function signature's requirement it's only the protocol type, but if it appears as a type of a variable, it's an existential). This patch centralizes the logic of whether a type should be wrapped in an existential in a new "maybeWrapInExistential" in the builders.
