### PR TITLE
[CXX-Interop] Respect NS_REFINED_FOR_SWIFT importing anon enums

### DIFF
--- a/test/Interop/Cxx/enum/Inputs/c-enums-NS_OPTIONS.h
+++ b/test/Interop/Cxx/enum/Inputs/c-enums-NS_OPTIONS.h
@@ -17,6 +17,7 @@ extern "C" {
 
 #define CF_OPTIONS(_type, _name) _type __attribute__((availability(swift, unavailable))) _name; enum __CF_OPTIONS_ATTRIBUTES : _name
 #define NS_OPTIONS(_type, _name) CF_OPTIONS(_type, _name)
+#define NS_REFINED_FOR_SWIFT __attribute__((swift_private))
 
 typedef unsigned long NSUInteger;
 
@@ -26,4 +27,16 @@ typedef NS_OPTIONS(NSUInteger, NSBinarySearchingOptions) {
 	NSBinarySearchingInsertionIndex = (1UL << 10),
 };
 
+typedef NS_OPTIONS(NSUInteger, NSAttributedStringFormattingOptions) {
+  NSAttributedStringFormattingInsertArgumentAttributesWithoutMerging = 1 << 0,
+  NSAttributedStringFormattingApplyReplacementIndexAttribute = 1 << 1,
+} NS_REFINED_FOR_SWIFT;
+
+@interface NSAttributedString
+@end
+
+@interface NSAttributedString (NSAttributedStringFormatting)
+- (instancetype)initWithOptions:(NSAttributedStringFormattingOptions)options
+    NS_REFINED_FOR_SWIFT;
+@end
 }

--- a/test/Interop/Cxx/enum/c-enums-NS_OPTIONS-NS_REFINED_FOR_SWIFT.swift
+++ b/test/Interop/Cxx/enum/c-enums-NS_OPTIONS-NS_REFINED_FOR_SWIFT.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=CenumsNSOptions -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
+// REQUIRES: objc_interop
+
+import CenumsNSOptions
+
+// CHECK:      typealias NSAttributedStringFormattingOptions = UInt
+// CHECK-NEXT: struct __NSAttributedStringFormattingOptions : OptionSet, @unchecked Sendable {
+// CHECK-NEXT:   init(rawValue: UInt)
+// CHECK-NEXT:   let rawValue: UInt
+// CHECK-NEXT:   typealias RawValue = UInt
+// CHECK-NEXT:   typealias Element = __NSAttributedStringFormattingOptions
+// CHECK-NEXT:   typealias ArrayLiteralElement = __NSAttributedStringFormattingOptions
+// CHECK-NEXT:   static var insertArgumentAttributesWithoutMerging: __NSAttributedStringFormattingOptions { get }
+// CHECK-NEXT:   @available(swift, obsoleted: 3, renamed: "insertArgumentAttributesWithoutMerging")
+// CHECK-NEXT:   static var InsertArgumentAttributesWithoutMerging: __NSAttributedStringFormattingOptions { get }
+// CHECK-NEXT:   static var applyReplacementIndexAttribute: __NSAttributedStringFormattingOptions { get }
+// CHECK-NEXT:   @available(swift, obsoleted: 3, renamed: "applyReplacementIndexAttribute")
+// CHECK-NEXT:   static var ApplyReplacementIndexAttribute: __NSAttributedStringFormattingOptions { get }
+// CHECK-NEXT: }
+
+// CHECK:      extension NSAttributedString {
+// CHECK-NEXT:   init!(__options options: __NSAttributedStringFormattingOptions = [])
+// CHECK-NEXT: }


### PR DESCRIPTION
When an anonymous enum is imported, its imported name is under some circumstances derived from the type that it is backed by. NS_REFINED_FOR_SWIFT is a macro that produces a __attribute__((swift_private)) that when attached to a declaration, the imported name of this declaration should have two underscores prepended. When the name anonymous enum is derived from another declaration, and said declaration does not have the same swift private attribute, the __ is dropped. This patch fixes this.
