### PR TITLE
[RequirementMachine] Implement inference and minimization of same-shape requirements.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2545,6 +2545,10 @@ ERROR(requires_not_suitable_archetype,none,
       "generic parameter or associated type",
       (Type))
 
+ERROR(invalid_shape_requirement,none,
+      "invalid same-shape requirement between %0 and %1",
+      (Type, Type))
+
 ERROR(requires_generic_params_made_equal,none,
       "same-type requirement makes generic parameters %0 and %1 equivalent",
       (Type, Type))

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -426,6 +426,10 @@ public:
   /// whose root generic parameter is a pack.
   Type getReducedShape(Type type) const;
 
+  /// Returns \c true if the given type parameter packs are in
+  /// the same shape equivalence class.
+  bool haveSameShape(Type type1, Type type2) const;
+
   /// Get the ordinal of a generic parameter in this generic signature.
   ///
   /// For example, if you have a generic signature for a nested context like:

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -419,6 +419,13 @@ public:
   /// Lookup a nested type with the given name within this type parameter.
   TypeDecl *lookupNestedType(Type type, Identifier name) const;
 
+  /// Returns the shape equivalence class of the given type parameter.
+  ///
+  /// \param type The type parameter to compute the reduced shape for.
+  /// Only type parameter packs have a shape, including dependent members
+  /// whose root generic parameter is a pack.
+  Type getReducedShape(Type type) const;
+
   /// Get the ordinal of a generic parameter in this generic signature.
   ///
   /// For example, if you have a generic signature for a nested context like:

--- a/include/swift/AST/Requirement.h
+++ b/include/swift/AST/Requirement.h
@@ -58,7 +58,7 @@ public:
   Requirement subst(Args &&...args) const {
     auto newFirst = getFirstType().subst(std::forward<Args>(args)...);
     switch (getKind()) {
-    case RequirementKind::SameCount:
+    case RequirementKind::SameShape:
     case RequirementKind::Conformance:
     case RequirementKind::Superclass:
     case RequirementKind::SameType: {

--- a/include/swift/AST/RequirementBase.h
+++ b/include/swift/AST/RequirementBase.h
@@ -36,9 +36,9 @@ enum class RequirementKind : unsigned {
   /// A layout bound T : L, where T is a type that depends on a generic
   /// parameter and L is some layout specification that should bound T.
   Layout,
-  /// A same-count requirement T.count == U.count, where T and U are pack
+  /// A same-shape requirement shape(T) == shape(U), where T and U are pack
   /// parameters.
-  SameCount
+  SameShape
 
   // Note: there is code that packs this enum in a 3-bit bitfield.  Audit users
   // when adding enumerators.
@@ -105,7 +105,7 @@ public:
         hash_value(requirement.FirstTypeAndKind.getOpaqueValue());
     llvm::hash_code second;
     switch (requirement.getKind()) {
-    case RequirementKind::SameCount:
+    case RequirementKind::SameShape:
     case RequirementKind::Conformance:
     case RequirementKind::Superclass:
     case RequirementKind::SameType:
@@ -127,7 +127,7 @@ public:
       return false;
 
     switch (lhs.getKind()) {
-    case RequirementKind::SameCount:
+    case RequirementKind::SameShape:
     case RequirementKind::Conformance:
     case RequirementKind::Superclass:
     case RequirementKind::SameType:

--- a/include/swift/SIL/SILWitnessVisitor.h
+++ b/include/swift/SIL/SILWitnessVisitor.h
@@ -57,8 +57,8 @@ public:
     auto requirements = protocol->getRequirementSignature().getRequirements();
     for (const auto &reqt : requirements) {
       switch (reqt.getKind()) {
-      case RequirementKind::SameCount:
-        llvm_unreachable("Same-count requirement not supported here");
+      case RequirementKind::SameShape:
+        llvm_unreachable("Same-shape requirement not supported here");
 
       // These requirements don't show up in the witness table.
       case RequirementKind::Superclass:

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -5584,8 +5584,8 @@ ASTContext::getOpenedElementSignature(CanGenericSignature baseGenericSig) {
 
   for (auto requirement : baseGenericSig.getRequirements()) {
     switch (requirement.getKind()) {
-    case RequirementKind::SameCount:
-      // Drop same-length requirements from the element signature.
+    case RequirementKind::SameShape:
+      // Drop same-shape requirements from the element signature.
       break;
     case RequirementKind::Conformance:
     case RequirementKind::Superclass:

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -635,8 +635,8 @@ Type ASTBuilder::createConstrainedExistentialType(
   llvm::SmallDenseMap<Identifier, Type> cmap;
   for (const auto &req : constraints) {
     switch (req.getKind()) {
-    case RequirementKind::SameCount:
-      llvm_unreachable("Same-count requirement not supported here");
+    case RequirementKind::SameShape:
+      llvm_unreachable("Same-shape requirement not supported here");
     case RequirementKind::Conformance:
     case RequirementKind::Superclass:
     case RequirementKind::Layout:

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -4277,8 +4277,8 @@ void Requirement::dump() const {
 }
 void Requirement::dump(raw_ostream &out) const {
   switch (getKind()) {
-  case RequirementKind::SameCount:
-    out << "same_count: ";
+  case RequirementKind::SameShape:
+    out << "same_shape: ";
     break;
   case RequirementKind::Conformance:
     out << "conforms_to: ";

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2868,8 +2868,8 @@ void ASTMangler::appendRequirement(const Requirement &reqt,
   Type FirstTy = reqt.getFirstType()->getCanonicalType();
 
   switch (reqt.getKind()) {
-  case RequirementKind::SameCount:
-    llvm_unreachable("Same-count requirement not supported here");
+  case RequirementKind::SameShape:
+    llvm_unreachable("Same-shape requirement not supported here");
   case RequirementKind::Layout:
     break;
   case RequirementKind::Conformance: {
@@ -2891,8 +2891,8 @@ void ASTMangler::appendRequirement(const Requirement &reqt,
   if (auto *DT = FirstTy->getAs<DependentMemberType>()) {
     if (tryMangleTypeSubstitution(DT, sig)) {
       switch (reqt.getKind()) {
-        case RequirementKind::SameCount:
-          llvm_unreachable("Same-count requirement not supported here");
+        case RequirementKind::SameShape:
+          llvm_unreachable("Same-shape requirement not supported here");
         case RequirementKind::Conformance:
           return appendOperator("RQ");
         case RequirementKind::Layout:
@@ -2912,8 +2912,8 @@ void ASTMangler::appendRequirement(const Requirement &reqt,
     addTypeSubstitution(DT, sig);
     assert(gpBase);
     switch (reqt.getKind()) {
-      case RequirementKind::SameCount:
-        llvm_unreachable("Same-count requirement not supported here");
+      case RequirementKind::SameShape:
+        llvm_unreachable("Same-shape requirement not supported here");
       case RequirementKind::Conformance:
         return appendOpWithGenericParamIndex(isAssocTypeAtDepth ? "RP" : "Rp",
                                              gpBase, lhsBaseIsProtocolSelf);
@@ -2933,8 +2933,8 @@ void ASTMangler::appendRequirement(const Requirement &reqt,
   }
   GenericTypeParamType *gpBase = FirstTy->castTo<GenericTypeParamType>();
   switch (reqt.getKind()) {
-    case RequirementKind::SameCount:
-      llvm_unreachable("Same-count requirement not supported here");
+    case RequirementKind::SameShape:
+      llvm_unreachable("Same-shape requirement not supported here");
     case RequirementKind::Conformance:
       return appendOpWithGenericParamIndex("R", gpBase);
     case RequirementKind::Layout:
@@ -3494,8 +3494,8 @@ void ASTMangler::appendConcreteProtocolConformance(
   bool firstRequirement = true;
   for (const auto &conditionalReq : conformance->getConditionalRequirements()) {
     switch (conditionalReq.getKind()) {
-    case RequirementKind::SameCount:
-      llvm_unreachable("Same-count requirement not supported here");
+    case RequirementKind::SameShape:
+      llvm_unreachable("Same-shape requirement not supported here");
     case RequirementKind::Layout:
     case RequirementKind::SameType:
     case RequirementKind::Superclass:
@@ -3645,8 +3645,8 @@ void ASTMangler::appendConstrainedExistential(Type base, GenericSignature sig,
   bool firstRequirement = true;
   for (const auto &reqt : requirements) {
     switch (reqt.getKind()) {
-    case RequirementKind::SameCount:
-      llvm_unreachable("Same-count requirement not supported here");
+    case RequirementKind::SameShape:
+      llvm_unreachable("Same-shape requirement not supported here");
     case RequirementKind::Layout:
     case RequirementKind::Conformance:
     case RequirementKind::Superclass:

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -240,7 +240,7 @@ PrintOptions PrintOptions::printSwiftInterfaceFile(ModuleDecl *ModuleToPrint,
             if (!isPublicOrUsableFromInline(req.getSecondType()))
               return false;
             break;
-          case RequirementKind::SameCount:
+          case RequirementKind::SameShape:
           case RequirementKind::Layout:
             break;
           }
@@ -1415,8 +1415,8 @@ bestRequirementPrintLocation(ProtocolDecl *proto, const Requirement &req) {
   bool inWhereClause;
 
   switch (req.getKind()) {
-  case RequirementKind::SameCount:
-    llvm_unreachable("Same-count requirements not supported here");
+  case RequirementKind::SameShape:
+    llvm_unreachable("Same-shape requirements not supported here");
   case RequirementKind::Layout:
   case RequirementKind::Conformance:
   case RequirementKind::Superclass: {
@@ -1510,7 +1510,7 @@ static unsigned getDepthOfRequirement(const Requirement &req) {
 
   case RequirementKind::Superclass:
   case RequirementKind::SameType:
-  case RequirementKind::SameCount: {
+  case RequirementKind::SameShape: {
     // Return the max valid depth of firstType and secondType.
     unsigned firstDepth = getDepthOfType(req.getFirstType());
     unsigned secondDepth = getDepthOfType(req.getSecondType());
@@ -1757,8 +1757,8 @@ void PrintAST::printSingleDepthOfGenericSignature(
         // We only print the second part of a requirement in the "inherited"
         // clause.
         switch (req.getKind()) {
-        case RequirementKind::SameCount:
-          llvm_unreachable("Same-count requirement not supported here");
+        case RequirementKind::SameShape:
+          llvm_unreachable("Same-shape requirement not supported here");
 
         case RequirementKind::Layout:
           req.getLayoutConstraint()->print(Printer, Options);
@@ -1788,10 +1788,10 @@ void PrintAST::printSingleDepthOfGenericSignature(
 void PrintAST::printRequirement(const Requirement &req) {
   printTransformedType(req.getFirstType());
   switch (req.getKind()) {
-  case RequirementKind::SameCount:
-    Printer << ".count == ";
+  case RequirementKind::SameShape:
+    Printer << ".shape == ";
     printTransformedType(req.getSecondType());
-    Printer << ".count";
+    Printer << ".shape";
     return;
   case RequirementKind::Layout:
     Printer << " : ";

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4067,8 +4067,8 @@ findGenericParameterReferences(CanGenericSignature genericSig,
     auto opaqueSig = opaque->getDecl()->getOpaqueInterfaceGenericSignature();
     for (const auto &req : opaqueSig.getRequirements()) {
       switch (req.getKind()) {
-      case RequirementKind::SameCount:
-        llvm_unreachable("Same-count requirement not supported here");
+      case RequirementKind::SameShape:
+        llvm_unreachable("Same-shape requirement not supported here");
 
       case RequirementKind::Conformance:
       case RequirementKind::Layout:

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -539,6 +539,11 @@ GenericSignatureImpl::getReducedShape(Type type) const {
   return getRequirementMachine()->getReducedShape(type);
 }
 
+bool
+GenericSignatureImpl::haveSameShape(Type type1, Type type2) const {
+  return getRequirementMachine()->haveSameShape(type1, type2);
+}
+
 unsigned GenericParamKey::findIndexIn(
                       TypeArrayView<GenericTypeParamType> genericParams) const {
   // For depth 0, we have random access. We perform the extra checking so that

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -534,6 +534,11 @@ GenericSignatureImpl::lookupNestedType(Type type, Identifier name) const {
   return getRequirementMachine()->lookupNestedType(type, name);
 }
 
+Type
+GenericSignatureImpl::getReducedShape(Type type) const {
+  return getRequirementMachine()->getReducedShape(type);
+}
+
 unsigned GenericParamKey::findIndexIn(
                       TypeArrayView<GenericTypeParamType> genericParams) const {
   // For depth 0, we have random access. We perform the extra checking so that

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -131,7 +131,7 @@ void GenericSignatureImpl::forEachParam(
     case RequirementKind::Superclass:
     case RequirementKind::Conformance:
     case RequirementKind::Layout:
-    case RequirementKind::SameCount:
+    case RequirementKind::SameShape:
       continue;
     }
 
@@ -160,7 +160,7 @@ bool GenericSignatureImpl::areAllParamsConcrete() const {
     case RequirementKind::Conformance:
     case RequirementKind::Superclass:
     case RequirementKind::Layout:
-    case RequirementKind::SameCount:
+    case RequirementKind::SameShape:
       continue;
     }
   }
@@ -654,7 +654,7 @@ bool Requirement::isCanonical() const {
     return false;
 
   switch (getKind()) {
-  case RequirementKind::SameCount:
+  case RequirementKind::SameShape:
   case RequirementKind::Conformance:
   case RequirementKind::SameType:
   case RequirementKind::Superclass:
@@ -674,7 +674,7 @@ Requirement Requirement::getCanonical() const {
   Type firstType = getFirstType()->getCanonicalType();
 
   switch (getKind()) {
-  case RequirementKind::SameCount:
+  case RequirementKind::SameShape:
   case RequirementKind::Conformance:
   case RequirementKind::SameType:
   case RequirementKind::Superclass: {
@@ -697,8 +697,8 @@ bool
 Requirement::isSatisfied(ArrayRef<Requirement> &conditionalRequirements,
                          bool allowMissing) const {
   switch (getKind()) {
-  case RequirementKind::SameCount:
-    llvm_unreachable("Same-count requirements not supported here");
+  case RequirementKind::SameShape:
+    llvm_unreachable("Same-shape requirements not supported here");
 
   case RequirementKind::Conformance: {
     auto *proto = getProtocolDecl();
@@ -738,8 +738,8 @@ Requirement::isSatisfied(ArrayRef<Requirement> &conditionalRequirements,
 
 bool Requirement::canBeSatisfied() const {
   switch (getKind()) {
-  case RequirementKind::SameCount:
-    llvm_unreachable("Same-count requirements not supported here");
+  case RequirementKind::SameShape:
+    llvm_unreachable("Same-shape requirements not supported here");
 
   case RequirementKind::Conformance:
     return getFirstType()->is<ArchetypeType>();
@@ -768,7 +768,7 @@ bool Requirement::canBeSatisfied() const {
 /// Determine the canonical ordering of requirements.
 static unsigned getRequirementKindOrder(RequirementKind kind) {
   switch (kind) {
-  case RequirementKind::SameCount: return 4;
+  case RequirementKind::SameShape: return 4;
   case RequirementKind::Conformance: return 2;
   case RequirementKind::Superclass: return 0;
   case RequirementKind::SameType: return 3;
@@ -916,7 +916,7 @@ void GenericSignature::verify(ArrayRef<Requirement> reqts) const {
 
     // Check canonicalization of requirement itself.
     switch (reqt.getKind()) {
-    case RequirementKind::SameCount:
+    case RequirementKind::SameShape:
       if (!reqt.getFirstType()->is<GenericTypeParamType>()) {
         llvm::errs() << "Left hand side is not a generic parameter: ";
         reqt.dump(llvm::errs());
@@ -1114,8 +1114,8 @@ static Requirement stripBoundDependentMemberTypes(Requirement req) {
   auto subjectType = stripBoundDependentMemberTypes(req.getFirstType());
 
   switch (req.getKind()) {
-  case RequirementKind::SameCount:
-    // Same-count requirements do not involve dependent member types.
+  case RequirementKind::SameShape:
+    // Same-shape requirements do not involve dependent member types.
     return req;
 
   case RequirementKind::Conformance:

--- a/lib/AST/RequirementMachine/ConcreteContraction.cpp
+++ b/lib/AST/RequirementMachine/ConcreteContraction.cpp
@@ -371,8 +371,8 @@ ConcreteContraction::substRequirement(const Requirement &req) const {
   auto firstType = req.getFirstType();
 
   switch (req.getKind()) {
-  case RequirementKind::SameCount:
-    llvm_unreachable("Same-count requirement not supported here");
+  case RequirementKind::SameShape:
+    llvm_unreachable("Same-shape requirement not supported here");
 
   case RequirementKind::Superclass:
   case RequirementKind::SameType: {
@@ -553,7 +553,7 @@ bool ConcreteContraction::performConcreteContraction(
 
     auto kind = req.req.getKind();
     switch (kind) {
-    case RequirementKind::SameCount:
+    case RequirementKind::SameShape:
       assert(req.req.getSecondType()->isTypeParameter());
       continue;
 

--- a/lib/AST/RequirementMachine/ConcreteContraction.cpp
+++ b/lib/AST/RequirementMachine/ConcreteContraction.cpp
@@ -554,7 +554,8 @@ bool ConcreteContraction::performConcreteContraction(
     auto kind = req.req.getKind();
     switch (kind) {
     case RequirementKind::SameCount:
-      llvm_unreachable("Same-count requirement not supported here");
+      assert(req.req.getSecondType()->isTypeParameter());
+      continue;
 
     case RequirementKind::SameType: {
       auto constraintType = req.req.getSecondType();

--- a/lib/AST/RequirementMachine/Diagnostics.cpp
+++ b/lib/AST/RequirementMachine/Diagnostics.cpp
@@ -105,6 +105,20 @@ bool swift::rewriting::diagnoseRequirementErrors(
       break;
     }
 
+    case RequirementError::Kind::InvalidShapeRequirement: {
+      if (error.requirement.hasError())
+        break;
+
+      auto lhs = error.requirement.getFirstType();
+      auto rhs = error.requirement.getSecondType();
+
+      // FIXME: Add tailored messages for specific issues.
+      ctx.Diags.diagnose(loc, diag::invalid_shape_requirement,
+                         lhs, rhs);
+      diagnosedError = true;
+      break;
+    }
+
     case RequirementError::Kind::ConflictingRequirement: {
       auto requirement = error.requirement;
       auto conflict = error.conflictingRequirement;

--- a/lib/AST/RequirementMachine/Diagnostics.cpp
+++ b/lib/AST/RequirementMachine/Diagnostics.cpp
@@ -182,8 +182,8 @@ bool swift::rewriting::diagnoseRequirementErrors(
         break;
 
       switch (requirement.getKind()) {
-      case RequirementKind::SameCount:
-        llvm_unreachable("Same-count requirement not supported here");
+      case RequirementKind::SameShape:
+        llvm_unreachable("Same-shape requirement not supported here");
 
       case RequirementKind::SameType:
         ctx.Diags.diagnose(loc, diag::redundant_same_type_to_concrete,

--- a/lib/AST/RequirementMachine/Diagnostics.h
+++ b/lib/AST/RequirementMachine/Diagnostics.h
@@ -34,6 +34,8 @@ struct RequirementError {
     /// A type requirement on a trivially invalid subject type,
     /// e.g. Bool: Collection.
     InvalidRequirementSubject,
+    /// An invalid shape requirement, e.g. length(T...) == length(Int)
+    InvalidShapeRequirement,
     /// A pair of conflicting requirements, T == Int, T == String
     ConflictingRequirement,
     /// A recursive requirement, e.g. T == G<T.A>.
@@ -71,6 +73,11 @@ public:
   static RequirementError forInvalidRequirementSubject(Requirement req,
                                                        SourceLoc loc) {
     return {Kind::InvalidRequirementSubject, req, loc};
+  }
+
+  static RequirementError forInvalidShapeRequirement(Requirement req,
+                                                     SourceLoc loc) {
+    return {Kind::InvalidShapeRequirement, req, loc};
   }
 
   static RequirementError forConflictingRequirement(Requirement req,

--- a/lib/AST/RequirementMachine/Diagnostics.h
+++ b/lib/AST/RequirementMachine/Diagnostics.h
@@ -34,7 +34,7 @@ struct RequirementError {
     /// A type requirement on a trivially invalid subject type,
     /// e.g. Bool: Collection.
     InvalidRequirementSubject,
-    /// An invalid shape requirement, e.g. length(T...) == length(Int)
+    /// An invalid shape requirement, e.g. T.shape == Int.shape
     InvalidShapeRequirement,
     /// A pair of conflicting requirements, T == Int, T == String
     ConflictingRequirement,

--- a/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
+++ b/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
@@ -696,9 +696,9 @@ RequirementMachine::lookupNestedType(Type depType, Identifier name) const {
   return nullptr;
 }
 
-Type RequirementMachine::getReducedShape(Type type) const {
-  if (!type->isTypeSequenceParameter())
-    return Type();
+MutableTerm
+RequirementMachine::getReducedShapeTerm(Type type) const {
+  assert(type->isTypeSequenceParameter());
 
   auto rootType = type->getRootGenericParam();
   auto term = Context.getMutableTermForType(rootType->getCanonicalType(),
@@ -714,7 +714,22 @@ Type RequirementMachine::getReducedShape(Type type) const {
   assert(term.back().getKind() == Symbol::Kind::Shape);
   MutableTerm reducedTerm(term.begin(), term.end() - 1);
 
-  return Map.getTypeForTerm(reducedTerm, getGenericParams());
+  return reducedTerm;
+}
+
+Type RequirementMachine::getReducedShape(Type type) const {
+  if (!type->isTypeSequenceParameter())
+    return Type();
+
+  return Map.getTypeForTerm(getReducedShapeTerm(type),
+                            getGenericParams());
+}
+
+bool RequirementMachine::haveSameShape(Type type1, Type type2) const {
+  auto term1 = getReducedShapeTerm(type1);
+  auto term2 = getReducedShapeTerm(type2);
+
+  return term1 == term2;
 }
 
 void RequirementMachine::verify(const MutableTerm &term) const {

--- a/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
+++ b/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
@@ -267,6 +267,7 @@ RequirementMachine::getLongestValidPrefix(const MutableTerm &term) const {
     case Symbol::Kind::Superclass:
     case Symbol::Kind::ConcreteType:
     case Symbol::Kind::ConcreteConformance:
+    case Symbol::Kind::Shape:
       llvm::errs() <<"Invalid symbol in a type term: " << term << "\n";
       abort();
     }
@@ -735,6 +736,7 @@ void RequirementMachine::verify(const MutableTerm &term) const {
       case Symbol::Kind::Superclass:
       case Symbol::Kind::ConcreteType:
       case Symbol::Kind::ConcreteConformance:
+      case Symbol::Kind::Shape:
         llvm::errs() << "Bad initial symbol in " << term << "\n";
         abort();
         break;
@@ -757,6 +759,7 @@ void RequirementMachine::verify(const MutableTerm &term) const {
     case Symbol::Kind::Superclass:
     case Symbol::Kind::ConcreteType:
     case Symbol::Kind::ConcreteConformance:
+    case Symbol::Kind::Shape:
       llvm::errs() << "Bad interior symbol " << symbol << " in " << term << "\n";
       abort();
       break;

--- a/lib/AST/RequirementMachine/InterfaceType.cpp
+++ b/lib/AST/RequirementMachine/InterfaceType.cpp
@@ -303,6 +303,7 @@ getTypeForSymbolRange(const Symbol *begin, const Symbol *end,
       case Symbol::Kind::Superclass:
       case Symbol::Kind::ConcreteType:
       case Symbol::Kind::ConcreteConformance:
+      case Symbol::Kind::Shape:
         llvm::errs() << "Invalid root symbol: " << MutableTerm(begin, end) << "\n";
         abort();
       }

--- a/lib/AST/RequirementMachine/MinimalConformances.cpp
+++ b/lib/AST/RequirementMachine/MinimalConformances.cpp
@@ -285,6 +285,7 @@ static const ProtocolDecl *getParentConformanceForTerm(Term lhs) {
   case Symbol::Kind::Superclass:
   case Symbol::Kind::ConcreteType:
   case Symbol::Kind::ConcreteConformance:
+  case Symbol::Kind::Shape:
     break;
   }
 

--- a/lib/AST/RequirementMachine/PropertyUnification.cpp
+++ b/lib/AST/RequirementMachine/PropertyUnification.cpp
@@ -647,6 +647,7 @@ void PropertyMap::addProperty(
   case Symbol::Kind::Name:
   case Symbol::Kind::GenericParam:
   case Symbol::Kind::AssociatedType:
+  case Symbol::Kind::Shape:
     break;
   }
 

--- a/lib/AST/RequirementMachine/RequirementBuilder.cpp
+++ b/lib/AST/RequirementMachine/RequirementBuilder.cpp
@@ -329,7 +329,7 @@ void RequirementBuilder::processConnectedComponents() {
     MutableTerm subjectTerm(pair.first);
     RequirementKind kind;
     if (subjectTerm.back().getKind() == Symbol::Kind::Shape) {
-      kind = RequirementKind::SameCount;
+      kind = RequirementKind::SameShape;
       // Strip off the shape symbol from the subject term.
       subjectTerm = MutableTerm{subjectTerm.begin(), subjectTerm.end() - 1};
     } else {

--- a/lib/AST/RequirementMachine/RequirementBuilder.cpp
+++ b/lib/AST/RequirementMachine/RequirementBuilder.cpp
@@ -331,7 +331,7 @@ void RequirementBuilder::processConnectedComponents() {
     if (subjectTerm.back().getKind() == Symbol::Kind::Shape) {
       kind = RequirementKind::SameShape;
       // Strip off the shape symbol from the subject term.
-      subjectTerm = MutableTerm{subjectTerm.begin(), subjectTerm.end() - 1};
+      subjectTerm = MutableTerm(subjectTerm.begin(), subjectTerm.end() - 1);
     } else {
       kind = RequirementKind::SameType;
     }

--- a/lib/AST/RequirementMachine/RequirementBuilder.cpp
+++ b/lib/AST/RequirementMachine/RequirementBuilder.cpp
@@ -243,6 +243,7 @@ void RequirementBuilder::addRequirementRules(ArrayRef<unsigned> rules) {
       case Symbol::Kind::Name:
       case Symbol::Kind::AssociatedType:
       case Symbol::Kind::GenericParam:
+      case Symbol::Kind::Shape:
         break;
       }
 

--- a/lib/AST/RequirementMachine/RequirementBuilder.cpp
+++ b/lib/AST/RequirementMachine/RequirementBuilder.cpp
@@ -43,6 +43,7 @@ struct ConnectedComponent {
   Type ConcreteType;
 
   void buildRequirements(Type subjectType,
+                         RequirementKind kind,
                          std::vector<Requirement> &reqs,
                          std::vector<ProtocolTypeAlias> &aliases);
 };
@@ -68,6 +69,7 @@ struct ConnectedComponent {
 ///
 ///   A == X, B == X, C == X, D == X
 void ConnectedComponent::buildRequirements(Type subjectType,
+                                           RequirementKind kind,
                                            std::vector<Requirement> &reqs,
                                            std::vector<ProtocolTypeAlias> &aliases) {
   std::sort(Members.begin(), Members.end(),
@@ -81,12 +83,14 @@ void ConnectedComponent::buildRequirements(Type subjectType,
     }
 
     for (auto constraintType : Members) {
-      reqs.emplace_back(RequirementKind::SameType,
-                        subjectType, constraintType);
+      reqs.emplace_back(kind, subjectType, constraintType);
       subjectType = constraintType;
     }
 
   } else {
+    // Shape requirements cannot be concrete.
+    assert(kind == RequirementKind::SameType);
+
     // If there are multiple protocol typealiases in the connected component,
     // lower them all to a series of identical concrete-type aliases.
     for (auto name : Aliases) {
@@ -135,7 +139,7 @@ class RequirementBuilder {
 
   // Temporary state populated by addRequirementRules() and
   // addTypeAliasRules().
-  llvm::SmallDenseMap<TypeBase *, ConnectedComponent> Components;
+  llvm::SmallDenseMap<Term, ConnectedComponent> Components;
 
 public:
   // Results.
@@ -229,7 +233,7 @@ void RequirementBuilder::addRequirementRules(ArrayRef<unsigned> rules) {
         if (ReconstituteSugar)
           concreteType = concreteType->reconstituteSugar(/*recursive=*/true);
 
-        auto &component = Components[subjectType.getPointer()];
+        auto &component = Components[rule.getRHS()];
         assert(!component.ConcreteType);
         component.ConcreteType = concreteType;
         return;
@@ -250,28 +254,18 @@ void RequirementBuilder::addRequirementRules(ArrayRef<unsigned> rules) {
       llvm_unreachable("Invalid symbol kind");
     }
 
-    if (rule.getLHS().back().getKind() == Symbol::Kind::Shape) {
+    assert(rule.getLHS().back().getKind() != Symbol::Kind::Protocol);
+
+    MutableTerm constraintTerm(rule.getLHS());
+    if (constraintTerm.back().getKind() == Symbol::Kind::Shape) {
       assert(rule.getRHS().back().getKind() == Symbol::Kind::Shape);
-
-      // Strip off the shape symbols from either side of the rule.
-      MutableTerm lhsTerm(rule.getLHS().begin(),
-                          rule.getLHS().end() - 1);
-      MutableTerm rhsTerm(rule.getRHS().begin(),
-                          rule.getRHS().end() - 1);
-
-      // Add a SameCount requirement between the two parameter packs.
-      auto constraintType = Map.getTypeForTerm(lhsTerm, GenericParams);
-      auto subjectType = Map.getTypeForTerm(rhsTerm, GenericParams);
-      Reqs.emplace_back(RequirementKind::SameCount,
-                        subjectType, constraintType);
-      return;
+      // Strip off the shape symbol from the constraint term.
+      constraintTerm = MutableTerm(constraintTerm.begin(),
+                                   constraintTerm.end() - 1);
     }
 
-    assert(rule.getLHS().back().getKind() != Symbol::Kind::Protocol);
-    auto constraintType = Map.getTypeForTerm(rule.getLHS(), GenericParams);
-    auto subjectType = Map.getTypeForTerm(rule.getRHS(), GenericParams);
-
-    Components[subjectType.getPointer()].Members.push_back(constraintType);
+    auto constraintType = Map.getTypeForTerm(constraintTerm, GenericParams);
+    Components[rule.getRHS()].Members.push_back(constraintType);
   };
 
   if (Debug) {
@@ -319,11 +313,11 @@ void RequirementBuilder::addTypeAliasRules(ArrayRef<unsigned> rules) {
       if (ReconstituteSugar)
         concreteType = concreteType->reconstituteSugar(/*recursive=*/true);
 
-      auto &component = Components[subjectType.getPointer()];
+      auto &component = Components[rule.getRHS()];
       assert(!component.ConcreteType);
-      Components[subjectType.getPointer()].ConcreteType = concreteType;
+      Components[rule.getRHS()].ConcreteType = concreteType;
     } else {
-      Components[subjectType.getPointer()].Aliases.push_back(name);
+      Components[rule.getRHS()].Aliases.push_back(name);
     }
   }
 }
@@ -332,7 +326,18 @@ void RequirementBuilder::processConnectedComponents() {
   // Now, convert each connected component into a series of same-type
   // requirements.
   for (auto &pair : Components) {
-    pair.second.buildRequirements(pair.first, Reqs, Aliases);
+    MutableTerm subjectTerm(pair.first);
+    RequirementKind kind;
+    if (subjectTerm.back().getKind() == Symbol::Kind::Shape) {
+      kind = RequirementKind::SameCount;
+      // Strip off the shape symbol from the subject term.
+      subjectTerm = MutableTerm{subjectTerm.begin(), subjectTerm.end() - 1};
+    } else {
+      kind = RequirementKind::SameType;
+    }
+
+    auto subjectType = Map.getTypeForTerm(subjectTerm, GenericParams);
+    pair.second.buildRequirements(subjectType, kind, Reqs, Aliases);
   }
 }
 

--- a/lib/AST/RequirementMachine/RequirementBuilder.cpp
+++ b/lib/AST/RequirementMachine/RequirementBuilder.cpp
@@ -250,6 +250,23 @@ void RequirementBuilder::addRequirementRules(ArrayRef<unsigned> rules) {
       llvm_unreachable("Invalid symbol kind");
     }
 
+    if (rule.getLHS().back().getKind() == Symbol::Kind::Shape) {
+      assert(rule.getRHS().back().getKind() == Symbol::Kind::Shape);
+
+      // Strip off the shape symbols from either side of the rule.
+      MutableTerm lhsTerm(rule.getLHS().begin(),
+                          rule.getLHS().end() - 1);
+      MutableTerm rhsTerm(rule.getRHS().begin(),
+                          rule.getRHS().end() - 1);
+
+      // Add a SameCount requirement between the two parameter packs.
+      auto constraintType = Map.getTypeForTerm(lhsTerm, GenericParams);
+      auto subjectType = Map.getTypeForTerm(rhsTerm, GenericParams);
+      Reqs.emplace_back(RequirementKind::SameCount,
+                        subjectType, constraintType);
+      return;
+    }
+
     assert(rule.getLHS().back().getKind() != Symbol::Kind::Protocol);
     auto constraintType = Map.getTypeForTerm(rule.getLHS(), GenericParams);
     auto subjectType = Map.getTypeForTerm(rule.getRHS(), GenericParams);

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -500,13 +500,10 @@ struct InferRequirementsWalker : public TypeWalker {
       SmallVector<Type, 2> packReferences;
       packExpansion->getPatternType()->getTypeSequenceParameters(packReferences);
 
-      if (packReferences.size() > 1) {
-        auto first = packReferences.begin();
-        auto second = first + 1;
-        while (second != packReferences.end()) {
-          Requirement req(RequirementKind::SameShape, *first++, *second++);
-          desugarRequirement(req, SourceLoc(), reqs, errors);
-        }
+      auto countType = packExpansion->getCountType();
+      for (auto pack : packReferences) {
+        Requirement req(RequirementKind::SameShape, countType, pack);
+        desugarRequirement(req, SourceLoc(), reqs, errors);
       }
     }
 

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -359,10 +359,10 @@ static void desugarSameShapeRequirement(Type lhs, Type rhs, SourceLoc loc,
   // For now, only allow shape requirements directly between pack types.
   if (!lhs->isTypeSequenceParameter() || !rhs->isTypeSequenceParameter()) {
     errors.push_back(RequirementError::forInvalidShapeRequirement(
-        {RequirementKind::SameCount, lhs, rhs}, loc));
+        {RequirementKind::SameShape, lhs, rhs}, loc));
   }
 
-  result.emplace_back(RequirementKind::SameCount,
+  result.emplace_back(RequirementKind::SameShape,
                       lhs->getRootGenericParam(),
                       rhs->getRootGenericParam());
 }
@@ -378,7 +378,7 @@ swift::rewriting::desugarRequirement(Requirement req, SourceLoc loc,
   auto firstType = req.getFirstType();
 
   switch (req.getKind()) {
-  case RequirementKind::SameCount:
+  case RequirementKind::SameShape:
     desugarSameShapeRequirement(firstType, req.getSecondType(),
                                 loc, result, errors);
     break;
@@ -504,7 +504,7 @@ struct InferRequirementsWalker : public TypeWalker {
         auto first = packReferences.begin();
         auto second = first + 1;
         while (second != packReferences.end()) {
-          Requirement req(RequirementKind::SameCount, *first++, *second++);
+          Requirement req(RequirementKind::SameShape, *first++, *second++);
           desugarRequirement(req, SourceLoc(), reqs, errors);
         }
       }
@@ -613,8 +613,8 @@ void swift::rewriting::realizeRequirement(
   auto *moduleForInference = dc->getParentModule();
 
   switch (req.getKind()) {
-  case RequirementKind::SameCount:
-    llvm_unreachable("Same-count requirement not supported here");
+  case RequirementKind::SameShape:
+    llvm_unreachable("Same-shape requirement not supported here");
 
   case RequirementKind::Superclass:
   case RequirementKind::Conformance: {

--- a/lib/AST/RequirementMachine/RequirementMachine.h
+++ b/lib/AST/RequirementMachine/RequirementMachine.h
@@ -160,7 +160,13 @@ public:
   ConformancePath getConformancePath(Type type, ProtocolDecl *protocol);
   TypeDecl *lookupNestedType(Type depType, Identifier name) const;
 
+private:
+  MutableTerm getReducedShapeTerm(Type type) const;
+
+public:
   Type getReducedShape(Type type) const;
+
+  bool haveSameShape(Type type1, Type type2) const;
 
   llvm::DenseMap<const ProtocolDecl *, RequirementSignature>
   computeMinimalProtocolRequirements();

--- a/lib/AST/RequirementMachine/RequirementMachine.h
+++ b/lib/AST/RequirementMachine/RequirementMachine.h
@@ -160,6 +160,8 @@ public:
   ConformancePath getConformancePath(Type type, ProtocolDecl *protocol);
   TypeDecl *lookupNestedType(Type depType, Identifier name) const;
 
+  Type getReducedShape(Type type) const;
+
   llvm::DenseMap<const ProtocolDecl *, RequirementSignature>
   computeMinimalProtocolRequirements();
 

--- a/lib/AST/RequirementMachine/RewriteContext.cpp
+++ b/lib/AST/RequirementMachine/RewriteContext.cpp
@@ -194,7 +194,8 @@ static DebugOptions parseDebugFlags(StringRef debugFlags) {
 }
 
 RewriteContext::RewriteContext(ASTContext &ctx)
-    : Context(ctx),
+    : TheShapeSymbol(nullptr),
+      Context(ctx),
       Stats(ctx.Stats),
       SymbolHistogram(Symbol::NumKinds),
       TermHistogram(4, /*Start=*/1),

--- a/lib/AST/RequirementMachine/RewriteContext.h
+++ b/lib/AST/RequirementMachine/RewriteContext.h
@@ -45,6 +45,9 @@ class RewriteContext final {
   /// Folding set for uniquing symbols.
   llvm::FoldingSet<Symbol::Storage> Symbols;
 
+  /// The singleton storage for shape symbols.
+  Symbol::Storage *TheShapeSymbol;
+
   /// Folding set for uniquing terms.
   llvm::FoldingSet<Term::Storage> Terms;
 

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -551,6 +551,12 @@ void RewriteSystem::verifyRewriteRules(ValidityPolicy policy) const {
         ASSERT_RULE(symbol.getKind() != Symbol::Kind::Layout);
         ASSERT_RULE(symbol.getKind() != Symbol::Kind::Superclass);
         ASSERT_RULE(symbol.getKind() != Symbol::Kind::ConcreteType);
+        ASSERT_RULE(symbol.getKind() != Symbol::Kind::Shape);
+      }
+
+      // A shape symbol must follow a generic param symbol
+      if (symbol.getKind() == Symbol::Kind::Shape) {
+        ASSERT_RULE(index > 0 && lhs[index - 1].getKind() == Symbol::Kind::GenericParam);
       }
 
       if (!rule.isLHSSimplified() &&
@@ -594,6 +600,15 @@ void RewriteSystem::verifyRewriteRules(ValidityPolicy policy) const {
       ASSERT_RULE(symbol.getKind() != Symbol::Kind::Layout);
       ASSERT_RULE(symbol.getKind() != Symbol::Kind::Superclass);
       ASSERT_RULE(symbol.getKind() != Symbol::Kind::ConcreteType);
+
+      if (index != lhs.size() - 1) {
+        ASSERT_RULE(symbol.getKind() != Symbol::Kind::Shape);
+      }
+
+      // A shape symbol must follow a generic param symbol
+      if (symbol.getKind() == Symbol::Kind::Shape) {
+        ASSERT_RULE(index > 0 && rhs[index - 1].getKind() == Symbol::Kind::GenericParam);
+      }
 
       // Completion can introduce a rule of the form
       //

--- a/lib/AST/RequirementMachine/Rule.cpp
+++ b/lib/AST/RequirementMachine/Rule.cpp
@@ -72,6 +72,7 @@ const ProtocolDecl *Rule::isAnyConformanceRule() const {
     case Symbol::Kind::Name:
     case Symbol::Kind::AssociatedType:
     case Symbol::Kind::GenericParam:
+    case Symbol::Kind::Shape:
       break;
     }
 

--- a/lib/AST/RequirementMachine/RuleBuilder.cpp
+++ b/lib/AST/RequirementMachine/RuleBuilder.cpp
@@ -298,9 +298,25 @@ void RuleBuilder::addRequirement(const Requirement &req,
   MutableTerm constraintTerm;
 
   switch (req.getKind()) {
-  case RequirementKind::SameCount:
-    // TODO
-    return;
+  case RequirementKind::SameCount: {
+    // A same-shape requirement length(T...) == length(U...)
+    // becomes a rewrite rule:
+    //
+    //    T.[shape] => U.[shape]
+    auto otherType = CanType(req.getSecondType());
+    assert(otherType->isTypeSequenceParameter());
+
+    constraintTerm = (substitutions
+                      ? Context.getRelativeTermForType(
+                            otherType, *substitutions)
+                      : Context.getMutableTermForType(
+                            otherType, proto));
+
+    // Add the [shape] symbol to both sides.
+    subjectTerm.add(Symbol::forShape(Context));
+    constraintTerm.add(Symbol::forShape(Context));
+    break;
+  }
 
   case RequirementKind::Conformance: {
     // A conformance requirement T : P becomes a rewrite rule

--- a/lib/AST/RequirementMachine/RuleBuilder.cpp
+++ b/lib/AST/RequirementMachine/RuleBuilder.cpp
@@ -298,8 +298,8 @@ void RuleBuilder::addRequirement(const Requirement &req,
   MutableTerm constraintTerm;
 
   switch (req.getKind()) {
-  case RequirementKind::SameCount: {
-    // A same-shape requirement length(T...) == length(U...)
+  case RequirementKind::SameShape: {
+    // A same-shape requirement T.shape == U.shape
     // becomes a rewrite rule:
     //
     //    T.[shape] => U.[shape]

--- a/lib/AST/RequirementMachine/RuleBuilder.cpp
+++ b/lib/AST/RequirementMachine/RuleBuilder.cpp
@@ -299,7 +299,8 @@ void RuleBuilder::addRequirement(const Requirement &req,
 
   switch (req.getKind()) {
   case RequirementKind::SameCount:
-      llvm_unreachable("Same-count requirement not supported here");
+    // TODO
+    return;
 
   case RequirementKind::Conformance: {
     // A conformance requirement T : P becomes a rewrite rule

--- a/lib/AST/RequirementMachine/Symbol.cpp
+++ b/lib/AST/RequirementMachine/Symbol.cpp
@@ -307,27 +307,13 @@ Symbol Symbol::forGenericParam(GenericTypeParamType *param,
 }
 
 Symbol Symbol::forShape(RewriteContext &ctx) {
-  llvm::FoldingSetNodeID id;
-  id.AddInteger(unsigned(Kind::Shape));
-
-  void *insertPos = nullptr;
-  if (auto *symbol = ctx.Symbols.FindNodeOrInsertPos(id, insertPos))
+  if (auto *symbol = ctx.TheShapeSymbol)
     return symbol;
 
   unsigned size = Storage::totalSizeToAlloc<unsigned, Term>(0, 0);
   void *mem = ctx.Allocator.Allocate(size, alignof(Storage));
   auto *symbol = new (mem) Storage(Storage::ForShape());
-
-#ifndef NDEBUG
-  llvm::FoldingSetNodeID newID;
-  symbol->Profile(newID);
-  assert(id == newID);
-#endif
-
-  ctx.Symbols.InsertNode(symbol, insertPos);
-  ctx.SymbolHistogram.add(unsigned(Kind::Shape));
-
-  return symbol;
+  return (ctx.TheShapeSymbol = symbol);
 }
 
 /// Creates a layout symbol, representing a layout constraint.

--- a/lib/AST/RequirementMachine/Symbol.h
+++ b/lib/AST/RequirementMachine/Symbol.h
@@ -113,6 +113,10 @@ public:
     /// An unbound identifier name.
     Name,
 
+    /// A shape term 'T.[shape]'. The parent term must be a
+    /// generic parameter.
+    Shape,
+
     //////
     ////// "Property-like" symbol kinds:
     //////
@@ -130,7 +134,7 @@ public:
     ConcreteType,
   };
 
-  static const unsigned NumKinds = 8;
+  static const unsigned NumKinds = 9;
 
   static const StringRef Kinds[];
 

--- a/lib/AST/RequirementMachine/Symbol.h
+++ b/lib/AST/RequirementMachine/Symbol.h
@@ -204,6 +204,8 @@ public:
   static Symbol forGenericParam(GenericTypeParamType *param,
                                 RewriteContext &ctx);
 
+  static Symbol forShape(RewriteContext &ctx);
+
   static Symbol forLayout(LayoutConstraint layout,
                           RewriteContext &ctx);
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4203,8 +4203,8 @@ CanType ProtocolCompositionType::getMinimalCanonicalType(
     }
 
     switch (Req.getKind()) {
-    case RequirementKind::SameCount:
-      llvm_unreachable("Same-count requirement not supported here");
+    case RequirementKind::SameShape:
+      llvm_unreachable("Same-shape requirement not supported here");
     case RequirementKind::Superclass:
     case RequirementKind::Conformance:
       MinimalMembers.push_back(Req.getSecondType());

--- a/lib/AST/TypeWalker.cpp
+++ b/lib/AST/TypeWalker.cpp
@@ -114,7 +114,7 @@ class Traversal : public TypeVisitor<Traversal, bool>
         return true;
 
       switch (req.getKind()) {
-      case RequirementKind::SameCount:
+      case RequirementKind::SameShape:
       case RequirementKind::SameType:
       case RequirementKind::Conformance:
       case RequirementKind::Superclass:

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5907,8 +5907,8 @@ GenericRequirementsMetadata irgen::addGenericRequirements(
   GenericRequirementsMetadata metadata;
   for (auto &requirement : requirements) {
     switch (auto kind = requirement.getKind()) {
-    case RequirementKind::SameCount:
-      llvm_unreachable("Same-count requirement not supported here");
+    case RequirementKind::SameShape:
+      llvm_unreachable("Same-shape requirement not supported here");
 
     case RequirementKind::Layout:
       ++metadata.NumRequirements;

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -267,7 +267,7 @@ irgen::enumerateGenericSignatureRequirements(CanGenericSignature signature,
   for (auto &reqt : signature.getRequirements()) {
     switch (reqt.getKind()) {
       // Ignore these; they don't introduce extra requirements.
-      case RequirementKind::SameCount:
+      case RequirementKind::SameShape:
       case RequirementKind::Superclass:
       case RequirementKind::SameType:
       case RequirementKind::Layout:

--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -1635,8 +1635,8 @@ public:
     for (auto reqt : nomGenericSig.getRequirements()) {
       auto firstTy = reqt.getFirstType().subst(substGPMap);
       switch (auto kind = reqt.getKind()) {
-      case RequirementKind::SameCount:
-        llvm_unreachable("Same-count requirement not supported here");
+      case RequirementKind::SameShape:
+        llvm_unreachable("Same-shape requirement not supported here");
 
       case RequirementKind::SameType:
         // Skip same-type constraints that define away primary generic params,

--- a/lib/SIL/IR/SIL.cpp
+++ b/lib/SIL/IR/SIL.cpp
@@ -163,7 +163,7 @@ FormalLinkage swift::getGenericSignatureLinkage(CanGenericSignature sig) {
     // a dependent type.
 
     switch (req.getKind()) {
-    case RequirementKind::SameCount:
+    case RequirementKind::SameShape:
     case RequirementKind::Layout:
       continue;
 

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -210,8 +210,8 @@ static bool diagnoseUnsatisfiedRequirements(ADContext &context,
       }
     }
     switch (req.getKind()) {
-    case RequirementKind::SameCount:
-      llvm_unreachable("Same-count requirement not supported here");
+    case RequirementKind::SameShape:
+      llvm_unreachable("Same-shape requirement not supported here");
 
     // Check layout requirements.
     case RequirementKind::Layout: {

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -1119,7 +1119,7 @@ static bool hasNonSelfContainedRequirements(ArchetypeType *Archetype,
       // FIXME: Second type of a superclass requirement may contain
       // generic parameters.
       continue;
-    case RequirementKind::SameCount:
+    case RequirementKind::SameShape:
     case RequirementKind::SameType: {
       // Check if this requirement contains more than one generic param.
       // If this is the case, then these archetypes are interdependent and
@@ -1171,7 +1171,7 @@ static void collectRequirements(ArchetypeType *Archetype, GenericSignature Sig,
           CurrentGP)
         CollectedReqs.push_back(Req);
       continue;
-    case RequirementKind::SameCount:
+    case RequirementKind::SameShape:
     case RequirementKind::SameType: {
       // Check if this requirement contains more than one generic param.
       // If this is the case, then these archetypes are interdependent and

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2414,8 +2414,8 @@ bool AddExplicitExistentialCoercion::isRequired(
                                   ArrayRef<Requirement> requirements) {
       for (const auto &req : requirements) {
         switch (req.getKind()) {
-        case RequirementKind::SameCount:
-          llvm_unreachable("Same-count requirement not supported here");
+        case RequirementKind::SameShape:
+          llvm_unreachable("Same-shape requirement not supported here");
 
         case RequirementKind::Superclass:
         case RequirementKind::Conformance:
@@ -2450,8 +2450,8 @@ bool AddExplicitExistentialCoercion::isRequired(
         auto requirementSig = protocol->getRequirementSignature();
         for (const auto &req : requirementSig.getRequirements()) {
           switch (req.getKind()) {
-          case RequirementKind::SameCount:
-            llvm_unreachable("Same-count requirement not supported here");
+          case RequirementKind::SameShape:
+            llvm_unreachable("Same-shape requirement not supported here");
 
           case RequirementKind::Conformance:
           case RequirementKind::Layout:

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3989,8 +3989,8 @@ static ConstraintFix *fixRequirementFailure(ConstraintSystem &cs, Type type1,
   auto *reqLoc = cs.getConstraintLocator(anchor, path);
 
   switch (req.getRequirementKind()) {
-  case RequirementKind::SameCount:
-    llvm_unreachable("Same-count requirement not supported here");
+  case RequirementKind::SameShape:
+    llvm_unreachable("Same-shape requirement not supported here");
 
   case RequirementKind::SameType: {
     return SkipSameTypeRequirement::create(cs, type1, type2, reqLoc);
@@ -13598,8 +13598,8 @@ void ConstraintSystem::addConstraint(Requirement req,
   bool conformsToAnyObject = false;
   Optional<ConstraintKind> kind;
   switch (req.getKind()) {
-  case RequirementKind::SameCount:
-    llvm_unreachable("Same-count requirement not supported here");
+  case RequirementKind::SameShape:
+    llvm_unreachable("Same-shape requirement not supported here");
 
   case RequirementKind::Conformance:
     kind = ConstraintKind::ConformsTo;

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -122,8 +122,8 @@ void LocatorPathElt::dump(raw_ostream &out) const {
   auto dumpReqKind = [&out](RequirementKind kind) {
     out << " (";
     switch (kind) {
-    case RequirementKind::SameCount:
-      out << "same_length";
+    case RequirementKind::SameShape:
+      out << "same_shape";
       break;
     case RequirementKind::Conformance:
       out << "conformance";

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1769,8 +1769,8 @@ void ConstraintSystem::openGenericRequirement(
 
   auto kind = req.getKind();
   switch (kind) {
-  case RequirementKind::SameCount:
-    llvm_unreachable("Same-count requirement not supported here");
+  case RequirementKind::SameShape:
+    llvm_unreachable("Same-shape requirement not supported here");
   case RequirementKind::Conformance: {
     auto protoDecl = req.getProtocolDecl();
     // Determine whether this is the protocol 'Self' constraint we should
@@ -6611,8 +6611,8 @@ static bool doesMemberHaveUnfulfillableConstraintsWithExistentialBase(
 
   for (const auto &req : sig.getRequirements()) {
     switch (req.getKind()) {
-    case RequirementKind::SameCount:
-      llvm_unreachable("Same-count requirement not supported here");
+    case RequirementKind::SameShape:
+      llvm_unreachable("Same-shape requirement not supported here");
 
     case RequirementKind::Superclass: {
       if (req.getFirstType()->getRootGenericParam()->getDepth() > 0 &&

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -41,7 +41,7 @@ static void forAllRequirementTypes(
   std::move(source).visitRequirements(TypeResolutionStage::Interface,
       [&](const Requirement &req, RequirementRepr *reqRepr) {
     switch (req.getKind()) {
-    case RequirementKind::SameCount:
+    case RequirementKind::SameShape:
     case RequirementKind::Conformance:
     case RequirementKind::SameType:
     case RequirementKind::Superclass:

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2583,8 +2583,8 @@ static void checkSpecializeAttrRequirements(SpecializeAttr *attr,
     }
 
     switch (specializedReq.getKind()) {
-    case RequirementKind::SameCount:
-      llvm_unreachable("Same-count requirement not supported here");
+    case RequirementKind::SameShape:
+      llvm_unreachable("Same-shape requirement not supported here");
 
     case RequirementKind::Conformance:
     case RequirementKind::Superclass:

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -649,8 +649,8 @@ Type TypeChecker::typeCheckParameterDefault(Expr *&defaultValue,
       auto &requirement = requirements[reqIdx];
 
       switch (requirement.getKind()) {
-      case RequirementKind::SameCount:
-        llvm_unreachable("Same-count requirement not supported here");
+      case RequirementKind::SameShape:
+        llvm_unreachable("Same-shape requirement not supported here");
 
       case RequirementKind::SameType: {
         auto lhsTy = requirement.getFirstType();

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1167,7 +1167,7 @@ static void checkProtocolSelfRequirements(ProtocolDecl *proto,
       TypeResolutionStage::Interface,
       [proto](const Requirement &req, RequirementRepr *reqRepr) {
         switch (req.getKind()) {
-        case RequirementKind::SameCount:
+        case RequirementKind::SameShape:
         case RequirementKind::Conformance:
         case RequirementKind::Layout:
         case RequirementKind::Superclass:

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -364,7 +364,7 @@ void TypeChecker::checkReferencedGenericParams(GenericContext *dc) {
     Type second;
 
     switch (req.getKind()) {
-    case RequirementKind::SameCount:
+    case RequirementKind::SameShape:
     case RequirementKind::Superclass:
     case RequirementKind::SameType:
       second = req.getSecondType();
@@ -801,8 +801,8 @@ void TypeChecker::diagnoseRequirementFailure(
 
   const auto reqKind = req.getKind();
   switch (reqKind) {
-  case RequirementKind::SameCount:
-    llvm_unreachable("Same-count requirement not supported here");
+  case RequirementKind::SameShape:
+    llvm_unreachable("Same-shape requirement not supported here");
 
   case RequirementKind::Conformance: {
     diagnoseConformanceFailure(substReq.getFirstType(),

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4895,8 +4895,8 @@ hasInvariantSelfRequirement(const ProtocolDecl *proto,
 
   for (auto req : reqSig) {
     switch (req.getKind()) {
-    case RequirementKind::SameCount:
-      llvm_unreachable("Same-count requirement not supported here");
+    case RequirementKind::SameShape:
+      llvm_unreachable("Same-shape requirement not supported here");
 
     case RequirementKind::SameType:
       if (req.getSecondType()->isTypeParameter()) {
@@ -4929,8 +4929,8 @@ static void diagnoseInvariantSelfRequirement(
   unsigned kind = 0;
 
   switch (req.getKind()) {
-  case RequirementKind::SameCount:
-    llvm_unreachable("Same-count requirement not supported here");
+  case RequirementKind::SameShape:
+    llvm_unreachable("Same-shape requirement not supported here");
 
   case RequirementKind::SameType:
   if (req.getSecondType()->isTypeParameter()) {

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -317,8 +317,8 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitnesses(
             for (auto &reqt : witnessContext->getGenericSignatureOfContext()
                                             .getRequirements()) {
               switch (reqt.getKind()) {
-              case RequirementKind::SameCount:
-                llvm_unreachable("Same-count requirement not supported here");
+              case RequirementKind::SameShape:
+                llvm_unreachable("Same-shape requirement not supported here");
 
               case RequirementKind::Conformance:
               case RequirementKind::Superclass:
@@ -1070,8 +1070,8 @@ static void sanitizeProtocolRequirements(
 
   for (const auto &req : requirements) {
     switch (req.getKind()) {
-    case RequirementKind::SameCount:
-      llvm_unreachable("Same-count requirement not supported here");
+    case RequirementKind::SameShape:
+      llvm_unreachable("Same-shape requirement not supported here");
 
     case RequirementKind::Conformance:
     case RequirementKind::SameType:
@@ -1738,7 +1738,7 @@ static Comparison compareDeclsForInference(DeclContext *DC, ValueDecl *decl1,
       class1 = reqt.getSecondType();
       break;
 
-    case RequirementKind::SameCount:
+    case RequirementKind::SameShape:
     case RequirementKind::SameType:
     case RequirementKind::Layout:
       break;
@@ -1771,7 +1771,7 @@ static Comparison compareDeclsForInference(DeclContext *DC, ValueDecl *decl1,
       class2 = reqt.getSecondType();
       break;
 
-    case RequirementKind::SameCount:
+    case RequirementKind::SameShape:
     case RequirementKind::SameType:
     case RequirementKind::Layout:
       break;

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -435,7 +435,7 @@ static inline OperatorFixity getASTOperatorFixity(OperatorKind fixity) {
 // These IDs must \em not be renumbered or reordered without incrementing
 // the module version.
 enum GenericRequirementKind : uint8_t {
-  SameCount = 0,
+  SameShape = 0,
   Conformance = 1,
   SameType    = 2,
   Superclass  = 3,

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1337,7 +1337,7 @@ static uint8_t getRawStableRequirementKind(RequirementKind kind) {
     return GenericRequirementKind::KIND;
 
   switch (kind) {
-  CASE(SameCount)
+  CASE(SameShape)
   CASE(Conformance)
   CASE(Superclass)
   CASE(SameType)

--- a/lib/SymbolGraphGen/JSON.cpp
+++ b/lib/SymbolGraphGen/JSON.cpp
@@ -93,8 +93,8 @@ void swift::symbolgraphgen::serialize(const Requirement &Req,
                                       llvm::json::OStream &OS) {
   StringRef Kind;
   switch (Req.getKind()) {
-    case RequirementKind::SameCount:
-      Kind = "sameLength";
+    case RequirementKind::SameShape:
+      Kind = "sameShape";
       break;
     case RequirementKind::Conformance:
       Kind = "conformance";

--- a/stdlib/public/Reflection/TypeRef.cpp
+++ b/stdlib/public/Reflection/TypeRef.cpp
@@ -314,11 +314,11 @@ public:
   void visitTypeRefRequirement(const TypeRefRequirement &req) {
     printHeader("requirement ");
     switch (req.getKind()) {
-    case RequirementKind::SameCount:
+    case RequirementKind::SameShape:
       printRec(req.getFirstType());
-      stream << ".count == ";
+      stream << ".shape == ";
       printRec(req.getSecondType());
-      stream << ".count";
+      stream << ".shape";
       break;
     case RequirementKind::Conformance:
     case RequirementKind::Superclass:
@@ -898,7 +898,7 @@ public:
 
   Demangle::NodePointer visitTypeRefRequirement(const TypeRefRequirement &req) {
     switch (req.getKind()) {
-    case RequirementKind::SameCount: {
+    case RequirementKind::SameShape: {
       // Not implemented.
       return nullptr;
     }
@@ -1304,7 +1304,7 @@ public:
       return None;
 
     switch (req.getKind()) {
-    case RequirementKind::SameCount:
+    case RequirementKind::SameShape:
     case RequirementKind::Conformance:
     case RequirementKind::Superclass:
     case RequirementKind::SameType: {

--- a/test/Generics/pack-shape-requirements.swift
+++ b/test/Generics/pack-shape-requirements.swift
@@ -13,3 +13,33 @@ func inferSameShape<@_typeSequence T, @_typeSequence U>(ts t: T..., us u: U...) 
 // CHECK-NEXT: Generic signature: <@_typeSequence T, @_typeSequence U where T : P, T.count == U.count, U : P>
 func desugarSameShape<@_typeSequence T, @_typeSequence U>(ts t: T..., us u: U...) where T: P, U: P, ((T.A, U.A)...): Any {
 }
+
+// CHECK-LABEL: multipleSameShape1(ts:us:vs:)
+// CHECK-NEXT: Generic signature: <@_typeSequence T, @_typeSequence U, @_typeSequence V where T.count == U.count, U.count == V.count>
+func multipleSameShape1<@_typeSequence T, @_typeSequence U, @_typeSequence V>(ts t: T..., us u: U..., vs v: V...) where ((T, U, V)...): Any {
+}
+
+// CHECK-LABEL: multipleSameShape2(ts:us:vs:)
+// CHECK-NEXT: Generic signature: <@_typeSequence T, @_typeSequence U, @_typeSequence V where T.count == U.count, U.count == V.count>
+func multipleSameShape2<@_typeSequence T, @_typeSequence U, @_typeSequence V>(ts t: T..., us u: U..., vs v: V...) where ((V, T, U)...): Any {
+}
+
+// CHECK-LABEL: multipleSameShape3(ts:us:vs:)
+// CHECK-NEXT: Generic signature: <@_typeSequence T, @_typeSequence U, @_typeSequence V where T.count == U.count, U.count == V.count>
+func multipleSameShape3<@_typeSequence T, @_typeSequence U, @_typeSequence V>(ts t: T..., us u: U..., vs v: V...) where ((U, V, T)...): Any {
+}
+
+// CHECK-LABEL: multipleSameShape4(ts:us:vs:)
+// CHECK-NEXT: Generic signature: <@_typeSequence T, @_typeSequence U, @_typeSequence V where T.count == U.count, U.count == V.count>
+func multipleSameShape4<@_typeSequence T, @_typeSequence U, @_typeSequence V>(ts t: T..., us u: U..., vs v: V...) where ((U, T, V)...): Any {
+}
+
+// CHECK-LABEL: multipleSameShape5(ts:us:vs:)
+// CHECK-NEXT: Generic signature: <@_typeSequence T, @_typeSequence U, @_typeSequence V where T.count == U.count, U.count == V.count>
+func multipleSameShape5<@_typeSequence T, @_typeSequence U, @_typeSequence V>(ts t: T..., us u: U..., vs v: V...) where ((T, V, U)...): Any {
+}
+
+// CHECK-LABEL: multipleSameShape6(ts:us:vs:)
+// CHECK-NEXT: Generic signature: <@_typeSequence T, @_typeSequence U, @_typeSequence V where T.count == U.count, U.count == V.count>
+func multipleSameShape6<@_typeSequence T, @_typeSequence U, @_typeSequence V>(ts t: T..., us u: U..., vs v: V...) where ((V, U, T)...): Any {
+}

--- a/test/Generics/pack-shape-requirements.swift
+++ b/test/Generics/pack-shape-requirements.swift
@@ -5,42 +5,42 @@ protocol P {
 }
 
 // CHECK-LABEL: inferSameShape(ts:us:)
-// CHECK-NEXT: Generic signature: <@_typeSequence T, @_typeSequence U where T.count == U.count>
+// CHECK-NEXT: Generic signature: <@_typeSequence T, @_typeSequence U where T.shape == U.shape>
 func inferSameShape<@_typeSequence T, @_typeSequence U>(ts t: T..., us u: U...) where ((T, U)...): Any {
 }
 
 // CHECK-LABEL: desugarSameShape(ts:us:)
-// CHECK-NEXT: Generic signature: <@_typeSequence T, @_typeSequence U where T : P, T.count == U.count, U : P>
+// CHECK-NEXT: Generic signature: <@_typeSequence T, @_typeSequence U where T : P, T.shape == U.shape, U : P>
 func desugarSameShape<@_typeSequence T, @_typeSequence U>(ts t: T..., us u: U...) where T: P, U: P, ((T.A, U.A)...): Any {
 }
 
 // CHECK-LABEL: multipleSameShape1(ts:us:vs:)
-// CHECK-NEXT: Generic signature: <@_typeSequence T, @_typeSequence U, @_typeSequence V where T.count == U.count, U.count == V.count>
+// CHECK-NEXT: Generic signature: <@_typeSequence T, @_typeSequence U, @_typeSequence V where T.shape == U.shape, U.shape == V.shape>
 func multipleSameShape1<@_typeSequence T, @_typeSequence U, @_typeSequence V>(ts t: T..., us u: U..., vs v: V...) where ((T, U, V)...): Any {
 }
 
 // CHECK-LABEL: multipleSameShape2(ts:us:vs:)
-// CHECK-NEXT: Generic signature: <@_typeSequence T, @_typeSequence U, @_typeSequence V where T.count == U.count, U.count == V.count>
+// CHECK-NEXT: Generic signature: <@_typeSequence T, @_typeSequence U, @_typeSequence V where T.shape == U.shape, U.shape == V.shape>
 func multipleSameShape2<@_typeSequence T, @_typeSequence U, @_typeSequence V>(ts t: T..., us u: U..., vs v: V...) where ((V, T, U)...): Any {
 }
 
 // CHECK-LABEL: multipleSameShape3(ts:us:vs:)
-// CHECK-NEXT: Generic signature: <@_typeSequence T, @_typeSequence U, @_typeSequence V where T.count == U.count, U.count == V.count>
+// CHECK-NEXT: Generic signature: <@_typeSequence T, @_typeSequence U, @_typeSequence V where T.shape == U.shape, U.shape == V.shape>
 func multipleSameShape3<@_typeSequence T, @_typeSequence U, @_typeSequence V>(ts t: T..., us u: U..., vs v: V...) where ((U, V, T)...): Any {
 }
 
 // CHECK-LABEL: multipleSameShape4(ts:us:vs:)
-// CHECK-NEXT: Generic signature: <@_typeSequence T, @_typeSequence U, @_typeSequence V where T.count == U.count, U.count == V.count>
+// CHECK-NEXT: Generic signature: <@_typeSequence T, @_typeSequence U, @_typeSequence V where T.shape == U.shape, U.shape == V.shape>
 func multipleSameShape4<@_typeSequence T, @_typeSequence U, @_typeSequence V>(ts t: T..., us u: U..., vs v: V...) where ((U, T, V)...): Any {
 }
 
 // CHECK-LABEL: multipleSameShape5(ts:us:vs:)
-// CHECK-NEXT: Generic signature: <@_typeSequence T, @_typeSequence U, @_typeSequence V where T.count == U.count, U.count == V.count>
+// CHECK-NEXT: Generic signature: <@_typeSequence T, @_typeSequence U, @_typeSequence V where T.shape == U.shape, U.shape == V.shape>
 func multipleSameShape5<@_typeSequence T, @_typeSequence U, @_typeSequence V>(ts t: T..., us u: U..., vs v: V...) where ((T, V, U)...): Any {
 }
 
 // CHECK-LABEL: multipleSameShape6(ts:us:vs:)
-// CHECK-NEXT: Generic signature: <@_typeSequence T, @_typeSequence U, @_typeSequence V where T.count == U.count, U.count == V.count>
+// CHECK-NEXT: Generic signature: <@_typeSequence T, @_typeSequence U, @_typeSequence V where T.shape == U.shape, U.shape == V.shape>
 func multipleSameShape6<@_typeSequence T, @_typeSequence U, @_typeSequence V>(ts t: T..., us u: U..., vs v: V...) where ((V, U, T)...): Any {
 }
 
@@ -53,7 +53,7 @@ struct Ts<@_typeSequence T> {
 
     struct Vs<@_typeSequence V> {
       // CHECK-LABEL: Ts.Us.Vs.packEquality()
-      // CHECK-NEXT: Generic signature: <@_typeSequence T, @_typeSequence U, @_typeSequence V where T == U, T.count == V.count>
+      // CHECK-NEXT: Generic signature: <@_typeSequence T, @_typeSequence U, @_typeSequence V where T == U, T.shape == V.shape>
       func packEquality() where T == U, ((U, V)...): Any {
       }
     }

--- a/test/Generics/pack-shape-requirements.swift
+++ b/test/Generics/pack-shape-requirements.swift
@@ -43,3 +43,19 @@ func multipleSameShape5<@_typeSequence T, @_typeSequence U, @_typeSequence V>(ts
 // CHECK-NEXT: Generic signature: <@_typeSequence T, @_typeSequence U, @_typeSequence V where T.count == U.count, U.count == V.count>
 func multipleSameShape6<@_typeSequence T, @_typeSequence U, @_typeSequence V>(ts t: T..., us u: U..., vs v: V...) where ((V, U, T)...): Any {
 }
+
+struct Ts<@_typeSequence T> {
+  struct Us<@_typeSequence U> {
+    // CHECK-LABEL: Ts.Us.packEquality()
+    // CHECK-NEXT: Generic signature: <@_typeSequence T, @_typeSequence U where T == U>
+    func packEquality() where T == U, ((T, U)...): Any {
+    }
+
+    struct Vs<@_typeSequence V> {
+      // CHECK-LABEL: Ts.Us.Vs.packEquality()
+      // CHECK-NEXT: Generic signature: <@_typeSequence T, @_typeSequence U, @_typeSequence V where T == U, T.count == V.count>
+      func packEquality() where T == U, ((U, V)...): Any {
+      }
+    }
+  }
+}

--- a/test/Generics/pack-shape-requirements.swift
+++ b/test/Generics/pack-shape-requirements.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -typecheck -enable-experimental-variadic-generics %s -debug-generic-signatures 2>&1 | %FileCheck %s
+
+protocol P {
+  associatedtype A
+}
+
+// CHECK-LABEL: inferSameShape(ts:us:)
+// CHECK-NEXT: Generic signature: <@_typeSequence T, @_typeSequence U where T.count == U.count>
+func inferSameShape<@_typeSequence T, @_typeSequence U>(ts t: T..., us u: U...) where ((T, U)...): Any {
+}
+
+// CHECK-LABEL: desugarSameShape(ts:us:)
+// CHECK-NEXT: Generic signature: <@_typeSequence T, @_typeSequence U where T : P, T.count == U.count, U : P>
+func desugarSameShape<@_typeSequence T, @_typeSequence U>(ts t: T..., us u: U...) where T: P, U: P, ((T.A, U.A)...): Any {
+}

--- a/tools/swift-ide-test/ModuleAPIDiff.cpp
+++ b/tools/swift-ide-test/ModuleAPIDiff.cpp
@@ -756,7 +756,7 @@ public:
                 convertToTypeName(Req.getSecondType())});
         break;
       case RequirementKind::Layout:
-      case RequirementKind::SameCount:
+      case RequirementKind::SameShape:
         // FIXME
         assert(false && "Not implemented");
         break;


### PR DESCRIPTION
A "same-shape" requirement states that two type parameter packs have the same structure, including having the same length. Same-shape requirements cannot be written explicitly; they can only be inferred from same-type requirements between parameter packs and pack expansions that contain multiple parameter packs:

```swift
// '(T, U)...' implies a same-shape requirement between T and U.
func inferSameShape<@_typeSequence T, @_typeSequence U>(ts t: T..., us u: U...) where ((T, U)...): Any
```

Same-shape requirements between dependent member types are desugared to equate the root type parameter shapes:

```swift
protocol P {
  associatedtype A
}

// '(T.A, U.A)...' implies a same-shape requirement between T and U.
func inferSameShape<@_typeSequence T, @_typeSequence U>(ts t: T..., us u: U...) where ((T.A, U.A)...): Any
```

A same-shape requirement is a rewrite rule:

```
T.[shape] => U.[shape]
```

`[shape]` is a new symbol that can be appended to generic parameter terms. In the future, we can allow concrete shape requirements using a concrete shape property symbol, e.g.

```
T.[shape].[concreteShape: PackType(Int, U...)] => T.[shape]
```