### PR TITLE
[CanonicalizeOSSALifetime] Extend Onone lifetimes.

### DIFF
--- a/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
@@ -130,7 +130,7 @@ void diagnoseRequiredCopyOfMoveOnly(Operand *use,
 ///
 /// This result remains valid during copy rewriting. The only instructions
 /// referenced it contains are consumes that cannot be deleted.
-class CanonicalOSSAConsumeInfo {
+class CanonicalOSSAConsumeInfo final {
   /// Map blocks on the lifetime boundary to the last consuming instruction.
   llvm::SmallDenseMap<SILBasicBlock *, SILInstruction *, 4> finalBlockConsumes;
 
@@ -159,6 +159,10 @@ public:
     return false;
   }
 
+  CanonicalOSSAConsumeInfo() {}
+  CanonicalOSSAConsumeInfo(CanonicalOSSAConsumeInfo const &) = delete;
+  CanonicalOSSAConsumeInfo &
+  operator=(CanonicalOSSAConsumeInfo const &) = delete;
   SWIFT_ASSERT_ONLY_DECL(void dump() const LLVM_ATTRIBUTE_USED);
 };
 
@@ -169,7 +173,7 @@ public:
 ///
 /// TODO: Move all the private per-definition members into an implementation
 /// class in the .cpp file.
-class CanonicalizeOSSALifetime {
+class CanonicalizeOSSALifetime final {
 public:
   /// Find the original definition of a potentially copied value. \p copiedValue
   /// must be an owned value. It is usually a copy but may also be a destroy.
@@ -331,7 +335,7 @@ public:
 
   InstModCallbacks &getCallbacks() { return deleter.getCallbacks(); }
 
-protected:
+private:
   void recordDebugValue(DebugValueInst *dvi) { debugValues.insert(dvi); }
 
   void recordConsumingUse(Operand *use) {

--- a/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
@@ -304,6 +304,7 @@ public:
     // analysis, freeing its memory.
     accessBlocks = nullptr;
     consumes.clear();
+    destroys.clear();
 
     liveness.initializeDef(def);
   }

--- a/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
@@ -347,7 +347,10 @@ private:
 
   void extendLivenessThroughOverlappingAccess();
 
-  void findExtendedBoundary(PrunedLivenessBoundary &boundary);
+  void findOriginalBoundary(PrunedLivenessBoundary &boundary);
+
+  void findExtendedBoundary(PrunedLivenessBoundary const &originalBoundary,
+                            PrunedLivenessBoundary &boundary);
 
   void insertDestroysOnBoundary(PrunedLivenessBoundary const &boundary);
 

--- a/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
@@ -240,9 +240,6 @@ private:
   /// Visited set for general def-use traversal that prevents revisiting values.
   GraphNodeWorklist<SILValue, 8> defUseWorklist;
 
-  /// Visited set general CFG traversal that prevents revisiting blocks.
-  GraphNodeWorklist<SILBasicBlock *, 8> blockWorklist;
-
   /// Pruned liveness for the extended live range including copies. For this
   /// purpose, only consuming instructions are considered "lifetime
   /// ending". end_borrows do not end a liverange that may include owned copies.

--- a/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
@@ -349,7 +349,7 @@ private:
 
   void findExtendedBoundary(PrunedLivenessBoundary &boundary);
 
-  void insertDestroysOnBoundary(PrunedLivenessBoundary &boundary);
+  void insertDestroysOnBoundary(PrunedLivenessBoundary const &boundary);
 
   void rewriteCopies();
 };

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressChecker.cpp
@@ -746,7 +746,9 @@ struct MoveOnlyChecker {
           instToDelete->eraseFromParent();
         })),
         canonicalizer(
-            false /*pruneDebugMode*/, accessBlockAnalysis, domTree, deleter,
+            false /*pruneDebugMode*/,
+            !fn->shouldOptimize() /*maximizeLifetime*/, accessBlockAnalysis,
+            domTree, deleter,
             [&](Operand *use) { consumingUsesNeedingCopy.push_back(use); },
             [&](Operand *use) { finalConsumingUses.push_back(use); }) {}
 

--- a/lib/SILOptimizer/Mandatory/MoveOnlyObjectChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyObjectChecker.cpp
@@ -401,8 +401,9 @@ bool MoveOnlyChecker::check(NonLocalAccessBlockAnalysis *accessBlockAnalysis,
   };
 
   CanonicalizeOSSALifetime canonicalizer(
-      false /*pruneDebugMode*/, accessBlockAnalysis, domTree, deleter,
-      foundConsumingUseNeedingCopy, foundConsumingUseNotNeedingCopy);
+      false /*pruneDebugMode*/, !fn->shouldOptimize() /*maximizeLifetime*/,
+      accessBlockAnalysis, domTree, deleter, foundConsumingUseNeedingCopy,
+      foundConsumingUseNotNeedingCopy);
   auto moveIntroducers = llvm::makeArrayRef(moveIntroducersToProcess.begin(),
                                             moveIntroducersToProcess.end());
   SmallPtrSet<MarkMustCheckInst *, 4> valuesWithDiagnostics;

--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -350,8 +350,10 @@ void SILCombiner::canonicalizeOSSALifetimes(SILInstruction *currentInst) {
   InstructionDeleter deleter(std::move(canonicalizeCallbacks));
 
   DominanceInfo *domTree = DA->get(&Builder.getFunction());
-  CanonicalizeOSSALifetime canonicalizer(false /*prune debug*/, NLABA, domTree,
-                                         deleter);
+  CanonicalizeOSSALifetime canonicalizer(
+      false /*prune debug*/,
+      !parentTransform->getFunction()->shouldOptimize() /*maximize lifetime*/,
+      NLABA, domTree, deleter);
   CanonicalizeBorrowScope borrowCanonicalizer(deleter);
 
   while (!defsToCanonicalize.empty()) {

--- a/lib/SILOptimizer/Transforms/CopyPropagation.cpp
+++ b/lib/SILOptimizer/Transforms/CopyPropagation.cpp
@@ -373,9 +373,9 @@ static bool sinkOwnedForward(SILInstruction *ownedForward,
 namespace {
 
 class CopyPropagation : public SILFunctionTransform {
-  /// True if debug_value instructions should be pruned.
+  /// If true, debug_value instructions should be pruned.
   bool pruneDebug;
-  /// True if all values should be canonicalized.
+  /// If true, all values will be canonicalized.
   bool canonicalizeAll;
   /// If true, then borrow scopes will be canonicalized, allowing copies of
   /// guaranteed values to be optimized. Does *not* shrink the borrow scope.

--- a/lib/SILOptimizer/Transforms/CopyPropagation.cpp
+++ b/lib/SILOptimizer/Transforms/CopyPropagation.cpp
@@ -437,8 +437,9 @@ void CopyPropagation::run() {
 
   // canonicalizer performs all modifications through deleter's callbacks, so we
   // don't need to explicitly check for changes.
-  CanonicalizeOSSALifetime canonicalizer(pruneDebug, accessBlockAnalysis,
-                                         domTree, deleter);
+  CanonicalizeOSSALifetime canonicalizer(
+      pruneDebug, /*maximizeLifetime=*/!getFunction()->shouldOptimize(),
+      accessBlockAnalysis, domTree, deleter);
 
   // NOTE: We assume that the function is in reverse post order so visiting the
   //       blocks and pushing begin_borrows as we see them and then popping them

--- a/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
@@ -110,7 +110,7 @@ static DestroyValueInst *dynCastToDestroyOf(SILInstruction *instruction,
 }
 
 //===----------------------------------------------------------------------===//
-//                    MARK: Step 1. Compute pruned liveness
+// MARK: Step 1. Compute pruned liveness
 //===----------------------------------------------------------------------===//
 
 bool CanonicalizeOSSALifetime::computeCanonicalLiveness() {

--- a/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
@@ -657,8 +657,8 @@ static void insertDestroyBeforeInstruction(SILInstruction *nextInstruction,
   ++NumDestroysGenerated;
 }
 
-/// Populate `consumes` with the final destroy points once copies are
-/// eliminated. This only applies to owned values.
+/// Inserts destroys along the boundary where needed and records all final
+/// consuming uses.
 ///
 /// Observations:
 /// - currentDef must be postdominated by some subset of its

--- a/test/SILOptimizer/copy_propagation.sil
+++ b/test/SILOptimizer/copy_propagation.sil
@@ -668,27 +668,13 @@ bb1:
 
 // Original Overlapping (unnecessarily extends pruned liveness):
 //
-// TODO: this copy could be avoided but is probably an unusual case,
-// and sinking the destroy outside the access scope might help to
-// optimize the access itself.
-//
-//     %def
-//     begin_access // access scope unrelated to def
-//     use %def     // pruned liveness ends here
-//     br bb1
-// bb1:
-//     destroy %def
-//     end_access
-//
 // CHECK-LABEL: sil [ossa] @testOriginalOverlapInDeadBlock : $@convention(thin) () -> () {
 // CHECK:   [[DEF:%.*]] = apply %{{.*}}() : $@convention(thin) () -> @owned AnyObject
 // CHECK:   begin_access
-// CHECK:   [[COPY:%.*]] = copy_value [[DEF]] : $AnyObject
-// CHECK:   store [[COPY]] to [init] %{{.*}} : $*AnyObject
+// CHECK:   store [[DEF]] to [init] %{{.*}} : $*AnyObject
 // CHECK:   br bb1
 // CHECK: bb1:
 // CHECK:   end_access
-// CHECK:   destroy_value [[DEF]] : $AnyObject
 // CHECK-LABEL: } // end sil function 'testOriginalOverlapInDeadBlock'
 sil [ossa] @testOriginalOverlapInDeadBlock : $@convention(thin) () -> () {
 bb0:

--- a/test/SILOptimizer/copy_propagation_onone.sil
+++ b/test/SILOptimizer/copy_propagation_onone.sil
@@ -1,0 +1,665 @@
+// RUN: %target-sil-opt -copy-propagation -canonical-ossa-rewrite-borrows -enable-sil-verify-all -opt-mode=none %s | %FileCheck %s --check-prefixes=CHECK,CHECK-ONONE
+
+class C {}
+
+sil [ossa] @get : $@convention(thin) () -> @owned C
+
+sil [ossa] @see : $@convention(thin) (@guaranteed C) -> ()
+
+sil [ossa] @end : $@convention(thin) (@owned C) -> ()
+
+sil [ossa] @other : $@convention(thin) () -> ()
+
+// Standard -O copy-propagation behavior.
+//
+// CHECK-LABEL: sil [ossa] @diamond__consume_lb__use_r : {{.*}} {
+// CHECK:       [[INSTANCE:%[^,]+]] = apply
+// CHECK:       cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:     [[LEFT]]:
+// CHECK:       apply {{%[^,]+}}([[INSTANCE]])
+// CHECK:       apply {{%[^,]+}}([[INSTANCE]])
+// CHECK:       br [[BOTTOM:bb[0-9]+]]
+// CHECK:     [[RIGHT]]:
+// CHECK:       [[COPY:%[^,]+]] = copy_value [[INSTANCE]] :
+// CHECK:       apply {{%[^,]+}}([[COPY]])
+// CHECK:       br [[BOTTOM]]
+// CHECK:     [[BOTTOM]]:
+// CHECK:       store [[INSTANCE]]
+// CHECK-LABEL: } // end sil function 'diamond__consume_lb__use_r'
+sil [ossa] @diamond__consume_lb__use_r : $@convention(thin) () -> @out C {
+top(%addr : $*C):
+    %get = function_ref @get : $@convention(thin) () -> @owned C
+    %instance = apply %get() : $@convention(thin) () -> @owned C
+    %copy = copy_value %instance : $C
+    cond_br undef, left, right
+left:
+    %see = function_ref @see : $@convention(thin) (@guaranteed C) -> ()
+    apply %see(%instance) : $@convention(thin) (@guaranteed C) -> ()
+    destroy_value %instance : $C
+    apply %see(%copy) : $@convention(thin) (@guaranteed C) -> ()
+    br bottom
+right:
+    %end = function_ref @end : $@convention(thin) (@owned C) -> ()
+    apply %end(%instance) : $@convention(thin) (@owned C) -> ()
+    br bottom
+bottom:
+    store %copy to [init] %addr : $*C
+    %retval = tuple ()
+    return %retval : $()
+}
+
+// There is a consuming use in right.  So bottom is a consumed block.  Liveness
+// is retracted up to the consume in right and up to the bottom of left.
+// CHECK-LABEL: sil [ossa] @diamond__consume_r__use_l__destroy_b : {{.*}} {
+// CHECK:         [[INSTANCE:%[^,]+]] = apply
+// CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[LEFT]]:
+// CHECK:         apply {{%[^,]+}}([[INSTANCE]])
+// CHECK:         destroy_value [[INSTANCE]] : $C
+// CHECK:         br [[BOTTOM:bb[0-9]+]]
+// CHECK:       [[RIGHT]]:
+// CHECK:         apply {{%[^,]+}}([[INSTANCE]])
+// CHECK:         br [[BOTTOM]]
+// CHECK:       [[BOTTOM]]:
+// CHECK-NOT:     destroy_value [[INSTANCE]]
+// CHECK-LABEL: } // end sil function 'diamond__consume_r__use_l__destroy_b'
+sil [ossa] @diamond__consume_r__use_l__destroy_b : $@convention(thin) () -> () {
+top:
+    %get = function_ref @get : $@convention(thin) () -> @owned C
+    %instance = apply %get() : $@convention(thin) () -> @owned C
+    %copy = copy_value %instance : $C
+    cond_br undef, left, right
+left:
+    destroy_value %copy : $C
+    %see = function_ref @see : $@convention(thin) (@guaranteed C) -> ()
+    apply %see(%instance) : $@convention(thin) (@guaranteed C) -> ()
+    br bottom
+right:
+    %end = function_ref @end : $@convention(thin) (@owned C) -> ()
+    apply %end(%copy) : $@convention(thin) (@owned C) -> ()
+    br bottom
+bottom:
+    destroy_value %instance : $C
+    %retval = tuple ()
+    return %retval : $()
+}
+
+// Only the consuming in r2 counts as a consume, so only bottom is a consumed
+// block.
+// CHECK-LABEL: sil [ossa] @diamond_2r__consume_r1r2__use_l__destroy_b : {{.*}} {
+// CHECK:         [[INSTANCE:%[^,]+]] = apply
+// CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT1:bb[0-9]+]]
+// CHECK:       [[LEFT]]:
+// CHECK:         apply {{%[^,]+}}([[INSTANCE:%[^,]+]]) : $@convention(thin) (@guaranteed C) -> ()
+// CHECK:         destroy_value [[INSTANCE:%[^,]+]] : $C
+// CHECK:         br [[BOTTOM:bb[0-9]+]]
+// CHECK:       [[RIGHT1]]:
+// CHECK:         [[COPY:%[^,]+]] = copy_value [[INSTANCE:%[^,]+]] : $C
+// CHECK:         apply {{%[^,]+}}([[COPY]])
+// CHECK:         br [[RIGHT2:bb[0-9]+]]
+// CHECK:       [[RIGHT2]]:
+// CHECK:         apply {{%[^,]+}}([[INSTANCE:%[^,]+]])
+// CHECK-NOT:     destroy_value
+// CHECK:         br [[BOTTOM]]
+// CHECK:       [[BOTTOM]]:
+// CHECK-NOT: destroy_value
+// CHECK-LABEL: } // end sil function 'diamond_2r__consume_r1r2__use_l__destroy_b'
+sil [ossa] @diamond_2r__consume_r1r2__use_l__destroy_b : $@convention(thin) () -> () {
+top:
+    %get = function_ref @get : $@convention(thin) () -> @owned C
+    %instance = apply %get() : $@convention(thin) () -> @owned C
+    %copy = copy_value %instance : $C
+    %copy2 = copy_value %copy : $C
+    cond_br undef, left, right
+left:
+    destroy_value %copy : $C
+    destroy_value %copy2 : $C
+    %see = function_ref @see : $@convention(thin) (@guaranteed C) -> ()
+    apply %see(%instance) : $@convention(thin) (@guaranteed C) -> ()
+    br bottom
+right:
+    %end = function_ref @end : $@convention(thin) (@owned C) -> ()
+    apply %end(%copy) : $@convention(thin) (@owned C) -> ()
+    br right2
+right2:
+    apply %end(%copy2) : $@convention(thin) (@owned C) -> ()
+    br bottom
+bottom:
+    destroy_value %instance : $C
+    %retval = tuple ()
+    return %retval : $()
+}
+
+// There are no consuming uses, so avoiding copies doesn't entail shortening the
+// lifetime.
+// CHECK-LABEL: sil [ossa] @diamond__use_lr__destroy_b : {{.*}} {
+// CHECK:         [[INSTANCE:%[^,]+]] = apply
+// CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[LEFT]]:
+// CHECK:         apply {{%[^,]+}}([[INSTANCE]])
+// CHECK:         br [[BOTTOM:bb[0-9]+]]
+// CHECK:       [[RIGHT]]:
+// CHECK:         apply {{%[^,]+}}([[INSTANCE]])
+// CHECK:         br [[BOTTOM]]
+// CHECK:       [[BOTTOM]]:
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK-LABEL: } // end sil function 'diamond__use_lr__destroy_b'
+sil [ossa] @diamond__use_lr__destroy_b : $@convention(thin) () -> () {
+top:
+    %get = function_ref @get : $@convention(thin) () -> @owned C
+    %instance = apply %get() : $@convention(thin) () -> @owned C
+    %copy = copy_value %instance : $C
+    %see = function_ref @see : $@convention(thin) (@guaranteed C) -> ()
+    cond_br undef, left, right
+left:
+    apply %see(%instance) : $@convention(thin) (@guaranteed C) -> ()
+    br bottom
+right:
+    apply %see(%copy) : $@convention(thin) (@guaranteed C) -> ()
+    br bottom
+bottom:
+    destroy_value %instance : $C
+    destroy_value %copy : $C
+    %retval = tuple ()
+    return %retval : $()
+}
+
+// Don't shorten the lifetime if there's a single consuming use.
+// CHECK-LABEL: sil [ossa] @line_3__use_m__destroy_b : {{.*}} {
+// CHECK:         [[INSTANCE:%[^,]+]] = apply
+// CHECK:         br [[MIDDLE:bb[0-9]+]]
+// CHECK:       [[MIDDLE]]:
+// CHECK:         apply {{%[^,]+}}([[INSTANCE]])
+// CHECK:         br [[BOTTOM:bb[0-9]+]]
+// CHECK:       [[BOTTOM]]:
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK-LABEL: } // end sil function 'line_3__use_m__destroy_b'
+sil [ossa] @line_3__use_m__destroy_b : $@convention(thin) () -> () {
+top:
+    %get = function_ref @get : $@convention(thin) () -> @owned C
+    %instance = apply %get() : $@convention(thin) () -> @owned C
+    %see = function_ref @see : $@convention(thin) (@guaranteed C) -> ()
+    br middle
+middle:
+    apply %see(%instance) : $@convention(thin) (@guaranteed C) -> ()
+    br bottom
+bottom:
+    destroy_value %instance : $C
+    %retval = tuple ()
+    return %retval : $()
+}
+
+// Don't shorten the unconsumed lifetime on the left side.
+// CHECK-LABEL: sil [ossa] @diamond_2l_2r__consume_r1__use_l1__destroy_l2 : {{.*}} {
+// CHECK:         [[INSTANCE:%[^,]+]] = apply
+// CHECK:         cond_br undef, [[LEFT1:bb[0-9]+]], [[RIGHT1:bb[0-9]+]]
+// CHECK:       [[LEFT1]]:
+// CHECK:         apply {{%[^,]+}}([[INSTANCE]])
+// CHECK:         br [[LEFT2:bb[0-9]+]]
+// CHECK:       [[LEFT2]]:
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:       [[RIGHT1]]:
+// CHECK:         apply {{%[^,]+}}([[INSTANCE]])
+// CHECK-LABEL: } // end sil function 'diamond_2l_2r__consume_r1__use_l1__destroy_l2'
+sil [ossa] @diamond_2l_2r__consume_r1__use_l1__destroy_l2 : $@convention(thin) () -> () {
+top:
+    %get = function_ref @get : $@convention(thin) () -> @owned C
+    %instance = apply %get() : $@convention(thin) () -> @owned C
+    cond_br undef, left, right
+left:
+    %see = function_ref @see : $@convention(thin) (@guaranteed C) -> ()
+    apply %see(%instance) : $@convention(thin) (@guaranteed C) -> ()
+    br left2
+left2:
+    destroy_value %instance : $C
+    br bottom
+right:
+    %end = function_ref @end : $@convention(thin) (@owned C) -> ()
+    apply %end(%instance) : $@convention(thin) (@owned C) -> ()
+    br right2
+right2:
+    br bottom
+bottom:
+    %retval = tuple ()
+    return %retval : $()
+}
+
+// Verify that lifetime is not shortened up to boundary block if destroy was
+// previously in its unique successor.
+// CHECK-LABEL: sil [ossa] @doublediamond_2d2l__consume_r11_r21__use_l11__destroy_l11_l22 : $@convention(thin) () -> () {
+// CHECK:         [[INSTANCE:%[^,]+]] = apply
+// CHECK:         cond_br undef, [[LEFT11:bb[0-9]+]], [[RIGHT11:bb[0-9]+]]
+// CHECK:       [[LEFT11]]:
+// CHECK:         apply {{%[^,]+}}([[INSTANCE]]) : $@convention(thin) (@guaranteed C) -> ()
+// CHECK:         br [[MIDDLE:bb[0-9]+]]
+// CHECK:       [[RIGHT11]]:
+// CHECK:         [[COPY:%[^,]+]] = copy_value [[INSTANCE]]
+// CHECK:         apply {{%[^,]+}}([[COPY]])
+// CHECK:         br [[MIDDLE]]
+// CHECK:       [[MIDDLE]]:
+// CHECK:         cond_br undef, [[LEFT21:bb[0-9]+]], [[RIGHT21:bb[0-9]+]]
+// CHECK:       [[LEFT21]]:
+// CHECK:         br [[LEFT22:bb[0-9]+]]
+// CHECK:       [[LEFT22]]:
+//                The main check: the destroy hasn't been hoisted.
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[RIGHT21]]:
+// CHECK:         apply {{%[^,]+}}([[INSTANCE]])
+// CHECK:         br [[EXIT]]
+// CHECK-LABEL: } // end sil function 'doublediamond_2d2l__consume_r11_r21__use_l11__destroy_l11_l22'
+sil [ossa] @doublediamond_2d2l__consume_r11_r21__use_l11__destroy_l11_l22 : $@convention(thin) () -> () {
+top:
+    %get = function_ref @get : $@convention(thin) () -> @owned C
+    %see = function_ref @see : $@convention(thin) (@guaranteed C) -> ()
+    %end = function_ref @end : $@convention(thin) (@owned C) -> ()
+    %instance = apply %get() : $@convention(thin) () -> @owned C
+    %copy = copy_value %instance : $C
+    cond_br undef, left11, right11
+left11:
+    apply %see(%instance) : $@convention(thin) (@guaranteed C) -> ()
+    destroy_value %instance : $C
+    br middle
+right11:
+    apply %end(%instance) : $@convention(thin) (@owned C) -> ()
+    br middle
+middle:
+    cond_br undef, left21, right21
+left21:
+    br left22
+
+left22:
+    destroy_value %copy : $C
+    br bottom
+right21:
+    apply %end(%copy) : $@convention(thin) (@owned C) -> ()
+    br bottom
+bottom:
+    %retval = tuple ()
+    return %retval : $()
+}
+
+
+// Verify that we don't shrink the lifetime even when there was a destroy
+// already in the barrier block (left21).
+// CHECK-LABEL: sil [ossa] @doublediamond_2d2l__consume_r11_r21__use_l11__destroy_l11_l21_l22_r21 : {{.*}} {
+// CHECK:         [[INSTANCE:%[^,]+]] = apply
+// CHECK:         cond_br undef, [[LEFT11:bb[0-9]+]], [[RIGHT11:bb[0-9]+]]
+// CHECK:       [[LEFT11]]:
+// CHECK:         apply {{%[^,]+}}([[INSTANCE]])
+// CHECK:         br [[MIDDLE:bb[0-9]+]]
+// CHECK:       [[RIGHT11]]:
+// CHECK:         [[COPY:%[^,]+]] = copy_value [[INSTANCE]]
+// CHECK:         apply {{%[^,]+}}([[COPY]])
+// CHECK:         br [[MIDDLE]]
+// CHECK:       [[MIDDLE]]:
+// CHECK:         cond_br undef, [[LEFT21:bb[0-9]+]], [[RIGHT21:bb[0-9]+]]
+// CHECK:       [[LEFT21]]:
+// CHECK:         br [[LEFT22:bb[0-9]+]]
+// CHECK:       [[LEFT22]]:
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[RIGHT21]]:
+// CHECK:         apply {{%[^,]+}}([[INSTANCE]])
+// CHECK:         br [[EXIT]]
+// CHECK:       [[EXIT]]:
+// CHECK-LABEL: } // end sil function 'doublediamond_2d2l__consume_r11_r21__use_l11__destroy_l11_l21_l22_r21'
+sil [ossa] @doublediamond_2d2l__consume_r11_r21__use_l11__destroy_l11_l21_l22_r21 : $@convention(thin) () -> () {
+top:
+    %get = function_ref @get : $@convention(thin) () -> @owned C
+    %see = function_ref @see : $@convention(thin) (@guaranteed C) -> ()
+    %end = function_ref @end : $@convention(thin) (@owned C) -> ()
+    %instance = apply %get() : $@convention(thin) () -> @owned C
+    %copy = copy_value %instance : $C
+    cond_br undef, left1, right1
+left1:
+    apply %see(%instance) : $@convention(thin) (@guaranteed C) -> ()
+    destroy_value %instance : $C
+    br middle
+right1:
+    apply %end(%instance) : $@convention(thin) (@owned C) -> ()
+    br middle
+middle:
+    %copy2 = copy_value %copy : $C
+    cond_br undef, left21, right21
+left21:
+    destroy_value %copy2 : $C
+    br left22
+
+left22:
+    destroy_value %copy : $C
+    br bottom
+right21:
+    destroy_value %copy2 : $C
+    apply %end(%copy) : $@convention(thin) (@owned C) -> ()
+    br bottom
+bottom:
+    %retval = tuple ()
+    return %retval : $()
+}
+
+// Verify that lifetime ends in boundary block when there is an extra copy and
+// both it and the original are destroyed in the boundary block.
+// 
+// CHECK-LABEL: sil [ossa] @doublediamond__consume_r11_r21__use_l11__destroy_l11_l21_r21 : {{.*}} {
+// CHECK:         [[INSTANCE:%[^,]+]] = apply
+// CHECK:         cond_br undef, [[LEFT11:bb[0-9]+]], [[RIGHT11:bb[0-9]+]]
+// CHECK:       [[LEFT11]]:
+// CHECK:         apply {{%[^,]+}}([[INSTANCE]])
+// CHECK:         br [[MIDDLE:bb[0-9]+]]
+// CHECK:       [[RIGHT11]]:
+// CHECK:         [[COPY:%[^,]+]] = copy_value [[INSTANCE]]
+// CHECK:         apply {{%[^,]+}}([[COPY]])
+// CHECK:         br [[MIDDLE]]
+// CHECK:       [[MIDDLE]]:
+// CHECK:         cond_br undef, [[LEFT21:bb[0-9]+]], [[RIGHT21:bb[0-9]+]]
+// CHECK:       [[LEFT21]]:
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[RIGHT21]]:
+// CHECK:         apply {{%[^,]+}}([[INSTANCE]])
+// CHECK:         br [[EXIT]]
+// CHECK-LABEL: } // end sil function 'doublediamond__consume_r11_r21__use_l11__destroy_l11_l21_r21'
+sil [ossa] @doublediamond__consume_r11_r21__use_l11__destroy_l11_l21_r21 : $@convention(thin) () -> () {
+top:
+    %get = function_ref @get : $@convention(thin) () -> @owned C
+    %see = function_ref @see : $@convention(thin) (@guaranteed C) -> ()
+    %end = function_ref @end : $@convention(thin) (@owned C) -> ()
+    %instance = apply %get() : $@convention(thin) () -> @owned C
+    %copy = copy_value %instance : $C
+    cond_br undef, left11, right11
+left11:
+    apply %see(%instance) : $@convention(thin) (@guaranteed C) -> ()
+    destroy_value %instance : $C
+    br middle
+right11:
+    apply %end(%instance) : $@convention(thin) (@owned C) -> ()
+    br middle
+middle:
+    %copy2 = copy_value %copy : $C
+    cond_br undef, left21, right21
+left21:
+    destroy_value %copy2 : $C
+    destroy_value %copy : $C
+    br bottom
+right21:
+    destroy_value %copy2 : $C
+    apply %end(%copy) : $@convention(thin) (@owned C) -> ()
+    br bottom
+bottom:
+    %retval = tuple ()
+    return %retval : $()
+}
+
+// Verify that we don't hoist destroys up to a dead arg.
+// CHECK-LABEL: sil [ossa] @line_2__def_arg_b__destroy_b : $@convention(thin) () -> () {
+// CHECK:         [[INSTANCE:%[^,]+]] = apply
+// CHECK:         br [[BOTTOM:bb[0-9]+]]([[INSTANCE]] :
+// CHECK:       [[BOTTOM]]([[PHI:%[^,]+]] :
+// CHECK:         apply
+// CHECK:         apply
+// CHECK:         destroy_value [[PHI]]
+// CHECK-LABEL: } // end sil function 'line_2__def_arg_b__destroy_b'
+sil [ossa] @line_2__def_arg_b__destroy_b : $@convention(thin) () -> () {
+top:
+    %get = function_ref @get : $@convention(thin) () -> @owned C
+    %see = function_ref @see : $@convention(thin) (@guaranteed C) -> ()
+    %end = function_ref @end : $@convention(thin) (@owned C) -> ()
+    %other = function_ref @other : $@convention(thin) () -> ()
+    %instance = apply %get() : $@convention(thin) () -> @owned C
+    br bottom(%instance : $C)
+bottom(%phi : @owned $C):
+    apply %other() : $@convention(thin) () -> ()
+    apply %other() : $@convention(thin) () -> ()
+    destroy_value %phi : $C
+    %retval = tuple ()
+    return %retval : $()
+}
+
+// Verify that when original liveness extends to the bottom of a control-flow
+// merge block, if there is no subsequent consume, it continues to extend there.
+//
+// CHECK-LABEL: sil [ossa] @consumedAtEntry_predecessor_is_control_flow_merge : {{.*}} {
+// CHECK:         [[INSTANCE:%[^,]+]] = apply
+// CHECK:         cond_br undef, [[LEFT_TOP:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[LEFT_TOP]]:
+// CHECK:         cond_br undef, [[LEFT_LEFT:bb[0-9]+]], [[LEFT_RIGHT:bb[0-9]+]]
+// CHECK:       [[LEFT_LEFT]]:
+// CHECK:         br [[LEFT_BOTTOM:bb[0-9]+]]
+// CHECK:       [[LEFT_RIGHT]]:
+// CHECK:         br [[LEFT_BOTTOM]]
+// CHECK:       [[LEFT_BOTTOM]]:
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[RIGHT]]:
+// CHECK:         apply {{%[^,]+}}([[INSTANCE]])
+// CHECK:         br [[EXIT]]
+// CHECK:       [[EXIT]]:
+// CHECK-LABEL: } // end sil function 'consumedAtEntry_predecessor_is_control_flow_merge'
+sil [ossa] @consumedAtEntry_predecessor_is_control_flow_merge : $@convention(thin) () -> () {
+top:
+    %get = function_ref @get : $@convention(thin) () -> @owned C
+    %see = function_ref @see : $@convention(thin) (@guaranteed C) -> ()
+    %end = function_ref @end : $@convention(thin) (@owned C) -> ()
+    %instance = apply %get() : $@convention(thin) () -> @owned C
+    %copy = copy_value %instance : $C
+    cond_br undef, left_top, right
+
+left_top:
+    cond_br undef, left_left, left_right
+
+left_left:
+    br left_bottom
+
+left_right:
+    br left_bottom
+
+left_bottom:
+    destroy_value %copy : $C
+    br exit
+
+right:
+    apply %end(%copy) : $@convention(thin) (@owned C) -> ()
+    br exit
+
+exit:
+    destroy_value %instance : $C
+    %retval = tuple ()
+    return %retval : $()
+}
+
+// Verify that multiple live terminators only result in a single extension into
+// the destination block edge.
+//
+// CHECK-LABEL: sil [ossa] @consumedAtEntry_predecessor_is_control_flow_merge__multiple_terminators_live : {{.*}} {
+// CHECK:         [[INSTANCE:%[^,]+]] = apply
+// CHECK:         cond_br undef, [[LEFT_TOP:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[LEFT_TOP]]:
+// CHECK:         cond_br undef, [[LEFT_LEFT:bb[0-9]+]], [[LEFT_RIGHT:bb[0-9]+]]
+// CHECK:       [[LEFT_LEFT]]:
+// CHECK:         br [[LEFT_BOTTOM:bb[0-9]+]]
+// CHECK:       [[LEFT_RIGHT]]:
+// CHECK:         br [[LEFT_BOTTOM]]
+// CHECK:       [[LEFT_BOTTOM]]:
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[RIGHT]]:
+// CHECK:         apply {{%[^,]+}}([[INSTANCE]])
+// CHECK:         br [[EXIT]]
+// CHECK-LABEL: } // end sil function 'consumedAtEntry_predecessor_is_control_flow_merge__multiple_terminators_live'
+sil [ossa] @consumedAtEntry_predecessor_is_control_flow_merge__multiple_terminators_live : $@convention(thin) () -> () {
+top:
+    %get = function_ref @get : $@convention(thin) () -> @owned C
+    %see = function_ref @see : $@convention(thin) (@guaranteed C) -> ()
+    %end = function_ref @end : $@convention(thin) (@owned C) -> ()
+    %instance = apply %get() : $@convention(thin) () -> @owned C
+    %copy = copy_value %instance : $C
+    cond_br undef, left_top, right
+
+left_top:
+    cond_br undef, left_left, left_right
+
+left_left:
+    destroy_value %copy : $C
+    br left_bottom
+
+left_right:
+    destroy_value %copy : $C
+    br left_bottom
+
+left_bottom:
+    br exit
+
+right:
+    apply %end(%copy) : $@convention(thin) (@owned C) -> ()
+    br exit
+
+exit:
+    destroy_value %instance : $C
+    %retval = tuple ()
+    return %retval : $()
+}
+
+// Verify that a control-flow branch "grand predecessor" gets destroys in the
+// right places in its successors.
+// CHECK-LABEL: sil [ossa] @consumedAtEntry_predecessor_is_control_flow_branch : {{.*}} {
+// CHECK:         [[REGISTER_3:%[^,]+]] = apply
+// CHECK:         cond_br undef, [[LEFT_TOP:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[LEFT_TOP]]:
+// CHECK:         cond_br undef, [[LEFT_LEFT:bb[0-9]+]], [[LEFT_RIGHT:bb[0-9]+]]
+// CHECK:       [[LEFT_LEFT]]:
+// CHECK:         destroy_value [[REGISTER_3]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[LEFT_RIGHT]]:
+// CHECK:         destroy_value [[REGISTER_3]]
+// CHECK:         br [[EXIT]]
+// CHECK:       [[RIGHT]]:
+// CHECK:         apply {{%[^,]+}}([[REGISTER_3]])
+// CHECK:         br [[EXIT]]
+// CHECK-LABEL: } // end sil function 'consumedAtEntry_predecessor_is_control_flow_branch'
+sil [ossa] @consumedAtEntry_predecessor_is_control_flow_branch : $@convention(thin) () -> () {
+top:
+    %get = function_ref @get : $@convention(thin) () -> @owned C
+    %see = function_ref @see : $@convention(thin) (@guaranteed C) -> ()
+    %end = function_ref @end : $@convention(thin) (@owned C) -> ()
+    %instance = apply %get() : $@convention(thin) () -> @owned C
+    %copy = copy_value %instance : $C
+    cond_br undef, left_top, right
+
+left_top:
+    destroy_value %copy : $C
+    cond_br undef, left_left, left_right
+
+left_left:
+    br exit
+
+left_right:
+    br exit
+
+right:
+    apply %end(%copy) : $@convention(thin) (@owned C) -> ()
+    br exit
+
+exit:
+    destroy_value %instance : $C
+    %retval = tuple ()
+    return %retval : $()
+}
+
+// Verify that a control-flow branch "grand predecessor" gets destroys in the
+// right places in its successors.  When one branch has a destroy.
+// CHECK-LABEL: sil [ossa] @consumedAtEntry_predecessor_is_control_flow_branch__2 : {{.*}} {
+// CHECK:         [[INSTANCE:%[^,]+]] = apply
+// CHECK:         cond_br undef, [[LEFT_TOP:bb[0-9]+]], [[RIGHT:bb[0-9]+]]                         
+// CHECK:       [[LEFT_TOP]]:                                              
+// CHECK:         cond_br undef, [[LEFT_LEFT:bb[0-9]+]], [[LEFT_RIGHT:bb[0-9]+]]                         
+// CHECK:       [[LEFT_LEFT]]:                                              
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         br [[EXIT:bb[0-9]+]]                                          
+// CHECK:       [[LEFT_RIGHT]]:                                              
+// CHECK:         apply {{%[^,]+}}([[INSTANCE]])
+// CHECK:         br [[EXIT]]                                          
+// CHECK:       [[RIGHT]]:                                              
+// CHECK:         apply {{%[^,]+}}([[INSTANCE]])
+// CHECK:         br [[EXIT]]                                          
+// CHECK-LABEL: } // end sil function 'consumedAtEntry_predecessor_is_control_flow_branch__2'
+sil [ossa] @consumedAtEntry_predecessor_is_control_flow_branch__2 : $@convention(thin) () -> () {
+top:
+    %get = function_ref @get : $@convention(thin) () -> @owned C
+    %see = function_ref @see : $@convention(thin) (@guaranteed C) -> ()
+    %end = function_ref @end : $@convention(thin) (@owned C) -> ()
+    %instance = apply %get() : $@convention(thin) () -> @owned C
+    %copy = copy_value %instance : $C
+    cond_br undef, left_top, right
+
+left_top:
+    cond_br undef, left_left, left_right
+
+left_left:
+    destroy_value %copy : $C
+    br exit
+
+left_right:
+    apply %end(%copy) : $@convention(thin) (@owned C) -> ()
+    br exit
+
+right:
+    apply %end(%copy) : $@convention(thin) (@owned C) -> ()
+    br exit
+
+exit:
+    destroy_value %instance : $C
+    %retval = tuple ()
+    return %retval : $()
+}
+
+// Verify that a control-flow branch "grand predecessor" gets destroys in the
+// right places in its successors.  When one branch has a destroy the boundary
+// can be extended to.
+// CHECK-LABEL: sil [ossa] @consumedAtEntry_predecessor_is_control_flow_branch__3 : {{.*}} {
+// CHECK:         [[INSTANCE:%[^,]+]] = apply
+// CHECK:         cond_br undef, [[LEFT_TOP:bb[0-9]+]], [[RIGHT:bb[0-9]+]]                         
+// CHECK:       [[LEFT_TOP]]:                                              
+// CHECK:         cond_br undef, [[LEFT_LEFT:bb[0-9]+]], [[LEFT_RIGHT:bb[0-9]+]]                         
+// CHECK:       [[LEFT_LEFT]]:                                              
+// CHECK:         apply
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         br [[EXIT:bb[0-9]+]]                                          
+// CHECK:       [[LEFT_RIGHT]]:                                              
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK:         br [[EXIT]]                                          
+// CHECK:       [[RIGHT]]:                                              
+// CHECK:         apply {{%[^,]+}}([[INSTANCE]])
+// CHECK:         br [[EXIT]]                                          
+// CHECK-LABEL: } // end sil function 'consumedAtEntry_predecessor_is_control_flow_branch__3'
+sil [ossa] @consumedAtEntry_predecessor_is_control_flow_branch__3 : $@convention(thin) () -> () {
+top:
+    %get = function_ref @get : $@convention(thin) () -> @owned C
+    %see = function_ref @see : $@convention(thin) (@guaranteed C) -> ()
+    %end = function_ref @end : $@convention(thin) (@owned C) -> ()
+    %instance = apply %get() : $@convention(thin) () -> @owned C
+    %copy = copy_value %instance : $C
+    cond_br undef, left_top, right
+
+left_top:
+    cond_br undef, left_left, left_right
+
+left_left:
+    %other = function_ref @other : $@convention(thin) () -> ()
+    apply %other() : $@convention(thin) () -> ()
+    destroy_value %copy : $C
+    br exit
+
+left_right:
+    destroy_value %copy : $C
+    br exit
+
+right:
+    apply %end(%copy) : $@convention(thin) (@owned C) -> ()
+    br exit
+
+exit:
+    destroy_value %instance : $C
+    %retval = tuple ()
+    return %retval : $()
+}

--- a/test/SILOptimizer/moveonly_lifetime.swift
+++ b/test/SILOptimizer/moveonly_lifetime.swift
@@ -1,0 +1,45 @@
+// RUN: %target-swift-emit-sil -Onone -verify -enable-experimental-move-only %s | %FileCheck %s
+
+@_moveOnly
+class C {}
+
+@_silgen_name("getC")
+func getC() -> C
+
+@_silgen_name("takeC")
+func takeC(_ c: __owned C)
+
+@_silgen_name("borrowC")
+func borrowC(_ c: C)
+
+@_silgen_name("something")
+func something()
+
+// Verify that a move-only value's lifetime extends to the end of the
+// non-consuming scope where it appears but not further (which would require a
+// copy).
+//
+// CHECK-LABEL: sil hidden @test_diamond__consume_r__use_l : $@convention(thin) (Bool) -> () {
+// CHECK:         [[INSTANCE:%[^,]+]] = move_value [lexical] {{%[^,]+}}
+// CHECK:         cond_br {{%[^,]+}}, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[LEFT]]:
+// CHECK:         [[BORROW_C:%[^,]+]] = function_ref @borrowC
+// CHECK:         apply [[BORROW_C]]([[INSTANCE]])
+// CHECK:         [[SOMETHING:%[^,]+]] = function_ref @something
+// CHECK:         apply [[SOMETHING]]
+// CHECK:         [[DESTROY_C:%[^,]+]] = function_ref @$s17moveonly_lifetime1CCfD
+// CHECK:         apply [[DESTROY_C]]([[INSTANCE]])
+// CHECK:       [[RIGHT]]:
+// CHECK:         [[TAKE_C:%[^,]+]] = function_ref @takeC
+// CHECK:         apply [[TAKE_C]]([[INSTANCE]])
+// CHECK-LABEL: } // end sil function 'test_diamond__consume_r__use_l'
+@_silgen_name("test_diamond__consume_r__use_l")
+func test_diamond(_ condition: Bool) {
+  let c = getC()
+  if condition {
+    borrowC(c)
+    something()
+  } else {
+    takeC(c)
+  }
+}


### PR DESCRIPTION
To improve the debugging experience of values whose lifetimes are canonicalized without compromising the semantics expressed in the source language, when canonicalizing OSSA lifetimes at Onone, lengthen lifetimes as much as possible without incurring copies that would be eliminated at O.

rdar://99618502

