### PR TITLE
[ConstraintSystem] Reformat type inference debug output to use `|`

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4421,8 +4421,8 @@ public:
 
     if (isDebugMode()) {
       auto &log = llvm::errs();
-      log.indent(solverState ? solverState->getCurrentIndent() + 4 : 0)
-          << "Failed constraint ";
+      log.indent(solverState ? solverState->getCurrentIndent() : 2) << "|";
+      log.indent(2) << "`- Failed constraint ";
       constraint->print(log, &getASTContext().SourceMgr);
       log << "\n";
     }
@@ -4446,7 +4446,8 @@ public:
 
     if (isDebugMode() && getPhase() == ConstraintSystemPhase::Solving) {
       auto &log = llvm::errs();
-      log.indent(solverState->getCurrentIndent() + 4) << "Added constraint: ";
+      log.indent(solverState->getCurrentIndent()) << "|";
+      log.indent(4) << "`- Added constraint: ";
       constraint->print(log, &getASTContext().SourceMgr,
                         solverState->getCurrentIndent() + 4);
       log << ")\n";
@@ -4464,8 +4465,8 @@ public:
 
     if (isDebugMode() && getPhase() == ConstraintSystemPhase::Solving) {
       auto &log = llvm::errs();
-      log.indent(solverState->getCurrentIndent() + 4)
-          << "Removed constraint: ";
+      log.indent(solverState->getCurrentIndent()) << "|";
+      log.indent(4) << "`- Removed constraint: ";
       constraint->print(log, &getASTContext().SourceMgr,
                         solverState->getCurrentIndent() + 4);
       log << "\n";
@@ -6434,7 +6435,7 @@ public:
 
   void print(llvm::raw_ostream &Out, SourceManager *SM, unsigned indent) const {
     Out << "conjunction element ";
-    Element->print(Out, SM, indent);
+    Element->print(Out, SM, indent + 2);
   }
 
 private:

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4422,9 +4422,9 @@ public:
     if (isDebugMode()) {
       auto &log = llvm::errs();
       log.indent(solverState ? solverState->getCurrentIndent() + 4 : 0)
-          << "(failed constraint ";
+          << "Failed constraint ";
       constraint->print(log, &getASTContext().SourceMgr);
-      log << ")\n";
+      log << "\n";
     }
   }
 
@@ -4446,7 +4446,7 @@ public:
 
     if (isDebugMode() && getPhase() == ConstraintSystemPhase::Solving) {
       auto &log = llvm::errs();
-      log.indent(solverState->getCurrentIndent() + 4) << "(added constraint: ";
+      log.indent(solverState->getCurrentIndent() + 4) << "Added constraint: ";
       constraint->print(log, &getASTContext().SourceMgr,
                         solverState->getCurrentIndent() + 4);
       log << ")\n";
@@ -4465,10 +4465,10 @@ public:
     if (isDebugMode() && getPhase() == ConstraintSystemPhase::Solving) {
       auto &log = llvm::errs();
       log.indent(solverState->getCurrentIndent() + 4)
-          << "(removed constraint: ";
+          << "Removed constraint: ";
       constraint->print(log, &getASTContext().SourceMgr,
                         solverState->getCurrentIndent() + 4);
-      log << ")\n";
+      log << "\n";
     }
 
     if (solverState)

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -55,8 +55,8 @@ void ConstraintSystem::increaseScore(ScoreKind kind, unsigned value) {
   if (isDebugMode() && value > 0) {
     if (solverState)
       llvm::errs().indent(solverState->getCurrentIndent());
-    llvm::errs() << "(increasing '" << Score::getNameFor(kind) << "' score by "  << value 
-                 << ")\n";
+    llvm::errs() << "Increasing '" << Score::getNameFor(kind) << "' score by "  << value
+                 << "\n";
   }
 
   unsigned index = static_cast<unsigned>(kind);
@@ -73,7 +73,7 @@ bool ConstraintSystem::worseThanBestSolution() const {
 
   if (isDebugMode()) {
     llvm::errs().indent(solverState->getCurrentIndent())
-      << "(solution is worse than the best solution)\n";
+      << "Solution is worse than the best solution\n";
   }
 
   return true;

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -53,10 +53,10 @@ void ConstraintSystem::increaseScore(ScoreKind kind, unsigned value) {
   }
 
   if (isDebugMode() && value > 0) {
-    if (solverState)
-      llvm::errs().indent(solverState->getCurrentIndent());
-    llvm::errs() << "Increasing '" << Score::getNameFor(kind) << "' score by "  << value
-                 << "\n";
+    auto &log = llvm::errs();
+    log.indent(solverState ? solverState->getCurrentIndent() : 2) << "|";
+    log.indent(2) << "`- Increasing '" << Score::getNameFor(kind)
+                  << "' score by " << value << "\n";
   }
 
   unsigned index = static_cast<unsigned>(kind);
@@ -73,7 +73,7 @@ bool ConstraintSystem::worseThanBestSolution() const {
 
   if (isDebugMode()) {
     llvm::errs().indent(solverState->getCurrentIndent())
-      << "Solution is worse than the best solution\n";
+      << "| Solution is worse than the best solution\n";
   }
 
   return true;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11353,9 +11353,8 @@ retry_after_fail:
       PrintOptions PO;
       PO.PrintTypesForDebugging = true;
       llvm::errs().indent(solverState ? solverState->getCurrentIndent() : 0)
-        << "(common result type for $T" << fnTypeVar->getID() << " is "
-        << commonResultType.getString(PO)
-        << ")\n";
+          << "Common result type for $T" << fnTypeVar->getID() << " is "
+          << commonResultType.getString(PO) << "\n";
     }
 
     // Introduction of a `Bind` constraint here could result in the disconnect

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11352,9 +11352,10 @@ retry_after_fail:
     if (isDebugMode()) {
       PrintOptions PO;
       PO.PrintTypesForDebugging = true;
-      llvm::errs().indent(solverState ? solverState->getCurrentIndent() : 0)
-          << "Common result type for $T" << fnTypeVar->getID() << " is "
-          << commonResultType.getString(PO) << "\n";
+      auto &log = llvm::errs();
+      log.indent(solverState ? solverState->getCurrentIndent() : 0) << "|";
+      log.indent(2) << "Common result type for $T" << fnTypeVar->getID()
+                    << " is " << commonResultType.getString(PO) << "\n";
     }
 
     // Introduction of a `Bind` constraint here could result in the disconnect

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -348,7 +348,7 @@ bool ConstraintSystem::simplify() {
     if (isDebugMode()) {
       auto &log = llvm::errs();
       log.indent(solverState->getCurrentIndent());
-      log << "(considering -> ";
+      log << "Considering -> ";
       constraint->print(log, &getASTContext().SourceMgr);
       log << "\n";
 
@@ -357,7 +357,7 @@ bool ConstraintSystem::simplify() {
       if (constraint->getKind() != ConstraintKind::Disjunction &&
           constraint->getKind() != ConstraintKind::Conjunction) {
         log.indent(solverState->getCurrentIndent() + 2)
-            << "(simplification result:\n";
+            << "Simplification result:\n";
       }
     }
 
@@ -367,8 +367,7 @@ bool ConstraintSystem::simplify() {
       retireFailedConstraint(constraint);
       if (isDebugMode()) {
         auto &log = llvm::errs();
-        log.indent(solverState->getCurrentIndent() + 2) << ")\n";
-        log.indent(solverState->getCurrentIndent() + 2) << "(outcome: error)\n";
+        log.indent(solverState->getCurrentIndent() + 2) << "Outcome: error\n";
       }
       break;
 
@@ -378,9 +377,8 @@ bool ConstraintSystem::simplify() {
       retireConstraint(constraint);
       if (isDebugMode()) {
         auto &log = llvm::errs();
-        log.indent(solverState->getCurrentIndent() + 2) << ")\n";
         log.indent(solverState->getCurrentIndent() + 2)
-            << "(outcome: simplified)\n";
+            << "Outcome: simplified\n";
       }
       break;
 
@@ -389,16 +387,10 @@ bool ConstraintSystem::simplify() {
         ++solverState->NumUnsimplifiedConstraints;
       if (isDebugMode()) {
         auto &log = llvm::errs();
-        log.indent(solverState->getCurrentIndent() + 2) << ")\n";
         log.indent(solverState->getCurrentIndent() + 2)
-            << "(outcome: unsolved)\n";
+            << "Outcome: unsolved\n";
       }
       break;
-    }
-
-    if (isDebugMode()) {
-      auto &log = llvm::errs();
-      log.indent(solverState->getCurrentIndent()) << ")\n";
     }
 
     // Check whether a constraint failed. If so, we're done.
@@ -1658,9 +1650,9 @@ ConstraintSystem::filterDisjunction(
 
     if (isDebugMode()) {
       llvm::errs().indent(solverState ? solverState->getCurrentIndent() : 0)
-        << "(disabled disjunction term ";
+        << "Disabled disjunction term ";
       constraint->print(llvm::errs(), &ctx.SourceMgr);
-      llvm::errs() << ")\n";
+      llvm::errs() << "\n";
     }
 
     if (restoreOnFail)
@@ -1717,9 +1709,8 @@ ConstraintSystem::filterDisjunction(
 
     if (isDebugMode()) {
       llvm::errs().indent(solverState ? solverState->getCurrentIndent(): 0)
-        << "(introducing single enabled disjunction term ";
+        << "Introducing single enabled disjunction term ";
       choice->print(llvm::errs(), &ctx.SourceMgr);
-      llvm::errs() << ")\n";
     }
 
     simplifyDisjunctionChoice(choice);

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -347,17 +347,19 @@ bool ConstraintSystem::simplify() {
 
     if (isDebugMode()) {
       auto &log = llvm::errs();
-      log.indent(solverState->getCurrentIndent());
-      log << "Considering -> ";
-      constraint->print(log, &getASTContext().SourceMgr);
+      log.indent(solverState->getCurrentIndent()) << "|"
+                                                  << "\n";
+      log.indent(solverState->getCurrentIndent()) << "`-> Considering -> ";
+      constraint->print(log, &getASTContext().SourceMgr,
+                        solverState->getCurrentIndent() + 2);
       log << "\n";
 
       // {Dis, Con}junction are returned unsolved in \c simplifyConstraint() and
       // handled separately by solver steps.
       if (constraint->getKind() != ConstraintKind::Disjunction &&
           constraint->getKind() != ConstraintKind::Conjunction) {
-        log.indent(solverState->getCurrentIndent() + 2)
-            << "Simplification result:\n";
+        log.indent(solverState->getCurrentIndent()) << "|";
+        log.indent(2) << "`- Simplification result:\n";
       }
     }
 
@@ -367,7 +369,8 @@ bool ConstraintSystem::simplify() {
       retireFailedConstraint(constraint);
       if (isDebugMode()) {
         auto &log = llvm::errs();
-        log.indent(solverState->getCurrentIndent() + 2) << "Outcome: error\n";
+        log.indent(solverState->getCurrentIndent()) << "|";
+        log.indent(2) << "`-- Outcome: error\n";
       }
       break;
 
@@ -377,8 +380,8 @@ bool ConstraintSystem::simplify() {
       retireConstraint(constraint);
       if (isDebugMode()) {
         auto &log = llvm::errs();
-        log.indent(solverState->getCurrentIndent() + 2)
-            << "Outcome: simplified\n";
+        log.indent(solverState->getCurrentIndent()) << "|";
+        log.indent(2) << "`-- Outcome: simplified\n";
       }
       break;
 
@@ -387,8 +390,8 @@ bool ConstraintSystem::simplify() {
         ++solverState->NumUnsimplifiedConstraints;
       if (isDebugMode()) {
         auto &log = llvm::errs();
-        log.indent(solverState->getCurrentIndent() + 2)
-            << "Outcome: unsolved\n";
+        log.indent(solverState->getCurrentIndent()) << "|";
+        log.indent(2) << "`-- Outcome: unsolved\n";
       }
       break;
     }
@@ -1649,10 +1652,11 @@ ConstraintSystem::filterDisjunction(
     }
 
     if (isDebugMode()) {
-      llvm::errs().indent(solverState ? solverState->getCurrentIndent() : 0)
-        << "Disabled disjunction term ";
+      auto &log = llvm::errs();
+      log.indent(solverState ? solverState->getCurrentIndent() : 0) << "|";
+      log.indent(2) << "Disabled disjunction term ";
       constraint->print(llvm::errs(), &ctx.SourceMgr);
-      llvm::errs() << "\n";
+      log << "\n";
     }
 
     if (restoreOnFail)
@@ -1708,8 +1712,9 @@ ConstraintSystem::filterDisjunction(
     }
 
     if (isDebugMode()) {
-      llvm::errs().indent(solverState ? solverState->getCurrentIndent(): 0)
-        << "Introducing single enabled disjunction term ";
+      auto &log = llvm::errs();
+      log.indent(solverState ? solverState->getCurrentIndent() : 2) << "|";
+      log.indent(2) << "Introducing single enabled disjunction term ";
       choice->print(llvm::errs(), &ctx.SourceMgr);
     }
 

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -351,7 +351,8 @@ StepResult ComponentStep::take(bool prevFailed) {
 
   auto bestBindings = CS.determineBestBindings([&](const BindingSet &bindings) {
     if (CS.isDebugMode() && bindings.hasViableBindings()) {
-      bos.indent(CS.solverState->getCurrentIndent() + 2);
+      bos.indent(CS.solverState->getCurrentIndent());
+      bos << "`- ";
       bindings.dump(bos, CS.solverState->getCurrentIndent() + 2);
       bos << "\n";
     }
@@ -362,7 +363,7 @@ StepResult ComponentStep::take(bool prevFailed) {
   if (CS.isDebugMode()) {
     if (!potentialBindings.empty()) {
       auto &log = getDebugLogger();
-      log << "Potential Binding(s): " << '\n';
+      log << "| Potential Binding(s): " << '\n';
       log << potentialBindings;
     }
 
@@ -380,8 +381,8 @@ StepResult ComponentStep::take(bool prevFailed) {
     }
     if (!overloadDisjunctions.empty()) {
       auto &log = getDebugLogger();
-      log.indent(2);
-      log << "Disjunction(s) = [";
+      //      log.indent(2);
+      log << "`- Disjunction(s) = [";
       interleave(overloadDisjunctions, log, ", ");
       log << "]\n";
     }
@@ -473,9 +474,9 @@ StepResult ComponentStep::take(bool prevFailed) {
   auto solution = CS.finalize();
   if (CS.isDebugMode()) {
     auto &log = getDebugLogger();
-    log << "Found solution:";
+    log << "<! Found solution:";
     getCurrentScore().print(log);
-    log << "\n";
+    log << ">\n";
   }
 
   Solutions.push_back(std::move(solution));

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -243,9 +243,9 @@ bool SplitterStep::mergePartialSolutions() const {
       solutionMemory += solution.getTotalMemory();
       if (CS.isDebugMode()) {
         auto &log = getDebugLogger();
-        log << "(composed solution:";
+        log << "<! Composed solution:";
         CS.CurrentScore.print(log);
-        log << ")\n";
+        log << ">\n";
       }
 
       // Save this solution.
@@ -352,9 +352,8 @@ StepResult ComponentStep::take(bool prevFailed) {
   auto bestBindings = CS.determineBestBindings([&](const BindingSet &bindings) {
     if (CS.isDebugMode() && bindings.hasViableBindings()) {
       bos.indent(CS.solverState->getCurrentIndent() + 2);
-      bos << "(";
       bindings.dump(bos, CS.solverState->getCurrentIndent() + 2);
-      bos << ")\n";
+      bos << "\n";
     }
   });
 
@@ -363,7 +362,7 @@ StepResult ComponentStep::take(bool prevFailed) {
   if (CS.isDebugMode()) {
     if (!potentialBindings.empty()) {
       auto &log = getDebugLogger();
-      log << "(Potential Binding(s): " << '\n';
+      log << "Potential Binding(s): " << '\n';
       log << potentialBindings;
     }
 
@@ -385,11 +384,6 @@ StepResult ComponentStep::take(bool prevFailed) {
       log << "Disjunction(s) = [";
       interleave(overloadDisjunctions, log, ", ");
       log << "]\n";
-
-      if (!potentialBindings.empty() || !overloadDisjunctions.empty()) {
-        auto &log = getDebugLogger();
-        log << ")\n";
-      }
     }
   }
 
@@ -479,9 +473,9 @@ StepResult ComponentStep::take(bool prevFailed) {
   auto solution = CS.finalize();
   if (CS.isDebugMode()) {
     auto &log = getDebugLogger();
-    log << "(found solution:";
+    log << "Found solution:";
     getCurrentScore().print(log);
-    log << ")\n";
+    log << "\n";
   }
 
   Solutions.push_back(std::move(solution));
@@ -500,8 +494,8 @@ StepResult ComponentStep::finalize(bool isSuccess) {
 
   if (CS.isDebugMode()) {
     auto &log = getDebugLogger();
-    log << (isSuccess ? "finished" : "failed") << " component #" << Index
-        << ")\n";
+    log << (isSuccess ? "Finished" : "Failed") << " component #" << Index
+        << "}\n";
   }
 
   // If we came either back to this step and previous
@@ -554,7 +548,7 @@ StepResult TypeVariableStep::resume(bool prevFailed) {
   ActiveChoice.reset();
 
   if (CS.isDebugMode())
-    getDebugLogger() << ")\n";
+    getDebugLogger() << "}\n";
 
   // Let's check if we should stop right before
   // attempting any new bindings.
@@ -600,7 +594,7 @@ StepResult DisjunctionStep::resume(bool prevFailed) {
   ActiveChoice.reset();
 
   if (CS.isDebugMode())
-    getDebugLogger() << ")\n";
+    getDebugLogger() << "}\n";
 
   // Attempt next disjunction choice (if any left).
   return take(prevFailed);
@@ -880,7 +874,7 @@ StepResult ConjunctionStep::resume(bool prevFailed) {
   if (Snapshot && Snapshot->isScoped()) {
     Snapshot.reset();
     if (CS.isDebugMode())
-      getDebugLogger() << ")\n";
+      getDebugLogger() << "}\n";
     
     return done(/*isSuccess=*/!prevFailed);
   }
@@ -893,7 +887,7 @@ StepResult ConjunctionStep::resume(bool prevFailed) {
   ActiveChoice.reset();
 
   if (CS.isDebugMode())
-    getDebugLogger() << ")\n";
+    getDebugLogger() << "}\n";
 
   // Check whether it makes sense to continue solving
   // this conjunction. Note that for conjunction constraint
@@ -961,7 +955,7 @@ StepResult ConjunctionStep::resume(bool prevFailed) {
     if (Conjunction->isIsolated()) {
       if (CS.isDebugMode()) {
         auto &log = getDebugLogger();
-        log << "(applying conjunction result to outer context\n";
+        log << "{Applying conjunction result to outer context\n";
       }
 
       assert(

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -476,7 +476,8 @@ private:
     
     if (CS.isDebugMode()) {
       auto &log = getDebugLogger();
-      log << "Type variables in scope = "
+      //      log.indent(CS.solverState->getCurrentIndent());
+      log << "`- Type variables in scope = "
           << "[";
       auto typeVars = CS.getTypeVariables();
       PrintOptions PO;
@@ -537,10 +538,10 @@ public:
       if (CS.isDebugMode()) {
         auto &log = getDebugLogger();
         log << "{\n";
-        log.indent(CS.solverState->getCurrentIndent());
-        log << "Attempting ";
+        log.indent(CS.solverState->getCurrentIndent() + 2);
+        log << "!> Attempting ";
         choice->print(log, &CS.getASTContext().SourceMgr, CS.solverState->getCurrentIndent() + 2);
-        log << '\n';
+        log << "\n";
       }
 
       {

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -469,7 +469,7 @@ private:
     
     if (CS.isDebugMode()) {
       auto &log = getDebugLogger();
-      log << "(solving component #" << Index << '\n';
+      log << "{Solving component #" << Index << '\n';
     }
     
     ComponentScope = std::make_unique<Scope>(*this);
@@ -536,7 +536,9 @@ public:
 
       if (CS.isDebugMode()) {
         auto &log = getDebugLogger();
-        log << "(attempting ";
+        log << "{\n";
+        log.indent(CS.solverState->getCurrentIndent());
+        log << "Attempting ";
         choice->print(log, &CS.getASTContext().SourceMgr, CS.solverState->getCurrentIndent() + 2);
         log << '\n';
       }
@@ -557,7 +559,7 @@ public:
       }
 
       if (CS.isDebugMode())
-        getDebugLogger() << ")\n";
+        getDebugLogger() << "}\n";
 
       // If this binding didn't match, let's check if we've attempted
       // enough bindings to stop, because some producers might need

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -1604,49 +1604,43 @@ void ConstraintGraph::dumpActiveScopeChanges(llvm::raw_ostream &out,
   PrintOptions PO;
   PO.PrintTypesForDebugging = true;
   out.indent(indent);
-  out << "(Changes:\n";
+  out << "Changes:\n";
   if (!tvWithboundTypes.empty()) {
     out.indent(indent + 2);
-    out << "(Newly Bound: \n";
+    out << "Newly Bound: \n";
     for (const auto &tvWithType : tvWithboundTypes) {
       out.indent(indent + 4);
       out << "> $T" << tvWithType.first->getImpl().getID() << " := ";
       tvWithType.second->print(out, PO);
       out << '\n';
     }
-    out.indent(indent + 2);
-    out << ")\n";
   }
   if (!addedTypeVars.empty()) {
     out.indent(indent + 2);
-    auto heading = (addedTypeVars.size() > 1) ? "(New Type Variables: \n"
-                                              : "(New Type Variable: \n";
+    auto heading = (addedTypeVars.size() > 1) ? "New Type Variables: \n"
+                                              : "New Type Variable: \n";
     out << heading;
     for (const auto &typeVar : addedTypeVars) {
       out.indent(indent + 4);
       out << "> $T" << typeVar->getImpl().getID();
       out << '\n';
     }
-    out.indent(indent + 2);
-    out << ")\n";
   }
   if (!equivTypeVars.empty()) {
     out.indent(indent + 2);
-    auto heading = (equivTypeVars.size() > 1) ? "(New Equivalences: \n"
-                                              : "(New Equivalence: \n";
+    auto heading = (equivTypeVars.size() > 1) ? "New Equivalences: \n"
+                                              : "New Equivalence: \n";
     out << heading;
     for (const auto &typeVar : equivTypeVars) {
       out.indent(indent + 4);
       out << "> $T" << typeVar->getImpl().getID();
       out << '\n';
     }
-    out.indent(indent + 2);
-    out << ")\n";
   }
   if (!addedConstraints.empty()) {
     out.indent(indent + 2);
-    auto heading = (addedConstraints.size() > 1) ? "(Added Constraints: \n"
-                                                 : "(Added Constraint: \n";
+    auto heading = (addedConstraints.size() > 1) ? "Added Constraints: \n"
+                                                 : "Added Constraint: \n";
     out << heading;
     for (const auto &constraint : addedConstraints) {
       out.indent(indent + 4);
@@ -1654,13 +1648,11 @@ void ConstraintGraph::dumpActiveScopeChanges(llvm::raw_ostream &out,
       constraint->print(out, &CS.getASTContext().SourceMgr, indent + 6);
       out << '\n';
     }
-    out.indent(indent + 2);
-    out << ")\n";
   }
   if (!removedConstraints.empty()) {
     out.indent(indent + 2);
-    auto heading = (removedConstraints.size() > 1) ? "(Removed Constraints: \n"
-                                                   : "(Removed Constraint: \n";
+    auto heading = (removedConstraints.size() > 1) ? "Removed Constraints: \n"
+                                                   : "Removed Constraint: \n";
     out << heading;
     for (const auto &constraint : removedConstraints) {
       out.indent(indent + 4);
@@ -1668,11 +1660,8 @@ void ConstraintGraph::dumpActiveScopeChanges(llvm::raw_ostream &out,
       constraint->print(out, &CS.getASTContext().SourceMgr, indent + 6);
       out << '\n';
     }
-    out.indent(indent + 2);
-    out << ")\n";
   }
-  out.indent(indent);
-  out << ")\n";
+  out << '\n';
 }
 
 void ConstraintGraph::printConnectedComponents(

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -1603,65 +1603,74 @@ void ConstraintGraph::dumpActiveScopeChanges(llvm::raw_ostream &out,
   // Print out Changes.
   PrintOptions PO;
   PO.PrintTypesForDebugging = true;
-  out.indent(indent);
-  out << "Changes:\n";
+  out.indent(indent) << "|"
+                     << "\n";
+  ;
+  out.indent(indent) << "|  * Changes:\n";
+  //  out.indent(2) << "* Changes:\n";
   if (!tvWithboundTypes.empty()) {
-    out.indent(indent + 2);
-    out << "Newly Bound: \n";
+    out.indent(indent) << "|";
+    out.indent(2) << "| Newly Bound: \n";
     for (const auto &tvWithType : tvWithboundTypes) {
-      out.indent(indent + 4);
-      out << "> $T" << tvWithType.first->getImpl().getID() << " := ";
+      out.indent(indent) << "|";
+      out.indent(2) << "|";
+      out.indent(2) << "> $T" << tvWithType.first->getImpl().getID() << " := ";
       tvWithType.second->print(out, PO);
       out << '\n';
     }
   }
   if (!addedTypeVars.empty()) {
-    out.indent(indent + 2);
-    auto heading = (addedTypeVars.size() > 1) ? "New Type Variables: \n"
-                                              : "New Type Variable: \n";
-    out << heading;
+    out.indent(indent) << "|";
+    auto heading = (addedTypeVars.size() > 1) ? "| New Type Variables: \n"
+                                              : "| New Type Variable: \n";
+    out.indent(2) << heading;
     for (const auto &typeVar : addedTypeVars) {
-      out.indent(indent + 4);
-      out << "> $T" << typeVar->getImpl().getID();
+      out.indent(indent) << "|";
+      out.indent(2) << "|";
+      out.indent(2) << "> $T" << typeVar->getImpl().getID();
       out << '\n';
     }
   }
   if (!equivTypeVars.empty()) {
-    out.indent(indent + 2);
-    auto heading = (equivTypeVars.size() > 1) ? "New Equivalences: \n"
-                                              : "New Equivalence: \n";
-    out << heading;
+    out.indent(indent) << "|";
+    auto heading = (equivTypeVars.size() > 1) ? "| New Equivalences: \n"
+                                              : "| New Equivalence: \n";
+    out.indent(2) << heading;
     for (const auto &typeVar : equivTypeVars) {
-      out.indent(indent + 4);
-      out << "> $T" << typeVar->getImpl().getID();
+      out.indent(indent) << "|";
+      out.indent(2) << "|";
+      out.indent(2) << "> $T" << typeVar->getImpl().getID();
       out << '\n';
     }
   }
   if (!addedConstraints.empty()) {
-    out.indent(indent + 2);
-    auto heading = (addedConstraints.size() > 1) ? "Added Constraints: \n"
-                                                 : "Added Constraint: \n";
-    out << heading;
+    out.indent(indent) << "|";
+    auto heading = (addedConstraints.size() > 1) ? "| Added Constraints: \n"
+                                                 : "| Added Constraint: \n";
+    out.indent(2) << heading;
     for (const auto &constraint : addedConstraints) {
-      out.indent(indent + 4);
-      out << "> ";
+      out.indent(indent) << "|";
+      out.indent(2) << "|";
+      out.indent(2) << "> ";
       constraint->print(out, &CS.getASTContext().SourceMgr, indent + 6);
       out << '\n';
     }
   }
   if (!removedConstraints.empty()) {
-    out.indent(indent + 2);
-    auto heading = (removedConstraints.size() > 1) ? "Removed Constraints: \n"
-                                                   : "Removed Constraint: \n";
-    out << heading;
+    out.indent(indent) << "|";
+    auto heading = (removedConstraints.size() > 1) ? "| Removed Constraints: \n"
+                                                   : "| Removed Constraint: \n";
+    out.indent(2) << heading;
     for (const auto &constraint : removedConstraints) {
-      out.indent(indent + 4);
-      out << "> ";
+      out.indent(indent) << "|";
+      out.indent(2) << "|";
+      out.indent(2) << "> ";
       constraint->print(out, &CS.getASTContext().SourceMgr, indent + 6);
       out << '\n';
     }
   }
-  out << '\n';
+  out.indent(indent) << "|"
+                     << "\n";
 }
 
 void ConstraintGraph::printConnectedComponents(

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3547,8 +3547,8 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
     PO.PrintTypesForDebugging = true;
 
     auto &log = llvm::errs();
-    log.indent(solverState ? solverState->getCurrentIndent() : 2);
-    log << "Overload set choice binding ";
+    log.indent(solverState ? solverState->getCurrentIndent() : 2) << "|";
+    log.indent(2) << "Overload set choice binding ";
     boundType->print(log, PO);
     log << " := ";
     adjustedRefType->print(log, PO);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3548,7 +3548,7 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
 
     auto &log = llvm::errs();
     log.indent(solverState ? solverState->getCurrentIndent() : 2);
-    log << "(overload set choice binding ";
+    log << "Overload set choice binding ";
     boundType->print(log, PO);
     log << " := ";
     adjustedRefType->print(log, PO);
@@ -3566,7 +3566,7 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
           [&]() { log << ", "; });
       log << "]";
     }
-    log << ")\n";
+    log << "\n";
   }
 
   if (auto *decl = choice.getDeclOrNull()) {

--- a/test/Concurrency/async_overload_filtering.swift
+++ b/test/Concurrency/async_overload_filtering.swift
@@ -16,11 +16,11 @@ func filter_async(_: String) -> Void {}
 
 var a: String? = nil
 
-// CHECK: attempting disjunction choice $T0 bound to decl async_overload_filtering.(file).filter_async(fn2:)
-// CHECK-NEXT: overload set choice binding $T0 := {{.*}}
-// CHECK-NEXT: (considering -> ({{.*}}) -> {{.*}} applicable fn {{.*}}
-// CHECK: increasing 'sync-in-asynchronous' score by 1
-// CHECK: solution is worse than the best solution
+// CHECK: Attempting disjunction choice $T0 bound to decl async_overload_filtering.(file).filter_async(fn2:)
+// CHECK-NEXT: Overload set choice binding [[A:\$T[0-9]+]] := {{.*}}
+// CHECK: `-> Considering -> ({{.*}}) -> {{.*}} applicable fn [[A]]
+// CHECK: | `- Increasing 'sync-in-asynchronous' score by 1
+// CHECK: | Solution is worse than the best solution
 filter_async {
   Obj()
 }.op("" + (a ?? "a"))

--- a/test/Constraints/common_type.swift
+++ b/test/Constraints/common_type.swift
@@ -27,27 +27,27 @@ func f(_: Int) -> X { return X() }
 func f(_: Double) -> Y { return Y() }
 
 func testCallCommonType() {
-  // CHECK: overload set choice binding $T{{[0-9]+}} := (Int) -> X
-  // CHECK: (considering -> $T{{[0-9]+}}[.g: value] == [[G:\$T[0-9]+]]
-  // CHECK: (common result type for [[G]] is Int)
-  // CHECK: (overload set choice binding $T{{[0-9]+}} := (Double) -> Y)
-  // CHECK: (considering -> $T{{[0-9]+}}[.g: value] == [[F:\$T[0-9]+]]
-  // CHECK: (common result type for [[F]] is Double)
+  // CHECK: Overload set choice binding $T{{[0-9]+}} := (Int) -> X
+  // CHECK: `-> Considering -> $T{{[0-9]+}}[.g: value] == [[G:\$T[0-9]+]]
+  // CHECK: | Common result type for [[G]] is Int
+  // CHECK: Overload set choice binding $T{{[0-9]+}} := (Double) -> Y
+  // CHECK: `-> Considering -> $T{{[0-9]+}}[.g: value] == [[F:\$T[0-9]+]]
+  // CHECK: | Common result type for [[F]] is Double
   _ = f(0).g(0)
 }
 
 func testSubscriptCommonType() {
   // CHECK: subscript_expr
-  // CHECK: overload set choice binding $T{{[0-9]+}} := (Int) -> X
-  // CHECK: (common result type for $T{{[0-9]+}} is String)
-  // CHECK: (overload set choice binding $T{{[0-9]+}} := (Double) -> Y)
-  // CHECK: (common result type for $T{{[0-9]+}} is Substring)
+  // CHECK: Overload set choice binding $T{{[0-9]+}} := (Int) -> X
+  // CHECK: | Common result type for $T{{[0-9]+}} is String
+  // CHECK: Overload set choice binding $T{{[0-9]+}} := (Double) -> Y
+  // CHECK: | Common result type for $T{{[0-9]+}} is Substring
   _ = f(0)[0]
 }
 
 func testCommonTypeIUO() {
-  // CHECK: overload set choice binding $T{{[0-9]+}} := (Int) -> X
-  // CHECK-NOT: common result type
+  // CHECK:     Overload set choice binding $T{{[0-9]+}} := (Int) -> X
+  // CHECK-NOT: | Common result type
     _ = f(0).iuo(0)
 }
 
@@ -60,10 +60,10 @@ struct Z {
 }
 
 func testCommonTypeInit() {
-  // CHECK: common result type for {{.*}} is Z
+  // CHECK: | Common result type for {{.*}} is Z
   _ = Z(a: 0)
 
-  // CHECK-NOT: common result type
+  // CHECK-NOT: | Common result type
   _ = Z(b: 0)
 }
 
@@ -76,9 +76,9 @@ class InheritsDynamicSelf: DynamicSelf {
 }
 
 func testCommonTypeDynamicSelf(ds: DynamicSelf, ids: InheritsDynamicSelf) {
-  // CHECK: common result type for {{.*}} is DynamicSelf
+  // CHECK: | Common result type for {{.*}} is DynamicSelf
   _ = ds.foo(0)
-  // CHECK: common result type for {{.*}} is InheritsDynamicSelf
+  // CHECK: | Common result type for {{.*}} is InheritsDynamicSelf
   _ = ids.foo(0)
 }
 

--- a/test/Constraints/common_type_objc.swift
+++ b/test/Constraints/common_type_objc.swift
@@ -14,9 +14,9 @@ import Foundation
 }
 
 func testOptional(obj: P) {
-  // CHECK: common result type for {{.*}} is Int
+  // CHECK: | Common result type for {{.*}} is Int
   _ = obj.opt?(1)
 
-  // CHECK: common result type for {{.*}} is Int
+  // CHECK: | Common result type for {{.*}} is Int
   _ = obj.opt!(1)
 }

--- a/test/Constraints/one_way_solve.swift
+++ b/test/Constraints/one_way_solve.swift
@@ -27,23 +27,23 @@ func testTernaryOneWayOverload(b: Bool) {
   // CHECK: 2: $T{{[0-9]+}} $T{{[0-9]+}} $T{{[0-9]+}}
   // CHECK: 0: $T{{[0-9]+}} $T{{[0-9]+}} $T{{[0-9]+}}
 
-  // CHECK: solving component #1
-  // CHECK: (attempting type variable [[C]] := Int8
+  // CHECK: Solving component #1
+  // CHECK: Attempting type variable [[C]] := Int8
 
-  // CHECK: solving component #1
-  // CHECK: (attempting type variable [[C]] := Int8
+  // CHECK: Solving component #1
+  // CHECK: Attempting type variable [[C]] := Int8
 
-  // CHECK: solving component #1
-  // CHECK: (attempting type variable [[C]] := Int8
+  // CHECK: Solving component #1
+  // CHECK: Attempting type variable [[C]] := Int8
 
-  // CHECK: solving component #1
-  // CHECK: (attempting type variable [[C]] := Int8
-  // CHECK: (considering -> $T{{[0-9]+}} conv [[C]]
-  // CHECK: (considering -> $T{{[0-9]+}} conv [[C]]
-  // CHECK: (considering -> [[C]] conv Int8
-  // CHECK: (found solution: [component: non-default literal(s), value: 2] [component: use of overloaded unapplied function(s), value: 2])
+  // CHECK: Solving component #1
+  // CHECK: Attempting type variable [[C]] := Int8
+  // CHECK: `-> Considering -> [[A]] conv [[C]]
+  // CHECK: `-> Considering -> [[B]] conv [[C]]
+  // CHECK: `-> Considering -> [[C]] conv Int8
+  // CHECK: <! Found solution: [component: non-default literal(s), value: 2] [component: use of overloaded unapplied function(s), value: 2]>
 
-  // CHECK: (composed solution: [component: non-default literal(s), value: 2] [component: use of overloaded unapplied function(s), value: 2])
-  // CHECK-NOT: (composed solution: [component: non-default literal(s), value: 2] [component: use of overloaded unapplied function(s), value: 2])
+  // CHECK: <! Composed solution: [component: non-default literal(s), value: 2] [component: use of overloaded unapplied function(s), value: 2]>
+  // CHECK-NOT: <! Composed solution: [component: non-default literal(s), value: 2] [component: use of overloaded unapplied function(s), value: 2]>
   let _: Int8 = b ? Builtin.one_way(int8Or16(17)) : Builtin.one_way(int8Or16(42))
 }

--- a/test/Constraints/overload_filtering.swift
+++ b/test/Constraints/overload_filtering.swift
@@ -9,9 +9,9 @@ func foo(_: Int, _: Int) { }
 func foo(_: Int, _: Int, _: Int) { }
 
 func testModuleScope(i: Int) {
-  // CHECK: (disabled disjunction term {{.*}} (Int) -> ()
-  // CHECK-NEXT: (disabled disjunction term {{.*}} (Int, Int, Int) -> ()
-  // CHECK: (introducing single enabled disjunction term {{.*}} (Int, Int) -> ()
+  // CHECK:      | Disabled disjunction term {{.*}} (Int) -> ()
+  // CHECK-NEXT: | Disabled disjunction term {{.*}} (Int, Int, Int) -> ()
+  // CHECK:      | Introducing single enabled disjunction term {{.*}} (Int, Int) -> ()
   foo(i, i)
 }
 
@@ -26,20 +26,20 @@ struct X {
 }
 
 func testSubscript(x: X, i: Int) {
-  // CHECK: disabled disjunction term {{.*}}X.subscript(_:)
-  // CHECK-NEXT: disabled disjunction term {{.*}}X.subscript(_:_:_:)
-  // CHECK-NEXT: introducing single enabled disjunction term {{.*}} bound to decl overload_filtering.(file).X.subscript(_:_:)
+  // CHECK:      | Disabled disjunction term {{.*}}X.subscript(_:)
+  // CHECK-NEXT: | Disabled disjunction term {{.*}}X.subscript(_:_:_:)
+  // CHECK-NEXT: | Introducing single enabled disjunction term {{.*}} bound to decl overload_filtering.(file).X.subscript(_:_:)
   _ = x[i, i]
 }
 
 func testUnresolvedMember(i: Int) -> X {
-  // CHECK: disabled disjunction term {{.*}} bound to decl overload_filtering.(file).X.init(_:)
-  // CHECK-NEXT: disabled disjunction term {{.*}} bound to decl overload_filtering.(file).X.init(_:_:_:)
-  // CHECK-NEXT: (removed constraint: disjunction
+  // CHECK:      | Disabled disjunction term {{.*}} bound to decl overload_filtering.(file).X.init(_:)
+  // CHECK-NEXT: | Disabled disjunction term {{.*}} bound to decl overload_filtering.(file).X.init(_:_:_:)
+  // CHECK-NEXT: | `- Removed constraint: disjunction
   // CHECK-NEXT: > [[A:\$T[0-9]+]] bound to decl overload_filtering
   // CHECK-NEXT: > [disabled] [[A]] bound to decl overload_filtering
   // CHECK-NEXT: > [disabled] [[A]] bound to decl overload_filtering
-  // CHECK-NEXT: introducing single enabled disjunction term {{.*}} bound to decl overload_filtering.(file).X.init(_:_:)
+  // CHECK-NEXT: | Introducing single enabled disjunction term {{.*}} bound to decl overload_filtering.(file).X.init(_:_:)
   return .init(i, i)
 }
 
@@ -58,13 +58,13 @@ func test_member_filtering() {
   }
 
   func test(s: S) {
-    // CHECK: disabled disjunction term {{.*}} bound to decl overload_filtering.(file).test_member_filtering().S.bar(v:)
-    // CHECK-NEXT: disabled disjunction term {{.*}} bound to decl overload_filtering.(file).test_member_filtering().S.bar(a:b:)
-    // CHECK-NEXT: (removed constraint: disjunction
+    // CHECK:      | Disabled disjunction term {{.*}} bound to decl overload_filtering.(file).test_member_filtering().S.bar(v:)
+    // CHECK-NEXT: | Disabled disjunction term {{.*}} bound to decl overload_filtering.(file).test_member_filtering().S.bar(a:b:)
+    // CHECK-NEXT: `- Removed constraint: disjunction
     // CHECK-NEXT: > [[B:\$T[0-9]+]] bound to decl overload_filtering
     // CHECK-NEXT: > [disabled] [[B]] bound to decl overload_filtering
     // CHECK-NEXT: > [disabled] [[B]] bound to decl overload_filtering
-    // CHECK-NEXT: introducing single enabled disjunction term {{.*}} bound to decl overload_filtering.(file).test_member_filtering().S.bar
+    // CHECK-NEXT: | Introducing single enabled disjunction term {{.*}} bound to decl overload_filtering.(file).test_member_filtering().S.bar
     s.foo(42).bar(42)
   }
 }


### PR DESCRIPTION
This replaces the `()` grouping in the type inference debug output to use `|` instead to make it easier to follow nested solver steps.

```
  | Potential Binding(s): 
  `- $T1 [attributes: delayed, [literal: integer]] [with possible bindings: (default type of literal) Int]
  `- $T2 [attributes: delayed, [literal: string]] [with possible bindings: (default type of literal) String]
  `- Disjunction(s) = [$T0]
  {
    !> Attempting disjunction choice $T0 bound to decl Swift.(file).String extension.+ : (String.Type) -> (String, String) -> String [[locator@0x13e9bae00 [OverloadedDeclRef@/Users/amritpankaur/test.swift:81:3]]];
    |  Overload set choice binding $T0 := (String, String) -> String
    |
    `-> Considering -> (_const $T1, _const $T2) -> $T3 applicable fn $T0 [[locator@0x13e9bc5f0 [Binary@/Users/amritpankaur/test.swift:81:3 -> apply function]]];
    |  `- Simplification result:
    |    `- Added constraint: $T1 operator arg conv String [[locator@0x13e9bc6c0 [Binary@/Users/amritpankaur/test.swift:81:3 -> apply argument -> comparing call argument #0 to parameter #0]]];)
    |    `- Added constraint: $T2 operator arg conv String [[locator@0x13e9bc760 [Binary@/Users/amritpankaur/test.swift:81:3 -> apply argument -> comparing call argument #1 to parameter #1]]];)
    |    `- Removed constraint: (_const $T1, _const $T2) -> $T3 applicable fn $T0 [[locator@0x13e9bc5f0 [Binary@/Users/amritpankaur/test.swift:81:3 -> apply function]]];
    |  `-- Outcome: simplified
    |
    |  * Changes:
    |  | Newly Bound: 
    |  |  > $T0 := (String, String) -> String
    |  |  > $T3 := String
    |  | Added Constraints: 
    |  |  > $T1 operator arg conv String [[locator@0x13e9bc6c0 [Binary@/Users/amritpankaur/test.swift:81:3 -> apply argument -> comparing call argument #0 to parameter #0]]];
    |  |  > $T2 operator arg conv String [[locator@0x13e9bc760 [Binary@/Users/amritpankaur/test.swift:81:3 -> apply argument -> comparing call argument #1 to parameter #1]]];
    |  | Removed Constraint: 
    |  |  > (_const $T1, _const $T2) -> $T3 applicable fn $T0 [[locator@0x13e9bc5f0 [Binary@/Users/amritpankaur/test.swift:81:3 -> apply function]]];
    |
    ...
  }
```