### PR TITLE
[SILGen] Avoid delaying functions with user-written code

### DIFF
--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -556,6 +556,12 @@ struct SILDeclRef {
 
   bool isImplicit() const;
 
+  /// Whether the referenced function contains user code. This is generally true
+  /// for a non-implicit decls, but may also be true for implicit decls if
+  /// explicitly written code has been spliced into the body. This is the case
+  /// for e.g a lazy variable getter.
+  bool hasUserWrittenCode() const;
+
   /// Return the scope in which the parent class of a method (i.e. class
   /// containing this declaration) can be subclassed, returning NotApplicable if
   /// this is not a method, there is no such class, or the class cannot be

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1186,7 +1186,7 @@ static void emitOrDelayFunction(SILGenModule &SGM,
   // Implicit decls may be delayed if they can't be used externally.
   auto linkage = constant.getLinkage(ForDefinition);
   bool mayDelay = !forceEmission &&
-             (constant.isImplicit() &&
+             (!constant.hasUserWrittenCode() &&
               !constant.isDynamicallyReplaceable() &&
               !isPossiblyUsedExternally(linkage, SGM.M.isWholeModule()));
 

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -714,7 +714,9 @@ Expr *swift::buildPropertyWrapperInitCall(
   ApplyExpr *innermostInit = nullptr;
 
   // Projected-value initializers don't compose, so no need to iterate
-  // over the wrapper attributes.
+  // over the wrapper attributes. NOTE: If this ever changes, you'll need to
+  // update SILDeclRef::hasUserWrittenCode to account for any spliced in
+  // user-written code.
   if (initKind == PropertyWrapperInitKind::ProjectedValue) {
     auto typeExpr = TypeExpr::createImplicit(backingStorageType, ctx);
     auto *argList = ArgumentList::forImplicitSingle(ctx, ctx.Id_projectedValue,

--- a/test/SILGen/delayed_functions.swift
+++ b/test/SILGen/delayed_functions.swift
@@ -1,0 +1,125 @@
+// RUN: %target-swift-emit-silgen -primary-file %s | %FileCheck %s --check-prefix=SINGLE
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s --check-prefix=WHOLEMOD
+// RUN: %target-swift-emit-sil -verify -primary-file %s
+
+// https://github.com/apple/swift/issues/61128
+// Ensure we only delay emission of functions that do not contain user code.
+
+// We cannot delay functions that contain user code.
+// SINGLE-LABEL: sil hidden [ossa] @$s17delayed_functions3fooSiyF : $@convention(thin) () -> Int
+// WHOLEMOD-LABEL: sil hidden [ossa] @$s17delayed_functions3fooSiyF : $@convention(thin) () -> Int
+func foo() -> Int { 5 }
+
+// Cannot delay property intializers that contain user code.
+struct R {
+  // variable initialization expression of R.i
+  // SINGLE-LABEL: sil hidden [transparent] [ossa] @$s17delayed_functions1RV1iSivpfi : $@convention(thin) () -> Int
+  // WHOLEMOD-LABEL: sil hidden [transparent] [ossa] @$s17delayed_functions1RV1iSivpfi : $@convention(thin) () -> Int
+  var i = 0
+
+  // R.j.getter
+  // SINGLE-LABEL: sil hidden [lazy_getter] [noinline] [ossa] @$s17delayed_functions1RV1jSivg : $@convention(method) (@inout R) -> Int
+  // WHOLEMOD-LABEL: sil hidden [lazy_getter] [noinline] [ossa] @$s17delayed_functions1RV1jSivg : $@convention(method) (@inout R) -> Int
+  lazy var j = Int.max + 1 // expected-error {{results in an overflow}}
+}
+
+@propertyWrapper
+struct Wrapper<T> {
+  var wrappedValue: T
+  init(wrappedValue: T) {
+    self.wrappedValue = wrappedValue
+  }
+  init(wrappedValue: T, _ x: Int) {
+    self.wrappedValue = wrappedValue
+  }
+}
+
+struct Projected<T> {
+  var value: T
+}
+@propertyWrapper
+struct ProjectedWrapper<T> {
+  var wrappedValue: T
+  init(wrappedValue: T) {
+    self.wrappedValue = wrappedValue
+  }
+  var projectedValue: Projected<T> {
+    .init(value: wrappedValue)
+  }
+  init(projectedValue: Projected<T>) {
+    self.wrappedValue = projectedValue.value
+  }
+}
+
+struct S {
+  // We can delay property wrapper backing initializers if they don't contain user code.
+  // property wrapper backing initializer of S.i
+  // SINGLE-LABEL: sil hidden [ossa] @$s17delayed_functions1SV1iSivpfP : $@convention(thin) (Int) -> Wrapper<Int>
+  // WHOLEMOD-NOT: sil hidden [ossa] @$s17delayed_functions1SV1iSivpfP : $@convention(thin) (Int) -> Wrapper<Int>
+  @Wrapper var i: Int
+
+  // But not if they contain user code.
+  // property wrapper backing initializer of S.j
+  // SINGLE-LABEL: sil hidden [ossa] @$s17delayed_functions1SV1jSSvpfP : $@convention(thin) (@owned String) -> @owned Wrapper<String>
+  // WHOLEMOD-LABEL: sil hidden [ossa] @$s17delayed_functions1SV1jSSvpfP : $@convention(thin) (@owned String) -> @owned Wrapper<String>
+
+  // variable initialization expression of S._j
+  // SINGLE-LABEL: sil hidden [transparent] [ossa] @$s17delayed_functions1SV2_j33_6D0D158845E4BE9792202A0D16664A88LLAA7WrapperVySSGvpfi : $@convention(thin) () -> @owned String
+  // WHOLEMOD-LABEL: sil hidden [transparent] [ossa] @$s17delayed_functions1SV2_j33_6D0D158845E4BE9792202A0D16664A88LLAA7WrapperVySSGvpfi : $@convention(thin) () -> @owned String
+  @Wrapper(5) var j = ""
+
+  // variable initialization expression of S._k
+  // SINGLE-LABEL: sil hidden [transparent] [ossa] @$s17delayed_functions1SV2_k33_6D0D158845E4BE9792202A0D16664A88LLAA7WrapperVySiGvpfi : $@convention(thin) () -> Int
+  // WHOLEMOD-LABEL: sil hidden [transparent] [ossa] @$s17delayed_functions1SV2_k33_6D0D158845E4BE9792202A0D16664A88LLAA7WrapperVySiGvpfi : $@convention(thin) () -> Int
+  @Wrapper var k = Int.max + 1 // expected-error 2{{results in an overflow}}
+
+  // property wrapper backing initializer of S.l
+  // SINGLE-LABEL: sil hidden [ossa] @$s17delayed_functions1SV1lSSvpfP : $@convention(thin) (@owned String) -> @owned Wrapper<Wrapper<String>>
+  // WHOLEMOD-LABEL: sil hidden [ossa] @$s17delayed_functions1SV1lSSvpfP : $@convention(thin) (@owned String) -> @owned Wrapper<Wrapper<String>>
+
+  // variable initialization expression of S._l
+  // SINGLE-LABEL: sil hidden [transparent] [ossa] @$s17delayed_functions1SV2_l33_6D0D158845E4BE9792202A0D16664A88LLAA7WrapperVyAGySSGGvpfi : $@convention(thin) () -> @owned String
+  // WHOLEMOD-LABEL: sil hidden [transparent] [ossa] @$s17delayed_functions1SV2_l33_6D0D158845E4BE9792202A0D16664A88LLAA7WrapperVyAGySSGGvpfi : $@convention(thin) () -> @owned String
+  @Wrapper
+  @Wrapper(.random() ? 1 : 2)
+  var l = ""
+}
+
+// The backing init for a projected wrapper can be delayed.
+// property wrapper init from projected value of x #1 in takesProjected(_:)
+// SINGLE-LABEL: sil hidden [ossa] @$s17delayed_functions14takesProjectedyyAA0D7WrapperVySiGF1xL_SivpfW : $@convention(thin) (Projected<Int>) -> ProjectedWrapper<Int>
+// WHOLEMOD-NOT: sil hidden [ossa] @$s17delayed_functions14takesProjectedyyAA0D7WrapperVySiGF1xL_SivpfW : $@convention(thin) (Projected<Int>) -> ProjectedWrapper<Int>
+func takesProjected(@ProjectedWrapper _ x: Int) {}
+
+struct HasPrivate {
+  // These backing initializers can be dropped entirely as they're private and
+  // unused.
+
+  // property wrapper backing initializer of x #1 in HasPrivate.testPrivateWrapper(x:)
+  // SINGLE-NOT: sil private [ossa] @$s17delayed_functions10HasPrivateV04testD7Wrapper{{.*}}LL1xyAA09ProjectedF0VySiG_tFAFL_SivpfP : $@convention(thin) (Int) -> ProjectedWrapper<Int>
+  // WHOLEMOD-NOT: sil private [ossa] @$s17delayed_functions10HasPrivateV04testD7Wrapper{{.*}}LL1xyAA09ProjectedF0VySiG_tFAFL_SivpfP : $@convention(thin) (Int) -> ProjectedWrapper<Int>
+
+  // property wrapper init from projected value of x #1 in HasPrivate.testPrivateWrapper(x:)
+  // SINGLE-NOT: sil private [ossa] @$s17delayed_functions10HasPrivateV04testD7Wrapper{{.*}}LL1xyAA09ProjectedF0VySiG_tFAFL_SivpfW : $@convention(thin) (Projected<Int>) -> ProjectedWrapper<Int>
+  // WHOLEMOD-NOT: sil private [ossa] @$s17delayed_functions10HasPrivateV04testD7Wrapper{{.*}}LL1xyAA09ProjectedF0VySiG_tFAFL_SivpfW : $@convention(thin) (Projected<Int>) -> ProjectedWrapper<Int>
+
+  // The function itself needs to be emitted because it can contain user code.
+  // HasPrivate.testPrivateWrapper(x:)
+  // SINGLE: sil private [ossa] @$s17delayed_functions10HasPrivateV04testD7Wrapper{{.*}}LL1xyAA09ProjectedF0VySiG_tF : $@convention(method) (ProjectedWrapper<Int>, HasPrivate) -> ()
+  // WHOLEMOD: sil private [ossa] @$s17delayed_functions10HasPrivateV04testD7Wrapper{{.*}}LL1xyAA09ProjectedF0VySiG_tF : $@convention(method) (ProjectedWrapper<Int>, HasPrivate) -> ()
+  private func testPrivateWrapper(@ProjectedWrapper x: Int) {}
+
+  // property wrapper backing initializer of x #1 in HasPrivate.testFilePrivateWrapper(x:)
+  // SINGLE-NOT: sil private [ossa] @$s17delayed_functions10HasPrivateV08testFileD7Wrapper{{.*}}LL1xyAA09ProjectedG0VySiG_tFAFL_SivpfP : $@convention(thin) (Int) -> ProjectedWrapper<Int>
+  // WHOLEMOD-NOT: sil private [ossa] @$s17delayed_functions10HasPrivateV08testFileD7Wrapper{{.*}}LL1xyAA09ProjectedG0VySiG_tFAFL_SivpfP : $@convention(thin) (Int) -> ProjectedWrapper<Int>
+
+  // property wrapper init from projected value of x #1 in HasPrivate.testFilePrivateWrapper(x:)
+  // SINGLE-NOT: sil private [ossa] @$s17delayed_functions10HasPrivateV08testFileD7Wrapper{{.*}}LL1xyAA09ProjectedG0VySiG_tFAFL_SivpfW : $@convention(thin) (Projected<Int>) -> ProjectedWrapper<Int>
+  // WHOLEMOD-NOT: sil private [ossa] @$s17delayed_functions10HasPrivateV08testFileD7Wrapper{{.*}}LL1xyAA09ProjectedG0VySiG_tFAFL_SivpfW : $@convention(thin) (Projected<Int>) -> ProjectedWrapper<Int>
+
+  // The function itself needs to be emitted because it can contain user code.
+  // HasPrivate.testFilePrivateWrapper(x:)
+  // SINGLE: sil private [ossa] @$s17delayed_functions10HasPrivateV08testFileD7Wrapper{{.*}}LL1xyAA09ProjectedG0VySiG_tF : $@convention(method) (ProjectedWrapper<Int>, HasPrivate) -> ()
+  // WHOLEMOD: sil private [ossa] @$s17delayed_functions10HasPrivateV08testFileD7Wrapper{{.*}}LL1xyAA09ProjectedG0VySiG_tF : $@convention(method) (ProjectedWrapper<Int>, HasPrivate) -> ()
+  fileprivate func testFilePrivateWrapper(@ProjectedWrapper x: Int) {}
+}

--- a/test/SILGen/property_wrapper_parameter.swift
+++ b/test/SILGen/property_wrapper_parameter.swift
@@ -1,6 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t -enable-library-evolution %S/Inputs/def_structA.swift
-// RUN: %target-swift-emit-silgen %s -I %t | %FileCheck %s
+
+// This uses '-primary-file' to ensure we're conservative with lazy SIL emission.
+// RUN: %target-swift-emit-silgen -primary-file %s -I %t | %FileCheck %s
+
 import def_structA
 
 public struct Projection<T> {
@@ -388,6 +391,15 @@ struct HasPrivate {
 
   // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter10HasPrivateV08testFileE7Wrapper{{.*}}LL1xyAA0H0VySiG_tF : $@convention(method) (Wrapper<Int>, HasPrivate) -> ()
   fileprivate func testFilePrivateWrapper(@Wrapper x: Int) {}
+
+  func usesWrapperFunctions() {
+    // These are needed to ensure we emit the backing initializers. Otherwise
+    // lazy SILGen emission is happy to drop them.
+    testPrivateWrapper(x: 0)
+    testPrivateWrapper($x: Projection(wrappedValue: 0))
+    testFilePrivateWrapper(x: 0)
+    testFilePrivateWrapper($x: Projection(wrappedValue: 0))
+  }
 }
 
 @propertyWrapper


### PR DESCRIPTION
Previously we would delay the emission of lazy variable getters and stored property initializers for property wrapper backing storage. This could lead to their definitions being dropped if unused, meaning that we wouldn't run the mandatory diagnostics passes over them.

Fix the logic such that we consider such cases as having user-written code, and account for a couple of cases where we can delay emission where we didn't previously. There are more cases we can consider as not having "user-written code" here, but I'm leaving that as future work for now, as `emitOrDelayFunction` is currently only used for a handful of SILDeclRef kinds.

This is a source breaking change, but only for invalid (albeit unused) code.

rdar://99962285
Resolves #61128