### PR TITLE
Define critical SILInstruction and SILBasicBlock getters inline.

### DIFF
--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -659,4 +659,26 @@ template <> struct DenseMapInfo<swift::PhiValue> {
 
 } // end namespace llvm
 
+//===----------------------------------------------------------------------===//
+// Inline SILInstruction implementations
+//===----------------------------------------------------------------------===//
+
+namespace swift {
+
+inline SILFunction *SILInstruction::getFunction() const {
+  return getParent()->getParent();
+}
+
+inline SILInstruction *SILInstruction::getPreviousInstruction() {
+  auto pos = getIterator();
+  return pos == getParent()->begin() ? nullptr : &*std::prev(pos);
+}
+
+inline SILInstruction *SILInstruction::getNextInstruction() {
+  auto nextPos = std::next(getIterator());
+  return nextPos == getParent()->end() ? nullptr : &*nextPos;
+}
+
+} // end swift namespace
+
 #endif

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -1461,4 +1461,20 @@ private:
 
 } // end llvm namespace
 
+//===----------------------------------------------------------------------===//
+// Inline SIL implementations
+//===----------------------------------------------------------------------===//
+
+namespace swift {
+
+inline bool SILBasicBlock::isEntry() const {
+  return this == &*getParent()->begin();
+}
+
+inline SILModule &SILInstruction::getModule() const {
+  return getFunction()->getModule();
+}
+
+} // end swift namespace
+
 #endif

--- a/lib/SIL/IR/SILBasicBlock.cpp
+++ b/lib/SIL/IR/SILBasicBlock.cpp
@@ -361,10 +361,6 @@ ScopeCloner::getOrCreateClonedScope(const SILDebugScope *OrigScope) {
   return ClonedScope;
 }
 
-bool SILBasicBlock::isEntry() const {
-  return this == &*getParent()->begin();
-}
-
 /// Declared out of line so we can have a declaration of SILArgument.
 #define ARGUMENT(NAME, PARENT)                                                 \
   NAME##ArrayRef SILBasicBlock::get##NAME##s() const {                         \

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -104,24 +104,6 @@ transferNodesFromList(llvm::ilist_traits<SILInstruction> &L2,
   ASSERT_IMPLEMENTS_STATIC(CLASS, PARENT, classof, bool(SILNodePointer));
 #include "swift/SIL/SILNodes.def"
 
-SILFunction *SILInstruction::getFunction() const {
-  return getParent()->getParent();
-}
-
-SILModule &SILInstruction::getModule() const {
-  return getFunction()->getModule();
-}
-
-SILInstruction *SILInstruction::getPreviousInstruction() {
-  auto pos = getIterator();
-  return pos == getParent()->begin() ? nullptr : &*std::prev(pos);
-}
-
-SILInstruction *SILInstruction::getNextInstruction() {
-  auto nextPos = std::next(getIterator());
-  return nextPos == getParent()->end() ? nullptr : &*nextPos;
-}
-
 void SILInstruction::removeFromParent() {
 #ifndef NDEBUG
   for (auto result : getResults()) {


### PR DESCRIPTION
It makes no sense to operate on the block's instruction list without also including SILBasicBlock.h anyway. Similarly, it doesn't make sense to query the entry block without including SILFunction.h.

Now we can call these simple getters in critical-path loops assuming they are as cheap as a load. I was avoiding calling these in critical path code, which resulted in less readability and consistency across the code base.
