### PR TITLE
[Sema/DI] TypeWrappers: Add support for `let` properties

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6571,6 +6571,17 @@ ERROR(type_wrapper_requires_subscript,none,
       " - subscript(storedKeyPath:)",
       (DeclName))
 
+ERROR(type_wrapper_requires_readonly_subscript,none,
+      "type wrapper type %0 does not contain a required ready-only subscript",
+      (DeclName))
+
+ERROR(type_wrapper_requires_writable_subscript,none,
+      "type wrapper type %0 does not contain a required writable subscript",
+      (DeclName))
+
+NOTE(add_type_wrapper_subscript_stub_note,none,
+     "do you want to add a stub?", ())
+
 ERROR(type_wrapper_failable_init,none,
       "type wrapper initializer %0 cannot be failable", (DeclName))
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3771,6 +3771,9 @@ void AttributeChecker::visitTypeWrapperAttr(TypeWrapperAttr *attr) {
     llvm::SmallDenseMap<SubscriptDecl *, SmallVector<UnviabilityReason, 2>, 2>
         nonViableSubscripts;
 
+    bool hasReadOnly = false;
+    bool hasWritable = false;
+
     for (auto *decl : subscripts) {
       auto *subscript = cast<SubscriptDecl>(decl);
 
@@ -3782,6 +3785,10 @@ void AttributeChecker::visitTypeWrapperAttr(TypeWrapperAttr *attr) {
               BGT->isReferenceWritableKeyPath())) {
           nonViableSubscripts[subscript].push_back(
               UnviabilityReason::InvalidType);
+        } else {
+          hasReadOnly |= BGT->isKeyPath();
+          hasWritable |=
+              BGT->isWritableKeyPath() || BGT->isReferenceWritableKeyPath();
         }
       } else {
         nonViableSubscripts[subscript].push_back(
@@ -3791,6 +3798,41 @@ void AttributeChecker::visitTypeWrapperAttr(TypeWrapperAttr *attr) {
       if (isLessAccessibleThanType(subscript))
         nonViableSubscripts[subscript].push_back(
             UnviabilityReason::Inaccessible);
+    }
+
+    if (!hasReadOnly) {
+      auto &DE = ctx.Diags;
+      DE.diagnoseWithNotes(
+          DE.diagnose(nominal->getLoc(),
+                      diag::type_wrapper_requires_readonly_subscript,
+                      nominal->getName()),
+          [&]() {
+            DE.diagnose(nominal->getLoc(),
+                        diag::add_type_wrapper_subscript_stub_note)
+                .fixItInsertAfter(
+                    nominal->getBraces().Start,
+                    "\nsubscript<Value>(storageKeyPath path: KeyPath<<#Base#>, "
+                    "Value>) -> Value { get { <#code#> } }");
+          });
+      attr->setInvalid();
+    }
+
+    if (!hasWritable) {
+      auto &DE = ctx.Diags;
+      DE.diagnoseWithNotes(
+          DE.diagnose(nominal->getLoc(),
+                      diag::type_wrapper_requires_writable_subscript,
+                      nominal->getName()),
+          [&]() {
+            DE.diagnose(nominal->getLoc(),
+                        diag::add_type_wrapper_subscript_stub_note)
+                .fixItInsertAfter(
+                    nominal->getBraces().Start,
+                    "\nsubscript<Value>(storageKeyPath path: "
+                    "WritableKeyPath<<#Base#>, "
+                    "Value>) -> Value { get { <#code#> } set { <#code#> } }");
+          });
+      attr->setInvalid();
     }
 
     if (subscripts.size() - nonViableSubscripts.size() == 0) {

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -3306,7 +3306,8 @@ static void finishStorageImplInfo(AbstractStorageDecl *storage,
     } else if (var->hasAttachedPropertyWrapper()) {
       finishPropertyWrapperImplInfo(var, info);
     } else if (var->isAccessedViaTypeWrapper()) {
-      info = StorageImplInfo::getMutableComputed();
+      info = var->isLet() ? StorageImplInfo::getImmutableComputed()
+                          : StorageImplInfo::getMutableComputed();
     }
   }
 

--- a/lib/Sema/TypeCheckTypeWrapper.cpp
+++ b/lib/Sema/TypeCheckTypeWrapper.cpp
@@ -325,7 +325,7 @@ bool IsPropertyAccessedViaTypeWrapper::evaluate(Evaluator &evaluator,
   if (!(parent && parent->hasTypeWrapper()))
     return false;
 
-  if (property->isStatic() || property->isLet())
+  if (property->isStatic())
     return false;
 
   // If this property has `@typeWrapperIgnored` attribute

--- a/test/Interpreter/Inputs/type_wrapper_defs.swift
+++ b/test/Interpreter/Inputs/type_wrapper_defs.swift
@@ -7,6 +7,13 @@ public struct Wrapper<S> {
     self.underlying = memberwise
   }
 
+  public subscript<V>(storageKeyPath path: KeyPath<S, V>) -> V {
+    get {
+      print("in read-only getter")
+      return underlying[keyPath: path]
+    }
+  }
+
   public subscript<V>(storageKeyPath path: WritableKeyPath<S, V>) -> V {
     get {
       print("in getter")

--- a/test/Interpreter/Inputs/type_wrapper_defs.swift
+++ b/test/Interpreter/Inputs/type_wrapper_defs.swift
@@ -310,3 +310,31 @@ public class ClassWithConvenienceInit<T> {
     print(self.b)
   }
 }
+
+@Wrapper
+public struct TypeWithLetProperties<T> {
+  let a: T
+  let b: Int
+
+  public init(a: T, b: Int? = nil, onSet: (() -> Void)? = nil) {
+    self.a = a
+    if let b {
+      self.b = b
+    } else {
+      self.b = 0
+    }
+
+    print("--Before onSet--")
+
+    print(self.a)
+    print(self.b)
+
+    if let onSet {
+      onSet()
+
+      print("--After onSet--")
+      print(self.a)
+      print(self.b)
+    }
+  }
+}

--- a/test/Interpreter/type_wrappers.swift
+++ b/test/Interpreter/type_wrappers.swift
@@ -588,3 +588,38 @@ do {
   // CHECK-NEXT: in getter
   // CHECK-NEXT: Optional((-1, "ultimate question", (a: 1, b: 2.0, c: 3)))
 }
+
+do {
+  class X : CustomStringConvertible {
+    var x: [Int] = []
+
+    var description: String {
+      "X(x: \(x))"
+    }
+  }
+
+  var arg = X()
+
+  let test1 = TypeWithLetProperties(a: arg, b: 42) {
+    arg.x.append(1)
+  }
+  // CHECK: Wrapper.init($Storage(a: X(x: []), b: 42))
+  // CHECK-NEXT: --Before onSet--
+  // CHECK-NEXT: in read-only getter
+  // CHECK-NEXT: X(x: [])
+  // CHECK-NEXT: in read-only getter
+  // CHECK-NEXT: 42
+  // CHECK-NEXT: --After onSet--
+  // CHECK-NEXT: in read-only getter
+  // CHECK-NEXT: X(x: [1])
+  // CHECK-NEXT: in read-only getter
+  // CHECK-nEXT: 42
+
+  let test2 = TypeWithLetProperties(a: Optional.some([1, 2, 3]))
+  // CHECK: Wrapper.init($Storage(a: Optional([1, 2, 3]), b: 0))
+  // CHECK-NEXT: --Before onSet--
+  // CHECK-NEXT: in read-only getter
+  // CHECK-NEXT: Optional([1, 2, 3])
+  // CHECK-NEXT: in read-only getter
+  // CHECK-NEXT: 0
+}

--- a/test/Interpreter/type_wrappers.swift
+++ b/test/Interpreter/type_wrappers.swift
@@ -358,10 +358,11 @@ testPropertyWrappers()
 
 do {
   var person = PersonWithUnmanagedTest(name: "Arthur Dent")
-  // CHECK: Wrapper.init($Storage(_favoredColor: type_wrapper_defs.PropWrapper<Swift.String>(value: "red")))
+  // CHECK: Wrapper.init($Storage(name: "Arthur Dent", _favoredColor: type_wrapper_defs.PropWrapper<Swift.String>(value: "red")))
 
   print(person.name)
-  // CHECK: Arthur Dent
+  // CHECK: in read-only getter
+  // CHECK-NEXT: Arthur Dent
 
   print(person.age)
   // CHECK: 30

--- a/test/SILOptimizer/type_wrapper_definite_init_diagnostics.swift
+++ b/test/SILOptimizer/type_wrapper_definite_init_diagnostics.swift
@@ -1,0 +1,91 @@
+// RUN: %target-swift-frontend -enable-experimental-feature TypeWrappers -enable-copy-propagation=requested-passes-only -emit-sil -primary-file %s -o /dev/null -verify
+
+// REQUIRES: asserts
+
+@typeWrapper
+struct Wrapper<S> {
+  var underlying: S
+
+  init(memberwise: S) { self.underlying = memberwise }
+
+  subscript<V>(storageKeyPath path: KeyPath<S, V>) -> V {
+    get { underlying[keyPath: path] }
+  }
+
+  subscript<V>(storageKeyPath path: WritableKeyPath<S, V>) -> V {
+    get { underlying[keyPath: path] }
+    set { underlying[keyPath: path] = newValue }
+  }
+}
+
+do {
+  @Wrapper
+  struct ImmutableTest1 {
+    let x: Int
+
+    init(x: Int) {
+      self.x = x
+      self.x = 0 // expected-error {{immutable value 'self.x' may only be initialized once}}
+    }
+  }
+
+  @Wrapper
+  class ImmutableTest2 {
+    let a: Int
+    let b: String
+
+    init(a: Int, b: String) {
+      self.a = 0
+      self.a = a // expected-error {{immutable value 'self.a' may only be initialized once}}
+
+      self.b = b
+      self.b = "" // expected-error {{immutable value 'self.b' may only be initialized once}}
+    }
+  }
+
+  // FIXME: Diagnostics should mention `self.b` or `self.a` and not `self.$_storage`
+
+  @Wrapper
+  struct ImmutableTest3 {
+    let a: Int
+    let b: String
+
+    init() {
+      self.b = "" // Ok
+      self.a = 42 // Ok
+    }
+
+    init(a: Int = 42) {
+      self.a = a
+      print(self.a) // expected-error {{'self' used before all stored properties are initialized}} expected-note {{'self.$_storage' not initialized}}
+      self.b = ""
+    }
+
+    /* FIXME: This test is crashing in findFullInitializationPoints
+    init(b: String) {
+      self.b = b
+      print(self.a)
+    }
+    */
+
+    init(otherB: String?) {
+      self.a = 0
+
+      if let b = otherB {
+        self.b = b
+      }
+    } // expected-error {{return from initializer without initializing all stored properties}} expected-note {{'self.$_storage' not initialized}}
+
+    init(optB: String? = nil) {
+      if let optB {
+        self.b = optB
+        print(self.b) // expected-error {{'self' used before all stored properties are initialized}} expected-note {{'self.$_storage' not initialized}}
+      } else {
+        self.b = ""
+        print(self.b) // expected-error {{'self' used before all stored properties are initialized}} expected-note {{'self.$_storage' not initialized}}
+      }
+
+      self.a = 0
+    }
+  }
+}

--- a/test/SILOptimizer/type_wrapper_in_user_defined_init_lowering.sil
+++ b/test/SILOptimizer/type_wrapper_in_user_defined_init_lowering.sil
@@ -9,6 +9,7 @@ import SwiftShims
 @typeWrapper class MyWrapper<S> {
   @_hasStorage var underlying: S { get set }
   init(memberwise s: S)
+  subscript<V>(storageKeyPath path: KeyPath<S, V>) -> V { get }
   subscript<V>(storageKeyPath path: WritableKeyPath<S, V>) -> V { get set }
   deinit
 }

--- a/test/type/type_wrapper.swift
+++ b/test/type/type_wrapper.swift
@@ -480,3 +480,26 @@ func testMissingReadOnlyAndWritableSubscriptsAreDiagnosed() {
     }
   }
 }
+
+func testIncorrectUsesOfImmutableProperties() {
+  class X<T> {
+    var storage: [T]
+
+    init(storage: [T]) {
+      self.storage = storage
+    }
+  }
+
+  @NoopWrapper
+  struct Test<T> {
+    let x: T? // expected-note {{change 'let' to 'var' to make it mutable}}
+
+    init(x: T) {
+      self.x = x
+    }
+  }
+
+  let test = Test(x: X(storage: [1, 2, 3]))
+  test.x = X(storage: [0]) // expected-error {{cannot assign to property: 'x' is a 'let' constant}}
+  test.x?.storage.append(0) // Ok
+}

--- a/test/type/type_wrapper.swift
+++ b/test/type/type_wrapper.swift
@@ -351,7 +351,7 @@ func testDeclarationsWithUnmanagedProperties() {
   }
 
   _ = WithDefaultedLet(age: 32) // Ok
-  _ = WithDefaultedLet(name: "", age: 0) // expected-error {{extra argument 'name' in call}}
+  _ = WithDefaultedLet(name: "", age: 0) // Ok
 
   @NoopWrapper
   struct WithLazy {


### PR DESCRIPTION
Allow type wrappers to managed `let` properties. This means that a
type wrapper needs to declare both read-only and writable subscripts.

Resolves: rdar://100425719

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
