### PR TITLE
docs: link to Ubuntu 22.04 deps in `GettingStarted.md`

### DIFF
--- a/docs/HowToGuides/GettingStarted.md
+++ b/docs/HowToGuides/GettingStarted.md
@@ -154,6 +154,7 @@ Double-check that running `pwd` prints a path ending with `swift`.
 
 1. The latest Linux dependencies are listed in the respective Dockerfiles:
    * [Ubuntu 20.04](https://github.com/apple/swift-docker/blob/main/swift-ci/master/ubuntu/20.04/Dockerfile)
+   * [Ubuntu 22.04](https://github.com/apple/swift-docker/blob/main/swift-ci/master/ubuntu/22.04/Dockerfile)
    * [CentOS 7](https://github.com/apple/swift-docker/blob/main/swift-ci/master/centos/7/Dockerfile)
    * [Amazon Linux 2](https://github.com/apple/swift-docker/blob/main/swift-ci/master/amazon-linux/2/Dockerfile)
 


### PR DESCRIPTION
Currently, only a link to Ubuntu 20.04 dependencies is present. Those dependencies won't work for Ubuntu 22.04.

<!-- What's in this pull request?
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

Resolves #NNNNN, fix apple/llvm-project#MMMMM.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
