### PR TITLE
[SourceKit] Disable SourceKit/CompileNotifications/diagnostics.swift in ASAN

### DIFF
--- a/test/SourceKit/CompileNotifications/diagnostics.swift
+++ b/test/SourceKit/CompileNotifications/diagnostics.swift
@@ -1,4 +1,6 @@
 // RUN: %sourcekitd-test -req=track-compiles == -req=sema %s -- %s | %FileCheck %s -check-prefix=NODIAGS
+// REQUIRES: no_asan
+
 // NODIAGS: key.notification: source.notification.compile-did-finish
 // NODIAGS-NEXT: key.diagnostics: [
 // NODIAGS-NEXT: ]


### PR DESCRIPTION
Disable the test case while we are investigating.

rdar://100508999