### PR TITLE
Clear up stale values for swift-darwin-supported-archs from CMake caches

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -393,6 +393,12 @@ def apply_default_arguments(toolchain, args):
             if (target.platform.is_darwin and
                 target.arch in supported_archs)
         ]
+    else:
+        # Clear the value explicitly from CMakeCache.txt
+        # to avoid picking up a stale value that can cause
+        # build failures
+        args.extra_cmake_options.append(
+            '-USWIFT_DARWIN_SUPPORTED_ARCHS')
 
     # Filter out any macOS stdlib deployment targets that are not supported
     # by the macOS SDK.


### PR DESCRIPTION
This will prevent weird build failures when a run was made with the argument set.