### PR TITLE
[New parser] Enable round-trip testing of the new parser in +Asserts builds

### DIFF
--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -31,6 +31,9 @@ using namespace swift;
 
 LangOptions::LangOptions() {
   // Note: Introduce default-on language options here.
+#ifndef NDEBUG
+  Features.insert(Feature::ParserRoundTrip);
+#endif
 }
 
 struct SupportedConditionalValue {


### PR DESCRIPTION
The new parser is designed to always provide a byte-for-byte accurate representation of the input source program. Verify this "round-trip" property in +Asserts builds.