### PR TITLE
Install both compiler-rt and new built-ins/runtimes components.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -19,7 +19,7 @@ swift-install-components=back-deployment;compiler;clang-builtin-headers;stdlib;s
 [preset: mixin_buildbot_install_components_with_clang]
 
 swift-install-components=autolink-driver;back-deployment;compiler;clang-resource-dir-symlink;stdlib;sdk-overlay;parser-lib;static-mirror-lib;toolchain-tools;license;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers
-llvm-install-components=llvm-cov;llvm-profdata;IndexStore;clang;clang-resource-headers;compiler-rt;clangd;dsymutil;LTO;clang-features-file
+llvm-install-components=llvm-cov;llvm-profdata;IndexStore;clang;clang-resource-headers;compiler-rt;builtins;runtimes;clangd;dsymutil;LTO;clang-features-file
 
 [preset: mixin_buildbot_trunk_base]
 # Build standard library and SDK overlay for iOS device and simulator.
@@ -802,7 +802,7 @@ no-swift-stdlib-assertions
 [preset: mixin_linux_install_components_with_clang]
 
 swift-install-components=autolink-driver;compiler;clang-resource-dir-symlink;stdlib;swift-remote-mirror;sdk-overlay;parser-lib;static-mirror-lib;toolchain-tools;license;sourcekit-inproc
-llvm-install-components=llvm-cov;llvm-profdata;IndexStore;clang;clang-resource-headers;compiler-rt;clangd;lld;LTO;clang-features-file
+llvm-install-components=llvm-cov;llvm-profdata;IndexStore;clang;clang-resource-headers;compiler-rt;builtins;runtimes;clangd;lld;LTO;clang-features-file
 
 [preset: mixin_linux_installation]
 mixin-preset=
@@ -2631,7 +2631,7 @@ darwin-toolchain-display-name-short=Swift Development Snapshot
 darwin-toolchain-display-name=Swift Development Snapshot
 darwin-toolchain-name=swift-DEVELOPMENT-SNAPSHOT
 darwin-toolchain-version=3.999.999
-llvm-install-components=clang;clang-resource-headers;compiler-rt;libclang;libclang-headers;dsymutil;clang-features-file
+llvm-install-components=clang;clang-resource-headers;compiler-rt;builtins;runtimes;libclang;libclang-headers;dsymutil;clang-features-file
 swift-install-components=back-deployment;compiler;clang-builtin-headers;stdlib;sdk-overlay;license;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers
 symbols-package=%(symbols_package)s
 install-symroot=%(install_symroot)s


### PR DESCRIPTION
This would ease the transition to adopt LLVM runtimes in build-script.