### PR TITLE
[Distributed] fix deprecation warning in `LocalTesting`

### DIFF
--- a/stdlib/public/Distributed/LocalTestingDistributedActorSystem.swift
+++ b/stdlib/public/Distributed/LocalTestingDistributedActorSystem.swift
@@ -27,7 +27,7 @@ import WinSDK
 /// prototyping stages of development where a real system is not necessary yet.
 @available(SwiftStdlib 5.7, *)
 public final class LocalTestingDistributedActorSystem: DistributedActorSystem, @unchecked Sendable {
-  public typealias ActorID = LocalTestingActorAddress
+  public typealias ActorID = LocalTestingActorID
   public typealias ResultHandler = LocalTestingInvocationResultHandler
   public typealias InvocationEncoder = LocalTestingInvocationEncoder
   public typealias InvocationDecoder = LocalTestingInvocationDecoder
@@ -114,12 +114,12 @@ public final class LocalTestingDistributedActorSystem: DistributedActorSystem, @
 
     init() {}
 
-    mutating func next() -> LocalTestingActorAddress {
+    mutating func next() -> LocalTestingActorID {
       let id: Int = self.counterLock.withLock {
         self.counter += 1
         return self.counter
       }
-      return LocalTestingActorAddress(parse: "\(id)")
+      return LocalTestingActorID(parse: "\(id)")
     }
   }
 }

--- a/stdlib/public/Distributed/LocalTestingDistributedActorSystem.swift
+++ b/stdlib/public/Distributed/LocalTestingDistributedActorSystem.swift
@@ -119,7 +119,7 @@ public final class LocalTestingDistributedActorSystem: DistributedActorSystem, @
         self.counter += 1
         return self.counter
       }
-      return LocalTestingActorID(parse: "\(id)")
+      return LocalTestingActorID(id: "\(id)")
     }
   }
 }


### PR DESCRIPTION
This change fixes following warnings:

```
LocalTestingDistributedActorSystem.swift:30:30: warning: 'LocalTestingActorAddress' is deprecated: renamed to 'LocalTestingActorID'
  public typealias ActorID = LocalTestingActorAddress
                             ^
LocalTestingDistributedActorSystem.swift:30:30: note: use 'LocalTestingActorID' instead
  public typealias ActorID = LocalTestingActorAddress
                             ^~~~~~~~~~~~~~~~~~~~~~~~
                             LocalTestingActorID
LocalTestingDistributedActorSystem.swift:117:29: warning: 'LocalTestingActorAddress' is deprecated: renamed to 'LocalTestingActorID'
    mutating func next() -> LocalTestingActorAddress {
                            ^
LocalTestingDistributedActorSystem.swift:117:29: note: use 'LocalTestingActorID' instead
    mutating func next() -> LocalTestingActorAddress {
                            ^~~~~~~~~~~~~~~~~~~~~~~~
                            LocalTestingActorID
```