### PR TITLE
fix the readonly_arrays.swift test

### DIFF
--- a/lib/IRGen/GenConstant.cpp
+++ b/lib/IRGen/GenConstant.cpp
@@ -288,8 +288,10 @@ llvm::Constant *irgen::emitConstantObject(IRGenModule &IGM, ObjectInst *OI,
       IGM.swiftImmortalRefCount = var;
     }
     if (!IGM.swiftStaticArrayMetadata) {
-      // HACK: This should be an alias to this symbol rather than a direct
-      // reference.
+
+      // Static arrays can only contain trivial elements. Therefore we can reuse
+      // the metadata of the empty array buffer. The important thing is that its
+      // deinit is a no-op and does not actually destroy any elements.
       auto *var = new llvm::GlobalVariable(IGM.Module, IGM.TypeMetadataStructTy,
                                         /*constant*/ true, llvm::GlobalValue::ExternalLinkage,
                                         /*initializer*/ nullptr, "$ss19__EmptyArrayStorageCN");

--- a/test/SILOptimizer/readonly_arrays.swift
+++ b/test/SILOptimizer/readonly_arrays.swift
@@ -9,12 +9,12 @@
 
 // Check if the optimizer is able to convert array literals to constant statically initialized arrays.
 
-// CHECK: @"$s4test11arrayLookupyS2iFTv_r" = {{.*}} constant {{.*}} @_swiftStaticArrayMetadata, {{.*}} @_swiftImmortalRefCount
-// CHECK: @"$s4test11returnArraySaySiGyFTv_r" = {{.*}} constant {{.*}} @_swiftStaticArrayMetadata, {{.*}} @_swiftImmortalRefCount
-// CHECK: @"$s4test9passArrayyyFTv_r" = {{.*}} constant {{.*}} @_swiftStaticArrayMetadata, {{.*}} @_swiftImmortalRefCount
-// CHECK: @"$s4test9passArrayyyFTv0_r" = {{.*}} constant {{.*}} @_swiftStaticArrayMetadata, {{.*}} @_swiftImmortalRefCount
-// CHECK: @"$s4test10storeArrayyyFTv_r" = {{.*}} constant {{.*}} @_swiftStaticArrayMetadata, {{.*}} @_swiftImmortalRefCount
-// CHECK: @"$s4test3StrV14staticVariable_WZTv_r" = {{.*}} constant {{.*}} @_swiftStaticArrayMetadata, {{.*}} @_swiftImmortalRefCount
+// CHECK: @"$s4test11arrayLookupyS2iFTv_r" = {{.*}} constant {{.*}} @"$ss19__EmptyArrayStorageCN", {{.*}} @_swiftImmortalRefCount
+// CHECK: @"$s4test11returnArraySaySiGyFTv_r" = {{.*}} constant {{.*}} @"$ss19__EmptyArrayStorageCN", {{.*}} @_swiftImmortalRefCount
+// CHECK: @"$s4test9passArrayyyFTv_r" = {{.*}} constant {{.*}} @"$ss19__EmptyArrayStorageCN", {{.*}} @_swiftImmortalRefCount
+// CHECK: @"$s4test9passArrayyyFTv0_r" = {{.*}} constant {{.*}} @"$ss19__EmptyArrayStorageCN", {{.*}} @_swiftImmortalRefCount
+// CHECK: @"$s4test10storeArrayyyFTv_r" = {{.*}} constant {{.*}} @"$ss19__EmptyArrayStorageCN", {{.*}} @_swiftImmortalRefCount
+// CHECK: @"$s4test3StrV14staticVariable_WZTv_r" = {{.*}} constant {{.*}} @"$ss19__EmptyArrayStorageCN", {{.*}} @_swiftImmortalRefCount
 // CHECK-NOT: swift_initStaticObject
 
 // UNSUPPORTED: use_os_stdlib


### PR DESCRIPTION
Also, add a comment for the changed metadata symbol name for static read-only arrays.

rdar://100508215