### PR TITLE
[SILGen] Cleanup profiler handling

### DIFF
--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -483,9 +483,6 @@ struct SILDeclRef {
     return result;
   }
 
-  /// True is the decl ref references any kind of thunk.
-  bool isAnyThunk() const;
-
   /// True if the decl ref references a thunk from a natively foreign
   /// declaration to Swift calling convention.
   bool isForeignToNativeThunk() const;

--- a/include/swift/SIL/SILProfiler.h
+++ b/include/swift/SIL/SILProfiler.h
@@ -31,9 +31,6 @@ class SILCoverageMap;
 class SILFunction;
 class SILModule;
 
-/// Returns whether the given AST node requires profiling instrumentation.
-bool doesASTRequireProfiling(SILModule &M, ASTNode N, SILDeclRef Constant);
-
 /// SILProfiler - Maps AST nodes to profile counters.
 class SILProfiler : public SILAllocated<SILProfiler> {
 private:

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -933,11 +933,6 @@ bool SILDeclRef::isBackDeployed() const {
   return false;
 }
 
-bool SILDeclRef::isAnyThunk() const {
-  return isForeignToNativeThunk() || isNativeToForeignThunk() ||
-         isDistributedThunk() || isBackDeploymentThunk();
-}
-
 bool SILDeclRef::isForeignToNativeThunk() const {
   // If this isn't a native entry-point, it's not a foreign-to-native thunk.
   if (isForeign)
@@ -1101,7 +1096,7 @@ std::string SILDeclRef::mangle(ManglingKind MKind) const {
     // Use the SILGen name only for the original non-thunked, non-curried entry
     // point.
     if (auto NameA = getDecl()->getAttrs().getAttribute<SILGenNameAttr>())
-      if (!NameA->Name.empty() && !isAnyThunk()) {
+      if (!NameA->Name.empty() && !isThunk()) {
         return NameA->Name.str();
       }
       

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1173,24 +1173,20 @@ void SILGenModule::emitFunctionDefinition(SILDeclRef constant, SILFunction *f) {
 
 /// Emit a function now, if it's externally usable or has been referenced in
 /// the current TU, or remember how to emit it later if not.
-static void emitOrDelayFunction(SILGenModule &SGM,
-                                SILDeclRef constant,
-                                bool forceEmission = false) {
+static void emitOrDelayFunction(SILGenModule &SGM, SILDeclRef constant) {
   assert(!constant.isThunk());
   assert(!constant.isClangImported());
 
   auto emitAfter = SGM.lastEmittedFunction;
 
-  SILFunction *f = nullptr;
-
   // Implicit decls may be delayed if they can't be used externally.
   auto linkage = constant.getLinkage(ForDefinition);
-  bool mayDelay = !forceEmission &&
-             (!constant.hasUserWrittenCode() &&
-              !constant.isDynamicallyReplaceable() &&
-              !isPossiblyUsedExternally(linkage, SGM.M.isWholeModule()));
+  bool mayDelay = !constant.hasUserWrittenCode() &&
+                  !constant.isDynamicallyReplaceable() &&
+                  !isPossiblyUsedExternally(linkage, SGM.M.isWholeModule());
 
   // Avoid emitting a delayable definition if it hasn't already been referenced.
+  SILFunction *f = nullptr;
   if (mayDelay)
     f = SGM.getEmittedFunction(constant, ForDefinition);
   else
@@ -1444,12 +1440,8 @@ void SILGenModule::emitFunction(FuncDecl *fd) {
 
   emitAbstractFuncDecl(fd);
 
-  if (fd->hasBody()) {
-    SILDeclRef constant(decl);
-    bool ForCoverageMapping = doesASTRequireProfiling(M, fd, constant);
-    emitOrDelayFunction(*this, constant,
-                        /*forceEmission=*/ForCoverageMapping);
-  }
+  if (fd->hasBody())
+    emitOrDelayFunction(*this, SILDeclRef(decl));
 }
 
 void SILGenModule::addGlobalVariable(VarDecl *global) {

--- a/test/Profiler/Inputs/unmapped_secondary.swift
+++ b/test/Profiler/Inputs/unmapped_secondary.swift
@@ -1,0 +1,22 @@
+// A secondary file for unmapped.swift that can contain profiled code.
+
+@propertyWrapper
+struct Wrapper<T> {
+  var wrappedValue: T
+}
+
+struct Projected<T> {
+  var value: T
+}
+
+@propertyWrapper
+struct WrapperWithProjectedValue<T> {
+  var wrappedValue: T
+  init(projectedValue: Projected<T>) {
+    self.wrappedValue = projectedValue.value
+  }
+  var projectedValue: Projected<T> {
+    Projected(value: wrappedValue)
+  }
+}
+

--- a/test/Profiler/coverage_var_init.swift
+++ b/test/Profiler/coverage_var_init.swift
@@ -32,13 +32,13 @@ struct S {
 }
 
 final class VarInit {
-  // CHECK: sil_coverage_map {{.*}} "$s17coverage_var_init7VarInitC018initializedWrapperE0SivpfP"
-  // CHECK-NEXT: [[@LINE+1]]:4 -> [[@LINE+1]]:42 : 0
-  @Wrapper var initializedWrapperInit = 2
-
   // CHECK: sil_coverage_map {{.*}} // variable initialization expression of coverage_var_init.VarInit.(_autoclosureWrapperInit
   // CHECK-NEXT: [[@LINE+1]]:52 -> [[@LINE+1]]:53
   @AutoClosureWrapper var autoclosureWrapperInit = 3
+
+  // CHECK: sil_coverage_map {{.*}} "$s17coverage_var_init7VarInitC019_initializedWrapper{{.*}}" {{.*}} // variable initialization expression of coverage_var_init.VarInit.(_initializedWrapperInit
+  // CHECK-NEXT: [[@LINE+1]]:41 -> [[@LINE+1]]:42 : 0
+  @Wrapper var initializedWrapperInit = 2
 
   // CHECK: sil_coverage_map {{.*}} "$s17coverage_var_init7VarInitC04lazydE033_49373CB2DFB47C8DC62FA963604688DFLLSSvgSSyXEfU_"
   // CHECK-NEXT: [[@LINE+1]]:42 -> [[@LINE+3]]:4 : 0

--- a/test/Profiler/unmapped.swift
+++ b/test/Profiler/unmapped.swift
@@ -1,5 +1,6 @@
-// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -suppress-warnings -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name unmapped %s | %FileCheck %s
-// RUN: %target-swift-frontend -profile-generate -profile-coverage-mapping -emit-ir %s
+// This uses '-primary-file' to ensure we're conservative with lazy SIL emission.
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -suppress-warnings -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name unmapped -primary-file %s %S/Inputs/unmapped_secondary.swift | %FileCheck %s
+// RUN: %target-swift-frontend -profile-generate -profile-coverage-mapping -emit-ir %s %S/Inputs/unmapped_secondary.swift
 
 // This test is exclusively for AST that we should never profile, as there is
 // no interesting user-written code.
@@ -18,10 +19,20 @@ struct R : Codable {
   var y: Int
 }
 
+struct Q {
+  // Don't profile the backing initializer.
+  @Wrapper
+  var x: Int
+}
+
 // Don't profile the implicit rawValue.
 enum E : Int {
   case a
 }
+
+// Don't profile the backing initalizers of the property wrapper.
+@available(*, unavailable)
+func hasExternalPropertyWrapper(@WrapperWithProjectedValue x: Int) {}
 
 // We don't profile unavailable functions, as they don't provide useful coverage
 // info.
@@ -46,11 +57,6 @@ extension TypeWithUnavailableMethods {
   public func baz() -> Int {
     .random() ? 1 : 2
   }
-}
-
-@propertyWrapper
-struct Wrapper<T> {
-  var wrappedValue: T
 }
 
 @available(*, unavailable)


### PR DESCRIPTION
- Use `SILDeclRef::hasUserWrittenCode` in `shouldProfile`, which subsumes existing logic and avoids emitting coverage maps for property wrapper backing initializers without user code (rdar://99931619).
- Stop forcing emission of functions for profiling, as we should now always SILGen functions with user-written code.
- Remove `setUpForProfiling`, instead creating the SILProfilers when we emit the function definitions. This matches what we do for other SILDeclRefs.

Also noticed that `SILDeclRef::isAnyThunk` is an exact copy of `SILDeclRef::isThunk`, and can be dropped.