### PR TITLE
[CMake with Swift] Add toolchain lib path for stage != 0 bootstrapping builds

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -579,7 +579,12 @@ function(_add_swift_runtime_link_flags target relpath_to_lib_dir bootstrapping)
           target_link_directories(${target} PRIVATE "${sdk_dir}")
 
           # Include the abi stable system stdlib in our rpath.
-         set(swift_runtime_rpath "/usr/lib/swift")
+          set(swift_runtime_rpath "/usr/lib/swift")
+
+          # Add in the toolchain directory so we can grab compatibility libraries
+          get_filename_component(TOOLCHAIN_BIN_DIR ${SWIFT_EXEC_FOR_SWIFT_MODULES} DIRECTORY)
+          get_filename_component(TOOLCHAIN_LIB_DIR "${TOOLCHAIN_BIN_DIR}/../lib/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}" ABSOLUTE)
+          target_link_directories(${target} PUBLIC ${TOOLCHAIN_LIB_DIR})
         endif()
       endif()
     endif()

--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -167,7 +167,12 @@ function(add_sourcekit_swift_runtime_link_flags target path HAS_SWIFT_MODULES)
           target_link_directories(${target} PRIVATE "${sdk_dir}")
 
           # Include the abi stable system stdlib in our rpath.
-         set(swift_runtime_rpath "/usr/lib/swift")
+          set(swift_runtime_rpath "/usr/lib/swift")
+
+          # Add in the toolchain directory so we can grab compatibility libraries
+          get_filename_component(TOOLCHAIN_BIN_DIR ${SWIFT_EXEC_FOR_SWIFT_MODULES} DIRECTORY)
+          get_filename_component(TOOLCHAIN_LIB_DIR "${TOOLCHAIN_BIN_DIR}/../lib/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}" ABSOLUTE)
+          target_link_directories(${target} PUBLIC ${TOOLCHAIN_LIB_DIR})
         endif()
       endif()
     endif()


### PR DESCRIPTION
Fixes a linker failure where we cannot find the compatibility libraries.
