### PR TITLE
Fix failures in update_checkout tests because of missing user identity

### DIFF
--- a/utils/update_checkout/tests/scheme_mock.py
+++ b/utils/update_checkout/tests/scheme_mock.py
@@ -125,6 +125,8 @@ def setup_mock_remote(base_dir):
             with open(filename_path, 'w') as f:
                 f.write(contents)
             call_quietly(['git', 'add', filename], cwd=local_repo_path)
+            call_quietly(['git', 'config', '--local', 'user.email', 'swift-test@example.com'], cwd=local_repo_path)
+            call_quietly(['git', 'config', '--local', 'user.name', 'Swift Test'], cwd=local_repo_path)
             call_quietly(['git', 'commit', '-m', 'Commit %d' % i],
                          cwd=local_repo_path)
             call_quietly(['git', 'push', 'origin', 'main'],


### PR DESCRIPTION
This fixes the following failures in the `Python/update_checkout.swift` test:

```
======================================================================
ERROR: test_simple_clone (tests.test_clone.CloneTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/npohilets/git_tree/swift-project/swift/utils/update_checkout/tests/scheme_mock.py", line 81, in call_quietly
    subprocess.check_output(*args, **kwargs)
  File "/opt/homebrew/Cellar/python@3.10/3.10.6_2/Frameworks/Python.framework/Versions/3.10/lib/python3.10/subprocess.py", line 420, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/opt/homebrew/Cellar/python@3.10/3.10.6_2/Frameworks/Python.framework/Versions/3.10/lib/python3.10/subprocess.py", line 524, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['git', 'commit', '-m', 'Commit 0']' returned non-zero exit status 128.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/npohilets/git_tree/swift-project/swift/utils/update_checkout/tests/scheme_mock.py", line 170, in setUp
    (self.local_path, self.remote_path) = setup_mock_remote(self.workspace)
  File "/Users/npohilets/git_tree/swift-project/swift/utils/update_checkout/tests/scheme_mock.py", line 128, in setup_mock_remote
    call_quietly(['git', 'commit', '-m', 'Commit %d' % i],
  File "/Users/npohilets/git_tree/swift-project/swift/utils/update_checkout/tests/scheme_mock.py", line 83, in call_quietly
    raise CallQuietlyException(command=e.cmd, returncode=e.returncode,
tests.scheme_mock.CallQuietlyException: Command returned a non-zero exit status 128:
Command: git commit -m Commit 0
Output: Author identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: unable to auto-detect email address (got 'npohilets@XXXXXXXXXX.(none)')
```

When running `utils/update_checkout/run_tests.py` directly `$HOME` is available, and `git` picks up real config from `$HOME/.gitconfig`. But when running using LIT, `$HOME` is not set, and tests were failing.