### PR TITLE
[5.7][android] Update to LTS NDK 25b (#60938)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,8 +315,6 @@ set(SWIFT_ANDROID_API_LEVEL "" CACHE STRING
 
 set(SWIFT_ANDROID_NDK_PATH "" CACHE STRING
   "Path to the directory that contains the Android NDK tools that are executable on the build machine")
-set(SWIFT_ANDROID_NDK_CLANG_VERSION "12.0.8" CACHE STRING
-  "The Clang version to use when building for Android.")
 set(SWIFT_ANDROID_DEPLOY_DEVICE_PATH "" CACHE STRING
   "Path on an Android device where build products will be pushed. These are used when running the test suite against the device")
 

--- a/docs/Android.md
+++ b/docs/Android.md
@@ -33,7 +33,7 @@ To follow along with this guide, you'll need:
    Ubuntu 18.04 or Ubuntu 16.04. Before attempting to build for Android,
    please make sure you are able to build for Linux by following the
    instructions in the Swift project README.
-2. The latest version of the Android NDK (r23b at the time of this writing),
+3. The latest version of the Android LTS NDK (r25b at the time of this writing),
    available to download here:
    https://developer.android.com/ndk/downloads/index.html.
 3. An Android device with remote debugging enabled or the emulator. We require
@@ -49,7 +49,7 @@ Enter your Swift directory, then run the build script, passing the path to the
 Android NDK:
 
 ```
-$ NDK_PATH=path/to/android-ndk-r23b
+$ NDK_PATH=path/to/android-ndk-r25b
 $ utils/build-script \
     -R \                                       # Build in ReleaseAssert mode.
     --android \                                # Build for Android.
@@ -70,7 +70,7 @@ Then use the built Swift compiler from the previous step to compile a Swift
 source file, targeting Android:
 
 ```
-$ NDK_PATH="path/to/android-ndk-r23b"
+$ NDK_PATH="path/to/android-ndk-r25b"
 $ build/Ninja-ReleaseAssert/swift-linux-x86_64/bin/swiftc \          # The Swift compiler built in the previous step
                                                                      # The location of the tools used to build Android binaries
     -tools-directory ${NDK_PATH}/toolchains/llvm/prebuilt/linux-x86_64/bin/ \
@@ -116,7 +116,7 @@ $ adb push build/Ninja-ReleaseAssert/swift-linux-x86_64/lib/swift/android/libswi
 In addition, you'll also need to copy the Android NDK's libc++:
 
 ```
-$ adb push /path/to/android-ndk-r23b/sources/cxx-stl/llvm-libc++/libs/armeabi-v7a/libc++_shared.so /data/local/tmp
+$ adb push /path/to/android-ndk-r25b/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/arm-linux-androideabi/libc++_shared.so /data/local/tmp
 ```
 
 Finally, you'll need to copy the `hello` executable you built in the
@@ -159,7 +159,7 @@ $ utils/build-script \
   -R \                               # Build in ReleaseAssert mode.
   -T \                               # Run all tests, including on the Android device (add --host-test to only run Android tests on the linux host).
   --android \                        # Build for Android.
-  --android-ndk ~/android-ndk-r23b \  # Path to an Android NDK.
+  --android-ndk ~/android-ndk-r25b \  # Path to an Android NDK.
   --android-arch armv7 \             # Optionally specify Android architecture, alternately aarch64
   --android-api-level 21
 ```

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -457,7 +457,8 @@ function(_add_target_variant_link_flags)
     # We need to add the math library, which is linked implicitly by libc++
     list(APPEND result "-lm")
     if(NOT "${SWIFT_ANDROID_NDK_PATH}" STREQUAL "")
-      list(APPEND result "-resource-dir=${SWIFT_SDK_ANDROID_ARCH_${LFLAGS_ARCH}_PATH}/../lib64/clang/${SWIFT_ANDROID_NDK_CLANG_VERSION}")
+      file(GLOB RESOURCE_DIR ${SWIFT_SDK_ANDROID_ARCH_${LFLAGS_ARCH}_PATH}/../lib64/clang/*)
+      list(APPEND result "-resource-dir=${RESOURCE_DIR}")
     endif()
 
     # link against the custom C++ library


### PR DESCRIPTION
Cherrypick of 5.7-relevant portions of #60938 and single doc change from #61873

__Explanation:__ Make it so that the Swift build detects the clang shipping in the Android NDK, rather than having to manually update `SWIFT_ANDROID_NDK_CLANG_VERSION` every time, by extracting the versioned resource directory from the NDK using `file(GLOB)`.

__Scope:__ Only affects cross-compiling for Android with the NDK

__SR Issue:__ None

__Risk:__ Essentially none, since it only affects Android

__Testing:__ This patch got trunk compiling on the community Android CI again with the latest NDK 25b.

__Reviewer:__ @DougGregor

This pull will keep 5.7 patch releases compiling with future NDK releases, rather than having to [manually patch this repo with the new clang version each time](https://github.com/buttaface/swift-android-sdk/commit/e16bd2464fe944faee21b2f579b54006c0c531bc#diff-2d60757a966dd211063b699be169295db694f29a37d6dc72b0ff9146f57f3d4cR10). Since this pull is so low-risk, I thought it is worth getting in to 5.7.