### PR TITLE
Don’t suggest adding the project in the "submit a bug report" message

### DIFF
--- a/include/swift/Basic/Compiler.h
+++ b/include/swift/Basic/Compiler.h
@@ -94,14 +94,13 @@
 #endif
 
 #define SWIFT_BUG_REPORT_MESSAGE_BASE \
-  "submit a bug report (" SWIFT_BUG_REPORT_URL \
-  ") and include the project"
+  "submit a bug report (" SWIFT_BUG_REPORT_URL ")"
 
 #define SWIFT_BUG_REPORT_MESSAGE \
   "please " SWIFT_BUG_REPORT_MESSAGE_BASE
 
 #define SWIFT_CRASH_BUG_REPORT_MESSAGE \
-  "Please " SWIFT_BUG_REPORT_MESSAGE_BASE " and the crash backtrace."
+  "Please " SWIFT_BUG_REPORT_MESSAGE_BASE " and include the crash backtrace."
 
 // Conditionally exclude declarations or statements that are only needed for
 // assertions from release builds (NDEBUG) without cluttering the surrounding

--- a/test/Frontend/batch_mode_output_file_map_missing_primary.swift
+++ b/test/Frontend/batch_mode_output_file_map_missing_primary.swift
@@ -5,4 +5,4 @@
 // RUN: not %target-swift-frontend -parse -primary-file main.swift -primary-file file-01.swift -supplementary-output-file-map %S/Inputs/supplementary_output_filemap_missing_a_primary.yaml >%t/errs.txt 2>&1
 // RUN: %FileCheck %s <%t/errs.txt
 
-// CHECK: error: supplementary output file map '{{.*}}supplementary_output_filemap_missing_a_primary.yaml' is missing an entry for 'file-01.swift' (this likely indicates a compiler issue; please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the project)
+// CHECK: error: supplementary output file map '{{.*}}supplementary_output_filemap_missing_a_primary.yaml' is missing an entry for 'file-01.swift' (this likely indicates a compiler issue; please submit a bug report (https://swift.org/contributing/#reporting-bugs)){{$}}

--- a/test/Sema/rdar38885760.swift
+++ b/test/Sema/rdar38885760.swift
@@ -3,7 +3,7 @@
 // RUN: not %target-swift-frontend -typecheck %s -parse-stdlib 2>%t/fallback_diagnostic.txt
 // RUN: %FileCheck %s --check-prefix FALLBACK-DIAGNOSTIC <%t/fallback_diagnostic.txt
 //
-// FALLBACK-DIAGNOSTIC: error: failed to produce diagnostic for expression; please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the project
+// FALLBACK-DIAGNOSTIC: error: failed to produce diagnostic for expression; please submit a bug report (https://swift.org/contributing/#reporting-bugs){{$}}
 
 import Swift
 

--- a/test/Serialization/Recovery/crash-recovery.swift
+++ b/test/Serialization/Recovery/crash-recovery.swift
@@ -12,7 +12,7 @@ public class Sub: Base {
   public override func disappearingMethod() {}
 }
 
-// CHECK-CRASH: error: fatal error encountered while reading from module 'Lib'; please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the project
+// CHECK-CRASH: error: fatal error encountered while reading from module 'Lib'; please submit a bug report (https://swift.org/contributing/#reporting-bugs){{$}}
 // CHECK-CRASH-4: Compiling with effective version 4.1.50
 // CHECK-CRASH-4_2: Compiling with effective version 4.2
 // CHECK-CRASH: While loading members for 'Sub' (in module 'Lib')


### PR DESCRIPTION
Instead, stimulate users to follow the referenced bug reporting guidelines, which contain all the necessary information. We’d rather encourage attempts at reducing issues before attaching Xcode projects. This is an accompaniment to https://github.com/apple/swift-org-website/pull/158.