### PR TITLE
test: check static linking of FoundationNetworking

### DIFF
--- a/test/Misc/foundation_static_linking.swift
+++ b/test/Misc/foundation_static_linking.swift
@@ -1,3 +1,4 @@
+// REQUIRES: OS=linux-gnu
 // RUN: %target-swiftc_driver -static-stdlib -o %t/foundation_static_linking %s 
 // RUN: not --crash  %t/foundation_static_linking
 

--- a/test/Misc/foundation_static_linking.swift
+++ b/test/Misc/foundation_static_linking.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swiftc_driver -static-stdlib -o %t/foundation_static_linking %s 
+// RUN: not --crash  %t/foundation_static_linking
+
+import Foundation
+
+_ = try! Data(contentsOf: URL(string: "http://httpbin.org/get")!)


### PR DESCRIPTION
This trivial file when built with `-static-stdlib` is supposed to be statically linked with `FoundationNetworking`, but crashes on Ubuntu (and potentially all Linux distributions) with this error:

```
Foundation/NSSwiftRuntime.swift:409: Fatal error: You must link or load module FoundationNetworking to load non-file: URL content using String(contentsOf:…), Data(contentsOf:…), etc.
Trace/breakpoint trap
```

This was fixed in https://github.com/apple/swift-corelibs-foundation/pull/3135 for Swift 5.5, but regressed in Swift 5.6 and Swift 5.7. Having this test should help us prevent subsequent regressions.

<!-- What's in this pull request? -->

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
<!-- Resolves #NNNNN, fix apple/llvm-project#MMMMM. -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
