### PR TITLE
[cxx-interop] Handle `std::string`s with `\0` character

### DIFF
--- a/stdlib/public/Cxx/std/String.swift
+++ b/stdlib/public/Cxx/std/String.swift
@@ -27,7 +27,12 @@ extension std.string: ExpressibleByStringLiteral {
 
 extension String {
   public init(cxxString: std.string) {
-    self.init(cString: cxxString.__c_strUnsafe())
+    let buffer = UnsafeBufferPointer<CChar>(
+      start: cxxString.__c_strUnsafe(),
+      count: cxxString.size())
+    self = buffer.withMemoryRebound(to: UInt8.self) {
+      String(decoding: $0, as: UTF8.self)
+    }
     withExtendedLifetime(cxxString) {}
   }
 }

--- a/test/Interop/Cxx/stdlib/overlay/std-string-overlay.swift
+++ b/test/Interop/Cxx/stdlib/overlay/std-string-overlay.swift
@@ -30,6 +30,11 @@ StdStringOverlayTestSuite.test("std::string <=> Swift.String") {
   expectEqual(cxx5.size(), 10)
   let swift5 = String(cxxString: cxx5)
   expectEqual(swift5, "emoji_🤖")
+
+  let cxx6 = std.string("xyz\0abc")
+  expectEqual(cxx6.size(), 7)
+  let swift6 = String(cxxString: cxx6)
+  expectEqual(swift6, "xyz\0abc")
 }
 
 extension std.string.const_iterator: UnsafeCxxInputIterator {


### PR DESCRIPTION
Previously the conversion mechanism called `std::string::c_str` and passed it to `String(cString:)` which accepts a null-terminated string. If the string contains a `\0` character, this failed to initialize the entire string properly.