### PR TITLE
build-script: add missing DocC dependency

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/swiftdoccrender.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftdoccrender.py
@@ -13,6 +13,7 @@
 import os
 
 from . import product
+from . import swiftdocc
 from .. import shell
 
 
@@ -69,4 +70,4 @@ class SwiftDocCRender(product.Product):
 
     @classmethod
     def get_dependencies(cls):
-        return []
+        return [swiftdocc.SwiftDocC]


### PR DESCRIPTION
Without this dependency, passing both `--swiftdocc` and `--install-swiftdocc` to `build-script` causes it to crash with this stack trace:

```
Traceback (most recent call last):
  File "./swift/utils/build-script", line 789, in <module>
    exit_code = main()
  File "./swift/utils/build-script", line 784, in main
    return main_normal()
  File "./swift/utils/build-script", line 740, in main_normal
    invocation.execute()
  File "./swift/utils/swift_build_support/swift_build_support/build_script_invocation.py", line 670, in execute
    (self.impl_env, self.impl_args) = self.convert_to_impl_arguments()
  File "./swift/utils/swift_build_support/swift_build_support/build_script_invocation.py", line 147, in convert_to_impl_arguments
    for product_class in sum(list(self.compute_product_pipelines()[0]), []):
  File "./swift/utils/swift_build_support/swift_build_support/build_script_invocation.py", line 664, in compute_product_pipelines
    return builder.finalize(shouldInfer=self.args.infer_dependencies)
  File "./swift/utils/swift_build_support/swift_build_support/productpipeline_list_builder.py", line 198, in finalize
    result = self.infer()
  File "./swift/utils/swift_build_support/swift_build_support/productpipeline_list_builder.py", line 157, in infer
    build_graph.produce_scheduled_build(enabled_pipeline)[0]
  File "./swift/utils/swift_build_support/swift_build_support/build_graph.py", line 150, in produce_scheduled_build
    dag.set_root(entry)
  File "./swift/utils/swift_build_support/swift_build_support/build_graph.py", line 95, in set_root
    assert self.root is None
AssertionError
```

Apparently, the absence of this explicit dependency makes `build_graph.py` code think that `SwiftDocCRender` and `SwiftDocC` are independent root targets, which it can't handle. Making one a dependency of the other resolves the issue.
