### PR TITLE
[NFC] Add parsing helpers for @attr(<identifier>)

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1469,6 +1469,9 @@ ERROR(attr_expected_integer_literal,none,
 ERROR(attr_expected_option_such_as,none,
       "expected '%0' option such as '%1'", (StringRef, StringRef))
 
+ERROR(attr_expected_option_identifier,none,
+      "expected '%0' option to be an identifier", (StringRef))
+
 ERROR(attr_unknown_option,none,
       "unknown option '%0' for attribute '%1'", (StringRef, StringRef))
 
@@ -1482,17 +1485,8 @@ ERROR(attr_expected_colon_after_label,none,
 ERROR(alignment_must_be_positive_integer,none,
       "alignment value must be a positive integer literal", ())
 
-ERROR(swift_native_objc_runtime_base_must_be_identifier,none,
-      "@_swift_native_objc_runtime_base class name must be an identifier", ())
-
-ERROR(objc_runtime_name_must_be_identifier,none,
-      "@_objcRuntimeName name must be an identifier", ())
-
 ERROR(attr_only_at_non_local_scope, none,
       "attribute '%0' can only be used in a non-local scope", (StringRef))
-
-ERROR(projection_value_property_not_identifier,none,
-      "@_projectedValueProperty name must be an identifier", ())
 
 // Access control
 ERROR(attr_access_expected_set,none,

--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -315,6 +315,18 @@ IDENTIFIER_WITH_NAME(TypeWrapperProperty, "$_storage")
 IDENTIFIER(storageKeyPath)
 IDENTIFIER(memberwise)
 
+// Attribute options
+IDENTIFIER_(_always)
+IDENTIFIER_(assumed)
+IDENTIFIER(checked)
+IDENTIFIER(never)
+IDENTIFIER(none)
+IDENTIFIER(safe)
+IDENTIFIER(size)
+IDENTIFIER(speed)
+IDENTIFIER(unchecked)
+IDENTIFIER(unsafe)
+
 // The singleton instance of TupleTypeDecl in the Builtin module
 IDENTIFIER(TheTupleType)
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -896,7 +896,7 @@ public:
   
   /// Parse the specified expected token and return its location on success.  On failure, emit the specified
   /// error diagnostic,  a note at the specified note location, and return the location of the previous token.
-  bool parseMatchingToken(tok K, SourceLoc &TokLoc, Diag<> ErrorDiag,
+  bool parseMatchingToken(tok K, SourceLoc &TokLoc, Diagnostic ErrorDiag,
                           SourceLoc OtherLoc);
 
   /// Returns the proper location for a missing right brace, parenthesis, etc.

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -975,7 +975,7 @@ bool Parser::parseToken(tok K, SourceLoc &TokLoc, const Diagnostic &D) {
   return true;
 }
 
-bool Parser::parseMatchingToken(tok K, SourceLoc &TokLoc, Diag<> ErrorDiag,
+bool Parser::parseMatchingToken(tok K, SourceLoc &TokLoc, Diagnostic ErrorDiag,
                                 SourceLoc OtherLoc) {
   Diag<> OtherNote;
   switch (K) {


### PR DESCRIPTION
Extends the existing `parseSingleAttrOption()` helper to also be able to parse a single arbitrary `Identifier`. This simplifies the handling of `SwiftNativeObjCRuntimeBaseAttr`, `ObjCRuntimeNameAttr`, and `ProjectedValuePropertyAttr`.

Extracted from #60630.
