### PR TITLE
build: enable handling of alpine-linux-musl triple

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/product.py
+++ b/utils/swift_build_support/swift_build_support/products/product.py
@@ -339,7 +339,7 @@ class Product(object):
 
         return toolchain_file
 
-    def get_linux_abi(self, arch):
+    def get_linux_target_components(self, arch):
         # Map tuples of (platform, arch) to ABI
         #
         # E.x.: Hard ABI or Soft ABI for Linux map to gnueabihf
@@ -348,22 +348,37 @@ class Product(object):
             'armv7': ('arm', 'gnueabihf')
         }
 
-        # Default is just arch, gnu
-        sysroot_arch, abi = arch_platform_to_abi.get(arch, (arch, 'gnu'))
-        return sysroot_arch, abi
+        abi = 'gnu'
+        vendor = 'unknown'
+
+        try:
+            output = shell.capture(["clang", "--version"])
+
+            # clang can't handle default `*-unknown-linux-*` components on Alpine,
+            # it needs special handling to propagate `vendor` and `abi` intact
+            if 'alpine-linux-musl' in output:
+                vendor = 'alpine'
+                abi = 'musl'
+
+            sysroot_arch, abi = arch_platform_to_abi.get(arch, (arch, abi))
+
+        except BaseException:
+            # Default is just arch, gnu
+            sysroot_arch, abi = arch_platform_to_abi.get(arch, (arch, abi))
+        return sysroot_arch, vendor, abi
 
     def get_linux_sysroot(self, platform, arch):
         if not self.is_cross_compile_target('{}-{}'.format(platform, arch)):
             return None
-        sysroot_arch, abi = self.get_linux_abi(arch)
+        sysroot_arch, abi = self.get_linux_target_components(arch)
         # $ARCH-$PLATFORM-$ABI
         # E.x.: aarch64-linux-gnu
         sysroot_dirname = '{}-{}-{}'.format(sysroot_arch, platform, abi)
         return os.path.join(os.sep, 'usr', sysroot_dirname)
 
     def get_linux_target(self, platform, arch):
-        sysroot_arch, abi = self.get_linux_abi(arch)
-        return '{}-unknown-linux-{}'.format(sysroot_arch, abi)
+        sysroot_arch, vendor, abi = self.get_linux_target_components(arch)
+        return '{}-{}-linux-{}'.format(sysroot_arch, vendor, abi)
 
     def generate_linux_toolchain_file(self, platform, arch):
         """

--- a/utils/swift_build_support/swift_build_support/products/product.py
+++ b/utils/swift_build_support/swift_build_support/products/product.py
@@ -352,7 +352,7 @@ class Product(object):
         vendor = 'unknown'
 
         try:
-            output = shell.capture(["clang", "--version"])
+            output = shell.capture([self.toolchain.cc, "--print-target-triple"])
 
             # clang can't handle default `*-unknown-linux-*` components on Alpine,
             # it needs special handling to propagate `vendor` and `abi` intact


### PR DESCRIPTION
Currently, when building LLVM/clang on Alpine Linux, CMake toolchain file specifies incorrect `<cpu_arch>-unknown-linux-musl` target, which makes the build immediately fail. Correct target that allows building on Alpine should be specified as `<cpu_arch>-alpine-linux-musl`, with `<cpu_arch>` replaced with respective CPU platform, e.g. `aarch64`.

<!-- What's in this pull request?
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
Resolves #NNNNN, fix apple/llvm-project#MMMMM.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
