### PR TITLE
Sign executables for target Apple platforms with a post build event

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -2668,17 +2668,9 @@ function(add_swift_target_executable name)
         # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/5291)
         set_property(TARGET ${VARIANT_NAME} PROPERTY OSX_ARCHITECTURES "${arch}")
 
-        add_custom_command_target(unused_var2
-         COMMAND "codesign" "-f" "-s" "-" "${SWIFT_RUNTIME_OUTPUT_INTDIR}/${VARIANT_NAME}"
-         CUSTOM_TARGET_NAME "${VARIANT_NAME}_signed"
-         OUTPUT "${SWIFT_RUNTIME_OUTPUT_INTDIR}/${VARIANT_NAME}_signed"
-         DEPENDS ${VARIANT_NAME})
-      else()
-        # No code signing on other platforms.
-        add_custom_command_target(unused_var2
-         CUSTOM_TARGET_NAME "${VARIANT_NAME}_signed"
-         OUTPUT "${SWIFT_RUNTIME_OUTPUT_INTDIR}/${VARIANT_NAME}_signed"
-         DEPENDS ${VARIANT_NAME})
+        add_custom_command(TARGET ${VARIANT_NAME}
+          POST_BUILD
+         COMMAND "codesign" "-f" "-s" "-" "${SWIFT_RUNTIME_OUTPUT_INTDIR}/${VARIANT_NAME}")
        endif()
     endforeach()
   endforeach()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -308,7 +308,7 @@ foreach(SDK ${SWIFT_SDKS})
               "swift-reflection-test${DEFAULT_OSX_VARIANT_SUFFIX}")
         else()
           list(APPEND test_dependencies
-              "swift-reflection-test${VARIANT_SUFFIX}_signed")
+              "swift-reflection-test${VARIANT_SUFFIX}")
         endif()
       endif()
 


### PR DESCRIPTION
...instead of using ad hoc targets.

This way executables are already signed before running tests, and this will happen even if users want to test manually with `lit.py`.

Addresses rdar://66654434