### PR TITLE
Sema: Avoid crashing in `diagnoseDeclAsyncAvailability()` when call expr cannot be determined

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3611,8 +3611,8 @@ diagnoseDeclAsyncAvailability(const ValueDecl *D, SourceRange R,
 
   if (const AbstractFunctionDecl *afd = dyn_cast<AbstractFunctionDecl>(D)) {
     if (const AbstractFunctionDecl *asyncAlt = afd->getAsyncAlternative()) {
-      assert(call && "No call calling async alternative function");
-      ctx.Diags.diagnose(call->getLoc(), diag::warn_use_async_alternative);
+      SourceLoc diagLoc = call ? call->getLoc() : R.Start;
+      ctx.Diags.diagnose(diagLoc, diag::warn_use_async_alternative);
 
       if (auto *accessor = dyn_cast<AccessorDecl>(asyncAlt)) {
         SmallString<32> name;

--- a/test/attr/Inputs/custom-modules/objc_async.h
+++ b/test/attr/Inputs/custom-modules/objc_async.h
@@ -13,6 +13,9 @@ typedef void (^CompletionHandler)(NSInteger);
 
 -(void)asyncImportSame:(NSInteger)arg completionHandler:(void (^)(NSInteger))handler;
 -(void)asyncImportSame:(NSInteger)arg replyTo:(void (^)(NSInteger))handler __attribute__((swift_async(none)));
+
+-(void)simpleOnMainActorWithCompletionHandler:(void (^)(NSInteger))handler __attribute__((swift_attr("@MainActor")));
+
 @end
 
 #pragma clang assume_nonnull end

--- a/test/attr/attr_availability_async_rename.swift
+++ b/test/attr/attr_availability_async_rename.swift
@@ -325,6 +325,14 @@ func asyncContext(t: HandlerTest) async {
   t.asyncImportSame(1, replyTo: { _ in })
 }
 
+@MainActor
+@available(SwiftStdlib 5.5, *)
+func mainActorAsyncContext(t: HandlerTest) async {
+  // expected-warning@+1{{consider using asynchronous alternative function}}
+  t.simpleOnMainActor(completionHandler: { _ in })
+  await t.simpleOnMainActor()
+}
+
 @available(SwiftStdlib 5.5, *)
 func syncContext(t: HandlerTest) {
   goodFunc1(value: "Hello") { _ in }


### PR DESCRIPTION
The `call` argument to `diagnoseDeclAsyncAvailability()` may be `nullptr` when the structure of the AST prevents `getEnclosingApplyExpr()` from finding the enclosing apply. The diagnostics implementation introduced with https://github.com/apple/swift/pull/60663 needs to tollerate this, similar to the rest of `diagnoseDeclAsyncAvailability()`.

Resolves rdar://100862513