### PR TITLE
[interop][SwiftToCxx] bridge ObjC class types to C++ (without Obj…

### DIFF
--- a/test/Interop/ObjCToSwiftToObjCxx/bridge-objc-types-back-to-objcxx-execution.mm
+++ b/test/Interop/ObjCToSwiftToObjCxx/bridge-objc-types-back-to-objcxx-execution.mm
@@ -1,0 +1,132 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -typecheck %t/use-objc-types.swift -typecheck -module-name UseObjCTy -emit-clang-header-path %t/UseObjCTy.h -I %t -enable-experimental-cxx-interop -clang-header-expose-public-decls
+
+// RUN: %target-interop-build-clangxx -std=c++20 -fobjc-arc -c %t/use-swift-objc-types.mm -I %t -o %t/swift-objc-execution.o
+// RUN: %target-interop-build-swift %t/use-objc-types.swift -o %t/swift-objc-execution -Xlinker %t/swift-objc-execution.o -module-name UseObjCTy -Xfrontend -entry-point-function-name -Xfrontend swiftMain -I %t
+
+// RUN: %target-codesign %t/swift-objc-execution
+// RUN: %target-run %t/swift-objc-execution | %FileCheck %s
+// RUN: %target-run %t/swift-objc-execution | %FileCheck --check-prefix=DESTROY %s
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+//--- header.h
+
+#import <Foundation/Foundation.h>
+
+@interface ObjCKlass: NSObject
+-(ObjCKlass * _Nonnull) init:(int)x;
+-(int)getValue;
+@end
+
+//--- module.modulemap
+module ObjCTest {
+    header "header.h"
+}
+
+//--- use-objc-types.swift
+import ObjCTest
+
+public func retObjClass() -> ObjCKlass {
+    return ObjCKlass(1)
+}
+
+public func retObjClassNull() -> ObjCKlass? {
+    return nil
+}
+
+public func retObjClassNullable() -> ObjCKlass? {
+    return retObjClass()
+}
+
+public func takeObjCClass(_ x: ObjCKlass) {
+    print("OBJClass:", x.getValue());
+}
+
+public func takeObjCClassInout(_ x: inout ObjCKlass) {
+    x = ObjCKlass(x.getValue() + 1)
+}
+
+public func takeObjCClassNullable(_ x: ObjCKlass?) {
+    if let x = x {
+        print("OBJClass:", x.getValue());
+    } else {
+        print("NIL");
+    }
+}
+
+public func passThroughObjClass(_ x: ObjCKlass?) -> ObjCKlass? {
+    return x
+}
+
+//--- use-swift-objc-types.mm
+
+#include "header.h"
+#include "UseObjCTy.h"
+#include <assert.h>
+#include <stdio.h>
+
+int globalCounter = 0;
+
+struct DeinitPrinter {
+    ~DeinitPrinter() {
+        puts("destroy ObjCKlass");
+        --globalCounter;
+    }
+};
+
+@implementation ObjCKlass {
+    int _x;
+    DeinitPrinter _printer;
+}
+- (ObjCKlass * _Nonnull) init:(int)x {
+    ObjCKlass *result = [super init];
+    result->_x = x;
+    puts("create ObjCKlass");
+    ++globalCounter;
+    return result;
+}
+
+-(int)getValue {
+    return self->_x;
+}
+
+@end
+
+int main() {
+  using namespace UseObjCTy;
+  @autoreleasepool {
+    ObjCKlass* val = retObjClass();
+    assert(val.getValue == 1);
+    assert(globalCounter == 1);
+    takeObjCClass(val);
+    takeObjCClassInout(val);
+    takeObjCClassNullable(val);
+    takeObjCClassNullable(retObjClassNull());
+  }
+  assert(globalCounter == 0);
+// CHECK: create ObjCKlass
+// CHECK-NEXT: OBJClass: 1
+// CHECK-NEXT: create ObjCKlass
+// CHECK: OBJClass: 2
+// CHECK-NEXT: NIL
+// DESTROY: destroy ObjCKlass
+// DESTROY: destroy ObjCKlass
+  puts("Part2");
+  @autoreleasepool {
+    ObjCKlass* val = retObjClassNullable();
+    assert(globalCounter == 1);
+    assert(val.getValue == 1);
+    takeObjCClassNullable(passThroughObjClass(val));
+  }
+  assert(globalCounter == 0);
+// CHECK: Part2
+// CHECK-NEXT: create ObjCKlass
+// CHECK-NEXT: OBJClass: 1
+// CHECK-NEXT: destroy ObjCKlass
+// DESTROY: destroy ObjCKlass
+  return 0;
+}

--- a/test/Interop/ObjCToSwiftToObjCxx/bridge-objc-types-back-to-objcxx.swift
+++ b/test/Interop/ObjCToSwiftToObjCxx/bridge-objc-types-back-to-objcxx.swift
@@ -1,0 +1,66 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -typecheck %t/use-objc-types.swift -typecheck -module-name UseObjCTy -emit-clang-header-path %t/UseObjCTy.h -I %t -enable-experimental-cxx-interop -clang-header-expose-public-decls
+
+// RUN: %FileCheck %s < %t/UseObjCTy.h
+
+// FIXME: remove once https://github.com/apple/swift/pull/60971 lands.
+// RUN: echo "#include \"header.h\"" > %t/full-header.h
+// RUN: cat %t/UseObjCTy.h >> %t/full-header.h
+
+// RUN: %target-interop-build-clangxx -std=gnu++20 -fobjc-arc -c -x objective-c++-header %t/full-header.h -o %t/o.o
+
+// REQUIRES: objc_interop
+
+//--- header.h
+
+@interface ObjCKlass
+-(ObjCKlass * _Nonnull) init;
+@end
+
+//--- module.modulemap
+module ObjCTest {
+    header "header.h"
+}
+
+//--- use-objc-types.swift
+import ObjCTest
+
+public func retObjClass() -> ObjCKlass {
+    return ObjCKlass()
+}
+
+public func takeObjCClass(_ x: ObjCKlass) {
+}
+
+public func takeObjCClassInout(_ x: inout ObjCKlass) {
+}
+
+public func takeObjCClassNullable(_ x: ObjCKlass?) {
+}
+
+public func retObjClassNullable() -> ObjCKlass? {
+    return nil
+}
+
+// CHECK: ObjCKlass *_Nonnull $s9UseObjCTy03retB5ClassSo0B6CKlassCyF(void) SWIFT_NOEXCEPT SWIFT_CALL;
+// CHECK-NEXT: ObjCKlass *_Nullable $s9UseObjCTy03retB13ClassNullableSo0B6CKlassCSgyF(void) SWIFT_NOEXCEPT SWIFT_CALL;
+// CHECK-NEXT: void $s9UseObjCTy04takeB6CClassyySo0B6CKlassCF(ObjCKlass *_Nonnull x) SWIFT_NOEXCEPT SWIFT_CALL;
+// CHECK-NEXT: void $s9UseObjCTy04takeB11CClassInoutyySo0B6CKlassCzF(ObjCKlass *_Nonnull __strong * _Nonnull x) SWIFT_NOEXCEPT SWIFT_CALL;
+// CHECK-NEXT: void $s9UseObjCTy04takeB14CClassNullableyySo0B6CKlassCSgF(ObjCKlass *_Nullable x) SWIFT_NOEXCEPT SWIFT_CALL;
+
+// CHECK: inline ObjCKlass *_Nonnull retObjClass() noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT: return (__bridge_transfer ObjCKlass *)(__bridge void *)_impl::$s9UseObjCTy03retB5ClassSo0B6CKlassCyF();
+
+// CHECK: inline ObjCKlass *_Nullable retObjClassNullable() noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT: return (__bridge_transfer ObjCKlass *)(__bridge void *)_impl::$s9UseObjCTy03retB13ClassNullableSo0B6CKlassCSgyF();
+
+// CHECK: void takeObjCClass(ObjCKlass *_Nonnull x) noexcept {
+// CHECK-NEXT: return _impl::$s9UseObjCTy04takeB6CClassyySo0B6CKlassCF(x);
+
+// CHECK: inline void takeObjCClassInout(ObjCKlass *_Nonnull __strong & x) noexcept {
+// CHECK-NEXT: return _impl::$s9UseObjCTy04takeB11CClassInoutyySo0B6CKlassCzF(&x);
+
+// CHECK: inline void takeObjCClassNullable(ObjCKlass *_Nullable x) noexcept {
+// CHECK-NEXT: return _impl::$s9UseObjCTy04takeB14CClassNullableyySo0B6CKlassCSgF(x);

--- a/test/Interop/ObjCToSwiftToObjCxx/lit.local.cfg
+++ b/test/Interop/ObjCToSwiftToObjCxx/lit.local.cfg
@@ -1,0 +1,1 @@
+config.suffixes = ['.swift', '.cpp', '.mm']


### PR DESCRIPTION
…C guards first)

In the future we should add `#if __OBJC__` guards.