### PR TITLE
Add debug_value [trace] attribute.

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -3804,7 +3804,7 @@ debug_value
 
 ::
 
-  sil-instruction ::= debug_value '[poison]'? '[moved]'? sil-operand (',' debug-var-attr)* advanced-debug-var-attr* (',' 'expr' debug-info-expr)?
+  sil-instruction ::= debug_value '[poison]'? '[moved]'? '[trace]'? sil-operand (',' debug-var-attr)* advanced-debug-var-attr* (',' 'expr' debug-info-expr)?
 
   debug_value %1 : $Int
 
@@ -3909,6 +3909,8 @@ It is worth noting that a SIL DIExpression is similar to
 `!DIExpression <https://www.llvm.org/docs/LangRef.html#diexpression>`_ in LLVM debug
 info metadata. While LLVM represents ``!DIExpression`` are a list of 64-bit integers,
 SIL DIExpression can have elements with various types, like AST nodes or strings.
+
+The ``[trace]`` flag is available for compiler unit testing. It is not produced during normal compilation. It is used combination with internal logging and optimization controls to select specific values to trace or to transform. For example, liveness analysis combines all "traced" values into a single live range with multiple definitions. This exposes corner cases that cannot be represented by passing valid SIL through the pipeline.
 
 Profiling
 ~~~~~~~~~

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -957,10 +957,12 @@ public:
   DebugValueInst *createDebugValue(SILLocation Loc, SILValue src,
                                    SILDebugVariable Var,
                                    bool poisonRefs = false,
-                                   bool wasMoved = false);
+                                   bool wasMoved = false,
+                                   bool trace = false);
   DebugValueInst *createDebugValueAddr(SILLocation Loc, SILValue src,
                                        SILDebugVariable Var,
-                                       bool wasMoved = false);
+                                       bool wasMoved = false,
+                                       bool trace = false);
 
   /// Create a debug_value according to the type of \p src
   SILInstruction *emitDebugDescription(SILLocation Loc, SILValue src,

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1283,7 +1283,7 @@ SILCloner<ImplClass>::visitDebugValueInst(DebugValueInst *Inst) {
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   auto *NewInst = getBuilder().createDebugValue(
       Inst->getLoc(), getOpValue(Inst->getOperand()), VarInfo,
-      Inst->poisonRefs(), Inst->getWasMoved());
+      Inst->poisonRefs(), Inst->getWasMoved(), Inst->hasTrace());
   remapDebugVarInfo(DebugVarCarryingInst(NewInst));
   recordClonedInstruction(Inst, NewInst);
 }

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -4832,13 +4832,15 @@ class DebugValueInst final
   USE_SHARED_UINT8;
 
   DebugValueInst(SILDebugLocation DebugLoc, SILValue Operand,
-                 SILDebugVariable Var, bool poisonRefs, bool operandWasMoved);
+                 SILDebugVariable Var, bool poisonRefs, bool operandWasMoved,
+                 bool trace);
   static DebugValueInst *create(SILDebugLocation DebugLoc, SILValue Operand,
                                 SILModule &M, SILDebugVariable Var,
-                                bool poisonRefs, bool operandWasMoved);
+                                bool poisonRefs, bool operandWasMoved,
+                                bool trace);
   static DebugValueInst *createAddr(SILDebugLocation DebugLoc, SILValue Operand,
                                     SILModule &M, SILDebugVariable Var,
-                                    bool operandWasMoved);
+                                    bool operandWasMoved, bool trace);
 
   SIL_DEBUG_VAR_SUPPLEMENT_TRAILING_OBJS_IMPL()
 
@@ -4914,6 +4916,12 @@ public:
 
   void setPoisonRefs(bool poisonRefs = true) {
     sharedUInt8().DebugValueInst.poisonRefs = poisonRefs;
+  }
+
+  bool hasTrace() const { return sharedUInt8().DebugValueInst.trace; }
+
+  void setTrace(bool trace = true) {
+    sharedUInt8().DebugValueInst.trace = trace;
   }
 };
 

--- a/include/swift/SIL/SILNode.h
+++ b/include/swift/SIL/SILNode.h
@@ -204,7 +204,8 @@ protected:
 
     SHARED_FIELD(DebugValueInst, uint8_t
       poisonRefs : 1,
-      operandWasMoved : 1);
+      operandWasMoved : 1,
+      trace : 1);
 
     SHARED_FIELD(AllocStackInst, uint8_t
       dynamicLifetime : 1,

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -572,6 +572,10 @@ public:
     return true;
   }
 
+  /// Returns true if this value should be traced for optimization debugging
+  /// (it has a debug_value [trace] user).
+  bool hasDebugTrace() const;
+
   static bool classof(SILNodePointer node) {
     return node->getKind() >= SILNodeKind::First_ValueBase &&
            node->getKind() <= SILNodeKind::Last_ValueBase;

--- a/lib/SIL/IR/SILBuilder.cpp
+++ b/lib/SIL/IR/SILBuilder.cpp
@@ -589,24 +589,26 @@ void SILBuilder::emitDestructureValueOperation(
 DebugValueInst *SILBuilder::createDebugValue(SILLocation Loc, SILValue src,
                                              SILDebugVariable Var,
                                              bool poisonRefs,
-                                             bool operandWasMoved) {
+                                             bool operandWasMoved,
+                                             bool trace) {
   llvm::SmallString<4> Name;
   // Debug location overrides cannot apply to debug value instructions.
   DebugLocOverrideRAII LocOverride{*this, None};
   return insert(DebugValueInst::create(
       getSILDebugLocation(Loc), src, getModule(),
-      *substituteAnonymousArgs(Name, Var, Loc), poisonRefs, operandWasMoved));
+      *substituteAnonymousArgs(Name, Var, Loc), poisonRefs, operandWasMoved,
+      trace));
 }
 
 DebugValueInst *SILBuilder::createDebugValueAddr(SILLocation Loc, SILValue src,
                                                  SILDebugVariable Var,
-                                                 bool wasMoved) {
+                                                 bool wasMoved, bool trace) {
   llvm::SmallString<4> Name;
   // Debug location overrides cannot apply to debug addr instructions.
   DebugLocOverrideRAII LocOverride{*this, None};
   return insert(DebugValueInst::createAddr(
       getSILDebugLocation(Loc), src, getModule(),
-      *substituteAnonymousArgs(Name, Var, Loc), wasMoved));
+      *substituteAnonymousArgs(Name, Var, Loc), wasMoved, trace));
 }
 
 void SILBuilder::emitScopedBorrowOperation(SILLocation loc, SILValue original,

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -351,7 +351,7 @@ SILType AllocBoxInst::getAddressType() const {
 
 DebugValueInst::DebugValueInst(SILDebugLocation DebugLoc, SILValue Operand,
                                SILDebugVariable Var, bool poisonRefs,
-                               bool wasMoved)
+                               bool wasMoved, bool trace)
     : UnaryInstructionBase(DebugLoc, Operand),
       SILDebugVariableSupplement(Var.DIExpr.getNumElements(),
                                  Var.Type.hasValue(), Var.Loc.hasValue(),
@@ -365,21 +365,22 @@ DebugValueInst::DebugValueInst(SILDebugLocation DebugLoc, SILValue Operand,
   setPoisonRefs(poisonRefs);
   if (wasMoved)
     markAsMoved();
+  setTrace(trace);
 }
 
 DebugValueInst *DebugValueInst::create(SILDebugLocation DebugLoc,
                                        SILValue Operand, SILModule &M,
                                        SILDebugVariable Var, bool poisonRefs,
-                                       bool wasMoved) {
+                                       bool wasMoved, bool trace) {
   void *buf = allocateDebugVarCarryingInst<DebugValueInst>(M, Var);
   return ::new (buf)
-      DebugValueInst(DebugLoc, Operand, Var, poisonRefs, wasMoved);
+    DebugValueInst(DebugLoc, Operand, Var, poisonRefs, wasMoved, trace);
 }
 
 DebugValueInst *DebugValueInst::createAddr(SILDebugLocation DebugLoc,
                                            SILValue Operand, SILModule &M,
                                            SILDebugVariable Var,
-                                           bool wasMoved) {
+                                           bool wasMoved, bool trace) {
   // For alloc_stack, debug_value is used to annotate the associated
   // memory location, so we shouldn't attach op_deref.
   if (!isa<AllocStackInst>(Operand))
@@ -387,7 +388,7 @@ DebugValueInst *DebugValueInst::createAddr(SILDebugLocation DebugLoc,
       {SILDIExprElement::createOperator(SILDIExprOperator::Dereference)});
   void *buf = allocateDebugVarCarryingInst<DebugValueInst>(M, Var);
   return ::new (buf) DebugValueInst(DebugLoc, Operand, Var,
-                                    /*poisonRefs=*/false, wasMoved);
+                                    /*poisonRefs=*/false, wasMoved, trace);
 }
 
 bool DebugValueInst::exprStartsWithDeref() const {

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1737,6 +1737,8 @@ public:
       *this << "[poison] ";
     if (DVI->getWasMoved())
       *this << "[moved] ";
+    if (DVI->hasTrace())
+      *this << "[trace] ";
     *this << getIDAndType(DVI->getOperand());
     printDebugVar(DVI->getVarInfo(),
                   &DVI->getModule().getASTContext().SourceMgr);

--- a/lib/SIL/IR/SILValue.cpp
+++ b/lib/SIL/IR/SILValue.cpp
@@ -118,6 +118,16 @@ bool ValueBase::isLexical() const {
   return false;
 }
 
+bool ValueBase::hasDebugTrace() const {
+  for (auto *op : getUses()) {
+    if (auto *debugValue = dyn_cast<DebugValueInst>(op->getUser())) {
+      if (debugValue->hasTrace())
+        return true;
+    }
+  }
+  return false;
+}
+
 SILBasicBlock *SILNode::getParentBlock() const {
   if (auto *Inst = dyn_cast<SILInstruction>(this))
     return Inst->getParent();

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -3347,6 +3347,7 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
   case SILInstructionKind::DebugValueInst: {
     bool poisonRefs = false;
     bool wasMoved = false;
+    bool hasTrace = false;
     SILDebugVariable VarInfo;
 
     // Allow for poison and moved to be in either order.
@@ -3357,6 +3358,8 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
         poisonRefs = true;
       else if (attributeName == "moved")
         wasMoved = true;
+      else if (attributeName == "trace")
+        hasTrace = true;
       else {
         P.diagnose(attributeLoc, diag::sil_invalid_attribute_for_instruction,
                    attributeName, "debug_value");
@@ -3369,7 +3372,8 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
       return true;
     if (Val->getType().isAddress())
       assert(!poisonRefs && "debug_value w/ address value does not support poison");
-    ResultVal = B.createDebugValue(InstLoc, Val, VarInfo, poisonRefs, wasMoved);
+    ResultVal = B.createDebugValue(InstLoc, Val, VarInfo, poisonRefs, wasMoved,
+                                   hasTrace);
     break;
   }
 

--- a/test/SIL/Parser/basic.sil
+++ b/test/SIL/Parser/basic.sil
@@ -1309,6 +1309,7 @@ sil @debug_value : $@convention(thin) (Int, @in P, AnyObject) -> () {
 bb0(%0 : $Int, %1 : $*P, %2 : $AnyObject):
   debug_value %0 : $Int         // CHECK: debug_value %0 : $Int
   debug_value [poison] %2 : $AnyObject // CHECK: debug_value [poison] %2 : $AnyObject
+  debug_value [trace] %2 : $AnyObject // CHECK: debug_value [trace] %2 : $AnyObject
   debug_value %1 : $*P, expr op_deref // CHECK: debug_value %1 : $*any P, expr op_deref
   unreachable
 }

--- a/test/SIL/cloning.sil
+++ b/test/SIL/cloning.sil
@@ -94,3 +94,16 @@ entry(%0 : @owned $Builtin.NativeObject):
   %res = apply %callee_move_value(%0) : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject
   return %res : $Builtin.NativeObject
 }
+
+sil [ossa] @callee_debug_value : $@convention(thin) (@owned X) -> @owned X {
+entry(%0 : @owned $X):
+  debug_value [trace] %0 : $X
+  return %0 : $X
+}
+
+sil [ossa] @caller_debug_value : $@convention(thin) (@owned X) -> @owned X {
+entry(%0 : @owned $X):
+  %callee_debug_value = function_ref @callee_debug_value : $@convention(thin) (@owned X) -> @owned X
+  %res = apply %callee_debug_value(%0) : $@convention(thin) (@owned X) -> @owned X
+  return %res : $X
+}


### PR DESCRIPTION
This lets us write optimizer unit tests and selectively debug the optimizer in general. We'll be able trace analyses and control optimization selectively for certain values.

Adding a trace flag to debug_value is the easiest way to start using it experimentally and develop the rest of the infrastructure. If this takes off, then we can consider a new `trace_value` instruction. For now, reusing debug_value is the least intrusive way to start writing liveness unit tests.