### PR TITLE
test/Interpreter/keypath.swift does not work in back-deployment scenarios anymore

### DIFF
--- a/test/Interpreter/keypath.swift
+++ b/test/Interpreter/keypath.swift
@@ -1,6 +1,9 @@
 // RUN: %target-run-simple-swift | %FileCheck %s
 // REQUIRES: executable_test
 
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
 class MyLabel {
   var text = "label"
 }


### PR DESCRIPTION


The file check expectations (the way we print stuff) is different after #60133.

rdar://100564676
