### PR TITLE
Work Around _swiftStaticArrayMetadata Alias Breakage

### DIFF
--- a/lib/IRGen/GenConstant.cpp
+++ b/lib/IRGen/GenConstant.cpp
@@ -288,9 +288,11 @@ llvm::Constant *irgen::emitConstantObject(IRGenModule &IGM, ObjectInst *OI,
       IGM.swiftImmortalRefCount = var;
     }
     if (!IGM.swiftStaticArrayMetadata) {
+      // HACK: This should be an alias to this symbol rather than a direct
+      // reference.
       auto *var = new llvm::GlobalVariable(IGM.Module, IGM.TypeMetadataStructTy,
                                         /*constant*/ true, llvm::GlobalValue::ExternalLinkage,
-                                        /*initializer*/ nullptr, "_swiftStaticArrayMetadata");
+                                        /*initializer*/ nullptr, "$ss19__EmptyArrayStorageCN");
       IGM.swiftStaticArrayMetadata = var;
     }
     elts[0] = llvm::ConstantStruct::get(ObjectHeaderTy, {

--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -85,12 +85,6 @@ __asm__("  .globl __swiftImmortalRefCount\n");
   #error("unsupported pointer width")
 #endif
 
-// Static arrays can only contain trivial elements. Therefore we can reuse
-// the metadata of the empty array buffer. The important thing is that its
-// deinit is a no-op and does not actually destroy any elements.
-__asm__("  .globl __swiftStaticArrayMetadata\n");
-__asm__(".set __swiftStaticArrayMetadata, _$ss19__EmptyArrayStorageCN\n");
-
 #endif
 
 SWIFT_RUNTIME_STDLIB_API


### PR DESCRIPTION
The alias defined here with the `.set` directive doesn't actually define a symbolic alias that the linker respects in all cases. The resulting standard library dylib _does_ contain a reference to the aliased symbol with the correct value, but the resulting symbol is not actually considered relocatable by the linker. Thus, its value may not always get fixed up properly.

Work around this by dropping the alias for now - directly use the type metadata for Swift.__EmptyArrayStorage instead.

rdar://100288247