### PR TITLE
[Dependency Scanning] Share the Clang Dependency Scanning service among scanner invocations.

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -502,6 +502,9 @@ class GlobalModuleDependenciesCache {
     ModuleDependenciesKindMap ModuleDependenciesMap;
   };
 
+  /// The 'persistent' Clang dependency scanner service
+  clang::tooling::dependencies::DependencyScanningService clangScanningService;
+
   /// All cached Swift source module dependencies, in the order in which they were encountered
   std::vector<ModuleDependencyID> AllSourceModules;
 
@@ -616,9 +619,6 @@ private:
   StringRef mainScanModuleName;
   /// Set containing all of the Clang modules that have already been seen.
   llvm::StringSet<> alreadySeenClangModules;
-  /// The 'persistent' Clang dependency scanner service
-  /// TODO: Share this service among common scanner invocations
-  clang::tooling::dependencies::DependencyScanningService clangScanningService;
   /// The Clang dependency scanner tool
   clang::tooling::dependencies::DependencyScanningTool clangScanningTool;
 

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -225,7 +225,15 @@ void ModuleDependencies::addBridgingModuleDependency(
   }
 }
 
-GlobalModuleDependenciesCache::GlobalModuleDependenciesCache() {}
+GlobalModuleDependenciesCache::GlobalModuleDependenciesCache()
+  : clangScanningService(
+                         clang::tooling::dependencies::ScanningMode::DependencyDirectivesScan,
+                         clang::tooling::dependencies::ScanningOutputFormat::Full,
+                         clang::CASOptions(),
+                         /* Cache */ nullptr,
+                         /* SharedFS */ nullptr,
+                         /* ReuseFileManager */ false,
+                         /* OptimizeArgs */ false) {}
 GlobalModuleDependenciesCache::TargetSpecificGlobalCacheState *
 GlobalModuleDependenciesCache::getCurrentCache() const {
   assert(CurrentTriple.hasValue() &&
@@ -536,15 +544,7 @@ ModuleDependenciesCache::ModuleDependenciesCache(
     StringRef mainScanModuleName)
     : globalCache(globalCache),
       mainScanModuleName(mainScanModuleName),
-      clangScanningService(
-          clang::tooling::dependencies::ScanningMode::DependencyDirectivesScan,
-          clang::tooling::dependencies::ScanningOutputFormat::Full,
-          clang::CASOptions(),
-          /* Cache */ nullptr,
-          /* SharedFS */ nullptr,
-          /* ReuseFileManager */ false,
-          /* OptimizeArgs */ false),
-      clangScanningTool(clangScanningService) {
+      clangScanningTool(globalCache.clangScanningService) {
   for (auto kind = ModuleDependenciesKind::FirstKind;
        kind != ModuleDependenciesKind::LastKind; ++kind) {
     ModuleDependenciesMap.insert(


### PR DESCRIPTION
It was recently moved to the `ModuleDependenciesCache`. This is undesireable, instead this should live in the `GlobalModuleDependenciesCache` so that we benefit from the filesystem caching it performs across different scanning actions.
