### PR TITLE
build-script-impl: remove unused `LIBXML2_SOURCE_DIR`

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1245,7 +1245,6 @@ LIBICU_SOURCE_DIR="${WORKSPACE}/icu"
 LIBCXX_SOURCE_DIR="${WORKSPACE}/llvm-project/runtimes"
 EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR="${WORKSPACE}/swift-experimental-string-processing"
 SWIFTSYNTAX_SOURCE_DIR="${WORKSPACE}/swift-syntax"
-LIBXML2_SOURCE_DIR="${WORKSPACE}/libxml2"
 SWIFT_SYNTAX_SOURCE_DIR="${WORKSPACE}/swift-syntax"
 
 # We cannot currently apply the normal rules of skipping here for LLVM. Even if


### PR DESCRIPTION
This variable is unused, since `libxml2` is currently build by CMake, not by `build-script-impl`.
