### PR TITLE
Warn on incorrect usage of implicit self in non-escaping closure that captures self weakly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 _**Note:** This is in reverse chronological order, so newer entries are added to the top._
 
-## Swift 6.0
+## Swift 5.8
 
 * [SE-0365][]:
  
-  Implicit `self` is now permitted for `weak self` captures, after `self` is unwrapped.
+  In Swift 6 mode, implicit `self` is now permitted for `weak self` captures, after `self` is unwrapped.
 
-  For example, the usage of implicit `self` below is now permitted:
+  For example, the usage of implicit `self` below is permitted in Swift 6:
 
   ```swift
   class ViewController {
@@ -43,8 +43,6 @@ _**Note:** This is in reverse chronological order, so newer entries are added to
   ```
 
   In Swift 6, the above code will no longer compile. `weak self` captures in non-escaping closures now have the same behavior as captures in escaping closures (as described in [SE-0365][]). Code relying on the previous behavior will need to be updated to either unwrap `self` (e.g. by adding a `guard let self else return` statement), or to use a different capture method (e.g. using `[self]` or `[unowned self]` instead of `[weak self]`).
-
-## Swift 5.8
 
 * [SE-0362][]:
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3949,6 +3949,20 @@ ERROR(implicit_use_of_self_in_closure,none,
       "implicit use of 'self' in closure; use 'self.' to make"
       " capture semantics explicit", ())
 
+ERROR(incorrect_implicit_self_behavior,none,
+      "use of implicit 'self' is not allowed before 'self' has been unwrapped",
+      ())
+NOTE(note_unwrap_self,none,
+      "unwrap 'self' before using implicit self", ())
+
+WARNING(incorrect_unwrapped_implicit_self_behavior,none,
+      "'self' unwrap condition does not affect uses of implicit self in "
+      "non-escaping closure, because implicit self is always non-optional "
+      "in Swift 5 mode; this is supported in Swift 6 without a warning",
+      ())
+NOTE(note_reference_self_explicitly_to_silence_warning,none,
+      "reference 'self.' explicitly to silence this warning", ())
+
 WARNING(recursive_accessor_reference,none,
         "attempting to %select{access|modify}1 %0 within its own "
         "%select{getter|setter}1", (Identifier, bool))

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1676,7 +1676,7 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
         }
       }
 
-      if (conditionalStmt == nullptr) {
+      if (!conditionalStmt) {
         return false;
       }
 

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -332,7 +332,7 @@ LookupResult TypeChecker::lookupMember(DeclContext *dc,
   dc->lookupQualified(type, name, subOptions, lookupResults);
 
   for (auto found : lookupResults)
-    builder.add(found, nullptr, nullptr, type, /*isOuter=*/false);
+    builder.add(found, nullptr, /*baseDecl=*/nullptr, type, /*isOuter=*/false);
 
   return result;
 }

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -787,6 +787,12 @@ public class TestImplicitSelfForWeakSelfCapture {
       method() // expected-note {{reference 'self.' explicitly to silence this warning}} {{7-7=self.}}
       print(value) // expected-note {{reference 'self.' explicitly to silence this warning}} {{13-13=self.}}
     }
+
+    doVoidStuffNonEscaping { [weak self] in
+      guard let self = self else { return }
+      self.method()
+      print(self.value)
+    }
     
     doVoidStuffNonEscaping { [weak self] in
       if let self = self { // expected-warning {{'self' unwrap condition does not affect uses of implicit self in non-escaping closure, because implicit self is always non-optional in Swift 5 mode; this is supported in Swift 6 without a warning}}
@@ -799,6 +805,19 @@ public class TestImplicitSelfForWeakSelfCapture {
       }
 
       method() // expected-warning {{use of implicit 'self' is not allowed before 'self' has been unwrapped; this is an error in Swift 6}} expected-note {{unwrap 'self' before using implicit self}}
+    }
+
+    doVoidStuffNonEscaping { [weak self] in
+      if let self = self {
+        self.method()
+        print(self.value)
+      }
+
+      if let self = self {
+        print(self.value)
+      }
+
+      self?.method()
     }
     
     doVoidStuff { [weak self] in

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -772,12 +772,12 @@ public class TestImplicitSelfForWeakSelfCapture {
       self.method()
     }
     
-    doVoidStuffNonEscaping { [weak self] in // {{44-44=\nguard let self else { return }}}
+    doVoidStuffNonEscaping { [weak self] in // {{44-44=\nguard let self else { return }}} expected-warning {{variable 'self' was written to, but never read}}
       method() // expected-warning {{use of implicit 'self' is not allowed before 'self' has been unwrapped; this is an error in Swift 6}} expected-note {{unwrap 'self' before using implicit self}}
       print(value) // expected-warning {{use of implicit 'self' is not allowed before 'self' has been unwrapped; this is an error in Swift 6}} expected-note {{unwrap 'self' before using implicit self}}
     }
 
-    doStuffNonEscaping { [weak self] in // {{44-44=\nguard let self else { return <#value#> }}}
+    doStuffNonEscaping { [weak self] in // {{44-44=\nguard let self else { return <#value#> }}} expected-warning {{variable 'self' was written to, but never read}}
       method() // expected-warning {{use of implicit 'self' is not allowed before 'self' has been unwrapped; this is an error in Swift 6}} expected-note {{unwrap 'self' before using implicit self}}
       return value // expected-warning {{use of implicit 'self' is not allowed before 'self' has been unwrapped; this is an error in Swift 6}} expected-note {{unwrap 'self' before using implicit self}}
     }
@@ -789,12 +789,12 @@ public class TestImplicitSelfForWeakSelfCapture {
     }
     
     doVoidStuffNonEscaping { [weak self] in
-      if let self = self {
+      if let self = self { // expected-warning {{'self' unwrap condition does not affect uses of implicit self in non-escaping closure, because implicit self is always non-optional in Swift 5 mode; this is supported in Swift 6 without a warning}}
         method() // expected-note {{reference 'self.' explicitly to silence this warning}} {{9-9=self.}}
         print(self.value)
       }
 
-      if let self = self {
+      if let self = self { // expected-warning {{'self' unwrap condition does not affect uses of implicit self in non-escaping closure, because implicit self is always non-optional in Swift 5 mode; this is supported in Swift 6 without a warning}}
         print(value) // expected-note {{reference 'self.' explicitly to silence this warning}} {{15-15=self.}}
       }
 
@@ -818,6 +818,13 @@ public class TestImplicitSelfForWeakSelfCapture {
       guard let self = self ?? TestImplicitSelfForWeakSelfCapture.staticOptional else { return } // expected-warning {{'self' unwrap condition does not affect uses of implicit self in non-escaping closure, because implicit self is always non-optional in Swift 5 mode; this is supported in Swift 6 without a warning}}
       method() // expected-note {{reference 'self.' explicitly to silence this warning}} {{7-7=self.}}
       self.method()
+    }
+
+    doVoidStuffNonEscaping { [weak self] in // {{46-46=\nguard let self else { return }}}
+      doVoidStuff { [weak self] in // expected-warning {{variable 'self' was written to, but never read}}
+        method() // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}}
+      }
+      method() // expected-warning {{use of implicit 'self' is not allowed before 'self' has been unwrapped; this is an error in Swift 6}} expected-note {{unwrap 'self' before using implicit self}}
     }
   }
 }


### PR DESCRIPTION
As a [follow-up](https://github.com/apple/swift/pull/40702#issuecomment-1267615682) to SE-0365, this PR adds a new warning for incorrect usage of implicit self in non-escaping closures that capture self weakly.

In Swift 5 mode, non-escaping closures are incorrectly allowed to use implicit self, even is self is optional:

```swift
// Compiles in Swift 5:
doVoidStuffNonEscaping { [weak self] in
  method()
}
```

We now emit a warning in this case:

```swift
doVoidStuffNonEscaping { [weak self] in 
  // warning: use of implicit 'self' is not allowed before 'self' has been unwrapped; this is an error in Swift 6
  // note: unwrap 'self' before using implicit self (fixit: insert 'guard let self else { return }')
  method()
}
```

In cases where self _is_ unwrapped, the implicit self decl still doesn't actually refer to the unwrapped self decl. In Swift 5.7 this emits a _"value 'self' was defined but never used; consider replacing with boolean test"_ warning, but we now instead emit a tailored warning with a fix-it to use explicit self:

```swift
doVoidStuffNonEscaping { [weak self] in 
  // warning: 'self' unwrap condition does not affect uses of implicit self in non-escaping closure, 
  // because implicit self is always non-optional in Swift 5 mode; this is supported in Swift 6 
  // without a warning
  guard let self else { return }
  // note: reference 'self.' explicitly to silence this warning (fixit: insert 'self.')
  method()
  // note: reference 'self.' explicitly to silence this warning (fixit: insert 'self.')
  anotherMethod()
}
```

Reviewers: @xedin