### PR TITLE
build-script: validate arguments before running `sccache`

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -679,12 +679,6 @@ def main_normal():
         toolchain.libtool = args.host_libtool
     if args.cmake is not None:
         toolchain.cmake = args.cmake
-    if args.sccache:
-        print("Ensuring the sccache server is running...")
-        # Use --show-stats to ensure the server is started, because using
-        # --start-server will fail if the server is already running.
-        # Capture the output because we don't want to see the stats.
-        shell.capture([toolchain.sccache, "--show-stats"])
 
     cmake = CMake(args=args, toolchain=toolchain)
     # Check the CMake version is sufficient on Linux and build from source
@@ -699,6 +693,13 @@ def main_normal():
 
     # Validate the arguments.
     validate_arguments(toolchain, args)
+
+    if args.sccache:
+        print("Ensuring the sccache server is running...")
+        # Use --show-stats to ensure the server is started, because using
+        # --start-server will fail if the server is already running.
+        # Capture the output because we don't want to see the stats.
+        shell.capture([toolchain.sccache, "--show-stats"])
 
     # Create the build script invocation.
     invocation = build_script_invocation.BuildScriptInvocation(toolchain, args)


### PR DESCRIPTION
When a user passes `--sccache` flag when `sccache` is not installed, we still attempt to make a shell invocation to `sccache`, which leads to an inscrutable error:

```
Traceback (most recent call last):
  File "/root/swift-source/swift/utils/build-script", line 789, in <module>
    exit_code = main()
  File "/root/swift-source/swift/utils/build-script", line 784, in main
    return main_normal()
  File "/root/swift-source/swift/utils/build-script", line 687, in main_normal
    shell.capture([toolchain.sccache, "--show-stats"])
  File "/root/swift-source/swift/utils/swift_build_support/swift_build_support/shell.py", line 133, in capture
    return subprocess.check_output(command, env=_env, stderr=stderr,
  File "/usr/lib/python3.10/subprocess.py", line 420, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.10/subprocess.py", line 501, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/usr/lib/python3.10/subprocess.py", line 969, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.10/subprocess.py", line 1720, in _execute_child
    and os.path.dirname(executable)
  File "/usr/lib/python3.10/posixpath.py", line 152, in dirname
    p = os.fspath(p)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

`validate_arguments` should be called before `shell.capture([toolchain.sccache, "--show-stats"])` so that a more meaningful error message is shown to the user, asking them to install `sccache`:

```
[utils/build-script] ERROR: can't find sccache (please install sccache)
```

<!-- What's in this pull request?
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue

Resolves #NNNNN, fix apple/llvm-project#MMMMM.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
