### PR TITLE
[cxx-interop] Do not crash for non-ASCII strings

### DIFF
--- a/stdlib/public/Cxx/std/String.swift
+++ b/stdlib/public/Cxx/std/String.swift
@@ -14,7 +14,7 @@ extension std.string {
   public init(_ string: String) {
     self.init()
     for char in string.utf8 {
-      self.push_back(value_type(char))
+      self.push_back(value_type(bitPattern: char))
     }
   }
 }

--- a/test/Interop/Cxx/stdlib/overlay/std-string-overlay.swift
+++ b/test/Interop/Cxx/stdlib/overlay/std-string-overlay.swift
@@ -19,6 +19,17 @@ StdStringOverlayTestSuite.test("std::string <=> Swift.String") {
 
   let cxx3: std.string = "literal"
   expectEqual(cxx3.size(), 7)
+
+  // Non-ASCII characters are represented by more than one CChar.
+  let cxx4: std.string = "тест"
+  expectEqual(cxx4.size(), 8)
+  let swift4 = String(cxxString: cxx4)
+  expectEqual(swift4, "тест")
+
+  let cxx5: std.string = "emoji_🤖"
+  expectEqual(cxx5.size(), 10)
+  let swift5 = String(cxxString: cxx5)
+  expectEqual(swift5, "emoji_🤖")
 }
 
 extension std.string.const_iterator: UnsafeCxxInputIterator {


### PR DESCRIPTION
This fixes a crash that happened when creating an instance of `std::string` from a `Swift.String` that contains non-ASCII characters.

When converted to a UTF-8 array, such characters might be represented by numbers that fall out of `CChar`'s boundaries if they have a sign bit set to 1. This is normal and shouldn't trigger a crash or an assertion failure.