### PR TITLE
[Sema] Don't ignore implicit AST nodes in diagnoseUnhandledThrowSite

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4043,10 +4043,10 @@ generateForEachStmtConstraints(
   // `.next()`. `next()` is called on each iteration of the loop.
   {
     auto *nextRef = UnresolvedDotExpr::createImplicit(
-      ctx,
-      new (ctx) DeclRefExpr(makeIteratorVar, DeclNameLoc(),
-                            /*Implicit=*/true),
-      ctx.Id_next, /*labels=*/ArrayRef<Identifier>());
+        ctx,
+        new (ctx) DeclRefExpr(makeIteratorVar, DeclNameLoc(stmt->getForLoc()),
+                              /*Implicit=*/true),
+        ctx.Id_next, /*labels=*/ArrayRef<Identifier>());
     nextRef->setFunctionRefKind(FunctionRefKind::SingleApply);
 
     Expr *nextCall = CallExpr::createImplicitEmpty(ctx, nextRef);

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -1775,9 +1775,6 @@ public:
   void diagnoseUnhandledThrowSite(DiagnosticEngine &Diags, ASTNode E,
                                   bool isTryCovered,
                                   const PotentialEffectReason &reason) {
-    if (E.isImplicit())
-      return;
-
     switch (getKind()) {
     case Kind::PotentiallyHandled:
       if (IsNonExhaustiveCatch) {

--- a/test/Concurrency/async_sequence_syntax.swift
+++ b/test/Concurrency/async_sequence_syntax.swift
@@ -9,7 +9,10 @@ func missingAsync<T : AsyncSequence>(_ seq: T) throws {
 
 @available(SwiftStdlib 5.1, *)
 func missingThrows<T : AsyncSequence>(_ seq: T) async {
-  for try await _ in seq { } // expected-error{{error is not handled because the enclosing function is not declared 'throws'}}
+  for try await _ in seq { } 
+  // expected-error@-1 {{error is not handled because the enclosing function is not declared 'throws'}}
+  // expected-error@-2 {{call can throw, but the error is not handled}}
+  // expected-note@-3 {{call is to 'rethrows' function, but a conformance has a throwing witness}}
 }
 
 @available(SwiftStdlib 5.1, *)
@@ -27,7 +30,9 @@ func missingThrowingInBlock<T : AsyncSequence>(_ seq: T) {
 @available(SwiftStdlib 5.1, *)
 func missingTryInBlock<T : AsyncSequence>(_ seq: T) { 
   executeAsync { 
-    for await _ in seq { } // expected-error{{call can throw, but the error is not handled}}
+    for await _ in seq { } 
+    // expected-error@-1 2{{call can throw, but the error is not handled}}
+    // expected-note@-2 {{call is to 'rethrows' function, but a conformance has a throwing witness}}
   }
 }
 

--- a/test/decl/func/throwing_functions.swift
+++ b/test/decl/func/throwing_functions.swift
@@ -279,3 +279,14 @@ struct FunctionHolder {
   }
 }
 
+// https://github.com/apple/swift/issues/61368
+
+@propertyWrapper
+struct Wrapper {
+  var wrappedValue: Int?
+  init() throws {}
+}
+
+struct Repro {
+  @Wrapper var x // expected-error {{call can throw, but errors cannot be thrown out of a property initializer}}
+}


### PR DESCRIPTION
Resolves https://github.com/apple/swift/issues/61368

This partially reverts https://github.com/apple/swift/commit/d461eab3f0bb0262fd72ef8c624861d317777986 as it caused a regression where the 5.7 compiler hangs (but crashes on `main`), because `diagnoseUnhandledThrowSite` was ignoring implicit nodes, which was causing a throwing property wrapper init call to not get diagnosed since it's created implicitly.

We used to diagnose it on 5.6, but stopped doing it from 5.7 onwards.