### PR TITLE
[android][test] Tweaks to get the new failing C++ Interop tests working

### DIFF
--- a/test/Interop/Cxx/class/memory-layout-silgen.swift
+++ b/test/Interop/Cxx/class/memory-layout-silgen.swift
@@ -1,5 +1,8 @@
 // RUN: %target-swiftxx-frontend -I %S/Inputs -emit-ir -o - %s | %FileCheck %s
 
+// XFAIL: OS=linux-android
+// XFAIL: OS=linux-androideabi
+
 import MemoryLayout
 
 var v = PrivateMemberLayout()

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1681,6 +1681,7 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
         '-target', config.variant_triple,
         '-sdk', shell_quote(config.variant_sdk)])
     config.target_swift_ide_test = ' '.join([
+        'env', 'SDKROOT={}'.format(shell_quote(config.variant_sdk)),
         config.swift_ide_test,
         '-target', config.variant_triple,
         config.resource_dir_opt, mcp_opt, ccp_opt])
@@ -1702,7 +1703,7 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
         config.swiftc, '-emit-pcm',
         '-target', config.variant_triple])
     config.target_clang = ' '.join([
-        'clang++',
+        '{}/clang++'.format(tools_directory),
         '-target', config.variant_triple,
         clang_mcp_opt, '-isystem', config.variant_sdk, config.target_cc_options,
         '-fobjc-runtime=ios-5.0'])


### PR DESCRIPTION
@drodriguez, let me know what you think: haven't tested the two failing tests that use `swift-ide-test` with this pull, but confirmed with a prebuilt toolchain snapshot that the last clang change gets the new `SwiftToCxx` tests working. Four of the five tests failing on the Android CI pass natively on Android, so I only disabled the one `memory-layout-silgen.swift` that fails both when cross-compiling with the NDK and natively compiling in the Termux app.

If you can try this out with an Android cross-compilation build you have lying around and let me know what you think, that'd be great, as I almost never build the Swift compiler on linux these days.
