### PR TITLE
Move `SWIFT_RETURNS_NONNULL` and `SWIFT_NODISCARD` attributes after the function name for exported functions.

### DIFF
--- a/include/swift/Runtime/Heap.h
+++ b/include/swift/Runtime/Heap.h
@@ -29,8 +29,9 @@ namespace swift {
 // Never returns nil. The returned memory is uninitialized. 
 //
 // An "alignment mask" is just the alignment (a power of 2) minus 1.
-SWIFT_RETURNS_NONNULL SWIFT_NODISCARD SWIFT_RUNTIME_EXPORT
-void *swift_slowAlloc(size_t bytes, size_t alignMask);
+SWIFT_RUNTIME_EXPORT
+void *swift_slowAlloc SWIFT_RETURNS_NONNULL SWIFT_NODISCARD(size_t bytes,
+                                                            size_t alignMask);
 
 // If the caller cannot promise to zero the object during destruction,
 // then call these corresponding APIs:

--- a/include/swift/Runtime/HeapObject.h
+++ b/include/swift/Runtime/HeapObject.h
@@ -61,10 +61,10 @@ struct OpaqueValue;
 ///
 /// POSSIBILITIES: The argument order is fair game.  It may be useful
 /// to have a variant which guarantees zero-initialized memory.
-SWIFT_RETURNS_NONNULL SWIFT_NODISCARD SWIFT_RUNTIME_EXPORT
-HeapObject *swift_allocObject(HeapMetadata const *metadata,
-                              size_t requiredSize,
-                              size_t requiredAlignmentMask);
+SWIFT_RUNTIME_EXPORT
+HeapObject *swift_allocObject SWIFT_RETURNS_NONNULL
+SWIFT_NODISCARD(HeapMetadata const *metadata, size_t requiredSize,
+                size_t requiredAlignmentMask);
 
 /// Initializes the object header of a stack allocated object.
 ///
@@ -117,8 +117,8 @@ BoxPair swift_makeBoxUnique(OpaqueValue *buffer, Metadata const *type,
                                     size_t alignMask);
 
 /// Returns the address of a heap object representing all empty box types.
-SWIFT_RETURNS_NONNULL SWIFT_NODISCARD SWIFT_RUNTIME_EXPORT
-HeapObject* swift_allocEmptyBox();
+SWIFT_RUNTIME_EXPORT
+HeapObject *swift_allocEmptyBox SWIFT_RETURNS_NONNULL SWIFT_NODISCARD();
 
 /// Atomically increments the retain count of an object.
 ///

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -313,21 +313,19 @@ swift_getGenericMetadata(MetadataRequest request,
 ///   - installing new v-table entries and overrides; and
 ///   - registering the class with the runtime under ObjC interop.
 /// Most of this work can be achieved by calling swift_initClassMetadata.
-SWIFT_RETURNS_NONNULL SWIFT_NODISCARD SWIFT_RUNTIME_EXPORT
-ClassMetadata *
-swift_allocateGenericClassMetadata(const ClassDescriptor *description,
-                                   const void *arguments,
-                                   const GenericClassMetadataPattern *pattern);
+SWIFT_RUNTIME_EXPORT
+ClassMetadata *swift_allocateGenericClassMetadata SWIFT_RETURNS_NONNULL
+SWIFT_NODISCARD(const ClassDescriptor *description, const void *arguments,
+                const GenericClassMetadataPattern *pattern);
 
 /// Allocate a generic value metadata object.  This is intended to be
 /// called by the metadata instantiation function of a generic struct or
 /// enum.
-SWIFT_RETURNS_NONNULL SWIFT_NODISCARD SWIFT_RUNTIME_EXPORT
-ValueMetadata *
-swift_allocateGenericValueMetadata(const ValueTypeDescriptor *description,
-                                   const void *arguments,
-                                   const GenericValueMetadataPattern *pattern,
-                                   size_t extraDataSize);
+SWIFT_RUNTIME_EXPORT
+ValueMetadata *swift_allocateGenericValueMetadata SWIFT_RETURNS_NONNULL
+SWIFT_NODISCARD(const ValueTypeDescriptor *description, const void *arguments,
+                const GenericValueMetadataPattern *pattern,
+                size_t extraDataSize);
 
 /// Check that the given metadata has the right state.
 SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)


### PR DESCRIPTION
More recent versions of Clang (~July 2022) have stricter enforcement of the positioning of attributes; for example, the `nonnull` and `nodiscard` attributes can no longer precede the `extern "C"` specifier and must follow the name of the function (and not the signature of the function) to which they apply.

This appears to just affect functions exported with `extern "C"`; other functions using these attributes can still have these attributes first without issue. 🤷🏻‍♂️ 

I have mixed feelings about the formatting here, but it's what `clang-format` did.