### PR TITLE
Sema: Diagnose `if #_hasSymbol` as unsupported on non-Darwin targets

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6618,9 +6618,7 @@ WARNING(has_symbol_decl_must_be_weak,none,
         "%0 %1 is not a weakly linked declaration",
         (DescriptiveDeclKind, DeclName))
 ERROR(has_symbol_invalid_expr,none,
-      "#_hasSymbol condition must refer to a declaration", ())
-ERROR(has_symbol_unsupported_in_closures,none,
-      "#_hasSymbol is not supported in closures", ())
+      "'#_hasSymbol' condition must refer to a declaration", ())
 
 //------------------------------------------------------------------------------
 // MARK: Type erasure

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6619,6 +6619,8 @@ WARNING(has_symbol_decl_must_be_weak,none,
         (DescriptiveDeclKind, DeclName))
 ERROR(has_symbol_invalid_expr,none,
       "'#_hasSymbol' condition must refer to a declaration", ())
+ERROR(has_symbol_unsupported,none,
+      "'#_hasSymbol' is unsupported on target '%0'", (StringRef))
 
 //------------------------------------------------------------------------------
 // MARK: Type erasure

--- a/test/Parse/has_symbol.swift
+++ b/test/Parse/has_symbol.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/Library.swiftmodule -parse-as-library %t/Library.swift -enable-library-evolution
 // RUN: %target-swift-frontend -typecheck -verify %t/Client.swift -I %t
 
-// UNSUPPORTED: OS=windows-msvc
+// REQUIRES: VENDOR=apple
 
 //--- Library.swift
 

--- a/test/Sema/has_symbol.swift
+++ b/test/Sema/has_symbol.swift
@@ -95,11 +95,11 @@ func testNotWeakDeclDiagnostics(_ s: LocalStruct) {
 
 func testInvalidExpressionsDiagnostics() {
   if #_hasSymbol(unknownDecl) {} // expected-error {{cannot find 'unknownDecl' in scope}}
-  if #_hasSymbol(noArgFunc()) {} // expected-error {{#_hasSymbol condition must refer to a declaration}}
-  if #_hasSymbol(global - 1) {} // expected-error {{#_hasSymbol condition must refer to a declaration}}
-  if #_hasSymbol(S.staticFunc()) {} // expected-error {{#_hasSymbol condition must refer to a declaration}}
-  if #_hasSymbol(C.classFunc()) {} // expected-error {{#_hasSymbol condition must refer to a declaration}}
-  if #_hasSymbol(1 as Int) {} // expected-error {{#_hasSymbol condition must refer to a declaration}}
+  if #_hasSymbol(noArgFunc()) {} // expected-error {{'#_hasSymbol' condition must refer to a declaration}}
+  if #_hasSymbol(global - 1) {} // expected-error {{'#_hasSymbol' condition must refer to a declaration}}
+  if #_hasSymbol(S.staticFunc()) {} // expected-error {{'#_hasSymbol' condition must refer to a declaration}}
+  if #_hasSymbol(C.classFunc()) {} // expected-error {{'#_hasSymbol' condition must refer to a declaration}}
+  if #_hasSymbol(1 as Int) {} // expected-error {{'#_hasSymbol' condition must refer to a declaration}}
   if #_hasSymbol(1 as S) {} // expected-error {{cannot convert value of type 'Int' to type 'S' in coercion}}
 }
 
@@ -127,11 +127,11 @@ func testClosure() {
   doIt { if #_hasSymbol(ambiguousFunc) {} } // expected-error {{ambiguous use of 'ambiguousFunc()'}}
   doIt { if #_hasSymbol(localFunc) {} } // expected-warning {{global function 'localFunc()' is not a weakly linked declaration}}
   doIt { if #_hasSymbol(unknownDecl) {} } // expected-error {{cannot find 'unknownDecl' in scope}}
-  doIt { if #_hasSymbol(noArgFunc()) {} } // expected-error {{#_hasSymbol condition must refer to a declaration}}
-  doIt { if #_hasSymbol(global - 1) {} } // expected-error {{#_hasSymbol condition must refer to a declaration}}
-  doIt { if #_hasSymbol(S.staticFunc()) {} } // expected-error {{#_hasSymbol condition must refer to a declaration}}
-  doIt { if #_hasSymbol(C.classFunc()) {} } // expected-error {{#_hasSymbol condition must refer to a declaration}}
-  doIt { if #_hasSymbol(1 as Int) {} } // expected-error {{#_hasSymbol condition must refer to a declaration}}
+  doIt { if #_hasSymbol(noArgFunc()) {} } // expected-error {{'#_hasSymbol' condition must refer to a declaration}}
+  doIt { if #_hasSymbol(global - 1) {} } // expected-error {{'#_hasSymbol' condition must refer to a declaration}}
+  doIt { if #_hasSymbol(S.staticFunc()) {} } // expected-error {{'#_hasSymbol' condition must refer to a declaration}}
+  doIt { if #_hasSymbol(C.classFunc()) {} } // expected-error {{'#_hasSymbol' condition must refer to a declaration}}
+  doIt { if #_hasSymbol(1 as Int) {} } // expected-error {{'#_hasSymbol' condition must refer to a declaration}}
   doIt { if #_hasSymbol(1 as S) {} } // expected-error {{cannot convert value of type 'Int' to type 'S' in coercion}}
 }
 
@@ -164,7 +164,7 @@ struct MyView {
   }
 
   @ViewBuilder var noArgFuncView: some View {
-    if #_hasSymbol(noArgFunc()) { image } // expected-error {{#_hasSymbol condition must refer to a declaration}}
+    if #_hasSymbol(noArgFunc()) { image } // expected-error {{'#_hasSymbol' condition must refer to a declaration}}
     else { image }
   }
 }

--- a/test/Sema/has_symbol.swift
+++ b/test/Sema/has_symbol.swift
@@ -3,7 +3,7 @@
 // RUN: %target-typecheck-verify-swift -disable-availability-checking -I %t
 // RUN: %target-typecheck-verify-swift -disable-availability-checking -I %t -enable-experimental-feature ResultBuilderASTTransform
 
-// UNSUPPORTED: OS=windows-msvc
+// REQUIRES: VENDOR=apple
 
 @_weakLinked import has_symbol_helper
 

--- a/test/Sema/has_symbol_unsupported.swift
+++ b/test/Sema/has_symbol_unsupported.swift
@@ -1,0 +1,8 @@
+// RUN: %target-typecheck-verify-swift
+// UNSUPPORTED: VENDOR=apple
+
+// Verify that #_hasSymbol is rejected on non-Darwin platforms
+
+func foo() {}
+
+if #_hasSymbol(foo) { } // expected-error {{'#_hasSymbol' is unsupported on target}}


### PR DESCRIPTION
The initial implementation of SILGen for `if #_hasSymbol` will assume it is targeting Darwin so we should diagnose attempts to use the feature on other platforms.