### PR TITLE
Ensure that there is a syntax error even with lazy parsing.

### DIFF
--- a/validation-test/Parse/delayed-members-open-prop-scope.swift
+++ b/validation-test/Parse/delayed-members-open-prop-scope.swift
@@ -1,5 +1,7 @@
 // RUN: not %target-swift-frontend -typecheck -experimental-skip-all-function-bodies %s
 
+var : Int
+
 struct A {
   let prop: Int = {
 


### PR DESCRIPTION
Without any syntax errors prior to lazy parsing, we'll reject this in valid-parse testing of the new parser. Adding this doesn't change the fundamental nature of this test.
