### PR TITLE
[AST] Move generic parameter logic for accessor decl from parser to GenericParamListRequest

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -7133,32 +7133,24 @@ class AccessorDecl final : public FuncDecl {
                AccessorKind accessorKind, AbstractStorageDecl *storage,
                SourceLoc staticLoc, StaticSpellingKind staticSpelling,
                bool async, SourceLoc asyncLoc, bool throws, SourceLoc throwsLoc,
-               bool hasImplicitSelfDecl, GenericParamList *genericParams,
-               DeclContext *parent)
-    : FuncDecl(DeclKind::Accessor,
-               staticLoc, staticSpelling, /*func loc*/ declLoc,
-               /*name*/ Identifier(), /*name loc*/ declLoc,
-               async, asyncLoc, throws, throwsLoc,
-               hasImplicitSelfDecl, genericParams, parent),
-      AccessorKeywordLoc(accessorKeywordLoc),
-      Storage(storage) {
+               bool hasImplicitSelfDecl, DeclContext *parent)
+      : FuncDecl(DeclKind::Accessor, staticLoc, staticSpelling,
+                 /*func loc*/ declLoc,
+                 /*name*/ Identifier(), /*name loc*/ declLoc, async, asyncLoc,
+                 throws, throwsLoc, hasImplicitSelfDecl,
+                 /*genericParams*/ nullptr, parent),
+        AccessorKeywordLoc(accessorKeywordLoc), Storage(storage) {
     assert(!async || accessorKind == AccessorKind::Get
            && "only get accessors can be async");
     Bits.AccessorDecl.AccessorKind = unsigned(accessorKind);
   }
 
-  static AccessorDecl *createImpl(ASTContext &ctx,
-                                  SourceLoc declLoc,
-                                  SourceLoc accessorKeywordLoc,
-                                  AccessorKind accessorKind,
-                                  AbstractStorageDecl *storage,
-                                  SourceLoc staticLoc,
-                                  StaticSpellingKind staticSpelling,
-                                  bool async, SourceLoc asyncLoc,
-                                  bool throws, SourceLoc throwsLoc,
-                                  GenericParamList *genericParams,
-                                  DeclContext *parent,
-                                  ClangNode clangNode);
+  static AccessorDecl *
+  createImpl(ASTContext &ctx, SourceLoc declLoc, SourceLoc accessorKeywordLoc,
+             AccessorKind accessorKind, AbstractStorageDecl *storage,
+             SourceLoc staticLoc, StaticSpellingKind staticSpelling, bool async,
+             SourceLoc asyncLoc, bool throws, SourceLoc throwsLoc,
+             DeclContext *parent, ClangNode clangNode);
 
   Optional<bool> getCachedIsTransparent() const {
     if (Bits.AccessorDecl.IsTransparentComputed)
@@ -7174,21 +7166,15 @@ public:
                                           AbstractStorageDecl *storage,
                                           StaticSpellingKind staticSpelling,
                                           bool async, bool throws,
-                                          GenericParamList *genericParams,
                                           Type fnRetType, DeclContext *parent);
 
-  static AccessorDecl *create(ASTContext &ctx, SourceLoc declLoc,
-                              SourceLoc accessorKeywordLoc,
-                              AccessorKind accessorKind,
-                              AbstractStorageDecl *storage,
-                              SourceLoc staticLoc,
-                              StaticSpellingKind staticSpelling,
-                              bool async, SourceLoc asyncLoc,
-                              bool throws, SourceLoc throwsLoc,
-                              GenericParamList *genericParams,
-                              ParameterList *parameterList,
-                              Type fnRetType, DeclContext *parent,
-                              ClangNode clangNode = ClangNode());
+  static AccessorDecl *
+  create(ASTContext &ctx, SourceLoc declLoc, SourceLoc accessorKeywordLoc,
+         AccessorKind accessorKind, AbstractStorageDecl *storage,
+         SourceLoc staticLoc, StaticSpellingKind staticSpelling, bool async,
+         SourceLoc asyncLoc, bool throws, SourceLoc throwsLoc,
+         ParameterList *parameterList, Type fnRetType, DeclContext *parent,
+         ClangNode clangNode = ClangNode());
 
   SourceLoc getAccessorKeywordLoc() const { return AccessorKeywordLoc; }
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1242,10 +1242,8 @@ public:
                bool HasLetOrVarKeyword = true);
 
   struct ParsedAccessors;
-  ParserStatus parseGetSet(ParseDeclOptions Flags,
-                           GenericParamList *GenericParams,
-                           ParameterList *Indices, TypeRepr *ResultType,
-                           ParsedAccessors &accessors,
+  ParserStatus parseGetSet(ParseDeclOptions Flags, ParameterList *Indices,
+                           TypeRepr *ResultType, ParsedAccessors &accessors,
                            AbstractStorageDecl *storage, SourceLoc StaticLoc);
   ParserResult<VarDecl> parseDeclVarGetSet(PatternBindingEntry &entry,
                                            ParseDeclOptions Flags,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -8560,18 +8560,12 @@ bool FuncDecl::isStatic() const {
     false);
 }
 
-AccessorDecl *AccessorDecl::createImpl(ASTContext &ctx,
-                                       SourceLoc declLoc,
-                                       SourceLoc accessorKeywordLoc,
-                                       AccessorKind accessorKind,
-                                       AbstractStorageDecl *storage,
-                                       SourceLoc staticLoc,
-                                       StaticSpellingKind staticSpelling,
-                                       bool async, SourceLoc asyncLoc,
-                                       bool throws, SourceLoc throwsLoc,
-                                       GenericParamList *genericParams,
-                                       DeclContext *parent,
-                                       ClangNode clangNode) {
+AccessorDecl *AccessorDecl::createImpl(
+    ASTContext &ctx, SourceLoc declLoc, SourceLoc accessorKeywordLoc,
+    AccessorKind accessorKind, AbstractStorageDecl *storage,
+    SourceLoc staticLoc, StaticSpellingKind staticSpelling, bool async,
+    SourceLoc asyncLoc, bool throws, SourceLoc throwsLoc, DeclContext *parent,
+    ClangNode clangNode) {
   bool hasImplicitSelfDecl = parent->isTypeContext();
   size_t size = sizeof(AccessorDecl) + (hasImplicitSelfDecl
                                         ? sizeof(ParamDecl *)
@@ -8579,9 +8573,9 @@ AccessorDecl *AccessorDecl::createImpl(ASTContext &ctx,
   void *buffer = allocateMemoryForDecl<AccessorDecl>(ctx, size,
                                                      !clangNode.isNull());
   auto D = ::new (buffer)
-      AccessorDecl(declLoc, accessorKeywordLoc, accessorKind,
-                   storage, staticLoc, staticSpelling, async, asyncLoc, throws, throwsLoc,
-                   hasImplicitSelfDecl, genericParams, parent);
+      AccessorDecl(declLoc, accessorKeywordLoc, accessorKind, storage,
+                   staticLoc, staticSpelling, async, asyncLoc, throws,
+                   throwsLoc, hasImplicitSelfDecl, parent);
   if (clangNode)
     D->setClangNode(clangNode);
   if (hasImplicitSelfDecl)
@@ -8590,38 +8584,30 @@ AccessorDecl *AccessorDecl::createImpl(ASTContext &ctx,
   return D;
 }
 
-AccessorDecl *
-AccessorDecl::createDeserialized(ASTContext &ctx, AccessorKind accessorKind,
-                                 AbstractStorageDecl *storage,
-                                 StaticSpellingKind staticSpelling,
-                                 bool async, bool throws, GenericParamList *genericParams,
-                                 Type fnRetType, DeclContext *parent) {
+AccessorDecl *AccessorDecl::createDeserialized(
+    ASTContext &ctx, AccessorKind accessorKind, AbstractStorageDecl *storage,
+    StaticSpellingKind staticSpelling, bool async, bool throws, Type fnRetType,
+    DeclContext *parent) {
   assert(fnRetType && "Deserialized result type must not be null");
   auto *const D = AccessorDecl::createImpl(
       ctx, SourceLoc(), SourceLoc(), accessorKind, storage, SourceLoc(),
-      staticSpelling, async, SourceLoc(), throws, SourceLoc(), genericParams, parent, ClangNode());
+      staticSpelling, async, SourceLoc(), throws, SourceLoc(), parent,
+      ClangNode());
   D->setResultInterfaceType(fnRetType);
   return D;
 }
 
-AccessorDecl *AccessorDecl::create(ASTContext &ctx,
-                                   SourceLoc declLoc,
-                                   SourceLoc accessorKeywordLoc,
-                                   AccessorKind accessorKind,
-                                   AbstractStorageDecl *storage,
-                                   SourceLoc staticLoc,
-                                   StaticSpellingKind staticSpelling,
-                                   bool async, SourceLoc asyncLoc,
-                                   bool throws, SourceLoc throwsLoc,
-                                   GenericParamList *genericParams,
-                                   ParameterList * bodyParams,
-                                   Type fnRetType,
-                                   DeclContext *parent,
-                                   ClangNode clangNode) {
+AccessorDecl *
+AccessorDecl::create(ASTContext &ctx, SourceLoc declLoc,
+                     SourceLoc accessorKeywordLoc, AccessorKind accessorKind,
+                     AbstractStorageDecl *storage, SourceLoc staticLoc,
+                     StaticSpellingKind staticSpelling, bool async,
+                     SourceLoc asyncLoc, bool throws, SourceLoc throwsLoc,
+                     ParameterList *bodyParams, Type fnRetType,
+                     DeclContext *parent, ClangNode clangNode) {
   auto *D = AccessorDecl::createImpl(
-      ctx, declLoc, accessorKeywordLoc, accessorKind, storage,
-      staticLoc, staticSpelling, async, asyncLoc, throws, throwsLoc,
-      genericParams, parent, clangNode);
+      ctx, declLoc, accessorKeywordLoc, accessorKind, storage, staticLoc,
+      staticSpelling, async, asyncLoc, throws, throwsLoc, parent, clangNode);
   D->setParameters(bodyParams);
   D->setResultInterfaceType(fnRetType);
   return D;
@@ -9517,7 +9503,6 @@ bool ActorIsolation::isDistributedActor() const {
   return getKind() == ActorInstance && getActor()->isDistributedActor();
 }
 
-BuiltinTupleDecl::BuiltinTupleDecl(Identifier Name,
-                                   DeclContext *Parent)
-  : NominalTypeDecl(DeclKind::BuiltinTuple, Parent, Name, SourceLoc(),
-                    ArrayRef<InheritedEntry>(), nullptr) {}
+BuiltinTupleDecl::BuiltinTupleDecl(Identifier Name, DeclContext *Parent)
+    : NominalTypeDecl(DeclKind::BuiltinTuple, Parent, Name, SourceLoc(),
+                      ArrayRef<InheritedEntry>(), nullptr) {}

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2845,6 +2845,11 @@ createOpaqueParameterGenericParams(GenericContext *genericContext, GenericParamL
   if (!value)
     return { };
 
+  // Consider storage signature opaque parameters for accessor declaration. 
+  if (auto *AD = dyn_cast<AccessorDecl>(value)) {
+    value = AD->getStorage();
+  }
+
   // Functions, initializers, and subscripts can contain opaque parameters.
   ParameterList *params = nullptr;
   if (auto func = dyn_cast<AbstractFunctionDecl>(value))

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2845,11 +2845,6 @@ createOpaqueParameterGenericParams(GenericContext *genericContext, GenericParamL
   if (!value)
     return { };
 
-  // Consider storage signature opaque parameters for accessor declaration. 
-  if (auto *AD = dyn_cast<AccessorDecl>(value)) {
-    value = AD->getStorage();
-  }
-
   // Functions, initializers, and subscripts can contain opaque parameters.
   ParameterList *params = nullptr;
   if (auto func = dyn_cast<AbstractFunctionDecl>(value))
@@ -2964,6 +2959,20 @@ GenericParamListRequest::evaluate(Evaluator &evaluator, GenericContext *value) c
     auto result = GenericParamList::create(ctx, SourceLoc(), selfDecl,
                                            SourceLoc());
     return result;
+  }
+
+  // AccessorDecl generic parameter list is the same of its storage
+  // context.
+  if (auto *AD = dyn_cast<AccessorDecl>(value)) {
+    auto *GC = AD->getStorage()->getAsGenericContext();
+    if (!GC)
+      return nullptr;
+
+    auto *GP = GC->getGenericParams();
+    if (!GP)
+      return nullptr;
+
+    return GP->clone(AD->getDeclContext());
   }
 
   auto parsedGenericParams = value->getParsedGenericParams();

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4775,9 +4775,7 @@ makeBaseClassMemberAccessors(DeclContext *declContext,
       StaticSpellingKind::None, // TODO: we should handle static vars.
       /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
       /*Throws=*/false,
-      /*ThrowsLoc=*/SourceLoc(),
-      /*GenericParams=*/nullptr, bodyParams, computedType,
-      declContext);
+      /*ThrowsLoc=*/SourceLoc(), bodyParams, computedType, declContext);
   getterDecl->setIsTransparent(true);
   getterDecl->setAccess(AccessLevel::Public);
   getterDecl->setBodySynthesizer(synthesizeBaseClassFieldGetterBody,
@@ -4809,9 +4807,8 @@ makeBaseClassMemberAccessors(DeclContext *declContext,
       StaticSpellingKind::None, // TODO: we should handle static vars.
       /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
       /*Throws=*/false,
-      /*ThrowsLoc=*/SourceLoc(),
-      /*GenericParams=*/nullptr, setterBodyParams,
-      TupleType::getEmpty(ctx), declContext);
+      /*ThrowsLoc=*/SourceLoc(), setterBodyParams, TupleType::getEmpty(ctx),
+      declContext);
   setterDecl->setIsTransparent(true);
   setterDecl->setAccess(AccessLevel::Public);
   setterDecl->setBodySynthesizer(synthesizeBaseClassFieldSetterBody,

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -106,15 +106,13 @@ static FuncDecl *createFuncOrAccessor(ClangImporter::Implementation &impl,
                                       ClangNode clangNode) {
   FuncDecl *decl;
   if (accessorInfo) {
-    decl = AccessorDecl::create(impl.SwiftContext, funcLoc,
-                                /*accessorKeywordLoc*/ SourceLoc(),
-                                accessorInfo->Kind, accessorInfo->Storage,
-                                /*StaticLoc*/ SourceLoc(),
-                                StaticSpellingKind::None,
-                                async, /*AsyncLoc=*/SourceLoc(),
-                                throws, /*ThrowsLoc=*/SourceLoc(),
-                                genericParams, bodyParams,
-                                resultTy, dc, clangNode);
+    decl = AccessorDecl::create(
+        impl.SwiftContext, funcLoc,
+        /*accessorKeywordLoc*/ SourceLoc(), accessorInfo->Kind,
+        accessorInfo->Storage,
+        /*StaticLoc*/ SourceLoc(), StaticSpellingKind::None, async,
+        /*AsyncLoc=*/SourceLoc(), throws, /*ThrowsLoc=*/SourceLoc(), bodyParams,
+        resultTy, dc, clangNode);
   } else {
     decl = FuncDecl::createImported(impl.SwiftContext, funcLoc, name, nameLoc,
                                     async, throws, bodyParams, resultTy,
@@ -599,19 +597,15 @@ static bool addErrorDomain(NominalTypeDecl *swiftDecl,
 
   auto *params = ParameterList::createEmpty(C);
 
-  auto getterDecl = AccessorDecl::create(C,
-                     /*FuncLoc=*/SourceLoc(),
-                     /*AccessorKeywordLoc=*/SourceLoc(),
-                     AccessorKind::Get,
-                     errorDomainPropertyDecl,
-                     /*StaticLoc=*/SourceLoc(),
-                     StaticSpellingKind::None,
-                     /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
-                     /*Throws=*/false,
-                     /*ThrowsLoc=*/SourceLoc(),
-                     /*GenericParams=*/nullptr,
-                     params,
-                     stringTy, swiftDecl);
+  auto getterDecl = AccessorDecl::create(
+      C,
+      /*FuncLoc=*/SourceLoc(),
+      /*AccessorKeywordLoc=*/SourceLoc(), AccessorKind::Get,
+      errorDomainPropertyDecl,
+      /*StaticLoc=*/SourceLoc(), StaticSpellingKind::None,
+      /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
+      /*Throws=*/false,
+      /*ThrowsLoc=*/SourceLoc(), params, stringTy, swiftDecl);
   getterDecl->setIsObjC(false);
   getterDecl->setIsDynamic(false);
   getterDecl->setIsTransparent(false);

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -92,8 +92,7 @@ static AccessorDecl *makeFieldGetterDecl(ClangImporter::Implementation &Impl,
       /*StaticLoc=*/SourceLoc(), StaticSpellingKind::None,
       /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
       /*Throws=*/false,
-      /*ThrowsLoc=*/SourceLoc(),
-      /*GenericParams=*/nullptr, params, getterType, importedDecl, clangNode);
+      /*ThrowsLoc=*/SourceLoc(), params, getterType, importedDecl, clangNode);
   getterDecl->setAccess(AccessLevel::Public);
   getterDecl->setIsObjC(false);
   getterDecl->setIsDynamic(false);
@@ -122,8 +121,7 @@ static AccessorDecl *makeFieldSetterDecl(ClangImporter::Implementation &Impl,
       /*StaticLoc=*/SourceLoc(), StaticSpellingKind::None,
       /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
       /*Throws=*/false,
-      /*ThrowsLoc=*/SourceLoc(),
-      /*GenericParams=*/nullptr, params, voidTy, importedDecl, clangNode);
+      /*ThrowsLoc=*/SourceLoc(), params, voidTy, importedDecl, clangNode);
   setterDecl->setIsObjC(false);
   setterDecl->setIsDynamic(false);
   setterDecl->setSelfAccessKind(SelfAccessKind::Mutating);
@@ -409,8 +407,7 @@ ValueDecl *SwiftDeclSynthesizer::createConstant(
       /*StaticLoc=*/SourceLoc(), StaticSpellingKind::None,
       /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
       /*Throws=*/false,
-      /*ThrowsLoc=*/SourceLoc(),
-      /*GenericParams=*/nullptr, params, type, dc);
+      /*ThrowsLoc=*/SourceLoc(), params, type, dc);
   func->setStatic(isStatic);
   func->setAccess(getOverridableAccessLevel(dc));
   func->setIsObjC(false);
@@ -1341,8 +1338,7 @@ void SwiftDeclSynthesizer::makeEnumRawValueGetter(EnumDecl *enumDecl,
       /*StaticLoc=*/SourceLoc(), StaticSpellingKind::None,
       /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
       /*Throws=*/false,
-      /*ThrowsLoc=*/SourceLoc(),
-      /*GenericParams=*/nullptr, params, rawTy, enumDecl);
+      /*ThrowsLoc=*/SourceLoc(), params, rawTy, enumDecl);
   getterDecl->setImplicit();
   getterDecl->setIsObjC(false);
   getterDecl->setIsDynamic(false);
@@ -1406,8 +1402,7 @@ AccessorDecl *SwiftDeclSynthesizer::makeStructRawValueGetter(
       /*StaticLoc=*/SourceLoc(), StaticSpellingKind::None,
       /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
       /*Throws=*/false,
-      /*ThrowsLoc=*/SourceLoc(),
-      /*GenericParams=*/nullptr, params, computedType, structDecl);
+      /*ThrowsLoc=*/SourceLoc(), params, computedType, structDecl);
   getterDecl->setImplicit();
   getterDecl->setIsObjC(false);
   getterDecl->setIsDynamic(false);
@@ -1436,8 +1431,7 @@ AccessorDecl *SwiftDeclSynthesizer::buildSubscriptGetterDecl(
       /*StaticLoc=*/SourceLoc(), subscript->getStaticSpelling(),
       /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
       /*Throws=*/false,
-      /*ThrowsLoc=*/SourceLoc(),
-      /*GenericParams=*/nullptr, params, elementTy, dc, getter->getClangNode());
+      /*ThrowsLoc=*/SourceLoc(), params, elementTy, dc, getter->getClangNode());
 
   thunk->setAccess(getOverridableAccessLevel(dc));
 
@@ -1480,8 +1474,7 @@ AccessorDecl *SwiftDeclSynthesizer::buildSubscriptSetterDecl(
       /*StaticLoc=*/SourceLoc(), subscript->getStaticSpelling(),
       /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
       /*Throws=*/false,
-      /*ThrowsLoc=*/SourceLoc(),
-      /*GenericParams=*/nullptr, valueIndicesPL, TupleType::getEmpty(C), dc,
+      /*ThrowsLoc=*/SourceLoc(), valueIndicesPL, TupleType::getEmpty(C), dc,
       setter->getClangNode());
 
   thunk->setAccess(getOverridableAccessLevel(dc));
@@ -1622,7 +1615,7 @@ SubscriptDecl *SwiftDeclSynthesizer::makeSubscript(FuncDecl *getter,
       ctx, getterImpl->getLoc(), getterImpl->getLoc(), AccessorKind::Get,
       subscript, SourceLoc(), subscript->getStaticSpelling(),
       /*async*/ false, SourceLoc(),
-      /*throws*/ false, SourceLoc(), nullptr, bodyParams, elementTy, dc);
+      /*throws*/ false, SourceLoc(), bodyParams, elementTy, dc);
   getterDecl->setAccess(AccessLevel::Public);
   getterDecl->setImplicit();
   getterDecl->setIsDynamic(false);
@@ -1649,7 +1642,7 @@ SubscriptDecl *SwiftDeclSynthesizer::makeSubscript(FuncDecl *getter,
         ctx, setterImpl->getLoc(), setterImpl->getLoc(), AccessorKind::Set,
         subscript, SourceLoc(), subscript->getStaticSpelling(),
         /*async*/ false, SourceLoc(),
-        /*throws*/ false, SourceLoc(), nullptr, setterParamList,
+        /*throws*/ false, SourceLoc(), setterParamList,
         TupleType::getEmpty(ctx), dc);
     setterDecl->setAccess(AccessLevel::Public);
     setterDecl->setImplicit();
@@ -1697,8 +1690,8 @@ VarDecl *SwiftDeclSynthesizer::makeDereferencedPointeeProperty(
       ctx, dereferenceFunc->getLoc(), dereferenceFunc->getLoc(),
       AccessorKind::Get, result, SourceLoc(), StaticSpellingKind::None,
       /*async*/ false, SourceLoc(),
-      /*throws*/ false, SourceLoc(), nullptr, ParameterList::createEmpty(ctx),
-      elementTy, dc);
+      /*throws*/ false, SourceLoc(), ParameterList::createEmpty(ctx), elementTy,
+      dc);
   getterDecl->setAccess(AccessLevel::Public);
   getterDecl->setImplicit();
   getterDecl->setIsDynamic(false);
@@ -1993,7 +1986,7 @@ SwiftDeclSynthesizer::makeComputedPropertyFromCXXMethods(FuncDecl *getter,
       ctx, getter->getLoc(), getter->getLoc(), AccessorKind::Get, result,
       SourceLoc(), StaticSpellingKind::None,
       /*async*/ false, SourceLoc(),
-      /*throws*/ false, SourceLoc(), nullptr, ParameterList::createEmpty(ctx),
+      /*throws*/ false, SourceLoc(), ParameterList::createEmpty(ctx),
       getter->getResultInterfaceType(), dc);
   getterDecl->setAccess(AccessLevel::Public);
   getterDecl->setImplicit();
@@ -2019,7 +2012,7 @@ SwiftDeclSynthesizer::makeComputedPropertyFromCXXMethods(FuncDecl *getter,
         ctx, setter->getLoc(), setter->getLoc(), AccessorKind::Set, result,
         SourceLoc(), StaticSpellingKind::None,
         /*async*/ false, SourceLoc(),
-        /*throws*/ false, SourceLoc(), nullptr, setterParamList,
+        /*throws*/ false, SourceLoc(), setterParamList,
         setter->getResultInterfaceType(), dc);
     setterDecl->setAccess(AccessLevel::Public);
     setterDecl->setImplicit();

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -6235,16 +6235,11 @@ ParserResult<TypeDecl> Parser::parseDeclAssociatedType(Parser::ParseDeclOptions 
 
 /// This function creates an accessor function (with no body) for a computed
 /// property or subscript.
-static AccessorDecl *createAccessorFunc(SourceLoc DeclLoc,
-                                    ParameterList *param,
-                                    GenericParamList *GenericParams,
-                                    ParameterList *Indices,
-                                    SourceLoc StaticLoc,
-                                    Parser::ParseDeclOptions Flags,
-                                    AccessorKind Kind,
-                                    AbstractStorageDecl *storage,
-                                    Parser *P, SourceLoc AccessorKeywordLoc,
-                                    SourceLoc asyncLoc, SourceLoc throwsLoc) {
+static AccessorDecl *createAccessorFunc(
+    SourceLoc DeclLoc, ParameterList *param, ParameterList *Indices,
+    SourceLoc StaticLoc, Parser::ParseDeclOptions Flags, AccessorKind Kind,
+    AbstractStorageDecl *storage, Parser *P, SourceLoc AccessorKeywordLoc,
+    SourceLoc asyncLoc, SourceLoc throwsLoc) {
   // First task, set up the value argument list.  This is the "newValue" name
   // (for setters) followed by the index list (for subscripts).  For
   // non-subscript getters, this degenerates down to "()".
@@ -6299,18 +6294,11 @@ static AccessorDecl *createAccessorFunc(SourceLoc DeclLoc,
   }
 
   // Start the function.
-  auto *D = AccessorDecl::create(P->Context,
-                                 /*FIXME FuncLoc=*/DeclLoc,
-                                 AccessorKeywordLoc,
-                                 Kind, storage,
-                                 StaticLoc, StaticSpellingKind::None,
-                                 asyncLoc.isValid(), asyncLoc,
-                                 throwsLoc.isValid(), throwsLoc,
-                                 (GenericParams
-                                  ? GenericParams->clone(P->CurDeclContext)
-                                  : nullptr),
-                                 ValueArg, Type(),
-                                 P->CurDeclContext);
+  auto *D = AccessorDecl::create(
+      P->Context,
+      /*FIXME FuncLoc=*/DeclLoc, AccessorKeywordLoc, Kind, storage, StaticLoc,
+      StaticSpellingKind::None, asyncLoc.isValid(), asyncLoc,
+      throwsLoc.isValid(), throwsLoc, ValueArg, Type(), P->CurDeclContext);
 
   return D;
 }
@@ -6664,9 +6652,8 @@ ParserStatus Parser::parseGetEffectSpecifier(ParsedAccessors &accessors,
   return Status;
 }
 
-ParserStatus Parser::parseGetSet(ParseDeclOptions Flags,
-                                 GenericParamList *GenericParams,
-                                 ParameterList *Indices, TypeRepr *ResultType,
+ParserStatus Parser::parseGetSet(ParseDeclOptions Flags, ParameterList *Indices,
+                                 TypeRepr *ResultType,
                                  ParsedAccessors &accessors,
                                  AbstractStorageDecl *storage,
                                  SourceLoc StaticLoc) {
@@ -6721,11 +6708,10 @@ ParserStatus Parser::parseGetSet(ParseDeclOptions Flags,
     assert(Tok.is(tok::l_brace));
     accessors.LBLoc = Tok.getLoc();
     auto getter =
-        createAccessorFunc(Tok.getLoc(), /*ValueNamePattern*/ nullptr,
-                           GenericParams, Indices, StaticLoc, Flags,
-                           AccessorKind::Get, storage, this,
+        createAccessorFunc(Tok.getLoc(), /*ValueNamePattern*/ nullptr, Indices,
+                           StaticLoc, Flags, AccessorKind::Get, storage, this,
                            /*AccessorKeywordLoc*/ SourceLoc(),
-                           /*asyncLoc*/SourceLoc(), /*throwsLoc*/SourceLoc());
+                           /*asyncLoc*/ SourceLoc(), /*throwsLoc*/ SourceLoc());
     accessors.add(getter);
     parseAbstractFunctionBody(getter);
     accessors.RBLoc = getter->getEndLoc();
@@ -6824,10 +6810,9 @@ ParserStatus Parser::parseGetSet(ParseDeclOptions Flags,
                                       hasEffectfulGet, Kind, Loc);
 
     // Set up a function declaration.
-    auto accessor = createAccessorFunc(Loc, ValueNamePattern, GenericParams,
-                                       Indices, StaticLoc, Flags,
-                                       Kind, storage, this, Loc,
-                                       asyncLoc, throwsLoc);
+    auto accessor =
+        createAccessorFunc(Loc, ValueNamePattern, Indices, StaticLoc, Flags,
+                           Kind, storage, this, Loc, asyncLoc, throwsLoc);
     accessor->getAttrs() = Attributes;
 
     // Collect this accessor and detect conflicts.
@@ -6944,8 +6929,7 @@ Parser::parseDeclVarGetSet(PatternBindingEntry &entry, ParseDeclOptions Flags,
   ParsedAccessors accessors;
   auto typedPattern = dyn_cast<TypedPattern>(pattern);
   auto *resultTypeRepr = typedPattern ? typedPattern->getTypeRepr() : nullptr;
-  auto AccessorStatus = parseGetSet(Flags, /*GenericParams=*/nullptr,
-                                    /*Indices=*/nullptr, resultTypeRepr,
+  auto AccessorStatus = parseGetSet(Flags, /*Indices=*/nullptr, resultTypeRepr,
                                     accessors, storage, StaticLoc);
   if (AccessorStatus.hasCodeCompletion())
     return makeParserCodeCompletionStatus();
@@ -8559,8 +8543,8 @@ Parser::parseDeclSubscript(SourceLoc StaticLoc,
       Status.setIsParseError();
     }
   } else if (!Status.hasCodeCompletion()) {
-    Status |= parseGetSet(Flags, GenericParams, Indices.get(), ElementTy.get(),
-                          accessors, Subscript, StaticLoc);
+    Status |= parseGetSet(Flags, Indices.get(), ElementTy.get(), accessors,
+                          Subscript, StaticLoc);
   }
 
   // Now that it's been parsed, set the end location.

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -895,14 +895,13 @@ static ValueDecl *deriveHashable_hashValue(DerivedConformance &derived) {
 
   ParameterList *params = ParameterList::createEmpty(C);
 
-  AccessorDecl *getterDecl = AccessorDecl::create(C,
+  AccessorDecl *getterDecl = AccessorDecl::create(
+      C,
       /*FuncLoc=*/SourceLoc(), /*AccessorKeywordLoc=*/SourceLoc(),
       AccessorKind::Get, hashValueDecl,
       /*StaticLoc=*/SourceLoc(), StaticSpellingKind::None,
       /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
-      /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(),
-      /*GenericParams=*/nullptr, params,
-      intType, parentDC);
+      /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(), params, intType, parentDC);
   getterDecl->setImplicit();
   getterDecl->setBodySynthesizer(&deriveBodyHashable_hashValue);
   getterDecl->setSynthesized();

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -506,15 +506,15 @@ DerivedConformance::declareDerivedPropertyGetter(VarDecl *property,
   auto &C = property->getASTContext();
   auto parentDC = property->getDeclContext();
   ParameterList *params = ParameterList::createEmpty(C);
-  
-  auto getterDecl = AccessorDecl::create(C,
-    /*FuncLoc=*/SourceLoc(), /*AccessorKeywordLoc=*/SourceLoc(),
-    AccessorKind::Get, property,
-    /*StaticLoc=*/SourceLoc(), StaticSpellingKind::None,
-    /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
-    /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(),
-    /*GenericParams=*/nullptr, params,
-    property->getInterfaceType(), parentDC);
+
+  auto getterDecl = AccessorDecl::create(
+      C,
+      /*FuncLoc=*/SourceLoc(), /*AccessorKeywordLoc=*/SourceLoc(),
+      AccessorKind::Get, property,
+      /*StaticLoc=*/SourceLoc(), StaticSpellingKind::None,
+      /*Async=*/false, /*AsyncLoc=*/SourceLoc(),
+      /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(), params,
+      property->getInterfaceType(), parentDC);
   getterDecl->setImplicit();
   getterDecl->setIsTransparent(false);
   getterDecl->copyFormalAccessFrom(property);

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3516,8 +3516,8 @@ public:
                                         resultType, DC);
     } else {
       auto *accessor = AccessorDecl::createDeserialized(
-          ctx, accessorKind, storage, staticSpelling.getValue(),
-          async, throws, genericParams, resultType, DC);
+          ctx, accessorKind, storage, staticSpelling.getValue(), async, throws,
+          resultType, DC);
       accessor->setIsTransparent(isTransparent);
 
       fn = accessor;

--- a/test/type/opaque_parameters.swift
+++ b/test/type/opaque_parameters.swift
@@ -115,3 +115,19 @@ typealias FnType<T> = (T) -> Void
 
 func consumingA(fn: (some P) -> Void) { } // expected-error{{'some' cannot appear in parameter position in parameter type '(some P) -> Void'}}
 func consumingB(fn: FnType<some P>) { } // expected-error{{'some' cannot appear in parameter position in parameter type '(some P) -> Void'}}
+
+// https://github.com/apple/swift/issues/61387
+struct I61387 {
+  subscript(s: some StringProtocol) -> String {
+    fatalError()
+  }
+}
+
+struct I61387_1 {
+  subscript(s: some StringProtocol) -> String {
+    get { fatalError() }
+    set {
+      fatalError()
+    }
+  }
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
`AbstractFunctionDecl::isGenericContext` being based on `getGenericParams()` which is `nullptr` in this case for `AccessorDecl` because `createOpaqueParameterGenericParams` was not be able to create the implicit generic param list correctly because it was looking to itself but in fact it should look through subscript(storage) signature instead. 

This refectors generic parameters logic for accessor declaration to be a copy of the storage at `GenericParamListRequest ` instead of parse time. See Slava's comment bellow.
<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #61387

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
