### PR TITLE
Disable '_move' contextual keyword absent -enable-experimental-move-only

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -432,7 +432,8 @@ ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
    return sub;
   }
 
-  if (Tok.isContextualKeyword("_move")) {
+  if (Context.LangOpts.hasFeature(Feature::MoveOnly)
+      && Tok.isContextualKeyword("_move")) {
     Tok.setKind(tok::contextual_keyword);
     SourceLoc awaitLoc = consumeToken();
     ParserResult<Expr> sub =

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -409,6 +409,8 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
 
     void checkMoveExpr(MoveExpr *moveExpr) {
       // Make sure the MoveOnly feature is set. If not, error.
+      // This should not currently be reached because the parse should ignore
+      // the _move keyword unless the feature flag is set.
       if (!Ctx.LangOpts.hasFeature(Feature::MoveOnly)) {
         auto error =
           diag::experimental_moveonly_feature_can_only_be_used_when_enabled;

--- a/test/Parse/move_func_decl.swift
+++ b/test/Parse/move_func_decl.swift
@@ -1,0 +1,14 @@
+// RUN: %target-typecheck-verify-swift  -disable-availability-checking
+
+// rdar://100872195 (error: 'move' can only be applied to lvalues , error: Can not use feature when experimental move only is disabled!)
+//
+// Identifiers with a single underscore are not reserved for use by the language implementation. It is perfectly valid for a library to define its own '_move'.
+// The contextual _move keyword should only be parse when it is followed by an lvalue, so should *not* conflict with user-defined '_move' functions.
+// https://github.com/apple/swift-evolution/blob/main/proposals/0366-move-function.md#source-compatibility
+
+func _move<T>(t: T) -> T { return t }
+
+func testUserMove() {
+  let t = String()
+  let _ = _move(t: t)
+}


### PR DESCRIPTION
Fixes rdar://100872195 ( error: 'move' can only be applied to lvalues
 error: Can not use feature when experimental move only is disabled!)

Identifiers with a single underscore are not reserved for use by the language implementation. It is perfectly valid for a library to define its own '_move'.

The contextual _move keyword should only be parse when it is followed by an lvalue, so should *not* conflict with user-defined '_move' functions:
https://github.com/apple/swift-evolution/blob/main/proposals/0366-move-function.md#source-compatibility