### PR TITLE
Target all stdlib archs when building on Apple Silicon in CI

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -392,8 +392,6 @@ install-libcxx
 [preset: buildbot_incremental,tools=RA,stdlib=RA,apple_silicon]
 mixin-preset=buildbot_incremental,tools=RA,stdlib=RA
 
-swift-darwin-supported-archs=arm64
-
 [preset: buildbot_incremental,tools=RA,stdlib=RA,xcode]
 mixin-preset=buildbot_incremental,tools=RA,stdlib=RA
 build-subdir=buildbot_incremental_xcode


### PR DESCRIPTION
The underlying issue that required restricting to `arm64` has been fixed in #38415

Addresses rdar://77191256