### PR TITLE
Swift Optimizer: add side effect analysis

### DIFF
--- a/SwiftCompilerSources/Sources/Basic/Utils.swift
+++ b/SwiftCompilerSources/Sources/Basic/Utils.swift
@@ -40,19 +40,31 @@ public func assert(_ condition: Bool, file: StaticString = #fileID, line: UInt =
   }
 }
 
+//===----------------------------------------------------------------------===//
+//                            Debugging Utilities
+//===----------------------------------------------------------------------===//
+
+/// Let's lldb's `po` command not print any "internal" properties of the conforming type.
+///
+/// This is useful if the `description` already contains all the information of a type instance.
+public protocol NoReflectionChildren : CustomReflectable { }
+
+public extension NoReflectionChildren {
+  var customMirror: Mirror { Mirror(self, children: []) }
+}
+
 
 //===----------------------------------------------------------------------===//
 //                              StringRef
 //===----------------------------------------------------------------------===//
 
-public struct StringRef : CustomStringConvertible, CustomReflectable {
+public struct StringRef : CustomStringConvertible, NoReflectionChildren {
   let _bridged: llvm.StringRef
 
   public init(bridged: llvm.StringRef) { self._bridged = bridged }
 
   public var string: String { _bridged.string }
   public var description: String { string }
-  public var customMirror: Mirror { Mirror(self, children: []) }
   
   public static func ==(lhs: StringRef, rhs: StaticString) -> Bool {
     let lhsBuffer = UnsafeBufferPointer<UInt8>(

--- a/SwiftCompilerSources/Sources/Optimizer/DataStructures/BasicBlockRange.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/DataStructures/BasicBlockRange.swift
@@ -46,7 +46,7 @@ import SIL
 /// This type should be a move-only type, but unfortunately we don't have move-only
 /// types yet. Therefore it's needed to call `deinitialize()` explicitly to
 /// destruct this data structure, e.g. in a `defer {}` block.
-struct BasicBlockRange : CustomStringConvertible, CustomReflectable {
+struct BasicBlockRange : CustomStringConvertible, NoReflectionChildren {
 
   /// The dominating begin block.
   let begin: BasicBlock
@@ -148,8 +148,6 @@ struct BasicBlockRange : CustomStringConvertible, CustomReflectable {
       interiors: \(interiors)
       """
   }
-
-  var customMirror: Mirror { Mirror(self, children: []) }
 
   /// TODO: once we have move-only types, make this a real deinit.
   mutating func deinitialize() {

--- a/SwiftCompilerSources/Sources/Optimizer/DataStructures/BasicBlockWorklist.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/DataStructures/BasicBlockWorklist.swift
@@ -56,6 +56,8 @@ struct BasicBlockWorklist : CustomStringConvertible, NoReflectionChildren {
     """
   }
 
+  var function: Function { pushedBlocks.function }
+
   /// TODO: once we have move-only types, make this a real deinit.
   mutating func deinitialize() {
     pushedBlocks.deinitialize()

--- a/SwiftCompilerSources/Sources/Optimizer/DataStructures/BasicBlockWorklist.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/DataStructures/BasicBlockWorklist.swift
@@ -20,7 +20,7 @@ import SIL
 /// This type should be a move-only type, but unfortunately we don't have move-only
 /// types yet. Therefore it's needed to call `deinitialize()` explicitly to
 /// destruct this data structure, e.g. in a `defer {}` block.
-struct BasicBlockWorklist : CustomStringConvertible, CustomReflectable {
+struct BasicBlockWorklist : CustomStringConvertible, NoReflectionChildren {
   private var worklist: Stack<BasicBlock>
   private var pushedBlocks: BasicBlockSet
 
@@ -55,8 +55,6 @@ struct BasicBlockWorklist : CustomStringConvertible, CustomReflectable {
     pushed:   \(pushedBlocks)
     """
   }
-
-  var customMirror: Mirror { Mirror(self, children: []) }
 
   /// TODO: once we have move-only types, make this a real deinit.
   mutating func deinitialize() {

--- a/SwiftCompilerSources/Sources/Optimizer/DataStructures/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/DataStructures/CMakeLists.txt
@@ -9,6 +9,7 @@
 swift_compiler_sources(Optimizer
   BasicBlockRange.swift
   BasicBlockWorklist.swift
+  DeadEndBlocks.swift
   FunctionUses.swift
   InstructionRange.swift
   Set.swift

--- a/SwiftCompilerSources/Sources/Optimizer/DataStructures/DeadEndBlocks.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/DataStructures/DeadEndBlocks.swift
@@ -1,0 +1,51 @@
+//===--- DeadEndBlocks.swift ----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SIL
+
+/// A utility for finding dead-end blocks.
+///
+/// Dead-end blocks are blocks from which there is no path to the function exit
+/// (`return`, `throw` or unwind). These are blocks which end with an unreachable
+/// instruction and blocks from which all paths end in "unreachable" blocks.
+struct DeadEndBlocks : CustomStringConvertible, NoReflectionChildren {
+  private var worklist: BasicBlockWorklist
+  
+  init(function: Function, _ context: PassContext) {
+    self.worklist = BasicBlockWorklist(context)
+    
+    // Initialize the worklist with all function-exiting blocks.
+    for block in function.blocks where block.terminator.isFunctionExiting {
+      worklist.pushIfNotVisited(block)
+    }
+    
+    // Propagate lifeness up the control flow.
+    while let block = worklist.pop() {
+      worklist.pushIfNotVisited(contentsOf: block.predecessors)
+    }
+  }
+  
+  /// Returns true if `block` is a dead-end block.
+  func isDeadEnd(block: BasicBlock) -> Bool {
+    return !worklist.hasBeenPushed(block)
+  }
+
+  var description: String {
+    let blockNames = worklist.function.blocks.filter(isDeadEnd).map(\.name)
+    return "[" + blockNames.joined(separator: ",") + "]"
+  }
+
+  /// TODO: once we have move-only types, make this a real deinit.
+  mutating func deinitialize() {
+    worklist.deinitialize()
+  }
+}

--- a/SwiftCompilerSources/Sources/Optimizer/DataStructures/InstructionRange.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/DataStructures/InstructionRange.swift
@@ -38,7 +38,7 @@ import SIL
 /// This type should be a move-only type, but unfortunately we don't have move-only
 /// types yet. Therefore it's needed to call `deinitialize()` explicitly to
 /// destruct this data structure, e.g. in a `defer {}` block.
-struct InstructionRange : CustomStringConvertible, CustomReflectable {
+struct InstructionRange : CustomStringConvertible, NoReflectionChildren {
   
   /// The dominating begin instruction.
   let begin: Instruction
@@ -138,8 +138,6 @@ struct InstructionRange : CustomStringConvertible, CustomReflectable {
       interiors:\(interiors.map { $0.description }.joined(separator: "\n          "))
       """
   }
-
-  var customMirror: Mirror { Mirror(self, children: []) }
 
   /// TODO: once we have move-only types, make this a real deinit.
   mutating func deinitialize() {

--- a/SwiftCompilerSources/Sources/Optimizer/DataStructures/Set.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/DataStructures/Set.swift
@@ -21,7 +21,7 @@ import OptimizerBridging
 /// This type should be a move-only type, but unfortunately we don't have move-only
 /// types yet. Therefore it's needed to call `deinitialize()` explicitly to
 /// destruct this data structure, e.g. in a `defer {}` block.
-struct BasicBlockSet : CustomStringConvertible, CustomReflectable {
+struct BasicBlockSet : CustomStringConvertible, NoReflectionChildren {
 
   private let context: PassContext
   private let bridged: BridgedBasicBlockSet
@@ -52,7 +52,6 @@ struct BasicBlockSet : CustomStringConvertible, CustomReflectable {
     return "{" + blockNames.joined(separator: ", ") + "}"
   }
 
-  var customMirror: Mirror { Mirror(self, children: []) }
 
   /// TODO: once we have move-only types, make this a real deinit.
   mutating func deinitialize() {
@@ -68,7 +67,7 @@ struct BasicBlockSet : CustomStringConvertible, CustomReflectable {
 /// This type should be a move-only type, but unfortunately we don't have move-only
 /// types yet. Therefore it's needed to call `deinitialize()` explicitly to
 /// destruct this data structure, e.g. in a `defer {}` block.
-struct ValueSet : CustomStringConvertible, CustomReflectable {
+struct ValueSet : CustomStringConvertible, NoReflectionChildren {
 
   private let context: PassContext
   private let bridged: BridgedNodeSet
@@ -113,8 +112,6 @@ struct ValueSet : CustomStringConvertible, CustomReflectable {
     return d
   }
 
-  var customMirror: Mirror { Mirror(self, children: []) }
-
   /// TODO: once we have move-only types, make this a real deinit.
   mutating func deinitialize() {
     PassContext_freeNodeSet(context._bridged, bridged)
@@ -129,7 +126,7 @@ struct ValueSet : CustomStringConvertible, CustomReflectable {
 /// This type should be a move-only type, but unfortunately we don't have move-only
 /// types yet. Therefore it's needed to call `deinitialize()` explicitly to
 /// destruct this data structure, e.g. in a `defer {}` block.
-struct InstructionSet : CustomStringConvertible, CustomReflectable {
+struct InstructionSet : CustomStringConvertible, NoReflectionChildren {
 
   private let context: PassContext
   private let bridged: BridgedNodeSet
@@ -164,8 +161,6 @@ struct InstructionSet : CustomStringConvertible, CustomReflectable {
     d += "}\n"
     return d
   }
-
-  var customMirror: Mirror { Mirror(self, children: []) }
 
   /// TODO: once we have move-only types, make this a real deinit.
   mutating func deinitialize() {

--- a/SwiftCompilerSources/Sources/Optimizer/DataStructures/Set.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/DataStructures/Set.swift
@@ -46,12 +46,12 @@ struct BasicBlockSet : CustomStringConvertible, NoReflectionChildren {
   }
 
   var description: String {
-    let function = BasicBlockSet_getFunction(bridged).function
     let blockNames = function.blocks.enumerated().filter { contains($0.1) }
                                                  .map { "bb\($0.0)"}
     return "{" + blockNames.joined(separator: ", ") + "}"
   }
 
+  var function: Function { BasicBlockSet_getFunction(bridged).function }
 
   /// TODO: once we have move-only types, make this a real deinit.
   mutating func deinitialize() {

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CMakeLists.txt
@@ -9,6 +9,7 @@
 swift_compiler_sources(Optimizer
   AssumeSingleThreaded.swift
   ComputeEscapeEffects.swift
+  ComputeSideEffects.swift
   ObjCBridgingOptimization.swift
   MergeCondFails.swift
   ReleaseDevirtualizer.swift

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 swift_compiler_sources(Optimizer
   AssumeSingleThreaded.swift
-  ComputeEffects.swift
+  ComputeEscapeEffects.swift
   ObjCBridgingOptimization.swift
   MergeCondFails.swift
   ReleaseDevirtualizer.swift

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeEffects.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeEffects.swift
@@ -12,31 +12,27 @@
 
 import SIL
 
-/// Computes effects for function arguments.
+/// Computes escape effects for function arguments.
 ///
 /// For example, if an argument does not escape, adds a non-escaping effect,
-/// e.g. "[escapes !%0.**]":
-///
-///   sil [escapes !%0.**] @foo : $@convention(thin) (@guaranteed X) -> () {
+/// ```
+///   sil @foo : $@convention(thin) (@guaranteed X) -> () {
+///   [%0: noecape **]
 ///   bb0(%0 : $X):
 ///     %1 = tuple ()
 ///     return %1 : $()
 ///   }
-///
+/// ```
 /// The pass does not try to change or re-compute _defined_ effects.
-/// Currently, only escaping effects are handled.
-/// In future, this pass may also add other effects, like memory side effects.
+///
 let computeEffects = FunctionPass(name: "compute-effects", {
   (function: Function, context: PassContext) in
-  var argsWithDefinedEffects = getArgIndicesWithDefinedEffects(of: function)
 
-  struct IgnoreRecursiveCallVisitor : EscapeVisitor {
-    func visitUse(operand: Operand, path: EscapePath) -> UseResult {
-      return isOperandOfRecursiveCall(operand) ? .ignore : .continueWalk
-    }
-  }
-  var newEffects = Stack<ArgumentEffect>(context)
+  var newEffects = Stack<EscapeEffects.ArgumentEffect>(context)
+  defer { newEffects.deinitialize() }
+
   let returnInst = function.returnInstruction
+  let argsWithDefinedEffects = getArgIndicesWithDefinedEscapingEffects(of: function)
 
   for arg in function.arguments {
     // We are not interested in arguments with trivial types.
@@ -44,11 +40,19 @@ let computeEffects = FunctionPass(name: "compute-effects", {
     
     // Also, we don't want to override defined effects.
     if argsWithDefinedEffects.contains(arg.index) { continue }
-    
+
+    struct IgnoreRecursiveCallVisitor : EscapeVisitor {
+      func visitUse(operand: Operand, path: EscapePath) -> UseResult {
+        return isOperandOfRecursiveCall(operand) ? .ignore : .continueWalk
+      }
+    }
+
     // First check: is the argument (or a projected value of it) escaping at all?
     if !arg.at(.anything).isEscapingWhenWalkingDown(using: IgnoreRecursiveCallVisitor(),
                                                     context) {
-      newEffects.push(ArgumentEffect(.notEscaping, argumentIndex: arg.index, pathPattern: SmallProjectionPath(.anything)))
+      let effect = EscapeEffects.ArgumentEffect(.notEscaping, argumentIndex: arg.index,
+                                                pathPattern: SmallProjectionPath(.anything))
+      newEffects.push(effect)
       continue
     }
   
@@ -62,17 +66,16 @@ let computeEffects = FunctionPass(name: "compute-effects", {
   }
 
   context.modifyEffects(in: function) { (effects: inout FunctionEffects) in
-    effects.removeDerivedEffects()
-    effects.argumentEffects.append(contentsOf: newEffects)
+    effects.escapeEffects.arguments = effects.escapeEffects.arguments.filter { !$0.isDerived }
+    effects.escapeEffects.arguments.append(contentsOf: newEffects)
   }
-  newEffects.removeAll()
 })
 
 
 /// Returns true if an argument effect was added.
 private
 func addArgEffects(_ arg: FunctionArgument, argPath ap: SmallProjectionPath,
-                   to newEffects: inout Stack<ArgumentEffect>,
+                   to newEffects: inout Stack<EscapeEffects.ArgumentEffect>,
                    _ returnInst: ReturnInst?, _ context: PassContext) -> Bool {
   // Correct the path if the argument is not a class reference itself, but a value type
   // containing one or more references.
@@ -141,39 +144,36 @@ func addArgEffects(_ arg: FunctionArgument, argPath ap: SmallProjectionPath,
     return false
   }
 
-  let effect: ArgumentEffect
+  let effect: EscapeEffects.ArgumentEffect
   switch result {
   case .notSet:
-    effect = ArgumentEffect(.notEscaping, argumentIndex: arg.index, pathPattern: argPath)
+    effect = EscapeEffects.ArgumentEffect(.notEscaping, argumentIndex: arg.index, pathPattern: argPath)
   case .toReturn(let toPath):
     let exclusive = isExclusiveEscapeToReturn(fromArgument: arg, fromPath: argPath,
                                               toPath: toPath, returnInst: returnInst, context)
-    effect = ArgumentEffect(.escapingToReturn(toPath, exclusive),
-                            argumentIndex: arg.index, pathPattern: argPath)
+    effect = EscapeEffects.ArgumentEffect(.escapingToReturn(toPath, exclusive),
+                                          argumentIndex: arg.index, pathPattern: argPath)
   case .toArgument(let toArgIdx, let toPath):
     let exclusive = isExclusiveEscapeToArgument(fromArgument: arg, fromPath: argPath,
                                                 toArgumentIndex: toArgIdx, toPath: toPath, context)
-    effect = ArgumentEffect(.escapingToArgument(toArgIdx, toPath, exclusive),
-                            argumentIndex: arg.index, pathPattern: argPath)
+    effect = EscapeEffects.ArgumentEffect(.escapingToArgument(toArgIdx, toPath, exclusive),
+                                          argumentIndex: arg.index, pathPattern: argPath)
   }
   newEffects.push(effect)
   return true
 }
 
 /// Returns a set of argument indices for which there are "defined" effects (as opposed to derived effects).
-private func getArgIndicesWithDefinedEffects(of function: Function) -> Set<Int> {
+private func getArgIndicesWithDefinedEscapingEffects(of function: Function) -> Set<Int> {
   var argsWithDefinedEffects = Set<Int>()
 
-  for effect in function.effects.argumentEffects {
+  for effect in function.effects.escapeEffects.arguments {
     if effect.isDerived { continue }
 
     argsWithDefinedEffects.insert(effect.argumentIndex)
-
     switch effect.kind {
-    case .notEscaping, .escapingToReturn:
-      break
-    case .escapingToArgument(let toArgIdx, _, _):
-      argsWithDefinedEffects.insert(toArgIdx)
+      case .notEscaping, .escapingToReturn:         break
+      case .escapingToArgument(let toArgIdx, _, _): argsWithDefinedEffects.insert(toArgIdx)
     }
   }
   return argsWithDefinedEffects

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeEscapeEffects.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeEscapeEffects.swift
@@ -1,4 +1,4 @@
-//===--- ComputeEffects.swift - Compute function effects ------------------===//
+//===--- ComputeEscapeEffects.swift ----------------------------------------==//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -25,7 +25,7 @@ import SIL
 /// ```
 /// The pass does not try to change or re-compute _defined_ effects.
 ///
-let computeEffects = FunctionPass(name: "compute-effects", {
+let computeEscapeEffects = FunctionPass(name: "compute-escape-effects", {
   (function: Function, context: PassContext) in
 
   var newEffects = Stack<EscapeEffects.ArgumentEffect>(context)

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeSideEffects.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeSideEffects.swift
@@ -1,0 +1,468 @@
+//===--- ComputeSideEffects.swift ------------------------------------------==//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SIL
+
+/// Computes function side effects.
+///
+/// Computes the `SideEffects` for a function, which consists of argument- and global
+/// effects.
+/// For example, if a function writes to the first argument and reads from a global variable,
+/// the side effects
+/// ```
+///   [%0: write v**]
+///   [global: read]
+/// ```
+/// are computed.
+///
+let computeSideEffects = FunctionPass(name: "compute-side-effects", {
+  (function: Function, context: PassContext) in
+
+  if function.isAvailableExternally {
+    // We cannot assume anything about function, which are defined in another module,
+    // even if the serialized SIL of its body is available in the current module.
+    // If the other module was compiled with library evolution, the implementation
+    // (and it's effects) might change in future versions of the other module/library.
+    //
+    // TODO: only do this for functions which are de-serialized from library-evolution modules.
+    return
+  }
+
+  if function.effectAttribute != .none {
+    // Don't try to infer side effects if there are defined effect attributes.
+    return
+  }
+
+  var collectedEffects = CollectedEffects(function: function, context)
+
+  var deadEndBlocks = DeadEndBlocks(function: function, context)
+  defer { deadEndBlocks.deinitialize() }
+  
+  // First step: collect effects from all instructions.
+  //
+  for block in function.blocks {
+    // Effects in blocks from which the function doesn't return are not relevant for the caller.
+    if deadEndBlocks.isDeadEnd(block: block) {
+      continue
+    }
+    for inst in block.instructions {
+      collectedEffects.addInstructionEffects(inst)
+    }
+  }
+
+  // Second step: If an argument has unknown uses, we must add all previously collected
+  // global effects to the argument, because we don't know to wich "global" side-effect
+  // instruction the argument might have escaped.
+  for argument in function.arguments {
+    collectedEffects.addEffectsForEcapingArgument(argument: argument)
+  }
+
+  // Finally replace the function's side effects.
+  context.modifyEffects(in: function) { (effects: inout FunctionEffects) in
+    effects.sideEffects = SideEffects(arguments: collectedEffects.argumentEffects, global: collectedEffects.globalEffects)
+  }
+})
+
+/// The collected argument and global side effects of the function.
+private struct CollectedEffects {
+
+  private let context: PassContext
+  private let calleeAnalysis: CalleeAnalysis
+
+  private(set) var argumentEffects: [SideEffects.ArgumentEffects]
+  private(set) var globalEffects = SideEffects.GlobalEffects()
+
+  init(function: Function, _ context: PassContext) {
+    self.context = context
+    self.calleeAnalysis = context.calleeAnalysis
+    self.argumentEffects = Array(repeating: SideEffects.ArgumentEffects(), count: function.entryBlock.arguments.count)
+  }
+
+  mutating func addInstructionEffects(_ inst: Instruction) {
+    switch inst {
+    case is CopyValueInst, is RetainValueInst, is StrongRetainInst:
+      addEffects(.copy, to: inst.operands[0].value, fromInitialPath: SmallProjectionPath(.anyValueFields))
+
+    case is DestroyValueInst, is ReleaseValueInst, is StrongReleaseInst:
+      addDestroyEffects(of: inst.operands[0].value)
+
+    case let da as DestroyAddrInst:
+      addDestroyEffects(of: da.operand)
+
+    case let copy as CopyAddrInst:
+      addEffects(.read, to: copy.source)
+      addEffects(.write, to: copy.destination)
+
+      if !copy.isTakeOfSrc {
+        addEffects(.copy, to: copy.source)
+      }
+      if !copy.isInitializationOfDest {
+        addDestroyEffects(of: copy.destination)
+      }
+
+    case let store as StoreInst:
+      addEffects(.write, to: store.destination)
+      if store.destinationOwnership == .assign {
+        addDestroyEffects(of: store.destination)
+      }
+
+    case let store as StoreWeakInst:
+      addEffects(.write, to: store.destination)
+
+    case let store as StoreUnownedInst:
+      addEffects(.write, to: store.destination)
+
+    case is LoadInst, is LoadWeakInst, is LoadUnownedInst, is LoadBorrowInst:
+      let addr = inst.operands[0].value
+      addEffects(.read, to: addr)
+
+    case let apply as FullApplySite:
+      let calleeValue = apply.callee
+      if apply.callee.type.isCalleeConsumedFunction {
+        addDestroyEffects(of: calleeValue)
+      }
+      handleApply(apply)
+
+    case let pa as PartialApplyInst:
+      if pa.canBeAppliedInFunction(context) {
+        // Only if the created closure can actually be called in the function
+        // we have to consider side-effects within the closure.
+        handleApply(pa)
+      }
+
+    case let fl as FixLifetimeInst:
+      // A fix_lifetime instruction acts like a read on the operand to prevent
+      // releases moving above the fix_lifetime.
+      addEffects(.read, to: fl.operand)
+
+      // Instructions which have effects defined in SILNodes.def, but those effects are
+      // not relevant for our purpose.
+      // In most cases these conservative effects are there to prevent code re-scheduling within
+      // the function. But this is not relevant for side effect summaries which we compute here.
+    case is DeallocStackInst, is DeallocStackRefInst,
+      is BeginAccessInst, is EndAccessInst,
+      is BeginBorrowInst, is EndBorrowInst,
+      is DebugValueInst, is KeyPathInst, is FixLifetimeInst,
+      is EndApplyInst, is AbortApplyInst,
+      is EndCOWMutationInst, is UnconditionalCheckedCastInst,
+      is CondFailInst:
+      break
+
+    default:
+      if inst.mayRelease {
+        globalEffects = .worstEffects
+      }
+      if inst.mayReadFromMemory {
+        globalEffects.memory.read = true
+      }
+      if inst.mayWriteToMemory {
+        globalEffects.memory.write = true
+      }
+      if inst.hasUnspecifiedSideEffects {
+        globalEffects.ownership.copy = true
+      }
+
+      // Ignore "local" allocations, which don't escape. They cannot be observed
+      // from outside the function.
+      if let alloc = inst as? Allocation, !(inst is AllocStackInst),
+         alloc.isEscaping(context) {
+        globalEffects.allocates = true
+      }
+    }
+  }
+  
+  mutating func addEffectsForEcapingArgument(argument: FunctionArgument) {
+    var escapeWalker = ArgumentEscapingWalker()
+
+    if escapeWalker.hasUnknownUses(argument: argument) {
+      // Worst case: we don't know anything about how the argument escapes.
+      addEffects(globalEffects.restrictedTo(argument: argument, withConvention: argument.convention), to: argument)
+
+    } else if escapeWalker.foundTakingLoad {
+      // In most cases we can just ignore loads. But if the load is actually "taking" the
+      // underlying memory allocation, we must consider this as a "destroy", because we don't
+      // know what's happening with the loaded value. If there is any destroying instruction in the
+      // function, it might be the destroy of the loaded value.
+      let effects = SideEffects.GlobalEffects(ownership: globalEffects.ownership)
+      addEffects(effects.restrictedTo(argument: argument, withConvention: argument.convention), to: argument)
+
+    } else if escapeWalker.foundConsumingPartialApply && globalEffects.ownership.destroy {
+      // Similar situation with apply instructions which consume the callee closure.
+      addEffects(.destroy, to: argument)
+    }
+  }
+  
+  private mutating func handleApply(_ apply: ApplySite) {
+    let callees = calleeAnalysis.getCallees(callee: apply.callee)
+
+    guard let callees = callees else {
+      // We don't know which function(s) are called.
+      globalEffects = .worstEffects
+      for argument in apply.arguments {
+        addEffects(.worstEffects, to: argument)
+      }
+      return
+    }
+    for callee in callees {
+      if let sideEffects = callee.effects.sideEffects {
+        globalEffects.merge(with: sideEffects.global)
+      } else {
+        // The callee doesn't have any computed effects. At least we can do better
+        // if it has any defined effect attribute (like e.g. `[readnone]`).
+        globalEffects.merge(with: callee.definedSideEffects)
+      }
+    }
+
+    for (argumentIdx, argument) in apply.arguments.enumerated() {
+      let calleeArgIdx = apply.calleeArgIndex(callerArgIndex: argumentIdx)
+      for callee in callees {
+        if let sideEffects = callee.effects.sideEffects {
+          let calleeEffect = sideEffects.getArgumentEffects(for: calleeArgIdx)
+
+          // Merge the callee effects into this function's effects
+          if let calleePath = calleeEffect.read    { addEffects(.read,    to: argument, fromInitialPath: calleePath) }
+          if let calleePath = calleeEffect.write   { addEffects(.write,   to: argument, fromInitialPath: calleePath) }
+          if let calleePath = calleeEffect.copy    { addEffects(.copy,    to: argument, fromInitialPath: calleePath) }
+          if let calleePath = calleeEffect.destroy { addEffects(.destroy, to: argument, fromInitialPath: calleePath) }
+        } else {
+          var calleeEffects = callee.definedSideEffects
+
+          let convention = callee.getArgumentConvention(for: calleeArgIdx)
+          if convention.isIndirectIn {
+            calleeEffects.memory.read = true
+          } else if convention == .indirectOut {
+            calleeEffects.memory.write = true
+          }
+          addEffects(calleeEffects.restrictedTo(argument: argument, withConvention: convention), to: argument)
+        }
+      }
+    }
+  }
+
+  private mutating func addDestroyEffects(of addressOrValue: Value) {
+    // First thing: add the destroy effect itself.
+    addEffects(.destroy, to: addressOrValue)
+
+    // Second: add all effects of (potential) destructors which might be called if the destroy
+    // deallocates an object.
+    if let destructors = calleeAnalysis.getDestructors(of: addressOrValue.type) {
+      for destructor in destructors {
+        globalEffects.merge(with: destructor.effects.accumulatedSideEffects)
+      }
+    } else {
+      globalEffects = .worstEffects
+    }
+  }
+
+  /// Adds effects to a specific value.
+  ///
+  /// If the value comes from an argument (or mutliple arguments), then the effects are added
+  /// to the corrseponding `argumentEffects`. Otherwise they are added to the `global` effects.
+  private mutating func addEffects(_ effects: SideEffects.GlobalEffects, to value: Value,
+                                   fromInitialPath: SmallProjectionPath? = nil) {
+
+    /// Collects the (non-address) roots of a value.
+    struct GetRootsWalker : ValueUseDefWalker {
+      // All function-argument roots of the value, including the path from the arguments to the values.
+      var roots: Stack<(FunctionArgument, SmallProjectionPath)>
+
+      // True, if the value has at least one non function-argument root.
+      var nonArgumentRootsFound = false
+
+      var walkUpCache = WalkerCache<SmallProjectionPath>()
+
+      init(_ context: PassContext) {
+        self.roots = Stack(context)
+      }
+
+      mutating func rootDef(value: Value, path: SmallProjectionPath) -> WalkResult {
+        if let arg = value as? FunctionArgument {
+          roots.push((arg, path))
+        } else if value is Allocation {
+          // Ignore effects on local allocations - even if those allocations escape.
+          // Effects on local (potentially escaping) allocations cannot be relevant in the caller.
+          return .continueWalk
+        } else {
+          nonArgumentRootsFound = true
+        }
+        return .continueWalk
+      }
+    }
+
+    var findRoots = GetRootsWalker(context)
+    if value.type.isAddress {
+      // If there is no initial path provided, select all value fields.
+      let path = fromInitialPath ?? SmallProjectionPath(.anyValueFields)
+
+      let accessPath = value.getAccessPath(fromInitialPath: path)
+      switch accessPath.base {
+        case .stack:
+          // We don't care about read and writes from/to stack locations (because they are
+          // not observable from outside the function). But we need to consider copies and destroys.
+          // For example, an argument could be "moved" to a stack location, which is eventually destroyed.
+          // In this case it's in fact the original argument value which is destroyed.
+          globalEffects.ownership.merge(with: effects.ownership)
+          return
+        case .argument(let arg):
+          // The `value` is an address projection of an indirect argument.
+          argumentEffects[arg.index].merge(effects, with: accessPath.projectionPath)
+          return
+        default:
+          // Handle address `value`s which are are field projections from class references in direct arguments.
+          if !findRoots.visitAccessStorageRoots(of: accessPath) {
+            findRoots.nonArgumentRootsFound = true
+          }
+      }
+    } else {
+      // Handle non-address `value`s which are projections from a direct arguments.
+      let path: SmallProjectionPath
+      if let fromInitialPath = fromInitialPath {
+        path = fromInitialPath
+      } else if value.type.isClass {
+        path = SmallProjectionPath(.anyValueFields).push(.anyClassField)
+      } else {
+        path = SmallProjectionPath(.anyValueFields).push(.anyClassField).push(.anyValueFields)
+      }
+      _ = findRoots.walkUp(value: value, path: path)
+    }
+    // Because of phi-arguments, a single (non-address) `value` can come from multiple arguments.
+    while let (arg, path) = findRoots.roots.pop() {
+      argumentEffects[arg.index].merge(effects, with: path)
+    }
+    if findRoots.nonArgumentRootsFound {
+      // The `value` comes from some non-argument root, e.g. a load instruction.
+      globalEffects.merge(with: effects)
+    }
+  }
+}
+
+/// Checks if an argument escapes to some unknown user.
+private struct ArgumentEscapingWalker : ValueDefUseWalker, AddressDefUseWalker {
+  var walkDownCache = WalkerCache<UnusedWalkingPath>()
+
+  /// True if the argument escapes to a load which (potentially) "takes" the memory location.
+  private(set) var foundTakingLoad = false
+
+  /// True, if the argument escapes to a closure context which might be destroyed when called.
+  private(set) var foundConsumingPartialApply = false
+
+  mutating func hasUnknownUses(argument: FunctionArgument) -> Bool {
+    if argument.type.isAddress {
+      return walkDownUses(ofAddress: argument, path: UnusedWalkingPath()) == .abortWalk
+    } else if argument.type.isTrivial(in: argument.function) {
+      return false
+    } else {
+      return walkDownUses(ofValue: argument, path: UnusedWalkingPath()) == .abortWalk
+    }
+  }
+
+  mutating func leafUse(value: Operand, path: UnusedWalkingPath) -> WalkResult {
+    switch value.instruction {
+    case is RefTailAddrInst, is RefElementAddrInst, is ProjectBoxInst:
+      return walkDownUses(ofAddress: value.instruction as! SingleValueInstruction, path: path)
+
+    // Warning: all instruction listed here, must also be handled in `CollectedEffects.addInstructionEffects`
+    case is CopyValueInst, is RetainValueInst, is StrongRetainInst,
+         is DestroyValueInst, is ReleaseValueInst, is StrongReleaseInst,
+         is DebugValueInst, is UnconditionalCheckedCastInst,
+         is ReturnInst:
+      return .continueWalk
+
+    case let apply as ApplySite:
+      if apply.isCalleeOperand(value) {
+        // `CollectedEffects.handleApply` only handles argument operands of an apply, but not the callee operand.
+        return .abortWalk
+      }
+      if let pa = apply as? PartialApplyInst, !pa.isOnStack {
+        foundConsumingPartialApply = true
+      }
+      return .continueWalk
+    default:
+      return .abortWalk
+    }
+  }
+
+  mutating func leafUse(address: Operand, path: UnusedWalkingPath) -> WalkResult {
+    let inst = address.instruction
+    let function = inst.function
+    switch inst {
+    case let copy as CopyAddrInst:
+      if address == copy.sourceOperand &&
+          !address.value.type.isTrivial(in: inst.function) &&
+          (!function.hasOwnership || copy.isTakeOfSrc) {
+        foundTakingLoad = true
+      }
+      return .continueWalk
+ 
+    case let load as LoadInst:
+      if !address.value.type.isTrivial(in: function) &&
+          // In non-ossa SIL we don't know if a load is taking.
+          (!function.hasOwnership || load.ownership == .take) {
+        foundTakingLoad = true
+      }
+      return .continueWalk
+
+    case is LoadWeakInst, is LoadUnownedInst, is LoadBorrowInst:
+      if !function.hasOwnership && !address.value.type.isTrivial(in: function) {
+        foundTakingLoad = true
+      }
+      return .continueWalk
+
+    // Warning: all instruction listed here, must also be handled in `CollectedEffects.addInstructionEffects`
+    case is StoreInst, is StoreWeakInst, is StoreUnownedInst, is ApplySite, is DestroyAddrInst:
+      return .continueWalk
+
+    default:
+      return .abortWalk
+    }
+  }
+}
+
+private extension SideEffects.GlobalEffects {
+  static var read: Self    { Self(memory: SideEffects.Memory(read: true)) }
+  static var write: Self   { Self(memory: SideEffects.Memory(write: true)) }
+  static var copy: Self    { Self(ownership: SideEffects.Ownership(copy: true)) }
+  static var destroy: Self { Self(ownership: SideEffects.Ownership(destroy: true)) }
+}
+
+private extension SideEffects.ArgumentEffects {
+  mutating func merge(_ effects: SideEffects.GlobalEffects, with path: SmallProjectionPath) {
+    if effects.memory.read       { read.merge(with: path) }
+    if effects.memory.write      { write.merge(with: path) }
+    if effects.ownership.copy    { copy.merge(with: path) }
+    if effects.ownership.destroy { destroy.merge(with: path) }
+  }
+}
+
+private extension PartialApplyInst {
+  func canBeAppliedInFunction(_ context: PassContext) -> Bool {
+    struct EscapesToApply : EscapeVisitor {
+      func visitUse(operand: Operand, path: EscapePath) -> UseResult {
+        switch operand.instruction {
+        case is ApplySite:
+          // Any escape to apply - regardless if it's an argument or the callee operand - might cause
+          // the closure to be called.
+          return .abort
+        case is ReturnInst:
+          return .ignore
+        default:
+          return .continueWalk
+        }
+      }
+      func hasRelevantType(_ value: Value, at path: SmallProjectionPath, analyzeAddresses: Bool) -> Bool {
+        true
+      }
+    }
+
+    return self.isEscapingWhenWalkingDown(using: EscapesToApply(), context)
+  }
+}

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ReleaseDevirtualizer.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ReleaseDevirtualizer.swift
@@ -113,18 +113,17 @@ private struct FindAllocationOfRelease : ValueUseDefWalker {
   private let allocInst: AllocRefInstBase
   private var allocFound = false
 
-  var walkUpCache = WalkerCache<SmallProjectionPath>()
+  var walkUpCache = WalkerCache<UnusedWalkingPath>()
 
   init(allocation: AllocRefInstBase) { allocInst = allocation }
 
   /// The top-level entry point: returns true if the root of `value` is the `allocInst`.
   mutating func allocationIsRoot(of value: Value) -> Bool {
-    let path = SmallProjectionPath().push(.anyValueFields)
-    return walkUp(value: value, path: path) != .abortWalk &&
+    return walkUp(value: value, path: UnusedWalkingPath()) != .abortWalk &&
            allocFound
   }
 
-  mutating func rootDef(value: Value, path: SmallProjectionPath) -> WalkResult {
+  mutating func rootDef(value: Value, path: UnusedWalkingPath) -> WalkResult {
     if value == allocInst {
       allocFound = true
       return .continueWalk
@@ -134,7 +133,7 @@ private struct FindAllocationOfRelease : ValueUseDefWalker {
 
   // This function is called for `struct` and `tuple` instructions in case the `path` doesn't select
   // a specific operand but all operands.
-  mutating func walkUpAllOperands(of def: Instruction, path: SmallProjectionPath) -> WalkResult {
+  mutating func walkUpAllOperands(of def: Instruction, path: UnusedWalkingPath) -> WalkResult {
   
     // Instead of walking up _all_ operands (which would be the default behavior), require that only a
     // _single_ operand is not trivial and walk up that operand.

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
@@ -52,6 +52,7 @@ private func registerSwiftPasses() {
   // Function passes
   registerPass(mergeCondFailsPass, { mergeCondFailsPass.run($0) })
   registerPass(computeEscapeEffects, { computeEscapeEffects.run($0) })
+  registerPass(computeSideEffects, { computeSideEffects.run($0) })
   registerPass(objCBridgingOptimization, { objCBridgingOptimization.run($0) })
   registerPass(stackPromotion, { stackPromotion.run($0) })
   registerPass(functionStackProtection, { functionStackProtection.run($0) })

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
@@ -70,6 +70,7 @@ private func registerSwiftPasses() {
   registerPass(escapeInfoDumper, { escapeInfoDumper.run($0) })
   registerPass(addressEscapeInfoDumper, { addressEscapeInfoDumper.run($0) })
   registerPass(accessDumper, { accessDumper.run($0) })
+  registerPass(deadEndBlockDumper, { deadEndBlockDumper.run($0) })
   registerPass(rangeDumper, { rangeDumper.run($0) })
   registerPass(runUnitTests, { runUnitTests.run($0) })
 }

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
@@ -51,7 +51,7 @@ private func registerSwiftPasses() {
 
   // Function passes
   registerPass(mergeCondFailsPass, { mergeCondFailsPass.run($0) })
-  registerPass(computeEffects, { computeEffects.run($0) })
+  registerPass(computeEscapeEffects, { computeEscapeEffects.run($0) })
   registerPass(objCBridgingOptimization, { objCBridgingOptimization.run($0) })
   registerPass(stackPromotion, { stackPromotion.run($0) })
   registerPass(functionStackProtection, { functionStackProtection.run($0) })

--- a/SwiftCompilerSources/Sources/Optimizer/TestPasses/AccessDumper.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/TestPasses/AccessDumper.swift
@@ -48,11 +48,12 @@ let accessDumper = FunctionPass(name: "dump-access", {
   print("End accesses for \(function.name)")
 })
 
-private struct AccessStoragePathVisitor : AccessStoragePathWalker {
+private struct AccessStoragePathVisitor : ValueUseDefWalker {
   var walkUpCache = WalkerCache<Path>()
-  mutating func visit(accessStoragePath: ProjectedValue) {
-    print("    Storage: \(accessStoragePath.value)")
-    print("    Path: \"\(accessStoragePath.path)\"")
+  mutating func rootDef(value: Value, path: SmallProjectionPath) -> WalkResult {
+    print("    Storage: \(value)")
+    print("    Path: \"\(path)\"")
+    return .continueWalk
   }
 }
 

--- a/SwiftCompilerSources/Sources/Optimizer/TestPasses/AccessDumper.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/TestPasses/AccessDumper.swift
@@ -59,8 +59,7 @@ private struct AccessStoragePathVisitor : AccessStoragePathWalker {
 private func printAccessInfo(address: Value) {
   print("Value: \(address)")
 
-  var apw = AccessPathWalker()
-  let (ap, scope) = apw.getAccessPathWithScope(of: address)
+  let (ap, scope) = address.accessPathWithScope
   if let beginAccess = scope {
     print("  Scope: \(beginAccess)")
   } else {
@@ -79,9 +78,8 @@ private func printAccessInfo(address: Value) {
 private func checkAliasInfo(forArgumentsOf apply: ApplyInst, expectDistinct: Bool) {
   let address1 = apply.arguments[0]
   let address2 = apply.arguments[1]
-  var apw = AccessPathWalker()
-  let path1 = apw.getAccessPath(of: address1)
-  let path2 = apw.getAccessPath(of: address2)
+  let path1 = address1.accessPath
+  let path2 = address2.accessPath
 
   if path1.isDistinct(from: path2) != expectDistinct {
     print("wrong isDistinct result of \(apply)")

--- a/SwiftCompilerSources/Sources/Optimizer/TestPasses/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/TestPasses/CMakeLists.txt
@@ -9,6 +9,7 @@
 swift_compiler_sources(Optimizer
   FunctionUsesDumper.swift
   AccessDumper.swift
+  DeadEndBlockDumper.swift
   EscapeInfoDumper.swift
   SILPrinter.swift
   RangeDumper.swift

--- a/SwiftCompilerSources/Sources/Optimizer/TestPasses/DeadEndBlockDumper.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/TestPasses/DeadEndBlockDumper.swift
@@ -1,0 +1,26 @@
+//===--- DeadEndBlockDumper.swift -----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SIL
+
+let deadEndBlockDumper = FunctionPass(name: "dump-deadendblocks", {
+  (function: Function, context: PassContext) in
+
+  
+  print("Function \(function.name)")
+  
+  var deadEndBlocks = DeadEndBlocks(function: function, context)
+  print(deadEndBlocks)
+  defer { deadEndBlocks.deinitialize() }
+
+  print("end function \(function.name)")
+})

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/AccessUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/AccessUtils.swift
@@ -337,108 +337,75 @@ enum EnclosingScope {
   case base(AccessBase)
 }
 
-/// A walker utility that, given an address value, computes the `AccessPath`
-/// of the access (the base address and the address projections to the accessed fields) and
-/// the innermost enclosing scope (`begin_access`).
-struct AccessPathWalker {
-  mutating func getAccessPath(of address: Value) -> AccessPath {
-    assert(address.type.isAddress, "Expected address")
-    walker.start()
-    if walker.walkUp(address: address, path: Walker.Path()) == .abortWalk {
-      assert(walker.result.base == .unidentified,
+private struct AccessPathWalker : AddressUseDefWalker {
+  var result = AccessPath.unidentified()
+  var foundBeginAccess: BeginAccessInst?
+
+  mutating func walk(startAt address: Value, initialPath: SmallProjectionPath = SmallProjectionPath()) {
+    if walkUp(address: address, path: Path(projectionPath: initialPath)) == .abortWalk {
+      assert(result.base == .unidentified,
              "shouldn't have set an access base in an aborted walk")
     }
-    return walker.result
   }
 
-  mutating func getAccessPathWithScope(of address: Value) -> (AccessPath, scope: BeginAccessInst?) {
-    let ap = getAccessPath(of: address)
-    return (ap, walker.foundBeginAccess)
+  struct Path : SmallProjectionWalkingPath {
+    let projectionPath: SmallProjectionPath
+
+    // Tracks whether an `index_addr` instruction was crossed.
+    // It should be (FIXME: check if it's enforced) that operands
+    // of `index_addr` must be `tail_addr` or other `index_addr` results.
+    let indexAddr: Bool
+
+    init(projectionPath: SmallProjectionPath = SmallProjectionPath(), indexAddr: Bool = false) {
+      self.projectionPath = projectionPath
+      self.indexAddr = indexAddr
+    }
+
+    func with(projectionPath: SmallProjectionPath) -> Self {
+      return Self(projectionPath: projectionPath, indexAddr: indexAddr)
+    }
+
+    func with(indexAddr: Bool) -> Self {
+      return Self(projectionPath: projectionPath, indexAddr: indexAddr)
+    }
+
+    func merge(with other: Self) -> Self {
+      return Self(
+        projectionPath: projectionPath.merge(with: other.projectionPath),
+        indexAddr: indexAddr || other.indexAddr
+      )
+    }
   }
 
-  mutating func getAccessBase(of address: Value) -> AccessBase {
-    getAccessPath(of: address).base
+  mutating func rootDef(address: Value, path: Path) -> WalkResult {
+    assert(result.base == .unidentified, "rootDef should only called once")
+    // Try identifying the address a pointer originates from
+    if let p2ai = address as? PointerToAddressInst {
+      if let originatingAddr = p2ai.originatingAddress {
+        return walkUp(address: originatingAddr, path: path)
+      } else {
+        self.result = AccessPath(base: .pointer(p2ai), projectionPath: path.projectionPath)
+        return .continueWalk
+      }
+    }
+
+    let base = AccessBase(baseAddress: address)
+    self.result = AccessPath(base: base, projectionPath: path.projectionPath)
+    return .continueWalk
   }
 
-  mutating func getEnclosingScope(of address: Value) -> EnclosingScope {
-    let accessPath = getAccessPath(of: address)
-  
-    if let ba = walker.foundBeginAccess {
-      return .scope(ba)
+  mutating func walkUp(address: Value, path: Path) -> WalkResult {
+    if address is IndexAddrInst {
+      // Track that we crossed an `index_addr` during the walk-up
+      return walkUpDefault(address: address, path: path.with(indexAddr: true))
+    } else if path.indexAddr && !canBeOperandOfIndexAddr(address) {
+      // An `index_addr` instruction cannot be derived from an address
+      // projection. Bail out
+      return .abortWalk
+    } else if let ba = address as? BeginAccessInst, foundBeginAccess == nil {
+      foundBeginAccess = ba
     }
-    return .base(accessPath.base)
-  }
-
-  private var walker = Walker()
-
-  private struct Walker : AddressUseDefWalker {
-    private(set) var result = AccessPath.unidentified()
-    private(set) var foundBeginAccess: BeginAccessInst?
-
-    mutating func start() {
-      result = .unidentified()
-      foundBeginAccess = nil
-    }
-
-    struct Path : SmallProjectionWalkingPath {
-      let projectionPath: SmallProjectionPath
-
-      // Tracks whether an `index_addr` instruction was crossed.
-      // It should be (FIXME: check if it's enforced) that operands
-      // of `index_addr` must be `tail_addr` or other `index_addr` results.
-      let indexAddr: Bool
-
-      init(projectionPath: SmallProjectionPath = SmallProjectionPath(), indexAddr: Bool = false) {
-        self.projectionPath = projectionPath
-        self.indexAddr = indexAddr
-      }
-
-      func with(projectionPath: SmallProjectionPath) -> Self {
-        return Self(projectionPath: projectionPath, indexAddr: indexAddr)
-      }
-
-      func with(indexAddr: Bool) -> Self {
-        return Self(projectionPath: projectionPath, indexAddr: indexAddr)
-      }
-
-      func merge(with other: Self) -> Self {
-        return Self(
-          projectionPath: projectionPath.merge(with: other.projectionPath),
-          indexAddr: indexAddr || other.indexAddr
-        )
-      }
-    }
-
-    mutating func rootDef(address: Value, path: Path) -> WalkResult {
-      assert(result.base == .unidentified, "rootDef should only called once")
-      // Try identifying the address a pointer originates from
-      if let p2ai = address as? PointerToAddressInst {
-        if let originatingAddr = p2ai.originatingAddress {
-          return walkUp(address: originatingAddr, path: path)
-        } else {
-          self.result = AccessPath(base: .pointer(p2ai), projectionPath: path.projectionPath)
-          return .continueWalk
-        }
-      }
-
-      let base = AccessBase(baseAddress: address)
-      self.result = AccessPath(base: base, projectionPath: path.projectionPath)
-      return .continueWalk
-    }
-
-    mutating func walkUp(address: Value, path: Path) -> WalkResult {
-      if address is IndexAddrInst {
-        // Track that we crossed an `index_addr` during the walk-up
-        return walkUpDefault(address: address, path: path.with(indexAddr: true))
-      } else if path.indexAddr && !canBeOperandOfIndexAddr(address) {
-        // An `index_addr` instruction cannot be derived from an address
-        // projection. Bail out
-        return .abortWalk
-      } else if let ba = address as? BeginAccessInst, foundBeginAccess == nil {
-        foundBeginAccess = ba
-      }
-      return walkUpDefault(address: address, path: path.with(indexAddr: false))
-    }
+    return walkUpDefault(address: address, path: path.with(indexAddr: false))
   }
 }
 
@@ -451,27 +418,36 @@ extension Value {
   // go through phi-arguments, the AccessPathWalker will allocate memnory in its cache.
 
   /// Computes the access base of this address value.
-  var accessBase: AccessBase {
-    var apWalker = AccessPathWalker()
-    return apWalker.getAccessBase(of: self)
-  }
+  var accessBase: AccessBase { accessPath.base }
 
   /// Computes the access path of this address value.
   var accessPath: AccessPath {
-    var apWalker = AccessPathWalker()
-    return apWalker.getAccessPath(of: self)
+    var walker = AccessPathWalker()
+    walker.walk(startAt: self)
+    return walker.result
+  }
+
+  func getAccessPath(fromInitialPath: SmallProjectionPath) -> AccessPath {
+    var walker = AccessPathWalker()
+    walker.walk(startAt: self, initialPath: fromInitialPath)
+    return walker.result
   }
 
   /// Computes the access path of this address value and also returns the scope.
   var accessPathWithScope: (AccessPath, scope: BeginAccessInst?) {
-    var apWalker = AccessPathWalker()
-    return apWalker.getAccessPathWithScope(of: self)
+    var walker = AccessPathWalker()
+    walker.walk(startAt: self)
+    return (walker.result, walker.foundBeginAccess)
   }
 
   /// Computes the enclosing access scope of this address value.
   var enclosingAccessScope: EnclosingScope {
-    var apWalker = AccessPathWalker()
-    return apWalker.getEnclosingScope(of: self)
+    var walker = AccessPathWalker()
+    walker.walk(startAt: self)
+    if let ba = walker.foundBeginAccess {
+      return .scope(ba)
+    }
+    return .base(walker.result.base)
   }
 }
 

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/AccessUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/AccessUtils.swift
@@ -462,11 +462,7 @@ extension Value {
 ///   %addr = struct_element_addr %base : $X, #X.e
 ///   store %v to [trivial] %addr : $*Int
 /// ```
-protocol AccessStoragePathWalker : ValueUseDefWalker where Path == SmallProjectionPath {
-  mutating func visit(accessStoragePath: ProjectedValue)
-}
-
-extension AccessStoragePathWalker {
+extension ValueUseDefWalker where Path == SmallProjectionPath {
   /// The main entry point.
   /// Given an `accessPath` where the access base is a reference (class, tail, box), call
   /// the `visit` function for all storage roots with a the corresponding path.
@@ -485,10 +481,5 @@ extension AccessStoragePathWalker {
       case .stack, .global, .argument, .yield, .pointer, .unidentified:
         return false
     }
-  }
-
-  mutating func rootDef(value: Value, path: SmallProjectionPath) -> WalkResult {
-    visit(accessStoragePath: value.at(path))
-    return .continueWalk
   }
 }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
@@ -154,6 +154,11 @@ extension Value {
     return self.at(SmallProjectionPath()).isEscaping(using: visitor, context)
   }
 
+  func isEscapingWhenWalkingDown<V: EscapeVisitor>(using visitor: V = DefaultVisitor(),
+                                                   _ context: PassContext) -> Bool {
+    return self.at(SmallProjectionPath()).isEscapingWhenWalkingDown(using: visitor, context)
+  }
+
   /// The un-projected version of `ProjectedValue.visit()`.
   func visit<V: EscapeVisitorWithResult>(using visitor: V, _ context: PassContext) -> V.Result? {
     return self.at(SmallProjectionPath()).visit(using: visitor, context)

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/WalkUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/WalkUtils.swift
@@ -359,11 +359,14 @@ extension ValueDefUseWalker {
         return .continueWalk
       }
     case let cbr as CondBranchInst:
-      let val = cbr.getArgument(for: operand)
-      if let path = walkDownCache.needWalk(for: val, path: path) {
-        return walkDownUses(ofValue: val, path: path)
+      if let val = cbr.getArgument(for: operand) {
+        if let path = walkDownCache.needWalk(for: val, path: path) {
+          return walkDownUses(ofValue: val, path: path)
+        } else {
+          return .continueWalk
+        }
       } else {
-        return .continueWalk
+        return leafUse(value: operand, path: path)
       }
     case let se as SwitchEnumInst:
       if let (caseIdx, path) = path.pop(kind: .enumCase),

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/WalkUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/WalkUtils.swift
@@ -106,6 +106,16 @@ extension SmallProjectionWalkingPath {
   }
 }
 
+/// A walking path which matches everything.
+///
+/// Useful for walkers which don't care about the path and unconditionally walk to all defs/uses.
+struct UnusedWalkingPath : WalkingPath {
+  func merge(with: Self) -> Self { self }
+  func pop(kind: FieldKind) -> (index: Int, path: Self)? { nil }
+  func popIfMatches(_ kind: FieldKind, index: Int?) -> Self? { self }
+  func push(_ kind: FieldKind, index: Int) -> Self { self }
+}
+
 /// Caches the state of a walk.
 ///
 /// A client must provide this cache in a `walkUpCache` or `walkDownCache` property.

--- a/SwiftCompilerSources/Sources/SIL/ApplySite.swift
+++ b/SwiftCompilerSources/Sources/SIL/ApplySite.swift
@@ -67,17 +67,30 @@ public protocol ApplySite : Instruction {
 extension ApplySite {
   public var callee: Value { operands[ApplyOperands.calleeOperandIndex].value }
 
-  public var arguments: LazyMapSequence<OperandArray, Value> {
+  /// Returns the subset of operands which are argument operands.
+  ///
+  /// This does not include the callee function operand.
+  public var argumentOperands: OperandArray {
     let numArgs = ApplySite_getNumArguments(bridged)
     let offset = ApplyOperands.firstArgumentIndex
-    let argOps = operands[offset..<(numArgs + offset)]
-    return argOps.lazy.map { $0.value }
+    return operands[offset..<(numArgs + offset)]
+  }
+
+  /// Returns the subset of operand values which are arguments.
+  ///
+  /// This does not include the callee function operand.
+  public var arguments: LazyMapSequence<OperandArray, Value> {
+    argumentOperands.lazy.map { $0.value }
   }
 
   public var substitutionMap: SubstitutionMap {
     SubstitutionMap(ApplySite_getSubstitutionMap(bridged))
   }
 
+  /// Returns the argument index of an operand.
+  ///
+  /// Returns nil if 'operand' is not an argument operand. This is the case if
+  /// it's the callee function operand.
   public func argumentIndex(of operand: Operand) -> Int? {
     let opIdx = operand.index
     if opIdx >= ApplyOperands.firstArgumentIndex &&
@@ -87,6 +100,11 @@ extension ApplySite {
     return nil
   }
 
+  /// Returns true if `operand` is the callee function operand and not am argument operand.
+  public func isCalleeOperand(_ operand: Operand) -> Bool {
+    return operand.index < ApplyOperands.firstArgumentIndex
+  }
+  
   public func getArgumentConvention(calleeArgIndex: Int) -> ArgumentConvention {
     return ApplySite_getArgumentConvention(bridged, calleeArgIndex).convention
   }

--- a/SwiftCompilerSources/Sources/SIL/Argument.swift
+++ b/SwiftCompilerSources/Sources/SIL/Argument.swift
@@ -128,6 +128,36 @@ public enum ArgumentConvention {
   /// guarantees its validity for the entirety of the call.
   case directGuaranteed
 
+  public var isIndirect: Bool {
+    switch self {
+    case .indirectIn, .indirectInConstant, .indirectInGuaranteed,
+         .indirectInout, .indirectInoutAliasable, .indirectOut:
+      return true
+    case .directOwned, .directUnowned, .directGuaranteed:
+      return false
+    }
+  }
+
+  public var isIndirectIn: Bool {
+    switch self {
+    case .indirectIn, .indirectInConstant, .indirectInGuaranteed:
+      return true
+    case .directOwned, .directUnowned, .directGuaranteed,
+         .indirectInout, .indirectInoutAliasable, .indirectOut:
+      return false
+    }
+  }
+
+  public var isGuaranteed: Bool {
+    switch self {
+    case .indirectInGuaranteed, .directGuaranteed:
+      return true
+    case .indirectIn, .indirectInConstant, .directOwned, .directUnowned,
+         .indirectInout, .indirectInoutAliasable, .indirectOut:
+      return false
+    }
+  }
+
   public var isExclusiveIndirect: Bool {
     switch self {
     case .indirectIn,

--- a/SwiftCompilerSources/Sources/SIL/Effects.swift
+++ b/SwiftCompilerSources/Sources/SIL/Effects.swift
@@ -10,156 +10,100 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// An effect on a function argument.
-public struct ArgumentEffect : CustomStringConvertible, CustomReflectable {
-
-  public typealias Path = SmallProjectionPath
-
-  public enum Kind {
-    /// The argument value does not escape.
-    ///
-    /// Syntax examples:
-    ///    [%0: noescape]      // argument 0 does not escape
-    ///    [%0: noescape **]   // argument 0 and all transitively contained values do not escape
-    ///
-    case notEscaping
-    
-    /// The argument value escapes to the function return value.
-    ///
-    /// Syntax examples:
-    ///    [%0: escape s1 => %r]   // field 2 of argument 0 exclusively escapes via return.
-    ///    [%0: escape s1 -> %r]   // field 2 of argument 0 - and other values - escape via return
-    ///
-    /// The "exclusive" flag (= second payload) is true if only the argument escapes,
-    /// but nothing else escapes to the return value.
-    /// For example, "exclusive" is true for the following function:
-    ///
-    ///   @_effect(escaping c => return)
-    ///   func exclusiveEscape(_ c: Class) -> Class { return c }
-    ///
-    /// but not in this case:
-    ///
-    ///   var global: Class
-    ///
-    ///   @_effect(escaping c -> return)
-    ///   func notExclusiveEscape(_ c: Class) -> Class { return cond ? c : global }
-    ///
-    case escapingToReturn(Path, Bool)         // toPath, exclusive
-
-    /// Like `escapingToReturn`, but the argument escapes to another argument.
-    ///
-    /// Example: The argument effects of
-    ///   func argToArgEscape(_ r: inout Class, _ c: Class) { r = c }
-    ///
-    /// would be
-    ///    [%1: escape => %0]   // Argument 1 escapes to argument 0
-    ///
-    case escapingToArgument(Int, Path, Bool)  // toArgumentIndex, toPath, exclusive
-  }
-
-  /// To which argument does this effect apply to?
-  public let argumentIndex: Int
-  
-  /// To which projection(s) of the argument does this effect apply to?
-  public let pathPattern: Path
-  
-  /// The kind of effect.
-  public let kind: Kind
-  
-  /// True, if this effect is derived in an optimization pass.
-  /// False, if this effect is defined in the Swift source code.
-  public let isDerived: Bool
-
-  public init(_ kind: Kind, argumentIndex: Int, pathPattern: Path, isDerived: Bool = true) {
-    self.argumentIndex = argumentIndex
-    self.pathPattern = pathPattern
-    self.kind = kind
-    self.isDerived = isDerived
-  }
-
-  /// Copy the ArgumentEffect by applying a delta on the argument index.
-  ///
-  /// This is used when copying argument effects for specialized functions where
-  /// the indirect result is converted to a direct return value (in this case the
-  /// `resultArgDelta` is -1).
-  init?(copiedFrom srcEffect: ArgumentEffect, resultArgDelta: Int) {
-    if srcEffect.argumentIndex + resultArgDelta < 0 {
-      return nil
-    }
-    self.argumentIndex = srcEffect.argumentIndex + resultArgDelta
-    self.pathPattern = srcEffect.pathPattern
-    self.isDerived = srcEffect.isDerived
-
-    switch srcEffect.kind {
-    case .notEscaping:
-      self.kind = .notEscaping
-    case .escapingToReturn(let toPath, let exclusive):
-      if resultArgDelta > 0 {
-        if resultArgDelta != 1 {
-          return nil
-        }
-        self.kind = .escapingToArgument(0, toPath, exclusive)
-      } else {
-        self.kind = .escapingToReturn(toPath, exclusive)
-      }
-    case .escapingToArgument(let toArgIdx, let toPath, let exclusive):
-      let resultingToArgIdx = toArgIdx + resultArgDelta
-      if resultingToArgIdx < 0 {
-        if resultingToArgIdx != -1 {
-          return nil
-        }
-        self.kind = .escapingToReturn(toPath, exclusive)
-      } else {
-        self.kind = .escapingToArgument(resultingToArgIdx, toPath, exclusive)
-      }
-    }
-  }
-
-  public func matches(_ rhsArgIdx: Int, _ rhsPath: Path) -> Bool {
-    return argumentIndex == rhsArgIdx && rhsPath.matches(pattern: pathPattern)
-  }
-
-  public var headerDescription: String {
-    "%\(argumentIndex)\(isDerived ? "" : "!"): "
-  }
-
-  public var bodyDescription: String {
-    let patternStr = pathPattern.isEmpty ? "" : " \(pathPattern)"
-    switch kind {
-      case .notEscaping:
-        return "noescape\(patternStr)"
-      case .escapingToReturn(let toPath, let exclusive):
-        let toPathStr = (toPath.isEmpty ? "" : ".\(toPath)")
-        return "escape\(patternStr) \(exclusive ? "=>" : "->") %r\(toPathStr)"
-      case .escapingToArgument(let toArgIdx, let toPath, let exclusive):
-        let toPathStr = (toPath.isEmpty ? "" : ".\(toPath)")
-        return "escape\(patternStr) \(exclusive ? "=>" : "->") %\(toArgIdx)\(toPathStr)"
-    }
-  }
-
-  public var description: String {
-    headerDescription + bodyDescription
-  }
-
-  public var customMirror: Mirror { Mirror(self, children: []) }
-}
-
-/// All argument effects for a function.
+/// All effects for a function.
 ///
-/// In future we might add non-argument-specific effects, too, like `readnone`, `readonly`.
-public struct FunctionEffects : CustomStringConvertible, CustomReflectable {
-  public var argumentEffects: [ArgumentEffect] = []
-  
+/// It consists of escape and side effects.
+public struct FunctionEffects : CustomStringConvertible, NoReflectionChildren {
+
+  public var escapeEffects = EscapeEffects(arguments: [])
+
+  // If nil, the side effects are not computed yet and clients need to assume
+  // the worst effects (using `Function.getDefinedSideEffects()`).
+  public var sideEffects: SideEffects?
+
   public init() {}
 
   public init(copiedFrom src: FunctionEffects, resultArgDelta: Int) {
-    self.argumentEffects = src.argumentEffects.compactMap {
-        ArgumentEffect(copiedFrom: $0, resultArgDelta: resultArgDelta)
-      }
+    self.escapeEffects = EscapeEffects(arguments: src.escapeEffects.arguments.compactMap {
+        EscapeEffects.ArgumentEffect(copiedFrom: $0, resultArgDelta: resultArgDelta)
+      })
+    // Cannot copy side effects
+    self.sideEffects = nil
   }
 
-  public func canEscape(argumentIndex: Int, path: ArgumentEffect.Path, analyzeAddresses: Bool) -> Bool {
-    return !argumentEffects.contains(where: {
+  /// The "accumulated" side-effects of the function, which includes the global effects and
+  /// all argument effects.
+  public var accumulatedSideEffects: SideEffects.GlobalEffects {
+    if let sideEffects = sideEffects {
+      return sideEffects.accumulatedEffects
+    }
+    return .worstEffects
+  }
+
+  public var description: String {
+    var numArgEffects = escapeEffects.arguments.reduce(0, { max($0, $1.argumentIndex) }) + 1
+    if let sideEffects = sideEffects {
+      numArgEffects = max(numArgEffects, sideEffects.arguments.count)
+    }
+    var result = ""
+    for argIdx in 0..<numArgEffects {
+      var argStrings: [String] = []
+      for escEffect in escapeEffects.arguments where escEffect.argumentIndex == argIdx {
+        argStrings.append(escEffect.bodyDescription)
+      }
+      if let sideEffects = sideEffects, argIdx < sideEffects.arguments.count {
+        let argDescription = sideEffects.arguments[argIdx].bodyDescription
+        if !argDescription.isEmpty {
+          argStrings.append(argDescription)
+        }
+      }
+      if !argStrings.isEmpty {
+        result += "[%\(argIdx): " + argStrings.joined(separator: ", ") + "]\n"
+      }
+    }
+    if let sideEffects = sideEffects {
+      result += "[global: \(sideEffects.global)]\n"
+    }
+    return result
+  }
+}
+
+extension Function {
+  
+  /// The global side effects of the function which are defined by attributes.
+  ///
+  /// This API should be used if there are no derived side-effects available, i.e. `effects.sideEffects` is nil.
+  /// It returns "worstEffects" unless an effect attribute (e.g. `[readnone]`) is set for the function.
+  public var definedSideEffects: SideEffects.GlobalEffects {
+    var result = SideEffects.GlobalEffects.worstEffects
+    switch effectAttribute {
+    case .none:
+      break
+    case .readNone:
+      result.memory.read = false
+      result.memory.write = false
+      result.ownership.destroy = false
+      result.allocates = false
+    case .readOnly:
+      result.memory.write = false
+      result.ownership.destroy = false
+      result.allocates = false
+    case .releaseNone:
+      result.ownership.destroy = false
+    }
+    return result
+  }
+}
+
+/// Escape effects.
+///
+/// The escape effects describe which arguments are not escaping or escaping to
+/// the return value or other arguments.
+public struct EscapeEffects : CustomStringConvertible, NoReflectionChildren {
+  public var arguments: [ArgumentEffect]
+
+  public func canEscape(argumentIndex: Int, path: SmallProjectionPath, analyzeAddresses: Bool) -> Bool {
+    return !arguments.contains(where: {
       if case .notEscaping = $0.kind, $0.argumentIndex == argumentIndex {
 
         // Any address of a class property of an object, which is passed to the function, cannot
@@ -174,35 +118,399 @@ public struct FunctionEffects : CustomStringConvertible, CustomReflectable {
     })
   }
 
-
-  public mutating func removeDerivedEffects() {
-    argumentEffects = argumentEffects.filter { !$0.isDerived }
+  public var description: String {
+    let maxArgIdx = arguments.reduce(0) { max($0, $1.argumentIndex) }
+    var result = ""
+    for argIdx in 0...maxArgIdx {
+      var argStrings: [String] = []
+      for escEffect in arguments where escEffect.argumentIndex == argIdx {
+        argStrings.append(escEffect.bodyDescription)
+      }
+      if !argStrings.isEmpty {
+        result += "[%\(argIdx): " + argStrings.joined(separator: ", ") + "]\n"
+      }
+    }
+    return result
   }
 
-  public var argumentEffectsDescription: String {
-    var currentArgIdx = -1
-    var currentIsDerived = false
-    var result = ""
-    for effect in argumentEffects {
-      if effect.argumentIndex != currentArgIdx ||  effect.isDerived != currentIsDerived {
-        if currentArgIdx >= 0 { result += "]\n" }
-        result += "[\(effect.headerDescription)"
-        currentArgIdx = effect.argumentIndex
-        currentIsDerived = effect.isDerived
-      } else {
-        result += ", "
-      }
-      result += effect.bodyDescription
+  /// An escape effect on a function argument.
+  public struct ArgumentEffect : CustomStringConvertible, NoReflectionChildren {
+
+    public enum Kind {
+      /// The argument value does not escape.
+      ///
+      /// Syntax examples:
+      ///    [%0: noescape]      // argument 0 does not escape
+      ///    [%0: noescape **]   // argument 0 and all transitively contained values do not escape
+      ///
+      case notEscaping
+      
+      /// The argument value escapes to the function return value.
+      ///
+      /// Syntax examples:
+      ///    [%0: escape s1 => %r]   // field 2 of argument 0 exclusively escapes via return.
+      ///    [%0: escape s1 -> %r]   // field 2 of argument 0 - and other values - escape via return
+      ///
+      /// The "exclusive" flag (= second payload) is true if only the argument escapes,
+      /// but nothing else escapes to the return value.
+      /// For example, "exclusive" is true for the following function:
+      ///
+      ///   @_effect(escaping c => return)
+      ///   func exclusiveEscape(_ c: Class) -> Class { return c }
+      ///
+      /// but not in this case:
+      ///
+      ///   var global: Class
+      ///
+      ///   @_effect(escaping c -> return)
+      ///   func notExclusiveEscape(_ c: Class) -> Class { return cond ? c : global }
+      ///
+      case escapingToReturn(SmallProjectionPath, Bool)         // toPath, exclusive
+
+      /// Like `escapingToReturn`, but the argument escapes to another argument.
+      ///
+      /// Example: The argument effects of
+      ///   func argToArgEscape(_ r: inout Class, _ c: Class) { r = c }
+      ///
+      /// would be
+      ///    [%1: escape => %0]   // Argument 1 escapes to argument 0
+      ///
+      case escapingToArgument(Int, SmallProjectionPath, Bool)  // toArgumentIndex, toPath, exclusive
     }
-    if currentArgIdx >= 0 { result += "]\n" }
+
+    /// To which argument does this effect apply to?
+    public let argumentIndex: Int
+    
+    /// To which projection(s) of the argument does this effect apply to?
+    public let pathPattern: SmallProjectionPath
+    
+    /// The kind of effect.
+    public let kind: Kind
+    
+    /// True, if this effect is derived in an optimization pass.
+    /// False, if this effect is defined in the Swift source code.
+    public let isDerived: Bool
+
+    public init(_ kind: Kind, argumentIndex: Int, pathPattern: SmallProjectionPath, isDerived: Bool = true) {
+      self.argumentIndex = argumentIndex
+      self.pathPattern = pathPattern
+      self.kind = kind
+      self.isDerived = isDerived
+    }
+
+    /// Copy the ArgumentEffect by applying a delta on the argument index.
+    ///
+    /// This is used when copying argument effects for specialized functions where
+    /// the indirect result is converted to a direct return value (in this case the
+    /// `resultArgDelta` is -1).
+    init?(copiedFrom srcEffect: ArgumentEffect, resultArgDelta: Int) {
+      if srcEffect.argumentIndex + resultArgDelta < 0 {
+        return nil
+      }
+      self.argumentIndex = srcEffect.argumentIndex + resultArgDelta
+      self.pathPattern = srcEffect.pathPattern
+      self.isDerived = srcEffect.isDerived
+
+      switch srcEffect.kind {
+      case .notEscaping:
+        self.kind = .notEscaping
+
+      case .escapingToReturn(let toPath, let exclusive):
+        if resultArgDelta > 0 {
+          if resultArgDelta != 1 {
+            return nil
+          }
+          self.kind = .escapingToArgument(0, toPath, exclusive)
+        } else {
+          self.kind = .escapingToReturn(toPath, exclusive)
+        }
+      case .escapingToArgument(let toArgIdx, let toPath, let exclusive):
+        let resultingToArgIdx = toArgIdx + resultArgDelta
+        if resultingToArgIdx < 0 {
+          if resultingToArgIdx != -1 {
+            return nil
+          }
+          self.kind = .escapingToReturn(toPath, exclusive)
+        } else {
+          self.kind = .escapingToArgument(resultingToArgIdx, toPath, exclusive)
+        }
+      }
+    }
+
+    public func matches(_ rhsArgIdx: Int, _ rhsPath: SmallProjectionPath) -> Bool {
+      if argumentIndex != rhsArgIdx {
+        return false
+      }
+      return rhsPath.matches(pattern: pathPattern)
+    }
+
+    public var bodyDescription: String {
+      let patternStr = (isDerived ? "" : "!") + (pathPattern.isEmpty ? "" : " \(pathPattern)")
+      switch kind {
+        case .notEscaping:
+          return "noescape\(patternStr)"
+        case .escapingToReturn(let toPath, let exclusive):
+          let toPathStr = (toPath.isEmpty ? "" : ".\(toPath)")
+          return "escape\(patternStr) \(exclusive ? "=>" : "->") %r\(toPathStr)"
+        case .escapingToArgument(let toArgIdx, let toPath, let exclusive):
+          let toPathStr = (toPath.isEmpty ? "" : ".\(toPath)")
+          return "escape\(patternStr) \(exclusive ? "=>" : "->") %\(toArgIdx)\(toPathStr)"
+      }
+    }
+
+    public var description: String {
+      "\(argumentIndex): \(bodyDescription)"
+    }
+  }
+}
+
+/// Side effects.
+///
+/// Side effects describe the memory (read, write) and ownership (copy, destroy)
+/// of the function arguments and the function as a whole.
+public struct SideEffects : CustomStringConvertible, NoReflectionChildren {
+  /// Effects, which can be attributed to a specific argument.
+  ///
+  /// This array is indexed by the argument index. Arguments which indices, which
+  /// are not included in this array, are defined to have no effects.
+  public let arguments: [ArgumentEffects]
+  
+  /// Effects, which cannot be attributed to a specific argument.
+  public let global: GlobalEffects
+  
+  public init(arguments: [ArgumentEffects], global: GlobalEffects) {
+    self.arguments = arguments
+    self.global = global
+  }
+
+  /// Returns the effects of an argument.
+  ///
+  /// In constrast to using `arguments` directly, it's valid to have an `argumentIndex`
+  /// which is larger than the number of elements in `arguments`.
+  public func getArgumentEffects(for argumentIndex: Int) -> ArgumentEffects {
+    if argumentIndex < arguments.count {
+      return arguments[argumentIndex]
+    }
+    return ArgumentEffects()
+  }
+
+  /// The "accumulated" effects of the function, which includes the `global` effects and
+  /// all argument effects.
+  public var accumulatedEffects: GlobalEffects {
+    var result = global
+    for argEffect in arguments {
+      if argEffect.read != nil    { result.memory.read = true }
+      if argEffect.write != nil   { result.memory.write = true }
+      if argEffect.copy != nil    { result.ownership.copy = true }
+      if argEffect.destroy != nil { result.ownership.destroy = true }
+    }
     return result
   }
 
   public var description: String {
-    return argumentEffectsDescription
+    var result = ""
+    for (argIdx, argument) in arguments.enumerated() {
+      let argDescription = argument.bodyDescription
+      if !argDescription.isEmpty {
+        result += "[%\(argIdx): \(argDescription)]\n"
+      }
+    }
+    result += "[global: \(global)]\n"
+    return result
   }
   
-  public var customMirror: Mirror { Mirror(self, children: []) }
+  /// Side-effects of a specific function argument.
+  ///
+  /// The paths describe what (projeted) values of an argument are affected.
+  /// If a path is nil, than there is no such effect on the argument.
+  ///
+  /// A path can contain any projection or wildcards, as long as there is no load involved.
+  /// In other words, an effect path can refer to the argument value directly or to anything the
+  /// argument "points to", but does not cover anything which is loaded from memory.
+  /// For example, if the `write` path for an inout argument is nil, there is no write to the inout address.
+  /// But there might very well be a write to a class field of a reference which is loaded from the inout.
+  /// ```
+  ///   bb0(%0 : $*X):                   // inout
+  ///     %1 = load %0                   // read path = v**
+  ///     %2 = ref_element_addr %1, #f
+  ///     store %x to %2                 // not covered by argument effects! -> goes to global effects
+  /// ```
+  ///
+  /// For direct argument it's different, because a direct argument (which contains a class reference) can point
+  /// to a class field.
+  /// ```
+  ///   bb0(%0 : $X):                    // direct argument
+  ///     %1 = ref_element_addr %0, #f
+  ///     store %x to %1                 // write path = c*.v**
+  ///     %2 = load %1                   // read path = c*.v**
+  ///     %3 = ref_element_addr %2, #f
+  ///     store %x to %3                 // not covered by argument effects! -> goes to global effects
+  /// ```
+  public struct ArgumentEffects : Equatable, CustomStringConvertible, NoReflectionChildren {
+
+    /// If not nil, the function may read from the argument at the path.
+    public var read: SmallProjectionPath?
+
+    /// If not nil, the function may write to the argument at the path.
+    public var write: SmallProjectionPath?
+    
+    /// If not nil, the function may copy/retain the argument at the path (only non-trivial values).
+    public var copy: SmallProjectionPath?
+    
+    /// If not nil, the function may destroy/release the argument at the path (only non-trivial values).
+    public var destroy: SmallProjectionPath?
+
+    public init() {}
+
+    var isEmpty: Bool { self == ArgumentEffects() }
+
+    /// The `description` without the square brackets
+    public var bodyDescription: String {
+      var results: [String] = []
+      if let path = read    { results.append("read \(path)") }
+      if let path = write   { results.append("write \(path)") }
+      if let path = copy    { results.append("copy \(path)") }
+      if let path = destroy { results.append("destroy \(path)") }
+      return results.joined(separator: ", ")
+    }
+
+    public var description: String { "[\(bodyDescription)]" }
+  }
+
+  /// "Global" effects of the function.
+  ///
+  /// Global effects are effects which cannot be associated with function arguments,
+  /// for example reading from a global variable or reading from loaded value from an argument.
+  public struct GlobalEffects : Equatable, CustomStringConvertible, NoReflectionChildren {
+
+    /// Memory reads and writes.
+    public var memory: Memory
+    
+    /// Copies and destroys.
+    public var ownership: Ownership
+
+    /// If true, the function may allocate an object.
+    ///
+    /// This only includes allocations, which escape the function. Local allocations
+    /// are not observable form the outside and are therefore not considered.
+    public var allocates: Bool
+
+    /// When called with default arguments, it creates an "effect-free" GlobalEffects.
+    public init(memory: Memory = Memory(read: false, write: false),
+                ownership: Ownership = Ownership(copy: false, destroy: false),
+                allocates: Bool = false) {
+      self.memory = memory
+      self.ownership = ownership
+      self.allocates = allocates
+    }
+
+    public mutating func merge(with other: GlobalEffects) {
+      memory.merge(with: other.memory)
+      ownership.merge(with: other.ownership)
+      allocates = allocates || other.allocates
+    }
+
+    /// Removes effects, which cannot occur for an `argument` value with a given `convention`.
+    public func restrictedTo(argument: Value, withConvention convention: ArgumentConvention) -> GlobalEffects {
+      var result = self
+      let isTrivial = argument.type.isTrivial(in: argument.function)
+      if isTrivial {
+        // There cannot be any ownership effects on trivial arguments.
+        result.ownership = SideEffects.Ownership()
+      }
+      switch convention {
+      case .indirectIn, .indirectInConstant:
+        result.memory.write = false
+      case .indirectInGuaranteed:
+        result.memory.write = false
+        result.ownership.destroy = false
+      case .indirectOut:
+        result.memory.read = false
+        result.ownership.copy = false
+        result.ownership.destroy = false
+
+      // Note that `directGuaranteed` still has a "destroy" effect, because an object stored in
+      // a class property could be destroyed.
+      case .directOwned, .directUnowned, .directGuaranteed:
+        if isTrivial {
+          // Trivial direct arguments cannot have class properties which could be loaded from/stored to.
+          result.memory = SideEffects.Memory()
+        }
+        break
+      case .indirectInout, .indirectInoutAliasable:
+        break
+      }
+      return result
+    }
+
+    public static var worstEffects: GlobalEffects {
+      GlobalEffects(memory: .worstEffects, ownership: .worstEffects, allocates: true)
+    }
+
+    public var description: String {
+      var res: [String] = [memory.description, ownership.description].filter { !$0.isEmpty }
+      if allocates { res += ["allocate"] }
+      return res.joined(separator: ",")
+    }
+  }
+
+  /// Memory read and write effects.
+  public struct Memory : Equatable, CustomStringConvertible, NoReflectionChildren {
+    public var read: Bool
+    public var write: Bool
+
+    public init(read: Bool = false, write: Bool = false) {
+      self.read = read
+      self.write = write
+    }
+
+    public var description: String {
+      switch (read, write) {
+        case (false, false): return ""
+        case (false, true):  return "write"
+        case (true, false):  return "read"
+        case (true, true):   return "read,write"
+      }
+    }
+
+    public mutating func merge(with other: Memory) {
+      read = read || other.read
+      write = write || other.write
+    }
+
+    public static var worstEffects: Memory {
+      Memory(read: true, write: true)
+    }
+  }
+
+  /// Copy and destroy effects.
+  public struct Ownership : Equatable, CustomStringConvertible, NoReflectionChildren {
+    public var copy: Bool
+    public var destroy: Bool
+
+    public init(copy: Bool = false, destroy: Bool = false) {
+      self.copy = copy
+      self.destroy = destroy
+    }
+
+    public var description: String {
+      switch (copy, destroy) {
+        case (false, false): return ""
+        case (false, true):  return "destroy"
+        case (true, false):  return "copy"
+        case (true, true):   return "copy,destroy"
+      }
+    }
+
+    public mutating func merge(with other: Ownership) {
+      copy = copy || other.copy
+      destroy = destroy || other.destroy
+    }
+
+    public static var worstEffects: Ownership {
+      Ownership(copy: true, destroy: true)
+    }
+  }
 }
 
 //===----------------------------------------------------------------------===//
@@ -212,11 +520,11 @@ public struct FunctionEffects : CustomStringConvertible, CustomReflectable {
 extension StringParser {
 
   mutating func parseEffectFromSource(for function: Function,
-                            params: Dictionary<String, Int>) throws -> ArgumentEffect {
+                            params: Dictionary<String, Int>) throws -> EscapeEffects.ArgumentEffect {
     if consume("notEscaping") {
       let argIdx = try parseArgumentIndexFromSource(for: function, params: params)
       let path = try parsePathPatternFromSource(for: function, type: function.argumentTypes[argIdx])
-      return ArgumentEffect(.notEscaping, argumentIndex: argIdx, pathPattern: path, isDerived: false)
+      return EscapeEffects.ArgumentEffect(.notEscaping, argumentIndex: argIdx, pathPattern: path, isDerived: false)
     }
     if consume("escaping") {
       let fromArgIdx = try parseArgumentIndexFromSource(for: function, params: params)
@@ -229,22 +537,22 @@ extension StringParser {
             try throwError("multi-value returns not supported yet")
           }
           let toPath = try parsePathPatternFromSource(for: function, type: function.argumentTypes[0])
-          return ArgumentEffect(.escapingToArgument(0, toPath, exclusive),
-                                argumentIndex: fromArgIdx, pathPattern: fromPath, isDerived: false)
+          return EscapeEffects.ArgumentEffect(.escapingToArgument(0, toPath, exclusive),
+                                      argumentIndex: fromArgIdx, pathPattern: fromPath, isDerived: false)
         }
         let toPath = try parsePathPatternFromSource(for: function, type: function.resultType)
-        return ArgumentEffect(.escapingToReturn(toPath, exclusive),
-                              argumentIndex: fromArgIdx, pathPattern: fromPath, isDerived: false)
+        return EscapeEffects.ArgumentEffect(.escapingToReturn(toPath, exclusive),
+                                    argumentIndex: fromArgIdx, pathPattern: fromPath, isDerived: false)
       }
       let toArgIdx = try parseArgumentIndexFromSource(for: function, params: params)
       let toPath = try parsePathPatternFromSource(for: function, type: function.argumentTypes[toArgIdx])
-      return ArgumentEffect(.escapingToArgument(toArgIdx, toPath, exclusive),
-                            argumentIndex: fromArgIdx, pathPattern: fromPath, isDerived: false)
+      return EscapeEffects.ArgumentEffect(.escapingToArgument(toArgIdx, toPath, exclusive),
+                                  argumentIndex: fromArgIdx, pathPattern: fromPath, isDerived: false)
     }
     try throwError("unknown effect")
   }
 
-  mutating func parseArgumentIndexFromSource(for function: Function,
+  private mutating func parseArgumentIndexFromSource(for function: Function,
                                              params: Dictionary<String, Int>) throws -> Int {
     if consume("self") {
       if !function.hasSelfArgument {
@@ -261,50 +569,99 @@ extension StringParser {
     try throwError("parameter name expected")
   }
   
-  mutating func parsePathPatternFromSource(for function: Function, type: Type) throws -> ArgumentEffect.Path {
+  private mutating func parsePathPatternFromSource(for function: Function, type: Type) throws -> SmallProjectionPath {
     if consume(".") {
       return try parseProjectionPathFromSource(for: function, type: type)
     }
     if !type.isClass {
       try throwError("the value is not a class - add 'anyValueFields'")
     }
-    return ArgumentEffect.Path()
+    return SmallProjectionPath()
   }
 
   mutating func parseEffectsFromSIL(to effects: inout FunctionEffects) throws {
+    if consume("global") {
+      if !consume(":") {
+        try throwError("expected ':'")
+      }
+      try parseGlobalSideEffectsFromSIL(to: &effects)
+      return
+    }
     let argumentIndex = try parseArgumentIndexFromSIL()
-    let isDerived = !consume("!")
     if !consume(":") {
       try throwError("expected ':'")
     }
+    try parseEffectsFromSIL(argumentIndex: argumentIndex, to: &effects)
+  }
+  
+  mutating func parseEffectsFromSIL(argumentIndex: Int, to effects: inout FunctionEffects) throws {
     repeat {
-      let effect = try parseEffectFromSIL(argumentIndex: argumentIndex, isDerived: isDerived)
-      effects.argumentEffects.append(effect)
-    } while consume(",")
-  }
+      if consume("noescape") {
+        let isDerived = !consume("!")
+        let path = try parseProjectionPathFromSIL()
+        let effect = EscapeEffects.ArgumentEffect(.notEscaping, argumentIndex: argumentIndex,
+                                                  pathPattern: path, isDerived: isDerived)
+        effects.escapeEffects.arguments.append(effect)
 
-  mutating func parseEffectFromSIL(argumentIndex: Int, isDerived: Bool) throws -> ArgumentEffect {
-    if consume("noescape") {
-      let path = try parseProjectionPathFromSIL()
-      return ArgumentEffect(.notEscaping, argumentIndex: argumentIndex, pathPattern: path, isDerived: isDerived)
-    }
-    if consume("escape") {
-      let fromPath = try parseProjectionPathFromSIL()
-      let exclusive = try parseEscapingArrow()
-      if consume("%r") {
-        let toPath = consume(".") ? try parseProjectionPathFromSIL() : ArgumentEffect.Path()
-        return ArgumentEffect(.escapingToReturn(toPath, exclusive),
-                              argumentIndex: argumentIndex, pathPattern: fromPath, isDerived: isDerived)
+      } else if consume("escape") {
+        let isDerived = !consume("!")
+        let fromPath = try parseProjectionPathFromSIL()
+        let exclusive = try parseEscapingArrow()
+        let effect: EscapeEffects.ArgumentEffect
+        if consume("%r") {
+          let toPath = consume(".") ? try parseProjectionPathFromSIL() : SmallProjectionPath()
+          effect = EscapeEffects.ArgumentEffect(.escapingToReturn(toPath, exclusive),
+                                                argumentIndex: argumentIndex, pathPattern: fromPath, isDerived: isDerived)
+        } else {
+          let toArgIdx = try parseArgumentIndexFromSIL()
+          let toPath = consume(".") ? try parseProjectionPathFromSIL() : SmallProjectionPath()
+          effect = EscapeEffects.ArgumentEffect(.escapingToArgument(toArgIdx, toPath, exclusive),
+                                                argumentIndex: argumentIndex, pathPattern: fromPath, isDerived: isDerived)
+        }
+        effects.escapeEffects.arguments.append(effect)
+
+      } else if consume("read") {
+        try parseSideEffectPath(\.read, for: argumentIndex)
+      } else if consume("write") {
+        try parseSideEffectPath(\.write, for: argumentIndex)
+      } else if consume("copy") {
+        try parseSideEffectPath(\.copy, for: argumentIndex)
+      } else if consume("destroy") {
+        try parseSideEffectPath(\.destroy, for: argumentIndex)
+      } else {
+        try throwError("unknown effect")
       }
-      let toArgIdx = try parseArgumentIndexFromSIL()
-      let toPath = consume(".") ? try parseProjectionPathFromSIL() : ArgumentEffect.Path()
-      return ArgumentEffect(.escapingToArgument(toArgIdx, toPath, exclusive),
-                            argumentIndex: argumentIndex, pathPattern: fromPath, isDerived: isDerived)
+    } while consume(",")
+
+    func parseSideEffectPath(_ e: WritableKeyPath<SideEffects.ArgumentEffects, SmallProjectionPath?>, for argumentIndex: Int) throws {
+      var arguments = effects.sideEffects?.arguments ?? []
+      while arguments.count <= argumentIndex {
+        arguments.append(SideEffects.ArgumentEffects())
+      }
+      arguments[argumentIndex][keyPath: e] = try parseProjectionPathFromSIL()
+      let global = effects.sideEffects?.global ?? SideEffects.GlobalEffects()
+      effects.sideEffects = SideEffects(arguments: arguments, global: global)
     }
-    try throwError("unknown effect")
   }
 
-  mutating func parseArgumentIndexFromSIL() throws -> Int {
+  mutating func parseGlobalSideEffectsFromSIL(to effects: inout FunctionEffects) throws {
+    var globalEffects = SideEffects.GlobalEffects()
+    repeat {
+      if consume("read")          { globalEffects.memory.read = true }
+      else if consume("write")    { globalEffects.memory.write = true }
+      else if consume("copy")     { globalEffects.ownership.copy = true }
+      else if consume("destroy")  { globalEffects.ownership.destroy = true }
+      else if consume("allocate") { globalEffects.allocates = true }
+      else {
+        break
+      }
+    } while consume(",")
+    let arguments = effects.sideEffects?.arguments ?? []
+    effects.sideEffects = SideEffects(arguments: arguments, global: globalEffects)
+    return
+  }
+
+  private mutating func parseArgumentIndexFromSIL() throws -> Int {
     if consume("%") {
       if let argIdx = consumeInt() {
         return argIdx
@@ -319,5 +676,14 @@ extension StringParser {
     if consume("->") { return false }
     try throwError("expected '=>' or '->'")
   }
+}
 
+public extension Optional where Wrapped == SmallProjectionPath {
+  mutating func merge(with path: SmallProjectionPath) {
+    if let existingPath = self {
+      self = existingPath.merge(with: path)
+    } else {
+      self = path
+    }
+  }
 }

--- a/SwiftCompilerSources/Sources/SIL/Function.swift
+++ b/SwiftCompilerSources/Sources/SIL/Function.swift
@@ -33,6 +33,11 @@ final public class Function : CustomStringConvertible, HasShortDescription, Hash
 
   public var hasOwnership: Bool { SILFunction_hasOwnership(bridged) != 0 }
 
+  /// Returns true if the function is a definition and not only an external declaration.
+  ///
+  /// This is the case if the functioun contains a body, i.e. some basic blocks.
+  public var isDefinition: Bool { blocks.first != nil }
+
   public var entryBlock: BasicBlock {
     SILFunction_firstBlock(bridged).block!
   }
@@ -50,9 +55,22 @@ final public class Function : CustomStringConvertible, HasShortDescription, Hash
     blocks.lazy.flatMap { $0.instructions }
   }
 
+  /// The number of indirect result arguments.
   public var numIndirectResultArguments: Int {
     SILFunction_numIndirectResultArguments(bridged)
   }
+  
+  /// The number of arguments which correspond to parameters (and not to indirect results).
+  public var numParameterArguments: Int {
+    SILFunction_numParameterArguments(bridged)
+  }
+
+  /// The total number of arguments.
+  ///
+  /// This is the sum of indirect result arguments and parameter arguments.
+  /// If the function is a definition (i.e. it has at least an entry block), this is the
+  /// number of arguments of the function's entry block.
+  public var numArguments: Int { numIndirectResultArguments + numParameterArguments }
 
   public var hasSelfArgument: Bool {
     SILFunction_getSelfArgumentIndex(bridged) >= 0
@@ -66,6 +84,13 @@ final public class Function : CustomStringConvertible, HasShortDescription, Hash
   
   public var argumentTypes: ArgumentTypeArray { ArgumentTypeArray(function: self) }
   public var resultType: Type { SILFunction_getSILResultType(bridged).type }
+
+  public func getArgumentConvention(for argumentIndex: Int) -> ArgumentConvention {
+    if argumentIndex < numIndirectResultArguments {
+      return .indirectOut
+    }
+    return SILFunction_getSILArgumentConvention(bridged, argumentIndex).convention
+  }
 
   public var returnInstruction: ReturnInst? {
     for block in blocks.reversed() {
@@ -93,6 +118,60 @@ final public class Function : CustomStringConvertible, HasShortDescription, Hash
   public func hasSemanticsAttribute(_ attr: StaticString) -> Bool {
     attr.withUTF8Buffer { (buffer: UnsafeBufferPointer<UInt8>) in
       SILFunction_hasSemanticsAttr(bridged, llvm.StringRef(buffer.baseAddress!, buffer.count)) != 0
+    }
+  }
+
+  /// Kinds of effect attributes which can be defined for a Swift function.
+  public enum EffectAttribute {
+    /// No effect attribute is specified.
+    case none
+    
+    /// `[readnone]`
+    ///
+    /// A readnone function does not have any observable memory read or write operations.
+    /// This does not mean that the function cannot read or write at all. For example,
+    /// it’s allowed to allocate and write to local objects inside the function.
+    ///
+    /// A function can be marked as readnone if two calls of the same function with the
+    /// same parameters can be simplified to one call (e.g. by the CSE optimization).
+    /// Some conclusions:
+    /// * A readnone function must not return a newly allocated class instance.
+    /// * A readnone function can return a newly allocated copy-on-write object,
+    ///   like an Array, because COW data types conceptually behave like value types.
+    /// * A readnone function must not release any parameter or any object indirectly
+    ///   referenced from a parameter.
+    /// * Any kind of observable side-effects are not allowed, like `print`, file IO, etc.
+    case readNone
+    
+    /// `[readonly]`
+    ///
+    /// A readonly function does not have any observable memory write operations.
+    /// Similar to readnone, a readonly function is allowed to contain writes to e.g. local objects, etc.
+    ///
+    /// A function can be marked as readonly if it’s save to eliminate a call to such
+    /// a function if its return value is not used.
+    /// The same conclusions as for readnone also apply to readonly.
+    case readOnly
+    
+    /// `[releasenone]`
+    ///
+    /// A releasenone function must not perform any observable release-operation on an object.
+    /// This means, it must not do anything which might let the caller observe any decrement of
+    /// a reference count or any deallocations.
+    /// Note that it's allowed to release an object if the release is balancing a retain in the
+    /// same function. Also, it's allowed to release (and deallocate) local objects which were
+    /// allocated in the same function.
+    case releaseNone
+  }
+
+  /// The effect attribute which is specified in the source code (if any).
+  public var effectAttribute: EffectAttribute {
+    switch SILFunction_getEffectAttribute(bridged) {
+      case EffectKind_none: return .none
+      case EffectKind_readNone: return .readNone
+      case EffectKind_readOnly: return .readOnly
+      case EffectKind_releaseNone: return .releaseNone
+      default: fatalError()
     }
   }
 

--- a/SwiftCompilerSources/Sources/SIL/Function.swift
+++ b/SwiftCompilerSources/Sources/SIL/Function.swift
@@ -213,33 +213,47 @@ final public class Function : CustomStringConvertible, HasShortDescription, Hash
       // writeFn
       { (f: BridgedFunction, os: BridgedOStream, idx: Int) in
         let s: String
+        let effects = f.function.effects
         if idx >= 0 {
-          s = f.function.effects.argumentEffects[idx].bodyDescription
+          if idx < effects.escapeEffects.arguments.count {
+            s = effects.escapeEffects.arguments[idx].bodyDescription
+          } else {
+            let globalIdx = idx - effects.escapeEffects.arguments.count
+            if globalIdx == 0 {
+              s = effects.sideEffects!.global.description
+            } else {
+              let seIdx = globalIdx - 1
+              s = effects.sideEffects!.getArgumentEffects(for: seIdx).bodyDescription
+            }
+          }
         } else {
-          s = f.function.effects.argumentEffectsDescription
+          s = effects.description
         }
         s._withStringRef { OStream_write(os, $0) }
       },
       // parseFn:
-      { (f: BridgedFunction, str: llvm.StringRef, fromSIL: Int, argumentIndex: Int, isDerived: Int, paramNames: BridgedArrayRef) -> BridgedParsingError in
+      { (f: BridgedFunction, str: llvm.StringRef, mode: ParseEffectsMode, argumentIndex: Int, paramNames: BridgedArrayRef) -> BridgedParsingError in
         do {
           var parser = StringParser(str.string)
+          let function = f.function
 
-          if fromSIL != 0 && argumentIndex < 0 {
-            try parser.parseEffectsFromSIL(to: &f.function.effects)
-          } else {
-            let effect: ArgumentEffect
-            if fromSIL != 0 {
-              effect = try parser.parseEffectFromSIL(argumentIndex: argumentIndex, isDerived: isDerived != 0)
-            } else {
-              let paramToIdx = paramNames.withElements(ofType: llvm.StringRef.self) {
-                  (buffer: UnsafeBufferPointer<llvm.StringRef>) -> Dictionary<String, Int> in
-                let keyValPairs = buffer.enumerated().lazy.map { ($0.1.string, $0.0) }
-                return Dictionary(uniqueKeysWithValues: keyValPairs)
-              }
-              effect = try parser.parseEffectFromSource(for: f.function, params: paramToIdx)
+          switch mode {
+          case ParseArgumentEffectsFromSource:
+            let paramToIdx = paramNames.withElements(ofType: llvm.StringRef.self) {
+                (buffer: UnsafeBufferPointer<llvm.StringRef>) -> Dictionary<String, Int> in
+              let keyValPairs = buffer.enumerated().lazy.map { ($0.1.string, $0.0) }
+              return Dictionary(uniqueKeysWithValues: keyValPairs)
             }
-            f.function.effects.argumentEffects.append(effect)
+            let effect = try parser.parseEffectFromSource(for: function, params: paramToIdx)
+            function.effects.escapeEffects.arguments.append(effect)
+          case ParseArgumentEffectsFromSIL:
+            try parser.parseEffectsFromSIL(argumentIndex: argumentIndex, to: &function.effects)
+          case ParseGlobalEffectsFromSIL:
+            try parser.parseGlobalSideEffectsFromSIL(to: &function.effects)
+          case ParseMultipleEffectsFromSIL:
+            try parser.parseEffectsFromSIL(to: &function.effects)
+          default:
+            fatalError("invalid ParseEffectsMode")
           }
           if !parser.isEmpty() { try parser.throwError("syntax error") }
         } catch let error as ParsingError {
@@ -269,12 +283,24 @@ final public class Function : CustomStringConvertible, HasShortDescription, Hash
       },
       // getEffectInfo
       {  (f: BridgedFunction, idx: Int) -> BridgedEffectInfo in
-        let argEffects = f.function.effects.argumentEffects
-        if idx >= argEffects.count {
-          return BridgedEffectInfo(argumentIndex: -1, isDerived: false)
+        let effects = f.function.effects
+        if idx < effects.escapeEffects.arguments.count {
+          let effect = effects.escapeEffects.arguments[idx]
+          return BridgedEffectInfo(argumentIndex: effect.argumentIndex,
+                                   isDerived: effect.isDerived, isEmpty: false, isValid: true)
         }
-        let effect = argEffects[idx]
-        return BridgedEffectInfo(argumentIndex: effect.argumentIndex, isDerived: effect.isDerived)
+        if let sideEffects = effects.sideEffects {
+          let globalIdx = idx - effects.escapeEffects.arguments.count
+          if globalIdx == 0 {
+            return BridgedEffectInfo(argumentIndex: -1, isDerived: true, isEmpty: false, isValid: true)
+          }
+          let seIdx = globalIdx - 1
+          if seIdx < sideEffects.arguments.count {
+            return BridgedEffectInfo(argumentIndex: seIdx, isDerived: true,
+                                     isEmpty: sideEffects.arguments[seIdx].isEmpty, isValid: true)
+          }
+        }
+        return BridgedEffectInfo(argumentIndex: -1, isDerived: false, isEmpty: true, isValid: false)
       }
     )
   }

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -759,6 +759,7 @@ final public class TryApplyInst : TermInst, FullApplySite {
 final public class BranchInst : TermInst {
   public var targetBlock: BasicBlock { BranchInst_getTargetBlock(bridged).block }
 
+  /// Returns the target block argument for the cond_br `operand`.
   public func getArgument(for operand: Operand) -> Argument {
     return targetBlock.arguments[operand.index]
   }
@@ -776,8 +777,15 @@ final public class CondBranchInst : TermInst {
     return ops[(CondBranchInst_getNumTrueArgs(bridged) &+ 1)..<ops.count]
   }
 
-  public func getArgument(for operand: Operand) -> Argument {
-    let argIdx = operand.index - 1
+  /// Returns the true or false block argument for the cond_br `operand`.
+  ///
+  /// Return nil if `operand` is the condition itself.
+  public func getArgument(for operand: Operand) -> Argument? {
+    let opIdx = operand.index
+    if opIdx == 0 {
+      return nil
+    }
+    let argIdx = opIdx - 1
     let numTrueArgs = CondBranchInst_getNumTrueArgs(bridged)
     if (0..<numTrueArgs).contains(argIdx) {
       return trueBlock.arguments[argIdx]

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -104,6 +104,10 @@ public class Instruction : ListNode, CustomStringConvertible, Hashable {
     return SILInstruction_mayRelease(bridged)
   }
 
+  public final var hasUnspecifiedSideEffects: Bool {
+    return SILInstruction_hasUnspecifiedSideEffects(bridged)
+  }
+
   public func visitReferencedFunctions(_ cl: (Function) -> ()) {
   }
 
@@ -273,6 +277,9 @@ final public class UnconditionalCheckedCastAddrInst : Instruction {
   public override var mayTrap: Bool { true }
 }
 
+final public class EndApplyInst : Instruction, UnaryInstruction {}
+final public class AbortApplyInst : Instruction, UnaryInstruction {}
+
 final public class SetDeallocatingInst : Instruction, UnaryInstruction {}
 
 final public class DeallocRefInst : Instruction, UnaryInstruction {}
@@ -312,7 +319,15 @@ final public class UnimplementedRefCountingInst : RefCountingInst {}
 final public class UnimplementedSingleValueInst : SingleValueInstruction {
 }
 
-final public class LoadInst : SingleValueInstruction, UnaryInstruction {}
+final public class LoadInst : SingleValueInstruction, UnaryInstruction {
+  // must match with enum class LoadOwnershipQualifier
+  public enum LoadOwnership: Int {
+    case unqualified = 0, take = 1, copy = 2, trivial = 3
+  }
+  public var ownership: LoadOwnership {
+    LoadOwnership(rawValue: LoadInst_getLoadOwnership(bridged))!
+  }
+}
 
 final public class LoadWeakInst : SingleValueInstruction, UnaryInstruction {}
 final public class LoadUnownedInst : SingleValueInstruction, UnaryInstruction {}
@@ -570,11 +585,20 @@ extension BridgedAccessKind {
 // TODO: add support for begin_unpaired_access
 final public class BeginAccessInst : SingleValueInstruction, UnaryInstruction {
   public var accessKind: AccessKind { BeginAccessInst_getAccessKind(bridged).kind }
+
+  public var isStatic: Bool { BeginAccessInst_isStatic(bridged) != 0 }
 }
 
+// An instruction that is always paired with a scope ending instruction
+// such as `begin_access` (ending with `end_access`) and `alloc_stack`
+// (ending with `dealloc_stack`).
 public protocol ScopedInstruction {
+  // The type of the ending instructions (while `IteratorProtocol` would be
+  // ideal, for performance reasons we allow the user to specify any type as return)
   associatedtype EndInstructions
 
+  // The instructions that end the scope of the instruction denoted
+  // by `self`.
   var endInstructions: EndInstructions { get }
 }
 
@@ -646,7 +670,7 @@ class MarkMustCheckInst : SingleValueInstruction, UnaryInstruction {}
 //                      single-value allocation instructions
 //===----------------------------------------------------------------------===//
 
-public protocol Allocation : AnyObject { }
+public protocol Allocation : SingleValueInstruction { }
 
 final public class AllocStackInst : SingleValueInstruction, Allocation {
 }

--- a/SwiftCompilerSources/Sources/SIL/Operand.swift
+++ b/SwiftCompilerSources/Sources/SIL/Operand.swift
@@ -13,7 +13,7 @@
 import SILBridging
 
 /// An operand of an instruction.
-public struct Operand : CustomStringConvertible, CustomReflectable {
+public struct Operand : CustomStringConvertible, NoReflectionChildren {
   fileprivate let bridged: BridgedOperand
 
   init(_ bridged: BridgedOperand) {
@@ -39,8 +39,6 @@ public struct Operand : CustomStringConvertible, CustomReflectable {
   public var isTypeDependent: Bool { Operand_isTypeDependent(bridged) != 0 }
   
   public var description: String { "operand #\(index) of \(instruction)" }
-  
-  public var customMirror: Mirror { Mirror(self, children: []) }
 }
 
 public struct OperandArray : RandomAccessCollection, CustomReflectable {

--- a/SwiftCompilerSources/Sources/SIL/Registration.swift
+++ b/SwiftCompilerSources/Sources/SIL/Registration.swift
@@ -51,6 +51,8 @@ public func registerSILClasses() {
   register(DebugValueInst.self)
   register(UnconditionalCheckedCastAddrInst.self)
   register(SetDeallocatingInst.self)
+  register(EndApplyInst.self)
+  register(AbortApplyInst.self)
   register(DeallocRefInst.self)
   register(StrongRetainInst.self)
   register(RetainValueInst.self)

--- a/SwiftCompilerSources/Sources/SIL/SmallProjectionPath.swift
+++ b/SwiftCompilerSources/Sources/SIL/SmallProjectionPath.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Basic
+
 /// A small and very efficient representation of a projection path.
 ///
 /// A `SmallProjectionPath` can be parsed and printed in SIL syntax and parsed from Swift
@@ -37,7 +39,7 @@
 /// which means: it represents any number of any kind of projections.
 /// Though, it's very unlikely that the limit will be reached in real world scenarios.
 ///
-public struct SmallProjectionPath : CustomStringConvertible, CustomReflectable, Hashable {
+public struct SmallProjectionPath : Hashable, CustomStringConvertible, NoReflectionChildren {
 
   /// The physical representation of the path. The path components are stored in
   /// reverse order: the first path component is stored in the lowest bits (LSB),
@@ -403,8 +405,6 @@ public struct SmallProjectionPath : CustomStringConvertible, CustomReflectable, 
     }
     return false
   }
-
-  public var customMirror: Mirror { Mirror(self, children: []) }
 }
 
 //===----------------------------------------------------------------------===//

--- a/SwiftCompilerSources/Sources/SIL/Type.swift
+++ b/SwiftCompilerSources/Sources/SIL/Type.swift
@@ -13,7 +13,7 @@
 import Basic
 import SILBridging
 
-public struct Type : CustomStringConvertible, CustomReflectable {
+public struct Type : CustomStringConvertible, NoReflectionChildren {
   public let bridged: BridgedType
   
   public var isAddress: Bool { SILType_isAddress(bridged) != 0 }
@@ -53,8 +53,6 @@ public struct Type : CustomStringConvertible, CustomReflectable {
   public var description: String {
     String(_cxxString: SILType_debugDescription(bridged))
   }
-
-  public var customMirror: Mirror { Mirror(self, children: []) }
 }
 
 extension Type: Equatable {

--- a/SwiftCompilerSources/Sources/SIL/Type.swift
+++ b/SwiftCompilerSources/Sources/SIL/Type.swift
@@ -36,6 +36,7 @@ public struct Type : CustomStringConvertible, NoReflectionChildren {
   public var isStruct: Bool { SILType_isStruct(bridged) != 0 }
   public var isTuple: Bool { SILType_isTuple(bridged) != 0 }
   public var isEnum: Bool { SILType_isEnum(bridged) != 0 }
+  public var isFunction: Bool { SILType_isFunction(bridged) }
 
   public var tupleElements: TupleElementArray { TupleElementArray(type: self) }
 
@@ -43,6 +44,8 @@ public struct Type : CustomStringConvertible, NoReflectionChildren {
     NominalFieldsArray(type: self, function: function)
   }
 
+  public var isCalleeConsumedFunction: Bool { SILType_isCalleeConsumedFunction(bridged) }
+  
   public func getIndexOfEnumCase(withName name: String) -> Int? {
     let idx = name._withStringRef {
       SILType_getCaseIdxOfEnumType(bridged, $0)

--- a/SwiftCompilerSources/Sources/SIL/Utils.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utils.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Basic
 import SILBridging
 
 // Need to export "Basic" to make `Basic.assert` available in the Optimizer module.
@@ -93,9 +94,8 @@ public protocol HasShortDescription {
   var shortDescription: String { get }
 }
 
-private struct CustomMirrorChild : CustomStringConvertible, CustomReflectable {
+private struct CustomMirrorChild : CustomStringConvertible, NoReflectionChildren {
   public var description: String
-  public var customMirror: Mirror { Mirror(self, children: []) }
   
   public init(description: String) { self.description = description }
 }

--- a/SwiftCompilerSources/Sources/SIL/VTable.swift
+++ b/SwiftCompilerSources/Sources/SIL/VTable.swift
@@ -12,12 +12,12 @@
 
 import SILBridging
 
-public struct VTable : CustomStringConvertible, CustomReflectable {
+public struct VTable : CustomStringConvertible, NoReflectionChildren {
   let bridged: BridgedVTable
 
   public init(bridged: BridgedVTable) { self.bridged = bridged }
 
-  public struct Entry : CustomStringConvertible, CustomReflectable {
+  public struct Entry : CustomStringConvertible, NoReflectionChildren {
     fileprivate let bridged: BridgedVTableEntry
     
     public var function: Function { SILVTableEntry_getFunction(bridged).function }
@@ -26,8 +26,6 @@ public struct VTable : CustomStringConvertible, CustomReflectable {
       let stdString = SILVTableEntry_debugDescription(bridged)
       return String(_cxxString: stdString)
     }
-
-    public var customMirror: Mirror { Mirror(self, children: []) }
   }
 
   public struct EntryArray : BridgedRandomAccessCollection {
@@ -50,6 +48,4 @@ public struct VTable : CustomStringConvertible, CustomReflectable {
     let stdString = SILVTable_debugDescription(bridged)
     return String(_cxxString: stdString)
   }
-
-  public var customMirror: Mirror { Mirror(self, children: []) }
 }

--- a/SwiftCompilerSources/Sources/SIL/WitnessTable.swift
+++ b/SwiftCompilerSources/Sources/SIL/WitnessTable.swift
@@ -12,12 +12,12 @@
 
 import SILBridging
 
-public struct WitnessTable : CustomStringConvertible, CustomReflectable {
+public struct WitnessTable : CustomStringConvertible, NoReflectionChildren {
   public let bridged: BridgedWitnessTable
 
   public init(bridged: BridgedWitnessTable) { self.bridged = bridged }
 
-  public struct Entry : CustomStringConvertible, CustomReflectable {
+  public struct Entry : CustomStringConvertible, NoReflectionChildren {
     fileprivate let bridged: BridgedWitnessTableEntry
     
     public enum Kind {
@@ -49,8 +49,6 @@ public struct WitnessTable : CustomStringConvertible, CustomReflectable {
       let stdString = SILWitnessTableEntry_debugDescription(bridged)
       return String(_cxxString: stdString)
     }
-
-    public var customMirror: Mirror { Mirror(self, children: []) }
   }
 
   public struct EntryArray : BridgedRandomAccessCollection {
@@ -73,11 +71,9 @@ public struct WitnessTable : CustomStringConvertible, CustomReflectable {
     let stdString = SILWitnessTable_debugDescription(bridged)
     return String(_cxxString: stdString)
   }
-
-  public var customMirror: Mirror { Mirror(self, children: []) }
 }
 
-public struct DefaultWitnessTable : CustomStringConvertible, CustomReflectable {
+public struct DefaultWitnessTable : CustomStringConvertible, NoReflectionChildren {
   public let bridged: BridgedDefaultWitnessTable
 
   public init(bridged: BridgedDefaultWitnessTable) { self.bridged = bridged }
@@ -93,8 +89,6 @@ public struct DefaultWitnessTable : CustomStringConvertible, CustomReflectable {
     let stdString = SILDefaultWitnessTable_debugDescription(bridged)
     return String(_cxxString: stdString)
   }
-
-  public var customMirror: Mirror { Mirror(self, children: []) }
 }
 
 extension OptionalBridgedWitnessTable {

--- a/docs/SIL-Utilities.md
+++ b/docs/SIL-Utilities.md
@@ -99,6 +99,15 @@ A set of utilities for analyzing memory accesses. It defines the following conce
 
 ## Control- and Dataflow
 
+#### `DeadEndBlocks`
+A utility for finding dead-end blocks.
+Dead-end blocks are blocks from which there is no path to the function exit (`return`, `throw` or unwind).
+These are blocks which end with an unreachable instruction and blocks from which all paths end in "unreachable" blocks.
+
+**Uses:** `BasicBlockWorklist`  
+**Related C++ utilities:** `DeadEndBlocks`  
+**Status:** done
+
 #### `BasicBlockRange`
 Defines a range from a dominating "begin" block to one or more "end" blocks. To be used for all kind of backward block reachability analysis.
 

--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -956,7 +956,7 @@ Functions
   decl ::= sil-function
   sil-function ::= 'sil' sil-linkage? sil-function-attribute+
                      sil-function-name ':' sil-type
-                     '{' argument-effect* sil-basic-block* '}'
+                     '{' effects* sil-basic-block* '}'
   sil-function-name ::= '@' [A-Za-z_0-9]+
 
 SIL functions are defined with the ``sil`` keyword. SIL function names
@@ -1128,20 +1128,32 @@ of runtime functions are allowed to be called from the function.
 Argument Effects
 ````````````````
 
-The effects for function arguments. For details see the documentation
-in ``SwiftCompilerSources/Sources/SIL/Effects.swift``.
+The function effects, especially for function arguments. For details see the
+documentation in ``SwiftCompilerSources/Sources/SIL/Effects.swift``.
 ::
 
-  argument-effect ::= '[' argument-name defined-effect? ':' effect (',' effect)*]'
+  effects ::= '[' argument-name ':' argument-effect (',' argument-effect)*]'
+  effects ::= '[' 'global' ':' global-effect (',' global-effect)*]'
   argument-name ::= '%' [0-9]+
-  defined-effect ::= '!'    // the effect is defined in the source code and not
-                            // derived by the optimizer
 
-  effect ::= 'noescape' projection-path?
-  effect ::= 'escape' projection-path? '=>' arg-or-return  // exclusive escape
-  effect ::= 'escape' projection-path? '->' arg-or-return  // not-exclusive escape
+  argument-effect ::= 'noescape' defined-effect? projection-path?
+  argument-effect ::= 'escape' defined-effect? projection-path? '=>' arg-or-return  // exclusive escape
+  argument-effect ::= 'escape' defined-effect? projection-path? '->' arg-or-return  // not-exclusive escape
+  argument-effect ::= side-effect
+
+  global-effect ::= 'traps'
+  global-effect ::= 'allocates'
+  global-effect ::= side-effect
+
+  side-effect ::= 'read' projection-path?
+  side-effect ::= 'write' projection-path?
+  side-effect ::= 'copy' projection-path?
+  side-effect ::= 'read' projection-path?
+
   arg-or-return ::= argument-name ('.' projection-path)?
   arg-or-return ::= '%r' ('.' projection-path)?
+  defined-effect ::= '!'    // the effect is defined in the source code and not
+                            // derived by the optimizer
 
   projection-path ::= path-component ('.' path-component)* 
   path-component ::= 's' [0-9]+        // struct field

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -176,6 +176,13 @@ typedef enum {
 } BridgedMemoryBehavior;
 
 typedef enum {
+  EffectKind_none,
+  EffectKind_readNone,
+  EffectKind_readOnly,
+  EffectKind_releaseNone,
+} BridgedEffectAttributeKind;
+
+typedef enum {
   AccessKind_Init,
   AccessKind_Read,
   AccessKind_Modify,
@@ -249,15 +256,18 @@ SwiftInt SILFunction_hasOwnership(BridgedFunction function);
 OptionalBridgedBasicBlock SILFunction_firstBlock(BridgedFunction function);
 OptionalBridgedBasicBlock SILFunction_lastBlock(BridgedFunction function);
 SwiftInt SILFunction_numIndirectResultArguments(BridgedFunction function);
+SwiftInt SILFunction_numParameterArguments(BridgedFunction function);
 SwiftInt SILFunction_getSelfArgumentIndex(BridgedFunction function);
 SwiftInt SILFunction_getNumSILArguments(BridgedFunction function);
 BridgedType SILFunction_getSILArgumentType(BridgedFunction function, SwiftInt idx);
+BridgedArgumentConvention SILFunction_getSILArgumentConvention(BridgedFunction function, SwiftInt idx);
 BridgedType SILFunction_getSILResultType(BridgedFunction function);
 SwiftInt SILFunction_isSwift51RuntimeAvailable(BridgedFunction function);
 SwiftInt SILFunction_isPossiblyUsedExternally(BridgedFunction function);
 SwiftInt SILFunction_isAvailableExternally(BridgedFunction function);
 SwiftInt SILFunction_hasSemanticsAttr(BridgedFunction function,
                                       llvm::StringRef attrName);
+BridgedEffectAttributeKind SILFunction_getEffectAttribute(BridgedFunction function);
 SwiftInt SILFunction_needsStackProtection(BridgedFunction function);
 void SILFunction_setNeedStackProtection(BridgedFunction function,
                                         SwiftInt needSP);
@@ -316,6 +326,8 @@ SwiftInt SILType_isClass(BridgedType type);
 SwiftInt SILType_isStruct(BridgedType type);
 SwiftInt SILType_isTuple(BridgedType type);
 SwiftInt SILType_isEnum(BridgedType type);
+bool SILType_isFunction(BridgedType type);
+bool SILType_isCalleeConsumedFunction(BridgedType type);
 SwiftInt SILType_getNumTupleElements(BridgedType type);
 BridgedType SILType_getTupleElementType(BridgedType type, SwiftInt elementIdx);
 SwiftInt SILType_getNumNominalFields(BridgedType type);
@@ -342,6 +354,7 @@ void SILInstruction_setOperand(BridgedInstruction inst, SwiftInt index,
 swift::SILDebugLocation SILInstruction_getLocation(BridgedInstruction inst);
 BridgedMemoryBehavior SILInstruction_getMemBehavior(BridgedInstruction inst);
 bool SILInstruction_mayRelease(BridgedInstruction inst);
+bool SILInstruction_hasUnspecifiedSideEffects(BridgedInstruction inst);
 
 BridgedInstruction MultiValueInstResult_getParent(BridgedMultiValueResult result);
 SwiftInt MultiValueInstResult_getIndex(BridgedMultiValueResult result);
@@ -352,6 +365,7 @@ BridgedMultiValueResult
 BridgedArrayRef TermInst_getSuccessors(BridgedInstruction term);
 
 llvm::StringRef CondFailInst_getMessage(BridgedInstruction cfi);
+SwiftInt LoadInst_getLoadOwnership(BridgedInstruction load);
 BridgedBuiltinID BuiltinInst_getID(BridgedInstruction bi);
 SwiftInt AddressToPointerInst_needsStackProtection(BridgedInstruction atp);
 SwiftInt IndexAddrInst_needsStackProtection(BridgedInstruction ia);
@@ -384,6 +398,7 @@ SwiftInt SwitchEnumInst_getNumCases(BridgedInstruction se);
 SwiftInt SwitchEnumInst_getCaseIndex(BridgedInstruction se, SwiftInt idx);
 SwiftInt StoreInst_getStoreOwnership(BridgedInstruction store);
 BridgedAccessKind BeginAccessInst_getAccessKind(BridgedInstruction beginAccess);
+SwiftInt BeginAccessInst_isStatic(BridgedInstruction beginAccess);
 SwiftInt CopyAddrInst_isTakeOfSrc(BridgedInstruction copyAddr);
 SwiftInt CopyAddrInst_isInitializationOfDest(BridgedInstruction copyAddr);
 void RefCountingInst_setIsAtomic(BridgedInstruction rc, bool isAtomic);

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -219,7 +219,16 @@ typedef enum {
 struct BridgedEffectInfo {
   SwiftInt argumentIndex;
   bool isDerived;
+  bool isEmpty;
+  bool isValid;
 };
+
+typedef enum {
+  ParseArgumentEffectsFromSource,
+  ParseArgumentEffectsFromSIL,
+  ParseGlobalEffectsFromSIL,
+  ParseMultipleEffectsFromSIL
+} ParseEffectsMode;
 
 void registerBridgedClass(llvm::StringRef className, SwiftMetatype metatype);
 
@@ -230,7 +239,7 @@ typedef void (* _Nonnull FunctionWriteFn)(BridgedFunction,
                                           BridgedOStream, SwiftInt);
 typedef BridgedParsingError (*_Nonnull FunctionParseFn)(BridgedFunction,
                                                         llvm::StringRef,
-                                                        SwiftInt, SwiftInt, SwiftInt,
+                                                        ParseEffectsMode, SwiftInt,
                                                         BridgedArrayRef);
 typedef SwiftInt (* _Nonnull FunctionCopyEffectsFn)(BridgedFunction,
                                                     BridgedFunction);

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -167,7 +167,7 @@ class SILFunction
     public SwiftObjectHeader {
     
 private:
-  void *libswiftSpecificData[1];
+  void *libswiftSpecificData[4];
 
 public:
   using BlockListType = llvm::iplist<SILBasicBlock>;
@@ -1044,9 +1044,12 @@ public:
     EffectsKindAttr = unsigned(E);
   }
   
-  std::pair<const char *, int>  parseEffects(StringRef attrs, bool fromSIL,
-                                             int argumentIndex, bool isDerived,
-                                             ArrayRef<StringRef> paramNames);
+  std::pair<const char *, int>  parseArgumentEffectsFromSource(StringRef effectStr,
+                                                              ArrayRef<StringRef> paramNames);
+  std::pair<const char *, int>  parseArgumentEffectsFromSIL(StringRef effectStr,
+                                                           int argumentIndex);
+  std::pair<const char *, int>  parseGlobalEffectsFromSIL(StringRef effectStr);
+  std::pair<const char *, int>  parseMultipleEffectsFromSIL(StringRef effectStr);
   void writeEffect(llvm::raw_ostream &OS, int effectIdx) const;
   void writeEffects(llvm::raw_ostream &OS) const {
     writeEffect(OS, -1);

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -245,6 +245,8 @@ SWIFT_FUNCTION_PASS(AccessDumper, "dump-access",
      "Dump access information")
 SWIFT_FUNCTION_PASS(ComputeEscapeEffects, "compute-escape-effects",
      "Computes function escape effects")
+SWIFT_FUNCTION_PASS(ComputeSideEffects, "compute-side-effects",
+     "Computes function side effects")
 PASS(FlowIsolation, "flow-isolation",
      "Enforces flow-sensitive actor isolation rules")
 PASS(FunctionOrderPrinter, "function-order-printer",

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -243,8 +243,8 @@ SWIFT_FUNCTION_PASS(AddressEscapeInfoDumper, "dump-addr-escape-info",
      "Dumps address escape information")
 SWIFT_FUNCTION_PASS(AccessDumper, "dump-access",
      "Dump access information")
-SWIFT_FUNCTION_PASS(ComputeEffects, "compute-effects",
-     "Computes function effects")
+SWIFT_FUNCTION_PASS(ComputeEscapeEffects, "compute-escape-effects",
+     "Computes function escape effects")
 PASS(FlowIsolation, "flow-isolation",
      "Enforces flow-sensitive actor isolation rules")
 PASS(FunctionOrderPrinter, "function-order-printer",

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -235,6 +235,8 @@ PASS(EmitDFDiagnostics, "dataflow-diagnostics",
      "Emit SIL Diagnostics")
 PASS(EscapeAnalysisDumper, "escapes-dump",
      "Dump Escape Analysis Results")
+SWIFT_FUNCTION_PASS(DeadEndBlockDumper, "dump-deadendblocks",
+     "Tests the DeadEndBlocks utility")
 SWIFT_FUNCTION_PASS(EscapeInfoDumper, "dump-escape-info",
      "Dumps escape information")
 SWIFT_FUNCTION_PASS(AddressEscapeInfoDumper, "dump-addr-escape-info",

--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -140,8 +140,8 @@ void SILFunctionBuilder::addFunctionAttributes(
       }
     }
     for (const EffectsAttr *effectsAttr : llvm::reverse(customEffects)) {
-      auto error = F->parseEffects(effectsAttr->getCustomString(),
-        /*fromSIL*/ false, /*argumentIndex*/ -1, /*isDerived*/ false, paramNames);
+      auto error = F->parseArgumentEffectsFromSource(
+                                effectsAttr->getCustomString(), paramNames);
       if (error.first) {
         SourceLoc loc = effectsAttr->getCustomStringLocation();
         if (loc.isValid())

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -6670,9 +6670,7 @@ bool SILParserState::parseDeclSIL(Parser &P) {
         StringRef effectsStr = P.SourceMgr.extractText(
                       CharSourceRange(P.SourceMgr, effectsStart, effectsEnd));
 
-        auto error = FunctionState.F->parseEffects(effectsStr, /*fromSIL*/true,
-                                     /*argumentIndex*/ -1, /*isDerived*/ false,
-                                     {});
+        auto error = FunctionState.F->parseMultipleEffectsFromSIL(effectsStr);
         if (error.first) {
           SourceLoc loc = effectsStart;
           if (loc.isValid())

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -638,7 +638,7 @@ static void addHighLevelFunctionPipeline(SILPassPipelinePlan &P) {
   addHighLevelLoopOptPasses(P);
   
   P.addStringOptimization();
-  P.addComputeEffects();
+  P.addComputeEscapeEffects();
 }
 
 // After "high-level" function passes have processed the entire call tree, run
@@ -653,7 +653,7 @@ static void addHighLevelModulePipeline(SILPassPipelinePlan &P) {
   // Do the first stack promotion on high-level SIL before serialization.
   //
   // FIXME: why does StackPromotion need to run in the module pipeline?
-  P.addComputeEffects();
+  P.addComputeEscapeEffects();
   P.addStackPromotion();
 
   P.addGlobalOpt();
@@ -694,7 +694,7 @@ static void addClosureSpecializePassPipeline(SILPassPipelinePlan &P) {
   
   // ComputeEffects should be done at the end of a function-pipeline. The next
   // pass (GlobalOpt) is a module pass, so this is the end of a function-pipeline.
-  P.addComputeEffects();
+  P.addComputeEscapeEffects();
 
   // Hoist globals out of loops.
   // Global-init functions should not be inlined GlobalOpt is done.
@@ -725,7 +725,7 @@ static void addClosureSpecializePassPipeline(SILPassPipelinePlan &P) {
   // passes can expose more inlining opportunities.
   addSimplifyCFGSILCombinePasses(P);
 
-  P.addComputeEffects();
+  P.addComputeEscapeEffects();
 
   // We do this late since it is a pass like the inline caches that we only want
   // to run once very late. Make sure to run at least one round of the ARC
@@ -746,7 +746,7 @@ static void addLowLevelPassPipeline(SILPassPipelinePlan &P) {
 
   // We've done a lot of optimizations on this function, attempt to FSO.
   P.addFunctionSignatureOpts();
-  P.addComputeEffects();
+  P.addComputeEscapeEffects();
 }
 
 static void addLateLoopOptPassPipeline(SILPassPipelinePlan &P) {
@@ -775,7 +775,7 @@ static void addLateLoopOptPassPipeline(SILPassPipelinePlan &P) {
 
   // Sometimes stack promotion can catch cases only at this late stage of the
   // pipeline, after FunctionSignatureOpts.
-  P.addComputeEffects();
+  P.addComputeEscapeEffects();
   P.addStackPromotion();
 
   // Optimize overflow checks.

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -639,6 +639,7 @@ static void addHighLevelFunctionPipeline(SILPassPipelinePlan &P) {
   
   P.addStringOptimization();
   P.addComputeEscapeEffects();
+  P.addComputeSideEffects();
 }
 
 // After "high-level" function passes have processed the entire call tree, run
@@ -654,6 +655,7 @@ static void addHighLevelModulePipeline(SILPassPipelinePlan &P) {
   //
   // FIXME: why does StackPromotion need to run in the module pipeline?
   P.addComputeEscapeEffects();
+  P.addComputeSideEffects();
   P.addStackPromotion();
 
   P.addGlobalOpt();
@@ -695,6 +697,7 @@ static void addClosureSpecializePassPipeline(SILPassPipelinePlan &P) {
   // ComputeEffects should be done at the end of a function-pipeline. The next
   // pass (GlobalOpt) is a module pass, so this is the end of a function-pipeline.
   P.addComputeEscapeEffects();
+  P.addComputeSideEffects();
 
   // Hoist globals out of loops.
   // Global-init functions should not be inlined GlobalOpt is done.
@@ -726,6 +729,7 @@ static void addClosureSpecializePassPipeline(SILPassPipelinePlan &P) {
   addSimplifyCFGSILCombinePasses(P);
 
   P.addComputeEscapeEffects();
+  P.addComputeSideEffects();
 
   // We do this late since it is a pass like the inline caches that we only want
   // to run once very late. Make sure to run at least one round of the ARC
@@ -747,6 +751,7 @@ static void addLowLevelPassPipeline(SILPassPipelinePlan &P) {
   // We've done a lot of optimizations on this function, attempt to FSO.
   P.addFunctionSignatureOpts();
   P.addComputeEscapeEffects();
+  P.addComputeSideEffects();
 }
 
 static void addLateLoopOptPassPipeline(SILPassPipelinePlan &P) {
@@ -776,6 +781,7 @@ static void addLateLoopOptPassPipeline(SILPassPipelinePlan &P) {
   // Sometimes stack promotion can catch cases only at this late stage of the
   // pipeline, after FunctionSignatureOpts.
   P.addComputeEscapeEffects();
+  P.addComputeSideEffects();
   P.addStackPromotion();
 
   // Optimize overflow checks.

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -743,13 +743,18 @@ SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
     if (kind == SIL_ARG_EFFECTS_ATTR) {
       IdentifierID effectID;
       unsigned isDerived;
+      unsigned isGlobalSideEffects;
       unsigned argumentIndex;
-      SILArgEffectsAttrLayout::readRecord(scratch, effectID,
-                                          argumentIndex, isDerived);
+      SILArgEffectsAttrLayout::readRecord(scratch, effectID, argumentIndex,
+                                          isGlobalSideEffects, isDerived);
       if (shouldAddEffectAttrs) {
         StringRef effectStr = MF->getIdentifierText(effectID);
-        auto error = fn->parseEffects(effectStr, /*fromSIL*/ true,
-                                      argumentIndex, isDerived, {});
+        std::pair<const char *, int> error;
+        if (isGlobalSideEffects) {
+          error = fn->parseGlobalEffectsFromSIL(effectStr);
+        } else {
+          error = fn->parseArgumentEffectsFromSIL(effectStr, (int)argumentIndex);
+        }
         (void)error;
         assert(!error.first && "effects deserialization error");
       }

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 713; // @_noMetadata attribute in @_specialize
+const uint16_t SWIFTMODULE_VERSION_MINOR = 714; // New flag in SIL_ARG_EFFECTS_ATTR
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -320,6 +320,7 @@ namespace sil_block {
       BCRecordLayout<SIL_ARG_EFFECTS_ATTR,
                      IdentifierIDField, // argument effects string
                      BCVBR<8>,          // argumentIndex
+                     BCFixed<1>,        // argumentIndexValid
                      BCFixed<1>         // isDerived
                      >;
 

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -529,10 +529,12 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
 
       IdentifierID effectsStrID = S.addUniquedStringRef(OS.str());
       unsigned abbrCode = SILAbbrCodes[SILArgEffectsAttrLayout::Code];
+      bool isGlobalSideEffects = (argumentIndex < 0);
+      unsigned argIdx = (isGlobalSideEffects ? 0 : (unsigned)argumentIndex);
 
       SILArgEffectsAttrLayout::emitRecord(
-          Out, ScratchRecord, abbrCode,
-          effectsStrID, (unsigned)argumentIndex, (unsigned)isDerived);
+          Out, ScratchRecord, abbrCode, effectsStrID,
+          argIdx, (unsigned)isGlobalSideEffects, (unsigned)isDerived);
     });
 
   if (NoBody)

--- a/test/SILGen/effectsattr.swift
+++ b/test/SILGen/effectsattr.swift
@@ -15,12 +15,12 @@
 @_effects(releasenone) @_silgen_name("func4") func func4() { }
 
 //CHECK-LABEL: sil hidden [ossa] @func5
-//CHECK-NEXT:  [%0!: noescape **]
+//CHECK-NEXT:  [%0: noescape! **]
 //CHECK-NEXT:  {{^[^[]}}
 @_effects(notEscaping t.**) @_silgen_name("func5") func func5<T>(_ t: T) { }
 
 //CHECK-LABEL: sil hidden [ossa] @func6
-//CHECK-NEXT:  [%1!: escape v**.c* => %0.v**]
+//CHECK-NEXT:  [%1: escape! v**.c* => %0.v**]
 //CHECK-NEXT:  {{^[^[]}}
 @_effects(escaping t.value**.class* => return.value**) @_silgen_name("func6") func func6<T>(_ t: T) -> T { }
 
@@ -28,8 +28,8 @@ struct Mystr<T> {
   var sf: T
 
   //CHECK-LABEL: sil hidden [ossa] @func7
-  //CHECK-NEXT:  [%3!: noescape **]
-  //CHECK-NEXT:  [%2!: escape v** -> %1.s0.v**]
+  //CHECK-NEXT:  [%2: escape! v** -> %1.s0.v**]
+  //CHECK-NEXT:  [%3: noescape! **]
   //CHECK-NEXT:  {{^[^[]}}
   @_effects(notEscaping self.**)
   @_effects(escaping s.value** -> t.sf.value**)

--- a/test/SILOptimizer/cross-module-effects.swift
+++ b/test/SILOptimizer/cross-module-effects.swift
@@ -25,7 +25,8 @@ public final class X {
 }
 
 // CHECK-FR-MODULE-LABEL: sil [canonical] @$s6Module17noInlineNoEffectsySiAA1XCF :
-// CHECK-FR-MODULE-NEXT:  [%0: noescape **]
+// CHECK-FR-MODULE-NEXT:  [%0: noescape **, read c0.v**]
+// CHECK-FR-MODULE-NEXT:  [global: ]
 // CHECK-FR-MODULE-NEXT:  {{^[^[]}}
 // CHECK-LE-MODULE-NOT: @$s6Module17noInlineNoEffectsySiAA1XCF
 public func noInlineNoEffects(_ x: X) -> Int {
@@ -33,7 +34,8 @@ public func noInlineNoEffects(_ x: X) -> Int {
 }
 
 // CHECK-FR-MODULE-LABEL: sil [serialized] [noinline] [canonical] @$s6Module15inlineNoEffectsySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int {
-// CHECK-FR-MODULE-NEXT:  [%0: noescape **]
+// CHECK-FR-MODULE-NEXT:  [%0: noescape **, read c0.v**]
+// CHECK-FR-MODULE-NEXT:  [global: ]
 // CHECK-FR-MODULE-NEXT:  {{^[^[]}}
 // CHECK-LE-MODULE-LABEL: sil [serialized] [noinline] [canonical] @$s6Module15inlineNoEffectsySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int {
 // CHECK-LE-MODULE-NEXT:  {{^[^[]}}
@@ -44,7 +46,8 @@ public func inlineNoEffects(_ x: X) -> Int {
 }
 
 // CHECK-FR-MODULE-LABEL: sil [canonical] @$s6Module14internalCalleeySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int {
-// CHECK-FR-MODULE-NEXT:  [%0: noescape **]
+// CHECK-FR-MODULE-NEXT:  [%0: noescape **, read c0.v**]
+// CHECK-FR-MODULE-NEXT:  [global: ]
 // CHECK-FR-MODULE-NEXT:  {{^[^[]}}
 // CHECK-LE-MODULE-LABEL: sil [canonical] @$s6Module14internalCalleeySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int{{$}}
 @usableFromInline
@@ -53,7 +56,8 @@ func internalCallee(_ x: X) -> Int {
 }
 
 // CHECK-FR-MODULE-LABEL: sil [canonical] @$s6Module19noInlineWithEffectsySiAA1XCF :
-// CHECK-FR-MODULE-NEXT:  [%0: noescape! **]
+// CHECK-FR-MODULE-NEXT:  [%0: noescape! **, read c0.v**]
+// CHECK-FR-MODULE-NEXT:  [global: ]
 // CHECK-FR-MODULE-NEXT:  {{^[^[]}}
 // CHECK-LE-MODULE-NOT: @$s6Module19noInlineWithEffectsySiAA1XCF
 @_effects(notEscaping x.**)
@@ -62,7 +66,8 @@ public func noInlineWithEffects(_ x: X) -> Int {
 }
 
 // CHECK-FR-MODULE-LABEL: sil [serialized] [noinline] [canonical] @$s6Module17inlineWithEffectsySiAA1XCF :
-// CHECK-FR-MODULE-NEXT:  [%0: noescape! **]
+// CHECK-FR-MODULE-NEXT:  [%0: noescape! **, read c0.v**]
+// CHECK-FR-MODULE-NEXT:  [global: ]
 // CHECK-FR-MODULE-NEXT:  {{^[^[]}}
 // CHECK-LE-MODULE-LABEL: sil [serialized] [noinline] [canonical] @$s6Module17inlineWithEffectsySiAA1XCF :
 // CHECK-LE-MODULE-NEXT:  [%0: noescape! **]
@@ -75,7 +80,8 @@ public func inlineWithEffects(_ x: X) -> Int {
 }
 
 // CHECK-FR-MODULE-LABEL: sil [serialized] [noinline] [canonical] @$s6Module12simpleInlineySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int {
-// CHECK-FR-MODULE-NEXT:  [%0: noescape **]
+// CHECK-FR-MODULE-NEXT:  [%0: noescape **, read c0.v**]
+// CHECK-FR-MODULE-NEXT:  [global: ]
 // CHECK-FR-MODULE-NEXT:  {{^[^[]}}
 // CHECK-LE-MODULE-LABEL: sil [serialized] [noinline] [canonical] @$s6Module12simpleInlineySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int {
 // CHECK-LE-MODULE-NEXT:  {{^[^[]}}
@@ -100,7 +106,8 @@ public func callit1() -> Int {
 }
 
 // CHECK-FR-MAIN-LABEL: sil @$s6Module17noInlineNoEffectsySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int
-// CHECK-FR-MAIN-NEXT:  [%0: noescape **]
+// CHECK-FR-MAIN-NEXT:  [%0: noescape **, read c0.v**]
+// CHECK-FR-MAIN-NEXT:  [global: ]
 // CHECK-FR-MAIN-NEXT:  {{^[^[]}}
 // CHECK-LE-MAIN-LABEL: sil @$s6Module17noInlineNoEffectsySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int{{$}}
 
@@ -115,7 +122,8 @@ public func callit2() -> Int {
 }
 
 // CHECK-FR-MAIN-LABEL: sil public_external [noinline] @$s6Module15inlineNoEffectsySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int {
-// CHECK-FR-MAIN-NEXT:  [%0: noescape **]
+// CHECK-FR-MAIN-NEXT:  [%0: noescape **, read c0.v**]
+// CHECK-FR-MAIN-NEXT:  [global: ]
 // CHECK-FR-MAIN-NEXT:  {{^[^[]}}
 // CHECK-LE-MAIN-LABEL: sil public_external [noinline] @$s6Module15inlineNoEffectsySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int {
 // CHECK-LE-MAIN-NEXT:  {{^[^[]}}
@@ -162,13 +170,15 @@ public func callit5() -> Int {
 }
 
 // CHECK-FR-MAIN-LABEL: sil public_external [noinline] @$s6Module12simpleInlineySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int {
-// CHECK-FR-MAIN-NEXT:  [%0: noescape **]
+// CHECK-FR-MAIN-NEXT:  [%0: noescape **, read c0.v**]
+// CHECK-FR-MAIN-NEXT:  [global: ]
 // CHECK-FR-MAIN-NEXT:  {{^[^[]}}
 // CHECK-LE-MAIN-LABEL: sil public_external [noinline] @$s6Module12simpleInlineySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int {
 // CHECK-LE-MAIN-NEXT:  {{^[^[]}}
 
 // CHECK-FR-MAIN-LABEL: sil @$s6Module14internalCalleeySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int {
-// CHECK-FR-MAIN-NEXT:  [%0: noescape **]
+// CHECK-FR-MAIN-NEXT:  [%0: noescape **, read c0.v**]
+// CHECK-FR-MAIN-NEXT:  [global: ]
 // CHECK-FR-MAIN-NEXT:  {{^[^[]}}
 // CHECK-LE-MAIN-LABEL: sil @$s6Module14internalCalleeySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int{{$}}
 

--- a/test/SILOptimizer/cross-module-effects.swift
+++ b/test/SILOptimizer/cross-module-effects.swift
@@ -53,7 +53,7 @@ func internalCallee(_ x: X) -> Int {
 }
 
 // CHECK-FR-MODULE-LABEL: sil [canonical] @$s6Module19noInlineWithEffectsySiAA1XCF :
-// CHECK-FR-MODULE-NEXT:  [%0!: noescape **]
+// CHECK-FR-MODULE-NEXT:  [%0: noescape! **]
 // CHECK-FR-MODULE-NEXT:  {{^[^[]}}
 // CHECK-LE-MODULE-NOT: @$s6Module19noInlineWithEffectsySiAA1XCF
 @_effects(notEscaping x.**)
@@ -62,10 +62,10 @@ public func noInlineWithEffects(_ x: X) -> Int {
 }
 
 // CHECK-FR-MODULE-LABEL: sil [serialized] [noinline] [canonical] @$s6Module17inlineWithEffectsySiAA1XCF :
-// CHECK-FR-MODULE-NEXT:  [%0!: noescape **]
+// CHECK-FR-MODULE-NEXT:  [%0: noescape! **]
 // CHECK-FR-MODULE-NEXT:  {{^[^[]}}
 // CHECK-LE-MODULE-LABEL: sil [serialized] [noinline] [canonical] @$s6Module17inlineWithEffectsySiAA1XCF :
-// CHECK-LE-MODULE-NEXT:  [%0!: noescape **]
+// CHECK-LE-MODULE-NEXT:  [%0: noescape! **]
 // CHECK-LE-MODULE-NEXT:  {{^[^[]}}
 @inlinable
 @inline(never)
@@ -131,7 +131,7 @@ public func callit3() -> Int {
 }
 
 // CHECK-FR-MAIN-LABEL: sil @$s6Module19noInlineWithEffectsySiAA1XCF
-// CHECK-FR-MAIN-NEXT:  [%0!: noescape **]
+// CHECK-FR-MAIN-NEXT:  [%0: noescape! **]
 // CHECK-FR-MAIN-NEXT:  {{^[^[]}}
 
 // CHECK-MAIN-LABEL: sil [noinline] @$s4Main7callit4SiyF :
@@ -145,10 +145,10 @@ public func callit4() -> Int {
 }
 
 // CHECK-FR-MAIN-LABEL: sil public_external [noinline] @$s6Module17inlineWithEffectsySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int {
-// CHECK-FR-MAIN-NEXT:  [%0!: noescape **]
+// CHECK-FR-MAIN-NEXT:  [%0: noescape! **]
 // CHECK-FR-MAIN-NEXT:  {{^[^[]}}
 // CHECK-LE-MAIN-LABEL: sil public_external [noinline] @$s6Module17inlineWithEffectsySiAA1XCF : $@convention(thin) (@guaranteed X) -> Int {
-// CHECK-LE-MAIN-NEXT:  [%0!: noescape **]
+// CHECK-LE-MAIN-NEXT:  [%0: noescape! **]
 // CHECK-LE-MAIN-NEXT:  {{^[^[]}}
 
 // CHECK-MAIN-LABEL: sil [noinline] @$s4Main7callit5SiyF :

--- a/test/SILOptimizer/deadendblocks.sil
+++ b/test/SILOptimizer/deadendblocks.sil
@@ -1,0 +1,81 @@
+// RUN: %target-sil-opt %s -dump-deadendblocks -o /dev/null | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+// CHECK-LABEL: Function simple_test
+// CHECK:       [bb2]
+// CHECK:       end function simple_test
+sil @simple_test : $@convention(thin) () -> () {
+bb0:
+  cond_br undef, bb1, bb2
+bb1:
+  br bb3
+bb2:
+  unreachable
+bb3:
+  %r = tuple ()
+  return %r : $()
+}
+
+sil @throwing_fun : $@convention(thin) () -> ((), @error any Error)
+
+// CHECK-LABEL: Function test_throw
+// CHECK:       [bb1]
+// CHECK:       end function test_throw
+sil @test_throw : $@convention(thin) () -> ((), @error any Error) {
+bb0:
+  %0 = function_ref @throwing_fun : $@convention(thin) () -> ((), @error any Error)
+  try_apply %0() : $@convention(thin) () -> ((), @error any Error), normal bb1, error bb2
+bb1(%2: $()):
+  unreachable
+bb2(%3 : $Error):
+  throw %3 : $Error
+}
+
+
+// CHECK-LABEL: Function test_unwind
+// CHECK:       [bb1]
+// CHECK:       end function test_unwind
+sil @test_unwind : $@yield_once @convention(thin) () -> @yields () {
+bb0:
+  %t = tuple ()
+  yield %t : $(), resume bb1, unwind bb2
+bb1:
+  unreachable
+bb2:
+  unwind
+}
+
+// CHECK-LABEL: Function complex_cfg
+// CHECK:       [bb7,bb8,bb9]
+// CHECK:       end function complex_cfg
+sil @complex_cfg : $@convention(thin) () -> ((), @error any Error) {
+bb0:
+  cond_br undef, bb1, bb7
+bb1:
+  %0 = function_ref @throwing_fun : $@convention(thin) () -> ((), @error any Error)
+  try_apply %0() : $@convention(thin) () -> ((), @error any Error), normal bb2, error bb3
+bb2(%2: $()):
+  br bb4
+bb3(%3 : $Error):
+  throw %3 : $Error
+bb4:
+  cond_br undef, bb5, bb6
+bb5:
+  br bb4
+bb6:
+  %r = tuple ()
+  return %r : $()
+bb7:
+  br bb8
+bb8:
+  cond_br undef, bb8, bb9
+bb9:
+  unreachable
+}
+

--- a/test/SILOptimizer/escape_effects.sil
+++ b/test/SILOptimizer/escape_effects.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt %s -compute-effects | %FileCheck %s
+// RUN: %target-sil-opt %s -compute-escape-effects | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 

--- a/test/SILOptimizer/escape_effects_objc.sil
+++ b/test/SILOptimizer/escape_effects_objc.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt %s -compute-effects | %FileCheck %s
+// RUN: %target-sil-opt %s -compute-escape-effects | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: objc_interop

--- a/test/SILOptimizer/escape_info_objc.sil
+++ b/test/SILOptimizer/escape_info_objc.sil
@@ -4,9 +4,6 @@
 // REQUIRES: objc_interop
 // REQUIRES: PTRSIZE=64
 
-// Currently failing on arm: rdar://92963081
-// REQUIRES: CPU=x86_64
-
 sil_stage canonical
 
 import Builtin
@@ -20,7 +17,7 @@ sil @$ss23_ContiguousArrayStorageCfD : $@convention(method) <Element> (@owned _C
 }
 
 sil @array_adopt_storage_class : $@convention(method) (@owned _ContiguousArrayStorage<X>, Int, @thin Array<X>.Type) -> (@owned Array<X>, UnsafeMutablePointer<X>) {
-[%0!: escape => %r.0.v**, escape c*.v** => %r.0.v**.c*.v**, escape c*.v** => %r.1.v**] 
+[%0: escape! => %r.0.v**, escape c*.v** => %r.0.v**.c*.v**, escape c*.v** => %r.1.v**] 
 }
 
 sil @array_adopt_storage : $@convention(thin) (@owned _ContiguousArrayStorage<Int>) -> (@owned Array<Int>, UnsafeMutablePointer<Int>) {

--- a/test/SILOptimizer/existential_metatype.swift
+++ b/test/SILOptimizer/existential_metatype.swift
@@ -4,7 +4,7 @@ protocol SomeP {}
 public enum SpecialEnum : SomeP {}
 
 // CHECK-LABEL: sil shared [noinline] @$s20existential_metatype17checkProtocolType0aE0Sbxm_tAA5SomePRzlFAA11SpecialEnumO_Tg5Tf4d_n : $@convention(thin) () -> Bool {
-// CHECK-NEXT: bb0:
+// CHECK:       bb0:
 // CHECK-NEXT:   %0 = integer_literal $Builtin.Int1, -1
 // CHECK-NEXT:   %1 = struct $Bool (%0 : $Builtin.Int1)
 // CHECK-NEXT:   return %1 : $Bool

--- a/test/SILOptimizer/existential_specializer_indirect_class.sil
+++ b/test/SILOptimizer/existential_specializer_indirect_class.sil
@@ -21,13 +21,13 @@ bb0(%0 : $*ClassProtocol):
 
 // Check that all the opened types are optimized away in the specialization of test_indirect_class_protocol_guaranteed
 // CHECK-LABEL: sil shared @$s39test_indirect_class_protocol_guaranteedTf4e_n : $@convention(thin) <τ_0_0 where τ_0_0 : ClassProtocol> (@in_guaranteed τ_0_0) -> ()
-// CHECK-NEXT: //
-// CHECK-NEXT: bb0(%0 : $*τ_0_0):
+// CHECK:        bb0(%0 : $*τ_0_0):
   // CHECK-NEXT: [[INPUT:%1]] = load %0
   // CHECK-NEXT: [[ARG:%.*]] = unchecked_ref_cast [[INPUT]]
   // CHECK-NEXT: [[METHOD:%.*]] = witness_method $C, #ClassProtocol.method
   // CHECK-NEXT: apply [[METHOD]]<C>([[ARG]])
   // CHECK-NEXT: return undef
+  // CHECK:      } // end sil function '$s39test_indirect_class_protocol_guaranteedTf4e_n'
   
 sil @test_indirect_class_protocol_guaranteed : $@convention(thin) (@in_guaranteed ClassProtocol) -> () {
 bb0(%0 : $*ClassProtocol):
@@ -48,8 +48,9 @@ bb0(%0 : $*ClassProtocol):
 // Check the generated specialization of test_indirect_class_protocol
 // CHECK-LABEL: sil shared @$s28test_indirect_class_protocolTf4e_n4main1CC_Tg5Tf4d_n : $@convention(thin) () -> ()
 // Make sure *everything* was inlined / optimized away
-// CHECK-NEXT: bb0:
+// CHECK:      bb0:
 // CHECK-NEXT: return undef
+// CHECK:      } // end sil function '$s28test_indirect_class_protocolTf4e_n4main1CC_Tg5Tf4d_n'
 
 sil @invoke_indirect_class_protocol : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : $C):

--- a/test/SILOptimizer/function_effects.sil
+++ b/test/SILOptimizer/function_effects.sil
@@ -132,10 +132,10 @@ bb0(%0 : @guaranteed $Z):
 }
 
 // CHECK-LABEL: sil @not_escaping_argument
-// CHECK-NEXT:  [%0!: noescape **]
+// CHECK-NEXT:  [%0: noescape! **]
 // CHECK-NEXT:  {{^[^[]}}
 sil @not_escaping_argument : $@convention(thin) (@guaranteed Z) -> () {
-[%0!: noescape **]
+[%0: noescape! **]
 bb0(%0 : $Z):
   %1 = ref_element_addr %0 : $Z, #Z.y
   %2 = global_addr @globalY : $*Y

--- a/test/SILOptimizer/functionsigopts_crash.swift
+++ b/test/SILOptimizer/functionsigopts_crash.swift
@@ -25,7 +25,8 @@ public struct S : P {
 //   * FSO: argument explosion 
 
 // CHECK-LABEL: sil shared [noinline] @$s4main6testityyAA1P_pFTf4e_nAA1SV_Tg5Tf4x_n : $@convention(thin) (Int) -> () { 
-// CHECK-NEXT: // %0 "p"
+// CHECK:       // %0 "p"
+// CHECK:       } // end sil function '$s4main6testityyAA1P_pFTf4e_nAA1SV_Tg5Tf4x_n'
 @inline(never)
 func testit(_ p: P) {
   p.foo()

--- a/test/SILOptimizer/optionset.swift
+++ b/test/SILOptimizer/optionset.swift
@@ -18,24 +18,26 @@ public struct TestOptions: OptionSet {
 // CHECK:   %initval = struct $TestOptions ([[INT]] : $Int)
 let globalTestOptions: TestOptions = [.first, .second, .third, .fourth]
 
-// CHECK-LABEL: sil @{{.*}}returnTestOptions{{.*}}
-// CHECK-NEXT: bb0:
+// CHECK-LABEL: sil @$s4test17returnTestOptionsAA0cD0VyF
+// CHECK:      bb0:
 // CHECK-NEXT:   builtin
 // CHECK-NEXT:   integer_literal {{.*}}, 15
 // CHECK-NEXT:   struct $Int
 // CHECK:        struct $TestOptions
 // CHECK-NEXT:   return
+// CHECK:      } // end sil function '$s4test17returnTestOptionsAA0cD0VyF'
 public func returnTestOptions() -> TestOptions {
     return [.first, .second, .third, .fourth]
 }
 
-// CHECK-LABEL: sil @{{.*}}returnEmptyTestOptions{{.*}}
-// CHECK-NEXT: bb0:
+// CHECK-LABEL: sil @$s4test22returnEmptyTestOptionsAA0dE0VyF
+// CHECK:      bb0:
 // CHECK-NEXT:   integer_literal {{.*}}, 0
 // CHECK-NEXT:   struct $Int
 // CHECK:        builtin "onFastPath"() : $()
 // CHECK-NEXT:   struct $TestOptions
 // CHECK-NEXT:   return
+// CHECK:      } // end sil function '$s4test22returnEmptyTestOptionsAA0dE0VyF'
 public func returnEmptyTestOptions() -> TestOptions {
     return []
 }

--- a/test/SILOptimizer/side_effects.sil
+++ b/test/SILOptimizer/side_effects.sil
@@ -1,0 +1,1071 @@
+// RUN: %target-sil-opt %s -parse-serialized-sil -module-name test -compute-side-effects | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+
+import Builtin
+import Swift
+
+//////////////////
+// Declarations //
+//////////////////
+
+enum Never {}
+
+final class X {
+  @_hasStorage var a: Int32
+  @_hasStorage var x: X
+
+  init()
+  deinit
+}
+
+class Y {
+}
+
+struct SP {
+  var value: X
+}
+
+struct TwoSPs {
+  var sp1: SP
+  var sp2: SP
+}
+
+enum EP {
+  case none
+  case data(SP, Builtin.Int1)
+}
+
+class List {
+  var x: Int32
+  let next: List
+}
+
+struct S {
+  var l: List
+  var y: Int32
+}
+
+struct Ptr {
+  var p: Int32
+}
+
+
+sil_global public @global_var : $Int32
+
+sil [_semantics "programtermination_point"] @exitfunc : $@convention(thin) () -> Never
+sil [readnone] @pure_func : $@convention(thin) () -> ()
+sil [readnone] @readnone_owned : $@convention(thin) (@owned X) -> @owned X
+sil [releasenone] @releasenone_func : $@convention(thin) () -> ()
+sil [readonly] @readonly_owned : $@convention(thin) (@owned X) -> ()
+sil [readonly] @readonly_guaranteed : $@convention(thin) (@guaranteed X) -> ()
+sil [readonly] @readonly_indirect_params : $@convention(thin) (@in_guaranteed X, @inout X) -> @out X
+sil [readnone] @readnone_indirect_params : $@convention(thin) (@in_guaranteed X, @inout X) -> @out X
+
+sil @unknown_func : $@convention(thin) () -> ()
+sil @unknown_func_with_in_arg : $@convention(thin) (@in X) -> ()
+sil @unknown_func_with_in_guaranteed_arg : $@convention(thin) (@in_guaranteed X) -> ()
+sil @unknown_func_with_inout_arg : $@convention(thin) (@inout SP) -> ()
+sil @unknown_func_with_trivial_args : $@convention(thin) (@in Int32, Int32) -> ()
+
+
+sil @$s4test1XCfD : $@convention(method) (@owned X) -> () {
+[global: copy, write]
+}
+
+// CHECK-LABEL: sil @load_store_to_args
+// CHECK-NEXT:  [%0: read v**]
+// CHECK-NEXT:  [%1: write v**]
+// CHECK-NEXT:  [%2: write c0.v**]
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+sil @load_store_to_args : $@convention(thin) (@inout Int32, @inout Int32, @guaranteed X) -> () {
+bb0(%0 : $*Int32, %1 : $*Int32, %2 : $X):
+  %l1 = load %0 : $*Int32
+  store %l1 to %1  : $*Int32
+  %a = ref_element_addr %2 : $X, #X.a
+  store %l1 to %a : $*Int32
+
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @call_load_store_to_args1
+// CHECK-NEXT:  [%0: write c0.v**]
+// CHECK-NEXT:  [%1: read v**]
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+sil @call_load_store_to_args1 : $@convention(thin) (@guaranteed X, @inout Int32, @inout Int32) -> () {
+bb0(%0 : $X, %1 : $*Int32, %2 : $*Int32):
+  %s = alloc_stack $Int32
+
+  %f = function_ref @load_store_to_args : $@convention(thin) (@inout Int32, @inout Int32, @guaranteed X) -> ()
+  %ap = apply %f(%1, %s, %0) : $@convention(thin) (@inout Int32, @inout Int32, @guaranteed X) -> ()
+
+  dealloc_stack %s : $*Int32
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @call_load_store_to_args2
+// CHECK-NEXT:  [%0: read c1.v**, write c0.v**]
+// CHECK-NEXT:  [%1: read v**]
+// CHECK-NEXT:  [global: write]
+// CHECK-NEXT:  {{^[^[]}}
+sil @call_load_store_to_args2 : $@convention(thin) (@guaranteed X, @inout Int32) -> () {
+bb0(%0 : $X, %1 : $*Int32):
+  %xa = ref_element_addr %0 : $X, #X.x
+  %x2 = load %xa : $*X
+  %a = ref_element_addr %x2 : $X, #X.a
+
+  %f = function_ref @load_store_to_args : $@convention(thin) (@inout Int32, @inout Int32, @guaranteed X) -> ()
+  %ap = apply %f(%1, %a, %0) : $@convention(thin) (@inout Int32, @inout Int32, @guaranteed X) -> ()
+
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @partial_apply_load_store_to_args
+// CHECK-NEXT:  [%0: read v**]
+// CHECK-NEXT:  [%1: write v**]
+// CHECK-NEXT:  [%2: write c0.v**, destroy c*.v**]
+// CHECK-NEXT:  [global: read,write,copy,destroy,allocate]
+// CHECK-NEXT:  {{^[^[]}}
+sil @partial_apply_load_store_to_args : $@convention(thin) (@inout Int32, @inout Int32, @guaranteed X) -> () {
+bb0(%0 : $*Int32, %1 : $*Int32, %2 : $X):
+  %f = function_ref @load_store_to_args : $@convention(thin) (@inout Int32, @inout Int32, @guaranteed X) -> ()
+  %c = partial_apply %f(%1, %2) : $@convention(thin) (@inout Int32, @inout Int32, @guaranteed X) -> ()
+  // The apply may call deinit of the callee_owned thick function. Therefore the
+  // function effects are conservative.
+  // %c is implicitly released which may call deinit of the boxed X.
+  %ap = apply %c(%0) : $@callee_owned (@inout Int32) -> ()
+
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @guaranteed_partial_apply_load_store_to_args
+// CHECK-NEXT:  [%0: read v**]
+// CHECK-NEXT:  [%1: write v**]
+// CHECK-NEXT:  [%2: write c0.v**]
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+sil @guaranteed_partial_apply_load_store_to_args : $@convention(thin) (@inout Int32, @inout Int32, @guaranteed X) -> () {
+bb0(%0 : $*Int32, %1 : $*Int32, %2 : $X):
+  %f = function_ref @load_store_to_args : $@convention(thin) (@inout Int32, @inout Int32, @guaranteed X) -> ()
+  %c = partial_apply [callee_guaranteed] %f(%1, %2) : $@convention(thin) (@inout Int32, @inout Int32, @guaranteed X) -> ()
+  %ap = apply %c(%0) : $@callee_guaranteed (@inout Int32) -> ()
+
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @stack_partial_apply_load_store_to_args
+// CHECK-NEXT:  [%0: read v**]
+// CHECK-NEXT:  [%1: write v**]
+// CHECK-NEXT:  [%2: write c0.v**]
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+sil @stack_partial_apply_load_store_to_args : $@convention(thin) (@inout Int32, @inout Int32, @guaranteed X) -> () {
+bb0(%0 : $*Int32, %1 : $*Int32, %2 : $X):
+  %f = function_ref @load_store_to_args : $@convention(thin) (@inout Int32, @inout Int32, @guaranteed X) -> ()
+  %c = partial_apply [on_stack] %f(%1, %2) : $@convention(thin) (@inout Int32, @inout Int32, @guaranteed X) -> ()
+  %ap = apply %c(%0) : $@noescape @callee_owned (@inout Int32) -> ()
+  dealloc_stack %c : $@noescape @callee_owned (@inout Int32) -> ()
+
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @load_store_to_unknown
+// CHECK-NEXT:  [%1: read c1.v**]
+// CHECK-NEXT:  [global: read,write]
+// CHECK-NEXT:  {{^[^[]}}
+sil @load_store_to_unknown : $@convention(thin) (Int32, @guaranteed X) -> () {
+bb0(%0 : $Int32, %1 : $X):
+  %xa = ref_element_addr %1 : $X, #X.x
+  %x2 = load %xa : $*X
+  %a = ref_element_addr %x2 : $X, #X.a
+  store %0 to %a  : $*Int32
+  %l = load %a : $*Int32
+
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @retain_and_store
+// CHECK-NEXT:  [%0: write v**]
+// CHECK-NEXT:  [%1: copy v**]
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+sil @retain_and_store : $@convention(thin) (@guaranteed X) -> @out X {
+bb0(%0 : $*X, %1 : $X):
+  strong_retain %1 : $X
+  store %1 to %0  : $*X
+
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @release_owned
+// CHECK-NEXT:  [%0: destroy c*.v**]
+// CHECK-NEXT:  [global: write,copy]
+// CHECK-NEXT:  {{^[^[]}}
+sil @release_owned : $@convention(thin) (@owned X) -> () {
+bb0(%0 : $X):
+  strong_release %0 : $X
+
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @call_unknown
+// CHECK-NEXT:  [global: read,write,copy,destroy,allocate]
+// CHECK-NEXT:  {{^[^[]}}
+sil @call_unknown : $@convention(thin) () -> () {
+bb0:
+  %u = function_ref @unknown_func : $@convention(thin) () -> ()
+  %a = apply %u() : $@convention(thin) () -> ()
+
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @call_unknown_func_with_trivial_args
+// CHECK-NEXT:  [%0: read v**]
+// CHECK-NEXT:  [global: read,write,copy,destroy,allocate]
+// CHECK-NEXT:  {{^[^[]}}
+sil @call_unknown_func_with_trivial_args : $@convention(thin) (@in Int32, Int32) -> () {
+bb0(%0 : $*Int32, %1 : $Int32):
+  %2 = function_ref @unknown_func_with_trivial_args : $@convention(thin) (@in Int32, Int32) -> ()
+  %3 = apply %2(%0, %1) : $@convention(thin) (@in Int32, Int32) -> ()
+
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @load_store_to_local
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+sil @load_store_to_local : $@convention(thin) (Int32) -> () {
+bb0(%0 : $Int32):
+  %x = alloc_ref $X
+  %a = ref_element_addr %x : $X, #X.a
+  store %0 to %a : $*Int32
+  %l1 = load %a : $*Int32
+
+  %b = alloc_box $<τ_0_0> { var τ_0_0 } <Int32>
+  %ba = project_box %b : $<τ_0_0> { var τ_0_0 } <Int32>, 0
+  store %0 to %ba : $*Int32
+  %l2 = load %ba : $*Int32
+
+  %s = alloc_stack $Int32
+  store %0 to %s : $*Int32
+  %l3 = load %s : $*Int32
+  dealloc_stack %s : $*Int32
+
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @condfail
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+sil @condfail : $@convention(thin) (Builtin.Int1) -> () {
+bb0(%0 : $Builtin.Int1):
+  cond_fail %0 : $Builtin.Int1
+
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @checkedcast
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+sil @checkedcast : $@convention(thin) (Builtin.NativeObject) -> () {
+bb0(%0 : $Builtin.NativeObject):
+  unconditional_checked_cast %0 : $Builtin.NativeObject to X
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @checkedaddr
+sil @checkedaddr : $@convention(thin) (Builtin.NativeObject, X) -> () {
+// CHECK-NEXT:  [%0: read v**.c*.v**, write v**.c*.v**, copy v**.c*.v**, destroy v**.c*.v**]
+// CHECK-NEXT:  [%1: read c*.v**, write c*.v**, copy c*.v**, destroy c*.v**]
+// CHECK-NEXT:  [global: read,write,copy,destroy,allocate]
+// CHECK-NEXT:  {{^[^[]}}
+bb0(%0 : $Builtin.NativeObject, %1 : $X):
+  unconditional_checked_cast_addr Builtin.NativeObject in %0 : $Builtin.NativeObject to X in %1 : $X
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @test_project_box
+// CHECK-NEXT:  [%0: read c0.v**]
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+sil @test_project_box : $@convention(thin) (<τ_0_0> { var τ_0_0 } <Builtin.Int32>) -> Builtin.Int32 {
+bb0(%0 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>):
+  %a = project_box %0 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>, 0
+  %l = load %a : $*Builtin.Int32
+  return %l : $Builtin.Int32
+}
+
+// CHECK-LABEL: sil [ossa] @projections
+// CHECK-NEXT:  [%0: read e1.0.s0.c0.s0.v**]
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+sil [ossa] @projections : $@convention(thin) (@guaranteed EP) -> Builtin.Int32 {
+bb0(%0 : @guaranteed $EP):
+  %1 = unchecked_enum_data %0 : $EP, #EP.data!enumelt
+  %2 = tuple_extract %1 : $(SP, Builtin.Int1), 0
+  %3 = struct_extract %2 : $SP, #SP.value
+  %b = begin_borrow %3 : $X
+  %4 = ref_element_addr %b : $X, #X.a
+  %5 = begin_access [read] [dynamic] %4 : $*Int32
+  %6 = struct_element_addr %5 : $*Int32, #Int32._value
+  %7 = load [trivial] %6 : $*Builtin.Int32
+  end_access %5 : $*Int32
+  end_borrow %b : $X
+  return %7 : $Builtin.Int32
+}
+
+sil @two_addr_args : $@convention(thin) (@inout Int32, @inout SP) -> () {
+[%0: write s1]
+[%1: write s0.v**]
+[global: ]
+}
+
+// CHECK-LABEL: sil [ossa] @path_concatenation
+// CHECK-NEXT:  [%0: write s0.c0.s1]
+// CHECK-NEXT:  [%1: write s1.s0.v**]
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+sil [ossa] @path_concatenation : $@convention(thin) (@guaranteed SP, @inout TwoSPs) -> () {
+bb0(%0 : @guaranteed $SP, %1 : $*TwoSPs):
+  %2 = struct_extract %0 : $SP, #SP.value
+  %3 = ref_element_addr %2 : $X, #X.a
+  %4 = struct_element_addr %1 : $*TwoSPs, #TwoSPs.sp2
+  %f = function_ref @two_addr_args : $@convention(thin) (@inout Int32, @inout SP) -> ()
+  %ap = apply %f(%3, %4) : $@convention(thin) (@inout Int32, @inout SP) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+sil @two_addr_args2 : $@convention(thin) (@inout Int32, @inout X) -> () {
+[%0: write v**]
+[%1: write v**]
+}
+
+// CHECK-LABEL: sil [ossa] @path_merging
+// CHECK-NEXT:  [%0: write s0.c*.v**]
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+sil [ossa] @path_merging : $@convention(thin) (@guaranteed SP) -> () {
+bb0(%0 : @guaranteed $SP):
+  %1 = struct_extract %0 : $SP, #SP.value
+  %2 = ref_element_addr %1 : $X, #X.a
+  %3 = ref_element_addr %1 : $X, #X.x
+  %f = function_ref @two_addr_args2 : $@convention(thin) (@inout Int32, @inout X) -> ()
+  %ap = apply %f(%2, %3) : $@convention(thin) (@inout Int32, @inout X) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @multiple_arg_roots1
+// CHECK-NEXT:  [%0: read s0.c0.v**]
+// CHECK-NEXT:  [%1: read c0.v**]
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+sil @multiple_arg_roots1 : $@convention(thin) (@guaranteed SP, @guaranteed X) -> Int32 {
+bb0(%0 : $SP, %1 : $X):
+  cond_br undef, bb1, bb2
+bb1:
+  %2 = struct_extract %0 : $SP, #SP.value
+  br bb3(%2 : $X)
+bb2:
+  br bb3(%1 : $X)
+bb3(%5 : $X):
+  %6 = ref_element_addr %5 : $X, #X.a
+  %7 = load %6 : $*Int32
+  return %7 : $Int32
+}
+
+// CHECK-LABEL: sil @multiple_arg_roots_and_load
+// CHECK-NEXT:  [%0: read s0.c0.v**]
+// CHECK-NEXT:  [%1: read c0.v**]
+// CHECK-NEXT:  [%2: read v**]
+// CHECK-NEXT:  [global: read]
+// CHECK-NEXT:  {{^[^[]}}
+sil @multiple_arg_roots_and_load : $@convention(thin) (@guaranteed SP, @guaranteed X, @in_guaranteed X) -> Int32 {
+bb0(%0 : $SP, %1 : $X, %2 : $*X):
+  cond_br undef, bb1, bb2
+bb1:
+  cond_br undef, bb3, bb4
+bb2:
+  %5 = struct_extract %0 : $SP, #SP.value
+  br bb5(%5 : $X)
+bb3:
+  br bb5(%1 : $X)
+bb4:
+  %8 = load %2 : $*X
+  br bb5(%8 : $X)
+bb5(%10 : $X):
+  %11 = ref_element_addr %10 : $X, #X.a
+  %12 = load %11 : $*Int32
+  return %12 : $Int32
+}
+
+// CHECK-LABEL: sil @load_from_global_var
+// CHECK-NEXT:  [global: read]
+// CHECK-NEXT:  {{^[^[]}}
+sil @load_from_global_var : $@convention(thin) () -> Int32 {
+bb0:
+  %0 = global_addr @global_var : $*Int32
+  %1 = load %0 : $*Int32
+  return %1 : $Int32
+}
+
+// CHECK-LABEL: sil [ossa] @forward_to_return
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+sil [ossa] @forward_to_return : $@convention(thin) (@owned SP) -> @owned SP {
+bb0(%0 : @owned $SP):
+  return %0 : $SP
+}
+
+// CHECK-LABEL: sil [ossa] @store_destoys
+// CHECK-NEXT:  [%0: write v**, destroy v**]
+// CHECK-NEXT:  [%1: write c*.v**, copy c*.v**]
+// CHECK-NEXT:  [global: write,copy]
+// CHECK-NEXT:  {{^[^[]}}
+sil [ossa] @store_destoys : $@convention(thin) (@inout X, @owned X) -> () {
+bb0(%0 : $*X, %1 : @owned $X):
+  store %1 to [assign] %0 : $*X
+  %2 = tuple ()
+  return %2 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @unknown_destructor_effects
+// CHECK-NEXT:  [%0: write v**, destroy v**]
+// CHECK-NEXT:  [%1: read c*.v**, write c*.v**, copy c*.v**, destroy c*.v**]
+// CHECK-NEXT:  [global: read,write,copy,destroy,allocate]
+// CHECK-NEXT:  {{^[^[]}}
+sil [ossa] @unknown_destructor_effects : $@convention(thin) (@inout Y, @owned Y) -> () {
+bb0(%0 : $*Y, %1 : @owned $Y):
+  store %1 to [assign] %0 : $*Y
+  %2 = tuple ()
+  return %2 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @store_doesnt_destroy
+// CHECK-NEXT:  [%0: write v**]
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+sil [ossa] @store_doesnt_destroy : $@convention(thin) (@owned X) -> @out X {
+bb0(%0 : $*X, %1 : @owned $X):
+  store %1 to [init] %0 : $*X
+  %2 = tuple ()
+  return %2 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @copy_destoys
+// CHECK-NEXT:  [%0: write v**, destroy v**]
+// CHECK-NEXT:  [%1: read v**, copy v**]
+// CHECK-NEXT:  [global: write,copy]
+// CHECK-NEXT:  {{^[^[]}}
+sil [ossa] @copy_destoys : $@convention(thin) (@inout X, @in_guaranteed X) -> () {
+bb0(%0 : $*X, %1 : $*X):
+  copy_addr %1 to %0 : $*X
+  %2 = tuple ()
+  return %2 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @copy_doesnt_destoy
+// CHECK-NEXT:  [%0: write v**]
+// CHECK-NEXT:  [%1: read v**, copy v**]
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+sil [ossa] @copy_doesnt_destoy : $@convention(thin) (@in_guaranteed X) -> @out X {
+bb0(%0 : $*X, %1 : $*X):
+  copy_addr %1 to [initialization] %0 : $*X
+  %2 = tuple ()
+  return %2 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @destroy_value_effects1
+// CHECK-NEXT:  [%0: destroy v**.c*.v**]
+// CHECK-NEXT:  [global: read,write,copy,destroy,allocate]
+// CHECK-NEXT:  {{^[^[]}}
+sil [ossa] @destroy_value_effects1 : $@convention(thin) (@owned SP) -> () {
+bb0(%0 : @owned $SP):
+  destroy_value %0 : $SP
+  %2 = tuple ()
+  return %2 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @destroy_value_effects2
+// CHECK-NEXT:  [%0: destroy s0.c*.v**]
+// CHECK-NEXT:  [global: write,copy]
+// CHECK-NEXT:  {{^[^[]}}
+sil [ossa] @destroy_value_effects2 : $@convention(thin) (@owned SP) -> () {
+bb0(%0 : @owned $SP):
+  (%1) = destructure_struct %0 : $SP
+  destroy_value %1 : $X
+  %2 = tuple ()
+  return %2 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @destroy_addr_effects
+// CHECK-NEXT:  [%0: destroy v**]
+// CHECK-NEXT:  [global: write,copy]
+// CHECK-NEXT:  {{^[^[]}}
+sil [ossa] @destroy_addr_effects : $@convention(thin) (@in X) -> () {
+bb0(%0 : $*X):
+  destroy_addr %0 : $*X
+  %2 = tuple ()
+  return %2 : $()
+}
+
+// CHECK-LABEL: sil @release_value_effects
+// CHECK-NEXT:  [%0: destroy c*.v**]
+// CHECK-NEXT:  [global: write,copy]
+// CHECK-NEXT:  {{^[^[]}}
+sil @release_value_effects : $@convention(thin) (@owned X) -> () {
+bb0(%0 : $X):
+  release_value %0 : $X
+  %2 = tuple ()
+  return %2 : $()
+}
+
+// CHECK-LABEL: sil @strong_release_effects
+// CHECK-NEXT:  [%0: destroy c*.v**]
+// CHECK-NEXT:  [global: write,copy]
+// CHECK-NEXT:  {{^[^[]}}
+sil @strong_release_effects : $@convention(thin) (@owned X) -> () {
+bb0(%0 : $X):
+  strong_release %0 : $X
+  %2 = tuple ()
+  return %2 : $()
+}
+
+// CHECK-LABEL: sil @load_and_release
+// CHECK-NEXT:  [%0: read v**, copy v**, destroy v**]
+// CHECK-NEXT:  [global: write,copy,destroy]
+// CHECK-NEXT:  {{^[^[]}}
+sil @load_and_release : $@convention(thin) (@in X) -> () {
+bb0(%0 : $*X):
+  %1 = load %0 : $*X
+  strong_release %1 : $X
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil [ossa] @load_take_and_destroy
+// CHECK-NEXT:  [%0: read v**, copy v**, destroy v**]
+// CHECK-NEXT:  [global: write,copy,destroy]
+// CHECK-NEXT:  {{^[^[]}}
+sil [ossa] @load_take_and_destroy : $@convention(thin) (@in X) -> () {
+bb0(%0 : $*X):
+  %1 = load [take] %0 : $*X
+  destroy_value %1 : $X
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil [ossa] @load_copy_and_destroy
+// CHECK-NEXT:  [%0: read v**]
+// CHECK-NEXT:  [global: write,copy,destroy]
+// CHECK-NEXT:  {{^[^[]}}
+sil [ossa] @load_copy_and_destroy : $@convention(thin) (@in_guaranteed X) -> () {
+bb0(%0 : $*X):
+  %1 = load [copy] %0 : $*X
+  destroy_value %1 : $X
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil [ossa] @copy_addr_take_and_destroy
+// CHECK-NEXT:  [%0: read v**, copy v**, destroy v**]
+// CHECK-NEXT:  [global: write,copy,destroy]
+// CHECK-NEXT:  {{^[^[]}}
+sil [ossa] @copy_addr_take_and_destroy : $@convention(thin) (@in X) -> () {
+bb0(%0 : $*X):
+  %1 = alloc_stack $X
+  copy_addr [take] %0 to [initialization] %1 : $*X
+  destroy_addr %1 : $*X
+  dealloc_stack %1 : $*X
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil [ossa] @copy_addr_take_and_init
+// CHECK-NEXT:  [%0: write v**]
+// CHECK-NEXT:  [%1: read v**]
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+sil [ossa] @copy_addr_take_and_init : $@convention(thin) (@in X) -> @out X {
+bb0(%0 : $*X, %1 : $*X):
+  copy_addr [take] %1 to [initialization] %0 : $*X
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil [ossa] @copy_addr_and_destroy
+// CHECK-NEXT:  [%0: read v**, copy v**]
+// CHECK-NEXT:  [global: write,copy,destroy]
+// CHECK-NEXT:  {{^[^[]}}
+sil [ossa] @copy_addr_and_destroy : $@convention(thin) (@in_guaranteed X) -> () {
+bb0(%0 : $*X):
+  %1 = alloc_stack $X
+  copy_addr %0 to [initialization] %1 : $*X
+  destroy_addr %1 : $*X
+  dealloc_stack %1 : $*X
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil [ossa] @pass_arg_to_unknown_function
+// CHECK-NEXT:  [%0: read s1.v**, write s1.v**, copy s1.v**, destroy s1.v**]
+// CHECK-NEXT:  [global: read,write,copy,destroy,allocate]
+// CHECK-NEXT:  {{^[^[]}}
+sil [ossa] @pass_arg_to_unknown_function : $@convention(thin) (@inout TwoSPs) -> () {
+bb0(%0 : $*TwoSPs):
+  %1 = struct_element_addr %0 : $*TwoSPs, #TwoSPs.sp2
+  %f = function_ref @unknown_func_with_inout_arg : $@convention(thin) (@inout SP) -> ()
+  %a = apply %f(%1) : $@convention(thin) (@inout SP) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil [ossa] @copy_addr_and_consume_by_unknown_func
+// CHECK-NEXT:  [%0: read v**, copy v**, destroy v**]
+// CHECK-NEXT:  [global: read,write,copy,destroy,allocate]
+// CHECK-NEXT:  {{^[^[]}}
+sil [ossa] @copy_addr_and_consume_by_unknown_func : $@convention(thin) (@in X) -> () {
+bb0(%0 : $*X):
+  %1 = alloc_stack $X
+  copy_addr [take] %0 to [initialization] %1 : $*X
+  %f = function_ref @unknown_func_with_in_arg : $@convention(thin) (@in X) -> ()
+  %a = apply %f(%1) : $@convention(thin) (@in X) -> ()
+  dealloc_stack %1 : $*X
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @call_noreturn
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+sil @call_noreturn : $@convention(thin) () -> () {
+bb0:
+  cond_br undef, bb1, bb2
+
+bb1:
+  %u = function_ref @exitfunc : $@convention(thin) () -> Never
+  %a = apply %u() : $@convention(thin) () -> Never
+  unreachable
+
+bb2:
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @call_readnone
+// CHECK-NEXT:  [global: copy]
+// CHECK-NEXT:  {{^[^[]}}
+sil @call_readnone : $@convention(thin) () -> () {
+bb0:
+  %u = function_ref @pure_func : $@convention(thin) () -> ()
+  %a = apply %u() : $@convention(thin) () -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @call_releasenone
+// CHECK-NEXT:  [global: read,write,copy,allocate]
+// CHECK-NEXT:  {{^[^[]}}
+sil @call_releasenone : $@convention(thin) () -> () {
+bb0:
+  %u = function_ref @releasenone_func : $@convention(thin) () -> ()
+  %a = apply %u() : $@convention(thin) () -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+
+// CHECK-LABEL: sil @call_readonly_owned
+// CHECK-NEXT:  [%0: read c*.v**, copy c*.v**]
+// CHECK-NEXT:  [global: read,copy]
+// CHECK-NEXT:  {{^[^[]}}
+sil @call_readonly_owned : $@convention(thin) (@owned X) -> () {
+bb0(%0 : $X):
+  %u = function_ref @readonly_owned : $@convention(thin) (@owned X) -> ()
+  %a = apply %u(%0) : $@convention(thin) (@owned X) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil [ossa] @call_readnone_owned
+// CHECK-NEXT:  [%0: copy c*.v**]
+// CHECK-NEXT:  [global: copy]
+// CHECK-NEXT:  {{^[^[]}}
+sil [ossa] @call_readnone_owned : $@convention(thin) (@owned X) -> @owned X {
+bb0(%0 : @owned $X):
+  %u = function_ref @readnone_owned : $@convention(thin) (@owned X) -> @owned X
+  %a = apply %u(%0) : $@convention(thin) (@owned X) -> @owned X
+  return %a : $X
+}
+
+// CHECK-LABEL: sil @call_readonly_guaranteed
+// CHECK-NEXT:  [%0: read c*.v**, copy c*.v**]
+// CHECK-NEXT:  [global: read,copy]
+// CHECK-NEXT:  {{^[^[]}}
+sil @call_readonly_guaranteed : $@convention(thin) (@guaranteed X) -> () {
+bb0(%0 : $X):
+  %u = function_ref @readonly_guaranteed : $@convention(thin) (@guaranteed X) -> ()
+  %a = apply %u(%0) : $@convention(thin) (@guaranteed X) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @call_readonly_indirect_params
+// CHECK-NEXT:  [%0: write v**]
+// CHECK-NEXT:  [%1: read v**, copy v**]
+// CHECK-NEXT:  [%2: read v**, copy v**]
+// CHECK-NEXT:  [global: read,copy]
+// CHECK-NEXT:  {{^[^[]}}
+sil @call_readonly_indirect_params : $@convention(thin) (@in_guaranteed X, @inout X) -> @out X {
+bb0(%0 : $*X, %1 : $*X, %2 : $*X):
+  %u = function_ref @readonly_indirect_params : $@convention(thin) (@in_guaranteed X, @inout X) -> @out X
+  %a = apply %u(%0, %1, %2) : $@convention(thin) (@in_guaranteed X, @inout X) -> @out X
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @call_readnone_indirect_params
+// CHECK-NEXT:  [%0: write v**]
+// CHECK-NEXT:  [%1: read v**, copy v**]
+// CHECK-NEXT:  [%2: read v**, copy v**]
+// CHECK-NEXT:  [global: read,copy]
+// CHECK-NEXT:  {{^[^[]}}
+sil @call_readnone_indirect_params : $@convention(thin) (@in_guaranteed X, @inout X) -> @out X {
+bb0(%0 : $*X, %1 : $*X, %2 : $*X):
+  %u = function_ref @readonly_indirect_params : $@convention(thin) (@in_guaranteed X, @inout X) -> @out X
+  %a = apply %u(%0, %1, %2) : $@convention(thin) (@in_guaranteed X, @inout X) -> @out X
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @call_unknown_func_with_in_guaranteed_arg
+// CHECK-NEXT:  [%0: read v**, copy v**]
+// CHECK-NEXT:  [global: read,write,copy,destroy,allocate]
+// CHECK-NEXT:  {{^[^[]}}
+sil @call_unknown_func_with_in_guaranteed_arg : $@convention(thin) (@in_guaranteed X) -> () {
+bb0(%0 : $*X):
+  %1 = function_ref @unknown_func_with_in_guaranteed_arg : $@convention(thin) (@in_guaranteed X) -> ()
+  %2 = apply %1(%0) : $@convention(thin) (@in_guaranteed X) -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @test_escaping_in_argument
+// CHECK-NEXT:  [%0: read v**, copy v**]
+// CHECK-NEXT:  [global: read,write,copy,destroy,allocate]
+// CHECK-NEXT:  {{^[^[]}}
+sil @test_escaping_in_argument : $@convention(thin) (@in_guaranteed X) -> () {
+bb0(%0 : $*X):
+  %1 = address_to_pointer %0 : $*X to $Builtin.RawPointer
+  %3 = function_ref @unknown_func : $@convention(thin) () -> ()
+  %4 = apply %3() : $@convention(thin) () -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil [ossa] @copy_argument
+// CHECK-NEXT:  [%0: copy v**]
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+sil [ossa] @copy_argument : $@convention(thin) (@owned SP) -> @owned TwoSPs {
+bb0(%0 : @owned $SP):
+  %1 = copy_value %0 : $SP
+  %2 = struct $TwoSPs(%0 : $SP, %1 : $SP)
+  return %2 : $TwoSPs
+}
+
+// CHECK-LABEL: sil @fix_lifetime_test
+// CHECK-NEXT:  [%0: read c*.v**]
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+sil @fix_lifetime_test : $@convention(thin) (@guaranteed X) -> () {
+bb0(%0 : $X):
+  fix_lifetime %0 : $X
+  %3 = tuple()
+  return %3 : $()
+}
+
+// CHECK-LABEL: sil @not_called_partial_apply
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+sil @not_called_partial_apply : $@convention(thin) (@in Int32) ->  @owned @callee_owned (Bool) -> Int32 {
+bb0(%0 : $*Int32):
+  %2 = function_ref @closure : $@convention(thin) (Bool, @in Int32) -> Int32
+  %3 = partial_apply %2(%0) : $@convention(thin) (Bool, @in Int32) -> Int32
+  return %3 : $@callee_owned (Bool) -> Int32
+}
+
+// CHECK-LABEL: sil @two_nonstack_partial_applies
+// CHECK-NEXT:  [%0: read v**]
+// CHECK-NEXT:  [%1: write v**]
+// CHECK-NEXT:  [%2: write c0.v**]
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+sil @two_nonstack_partial_applies : $@convention(thin) (@inout Int32, @inout Int32, @guaranteed X) -> () {
+bb0(%0 : $*Int32, %1 : $*Int32, %2 : $X):
+  %f = function_ref @load_store_to_args : $@convention(thin) (@inout Int32, @inout Int32, @guaranteed X) -> ()
+  %c1 = partial_apply [callee_guaranteed] %f(%2) : $@convention(thin) (@inout Int32, @inout Int32, @guaranteed X) -> ()
+  %c2 = partial_apply [callee_guaranteed] %c1(%1) : $@callee_guaranteed (@inout Int32, @inout Int32) -> ()
+  %ap = apply %c2(%0) : $@callee_guaranteed (@inout Int32) -> ()
+
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @two_stack_partial_applies
+// CHECK-NEXT:  [%0: read v**]
+// CHECK-NEXT:  [%1: write v**]
+// CHECK-NEXT:  [%2: write c0.v**]
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+sil @two_stack_partial_applies : $@convention(thin) (@inout Int32, @inout Int32, @guaranteed X) -> () {
+bb0(%0 : $*Int32, %1 : $*Int32, %2 : $X):
+  %f = function_ref @load_store_to_args : $@convention(thin) (@inout Int32, @inout Int32, @guaranteed X) -> ()
+  %c1 = partial_apply [on_stack] %f(%2) : $@convention(thin) (@inout Int32, @inout Int32, @guaranteed X) -> ()
+  %c2 = partial_apply [on_stack] %c1(%1) : $@noescape @callee_owned (@inout Int32, @inout Int32) -> ()
+  %ap = apply %c2(%0) : $@noescape @callee_owned (@inout Int32) -> ()
+  dealloc_stack %c2 : $@noescape @callee_owned (@inout Int32) -> ()
+  dealloc_stack %c1 : $@noescape @callee_owned (@inout Int32, @inout Int32) -> ()
+
+  %r = tuple ()
+  return %r : $()
+}
+
+sil @closure : $@convention(thin) (Bool, @in Int32) -> Int32
+
+sil public_external @public_external_func : $@convention(thin) () -> () {
+bb0:
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @call_public_external_func
+// CHECK-NEXT:  [global: read,write,copy,destroy,allocate]
+// CHECK-NEXT:  {{^[^[]}}
+sil @call_public_external_func : $@convention(thin) () -> () {
+bb0:
+  %u = function_ref @public_external_func : $@convention(thin) () -> ()
+  %a = apply %u() : $@convention(thin) () -> ()
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil [ossa] @non_escaping_allocation
+// CHECK-NEXT:  [global: write,copy]
+// CHECK-NEXT:  {{^[^[]}}
+sil [ossa] @non_escaping_allocation : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_ref $X
+  destroy_value %0 :$X
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil [ossa] @escaping_allocation
+// CHECK-NEXT:  [global: allocate]
+// CHECK-NEXT:  {{^[^[]}}
+sil [ossa] @escaping_allocation : $@convention(thin) () -> @owned X {
+bb0:
+  %0 = alloc_ref $X
+  return %0 : $X
+}
+
+// CHECK-LABEL: sil [ossa] @readIdentifiedArg
+// CHECK-NEXT:  [%0: read v**]
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+sil [ossa] @readIdentifiedArg : $@convention(thin) (@in Int32) -> Int32 {
+bb0(%0 : $*Int32):
+  %res = load [trivial] %0 : $*Int32
+  return %res : $Int32
+}
+
+// CHECK-LABEL: sil [ossa] @writeIdentifiedArg
+// CHECK-NEXT:  [%0: write v**]
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+sil [ossa] @writeIdentifiedArg : $@convention(thin) (@inout Int32) -> () {
+bb0(%0 : $*Int32):
+  %2 = integer_literal $Builtin.Int32, 42
+  %3 = struct $Int32 (%2 : $Builtin.Int32)
+  store %3 to [trivial] %0 : $*Int32
+  %5 = tuple ()
+  return %5 : $()
+}
+
+
+// CHECK-LABEL: sil [ossa] @$writeToHead
+// CHECK-NEXT:  [%0: write s0.c0.v**]
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+sil [ossa] @$writeToHead : $@convention(thin) (@guaranteed S) -> () {
+bb0(%0 : @guaranteed $S):
+  debug_value %0 : $S, let, name "s", argno 1
+  %2 = struct_extract %0 : $S, #S.l
+  %3 = integer_literal $Builtin.Int32, 10
+  %4 = struct $Int32 (%3 : $Builtin.Int32)
+  %5 = begin_borrow [lexical] %2 : $List
+  %6 = ref_element_addr %5 : $List, #List.x
+  %7 = begin_access [modify] [dynamic] %6 : $*Int32
+  store %4 to [trivial] %7 : $*Int32
+  end_access %7 : $*Int32
+  end_borrow %5 : $List
+  %11 = tuple ()
+  return %11 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @storeToArgs
+// CHECK-NEXT:  [%0: write c0.v**]
+// CHECK-NEXT:  [%1: write c0.v**]
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+sil [ossa] @storeToArgs : $@convention(thin) (@guaranteed List, @guaranteed List) -> () {
+bb0(%1 : @guaranteed $List, %2 : @guaranteed $List):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %8 = integer_literal $Builtin.Int32, 10
+  %9 = struct $Int32 (%8 : $Builtin.Int32)
+  %10 = ref_element_addr %1 : $List, #List.x
+  %11 = begin_access [modify] [dynamic] %10 : $*Int32
+  store %9 to [trivial] %11 : $*Int32
+  end_access %11 : $*Int32
+  %14 = tuple ()
+  br bb3
+
+bb2:
+  %16 = integer_literal $Builtin.Int32, 20
+  %17 = struct $Int32 (%16 : $Builtin.Int32)
+  %18 = ref_element_addr %2 : $List, #List.x
+  %19 = begin_access [modify] [dynamic] %18 : $*Int32
+  store %17 to [trivial] %19 : $*Int32
+  end_access %19 : $*Int32
+  %22 = tuple ()
+  br bb3
+
+bb3:
+  %24 = tuple ()
+  return %24 : $()
+}
+
+// CHECK-LABEL: sil @storeMaybeLocalPhi
+// CHECK-NEXT:  [%0: read c*.v**, write c*.v**, copy **, destroy c*.v**]
+// CHECK-NEXT:  [global: read,write,copy,destroy,allocate]
+// CHECK-NEXT:  {{^[^[]}}
+sil @storeMaybeLocalPhi : $@convention(thin) (@guaranteed List) -> () {
+bb0(%1 : $List):
+  cond_br undef, bb1, bb2
+
+bb1:
+  strong_retain %1 : $List
+  br bb3(%1 : $List)
+
+bb2:
+  %10 = alloc_ref $List
+  br bb3(%10 : $List)
+
+bb3(%12 : $List):
+  %14 = integer_literal $Builtin.Int32, 20
+  %15 = struct $Int32 (%14 : $Builtin.Int32)
+  %16 = ref_element_addr %12 : $List, #List.x
+  %17 = begin_access [modify] [dynamic] %16 : $*Int32
+  store %15 to %17 : $*Int32
+  end_access %17 : $*Int32
+  %20 = tuple ()
+  strong_release %12 : $List
+  %22 = tuple ()
+  return %22 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @testStructPhiCommon
+// CHECK-NEXT:  [%0: write s0.v**]
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+sil [ossa] @testStructPhiCommon : $@convention(thin) (@inout Ptr) -> () {
+bb0(%0 : $*Ptr):
+  %2 = struct_element_addr %0 : $*Ptr, #Ptr.p
+  cond_br undef, bb1, bb2
+
+bb1:
+  %3 = address_to_pointer %2 : $*Int32 to $Builtin.RawPointer
+  br bb3(%3 : $Builtin.RawPointer)
+
+bb2:
+  %5 = address_to_pointer %2 : $*Int32 to $Builtin.RawPointer
+  br bb3(%5 : $Builtin.RawPointer)
+
+bb3(%6 : $Builtin.RawPointer) :
+  %7 = pointer_to_address %6 : $Builtin.RawPointer to $*Int32
+  %8 = integer_literal $Builtin.Int32, 2
+  %9 = struct $Int32 (%8 : $Builtin.Int32)
+  store %9 to [trivial] %7 : $*Int32
+  %22 = tuple ()
+  return %22 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @calleeWriteToHead
+// CHECK-NEXT:  [%0: write s0.c0.v**]
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+sil [ossa] @calleeWriteToHead : $@convention(thin) (@guaranteed S) -> () {
+bb0(%0 : @guaranteed $S):
+  debug_value %0 : $S, let, name "s", argno 1
+  %2 = struct_extract %0 : $S, #S.l
+  %3 = integer_literal $Builtin.Int32, 10
+  %4 = struct $Int32 (%3 : $Builtin.Int32)
+  %5 = begin_borrow [lexical] %2 : $List
+  %6 = ref_element_addr %5 : $List, #List.x
+  %7 = begin_access [modify] [dynamic] %6 : $*Int32
+  %writeArg = function_ref @writeIdentifiedArg : $@convention(thin) (@inout Int32) -> ()
+  %app = apply %writeArg(%7) : $@convention(thin) (@inout Int32) -> ()
+  end_access %7 : $*Int32
+  end_borrow %5 : $List
+  %11 = tuple ()
+  return %11 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @has_partial_apply
+// CHECK-NEXT:  [%0: write c0.v**]
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+sil [ossa] @has_partial_apply : $@convention(thin) (@guaranteed List) -> () {
+bb0(%0 : @guaranteed $List):
+  %f = function_ref @storeToArgs : $@convention(thin) (@guaranteed List, @guaranteed List) -> ()
+  %clo = partial_apply [callee_guaranteed] [on_stack] %f(%0) : $@convention(thin) (@guaranteed List, @guaranteed List) -> ()
+  %res = apply %clo(%0) : $@noescape @callee_guaranteed (@guaranteed List) -> ()
+  dealloc_stack %clo : $@noescape @callee_guaranteed (@guaranteed List) -> ()
+  %r = tuple()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil [ossa] @readIdentifiedBoxArg
+// CHECK-NEXT:  [%0: read c0.v**]
+// CHECK-NEXT:  [global: ]
+// CHECK-NEXT:  {{^[^[]}}
+sil [ossa] @readIdentifiedBoxArg : $@convention(thin) (@guaranteed { var Int32 }) -> Int32 {
+bb0(%0 : @guaranteed ${ var Int32 }):
+  %1 = project_box %0 : ${ var Int32 }, 0
+  %5 = begin_access [read] [dynamic] %1 : $*Int32
+  %6 = load [trivial] %5 : $*Int32
+  end_access %5 : $*Int32
+  return %6 : $Int32
+}

--- a/test/SILOptimizer/stack_promotion.sil
+++ b/test/SILOptimizer/stack_promotion.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -compute-effects -stack-promotion -enable-sil-verify-all %s | %FileCheck %s
+// RUN: %target-sil-opt -compute-escape-effects -stack-promotion -enable-sil-verify-all %s | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 


### PR DESCRIPTION
So far, function effects only included escape effects. This PR adds side-effects.
It also involves refactoring of the existing escape effects. The SIL effect syntax changed a bit. Details are in docs/SIL.rst

The new ComputeSideEffects pass computes the side effects for a function, which consists of argument- and global effects.
This is similar to the ComputeEscapeEffects pass, just for side-effects.

Side effects are not used yet. This PR just adds the data structures and the pass which computes the effects.

For details see the commit messages.