### PR TITLE
[cxx-interop] Allow using `std::map` subscript

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3200,8 +3200,12 @@ namespace {
         if (importedName.isSubscriptAccessor()) {
           assert(func->getParameters()->size() == 1);
           auto typeDecl = dc->getSelfNominalTypeDecl();
-          auto parameterType = func->getParameters()->get(0)->getType();
+          auto parameter = func->getParameters()->get(0);
+          auto parameterType = parameter->getType();
           if (!typeDecl || !parameterType)
+            return nullptr;
+          if (parameter->isInOut())
+            // Subscripts with inout parameters are not allowed in Swift.
             return nullptr;
 
           auto &getterAndSetter = Impl.cxxSubscripts[{ typeDecl,

--- a/test/Interop/Cxx/operators/Inputs/member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/member-inline.h
@@ -159,6 +159,32 @@ public:
   }
 };
 
+struct ReadOnlyRvalueParam {
+private:
+  int values[5] = {1, 2, 3, 4, 5};
+
+public:
+  const int &operator[](int &&x) const { return values[x]; }
+};
+
+struct ReadWriteRvalueParam {
+private:
+  int values[5] = {1, 2, 3, 4, 5};
+
+public:
+  const int &operator[](int &&x) const { return values[x]; }
+  int &operator[](int&& x) { return values[x]; }
+};
+
+struct ReadWriteRvalueGetterParam {
+private:
+  int values[5] = {1, 2, 3, 4, 5};
+  
+public:
+  const int &operator[](int &&x) const { return values[x]; }
+  int &operator[](int x) { return values[x]; }
+};
+
 struct DifferentTypesArray {
 private:
   int values[3] = { 1, 2, 3 };

--- a/test/Interop/Cxx/operators/member-inline-typechecker.swift
+++ b/test/Interop/Cxx/operators/member-inline-typechecker.swift
@@ -30,6 +30,15 @@ var writeOnlyIntArray = WriteOnlyIntArray()
 writeOnlyIntArray[2] = 654
 let writeOnlyValue = writeOnlyIntArray[2]
 
+var readOnlyRvalueParam = ReadOnlyRvalueParam()
+let readOnlyRvalueVal = readOnlyRvalueParam[1] // expected-error {{value of type 'ReadOnlyRvalueParam' has no subscripts}}
+
+var readWriteRvalueParam = ReadWriteRvalueParam()
+let readWriteRvalueVal = readWriteRvalueParam[1] // expected-error {{value of type 'ReadWriteRvalueParam' has no subscripts}}
+
+var readWriteRvalueGetterParam = ReadWriteRvalueGetterParam()
+let readWriteRvalueGetterVal = readWriteRvalueGetterParam[1]
+
 var diffTypesArray = DifferentTypesArray()
 let diffTypesResultInt: Int32 = diffTypesArray[0]
 let diffTypesResultDouble: Double = diffTypesArray[0.5]

--- a/test/Interop/Cxx/stdlib/Inputs/module.modulemap
+++ b/test/Interop/Cxx/stdlib/Inputs/module.modulemap
@@ -7,3 +7,8 @@ module StdString {
   header "std-string.h"
   requires cplusplus
 }
+
+module StdMap {
+  header "std-map.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/stdlib/Inputs/std-map.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-map.h
@@ -1,0 +1,10 @@
+#ifndef TEST_INTEROP_CXX_STDLIB_INPUTS_STD_MAP_H
+#define TEST_INTEROP_CXX_STDLIB_INPUTS_STD_MAP_H
+
+#include <map>
+
+using Map = std::map<int, int>;
+
+inline Map initMap() { return {{1, 3}, {2, 2}, {3, 3}}; }
+
+#endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_MAP_H

--- a/test/Interop/Cxx/stdlib/use-std-map.swift
+++ b/test/Interop/Cxx/stdlib/use-std-map.swift
@@ -1,0 +1,29 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
+//
+// REQUIRES: executable_test
+//
+// Enable this everywhere once we have a solution for modularizing other C++ stdlibs: rdar://87654514
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+import StdlibUnittest
+import StdMap
+
+var StdMapTestSuite = TestSuite("StdMap")
+
+#if !os(Linux) // https://github.com/apple/swift/issues/61412
+StdMapTestSuite.test("init") {
+  let m = Map()
+  expectEqual(m.size(), 0)
+  expectTrue(m.empty())
+}
+#endif
+
+StdMapTestSuite.test("subscript") {
+  var m = initMap()
+  let at1 = m[1]
+  expectEqual(at1, 3)
+  expectEqual(m[2], 2)
+  expectEqual(m[3], 3)
+}
+
+runAllTests()


### PR DESCRIPTION
This fixes an error that occurred when trying to use the subscript on an instance `std::map`:
```
error: cannot assign through subscript: 'map' is immutable
```
This was happening even with a mutable `std::map` instance.

`std::map::operator[]` has two overloads:
* `T& operator[]( const Key& key )`
* `T& operator[]( Key&& key )`

The second one is imported with an `inout` parameter, and we picked it as an implementation of the subscript getter because it was the last of the two overloads to get imported.

Swift does not allow subscripts with `inout` parameters. This is checked at the AST level, and those checks do not run for synthesized Swift code. This caused Swift to produce a surprising error which actually indicated that the argument of the subscript, not the instance itself, must be mutable.

rdar://100529571