### PR TITLE
platform: correct header for `ssse3`

### DIFF
--- a/stdlib/public/Platform/visualc.modulemap
+++ b/stdlib/public/Platform/visualc.modulemap
@@ -58,7 +58,7 @@ module _visualc_intrinsics [system] [extern_c] {
 
     explicit module ssse3 {
       export sse3
-      header "tmmintrinh"
+      header "tmmintrin.h"
     }
 
     explicit module sse4_1 {


### PR DESCRIPTION
Cherry-pick the change from main to correct the spelling for the ssse3 header.  This should allow the use of the header in clients.