### PR TITLE
ClangImporter: simplify logic for mutability attribute

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -107,7 +107,8 @@ WARNING(import_multiple_mainactor_attr,none,
       (StringRef, StringRef))
 
 WARNING(contradicting_mutation_attrs,none,
-        "attribute 'nonmutating' is ignored when combined with attribute 'mutating'", ())
+        "attribute '%0' is ignored when combined with attribute '%1'",
+        (StringRef, StringRef))
 
 WARNING(nonmutating_without_const,none,
         "attribute 'nonmutating' has no effect on non-const method", ())

--- a/test/Interop/Cxx/class/Inputs/mutability-annotations.h
+++ b/test/Interop/Cxx/class/Inputs/mutability-annotations.h
@@ -25,7 +25,7 @@ struct HasMutableProperty {
 
   int noAnnotation() const { return b; }
 
-  // expected-warning@+1 {{attribute 'nonmutating' is ignored when combined with attribute 'mutating'}}
+  // expected-warning@+1 {{attribute 'mutating' is ignored when combined with attribute 'nonmutating'}}
   int contradictingAnnotations() const __attribute__((__swift_attr__("nonmutating"))) __attribute__((__swift_attr__("mutating"))) {
     return b;
   }


### PR DESCRIPTION
Take the spellings for the attributes as parameters for the diagnostics to allow us to reference the ignored the attribute properly.  Use direct pointer checks instead of an unnecessary `llvm::Optional` around a nullable pointer.  Use `llvm::StringRef` to simplify the comparison. This avoids re-spelling the attribute parameters which have already been checked by `isMutabilityAttr` for the contradiction.