### PR TITLE
[Profiler] Use proper SILDeclRef for top-level code

### DIFF
--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -334,8 +334,11 @@ void SILFunction::deleteSnapshot(int ID) {
 
 void SILFunction::createProfiler(ASTNode Root, SILDeclRef Ref) {
   assert(!Profiler && "Function already has a profiler");
+  assert(Root && "Cannot profile a null ASTNode");
+  assert(Ref && "Must have non-null SILDeclRef");
+
   Profiler = SILProfiler::create(Module, Root, Ref);
-  if (!Profiler || Ref.isNull())
+  if (!Profiler)
     return;
 
   // If we loaded a profile, set the entry counts for functions and closures

--- a/lib/SIL/IR/SILProfiler.cpp
+++ b/lib/SIL/IR/SILProfiler.cpp
@@ -40,14 +40,6 @@ static bool shouldProfile(ASTNode N, SILDeclRef Constant) {
                << "Skipping ASTNode: invalid start/end locations\n");
     return false;
   }
-  if (!Constant) {
-    // We should only ever have a null SILDeclRef for top-level code, which is
-    // always user-written, and should always be profiled.
-    // FIXME: Once top-level code is unified under a single SILProfiler, this
-    // case can be eliminated.
-    assert(isa<TopLevelCodeDecl>(N.get<Decl *>()));
-    return true;
-  }
 
   // Do not profile AST nodes in unavailable contexts.
   auto *DC = Constant.getInnermostDeclContext();


### PR DESCRIPTION
Use a main entry-point instead of a null SILDeclRef. Eventually we'll want to unify the emission here such that we visit all the TopLevelDecls in one shot (and just use a single profiler), but for now we can just hand the SILProfiler the expected SILDeclRef.