### PR TITLE
Sema: Accept `if #_hasSymbol()` conditions in closure contexts

### DIFF
--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -398,6 +398,7 @@ public:
 class PoundHasSymbolInfo final : public ASTAllocated<PoundHasSymbolInfo> {
   Expr *SymbolExpr;
   ConcreteDeclRef ReferencedDecl;
+  bool Invalid;
 
   SourceLoc PoundLoc;
   SourceLoc LParenLoc;
@@ -405,7 +406,7 @@ class PoundHasSymbolInfo final : public ASTAllocated<PoundHasSymbolInfo> {
 
   PoundHasSymbolInfo(SourceLoc PoundLoc, SourceLoc LParenLoc, Expr *SymbolExpr,
                      SourceLoc RParenLoc)
-      : SymbolExpr(SymbolExpr), ReferencedDecl(), PoundLoc(PoundLoc),
+      : SymbolExpr(SymbolExpr), ReferencedDecl(), Invalid(), PoundLoc(PoundLoc),
         LParenLoc(LParenLoc), RParenLoc(RParenLoc){};
 
 public:
@@ -418,6 +419,10 @@ public:
 
   ConcreteDeclRef getReferencedDecl() { return ReferencedDecl; }
   void setReferencedDecl(ConcreteDeclRef CDR) { ReferencedDecl = CDR; }
+
+  /// Returns true if the referenced decl has been diagnosed as invalid.
+  bool isInvalid() const { return Invalid; }
+  void setInvalid() { Invalid = true; }
 
   SourceLoc getLParenLoc() const { return LParenLoc; }
   SourceLoc getRParenLoc() const { return RParenLoc; }

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1394,8 +1394,17 @@ public:
     for (auto &elt : C) {
       switch (elt.getKind()) {
       case StmtConditionElement::CK_Availability:
-      case StmtConditionElement::CK_HasSymbol:
         break;
+      case StmtConditionElement::CK_HasSymbol: {
+        auto E = elt.getHasSymbolInfo()->getSymbolExpr();
+        if (!E)
+          return true;
+        E = doIt(E);
+        if (!E)
+          return true;
+        elt.getHasSymbolInfo()->setSymbolExpr(E);
+        break;
+      }
       case StmtConditionElement::CK_Boolean: {
         auto E = elt.getBoolean();
         // Walk an expression condition normally.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8927,12 +8927,14 @@ ExprWalker::rewriteTarget(SolutionApplicationTarget target) {
 
       case StmtConditionElement::CK_HasSymbol: {
         ConstraintSystem &cs = solution.getConstraintSystem();
+        auto info = condElement.getHasSymbolInfo();
         auto target = *cs.getSolutionApplicationTarget(&condElement);
         auto resolvedTarget = rewriteTarget(target);
-        if (!resolvedTarget)
+        if (!resolvedTarget) {
+          info->setInvalid();
           return None;
+        }
 
-        auto info = condElement.getHasSymbolInfo();
         auto rewrittenExpr = resolvedTarget->getAsExpr();
         info->setSymbolExpr(rewrittenExpr);
         info->setReferencedDecl(

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4369,10 +4369,15 @@ bool ConstraintSystem::generateConstraints(StmtCondition condition,
       continue;
 
     case StmtConditionElement::CK_HasSymbol: {
-      ASTContext &ctx = getASTContext();
-      ctx.Diags.diagnose(condElement.getStartLoc(),
-                         diag::has_symbol_unsupported_in_closures);
-      return true;
+      Expr *symbolExpr = condElement.getHasSymbolInfo()->getSymbolExpr();
+      auto target = SolutionApplicationTarget(symbolExpr, dc, CTP_Unused,
+                                              Type(), /*isDiscarded=*/false);
+
+      if (generateConstraints(target, FreeTypeVariableBinding::Disallow))
+        return true;
+
+      setSolutionApplicationTarget(&condElement, target);
+      continue;
     }
 
     case StmtConditionElement::CK_Boolean: {

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -4319,6 +4319,9 @@ static void checkLabeledStmtConditions(ASTContext &ctx,
 
     case StmtConditionElement::CK_HasSymbol: {
       auto info = elt.getHasSymbolInfo();
+      if (info->isInvalid())
+        break;
+
       auto symbolExpr = info->getSymbolExpr();
       if (!symbolExpr)
         break;
@@ -4334,11 +4337,13 @@ static void checkLabeledStmtConditions(ASTContext &ctx,
           ctx.Diags.diagnose(symbolExpr->getLoc(),
                              diag::has_symbol_decl_must_be_weak,
                              decl->getDescriptiveKind(), decl->getName());
+          info->setInvalid();
         }
       } else {
         // Diagnose because we weren't able to interpret the expression as one
         // that uniquely identifies a single declaration.
         ctx.Diags.diagnose(symbolExpr->getLoc(), diag::has_symbol_invalid_expr);
+        info->setInvalid();
       }
       break;
     }

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -4302,6 +4302,50 @@ checkImplicitPromotionsInCondition(const StmtConditionElement &cond,
   }
 }
 
+/// Perform MiscDiagnostics for the conditions belonging to a \c
+/// LabeledConditionalStmt.
+static void checkLabeledStmtConditions(ASTContext &ctx,
+                                       const LabeledConditionalStmt *stmt,
+                                       DeclContext *DC) {
+  for (auto elt : stmt->getCond()) {
+    // Check for implicit optional promotions in stmt-condition patterns.
+    checkImplicitPromotionsInCondition(elt, ctx);
+
+    switch (elt.getKind()) {
+    case StmtConditionElement::CK_Boolean:
+    case StmtConditionElement::CK_PatternBinding:
+    case StmtConditionElement::CK_Availability:
+      break;
+
+    case StmtConditionElement::CK_HasSymbol: {
+      auto info = elt.getHasSymbolInfo();
+      auto symbolExpr = info->getSymbolExpr();
+      if (!symbolExpr)
+        break;
+
+      if (!symbolExpr->getType())
+        break;
+
+      if (auto decl = info->getReferencedDecl().getDecl()) {
+        // `if #_hasSymbol(someStronglyLinkedSymbol)` is functionally a no-op
+        // and may indicate the developer has mis-identified the declaration
+        // they want to check (or forgot to import the module weakly).
+        if (!decl->isWeakImported(DC->getParentModule())) {
+          ctx.Diags.diagnose(symbolExpr->getLoc(),
+                             diag::has_symbol_decl_must_be_weak,
+                             decl->getDescriptiveKind(), decl->getName());
+        }
+      } else {
+        // Diagnose because we weren't able to interpret the expression as one
+        // that uniquely identifies a single declaration.
+        ctx.Diags.diagnose(symbolExpr->getLoc(), diag::has_symbol_invalid_expr);
+      }
+      break;
+    }
+    }
+  }
+}
+
 static void diagnoseUnintendedOptionalBehavior(const Expr *E,
                                                const DeclContext *DC) {
   if (!E || isa<ErrorExpr>(E) || !E->getType())
@@ -5290,11 +5334,9 @@ void swift::performStmtDiagnostics(const Stmt *S, DeclContext *DC) {
     checkSwitch(ctx, switchStmt, DC);
 
   checkStmtConditionTrailingClosure(ctx, S);
-  
-  // Check for implicit optional promotions in stmt-condition patterns.
+
   if (auto *lcs = dyn_cast<LabeledConditionalStmt>(S))
-    for (const auto &elt : lcs->getCond())
-      checkImplicitPromotionsInCondition(elt, ctx);
+    checkLabeledStmtConditions(ctx, lcs, DC);
 
   if (!ctx.LangOpts.DisableAvailabilityChecking)
     diagnoseStmtAvailability(S, const_cast<DeclContext*>(DC));

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -448,8 +448,7 @@ static Expr *getDeclRefProvidingExpressionForHasSymbol(Expr *E) {
   return E;
 }
 
-static ConcreteDeclRef
-getReferencedDeclForHasSymbolCondition(ASTContext &Context, Expr *E) {
+ConcreteDeclRef TypeChecker::getReferencedDeclForHasSymbolCondition(Expr *E) {
   // Match DotSelfExprs (e.g. `SomeStruct.self`) when the type is static.
   if (auto DSE = dyn_cast<DotSelfExpr>(E)) {
     if (DSE->isStaticallyDerivedMetatype())
@@ -461,7 +460,6 @@ getReferencedDeclForHasSymbolCondition(ASTContext &Context, Expr *E) {
       return CDR;
   }
 
-  Context.Diags.diagnose(E->getLoc(), diag::has_symbol_invalid_expr);
   return ConcreteDeclRef();
 }
 
@@ -506,20 +504,10 @@ bool TypeChecker::typeCheckStmtConditionElement(StmtConditionElement &elt,
     auto exprTy = TypeChecker::typeCheckExpression(E, dc);
     Info->setSymbolExpr(E);
 
-    if (!exprTy)
-      return true;
+    if (exprTy)
+      Info->setReferencedDecl(getReferencedDeclForHasSymbolCondition(E));
 
-    auto CDR = getReferencedDeclForHasSymbolCondition(Context, E);
-    if (!CDR)
-      return true;
-
-    auto decl = CDR.getDecl();
-    if (!decl->isWeakImported(dc->getParentModule())) {
-      Context.Diags.diagnose(E->getLoc(), diag::has_symbol_decl_must_be_weak,
-                             decl->getDescriptiveKind(), decl->getName());
-    }
-    Info->setReferencedDecl(CDR);
-    return false;
+    return !exprTy;
   }
 
   if (auto E = elt.getBooleanOrNull()) {

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -504,10 +504,13 @@ bool TypeChecker::typeCheckStmtConditionElement(StmtConditionElement &elt,
     auto exprTy = TypeChecker::typeCheckExpression(E, dc);
     Info->setSymbolExpr(E);
 
-    if (exprTy)
-      Info->setReferencedDecl(getReferencedDeclForHasSymbolCondition(E));
+    if (!exprTy) {
+      Info->setInvalid();
+      return true;
+    }
 
-    return !exprTy;
+    Info->setReferencedDecl(getReferencedDeclForHasSymbolCondition(E));
+    return false;
   }
 
   if (auto E = elt.getBooleanOrNull()) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -441,6 +441,10 @@ Expr *substituteInputSugarTypeForResult(ApplyExpr *E);
 bool typeCheckStmtConditionElement(StmtConditionElement &elt, bool &isFalsable,
                                    DeclContext *dc);
 
+/// Returns the unique decl ref identified by the expr according to the
+/// requirements of the \c #_hasSymbol() condition type.
+ConcreteDeclRef getReferencedDeclForHasSymbolCondition(Expr *E);
+
 void typeCheckASTNode(ASTNode &node, DeclContext *DC,
                       bool LeaveBodyUnchecked = false);
 

--- a/test/Sema/has_symbol.swift
+++ b/test/Sema/has_symbol.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/has_symbol_helper.swiftmodule -parse-as-library %S/Inputs/has_symbol_helper.swift -enable-library-evolution
 // RUN: %target-typecheck-verify-swift -disable-availability-checking -I %t
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -I %t -enable-experimental-feature ResultBuilderASTTransform
 
 // UNSUPPORTED: OS=windows-msvc
 
@@ -159,6 +160,11 @@ struct MyView {
     
   @ViewBuilder var localFuncView: some View {
     if #_hasSymbol(localFunc) { image } // expected-warning {{global function 'localFunc()' is not a weakly linked declaration}}
+    else { image }
+  }
+
+  @ViewBuilder var noArgFuncView: some View {
+    if #_hasSymbol(noArgFunc()) { image } // expected-error {{#_hasSymbol condition must refer to a declaration}}
     else { image }
   }
 }


### PR DESCRIPTION
This is a follow up to https://github.com/apple/swift/pull/61148 that adds support for `if #_hasSymbol()` in closure contexts.

Resolves rdar://100129165