### PR TITLE
[interop][SwiftToCxx] clarify Swift to C++ status doc

### DIFF
--- a/docs/CppInteroperability/CppInteroperabilityStatus.md
+++ b/docs/CppInteroperability/CppInteroperabilityStatus.md
@@ -137,11 +137,21 @@ This status table describes which of the following Swift language features have 
 
 **Functions**
 
+Swift functions can be called from C++, with some restrictions. See this table for details:
+
 | **Swift Language Feature**     | **Implemented Experimental Support For Using It In C++** |
 |--------------------------------|----------------------------------------------------------|
 | Top-level `@_cdecl` functions  | Yes                                                      |
-| Top-level Swift functions      | Partially, only with primitive and Swift struct and enum types. Class, protocol, and SIMD types are not supported.    |
+| Top-level Swift functions      | Yes |
+| Swift Methods                  | Yes (see the **Methods** section below for more details) |
+| Primitive parameter or result types  | Yes           |
+| Swift `struct`/`enum`/`class` parameter or result types  | Yes           |
 | `inout` parameters             | Yes                                                      |
+| C++ `struct`/`class` parameter or result types  | Yes   |
+| Objective-C `@interface` parameter or result types  | Yes   |
+| Swift closure parameter or result types  | No           |
+| Swift protocol type parameter or result types  | No           |
+| SIMD type parameter or result types  | No           |
 | Variadic parameters            | No                                                       |
 | Multiple return values         | No                                                       |
 
@@ -152,7 +162,7 @@ This status table describes which of the following Swift language features have 
 | Fixed layout structs           | Yes                                                      |
 | Resilient / opaque structs     | Yes                                                      |
 | Copy and destroy semantics     | Yes                                                      |
-| Initializers                   | Partially, as static `init` methods. No failable support |
+| Initializers                   | Yes (except for throwing initializers)                   |
 
 **Enums**
 
@@ -172,13 +182,13 @@ This status table describes which of the following Swift language features have 
 |--------------------------------|----------------------------------------------------------|
 | Class reference values         | Yes                                                      |
 | ARC semantics                  | Yes (C++ copy constructor,assignment operator, destructor perform ARC operations)  |
-| Initializers                   | Yes |
+| Initializers                   | Yes (except for throwing initializers) |
 
 **Methods**
 
 | **Swift Language Feature**     | **Implemented Experimental Support For Using It In C++** |
 |--------------------------------|----------------------------------------------------------|
-| Instance methods               | Yes on structs and enums. Only 'final' method calls on class types are correctly supported though (virtual calls won't be virtual due to a bug right now) |
+| Instance methods               | Yes on structs and enums. Instance methods on class types are partially supported (virtual calls won't be virtual due to a bug right now) |
 | Static methods                 | No                                                       |
 
 **Properties**
@@ -206,6 +216,6 @@ This status table describes which of the following Swift standard library APIs h
 
 | **Swift Library Type**     | **Can be used from C++** |
 |--------------------------------|----------------------------------------------------------|
-| `String`     | Can be used as a type in C++. APIs in extensions are not exposed to C++   |
-| `Array<T>`   | Can be used as a type in C++. Limited set of APIs in some extensions are exposed to C++.   |
-| `Optional<T>`   | Can be used as a type in C++. APIs in extensions are not exposed to C++   |
+| `String`     | Can be used as a type in C++. APIs in extensions are not exposed to C++. Conversion between `std.string` is not yet supported   |
+| `Array<T>`   | Can be used as a type in C++. Ranged for loops are supported. Limited set of APIs in some extensions are exposed to C++. |
+| `Optional<T>`   | Can be used as a type in C++. `get` extracts the optional value and it's also implicitly castable to `bool`. Can't be constructed from C++ yet.  |


### PR DESCRIPTION
More clarification for the status doc.
