### PR TITLE
[libSyntax] Model parameter modifiers as a `ModifierList`

### DIFF
--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -254,70 +254,75 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
         status.setHasCodeCompletionAndIsError();
       }
     }
-    
-    // ('inout' | '__shared' | '__owned' | isolated)?
-    bool hasSpecifier = false;
-    while (Tok.is(tok::kw_inout) ||
-           Tok.isContextualKeyword("__shared") ||
-           Tok.isContextualKeyword("__owned") ||
-           Tok.isContextualKeyword("isolated") ||
-           Tok.isContextualKeyword("_const")) {
 
-      if (Tok.isContextualKeyword("isolated")) {
-        // did we already find an 'isolated' type modifier?
-        if (param.IsolatedLoc.isValid()) {
-          diagnose(Tok, diag::parameter_specifier_repeated)
+    {
+      SyntaxParsingContext ModifiersContext(SyntaxContext, SyntaxKind::ModifierList);
+
+      // ('inout' | '__shared' | '__owned' | isolated)?
+      bool hasSpecifier = false;
+      while (Tok.is(tok::kw_inout) ||
+             Tok.isContextualKeyword("__shared") ||
+             Tok.isContextualKeyword("__owned") ||
+             Tok.isContextualKeyword("isolated") ||
+             Tok.isContextualKeyword("_const")) {
+        SyntaxParsingContext ModContext(SyntaxContext, SyntaxKind::DeclModifier);
+
+        if (Tok.isContextualKeyword("isolated")) {
+          // did we already find an 'isolated' type modifier?
+          if (param.IsolatedLoc.isValid()) {
+            diagnose(Tok, diag::parameter_specifier_repeated)
               .fixItRemove(Tok.getLoc());
-          consumeToken();
+            consumeToken();
+            continue;
+          }
+
+          // is this 'isolated' token the identifier of an argument label?
+          bool partOfArgumentLabel = lookahead<bool>(1, [&](CancellableBacktrackingScope &) {
+            if (Tok.is(tok::colon))
+              return true;  // isolated :
+
+            // isolated x :
+            return Tok.canBeArgumentLabel() && peekToken().is(tok::colon);
+          });
+
+          if (partOfArgumentLabel)
+            break;
+
+          // consume 'isolated' as type modifier
+          param.IsolatedLoc = consumeToken();
           continue;
         }
 
-        // is this 'isolated' token the identifier of an argument label?
-        bool partOfArgumentLabel = lookahead<bool>(1, [&](CancellableBacktrackingScope &) {
-          if (Tok.is(tok::colon))
-            return true;  // isolated :
-
-          // isolated x :
-          return Tok.canBeArgumentLabel() && peekToken().is(tok::colon);
-        });
-
-        if (partOfArgumentLabel)
-          break;
-
-        // consume 'isolated' as type modifier
-        param.IsolatedLoc = consumeToken();
-        continue;
-      }
-
-      if (Tok.isContextualKeyword("_const")) {
-        param.CompileConstLoc = consumeToken();
-        continue;
-      }
-
-      if (!hasSpecifier) {
-        if (Tok.is(tok::kw_inout)) {
-          // This case is handled later when mapping to ParamDecls for
-          // better fixits.
-          param.SpecifierKind = ParamDecl::Specifier::InOut;
-          param.SpecifierLoc = consumeToken();
-        } else if (Tok.isContextualKeyword("__shared")) {
-          // This case is handled later when mapping to ParamDecls for
-          // better fixits.
-          param.SpecifierKind = ParamDecl::Specifier::Shared;
-          param.SpecifierLoc = consumeToken();
-        } else if (Tok.isContextualKeyword("__owned")) {
-          // This case is handled later when mapping to ParamDecls for
-          // better fixits.
-          param.SpecifierKind = ParamDecl::Specifier::Owned;
-          param.SpecifierLoc = consumeToken();
+        if (Tok.isContextualKeyword("_const")) {
+          param.CompileConstLoc = consumeToken();
+          continue;
         }
-        hasSpecifier = true;
-      } else {
-        // Redundant specifiers are fairly common, recognize, reject, and
-        // recover from this gracefully.
-        diagnose(Tok, diag::parameter_specifier_repeated)
-          .fixItRemove(Tok.getLoc());
-        consumeToken();
+
+        if (!hasSpecifier) {
+          if (Tok.is(tok::kw_inout)) {
+            // This case is handled later when mapping to ParamDecls for
+            // better fixits.
+            param.SpecifierKind = ParamDecl::Specifier::InOut;
+            param.SpecifierLoc = consumeToken();
+          } else if (Tok.isContextualKeyword("__shared")) {
+            // This case is handled later when mapping to ParamDecls for
+            // better fixits.
+            param.SpecifierKind = ParamDecl::Specifier::Shared;
+            param.SpecifierLoc = consumeToken();
+          } else if (Tok.isContextualKeyword("__owned")) {
+            // This case is handled later when mapping to ParamDecls for
+            // better fixits.
+            param.SpecifierKind = ParamDecl::Specifier::Owned;
+            param.SpecifierLoc = consumeToken();
+          }
+          hasSpecifier = true;
+        } else {
+          // Redundant specifiers are fairly common, recognize, reject, and
+          // recover from this gracefully.
+          diagnose(Tok, diag::parameter_specifier_repeated)
+            .fixItRemove(Tok.getLoc());
+          consumeToken();
+        }
       }
     }
     

--- a/test/Syntax/Inputs/serialize_functions.json
+++ b/test/Syntax/Inputs/serialize_functions.json
@@ -1,0 +1,795 @@
+{
+  "kind": "SourceFile",
+  "layout": [
+    null,
+    {
+      "kind": "CodeBlockItemList",
+      "layout": [
+        {
+          "kind": "CodeBlockItem",
+          "layout": [
+            null,
+            {
+              "kind": "FunctionDecl",
+              "layout": [
+                null,
+                null,
+                null,
+                null,
+                null,
+                {
+                  "tokenKind": {
+                    "kind": "kw_func"
+                  },
+                  "leadingTrivia": "\/\/ RUN: %swift-syntax-test -input-source-filename %s -serialize-raw-tree > %t\n\/\/ RUN: diff %S\/Inputs\/serialize_functions.json %t -u\n\n",
+                  "trailingTrivia": " ",
+                  "presence": "Present"
+                },
+                null,
+                {
+                  "tokenKind": {
+                    "kind": "identifier",
+                    "text": "oneName"
+                  },
+                  "leadingTrivia": "",
+                  "trailingTrivia": "",
+                  "presence": "Present"
+                },
+                null,
+                null,
+                null,
+                {
+                  "kind": "FunctionSignature",
+                  "layout": [
+                    null,
+                    {
+                      "kind": "ParameterClause",
+                      "layout": [
+                        null,
+                        {
+                          "tokenKind": {
+                            "kind": "l_paren"
+                          },
+                          "leadingTrivia": "",
+                          "trailingTrivia": "",
+                          "presence": "Present"
+                        },
+                        null,
+                        {
+                          "kind": "FunctionParameterList",
+                          "layout": [
+                            {
+                              "kind": "FunctionParameter",
+                              "layout": [
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                {
+                                  "tokenKind": {
+                                    "kind": "identifier",
+                                    "text": "name"
+                                  },
+                                  "leadingTrivia": "",
+                                  "trailingTrivia": "",
+                                  "presence": "Present"
+                                },
+                                null,
+                                null,
+                                null,
+                                {
+                                  "tokenKind": {
+                                    "kind": "colon"
+                                  },
+                                  "leadingTrivia": "",
+                                  "trailingTrivia": " ",
+                                  "presence": "Present"
+                                },
+                                null,
+                                {
+                                  "kind": "SimpleTypeIdentifier",
+                                  "layout": [
+                                    null,
+                                    {
+                                      "tokenKind": {
+                                        "kind": "identifier",
+                                        "text": "String"
+                                      },
+                                      "leadingTrivia": "",
+                                      "trailingTrivia": "",
+                                      "presence": "Present"
+                                    },
+                                    null,
+                                    null
+                                  ],
+                                  "presence": "Present"
+                                },
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null
+                              ],
+                              "presence": "Present"
+                            }
+                          ],
+                          "presence": "Present"
+                        },
+                        null,
+                        {
+                          "tokenKind": {
+                            "kind": "r_paren"
+                          },
+                          "leadingTrivia": "",
+                          "trailingTrivia": " ",
+                          "presence": "Present"
+                        }
+                      ],
+                      "presence": "Present"
+                    },
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+                  ],
+                  "presence": "Present"
+                },
+                null,
+                null,
+                null,
+                {
+                  "kind": "CodeBlock",
+                  "layout": [
+                    null,
+                    {
+                      "tokenKind": {
+                        "kind": "l_brace"
+                      },
+                      "leadingTrivia": "",
+                      "trailingTrivia": "",
+                      "presence": "Present"
+                    },
+                    null,
+                    {
+                      "kind": "CodeBlockItemList",
+                      "layout": [],
+                      "presence": "Present"
+                    },
+                    null,
+                    {
+                      "tokenKind": {
+                        "kind": "r_brace"
+                      },
+                      "leadingTrivia": "",
+                      "trailingTrivia": "",
+                      "presence": "Present"
+                    }
+                  ],
+                  "presence": "Present"
+                }
+              ],
+              "presence": "Present"
+            },
+            null,
+            null,
+            null,
+            null
+          ],
+          "presence": "Present"
+        },
+        {
+          "kind": "CodeBlockItem",
+          "layout": [
+            null,
+            {
+              "kind": "FunctionDecl",
+              "layout": [
+                null,
+                null,
+                null,
+                null,
+                null,
+                {
+                  "tokenKind": {
+                    "kind": "kw_func"
+                  },
+                  "leadingTrivia": "\n",
+                  "trailingTrivia": " ",
+                  "presence": "Present"
+                },
+                null,
+                {
+                  "tokenKind": {
+                    "kind": "identifier",
+                    "text": "oneName"
+                  },
+                  "leadingTrivia": "",
+                  "trailingTrivia": "",
+                  "presence": "Present"
+                },
+                null,
+                null,
+                null,
+                {
+                  "kind": "FunctionSignature",
+                  "layout": [
+                    null,
+                    {
+                      "kind": "ParameterClause",
+                      "layout": [
+                        null,
+                        {
+                          "tokenKind": {
+                            "kind": "l_paren"
+                          },
+                          "leadingTrivia": "",
+                          "trailingTrivia": "",
+                          "presence": "Present"
+                        },
+                        null,
+                        {
+                          "kind": "FunctionParameterList",
+                          "layout": [
+                            {
+                              "kind": "FunctionParameter",
+                              "layout": [
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                {
+                                  "tokenKind": {
+                                    "kind": "identifier",
+                                    "text": "firstName"
+                                  },
+                                  "leadingTrivia": "",
+                                  "trailingTrivia": " ",
+                                  "presence": "Present"
+                                },
+                                null,
+                                {
+                                  "tokenKind": {
+                                    "kind": "identifier",
+                                    "text": "secondName"
+                                  },
+                                  "leadingTrivia": "",
+                                  "trailingTrivia": "",
+                                  "presence": "Present"
+                                },
+                                null,
+                                {
+                                  "tokenKind": {
+                                    "kind": "colon"
+                                  },
+                                  "leadingTrivia": "",
+                                  "trailingTrivia": " ",
+                                  "presence": "Present"
+                                },
+                                null,
+                                {
+                                  "kind": "SimpleTypeIdentifier",
+                                  "layout": [
+                                    null,
+                                    {
+                                      "tokenKind": {
+                                        "kind": "identifier",
+                                        "text": "String"
+                                      },
+                                      "leadingTrivia": "",
+                                      "trailingTrivia": "",
+                                      "presence": "Present"
+                                    },
+                                    null,
+                                    null
+                                  ],
+                                  "presence": "Present"
+                                },
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null
+                              ],
+                              "presence": "Present"
+                            }
+                          ],
+                          "presence": "Present"
+                        },
+                        null,
+                        {
+                          "tokenKind": {
+                            "kind": "r_paren"
+                          },
+                          "leadingTrivia": "",
+                          "trailingTrivia": " ",
+                          "presence": "Present"
+                        }
+                      ],
+                      "presence": "Present"
+                    },
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+                  ],
+                  "presence": "Present"
+                },
+                null,
+                null,
+                null,
+                {
+                  "kind": "CodeBlock",
+                  "layout": [
+                    null,
+                    {
+                      "tokenKind": {
+                        "kind": "l_brace"
+                      },
+                      "leadingTrivia": "",
+                      "trailingTrivia": "",
+                      "presence": "Present"
+                    },
+                    null,
+                    {
+                      "kind": "CodeBlockItemList",
+                      "layout": [],
+                      "presence": "Present"
+                    },
+                    null,
+                    {
+                      "tokenKind": {
+                        "kind": "r_brace"
+                      },
+                      "leadingTrivia": "",
+                      "trailingTrivia": "",
+                      "presence": "Present"
+                    }
+                  ],
+                  "presence": "Present"
+                }
+              ],
+              "presence": "Present"
+            },
+            null,
+            null,
+            null,
+            null
+          ],
+          "presence": "Present"
+        },
+        {
+          "kind": "CodeBlockItem",
+          "layout": [
+            null,
+            {
+              "kind": "FunctionDecl",
+              "layout": [
+                null,
+                null,
+                null,
+                null,
+                null,
+                {
+                  "tokenKind": {
+                    "kind": "kw_func"
+                  },
+                  "leadingTrivia": "\n",
+                  "trailingTrivia": " ",
+                  "presence": "Present"
+                },
+                null,
+                {
+                  "tokenKind": {
+                    "kind": "identifier",
+                    "text": "const"
+                  },
+                  "leadingTrivia": "",
+                  "trailingTrivia": "",
+                  "presence": "Present"
+                },
+                null,
+                null,
+                null,
+                {
+                  "kind": "FunctionSignature",
+                  "layout": [
+                    null,
+                    {
+                      "kind": "ParameterClause",
+                      "layout": [
+                        null,
+                        {
+                          "tokenKind": {
+                            "kind": "l_paren"
+                          },
+                          "leadingTrivia": "",
+                          "trailingTrivia": "",
+                          "presence": "Present"
+                        },
+                        null,
+                        {
+                          "kind": "FunctionParameterList",
+                          "layout": [
+                            {
+                              "kind": "FunctionParameter",
+                              "layout": [
+                                null,
+                                null,
+                                null,
+                                {
+                                  "kind": "ModifierList",
+                                  "layout": [
+                                    {
+                                      "kind": "DeclModifier",
+                                      "layout": [
+                                        null,
+                                        {
+                                          "tokenKind": {
+                                            "kind": "identifier",
+                                            "text": "_const"
+                                          },
+                                          "leadingTrivia": "",
+                                          "trailingTrivia": " ",
+                                          "presence": "Present"
+                                        },
+                                        null,
+                                        null
+                                      ],
+                                      "presence": "Present"
+                                    }
+                                  ],
+                                  "presence": "Present"
+                                },
+                                null,
+                                {
+                                  "tokenKind": {
+                                    "kind": "kw__"
+                                  },
+                                  "leadingTrivia": "",
+                                  "trailingTrivia": " ",
+                                  "presence": "Present"
+                                },
+                                null,
+                                {
+                                  "tokenKind": {
+                                    "kind": "identifier",
+                                    "text": "map"
+                                  },
+                                  "leadingTrivia": "",
+                                  "trailingTrivia": "",
+                                  "presence": "Present"
+                                },
+                                null,
+                                {
+                                  "tokenKind": {
+                                    "kind": "colon"
+                                  },
+                                  "leadingTrivia": "",
+                                  "trailingTrivia": " ",
+                                  "presence": "Present"
+                                },
+                                null,
+                                {
+                                  "kind": "SimpleTypeIdentifier",
+                                  "layout": [
+                                    null,
+                                    {
+                                      "tokenKind": {
+                                        "kind": "identifier",
+                                        "text": "String"
+                                      },
+                                      "leadingTrivia": "",
+                                      "trailingTrivia": "",
+                                      "presence": "Present"
+                                    },
+                                    null,
+                                    null
+                                  ],
+                                  "presence": "Present"
+                                },
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null
+                              ],
+                              "presence": "Present"
+                            }
+                          ],
+                          "presence": "Present"
+                        },
+                        null,
+                        {
+                          "tokenKind": {
+                            "kind": "r_paren"
+                          },
+                          "leadingTrivia": "",
+                          "trailingTrivia": " ",
+                          "presence": "Present"
+                        }
+                      ],
+                      "presence": "Present"
+                    },
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+                  ],
+                  "presence": "Present"
+                },
+                null,
+                null,
+                null,
+                {
+                  "kind": "CodeBlock",
+                  "layout": [
+                    null,
+                    {
+                      "tokenKind": {
+                        "kind": "l_brace"
+                      },
+                      "leadingTrivia": "",
+                      "trailingTrivia": "",
+                      "presence": "Present"
+                    },
+                    null,
+                    {
+                      "kind": "CodeBlockItemList",
+                      "layout": [],
+                      "presence": "Present"
+                    },
+                    null,
+                    {
+                      "tokenKind": {
+                        "kind": "r_brace"
+                      },
+                      "leadingTrivia": "",
+                      "trailingTrivia": "",
+                      "presence": "Present"
+                    }
+                  ],
+                  "presence": "Present"
+                }
+              ],
+              "presence": "Present"
+            },
+            null,
+            null,
+            null,
+            null
+          ],
+          "presence": "Present"
+        },
+        {
+          "kind": "CodeBlockItem",
+          "layout": [
+            null,
+            {
+              "kind": "FunctionDecl",
+              "layout": [
+                null,
+                null,
+                null,
+                null,
+                null,
+                {
+                  "tokenKind": {
+                    "kind": "kw_func"
+                  },
+                  "leadingTrivia": "\n",
+                  "trailingTrivia": " ",
+                  "presence": "Present"
+                },
+                null,
+                {
+                  "tokenKind": {
+                    "kind": "identifier",
+                    "text": "isolated"
+                  },
+                  "leadingTrivia": "",
+                  "trailingTrivia": "",
+                  "presence": "Present"
+                },
+                null,
+                null,
+                null,
+                {
+                  "kind": "FunctionSignature",
+                  "layout": [
+                    null,
+                    {
+                      "kind": "ParameterClause",
+                      "layout": [
+                        null,
+                        {
+                          "tokenKind": {
+                            "kind": "l_paren"
+                          },
+                          "leadingTrivia": "",
+                          "trailingTrivia": "",
+                          "presence": "Present"
+                        },
+                        null,
+                        {
+                          "kind": "FunctionParameterList",
+                          "layout": [
+                            {
+                              "kind": "FunctionParameter",
+                              "layout": [
+                                null,
+                                null,
+                                null,
+                                {
+                                  "kind": "ModifierList",
+                                  "layout": [
+                                    {
+                                      "kind": "DeclModifier",
+                                      "layout": [
+                                        null,
+                                        {
+                                          "tokenKind": {
+                                            "kind": "identifier",
+                                            "text": "isolated"
+                                          },
+                                          "leadingTrivia": "",
+                                          "trailingTrivia": " ",
+                                          "presence": "Present"
+                                        },
+                                        null,
+                                        null
+                                      ],
+                                      "presence": "Present"
+                                    }
+                                  ],
+                                  "presence": "Present"
+                                },
+                                null,
+                                {
+                                  "tokenKind": {
+                                    "kind": "kw__"
+                                  },
+                                  "leadingTrivia": "",
+                                  "trailingTrivia": " ",
+                                  "presence": "Present"
+                                },
+                                null,
+                                {
+                                  "tokenKind": {
+                                    "kind": "identifier",
+                                    "text": "map"
+                                  },
+                                  "leadingTrivia": "",
+                                  "trailingTrivia": "",
+                                  "presence": "Present"
+                                },
+                                null,
+                                {
+                                  "tokenKind": {
+                                    "kind": "colon"
+                                  },
+                                  "leadingTrivia": "",
+                                  "trailingTrivia": " ",
+                                  "presence": "Present"
+                                },
+                                null,
+                                {
+                                  "kind": "SimpleTypeIdentifier",
+                                  "layout": [
+                                    null,
+                                    {
+                                      "tokenKind": {
+                                        "kind": "identifier",
+                                        "text": "String"
+                                      },
+                                      "leadingTrivia": "",
+                                      "trailingTrivia": "",
+                                      "presence": "Present"
+                                    },
+                                    null,
+                                    null
+                                  ],
+                                  "presence": "Present"
+                                },
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null
+                              ],
+                              "presence": "Present"
+                            }
+                          ],
+                          "presence": "Present"
+                        },
+                        null,
+                        {
+                          "tokenKind": {
+                            "kind": "r_paren"
+                          },
+                          "leadingTrivia": "",
+                          "trailingTrivia": " ",
+                          "presence": "Present"
+                        }
+                      ],
+                      "presence": "Present"
+                    },
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+                  ],
+                  "presence": "Present"
+                },
+                null,
+                null,
+                null,
+                {
+                  "kind": "CodeBlock",
+                  "layout": [
+                    null,
+                    {
+                      "tokenKind": {
+                        "kind": "l_brace"
+                      },
+                      "leadingTrivia": "",
+                      "trailingTrivia": "",
+                      "presence": "Present"
+                    },
+                    null,
+                    {
+                      "kind": "CodeBlockItemList",
+                      "layout": [],
+                      "presence": "Present"
+                    },
+                    null,
+                    {
+                      "tokenKind": {
+                        "kind": "r_brace"
+                      },
+                      "leadingTrivia": "",
+                      "trailingTrivia": "",
+                      "presence": "Present"
+                    }
+                  ],
+                  "presence": "Present"
+                }
+              ],
+              "presence": "Present"
+            },
+            null,
+            null,
+            null,
+            null
+          ],
+          "presence": "Present"
+        }
+      ],
+      "presence": "Present"
+    },
+    null,
+    {
+      "tokenKind": {
+        "kind": "eof",
+        "text": ""
+      },
+      "leadingTrivia": "\n",
+      "trailingTrivia": "",
+      "presence": "Present"
+    }
+  ],
+  "presence": "Present"
+}

--- a/test/Syntax/serialize_functions.swift
+++ b/test/Syntax/serialize_functions.swift
@@ -1,0 +1,7 @@
+// RUN: %swift-syntax-test -input-source-filename %s -serialize-raw-tree > %t
+// RUN: diff %S/Inputs/serialize_functions.json %t -u
+
+func oneName(name: String) {}
+func oneName(firstName secondName: String) {}
+func const(_const _ map: String) {}
+func isolated(isolated _ map: String) {}


### PR DESCRIPTION
This fixes a libSyntax misparse where the first parameter name was parsed as the `isolated` token.