### PR TITLE
[SILOptimizer] NFC: Run type wrapper test-case only in asserts mode

### DIFF
--- a/test/SILOptimizer/type_wrapper_init_transform.swift
+++ b/test/SILOptimizer/type_wrapper_init_transform.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-frontend -enable-experimental-feature TypeWrappers -module-name test -disable-availability-checking -Xllvm -sil-print-after=definite-init -emit-sil %s -o /dev/null 2>&1 | %FileCheck %s
 
+// REQUIRES: asserts
+
 @typeWrapper
 public struct Wrapper<S> {
   var underlying: S


### PR DESCRIPTION
`TypeWrappers` feature is experimental and the flag is not supported in production compilers.

Resolves: rdar://100737643

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
