### PR TITLE
[MiscDiagnostics] OpaqueChecker: Double-check validity of last expres…

### DIFF
--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -571,4 +571,10 @@ do {
     let x = S2()
     x // expected-warning {{expression of type 'S2' is unused}}
   }
+
+  func test5() -> some P1 {
+    // expected-error@-1 {{function declares an opaque return type, but has no return statements in its body from which to infer an underlying type}}
+    let x = invalid // expected-error {{cannot find 'invalid' in scope}}
+    x
+  }
 }


### PR DESCRIPTION
…sion

It's possible that TypeChecker::typeCheckStmt has did not propagate `HadError` properly while checking the body of a function, so opaque result checker has to be careful about requesting types from expressions.

Resolves: rdar://100066109

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
