### PR TITLE
Fix lexical destroy folding to handle PointerEscape

### DIFF
--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -239,7 +239,7 @@ OPERAND_OWNERSHIP(PointerEscape, UncheckedOwnershipConversion)
 OPERAND_OWNERSHIP(PointerEscape, ConvertEscapeToNoEscape)
 
 // UncheckedBitwiseCast ownership behaves like RefToUnowned. It produces an
-// Unowned values from a non-trivial value, without consuming or borrowing the
+// Unowned value from a non-trivial value, without consuming or borrowing the
 // non-trivial value. Unlike RefToUnowned, a bitwise cast works on a compound
 // value and may truncate the value. The resulting value is still Unowned and
 // should be immediately copied to produce an owned value. These happen for two

--- a/test/SILOptimizer/copy_propagation.sil
+++ b/test/SILOptimizer/copy_propagation.sil
@@ -928,19 +928,3 @@ bb0:
   %99 = tuple ()
   return %99 : $()
 }
-
-// Lexical destroy hoisting cannot handle a PointerEscape.
-//
-// CHECK-LABEL: sil [ossa] @testNoLexicalHoistEscape : $@convention(thin) (@owned Optional<@Sendable @callee_guaranteed () -> ()>) -> @owned Optional<@callee_guaranteed () -> ()> {
-// CHECK: bb0(%0 : @owned $Optional<@Sendable @callee_guaranteed () -> ()>):
-// CHECK:   [[CAST:%.*]] = unchecked_bitwise_cast %0 : $Optional<@Sendable @callee_guaranteed () -> ()> to $Optional<@callee_guaranteed () -> ()>
-// CHECK:   [[COPY:%.*]] = copy_value [[CAST]] : $Optional<@callee_guaranteed () -> ()>
-// CHECK:   destroy_value %0 : $Optional<@Sendable @callee_guaranteed () -> ()>
-// CHECK-LABEL: } // end sil function 'testNoLexicalHoistEscape'
-sil [ossa] @testNoLexicalHoistEscape : $@convention(thin) (@owned Optional<@Sendable @callee_guaranteed () -> ()>) -> @owned Optional<@callee_guaranteed () -> ()> {
-bb0(%0 : @owned $Optional<@Sendable @callee_guaranteed () -> ()>):
-  %cast = unchecked_bitwise_cast %0 : $Optional<@Sendable @callee_guaranteed () -> ()> to $Optional<@callee_guaranteed () -> ()>
-  %copy = copy_value %cast : $Optional<@callee_guaranteed () -> ()>
-  destroy_value %0 : $Optional<@Sendable @callee_guaranteed () -> ()>
-  return %copy : $Optional<@callee_guaranteed () -> ()>
-}

--- a/test/SILOptimizer/lexical_destroy_folding.sil
+++ b/test/SILOptimizer/lexical_destroy_folding.sil
@@ -5,6 +5,7 @@
 // =============================================================================
 
 class C {}
+class D {}
 
 sil [ossa] @barrier : $@convention(thin) () -> ()
 sil [ossa] @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
@@ -854,6 +855,30 @@ entry(%instance : @owned $@convention(thick) () -> ()):
   destroy_value %instance : $@convention(thick) () -> ()
   %retval = tuple ()
   return %retval : $()
+}
+
+// Lexical destroy folding cannot handle a PointerEscape.
+//
+// CHECK-LABEL: sil [ossa] @dont_fold_over_escape : $@convention(thin) (@owned C) -> @owned D {
+// CHECK: bb0(%0 : @owned $C):
+// CHECK:   [[CAST:%.*]] = unchecked_bitwise_cast %0 : $C to $D
+// CHECK:   [[BORROW:%.*]] = begin_borrow [lexical] %0 : $C
+// CHECK:   [[COPY0:%.*]] = copy_value [[BORROW]] : $C
+// CHECK:   apply %{{.*}}([[COPY0]]) : $@convention(thin) (@owned C) -> ()
+// CHECK:   [[COPY1:%.*]] = copy_value [[CAST]] : $D
+// CHECK:   destroy_value %0 : $C
+// CHECK-LABEL: } // end sil function 'dont_fold_over_escape'
+sil [ossa] @dont_fold_over_escape : $@convention(thin) (@owned C) -> @owned D {
+bb0(%0 : @owned $C):
+  %callee_owned = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
+  %cast = unchecked_bitwise_cast %0 : $C to $D
+  %lifetime = begin_borrow [lexical] %0 : $C
+  %copy0 = copy_value %lifetime : $C
+  apply %callee_owned(%copy0) : $@convention(thin) (@owned C) -> ()
+  end_borrow %lifetime : $C
+  %copy = copy_value %cast : $D
+  destroy_value %0 : $C
+  return %copy : $D
 }
 
 // =============================================================================

--- a/test/SILOptimizer/lexical_destroy_hoisting.sil
+++ b/test/SILOptimizer/lexical_destroy_hoisting.sil
@@ -455,6 +455,21 @@ entry(%instance : @owned $C, %input : $S):
     return %retval : $()
 }
 
+// Lexical destroy hoisting cannot handle a PointerEscape.
+//
+// CHECK-LABEL: sil [ossa] @dont_hoist_over_escape : $@convention(thin) (@owned Optional<@Sendable @callee_guaranteed () -> ()>) -> @owned Optional<@callee_guaranteed () -> ()> {
+// CHECK: bb0(%0 : @owned $Optional<@Sendable @callee_guaranteed () -> ()>):
+// CHECK:   [[CAST:%.*]] = unchecked_bitwise_cast %0 : $Optional<@Sendable @callee_guaranteed () -> ()> to $Optional<@callee_guaranteed () -> ()>
+// CHECK:   [[COPY:%.*]] = copy_value [[CAST]] : $Optional<@callee_guaranteed () -> ()>
+// CHECK:   destroy_value %0 : $Optional<@Sendable @callee_guaranteed () -> ()>
+// CHECK-LABEL: } // end sil function 'dont_hoist_over_escape'
+sil [ossa] @dont_hoist_over_escape : $@convention(thin) (@owned Optional<@Sendable @callee_guaranteed () -> ()>) -> @owned Optional<@callee_guaranteed () -> ()> {
+bb0(%0 : @owned $Optional<@Sendable @callee_guaranteed () -> ()>):
+  %cast = unchecked_bitwise_cast %0 : $Optional<@Sendable @callee_guaranteed () -> ()> to $Optional<@callee_guaranteed () -> ()>
+  %copy = copy_value %cast : $Optional<@callee_guaranteed () -> ()>
+  destroy_value %0 : $Optional<@Sendable @callee_guaranteed () -> ()>
+  return %copy : $Optional<@callee_guaranteed () -> ()>
+}
 
 // =============================================================================
 // instruction tests                                                          }}


### PR DESCRIPTION
    We can't prevent using an unchecked_bitwise_cast in SIL without
    protecting the base value's lifetime. So handle it gracefully.

    Observed by Nate Chandler