### PR TITLE
[Test] Re-disable some Reflection tests on ARM64e.

### DIFF
--- a/test/Reflection/conformance_descriptors.swift
+++ b/test/Reflection/conformance_descriptors.swift
@@ -3,6 +3,9 @@
 // Temporarily disable on AArch64 Linux (rdar://88451721)
 // UNSUPPORTED: OS=linux-gnu && CPU=aarch64
 
+// rdar://100558042
+// UNSUPPORTED: CPU=arm64e
+
 // RUN: %empty-directory(%t)
 
 // RUN: %target-build-swift %S/Inputs/ConcreteTypes.swift %S/Inputs/GenericTypes.swift %S/Inputs/Protocols.swift %S/Inputs/Extensions.swift %S/Inputs/Closures.swift %S/Inputs/Conformances.swift -parse-as-library -emit-module -emit-library -module-name ConformanceCheck -o %t/Conformances

--- a/test/Reflection/typeref_decoding_imported.swift
+++ b/test/Reflection/typeref_decoding_imported.swift
@@ -3,6 +3,9 @@
 // https://github.com/apple/swift/issues/55339
 // XFAIL: OS=openbsd
 
+// rdar://100558042
+// UNSUPPORTED: CPU=arm64e
+
 // RUN: %empty-directory(%t)
 
 // RUN: %target-build-swift %S/Inputs/ImportedTypes.swift %S/Inputs/ImportedTypesOther.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -o %t/%target-library-name(TypesToReflect) -I %S/Inputs

--- a/test/Reflection/typeref_decoding_objc.swift
+++ b/test/Reflection/typeref_decoding_objc.swift
@@ -6,6 +6,9 @@
 // Disable asan builds until we build swift-reflection-dump and the reflection library with the same compile: rdar://problem/30406870
 // REQUIRES: no_asan
 
+// rdar://100558042
+// UNSUPPORTED: CPU=arm64e
+
 // CHECK: FIELDS:
 // CHECK: =======
 // CHECK: TypesToReflect.OC

--- a/test/Reflection/typeref_lowering.swift
+++ b/test/Reflection/typeref_lowering.swift
@@ -2,6 +2,9 @@
 // XFAIL: OS=windows-msvc
 // RUN: %empty-directory(%t)
 
+// rdar://100558042
+// UNSUPPORTED: CPU=arm64e
+
 // RUN: %target-build-swift -Xfrontend -disable-availability-checking %S/Inputs/TypeLowering.swift -parse-as-library -emit-module -emit-library -module-name TypeLowering -o %t/%target-library-name(TypesToReflect)
 // RUN: %target-build-swift -Xfrontend -disable-availability-checking %S/Inputs/TypeLowering.swift %S/Inputs/main.swift -emit-module -emit-executable -module-name TypeLowering -o %t/TypesToReflect
 


### PR DESCRIPTION
These tests are still broken on ARM64e:

Reflection/conformance_descriptors.swift
Reflection/typeref_decoding_imported.swift
Reflection/typeref_decoding_objc.swift
Reflection/typeref_lowering.swift

rdar://100558042