### PR TITLE
test: add `CxxShim` import for test

### DIFF
--- a/test/Interop/Cxx/class/inheritance/fields.swift
+++ b/test/Interop/Cxx/class/inheritance/fields.swift
@@ -5,6 +5,7 @@
 // Windows doesn't support -lc++ or -lstdc++.
 // UNSUPPORTED: OS=windows-msvc
 
+import CxxShim
 import StdlibUnittest
 import Fields
 


### PR DESCRIPTION
This test would fail on windows when built with assertions as the `CxxShim` module was not imported.  Add the missing import which is required to enable this test on Windows.