### PR TITLE
update-checkout: Do not update repository if not listed in the given branch-scheme

### DIFF
--- a/utils/python_format.py
+++ b/utils/python_format.py
@@ -35,7 +35,6 @@ _KNOWN_SCRIPT_PATHS = [
     _SWIFT_PATH / "test/Driver/Inputs/fake-toolchain/ld",
     _SWIFT_PATH / "utils/80+-check",
     _SWIFT_PATH / "utils/backtrace-check",
-    _SWIFT_PATH / "utils/build-parser-lib",
     _SWIFT_PATH / "utils/build-script",
     _SWIFT_PATH / "utils/check-incremental",
     _SWIFT_PATH / "utils/coverage/coverage-build-db",

--- a/utils/update_checkout/tests/test_clone.py
+++ b/utils/update_checkout/tests/test_clone.py
@@ -10,6 +10,8 @@
 #
 # ===----------------------------------------------------------------------===#
 
+import os
+
 from . import scheme_mock
 
 
@@ -23,3 +25,51 @@ class CloneTestCase(scheme_mock.SchemeMockTestCase):
                    '--config', self.config_path,
                    '--source-root', self.source_root,
                    '--clone'])
+
+        for repo in self.get_all_repos():
+            repo_path = os.path.join(self.source_root, repo)
+            self.assertTrue(os.path.isdir(repo_path))
+
+
+class SchemeWithMissingRepoTestCase(scheme_mock.SchemeMockTestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.base_args = [
+            self.update_checkout_path,
+            "--config",
+            self.config_path,
+            "--source-root",
+            self.source_root,
+        ]
+
+        repos = self.get_all_repos()
+        repos.pop()
+
+        self.scheme_name = "missing-repo"
+        scheme = {
+            "aliases": [self.scheme_name],
+            "repos": dict((repo, "main") for repo in repos),
+        }
+        self.add_branch_scheme(self.scheme_name, scheme)
+
+    # Test that we do not clone a repository that is not listed in the
+    # given branch-scheme.
+    def test_clone(self):
+        self.call(self.base_args + ["--scheme", self.scheme_name, "--clone"])
+
+        missing_repo_path = os.path.join(
+            self.source_root, self.get_all_repos().pop()
+        )
+        self.assertFalse(os.path.isdir(missing_repo_path))
+
+    # Test that we do not update a repository that is not listed in the given
+    # branch-scheme---doing so will cause an irrelevant failure in an attempt
+    # to query the branch-scheme about the target branch for that repository.
+    def test_update(self):
+        # First, clone using the default branch-scheme, which has mappings for
+        # all repositories.
+        self.call(self.base_args + ["--clone"])
+
+        # Then, update using our custom scheme---a subset of the default one.
+        self.call(self.base_args + ["--scheme", self.scheme_name])

--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -266,6 +266,20 @@ def update_all_repositories(args, config, scheme_name, cross_repos_pr):
         if repo_name in args.skip_repository_list:
             print("Skipping update of '" + repo_name + "', requested by user")
             continue
+
+        # If the repository is not listed in the branch-scheme, skip it.
+        if scheme_map and repo_name not in scheme_map:
+            # If the repository exists locally, notify we are skipping it.
+            if os.path.isdir(os.path.join(args.source_root, repo_name)):
+                print(
+                    "Skipping update of '"
+                    + repo_name
+                    + "', repository not listed in the '"
+                    + scheme_name
+                    + "' branch-scheme"
+                )
+            continue
+
         my_args = [args.source_root, config,
                    repo_name,
                    scheme_name,


### PR DESCRIPTION
Consider two branch-schemes, where the second is a subset of the first. Suppose repositories have been cloned using the first branch scheme. Previously, a successive update using the second branch-scheme would cause update-checkout to fail in an attempt to query the branch-scheme about the target branch for a repository it does not map, even though the update, given no further errors, can be considered successful.