### PR TITLE
[SIL] Fix linkage of external property wrapper backing initializers

### DIFF
--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -380,7 +380,10 @@ struct SILDeclRef {
   bool isAlwaysInline() const;
   /// True if the function has the @_backDeploy attribute.
   bool isBackDeployed() const;
-  
+
+  /// Return the expected linkage for a definition of this declaration.
+  SILLinkage getDefinitionLinkage() const;
+
   /// Return the expected linkage of this declaration.
   SILLinkage getLinkage(ForDefinition_t forDefinition) const;
 

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -459,10 +459,14 @@ SILLinkage SILDeclRef::getDefinitionLinkage() const {
   if (isPropertyWrapperBackingInitializer()) {
     auto *dc = decl->getDeclContext();
 
-    // Property wrapper generators of public functions have PublicNonABI
-    // linkage.
-    if (isa<ParamDecl>(decl) && isSerialized())
-      return SILLinkage::PublicNonABI;
+    // External property wrapper backing initializers have linkage based
+    // on the access level of their function.
+    if (isa<ParamDecl>(decl)) {
+      if (isa<AbstractClosureExpr>(dc))
+        return privateLinkage();
+
+      decl = cast<ValueDecl>(dc->getAsDecl());
+    }
 
     // Property wrappers in types have linkage based on the access level of
     // their nominal.

--- a/test/SILGen/always_emit_into_client_attribute.swift
+++ b/test/SILGen/always_emit_into_client_attribute.swift
@@ -29,3 +29,21 @@ public struct S {
     set { }
   }
 }
+
+public final class C {
+  // C.__allocating_init()
+  // CHECK-LABEL: sil non_abi [serialized] [exact_self_class] [ossa] @$s33always_emit_into_client_attribute1CCACycfC : $@convention(method) (@thick C.Type) -> @owned C
+
+  // C.init()
+  // CHECK-LABEL: sil non_abi [serialized] [ossa] @$s33always_emit_into_client_attribute1CCACycfc : $@convention(method) (@owned C) -> @owned C
+  @_alwaysEmitIntoClient
+  public init() {}
+
+  // C.deinit
+  // CHECK-LABEL: sil non_abi [serialized] [ossa] @$s33always_emit_into_client_attribute1CCfd : $@convention(method) (@guaranteed C) -> @owned Builtin.NativeObject
+
+  // C.__deallocating_deinit
+  // CHECK-LABEL: sil non_abi [serialized] [ossa] @$s33always_emit_into_client_attribute1CCfD : $@convention(method) (@owned C) -> ()
+  @_alwaysEmitIntoClient
+  deinit {}
+}

--- a/test/SILGen/property_wrapper_parameter.swift
+++ b/test/SILGen/property_wrapper_parameter.swift
@@ -94,10 +94,10 @@ struct ImplementationDetail<T> {
 
 struct TestStructInit {
   // property wrapper backing initializer of number #1 in TestStructInit.init(number:message:)
-  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter14TestStructInitV6number7messageAcA7WrapperVySiG_SStcfcADL_SivpfP : $@convention(thin) (Int) -> Wrapper<Int>
+  // CHECK-LABEL: sil hidden [ossa] @$s26property_wrapper_parameter14TestStructInitV6number7messageAcA7WrapperVySiG_SStcfcADL_SivpfP : $@convention(thin) (Int) -> Wrapper<Int>
 
   // property wrapper init from projected value of number #1 in TestStructInit.init(number:message:)
-  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter14TestStructInitV6number7messageAcA7WrapperVySiG_SStcfcADL_SivpfW : $@convention(thin) (Projection<Int>) -> Wrapper<Int>
+  // CHECK-LABEL: sil hidden [ossa] @$s26property_wrapper_parameter14TestStructInitV6number7messageAcA7WrapperVySiG_SStcfcADL_SivpfW : $@convention(thin) (Projection<Int>) -> Wrapper<Int>
 
   // CHECK-LABEL: sil hidden [ossa] @$s26property_wrapper_parameter14TestStructInitV6number7messageAcA7WrapperVySiG_SStcfC : $@convention(method) (Wrapper<Int>, @owned String, @thin TestStructInit.Type) -> TestStructInit
   init(@Wrapper number: Int, @ImplementationDetail message: String) {
@@ -123,10 +123,10 @@ struct TestStructInit {
 
 class TestClassInit {
   // property wrapper backing initializer of number #1 in TestClassInit.init(number:message:)
-  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter13TestClassInitC6number7messageAcA7WrapperVySiG_SStcfcADL_SivpfP : $@convention(thin) (Int) -> Wrapper<Int>
+  // CHECK-LABEL: sil hidden [ossa] @$s26property_wrapper_parameter13TestClassInitC6number7messageAcA7WrapperVySiG_SStcfcADL_SivpfP : $@convention(thin) (Int) -> Wrapper<Int>
 
   // property wrapper init from projected value of number #1 in TestClassInit.init(number:message:)
-  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter13TestClassInitC6number7messageAcA7WrapperVySiG_SStcfcADL_SivpfW : $@convention(thin) (Projection<Int>) -> Wrapper<Int>
+  // CHECK-LABEL: sil hidden [ossa] @$s26property_wrapper_parameter13TestClassInitC6number7messageAcA7WrapperVySiG_SStcfcADL_SivpfW : $@convention(thin) (Projection<Int>) -> Wrapper<Int>
 
   // TestClassInit.__allocating_init(number:message:)
   // CHECK-LABEL: sil hidden [exact_self_class] [ossa] @$s26property_wrapper_parameter13TestClassInitC6number7messageAcA7WrapperVySiG_SStcfC : $@convention(method) (Wrapper<Int>, @owned String, @thick TestClassInit.Type) -> @owned TestClassInit
@@ -172,7 +172,7 @@ public struct AutoClosureWrapper<T> {
 }
 
 // property wrapper backing initializer of value #1 in testAutoClosureWrapper<A>(value:)
-// CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter22testAutoClosureWrapper5valueyAA0efG0VyxG_tlFACL_xvpfP : $@convention(thin) <T> (@noescape @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <T>) -> @out AutoClosureWrapper<T>
+// CHECK-LABEL: sil hidden [ossa] @$s26property_wrapper_parameter22testAutoClosureWrapper5valueyAA0efG0VyxG_tlFACL_xvpfP : $@convention(thin) <T> (@noescape @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <T>) -> @out AutoClosureWrapper<T>
 // CHECK: function_ref @$s26property_wrapper_parameter18AutoClosureWrapperV12wrappedValueACyxGxyXK_tcfC : $@convention(method) <τ_0_0> (@noescape @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <τ_0_0>, @thin AutoClosureWrapper<τ_0_0>.Type) -> @out AutoClosureWrapper<τ_0_0>
 
 // CHECK-LABEL: sil hidden [ossa] @$s26property_wrapper_parameter22testAutoClosureWrapper5valueyAA0efG0VyxG_tlF : $@convention(thin) <T> (@in_guaranteed AutoClosureWrapper<T>) -> ()
@@ -370,6 +370,26 @@ func genericContext<T>(_: T) where T: P {
   inner(b: 1)
 }
 
+struct HasPrivate {
+  // property wrapper backing initializer of x #1 in HasPrivate.testPrivateWrapper(x:)
+  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter10HasPrivateV04testE7Wrapper{{.*}}LL1xyAA0G0VySiG_tFAFL_SivpfP : $@convention(thin) (Int) -> Wrapper<Int>
+
+  // property wrapper init from projected value of x #1 in HasPrivate.testPrivateWrapper(x:)
+  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter10HasPrivateV04testE7Wrapper{{.*}}LL1xyAA0G0VySiG_tFAFL_SivpfW : $@convention(thin) (Projection<Int>) -> Wrapper<Int>
+
+  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter10HasPrivateV04testE7Wrapper{{.*}}LL1xyAA0G0VySiG_tF : $@convention(method) (Wrapper<Int>, HasPrivate) -> ()
+  private func testPrivateWrapper(@Wrapper x: Int) {}
+
+  // property wrapper backing initializer of x #1 in HasPrivate.testFilePrivateWrapper(x:)
+  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter10HasPrivateV08testFileE7Wrapper{{.*}}LL1xyAA0H0VySiG_tFAFL_SivpfP : $@convention(thin) (Int) -> Wrapper<Int>
+
+  // property wrapper init from projected value of x #1 in HasPrivate.testFilePrivateWrapper(x:)
+  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter10HasPrivateV08testFileE7Wrapper{{.*}}LL1xyAA0H0VySiG_tFAFL_SivpfW : $@convention(thin) (Projection<Int>) -> Wrapper<Int>
+
+  // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter10HasPrivateV08testFileE7Wrapper{{.*}}LL1xyAA0H0VySiG_tF : $@convention(method) (Wrapper<Int>, HasPrivate) -> ()
+  fileprivate func testFilePrivateWrapper(@Wrapper x: Int) {}
+}
+
 @propertyWrapper
 public struct PublicWrapper<T> {
   public var wrappedValue: T
@@ -411,6 +431,10 @@ public func publicFunc(@PublicWrapper value: String) {
   // CHECK: sil shared [serialized] [ossa] @$s26property_wrapper_parameter13inlinableFunc5valueyAA13PublicWrapperVySSG_tFySScfu_ : $@convention(thin) (@guaranteed String) -> ()
   // CHECK: function_ref @$s26property_wrapper_parameter10publicFunc5valueyAA13PublicWrapperVySSG_tFACL_SSvpfP : $@convention(thin) (@owned String) -> @owned PublicWrapper<String>
   // CHECK: function_ref @$s26property_wrapper_parameter10publicFunc5valueyAA13PublicWrapperVySSG_tF : $@convention(thin) (@guaranteed PublicWrapper<String>) -> ()
+
+  // property wrapper init from projected value of $x #1 in closure #1 in implicit closure #1 in inlinableFunc(value:)
+  // CHECK: sil shared [serialized] [ossa] @$s26property_wrapper_parameter13inlinableFunc5valueyAA13PublicWrapperVySSG_tFyAEySiGcfu0_yAGcfU_2$xL_AGvpfW : $@convention(thin) (PublicWrapper<Int>) -> PublicWrapper<Int>
+  let _: (PublicWrapper<Int>) -> Void = { $x in }
 }
 
 @propertyWrapper


### PR DESCRIPTION
Refactor the linkage computation for a SILDeclRef, and fix the linkage for external property wrapper backing initializers such that it depends on the access level of the function it's attached to.

rdar://100240367
Resolves #61233