### PR TITLE
[tools] Show helpful message when demangling '_'

### DIFF
--- a/tools/swift-demangle/swift-demangle.cpp
+++ b/tools/swift-demangle/swift-demangle.cpp
@@ -392,10 +392,9 @@ int main(int argc, char **argv) {
     swift::Demangle::Context DCtx;
     for (llvm::StringRef name : InputNames) {
       if (name == "_") {
-        llvm::errs()
-            << "warning: input symbol '_' is likely the result of variable "
-               "expansion by the shell. Either remove the '_$' prefix, single "
-               "quote the symbol, or escape the '$' with a backslash";
+        llvm::errs() << "warning: input symbol '_' is likely the result of "
+                        "variable expansion by the shell. Ensure the argument "
+                        "is quoted or escaped.\n";
         continue;
       }
       if (name.startswith("S") || name.startswith("s") ) {

--- a/tools/swift-demangle/swift-demangle.cpp
+++ b/tools/swift-demangle/swift-demangle.cpp
@@ -391,6 +391,13 @@ int main(int argc, char **argv) {
   } else {
     swift::Demangle::Context DCtx;
     for (llvm::StringRef name : InputNames) {
+      if (name == "_") {
+        llvm::errs()
+            << "warning: input symbol '_' is likely the result of variable "
+               "expansion by the shell. Either remove the '_$' prefix, single "
+               "quote the symbol, or escape the '$' with a backslash";
+        continue;
+      }
       if (name.startswith("S") || name.startswith("s") ) {
         std::string correctedName = std::string("$") + name.str();
         demangle(llvm::outs(), correctedName, DCtx, options);


### PR DESCRIPTION
From most shells, the symbol(s) given to `swift demangle` should be quoted or escaped, otherwise the shell will perform variable expansion on the `$...` suffix of the symbol. For example:

```
% swift demangle _$sScMMa
_ ---> _
```

Instead the command should be edited to one of the following:
```
% swift demangle sScMMa
_$sScMMa ---> type metadata accessor for Swift.MainActor
% swift demangle '_$sScMMa'
_$sScMMa ---> type metadata accessor for Swift.MainActor
% swift demangle _\$sScMMa
_$sScMMa ---> type metadata accessor for Swift.MainActor
```

When variable expansion has happened, `swift demangle` will see the symbol only as "`_`". This change adds a warning that identifies the likely issue, and contains suggestions on how the user can fix and rerun the invocation.