### PR TITLE
Adapt `memberOf` Relationships Stemming from Default Implementations to Extension Block Symbol Format

### DIFF
--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -411,11 +411,21 @@ void SymbolGraph::recordDefaultImplementationRelationships(Symbol S) {
 
           // If P is from a different module, and it's being added to a type
           // from the current module, add a `memberOf` relation to the extended
-          // protocol.
+          // protocol or the respective extension block.
           if (!Walker.isOurModule(MemberVD->getModuleContext()) && VD->getDeclContext()) {
-            if (auto *ExP = VD->getDeclContext()->getSelfNominalTypeDecl()) {
+            if (const auto *Extension =
+                    dyn_cast_or_null<ExtensionDecl>(VD->getDeclContext())) {
+              if (this->Walker.shouldBeRecordedAsExtension(Extension)) {
+                recordEdge(Symbol(this, VD, nullptr),
+                           Symbol(this, Extension, nullptr),
+                           RelationshipKind::MemberOf());
+                continue;
+              }
+            }
+            if (auto *ExtendedProtocol =
+                    VD->getDeclContext()->getSelfNominalTypeDecl()) {
               recordEdge(Symbol(this, VD, nullptr),
-                         Symbol(this, ExP, nullptr),
+                         Symbol(this, ExtendedProtocol, nullptr),
                          RelationshipKind::MemberOf());
             }
           }

--- a/test/SymbolGraph/Relationships/DefaultImplementationOf/External.swift
+++ b/test/SymbolGraph/Relationships/DefaultImplementationOf/External.swift
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %S/Inputs/RemoteP.swift -module-name RemoteP -emit-module -emit-module-path %t/
+// RUN: %target-build-swift %s -module-name External -emit-module -emit-module-path %t/ -I %t
+// RUN: %target-swift-symbolgraph-extract -module-name External -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/External@RemoteP.symbols.json
+// RUN: %FileCheck %s --input-file %t/External@RemoteP.symbols.json --check-prefix MEMBER
+
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %S/Inputs/RemoteP.swift -module-name RemoteP -emit-module -emit-module-path %t/
+// RUN: %target-build-swift %s -module-name External -emit-module -emit-module-path %t/ -I %t
+// RUN: %target-swift-symbolgraph-extract -module-name External -I %t -pretty-print -output-dir %t -emit-extension-block-symbols
+// RUN: %FileCheck %s --input-file %t/External@RemoteP.symbols.json
+// RUN: %FileCheck %s --input-file %t/External@RemoteP.symbols.json --check-prefix MEMBEREBS
+// RUN: %FileCheck %s --input-file %t/External@RemoteP.symbols.json --check-prefix EXTENSIONTOEBS
+
+import RemoteP
+
+public extension RemoteP {
+    func someFunc() {}
+}
+
+// Default implementations that are for protocols in a different module should have a `memberOf`
+// relation linking them to a local symbol. If the default implementation is not defined on a local
+// protocol, the extension block symbol defining the default implementation should be the target
+// of the memberOf relationship.
+
+// CHECK:           "kind": "defaultImplementationOf"
+// CHECK-NEXT:      "source": "s:7RemotePAAP8ExternalE8someFuncyyF"
+// CHECK-NEXT:      "target": "s:7RemotePAAP8someFuncyyF"
+// CHECK-NEXT:      "targetFallback": "RemoteP.RemoteP.someFunc()"
+
+// MEMBER:           "kind": "memberOf"
+// MEMBER-NEXT:      "source": "s:7RemotePAAP8ExternalE8someFuncyyF"
+// MEMBER-NEXT:      "target": "s:7RemotePAAP"
+// MEMBER-NEXT:      "targetFallback": "RemoteP.RemoteP"
+
+// MEMBEREBS:        "kind": "memberOf"
+// MEMBEREBS-NEXT:   "source": "s:7RemotePAAP8ExternalE8someFuncyyF"
+// MEMBEREBS-NEXT:   "target": "s:e:s:7RemotePAAP8ExternalE8someFuncyyF"
+// MEMBEREBS-NEXT:   "targetFallback": "RemoteP.RemoteP"
+
+// EXTENSIONTOEBS:      "kind": "extensionTo"
+// EXTENSIONTOEBS-NEXT: "source": "s:e:s:7RemotePAAP8ExternalE8someFuncyyF"
+// EXTENSIONTOEBS-NEXT: "target": "s:7RemotePAAP"
+// EXTENSIONTOEBS-NEXT: "targetFallback": "RemoteP.RemoteP"

--- a/test/SymbolGraph/Relationships/DefaultImplementationOf/Remote.swift
+++ b/test/SymbolGraph/Relationships/DefaultImplementationOf/Remote.swift
@@ -5,6 +5,13 @@
 // RUN: %FileCheck %s --input-file %t/Remote.symbols.json
 // RUN: %FileCheck %s --input-file %t/Remote.symbols.json --check-prefix MEMBER
 
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %S/Inputs/RemoteP.swift -module-name RemoteP -emit-module -emit-module-path %t/
+// RUN: %target-build-swift %s -module-name Remote -emit-module -emit-module-path %t/ -I %t
+// RUN: %target-swift-symbolgraph-extract -module-name Remote -I %t -pretty-print -output-dir %t -emit-extension-block-symbols
+// RUN: %FileCheck %s --input-file %t/Remote.symbols.json
+// RUN: %FileCheck %s --input-file %t/Remote.symbols.json --check-prefix MEMBER
+
 import RemoteP
 
 public protocol LocalP: RemoteP {}
@@ -13,8 +20,9 @@ public extension LocalP {
     func someFunc() {}
 }
 
-// default implementations that are for protocols in a different module should have a `memberOf`
-// relation linking them to a local symbol, if one exists
+// Default implementations that are for protocols in a different module should have a `memberOf`
+// relation linking them to a local symbol. If the default implementation is defined on a local
+// protocol, this local protocol is the target of the memberOf relationship.
 
 // CHECK:           "kind": "defaultImplementationOf"
 // CHECK-NEXT:      "source": "s:6Remote6LocalPPAAE8someFuncyyF"


### PR DESCRIPTION
<!-- What's in this pull request? -->
This is a follow-up PR to #59047. It completes the implementation of the Extension Block Symbol Format by moving the target of `memberOf` that stem from default implementations to the extension block symbol. Of course, this only applies if the `-emit-extension-block-symbols` flag is used.

As `memberOf` relationships could already appear on `swift.extension` symbols prior to this commit, the Symbol Graph Format Version does not need to be increased and no change to apple/swift-docc is required.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
This is the last change to the actual symbol graph generation logic required to resolve apple/swift-docc#210.
A first follow-up PR will add a CLI flag for explicitly disabling the Extension Block Symbol Format and list the feature in [lib/Option/features.json](https://github.com/apple/swift/blob/main/lib/Option/features.json). A second and final follow-up PR will eventually make the Extension Block Symbol Format the default behavior.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
