### PR TITLE
[CSClosure] Don't try to infer types for implicitly wrapped parameters

### DIFF
--- a/lib/Sema/CSClosure.cpp
+++ b/lib/Sema/CSClosure.cpp
@@ -97,6 +97,13 @@ public:
         return Action::Continue(expr);
 
       if (auto *wrappedVar = var->getOriginalWrappedProperty()) {
+        // If there is no type it means that the body of the
+        // closure hasn't been resolved yet, so we can
+        // just skip it and wait for \c applyPropertyWrapperToParameter
+        // to assign types.
+        if (wrappedVar->hasImplicitPropertyWrapper())
+          return Action::Continue(expr);
+
         auto outermostWrapperAttr =
             wrappedVar->getOutermostAttachedPropertyWrapper();
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4511,6 +4511,7 @@ ConstraintSystem::applyPropertyWrapperToParameter(
       auto wrappedValueType = getType(param->getPropertyWrapperWrappedValueVar());
       addConstraint(ConstraintKind::PropertyWrapper, projectionType, wrappedValueType,
                     getConstraintLocator(param));
+      setType(param->getPropertyWrapperProjectionVar(), projectionType);
     }
 
     initKind = PropertyWrapperInitKind::ProjectedValue;
@@ -4518,6 +4519,7 @@ ConstraintSystem::applyPropertyWrapperToParameter(
     Type wrappedValueType = computeWrappedValueType(param, wrapperType);
     addConstraint(matchKind, paramType, wrappedValueType, locator);
     initKind = PropertyWrapperInitKind::WrappedValue;
+    setType(param->getPropertyWrapperWrappedValueVar(), wrappedValueType);
   }
 
   appliedPropertyWrappers[anchor].push_back({ wrapperType, initKind });

--- a/validation-test/Sema/SwiftUI/builder_with_implicit_property_wrapper_inference.swift
+++ b/validation-test/Sema/SwiftUI/builder_with_implicit_property_wrapper_inference.swift
@@ -1,0 +1,29 @@
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.15 -swift-version 5
+
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+import SwiftUI
+
+struct Example: View {
+  struct Item: Identifiable {
+    var id: Int
+    var title: String
+    var isOn: Bool = .random()
+  }
+
+  @State var items = [
+    Item(id: 0, title: "")
+  ]
+
+  var body: some View {
+    List {
+      Section {
+        ForEach($items) { $item in
+          Toggle(item.title, isOn: $item.isOn.animation())
+        }
+        .onDelete { items.remove(atOffsets: $0) }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Update `applyPropertyWrapperToParameter` to set types to projected and wrapped values and allow `TypeVariableRefFinder` to skip decls with implicit property wrappers that are not yet resolved.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
