### PR TITLE
[cxx-interop] Add initial benchmark to compare vector<uint32_t> sum i…

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -199,6 +199,7 @@ set(SWIFT_BENCH_MODULES
     single-source/WordCount
     single-source/XorLoop
     cxx-source/CreateObjects
+    cxx-source/CxxVectorSum
     cxx-source/ReadAccessor
 )
 

--- a/benchmark/Package.swift
+++ b/benchmark/Package.swift
@@ -169,7 +169,9 @@ targets += cxxSingleSourceLibraries.map { name in
     swiftSettings: [.unsafeFlags(["-Xfrontend",
                                   "-enable-experimental-cxx-interop",
                                   "-I",
-                                  "utils/CxxTests"])])
+                                  "utils/CxxTests",
+                                  // FIXME: https://github.com/apple/swift/issues/61453
+                                  "-Xfrontend", "-validate-tbd-against-ir=none"])])
 }
 
 targets += multiSourceLibraries.map { lib in

--- a/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
+++ b/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
@@ -484,6 +484,8 @@ function (swift_benchmark_compile_archopts)
       set(cxx_options "")
       if ("${module_name_path}" MATCHES ".*cxx-source/.*")
         list(APPEND cxx_options "-Xfrontend" "-enable-experimental-cxx-interop" "-I" "${srcdir}/utils/CxxTests/")
+        # FIXME: https://github.com/apple/swift/issues/61453
+        list(APPEND cxx_options "-Xfrontend" "-validate-tbd-against-ir=none")
       endif()
 
       if ("${bench_flags}" MATCHES "-whole-module.*")

--- a/benchmark/cxx-source/CxxVectorSum.swift
+++ b/benchmark/cxx-source/CxxVectorSum.swift
@@ -53,6 +53,7 @@ func makeVectorOnce() {
 // establish an expected threshold of performance, which when exceeded should
 // fail the benchmark.
 
+// FIXME: Bump up to 50k and 10 once the sequence is faster.
 let vectorSize = 25_000
 let iterRepeatFactor = 7
 

--- a/benchmark/cxx-source/CxxVectorSum.swift
+++ b/benchmark/cxx-source/CxxVectorSum.swift
@@ -21,24 +21,33 @@ public let benchmarks = [
   BenchmarkInfo(
       name: "CxxVecU32.Sum.Cxx.RangedForLoop",
       runFunction: run_CxxVectorOfU32_Sum_Cxx_RangedForLoop,
-      tags: [.validation, .bridging, .cxxInterop]),
+      tags: [.validation, .bridging, .cxxInterop],
+      setUpFunction: makeVectorOnce),
   BenchmarkInfo(
     name: "CxxVecU32.Sum.Swift.ForInLoop",
     runFunction: run_CxxVectorOfU32_Sum_Swift_ForInLoop,
-    tags: [.validation, .bridging, .cxxInterop]),
+    tags: [.validation, .bridging, .cxxInterop],
+    setUpFunction: makeVectorOnce),
   BenchmarkInfo(
     name: "CxxVecU32.Sum.Swift.IteratorLoop",
     runFunction: run_CxxVectorOfU32_Sum_Swift_RawIteratorLoop,
-    tags: [.validation, .bridging, .cxxInterop]),
+    tags: [.validation, .bridging, .cxxInterop],
+    setUpFunction: makeVectorOnce),
   BenchmarkInfo(
     name: "CxxVecU32.Sum.Swift.SubscriptLoop",
     runFunction: run_CxxVectorOfU32_Sum_Swift_IndexAndSubscriptLoop,
-    tags: [.validation, .bridging, .cxxInterop]),
+    tags: [.validation, .bridging, .cxxInterop],
+    setUpFunction: makeVectorOnce),
   BenchmarkInfo(
     name: "CxxVecU32.Sum.Swift.Reduce",
     runFunction: run_CxxVectorOfU32_Sum_Swift_Reduce,
-    tags: [.validation, .bridging, .cxxInterop])
+    tags: [.validation, .bridging, .cxxInterop],
+    setUpFunction: makeVectorOnce)
 ]
+
+func makeVectorOnce() {
+    initVector(vectorSize)
+}
 
 // FIXME: compare CxxVectorOfU32SumInCxx to CxxVectorOfU32SumInSwift and
 // establish an expected threshold of performance, which when exceeded should

--- a/benchmark/cxx-source/CxxVectorSum.swift
+++ b/benchmark/cxx-source/CxxVectorSum.swift
@@ -31,6 +31,10 @@ public let benchmarks = [
     runFunction: run_CxxVectorOfU32_Sum_Swift_RawIteratorLoop,
     tags: [.validation, .bridging, .cxxInterop]),
   BenchmarkInfo(
+    name: "CxxVectorOfU32.Sum.Swift.RawIteratorLoop.WithCxxInlineHelpers",
+    runFunction: run_CxxVectorOfU32_Sum_Swift_RawIteratorLoop_WithCxxInlineHelpers,
+    tags: [.validation, .bridging, .cxxInterop]),
+  BenchmarkInfo(
     name: "CxxVectorOfU32.Sum.Swift.IndexAndSubscriptLoop",
     runFunction: run_CxxVectorOfU32_Sum_Swift_IndexAndSubscriptLoop,
     tags: [.validation, .bridging, .cxxInterop]),
@@ -68,7 +72,7 @@ public func run_CxxVectorOfU32_Sum_Swift_ForInLoop(_ n: Int) {
 // This function should have comparable performance to
 // `run_CxxVectorOfU32_Sum_Cxx_RangedForLoop`.
 @inline(never)
-public func run_CxxVectorOfU32_Sum_Swift_RawIteratorLoop(_ n: Int) {
+public func run_CxxVectorOfU32_Sum_Swift_RawIteratorLoop_WithCxxInlineHelpers(_ n: Int) {
   let vectorOfU32 = makeVector32(vectorSize)
   var sum: UInt32 = 0
   for _ in 0..<(n * iterRepeatFactor) {
@@ -77,6 +81,23 @@ public func run_CxxVectorOfU32_Sum_Swift_RawIteratorLoop(_ n: Int) {
     while !cmp(b, e) {
         sum = sum &+ b.pointee
         b = next(b)
+    }
+  }
+  blackHole(sum)
+}
+
+// This function should have comparable performance to
+// `run_CxxVectorOfU32_Sum_Cxx_RangedForLoop`.
+@inline(never)
+public func run_CxxVectorOfU32_Sum_Swift_RawIteratorLoop(_ n: Int) {
+  let vectorOfU32 = makeVector32(vectorSize)
+  var sum: UInt32 = 0
+  for _ in 0..<(n * iterRepeatFactor) {
+    var b = vectorOfU32.__beginUnsafe()
+    let e = vectorOfU32.__endUnsafe()
+    while b != e {
+        sum = sum &+ b.pointee
+        b = b.successor()
     }
   }
   blackHole(sum)

--- a/benchmark/cxx-source/CxxVectorSum.swift
+++ b/benchmark/cxx-source/CxxVectorSum.swift
@@ -48,8 +48,8 @@ public let benchmarks = [
 // establish an expected threshold of performance, which when exceeded should
 // fail the benchmark.
 
-let vectorSize = 100_000
-let iterRepeatFactor = 10
+let vectorSize = 25_000
+let iterRepeatFactor = 5
 
 @inline(never)
 public func run_CxxVectorOfU32_Sum_Cxx_RangedForLoop(_ n: Int) {

--- a/benchmark/cxx-source/CxxVectorSum.swift
+++ b/benchmark/cxx-source/CxxVectorSum.swift
@@ -54,7 +54,7 @@ func makeVectorOnce() {
 // fail the benchmark.
 
 let vectorSize = 25_000
-let iterRepeatFactor = 5
+let iterRepeatFactor = 7
 
 @inline(never)
 public func run_CxxVectorOfU32_Sum_Cxx_RangedForLoop(_ n: Int) {

--- a/benchmark/cxx-source/CxxVectorSum.swift
+++ b/benchmark/cxx-source/CxxVectorSum.swift
@@ -1,0 +1,89 @@
+//===--- CxxVectorSum.swift -----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2012 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// This is a benchmark that tracks how quickly Swift can sum up a C++ vector
+// as compared to the C++ implementation of such sum.
+
+import TestsUtils
+import CxxStdlibPerformance
+import Cxx
+
+public let benchmarks = [
+  BenchmarkInfo(
+      name: "CxxVectorOfU32SumInCxx",
+      runFunction: run_CxxVectorOfU32SumInCxx,
+      tags: [.validation, .bridging, .cxxInterop],
+      setUpFunction: create_CxxVectorOfU32),
+  BenchmarkInfo(
+    name: "CxxVectorOfU32SumInSwift_Fastest",
+    runFunction: run_CxxVectorOfU32SumInSwift_Fastest,
+    tags: [.validation, .bridging, .cxxInterop],
+    setUpFunction: create_CxxVectorOfU32),
+  BenchmarkInfo(
+    name: "CxxVectorOfU32SumInSwift",
+    runFunction: run_CxxVectorOfU32SumInSwift,
+    tags: [.validation, .bridging, .cxxInterop],
+    setUpFunction: create_CxxVectorOfU32)
+]
+
+// FIXME: compare CxxVectorOfU32SumInCxx to CxxVectorOfU32SumInSwift and
+// establish an expected threshold of performance, which when exceeded should
+// fail the benchmark.
+
+var vectorOfU32: VectorOfU32!
+
+func create_CxxVectorOfU32() {
+    vectorOfU32 = makeVector32(1_000_000)
+}
+
+@inline(never)
+public func run_CxxVectorOfU32SumInCxx(_ n: Int) {
+  // FIXME: Use no implicitly copyable, immutable borrow instead.
+  // https://github.com/apple/swift/issues/61454
+  let sum = testVector32Sum(&vectorOfU32)
+  blackHole(sum)
+}
+
+// This function should have comparable performance to `run_CxxVectorOfU32SumInCxx`.
+@inline(never)
+public func run_CxxVectorOfU32SumInSwift_Fastest(_ n: Int) {
+  var sum: UInt32 = 0
+  // begin mutating, end mutating needed to avoid copies right now.
+  var b = vectorOfU32.beginMutating()
+  let e = vectorOfU32.endMutating()
+  while !cmp(b, e) {
+    sum = sum &+ b.pointee
+    b = next(b)
+  }
+  blackHole(sum)
+}
+
+public func !=(_ y: VectorOfU32.const_iterator, _ x: VectorOfU32.const_iterator) -> Bool {
+    return y.__baseUnsafe() != x.__baseUnsafe()
+}
+
+public func ==(_ y: VectorOfU32.const_iterator, _ x: VectorOfU32.const_iterator) -> Bool {
+    return y.__baseUnsafe() == x.__baseUnsafe()
+}
+
+extension VectorOfU32.const_iterator : Equatable, UnsafeCxxInputIterator { }
+
+extension VectorOfU32: CxxSequence {}
+
+@inline(never)
+public func run_CxxVectorOfU32SumInSwift(_ n: Int) {
+    var sum: UInt32 = 0
+    for i in vectorOfU32 {
+        sum = sum &+ i
+    }
+    blackHole(sum)
+}

--- a/benchmark/cxx-source/CxxVectorSum.swift
+++ b/benchmark/cxx-source/CxxVectorSum.swift
@@ -19,52 +19,92 @@ import Cxx
 
 public let benchmarks = [
   BenchmarkInfo(
-      name: "CxxVectorOfU32SumInCxx",
-      runFunction: run_CxxVectorOfU32SumInCxx,
-      tags: [.validation, .bridging, .cxxInterop],
-      setUpFunction: create_CxxVectorOfU32),
+      name: "CxxVectorOfU32.Sum.Cxx.RangedForLoop",
+      runFunction: run_CxxVectorOfU32_Sum_Cxx_RangedForLoop,
+      tags: [.validation, .bridging, .cxxInterop]),
   BenchmarkInfo(
-    name: "CxxVectorOfU32SumInSwift_Fastest",
-    runFunction: run_CxxVectorOfU32SumInSwift_Fastest,
-    tags: [.validation, .bridging, .cxxInterop],
-    setUpFunction: create_CxxVectorOfU32),
+    name: "CxxVectorOfU32.Sum.Swift.ForInLoop",
+    runFunction: run_CxxVectorOfU32_Sum_Swift_ForInLoop,
+    tags: [.validation, .bridging, .cxxInterop]),
   BenchmarkInfo(
-    name: "CxxVectorOfU32SumInSwift",
-    runFunction: run_CxxVectorOfU32SumInSwift,
-    tags: [.validation, .bridging, .cxxInterop],
-    setUpFunction: create_CxxVectorOfU32)
+    name: "CxxVectorOfU32.Sum.Swift.RawIteratorLoop",
+    runFunction: run_CxxVectorOfU32_Sum_Swift_RawIteratorLoop,
+    tags: [.validation, .bridging, .cxxInterop]),
+  BenchmarkInfo(
+    name: "CxxVectorOfU32.Sum.Swift.IndexAndSubscriptLoop",
+    runFunction: run_CxxVectorOfU32_Sum_Swift_IndexAndSubscriptLoop,
+    tags: [.validation, .bridging, .cxxInterop]),
+  BenchmarkInfo(
+    name: "CxxVectorOfU32.Sum.Swift.Reduce",
+    runFunction: run_CxxVectorOfU32_Sum_Swift_Reduce,
+    tags: [.validation, .bridging, .cxxInterop])
 ]
 
 // FIXME: compare CxxVectorOfU32SumInCxx to CxxVectorOfU32SumInSwift and
 // establish an expected threshold of performance, which when exceeded should
 // fail the benchmark.
 
-var vectorOfU32: VectorOfU32!
-
-func create_CxxVectorOfU32() {
-    vectorOfU32 = makeVector32(1_000_000)
-}
+let vectorSize = 100_000
+let iterRepeatFactor = 10
 
 @inline(never)
-public func run_CxxVectorOfU32SumInCxx(_ n: Int) {
-  // FIXME: Use no implicitly copyable, immutable borrow instead.
-  // https://github.com/apple/swift/issues/61454
-  let sum = testVector32Sum(&vectorOfU32)
+public func run_CxxVectorOfU32_Sum_Cxx_RangedForLoop(_ n: Int) {
+  let sum = testVector32Sum(vectorSize, n * iterRepeatFactor)
   blackHole(sum)
 }
 
-// This function should have comparable performance to `run_CxxVectorOfU32SumInCxx`.
 @inline(never)
-public func run_CxxVectorOfU32SumInSwift_Fastest(_ n: Int) {
+public func run_CxxVectorOfU32_Sum_Swift_ForInLoop(_ n: Int) {
+    let vectorOfU32 = makeVector32(vectorSize)
+    var sum: UInt32 = 0
+    for _ in 0..<(n * iterRepeatFactor) {
+      for x in vectorOfU32 {
+        sum = sum &+ x
+      }
+    }
+    blackHole(sum)
+}
+
+// This function should have comparable performance to
+// `run_CxxVectorOfU32_Sum_Cxx_RangedForLoop`.
+@inline(never)
+public func run_CxxVectorOfU32_Sum_Swift_RawIteratorLoop(_ n: Int) {
+  let vectorOfU32 = makeVector32(vectorSize)
   var sum: UInt32 = 0
-  // begin mutating, end mutating needed to avoid copies right now.
-  var b = vectorOfU32.beginMutating()
-  let e = vectorOfU32.endMutating()
-  while !cmp(b, e) {
-    sum = sum &+ b.pointee
-    b = next(b)
+  for _ in 0..<(n * iterRepeatFactor) {
+    var b = vectorOfU32.__beginUnsafe()
+    let e = vectorOfU32.__endUnsafe()
+    while !cmp(b, e) {
+        sum = sum &+ b.pointee
+        b = next(b)
+    }
   }
   blackHole(sum)
+}
+
+@inline(never)
+public func run_CxxVectorOfU32_Sum_Swift_IndexAndSubscriptLoop(_ n: Int) {
+  let vectorOfU32 = makeVector32(vectorSize)
+  var sum: UInt32 = 0
+  for _ in 0..<(n * iterRepeatFactor) {
+    var i = 0
+    let e = vectorOfU32.size()
+    while i != e {
+        sum = sum &+ vectorOfU32[i]
+        i = i &+ 1
+    }
+  }
+  blackHole(sum)
+}
+
+@inline(never)
+public func run_CxxVectorOfU32_Sum_Swift_Reduce(_ n: Int) {
+    let vectorOfU32 = makeVector32(vectorSize)
+    var sum: UInt32 = 0
+    for _ in 0..<(n * iterRepeatFactor) {
+      sum = vectorOfU32.reduce(sum, &+)
+    }
+    blackHole(sum)
 }
 
 public func !=(_ y: VectorOfU32.const_iterator, _ x: VectorOfU32.const_iterator) -> Bool {
@@ -78,12 +118,3 @@ public func ==(_ y: VectorOfU32.const_iterator, _ x: VectorOfU32.const_iterator)
 extension VectorOfU32.const_iterator : Equatable, UnsafeCxxInputIterator { }
 
 extension VectorOfU32: CxxSequence {}
-
-@inline(never)
-public func run_CxxVectorOfU32SumInSwift(_ n: Int) {
-    var sum: UInt32 = 0
-    for i in vectorOfU32 {
-        sum = sum &+ i
-    }
-    blackHole(sum)
-}

--- a/benchmark/cxx-source/CxxVectorSum.swift
+++ b/benchmark/cxx-source/CxxVectorSum.swift
@@ -17,6 +17,10 @@ import TestsUtils
 import CxxStdlibPerformance
 import Cxx
 
+// FIXME: Linux needs fix for https://github.com/apple/swift/issues/61547.
+#if os(Linux)
+public let benchmarks: [BenchmarkInfo] = []
+#else
 public let benchmarks = [
   BenchmarkInfo(
       name: "CxxVecU32.sum.Cxx.rangedForLoop",
@@ -122,3 +126,4 @@ public func run_CxxVectorOfU32_Sum_Swift_Reduce(_ n: Int) {
 extension VectorOfU32.const_iterator : Equatable, UnsafeCxxInputIterator { }
 
 extension VectorOfU32: CxxSequence {}
+#endif

--- a/benchmark/cxx-source/CxxVectorSum.swift
+++ b/benchmark/cxx-source/CxxVectorSum.swift
@@ -19,27 +19,23 @@ import Cxx
 
 public let benchmarks = [
   BenchmarkInfo(
-      name: "CxxVectorOfU32.Sum.Cxx.RangedForLoop",
+      name: "CxxVecU32.Sum.Cxx.RangedForLoop",
       runFunction: run_CxxVectorOfU32_Sum_Cxx_RangedForLoop,
       tags: [.validation, .bridging, .cxxInterop]),
   BenchmarkInfo(
-    name: "CxxVectorOfU32.Sum.Swift.ForInLoop",
+    name: "CxxVecU32.Sum.Swift.ForInLoop",
     runFunction: run_CxxVectorOfU32_Sum_Swift_ForInLoop,
     tags: [.validation, .bridging, .cxxInterop]),
   BenchmarkInfo(
-    name: "CxxVectorOfU32.Sum.Swift.RawIteratorLoop",
+    name: "CxxVecU32.Sum.Swift.IteratorLoop",
     runFunction: run_CxxVectorOfU32_Sum_Swift_RawIteratorLoop,
     tags: [.validation, .bridging, .cxxInterop]),
   BenchmarkInfo(
-    name: "CxxVectorOfU32.Sum.Swift.RawIteratorLoop.WithCxxInlineHelpers",
-    runFunction: run_CxxVectorOfU32_Sum_Swift_RawIteratorLoop_WithCxxInlineHelpers,
-    tags: [.validation, .bridging, .cxxInterop]),
-  BenchmarkInfo(
-    name: "CxxVectorOfU32.Sum.Swift.IndexAndSubscriptLoop",
+    name: "CxxVecU32.Sum.Swift.SubscriptLoop",
     runFunction: run_CxxVectorOfU32_Sum_Swift_IndexAndSubscriptLoop,
     tags: [.validation, .bridging, .cxxInterop]),
   BenchmarkInfo(
-    name: "CxxVectorOfU32.Sum.Swift.Reduce",
+    name: "CxxVecU32.Sum.Swift.Reduce",
     runFunction: run_CxxVectorOfU32_Sum_Swift_Reduce,
     tags: [.validation, .bridging, .cxxInterop])
 ]
@@ -72,23 +68,6 @@ public func run_CxxVectorOfU32_Sum_Swift_ForInLoop(_ n: Int) {
 // This function should have comparable performance to
 // `run_CxxVectorOfU32_Sum_Cxx_RangedForLoop`.
 @inline(never)
-public func run_CxxVectorOfU32_Sum_Swift_RawIteratorLoop_WithCxxInlineHelpers(_ n: Int) {
-  let vectorOfU32 = makeVector32(vectorSize)
-  var sum: UInt32 = 0
-  for _ in 0..<(n * iterRepeatFactor) {
-    var b = vectorOfU32.__beginUnsafe()
-    let e = vectorOfU32.__endUnsafe()
-    while !cmp(b, e) {
-        sum = sum &+ b.pointee
-        b = next(b)
-    }
-  }
-  blackHole(sum)
-}
-
-// This function should have comparable performance to
-// `run_CxxVectorOfU32_Sum_Cxx_RangedForLoop`.
-@inline(never)
 public func run_CxxVectorOfU32_Sum_Swift_RawIteratorLoop(_ n: Int) {
   let vectorOfU32 = makeVector32(vectorSize)
   var sum: UInt32 = 0
@@ -108,11 +87,8 @@ public func run_CxxVectorOfU32_Sum_Swift_IndexAndSubscriptLoop(_ n: Int) {
   let vectorOfU32 = makeVector32(vectorSize)
   var sum: UInt32 = 0
   for _ in 0..<(n * iterRepeatFactor) {
-    var i = 0
-    let e = vectorOfU32.size()
-    while i != e {
-        sum = sum &+ vectorOfU32[i]
-        i = i &+ 1
+    for i in 0..<vectorOfU32.size() {
+      sum = sum &+ vectorOfU32[i]
     }
   }
   blackHole(sum)
@@ -126,14 +102,6 @@ public func run_CxxVectorOfU32_Sum_Swift_Reduce(_ n: Int) {
       sum = vectorOfU32.reduce(sum, &+)
     }
     blackHole(sum)
-}
-
-public func !=(_ y: VectorOfU32.const_iterator, _ x: VectorOfU32.const_iterator) -> Bool {
-    return y.__baseUnsafe() != x.__baseUnsafe()
-}
-
-public func ==(_ y: VectorOfU32.const_iterator, _ x: VectorOfU32.const_iterator) -> Bool {
-    return y.__baseUnsafe() == x.__baseUnsafe()
 }
 
 extension VectorOfU32.const_iterator : Equatable, UnsafeCxxInputIterator { }

--- a/benchmark/cxx-source/CxxVectorSum.swift
+++ b/benchmark/cxx-source/CxxVectorSum.swift
@@ -19,27 +19,27 @@ import Cxx
 
 public let benchmarks = [
   BenchmarkInfo(
-      name: "CxxVecU32.Sum.Cxx.RangedForLoop",
+      name: "CxxVecU32.sum.Cxx.rangedForLoop",
       runFunction: run_CxxVectorOfU32_Sum_Cxx_RangedForLoop,
       tags: [.validation, .bridging, .cxxInterop],
       setUpFunction: makeVectorOnce),
   BenchmarkInfo(
-    name: "CxxVecU32.Sum.Swift.ForInLoop",
+    name: "CxxVecU32.sum.Swift.forInLoop",
     runFunction: run_CxxVectorOfU32_Sum_Swift_ForInLoop,
     tags: [.validation, .bridging, .cxxInterop],
     setUpFunction: makeVectorOnce),
   BenchmarkInfo(
-    name: "CxxVecU32.Sum.Swift.IteratorLoop",
+    name: "CxxVecU32.sum.Swift.iteratorLoop",
     runFunction: run_CxxVectorOfU32_Sum_Swift_RawIteratorLoop,
     tags: [.validation, .bridging, .cxxInterop],
     setUpFunction: makeVectorOnce),
   BenchmarkInfo(
-    name: "CxxVecU32.Sum.Swift.SubscriptLoop",
+    name: "CxxVecU32.sum.Swift.subscriptLoop",
     runFunction: run_CxxVectorOfU32_Sum_Swift_IndexAndSubscriptLoop,
     tags: [.validation, .bridging, .cxxInterop],
     setUpFunction: makeVectorOnce),
   BenchmarkInfo(
-    name: "CxxVecU32.Sum.Swift.Reduce",
+    name: "CxxVecU32.sum.Swift.reduce",
     runFunction: run_CxxVectorOfU32_Sum_Swift_Reduce,
     tags: [.validation, .bridging, .cxxInterop],
     setUpFunction: makeVectorOnce)

--- a/benchmark/cxx-source/CxxVectorSum.swift
+++ b/benchmark/cxx-source/CxxVectorSum.swift
@@ -82,8 +82,10 @@ public func run_CxxVectorOfU32_Sum_Swift_RawIteratorLoop(_ n: Int) {
   blackHole(sum)
 }
 
+// Need to wait for https://github.com/apple/swift/issues/61499
 @inline(never)
 public func run_CxxVectorOfU32_Sum_Swift_IndexAndSubscriptLoop(_ n: Int) {
+#if FIXED_61499
   let vectorOfU32 = makeVector32(vectorSize)
   var sum: UInt32 = 0
   for _ in 0..<(n * iterRepeatFactor) {
@@ -92,6 +94,9 @@ public func run_CxxVectorOfU32_Sum_Swift_IndexAndSubscriptLoop(_ n: Int) {
     }
   }
   blackHole(sum)
+#else
+  run_CxxVectorOfU32_Sum_Swift_RawIteratorLoop(n)
+#endif
 }
 
 @inline(never)

--- a/benchmark/utils/CxxTests/CxxStdlibPerformance.h
+++ b/benchmark/utils/CxxTests/CxxStdlibPerformance.h
@@ -14,10 +14,13 @@ inline VectorOfU32 makeVector32(size_t size) {
     return result;
 }
 
-inline uint32_t testVector32Sum(VectorOfU32 &vector) {
+inline uint32_t testVector32Sum(size_t vectorSize, size_t iters) {
+    auto vector = makeVector32(vectorSize);
     auto sum = uint32_t(0);
-    for (auto i : vector) {
-        sum += i;
+    for (size_t i = 0; i < iters; ++i) {
+        for (auto x : vector) {
+            sum += x;
+        }
     }
     return sum;
 }

--- a/benchmark/utils/CxxTests/CxxStdlibPerformance.h
+++ b/benchmark/utils/CxxTests/CxxStdlibPerformance.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+using VectorOfU32 = std::vector<uint32_t>;
+
+inline VectorOfU32 makeVector32(size_t size) {
+    auto result = VectorOfU32();
+    result.reserve(size);
+    for (size_t i = 0; i < size; ++i) {
+        result.push_back(uint32_t(i));
+    }
+    return result;
+}
+
+inline uint32_t testVector32Sum(VectorOfU32 &vector) {
+    auto sum = uint32_t(0);
+    for (auto i : vector) {
+        sum += i;
+    }
+    return sum;
+}
+
+template<class T>
+inline T next(const T& i) { return i + 1; }
+
+template<class T>
+inline bool cmp(const T &lhs, const T &rhs) { return lhs == rhs; }

--- a/benchmark/utils/CxxTests/CxxStdlibPerformance.h
+++ b/benchmark/utils/CxxTests/CxxStdlibPerformance.h
@@ -25,8 +25,5 @@ inline uint32_t testVector32Sum(size_t vectorSize, size_t iters) {
     return sum;
 }
 
-template<class T>
-inline T next(const T& i) { return i + 1; }
-
-template<class T>
-inline bool cmp(const T &lhs, const T &rhs) { return lhs == rhs; }
+// FIXME: remove when the templated operator == is correctly bridged.
+inline bool operator ==(const VectorOfU32::const_iterator &lhs, const VectorOfU32::const_iterator &rhs) { return lhs.base() == rhs.base(); }

--- a/benchmark/utils/CxxTests/CxxStdlibPerformance.h
+++ b/benchmark/utils/CxxTests/CxxStdlibPerformance.h
@@ -5,13 +5,21 @@
 
 using VectorOfU32 = std::vector<uint32_t>;
 
-inline VectorOfU32 makeVector32(size_t size) {
-    auto result = VectorOfU32();
-    result.reserve(size);
-    for (size_t i = 0; i < size; ++i) {
-        result.push_back(uint32_t(i));
+static inline VectorOfU32 vec;
+
+inline void initVector(size_t size) {
+    if (!vec.empty()) {
+        return;
     }
-    return result;
+    vec.reserve(size);
+    for (size_t i = 0; i < size; ++i) {
+        vec.push_back(uint32_t(i));
+    }
+}
+
+inline VectorOfU32 makeVector32(size_t size) {
+    initVector(size);
+    return vec;
 }
 
 inline uint32_t testVector32Sum(size_t vectorSize, size_t iters) {

--- a/benchmark/utils/CxxTests/module.modulemap
+++ b/benchmark/utils/CxxTests/module.modulemap
@@ -7,3 +7,8 @@ module CxxSubscripts {
   header "Subscripts.h"
   requires cplusplus
 }
+
+module CxxStdlibPerformance {
+  header "CxxStdlibPerformance.h"
+  requires cplusplus
+}

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -50,6 +50,7 @@ import ClassArrayGetter
 import CodableTest
 import Combos
 import CreateObjects
+import CxxVectorSum
 import DataBenchmarks
 import DeadArray
 import DevirtualizeProtocolComposition
@@ -233,6 +234,7 @@ register(CodableTest.benchmarks)
 register(Combos.benchmarks)
 register(ClassArrayGetter.benchmarks)
 register(CreateObjects.benchmarks)
+register(CxxVectorSum.benchmarks)
 register(DataBenchmarks.benchmarks)
 register(DeadArray.benchmarks)
 register(DevirtualizeProtocolComposition.benchmarks)


### PR DESCRIPTION
…n C++ vs Swift

This benchmark compares the performance of summing up a vector of a million elements between Swift and C++.

Initial numbers on M1 Mac:

```
#,TEST,SAMPLES,MIN(μs),MAX(μs),MEAN(μs),SD(μs),MEDIAN(μs)
139,CreateObjects,200,11,29,14,2,15
140,CxxVectorOfU32SumInCxx,200,77,107,95,7,93
141,CxxVectorOfU32SumInSwift,36,24980,27957,25654,646,25546
142,CxxVectorOfU32SumInSwift_Fastest,200,77,83,77,1,77
```

We're investigating why the `CxxVectorOfU32SumInSwift` is slower and how to correctly fix it.