### PR TITLE
[interop][SwiftToCxx] add -enable-experimental-cxx-interop-in-clang-h…

### DIFF
--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -392,6 +392,10 @@ public:
   /// header.
   bool ExposePublicDeclsInClangHeader = false;
 
+  /// Emit C++ bindings for the exposed Swift declarations in the generated
+  /// clang header.
+  bool EnableExperimentalCxxInteropInClangHeader = false;
+
   /// \return true if the given action only parses without doing other compilation steps.
   static bool shouldActionOnlyParse(ActionType);
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -630,6 +630,11 @@ def enable_experimental_cxx_interop :
   Flags<[FrontendOption, HelpHidden, ModuleInterfaceOption]>,
   HelpText<"Enable experimental C++ interop code generation and config directives">;
 
+def enable_experimental_cxx_interop_in_clang_header :
+  Flag<["-"], "enable-experimental-cxx-interop-in-clang-header">,
+  Flags<[FrontendOption, NoDriverOption, HelpHidden]>,
+  HelpText<"Enable experimental Swift to C++ interop code generation in generated Clang header">;
+
 def experimental_cxx_stdlib :
   Separate<["-"], "experimental-cxx-stdlib">,
   Flags<[HelpHidden]>,

--- a/include/swift/PrintAsClang/PrintAsClang.h
+++ b/include/swift/PrintAsClang/PrintAsClang.h
@@ -18,6 +18,7 @@
 #include "swift/AST/Identifier.h"
 
 namespace swift {
+class FrontendOptions;
 class IRGenOptions;
 class ModuleDecl;
 class ValueDecl;
@@ -34,7 +35,7 @@ class ValueDecl;
 /// Returns true on error.
 bool printAsClangHeader(raw_ostream &out, ModuleDecl *M,
                         StringRef bridgingHeader,
-                        bool ExposePublicDeclsInClangHeader,
+                        const FrontendOptions &frontendOpts,
                         const IRGenOptions &irGenOpts);
 }
 

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -286,6 +286,8 @@ bool ArgsToFrontendOptionsConverter::convert(
   Opts.DisableBuildingInterface = Args.hasArg(OPT_disable_building_interface);
   Opts.ExposePublicDeclsInClangHeader =
       Args.hasArg(OPT_clang_header_expose_public_decls);
+  Opts.EnableExperimentalCxxInteropInClangHeader =
+      Args.hasArg(OPT_enable_experimental_cxx_interop_in_clang_header);
 
   computeImportObjCHeaderOptions();
   computeImplicitImportModuleNames(OPT_import_module, /*isTestable=*/false);

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -181,15 +181,15 @@ static bool writeSIL(SILModule &SM, const PrimarySpecificPaths &PSPs,
 /// \see swift::printAsClangHeader
 static bool printAsClangHeaderIfNeeded(StringRef outputPath, ModuleDecl *M,
                                        StringRef bridgingHeader,
-                                       bool ExposePublicDeclsInClangHeader,
+                                       const FrontendOptions &frontendOpts,
                                        const IRGenOptions &irGenOpts) {
   if (outputPath.empty())
     return false;
-  return withOutputFile(
-      M->getDiags(), outputPath, [&](raw_ostream &out) -> bool {
-        return printAsClangHeader(out, M, bridgingHeader,
-                                  ExposePublicDeclsInClangHeader, irGenOpts);
-      });
+  return withOutputFile(M->getDiags(), outputPath,
+                        [&](raw_ostream &out) -> bool {
+                          return printAsClangHeader(out, M, bridgingHeader,
+                                                    frontendOpts, irGenOpts);
+                        });
 }
 
 /// Prints the stable module interface for \p M to \p outputPath.
@@ -936,8 +936,8 @@ static bool emitAnyWholeModulePostTypeCheckSupplementaryOutputs(
     }
     hadAnyError |= printAsClangHeaderIfNeeded(
         Invocation.getClangHeaderOutputPathForAtMostOnePrimary(),
-        Instance.getMainModule(), BridgingHeaderPathForPrint,
-        opts.ExposePublicDeclsInClangHeader, Invocation.getIRGenOptions());
+        Instance.getMainModule(), BridgingHeaderPathForPrint, opts,
+        Invocation.getIRGenOptions());
   }
 
   // Only want the header if there's been any errors, ie. there's not much

--- a/test/Interop/SwiftToCxx/expose-attr/expose-swift-decls-to-cxx.swift
+++ b/test/Interop/SwiftToCxx/expose-attr/expose-swift-decls-to-cxx.swift
@@ -4,6 +4,9 @@
 
 // RUN: %check-interop-cxx-header-in-clang(%t/expose.h -Wno-error=unused-function)
 
+// RUN: %target-swift-frontend %s -typecheck -module-name Expose -enable-experimental-cxx-interop-in-clang-header -emit-clang-header-path %t/expose.h
+// RUN: %FileCheck %s < %t/expose.h
+
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -emit-module -module-name Expose -o %t
 // RUN: %target-swift-frontend -parse-as-library %t/Expose.swiftmodule -typecheck -module-name Expose -enable-experimental-cxx-interop -emit-clang-header-path %t/expose.h


### PR DESCRIPTION
…eader flag that lets you enable reverse interop only
