### PR TITLE
Runtime: split out `extern "C"` marker from `SWIFT_RUNTIME_EXPORT`

### DIFF
--- a/include/swift/Runtime/Casting.h
+++ b/include/swift/Runtime/Casting.h
@@ -21,6 +21,8 @@
 
 namespace swift {
 
+SWIFT_BEGIN_DECLS
+
 /// Perform a checked dynamic cast of a value to a target type.
 ///
 /// \param dest A buffer into which to write the destination value.
@@ -243,6 +245,8 @@ const Metadata *swift_getObjectType(HeapObject *object);
 SWIFT_RUNTIME_EXPORT
 const WitnessTable *swift_conformsToProtocol(const Metadata *type,
                                             const ProtocolDescriptor *protocol);
+
+SWIFT_END_DECLS
 
 } // end namespace swift
 

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -70,30 +70,41 @@ struct AsyncTaskAndContext {
   AsyncContext *InitialContext;
 };
 
+SWIFT_BEGIN_DECLS
+
 /// Create a task object.
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
-AsyncTaskAndContext swift_task_create(
-    size_t taskCreateFlags,
-    TaskOptionRecord *options,
-    const Metadata *futureResultType,
-    void *closureEntry, HeapObject *closureContext);
+AsyncTaskAndContext swift_task_create(size_t taskCreateFlags,
+                                      TaskOptionRecord *options,
+                                      const Metadata *futureResultType,
+                                      void *closureEntry,
+                                      HeapObject *closureContext);
+
+SWIFT_END_DECLS
 
 /// Caution: not all future-initializing functions actually throw, so
 /// this signature may be incorrect.
 using FutureAsyncSignature =
   AsyncSignature<void(void*), /*throws*/ true>;
 
+SWIFT_BEGIN_DECLS
+
 /// Create a task object.
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
-AsyncTaskAndContext swift_task_create_common(
-    size_t taskCreateFlags,
-    TaskOptionRecord *options,
-    const Metadata *futureResultType,
-    TaskContinuationFunction *function, void *closureContext,
-    size_t initialContextSize);
+AsyncTaskAndContext
+swift_task_create_common(size_t taskCreateFlags, TaskOptionRecord *options,
+                         const Metadata *futureResultType,
+                         TaskContinuationFunction *function,
+                         void *closureContext,
+                         size_t initialContextSize);
+
+SWIFT_END_DECLS
 
 #if SWIFT_CONCURRENCY_TASK_TO_THREAD_MODEL
 #define SWIFT_TASK_RUN_INLINE_INITIAL_CONTEXT_BYTES 4096
+
+SWIFT_BEGIN_DECLS
+
 /// Begin an async context in the current sync context and run the indicated
 /// closure in it.
 ///
@@ -104,7 +115,12 @@ SWIFT_CC(swift)
 void swift_task_run_inline(OpaqueValue *result, void *closureAFP,
                            OpaqueValue *closureContext,
                            const Metadata *futureResultType);
+
+SWIFT_END_DECLS
+
 #endif
+
+SWIFT_BEGIN_DECLS
 
 /// Allocate memory in a task.
 ///
@@ -141,8 +157,7 @@ void swift_task_cancel_group_child_tasks(TaskGroup *group);
 /// This has no effect if the task already has at least the given priority.
 /// Returns the priority of the task.
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
-JobPriority
-swift_task_escalate(AsyncTask *task, JobPriority newPriority);
+JobPriority swift_task_escalate(AsyncTask *task, JobPriority newPriority);
 
 // TODO: "async let wait" and "async let destroy" would be expressed
 //       similar to like TaskFutureWait;
@@ -156,10 +171,9 @@ swift_task_escalate(AsyncTask *task, JobPriority newPriority);
 ///     -> Success
 /// \endcode
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swiftasync)
-void swift_task_future_wait(OpaqueValue *,
-         SWIFT_ASYNC_CONTEXT AsyncContext *, AsyncTask *,
-         TaskContinuationFunction *,
-         AsyncContext *);
+void
+swift_task_future_wait(OpaqueValue *, SWIFT_ASYNC_CONTEXT AsyncContext *,
+                       AsyncTask *, TaskContinuationFunction *, AsyncContext *);
 
 /// Wait for a potentially-throwing future task to complete.
 ///
@@ -170,12 +184,12 @@ void swift_task_future_wait(OpaqueValue *,
 ///    async throws -> Success
 /// \endcode
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swiftasync)
-void swift_task_future_wait_throwing(
-  OpaqueValue *,
-  SWIFT_ASYNC_CONTEXT AsyncContext *,
-  AsyncTask *,
-  ThrowingTaskFutureWaitContinuationFunction *,
-  AsyncContext *);
+void
+swift_task_future_wait_throwing(OpaqueValue *,
+                                SWIFT_ASYNC_CONTEXT AsyncContext *,
+                                AsyncTask *,
+                                ThrowingTaskFutureWaitContinuationFunction *,
+                                AsyncContext *);
 
 /// Wait for a readyQueue of a Channel to become non empty.
 ///
@@ -187,12 +201,13 @@ void swift_task_future_wait_throwing(
 ///     group: Builtin.RawPointer
 /// ) async -> T
 /// \endcode
-SWIFT_EXPORT_FROM(swift_Concurrency)
-SWIFT_CC(swiftasync)
-void swift_taskGroup_wait_next_throwing(
-    OpaqueValue *resultPointer, SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
-    TaskGroup *group, ThrowingTaskFutureWaitContinuationFunction *resumeFn,
-    AsyncContext *callContext);
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swiftasync)
+void
+swift_taskGroup_wait_next_throwing(OpaqueValue *resultPointer,
+                                   SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
+                                   TaskGroup *group,
+                                   ThrowingTaskFutureWaitContinuationFunction *resumeFn,
+                                   AsyncContext *callContext);
 
 /// Initialize a `TaskGroup` in the passed `group` memory location.
 /// The caller is responsible for retaining and managing the group's lifecycle.
@@ -322,11 +337,15 @@ void swift_asyncLet_begin(AsyncLet *alet,
                           void *closureEntryPoint, HeapObject *closureContext,
                           void *resultBuffer);
 
+SWIFT_END_DECLS
+
 /// This matches the ABI of a closure `<T>(Builtin.RawPointer) async -> T`
 using AsyncLetWaitSignature =
     SWIFT_CC(swiftasync)
     void(OpaqueValue *,
          SWIFT_ASYNC_CONTEXT AsyncContext *, AsyncTask *, Metadata *);
+
+SWIFT_BEGIN_DECLS
 
 /// DEPRECATED. swift_asyncLet_get is used instead.
 /// Wait for a non-throwing async-let to complete.
@@ -608,6 +627,8 @@ void swift_task_localValuePop();
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_localsCopyTo(AsyncTask* target);
 
+SWIFT_END_DECLS
+
 /// This should have the same representation as an enum like this:
 ///    enum NearestTaskDeadline {
 ///      case none
@@ -626,12 +647,13 @@ struct NearestTaskDeadline {
   Kind ValueKind;
 };
 
+SWIFT_BEGIN_DECLS
+
 /// Returns the nearest deadline that's been registered with this task.
 ///
 /// This must be called synchronously with the task.
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
-NearestTaskDeadline
-swift_task_getNearestDeadline(AsyncTask *task);
+NearestTaskDeadline swift_task_getNearestDeadline(AsyncTask *task);
 
 /// Switch the current task to a new executor if we aren't already
 /// running on a compatible executor.
@@ -680,8 +702,12 @@ void swift_task_enqueue(Job *job, ExecutorRef executor);
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_enqueueGlobal(Job *job);
 
+SWIFT_END_DECLS
+
 /// A count in nanoseconds.
 using JobDelay = unsigned long long;
+
+SWIFT_BEGIN_DECLS
 
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_enqueueGlobalWithDelay(JobDelay delay, Job *job);
@@ -694,27 +720,43 @@ void swift_task_enqueueGlobalWithDeadline(long long sec, long long nsec,
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_enqueueMainExecutor(Job *job);
 
+SWIFT_END_DECLS
+
 #if SWIFT_CONCURRENCY_ENABLE_DISPATCH
+
+SWIFT_BEGIN_DECLS
 
 /// Enqueue the given job on the main executor.
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_enqueueOnDispatchQueue(Job *job, HeapObject *queue);
 
+SWIFT_END_DECLS
+
 #endif
 
 /// A hook to take over global enqueuing.
 typedef SWIFT_CC(swift) void (*swift_task_enqueueGlobal_original)(Job *job);
-SWIFT_EXPORT_FROM(swift_Concurrency)
-SWIFT_CC(swift) void (*swift_task_enqueueGlobal_hook)(
+
+SWIFT_BEGIN_DECLS
+
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+extern void (*swift_task_enqueueGlobal_hook)(
     Job *job, swift_task_enqueueGlobal_original original);
+
+SWIFT_END_DECLS
 
 /// A hook to take over global enqueuing with delay.
 typedef SWIFT_CC(swift) void (*swift_task_enqueueGlobalWithDelay_original)(
     unsigned long long delay, Job *job);
-SWIFT_EXPORT_FROM(swift_Concurrency)
-SWIFT_CC(swift) void (*swift_task_enqueueGlobalWithDelay_hook)(
+
+SWIFT_BEGIN_DECLS
+
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+extern void (*swift_task_enqueueGlobalWithDelay_hook)(
     unsigned long long delay, Job *job,
     swift_task_enqueueGlobalWithDelay_original original);
+
+SWIFT_END_DECLS
 
 typedef SWIFT_CC(swift) void (*swift_task_enqueueGlobalWithDeadline_original)(
     long long sec,
@@ -722,8 +764,11 @@ typedef SWIFT_CC(swift) void (*swift_task_enqueueGlobalWithDeadline_original)(
     long long tsec,
     long long tnsec,
     int clock, Job *job);
-SWIFT_EXPORT_FROM(swift_Concurrency)
-SWIFT_CC(swift) void (*swift_task_enqueueGlobalWithDeadline_hook)(
+
+SWIFT_BEGIN_DECLS
+
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+extern void (*swift_task_enqueueGlobalWithDeadline_hook)(
     long long sec,
     long long nsec,
     long long tsec,
@@ -731,11 +776,16 @@ SWIFT_CC(swift) void (*swift_task_enqueueGlobalWithDeadline_hook)(
     int clock, Job *job,
     swift_task_enqueueGlobalWithDeadline_original original);
 
+SWIFT_END_DECLS
+
 /// A hook to take over main executor enqueueing.
 typedef SWIFT_CC(swift) void (*swift_task_enqueueMainExecutor_original)(
     Job *job);
-SWIFT_EXPORT_FROM(swift_Concurrency)
-SWIFT_CC(swift) void (*swift_task_enqueueMainExecutor_hook)(
+
+SWIFT_BEGIN_DECLS
+
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+extern void (*swift_task_enqueueMainExecutor_hook)(
     Job *job, swift_task_enqueueMainExecutor_original original);
 
 /// Initialize the runtime storage for a default actor.
@@ -756,8 +806,7 @@ void swift_defaultActor_deallocateResilient(HeapObject *actor);
 
 /// Initialize the runtime storage for a distributed remote actor.
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
-OpaqueValue*
-swift_distributedActor_remote_initialize(const Metadata *actorType);
+OpaqueValue* swift_distributedActor_remote_initialize(const Metadata *actorType);
 
 /// Enqueue a job on the default actor implementation.
 ///
@@ -817,7 +866,7 @@ void swift_continuation_throwingResumeWithError(AsyncTask *continuation,
                                                 /* +1 */ SwiftError *error);
 
 /// SPI helper to log a misuse of a `CheckedContinuation` to the appropriate places in the OS.
-extern "C" SWIFT_CC(swift)
+SWIFT_CC(swift)
 void swift_continuation_logFailedCheck(const char *message);
 
 /// Drain the queue
@@ -854,7 +903,11 @@ void swift_task_reportUnexpectedExecutor(
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 JobPriority swift_task_getCurrentThreadPriority(void);
 
+SWIFT_END_DECLS
+
 #if SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR
+
+SWIFT_BEGIN_DECLS
 
 /// Donate this thread to the global executor until either the
 /// given condition returns true or we've run out of cooperative
@@ -862,6 +915,8 @@ JobPriority swift_task_getCurrentThreadPriority(void);
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_donateThreadToGlobalExecutorUntil(bool (*condition)(void*),
                                                   void *context);
+
+SWIFT_END_DECLS
 
 #endif
 

--- a/include/swift/Runtime/Debug.h
+++ b/include/swift/Runtime/Debug.h
@@ -243,25 +243,25 @@ void _swift_reportToDebugger(uintptr_t flags, const char *message,
                              RuntimeErrorDetails *details = nullptr);
 
 SWIFT_RUNTIME_STDLIB_SPI
-bool _swift_reportFatalErrorsToDebugger;
+extern bool _swift_reportFatalErrorsToDebugger;
 
 SWIFT_RUNTIME_STDLIB_SPI
 bool _swift_shouldReportFatalErrorsToDebugger();
 
 SWIFT_RUNTIME_STDLIB_SPI
-bool _swift_debug_metadataAllocationIterationEnabled;
+extern bool _swift_debug_metadataAllocationIterationEnabled;
 
 SWIFT_RUNTIME_STDLIB_SPI
-const void * const _swift_debug_allocationPoolPointer;
+extern const void * const _swift_debug_allocationPoolPointer;
 
 SWIFT_RUNTIME_STDLIB_SPI
-std::atomic<const void *> _swift_debug_metadataAllocationBacktraceList;
+extern std::atomic<const void *> _swift_debug_metadataAllocationBacktraceList;
 
 SWIFT_RUNTIME_STDLIB_SPI
-const void * const _swift_debug_protocolConformanceStatePointer;
+extern const void * const _swift_debug_protocolConformanceStatePointer;
 
 SWIFT_RUNTIME_STDLIB_SPI
-const uint64_t _swift_debug_multiPayloadEnumPointerSpareBitsMask;
+extern const uint64_t _swift_debug_multiPayloadEnumPointerSpareBitsMask;
 
 // namespace swift
 }

--- a/include/swift/Runtime/Enum.h
+++ b/include/swift/Runtime/Enum.h
@@ -34,6 +34,8 @@ template <typename Runtime> struct TargetEnumMetadata;
 using EnumMetadata = TargetEnumMetadata<InProcess>;
 struct TypeLayout;
 
+SWIFT_BEGIN_DECLS
+
 /// Initialize the type metadata for a single-case enum type.
 ///
 /// \param enumType - pointer to the instantiated but uninitialized metadata
@@ -58,10 +60,14 @@ void swift_initEnumMetadataSinglePayload(EnumMetadata *enumType,
                                          const TypeLayout *payload,
                                          unsigned emptyCases);
 
+SWIFT_END_DECLS
+
 using getExtraInhabitantTag_t =
   SWIFT_CC(swift) unsigned (const OpaqueValue *value,
                             unsigned numExtraInhabitants,
                             const Metadata *payloadType);
+
+SWIFT_BEGIN_DECLS
 
 /// Implement getEnumTagSinglePayload generically in terms of a
 /// payload type with a getExtraInhabitantIndex function.
@@ -79,11 +85,15 @@ unsigned swift_getEnumTagSinglePayloadGeneric(const OpaqueValue *value,
                                               const Metadata *payloadType,
                                               getExtraInhabitantTag_t *getTag);
 
+SWIFT_END_DECLS
+
 using storeExtraInhabitantTag_t =
   SWIFT_CC(swift) void (OpaqueValue *value,
                         unsigned whichCase,
                         unsigned numExtraInhabitants,
                         const Metadata *payloadType);
+
+SWIFT_BEGIN_DECLS
 
 /// Implement storeEnumTagSinglePayload generically in terms of a
 /// payload type with a storeExtraInhabitant function.
@@ -147,6 +157,9 @@ void swift_storeMultiPayloadEnumTagSinglePayload(OpaqueValue *value,
                                                  uint32_t index,
                                                  uint32_t numExtraCases,
                                                  const Metadata *enumType);
+
+SWIFT_END_DECLS
+
 }
 
 #endif

--- a/include/swift/Runtime/Error.h
+++ b/include/swift/Runtime/Error.h
@@ -30,6 +30,8 @@ namespace swift {
 
 struct SwiftError;
 
+SWIFT_BEGIN_DECLS
+
 /// Allocate a catchable error object.
 ///
 /// If value is nonnull, it should point to a value of \c type, which will be
@@ -46,11 +48,15 @@ BoxPair swift_allocError(const Metadata *type,
 SWIFT_RUNTIME_STDLIB_API
 void swift_deallocError(SwiftError *error, const Metadata *type);
 
+SWIFT_END_DECLS
+
 struct ErrorValueResult {
   const OpaqueValue *value;
   const Metadata *type;
   const WitnessTable *errorConformance;
 };
+
+SWIFT_BEGIN_DECLS
 
 /// Extract a pointer to the value, the type metadata, and the Error
 /// protocol witness from an error object.
@@ -66,19 +72,17 @@ void swift_getErrorValue(const SwiftError *errorObject,
 
 /// Called when throwing an error.  Serves as a breakpoint hook
 /// for debuggers.
-SWIFT_CC(swift)
-SWIFT_RUNTIME_STDLIB_API void
-swift_willThrow(SWIFT_CONTEXT void *unused,
-                SWIFT_ERROR_RESULT SwiftError **object);
+SWIFT_RUNTIME_STDLIB_API
+SWIFT_CC(swift) void swift_willThrow(SWIFT_CONTEXT void *unused,
+                                     SWIFT_ERROR_RESULT SwiftError **object);
 
 /// Called when an error is thrown out of the top level of a script.
-SWIFT_CC(swift)
-SWIFT_RUNTIME_STDLIB_API SWIFT_NORETURN void
-swift_errorInMain(SwiftError *object);
+SWIFT_RUNTIME_STDLIB_API SWIFT_NORETURN
+SWIFT_CC(swift) void swift_errorInMain(SwiftError *object);
 
 /// Called when the try! operator fails.
-SWIFT_CC(swift)
-SWIFT_RUNTIME_STDLIB_API SWIFT_NORETURN void
+SWIFT_RUNTIME_STDLIB_API SWIFT_NORETURN
+SWIFT_CC(swift) void
 swift_unexpectedError(SwiftError *object, OpaqueValue *filenameStart,
                       long filenameLength, bool isAscii, unsigned long line);
 
@@ -89,6 +93,8 @@ SwiftError *swift_errorRetain(SwiftError *object);
 /// Release an error box.
 SWIFT_RUNTIME_STDLIB_API
 void swift_errorRelease(SwiftError *object);
+
+SWIFT_END_DECLS
 
 } // end namespace swift
 

--- a/include/swift/Runtime/Exclusivity.h
+++ b/include/swift/Runtime/Exclusivity.h
@@ -28,6 +28,8 @@ template <typename Runtime> struct TargetValueBuffer;
 struct InProcess;
 using ValueBuffer = TargetValueBuffer<InProcess>;
 
+SWIFT_BEGIN_DECLS
+
 /// Begin dynamically tracking an access.
 ///
 /// The buffer is opaque scratch space that the runtime may use for
@@ -57,9 +59,13 @@ void swift_endAccess(ValueBuffer *buffer);
 /// state.  (We also need to not leave references to scratch
 /// buffers on the stack sitting around in the runtime.)
 SWIFT_RUNTIME_EXPORT
-bool _swift_disableExclusivityChecking;
+extern bool _swift_disableExclusivityChecking;
+
+SWIFT_END_DECLS
 
 #ifndef NDEBUG
+
+SWIFT_BEGIN_DECLS
 
 /// Dump all accesses currently tracked by the runtime.
 ///
@@ -69,6 +75,8 @@ bool _swift_disableExclusivityChecking;
 /// happen. This eases debugging.
 SWIFT_RUNTIME_EXPORT
 void swift_dumpTrackedAccesses();
+
+SWIFT_END_DECLS
 
 #endif
 
@@ -90,6 +98,8 @@ void swift_task_exitThreadLocalContextBackdeploy56(char *state);
 #  define swift_task_enterThreadLocalContext swift_task_enterThreadLocalContextBackDeploy
 #  define swift_task_exitThreadLocalContext swift_task_exitThreadLocalContextBackDeploy
 #endif
+
+SWIFT_BEGIN_DECLS
 
 /// Called when a task inits, resumes and returns control to caller synchronous
 /// code to update any exclusivity specific state associated with the task.
@@ -114,6 +124,8 @@ void swift_task_enterThreadLocalContext(char *state);
 /// Exclusivity.cpp.
 SWIFT_RUNTIME_EXPORT
 void swift_task_exitThreadLocalContext(char *state);
+
+SWIFT_END_DECLS
 
 #endif
 

--- a/include/swift/Runtime/Heap.h
+++ b/include/swift/Runtime/Heap.h
@@ -25,17 +25,20 @@
 #include "swift/shims/Visibility.h"
 
 namespace swift {
+SWIFT_BEGIN_DECLS
 // Allocate plain old memory. This is the generalized entry point
 // Never returns nil. The returned memory is uninitialized. 
 //
 // An "alignment mask" is just the alignment (a power of 2) minus 1.
-SWIFT_EXTERN_C SWIFT_RETURNS_NONNULL SWIFT_NODISCARD SWIFT_RUNTIME_EXPORT_ATTRIBUTE
+SWIFT_RETURNS_NONNULL SWIFT_NODISCARD SWIFT_RUNTIME_EXPORT
 void *swift_slowAlloc(size_t bytes, size_t alignMask);
 
 // If the caller cannot promise to zero the object during destruction,
 // then call these corresponding APIs:
 SWIFT_RUNTIME_EXPORT
 void swift_slowDealloc(void *ptr, size_t bytes, size_t alignMask);
+
+SWIFT_END_DECLS
 
 /// Allocate and construct an instance of type \c T.
 ///

--- a/include/swift/Runtime/HeapObject.h
+++ b/include/swift/Runtime/HeapObject.h
@@ -42,6 +42,8 @@ using HeapMetadata = TargetHeapMetadata<InProcess>;
 
 struct OpaqueValue;
 
+SWIFT_BEGIN_DECLS
+
 /// Allocates a new heap object.  The returned memory is
 /// uninitialized outside of the heap-object header.  The object
 /// has an initial retain count of 1, and its metadata is set to
@@ -61,7 +63,7 @@ struct OpaqueValue;
 ///
 /// POSSIBILITIES: The argument order is fair game.  It may be useful
 /// to have a variant which guarantees zero-initialized memory.
-SWIFT_EXTERN_C SWIFT_RETURNS_NONNULL SWIFT_NODISCARD SWIFT_RUNTIME_EXPORT_ATTRIBUTE
+SWIFT_RETURNS_NONNULL SWIFT_NODISCARD SWIFT_RUNTIME_EXPORT
 HeapObject *swift_allocObject(HeapMetadata const *metadata,
                               size_t requiredSize,
                               size_t requiredAlignmentMask);
@@ -92,10 +94,14 @@ HeapObject *swift_initStaticObject(HeapMetadata const *metadata,
 SWIFT_RUNTIME_EXPORT
 void swift_verifyEndOfLifetime(HeapObject *object);
 
+SWIFT_END_DECLS
+
 struct BoxPair {
   HeapObject *object;
   OpaqueValue *buffer;
 };
+
+SWIFT_BEGIN_DECLS
 
 /// Allocates a heap object that can contain a value of the given type.
 /// Returns a Box structure containing a HeapObject* pointer to the
@@ -117,7 +123,7 @@ BoxPair swift_makeBoxUnique(OpaqueValue *buffer, Metadata const *type,
                                     size_t alignMask);
 
 /// Returns the address of a heap object representing all empty box types.
-SWIFT_EXTERN_C SWIFT_RETURNS_NONNULL SWIFT_NODISCARD SWIFT_RUNTIME_EXPORT_ATTRIBUTE
+SWIFT_RETURNS_NONNULL SWIFT_NODISCARD SWIFT_RUNTIME_EXPORT
 HeapObject* swift_allocEmptyBox();
 
 /// Atomically increments the retain count of an object.
@@ -344,6 +350,8 @@ void swift_deallocBox(HeapObject *object);
 SWIFT_RUNTIME_EXPORT
 OpaqueValue *swift_projectBox(HeapObject *object);
 
+SWIFT_END_DECLS
+
 /// RAII object that wraps a Swift heap object and releases it upon
 /// destruction.
 class SwiftRAII {
@@ -394,6 +402,8 @@ public:
 struct UnownedReference {
   HeapObject *Value;
 };
+
+SWIFT_BEGIN_DECLS
 
 /// Increment the unowned retain count.
 SWIFT_RUNTIME_EXPORT
@@ -452,6 +462,8 @@ void swift_nonatomic_unownedRetainStrongAndRelease(HeapObject *value);
 /// Aborts if the object has been deallocated.
 SWIFT_RUNTIME_EXPORT
 void swift_unownedCheck(HeapObject *value);
+
+SWIFT_END_DECLS
 
 static inline void swift_unownedInit(UnownedReference *ref, HeapObject *value) {
   ref->Value = value;
@@ -528,6 +540,8 @@ static inline bool swift_unownedIsEqual(UnownedReference *ref,
 
 // Defined in Runtime/WeakReference.h
 class WeakReference;
+
+SWIFT_BEGIN_DECLS
 
 /// Initialize a weak reference.
 ///
@@ -1073,33 +1087,37 @@ static inline bool swift_unknownObjectUnownedIsEqual(UnownedReference *ref,
 
 #endif // SWIFT_OBJC_INTEROP
 
+SWIFT_END_DECLS
+
 struct TypeNamePair {
   const char *data;
   uintptr_t length;
 };
 
+SWIFT_BEGIN_DECLS
+
 /// Return the name of a Swift type represented by a metadata object.
 /// func _getTypeName(_ type: Any.Type, qualified: Bool)
 ///   -> (UnsafePointer<UInt8>, Int)
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
-TypeNamePair
-swift_getTypeName(const Metadata *type, bool qualified);
+SWIFT_RUNTIME_STDLIB_API SWIFT_CC(swift)
+TypeNamePair swift_getTypeName(const Metadata *type, bool qualified);
 
 /// Return the mangled name of a Swift type represented by a metadata object.
 /// func _getMangledTypeName(_ type: Any.Type)
 ///   -> (UnsafePointer<UInt8>, Int)
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
+SWIFT_RUNTIME_STDLIB_API SWIFT_CC(swift)
 TypeNamePair
-swift_getFunctionFullNameFromMangledName(
-        const char *mangledNameStart, uintptr_t mangledNameLength);
+swift_getFunctionFullNameFromMangledName(const char *mangledNameStart,
+                                         uintptr_t mangledNameLength);
 
 /// Return the human-readable full name of the mangled function name passed in.
 /// func _getMangledTypeName(_ mangledName: UnsafePointer<UInt8>,
 ///                          mangledNameLength: UInt)
 ///   -> (UnsafePointer<UInt8>, Int)
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
-TypeNamePair
-swift_getMangledTypeName(const Metadata *type);
+SWIFT_RUNTIME_STDLIB_API SWIFT_CC(swift)
+TypeNamePair swift_getMangledTypeName(const Metadata *type);
+
+SWIFT_END_DECLS
 
 } // end namespace swift
 

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -101,12 +101,16 @@ struct YieldOnceCoroutine<ResultTy(ArgTys...)> {
 
 #endif
 
+SWIFT_BEGIN_DECLS
+
 /// A standard routine, suitable for placement in the value witness
 /// table, for copying an opaque POD object.
 SWIFT_RUNTIME_EXPORT
 OpaqueValue *swift_copyPOD(OpaqueValue *dest,
                            OpaqueValue *src,
                            const Metadata *self);
+
+SWIFT_END_DECLS
 
 template <>
 inline void ValueWitnessTable::publishLayout(const TypeLayout &layout) {
@@ -131,40 +135,41 @@ template <> inline bool ValueWitnessTable::checkIsComplete() const {
 
 // Standard value-witness tables.
 
-#define BUILTIN_TYPE(Symbol, _) \
-  SWIFT_RUNTIME_EXPORT const ValueWitnessTable VALUE_WITNESS_SYM(Symbol);
-#define BUILTIN_POINTER_TYPE(Symbol, _) \
-  SWIFT_RUNTIME_EXPORT const ValueWitnessTable VALUE_WITNESS_SYM(Symbol);
+SWIFT_BEGIN_DECLS
+
+#define BUILTIN_TYPE(Symbol, _)                                                 \
+  SWIFT_RUNTIME_EXPORT extern const ValueWitnessTable VALUE_WITNESS_SYM(Symbol);
+#define BUILTIN_POINTER_TYPE(Symbol, _)                                         \
+  SWIFT_RUNTIME_EXPORT extern const ValueWitnessTable VALUE_WITNESS_SYM(Symbol);
 #include "swift/Runtime/BuiltinTypes.def"
 
 // The () -> () table can be used for arbitrary function types.
 SWIFT_RUNTIME_EXPORT
-const ValueWitnessTable
+extern const ValueWitnessTable
   VALUE_WITNESS_SYM(FUNCTION_MANGLING);     // () -> ()
 
 // The @differentiable(reverse) () -> () table can be used for differentiable
 // function types.
 SWIFT_RUNTIME_EXPORT
-const ValueWitnessTable
-  VALUE_WITNESS_SYM(DIFF_FUNCTION_MANGLING); // @differentiable(reverse) () -> ()
+extern const ValueWitnessTable VALUE_WITNESS_SYM(DIFF_FUNCTION_MANGLING);
 
 // The @noescape () -> () table can be used for arbitrary noescaping function types.
 SWIFT_RUNTIME_EXPORT
-const ValueWitnessTable
-  VALUE_WITNESS_SYM(NOESCAPE_FUNCTION_MANGLING);     // @noescape () -> ()
+extern const ValueWitnessTable VALUE_WITNESS_SYM(NOESCAPE_FUNCTION_MANGLING);
 
 // The @convention(thin) () -> () table can be used for arbitrary thin function types.
 SWIFT_RUNTIME_EXPORT
-const ValueWitnessTable
-  VALUE_WITNESS_SYM(THIN_FUNCTION_MANGLING);    // @convention(thin) () -> ()
+extern const ValueWitnessTable VALUE_WITNESS_SYM(THIN_FUNCTION_MANGLING);
 
 // The () table can be used for arbitrary empty types.
 SWIFT_RUNTIME_EXPORT
-const ValueWitnessTable VALUE_WITNESS_SYM(EMPTY_TUPLE_MANGLING);        // ()
+extern const ValueWitnessTable VALUE_WITNESS_SYM(EMPTY_TUPLE_MANGLING);
 
-// The table for aligned-pointer-to-pointer types.
+// The Builtin.NativeObject.Type table for aligned-pointer-to-pointer types.
 SWIFT_RUNTIME_EXPORT
-const ValueWitnessTable METATYPE_VALUE_WITNESS_SYM(Bo); // Builtin.NativeObject.Type
+extern const ValueWitnessTable METATYPE_VALUE_WITNESS_SYM(Bo);
+
+SWIFT_END_DECLS
 
 /// Return the value witnesses for unmanaged pointers.
 static inline const ValueWitnessTable &getUnmanagedPointerValueWitnesses() {
@@ -184,35 +189,38 @@ getUnmanagedPointerPointerValueWitnesses() {
 
 using OpaqueMetadata = TargetOpaqueMetadata<InProcess>;
 
+SWIFT_BEGIN_DECLS
+
 // Standard POD opaque metadata.
 // The "Int" metadata are used for arbitrary POD data with the
 // matching characteristics.
 using FullOpaqueMetadata = FullMetadata<OpaqueMetadata>;
-#define BUILTIN_TYPE(Symbol, Name) \
-    SWIFT_RUNTIME_EXPORT \
-    const FullOpaqueMetadata METADATA_SYM(Symbol);
+#define BUILTIN_TYPE(Symbol, Name)                                              \
+    SWIFT_RUNTIME_EXPORT extern const FullOpaqueMetadata METADATA_SYM(Symbol);
 #include "swift/Runtime/BuiltinTypes.def"
 
 /// The standard metadata for the empty tuple type.
 SWIFT_RUNTIME_EXPORT
-const
-  FullMetadata<TupleTypeMetadata> METADATA_SYM(EMPTY_TUPLE_MANGLING);
+extern const FullMetadata<TupleTypeMetadata> METADATA_SYM(EMPTY_TUPLE_MANGLING);
 
 /// The standard metadata for the empty protocol composition type, Any.
 SWIFT_RUNTIME_EXPORT
-const
-  FullMetadata<ExistentialTypeMetadata> METADATA_SYM(ANY_MANGLING);
+extern const FullMetadata<ExistentialTypeMetadata> METADATA_SYM(ANY_MANGLING);
 
 /// The standard metadata for the empty class-constrained protocol composition
 /// type, AnyObject.
 SWIFT_RUNTIME_EXPORT
-const
-  FullMetadata<ExistentialTypeMetadata> METADATA_SYM(ANYOBJECT_MANGLING);
+extern const FullMetadata<ExistentialTypeMetadata>
+METADATA_SYM(ANYOBJECT_MANGLING);
+
+SWIFT_END_DECLS
 
 
 /// True if two context descriptors in the currently running program describe
 /// the same context.
 bool equalContexts(const ContextDescriptor *a, const ContextDescriptor *b);
+
+SWIFT_BEGIN_DECLS
 
 /// Determines whether two type context descriptors describe the same type
 /// context.
@@ -228,10 +236,14 @@ SWIFT_CC(swift)
 bool swift_compareTypeContextDescriptors(const TypeContextDescriptor *lhs,
                                          const TypeContextDescriptor *rhs);
 
+SWIFT_END_DECLS
+
 /// Compute the bounds of class metadata with a resilient superclass.
 ClassMetadataBounds getResilientMetadataBounds(
                                            const ClassDescriptor *descriptor);
 int32_t getResilientImmediateMembersOffset(const ClassDescriptor *descriptor);
+
+SWIFT_BEGIN_DECLS
 
 /// Fetch a uniqued metadata object for a nominal type which requires
 /// singleton metadata initialization.
@@ -313,7 +325,7 @@ swift_getGenericMetadata(MetadataRequest request,
 ///   - installing new v-table entries and overrides; and
 ///   - registering the class with the runtime under ObjC interop.
 /// Most of this work can be achieved by calling swift_initClassMetadata.
-SWIFT_EXTERN_C SWIFT_RETURNS_NONNULL SWIFT_NODISCARD SWIFT_RUNTIME_EXPORT_ATTRIBUTE
+SWIFT_RETURNS_NONNULL SWIFT_NODISCARD SWIFT_RUNTIME_EXPORT
 ClassMetadata *
 swift_allocateGenericClassMetadata(const ClassDescriptor *description,
                                    const void *arguments,
@@ -322,7 +334,7 @@ swift_allocateGenericClassMetadata(const ClassDescriptor *description,
 /// Allocate a generic value metadata object.  This is intended to be
 /// called by the metadata instantiation function of a generic struct or
 /// enum.
-SWIFT_EXTERN_C SWIFT_RETURNS_NONNULL SWIFT_NODISCARD SWIFT_RUNTIME_EXPORT_ATTRIBUTE
+SWIFT_RETURNS_NONNULL SWIFT_NODISCARD SWIFT_RUNTIME_EXPORT
 ValueMetadata *
 swift_allocateGenericValueMetadata(const ValueTypeDescriptor *description,
                                    const void *arguments,
@@ -555,7 +567,11 @@ size_t swift_getTupleTypeLayout2(TypeLayout *tupleLayout,
                                  const TypeLayout *elt0,
                                  const TypeLayout *elt1);
 
+SWIFT_END_DECLS
+
 struct OffsetPair { size_t First; size_t Second; };
+
+SWIFT_BEGIN_DECLS
 
 /// Perform layout as if for a three-element tuple whose elements have
 /// the given layouts.
@@ -723,6 +739,8 @@ OpaqueValue *swift_assignExistentialWithCopy(OpaqueValue *dest,
                                              const OpaqueValue *src,
                                              const Metadata *type);
 
+SWIFT_END_DECLS
+
 /// Perform a copy-assignment from one existential container to another.
 /// Both containers must be of the same existential type representable with no
 /// witness tables.
@@ -828,6 +846,8 @@ inline constexpr unsigned swift_getFunctionPointerExtraInhabitantCount() {
 std::string nameForMetadata(const Metadata *type,
                             bool qualified = true);
 
+SWIFT_BEGIN_DECLS
+
 /// Register a block of protocol records for dynamic lookup.
 SWIFT_RUNTIME_EXPORT
 void swift_registerProtocols(const ProtocolRecord *begin,
@@ -842,6 +862,8 @@ void swift_registerProtocolConformances(const ProtocolConformanceRecord *begin,
 SWIFT_RUNTIME_EXPORT
 void swift_registerTypeMetadataRecords(const TypeMetadataRecord *begin,
                                        const TypeMetadataRecord *end);
+
+SWIFT_END_DECLS
 
 /// Return the superclass, if any.  The result is nullptr for root
 /// classes and class protocol types.
@@ -861,6 +883,8 @@ void verifyMangledNameRoundtrip(const Metadata *metadata);
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
 const TypeContextDescriptor *swift_getTypeContextDescriptor(const Metadata *type);
+
+SWIFT_BEGIN_DECLS
 
 // Defined in KeyPath.swift in the standard library.
 SWIFT_RUNTIME_EXPORT
@@ -899,6 +923,8 @@ void swift_enableDynamicReplacementScope(const DynamicReplacementScope *scope);
 
 SWIFT_RUNTIME_EXPORT
 void swift_disableDynamicReplacementScope(const DynamicReplacementScope *scope);
+
+SWIFT_END_DECLS
 
 #pragma clang diagnostic pop
 

--- a/include/swift/Runtime/Numeric.h
+++ b/include/swift/Runtime/Numeric.h
@@ -60,11 +60,15 @@ public:
   size_t getBitWidth() const { return Flags.getBitWidth(); }
 };
 
-SWIFT_RUNTIME_EXPORT SWIFT_CC(swift) 
+SWIFT_BEGIN_DECLS
+
+SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
 float swift_intToFloat32(IntegerLiteral value);
 
 SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
 double swift_intToFloat64(IntegerLiteral value);
+
+SWIFT_END_DECLS
 
 // TODO: Float16 instead of just truncating from float?
 // TODO: Float80 on x86?

--- a/include/swift/Runtime/Once.h
+++ b/include/swift/Runtime/Once.h
@@ -23,6 +23,8 @@ namespace swift {
 
 typedef swift::once_t swift_once_t;
 
+SWIFT_BEGIN_DECLS
+
 /// Runs the given function with the given context argument exactly once.
 /// The predicate argument must point to a global or static variable of static
 /// extent of type swift_once_t.
@@ -31,6 +33,8 @@ typedef swift::once_t swift_once_t;
 /// this is exposed so that the compiler can generate calls to it.
 SWIFT_RUNTIME_EXPORT
 void swift_once(swift_once_t *predicate, void (*fn)(void *), void *context);
+
+SWIFT_END_DECLS
 
 }
 

--- a/stdlib/public/BackDeployConcurrency/ConcurrencyRuntime.h
+++ b/stdlib/public/BackDeployConcurrency/ConcurrencyRuntime.h
@@ -52,27 +52,32 @@ struct AsyncTaskAndContext {
   AsyncContext *InitialContext;
 };
 
+SWIFT_BEGIN_DECLS
+
 /// Create a task object.
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
-AsyncTaskAndContext swift_task_create(
-    size_t taskCreateFlags,
-    TaskOptionRecord *options,
-    const Metadata *futureResultType,
-    void *closureEntry, HeapObject *closureContext);
+AsyncTaskAndContext swift_task_create(size_t taskCreateFlags,
+                                      TaskOptionRecord *options,
+                                      const Metadata *futureResultType,
+                                      void *closureEntry,
+                                      HeapObject *closureContext);
+
+SWIFT_END_DECLS
 
 /// Caution: not all future-initializing functions actually throw, so
 /// this signature may be incorrect.
 using FutureAsyncSignature =
   AsyncSignature<void(void*), /*throws*/ true>;
 
+SWIFT_BEGIN_DECLS
+
 /// Create a task object.
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
-AsyncTaskAndContext swift_task_create_common(
-    size_t taskCreateFlags,
-    TaskOptionRecord *options,
-    const Metadata *futureResultType,
-    FutureAsyncSignature::FunctionType *function, void *closureContext,
-    size_t initialContextSize);
+AsyncTaskAndContext
+swift_task_create_common(size_t taskCreateFlags, TaskOptionRecord *options,
+                         const Metadata *futureResultType,
+                         FutureAsyncSignature::FunctionType *function,
+                         void *closureContext, size_t initialContextSize);
 
 /// Allocate memory in a task.
 ///
@@ -290,11 +295,15 @@ void swift_asyncLet_begin(AsyncLet *alet,
                           void *closureEntryPoint, HeapObject *closureContext,
                           void *resultBuffer);
 
+SWIFT_END_DECLS
+
 /// This matches the ABI of a closure `<T>(Builtin.RawPointer) async -> T`
 using AsyncLetWaitSignature =
     SWIFT_CC(swiftasync)
     void(OpaqueValue *,
          SWIFT_ASYNC_CONTEXT AsyncContext *, AsyncTask *, Metadata *);
+
+SWIFT_BEGIN_DECLS
 
 /// DEPRECATED. swift_asyncLet_get is used instead.
 /// Wait for a non-throwing async-let to complete.
@@ -609,6 +618,8 @@ void swift_task_localValuePop();
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_localsCopyTo(AsyncTask* target);
 
+SWIFT_END_DECLS
+
 /// This should have the same representation as an enum like this:
 ///    enum NearestTaskDeadline {
 ///      case none
@@ -626,6 +637,8 @@ struct NearestTaskDeadline {
   TaskDeadline Value;
   Kind ValueKind;
 };
+
+SWIFT_BEGIN_DECLS
 
 /// Returns the nearest deadline that's been registered with this task.
 ///
@@ -670,8 +683,12 @@ void swift_task_enqueue(Job *job, ExecutorRef executor);
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_enqueueGlobal(Job *job);
 
+SWIFT_END_DECLS
+
 /// A count in nanoseconds.
 using JobDelay = unsigned long long;
+
+SWIFT_BEGIN_DECLS
 
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_enqueueGlobalWithDelay(JobDelay delay, Job *job);
@@ -680,34 +697,57 @@ void swift_task_enqueueGlobalWithDelay(JobDelay delay, Job *job);
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_enqueueMainExecutor(Job *job);
 
+SWIFT_END_DECLS
+
 #if SWIFT_CONCURRENCY_ENABLE_DISPATCH
+
+SWIFT_BEGIN_DECLS
 
 /// Enqueue the given job on the main executor.
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_enqueueOnDispatchQueue(Job *job, HeapObject *queue);
 
+SWIFT_END_DECLS
+
 #endif
 
 /// A hook to take over global enqueuing.
 typedef SWIFT_CC(swift) void (*swift_task_enqueueGlobal_original)(Job *job);
-SWIFT_EXPORT_FROM(swift_Concurrency)
-SWIFT_CC(swift) void (*swift_task_enqueueGlobal_hook)(
+
+SWIFT_BEGIN_DECLS
+
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+extern void (*swift_task_enqueueGlobal_hook)(
     Job *job, swift_task_enqueueGlobal_original original);
+
+SWIFT_END_DECLS
 
 /// A hook to take over global enqueuing with delay.
 typedef SWIFT_CC(swift) void (*swift_task_enqueueGlobalWithDelay_original)(
     unsigned long long delay, Job *job);
-SWIFT_EXPORT_FROM(swift_Concurrency)
-SWIFT_CC(swift) void (*swift_task_enqueueGlobalWithDelay_hook)(
+
+SWIFT_BEGIN_DECLS
+
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+extern void (*swift_task_enqueueGlobalWithDelay_hook)(
     unsigned long long delay, Job *job,
     swift_task_enqueueGlobalWithDelay_original original);
+
+SWIFT_END_DECLS
 
 /// A hook to take over main executor enqueueing.
 typedef SWIFT_CC(swift) void (*swift_task_enqueueMainExecutor_original)(
     Job *job);
-SWIFT_EXPORT_FROM(swift_Concurrency)
-SWIFT_CC(swift) void (*swift_task_enqueueMainExecutor_hook)(
+
+SWIFT_BEGIN_DECLS
+
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+extern void (*swift_task_enqueueMainExecutor_hook)(
     Job *job, swift_task_enqueueMainExecutor_original original);
+
+SWIFT_END_DECLS
+
+SWIFT_BEGIN_DECLS
 
 /// Initialize the runtime storage for a default actor.
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
@@ -788,7 +828,7 @@ void swift_continuation_throwingResumeWithError(AsyncTask *continuation,
                                                 /* +1 */ SwiftError *error);
 
 /// SPI helper to log a misuse of a `CheckedContinuation` to the appropriate places in the OS.
-extern "C" SWIFT_CC(swift)
+SWIFT_CC(swift)
 void swift_continuation_logFailedCheck(const char *message);
 
 /// Drain the queue
@@ -825,7 +865,11 @@ void swift_task_reportUnexpectedExecutor(
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 JobPriority swift_task_getCurrentThreadPriority(void);
 
+SWIFT_END_DECLS
+
 #if SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR
+
+SWIFT_BEGIN_DECLS
 
 /// Donate this thread to the global executor until either the
 /// given condition returns true or we've run out of cooperative
@@ -834,9 +878,14 @@ SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_donateThreadToGlobalExecutorUntil(bool (*condition)(void*),
                                                   void *context);
 
+SWIFT_END_DECLS
+
 #endif
 
 #ifdef __APPLE__
+
+SWIFT_BEIGN_DECLS
+
 /// A magic symbol whose address is the mask to apply to a frame pointer to
 /// signal that it is an async frame. Do not try to read the actual value of
 /// this global, it will crash.
@@ -846,6 +895,9 @@ void swift_task_donateThreadToGlobalExecutorUntil(bool (*condition)(void*),
 /// the bit is not used and the address is always 0.
 SWIFT_EXPORT_FROM(swift_Concurrency)
 struct { char c; } swift_async_extendedFramePointerFlags;
+
+SWIFT_END_DECLS
+
 #endif
 
 }

--- a/stdlib/public/Concurrency/Clock.cpp
+++ b/stdlib/public/Concurrency/Clock.cpp
@@ -24,8 +24,9 @@
 
 using namespace swift;
 
-SWIFT_EXPORT_FROM(swift_Concurrency)
-SWIFT_CC(swift)
+SWIFT_BEGIN_DECLS
+
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_get_time(
   long long *seconds,
   long long *nanoseconds,
@@ -108,8 +109,7 @@ void swift_get_time(
   abort(); // Invalid clock_id
 }
 
-SWIFT_EXPORT_FROM(swift_Concurrency)
-SWIFT_CC(swift)
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_get_clock_res(
   long long *seconds,
   long long *nanoseconds,
@@ -168,3 +168,5 @@ switch (clock_id) {
   }
   abort(); // Invalid clock_id
 }
+
+SWIFT_END_DECLS

--- a/stdlib/public/Concurrency/Debug.h
+++ b/stdlib/public/Concurrency/Debug.h
@@ -21,33 +21,42 @@
 
 namespace swift {
 
+SWIFT_BEGIN_DECLS
+
 // Dispatch knows about these symbol names. Don't change them without consulting
 // dispatch.
 
 /// The metadata pointer used for job objects.
 SWIFT_EXPORT_FROM(swift_Concurrency)
-const void *const _swift_concurrency_debug_jobMetadata;
+extern const void *const _swift_concurrency_debug_jobMetadata;
 
 /// The metadata pointer used for async task objects.
 SWIFT_EXPORT_FROM(swift_Concurrency)
-const void *const _swift_concurrency_debug_asyncTaskMetadata;
+extern const void *const _swift_concurrency_debug_asyncTaskMetadata;
 
 /// A fake metadata pointer placed at the start of async task slab allocations.
 SWIFT_EXPORT_FROM(swift_Concurrency)
-const void *const _swift_concurrency_debug_asyncTaskSlabMetadata;
+extern const void *const _swift_concurrency_debug_asyncTaskSlabMetadata;
 
 SWIFT_EXPORT_FROM(swift_Concurrency)
-const void *const _swift_concurrency_debug_non_future_adapter;
+extern const void *const _swift_concurrency_debug_non_future_adapter;
+
 SWIFT_EXPORT_FROM(swift_Concurrency)
-const void *const _swift_concurrency_debug_future_adapter;
+extern const void *const _swift_concurrency_debug_future_adapter;
+
 SWIFT_EXPORT_FROM(swift_Concurrency)
-const void *const _swift_concurrency_debug_task_wait_throwing_resume_adapter;
+extern const void *const
+_swift_concurrency_debug_task_wait_throwing_resume_adapter;
+
 SWIFT_EXPORT_FROM(swift_Concurrency)
-const void *const _swift_concurrency_debug_task_future_wait_resume_adapter;
+extern const void *const
+_swift_concurrency_debug_task_future_wait_resume_adapter;
 
 /// Whether the runtime we are inspecting supports priority escalation
 SWIFT_EXPORT_FROM(swift_Concurrency)
-bool _swift_concurrency_debug_supportsPriorityEscalation;
+extern bool _swift_concurrency_debug_supportsPriorityEscalation;
+
+SWIFT_END_DECLS
 
 } // namespace swift
 

--- a/stdlib/public/Concurrency/GlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/GlobalExecutor.cpp
@@ -61,17 +61,20 @@
 
 using namespace swift;
 
-SWIFT_CC(swift)
-void (*swift::swift_task_enqueueGlobal_hook)(
-    Job *job, swift_task_enqueueGlobal_original original) = nullptr;
+namespace swift {
+
+SWIFT_BEGIN_DECLS
 
 SWIFT_CC(swift)
-void (*swift::swift_task_enqueueGlobalWithDelay_hook)(
-    JobDelay delay, Job *job,
-    swift_task_enqueueGlobalWithDelay_original original) = nullptr;
+void (*swift_task_enqueueGlobal_hook)(Job *job,
+                                      swift_task_enqueueGlobal_original original) = nullptr;
 
 SWIFT_CC(swift)
-void (*swift::swift_task_enqueueGlobalWithDeadline_hook)(
+void (*swift_task_enqueueGlobalWithDelay_hook)(JobDelay delay, Job *job,
+                                               swift_task_enqueueGlobalWithDelay_original original) = nullptr;
+
+SWIFT_CC(swift)
+void (*swift_task_enqueueGlobalWithDeadline_hook)(
     long long sec,
     long long nsec,
     long long tsec,
@@ -80,8 +83,12 @@ void (*swift::swift_task_enqueueGlobalWithDeadline_hook)(
     swift_task_enqueueGlobalWithDeadline_original original) = nullptr;
 
 SWIFT_CC(swift)
-void (*swift::swift_task_enqueueMainExecutor_hook)(
+void (*swift_task_enqueueMainExecutor_hook)(
     Job *job, swift_task_enqueueMainExecutor_original original) = nullptr;
+
+SWIFT_END_DECLS
+
+}
 
 #if SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR
 #include "CooperativeGlobalExecutor.inc"

--- a/stdlib/public/Distributed/DistributedActor.cpp
+++ b/stdlib/public/Distributed/DistributedActor.cpp
@@ -32,13 +32,16 @@ findDistributedAccessor(const char *targetNameStart, size_t targetNameLength) {
   return nullptr;
 }
 
-SWIFT_CC(swift)
-SWIFT_EXPORT_FROM(swiftDistributed)
+SWIFT_BEGIN_DECLS
+
+SWIFT_EXPORT_FROM(swiftDistributed) SWIFT_CC(swift)
 void *swift_distributed_getGenericEnvironment(const char *targetNameStart,
                                               size_t targetNameLength) {
   auto *accessor = findDistributedAccessor(targetNameStart, targetNameLength);
   return accessor ? accessor->GenericEnvironment.get() : nullptr;
 }
+
+SWIFT_END_DECLS
 
 /// func _executeDistributedTarget<D: DistributedTargetInvocationDecoder>(
 ///    on: AnyObject,
@@ -64,9 +67,12 @@ using TargetExecutorSignature =
                         /*decoderWitnessTable=*/void **),
                    /*throws=*/true>;
 
-SWIFT_CC(swiftasync)
-SWIFT_EXPORT_FROM(swiftDistributed)
-TargetExecutorSignature::FunctionType swift_distributed_execute_target;
+SWIFT_BEGIN_DECLS
+
+SWIFT_CC(swiftasync) SWIFT_EXPORT_FROM(swiftDistributed)
+extern TargetExecutorSignature::FunctionType swift_distributed_execute_target;
+
+SWIFT_END_DECLS
 
 /// Accessor takes:
 ///   - an async context

--- a/stdlib/public/SwiftShims/swift/shims/GlobalObjects.h
+++ b/stdlib/public/SwiftShims/swift/shims/GlobalObjects.h
@@ -27,8 +27,9 @@
 #ifndef __swift__
 namespace swift {
 #endif
-extern "C" {
 #endif
+
+SWIFT_BEGIN_DECLS
 
 struct _SwiftArrayBodyStorage {
   __swift_intptr_t count;
@@ -41,7 +42,7 @@ struct _SwiftEmptyArrayStorage {
 };
 
 SWIFT_RUNTIME_STDLIB_API
-struct _SwiftEmptyArrayStorage _swiftEmptyArrayStorage;
+extern struct _SwiftEmptyArrayStorage _swiftEmptyArrayStorage;
 
 struct _SwiftDictionaryBodyStorage {
   __swift_intptr_t count;
@@ -79,19 +80,19 @@ struct _SwiftEmptySetSingleton {
 };
 
 SWIFT_RUNTIME_STDLIB_API
-struct _SwiftEmptyDictionarySingleton _swiftEmptyDictionarySingleton;
+extern struct _SwiftEmptyDictionarySingleton _swiftEmptyDictionarySingleton;
 
 SWIFT_RUNTIME_STDLIB_API
-struct _SwiftEmptySetSingleton _swiftEmptySetSingleton;
+extern struct _SwiftEmptySetSingleton _swiftEmptySetSingleton;
 
 struct _SwiftHashingParameters {
   __swift_uint64_t seed0;
   __swift_uint64_t seed1;
   __swift_bool deterministic;
 };
-  
+
 SWIFT_RUNTIME_STDLIB_API
-struct _SwiftHashingParameters _swift_stdlib_Hashing_parameters;
+extern struct _SwiftHashingParameters _swift_stdlib_Hashing_parameters;
 
 #ifdef __cplusplus
 
@@ -105,7 +106,8 @@ static_assert(
     4 * sizeof(__swift_intptr_t) + sizeof(__swift_int64_t),
   "_SwiftSetBodyStorage has unexpected size");
 
-} // extern "C"
+SWIFT_END_DECLS
+
 #ifndef __swift__
 } // namespace swift
 #endif

--- a/stdlib/public/SwiftShims/swift/shims/Visibility.h
+++ b/stdlib/public/SwiftShims/swift/shims/Visibility.h
@@ -204,26 +204,22 @@
 #define SWIFT_IMAGE_EXPORTS_swift_Differentiation 0
 #endif
 
-#define SWIFT_EXPORT_FROM_ATTRIBUTE(LIBRARY)                          \
-  SWIFT_MACRO_IF(SWIFT_IMAGE_EXPORTS_##LIBRARY,                       \
-                 SWIFT_ATTRIBUTE_FOR_EXPORTS,                         \
-                 SWIFT_ATTRIBUTE_FOR_IMPORTS)
+#define SWIFT_EXPORT_FROM(LIBRARY)                                              \
+  SWIFT_MACRO_IF(SWIFT_IMAGE_EXPORTS_##LIBRARY,                                 \
+                 SWIFT_ATTRIBUTE_FOR_EXPORTS, SWIFT_ATTRIBUTE_FOR_IMPORTS)
 
-// SWIFT_EXPORT_FROM(LIBRARY) declares something to be a C-linkage
-// entity exported by the given library.
-//
+#if defined(__cplusplus)
+#define SWIFT_BEGIN_DECLS extern "C" {
+#define SWIFT_END_DECLS }
+#else
+#define SWIFT_BEGIN_DECLS
+#define SWIFT_END_DECLS
+#endif
+
 // SWIFT_RUNTIME_EXPORT is just SWIFT_EXPORT_FROM(swiftCore).
 //
 // TODO: use this in shims headers in overlays.
-#if defined(__cplusplus)
-#define SWIFT_EXPORT_FROM(LIBRARY) extern "C" SWIFT_EXPORT_FROM_ATTRIBUTE(LIBRARY)
-#define SWIFT_EXTERN_C extern "C" 
-#else
-#define SWIFT_EXPORT_FROM(LIBRARY) SWIFT_EXPORT_FROM_ATTRIBUTE(LIBRARY)
-#define SWIFT_EXTERN_C
-#endif
 #define SWIFT_RUNTIME_EXPORT SWIFT_EXPORT_FROM(swiftCore)
-#define SWIFT_RUNTIME_EXPORT_ATTRIBUTE SWIFT_EXPORT_FROM_ATTRIBUTE(swiftCore)
 
 #if __cplusplus > 201402l && __has_cpp_attribute(fallthrough)
 #define SWIFT_FALLTHROUGH [[fallthrough]]

--- a/stdlib/public/runtime/AnyHashableSupport.cpp
+++ b/stdlib/public/runtime/AnyHashableSupport.cpp
@@ -131,6 +131,8 @@ const Metadata *swift::hashable_support::findHashableBaseType(
   return findHashableBaseTypeImpl</*KnownToConformToHashable=*/ false>(type);
 }
 
+SWIFT_BEGIN_DECLS
+
 // internal func _makeAnyHashableUsingDefaultRepresentation<H : Hashable>(
 //   of value: H,
 //   storingResultInto result: UnsafeMutablePointer<AnyHashable>)
@@ -192,3 +194,4 @@ void _swift_makeAnyHashableUpcastingToHashableBaseType(
   }
 }
 
+SWIFT_END_DECLS

--- a/stdlib/public/runtime/Array.cpp
+++ b/stdlib/public/runtime/Array.cpp
@@ -134,6 +134,8 @@ static void array_copy_operation(OpaqueValue *dest, OpaqueValue *src,
   } while (i != 0);
 }
 
+SWIFT_BEGIN_DECLS
+
 SWIFT_RUNTIME_EXPORT
 void swift_arrayInitWithCopy(OpaqueValue *dest, OpaqueValue *src, size_t count,
                              const Metadata *self) {
@@ -208,3 +210,5 @@ void swift_arrayDestroy(OpaqueValue *begin, size_t count, const Metadata *self) 
     wtable->destroy(obj, self);
   }
 }
+
+SWIFT_END_DECLS

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -65,11 +65,15 @@ static const char *class_getName(const ClassMetadata* type) {
     reinterpret_cast<Class>(const_cast<ClassMetadata*>(type)));
 }
 
+SWIFT_BEGIN_DECLS
+
 // Aliases for Swift runtime entry points for Objective-C types.
-extern "C" const void *swift_dynamicCastObjCProtocolConditional(
-                         const void *object,
-                         size_t numProtocols,
-                         Protocol * const *protocols);
+const void *
+swift_dynamicCastObjCProtocolConditional(const void *object,
+                                         size_t numProtocols,
+                                         Protocol * const *protocols);
+
+SWIFT_END_DECLS
 #endif
 
 #if SWIFT_STDLIB_HAS_TYPE_PRINTING
@@ -152,8 +156,12 @@ static Lazy<llvm::DenseMap<llvm::StringRef, std::pair<const char *, size_t>>>
 /// Access MUST be protected using `MangledToPrettyFunctionNameCache`.
   MangledToPrettyFunctionNameCache;
 
+namespace swift {
+
+SWIFT_BEGIN_DECLS
+
 TypeNamePair
-swift::swift_getTypeName(const Metadata *type, bool qualified) {
+swift_getTypeName(const Metadata *type, bool qualified) {
   TypeNameCacheKey key = TypeNameCacheKey(type, qualified ? TypeNameKind::Qualified: TypeNameKind::NotQualified);
   auto &cache = TypeNameCache.get();
 
@@ -191,6 +199,10 @@ swift::swift_getTypeName(const Metadata *type, bool qualified) {
     cache.insert({key, {result, size}});
     return TypeNamePair{result, size};
   }
+}
+
+SWIFT_END_DECLS
+
 }
 
 /// Return mangled name for the given type.
@@ -425,12 +437,19 @@ _dynamicCastClassMetatype(const ClassMetadata *sourceType,
 }
 
 #if !SWIFT_OBJC_INTEROP // __SwiftValue is a native class
+
+SWIFT_BEGIN_DECLS
+
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
 bool swift_unboxFromSwiftValueWithType(OpaqueValue *source,
                                        OpaqueValue *result,
                                        const Metadata *destinationType);
+
 /// Nominal type descriptor for Swift.__SwiftValue
-extern "C" const ClassDescriptor NOMINAL_TYPE_DESCR_SYM(s12__SwiftValueC);
+extern const ClassDescriptor NOMINAL_TYPE_DESCR_SYM(s12__SwiftValueC);
+
+SWIFT_END_DECLS
+
 #endif
 
 /// Dynamically cast a class instance to a Swift class type.
@@ -683,9 +702,13 @@ findDynamicValueAndType(OpaqueValue *value, const Metadata *type,
   }
 }
 
-extern "C" const Metadata *
-swift::swift_getDynamicType(OpaqueValue *value, const Metadata *self,
-                            bool existentialMetatype) {
+namespace swift {
+
+SWIFT_BEGIN_DECLS
+
+const Metadata *
+swift_getDynamicType(OpaqueValue *value, const Metadata *self,
+                     bool existentialMetatype) {
   OpaqueValue *outValue;
   const Metadata *outType;
   bool canTake = false;
@@ -695,10 +718,16 @@ swift::swift_getDynamicType(OpaqueValue *value, const Metadata *self,
   return outType;
 }
 
+SWIFT_END_DECLS
+
+}
+
 #if SWIFT_OBJC_INTEROP
+
+SWIFT_BEGIN_DECLS
+
 SWIFT_RUNTIME_EXPORT
-id
-swift_dynamicCastMetatypeToObjectConditional(const Metadata *metatype) {
+id swift_dynamicCastMetatypeToObjectConditional(const Metadata *metatype) {
   switch (metatype->getKind()) {
   case MetadataKind::Class:
   case MetadataKind::ObjCClassWrapper:
@@ -713,9 +742,10 @@ swift_dynamicCastMetatypeToObjectConditional(const Metadata *metatype) {
 }
 
 SWIFT_RUNTIME_EXPORT
-id
-swift_dynamicCastMetatypeToObjectUnconditional(const Metadata *metatype,
-                                               const char *file, unsigned line, unsigned column) {
+id swift_dynamicCastMetatypeToObjectUnconditional(const Metadata *metatype,
+                                                  const char *file,
+                                                  unsigned line,
+                                                  unsigned column) {
   switch (metatype->getKind()) {
   case MetadataKind::Class:
   case MetadataKind::ObjCClassWrapper:
@@ -732,6 +762,8 @@ swift_dynamicCastMetatypeToObjectUnconditional(const Metadata *metatype,
   }
   }
 }
+
+SWIFT_END_DECLS
 
 #endif
 
@@ -1202,7 +1234,11 @@ MetadataResponse _getBridgedObjectiveCType(
   
 } // unnamed namespace
 
-extern "C" const ProtocolDescriptor PROTOCOL_DESCR_SYM(s21_ObjectiveCBridgeable);
+SWIFT_BEGIN_DECLS
+
+extern const ProtocolDescriptor PROTOCOL_DESCR_SYM(s21_ObjectiveCBridgeable);
+
+SWIFT_END_DECLS
 
 #if SWIFT_OBJC_INTEROP
 static id bridgeAnythingNonVerbatimToObjectiveC(OpaqueValue *src,
@@ -1317,11 +1353,20 @@ id _bridgeAnythingNonVerbatimToObjectiveC(OpaqueValue *src,
 #define BRIDGING_CONFORMANCE_SYM \
   MANGLE_SYM(s19_BridgeableMetatypeVs21_ObjectiveCBridgeablesWP)
 
-extern "C" const _ObjectiveCBridgeableWitnessTable BRIDGING_CONFORMANCE_SYM;
+SWIFT_BEGIN_DECLS
+
+const _ObjectiveCBridgeableWitnessTable BRIDGING_CONFORMANCE_SYM;
+
+SWIFT_END_DECLS
+
 #endif
 
 /// Nominal type descriptor for Swift.String.
-extern "C" const StructDescriptor NOMINAL_TYPE_DESCR_SYM(SS);
+SWIFT_BEGIN_DECLS
+
+extern const StructDescriptor NOMINAL_TYPE_DESCR_SYM(SS);
+
+SWIFT_END_DECLS
 
 static const _ObjectiveCBridgeableWitnessTable *
 swift_conformsToObjectiveCBridgeable(const Metadata *T) {
@@ -1378,7 +1423,10 @@ findBridgeWitness(const Metadata *T) {
 // Called by inlined stdlib code.
 #define _getBridgedNonVerbatimObjectiveCType \
   MANGLE_SYM(s36_getBridgedNonVerbatimObjectiveCTypeyypXpSgxmlF)
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
+
+SWIFT_BEGIN_DECLS
+
+SWIFT_RUNTIME_STDLIB_API SWIFT_CC(swift)
 const Metadata *_getBridgedNonVerbatimObjectiveCType(
   const Metadata *value, const Metadata *T
 ) {
@@ -1395,28 +1443,30 @@ const Metadata *_getBridgedNonVerbatimObjectiveCType(
   return nullptr;
 }
 
+SWIFT_END_DECLS
+
 #if SWIFT_OBJC_INTEROP
+
+SWIFT_BEGIN_DECLS
 
 // @_silgen_name("_bridgeNonVerbatimFromObjectiveCToAny")
 // func _bridgeNonVerbatimFromObjectiveCToAny(
 //     x: AnyObject,
 //     inout result: Any?
 // )
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
-void
-_bridgeNonVerbatimFromObjectiveCToAny(HeapObject *sourceValue,
-                                      OpaqueValue *destValue);
+SWIFT_RUNTIME_STDLIB_INTERNAL SWIFT_CC(swift)
+extern void _bridgeNonVerbatimFromObjectiveCToAny(HeapObject *sourceValue,
+                                                  OpaqueValue *destValue);
 
 // @_silgen_name("_bridgeNonVerbatimBoxedValue")
 // func _bridgeNonVerbatimBoxedValue<NativeType>(
 //     x: UnsafePointer<NativeType>,
 //     inout result: NativeType?
 // )
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
-void
-_bridgeNonVerbatimBoxedValue(const OpaqueValue *sourceValue,
-                             OpaqueValue *destValue,
-                             const Metadata *nativeType);
+SWIFT_RUNTIME_STDLIB_INTERNAL SWIFT_CC(swift)
+extern void _bridgeNonVerbatimBoxedValue(const OpaqueValue *sourceValue,
+                                         OpaqueValue *destValue,
+                                         const Metadata *nativeType);
 
 // Try bridging by conversion to Any or boxing if applicable.
 static bool tryBridgeNonVerbatimFromObjectiveCUniversal(
@@ -1462,15 +1512,12 @@ static bool tryBridgeNonVerbatimFromObjectiveCUniversal(
 // Called by inlined stdlib code.
 #define _bridgeNonVerbatimFromObjectiveC \
   MANGLE_SYM(s32_bridgeNonVerbatimFromObjectiveCyyyXl_xmxSgztlF)
+
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
-void
-_bridgeNonVerbatimFromObjectiveC(
-  HeapObject *sourceValue,
-  const Metadata *nativeType,
-  OpaqueValue *destValue,
-  const Metadata *nativeType_
-) {
-  
+void _bridgeNonVerbatimFromObjectiveC(HeapObject *sourceValue,
+                                      const Metadata *nativeType,
+                                      OpaqueValue *destValue,
+                                      const Metadata *nativeType_) {
   if (tryBridgeNonVerbatimFromObjectiveCUniversal(sourceValue, nativeType,
                                                   destValue))
     return;
@@ -1509,14 +1556,12 @@ _bridgeNonVerbatimFromObjectiveC(
 /// Called by inlined stdlib code.
 #define _bridgeNonVerbatimFromObjectiveCConditional \
   MANGLE_SYM(s43_bridgeNonVerbatimFromObjectiveCConditionalySbyXl_xmxSgztlF)
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
-bool
-_bridgeNonVerbatimFromObjectiveCConditional(
-  HeapObject *sourceValue,
-  const Metadata *nativeType,
-  OpaqueValue *destValue,
-  const Metadata *nativeType_
-) {
+
+SWIFT_RUNTIME_STDLIB_API SWIFT_CC(swift)
+bool _bridgeNonVerbatimFromObjectiveCConditional(HeapObject *sourceValue,
+                                                 const Metadata *nativeType,
+                                                 OpaqueValue *destValue,
+                                                 const Metadata *nativeType_) {
   if (tryBridgeNonVerbatimFromObjectiveCUniversal(sourceValue, nativeType,
                                                   destValue))
     return true;
@@ -1552,13 +1597,18 @@ _bridgeNonVerbatimFromObjectiveCConditional(
     destValue, nativeType, nativeType, bridgeWitness);
 }
 
+SWIFT_END_DECLS
+
 #endif // SWIFT_OBJC_INTEROP
 
 // func _isBridgedNonVerbatimToObjectiveC<T>(_: T.Type) -> Bool
 // Called by inlined stdlib code.
 #define _isBridgedNonVerbatimToObjectiveC \
   MANGLE_SYM(s33_isBridgedNonVerbatimToObjectiveCySbxmlF)
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
+
+SWIFT_BEGIN_DECLS
+
+SWIFT_RUNTIME_STDLIB_API SWIFT_CC(swift)
 bool _isBridgedNonVerbatimToObjectiveC(const Metadata *value,
                                        const Metadata *T) {
   assert(!swift_isClassOrObjCExistentialTypeImpl(T));
@@ -1568,22 +1618,22 @@ bool _isBridgedNonVerbatimToObjectiveC(const Metadata *value,
 }
 
 // func _isClassOrObjCExistential<T>(x: T.Type) -> Bool
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
+SWIFT_RUNTIME_STDLIB_API SWIFT_CC(swift)
 bool _swift_isClassOrObjCExistentialType(const Metadata *value,
-                                                    const Metadata *T) {
+                                         const Metadata *T) {
   return swift_isClassOrObjCExistentialTypeImpl(T);
 }
 
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
+SWIFT_RUNTIME_STDLIB_API SWIFT_CC(swift)
 void _swift_setClassMetadata(const HeapMetadata *newClassMetadata,
-                             HeapObject* onObject,
-                             const Metadata *T) {
+                             HeapObject* onObject, const Metadata *T) {
   assert(T == newClassMetadata);
   onObject->metadata = newClassMetadata;
 }
 
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
-const Metadata *swift::_swift_class_getSuperclass(const Metadata *theClass) {
+namespace swift {
+SWIFT_RUNTIME_STDLIB_INTERNAL SWIFT_CC(swift)
+const Metadata *_swift_class_getSuperclass(const Metadata *theClass) {
   if (const ClassMetadata *classType = theClass->getClassObject()) {
     if (classHasSuperclass(classType))
       return getMetadataForClass(classType->Superclass);
@@ -1596,6 +1646,7 @@ const Metadata *swift::_swift_class_getSuperclass(const Metadata *theClass) {
   }
 
   return nullptr;
+}
 }
 
 // Called by compiler-generated cast code.
@@ -1610,13 +1661,18 @@ bool swift_isOptionalType(const Metadata *type) {
   return type->getKind() == MetadataKind::Optional;
 }
 
+SWIFT_END_DECLS
+
 #if !SWIFT_OBJC_INTEROP
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
+
+SWIFT_BEGIN_DECLS
+
+SWIFT_RUNTIME_STDLIB_INTERNAL SWIFT_CC(swift)
 bool _swift_isOptional(OpaqueValue *src, const Metadata *type) {
   return swift_isOptionalType(type);
 }
 
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_SPI
+SWIFT_RUNTIME_STDLIB_SPI SWIFT_CC(swift)
 HeapObject *_swift_extractDynamicValue(OpaqueValue *value, const Metadata *self) {
   OpaqueValue *outValue;
   const Metadata *outType;
@@ -1635,7 +1691,7 @@ HeapObject *_swift_extractDynamicValue(OpaqueValue *value, const Metadata *self)
   return nullptr;
 }
 
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
+SWIFT_RUNTIME_STDLIB_INTERNAL SWIFT_CC(swift)
 HeapObject *_swift_bridgeToObjectiveCUsingProtocolIfPossible(
   OpaqueValue *src, const Metadata *srcType) {
   assert(!swift_isClassOrObjCExistentialTypeImpl(srcType));
@@ -1657,6 +1713,9 @@ HeapObject *_swift_bridgeToObjectiveCUsingProtocolIfPossible(
     return nullptr;
   }
 }
+
+SWIFT_END_DECLS
+
 #endif
 
 #define OVERRIDE_CASTING COMPATIBILITY_OVERRIDE

--- a/stdlib/public/runtime/DynamicCast.cpp
+++ b/stdlib/public/runtime/DynamicCast.cpp
@@ -155,13 +155,24 @@ static HeapObject * getNonNullSrcObject(OpaqueValue *srcValue,
 
 #define _bridgeAnythingToObjectiveC                                 \
   MANGLE_SYM(s27_bridgeAnythingToObjectiveCyyXlxlF)
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
+
+SWIFT_BEGIN_DECLS
+
+SWIFT_RUNTIME_STDLIB_API SWIFT_CC(swift)
 HeapObject *_bridgeAnythingToObjectiveC(
   OpaqueValue *src, const Metadata *srcType);
 
+SWIFT_END_DECLS
+
 #if SWIFT_OBJC_INTEROP
+
+SWIFT_BEGIN_DECLS
+
 SWIFT_RUNTIME_EXPORT
-id swift_dynamicCastMetatypeToObjectConditional(const Metadata *metatype);
+extern id swift_dynamicCastMetatypeToObjectConditional(const Metadata *metatype);
+
+SWIFT_END_DECLS
+
 #endif
 
 // protocol _ObjectiveCBridgeable {

--- a/stdlib/public/runtime/Enum.cpp
+++ b/stdlib/public/runtime/Enum.cpp
@@ -26,7 +26,7 @@ using namespace swift;
 
 // So remote inspection/debugging tools can obtain
 // information about this process.
-SWIFT_RUNTIME_STDLIB_SPI
+extern "C" SWIFT_RUNTIME_STDLIB_SPI
 const uint64_t _swift_debug_multiPayloadEnumPointerSpareBitsMask
   = _swift_abi_SwiftSpareBitsMask;
 
@@ -332,9 +332,13 @@ swift::swift_storeEnumTagMultiPayload(OpaqueValue *value,
   }
 }
 
+namespace swift {
+
+SWIFT_BEGIN_DECLS
+
 unsigned
-swift::swift_getEnumCaseMultiPayload(const OpaqueValue *value,
-                                     const EnumMetadata *enumType) {
+swift_getEnumCaseMultiPayload(const OpaqueValue *value,
+                              const EnumMetadata *enumType) {
   auto layout = getMultiPayloadLayout(enumType);
   unsigned numPayloads = enumType->getDescription()->getNumPayloadCases();
 
@@ -354,4 +358,8 @@ swift::swift_getEnumCaseMultiPayload(const OpaqueValue *value,
              + numPayloads;
     }
   }
+}
+
+SWIFT_END_DECLS
+
 }

--- a/stdlib/public/runtime/EnvironmentVariables.cpp
+++ b/stdlib/public/runtime/EnvironmentVariables.cpp
@@ -237,10 +237,18 @@ void swift::runtime::environment::initialize(void *context) {
 }
 #endif
 
+SWIFT_BEGIN_DECLS
+
 SWIFT_RUNTIME_EXPORT
 bool swift_COWChecksEnabled() {
   return runtime::environment::SWIFT_DEBUG_ENABLE_COW_CHECKS();
 }
+
+SWIFT_END_DECLS
+
+namespace swift {
+namespace runtime {
+namespace environment {
 
 SWIFT_RUNTIME_STDLIB_SPI bool concurrencyEnableCooperativeQueues() {
   return runtime::environment::
@@ -255,4 +263,8 @@ SWIFT_RUNTIME_STDLIB_SPI bool concurrencyEnableJobDispatchIntegration() {
 
 SWIFT_RUNTIME_STDLIB_SPI bool concurrencyValidateUncheckedContinuations() {
   return runtime::environment::SWIFT_DEBUG_VALIDATE_UNCHECKED_CONTINUATIONS();
+}
+
+}
+}
 }

--- a/stdlib/public/runtime/ErrorDefaultImpls.cpp
+++ b/stdlib/public/runtime/ErrorDefaultImpls.cpp
@@ -19,9 +19,11 @@
 #include "swift/Runtime/Metadata.h"
 using namespace swift;
 
+SWIFT_BEGIN_DECLS
+
 // @_silgen_name("_swift_stdlib_getDefaultErrorCode")
 // func _getDefaultErrorCode<T : Error>(_ x: T) -> Int
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_SPI
+SWIFT_RUNTIME_STDLIB_SPI SWIFT_CC(swift)
 intptr_t _swift_stdlib_getDefaultErrorCode(OpaqueValue *error,
                                            const Metadata *T,
                                            const WitnessTable *Error) {
@@ -39,3 +41,5 @@ intptr_t _swift_stdlib_getDefaultErrorCode(OpaqueValue *error,
 
   return result;
 }
+
+SWIFT_END_DECLS

--- a/stdlib/public/runtime/ErrorObjectCommon.cpp
+++ b/stdlib/public/runtime/ErrorObjectCommon.cpp
@@ -26,13 +26,20 @@ using namespace swift;
 
 void (*swift::_swift_willThrow)(SwiftError *error);
 
+namespace swift {
+
+SWIFT_BEGIN_DECLS
+
 /// Breakpoint hook for debuggers, and calls _swift_willThrow if set.
-SWIFT_CC(swift) void
-swift::swift_willThrow(SWIFT_CONTEXT void *unused,
-                       SWIFT_ERROR_RESULT SwiftError **error) {
+SWIFT_CC(swift) void swift_willThrow(SWIFT_CONTEXT void *unused,
+                                     SWIFT_ERROR_RESULT SwiftError **error) {
   // Cheap check to bail out early, since we expect there to be no callbacks
   // the vast majority of the time.
   if (SWIFT_LIKELY(!_swift_willThrow))
     return;
   _swift_willThrow(*error);
+}
+
+SWIFT_END_DECLS
+
 }

--- a/stdlib/public/runtime/ErrorObjectNative.cpp
+++ b/stdlib/public/runtime/ErrorObjectNative.cpp
@@ -64,11 +64,13 @@ static const FullMetadata<HeapMetadata> ErrorMetadata{
   HeapMetadata(MetadataKind::ErrorObject),
 };
 
-BoxPair
-swift::swift_allocError(const swift::Metadata *type,
-                        const swift::WitnessTable *errorConformance,
-                        OpaqueValue *initialValue,
-                        bool isTake) {
+namespace swift {
+
+SWIFT_BEGIN_DECLS
+
+BoxPair swift_allocError(const swift::Metadata *type,
+                         const swift::WitnessTable *errorConformance,
+                         OpaqueValue *initialValue, bool isTake) {
   auto sizeAndAlign = _getErrorAllocatedSizeAndAlignmentMask(type);
   
   auto allocated = swift_allocObject(&ErrorMetadata,
@@ -91,27 +93,28 @@ swift::swift_allocError(const swift::Metadata *type,
   return BoxPair{allocated, valuePtr};
 }
 
-void
-swift::swift_deallocError(SwiftError *error, const Metadata *type) {
+void swift_deallocError(SwiftError *error, const Metadata *type) {
   auto sizeAndAlign = _getErrorAllocatedSizeAndAlignmentMask(type);
   swift_deallocUninitializedObject(error, sizeAndAlign.first, sizeAndAlign.second);
 }
 
-void
-swift::swift_getErrorValue(const SwiftError *errorObject,
-                           void **scratch,
-                           ErrorValueResult *out) {
+void swift_getErrorValue(const SwiftError *errorObject, void **scratch,
+                         ErrorValueResult *out) {
   out->value = errorObject->getValue();
   out->type = errorObject->type;
   out->errorConformance = errorObject->errorConformance;
 }
 
-SwiftError *swift::swift_errorRetain(SwiftError *error) {
+SwiftError *swift_errorRetain(SwiftError *error) {
   return static_cast<SwiftError*>(swift_retain(error));
 }
 
-void swift::swift_errorRelease(SwiftError *error) {
+void swift_errorRelease(SwiftError *error) {
   swift_release(error);
+}
+
+SWIFT_END_DECLS
+
 }
 
 #endif

--- a/stdlib/public/runtime/ErrorObjectTestSupport.h
+++ b/stdlib/public/runtime/ErrorObjectTestSupport.h
@@ -19,7 +19,12 @@
 
 namespace swift {
 
-SWIFT_RUNTIME_EXPORT void (*_swift_willThrow)(SwiftError *error);
+SWIFT_BEGIN_DECLS
+
+SWIFT_RUNTIME_EXPORT
+extern void (*_swift_willThrow)(SwiftError *error);
+
+SWIFT_END_DECLS
 
 }
 

--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -323,6 +323,8 @@ reportNow(uint32_t flags, const char *message)
 #endif
 }
 
+SWIFT_BEGIN_DECLS
+
 SWIFT_NOINLINE SWIFT_RUNTIME_EXPORT void
 _swift_runtime_on_report(uintptr_t flags, const char *message,
                          RuntimeErrorDetails *details) {
@@ -335,6 +337,8 @@ _swift_runtime_on_report(uintptr_t flags, const char *message,
                : // Clobber list, empty.
                );
 }
+
+SWIFT_END_DECLS
 
 void swift::_swift_reportToDebugger(uintptr_t flags, const char *message,
                                     RuntimeErrorDetails *details) {
@@ -404,11 +408,16 @@ swift::warning(uint32_t flags, const char *format, ...)
   warningv(flags, format, args);
 }
 
+SWIFT_BEGIN_DECLS
+
 // Crash when a deleted method is called by accident.
-SWIFT_RUNTIME_EXPORT SWIFT_NORETURN void swift_deletedMethodError() {
+SWIFT_RUNTIME_EXPORT SWIFT_NORETURN
+void swift_deletedMethodError() {
   swift::fatalError(/* flags = */ 0,
                     "Fatal error: Call of deleted method\n");
 }
+
+SWIFT_END_DECLS
 
 // Crash due to a retain count overflow.
 // FIXME: can't pass the object's address from InlineRefCounts without hacks

--- a/stdlib/public/runtime/Float16Support.cpp
+++ b/stdlib/public/runtime/Float16Support.cpp
@@ -56,6 +56,8 @@ static float fromEncoding(unsigned int e) {
 // but who knows what could go wrong, and they're tiny functions.
 # include <immintrin.h>
 
+SWIFT_BEGIN_DECLS
+
 SWIFT_RUNTIME_EXPORT float __gnu_h2f_ieee(short h) {
   return _mm_cvtss_f32(_mm_cvtph_ps(_mm_set_epi64x(0,h)));
 }
@@ -66,7 +68,11 @@ SWIFT_RUNTIME_EXPORT short __gnu_f2h_ieee(float f) {
   );
 }
 
+SWIFT_END_DECLS
+
 #else
+
+SWIFT_BEGIN_DECLS
 
 // Input in di, result in xmm0. We can get that calling convention in C++
 // by taking a int16 arg instead of Float16, which we don't have (or else
@@ -117,7 +123,11 @@ SWIFT_RUNTIME_EXPORT unsigned short __gnu_f2h_ieee(float f) {
   return (int)signbit >> 16 | magnitude;
 }
 
+SWIFT_END_DECLS
+
 #endif
+
+SWIFT_BEGIN_DECLS
 
 // Input in xmm0, result in di. We can get that calling convention in C++
 // by returning uint16 instead of Float16, which we don't have (or else
@@ -150,10 +160,18 @@ SWIFT_RUNTIME_EXPORT unsigned short __truncdfhf2(double d) {
   return __gnu_f2h_ieee(f);
 }
 
+SWIFT_END_DECLS
+
 #if defined(__ARM_EABI__)
+
+SWIFT_BEGIN_DECLS
+
 SWIFT_RUNTIME_EXPORT unsigned short __aeabi_d2h(double d) {
   return __truncdfhf2(d);
 }
+
+SWIFT_END_DECLS
+
 #endif
 
 #endif // defined(__x86_64__) && !defined(__APPLE__)

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -140,10 +140,14 @@ HeapObject *swift::swift_allocObject(HeapMetadata const *metadata,
   CALL_IMPL(swift_allocObject, (metadata, requiredSize, requiredAlignmentMask));
 }
 
+SWIFT_BEGIN_DECLS
+
 SWIFT_RUNTIME_EXPORT
 HeapObject *(*SWIFT_RT_DECLARE_ENTRY _swift_allocObject)(
     HeapMetadata const *metadata, size_t requiredSize,
     size_t requiredAlignmentMask) = _swift_allocObject_;
+
+SWIFT_END_DECLS
 
 HeapObject *
 swift::swift_initStackObject(HeapMetadata const *metadata,
@@ -200,15 +204,19 @@ swift::swift_verifyEndOfLifetime(HeapObject *object) {
                       "Fatal error: Weak reference to stack object\n");
 }
 
+SWIFT_BEGIN_DECLS
+
 /// Allocate a reference-counted object on the heap that
 /// occupies <size> bytes of maximally-aligned storage.  The object is
 /// uninitialized except for its header.
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_SPI
-HeapObject* swift_bufferAllocate(
-  HeapMetadata const* bufferType, size_t size, size_t alignMask)
+SWIFT_RUNTIME_STDLIB_SPI SWIFT_CC(swift)
+HeapObject* swift_bufferAllocate(HeapMetadata const* bufferType, size_t size,
+                                 size_t alignMask)
 {
   return swift::swift_allocObject(bufferType, size, alignMask);
 }
+
+SWIFT_END_DECLS
 
 namespace {
 /// Heap object destructor for a generic box allocated with swift_allocBox.
@@ -359,9 +367,13 @@ HeapObject *swift::swift_retain(HeapObject *object) {
 #endif
 }
 
+SWIFT_BEGIN_DECLS
+
 SWIFT_RUNTIME_EXPORT
 HeapObject *(*SWIFT_RT_DECLARE_ENTRY _swift_retain)(HeapObject *object) =
     _swift_retain_;
+
+SWIFT_END_DECLS
 
 HeapObject *swift::swift_nonatomic_retain(HeapObject *object) {
   SWIFT_RT_TRACK_INVOCATION(object, swift_nonatomic_retain);
@@ -386,9 +398,13 @@ HeapObject *swift::swift_retain_n(HeapObject *object, uint32_t n) {
 #endif
 }
 
+SWIFT_BEGIN_DECLS
+
 SWIFT_RUNTIME_EXPORT
 HeapObject *(*SWIFT_RT_DECLARE_ENTRY _swift_retain_n)(
     HeapObject *object, uint32_t n) = _swift_retain_n_;
+
+SWIFT_END_DECLS
 
 HeapObject *swift::swift_nonatomic_retain_n(HeapObject *object, uint32_t n) {
   SWIFT_RT_TRACK_INVOCATION(object, swift_nonatomic_retain_n);
@@ -412,9 +428,13 @@ void swift::swift_release(HeapObject *object) {
 #endif
 }
 
+SWIFT_BEGIN_DECLS
+
 SWIFT_RUNTIME_EXPORT
 void (*SWIFT_RT_DECLARE_ENTRY _swift_release)(HeapObject *object) =
     _swift_release_;
+
+SWIFT_END_DECLS
 
 void swift::swift_nonatomic_release(HeapObject *object) {
   SWIFT_RT_TRACK_INVOCATION(object, swift_nonatomic_release);
@@ -437,9 +457,13 @@ void swift::swift_release_n(HeapObject *object, uint32_t n) {
 #endif
 }
 
+SWIFT_BEGIN_DECLS
+
 SWIFT_RUNTIME_EXPORT
 void (*SWIFT_RT_DECLARE_ENTRY _swift_release_n)(HeapObject *object,
                                                 uint32_t n) = _swift_release_n_;
+
+SWIFT_END_DECLS
 
 void swift::swift_nonatomic_release_n(HeapObject *object, uint32_t n) {
   SWIFT_RT_TRACK_INVOCATION(object, swift_nonatomic_release_n);
@@ -598,9 +622,13 @@ HeapObject *swift::swift_tryRetain(HeapObject *object) {
   CALL_IMPL(swift_tryRetain, (object));
 }
 
+SWIFT_BEGIN_DECLS
+
 SWIFT_RUNTIME_EXPORT
 HeapObject *(*SWIFT_RT_DECLARE_ENTRY _swift_tryRetain)(HeapObject *object) =
     _swift_tryRetain_;
+
+SWIFT_END_DECLS
 
 bool swift::swift_isDeallocating(HeapObject *object) {
   if (!isValidPointerForNativeRetain(object))
@@ -950,6 +978,8 @@ WeakReference *swift::swift_weakTakeAssign(WeakReference *dest,
 
 #ifndef NDEBUG
 
+SWIFT_BEGIN_DECLS
+
 /// Returns true if the "immutable" flag is set on \p object.
 ///
 /// Used for runtime consistency checking of COW buffers.
@@ -966,6 +996,8 @@ SWIFT_RUNTIME_EXPORT
 bool _swift_setImmutableCOWBuffer(HeapObject *object, bool immutable) {
   return object->refCounts.setIsImmutableCOWBuffer(immutable);
 }
+
+SWIFT_END_DECLS
 
 void HeapObject::dump() const {
   auto *Self = const_cast<HeapObject *>(this);

--- a/stdlib/public/runtime/KeyPaths.cpp
+++ b/stdlib/public/runtime/KeyPaths.cpp
@@ -18,10 +18,14 @@
 
 using namespace swift;
 
+SWIFT_BEGIN_DECLS
+
 SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
 void swift_copyKeyPathTrivialIndices(const void *src, void *dest, size_t bytes) {
   memcpy(dest, src, bytes);
 }
+
+SWIFT_END_DECLS
 
 SWIFT_CC(swift)
 static bool equateGenericArguments(const void *a, const void *b, size_t bytes) {
@@ -47,6 +51,8 @@ struct KeyPathGenericWitnessTable {
   SWIFT_CC(swift) intptr_t (* __ptrauth_swift_runtime_function_entry_with_key(swift::SpecialPointerAuthDiscriminators::KeyPathHash) hash)(const void *src, size_t bytes);
 };
 
+SWIFT_BEGIN_DECLS
+
 /// A prefab witness table for computed key path components that only include
 /// captured generic arguments.
 SWIFT_RUNTIME_EXPORT
@@ -56,6 +62,8 @@ KeyPathGenericWitnessTable swift_keyPathGenericWitnessTable = {
   equateGenericArguments,
   hashGenericArguments,
 };
+
+SWIFT_END_DECLS
 
 /****************************************************************************/
 /** Projection functions ****************************************************/

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -6493,9 +6493,13 @@ const TypeContextDescriptor *swift::swift_getTypeContextDescriptor(const Metadat
 // implementation of these functions is in the standard library in
 // KeyPath.swift.
 
+SWIFT_BEGIN_DECLS
+
 SWIFT_RUNTIME_STDLIB_SPI
-const HeapObject *swift_getKeyPathImpl(const void *pattern,
-                                       const void *arguments);
+extern const HeapObject *swift_getKeyPathImpl(const void *pattern,
+                                              const void *arguments);
+
+SWIFT_END_DECLS
 
 #define OVERRIDE_KEYPATH COMPATIBILITY_OVERRIDE
 #define OVERRIDE_WITNESSTABLE COMPATIBILITY_OVERRIDE

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1936,7 +1936,9 @@ swift_getTypeByMangledNameImpl(MetadataRequest request, StringRef typeName,
                                     substGenericParam, substWitnessTable);
 }
 
-SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT
+SWIFT_BEGIN_DECLS
+
+SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
 const Metadata * _Nullable
 swift_getTypeByMangledNameInEnvironment(
                         const char *typeNameStart,
@@ -1955,7 +1957,7 @@ swift_getTypeByMangledNameInEnvironment(
     }).getType().getMetadata();
 }
 
-SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT
+SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
 const Metadata * _Nullable
 swift_getTypeByMangledNameInEnvironmentInMetadataState(
                         size_t metadataState,
@@ -1975,7 +1977,7 @@ swift_getTypeByMangledNameInEnvironmentInMetadataState(
     }).getType().getMetadata();
 }
 
-SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT
+SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
 const Metadata * _Nullable
 swift_getTypeByMangledNameInContext(
                         const char *typeNameStart,
@@ -1994,7 +1996,7 @@ swift_getTypeByMangledNameInContext(
     }).getType().getMetadata();
 }
 
-SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT
+SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
 const Metadata * _Nullable
 swift_getTypeByMangledNameInContextInMetadataState(
                         size_t metadataState,
@@ -2015,7 +2017,7 @@ swift_getTypeByMangledNameInContextInMetadataState(
 }
 
 /// Demangle a mangled name, but don't allow symbolic references.
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
+SWIFT_RUNTIME_STDLIB_INTERNAL SWIFT_CC(swift)
 const Metadata *_Nullable
 swift_stdlib_getTypeByMangledNameUntrusted(const char *typeNameStart,
                                            size_t typeNameLength) {
@@ -2028,6 +2030,8 @@ swift_stdlib_getTypeByMangledNameUntrusted(const char *typeNameStart,
   return swift_getTypeByMangledName(MetadataState::Complete, typeName, nullptr,
                                     {}, {}).getType().getMetadata();
 }
+
+SWIFT_END_DECLS
 
 // ==== Function metadata functions ----------------------------------------------
 
@@ -2111,8 +2115,9 @@ static const Metadata *decodeType(TypeDecoder<DecodedMetadataBuilder> &decoder,
   return builtTypeOrError.getType();
 }
 
-SWIFT_CC(swift)
-SWIFT_RUNTIME_STDLIB_SPI
+SWIFT_BEGIN_DECLS
+
+SWIFT_RUNTIME_STDLIB_SPI SWIFT_CC(swift)
 unsigned swift_func_getParameterCount(const char *typeNameStart,
                                       size_t typeNameLength) {
   StackAllocatedDemangler<1024> demangler;
@@ -2126,7 +2131,8 @@ unsigned swift_func_getParameterCount(const char *typeNameStart,
   return parameterList->getNumChildren();
 }
 
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_SPI
+
+SWIFT_RUNTIME_STDLIB_SPI SWIFT_CC(swift)
 const Metadata *_Nullable
 swift_func_getReturnTypeInfo(const char *typeNameStart, size_t typeNameLength,
                              GenericEnvironmentDescriptor *genericEnv,
@@ -2162,9 +2168,8 @@ swift_func_getReturnTypeInfo(const char *typeNameStart, size_t typeNameLength,
   return decodeType(decoder, resultType->getFirstChild());
 }
 
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_SPI
-unsigned
-swift_func_getParameterTypeInfo(
+SWIFT_RUNTIME_STDLIB_SPI SWIFT_CC(swift)
+unsigned swift_func_getParameterTypeInfo(
     const char *typeNameStart, size_t typeNameLength,
     GenericEnvironmentDescriptor *genericEnv,
     const void * const *genericArguments,
@@ -2220,8 +2225,7 @@ swift_func_getParameterTypeInfo(
   return typesLength;
 }
 
-SWIFT_CC(swift)
-SWIFT_RUNTIME_STDLIB_SPI
+SWIFT_RUNTIME_STDLIB_SPI SWIFT_CC(swift)
 BufferAndSize
 swift_distributed_getWitnessTables(GenericEnvironmentDescriptor *genericEnv,
                                    const void *const *genericArguments) {
@@ -2256,7 +2260,7 @@ swift_distributed_getWitnessTables(GenericEnvironmentDescriptor *genericEnv,
 
 // ==== End of Function metadata functions ---------------------------------------
 
-SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT
+SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
 MetadataResponse
 swift_getOpaqueTypeMetadata(MetadataRequest request,
                             const void * const *arguments,
@@ -2275,7 +2279,7 @@ swift_getOpaqueTypeMetadata(MetadataRequest request,
     }).getType().getResponse();
 }
 
-SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT
+SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
 const WitnessTable *
 swift_getOpaqueTypeConformance(const void * const *arguments,
                                const OpaqueTypeDescriptor *descriptor,
@@ -2285,6 +2289,8 @@ swift_getOpaqueTypeConformance(const void * const *arguments,
                                     arguments, descriptor, index);
   return (const WitnessTable *)response.Value;
 }
+
+SWIFT_END_DECLS
 
 #if SWIFT_OBJC_INTEROP
 

--- a/stdlib/public/runtime/Numeric.cpp
+++ b/stdlib/public/runtime/Numeric.cpp
@@ -50,10 +50,18 @@ static T convert(IntegerLiteral value) {
   return result;
 }
 
-float swift::swift_intToFloat32(IntegerLiteral value) {
+namespace swift {
+
+SWIFT_BEGIN_DECLS
+
+float swift_intToFloat32(IntegerLiteral value) {
   return convert<float>(value);
 }
 
-double swift::swift_intToFloat64(IntegerLiteral value) {
+double swift_intToFloat64(IntegerLiteral value) {
   return convert<double>(value);
+}
+
+SWIFT_END_DECLS
+
 }

--- a/stdlib/public/runtime/Once.cpp
+++ b/stdlib/public/runtime/Once.cpp
@@ -42,7 +42,14 @@ static_assert(sizeof(swift_once_t) <= sizeof(void*),
 /// Runs the given function with the given context argument exactly once.
 /// The predicate argument must point to a global or static variable of static
 /// extent of type swift_once_t.
-void swift::swift_once(swift_once_t *predicate, void (*fn)(void *),
-                       void *context) {
+namespace swift {
+
+SWIFT_BEGIN_DECLS
+
+void swift_once(swift_once_t *predicate, void (*fn)(void *), void *context) {
   swift::once(*predicate, fn, context);
+}
+
+SWIFT_END_DECLS
+
 }

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -102,8 +102,13 @@ public:
 };
 
 #if SWIFT_HAS_ISA_MASKING
-  SWIFT_RUNTIME_EXPORT
-  uintptr_t swift_isaMask;
+
+SWIFT_BEGIN_DECLS
+
+SWIFT_RUNTIME_EXPORT
+uintptr_t swift_isaMask;
+
+SWIFT_END_DECLS
 
 // Hardcode the mask. We have our own copy of the value, as it's hard to work
 // out the proper includes from libobjc. The values MUST match the ones from
@@ -133,6 +138,7 @@ public:
 #  else
 #    error Unknown architecture for masked isa.
 #  endif
+
 #endif
 
 #if SWIFT_OBJC_INTEROP
@@ -276,9 +282,13 @@ public:
   const ContextDescriptor *
   _searchConformancesByMangledTypeName(Demangle::NodePointer node);
 
+  SWIFT_BEGIN_DECLS
+
   SWIFT_RUNTIME_EXPORT
   Demangle::NodePointer _swift_buildDemanglingForMetadata(const Metadata *type,
                                                           Demangle::Demangler &Dem);
+
+  SWIFT_END_DECLS
 
   /// Callback used to provide the substitution of a generic parameter
   /// (described by depth/index) to its metadata.
@@ -393,6 +403,9 @@ public:
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wreturn-type-c-linkage" 
+
+  SWIFT_BEGIN_DECLS
+
   /// Retrieve the type metadata described by the given demangled type name.
   ///
   /// \p substGenericParam Function that provides generic argument metadata
@@ -421,6 +434,9 @@ public:
                                const void * const *arguments,
                                SubstGenericParameterFn substGenericParam,
                                SubstDependentWitnessTableFn substWitnessTable);
+
+  SWIFT_END_DECLS
+
 #pragma clang diagnostic pop
 
   /// Function object that produces substitutions for the generic parameters

--- a/stdlib/public/runtime/ReflectionMirror.cpp
+++ b/stdlib/public/runtime/ReflectionMirror.cpp
@@ -307,12 +307,13 @@ struct swift_closure {
   void *fptr;
   HeapObject *context;
 };
+
 #if SWIFT_LIBRARY_EVOLUTION
-SWIFT_RUNTIME_STDLIB_API SWIFT_CC(swift) swift_closure
-MANGLE_SYM(s20_playgroundPrintHookySScSgvg)();
+extern "C" SWIFT_RUNTIME_STDLIB_API
+SWIFT_CC(swift) swift_closure MANGLE_SYM(s20_playgroundPrintHookySScSgvg)();
 #else
-SWIFT_RUNTIME_STDLIB_API swift_closure
-MANGLE_SYM(s20_playgroundPrintHookySScSgvp);
+extern "C" SWIFT_RUNTIME_STDLIB_API
+swift_closure MANGLE_SYM(s20_playgroundPrintHookySScSgvp);
 #endif
 
 static bool _shouldReportMissingReflectionMetadataWarnings() {
@@ -981,7 +982,7 @@ auto call(OpaqueValue *passedValue, const Metadata *T, const Metadata *passedTyp
 
 
 // func _getNormalizedType<T>(_: T, type: Any.Type) -> Any.Type
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
+extern "C" SWIFT_RUNTIME_STDLIB_API SWIFT_CC(swift)
 const Metadata *swift_reflectionMirror_normalizedType(OpaqueValue *value,
                                                       const Metadata *type,
                                                       const Metadata *T) {
@@ -989,13 +990,13 @@ const Metadata *swift_reflectionMirror_normalizedType(OpaqueValue *value,
 }
 
 // func _getMetadataKind(_ type: Any.Type) -> UInt
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
+extern "C" SWIFT_RUNTIME_STDLIB_API SWIFT_CC(swift)
 uintptr_t swift_getMetadataKind(const Metadata *type) {
   return static_cast<uintptr_t>(type->getKind());
 }
 
 // func _getChildCount<T>(_: T, type: Any.Type) -> Int
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
+extern "C" SWIFT_RUNTIME_STDLIB_API SWIFT_CC(swift)
 intptr_t swift_reflectionMirror_count(OpaqueValue *value,
                                       const Metadata *type,
                                       const Metadata *T) {
@@ -1005,7 +1006,7 @@ intptr_t swift_reflectionMirror_count(OpaqueValue *value,
 }
 
 // func _getChildCount(_ type: Any.Type) -> Int
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
+extern "C" SWIFT_RUNTIME_STDLIB_API SWIFT_CC(swift)
 intptr_t swift_reflectionMirror_recursiveCount(const Metadata *type) {
   return call(nullptr, type, type, [](ReflectionMirrorImpl *impl) {
     return impl->recursiveCount();
@@ -1017,7 +1018,7 @@ intptr_t swift_reflectionMirror_recursiveCount(const Metadata *type) {
 //   index: Int,
 //   fieldMetadata: UnsafeMutablePointer<_FieldReflectionMetadata>
 // ) -> Any.Type
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
+extern "C" SWIFT_RUNTIME_STDLIB_API SWIFT_CC(swift)
 const Metadata *swift_reflectionMirror_recursiveChildMetadata(
                                        const Metadata *type,
                                        intptr_t index,
@@ -1036,7 +1037,7 @@ const Metadata *swift_reflectionMirror_recursiveChildMetadata(
 //   type: Any.Type,
 //   index: Int
 // ) -> Int
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
+extern "C" SWIFT_RUNTIME_STDLIB_API SWIFT_CC(swift)
 intptr_t swift_reflectionMirror_recursiveChildOffset(
                                        const Metadata *type,
                                        intptr_t index) {
@@ -1056,12 +1057,12 @@ intptr_t swift_reflectionMirror_recursiveChildOffset(
 //   outName: UnsafeMutablePointer<UnsafePointer<CChar>?>,
 //   outFreeFunc: UnsafeMutablePointer<NameFreeFunc?>
 // ) -> Any
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
-AnyReturn swift_reflectionMirror_subscript(OpaqueValue *value, const Metadata *type,
-                                           intptr_t index,
-                                           const char **outName,
-                                           void (**outFreeFunc)(const char *),
-                                           const Metadata *T) {
+extern "C" SWIFT_RUNTIME_STDLIB_API
+SWIFT_CC(swift) AnyReturn
+swift_reflectionMirror_subscript(OpaqueValue *value, const Metadata *type,
+                                 intptr_t index, const char **outName,
+                                 void (**outFreeFunc)(const char *),
+                                 const Metadata *T) {
   return call(value, T, type, [&](ReflectionMirrorImpl *impl) {
     return impl->subscript(index, outName, outFreeFunc);
   });
@@ -1069,19 +1070,19 @@ AnyReturn swift_reflectionMirror_subscript(OpaqueValue *value, const Metadata *t
 #pragma clang diagnostic pop
 
 // func _getDisplayStyle<T>(_: T) -> CChar
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
+extern "C" SWIFT_RUNTIME_STDLIB_API SWIFT_CC(swift)
 char swift_reflectionMirror_displayStyle(OpaqueValue *value, const Metadata *T) {
   return call(value, T, nullptr, [](ReflectionMirrorImpl *impl) { return impl->displayStyle(); });
 }
 
 // func _getEnumCaseName<T>(_ value: T) -> UnsafePointer<CChar>?
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
+extern "C" SWIFT_RUNTIME_STDLIB_API SWIFT_CC(swift)
 const char *swift_EnumCaseName(OpaqueValue *value, const Metadata *T) {
   return call(value, T, nullptr, [](ReflectionMirrorImpl *impl) { return impl->enumCaseName(); });
 }
 
 // func _opaqueSummary(_ metadata: Any.Type) -> UnsafePointer<CChar>?
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
+extern "C" SWIFT_RUNTIME_STDLIB_API SWIFT_CC(swift)
 const char *swift_OpaqueSummary(const Metadata *T) {
   switch (T->getKind()) {
     case MetadataKind::Class:
@@ -1121,7 +1122,7 @@ const char *swift_OpaqueSummary(const Metadata *T) {
 
 #if SWIFT_OBJC_INTEROP
 // func _getQuickLookObject<T>(_: T) -> AnyObject?
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
+extern "C" SWIFT_RUNTIME_STDLIB_API SWIFT_CC(swift)
 id swift_reflectionMirror_quickLookObject(OpaqueValue *value, const Metadata *T) {
   return call(value, T, nullptr, [](ReflectionMirrorImpl *impl) { return impl->quickLookObject(); });
 }

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -1509,9 +1509,10 @@ struct ClassExtents {
   size_t positive; 
 };
 
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_SPI
-ClassExtents
-_swift_getSwiftClassInstanceExtents(const Metadata *c) {
+SWIFT_BEGIN_DECLS
+
+SWIFT_RUNTIME_STDLIB_SPI SWIFT_CC(swift)
+ClassExtents _swift_getSwiftClassInstanceExtents(const Metadata *c) {
   assert(c && c->isClassObject());
   auto metaData = c->getClassObject();
   return ClassExtents{
@@ -1520,11 +1521,14 @@ _swift_getSwiftClassInstanceExtents(const Metadata *c) {
   };
 }
 
+SWIFT_END_DECLS
+
 #if SWIFT_OBJC_INTEROP
 
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_SPI
-ClassExtents
-_swift_getObjCClassInstanceExtents(const ClassMetadata* c) {
+SWIFT_BEGIN_DECLS
+
+SWIFT_RUNTIME_STDLIB_SPI SWIFT_CC(swift)
+ClassExtents _swift_getObjCClassInstanceExtents(const ClassMetadata* c) {
   // Pure ObjC classes never have negative extents.
   if (c->isPureObjC())
     return ClassExtents{0, class_getInstanceSize(class_const_cast(c))};
@@ -1532,8 +1536,7 @@ _swift_getObjCClassInstanceExtents(const ClassMetadata* c) {
   return _swift_getSwiftClassInstanceExtents(c);
 }
 
-SWIFT_CC(swift)
-SWIFT_RUNTIME_EXPORT
+SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
 void swift_objc_swift3ImplicitObjCEntrypoint(id self, SEL selector,
                                              const char *filename,
                                              size_t filenameLength,
@@ -1612,6 +1615,8 @@ void swift_objc_swift3ImplicitObjCEntrypoint(id self, SEL selector,
   free(message);
   free(nullTerminatedFilename);
 }
+
+SWIFT_END_DECLS
 
 const Metadata *swift::getNSObjectMetadata() {
   return SWIFT_LAZY_CONSTANT(

--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -24,18 +24,24 @@
 #include <stdlib.h>
 
 namespace swift {
+
+SWIFT_BEGIN_DECLS
+
 // FIXME(ABI)#76 : does this declaration need SWIFT_RUNTIME_STDLIB_API?
 // _direct type metadata for Swift.__EmptyArrayStorage
 SWIFT_RUNTIME_STDLIB_API
-ClassMetadata CLASS_METADATA_SYM(s19__EmptyArrayStorage);
+extern ClassMetadata CLASS_METADATA_SYM(s19__EmptyArrayStorage);
 
 // _direct type metadata for Swift.__EmptyDictionarySingleton
 SWIFT_RUNTIME_STDLIB_API
-ClassMetadata CLASS_METADATA_SYM(s26__EmptyDictionarySingleton);
+extern ClassMetadata CLASS_METADATA_SYM(s26__EmptyDictionarySingleton);
 
 // _direct type metadata for Swift.__EmptySetSingleton
 SWIFT_RUNTIME_STDLIB_API
-ClassMetadata CLASS_METADATA_SYM(s19__EmptySetSingleton);
+extern ClassMetadata CLASS_METADATA_SYM(s19__EmptySetSingleton);
+
+SWIFT_END_DECLS
+
 } // namespace swift
 
 SWIFT_RUNTIME_STDLIB_API

--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -103,10 +103,11 @@ static uint64_t uint64ToStringImpl(char *Buffer, uint64_t Value,
   return size_t(P - Buffer);
 }
 
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
+SWIFT_BEGIN_DECLS
+
+SWIFT_RUNTIME_STDLIB_API SWIFT_CC(swift)
 uint64_t swift_int64ToString(char *Buffer, size_t BufferLength,
-                             int64_t Value, int64_t Radix,
-                             bool Uppercase) {
+                             int64_t Value, int64_t Radix, bool Uppercase) {
   if ((Radix >= 10 && BufferLength < 32) || (Radix < 10 && BufferLength < 65))
     swift::crash("swift_int64ToString: insufficient buffer size");
 
@@ -127,10 +128,9 @@ uint64_t swift_int64ToString(char *Buffer, size_t BufferLength,
                             Negative);
 }
 
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
+SWIFT_RUNTIME_STDLIB_API SWIFT_CC(swift)
 uint64_t swift_uint64ToString(char *Buffer, intptr_t BufferLength,
-                              uint64_t Value, int64_t Radix,
-                              bool Uppercase) {
+                              uint64_t Value, int64_t Radix, bool Uppercase) {
   if ((Radix >= 10 && BufferLength < 32) || (Radix < 10 && BufferLength < 64))
     swift::crash("swift_int64ToString: insufficient buffer size");
 
@@ -140,6 +140,8 @@ uint64_t swift_uint64ToString(char *Buffer, intptr_t BufferLength,
   return uint64ToStringImpl(Buffer, Value, Radix, Uppercase,
                             /*Negative=*/false);
 }
+
+SWIFT_END_DECLS
 
 #if SWIFT_STDLIB_HAS_LOCALE
 #if defined(__APPLE__) || defined(__FreeBSD__) || defined(__ANDROID__)
@@ -175,39 +177,49 @@ static locale_t getCLocale() {
 #endif
 #endif // SWIFT_STDLIB_HAS_LOCALE
 
+SWIFT_BEGIN_DECLS
+
 // TODO: replace this with a float16 implementation instead of calling _float.
 // Argument type will have to stay float, though; only the formatting changes.
 // Note, return type is __swift_ssize_t, not uint64_t as with the other
 // formatters. We'd use this type there if we could, but it's ABI so we can't
 // go back and change it.
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
+SWIFT_RUNTIME_STDLIB_API SWIFT_CC(swift)
 __swift_ssize_t swift_float16ToString(char *Buffer, size_t BufferLength,
                                       float Value, bool Debug) {
   __fp16 v = Value;
   return swift_dtoa_optimal_binary16_p(&v, Buffer, BufferLength);
 }
 
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
+SWIFT_RUNTIME_STDLIB_API SWIFT_CC(swift)
 uint64_t swift_float32ToString(char *Buffer, size_t BufferLength,
                                float Value, bool Debug) {
   return swift_dtoa_optimal_float(Value, Buffer, BufferLength);
 }
 
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
+SWIFT_RUNTIME_STDLIB_API SWIFT_CC(swift)
 uint64_t swift_float64ToString(char *Buffer, size_t BufferLength,
                                double Value, bool Debug) {
   return swift_dtoa_optimal_double(Value, Buffer, BufferLength);
 }
 
+SWIFT_END_DECLS
+
 // We only support float80 on platforms that use that exact format for 'long double'
 // This should match the conditionals in Runtime.swift
 #if !defined(_WIN32) && !defined(__ANDROID__) && (defined(__i386__) || defined(__i686__) || defined(__x86_64__))
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
+
+SWIFT_BEGIN_DECLS
+
+SWIFT_RUNTIME_STDLIB_API SWIFT_CC(swift)
 uint64_t swift_float80ToString(char *Buffer, size_t BufferLength,
                                long double Value, bool Debug) {
   // SwiftDtoa.cpp automatically enables float80 on platforms that use it for 'long double'
   return swift_dtoa_optimal_float80_p(&Value, Buffer, BufferLength);
 }
+
+SWIFT_END_DECLS
+
 #endif
 
 #if SWIFT_STDLIB_HAS_STDIN

--- a/stdlib/public/stubs/ThreadLocalStorage.cpp
+++ b/stdlib/public/stubs/ThreadLocalStorage.cpp
@@ -16,15 +16,18 @@
 #include "swift/Runtime/Debug.h"
 #include "swift/Threading/ThreadLocalStorage.h"
 
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
-void _stdlib_destroyTLS(void *);
+SWIFT_BEGIN_DECLS
 
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
-void *_stdlib_createTLS(void);
+SWIFT_RUNTIME_STDLIB_API SWIFT_CC(swift)
+extern void _stdlib_destroyTLS(void *);
+
+SWIFT_RUNTIME_STDLIB_API SWIFT_CC(swift)
+extern void *_stdlib_createTLS(void);
+
+SWIFT_END_DECLS
 
 SWIFT_RUNTIME_STDLIB_INTERNAL
-void *
-_swift_stdlib_threadLocalStorageGet(void) {
+void * _swift_stdlib_threadLocalStorageGet(void) {
 
 #if SWIFT_THREADING_NONE
 


### PR DESCRIPTION
Although the runtime exported symbols must be exported with "C" linkage and decoration, we split out the externalisation in the C++ mode.  This is required to ensure that we are able to attribute the functions without following the more stringent rules that clang now enforces which place the attributes following the identifier to which they appertain, resulting in the attributes interleaving within the signature.  The resulting spelling is more difficult to process for humans as well as more difficult to identify as function declarations making code perusal a challenge, particularly for the uninitiated.