### PR TITLE
Split out SWIFT_ENABLE_REFLECTION into a separate SWIFT_STDLIB_REFLECTION_METADATA CMake flag to control whether stdlib is built with reflection metadata or not

### DIFF
--- a/stdlib/cmake/modules/StdlibOptions.cmake
+++ b/stdlib/cmake/modules/StdlibOptions.cmake
@@ -169,8 +169,11 @@ option(SWIFT_STDLIB_HAS_COMMANDLINE
        TRUE)
 
 option(SWIFT_ENABLE_REFLECTION
-  "Build stdlib with support for runtime reflection and mirrors."
-  TRUE)
+       "Build stdlib with support for runtime reflection and mirrors."
+       TRUE)
+
+set(SWIFT_STDLIB_REFLECTION_METADATA "enabled" CACHE STRING
+    "Build stdlib with runtime metadata (valid options are 'enabled', 'disabled' and 'debugger-only').")
 
 if(SWIFT_FREESTANDING_FLAVOR STREQUAL "apple" AND NOT SWIFT_FREESTANDING_IS_DARWIN)
   set(SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY_default TRUE)

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -498,10 +498,18 @@ function(_compile_swift_files
     list(APPEND swift_flags "-Xfrontend" "-emit-sorted-sil")
   endif()
 
-  if(NOT SWIFT_ENABLE_REFLECTION)
-    list(APPEND swift_flags "-Xfrontend" "-reflection-metadata-for-debugger-only")
-  else()
+  if(SWIFT_ENABLE_REFLECTION)
     list(APPEND swift_flags "-D" "SWIFT_ENABLE_REFLECTION")
+  endif()
+
+  if("${SWIFT_STDLIB_REFLECTION_METADATA}" STREQUAL "enabled")
+    # do nothing, emitting reflection metadata is the default in swiftc
+  elseif("${SWIFT_STDLIB_REFLECTION_METADATA}" STREQUAL "debugger-only")
+    list(APPEND swift_flags "-Xfrontend" "-reflection-metadata-for-debugger-only")
+  elseif("${SWIFT_STDLIB_REFLECTION_METADATA}" STREQUAL "disabled")
+    list(APPEND swift_flags "-Xfrontend" "-disable-reflection-metadata")
+  else()
+    message(FATAL_ERROR "Invalid SWIFT_STDLIB_REFLECTION_METADATA value: ${SWIFT_STDLIB_REFLECTION_METADATA}")
   endif()
 
   if(NOT "${SWIFT_STDLIB_TRAP_FUNCTION}" STREQUAL "")

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2516,6 +2516,7 @@ swift-enable-dispatch=0
 swift-implicit-concurrency-import=0
 swift-stdlib-support-back-deployment=0
 swift-enable-reflection=0
+swift-stdlib-reflection-metadata=debugger-only
 swift-stdlib-stable-abi=0
 swift-stdlib-has-dladdr=0
 swift-stdlib-supports-backtrace-reporting=0

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -203,6 +203,7 @@ KNOWN_SETTINGS=(
     swift-implicit-concurrency-import             "1"               "whether to implicitly import the Swift concurrency module"
     swift-stdlib-support-back-deployment          "1"               "whether to support back-deployment of built binaries to older OS versions"
     swift-enable-reflection                       "1"               "whether to support reflection and mirrors"
+    swift-stdlib-reflection-metadata              "enabled"         "whether to build stdlib with runtime metadata (valid options are 'enabled', 'disabled' and 'debugger-only')"
     swift-stdlib-has-dladdr                       "1"               "whether to build stdlib assuming the runtime environment provides dladdr API"
     swift-stdlib-supports-backtrace-reporting     ""                "whether to build stdlib assuming the runtime environment provides the backtrace(3) API, if not set defaults to true on all platforms except for Cygwin, Haiku and wasm"
     swift-runtime-static-image-inspection         "0"               "whether to build stdlib assuming the runtime environment only supports a single runtime image with Swift code"
@@ -2002,6 +2003,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DSWIFT_STDLIB_TRAP_FUNCTION:STRING="${SWIFT_STDLIB_TRAP_FUNCTION}"
                     -DSWIFT_STDLIB_EXPERIMENTAL_HERMETIC_SEAL_AT_LINK:BOOL=$(true_false "${SWIFT_STDLIB_EXPERIMENTAL_HERMETIC_SEAL_AT_LINK}")
                     -DSWIFT_STDLIB_DISABLE_INSTANTIATION_CACHES:BOOL=$(true_false "${SWIFT_STDLIB_DISABLE_INSTANTIATION_CACHES}")
+                    -DSWIFT_STDLIB_REFLECTION_METADATA:STRING="${SWIFT_STDLIB_REFLECTION_METADATA}"
                     -DSWIFT_NATIVE_LLVM_TOOLS_PATH:STRING="${native_llvm_tools_path}"
                     -DSWIFT_NATIVE_CLANG_TOOLS_PATH:STRING="${native_clang_tools_path}"
                     -DSWIFT_NATIVE_SWIFT_TOOLS_PATH:STRING="${native_swift_tools_path}"


### PR DESCRIPTION
rdar://91322381