### PR TITLE
[WebAssembly] Repair test/IRGen/wasm-absolute-func-ptr.swift

### DIFF
--- a/test/IRGen/wasm-absolute-func-ptr.swift
+++ b/test/IRGen/wasm-absolute-func-ptr.swift
@@ -2,5 +2,5 @@
 
 // REQUIRES: CODEGENERATOR=WebAssembly
 
-// CHECK: @"\01l_entry_point" = private constant { i32 } { i32 ptrtoint (i32 (i32, i8*)* @main to i32) }, section "swift5_entry", align 4
+// CHECK: @"\01l_entry_point" = private constant { i32{{.*}} { i32 ptrtoint (i32 (i32, i8*)* @main to i32){{.*}} }, section "swift5_entry", align 4
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Fix failing test for WebAssembly codegen.
This test has been broken since 71d993886ae8db3cd9edc3e12aff4e6aa3e6a379

https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-20.04-webassembly/868/

