### PR TITLE
Add code owners for the parser

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+# Order is important. The last matching pattern has the most precedence.
+
+# Owners of the parser
+include/swift/Parse @ahoppen @bnbarham @CodaFi @DougGregor @rintaro
+lib/Parse           @ahoppen @bnbarham @CodaFi @DougGregor @rintaro
+test/Parse          @ahoppen @bnbarham @CodaFi @DougGregor @rintaro


### PR DESCRIPTION
This will allow @ahoppen @bnbarham @CodaFi @DougGregor and @rintaro to be notified when changes are made to the parser to make sure corresponding changes are also done in the new parser, implemented inside the swift-syntax repo.