### PR TITLE
Fix unchecked_bitwise_cast to "escape" its operand's ownership

### DIFF
--- a/test/SILOptimizer/copy_propagation.sil
+++ b/test/SILOptimizer/copy_propagation.sil
@@ -875,6 +875,7 @@ bb0(%instance : @owned $C):
 // CHECK-NOT:     destroy_value
 // CHECK-LABEL: } // end sil function 'dont_extend_beyond_nonoverlapping_endaccess_after_destroyvalue_in_consuming_block'
 sil [ossa] @dont_extend_beyond_nonoverlapping_endaccess_after_destroyvalue_in_consuming_block : $@convention(thin) () -> () {
+bb0:
   %instance = apply undef() : $@convention(thin) () -> @owned C
   %addr = alloc_stack [lexical] $C, var
   %access = begin_access [static] [modify] %addr : $*C
@@ -884,4 +885,53 @@ sil [ossa] @dont_extend_beyond_nonoverlapping_endaccess_after_destroyvalue_in_co
   dealloc_stack %addr : $*C
   %retval = tuple()
   return %retval : $()
+}
+
+sil @closureGetter : $@convention(thin) () -> @owned Optional<@Sendable @callee_guaranteed () -> ()>
+
+// This pattern is produced by SILGen doUncheckedConversion.
+// rdar://100527903 (Overrelease of optional closure when using shorthand syntax)
+//
+// Copy propagation cannot handle a PointerEscape.
+//
+// CHECK-LABEL: sil hidden [ossa] @testBitwiseClosureEscape : $@convention(thin) () -> () {
+// CHECK: [[V:%.*]] = apply %0() : $@convention(thin) () -> @owned Optional<@Sendable @callee_guaranteed () -> ()>
+// CHECK: [[CP1:%.*]] = copy_value [[V]] : $Optional<@Sendable @callee_guaranteed () -> ()>
+// CHECK: destroy_value [[V]] : $Optional<@Sendable @callee_guaranteed () -> ()>
+// CHECK: [[CAST:%.*]] = unchecked_bitwise_cast [[CP1]] : $Optional<@Sendable @callee_guaranteed () -> ()> to $Optional<@callee_guaranteed () -> ()>
+// CHECK-NEXT: [[CASTCP:%.*]] = copy_value [[CAST]] : $Optional<@callee_guaranteed () -> ()>
+// CHECK:      store [[CASTCP]] to [init]
+// CHECK:   destroy_value [[CP1]] : $Optional<@Sendable @callee_guaranteed () -> ()>
+// CHECK-LABEL: } // end sil function 'testBitwiseClosureEscape'
+sil hidden [ossa] @testBitwiseClosureEscape : $@convention(thin) () -> () {
+bb0:
+  %2 = function_ref @closureGetter : $@convention(thin) () -> @owned Optional<@Sendable @callee_guaranteed () -> ()>
+  %3 = apply %2() : $@convention(thin) () -> @owned Optional<@Sendable @callee_guaranteed () -> ()>
+  %13 = copy_value %3 : $Optional<@Sendable @callee_guaranteed () -> ()>
+  %14 = alloc_stack $Optional<@callee_guaranteed () -> ()>
+  destroy_value %3 : $Optional<@Sendable @callee_guaranteed () -> ()>
+  %17 = unchecked_bitwise_cast %13 : $Optional<@Sendable @callee_guaranteed () -> ()> to $Optional<@callee_guaranteed () -> ()>
+  %18 = copy_value %17 : $Optional<@callee_guaranteed () -> ()>
+  store %18 to [init] %14 : $*Optional<@callee_guaranteed () -> ()>
+  destroy_addr %14 : $*Optional<@callee_guaranteed () -> ()>
+  destroy_value %13 : $Optional<@Sendable @callee_guaranteed () -> ()>
+  dealloc_stack %14 : $*Optional<@callee_guaranteed () -> ()>
+  %99 = tuple ()
+  return %99 : $()
+}
+
+// Lexical destroy hoisting cannot handle a PointerEscape.
+//
+// CHECK-LABEL: sil [ossa] @testNoLexicalHoistEscape : $@convention(thin) (@owned Optional<@Sendable @callee_guaranteed () -> ()>) -> @owned Optional<@callee_guaranteed () -> ()> {
+// CHECK: bb0(%0 : @owned $Optional<@Sendable @callee_guaranteed () -> ()>):
+// CHECK:   [[CAST:%.*]] = unchecked_bitwise_cast %0 : $Optional<@Sendable @callee_guaranteed () -> ()> to $Optional<@callee_guaranteed () -> ()>
+// CHECK:   [[COPY:%.*]] = copy_value [[CAST]] : $Optional<@callee_guaranteed () -> ()>
+// CHECK:   destroy_value %0 : $Optional<@Sendable @callee_guaranteed () -> ()>
+// CHECK-LABEL: } // end sil function 'testNoLexicalHoistEscape'
+sil [ossa] @testNoLexicalHoistEscape : $@convention(thin) (@owned Optional<@Sendable @callee_guaranteed () -> ()>) -> @owned Optional<@callee_guaranteed () -> ()> {
+bb0(%0 : @owned $Optional<@Sendable @callee_guaranteed () -> ()>):
+  %cast = unchecked_bitwise_cast %0 : $Optional<@Sendable @callee_guaranteed () -> ()> to $Optional<@callee_guaranteed () -> ()>
+  %copy = copy_value %cast : $Optional<@callee_guaranteed () -> ()>
+  destroy_value %0 : $Optional<@Sendable @callee_guaranteed () -> ()>
+  return %copy : $Optional<@callee_guaranteed () -> ()>
 }

--- a/test/SILOptimizer/copy_propagation_borrow.sil
+++ b/test/SILOptimizer/copy_propagation_borrow.sil
@@ -243,13 +243,12 @@ bb3:
 // CHECK:      bb1:
 // CHECK-NEXT:   [[COPY:%.*]] = copy_value [[OUTERCOPY]] : $C
 // CHECK-NEXT:   apply %{{.*}}([[COPY]]) : $@convention(thin) (@owned C) -> ()
-// CHECK-NEXT:   destroy_value %0 : $C
 // CHECK-NEXT:   br bb3
 // CHECK:      bb2:
-// CHECK-NEXT:   destroy_value %0 : $C
 // CHECK-NEXT:   br bb3
 // CHECK:      bb3:
 // CHECK-NEXT:   destroy_value [[OUTERCOPY]] : $C
+// CHECK-NEXT:   destroy_value %0 : $C
 // CHECK-LABEL: } // end sil function 'testLocalBorrowPostDomDestroy'
 sil [ossa] @testLocalBorrowPostDomDestroy : $@convention(thin) (@owned C) -> () {
 bb0(%0 : @owned $C):
@@ -285,11 +284,9 @@ bb3:
 // CHECK:      bb1:
 // CHECK-NEXT:   apply %{{.*}}([[OUTERCOPY]]) : $@convention(thin) (@guaranteed C) -> ()
 // CHECK-NEXT:   apply %{{.*}}([[OUTERCOPY]]) : $@convention(thin) (@owned C) -> ()
-// CHECK-NEXT:   destroy_value %0 : $C
 // CHECK-NEXT:   br bb3
 // CHECK:      bb2:
 // CHECK-NEXT:   apply %{{.*}}([[OUTERCOPY]]) : $@convention(thin) (@guaranteed C) -> ()
-// CHECK-NEXT:   destroy_value %0 : $C
 // CHECK-NEXT:   destroy_value [[OUTERCOPY]] : $C
 // CHECK-NEXT:   br bb3
 // CHECK:      bb3:
@@ -328,13 +325,11 @@ bb3:
 // CHECK-NEXT:  apply %{{.*}}([[OUTERCOPY]]) : $@convention(thin) (@guaranteed C) -> ()
 // CHECK-NEXT:  [[ARGCOPY:%.*]] = copy_value [[OUTERCOPY]] : $C
 // CHECK-NEXT:  apply %2([[OUTERCOPY]], [[ARGCOPY:%.*]]) : $@convention(thin) (@owned C, @owned C) -> ()
-// CHECK-NEXT:  destroy_value %0 : $C
 // CHECK-NEXT:  br bb3
 // CHECK:     bb2:
 // CHECK-NEXT:  apply %{{.*}}([[OUTERCOPY]]) : $@convention(thin) (@guaranteed C) -> ()
 //
 // This copy would be eliminated if the outer lifetime were also canonicalized (no unchecked_ownership_conversion)
-// CHECK-NEXT:  destroy_value %0 : $C
 // CHECK-NEXT:  [[COPY2:%.*]] = copy_value [[OUTERCOPY]] : $C
 // CHECK-NEXT:  destroy_value [[COPY2]] : $C
 // CHECK-NEXT:  destroy_value %4 : $C


### PR DESCRIPTION
Fix unchecked_bitwise_cast to "escape" its operand's ownership

This makes it impossible for OSSA utilities to reason about the
lifetime of the value being cast. This fixes bugs in which SILGen
generates bitwise casts without protecting that lifetime.

Also fix LexicalDestroyHoisting to bail out when ownership escapes via a
`PointerEscape` operand.

Fixes rdar://100527903 (Overrelease of optional closure when using shorthand syntax)

The previous OSSA strategy was to gradually eliminate all "pointer
escape" SIL patterns. That would define away a class of bugs in the
OSSA utilities themselves. This was not friendly to developers working
on SILGen, and we still don't have verification that can catch these
bugs.

The new strategy is to make all OSSA utilities aware of pointer
escapes. This acknowledges reality that SIL is imperfect. Instead,
optimizer support for transforming SIL always needs to recognize
potentially dangerous patterns.

The downside of this new strategy is that it hides performance
problems because SIL optimizations can give up whenever they happen to
see a "pointer escape". We need to keep working on this problem
without being motivated by miscompiling code.