### PR TITLE
[SILGen] TypeWrappers:  Support default values in user-defined initializers

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5714,6 +5714,11 @@ public:
   /// backing property will be treated as the member-initialized property.
   bool isMemberwiseInitialized(bool preferDeclaredProperties) const;
 
+  /// Check whether this variable presents a local storage synthesized
+  /// by the compiler in a user-defined designated initializer to
+  /// support initialization of type wrapper managed properties.
+  bool isTypeWrapperLocalStorageForInitializer() const;
+
   /// Return the range of semantics attributes attached to this VarDecl.
   auto getSemanticsAttrs() const
       -> decltype(getAttrs().getAttributes<SemanticsAttr>()) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6504,6 +6504,14 @@ bool VarDecl::isMemberwiseInitialized(bool preferDeclaredProperties) const {
   return true;
 }
 
+bool VarDecl::isTypeWrapperLocalStorageForInitializer() const {
+  if (auto *ctor =
+          dyn_cast_or_null<ConstructorDecl>(getDeclContext()->getAsDecl())) {
+    return this == ctor->getLocalTypeWrapperStorageVar();
+  }
+  return false;
+}
+
 bool VarDecl::isLet() const {
   // An awful hack that stabilizes the value of 'isLet' for ParamDecl instances.
   //

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1335,29 +1335,96 @@ void SILGenFunction::emitPatternBinding(PatternBindingDecl *PBD,
   auto initialization = emitPatternBindingInitialization(PBD->getPattern(idx),
                                                          JumpDest::invalid());
 
-  if (auto *Init = PBD->getExecutableInit(idx)) {
+  auto emitInitializer = [&](Expr *initExpr, VarDecl *var, bool forLocalContext,
+                             InitializationPtr &initialization) {
     // If an initial value expression was specified by the decl, emit it into
     // the initialization.
-    FullExpr Scope(Cleanups, CleanupLocation(Init));
+    FullExpr Scope(Cleanups, CleanupLocation(initExpr));
 
-    auto *var = PBD->getSingleVar();
-    if (var && var->getDeclContext()->isLocalContext()) {
+    if (forLocalContext) {
       if (auto *orig = var->getOriginalWrappedProperty()) {
         auto initInfo = orig->getPropertyWrapperInitializerInfo();
         if (auto *placeholder = initInfo.getWrappedValuePlaceholder()) {
-          Init = placeholder->getOriginalWrappedValue();
+          initExpr = placeholder->getOriginalWrappedValue();
 
-          auto value = emitRValue(Init);
-          emitApplyOfPropertyWrapperBackingInitializer(SILLocation(PBD), orig,
-                                                       getForwardingSubstitutionMap(),
-                                                       std::move(value))
-            .forwardInto(*this, SILLocation(PBD), initialization.get());
+          auto value = emitRValue(initExpr);
+          emitApplyOfPropertyWrapperBackingInitializer(
+              PBD, orig, getForwardingSubstitutionMap(), std::move(value))
+              .forwardInto(*this, SILLocation(PBD), initialization.get());
           return;
         }
       }
     }
 
-    emitExprInto(Init, initialization.get(), SILLocation(PBD));
+    emitExprInto(initExpr, initialization.get(), SILLocation(PBD));
+  };
+
+  auto *singleVar = PBD->getSingleVar();
+  if (auto *Init = PBD->getExecutableInit(idx)) {
+    // If an initial value expression was specified by the decl, emit it into
+    // the initialization.
+    bool isLocalVar =
+        singleVar && singleVar->getDeclContext()->isLocalContext();
+    emitInitializer(Init, singleVar, isLocalVar, initialization);
+  } else if (singleVar &&
+             singleVar->isTypeWrapperLocalStorageForInitializer()) {
+    // If any of the type wrapper managed properties had default initializers
+    // we need to emit them as assignments to `_storage` elements as part
+    // of its initialization.
+
+    auto storageVarType = singleVar->getType()->castTo<TupleType>();
+    auto *wrappedDecl = cast<NominalTypeDecl>(
+        singleVar->getDeclContext()->getInnermostTypeContext());
+
+    SmallVector<std::pair<VarDecl *, Expr *>, 2> fieldsToInitialize;
+    fieldsToInitialize.resize_for_overwrite(storageVarType->getNumElements());
+
+    unsigned numInitializable = 0;
+    for (auto member : wrappedDecl->getMembers()) {
+      auto *PBD = dyn_cast<PatternBindingDecl>(member);
+      // Check every member that is managed by the type wrapper.
+      if (!(PBD && PBD->getSingleVar() &&
+            PBD->getSingleVar()->isAccessedViaTypeWrapper()))
+        continue;
+
+      auto *field = PBD->getSingleVar();
+      auto fieldNo = storageVarType->getNamedElementId(field->getName());
+
+      if (auto *initExpr = PBD->getInit(/*index=*/0)) {
+        fieldsToInitialize[fieldNo] = {PBD->getSingleVar(), initExpr};
+        ++numInitializable;
+      }
+    }
+
+    if (numInitializable == 0) {
+      initialization->finishUninitialized(*this);
+      return;
+    }
+
+    // If there are any initializable fields, let's split _storage into
+    // element initializers and emit initializations for individual fields.
+
+    assert(initialization->canSplitIntoTupleElements());
+
+    SmallVector<InitializationPtr, 4> scratch;
+    auto fieldInits = initialization->splitIntoTupleElements(
+        *this, PBD, storageVarType->getCanonicalType(), scratch);
+
+    for (unsigned i : range(fieldInits.size())) {
+      VarDecl *field;
+      Expr *initExpr;
+
+      std::tie(field, initExpr) = fieldsToInitialize[i];
+
+      auto &fieldInit = fieldInits[i];
+      if (initExpr) {
+        emitInitializer(initExpr, field, /*forLocalContext=*/true, fieldInit);
+      } else {
+        fieldInit->finishUninitialized(*this);
+      }
+    }
+
+    initialization->finishInitialization(*this);
   } else {
     // Otherwise, mark it uninitialized for DI to resolve.
     initialization->finishUninitialized(*this);

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
@@ -468,8 +468,6 @@ DIMemoryObjectInfo::getPathStringToElement(unsigned Element,
 
 /// If the specified value is a 'let' property in an initializer, return true.
 bool DIMemoryObjectInfo::isElementLetProperty(unsigned Element) const {
-  NullablePtr<NominalTypeDecl> NTD;
-
   // If this is an element of a `_storage` tuple, we need to
   // check the `$Storage` to determine whether underlying storage
   // backing element is immutable.
@@ -477,15 +475,22 @@ bool DIMemoryObjectInfo::isElementLetProperty(unsigned Element) const {
     auto *wrappedType = cast<NominalTypeDecl>(
         storageVar->getDeclContext()->getInnermostTypeContext());
     assert(wrappedType && "_storage reference without type wrapper");
-    NTD = wrappedType->getTypeWrapperStorageDecl();
-  } else {
-    // If we aren't representing 'self' in a non-delegating initializer, then we
-    // can't have 'let' properties.
-    if (!isNonDelegatingInit())
-      return IsLet;
 
-    NTD = MemorySILType.getNominalOrBoundGenericNominal();
+    auto storageVarType = storageVar->getInterfaceType()->getAs<TupleType>();
+    assert(Element < storageVarType->getNumElements());
+    auto propertyName = storageVarType->getElement(Element).getName();
+
+    auto *storageDecl = wrappedType->getTypeWrapperStorageDecl();
+    auto *property = storageDecl->lookupDirect(propertyName).front();
+    return cast<VarDecl>(property)->isLet();
   }
+
+  // If we aren't representing 'self' in a non-delegating initializer, then we
+  // can't have 'let' properties.
+  if (!isNonDelegatingInit())
+    return IsLet;
+
+  auto NTD = MemorySILType.getNominalOrBoundGenericNominal();
 
   if (!NTD) {
     // Otherwise, we miscounted elements?
@@ -496,7 +501,7 @@ bool DIMemoryObjectInfo::isElementLetProperty(unsigned Element) const {
   auto &Module = MemoryInst->getModule();
 
   auto expansionContext = TypeExpansionContext(*MemoryInst->getFunction());
-  for (auto *VD : NTD.get()->getStoredProperties()) {
+  for (auto *VD : NTD->getStoredProperties()) {
     auto FieldType = MemorySILType.getFieldType(VD, Module, expansionContext);
     unsigned NumFieldElements =
         getElementCountRec(expansionContext, Module, FieldType, false);

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -213,20 +213,6 @@ static void maybeAddTypeWrapperDefaultArg(ParamDecl *arg, VarDecl *var,
   if (!initExpr)
     return;
 
-  // Type wrapper variables are never initialized directly,
-  // initialization expression (if any) becomes an default
-  // argument of the initializer synthesized by the type wrapper.
-  {
-    // Since type wrapper is applied to backing property, that's
-    // the the initializer it subsumes.
-    if (var->hasAttachedPropertyWrapper()) {
-      auto *backingVar = var->getPropertyWrapperBackingProperty();
-      PBD = backingVar->getParentPatternBinding();
-    }
-
-    PBD->setInitializerSubsumed(/*index=*/0);
-  }
-
   arg->setDefaultExpr(initExpr, PBD->isInitializerChecked(/*index=*/0));
   arg->setDefaultArgumentKind(DefaultArgumentKind::Normal);
 }

--- a/lib/Sema/TypeCheckTypeWrapper.cpp
+++ b/lib/Sema/TypeCheckTypeWrapper.cpp
@@ -227,6 +227,13 @@ VarDecl *GetTypeWrapperStorageForProperty::evaluate(Evaluator &evaluator,
   auto *storage = wrappedType->getTypeWrapperStorageDecl();
   assert(storage);
 
+  // Type wrapper variables are never initialized directly,
+  // initialization expression (if any) becomes an default
+  // argument of the initializer synthesized by the type wrapper.
+  if (auto *PBD = property->getParentPatternBinding()) {
+    PBD->setInitializerSubsumed(/*index=*/0);
+  }
+
   return injectProperty(storage, property->getName(),
                         property->getValueInterfaceType(),
                         property->getIntroducer(), AccessLevel::Internal);

--- a/test/Interpreter/Inputs/type_wrapper_defs.swift
+++ b/test/Interpreter/Inputs/type_wrapper_defs.swift
@@ -282,7 +282,11 @@ public class UserDefinedInitWithConditionalTest<T> {
 @Wrapper
 public class ClassWithConvenienceInit<T> {
   public var a: T?
-  public var b: String
+  public var b: String = ""
+
+  public init(aWithoutB: T?) {
+    self.a = aWithoutB
+  }
 
   init(a: T?, b: String) {
     // Just to test that conditionals work properly
@@ -336,5 +340,33 @@ public struct TypeWithLetProperties<T> {
       print(self.a)
       print(self.b)
     }
+  }
+}
+
+@Wrapper
+public class TypeWithDefaultedLetProperties<T> {
+  let a: T? = nil
+  let b: Int = 0
+
+  public init() {
+    print(self.a)
+    print(self.b)
+  }
+}
+
+@Wrapper
+public class TypeWithSomeDefaultedLetProperties<T> {
+  let a: T
+  let b: Int? = 0
+  @PropWrapper var c: String = "<default>"
+  @PropWrapperWithoutInit(value: [1, ""]) var d: [Any]
+
+  public init(a: T) {
+    self.a = a
+    self.c = "a"
+
+    print(self.a)
+    print(self.b)
+    print(self.c)
   }
 }

--- a/test/Interpreter/type_wrappers.swift
+++ b/test/Interpreter/type_wrappers.swift
@@ -563,6 +563,9 @@ do {
   // CHECK-NEXT: in getter
   // CHECK-NEXT: <modified>
 
+  let test2 = ClassWithConvenienceInit(aWithoutB: [1, ""])
+  // CHECK: Wrapper.init($Storage(a: Optional([1, ""]), b: ""))
+
   func test<T>(_ v: T) {
     let test1 = ClassWithConvenienceInit<(Int, String, T)>()
     test1.a = (-1, "ultimate question", v)
@@ -622,4 +625,22 @@ do {
   // CHECK-NEXT: Optional([1, 2, 3])
   // CHECK-NEXT: in read-only getter
   // CHECK-NEXT: 0
+
+  let test3 = TypeWithDefaultedLetProperties<[String]>()
+  // CHECK: Wrapper.init($Storage(a: nil, b: 0))
+  // CHECK-NEXT: in read-only getter
+  // CHECK-NEXT: nil
+  // CHECK-NEXT: in read-only getter
+  // CHECK-NEXT: 0
+
+  let test4 = TypeWithSomeDefaultedLetProperties(a: ["", 1.0])
+  // CHECK: Wrapper.init($Storage(a: ["", 1.0], b: Optional(0), _c: type_wrapper_defs.PropWrapper<Swift.String>(value: "<default>"), _d: type_wrapper_defs.PropWrapperWithoutInit<Swift.Array<Any>>(value: [1, ""])))
+  // CHECK-NEXT: in getter
+  // CHECK-NEXT: in setter => PropWrapper<String>(value: "a")
+  // CHECK-NEXT: in read-only getter
+  // CHECK-NEXT: ["", 1.0]
+  // CHECK-NEXT: in read-only getter
+  // CHECK-NEXT: Optional(0)
+  // CHECK-NEXT: in getter
+  // CHECK-NEXT: a
 }

--- a/test/SILOptimizer/type_wrapper_definite_init_diagnostics.swift
+++ b/test/SILOptimizer/type_wrapper_definite_init_diagnostics.swift
@@ -88,4 +88,19 @@ do {
       self.a = 0
     }
   }
+
+  @Wrapper
+  struct ImmutableReassignmentTest {
+    let x: Int = 42
+
+    init(x: Int) {
+      self.x = x // expected-error {{immutable value 'self.x' may only be initialized once}}
+    }
+
+    init(optX: Int?) {
+      if let x = optX {
+        self.x = x // expected-error {{immutable value 'self.x' may only be initialized once}}
+      }
+    }
+  }
 }


### PR DESCRIPTION
All of the property initializers are injected as initializations
of individual `_storage` fields.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
