### PR TITLE
[Threading][Tests] Don't test timeouts on threading=none.

### DIFF
--- a/unittests/Threading/ConditionVariable.cpp
+++ b/unittests/Threading/ConditionVariable.cpp
@@ -54,6 +54,7 @@ TEST(ConditionVariableTest, CriticalSectionThreaded) {
   criticalSectionThreaded(cond);
 }
 
+#if !SWIFT_THREADING_NONE
 // Check that timeouts work
 TEST(ConditionVariableTest, Timeout) {
   using namespace std::chrono_literals;
@@ -95,7 +96,6 @@ TEST(ConditionVariableTest, Timeout) {
   ASSERT_GE(duration.count(), 0.5);
 }
 
-#if !SWIFT_THREADING_NONE
 // Check that signal() wakes exactly one waiter
 TEST(ConditionVariableTest, Signal) {
   ConditionVariable cond;


### PR DESCRIPTION
The preprocessor condition stopping tests from running for `threading=none` was in slightly the wrong place.

rdar://100707643
