### PR TITLE
Add replace self.init with Builtin.unreachable in Mirror

### DIFF
--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -482,8 +482,7 @@ public struct Mirror {
     displayStyle: DisplayStyle? = nil,
     ancestorRepresentation: AncestorRepresentation = .generated
   ) where C.Element == Child {
-    // FIXME: Can't use Builtin.unreachable() due to https://github.com/apple/swift/issues/57622.
-    self.init(reflecting: subject)
+    Builtin.unreachable()
   }
   public init<Subject, C: Collection>(
     _ subject: Subject,
@@ -491,8 +490,7 @@ public struct Mirror {
     displayStyle: DisplayStyle? = nil,
     ancestorRepresentation: AncestorRepresentation = .generated
   ) {
-    // FIXME: Can't use Builtin.unreachable() due to https://github.com/apple/swift/issues/57622.
-    self.init(reflecting: subject)
+    Builtin.unreachable()
   }
   public init<Subject>(
     _ subject: Subject,
@@ -500,8 +498,7 @@ public struct Mirror {
     displayStyle: DisplayStyle? = nil,
     ancestorRepresentation: AncestorRepresentation = .generated
   ) {
-    // FIXME: Can't use Builtin.unreachable() due to https://github.com/apple/swift/issues/57622.
-    self.init(reflecting: subject)
+    Builtin.unreachable()
   }
   public let subjectType: Any.Type
   public let children: Children


### PR DESCRIPTION
Replaced `self.init` calls with `Builtin.unreachable()` calls that was previously not allowed due to a (now fixed) issue. If you could have a look and run the CI bot, that would be appreciated @AnthonyLatsis, thanks.

Just a note I think that this change resulted in more "unsupported" test cases which may be something to check.

Resolves #61326 
