### PR TITLE
Enable SE-0365 behavior in Swift 5 mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 _**Note:** This is in reverse chronological order, so newer entries are added to the top._
 
-## Swift 6.0
+## Swift 5.8
 
 * [SE-0365][]:
  
   Implicit `self` is now permitted for `weak self` captures, after `self` is unwrapped.
 
-  For example, the usage of implicit `self` below is now permitted:
+  For example, the usage of implicit `self` below is permitted:
 
   ```swift
   class ViewController {
@@ -43,8 +43,6 @@ _**Note:** This is in reverse chronological order, so newer entries are added to
   ```
 
   In Swift 6, the above code will no longer compile. `weak self` captures in non-escaping closures now have the same behavior as captures in escaping closures (as described in [SE-0365][]). Code relying on the previous behavior will need to be updated to either unwrap `self` (e.g. by adding a `guard let self else return` statement), or to use a different capture method (e.g. using `[self]` or `[unowned self]` instead of `[weak self]`).
-
-## Swift 5.8
 
 * [SE-0362][]:
 

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1538,6 +1538,20 @@ static bool closureHasWeakSelfCapture(const AbstractClosureExpr *ACE) {
   return false;
 }
 
+/// Whether or not this closure with a `weak self` capture is permitted
+/// to use implicit self. We can't permit this for escaping closures in
+/// Swift 5 mode, because the implicit self AST in Swift 5 would cause
+/// self to be captured strongly instead of weakly.
+static bool
+allowsImplicitSelfForWeakSelfCapture(const AbstractClosureExpr *ACE) {
+  if (ACE->getASTContext().LangOpts.isSwiftVersionAtLeast(6)) {
+    return true;
+  }
+
+  return AnyFunctionRef(const_cast<AbstractClosureExpr *>(ACE))
+      .isKnownNoEscape();
+}
+
 /// Whether or not implicit self decls in this closure require manual
 /// lookup in order to perform diagnostics with the semantics described
 /// in SE-0365. This is necessary for closures that capture self weakly
@@ -1640,7 +1654,8 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
       // let self = .someOptionalVariable else { return }` or `let self =
       // someUnrelatedVariable`. If self hasn't been unwrapped yet and is still
       // an optional, we would have already hit an error elsewhere.
-      if (closureHasWeakSelfCapture(inClosure)) {
+      if (closureHasWeakSelfCapture(inClosure) &&
+          allowsImplicitSelfForWeakSelfCapture(inClosure)) {
         return !implicitWeakSelfReferenceIsValid(DRE, inClosure);
       }
 

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -332,7 +332,7 @@ LookupResult TypeChecker::lookupMember(DeclContext *dc,
   dc->lookupQualified(type, name, subOptions, lookupResults);
 
   for (auto found : lookupResults)
-    builder.add(found, nullptr, nullptr, type, /*isOuter=*/false);
+    builder.add(found, nullptr, /*baseDecl=*/nullptr, type, /*isOuter=*/false);
 
   return result;
 }

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -261,12 +261,12 @@ class ExplicitSelfRequiredTest {
   // because its `sawError` flag is set to true. To preserve the "capture 'y' was never used" warnings
   // above, we put these cases in their own method.
   func weakSelfError() {
-    doVoidStuff({ [weak self] in x += 1 }) // expected-error {{reference to property 'x' in closure requires explicit use of 'self' to make capture semantics explicit}}
-    doVoidStuffNonEscaping({ [weak self] in x += 1 }) // expected-warning {{reference to property 'x' in closure requires explicit use of 'self' to make capture semantics explicit}}
-    doStuff({ [weak self] in x+1 }) // expected-error {{reference to property 'x' in closure requires explicit use of 'self' to make capture semantics explicit}}
-    doVoidStuff({ [weak self] in _ = method() }) // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}}
-    doVoidStuffNonEscaping({ [weak self] in _ = method() }) // expected-warning {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}}
-    doStuff({ [weak self] in method() }) // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}}
+    doVoidStuff({ [weak self] in x += 1 }) // expected-error {{reference to property 'x' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-warning {{variable 'self' was written to, but never read}}
+    doVoidStuffNonEscaping({ [weak self] in x += 1 }) // expected-warning {{reference to property 'x' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-warning {{variable 'self' was written to, but never read}}
+    doStuff({ [weak self] in x+1 }) // expected-error {{reference to property 'x' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-warning {{variable 'self' was written to, but never read}}
+    doVoidStuff({ [weak self] in _ = method() }) // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-warning {{variable 'self' was written to, but never read}}
+    doVoidStuffNonEscaping({ [weak self] in _ = method() }) // expected-warning {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-warning {{variable 'self' was written to, but never read}}
+    doStuff({ [weak self] in method() }) // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-warning {{variable 'self' was written to, but never read}}
   }
 }
 
@@ -775,7 +775,7 @@ public class TestImplicitSelfForWeakSelfCapture {
     }
     
     doVoidStuff { [weak self] in
-      guard let self = self ?? TestImplicitSelfForWeakSelfCapture.staticOptional else { return }
+      guard let self = self ?? TestImplicitSelfForWeakSelfCapture.staticOptional else { return } // expected-warning {{value 'self' was defined but never used; consider replacing with boolean test}}
       method() // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}}
     }
     
@@ -811,7 +811,7 @@ public class TestImplicitSelfForWeakSelfCapture {
     }
     
     doVoidStuffNonEscaping { [weak self] in
-      guard let self = self ?? TestImplicitSelfForWeakSelfCapture.staticOptional else { return }
+      guard let self = self ?? TestImplicitSelfForWeakSelfCapture.staticOptional else { return } // expected-warning {{value 'self' was defined but never used; consider replacing with boolean test}}
       method() // expected-warning {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}}
     }
   }

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -257,13 +257,16 @@ class ExplicitSelfRequiredTest {
     return 42
   }
   
+  // The error emitted by these cases cause `VarDeclUsageChecker` to not run analysis on this method,
+  // because its `sawError` flag is set to true. To preserve the "capture 'y' was never used" warnings
+  // above, we put these cases in their own method.
   func weakSelfError() {
-    doVoidStuff({ [weak self] in x += 1 }) // expected-error {{reference to property 'x' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-warning {{variable 'self' was written to, but never read}}
-    doVoidStuffNonEscaping({ [weak self] in x += 1 }) // expected-warning {{variable 'self' was written to, but never read}}
-    doStuff({ [weak self] in x+1 }) // expected-error {{reference to property 'x' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-warning {{variable 'self' was written to, but never read}}
-    doVoidStuff({ [weak self] in _ = method() }) // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-warning {{variable 'self' was written to, but never read}}
-    doVoidStuffNonEscaping({ [weak self] in _ = method() }) // expected-warning {{variable 'self' was written to, but never read}}
-    doStuff({ [weak self] in method() }) // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-warning {{variable 'self' was written to, but never read}}
+    doVoidStuff({ [weak self] in x += 1 }) // expected-error {{reference to property 'x' in closure requires explicit use of 'self' to make capture semantics explicit}}
+    doVoidStuffNonEscaping({ [weak self] in x += 1 }) // expected-warning {{reference to property 'x' in closure requires explicit use of 'self' to make capture semantics explicit}}
+    doStuff({ [weak self] in x+1 }) // expected-error {{reference to property 'x' in closure requires explicit use of 'self' to make capture semantics explicit}}
+    doVoidStuff({ [weak self] in _ = method() }) // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}}
+    doVoidStuffNonEscaping({ [weak self] in _ = method() }) // expected-warning {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}}
+    doStuff({ [weak self] in method() }) // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}}
   }
 }
 
@@ -739,21 +742,28 @@ public class TestImplicitCaptureOfExplicitCaptureOfSelfInEscapingClosure {
 }
 
 public class TestImplicitSelfForWeakSelfCapture {
-  static var staticOptional: TestImplicitSelfForWeakSelfCapture? = .init()
+  static let staticOptional: TestImplicitSelfForWeakSelfCapture? = .init()
   func method() { }
   
   private init() {
     doVoidStuff { [weak self] in
       method() // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}}
       guard let self = self else { return }
-      method() // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}}
-      self.method()
+      method()
+    }
+    
+    doVoidStuff { [weak self] in
+      guard let self else { return }
+      method()
     }
     
     doVoidStuff { [weak self] in
       if let self = self {
-        method() // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}}
-        self.method()
+        method()
+      }
+
+      if let self {
+        method()
       }
     }
     
@@ -767,40 +777,42 @@ public class TestImplicitSelfForWeakSelfCapture {
     doVoidStuff { [weak self] in
       guard let self = self ?? TestImplicitSelfForWeakSelfCapture.staticOptional else { return }
       method() // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}}
-      self.method()
     }
     
     doVoidStuffNonEscaping { [weak self] in
-      method()
+      method() // expected-warning {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}}
       guard let self = self else { return }
       method()
-      self.method()
     }
     
     doVoidStuffNonEscaping { [weak self] in
       if let self = self {
         method()
-        self.method()
       }
     }
     
     doVoidStuff { [weak self] in
       let `self`: TestImplicitSelfForWeakSelfCapture? = self ?? TestImplicitSelfForWeakSelfCapture.staticOptional
-      guard let self = self else { return } // expected-warning {{value 'self' was defined but never used; consider replacing with boolean test}}
+      guard let self = self else { return }
       method() // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}}
     }
     
     doVoidStuffNonEscaping { [weak self] in
       let `self`: TestImplicitSelfForWeakSelfCapture? = self ?? TestImplicitSelfForWeakSelfCapture.staticOptional
       guard let self = self else { return }
-      method()
-      self.method()
+      method() // expected-warning {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}}
+    }
+    
+    doVoidStuffNonEscaping { [weak self] in
+      guard let self = self else { return } // expected-warning {{value 'self' was defined but never used; consider replacing with boolean test}}
+      doVoidStuff { // expected-note {{capture 'self' explicitly to enable implicit 'self' in this closure}}
+        method() // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}} expected-note {{reference 'self.' explicitly}}
+      }
     }
     
     doVoidStuffNonEscaping { [weak self] in
       guard let self = self ?? TestImplicitSelfForWeakSelfCapture.staticOptional else { return }
-      method()
-      self.method()
+      method() // expected-warning {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}}
     }
   }
 }

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -749,21 +749,21 @@ public class TestImplicitSelfForWeakSelfCapture {
     doVoidStuff { [weak self] in
       method() // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}}
       guard let self = self else { return }
-      method()
+      method() // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}}
     }
     
     doVoidStuff { [weak self] in
       guard let self else { return }
-      method()
+      method() // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}}
     }
     
     doVoidStuff { [weak self] in
       if let self = self {
-        method()
+        method() // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}}
       }
 
       if let self {
-        method()
+        method() // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}}
       }
     }
     

--- a/test/expr/closure/closures.swift
+++ b/test/expr/closure/closures.swift
@@ -749,21 +749,21 @@ public class TestImplicitSelfForWeakSelfCapture {
     doVoidStuff { [weak self] in
       method() // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}}
       guard let self = self else { return }
-      method() // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}}
+      method()
     }
     
     doVoidStuff { [weak self] in
       guard let self else { return }
-      method() // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}}
+      method()
     }
     
     doVoidStuff { [weak self] in
       if let self = self {
-        method() // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}}
+        method()
       }
 
       if let self {
-        method() // expected-error {{call to method 'method' in closure requires explicit use of 'self' to make capture semantics explicit}}
+        method()
       }
     }
     

--- a/test/expr/closure/closures_swift6.swift
+++ b/test/expr/closure/closures_swift6.swift
@@ -91,9 +91,18 @@ public class TestImplicitSelfForWeakSelfCapture {
       guard let self = self else { return }
       method()
     }
+
+    doVoidStuff { [weak self] in
+      guard let self else { return }
+      method()
+    }
     
     doVoidStuff { [weak self] in
       if let self = self {
+        method()
+      }
+
+      if let self {
         method()
       }
     }

--- a/test/expr/closure/implicit_weak_capture.swift
+++ b/test/expr/closure/implicit_weak_capture.swift
@@ -1,0 +1,29 @@
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking)
+
+// REQUIRES: executable_test
+
+func runIn10ms(_ closure: @escaping @Sendable () -> Void) {
+  Task {
+    try! await Task.sleep(nanoseconds: 10_000_000)
+    closure()
+  }
+}
+
+final class Weak: Sendable {
+  let property = "Self exists"
+
+  func test() {
+    runIn10ms { [weak self] in
+      if let self {
+        // Use implicit self -- this should not result in a strong capture
+        _ = property
+        fatalError("Self was unexpectedly captured strongly")
+      } else {
+        print("Self was captured weakly")
+      }
+    }
+  }
+}
+
+Weak().test()
+try await Task.sleep(nanoseconds: 20_000_000)


### PR DESCRIPTION
This PR enables the behavior defined in SE-0365 for Swift 5 language modes.

The expands on https://github.com/apple/swift/pull/40702, which implemented SE-0365 only in Swift 6 mode.